### PR TITLE
chore(incremental): log paths at too-many-changed fallback (#5668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,22 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [0.1.7.3] — 2026-06-27
+
+**Diagnostic logging for the incremental too-many-changed fallback.** Pure
+observability — no behavior change.
+
+### Changed
+
+- **Log changed/deleted paths at the too-many-changed fallback (#5668):** when
+  the incremental reindex falls back to a full reindex on `too-many-changed`, the
+  daemon now logs the actual changed and deleted file paths (capped at 60), at
+  both the pre- and post-hash-gate fallback sites — instead of only the count. A
+  *persistent* fallback (the reindex-loop class addressed in 0.1.7.1/0.1.7.2) is
+  now debuggable from the logs rather than invisible.
+
+---
+
 ## [0.1.7.2] — 2026-06-27
 
 **Hotfix: complete the 0.1.7.1 reindex-loop fix.** 0.1.7.1 made the incremental

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -152,6 +152,17 @@ func StampFile(absPath string) (FileStamp, error) {
 	}, nil
 }
 
+// capDiagPaths returns up to 60 paths for diagnostic logging so a persistent
+// too-many-changed loop's offending files are visible without flooding the log
+// on a genuinely large changeset (#5668).
+func capDiagPaths(paths []string) []string {
+	const max = 60
+	if len(paths) <= max {
+		return paths
+	}
+	return paths[:max]
+}
+
 // TryIncremental attempts a file-level incremental reindex for repoPath.
 // stateDir is the on-disk directory where graph.fb and file-index.json live.
 // logger may be nil (falls back to stderr).
@@ -231,6 +242,11 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// config overrides the env-var / gitmeta path when non-nil.
 	limit := effectiveLimit(absRepo, cfg)
 	if totalChanged > limit {
+		// DIAG (#5668): surface the actual paths driving the fallback. A persistent
+		// too-many-changed loop is invisible when only the count is logged; this
+		// makes the offending files debuggable.
+		logger.Printf("incremental: too-many-changed DIAG repo=%s changed=%d deleted=%d changed_paths=%v deleted_paths=%v",
+			absRepo, len(changedFiles), len(deletedFiles), capDiagPaths(changedFiles), capDiagPaths(deletedFiles))
 		// Persist the manifest-GC deletions (applied above) BEFORE falling back,
 		// so now-absent files — e.g. build artifacts newly excluded by the
 		// gitignore-aware walk — don't recur as deletedFiles and re-trip this
@@ -278,6 +294,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	// Re-check trigger limit after whitespace filtering.
 	if len(reallyChanged) > limit {
+		// DIAG (#5668): surface the paths that survived the hash gate.
+		logger.Printf("incremental: too-many-changed-after-hash DIAG repo=%s reallyChanged=%d paths=%v",
+			absRepo, len(reallyChanged), capDiagPaths(reallyChanged))
 		// Persist the manifest-GC deletions before falling back (see #5667).
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return fallback(t0, fmt.Sprintf("too-many-changed after-hash-gate files=%d limit=%d",


### PR DESCRIPTION
Closes #5668. Pure observability for the incremental reindex.

When the incremental pass falls back to a full reindex on `too-many-changed`, the daemon logged only the **count** — so a *persistent* fallback (the reindex-loop class fixed in #5665/#5667) was invisible: you couldn't see which files kept tripping it. This logs the actual changed/deleted paths (capped at 60) at both the pre- and post-hash-gate fallback sites.

No behavior change to the reindex decision — logging only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)