### PR TITLE
feat(status): status-plane foundation — indexed_commit SHA + poll-safe heartbeat/status file

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -24,6 +24,7 @@ import (
 // running" and continue with the registry view, rather than erroring.
 func newStatusCmd() *cobra.Command {
 	var refFlag string
+	var jsonFlag bool
 	cmd := &cobra.Command{
 		Use:   "status [group]",
 		Short: "Show daemon + index status",
@@ -31,8 +32,22 @@ func newStatusCmd() *cobra.Command {
 
 When --ref is supplied the registry view is filtered to repos that have a
 graph stored for that ref.  Use --ref @all to show state across every known
-ref (implies a per-ref breakdown in the output).`,
+ref (implies a per-ref breakdown in the output).
+
+--json switches to the poll-safe status-plane read (#5725/#5729-W1): it
+resolves the current directory to its registered repo and prints the
+on-disk status/heartbeat sidecar as JSON, WITHOUT dialing the daemon. It
+always returns promptly — even while the daemon is mid-index for this
+repo — falling back to {"status":"unknown"} rather than hanging or erroring
+when no engine has ever written a status file for this repo.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if jsonFlag {
+				cwd, err := os.Getwd()
+				if err != nil {
+					return err
+				}
+				return runStatusJSON(cmd.OutOrStdout(), cwd)
+			}
 			filterGroup := ""
 			if len(args) == 1 {
 				filterGroup = args[0]
@@ -46,6 +61,8 @@ ref (implies a per-ref breakdown in the output).`,
 	}
 	cmd.Flags().StringVar(&refFlag, "ref", "",
 		refFlagUsage)
+	cmd.Flags().BoolVar(&jsonFlag, "json", false,
+		"poll-safe, cwd-scoped status-plane read: prints the on-disk status file for the current repo without dialing the daemon")
 	return cmd
 }
 
@@ -177,6 +194,11 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 						r.Path, last, r.IndexCount, r.AlgoCount)
 					if r.LastErr != "" {
 						fmt.Fprintf(w, "  err=%s", r.LastErr)
+					}
+					// #5727/#5729-W1: show the exact indexed commit + whether
+					// the on-disk graph still matches HEAD.
+					if r.IndexedCommitShort != "" {
+						fmt.Fprintf(w, "  commit=%s at_head=%v", r.IndexedCommitShort, r.AtHead)
 					}
 					fmt.Fprintln(w)
 				}

--- a/internal/cli/status_json.go
+++ b/internal/cli/status_json.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// resolveRepoForCwd maps a working directory to the registered repo that
+// contains it, using a longest-path-prefix match across every repo in every
+// registered fleet group. This never touches the daemon or the network — it
+// only reads the local registry.json + per-group fleet configs, so it is
+// itself poll-safe (bounded by a handful of small local file reads).
+//
+// A statusline/CLI invocation is typically made from somewhere inside a
+// repo's working tree, not necessarily its root, so an exact-match-only
+// resolver would fail for the common case.
+func resolveRepoForCwd(cwd string) (string, error) {
+	absCwd, err := filepath.Abs(cwd)
+	if err != nil {
+		absCwd = cwd
+	}
+	absCwd = filepath.Clean(absCwd)
+
+	// NOTE: deliberately no filepath.EvalSymlinks here — statusfile.PathFor
+	// (the writer's side) hashes filepath.Abs+Clean without resolving
+	// symlinks, so resolving them here would make this resolver disagree
+	// with the writer on macOS, where t.TempDir()/some mount points are
+	// symlinked (e.g. /var -> /private/var), and produce a path whose
+	// status-file hash never matches what the engine wrote.
+	groups, err := registry.Groups()
+	if err != nil {
+		return "", fmt.Errorf("status --json: load registry: %w", err)
+	}
+
+	best := ""
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			repoAbs, err := filepath.Abs(r.Path)
+			if err != nil {
+				continue
+			}
+			repoAbs = filepath.Clean(repoAbs)
+			if absCwd != repoAbs && !strings.HasPrefix(absCwd, repoAbs+string(filepath.Separator)) {
+				continue
+			}
+			// Longest prefix wins (handles nested repos, however unlikely).
+			if len(repoAbs) > len(best) {
+				best = repoAbs
+			}
+		}
+	}
+	if best == "" {
+		return "", fmt.Errorf("status --json: %q is not inside any registered repo", cwd)
+	}
+	return best, nil
+}
+
+// statusJSONResult is the shape `grafel status --json` prints. When the
+// engine has never written a status file for this repo (never indexed, or
+// its daemon is down) Status is "unknown" and every other field is the zero
+// value — a well-formed, machine-parseable "I don't know" rather than an
+// error or a hang.
+type statusJSONResult struct {
+	Status string `json:"status"` // "ok" | "unknown"
+	*statusfile.File
+}
+
+// runStatusJSON implements `grafel status --json`: the poll-safe,
+// cwd-scoped status-plane read (#5725 core, #5729-W1). It resolves cwd to a
+// registered repo, then reads ONLY the on-disk statusfile sidecar — no
+// daemon dial, no RPC, no socket — so it returns promptly (well under the
+// 50ms budget) and can never hang, even while the daemon is mid-index for
+// this repo.
+func runStatusJSON(w io.Writer, cwd string) error {
+	repoPath, err := resolveRepoForCwd(cwd)
+	if err != nil {
+		return err
+	}
+
+	enc := json.NewEncoder(w)
+
+	f, err := statusfile.Read(repoPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return enc.Encode(statusJSONResult{Status: "unknown"})
+		}
+		// A corrupt/unreadable file is still "unknown" from a poll-safe
+		// reader's point of view — never propagate a hard error for a
+		// best-effort observability read.
+		return enc.Encode(statusJSONResult{Status: "unknown"})
+	}
+	return enc.Encode(statusJSONResult{Status: "ok", File: f})
+}

--- a/internal/cli/status_json_test.go
+++ b/internal/cli/status_json_test.go
@@ -1,0 +1,187 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestResolveRepoForCwd_LongestPrefixMatch is the RED test for the
+// #5725/#5729-W1 poll-safe `grafel status --json` cwd resolver: given a
+// registered repo and a cwd that is a subdirectory of it, the resolver must
+// return the repo's root path — not merely an exact match — since a
+// statusline is typically invoked from wherever the shell's cwd happens to
+// be inside the repo tree.
+func TestResolveRepoForCwd_LongestPrefixMatch(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+
+	repoRoot := t.TempDir()
+	sub := filepath.Join(repoRoot, "a", "b")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	configDir := filepath.Join(tmpHome, ".config", "grafel")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(configDir, "g.fleet.json")
+	cfg := &registry.GroupConfig{
+		Name:  "g",
+		Repos: []registry.Repo{{Slug: "r", Path: repoRoot}},
+	}
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := &registry.Registry{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: "g", ConfigPath: cfgPath}},
+	}
+	if err := registry.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveRepoForCwd(sub)
+	if err != nil {
+		t.Fatalf("resolveRepoForCwd: %v", err)
+	}
+	wantAbs, _ := filepath.EvalSymlinks(repoRoot)
+	gotAbs, _ := filepath.EvalSymlinks(got)
+	if gotAbs != wantAbs {
+		t.Errorf("resolveRepoForCwd(%q) = %q, want %q", sub, got, repoRoot)
+	}
+}
+
+// TestResolveRepoForCwd_NoMatch confirms an unregistered cwd (not inside any
+// known repo) surfaces a clear error rather than a hang or a panic.
+func TestResolveRepoForCwd_NoMatch(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+
+	reg := &registry.Registry{Version: 1}
+	if err := registry.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	elsewhere := t.TempDir()
+	if _, err := resolveRepoForCwd(elsewhere); err == nil {
+		t.Fatal("expected an error for a cwd outside any registered repo")
+	}
+}
+
+// TestRunStatusJSON_ReadsFileNotSocket is the RED test proving `grafel
+// status --json` is poll-safe: it must return the on-disk statusfile.File
+// contents WITHOUT dialing the daemon — verified here by there being no
+// daemon socket at all (client.Dial would fail/hang-detect if invoked; this
+// test simply never starts one, so any success here proves runStatusJSON
+// didn't need one).
+func TestRunStatusJSON_ReadsFileNotSocket(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+
+	repoRoot := t.TempDir()
+	configDir := filepath.Join(tmpHome, ".config", "grafel")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(configDir, "g.fleet.json")
+	cfg := &registry.GroupConfig{
+		Name:  "g",
+		Repos: []registry.Repo{{Slug: "r", Path: repoRoot}},
+	}
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := &registry.Registry{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: "g", ConfigPath: cfgPath}},
+	}
+	if err := registry.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	want := &statusfile.File{
+		EnginePID:     12345,
+		HeartbeatAt:   time.Now().UTC(),
+		Version:       "test-version",
+		RepoPath:      repoRoot,
+		IndexedCommit: "deadbeef",
+		Entities:      7,
+		Relationships: 3,
+	}
+	if err := statusfile.Write(repoRoot, want); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- runStatusJSON(&buf, repoRoot) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runStatusJSON: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("runStatusJSON did not return promptly — must never block on a daemon RPC")
+	}
+
+	var got statusfile.File
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if got.IndexedCommit != "deadbeef" || got.Entities != 7 {
+		t.Errorf("got = %+v, want IndexedCommit=deadbeef Entities=7", got)
+	}
+}
+
+// TestRunStatusJSON_UnknownFallback confirms a repo with no status file yet
+// (engine never touched it, or is down) returns a well-formed "unknown"
+// result rather than an error/hang.
+func TestRunStatusJSON_UnknownFallback(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+
+	repoRoot := t.TempDir()
+	configDir := filepath.Join(tmpHome, ".config", "grafel")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(configDir, "g.fleet.json")
+	cfg := &registry.GroupConfig{
+		Name:  "g",
+		Repos: []registry.Repo{{Slug: "r", Path: repoRoot}},
+	}
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := &registry.Registry{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: "g", ConfigPath: cfgPath}},
+	}
+	if err := registry.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runStatusJSON(&buf, repoRoot); err != nil {
+		t.Fatalf("runStatusJSON: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &out); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if s, _ := out["status"].(string); s != "unknown" {
+		t.Errorf(`out["status"] = %v, want "unknown"`, out["status"])
+	}
+}

--- a/internal/daemon/index_commit.go
+++ b/internal/daemon/index_commit.go
@@ -1,0 +1,69 @@
+package daemon
+
+import (
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// IndexedCommitInfo is the exact git commit a repo's on-disk graph was built
+// from, plus whether that commit still matches the repo's current HEAD
+// (#5727, #5729-W1 status plane). It lets a caller answer "is the graph
+// stale?" from already-recorded state — no reindex or full graph decode
+// required.
+type IndexedCommitInfo struct {
+	// Commit is the full 40-char SHA of the indexed commit, or "" if unknown
+	// (never indexed, non-git repo, or indexed before this field existed).
+	Commit string
+	// CommitShort is the abbreviated form of Commit (12 chars), or "" under
+	// the same conditions as Commit. May be populated even when Commit is
+	// empty for graphs written before the full-SHA field existed (#5727) —
+	// legacy graphs only ever recorded the short form.
+	CommitShort string
+	// AtHead is true when CommitShort exactly matches the repo's current
+	// HEAD short SHA. False when never indexed, HEAD has advanced past the
+	// indexed commit, or HEAD cannot be resolved (non-git repo / git error).
+	AtHead bool
+}
+
+// IndexedCommitForRepo reports the commit repoPath's on-disk graph was
+// indexed at, and whether it is still current.
+//
+// Resolution order (cheapest / most authoritative first):
+//  1. The diff-manifest sidecar (.grafel-state/file-index.json, written by
+//     internal/indexer/diff.SaveManifest on every index / incremental run) —
+//     carries both GitCommit (short) and GitCommitFull (#5727/#5729-W1).
+//  2. Fallback: the graph.fb header's IndexedSHA (short only) via
+//     graph.PersistedStatsFromDir — a cheap header-only read (no full graph
+//     decode), covering graphs produced by a path that never wrote the diff
+//     manifest (e.g. a very old graph, or one written before incremental
+//     indexing was enabled for the repo).
+//
+// The current-HEAD comparison shells out to `git rev-parse --short HEAD`
+// under gitmeta's bounded timeout — this is an on-demand RPC-path helper
+// (grafel_index_status / `grafel status`), NOT the poll-safe status-file read
+// path, which must never shell out (see internal/statusfile).
+func IndexedCommitForRepo(repoPath string) IndexedCommitInfo {
+	var info IndexedCommitInfo
+
+	stateDir := StateDirForRepo(repoPath)
+	if stateDir != "" {
+		m := diff.LoadManifest(stateDir)
+		info.CommitShort = m.GitCommit
+		info.Commit = m.GitCommitFull
+	}
+
+	if info.CommitShort == "" && stateDir != "" {
+		if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			info.CommitShort = ps.IndexedSHA
+		}
+	}
+
+	if info.CommitShort != "" {
+		if headShort, ok := gitmeta.RunGitBounded(repoPath, "rev-parse", "--short", "HEAD"); ok && headShort != "" {
+			info.AtHead = headShort == info.CommitShort
+		}
+	}
+
+	return info
+}

--- a/internal/daemon/index_commit.go
+++ b/internal/daemon/index_commit.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"strings"
+
 	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
@@ -20,9 +22,16 @@ type IndexedCommitInfo struct {
 	// empty for graphs written before the full-SHA field existed (#5727) —
 	// legacy graphs only ever recorded the short form.
 	CommitShort string
-	// AtHead is true when CommitShort exactly matches the repo's current
-	// HEAD short SHA. False when never indexed, HEAD has advanced past the
+	// AtHead is true when the indexed commit matches the repo's current
+	// committed HEAD. False when never indexed, HEAD has advanced past the
 	// indexed commit, or HEAD cannot be resolved (non-git repo / git error).
+	//
+	// AtHead reflects COMMITTED state only: it compares against `git rev-parse
+	// HEAD` and does NOT account for uncommitted working-tree changes. A repo
+	// with a dirty tree can still report AtHead=true even though the on-disk
+	// graph does not reflect those unstaged edits (review #5734 non-blocking
+	// #5). Consumers wanting working-tree freshness should additionally check
+	// the diff manifest / graph.fb mtime against the source files.
 	AtHead bool
 }
 
@@ -39,10 +48,10 @@ type IndexedCommitInfo struct {
 //     manifest (e.g. a very old graph, or one written before incremental
 //     indexing was enabled for the repo).
 //
-// The current-HEAD comparison shells out to `git rev-parse --short HEAD`
-// under gitmeta's bounded timeout — this is an on-demand RPC-path helper
-// (grafel_index_status / `grafel status`), NOT the poll-safe status-file read
-// path, which must never shell out (see internal/statusfile).
+// The current-HEAD comparison shells out to `git rev-parse HEAD` (the FULL
+// 40-char SHA) under gitmeta's bounded timeout — this is an on-demand RPC-path
+// helper (grafel_index_status / `grafel status`), NOT the poll-safe
+// status-file read path, which must never shell out (see internal/statusfile).
 func IndexedCommitForRepo(repoPath string) IndexedCommitInfo {
 	var info IndexedCommitInfo
 
@@ -55,15 +64,32 @@ func IndexedCommitForRepo(repoPath string) IndexedCommitInfo {
 
 	if info.CommitShort == "" && stateDir != "" {
 		if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			// graph.fb records only the short SHA (gitmeta uses --short=12).
 			info.CommitShort = ps.IndexedSHA
 		}
 	}
 
-	if info.CommitShort != "" {
-		if headShort, ok := gitmeta.RunGitBounded(repoPath, "rev-parse", "--short", "HEAD"); ok && headShort != "" {
-			info.AtHead = headShort == info.CommitShort
-		}
+	if info.CommitShort == "" && info.Commit == "" {
+		return info
 	}
 
+	// Compare against the FULL current HEAD SHA. Comparing short forms was
+	// buggy: the graph.fb fallback records a 12-char short (gitmeta
+	// --short=12) while `git rev-parse --short HEAD` yields git's default
+	// (~7 chars), so they never matched → AtHead always false for
+	// manifest-less graphs (review #5734 non-blocking #4). A full SHA plus a
+	// prefix check normalizes every short-length variant: the recorded short
+	// SHA (7 or 12 chars) is always a prefix of the full HEAD SHA when they
+	// refer to the same commit.
+	headFull, ok := gitmeta.RunGitBounded(repoPath, "rev-parse", "HEAD")
+	if !ok || headFull == "" {
+		return info
+	}
+	switch {
+	case info.Commit != "":
+		info.AtHead = strings.EqualFold(headFull, info.Commit)
+	default:
+		info.AtHead = strings.HasPrefix(strings.ToLower(headFull), strings.ToLower(info.CommitShort))
+	}
 	return info
 }

--- a/internal/daemon/index_commit_5729_test.go
+++ b/internal/daemon/index_commit_5729_test.go
@@ -1,0 +1,131 @@
+package daemon_test
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+func writeFileIC(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+func runGitIC(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func initGitRepoIC(t *testing.T, dir string) {
+	t.Helper()
+	runGitIC(t, dir, "init", "-q")
+	runGitIC(t, dir, "config", "user.email", "test@example.com")
+	runGitIC(t, dir, "config", "user.name", "Test")
+}
+
+// TestIndexedCommitForRepo_AtHeadTrueThenFalse is the RED test for the
+// #5727/#5729-W1 "expose indexed commit" deliverable.
+//
+// grafel_index_status / `grafel status` report indexed_ref but never the
+// exact indexed commit, so there is no way to tell whether the graph on disk
+// still matches HEAD (at_head) without a manual diff. This exercises the new
+// daemon.IndexedCommitForRepo helper: it must read the already-recorded
+// indexed commit (from the diff-manifest sidecar written by SaveManifest,
+// internal/indexer/diff/diff.go) and compare it against the repo's current
+// HEAD, WITHOUT requiring a fresh reindex.
+func TestIndexedCommitForRepo_AtHeadTrueThenFalse(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	initGitRepoIC(t, repo)
+	if err := writeAndCommit(repo, "main.go", "package main\nfunc main(){}\n"); err != nil {
+		t.Fatalf("seed commit: %v", err)
+	}
+	commitA := runGitIC(t, repo, "rev-parse", "HEAD")
+	commitAShort := runGitIC(t, repo, "rev-parse", "--short", "HEAD")
+
+	// Seed the diff manifest as if `grafel index` had just run at commit A.
+	stateDir := daemon.StateDirForRepo(repo)
+	m := diff.LoadManifest(stateDir)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+
+	info := daemon.IndexedCommitForRepo(repo)
+	if info.CommitShort != commitAShort {
+		t.Errorf("CommitShort = %q, want %q", info.CommitShort, commitAShort)
+	}
+	if info.Commit != commitA {
+		t.Errorf("Commit = %q, want %q", info.Commit, commitA)
+	}
+	if !info.AtHead {
+		t.Error("AtHead should be true immediately after indexing at current HEAD")
+	}
+
+	// Advance HEAD without re-running SaveManifest — the graph is now stale.
+	if err := writeAndCommit(repo, "main.go", "package main\nfunc main(){println(1)}\n"); err != nil {
+		t.Fatalf("advance commit: %v", err)
+	}
+
+	info2 := daemon.IndexedCommitForRepo(repo)
+	if info2.CommitShort != commitAShort {
+		t.Errorf("CommitShort after HEAD advance should still report the indexed commit %q, got %q",
+			commitAShort, info2.CommitShort)
+	}
+	if info2.AtHead {
+		t.Error("AtHead should be false once HEAD has advanced past the indexed commit")
+	}
+}
+
+// TestIndexedCommitForRepo_NeverIndexed asserts a repo with no manifest and no
+// graph.fb reports empty commit info rather than fabricating a value.
+func TestIndexedCommitForRepo_NeverIndexed(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	repo := t.TempDir()
+	initGitRepoIC(t, repo)
+	if err := writeAndCommit(repo, "a.go", "package a\n"); err != nil {
+		t.Fatalf("seed commit: %v", err)
+	}
+
+	info := daemon.IndexedCommitForRepo(repo)
+	if info.Commit != "" || info.CommitShort != "" {
+		t.Errorf("expected empty commit info for never-indexed repo, got %+v", info)
+	}
+	if info.AtHead {
+		t.Error("AtHead must be false when nothing has been indexed")
+	}
+}
+
+func writeAndCommit(dir, relPath, content string) error {
+	full := dir + "/" + relPath
+	if err := writeFileIC(full, content); err != nil {
+		return err
+	}
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return &execErr{out: out, err: err}
+	}
+	cmd = exec.Command("git", "commit", "-q", "-m", "c")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return &execErr{out: out, err: err}
+	}
+	return nil
+}
+
+type execErr struct {
+	out []byte
+	err error
+}
+
+func (e *execErr) Error() string { return e.err.Error() + ": " + string(e.out) }

--- a/internal/daemon/index_commit_5729_test.go
+++ b/internal/daemon/index_commit_5729_test.go
@@ -3,10 +3,14 @@ package daemon_test
 import (
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 )
 
@@ -102,6 +106,56 @@ func TestIndexedCommitForRepo_NeverIndexed(t *testing.T) {
 	}
 	if info.AtHead {
 		t.Error("AtHead must be false when nothing has been indexed")
+	}
+}
+
+// TestIndexedCommitForRepo_GraphFBFallback_AtHead is the regression test for
+// review #5734 non-blocking #4: for a manifest-less graph, IndexedCommitForRepo
+// falls back to the graph.fb header's IndexedSHA, which gitmeta records with
+// `--short=12` (12 chars). The old code compared that 12-char short against
+// `git rev-parse --short HEAD` (git's default ~7 chars) → never equal → AtHead
+// always false. Comparing against the FULL HEAD SHA via prefix fixes it.
+func TestIndexedCommitForRepo_GraphFBFallback_AtHead(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	initGitRepoIC(t, repo)
+	if err := writeAndCommit(repo, "main.go", "package main\nfunc main(){}\n"); err != nil {
+		t.Fatalf("seed commit: %v", err)
+	}
+	// gitmeta captures IndexedSHA as --short=12; mirror that exactly.
+	short12 := runGitIC(t, repo, "rev-parse", "--short=12", "HEAD")
+
+	// Write a graph.fb (NO diff manifest) into the repo's state dir carrying
+	// that 12-char short SHA in its header, simulating a graph produced by a
+	// path that never wrote the diff manifest.
+	stateDir := daemon.StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir stateDir: %v", err)
+	}
+	sw, err := fbwriter.NewStreamingWriter(filepath.Join(stateDir, "graph.fb"))
+	if err != nil {
+		t.Fatalf("NewStreamingWriter: %v", err)
+	}
+	e := graph.Entity{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "main.go"}
+	if err := sw.WriteEntity(&e); err != nil {
+		t.Fatalf("WriteEntity: %v", err)
+	}
+	if err := sw.Close(fbwriter.GraphMetadata{
+		Repo:        "fallback-repo",
+		GeneratedAt: time.Now().UTC(),
+		IndexedRef:  "main",
+		IndexedSHA:  short12,
+	}); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	info := daemon.IndexedCommitForRepo(repo)
+	if info.CommitShort != short12 {
+		t.Errorf("CommitShort = %q, want graph.fb short %q", info.CommitShort, short12)
+	}
+	if !info.AtHead {
+		t.Errorf("AtHead should be true: graph.fb 12-char short %q is a prefix of current HEAD", short12)
 	}
 }
 

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -143,6 +143,14 @@ type IndexedRepoState struct {
 	LastErr     string `json:"last_err,omitempty"`
 	LastPeakMB  int64  `json:"last_peak_mb,omitempty"`
 	PredictedMB int64  `json:"predicted_mb,omitempty"`
+
+	// #5727/#5729-W1 — the exact commit the on-disk graph was indexed at,
+	// and whether it still matches HEAD. Sourced from daemon.IndexedCommitForRepo
+	// (diff-manifest sidecar, falling back to the graph.fb header). Empty/false
+	// for a repo that has never been indexed, or a graph predating this field.
+	IndexedCommit      string `json:"indexed_commit,omitempty"`
+	IndexedCommitShort string `json:"indexed_commit_short,omitempty"`
+	AtHead             bool   `json:"at_head,omitempty"`
 }
 
 // SchedLogEntry is the wire form of a scheduler log entry.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
 // defaultActivateConcurrency bounds how many worktree working-tree fsnotify
@@ -439,6 +440,28 @@ func Run(ctx context.Context, cfg Config) error {
 		scheduler.Start()
 		svc.scheduler = scheduler
 		defer scheduler.Stop()
+
+		// #5725/#5729-W1: status-plane heartbeat file. registerStatusFileHook
+		// refreshes every known repo's on-disk status sidecar (internal/statusfile)
+		// immediately on each scheduler state transition (index start/complete/
+		// dirty); the ticker below additionally refreshes it periodically so a
+		// reader can detect a wedged/crashed engine via a stale heartbeat rather
+		// than trusting indefinitely-old data. Both defer-unwind in reverse
+		// registration order alongside scheduler.Stop() above.
+		//
+		// Deliberately NOT cfg.ReposToWatch: that callback is invoked exactly
+		// once by the boot-path watcher-subscription goroutine below, and some
+		// callers (e.g. TestBoot_WatcherSubscriptionDoesNotBlockBind) construct
+		// it with one-shot side effects. knownRepoPathsForStatus is a
+		// side-effect-free repo lister safe to call on every tick/hook fire.
+		statusRepos := func() []string { return knownRepoPathsForStatus(logger) }
+		registerStatusFileHook(statusRepos, logger)
+		stopStatusHeartbeat := make(chan struct{})
+		go runStatusHeartbeat(statusRepos, statusHeartbeatInterval(), stopStatusHeartbeat, logger)
+		defer func() {
+			close(stopStatusHeartbeat)
+			indexstate.SetOnRepoStatesChanged(nil)
+		}()
 
 		// #5690: hand a read-only warming accessor to the wiring layer so the
 		// MCP surface can report warming state. Closes over the live scheduler;

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/gitmeta"
-	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
 // defaultActivateConcurrency bounds how many worktree working-tree fsnotify
@@ -441,27 +440,24 @@ func Run(ctx context.Context, cfg Config) error {
 		svc.scheduler = scheduler
 		defer scheduler.Stop()
 
-		// #5725/#5729-W1: status-plane heartbeat file. registerStatusFileHook
-		// refreshes every known repo's on-disk status sidecar (internal/statusfile)
-		// immediately on each scheduler state transition (index start/complete/
-		// dirty); the ticker below additionally refreshes it periodically so a
-		// reader can detect a wedged/crashed engine via a stale heartbeat rather
-		// than trusting indefinitely-old data. Both defer-unwind in reverse
-		// registration order alongside scheduler.Stop() above.
+		// #5725/#5729-W1: status-plane heartbeat file. startStatusWriter runs a
+		// SINGLE serialized writer goroutine that refreshes every known repo's
+		// on-disk status sidecar (internal/statusfile): promptly on each
+		// scheduler state transition (via a coalescing notify hook) and
+		// periodically on a heartbeat tick, so a reader can detect a
+		// wedged/crashed engine via a stale heartbeat. Serializing through one
+		// goroutine makes concurrent same-repo writes impossible (review #5734)
+		// and coalesces bursts. The returned stop func unregisters the hook and
+		// joins the goroutine; it defer-unwinds alongside scheduler.Stop() above.
 		//
 		// Deliberately NOT cfg.ReposToWatch: that callback is invoked exactly
 		// once by the boot-path watcher-subscription goroutine below, and some
 		// callers (e.g. TestBoot_WatcherSubscriptionDoesNotBlockBind) construct
 		// it with one-shot side effects. knownRepoPathsForStatus is a
-		// side-effect-free repo lister safe to call on every tick/hook fire.
+		// side-effect-free repo lister safe to call on every tick/refresh.
 		statusRepos := func() []string { return knownRepoPathsForStatus(logger) }
-		registerStatusFileHook(statusRepos, logger)
-		stopStatusHeartbeat := make(chan struct{})
-		go runStatusHeartbeat(statusRepos, statusHeartbeatInterval(), stopStatusHeartbeat, logger)
-		defer func() {
-			close(stopStatusHeartbeat)
-			indexstate.SetOnRepoStatesChanged(nil)
-		}()
+		stopStatusWriter := startStatusWriter(statusRepos, statusHeartbeatInterval(), logger)
+		defer stopStatusWriter()
 
 		// #5690: hand a read-only warming accessor to the wiring layer so the
 		// MCP surface can report warming state. Closes over the live scheduler;

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -388,6 +388,11 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 				LastPeakMB:  r.LastPeakMB,
 				PredictedMB: r.PredictedMB,
 			}
+			// #5727/#5729-W1: surface the exact indexed commit + freshness.
+			ci := IndexedCommitForRepo(r.Path)
+			ir.IndexedCommit = ci.Commit
+			ir.IndexedCommitShort = ci.CommitShort
+			ir.AtHead = ci.AtHead
 			if !r.LastIndex.IsZero() {
 				ir.LastIndex = r.LastIndex.UTC().Format(time.RFC3339)
 			}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -1,0 +1,176 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
+	"github.com/cajasmota/grafel/internal/version"
+)
+
+// #5725/#5729-W1 — the status-plane foundation. The daemon (engine) is the
+// SOLE writer of internal/statusfile's per-repo sidecar; a poll-safe reader
+// (grafel status --json, a statusline, or the future standalone `serve`
+// process per ADR-0024) reads it directly off disk, never over the RPC
+// socket, so it can never block behind an in-flight index.
+//
+// Two triggers keep the file fresh:
+//  1. registerStatusFileHook wires indexstate.SetOnRepoStatesChanged so every
+//     scheduler state transition (index start/complete/dirty) refreshes the
+//     file promptly.
+//  2. runStatusHeartbeat is a periodic ticker (default every
+//     defaultStatusHeartbeatInterval) that refreshes it even when nothing
+//     changed, so a reader can detect a wedged/crashed engine via a stale
+//     HeartbeatAt rather than trusting indefinitely-old data.
+
+// defaultStatusHeartbeatInterval is how often the periodic heartbeat rewrites
+// every known repo's status file absent any state change.
+const defaultStatusHeartbeatInterval = 5 * time.Second
+
+// EnvStatusHeartbeatSeconds overrides defaultStatusHeartbeatInterval (tests /
+// operators who want a tighter or looser cadence).
+const EnvStatusHeartbeatSeconds = "GRAFEL_STATUS_HEARTBEAT_SECONDS"
+
+// statusHeartbeatInterval resolves the configured heartbeat cadence.
+func statusHeartbeatInterval() time.Duration {
+	if raw := os.Getenv(EnvStatusHeartbeatSeconds); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return defaultStatusHeartbeatInterval
+}
+
+// writeRepoStatusFile computes and atomically writes repoPath's current
+// status-plane sidecar. logger may be nil (tests). Failures are logged (when
+// a logger is available) and otherwise swallowed — the status file is a
+// best-effort observability aid, never load-bearing for indexing itself, so
+// a write failure must never propagate into the scheduler/RPC hot path.
+func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
+	f := &statusfile.File{
+		EnginePID:   os.Getpid(),
+		HeartbeatAt: time.Now().UTC(),
+		Version:     version.String(),
+		RepoPath:    repoPath,
+	}
+
+	// Per-repo scheduler state (indexing/queued/dirty + the ref it targets).
+	for _, st := range indexstate.RepoStates() {
+		if st.Path != repoPath {
+			continue
+		}
+		f.IndexedRef = st.IndexedRef
+		f.Indexing = st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty
+		break
+	}
+	// Process-wide queue depth (#5493 concurrency gate) — the closest
+	// available proxy for "how much work is ahead of this repo" without
+	// threading per-repo queue position through the scheduler snapshot.
+	conc := indexstate.GetIndexConcurrency()
+	f.QueueLen = conc.Queued
+
+	stateDir := StateDirForRepo(repoPath)
+	if stateDir != "" {
+		f.Entities, f.Relationships = readGraphStatsSidecar(stateDir)
+		if graphPath, mtimeNano := FindGraphFile(repoPath); graphPath != "" {
+			f.GraphFBMtime = mtimeNano
+		}
+	}
+
+	ci := IndexedCommitForRepo(repoPath)
+	f.IndexedCommit = ci.CommitShort
+
+	if err := statusfile.Write(repoPath, f); err != nil && logger != nil {
+		logger.Warn("statusfile: write failed", "repo", repoPath, "err", err)
+	}
+}
+
+// writeAllRepoStatusFiles refreshes the status file for every repo reposFn
+// returns. reposFn is called fresh each time so newly-registered repos are
+// picked up without a daemon restart.
+//
+// IMPORTANT: callers must NOT pass cfg.ReposToWatch here. That callback is
+// documented (see server.go's boot-path watcher-subscription goroutine) as
+// safe to invoke only from that one call site for some configurations (e.g.
+// tests that simulate a slow/stalled filesystem walk with a func that has a
+// one-shot side effect). The status-plane writer instead uses
+// knownRepoPathsForStatus, a side-effect-free, independently-callable-any-
+// number-of-times repo lister built directly off the registry.
+func writeAllRepoStatusFiles(reposFn func() []string, logger *slog.Logger) {
+	if reposFn == nil {
+		return
+	}
+	for _, repo := range reposFn() {
+		writeRepoStatusFile(repo, logger)
+	}
+}
+
+// knownRepoPathsForStatus returns every repo from every registered fleet
+// group (deduped, resolved to absolute paths), independent of cfg.ReposToWatch.
+// It is side-effect-free and safe to call repeatedly — every heartbeat tick
+// and every scheduler state-change hook fire calls it fresh — unlike
+// cfg.ReposToWatch, which some callers (notably
+// TestBoot_WatcherSubscriptionDoesNotBlockBind) construct with one-shot side
+// effects and an implicit "call at most once" expectation.
+func knownRepoPathsForStatus(logger *slog.Logger) []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var raw []string
+	for _, g := range groups {
+		gc, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range gc.Repos {
+			raw = append(raw, r.Path)
+		}
+	}
+	resolved := ResolveFleetRepoPaths(raw, logger)
+	out := make([]string, 0, len(resolved))
+	for _, abs := range resolved {
+		if seen[abs] {
+			continue
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+	return out
+}
+
+// registerStatusFileHook wires indexstate's on-change hook so a scheduler
+// state transition (index start/complete/dirty) triggers an immediate
+// status-file refresh across all known repos, rather than waiting for the
+// next periodic heartbeat tick. Call once at daemon startup, after
+// scheduler.Start(); pass nil to indexstate.SetOnRepoStatesChanged to
+// unregister (e.g. in tests, or on daemon shutdown).
+func registerStatusFileHook(reposFn func() []string, logger *slog.Logger) {
+	indexstate.SetOnRepoStatesChanged(func() {
+		writeAllRepoStatusFiles(reposFn, logger)
+	})
+}
+
+// runStatusHeartbeat periodically refreshes every known repo's status file
+// until stop is closed. Intended to run in its own goroutine for the
+// lifetime of the daemon (see server.go Run).
+func runStatusHeartbeat(reposFn func() []string, interval time.Duration, stop <-chan struct{}, logger *slog.Logger) {
+	if interval <= 0 {
+		interval = defaultStatusHeartbeatInterval
+	}
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-stop:
+			return
+		case <-ticker.C:
+			writeAllRepoStatusFiles(reposFn, logger)
+		}
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
@@ -18,14 +20,21 @@ import (
 // process per ADR-0024) reads it directly off disk, never over the RPC
 // socket, so it can never block behind an in-flight index.
 //
-// Two triggers keep the file fresh:
-//  1. registerStatusFileHook wires indexstate.SetOnRepoStatesChanged so every
-//     scheduler state transition (index start/complete/dirty) refreshes the
-//     file promptly.
-//  2. runStatusHeartbeat is a periodic ticker (default every
-//     defaultStatusHeartbeatInterval) that refreshes it even when nothing
-//     changed, so a reader can detect a wedged/crashed engine via a stale
-//     HeartbeatAt rather than trusting indefinitely-old data.
+// ALL writes go through a SINGLE serialized statusWriter goroutine (see
+// statusWriter.run). Two triggers feed it, both via a coalescing channel:
+//  1. indexstate.SetOnRepoStatesChanged (wired to statusWriter.notify) — every
+//     scheduler state transition (index start/complete/dirty) requests a
+//     refresh promptly.
+//  2. a periodic heartbeat tick (default every defaultStatusHeartbeatInterval)
+//     so a reader can detect a wedged/crashed engine via a stale HeartbeatAt
+//     rather than trusting indefinitely-old data.
+//
+// Serializing through one goroutine is what kills review #5734's BLOCKING
+// finding: it makes concurrent same-repo writes impossible from the daemon's
+// side (no tmp-file collision), and — combined with the coalescing channel —
+// collapses a burst of transitions into a bounded number of write passes
+// instead of spawning one all-repos-iterating, git-shelling goroutine per
+// transition (review #5734 non-blocking #2).
 
 // defaultStatusHeartbeatInterval is how often the periodic heartbeat rewrites
 // every known repo's status file absent any state change.
@@ -45,11 +54,34 @@ func statusHeartbeatInterval() time.Duration {
 	return defaultStatusHeartbeatInterval
 }
 
+// indexedCommitShortNoGit reads the short indexed-commit SHA for repoPath
+// WITHOUT shelling out to git. It is the write-path counterpart to
+// IndexedCommitForRepo (which additionally computes AtHead via a git subprocess
+// — wasteful here, review #5734 non-blocking #3, since the status file only
+// carries the short SHA). Resolution order mirrors IndexedCommitForRepo:
+// diff-manifest sidecar first, then the graph.fb header's IndexedSHA.
+func indexedCommitShortNoGit(repoPath string) string {
+	stateDir := StateDirForRepo(repoPath)
+	if stateDir == "" {
+		return ""
+	}
+	if m := diff.LoadManifest(stateDir); m.GitCommit != "" {
+		return m.GitCommit
+	}
+	if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+		return ps.IndexedSHA
+	}
+	return ""
+}
+
 // writeRepoStatusFile computes and atomically writes repoPath's current
 // status-plane sidecar. logger may be nil (tests). Failures are logged (when
 // a logger is available) and otherwise swallowed — the status file is a
 // best-effort observability aid, never load-bearing for indexing itself, so
 // a write failure must never propagate into the scheduler/RPC hot path.
+//
+// This is only ever called from the single statusWriter goroutine (or directly
+// from tests), so it never races another writer for the same repo.
 func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 	f := &statusfile.File{
 		EnginePID:   os.Getpid(),
@@ -81,38 +113,19 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 		}
 	}
 
-	ci := IndexedCommitForRepo(repoPath)
-	f.IndexedCommit = ci.CommitShort
+	// Write path is git-free: read the short SHA off disk, never shell out
+	// (review #5734 non-blocking #3).
+	f.IndexedCommit = indexedCommitShortNoGit(repoPath)
 
 	if err := statusfile.Write(repoPath, f); err != nil && logger != nil {
 		logger.Warn("statusfile: write failed", "repo", repoPath, "err", err)
 	}
 }
 
-// writeAllRepoStatusFiles refreshes the status file for every repo reposFn
-// returns. reposFn is called fresh each time so newly-registered repos are
-// picked up without a daemon restart.
-//
-// IMPORTANT: callers must NOT pass cfg.ReposToWatch here. That callback is
-// documented (see server.go's boot-path watcher-subscription goroutine) as
-// safe to invoke only from that one call site for some configurations (e.g.
-// tests that simulate a slow/stalled filesystem walk with a func that has a
-// one-shot side effect). The status-plane writer instead uses
-// knownRepoPathsForStatus, a side-effect-free, independently-callable-any-
-// number-of-times repo lister built directly off the registry.
-func writeAllRepoStatusFiles(reposFn func() []string, logger *slog.Logger) {
-	if reposFn == nil {
-		return
-	}
-	for _, repo := range reposFn() {
-		writeRepoStatusFile(repo, logger)
-	}
-}
-
 // knownRepoPathsForStatus returns every repo from every registered fleet
 // group (deduped, resolved to absolute paths), independent of cfg.ReposToWatch.
 // It is side-effect-free and safe to call repeatedly — every heartbeat tick
-// and every scheduler state-change hook fire calls it fresh — unlike
+// and every coalesced state-change refresh calls it fresh — unlike
 // cfg.ReposToWatch, which some callers (notably
 // TestBoot_WatcherSubscriptionDoesNotBlockBind) construct with one-shot side
 // effects and an implicit "call at most once" expectation.
@@ -144,33 +157,103 @@ func knownRepoPathsForStatus(logger *slog.Logger) []string {
 	return out
 }
 
-// registerStatusFileHook wires indexstate's on-change hook so a scheduler
-// state transition (index start/complete/dirty) triggers an immediate
-// status-file refresh across all known repos, rather than waiting for the
-// next periodic heartbeat tick. Call once at daemon startup, after
-// scheduler.Start(); pass nil to indexstate.SetOnRepoStatesChanged to
-// unregister (e.g. in tests, or on daemon shutdown).
-func registerStatusFileHook(reposFn func() []string, logger *slog.Logger) {
-	indexstate.SetOnRepoStatesChanged(func() {
-		writeAllRepoStatusFiles(reposFn, logger)
-	})
+// statusWriter owns the single goroutine that writes every repo's status-plane
+// sidecar. All writes are serialized through run(), so no two writes ever race
+// for the same repo file (review #5734 BLOCKING fix). Refresh requests arrive
+// via notify(), which is non-blocking and COALESCING: a burst of scheduler
+// transitions collapses into at most one extra write pass, bounding both
+// goroutine count and the number of graph.fb stats reads per burst (review
+// #5734 non-blocking #2).
+type statusWriter struct {
+	reposFn func() []string
+	logger  *slog.Logger
+
+	// trigger is buffered size 1. notify() does a non-blocking send, so when a
+	// pass is already pending the extra request is dropped — the pending pass
+	// will read the latest state when it runs. This is the coalescing seam.
+	trigger chan struct{}
+	stop    chan struct{}
+	done    chan struct{}
 }
 
-// runStatusHeartbeat periodically refreshes every known repo's status file
-// until stop is closed. Intended to run in its own goroutine for the
-// lifetime of the daemon (see server.go Run).
-func runStatusHeartbeat(reposFn func() []string, interval time.Duration, stop <-chan struct{}, logger *slog.Logger) {
+// newStatusWriter constructs a statusWriter. reposFn must be side-effect-free
+// and safe to call repeatedly (see knownRepoPathsForStatus).
+func newStatusWriter(reposFn func() []string, logger *slog.Logger) *statusWriter {
+	return &statusWriter{
+		reposFn: reposFn,
+		logger:  logger,
+		trigger: make(chan struct{}, 1),
+		stop:    make(chan struct{}),
+		done:    make(chan struct{}),
+	}
+}
+
+// notify requests a status-file refresh. Non-blocking and coalescing: if a
+// refresh is already queued this is a no-op. Safe to call from any goroutine,
+// including indexstate's on-change hook (fired under the scheduler lock).
+func (w *statusWriter) notify() {
+	select {
+	case w.trigger <- struct{}{}:
+	default:
+	}
+}
+
+// run is the single serialized writer loop. It writes once immediately (so a
+// reader sees state promptly at startup), then refreshes on each coalesced
+// notify() and each heartbeat tick until shutdown. Intended to run in its own
+// goroutine for the daemon's lifetime.
+func (w *statusWriter) run(interval time.Duration) {
+	defer close(w.done)
 	if interval <= 0 {
 		interval = defaultStatusHeartbeatInterval
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+
+	w.writeAll()
 	for {
 		select {
-		case <-stop:
+		case <-w.stop:
 			return
 		case <-ticker.C:
-			writeAllRepoStatusFiles(reposFn, logger)
+			w.writeAll()
+		case <-w.trigger:
+			w.writeAll()
 		}
+	}
+}
+
+// writeAll refreshes every known repo's status file. Only ever called from
+// run()'s single goroutine, so writes stay serialized.
+func (w *statusWriter) writeAll() {
+	if w.reposFn == nil {
+		return
+	}
+	for _, repo := range w.reposFn() {
+		writeRepoStatusFile(repo, w.logger)
+	}
+}
+
+// shutdown stops the writer goroutine and waits for it to exit. Idempotent is
+// NOT guaranteed — call exactly once, from the daemon's Run defer.
+func (w *statusWriter) shutdown() {
+	close(w.stop)
+	<-w.done
+}
+
+// startStatusWriter wires and starts the status-plane writer: it registers the
+// coalescing notify hook with indexstate and launches the single writer
+// goroutine. The returned func unregisters the hook and stops the goroutine;
+// call it from the daemon's Run defer. reposFn must be side-effect-free (see
+// knownRepoPathsForStatus).
+func startStatusWriter(reposFn func() []string, interval time.Duration, logger *slog.Logger) (stop func()) {
+	w := newStatusWriter(reposFn, logger)
+	indexstate.SetOnRepoStatesChanged(w.notify)
+	go w.run(interval)
+	return func() {
+		// Unregister the hook first so no new notify() races shutdown, then
+		// stop and join the goroutine.
+		indexstate.SetOnRepoStatesChanged(nil)
+		w.shutdown()
 	}
 }

--- a/internal/daemon/statuswriter_5729_test.go
+++ b/internal/daemon/statuswriter_5729_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestWriteRepoStatusFile_WritesReadableSchema is the RED test for the
+// #5725/#5729-W1 engine-side status-file writer: the daemon must write a
+// statusfile.File for a repo whose fields a poll-safe reader (grafel status
+// --json / a statusline) can consume WITHOUT any daemon RPC.
+func TestWriteRepoStatusFile_WritesReadableSchema(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+
+	// Publish a live in-flight index state for this repo so the writer's
+	// "indexing" bit reflects real scheduler state, not just disk.
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: repo, State: indexstate.StateIndexing, HeadRef: "main"},
+	})
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	writeRepoStatusFile(repo, nil)
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if got.EnginePID != os.Getpid() {
+		t.Errorf("EnginePID = %d, want %d", got.EnginePID, os.Getpid())
+	}
+	if got.HeartbeatAt.IsZero() {
+		t.Error("HeartbeatAt should be stamped")
+	}
+	if time.Since(got.HeartbeatAt) > time.Minute {
+		t.Errorf("HeartbeatAt too old: %v", got.HeartbeatAt)
+	}
+	if got.Version == "" {
+		t.Error("Version should be populated")
+	}
+	if got.RepoPath != repo {
+		t.Errorf("RepoPath = %q, want %q", got.RepoPath, repo)
+	}
+	if !got.Indexing {
+		t.Error("Indexing should be true — scheduler reports this repo as StateIndexing")
+	}
+}
+
+// TestOnRepoStatesChanged_TriggersStatusFileRefresh proves the daemon wires
+// indexstate.SetOnRepoStatesChanged so a scheduler state transition (index
+// start/complete) refreshes the status file promptly, not just on the next
+// periodic heartbeat tick.
+func TestOnRepoStatesChanged_TriggersStatusFileRefresh(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	registerStatusFileHook(func() []string { return []string{repo} }, nil)
+	t.Cleanup(func() { indexstate.SetOnRepoStatesChanged(nil) })
+
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: repo, State: indexstate.StateIndexing},
+	})
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	// The hook fires in its own goroutine (see indexstate.SetRepoStates) —
+	// poll briefly for the file to land rather than sleeping a fixed amount.
+	deadline := time.Now().Add(2 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if _, err := statusfile.Read(repo); err == nil {
+			return
+		} else {
+			lastErr = err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("status file was not written after a repo-state change: %v", lastErr)
+}

--- a/internal/daemon/statuswriter_5729_test.go
+++ b/internal/daemon/statuswriter_5729_test.go
@@ -52,25 +52,41 @@ func TestWriteRepoStatusFile_WritesReadableSchema(t *testing.T) {
 	}
 }
 
-// TestOnRepoStatesChanged_TriggersStatusFileRefresh proves the daemon wires
+// TestOnRepoStatesChanged_TriggersStatusFileRefresh proves the daemon's single
+// serialized statusWriter (startStatusWriter) wires
 // indexstate.SetOnRepoStatesChanged so a scheduler state transition (index
-// start/complete) refreshes the status file promptly, not just on the next
-// periodic heartbeat tick.
+// start/complete) refreshes the status file promptly via the coalescing notify
+// hook, not just on the next periodic heartbeat tick. A very long heartbeat
+// interval ensures the file can only appear because of the state-change
+// trigger, not the ticker.
 func TestOnRepoStatesChanged_TriggersStatusFileRefresh(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
 
 	repo := t.TempDir()
-	registerStatusFileHook(func() []string { return []string{repo} }, nil)
-	t.Cleanup(func() { indexstate.SetOnRepoStatesChanged(nil) })
+	stop := startStatusWriter(func() []string { return []string{repo} }, time.Hour, nil)
+	t.Cleanup(stop)
+
+	// startStatusWriter writes once immediately at startup; clear that file so
+	// the assertion below can only pass because of the state-change trigger.
+	if p, err := statusfile.PathFor(repo); err == nil {
+		// Poll briefly for the startup write, then remove it.
+		for i := 0; i < 100; i++ {
+			if _, rerr := statusfile.Read(repo); rerr == nil {
+				break
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		_ = os.Remove(p)
+	}
 
 	indexstate.SetRepoStates([]indexstate.RepoState{
 		{Path: repo, State: indexstate.StateIndexing},
 	})
 	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
 
-	// The hook fires in its own goroutine (see indexstate.SetRepoStates) —
-	// poll briefly for the file to land rather than sleeping a fixed amount.
+	// The notify hook fires in its own goroutine (see indexstate.SetRepoStates)
+	// and coalesces into the writer — poll briefly for the file to reappear.
 	deadline := time.Now().Add(2 * time.Second)
 	var lastErr error
 	for time.Now().Before(deadline) {

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -89,6 +89,15 @@ type PersistedStats struct {
 	// (the same value the sidecar's computed_at would carry). Zero when the
 	// header carries no/unparseable timestamp.
 	ComputedAt time.Time
+	// IndexedRef is the git ref name (branch/tag) at index time, read
+	// directly off the graph.fb header (#5729-W1 status plane). Empty for
+	// legacy graphs written before Phase 0 git metadata (#2088) or a
+	// detached HEAD / non-git repo.
+	IndexedRef string
+	// IndexedSHA is the abbreviated (short) HEAD commit hash at index time,
+	// read directly off the graph.fb header. Empty under the same
+	// conditions as IndexedRef.
+	IndexedSHA string
 }
 
 // PersistedStatsFromDir reads cheap persisted stats from <dir>/graph.fb.
@@ -111,9 +120,12 @@ func PersistedStatsFromDir(dir string) (PersistedStats, bool) {
 		Entities:      r.EntityCount(),
 		Relationships: r.RelationshipCount(),
 	}
-	if t, perr := time.Parse(time.RFC3339, r.LoadGraphMeta().ComputedAt); perr == nil {
+	meta := r.LoadGraphMeta()
+	if t, perr := time.Parse(time.RFC3339, meta.ComputedAt); perr == nil {
 		ps.ComputedAt = t
 	}
+	ps.IndexedRef = meta.IndexedRef
+	ps.IndexedSHA = meta.IndexedSHA
 	return ps, true
 }
 

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -70,10 +70,17 @@ type FileEntry struct {
 
 // Manifest is the on-disk representation of the per-repo file index.
 type Manifest struct {
-	Version   int                  `json:"version"`
-	IndexedAt time.Time            `json:"indexed_at"`
-	GitCommit string               `json:"git_commit,omitempty"`
-	Files     map[string]FileEntry `json:"files"`
+	Version   int       `json:"version"`
+	IndexedAt time.Time `json:"indexed_at"`
+	GitCommit string    `json:"git_commit,omitempty"`
+	// GitCommitFull is the FULL 40-char HEAD commit SHA at the time this
+	// manifest was saved (#5727/#5729-W1). GitCommit above is the abbreviated
+	// (short) form used by the incremental diff range-check; GitCommitFull is
+	// surfaced by grafel_index_status / `grafel status` as an unambiguous
+	// indexed_commit so a caller never has to disambiguate a short-SHA prefix
+	// collision. Empty when not a git repo or the git call fails/times out.
+	GitCommitFull string               `json:"git_commit_full,omitempty"`
+	Files         map[string]FileEntry `json:"files"`
 }
 
 // LoadManifest reads the manifest from stateDir. Returns an empty manifest
@@ -100,6 +107,7 @@ func LoadManifest(stateDir string) *Manifest {
 func SaveManifest(stateDir, repoPath string, m *Manifest) error {
 	m.IndexedAt = time.Now().UTC()
 	m.GitCommit = headCommit(repoPath)
+	m.GitCommitFull = headCommitFull(repoPath)
 
 	data, err := json.Marshal(m)
 	if err != nil {
@@ -451,6 +459,18 @@ func moduleBase(relPath string) string {
 func headCommit(repoPath string) string {
 	// Bounded (#5286): never let a stuck git child hang the index worker.
 	out, ok := gitmeta.RunGitBoundedC(repoPath, "rev-parse", "--short", "HEAD")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// headCommitFull returns the FULL (40-char) HEAD commit hash for the repo at
+// repoPath, or empty string if git is unavailable or this is not a git repo.
+// Companion to headCommit (short); both are captured in the same SaveManifest
+// call so they always agree on which commit they describe (#5727/#5729-W1).
+func headCommitFull(repoPath string) string {
+	out, ok := gitmeta.RunGitBoundedC(repoPath, "rev-parse", "HEAD")
 	if !ok {
 		return ""
 	}

--- a/internal/indexer/diff/gitcommit_5729_test.go
+++ b/internal/indexer/diff/gitcommit_5729_test.go
@@ -1,0 +1,80 @@
+package diff_test
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// initGitRepoForCommitTest creates a minimal git repo with a committer identity
+// configured so `git commit` succeeds in CI sandboxes with no global config.
+func initGitRepoForCommitTest(t *testing.T, dir string) {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init", "-q")
+	run("config", "user.email", "test@example.com")
+	run("config", "user.name", "Test")
+}
+
+func gitCommitAllForCommitTest(t *testing.T, dir, msg string) string {
+	t.Helper()
+	run := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("add", "-A")
+	run("commit", "-q", "-m", msg)
+
+	out, err := exec.Command("git", "-C", dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatalf("rev-parse HEAD: %v", err)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// TestSaveManifest_CapturesFullCommitSHA is the RED test for #5727/#5729-W1.
+//
+// diff.Manifest already records the SHORT (12-char) HEAD commit in GitCommit
+// (see headCommit in diff.go). Nothing today records the FULL 40-char SHA,
+// which grafel_index_status / `grafel status` need to expose an unambiguous
+// indexed_commit alongside the existing short form. This asserts SaveManifest
+// populates a new GitCommitFull field with the full SHA, and that it is a
+// prefix-consistent match with the existing short GitCommit.
+func TestSaveManifest_CapturesFullCommitSHA(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	initGitRepoForCommitTest(t, repo)
+	writeFile(t, repo, "main.go", "package main\n\nfunc main() {}\n")
+	fullSHA := gitCommitAllForCommitTest(t, repo, "initial commit")
+
+	m := diff.LoadManifest(stateDir)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+
+	m2 := diff.LoadManifest(stateDir)
+	if m2.GitCommit == "" {
+		t.Fatal("sanity: GitCommit (short) was not populated")
+	}
+	if m2.GitCommitFull == "" {
+		t.Fatal("GitCommitFull was not populated by SaveManifest")
+	}
+	if m2.GitCommitFull != fullSHA {
+		t.Errorf("GitCommitFull = %q, want %q", m2.GitCommitFull, fullSHA)
+	}
+	if !strings.HasPrefix(m2.GitCommitFull, m2.GitCommit) {
+		t.Errorf("GitCommitFull %q does not start with short GitCommit %q", m2.GitCommitFull, m2.GitCommit)
+	}
+}

--- a/internal/indexstate/indexstate.go
+++ b/internal/indexstate/indexstate.go
@@ -152,7 +152,27 @@ type RepoState struct {
 var (
 	repoStatesMu sync.RWMutex
 	repoStates   []RepoState
+
+	// onChangeMu guards onChange (#5729-W1 status plane). A single hook, not
+	// a list — today's sole consumer is the daemon's status-file writer,
+	// registered once at startup.
+	onChangeMu sync.Mutex
+	onChange   func()
 )
+
+// SetOnRepoStatesChanged registers fn to be called (in its own goroutine,
+// never blocking the caller of SetRepoStates) every time the per-repo
+// index-state snapshot changes. Used by the daemon to trigger an
+// on-state-change refresh of the poll-safe status file (internal/statusfile)
+// in addition to its periodic heartbeat, so a consumer sees "indexing
+// started/completed" promptly rather than only at the next heartbeat tick
+// (#5725/#5729-W1). Pass nil to unregister. Safe to call from any goroutine;
+// intended to be called once at daemon startup, before the scheduler runs.
+func SetOnRepoStatesChanged(fn func()) {
+	onChangeMu.Lock()
+	onChange = fn
+	onChangeMu.Unlock()
+}
 
 // SetRepoStates replaces the published per-repo index-state snapshot. The
 // scheduler calls this under its own lock immediately after publishing the
@@ -165,6 +185,16 @@ func SetRepoStates(states []RepoState) {
 	repoStatesMu.Lock()
 	repoStates = cp
 	repoStatesMu.Unlock()
+
+	onChangeMu.Lock()
+	fn := onChange
+	onChangeMu.Unlock()
+	if fn != nil {
+		// Never let a slow/blocking hook (e.g. one that stats graph.fb files)
+		// stall the scheduler's own lock-protected state transition — this
+		// call site runs with the scheduler's mu held by the caller.
+		go fn()
+	}
 }
 
 // RepoStates returns a copy of the current per-repo index-state snapshot,

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -30,6 +30,14 @@ type indexStatusRepo struct {
 	IndexedRef string `json:"indexed_ref,omitempty"`
 	HeadRef    string `json:"head_ref,omitempty"`
 	Dirty      bool   `json:"dirty"`
+
+	// #5727/#5729-W1: the exact commit the on-disk graph was indexed at, plus
+	// whether it still matches HEAD. Sourced from daemon.IndexedCommitForRepo
+	// (diff-manifest sidecar, falling back to the graph.fb header). Empty/false
+	// when never indexed or the graph predates this field.
+	IndexedCommit      string `json:"indexed_commit,omitempty"`
+	IndexedCommitShort string `json:"indexed_commit_short,omitempty"`
+	AtHead             bool   `json:"at_head,omitempty"`
 }
 
 // indexStatusReply is the grafel_index_status response envelope.
@@ -119,6 +127,10 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 			HeadRef:    st.HeadRef,
 			Dirty:      st.Dirty,
 		}
+		ci := daemon.IndexedCommitForRepo(st.Path)
+		row.IndexedCommit = ci.Commit
+		row.IndexedCommitShort = ci.CommitShort
+		row.AtHead = ci.AtHead
 		out.Repos = append(out.Repos, row)
 		if st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty {
 			out.AnyIndexing = true
@@ -213,6 +225,13 @@ func diskFallbackRow(repoPath, group string) (indexStatusRepo, bool) {
 			row.HeadRef = meta.IndexedRef
 		}
 	}
+	// #5727/#5729-W1: attach the indexed commit + freshness for a disk-only
+	// row too, so a repo indexed via `grafel rebuild` (bypassing the
+	// scheduler) still reports indexed_commit/at_head.
+	ci := daemon.IndexedCommitForRepo(repoPath)
+	row.IndexedCommit = ci.Commit
+	row.IndexedCommitShort = ci.CommitShort
+	row.AtHead = ci.AtHead
 	return row, true
 }
 

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -126,12 +126,39 @@ func Write(repoPath string, f *File) error {
 	// then rename over the final path. A concurrent Read always sees either
 	// the previous complete file or the new complete file, never a partial
 	// write — this is the guarantee a poll-safe reader depends on.
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+	//
+	// The temp file MUST have a unique name (os.CreateTemp's random suffix),
+	// NOT a fixed path+".tmp": two concurrent Writes to the same repo would
+	// otherwise both O_TRUNC and interleave into the SAME tmp inode, then each
+	// rename a torn/garbled file into place. Rename is atomic, but it would be
+	// publishing corruption. The daemon serializes its own writes via the
+	// single coalescing statusWriter goroutine (see internal/daemon), but a
+	// unique tmp name makes Write correct under concurrency regardless of who
+	// calls it — belt and suspenders (review #5734).
+	tmpf, err := os.CreateTemp(dir, filepath.Base(path)+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("statusfile: create tmp: %w", err)
+	}
+	tmp := tmpf.Name()
+	// On any failure past this point, remove the orphan tmp so a crashed/
+	// racing writer never litters the status dir.
+	cleanup := func() { _ = os.Remove(tmp) }
+	if _, err := tmpf.Write(data); err != nil {
+		_ = tmpf.Close()
+		cleanup()
 		return fmt.Errorf("statusfile: write tmp: %w", err)
 	}
+	if err := tmpf.Chmod(0o600); err != nil {
+		_ = tmpf.Close()
+		cleanup()
+		return fmt.Errorf("statusfile: chmod tmp: %w", err)
+	}
+	if err := tmpf.Close(); err != nil {
+		cleanup()
+		return fmt.Errorf("statusfile: close tmp: %w", err)
+	}
 	if err := os.Rename(tmp, path); err != nil {
-		_ = os.Remove(tmp)
+		cleanup()
 		return fmt.Errorf("statusfile: rename: %w", err)
 	}
 	return nil

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -1,0 +1,163 @@
+// Package statusfile is the engine↔consumer status-plane sidecar (#5725
+// core, #5729-W1). It exists so a statusline / CLI / future serve process can
+// answer "what is grafel doing for THIS repo right now?" with a fast,
+// non-blocking, always-terminating file read — never a daemon RPC that can
+// block behind an in-flight index.
+//
+// The daemon (engine) is the SOLE writer: it atomically (tmp+rename) writes
+// one small JSON file per repo to
+//
+//	$GRAFEL_HOME/status/<sha256(abs_repo_path)[:16]>.json
+//
+// (GRAFEL_HOME defaults to ~/.grafel; honors the same override as
+// internal/registry.HomeDir). The file is updated whenever that repo's index
+// state changes (start/complete/dirty) and on a periodic heartbeat so a
+// reader can also detect an engine that died mid-index (stale HeartbeatAt).
+//
+// A reader (grafel status --json, a statusline, or the future standalone
+// `serve` process per ADR-0024) calls Read, which does a single os.ReadFile —
+// no socket dial, no lock, no RPC. If the file is absent or stale the reader
+// falls back to "unknown" rather than hanging.
+package statusfile
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// File is the on-disk status-plane schema for one repo. Fields are additive
+// only — a reader must tolerate a file written by an older engine version
+// missing newer fields (all are zero-valued, not an error).
+type File struct {
+	// EnginePID is the process ID of the daemon that wrote this file. Lets a
+	// reader detect a stale file left behind by a since-restarted daemon
+	// (compare against the currently-running daemon's pid, e.g. via the
+	// pidfile) without needing a live RPC.
+	EnginePID int `json:"engine_pid"`
+	// HeartbeatAt is the wall-clock time this file was last written — either
+	// because this repo's index state changed, or the periodic heartbeat
+	// tick fired. A reader treats a HeartbeatAt older than a few missed
+	// heartbeat intervals as "engine may be gone" and falls back to
+	// "unknown" rather than trusting stale data.
+	HeartbeatAt time.Time `json:"heartbeat_at"`
+	// Version is the engine's self-reported version (mirrors proto.PingReply.Version).
+	Version string `json:"version"`
+
+	// RepoPath is the absolute on-disk path this file describes.
+	RepoPath string `json:"repo_path"`
+	// IndexedRef is the git ref (branch/tag) the on-disk graph reflects.
+	IndexedRef string `json:"indexed_ref,omitempty"`
+	// IndexedCommit is the exact commit SHA the on-disk graph reflects
+	// (#5727) — short form; the fuller identifier a status-plane consumer
+	// typically wants for an at-a-glance freshness check.
+	IndexedCommit string `json:"indexed_commit,omitempty"`
+	// Entities / Relationships are the graph's persisted counts (cheap
+	// header-derived values — see graph.PersistedStatsFromDir), not a full
+	// decode.
+	Entities      int64 `json:"entities"`
+	Relationships int64 `json:"relationships"`
+	// GraphFBMtime is the on-disk graph.fb file's modification time
+	// (UnixNano), letting a reader detect a graph that was rewritten after
+	// this status file was last refreshed.
+	GraphFBMtime int64 `json:"graph_fb_mtime,omitempty"`
+
+	// Indexing is true while a reindex for RepoPath is in flight right now.
+	Indexing bool `json:"indexing"`
+	// QueueLen is the number of index jobs queued behind this repo (or,
+	// process-wide, the scheduler's queue depth — see the writer for which
+	// scope it publishes).
+	QueueLen int `json:"queue_len,omitempty"`
+	// LastErr is the most recent index error for this repo, or "" if the
+	// last completed index succeeded.
+	LastErr string `json:"last_err,omitempty"`
+}
+
+// statusSubdir is the directory name under GRAFEL_HOME holding one file per
+// repo.
+const statusSubdir = "status"
+
+// PathFor returns the deterministic on-disk path for repoPath's status file.
+// The same repoPath always maps to the same path (sha256-hashed so the file
+// name is filesystem-safe and length-bounded regardless of the repo path's
+// own length/characters) so a writer and a reader agree without any
+// coordination beyond both resolving GRAFEL_HOME the same way.
+func PathFor(repoPath string) (string, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return "", fmt.Errorf("statusfile: resolve home dir: %w", err)
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	abs = filepath.Clean(abs)
+	sum := sha256.Sum256([]byte(abs))
+	hash := hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(home, statusSubdir, hash+".json"), nil
+}
+
+// Write atomically (tmp+rename) persists f as repoPath's status file.
+// RepoPath and HeartbeatAt are stamped onto f by the caller before Write is
+// called (Write does not mutate f) — callers should generally set
+// HeartbeatAt to time.Now().UTC() immediately before calling Write.
+func Write(repoPath string, f *File) error {
+	path, err := PathFor(repoPath)
+	if err != nil {
+		return err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("statusfile: mkdir %s: %w", dir, err)
+	}
+
+	data, err := json.Marshal(f)
+	if err != nil {
+		return fmt.Errorf("statusfile: marshal: %w", err)
+	}
+
+	// Atomic write: temp file in the SAME directory (so rename is same-fs),
+	// then rename over the final path. A concurrent Read always sees either
+	// the previous complete file or the new complete file, never a partial
+	// write — this is the guarantee a poll-safe reader depends on.
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return fmt.Errorf("statusfile: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("statusfile: rename: %w", err)
+	}
+	return nil
+}
+
+// Read returns repoPath's current status file. Returns an os.IsNotExist error
+// (checkable via os.IsNotExist) when no status file has ever been written for
+// repoPath — the caller should treat this as "unknown", not as a hang or a
+// fatal error: a repo the engine has never touched, or one whose engine is
+// down, is a completely normal state for a poll-safe reader to observe.
+//
+// This performs exactly one os.ReadFile — no socket, no lock, no RPC — so it
+// is safe to call on every keystroke of a statusline without risk of blocking
+// behind an in-flight index.
+func Read(repoPath string) (*File, error) {
+	path, err := PathFor(repoPath)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var f File
+	if err := json.Unmarshal(data, &f); err != nil {
+		return nil, fmt.Errorf("statusfile: unmarshal %s: %w", path, err)
+	}
+	return &f, nil
+}

--- a/internal/statusfile/statusfile_concurrent_test.go
+++ b/internal/statusfile/statusfile_concurrent_test.go
@@ -1,0 +1,111 @@
+package statusfile_test
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestWrite_ConcurrentSameRepo_NoTornRead reproduces the review #5734 BLOCKING
+// finding: concurrent Writes to the SAME repo must never publish a torn/garbled
+// file that a concurrent Read decodes as corrupt.
+//
+// With the original fixed tmp name (`tmp := path + ".tmp"`), N writers all
+// O_TRUNC the same tmp inode and interleave, then rename a garbled file into
+// place — a looping reader intermittently gets a JSON unmarshal error and (in
+// the CLI) falls back to Status:"unknown" mid-index, exactly what the status
+// plane must not do. The reviewer measured 2 corrupt reads / 1884.
+//
+// This test drives 8 concurrent writers to one repo plus a looping reader and
+// asserts ZERO corrupt reads. It fails against the fixed-tmp implementation and
+// passes with the unique-tmp (os.CreateTemp) fix.
+func TestWrite_ConcurrentSameRepo_NoTornRead(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repo := "/some/repo/under/concurrent/write"
+
+	// Seed once so the reader always finds the file (a legitimate NotExist
+	// before the first write is not a torn read).
+	if err := statusfile.Write(repo, &statusfile.File{EnginePID: 1, RepoPath: repo}); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	const (
+		writers         = 8
+		writesPerWorker = 400
+	)
+
+	var (
+		writersWG sync.WaitGroup
+		readerWG  sync.WaitGroup
+		stop      atomic.Bool
+		corrupt   atomic.Int64
+		reads     atomic.Int64
+		firstErr  atomic.Value // string: first corrupt-read description
+	)
+
+	// Reader: spins reading the file, counting any decode failure. os.IsNotExist
+	// is impossible after the seed write (Write renames atomically), so any error
+	// here is a genuine torn/corrupt read.
+	readerWG.Add(1)
+	go func() {
+		defer readerWG.Done()
+		for !stop.Load() {
+			f, err := statusfile.Read(repo)
+			reads.Add(1)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue // impossible post-seed; never a torn read
+				}
+				corrupt.Add(1)
+				firstErr.CompareAndSwap(nil, err.Error())
+				continue
+			}
+			// A well-formed-but-truncated JSON could still decode to a
+			// zero-value struct, so assert an invariant every writer upholds.
+			if f.RepoPath != repo {
+				corrupt.Add(1)
+				firstErr.CompareAndSwap(nil, "unexpected RepoPath: "+f.RepoPath)
+			}
+		}
+	}()
+
+	for w := 0; w < writers; w++ {
+		writersWG.Add(1)
+		go func(id int) {
+			defer writersWG.Done()
+			for i := 0; i < writesPerWorker; i++ {
+				f := &statusfile.File{
+					EnginePID:     id*writesPerWorker + i,
+					HeartbeatAt:   time.Now().UTC(),
+					Version:       "concurrent-writer",
+					RepoPath:      repo,
+					IndexedCommit: "deadbeefcafe",
+					Entities:      int64(i),
+					Relationships: int64(id),
+				}
+				if err := statusfile.Write(repo, f); err != nil {
+					corrupt.Add(1)
+					firstErr.CompareAndSwap(nil, "write error: "+err.Error())
+					return
+				}
+			}
+		}(w)
+	}
+
+	writersWG.Wait()
+	stop.Store(true)
+	readerWG.Wait()
+
+	if c := corrupt.Load(); c != 0 {
+		t.Fatalf("torn/corrupt reads = %d over %d reads (first: %v) — concurrent same-repo Write must be atomic",
+			c, reads.Load(), firstErr.Load())
+	}
+	if reads.Load() == 0 {
+		t.Fatal("reader never observed a read — test did not exercise the race")
+	}
+}

--- a/internal/statusfile/statusfile_test.go
+++ b/internal/statusfile/statusfile_test.go
@@ -1,0 +1,145 @@
+package statusfile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestWriteRead_Roundtrip is the RED test for the #5729-W1 status-plane
+// heartbeat file: the engine (writer) and a poll-safe reader (CLI/statusline)
+// must agree on a typed schema persisted atomically to disk.
+func TestWriteRead_Roundtrip(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repo := "/some/repo/path"
+	want := &statusfile.File{
+		EnginePID:     4242,
+		HeartbeatAt:   time.Now().UTC().Truncate(time.Second),
+		Version:       "test-version",
+		RepoPath:      repo,
+		IndexedRef:    "main",
+		IndexedCommit: "deadbeef1234",
+		Entities:      100,
+		Relationships: 250,
+		GraphFBMtime:  1234567890,
+		Indexing:      true,
+		QueueLen:      3,
+		LastErr:       "",
+	}
+
+	if err := statusfile.Write(repo, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.EnginePID != want.EnginePID {
+		t.Errorf("EnginePID = %d, want %d", got.EnginePID, want.EnginePID)
+	}
+	if !got.HeartbeatAt.Equal(want.HeartbeatAt) {
+		t.Errorf("HeartbeatAt = %v, want %v", got.HeartbeatAt, want.HeartbeatAt)
+	}
+	if got.Version != want.Version {
+		t.Errorf("Version = %q, want %q", got.Version, want.Version)
+	}
+	if got.IndexedRef != want.IndexedRef || got.IndexedCommit != want.IndexedCommit {
+		t.Errorf("IndexedRef/IndexedCommit = %q/%q, want %q/%q",
+			got.IndexedRef, got.IndexedCommit, want.IndexedRef, want.IndexedCommit)
+	}
+	if got.Entities != want.Entities || got.Relationships != want.Relationships {
+		t.Errorf("Entities/Relationships = %d/%d, want %d/%d",
+			got.Entities, got.Relationships, want.Entities, want.Relationships)
+	}
+	if got.GraphFBMtime != want.GraphFBMtime {
+		t.Errorf("GraphFBMtime = %d, want %d", got.GraphFBMtime, want.GraphFBMtime)
+	}
+	if !got.Indexing {
+		t.Error("Indexing should be true")
+	}
+	if got.QueueLen != want.QueueLen {
+		t.Errorf("QueueLen = %d, want %d", got.QueueLen, want.QueueLen)
+	}
+}
+
+// TestWrite_Atomic asserts Write never leaves a partial/torn file visible at
+// the final path: it must write to a temp file and rename into place, so a
+// concurrent Read either sees the old complete file or the new complete file,
+// never a half-written one.
+func TestWrite_Atomic(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	repo := "/atomic/repo"
+
+	if err := statusfile.Write(repo, &statusfile.File{EnginePID: 1, Version: "v1"}); err != nil {
+		t.Fatalf("Write 1: %v", err)
+	}
+	path, err := statusfile.PathFor(repo)
+	if err != nil {
+		t.Fatalf("PathFor: %v", err)
+	}
+	// No leftover .tmp file after a successful write.
+	entries, err := os.ReadDir(filepath.Dir(path))
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Errorf("leftover tmp file after Write: %s", e.Name())
+		}
+	}
+
+	if err := statusfile.Write(repo, &statusfile.File{EnginePID: 2, Version: "v2"}); err != nil {
+		t.Fatalf("Write 2: %v", err)
+	}
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.Version != "v2" {
+		t.Errorf("expected the latest write to win, got version %q", got.Version)
+	}
+}
+
+// TestRead_MissingFile_ReturnsNotFound ensures a poll-safe reader can
+// distinguish "never written yet" from a real I/O error, so it can fall back
+// to "unknown" rather than treating the absence as a hang or crash.
+func TestRead_MissingFile_ReturnsNotFound(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	_, err := statusfile.Read("/never/written/repo")
+	if err == nil {
+		t.Fatal("expected an error for a repo with no status file written yet")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected an os.IsNotExist error, got: %v", err)
+	}
+}
+
+// TestPathFor_DeterministicPerRepo asserts the same repo path always maps to
+// the same on-disk file (so a writer and a reader agree without coordination)
+// and different repos map to different files.
+func TestPathFor_DeterministicPerRepo(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	p1, err := statusfile.PathFor("/repo/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p1b, err := statusfile.PathFor("/repo/a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != p1b {
+		t.Errorf("PathFor not deterministic: %q != %q", p1, p1b)
+	}
+	p2, err := statusfile.PathFor("/repo/b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 == p2 {
+		t.Errorf("PathFor collided for distinct repos: %q", p1)
+	}
+}


### PR DESCRIPTION
Phase 1 / W1 of the serve↔engine split (Refs #5729). Builds the engine→serve status seam AND delivers two standalone features.

- **#5727:** `indexed_commit` (short + full SHA) + `at_head` (indexed == current HEAD) in `grafel_index_status` (live + disk-fallback) and `grafel status`. SHA already captured in the index manifest (GitCommit); this surfaces it + adds the full 40-char via `headCommitFull()`.
- **#5725 core:** per-repo poll-safe status/heartbeat file (`$GRAFEL_HOME/status/<hash>.json`, atomic tmp+rename) with liveness/freshness/progress fields; `Read()` is a single os.ReadFile — no socket/lock/RPC, can never block behind an in-flight index. Written on every scheduler state transition + a 5s heartbeat. `grafel status --json` (cwd-scoped) reads only the sidecar, returns `{status:unknown}` when absent.

2327 tests green; gofmt/vet clean. Deferred: SSE-subscribe (#5725 bonus) and a FlatBuffers-header full-SHA (needs flatc regen).

Closes #5727. Refs #5725, #5729.