### PR TITLE
fix(worktree): dedup worktree parents by git root, not module path (#5675)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cajasmota/grafel/internal/docgen"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/jobs"
 	"github.com/cajasmota/grafel/internal/mcp"
@@ -795,6 +796,10 @@ func daemonWorktreeParents() []worktree.ParentRepo {
 		return nil
 	}
 	seen := map[string]bool{}
+	// Memoize git common-dir resolution within this call: a monorepo has many
+	// slugs whose paths resolve to the same root, and even distinct paths may
+	// repeat, so resolve each abs path at most once.
+	commonDir := map[string]string{}
 	var out []worktree.ParentRepo
 	for _, g := range groups {
 		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
@@ -809,9 +814,26 @@ func daemonWorktreeParents() []worktree.ParentRepo {
 			if aerr != nil {
 				abs = r.Path
 			}
-			// Dedup on (group, path): a repo may legitimately appear in
-			// multiple groups, but within a group the path is unique.
-			key := g.Name + "\x00" + abs
+			// Dedup on (group, git common-dir), NOT (group, path). In a
+			// monorepo the N module slugs are N distinct subdir paths of ONE
+			// git root; they all share a single git common-dir and therefore
+			// report the SAME `git worktree list`. Keying on the common-dir
+			// collapses them to a single representative parent (the first slug
+			// seen) instead of N parents that each re-discover the same
+			// worktrees — the #5675 reindex storm. Independent repos have
+			// distinct common-dirs and so remain distinct parents.
+			root, ok := commonDir[abs]
+			if !ok {
+				root = gitmeta.ResolveCommonDir(abs)
+				commonDir[abs] = root
+			}
+			// Fall back to path-keyed dedup when common-dir resolution fails
+			// (path is not a git repo / git unavailable) so nothing is dropped.
+			keyBase := root
+			if keyBase == "" {
+				keyBase = abs
+			}
+			key := g.Name + "\x00" + keyBase
 			if seen[key] {
 				continue
 			}

--- a/cmd/grafel/daemon_worktree_parents_5675_test.go
+++ b/cmd/grafel/daemon_worktree_parents_5675_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// initGitRepo creates a real git repo at dir with one commit so that
+// `git rev-parse --git-common-dir` and `git worktree list` behave normally.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+}
+
+// writeWorktreeGroup registers a group named `name` with the given repos and
+// track_worktrees enabled, via a temp GRAFEL_HOME registry.
+func writeWorktreeGroup(t *testing.T, name string, repos []registry.Repo) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+
+	cfg := &registry.GroupConfig{Name: name, Repos: repos}
+	cfg.Features.TrackWorktrees = true
+
+	cfgPath := filepath.Join(home, name+".json")
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup(name, cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+}
+
+// TestDaemonWorktreeParents_MonorepoCollapses is the #5675 regression proof.
+// One git root with TWO registered module slugs at distinct subdir paths must
+// produce exactly ONE worktree parent (they share a git common-dir, so they
+// would otherwise independently discover the SAME worktrees → reindex storm).
+func TestDaemonWorktreeParents_MonorepoCollapses(t *testing.T) {
+	root := t.TempDir()
+	initGitRepo(t, root)
+	modA := filepath.Join(root, "services", "a")
+	modB := filepath.Join(root, "services", "b")
+	if err := os.MkdirAll(modA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(modB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeWorktreeGroup(t, "mono", []registry.Repo{
+		{Slug: "mono-a", Path: modA},
+		{Slug: "mono-b", Path: modB},
+	})
+
+	got := daemonWorktreeParents()
+	if len(got) != 1 {
+		t.Fatalf("monorepo: got %d parents, want 1 (slugs sharing one git root must collapse): %+v", len(got), got)
+	}
+}
+
+// TestDaemonWorktreeParents_SeparateReposStaySeparate proves no regression for
+// a group of RELATED but independent repos (each its own .git / distinct git
+// root): each must remain its OWN parent.
+func TestDaemonWorktreeParents_SeparateReposStaySeparate(t *testing.T) {
+	base := t.TempDir()
+	repo1 := filepath.Join(base, "r1")
+	repo2 := filepath.Join(base, "r2")
+	initGitRepo(t, repo1)
+	initGitRepo(t, repo2)
+
+	writeWorktreeGroup(t, "related", []registry.Repo{
+		{Slug: "r1", Path: repo1},
+		{Slug: "r2", Path: repo2},
+	})
+
+	got := daemonWorktreeParents()
+	if len(got) != 2 {
+		t.Fatalf("separate repos: got %d parents, want 2 (distinct git roots must stay separate): %+v", len(got), got)
+	}
+}
+
+// TestDaemonWorktreeParents_SingleRepo: one repo → one parent.
+func TestDaemonWorktreeParents_SingleRepo(t *testing.T) {
+	repo := t.TempDir()
+	initGitRepo(t, repo)
+
+	writeWorktreeGroup(t, "single", []registry.Repo{
+		{Slug: "single", Path: repo},
+	})
+
+	got := daemonWorktreeParents()
+	if len(got) != 1 {
+		t.Fatalf("single repo: got %d parents, want 1: %+v", len(got), got)
+	}
+}
+
+// TestDaemonWorktreeParents_NonGitGraceful: a registered path that is NOT a git
+// repo must not panic and must fall back to path-keyed behavior (kept, not
+// dropped). Two distinct non-git paths → two parents.
+func TestDaemonWorktreeParents_NonGitGraceful(t *testing.T) {
+	base := t.TempDir()
+	p1 := filepath.Join(base, "notgit1")
+	p2 := filepath.Join(base, "notgit2")
+	if err := os.MkdirAll(p1, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(p2, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeWorktreeGroup(t, "nongit", []registry.Repo{
+		{Slug: "ng1", Path: p1},
+		{Slug: "ng2", Path: p2},
+	})
+
+	got := daemonWorktreeParents()
+	if len(got) != 2 {
+		t.Fatalf("non-git paths: got %d parents, want 2 (fallback path-keyed, none dropped): %+v", len(got), got)
+	}
+}

--- a/internal/daemon/watch/githead_poller.go
+++ b/internal/daemon/watch/githead_poller.go
@@ -208,29 +208,7 @@ func (p *GitHeadPoller) GroupCount() int {
 // (e.g. macOS /tmp → /private/tmp) so that the base repo and its linked
 // worktrees map to the same key. Returns "" if repoPath is not a git repo.
 func resolveCommonDir(repoPath string) string {
-	raw := gitmeta.RunGit(repoPath, "rev-parse", "--git-common-dir")
-	if raw == "" {
-		return ""
-	}
-	// --git-common-dir may return a relative path (e.g. ".git") for the base
-	// repo; resolve it relative to the repo root.
-	var abs string
-	if filepath.IsAbs(raw) {
-		abs = raw
-	} else {
-		var err error
-		abs, err = filepath.Abs(filepath.Join(repoPath, raw))
-		if err != nil {
-			return ""
-		}
-	}
-	// Resolve symlinks so macOS /tmp → /private/tmp and similar OS symlinks
-	// don't create spurious duplicate groups.
-	real, err := filepath.EvalSymlinks(abs)
-	if err != nil {
-		return filepath.Clean(abs) // fallback: clean without symlink resolution
-	}
-	return real
+	return gitmeta.ResolveCommonDir(repoPath)
 }
 
 // refFileForBranch returns the path to the ref file for a given branch name

--- a/internal/gitmeta/commondir.go
+++ b/internal/gitmeta/commondir.go
@@ -1,0 +1,36 @@
+package gitmeta
+
+import "path/filepath"
+
+// ResolveCommonDir resolves the git common-dir for repoPath to a canonical
+// absolute path. All linked worktrees of a repo — and every subdirectory of a
+// single git root (e.g. the module slugs of a monorepo) — share ONE common-dir,
+// so it is the correct key for deduplicating "which repos share one git root".
+//
+// filepath.EvalSymlinks is applied so OS-level symlinks (e.g. macOS
+// /tmp → /private/tmp) do not produce spurious distinct keys. Returns "" when
+// repoPath is not a git repository (or git is unavailable); callers should fall
+// back to a path-based key in that case rather than dropping the entry.
+func ResolveCommonDir(repoPath string) string {
+	raw := RunGit(repoPath, "rev-parse", "--git-common-dir")
+	if raw == "" {
+		return ""
+	}
+	// --git-common-dir may return a relative path (e.g. ".git") for the base
+	// repo; resolve it relative to the repo root.
+	var abs string
+	if filepath.IsAbs(raw) {
+		abs = raw
+	} else {
+		var err error
+		abs, err = filepath.Abs(filepath.Join(repoPath, raw))
+		if err != nil {
+			return ""
+		}
+	}
+	real, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return filepath.Clean(abs) // fallback: clean without symlink resolution
+	}
+	return real
+}


### PR DESCRIPTION
## Summary
Fixes item 1 of #5675 — the **critical worktree indexing storm**. `daemonWorktreeParents()` deduped worktree parents on `(group, absolute path)`. In a monorepo the N module slugs are N distinct subdir paths of **one** git root, so each became its own worktree parent and independently ran `git worktree list` — which reports the git root's shared worktrees — so every slug discovered the **same** worktrees. Result: N×(worktrees) full-monorepo reindexes on every daemon boot (the reporter saw 16 identical `per-parent cap enforced` lines), starving real module indexing.

## Change
- Dedup key changed from `(group, path)` → `(group, git-common-dir)`, so all module slugs sharing one git root collapse to a **single representative parent**. `git worktree list` from any subdir walks up to the same root, so the representative discovers every worktree the dropped slugs would have — nothing is lost.
- Lifted the existing `resolveCommonDir` (was private to the watch poller) into `internal/gitmeta` as exported `ResolveCommonDir` (single source of truth; the poller now delegates — no behavior change, no import cycle). Per-call memoization resolves each path at most once.
- Non-git / resolution-failure paths **fall back to the old path-based key** (entries retained, never dropped, cannot collide with a real git root).
- Replaced the stale "within a group the path is unique" comment.

## Why the collapse is safe (verified in review)
Worktree indexing is routed by the worktree's own **path** (`OnActivate` → `AddRepo(child.Path)` / `Enqueue(child.Path)`), not by the parent slug. `ParentSlug` is used only for logging and `grafel status` display. The dedup key is group-prefixed, so a git root registered in two groups still yields one parent per group. Separate independent repos (distinct git roots) are unaffected.

## Tests (real `git init` repos, TDD)
- `TestDaemonWorktreeParents_MonorepoCollapses` — 2 slugs under one root → **1** parent (fails on old code: got 2).
- `TestDaemonWorktreeParents_SeparateReposStaySeparate` — 2 distinct git roots → **2** parents (no regression).
- `TestDaemonWorktreeParents_SingleRepo` — 1 parent.
- `TestDaemonWorktreeParents_NonGitGraceful` — non-git paths retained via fallback, no panic.

## Verification
`go build ./...`, `go vet`, `gofmt` clean; `go test ./cmd/grafel/... ./internal/daemon/... ./internal/gitmeta/...` all pass. Independently reviewed: APPROVE-WITH-NITS, no correctness defects; collapse-safety definitively confirmed.

### Known follow-up (non-blocking, from review)
Representative selection is "first slug seen." If a group registers **both** a module-subdir slug and the git-root slug with the subdir ordered first, the collapse keeps the subdir path, whose `<path>/.git/worktrees` doesn't resolve, so that root loses its fsnotify onboarding fast-path and falls back to the ~60s reconciliation poll (latency only, not correctness; pure subdir-only monorepos never had the fast-path anyway). Follow-up: prefer the representative whose `gitWorktreesDir` resolves (root-most path).

Part of #5675 (companion to #5676, #5677; fd hardening follows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs #5675