### PR TITLE
fix(doctor): O(E) health computation + single graph load; status relabel (#5689, #5693)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -262,7 +262,7 @@ func TestDoctorRunsCleanly(t *testing.T) {
 		t.Fatal(err)
 	}
 	out := &bytes.Buffer{}
-	if err := runDoctor(out); err != nil {
+	if err := runDoctor(out, false); err != nil {
 		t.Fatal(err)
 	}
 	if !strings.Contains(out.String(), "Group: demo") {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -33,6 +33,7 @@ func newDoctorCmd() *cobra.Command {
 	var refFlag string
 	var jsonOut bool
 	var quick bool
+	var deep bool
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run health checks across all groups",
@@ -48,6 +49,13 @@ health report. Exits non-zero when any Critical check fails.
 --quick      Cheap two-check mode: CLI SHA + daemon /healthz (500ms cap).
              Prints a one-line warning on drift but never blocks the caller.
              Used internally by every CLI command's entry point.
+
+--deep       Opt into full-load recomputation of the enriched health report.
+             The default path already loads each repo graph at most once (a
+             single O(E) pass — no multi-minute hang on 250k+-entity graphs,
+             #5689) and sources counts from the live graph, so --deep no longer
+             changes the numbers when the load succeeds. Retained for its
+             documented full-recompute semantics.
 
 --ref        Filter runtime graph-state checks to a specific ref.
 --ref @all   Check health across every known ref.`,
@@ -86,7 +94,7 @@ health report. Exits non-zero when any Critical check fails.
 			} else if isAll {
 				fmt.Fprintf(w, "Note: --ref @all — running doctor across all known refs.\n\n")
 			}
-			if err := runDoctor(w); err != nil {
+			if err := runDoctor(w, deep); err != nil {
 				return err
 			}
 			if auditDocs {
@@ -114,6 +122,11 @@ health report. Exits non-zero when any Critical check fails.
 		"emit machine-readable JSON report (schema_version=1); exits non-zero on Critical drift")
 	cmd.Flags().BoolVar(&quick, "quick", false,
 		"run only the two cheap checks: CLI SHA + daemon /healthz (500ms); never blocks caller")
+	cmd.Flags().BoolVar(&deep, "deep", false,
+		"opt into full-load recomputation of the enriched health report. The default path "+
+			"already loads each repo graph at most once and sources counts from the live graph, "+
+			"so this no longer changes the numbers when the load succeeds; retained for its "+
+			"documented full-recompute semantics (#5689)")
 	return cmd
 }
 
@@ -181,7 +194,7 @@ func runDoctorAuditDocs(w io.Writer) error {
 
 // runDoctor runs every health check and reports to w. It returns nil
 // even when checks fail — the report itself is the user signal.
-func runDoctor(w io.Writer) error {
+func runDoctor(w io.Writer, deep bool) error {
 	fmt.Fprintf(w, "%s grafel %s\n", statusOK, version.String())
 
 	bin, err := os.Executable()
@@ -237,7 +250,7 @@ func runDoctor(w io.Writer) error {
 
 	// Print enriched health report for each group
 	fmt.Fprintf(w, "\n--- Enriched Health Report ---\n")
-	healthReports := ComputeDoctorHealth(groups)
+	healthReports := ComputeDoctorHealth(groups, deep)
 	PrintDoctorHealth(w, healthReports)
 
 	return nil

--- a/internal/cli/doctor_integration_test.go
+++ b/internal/cli/doctor_integration_test.go
@@ -21,7 +21,7 @@ func TestDoctorHealthGroupAggregation(t *testing.T) {
 	// Test with empty group list
 	groups := []registry.GroupRef{}
 
-	health := ComputeDoctorHealth(groups)
+	health := ComputeDoctorHealth(groups, false)
 
 	if len(health) != 0 {
 		t.Errorf("expected 0 health reports for empty input, got %d", len(health))
@@ -57,7 +57,7 @@ func TestComputeRepoHealthStale(t *testing.T) {
 		Stack: registry.StackList{"go"},
 	}
 
-	health := computeRepoHealth(repo)
+	health := computeRepoHealth(repo, false)
 
 	if health.Status != "STALE" {
 		t.Errorf("expected status STALE, got %q", health.Status)

--- a/internal/cli/doctor_perf_test.go
+++ b/internal/cli/doctor_perf_test.go
@@ -1,0 +1,235 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// smallDoc builds a tiny graph used by the perf/sidecar tests:
+//
+//	entities:      e1, e2, e3
+//	relationships: e1 -> e2 (CALLS, in-repo), e1 -> ext-9 (CALLS, cross-repo)
+//
+// Derived truth: 1 cross-repo edge (ext-9 is not an entity here) and 2 orphan
+// entities (e1 and e3 have no incoming edge; e2 does).
+func smallDoc(t *testing.T, computedAt time.Time) *graph.Document {
+	t.Helper()
+	return &graph.Document{
+		Version:     1,
+		GeneratedAt: computedAt,
+		Stats:       graph.Stats{Entities: 3, Relationships: 2, Files: 3},
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "e2", Name: "B", Kind: "function", SourceFile: "b.go", Language: "go"},
+			{ID: "e3", Name: "C", Kind: "function", SourceFile: "c.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "e1", ToID: "e2", Kind: "CALLS"},
+			{FromID: "e1", ToID: "ext-9", Kind: "CALLS"},
+		},
+	}
+}
+
+// writeRepoWithGraph creates a repo dir (with .git), writes graph.fb, and writes
+// a graph-stats.json sidecar with the given entity/relationship counts. It
+// returns the repo path.
+func writeRepoWithGraph(t *testing.T, root, slug string, doc *graph.Document, sideEntities, sideRels int) string {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(filepath.Join(repoPath, ".git"), 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	side := &graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         doc.GeneratedAt,
+		TotalEntities:      sideEntities,
+		TotalRelationships: sideRels,
+	}
+	if err := graph.WriteSidecar(filepath.Join(stateDir, "graph.fb"), side, true); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	return repoPath
+}
+
+// TestComputeCrossRepoAndOrphans verifies the single O(E) adjacency pass that
+// replaced the old O(relationships×entities) nested scan (#5689).
+func TestComputeCrossRepoAndOrphans(t *testing.T) {
+	doc := smallDoc(t, time.Now())
+	cross, orphans := computeCrossRepoAndOrphans(doc)
+	if cross != 1 {
+		t.Errorf("cross-repo edges = %d, want 1", cross)
+	}
+	if orphans != 2 {
+		t.Errorf("orphan entities = %d, want 2", orphans)
+	}
+}
+
+// TestComputeRepoHealth_LoadsGraphAtMostOnce is the anti-regression guard for
+// #5689: the doctor health path must load the (potentially 291k-entity) graph at
+// most once per repo — never the old three-loads-per-repo pattern — and must not
+// run the O(E×N) scan.
+func TestComputeRepoHealth_LoadsGraphAtMostOnce(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := writeRepoWithGraph(t, tmp, "repo", smallDoc(t, time.Now()), 3, 2)
+
+	var loads int32
+	orig := loadGraphFromDir
+	loadGraphFromDir = func(dir string) (*graph.Document, error) {
+		atomic.AddInt32(&loads, 1)
+		return orig(dir)
+	}
+	t.Cleanup(func() { loadGraphFromDir = orig })
+
+	rh := computeRepoHealth(registry.Repo{Slug: "repo", Path: repoPath}, false)
+
+	if got := atomic.LoadInt32(&loads); got > 1 {
+		t.Fatalf("graph loaded %d times, want at most 1 (#5689 regression)", got)
+	}
+	if rh.CrossRepoEdges != 1 {
+		t.Errorf("CrossRepoEdges = %d, want 1", rh.CrossRepoEdges)
+	}
+	if rh.orphanEntities != 2 {
+		t.Errorf("orphanEntities = %d, want 2", rh.orphanEntities)
+	}
+}
+
+// TestComputeRepoHealth_LiveCountsWhenLoadSucceeds verifies that when the graph
+// loads, entity/relationship counts come from the LIVE graph (doc.Stats) — the
+// same snapshot as the orphan/cross-repo metrics — even when the sidecar is
+// stale, and that deep does not change the counts. This is the fix for the
+// stale-count / >100% OrphanRate inconsistency.
+func TestComputeRepoHealth_LiveCountsWhenLoadSucceeds(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	// Sidecar deliberately DISAGREES with the live graph (stale sidecar: 999/888)
+	// so we can prove the live doc.Stats (3/2) wins when the load succeeds.
+	repoPath := writeRepoWithGraph(t, tmp, "repo", smallDoc(t, time.Now()), 999, 888)
+	repo := registry.Repo{Slug: "repo", Path: repoPath}
+
+	def := computeRepoHealth(repo, false)
+	if def.Entities != 3 || def.Relationships != 2 {
+		t.Errorf("default entities/rels = %d/%d, want 3/2 (live graph, not stale sidecar)", def.Entities, def.Relationships)
+	}
+
+	deep := computeRepoHealth(repo, true)
+	if deep.Entities != 3 || deep.Relationships != 2 {
+		t.Errorf("deep entities/rels = %d/%d, want 3/2 (live graph)", deep.Entities, deep.Relationships)
+	}
+
+	// deep no longer changes counts, and the graph-derived metrics match.
+	if def.Entities != deep.Entities || def.Relationships != deep.Relationships ||
+		def.CrossRepoEdges != deep.CrossRepoEdges || def.orphanEntities != deep.orphanEntities {
+		t.Errorf("default and deep differ when load succeeds: def=%+v deep=%+v", def, deep)
+	}
+}
+
+// TestComputeRepoHealth_SidecarFallbackOnLoadFailure verifies the degraded path:
+// when the graph fails to load, counts fall back to the graph-stats.json sidecar
+// and the graph-derived metrics (cross-repo/orphans) are zero.
+func TestComputeRepoHealth_SidecarFallbackOnLoadFailure(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := writeRepoWithGraph(t, tmp, "repo", smallDoc(t, time.Now()), 999, 888)
+	repo := registry.Repo{Slug: "repo", Path: repoPath}
+
+	// Force the graph load to fail (simulates a missing/corrupt graph.fb).
+	orig := loadGraphFromDir
+	loadGraphFromDir = func(string) (*graph.Document, error) {
+		return nil, os.ErrNotExist
+	}
+	t.Cleanup(func() { loadGraphFromDir = orig })
+
+	rh := computeRepoHealth(repo, false)
+	if rh.Entities != 999 || rh.Relationships != 888 {
+		t.Errorf("entities/rels = %d/%d, want 999/888 (sidecar fallback on load failure)", rh.Entities, rh.Relationships)
+	}
+	if rh.CrossRepoEdges != 0 || rh.orphanEntities != 0 {
+		t.Errorf("derived metrics = (%d,%d), want (0,0) when the graph can't be loaded", rh.CrossRepoEdges, rh.orphanEntities)
+	}
+}
+
+// TestComputeRepoHealth_MatchingSidecarEquivalent asserts the HARD CONSTRAINT:
+// for a normal repo whose sidecar matches the graph, default and --deep yield
+// identical values (output equivalence).
+func TestComputeRepoHealth_MatchingSidecarEquivalent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+	repoPath := writeRepoWithGraph(t, tmp, "repo", smallDoc(t, time.Now()), 3, 2)
+	repo := registry.Repo{Slug: "repo", Path: repoPath}
+
+	def := computeRepoHealth(repo, false)
+	deep := computeRepoHealth(repo, true)
+
+	if def.Entities != deep.Entities || def.Relationships != deep.Relationships ||
+		def.CrossRepoEdges != deep.CrossRepoEdges || def.orphanEntities != deep.orphanEntities {
+		t.Errorf("default and deep differ for matching sidecar: def=%+v deep=%+v", def, deep)
+	}
+	if def.Entities != 3 || def.Relationships != 2 {
+		t.Errorf("entities/rels = %d/%d, want 3/2", def.Entities, def.Relationships)
+	}
+}
+
+// TestComputeDoctorHealth_EndToEnd wires a real group config + repo through
+// ComputeDoctorHealth and confirms the enriched report aggregates the
+// sidecar-sourced counts and the single-pass orphan/cross-repo metrics, and that
+// PrintDoctorHealth still renders.
+func TestComputeDoctorHealth_EndToEnd(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := writeRepoWithGraph(t, tmp, "svc", smallDoc(t, time.Now()), 3, 2)
+
+	// Minimal group config referencing the repo.
+	cfgPath := filepath.Join(tmp, "group.json")
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Repos: []registry.Repo{{Slug: "svc", Path: repoPath, Stack: registry.StackList{"go"}}},
+	}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+
+	reports := ComputeDoctorHealth([]registry.GroupRef{{Name: "g1", ConfigPath: cfgPath}}, false)
+	if len(reports) != 1 {
+		t.Fatalf("got %d group reports, want 1", len(reports))
+	}
+	g := reports[0]
+	if g.TotalEntities != 3 {
+		t.Errorf("TotalEntities = %d, want 3 (sidecar)", g.TotalEntities)
+	}
+	if g.TotalRelationships != 2 {
+		t.Errorf("TotalRelationships = %d, want 2 (sidecar)", g.TotalRelationships)
+	}
+	if g.TotalCrossRepoEdges != 1 {
+		t.Errorf("TotalCrossRepoEdges = %d, want 1", g.TotalCrossRepoEdges)
+	}
+	if g.OrphanEntities != 2 {
+		t.Errorf("OrphanEntities = %d, want 2", g.OrphanEntities)
+	}
+
+	var buf bytes.Buffer
+	PrintDoctorHealth(&buf, reports)
+	if !bytes.Contains(buf.Bytes(), []byte("svc")) {
+		t.Errorf("enriched report did not render repo slug:\n%s", buf.String())
+	}
+}

--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -24,7 +24,17 @@ type DoctorRepoHealth struct {
 	Entities       int
 	Relationships  int
 	CrossRepoEdges int
+
+	// orphanEntities is the number of entities in this repo with no incoming
+	// relationship. Computed once (O(E)) during computeRepoHealth and summed
+	// by computeQualityMetrics so the graph is loaded at most once per repo.
+	orphanEntities int
 }
+
+// loadGraphFromDir is an indirection over graph.LoadGraphFromDir so tests can
+// count how many times the (potentially large) graph is loaded and assert the
+// doctor path loads it at most once per repo (#5689).
+var loadGraphFromDir = graph.LoadGraphFromDir
 
 // DoctorGroupHealth aggregates health metrics for a group and all its repos.
 type DoctorGroupHealth struct {
@@ -59,8 +69,25 @@ type DoctorGroupHealth struct {
 }
 
 // ComputeDoctorHealth aggregates daemon and group health into a comprehensive report.
-// It reads graph files, candidate counts, and watcher state for each group.
-func ComputeDoctorHealth(groups []registry.GroupRef) []*DoctorGroupHealth {
+// It reads candidate counts, watcher state, and the graph-stats.json sidecar for
+// each repo.
+//
+// #5689: the report loads each repo's graph AT MOST ONCE and derives cross-repo
+// edges + orphan entities from a SINGLE O(E) adjacency pass. This replaces the
+// old path that loaded the full graph three times per repo and ran an
+// O(relationships×entities) nested scan, which hung for minutes on large
+// (>250k-entity) graphs.
+//
+// Entity/relationship counts come from the live graph (doc.Stats) when the load
+// succeeds — same snapshot as the orphan/cross-repo metrics, so OrphanRate can
+// never mix a stale sidecar denominator with a live numerator (>100%). The
+// graph-stats.json sidecar is used only as a fallback when the graph can't be
+// loaded (the degraded path where orphans can't be computed anyway).
+//
+// deep is retained for its documented full-recompute semantics; since the
+// default path already loads the graph, it no longer changes the counts when the
+// load succeeds.
+func ComputeDoctorHealth(groups []registry.GroupRef, deep bool) []*DoctorGroupHealth {
 	var result []*DoctorGroupHealth
 
 	for _, g := range groups {
@@ -79,7 +106,7 @@ func ComputeDoctorHealth(groups []registry.GroupRef) []*DoctorGroupHealth {
 
 		// Aggregate per-repo health
 		for _, r := range cfg.Repos {
-			rh := computeRepoHealth(r)
+			rh := computeRepoHealth(r, deep)
 			health.Repos = append(health.Repos, rh)
 			health.TotalEntities += rh.Entities
 			health.TotalRelationships += rh.Relationships
@@ -113,7 +140,13 @@ func ComputeDoctorHealth(groups []registry.GroupRef) []*DoctorGroupHealth {
 }
 
 // computeRepoHealth assembles the health snapshot for a single repo.
-func computeRepoHealth(r registry.Repo) *DoctorRepoHealth {
+//
+// Last-indexed time is read from the graph-stats.json sidecar. Entity and
+// relationship counts come from the live graph (doc.Stats) when it loads,
+// falling back to the sidecar only when the load fails. Cross-repo edges and
+// orphan entities (no sidecar) are computed from a SINGLE O(E) adjacency pass
+// that loads the graph at most once.
+func computeRepoHealth(r registry.Repo, deep bool) *DoctorRepoHealth {
 	rh := &DoctorRepoHealth{
 		Slug:           r.Slug,
 		Path:           r.Path,
@@ -158,46 +191,74 @@ func computeRepoHealth(r registry.Repo) *DoctorRepoHealth {
 		}
 	}
 
-	// Load full graph to count cross-repo edges
-	doc, err := graph.LoadGraphFromDir(stateDir)
+	// Load the graph AT MOST ONCE to derive the metrics that have no sidecar:
+	// cross-repo edges and orphan entities. Both are computed in a single O(E)
+	// adjacency pass (previously an O(relationships×entities) nested scan +
+	// three separate full-graph loads per repo — the #5689 hang).
+	//
+	// When the load SUCCEEDS we source entity/relationship counts from the live
+	// graph (doc.Stats) unconditionally, so the orphan numerator and the entity
+	// denominator of OrphanRate are always the SAME snapshot — a stale sidecar
+	// can no longer produce a nonsensical >100% rate. The graph-stats.json
+	// sidecar values read above are the fallback used ONLY when the load fails
+	// (the degraded path where orphans/cross-repo can't be computed anyway).
+	//
+	// deep is retained for its documented full-recompute semantics; because the
+	// default path already loads the graph for orphans, it no longer changes the
+	// counts when the load succeeds.
+	_ = deep
+	doc, err := loadGraphFromDir(stateDir)
 	if err == nil && doc != nil {
 		rh.Entities = doc.Stats.Entities
 		rh.Relationships = doc.Stats.Relationships
+		rh.CrossRepoEdges, rh.orphanEntities = computeCrossRepoAndOrphans(doc)
 	}
-
-	// Count cross-repo edges (edges pointing outside this repo)
-	rh.CrossRepoEdges = countCrossRepoEdgesForRepo(r.Slug, stateDir)
 
 	return rh
 }
 
-// computeQualityMetrics aggregates orphan rate, bug rate, and candidate counts for a group.
-func computeQualityMetrics(health *DoctorGroupHealth) {
-	// Compute orphan rate from all repos
-	totalOrphans := 0
-	for _, r := range health.Repos {
-		stateDir := daemon.StateDirForRepo(r.Path)
-		doc, err := graph.LoadGraphFromDir(stateDir)
-		if err != nil || doc == nil {
+// computeCrossRepoAndOrphans derives, in a single O(E) pass, the number of
+// cross-repo edges (relationships whose ToID is not an entity in this repo)
+// and the number of orphan entities (entities with no incoming relationship).
+//
+// This replaces the old O(relationships×entities) nested loop; on a 291k-entity
+// / 1.4M-edge graph that scan was ≈10^12 operations. Membership lookups here are
+// O(1) via a pre-built entity-ID set, so the whole pass is O(E+N).
+func computeCrossRepoAndOrphans(doc *graph.Document) (crossRepo, orphans int) {
+	entityIDs := make(map[string]struct{}, len(doc.Entities))
+	for _, e := range doc.Entities {
+		entityIDs[e.ID] = struct{}{}
+	}
+	hasIncoming := make(map[string]bool, len(doc.Relationships))
+	for _, rel := range doc.Relationships {
+		if rel.ToID == "" {
 			continue
 		}
-
-		// Track entities with incoming relationships
-		hasIncoming := make(map[string]bool)
-		for _, rel := range doc.Relationships {
-			if rel.ToID != "" {
-				hasIncoming[rel.ToID] = true
-			}
+		hasIncoming[rel.ToID] = true
+		if _, ok := entityIDs[rel.ToID]; !ok {
+			// ToID points at something not in this repo → cross-repo edge.
+			crossRepo++
 		}
-
-		// Count orphans
-		for _, e := range doc.Entities {
-			if !hasIncoming[e.ID] {
-				totalOrphans++
-				health.OrphanEntities++
-			}
+	}
+	for _, e := range doc.Entities {
+		if !hasIncoming[e.ID] {
+			orphans++
 		}
+	}
+	return crossRepo, orphans
+}
 
+// computeQualityMetrics aggregates orphan rate, bug rate, and candidate counts
+// for a group. Orphan counts are taken from the per-repo values already computed
+// by computeRepoHealth (single O(E) pass) — this function loads no graph. The
+// only per-repo I/O here is the cheap enrichment-candidates.json sidecar read.
+func computeQualityMetrics(health *DoctorGroupHealth) {
+	// Aggregate orphan counts computed once per repo in computeRepoHealth, and
+	// read the (cheap) candidate-count sidecar.
+	for _, r := range health.Repos {
+		health.OrphanEntities += r.orphanEntities
+
+		stateDir := daemon.StateDirForRepo(r.Path)
 		// Load candidate counts (enrichSubjects = unique entities needing enrichment).
 		enrichSubjects, _, _, repairCount := loadCandidateCounts(stateDir)
 		health.PendingEnrichments += enrichSubjects
@@ -212,34 +273,6 @@ func computeQualityMetrics(health *DoctorGroupHealth) {
 	// Bug rate is a placeholder for unresolved-edges metric
 	// This would be populated from a bug-rate.json or similar in a real scenario
 	health.BugRate = 0.0
-}
-
-// countCrossRepoEdgesForRepo counts relationships that point to entities in other repos.
-// For now, this is a simplified count; in a full implementation it would compare
-// entity IDs across repos to identify actual cross-repo edges.
-func countCrossRepoEdgesForRepo(slug string, stateDir string) int {
-	doc, err := graph.LoadGraphFromDir(stateDir)
-	if err != nil || doc == nil {
-		return 0
-	}
-
-	// Placeholder: count relationships pointing to external IDs.
-	// A more sophisticated implementation would check if ToID belongs to a different repo.
-	count := 0
-	for _, rel := range doc.Relationships {
-		// Simple heuristic: if ToID doesn't match any entity in this repo, it's cross-repo
-		found := false
-		for _, e := range doc.Entities {
-			if e.ID == rel.ToID {
-				found = true
-				break
-			}
-		}
-		if !found && rel.ToID != "" {
-			count++
-		}
-	}
-	return count
 }
 
 // PrintDoctorHealth writes the enriched health report to w in human-readable format.

--- a/internal/cli/doctor_summary_test.go
+++ b/internal/cli/doctor_summary_test.go
@@ -27,7 +27,7 @@ func TestComputeRepoHealth(t *testing.T) {
 		Stack: registry.StackList{"go"},
 	}
 
-	health := computeRepoHealth(repo)
+	health := computeRepoHealth(repo, false)
 
 	// Verify basic fields
 	if health.Slug != "test-repo" {
@@ -52,7 +52,7 @@ func TestComputeRepoHealthMissing(t *testing.T) {
 		Stack: registry.StackList{"go"},
 	}
 
-	health := computeRepoHealth(repo)
+	health := computeRepoHealth(repo, false)
 
 	if health.Status != "MISSING" {
 		t.Errorf("health.Status = %q, want %q", health.Status, "MISSING")
@@ -61,7 +61,7 @@ func TestComputeRepoHealthMissing(t *testing.T) {
 
 // TestComputeDoctorHealthEmpty verifies handling of empty group list.
 func TestComputeDoctorHealthEmpty(t *testing.T) {
-	result := ComputeDoctorHealth([]registry.GroupRef{})
+	result := ComputeDoctorHealth([]registry.GroupRef{}, false)
 
 	if len(result) != 0 {
 		t.Errorf("ComputeDoctorHealth([]) returned %d groups, want 0", len(result))
@@ -191,6 +191,6 @@ func BenchmarkComputeRepoHealth(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = computeRepoHealth(repo)
+		_ = computeRepoHealth(repo, false)
 	}
 }

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -309,9 +309,14 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 		fmtInt(s.ProcessFlows),
 		fmtInt(s.HTTPEndpoints))
 
-	// Print pending candidates.
+	// Print available optional candidates.
+	//
+	// #5693: these are OPTIONAL LLM-enrichment/repair opportunities recomputed
+	// from the current graph — not a live daemon queue. Nothing auto-drains
+	// them (they cost tokens; the user runs enrichment to apply). The wording
+	// deliberately avoids "Pending", which reads as a stuck/blocked queue.
 	if s.EnrichmentCandidates > 0 || s.RepairCandidates > 0 {
-		fmt.Fprintf(w, "  Pending: %s enrichment candidates · %s repair candidates\n",
+		fmt.Fprintf(w, "  Available (optional; run enrichment to apply — nothing auto-drains): %s enrichment opportunities · %s repair candidates\n",
 			fmtInt(s.EnrichmentCandidates),
 			fmtInt(s.RepairCandidates))
 	}

--- a/internal/cli/status_stats_test.go
+++ b/internal/cli/status_stats_test.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -460,5 +462,34 @@ func TestLoadCandidateCountsMissing(t *testing.T) {
 	}
 	if repair != 0 {
 		t.Errorf("expected 0 repair candidates when file missing, got %d", repair)
+	}
+}
+
+// TestPrintStatusSummary_EnrichmentWording asserts the #5693 relabel: the
+// optional-enrichment line must NOT read as a stuck/blocked daemon queue. The
+// old "Pending: N enrichment candidates" wording is gone; the new wording marks
+// the count as optional and explains nothing auto-drains it.
+func TestPrintStatusSummary_EnrichmentWording(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:            "g",
+		RepoStats:            map[string]*RepoStatus{},
+		EnrichmentCandidates: 42,
+		RepairCandidates:     7,
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+
+	if strings.Contains(out, "Pending:") {
+		t.Errorf("output still uses stuck-queue wording %q:\n%s", "Pending:", out)
+	}
+	if !strings.Contains(out, "enrichment opportunities") {
+		t.Errorf("output missing 'enrichment opportunities' relabel:\n%s", out)
+	}
+	if !strings.Contains(out, "optional") || !strings.Contains(out, "nothing auto-drains") {
+		t.Errorf("output does not clarify the count is optional / not auto-drained:\n%s", out)
+	}
+	if !strings.Contains(out, "42") || !strings.Contains(out, "7") {
+		t.Errorf("output missing the counts (42 enrichment, 7 repair):\n%s", out)
 	}
 }

--- a/internal/dashboard/handlers_diagnostics.go
+++ b/internal/dashboard/handlers_diagnostics.go
@@ -152,7 +152,11 @@ func (s *Server) handleDiagnostics(w http.ResponseWriter, r *http.Request) {
 	// ── Per-group section ───────────────────────────────────────────────────
 	groups, err := registry.Groups()
 	if err == nil {
-		healthReports := cli.ComputeDoctorHealth(groups)
+		// deep=false: the health path loads each repo graph at most once and
+		// runs a single O(E) pass — never the old multi-minute O(E×N) scan on
+		// large graphs (#5689). Counts come from the live graph (same snapshot
+		// as orphan/cross-repo metrics).
+		healthReports := cli.ComputeDoctorHealth(groups, false)
 		for _, gh := range healthReports {
 			reply.Groups = append(reply.Groups, convertGroupHealth(gh))
 		}


### PR DESCRIPTION
Closes #5689. Closes #5693. `grafel doctor` loaded the full graph 3× per repo and ran an O(relationships×entities) ≈10¹² cross-repo count loop → multi-minute hang on a 291k-entity graph. Now: at-most-one graph load per repo + a single O(E+N) `computeCrossRepoAndOrphans` pass; counts taken from the loaded graph's Stats (same snapshot as orphans, no >100% OrphanRate), sidecar only as a load-failure fallback; `--deep` retained. Dashboard diagnostics path de-hung too. Also (#5693) relabels the 'Pending: N enrichment candidates' status line so it reads as optional LLM opportunities, not a stuck queue (no counting change). Reviewed: APPROVE-WITH-NITS (nit fixed). Refs #5681.