### PR TITLE
fix(links): version/prefix-aware HTTP joins + honest orphan metric

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -213,6 +213,23 @@ func applyURLPatternNorm(consumerPath, producerPath string) (confidence float64,
 // difference is an implementation detail, not an architectural ambiguity.
 const urlPatternNormConfidence = 0.95
 
+// standardAPIPrefixCandidates is the single, ordered source-of-truth list of
+// well-known API/version mount prefixes shared by every prefix-aware HTTP
+// join strategy in this file. It backs both crossRepoPrefixCandidates (the
+// consumer-side injection retry, #2569) and pathNormPrefixSegments (the
+// path_normalized strategy, #3752).
+//
+// #5688: these two lists drifted — crossRepoPrefixCandidates was missing the
+// bare "/v2" form that pathNormPrefixSegments carried, so a consumer with no
+// prefix (`GET /orders`) could join a versioned producer (`/api/v2/orders`)
+// but NOT a bare-version producer (`/v2/orders`), because the injection retry
+// never tried prepending "/v2". Reconciled to one list so the vocabularies
+// can never diverge again.
+//
+// Order matters: more-specific (longer) prefixes are tried first so
+// `/api/v1` is preferred over `/api` when both would match.
+var standardAPIPrefixCandidates = []string{"/api/v1", "/api/v2", "/api", "/v1", "/v2"}
+
 // crossRepoPrefixCandidates is the ordered list of well-known API mount
 // prefixes tried when a consumer path has no prefix of its own and the
 // standard byPath probing misses (#2569). This mirrors prefixCandidates in
@@ -220,10 +237,7 @@ const urlPatternNormConfidence = 0.95
 // cross-repo linking level so that a frontend consumer emitting a raw path
 // such as `/searchBuildings` can be matched to a backend producer mounted
 // at `/api/v1/searchBuildings`.
-//
-// Order matters: more-specific (longer) prefixes are tried first so
-// `/api/v1` is preferred over `/api` when both would match.
-var crossRepoPrefixCandidates = []string{"/api/v1", "/api/v2", "/api", "/v1"}
+var crossRepoPrefixCandidates = standardAPIPrefixCandidates
 
 // caseNormalizePathSegments produces a canonical form of a path for the
 // case_style_normalized cross-repo matching strategy (#2703, broadened in
@@ -499,11 +513,12 @@ func literalFillsParamSlot(consumerPath, producerPath string) bool {
 // it is the leading segment group.
 //
 // This is intentionally identical in spirit to apiPrefixRe / stripAPIPrefix but
-// kept as an explicit, ordered, configurable list so the path_normalized
-// strategy's prefix vocabulary is self-documenting and tunable independently of
-// the byPath generic-strip alias. Longer (more specific) prefixes come first so
-// `/api/v1` is preferred over `/api`.
-var pathNormPrefixSegments = []string{"/api/v1", "/api/v2", "/api", "/v1", "/v2"}
+// kept as an explicit, ordered list so the path_normalized strategy's prefix
+// vocabulary is self-documenting. #5688: backed by the same
+// standardAPIPrefixCandidates source of truth as crossRepoPrefixCandidates so
+// the two vocabularies cannot drift apart again. Longer (more specific)
+// prefixes come first so `/api/v1` is preferred over `/api`.
+var pathNormPrefixSegments = standardAPIPrefixCandidates
 
 // pathNormalizeForMatch produces the canonical comparison key used by the
 // path_normalized cross-repo strategy (#3752). It is deliberately a SEPARATE,
@@ -620,6 +635,38 @@ func distinctEndpointCount(cands []*httpEndpointHit) int {
 		}
 		key := strings.ToUpper(p.verb) + " " + path
 		seen[key] = true
+	}
+	return len(seen)
+}
+
+// distinctEndpointPathCount reports how many DISTINCT server endpoint PATHS
+// (verb-agnostic) a candidate set represents. This backs the #5688
+// ambiguity guards added to the main cross-repo join loop and its prefix /
+// case-style / url-pattern / literal-fill retry sweeps.
+//
+// Unlike distinctEndpointCount (which keys on (verb, path) for the #3752
+// path_normalized strategy, where candidates are ALREADY pre-filtered to a
+// single exact verb before the guard runs), these #5688 guard sites see
+// candidate sets that legitimately span MULTIPLE verbs for the SAME path
+// (e.g. GET /api/v1/buildings and POST /api/v1/buildings both surviving a
+// prefix-strip or case-normalize alias lookup) — that is not ambiguity, it is
+// exactly the shape pickProducerForConsumer's verb-tiering is designed to
+// resolve (exact-verb match wins; ANY-verb is only a fallback). Keying on
+// verb+path there would misclassify same-path/different-verb candidate sets
+// as ambiguous and wrongly refuse to link them. Counting DISTINCT PATHS ONLY
+// (ignoring verb) is the correct ambiguity axis for those call sites: it is
+// ambiguous only when the candidates disagree about WHICH ROUTE (path) the
+// consumer means, not about which verb it uses on that route.
+func distinctEndpointPathCount(cands []*httpEndpointHit) int {
+	seen := map[string]bool{}
+	for _, p := range cands {
+		path := p.canonicalPath
+		if path == "" {
+			if _, pp, ok := parseHTTPName(p.name); ok {
+				path = pp
+			}
+		}
+		seen[path] = true
 	}
 	return len(seen)
 }
@@ -1465,6 +1512,38 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// deterministic.
 					p, quality := pickProducerForConsumer(c, producersByRepo[pRepo])
 
+					// #5688 — ambiguity guard. producersByRepo[pRepo] can
+					// contain MULTIPLE DISTINCT canonical producer paths when
+					// the verb-wildcarding / mount-prefix wildcarding steps
+					// above pulled in several routes that only look alike
+					// after the generic API/version-prefix strip (e.g. a
+					// bare consumer `/orders` pulling in BOTH `/v1/orders`
+					// AND `/v2/orders`, which both alias to the same
+					// generic-stripped bucket). Picking either one would be
+					// a guess masquerading as a resolved link. Reuse the
+					// same distinctEndpointPathCount ambiguity guard the
+					// path_normalized strategy (#3752) already relies on;
+					// when it fires here, blank out the pick so every later
+					// per-consumer retry stage below (all gated on p == nil)
+					// is skipped too, and the consumer is classified
+					// "prefix_version_mismatch" rather than silently linked.
+					//
+					// EXEMPTION (#1496 GraphQL root): a GraphQL service
+					// intentionally multiplexes many distinct resolver-field
+					// paths (`/graphql/Query/searchProducts`,
+					// `/graphql/Query/order`, ...) under one physical
+					// `/graphql` transport root, and every field producer is
+					// deliberately aliased there so a client that only knows
+					// the root can match the service. That fan-out is NOT the
+					// same-looking-different-endpoints ambiguity this guard
+					// targets — it is one endpoint (one HTTP route) serving
+					// many GraphQL operations — so it must not trip the guard.
+					ambiguousProducers := !strings.EqualFold(c.verb, "GRAPHQL") &&
+						distinctEndpointPathCount(producersByRepo[pRepo]) > 1
+					if ambiguousProducers {
+						p, quality = nil, ""
+					}
+
 					// #2702 — mount-prefix attribution. The wildcarding step
 					// above this loop can pull a producer into producersByRepo
 					// via a discovered url_mount_point prefix; when that
@@ -1492,11 +1571,19 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// path (e.g. `/searchBuildings`) while the backend mounts the
 					// route at `/api/v1/searchBuildings`.
 					//
-					// First match wins; edge is stamped with
+					// #5688: the retry now collects the UNION of candidates
+					// across every standard-prefix candidate BEFORE deciding,
+					// rather than breaking on the first prefix that happens to
+					// match. Breaking early silently preferred one version
+					// over another when the consumer path was genuinely
+					// ambiguous (e.g. both `/v1/orders` and `/v2/orders` exist
+					// and the bare consumer `/orders` could mean either) — the
+					// same class of false-positive distinctEndpointPathCount
+					// already guards against elsewhere. Edge is stamped with
 					// Properties["prefix_normalized"] (e.g. "api/v1") so the
 					// resolution is traceable in the graph.
 					var prefixNormalized string
-					if p == nil {
+					if p == nil && !ambiguousProducers {
 						consumerPath := c.canonicalPath
 						if consumerPath == "" {
 							if _, parsed, ok := parseHTTPName(c.name); ok {
@@ -1507,20 +1594,33 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						// Only attempt when the consumer path has no API/version
 						// prefix itself — a double-prefixed path would be invalid.
 						if _, hasPrefix := stripAPIPrefix(normConsumerPath); !hasPrefix && normConsumerPath != "" {
-							for _, pfx := range crossRepoPrefixCandidates {
+							allPfxCandidates := make([]*httpEndpointHit, 0)
+							pfxByStampedID := map[string]string{}
+							for _, pfx := range standardAPIPrefixCandidates {
 								prefixedKey := pfx + normConsumerPath
-								pfxCandidates := make([]*httpEndpointHit, 0)
 								for _, h := range byPath[prefixedKey] {
 									if h.repo == pRepo && h.side == sideProducer {
-										pfxCandidates = appendUnique(pfxCandidates, h)
+										before := len(allPfxCandidates)
+										allPfxCandidates = appendUnique(allPfxCandidates, h)
+										if len(allPfxCandidates) > before {
+											pfxByStampedID[h.stampedID] = pfx
+										}
 									}
 								}
-								if len(pfxCandidates) > 0 {
-									sort.SliceStable(pfxCandidates, func(i, j int) bool { return less(pfxCandidates[i], pfxCandidates[j]) })
-									p, quality = pickProducerForConsumer(c, pfxCandidates)
+							}
+							if len(allPfxCandidates) > 0 {
+								if distinctEndpointPathCount(allPfxCandidates) > 1 {
+									// Ambiguous: multiple distinct producer routes
+									// (typically differing only by version) all
+									// match the bare consumer path. Refuse rather
+									// than guess, and block every later retry
+									// stage below too.
+									ambiguousProducers = true
+								} else {
+									sort.SliceStable(allPfxCandidates, func(i, j int) bool { return less(allPfxCandidates[i], allPfxCandidates[j]) })
+									p, quality = pickProducerForConsumer(c, allPfxCandidates)
 									if p != nil {
-										prefixNormalized = strings.TrimPrefix(pfx, "/")
-										break
+										prefixNormalized = strings.TrimPrefix(pfxByStampedID[p.stampedID], "/")
 									}
 								}
 							}
@@ -1542,7 +1642,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// traceable in the graph, mirroring the prefix_normalized
 					// annotation used by the older retry.
 					appliedMountPrefix := preselectedMountPrefix
-					if p == nil {
+					if p == nil && !ambiguousProducers {
 						consumerPath := c.canonicalPath
 						if consumerPath == "" {
 							if _, parsed, ok := parseHTTPName(c.name); ok {
@@ -1603,7 +1703,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// First match wins; edge is stamped with
 					// Properties["resolve_strategy"] = "case_style_normalized".
 					var caseNormalized bool
-					if p == nil {
+					if p == nil && !ambiguousProducers {
 						consumerPath := c.canonicalPath
 						if consumerPath == "" {
 							if _, parsed, ok := parseHTTPName(c.name); ok {
@@ -1664,7 +1764,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// is set to "url_pattern" so the resolution is traceable.
 					var urlPatternNormAnnotation string
 					var urlPatternNormConfidenceVal float64
-					if p == nil {
+					if p == nil && !ambiguousProducers {
 						consumerPath := c.canonicalPath
 						if consumerPath == "" {
 							if _, parsed, ok := parseHTTPName(c.name); ok {
@@ -1707,7 +1807,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					// `/recents/buildings` producer would have matched in an
 					// earlier stage and left p non-nil here.
 					var literalParamFilled bool
-					if p == nil {
+					if p == nil && !ambiguousProducers {
 						consumerPath := c.canonicalPath
 						if consumerPath == "" {
 							if _, parsed, ok := parseHTTPName(c.name); ok {
@@ -1991,6 +2091,14 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				sort.Strings(pRepoNamesCN)
 				allConsumers[cKey] = true
 				for _, pRepo := range pRepoNamesCN {
+					// #5688 — same ambiguity guard as the main loop: the
+					// prefix-stripped byCaseNorm alias can pull in MULTIPLE
+					// distinct producer routes (e.g. /v1/orders and
+					// /v2/orders both alias to /orders) for a bare consumer.
+					// Refuse rather than guess.
+					if distinctEndpointPathCount(producersByRepoCN[pRepo]) > 1 {
+						continue
+					}
 					p, quality := pickProducerForConsumer(c, producersByRepoCN[pRepo])
 					if p == nil {
 						continue
@@ -2103,6 +2211,13 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				sort.Strings(pRepoNames2)
 				allConsumers[cKey] = true
 				for _, pRepo := range pRepoNames2 {
+					// #5688 — ambiguity guard, mirroring the main loop and the
+					// case_style_normalized sweep: refuse rather than guess
+					// when multiple distinct producer routes collapse to the
+					// same normalized-pattern key.
+					if distinctEndpointPathCount(producersByRepo2[pRepo]) > 1 {
+						continue
+					}
 					p, _ := pickProducerForConsumer(c, producersByRepo2[pRepo])
 					if p == nil {
 						continue
@@ -2230,6 +2345,13 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				sort.Strings(pRepoNamesLF)
 				allConsumers[cKey] = true
 				for _, pRepo := range pRepoNamesLF {
+					// #5688 — ambiguity guard, mirroring the main loop and the
+					// case_style_normalized sweep: refuse rather than guess
+					// when multiple distinct producer routes are eligible
+					// literal-fill targets for the same consumer.
+					if distinctEndpointPathCount(producersByRepoLF[pRepo]) > 1 {
+						continue
+					}
 					p, quality := pickProducerForConsumer(c, producersByRepoLF[pRepo])
 					if p == nil {
 						continue
@@ -2773,7 +2895,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						consumerPath = p
 					}
 				}
-				missesByReason[classifyOrphanReason(consumerPath)]++
+				missesByReason[classifyOrphanReason(consumerPath, allProducers)]++
 			}
 		}
 	}
@@ -2985,23 +3107,49 @@ func pickProducerForConsumer(c *httpEndpointHit, candidates []*httpEndpointHit) 
 var dynamicBaseURLRe = regexp.MustCompile(`^/\{[^}]*\}(?:/|$)`)
 
 // classifyOrphanReason returns the stable miss-reason taxonomy key for a
-// consumer path that the HTTP pass could not resolve. Two buckets are
-// recognised today:
+// consumer path that the HTTP pass could not resolve. Four buckets are
+// recognised (expanded in #5680 from the original two — see below):
 //
-//   - "dynamic_baseurl"  — first segment is a `{template}` expression
+//   - "dynamic_baseurl"        — first segment is a `{template}` expression
 //     (e.g. `/{apiUrl}/things`, `/{base_url.rstrip(`)
 //     or the path is otherwise malformed by a partial
 //     string-template extraction.
-//   - "no_endpoint_match" — the path looks well-formed but no producer in
-//     any other repo serves it. The dominant case for
-//     acme is calls to external services (third-
-//     party APIs, Cognito JWKS, NYC OpenData, etc.).
+//   - "no_server_definition"   — the group produced ZERO producer-side HTTP
+//     endpoint hits at all (allProducers is empty). There
+//     is nothing anywhere to join against, so the miss says
+//     nothing about this specific path's shape — it is an
+//     indexing/coverage gap (the server repo hasn't been
+//     extracted, or genuinely defines no HTTP surface), not
+//     a matching failure. Checked FIRST because it dominates:
+//     when it applies, every other bucket would be equally
+//     true and misleadingly specific.
+//   - "prefix_version_mismatch" — a producer population exists and at least
+//     one producer's standard-prefix-stripped path equals
+//     this consumer's own standard-prefix-stripped path
+//     (they are the SAME logical route once version/API
+//     prefixes are normalized away), yet the pair did not
+//     resolve — almost always because #5688's ambiguity
+//     guard refused a genuinely ambiguous version fan-out
+//     (e.g. both `/v1/orders` and `/v2/orders` exist for a
+//     bare `/orders` consumer). Distinct from a real
+//     structural miss: an operator can act on this by
+//     pinning a version or consolidating routes.
+//   - "no_endpoint_match"      — the path looks well-formed, a producer
+//     population exists, but no producer anywhere is even
+//     structurally related to it. The dominant case for
+//     acme is calls to external services (third-party APIs,
+//     Cognito JWKS, NYC OpenData, etc.).
 //
-// The classification is deliberately conservative: anything ambiguous falls
-// into "no_endpoint_match" so the bucket reflects what an operator can act
-// on (add the producer, fix the prefix) versus what's structurally outside
-// the group's resolution domain.
-func classifyOrphanReason(consumerPath string) string {
+// The classification is deliberately conservative: anything not positively
+// identified as one of the first three falls into "no_endpoint_match" so the
+// bucket reflects what an operator can act on (add the producer, fix the
+// prefix) versus what's structurally outside the group's resolution domain.
+func classifyOrphanReason(consumerPath string, allProducers []*httpEndpointHit) string {
+	// #5680: a group with zero producer-side hits can never resolve ANY
+	// consumer call — the miss is about coverage, not this path's shape.
+	if len(allProducers) == 0 {
+		return "no_server_definition"
+	}
 	if consumerPath == "" {
 		return "no_endpoint_match"
 	}
@@ -3013,6 +3161,33 @@ func classifyOrphanReason(consumerPath string) string {
 	}
 	if dynamicBaseURLRe.MatchString(consumerPath) {
 		return "dynamic_baseurl"
+	}
+	// #5680: prefix/version-related near-miss. If stripping the standard
+	// API/version prefix from the consumer path yields the SAME key as
+	// stripping it from at least one producer path, this is structurally the
+	// same route under a different version/mount — the residual miss (if any)
+	// is a version-fan-out ambiguity, not a genuine "no such route" case.
+	consumerStripped := normalizePathForIndex(consumerPath)
+	if stripped, ok := stripAPIPrefix(consumerStripped); ok {
+		consumerStripped = stripped
+	}
+	for _, p := range allProducers {
+		producerPath := p.canonicalPath
+		if producerPath == "" {
+			if _, pp, ok := parseHTTPName(p.name); ok {
+				producerPath = pp
+			}
+		}
+		if producerPath == "" {
+			continue
+		}
+		producerStripped := normalizePathForIndex(producerPath)
+		if stripped, ok := stripAPIPrefix(producerStripped); ok {
+			producerStripped = stripped
+		}
+		if consumerStripped != "" && consumerStripped == producerStripped {
+			return "prefix_version_mismatch"
+		}
 	}
 	return "no_endpoint_match"
 }

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -3562,8 +3562,16 @@ func TestClassifyOrphanReason(t *testing.T) {
 		{"", "no_endpoint_match"},
 		{"/{x}", "dynamic_baseurl"}, // entire path is one template segment
 	}
+	// A non-empty, unrelated producer population so these cases exercise the
+	// pre-existing dynamic_baseurl / no_endpoint_match classification rather
+	// than the new #5680 no_server_definition bucket (which only fires when
+	// the group has ZERO producer hits at all — see
+	// TestClassifyOrphanReason_NoServerDefinition below).
+	unrelatedProducers := []*httpEndpointHit{
+		{canonicalPath: "/completely/unrelated/path", side: sideProducer, repo: "backend"},
+	}
 	for _, tc := range cases {
-		got := classifyOrphanReason(tc.path)
+		got := classifyOrphanReason(tc.path, unrelatedProducers)
 		if got != tc.want {
 			t.Errorf("classifyOrphanReason(%q) = %q, want %q", tc.path, got, tc.want)
 		}
@@ -4181,5 +4189,327 @@ func TestHTTPPass_RuntimeEnumExpansion_NoFalseLinks(t *testing.T) {
 		case "frontend::fnNoAnchor":
 			t.Errorf("#4315: anchor-less /{*}/{*} must stay orphan, got %+v", l)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #5688 / #5680 — version/prefix-aware HTTP joins + honest orphan metric
+// ---------------------------------------------------------------------------
+
+// TestHTTPPass_CrossRepo_BareVersionPrefix_Symmetric verifies that a bare
+// consumer path (`GET /orders`, no prefix at all) joins a producer mounted at
+// a BARE version prefix (`GET /v2/orders`, no `/api` segment). Before #5688,
+// crossRepoPrefixCandidates (the prefix-injection retry vocabulary) was
+// missing bare "/v2" — its sibling pathNormPrefixSegments had it — so this
+// pairing depended entirely on the generic apiPrefixRe byPath alias. This
+// test pins the behaviour directly against the fast repoGraph-level entry
+// point (loadAllGraphs + runHTTPPass), independent of which internal
+// strategy resolves it.
+func TestHTTPPass_CrossRepo_BareVersionPrefix_Symmetric(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "OrdersView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/v2/orders", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/v2/orders",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "fetchOrders", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/orders", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/orders",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchOrders",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := PathsFor(home, "g5688-bare-v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := runHTTPPass(graphs, paths, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(paths.Links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP && l.Source == "frontend::fn1" && l.Target == "backend::h1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("#5688: expected cross-repo link frontend::fn1 -> backend::h1 for /orders -> /v2/orders (bare version prefix); got links=%+v orphan=%d", doc.Links, res.OrphanCalls)
+	}
+}
+
+// TestHTTPPass_CrossRepo_VersionedAPIPrefix_Symmetric is the sibling case:
+// a consumer `GET /orders` must join a producer mounted at the versioned
+// `/api/v2/orders` form. Pinned alongside the bare-v2 case so a regression
+// in either the generic prefix strip or the injection retry surfaces here.
+func TestHTTPPass_CrossRepo_VersionedAPIPrefix_Symmetric(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "OrdersView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/api/v2/orders", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v2/orders",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "fetchOrders", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/orders", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/orders",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchOrders",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := PathsFor(home, "g5688-versioned-v2")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runHTTPPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(paths.Links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP && l.Source == "frontend::fn1" && l.Target == "backend::h1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("#5688: expected cross-repo link frontend::fn1 -> backend::h1 for /orders -> /api/v2/orders (versioned prefix); got %+v", doc.Links)
+	}
+}
+
+// TestHTTPPass_CrossRepo_AmbiguousVersionPrefix_NoFalseLink verifies the
+// ambiguity guard: when TWO distinct producers in the same target repo would
+// both match a bare consumer path once the standard version prefix is
+// stripped (e.g. `/v1/orders` AND `/v2/orders` both collapse to `/orders`),
+// the symmetric matcher must NOT guess — no link is emitted for either.
+func TestHTTPPass_CrossRepo_AmbiguousVersionPrefix_NoFalseLink(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "OrdersViewV1", "kind": "Controller", "source_file": "app/v1_views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/v1/orders", "kind": "http_endpoint",
+				"source_file": "app/v1_views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/v1/orders",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+			{"id": "h2", "name": "OrdersViewV2", "kind": "Controller", "source_file": "app/v2_views.py"},
+			{
+				"id": "ep2", "name": "http:GET:/v2/orders", "kind": "http_endpoint",
+				"source_file": "app/v2_views.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/v2/orders",
+					"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+			{"from_id": "h2", "to_id": "ep2", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "fetchOrders", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep3", "name": "http:GET:/orders", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/orders",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchOrders",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := PathsFor(home, "g5688-ambiguous")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runHTTPPass(graphs, paths, nil); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(paths.Links)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP && l.Source == "frontend::fn1" {
+			t.Errorf("#5688: ambiguous /orders (matches both /v1/orders and /v2/orders) must NOT link; got %+v", l)
+		}
+	}
+}
+
+// TestHTTPPass_OrphanMetric_NoServerDefinition verifies #5680's metric
+// de-conflation: when the group's producer repo has ZERO endpoint
+// DEFINITIONS at all (no http_endpoint_synthesis producer hits anywhere),
+// every unresolved consumer call must be classified "no_server_definition"
+// (there is nothing to join against) rather than the generic
+// "no_endpoint_match" (which implies a producer population exists but
+// nothing shaped like this specific path was found in it). It also pins the
+// orphan_calls <= calls invariant at the http_pass level.
+func TestHTTPPass_OrphanMetric_NoServerDefinition(t *testing.T) {
+	root := fixtureRoot(t)
+	// "backend" repo exists in the group but defines NO http endpoints at all.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "SomeHelper", "kind": "Function", "source_file": "app/helpers.py"},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "fetchOrders", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/orders", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/orders",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchOrders",
+				},
+			},
+			{"id": "fn2", "name": "fetchUsers", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep3", "name": "http:GET:/users", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/users",
+					"framework": "fetch", "pattern_type": "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchUsers",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paths, err := PathsFor(home, "g5680-no-server-def")
+	if err != nil {
+		t.Fatal(err)
+	}
+	res, err := runHTTPPass(graphs, paths, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Invariant: orphan_calls must never exceed the total consumer population
+	// counted at this level.
+	totalConsumers := res.CrossRepoResolved + res.OrphanCalls
+	if res.OrphanCalls > totalConsumers {
+		t.Errorf("#5680: orphan_calls (%d) must not exceed total calls (%d)", res.OrphanCalls, totalConsumers)
+	}
+	if res.OrphanCalls != 2 {
+		t.Errorf("#5680: expected both consumer calls to be orphaned (no producer anywhere), got OrphanCalls=%d", res.OrphanCalls)
+	}
+
+	got := res.CrossRepoResolveMissesByReason["no_server_definition"]
+	if got != 2 {
+		t.Errorf("#5680: expected 2 misses classified no_server_definition (zero producer definitions in group), got %d; full breakdown=%+v", got, res.CrossRepoResolveMissesByReason)
+	}
+	if n := res.CrossRepoResolveMissesByReason["no_endpoint_match"]; n != 0 {
+		t.Errorf("#5680: expected 0 misses classified no_endpoint_match when the group has zero server definitions (should be no_server_definition instead), got %d", n)
+	}
+}
+
+// TestClassifyOrphanReason_NoServerDefinition unit-tests classifyOrphanReason
+// directly: when the producer population passed in is empty, the reason must
+// be "no_server_definition" regardless of path shape (even for a well-formed
+// static path that would otherwise be "no_endpoint_match").
+func TestClassifyOrphanReason_NoServerDefinition(t *testing.T) {
+	if got := classifyOrphanReason("/orders", nil); got != "no_server_definition" {
+		t.Errorf("classifyOrphanReason with zero producers: want no_server_definition, got %q", got)
+	}
+}
+
+// TestClassifyOrphanReason_PrefixVersionMismatch unit-tests the new
+// prefix_version_mismatch bucket: a consumer path that collapses to the same
+// standard-prefix-stripped key as an existing producer (but wasn't linked —
+// e.g. due to the ambiguity guard) must be classified distinctly from a
+// wholly-unrelated miss.
+func TestClassifyOrphanReason_PrefixVersionMismatch(t *testing.T) {
+	producers := []*httpEndpointHit{
+		{canonicalPath: "/v1/orders", side: sideProducer, repo: "backend"},
+		{canonicalPath: "/v2/orders", side: sideProducer, repo: "backend"},
+	}
+	if got := classifyOrphanReason("/orders", producers); got != "prefix_version_mismatch" {
+		t.Errorf("classifyOrphanReason for ambiguous version-prefixed producers: want prefix_version_mismatch, got %q", got)
+	}
+	// Sanity: a path with no structural relationship to any producer still
+	// falls back to the generic bucket.
+	if got := classifyOrphanReason("/completely-unrelated", producers); got != "no_endpoint_match" {
+		t.Errorf("classifyOrphanReason for unrelated path: want no_endpoint_match, got %q", got)
 	}
 }

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -1473,14 +1473,32 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 		extractionNote = "regex-based detectors in use; cross-check any framework count that looks off (see by_framework.*.confidence)"
 	}
 
+	// #5680: orphan_calls / cross_repo_resolved are counted from DISTINCT
+	// FETCHES-edge caller entities (any entity kind), while
+	// definitions/calls/legacy_kind are counted from http_endpoint* KIND
+	// entities — two different populations. Comparing orphan_calls directly
+	// against calls is dishonest (orphan_calls can legitimately exceed
+	// calls, e.g. when plain Function entities participate in FETCHES edges
+	// without themselves being classified as call-kind entities). call_sites
+	// is the correct, SAME-population denominator for the orphan rate:
+	// every FETCHES-edge caller this pass actually classified, resolved or
+	// not. no_server_definitions flags the degenerate case where the group
+	// produced zero endpoint definitions at all, so a near-100% orphan rate
+	// reads as "nothing to join against" rather than "everything failed to
+	// match".
+	totalCallSites := totalOrphans + totalCross
+	noServerDefinitions := totalDefs == 0
+
 	return jsonResult(map[string]any{
 		"totals": map[string]any{
-			"definitions":         totalDefs,
-			"calls":               totalCalls,
-			"legacy_kind":         totalLegacy,
-			"orphan_calls":        totalOrphans,
-			"cross_repo_resolved": totalCross,
-			"cross_repo_links":    len(lg.Links),
+			"definitions":           totalDefs,
+			"calls":                 totalCalls,
+			"legacy_kind":           totalLegacy,
+			"orphan_calls":          totalOrphans,
+			"cross_repo_resolved":   totalCross,
+			"cross_repo_links":      len(lg.Links),
+			"call_sites":            totalCallSites,
+			"no_server_definitions": noServerDefinitions,
 		},
 		"per_repo":     perRepo,
 		"by_framework": byFrameworkOut,

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -1562,3 +1562,85 @@ func TestEndpointResolution_OrphanOnlyPopulatesLinkedTargets(t *testing.T) {
 		t.Error("orphanOnly=true: linkedTargets must contain the link target")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #5680 — orphan-metric de-conflation / mis-scaling fix
+// ---------------------------------------------------------------------------
+
+// buildNoServerDefDoc returns a document with ZERO http_endpoint* definitions
+// but several plain Function entities that FETCH unresolved targets. Before
+// #5680, `orphan_calls` (derived from unique FETCHES FromIDs, ANY entity
+// kind) and `calls` (derived strictly from http_endpoint_call /
+// client-synthesis KIND entities) were computed over different populations:
+// a caller can participate in a FETCHES edge without itself being counted as
+// a "call" entity. This fixture reproduces exactly that: 3 distinct Function
+// callers fetch unresolved targets, so orphan_calls=3 while calls=0 —
+// orphan_calls > calls.
+func buildNoServerDefDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn_a", Name: "callA", Kind: "Function", SourceFile: "a.go", StartLine: 1},
+			{ID: "fn_b", Name: "callB", Kind: "Function", SourceFile: "b.go", StartLine: 1},
+			{ID: "fn_c", Name: "callC", Kind: "Function", SourceFile: "c.go", StartLine: 1},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "fn_a", ToID: "orphan_1", Kind: "FETCHES"},
+			{FromID: "fn_b", ToID: "orphan_2", Kind: "FETCHES"},
+			{FromID: "fn_c", ToID: "orphan_3", Kind: "FETCHES"},
+		},
+	}
+}
+
+// TestEndpointStats_OrphanCallsNeverExceedsCallSites pins the #5680 fix: the
+// response must expose an honest, SAME-population denominator for the
+// orphan rate (call_sites = orphan_calls + cross_repo_resolved) rather than
+// implying orphan_calls is a fraction of the differently-scoped `calls`
+// entity count. orphan_calls must never exceed call_sites.
+func TestEndpointStats_OrphanCallsNeverExceedsCallSites(t *testing.T) {
+	srv := newTestServer(t, buildNoServerDefDoc())
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+	totals := res["totals"].(map[string]any)
+
+	orphans := getFloat(t, totals, "orphan_calls")
+	if orphans != 3 {
+		t.Fatalf("orphan_calls: want 3, got %v", orphans)
+	}
+	callSites := getFloat(t, totals, "call_sites")
+	if callSites != 3 {
+		t.Errorf("call_sites: want 3 (orphan_calls + cross_repo_resolved), got %v", callSites)
+	}
+	if orphans > callSites {
+		t.Errorf("#5680: orphan_calls (%v) must not exceed call_sites (%v)", orphans, callSites)
+	}
+
+	// This group produced ZERO endpoint definitions at all — the metric must
+	// say so honestly rather than silently reporting a ~100% orphan rate
+	// that looks like a matching failure.
+	if defs := getFloat(t, totals, "definitions"); defs != 0 {
+		t.Fatalf("sanity: definitions want 0, got %v", defs)
+	}
+	noServerDef, ok := totals["no_server_definitions"].(bool)
+	if !ok || !noServerDef {
+		t.Errorf("#5680: expected totals.no_server_definitions=true when definitions=0, got %v", totals["no_server_definitions"])
+	}
+}
+
+// TestEndpointStats_CallSitesConsistentWithNormalGroup verifies the new
+// call_sites/orphan_rate fields behave sanely on the existing mixed fixture
+// (buildEndpointDoc) too, and that no_server_definitions is false when
+// definitions are present.
+func TestEndpointStats_CallSitesConsistentWithNormalGroup(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+	totals := res["totals"].(map[string]any)
+
+	orphans := getFloat(t, totals, "orphan_calls")
+	cross := getFloat(t, totals, "cross_repo_resolved")
+	callSites := getFloat(t, totals, "call_sites")
+	if callSites != orphans+cross {
+		t.Errorf("call_sites: want orphan_calls+cross_repo_resolved=%v, got %v", orphans+cross, callSites)
+	}
+	if noServerDef, ok := totals["no_server_definitions"].(bool); !ok || noServerDef {
+		t.Errorf("expected no_server_definitions=false when definitions>0, got %v", totals["no_server_definitions"])
+	}
+}


### PR DESCRIPTION
#5688 quick-wins + #5680 metric de-conflation (Refs #5688, #5680, #5729).

**#5688 — matching:**
- Reconciled the two divergent prefix lists into one `standardAPIPrefixCandidates` (was missing bare `/v2` in the injection list).
- Prefix-injection retry now collects the UNION across standard prefixes before deciding, instead of breaking on first match (which silently preferred one version under genuine ambiguity).
- Added a verb-agnostic `distinctEndpointPathCount` ambiguity guard to 5 join strategies: a consumer resolving to >1 distinct producer path emits NO link rather than guessing. (Kept separate from the pre-existing verb-aware `distinctEndpointCount`; reusing it caused 3 regressions on legitimate multi-verb/same-path sets — fixed with the path-only helper + a GraphQL-root #1496 exemption.)

**#5680 — metric:**
- `classifyOrphanReason` now distinguishes `no_server_definition` (zero producer defs in target repo) and `prefix_version_mismatch` from `dynamic_baseurl`/`no_endpoint_match`.
- `handleEndpointStats` reports `call_sites` (the honest denominator) + `no_server_definitions` so orphan rate is computed against the population it measures, not the unrelated entity-kind `calls` count.

8 new tests + 3 previously-regressed tests green; build/vet/gofmt clean; goldens no regression. Remaining #5688 (structural non-Django `url_mount_point` + cross-module base-URL resolution) tracked separately — base-URL resolution deferred to v0.1.9 per plan.

Refs #5688, #5680, #5729.