### PR TITLE
feat(treesitter): per-parse watchdog + bounded parseMu — no single parse can freeze the daemon (#5658)

### DIFF
--- a/internal/treesitter/parse_watchdog_5473_test.go
+++ b/internal/treesitter/parse_watchdog_5473_test.go
@@ -1,0 +1,121 @@
+package treesitter_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/treesitter"
+	"github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// bigGoSource builds a large but syntactically valid Go file whose parse takes
+// far longer than a sub-millisecond budget, so a tiny GRAFEL_PARSE_TIMEOUT
+// halts it deterministically (the C deadline is checked periodically from the
+// main parse loop, which a 600KB+ input cycles through many times). This is the
+// "controllable input" stand-in for a real runaway — we make the parse provably
+// exceed the deadline without depending on a pathological grammar/input.
+func bigGoSource(terms int) []byte {
+	var b strings.Builder
+	b.WriteString("package p\n\nvar x = 1")
+	for i := 0; i < terms; i++ {
+		b.WriteString(" + 1")
+	}
+	b.WriteString("\n")
+	return []byte(b.String())
+}
+
+// TestParse_WatchdogHaltsRunawayAndReleasesLock proves the #5473 safety net:
+//  1. a parse that exceeds the per-parse deadline returns a BOUNDED, sentinel
+//     error (official.ErrParseDeadlineExceeded) instead of hanging, and
+//  2. parseMu is released afterwards — a subsequent normal parse succeeds
+//     (a leaked lock would deadlock here, which the timed wait surfaces as a
+//     clear failure rather than a hang).
+func TestParse_WatchdogHaltsRunawayAndReleasesLock(t *testing.T) {
+	// Arm the watchdog tightly. 1ms is comfortably above tree-sitter's deadline
+	// granularity (the binding's own timeout tests use 1000µs) yet far below the
+	// time to parse the large input below, so the halt is deterministic.
+	t.Setenv("GRAFEL_PARSE_TIMEOUT", "1ms")
+
+	f := treesitter.NewParserFactory(nil)
+	big := bigGoSource(200_000)
+
+	// The runaway parse must return promptly with the bounded sentinel error,
+	// never hang. Run it in a goroutine and fail loudly if it does not return.
+	type result struct {
+		res *treesitter.ParseResult
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		res, err := f.Parse(context.Background(), big, "go")
+		done <- result{res, err}
+	}()
+
+	var got result
+	select {
+	case got = <-done:
+	case <-time.After(15 * time.Second):
+		t.Fatal("watchdog parse did not return — the deadline did not halt the parse (hang)")
+	}
+	if got.err == nil {
+		t.Fatalf("expected a bounded watchdog error, got nil (res=%+v)", got.res)
+	}
+	if !errors.Is(got.err, official.ErrParseDeadlineExceeded) {
+		t.Fatalf("expected error to wrap official.ErrParseDeadlineExceeded, got: %v", got.err)
+	}
+	if got.res != nil {
+		t.Fatalf("watchdog halt must yield no ParseResult, got: %+v", got.res)
+	}
+
+	// Lock-release invariant: with a normal budget restored, a subsequent parse
+	// must succeed. If parseMu had leaked, this would block forever.
+	t.Setenv("GRAFEL_PARSE_TIMEOUT", "20s")
+	next := make(chan result, 1)
+	go func() {
+		res, err := f.Parse(context.Background(), []byte("package main\nfunc main() {}\n"), "go")
+		next <- result{res, err}
+	}()
+	select {
+	case got = <-next:
+	case <-time.After(15 * time.Second):
+		t.Fatal("subsequent parse hung — parseMu was not released after the watchdog halt")
+	}
+	if got.err != nil {
+		t.Fatalf("subsequent normal parse failed: %v", got.err)
+	}
+	if got.res == nil || got.res.TSTree == nil {
+		t.Fatalf("subsequent normal parse produced no tree: %+v", got.res)
+	}
+	got.res.TSTree.Close()
+}
+
+// TestParse_NormalParseUnaffectedByWatchdog confirms a healthy parse completes
+// well within the deadline and is not disturbed by the watchdog: no error, a
+// real tree, and elapsed time far below the configured budget.
+func TestParse_NormalParseUnaffectedByWatchdog(t *testing.T) {
+	t.Setenv("GRAFEL_PARSE_TIMEOUT", "20s")
+
+	f := treesitter.NewParserFactory(nil)
+	src := []byte("package main\n\nfunc add(a, b int) int { return a + b }\n")
+
+	start := time.Now()
+	res, err := f.Parse(context.Background(), src, "go")
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("normal parse returned an error: %v", err)
+	}
+	if res == nil || res.TSTree == nil {
+		t.Fatalf("normal parse produced no tree: %+v", res)
+	}
+	defer res.TSTree.Close()
+	if res.NodeCount == 0 {
+		t.Fatalf("normal parse produced an empty tree (NodeCount=0)")
+	}
+	if elapsed >= 20*time.Second {
+		t.Fatalf("normal parse took %v — should be well under the deadline", elapsed)
+	}
+}

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -183,18 +183,28 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 	indexstate.AcquireParseSlot()
 	defer indexstate.ReleaseParseSlot()
 
-	// Issue #481 — serialise parse calls across goroutines (see ParserFactory
-	// godoc for the rationale).
-	parseMu.Lock()
+	// Parser construction/teardown operate on a per-call, independent parser
+	// instance (fresh ts_parser_new + SetLanguage; Close frees only that
+	// parser, and the produced tree outlives it). Issue #481's
+	// non-determinism is specific to the parse itself, so we keep those out of
+	// the critical section and serialise ONLY the parse below.
 	p, err := adapter.NewParser(lang)
 	if err != nil {
-		parseMu.Unlock()
 		return nil, fmt.Errorf("treesitter: parser init failed for language %s: %w", language, err)
 	}
+	defer p.Close()
+
+	// Issue #481 — serialise the parse across goroutines (see ParserFactory
+	// godoc for the rationale). The per-parse watchdog in official.Parse
+	// (GRAFEL_PARSE_TIMEOUT) bounds how long this critical section can be held:
+	// a runaway parse is halted at the deadline and returns an error instead of
+	// hanging, so a single pathological file can no longer pin parseMu — and
+	// thus ALL in-process parsing — indefinitely (was: ~26-min freeze, #5473).
+	parseMu.Lock()
 	tree, err := p.Parse(source)
-	p.Close()
 	parseMu.Unlock()
 	if err != nil {
+		span.RecordError(err)
 		return nil, fmt.Errorf("treesitter: parse failed for language %s: %w", language, err)
 	}
 	if tree == nil {

--- a/internal/treesitter/ts/official/official.go
+++ b/internal/treesitter/ts/official/official.go
@@ -15,6 +15,9 @@ package official
 
 import (
 	"errors"
+	"fmt"
+	"os"
+	"time"
 
 	tsofficial "github.com/tree-sitter/go-tree-sitter"
 
@@ -24,7 +27,39 @@ import (
 // adapterName is stamped on every Language this adapter produces.
 const adapterName = "official"
 
+// defaultParseTimeout bounds a single tree-sitter parse. Override per-process
+// with GRAFEL_PARSE_TIMEOUT (a Go duration, e.g. "20s", "500ms"); "0" disables
+// the watchdog entirely. A normal parse finishes in well under a second, so the
+// deadline only ever fires on a pathological/runaway parse.
+const defaultParseTimeout = 20 * time.Second
+
+// parseTimeoutEnv is the env var that tunes the per-parse watchdog deadline.
+const parseTimeoutEnv = "GRAFEL_PARSE_TIMEOUT"
+
+// ErrParseDeadlineExceeded is returned by Parse when the per-parse watchdog
+// halts a runaway tree-sitter parse before it completes (#5473). It is a
+// distinct sentinel so callers (and tests) can tell a watchdog kill from a
+// genuine empty/failed parse, and so the daemon logs a bounded error instead of
+// freezing. See parseTimeout / Parse for the mechanism.
+var ErrParseDeadlineExceeded = errors.New("treesitter/official: parse exceeded watchdog deadline")
+
 var errWrongAdapter = errors.New("treesitter/ts/official: language was not produced by the official adapter")
+
+// parseTimeout resolves the per-parse watchdog deadline from the environment,
+// falling back to defaultParseTimeout. A non-negative value is honoured (0 ==
+// disabled); a malformed or negative value falls back to the default rather
+// than silently disabling the safety net.
+func parseTimeout() time.Duration {
+	v := os.Getenv(parseTimeoutEnv)
+	if v == "" {
+		return defaultParseTimeout
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil || d < 0 {
+		return defaultParseTimeout
+	}
+	return d
+}
 
 // Adapter implements ts.Adapter over tree-sitter/go-tree-sitter.
 type Adapter struct{}
@@ -70,11 +105,51 @@ type Parser struct {
 	p *tsofficial.Parser
 }
 
-// Parse implements ts.Parser. The official binding does not return an error;
-// a nil tree maps to (nil, nil).
+// Parse implements ts.Parser. It does a fresh parse (no oldTree reuse) bounded
+// by a per-parse wall-clock watchdog so a single pathological input can never
+// pin the daemon indefinitely (#5473).
+//
+// Why this matters. A runtime build was observed sitting ~26 min in one runaway
+// C parse (ts_parser_parse / ts_node_child hot). Because the factory holds a
+// process-wide parse mutex (issue #481) AND a parse slot across this call, that
+// one hung parse froze ALL in-process parsing and the daemon went silent. The
+// bare p.Parse(source, nil) is unbounded.
+//
+// Mechanism (v0.24-native). go-tree-sitter v0.24 exposes the C wall-clock
+// deadline ts_parser_set_timeout_micros: tree-sitter checks the elapsed budget
+// periodically from its main parse loop and, once exceeded, halts early and
+// returns a nil tree. That is exactly the cancellation path the v0.25 progress
+// callback would provide, without the goroutine/cancellation-flag plumbing. On
+// a halt we return ErrParseDeadlineExceeded so the factory converts the freeze
+// into a bounded, logged per-file failure and releases parseMu + the slot. A
+// genuine empty parse (no halt) still maps to (nil, nil). The parser is
+// single-use here (the factory closes it after this call), so no Reset of the
+// halted state is needed.
+//
+// Caveat: a true tight C loop that never reaches a deadline-check site would
+// still need an upstream fix; the observed runaway was in the main loop, which
+// does check.
 func (p *Parser) Parse(source []byte) (ts.Tree, error) {
+	timeout := parseTimeout()
+	// SetTimeoutMicros(0) is tree-sitter's "no deadline" default; a positive
+	// budget arms the watchdog.
+	p.p.SetTimeoutMicros(uint64(timeout.Microseconds()))
+
+	start := time.Now()
 	tree := p.p.Parse(source, nil)
 	if tree == nil {
+		// With a language set, the v0.24 binding returns a nil tree only when
+		// the parse halted early on the wall-clock deadline (a genuine parse —
+		// including of empty input — yields a real, possibly all-ERROR tree, not
+		// nil). So a nil tree under an armed watchdog IS the deadline firing; we
+		// report it directly rather than re-deriving it from elapsed wall-clock,
+		// which races the C clock and is flaky under load. When the watchdog is
+		// disabled (timeout == 0) there is no deadline to attribute a nil tree
+		// to, so it maps to (nil, nil) as the bare binding did.
+		if timeout > 0 {
+			return nil, fmt.Errorf("%w of %s after %s (%s; possible pathological/runaway parse, #5473)",
+				ErrParseDeadlineExceeded, timeout, time.Since(start).Round(time.Millisecond), parseTimeoutEnv)
+		}
 		return nil, nil
 	}
 	return &Tree{t: tree}, nil

--- a/internal/treesitter/ts/official/official_test.go
+++ b/internal/treesitter/ts/official/official_test.go
@@ -1,0 +1,37 @@
+package official
+
+import (
+	"testing"
+	"time"
+)
+
+// TestParseTimeout_EnvResolution pins the watchdog deadline resolution: an unset
+// or malformed GRAFEL_PARSE_TIMEOUT falls back to the default (never silently
+// disabling the safety net), a valid duration is honoured, and "0" disables the
+// watchdog. Pure function — no grammar/CGO needed, fully deterministic.
+//
+// os.Getenv treats an empty value the same as absent, so the empty case stands
+// in for "unset" (the default branch) without mutating process-global state
+// beyond t.Setenv's scoped, auto-restored override.
+func TestParseTimeout_EnvResolution(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{name: "empty/unset uses default", val: "", want: defaultParseTimeout},
+		{name: "valid seconds", val: "5s", want: 5 * time.Second},
+		{name: "valid millis", val: "250ms", want: 250 * time.Millisecond},
+		{name: "zero disables", val: "0", want: 0},
+		{name: "malformed falls back to default", val: "not-a-duration", want: defaultParseTimeout},
+		{name: "negative falls back to default", val: "-3s", want: defaultParseTimeout},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(parseTimeoutEnv, tc.val)
+			if got := parseTimeout(); got != tc.want {
+				t.Fatalf("parseTimeout() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

A runtime build was observed sitting ~26 min pinned in a **single runaway tree-sitter parse** (`ts_parser_parse` / `ts_node_child` hot), log frozen, daemon silent. Two amplifiers turned one bad parse into a total freeze:

1. **No per-parse timeout.** `official.Parse` did a bare, unbounded `p.Parse(source, nil)`.
2. **Global serialization.** `parser.go` held the process-wide `parseMu` (#481) **and** a parse slot across the *entire* C parse — so the one hung parse blocked **all** in-process parsing indefinitely.

## What

A per-parse wall-clock **watchdog** so a runaway parse becomes a bounded, logged error instead of a freeze.

**Deadline (v0.24-native).** `official.Parse` arms tree-sitter's C wall-clock deadline via `ts_parser_set_timeout_micros` (`Parser.SetTimeoutMicros`) before each parse. tree-sitter checks the budget periodically from its main parse loop and halts early, returning a nil tree — the same interrupt point the v0.25 progress callback would hit, minus the goroutine/cancellation-flag plumbing. The budget is env-tunable via **`GRAFEL_PARSE_TIMEOUT`** (Go duration, default **20s**; `0` disables; malformed/negative falls back to the default — never silently off). On a halt, `Parse` returns the sentinel **`ErrParseDeadlineExceeded`**, which the factory wraps (`%w`) and records on the OTel span: a bounded, logged per-file failure.

**Narrowed `parseMu` (#481).** The critical section now wraps **only** `p.Parse`. Parser construction/teardown act on a per-call, independent parser (and the produced tree outlives `Close`), so they no longer sit under the global mutex. Combined with the watchdog bounding the parse, **one pathological file can pin `parseMu` for at most the deadline — never indefinitely.**

> Re-targets draft #5658 (which used the v0.25 `ParseWithOptions` + `ProgressCallback` path) to the **v0.24** API, since `main` reverted the v0.25 bump (Wave A). See the comment thread on #5658.

## Tests

- `parseTimeout()` env-resolution table test (pure, no CGO).
- Factory-level: a controllable large-but-valid input parsed under a `1ms` budget returns `ErrParseDeadlineExceeded` (deterministic halt, **no hang**), then a subsequent normal parse succeeds — proving `parseMu` was released.
- A normal small parse under the default budget returns a real tree, well within the deadline.

`go build ./internal/treesitter/...` and `go test ./internal/treesitter/ ./internal/treesitter/ts/official/` green; `gofmt` clean.

Caveat: a true tight C loop that never reaches a deadline-check site would still need an upstream fix; the observed runaway was in the main loop, which does check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)