### PR TITLE
fix(doctor): resolve enclosing git root before warning missing .git (#5675)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/process"
@@ -391,8 +392,11 @@ func checkRepo(w io.Writer, r registry.Repo) {
 		fmt.Fprintf(w, "  %s repo %s (%s): %v\n", statusFail, r.Slug, r.Path, err)
 		return
 	}
-	gitDir := filepath.Join(r.Path, ".git")
-	if _, err := os.Stat(gitDir); err != nil {
+	// Resolve the enclosing git root (walk up) before deciding .git is missing.
+	// In a single-.git monorepo the only .git lives at the repo root, so a
+	// module subdir has no .git of its own — statting a literal .git in r.Path
+	// would falsely flag every module (#5675).
+	if !gitmeta.HasGitDirInTree(r.Path) {
 		fmt.Fprintf(w, "  %s repo %s: missing .git\n", statusWarn, r.Slug)
 	} else {
 		fmt.Fprintf(w, "  %s repo %s (%s)\n", statusOK, r.Slug, r.Stack.String())

--- a/internal/cli/doctor_checkrepo_test.go
+++ b/internal/cli/doctor_checkrepo_test.go
@@ -1,0 +1,77 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestCheckRepoGitDetection covers the four .git-resolution cases for checkRepo
+// (issue #5675 item 4): a normal single repo with its own .git must pass OK; a
+// repo with no .git anywhere up the tree must warn "missing .git"; a module
+// subdir of a single-.git monorepo must NOT warn (the .git lives at the repo
+// root); and each repo of a related-repo group (each its own .git) must pass OK.
+func TestCheckRepoGitDetection(t *testing.T) {
+	base := t.TempDir()
+
+	// Case: normal single repo — .git at the repo path itself.
+	singleRepo := filepath.Join(base, "single")
+	mustMkdir(t, filepath.Join(singleRepo, ".git"))
+
+	// Case: no .git anywhere up the tree.
+	noGit := filepath.Join(base, "no-git-tree", "plain")
+	mustMkdir(t, noGit)
+
+	// Case: monorepo module — single .git at the monorepo root, module is a
+	// subdir with no .git of its own.
+	monoRoot := filepath.Join(base, "mono")
+	mustMkdir(t, filepath.Join(monoRoot, ".git"))
+	monoModule := filepath.Join(monoRoot, "services", "api")
+	mustMkdir(t, monoModule)
+
+	// Case: related repos — two independent repos, each its own .git.
+	relA := filepath.Join(base, "related", "svc-a")
+	relB := filepath.Join(base, "related", "svc-b")
+	mustMkdir(t, filepath.Join(relA, ".git"))
+	mustMkdir(t, filepath.Join(relB, ".git"))
+
+	tests := []struct {
+		name     string
+		path     string
+		wantWarn bool
+	}{
+		{"single-repo-ok", singleRepo, false},
+		{"no-git-warns", noGit, true},
+		{"monorepo-module-no-warn", monoModule, false},
+		{"related-repo-a-ok", relA, false},
+		{"related-repo-b-ok", relB, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			checkRepo(&buf, registry.Repo{
+				Slug:  tt.name,
+				Path:  tt.path,
+				Stack: registry.StackList{"go"},
+			})
+			out := buf.String()
+			gotWarn := strings.Contains(out, "missing .git")
+			if gotWarn != tt.wantWarn {
+				t.Errorf("checkRepo(%s): missing .git warning = %v, want %v\noutput:\n%s",
+					tt.path, gotWarn, tt.wantWarn, out)
+			}
+		})
+	}
+}
+
+func mustMkdir(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+}

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -10,10 +10,34 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
 )
+
+// HasGitDirInTree walks dir upward looking for a .git file or directory,
+// indicating an enclosing git repository. It returns true if .git is found
+// anywhere from dir up to the filesystem root, false otherwise. This is a fast,
+// subprocess-free check (no `git` invocation) that correctly recognises a
+// module subdirectory of a single-.git monorepo as being inside a git repo.
+func HasGitDirInTree(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	cur := dir
+	for {
+		if _, err := os.Stat(filepath.Join(cur, ".git")); err == nil {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			// Reached filesystem root.
+			return false
+		}
+		cur = parent
+	}
+}
 
 // EnvGitTimeout overrides the default external-git deadline (in seconds) used
 // by the bounded runners below. A value ≤ 0 disables the cap (not recommended).

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -227,22 +227,7 @@ func pathContains(ancestor, child string) bool {
 // it walks to the filesystem root without finding one. This is a fast check
 // to avoid subprocess calls to gitmeta.Capture for non-git directories (#2563).
 func hasGitDirInTree(dir string) bool {
-	if dir == "" {
-		return false
-	}
-	cur := dir
-	for {
-		gitPath := filepath.Join(cur, ".git")
-		if _, err := os.Stat(gitPath); err == nil {
-			return true
-		}
-		parent := filepath.Dir(cur)
-		if parent == cur {
-			// Reached filesystem root.
-			return false
-		}
-		cur = parent
-	}
+	return gitmeta.HasGitDirInTree(dir)
 }
 
 // groupFromCWD walks dir upward looking for .grafel/group.json which


### PR DESCRIPTION
## Summary
Fixes item 4 of #5675. `grafel doctor` (and by extension the dashboard hint that keys off its output) emitted a false `missing .git` warning for **every** module of a single-`.git` monorepo, because `checkRepo` stat'd a literal `.git` in each module path instead of resolving the enclosing git root. This is the first error a monorepo user hits during setup.

## Change
- `checkRepo` now walks up to the git root; it only warns `missing .git` when **no** `.git` exists anywhere up the tree from the module path.
- Lifted the existing walk-up helper out of `internal/mcp` into the leaf `internal/gitmeta` package as exported `HasGitDirInTree`, and made the old `mcp.hasGitDirInTree` delegate to it (single source of truth, no import cycle, no behavior change in the mcp path). Filesystem walk-up — no `git` subprocess per repo.

## No regression (verified by test)
`TestCheckRepoGitDetection` (table-driven) asserts on the warning string for all of:
- normal single repo with its own `.git` → **OK**
- no `.git` anywhere up the tree → **warns** (unchanged)
- monorepo module subdir under a root `.git` → **no warn** (the bug)
- related-repo group, each its own `.git` → **OK**

Output strings for both OK/warn branches are byte-for-byte unchanged; only the branch condition changed. A git-worktree `.git` *file* is also correctly recognized (stat, not IsDir).

## Verification
`go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/cli/... ./internal/gitmeta/... ./internal/mcp/...` all pass. Independently code-reviewed: APPROVE, no defects.

Closes item 4 of #5675 (remaining items — worktree storm, cap=0 disable, fd hardening — tracked as follow-up PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #5675