### PR TITLE
fix(fbwriter): fail-soft on oversized-graph marshal panic + scheduler recover so the daemon survives

### DIFF
--- a/internal/daemon/sched/failsoft_5726_test.go
+++ b/internal/daemon/sched/failsoft_5726_test.go
@@ -1,0 +1,57 @@
+package sched
+
+// Issue #5726 / epic #5729 — the daemon must survive a panic raised during an
+// index (e.g. the flatbuffers 2-GiB marshal abort). The scheduler worker loop
+// must recover, log a degraded-state message, release the reserved budget, and
+// keep serving subsequent jobs.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestWorkerSurvivesIndexPanic enqueues a job whose IndexFn panics, then a
+// second job for a different repo. The worker must recover from the panic and
+// still run the second job (proving the worker goroutine survived).
+func TestWorkerSurvivesIndexPanic(t *testing.T) {
+	var okCalls atomic.Int32
+	okRan := make(chan struct{})
+
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, repo string, _ string) error {
+			switch repo {
+			case "/panic":
+				panic("boom: simulated oversized-graph marshal panic (#5726)")
+			case "/ok":
+				if okCalls.Add(1) == 1 {
+					close(okRan)
+				}
+			}
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	// This job panics inside runIndex. Without a recover the worker goroutine
+	// (and the whole process) aborts.
+	s.Enqueue("/panic")
+	// Give the worker a moment to pick up and blow up on the first job.
+	time.Sleep(100 * time.Millisecond)
+	// A subsequent job must still be serviced.
+	s.Enqueue("/ok")
+
+	select {
+	case <-okRan:
+		// Worker survived the panic and processed the next job.
+	case <-time.After(3 * time.Second):
+		t.Fatal("worker did not survive the index panic: subsequent job was never run")
+	}
+
+	if got := okCalls.Load(); got != 1 {
+		t.Errorf("expected the follow-up job to run exactly once, got %d", got)
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1153,22 +1153,41 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 	var err error
 	incrementalDone := false
-	if s.cfg.Incremental != nil && s.cfg.ExtractorConfig.IsIncrementalEnabled() {
-		res := s.cfg.Incremental(jobCtx, repoPath, tok.ref)
-		if res.Done {
-			incrementalDone = true
-			s.logEvent("incremental_ok", repoPath,
-				"changed_files="+itoa(int64(res.ChangedFiles)))
-		} else {
-			s.logEvent("incremental_fallback", repoPath,
-				"reason="+res.FallbackReason)
-			s.logger.Info("sched: incremental fallback", "repo", repoPath, "reason", res.FallbackReason)
-		}
-	}
+	// Issue #5726 / epic #5729 — defense in depth. An index can panic for
+	// reasons the fbwriter fail-soft doesn't catch (e.g. a flatbuffers 2-GiB
+	// abort raised inside the streaming WriteEntity path, or any other bug in
+	// an extractor). A panic here would unwind through the worker goroutine and
+	// abort the ENTIRE daemon (launchd relaunches it → 60–90s reindex outage,
+	// every MCP bridge severed). Recover so ANY index panic becomes a normal
+	// error: the worker keeps serving, the reserved budget is released via the
+	// existing err path below, and we log a clear degraded-state message.
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("index panicked (recovered): %v", r)
+				s.logEvent("index_panic", repoPath, fmt.Sprintf("recovered panic during index: %v", r))
+				s.logger.Error("sched: index panicked — recovered; daemon continues in degraded state (repo left at last-good graph)",
+					"repo", repoPath, "ref", tok.ref, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
 
-	if !incrementalDone && s.cfg.Index != nil {
-		err = s.cfg.Index(jobCtx, repoPath, tok.ref)
-	}
+		if s.cfg.Incremental != nil && s.cfg.ExtractorConfig.IsIncrementalEnabled() {
+			res := s.cfg.Incremental(jobCtx, repoPath, tok.ref)
+			if res.Done {
+				incrementalDone = true
+				s.logEvent("incremental_ok", repoPath,
+					"changed_files="+itoa(int64(res.ChangedFiles)))
+			} else {
+				s.logEvent("incremental_fallback", repoPath,
+					"reason="+res.FallbackReason)
+				s.logger.Info("sched: incremental fallback", "repo", repoPath, "reason", res.FallbackReason)
+			}
+		}
+
+		if !incrementalDone && s.cfg.Index != nil {
+			err = s.cfg.Index(jobCtx, repoPath, tok.ref)
+		}
+	}()
 
 	close(sampleStop)
 	sampleWG.Wait()

--- a/internal/graph/fbwriter/failsoft_5726_test.go
+++ b/internal/graph/fbwriter/failsoft_5726_test.go
@@ -1,0 +1,85 @@
+package fbwriter
+
+// Issue #5726 — fail-soft on oversized-graph marshal panic.
+//
+// On a very large graph the flatbuffers builder panics with
+// "cannot grow buffer beyond 2 gigabytes" (the library's hard cap). That
+// panic originates in the vendored flatbuffers library, so the daemon can
+// only survive it by recover()-ing at the fbwriter boundary and returning a
+// normal error. These are white-box tests (package fbwriter) so they can drive
+// the internal marshalPanicHook seam.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func withMarshalPanic(t *testing.T, msg string) {
+	t.Helper()
+	orig := marshalPanicHook
+	marshalPanicHook = func() { panic(msg) }
+	t.Cleanup(func() { marshalPanicHook = orig })
+}
+
+// TestStreamingMarshalRecoversPanic asserts that a panic raised inside the
+// marshal path is converted into a returned error rather than propagating and
+// aborting the process.
+func TestStreamingMarshalRecoversPanic(t *testing.T) {
+	withMarshalPanic(t, "cannot grow buffer beyond 2 gigabytes")
+
+	doc := &graph.Document{Repo: "huge-repo"}
+
+	out, err := Marshal(doc)
+	if err == nil {
+		t.Fatal("expected an error from the recovered marshal panic, got nil (panic would have aborted the daemon)")
+	}
+	if out != nil {
+		t.Errorf("expected nil output on marshal error, got %d bytes", len(out))
+	}
+	if !strings.Contains(err.Error(), "too large to serialize") {
+		t.Errorf("error should describe the oversized-graph failure, got: %v", err)
+	}
+}
+
+// TestWriteAtomicPreservesLastGoodOnPanic writes a valid graph.fb, then attempts
+// a second WriteAtomic whose marshal panics (recovered → error). The original
+// graph.fb must stay byte-identical and no stray .tmp may remain.
+func TestWriteAtomicPreservesLastGoodOnPanic(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "graph.fb")
+
+	good := &graph.Document{
+		Repo: "good",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go", StartLine: 1},
+		},
+	}
+	if err := WriteAtomic(out, good); err != nil {
+		t.Fatalf("initial WriteAtomic: %v", err)
+	}
+	before, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read last-good: %v", err)
+	}
+
+	// Now a marshal that panics part-way through serialization.
+	withMarshalPanic(t, "cannot grow buffer beyond 2 gigabytes")
+	if err := WriteAtomic(out, good); err == nil {
+		t.Fatal("expected WriteAtomic to return an error when marshal panics, got nil")
+	}
+
+	after, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read graph.fb after failed write: %v", err)
+	}
+	if string(before) != string(after) {
+		t.Errorf("last-good graph.fb was mutated by a failed write: before=%d bytes after=%d bytes", len(before), len(after))
+	}
+	if _, err := os.Stat(out + ".tmp"); !os.IsNotExist(err) {
+		t.Errorf("stray .tmp left behind after failed marshal: statErr=%v", err)
+	}
+}

--- a/internal/graph/fbwriter/streaming.go
+++ b/internal/graph/fbwriter/streaming.go
@@ -153,13 +153,22 @@ func (sw *StreamingWriter) WriteRelationship(r *graph.Relationship) error {
 // via streaming because they are assembled at the end of the index pass by
 // the graph-algo engine — a separate call site from the per-entity extraction
 // loop.
-func (sw *StreamingWriter) Close(meta GraphMetadata) error {
+func (sw *StreamingWriter) Close(meta GraphMetadata) (err error) {
 	if sw.closed {
 		return fmt.Errorf("fbwriter.StreamingWriter: already closed")
 	}
 	sw.closed = true
 
-	buf := sw.finalize(meta)
+	// Issue #5726 — fail-soft on oversized graphs. finalize() drives the same
+	// flatbuffers builder that panics past 2 GiB. Recover here so the streaming
+	// full-index path degrades to a returned error too, and make sure we never
+	// leave a half-written .tmp (or perform the rename) when serialization
+	// blew up — the previously-good graph.fb must stay intact.
+	buf, err := sw.finalizeSafe(meta)
+	if err != nil {
+		os.Remove(sw.outPath + ".tmp")
+		return err
+	}
 
 	// In-memory mode (outPath == "") — nothing to write.
 	if sw.outPath == "" {
@@ -175,6 +184,18 @@ func (sw *StreamingWriter) Close(meta GraphMetadata) error {
 		return fmt.Errorf("fbwriter.StreamingWriter: rename: %w", err)
 	}
 	return nil
+}
+
+// finalizeSafe wraps finalize with a recover so a flatbuffers 2-GiB builder
+// panic (#5726) is surfaced as a normal error instead of aborting the daemon.
+func (sw *StreamingWriter) finalizeSafe(meta GraphMetadata) (buf []byte, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			buf = nil
+			err = fmt.Errorf("fbwriter: graph too large to serialize: %v", r)
+		}
+	}()
+	return sw.finalize(meta), nil
 }
 
 // finalize builds the top-level Graph table and returns the finished bytes.
@@ -276,9 +297,37 @@ func (sw *StreamingWriter) RelationshipCount() int { return len(sw.relOffsets) }
 // through an in-memory StreamingWriter (no filesystem I/O). This ensures
 // WriteAtomic and the streaming pipeline share identical serialization code.
 
-func streamingMarshal(doc *graph.Document) ([]byte, error) {
+// marshalPanicHook is a test-only seam. When non-nil it is invoked inside the
+// serialization body of streamingMarshal so a unit test can simulate the
+// flatbuffers library's hard-2-GiB "cannot grow buffer beyond 2 gigabytes"
+// panic (issue #5726) without actually allocating 2 GiB. It is always nil in
+// production builds.
+var marshalPanicHook func()
+
+func streamingMarshal(doc *graph.Document) (out []byte, err error) {
+	// Issue #5726 — fail-soft on oversized graphs. The flatbuffers builder
+	// panics with "cannot grow buffer beyond 2 gigabytes" once serialization
+	// crosses the library's hard 2-GiB cap. That panic originates in the
+	// vendored flatbuffers library, so recover() at this boundary is the only
+	// way to keep it from unwinding through the daemon's index worker and
+	// aborting the whole process. We surface it as a normal error the caller
+	// can handle — WriteAtomic then leaves the previous graph.fb untouched and
+	// the scheduler logs a degraded state instead of crashing.
+	defer func() {
+		if r := recover(); r != nil {
+			out = nil
+			err = fmt.Errorf("fbwriter: graph too large to serialize: %v", r)
+		}
+	}()
+
 	if doc == nil {
 		return nil, fmt.Errorf("nil document")
+	}
+
+	// Test seam (#5726): simulate the flatbuffers 2-GiB builder panic that
+	// occurs mid-serialization on very large graphs.
+	if marshalPanicHook != nil {
+		marshalPanicHook()
 	}
 
 	// In-memory mode: outPath == "" skips the filesystem write in Close.

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -38,6 +38,11 @@ func WriteAtomic(outPath string, doc *graph.Document) error {
 	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
 		return fmt.Errorf("fbwriter: mkdir %s: %w", filepath.Dir(outPath), err)
 	}
+	// Issue #5726 — last-good preservation. Marshal runs to completion (and now
+	// fail-softs an oversized-graph panic into an error, see streamingMarshal)
+	// BEFORE we touch the filesystem. On a marshal error we return here without
+	// ever creating the sibling .tmp or performing the rename, so a previously
+	// written graph.fb stays byte-identical and fully intact.
 	buf, err := Marshal(doc)
 	if err != nil {
 		return fmt.Errorf("fbwriter: marshal: %w", err)


### PR DESCRIPTION
Phase 0 of the MCP/engine decouple epic (Refs #5729). Crash-stopper for the FlatBuffers 2 GiB marshal panic.

- streamingMarshal + StreamingWriter.Close now recover the flatbuffers panic and return an error instead of aborting the process; the incomplete .tmp is cleaned up, so the prior graph.fb stays byte-identical (last-good preserved).
- scheduler runIndex wraps the index/incremental callback in recover(): an index panic becomes a logged degraded-state event, the RSS budget is released, and the worker keeps serving.
- Tested via an injected marshal-panic hook (the real 2 GiB abort can't be triggered in a unit test): RED then GREEN, 114 + 256 tests pass; happy-path byte-parity preserved.

Scope: crash-stopper ONLY. Removing the 2 GiB cliff (shard/stream fbwriter) is the part-2 / Phase 1b follow-up — #5726 stays open for that.

Refs #5726, #5729.