### PR TITLE
fix(extractors): incremental indexer no longer serves stale/empty graph silently

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -661,6 +661,20 @@ func runDaemon(argv []string) error {
 				ChangedFiles:   res.ChangedFiles,
 			}
 		},
+		// #5710 follow-up: cheap entity count for the "indexer: completed" log so
+		// a silent 0-entity completion (empty-graph store recreation) is visible.
+		// Reads the graph.fb header (no entity materialization); -1 when the
+		// materialized graph is absent/unreadable.
+		SchedulerEntityCount: func(repoPath string, ref string) int {
+			stateDir := daemon.StateDirForRepoRef(repoPath, ref)
+			if stateDir == "" {
+				stateDir = daemon.StateDirForRepo(repoPath)
+			}
+			if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+				return ps.Entities
+			}
+			return -1
+		},
 		// Single source of truth for the incremental toggle (issue #2397).
 		ExtractorConfig: &extractorCfg,
 

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -136,6 +136,15 @@ type IncrementalResult struct {
 // to fall through to IndexFn (full reindex fallback).
 type IncrementalFn func(ctx context.Context, repoPath string, ref string) IncrementalResult
 
+// EntityCountFn returns the number of entities in the materialized graph for
+// (repoPath, ref), or -1 when it cannot be determined cheaply. Injected so the
+// completion log can surface entities=N without the scheduler importing the
+// daemon store-layout / graph packages (avoids an import cycle). Used purely
+// for observability (#5710 follow-up): a 0-entity completion is a silent-empty
+// signal that must be visible at a glance. nil → entities is omitted from the
+// log.
+type EntityCountFn func(repoPath string, ref string) int
+
 // Config wires the scheduler. All function fields are required; nil
 // causes Enqueue to short-circuit with a logged warning.
 type Config struct {
@@ -230,6 +239,13 @@ type Config struct {
 	// Default (nil): incremental path is never tried; behaviour is identical
 	// to before this field was added.
 	Incremental IncrementalFn
+
+	// EntityCount, when non-nil, returns the entity count of the materialized
+	// graph for a (repoPath, ref) after an index completes. It is used only to
+	// annotate the "indexer: completed" log with entities=N so a silent 0-entity
+	// completion (e.g. an empty-graph store recreation, #5710) is visible.
+	// nil → the entities field is omitted.
+	EntityCount EntityCountFn
 
 	// ExtractorConfig, when non-nil, is consulted by the scheduler to
 	// determine whether the incremental reindex path is active (issue #2397).
@@ -1226,7 +1242,13 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	allocDiff := observedPeakMB - tok.predictedMB
 	s.logEvent("index_ok", repoPath,
 		dur.String()+" peak="+formatMB(observedPeakMB))
-	s.logger.Info("indexer: completed", "repo", repoPath, "took", dur, "peak_heap_mb", observedPeakMB, "alloc_diff_mb", allocDiff)
+	// #5710 follow-up: stamp entities=N so a silent 0-entity completion (e.g. an
+	// empty-graph store recreation) is visible at a glance. -1 means "unknown".
+	ents := -1
+	if s.cfg.EntityCount != nil {
+		ents = s.cfg.EntityCount(repoPath, tok.ref)
+	}
+	s.logger.Info("indexer: completed", "repo", repoPath, "took", dur, "peak_heap_mb", observedPeakMB, "alloc_diff_mb", allocDiff, "entities", ents)
 
 	// Schedule the downstream cross-repo link pass for each group this repo
 	// belongs to. The group-scope algorithm pass is NOT scheduled here — it is

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -101,6 +101,12 @@ type Config struct {
 	// the incremental path is never tried (default: full reindex always).
 	SchedulerIncremental func(ctx context.Context, repo string, ref string) sched.IncrementalResult
 
+	// SchedulerEntityCount, when non-nil, returns the entity count of the
+	// materialized graph for (repo, ref). Wired into the scheduler so the
+	// "indexer: completed" log carries entities=N, making a silent 0-entity
+	// completion visible (#5710 follow-up). nil → entities omitted.
+	SchedulerEntityCount func(repo string, ref string) int
+
 	// ExtractorConfig, when non-nil, is passed to the scheduler so it can
 	// consult IsIncrementalEnabled() instead of reading
 	// GRAFEL_INCREMENTAL_REINDEX from the process env directly (issue
@@ -420,6 +426,8 @@ func Run(ctx context.Context, cfg Config) error {
 			// S3 incremental file-level reindex (issue #2153). When nil
 			// the scheduler falls through to full reindex on every tick.
 			Incremental: cfg.SchedulerIncremental,
+			// #5710 follow-up: entities=N on the completion log.
+			EntityCount: cfg.SchedulerEntityCount,
 			// Issue #2397: single source of truth for the incremental toggle.
 			// The scheduler calls ExtractorConfig.IsIncrementalEnabled()
 			// rather than reading the env var directly.

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -299,34 +299,41 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			totalChanged, limit))
 	}
 	if totalChanged == 0 {
-		// --- #5710 (follow-up): empty-graph guard ---
-		// A no-op is only SAFE when the graph the ref pin resolves to is a
-		// materialized, non-empty graph. After a store relocation/recreation
-		// (repo moved → new path-keyed store, store hash changed) the ref→graph
-		// pin can survive while the backing graph in the NEW store is empty
-		// (0 entities / no graph.fb). HEAD still equals manifest.GitCommit, so
-		// the HEAD-advance guard above sees no advance — and the pre-fix code
-		// happily reported success (Done:true) over that empty graph while the
-		// working tree was full of indexable source. That is silent success
-		// over an empty graph: `grafel index --async` "completes" fast + cheap
-		// and leaves 0 entities.
+		// --- #5710 (follow-up): absent-graph guard ---
+		// A no-op is only SAFE when the ref pin resolves to a MATERIALIZED
+		// graph.fb. After a store relocation/recreation (repo moved → new
+		// path-keyed store, store hash changed) the ref→graph pin can survive
+		// while the NEW store has NO graph.fb at all. HEAD still equals
+		// manifest.GitCommit, so the HEAD-advance guard above sees no advance —
+		// and the pre-fix code reported success (Done:true) over that absent
+		// graph while the working tree was full of source. That is silent
+		// success over an empty graph: `grafel index --async` "completes" fast
+		// + cheap and leaves 0 entities.
+		//
+		// The guard fires on ABSENCE only (graph.fb missing), NOT on a
+		// present-but-0-entity graph. This is deliberate and loop-proof:
+		//   - The real reported case starts with an absent graph.fb in the
+		//     fresh store, so !ok still catches it and forces the reindex.
+		//   - A forced reindex WRITES a graph.fb (present, even if 0 entities),
+		//     so the next cycle sees ok=true → clean no-op. No infinite loop.
+		//   - A genuinely codeless repo whose walked files (e.g. .txt / LICENSE
+		//     / extensionless — no registered extractor) yield 0 entities keeps
+		//     a present-0-entity graph and correctly no-ops. Firing on
+		//     0-entities would re-index it every cycle forever (~9min each) on
+		//     the hot reactive path — the loop the reviewer reproduced.
 		//
 		// PersistedStatsFromDir reads the graph.fb header cheaply (no entity
-		// materialization) and reports ok=false when graph.fb is absent. Treat
-		// "no materialized graph" OR "0 entities" as empty. When the graph is
-		// empty but the walked working-tree set is NON-empty (indexable files
-		// exist), do NOT no-op and do NOT advance the manifest (which would
-		// self-conceal the emptiness on every later poll) — force a full
-		// reindex via the same fallback signal the too-many-changed path emits.
-		ps, ok := graph.PersistedStatsFromDir(stateDir)
-		graphEmpty := !ok || ps.Entities == 0
-		if graphEmpty && len(allFiles) > 0 {
-			logger.Printf("incremental: empty-graph-nonempty-tree files=%d entities=0 (materialized=%t) → force full reindex",
-				len(allFiles), ok)
-			return fallback(t0, fmt.Sprintf("empty-graph-nonempty-tree files=%d", len(allFiles)))
+		// materialization) and reports ok=false only when graph.fb is absent
+		// or unreadable. When absent AND the walked working-tree set is
+		// non-empty, do NOT no-op and do NOT advance the manifest (which would
+		// self-conceal the absence on every later poll) — force a full reindex
+		// via the same fallback signal the too-many-changed path emits.
+		if _, ok := graph.PersistedStatsFromDir(stateDir); !ok && len(allFiles) > 0 {
+			logger.Printf("incremental: absent-graph-nonempty-tree files=%d → force full reindex", len(allFiles))
+			return fallback(t0, fmt.Sprintf("absent-graph-nonempty-tree files=%d", len(allFiles)))
 		}
 		// Nothing to do — manifest is already up-to-date and the graph is a
-		// genuine reflection of the (possibly empty) tree.
+		// genuine reflection of the (possibly empty / codeless) tree.
 		diff.UpdateManifest(absRepo, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return Result{Done: true, Duration: time.Since(t0)}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -299,7 +299,34 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			totalChanged, limit))
 	}
 	if totalChanged == 0 {
-		// Nothing to do — manifest is already up-to-date.
+		// --- #5710 (follow-up): empty-graph guard ---
+		// A no-op is only SAFE when the graph the ref pin resolves to is a
+		// materialized, non-empty graph. After a store relocation/recreation
+		// (repo moved → new path-keyed store, store hash changed) the ref→graph
+		// pin can survive while the backing graph in the NEW store is empty
+		// (0 entities / no graph.fb). HEAD still equals manifest.GitCommit, so
+		// the HEAD-advance guard above sees no advance — and the pre-fix code
+		// happily reported success (Done:true) over that empty graph while the
+		// working tree was full of indexable source. That is silent success
+		// over an empty graph: `grafel index --async` "completes" fast + cheap
+		// and leaves 0 entities.
+		//
+		// PersistedStatsFromDir reads the graph.fb header cheaply (no entity
+		// materialization) and reports ok=false when graph.fb is absent. Treat
+		// "no materialized graph" OR "0 entities" as empty. When the graph is
+		// empty but the walked working-tree set is NON-empty (indexable files
+		// exist), do NOT no-op and do NOT advance the manifest (which would
+		// self-conceal the emptiness on every later poll) — force a full
+		// reindex via the same fallback signal the too-many-changed path emits.
+		ps, ok := graph.PersistedStatsFromDir(stateDir)
+		graphEmpty := !ok || ps.Entities == 0
+		if graphEmpty && len(allFiles) > 0 {
+			logger.Printf("incremental: empty-graph-nonempty-tree files=%d entities=0 (materialized=%t) → force full reindex",
+				len(allFiles), ok)
+			return fallback(t0, fmt.Sprintf("empty-graph-nonempty-tree files=%d", len(allFiles)))
+		}
+		// Nothing to do — manifest is already up-to-date and the graph is a
+		// genuine reflection of the (possibly empty) tree.
 		diff.UpdateManifest(absRepo, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return Result{Done: true, Duration: time.Since(t0)}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -213,6 +213,57 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		}
 	}
 
+	// --- #5710: HEAD-advance detection ---
+	// diff.FilterWithGit / diff.GitChangedFiles only ever compute
+	// `git diff --name-only HEAD` — working-tree vs the CURRENT HEAD. After a
+	// fetch+reset / checkout / pull the working tree already matches the new
+	// HEAD, so that diff is empty even though the indexed graph is still
+	// pinned at manifest.GitCommit (the commit we last actually indexed).
+	// Compare the persisted manifest commit against the repo's current HEAD
+	// and, when they differ, union in the commit-RANGE diff so those files
+	// enter the changed-file set and flow through the normal trigger-limit /
+	// AST-hash-gate machinery below (a large advance correctly trips the
+	// too-many-changed full-reindex fallback).
+	//
+	// headAdvanceUnconfirmed is set when HEAD moved but we could NOT compute
+	// the range diff (e.g. manifest.GitCommit is no longer reachable — gc,
+	// shallow clone, history rewrite). In that case we must not trust a
+	// totalChanged==0 result below: report unresolved-range-diff as an
+	// explicit fallback so a full reindex reconciles the graph rather than
+	// silently no-op'ing.
+	headAdvanceUnconfirmed := false
+	currentHead := diff.HeadCommit(absRepo)
+	if manifest.GitCommit != "" && currentHead != "" && manifest.GitCommit != currentHead {
+		rangeChanged, rErr := diff.GitChangedFilesSince(absRepo, manifest.GitCommit)
+		if rErr != nil {
+			headAdvanceUnconfirmed = true
+			logger.Printf("incremental: head-advance range-diff unconfirmed old=%s new=%s err=%v",
+				manifest.GitCommit, currentHead, rErr)
+		} else if len(rangeChanged) > 0 {
+			seen := make(map[string]bool, len(changedFiles))
+			for _, f := range changedFiles {
+				seen[f] = true
+			}
+			for f := range rangeChanged {
+				if allFilesSet[f] && !seen[f] {
+					changedFiles = append(changedFiles, f)
+					seen[f] = true
+				}
+			}
+		}
+	}
+	if headAdvanceUnconfirmed {
+		// We cannot trust the changed-file accounting when the commit-range
+		// diff itself failed to confirm what moved between manifest.GitCommit
+		// and currentHead. Force a full-reindex fallback WITHOUT touching the
+		// manifest — advancing manifest.GitCommit here (as the pre-fix
+		// totalChanged==0/too-many-changed paths unconditionally did) would
+		// reproduce the exact #5710 self-conceal bug: the manifest would
+		// claim "indexed to HEAD" while the graph never actually caught up,
+		// and every subsequent poll would see 0 changes forever.
+		return fallback(t0, fmt.Sprintf("head-advance-unconfirmed old=%s new=%s", manifest.GitCommit, currentHead))
+	}
+
 	// --- Manifest GC (#2170): eagerly remove entries for deleted files ---
 	// Remove them from the manifest NOW so that if we fall back to full reindex
 	// or succeed incrementally, the manifest saved at the end does not contain

--- a/internal/extractors/incremental_fallback_reconcile_5668_test.go
+++ b/internal/extractors/incremental_fallback_reconcile_5668_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 )
 
@@ -35,6 +36,16 @@ func TestIncremental_FallbackRefreshesStampsAndReconciles(t *testing.T) {
 	for i, rel := range files {
 		writeFile(t, repo, rel, fmt.Sprintf("package p\n\nfunc F%d() {}\n", i))
 	}
+
+	// A non-empty graph must already be materialized so pass 2's terminal no-op
+	// resolves to a real graph (in production the pass-1 fallback's full index
+	// writes it). Without this, the #5710 empty-graph guard would (correctly)
+	// force a fallback over a 0-entity graph. See incremental.go's empty-graph
+	// guard.
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F0", "a.go"),
+			Name: "F0", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
 
 	// Seed a manifest with deliberately WRONG stamps for every on-disk file, so
 	// the change-detector reports all 5 as changed (5 > limit 2 → fallback).

--- a/internal/extractors/incremental_loop_5667_test.go
+++ b/internal/extractors/incremental_loop_5667_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 )
 
@@ -29,6 +30,17 @@ func TestTryIncremental_FlushesStaleManifest_NoLoop(t *testing.T) {
 	stateDir := t.TempDir()
 	writeFile(t, repo, "a.go", "package p\n\nfunc A() {}\n")
 	writeFile(t, repo, "b.go", "package p\n\nfunc B() {}\n")
+
+	// A non-empty graph must already be materialized: cycle 2's terminal no-op
+	// is only a legitimate success when the pin resolves to a real graph. In
+	// production the cycle-1 too-many-changed fallback triggers a full index
+	// that writes this graph.fb; the unit test materializes it up front (a prior
+	// index left it) so the #5710 empty-graph guard does not (correctly) force a
+	// fallback over a 0-entity graph.
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "A", "a.go"),
+			Name: "A", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
 
 	// Seed a manifest with correct hashes for the two real files plus 60 stale
 	// entries for files that are NOT on disk (above even the main-branch limit

--- a/internal/extractors/incremental_test.go
+++ b/internal/extractors/incremental_test.go
@@ -939,13 +939,14 @@ func TestIncremental_HeadUnchanged_CleanTree_StillNoOps(t *testing.T) {
 // success over an empty graph.
 // ─────────────────────────────────────────────────────────────────────────────
 
-// TestIncremental_EmptyGraphNonEmptyTree_ForcesFullParse is the RED test for
-// the follow-up. The prior graph has 0 entities and the manifest is fully in
-// sync (GitCommit == HEAD, every file stamped) so nothing "changed", yet the
+// TestIncremental_AbsentGraphNonEmptyTree_ForcesFullParse is the RED test for
+// the follow-up. It reproduces the real store-recreation case: the ref pin
+// survives but the NEW store has NO graph.fb, while the manifest is fully in
+// sync (GitCommit == HEAD, every file stamped) so nothing "changed" and the
 // working tree contains indexable source. TryIncremental must NOT silently
 // no-op — it must force a full reindex (Done:false) rather than reporting
-// success over the empty graph.
-func TestIncremental_EmptyGraphNonEmptyTree_ForcesFullParse(t *testing.T) {
+// success over the absent graph.
+func TestIncremental_AbsentGraphNonEmptyTree_ForcesFullParse(t *testing.T) {
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 
@@ -953,30 +954,32 @@ func TestIncremental_EmptyGraphNonEmptyTree_ForcesFullParse(t *testing.T) {
 	writeFile(t, repo, "core.go", "package core\n\nfunc Alpha() {}\n")
 	gitCommitAll(t, repo, "commit A")
 
-	// Simulate the relocated/recreated store: a materialized-but-EMPTY graph
-	// (0 entities) pinned for this ref, plus a manifest that is fully in sync
-	// with the working tree (so the change-set is empty).
-	buildMinimalGraph(t, stateDir, nil, nil) // 0 entities
+	// Simulate the relocated/recreated store: the manifest is fully in sync
+	// with the working tree (so the change-set is empty), but there is NO
+	// materialized graph.fb in the fresh store.
 	seedManifest(t, repo, stateDir)
+	if _, err := os.Stat(filepath.Join(stateDir, "graph.fb")); !os.IsNotExist(err) {
+		t.Fatalf("sanity: expected no graph.fb in fresh store, stat err=%v", err)
+	}
 
 	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
 
 	if res.Done && res.ChangedFiles == 0 {
-		t.Fatalf("#5710 empty-graph regression: TryIncremental silently no-op'd over a 0-entity graph " +
-			"with a non-empty indexable working tree: Done=true ChangedFiles=0 (should force full reindex)")
+		t.Fatalf("#5710 absent-graph regression: TryIncremental silently no-op'd with an absent graph.fb " +
+			"and a non-empty indexable working tree: Done=true ChangedFiles=0 (should force full reindex)")
 	}
 	if res.Done {
-		t.Fatalf("#5710 empty-graph: expected a forced full-reindex fallback, got Done=true ChangedFiles=%d", res.ChangedFiles)
+		t.Fatalf("#5710 absent-graph: expected a forced full-reindex fallback, got Done=true ChangedFiles=%d", res.ChangedFiles)
 	}
 	if res.FallbackReason == "" {
-		t.Errorf("expected a non-empty FallbackReason on the empty-graph forced fallback")
+		t.Errorf("expected a non-empty FallbackReason on the absent-graph forced fallback")
 	}
 	t.Logf("forced-fallback reason: %s", res.FallbackReason)
 }
 
 // TestIncremental_EmptyGraphEmptyTree_StillNoOps is the negative guard: a
-// genuinely-empty repo (no indexable files in the working tree) with an empty
-// graph must still no-op cleanly. The empty-graph guard must not force a
+// genuinely-empty repo (no indexable files in the working tree) with a present
+// empty graph must still no-op cleanly. The absent-graph guard must not force a
 // pointless full parse of an actually-empty tree.
 func TestIncremental_EmptyGraphEmptyTree_StillNoOps(t *testing.T) {
 	repo := t.TempDir()
@@ -986,7 +989,7 @@ func TestIncremental_EmptyGraphEmptyTree_StillNoOps(t *testing.T) {
 	// No source files — an empty tree. Commit --allow-empty so HEAD exists.
 	runGit(t, repo, "commit", "-q", "--allow-empty", "-m", "empty")
 
-	buildMinimalGraph(t, stateDir, nil, nil) // 0 entities — legitimately empty
+	buildMinimalGraph(t, stateDir, nil, nil) // present, 0 entities — legitimately empty
 	seedManifest(t, repo, stateDir)          // stamps nothing (no files)
 
 	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
@@ -995,6 +998,40 @@ func TestIncremental_EmptyGraphEmptyTree_StillNoOps(t *testing.T) {
 	}
 	if res.ChangedFiles != 0 {
 		t.Errorf("ChangedFiles should be 0 on a genuinely-empty repo, got %d", res.ChangedFiles)
+	}
+}
+
+// TestIncremental_CodelessRepo_PresentZeroEntityGraph_NoLoop is the reviewer's
+// loop-regression guard. A repo whose walked files are all non-extractable
+// (e.g. only notes.txt / LICENSE — no registered extractor) legitimately
+// produces a PRESENT graph.fb with 0 entities. The absent-graph guard must
+// treat this as a clean no-op, NOT force a reindex — otherwise the hot
+// reactive path loops a full reindex forever (~9min each cycle). Run two
+// cycles to prove it converges (does not loop).
+func TestIncremental_CodelessRepo_PresentZeroEntityGraph_NoLoop(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepo(t, repo)
+	// Non-extractable content only: a plain-text note and a LICENSE. walk.WalkRepo
+	// surfaces these, but no registered extractor handles them → 0 entities.
+	writeFile(t, repo, "notes.txt", "just some notes, not code\n")
+	writeFile(t, repo, "LICENSE", "MIT License\n\nCopyright ...\n")
+	gitCommitAll(t, repo, "docs only")
+
+	// A full index of this repo produces a present-but-0-entity graph.fb.
+	buildMinimalGraph(t, stateDir, nil, nil) // present, 0 entities
+	seedManifest(t, repo, stateDir)
+
+	for cycle := 1; cycle <= 2; cycle++ {
+		res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+		if !res.Done {
+			t.Fatalf("cycle %d: codeless repo must no-op (present 0-entity graph), got fallback reason=%q — "+
+				"the absent-graph guard is looping on a present-but-empty graph", cycle, res.FallbackReason)
+		}
+		if res.ChangedFiles != 0 {
+			t.Errorf("cycle %d: ChangedFiles should be 0 for a codeless repo, got %d", cycle, res.ChangedFiles)
+		}
 	}
 }
 

--- a/internal/extractors/incremental_test.go
+++ b/internal/extractors/incremental_test.go
@@ -29,6 +29,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -96,11 +97,20 @@ func buildMinimalGraph(t *testing.T, stateDir string, entities []graph.Entity, r
 // seedManifest writes a diff manifest for the current state of the files in repo.
 func seedManifest(t *testing.T, repo, stateDir string) {
 	t.Helper()
-	// Walk repo to get all files.
+	// Walk repo to get all files. Skip .git — walkSourceFiles (the production
+	// path, via walk.WalkRepo) never surfaces it, so including it here would
+	// make the seeded manifest disagree with TryIncremental's own walk and
+	// spuriously report every .git internal as "deleted".
 	var paths []string
 	_ = filepath.WalkDir(repo, func(path string, d os.DirEntry, err error) error {
-		if err != nil || d.IsDir() {
+		if err != nil {
 			return err
+		}
+		if d.IsDir() {
+			if d.Name() == ".git" {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 		rel, _ := filepath.Rel(repo, path)
 		paths = append(paths, filepath.ToSlash(rel))
@@ -111,6 +121,41 @@ func seedManifest(t *testing.T, repo, stateDir string) {
 	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
 		t.Fatalf("save manifest: %v", err)
 	}
+}
+
+// runGit runs a git subcommand in dir, failing the test on error. Used by the
+// #5710 HEAD-advance tests, which need a REAL git repo (unlike the rest of
+// this file's tests, which run against plain non-git temp dirs and exercise
+// the hash-based Filter fallback rather than the git-aware path).
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// initGitRepo initializes dir as a git repo with a committed identity config,
+// so `git commit` works without relying on global user config.
+func initGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init", "-q")
+	runGit(t, dir, "config", "user.email", "test@test")
+	runGit(t, dir, "config", "user.name", "Test")
+}
+
+// gitCommitAll stages every change in dir and commits it, returning the new
+// short HEAD commit hash.
+func gitCommitAll(t *testing.T, dir, msg string) string {
+	t.Helper()
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-q", "-m", msg)
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "--short", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return string(bytes.TrimSpace(out))
 }
 
 // loadGraphEntityNames loads graph.fb from stateDir and returns a sorted
@@ -779,6 +824,104 @@ func TestIncremental_NoChanges_DoneWithoutWork(t *testing.T) {
 	}
 	if res.ChangedFiles != 0 {
 		t.Errorf("ChangedFiles should be 0 when nothing changed, got %d", res.ChangedFiles)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #5710 — incremental indexer no-ops on a HEAD advance with a clean
+// working tree (fetch+reset / checkout / pull), silently serving a stale
+// graph. `git diff --name-only HEAD` (working-tree-vs-HEAD) is empty in this
+// scenario because the working tree already matches the NEW HEAD, so the
+// pre-fix code reported changed_files=0 and — worse — advanced the persisted
+// manifest.GitCommit to the new HEAD anyway, self-concealing the staleness on
+// every subsequent poll.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIncremental_HeadAdvance_CleanWorkingTree_DetectsChange is the RED test
+// for #5710. It indexes at commit A, advances HEAD to commit B via a real git
+// commit (leaving a clean working tree diffed against B), and asserts
+// TryIncremental does NOT silently no-op: it must either report the changed
+// files from the A..B range or trip the too-many-changed fallback — anything
+// but Done:true with ChangedFiles:0 while the manifest still claims commit A.
+// It also asserts the manifest is not advanced to commit B while the graph
+// itself is still at commit A (no self-conceal).
+func TestIncremental_HeadAdvance_CleanWorkingTree_DetectsChange(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepo(t, repo)
+
+	// Commit A: baseline with one function.
+	writeFile(t, repo, "core.go", "package core\n\nfunc Alpha() {}\n")
+	commitA := gitCommitAll(t, repo, "commit A")
+
+	entityAlpha := graph.Entity{
+		ID:   graph.EntityID("test-repo", "SCOPE.Operation", "Alpha", "core.go"),
+		Name: "Alpha", Kind: "SCOPE.Operation", SourceFile: "core.go", Language: "go",
+	}
+	buildMinimalGraph(t, stateDir, []graph.Entity{entityAlpha}, nil)
+	seedManifest(t, repo, stateDir)
+
+	// Sanity: the manifest we just seeded recorded commit A as the indexed HEAD.
+	mA := diff.LoadManifest(stateDir)
+	if mA.GitCommit != commitA {
+		t.Fatalf("sanity: manifest.GitCommit = %q, want seeded commit %q", mA.GitCommit, commitA)
+	}
+
+	// Advance HEAD to commit B via a real commit — the working tree ends up
+	// clean against B, exactly like a fetch+reset/checkout/pull would leave it.
+	writeFile(t, repo, "core.go", "package core\n\nfunc Alpha() {}\n\nfunc Beta() {}\n")
+	commitB := gitCommitAll(t, repo, "commit B")
+	if commitB == commitA {
+		t.Fatalf("sanity: HEAD did not advance")
+	}
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+
+	if res.Done && res.ChangedFiles == 0 {
+		t.Fatalf("#5710 regression: TryIncremental silently no-op'd on a HEAD advance "+
+			"(commit %s -> %s) with a clean working tree: Done=true ChangedFiles=0", commitA, commitB)
+	}
+
+	// The manifest must not claim we're at commit B unless the graph actually
+	// reflects it. A Done:false (fallback) result must leave the manifest
+	// pinned at A (or at whatever commit the graph truly reflects) so the
+	// caller's full-reindex retry is not itself skipped by a stale manifest.
+	mAfter := diff.LoadManifest(stateDir)
+	if !res.Done && mAfter.GitCommit == commitB {
+		t.Errorf("#5710 self-conceal: manifest.GitCommit advanced to %s (new HEAD) even though "+
+			"TryIncremental did not complete the reindex (Done=false, reason=%s) — graph is still stale "+
+			"but the manifest now claims it is current", commitB, res.FallbackReason)
+	}
+}
+
+// TestIncremental_HeadUnchanged_CleanTree_StillNoOps is the steady-state
+// regression guard for #5710: a repo whose HEAD has NOT moved since the last
+// index (manifest.GitCommit == current HEAD) and has a clean working tree
+// must still report ChangedFiles=0 — the fix must not turn every incremental
+// poll into an unconditional git-range diff / reindex.
+func TestIncremental_HeadUnchanged_CleanTree_StillNoOps(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepo(t, repo)
+	writeFile(t, repo, "stable.go", "package p\n\nfunc Stable() {}\n")
+	gitCommitAll(t, repo, "commit A")
+
+	entities := []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Stable", "stable.go"),
+			Name: "Stable", Kind: "SCOPE.Operation", SourceFile: "stable.go", Language: "go"},
+	}
+	buildMinimalGraph(t, stateDir, entities, nil)
+	seedManifest(t, repo, stateDir)
+
+	// No mutation, no commit — HEAD is exactly what the manifest recorded.
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental: unexpected fallback on a genuinely unchanged git repo: %s", res.FallbackReason)
+	}
+	if res.ChangedFiles != 0 {
+		t.Errorf("ChangedFiles should be 0 on a genuinely unchanged git repo, got %d", res.ChangedFiles)
 	}
 }
 

--- a/internal/extractors/incremental_test.go
+++ b/internal/extractors/incremental_test.go
@@ -926,6 +926,79 @@ func TestIncremental_HeadUnchanged_CleanTree_StillNoOps(t *testing.T) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Issue #5710 (follow-up) — empty-graph / non-empty-tree silent success.
+//
+// A store relocation/recreation (repo moved → new path-keyed store, store hash
+// changed) can retain the ref→graph pin while the backing graph in the new
+// store is EMPTY (0 entities). Because HEAD == manifest.GitCommit here, the
+// HEAD-advance guard finds no advance; the pre-fix totalChanged==0 path then
+// happily no-op'd and reported success (Done:true) over a 0-entity graph while
+// the working tree was full of indexable source. The result: `grafel index
+// --async` "completes" in ~1m20s with peak heap ~74MB (vs ~9min/~450MB) and
+// leaves an empty graph, with `status` showing indexes=1. This is silent
+// success over an empty graph.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestIncremental_EmptyGraphNonEmptyTree_ForcesFullParse is the RED test for
+// the follow-up. The prior graph has 0 entities and the manifest is fully in
+// sync (GitCommit == HEAD, every file stamped) so nothing "changed", yet the
+// working tree contains indexable source. TryIncremental must NOT silently
+// no-op — it must force a full reindex (Done:false) rather than reporting
+// success over the empty graph.
+func TestIncremental_EmptyGraphNonEmptyTree_ForcesFullParse(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepo(t, repo)
+	writeFile(t, repo, "core.go", "package core\n\nfunc Alpha() {}\n")
+	gitCommitAll(t, repo, "commit A")
+
+	// Simulate the relocated/recreated store: a materialized-but-EMPTY graph
+	// (0 entities) pinned for this ref, plus a manifest that is fully in sync
+	// with the working tree (so the change-set is empty).
+	buildMinimalGraph(t, stateDir, nil, nil) // 0 entities
+	seedManifest(t, repo, stateDir)
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+
+	if res.Done && res.ChangedFiles == 0 {
+		t.Fatalf("#5710 empty-graph regression: TryIncremental silently no-op'd over a 0-entity graph " +
+			"with a non-empty indexable working tree: Done=true ChangedFiles=0 (should force full reindex)")
+	}
+	if res.Done {
+		t.Fatalf("#5710 empty-graph: expected a forced full-reindex fallback, got Done=true ChangedFiles=%d", res.ChangedFiles)
+	}
+	if res.FallbackReason == "" {
+		t.Errorf("expected a non-empty FallbackReason on the empty-graph forced fallback")
+	}
+	t.Logf("forced-fallback reason: %s", res.FallbackReason)
+}
+
+// TestIncremental_EmptyGraphEmptyTree_StillNoOps is the negative guard: a
+// genuinely-empty repo (no indexable files in the working tree) with an empty
+// graph must still no-op cleanly. The empty-graph guard must not force a
+// pointless full parse of an actually-empty tree.
+func TestIncremental_EmptyGraphEmptyTree_StillNoOps(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepo(t, repo)
+	// No source files — an empty tree. Commit --allow-empty so HEAD exists.
+	runGit(t, repo, "commit", "-q", "--allow-empty", "-m", "empty")
+
+	buildMinimalGraph(t, stateDir, nil, nil) // 0 entities — legitimately empty
+	seedManifest(t, repo, stateDir)          // stamps nothing (no files)
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental: unexpected fallback on a genuinely-empty repo: %s", res.FallbackReason)
+	}
+	if res.ChangedFiles != 0 {
+		t.Errorf("ChangedFiles should be 0 on a genuinely-empty repo, got %d", res.ChangedFiles)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Test: golden-file semantic equivalence — full reindex vs incremental
 // ─────────────────────────────────────────────────────────────────────────────
 //

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -229,6 +229,51 @@ func UpdateManifest(absRepo string, relPaths []string, m *Manifest) {
 	}
 }
 
+// GitChangedFilesSince uses `git diff --name-only fromCommit..HEAD` to return
+// the set of repo-relative paths that differ between fromCommit and the
+// current HEAD. This is the commit-RANGE counterpart to GitChangedFiles
+// (which only sees working-tree-vs-HEAD): it is what detects a HEAD advance
+// (fetch+reset / checkout / pull) that leaves a clean working tree against
+// the new HEAD, where `git diff --name-only HEAD` reports nothing even
+// though the indexed graph is still pinned at fromCommit (#5710).
+//
+// Returns an error when the diff cannot be computed (e.g. fromCommit is no
+// longer reachable — shallow clone, rebase, gc) so the caller can treat the
+// range as UNCONFIRMED rather than silently assuming nothing changed.
+func GitChangedFilesSince(repoPath, fromCommit string) (map[string]bool, error) {
+	if fromCommit == "" {
+		return nil, fmt.Errorf("git diff range: empty fromCommit")
+	}
+	if _, ok := gitmeta.RunGitBoundedC(repoPath, "rev-parse", "--is-inside-work-tree"); !ok {
+		return nil, nil // not a git repo (or git wedged) — not an error
+	}
+
+	rangeSpec := fromCommit + "..HEAD"
+	diffOut, ok := gitmeta.RunGitBoundedC(repoPath, "diff", "--name-only", rangeSpec)
+	if !ok {
+		return nil, fmt.Errorf("git diff %s: bounded git failed (timeout, unreachable commit, or no HEAD)", rangeSpec)
+	}
+
+	changed := make(map[string]bool)
+	sc := bufio.NewScanner(bytes.NewReader(diffOut))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			changed[line] = true
+		}
+	}
+	return changed, nil
+}
+
+// HeadCommit returns the short HEAD commit hash for the repo at repoPath, or
+// empty string if git is unavailable or this is not a git repo. Exported
+// wrapper around headCommit for callers outside this package (e.g. the
+// incremental extractor's HEAD-advance detection, #5710) that need to compare
+// the manifest's last-indexed commit against the repo's current HEAD.
+func HeadCommit(repoPath string) string {
+	return headCommit(repoPath)
+}
+
 // GitChangedFiles uses `git diff --name-only HEAD` to return the set of
 // repo-relative paths changed since the last HEAD commit. Returns nil when
 // the repo is not a git repository or git is not available.


### PR DESCRIPTION
Refs #5710

## Problem
The incremental indexer silently no-op'd, leaving a stale or empty graph served as healthy:
- **HEAD advance, clean tree:** change-set came only from `git diff --name-only HEAD`, so after fetch+reset/checkout the tree matched the new HEAD → `changed_files=0` → graph stayed pinned to the old commit. The persisted last-indexed commit (`manifest.GitCommit`) was written but never read. It also self-concealed by re-stamping the manifest to the new commit.
- **Fresh/empty store (comment 2):** after a repo relocation the ref pin survived but the new store's graph was absent; `index --async` reported `completed` over a 0-entity graph.

## Fix
- Compare `manifest.GitCommit` vs current HEAD at the top of `TryIncremental`; on divergence, union the `indexed..HEAD` range diff → flows through the existing too-many-changed → full reindex. Range-diff failure → explicit fallback WITHOUT advancing the manifest (no self-conceal).
- Guard the `totalChanged==0` no-op: if graph.fb is **absent** but the tree is non-empty → force a full reindex (catches store-recreation; loop-proof since a reindex writes graph.fb). A present 0-entity codeless repo correctly no-ops (regression-tested for 2 cycles).
- `entities=N` on the `indexer: completed` log so a silent 0-entity completion is visible.

Known limitation (documented): a transient *total* extraction failure over a real repo at a static HEAD can persist a present-0-entity graph the absent-only guard won't re-fire on — observable via `entities=N` and recovered by the next commit (HEAD-advance) or `rebuild`. Chosen over the alternative, which caused a certain infinite reindex loop on legitimately-codeless repos.

## Tests
HEAD-advance, absent-graph-forces-reindex, codeless-repo-no-loop (2 cycles), steady-state no-op. Full `go test ./...` green. Two independent Opus review rounds (first caught a real infinite-loop bug, now fixed; second: APPROVE).