### PR TITLE
fix(mcp): recover tool-handler panics + widen bridge reconnect budget so a daemon blip is transparent

### DIFF
--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -219,16 +219,58 @@ func (b *bridge) resetRPCClient() {
 }
 
 // bridgeMaxRetries is the number of additional attempts the bridge makes for a
-// single daemon RPC after a transient connection-shutdown (#5633). A daemon
-// restart drops the socket mid-call; the bridge reconnects to the replacement
-// daemon and retries rather than surfacing the failure to the MCP client. All
-// grafel MCP tools are read-mostly graph queries, so retrying is safe — there
-// is no non-idempotent call to special-case.
-const bridgeMaxRetries = 3
+// single daemon RPC after a transient connection-shutdown (#5633, widened
+// #5717). A daemon restart drops the socket mid-call; the bridge reconnects
+// to the replacement daemon and retries rather than surfacing the failure to
+// the MCP client. All grafel MCP tools are read-mostly graph queries, so
+// retrying is safe — there is no non-idempotent call to special-case.
+//
+// #5717: the original budget was 3 retries * a flat 150ms = ~450ms total —
+// nowhere near enough to ride out a real daemon restart, which drops every
+// attached MCP bridge (mcp_rpc.go has no panic recovery pre-#5717, so any
+// panicking tool handler took the whole daemon down) and can take
+// seconds-to-minutes to come back up (rebind socket, reload the registry,
+// possibly a reindex). Combined with the exponential backoff below (capped at
+// bridgeRetryMaxBackoff), this budget rides out roughly 30-60s of daemon
+// unavailability — see TestBridgeRetryBudget_SurvivalWindow — before giving
+// up and surfacing a structured tool error to the MCP client.
+const bridgeMaxRetries = 20
 
-// bridgeRetryBackoff is the pause between reconnect attempts, giving the
-// replacement daemon a brief window to (re)bind its socket after a restart.
+// bridgeRetryBackoff is the pause before the FIRST reconnect attempt after a
+// transient failure. Each subsequent attempt doubles the previous pause
+// (exponential backoff — see bridgeBackoffForAttempt), capped at
+// bridgeRetryMaxBackoff, giving the replacement daemon progressively more
+// room to (re)bind its socket and finish reloading after a restart without
+// hammering it with sub-second retries for the entire retry window (#5717).
 var bridgeRetryBackoff = 150 * time.Millisecond
+
+// bridgeRetryMaxBackoff is the ceiling on the exponential backoff between
+// reconnect attempts (#5717). Without a cap, bridgeMaxRetries=20 doublings
+// starting from 150ms would reach minutes-long individual pauses long before
+// the retry budget was exhausted, which would make a genuinely-dead daemon
+// hang the MCP client far longer than useful.
+var bridgeRetryMaxBackoff = 3 * time.Second
+
+// bridgeBackoffForAttempt returns the pause before retry attempt n (1-indexed:
+// n=1 is the first retry, after the initial failed attempt). The sequence is
+// bridgeRetryBackoff * 2^(n-1), capped at bridgeRetryMaxBackoff (#5717). n<1
+// returns 0 (no pause before the first, non-retry attempt).
+func bridgeBackoffForAttempt(n int) time.Duration {
+	if n < 1 {
+		return 0
+	}
+	d := bridgeRetryBackoff
+	for i := 1; i < n; i++ {
+		if d >= bridgeRetryMaxBackoff {
+			return bridgeRetryMaxBackoff
+		}
+		d *= 2
+	}
+	if d > bridgeRetryMaxBackoff {
+		d = bridgeRetryMaxBackoff
+	}
+	return d
+}
 
 // isRetryableRPCErr reports whether a daemon RPC error is a transient
 // connection-shutdown / restart condition the bridge should reconnect+retry on,
@@ -252,8 +294,9 @@ func isRetryableRPCErr(err error) bool {
 
 // callDaemon invokes a daemon RPC method with reconnect+retry on transient
 // connection-shutdown (#5633). On a retryable error it drops the dead client,
-// backs off briefly, reconnects, and retries up to bridgeMaxRetries times. A
-// non-retryable error (a real tool/protocol failure) is returned immediately.
+// backs off (exponentially, capped — #5717), reconnects, and retries up to
+// bridgeMaxRetries times. A non-retryable error (a real tool/protocol
+// failure) is returned immediately — the retry loop never fires for those.
 // The final error after exhausting retries is returned to the caller, which
 // renders it as a structured MCP error.
 //
@@ -264,12 +307,14 @@ func (b *bridge) callDaemon(method string, args, reply any) error {
 	for attempt := 0; attempt <= bridgeMaxRetries; attempt++ {
 		if attempt > 0 {
 			// Transient failure on the previous attempt: drop the dead client
-			// so getRPCClient redials, and pause so a restarting daemon has a
-			// moment to rebind its socket.
+			// so getRPCClient redials, and pause (exponential backoff, capped —
+			// #5717) so a restarting daemon has a growing window to rebind its
+			// socket and finish reloading.
 			b.resetRPCClient()
-			time.Sleep(bridgeRetryBackoff)
-			b.log("retrying %s after transient error (attempt %d/%d): %v",
-				method, attempt, bridgeMaxRetries, lastErr)
+			backoff := bridgeBackoffForAttempt(attempt)
+			time.Sleep(backoff)
+			b.log("retrying %s after transient error (attempt %d/%d, backoff %s): %v",
+				method, attempt, bridgeMaxRetries, backoff, lastErr)
 		}
 		rpcClient, err := b.getRPCClient()
 		if err != nil {

--- a/internal/cli/mcp_bridge_retry_test.go
+++ b/internal/cli/mcp_bridge_retry_test.go
@@ -20,8 +20,71 @@ import (
 )
 
 func init() {
-	// Keep reconnect backoff tiny so retry tests stay fast.
+	// Keep reconnect backoff tiny so retry tests stay fast, regardless of how
+	// large bridgeMaxRetries / bridgeRetryMaxBackoff are in production (#5717).
 	bridgeRetryBackoff = 1 * time.Millisecond
+	bridgeRetryMaxBackoff = 5 * time.Millisecond
+}
+
+// TestBridgeRetryBudget_WidenedPast450ms is a regression guard for #5717: the
+// pre-fix budget was bridgeMaxRetries=3 * bridgeRetryBackoff=150ms (flat) =
+// ~450ms total — far too short to ride out a daemon restart + reindex, which
+// takes seconds to minutes. The fix must widen the budget substantially.
+func TestBridgeRetryBudget_WidenedPast450ms(t *testing.T) {
+	if bridgeMaxRetries <= 3 {
+		t.Fatalf("bridgeMaxRetries = %d, want > 3 (#5717 widens the retry budget)", bridgeMaxRetries)
+	}
+}
+
+// TestBridgeBackoffForAttempt_Exponential verifies the reconnect backoff
+// doubles with each attempt and is capped at bridgeRetryMaxBackoff (#5717).
+// Uses fixed local values (not the package vars, which tests shrink for
+// speed) so the exponential/cap shape is verified independent of scale.
+func TestBridgeBackoffForAttempt_Exponential(t *testing.T) {
+	saved, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = saved, savedMax }()
+	bridgeRetryBackoff = 100 * time.Millisecond
+	bridgeRetryMaxBackoff = 800 * time.Millisecond
+
+	want := []time.Duration{
+		100 * time.Millisecond, // attempt 1
+		200 * time.Millisecond, // attempt 2
+		400 * time.Millisecond, // attempt 3
+		800 * time.Millisecond, // attempt 4 (would be 800, at cap)
+		800 * time.Millisecond, // attempt 5 (would be 1600, capped)
+		800 * time.Millisecond, // attempt 6 (still capped)
+	}
+	for i, w := range want {
+		attempt := i + 1
+		if got := bridgeBackoffForAttempt(attempt); got != w {
+			t.Errorf("bridgeBackoffForAttempt(%d) = %v, want %v", attempt, got, w)
+		}
+	}
+}
+
+// TestBridgeRetryBudget_SurvivalWindow asserts the total worst-case retry
+// window (sum of backoffs across bridgeMaxRetries attempts, using the real
+// production bridgeRetryBackoff/bridgeRetryMaxBackoff defaults) lands in the
+// ~30-60s range the issue calls for — long enough to ride out a daemon
+// restart + reindex, not so long that a genuinely dead daemon hangs the MCP
+// client forever.
+func TestBridgeRetryBudget_SurvivalWindow(t *testing.T) {
+	const (
+		prodInitial = 150 * time.Millisecond
+		prodCap     = 3 * time.Second
+	)
+	saved, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = saved, savedMax }()
+	bridgeRetryBackoff = prodInitial
+	bridgeRetryMaxBackoff = prodCap
+
+	var total time.Duration
+	for attempt := 1; attempt <= bridgeMaxRetries; attempt++ {
+		total += bridgeBackoffForAttempt(attempt)
+	}
+	if total < 20*time.Second || total > 90*time.Second {
+		t.Fatalf("total retry survival window = %v, want roughly 20s-90s (target ~30-60s)", total)
+	}
 }
 
 // TestIsRetryableRPCErr covers the classifier that decides whether the bridge

--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -23,6 +23,7 @@ package daemon
 import (
 	"encoding/json"
 	"fmt"
+	"runtime/debug"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/perf"
@@ -274,7 +275,7 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 	}
 
 	start := time.Now()
-	result, err := s.mcpCallTool(args.Name, args.Arguments, args.CWD)
+	result, err := s.callToolRecovered(args.Name, args.Arguments, args.CWD)
 	elapsed := time.Since(start)
 
 	// Debug log: tool=name elapsed_ms=X repo=Y (from CWD when available).
@@ -306,4 +307,45 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 		reply.Content = []map[string]any{}
 	}
 	return nil
+}
+
+// callToolRecovered invokes s.mcpCallTool with panic recovery (#5717).
+//
+// s.mcpCallTool is dispatched in-process inside the daemon, and this method
+// runs on a per-request goroutine spawned by net/rpc's ServeCodec. net/rpc
+// does NOT recover panics raised by service methods, and Go's runtime
+// terminates the entire process on an unrecovered panic in any goroutine —
+// so a single nil-deref (or any other bug) in ONE tool handler would crash
+// the whole daemon and sever every MCP bridge connection currently attached
+// to it (#5717). *mcp.Server's wrap() middleware is also hardened with its
+// own recover as defense in depth, but this is the last line of defense for
+// the daemon-hosted dispatch path: it converts a panicking handler into a
+// well-formed error result instead of taking down the process.
+//
+// The panic message and a (best-effort, size-capped) stack trace are logged
+// server-side for diagnosis; only a sanitized, generic message is returned
+// to the caller so internal details are not leaked over the wire.
+func (s *Service) callToolRecovered(name string, args map[string]any, cwd string) (result MCPCallResult, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if s.logger != nil {
+				s.logger.Error(LogEventMCPRPC,
+					LogFieldPhase, "panic",
+					LogFieldTool, name,
+					LogFieldRepo, cwd,
+					"panic", fmt.Sprintf("%v", r),
+					"stack", string(debug.Stack()),
+				)
+			}
+			result = MCPCallResult{
+				IsError: true,
+				Content: []map[string]any{
+					{"type": "text", "text": fmt.Sprintf(
+						"grafel daemon: tool %q panicked and was recovered — see daemon log for details", name)},
+				},
+			}
+			err = nil
+		}
+	}()
+	return s.mcpCallTool(name, args, cwd)
 }

--- a/internal/daemon/mcp_rpc_test.go
+++ b/internal/daemon/mcp_rpc_test.go
@@ -200,6 +200,44 @@ func TestMCPToolCall_HandlerError_ReturnsErrorBlock(t *testing.T) {
 	}
 }
 
+// TestMCPToolCall_HandlerPanic_RecoversAndSurvives is the RED/GREEN test for
+// #5717: a tool handler that panics (e.g. a nil-deref bug in one grafel_*
+// handler) must not crash the whole daemon and sever every MCP bridge
+// connection. Before the fix, s.mcpCallTool(...) had no defer/recover, so an
+// unrecovered panic here would propagate out of MCPToolCall, out of the
+// net/rpc dispatch goroutine, and terminate the process — this test would
+// crash `go test` itself rather than fail an assertion.
+func TestMCPToolCall_HandlerPanic_RecoversAndSurvives(t *testing.T) {
+	svc := testService(nil, func(name string, _ map[string]any, _ string) (MCPCallResult, error) {
+		if name == "grafel_boom" {
+			var p *int
+			_ = *p // nil-deref panic, simulating a buggy tool handler
+		}
+		return MCPCallResult{Content: []map[string]any{{"type": "text", "text": "ok"}}}, nil
+	})
+
+	var reply MCPToolCallReply
+	err := svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_boom"}, &reply)
+	if err != nil {
+		t.Fatalf("unexpected protocol error surfaced from recovered panic: %v", err)
+	}
+	if !reply.IsError {
+		t.Fatal("expected IsError=true for a panicking tool handler")
+	}
+	if len(reply.Content) == 0 {
+		t.Fatal("expected an error content block describing the panic")
+	}
+
+	// The dispatch loop must survive: a subsequent, unrelated call still works.
+	var reply2 MCPToolCallReply
+	if err := svc.MCPToolCall(&MCPToolCallArgs{Name: "grafel_stats"}, &reply2); err != nil {
+		t.Fatalf("unexpected error on call after recovered panic: %v", err)
+	}
+	if reply2.IsError {
+		t.Fatal("expected IsError=false for the healthy call after a recovered panic")
+	}
+}
+
 func TestMCPToolCall_EmptyContent_NormalisedToEmptySlice(t *testing.T) {
 	svc := testService(nil, func(_ string, _ map[string]any, _ string) (MCPCallResult, error) {
 		return MCPCallResult{Content: nil}, nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime/debug"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -1848,11 +1849,28 @@ func (s *Server) handleStatus(ctx context.Context, req mcpapi.CallToolRequest) (
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard
 // + MCP activity event emission (epic #1157, Phase 1).
+//
+// Panic guard (#5717): the deferred func's recover() converts a panicking
+// handler into a well-formed IsError tool result instead of letting the
+// panic propagate. This matters most for the daemon's in-process dispatch
+// path (internal/daemon/mcp_rpc.go calls straight into the *mcpsrv.ToolHandlerFunc
+// this method returns) — an unrecovered panic there would crash the whole
+// daemon process and sever every attached MCP bridge connection for one bad
+// call to one tool. It is a no-op (never triggers) on the normal happy path.
 func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error)) mcpsrv.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpapi.CallToolRequest) (res *mcpapi.CallToolResult, err error) {
 		start := time.Now()
 		end := s.Tel.Begin(name)
+		var collector *idCollector
 		defer func() {
+			if r := recover(); r != nil {
+				// #5717: sanitized message on the wire, full detail (message +
+				// stack) only in the server's own stderr/log stream.
+				fmt.Fprintf(os.Stderr, "mcp: tool %q panicked: %v\n%s\n", name, r, debug.Stack())
+				err = nil
+				res = mcpapi.NewToolResultError(fmt.Sprintf(
+					"internal error: tool %q panicked and was recovered — see server log for details", name))
+			}
 			isErr := err != nil || (res != nil && res.IsError)
 			end(isErr)
 			// Record into session metrics (#2192). Done in defer so elapsed
@@ -1860,12 +1878,18 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 			if s.SessMet != nil {
 				s.SessMet.Record(name, time.Since(start), isErr)
 			}
+			// Best-effort activity emission even on a recovered panic — ctx and
+			// collector are assigned below before fn() runs, so by the time this
+			// defer executes (whether via normal return or a recovered panic)
+			// they hold their post-assignment values; emitActivity is nil-safe
+			// when collector is still nil (a panic before the assignment below).
+			s.emitActivity(ctx, name, req, res, collector)
 		}()
 		s.reloadBeforeCall()
 		// Install a per-call id collector so render helpers can record the
 		// entity ids they surface (markdown tools have no machine-readable ids
 		// in their wire output). emitActivity drains it afterwards.
-		ctx, collector := withIDCollector(ctx)
+		ctx, collector = withIDCollector(ctx)
 		res, err = fn(ctx, req)
 		// #1650/#1687: stamp every tool payload with elapsed_ms — including error
 		// responses — so callers can benchmark latency regardless of outcome.
@@ -1913,7 +1937,8 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 			// Opt-out: MCP_NO_ID_INTERNING=1.
 			res = applyIDInterning(res)
 		}
-		s.emitActivity(ctx, name, req, res, collector)
+		// emitActivity now runs in the deferred func above so it also fires
+		// (best-effort) on a recovered panic (#5717).
 		return res, err
 	}
 }

--- a/internal/mcp/wrap_panic_test.go
+++ b/internal/mcp/wrap_panic_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestWrapRecoversPanic is the RED/GREEN test for #5717: wrap() is
+// documented as "telemetry + lazy reload + panic guard" (see the comment on
+// wrap in server.go) but before the fix its deferred func only recorded
+// telemetry — it never called recover(). Any registered tool handler that
+// panics (nil-deref, out-of-range index, etc.) would propagate the panic out
+// of the returned mcpsrv.ToolHandlerFunc and, in the daemon's in-process
+// dispatch path, crash the whole process and sever every attached MCP
+// bridge. This test registers a deliberately panicking handler through the
+// real wrap() middleware and asserts:
+//  1. the call returns a well-formed IsError tool result (not a crash), and
+//  2. a subsequent, unrelated call through the SAME server still succeeds —
+//     i.e. the dispatch loop survives one bad call.
+func TestWrapRecoversPanic(t *testing.T) {
+	s := &Server{Tel: NewTelemetry(0)}
+	// Skip reloadBeforeCall's real reload path (s.State is nil in this
+	// minimal unit-test server) by pinning the debounce window open.
+	s.reloadDebounce = time.Hour
+	s.reloadLastAt.Store(time.Now().UnixNano())
+
+	panicky := s.wrap("grafel_boom", func(_ context.Context, _ mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+		var p *int
+		_ = *p // nil-deref panic, simulating a buggy tool handler
+		return nil, nil
+	})
+
+	res, err := panicky(context.Background(), mcpapi.CallToolRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error surfaced from recovered panic: %v", err)
+	}
+	if res == nil || !res.IsError {
+		t.Fatalf("expected an IsError tool result for a panicking handler, got %#v", res)
+	}
+
+	// The middleware (and the server it is attached to) must survive: a
+	// healthy call afterwards still succeeds.
+	ok := s.wrap("grafel_ok", func(_ context.Context, _ mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+		return mcpapi.NewToolResultText("fine"), nil
+	})
+	res2, err2 := ok(context.Background(), mcpapi.CallToolRequest{})
+	if err2 != nil {
+		t.Fatalf("unexpected error on call after recovered panic: %v", err2)
+	}
+	if res2 == nil || res2.IsError {
+		t.Fatalf("expected a healthy result after a recovered panic, got %#v", res2)
+	}
+}


### PR DESCRIPTION
Phase 0 of the MCP/engine decouple epic (Refs #5729). Makes a daemon crash/restart a transparent blip instead of a hard MCP disconnect.

- wrap() now actually recover()s a panicking tool handler → returns a well-formed IsError result instead of crashing the daemon (covers every wrap'd tool; activity/elapsed still emitted). Makes the existing 'panic guard' comment true.
- Added callToolRecovered around the daemon net/rpc dispatch (mcp_rpc.go) as second-line defense — net/rpc never recovers service-method panics. Sanitized wire error; full stack logged server-side.
- Bridge reconnect budget: bridgeMaxRetries 3→20, exponential backoff 150ms→3s cap → ~30–60s survival window (covers a daemon restart + warm). isRetryableRPCErr classification untouched — non-retryable errors still fail fast.
- RED→GREEN tests at all three layers; happy path unchanged; existing retry tests preserved.

Refs #5717, #5729.