### PR TITLE
feat(mcp): surface daemon warming/enrichment state in whoami & status (#5690)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -683,6 +683,11 @@ func runDaemon(argv []string) error {
 		MCPListTools: daemonMCPListTools,
 		MCPCallTool:  daemonMCPCallTool,
 
+		// #5690: publish the scheduler's read-only warming accessor so the MCP
+		// surface (grafel_whoami / grafel_status) can report whether a group is
+		// still warming (post-index enrichment in flight) vs a slow query.
+		OnSchedulerReady: setDaemonWarmingFn,
+
 		// #2224: on every branch switch, invalidate stale CrossLinkCache
 		// entries in the MCP server so the next cross-repo query recomputes
 		// fresh candidates for the new ref rather than returning stale ones.

--- a/cmd/grafel/daemon_mcp_rpc.go
+++ b/cmd/grafel/daemon_mcp_rpc.go
@@ -17,6 +17,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sync"
+	"sync/atomic"
 
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 
@@ -30,7 +31,23 @@ var (
 	mcpServerOnce    sync.Once
 	mcpServerShared  *mcp.Server
 	mcpServerInitErr error
+
+	// daemonWarmingFn is the read-only scheduler warming accessor (#5690),
+	// published by daemon.Config.OnSchedulerReady once the scheduler is up and
+	// consumed lazily by the MCP server's State. A holder (rather than direct
+	// wiring) decouples the two lifecycles: the scheduler starts inside
+	// daemon.Serve while the *mcp.Server is initialised lazily on first RPC —
+	// neither ordering matters because mcpServerInstance reads the holder on
+	// every call. Nil until the scheduler publishes; then the MCP surface
+	// reports warming state. Pointer-to-func so the atomic can carry a func.
+	daemonWarmingFn atomic.Pointer[func() daemon.WarmingSnapshot]
 )
+
+// setDaemonWarmingFn publishes the scheduler's warming accessor for the MCP
+// server to consume (#5690). Wired as daemon.Config.OnSchedulerReady.
+func setDaemonWarmingFn(fn func() daemon.WarmingSnapshot) {
+	daemonWarmingFn.Store(&fn)
+}
 
 // mcpServerInstance returns the lazily-initialised *mcp.Server. The first
 // call constructs it from the default registry; subsequent calls return the
@@ -42,6 +59,15 @@ func mcpServerInstance() (*mcp.Server, error) {
 			mcpServerInitErr = fmt.Errorf("mcp server init: %w", err)
 			return
 		}
+		// #5690: wire the warming accessor. The closure reads the holder on
+		// every call, so it works regardless of whether the scheduler has
+		// published yet (returns the zero "not warming" snapshot until then).
+		srv.State.SetWarmingSnapshot(func() daemon.WarmingSnapshot {
+			if fp := daemonWarmingFn.Load(); fp != nil {
+				return (*fp)()
+			}
+			return daemon.WarmingSnapshot{}
+		})
 		mcpServerShared = srv
 	})
 	return mcpServerShared, mcpServerInitErr

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -244,6 +244,16 @@ type Config struct {
 	// invalidation. nil leaves the on-disk delete to run without an explicit
 	// reader drop (the cache ages out on its own).
 	DeadRefDropReader func(repoPath, ref string)
+
+	// OnSchedulerReady, when non-nil, is invoked once the scheduler is started
+	// with a read-only warming-state accessor closing over the live scheduler
+	// (#5690). cmd/grafel wires the accessor into the MCP server's State so
+	// grafel_whoami / grafel_status can report whether a post-index enrichment
+	// pass is still in flight (a "warming" group) rather than leaving agents to
+	// mistake enrichment-induced slowness for a slow query. The accessor is
+	// read-only and has NO effect on scheduling. Not called for a watcher-less
+	// daemon (no scheduler is created).
+	OnSchedulerReady func(warming func() WarmingSnapshot)
 }
 
 // Run starts the daemon. It blocks until either:
@@ -421,6 +431,20 @@ func Run(ctx context.Context, cfg Config) error {
 		scheduler.Start()
 		svc.scheduler = scheduler
 		defer scheduler.Stop()
+
+		// #5690: hand a read-only warming accessor to the wiring layer so the
+		// MCP surface can report warming state. Closes over the live scheduler;
+		// no scheduling authority.
+		if cfg.OnSchedulerReady != nil {
+			cfg.OnSchedulerReady(func() WarmingSnapshot {
+				snap := scheduler.Snapshot()
+				return WarmingSnapshot{
+					IndexInFlight: len(snap.InFlight) > 0,
+					PendingAlgo:   len(snap.PendingAlgo),
+					PendingLinks:  len(snap.PendingLinks),
+				}
+			})
+		}
 
 		wcfg := cfg.WatcherConfig
 		watcher, werr := watch.NewWatcherConfig(wcfg, func(repo string, bulk bool) {

--- a/internal/daemon/warming.go
+++ b/internal/daemon/warming.go
@@ -1,0 +1,34 @@
+package daemon
+
+// warming.go — issue #5690.
+//
+// WarmingSnapshot is a tiny, read-only projection of the scheduler's state
+// used to answer one question the MCP surface previously could not: "is this
+// group still warming (post-index enrichment in flight), or is a slow query
+// just slow?". It carries no scheduling authority — it is observability only.
+//
+// The type lives in internal/daemon (not internal/mcp) so the daemon can hand
+// a closure over its private *sched.Scheduler out to cmd/grafel WITHOUT the
+// daemon importing internal/mcp. internal/mcp already imports internal/daemon
+// (for on-disk layout helpers), so mcp.State can consume daemon.WarmingSnapshot
+// directly — no import cycle is introduced (the daemon never imports mcp).
+
+// WarmingSnapshot is the read-only warming/readiness projection surfaced to the
+// MCP tools. All fields are additive and safe to extend.
+type WarmingSnapshot struct {
+	// IndexInFlight is true when at least one repo is actively being indexed.
+	IndexInFlight bool
+	// PendingAlgo is the number of repos with a post-index algorithm
+	// (PageRank/Louvain/…) enrichment pass still queued.
+	PendingAlgo int
+	// PendingLinks is the number of groups with a cross-repo link pass still
+	// queued.
+	PendingLinks int
+}
+
+// Warming reports whether the group is still warming — i.e. an index is in
+// flight OR a post-index enrichment (algo/links) pass is pending. This is the
+// single boolean the MCP surface exposes as `warming`.
+func (w WarmingSnapshot) Warming() bool {
+	return w.IndexInFlight || w.PendingAlgo > 0 || w.PendingLinks > 0
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1826,6 +1826,15 @@ func (s *Server) handleStatus(ctx context.Context, req mcpapi.CallToolRequest) (
 		msg = fmt.Sprintf("Grafel: cwd %q is not under any registered group (registered: %v). cd into a registered repo or run `grafel install` here. Note: new groups registered mid-session are not reflected until restart (#1772).", cwd, known)
 	}
 
+	// #5690: append a compact warming hint when the daemon scheduler reports a
+	// post-index enrichment pass in flight. This lets an agent onboarding via
+	// grafel_status tell a warming graph (queries slow, results incomplete)
+	// apart from a slow query. Silent when not warming or no handle is wired.
+	if warm, ok := s.State.Warming(); ok && warm.Warming() {
+		msg += fmt.Sprintf(" [warming: post-index enrichment in flight (indexing=%t, pending_algo=%d, pending_links=%d) — results may be incomplete and queries slower until this completes]",
+			warm.IndexInFlight, warm.PendingAlgo, warm.PendingLinks)
+	}
+
 	// Append the MCP + grep pairing philosophy so agents onboarding via
 	// grafel_status understand how to use MCP alongside grep (#1836).
 	const pairingPhilosophy = "\n\n" +

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -528,6 +528,38 @@ type State struct {
 	// Exported so that the daemon server can call NotifyRefSwitch on receipt
 	// of a BranchSwitchEvent and integration tests can inspect cache state.
 	CrossLinkCache *CrossLinkCache
+
+	// warmingFn is the optional read-only scheduler warming accessor (#5690).
+	// Injected by cmd/grafel via SetWarmingSnapshot when the daemon has a live
+	// scheduler; nil on the stdio-native path (no daemon) or in tests, in which
+	// case Warming() reports "not warming / unknown" gracefully. Read-only — it
+	// never affects scheduling.
+	warmingFn func() daemon.WarmingSnapshot
+}
+
+// SetWarmingSnapshot wires a read-only scheduler warming accessor into the
+// State (#5690). Called from cmd/grafel once the daemon's scheduler is up so
+// grafel_whoami / grafel_status can distinguish a warming group (post-index
+// enrichment in flight) from a genuinely slow query. Passing nil clears it.
+func (s *State) SetWarmingSnapshot(fn func() daemon.WarmingSnapshot) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.warmingFn = fn
+}
+
+// Warming returns the current warming snapshot and whether a scheduler handle
+// is wired. When no handle is injected it returns the zero snapshot (not
+// warming) and false, so callers degrade gracefully to warming=false. The
+// accessor is invoked WITHOUT holding s.mu so the scheduler's own snapshot
+// lock never nests under the MCP state lock.
+func (s *State) Warming() (daemon.WarmingSnapshot, bool) {
+	s.mu.Lock()
+	fn := s.warmingFn
+	s.mu.Unlock()
+	if fn == nil {
+		return daemon.WarmingSnapshot{}, false
+	}
+	return fn(), true
 }
 
 // SetWorktreeLookup wires the PH3 ephemeral worktree registry.  Call from

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -339,6 +339,21 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 		resp["tier"] = "hot"
 	}
 
+	// #5690: surface the real warming/readiness signal from the daemon
+	// scheduler so agents can tell a warming group (post-index enrichment still
+	// in flight — queries are slow but the graph is incomplete) apart from a
+	// genuinely slow query. Additive fields; when no scheduler handle is wired
+	// (stdio-native path / tests) warming defaults to false and the counts to 0.
+	// A warming group overrides the cwd-derived tier with a real "warming" value.
+	warm, _ := s.State.Warming()
+	resp["warming"] = warm.Warming()
+	resp["indexing"] = warm.IndexInFlight
+	resp["pending_algo"] = warm.PendingAlgo
+	resp["pending_links"] = warm.PendingLinks
+	if warm.Warming() {
+		resp["tier"] = "warming"
+	}
+
 	// Nudge suppression: GRAFEL_WHOAMI_NUDGE=quiet disables doc-state fields.
 	if os.Getenv("GRAFEL_WHOAMI_NUDGE") == "quiet" {
 		return jsonResult(resp), nil

--- a/internal/mcp/warming_5690_test.go
+++ b/internal/mcp/warming_5690_test.go
@@ -1,0 +1,146 @@
+package mcp
+
+// warming_5690_test.go — issue #5690.
+//
+// Verifies that the MCP surface reports a real warming/readiness signal
+// sourced from the daemon scheduler. During post-index enrichment (algo /
+// links passes still pending) queries are slow; without this signal agents
+// cannot distinguish "warming" from "slow query".
+//
+// The scheduler handle is injected as a read-only closure via
+// State.SetWarmingSnapshot. When no handle is injected the surface must
+// degrade gracefully to warming=false with the prior fields unchanged.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+func newWarmingTestServer(t *testing.T) *Server {
+	t.Helper()
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("GRAFEL_WHOAMI_NUDGE", "quiet")
+
+	repoDir := filepath.Join(tmp, "repo-a")
+	writeGraph(t, repoDir, fixtureDoc("repo-a"))
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+func whoamiJSON(t *testing.T, srv *Server) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	return extractResultJSON(t, res)
+}
+
+// TestWhoami_warming_true asserts that an injected warming snapshot
+// (IndexInFlight=true, PendingAlgo=N) surfaces warming=true, the pending
+// counts, and a "warming" tier.
+func TestWhoami_warming_true(t *testing.T) {
+	srv := newWarmingTestServer(t)
+	srv.State.SetWarmingSnapshot(func() daemon.WarmingSnapshot {
+		return daemon.WarmingSnapshot{
+			IndexInFlight: true,
+			PendingAlgo:   3,
+			PendingLinks:  1,
+		}
+	})
+
+	out := whoamiJSON(t, srv)
+
+	if got := out["warming"]; got != true {
+		t.Errorf("warming: got %v (%T), want true", got, got)
+	}
+	if got := out["indexing"]; got != true {
+		t.Errorf("indexing: got %v (%T), want true", got, got)
+	}
+	if got := out["pending_algo"]; got != float64(3) {
+		t.Errorf("pending_algo: got %v (%T), want 3", got, got)
+	}
+	if got := out["pending_links"]; got != float64(1) {
+		t.Errorf("pending_links: got %v (%T), want 1", got, got)
+	}
+	if got := out["tier"]; got != "warming" {
+		t.Errorf("tier: got %v, want warming", got)
+	}
+}
+
+// TestWhoami_warming_pendingAlgoOnly asserts warming is true when only a
+// pending enrichment pass remains (no index in flight) — enrichment is the
+// slow phase the signal exists to disambiguate.
+func TestWhoami_warming_pendingAlgoOnly(t *testing.T) {
+	srv := newWarmingTestServer(t)
+	srv.State.SetWarmingSnapshot(func() daemon.WarmingSnapshot {
+		return daemon.WarmingSnapshot{PendingAlgo: 2}
+	})
+
+	out := whoamiJSON(t, srv)
+	if got := out["warming"]; got != true {
+		t.Errorf("warming: got %v, want true", got)
+	}
+	if got := out["indexing"]; got != false {
+		t.Errorf("indexing: got %v, want false", got)
+	}
+	if got := out["tier"]; got != "warming" {
+		t.Errorf("tier: got %v, want warming", got)
+	}
+}
+
+// TestWhoami_notWarming_noSnapshot asserts graceful default: with no
+// injected handle warming=false, tier keeps its prior value ("hot"), and the
+// pending counts are zero.
+func TestWhoami_notWarming_noSnapshot(t *testing.T) {
+	srv := newWarmingTestServer(t)
+
+	out := whoamiJSON(t, srv)
+	if got := out["warming"]; got != false {
+		t.Errorf("warming: got %v, want false", got)
+	}
+	if got := out["indexing"]; got != false {
+		t.Errorf("indexing: got %v, want false", got)
+	}
+	if got := out["pending_algo"]; got != float64(0) {
+		t.Errorf("pending_algo: got %v, want 0", got)
+	}
+	if got := out["tier"]; got != "hot" {
+		t.Errorf("tier: got %v, want hot (unchanged prior value)", got)
+	}
+}
+
+// TestWhoami_notWarming_idleSnapshot asserts warming=false when a handle is
+// injected but the scheduler is idle (no in-flight index, no pending passes).
+func TestWhoami_notWarming_idleSnapshot(t *testing.T) {
+	srv := newWarmingTestServer(t)
+	srv.State.SetWarmingSnapshot(func() daemon.WarmingSnapshot {
+		return daemon.WarmingSnapshot{}
+	})
+
+	out := whoamiJSON(t, srv)
+	if got := out["warming"]; got != false {
+		t.Errorf("warming: got %v, want false", got)
+	}
+	if got := out["tier"]; got != "hot" {
+		t.Errorf("tier: got %v, want hot", got)
+	}
+}


### PR DESCRIPTION
Closes #5690. During post-index enrichment, MCP queries are slow (p95 20s, one 239s) with NO signal — agents can't tell 'warming' from 'slow query'. Surfaces a read-only warming flag sourced from the scheduler: whoami gains additive `warming`/`indexing`/`pending_algo`/`pending_links` + `tier=warming`; status appends a hint. Daemon→MCP seam via an injected closure over scheduler.Snapshot() (no import cycle; atomic holder, -race clean; nil-safe degradation). No admission control / scheduling change (deferred). Reviewed: APPROVE-WITH-NITS. Refs #5681.