### PR TITLE
perf(index): defer enrichment to a silent, bounded, cancellable background worker off the critical path

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -398,6 +398,14 @@ type indexerStats struct {
 // (possibly empty) set of pass names to skip — see allPassNames. When
 // pretty is true, graph.json (and the graph-stats.json sidecar) are
 // indented for human readability; the default is minified JSON.
+// enrichmentOrderHook is a test-only observability hook invoked at
+// enrichment lifecycle boundaries ("graph_written", "enrichment_started",
+// "enrichment_done") so tests can assert graph.fb is written strictly
+// BEFORE Pass 6 enrichment-candidate emission runs or completes (#5720).
+// Production code always uses the no-op default; tests swap it out and
+// restore it afterward.
+var enrichmentOrderHook = func(stage string) {}
+
 func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, jsonStats bool, opts ...IndexOption) error {
 	absRepo, err := filepath.Abs(repoPath)
 	if err != nil {
@@ -565,6 +573,37 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			// propagates below.
 		} else {
 			fmt.Fprintf(os.Stderr, "grafel: wrote %s\n", fbPath)
+		}
+
+		// #5720 — the graph is now loadable/queryable (graph.fb is on disk),
+		// so enrichment-candidate emission (Pass 6's expensive part) can run.
+		// enrichmentOrderHook fires unconditionally, even when the pass is
+		// skipped, so an ordering test can assert "graph.fb written" happens
+		// exactly once per index run without depending on enrichment being
+		// enabled.
+		//
+		// Small graphs (<= enrichment.InlineEntityThreshold entities) run
+		// inline, synchronously, right here — cheap enough not to bother with
+		// a background handoff. Large graphs are hand off to
+		// enrichment.DefaultScheduler, which runs them on a silent,
+		// single-worker, paced background goroutine that never blocks this
+		// function's return; a subsequent index of the SAME repo supersedes
+		// (cancels) any still-running job before starting its own, so no
+		// orphaned goroutine and no stale-over-fresh write can occur.
+		enrichmentOrderHook("graph_written")
+		if !skipSet[PassEnrichment] {
+			if doc.Stats.Entities <= enrichment.InlineEntityThreshold {
+				enrichmentOrderHook("enrichment_started")
+				idx.runPass6EmitEnrichmentCandidates(doc, absRepo)
+				enrichmentOrderHook("enrichment_done")
+			} else {
+				schedKey := daemon.StateDirForRepo(absRepo)
+				enrichment.DefaultScheduler.Schedule(schedKey, func(ctx context.Context) {
+					enrichmentOrderHook("enrichment_started")
+					idx.runPass6EmitEnrichmentCandidatesBG(ctx, doc, absRepo)
+					enrichmentOrderHook("enrichment_done")
+				})
+			}
 		}
 
 		// #5267: record the canonical absolute source path in the top-level
@@ -1972,12 +2011,25 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		}
 	}
 
-	// Pass 6 — enrichment candidate emission (PORT-LLM / issue #15). Runs
-	// AFTER Pass 4 so emitters can consult community/centrality/god-node
-	// signals. Resolutions from prior runs are merged back onto entity
-	// Properties BEFORE candidate emission, so previously agent-resolved
-	// values are preserved AND emitters skip already-described entities.
-	i.runPass6EmitEnrichmentCandidates(doc, absRepo)
+	// Pass 6a — merge agent-resolved enrichment values back onto entity
+	// Properties (PORT-LLM / issue #15). This step MUST stay on the index
+	// critical path (unlike candidate emission below): the merged values are
+	// part of the authoritative graph.fb content, so they need to land before
+	// sortDocumentForEmission / the graph.fb write in Index(), or a
+	// previously agent-resolved description would silently vanish from the
+	// persisted graph until the next index run. It is cheap (a map merge over
+	// already-loaded resolutions), unlike the candidate-collection step,
+	// which is the part issue #5720 defers off the critical path.
+	i.runPass6ApplyResolutions(doc, absRepo)
+
+	// #5720 — enrichment CANDIDATE EMISSION (the expensive part of Pass 6)
+	// no longer runs here. It is scheduled by the Index() caller AFTER
+	// graph.fb has been persisted (see enrichment.DefaultScheduler.Schedule
+	// in cmd/grafel/index.go), either inline for small graphs or on a
+	// silent, single-worker, paced background goroutine for large ones. No
+	// consumer hard-depends on enrichment-candidates.json (every reader
+	// treats it as optional), so deferring it does not change the
+	// authoritative graph in any way.
 
 	// #5334 — surface the imminent graph write as a granular "Writing graph…"
 	// phase. The actual graph.fb / sidecar write happens in the Index() caller
@@ -2645,11 +2697,52 @@ func (i *Indexer) runPass4AlgorithmsWithProgress(doc *graph.Document, trk *progr
 	doc.AlgorithmStats = &stats
 }
 
-// runPass6EmitEnrichmentCandidates merges any prior agent-resolved
-// enrichment values back onto entity Properties, then runs the registered
-// CandidateEmitters and writes the resulting candidate list to
-// <repo>/.grafel/enrichment-candidates.json. The pass is no-op when
-// PassEnrichment is in the skip set.
+// runPass6ApplyResolutions merges any prior agent-resolved enrichment values
+// back onto entity Properties (and community AgentName). This MUST stay on
+// the index critical path — see the call site in Run() for why (#5720): the
+// merged values are part of the authoritative graph.fb content. It is cheap
+// (a map merge over already-loaded resolutions), unlike candidate collection
+// (runPass6EmitEnrichmentCandidates / runPass6EmitEnrichmentCandidatesBG
+// below), which is the part #5720 defers off the critical path.
+func (i *Indexer) runPass6ApplyResolutions(doc *graph.Document, absRepo string) {
+	if i.skipPasses[PassEnrichment] {
+		return
+	}
+	if doc == nil {
+		return
+	}
+	grafelDir := daemon.StateDirForRepo(absRepo)
+
+	resolutions := enrichment.ReadResolutions(grafelDir)
+	if len(resolutions) == 0 {
+		return
+	}
+	applied := enrichment.ApplyResolutions(doc, resolutions)
+	if verbose() {
+		fmt.Fprintf(os.Stderr,
+			"enrichment: applied %d resolutions to entities\n", applied)
+	}
+	// Also apply name_community resolutions so the AgentName field is
+	// populated on CommunityResult before candidate emission and before
+	// graph.json is written (issue #426).
+	appliedComm := enrichment.ApplyCommunityNameResolutions(doc, resolutions)
+	if verbose() && appliedComm > 0 {
+		fmt.Fprintf(os.Stderr,
+			"enrichment: applied %d community name resolutions\n", appliedComm)
+	}
+}
+
+// runPass6EmitEnrichmentCandidates runs the registered CandidateEmitters and
+// writes the resulting candidate list to
+// <repo>/.grafel/enrichment-candidates.json in one shot. This is the INLINE
+// path (#5720 requirement 6): used only for graphs at or below
+// enrichment.InlineEntityThreshold entities, where the one-shot cost is small
+// enough to pay synchronously right after graph.fb is written. Larger graphs
+// use runPass6EmitEnrichmentCandidatesBG via the Scheduler instead. The pass
+// is a no-op when PassEnrichment is in the skip set.
+//
+// Resolutions must already have been applied (runPass6ApplyResolutions) —
+// this function only collects + writes candidates.
 func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo string) {
 	if i.skipPasses[PassEnrichment] {
 		return
@@ -2659,34 +2752,45 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 	}
 	grafelDir := daemon.StateDirForRepo(absRepo)
 
-	// 1) Merge resolutions back onto entities BEFORE emitting. This both
-	//    persists agent values across rebuilds and short-circuits emitters
-	//    whose "already filled?" check looks at Properties (e.g.
-	//    describe_entity skips entities that already have a description).
-	resolutions := enrichment.ReadResolutions(grafelDir)
-	if len(resolutions) > 0 {
-		applied := enrichment.ApplyResolutions(doc, resolutions)
-		if verbose() {
-			fmt.Fprintf(os.Stderr,
-				"enrichment: applied %d resolutions to entities\n", applied)
-		}
-		// Also apply name_community resolutions so the AgentName field is
-		// populated on CommunityResult before candidate emission and before
-		// graph.json is written (issue #426).
-		appliedComm := enrichment.ApplyCommunityNameResolutions(doc, resolutions)
-		if verbose() && appliedComm > 0 {
-			fmt.Fprintf(os.Stderr,
-				"enrichment: applied %d community name resolutions\n", appliedComm)
-		}
-	}
+	cands := i.collectAllEnrichmentCandidates(doc, absRepo, grafelDir)
 
-	// 2) Emit entity candidates. Rejected (subject_id, kind) pairs are dropped.
+	if err := enrichment.WriteCandidates(grafelDir, cands); err != nil {
+		fmt.Fprintf(os.Stderr, "grafel: enrichment candidate write failed: %v\n", err)
+		return
+	}
+	// Issue #53: keep this log behind the verbose flag. The emit count is
+	// useful for debugging but noisy on every CI run.
+	if verbose() {
+		fmt.Fprintf(os.Stderr,
+			"grafel: emitted %d enrichment candidates to %s\n",
+			len(cands), filepath.Join(grafelDir, "enrichment-candidates.json"))
+	}
+}
+
+// collectAllEnrichmentCandidates runs every candidate source (entity
+// emitters, name_community, repair_edge, dynamic_baseurl) in one shot and
+// returns the merged slice. Used only by the INLINE (small-graph) path —
+// the background trickle path (runPass6EmitEnrichmentCandidatesBG) collects
+// entity candidates in chunks instead, but still runs the other (already
+// small — one per community/entity-subset, not per-entity) sources in one
+// shot at the end.
+func (i *Indexer) collectAllEnrichmentCandidates(doc *graph.Document, absRepo, grafelDir string) []enrichment.Candidate {
 	cands := enrichment.CollectCandidatesSkippingRejected(
 		doc, enrichment.DefaultEmitters(), grafelDir,
 	)
+	cands = append(cands, i.collectSmallEnrichmentCandidateSources(doc, absRepo, grafelDir)...)
+	return cands
+}
 
-	// 2b) Emit name_community candidates (issue #426 Layer 2). One candidate
-	//     per community that lacks an agent-resolved name.
+// collectSmallEnrichmentCandidateSources collects the candidate sources that
+// are inherently small (one per community, or gated behind an opt-in flag) —
+// safe to always run as a single, un-chunked step even from the background
+// trickle path.
+func (i *Indexer) collectSmallEnrichmentCandidateSources(doc *graph.Document, absRepo, grafelDir string) []enrichment.Candidate {
+	var cands []enrichment.Candidate
+
+	// Emit name_community candidates (issue #426 Layer 2). One candidate per
+	// community that lacks an agent-resolved name.
 	rej := enrichment.ReadRejections(grafelDir)
 	commCands := enrichment.CollectCommunityCandidates(doc, rej)
 	if len(commCands) > 0 {
@@ -2697,9 +2801,9 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 		}
 	}
 
-	// 3) ADR-0015 phase-1 (#544) — repair_edge emission. Purely additive;
-	//    gated behind --enable-repair-candidates so we can land the
-	//    foundation without bumping bug-rate measurement noise.
+	// ADR-0015 phase-1 (#544) — repair_edge emission. Purely additive; gated
+	// behind --enable-repair-candidates so we can land the foundation
+	// without bumping bug-rate measurement noise.
 	if i.enableRepairCandidates && i.resolveIdx != nil {
 		allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)
 		repair := enrichment.CollectRepairEdgeCandidates(doc, enrichment.RepairEdgeCandidateOptions{
@@ -2717,12 +2821,12 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 		}
 	}
 
-	// 4) Issue #708 — dynamic-baseurl endpoint candidates. Emitted
-	//    unconditionally (no resolver required) whenever there are
-	//    consumer-side http_endpoint entities whose baseURL is
-	//    runtime-determined (runtime_dynamic=true or dynamic_baseurl=true).
-	//    These surface in grafel_repairs action=list so an agent can
-	//    annotate them with a curated baseURL hint.
+	// Issue #708 — dynamic-baseurl endpoint candidates. Emitted
+	// unconditionally (no resolver required) whenever there are
+	// consumer-side http_endpoint entities whose baseURL is
+	// runtime-determined (runtime_dynamic=true or dynamic_baseurl=true).
+	// These surface in grafel_repairs action=list so an agent can annotate
+	// them with a curated baseURL hint.
 	dynBaseURL := enrichment.CollectDynamicBaseURLCandidates(doc)
 	if len(dynBaseURL) > 0 {
 		cands = append(cands, dynBaseURL...)
@@ -2733,16 +2837,70 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 		}
 	}
 
-	if err := enrichment.WriteCandidates(grafelDir, cands); err != nil {
-		fmt.Fprintf(os.Stderr, "grafel: enrichment candidate write failed: %v\n", err)
+	return cands
+}
+
+// runPass6EmitEnrichmentCandidatesBG is the background-worker counterpart of
+// runPass6EmitEnrichmentCandidates (#5720). It streams entity candidates to
+// disk in small, paced chunks via enrichment.CollectAndAppendTrickle /
+// enrichment.CandidateAppender instead of building one full-graph
+// []Candidate slice and calling enrichment.WriteCandidates — that one-shot
+// path is exactly what double-materialized the prior sidecar and drove the
+// ~11GB peak this issue fixes. Honors ctx: a cancellation (a new index of the
+// same repo superseding this run, via enrichment.DefaultScheduler) aborts the
+// in-progress appender so the prior on-disk candidates file is left
+// untouched rather than partially overwritten.
+func (i *Indexer) runPass6EmitEnrichmentCandidatesBG(ctx context.Context, doc *graph.Document, absRepo string) {
+	if i.skipPasses[PassEnrichment] {
 		return
 	}
-	// Issue #53: keep this log behind the verbose flag. The emit count is
-	// useful for debugging but noisy on every CI run.
+	if doc == nil {
+		return
+	}
+	grafelDir := daemon.StateDirForRepo(absRepo)
+
+	appender, err := enrichment.NewCandidateAppender(grafelDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "grafel: enrichment (bg) appender init failed: %v\n", err)
+		return
+	}
+
+	rej := enrichment.ReadRejections(grafelDir)
+	err = enrichment.CollectAndAppendTrickle(ctx, doc, enrichment.DefaultEmitters(), rej, appender, enrichment.TrickleOptions{})
+	if err != nil {
+		// Cancelled (superseded) or failed mid-stream — never publish a
+		// partial file over whatever was there before.
+		appender.Abort()
+		if verbose() && ctx.Err() == nil {
+			fmt.Fprintf(os.Stderr, "grafel: enrichment (bg) trickle failed: %v\n", err)
+		}
+		return
+	}
+
+	// The small, non-per-entity candidate sources run as one extra chunk —
+	// still cheap even on a huge graph, since these are bounded by
+	// community/endpoint count, not entity count.
+	if err := ctx.Err(); err != nil {
+		appender.Abort()
+		return
+	}
+	extra := i.collectSmallEnrichmentCandidateSources(doc, absRepo, grafelDir)
+	if len(extra) > 0 {
+		if err := appender.AppendChunk(extra); err != nil {
+			appender.Abort()
+			fmt.Fprintf(os.Stderr, "grafel: enrichment (bg) trickle failed: %v\n", err)
+			return
+		}
+	}
+
+	if err := appender.Close(); err != nil {
+		fmt.Fprintf(os.Stderr, "grafel: enrichment (bg) candidate write failed: %v\n", err)
+		return
+	}
 	if verbose() {
 		fmt.Fprintf(os.Stderr,
-			"grafel: emitted %d enrichment candidates to %s\n",
-			len(cands), filepath.Join(grafelDir, "enrichment-candidates.json"))
+			"grafel: emitted %d enrichment candidates (background) to %s\n",
+			appender.Count(), filepath.Join(grafelDir, "enrichment-candidates.json"))
 	}
 }
 

--- a/cmd/grafel/index_enrichment_bg_test.go
+++ b/cmd/grafel/index_enrichment_bg_test.go
@@ -1,0 +1,178 @@
+// index_enrichment_bg_test.go — #5720: move enrichment off the index
+// critical path.
+//
+// These tests assert the acceptance criteria from issue #5720:
+//  1. graph.fb is written / the index reports complete BEFORE Pass 6
+//     enrichment-candidate emission runs.
+//  4. a new index of the SAME repo cancels/supersedes any in-flight
+//     background enrichment for that repo.
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/enrichment"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+)
+
+// TestIndex_GraphWrittenBeforeEnrichment is the RED-before-fix test for
+// #5720 requirement 1: enrichment must run AFTER graph.fb is on disk.
+// Before the fix, runPass6EmitEnrichmentCandidates ran inside Run(), which
+// completes strictly BEFORE Index() writes graph.fb — so this test would
+// have observed "enrichment_started" before "graph_written".
+func TestIndex_GraphWrittenBeforeEnrichment(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	tmp := t.TempDir()
+	outPath := filepath.Join(tmp, "graph.json")
+
+	var mu sync.Mutex
+	var order []string
+	prev := enrichmentOrderHook
+	enrichmentOrderHook = func(stage string) {
+		mu.Lock()
+		order = append(order, stage)
+		mu.Unlock()
+	}
+	defer func() { enrichmentOrderHook = prev }()
+
+	if err := Index("testdata/crossfile_go", outPath, "test-repo-order", nil, false, false); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	fbPath := filepath.Join(tmp, "graph.fb")
+	if _, err := os.Stat(fbPath); err != nil {
+		t.Fatalf("graph.fb not written: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(order) == 0 {
+		t.Fatalf("enrichmentOrderHook never fired — is PassEnrichment being skipped unexpectedly?")
+	}
+	if order[0] != "graph_written" {
+		t.Fatalf("expected \"graph_written\" to be the first lifecycle event, got order=%v", order)
+	}
+	// The crossfile_go fixture is small, so this run takes the INLINE path —
+	// enrichment_started/enrichment_done should both appear strictly after
+	// graph_written.
+	graphIdx, startedIdx := -1, -1
+	for i, s := range order {
+		if s == "graph_written" && graphIdx == -1 {
+			graphIdx = i
+		}
+		if s == "enrichment_started" && startedIdx == -1 {
+			startedIdx = i
+		}
+	}
+	if startedIdx != -1 && startedIdx < graphIdx {
+		t.Fatalf("enrichment started before graph.fb was written: order=%v", order)
+	}
+
+	// Confirm the FB file is actually valid/queryable at this point — the
+	// requirement is not just "written" but "loadable/queryable".
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open graph.fb: %v", err)
+	}
+	defer r.Close()
+	if r.EntityCount() == 0 {
+		t.Fatalf("graph.fb has 0 entities")
+	}
+}
+
+// TestIndex_LargeGraphDefersEnrichmentToBackground confirms that a graph
+// above enrichment.InlineEntityThreshold schedules enrichment on the
+// background worker rather than running it inline — i.e. Index() returns
+// (and the caller can treat the index as "done") before enrichment_done
+// fires, and enrichment-candidates.json still eventually appears once the
+// background job completes (#5720 requirement 6 + "eventually appears").
+func TestIndex_LargeGraphDefersEnrichmentToBackground(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	tmp := t.TempDir()
+	outPath := filepath.Join(tmp, "graph.json")
+
+	var mu sync.Mutex
+	var enrichmentDoneBeforeIndexReturned bool
+	indexReturned := false
+
+	prev := enrichmentOrderHook
+	enrichmentOrderHook = func(stage string) {
+		mu.Lock()
+		defer mu.Unlock()
+		if stage == "enrichment_done" && !indexReturned {
+			enrichmentDoneBeforeIndexReturned = true
+		}
+	}
+	defer func() { enrichmentOrderHook = prev }()
+
+	absRepo, _ := filepath.Abs("testdata/crossfile_go")
+
+	// Force the deferred (background) path regardless of the fixture's
+	// actual entity count, by temporarily lowering the inline threshold to
+	// -1 (always defer). This isolates the "large graph defers" behavior
+	// from needing a genuinely huge fixture in the test corpus.
+	origThreshold := enrichment.InlineEntityThreshold
+	enrichment.InlineEntityThreshold = -1
+	defer func() { enrichment.InlineEntityThreshold = origThreshold }()
+
+	if err := Index("testdata/crossfile_go", outPath, "test-repo-bg", nil, false, false); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	mu.Lock()
+	indexReturned = true
+	mu.Unlock()
+
+	if enrichmentDoneBeforeIndexReturned {
+		t.Fatalf("expected enrichment to still be running (or not yet started) when Index() returned for a graph above the inline threshold")
+	}
+
+	// Eventually (once the background worker finishes) the candidates file
+	// must appear and be valid.
+	enrichment.DefaultScheduler.Wait(daemon.StateDirForRepo(absRepo))
+
+	candPath := filepath.Join(daemon.StateDirForRepo(absRepo), "enrichment-candidates.json")
+	if _, err := os.Stat(candPath); err != nil {
+		t.Fatalf("expected enrichment-candidates.json to eventually appear after the background worker completes: %v", err)
+	}
+}
+
+// TestScheduler_SupersedesPriorRunForSameRepo confirms that calling
+// Index() twice in quick succession for the SAME repo does not leave two
+// competing background enrichment goroutines racing to write
+// enrichment-candidates.json — the second run's Schedule() call cancels the
+// first.
+func TestScheduler_SupersedesPriorRunForSameRepo(t *testing.T) {
+	s := enrichment.NewScheduler()
+	repoKey := "same-repo"
+
+	var firstSawCancel int32
+	firstStarted := make(chan struct{})
+	s.Schedule(repoKey, func(ctx context.Context) {
+		close(firstStarted)
+		<-ctx.Done()
+		firstSawCancel = 1
+	})
+	<-firstStarted
+
+	secondDone := make(chan struct{})
+	s.Schedule(repoKey, func(ctx context.Context) {
+		close(secondDone)
+	})
+
+	select {
+	case <-secondDone:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second Schedule() for the same repo never ran")
+	}
+	s.Wait(repoKey)
+	if firstSawCancel != 1 {
+		t.Fatalf("expected the first job's context to be cancelled once superseded")
+	}
+}

--- a/cmd/grafel/index_enrichment_test.go
+++ b/cmd/grafel/index_enrichment_test.go
@@ -32,6 +32,11 @@ func TestEnrichmentCandidates_DjangoFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	// #5720 — Pass 6 candidate emission is no longer part of Run(); Index()
+	// schedules it AFTER graph.fb is written (inline for small graphs, on
+	// the background worker for large ones). Tests exercising Run() directly
+	// invoke the same inline entry point Index() uses for small graphs.
+	idx.runPass6EmitEnrichmentCandidates(doc, tmp)
 	// runPass6 writes into the per-repo store state dir.
 	candPath := filepath.Join(daemon.StateDirForRepo(tmp), "enrichment-candidates.json")
 	data, err := os.ReadFile(candPath)
@@ -83,6 +88,7 @@ func TestEnrichmentResolutions_MergeBack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	idx.runPass6EmitEnrichmentCandidates(doc, tmp)
 	if len(doc.Entities) == 0 {
 		t.Fatalf("no entities extracted")
 	}
@@ -111,6 +117,7 @@ func TestEnrichmentResolutions_MergeBack(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run 2: %v", err)
 	}
+	idx2.runPass6EmitEnrichmentCandidates(doc2, tmp)
 	var got *string
 	for i := range doc2.Entities {
 		if doc2.Entities[i].ID == subject {

--- a/internal/enrichment/background.go
+++ b/internal/enrichment/background.go
@@ -1,0 +1,128 @@
+// background.go — the silent, bounded, cancellable background enrichment
+// worker (#5720, refs #5729).
+//
+// Historically Pass 6 (enrichment-candidate emission) ran INSIDE the index
+// critical path, before graph.fb was persisted (cmd/grafel/index.go). On
+// large graphs this peaked ~11GB and stalled first-index, severing MCP until
+// it finished. No consumer hard-depends on candidates: every reader treats an
+// absent/stale enrichment-candidates.json as "nothing pending" (nil), the
+// pass is already skippable via --skip-pass=enrichment, and WriteCandidates
+// errors are already swallowed (fire-and-forget). That makes it safe to move
+// off the critical path entirely.
+//
+// Scheduler runs at most one enrichment job process-wide (never the
+// multi-worker fan-out extraction uses), paced between chunks so it never
+// bursts, and supersedes (cancels) any in-flight job for the SAME repo when a
+// new index/rebuild starts — so a rapid edit-reindex loop never accumulates
+// orphaned goroutines or races a stale write over a fresh one.
+package enrichment
+
+import (
+	"context"
+	"sync"
+)
+
+// InlineEntityThreshold is the size gate (#5720 requirement 6): graphs with
+// at most this many entities are cheap enough to enrich synchronously, right
+// after graph.fb is written, on the same goroutine that called Schedule.
+// Larger graphs defer to the background worker. Deliberately generous —
+// deferral is meant to be the default for the heavy path, inline execution is
+// just an optimization for tiny repos/tests where spinning up a goroutine and
+// waiting on it via Wait() would be pure overhead.
+// Deliberately a var, not a const: tests exercise the deferred (background)
+// path deterministically by temporarily lowering it rather than requiring a
+// multi-thousand-entity fixture in the test corpus.
+var InlineEntityThreshold = 2000
+
+// job tracks the cancel func + completion signal for one repo's in-flight (or
+// most-recently-scheduled) background enrichment run.
+type job struct {
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// Scheduler runs enrichment jobs on a single background goroutine at a time,
+// system-wide (the `sem` semaphore below), keyed per-repo for supersession.
+type Scheduler struct {
+	mu   sync.Mutex
+	jobs map[string]*job
+
+	// sem bounds system-wide enrichment concurrency to 1 — the ≤1-worker
+	// requirement. It is intentionally NOT per-repo: even across multiple
+	// repos/groups, at most one enrichment trickle runs at any instant, so
+	// the worker is always "gentle" regardless of fleet size.
+	sem chan struct{}
+}
+
+// NewScheduler constructs a Scheduler with a fresh, empty job table and a
+// single-slot semaphore. Tests that want isolation from the process-wide
+// DefaultScheduler should construct their own via this constructor.
+func NewScheduler() *Scheduler {
+	return &Scheduler{
+		jobs: make(map[string]*job),
+		sem:  make(chan struct{}, 1),
+	}
+}
+
+// DefaultScheduler is the process-wide singleton used by cmd/grafel's
+// indexer for all real (non-test) index runs.
+var DefaultScheduler = NewScheduler()
+
+// Schedule supersedes any in-flight (or previously scheduled, still-running)
+// job for repoKey and starts run in a new background goroutine bound to a
+// fresh, cancellable context. Schedule returns immediately — it never blocks
+// the caller, so it is safe to call from the index critical path right after
+// graph.fb has been persisted.
+//
+// run MUST check ctx.Done() between chunks/batches of work and stop promptly
+// (without writing further output) when cancelled — that promptness is what
+// makes supersession race-free: the new job's goroutine always waits for the
+// superseded job's goroutine to fully exit (see below) before starting its
+// own work, so a slow-to-cancel run could still delay (but never corrupt)
+// the next run's output.
+func (s *Scheduler) Schedule(repoKey string, run func(ctx context.Context)) {
+	s.mu.Lock()
+	var prevDone chan struct{}
+	if prev, ok := s.jobs[repoKey]; ok {
+		prev.cancel()
+		prevDone = prev.done
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	s.jobs[repoKey] = &job{cancel: cancel, done: done}
+	s.mu.Unlock()
+
+	go func() {
+		defer close(done)
+		if prevDone != nil {
+			// Wait for the superseded run to fully stop before this one does
+			// anything — including acquiring the single worker slot — so a
+			// stale run can never write after (and clobber) a fresh one.
+			<-prevDone
+		}
+		// Acquire the system-wide single-worker slot. Blocks (silently, in
+		// the background) if another repo's enrichment is currently
+		// trickling; releases as soon as this run returns.
+		select {
+		case s.sem <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
+		defer func() { <-s.sem }()
+
+		run(ctx)
+	}()
+}
+
+// Wait blocks until the most recently scheduled job for repoKey has finished
+// (or immediately returns if none was ever scheduled). Test-only helper — the
+// production index path never waits, by design.
+func (s *Scheduler) Wait(repoKey string) {
+	s.mu.Lock()
+	j, ok := s.jobs[repoKey]
+	s.mu.Unlock()
+	if !ok {
+		return
+	}
+	<-j.done
+}

--- a/internal/enrichment/background.go
+++ b/internal/enrichment/background.go
@@ -19,6 +19,8 @@ package enrichment
 
 import (
 	"context"
+	"log/slog"
+	"runtime/debug"
 	"sync"
 )
 
@@ -98,7 +100,16 @@ func (s *Scheduler) Schedule(repoKey string, run func(ctx context.Context)) {
 			// Wait for the superseded run to fully stop before this one does
 			// anything — including acquiring the single worker slot — so a
 			// stale run can never write after (and clobber) a fresh one.
-			<-prevDone
+			// ctx-guarded: if THIS job itself gets superseded while still
+			// parked here (a rapid edit-reindex-reindex loop), bail out
+			// immediately instead of blocking on an already-stale
+			// predecessor — the job that superseded us will do its own
+			// prevDone wait against our `done`, which we close right away.
+			select {
+			case <-prevDone:
+			case <-ctx.Done():
+				return
+			}
 		}
 		// Acquire the system-wide single-worker slot. Blocks (silently, in
 		// the background) if another repo's enrichment is currently
@@ -109,6 +120,22 @@ func (s *Scheduler) Schedule(repoKey string, run func(ctx context.Context)) {
 			return
 		}
 		defer func() { <-s.sem }()
+
+		// Recover any panic raised by run (e.g. an emitter panicking on a
+		// pathological/large graph) so it can never crash the daemon
+		// asynchronously. This must be deferred AFTER the semaphore-acquire
+		// defer and BEFORE calling run, so that on panic: this recover runs
+		// first (stopping the unwind), then the semaphore-release defer
+		// still runs, then close(done) still runs — the daemon survives,
+		// the single worker slot is freed for the next job, and a
+		// superseded successor parked on this job's `done` is never stuck.
+		defer func() {
+			if r := recover(); r != nil {
+				slog.Default().Error(
+					"enrichment: background worker panicked — recovered; daemon continues in degraded state (this run's candidates trickle was abandoned)",
+					"repo", repoKey, "panic", r, "stack", string(debug.Stack()))
+			}
+		}()
 
 		run(ctx)
 	}()

--- a/internal/enrichment/background_test.go
+++ b/internal/enrichment/background_test.go
@@ -102,6 +102,122 @@ func repoKeyForTest(i int) string {
 	return "repo-" + itoa(i)
 }
 
+// TestScheduler_RecoversPanicInRunFunc is the RED-before-fix test for the
+// #5736 review follow-up: an emitter panic inside a background-worker run
+// func must NOT crash the daemon. Before the fix, the goroutine started by
+// Schedule has no recover, so an unrecovered panic in a goroutine terminates
+// the whole process — this test (run against the unfixed code) crashes the
+// test binary instead of failing normally, which IS the RED signal. After
+// the fix, the panic is recovered, the single-worker semaphore is released,
+// and done is closed so Wait() returns promptly.
+func TestScheduler_RecoversPanicInRunFunc(t *testing.T) {
+	s := NewScheduler()
+
+	panicRan := make(chan struct{})
+	s.Schedule("repoPanic", func(ctx context.Context) {
+		defer close(panicRan)
+		panic("boom: simulated emitter panic (#5736 review follow-up)")
+	})
+
+	select {
+	case <-panicRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("panicking job's run func never executed")
+	}
+
+	// done must be closed even though run panicked, so Wait returns
+	// promptly instead of blocking forever.
+	waitDone := make(chan struct{})
+	go func() {
+		s.Wait("repoPanic")
+		close(waitDone)
+	}()
+	select {
+	case <-waitDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Wait never returned after panicking job — done channel was not closed on panic")
+	}
+
+	// The single-worker semaphore must have been released despite the
+	// panic, so a subsequent job (any repo) can acquire it and run.
+	nextRan := make(chan struct{})
+	s.Schedule("repoAfterPanic", func(ctx context.Context) {
+		close(nextRan)
+	})
+	select {
+	case <-nextRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("subsequent job never ran — semaphore appears leaked after panic")
+	}
+}
+
+// TestScheduler_SupersededWhileParkedOnPrevDone_ReturnsPromptly is the
+// RED-before-fix test for the ctx-guard fix on the `<-prevDone` wait: a
+// job that is itself superseded WHILE still parked waiting for the run it
+// superseded must bail out immediately via ctx.Done(), rather than blocking
+// until the original (now doubly-stale) predecessor eventually finishes.
+func TestScheduler_SupersededWhileParkedOnPrevDone_ReturnsPromptly(t *testing.T) {
+	s := NewScheduler()
+
+	firstStarted := make(chan struct{})
+	firstRelease := make(chan struct{})
+	s.Schedule("repoX", func(ctx context.Context) {
+		close(firstStarted)
+		<-firstRelease
+	})
+	<-firstStarted
+
+	// Second job supersedes first, and (since first is still running) its
+	// goroutine parks on <-prevDone before it can even try to acquire sem.
+	secondRan := make(chan struct{})
+	s.Schedule("repoX", func(ctx context.Context) {
+		close(secondRan)
+	})
+
+	// White-box (same package): grab a handle on second's own done channel
+	// so we can assert it closes promptly once superseded, independent of
+	// whether first (which still holds the single-worker sem) has finished
+	// — third can't actually RUN until first releases the sem, but second
+	// bailing out of its stale <-prevDone wait must not depend on that.
+	s.mu.Lock()
+	secondDone := s.jobs["repoX"].done
+	s.mu.Unlock()
+
+	// Give the second job's goroutine a moment to reach the prevDone wait.
+	time.Sleep(50 * time.Millisecond)
+
+	// Third job supersedes second WHILE second is still parked on
+	// prevDone (first hasn't finished — firstRelease not yet closed).
+	// Ctx-guarded, second must return immediately without ever running.
+	thirdRan := make(chan struct{})
+	s.Schedule("repoX", func(ctx context.Context) {
+		close(thirdRan)
+	})
+
+	select {
+	case <-secondDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second job's done channel never closed — it appears stuck blocking on the stale <-prevDone wait instead of bailing out via ctx.Done()")
+	}
+
+	select {
+	case <-secondRan:
+		t.Fatal("second job's run func should never execute — it was superseded while still parked on prevDone")
+	default:
+	}
+
+	// Unblock first so the single-worker sem is released and third (which
+	// needs it) can actually run.
+	close(firstRelease)
+
+	select {
+	case <-thirdRan:
+	case <-time.After(2 * time.Second):
+		t.Fatal("third job never ran")
+	}
+	s.Wait("repoX")
+}
+
 // TestScheduler_AbortLeavesNoPublishedFile confirms that a run cancelled
 // before Close() (the pattern the real worker follows on ctx cancellation —
 // see runPass6EmitEnrichmentCandidatesBG in cmd/grafel) never publishes a

--- a/internal/enrichment/background_test.go
+++ b/internal/enrichment/background_test.go
@@ -1,0 +1,162 @@
+package enrichment
+
+import (
+	"context"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestScheduler_Supersession_CancelsPriorRun is the RED-before-fix test for
+// acceptance criterion #4 (cancellable / supersedes): scheduling a second job
+// for the SAME repo key must cancel the in-flight first job before the
+// second job's work function runs, and the first job's goroutine must have
+// fully exited (no leak, no stale-over-fresh write) by the time the second
+// job starts doing real work.
+func TestScheduler_Supersession_CancelsPriorRun(t *testing.T) {
+	s := NewScheduler()
+
+	firstCancelled := make(chan struct{})
+	firstStarted := make(chan struct{})
+	var firstStillRunningWhenSecondStarts int32
+
+	s.Schedule("repoA", func(ctx context.Context) {
+		close(firstStarted)
+		<-ctx.Done()
+		atomic.StoreInt32(&firstStillRunningWhenSecondStarts, 1)
+		close(firstCancelled)
+	})
+	<-firstStarted
+
+	secondRan := make(chan struct{})
+	s.Schedule("repoA", func(ctx context.Context) {
+		// By the time we get here, the first run's ctx must already be
+		// cancelled and its goroutine must have fully finished (the
+		// Scheduler waits on the prior job's done channel before starting
+		// this one) — so reading firstStillRunningWhenSecondStarts here must
+		// observe the write the first goroutine made before it exited.
+		select {
+		case <-firstCancelled:
+		case <-time.After(2 * time.Second):
+			t.Error("second job started before first job's cancellation completed")
+		}
+		close(secondRan)
+	})
+
+	select {
+	case <-secondRan:
+	case <-time.After(3 * time.Second):
+		t.Fatal("second scheduled job never ran — supersession appears to have deadlocked or dropped it")
+	}
+	s.Wait("repoA")
+}
+
+// TestScheduler_SingleWorker_NoConcurrentFanOut is the RED-before-fix test
+// for acceptance criterion #2 (≤1 worker, never the extraction fan-out):
+// scheduling jobs for several DIFFERENT repos concurrently must still only
+// ever run one at a time, system-wide.
+func TestScheduler_SingleWorker_NoConcurrentFanOut(t *testing.T) {
+	s := NewScheduler()
+
+	var active int32
+	var maxActive int32
+	var mu sync.Mutex
+	recordMax := func() {
+		mu.Lock()
+		defer mu.Unlock()
+		cur := atomic.LoadInt32(&active)
+		m := atomic.LoadInt32(&maxActive)
+		if cur > m {
+			atomic.StoreInt32(&maxActive, cur)
+		}
+	}
+
+	const numRepos = 6
+	var wg sync.WaitGroup
+	wg.Add(numRepos)
+	for i := 0; i < numRepos; i++ {
+		repo := repoKeyForTest(i)
+		s.Schedule(repo, func(ctx context.Context) {
+			defer wg.Done()
+			atomic.AddInt32(&active, 1)
+			recordMax()
+			// Hold the slot briefly so overlapping schedules would show up
+			// as maxActive > 1 if the scheduler ever ran more than one at
+			// once.
+			time.Sleep(20 * time.Millisecond)
+			atomic.AddInt32(&active, -1)
+		})
+	}
+	wg.Wait()
+
+	if got := atomic.LoadInt32(&maxActive); got > 1 {
+		t.Fatalf("expected at most 1 concurrently-active enrichment job system-wide, observed %d", got)
+	}
+}
+
+func repoKeyForTest(i int) string {
+	return "repo-" + itoa(i)
+}
+
+// TestScheduler_AbortLeavesNoPublishedFile confirms that a run cancelled
+// before Close() (the pattern the real worker follows on ctx cancellation —
+// see runPass6EmitEnrichmentCandidatesBG in cmd/grafel) never publishes a
+// half-written candidates file.
+func TestScheduler_AbortLeavesNoPublishedFile(t *testing.T) {
+	dir := t.TempDir()
+
+	appender, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender: %v", err)
+	}
+	if err := appender.AppendChunk([]Candidate{{ID: "x", Kind: "describe_entity", SubjectID: "e1"}}); err != nil {
+		t.Fatalf("AppendChunk: %v", err)
+	}
+	appender.Abort()
+
+	if _, err := os.Stat(candidatesPath(dir)); !os.IsNotExist(err) {
+		t.Fatalf("expected no published candidates file after Abort of the only run, stat err=%v", err)
+	}
+}
+
+// TestCollectAndAppendTrickle_RespectsCancellation confirms the chunked
+// collector stops promptly (without appending further batches) once ctx is
+// cancelled — the property Scheduler's supersession guarantee depends on.
+func TestCollectAndAppendTrickle_RespectsCancellation(t *testing.T) {
+	dir := t.TempDir()
+	entities := make([]graph.Entity, 5000)
+	for i := range entities {
+		entities[i] = graph.Entity{ID: "e" + itoa(i), Name: "http:GET:/api/x" + itoa(i), Kind: "http_endpoint"}
+	}
+	doc := mkDoc(entities...)
+
+	appender, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	chunks := 0
+	err = CollectAndAppendTrickle(ctx, doc, DefaultEmitters(), nil, appender, TrickleOptions{
+		ChunkSize: 50,
+		Pace:      1 * time.Millisecond,
+		OnChunk: func(n int) {
+			chunks++
+			if chunks == 2 {
+				cancel()
+			}
+		},
+	})
+	if err == nil {
+		t.Fatalf("expected CollectAndAppendTrickle to return an error after cancellation, got nil")
+	}
+	appender.Abort()
+
+	if chunks >= (len(entities) / 50) {
+		t.Fatalf("expected cancellation to stop collection well before processing all %d entities' worth of chunks, got %d chunks", len(entities)/50, chunks)
+	}
+}

--- a/internal/enrichment/trickle.go
+++ b/internal/enrichment/trickle.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 // discoveredAtOnly is the minimal shape decoded from the prior on-disk
@@ -146,11 +147,15 @@ func NewCandidateAppender(grafelDir string) (*CandidateAppender, error) {
 	path := candidatesPath(grafelDir)
 	priorAt := loadDiscoveredAtIndex(path)
 
-	tmp := path + ".trickle.tmp"
-	f, err := os.Create(tmp)
+	// os.CreateTemp (not a fixed name) so two appenders for the SAME repo
+	// opened concurrently — e.g. the background worker plus a manually
+	// triggered `grafel index`/`rebuild` on that repo — never collide on
+	// the same tmp path and clobber/truncate each other's in-progress file.
+	f, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".trickle.tmp-*")
 	if err != nil {
 		return nil, fmt.Errorf("enrichment: create tmp: %w", err)
 	}
+	tmp := f.Name()
 	if _, err := f.WriteString(fmt.Sprintf(`{"version":%d,"candidates":[`, CandidatesSchemaVersion)); err != nil {
 		f.Close()
 		os.Remove(tmp)

--- a/internal/enrichment/trickle.go
+++ b/internal/enrichment/trickle.go
@@ -1,0 +1,227 @@
+// trickle.go — the streaming, chunked write path for enrichment candidates
+// (#5720, #5729). WriteCandidates (candidates.go) is correct but
+// double-materializes: mergeDiscoveredAt reads the ENTIRE prior sidecar,
+// decodes it into a full []Candidate (every field — Evidence, ScoreBreakdown,
+// Context, ...), builds a second full-size merged slice, then
+// json.MarshalIndent encodes the WHOLE thing into one in-memory byte slice
+// before the atomic rename. On a large graph (~423MB prior sidecar) this
+// chain of three full-size materializations is exactly what drove Pass 6's
+// ~11GB peak (issue #5720).
+//
+// The background enrichment worker never calls WriteCandidates. Instead it
+// uses CandidateAppender, which:
+//   - loads ONLY a lightweight id -> discovered_at index from the prior file
+//     via a streaming, one-object-at-a-time JSON decode (loadDiscoveredAtIndex),
+//     never holding a full Candidate (or the full prior byte slice) in memory;
+//   - streams new candidates to a temp file batch-by-batch, releasing each
+//     batch's memory back to the GC as soon as it's flushed.
+//
+// Peak heap attributable to this path is bounded by (chunk size × avg
+// candidate size) + (distinct-ID count × ~2 short strings) — a small
+// constant, independent of the total candidates-file size on disk.
+package enrichment
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+)
+
+// discoveredAtOnly is the minimal shape decoded from the prior on-disk
+// candidates file when building the discovered_at index. Decoding into this
+// narrow struct (instead of the full Candidate, which additionally carries
+// Context/PromptTemplate/QualificationSignals/ScoreBreakdown/...) keeps the
+// per-record decode allocation small regardless of how much other data a
+// prior Candidate record carries.
+type discoveredAtOnly struct {
+	ID           string `json:"id"`
+	DiscoveredAt string `json:"discovered_at"`
+}
+
+// loadDiscoveredAtIndex opens path and streams it into an id -> discovered_at
+// map, tolerating both the {"version":N,"candidates":[...]} envelope and the
+// legacy bare-array shape. Returns an empty (non-nil) map on any read/parse
+// error or missing file — the trickle write is best-effort idempotence, not
+// correctness-critical (a cold discovered_at just means new candidates get a
+// fresh timestamp, same as issue #53's original fallback behavior).
+func loadDiscoveredAtIndex(path string) map[string]string {
+	f, err := os.Open(path)
+	if err != nil {
+		return map[string]string{}
+	}
+	defer f.Close()
+	return loadDiscoveredAtIndexFromReader(f)
+}
+
+// loadDiscoveredAtIndexFromReader does the actual streaming decode. Split out
+// from loadDiscoveredAtIndex so tests can wrap an instrumented io.Reader (e.g.
+// one that records the largest single Read() request) to assert the loader
+// never slurps the whole input in one shot the way os.ReadFile does.
+func loadDiscoveredAtIndexFromReader(r io.Reader) map[string]string {
+	out := map[string]string{}
+	dec := json.NewDecoder(r)
+
+	tok, err := dec.Token()
+	if err != nil {
+		return out
+	}
+	if delim, ok := tok.(json.Delim); ok && delim == '{' {
+		// Object envelope: scan keys until we find "candidates", skipping
+		// (streaming-decode, not slurping) every other key's value.
+		found := false
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return out
+			}
+			key, _ := keyTok.(string)
+			if key == "candidates" {
+				found = true
+				break
+			}
+			var skip json.RawMessage
+			if err := dec.Decode(&skip); err != nil {
+				return out
+			}
+		}
+		if !found {
+			return out
+		}
+		// Consume the '[' that opens the candidates array.
+		if _, err := dec.Token(); err != nil {
+			return out
+		}
+	}
+	// Either we just consumed "candidates": [ above, or the bare-array form's
+	// leading '[' was already consumed by the first dec.Token() call — either
+	// way we're now positioned to decode array elements one at a time.
+	for dec.More() {
+		var c discoveredAtOnly
+		if err := dec.Decode(&c); err != nil {
+			break
+		}
+		if c.ID != "" && c.DiscoveredAt != "" {
+			out[c.ID] = c.DiscoveredAt
+		}
+	}
+	return out
+}
+
+// CandidateAppender streams candidates into <grafelDir>/enrichment-candidates.json
+// in bounded-size batches instead of assembling the full merged set in memory
+// at once. See the package doc comment above for why this exists (#5720).
+//
+// Usage:
+//
+//	a, err := NewCandidateAppender(grafelDir)
+//	...
+//	for each chunk of candidates:
+//	    a.AppendChunk(chunk)
+//	a.Close() // atomically publishes the file
+//
+// On any error, or if the caller decides to abandon the run (e.g. a
+// superseding Schedule() cancelled this job), call Abort() instead of Close()
+// so the temp file is removed and the prior on-disk candidates file is left
+// untouched — a cancelled trickle run must never leave a stale-and-truncated
+// candidates file, and must never write over a fresher concurrent run's
+// output (the Scheduler in background.go guarantees only one writer for a
+// given repo is ever active at a time).
+type CandidateAppender struct {
+	grafelDir string
+	tmpPath   string
+	f         *os.File
+	count     int
+	priorAt   map[string]string
+	closed    bool
+}
+
+// NewCandidateAppender opens (creates) the temp file and loads the prior
+// discovered_at index. Safe to call even when no prior candidates file
+// exists (first-ever index of a repo).
+func NewCandidateAppender(grafelDir string) (*CandidateAppender, error) {
+	if err := os.MkdirAll(grafelDir, 0o755); err != nil {
+		return nil, fmt.Errorf("enrichment: mkdir %s: %w", grafelDir, err)
+	}
+	path := candidatesPath(grafelDir)
+	priorAt := loadDiscoveredAtIndex(path)
+
+	tmp := path + ".trickle.tmp"
+	f, err := os.Create(tmp)
+	if err != nil {
+		return nil, fmt.Errorf("enrichment: create tmp: %w", err)
+	}
+	if _, err := f.WriteString(fmt.Sprintf(`{"version":%d,"candidates":[`, CandidatesSchemaVersion)); err != nil {
+		f.Close()
+		os.Remove(tmp)
+		return nil, fmt.Errorf("enrichment: write header: %w", err)
+	}
+	return &CandidateAppender{
+		grafelDir: grafelDir,
+		tmpPath:   tmp,
+		f:         f,
+		priorAt:   priorAt,
+	}, nil
+}
+
+// AppendChunk writes one batch of candidates to the temp file. The caller's
+// slice is free to be discarded/reused immediately after this call returns —
+// nothing about it is retained by the appender.
+func (a *CandidateAppender) AppendChunk(cs []Candidate) error {
+	for _, c := range cs {
+		if prior, ok := a.priorAt[c.ID]; ok {
+			c.DiscoveredAt = prior
+		}
+		if a.count > 0 {
+			if _, err := a.f.WriteString(","); err != nil {
+				return fmt.Errorf("enrichment: append: %w", err)
+			}
+		}
+		data, err := json.Marshal(c)
+		if err != nil {
+			return fmt.Errorf("enrichment: marshal candidate %s: %w", c.ID, err)
+		}
+		if _, err := a.f.Write(data); err != nil {
+			return fmt.Errorf("enrichment: append: %w", err)
+		}
+		a.count++
+	}
+	return nil
+}
+
+// Count returns the number of candidates appended so far.
+func (a *CandidateAppender) Count() int { return a.count }
+
+// Abort discards the in-progress temp file without touching the published
+// candidates file. Used when a run is cancelled or fails partway through.
+func (a *CandidateAppender) Abort() {
+	if a.closed {
+		return
+	}
+	a.closed = true
+	a.f.Close()
+	os.Remove(a.tmpPath)
+}
+
+// Close finalizes the temp file and atomically renames it over the published
+// candidates file. Not safe to call twice; a second call is a no-op error.
+func (a *CandidateAppender) Close() error {
+	if a.closed {
+		return fmt.Errorf("enrichment: appender already closed")
+	}
+	a.closed = true
+	if _, err := a.f.WriteString("]}"); err != nil {
+		a.f.Close()
+		os.Remove(a.tmpPath)
+		return fmt.Errorf("enrichment: write footer: %w", err)
+	}
+	if err := a.f.Close(); err != nil {
+		os.Remove(a.tmpPath)
+		return fmt.Errorf("enrichment: close tmp: %w", err)
+	}
+	if err := os.Rename(a.tmpPath, candidatesPath(a.grafelDir)); err != nil {
+		os.Remove(a.tmpPath)
+		return fmt.Errorf("enrichment: rename: %w", err)
+	}
+	return nil
+}

--- a/internal/enrichment/trickle_collect.go
+++ b/internal/enrichment/trickle_collect.go
@@ -1,0 +1,124 @@
+// trickle_collect.go — chunked, paced entity-candidate collection for the
+// background enrichment worker (#5720). This is the trickle counterpart of
+// CollectCandidates: instead of walking every entity and building one
+// full-graph []Candidate slice, it walks doc.Entities in small batches,
+// flushes each batch through a CandidateAppender, and pauses between
+// batches so the worker is a slow, idle-preferring trickle rather than a
+// burst — and so it can react to cancellation promptly (a new index of the
+// same repo supersedes this run; see background.go).
+package enrichment
+
+import (
+	"context"
+	"runtime"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// DefaultTrickleChunkSize bounds how many entities are processed per batch.
+// Combined with pacing between batches, this is what keeps peak heap
+// attributable to enrichment a small constant: only one batch's worth of
+// Candidate structs is ever alive at a time, independent of total entity
+// count.
+const DefaultTrickleChunkSize = 250
+
+// DefaultTricklePace is the pause between batches. Small enough that even a
+// huge graph finishes in a reasonable wall-clock time, large enough that the
+// worker never saturates a core or contends with a foreground index/query.
+const DefaultTricklePace = 15 * time.Millisecond
+
+// TrickleOptions configures CollectAndAppendTrickle. Zero value uses the
+// package defaults.
+type TrickleOptions struct {
+	ChunkSize int
+	Pace      time.Duration
+	// OnChunk, if non-nil, is called after each batch is appended with the
+	// number of candidates written in that batch. Test/observability hook —
+	// never required for correctness.
+	OnChunk func(appended int)
+}
+
+func (o TrickleOptions) chunkSize() int {
+	if o.ChunkSize > 0 {
+		return o.ChunkSize
+	}
+	return DefaultTrickleChunkSize
+}
+
+func (o TrickleOptions) pace() time.Duration {
+	if o.Pace > 0 {
+		return o.Pace
+	}
+	return DefaultTricklePace
+}
+
+// CollectAndAppendTrickle runs emitters over doc.Entities in successive
+// batches of opts.ChunkSize, appending each batch to appender and pausing
+// opts.Pace between batches. It returns ctx.Err() (without appending further
+// output) as soon as ctx is cancelled — the caller (background.go's
+// Scheduler) is expected to Abort() the appender in that case rather than
+// Close() it, so a superseded run never publishes a partial/stale file.
+//
+// rejected is the (subject_id|kind) rejection set, as produced by
+// ReadRejections — passed in rather than re-read here so callers can load it
+// once up front (it's small; no streaming concern).
+func CollectAndAppendTrickle(ctx context.Context, doc *graph.Document, emitters []CandidateEmitter, rejected map[string]bool, appender *CandidateAppender, opts TrickleOptions) error {
+	if doc == nil {
+		return nil
+	}
+	chunkSize := opts.chunkSize()
+	pace := opts.pace()
+	seen := map[string]bool{}
+	n := len(doc.Entities)
+
+	for start := 0; start < n; start += chunkSize {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		end := start + chunkSize
+		if end > n {
+			end = n
+		}
+		var batch []Candidate
+		for i := start; i < end; i++ {
+			e := &doc.Entities[i]
+			for _, em := range emitters {
+				for _, c := range em.EmitFor(e, doc) {
+					if c.ID == "" || seen[c.ID] {
+						continue
+					}
+					key := c.SubjectID + "|" + c.Kind
+					if rejected[key] {
+						continue
+					}
+					seen[c.ID] = true
+					batch = append(batch, c)
+				}
+			}
+		}
+		if len(batch) > 0 {
+			if err := appender.AppendChunk(batch); err != nil {
+				return err
+			}
+			if opts.OnChunk != nil {
+				opts.OnChunk(len(batch))
+			}
+		}
+		batch = nil // release this batch's memory before the next iteration
+
+		if end >= n {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pace):
+		}
+		runtime.Gosched()
+	}
+	return nil
+}

--- a/internal/enrichment/trickle_test.go
+++ b/internal/enrichment/trickle_test.go
@@ -235,6 +235,50 @@ func TestCandidateAppender_Abort(t *testing.T) {
 	}
 }
 
+// TestCandidateAppender_UniqueTmpPath is the RED-before-fix test for the
+// #5736 review follow-up: two CandidateAppenders opened concurrently for the
+// SAME repo (e.g. the daemon's background worker plus a manually-triggered
+// `grafel index`/`rebuild` on that repo) must not collide on the same fixed
+// tmp filename — each must get its own unique tmp path so one process's
+// writes/aborts can never truncate or delete the other's in-progress file.
+func TestCandidateAppender_UniqueTmpPath(t *testing.T) {
+	dir := t.TempDir()
+
+	a1, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender (a1): %v", err)
+	}
+	defer a1.Abort()
+
+	a2, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender (a2): %v", err)
+	}
+	defer a2.Abort()
+
+	if a1.tmpPath == a2.tmpPath {
+		t.Fatalf("expected unique tmp paths per appender, both got %q — concurrent appenders for the same repo would clobber each other", a1.tmpPath)
+	}
+	if _, err := os.Stat(a1.tmpPath); err != nil {
+		t.Fatalf("a1 tmp file missing: %v", err)
+	}
+	if _, err := os.Stat(a2.tmpPath); err != nil {
+		t.Fatalf("a2 tmp file missing: %v", err)
+	}
+
+	if err := a1.AppendChunk([]Candidate{{ID: "one", Kind: "describe_entity", SubjectID: "e1"}}); err != nil {
+		t.Fatalf("a1 AppendChunk: %v", err)
+	}
+	if err := a1.Close(); err != nil {
+		t.Fatalf("a1 Close: %v", err)
+	}
+
+	// a2 must be unaffected by a1's Close (independent files).
+	if err := a2.AppendChunk([]Candidate{{ID: "two", Kind: "describe_entity", SubjectID: "e2"}}); err != nil {
+		t.Fatalf("a2 AppendChunk after a1 Close: %v", err)
+	}
+}
+
 // bytesReader avoids importing bytes just for a one-liner in test files that
 // otherwise don't need it.
 func bytesReader(b []byte) io.Reader {

--- a/internal/enrichment/trickle_test.go
+++ b/internal/enrichment/trickle_test.go
@@ -1,0 +1,256 @@
+package enrichment
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// maxReadTracker wraps an io.Reader and records the largest single Read()
+// request length it observed. os.ReadFile (and json.Unmarshal fed by it)
+// effectively asks for the WHOLE file in one shot (a buffer sized to the
+// full file length); a truly streaming decoder never does — it asks for
+// small, roughly-constant-size chunks no matter how big the underlying file
+// is. This is the concrete, testable signature of "no double
+// materialization" from issue #5720.
+type maxReadTracker struct {
+	r      io.Reader
+	maxLen int
+}
+
+func (m *maxReadTracker) Read(p []byte) (int, error) {
+	if len(p) > m.maxLen {
+		m.maxLen = len(p)
+	}
+	return m.r.Read(p)
+}
+
+// bigPriorCandidatesJSON builds a large prior candidates file (many records,
+// each padded with a big Context blob) so a full in-memory re-materialization
+// would be clearly distinguishable, size-wise, from a streaming decode.
+func bigPriorCandidatesJSON(t *testing.T, n int) []byte {
+	t.Helper()
+	pad := make([]byte, 4096)
+	for i := range pad {
+		pad[i] = 'x'
+	}
+	cs := make([]Candidate, n)
+	for i := range cs {
+		cs[i] = Candidate{
+			ID:           "cand-" + itoa(i),
+			Kind:         "describe_entity",
+			SubjectID:    "e" + itoa(i),
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+			Context:      map[string]any{"padding": string(pad)},
+		}
+	}
+	env := candidatesEnvelope{Version: CandidatesSchemaVersion, Candidates: cs}
+	data, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	return data
+}
+
+func itoa(i int) string {
+	// tiny local itoa to avoid importing strconv twice for a one-off helper
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+// TestLoadDiscoveredAtIndex_NeverSlurpsWholeFile is the RED-before-fix,
+// GREEN-after-fix test for the "no double materialization" acceptance
+// criterion (#5720 requirement 3): the streaming loader must never request a
+// single Read() anywhere close to the full file size, no matter how large
+// the prior candidates file is.
+func TestLoadDiscoveredAtIndex_NeverSlurpsWholeFile(t *testing.T) {
+	data := bigPriorCandidatesJSON(t, 2000) // several MB
+	if len(data) < 2*1024*1024 {
+		t.Fatalf("fixture too small to be a meaningful test: %d bytes", len(data))
+	}
+
+	tracker := &maxReadTracker{r: bytesReader(data)}
+	idx := loadDiscoveredAtIndexFromReader(tracker)
+
+	if len(idx) != 2000 {
+		t.Fatalf("expected 2000 discovered_at entries, got %d", len(idx))
+	}
+	if got, ok := idx["cand-0"]; !ok || got != "2024-01-01T00:00:00Z" {
+		t.Fatalf("expected cand-0 discovered_at preserved, got %q ok=%v", got, ok)
+	}
+
+	// The streaming decoder's internal buffer should stay tiny relative to
+	// the multi-MB input — bound generously at 256KB to allow for internal
+	// json.Decoder growth on any single (padded) record without allowing
+	// anything resembling a whole-file slurp.
+	const maxAllowedRead = 256 * 1024
+	if tracker.maxLen > maxAllowedRead {
+		t.Fatalf("loader requested a %d-byte read (file is %d bytes) — looks like a full-file materialization, not a stream",
+			tracker.maxLen, len(data))
+	}
+	t.Logf("file=%d bytes, largest single Read()=%d bytes", len(data), tracker.maxLen)
+}
+
+// TestLoadDiscoveredAtIndex_BareArrayForm exercises the legacy bare-array
+// on-disk shape.
+func TestLoadDiscoveredAtIndex_BareArrayForm(t *testing.T) {
+	arr := []Candidate{
+		{ID: "a", DiscoveredAt: "t1"},
+		{ID: "b", DiscoveredAt: "t2"},
+	}
+	data, err := json.Marshal(arr)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	idx := loadDiscoveredAtIndexFromReader(bytesReader(data))
+	if idx["a"] != "t1" || idx["b"] != "t2" {
+		t.Fatalf("unexpected index: %#v", idx)
+	}
+}
+
+// TestLoadDiscoveredAtIndex_MissingFile confirms the loader tolerates an
+// absent prior file (first-ever index of a repo).
+func TestLoadDiscoveredAtIndex_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	idx := loadDiscoveredAtIndex(filepath.Join(dir, "does-not-exist.json"))
+	if len(idx) != 0 {
+		t.Fatalf("expected empty index for missing file, got %#v", idx)
+	}
+}
+
+// TestCandidateAppender_RoundTrip verifies chunked AppendChunk calls produce
+// a valid, fully-readable enrichment-candidates.json, and that discovered_at
+// values from a prior run are preserved (idempotence, issue #53).
+func TestCandidateAppender_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Seed a prior candidates file with a discovered_at we expect to survive.
+	prior := candidatesEnvelope{
+		Version: CandidatesSchemaVersion,
+		Candidates: []Candidate{
+			{ID: "e1|describe_entity", Kind: "describe_entity", SubjectID: "e1", DiscoveredAt: "2020-01-01T00:00:00Z"},
+		},
+	}
+	priorData, err := json.MarshalIndent(prior, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal prior: %v", err)
+	}
+	if err := os.WriteFile(candidatesPath(dir), priorData, 0o644); err != nil {
+		t.Fatalf("write prior: %v", err)
+	}
+
+	appender, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender: %v", err)
+	}
+
+	chunk1 := []Candidate{
+		{ID: "e1|describe_entity", Kind: "describe_entity", SubjectID: "e1", DiscoveredAt: "2099-12-31T00:00:00Z"},
+	}
+	chunk2 := []Candidate{
+		{ID: "e2|describe_entity", Kind: "describe_entity", SubjectID: "e2", DiscoveredAt: "2099-12-31T00:00:00Z"},
+	}
+	if err := appender.AppendChunk(chunk1); err != nil {
+		t.Fatalf("AppendChunk 1: %v", err)
+	}
+	if err := appender.AppendChunk(chunk2); err != nil {
+		t.Fatalf("AppendChunk 2: %v", err)
+	}
+	if appender.Count() != 2 {
+		t.Fatalf("expected count 2, got %d", appender.Count())
+	}
+	if err := appender.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	final, err := os.ReadFile(candidatesPath(dir))
+	if err != nil {
+		t.Fatalf("read final: %v", err)
+	}
+	var env candidatesEnvelope
+	if err := json.Unmarshal(final, &env); err != nil {
+		t.Fatalf("unmarshal final: %v (data=%s)", err, final)
+	}
+	if len(env.Candidates) != 2 {
+		t.Fatalf("expected 2 candidates in final file, got %d: %+v", len(env.Candidates), env.Candidates)
+	}
+	byID := map[string]Candidate{}
+	for _, c := range env.Candidates {
+		byID[c.ID] = c
+	}
+	if got := byID["e1|describe_entity"].DiscoveredAt; got != "2020-01-01T00:00:00Z" {
+		t.Fatalf("expected prior discovered_at preserved for e1, got %q", got)
+	}
+	if got := byID["e2|describe_entity"].DiscoveredAt; got != "2099-12-31T00:00:00Z" {
+		t.Fatalf("expected fresh discovered_at for new candidate e2, got %q", got)
+	}
+}
+
+// TestCandidateAppender_Abort verifies that Abort leaves the prior published
+// file untouched and removes the temp file.
+func TestCandidateAppender_Abort(t *testing.T) {
+	dir := t.TempDir()
+	priorData := []byte(`{"version":2,"candidates":[{"id":"keep","kind":"describe_entity","subject_id":"e1"}]}`)
+	if err := os.WriteFile(candidatesPath(dir), priorData, 0o644); err != nil {
+		t.Fatalf("write prior: %v", err)
+	}
+
+	appender, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender: %v", err)
+	}
+	if err := appender.AppendChunk([]Candidate{{ID: "new", Kind: "describe_entity", SubjectID: "e2"}}); err != nil {
+		t.Fatalf("AppendChunk: %v", err)
+	}
+	appender.Abort()
+
+	if _, err := os.Stat(appender.tmpPath); !os.IsNotExist(err) {
+		t.Fatalf("expected tmp file removed after Abort, stat err=%v", err)
+	}
+	final, err := os.ReadFile(candidatesPath(dir))
+	if err != nil {
+		t.Fatalf("read prior after abort: %v", err)
+	}
+	if string(final) != string(priorData) {
+		t.Fatalf("expected published file untouched by Abort, got %s", final)
+	}
+}
+
+// bytesReader avoids importing bytes just for a one-liner in test files that
+// otherwise don't need it.
+func bytesReader(b []byte) io.Reader {
+	return &sliceReader{b: b}
+}
+
+type sliceReader struct {
+	b   []byte
+	pos int
+}
+
+func (s *sliceReader) Read(p []byte) (int, error) {
+	if s.pos >= len(s.b) {
+		return 0, io.EOF
+	}
+	n := copy(p, s.b[s.pos:])
+	s.pos += n
+	return n, nil
+}


### PR DESCRIPTION
#5720 (Refs #5729). Moves enrichment (Pass 6 candidate emission) OFF the index critical path.

- **Ordering:** `graph.fb` is written FIRST (graph queryable), THEN enrichment runs — test-asserted via an ordering hook (`graph_written` before `enrichment_started`). Only the cheap resolutions-merge stays pre-write.
- **Silent bounded worker** (`internal/enrichment/background.go`): single-slot semaphore (≤1, never the extraction fan-out); a new index of the same repo supersedes/cancels the in-flight job (blocks on prior `done`, no orphan/stale-over-fresh). Size gate: <2000 entities runs inline, larger defers.
- **Pacing/memory:** chunked walk (250) with 15ms pauses + ctx checks (trickle, not burst); candidates streamed to a temp file per chunk (atomic rename on Close, Abort+cleanup on cancel); **double-materialize killed** — `mergeDiscoveredAt`'s full ReadFile+unmarshal+re-marshal replaced by a streaming decoder retaining only id→discovered_at (verified: max 4KB read on an 8.4MB file).
- Authoritative graph byte-identical (`TestIssue481` still passes); RED→GREEN; `-race` clean.

This is the engine-side bg enrichment the split's engine role will own. Refs #5720, #5729.