### PR TITLE
fix(worktree): honor GRAFEL_MAX_WORKTREES_PER_REPO=0 as disable (#5675)

### DIFF
--- a/internal/daemon/worktree/export_test.go
+++ b/internal/daemon/worktree/export_test.go
@@ -12,3 +12,9 @@ func ParseWorktreeListForTest(s string) []RawWorktree {
 func (w *Watcher) IntervalForTest() time.Duration {
 	return w.interval
 }
+
+// MaxWorktreesForTest exposes the package-internal maxWorktrees resolver for
+// white-box unit tests in the _test package.
+func MaxWorktreesForTest() int {
+	return maxWorktrees()
+}

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -400,9 +400,22 @@ func runWorktreeList(repoPath string) ([]RawWorktree, error) {
 const defaultMaxWorktrees = 10
 
 // maxWorktrees reads GRAFEL_MAX_WORKTREES_PER_REPO or returns the default.
+//
+// Semantics:
+//   - unset / empty       → defaultMaxWorktrees (10)
+//   - invalid/non-numeric → defaultMaxWorktrees (10)
+//   - negative            → defaultMaxWorktrees (10); a negative cap is
+//     meaningless, so we fall back to the safe default rather than disabling.
+//   - explicit 0          → 0, an intentional escape hatch that disables
+//     worktree/branch-snapshot indexing entirely (large monorepos).
+//   - positive n          → n
+//
+// An explicit 0 MUST be honored (n >= 0), which is why it is distinguished
+// from "unset". Previously the guard was n > 0, which silently floored 0 back
+// to the default.
 func maxWorktrees() int {
 	if v := os.Getenv("GRAFEL_MAX_WORKTREES_PER_REPO"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
 			return n
 		}
 	}
@@ -480,6 +493,10 @@ type Watcher struct {
 	// worktree was removed).  Used by the daemon to unsubscribe the
 	// worktree working tree from the file watcher.  May be nil.
 	OnExpire func(child *WorktreeChild)
+
+	// disabledLogOnce ensures the "indexing disabled" line (cap==0) is logged
+	// at most once per process, not on every ~60s tick / debounced Sync.
+	disabledLogOnce sync.Once
 }
 
 // defaultPollInterval is the default reconciliation interval.
@@ -666,6 +683,20 @@ func (w *Watcher) Sync() { w.poll() }
 func (w *Watcher) poll() {
 	parents := w.parents()
 	cap := maxWorktrees()
+
+	// A resolved cap of 0 is the explicit disable escape hatch. We deliberately
+	// flow through the normal poll body rather than short-circuiting: enforceCap
+	// keeps zero, so nothing new is onboarded, and — critically — the expiry
+	// pass below still runs, marking any children activated under a previous
+	// cap>0 as expired so OnExpire fires and the daemon tears down their
+	// fsnotify watches / reindex jobs. Log the disabled state once per process
+	// (not every tick) so operators see it without per-tick spam.
+	if cap == 0 {
+		w.disabledLogOnce.Do(func() {
+			w.logger.Info("worktree: indexing disabled (GRAFEL_MAX_WORKTREES_PER_REPO=0)")
+		})
+	}
+
 	now := time.Now().UTC()
 
 	// Track every path seen in this tick across all parents.
@@ -684,7 +715,9 @@ func (w *Watcher) poll() {
 		}
 
 		kept, skipped := enforceCap(linked, cap)
-		if skipped > 0 {
+		// cap==0 is the disable escape hatch, already logged once above; don't
+		// emit the per-parent cap-enforced Warn every tick in that case.
+		if skipped > 0 && cap > 0 {
 			w.logger.Warn("worktree: per-parent cap enforced", "group", p.GroupName, "slug", p.Slug, "total", len(linked), "kept", cap, "skipped", skipped, "cap", cap, "override_env", "GRAFEL_MAX_WORKTREES_PER_REPO")
 		}
 

--- a/internal/daemon/worktree/worktree_test.go
+++ b/internal/daemon/worktree/worktree_test.go
@@ -218,6 +218,117 @@ func TestWatcher_cap_15_worktrees_keeps_10(t *testing.T) {
 	}
 }
 
+func TestMaxWorktrees_resolves_env(t *testing.T) {
+	cases := []struct {
+		name string
+		set  bool
+		val  string
+		want int
+	}{
+		{name: "unset defaults to 10", set: false, want: 10},
+		{name: "positive value honored", set: true, val: "5", want: 5},
+		{name: "explicit zero disables", set: true, val: "0", want: 0},
+		{name: "invalid string defaults to 10", set: true, val: "abc", want: 10},
+		{name: "negative defaults to 10", set: true, val: "-3", want: 10},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.set {
+				t.Setenv("GRAFEL_MAX_WORKTREES_PER_REPO", tc.val)
+			} else {
+				os.Unsetenv("GRAFEL_MAX_WORKTREES_PER_REPO")
+			}
+			if got := worktree.MaxWorktreesForTest(); got != tc.want {
+				t.Fatalf("maxWorktrees()=%d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWatcher_cap_0_disables_indexing(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	t.Setenv("GRAFEL_MAX_WORKTREES_PER_REPO", "0")
+
+	for i := 0; i < 5; i++ {
+		wtDir := filepath.Join(tmp, "wt", string(rune('a'+i)))
+		addWorktree(t, repoDir, wtDir, "feat/branch-"+string(rune('a'+i)))
+	}
+
+	storePath := filepath.Join(tmp, "worktrees.json")
+	store := worktree.NewStore(storePath)
+
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{
+			{GroupName: "grp", Slug: "repo", Path: repoDir},
+		}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+	w.Poll()
+
+	active := store.Active()
+	if len(active) != 0 {
+		t.Fatalf("want 0 active (cap=0 disables indexing), got %d", len(active))
+	}
+}
+
+// TestWatcher_cap_0_tears_down_active_children verifies that flipping
+// GRAFEL_MAX_WORKTREES_PER_REPO to 0 on an already-melting daemon does not just
+// stop onboarding new worktrees — it also reaps children that were activated
+// under a previous cap>0. The expiry pass must run (not be short-circuited) so
+// OnExpire fires and the daemon unsubscribes the working tree.
+func TestWatcher_cap_0_tears_down_active_children(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+
+	for i := 0; i < 3; i++ {
+		wtDir := filepath.Join(tmp, "wt", string(rune('a'+i)))
+		addWorktree(t, repoDir, wtDir, "feat/branch-"+string(rune('a'+i)))
+	}
+
+	store := worktree.NewStore(filepath.Join(tmp, "worktrees.json"))
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "grp", Slug: "repo", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+
+	var expired []*worktree.WorktreeChild
+	w.OnExpire = func(c *worktree.WorktreeChild) { expired = append(expired, c) }
+
+	// First tick under the default cap (10): all 3 worktrees activate.
+	w.Poll()
+	if len(store.Active()) != 3 {
+		t.Fatalf("setup: want 3 active before disable, got %d", len(store.Active()))
+	}
+
+	// Operator flips the escape hatch to shed load.
+	t.Setenv("GRAFEL_MAX_WORKTREES_PER_REPO", "0")
+	w.Poll()
+
+	if len(store.Active()) != 0 {
+		t.Fatalf("want 0 active after cap=0 teardown, got %d", len(store.Active()))
+	}
+	if len(expired) != 3 {
+		t.Fatalf("want OnExpire to fire for all 3 torn-down children, got %d", len(expired))
+	}
+}
+
 func TestWatcher_removal_marks_expired(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")


### PR DESCRIPTION
## Summary
Fixes item 3 of #5675. `GRAFEL_MAX_WORKTREES_PER_REPO=0` was silently floored back to the default of 10 (`maxWorktrees()` guarded on `n > 0`), leaving **no way to disable** worktree/branch-snapshot indexing on large monorepos — the reporter had to fully uninstall.

## Change
- `maxWorktrees()`: guard `n > 0` → `n >= 0` so an explicit `0` is honored. Unset → default 10; invalid/non-numeric → 10; negative → 10 (meaningless input keeps a normal repo working); only an explicit, unambiguous `0` disables. Documented in the function's doc block.
- `poll()`: a resolved cap of 0 now **flows through the normal path** — `enforceCap(linked, 0)` onboards nothing, and the existing expiry pass then tears down any **already-active** worktree children (`OnExpire` → unsubscribe watches → reap stores). So `=0` is a true escape hatch even on an already-running/melting daemon, not just from a clean start.
- The per-parent `cap enforced` Warn is suppressed when fully disabled (`skipped > 0 && cap > 0`); a single `worktree: indexing disabled` Info is logged once per process (`sync.Once`) — no per-tick spam.

## Tests
- `TestMaxWorktrees_resolves_env` — unset→10, "5"→5, "0"→0, "abc"→10, "-3"→10.
- `TestWatcher_cap_0_disables_indexing` — `=0` from a clean store → 0 active.
- `TestWatcher_cap_0_tears_down_active_children` — 3 worktrees activate under default cap, then `=0` → asserts `store.Active()==0` **and** `OnExpire` fired for all 3. Fails on a naive short-circuit implementation, passes here (proves teardown).
- `TestWatcher_cap_15_worktrees_keeps_10` unchanged — normal cap behavior preserved.

## Verification
`go build ./...`, `go vet`, `gofmt` clean; `go test ./internal/daemon/worktree/...` passes. Independently reviewed (initial short-circuit version was caught for a teardown gap and revised to this flow-through approach).

Part of #5675 (companion to #5676; worktree-storm dedup and fd hardening follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #5675