### PR TITLE
fix(incremental): fully reconcile manifest on too-many-changed fallback (#5668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,26 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ---
 
+## [0.1.7.3] — 2026-06-27
+
+**Hotfix: fully reconcile the manifest on the incremental fallback.** The
+`too-many-changed` fallback now refreshes file stamps and prunes absent entries
+(via `UpdateManifest`) before persisting — not just the in-memory manifest-GC
+(0.1.7.2). Without the stamp refresh, files whose manifest stamps were stale got
+re-reported as changed on every pass, re-tripping the fallback and looping a
+full reindex until a manual clean-manifest rebuild — the residual gap behind
+0.1.7.1/0.1.7.2. The fallback also now logs a sample of the actual
+changed/deleted paths so a recurrence is diagnosable instead of a bare count.
+
+### Fixed
+- **Incremental `too-many-changed` fallback fully reconciles the manifest
+  (#5668):** refresh stamps + prune entries absent from the gitignore-aware walk
+  before persisting, so stale stamps can't recur as changes and loop the
+  reindex; plus diagnostic path-sample logging at the fallback (supersedes the
+  diagnostic-only #5669).
+
+---
+
 ## [0.1.7.2] — 2026-06-27
 
 **Hotfix: complete the 0.1.7.1 reindex-loop fix.** 0.1.7.1 made the incremental

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -231,12 +231,19 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// config overrides the env-var / gitmeta path when non-nil.
 	limit := effectiveLimit(absRepo, cfg)
 	if totalChanged > limit {
-		// Persist the manifest-GC deletions (applied above) BEFORE falling back,
-		// so now-absent files — e.g. build artifacts newly excluded by the
-		// gitignore-aware walk — don't recur as deletedFiles and re-trip this
-		// fallback on every pass, looping the reindex forever (#5667). Without
-		// this save the GC is in-memory only and discarded on fallback.
+		// Fully reconcile + persist the manifest BEFORE falling back. Saving only
+		// the GC'd map (#5667) left file STAMPS stale and skipped the absent-entry
+		// prune, so the same files re-surfaced as changed/deleted on the next pass
+		// and re-tripped this fallback, looping the reindex even without a manual
+		// clean-manifest rebuild. UpdateManifest refreshes stamps AND prunes
+		// entries absent from the gitignore-aware walk, making the fallback path's
+		// manifest as clean as the success path's (#5668). Log a path SAMPLE so a
+		// recurrence is diagnosable, not just a bare count (#5668).
+		diff.UpdateManifest(absRepo, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
+		logger.Printf("incremental: too-many-changed files=%d limit=%d (changed=%d deleted=%d) changed=%v deleted=%v",
+			totalChanged, limit, len(changedFiles), len(deletedFiles),
+			samplePaths(changedFiles), samplePaths(deletedFiles))
 		return fallback(t0, fmt.Sprintf("too-many-changed files=%d limit=%d",
 			totalChanged, limit))
 	}
@@ -278,8 +285,11 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	// Re-check trigger limit after whitespace filtering.
 	if len(reallyChanged) > limit {
-		// Persist the manifest-GC deletions before falling back (see #5667).
+		// Fully reconcile + persist before falling back (see #5667, #5668).
+		diff.UpdateManifest(absRepo, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
+		logger.Printf("incremental: too-many-changed after-hash-gate files=%d limit=%d really=%v",
+			len(reallyChanged), limit, samplePaths(reallyChanged))
 		return fallback(t0, fmt.Sprintf("too-many-changed after-hash-gate files=%d limit=%d",
 			len(reallyChanged), limit))
 	}
@@ -767,6 +777,18 @@ func fallback(t0 time.Time, reason string) Result {
 		FallbackReason: reason,
 		Duration:       time.Since(t0),
 	}
+}
+
+// samplePaths returns up to 10 paths for diagnostic logging at the
+// too-many-changed fallback, so a recurrence shows WHICH files tripped it
+// instead of just a count (#5668), without flooding the log on a large
+// changeset.
+func samplePaths(s []string) []string {
+	const n = 10
+	if len(s) <= n {
+		return s
+	}
+	return append(append([]string{}, s[:n]...), fmt.Sprintf("…+%d more", len(s)-n))
 }
 
 // walkSourceFiles returns repo-relative forward-slash paths for all source

--- a/internal/extractors/incremental_fallback_reconcile_5668_test.go
+++ b/internal/extractors/incremental_fallback_reconcile_5668_test.go
@@ -1,0 +1,72 @@
+package extractors_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// TestIncremental_FallbackRefreshesStampsAndReconciles is the #5668 regression
+// test for the residual reindex-loop gap.
+//
+// When the incremental change-detector hits the too-many-changed fallback, it
+// must persist a FULLY RECONCILED manifest — UpdateManifest refreshes the
+// content stamps of the surviving files AND prunes entries absent from the
+// gitignore-aware walk. 0.1.7.2 saved only the GC'd map, which left STALE
+// STAMPS in place: on the next pass those files are re-reported as "changed",
+// re-trip the fallback, and the daemon loops a full reindex forever (the bug
+// behind 0.1.7.1/0.1.7.2 that needed a manual clean-manifest rebuild to clear).
+//
+// The test seeds a manifest whose on-disk files carry WRONG stamps so they all
+// read as changed and trip the fallback (limit=2). After one pass the persisted
+// manifest must have correct stamps, and a second pass must NOT fall back.
+// Against the pre-fix code the second pass still falls back (stamps never
+// refreshed) and this test fails.
+func TestIncremental_FallbackRefreshesStampsAndReconciles(t *testing.T) {
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "2") // fall back when >2 read as changed
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	files := []string{"a.go", "b.go", "c.go", "d.go", "e.go"}
+	for i, rel := range files {
+		writeFile(t, repo, rel, fmt.Sprintf("package p\n\nfunc F%d() {}\n", i))
+	}
+
+	// Seed a manifest with deliberately WRONG stamps for every on-disk file, so
+	// the change-detector reports all 5 as changed (5 > limit 2 → fallback).
+	m := diff.LoadManifest(stateDir)
+	for _, rel := range files {
+		m.Files[rel] = diff.FileEntry{SHA256: "0000000000000000", Size: 1, Mtime: 1}
+	}
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("save seeded manifest: %v", err)
+	}
+
+	// Pass 1: must fall back (too-many-changed).
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if res.Done {
+		t.Fatalf("pass 1: expected too-many-changed fallback, got Done=true")
+	}
+
+	// The fix: the persisted manifest must now carry REFRESHED stamps (not the
+	// "0000…" sentinel) for the surviving files.
+	reloaded := diff.LoadManifest(stateDir)
+	e, ok := reloaded.Files["a.go"]
+	if !ok {
+		t.Fatalf("a.go missing from reconciled manifest")
+	}
+	if e.SHA256 == "0000000000000000" || e.SHA256 == "" {
+		t.Fatalf("pass 1 did not reconcile: a.go still has the stale stamp %q — stamps were not refreshed on the fallback (the loop bug)", e.SHA256)
+	}
+
+	// Pass 2: stamps are correct now → nothing reads as changed → must NOT fall
+	// back. Against the pre-fix code this still loops (Done=false).
+	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res2.Done {
+		t.Fatalf("pass 2: loop NOT broken — second pass still fell back (reason=%q); a reconciled manifest must not re-trip too-many-changed", res2.FallbackReason)
+	}
+}


### PR DESCRIPTION
Closes the residual reindex-loop gap behind the 0.1.7.x series.

**Problem:** the `too-many-changed` fallback persisted only the in-memory manifest-GC (0.1.7.2 / #5667), leaving file **stamps stale** for surviving files. On the next pass those files re-read as *changed*, re-trip the fallback, and the daemon loops a full reindex — only a manual clean-manifest rebuild cleared it.

**Fix:** on both `too-many-changed` fallback paths, call `UpdateManifest` (refreshes stamps **and** prunes entries absent from the gitignore-aware walk) before `SaveManifest`, making the fallback path's manifest as clean as the success path's. Also logs a **sample of the changed/deleted paths** so a recurrence is diagnosable instead of a bare count — superseding the diagnostic-only #5669.

**Test:** `TestIncremental_FallbackRefreshesStampsAndReconciles` seeds on-disk files with stale stamps so they trip the fallback (limit 2), then asserts (a) the persisted manifest has refreshed stamps and (b) a second pass does **not** fall back. Against the pre-fix code the second pass still loops.

Deterministic, no live daemon needed; incremental + diff suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)