### PR TITLE
fix(extract): restore conservative background concurrency cap (revert #5692 lift)

### DIFF
--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -22,18 +22,16 @@ import (
 	"github.com/cajasmota/grafel/internal/executil"
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
-	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/treesitter"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// CoordinatorConfig governs subprocess fan-out. Background defaults are tuned
-// to stay memory-safe on a typical laptop while using more of a high-core host:
+// CoordinatorConfig governs subprocess fan-out. Defaults are tuned to
+// stay under the 600MB Phase-F target on a typical laptop:
 //
-//	Concurrency = backgroundConcurrency(NumCPU, hostMem)  → NumCPU/2, ceiling 12,
-//	              clamped by hostMem / 512MB per child (#5692; was capped at 4)
-//	BatchSize   = 80 files                                → ~100MB peak per subprocess
+//	Concurrency = NumCPU / 2 capped at 4   → 4 × 150MB = 600MB worst-case
+//	BatchSize   = 80 files                  → ~100MB peak per subprocess
 //
 // All fields zero-valued fall back to defaults.
 type CoordinatorConfig struct {
@@ -141,63 +139,38 @@ func (c CoordinatorConfig) concurrency() int {
 		}
 		return n
 	}
-	return backgroundConcurrency(runtime.NumCPU(), process.TotalMemoryMB())
+	return backgroundConcurrency(runtime.NumCPU())
 }
 
-const (
-	// backgroundConcurrencyCeiling is the absolute upper bound on concurrent
-	// extract subprocesses for a BACKGROUND (watch/churn) reindex. Raised from
-	// the historical hard 4 (#3648) to 12 (#5692) so high-core/NVMe hosts stop
-	// idling most of their cores during cold indexing; the memory-budget clamp
-	// in backgroundConcurrency still bounds total RSS on memory-constrained hosts.
-	backgroundConcurrencyCeiling = 12
-
-	// perSubprocessRSSBudgetMB is the memory reservation per extract child used
-	// to derive the memory-safety concurrency clamp. A child peaks well under
-	// this during extract (~80-150MB typical; see subproc.go's memory profile),
-	// so 512MB is a deliberately conservative reservation that keeps N children
-	// comfortably within host RAM even on batches with a few large files.
-	perSubprocessRSSBudgetMB = 512
-)
-
 // backgroundConcurrency computes the default number of concurrent extract
-// subprocesses for a BACKGROUND (watch/churn) reindex from the host core count
-// and total physical memory (MB; <=0 means "unknown" and skips the memory
-// clamp). It is a pure function so the formula is unit-testable (#5692).
+// subprocesses for a BACKGROUND (watch/churn) reindex: min(NumCPU/2, 4).
 //
-// Formula:
+// This cap is INTENTIONALLY low. The daemon reindexes in the background on a
+// developer's own machine while they are actively working; the goal is to leave
+// CPU headroom so continuous background indexing never hangs the box. It is
+// deliberately NOT sized to "use all the cores" — index speed is not the
+// priority here, developer-box responsiveness is.
 //
-//	cpuTarget = clamp(numCPU/2, 1, backgroundConcurrencyCeiling)
-//	memCap    = max(1, totalMemMB / perSubprocessRSSBudgetMB)   [only if known]
-//	result    = min(cpuTarget, memCap)
+// The cap compounds with the per-subprocess GOMAXPROCS cap (extractGOMAXPROCS,
+// default 2): each of these children also runs its own Go runtime pinned to 2
+// cores, so the effective background CPU draw is ~concurrency × 2 threads.
+// Lifting this cap toward the host core count therefore saturates every core
+// (concurrency × 2 threads) and is exactly the #3648 runaway we guard against.
 //
-// Properties (the #5692 hard constraints):
-//   - IDENTICAL to the pre-#5692 min(NumCPU/2, 4) default for hosts with <= 9
-//     cores and ample RAM — the ceiling only lifts above 9 cores.
-//   - Only ever LOOSENS where both cores AND memory allow; the memory clamp can
-//     only ever tighten below the CPU target, preserving the #3648 memory-safety
-//     intent (never fan out past what host RAM can hold).
-//   - Foreground (Interactive) rebuilds are untouched — they resolve to NumCPU
-//     above and do not call this function.
-func backgroundConcurrency(numCPU int, totalMemMB int64) int {
-	if numCPU < 1 {
-		numCPU = 1
-	}
+// Power users who genuinely want more cores opt in explicitly via
+// GRAFEL_EXTRACT_CONCURRENCY (or cpu.json / an explicit Concurrency field),
+// which is checked before this default. Foreground (Interactive) rebuilds are
+// untouched — the user is waiting on those, so they resolve to NumCPU above and
+// never call this function.
+//
+// Kept as a small pure function so the cap stays unit-testable (#3648).
+func backgroundConcurrency(numCPU int) int {
 	n := numCPU / 2
 	if n < 1 {
 		n = 1
 	}
-	if n > backgroundConcurrencyCeiling {
-		n = backgroundConcurrencyCeiling
-	}
-	if totalMemMB > 0 {
-		memCap := int(totalMemMB / perSubprocessRSSBudgetMB)
-		if memCap < 1 {
-			memCap = 1
-		}
-		if n > memCap {
-			n = memCap
-		}
+	if n > 4 {
+		n = 4
 	}
 	return n
 }

--- a/internal/daemon/extract/cpu_cap_test.go
+++ b/internal/daemon/extract/cpu_cap_test.go
@@ -3,8 +3,6 @@ package extract
 import (
 	"runtime"
 	"testing"
-
-	"github.com/cajasmota/grafel/internal/process"
 )
 
 // TestConcurrencyEnvOverride verifies the #3648 emergency throttle:
@@ -24,51 +22,44 @@ func TestConcurrencyEnvOverride(t *testing.T) {
 	// Garbage / non-positive values are ignored → fall back to auto-tune.
 	t.Setenv("GRAFEL_EXTRACT_CONCURRENCY", "not-a-number")
 	auto := (CoordinatorConfig{}).concurrency()
-	want := backgroundConcurrency(runtime.NumCPU(), process.TotalMemoryMB())
+	want := backgroundConcurrency(runtime.NumCPU())
 	if auto != want {
 		t.Fatalf("invalid env ignored: concurrency() = %d, want auto %d", auto, want)
 	}
 }
 
-// TestBackgroundConcurrencyFormula pins the #5692 background-fan-out formula:
-// scale with NumCPU (ceiling backgroundConcurrencyCeiling) but never exceed the
-// per-child RSS budget (totalMem / perSubprocessRSSBudgetMB). It is IDENTICAL to
-// the historical min(NumCPU/2, 4) for <=9-core hosts with ample RAM, only lifts
-// above 9 cores, and only tightens when memory is scarce.
-func TestBackgroundConcurrencyFormula(t *testing.T) {
-	const ampleMem = 65536 // 64 GB — memory clamp never binds
+// TestBackgroundConcurrencyCap pins the conservative background-fan-out default:
+// min(NumCPU/2, 4). This cap is INTENTIONALLY low — the daemon reindexes in the
+// background on the developer's own box while they work, and each child also
+// runs GOMAXPROCS=2, so the effective draw is ~concurrency × 2 threads. A low
+// cap leaves CPU headroom so background indexing never hangs the machine
+// (#3648). Index speed is not the priority; box responsiveness is. Power users
+// who want more cores opt in via GRAFEL_EXTRACT_CONCURRENCY (tested separately).
+//
+// #5692 briefly lifted this to a NumCPU/2 formula with a ceiling of 12 (only
+// memory-clamped); that saturated high-core dev boxes and was reverted. The cap
+// stays flat at 4 by default regardless of host core count.
+func TestBackgroundConcurrencyCap(t *testing.T) {
 	cases := []struct {
 		name   string
 		numCPU int
-		memMB  int64
 		want   int
 	}{
-		// Low-core hosts: unchanged from the historical formula.
-		{"1-core", 1, ampleMem, 1},
-		{"2-core", 2, ampleMem, 1},
-		{"4-core", 4, ampleMem, 2},
-		{"8-core", 8, ampleMem, 4}, // pre-#5692: min(4,4)=4 — unchanged
-		{"9-core", 9, ampleMem, 4}, // 9/2=4 — unchanged
-		// High-core hosts: the raised ceiling lets fan-out grow past the old 4.
-		{"10-core", 10, ampleMem, 5}, // was 4, now 5
-		{"16-core", 16, ampleMem, 8},
-		{"24-core-hits-ceiling", 24, ampleMem, backgroundConcurrencyCeiling},
-		{"64-core-ceiling", 64, ampleMem, backgroundConcurrencyCeiling},
-		// Memory clamp: high cores but scarce RAM tightens below the CPU target.
-		{"16-core-2GB", 16, 2048, 4},  // 2048/512=4 < cpuTarget 8
-		{"16-core-1GB", 16, 1024, 2},  // 1024/512=2
-		{"16-core-300MB", 16, 300, 1}, // floors at 1, never 0
-		// Unknown memory (<=0): skip the clamp, use the CPU target.
-		{"16-core-mem-unknown", 16, 0, 8},
-		{"16-core-mem-negative", 16, -1, 8},
-		// Degenerate core count clamps to 1.
-		{"zero-core", 0, ampleMem, 1},
+		{"1-core", 1, 1},
+		{"2-core", 2, 1},
+		{"4-core", 4, 2},
+		{"8-core", 8, 4},   // min(4, 4) = 4
+		{"9-core", 9, 4},   // 9/2 = 4
+		{"10-core", 10, 4}, // restored default: capped at 4, NOT 5 (#5692 lift reverted)
+		{"16-core", 16, 4}, // high-core host still capped at 4 by default
+		{"64-core", 64, 4}, // no ceiling-12 lift; stays conservative
+		{"zero-core", 0, 1},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := backgroundConcurrency(tc.numCPU, tc.memMB); got != tc.want {
-				t.Fatalf("backgroundConcurrency(%d, %d) = %d, want %d",
-					tc.numCPU, tc.memMB, got, tc.want)
+			if got := backgroundConcurrency(tc.numCPU); got != tc.want {
+				t.Fatalf("backgroundConcurrency(%d) = %d, want %d",
+					tc.numCPU, got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
The background extraction concurrency cap is intentionally low to leave CPU headroom so indexing doesn't hang the developer's machine (subprocesses also run GOMAXPROCS=2, so the cap compounds). PR #5705 (#5692) lifted it to up to 12 cores; this restores the original conservative `min(NumCPU/2, 4)` default (git-verified against 01fc1e1be^). Power users still opt into more via `GRAFEL_EXTRACT_CONCURRENCY`. The betweenness force-exact opt-out from #5692 is kept. Index time is not the priority — box responsiveness (and clear progress) is. Refs #5692.