### PR TITLE
fix(incremental): flush stale manifest entries to end the reindex loop (#5667)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [0.1.7.2] — 2026-06-27
+
+**Hotfix: complete the 0.1.7.1 reindex-loop fix.** 0.1.7.1 made the incremental
+change-detector gitignore-aware, but the persisted file-index manifest still
+retained entries for the now-ignored files — so they were detected as *deleted*
+on every pass, re-tripping the `too-many-changed` full-reindex fallback and
+keeping the daemon CPU-pinned at a static HEAD. This release flushes those
+stale entries.
+
+### Fixed
+
+- **Persist the manifest GC on the `too-many-changed` fallback (#5667):** the
+  incremental fallback now saves the garbage-collected manifest before falling
+  back, so files that became absent/ignored don't recur as `deletedFiles` and
+  loop the reindex. In addition, `UpdateManifest` now *reconciles* to the walked
+  set (drops entries no longer present) instead of being add-only, so no
+  index path — incremental or full — can leave a stale entry immortal.
+  Self-healing: the first reindex after upgrade flushes the leftover entries,
+  then the daemon settles.
+
+---
+
 ## [0.1.7.1] — 2026-06-27
 
 **Hotfix: incremental reindex loop on gitignored build artifacts.** The

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -231,6 +231,12 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// config overrides the env-var / gitmeta path when non-nil.
 	limit := effectiveLimit(absRepo, cfg)
 	if totalChanged > limit {
+		// Persist the manifest-GC deletions (applied above) BEFORE falling back,
+		// so now-absent files — e.g. build artifacts newly excluded by the
+		// gitignore-aware walk — don't recur as deletedFiles and re-trip this
+		// fallback on every pass, looping the reindex forever (#5667). Without
+		// this save the GC is in-memory only and discarded on fallback.
+		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return fallback(t0, fmt.Sprintf("too-many-changed files=%d limit=%d",
 			totalChanged, limit))
 	}
@@ -272,6 +278,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	// Re-check trigger limit after whitespace filtering.
 	if len(reallyChanged) > limit {
+		// Persist the manifest-GC deletions before falling back (see #5667).
+		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return fallback(t0, fmt.Sprintf("too-many-changed after-hash-gate files=%d limit=%d",
 			len(reallyChanged), limit))
 	}

--- a/internal/extractors/incremental_loop_5667_test.go
+++ b/internal/extractors/incremental_loop_5667_test.go
@@ -1,0 +1,72 @@
+package extractors_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// TestTryIncremental_FlushesStaleManifest_NoLoop is the end-to-end regression
+// test for #5667: a manifest carrying entries for files no longer in the walk
+// (e.g. build artifacts excluded by the gitignore-aware walk in 0.1.7.1) must
+// NOT loop the reindex forever.
+//
+// Before the fix, those absent entries were detected as deletedFiles on every
+// pass → too-many-changed → fallback that DISCARDED the manifest GC → next pass
+// saw the same absent entries again → infinite full-reindex loop at a static
+// HEAD. The fix persists the GC'd manifest on the fallback (and UpdateManifest
+// now prunes), so the stale entries are flushed once and a second pass settles.
+func TestTryIncremental_FlushesStaleManifest_NoLoop(t *testing.T) {
+	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "1")
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	writeFile(t, repo, "a.go", "package p\n\nfunc A() {}\n")
+	writeFile(t, repo, "b.go", "package p\n\nfunc B() {}\n")
+
+	// Seed a manifest with correct hashes for the two real files plus 60 stale
+	// entries for files that are NOT on disk (above even the main-branch limit
+	// of 50, so the fallback fires regardless of branch heuristics).
+	m := &diff.Manifest{Version: 1, Files: map[string]diff.FileEntry{}}
+	diff.UpdateManifest(repo, []string{"a.go", "b.go"}, m)
+	for i := 0; i < 60; i++ {
+		m.Files[fmt.Sprintf("build/ghost_%d.txt", i)] = diff.FileEntry{SHA256: "stale"}
+	}
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatal(err)
+	}
+
+	logger := log.New(io.Discard, "", 0)
+
+	// Cycle 1: the 60 absent entries trip too-many-changed → fallback. The fix
+	// must PERSIST the manifest GC before returning.
+	r1 := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if r1.Done {
+		t.Fatalf("cycle 1 should fall back (too-many-changed), got Done")
+	}
+	if !strings.Contains(r1.FallbackReason, "too-many-changed") {
+		t.Fatalf("cycle 1 expected a too-many-changed fallback, got %q", r1.FallbackReason)
+	}
+
+	// The persisted manifest must be free of the stale entries now.
+	got := diff.LoadManifest(stateDir)
+	for k := range got.Files {
+		if strings.HasPrefix(k, "build/") {
+			t.Fatalf("stale entry %q survived the fallback — the reindex would loop forever (#5667)", k)
+		}
+	}
+
+	// Cycle 2: with a flushed manifest and a static tree, nothing is deleted or
+	// changed → totalChanged==0 → Done, NOT another fallback. This is the proof
+	// that the loop terminates.
+	r2 := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if !r2.Done {
+		t.Fatalf("cycle 2 must be Done (loop terminated), got fallback=%q", r2.FallbackReason)
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -210,6 +210,23 @@ func UpdateManifest(absRepo string, relPaths []string, m *Manifest) {
 		}(rel)
 	}
 	wg.Wait()
+
+	// Reconcile (#5667): drop entries for files no longer in the walked set so
+	// the manifest cannot retain stale records — e.g. a file that became
+	// gitignored (build artifacts now excluded by walk.WalkRepo). All callers
+	// pass the complete current walk, so membership in relPaths is
+	// authoritative. Without this prune an entry, once added, is immortal: a
+	// now-ignored file is reported as "deleted" on every pass, perpetually
+	// tripping the too-many-changed full-reindex fallback and pinning the daemon.
+	want := make(map[string]struct{}, len(relPaths))
+	for _, r := range relPaths {
+		want[r] = struct{}{}
+	}
+	for k := range m.Files {
+		if _, ok := want[k]; !ok {
+			delete(m.Files, k)
+		}
+	}
 }
 
 // GitChangedFiles uses `git diff --name-only HEAD` to return the set of

--- a/internal/indexer/diff/manifest_prune_5667_test.go
+++ b/internal/indexer/diff/manifest_prune_5667_test.go
@@ -1,0 +1,43 @@
+package diff_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// TestUpdateManifest_PrunesStaleEntries is a regression test for #5667.
+//
+// UpdateManifest must reconcile the manifest to the walked set — entries for
+// files no longer in the walk (e.g. a file that became gitignored) must be
+// dropped. Before the fix UpdateManifest was add-only, so a now-ignored file's
+// entry was immortal and was reported as "deleted" on every pass, perpetually
+// tripping the too-many-changed full-reindex fallback and pinning the daemon.
+func TestUpdateManifest_PrunesStaleEntries(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.WriteFile(filepath.Join(repo, "real.go"), []byte("package p\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &diff.Manifest{Version: 1, Files: map[string]diff.FileEntry{
+		"real.go":         {},                  // in the walk — kept (re-hashed)
+		"ios/Pods/x.lock": {SHA256: "stale-1"}, // now gitignored — must be pruned
+		"android/.cxx/y":  {SHA256: "stale-2"}, // now gitignored — must be pruned
+	}}
+
+	diff.UpdateManifest(repo, []string{"real.go"}, m)
+
+	if _, ok := m.Files["real.go"]; !ok {
+		t.Errorf("walked file real.go must be present")
+	}
+	for _, stale := range []string{"ios/Pods/x.lock", "android/.cxx/y"} {
+		if _, ok := m.Files[stale]; ok {
+			t.Errorf("stale entry %q must be pruned — it would loop the reindex (#5667)", stale)
+		}
+	}
+	if len(m.Files) != 1 {
+		t.Errorf("manifest must equal the walked set (1 file), got %d entries", len(m.Files))
+	}
+}


### PR DESCRIPTION
Follow-up to #5666 (0.1.7.1), which was necessary but incomplete.

**Root cause.** 0.1.7.1 made `walkSourceFiles` gitignore-aware, so build-artifact dirs (`ios/Pods`, `android/.cxx`) stopped being walked. But the persisted file-index manifest still contained their entries, and `UpdateManifest` was **add-only** (never pruned), so on every pass those now-absent files were detected as `deletedFiles` → `too-many-changed` → full-reindex fallback. The fallback **discarded the in-memory manifest GC** (returned before any `SaveManifest`), so the next pass saw the same entries again → infinite full-reindex loop at a static HEAD (sustained 400–500% CPU, verified on a real mobile repo).

**Fix (two parts).**
1. Persist the GC'd manifest on both `too-many-changed` fallback paths before returning, so the deletions stick.
2. Make `diff.UpdateManifest` **reconcile** to the walked set (prune entries no longer present) instead of add-only — so no index path, incremental or full, can leave a stale entry immortal. All three callers pass the complete walk, so this is safe.

Self-healing: the first reindex after upgrade flushes the leftover entries, then the daemon settles.

**Tests.** `UpdateManifest` prunes stale entries; and an end-to-end test proves a `too-many-changed` fallback flushes the manifest so a **second** incremental cycle returns `Done` (no fallback) — i.e. the loop terminates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)