### PR TITLE
fix(incremental): honor .gitignore in change-detector to stop reindex loop (#5665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [0.1.7.1] — 2026-06-27
+
+**Hotfix: incremental reindex loop on gitignored build artifacts.** The
+incremental change-detector now honors `.gitignore`/`.grafelignore` the same way
+the full indexer does, so churning gitignored build-output directories (e.g.
+`ios/Pods`, `android/**/.cxx`) can no longer be counted as "changed" and trip a
+perpetual full-reindex loop that pinned daemon CPU.
+
+### Fixed
+
+- **Incremental change-detector honors ignore rules (#5665):** `walkSourceFiles`
+  now delegates to the same gitignore-aware `walk.WalkRepo` the full index uses,
+  so incremental change-detection and full indexing agree on which files exist.
+  Previously the incremental walk used a partial hardcoded denylist with no
+  `.gitignore` handling — gitignored build artifacts that build tooling constantly
+  regenerates entered the change manifest and perpetually triggered the
+  too-many-changed full-reindex fallback (sustained high CPU with a static HEAD).
+  Self-healing: the first reindex after upgrade flushes the stale ignored entries
+  from the manifest, then the loop stops.
+
+---
+
 ## [0.1.7] — 2026-06-27
 
 **Daemon stability hardening.** This release makes the parser path

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -57,6 +57,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/classifier"
 	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/daemon/walk"
 	"github.com/cajasmota/grafel/internal/engine"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/extractors/sresolver"
@@ -760,35 +761,28 @@ func fallback(t0 time.Time, reason string) Result {
 	}
 }
 
-// walkSourceFiles returns repo-relative forward-slash paths for all
-// source files under absRepo, excluding .git and common build artifacts.
-// This is a thin wrapper so the incremental path doesn't import internal/walk
-// directly (which would introduce a heavier dependency).
+// walkSourceFiles returns repo-relative forward-slash paths for all source
+// files under absRepo, using the SAME gitignore/.grafelignore-aware walker the
+// full indexer uses (walk.WalkRepo). This is deliberate: the incremental
+// change-detector and the full index must agree on which files exist.
+//
+// Previously this was a hand-rolled filepath.WalkDir with only a small
+// hardcoded directory denylist and NO .gitignore handling. The full index
+// (walk.WalkRepo) excluded gitignored build-artifact directories (e.g.
+// ios/Pods, android/**/.cxx), but this walker did not — so those gitignored
+// files entered the change manifest and, because build tooling constantly
+// regenerates/deletes them, were counted as "changed" on every poll. With the
+// HEAD static, that perpetually tripped the too-many-changed full-reindex
+// fallback (incremental.go ~line 233), pinning daemon CPU in an endless
+// reindex loop (#5665). Delegating to walk.WalkRepo makes both paths honor the
+// same ignore rules, so gitignored churn can no longer drive reindexing.
 func walkSourceFiles(absRepo string) ([]string, error) {
-	var paths []string
-	err := filepath.WalkDir(absRepo, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil // skip unreadable entries
-		}
-		name := d.Name()
-		if d.IsDir() {
-			switch name {
-			case ".git", "node_modules", "vendor", ".grafel",
-				"dist", "build", "__pycache__", ".mypy_cache":
-				return filepath.SkipDir
-			}
-			return nil
-		}
-		rel, relErr := filepath.Rel(absRepo, path)
-		if relErr != nil {
-			return nil
-		}
-		// Forward-slash always (diff manifest uses forward-slash keys).
-		rel = filepath.ToSlash(rel)
-		paths = append(paths, rel)
-		return nil
-	})
-	return paths, err
+	// Mirror the full indexer: probe sparse-checkout state so a partial
+	// working tree is walked consistently. ProbeRepo is best-effort and
+	// returns a zero-value (no sparse filtering) when the repo isn't sparse.
+	sparse := gitmeta.ProbeRepo(absRepo)
+	files, _, err := walk.WalkRepo(absRepo, &walk.Options{Sparse: &sparse})
+	return files, err
 }
 
 // entityRecordToGraphEntity converts a types.EntityRecord produced by an

--- a/internal/extractors/walk_gitignore_5665_test.go
+++ b/internal/extractors/walk_gitignore_5665_test.go
@@ -1,0 +1,67 @@
+package extractors
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWalkSourceFiles_HonorsGitignore is the regression test for #5665.
+//
+// The incremental change-detector's file walk must honor .gitignore exactly
+// the way the full indexer (walk.WalkRepo) does. Before the fix, walkSourceFiles
+// was a hand-rolled walk with only a small hardcoded denylist and NO .gitignore
+// handling, so gitignored build-artifact directories (e.g. ios/Pods,
+// android/**/.cxx) were walked and entered the change manifest. Because build
+// tooling constantly regenerates/deletes those files, they were counted as
+// "changed" on every poll — perpetually tripping the too-many-changed
+// full-reindex fallback and pinning the daemon CPU in an endless reindex loop
+// even though the repo HEAD never moved.
+//
+// This test fixes the walk at its source: gitignored paths must not appear in
+// the walk result, so they can never drive a reindex.
+func TestWalkSourceFiles_HonorsGitignore(t *testing.T) {
+	repo := t.TempDir()
+
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		abs := filepath.Join(repo, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// .gitignore excludes the churning build-artifact dirs (as real RN/iOS/
+	// Android repos do); main.go is a real tracked source file.
+	mustWrite(".gitignore", "Pods/\nandroid/app/.cxx/\n")
+	mustWrite("main.go", "package main\n\nfunc main() {}\n")
+	mustWrite("Pods/Manifest.lock", "PODS: []\n")
+	mustWrite("Pods/Target Support Files/Foo/Foo.modulemap", "module Foo {}\n")
+	mustWrite("android/app/.cxx/RelWithDebInfo/abc/index.json", "{}\n")
+
+	files, err := walkSourceFiles(repo)
+	if err != nil {
+		t.Fatalf("walkSourceFiles: %v", err)
+	}
+	got := make(map[string]bool, len(files))
+	for _, f := range files {
+		got[f] = true
+	}
+
+	if !got["main.go"] {
+		t.Errorf("expected tracked source file main.go to be walked; got %v", files)
+	}
+	for _, ignored := range []string{
+		"Pods/Manifest.lock",
+		"Pods/Target Support Files/Foo/Foo.modulemap",
+		"android/app/.cxx/RelWithDebInfo/abc/index.json",
+	} {
+		if got[ignored] {
+			t.Errorf("gitignored path %q must NOT be walked — counting it drives the reindex loop (#5665); got %v",
+				ignored, files)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The **incremental** change-detector's file walk (`walkSourceFiles`) did not honor `.gitignore`, while the **full** indexer (`walk.WalkRepo`) does. On a repo with gitignored build-artifact directories (`ios/Pods`, `android/**/.cxx`) and a **static HEAD**, build tooling constantly regenerates/deletes those files, so they were counted as "changed" on every poll → `too-many-changed` → **full reindex** → repeat forever. Sustained high daemon CPU with no commits.

## Fix

`walkSourceFiles` now delegates to the same gitignore/`.grafelignore`-aware `walk.WalkRepo` the full index already uses, so incremental change-detection and full indexing agree on which files exist. Gitignored churn can no longer drive reindexing.

**Self-healing:** the first reindex after upgrade flushes the stale ignored entries from the manifest, then the loop stops.

## Test

`TestWalkSourceFiles_HonorsGitignore` — builds a repo with a `.gitignore` excluding `Pods/` and `android/app/.cxx/`, asserts the tracked source file is walked and the gitignored artifacts are not. Full `Incremental` suite passes (no regressions).

Closes #5665

🤖 Generated with [Claude Code](https://claude.com/claude-code)