### PR TITLE
feat(lineage): DataAccess→Datastore/Schema READS/WRITES edges (#5687)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1480,6 +1480,21 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	i.stats.extSynth = extStats
 
+	// #5687 — data-layer lineage edges. Connect each SCOPE.DataAccess node to
+	// the EXISTING physical table entity it touches (SCOPE.Datastore/Schema),
+	// emitting READS_FROM (SELECT) / WRITES_TO (INSERT/UPDATE/DELETE/…) on an
+	// EXACT canonical table-name match. De-orphans the data-access/table layer so
+	// lineage queries can traverse function → DataAccess → table. Runs at Pass 4.5
+	// (before the Pass 4 graph algorithms) so the new edges participate in
+	// centrality/community. Append-only, deterministic, idempotent.
+	dlStats := external.SynthesizeDataLineageEdges(doc)
+	if verbose() || dlStats.EdgesAdded > 0 {
+		fmt.Fprintf(os.Stderr,
+			"data-lineage: data_access_seen=%d edges=%d reads_from=%d writes_to=%d ambiguous=%d unresolved=%d\n",
+			dlStats.DataAccessSeen, dlStats.EdgesAdded, dlStats.ReadsFrom,
+			dlStats.WritesTo, dlStats.Ambiguous, dlStats.Unresolved)
+	}
+
 	// #4480 — retarget THROWS / CATCHES edges from the synthetic
 	// SCOPE.ExceptionType convergence node to the REAL exception class entity
 	// (declared in-repo class, or the imported `ext:<Type>` placeholder just

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -641,6 +641,321 @@ func SynthesizeDBEntities(doc *graph.Document) Stats {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Issue #5687 — data-layer lineage edges (DataAccess → physical table).
+// ---------------------------------------------------------------------------
+
+// DataLineageStats summarises a SynthesizeDataLineageEdges run.
+type DataLineageStats struct {
+	// DataAccessSeen is the number of SCOPE.DataAccess entities with a
+	// resolvable (non-UNKNOWN) table name.
+	DataAccessSeen int
+	// EdgesAdded is the number of NEW READS_FROM / WRITES_TO edges appended.
+	EdgesAdded int
+	// ReadsFrom / WritesTo break EdgesAdded down by verb.
+	ReadsFrom int
+	WritesTo  int
+	// Ambiguous is the number of DataAccess table references that matched >1
+	// candidate table entity (same canonical name) and were skipped to avoid a
+	// wrong data-lineage join.
+	Ambiguous int
+	// Unresolved is the number of DataAccess table references whose canonical
+	// name matched no existing Datastore/Schema table entity.
+	Unresolved int
+}
+
+// parseDataAccessOp extracts the SQL operation from a
+// scope:dataaccess:<file>#<orm>:<op>:<table> qualified name (parts[1]).
+// Returns "" when the form is invalid.
+func parseDataAccessOp(qn string) string {
+	const prefix = "scope:dataaccess:"
+	if !strings.HasPrefix(qn, prefix) {
+		return ""
+	}
+	rest := qn[len(prefix):]
+	hash := strings.IndexByte(rest, '#')
+	if hash < 0 {
+		return ""
+	}
+	parts := strings.SplitN(rest[hash+1:], ":", 3)
+	if len(parts) != 3 {
+		return ""
+	}
+	return parts[1]
+}
+
+// dataLineageWriteOps is the set of operations that MUTATE a table (→ WRITES_TO).
+// Anything else — SELECT, or an unknown/empty op — is treated as a read
+// (→ READS_FROM), which is the safe default (never fabricates a write).
+var dataLineageWriteOps = map[string]bool{
+	"insert": true, "update": true, "delete": true,
+	"upsert": true, "truncate": true, "merge": true,
+}
+
+// lineageVerb maps a parsed SQL operation to its lineage relationship kind.
+func lineageVerb(op string) string {
+	if dataLineageWriteOps[strings.ToLower(strings.TrimSpace(op))] {
+		return string(types.RelationshipKindWritesTo)
+	}
+	return string(types.RelationshipKindReadsFrom)
+}
+
+// canonicalTableName normalises a physical table identifier so the same table
+// resolves across dialects. Rules (issue #5687):
+//
+//   - trim + lowercase;
+//   - strip surrounding quoting/bracketing an ORM/dialect may leave on
+//     (backtick, double/single quote, [brackets]);
+//   - drop a schema/catalog qualifier: keep only the segment after the last
+//     "." (public.orders → orders, mydb.sales.orders → orders);
+//   - fold a naive plural to its singular stem so an ORM class name (Order)
+//     and a migration table (orders) converge (orders → order,
+//     companies → company, addresses → address).
+//
+// Returns "" for empty or "unknown" input (those never produce an edge).
+func canonicalTableName(t string) string {
+	s := strings.ToLower(strings.TrimSpace(t))
+	if s == "" || s == "unknown" {
+		return ""
+	}
+	// Drop a schema/catalog qualifier (last segment wins).
+	if i := strings.LastIndex(s, "."); i >= 0 && i+1 < len(s) {
+		s = s[i+1:]
+	}
+	// Strip surrounding quotes/backticks/brackets.
+	s = strings.Trim(s, "`\"'[]")
+	if s == "" {
+		return ""
+	}
+	return singularize(s)
+}
+
+// singularize folds a common English plural table name to a singular stem.
+// Conservative on purpose: only well-known suffix rules, so it never mangles a
+// genuinely-singular name (e.g. "address" stays "address"; "class"/"status"
+// are guarded by the "ss"/"us" cases).
+func singularize(s string) string {
+	switch {
+	case strings.HasSuffix(s, "ies") && len(s) > 3:
+		return s[:len(s)-3] + "y" // companies → company
+	case strings.HasSuffix(s, "sses"): // addresses → address
+		return s[:len(s)-2]
+	case strings.HasSuffix(s, "ches"), strings.HasSuffix(s, "shes"),
+		strings.HasSuffix(s, "xes"), strings.HasSuffix(s, "zes"):
+		return s[:len(s)-2]
+	case strings.HasSuffix(s, "ss"), strings.HasSuffix(s, "us"),
+		strings.HasSuffix(s, "is"):
+		return s // class, status, analysis — already singular-ish
+	case strings.HasSuffix(s, "s") && len(s) > 1:
+		return s[:len(s)-1] // orders → order, users → user
+	default:
+		return s
+	}
+}
+
+// Candidate table-entity tiers: a physical migration Datastore table outranks
+// an ORM-derived Schema when both resolve to one canonical name (issue #5687
+// deterministic tie-break).
+const (
+	lineageTierDatastore = 0
+	lineageTierSchema    = 1
+)
+
+// datastoreTableSubtypes / schemaTableSubtypes are the entity subtypes that
+// represent a WHOLE relation (a table/view), as opposed to a column/field
+// member. Only these are eligible lineage targets — joining a DataAccess to a
+// SCOPE.Schema/field column entity would be a wrong edge.
+var datastoreTableSubtypes = map[string]bool{
+	"table": true, "view": true,
+}
+var schemaTableSubtypes = map[string]bool{
+	"table": true, "view": true, "entity": true, "model": true, "schema": true,
+}
+
+// lineageCandidate is one resolvable table entity keyed by canonical name.
+type lineageCandidate struct {
+	id   string
+	tier int
+}
+
+// SynthesizeDataLineageEdges (issue #5687) connects every SCOPE.DataAccess node
+// to the EXISTING physical table entity it touches, so data-lineage queries can
+// traverse function → DataAccess → table.
+//
+// For each SCOPE.DataAccess entity it parses the (op, table) pair out of the
+// QualifiedName (scope:dataaccess:<file>#<orm>:<op>:<table>) and emits:
+//
+//	SCOPE.DataAccess --READS_FROM--> SCOPE.Datastore/SCOPE.Schema   (SELECT)
+//	SCOPE.DataAccess --WRITES_TO---> SCOPE.Datastore/SCOPE.Schema   (INSERT/UPDATE/DELETE/UPSERT/TRUNCATE/MERGE)
+//
+// The target is the EXISTING table entity (never a new ext:db.* node): a
+// byName index over SCOPE.Datastore(table|view) and table-representing
+// SCOPE.Schema entities, keyed by canonicalTableName. HARD CONSTRAINT — an edge
+// is emitted ONLY on an EXACT canonical-name match that resolves to exactly one
+// candidate in the winning tier (Datastore beats Schema). UNKNOWN/empty tables
+// are dropped; an ambiguous canonical name (≥2 candidates in the winning tier)
+// is skipped so the pass never fabricates a wrong lineage edge.
+//
+// This ADDS edges alongside the pre-existing SynthesizeDBEntities ext:db.*
+// IMPORTS behaviour; it does not remove it. Deterministic, append-only, and
+// idempotent (a second run mints no duplicate edge).
+//
+// DynamoDB / NoSQL access is out of scope for this pass: there is no
+// Datastore/Schema table entity to join, so no edge is honestly emittable.
+func SynthesizeDataLineageEdges(doc *graph.Document) DataLineageStats {
+	if doc == nil {
+		return DataLineageStats{}
+	}
+
+	// Build the canonical byName index over existing relation-level table
+	// entities. A Datastore(table|view) and a Schema can share one canonical
+	// name; keep both, tiered, so the Datastore wins deterministically.
+	byName := make(map[string][]lineageCandidate)
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		var tier int
+		switch {
+		case e.Kind == "SCOPE.Datastore" && datastoreTableSubtypes[e.Subtype]:
+			tier = lineageTierDatastore
+		case e.Kind == "SCOPE.Schema" && schemaTableSubtypes[e.Subtype]:
+			tier = lineageTierSchema
+		default:
+			continue
+		}
+		canon := canonicalTableName(e.Name)
+		if canon == "" {
+			continue
+		}
+		byName[canon] = append(byName[canon], lineageCandidate{id: e.ID, tier: tier})
+	}
+
+	// Pre-index existing READS_FROM / WRITES_TO edges for idempotency.
+	knownEdges := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == string(types.RelationshipKindReadsFrom) ||
+			r.Kind == string(types.RelationshipKindWritesTo) {
+			knownEdges[r.FromID+"|"+r.ToID+"|"+r.Kind] = true
+		}
+	}
+
+	// resolve returns the single winning candidate ID for a canonical name.
+	// Datastore tier is tried first; exactly one candidate in that tier wins
+	// even if Schema candidates also exist. Falls back to the Schema tier only
+	// when no Datastore candidate is present. Returns ambiguous=true when the
+	// winning tier has ≥2 candidates.
+	resolve := func(canon string) (id string, ok, ambiguous bool) {
+		cands := byName[canon]
+		if len(cands) == 0 {
+			return "", false, false
+		}
+		var ds, sc []string
+		for _, c := range cands {
+			if c.tier == lineageTierDatastore {
+				ds = append(ds, c.id)
+			} else {
+				sc = append(sc, c.id)
+			}
+		}
+		switch {
+		case len(ds) == 1:
+			return ds[0], true, false
+		case len(ds) > 1:
+			return "", false, true // ambiguous physical tables
+		case len(sc) == 1:
+			return sc[0], true, false
+		default:
+			return "", false, true // ≥2 schema candidates, no datastore
+		}
+	}
+
+	// Collect new edges first for a deterministic append order.
+	type lineageEdge struct {
+		fromID, toID, kind, table string
+	}
+	var newEdges []lineageEdge
+
+	var stats DataLineageStats
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Kind != "SCOPE.DataAccess" {
+			continue
+		}
+		_, table, ok := parseDataAccessQN(e.QualifiedName)
+		if !ok {
+			// Fall back to the `table` property when the QN is not the stub form.
+			if e.Properties != nil {
+				table = e.Properties["table"]
+			}
+		}
+		canon := canonicalTableName(table)
+		if canon == "" {
+			continue // UNKNOWN / empty — dropped
+		}
+		stats.DataAccessSeen++
+
+		toID, resolved, ambiguous := resolve(canon)
+		if ambiguous {
+			stats.Ambiguous++
+			continue
+		}
+		if !resolved {
+			stats.Unresolved++
+			continue
+		}
+
+		op := parseDataAccessOp(e.QualifiedName)
+		if op == "" && e.Properties != nil {
+			op = e.Properties["operation"]
+		}
+		kind := lineageVerb(op)
+
+		key := e.ID + "|" + toID + "|" + kind
+		if knownEdges[key] {
+			continue
+		}
+		knownEdges[key] = true
+		newEdges = append(newEdges, lineageEdge{
+			fromID: e.ID, toID: toID, kind: kind, table: canon,
+		})
+	}
+
+	sort.Slice(newEdges, func(i, j int) bool {
+		if newEdges[i].fromID != newEdges[j].fromID {
+			return newEdges[i].fromID < newEdges[j].fromID
+		}
+		if newEdges[i].toID != newEdges[j].toID {
+			return newEdges[i].toID < newEdges[j].toID
+		}
+		return newEdges[i].kind < newEdges[j].kind
+	})
+
+	for _, e := range newEdges {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(e.fromID, e.toID, e.kind),
+			FromID: e.fromID,
+			ToID:   e.toID,
+			Kind:   e.kind,
+			Properties: map[string]string{
+				"table":      e.table,
+				"provenance": "DATA_LINEAGE_5687",
+				"generated":  "true",
+			},
+		})
+		stats.EdgesAdded++
+		if e.kind == string(types.RelationshipKindReadsFrom) {
+			stats.ReadsFrom++
+		} else {
+			stats.WritesTo++
+		}
+	}
+
+	if stats.EdgesAdded > 0 {
+		doc.Stats.Relationships = len(doc.Relationships)
+	}
+	return stats
+}
+
 // classifyExternal decides whether a stub-shaped ToID looks like an
 // external reference, and if so returns the canonical name we should
 // use for the placeholder entity.

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -6670,3 +6670,211 @@ func TestSynthesize_NoPlaceholderForRubyStdlib(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------
+// Issue #5687 — data-layer lineage edges.
+//
+// SynthesizeDataLineageEdges links each SCOPE.DataAccess node to the
+// EXISTING SCOPE.Datastore/SCOPE.Schema table entity it touches, choosing
+// READS_FROM (SELECT) or WRITES_TO (INSERT/UPDATE/DELETE/…) from the parsed
+// operation, gated on an EXACT canonical table-name match.
+// ---------------------------------------------------------------------
+
+// dataAccessEnt is a small helper building a SCOPE.DataAccess entity whose
+// QualifiedName encodes (file, orm, op, table) the way the dbmap extractor emits.
+func dataAccessEnt(id, file, orm, op, table string) graph.Entity {
+	return graph.Entity{
+		ID:            id,
+		Kind:          "SCOPE.DataAccess",
+		Name:          op + " " + table,
+		QualifiedName: "scope:dataaccess:" + file + "#" + orm + ":" + op + ":" + table,
+		SourceFile:    file,
+		Language:      "go",
+		Properties:    map[string]string{"operation": op, "table": table},
+	}
+}
+
+func datastoreTableEnt(id, name string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Kind:       "SCOPE.Datastore",
+		Subtype:    "table",
+		Name:       name,
+		SourceFile: "migrations/0001_init.sql",
+		Language:   "sql",
+	}
+}
+
+// hasLineageEdge reports whether doc has an edge fromID→toID of the given kind.
+func hasLineageEdge(doc *graph.Document, fromID, toID, kind string) bool {
+	for _, r := range doc.Relationships {
+		if r.FromID == fromID && r.ToID == toID && r.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSynthesizeDataLineageEdges_ReadsFrom is the primary red→green case: a
+// SELECT DataAccess on `orders` + a Datastore table `orders` must yield a
+// DataAccess --READS_FROM--> Datastore(orders) edge (orphan before, linked after).
+func TestSynthesizeDataLineageEdges_ReadsFrom(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000001", "internal/store/order.go", "gorm", "SELECT", "orders"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+		},
+	}
+
+	// Before: DataAccess is orphan — no READS_FROM/WRITES_TO edge exists.
+	for _, r := range doc.Relationships {
+		if r.Kind == "READS_FROM" || r.Kind == "WRITES_TO" {
+			t.Fatalf("precondition violated: unexpected %s edge before pass", r.Kind)
+		}
+	}
+
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 1 {
+		t.Fatalf("EdgesAdded=%d, want 1", stats.EdgesAdded)
+	}
+	if !hasLineageEdge(doc, "da00000000000001", "ds00000000000001", "READS_FROM") {
+		t.Fatalf("missing DataAccess --READS_FROM--> Datastore(orders) edge")
+	}
+}
+
+// TestSynthesizeDataLineageEdges_WritesTo covers the write verb (INSERT).
+func TestSynthesizeDataLineageEdges_WritesTo(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000002", "internal/store/order.go", "gorm", "INSERT", "orders"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 1 {
+		t.Fatalf("EdgesAdded=%d, want 1", stats.EdgesAdded)
+	}
+	if !hasLineageEdge(doc, "da00000000000002", "ds00000000000001", "WRITES_TO") {
+		t.Fatalf("missing DataAccess --WRITES_TO--> Datastore(orders) edge")
+	}
+	if hasLineageEdge(doc, "da00000000000002", "ds00000000000001", "READS_FROM") {
+		t.Fatalf("INSERT must not emit READS_FROM")
+	}
+}
+
+// TestSynthesizeDataLineageEdges_Canonicalization checks that a schema-qualified
+// DataAccess table (`public.orders`) still resolves to the bare `orders` table.
+func TestSynthesizeDataLineageEdges_Canonicalization(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000003", "internal/store/order.go", "sql", "SELECT", "public.orders"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 1 {
+		t.Fatalf("EdgesAdded=%d, want 1", stats.EdgesAdded)
+	}
+	if !hasLineageEdge(doc, "da00000000000003", "ds00000000000001", "READS_FROM") {
+		t.Fatalf("public.orders did not canonicalize to orders")
+	}
+}
+
+// TestSynthesizeDataLineageEdges_UnknownSkipped confirms UNKNOWN/empty tables
+// never produce an edge.
+func TestSynthesizeDataLineageEdges_UnknownSkipped(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000004", "internal/store/dyn.go", "sql", "SELECT", "UNKNOWN"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 0 {
+		t.Fatalf("EdgesAdded=%d, want 0 (UNKNOWN skipped)", stats.EdgesAdded)
+	}
+}
+
+// TestSynthesizeDataLineageEdges_AmbiguousSkipped confirms that when two
+// distinct Datastore tables share one canonical name, no edge is emitted
+// (exact-match-only; no wrong fan-out).
+func TestSynthesizeDataLineageEdges_AmbiguousSkipped(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000005", "internal/store/order.go", "sql", "SELECT", "orders"),
+			datastoreTableEnt("ds00000000000001", "public.orders"),
+			datastoreTableEnt("ds00000000000002", "sales.orders"),
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 0 {
+		t.Fatalf("EdgesAdded=%d, want 0 (ambiguous canonical name)", stats.EdgesAdded)
+	}
+	if stats.Ambiguous != 1 {
+		t.Fatalf("Ambiguous=%d, want 1", stats.Ambiguous)
+	}
+}
+
+// TestSynthesizeDataLineageEdges_DatastoreBeatsSchema confirms the deterministic
+// tie-break: when both a migration Datastore and an ORM Schema exist for one
+// canonical table, the Datastore node wins.
+func TestSynthesizeDataLineageEdges_DatastoreBeatsSchema(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000006", "internal/store/order.go", "gorm", "SELECT", "orders"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+			{ID: "sc00000000000001", Kind: "SCOPE.Schema", Subtype: "table", Name: "orders", Language: "go"},
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 1 {
+		t.Fatalf("EdgesAdded=%d, want 1", stats.EdgesAdded)
+	}
+	if !hasLineageEdge(doc, "da00000000000006", "ds00000000000001", "READS_FROM") {
+		t.Fatalf("Datastore should win over Schema for the lineage target")
+	}
+}
+
+// TestSynthesizeDataLineageEdges_SchemaFallback confirms that when ONLY an ORM
+// Schema table entity exists (no Datastore), the DataAccess still links to it.
+func TestSynthesizeDataLineageEdges_SchemaFallback(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000008", "internal/store/order.go", "gorm", "UPDATE", "orders"),
+			{ID: "sc00000000000002", Kind: "SCOPE.Schema", Subtype: "table", Name: "orders", Language: "go"},
+		},
+	}
+	stats := SynthesizeDataLineageEdges(doc)
+	if stats.EdgesAdded != 1 {
+		t.Fatalf("EdgesAdded=%d, want 1", stats.EdgesAdded)
+	}
+	if !hasLineageEdge(doc, "da00000000000008", "sc00000000000002", "WRITES_TO") {
+		t.Fatalf("missing DataAccess --WRITES_TO--> Schema(orders) fallback edge")
+	}
+}
+
+// TestSynthesizeDataLineageEdges_Idempotent confirms a second run adds nothing.
+func TestSynthesizeDataLineageEdges_Idempotent(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			dataAccessEnt("da00000000000007", "internal/store/order.go", "gorm", "SELECT", "orders"),
+			datastoreTableEnt("ds00000000000001", "orders"),
+		},
+	}
+	first := SynthesizeDataLineageEdges(doc)
+	second := SynthesizeDataLineageEdges(doc)
+	if first.EdgesAdded != 1 {
+		t.Fatalf("first EdgesAdded=%d, want 1", first.EdgesAdded)
+	}
+	if second.EdgesAdded != 0 {
+		t.Fatalf("second EdgesAdded=%d, want 0 (idempotent)", second.EdgesAdded)
+	}
+}


### PR DESCRIPTION
Closes #5687. Data-layer entities were ~100% orphan (DataAccess/Datastore/Schema/Model). New `SynthesizeDataLineageEdges` pass (Pass 4.5) emits `SCOPE.DataAccess --READS_FROM/WRITES_TO--> SCOPE.Datastore/Schema`, resolving the table name (parsed from the DataAccess QN) to the EXISTING table entity via a canonical byName index (verb from the SQL op). Exact-unique-match only: ambiguous canonical names are skipped (never first-wins), columns can't be targets, UNKNOWN/NoSQL(DynamoDB/Mongo) dropped, append-only + idempotent. JPA/GORM/Dapper/raw-sql covered. Reviewed: APPROVE-WITH-NITS (narrow canonicalization residuals noted for follow-up). Refs #5680 #5681.