### PR TITLE
fix(wizard): capture agent selection so only chosen adapters are scaffolded (#5701)

### DIFF
--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -42,6 +43,7 @@ func newGroupAddCmd() *cobra.Command {
 		runInst   bool
 		doIndex   bool
 		jsonOut   bool
+		toolsCSV  string
 	)
 
 	cmd := &cobra.Command{
@@ -84,6 +86,7 @@ Examples:
 				runInst:   runInst,
 				doIndex:   doIndex,
 				jsonOut:   jsonOut,
+				tools:     toolsCSV,
 			}
 			return runGroupAddImpl(cmd, args[0], gaFlags, "")
 		},
@@ -109,6 +112,8 @@ Examples:
 		"index the group via the daemon after registering (requires a running daemon)")
 	cmd.Flags().BoolVar(&jsonOut, "json", false,
 		"emit machine-readable JSON result")
+	cmd.Flags().StringVar(&toolsCSV, "tools", "",
+		"comma-separated AI coding tools whose rules files + MCP get scaffolded (e.g. claude,codex). When omitted, a pending selection from a prior `grafel install --tools` is adopted, else every supported tool is targeted. Run 'grafel tools list' for valid IDs")
 	return cmd
 }
 
@@ -123,6 +128,7 @@ type groupAddFlags struct {
 	runInst   bool
 	doIndex   bool
 	jsonOut   bool
+	tools     string // --tools CSV → GroupConfig.Tools (#5701)
 }
 
 type groupAddRepo struct {
@@ -161,6 +167,17 @@ func runGroupAddImpl(cmd *cobra.Command, group string, f groupAddFlags, socketPa
 	cfg := &registry.GroupConfig{Name: group, GroupDocs: f.groupDocs}
 	cfg.Features.Watchers = f.watchers
 	cfg.Features.GitHooks = f.gitHooks
+	// Per-tool selection (#5701): an explicit --tools value wins and is validated
+	// before any registration. When omitted, cfg.Tools is left empty so
+	// applyGroupConfig can adopt a pending selection stashed by an earlier
+	// `grafel install --tools`; absent that, the empty-means-all default applies.
+	if f.tools != "" {
+		ids, err := tooladapter.ParseToolsFlag(f.tools)
+		if err != nil {
+			return err
+		}
+		cfg.Tools = ids
+	}
 	for _, r := range repos {
 		cfg.Repos = append(cfg.Repos, registry.Repo{
 			Slug:  r.Slug,

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -371,7 +371,15 @@ func persistToolSelection(out io.Writer, ids []string) error {
 		return fmt.Errorf("read registry: %w", err)
 	}
 	if len(groups) == 0 {
-		fmt.Fprintf(out, "  tools:   %v (saved on first group registration)\n", ids)
+		// #5701 ordering footgun: no group exists yet, so there is nothing to
+		// write Tools into. Stash the selection so the next `wizard`/`group add`
+		// picks it up (consumePendingTools in applyGroupConfig) instead of
+		// silently dropping it and re-defaulting to all tools.
+		if err := savePendingTools(ids); err != nil {
+			fmt.Fprintf(out, "  ⚠ tools: could not stash selection: %v\n", err)
+			return nil
+		}
+		fmt.Fprintf(out, "  tools:   %v (stashed; applied on first group registration)\n", ids)
 		return nil
 	}
 	bin, _ := os.Executable()

--- a/internal/cli/pendingtools.go
+++ b/internal/cli/pendingtools.go
@@ -1,0 +1,81 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// pending_tools.json stashes a per-tool selection made by `grafel install
+// --tools` (or its picker) BEFORE any group exists. Historically that
+// selection was dropped on the floor (install.go printed "saved on first group
+// registration" but persisted nothing), so the very next `wizard`/`group add`
+// re-defaulted to all-tools and scaffolded rules folders + MCP for every
+// adapter — the #5701 ordering footgun. We now persist the intent here and the
+// next group registration consumes it (see applyGroupConfig).
+const pendingToolsFile = "pending_tools.json"
+
+// pendingToolsPath returns the path to the pending-selection file under the
+// grafel home dir.
+func pendingToolsPath() (string, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, pendingToolsFile), nil
+}
+
+// savePendingTools writes ids as the pending per-tool selection. ids is assumed
+// already validated/normalized (registry-order adapter IDs).
+func savePendingTools(ids []string) error {
+	p, err := pendingToolsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(struct {
+		Tools []string `json:"tools"`
+	}{Tools: ids}, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := p + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, p)
+}
+
+// consumePendingTools reads and DELETES the pending selection, returning the
+// normalized adapter IDs (nil when none/invalid). It is deliberately best-
+// effort: a missing or malformed file yields nil with no error, and the file is
+// removed once read so a stashed selection is applied to exactly one group.
+func consumePendingTools() []string {
+	p, err := pendingToolsPath()
+	if err != nil {
+		return nil
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	// Consume: remove regardless of parse outcome so a corrupt file can't wedge
+	// every future group registration.
+	_ = os.Remove(p)
+	var doc struct {
+		Tools []string `json:"tools"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return nil
+	}
+	ids := tooladapter.NormalizeSelection(doc.Tools)
+	if len(ids) == 0 {
+		return nil
+	}
+	return ids
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/mcptools"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -34,6 +35,7 @@ func newWizardCmd() *cobra.Command {
 		noIndex        bool
 		mcpToolsCSV    string
 		noMCP          bool
+		toolsCSV       string
 	)
 	cmd := &cobra.Command{
 		Use:   "wizard",
@@ -53,6 +55,7 @@ func newWizardCmd() *cobra.Command {
 				AgentHooks:     agentHooks,
 				RunInstall:     runInstall,
 				NoIndex:        noIndex,
+				Tools:          toolsCSV,
 				ErrOut:         cmd.ErrOrStderr(),
 			}
 			// Resolve the MCP-tools selection from flags (#5344). --no-mcp wins
@@ -83,6 +86,7 @@ func newWizardCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&noIndex, "no-index", false, "skip indexing the group at the end (default: index with live progress; requires a running daemon)")
 	cmd.Flags().StringVar(&mcpToolsCSV, "mcp-tools", "", "comma-separated AI tool IDs to register the grafel MCP server in (e.g. claude,cursor); skips the interactive picker. Without this flag (and without --no-mcp), interactive runs prompt and non-interactive runs register every detected tool")
 	cmd.Flags().BoolVar(&noMCP, "no-mcp", false, "do not register the grafel MCP server in any AI tool")
+	cmd.Flags().StringVar(&toolsCSV, "tools", "", "comma-separated AI coding tools whose rules files + MCP get scaffolded (e.g. claude,codex); when set, selection is non-interactive. Without it, interactive runs prompt and non-interactive runs target every supported tool. Run 'grafel tools list' for valid IDs")
 	return cmd
 }
 
@@ -97,6 +101,12 @@ type wizardOptions struct {
 	AgentHooks          bool
 	RunInstall          bool
 	NoIndex             bool
+	// Tools is the raw --tools CSV: the AI coding tools whose install artifacts
+	// (rules files + MCP) get scaffolded, persisted into GroupConfig.Tools
+	// (#5701). Empty means "no explicit choice": interactive runs prompt, non-
+	// interactive runs leave Tools empty so the historical empty-means-all
+	// contract at the Apply boundary is preserved.
+	Tools string
 	// MCPTools, when non-nil, is the resolved selection of AI tool IDs to
 	// register the grafel MCP server in (#5344): nil = no explicit choice
 	// (prompt interactively, or all-detected non-interactively), empty = none,
@@ -119,6 +129,19 @@ func runWizard(out io.Writer, opts wizardOptions) error {
 	cfg.Features.GitHooks = opts.GitHooks
 	cfg.Features.AgentHooks = opts.AgentHooks
 	cfg.GroupDocs = opts.GroupDocs
+
+	// Per-tool selection (#5701): an explicit --tools value wins in every path
+	// (interactive TUI, huh fallback, or non-interactive) and is validated up
+	// front so a bad ID fails before anything is registered. When absent, the
+	// interactive huh fallback prompts (see finishWizard) and non-interactive
+	// runs leave Tools empty (empty-means-all back-compat at Apply).
+	if opts.Tools != "" {
+		ids, err := tooladapter.ParseToolsFlag(opts.Tools)
+		if err != nil {
+			return err
+		}
+		cfg.Tools = ids
+	}
 
 	// NON-INTERACTIVE path (--repos/--parent/--exclude): unchanged flag-driven
 	// discovery, for scripting. Requires --group up front.
@@ -235,6 +258,18 @@ func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) 
 		cfg.GroupDocs = opts.GroupDocs
 	}
 
+	// Step 4a — choose which AI coding tools get their install artifacts (rules
+	// files + MCP) scaffolded (#5701). Only prompt when no explicit --tools was
+	// given (cfg.Tools already set) and we are interactive; the non-interactive
+	// path leaves cfg.Tools empty so the empty-means-all contract is preserved.
+	if len(cfg.Tools) == 0 && !opts.NonInteractive {
+		ids, err := promptTools()
+		if err != nil {
+			return err
+		}
+		cfg.Tools = ids
+	}
+
 	// Step 4b — choose which AI tools get the grafel MCP server (#5344). Only
 	// prompt interactively when no explicit selection was passed via flags. The
 	// non-interactive path leaves opts.MCPTools as-is (nil → all detected).
@@ -304,6 +339,44 @@ func promptMCPTools() (*[]string, error) {
 	return &selected, nil
 }
 
+// promptTools runs the per-tool enablement picker (#5701), mirroring
+// runToolWizard: every supported adapter is offered as a checkbox, pre-checked
+// when DetectInstalled() flagged it, and the toggled set is normalized to
+// registry-order adapter IDs. Returning an empty slice (the user unchecked
+// everything) is treated as "no explicit choice" — so the empty-means-all
+// contract at the Apply boundary is preserved rather than scaffolding nothing.
+//
+// It is a package var so both the huh (non-TTY) fallback AND the alt-screen TUI
+// (which invokes it just before entering the full-screen program) drive the
+// SAME picker, and so tests can inject a selection without a real terminal.
+var promptTools = func() ([]string, error) {
+	choices := tooladapter.WizardChoices(nil)
+	opts := make([]huh.Option[string], 0, len(choices))
+	var preselected []string
+	for _, c := range choices {
+		label := c.DisplayName
+		if c.Detected {
+			label += " (detected)"
+		}
+		opts = append(opts, huh.NewOption(label, c.ID).Selected(c.PreChecked))
+		if c.PreChecked {
+			preselected = append(preselected, c.ID)
+		}
+	}
+	selected := append([]string{}, preselected...)
+	if err := huh.NewMultiSelect[string]().
+		Title("AI coding tools to target").
+		Description("Rules files + MCP are scaffolded only for the tools you check.\n" + navHintMulti).
+		Options(opts...).
+		Height(wizardListHeight(len(opts))).
+		Value(&selected).
+		WithTheme(wizardTheme()).
+		Run(); err != nil {
+		return nil, err
+	}
+	return tooladapter.NormalizeSelection(selected), nil
+}
+
 // maybeIndexGroup indexes group with live progress unless noIndex is set. A
 // daemon-not-running condition is downgraded to a warning so the wizard still
 // completes successfully (the group is already registered).
@@ -346,6 +419,17 @@ type groupApplyOptions struct {
 // report or serialize what was written. Idempotent: re-running updates the
 // registry entry in place and overwrites the config atomically.
 func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOptions) (*install.Result, error) {
+	// #5701 ordering footgun: if this group has no explicit tool selection yet,
+	// adopt any pending one stashed by an earlier `grafel install --tools` that
+	// ran before any group existed. Consumed once (the file is deleted on read),
+	// so it applies to exactly the first group registered afterwards.
+	if len(cfg.Tools) == 0 {
+		if pending := consumePendingTools(); len(pending) > 0 {
+			cfg.Tools = pending
+			fmt.Fprintf(out, "applied stashed tool selection: %v\n", pending)
+		}
+	}
+
 	cfgPath, err := registry.ConfigPathFor(cfg.Name)
 	if err != nil {
 		return nil, err

--- a/internal/cli/wizard_tools_test.go
+++ b/internal/cli/wizard_tools_test.go
@@ -1,0 +1,277 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// enabledIDs resolves the effective adapter IDs for a config via the same
+// enablement path install.Apply uses, so asserting on it proves exactly which
+// adapters would be scaffolded (rules folders + MCP).
+func enabledIDs(cfg *registry.GroupConfig) []string {
+	var out []string
+	for _, a := range tooladapter.EnabledAdapters(cfg) {
+		out = append(out, a.ID())
+	}
+	return out
+}
+
+// TestWizard_ToolsFlagRestrictsSelection is the missing wizard→subset coverage
+// (#5701): a non-interactive wizard run with --tools claude,codex must persist
+// exactly {claude,codex} into GroupConfig.Tools and scaffold ONLY those two
+// adapters — none of kiro/codium/cursor/windsurf/copilot/antigravity.
+func TestWizard_ToolsFlagRestrictsSelection(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	out := &bytes.Buffer{}
+	err := runWizard(out, wizardOptions{
+		NonInteractive: true,
+		GroupName:      "demo",
+		ReposCSV:       repoA,
+		Tools:          "claude,codex",
+		Watchers:       false,
+		GitHooks:       true,
+		RunInstall:     true,
+	})
+	if err != nil {
+		t.Fatalf("wizard: %v\n%s", err, out.String())
+	}
+
+	cfg := loadCfg(t, "demo")
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude", "codex"}) {
+		t.Fatalf("persisted Tools = %v, want [claude codex]", cfg.Tools)
+	}
+	if got := enabledIDs(cfg); !reflect.DeepEqual(got, []string{"claude", "codex"}) {
+		t.Fatalf("enabled adapters = %v, want only [claude codex]", got)
+	}
+}
+
+// TestWizard_NoToolsFlagPreservesDefaultAll documents the non-interactive
+// default: with no --tools the historical empty-means-all contract is kept
+// (Tools stays empty; EnabledTools falls back to every adapter).
+func TestWizard_NoToolsFlagPreservesDefaultAll(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	out := &bytes.Buffer{}
+	if err := runWizard(out, wizardOptions{
+		NonInteractive: true,
+		GroupName:      "demo",
+		ReposCSV:       repoA,
+		Watchers:       false,
+		GitHooks:       true,
+		RunInstall:     true,
+	}); err != nil {
+		t.Fatalf("wizard: %v\n%s", err, out.String())
+	}
+
+	cfg := loadCfg(t, "demo")
+	if len(cfg.Tools) != 0 {
+		t.Fatalf("Tools should stay empty without --tools, got %v", cfg.Tools)
+	}
+	if got := enabledIDs(cfg); !reflect.DeepEqual(got, tooladapter.AllIDs()) {
+		t.Fatalf("empty Tools must resolve to all adapters, got %v", got)
+	}
+}
+
+// TestWizard_ToolsFlagUnknownErrors: a bogus --tools token is rejected.
+func TestWizard_ToolsFlagUnknownErrors(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	out := &bytes.Buffer{}
+	err := runWizard(out, wizardOptions{
+		NonInteractive: true,
+		GroupName:      "demo",
+		ReposCSV:       repoA,
+		Tools:          "claude,bogus",
+		RunInstall:     false,
+	})
+	if err == nil {
+		t.Fatal("expected error for unknown tool in --tools")
+	}
+}
+
+// TestGroupAdd_ToolsFlagRestrictsSelection: `group add --tools claude,codex`
+// persists exactly {claude,codex} and gates scaffolding to those adapters.
+func TestGroupAdd_ToolsFlagRestrictsSelection(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	cmd := newTestCmd(&bytes.Buffer{})
+	err := runGroupAddImpl(cmd, "demo", groupAddFlags{
+		repoArgs: []string{repoA},
+		tools:    "claude,codex",
+		rules:    false,
+		mcp:      false,
+		runInst:  true,
+		jsonOut:  true,
+	}, "")
+	if err != nil {
+		t.Fatalf("group add: %v", err)
+	}
+
+	cfg := loadCfg(t, "demo")
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude", "codex"}) {
+		t.Fatalf("persisted Tools = %v, want [claude codex]", cfg.Tools)
+	}
+	if got := enabledIDs(cfg); !reflect.DeepEqual(got, []string{"claude", "codex"}) {
+		t.Fatalf("enabled adapters = %v, want only [claude codex]", got)
+	}
+}
+
+// TestGroupAdd_ToolsFlagUnknownErrors: bogus --tools rejected before install.
+func TestGroupAdd_ToolsFlagUnknownErrors(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	cmd := newTestCmd(&bytes.Buffer{})
+	err := runGroupAddImpl(cmd, "demo", groupAddFlags{
+		repoArgs: []string{repoA},
+		tools:    "bogus",
+		runInst:  false,
+	}, "")
+	if err == nil {
+		t.Fatal("expected error for unknown tool in --tools")
+	}
+}
+
+// TestInteractiveTUI_CapturesEnablement is the reporter's exact scenario
+// (#5701): a human running the ordinary terminal `grafel wizard` (the
+// alt-screen TUI) picks {claude,codex}. Driving the SAME seam the TUI uses
+// (resolveInteractiveTools → newGroupConfigFromResult), we assert cfg.Tools is
+// set to exactly the picked set and only those two adapters would be scaffolded
+// — none of kiro/codium/cursor/windsurf/copilot/antigravity — with NO --tools
+// flag. The huh picker is injected so no real TTY is required.
+func TestInteractiveTUI_CapturesEnablement(t *testing.T) {
+	restore := promptTools
+	promptTools = func() ([]string, error) { return []string{"claude", "codex"}, nil }
+	defer func() { promptTools = restore }()
+
+	var out bytes.Buffer
+	toolIDs, err := resolveInteractiveTools(&out, wizardOptions{}) // no --tools
+	if err != nil {
+		t.Fatalf("resolveInteractiveTools: %v", err)
+	}
+	if !reflect.DeepEqual(toolIDs, []string{"claude", "codex"}) {
+		t.Fatalf("resolved enablement = %v, want [claude codex]", toolIDs)
+	}
+
+	repo := t.TempDir()
+	cfg := newGroupConfigFromResult(
+		wiztui.Result{GroupName: "demo"},
+		[]registry.Repo{{Slug: "r", Path: repo}},
+		false,
+		toolIDs,
+	)
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude", "codex"}) {
+		t.Fatalf("cfg.Tools = %v, want [claude codex]", cfg.Tools)
+	}
+	if got := enabledIDs(cfg); !reflect.DeepEqual(got, []string{"claude", "codex"}) {
+		t.Fatalf("enabled adapters = %v, want only [claude codex]", got)
+	}
+}
+
+// TestInteractiveTUI_ToolsFlagSkipsPrompt: --tools pre-seeds the interactive
+// enablement and the picker is NOT shown.
+func TestInteractiveTUI_ToolsFlagSkipsPrompt(t *testing.T) {
+	restore := promptTools
+	promptTools = func() ([]string, error) {
+		t.Fatal("promptTools must not run when --tools is provided")
+		return nil, nil
+	}
+	defer func() { promptTools = restore }()
+
+	var out bytes.Buffer
+	toolIDs, err := resolveInteractiveTools(&out, wizardOptions{Tools: "claude,codex"})
+	if err != nil {
+		t.Fatalf("resolveInteractiveTools: %v", err)
+	}
+	if !reflect.DeepEqual(toolIDs, []string{"claude", "codex"}) {
+		t.Fatalf("resolved enablement = %v, want [claude codex]", toolIDs)
+	}
+}
+
+// TestInteractiveTUI_DeselectAllHintsAndDefaultsToAll: unchecking everything is
+// treated as "no explicit choice" (empty→all preserved) and prints a --tools
+// hint rather than scaffolding nothing.
+func TestInteractiveTUI_DeselectAllHintsAndDefaultsToAll(t *testing.T) {
+	restore := promptTools
+	promptTools = func() ([]string, error) { return nil, nil } // deselect-all
+	defer func() { promptTools = restore }()
+
+	var out bytes.Buffer
+	toolIDs, err := resolveInteractiveTools(&out, wizardOptions{})
+	if err != nil {
+		t.Fatalf("resolveInteractiveTools: %v", err)
+	}
+	if len(toolIDs) != 0 {
+		t.Fatalf("deselect-all should yield empty enablement, got %v", toolIDs)
+	}
+	if !strings.Contains(out.String(), "--tools") {
+		t.Fatalf("expected a --tools hint on deselect-all, got %q", out.String())
+	}
+	// Empty enablement resolves to all adapters at the Apply boundary.
+	cfg := newGroupConfigFromResult(wiztui.Result{GroupName: "demo"}, nil, false, toolIDs)
+	if got := enabledIDs(cfg); !reflect.DeepEqual(got, tooladapter.AllIDs()) {
+		t.Fatalf("empty enablement must resolve to all adapters, got %v", got)
+	}
+}
+
+// TestPendingTools_AppliedAtGroupCreation covers the install-before-wizard
+// ordering footgun (#5701 item 3): a tool selection made by `grafel install`
+// while no groups exist is stashed as pending and consumed by the next group
+// registration instead of being silently dropped.
+func TestPendingTools_AppliedAtGroupCreation(t *testing.T) {
+	home := withSandboxHome(t)
+	repoA := filepath.Join(home, "repos", "alpha")
+	makeRepo(t, repoA)
+
+	// Simulate `grafel install --tools claude,codex` with no groups yet.
+	out := &bytes.Buffer{}
+	if err := persistToolSelection(out, []string{"claude", "codex"}); err != nil {
+		t.Fatalf("persistToolSelection: %v", err)
+	}
+
+	// Now register a group (no --tools) — it must pick up the pending set.
+	cmd := newTestCmd(&bytes.Buffer{})
+	if err := runGroupAddImpl(cmd, "demo", groupAddFlags{
+		repoArgs: []string{repoA},
+		rules:    false, mcp: false, runInst: true, jsonOut: true,
+	}, ""); err != nil {
+		t.Fatalf("group add: %v", err)
+	}
+
+	cfg := loadCfg(t, "demo")
+	if !reflect.DeepEqual(cfg.Tools, []string{"claude", "codex"}) {
+		t.Fatalf("pending selection not applied: Tools = %v, want [claude codex]", cfg.Tools)
+	}
+
+	// Pending file must be consumed (not re-applied to a second group).
+	repoB := filepath.Join(home, "repos", "beta")
+	makeRepo(t, repoB)
+	cmd2 := newTestCmd(&bytes.Buffer{})
+	if err := runGroupAddImpl(cmd2, "demo2", groupAddFlags{
+		repoArgs: []string{repoB},
+		rules:    false, mcp: false, runInst: true, jsonOut: true,
+	}, ""); err != nil {
+		t.Fatalf("group add 2: %v", err)
+	}
+	cfg2 := loadCfg(t, "demo2")
+	if len(cfg2.Tools) != 0 {
+		t.Fatalf("pending selection must be consumed once; demo2 Tools = %v", cfg2.Tools)
+	}
+}

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/mcptools"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -178,7 +179,18 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 	class, _ := detect.ClassifyPath(cwd)
 	drv := wizardDriver{class: class}
 
-	idxFn := makeIndexFunc(out, errOut, class, opts)
+	// Per-tool ENABLEMENT capture (#5701). The alt-screen TUI has an MCP-tools
+	// picker but no native enablement screen, so we capture the enablement set
+	// with the shared huh picker (promptTools) BEFORE entering the full-screen
+	// program — unless --tools already preset it. This makes the ordinary
+	// interactive `grafel wizard` scaffold only the tools the human checks
+	// (deselecting kiro/codium excludes them), no flag required.
+	toolIDs, err := resolveInteractiveTools(out, opts)
+	if err != nil {
+		return wiztui.Result{}, err
+	}
+
+	idxFn := makeIndexFunc(out, errOut, class, opts, toolIDs)
 	// Build the MCP-tools picker options (#5344) unless a flag already preset
 	// the selection (--mcp-tools / --no-mcp) — in which case the screen is
 	// skipped (empty options) and the flag selection is honoured by the
@@ -203,12 +215,49 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 	return res, res.IndexErr()
 }
 
+// resolveInteractiveTools resolves the per-tool ENABLEMENT set for the
+// interactive (alt-screen) wizard (#5701). An explicit --tools flag wins and
+// skips the prompt (validated; a bad ID errors before anything is registered).
+// Otherwise it runs the shared promptTools picker so the human's checkbox
+// selection — all eight adapters offered, detected ones pre-checked,
+// deselection honoured — becomes cfg.Tools. An empty result (deselect-all, no
+// flag) is left as-is: applyGroupConfig then falls back to the empty-means-all
+// default, and we print a one-line hint that --tools can pin a subset.
+func resolveInteractiveTools(out io.Writer, opts wizardOptions) ([]string, error) {
+	if opts.Tools != "" {
+		return tooladapter.ParseToolsFlag(opts.Tools)
+	}
+	ids, err := promptTools()
+	if err != nil {
+		return nil, err
+	}
+	if len(ids) == 0 {
+		fmt.Fprintln(out, "no tools selected — targeting all supported tools; pass --tools to pin a subset")
+	}
+	return ids, nil
+}
+
+// newGroupConfigFromResult assembles the GroupConfig for a new group from the
+// TUI result, the resolved repos, the agent-hooks opt-in, and the captured
+// per-tool enablement set (#5701). Pure/side-effect-free so the enablement
+// wiring is unit-testable without a terminal.
+func newGroupConfigFromResult(r wiztui.Result, repos []registry.Repo, agentHooks bool, toolIDs []string) *registry.GroupConfig {
+	cfg := &registry.GroupConfig{Name: r.GroupName}
+	cfg.Features.Watchers = r.Watchers
+	cfg.Features.GitHooks = r.GitHooks
+	cfg.Features.AgentHooks = agentHooks
+	cfg.GroupDocs = r.GroupDocs
+	cfg.Repos = repos
+	cfg.Tools = toolIDs
+	return cfg
+}
+
 // makeIndexFunc returns a wiztui.IndexFunc closure that, when the user confirms,
 // (1) assembles + applies the group config (register/install) and (2) starts the
 // daemon index, streaming broker progress.Events back to the model and the
 // terminal outcome. All registration happens HERE — only on confirm — so a
 // cancel registers nothing.
-func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wizardOptions) wiztui.IndexFunc {
+func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wizardOptions, toolIDs []string) wiztui.IndexFunc {
 	return func(r wiztui.Result) (<-chan progress.Event, <-chan wiztui.IndexOutcome) {
 		evCh := make(chan progress.Event, 64)
 		outCh := make(chan wiztui.IndexOutcome, 1)
@@ -242,13 +291,9 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 				return
 			}
 
-			// New-group path: assemble config, apply (register + install).
-			cfg := &registry.GroupConfig{Name: r.GroupName}
-			cfg.Features.Watchers = r.Watchers
-			cfg.Features.GitHooks = r.GitHooks
-			cfg.Features.AgentHooks = opts.AgentHooks
-			cfg.GroupDocs = r.GroupDocs
-			cfg.Repos = repos
+			// New-group path: assemble config (with the enablement set captured
+			// by resolveInteractiveTools), apply (register + install).
+			cfg := newGroupConfigFromResult(r, repos, opts.AgentHooks, toolIDs)
 			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel})
 			if err != nil {
 				outCh <- wiztui.IndexOutcome{Err: err}


### PR DESCRIPTION
Closes #5701. Terminal `grafel wizard`/`group add` never set `cfg.Tools`, so `EnabledTools` defaulted to all 8 adapters and scaffolded rules folders + MCP for kiro/codium/cursor/windsurf/copilot/antigravity regardless of the user's pick. Now every path — the interactive alt-screen TUI (the reporter's path), the huh fallback, `--tools`, and `group add` — captures a tool-enablement selection and populates `cfg.Tools` before Apply; deselect-all preserves empty-means-all with a hint. Kept separate from the `--mcp-tools` MCP-subset picker (so copilot etc. aren't wrongly dropped). Ordering footgun (install --tools before any group) fixed via a consumed-once pending_tools.json. Empty-means-all Apply contract untouched. Reviewed: APPROVE-WITH-NITS → TUI enablement gap closed. Refs #5680.