### PR TITLE
fix(dashboard): surface graph warm/load failures instead of an infinite 'Warming index…' spinner

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -257,6 +257,7 @@ type GraphCache struct {
 	mu       sync.Mutex
 	entries  map[string]*cacheEntry
 	loading  map[string]*loadGate // in-flight loads, keyed by group (singleflight)
+	warmErrs map[string]error     // last load error per cache key (#5722), cleared on success
 	ttl      time.Duration
 	Payloads *graphPayloadCache // pre-serialised dense graph JSON, keyed by group+params
 }
@@ -279,6 +280,7 @@ func NewGraphCache(ttl time.Duration) *GraphCache {
 	return &GraphCache{
 		entries:  map[string]*cacheEntry{},
 		loading:  map[string]*loadGate{},
+		warmErrs: map[string]error{},
 		ttl:      ttl,
 		Payloads: newGraphPayloadCache(),
 	}
@@ -311,6 +313,24 @@ func (c *GraphCache) GetGroupCachedForRef(groupName, ref string) (*DashGroup, bo
 	// but return immediately so we never block first paint.
 	go func() { _, _ = c.GetGroupForRef(groupName, ref) }()
 	return nil, false
+}
+
+// LastWarmError returns the error from the most recent load attempt for
+// groupName/ref, if any load has been attempted and the most recent one
+// failed. It returns (nil, false) when no attempt has failed yet — either
+// because the group is warm, or because it simply hasn't finished its first
+// warm attempt (the ordinary "still warming" case). Callers use this to
+// distinguish a genuine load failure (#5722) from a group that just hasn't
+// warmed up yet, so a failure can be surfaced instead of retried forever.
+func (c *GraphCache) LastWarmError(groupName, ref string) (error, bool) {
+	cacheKey := groupName
+	if ref != "" {
+		cacheKey = groupName + "@" + ref
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	err, ok := c.warmErrs[cacheKey]
+	return err, ok
 }
 
 // Invalidate drops the cached entry for group and all per-ref variants
@@ -413,6 +433,12 @@ func (c *GraphCache) GetGroupForRef(groupName, ref string) (*DashGroup, error) {
 	c.mu.Lock()
 	if err == nil {
 		c.entries[cacheKey] = &cacheEntry{group: grp, loadedAt: time.Now()}
+		delete(c.warmErrs, cacheKey)
+	} else {
+		// Record the failure (#5722) so a subsequent best-effort caller (e.g.
+		// the graph-stream endpoint) can distinguish "genuinely failed" from
+		// "just hasn't warmed yet" instead of surfacing an eternal retry.
+		c.warmErrs[cacheKey] = err
 	}
 	delete(c.loading, cacheKey)
 	c.mu.Unlock()

--- a/internal/dashboard/v2_graph_stream.go
+++ b/internal/dashboard/v2_graph_stream.go
@@ -116,6 +116,16 @@ func (s *Server) handleV2GraphStream(w http.ResponseWriter, r *http.Request) {
 	// in the background; the frontend handles warm-up separately.
 	grp, warm := s.graphs.GetGroupCachedForRef(group, refParam)
 	if !warm {
+		// #5722 — distinguish a genuine load FAILURE from the ordinary "still
+		// warming" case. EventSource can't read a non-2xx body, so a bare 503
+		// is indistinguishable from "warming" to the frontend and it retries
+		// forever. When the last warm attempt for this group actually failed,
+		// upgrade to SSE and emit a `connected` + distinguishable `error` event
+		// carrying the failure detail instead of the opaque 503.
+		if loadErr, failed := s.graphs.LastWarmError(group, refParam); failed {
+			writeV2GraphStreamLoadError(w, loadErr)
+			return
+		}
 		writeV2Err(w, http.StatusServiceUnavailable, "unavailable",
 			"group not loaded; warming up — retry shortly")
 		return
@@ -235,6 +245,36 @@ func streamGraphChunks(w http.ResponseWriter, flusher http.Flusher, nodes []v2Gr
 			chunk.Edges = []v2GraphEdge{}
 		}
 		writeV2SSEEvent(w, "chunk", jsonString(chunk))
+		flusher.Flush()
+	}
+}
+
+// v2GraphStreamError is the `error` event payload emitted when a PRIOR warm
+// attempt for the group actually failed (see writeV2GraphStreamLoadError).
+type v2GraphStreamError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// writeV2GraphStreamLoadError upgrades the response to SSE and emits a
+// `connected` event followed by a distinguishable `error` event carrying
+// loadErr's detail (#5722). EventSource cannot read a non-2xx response body,
+// so a genuine load failure MUST be delivered as an SSE frame (status 200)
+// rather than an HTTP error status, or the frontend has no way to tell it
+// apart from a transient "still warming" 503 and retries forever.
+func writeV2GraphStreamLoadError(w http.ResponseWriter, loadErr error) {
+	flusher, ok := w.(http.Flusher)
+	setV2SSEHeaders(w)
+	w.WriteHeader(http.StatusOK)
+	writeV2SSEEvent(w, "connected", fmt.Sprintf(`{"subscribed_at":%d}`, time.Now().UnixMilli()))
+	if ok {
+		flusher.Flush()
+	}
+	writeV2SSEEvent(w, "error", jsonString(v2GraphStreamError{
+		Code:    "load_failed",
+		Message: loadErr.Error(),
+	}))
+	if ok {
 		flusher.Flush()
 	}
 }

--- a/internal/dashboard/v2_graph_stream_test.go
+++ b/internal/dashboard/v2_graph_stream_test.go
@@ -14,11 +14,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 // sseEvent is one parsed SSE `event:`/`data:` block.
@@ -335,4 +338,95 @@ func TestGraphStream_ColdGroupReturns503(t *testing.T) {
 	}
 	// Give the background warm goroutine a beat so it doesn't race t.Cleanup.
 	time.Sleep(10 * time.Millisecond)
+}
+
+// TestGraphStream_LoadFailureEmitsSSEError verifies that when a PRIOR warm
+// attempt for the group has actually failed (as opposed to simply not having
+// completed yet), the stream endpoint distinguishes that from the transient
+// "still warming" 503: it upgrades to SSE and emits a `connected` then an
+// `error` event carrying the failure detail, so EventSource (which cannot
+// read a non-2xx body) can actually see why the load failed instead of
+// retrying forever against an opaque 503 (#5722).
+func TestGraphStream_LoadFailureEmitsSSEError(t *testing.T) {
+	archHome := t.TempDir()
+	daemonRoot := t.TempDir()
+	t.Setenv("GRAFEL_HOME", archHome)
+	t.Setenv("GRAFEL_DAEMON_ROOT", daemonRoot)
+
+	// Register a group whose config file is malformed, so loading it fails
+	// deterministically (registry.LoadGroupConfig returns an error) while
+	// registration itself (which only checks the file exists) succeeds.
+	configDir := filepath.Join(archHome, "configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	configPath := filepath.Join(configDir, "testgrp.fleet.json")
+	if err := os.WriteFile(configPath, []byte("not valid json"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	if err := registry.AddGroup("testgrp", configPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Force one synchronous load attempt so the failure is recorded BEFORE we
+	// hit the stream endpoint (mirrors the async warm the cache kicks off,
+	// without racing a background goroutine in the test).
+	if _, err := srv.graphs.GetGroupForRef("testgrp", ""); err == nil {
+		t.Fatal("GetGroupForRef: want error for a group with a missing config, got nil")
+	}
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v2/graph/testgrp/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (SSE, so EventSource can read the error event)", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("Content-Type = %q, want text/event-stream", ct)
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	events := readSSE(t, string(b))
+	if len(events) < 2 {
+		t.Fatalf("want at least connected+error, got %d events: %+v", len(events), events)
+	}
+	if events[0].Type != "connected" {
+		t.Errorf("first event = %q, want connected", events[0].Type)
+	}
+	var errEv *sseEvent
+	for i := range events {
+		if events[i].Type == "error" {
+			errEv = &events[i]
+			break
+		}
+	}
+	if errEv == nil {
+		t.Fatalf("no error event found in %+v", events)
+	}
+	var payload struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal([]byte(errEv.Data), &payload); err != nil {
+		t.Fatalf("error payload unmarshal: %v", err)
+	}
+	if payload.Code == "" {
+		t.Errorf("error payload code is empty")
+	}
+	if payload.Message == "" {
+		t.Errorf("error payload message is empty")
+	}
 }

--- a/webui-v2/src/hooks/use-graph-stream.ts
+++ b/webui-v2/src/hooks/use-graph-stream.ts
@@ -16,13 +16,24 @@
      • streaming — meta received; chunks are arriving, the payload grows,
                    the progress counter advances.
      • done      — `done` received; the payload is complete.
-     • error     — the stream dropped AFTER meta (a real mid-stream failure
-                   the caller should fall back from to the full-payload
-                   fetch, since the shapes are identical).
+     • error     — either (a) the stream dropped AFTER meta (a real
+                   mid-stream failure the caller should fall back from to the
+                   full-payload fetch, since the shapes are identical), (b)
+                   the backend emitted a distinguishable `error` SSE event
+                   (a genuine warm/load failure, not just "still warming" —
+                   #5722), or (c) the warm retry ceiling was reached with no
+                   success (#5722) — `errorMessage` carries a user-facing
+                   detail in cases (b)/(c) so the screen can surface it
+                   instead of spinning forever.
 
    EventSource can't read a non-2xx body, so a 503 (cold group) surfaces as
-   an `onerror` BEFORE any event. We distinguish that (→ warming, retry)
-   from a drop after meta (→ error, caller falls back).
+   an `onerror` BEFORE any event. We distinguish that (→ warming, retry) from
+   a drop after meta (→ error, caller falls back). #5722: a cold group whose
+   warm attempt has genuinely FAILED (not just not-yet-warm) is instead
+   signalled via a dedicated `error` SSE event the backend upgrades to (see
+   internal/dashboard/v2_graph_stream.go), and — belt and braces — a warm
+   that never succeeds at all trips a retry ceiling (see
+   lib/graph-stream-warm-policy) rather than retrying forever.
    ============================================================ */
 
 import { useEffect, useReducer, useRef, useState } from "react";
@@ -36,6 +47,7 @@ import {
   type GraphStreamMetaWire,
   type GraphStreamChunkWire,
 } from "@/lib/graph-stream-reducer";
+import { decideWarmRetry, parseWarmErrorEvent } from "@/lib/graph-stream-warm-policy";
 
 export type GraphStreamPhase = "idle" | "warming" | "streaming" | "done" | "error";
 
@@ -47,12 +59,14 @@ export interface UseGraphStreamResult {
   loadedNodes: number;
   /** Total nodes from `meta` (progress denominator); 0 until meta arrives. */
   totalNodes: number;
+  /**
+   * User-facing detail for the `error` phase (#5722): the backend's `error`
+   * SSE event message, or the retry-ceiling give-up message. Null outside
+   * the `error` phase, or for the (generic, caller-falls-back) mid-stream
+   * drop case where the fallback fetch's own error is what matters.
+   */
+  errorMessage: string | null;
 }
-
-// Reconnect/retry backoff for a COLD group (503 → warming). Bounded + capped so
-// a slow warm self-heals without hammering the endpoint; clamps to the last
-// element and keeps retrying. Mirrors the use-mcp-activity schedule.
-const WARM_BACKOFF_MS = [1000, 2000, 3500, 5000];
 
 type Action =
   | { type: "meta"; meta: GraphStreamMetaWire }
@@ -76,12 +90,20 @@ function reducer(state: GraphStreamState, action: Action): GraphStreamState {
 /**
  * Consume the progressive graph stream for `groupId`.
  *
- * @param enabled  When false (e.g. the caller fell back to the full-payload
- *                 fetch), no EventSource is opened and the hook stays idle.
+ * @param enabled   When false (e.g. the caller fell back to the full-payload
+ *                  fetch), no EventSource is opened and the hook stays idle.
+ * @param retryKey  #5722 — bump this (e.g. from a "Retry" button) to force a
+ *                  fresh connect cycle after the hook has given up (`error`
+ *                  phase), without needing to change `groupId`/`enabled`.
  */
-export function useGraphStream(groupId: string, enabled = true): UseGraphStreamResult {
+export function useGraphStream(
+  groupId: string,
+  enabled = true,
+  retryKey = 0,
+): UseGraphStreamResult {
   const [state, dispatch] = useReducer(reducer, undefined, initialStreamState);
   const [phase, setPhase] = useState<GraphStreamPhase>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   // Latest phase in a ref so the long-lived effect's handlers branch on the
   // current phase (warming-vs-mid-stream) without re-subscribing.
@@ -98,6 +120,7 @@ export function useGraphStream(groupId: string, enabled = true): UseGraphStreamR
     dispatch({ type: "reset" });
     setPhase("warming");
     phaseRef.current = "warming";
+    setErrorMessage(null);
 
     let cancelled = false;
     let es: EventSource | null = null;
@@ -123,15 +146,23 @@ export function useGraphStream(groupId: string, enabled = true): UseGraphStreamR
       }
     };
 
+    // #5722 — retry with the capped backoff schedule until the retry ceiling
+    // (decideWarmRetry) is reached, then GIVE UP: surface `error` with a
+    // helpful message instead of retrying forever.
     const scheduleWarmRetry = () => {
       if (cancelled || retryTimer !== null) return;
-      const idx = Math.min(warmAttempt, WARM_BACKOFF_MS.length - 1);
-      const delay = WARM_BACKOFF_MS[idx];
+      const decision = decideWarmRetry(warmAttempt);
       warmAttempt += 1;
+      if (decision.kind === "giveUp") {
+        setErrorMessage(decision.message);
+        setPhase("error");
+        phaseRef.current = "error";
+        return;
+      }
       retryTimer = setTimeout(() => {
         retryTimer = null;
         connect();
-      }, delay);
+      }, decision.delayMs);
     };
 
     const connect = () => {
@@ -176,10 +207,25 @@ export function useGraphStream(groupId: string, enabled = true): UseGraphStreamR
         closeES();
       });
 
-      conn.onerror = () => {
+      conn.onerror = (ev: Event) => {
         if (cancelled) return;
         // A clean close after `done` lands here too — ignore it.
         if (phaseRef.current === "done") return;
+        // #5722 — the backend's distinguishable `error` SSE event (a genuine
+        // warm/load failure, not just "still warming") ALSO surfaces here:
+        // per the EventSource spec, a server "event: error" line dispatches
+        // an event of type "error" the same as a native connection failure.
+        // The two are distinguished by shape: the server's carries `.data`
+        // (it's actually a MessageEvent), a bare connection failure does not.
+        if (ev instanceof MessageEvent && typeof ev.data === "string") {
+          const detail = parseWarmErrorEvent(ev.data);
+          closeES();
+          setErrorMessage(detail.message);
+          setPhase("error");
+          phaseRef.current = "error";
+          clearRetry();
+          return;
+        }
         closeES();
         if (sawMeta) {
           // Dropped MID-STREAM after meta — a real failure. Surface `error` so
@@ -205,12 +251,13 @@ export function useGraphStream(groupId: string, enabled = true): UseGraphStreamR
       clearRetry();
       closeES();
     };
-  }, [groupId, enabled]);
+  }, [groupId, enabled, retryKey]);
 
   return {
     state,
     phase,
     loadedNodes: state.payload.nodes.length,
     totalNodes: state.totalNodes,
+    errorMessage,
   };
 }

--- a/webui-v2/src/lib/graph-stream-warm-policy.test.ts
+++ b/webui-v2/src/lib/graph-stream-warm-policy.test.ts
@@ -1,0 +1,77 @@
+/* ============================================================
+   lib/graph-stream-warm-policy.test.ts — unit tests for the pure warm
+   retry/give-up policy + SSE error-event parsing (#5722).
+
+   Extracted as a pure seam (mirrors graph-stream-reducer) so the
+   retry-ceiling and error-parsing logic used by hooks/use-graph-stream is
+   unit-testable without a live EventSource.
+   ============================================================ */
+
+import { describe, expect, it } from "vitest";
+import {
+  MAX_WARM_ATTEMPTS,
+  WARM_BACKOFF_MS,
+  decideWarmRetry,
+  parseWarmErrorEvent,
+} from "./graph-stream-warm-policy";
+
+describe("decideWarmRetry", () => {
+  it("retries with the backoff schedule while under the ceiling", () => {
+    for (let attempt = 0; attempt < WARM_BACKOFF_MS.length; attempt++) {
+      const decision = decideWarmRetry(attempt);
+      expect(decision.kind).toBe("retry");
+      if (decision.kind === "retry") {
+        expect(decision.delayMs).toBe(WARM_BACKOFF_MS[attempt]);
+      }
+    }
+  });
+
+  it("clamps to the last backoff step once past the schedule but under the ceiling", () => {
+    const decision = decideWarmRetry(WARM_BACKOFF_MS.length + 1);
+    expect(decision.kind).toBe("retry");
+    if (decision.kind === "retry") {
+      expect(decision.delayMs).toBe(WARM_BACKOFF_MS[WARM_BACKOFF_MS.length - 1]);
+    }
+  });
+
+  it("gives up once the retry ceiling is reached, with a helpful message", () => {
+    const decision = decideWarmRetry(MAX_WARM_ATTEMPTS);
+    expect(decision.kind).toBe("giveUp");
+    if (decision.kind === "giveUp") {
+      expect(decision.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("never retries indefinitely — the ceiling is reached in finite attempts", () => {
+    let attempt = 0;
+    let decision = decideWarmRetry(attempt);
+    while (decision.kind === "retry" && attempt < 1000) {
+      attempt++;
+      decision = decideWarmRetry(attempt);
+    }
+    expect(decision.kind).toBe("giveUp");
+    expect(attempt).toBeLessThan(1000);
+  });
+});
+
+describe("parseWarmErrorEvent", () => {
+  it("parses a well-formed backend error payload", () => {
+    const parsed = parseWarmErrorEvent(
+      JSON.stringify({ code: "load_failed", message: "group testgrp: config file does not exist" }),
+    );
+    expect(parsed.code).toBe("load_failed");
+    expect(parsed.message).toBe("group testgrp: config file does not exist");
+  });
+
+  it("falls back to a generic message on malformed JSON", () => {
+    const parsed = parseWarmErrorEvent("not json");
+    expect(parsed.code).toBe("unknown");
+    expect(parsed.message.length).toBeGreaterThan(0);
+  });
+
+  it("falls back to a generic message when fields are missing", () => {
+    const parsed = parseWarmErrorEvent(JSON.stringify({}));
+    expect(parsed.code).toBe("unknown");
+    expect(parsed.message.length).toBeGreaterThan(0);
+  });
+});

--- a/webui-v2/src/lib/graph-stream-warm-policy.ts
+++ b/webui-v2/src/lib/graph-stream-warm-policy.ts
@@ -1,0 +1,79 @@
+/* ============================================================
+   lib/graph-stream-warm-policy.ts — pure warm retry/give-up policy +
+   backend SSE error-event parsing for the progressive graph stream (#5722).
+
+   Extracted as a pure seam (mirrors graph-stream-reducer) so the two
+   decisions the SSE consumer (hooks/use-graph-stream) has to make on a
+   pre-meta failure are unit-testable without a live EventSource:
+
+     • decideWarmRetry — given how many warm attempts have already been
+       made, either retry with the next backoff delay or GIVE UP with a
+       user-facing message once the ceiling is reached. Without a ceiling a
+       group whose warm attempt keeps failing (not just "still warming")
+       spins the "Warming index…" affordance forever with no way out (#5722).
+     • parseWarmErrorEvent — parses the backend's distinguishable `error` SSE
+       event (event: error, data: {"code","message"}) into a safe shape, with
+       a generic fallback if the payload is malformed.
+   ============================================================ */
+
+// Reconnect/retry backoff for a COLD group (503 → warming, or a genuine load
+// failure surfaced via the `error` event). Bounded + capped so a slow warm
+// self-heals without hammering the endpoint.
+export const WARM_BACKOFF_MS = [1000, 2000, 3500, 5000];
+
+// #5722 — retry ceiling. Once this many warm attempts have been made with no
+// success, give up and surface an error instead of retrying forever. Chosen
+// generously (comfortably longer than any real warm, even a slow one) so a
+// genuinely slow-but-eventually-successful warm is never cut short, while a
+// warm that is truly stuck or failing repeatedly still resolves to a visible
+// error within a bounded, human-scale window.
+export const MAX_WARM_ATTEMPTS = 8;
+
+export type WarmDecision =
+  | { kind: "retry"; delayMs: number }
+  | { kind: "giveUp"; message: string };
+
+/**
+ * Decide what to do after the `attempt`-th warm failure (0-indexed: the
+ * FIRST failure passes attempt=0). Retries with the capped backoff schedule
+ * until MAX_WARM_ATTEMPTS is reached, then gives up with a helpful message.
+ */
+export function decideWarmRetry(attempt: number): WarmDecision {
+  if (attempt >= MAX_WARM_ATTEMPTS) {
+    return {
+      kind: "giveUp",
+      message:
+        "The graph is taking too long to load. It may have failed to warm up — try again, or check the daemon.",
+    };
+  }
+  const idx = Math.min(attempt, WARM_BACKOFF_MS.length - 1);
+  return { kind: "retry", delayMs: WARM_BACKOFF_MS[idx] };
+}
+
+/** Parsed shape of the backend's `error` SSE event (v2GraphStreamError). */
+export interface WarmErrorDetail {
+  code: string;
+  message: string;
+}
+
+const GENERIC_WARM_ERROR_MESSAGE = "Could not load the graph.";
+
+/**
+ * Parse the backend's `error` SSE event payload (event: error, data:
+ * {"code","message"}). Falls back to a generic code/message when the payload
+ * is malformed or missing fields, so a parse failure never leaves the caller
+ * without a renderable error state.
+ */
+export function parseWarmErrorEvent(raw: string): WarmErrorDetail {
+  try {
+    const parsed = JSON.parse(raw) as { code?: unknown; message?: unknown };
+    const code = typeof parsed.code === "string" && parsed.code ? parsed.code : "unknown";
+    const message =
+      typeof parsed.message === "string" && parsed.message
+        ? parsed.message
+        : GENERIC_WARM_ERROR_MESSAGE;
+    return { code, message };
+  } catch {
+    return { code: "unknown", message: GENERIC_WARM_ERROR_MESSAGE };
+  }
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -135,7 +135,10 @@ export default function GraphScreen() {
   // endpoint, so the screen + cosmos canvas consume the growing payload with no
   // data-model change. If the stream drops mid-way we fall back to the
   // full-payload fetch (same shape) so the graph still loads.
-  const stream = useGraphStream(groupId);
+  // #5722 — bump on manual "Retry" so a give-up/error state can be retried
+  // without needing groupId/enabled to change.
+  const [retryNonce, setRetryNonce] = useState(0);
+  const stream = useGraphStream(groupId, true, retryNonce);
   const streamFailed = stream.phase === "error";
   // The full-payload fetch is the FALLBACK: only enabled once the stream has
   // genuinely failed. A tiny graph still streams instantly (it's a single
@@ -730,7 +733,21 @@ export default function GraphScreen() {
           <div className="grid h-full place-items-center bg-bg">
             <div className="text-center">
               <p className="text-md text-text">Could not load the graph.</p>
-              <p className="mt-1 text-sm text-text-3">Is this group indexed? Check the daemon.</p>
+              {/* #5722 — surface the ACTUAL failure detail (from the stream's
+                  distinguishable `error` event, or the retry-ceiling give-up
+                  message) when we have one, instead of always the generic
+                  "is this indexed?" copy. Falls back to the generic copy when
+                  the stream never reported a specific reason (e.g. the
+                  fallback fetch itself failed for an unrelated reason). */}
+              <p className="mt-1 text-sm text-text-3">
+                {stream.errorMessage ?? "Is this group indexed? Check the daemon."}
+              </p>
+              <button
+                onClick={() => setRetryNonce((n) => n + 1)}
+                className="mt-3 inline-flex h-7 items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 text-sm text-text-2 hover:bg-surface-2"
+              >
+                <RotateCcw size={13} /> Retry
+              </button>
             </div>
           </div>
         ) : nodes.length === 0 ? (


### PR DESCRIPTION
Closes #5722 (Refs #5729). Makes any dashboard warm/load failure visible instead of an eternal spinner.

**Backend** (`internal/dashboard/`): `GraphCache` tracks per-key `warmErrs` + `LastWarmError`. `handleV2GraphStream` — when a group is cold AND a prior warm actually FAILED, upgrades to SSE (200) emitting `event: connected` then `event: error` with `{code:load_failed, message}`. The ordinary cold/never-attempted 503 is unchanged.
**Frontend** (`webui-v2/`): new pure `graph-stream-warm-policy` module (`MAX_WARM_ATTEMPTS=8`, `decideWarmRetry`, `parseWarmErrorEvent`). `use-graph-stream` onerror distinguishes a server error-event from a bare connection drop → `phase:error`; retry loop hits a ceiling → `error` instead of forever; `graph.tsx` renders the backend error + Retry button.

RED→GREEN both sides; 906 Go + 239 frontend tests pass; tsc clean; happy path unchanged. Refs #5722, #5729.