### PR TITLE
revert: ABI-15 runtime bump (#5654) — daemon parse-loop regression

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/tree-sitter-grammars/tree-sitter-lua v0.3.0
 	github.com/tree-sitter-grammars/tree-sitter-toml v0.7.0
 	github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2
-	github.com/tree-sitter/go-tree-sitter v0.25.0
+	github.com/tree-sitter/go-tree-sitter v0.24.0
 	github.com/tree-sitter/tree-sitter-bash v0.23.3
 	github.com/tree-sitter/tree-sitter-c v0.23.6
 	github.com/tree-sitter/tree-sitter-c-sharp v0.23.1

--- a/go.sum
+++ b/go.sum
@@ -189,8 +189,6 @@ github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2 h1:Mmr9LYGTdr+8iD3ZEK1+j
 github.com/tree-sitter-grammars/tree-sitter-yaml v0.7.2/go.mod h1:tOZ8GmiIfLySKNOX58+PV2mvjFJdfciksfwotcELKbg=
 github.com/tree-sitter/go-tree-sitter v0.24.0 h1:kRZb6aBNfcI/u0Qh8XEt3zjNVnmxTisDBN+kXK0xRYQ=
 github.com/tree-sitter/go-tree-sitter v0.24.0/go.mod h1:x681iFVoLMEwOSIHA1chaLkXlroXEN7WY+VHGFaoDbk=
-github.com/tree-sitter/go-tree-sitter v0.25.0 h1:sx6kcg8raRFCvc9BnXglke6axya12krCJF5xJ2sftRU=
-github.com/tree-sitter/go-tree-sitter v0.25.0/go.mod h1:r77ig7BikoZhHrrsjAnv8RqGti5rtSyvDHPzgTPsUuU=
 github.com/tree-sitter/tree-sitter-bash v0.23.3 h1:6vE1tnlj04h/DGM+4RVMoVRcHLZ+NgWt7Fucj9XXyUA=
 github.com/tree-sitter/tree-sitter-bash v0.23.3/go.mod h1:AksQ6zE+sP9hnp7mKTMT7Q+CwpthV7VGQLXvweVXz9U=
 github.com/tree-sitter/tree-sitter-c v0.23.6 h1:aHcghKEBgyUDUcCKFT5fELp26UBU7RBltj5MkRYxyy8=

--- a/internal/treesitter/parser_test.go
+++ b/internal/treesitter/parser_test.go
@@ -315,21 +315,6 @@ func TestSupportedLanguages_EachLanguageParsesSnippet(t *testing.T) {
 			if err == nil && res.TSTree == nil {
 				t.Errorf("Parse(%s) returned nil tree", lang)
 			}
-			// ABI smoke gate (#5650, ABI-15 runtime bump): prove every
-			// registered grammar still loads under the active runtime by
-			// reaching the root node without a panic. An out-of-window grammar
-			// SIGSEGVs here under the old behavior, or — under v0.25 — fails at
-			// parser init (abiGuard / SetLanguage); either way this asserts the
-			// happy path produces a reachable, non-ERROR root.
-			if res.TSTree != nil {
-				root := res.TSTree.RootNode()
-				if root == nil {
-					t.Fatalf("Parse(%s): RootNode() is nil (ABI mismatch?)", lang)
-				}
-				if root.IsError() {
-					t.Errorf("Parse(%s): root node is ERROR", lang)
-				}
-			}
 		})
 	}
 }


### PR DESCRIPTION
Reverts #5654 (go-tree-sitter v0.24→v0.25 / ABI-15 runtime). The v0.25 runtime causes a daemon **parse loop**: the live daemon sat ~26 min at the ½-core cap in pure tree-sitter parsing (`ts_parser_parse`) with no log, no file changes, no external trigger — an internal re-parse loop. The pre-Wave-A build (v0.1.6+#5648) does not. Unit tests pass (grammars load) because a parse loop only manifests in the long-running daemon. Reverting to keep main releasable while the v0.25 parse-behavior regression is root-caused. #5473 (ABI-15) stays open; Wave A will be re-attempted once the regression is understood + a daemon parse-loop guard exists.