### PR TITLE
fix(extract/php): synthesize http_endpoint_definition for Slim routes + guard route-shaped ops from pruning

### DIFF
--- a/internal/engine/http_endpoint_php_producer.go
+++ b/internal/engine/http_endpoint_php_producer.go
@@ -592,3 +592,85 @@ func synthesizeLaravel(content string, emit emitFn, emitResource emitResourceFn)
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Slim Framework → http_endpoint_definition synthesis (#5733, refs #5688).
+// ---------------------------------------------------------------------------
+//
+// Non-Laravel PHP frameworks (Slim, CakePHP, CodeIgniter, Yii, WordPress, …)
+// are recognized by the regex-based custom extractors in
+// internal/custom/php/frameworks.go, but those extractors only ever emit a
+// statement-level SCOPE.Operation(subtype=endpoint) — never the flagship
+// http_endpoint_definition shape synthesizeLaravel produces. That leaves
+// their Routing cells at definitions:0 in the graph. This section adds the
+// first of those (Slim); the shape below is intentionally the smallest unit
+// of a small per-framework table so CakePHP/CodeIgniter/Yii/WordPress/etc.
+// can each be added later as one more entry, not a bespoke synthesizer.
+//
+// slimRouteVerbRe matches:
+//
+//	$app->get('/users/:id', function ($request, $response, $args) { ... });
+//	$app->post("/users", 'UserAction');
+//
+// Capture groups: 1=verb, 2=path (double-quoted), 3=path (single-quoted).
+// Slim v3/v4 route methods are get/post/put/patch/delete/options/any — the
+// same verb set Laravel's Route:: facade exposes, minus `map`/`group` (which
+// are route-REGISTRATION helpers, not verbs, and are intentionally excluded
+// here — group-prefix composition is a follow-up, see phpHasAnySlimRoute).
+var slimRouteVerbRe = regexp.MustCompile(
+	`(?m)\$app->(get|post|put|patch|delete|options|any)\s*\(\s*` +
+		`(?:"([^"]{1,500})"|'([^']{1,500})')`,
+)
+
+// phpHasAnySlimRoute is the fast-path gate mirroring phpHasAnyLaravelRoute:
+// no-op on any PHP file that isn't wiring up Slim routes.
+func phpHasAnySlimRoute(content string) bool {
+	return strings.Contains(content, "$app->get(") ||
+		strings.Contains(content, "$app->post(") ||
+		strings.Contains(content, "$app->put(") ||
+		strings.Contains(content, "$app->patch(") ||
+		strings.Contains(content, "$app->delete(") ||
+		strings.Contains(content, "$app->options(") ||
+		strings.Contains(content, "$app->any(")
+}
+
+// synthesizeSlim scans a PHP source file for Slim route registrations
+// ($app->get/post/put/patch/delete/options/any('/path', handler)) and emits
+// one http_endpoint_definition per route via emit, using the SAME canonical
+// shape synthesizeLaravel produces so the Routing cells, request/response
+// shape substrate, and auth/rate-limit stamping passes all reach parity.
+//
+// Slim's path-parameter syntax is `:name` — identical to Express — so the
+// path is canonicalized via httproutes.FrameworkExpress (colon-param walker)
+// rather than needing a bespoke Slim canonicalizer.
+//
+// The handler (closure, invokable class, or 'Controller::method' array/string
+// form) is intentionally NOT attributed here: Slim's action classes are
+// resolved via a DI container, so — unlike Laravel's static Controller@method
+// convention — there is no reliable static handler reference to forward.
+// This mirrors the closure-handler case in synthesizeLaravel (empty
+// handlerKind/handlerName).
+func synthesizeSlim(content string, emit emitFn) {
+	if !phpHasAnySlimRoute(content) {
+		return
+	}
+	for _, m := range slimRouteVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+
+		raw := ""
+		if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			raw = content[m[6]:m[7]]
+		}
+		if raw == "" {
+			continue
+		}
+
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		emit(verb, canonical, "slim", "", "")
+	}
+}

--- a/internal/engine/http_endpoint_php_producer_slim_test.go
+++ b/internal/engine/http_endpoint_php_producer_slim_test.go
@@ -1,0 +1,154 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers (mirrors collectLaravelSynthetics/collectLaravelMatches in
+// http_endpoint_php_producer_test.go for the Slim synthesizer).
+// ---------------------------------------------------------------------------
+
+type slimMatch struct {
+	method, path, framework, handlerKind, handlerName string
+}
+
+func collectSlimMatches(content string) []slimMatch {
+	var out []slimMatch
+	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
+		out = append(out, slimMatch{method, canonicalPath, framework, handlerKind, handlerName})
+	}
+	synthesizeSlim(content, emit)
+	return out
+}
+
+func collectSlimSynthetics(content string) []string {
+	var ids []string
+	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
+		ids = append(ids, "http:"+method+":"+canonicalPath)
+	}
+	synthesizeSlim(content, emit)
+	sort.Strings(ids)
+	return ids
+}
+
+// ---------------------------------------------------------------------------
+// Fast-path gate: no $app->verb(...) → no output
+// ---------------------------------------------------------------------------
+
+func TestSynthSlim_EmptyFile(t *testing.T) {
+	ids := collectSlimSynthetics("")
+	if len(ids) != 0 {
+		t.Errorf("expected 0 synthetics from empty file, got %v", ids)
+	}
+}
+
+func TestSynthSlim_NoRoutes(t *testing.T) {
+	src := `<?php
+echo "hello world";
+$x = new Foo();
+`
+	ids := collectSlimSynthetics(src)
+	if len(ids) != 0 {
+		t.Errorf("expected 0 synthetics, got %v", ids)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Explicit verb routes
+// ---------------------------------------------------------------------------
+
+func TestSynthSlim_VerbRoutes(t *testing.T) {
+	src := `<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app = AppFactory::create();
+
+$app->get('/users', function (Request $request, Response $response) {
+    return $response;
+});
+$app->post('/users', function (Request $request, Response $response) {
+    return $response;
+});
+$app->get('/users/:id', function (Request $request, Response $response, $args) {
+    return $response;
+});
+$app->put('/users/:id', function (Request $request, Response $response, $args) {
+    return $response;
+});
+$app->delete('/users/:id', function (Request $request, Response $response, $args) {
+    return $response;
+});
+
+$app->run();
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 5 {
+		t.Fatalf("expected 5 matches, got %d: %+v", len(matches), matches)
+	}
+
+	want := map[string]bool{
+		"GET /users":         false,
+		"POST /users":        false,
+		"GET /users/{id}":    false,
+		"PUT /users/{id}":    false,
+		"DELETE /users/{id}": false,
+	}
+	for _, m := range matches {
+		if m.framework != "slim" {
+			t.Errorf("expected framework=slim, got %q for %+v", m.framework, m)
+		}
+		key := m.method + " " + m.path
+		if _, ok := want[key]; !ok {
+			t.Errorf("unexpected match %+v", m)
+			continue
+		}
+		want[key] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("missing expected route %q; got: %+v", k, matches)
+		}
+	}
+}
+
+func TestSynthSlim_ColonParamCanonicalization(t *testing.T) {
+	src := `<?php
+$app->get('/invoices/:invoiceId/items/:itemId', function () {});
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].path != "/invoices/{invoiceId}/items/{itemId}" {
+		t.Errorf("path = %q, want /invoices/{invoiceId}/items/{itemId}", matches[0].path)
+	}
+	if matches[0].method != "GET" {
+		t.Errorf("method = %q, want GET", matches[0].method)
+	}
+}
+
+func TestSynthSlim_DoubleQuotedPath(t *testing.T) {
+	src := `<?php
+$app->get("/health", function () {});
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 1 || matches[0].path != "/health" {
+		t.Fatalf("expected 1 match for /health, got %+v", matches)
+	}
+}
+
+func TestSynthSlim_AnyVerb(t *testing.T) {
+	src := `<?php
+$app->any('/webhook', function () {});
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 1 || matches[0].method != "ANY" {
+		t.Fatalf("expected 1 ANY match, got %+v", matches)
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -1298,6 +1298,13 @@ func applyHTTPEndpointSynthesis(args DetectorPassArgs) DetectorPassResult {
 		phpRLBefore := len(entities)
 		// Producer side (#1419): Laravel Route::verb/resource/apiResource.
 		synthesizeLaravel(string(content), emit, emitResource)
+		// Producer side (#5733, refs #5688): Slim Framework
+		// $app->get/post/put/patch/delete/options/any('/path', handler)
+		// routes → the SAME http_endpoint_definition shape Laravel gets.
+		// Gated on phpHasAnySlimRoute so it no-ops on non-Slim PHP files;
+		// first entry in a small per-framework table other minor PHP
+		// frameworks (CakePHP, CodeIgniter, Yii, WordPress, …) can extend.
+		synthesizeSlim(string(content), emit)
 		// Producer side (#4752): reconcile route + group auth middleware
 		// (auth / role: / can: / withoutMiddleware) into the flat auth posture the
 		// authposture laravel resolver decodes live, over the endpoints emitted above.

--- a/internal/engine/precision_dedup.go
+++ b/internal/engine/precision_dedup.go
@@ -103,7 +103,7 @@ func dropStatementNoiseOperations(entities []types.EntityRecord, rels []types.Re
 	dropped := make(map[string]bool) // symbolic ID of each dropped Operation
 	out := make([]types.EntityRecord, 0, len(entities))
 	for _, e := range entities {
-		if e.Kind == "Operation" && isStatementNoiseOperationName(e.Name) {
+		if isOperationKind(e.Kind) && !isRouteShapedOperation(e) && isStatementNoiseOperationName(e.Name) {
 			dropped[symbolicID(e.Kind, e.Name)] = true
 			continue
 		}
@@ -293,6 +293,40 @@ func symbolicID(kind, name string) string {
 //
 // Everything else (including call idioms ending in `(` or `<`, dotted names,
 // and ordinary identifiers) is treated as a real operation and kept.
+// isOperationKind reports whether kind is an Operation-shaped kind that
+// dropStatementNoiseOperations is allowed to examine. Handles both the bare
+// "Operation" literal (some rule-engine/legacy paths) and the namespaced
+// "SCOPE.Operation" form (internal/types.EntityKindOperation, the on-disk
+// convention) so the noise filter behaves the same regardless of which
+// producer stamped the entity.
+func isOperationKind(kind string) bool {
+	return kind == "Operation" || kind == "SCOPE.Operation"
+}
+
+// isRouteShapedOperation reports whether an Operation-kind entity is a
+// recognized HTTP ROUTE captured by a framework's route-registration idiom
+// (e.g. the PHP custom extractors in internal/custom/php/frameworks.go for
+// Slim/CakePHP/CodeIgniter/Yii/WordPress/…, subtype "endpoint", stamped with
+// a `route_path` property) rather than genuine statement-level noise (a bare
+// decorator, an assignment fragment, a dangling keyword). These entities are
+// EXEMPT from dropStatementNoiseOperations even when their captured Name
+// looks noise-shaped (a route path such as "/users/:id" trips the "leading
+// keyword" / non-identifier heuristics that were tuned for source
+// statements, not URL paths) — deleting them silently zeroes out a
+// framework's endpoint count (#5733, refs #5688) before any real
+// http_endpoint_definition synthesis exists for it. Narrowly scoped: only
+// fires for Subtype "endpoint" carrying a route_path/route property, never
+// for the broader Operation population.
+func isRouteShapedOperation(e types.EntityRecord) bool {
+	if e.Subtype != "endpoint" {
+		return false
+	}
+	if e.Properties == nil {
+		return false
+	}
+	return e.Properties["route_path"] != "" || e.Properties["route"] != ""
+}
+
 func isStatementNoiseOperationName(name string) bool {
 	if name == "" {
 		return true // an unnamed Operation is noise

--- a/internal/engine/precision_dedup_test.go
+++ b/internal/engine/precision_dedup_test.go
@@ -257,3 +257,57 @@ my_chain = prompt | model | parser
 		t.Errorf("expected the real 'my_chain' Operation to survive (1), got %d", realChain)
 	}
 }
+
+// TestPrecision_RouteShapedOperationSurvivesNoiseFilter (#5733, refs #5688)
+// asserts a route-shaped SCOPE.Operation(subtype=endpoint, route_path=...)
+// — the shape internal/custom/php/frameworks.go stamps for non-Laravel PHP
+// frameworks (Slim, CakePHP, CodeIgniter, Yii, WordPress, …) — is EXEMPT
+// from dropStatementNoiseOperations even though its captured route path
+// ("/users/:id") trips the noise heuristics tuned for source-code
+// statements. A genuine statement-noise Operation with the SAME kind must
+// still be pruned, so the guard doesn't just disable the filter wholesale.
+func TestPrecision_RouteShapedOperationSurvivesNoiseFilter(t *testing.T) {
+	entities := []types.EntityRecord{
+		// Route-shaped: subtype=endpoint + route_path property. Must survive
+		// even though nothing about "/users/:id" looks like a real identifier.
+		{
+			Name: "/users/:id", Kind: "SCOPE.Operation", Subtype: "endpoint",
+			SourceFile: "public/index.php", StartLine: 12,
+			Properties: map[string]string{"framework": "slim", "route_path": "/users/:id"},
+		},
+		// Genuine statement noise with the SAME namespaced kind — must still
+		// be dropped; the guard must not blanket-disable the filter.
+		{Name: "@tool", Kind: "SCOPE.Operation", SourceFile: "a.php", StartLine: 4},
+		// A bare "Operation" kind route (legacy/rule-engine form) with the
+		// route-shape properties must ALSO survive.
+		{
+			Name: "/health", Kind: "Operation", Subtype: "endpoint",
+			SourceFile: "routes.php", StartLine: 3,
+			Properties: map[string]string{"route": "/health"},
+		},
+		// Real (non-route) Operation must be kept regardless.
+		{Name: "my_chain", Kind: "Operation", SourceFile: "a.php", StartLine: 12},
+	}
+
+	gotEnts, _ := applyPrecisionDedup(entities, nil)
+
+	gotNames := map[string]bool{}
+	for _, e := range gotEnts {
+		gotNames[e.Name] = true
+	}
+	if !gotNames["/users/:id"] {
+		t.Error("route-shaped SCOPE.Operation('/users/:id') must survive the noise filter")
+	}
+	if !gotNames["/health"] {
+		t.Error("route-shaped Operation('/health') must survive the noise filter")
+	}
+	if gotNames["@tool"] {
+		t.Error("genuine statement-noise SCOPE.Operation('@tool') must still be dropped")
+	}
+	if !gotNames["my_chain"] {
+		t.Error("real Operation('my_chain') must be kept")
+	}
+	if len(gotEnts) != 3 {
+		t.Errorf("entity count: want 3 survivors (2 routes + 1 real op), got %d: %+v", len(gotEnts), gotEnts)
+	}
+}

--- a/internal/quality/golden/php-slim-mini/.grafel/group.json
+++ b/internal/quality/golden/php-slim-mini/.grafel/group.json
@@ -1,0 +1,9 @@
+{
+  "group": "php-slim-mini",
+  "repos": [
+    {
+      "slug": "php-slim-mini",
+      "clone_url": ""
+    }
+  ]
+}

--- a/internal/quality/golden/php-slim-mini/expected.json
+++ b/internal/quality/golden/php-slim-mini/expected.json
@@ -1,0 +1,13 @@
+{
+  "fixture_name": "php-slim-mini",
+  "language": "php",
+  "description": "Tiny Slim Framework 4 REST API (restapi/v1/index.php) exercising $app->get/post/put/delete route registrations with Slim's `:param` path-parameter syntax. Used by the extraction-quality benchmark to detect the #5733 regression where non-Laravel PHP frameworks synthesized zero http_endpoint_definition entities.",
+  "expected_entities": [
+    { "name": "http:GET:/invoices", "kind": "http_endpoint_definition", "must_exist": true, "note": "Slim $app->get('/invoices', ...)." },
+    { "name": "http:POST:/invoices", "kind": "http_endpoint_definition", "must_exist": true, "note": "Slim $app->post('/invoices', ...)." },
+    { "name": "http:GET:/invoices/{id}", "kind": "http_endpoint_definition", "must_exist": true, "note": "Slim colon-param path canonicalized :id -> {id}." },
+    { "name": "http:PUT:/invoices/{id}", "kind": "http_endpoint_definition", "must_exist": true },
+    { "name": "http:DELETE:/invoices/{id}", "kind": "http_endpoint_definition", "must_exist": true }
+  ],
+  "expected_relationships": []
+}

--- a/internal/quality/golden/php-slim-mini/src/composer.json
+++ b/internal/quality/golden/php-slim-mini/src/composer.json
@@ -1,0 +1,7 @@
+{
+  "name": "grafel/php-slim-mini",
+  "require": {
+    "slim/slim": "^4.11",
+    "slim/psr7": "^1.6"
+  }
+}

--- a/internal/quality/golden/php-slim-mini/src/restapi/v1/index.php
+++ b/internal/quality/golden/php-slim-mini/src/restapi/v1/index.php
@@ -1,0 +1,35 @@
+<?php
+require __DIR__ . '/../../vendor/autoload.php';
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+$app = AppFactory::create();
+
+$app->get('/invoices', function (Request $request, Response $response) {
+    $response->getBody()->write(json_encode([]));
+    return $response;
+});
+
+$app->post('/invoices', function (Request $request, Response $response) {
+    $data = $request->getParsedBody();
+    $response->getBody()->write(json_encode($data));
+    return $response;
+});
+
+$app->get('/invoices/:id', function (Request $request, Response $response, $args) {
+    $response->getBody()->write(json_encode(['id' => $args['id']]));
+    return $response;
+});
+
+$app->put('/invoices/:id', function (Request $request, Response $response, $args) {
+    $response->getBody()->write(json_encode(['id' => $args['id']]));
+    return $response;
+});
+
+$app->delete('/invoices/:id', function (Request $request, Response $response, $args) {
+    return $response->withStatus(204);
+});
+
+$app->run();


### PR DESCRIPTION
Refs #5733, #5688. Fixes the Slim case of the non-Laravel-PHP endpoint gap (backend framework produced 0 endpoint definitions → all client calls orphan).

- `synthesizeSlim` (mirrors `synthesizeLaravel`, gated by `phpHasAnySlimRoute`): detects `$app->get/post/…('/path/:param', h)`, canonicalizes `:param`→`{param}` via the existing `httproutes` Express colon-param walker, emits real `http_endpoint_definition`. Documented as the first entry in an extensible pattern for CakePHP/CodeIgniter/Yii/WordPress (follow-ups).
- `precision_dedup`: exempts **route-shaped** `SCOPE.Operation` entities (Subtype `endpoint` + `route_path`/`route` prop) from the statement-noise filter — narrowly scoped; genuine noise (@tool, assignments, dangling keywords) still pruned. Handles both bare `Operation` and `SCOPE.Operation` kind forms.
- Tests: 6 Slim producer units + a pruning-guard test + new `php-slim-mini` golden (5 routes → 5 defs; RED 0/5 → GREEN 5/5). All existing goldens byte-identical (no regression to Laravel or any framework).

Remaining #5733 (follow-ups): synthesis for the other non-Laravel PHP frameworks + a `.htaccess`/mod_rewrite front-controller extractor.

Refs #5733, #5688, #5729.