### PR TITLE
fix(treesitter): per-parse watchdog so a runaway parse can't pin the daemon (#5473)

### DIFF
--- a/internal/treesitter/ts/official/official.go
+++ b/internal/treesitter/ts/official/official.go
@@ -15,6 +15,8 @@ package official
 
 import (
 	"errors"
+	"fmt"
+	"time"
 
 	tsofficial "github.com/tree-sitter/go-tree-sitter"
 
@@ -23,6 +25,24 @@ import (
 
 // adapterName is stamped on every Language this adapter produces.
 const adapterName = "official"
+
+// parseWatchdogTimeout bounds a single tree-sitter parse so a pathological
+// input can never pin the daemon indefinitely (#5473).
+//
+// Why this exists: go-tree-sitter v0.25 made Parser.Parse(text, oldTree) a thin
+// wrapper over ParseWithOptions(cb, oldTree, nil) — i.e. NO ParseOptions, hence
+// NO progress callback, so the parse is UNCANCELLABLE. v0.24's ParseCtx could
+// interrupt a parse by setting the cancellation flag; that flag path is
+// deprecated in v0.25 and the progress callback is now the only interrupt
+// mechanism. A v0.25 build was observed pinned ~26 min in pure C parsing
+// (ts_parser_parse / ts_node_child) on a single file, and because the factory
+// holds a process-wide parse mutex (issue #481) AND a parse slot across the
+// call, that one hung parse froze the whole in-process index pipeline. This
+// watchdog supplies a progress callback keyed off a wall-clock deadline: a
+// runaway parse is cancelled at the next callback tick, returning a nil tree
+// that the factory turns into a bounded, logged failure instead of an
+// unbounded hang. Defensive and worth keeping independent of the v0.25 bump.
+const parseWatchdogTimeout = 20 * time.Second
 
 var errWrongAdapter = errors.New("treesitter/ts/official: language was not produced by the official adapter")
 
@@ -70,11 +90,41 @@ type Parser struct {
 	p *tsofficial.Parser
 }
 
-// Parse implements ts.Parser. The official binding does not return an error;
-// a nil tree maps to (nil, nil).
+// Parse implements ts.Parser. It does a fresh parse (no oldTree reuse) bounded
+// by a wall-clock watchdog (see parseWatchdogTimeout): instead of the bare,
+// uncancellable p.Parse(source, nil), it calls ParseWithOptions with a progress
+// callback that cancels once the deadline passes. A cancelled or empty parse
+// yields a nil tree; a genuine empty parse maps to (nil, nil), while a
+// watchdog-cancelled parse returns a sentinel error so the caller logs a
+// bounded failure rather than the daemon silently hanging (#5473).
 func (p *Parser) Parse(source []byte) (ts.Tree, error) {
-	tree := p.p.Parse(source, nil)
+	deadline := time.Now().Add(parseWatchdogTimeout)
+	canceled := false
+	tree := p.p.ParseWithOptions(
+		func(offset int, _ tsofficial.Point) []byte {
+			if offset >= len(source) {
+				return nil
+			}
+			return source[offset:]
+		},
+		nil,
+		&tsofficial.ParseOptions{
+			// Returning true CANCELS the parse. tree-sitter invokes this
+			// periodically from its main parse loop, so a runaway parse is
+			// broken at the next tick instead of spinning forever.
+			ProgressCallback: func(tsofficial.ParseState) bool {
+				if time.Now().After(deadline) {
+					canceled = true
+					return true
+				}
+				return false
+			},
+		},
+	)
 	if tree == nil {
+		if canceled {
+			return nil, fmt.Errorf("treesitter/official: parse exceeded %s watchdog and was cancelled (possible pathological/v0.25 parse loop)", parseWatchdogTimeout)
+		}
 		return nil, nil
 	}
 	return &Tree{t: tree}, nil


### PR DESCRIPTION
## v0.25 daemon parse-loop — root-cause hypothesis + guard (Wave A / #5654)

**Symptom recap.** A daemon built from the `go-tree-sitter v0.24.0 → v0.25.0` bump sat ~26 min pinned at the ½-core parse cap, only `ts_parser_parse` / `ts_node_child` hot in `sample`, log frozen, no file changes, no MCP client, no quarantine — an internal re-parse with no external trigger. v0.24 settles fine. Unit tests pass.

### What I verified in the code (not speculation)
- `internal/treesitter/ts/official/official.go` `Parse` did a **fresh** parse: `p.p.Parse(source, nil)` — **nil oldTree, no incremental reuse**. So the "reused/edited old-tree fails to converge" theory is *out*; this is a from-scratch parse.
- There is **no timeout / progress callback / `ParseWithOptions` anywhere** in the repo. The parse was completely unbounded.
- `internal/treesitter/parser.go` holds **`parseMu` (issue #481) across the entire `p.Parse(source)` call** — a single global mutex serialising every in-process parse. It also holds a **parse slot** (`indexstate.AcquireParseSlot`, #5630) across the call. The parse-gate caps *concurrency* (the ½-core cap), **not per-parse duration**.

### Root cause — two layers

**Trigger (hypothesis): v0.25's ABI-15 core loops on an ABI-14 grammar / specific input.** v0.25 bumps tree-sitter core to **ABI 15** (adds reserved-words, supertype, language-name metadata to the parser). grafel's grammars are pinned at **v0.23.x = ABI 14** (go.mod). ABI 14 is *within* the supported range, so `SetLanguage` does **not** error and the `abiGuard` smoke-parse on trivial source passes — which is exactly why unit tests stay green. But ADR-0023 §6 already documents this runtime/grammar ABI window as the known hazard ("compiles + loads + trivial input works, real input crashes": runtime v0.24 + grammar v0.25 SIGSEGV'd at RootNode). Wave A is the same mismatch in the other direction (runtime v0.25 / grammar v0.23) and manifests as a **non-crashing infinite error-recovery loop** instead of a SIGSEGV. v0.25's changelog also shows heavy churn in the loop-prone areas (zero-width-token sibling traversal, `get_column` cache, saturating-subtraction underflow fix, "parsing hang with empty-point ranges") — a regression in that surface on a real file is equally plausible. The `ts_parser_parse` + `ts_node_child` hot frames = the main parse loop cycling through error recovery, consistent with both.

**Amplifier (verified, and the reason 26 min of total freeze): the parse is uncancellable AND serialised.** In v0.25, `Parser.Parse(text, oldTree)` is now literally `ParseWithOptions(cb, oldTree, nil)` — **nil options ⇒ no progress callback ⇒ the parse cannot be interrupted**. v0.24's `ParseCtx` could set the (now-deprecated) cancellation flag; v0.25 removed that as the interrupt path in favour of the progress callback, which grafel never adopted. So the one hung C parse never returns to Go → it holds `parseMu` (#481) and its parse slot forever → **every** other in-process parse blocks → the whole reactive/incremental index pipeline freezes and the log goes silent. The "no external trigger" is the in-process reactive/incremental reindex (`parsegate.go` header: `extractors.TryIncremental`) re-parsing a watched file after the daemon went idle.

### Fix plan for re-attempting Wave A safely
1. **Keep grammars inside the runtime's ABI window** and add a real (non-trivial) parse to the bench/smoke gate — the trivial `abiGuard` source cannot catch a mismatch that only loops on real input. Consider pinning the runtime and only accepting grammar versions within its ABI window (ADR-0023 §6 already recommends this).
2. When re-bumping, **adopt `ParseWithOptions`** (the v0.25-native API) rather than the bare `Parse`, so cancellation is wired in from the start.

### Defensive guard (staged on the branch, valuable regardless of cause)
A **per-parse wall-clock watchdog** in `official.Parse`: call `ParseWithOptions` with a `ProgressCallback` that returns `true` (cancel) once a 20s deadline passes. tree-sitter ticks the progress callback from its main parse loop, so a runaway parse is broken at the next tick, returns a nil tree, and the factory turns it into a **bounded, logged error** — releasing `parseMu` and the slot. This would have turned the 26-min total freeze into one logged per-file failure. → branch `chore/v25-regress-investigate-5473`, draft PR linked below. (Caveat: a true tight C loop that never reaches a callback site would still need an upstream fix; the observed sample was in the main loop, which does tick.)

### Definitive reproduction (for the follow-up)
Build the daemon **with symbols** (drop `-s -w`) + enable `/debug/pprof`, repro on the offending repo, and capture the **Go** stack + a `ts_parser_parse` CPU profile to pin the exact grammar+file (and confirm ABI-mismatch vs core-regression). A `-test.cpuprofile` harness that parses the corpus under v0.25 would isolate it in CI without the live daemon.

> Build of the staged guard was **not** verified locally (host load >12 during the session — machine-safety gate). gofmt is clean and the API matches `go-tree-sitter@v0.25.0` source; needs `go build ./internal/treesitter/...` before un-drafting.
