### PR TITLE
feat(treesitter): bump go-tree-sitter to v0.25 (ABI-15 runtime, no grammar changes) (#5650)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
 	github.com/tree-sitter-grammars/tree-sitter-toml v0.7.0
 	github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2
-	github.com/tree-sitter/go-tree-sitter v0.24.0
+	github.com/tree-sitter/go-tree-sitter v0.25.0
 	github.com/tree-sitter/tree-sitter-bash v0.23.3
 	github.com/tree-sitter/tree-sitter-c v0.23.6
 	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -189,6 +189,8 @@ github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2 h1:Mmr9LYGTdr+8iD3ZEK1+j
 github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2/go.mod h1:tOZ8GmiIfLySKNOX58+PV2mvjFJdfciksfwotcELKbg=
 github.com/tree-sitter/go-tree-sitter v0.24.0 h1:kRZb6aBNfcI/u0Qh8XEt3zjNVnmxTisDBN+kXK0xRYQ=
 github.com/tree-sitter/go-tree-sitter v0.24.0/go.mod h1:x681iFVoLMEwOSIHA1chaLkXlroXEN7WY+VHGFaoDbk=
+github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
+github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
 github.com/tree-sitter/tree-sitter-bash v0.23.3 h1:6vE1tnlj04h/DGM+4RVMoVRcHLZ+NgWt7Fucj9XXyUA=
 github.com/tree-sitter/tree-sitter-bash v0.23.3/go.mod h1:AksQ6zE+sP9hnp7mKTMT7Q+CwpthV7VGQLXvweVXz9U=
 github.com/tree-sitter/tree-sitter-c v0.23.6 h1:aHcghKEBgyUDUcCKFT5fELp26UBU7RBltj5MkRYxyy8=

--- a/internal/treesitter/parser_test.go
+++ b/internal/treesitter/parser_test.go
@@ -315,6 +315,21 @@ func TestSupportedLanguages_EachLanguageParsesSnippet(t *testing.T) {
 			if err == nil && res.TSTree == nil {
 				t.Errorf("Parse(%s) returned nil tree", lang)
 			}
+			// ABI smoke gate (#5650, ABI-15 runtime bump): prove every
+			// registered grammar still loads under the active runtime by
+			// reaching the root node without a panic. An out-of-window grammar
+			// SIGSEGVs here under the old behavior, or — under v0.25 — fails at
+			// parser init (abiGuard / SetLanguage); either way this asserts the
+			// happy path produces a reachable, non-ERROR root.
+			if res.TSTree != nil {
+				root := res.TSTree.RootNode()
+				if root == nil {
+					t.Fatalf("Parse(%s): RootNode() is nil (ABI mismatch?)", lang)
+				}
+				if root.IsError() {
+					t.Errorf("Parse(%s): root node is ERROR", lang)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What

Wave A of the ABI-15 program (#5473): the **runtime-only** swap.

- Bump `github.com/tree-sitter/go-tree-sitter` **v0.24.0 → v0.25.0**, which bundles the tree-sitter v0.25 C runtime (**ABI 15**). `go mod tidy` run.
- **No grammar module versions changed.** All current ABI 13/14 grammars keep loading under the v0.25 runtime via `MIN_COMPATIBLE_LANGUAGE_VERSION = 13` (backward-compatible window). No extractor or golden changes.

## Compile impact

The binding API is backward-compatible. The `ts/official` adapter uses `Parse(text, nil)` (not the deprecated timeout/cancellation-flag APIs), so it compiles **unchanged** — no `ParseWithOptions` migration was needed. The per-language `abiGuard` (belt-and-suspenders) is retained as-is.

Bonus from v0.25: an out-of-window grammar now fails at parser init (`SetLanguage` returns a `LanguageError`) instead of compiling and SIGSEGV-ing at `RootNode()`.

## ABI smoke gate

`TestSupportedLanguages_EachLanguageParsesSnippet` already parses a snippet for every registered language; this PR strengthens it to also assert `RootNode()` is reachable and **non-ERROR** for each grammar. An ABI regression now surfaces as a loud test failure rather than a crash. All 28 entries green locally under the v0.25 runtime.

## Local validation (light — heavy build deferred to CI)

- `go build ./internal/treesitter/...` (CGO) — green
- smoke gate + parser tests — green (28/28 grammars)
- `gofmt -l` — clean

The full `go test ./...` (Go + CGO) and the **3-OS CI gate (incl. Windows)** do the heavy grammar-load validation.

Closes #5650

🤖 Generated with [Claude Code](https://claude.com/claude-code)