### PR TITLE
fix(wizard): register monorepos as one repo with Modules, not N flat repos

### DIFF
--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -715,9 +715,27 @@ func groupCandidates(class detect.Classification) []string {
 	return nil
 }
 
+// monorepoRepoForChosen builds the SINGLE registry.Repo for a monorepo action
+// given the chosen package sub-paths, mirroring `monorepo add`
+// (internal/cli/monorepo.go newMonorepoAddCmd): one Repo rooted at the
+// monorepo path with the chosen packages recorded as Modules — never one
+// flattened repo per package (D2: wrong graph model; D3: hooksDir then stats
+// a non-existent <pkg>/.git since only the root has a .git).
+func monorepoRepoForChosen(class detect.Classification, chosen []string) registry.Repo {
+	modules := append([]string(nil), chosen...)
+	sort.Strings(modules)
+	return registry.Repo{
+		Slug:    filepath.Base(class.AbsPath),
+		Path:    class.AbsPath,
+		Stack:   registry.StackList{detect.Stack(class.AbsPath)},
+		Modules: modules,
+	}
+}
+
 // resolveMonorepo detects packages via the shared classifier and presents a
-// [ ]/[✓] multiselect of package roots. Each selected package is registered as
-// its own repo (its absolute sub-path) with the module recorded.
+// [ ]/[✓] multiselect of package roots. The chosen packages are registered as
+// Modules on a single Repo rooted at the monorepo path (see
+// monorepoRepoForChosen) — not as one repo per package.
 func resolveMonorepoAction(out io.Writer, class detect.Classification) ([]registry.Repo, error) {
 	if class.Monorepo == detect.KindNone || len(class.Packages) == 0 {
 		// cwd isn't a monorepo — let the user point at one.
@@ -749,18 +767,7 @@ func resolveMonorepoAction(out io.Writer, class detect.Classification) ([]regist
 	if len(chosen) == 0 {
 		return nil, errors.New("no packages selected")
 	}
-	base := filepath.Base(class.AbsPath)
-	repos := make([]registry.Repo, 0, len(chosen))
-	for _, pkg := range chosen {
-		abs := filepath.Join(class.AbsPath, filepath.FromSlash(pkg))
-		repos = append(repos, registry.Repo{
-			Slug:    base + "-" + filepath.Base(pkg),
-			Path:    abs,
-			Stack:   registry.StackList{detect.Stack(abs)},
-			Modules: []string{pkg},
-		})
-	}
-	return repos, nil
+	return []registry.Repo{monorepoRepoForChosen(class, chosen)}, nil
 }
 
 // resolveAddToGroup lists existing groups, lets the user pick one, then multi-add

--- a/internal/cli/wizard_test.go
+++ b/internal/cli/wizard_test.go
@@ -1,0 +1,86 @@
+package cli
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/detect"
+)
+
+// TestMonorepoRepoForChosen_SingleRepoWithModules exercises the mapping
+// resolveMonorepoAction uses once the huh multiselect returns the user's
+// chosen packages (monorepoRepoForChosen). Regression coverage for D2/D3:
+// the wizard must register ONE registry.Repo rooted at the monorepo path
+// with the chosen packages recorded as Modules — never one flattened repo
+// per package (which produced slugs like "<root>-<module>" and made the
+// install hook loop stat a non-existent "<root>/<module>/.git").
+func TestMonorepoRepoForChosen_SingleRepoWithModules(t *testing.T) {
+	cases := []struct {
+		name    string
+		chosen  []string
+		wantMod []string
+	}{
+		{
+			name:    "single package",
+			chosen:  []string{"packages/pkg-a"},
+			wantMod: []string{"packages/pkg-a"},
+		},
+		{
+			name:    "several packages, unordered input",
+			chosen:  []string{"domains/foo", "packages/pkg-b", "packages/pkg-a"},
+			wantMod: []string{"domains/foo", "packages/pkg-a", "packages/pkg-b"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			class := mustClassify(root)
+
+			got := monorepoRepoForChosen(class, tc.chosen)
+
+			if got.Path != class.AbsPath {
+				t.Errorf("path = %q, want monorepo root %q", got.Path, class.AbsPath)
+			}
+			wantSlug := filepath.Base(class.AbsPath)
+			if got.Slug != wantSlug {
+				t.Errorf("slug = %q, want root-based slug %q (not a per-package slug)", got.Slug, wantSlug)
+			}
+			gotMod := append([]string(nil), got.Modules...)
+			sort.Strings(gotMod)
+			if !reflect.DeepEqual(gotMod, tc.wantMod) {
+				t.Errorf("modules = %v, want %v", gotMod, tc.wantMod)
+			}
+			if got.Stack == nil || len(got.Stack) != 1 || got.Stack[0] != detect.Stack(class.AbsPath) {
+				t.Errorf("stack = %v, want [%v]", got.Stack, detect.Stack(class.AbsPath))
+			}
+		})
+	}
+}
+
+// TestGroupCandidatesAndSingleRepo_UnchangedByMonorepoFix guards against
+// regressions in the ActionGroup / non-monorepo mapping paths, which must
+// keep their current one-repo-per-path behavior — only the monorepo mapping
+// changed.
+func TestGroupCandidatesAndSingleRepo_UnchangedByMonorepoFix(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+
+	repos := reposFromPaths([]string{a, b})
+	if len(repos) != 2 {
+		t.Fatalf("got %d repos, want 2 (group/single paths must stay one-repo-per-path)", len(repos))
+	}
+	if repos[0].Path != a || repos[1].Path != b {
+		t.Errorf("paths = [%s %s], want [%s %s]", repos[0].Path, repos[1].Path, a, b)
+	}
+	if repos[0].Slug != filepath.Base(a) || repos[1].Slug != filepath.Base(b) {
+		t.Errorf("slugs = [%s %s], want [%s %s]", repos[0].Slug, repos[1].Slug, filepath.Base(a), filepath.Base(b))
+	}
+	for _, r := range repos {
+		if len(r.Modules) != 0 {
+			t.Errorf("repo %s has Modules = %v, want none (not a monorepo mapping)", r.Slug, r.Modules)
+		}
+	}
+}

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"sort"
 	"time"
 
@@ -146,22 +145,13 @@ func (d wizardDriver) DefaultGroupName(repos []string) string {
 }
 
 // reposForResult maps the TUI result's chosen paths to registry.Repo records,
-// matching the per-action mapping the huh flow uses (monorepo packages get a
-// module label and a composite slug).
+// matching the per-action mapping the huh flow uses. A monorepo action maps
+// to EXACTLY ONE registry.Repo rooted at the monorepo path, with the chosen
+// packages recorded as Modules (see monorepoRepoForChosen) — never one
+// flattened repo per package (D2/D3).
 func reposForResult(class detect.Classification, r wiztui.Result) []registry.Repo {
 	if r.Action == wiztui.ActionMonorepo {
-		base := filepath.Base(class.AbsPath)
-		out := make([]registry.Repo, 0, len(r.Repos))
-		for _, pkg := range r.Repos {
-			abs := filepath.Join(class.AbsPath, filepath.FromSlash(pkg))
-			out = append(out, registry.Repo{
-				Slug:    base + "-" + filepath.Base(pkg),
-				Path:    abs,
-				Stack:   registry.StackList{detect.Stack(abs)},
-				Modules: []string{pkg},
-			})
-		}
-		return out
+		return []registry.Repo{monorepoRepoForChosen(class, r.Repos)}
 	}
 	return reposFromPaths(r.Repos)
 }

--- a/internal/cli/wizard_tui_run_test.go
+++ b/internal/cli/wizard_tui_run_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
+	"sort"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/cli/wiztui"
@@ -43,22 +45,33 @@ func TestWizardUseTUI_OptOutEnv(t *testing.T) {
 	}
 }
 
-// TestReposForResult_Monorepo: monorepo packages map to composite slugs with a
-// recorded module, matching the huh flow.
+// TestReposForResult_Monorepo: a monorepo action must map to EXACTLY ONE
+// registry.Repo rooted at the monorepo path, with the chosen packages
+// recorded as Modules — NOT one flattened repo per package (D2/D3: flattening
+// breaks the graph model and makes hooksDir stat a non-existent <pkg>/.git).
+// This mirrors `monorepo add`, which appends packages into r.Modules on a
+// single Repo (internal/cli/monorepo.go newMonorepoAddCmd).
 func TestReposForResult_Monorepo(t *testing.T) {
 	root := t.TempDir()
 	class := mustClassify(root)
-	// Force a monorepo-style result.
+	// Force a monorepo-style result with multiple chosen packages.
 	r := wiztui.Result{Action: wiztui.ActionMonorepo, Repos: []string{"services/auth", "packages/ui"}}
 	repos := reposForResult(class, r)
-	if len(repos) != 2 {
-		t.Fatalf("got %d repos, want 2", len(repos))
+	if len(repos) != 1 {
+		t.Fatalf("got %d repos, want 1 (single repo with Modules, not one per package)", len(repos))
+	}
+	got := repos[0]
+	if got.Path != class.AbsPath {
+		t.Errorf("path = %q, want monorepo root %q", got.Path, class.AbsPath)
 	}
 	base := filepath.Base(class.AbsPath)
-	if repos[0].Slug != base+"-auth" {
-		t.Errorf("slug = %q, want %q", repos[0].Slug, base+"-auth")
+	if got.Slug != base {
+		t.Errorf("slug = %q, want root-based slug %q", got.Slug, base)
 	}
-	if len(repos[0].Modules) != 1 || repos[0].Modules[0] != "services/auth" {
-		t.Errorf("modules = %v, want [services/auth]", repos[0].Modules)
+	wantModules := []string{"packages/ui", "services/auth"}
+	gotModules := append([]string(nil), got.Modules...)
+	sort.Strings(gotModules)
+	if !reflect.DeepEqual(gotModules, wantModules) {
+		t.Errorf("modules = %v, want %v", gotModules, wantModules)
 	}
 }


### PR DESCRIPTION
Closes #5712

## Problem
On a single-git-root monorepo, the wizard registered **each module as its own repo** (composite slugs `<root>-<module>`) instead of **one repo with a `Modules[]` list**. This flattened the graph model and made git-hooks install stat non-existent `<root>/<module>/.git` (`hooks for <root>/<module>: stat ...: no such file or directory`).

## Fix
Both wizard paths (`reposForResult` ActionMonorepo + `resolveMonorepoAction`) now build ONE `registry.Repo{Path: root, Slug: rootBase, Modules: chosenPackages}` via a shared `monorepoRepoForChosen` helper — mirroring the existing `grafel monorepo add` / `monorepo migrate` shape. Registering only the root repo also fixes the hook failure (one `hooks.Install` against a path that has `.git`).

## Not changed
Detection, `hooks.Install`, and genuine multi-repo `ActionGroup` flows are untouched (regression-tested). `Modules` are still fully indexed — extraction walks the whole repo `Path`; `Modules` is metadata (CWD→module routing, dashboard), never scopes the walk.

## Tests
`TestReposForResult_Monorepo` (1 repo, Path=root, Modules=chosen), `TestMonorepoRepoForChosen_SingleRepoWithModules`, `TestGroupCandidatesAndSingleRepo_UnchangedByMonorepoFix`. Fail on `main`, pass on the fix. `go test ./internal/cli/... ./internal/install/...` green (717). Independent adversarial review (Opus): APPROVE — confirmed Modules are indexed, no downstream consumer breaks.