### PR TITLE
fix(daemon): bound worktree fan-out + raise fd limits to stop crash-loop (#5675)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/caps"
 	"github.com/cajasmota/grafel/internal/daemon/extract"
+	"github.com/cajasmota/grafel/internal/daemon/fdlimit"
 	"github.com/cajasmota/grafel/internal/daemon/mode"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
@@ -434,6 +435,22 @@ func runDaemon(argv []string) error {
 	parseCap := runtime.GOMAXPROCS(0)
 	indexstate.SetParseConcurrency(parseCap)
 	gcLog.Printf("cpu-tune: in-process parse concurrency cap=%d (#5630)", parseCap)
+
+	// #5675: raise RLIMIT_NOFILE toward the hard limit so a worktree indexing
+	// storm (each subscribed working tree costs ~1 fd per directory on Linux
+	// inotify) cannot exhaust fds and crash the daemon into a KeepAlive/Restart
+	// relaunch loop. Best-effort and NON-FATAL: never lowers an already-high
+	// limit; a failure to raise is logged and startup continues. Overridable
+	// via GRAFEL_DAEMON_FD_LIMIT.
+	fdTarget := fdlimit.DefaultTarget
+	if v := envPositiveInt2("GRAFEL_DAEMON_FD_LIMIT"); v > 0 {
+		fdTarget = uint64(v)
+	}
+	if oldFD, newFD, ferr := fdlimit.Raise(fdTarget); ferr != nil {
+		gcLog.Printf("fd-tune: WARN could not raise RLIMIT_NOFILE (target=%d, current=%d): %v", fdTarget, oldFD, ferr)
+	} else {
+		gcLog.Printf("fd-tune: RLIMIT_NOFILE soft limit %d -> %d (target=%d)", oldFD, newFD, fdTarget)
+	}
 
 	// Parse daemon-only flags. The root cobra command has flag parsing
 	// disabled for "daemon" so we own the argv. Unknown flags exit

--- a/internal/daemon/activate_concurrency_test.go
+++ b/internal/daemon/activate_concurrency_test.go
@@ -1,0 +1,26 @@
+package daemon
+
+import "testing"
+
+// TestWorktreeActivateConcurrency verifies the OnActivate fan-out bound
+// resolver (#5675): env override wins when strictly positive, otherwise the
+// default applies. The bound caps how many worktree working-tree fsnotify
+// subscriptions may open concurrently so a burst cannot exhaust fds.
+func TestWorktreeActivateConcurrency(t *testing.T) {
+	if got := worktreeActivateConcurrency(); got != defaultActivateConcurrency {
+		t.Errorf("default = %d, want %d", got, defaultActivateConcurrency)
+	}
+
+	t.Setenv("GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY", "3")
+	if got := worktreeActivateConcurrency(); got != 3 {
+		t.Errorf("override = %d, want 3", got)
+	}
+
+	// Non-positive / garbage falls back to the default.
+	for _, bad := range []string{"0", "-1", "abc", ""} {
+		t.Setenv("GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY", bad)
+		if got := worktreeActivateConcurrency(); got != defaultActivateConcurrency {
+			t.Errorf("value %q: got %d, want default %d", bad, got, defaultActivateConcurrency)
+		}
+	}
+}

--- a/internal/daemon/fdlimit/fdlimit.go
+++ b/internal/daemon/fdlimit/fdlimit.go
@@ -1,0 +1,18 @@
+// Package fdlimit raises the process's RLIMIT_NOFILE (max open file
+// descriptors) soft limit at daemon startup.
+//
+// Background (#5675): a worktree indexing storm can subscribe many working
+// trees to the fsnotify watcher, each of which costs ~1 fd per directory on
+// Linux inotify. If the process hits its soft fd limit it dies while
+// persisting its store; launchd/systemd KeepAlive/Restart relaunches it and
+// boot re-discovery restarts the storm — an unbreakable crash-loop. Raising
+// the soft limit toward the hard limit is one layer of defense-in-depth so the
+// daemon has ample headroom before it can ever exhaust fds.
+//
+// The raise is always non-fatal and NEVER lowers an already-high limit.
+package fdlimit
+
+// DefaultTarget is a sane fd headroom target used when the caller does not
+// specify one. 65536 comfortably covers a large multi-worktree fleet on Linux
+// inotify while staying within typical hard-limit ceilings.
+const DefaultTarget uint64 = 65536

--- a/internal/daemon/fdlimit/fdlimit_other.go
+++ b/internal/daemon/fdlimit/fdlimit_other.go
@@ -1,0 +1,10 @@
+//go:build !linux && !darwin
+
+package fdlimit
+
+// Raise is a no-op on platforms without POSIX RLIMIT_NOFILE semantics
+// (e.g. Windows). It reports success with zero limits so callers can log a
+// uniform, non-fatal result.
+func Raise(target uint64) (old, updated uint64, err error) {
+	return 0, 0, nil
+}

--- a/internal/daemon/fdlimit/fdlimit_unix.go
+++ b/internal/daemon/fdlimit/fdlimit_unix.go
@@ -1,0 +1,78 @@
+//go:build linux || darwin
+
+package fdlimit
+
+import "syscall"
+
+// Raise raises the RLIMIT_NOFILE soft limit toward target (clamped to the hard
+// limit), and returns the previous and new soft limits.
+//
+// Guarantees:
+//   - It NEVER lowers the soft limit. If target is below the current soft
+//     limit, the current limit is left untouched and returned unchanged.
+//   - It is best-effort: on any Setrlimit failure it tries progressively
+//     smaller candidates (handling the Darwin quirk where setting Cur to an
+//     "unlimited" hard Max fails with EINVAL — the effective ceiling there is
+//     min(Max, kern.maxfilesperproc)). If none succeed, it returns the
+//     unchanged current limit together with the last error.
+//
+// Callers should treat a non-nil error as a warning, not a fatal condition.
+func Raise(target uint64) (old, updated uint64, err error) {
+	var lim syscall.Rlimit
+	if err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim); err != nil {
+		return 0, 0, err
+	}
+	old = lim.Cur
+
+	// Desired soft limit: at least the current (never lower), at most target.
+	desired := target
+	if desired < old {
+		desired = old
+	}
+
+	// Try a descending set of candidates. The first that Setrlimit accepts
+	// wins. Each candidate is clamped to the hard Max (raising Cur above Max
+	// is rejected for unprivileged processes on Linux). On Darwin the hard Max
+	// is often "unlimited" and the real cap is lower, so we fall back to
+	// smaller concrete targets on EINVAL.
+	for _, cand := range candidates(desired, lim.Max) {
+		if cand <= old {
+			// Would not raise (or would lower); skip.
+			continue
+		}
+		trial := lim
+		trial.Cur = cand
+		if e := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &trial); e == nil {
+			return old, cand, nil
+		} else {
+			err = e
+		}
+	}
+
+	// Nothing raised the limit; report the still-current value. err holds the
+	// last Setrlimit error (nil if every candidate was already <= old).
+	return old, old, err
+}
+
+// candidates returns a descending, de-duplicated list of soft-limit targets to
+// attempt, each clamped to the hard max. hardMax==0 is treated as "unknown"
+// and applies no clamp.
+func candidates(desired, hardMax uint64) []uint64 {
+	clamp := func(v uint64) uint64 {
+		if hardMax != 0 && v > hardMax {
+			return hardMax
+		}
+		return v
+	}
+	raw := []uint64{clamp(desired), clamp(DefaultTarget), clamp(10240)}
+	out := make([]uint64, 0, len(raw))
+	seen := make(map[uint64]bool, len(raw))
+	for _, v := range raw {
+		if v == 0 || seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}

--- a/internal/daemon/fdlimit/fdlimit_unix_test.go
+++ b/internal/daemon/fdlimit/fdlimit_unix_test.go
@@ -1,0 +1,117 @@
+//go:build linux || darwin
+
+package fdlimit
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestRaise_NeverLowers verifies that a target below the current soft limit
+// leaves the limit unchanged (the raise must never shrink an already-high
+// limit).
+func TestRaise_NeverLowers(t *testing.T) {
+	var before syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &before); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+
+	old, updated, err := Raise(1) // absurdly low target
+	if err != nil {
+		t.Fatalf("Raise(1) returned error: %v", err)
+	}
+	if old != before.Cur {
+		t.Errorf("old = %d, want current soft limit %d", old, before.Cur)
+	}
+	if updated < old {
+		t.Fatalf("Raise LOWERED the limit: old=%d new=%d", old, updated)
+	}
+
+	var after syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &after); err != nil {
+		t.Fatalf("Getrlimit after: %v", err)
+	}
+	if after.Cur < before.Cur {
+		t.Fatalf("soft limit was lowered on disk: before=%d after=%d", before.Cur, after.Cur)
+	}
+}
+
+// TestRaise_ReturnsNewGreaterOrEqualOld verifies the core postcondition:
+// updated >= old always holds, regardless of platform ceiling.
+func TestRaise_ReturnsNewGreaterOrEqualOld(t *testing.T) {
+	old, updated, err := Raise(DefaultTarget)
+	if err != nil {
+		// A non-nil error is acceptable (best-effort), but then the limit must
+		// be reported unchanged.
+		if updated != old {
+			t.Fatalf("Raise errored (%v) but reported a changed limit: old=%d new=%d", err, old, updated)
+		}
+		return
+	}
+	if updated < old {
+		t.Fatalf("Raise LOWERED the limit: old=%d new=%d", old, updated)
+	}
+}
+
+// TestRaise_RaisesFromLoweredLimit deterministically proves that Raise
+// increases the soft limit. We first LOWER our own soft limit (always
+// permitted) then assert Raise brings it back up toward the original — this
+// works on any platform regardless of the hard-max representation (Darwin
+// reports an effectively-infinite hard max, so testing "toward hard max"
+// directly is unreliable).
+func TestRaise_RaisesFromLoweredLimit(t *testing.T) {
+	var orig syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &orig); err != nil {
+		t.Fatalf("Getrlimit: %v", err)
+	}
+	t.Cleanup(func() { _ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &orig) })
+
+	const lowered = 256
+	if orig.Cur <= lowered {
+		t.Skipf("soft limit (%d) already at/below %d; cannot lower to test", orig.Cur, lowered)
+	}
+	low := orig
+	low.Cur = lowered
+	if err := syscall.Setrlimit(syscall.RLIMIT_NOFILE, &low); err != nil {
+		t.Fatalf("Setrlimit(lowered): %v", err)
+	}
+
+	old, updated, err := Raise(orig.Cur)
+	if err != nil {
+		t.Fatalf("Raise: %v", err)
+	}
+	if old != lowered {
+		t.Errorf("old = %d, want lowered value %d", old, lowered)
+	}
+	if updated <= old {
+		t.Fatalf("expected raise: old=%d new=%d (target=%d, hardMax=%d)", old, updated, orig.Cur, orig.Max)
+	}
+	if updated > orig.Max {
+		t.Fatalf("raised above hard max: new=%d hardMax=%d", updated, orig.Max)
+	}
+}
+
+// TestCandidates_DescendingClampedUnique checks the candidate generator clamps
+// to the hard max, drops zeros/dupes, and preserves descending priority.
+func TestCandidates_DescendingClampedUnique(t *testing.T) {
+	got := candidates(200000, 100000)
+	if len(got) == 0 {
+		t.Fatal("no candidates produced")
+	}
+	if got[0] != 100000 {
+		t.Errorf("first candidate = %d, want clamp to hardMax 100000", got[0])
+	}
+	seen := map[uint64]bool{}
+	for _, v := range got {
+		if v == 0 {
+			t.Errorf("candidate list contains zero: %v", got)
+		}
+		if v > 100000 {
+			t.Errorf("candidate %d exceeds hardMax 100000", v)
+		}
+		if seen[v] {
+			t.Errorf("duplicate candidate %d in %v", v, got)
+		}
+		seen[v] = true
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -27,6 +28,24 @@ import (
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/gitmeta"
 )
+
+// defaultActivateConcurrency bounds how many worktree working-tree fsnotify
+// subscriptions (watcher.AddRepo) may be opening at once (#5675). Kept small:
+// activations are normally dispatched one-at-a-time by the reconciliation poll,
+// so this only ever engages under an abnormal burst.
+const defaultActivateConcurrency = 8
+
+// worktreeActivateConcurrency resolves the OnActivate fan-out bound. It honours
+// GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY (strictly-positive integer) and falls
+// back to defaultActivateConcurrency otherwise.
+func worktreeActivateConcurrency() int {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultActivateConcurrency
+}
 
 // Config configures Run. Fields are required unless documented otherwise.
 type Config struct {
@@ -492,6 +511,19 @@ func Run(ctx context.Context, cfg Config) error {
 				}
 				wtWatcher := worktree.NewWatcher(wtStore, cfg.WorktreeParents, logger)
 
+				// #5675: bound the fsnotify-subscription fan-out. Each
+				// watcher.AddRepo(child.Path) subscribes the worktree's ENTIRE
+				// working tree, costing ~1 fd per directory on Linux inotify —
+				// UNBOUNDED by the number of activated worktrees. A burst of
+				// activations could open a flood of fds at once and crash the
+				// daemon into a KeepAlive/Restart relaunch loop. This semaphore
+				// caps how many subscriptions can be opening concurrently. For
+				// the common case (activations are dispatched sequentially by
+				// poll, one at a time) the semaphore is always immediately
+				// available — zero behavior change. Overridable via
+				// GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY.
+				activateSem := make(chan struct{}, worktreeActivateConcurrency())
+
 				// On activation, subscribe the worktree's WORKING TREE to the
 				// fsnotify watcher so uncommitted edits trigger a reactive
 				// reindex, and enqueue one immediate reindex of its ref tier.
@@ -499,7 +531,10 @@ func Run(ctx context.Context, cfg Config) error {
 				// RefCapture(worktreePath), so the graph lands in the correct
 				// per-ref dir keyed by the worktree path (multi-ref model).
 				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
-					if _, aerr := watcher.AddRepo(child.Path); aerr != nil {
+					activateSem <- struct{}{}
+					_, aerr := watcher.AddRepo(child.Path)
+					<-activateSem
+					if aerr != nil {
 						logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
 					}
 					scheduler.Enqueue(child.Path)

--- a/internal/daemon/service/install_test.go
+++ b/internal/daemon/service/install_test.go
@@ -71,6 +71,28 @@ func TestGeneratePlist_KeepAlive(t *testing.T) {
 	}
 }
 
+// TestGeneratePlist_SoftResourceLimits verifies the plist sets a
+// SoftResourceLimits/NumberOfFiles fd limit (#5675) so a worktree indexing
+// storm cannot exhaust fds and crash-loop under KeepAlive.
+func TestGeneratePlist_SoftResourceLimits(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "<key>SoftResourceLimits</key>") {
+		t.Errorf("plist missing SoftResourceLimits:\n%s", plist)
+	}
+	if !strings.Contains(plist, "<key>NumberOfFiles</key>") {
+		t.Errorf("plist missing NumberOfFiles:\n%s", plist)
+	}
+	if !strings.Contains(plist, "<integer>65536</integer>") {
+		t.Errorf("plist missing NumberOfFiles value 65536:\n%s", plist)
+	}
+	// NumberOfFiles must appear inside the SoftResourceLimits dict.
+	softIdx := strings.Index(plist, "<key>SoftResourceLimits</key>")
+	nofIdx := strings.Index(plist, "<key>NumberOfFiles</key>")
+	if softIdx < 0 || nofIdx < softIdx {
+		t.Errorf("NumberOfFiles not nested under SoftResourceLimits:\n%s", plist)
+	}
+}
+
 // TestGeneratePlist_RunAtLoad verifies RunAtLoad=true so the daemon
 // starts automatically when the user logs in.
 func TestGeneratePlist_RunAtLoad(t *testing.T) {

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -45,6 +45,15 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>KeepAlive</key>
     <true/>
 
+    <!-- #5675: fd headroom so a worktree indexing storm (each subscribed
+         working tree costs ~1 fd per directory) cannot exhaust fds and
+         crash-loop under KeepAlive. -->
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>65536</integer>
+    </dict>
+
     <key>StandardOutPath</key>
     <string>{{.LogDir}}/daemon.log</string>
 

--- a/internal/daemon/service/systemd_fdlimit_linux_test.go
+++ b/internal/daemon/service/systemd_fdlimit_linux_test.go
@@ -1,0 +1,33 @@
+//go:build linux
+
+package service_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/service"
+)
+
+// TestGenerateUnit_LimitNOFILE verifies the generated systemd unit sets an fd
+// limit in the [Service] section (#5675). This is the MOST important
+// service-unit change because the primary deployment target is a Linux VPS
+// under systemd; without it a worktree indexing storm can exhaust fds and
+// crash-loop under Restart=on-failure. Runs without a live systemd session.
+func TestGenerateUnit_LimitNOFILE(t *testing.T) {
+	unitBytes, err := service.GenerateUnit(service.Options{BinPath: "/usr/local/bin/grafel"})
+	if err != nil {
+		t.Fatalf("GenerateUnit: %v", err)
+	}
+	unit := string(unitBytes)
+	if !strings.Contains(unit, "LimitNOFILE=65536") {
+		t.Errorf("systemd unit missing LimitNOFILE=65536:\n%s", unit)
+	}
+	// The directive must live in the [Service] section, not [Unit]/[Install].
+	svcIdx := strings.Index(unit, "[Service]")
+	instIdx := strings.Index(unit, "[Install]")
+	limIdx := strings.Index(unit, "LimitNOFILE=")
+	if svcIdx < 0 || limIdx < svcIdx || (instIdx >= 0 && limIdx > instIdx) {
+		t.Errorf("LimitNOFILE not inside [Service] section:\n%s", unit)
+	}
+}

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -37,6 +37,10 @@ ExecStart={{.BinPath}} daemon
 Restart=on-failure
 RestartSec=3s
 Environment=HOME={{.Home}}
+# #5675: give the daemon ample fd headroom. A worktree indexing storm
+# subscribes many working trees to inotify (~1 fd per directory); without this
+# the process can exhaust fds and crash-loop under Restart=on-failure.
+LimitNOFILE=65536
 
 [Install]
 WantedBy=default.target

--- a/internal/daemon/service/systemd_linux_integration_test.go
+++ b/internal/daemon/service/systemd_linux_integration_test.go
@@ -97,6 +97,11 @@ func TestSystemdInstallUninstall(t *testing.T) {
 	if !strings.Contains(unit, "WantedBy=default.target") {
 		t.Errorf("rendered unit missing WantedBy=default.target:\n%s", unit)
 	}
+	// #5675: the [Service] section must set an fd limit so a worktree indexing
+	// storm cannot exhaust fds and crash-loop under Restart=on-failure.
+	if !strings.Contains(unit, "LimitNOFILE=65536") {
+		t.Errorf("rendered unit missing LimitNOFILE=65536:\n%s", unit)
+	}
 
 	// ── Write unit file and reload ────────────────────────────────────────
 	if err := os.MkdirAll(filepath.Dir(unitPath), 0o755); err != nil {

--- a/internal/daemon/worktree/persist_retry_test.go
+++ b/internal/daemon/worktree/persist_retry_test.go
@@ -1,0 +1,71 @@
+package worktree
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestStoreSave_RetriesTransientTmpFailure verifies the persist path recovers
+// from a transient `.tmp` write failure by retrying once (#5675), rather than
+// dropping the reconcile. We simulate the transient failure by pre-creating the
+// `.tmp` path as a directory: the first os.WriteFile fails ("is a directory"),
+// the retry removes the stale entry and succeeds.
+//
+// It also asserts the path is NEVER fatal — save() only ever returns an error;
+// nothing here exits the process.
+func TestStoreSave_RetriesTransientTmpFailure(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "worktrees.json")
+
+	s := NewStore(path)
+	s.children = []*WorktreeChild{{
+		ParentSlug:   "r",
+		GroupName:    "g",
+		Path:         "/some/worktree",
+		Branch:       "main",
+		DiscoveredAt: time.Now().UTC(),
+		LastSeenAt:   time.Now().UTC(),
+		Status:       StatusActive,
+	}}
+
+	// Inject a transient failure: the staging path exists as a directory, so
+	// the first WriteFile fails; the retry's os.Remove clears it.
+	tmp := path + ".tmp"
+	if err := os.Mkdir(tmp, 0o755); err != nil {
+		t.Fatalf("seed tmp dir: %v", err)
+	}
+
+	if err := s.save(); err != nil {
+		t.Fatalf("save() should recover via retry, got error: %v", err)
+	}
+
+	// The real store file must now exist with valid JSON content.
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("store file missing after save: %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("store file is empty after save")
+	}
+	// The staging file must have been renamed away.
+	if _, err := os.Stat(tmp); !os.IsNotExist(err) {
+		t.Errorf("tmp staging path still present after save: %v", err)
+	}
+}
+
+// TestStoreSave_SucceedsNormally guards the common (no-failure) path: a single
+// WriteFile + rename with no retry needed.
+func TestStoreSave_SucceedsNormally(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "worktrees.json")
+	s := NewStore(path)
+	s.children = []*WorktreeChild{{ParentSlug: "r", GroupName: "g", Path: "/w", Status: StatusActive}}
+	if err := s.save(); err != nil {
+		t.Fatalf("save(): %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("store file missing: %v", err)
+	}
+}

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -171,6 +171,12 @@ func (s *Store) Load() error {
 }
 
 // save writes the store atomically (caller must hold s.mu).
+//
+// It is resilient to a transient failure writing the `.tmp` staging file
+// (#5675): the daemon persists on every reconciliation tick, so a momentary
+// fd-exhaustion or I/O blip must not drop the whole reconcile. The `.tmp`
+// write is retried ONCE before giving up. The caller keeps this NON-FATAL —
+// nothing here ever calls os.Exit/log.Fatal.
 func (s *Store) save() error {
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o755); err != nil {
 		return err
@@ -181,7 +187,13 @@ func (s *Store) save() error {
 	}
 	tmp := s.path + ".tmp"
 	if err := os.WriteFile(tmp, data, 0o644); err != nil {
-		return err
+		// Retry once: a transient fd/I-O blip during a storm should not drop
+		// the reconcile silently. A best-effort remove of a possibly
+		// partially-written tmp precedes the retry.
+		_ = os.Remove(tmp)
+		if err2 := os.WriteFile(tmp, data, 0o644); err2 != nil {
+			return err2
+		}
 	}
 	return os.Rename(tmp, s.path)
 }
@@ -486,6 +498,19 @@ type Watcher struct {
 	interval time.Duration
 	logger   *slog.Logger
 
+	// pollMu serializes poll() against itself. The ticker loop (Start) and the
+	// debounced fsnotify goroutine (startGitDirsWatch) both call poll(); without
+	// this guard a burst could run two reconciliations concurrently and multiply
+	// the OnActivate fsnotify-subscription fan-out (#5675). It is distinct from
+	// store.mu (which only guards the children map) and always wraps — never is
+	// wrapped by — store.mu, so no lock-ordering deadlock is possible.
+	pollMu sync.Mutex
+
+	// lastSaveErrLog rate-limits the "failed to persist store" log so a
+	// per-tick persist failure during a storm cannot spam the log (#5675).
+	// Accessed only under pollMu (poll wraps the save + this log).
+	lastSaveErrLog time.Time
+
 	// OnActivate fires once per child when it becomes (or re-becomes)
 	// active — i.e. on first discovery and on re-activation after expiry.
 	// Used by the daemon to watch the worktree working tree and trigger an
@@ -503,6 +528,10 @@ type Watcher struct {
 
 // defaultPollInterval is the default reconciliation interval.
 const defaultPollInterval = 60 * time.Second
+
+// saveErrLogInterval bounds how often a store-persist failure is logged, so a
+// per-tick failure during an fd storm cannot flood the log (#5675).
+const saveErrLogInterval = 5 * time.Minute
 
 // pollInterval returns the reconciliation interval.
 //
@@ -683,6 +712,14 @@ func (w *Watcher) Poll() { w.poll() }
 func (w *Watcher) Sync() { w.poll() }
 
 func (w *Watcher) poll() {
+	// Serialize reconciliation passes (#5675). For the common case (single
+	// repo, no concurrent trigger) this is an uncontended lock — zero added
+	// latency. Under a burst it makes ticker + debounced-fsnotify polls run
+	// one-at-a-time instead of overlapping and multiplying the activation
+	// fan-out.
+	w.pollMu.Lock()
+	defer w.pollMu.Unlock()
+
 	parents := w.parents()
 	cap := maxWorktrees()
 
@@ -769,7 +806,13 @@ func (w *Watcher) poll() {
 		}
 	}
 	if err := w.store.save(); err != nil {
-		w.logger.Error("worktree: failed to persist store", "err", err)
+		// Non-fatal by design: the daemon keeps running on a persist failure
+		// (the reconcile is re-derived from git on the next tick). Rate-limit
+		// + demote to Warn so a per-tick storm can't flood the log (#5675).
+		if now.Sub(w.lastSaveErrLog) >= saveErrLogInterval {
+			w.logger.Warn("worktree: failed to persist store (non-fatal, will retry next reconcile)", "err", err)
+			w.lastSaveErrLog = now
+		}
 	}
 	w.store.mu.Unlock()
 

--- a/internal/daemon/worktree/worktree_test.go
+++ b/internal/daemon/worktree/worktree_test.go
@@ -5,6 +5,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -658,6 +660,57 @@ func TestWatcher_Sync_discovers_and_persists(t *testing.T) {
 	}
 	if len(store2.Active()) != 1 {
 		t.Fatalf("persisted store: want 1 active, got %d", len(store2.Active()))
+	}
+}
+
+// TestWatcher_poll_serialized verifies that two concurrent Poll() calls do NOT
+// run the reconciliation body at the same time (#5675). The ticker loop and the
+// debounced fsnotify goroutine both call poll(); overlapping passes would
+// multiply the OnActivate fsnotify-subscription fan-out and can exhaust fds.
+//
+// The parents() provider is called once at the very start of each poll body. We
+// instrument it to record the maximum observed concurrency: with the pollMu
+// guard it must never exceed 1.
+func TestWatcher_poll_serialized(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	addWorktree(t, repoDir, filepath.Join(tmp, "wt1"), "feat/serial")
+
+	store := worktree.NewStore(filepath.Join(tmp, "wt.json"))
+
+	var inFlight int32
+	var maxSeen int32
+	parents := func() []worktree.ParentRepo {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			cur := atomic.LoadInt32(&maxSeen)
+			if n <= cur || atomic.CompareAndSwapInt32(&maxSeen, cur, n) {
+				break
+			}
+		}
+		// Hold long enough that a non-serialized second poll would overlap.
+		time.Sleep(60 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "r", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() { defer wg.Done(); w.Poll() }()
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxSeen); got != 1 {
+		t.Fatalf("poll() ran with concurrency %d; want serialized (1)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
Fixes item 2 of #5675 — the **fd-exhaustion crash-loop**. Under a worktree storm the daemon could exhaust file descriptors and die while persisting its store; launchd/systemd `KeepAlive`/`Restart` relaunched it and boot re-discovery restarted the storm — an unbreakable loop. (Note: the `worktrees.json.tmp` persist failure the reporter saw was already non-fatal — a symptom, not the crash site; the real sink was unbounded fsnotify subscriptions.)

This is **defense-in-depth** — the companion dedup fix (#5678) removes most of the fan-out at the source; this makes an fd-crash-loop structurally impossible.

## Changes (4 areas)
1. **Raise `RLIMIT_NOFILE` at startup.** New `internal/daemon/fdlimit` package: `Raise(target)` reads the soft limit, computes `max(target, current)` (**never lowers**), and tries a descending, hard-max-clamped candidate list `[desired, 65536, 10240]` (handles the Darwin `EINVAL` quirk where only `Cur` can be set). Wired into `runDaemon` **non-fatally** (Warn + continue). Default 65536, overridable via `GRAFEL_DAEMON_FD_LIMIT`. No-op stub on non-linux/darwin.
2. **Bound the activation fan-out.** `poll()` is serialized with a dedicated `pollMu` (distinct from `store.mu`, always wraps it — no lock-order inversion), so the ticker and debounced-fsnotify polls can't overlap. `OnActivate`'s `watcher.AddRepo` is gated by a bounded semaphore (`GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY`, default 8). Both are uncontended/immediately-available in the common case — zero steady-state change.
3. **Harden the store persist (still non-fatal).** `Store.save()` retries a transient `.tmp` write once (removing the stale tmp first); the caller's log is demoted `Error`→`Warn` and rate-limited to once/5min. No `os.Exit`/`log.Fatal` anywhere on the persist path.
4. **Service-unit fd limits.** systemd `LimitNOFILE=65536` in `[Service]` (Linux — the primary deployment target); launchd `SoftResourceLimits→NumberOfFiles=65536`. Each on the correct `_linux.go`/`_darwin.go` build-tag side.

## Tests
- `fdlimit`: never-lowers, raises-from-lowered, new≥old, candidate list — all pass.
- `worktree`: `TestWatcher_poll_serialized` (4 concurrent polls, asserts max in-flight == 1) and `TestStoreSave_RetriesTransientTmpFailure` — **both fail when the fix is reverted, pass with it**; verified under `go test -race` (no data race on `lastSaveErrLog`).
- `service`: systemd `LimitNOFILE` + launchd `NumberOfFiles` generation asserted.
- `daemon`: activate-concurrency env override + safe default (bad/0/negative → 8, never a deadlocking 0-cap channel).

## Verification
`go test ./cmd/grafel/... ./internal/daemon/...` all pass, `-race` clean. `GOOS=darwin` builds clean; changed packages build clean for `GOOS=linux`/`windows` (only pre-existing unrelated tree-sitter cgo cross-compile noise). Independently reviewed: APPROVE-WITH-NITS, **no deadlock, no semaphore leak** (race-detector confirmed).

### Known nits (non-blocking, from review)
- `fdlimit_unix.go` doc-comment overstates the "target below current → unchanged" case: the 10240/65536 fallbacks still raise when the current limit is very low (the never-lower safety property holds regardless). Follow-up: tighten the comment or drop fallbacks when `target < old`.
- Semaphore uses explicit release rather than `defer` (panic-safety only; moot since an `AddRepo` panic crashes the daemon anyway).

Completes the #5675 set (with #5676, #5677, #5678).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #5675