### PR TITLE
fix(mcp): resolve get_source for nested-module files (module-relative source_file)

### DIFF
--- a/internal/mcp/get_source_nested_module_5682_test.go
+++ b/internal/mcp/get_source_nested_module_5682_test.go
@@ -1,0 +1,301 @@
+package mcp
+
+// get_source_nested_module_5682_test.go — regression coverage for #5682.
+//
+// THE BUG: get_source fails for files in nested build units (monorepos with
+// per-module go.mod / package.json / pom.xml / *.csproj). The indexer records
+// an entity's source_file RELATIVE TO ITS NESTED-MODULE ROOT (e.g. the file
+// services/billing/pkg/handler.go is recorded as "pkg/handler.go" because the
+// go.mod that anchors it lives at services/billing/). The read side, however,
+// joins the recorded source_file onto the GROUP/REPO root (LoadedRepo.Path):
+//
+//	abs = filepath.Join(lr.Path, e.SourceFile)   // <root>/pkg/handler.go — WRONG
+//
+// which points at a file that does not exist, and get_source returns
+//
+//	lstat <root>/pkg/handler.go: no such file or directory
+//
+// even though the file is really at <root>/services/billing/pkg/handler.go.
+//
+// THE FIX (read-side, lowest risk): resolveEntitySourcePath keeps the exact
+// happy-path join for files that live at the group root (single os.Stat), and
+// only on a not-exist result falls back — sibling loaded repos, then a bounded
+// unique-suffix walk from the repo root — to recover the real path.
+//
+// Non-vacuous proof: TestGetSource_NestedModuleRelativePath_5682 FAILS on the
+// pre-fix handler with the lstat error above. TestGetSource_RootLevelEntity_5682
+// pins the HARD CONSTRAINT that group-root files resolve EXACTLY as today.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// newTestServerWithRepoPath builds a Server whose single "test" group has one
+// repo whose LoadedRepo.Path is set to repoRoot (unlike newTestServer, which
+// leaves Path empty). This is required to exercise the join(lr.Path, ...) path
+// that the #5682 bug lives on.
+func newTestServerWithRepoPath(t *testing.T, repoSlug, repoRoot string, doc *graph.Document) *Server {
+	t.Helper()
+	doc.Repo = repoSlug
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{repoSlug: {Path: repoRoot}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{}}
+	lg.Repos[repoSlug] = &LoadedRepo{
+		Repo:       repoSlug,
+		Path:       repoRoot,
+		Doc:        doc,
+		LabelIndex: BuildLabelIndex(doc),
+		BM25:       BuildBM25(doc),
+	}
+	st.groups["test"] = lg
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+// TestGetSource_NestedModuleRelativePath_5682 is the load-bearing regression:
+// the entity's source_file is recorded RELATIVE TO ITS NESTED-MODULE ROOT
+// ("pkg/handler.go"), but the real file lives deeper at
+// services/billing/pkg/handler.go under the repo root. Pre-fix, get_source
+// stat's <root>/pkg/handler.go and fails; post-fix the bounded suffix walk
+// recovers the real path.
+func TestGetSource_NestedModuleRelativePath_5682(t *testing.T) {
+	root := t.TempDir()
+
+	// Nested build unit: services/billing/ carries its own go.mod, so the
+	// indexer records files under it module-relative (stripped of the module
+	// root prefix).
+	moduleDir := filepath.Join(root, "services", "billing")
+	pkgDir := filepath.Join(moduleDir, "pkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(moduleDir, "go.mod"),
+		[]byte("module example.com/billing\n\ngo 1.26\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	handlerSrc := strings.Join([]string{
+		"package pkg",
+		"",
+		"func Charge(amount int) int {",
+		"\t// MARKER_NESTED_CHARGE_BODY",
+		"\treturn amount",
+		"}",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(pkgDir, "handler.go"),
+		[]byte(handlerSrc), 0o644); err != nil {
+		t.Fatalf("write handler: %v", err)
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:            "ent_charge",
+			Name:          "Charge",
+			QualifiedName: "example.com/billing/pkg.Charge",
+			Kind:          "SCOPE.Operation", Subtype: "function",
+			// Module-relative — NOT relative to the repo root.
+			SourceFile: "pkg/handler.go",
+			StartLine:  3, EndLine: 6, Language: "go",
+			Properties: map[string]string{"module": "pkg"},
+		}},
+	}
+	srv := newTestServerWithRepoPath(t, "billing-mono", root, doc)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "ent_charge"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source returned tool error (the #5682 lstat bug):\n%s",
+			extractResultText(t, res))
+	}
+	text := extractResultText(t, res)
+	if !strings.Contains(text, "MARKER_NESTED_CHARGE_BODY") {
+		t.Errorf("nested-module source not returned, got:\n%s", text)
+	}
+}
+
+// TestGetSource_RootLevelEntity_5682 pins the HARD CONSTRAINT: an entity whose
+// source_file lives directly at the group/repo root resolves EXACTLY as today
+// (the plain join, no fallback needed). Guards against a regression where the
+// fallback machinery changes happy-path behaviour.
+func TestGetSource_RootLevelEntity_5682(t *testing.T) {
+	root := t.TempDir()
+	mainSrc := strings.Join([]string{
+		"package main",
+		"",
+		"func main() {",
+		"\t// MARKER_ROOT_MAIN_BODY",
+		"}",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(root, "main.go"),
+		[]byte(mainSrc), 0o644); err != nil {
+		t.Fatalf("write main: %v", err)
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:            "ent_main",
+			Name:          "main",
+			QualifiedName: "main.main",
+			Kind:          "SCOPE.Operation", Subtype: "function",
+			SourceFile: "main.go",
+			StartLine:  3, EndLine: 5, Language: "go",
+		}},
+	}
+	srv := newTestServerWithRepoPath(t, "root-repo", root, doc)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "ent_main"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("root-level get_source should succeed, got error:\n%s",
+			extractResultText(t, res))
+	}
+	text := extractResultText(t, res)
+	if !strings.Contains(text, "MARKER_ROOT_MAIN_BODY") {
+		t.Errorf("root-level source not returned, got:\n%s", text)
+	}
+}
+
+// TestGetSource_SiblingCollisionNotReturned_5682 pins review defect D2: a
+// colliding relative path present at a SIBLING repo's root must NOT be returned
+// when the entity's own repo (lr) holds the real nested file. The entity is
+// resolved to lr, so its source lives in lr; returning another repo's file for
+// a common path ("pkg/handler.go") would be silently-wrong source.
+func TestGetSource_SiblingCollisionNotReturned_5682(t *testing.T) {
+	// repoA (the entity's repo): nested build unit; real file is deep.
+	rootA := t.TempDir()
+	nestedDir := filepath.Join(rootA, "services", "billing", "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir A: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "handler.go"),
+		[]byte("package pkg\n\n// MARKER_CORRECT_REPO_A\nfunc Charge() {}\n"), 0o644); err != nil {
+		t.Fatalf("write A: %v", err)
+	}
+
+	// repoB (a sibling in the same group): a DECOY file at the same relative
+	// path but at the repo ROOT — the collision that D2 warns about.
+	rootB := t.TempDir()
+	decoyDir := filepath.Join(rootB, "pkg")
+	if err := os.MkdirAll(decoyDir, 0o755); err != nil {
+		t.Fatalf("mkdir B: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(decoyDir, "handler.go"),
+		[]byte("package pkg\n\n// MARKER_WRONG_REPO_B\nfunc Other() {}\n"), 0o644); err != nil {
+		t.Fatalf("write B: %v", err)
+	}
+
+	docA := &graph.Document{
+		Repo: "billing",
+		Entities: []graph.Entity{{
+			ID: "ent_charge", Name: "Charge",
+			QualifiedName: "billing.pkg.Charge",
+			Kind:          "SCOPE.Operation", Subtype: "function",
+			SourceFile: "pkg/handler.go", StartLine: 3, EndLine: 4, Language: "go",
+		}},
+	}
+	docB := &graph.Document{Repo: "gateway"} // no entities; just the decoy tree
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{
+			"billing": {Path: rootA},
+			"gateway": {Path: rootB},
+		}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	lg := &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{
+		"billing": {Repo: "billing", Path: rootA, Doc: docA, LabelIndex: BuildLabelIndex(docA), BM25: BuildBM25(docA)},
+		"gateway": {Repo: "gateway", Path: rootB, Doc: docB, LabelIndex: BuildLabelIndex(docB), BM25: BuildBM25(docB)},
+	}}
+	st.groups["test"] = lg
+	st.mu.Unlock()
+	srv := &Server{State: st, Tel: NewTelemetry(0)}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "entity_id": "billing::ent_charge"}
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("get_source error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("get_source returned tool error:\n%s", extractResultText(t, res))
+	}
+	text := extractResultText(t, res)
+	if !strings.Contains(text, "MARKER_CORRECT_REPO_A") {
+		t.Errorf("expected the in-repo nested file, got:\n%s", text)
+	}
+	if strings.Contains(text, "MARKER_WRONG_REPO_B") {
+		t.Errorf("D2 regression: returned the SIBLING repo's colliding file:\n%s", text)
+	}
+}
+
+// TestGetSource_SuffixIndexBuiltOncePerRepo_5682 pins review defect D1: the
+// filesystem tree is walked AT MOST ONCE per repo, no matter how many
+// nested-module lookups occur. It wraps the buildSuffixIndex seam with a call
+// counter and drives repeated resolveEntitySourcePath lookups that all miss the
+// happy-path stat (so each would have triggered a full walk in the pre-review
+// implementation).
+func TestGetSource_SuffixIndexBuiltOncePerRepo_5682(t *testing.T) {
+	root := t.TempDir()
+	nestedDir := filepath.Join(root, "services", "billing", "pkg")
+	if err := os.MkdirAll(nestedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(nestedDir, "handler.go"),
+		[]byte("package pkg\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Wrap the build seam with a counter (restored after the test). Tests in a
+	// package run sequentially unless t.Parallel is called, so the swap is safe.
+	orig := buildSuffixIndex
+	defer func() { buildSuffixIndex = orig }()
+	var mu sync.Mutex
+	builds := 0
+	buildSuffixIndex = func(r string) (map[string][]string, bool) {
+		mu.Lock()
+		builds++
+		mu.Unlock()
+		return orig(r)
+	}
+
+	lr := &LoadedRepo{Repo: "billing", Path: root}
+
+	// Many lookups on nested (happy-path-missing) source files.
+	for i := 0; i < 8; i++ {
+		got := resolveEntitySourcePath(lr, "pkg/handler.go")
+		want := filepath.Join(root, "services", "billing", "pkg", "handler.go")
+		if got != want {
+			t.Fatalf("lookup %d: got %q, want %q", i, got, want)
+		}
+	}
+	// A genuine miss should also be cheap (no extra build) — pins N2.
+	if got := resolveEntitySourcePath(lr, "pkg/missing.go"); got != filepath.Join(root, "pkg", "missing.go") {
+		t.Errorf("genuine miss should return the primary join, got %q", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if builds != 1 {
+		t.Errorf("D1: suffix index built %d times across repeated lookups, want exactly 1", builds)
+	}
+}

--- a/internal/mcp/get_source_path.go
+++ b/internal/mcp/get_source_path.go
@@ -1,0 +1,190 @@
+package mcp
+
+// get_source_path.go — filesystem-path resolution for entity source files
+// (#5682).
+//
+// THE BUG this closes: get_source (and the inspect/call-context read paths)
+// build a source file's absolute path by joining the recorded source_file onto
+// the GROUP/REPO root (LoadedRepo.Path):
+//
+//	abs = filepath.Join(lr.Path, e.SourceFile)
+//
+// In a monorepo with nested build units (per-module go.mod / package.json /
+// pom.xml / *.csproj) the indexer records source_file RELATIVE TO ITS
+// NESTED-MODULE ROOT, not to the group root. So a file physically at
+// <root>/services/billing/pkg/handler.go is recorded as "pkg/handler.go", and
+// the naive join stat's <root>/pkg/handler.go — which does not exist. On a repo
+// with ~300 nested modules this made get_source unusable for most files.
+//
+// THE FIX (read-side, lowest risk): resolveEntitySourcePath preserves the exact
+// happy-path behaviour for files that live at the group root — the same join,
+// plus a SINGLE os.Stat — and only when that path does not exist does it fall
+// back to an IN-REPO unique-suffix lookup that recovers the real path.
+//
+// The resolved entity already belongs to lr (resolveSourceEntity picks the repo
+// whose Document contains it), so its source file lives in lr's tree. We
+// therefore resolve ONLY within lr and never consult sibling repos: common
+// relative paths ("cmd/main.go", "pkg/handler.go") collide across repos in a
+// monorepo group, so returning the first sibling repo whose root + source_file
+// stats would silently return the WRONG file from another repo. In-repo-only is
+// both correct and cheaper (#5682 review D2).
+//
+// Cost contract:
+//   - Happy path (file at the group root): exactly one os.Stat over the
+//     pre-#5682 code; the identical path is returned.
+//   - Nested-module lookups: one os.Stat (miss) then an O(1) map lookup against
+//     a per-repo suffix index that is built by a SINGLE filesystem walk, cached
+//     on LoadedRepo, and re-armed on reload (getSuffixIndex). The tree is walked
+//     at most once per repo regardless of how many get_source / inspect lookups
+//     occur — no per-call walk, no inspect-loop amplification (#5682 review D1).
+//   - Genuine miss (deleted file): join → O(1) index lookup → "" → the same
+//     clear lstat error, cheap after the first index build (#5682 review N2).
+//
+// Why not Properties["module"]? The "module" property is a DERIVED LABEL
+// (internal/module.Derive: a depth-capped path prefix of the source_file), not
+// a record of the nested-module root directory, so it cannot reconstruct the
+// stripped prefix. The suffix index is the cheapest strategy that is actually
+// correct for the general nested-build-unit case.
+
+import (
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// suffixWalkFileBudget caps the number of regular files the suffix-index walk
+// will record before giving up, so a pathological tree can never turn the
+// index build into an unbounded filesystem scan. When the cap is hit the index
+// is marked partial and lookups conservatively return "" (uniqueness cannot be
+// proven over the unscanned remainder — #5682 review N1).
+const suffixWalkFileBudget = 200000
+
+// resolveEntitySourcePath returns the best absolute filesystem path for an
+// entity's recorded source_file, given the entity's resolved repo lr.
+//
+// Behaviour, in order:
+//
+//  1. An already-absolute source_file is returned unchanged.
+//  2. join(lr.Path, source_file) — the pre-#5682 happy path. Returned as-is
+//     when it exists (single os.Stat) OR when there is no repo root to fall
+//     back to (lr == nil / lr.Path == ""), preserving today's behaviour and
+//     error messages exactly.
+//  3. In-repo unique-suffix resolution via the per-repo suffix index, for a
+//     nested-module-relative source_file (#5682).
+//
+// On total failure the primary join is returned so the caller emits the same
+// clear lstat error as before.
+func resolveEntitySourcePath(lr *LoadedRepo, sourceFile string) string {
+	if sourceFile == "" {
+		return sourceFile
+	}
+	if filepath.IsAbs(sourceFile) {
+		return sourceFile
+	}
+
+	// No repo root to join against — nothing this helper can improve; return the
+	// recorded path verbatim (identical to the pre-#5682 `abs := e.SourceFile`).
+	if lr == nil || lr.Path == "" {
+		return sourceFile
+	}
+
+	primary := filepath.Join(lr.Path, sourceFile)
+	if _, err := os.Stat(primary); err == nil {
+		// Happy path: file lives at the group root exactly as recorded. Identical
+		// to pre-#5682 apart from this single Stat.
+		return primary
+	}
+
+	// In-repo unique-suffix resolution — recovers a nested-module-relative path
+	// (the primary #5682 case) via the precomputed suffix index.
+	if hit := lr.resolveSourceBySuffix(sourceFile); hit != "" {
+		return hit
+	}
+
+	// Nothing found — return the primary join so the caller reports the same
+	// clear "lstat <path>: no such file or directory" error as before.
+	return primary
+}
+
+// resolveSourceBySuffix resolves a repo-relative-ish source_file to an absolute
+// path within lr by finding the single indexed file whose path ends with
+// source_file at a path-segment boundary. Returns "" when there is no match,
+// more than one match (ambiguous — never guess), or the suffix index is partial
+// (budget-exhausted, so uniqueness is unprovable — #5682 review N1).
+func (lr *LoadedRepo) resolveSourceBySuffix(sourceFile string) string {
+	idx, partial := lr.getSuffixIndex()
+	if partial || len(idx) == 0 {
+		return ""
+	}
+	sf := strings.TrimPrefix(filepath.ToSlash(sourceFile), "/")
+	if sf == "" {
+		return ""
+	}
+	cands := idx[path.Base(sf)]
+	if len(cands) == 0 {
+		return ""
+	}
+	// Anchor on a leading separator so "pkg/handler.go" matches
+	// ".../billing/pkg/handler.go" but NOT ".../mypkg/handler.go".
+	suffix := "/" + sf
+	var match string
+	count := 0
+	for _, rel := range cands {
+		if rel == sf || strings.HasSuffix("/"+rel, suffix) {
+			match = rel
+			count++
+			if count > 1 {
+				return "" // ambiguous — refuse to guess
+			}
+		}
+	}
+	if count == 1 {
+		return filepath.Join(lr.Path, filepath.FromSlash(match))
+	}
+	return ""
+}
+
+// buildSuffixIndex walks root (skipping vendor / node_modules / .git and
+// capping the number of files recorded) and returns a basename -> repo-relative
+// (slash) paths index plus a partial flag that is true when the file budget was
+// exhausted. It is a package var so tests can wrap it with a call counter to
+// prove the tree is walked at most once per repo (#5682 review D1).
+var buildSuffixIndex = func(root string) (map[string][]string, bool) {
+	idx := map[string][]string{}
+	if root == "" {
+		return idx, false
+	}
+	files := 0
+	partial := false
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Unreadable dir/file — skip it, keep walking the rest.
+			if d != nil && d.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if d.IsDir() {
+			switch d.Name() {
+			case "vendor", "node_modules", ".git":
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		files++
+		if files > suffixWalkFileBudget {
+			partial = true
+			return filepath.SkipAll
+		}
+		rel, rerr := filepath.Rel(root, p)
+		if rerr != nil {
+			return nil
+		}
+		rel = filepath.ToSlash(rel)
+		idx[path.Base(rel)] = append(idx[path.Base(rel)], rel)
+		return nil
+	})
+	return idx, partial
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -293,6 +293,7 @@ type LoadedRepo struct {
 	pagerankOnce sync.Once
 	bm25Once     sync.Once                // #3377: BM25 built lazily on first search
 	mroInOnce    sync.Once                // #3834: reverse-INHERITS map built lazily
+	suffixOnce   sync.Once                // #5682: source-file suffix index built lazily
 	adjacency    *adjacency               // in/out neighbor lists (#1656)
 	callsAdj     map[string][]string      // CALLS-only forward adjacency (#1656)
 	stepAdj      map[string][]stepEdge    // STEP_IN_PROCESS forward adjacency (#2417)
@@ -304,6 +305,15 @@ type LoadedRepo struct {
 	// subclasses that inherit it. In-repo defining members only (external
 	// contract endpoints have no in-repo node to query callers of).
 	mroInbound map[string][]string
+	// suffixIndex maps a file basename -> the repo-relative (slash) paths of
+	// every source file with that basename under lr.Path (#5682). Built once by
+	// a single filesystem walk (getSuffixIndex) and used to resolve a
+	// nested-module-relative source_file to its real absolute path via a unique
+	// suffix match — O(1) per lookup, no per-call tree walk. suffixIndexPartial
+	// is true when the walk hit suffixWalkFileBudget and stopped early, in which
+	// case uniqueness cannot be proven and lookups conservatively return "".
+	suffixIndex        map[string][]string
+	suffixIndexPartial bool
 
 	semMtime time.Time
 	mtime    time.Time
@@ -349,6 +359,7 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.pagerankOnce = sync.Once{}
 	lr.bm25Once = sync.Once{}
 	lr.mroInOnce = sync.Once{}
+	lr.suffixOnce = sync.Once{}
 	lr.BM25 = nil
 	lr.adjacency = nil
 	lr.callsAdj = nil
@@ -356,6 +367,22 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.byID = nil
 	lr.topKPageRank = nil
 	lr.mroInbound = nil
+	lr.suffixIndex = nil
+	lr.suffixIndexPartial = false
+}
+
+// getSuffixIndex returns the source-file suffix index (basename -> repo-relative
+// paths) and whether the build was truncated by the file budget, building it on
+// first use via a single filesystem walk of lr.Path (#5682). Deliberately NOT
+// guarded by idxMu (matching getMROInbound): the build only touches the
+// filesystem, never other idxMu-guarded getters, so holding idxMu during a
+// potentially slow walk would needlessly serialise unrelated index builds.
+// sync.Once alone gives build-at-most-once per reload; resetIndexes() re-arms it.
+func (lr *LoadedRepo) getSuffixIndex() (map[string][]string, bool) {
+	lr.suffixOnce.Do(func() {
+		lr.suffixIndex, lr.suffixIndexPartial = buildSuffixIndex(lr.Path)
+	})
+	return lr.suffixIndex, lr.suffixIndexPartial
 }
 
 // getMROInbound returns the reverse-INHERITS map (defining-member id ->

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1476,10 +1476,9 @@ func attachCallContexts(entries []map[string]any, lr *LoadedRepo, e *graph.Entit
 	if start <= 0 {
 		return
 	}
-	abs := e.SourceFile
-	if !filepath.IsAbs(abs) && lr.Path != "" {
-		abs = filepath.Join(lr.Path, e.SourceFile)
-	}
+	// #5682: module-aware path resolution — recovers a nested-module-relative
+	// source_file via lr's precomputed suffix index.
+	abs := resolveEntitySourcePath(lr, e.SourceFile)
 	src, err := readRawSourceWindow(abs, start, end)
 	if err != nil || src == "" {
 		return
@@ -1562,10 +1561,8 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 		// and a resolvable source path.
 		ctx := ""
 		if lineNum > 0 && sourcePath != "" && lr.Path != "" {
-			abs := sourcePath
-			if !filepath.IsAbs(abs) {
-				abs = filepath.Join(lr.Path, sourcePath)
-			}
+			// #5682: module-aware path resolution (in-repo suffix index).
+			abs := resolveEntitySourcePath(lr, sourcePath)
 			lines, cached := lineCache[abs]
 			if !cached {
 				lines = readSourceLines(abs)
@@ -2585,10 +2582,9 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 					res.OwningClass, res.Member, res.DefiningClass,
 				)
 				e = res.DefiningEntity
-				abs := e.SourceFile
-				if !filepath.IsAbs(abs) && lr.Path != "" {
-					abs = filepath.Join(lr.Path, e.SourceFile)
-				}
+				// #5682: module-aware path resolution — recovers a
+				// nested-module-relative source_file via lr's suffix index.
+				abs := resolveEntitySourcePath(lr, e.SourceFile)
 				body, rerr := readInheritedBody(ctx, abs, e, contextLines)
 				if rerr != nil {
 					return mcpapi.NewToolResultError(rerr.Error()), nil
@@ -2598,10 +2594,10 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 		}
 	}
 
-	abs := e.SourceFile
-	if !filepath.IsAbs(abs) && lr.Path != "" {
-		abs = filepath.Join(lr.Path, e.SourceFile)
-	}
+	// #5682: module-aware path resolution — happy path (file at the group root)
+	// is the same join plus a single os.Stat; a nested-module-relative
+	// source_file resolves via lr's precomputed in-repo suffix index.
+	abs := resolveEntitySourcePath(lr, e.SourceFile)
 
 	// #2828 / #1614 — bound the requested span and SIGNAL any truncation.
 	// computeSourceSpan clamps a degenerate span (synthetic/shadow/route


### PR DESCRIPTION
Closes #5682. `get_source` failed for files in nested modules (module-root-relative `source_file` joined against the group root → `lstat …: no such file or directory`); a repo with ~311 nested build units hit this constantly. Fix: after the direct join misses, resolve via a per-repo **suffix index** (basename→relpaths) built once per repo via sync.Once and re-armed on reload — O(1) lookup, tree walked at most once regardless of call count (kills the per-call-walk + inspect amplification a first cut had). Unique-match only (ambiguous/partial → clean error, never a wrong file); sibling-repo fallback removed (the entity already resolves to its own repo, so a cross-repo path collision could return the wrong file). Root-level files unchanged (single os.Stat). Reviewed: REQUEST-CHANGES → fixed, with built-once + sibling-collision regression tests. Refs #5681.