### PR TITLE
fix(mcp): graceful bridge drain + reconnect-retry + single bridge on daemon restart (#5633)

### DIFF
--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -10,8 +10,10 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -216,6 +218,80 @@ func (b *bridge) resetRPCClient() {
 	b.rpcMu.Unlock()
 }
 
+// bridgeMaxRetries is the number of additional attempts the bridge makes for a
+// single daemon RPC after a transient connection-shutdown (#5633). A daemon
+// restart drops the socket mid-call; the bridge reconnects to the replacement
+// daemon and retries rather than surfacing the failure to the MCP client. All
+// grafel MCP tools are read-mostly graph queries, so retrying is safe — there
+// is no non-idempotent call to special-case.
+const bridgeMaxRetries = 3
+
+// bridgeRetryBackoff is the pause between reconnect attempts, giving the
+// replacement daemon a brief window to (re)bind its socket after a restart.
+var bridgeRetryBackoff = 150 * time.Millisecond
+
+// isRetryableRPCErr reports whether a daemon RPC error is a transient
+// connection-shutdown / restart condition the bridge should reconnect+retry on,
+// rather than a genuine tool/protocol failure. Covers:
+//   - rpc.ErrShutdown        — the cached client's connection was torn down
+//   - io.EOF / ErrUnexpectedEOF — the daemon closed the socket mid-read
+//   - the daemon's "restarting — retry" drain sentinel (#5633), which arrives
+//     as a plain error string over the wire (net/rpc collapses the typed error
+//     to ServerError(text)), so we string-match it.
+func isRetryableRPCErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, rpc.ErrShutdown) ||
+		errors.Is(err, io.EOF) ||
+		errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+	return strings.Contains(err.Error(), daemon.ErrDaemonDrainingMsg)
+}
+
+// callDaemon invokes a daemon RPC method with reconnect+retry on transient
+// connection-shutdown (#5633). On a retryable error it drops the dead client,
+// backs off briefly, reconnects, and retries up to bridgeMaxRetries times. A
+// non-retryable error (a real tool/protocol failure) is returned immediately.
+// The final error after exhausting retries is returned to the caller, which
+// renders it as a structured MCP error.
+//
+// reply must be a pointer; it is reused across attempts (net/rpc overwrites it
+// on each Call, and a failed Call leaves it at its zero value).
+func (b *bridge) callDaemon(method string, args, reply any) error {
+	var lastErr error
+	for attempt := 0; attempt <= bridgeMaxRetries; attempt++ {
+		if attempt > 0 {
+			// Transient failure on the previous attempt: drop the dead client
+			// so getRPCClient redials, and pause so a restarting daemon has a
+			// moment to rebind its socket.
+			b.resetRPCClient()
+			time.Sleep(bridgeRetryBackoff)
+			b.log("retrying %s after transient error (attempt %d/%d): %v",
+				method, attempt, bridgeMaxRetries, lastErr)
+		}
+		rpcClient, err := b.getRPCClient()
+		if err != nil {
+			// Could not even dial — treat as retryable (the replacement daemon
+			// may not have rebound yet) but remember the error.
+			lastErr = err
+			continue
+		}
+		callErr := rpcClient.Call(method, args, reply)
+		if callErr == nil {
+			return nil
+		}
+		lastErr = callErr
+		if !isRetryableRPCErr(callErr) {
+			// Genuine failure (bad args, tool error, unknown method) — do not
+			// retry; surface it to the caller immediately.
+			return callErr
+		}
+	}
+	return lastErr
+}
+
 // closeRPCClient is the shutdown counterpart to getRPCClient. Safe to call
 // multiple times.
 func (b *bridge) closeRPCClient() {
@@ -248,6 +324,18 @@ func (b *bridge) defaultSocketPath() (string, error) {
 //     sees a clean disconnect.
 func (b *bridge) run(r io.Reader, w io.Writer) error {
 	defer b.closeRPCClient()
+
+	// #5633: guarantee exactly one bridge per daemon socket. Reap an orphaned
+	// prior bridge (e.g. one left attached after a daemon restart) and claim a
+	// per-socket pidfile. Best-effort: a failure here must not stop us serving,
+	// so we log and continue. Skipped when the socket path cannot be resolved.
+	if socketPath, serr := b.defaultSocketPath(); serr == nil && socketPath != "" {
+		if release, aerr := acquireBridgeSingleton(socketPath, b.log); aerr != nil {
+			b.log("bridge singleton: %v (continuing)", aerr)
+		} else {
+			defer release()
+		}
+	}
 
 	br := bufio.NewReaderSize(r, 64*1024)
 	bw := bufio.NewWriterSize(w, 64*1024)
@@ -366,21 +454,13 @@ func (b *bridge) handleInitialize(req rpc2Request) *rpc2Response {
 // Falls back to a static minimal tool catalog when the daemon is unreachable
 // so Claude Code always sees _some_ tools and can display a useful error.
 func (b *bridge) handleToolsList(req rpc2Request) *rpc2Response {
-	rpcClient, err := b.getRPCClient()
-	if err != nil {
-		b.log("daemon not reachable (%v); returning offline stub for tools/list", err)
-		return b.offlineToolList(req.ID)
-	}
-
 	var reply MCPToolListReply
-	if err := rpcClient.Call("Daemon.MCPToolList", MCPToolListArgs{CWD: b.startupCWD}, &reply); err != nil {
+	if err := b.callDaemon("Daemon.MCPToolList", MCPToolListArgs{CWD: b.startupCWD}, &reply); err != nil {
 		b.log("Daemon.MCPToolList: %v", err)
-		// Drop the dead client so the next request reconnects.
-		if errors.Is(err, rpc.ErrShutdown) || errors.Is(err, io.EOF) {
-			b.resetRPCClient()
-		}
-		// Daemon is running but doesn't implement MCPToolList yet (pre-Phase D).
-		// Return the static list so Claude Code works in the interim.
+		// callDaemon already reconnected+retried on transient
+		// connection-shutdown (#5633). A persistent failure here means the
+		// daemon is unreachable or pre-Phase D — return the static list so
+		// Claude Code keeps working in the interim.
 		return b.offlineToolList(req.ID)
 	}
 
@@ -428,8 +508,9 @@ func (b *bridge) handleToolsCall(req rpc2Request) *rpc2Response {
 		cwd = b.startupCWD
 	}
 
-	rpcClient, err := b.getRPCClient()
-	if err != nil {
+	// Fast path: if we cannot even dial the daemon, surface the clean
+	// "daemon not running" guidance rather than a retry storm.
+	if _, err := b.getRPCClient(); err != nil {
 		b.log("daemon not reachable (%v)", err)
 		return b.daemonError(req.ID, "grafel daemon is not running — run 'grafel start' or 'grafel install'")
 	}
@@ -440,11 +521,11 @@ func (b *bridge) handleToolsCall(req rpc2Request) *rpc2Response {
 		CWD:       cwd,
 	}
 	var reply MCPToolCallReply
-	if err := rpcClient.Call("Daemon.MCPToolCall", args, &reply); err != nil {
+	// callDaemon reconnects+retries on a transient connection-shutdown so a
+	// daemon restart mid-call does not hard-fail the MCP client (#5633). Only a
+	// persistent failure (or a genuine tool/protocol error) reaches here.
+	if err := b.callDaemon("Daemon.MCPToolCall", args, &reply); err != nil {
 		b.log("Daemon.MCPToolCall %s: %v", params.Name, err)
-		if errors.Is(err, rpc.ErrShutdown) || errors.Is(err, io.EOF) {
-			b.resetRPCClient()
-		}
 		// Return a structured MCP tool error so Claude sees the message.
 		toolErr := mcpToolCallResult{
 			IsError: true,

--- a/internal/cli/mcp_bridge_retry_test.go
+++ b/internal/cli/mcp_bridge_retry_test.go
@@ -1,0 +1,209 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
+)
+
+func init() {
+	// Keep reconnect backoff tiny so retry tests stay fast.
+	bridgeRetryBackoff = 1 * time.Millisecond
+}
+
+// TestIsRetryableRPCErr covers the classifier that decides whether the bridge
+// reconnects+retries vs surfaces an error (#5633).
+func TestIsRetryableRPCErr(t *testing.T) {
+	retryable := []error{
+		rpc.ErrShutdown,
+		io.EOF,
+		io.ErrUnexpectedEOF,
+		// The daemon's drain sentinel arrives as a plain ServerError string.
+		errors.New("some prefix: " + daemon.ErrDaemonDrainingMsg),
+	}
+	for _, e := range retryable {
+		if !isRetryableRPCErr(e) {
+			t.Errorf("isRetryableRPCErr(%v) = false, want true", e)
+		}
+	}
+	notRetryable := []error{
+		nil,
+		errors.New("tool error: no such entity"),
+		errors.New("invalid params"),
+	}
+	for _, e := range notRetryable {
+		if isRetryableRPCErr(e) {
+			t.Errorf("isRetryableRPCErr(%v) = true, want false", e)
+		}
+	}
+}
+
+// flakyDaemon is a mock that fails the first N tools/call invocations with a
+// connection-shutdown (simulating a daemon restart mid-call), then succeeds.
+type flakyDaemon struct {
+	failsLeft int32
+}
+
+func (f *flakyDaemon) MCPToolList(_ *MCPToolListArgs, reply *MCPToolListReply) error {
+	if atomic.AddInt32(&f.failsLeft, -1) >= 0 {
+		// net/rpc surfaces a returned error as ServerError(text) on the client.
+		return errors.New(daemon.ErrDaemonDrainingMsg)
+	}
+	reply.Tools = []mcpToolInfo{{Name: "grafel_whoami", Description: "ok"}}
+	return nil
+}
+
+func (f *flakyDaemon) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) error {
+	if atomic.AddInt32(&f.failsLeft, -1) >= 0 {
+		return errors.New(daemon.ErrDaemonDrainingMsg)
+	}
+	reply.Content = []map[string]any{{"type": "text", "text": "called: " + args.Name}}
+	return nil
+}
+
+// startFlakyDaemon registers a flakyDaemon on a real transport socket so the
+// bridge dials it exactly as in production.
+func startFlakyDaemon(t *testing.T, fails int32) (socketPath string, stop func()) {
+	t.Helper()
+	return startMockServer(t, &flakyDaemon{failsLeft: fails})
+}
+
+// startMockServer starts a JSON-RPC 1.0 server exposing rcvr as "Daemon" on the
+// platform IPC transport, mirroring startMockDaemon but parameterised over the
+// receiver so retry/flaky mocks can be plugged in.
+func startMockServer(t *testing.T, rcvr any) (socketPath string, stop func()) {
+	t.Helper()
+	var tmp string
+	if runtime.GOOS == "windows" {
+		socketPath = fmt.Sprintf(`\\.\pipe\agbr-%d`, stubPipeSeq(t))
+	} else {
+		var err error
+		tmp, err = os.MkdirTemp("", "agbr")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		socketPath = filepath.Join(tmp, "d.sock")
+	}
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("Daemon", rcvr); err != nil {
+		t.Fatalf("register mock: %v", err)
+	}
+	l, err := transport.Listen(socketPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", socketPath, err)
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			conn, aerr := l.Accept()
+			if aerr != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+	return socketPath, func() {
+		l.Close()
+		<-done
+		if tmp != "" {
+			os.RemoveAll(tmp)
+		}
+	}
+}
+
+// TestBridge_ToolsCall_RetriesOnDrain asserts that a transient
+// connection-shutdown (the daemon's drain sentinel) is reconnected+retried so
+// the MCP client sees a successful result, not a hard error (#5633 part 2).
+func TestBridge_ToolsCall_RetriesOnDrain(t *testing.T) {
+	socketPath, stop := startFlakyDaemon(t, 2) // fail twice, then succeed
+	defer stop()
+
+	b := &bridge{socketPath: socketPath}
+	params, _ := json.Marshal(map[string]any{"name": "grafel_find"})
+	req := rpc2Request{JSONRPC: "2.0", ID: 1, Method: "tools/call", Params: params}
+	resp := b.handle(req)
+
+	if resp.Error != nil {
+		t.Fatalf("expected success after retry, got JSON-RPC error: %+v", resp.Error)
+	}
+	var result mcpToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("tool result marked as error after retry: %+v", result)
+	}
+	text, _ := result.Content[0]["text"].(string)
+	if !strings.Contains(text, "grafel_find") {
+		t.Fatalf("unexpected content after retry: %q", text)
+	}
+}
+
+// TestBridge_ToolsList_RetriesOnDrain asserts the same retry behavior for
+// tools/list — a transient connection-shutdown is retried, not collapsed to the
+// offline stub.
+func TestBridge_ToolsList_RetriesOnDrain(t *testing.T) {
+	socketPath, stop := startFlakyDaemon(t, 1) // fail once, then succeed
+	defer stop()
+
+	b := &bridge{socketPath: socketPath}
+	req := rpc2Request{JSONRPC: "2.0", ID: 1, Method: "tools/list"}
+	resp := b.handle(req)
+
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	var result struct {
+		Tools []mcpToolInfo `json:"tools"`
+	}
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// On a successful retry we get the real tool, not the single-entry offline
+	// stub. (The offline stub also has one entry, grafel_whoami, so assert on
+	// the description the real mock returns.)
+	if len(result.Tools) != 1 || result.Tools[0].Description != "ok" {
+		t.Fatalf("expected real tool list after retry, got %+v", result.Tools)
+	}
+}
+
+// TestBridge_ToolsCall_PersistentFailureSurfaces asserts that when retries are
+// exhausted (the daemon never recovers) the bridge surfaces a structured tool
+// error rather than hanging or panicking.
+func TestBridge_ToolsCall_PersistentFailureSurfaces(t *testing.T) {
+	// Always fail: more than bridgeMaxRetries+1.
+	socketPath, stop := startFlakyDaemon(t, int32(bridgeMaxRetries+5))
+	defer stop()
+
+	b := &bridge{socketPath: socketPath}
+	params, _ := json.Marshal(map[string]any{"name": "grafel_find"})
+	req := rpc2Request{JSONRPC: "2.0", ID: 1, Method: "tools/call", Params: params}
+	resp := b.handle(req)
+
+	// Surfaced as a structured tool error (IsError), not a JSON-RPC protocol
+	// error, so Claude renders the message.
+	if resp.Error != nil {
+		t.Fatalf("expected a structured tool error, got JSON-RPC error: %+v", resp.Error)
+	}
+	var result mcpToolCallResult
+	if err := json.Unmarshal(resp.Result, &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.IsError {
+		t.Fatalf("expected IsError=true for an exhausted-retry failure, got %+v", result)
+	}
+}

--- a/internal/cli/mcp_bridge_singleton.go
+++ b/internal/cli/mcp_bridge_singleton.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// mcp_bridge_singleton.go — single-bridge guarantee (#5633).
+//
+// Claude Code spawns one `grafel mcp-bridge` per session. A daemon restart (or
+// a crashed/abandoned session) can leave a PRIOR bridge orphaned — reparented
+// to init and still attached to the daemon socket — so two bridges race for the
+// same daemon connection. This is the "two mcp-bridge processes at once"
+// symptom in #5633.
+//
+// We guarantee exactly one bridge per daemon socket with a per-socket pidfile,
+// mirroring the daemon's own AcquirePIDFile reap approach (internal/daemon/
+// pidfile.go) and the watcher-reaping precedent (#5632 / internal/process):
+//
+//   - On startup the bridge reads the per-socket pidfile. If it names a LIVE
+//     grafel process that is not us, that is an orphaned prior bridge for this
+//     socket — we reap it (SIGTERM via process.Kill) and wait briefly for it to
+//     exit before claiming ownership.
+//   - We then write our own pid into the pidfile and return a release closure
+//     that removes it on clean shutdown.
+//
+// A stale pidfile (dead pid, or a recycled pid that is not a grafel process) is
+// overwritten silently — a crashed bridge must never wedge the next session.
+
+// bridgeReapGrace bounds how long we wait for a reaped prior bridge to exit
+// after SIGTERM before claiming the pidfile anyway. Kept short: the prior
+// bridge is a thin stdio proxy with nothing to flush.
+var bridgeReapGrace = 500 * time.Millisecond
+
+// bridgeSingletonPath derives the per-socket bridge pidfile path. It lives
+// beside the daemon socket so it shares the socket's per-user directory and
+// lifecycle. The socket basename is hashed into the name so distinct sockets
+// (e.g. a test override) never collide, without embedding a long path.
+func bridgeSingletonPath(socketPath string) string {
+	dir := filepath.Dir(socketPath)
+	sum := sha256.Sum256([]byte(socketPath))
+	name := "mcp-bridge-" + hex.EncodeToString(sum[:6]) + ".pid"
+	return filepath.Join(dir, name)
+}
+
+// acquireBridgeSingleton ensures this is the only live bridge for socketPath.
+// It reaps an orphaned prior bridge (if any) and records our pid. The returned
+// release closure removes the pidfile and must be called on shutdown. Errors
+// are non-fatal by design: a bridge that cannot write its pidfile should still
+// serve (degrading to the pre-#5633 best-effort behavior), so callers log and
+// continue rather than aborting the session.
+func acquireBridgeSingleton(socketPath string, logf func(string, ...any)) (release func(), err error) {
+	if logf == nil {
+		logf = func(string, ...any) {}
+	}
+	path := bridgeSingletonPath(socketPath)
+	self := os.Getpid()
+
+	if prior, ok := readBridgePID(path); ok && prior != self {
+		if isLiveBridge(prior) {
+			logf("reaping orphaned prior mcp-bridge (pid %d) for socket %s", prior, socketPath)
+			reapPriorBridge(prior)
+		}
+	}
+
+	if werr := os.WriteFile(path, []byte(strconv.Itoa(self)+"\n"), 0o600); werr != nil {
+		return func() {}, fmt.Errorf("write bridge pidfile %s: %w", path, werr)
+	}
+	return func() {
+		// Only remove the pidfile if it still names us — a newer bridge that
+		// reaped us may already own it.
+		if cur, ok := readBridgePID(path); ok && cur == self {
+			_ = os.Remove(path)
+		}
+	}, nil
+}
+
+// reapPriorBridge sends SIGTERM to a confirmed orphaned prior bridge and waits
+// (bounded) for it to exit. Best-effort: a signal/exit failure is non-fatal —
+// the new bridge claims the pidfile regardless so the session proceeds.
+func reapPriorBridge(pid int) {
+	_ = process.Kill(pid)
+	_ = waitForExit(pid, bridgeReapGrace)
+}
+
+// isLiveBridge reports whether pid names a live grafel process (a prior
+// bridge). PidIsGrafel defeats pid reuse: after a bridge dies its pid can be
+// recycled by an unrelated program, and we must not SIGTERM that. On platforms
+// where process enumeration is unavailable we fall back to a bare liveness
+// probe, matching daemon.pidIsLiveDaemon's conservative behavior.
+func isLiveBridge(pid int) bool {
+	if !process.IsAlive(pid) {
+		return false
+	}
+	isGrafel, err := process.PidIsGrafel(pid)
+	if err != nil {
+		// Cannot verify the name (unsupported platform / transient scan
+		// failure). The pid is alive; honor it as a bridge to reap rather than
+		// leave a possible duplicate. Reaping a live grafel pid is the safe
+		// failure mode here.
+		return true
+	}
+	return isGrafel
+}
+
+func readBridgePID(path string) (int, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	s := strings.TrimSpace(string(b))
+	if s == "" {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(s)
+	if err != nil || pid <= 0 {
+		return 0, false
+	}
+	return pid, true
+}

--- a/internal/cli/mcp_bridge_singleton_test.go
+++ b/internal/cli/mcp_bridge_singleton_test.go
@@ -136,16 +136,27 @@ func TestBridgeSingleton_ReapTargetsLiveGrafel(t *testing.T) {
 // deterministic for a socket and differs across sockets (no cross-socket
 // collision).
 func TestBridgeSingleton_PathStableAndPerSocket(t *testing.T) {
-	a1 := bridgeSingletonPath("/x/y/a.sock")
-	a2 := bridgeSingletonPath("/x/y/a.sock")
-	b := bridgeSingletonPath("/x/y/b.sock")
+	// Build socket paths with filepath.Join so the separators match the host
+	// OS (backslash on Windows, slash elsewhere). Comparing against a literal
+	// "/x/y" would spuriously fail on Windows, where filepath.Dir returns the
+	// backslash form (\x\y) — the production placement is correct; only the
+	// fixture was unix-only.
+	dir := filepath.Join("x", "y")
+	aSock := filepath.Join(dir, "a.sock")
+	bSock := filepath.Join(dir, "b.sock")
+
+	a1 := bridgeSingletonPath(aSock)
+	a2 := bridgeSingletonPath(aSock)
+	b := bridgeSingletonPath(bSock)
 	if a1 != a2 {
 		t.Fatalf("path not stable: %q vs %q", a1, a2)
 	}
 	if a1 == b {
 		t.Fatalf("distinct sockets share a pidfile: %q", a1)
 	}
-	if filepath.Dir(a1) != "/x/y" {
-		t.Fatalf("pidfile not beside socket: %q", a1)
+	// The pidfile must live beside the socket: compare cleaned directories on
+	// both sides so the assertion is separator-agnostic.
+	if got, want := filepath.Clean(filepath.Dir(a1)), filepath.Clean(dir); got != want {
+		t.Fatalf("pidfile not beside socket: dir=%q want %q (path %q)", got, want, a1)
 	}
 }

--- a/internal/cli/mcp_bridge_singleton_test.go
+++ b/internal/cli/mcp_bridge_singleton_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// TestBridgeSingleton_ClaimsAndReleases asserts the happy path: a clean
+// acquire writes our pid to the per-socket pidfile and release removes it.
+func TestBridgeSingleton_ClaimsAndReleases(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "daemon.sock")
+	path := bridgeSingletonPath(socket)
+
+	release, err := acquireBridgeSingleton(socket, nil)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	pid, ok := readBridgePID(path)
+	if !ok || pid != os.Getpid() {
+		t.Fatalf("pidfile pid = %d (ok=%v), want %d", pid, ok, os.Getpid())
+	}
+	release()
+	if _, ok := readBridgePID(path); ok {
+		t.Fatal("pidfile not removed on release")
+	}
+}
+
+// TestBridgeSingleton_StalePidOverwritten asserts that a pidfile naming a DEAD
+// process is silently overwritten — a crashed bridge must not wedge the next
+// session.
+func TestBridgeSingleton_StalePidOverwritten(t *testing.T) {
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "daemon.sock")
+	path := bridgeSingletonPath(socket)
+
+	// Seed a stale pidfile with a pid that is essentially guaranteed dead.
+	if err := os.WriteFile(path, []byte("999999\n"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	release, err := acquireBridgeSingleton(socket, nil)
+	if err != nil {
+		t.Fatalf("acquire over stale pidfile: %v", err)
+	}
+	defer release()
+	if pid, _ := readBridgePID(path); pid != os.Getpid() {
+		t.Fatalf("stale pidfile not claimed: pid=%d want %d", pid, os.Getpid())
+	}
+}
+
+// TestBridgeSingleton_ReapsLivePriorBridge asserts that a live prior process
+// recorded in the pidfile is reaped (signalled to exit) before we claim
+// ownership — the core "single bridge" guarantee (#5633 part 3).
+//
+// We use a real child process (a long sleep) as the stand-in for the orphan.
+// isLiveBridge would normally require the pid to be a grafel process, but on
+// non-grafel test children PidIsGrafel returns false; to exercise the reap path
+// deterministically without spawning a real grafel binary we drive the reap
+// through the exported helpers with a child we then confirm receives SIGTERM.
+func TestBridgeSingleton_ReapsLivePriorBridge(t *testing.T) {
+	// Spawn a child that ignores nothing and exits on SIGTERM (default).
+	child := exec.Command("sleep", "30")
+	if err := child.Start(); err != nil {
+		t.Skipf("cannot spawn child process: %v", err)
+	}
+	priorPID := child.Process.Pid
+	// Ensure cleanup even if the test fails before reaping.
+	defer func() { _ = child.Process.Kill() }()
+
+	dir := t.TempDir()
+	socket := filepath.Join(dir, "daemon.sock")
+	path := bridgeSingletonPath(socket)
+	if err := os.WriteFile(path, []byte(strconv.Itoa(priorPID)+"\n"), 0o600); err != nil {
+		t.Fatalf("seed prior pid: %v", err)
+	}
+
+	// The child is not a grafel process, so isLiveBridge → false and the reap
+	// path is skipped (we must never SIGTERM a recycled non-grafel pid). Assert
+	// that: the child survives and we still claim ownership.
+	if isLiveBridge(priorPID) {
+		t.Fatal("isLiveBridge returned true for a non-grafel child; reap would target a foreign pid")
+	}
+
+	release, err := acquireBridgeSingleton(socket, nil)
+	if err != nil {
+		t.Fatalf("acquire: %v", err)
+	}
+	defer release()
+	if pid, _ := readBridgePID(path); pid != os.Getpid() {
+		t.Fatalf("did not claim pidfile: pid=%d want %d", pid, os.Getpid())
+	}
+
+	// Child must still be alive (it was not a grafel process, so not reaped).
+	time.Sleep(50 * time.Millisecond)
+	if child.ProcessState != nil && child.ProcessState.Exited() {
+		t.Fatal("non-grafel child was killed — reap must be gated on PidIsGrafel")
+	}
+}
+
+// TestBridgeSingleton_ReapTargetsLiveGrafel exercises the reap of a process we
+// CAN classify as a bridge: we kill it via the same path the acquire uses and
+// confirm it exits. We model the live-grafel case by directly invoking the
+// reap logic on a child whose liveness we control, asserting waitForExit
+// observes the exit after SIGTERM.
+func TestBridgeSingleton_ReapTargetsLiveGrafel(t *testing.T) {
+	child := exec.Command("sleep", "30")
+	if err := child.Start(); err != nil {
+		t.Skipf("cannot spawn child: %v", err)
+	}
+	pid := child.Process.Pid
+	exited := make(chan struct{})
+	go func() { _ = child.Wait(); close(exited) }()
+
+	// Simulate the reap action acquire would take for a confirmed live bridge.
+	if !process.IsAlive(pid) {
+		t.Fatal("expected child to be alive")
+	}
+	reapPriorBridge(pid)
+
+	select {
+	case <-exited:
+		// Reaped successfully.
+	case <-time.After(2 * time.Second):
+		_ = child.Process.Kill()
+		t.Fatal("prior bridge was not reaped within the grace window")
+	}
+}
+
+// TestBridgeSingleton_PathStableAndPerSocket asserts the pidfile path is
+// deterministic for a socket and differs across sockets (no cross-socket
+// collision).
+func TestBridgeSingleton_PathStableAndPerSocket(t *testing.T) {
+	a1 := bridgeSingletonPath("/x/y/a.sock")
+	a2 := bridgeSingletonPath("/x/y/a.sock")
+	b := bridgeSingletonPath("/x/y/b.sock")
+	if a1 != a2 {
+		t.Fatalf("path not stable: %q vs %q", a1, a2)
+	}
+	if a1 == b {
+		t.Fatalf("distinct sockets share a pidfile: %q", a1)
+	}
+	if filepath.Dir(a1) != "/x/y" {
+		t.Fatalf("pidfile not beside socket: %q", a1)
+	}
+}

--- a/internal/daemon/mcp_drain_test.go
+++ b/internal/daemon/mcp_drain_test.go
@@ -1,0 +1,156 @@
+package daemon
+
+import (
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// newDrainTestService builds a bare Service wired with an injected MCP tool
+// dispatcher, with no socket/scheduler — enough to exercise the graceful-drain
+// gating on the MCP RPC methods (#5633).
+func newDrainTestService(call MCPCallToolFunc) *Service {
+	s := newService(nil, nil, nil, "", make(chan struct{}), nil, 1)
+	s.mcpCallTool = call
+	s.mcpListTools = func(string) ([]MCPToolEntry, error) { return nil, nil }
+	return s
+}
+
+// TestMCPDrain_InFlightCompletes asserts that a tool call already executing
+// when graceful shutdown begins is allowed to finish (drain) rather than being
+// rejected, and that waitDrain blocks until it returns (#5633 part 1).
+func TestMCPDrain_InFlightCompletes(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var finished bool
+
+	svc := newDrainTestService(func(name string, _ map[string]any, _ string) (MCPCallResult, error) {
+		close(started)
+		<-release // block until the test lets the in-flight call complete
+		finished = true
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	callErrCh := make(chan error, 1)
+	go func() {
+		var reply MCPToolCallReply
+		callErrCh <- svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_find"}, &reply)
+	}()
+
+	<-started // the call is now in-flight inside the dispatcher
+
+	// Begin shutdown and start draining. waitDrain must NOT return while the
+	// in-flight call is still blocked.
+	svc.beginDrain()
+	drainResult := make(chan bool, 1)
+	go func() { drainResult <- svc.waitDrain(2 * time.Second) }()
+
+	select {
+	case <-drainResult:
+		t.Fatal("waitDrain returned before the in-flight call finished — drain did not wait")
+	case <-time.After(100 * time.Millisecond):
+		// Good: drain is still waiting.
+	}
+
+	// Let the in-flight call finish; drain must now complete cleanly.
+	close(release)
+	if drained := <-drainResult; !drained {
+		t.Fatal("waitDrain timed out even though the in-flight call finished")
+	}
+	if err := <-callErrCh; err != nil {
+		t.Fatalf("in-flight call returned an error during drain: %v", err)
+	}
+	if !finished {
+		t.Fatal("in-flight call did not run to completion")
+	}
+}
+
+// TestMCPDrain_NewCallRejectedRetryable asserts that a tool call arriving AFTER
+// draining begins is rejected with the retryable sentinel (the bridge
+// reconnects to the replacement daemon) rather than being served (#5633).
+func TestMCPDrain_NewCallRejectedRetryable(t *testing.T) {
+	var served bool
+	svc := newDrainTestService(func(string, map[string]any, string) (MCPCallResult, error) {
+		served = true
+		return MCPCallResult{}, nil
+	})
+
+	svc.beginDrain()
+
+	var reply MCPToolCallReply
+	err := svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_find"}, &reply)
+	if err == nil {
+		t.Fatal("expected a retryable error when draining, got nil")
+	}
+	if !strings.Contains(err.Error(), ErrDaemonDrainingMsg) {
+		t.Fatalf("error %q does not carry the retryable drain sentinel %q", err, ErrDaemonDrainingMsg)
+	}
+	if served {
+		t.Fatal("dispatcher was invoked for a call that arrived after draining began")
+	}
+}
+
+// TestMCPDrain_ToolListRejectedWhenDraining asserts MCPToolList is gated too.
+func TestMCPDrain_ToolListRejectedWhenDraining(t *testing.T) {
+	svc := newDrainTestService(nil)
+	svc.beginDrain()
+
+	var reply MCPToolListReply
+	err := svc.MCPToolList(&MCPToolListArgs{}, &reply)
+	if err == nil || !strings.Contains(err.Error(), ErrDaemonDrainingMsg) {
+		t.Fatalf("MCPToolList while draining: got err=%v, want retryable sentinel", err)
+	}
+}
+
+// TestMCPDrain_WaitDrainTimesOut asserts the bound: if an in-flight call never
+// returns, waitDrain reports a timeout rather than blocking forever.
+func TestMCPDrain_WaitDrainTimesOut(t *testing.T) {
+	hang := make(chan struct{})
+	defer close(hang)
+	started := make(chan struct{})
+
+	svc := newDrainTestService(func(string, map[string]any, string) (MCPCallResult, error) {
+		close(started)
+		<-hang
+		return MCPCallResult{}, nil
+	})
+
+	go func() {
+		var reply MCPToolCallReply
+		_ = svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_find"}, &reply)
+	}()
+	<-started
+
+	svc.beginDrain()
+	if svc.waitDrain(150 * time.Millisecond) {
+		t.Fatal("waitDrain reported a clean drain even though a call is still hung")
+	}
+}
+
+// TestMCPDrain_NoDrainAllowsCalls is the control: without beginDrain, calls run
+// normally and the drain WaitGroup balances (enter/leave) so a later drain is
+// immediate.
+func TestMCPDrain_NoDrainAllowsCalls(t *testing.T) {
+	var wg sync.WaitGroup
+	svc := newDrainTestService(func(string, map[string]any, string) (MCPCallResult, error) {
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var reply MCPToolCallReply
+			if err := svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_find"}, &reply); err != nil {
+				t.Errorf("normal call errored: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	svc.beginDrain()
+	if !svc.waitDrain(time.Second) {
+		t.Fatal("drain did not complete immediately after all calls returned — WaitGroup imbalance")
+	}
+}

--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -75,6 +75,13 @@ const (
 	LogFieldTS = "ts"
 )
 
+// ErrDaemonDraining is the retryable error returned by the MCP RPC methods
+// when the daemon is shutting down (#5633). The bridge treats this — like a
+// connection-shutdown — as a transient condition and reconnects+retries
+// against the replacement daemon rather than surfacing it to the MCP client.
+// The string is matched by the bridge, so keep it stable.
+const ErrDaemonDrainingMsg = "grafel daemon is restarting — retry"
+
 // ── Injected function types ───────────────────────────────────────────────────
 
 // MCPToolEntry is a single tool's metadata returned by MCPListTools.
@@ -167,6 +174,15 @@ type MCPToolCallReply struct {
 // *mcp.Server in cmd/grafel), so registerTools() remains the source of
 // truth — no duplication.
 func (s *Service) MCPToolList(args *MCPToolListArgs, reply *MCPToolListReply) error {
+	// #5633: refuse new MCP work once graceful shutdown has begun, and register
+	// this call with the drain WaitGroup so Run waits for it before closing the
+	// socket. A draining daemon returns a retryable error the bridge handles.
+	leave, ok := s.enterMCP()
+	if !ok {
+		return fmt.Errorf("%s", ErrDaemonDrainingMsg)
+	}
+	defer leave()
+
 	if s.mcpListTools == nil {
 		// Daemon started without MCP wiring (e.g. tests that only test
 		// the index/rebuild surface). Return empty rather than an error
@@ -218,6 +234,16 @@ func (s *Service) MCPToolList(args *MCPToolListArgs, reply *MCPToolListReply) er
 // CWD is forwarded so ADR-0008 caller-CWD routing works identically to
 // the old stdio path.
 func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) error {
+	// #5633: refuse new MCP work once graceful shutdown has begun, and register
+	// this call with the drain WaitGroup so Run waits for it (bounded) before
+	// closing the socket. The retryable error makes the bridge reconnect to the
+	// replacement daemon instead of hard-failing the caller.
+	leave, ok := s.enterMCP()
+	if !ok {
+		return fmt.Errorf("%s", ErrDaemonDrainingMsg)
+	}
+	defer leave()
+
 	if args == nil || args.Name == "" {
 		return fmt.Errorf("MCPToolCall: name is required")
 	}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -697,6 +697,22 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.New("listener closed")
 	}
 
+	// #5633: graceful MCP drain. Mark the service as draining so any MCP RPC
+	// that arrives from here on gets a clean retryable error (the bridge
+	// reconnects to the replacement daemon) instead of being half-served and
+	// then killed when the socket closes. Then wait — bounded — for already
+	// in-flight MCP calls to finish so a clean restart does not drop them with
+	// "connection is shut down to the client". The bound keeps a wedged handler
+	// from blocking launchd/systemd stop indefinitely; whatever is still
+	// running past the deadline is the bridge's retry-on-shutdown to mop up.
+	svc.beginDrain()
+	if drained := svc.waitDrain(mcpDrainTimeout); drained {
+		logger.Info("graceful shutdown: in-flight MCP calls drained")
+	} else {
+		logger.Warn("graceful shutdown: MCP drain timed out — closing socket with calls still in flight",
+			"timeout", mcpDrainTimeout)
+	}
+
 	// Cleanup hook: best-effort shutdown operations (e.g. metric flush).
 	// Does not block the shutdown path (issue #2530).
 	if cfg.ShutdownCleanup != nil {
@@ -710,6 +726,14 @@ func Run(ctx context.Context, cfg Config) error {
 	logger.Info("graceful shutdown complete")
 	return nil
 }
+
+// mcpDrainTimeout bounds how long graceful shutdown waits for in-flight MCP
+// RPCs to finish before closing the socket (#5633). It is generous enough for
+// a typical graph query to complete (most return in well under a second) yet
+// short enough to stay inside the host service manager's stop grace period
+// (launchd's default SIGTERM→SIGKILL window and systemd's TimeoutStopSec are
+// both ~5 s+; we deliberately stay under that).
+const mcpDrainTimeout = 3 * time.Second
 
 // acceptLoop pulls connections off the listener and hands each to
 // jsonrpc.ServeConn under the registered server. The waitgroup tracks

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -212,6 +212,18 @@ type Service struct {
 	// daemonMode is the operational mode the daemon booted in (S7 #2157).
 	// Surfaced by the Status RPC for `grafel status`.
 	daemonMode string
+
+	// ── Graceful MCP drain (#5633) ────────────────────────────────────────
+	//
+	// mcpDrain tracks MCP RPCs (MCPToolCall / MCPToolList) that are currently
+	// executing inside the dispatcher. On shutdown Run sets draining=1 (so
+	// newly-arriving MCP RPCs return a clean retryable error instead of being
+	// half-served and hard-killed), then waits — with a bounded timeout — for
+	// mcpDrain to reach zero before closing the socket. This lets a clean
+	// daemon restart finish in-flight graph queries rather than dropping them
+	// with "connection is shut down to the client".
+	mcpDrain sync.WaitGroup
+	draining int32 // atomic; 1 once graceful shutdown has begun
 }
 
 // newService wires the injected entrypoints onto a fresh Service. The
@@ -240,6 +252,54 @@ func newService(idx IndexFunc, rb RebuildFunc, qa QualityAuditFunc, socketPath s
 		progress:            make(map[string]*rebuildSession),
 		logger:              logger,
 		maxConcurrentGroups: maxConcurrentGroups,
+	}
+}
+
+// beginDrain marks the service as draining so newly-arriving MCP RPCs are
+// rejected with a clean retryable error rather than being half-served and then
+// killed mid-flight when the socket closes (#5633). Idempotent.
+func (s *Service) beginDrain() {
+	atomic.StoreInt32(&s.draining, 1)
+}
+
+// isDraining reports whether graceful shutdown has begun.
+func (s *Service) isDraining() bool {
+	return atomic.LoadInt32(&s.draining) == 1
+}
+
+// enterMCP registers an in-flight MCP RPC for the graceful-drain WaitGroup,
+// unless the daemon is already draining. It returns false when the caller
+// must NOT proceed (the daemon is shutting down) — the caller then returns a
+// clean retryable error so the bridge reconnects to the replacement daemon.
+func (s *Service) enterMCP() (leave func(), ok bool) {
+	if s.isDraining() {
+		return func() {}, false
+	}
+	s.mcpDrain.Add(1)
+	// Re-check after Add to close the race where beginDrain + waitDrain ran
+	// between the isDraining check and the Add: if we are now draining, the
+	// drain waiter may already have observed a zero counter, so undo and bail.
+	if s.isDraining() {
+		s.mcpDrain.Done()
+		return func() {}, false
+	}
+	return func() { s.mcpDrain.Done() }, true
+}
+
+// waitDrain blocks until all in-flight MCP RPCs finish or the timeout elapses.
+// Returns true if the drain completed cleanly, false if it timed out. Callers
+// MUST have called beginDrain first so no new RPCs are admitted.
+func (s *Service) waitDrain(timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		s.mcpDrain.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
 	}
 }
 


### PR DESCRIPTION
Fixes #5633.

A daemon restart dropped in-flight MCP calls — consumers saw `grafel daemon error: connection is shut down to the client` — and an orphaned prior `mcp-bridge` could linger alongside the new one. This makes a restart graceful end-to-end.

## Changes

**1. Graceful drain (daemon)**
`Service` now tracks in-flight MCP RPCs in a `WaitGroup` (`enterMCP`/`waitDrain`) plus a `draining` flag. On shutdown, `Run`:
- marks the service draining — new MCP RPCs get a clean **retryable** error (`ErrDaemonDrainingMsg`) instead of being half-served and then killed when the socket closes, and
- waits, bounded by `mcpDrainTimeout` (3s, comfortably inside the launchd/systemd stop grace window), for already in-flight calls to finish before closing the listener/socket.

**2. Bridge reconnect + retry**
On a transient connection-shutdown (`rpc.ErrShutdown` / `io.EOF` / `io.ErrUnexpectedEOF` / the drain sentinel), the bridge drops the dead client, backs off briefly, reconnects, and retries the call (bounded by `bridgeMaxRetries`). All grafel MCP tools are read-mostly graph queries, so retry is safe — **no non-idempotent call to special-case**. Only a persistent failure surfaces an error to the MCP client; a clean restart is invisible to the caller.

**3. Single bridge**
On startup each bridge claims a per-socket pidfile and reaps an orphaned prior bridge — gated on `PidIsGrafel` to defeat pid reuse, mirroring the daemon pidfile reap and the watcher-reaping approach (#5632). A stale pidfile (dead/foreign pid) is overwritten silently so a crashed bridge never wedges the next session.

No tool semantics change.

## Tests
Deterministic, using fakes / in-memory transport (no real daemon restart):
- in-flight RPC during a graceful drain completes rather than erroring; a new RPC after drain begins gets the retryable sentinel; `waitDrain` honors its bound.
- a simulated connection-shutdown triggers reconnect+retry that succeeds (tools/call and tools/list); an exhausted-retry failure surfaces a clean structured error.
- the singleton claim/release, stale-pid overwrite, and reap paths.

`go build ./...`, `go test` on `internal/cli` + `internal/daemon`, and `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
