### PR TITLE
feat(mcp): model async triggers as inbound edges (DELIVERS_TO) so callers/impact/trace cross queues (#5686)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1737,6 +1737,20 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 		doc.Stats.Entities = len(doc.Entities)
 		doc.Stats.Relationships = len(doc.Relationships)
+
+		// Pass 7.6 — async-trigger edge synthesis (#5686). Runs after the
+		// event-flow walk so DELIVERS_TO trigger edges (topic → handler) live
+		// alongside the pub/sub edges. Gives async/event-driven handlers an
+		// inbound trigger so find_callers / impact_radius / trace no longer
+		// dead-end at the async boundary. Append-only, idempotent, CALLS-clean.
+		atStats := engine.ApplyAsyncTriggerEdges(doc)
+		if verbose() || atStats.DeliversEdges > 0 {
+			fmt.Fprintf(os.Stderr,
+				"grafel: async-trigger topics=%d delivers_edges=%d\n",
+				atStats.Topics, atStats.DeliversEdges)
+		}
+		doc.Stats.Entities = len(doc.Entities)
+		doc.Stats.Relationships = len(doc.Relationships)
 	}
 
 	// Pass 8 — module-level aggregation (issue #1383 / EPIC #1380).

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -342,6 +342,13 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 		// the Phase 3 companion-aware variant will swap in here.
 		_ = engine.RunEventFlow(doc, engine.DefaultEventFlowConfig())
 
+		// #5686 — re-synthesise async-trigger DELIVERS_TO edges. Idempotent:
+		// existing DELIVERS_TO edges survive stripProcessEntities, so this is a
+		// no-op unless a phantom-edge injection introduced a new same-repo
+		// subscription. Keeps the async inbound-trigger surface consistent with
+		// a full re-index.
+		_ = engine.ApplyAsyncTriggerEdges(doc)
+
 		// Update stats.
 		doc.Stats.Entities = len(doc.Entities)
 		doc.Stats.Relationships = len(doc.Relationships)

--- a/internal/engine/async_trigger_edges.go
+++ b/internal/engine/async_trigger_edges.go
@@ -1,0 +1,172 @@
+// Async-trigger edge synthesis (#5686).
+//
+// Async/event-driven handlers whose only trigger is a queue/topic subscription
+// carry an OUTBOUND SUBSCRIBES_TO edge (handler → topic) but no INBOUND edge.
+// As a result find_callers / impact_radius / trace all dead-end at the async
+// boundary: the handler looks like an orphan with zero production callers even
+// though it is triggered on every message delivered to the topic/queue it
+// subscribes to (SNS+SQS @SqsListener handlers, Go-Lambda SQS receive loops,
+// NATS subscribers, etc.).
+//
+// ApplyAsyncTriggerEdges is a PROJECT-SCOPE, APPEND-ONLY post-pass that runs
+// over the already-extracted topics + subscription edges. For every consumer
+// handler that SUBSCRIBES_TO a topic/queue, it emits the directional inverse —
+// a distinct DELIVERS_TO edge (topic → handler) — giving the handler an inbound
+// trigger edge. Combined with the existing inbound PUBLISHES_TO edge on the
+// topic, this completes the publisher → topic → handler chain so callers /
+// impact / trace can walk from a publisher (or the topic) into the handler.
+//
+// Design constraints:
+//   - Distinct kind, never CALLS. The pure call graph (process-flow BFS,
+//     calls/called_by) must stay clean. DELIVERS_TO surfaces only in the
+//     inbound/impact/trace/semantic-edge facets that already accept non-CALLS
+//     semantic edges.
+//   - No new extraction. The pass reads existing SUBSCRIBES_TO edges + topic
+//     entities; a handler with no SUBSCRIBES_TO edge is out of scope (nothing
+//     to invert).
+//   - Append-only + idempotent. Re-running never duplicates an edge and never
+//     modifies or removes existing entities/edges.
+//   - Intra-repo only. The cross-repo publisher↔subscriber join lives in the
+//     links topic pass (P7); this pass closes the SAME-repo async boundary that
+//     P7 skips (it requires ≥2 graphs).
+package engine
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// AsyncTriggerStats summarises one ApplyAsyncTriggerEdges run.
+type AsyncTriggerStats struct {
+	// Topics is the number of distinct topic/queue entities that had ≥1
+	// inbound SUBSCRIBES_TO handler.
+	Topics int
+	// DeliversEdges is the number of DELIVERS_TO edges newly synthesised.
+	DeliversEdges int
+}
+
+// asyncTriggerTopicKinds are the entity kinds that represent an async
+// delivery channel: a handler that SUBSCRIBES_TO one of these is triggered by
+// message delivery. Matched case-insensitively. Covers the broker MessageTopic
+// synthetics (kafka/sns/nats/pulsar/eventbridge/…), the SQS/RabbitMQ Queue
+// synthetics, and the managed event-bus event kind.
+var asyncTriggerTopicKinds = map[string]bool{
+	strings.ToUpper("SCOPE.MessageTopic"):  true,
+	strings.ToUpper("SCOPE.Queue"):         true,
+	strings.ToUpper("SCOPE.EventBusEvent"): true,
+}
+
+func isAsyncTriggerTopicKind(kind string) bool {
+	return asyncTriggerTopicKinds[strings.ToUpper(kind)]
+}
+
+// ApplyAsyncTriggerEdges synthesises DELIVERS_TO edges (topic → handler) for
+// every SUBSCRIBES_TO edge (handler → topic) whose target is a known async
+// topic/queue entity in `doc`. Edges are appended to doc in place. Safe to call
+// on a doc with no subscription edges (returns an empty stats record).
+func ApplyAsyncTriggerEdges(doc *graph.Document) AsyncTriggerStats {
+	stats := AsyncTriggerStats{}
+	if doc == nil {
+		return stats
+	}
+
+	// Index topic/queue entities by ID so we only invert subscriptions whose
+	// target is a real async channel (never a stray SUBSCRIBES_TO into a
+	// non-topic node).
+	topicIDs := make(map[string]bool)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if isAsyncTriggerTopicKind(e.Kind) {
+			topicIDs[e.ID] = true
+		}
+	}
+	if len(topicIDs) == 0 {
+		return stats
+	}
+
+	// Pre-record every existing DELIVERS_TO edge so re-runs are idempotent and
+	// duplicate SUBSCRIBES_TO edges (same handler+topic) collapse to one.
+	const deliversKind = string(types.RelationshipKindDeliversTo)
+	existing := make(map[string]bool)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if strings.EqualFold(r.Kind, deliversKind) {
+			existing[r.FromID+"\x00"+r.ToID] = true
+		}
+	}
+
+	// Collect (topic, handler) pairs from SUBSCRIBES_TO edges, deduped. Sorted
+	// for deterministic emission order.
+	type pair struct {
+		topicID   string
+		handlerID string
+		props     map[string]string
+	}
+	seenPair := make(map[string]bool)
+	topicsWithSub := make(map[string]bool)
+	var pairs []pair
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if !strings.EqualFold(r.Kind, string(types.RelationshipKindSubscribesTo)) {
+			continue
+		}
+		if r.FromID == "" || r.ToID == "" {
+			continue
+		}
+		// SUBSCRIBES_TO points handler(From) → topic(To). Only invert when the
+		// target is a recognised async topic/queue entity.
+		if !topicIDs[r.ToID] {
+			continue
+		}
+		key := r.ToID + "\x00" + r.FromID
+		if seenPair[key] {
+			continue
+		}
+		seenPair[key] = true
+		topicsWithSub[r.ToID] = true
+		pairs = append(pairs, pair{topicID: r.ToID, handlerID: r.FromID, props: r.Properties})
+	}
+	stats.Topics = len(topicsWithSub)
+
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].topicID != pairs[j].topicID {
+			return pairs[i].topicID < pairs[j].topicID
+		}
+		return pairs[i].handlerID < pairs[j].handlerID
+	})
+
+	for _, p := range pairs {
+		dedupKey := p.topicID + "\x00" + p.handlerID
+		if existing[dedupKey] {
+			continue
+		}
+		existing[dedupKey] = true
+
+		props := map[string]string{
+			"pattern_type": "async_trigger_synthesis",
+			"trigger":      "async",
+			"synthesized":  "true",
+		}
+		// Carry broker / messaging_layer context from the originating
+		// SUBSCRIBES_TO edge so the trigger reads coherently in inspect/expand.
+		for _, k := range []string{"broker", "messaging_layer", "queue_url", "queue_name"} {
+			if v, ok := p.props[k]; ok && v != "" {
+				props[k] = v
+			}
+		}
+
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:         graph.RelationshipID(p.topicID, p.handlerID, deliversKind),
+			FromID:     p.topicID,
+			ToID:       p.handlerID,
+			Kind:       deliversKind,
+			Properties: props,
+		})
+		stats.DeliversEdges++
+	}
+
+	return stats
+}

--- a/internal/engine/async_trigger_edges_test.go
+++ b/internal/engine/async_trigger_edges_test.go
@@ -1,0 +1,122 @@
+// Tests for the async-trigger edge-synthesis pass (#5686).
+//
+// Async/event-driven handlers whose only trigger is a queue/topic
+// subscription carry an OUTBOUND SUBSCRIBES_TO edge (handler → topic) but
+// no INBOUND edge, so callers/impact/trace dead-end at the async boundary.
+// ApplyAsyncTriggerEdges synthesises a distinct DELIVERS_TO edge
+// (topic → handler) that gives the handler an inbound trigger and completes
+// the publisher → topic → handler chain without polluting the CALLS graph.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildAsyncTriggerDoc builds a minimal SNS/SQS-shaped graph:
+//
+//	Publisher.publish --PUBLISHES_TO--> sqs:orders  <--SUBSCRIBES_TO-- Consumer.onOrder
+//
+// Both edges point AT the topic, so before the synthesis pass the consumer
+// handler has zero inbound edges (the reporter's dead-end).
+func buildAsyncTriggerDoc(repo string) *graph.Document {
+	doc := &graph.Document{Repo: repo}
+	doc.Entities = []graph.Entity{
+		{ID: "op:publish", Name: "Publisher.publish", Kind: "SCOPE.Operation", Language: "java", SourceFile: "Publisher.java"},
+		{ID: "op:onOrder", Name: "Consumer.onOrder", Kind: "SCOPE.Operation", Language: "java", SourceFile: "Consumer.java"},
+		{ID: "topic:orders", Name: "sqs:orders", Kind: "SCOPE.Queue", Language: "java", SourceFile: ""},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "pub:1", FromID: "op:publish", ToID: "topic:orders", Kind: "PUBLISHES_TO",
+			Properties: map[string]string{"broker": "sqs"}},
+		{ID: "sub:1", FromID: "op:onOrder", ToID: "topic:orders", Kind: "SUBSCRIBES_TO",
+			Properties: map[string]string{"broker": "sqs", "messaging_layer": "spring_sqs"}},
+	}
+	return doc
+}
+
+func inboundEdges(doc *graph.Document, toID string) []graph.Relationship {
+	var out []graph.Relationship
+	for _, r := range doc.Relationships {
+		if r.ToID == toID {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// TestApplyAsyncTriggerEdges_HandlerHasNoInboundBefore documents the pre-fix
+// dead-end: the consumer handler has NO inbound edge, so callers/impact/trace
+// cannot reach it.
+func TestApplyAsyncTriggerEdges_HandlerHasNoInboundBefore(t *testing.T) {
+	doc := buildAsyncTriggerDoc("fixture-async")
+	if in := inboundEdges(doc, "op:onOrder"); len(in) != 0 {
+		t.Fatalf("precondition: consumer handler should have 0 inbound edges before synthesis, got %d: %+v", len(in), in)
+	}
+}
+
+// TestApplyAsyncTriggerEdges_EmitsDeliversTo asserts the pass synthesises
+// exactly one DELIVERS_TO edge topic → handler (giving the handler an inbound
+// trigger), and does NOT emit any CALLS edge.
+func TestApplyAsyncTriggerEdges_EmitsDeliversTo(t *testing.T) {
+	doc := buildAsyncTriggerDoc("fixture-async")
+	stats := ApplyAsyncTriggerEdges(doc)
+	if stats.DeliversEdges != 1 {
+		t.Fatalf("expected 1 DELIVERS_TO edge, got %d", stats.DeliversEdges)
+	}
+
+	in := inboundEdges(doc, "op:onOrder")
+	if len(in) != 1 {
+		t.Fatalf("expected consumer handler to have exactly 1 inbound edge after synthesis, got %d: %+v", len(in), in)
+	}
+	e := in[0]
+	if e.Kind != asyncDeliversToKindLiteral {
+		t.Fatalf("inbound edge kind = %q, want DELIVERS_TO", e.Kind)
+	}
+	if e.FromID != "topic:orders" {
+		t.Fatalf("DELIVERS_TO FromID = %q, want topic:orders", e.FromID)
+	}
+	if e.ToID != "op:onOrder" {
+		t.Fatalf("DELIVERS_TO ToID = %q, want op:onOrder", e.ToID)
+	}
+
+	// Hard constraint: no CALLS edge synthesised (pure call graph stays clean).
+	for _, r := range doc.Relationships {
+		if r.Kind == "CALLS" {
+			t.Fatalf("pass must not emit CALLS edges; found %+v", r)
+		}
+	}
+
+	// The publisher → topic → handler chain is now fully connected inbound:
+	// handler's inbound is the topic; topic's inbound is the publisher.
+	topicIn := inboundEdges(doc, "topic:orders")
+	var sawPub bool
+	for _, r := range topicIn {
+		if r.Kind == "PUBLISHES_TO" && r.FromID == "op:publish" {
+			sawPub = true
+		}
+	}
+	if !sawPub {
+		t.Fatalf("expected topic to retain inbound PUBLISHES_TO from publisher; inbound=%+v", topicIn)
+	}
+}
+
+// TestApplyAsyncTriggerEdges_Idempotent verifies re-running the pass does not
+// duplicate DELIVERS_TO edges.
+func TestApplyAsyncTriggerEdges_Idempotent(t *testing.T) {
+	doc := buildAsyncTriggerDoc("fixture-async")
+	ApplyAsyncTriggerEdges(doc)
+	before := len(doc.Relationships)
+	stats := ApplyAsyncTriggerEdges(doc)
+	if stats.DeliversEdges != 0 {
+		t.Fatalf("second run should synthesise 0 new edges, got %d", stats.DeliversEdges)
+	}
+	if len(doc.Relationships) != before {
+		t.Fatalf("relationship count changed on re-run: before=%d after=%d", before, len(doc.Relationships))
+	}
+}
+
+// asyncDeliversToKindLiteral mirrors types.RelationshipKindDeliversTo so this
+// test stays in the engine package without importing types for one constant.
+const asyncDeliversToKindLiteral = "DELIVERS_TO"

--- a/internal/mcp/async_trigger_5686_test.go
+++ b/internal/mcp/async_trigger_5686_test.go
@@ -1,0 +1,127 @@
+package mcp
+
+// Async-trigger caller/impact/trace surfacing (#5686).
+//
+// An async/event-driven handler whose only trigger is a queue/topic
+// subscription previously had ZERO inbound edges: find_callers, impact_radius
+// and trace all dead-ended at the async boundary. engine.ApplyAsyncTriggerEdges
+// synthesises a DELIVERS_TO edge (topic → handler); these tests assert the MCP
+// read tools traverse it.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildAsyncTriggerGraph mirrors the engine fixture but as a graph the MCP
+// server can load. The DELIVERS_TO edge is what ApplyAsyncTriggerEdges emits:
+//
+//	Publisher.publish --PUBLISHES_TO--> sqs:orders --DELIVERS_TO--> Consumer.onOrder
+//	Consumer.onOrder  --SUBSCRIBES_TO--> sqs:orders
+func buildAsyncTriggerGraph(withDelivers bool) *graph.Document {
+	rels := []graph.Relationship{
+		{ID: "pub:1", FromID: "op:publish", ToID: "topic:orders", Kind: "PUBLISHES_TO"},
+		{ID: "sub:1", FromID: "op:onOrder", ToID: "topic:orders", Kind: "SUBSCRIBES_TO"},
+	}
+	if withDelivers {
+		rels = append(rels, graph.Relationship{
+			ID: "del:1", FromID: "topic:orders", ToID: "op:onOrder", Kind: "DELIVERS_TO",
+			Properties: map[string]string{"trigger": "async", "broker": "sqs"},
+		})
+	}
+	return minDoc(
+		[]graph.Entity{
+			{ID: "op:publish", Name: "Publisher.publish", Kind: "SCOPE.Operation", SourceFile: "pub.java", StartLine: 10, QualifiedName: "Publisher.publish"},
+			{ID: "op:onOrder", Name: "Consumer.onOrder", Kind: "SCOPE.Operation", SourceFile: "consumer.java", StartLine: 20, QualifiedName: "Consumer.onOrder"},
+			{ID: "topic:orders", Name: "sqs:orders", Kind: "SCOPE.Queue", SourceFile: ""},
+		},
+		rels,
+	)
+}
+
+// TestAsyncTrigger_FindCallers_DeadEndBeforeSynthesis is the RED assertion:
+// without the DELIVERS_TO edge the handler has no callers.
+func TestAsyncTrigger_FindCallers_DeadEndBeforeSynthesis(t *testing.T) {
+	srv := newTestServer(t, buildAsyncTriggerGraph(false))
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "op:onOrder",
+		"depth":     float64(2),
+	})
+	callers, _ := out["callers"].([]any)
+	if len(callers) != 0 {
+		t.Fatalf("pre-synthesis: expected async handler to have 0 callers (dead-end), got %d: %+v", len(callers), callers)
+	}
+}
+
+// TestAsyncTrigger_FindCallers_SurfacesTopicAndPublisher is the GREEN
+// assertion: with DELIVERS_TO, find_callers reaches the topic (depth 1) and the
+// publisher (depth 2, via the topic's inbound PUBLISHES_TO).
+func TestAsyncTrigger_FindCallers_SurfacesTopicAndPublisher(t *testing.T) {
+	srv := newTestServer(t, buildAsyncTriggerGraph(true))
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "op:onOrder",
+		"depth":     float64(2),
+	})
+	callers, _ := out["callers"].([]any)
+	names := map[string]bool{}
+	for _, c := range callers {
+		m := c.(map[string]any)
+		names[m["name"].(string)] = true
+	}
+	if !names["sqs:orders"] {
+		t.Errorf("expected topic sqs:orders as an inbound trigger (caller), got %+v", names)
+	}
+	if !names["Publisher.publish"] {
+		t.Errorf("expected publisher Publisher.publish reachable via topic at depth 2, got %+v", names)
+	}
+}
+
+// TestAsyncTrigger_ImpactRadius_CrossesAsyncBoundary asserts impact_radius no
+// longer dead-ends at the async handler. impact_radius walks INBOUND (what is
+// affected if this entity changes); before synthesis the handler had zero
+// inbound edges and returned an empty blast radius. With DELIVERS_TO the walk
+// crosses the async boundary into the topic and (transitively) the publisher.
+func TestAsyncTrigger_ImpactRadius_CrossesAsyncBoundary(t *testing.T) {
+	// Before: empty blast radius (dead-end).
+	srvBefore := newTestServer(t, buildAsyncTriggerGraph(false))
+	outBefore := callFlowTool(t, srvBefore.handleImpactRadius, map[string]any{
+		"entity_id": "op:onOrder",
+		"hops":      float64(3),
+	})
+	if before, _ := outBefore["affected"].([]any); len(before) != 0 {
+		t.Fatalf("pre-synthesis: async handler impact_radius should be empty (dead-end), got %+v", before)
+	}
+
+	// After: reaches the topic and the publisher across the async boundary.
+	srv := newTestServer(t, buildAsyncTriggerGraph(true))
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "op:onOrder",
+		"hops":      float64(3),
+	})
+	affected, _ := out["affected"].([]any)
+	names := map[string]bool{}
+	for _, a := range affected {
+		m := a.(map[string]any)
+		names[m["name"].(string)] = true
+	}
+	if !names["sqs:orders"] {
+		t.Errorf("impact_radius on async handler should surface topic sqs:orders across the boundary; got %+v", names)
+	}
+	if !names["Publisher.publish"] {
+		t.Errorf("impact_radius on async handler should reach publisher transitively; got %+v", names)
+	}
+}
+
+// TestAsyncTrigger_Trace_PublisherToHandler asserts a shortest-path trace from
+// the publisher to the handler completes through topic --DELIVERS_TO--> handler.
+func TestAsyncTrigger_Trace_PublisherToHandler(t *testing.T) {
+	srv := newTestServer(t, buildAsyncTriggerGraph(true))
+	out := callFlowTool(t, srv.handleShortestPath, map[string]any{
+		"source": "op:publish",
+		"target": "op:onOrder",
+	})
+	if found, _ := out["found"].(bool); !found {
+		t.Fatalf("trace publisher→handler should complete via DELIVERS_TO; got not found: %+v", out)
+	}
+}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -1760,6 +1760,11 @@ var inboundRefKinds = map[string]bool{
 	"STEP_IN_PROCESS": true,
 	"PRODUCES":        true,
 	"CONSUMES":        true,
+	// #5686: DELIVERS_TO (topic → handler) is the async-trigger inverse of
+	// SUBSCRIBES_TO. A handler with an inbound DELIVERS_TO is triggered by
+	// message delivery — a genuine inbound reference, so it must count as
+	// "used" (not dead code) and surface in the inbound reference walks.
+	"DELIVERS_TO": true,
 }
 
 // inboundNeighborStructuralKinds are edge kinds that carry NO predecessor /

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1527,7 +1527,15 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 	rels := lr.Doc.Relationships
 	byID := lr.getByID()
 	for _, ed := range lr.getAdjacency().Incoming(e.ID) {
-		if !strings.EqualFold(ed.kind, "CALLS") {
+		// #5686: besides direct CALLS callers, surface the async trigger of an
+		// event-driven handler. A DELIVERS_TO edge (topic → handler) is the
+		// synthesised inverse of SUBSCRIBES_TO; without it, an @SqsListener /
+		// Lambda-SQS / NATS handler shows ZERO callers in inspect. Rows carry
+		// trigger="async" so a consumer can tell a message-delivery trigger from
+		// a direct call.
+		isCall := strings.EqualFold(ed.kind, "CALLS")
+		isAsync := strings.EqualFold(ed.kind, string(types.RelationshipKindDeliversTo))
+		if !isCall && !isAsync {
 			continue
 		}
 		callerID := ed.target // Incoming: ed.target is the FromID (the caller)
@@ -1546,6 +1554,10 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 		entry := map[string]any{
 			"source":      sourceID,
 			"source_path": sourcePath,
+		}
+		if isAsync {
+			entry["trigger"] = "async"
+			entry["edge_kind"] = string(types.RelationshipKindDeliversTo)
 		}
 
 		lineNum := 0
@@ -1692,14 +1704,21 @@ var semanticEdgeKinds = map[string]struct{}{
 	string(types.RelationshipKindEnqueues):         {},
 	string(types.RelationshipKindPublishesTo):      {},
 	string(types.RelationshipKindSubscribesTo):     {},
-	string(types.RelationshipKindCaches):           {},
-	string(types.RelationshipKindInvalidates):      {},
-	string(types.RelationshipKindGatedBy):          {},
-	string(types.RelationshipKindHandlesCommand):   {},
-	string(types.RelationshipKindDataFlowsTo):      {},
-	string(types.RelationshipKindInjectedInto):     {},
-	string(types.RelationshipKindBinds):            {},
-	string(types.RelationshipKindDependsOnConfig):  {},
+	// #5686: async-trigger delivery edge (topic → handler), synthesised as the
+	// inverse of SUBSCRIBES_TO by engine.ApplyAsyncTriggerEdges. Projecting it
+	// here makes find_callers / neighbors(direction=in) surface the topic (and,
+	// transitively, the publisher) as an inbound trigger of an async handler
+	// that previously looked like an orphan. inspect lists it under
+	// semantic_edges and neighbors annotates rows with semantic_kind=DELIVERS_TO.
+	string(types.RelationshipKindDeliversTo):      {},
+	string(types.RelationshipKindCaches):          {},
+	string(types.RelationshipKindInvalidates):     {},
+	string(types.RelationshipKindGatedBy):         {},
+	string(types.RelationshipKindHandlesCommand):  {},
+	string(types.RelationshipKindDataFlowsTo):     {},
+	string(types.RelationshipKindInjectedInto):    {},
+	string(types.RelationshipKindBinds):           {},
+	string(types.RelationshipKindDependsOnConfig): {},
 	// #4307 (Layer 1 of epic #4294): the documentation-link edge emitted by the
 	// markdown ingest pass (SCOPE.Section --MENTIONS--> code entity). It is a
 	// genuine semantic relation ("this code is documented in that section"), not

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -584,6 +584,29 @@ const (
 	RelationshipKindSubscribesTo RelationshipKind = "SUBSCRIBES_TO"
 	RelationshipKindTransforms   RelationshipKind = "TRANSFORMS"
 
+	// #5686: async-trigger delivery edge. Synthesised intra-repo by
+	// engine.ApplyAsyncTriggerEdges as the DIRECTIONAL INVERSE of a
+	// SUBSCRIBES_TO edge: for every consumer handler that SUBSCRIBES_TO a
+	// topic/queue, the pass emits DELIVERS_TO from the topic → handler.
+	//
+	//   PUBLISHES_TO  : producer  → topic     (extractor, unchanged)
+	//   SUBSCRIBES_TO : handler   → topic     (extractor, unchanged)
+	//   DELIVERS_TO   : topic     → handler   (synthesised inbound trigger)
+	//
+	// Purpose: async/event-driven handlers whose only trigger is a queue/topic
+	// subscription previously had ZERO inbound edges, so find_callers,
+	// impact_radius and trace all dead-ended at the async boundary (the handler
+	// looked like an orphan with no production callers). DELIVERS_TO gives the
+	// handler an inbound trigger edge and — combined with the existing inbound
+	// PUBLISHES_TO on the topic — completes the publisher → topic → handler
+	// chain for inbound/impact/trace traversal.
+	//
+	// It is deliberately a DISTINCT kind (not CALLS): the pure call graph
+	// (process-flow BFS, calls/called_by) must stay clean. DELIVERS_TO surfaces
+	// only in the inbound/impact/trace/semantic-edge facets that already accept
+	// non-CALLS semantic edges.
+	RelationshipKindDeliversTo RelationshipKind = "DELIVERS_TO"
+
 	// #727: Real-time event channel edges. Emitted by the engine-layer
 	// synthesizers in internal/engine/{websocket_edges,sse_edges,
 	// graphql_subscriptions}.go. All append-only — they never replace or


### PR DESCRIPTION
Closes #5686. Reporter's #1 gap: SNS/SQS/@SqsListener + Go-Lambda async handlers showed ZERO production callers (SUBSCRIBES_TO points handler→topic, so handlers had no inbound trigger edge). New `DELIVERS_TO` (topic→handler) synthesized intra-repo (Pass 7.6), inverting SUBSCRIBES_TO for topic/queue/eventbus targets only; threaded into semantic/inbound/impact/trace/inspect facets (tagged trigger=async). Never touches the pure CALLS graph. Idempotent/append-only. find_callers now surfaces topic(hop1)+publisher(hop2); impact_radius & trace cross the async boundary. Reviewed: APPROVE-WITH-NITS. Refs #5681.