### PR TITLE
fix(wizard): focus TUI text inputs so Group name/Docs accept keystrokes

### DIFF
--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -3,6 +3,7 @@ package wiztui
 import (
 	"strings"
 
+	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 
 	prog "github.com/cajasmota/grafel/internal/progress"
@@ -408,7 +409,8 @@ func (m Model) enterName() (tea.Model, tea.Cmd) {
 	m.nameInput = newInputModel("Group name", desc, def, false)
 	m.scr = scrName
 	m.step = StepName
-	return m, m.nameInput.focusCmd()
+	// newInputModel already focuses the input; kick off the cursor blink.
+	return m, textinput.Blink
 }
 
 // repoNames renders a short, comma-joined list of repo basenames for the Name
@@ -445,7 +447,8 @@ func (m Model) updateName(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.docsInput = newInputModel("Path to shared group docs",
 			"A folder of shared markdown docs surfaced in the graph. Optional — press enter to skip.", "", true)
 		m.scr = scrDocs
-		return m, m.docsInput.focusCmd()
+		// newInputModel already focuses the input; kick off the cursor blink.
+		return m, textinput.Blink
 	}
 	return m, cmd
 }
@@ -497,7 +500,8 @@ func (m Model) updateMCP(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			"A folder of shared markdown docs surfaced in the graph. Optional — press enter to skip.", m.res.GroupDocs, true)
 		m.scr = scrDocs
 		m.step = StepName
-		return m, m.docsInput.focusCmd()
+		// newInputModel already focuses the input; kick off the cursor blink.
+		return m, textinput.Blink
 	}
 	var cmd tea.Cmd
 	m.mcpList, cmd = m.mcpList.Update(msg)

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -35,6 +35,8 @@ func key(s string) tea.KeyMsg {
 		return tea.KeyMsg{Type: tea.KeyCtrlC}
 	case "esc":
 		return tea.KeyMsg{Type: tea.KeyEsc}
+	case "backspace":
+		return tea.KeyMsg{Type: tea.KeyBackspace}
 	default:
 		return tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(s)}
 	}
@@ -262,6 +264,56 @@ func TestMCPScreenSkippedWhenSingleTool(t *testing.T) {
 	}
 	if m.res.MCPTools == nil || len(*m.res.MCPTools) != 1 || (*m.res.MCPTools)[0] != "claude" {
 		t.Errorf("MCPTools = %v, want [claude] auto-selected", m.res.MCPTools)
+	}
+}
+
+// TestNameInputAcceptsKeystrokes: the Name screen's text input must actually
+// be focused so runes and backspace edit the field (regression for the
+// value-receiver focusCmd bug where m.ti.Focus() mutated a throwaway copy of
+// the stored inputModel, leaving m.focus permanently false and every
+// tea.KeyMsg silently dropped by textinput.Model.Update).
+func TestNameInputAcceptsKeystrokes(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+		{Label: "/b", Value: "/b", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select (both pre-selected)
+	m = m.update(key("enter")) // confirm selection → name
+	if m.scr != scrName {
+		t.Fatalf("scr = %v, want scrName", m.scr)
+	}
+	before := m.nameInput.value()
+	m = m.update(key("x"))
+	if m.nameInput.value() != before+"x" {
+		t.Fatalf("nameInput.value() = %q after typing 'x', want %q (input is not focused/editable)", m.nameInput.value(), before+"x")
+	}
+	m = m.update(key("backspace"))
+	if m.nameInput.value() != before {
+		t.Fatalf("nameInput.value() = %q after backspace, want %q", m.nameInput.value(), before)
+	}
+}
+
+// TestDocsInputAcceptsKeystrokes: same regression, for the Docs screen input.
+func TestDocsInputAcceptsKeystrokes(t *testing.T) {
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+		{Label: "/b", Value: "/b", Selected: true},
+	}}
+	m := newTestModel(d, nilIndex)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // accept default name → docs
+	if m.scr != scrDocs {
+		t.Fatalf("scr = %v, want scrDocs", m.scr)
+	}
+	m = m.update(key("y"))
+	if m.docsInput.value() != "y" {
+		t.Fatalf("docsInput.value() = %q after typing 'y', want %q (input is not focused/editable)", m.docsInput.value(), "y")
+	}
+	m = m.update(key("backspace"))
+	if m.docsInput.value() != "" {
+		t.Fatalf("docsInput.value() = %q after backspace, want empty", m.docsInput.value())
 	}
 }
 

--- a/internal/cli/wiztui/widgets.go
+++ b/internal/cli/wiztui/widgets.go
@@ -317,10 +317,15 @@ func newInputModel(title, description, value string, optional bool) inputModel {
 	ti.Prompt = g.Cursor
 	ti.PromptStyle = cursorStyle
 	ti.Width = 50
+	// Focus immediately on the constructed value so the stored inputModel
+	// (copied into Model.nameInput / Model.docsInput by the caller) is
+	// already focused. A method that focused m.ti via a value receiver would
+	// only mutate a throwaway copy — textinput.Model.Focus() sets its focus
+	// flag directly on the receiver rather than through the returned Cmd, so
+	// that mutation would never reach the caller's copy (the bug this fixes).
+	ti.Focus()
 	return inputModel{title: title, description: description, ti: ti, optional: optional}
 }
-
-func (m inputModel) focusCmd() tea.Cmd { return m.ti.Focus() }
 
 func (m inputModel) value() string { return m.ti.Value() }
 


### PR DESCRIPTION
Closes #5711

## Problem
The full-screen wizard's **Group name** (and Docs) text input dropped every keystroke — the field could not be typed into or cleared, leaving new users stuck.

## Root cause
`inputModel.focusCmd()` had a value receiver, so `textinput.Focus()` mutated a throwaway copy; the stored `nameInput`/`docsInput` never had `focus=true`, and `bubbles/textinput.Model.Update` early-returns on `!focus`.

## Fix
- Focus at construction in `newInputModel` so the value stored on the model is already focused; removed the broken `focusCmd`.
- Former call sites return `textinput.Blink` (cursor animation) instead of the dead command.
- Fixed a latent `key()` test-helper gap (no `backspace` case).

## Tests
`TestNameInputAcceptsKeystrokes` / `TestDocsInputAcceptsKeystrokes` — type a rune + backspace, assert the value changes. Fail on `main`, pass on the fix. `go test ./internal/cli/...` green (386). Independent adversarial review: APPROVE (dual-focus provably harmless — `updateKey` routes keys to exactly one screen).