### PR TITLE
fix(mcp): grafel_index_status disk fallback so it agrees with CLI status

### DIFF
--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -17,6 +17,8 @@ import (
 
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
@@ -96,8 +98,10 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 	pathToGroup := s.repoPathToGroup()
 
 	states := indexstate.RepoStates()
+	seen := make(map[string]bool, len(states))
 	out := indexStatusReply{Repos: make([]indexStatusRepo, 0, len(states))}
 	for _, st := range states {
+		seen[st.Path] = true
 		group := pathToGroup[st.Path]
 
 		if groupFilter != "" && group != groupFilter {
@@ -120,6 +124,35 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 			out.AnyIndexing = true
 		}
 	}
+
+	// #5710: disk-backed fallback. A repo indexed by a PREVIOUS daemon
+	// lifetime, or via `grafel rebuild` (which bypasses Scheduler.runIndex),
+	// never populates indexstate's live snapshot — RepoStates() has no entry
+	// for it even though a materialized graph exists on disk. Without this,
+	// grafel_index_status disagreed with the CLI (`grafel status`, which reads
+	// the on-disk store/sidecars via ComputeStatusSummary): MCP reported
+	// repos:[] for a repo the CLI showed as fully indexed. This loop only
+	// fills repos ABSENT from the live snapshot (seen[path]==false) — a repo
+	// WITH a live entry (indexing/queued/dirty/current) is never touched here,
+	// so a genuinely in-flight repo's state is never masked.
+	for path, group := range pathToGroup {
+		if seen[path] {
+			continue
+		}
+		if groupFilter != "" && group != groupFilter {
+			continue
+		}
+		if repoFilter != "" && !repoMatches(path, repoFilter) {
+			continue
+		}
+		row, ok := diskFallbackRow(path, group)
+		if !ok {
+			continue
+		}
+		out.Repos = append(out.Repos, row)
+		// A disk-only row is by definition idle (`current`) — it never
+		// contributes to AnyIndexing.
+	}
 	// #5493: surface the daemon-wide gate counts so "indexing 2, queued 28" is
 	// visible (a 30-module group draining 2-at-a-time, not stalled).
 	ic := indexstate.GetIndexConcurrency()
@@ -136,6 +169,38 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 		out.AnyIndexing = true
 	}
 	return jsonResult(out), nil
+}
+
+// diskFallbackRow synthesizes a `current` grafel_index_status row for
+// repoPath by reading the on-disk materialized graph directly — the SAME
+// disk-read primitives the CLI's `grafel status` uses (daemon.FindGraphFile /
+// daemon.StateDirForRepo + graph.LoadGraphFromDir), rather than importing
+// internal/cli's ComputeStatusSummary, which would pull the full CLI command
+// surface (cobra flags, printing, etc.) into the MCP server for one field
+// lookup (#5710).
+//
+// Returns ok=false when neither graph.fb nor graph.json exists for repoPath
+// — i.e. the repo is genuinely never-indexed, so no row should be fabricated.
+func diskFallbackRow(repoPath, group string) (indexStatusRepo, bool) {
+	graphPath, _ := daemon.FindGraphFile(repoPath)
+	if graphPath == "" {
+		return indexStatusRepo{}, false
+	}
+	row := indexStatusRepo{
+		Repo:  repoPath,
+		Group: group,
+		State: indexstate.StateCurrent,
+	}
+	// Best-effort: attach the indexed ref/sha if the graph carries Phase 0
+	// git metadata (#2088). Absent for older graphs or non-git repos — the
+	// row is still valid without it. A disk-only row has no in-flight work,
+	// so head_ref mirrors indexed_ref (nothing pending beyond what's indexed).
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if doc, err := graph.LoadGraphFromDir(stateDir); err == nil && doc != nil {
+		row.IndexedRef = doc.IndexedRef
+		row.HeadRef = doc.IndexedRef
+	}
+	return row, true
 }
 
 // repoPathToGroup builds a path→group lookup from the registry. A repo path may

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -18,7 +18,7 @@ import (
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 
 	"github.com/cajasmota/grafel/internal/daemon"
-	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
@@ -172,12 +172,18 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 }
 
 // diskFallbackRow synthesizes a `current` grafel_index_status row for
-// repoPath by reading the on-disk materialized graph directly — the SAME
-// disk-read primitives the CLI's `grafel status` uses (daemon.FindGraphFile /
-// daemon.StateDirForRepo + graph.LoadGraphFromDir), rather than importing
-// internal/cli's ComputeStatusSummary, which would pull the full CLI command
-// surface (cobra flags, printing, etc.) into the MCP server for one field
-// lookup (#5710).
+// repoPath by reading the on-disk graph's HEADER only — NEVER a full decode.
+// grafel_index_status is a frequent, must-be-fast status probe; on a large
+// repo (hundreds of thousands of entities) a full graph.LoadGraphFromDir
+// would O(N)-decode+alloc every entity and relationship just to read one
+// header string, discarded immediately. Instead this uses the same cheap
+// header path as graph.PersistedStatsFromDir: fbreader.Open + LoadGraphMeta,
+// which reads header fields off the mmap WITHOUT touching any vector.
+//
+// Note this is NOT the CLI's `grafel status` code path — that
+// (ComputeStatusSummary → graph-stats.json sidecar, falling back to
+// graph.PersistedStatsFromDir) is likewise header/sidecar-only; we agree with
+// it on the answer while avoiding any full-graph decode.
 //
 // Returns ok=false when neither graph.fb nor graph.json exists for repoPath
 // — i.e. the repo is genuinely never-indexed, so no row should be fabricated.
@@ -191,14 +197,21 @@ func diskFallbackRow(repoPath, group string) (indexStatusRepo, bool) {
 		Group: group,
 		State: indexstate.StateCurrent,
 	}
-	// Best-effort: attach the indexed ref/sha if the graph carries Phase 0
-	// git metadata (#2088). Absent for older graphs or non-git repos — the
-	// row is still valid without it. A disk-only row has no in-flight work,
-	// so head_ref mirrors indexed_ref (nothing pending beyond what's indexed).
-	stateDir := daemon.StateDirForRepo(repoPath)
-	if doc, err := graph.LoadGraphFromDir(stateDir); err == nil && doc != nil {
-		row.IndexedRef = doc.IndexedRef
-		row.HeadRef = doc.IndexedRef
+	// Best-effort: attach the indexed ref if the graph.fb header carries Phase
+	// 0 git metadata (#2088). Read via the cheap header path — no entity or
+	// relationship is decoded. Only attempted for an actual graph.fb file:
+	// fbreader.Open interprets the bytes as FlatBuffers and PANICS on a
+	// graph.json (or otherwise non-fb) file, so a json-only repo is skipped
+	// here — the row is still valid without the ref. A disk-only row has no
+	// in-flight work, so head_ref mirrors indexed_ref (nothing pending beyond
+	// what's indexed).
+	if strings.HasSuffix(graphPath, ".fb") {
+		if r, err := fbreader.Open(graphPath); err == nil {
+			meta := r.LoadGraphMeta()
+			r.Close()
+			row.IndexedRef = meta.IndexedRef
+			row.HeadRef = meta.IndexedRef
+		}
 	}
 	return row, true
 }

--- a/internal/mcp/index_status_5710_test.go
+++ b/internal/mcp/index_status_5710_test.go
@@ -1,0 +1,103 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestIndexStatusDiskFallback verifies grafel_index_status no longer reports
+// repos:[] for a repo that has a fully materialized graph on disk but no
+// LIVE indexstate entry — the situation that arises when a repo was indexed
+// by a PREVIOUS daemon lifetime, or via `grafel rebuild` (which bypasses
+// Scheduler.runIndex and therefore never populates indexstate) (#5710).
+//
+// Three repos exercise the three cases in one call:
+//   - alpha: HAS a live indexstate entry (state=indexing) → must report the
+//     LIVE state verbatim; the disk fallback must never mask an in-flight repo.
+//   - beta: graph.json on disk, NO live indexstate entry → must synthesize a
+//     `current` row from disk (the bug: previously this repo vanished).
+//   - gamma: registered, NEITHER a live entry NOR a graph on disk → must
+//     still be absent (genuinely never-indexed; no row is fabricated).
+func TestIndexStatusDiskFallback(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	dir := t.TempDir()
+	rAlpha := filepath.Join(dir, "alpha")
+	rBeta := filepath.Join(dir, "beta")
+	rGamma := filepath.Join(dir, "gamma")
+	_ = os.MkdirAll(rAlpha, 0o755)
+	_ = os.MkdirAll(rBeta, 0o755)
+	_ = os.MkdirAll(rGamma, 0o755)
+
+	// alpha and beta both have a materialized graph on disk. gamma does not.
+	writeGraph(t, rAlpha, fixtureDoc("alpha"))
+	writeGraph(t, rBeta, fixtureDoc("beta"))
+
+	regPath := makeRegistry(t, dir, map[string]map[string]string{
+		"g": {"alpha": rAlpha, "beta": rBeta, "gamma": rGamma},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only alpha has a LIVE indexstate entry. beta and gamma have none — beta
+	// must be filled in from disk, gamma must stay absent.
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: rAlpha, State: indexstate.StateIndexing, HeadRef: "h-alpha", IndexedRef: "i-alpha"},
+	})
+
+	res := callTool(t, srv, "grafel_index_status", map[string]any{"group": "g"})
+	if res == nil || res.IsError {
+		t.Fatalf("grafel_index_status errored: %s", resultText(res))
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(resultText(res)), &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	repos, _ := m["repos"].([]any)
+
+	byPath := map[string]map[string]any{}
+	for _, r := range repos {
+		row := r.(map[string]any)
+		byPath[row["repo"].(string)] = row
+	}
+
+	// alpha: live state must win, unmasked by the disk fallback.
+	aRow, ok := byPath[rAlpha]
+	if !ok {
+		t.Fatalf("alpha row missing entirely: %v", repos)
+	}
+	if aRow["state"] != indexstate.StateIndexing {
+		t.Errorf("alpha state = %v, want indexing (live state must not be masked by disk fallback)", aRow["state"])
+	}
+	if aRow["head_ref"] != "h-alpha" || aRow["indexed_ref"] != "i-alpha" {
+		t.Errorf("alpha refs = head:%v indexed:%v, want h-alpha/i-alpha", aRow["head_ref"], aRow["indexed_ref"])
+	}
+
+	// beta: THE BUG — no live entry, but a graph exists on disk. Must be
+	// synthesized as a `current` row, not silently dropped.
+	bRow, ok := byPath[rBeta]
+	if !ok {
+		t.Fatalf("beta row missing — disk-backed fallback did not fire (repos: %v)", repos)
+	}
+	if bRow["state"] != indexstate.StateCurrent {
+		t.Errorf("beta state = %v, want current", bRow["state"])
+	}
+
+	// gamma: no live entry AND nothing on disk → must remain absent.
+	if _, ok := byPath[rGamma]; ok {
+		t.Fatalf("gamma row present but repo was never indexed on disk or live: %v", byPath[rGamma])
+	}
+
+	// any_indexing must still be true (alpha is indexing) — the disk-only
+	// beta row must not itself mark any_indexing, but must not suppress it
+	// either.
+	if v, _ := m["any_indexing"].(bool); !v {
+		t.Fatalf("any_indexing = %v, want true (alpha is indexing)", m["any_indexing"])
+	}
+}

--- a/internal/mcp/index_status_5710_test.go
+++ b/internal/mcp/index_status_5710_test.go
@@ -34,8 +34,13 @@ func TestIndexStatusDiskFallback(t *testing.T) {
 	_ = os.MkdirAll(rGamma, 0o755)
 
 	// alpha and beta both have a materialized graph on disk. gamma does not.
+	// beta is written as graph.fb carrying an IndexedRef in its header so the
+	// test asserts the disk fallback reads that ref via the CHEAP header path
+	// (fbreader.LoadGraphMeta) — no full entity/relationship decode (#5710).
 	writeGraph(t, rAlpha, fixtureDoc("alpha"))
-	writeGraph(t, rBeta, fixtureDoc("beta"))
+	betaDoc := fixtureDoc("beta")
+	betaDoc.IndexedRef = "main"
+	writeGraphFB(t, rBeta, betaDoc)
 
 	regPath := makeRegistry(t, dir, map[string]map[string]string{
 		"g": {"alpha": rAlpha, "beta": rBeta, "gamma": rGamma},
@@ -87,6 +92,10 @@ func TestIndexStatusDiskFallback(t *testing.T) {
 	}
 	if bRow["state"] != indexstate.StateCurrent {
 		t.Errorf("beta state = %v, want current", bRow["state"])
+	}
+	// The IndexedRef must be read from the graph.fb header via the cheap path.
+	if bRow["indexed_ref"] != "main" {
+		t.Errorf("beta indexed_ref = %v, want main (from fb header, cheap read)", bRow["indexed_ref"])
 	}
 
 	// gamma: no live entry AND nothing on disk → must remain absent.


### PR DESCRIPTION
Refs #5710

## Problem
MCP `grafel_index_status` returned `repos:[]` while CLI `grafel status` showed the fully-indexed repo. The MCP handler read only the scheduler's live in-memory `indexstate.RepoStates()` (populated only by `scheduler.runIndex`), so a repo indexed by a previous daemon lifetime or via `grafel rebuild` (which bypasses the scheduler) was invisible — even though its graph is on disk and the CLI (disk-backed) shows it.

## Fix
`diskFallbackRow` in `internal/mcp/index_status.go`: for registry repos with a graph on disk but NO live `indexstate` entry (tracked via `seen[path]`), synthesize a `current` row. The ref is read via the **cheap fb header** (`fbreader.Open` + `LoadGraphMeta().IndexedRef`) — no entity/relationship decode (a full `LoadGraphFromDir` would O(N)-decode a 287k-entity graph on every status probe). A live indexing/queued/dirty entry is never masked or duplicated; disk-only rows never set `any_indexing`.

## Tests
`TestIndexStatusDiskFallback` — live (unmasked) / disk-only (synthesized w/ correct `IndexedRef`) / absent (no fabrication). `go test ./internal/mcp/...` 1017 green. Two Opus review rounds (first caught a full-graph-load perf regression, now the cheap-header read; second: APPROVE).