### PR TITLE
fix(daemon): shutdown watchdog + pidfile reclaim for a wedged daemon

### DIFF
--- a/internal/daemon/pidfile.go
+++ b/internal/daemon/pidfile.go
@@ -3,10 +3,14 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"net/rpc/jsonrpc"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
 	"github.com/cajasmota/grafel/internal/process"
 )
 
@@ -15,27 +19,98 @@ import (
 // the wrapped error message so callers can surface it directly.
 var ErrAlreadyRunning = errors.New("daemon already running")
 
-// AcquirePIDFile writes the current pid to path, returning a release
-// closure. If path already contains a pid for a running process, the
-// call returns ErrAlreadyRunning. Stale pid files (the named process is
-// gone) are overwritten silently — a crash should never wedge startup.
+// socketHealthProbeTimeout bounds a single dial+Ping attempt when deciding
+// whether a live, correctly-named pidfile owner is actually serving (#5710).
+// Kept short — this runs synchronously on the `grafel start` path — but long
+// enough that a momentarily-busy daemon (e.g. mid-GC) is not misjudged.
+const socketHealthProbeTimeout = 300 * time.Millisecond
+
+// socketHealthProbeRetries is the number of retries (beyond the first
+// attempt) before a live grafel pid whose socket won't answer Ping is
+// treated as reclaimable. Guards against a false-positive reclaim of a
+// healthy daemon that is merely slow to respond to one probe.
+const socketHealthProbeRetries = 2
+
+// socketHealthProbe reports whether the daemon behind socketPath answers a
+// Ping RPC. It is a package variable (rather than a hardcoded call) so tests
+// can substitute a fake without standing up a real daemon + listener for
+// every pidfile-reclaim case; production code uses dialAndPing.
+var socketHealthProbe = dialAndPing
+
+// dialAndPing is the real health probe: dial the daemon's IPC transport and
+// issue a single Ping RPC, both bounded by timeout. transport/proto are leaf
+// packages that do not import package daemon (nor does this function import
+// internal/daemon/client, which itself imports package daemon — importing
+// client here would create an import cycle; see #5710).
+func dialAndPing(socketPath string, timeout time.Duration) bool {
+	conn, err := transport.DialTimeout(socketPath, timeout)
+	if err != nil {
+		return false
+	}
+	defer conn.Close()
+	_ = conn.SetDeadline(time.Now().Add(timeout))
+	rpcClient := jsonrpc.NewClient(conn)
+	defer rpcClient.Close()
+	var reply proto.PingReply
+	err = rpcClient.Call(proto.ServiceName+".Ping", proto.PingArgs{}, &reply)
+	return err == nil
+}
+
+// socketIsHealthy retries socketHealthProbe up to socketHealthProbeRetries
+// times (with a short pause between attempts) before declaring the socket
+// unhealthy. A single failed probe is not enough to condemn a live daemon —
+// only sustained unreachability across every attempt does.
+func socketIsHealthy(socketPath string) bool {
+	for attempt := 0; attempt <= socketHealthProbeRetries; attempt++ {
+		if socketHealthProbe(socketPath, socketHealthProbeTimeout) {
+			return true
+		}
+		if attempt < socketHealthProbeRetries {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	return false
+}
+
+// AcquirePIDFile writes the current pid to pidPath, returning a release
+// closure. If pidPath already contains a pid for a running grafel process,
+// AcquirePIDFile probes that daemon's socketPath with a Ping RPC:
+//
+//   - If the daemon answers, it is genuinely alive and serving — the call
+//     returns ErrAlreadyRunning, as before.
+//   - If the daemon does NOT answer within socketHealthProbeRetries+1
+//     attempts, it is treated as wedged (#5710 — e.g. blocked forever in
+//     graceful shutdown behind a stalled RPC) rather than "running": the old
+//     process is force-killed and the pidfile is reclaimed so `grafel start`
+//     is not permanently refused by a daemon that can never again serve a
+//     request.
+//
+// Stale pid files (the named process is gone entirely) are overwritten
+// silently, as before — a crash should never wedge startup.
 //
 // We deliberately do NOT use flock here: the goal is to detect another
 // daemon, and pid+syscall.Kill(pid,0) is portable across darwin/linux
 // without a new dependency.
-func AcquirePIDFile(path string) (release func(), err error) {
-	if existing, ok := readPID(path); ok && pidIsLiveDaemon(existing) {
-		return nil, fmt.Errorf("%w (pid %d)", ErrAlreadyRunning, existing)
+func AcquirePIDFile(pidPath, socketPath string) (release func(), err error) {
+	if existing, ok := readPID(pidPath); ok && pidIsLiveDaemonFunc(existing) {
+		if socketIsHealthy(socketPath) {
+			return nil, fmt.Errorf("%w (pid %d)", ErrAlreadyRunning, existing)
+		}
+		// The pid is alive and is a grafel process, but its socket will not
+		// answer a Ping within the bounded retry window — the daemon is wedged
+		// (e.g. stuck in graceful shutdown behind a stalled Rebuild RPC, #5710)
+		// and can never again serve a request. Reclaim rather than refuse.
+		_ = forceKillFunc(existing)
 	}
 	pid := os.Getpid()
-	if err := os.WriteFile(path, []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
-		return nil, fmt.Errorf("write pid file %s: %w", path, err)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(pid)+"\n"), 0o600); err != nil {
+		return nil, fmt.Errorf("write pid file %s: %w", pidPath, err)
 	}
 	return func() {
 		// Best-effort cleanup. Errors here are not actionable — if we
 		// can't remove our own pid file, the next startup will see a
 		// stale entry and overwrite it.
-		_ = os.Remove(path)
+		_ = os.Remove(pidPath)
 	}, nil
 }
 
@@ -94,6 +169,17 @@ func pidIsLiveDaemon(pid int) bool {
 	}
 	return isGrafel
 }
+
+// pidIsLiveDaemonFunc indirects pidIsLiveDaemon so tests can simulate "the
+// pidfile names a live grafel process" without spawning a real grafel
+// binary (process.PidIsGrafel matches on executable name, which a unit test
+// binary can never satisfy). Production code always uses pidIsLiveDaemon.
+var pidIsLiveDaemonFunc = pidIsLiveDaemon
+
+// forceKillFunc indirects process.ForceKill so the #5710 pidfile-reclaim
+// tests can observe/stub the kill without actually depending on
+// process.ForceKill's platform-specific signal delivery semantics.
+var forceKillFunc = process.ForceKill
 
 // pidAlive returns true when a process with the given pid exists. The
 // platform-specific liveness probe lives in internal/process: signal 0

--- a/internal/daemon/pidfile_test.go
+++ b/internal/daemon/pidfile_test.go
@@ -5,8 +5,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
+	"time"
 )
 
 // reapedChildPID starts and reaps a trivial child so we hold a PID that is
@@ -39,7 +41,7 @@ func TestAcquirePIDFile_StaleDeadPID_Proceeds(t *testing.T) {
 	dead := reapedChildPID(t)
 	writePIDFile(t, path, dead)
 
-	release, err := AcquirePIDFile(path)
+	release, err := AcquirePIDFile(path, "")
 	if err != nil {
 		t.Fatalf("expected stale dead-pid pidfile to be overwritten, got error: %v", err)
 	}
@@ -64,7 +66,7 @@ func TestAcquirePIDFile_LiveNonGrafelPID_TreatedStale(t *testing.T) {
 	// os.Getpid() here is the test binary ("daemon.test"), not "grafel".
 	writePIDFile(t, path, os.Getpid())
 
-	release, err := AcquirePIDFile(path)
+	release, err := AcquirePIDFile(path, "")
 	if err != nil {
 		t.Fatalf("expected live non-grafel pid to be treated as stale, got: %v", err)
 	}
@@ -81,7 +83,7 @@ func TestAcquirePIDFile_NoExistingFile_Succeeds(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "daemon.pid")
 
-	release, err := AcquirePIDFile(path)
+	release, err := AcquirePIDFile(path, "")
 	if err != nil {
 		t.Fatalf("AcquirePIDFile on empty dir: %v", err)
 	}
@@ -95,7 +97,7 @@ func TestAcquirePIDFile_NoExistingFile_Succeeds(t *testing.T) {
 func TestAcquirePIDFile_ReleaseRemovesFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "daemon.pid")
-	release, err := AcquirePIDFile(path)
+	release, err := AcquirePIDFile(path, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -127,5 +129,120 @@ func TestPidIsLiveDaemon(t *testing.T) {
 	// The test binary is live but is not "grafel".
 	if pidIsLiveDaemon(os.Getpid()) {
 		t.Fatal("live non-grafel pid must not be treated as the daemon owner")
+	}
+}
+
+// spawnLiveChild starts a disposable, long-lived child process and returns
+// its pid plus a cleanup that force-kills it (idempotent — safe to call even
+// if the test already killed it via forceKillFunc/AcquirePIDFile's reclaim
+// path). Used to stand in for "a live grafel daemon" pid: we cannot spawn a
+// real grafel binary in a unit test, so #5710 reclaim tests fake the
+// name-match decision via pidIsLiveDaemonFunc and only need a genuinely
+// live, killable pid underneath it.
+func spawnLiveChild(t *testing.T) (pid int, cleanup func()) {
+	t.Helper()
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/C", "ping -n 31 127.0.0.1 >NUL")
+	} else {
+		cmd = exec.Command("sleep", "30")
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("spawn live child: %v", err)
+	}
+	done := make(chan struct{})
+	go func() { _ = cmd.Wait(); close(done) }()
+	return cmd.Process.Pid, func() {
+		_ = cmd.Process.Kill()
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+		}
+	}
+}
+
+// withFakePidIsLiveDaemon overrides pidIsLiveDaemonFunc for the duration of
+// the test so AcquirePIDFile treats pid as "a live grafel daemon" without
+// requiring a real grafel binary.
+func withFakePidIsLiveDaemon(t *testing.T, wantPID int) {
+	t.Helper()
+	orig := pidIsLiveDaemonFunc
+	pidIsLiveDaemonFunc = func(pid int) bool { return pid == wantPID }
+	t.Cleanup(func() { pidIsLiveDaemonFunc = orig })
+}
+
+// withFakeSocketHealth overrides socketHealthProbe for the duration of the
+// test so AcquirePIDFile's reclaim decision doesn't need a real daemon
+// listening on socketPath.
+func withFakeSocketHealth(t *testing.T, healthy bool) {
+	t.Helper()
+	orig := socketHealthProbe
+	socketHealthProbe = func(string, time.Duration) bool { return healthy }
+	t.Cleanup(func() { socketHealthProbe = orig })
+}
+
+// #5710: a pidfile naming a live, grafel-named process whose socket does NOT
+// answer Ping (the wedged-daemon scenario — stuck in graceful shutdown behind
+// a stalled Rebuild RPC) must be RECLAIMED, not refused. AcquirePIDFile
+// should force-kill the old pid and overwrite the pidfile with our own.
+func TestAcquirePIDFile_LiveGrafelPID_UnhealthySocket_Reclaims(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.pid")
+
+	oldPID, cleanupChild := spawnLiveChild(t)
+	defer cleanupChild()
+	writePIDFile(t, path, oldPID)
+
+	withFakePidIsLiveDaemon(t, oldPID)
+	withFakeSocketHealth(t, false)
+
+	release, err := AcquirePIDFile(path, "/nonexistent/socket/for/probe")
+	if err != nil {
+		t.Fatalf("expected unhealthy-socket pidfile to be reclaimed, got error: %v", err)
+	}
+	defer release()
+
+	if got := ReadPIDFile(path); got != os.Getpid() {
+		t.Fatalf("pidfile = %d after reclaim, want current pid %d", got, os.Getpid())
+	}
+
+	// The old, wedged pid must actually be gone — otherwise the reclaim is a
+	// pidfile-only fiction and the real wedged process leaks.
+	deadline := time.Now().Add(2 * time.Second)
+	for pidAlive(oldPID) && time.Now().Before(deadline) {
+		time.Sleep(20 * time.Millisecond)
+	}
+	if pidAlive(oldPID) {
+		t.Fatalf("old pid %d still alive after reclaim; expected it to be force-killed", oldPID)
+	}
+}
+
+// #5710 false-positive guard: a pidfile naming a live, grafel-named process
+// whose socket DOES answer Ping must be refused as ErrAlreadyRunning — a
+// healthy daemon must never be force-killed just because it exists.
+func TestAcquirePIDFile_LiveGrafelPID_HealthySocket_RefusesNoReclaim(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "daemon.pid")
+
+	oldPID, cleanupChild := spawnLiveChild(t)
+	defer cleanupChild()
+	writePIDFile(t, path, oldPID)
+
+	withFakePidIsLiveDaemon(t, oldPID)
+	withFakeSocketHealth(t, true)
+
+	_, err := AcquirePIDFile(path, "/nonexistent/socket/for/probe")
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Fatalf("expected ErrAlreadyRunning for a healthy daemon, got: %v", err)
+	}
+
+	// The healthy "daemon" must NOT have been killed.
+	if !pidAlive(oldPID) {
+		t.Fatalf("healthy pid %d was killed — false-positive reclaim", oldPID)
+	}
+
+	// The pidfile must still name the original (healthy) owner, not us.
+	if got := ReadPIDFile(path); got != oldPID {
+		t.Fatalf("pidfile = %d after refused acquire, want unchanged original pid %d", got, oldPID)
 	}
 }

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -332,7 +332,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// wedged startup step (the isolated selftest daemon hangs here). Cheap +
 	// helps all platforms; does NOT change startup order/behavior.
 	logger.Info("startup: pidfile-acquire begin")
-	releasePID, err := AcquirePIDFile(cfg.Layout.PIDPath)
+	releasePID, err := AcquirePIDFile(cfg.Layout.PIDPath, cfg.Layout.SocketPath)
 	if err != nil {
 		return err
 	}
@@ -756,6 +756,21 @@ func Run(ctx context.Context, cfg Config) error {
 		return errors.New("listener closed")
 	}
 
+	// #5710: hard-exit watchdog. mcpDrainTimeout below bounds ONLY the MCP
+	// drain — it has no effect on connWG.Wait() near the end of this
+	// function, which joins every accepted connection including ones blocked
+	// inside a non-MCP RPC handler (e.g. Service.Rebuild, whose own timeout
+	// is rebuildRPCTimeout = 2h and which never observes shutdown). Without a
+	// backstop, a single stalled Rebuild call wedges Run() forever: it never
+	// returns, the deferred releasePID() never runs, and the pidfile is left
+	// pointing at a process that is alive but can never again serve a
+	// request. watchdogCtx bounds the ENTIRE graceful tail from here to the
+	// `return nil` below (not just connWG.Wait()) so it also covers a slow
+	// MCP drain; if it fires before the tail completes, force-exit rather
+	// than hang past launchd/systemd's SIGTERM→SIGKILL grace window.
+	watchdogCtx, watchdogCancel := context.WithTimeout(context.Background(), shutdownWatchdogTimeout())
+	defer watchdogCancel()
+
 	// #5633: graceful MCP drain. Mark the service as draining so any MCP RPC
 	// that arrives from here on gets a clean retryable error (the bridge
 	// reconnects to the replacement daemon) instead of being half-served and
@@ -778,12 +793,62 @@ func Run(ctx context.Context, cfg Config) error {
 		cfg.ShutdownCleanup()
 	}
 
-	// Stop accepting new connections, then wait for in-flight ones.
+	// Stop accepting new connections, then wait for in-flight ones — bounded
+	// by watchdogCtx (#5710). This is exactly the step that used to hang
+	// forever behind a stalled Rebuild RPC: connWG.Wait() blocks until every
+	// accepted connection's handler returns, and Rebuild has no shutdown/
+	// ctx.Done case in its own select.
 	_ = listener.Close()
 	<-acceptDone
-	connWG.Wait()
-	logger.Info("graceful shutdown complete")
-	return nil
+	connDone := make(chan struct{})
+	go func() {
+		connWG.Wait()
+		close(connDone)
+	}()
+	select {
+	case <-connDone:
+		logger.Info("graceful shutdown complete")
+		return nil
+	case <-watchdogCtx.Done():
+		// os.Exit skips every deferred cleanup in this function (releasePID,
+		// socket unlink), so we repeat the pidfile/socket removal explicitly
+		// before exiting — otherwise the force-killed process would leave
+		// the exact stale-pidfile wedge this change exists to prevent.
+		logger.Error("force-exit: graceful shutdown exceeded watchdog timeout",
+			"timeout", shutdownWatchdogTimeout())
+		releasePID()
+		_ = os.Remove(cfg.Layout.SocketPath)
+		osExit(1)
+		// Reached only when osExit has been overridden (tests): production
+		// os.Exit never returns, so this line only runs when a test stub
+		// swapped osExit for a no-op — proving Run() unblocks from the
+		// stalled connWG.Wait() instead of hanging forever (#5710).
+		return errors.New("graceful shutdown watchdog exceeded; force-exited")
+	}
+}
+
+// osExit is os.Exit, indirected through a package variable so the #5710
+// hard-exit watchdog is testable in-process: production always force-exits
+// the whole process, but tests substitute a no-op and assert Run() still
+// returns (via the fallback return just below the osExit call) instead of
+// hanging on connWG.Wait() forever — without killing the test binary itself.
+var osExit = os.Exit
+
+// SetShutdownExitFuncForTest overrides the #5710 hard-exit watchdog's exit
+// function for the duration of a test and returns a restore closure. Tests
+// live in package daemon_test (external), so this exported hook is the only
+// way to reach the unexported osExit var without creating an import cycle
+// (internal/daemon/client, needed to drive the daemon from a test, itself
+// imports package daemon).
+//
+// Production code must never call this. The suffix is dead-stripped by
+// nothing at build time — it is an ordinary exported function — but the name
+// mirrors this repo's established ForTest convention (see internal/docgen)
+// for hooks that exist solely to let tests reach otherwise-unexported state.
+func SetShutdownExitFuncForTest(f func(int)) (restore func()) {
+	prev := osExit
+	osExit = f
+	return func() { osExit = prev }
 }
 
 // mcpDrainTimeout bounds how long graceful shutdown waits for in-flight MCP
@@ -793,6 +858,32 @@ func Run(ctx context.Context, cfg Config) error {
 // (launchd's default SIGTERM→SIGKILL window and systemd's TimeoutStopSec are
 // both ~5 s+; we deliberately stay under that).
 const mcpDrainTimeout = 3 * time.Second
+
+// defaultShutdownWatchdog bounds the ENTIRE graceful-shutdown tail — from the
+// moment a shutdown trigger fires to Run() returning — not just the MCP
+// drain. #5710: a stalled Service.Rebuild RPC holds its connection open
+// indefinitely (rebuildRPCTimeout is 2h and has no shutdown/ctx.Done case),
+// so connWG.Wait() can block forever with no MCP-drain-timeout in the world
+// that would ever unblock it. 5s keeps the watchdog under launchd's default
+// SIGTERM→SIGKILL grace window (and systemd's TimeoutStopSec), matching the
+// same target mcpDrainTimeout above already stays under.
+const defaultShutdownWatchdog = 5 * time.Second
+
+// shutdownWatchdogEnv overrides defaultShutdownWatchdog with a Go duration
+// string (e.g. "200ms"), primarily so tests can exercise the force-exit path
+// without a real 5s wait.
+const shutdownWatchdogEnv = "GRAFEL_SHUTDOWN_WATCHDOG"
+
+// shutdownWatchdogTimeout resolves the watchdog bound: shutdownWatchdogEnv if
+// set to a valid positive duration, else defaultShutdownWatchdog.
+func shutdownWatchdogTimeout() time.Duration {
+	if raw := strings.TrimSpace(os.Getenv(shutdownWatchdogEnv)); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+	}
+	return defaultShutdownWatchdog
+}
 
 // acceptLoop pulls connections off the listener and hands each to
 // jsonrpc.ServeConn under the registered server. The waitgroup tracks

--- a/internal/daemon/shutdown_watchdog_test.go
+++ b/internal/daemon/shutdown_watchdog_test.go
@@ -1,0 +1,136 @@
+package daemon_test
+
+// shutdown_watchdog_test.go — regression test for issue #5710: a stalled
+// Service.Rebuild RPC (rebuildRPCTimeout = 2h, no shutdown/ctx.Done case)
+// holds its connection open indefinitely, so connWG.Wait() in Run()'s
+// graceful-shutdown tail can block forever, wedging the pidfile. This test
+// verifies the hard-exit watchdog: once shutdown is triggered while a
+// Rebuild is in flight, Run() must return within the (test-shortened)
+// watchdog timeout rather than hang.
+//
+// This test cannot substitute a fake RebuildFunc through a real subprocess
+// (cmd/grafel wires the production RebuildFunc, not an injectable stub), so
+// it drives daemon.Run in-process via the same harness as daemon_test.go
+// (runDaemonForTest / isolateDaemonEnv / waitDaemonReady, all defined in
+// that file within this same package). The watchdog's real behavior calls
+// os.Exit(1), which would kill the whole `go test` process if exercised
+// as-is; daemon.SetShutdownExitFuncForTest (server.go) is the exported hook
+// that lets an external test swap in a no-op and observe that Run() still
+// returns via its fallback path — proving the watchdog unblocked Run()
+// instead of hanging on connWG.Wait() forever.
+
+import (
+	"context"
+	"os"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestDaemon_ShutdownWatchdogForceExitsOnStalledRebuild is the #5710
+// RED/GREEN test. Before the watchdog existed, this test would hang until
+// its own outer timeout fired (a false "pass" only in the sense that `go
+// test` eventually kills it — in practice it demonstrated the same
+// unbounded hang the daemon suffers in production). With the watchdog, Run()
+// returns quickly once osExit is stubbed to survive the force-exit call.
+func TestDaemon_ShutdownWatchdogForceExitsOnStalledRebuild(t *testing.T) {
+	isolateDaemonEnv(t)
+
+	// #5710: server.go's shutdownWatchdogTimeout() honors this env var
+	// (shutdownWatchdogEnv) so the test doesn't wait out the real 5s default.
+	const testWatchdog = 300 * time.Millisecond
+	t.Setenv("GRAFEL_SHUTDOWN_WATCHDOG", testWatchdog.String())
+
+	var exitCalled atomic.Bool
+	var exitCode atomic.Int64
+	restore := daemon.SetShutdownExitFuncForTest(func(code int) {
+		exitCalled.Store(true)
+		exitCode.Store(int64(code))
+		// Deliberately do not exit — see server.go's watchdog branch: the
+		// `return` immediately after its osExit(1) call is reachable only
+		// when osExit does not actually terminate the process, which is
+		// exactly what lets this test observe Run() returning.
+	})
+	t.Cleanup(restore)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure layout: %v", err)
+	}
+
+	// RebuildFunc that blocks forever — simulates the stalled-rebuild
+	// deadlock from #5710. The channel is never closed; the handler
+	// goroutine (and the client goroutine driving it) are deliberately
+	// leaked for the test process's lifetime, matching the real scenario
+	// where a stalled rebuild is abandoned rather than cancelled.
+	blockForever := make(chan struct{})
+	rb := func(args proto.RebuildArgs) ([]string, string, error) {
+		<-blockForever
+		return nil, "", nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- daemon.Run(ctx, daemon.Config{Layout: layout, Rebuild: rb})
+	}()
+
+	waitDaemonReady(t, layout.SocketPath, 10*time.Second)
+
+	c, err := client.DialPath(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	rebuildStarted := make(chan struct{})
+	go func() {
+		close(rebuildStarted)
+		_, _ = c.Rebuild(proto.RebuildArgs{Group: "stall-group"})
+	}()
+	<-rebuildStarted
+	// Best-effort: give the RPC a moment to actually land server-side before
+	// triggering shutdown, so the watchdog genuinely races a stalled call in
+	// flight rather than one that hasn't arrived yet. The deadline assertion
+	// below is generous enough to tolerate scheduling slack either way.
+	time.Sleep(150 * time.Millisecond)
+
+	start := time.Now()
+	cancel() // trigger shutdown while the Rebuild call is stuck
+
+	select {
+	case runErr := <-runDone:
+		elapsed := time.Since(start)
+		t.Logf("Run returned after %s (watchdog=%s), err=%v, osExit called=%v code=%v",
+			elapsed, testWatchdog, runErr, exitCalled.Load(), exitCode.Load())
+		// Generous ceiling: an order of magnitude above the 300ms watchdog,
+		// but two+ orders of magnitude below the old unbounded (2h
+		// rebuildRPCTimeout-scale) hang this guards against.
+		if elapsed > 5*time.Second {
+			t.Fatalf("Run took %s to return; want well under 5s (watchdog=%s)", elapsed, testWatchdog)
+		}
+		if !exitCalled.Load() {
+			t.Fatal("expected the #5710 watchdog to invoke the exit func; it did not fire")
+		}
+		if exitCode.Load() != 1 {
+			t.Fatalf("exit func called with code %d, want 1", exitCode.Load())
+		}
+		if runErr == nil {
+			t.Fatal("expected Run to return a non-nil error on the force-exit path")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Run did not return within 8s of shutdown trigger — #5710 regression: watchdog did not unblock connWG.Wait()")
+	}
+
+	// The pidfile must not be left behind by the force-exit path: server.go
+	// explicitly removes it before calling osExit, since a real os.Exit
+	// would skip the deferred releasePID() entirely.
+	if _, statErr := os.Stat(layout.PIDPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected pidfile %s removed by force-exit cleanup, stat err = %v", layout.PIDPath, statErr)
+	}
+}

--- a/internal/process/process_darwin.go
+++ b/internal/process/process_darwin.go
@@ -40,6 +40,22 @@ func Kill(pid int) error {
 	return nil
 }
 
+// ForceKill sends SIGKILL to the process with the given PID. Unlike Kill
+// (SIGTERM), a process cannot ignore or handle this — used for #5710
+// pidfile reclaim, where the target daemon is alive but not responding on
+// its socket (e.g. wedged inside a stalled RPC) and a graceful SIGTERM
+// cannot be trusted to take effect promptly.
+func ForceKill(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("FindProcess(%d): %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal(%d, SIGKILL): %w", pid, err)
+	}
+	return nil
+}
+
 // CPUPercent returns the instantaneous %cpu of pid via `ps -o %cpu= -p <pid>`.
 // On macOS there is no /proc, so a single ps shell-out is the portable approach.
 func CPUPercent(pid int) (float64, error) {

--- a/internal/process/process_linux.go
+++ b/internal/process/process_linux.go
@@ -54,6 +54,22 @@ func Kill(pid int) error {
 	return nil
 }
 
+// ForceKill sends SIGKILL to the process with the given PID. Unlike Kill
+// (SIGTERM), a process cannot ignore or handle this — used for #5710
+// pidfile reclaim, where the target daemon is alive but not responding on
+// its socket (e.g. wedged inside a stalled RPC) and a graceful SIGTERM
+// cannot be trusted to take effect promptly.
+func ForceKill(pid int) error {
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("FindProcess(%d): %w", pid, err)
+	}
+	if err := proc.Signal(syscall.SIGKILL); err != nil {
+		return fmt.Errorf("signal(%d, SIGKILL): %w", pid, err)
+	}
+	return nil
+}
+
 // CPUPercent returns the instantaneous CPU usage of pid as a percentage
 // by reading /proc/<pid>/stat and computing user+sys ticks / clock ticks.
 // On Linux this is derived from two samples; for a single-shot reading it

--- a/internal/process/process_other.go
+++ b/internal/process/process_other.go
@@ -21,6 +21,11 @@ func Kill(pid int) error {
 	return fmt.Errorf("process.Kill: unsupported platform %s", runtime.GOOS)
 }
 
+// ForceKill sends an unconditional termination signal to the given PID.
+func ForceKill(pid int) error {
+	return fmt.Errorf("process.ForceKill: unsupported platform %s", runtime.GOOS)
+}
+
 // CPUPercent is not implemented on this platform.
 func CPUPercent(_ int) (float64, error) {
 	return 0, fmt.Errorf("process.CPUPercent: unsupported platform %s", runtime.GOOS)

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -74,6 +74,14 @@ func Kill(pid int) error {
 	return nil
 }
 
+// ForceKill terminates the given PID. On Windows there is no softer
+// "SIGKILL vs SIGTERM" distinction — TerminateProcess is already
+// unconditional — so this is an alias for Kill, kept for API symmetry with
+// the unix implementations (#5710 pidfile reclaim).
+func ForceKill(pid int) error {
+	return Kill(pid)
+}
+
 // CPUPercent is not implemented on Windows.
 func CPUPercent(_ int) (float64, error) {
 	return 0, fmt.Errorf("process.CPUPercent: unsupported platform windows")


### PR DESCRIPTION
Refs #5710

## Problem
A daemon wedged mid-rebuild (or otherwise spinning with a dead socket) blocks all restart-based recovery: graceful shutdown hangs forever on `connWG.Wait()` (the drain only covers MCP RPCs, not `Rebuild`, which has no shutdown context), so the process never exits and keeps its pidfile — then `grafel start` refuses with `daemon already running (pid N)`. Only `kill -9` + manual pidfile deletion recovers. (Observed live: a daemon pegged at 445% CPU for 3h with a dead socket, unrecoverable via CLI.)

## Fix (a + c; b deferred)
- **(a) hard-exit watchdog** — after a shutdown trigger, a bounded watchdog (`GRAFEL_SHUTDOWN_WATCHDOG`, default 5s) force-exits if the graceful tail (MCP drain + `connWG.Wait()`) doesn't complete. It explicitly removes the pidfile + socket before `os.Exit` (which skips defers). Graph writes are atomic tmp+rename, so a hard exit can orphan a `.tmp` but never corrupts the graph. Normal fast shutdown is unaffected (timer armed only on the shutdown path).
- **(c) pidfile reclaim** — `AcquirePIDFile` now probes the socket (dial + trivial `Ping`, 300ms × retries) when the pidfile names a live grafel process; a live-but-unhealthy owner (dead socket) is reclaimed (SIGKILL + overwrite) instead of honored. A healthy/busy daemon still answers Ping on a fresh connection → correctly refused, never false-killed.

**(b)** threading a cancel context into `Rebuild` (so SIGTERM stops the rebuild itself) is a deliberate follow-up.

## Tests
`TestDaemon_ShutdownWatchdogForceExitsOnStalledRebuild` (blocking Rebuild → shutdown → asserts Run returns + pidfile gone), `TestAcquirePIDFile_LiveGrafelPID_UnhealthySocket_Reclaims`, `...HealthySocket_RefusesNoReclaim`. `go test ./...` 220 packages green. Independent adversarial review (Opus): APPROVE — false-reclaim of a healthy busy daemon proven safe.