### PR TITLE
feat(quarantine): value-based detection — quarantine expensive ∧ unused dirs (#5619)

### DIFF
--- a/internal/daemon/watch/quarantine.go
+++ b/internal/daemon/watch/quarantine.go
@@ -189,6 +189,12 @@ type QuarantineTracker struct {
 	// lives in quarantine_content.go; this is the only coupling point. nil
 	// until first use (lazily initialised, kill-switch aware).
 	content *contentDetector
+	// value is the Q4 value-based detector (T2, #5619): quarantine a directory
+	// that is expensive to index AND never used (queried/referenced). Its state
+	// and logic live entirely in quarantine_value.go; this is the only field the
+	// core tracker reserves for it (kept minimal so the parallel Q5 content
+	// detector, #5620, does not collide on this file). Lazily initialised.
+	value *valueDetector
 }
 
 // NewQuarantineTracker constructs a tracker. audit may be nil.

--- a/internal/daemon/watch/quarantine_value.go
+++ b/internal/daemon/watch/quarantine_value.go
@@ -1,0 +1,261 @@
+// Package watch — quarantine_value.go
+//
+// Q4 of the self-healing index quarantine (epic #5394, tier T2: VALUE-based).
+//
+// Q1 (quarantine.go) catches a directory that *churns* pathologically — a build
+// loop arming reindex after reindex. That is the loudest signal. This file adds
+// the quieter, complementary one: a directory that is **expensive to index AND
+// never used**.
+//
+//	churn detector (T1):  "this dir keeps re-triggering work"   → cost over time
+//	value detector (T2):  "this dir costs a lot and earns nothing" → cost ∧ ¬use
+//
+// The data already exists — we just join two cheap per-directory signals:
+//
+//   - COST: how expensive a directory is to index/parse. Recorded via
+//     RecordIndexCost(repo, dir, cost). The caller supplies whatever proxy it
+//     has cheaply to hand: parse wall-time (ms), entity count, or file count —
+//     all monotonic "work" units. We accumulate the latest cost per directory.
+//   - USAGE: whether anything under the directory has been queried or referenced
+//     recently. This reuses the exact access signal Q3's Recover hook already
+//     observes (an MCP tool resolving an entity whose source file lives under
+//     the dir) — NoteUsage(repo, path) stamps "last used = now".
+//
+// Detect / Quarantine: a directory is quarantined with signal="value" when, at
+// the moment fresh cost is recorded for it, BOTH hold:
+//
+//	(1) its accumulated index cost ≥ CostThreshold        (expensive), and
+//	(2) it has had ZERO usage for at least UnusedGrace     (never used).
+//
+// SAFETY (same non-negotiable bar as T1):
+//   - Conservative: a CHEAP dir is never quarantined no matter how unused, and a
+//     RECENTLY-USED dir is never quarantined no matter how expensive. Both gates
+//     must trip.
+//   - A long grace period (UnusedGrace ≫ any plausible query gap) so a dir that
+//     is merely momentarily idle is not mistaken for dead.
+//   - Pins are respected; the repo root is never quarantined (relDir guards it).
+//   - Reuses the Q1 kill switch (GRAFEL_QUARANTINE_DISABLE disables BOTH
+//     detectors) plus a dedicated GRAFEL_QUARANTINE_VALUE_DISABLE for T2 only.
+//   - Persists through the shared <repo>/.grafel/quarantine.json, and self-heals
+//     exactly like a churn quarantine: a later query un-quarantines it via Q3
+//     Recover, and the quiet-window Sweep recovers it too. (A value quarantine
+//     records lastEvent=now so Sweep measures quiet from the quarantine moment —
+//     and any subsequent NoteUsage immediately recovers it.)
+//
+// Everything here is goroutine-safe under the tracker's existing mutex and
+// clock-injectable through the tracker's `now`, so the detect logic is testable
+// deterministically with an injected cost + usage and a fake clock.
+package watch
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// Value-detector tuning. Env-overridable (see valueConfig). Defaults are
+// deliberately conservative.
+//
+//   - defaultCostThreshold (2000): a directory must reach this much accumulated
+//     "index work" (entities/files parsed, or parse-ms — caller's unit) before
+//     it is even a candidate. A handful of small source files stays well under
+//     it; only a genuinely heavy directory (a large generated/vendored tree)
+//     qualifies. Set high so cheap dirs are categorically excluded.
+//   - defaultUnusedGrace (24h): the dir must have gone completely unqueried /
+//     unreferenced for a full day before "unused" is believed. Far longer than
+//     any realistic gap between two queries that touch a live area of the repo.
+const (
+	defaultCostThreshold = 2000
+	defaultUnusedGrace   = 24 * time.Hour
+)
+
+// valueConfig holds the resolved (env-aware) T2 thresholds.
+type valueConfig struct {
+	costThreshold int64
+	unusedGrace   time.Duration
+	disabled      bool
+}
+
+// loadValueConfig parses the T2 env each time a detector is created. Recognised:
+//
+//	GRAFEL_QUARANTINE_VALUE_DISABLE=1        — turn the T2 detector off only
+//	GRAFEL_QUARANTINE_VALUE_COST=<n>         — cost threshold (work units)
+//	GRAFEL_QUARANTINE_VALUE_UNUSED_SEC=<n>   — unused grace period, seconds
+//
+// (The Q1 GRAFEL_QUARANTINE_DISABLE kill switch disables the whole tracker, so
+// it is honoured upstream in every public entry point and not re-read here.)
+func loadValueConfig() valueConfig {
+	c := valueConfig{
+		costThreshold: defaultCostThreshold,
+		unusedGrace:   defaultUnusedGrace,
+	}
+	if v := os.Getenv("GRAFEL_QUARANTINE_VALUE_DISABLE"); v == "1" || v == "true" {
+		c.disabled = true
+	}
+	if v := os.Getenv("GRAFEL_QUARANTINE_VALUE_COST"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			c.costThreshold = n
+		}
+	}
+	if v := os.Getenv("GRAFEL_QUARANTINE_VALUE_UNUSED_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			c.unusedGrace = time.Duration(n) * time.Second
+		}
+	}
+	return c
+}
+
+// dirValue is the per-directory value bookkeeping: accumulated index cost and
+// the last time the directory was queried/referenced.
+type dirValue struct {
+	// cost is the latest recorded accumulated index cost (work units) for the
+	// directory. Higher = more expensive to index.
+	cost int64
+	// lastUse is when content under the directory was last queried/referenced.
+	// The zero value means "never used since the detector started observing it";
+	// firstSeen anchors the grace clock in that case.
+	lastUse time.Time
+	// firstSeen is when this directory was first observed by the value detector
+	// (first cost record). Used as the grace baseline when lastUse is zero, so a
+	// brand-new expensive dir is not quarantined before it has had a fair chance
+	// to be queried.
+	firstSeen time.Time
+}
+
+// valueDetector holds the T2 state. It does not own a mutex: every method runs
+// under the parent QuarantineTracker's mutex (callers hold q.mu), so the state
+// is consistent with the churn + quarantine maps it cooperates with.
+type valueDetector struct {
+	cfg valueConfig
+	// byDir[repo][relDir] → cost+usage bookkeeping.
+	byDir map[string]map[string]*dirValue
+}
+
+// ensureValueLocked lazily constructs the value detector. Caller holds q.mu.
+func (q *QuarantineTracker) ensureValueLocked() *valueDetector {
+	if q.value == nil {
+		q.value = &valueDetector{
+			cfg:   loadValueConfig(),
+			byDir: make(map[string]map[string]*dirValue),
+		}
+	}
+	return q.value
+}
+
+// valueEntryLocked returns (creating if needed) the bookkeeping for repo/rel.
+// Caller holds q.mu.
+func (v *valueDetector) entry(repo, rel string, now time.Time) *dirValue {
+	byDir := v.byDir[repo]
+	if byDir == nil {
+		byDir = make(map[string]*dirValue)
+		v.byDir[repo] = byDir
+	}
+	dv := byDir[rel]
+	if dv == nil {
+		dv = &dirValue{firstSeen: now}
+		byDir[rel] = dv
+	}
+	return dv
+}
+
+// RecordIndexCost records that indexing/parsing the directory containing path
+// cost `cost` work units (parse-ms, entity count, or file count — any monotonic
+// "work" proxy the indexer has cheaply to hand). It then evaluates the T2
+// predicate and quarantines the directory if it is now expensive ∧ unused.
+//
+// `path` may be the directory itself or any file under it — its directory is
+// what we attribute the cost to (matching how Observe/Recover key on relDir).
+//
+// Additive and safe to call from the index path: nil/disabled/out-of-repo and
+// already-quarantined are cheap no-ops. Returns true if THIS call quarantined
+// the directory.
+func (q *QuarantineTracker) RecordIndexCost(repo, path string, cost int64) (quarantined bool) {
+	if q == nil || q.cfg.disabled || cost <= 0 {
+		return false
+	}
+	rel, ok := relDir(repo, path)
+	if !ok {
+		return false
+	}
+	now := q.now()
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.ensureLoadedLocked(repo)
+
+	v := q.ensureValueLocked()
+	if v.cfg.disabled {
+		return false
+	}
+
+	dv := v.entry(repo, rel, now)
+	// Accumulate cost. We keep the running max so a dir that was indexed cheaply
+	// once and expensively later is judged on its worst (most expensive) pass,
+	// and a re-index never "forgets" how expensive the dir is.
+	if cost > dv.cost {
+		dv.cost = cost
+	}
+
+	// Already quarantined (this dir or an ancestor) → nothing to do.
+	if q.isQuarantinedRelLocked(repo, rel) {
+		return false
+	}
+
+	// Gate 1 — expensive?
+	if dv.cost < v.cfg.costThreshold {
+		return false
+	}
+	// Gate 2 — unused for the full grace period? Measure from the last use, or
+	// from when we first saw the dir if it has never been used.
+	since := dv.lastUse
+	if since.IsZero() {
+		since = dv.firstSeen
+	}
+	if now.Sub(since) < v.cfg.unusedGrace {
+		return false
+	}
+
+	// Both gates trip: expensive AND unused. Quarantine with signal="value".
+	detail := "cost " + strconv.FormatInt(dv.cost, 10) + " unused for " + v.cfg.unusedGrace.String()
+	q.quarantineLocked(repo, rel, "value", detail, now)
+	return true
+}
+
+// NoteUsage stamps "the directory containing path was just queried/referenced"
+// so the value detector will never treat it as unused. It reuses the same
+// access signal Q3's Recover observes — wire it from the MCP query hook
+// alongside Recover so both the "recover a quarantined dir" and the "keep a live
+// dir out of value-quarantine" effects fire from one access.
+//
+// Additive, nil/disabled/out-of-repo safe, cheap (a map stamp).
+func (q *QuarantineTracker) NoteUsage(repo, path string) {
+	if q == nil || q.cfg.disabled {
+		return
+	}
+	rel, ok := relDir(repo, path)
+	if !ok {
+		return
+	}
+	now := q.now()
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	v := q.ensureValueLocked()
+	if v.cfg.disabled {
+		return
+	}
+	// Stamp usage for the directory itself and every ancestor up to the repo
+	// root, so a query for a/b/c/x.go marks a, a/b and a/b/c all as used — an
+	// expensive parent whose children are queried is genuinely in use.
+	cur := rel
+	for {
+		dv := v.entry(repo, cur, now)
+		dv.lastUse = now
+		parent := slashDir(cur)
+		if parent == cur {
+			return
+		}
+		cur = parent
+	}
+}

--- a/internal/daemon/watch/quarantine_value_test.go
+++ b/internal/daemon/watch/quarantine_value_test.go
@@ -1,0 +1,262 @@
+package watch
+
+// quarantine_value_test.go — Q4 value-based detection (T2, #5619).
+//
+// These tests exercise the value detector deterministically (fake clock,
+// injected cost via RecordIndexCost, injected usage via NoteUsage, temp repo for
+// persistence). They verify the T2 contract:
+//   - expensive ∧ unused  → quarantined (signal="value");
+//   - expensive ∧ used    → NOT quarantined (recent use vetoes it);
+//   - cheap   ∧ unused    → NOT quarantined (under the cost threshold);
+//   - pinned dir          → never (Sweep skips pins; a later use recovers via Q3);
+//   - recovers on later use (Q3 Recover) and re-evaluates cleanly.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newValueTracker builds a tracker with a fixed value config + fake clock, so
+// the expensive/unused logic runs without real timing, env, or fsnotify. It
+// keeps the churn config from newTestTracker so both detectors coexist.
+func newValueTracker(t *testing.T) (*QuarantineTracker, *fakeClock) {
+	t.Helper()
+	q, clk := newTestTracker(t)
+	q.value = &valueDetector{
+		cfg: valueConfig{
+			costThreshold: 1000,
+			unusedGrace:   24 * time.Hour,
+		},
+		byDir: make(map[string]map[string]*dirValue),
+	}
+	return q, clk
+}
+
+func isQuarantined(q *QuarantineTracker, repo, rel string) bool {
+	for _, r := range q.List(repo) {
+		if r.Rel == rel {
+			return true
+		}
+	}
+	return false
+}
+
+func TestValue_ExpensiveAndUnusedIsQuarantined(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "vendor", "huge", "bundle.js")
+
+	// Record an expensive index pass (over the 1000 threshold). Not yet
+	// quarantined: the unused grace (24h) has not elapsed since first-seen.
+	if q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("expensive dir must NOT quarantine before the unused grace elapses")
+	}
+	if isQuarantined(q, repo, "vendor/huge") {
+		t.Fatalf("dir quarantined too early")
+	}
+
+	// Let a full day of no usage pass, then another index pass observes it: now
+	// it is expensive AND unused → quarantine.
+	clk.advance(25 * time.Hour)
+	if !q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("expensive ∧ unused dir must be quarantined after the grace period")
+	}
+	got := q.List(repo)
+	if len(got) != 1 || got[0].Rel != "vendor/huge" || got[0].Signal != "value" {
+		t.Fatalf("want vendor/huge quarantined with signal=value, got %+v", got)
+	}
+}
+
+func TestValue_ExpensiveButUsedIsNotQuarantined(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "gen", "schema.ts")
+
+	if q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("not expected to quarantine on first record")
+	}
+	// A day passes, but the dir IS queried right before re-evaluation — recent
+	// use must veto the value quarantine no matter how expensive.
+	clk.advance(25 * time.Hour)
+	q.NoteUsage(repo, heavy)
+	if q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("expensive but recently-USED dir must NOT be quarantined")
+	}
+	if isQuarantined(q, repo, "gen") {
+		t.Fatalf("used dir must not be quarantined")
+	}
+}
+
+func TestValue_CheapAndUnusedIsNotQuarantined(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	cheap := filepath.Join(repo, "src", "util.go")
+
+	// Cheap (under the 1000 threshold). Even after a long unused stretch it must
+	// never be quarantined — the cost gate excludes it categorically.
+	if q.RecordIndexCost(repo, cheap, 50) {
+		t.Fatalf("cheap dir must not quarantine")
+	}
+	clk.advance(72 * time.Hour)
+	if q.RecordIndexCost(repo, cheap, 50) {
+		t.Fatalf("cheap ∧ unused dir must NOT be quarantined")
+	}
+	if isQuarantined(q, repo, "src") {
+		t.Fatalf("cheap dir must never be quarantined")
+	}
+}
+
+func TestValue_PinnedDirIsNeverValueQuarantinedAway(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "vendor", "pinned", "x.js")
+
+	// Drive it into a value quarantine, then operator-pins it.
+	q.RecordIndexCost(repo, heavy, 5000)
+	clk.advance(25 * time.Hour)
+	if !q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("setup: expected value quarantine")
+	}
+	if !q.Pin(repo, "vendor/pinned") {
+		t.Fatalf("setup: pin should change state")
+	}
+
+	// A query under the pinned dir must NOT auto-recover it (operator override).
+	rel, recovered := q.Recover(repo, heavy)
+	if recovered || rel != "" {
+		t.Fatalf("pinned value-quarantine must not auto-recover, got (%q,%v)", rel, recovered)
+	}
+	if got := q.List(repo); len(got) != 1 || !got[0].Pinned {
+		t.Fatalf("pinned dir must stay quarantined+pinned, got %+v", got)
+	}
+
+	// And the quiet-window Sweep must never auto-heal a pinned dir either.
+	clk.advance(48 * time.Hour)
+	q.Sweep()
+	if !isQuarantined(q, repo, "vendor/pinned") {
+		t.Fatalf("Sweep must never auto-heal a pinned value-quarantine")
+	}
+}
+
+func TestValue_RecoversOnLaterUse(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "build", "out", "app.js")
+
+	q.RecordIndexCost(repo, heavy, 5000)
+	clk.advance(25 * time.Hour)
+	if !q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("setup: expected value quarantine")
+	}
+
+	// The dir later proves real — its content is queried. Q3 Recover lifts the
+	// value quarantine immediately, same as for a churn quarantine.
+	rel, recovered := q.Recover(repo, heavy)
+	if !recovered || rel != "build/out" {
+		t.Fatalf("query under a value-quarantined dir must recover it, got (%q,%v)", rel, recovered)
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("value-quarantined dir must be gone after recover: %+v", q.List(repo))
+	}
+}
+
+func TestValue_UsageWithinGraceDefersQuarantine(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "data", "blob.json")
+
+	q.RecordIndexCost(repo, heavy, 5000)
+	// 12h in (inside the 24h grace) the dir is queried → resets the unused clock.
+	clk.advance(12 * time.Hour)
+	q.NoteUsage(repo, heavy)
+	// 12h more (24h since first-seen, but only 12h since last use): still used.
+	clk.advance(12 * time.Hour)
+	if q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("a use within grace must reset the unused clock and defer quarantine")
+	}
+	// A further full day with no use → now genuinely unused → quarantine.
+	clk.advance(25 * time.Hour)
+	if !q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("after a full unused day post-use the dir must be quarantined")
+	}
+}
+
+func TestValue_AncestorUsageProtectsExpensiveParent(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	parent := filepath.Join(repo, "pkg", "core.go") // cost attributed to "pkg"
+	child := filepath.Join(repo, "pkg", "sub", "leaf.go")
+
+	q.RecordIndexCost(repo, parent, 5000)
+	clk.advance(25 * time.Hour)
+	// A query touches a CHILD under pkg → marks pkg (and pkg/sub) used.
+	q.NoteUsage(repo, child)
+	if q.RecordIndexCost(repo, parent, 5000) {
+		t.Fatalf("usage under a child must protect the expensive parent from value-quarantine")
+	}
+	if isQuarantined(q, repo, "pkg") {
+		t.Fatalf("pkg must not be quarantined while its children are queried")
+	}
+}
+
+func TestValue_PersistsAcrossReload(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	heavy := filepath.Join(repo, "vendor", "big", "x.js")
+
+	q.RecordIndexCost(repo, heavy, 5000)
+	clk.advance(25 * time.Hour)
+	if !q.RecordIndexCost(repo, heavy, 5000) {
+		t.Fatalf("setup: expected value quarantine")
+	}
+
+	// A fresh tracker reads the persisted set — the value quarantine survives.
+	q2, _ := newValueTracker(t)
+	got := q2.List(repo)
+	if len(got) != 1 || got[0].Rel != "vendor/big" || got[0].Signal != "value" {
+		t.Fatalf("value quarantine must persist across reload, got %+v", got)
+	}
+}
+
+func TestValue_DisabledAndNilSafe(t *testing.T) {
+	var nilq *QuarantineTracker
+	if nilq.RecordIndexCost("/repo", "/repo/x/y.go", 9999) {
+		t.Fatalf("nil receiver RecordIndexCost must be a safe no-op")
+	}
+	nilq.NoteUsage("/repo", "/repo/x/y.go") // must not panic
+
+	repo := t.TempDir()
+	// Whole-tracker kill switch (Q1) disables T2 too.
+	q, clk := newValueTracker(t)
+	q.cfg.disabled = true
+	clk.advance(72 * time.Hour)
+	if q.RecordIndexCost(repo, filepath.Join(repo, "v", "x.js"), 9999) {
+		t.Fatalf("disabled tracker must not value-quarantine")
+	}
+
+	// T2-only kill switch leaves the churn detector alone but disables value.
+	q2, clk2 := newValueTracker(t)
+	q2.value.cfg.disabled = true
+	q2.RecordIndexCost(repo, filepath.Join(repo, "w", "x.js"), 9999)
+	clk2.advance(72 * time.Hour)
+	if q2.RecordIndexCost(repo, filepath.Join(repo, "w", "x.js"), 9999) {
+		t.Fatalf("value-disabled tracker must not value-quarantine")
+	}
+}
+
+func TestValue_OutsideRepoAndZeroCostAreNoOps(t *testing.T) {
+	repo := t.TempDir()
+	q, clk := newValueTracker(t)
+	clk.advance(72 * time.Hour)
+
+	if q.RecordIndexCost(repo, "/elsewhere/x.js", 9999) {
+		t.Fatalf("path outside repo must be a no-op")
+	}
+	if q.RecordIndexCost(repo, filepath.Join(repo, "a", "x.js"), 0) {
+		t.Fatalf("zero cost must be a no-op")
+	}
+	if len(q.List(repo)) != 0 {
+		t.Fatalf("no quarantines expected, got %+v", q.List(repo))
+	}
+}

--- a/internal/mcp/quarantine_recover_5618_test.go
+++ b/internal/mcp/quarantine_recover_5618_test.go
@@ -32,12 +32,17 @@ func absRepoRoot(t *testing.T) string {
 
 type fakeRecoverer struct {
 	calls []struct{ repo, path string }
+	usage []struct{ repo, path string }
 	ret   bool
 }
 
 func (f *fakeRecoverer) Recover(repo, path string) (string, bool) {
 	f.calls = append(f.calls, struct{ repo, path string }{repo, path})
 	return "", f.ret
+}
+
+func (f *fakeRecoverer) NoteUsage(repo, path string) {
+	f.usage = append(f.usage, struct{ repo, path string }{repo, path})
 }
 
 func TestNoteEntityAccess_RelativeSourceResolvedToAbs(t *testing.T) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -287,6 +287,11 @@ type QuarantineRecoverer interface {
 	// Returns the recovered rel and whether anything changed. A no-op (and
 	// cheap) when path is not under a quarantined dir.
 	Recover(repo, path string) (rel string, recovered bool)
+	// NoteUsage records that the directory containing path was just queried /
+	// referenced, so the Q4 value-based detector (#5619) never treats it as
+	// unused. Cheap and best-effort. Same access signal as Recover, but it keeps
+	// a live-but-not-quarantined dir OUT of value-quarantine in the first place.
+	NoteUsage(repo, path string)
 }
 
 // SetQuarantineRecoverer wires the index-quarantine auto-recover hook (#5618)
@@ -311,6 +316,9 @@ func (s *Server) noteEntityAccess(lr *LoadedRepo, srcFile string) {
 		abs = filepath.Join(lr.Path, srcFile)
 	}
 	s.quarantineRecoverer.Recover(lr.Path, abs)
+	// Q4 (#5619): the same access also proves the dir is in use, so it must not
+	// later be value-quarantined as expensive-and-unused.
+	s.quarantineRecoverer.NoteUsage(lr.Path, abs)
 }
 
 // NewServer wires everything together: loads the registry, performs an


### PR DESCRIPTION
## What

Q4 of the self-healing index quarantine (epic #5394, **tier T2 — value-based**, builds on the #5616 substrate). Adds a **second detector** into the existing `QuarantineTracker` (`signal="value"`) alongside the churn detector: quarantine a directory that is **expensive to index AND never used** (queried / referenced).

Churn (T1) catches a dir that *keeps re-triggering work*. Value (T2) catches the quieter case: a dir that *costs a lot and earns nothing*.

## Mechanism

Two cheap per-directory signals, joined:

- **COST** — `RecordIndexCost(repo, path, cost)`, an additive method the index/parse path calls with whatever monotonic "work" proxy it has cheaply to hand (parse-ms, entity count, or file count). Running max per dir.
- **USAGE** — `NoteUsage(repo, path)` stamps last-used=now for the dir **and every ancestor**. It reuses the exact access signal Q3's `Recover` already observes, wired from the MCP query hook (`noteEntityAccess`) alongside `Recover` — so one query both recovers a quarantined dir and keeps a live dir *out* of value-quarantine in the first place.

**Predicate:** quarantine with `signal="value"` iff, when fresh cost is recorded, BOTH hold — (1) accumulated cost ≥ `CostThreshold`, and (2) zero usage for ≥ `UnusedGrace` (measured from last use, or first-seen if never used). A cheap dir is never quarantined no matter how unused; a recently-used dir is never quarantined no matter how expensive.

## Safety (same bar as T1)

- Both gates must trip (conservative); long default grace (24h) so a momentarily-idle dir isn't mistaken for dead.
- Pins respected; repo root never quarantined.
- Persists via the shared `.grafel/quarantine.json`; self-heals exactly like a churn quarantine — Q3 `Recover` (a later query) and the quiet-window `Sweep` both lift it.
- Kill switches: `GRAFEL_QUARANTINE_DISABLE` (whole tracker) + `GRAFEL_QUARANTINE_VALUE_DISABLE` (T2 only). Env-tunable: `GRAFEL_QUARANTINE_VALUE_COST`, `GRAFEL_QUARANTINE_VALUE_UNUSED_SEC`. Defaults: cost 2000 work units, grace 24h.

## Conflict avoidance (#5620 in parallel on this file)

All value logic lives in the new `internal/daemon/watch/quarantine_value.go` (+ test). The only edit to `quarantine.go` is a single reserved tracker field `value *valueDetector` (lazily initialised). The Q5 content detector (#5620) gets its own file — no collision.

## Tests

Deterministic (fake clock, injected cost + usage):
expensive∧unused → quarantined; expensive∧used → **not**; cheap∧unused → **not**; pinned → never (Sweep + Recover both skip); recovers on later use; ancestor-usage protects an expensive parent; usage-within-grace defers; persist across reload; nil/disabled/value-disabled/out-of-repo/zero-cost no-ops. Plus the MCP hook now feeds `NoteUsage` alongside `Recover`.

`go build ./...`, `go test -count=1 ./internal/daemon/watch/... ./internal/mcp/...`, `gofmt -l`, `go vet` — all green.

Closes #5619.

🤖 Generated with [Claude Code](https://claude.com/claude-code)