### PR TITLE
perf(daemon): skip periodic group-algo recompute when graph unchanged (#5655)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -821,10 +821,15 @@ func daemonGroupsForRepo(repoPath string) []string {
 }
 
 // daemonSchedulerStaleGroups returns the names of registered groups whose
-// group-algo overlay EXISTS on disk but has gone STALE relative to the current
-// per-repo graph.fb mtimes (#5403). It powers the scheduler's periodic
-// overlay-freshness sweep so a SETTLED group (no recent reindex → no link pass →
-// no scheduleGroupAlgo) still gets its stale overlay recomputed.
+// group-algo overlay EXISTS on disk, has gone stale relative to the per-repo
+// graph.fb mtimes, AND whose community-input graph actually CHANGED (#5403 +
+// #5655). It powers the scheduler's periodic overlay-freshness sweep so a
+// SETTLED group (no recent reindex → no link pass → no scheduleGroupAlgo) still
+// gets its overlay recomputed — but ONLY when a recompute would change anything.
+// OverlayNeedsRecompute applies the content gate (graph.CommunityInputHash): a
+// mere mtime drift whose community input is identical (a docs/comment/config
+// push, or an idle re-stat) settles the overlay in place and is NOT returned
+// here, so the sweep no longer fires a ~½-core Louvain burst on an idle daemon.
 //
 // Groups with NO overlay yet are deliberately excluded (OverlayNeedsRecompute
 // returns false for an absent overlay): those take the normal first-compute

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -27,6 +27,7 @@ package groupalgo
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
@@ -313,17 +314,38 @@ func IsOverlayStale(ov *Overlay, currentMtimes map[string]int64) bool {
 }
 
 // OverlayNeedsRecompute reports whether a group has an overlay on disk that has
-// gone STALE relative to the current per-repo graph.fb mtimes (#5403). It is the
+// gone STALE relative to the current per-repo graph.fb mtimes (#5403) AND whose
+// community-relevant input graph has actually CHANGED (#5655). It is the
 // settled-group freshness predicate the daemon's overlay sweep uses to decide
-// whether to proactively re-arm a group-algo pass.
+// whether to proactively re-arm a (heavy) group-algo pass.
+//
+// The mtime check is a cheap FIRST gate. But an mtime drift alone does NOT imply
+// the community-detection output would change: a docs-only / comment-only /
+// config-only push bumps a repo's graph.fb mtime while leaving the community
+// input graph (node-id set + weighted directed edge set) identical. Before
+// #5655 the sweep re-armed a full Louvain+PageRank+betweenness recompute on
+// every such mtime drift, so on an active group the periodic sweep fired a
+// ~½-core burst every interval even when the graph never changed (310 observed
+// recomputes since boot with no driving change).
+//
+// So when the mtime gate trips, this confirms with the deterministic content
+// gate (graph.CommunityInputHash, the same one RunGroupAlgorithmsIncremental
+// uses): if the freshly assembled union's hash still equals the overlay's stored
+// input_hash, a recompute would reproduce the existing overlay byte-for-byte —
+// there is nothing to recompute. In that case the overlay's source_mtimes are
+// refreshed IN PLACE (a cheap atomic rewrite, no algorithms) so the mtime gate
+// settles and does not re-trip next tick, and this returns false (the sweep
+// skips). A genuine input change (hash differs) returns true and the sweep arms
+// the full recompute as before.
 //
 // Crucially it returns false for an ABSENT overlay: a group that has never had a
 // group-algo pass should be left to the normal first-compute path (the link-pass
 // chain after its first reindex), NOT force-recomputed by the sweep. Only an
-// overlay that EXISTS and no longer matches the live graphs is "needs recompute".
-// A malformed/unreadable overlay also returns false (don't thrash on garbage;
-// the next reindex's pass rewrites it). Any error resolving the group or its
-// mtimes returns false — the sweep is best-effort and must never wedge.
+// overlay that EXISTS, no longer matches the live graphs, AND has a changed input
+// hash is "needs recompute". A malformed/unreadable overlay also returns false
+// (don't thrash on garbage; the next reindex's pass rewrites it). Any error
+// resolving the group or its mtimes returns false — the sweep is best-effort and
+// must never wedge.
 func OverlayNeedsRecompute(group string) bool {
 	path, err := OverlayPath(group)
 	if err != nil || path == "" {
@@ -342,5 +364,41 @@ func OverlayNeedsRecompute(group string) bool {
 	if err != nil {
 		return false
 	}
-	return IsOverlayStale(&ov, cur)
+	if !IsOverlayStale(&ov, cur) {
+		return false // mtimes match → fresh; cheapest path, no assembly needed.
+	}
+
+	// mtime drift detected. Confirm with the content gate before declaring a
+	// recompute necessary. An overlay with no recorded input_hash (written before
+	// the field existed) cannot be content-checked → fall back to the mtime
+	// verdict and recompute.
+	if ov.InputHash == "" {
+		return true
+	}
+	entities, rels, _, srcMtimes, aerr := AssembleGroupGraph(group)
+	if aerr != nil {
+		// Cannot assemble the union to hash-check → defer to the mtime verdict.
+		return true
+	}
+	if graph.CommunityInputHash(entities, rels) != ov.InputHash {
+		return true // community input genuinely changed → recompute.
+	}
+
+	// Unchanged community input despite an mtime drift (docs/comment/config push,
+	// or an idle re-stat): the existing overlay is exactly what a recompute would
+	// produce. Settle the mtime gate by refreshing source_mtimes in place — a
+	// cheap atomic rewrite, NO Louvain/PageRank/betweenness — so the sweep does
+	// not re-trip every interval. Preserve every other field verbatim.
+	ov.SourceMtimes = srcMtimes
+	if werr := WriteOverlayTo(path, &ov); werr != nil {
+		// Best-effort: if the settle write fails we simply re-evaluate next tick.
+		// Do NOT force a recompute on a write hiccup.
+		_ = werr
+	}
+	// Observable counterpart to the scheduler's "group-algo: starting": a sweep
+	// tick that found the group mtime-stale but content-identical skips the heavy
+	// pass entirely (#5655). This is the line an idle daemon should log every
+	// interval instead of re-running Louvain.
+	slog.Default().Info("group-algo: skipped (unchanged)", "group", group)
+	return false
 }

--- a/internal/graph/groupalgo/overlay_needs_recompute_content_5655_test.go
+++ b/internal/graph/groupalgo/overlay_needs_recompute_content_5655_test.go
@@ -1,0 +1,169 @@
+package groupalgo
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #5655: the periodic overlay-freshness sweep used a PURELY mtime-based
+// predicate (OverlayNeedsRecompute), so any graph.fb mtime bump — including a
+// docs-only / comment-only / config-only push, or an idle re-stat — re-armed a
+// full Louvain+PageRank+betweenness recompute even when the community input
+// graph was identical. That made an "idle" daemon burn a ~½-core burst every
+// sweep interval (310 observed recomputes with no driving change).
+//
+// The fix routes the predicate through the SAME deterministic content gate
+// (graph.CommunityInputHash) the incremental reindex path uses: an mtime drift
+// is only "needs recompute" when the input hash actually changed. An unchanged
+// input settles the overlay's source_mtimes in place (no algorithms) and
+// reports false, so the sweep skips.
+
+// writeFreshOverlay computes the group's real algo result and writes it with a
+// correct input_hash + current source_mtimes — the state right after a compute.
+func writeFreshOverlay(t *testing.T, group string) *GroupAlgoResult {
+	t.Helper()
+	res, err := RunGroupAlgorithms(group)
+	if err != nil {
+		t.Fatalf("RunGroupAlgorithms: %v", err)
+	}
+	if err := WriteOverlayFromResult(res); err != nil {
+		t.Fatalf("WriteOverlayFromResult: %v", err)
+	}
+	return res
+}
+
+// TestOverlayNeedsRecompute_UnchangedContent_Skips proves the periodic-sweep
+// win: a graph.fb mtime drift whose community input graph is IDENTICAL must NOT
+// report needs-recompute (so the sweep skips the heavy pass), the overlay must
+// be PRESERVED verbatim, and the mtime gate must be SETTLED so the next sweep
+// tick does not re-trip.
+func TestOverlayNeedsRecompute_UnchangedContent_Skips(t *testing.T) {
+	group, pathA, _, _ := setupIncrGroup(t)
+	first := writeFreshOverlay(t, group)
+
+	path, err := OverlayPath(group)
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+	before := readOverlayUnconditional(path)
+	if before == nil || before.InputHash == "" {
+		t.Fatal("setup: overlay must exist with an input_hash")
+	}
+
+	// Docs-only push shape: rewrite repo-A's graph.fb with the SAME community
+	// graph but a changed non-structural property → graph.fb mtime bumps, the
+	// community input hash is unchanged. The mtime gate trips; the content gate
+	// must veto the recompute.
+	repoA, _, _ := fixtureGraphs()
+	for i := range repoA.Entities {
+		if repoA.Entities[i].Properties == nil {
+			repoA.Entities[i].Properties = map[string]string{}
+		}
+		repoA.Entities[i].Properties["description"] = "edited docs"
+	}
+	writeFixtureRepo(t, "svc", pathA, repoA)
+
+	// Sanity: the mtime gate alone WOULD trip (the overlay's recorded mtimes no
+	// longer match) — so the skip is genuinely the content gate's doing.
+	cur, err := CurrentSourceMtimes(group)
+	if err != nil {
+		t.Fatalf("CurrentSourceMtimes: %v", err)
+	}
+	if !IsOverlayStale(before, cur) {
+		t.Fatal("setup: expected the mtime gate to trip after the docs edit")
+	}
+
+	if OverlayNeedsRecompute(group) {
+		t.Fatal("unchanged community input must NOT report needs-recompute (sweep should skip)")
+	}
+
+	// Overlay preserved verbatim (only source_mtimes settled).
+	after := readOverlayUnconditional(path)
+	if after == nil {
+		t.Fatal("overlay vanished after skip")
+	}
+	if after.InputHash != before.InputHash {
+		t.Errorf("input_hash drifted across a skip: %s != %s", after.InputHash, before.InputHash)
+	}
+	if len(after.Results) != len(before.Results) {
+		t.Errorf("results changed across a skip: %d != %d", len(after.Results), len(before.Results))
+	}
+	if after.InputHash != first.InputHash {
+		t.Errorf("skip overlay hash != original compute hash")
+	}
+
+	// mtime gate SETTLED: a second sweep tick must also skip (no re-trip).
+	if OverlayNeedsRecompute(group) {
+		t.Fatal("second sweep re-tripped after the skip settled source_mtimes")
+	}
+	settled := readOverlayUnconditional(path)
+	if IsOverlayStale(settled, cur) {
+		t.Fatal("source_mtimes were not settled to the current graph.fb after the skip")
+	}
+}
+
+// TestOverlayNeedsRecompute_ChangedContent_Recomputes proves correctness is
+// preserved: a genuine structural change (new tightly-connected cluster +
+// cross-cluster edge) flips the input hash, so the predicate reports
+// needs-recompute and the sweep arms the full pass.
+func TestOverlayNeedsRecompute_ChangedContent_Recomputes(t *testing.T) {
+	group, pathA, _, serviceID := setupIncrGroup(t)
+	writeFreshOverlay(t, group)
+
+	// Structural change in repo-A: add a new cluster wired into the existing graph.
+	repoA, _, _ := fixtureGraphs()
+	mkEnt := func(name string) graph.Entity {
+		return graph.Entity{ID: "svc:" + name, Name: name, Kind: "function", SourceFile: "svc/" + name + ".go", Language: "go"}
+	}
+	mkRel := func(from, to string) graph.Relationship {
+		return graph.Relationship{ID: from + "->" + to, FromID: from, ToID: to, Kind: "CALLS"}
+	}
+	cluster := []string{"c1", "c2", "c3", "c4", "c5", "c6"}
+	for _, n := range cluster {
+		repoA.Entities = append(repoA.Entities, mkEnt(n))
+	}
+	for i := 0; i < len(cluster); i++ {
+		for j := i + 1; j < len(cluster); j++ {
+			repoA.Relationships = append(repoA.Relationships, mkRel("svc:"+cluster[i], "svc:"+cluster[j]))
+		}
+	}
+	repoA.Relationships = append(repoA.Relationships, mkRel("svc:c1", serviceID))
+	writeFixtureRepo(t, "svc", pathA, repoA)
+
+	if !OverlayNeedsRecompute(group) {
+		t.Fatal("a genuine structural change MUST report needs-recompute")
+	}
+}
+
+// TestOverlayNeedsRecompute_LegacyOverlayNoHash_Recomputes: an overlay written
+// before the input_hash field existed cannot be content-checked, so an mtime
+// drift falls back to the mtime verdict (recompute) — never silently skipped.
+func TestOverlayNeedsRecompute_LegacyOverlayNoHash_Recomputes(t *testing.T) {
+	group, pathA, _, _ := setupIncrGroup(t)
+	writeFreshOverlay(t, group)
+
+	// Strip the input_hash to simulate a pre-#5309 overlay, keep stale mtimes.
+	path, err := OverlayPath(group)
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+	ov := readOverlayUnconditional(path)
+	if ov == nil {
+		t.Fatal("setup: overlay missing")
+	}
+	ov.InputHash = ""
+	if err := WriteOverlayTo(path, ov); err != nil {
+		t.Fatalf("rewrite legacy overlay: %v", err)
+	}
+
+	// Bump a graph.fb mtime (any content edit) so the mtime gate trips.
+	repoA, _, _ := fixtureGraphs()
+	repoA.Entities[0].Properties = map[string]string{"x": "y"}
+	writeFixtureRepo(t, "svc", filepath.Join(pathA), repoA)
+
+	if !OverlayNeedsRecompute(group) {
+		t.Fatal("a hash-less (legacy) overlay must defer to the mtime verdict and recompute")
+	}
+}


### PR DESCRIPTION
## Problem
The daemon's periodic overlay-freshness sweep recomputed the group-scope graph algorithms (Louvain communities + PageRank + betweenness) on its interval using a **purely mtime-based** staleness predicate. Any `graph.fb` mtime drift — a docs-only / comment-only / config-only push, or an idle re-stat — re-armed a **full** recompute even when the community-relevant input graph was identical. Each pass is a ~½-core burst, so an "idle" daemon never truly idled.

## Root cause
The content gate (`CommunityInputHash`) added in the incremental-reindex work was **not consulted by the periodic sweep's predicate** (`OverlayNeedsRecompute`) — that predicate only compared per-repo `graph.fb` mtimes, which move on any push regardless of whether the community graph changed.

## Fix
Route the predicate through the same deterministic content gate the incremental reindex path uses:
- The mtime check stays as a cheap **first filter**.
- When it trips, assemble the union (cheap) and compare the fresh `CommunityInputHash` to the overlay's stored `input_hash`.
  - **Hash matches** (unchanged community input): refresh the overlay's `source_mtimes` **in place** — a cheap atomic rewrite, **no Louvain/PageRank/betweenness** — so the mtime gate settles and does not re-trip next tick. Report `false` (sweep skips) and log `group-algo: skipped (unchanged)`.
  - **Hash differs** (genuine structural change): report `true` — the sweep arms the full recompute exactly as before. Correctness preserved.
- A hash-less **legacy** overlay (pre-hash field) defers to the mtime verdict and recomputes — never silently skipped.

Net effect: an idle daemon stops re-running the group algorithms; the periodic sweep logs skips instead of bursts.

## Tests
`internal/graph/groupalgo/overlay_needs_recompute_content_5655_test.go`:
- unchanged community input (docs-only-shape mtime drift) → predicate returns `false`, overlay preserved verbatim, `source_mtimes` settled so a second tick also skips;
- genuine structural change → predicate returns `true` (recompute);
- legacy hash-less overlay → defers to mtime verdict (recompute).

`go build ./...`; `go test -count=1 ./internal/graph/groupalgo/... ./internal/daemon/sched/...` green; `gofmt -l` clean.

Do not merge.