### PR TITLE
perf(index): betweenness force-exact opt-out + high-core extract concurrency (#5692)

### DIFF
--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -22,16 +22,18 @@ import (
 	"github.com/cajasmota/grafel/internal/executil"
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
+	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/treesitter"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// CoordinatorConfig governs subprocess fan-out. Defaults are tuned to
-// stay under the 600MB Phase-F target on a typical laptop:
+// CoordinatorConfig governs subprocess fan-out. Background defaults are tuned
+// to stay memory-safe on a typical laptop while using more of a high-core host:
 //
-//	Concurrency = NumCPU / 2 capped at 4   → 4 × 150MB = 600MB worst-case
-//	BatchSize   = 80 files                  → ~100MB peak per subprocess
+//	Concurrency = backgroundConcurrency(NumCPU, hostMem)  → NumCPU/2, ceiling 12,
+//	              clamped by hostMem / 512MB per child (#5692; was capped at 4)
+//	BatchSize   = 80 files                                → ~100MB peak per subprocess
 //
 // All fields zero-valued fall back to defaults.
 type CoordinatorConfig struct {
@@ -139,12 +141,63 @@ func (c CoordinatorConfig) concurrency() int {
 		}
 		return n
 	}
-	n := runtime.NumCPU() / 2
+	return backgroundConcurrency(runtime.NumCPU(), process.TotalMemoryMB())
+}
+
+const (
+	// backgroundConcurrencyCeiling is the absolute upper bound on concurrent
+	// extract subprocesses for a BACKGROUND (watch/churn) reindex. Raised from
+	// the historical hard 4 (#3648) to 12 (#5692) so high-core/NVMe hosts stop
+	// idling most of their cores during cold indexing; the memory-budget clamp
+	// in backgroundConcurrency still bounds total RSS on memory-constrained hosts.
+	backgroundConcurrencyCeiling = 12
+
+	// perSubprocessRSSBudgetMB is the memory reservation per extract child used
+	// to derive the memory-safety concurrency clamp. A child peaks well under
+	// this during extract (~80-150MB typical; see subproc.go's memory profile),
+	// so 512MB is a deliberately conservative reservation that keeps N children
+	// comfortably within host RAM even on batches with a few large files.
+	perSubprocessRSSBudgetMB = 512
+)
+
+// backgroundConcurrency computes the default number of concurrent extract
+// subprocesses for a BACKGROUND (watch/churn) reindex from the host core count
+// and total physical memory (MB; <=0 means "unknown" and skips the memory
+// clamp). It is a pure function so the formula is unit-testable (#5692).
+//
+// Formula:
+//
+//	cpuTarget = clamp(numCPU/2, 1, backgroundConcurrencyCeiling)
+//	memCap    = max(1, totalMemMB / perSubprocessRSSBudgetMB)   [only if known]
+//	result    = min(cpuTarget, memCap)
+//
+// Properties (the #5692 hard constraints):
+//   - IDENTICAL to the pre-#5692 min(NumCPU/2, 4) default for hosts with <= 9
+//     cores and ample RAM — the ceiling only lifts above 9 cores.
+//   - Only ever LOOSENS where both cores AND memory allow; the memory clamp can
+//     only ever tighten below the CPU target, preserving the #3648 memory-safety
+//     intent (never fan out past what host RAM can hold).
+//   - Foreground (Interactive) rebuilds are untouched — they resolve to NumCPU
+//     above and do not call this function.
+func backgroundConcurrency(numCPU int, totalMemMB int64) int {
+	if numCPU < 1 {
+		numCPU = 1
+	}
+	n := numCPU / 2
 	if n < 1 {
 		n = 1
 	}
-	if n > 4 {
-		n = 4
+	if n > backgroundConcurrencyCeiling {
+		n = backgroundConcurrencyCeiling
+	}
+	if totalMemMB > 0 {
+		memCap := int(totalMemMB / perSubprocessRSSBudgetMB)
+		if memCap < 1 {
+			memCap = 1
+		}
+		if n > memCap {
+			n = memCap
+		}
 	}
 	return n
 }

--- a/internal/daemon/extract/cpu_cap_test.go
+++ b/internal/daemon/extract/cpu_cap_test.go
@@ -3,6 +3,8 @@ package extract
 import (
 	"runtime"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/process"
 )
 
 // TestConcurrencyEnvOverride verifies the #3648 emergency throttle:
@@ -22,15 +24,53 @@ func TestConcurrencyEnvOverride(t *testing.T) {
 	// Garbage / non-positive values are ignored → fall back to auto-tune.
 	t.Setenv("GRAFEL_EXTRACT_CONCURRENCY", "not-a-number")
 	auto := (CoordinatorConfig{}).concurrency()
-	want := runtime.NumCPU() / 2
-	if want < 1 {
-		want = 1
-	}
-	if want > 4 {
-		want = 4
-	}
+	want := backgroundConcurrency(runtime.NumCPU(), process.TotalMemoryMB())
 	if auto != want {
 		t.Fatalf("invalid env ignored: concurrency() = %d, want auto %d", auto, want)
+	}
+}
+
+// TestBackgroundConcurrencyFormula pins the #5692 background-fan-out formula:
+// scale with NumCPU (ceiling backgroundConcurrencyCeiling) but never exceed the
+// per-child RSS budget (totalMem / perSubprocessRSSBudgetMB). It is IDENTICAL to
+// the historical min(NumCPU/2, 4) for <=9-core hosts with ample RAM, only lifts
+// above 9 cores, and only tightens when memory is scarce.
+func TestBackgroundConcurrencyFormula(t *testing.T) {
+	const ampleMem = 65536 // 64 GB — memory clamp never binds
+	cases := []struct {
+		name   string
+		numCPU int
+		memMB  int64
+		want   int
+	}{
+		// Low-core hosts: unchanged from the historical formula.
+		{"1-core", 1, ampleMem, 1},
+		{"2-core", 2, ampleMem, 1},
+		{"4-core", 4, ampleMem, 2},
+		{"8-core", 8, ampleMem, 4}, // pre-#5692: min(4,4)=4 — unchanged
+		{"9-core", 9, ampleMem, 4}, // 9/2=4 — unchanged
+		// High-core hosts: the raised ceiling lets fan-out grow past the old 4.
+		{"10-core", 10, ampleMem, 5}, // was 4, now 5
+		{"16-core", 16, ampleMem, 8},
+		{"24-core-hits-ceiling", 24, ampleMem, backgroundConcurrencyCeiling},
+		{"64-core-ceiling", 64, ampleMem, backgroundConcurrencyCeiling},
+		// Memory clamp: high cores but scarce RAM tightens below the CPU target.
+		{"16-core-2GB", 16, 2048, 4},  // 2048/512=4 < cpuTarget 8
+		{"16-core-1GB", 16, 1024, 2},  // 1024/512=2
+		{"16-core-300MB", 16, 300, 1}, // floors at 1, never 0
+		// Unknown memory (<=0): skip the clamp, use the CPU target.
+		{"16-core-mem-unknown", 16, 0, 8},
+		{"16-core-mem-negative", 16, -1, 8},
+		// Degenerate core count clamps to 1.
+		{"zero-core", 0, ampleMem, 1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := backgroundConcurrency(tc.numCPU, tc.memMB); got != tc.want {
+				t.Fatalf("backgroundConcurrency(%d, %d) = %d, want %d",
+					tc.numCPU, tc.memMB, got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -633,6 +633,89 @@ func betweennessSampleThresholdValue() int {
 // group was large enough to trigger the sampled approximation.
 func BetweennessSampleThreshold() int { return betweennessSampleThresholdValue() }
 
+// betweennessPath names the betweenness computation strategy ComputeCentrality
+// selects for a graph of a given size. It exists as an explicit value so the
+// choice is unit-testable and loggable without timing the run.
+type betweennessPath int
+
+const (
+	// betweennessPathExactWeighted — FloydWarshall + weighted Betweenness.
+	// Most accurate, O(V^3); only viable on tiny graphs (<= betweennessExactCutoff).
+	betweennessPathExactWeighted betweennessPath = iota
+	// betweennessPathExactBrandes — gonum's unweighted Brandes, O(V·E). Exact
+	// but the enrichment-bound cost on large graphs; used for mid-size graphs
+	// (between the FloydWarshall cutoff and the sampling threshold) and whenever
+	// exact computation is forced via GRAFEL_BETWEENNESS_FORCE_EXACT.
+	betweennessPathExactBrandes
+	// betweennessPathSampled — deterministic K-source sampled approximation
+	// (sampledBetweenness); used above the sampling threshold to bound cost on
+	// very large graphs (#5692).
+	betweennessPathSampled
+)
+
+func (p betweennessPath) String() string {
+	switch p {
+	case betweennessPathExactWeighted:
+		return "exact-weighted"
+	case betweennessPathExactBrandes:
+		return "exact-brandes"
+	case betweennessPathSampled:
+		return "sampled"
+	default:
+		return "unknown"
+	}
+}
+
+// chooseBetweennessPath selects the betweenness strategy purely from sizes and
+// the force-exact flag, so the gate is testable in isolation (#5692).
+//
+//   - forceExact=true  -> never sample; pick exact-weighted (<= exactCutoff) or
+//     exact-brandes. This is the operator opt-out for large graphs that need
+//     exact centrality and accept the O(V·E) cost.
+//   - nodes > sampleThreshold (>0) -> sampled approximation.
+//   - nodes <= exactCutoff         -> exact-weighted (FloydWarshall).
+//   - otherwise                    -> exact-brandes.
+//
+// For nodes <= sampleThreshold the result is IDENTICAL to the pre-#5692 code,
+// preserving the hard "small graphs unchanged" constraint.
+func chooseBetweennessPath(nodes, exactCutoff, sampleThreshold int, forceExact bool) betweennessPath {
+	if !forceExact && sampleThreshold > 0 && nodes > sampleThreshold {
+		return betweennessPathSampled
+	}
+	if nodes <= exactCutoff {
+		return betweennessPathExactWeighted
+	}
+	return betweennessPathExactBrandes
+}
+
+// betweennessForceExact reports whether GRAFEL_BETWEENNESS_FORCE_EXACT requests
+// that betweenness always be computed exactly (the pre-sampling behaviour),
+// bypassing the node-count sampling gate (#5692 opt-out). Any of the usual
+// truthy spellings (1/true/yes/on) enable it.
+func betweennessForceExact() bool {
+	return envTruthy(os.Getenv("GRAFEL_BETWEENNESS_FORCE_EXACT"))
+}
+
+// envTruthy interprets an env-var value as a boolean without pulling strconv.
+func envTruthy(v string) bool {
+	switch v {
+	case "1", "t", "T", "true", "TRUE", "True", "yes", "YES", "Yes", "on", "ON", "On":
+		return true
+	}
+	return false
+}
+
+// logBetweennessPath emits a single stderr line recording which betweenness path
+// ran, so operators can confirm on large graphs whether the sampled
+// approximation (or a forced-exact override) was taken (#5692). It does not
+// affect on-disk output bytes — reproducible-build mode governs artifact
+// content, not process logs.
+func logBetweennessPath(p betweennessPath, nodes int) {
+	fmt.Fprintf(os.Stderr,
+		"grafel: betweenness path=%s nodes=%d sample_threshold=%d force_exact=%v\n",
+		p, nodes, betweennessSampleThresholdValue(), betweennessForceExact())
+}
+
 func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[string]float64, map[string]float64) {
 	betw := make(map[string]float64, idx.next)
 	pr := make(map[string]float64, idx.next)
@@ -645,13 +728,22 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 	}
 
 	// Betweenness — choose exact-weighted vs unweighted vs sampled by size.
+	// The selection is factored into chooseBetweennessPath so it is unit-testable
+	// and so operators can force exact computation via GRAFEL_BETWEENNESS_FORCE_EXACT
+	// (#5692 opt-out). Below the sampling threshold the behaviour is IDENTICAL to
+	// the pre-#5692 code; only very large graphs take the sampled path.
+	nodes := int(idx.next)
+	bpath := chooseBetweennessPath(nodes, betwennessNodeCount(idx), betweennessSampleThresholdValue(), betweennessForceExact())
+	logBetweennessPath(bpath, nodes)
+
 	var raw map[int64]float64
-	switch {
-	case int(idx.next) > betweennessSampleThresholdValue():
-		// Large group union (#5349 A4): exact Brandes is O(V·E) and scary on
-		// 28k+ nodes. Use the deterministic sampled-pivot approximation.
+	switch bpath {
+	case betweennessPathSampled:
+		// Large group union (#5349 A4 / #5692): exact Brandes is O(V·E) and the
+		// enrichment-bound cost (~240s on a 291k-node graph). Use the
+		// deterministic sampled-pivot approximation.
 		raw = sampledBetweenness(g, betweennessSampleSize, betweennessSampleSeed)
-	case int(idx.next) <= betwennessNodeCount(idx):
+	case betweennessPathExactWeighted:
 		// FloydWarshall is O(V^3) and precomputes all shortest paths; on
 		// graphs <= cutoff this is the most accurate option.
 		shortest, ok := path.FloydWarshall(g)
@@ -659,6 +751,8 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 			raw = network.BetweennessWeighted(g, shortest)
 		}
 	}
+	// betweennessPathExactBrandes (and any FloydWarshall failure above) falls
+	// through to the unweighted Brandes exact computation.
 	if raw == nil {
 		raw = network.Betweenness(g)
 	}

--- a/internal/graph/algorithms_betweenness_path_test.go
+++ b/internal/graph/algorithms_betweenness_path_test.go
@@ -1,0 +1,95 @@
+package graph
+
+import "testing"
+
+// TestChooseBetweennessPath is the #5692 gate: the pure selector must return
+// exact-weighted for tiny graphs, exact-brandes for mid-size graphs, sampled
+// above the sampling threshold, and must honour the force-exact opt-out (never
+// sample when forced). Below the threshold the choice is IDENTICAL to the
+// pre-#5692 behaviour (hard "small graphs unchanged" constraint).
+func TestChooseBetweennessPath(t *testing.T) {
+	const cutoff = 3000
+	const thresh = 8000
+	cases := []struct {
+		name       string
+		nodes      int
+		forceExact bool
+		want       betweennessPath
+	}{
+		{"tiny-exact-weighted", 100, false, betweennessPathExactWeighted},
+		{"cutoff-boundary-weighted", 3000, false, betweennessPathExactWeighted},
+		{"mid-exact-brandes", 5000, false, betweennessPathExactBrandes},
+		{"threshold-boundary-not-sampled", 8000, false, betweennessPathExactBrandes},
+		{"above-threshold-sampled", 9000, false, betweennessPathSampled},
+		{"large-sampled", 291000, false, betweennessPathSampled},
+		{"force-exact-overrides-sampling", 9000, true, betweennessPathExactBrandes},
+		{"force-exact-tiny-still-weighted", 100, true, betweennessPathExactWeighted},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := chooseBetweennessPath(tc.nodes, cutoff, thresh, tc.forceExact)
+			if got != tc.want {
+				t.Fatalf("chooseBetweennessPath(%d, %d, %d, %v) = %s, want %s",
+					tc.nodes, cutoff, thresh, tc.forceExact, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestChooseBetweennessPath_ThresholdDisabled verifies a non-positive sampling
+// threshold disables sampling entirely (falls back to exact), so the operator
+// can turn sampling off by setting a huge/zero threshold as well as via the
+// force-exact flag.
+func TestChooseBetweennessPath_ThresholdDisabled(t *testing.T) {
+	if got := chooseBetweennessPath(1_000_000, 3000, 0, false); got != betweennessPathExactBrandes {
+		t.Fatalf("sampleThreshold=0 should disable sampling: got %s, want exact-brandes", got)
+	}
+}
+
+// TestBetweennessForceExactEnv verifies GRAFEL_BETWEENNESS_FORCE_EXACT parsing.
+func TestBetweennessForceExactEnv(t *testing.T) {
+	truthy := []string{"1", "true", "TRUE", "yes", "on", "T"}
+	for _, v := range truthy {
+		t.Setenv("GRAFEL_BETWEENNESS_FORCE_EXACT", v)
+		if !betweennessForceExact() {
+			t.Errorf("GRAFEL_BETWEENNESS_FORCE_EXACT=%q should be truthy", v)
+		}
+	}
+	falsy := []string{"", "0", "false", "no", "off", "garbage"}
+	for _, v := range falsy {
+		t.Setenv("GRAFEL_BETWEENNESS_FORCE_EXACT", v)
+		if betweennessForceExact() {
+			t.Errorf("GRAFEL_BETWEENNESS_FORCE_EXACT=%q should be falsy", v)
+		}
+	}
+}
+
+// TestForceExactBypassesSamplingGate is the integration proof of the opt-out:
+// with a deliberately tiny sampling threshold that WOULD sample a 200-node
+// graph, setting GRAFEL_BETWEENNESS_FORCE_EXACT=1 makes ComputeCentrality
+// produce EXACTLY the same betweenness as an exact run (threshold raised out of
+// the way) — i.e. the force flag bypasses the gate and the sampled path never
+// runs.
+func TestForceExactBypassesSamplingGate(t *testing.T) {
+	ents, rels := buildSyntheticGraph(200, 4, 3)
+	g, idx := BuildGraph(ents, rels)
+
+	// Forced exact, despite a threshold (10) far below the node count (200).
+	t.Setenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD", "10")
+	t.Setenv("GRAFEL_BETWEENNESS_FORCE_EXACT", "1")
+	forced, _ := ComputeCentrality(g, idx)
+
+	// Plain exact: threshold raised above the node count, no force.
+	t.Setenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD", "100000")
+	t.Setenv("GRAFEL_BETWEENNESS_FORCE_EXACT", "0")
+	exact, _ := ComputeCentrality(g, idx)
+
+	if len(forced) != len(exact) {
+		t.Fatalf("key count mismatch: forced=%d exact=%d", len(forced), len(exact))
+	}
+	for id, want := range exact {
+		if got := forced[id]; got != want {
+			t.Fatalf("force-exact diverged from exact for %s: got %v want %v", id, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #5692. Completes #5692 (companion to the merged phase-timing PR #5699). (A) Betweenness: adds a testable `chooseBetweennessPath` selector + `GRAFEL_BETWEENNESS_FORCE_EXACT` opt-out + a per-run log, on top of the existing #5356 sampled-Brandes (>8k nodes). Below-threshold behavior byte-identical. (B) Extract concurrency: replaces the hard background cap of 4 with `backgroundConcurrency(numCPU,totalMemMB)` = min(clamp(numCPU/2,1,12), totalMemMB/512) — identical for ≤9-core+ample-RAM hosts, lifts on high-core boxes (the reporter's 10-core was capped to ~5), tightens under memory pressure (preserves #3648). Foreground + env knobs untouched. Reviewed: APPROVE-WITH-NITS; base verified non-divergent, clean. Refs #5681.