### PR TITLE
feat(graph): persist per-phase indexing timings (extract_ms, link_ms)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -469,10 +469,15 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		idx.ingestDocs = true
 	}
 
+	// #5692: measure the extraction pipeline wall-clock so it can be persisted
+	// into the graph-stats.json sidecar (extract_ms) for index-timing
+	// observability. Pure measurement — no behaviour change to indexing.
+	extractStart := time.Now()
 	doc, err := idx.Run(context.Background(), absRepo)
 	if err != nil {
 		return err
 	}
+	extractMS := time.Since(extractStart).Milliseconds()
 
 	// Phase 0 git metadata (#2088). Capture HEAD ref + SHA + worktree flag
 	// and stamp them onto the document BEFORE the rename-detect pass so
@@ -619,6 +624,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 				GodNodes:           doc.AlgorithmStats.NumGodNodes,
 				ArticulationPoints: doc.AlgorithmStats.NumArticulationPts,
 				RuntimeMS:          doc.AlgorithmStats.RuntimeMS,
+				ExtractMS:          extractMS,
 				ParseErrorCanary:   canaryRaw,
 				ParseErrorSpike:    canarySpiked,
 			}

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -75,6 +75,10 @@ func RunLinksForGroup(group string) error {
 		srcPaths[r.Slug] = r.Path
 	}
 	links.SetRepoSourcePaths(srcPaths)
+	// #5692: time the cross-repo link phase so its duration can be persisted
+	// into each affected repo's graph-stats.json sidecar (link_ms) for
+	// index-timing observability. Pure measurement — no behaviour change.
+	linkStart := time.Now()
 	res, err := links.RunAllPasses(group, graphsDir, "")
 	if err != nil {
 		return err
@@ -83,6 +87,24 @@ func RunLinksForGroup(group string) error {
 	if _, perr := runPhantomEdgePass(group, cfg, res.OutLinks); perr != nil {
 		// Best-effort: log but don't fail the link pass.
 		fmt.Fprintf(os.Stderr, "grafel: phantom-edge pass warning: %v\n", perr)
+	}
+	// #5692: record link_ms into each group repo's dedicated link-stats.json.
+	// The link pass is the SOLE writer of that file, so this never races the
+	// reindex worker's graph-stats.json write. Best-effort — a write failure
+	// never fails the link pass (pure observability).
+	side := &graph.LinkStatsSidecar{
+		Version:    1,
+		ComputedAt: time.Now().UTC(),
+		LinkMS:     time.Since(linkStart).Milliseconds(),
+	}
+	for _, r := range cfg.Repos {
+		stateDir := daemon.StateDirForRepo(r.Path)
+		if stateDir == "" {
+			continue
+		}
+		if serr := graph.WriteLinkStats(stateDir, side); serr != nil {
+			fmt.Fprintf(os.Stderr, "grafel: link-stats write warning (%s): %v\n", r.Slug, serr)
+		}
 	}
 	return nil
 }

--- a/internal/daemon/state_migrate.go
+++ b/internal/daemon/state_migrate.go
@@ -19,6 +19,7 @@ var graphArtifactNames = []string{
 	"graph.fb",
 	"graph.json",
 	"graph-stats.json",
+	"link-stats.json",
 	".metadata.json",
 	"file-index.json",
 	"repair.json",

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -590,12 +590,18 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// what those surfaces read. Best-effort: a sidecar write failure never
 	// fails the reindex (graph.fb is already written, and the fbreader-header
 	// fallback still recovers the counts on a sidecar miss).
+	// #5692 — persist the extraction phase wall-clock (extract_ms) so `grafel
+	// feedback` can report where incremental reindex time goes. t0 marks the
+	// start of this incremental pass; by here the re-extract + scoped resolve +
+	// merge are done. Cross-repo link timing lives in a separate link-stats.json
+	// owned by the link pass, so nothing is carried forward here.
 	side := &graph.GraphStatsSidecar{
 		Version:            1,
 		ComputedAt:         doc.GeneratedAt,
 		TotalFiles:         doc.Stats.Files,
 		TotalEntities:      doc.Stats.Entities,
 		TotalRelationships: doc.Stats.Relationships,
+		ExtractMS:          time.Since(t0).Milliseconds(),
 	}
 	if serr := graph.WriteSidecar(fbPath, side, false); serr != nil {
 		logger.Printf("incremental: sidecar write failed: %v (non-fatal)", serr)

--- a/internal/extractors/incremental_extract_ms_5692_test.go
+++ b/internal/extractors/incremental_extract_ms_5692_test.go
@@ -1,0 +1,46 @@
+package extractors_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestIncremental_SidecarCarriesExtractMS is the phase-timing observability
+// test for #5692. The incremental reindex path (the scheduler's fast index)
+// is the dominant graph-stats.json writer in production; after it runs, the
+// sidecar must carry a non-zero extract_ms so `grafel feedback` can report
+// where indexing time goes.
+func TestIncremental_SidecarCarriesExtractMS(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc OldFunc() {}\n")
+	entities := []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "OldFunc", "svc/service.go"),
+			Name: "OldFunc", Kind: "SCOPE.Operation", SourceFile: "svc/service.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	// Edit the file so the incremental path re-extracts and rewrites the sidecar.
+	writeFile(t, repo, "svc/service.go", "package svc\n\nfunc NewFunc() {}\n")
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental: unexpected fallback: %s", res.FallbackReason)
+	}
+
+	side, err := graph.LoadSidecar(stateDir)
+	if err != nil {
+		t.Fatalf("load sidecar after incremental: %v", err)
+	}
+	if side.ExtractMS <= 0 {
+		t.Fatalf("expected extract_ms > 0 after incremental reindex, got %d", side.ExtractMS)
+	}
+	// link_ms is NOT written to graph-stats.json (it lives in link-stats.json,
+	// owned solely by the link pass), so the incremental writer never sets it.
+	t.Logf("extract_ms=%d", side.ExtractMS)
+}

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -144,7 +144,30 @@ type GraphStatsSidecar struct {
 	Modularity         float64   `json:"modularity"`
 	GodNodes           int       `json:"god_nodes"`
 	ArticulationPoints int       `json:"articulation_points"`
-	RuntimeMS          int64     `json:"runtime_ms"`
+	// RuntimeMS is the wall-clock duration of the graph-algorithm pass
+	// (Pass 4: Louvain / PageRank / articulation). Its meaning is unchanged
+	// since it was introduced; the extract/link phase timings below are
+	// tracked separately.
+	RuntimeMS int64 `json:"runtime_ms"`
+
+	// ExtractMS is the wall-clock duration (milliseconds) of the extraction
+	// phase for the index pass that produced this sidecar (#5692). Recorded so
+	// `grafel feedback` and future tooling can report where indexing time goes.
+	// A zero value means "unknown": the phase was not measured, or this sidecar
+	// was written before the field existed (back-compat).
+	//
+	// The measured span differs slightly by write path: on the full-index path
+	// it is scoped to the extraction pipeline (idx.Run) only; on the
+	// incremental reindex path it is the whole incremental pass wall-clock
+	// (manifest load + re-extract + scoped resolve + graph.fb write). Both are
+	// written in-band by the same goroutine that writes this sidecar, so the
+	// value is always consistent with the counts alongside it.
+	//
+	// It is written IN-BAND (by the reindex writer, sole owner of this file);
+	// the cross-repo link timing lives in a SEPARATE link-stats.json (see
+	// LinkStatsSidecar) so an unserialized link goroutine never races the
+	// reindex writer on this file's count fields (#5692).
+	ExtractMS int64 `json:"extract_ms,omitempty"`
 
 	// ParseErrorCanary is the A4 per-language parse-error-node canary report
 	// (#5414, epic #5359): per-language aggregate ERROR-node rates plus a
@@ -167,7 +190,11 @@ func WriteSidecar(outPath string, side *GraphStatsSidecar, pretty bool) error {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return fmt.Errorf("graph: mkdir %s: %w", dir, err)
 	}
-	target := filepath.Join(dir, "graph-stats.json")
+	return writeJSONAtomic(filepath.Join(dir, "graph-stats.json"), side, pretty)
+}
+
+// writeJSONAtomic encodes v to target via a sibling .tmp + rename.
+func writeJSONAtomic(target string, v any, pretty bool) error {
 	tmp := target + ".tmp"
 	f, err := os.Create(tmp)
 	if err != nil {
@@ -177,7 +204,7 @@ func WriteSidecar(outPath string, side *GraphStatsSidecar, pretty bool) error {
 	if pretty {
 		enc.SetIndent("", "  ")
 	}
-	if err := enc.Encode(side); err != nil {
+	if err := enc.Encode(v); err != nil {
 		f.Close()
 		os.Remove(tmp)
 		return fmt.Errorf("graph: encode sidecar: %w", err)
@@ -187,6 +214,74 @@ func WriteSidecar(outPath string, side *GraphStatsSidecar, pretty bool) error {
 		return err
 	}
 	return os.Rename(tmp, target)
+}
+
+// SidecarPath returns the graph-stats.json path inside stateDir.
+func SidecarPath(stateDir string) string {
+	return filepath.Join(stateDir, "graph-stats.json")
+}
+
+// LoadSidecar reads and decodes the graph-stats.json sidecar in stateDir.
+// Returns an error if the sidecar is absent or malformed.
+func LoadSidecar(stateDir string) (*GraphStatsSidecar, error) {
+	data, err := os.ReadFile(SidecarPath(stateDir))
+	if err != nil {
+		return nil, err
+	}
+	var side GraphStatsSidecar
+	if err := json.Unmarshal(data, &side); err != nil {
+		return nil, fmt.Errorf("graph: decode sidecar %s: %w", stateDir, err)
+	}
+	return &side, nil
+}
+
+// LinkStatsSidecar is the per-repo cross-repo-link timing sidecar written to
+// <repo-state>/link-stats.json (#5692). It is kept SEPARATE from
+// graph-stats.json on purpose: the cross-repo link pass runs on its own
+// per-group goroutine (scheduler AfterFunc) which is NOT serialized against the
+// reindex worker pool. Were link timing stamped into graph-stats.json, a
+// read-modify-write from the link goroutine could land between a reindex's
+// ReadFile and Rename and clobber the freshly written entity/relationship
+// counts. Giving the link pass its own file makes it the SOLE writer here, so
+// there is no cross-writer lost-update: link passes for a single group are
+// themselves serialized by the scheduler's per-group debounce.
+type LinkStatsSidecar struct {
+	Version    int       `json:"version"`
+	ComputedAt time.Time `json:"computed_at"`
+	// LinkMS is the wall-clock duration (milliseconds) of the most recent
+	// cross-repo link pass for the group this repo belongs to. Zero (or an
+	// absent file) means "unknown".
+	LinkMS int64 `json:"link_ms"`
+}
+
+// LinkStatsPath returns the link-stats.json path inside stateDir.
+func LinkStatsPath(stateDir string) string {
+	return filepath.Join(stateDir, "link-stats.json")
+}
+
+// WriteLinkStats atomically writes the link-stats.json sidecar into stateDir.
+// The link pass is the sole writer of this file, so no read-modify-write /
+// field-preservation is needed. Minified to match the other sidecars.
+func WriteLinkStats(stateDir string, side *LinkStatsSidecar) error {
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return fmt.Errorf("graph: mkdir %s: %w", stateDir, err)
+	}
+	return writeJSONAtomic(LinkStatsPath(stateDir), side, false)
+}
+
+// LoadLinkStats reads and decodes the link-stats.json sidecar in stateDir.
+// Returns an error if the file is absent (os.IsNotExist) or malformed;
+// callers treating absence as "link timing unknown" should check IsNotExist.
+func LoadLinkStats(stateDir string) (*LinkStatsSidecar, error) {
+	data, err := os.ReadFile(LinkStatsPath(stateDir))
+	if err != nil {
+		return nil, err
+	}
+	var side LinkStatsSidecar
+	if err := json.Unmarshal(data, &side); err != nil {
+		return nil, fmt.Errorf("graph: decode link-stats %s: %w", stateDir, err)
+	}
+	return &side, nil
 }
 
 // WriteAtomic marshals doc to JSON and writes it to outPath atomically by

--- a/internal/graph/sidecar_timing_test.go
+++ b/internal/graph/sidecar_timing_test.go
@@ -1,0 +1,141 @@
+package graph
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+// TestGraphStatsSidecar_ExtractMSRoundTrip verifies that the in-band extract_ms
+// phase timing added for #5692 survives a JSON encode → decode round-trip
+// alongside the existing algo runtime_ms.
+func TestGraphStatsSidecar_ExtractMSRoundTrip(t *testing.T) {
+	in := &GraphStatsSidecar{
+		Version:            1,
+		TotalEntities:      42,
+		TotalRelationships: 7,
+		RuntimeMS:          123,
+		ExtractMS:          456,
+	}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var out GraphStatsSidecar
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out.ExtractMS != in.ExtractMS {
+		t.Errorf("extract_ms round-trip: got %d, want %d", out.ExtractMS, in.ExtractMS)
+	}
+	if out.RuntimeMS != in.RuntimeMS {
+		t.Errorf("runtime_ms must be unchanged (back-compat): got %d, want %d", out.RuntimeMS, in.RuntimeMS)
+	}
+	// extract_ms must serialise under its documented snake_case key; link_ms
+	// must NOT appear in graph-stats.json (it lives in link-stats.json).
+	var raw map[string]any
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if _, ok := raw["extract_ms"]; !ok {
+		t.Errorf("expected extract_ms key in JSON, got: %s", b)
+	}
+	if _, ok := raw["link_ms"]; ok {
+		t.Errorf("link_ms must NOT be in graph-stats.json (owned by link-stats.json), got: %s", b)
+	}
+}
+
+// TestGraphStatsSidecar_BackCompatOldSidecar verifies that a sidecar written
+// before #5692 (no extract_ms key) still loads, with the field defaulting to
+// the zero value (= unknown).
+func TestGraphStatsSidecar_BackCompatOldSidecar(t *testing.T) {
+	old := `{"version":1,"total_entities":10,"total_relationships":3,"runtime_ms":50}`
+	var side GraphStatsSidecar
+	if err := json.Unmarshal([]byte(old), &side); err != nil {
+		t.Fatalf("legacy sidecar must still load: %v", err)
+	}
+	if side.TotalEntities != 10 || side.RuntimeMS != 50 {
+		t.Fatalf("legacy fields lost: %+v", side)
+	}
+	if side.ExtractMS != 0 {
+		t.Errorf("missing extract_ms must default to 0 (unknown), got %d", side.ExtractMS)
+	}
+}
+
+// TestLinkStatsSidecar_RoundTrip verifies the dedicated link-stats.json sidecar
+// round-trips link_ms through WriteLinkStats → LoadLinkStats, and that a
+// missing file surfaces as os.IsNotExist so callers can treat it as "unknown".
+func TestLinkStatsSidecar_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Absent file → IsNotExist (callers treat as link timing unknown).
+	if _, err := LoadLinkStats(dir); !os.IsNotExist(err) {
+		t.Fatalf("absent link-stats.json must be os.IsNotExist, got: %v", err)
+	}
+
+	if err := WriteLinkStats(dir, &LinkStatsSidecar{Version: 1, LinkMS: 321}); err != nil {
+		t.Fatalf("write link-stats: %v", err)
+	}
+	got, err := LoadLinkStats(dir)
+	if err != nil {
+		t.Fatalf("load link-stats: %v", err)
+	}
+	if got.LinkMS != 321 {
+		t.Errorf("link_ms round-trip: got %d, want 321", got.LinkMS)
+	}
+}
+
+// TestLinkStatsWrite_DoesNotClobberGraphStats is the regression guard for the
+// lost-update defect that split link timing into its own file (#5692). The link
+// pass (WriteLinkStats) and the reindex writer (WriteSidecar) must own separate
+// files, so a link write can never revert graph-stats.json's count/extract
+// fields even when it runs concurrently with a reindex.
+func TestLinkStatsWrite_DoesNotClobberGraphStats(t *testing.T) {
+	dir := t.TempDir()
+	outPath := dir + "/graph.json" // WriteSidecar derives the dir from this
+
+	// Reindex writes fresh counts + extract_ms into graph-stats.json.
+	orig := &GraphStatsSidecar{
+		Version:            1,
+		TotalEntities:      500,
+		TotalRelationships: 900,
+		ExtractMS:          1234,
+		RuntimeMS:          77,
+	}
+	if err := WriteSidecar(outPath, orig, false); err != nil {
+		t.Fatalf("write graph-stats: %v", err)
+	}
+
+	// Link pass records its duration — into link-stats.json only.
+	if err := WriteLinkStats(dir, &LinkStatsSidecar{Version: 1, LinkMS: 999}); err != nil {
+		t.Fatalf("write link-stats: %v", err)
+	}
+
+	// graph-stats.json counts + extract_ms must be untouched by the link write.
+	after, err := LoadSidecar(dir)
+	if err != nil {
+		t.Fatalf("reload graph-stats: %v", err)
+	}
+	if after.TotalEntities != 500 || after.TotalRelationships != 900 {
+		t.Errorf("link write clobbered counts: %+v", after)
+	}
+	if after.ExtractMS != 1234 || after.RuntimeMS != 77 {
+		t.Errorf("link write clobbered timing fields: %+v", after)
+	}
+
+	// link_ms is readable from its own file, and graph-stats.json never grew a
+	// link_ms key.
+	ls, err := LoadLinkStats(dir)
+	if err != nil {
+		t.Fatalf("load link-stats: %v", err)
+	}
+	if ls.LinkMS != 999 {
+		t.Errorf("link_ms: got %d, want 999", ls.LinkMS)
+	}
+	raw, _ := os.ReadFile(SidecarPath(dir))
+	var m map[string]any
+	_ = json.Unmarshal(raw, &m)
+	if _, ok := m["link_ms"]; ok {
+		t.Errorf("graph-stats.json must not carry link_ms: %s", raw)
+	}
+}


### PR DESCRIPTION
Refs #5692. Surfaces indexing phase timings so `grafel feedback`/tooling can report where index time goes (motivated by #5681). `extract_ms` is written in-band in `graph-stats.json` beside the counts; `link_ms` lives in a dedicated `link-stats.json` owned solely by the cross-repo link pass — so a link-timing write can never straddle a reindex's atomic rename and revert entity/relationship counts (the race caught in review). `runtime_ms` unchanged; back-compat via omitempty/absent-file. Reviewed: REQUEST-CHANGES → fixed (single-writer-per-file), with a no-clobber regression test. Refs #5681.