### PR TITLE
feat(install): write grafel guidance to personal ~/.claude/CLAUDE.md; declutter repo root (#5702)

### DIFF
--- a/cmd/grafel/issue2683_rules_files_test.go
+++ b/cmd/grafel/issue2683_rules_files_test.go
@@ -182,15 +182,15 @@ func TestIssue2683_DoctorReportsAllStatuses(t *testing.T) {
 
 	// Mutate repo[0] so we get one of every status:
 	//   AGENTS.md            → OK (untouched)
-	//   CLAUDE.md            → OUTDATED (rewrite with v=0 marker)
+	//   .codeium/instructions.md → OUTDATED (rewrite with v=0 marker)
 	//   .windsurfrules       → STALE (replace with graphify content)
 	//   .cursorrules         → MISSING (delete)
 	if err := os.WriteFile(
-		filepath.Join(repos[0], "CLAUDE.md"),
+		filepath.Join(repos[0], ".codeium", "instructions.md"),
 		[]byte("<!-- grafel:mcp-usage:start v=0 -->\nold\n<!-- grafel:mcp-usage:end -->\n"),
 		0o644,
 	); err != nil {
-		t.Fatalf("seed CLAUDE.md: %v", err)
+		t.Fatalf("seed .codeium/instructions.md: %v", err)
 	}
 	if err := os.WriteFile(
 		filepath.Join(repos[0], ".windsurfrules"),
@@ -233,8 +233,8 @@ func TestIssue2683_DoctorReportsAllStatuses(t *testing.T) {
 		}
 		found = true
 		joined := strings.Join(c.Drift, "\n")
-		if !strings.Contains(joined, "CLAUDE.md [OUTDATED]") {
-			t.Errorf("CLAUDE.md OUTDATED not reported: %s", joined)
+		if !strings.Contains(joined, ".codeium/instructions.md [OUTDATED]") {
+			t.Errorf(".codeium/instructions.md OUTDATED not reported: %s", joined)
 		}
 		if !strings.Contains(joined, ".windsurfrules [STALE]") {
 			t.Errorf(".windsurfrules STALE not reported: %s", joined)

--- a/internal/cli/group.go
+++ b/internal/cli/group.go
@@ -44,6 +44,7 @@ func newGroupAddCmd() *cobra.Command {
 		doIndex   bool
 		jsonOut   bool
 		toolsCSV  string
+		projGuide bool
 	)
 
 	cmd := &cobra.Command{
@@ -87,6 +88,7 @@ Examples:
 				doIndex:   doIndex,
 				jsonOut:   jsonOut,
 				tools:     toolsCSV,
+				projGuide: projGuide,
 			}
 			return runGroupAddImpl(cmd, args[0], gaFlags, "")
 		},
@@ -103,7 +105,9 @@ Examples:
 	cmd.Flags().BoolVar(&gitHooks, "git-hooks", true,
 		"install git hooks (post-merge/checkout reindex)")
 	cmd.Flags().BoolVar(&rules, "rules", true,
-		"write per-repo IDE rules files (CLAUDE.md/.cursorrules/.windsurfrules/AGENTS.md)")
+		"write per-repo IDE rules files (.cursorrules/.windsurfrules/AGENTS.md); Claude guidance goes to your personal ~/.claude/CLAUDE.md")
+	cmd.Flags().BoolVar(&projGuide, "project-guidance", false,
+		"also commit the grafel Claude guidance block to <repo>/.claude/CLAUDE.md for every repo (for teams that all use grafel); default off — personal ~/.claude/CLAUDE.md only")
 	cmd.Flags().BoolVar(&mcp, "mcp", true,
 		"register/refresh MCP settings (machine-level; safe to leave on)")
 	cmd.Flags().BoolVar(&runInst, "install", true,
@@ -129,6 +133,7 @@ type groupAddFlags struct {
 	doIndex   bool
 	jsonOut   bool
 	tools     string // --tools CSV → GroupConfig.Tools (#5701)
+	projGuide bool
 }
 
 type groupAddRepo struct {
@@ -192,11 +197,12 @@ func runGroupAddImpl(cmd *cobra.Command, group string, f groupAddFlags, socketPa
 		applyOut = io.Discard
 	}
 	res, err := applyGroupConfig(applyOut, cfg, groupApplyOptions{
-		RunInstall:   f.runInst,
-		SkipHooks:    !f.gitHooks,
-		SkipWatchers: !f.watchers,
-		SkipMCP:      !f.mcp,
-		SkipRules:    !f.rules,
+		RunInstall:      f.runInst,
+		SkipHooks:       !f.gitHooks,
+		SkipWatchers:    !f.watchers,
+		SkipMCP:         !f.mcp,
+		SkipRules:       !f.rules,
+		ProjectGuidance: f.projGuide,
 	})
 	if err != nil {
 		return err

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -36,6 +36,7 @@ func newWizardCmd() *cobra.Command {
 		mcpToolsCSV    string
 		noMCP          bool
 		toolsCSV       string
+		projGuide      bool
 	)
 	cmd := &cobra.Command{
 		Use:   "wizard",
@@ -43,20 +44,21 @@ func newWizardCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
 			opts := wizardOptions{
-				NonInteractive: nonInteractive,
-				GroupName:      groupName,
-				ParentDir:      parentDir,
-				ReposCSV:       reposCSV,
-				Repos:          repoPaths,
-				Excludes:       excludes,
-				GroupDocs:      groupDocs,
-				Watchers:       watchers,
-				GitHooks:       gitHooks,
-				AgentHooks:     agentHooks,
-				RunInstall:     runInstall,
-				NoIndex:        noIndex,
-				Tools:          toolsCSV,
-				ErrOut:         cmd.ErrOrStderr(),
+				NonInteractive:  nonInteractive,
+				GroupName:       groupName,
+				ParentDir:       parentDir,
+				ReposCSV:        reposCSV,
+				Repos:           repoPaths,
+				Excludes:        excludes,
+				GroupDocs:       groupDocs,
+				Watchers:        watchers,
+				GitHooks:        gitHooks,
+				AgentHooks:      agentHooks,
+				RunInstall:      runInstall,
+				NoIndex:         noIndex,
+				Tools:           toolsCSV,
+				ProjectGuidance: projGuide,
+				ErrOut:          cmd.ErrOrStderr(),
 			}
 			// Resolve the MCP-tools selection from flags (#5344). --no-mcp wins
 			// and registers none; --mcp-tools=a,b registers exactly those; with
@@ -87,6 +89,7 @@ func newWizardCmd() *cobra.Command {
 	cmd.Flags().StringVar(&mcpToolsCSV, "mcp-tools", "", "comma-separated AI tool IDs to register the grafel MCP server in (e.g. claude,cursor); skips the interactive picker. Without this flag (and without --no-mcp), interactive runs prompt and non-interactive runs register every detected tool")
 	cmd.Flags().BoolVar(&noMCP, "no-mcp", false, "do not register the grafel MCP server in any AI tool")
 	cmd.Flags().StringVar(&toolsCSV, "tools", "", "comma-separated AI coding tools whose rules files + MCP get scaffolded (e.g. claude,codex); when set, selection is non-interactive. Without it, interactive runs prompt and non-interactive runs target every supported tool. Run 'grafel tools list' for valid IDs")
+	cmd.Flags().BoolVar(&projGuide, "project-guidance", false, "also commit the grafel Claude guidance block to each <repo>/.claude/CLAUDE.md (for teams that all use grafel); default off — personal ~/.claude/CLAUDE.md only")
 	return cmd
 }
 
@@ -112,7 +115,11 @@ type wizardOptions struct {
 	// (prompt interactively, or all-detected non-interactively), empty = none,
 	// [ids] = exactly those. Set from --mcp-tools / --no-mcp.
 	MCPTools *[]string
-	ErrOut   io.Writer // stderr sink for warnings; nil → os.Stderr
+	// ProjectGuidance opts in to committing the grafel Claude guidance block to
+	// each <repo>/.claude/CLAUDE.md (for teams). Default off: personal
+	// ~/.claude/CLAUDE.md only (#5702). Set from --project-guidance.
+	ProjectGuidance bool
+	ErrOut          io.Writer // stderr sink for warnings; nil → os.Stderr
 }
 
 // errWriter returns the configured stderr sink, defaulting to os.Stderr.
@@ -283,7 +290,7 @@ func finishWizard(out io.Writer, cfg *registry.GroupConfig, opts wizardOptions) 
 
 	// Steps 5-7 — persist + register + manifests + install. Shared with the
 	// non-interactive `group add` command via applyGroupConfig.
-	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: opts.MCPTools}); err != nil {
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: opts.MCPTools, ProjectGuidance: opts.ProjectGuidance}); err != nil {
 		return err
 	}
 
@@ -409,6 +416,11 @@ type groupApplyOptions struct {
 	// selection (#5344). nil preserves today's behaviour (all enabled tools);
 	// an empty slice registers none. Threaded straight into install.Options.
 	MCPTools *[]string
+	// ProjectGuidance opts in to ALSO writing the repo-specific grafel Claude
+	// guidance block to <repo>/.claude/CLAUDE.md (committed; for teams). Default
+	// OFF — only the personal ~/.claude/CLAUDE.md self-gating block is written
+	// (#5702).
+	ProjectGuidance bool
 }
 
 // applyGroupConfig persists the group config, registers it in the global
@@ -451,14 +463,15 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	}
 	bin, _ := os.Executable()
 	res, err := install.Apply(install.Options{
-		Group:          cfg.Name,
-		Config:         cfg,
-		BinPath:        bin,
-		SkipHooks:      ga.SkipHooks,
-		SkipWatchers:   ga.SkipWatchers,
-		SkipMCP:        ga.SkipMCP,
-		SkipRulesFiles: ga.SkipRules,
-		MCPTools:       ga.MCPTools,
+		Group:           cfg.Name,
+		Config:          cfg,
+		BinPath:         bin,
+		SkipHooks:       ga.SkipHooks,
+		SkipWatchers:    ga.SkipWatchers,
+		SkipMCP:         ga.SkipMCP,
+		SkipRulesFiles:  ga.SkipRules,
+		MCPTools:        ga.MCPTools,
+		ProjectGuidance: ga.ProjectGuidance,
 	})
 	if err != nil {
 		return nil, err
@@ -473,10 +486,31 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 	}
 	fmt.Fprintf(out, "installed %d hooks, %d watchers, %d MCP entries\n",
 		len(res.HooksInstalled), len(res.WatcherUnits), len(res.MCPSettings))
+	reportGuidance(out, res)
 	for _, warn := range res.WatcherWarnings {
 		fmt.Fprintf(out, "warning: %s\n", warn)
 	}
 	return res, nil
+}
+
+// reportGuidance prints WHERE the grafel Claude guidance was written — the
+// personal ~/.claude/CLAUDE.md by default, plus any opt-in per-repo project
+// files and repos where a legacy committed block was decluttered (#5702).
+func reportGuidance(out io.Writer, res *install.Result) {
+	if res == nil {
+		return
+	}
+	if res.PersonalGuidancePath != "" {
+		fmt.Fprintf(out, "Claude guidance: wrote self-gating block to your PERSONAL %s\n", res.PersonalGuidancePath)
+	}
+	if len(res.ProjectGuidanceFiles) > 0 {
+		fmt.Fprintf(out, "Claude guidance: wrote PROJECT block to %d repo file(s) (committed): %s\n",
+			len(res.ProjectGuidanceFiles), strings.Join(res.ProjectGuidanceFiles, ", "))
+	}
+	if len(res.MigratedGuidanceRepos) > 0 {
+		fmt.Fprintf(out, "Claude guidance: removed legacy committed block from %d repo(s)\n",
+			len(res.MigratedGuidanceRepos))
+	}
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -820,7 +854,7 @@ func addReposToExistingGroup(out io.Writer, group string, repos []registry.Repo,
 	if added == 0 {
 		return errors.New("all selected repos are already in the group")
 	}
-	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall})
+	_, err = applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, ProjectGuidance: opts.ProjectGuidance})
 	if err != nil {
 		return err
 	}

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -294,7 +294,7 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 			// New-group path: assemble config (with the enablement set captured
 			// by resolveInteractiveTools), apply (register + install).
 			cfg := newGroupConfigFromResult(r, repos, opts.AgentHooks, toolIDs)
-			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel})
+			res, err := applyGroupConfig(&sink, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel, ProjectGuidance: opts.ProjectGuidance})
 			if err != nil {
 				outCh <- wiztui.IndexOutcome{Err: err}
 				return
@@ -515,7 +515,7 @@ func addReposToExistingGroupNoIndex(out io.Writer, group string, repos []registr
 	if added == 0 {
 		return errors.New("all selected repos are already in the group")
 	}
-	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel}); err != nil {
+	if _, err := applyGroupConfig(out, cfg, groupApplyOptions{RunInstall: opts.RunInstall, MCPTools: mcpSel, ProjectGuidance: opts.ProjectGuidance}); err != nil {
 		return err
 	}
 	fmt.Fprintf(out, "added %d repo(s) to group %q\n", added, group)

--- a/internal/install/guidance_test.go
+++ b/internal/install/guidance_test.go
@@ -1,0 +1,189 @@
+package install_test
+
+// guidance_test.go — #5702: grafel's Claude guidance defaults to the PERSONAL
+// ~/.claude/CLAUDE.md (self-gating, opt-in per developer), the project-root
+// CLAUDE.md is decluttered on install, and --project-guidance (ProjectGuidance)
+// commits a repo-specific block to <repo>/.claude/CLAUDE.md. Non-grafel content
+// is never touched.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// applyGuidance runs a real (non-dry-run) install under an isolated HOME with
+// only the Claude tool enabled, and returns the Result plus the paths that
+// matter for guidance assertions. MCP/hooks/watchers are skipped so the test
+// isolates the guidance path.
+func applyGuidance(t *testing.T, repo string, projectGuidance bool) *install.Result {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	cfg := &registry.GroupConfig{
+		Name:  "demo",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+		Tools: []string{"claude"},
+	}
+	res, err := install.Apply(install.Options{
+		Group:           "demo",
+		Config:          cfg,
+		BinPath:         "/usr/local/bin/grafel",
+		SkipHooks:       true,
+		SkipWatchers:    true,
+		SkipMCP:         true,
+		ProjectGuidance: projectGuidance,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	return res
+}
+
+// TestApply_WritesPersonalGuidanceIdempotent covers requirement (a): install
+// writes the self-gating block to the fake HOME's .claude/CLAUDE.md between the
+// markers; a re-run updates it in place (no duplicate).
+func TestApply_WritesPersonalGuidanceIdempotent(t *testing.T) {
+	repo := t.TempDir()
+	res := applyGuidance(t, repo, false)
+
+	personal := res.PersonalGuidancePath
+	if personal == "" {
+		t.Fatal("PersonalGuidancePath empty; personal guidance not written")
+	}
+	want := filepath.Join(os.Getenv("HOME"), ".claude", "CLAUDE.md")
+	if personal != want {
+		t.Fatalf("personal path = %q, want %q", personal, want)
+	}
+	data, err := os.ReadFile(personal)
+	if err != nil {
+		t.Fatalf("read personal guidance: %v", err)
+	}
+	s := string(data)
+	for _, sub := range []string{"self-gating", "grafel:mcp-usage:start", "ignore this section entirely"} {
+		if !strings.Contains(s, sub) {
+			t.Errorf("personal guidance missing %q:\n%s", sub, s)
+		}
+	}
+	if strings.Contains(s, "part of grafel group") {
+		t.Errorf("personal guidance must be group-agnostic:\n%s", s)
+	}
+
+	// Re-run: same HOME (env persists for the test), block updated in place.
+	cfg := &registry.GroupConfig{
+		Name:  "demo",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+		Tools: []string{"claude"},
+	}
+	if _, err := install.Apply(install.Options{
+		Group: "demo", Config: cfg, BinPath: "/usr/local/bin/grafel",
+		SkipHooks: true, SkipWatchers: true, SkipMCP: true,
+	}); err != nil {
+		t.Fatalf("re-Apply: %v", err)
+	}
+	data2, _ := os.ReadFile(personal)
+	if n := strings.Count(string(data2), "grafel:mcp-usage:start"); n != 1 {
+		t.Fatalf("expected exactly 1 block after re-install, got %d:\n%s", n, data2)
+	}
+}
+
+// TestApply_MigratesRepoRootClaudeMd covers requirement (b): a project-root
+// CLAUDE.md of "before\n<grafel block>\nafter" has ONLY the grafel block
+// removed; the before/after content is preserved.
+func TestApply_MigratesRepoRootClaudeMd(t *testing.T) {
+	repo := t.TempDir()
+	// Seed a repo-root CLAUDE.md with user content wrapping a grafel block.
+	block := "<!-- grafel:mcp-usage:start v=2 -->\n## grafel MCP\nold repo guidance\n<!-- grafel:mcp-usage:end -->"
+	seeded := "before-block content\n\n" + block + "\n\nafter-block content\n"
+	rootClaude := filepath.Join(repo, "CLAUDE.md")
+	if err := os.WriteFile(rootClaude, []byte(seeded), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := applyGuidance(t, repo, false)
+
+	data, err := os.ReadFile(rootClaude)
+	if err != nil {
+		t.Fatalf("repo-root CLAUDE.md should still exist: %v", err)
+	}
+	s := string(data)
+	if strings.Contains(s, "grafel:mcp-usage") {
+		t.Errorf("grafel block not stripped from repo-root CLAUDE.md:\n%s", s)
+	}
+	if !strings.Contains(s, "before-block content") || !strings.Contains(s, "after-block content") {
+		t.Errorf("surrounding content not preserved:\n%s", s)
+	}
+	found := false
+	for _, r := range res.MigratedGuidanceRepos {
+		if r == repo {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("repo not reported in MigratedGuidanceRepos: %v", res.MigratedGuidanceRepos)
+	}
+}
+
+// TestApply_ProjectGuidanceWritesRepoFile covers requirement (c):
+// --project-guidance writes the repo-specific block to <repo>/.claude/CLAUDE.md.
+func TestApply_ProjectGuidanceWritesRepoFile(t *testing.T) {
+	repo := t.TempDir()
+	res := applyGuidance(t, repo, true)
+
+	projPath := filepath.Join(repo, ".claude", "CLAUDE.md")
+	data, err := os.ReadFile(projPath)
+	if err != nil {
+		t.Fatalf("project guidance not written to %s: %v", projPath, err)
+	}
+	s := string(data)
+	if !strings.Contains(s, "grafel:mcp-usage:start") {
+		t.Errorf("project guidance missing block:\n%s", s)
+	}
+	// Repo-specific block carries the group name.
+	if !strings.Contains(s, "**demo**") {
+		t.Errorf("project guidance should embed group name:\n%s", s)
+	}
+	var reported bool
+	for _, p := range res.ProjectGuidanceFiles {
+		if p == projPath {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Errorf("project file not reported in ProjectGuidanceFiles: %v", res.ProjectGuidanceFiles)
+	}
+	// Personal file is ALSO written (project guidance is additive).
+	if res.PersonalGuidancePath == "" {
+		t.Errorf("personal guidance should still be written alongside project guidance")
+	}
+}
+
+// TestApply_LeavesNonGrafelClaudeMdUntouched covers requirement (d): a
+// repo-root CLAUDE.md with NO grafel block is never modified by install.
+func TestApply_LeavesNonGrafelClaudeMdUntouched(t *testing.T) {
+	repo := t.TempDir()
+	rootClaude := filepath.Join(repo, "CLAUDE.md")
+	original := "# Team conventions\n\nUse tabs. No grafel here.\n"
+	if err := os.WriteFile(rootClaude, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := applyGuidance(t, repo, false)
+
+	data, _ := os.ReadFile(rootClaude)
+	if string(data) != original {
+		t.Errorf("non-grafel CLAUDE.md was modified:\nwant %q\ngot  %q", original, string(data))
+	}
+	for _, r := range res.MigratedGuidanceRepos {
+		if r == repo {
+			t.Errorf("no-op repo wrongly reported as migrated: %v", res.MigratedGuidanceRepos)
+		}
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -56,6 +56,11 @@ type Options struct {
 	// The filter is by adapter ID, applied on top of the enabled-tools set, so
 	// a tool the group config doesn't enable is never registered even if named.
 	MCPTools *[]string
+	// ProjectGuidance, when true, ALSO writes the repo-specific (committed)
+	// grafel guidance block to <repo>/.claude/CLAUDE.md for every repo — for
+	// teams that all use grafel (#5702). Default OFF: only the personal
+	// ~/.claude/CLAUDE.md self-gating block is written. CLAUDE CODE ONLY.
+	ProjectGuidance bool
 }
 
 // Result reports what an Apply call did so the CLI can print a summary.
@@ -79,6 +84,18 @@ type Result struct {
 	// PreToolUse grep-interceptor hook (#4273). Empty unless agent hooks
 	// were enabled.
 	AgentHooksInstalled []string
+	// PersonalGuidancePath is the absolute path of the personal
+	// ~/.claude/CLAUDE.md the self-gating grafel guidance block was written
+	// to (#5702). Empty when no Claude adapter is enabled or rules are skipped.
+	PersonalGuidancePath string
+	// ProjectGuidanceFiles lists absolute <repo>/.claude/CLAUDE.md paths the
+	// repo-specific guidance block was written to under the opt-in
+	// --project-guidance mode. Empty by default.
+	ProjectGuidanceFiles []string
+	// MigratedGuidanceRepos lists repo paths where a legacy grafel guidance
+	// block was stripped from the repo-root CLAUDE.md (and/or
+	// <repo>/.claude/CLAUDE.md) to declutter the repo (#5702).
+	MigratedGuidanceRepos []string
 	// WatcherWarnings collects non-fatal watcher-activation failures. The
 	// group config is fully saved before watchers are activated, so a watcher
 	// that fails to load (e.g. a flaky launchctl error that survives the
@@ -136,6 +153,26 @@ func Apply(opts Options) (*Result, error) {
 		}
 	}
 
+	// Claude guidance (#5702) is Claude-only and lives outside the per-repo
+	// rules-file sweep. By default it is a self-gating GLOBAL block written
+	// ONCE to the personal ~/.claude/CLAUDE.md — grafel adoption is
+	// per-developer, so the guidance is personal/opt-in and never committed to
+	// a shared repo. The per-repo declutter + opt-in project block happen in
+	// the repo loop below.
+	claudeGuidance := !opts.SkipRulesFiles && anyAdapterIsClaude(adaptersForRepo)
+	if claudeGuidance {
+		personalPath, herr := personalGuidancePath()
+		if herr != nil {
+			return nil, fmt.Errorf("resolve personal guidance path: %w", herr)
+		}
+		if !opts.DryRun {
+			if werr := rulesfiles.UpsertGuidance(personalPath, rulesfiles.RenderPersonalBlock()); werr != nil {
+				return nil, fmt.Errorf("personal guidance %s: %w", personalPath, werr)
+			}
+		}
+		res.PersonalGuidancePath = personalPath
+	}
+
 	for _, r := range opts.Config.Repos {
 		repo := r.Path
 		if !filepath.IsAbs(repo) {
@@ -189,6 +226,35 @@ func Apply(opts Options) (*Result, error) {
 					}
 					res.RulesFiles[repo] = append([]string{}, targets...)
 				}
+			}
+		}
+		if claudeGuidance {
+			// Declutter (#5702): strip grafel's legacy marker-delimited block
+			// from the repo-root CLAUDE.md — and from <repo>/.claude/CLAUDE.md
+			// UNLESS we're about to (re)write it via --project-guidance. Only
+			// grafel's own block is removed; all surrounding user content is
+			// preserved, and a file is deleted only when grafel was its sole
+			// author.
+			migrateTargets := []string{"CLAUDE.md"}
+			if !opts.ProjectGuidance {
+				migrateTargets = append(migrateTargets, rulesfiles.ClaudeGuidanceRelPath)
+			}
+			if !opts.DryRun {
+				if rr, rerr := rulesfiles.RemoveTargets(repo, migrateTargets); rerr == nil && rr != nil &&
+					(len(rr.Stripped) > 0 || len(rr.Deleted) > 0) {
+					res.MigratedGuidanceRepos = append(res.MigratedGuidanceRepos, repo)
+				}
+			}
+			// Opt-in: teams that all use grafel commit a repo-specific block to
+			// <repo>/.claude/CLAUDE.md.
+			if opts.ProjectGuidance {
+				projPath := filepath.Join(repo, rulesfiles.ClaudeGuidanceRelPath)
+				if !opts.DryRun {
+					if werr := rulesfiles.UpsertGuidance(projPath, rulesfiles.RenderBlock(opts.Group)); werr != nil {
+						return nil, fmt.Errorf("project guidance for %s: %w", repo, werr)
+					}
+				}
+				res.ProjectGuidanceFiles = append(res.ProjectGuidanceFiles, projPath)
 			}
 		}
 		// The opt-in PreToolUse agent hook is Claude-only. Install it only
@@ -348,6 +414,27 @@ func anyAdapterSupportsAgentHook(adapters []tooladapter.Adapter) bool {
 	return false
 }
 
+// anyAdapterIsClaude reports whether the Claude Code adapter is enabled, which
+// gates the personal/project Claude guidance writes (#5702).
+func anyAdapterIsClaude(adapters []tooladapter.Adapter) bool {
+	for _, a := range adapters {
+		if a.ID() == "claude" {
+			return true
+		}
+	}
+	return false
+}
+
+// personalGuidancePath resolves ~/.claude/CLAUDE.md, honouring HOME so tests
+// can redirect it (reuses userHomeDir, the same resolver used for ~/.grafel).
+func personalGuidancePath() (string, error) {
+	home, err := userHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, rulesfiles.ClaudeGuidanceRelPath), nil
+}
+
 // Uninstall reverses Apply for a single group: removes hooks/watchers
 // and (optionally with purge) deletes per-group state.
 func Uninstall(group string, purge bool) error {
@@ -382,6 +469,12 @@ func Uninstall(group string, purge bool) error {
 			// author (#5274). Best-effort: I/O errors are ignored so a
 			// single unwritable file never blocks the rest of uninstall.
 			_, _ = rulesfiles.RemoveAll(r.Path)
+			// Also strip any grafel Claude guidance block from the repo-root
+			// CLAUDE.md and <repo>/.claude/CLAUDE.md — the legacy location and
+			// the opt-in --project-guidance location (#5702). Only grafel's own
+			// marker-delimited block is removed. The personal ~/.claude/CLAUDE.md
+			// is global (shared across groups) and is intentionally left intact.
+			_, _ = rulesfiles.RemoveTargets(r.Path, rulesfiles.LegacyClaudeGuidanceTargets)
 			u := watchers.Unit{Group: group, Repo: r.Path, BinPath: bin}
 			// Deregister from the OS scheduler before removing the unit file so
 			// that the OS does not attempt to launch a missing binary.

--- a/internal/install/rulesfiles/guidance_test.go
+++ b/internal/install/rulesfiles/guidance_test.go
@@ -1,0 +1,132 @@
+package rulesfiles
+
+// guidance_test.go — #5702: the personal self-gating Claude guidance block
+// (RenderPersonalBlock) and its idempotent, content-preserving writer
+// (UpsertGuidance). Also guards that the repo-root CLAUDE.md is no longer a
+// per-repo Target (guidance is personal now).
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestTargets_ExcludesRepoClaudeMd guards that the project-root CLAUDE.md is
+// no longer swept by WriteAll/Scan — its guidance moved to the personal
+// ~/.claude/CLAUDE.md (#5702).
+func TestTargets_ExcludesRepoClaudeMd(t *testing.T) {
+	for _, tgt := range Targets {
+		if tgt == "CLAUDE.md" {
+			t.Fatalf("Targets must not include repo-root CLAUDE.md anymore, got %v", Targets)
+		}
+	}
+}
+
+// TestRenderPersonalBlock_SelfGating verifies the personal block is generic
+// (no group name), carries the shared markers, and states the self-gating
+// pre-conditions so an agent ignores it unless grafel is connected + indexed.
+func TestRenderPersonalBlock_SelfGating(t *testing.T) {
+	b := RenderPersonalBlock()
+	mustContain := []string{
+		StartMarker,
+		EndMarker,
+		"self-gating",
+		"MCP server is connected",
+		"grafel_index_status",
+		"ignore this section entirely",
+		"auto-updated by `grafel install`",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(b, s) {
+			t.Errorf("personal block missing %q:\n%s", s, b)
+		}
+	}
+	// It is GLOBAL, so it must NOT embed a group-name placeholder or a group.
+	if strings.Contains(b, "<group-name>") || strings.Contains(b, "part of grafel group") {
+		t.Errorf("personal block must be group-agnostic:\n%s", b)
+	}
+}
+
+// TestUpsertGuidance_CreatesAndUpdatesInPlace verifies a fresh write creates
+// the file with exactly one block, and a re-write replaces it in place
+// (idempotent — never duplicated).
+func TestUpsertGuidance_CreatesAndUpdatesInPlace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude", "CLAUDE.md")
+
+	if err := UpsertGuidance(path, RenderPersonalBlock()); err != nil {
+		t.Fatalf("first UpsertGuidance: %v", err)
+	}
+	first, _ := os.ReadFile(path)
+	if n := strings.Count(string(first), "grafel:mcp-usage:start"); n != 1 {
+		t.Fatalf("expected 1 block after create, got %d:\n%s", n, first)
+	}
+
+	// Second write must not duplicate.
+	if err := UpsertGuidance(path, RenderPersonalBlock()); err != nil {
+		t.Fatalf("second UpsertGuidance: %v", err)
+	}
+	second, _ := os.ReadFile(path)
+	if n := strings.Count(string(second), "grafel:mcp-usage:start"); n != 1 {
+		t.Fatalf("expected still 1 block after re-write, got %d:\n%s", n, second)
+	}
+}
+
+// TestUpsertGuidance_PreservesSurroundingProse verifies UpsertGuidance never
+// touches a user's own content: it appends after existing prose and, on
+// re-write, replaces only the block while keeping the prose byte-for-byte.
+func TestUpsertGuidance_PreservesSurroundingProse(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
+	prose := "# My personal instructions\n\nAlways be concise.\n"
+	if err := os.WriteFile(path, []byte(prose), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := UpsertGuidance(path, RenderPersonalBlock()); err != nil {
+		t.Fatalf("UpsertGuidance: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), "Always be concise.") {
+		t.Errorf("user prose lost:\n%s", data)
+	}
+	if !strings.Contains(string(data), StartMarker) {
+		t.Errorf("block not appended:\n%s", data)
+	}
+
+	// Re-write: prose still intact, still one block.
+	if err := UpsertGuidance(path, RenderPersonalBlock()); err != nil {
+		t.Fatalf("re-write: %v", err)
+	}
+	data2, _ := os.ReadFile(path)
+	if !strings.Contains(string(data2), "Always be concise.") {
+		t.Errorf("user prose lost on re-write:\n%s", data2)
+	}
+	if n := strings.Count(string(data2), "grafel:mcp-usage:start"); n != 1 {
+		t.Errorf("expected 1 block after re-write, got %d:\n%s", n, data2)
+	}
+}
+
+// TestUpsertGuidance_NoStaleHeuristic proves UpsertGuidance does NOT apply the
+// predecessor/stale-file logic: a personal file that merely mentions
+// "archigraph" must still receive the block (WriteTargets would have skipped
+// it as mixed-stale).
+func TestUpsertGuidance_NoStaleHeuristic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "CLAUDE.md")
+	prose := "# Notes\n\nWe migrated off archigraph last year.\n"
+	if err := os.WriteFile(path, []byte(prose), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := UpsertGuidance(path, RenderPersonalBlock()); err != nil {
+		t.Fatalf("UpsertGuidance: %v", err)
+	}
+	data, _ := os.ReadFile(path)
+	if !strings.Contains(string(data), StartMarker) {
+		t.Errorf("block should have been written despite 'archigraph' mention:\n%s", data)
+	}
+	if !strings.Contains(string(data), "migrated off archigraph") {
+		t.Errorf("user prose lost:\n%s", data)
+	}
+}

--- a/internal/install/rulesfiles/rulesfiles.go
+++ b/internal/install/rulesfiles/rulesfiles.go
@@ -96,15 +96,37 @@ var PredecessorTokens = []string{
 //
 // The order is also the order in which doctor reports them, so the user
 // sees a consistent grouping per repo.
+// NOTE(#5702): the project-root CLAUDE.md is deliberately NOT in this list.
+// grafel's Claude guidance is now a self-gating block written to the PERSONAL
+// ~/.claude/CLAUDE.md by default (adoption is per-developer, not per-team, so
+// it should not be committed to a shared repo). The opt-in `--project-guidance`
+// path writes a repo-specific block to <repo>/.claude/CLAUDE.md instead — both
+// handled via UpsertGuidance, not this per-repo Targets sweep. Legacy repo-root
+// CLAUDE.md blocks are migrated away (stripped) on install.
 var Targets = []string{
 	"AGENTS.md",
-	"CLAUDE.md",
 	".windsurfrules",
 	".cursorrules",
 	".codeium/instructions.md",
 	".github/copilot-instructions.md",
 	".kiro/steering/grafel.md",
 	".agent/rules/grafel.md",
+}
+
+// ClaudeGuidanceRelPath is the relative path of the Claude Code guidance
+// file, ".claude/CLAUDE.md". It is joined with the user's HOME for the
+// PERSONAL guidance (default, #5702) and with a repo root for the opt-in
+// PROJECT guidance (`--project-guidance`). Both are written via
+// UpsertGuidance rather than the per-repo Targets sweep.
+var ClaudeGuidanceRelPath = filepath.Join(".claude", "CLAUDE.md")
+
+// LegacyClaudeGuidanceTargets are the per-repo paths that older grafel
+// versions wrote the guidance block into. On install grafel strips its own
+// marker-delimited block from these to declutter the repo (#5702). Only the
+// grafel block is removed; all surrounding user content is preserved.
+var LegacyClaudeGuidanceTargets = []string{
+	"CLAUDE.md",
+	filepath.Join(".claude", "CLAUDE.md"),
 }
 
 // Status is the per-file state reported by Scan / doctor.
@@ -358,7 +380,90 @@ func RenderBlock(groupName string) string {
 	return b.String()
 }
 
+// RenderPersonalBlock returns the marker-wrapped, self-gating GLOBAL Claude
+// guidance block for the personal ~/.claude/CLAUDE.md (#5702). Because it is
+// written once per developer (not per repo) it carries NO group name and is
+// intentionally generic: it tells the agent to first check that a grafel MCP
+// server is connected AND the cwd is an indexed repo, and to ignore the whole
+// section otherwise. The full guide still arrives via the MCP `instructions`
+// handshake when connected, so this block stays deliberately short.
+//
+// It uses the SAME StartMarker/EndMarker as RenderBlock so a re-install
+// replaces it in place (never duplicates) and doctor/uninstall can find it.
+func RenderPersonalBlock() string {
+	var b strings.Builder
+	fmt.Fprintln(&b, StartMarker)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## grafel — architecture knowledge graph (conditional; self-gating)")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "Before applying this section, check BOTH: (1) a `grafel` MCP server is connected (its tools are available); (2) your cwd is inside a grafel-indexed repo — verify with `grafel_orient` / `grafel_index_status` (non-empty = indexed).")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "If BOTH true → prefer grafel MCP over grep/manual reading for STRUCTURAL questions (where is X / who calls X / end-to-end flow → `grafel_find` / `grafel_expand` / `grafel_traces`); raw enumeration (every TODO, every `if err != nil`) → still grep.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "If grafel is NOT connected or the repo is NOT indexed → ignore this section entirely.")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "_Do not edit between the markers — this block is auto-updated by `grafel install`._")
+	fmt.Fprintln(&b)
+	fmt.Fprint(&b, EndMarker)
+	return b.String()
+}
+
+// UpsertGuidance writes a marker-wrapped guidance block into an arbitrary
+// absolute path — the personal ~/.claude/CLAUDE.md or an opt-in
+// <repo>/.claude/CLAUDE.md — idempotently and in place between the shared
+// markers (#5702).
+//
+// Unlike WriteTargets it applies NO predecessor / stale-file heuristics: the
+// surrounding content is arbitrary user prose that must be preserved verbatim.
+// It only creates the file when absent, replaces an existing grafel block in
+// place (covering re-install and older-version blocks), or appends the block
+// after a blank-line separator when the file exists with unrelated content.
+//
+// It reuses the same block regex and atomic writer as WriteTargets, so
+// idempotency and marker handling are identical.
+func UpsertGuidance(path, block string) error {
+	_, err := upsertPlain(path, block)
+	return err
+}
+
 // ── internal helpers ─────────────────────────────────────────────────
+
+// upsertPlain is upsert without the predecessor/stale-file branch: create /
+// replace-in-place / append only. Used by UpsertGuidance for the personal and
+// opt-in project Claude guidance files.
+func upsertPlain(path, block string) (action, error) {
+	existing, err := os.ReadFile(path)
+	switch {
+	case err != nil && !os.IsNotExist(err):
+		return actionUnknown, fmt.Errorf("read %s: %w", path, err)
+
+	case os.IsNotExist(err) || len(existing) == 0:
+		if err := atomicWrite(path, []byte(block)); err != nil {
+			return actionUnknown, err
+		}
+		return actionWroteFresh, nil
+
+	case blockRegexAnyVersion.Match(existing):
+		out := blockRegexAnyVersion.ReplaceAll(existing, []byte(strings.TrimRight(block, "\n")))
+		if err := atomicWrite(path, out); err != nil {
+			return actionUnknown, err
+		}
+		return actionReplacedBlock, nil
+
+	default:
+		buf := make([]byte, 0, len(existing)+len(block)+2)
+		buf = append(buf, existing...)
+		if existing[len(existing)-1] != '\n' {
+			buf = append(buf, '\n')
+		}
+		buf = append(buf, '\n')
+		buf = append(buf, []byte(block)...)
+		if err := atomicWrite(path, buf); err != nil {
+			return actionUnknown, err
+		}
+		return actionAppended, nil
+	}
+}
 
 // action codes returned by upsert; surfaced to WriteAll so callers can
 // log per-file decisions.

--- a/internal/install/rulesfiles/rulesfiles_test.go
+++ b/internal/install/rulesfiles/rulesfiles_test.go
@@ -169,13 +169,13 @@ func TestWriteAll_ReplacesOlderVersionBlock(t *testing.T) {
 func TestWriteAll_PreservesUnrelatedContent(t *testing.T) {
 	repo := t.TempDir()
 	original := "# My Project\n\nLocal notes that mention nothing relevant.\n"
-	if err := os.WriteFile(filepath.Join(repo, "CLAUDE.md"), []byte(original), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(repo, "AGENTS.md"), []byte(original), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
 		t.Fatalf("WriteAll: %v", err)
 	}
-	data, _ := os.ReadFile(filepath.Join(repo, "CLAUDE.md"))
+	data, _ := os.ReadFile(filepath.Join(repo, "AGENTS.md"))
 	if !bytes.Contains(data, []byte("# My Project")) {
 		t.Errorf("original content lost: %s", data)
 	}
@@ -257,10 +257,10 @@ func TestScan_StatusesAcrossFileShapes(t *testing.T) {
 		t.Fatalf("seed AGENTS.md: %v", err)
 	}
 
-	// CLAUDE.md → OUTDATED (older version).
+	// .cursorrules → OUTDATED (older version).
 	old := "<!-- grafel:mcp-usage:start v=0 -->\nbody\n<!-- grafel:mcp-usage:end -->\n"
-	if err := os.WriteFile(filepath.Join(repo, "CLAUDE.md"), []byte(old), 0o644); err != nil {
-		t.Fatalf("seed CLAUDE.md: %v", err)
+	if err := os.WriteFile(filepath.Join(repo, ".cursorrules"), []byte(old), 0o644); err != nil {
+		t.Fatalf("seed .cursorrules: %v", err)
 	}
 
 	// .windsurfrules → STALE (graphify content, no block).
@@ -269,7 +269,7 @@ func TestScan_StatusesAcrossFileShapes(t *testing.T) {
 		t.Fatalf("seed .windsurfrules: %v", err)
 	}
 
-	// .cursorrules, .codeium/instructions.md, .github/copilot-instructions.md → MISSING.
+	// .codeium/instructions.md, .github/copilot-instructions.md → MISSING.
 
 	statuses := Scan(repo)
 	byTarget := map[string]FileStatus{}
@@ -280,14 +280,11 @@ func TestScan_StatusesAcrossFileShapes(t *testing.T) {
 	if got := byTarget["AGENTS.md"].Status; got != StatusOK {
 		t.Errorf("AGENTS.md: expected OK, got %s", got)
 	}
-	if got := byTarget["CLAUDE.md"].Status; got != StatusOutdated {
-		t.Errorf("CLAUDE.md: expected OUTDATED, got %s", got)
+	if got := byTarget[".cursorrules"].Status; got != StatusOutdated {
+		t.Errorf(".cursorrules: expected OUTDATED, got %s", got)
 	}
 	if got := byTarget[".windsurfrules"].Status; got != StatusStale {
 		t.Errorf(".windsurfrules: expected STALE, got %s", got)
-	}
-	if got := byTarget[".cursorrules"].Status; got != StatusMissing {
-		t.Errorf(".cursorrules: expected MISSING, got %s", got)
 	}
 	if got := byTarget[".codeium/instructions.md"].Status; got != StatusMissing {
 		t.Errorf(".codeium/instructions.md: expected MISSING, got %s", got)
@@ -326,7 +323,7 @@ func TestIsPureStaleFile(t *testing.T) {
 func TestWriteAll_ReplacesLegacyArchigraphBlock(t *testing.T) {
 	repo := t.TempDir()
 	legacy := "# Notes\n\n<!-- archigraph:mcp-usage:start v=1 -->\n## archigraph MCP\nold guidance pointing at archigraph\n<!-- archigraph:mcp-usage:end -->\n"
-	path := filepath.Join(repo, "CLAUDE.md")
+	path := filepath.Join(repo, "AGENTS.md")
 	if err := os.WriteFile(path, []byte(legacy), 0o644); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
@@ -402,12 +399,12 @@ func TestRemoveAll_StripsBlockPreservesProse(t *testing.T) {
 	repo := t.TempDir()
 
 	// File with prose + grafel block → block stripped, prose kept.
-	mixedPath := filepath.Join(repo, "CLAUDE.md")
+	mixedPath := filepath.Join(repo, "AGENTS.md")
 	prose := "# My Project\n\nImportant local instructions.\n"
 	if _, err := WriteAll(repo, WriteOptions{GroupName: "demo"}); err != nil {
 		t.Fatalf("WriteAll: %v", err)
 	}
-	// Overwrite CLAUDE.md with prose + block so we control the prose.
+	// Overwrite AGENTS.md with prose + block so we control the prose.
 	mixed := prose + "\n" + RenderBlock("demo") + "\n"
 	if err := os.WriteFile(mixedPath, []byte(mixed), 0o644); err != nil {
 		t.Fatalf("seed mixed: %v", err)
@@ -418,10 +415,10 @@ func TestRemoveAll_StripsBlockPreservesProse(t *testing.T) {
 		t.Fatalf("RemoveAll: %v", err)
 	}
 
-	// CLAUDE.md keeps prose, loses the block.
+	// AGENTS.md keeps prose, loses the block.
 	data, rerr := os.ReadFile(mixedPath)
 	if rerr != nil {
-		t.Fatalf("CLAUDE.md should still exist: %v", rerr)
+		t.Fatalf("AGENTS.md should still exist: %v", rerr)
 	}
 	if strings.Contains(string(data), "grafel:mcp-usage") {
 		t.Errorf("grafel block not stripped from mixed file:\n%s", data)
@@ -429,8 +426,8 @@ func TestRemoveAll_StripsBlockPreservesProse(t *testing.T) {
 	if !strings.Contains(string(data), "Important local instructions.") {
 		t.Errorf("user prose lost:\n%s", data)
 	}
-	if !contains(res.Stripped, "CLAUDE.md") {
-		t.Errorf("CLAUDE.md not reported stripped: %+v", res)
+	if !contains(res.Stripped, "AGENTS.md") {
+		t.Errorf("AGENTS.md not reported stripped: %+v", res)
 	}
 
 	// Files that were ONLY the grafel block (every other Target, since

--- a/internal/install/tooladapter/adapters.go
+++ b/internal/install/tooladapter/adapters.go
@@ -12,7 +12,6 @@ import (
 // order of rulesfiles.Targets changes.
 const (
 	rulesAGENTS   = "AGENTS.md"
-	rulesCLAUDE   = "CLAUDE.md"
 	rulesWindsurf = ".windsurfrules"
 	rulesCursor   = ".cursorrules"
 	rulesCodeium  = ".codeium/instructions.md"
@@ -40,18 +39,22 @@ func hasMCPHost(tool mcpreg.Tool) bool {
 
 // ── claude ───────────────────────────────────────────────────────────
 //
-// The flagship: MCP (.claude.json) + skills (~/.claude/skills/) + rules
-// (CLAUDE.md) + the opt-in PreToolUse agent hook. Skills and the agent
-// hook stay Claude-only. CLAUDE.md is written here; AGENTS.md is owned by
-// the codex adapter (Claude Code also reads AGENTS.md, but to avoid two
-// adapters writing the same file the canonical owner is codex — see
-// rulesfiles package doc).
+// The flagship: MCP (.claude.json) + skills (~/.claude/skills/) + the opt-in
+// PreToolUse agent hook. Skills and the agent hook stay Claude-only.
+//
+// NOTE(#5702): Claude Code guidance is NO LONGER written as a per-repo
+// CLAUDE.md via this adapter's RulesFileTargets. It now goes to the PERSONAL
+// ~/.claude/CLAUDE.md (self-gating, opt-in per developer) — and, only with
+// `--project-guidance`, to <repo>/.claude/CLAUDE.md — both handled directly in
+// install.Apply via rulesfiles.UpsertGuidance. So this adapter returns NO
+// per-repo rules targets. AGENTS.md, which Claude Code also reads, remains
+// owned by the codex adapter.
 type claudeAdapter struct{}
 
 func (claudeAdapter) ID() string                 { return "claude" }
 func (claudeAdapter) DisplayName() string        { return "Claude Code" }
 func (claudeAdapter) DetectInstalled() bool      { return hasMCPHost(mcpreg.ClaudeCode) }
-func (claudeAdapter) RulesFileTargets() []string { return []string{rulesCLAUDE} }
+func (claudeAdapter) RulesFileTargets() []string { return nil }
 func (claudeAdapter) SupportsMCP() bool          { return true }
 func (claudeAdapter) MCPTool() mcpreg.Tool       { return mcpreg.ClaudeCode }
 func (claudeAdapter) SupportsSkills() bool       { return true }

--- a/internal/install/tooladapter/tooladapter_test.go
+++ b/internal/install/tooladapter/tooladapter_test.go
@@ -67,7 +67,8 @@ func TestRestrictedEnablement_OnlySubset(t *testing.T) {
 }
 
 // TestRestrictedEnablement_ClaudeOnly proves Claude-only keeps MCP + skills
-// + hook + CLAUDE.md and drops the other five rules files.
+// + hook and writes NO per-repo rules files: the Claude guidance now goes to
+// the personal ~/.claude/CLAUDE.md, not a committed repo file (#5702).
 func TestRestrictedEnablement_ClaudeOnly(t *testing.T) {
 	cfg := &registry.GroupConfig{Tools: []string{"claude"}}
 	ad := tooladapter.EnabledAdapters(cfg)
@@ -75,8 +76,8 @@ func TestRestrictedEnablement_ClaudeOnly(t *testing.T) {
 		t.Fatalf("expected only claude adapter, got %v", idsOf(ad))
 	}
 	a := ad[0]
-	if rt := unionRulesTargets(ad); !reflect.DeepEqual(rt, []string{"CLAUDE.md"}) {
-		t.Fatalf("claude rules targets = %v, want [CLAUDE.md]", rt)
+	if rt := unionRulesTargets(ad); len(rt) != 0 {
+		t.Fatalf("claude rules targets = %v, want none (guidance is personal ~/.claude/CLAUDE.md)", rt)
 	}
 	if !a.SupportsMCP() || a.MCPTool() != mcpreg.ClaudeCode {
 		t.Fatalf("claude must register ClaudeCode MCP")


### PR DESCRIPTION
Closes #5702. grafel guidance now goes to the PERSONAL `~/.claude/CLAUDE.md` as a self-gating conditional block (no-op unless grafel is connected AND the cwd repo is indexed), instead of the committed repo-root CLAUDE.md. Rationale: grafel is open-source, adoption is per-developer not per-team, so guidance should be personal/opt-in, not imposed on teammates via a committed file. On install it migrates by stripping grafel's marker-delimited block from the repo root (preserving all surrounding content). `--project-guidance` opt-in still writes a committed repo block to `.claude/CLAUDE.md` for all-grafel teams. Reuses existing markers/upsert; idempotent. Refs #5680 #5681 (container/software-factory cleanliness).