### PR TITLE
ci: gate PR/branch CI triggers to release tags + dispatch (conserve free-tier Actions minutes)

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -55,20 +55,13 @@ on:
     workflows: ["release"]
     types: [completed]
   workflow_dispatch:
-  pull_request:
-    # Cheap PR signal only — gated to install/release/daemon/cmd surface so docs
-    # and unrelated changes don't spend minutes. This NEVER schedules the full
-    # matrix (the matrix job is guarded to release/dispatch only).
-    paths:
-      - 'install.sh'
-      - 'install.ps1'
-      - '.github/workflows/release.yml'
-      - '.github/workflows/acceptance.yml'
-      - 'cmd/grafel/**'
-      - 'internal/daemon/**'
-      - 'internal/install/**'
-      - 'go.mod'
-      - 'go.sum'
+  # `pull_request` trigger (formerly here, path-gated to install/release/daemon/
+  # cmd surface) removed: gated to releases + manual dispatch to conserve
+  # free-tier minutes. The `pr-linux` job below is now dormant (its `if:
+  # github.event_name == 'pull_request'` guard never matches) until re-enabled
+  # via workflow_dispatch or a future re-add of this trigger. The full
+  # cross-OS matrix already only runs post-release (workflow_run) or on
+  # workflow_dispatch — unaffected by this change.
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,9 +15,12 @@ name: Windows CI
 # run lands in a few minutes rather than the full suite's 8-10.
 
 on:
-  pull_request:
-  push:
-    branches: [main]
+  # Gated to manual dispatch only to conserve free-tier minutes: this workflow
+  # is a pure PR/branch compile-and-test tripwire — it does not build or
+  # validate a release artifact (release.yml + test.yml's tag trigger already
+  # cover Windows on a release tag). Formerly ran on every `pull_request`
+  # (no path filter) and every push to main, which was the single largest
+  # Windows (2x-billed) minute sink in this repo.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Reserves GitHub Actions minutes for releases. Removes the pull_request / push-branches triggers from the minute-spenders (windows.yml — fires on every PR at 2x billing; acceptance.yml pr-linux). Keeps board-hygiene.yml (~9s closure-keyword lint). Full multi-OS CI still runs on release tags via release.yml + test.yml. Local build/test/vet + review is the PR gate now.