### PR TITLE
fix(mcp): locality-first, hub-aware subgraph expansion + cap markdown path (#5691)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -1377,6 +1377,98 @@ func buildRiskReason(e *graph.Entity, namedCallers, moduleNodes, total int, hasI
 // "truncated" flag + "truncation_note". Callers may raise it via max_nodes.
 const subgraphRawMaxNodes = 1500
 
+// subgraphHubDegree is the total-degree (in+out) cutoff above which a node is
+// treated as a hub for the stop-and-annotate guard (#5691). A node this
+// connected is a structural hub (e.g. a Module container aggregating an entire
+// package); crossing into it mid-walk would inherit its entire fan-out and
+// swamp the result with unrelated cross-module nodes. The bounded walk stops at
+// such a node and annotates the crossing rather than expanding it. IsGodNode
+// (precomputed centrality flag) also trips the guard. The cutoff is high enough
+// that ordinary well-referenced functions are never mistaken for hubs.
+const subgraphHubDegree = 1000
+
+// subgraphModulePrefix returns a cheap module/package proxy for a source path:
+// its directory portion. Used by the locality ranker to prefer same-module
+// neighbours when a frontier level must be truncated (#5691).
+func subgraphModulePrefix(path string) string {
+	if i := strings.LastIndexByte(path, '/'); i >= 0 {
+		return path[:i]
+	}
+	return ""
+}
+
+// newSubgraphRanker builds the locality-first, hub-aware ranker for a bounded
+// subgraph expansion rooted at `root` (#5691).
+//
+// Ordering (best first, so it survives truncation):
+//  1. non-hub targets before hub targets (never inherit a hub's fan-out),
+//  2. targets in the root's own source file,
+//  3. targets in the root's module/package,
+//  4. lower-degree targets (peripheral over central),
+//  5. deterministic id tiebreak.
+//
+// A target is a hub when its precomputed IsGodNode flag is set or its total
+// degree exceeds subgraphHubDegree.
+func newSubgraphRanker(adj *adjacency, byID map[string]*graph.Entity, root *graph.Entity) *bfsRanker {
+	degree := func(id string) int { return len(adj.Outgoing(id)) + len(adj.Incoming(id)) }
+	isHub := func(id string) bool {
+		if e := byID[id]; e != nil && e.IsGodNode {
+			return true
+		}
+		return degree(id) >= subgraphHubDegree
+	}
+	rootFile := ""
+	rootModule := ""
+	if root != nil {
+		rootFile = root.SourceFile
+		rootModule = subgraphModulePrefix(root.SourceFile)
+	}
+	return &bfsRanker{
+		isHub: isHub,
+		less: func(a, b bfsCandidate) bool {
+			ha, hb := isHub(a.target), isHub(b.target)
+			if ha != hb {
+				return !ha // non-hub first
+			}
+			ea, eb := byID[a.target], byID[b.target]
+			fa, fb := ea != nil && ea.SourceFile == rootFile, eb != nil && eb.SourceFile == rootFile
+			if fa != fb {
+				return fa // same file first
+			}
+			ma := ea != nil && subgraphModulePrefix(ea.SourceFile) == rootModule
+			mb := eb != nil && subgraphModulePrefix(eb.SourceFile) == rootModule
+			if ma != mb {
+				return ma // same module first
+			}
+			da, db := degree(a.target), degree(b.target)
+			if da != db {
+				return da < db // lower fan-out first
+			}
+			return a.target < b.target
+		},
+	}
+}
+
+// subgraphHubNote renders the hub-boundary annotation shared by the raw and
+// markdown subgraph paths (#5691): human names + degree for each hub the walk
+// stopped at, and the id->display map for structured output.
+func subgraphHubNote(hubIDs []string, byID map[string]*graph.Entity, adj *adjacency) []string {
+	if len(hubIDs) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(hubIDs))
+	for _, id := range hubIDs {
+		name := id
+		if e := byID[id]; e != nil && e.Name != "" {
+			name = e.Name
+		}
+		deg := len(adj.Outgoing(id)) + len(adj.Incoming(id))
+		names = append(names, fmt.Sprintf("%s (%d edges)", name, deg))
+	}
+	sort.Strings(names)
+	return names
+}
+
 // handleSubgraph is the unified handler for grafel_subgraph.
 // format="raw"      → JSON graph (nodes + edges), identical output to old get_subgraph.
 // format="markdown" → LLM-friendly Markdown summary, identical output to old summarize_subgraph.
@@ -1442,8 +1534,12 @@ func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpa
 			continue
 		}
 		adj := r.getAdjacency()
-		visited, nodesTruncated := bfsBounded(adj, target, depth, nil, maxNodes)
 		byID2 := r.getByID()
+		// Locality-first, hub-aware bounded expansion (#5691): rank the frontier
+		// by locality so local structure survives truncation, and stop at
+		// high-degree hubs instead of inheriting their fan-out.
+		ranker := newSubgraphRanker(adj, byID2, byID[target])
+		visited, nodesTruncated, hubIDs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsBoth)
 		type nodeOut struct {
 			EntityID   string `json:"entity_id"`
 			Name       string `json:"name"`
@@ -1521,14 +1617,29 @@ func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpa
 			"edges":      edges,
 			"node_count": len(nodes),
 			"edge_count": len(edges),
-			"truncated":  nodesTruncated,
+		}
+		// Hub boundaries: the walk stopped at these high-degree hubs rather than
+		// inheriting their fan-out. Surface them so the caller can narrow (#5691).
+		hubNames := subgraphHubNote(hubIDs, byID2, adj)
+		truncated := nodesTruncated || len(hubNames) > 0
+		out["truncated"] = truncated
+		var notes []string
+		if len(hubNames) > 0 {
+			out["hub_boundaries"] = hubNames
+			notes = append(notes, fmt.Sprintf(
+				"expanded into hub(s) [%s] and stopped there to avoid inheriting their fan-out; "+
+					"pass an entity_kind or module filter to narrow",
+				strings.Join(hubNames, ", ")))
 		}
 		if nodesTruncated {
-			out["truncation_note"] = fmt.Sprintf(
+			notes = append(notes, fmt.Sprintf(
 				"node expansion capped at max_nodes=%d to bound a high-degree subgraph; "+
 					"some nodes beyond the cap (and their edges) are omitted — narrow with a smaller "+
 					"depth, or pass a larger max_nodes for an explicit deeper pull",
-				maxNodes)
+				maxNodes))
+		}
+		if len(notes) > 0 {
+			out["truncation_note"] = strings.Join(notes, " ")
 		}
 		return jsonResult(out), nil
 	}
@@ -1548,6 +1659,13 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 	}
 	if depth > 4 {
 		depth = 4
+	}
+	// maxNodes bounds the markdown neighbourhood walk, matching the raw path
+	// (#5691). The former markdown walk was fully UNBOUNDED, so a node near a
+	// high-degree hub produced a Markdown list of the hub's entire fan-out.
+	maxNodes := argInt(req, "max_nodes", subgraphRawMaxNodes)
+	if maxNodes < 1 {
+		maxNodes = subgraphRawMaxNodes
 	}
 
 	repoHint, local := splitPrefixed(entityID)
@@ -1573,38 +1691,12 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 		}
 
 		adj := r.getAdjacency()
-
-		// Gather inbound callers (depth hops).
-		inVisited := map[string]int{}
-		inFront := []string{target}
-		for d := 0; d < depth; d++ {
-			next := []string{}
-			for _, n := range inFront {
-				for _, e := range adj.in[n] {
-					if _, seen := inVisited[e.target]; !seen {
-						inVisited[e.target] = d + 1
-						next = append(next, e.target)
-					}
-				}
-			}
-			inFront = next
-		}
-
-		// Gather outbound callees (depth hops).
-		outVisited := map[string]int{}
-		outFront := []string{target}
-		for d := 0; d < depth; d++ {
-			next := []string{}
-			for _, n := range outFront {
-				for _, e := range adj.out[n] {
-					if _, seen := outVisited[e.target]; !seen {
-						outVisited[e.target] = d + 1
-						next = append(next, e.target)
-					}
-				}
-			}
-			outFront = next
-		}
+		// Locality-first, hub-aware, BOUNDED walk in each direction (#5691).
+		// bfsBoundedRanked includes the start node at depth 0; the caller lists
+		// exclude it below.
+		ranker := newSubgraphRanker(adj, byID, root)
+		inVisited, _, inHubs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsIn)
+		outVisited, _, outHubs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsOut)
 
 		// Build callers list (sorted by hop then name).
 		type neighbor struct {
@@ -1615,6 +1707,9 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 		}
 		var callers []neighbor
 		for id, d := range inVisited {
+			if id == target {
+				continue // bfsBoundedRanked includes the start node at depth 0
+			}
 			if e := byID[id]; e != nil {
 				callers = append(callers, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
 			}
@@ -1628,6 +1723,9 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 
 		var callees []neighbor
 		for id, d := range outVisited {
+			if id == target {
+				continue // bfsBoundedRanked includes the start node at depth 0
+			}
 			if e := byID[id]; e != nil {
 				callees = append(callees, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
 			}
@@ -1688,6 +1786,23 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 			b.WriteString("\n")
 		} else {
 			b.WriteString("## Calls\n\n_No callees within the graph (leaf node or all edges unresolved)._\n\n")
+		}
+
+		// Hub boundaries: the walk stopped at these high-degree hubs rather than
+		// inheriting their fan-out (#5691). Surface them so the caller can narrow.
+		hubSeen := map[string]bool{}
+		var hubIDs []string
+		for _, id := range append(append([]string{}, inHubs...), outHubs...) {
+			if !hubSeen[id] {
+				hubSeen[id] = true
+				hubIDs = append(hubIDs, id)
+			}
+		}
+		if names := subgraphHubNote(hubIDs, byID, adj); len(names) > 0 {
+			b.WriteString(fmt.Sprintf(
+				"## Hub boundaries\n\n_Expanded into hub(s) [%s] and stopped there to avoid inheriting "+
+					"their fan-out. Pass an entity_kind or module filter to narrow._\n\n",
+				strings.Join(names, ", ")))
 		}
 
 		return mcpapi.NewToolResultText(b.String()), nil

--- a/internal/mcp/subgraph_locality_5691_test.go
+++ b/internal/mcp/subgraph_locality_5691_test.go
@@ -1,0 +1,163 @@
+// subgraph_locality_5691_test.go — regression tests for #5691.
+//
+// Bug: grafel_subgraph mode=expand on a node ~2 hops from a high-degree Module
+// hub (degree ~157k) returned ~157k neighbours dominated by unrelated
+// cross-module/mixed-kind nodes — it inherited the hub's entire fan-out.
+//
+//   - bfsBounded expanded adj.out/adj.in in Go MAP-ITERATION order with NO
+//     ranking; when it hit maxNodes it stopped arbitrarily, so a hub reached
+//     mid-walk dumped its whole neighbourhood and truncation kept whatever
+//     iterated first.
+//   - subgraphMarkdown had NO maxNodes bound at all — a fully unbounded walk.
+//
+// Fix: locality-first ranked frontier + hub-aware stop-and-annotate in the
+// bounded expansion, and give the markdown path the same maxNodes bound as raw.
+package mcp
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildHubRepo builds a repo where `root` sits in a small LOCAL cluster
+// (same file/module) but is ALSO one hop from a high-degree hub whose fan-out
+// would swamp the result if inherited.
+//
+//	root ──CALLS──▶ localA ──CALLS──▶ localB       (all in src/app/…)
+//	root ──CALLS──▶ hub ──CALLS──▶ leaf0..leafN    (hub in src/hub, leaves in src/other)
+func buildHubRepo(hubFanout int) *graph.Document {
+	doc := &graph.Document{Repo: "app"}
+	doc.Entities = []graph.Entity{
+		{ID: "root", Name: "RootFn", Kind: "SCOPE.Function", SourceFile: "src/app/root.ts", StartLine: 1},
+		{ID: "localA", Name: "LocalA", Kind: "SCOPE.Function", SourceFile: "src/app/util.ts", StartLine: 1},
+		{ID: "localB", Name: "LocalB", Kind: "SCOPE.Function", SourceFile: "src/app/util.ts", StartLine: 10},
+		{ID: "hub", Name: "PaymentHub", Kind: "SCOPE.Module", SourceFile: "src/hub/hub.ts", StartLine: 1},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "r1", FromID: "root", ToID: "localA", Kind: "CALLS"},
+		{ID: "r2", FromID: "localA", ToID: "localB", Kind: "CALLS"},
+		{ID: "r3", FromID: "root", ToID: "hub", Kind: "CALLS"},
+	}
+	for i := 0; i < hubFanout; i++ {
+		id := fmt.Sprintf("leaf%d", i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: id, Name: id, Kind: "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/other/leaf%d.ts", i), StartLine: 1,
+		})
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID: "rh" + id, FromID: "hub", ToID: id, Kind: "CALLS",
+		})
+	}
+	return doc
+}
+
+// TestSubgraph_ExpandStopsAtHub_5691 is the core regression: expanding `root`
+// at depth 2 must return the LOCAL cluster and NOT inherit the hub's fan-out;
+// the hub crossing must be annotated so the caller can narrow.
+//
+// RED on current code: the unranked/uncapped walk expands the hub and returns
+// all leaf* nodes with no hub annotation.
+func TestSubgraph_ExpandStopsAtHub_5691(t *testing.T) {
+	const fanout = 1200 // > the hub-degree cutoff, well under max_nodes=1500
+	srv := newTestServer(t, buildHubRepo(fanout))
+
+	out := callFlowTool(t, srv.handleSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(2),
+		"format":    "raw",
+	})
+	if out == nil {
+		t.Fatal("expected JSON output for format=raw")
+	}
+
+	nodes, _ := out["nodes"].([]any)
+	var names []string
+	for _, n := range nodes {
+		m, _ := n.(map[string]any)
+		if m == nil {
+			continue
+		}
+		names = append(names, fmt.Sprint(m["name"]))
+	}
+	joined := strings.Join(names, ",")
+
+	// 1) The local cluster must survive.
+	for _, want := range []string{"LocalA", "LocalB"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("local cluster node %q missing from expansion:\n%s", want, joined)
+		}
+	}
+	// 2) The hub's fan-out must NOT be inherited. A handful is tolerable; the
+	//    whole 1200-leaf neighbourhood is the bug.
+	leafCount := strings.Count(joined, "leaf")
+	if leafCount > 5 {
+		t.Errorf("hub fan-out inherited: %d leaf* nodes in expansion (want ~0). "+
+			"The bounded walk expanded the hub instead of stopping at it.\n%.400s",
+			leafCount, joined)
+	}
+	// 3) The hub crossing must be annotated so the caller can narrow.
+	note, _ := out["truncation_note"].(string)
+	_, hasBoundaries := out["hub_boundaries"]
+	if !hasBoundaries && !strings.Contains(strings.ToLower(note), "hub") {
+		t.Errorf("hub crossing not annotated: expected hub_boundaries or a hub note, got:\n%#v / %q",
+			out["hub_boundaries"], note)
+	}
+	if !strings.Contains(note+fmt.Sprint(out["hub_boundaries"]), "PaymentHub") {
+		t.Errorf("hub annotation should name the hub (PaymentHub); got note=%q boundaries=%v",
+			note, out["hub_boundaries"])
+	}
+}
+
+// TestSubgraph_MarkdownRespectsMaxNodes_5691 asserts the markdown path is now
+// bounded by max_nodes just like the raw path.
+//
+// RED on current code: subgraphMarkdown walks the whole neighbourhood and lists
+// all 2000 callees regardless of max_nodes.
+func TestSubgraph_MarkdownRespectsMaxNodes_5691(t *testing.T) {
+	doc := &graph.Document{Repo: "app"}
+	doc.Entities = []graph.Entity{
+		{ID: "root", Name: "RootFn", Kind: "SCOPE.Function", SourceFile: "src/app/root.ts", StartLine: 1},
+	}
+	const fanout = 2000
+	for i := 0; i < fanout; i++ {
+		id := fmt.Sprintf("callee%d", i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: id, Name: id, Kind: "SCOPE.Function",
+			SourceFile: fmt.Sprintf("src/other/callee%d.ts", i), StartLine: 1,
+		})
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID: "rc" + id, FromID: "root", ToID: id, Kind: "CALLS",
+		})
+	}
+	srv := newTestServer(t, doc)
+
+	const cap = 50
+	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(1),
+		"format":    "markdown",
+		"max_nodes": float64(cap),
+	})
+
+	// Parse "## Calls (N entities within …)".
+	re := regexp.MustCompile(`## Calls \((\d+) ent`)
+	m := re.FindStringSubmatch(text)
+	if m == nil {
+		t.Fatalf("could not find Calls header in markdown:\n%.400s", text)
+	}
+	n, _ := strconv.Atoi(m[1])
+	if n > cap {
+		t.Fatalf("markdown callee count %d exceeds max_nodes cap %d — the markdown path is unbounded", n, cap)
+	}
+	// Sanity: it should still list a healthy chunk of the neighbourhood.
+	if n == 0 {
+		t.Fatalf("markdown listed no callees; expected up to %d", cap)
+	}
+}

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"container/heap"
 	"math"
+	"sort"
 	"strconv"
 
 	"github.com/cajasmota/grafel/internal/graph"
@@ -164,6 +165,51 @@ func bfs(adj *adjacency, start string, depth int, contextFilter map[string]bool)
 	return visited
 }
 
+// bfsDir selects which adjacency directions a bounded BFS expands.
+type bfsDir int
+
+const (
+	bfsBoth bfsDir = iota // in+out (default neighbourhood walk)
+	bfsOut                // out-edges only (callees)
+	bfsIn                 // in-edges only (callers)
+)
+
+// bfsCandidate is a pending expansion target discovered while processing one
+// frontier level. depth is the target's hop distance (parent depth + 1).
+type bfsCandidate struct {
+	target string
+	depth  int
+}
+
+// bfsRanker customises bounded BFS for locality-aware truncation and hub
+// containment (#5691). Both hooks are optional; a nil *bfsRanker yields a plain
+// deterministic walk (candidates ordered by target id) with no hub guard.
+type bfsRanker struct {
+	// less orders same-level candidates; when a level is truncated the cap
+	// keeps the smallest under this ordering, so local structure survives while
+	// a hub's far-flung fan-out is dropped. Must be a strict weak ordering with
+	// a deterministic final tiebreak.
+	less func(a, b bfsCandidate) bool
+	// isHub reports whether expanding id would inherit a high-degree hub's
+	// fan-out. A hub node is still ADDED to the visited set (so the caller sees
+	// the boundary) but its neighbours are NOT expanded — the walk stops at it
+	// and the caller annotates the crossing. Never applied to the start node
+	// (the query target is always expanded).
+	isHub func(id string) bool
+}
+
+// rankCandidates orders a frontier level's candidates in place. With a ranker's
+// less hook it applies locality-first ordering; otherwise it falls back to a
+// stable order by target id. This replaces the old Go map-iteration order,
+// which made truncation non-deterministic (#5691).
+func rankCandidates(cands []bfsCandidate, ranker *bfsRanker) {
+	if ranker != nil && ranker.less != nil {
+		sort.SliceStable(cands, func(i, j int) bool { return ranker.less(cands[i], cands[j]) })
+		return
+	}
+	sort.SliceStable(cands, func(i, j int) bool { return cands[i].target < cands[j].target })
+}
+
 // bfsBounded is bfs with an optional node-count cap. When maxNodes > 0 and the
 // visited set reaches that many nodes, expansion stops early and truncated is
 // returned true. The cap bounds the pathological high-degree tail (a hub at
@@ -172,58 +218,85 @@ func bfs(adj *adjacency, start string, depth int, contextFilter map[string]bool)
 // (maxNodes<=0 disables the cap). Truncation is honest: callers surface a
 // marker rather than silently dropping nodes. (#3924)
 func bfsBounded(adj *adjacency, start string, depth int, contextFilter map[string]bool, maxNodes int) (map[string]int, bool) {
+	visited, truncated, _ := bfsBoundedRanked(adj, start, depth, contextFilter, maxNodes, nil, bfsBoth)
+	return visited, truncated
+}
+
+// bfsBoundedRanked is the ranked, hub-aware core behind bfsBounded (#5691).
+//
+// Each frontier level is processed atomically: all candidate targets are
+// gathered, ranked (locality-first via the ranker, else deterministically by
+// id), and only then added up to the cap. Ranking BEFORE the cap is what keeps
+// local structure alive under truncation — the old code stopped in arbitrary
+// map-iteration order, so a hub reached mid-walk dumped whatever iterated first.
+//
+// When nothing is truncated the visited SET is identical to the naive walk
+// (ranking only changes discovery order, and callers sort their output), so
+// small/normal graphs are unaffected.
+//
+// hubs holds the ids of hub nodes the walk declined to expand (stop-and-
+// annotate). dir selects in/out/both adjacency directions.
+func bfsBoundedRanked(adj *adjacency, start string, depth int, contextFilter map[string]bool, maxNodes int, ranker *bfsRanker, dir bfsDir) (map[string]int, bool, []string) {
 	visited := map[string]int{start: 0}
 	frontier := []string{start}
 	truncated := false
-	add := func(target string, d int) bool {
-		if _, seen := visited[target]; seen {
-			return true
+	var hubs []string
+	hubSeen := map[string]bool{}
+
+	consider := func(cands *[]bfsCandidate, candSeen map[string]bool, e edge, d int) {
+		if contextFilter != nil && !contextFilter[e.kind] {
+			return
 		}
-		if maxNodes > 0 && len(visited) >= maxNodes {
-			truncated = true
-			return false
+		if _, seen := visited[e.target]; seen {
+			return
 		}
-		visited[target] = d + 1
-		return true
+		if candSeen[e.target] {
+			return
+		}
+		candSeen[e.target] = true
+		*cands = append(*cands, bfsCandidate{target: e.target, depth: d + 1})
 	}
+
 	for d := 0; d < depth && !truncated; d++ {
-		next := []string{}
+		cands := make([]bfsCandidate, 0)
+		candSeen := map[string]bool{}
 		for _, n := range frontier {
-			for _, e := range adj.out[n] {
-				if contextFilter != nil && !contextFilter[e.kind] {
-					continue
+			// Hub-aware stop: don't inherit a hub's fan-out. The start node is
+			// exempt — it is the explicit query target and is always expanded.
+			if ranker != nil && ranker.isHub != nil && n != start && ranker.isHub(n) {
+				if !hubSeen[n] {
+					hubSeen[n] = true
+					hubs = append(hubs, n)
 				}
-				if _, seen := visited[e.target]; !seen {
-					if !add(e.target, d) {
-						break
-					}
-					next = append(next, e.target)
+				continue
+			}
+			if dir == bfsBoth || dir == bfsOut {
+				for _, e := range adj.out[n] {
+					consider(&cands, candSeen, e, d)
 				}
 			}
-			if truncated {
+			if dir == bfsBoth || dir == bfsIn {
+				for _, e := range adj.in[n] {
+					consider(&cands, candSeen, e, d)
+				}
+			}
+		}
+		rankCandidates(cands, ranker)
+		next := make([]string, 0, len(cands))
+		for _, c := range cands {
+			if maxNodes > 0 && len(visited) >= maxNodes {
+				truncated = true
 				break
 			}
-			for _, e := range adj.in[n] {
-				if contextFilter != nil && !contextFilter[e.kind] {
-					continue
-				}
-				if _, seen := visited[e.target]; !seen {
-					if !add(e.target, d) {
-						break
-					}
-					next = append(next, e.target)
-				}
-			}
-			if truncated {
-				break
-			}
+			visited[c.target] = c.depth
+			next = append(next, c.target)
 		}
 		frontier = next
 		if len(frontier) == 0 {
 			break
 		}
 	}
-	return visited, truncated
+	return visited, truncated, hubs
 }
 
 // pqItem is one entry in the dijkstra priority queue.


### PR DESCRIPTION
Closes #5691. `subgraph mode=expand` on a node near a high-degree hub inherited the hub's whole fan-out (157k neighbors); the markdown path was fully unbounded. Now: ranked bounded BFS (rank frontier, then cap — so local structure survives truncation: non-hub → same-file → same-module → low-fanout → id), hub-aware stop-and-annotate at degree≥1000/god-nodes, and `subgraphMarkdown` respects max_nodes. Untruncated visited-set is provably identical to the old walk (nil-ranker path unchanged); normal graphs unaffected. Reviewed: APPROVE-WITH-NITS (annotation wording corrected). Refs #5681.