### PR TITLE
refactor(daemon): carve serve/engine entrypoints + config (ADR-0024 split PR1, no behavior change)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -391,14 +391,55 @@ func envPositiveInt2(name string) int {
 	return n
 }
 
-// runDaemon is the long-running mode of the grafel binary. It is
-// wired into the CLI as a hidden `grafel daemon` subcommand —
-// users normally reach it via `grafel start`, which forks this
-// process and detaches.
+// daemonRunMode selects which of the daemon.Config-driven entrypoints
+// runDaemonMode hands off to at the end of its shared runtime-tune +
+// config-assembly prelude (ADR-0024 Phase 1: entrypoint/config carve).
+type daemonRunMode int
+
+const (
+	daemonRunModeServe daemonRunMode = iota
+	daemonRunModeEngine
+)
+
+// runDaemon is the long-running mode of the grafel binary. It is wired
+// into the CLI as a hidden `grafel daemon` subcommand — users normally
+// reach it via `grafel start`, which forks this process and detaches.
+//
+// ADR-0024 (serve/engine split, Phase 1): `daemon` is now a back-compat
+// shim that runs the SAME path as `grafel serve` (runServe below), so an
+// existing OS unit that still execs `grafel daemon` transparently becomes
+// a serve process. Zero client-visible change.
+func runDaemon(argv []string) error {
+	return runServe(argv)
+}
+
+// runServe is the `grafel serve` entrypoint (ADR-0024 Phase 1): the MCP
+// socket + dashboard plane, plus — while the capability flag
+// (daemon.SplitModeEnabled) is off, the default — the engine plane
+// in-process, identically to today's daemon. It shares the entire
+// runtime-tune + daemon.Config assembly prelude with runEngine via
+// runDaemonMode.
+func runServe(argv []string) error {
+	return runDaemonMode(argv, daemonRunModeServe)
+}
+
+// runEngine is the `grafel engine` entrypoint (ADR-0024 Phase 1): the
+// scheduler/watcher/extraction/fbwriter plane. In this PR it shares the
+// same config-assembly prelude as runServe but hands off to
+// daemon.RunEngine, which — until PR2 lands the real process split —
+// deliberately refuses to run standalone (see daemon.RunEngine's doc).
+func runEngine(argv []string) error {
+	return runDaemonMode(argv, daemonRunModeEngine)
+}
+
+// runDaemonMode holds the runtime-tune prelude (GC/GOMAXPROCS/fd-limit
+// tuning, flag parsing, layout/mode resolution, daemon.Config assembly)
+// shared by runServe and runEngine (ADR-0024 Phase 1 config carve), then
+// dispatches to daemon.RunServe or daemon.RunEngine depending on mode.
 //
 // All extractor + registry + linker work happens here. The CLI's other
 // subcommands are thin RPC clients (see internal/daemon/client).
-func runDaemon(argv []string) error {
+func runDaemonMode(argv []string, runMode daemonRunMode) error {
 	// Fix root-cause E (#2141): lower the GC trigger from the default 100%
 	// heap-growth to 50%. This trades ~5% additional CPU for ~30% lower
 	// steady-state heap by collecting unreachable objects twice as often.
@@ -789,7 +830,16 @@ func runDaemon(argv []string) error {
 	// begins serving requests. The scanner goroutine runs until ctx is cancelled.
 	startDaemonTierManager(ctx, logger)
 
-	return daemon.Run(ctx, cfg)
+	// ADR-0024 Phase 1: dispatch to the serve or engine entrypoint. Both
+	// currently execute the identical in-process daemon.Run body while the
+	// capability flag is off (the default); PR2 diverges these behind the
+	// real process split. See daemon.RunServe / daemon.RunEngine docs.
+	switch runMode {
+	case daemonRunModeEngine:
+		return daemon.RunEngine(ctx, daemon.EngineConfig{Config: cfg})
+	default:
+		return daemon.RunServe(ctx, daemon.ServeConfig{Config: cfg})
+	}
 }
 
 // daemonReposToWatch returns every repo from every registered group

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -50,6 +50,8 @@ func main() {
 	}
 	cli.Execute(cli.Hooks{
 		RunDaemon:       runDaemon,
+		RunServe:        runServe,
+		RunEngine:       runEngine,
 		RunLinks:        runLinksHook,
 		RunDashboard:    runDashboard,
 		RunQuality:      runQuality,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,9 +18,28 @@ type Hooks struct {
 	// RunDaemon runs the long-running daemon (the `grafel daemon`
 	// hidden subcommand). It blocks until the daemon exits. Wired from
 	// cmd/grafel because the daemon imports the extractor stack.
+	//
+	// ADR-0024 (serve/engine split, Phase 1): `daemon` is now a back-compat
+	// shim over the same path as RunServe, kept so an existing OS unit that
+	// still execs `grafel daemon` transparently becomes a serve process.
 	RunDaemon    func(argv []string) error
 	RunDashboard func(argv []string) error
 	RunQuality   func(argv []string) error
+
+	// RunServe runs the serve plane (MCP socket + dashboard + graph_cache
+	// mmap reads), and — while the ADR-0024 capability flag is off (the
+	// default) — the engine plane in-process too, identically to RunDaemon.
+	// It is the `grafel serve` hidden subcommand's entrypoint and is also
+	// what the back-compat `grafel daemon` shim calls. Wired from
+	// cmd/grafel for the same reason as RunDaemon.
+	RunServe func(argv []string) error
+
+	// RunEngine runs the engine plane (scheduler + watcher + extraction +
+	// fbwriter) as the `grafel engine` hidden subcommand's entrypoint. In
+	// this PR (ADR-0024 Phase 1: entrypoint/config carve only) it is not
+	// yet independently runnable — the real process split lands in PR2.
+	// Wired from cmd/grafel for the same reason as RunDaemon.
+	RunEngine func(argv []string) error
 	// RunLinks runs the cross-repo link passes for a group. Wired up
 	// from cmd/grafel so the daemon (Phase B) can re-trigger link
 	// passes whenever a registered repo's graph.json changes.

--- a/internal/cli/index.go
+++ b/internal/cli/index.go
@@ -218,6 +218,11 @@ var errDaemonNotRunning = errors.New(
 // newDaemonCmd exposes the long-running daemon mode. It is hidden from
 // the primary surface — users normally reach it through `grafel start`,
 // which forks the binary in this mode with stdio detached.
+//
+// ADR-0024 (serve/engine split, Phase 1): `daemon` is the back-compat name.
+// Its RunE calls the SAME path as `grafel serve` (RunServe) so an existing
+// OS unit (launchd/systemd/SCM) that still execs `grafel daemon` becomes a
+// serve process transparently — no client-visible change.
 func newDaemonCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:                "daemon",
@@ -225,10 +230,54 @@ func newDaemonCmd() *cobra.Command {
 		Hidden:             true,
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
+			if activeHooks.RunServe != nil {
+				return activeHooks.RunServe(args)
+			}
+			// Fallback for any host that has not yet wired RunServe.
 			if activeHooks.RunDaemon == nil {
 				return errors.New("daemon entrypoint not wired")
 			}
 			return activeHooks.RunDaemon(args)
+		},
+	}
+	return cmd
+}
+
+// newServeCmd exposes the serve plane (ADR-0024 Phase 1): the MCP socket,
+// the dashboard, and graph_cache mmap reads. Hidden — not part of the
+// public surface yet; `grafel daemon` remains the documented/back-compat
+// entrypoint until `grafel install`/OS units are retargeted in a later PR.
+func newServeCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "serve",
+		Short:              "Run the grafel serve plane (MCP socket + dashboard)",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if activeHooks.RunServe == nil {
+				return errors.New("serve entrypoint not wired")
+			}
+			return activeHooks.RunServe(args)
+		},
+	}
+	return cmd
+}
+
+// newEngineCmd exposes the engine plane (ADR-0024 Phase 1): the scheduler,
+// watcher, extraction, and fbwriter. Hidden. In this PR it is not yet
+// independently runnable — the real process split (serve spawning/
+// supervising an engine child) lands in PR2, epic #5729.
+func newEngineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:                "engine",
+		Short:              "Run the grafel engine plane (scheduler/watcher/extraction/fbwriter)",
+		Hidden:             true,
+		DisableFlagParsing: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if activeHooks.RunEngine == nil {
+				return errors.New("engine entrypoint not wired")
+			}
+			return activeHooks.RunEngine(args)
 		},
 	}
 	return cmd

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,6 +52,8 @@ func newRoot() *cobra.Command {
 		newRestartCmd(),
 		newLogsCmd(),
 		newDaemonCmd(),
+		newServeCmd(),
+		newEngineCmd(),
 		newMonorepoCmd(),
 		newWatchCmd(),
 		newIndexCmd(),

--- a/internal/daemon/serve_engine_split_test.go
+++ b/internal/daemon/serve_engine_split_test.go
@@ -1,0 +1,104 @@
+package daemon_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestRunServe_MatchesDaemonInProcessWiring is the ADR-0024 Phase 1
+// behavior-preservation regression (epic #5729): `grafel daemon` and
+// `grafel serve` must be byte-for-byte behaviorally identical while the
+// serve/engine split capability flag (GRAFEL_SPLIT_MODE) is off, which is
+// the default. It starts an in-process daemon via daemon.RunServe — the
+// same call both the `serve` cobra command and the back-compat `daemon`
+// shim make — and asserts it:
+//   - binds the MCP dispatch socket exactly like daemon.Run,
+//   - starts the engine plane (here: the injected IndexFunc) in-process
+//     with no separate process required, and
+//   - answers a real MCP RPC round-trip (Ping, Status, Index), matching
+//     the assertions daemon_test.go already makes against daemon.Run.
+func TestRunServe_MatchesDaemonInProcessWiring(t *testing.T) {
+	layout := runServeForTest(t, func(args proto.IndexArgs) (string, string, error) {
+		return args.RepoPath + "/.grafel/graph.json", `{"ok":true}`, nil
+	}, nil)
+
+	c, err := client.DialPath(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+
+	if r, err := c.Ping(); err != nil || r.Version == "" {
+		t.Fatalf("ping: %v %+v", err, r)
+	}
+
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.PID == 0 || st.SocketPath != layout.SocketPath {
+		t.Fatalf("status looks wrong: %+v", st)
+	}
+
+	reply, err := c.Index(proto.IndexArgs{RepoPath: "/tmp/fake-repo"})
+	if err != nil {
+		t.Fatalf("index rpc: %v", err)
+	}
+	if reply.StatsJSON == "" {
+		t.Fatalf("index rpc returned empty stats — engine plane did not run in-process")
+	}
+}
+
+// TestRunEngine_StandaloneNotYetImplemented documents the deliberate Phase 1
+// scope boundary: `grafel engine` is wired as a hidden cobra subcommand and
+// EngineConfig exists, but daemon.RunEngine does not yet run a serve-free
+// engine-only process — that lands with PR2's actual process split. This
+// pins the current, honest behavior (a clear error, not a silent duplicate
+// daemon) so a future change to it is a deliberate, reviewed decision.
+func TestRunEngine_StandaloneNotYetImplemented(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	err := daemon.RunEngine(ctx, daemon.EngineConfig{})
+	if err == nil {
+		t.Fatal("expected RunEngine to report standalone-not-yet-implemented, got nil error")
+	}
+}
+
+// runServeForTest mirrors runDaemonForTest (daemon_test.go) but starts the
+// daemon via daemon.RunServe instead of daemon.Run, so tests in this file
+// exercise the exact entrypoint `grafel serve` / `grafel daemon` now use.
+func runServeForTest(t *testing.T, idx daemon.IndexFunc, rb daemon.RebuildFunc) daemon.Layout {
+	t.Helper()
+	isolateDaemonEnv(t)
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- daemon.RunServe(ctx, daemon.ServeConfig{Config: daemon.Config{
+			Layout:  layout,
+			Index:   idx,
+			Rebuild: rb,
+		}})
+	}()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Logf("RunServe did not exit within 3s")
+		}
+	})
+	waitDaemonReady(t, layout.SocketPath, 10*time.Second)
+	return layout
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -262,6 +262,82 @@ type Config struct {
 	OnSchedulerReady func(warming func() WarmingSnapshot)
 }
 
+// SplitModeEnvVar names the capability flag that gates the serve/engine
+// process split (ADR-0024, epic #5729). Default OFF: RunServe runs the
+// entire daemon in-process — identical to today's Run — and does not spawn
+// a separate `grafel engine` child. PR2 will flip the ON branch of RunServe
+// to spawn and supervise a real engine child process instead of running the
+// engine plane inline.
+const SplitModeEnvVar = "GRAFEL_SPLIT_MODE"
+
+// SplitModeEnabled reports whether the serve/engine process-split
+// capability flag is turned on. See SplitModeEnvVar. Defaults to false
+// (single-process, today's behavior) so this PR (the entrypoint/config
+// carve) makes no behavior change.
+func SplitModeEnabled() bool {
+	v := strings.TrimSpace(os.Getenv(SplitModeEnvVar))
+	return v == "1" || strings.EqualFold(v, "true")
+}
+
+// ServeConfig is the serve-plane configuration (ADR-0024 Phase 1): the MCP
+// dispatch socket, the dashboard, and graph_cache mmap reads. It currently
+// composes the entire Config rather than a disjoint field set because,
+// while SplitModeEnabled() is false (the default), RunServe must start the
+// engine plane IN-PROCESS exactly as Run does today — it needs every
+// engine-plane field (scheduler, watcher, extraction, fbwriter hooks) to do
+// so. PR2 narrows ServeConfig to serve-only fields once the engine plane is
+// actually spawned as a separate child process instead of run inline.
+type ServeConfig struct {
+	Config
+}
+
+// EngineConfig is the engine-plane configuration (ADR-0024 Phase 1): the
+// scheduler, file watcher, extraction, and fbwriter. See ServeConfig's doc
+// for why it currently composes the full Config rather than a disjoint
+// subset — that split lands in PR2 alongside the real process spawn.
+type EngineConfig struct {
+	Config
+}
+
+// RunServe starts the serve plane: the MCP socket, the dashboard, and,
+// while SplitModeEnabled() is false (the default), the engine plane
+// in-process — byte-for-byte identical to Run. It is the implementation
+// behind both the `grafel serve` subcommand and the back-compat `grafel
+// daemon` shim, so an existing OS unit that still execs `daemon`
+// transparently becomes a serve process with zero client-visible change.
+//
+// This PR (the ADR-0024 Phase 1 entrypoint/config carve) does not yet spawn
+// a child process on the SplitModeEnabled()==true branch — both branches
+// call Run today. PR2 will replace the true branch with starting only the
+// serve-plane pieces here and spawning/supervising a `grafel engine` child
+// for the rest, without changing RunServe's signature or callers.
+func RunServe(ctx context.Context, cfg ServeConfig) error {
+	if SplitModeEnabled() {
+		// PR2 seam: spawn/supervise a `grafel engine` child here instead of
+		// running the engine plane inline. Until that lands, behavior is
+		// identical to the flag-off path.
+		return Run(ctx, cfg.Config)
+	}
+	return Run(ctx, cfg.Config)
+}
+
+// RunEngine starts the engine plane standalone: the scheduler, watcher,
+// extraction, and fbwriter, without the MCP socket or dashboard. ADR-0024
+// Phase 1 (this PR) wires the `grafel engine` entrypoint and the
+// EngineConfig type but does not yet carve Run's internals into a
+// serve-free engine-only code path — that lands with PR2's actual process
+// split. Until then, RunEngine deliberately refuses to run standalone
+// (rather than silently starting a full duplicate daemon under the
+// "engine" name), since SplitModeEnabled() is off by default and no
+// caller in this PR relies on RunEngine actually serving anything.
+func RunEngine(ctx context.Context, cfg EngineConfig) error {
+	_ = ctx
+	_ = cfg
+	return fmt.Errorf("grafel engine: standalone engine process not yet implemented " +
+		"(ADR-0024 Phase 1 is the entrypoint/config carve only; the process split " +
+		"lands in PR2, epic #5729)")
+}
+
 // Run starts the daemon. It blocks until either:
 //   - the Service receives Stop,
 //   - the process receives SIGTERM/SIGINT, or


### PR DESCRIPTION
**PR1 of the serve/engine split (ADR-0024, epic #5729).** Pure entrypoint/config carve with ZERO behavior change — the foundation the rest of the split builds on.

- Adds hidden `grafel serve` / `grafel engine` cobra commands + `RunServe`/`RunEngine` hooks; `grafel daemon` becomes a back-compat shim that routes through `RunServe`.
- Splits `daemon.Config` into embedded `ServeConfig`/`EngineConfig` (composition; no field narrowing yet) and carves `daemon.Run` into `RunServe`/`RunEngine`.
- `runDaemon` body factored into a shared `runDaemonMode(argv, runMode)` so the entire runtime-tune + config-assembly prelude stays verbatim; the three wrappers dispatch at the last step only.
- Capability flag `GRAFEL_SPLIT_MODE` (default OFF = single-process, today's behavior). `RunServe`'s ON branch is currently identical to OFF; `RunEngine` returns an explicit "not yet implemented (PR2)" error rather than silently duplicating a daemon.

**Behavior-preservation is the invariant:** existing daemon/cli/cmd tests pass UNCHANGED (no assertion weakened), `-race` clean, binary smoke-tested (`grafel daemon` starts/serves/shuts down identically; `grafel engine` errors cleanly). New `serve_engine_split_test.go` asserts `RunServe` ≡ `daemon.Run` wiring (socket bind + Ping/Status/Index RPC parity).

Independent Opus review APPROVE: flag-off path behaviorally identical verbatim; carve clean for PR2.

Refs #5729