### PR TITLE
fix(sched): reindex circuit-breaker so an over-2GiB repo stops hot-looping (refs #5726)

### DIFF
--- a/internal/daemon/sched/circuitbreaker_5726_test.go
+++ b/internal/daemon/sched/circuitbreaker_5726_test.go
@@ -11,22 +11,40 @@ package sched
 // immediately. The original #5726 report showed the panic logged 74x in
 // daemon.err, evidence of exactly this hot loop.
 //
-// This test proves the breaker: N rapid same-ref re-triggers after a failure
-// collapse into 1 real attempt (the rest are skipped, serving last-good,
-// during the backoff window), and a target-commit CHANGE resets the guard so
-// the new commit always gets a real attempt.
+// These tests drive the REAL production trigger path (Enqueue → RefCapture),
+// which always yields a CONSTANT branch name across same-branch commits and a
+// SHA that changes per commit. That is exactly why the breaker must key on the
+// commit SHA, not the branch ref: a fix commit on the same branch keeps the
+// name but changes the SHA (breaker must reset), and a detached HEAD has an
+// empty name but a valid SHA (breaker must still gate).
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func TestReindexCircuitBreaker_SameRefSkipsRepeatedFailures(t *testing.T) {
+// TestReindexCircuitBreaker_SameCommitSkips_NewCommitResets drives the
+// production Enqueue→RefCapture flow: the branch NAME is constant ("main")
+// throughout; only the commit SHA changes. This is the case the branch-name
+// keyed breaker got wrong — a same-branch fix commit would be skipped until
+// the backoff expired.
+func TestReindexCircuitBreaker_SameCommitSkips_NewCommitResets(t *testing.T) {
 	var calls atomic.Int32
+
+	var mu sync.Mutex
+	ref := "main" // CONSTANT branch name — never changes, exactly as production
+	sha := "sha-aaaaaaaaaaaa"
+
 	s := New(Config{
 		Workers: 1,
+		RefCapture: func(_ string) (string, string) {
+			mu.Lock()
+			defer mu.Unlock()
+			return ref, sha
+		},
 		Index: func(_ context.Context, _ string, _ string) error {
 			calls.Add(1)
 			return errBoom5726
@@ -35,33 +53,76 @@ func TestReindexCircuitBreaker_SameRefSkipsRepeatedFailures(t *testing.T) {
 	s.Start()
 	defer s.Stop()
 
-	// First trigger at commit "sha1": a real attempt, which fails and arms
-	// the breaker for ("/big", "sha1").
-	s.EnqueueRef("/big", "sha1")
+	// First trigger at commit sha-aaa: a real attempt, which fails and arms
+	// the breaker for that commit.
+	s.Enqueue("/big")
 	time.Sleep(150 * time.Millisecond)
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("expected exactly 1 real attempt for the first trigger, got %d", got)
 	}
 
-	// N rapid re-triggers at the SAME ref while the failure is fresh (well
+	// N rapid re-triggers at the SAME commit while the failure is fresh (well
 	// inside the 30s base backoff window). Without the breaker, every one of
 	// these re-attempts the doomed marshal — the #5726 hot loop. With the
 	// breaker, they must all be skipped: calls stays at 1.
 	for i := 0; i < 10; i++ {
-		s.EnqueueRef("/big", "sha1")
+		s.Enqueue("/big")
 		time.Sleep(30 * time.Millisecond)
 	}
 	if got := calls.Load(); got != 1 {
-		t.Errorf("breaker did not hold: expected calls to stay at 1 after 10 same-ref re-triggers, got %d (hot loop not bounded)", got)
+		t.Errorf("breaker did not hold: expected calls to stay at 1 after 10 same-commit re-triggers, got %d (hot loop not bounded)", got)
 	}
 
-	// A trigger at a DIFFERENT ref (new commit / legitimately new content)
-	// must always get a fresh real attempt — the breaker resets per-commit,
-	// it does not permanently wedge the repo.
-	s.EnqueueRef("/big", "sha2")
+	// A NEW commit on the SAME branch (developer commits a fix; RefCapture
+	// still reports ref="main" but a fresh SHA) must get a real attempt — the
+	// breaker resets per-commit, not per-branch. A branch-name-keyed breaker
+	// would wrongly skip this until the backoff window expired.
+	mu.Lock()
+	sha = "sha-bbbbbbbbbbbb"
+	mu.Unlock()
+	s.Enqueue("/big")
 	time.Sleep(150 * time.Millisecond)
 	if got := calls.Load(); got != 2 {
-		t.Errorf("expected a commit change to reset the breaker and trigger exactly 1 more real attempt, got %d total calls", got)
+		t.Errorf("expected a new commit on the same branch to reset the breaker and trigger exactly 1 more real attempt, got %d total calls", got)
+	}
+}
+
+// TestReindexCircuitBreaker_DetachedHeadGatesBySHA covers the gap the
+// branch-name keyed breaker left wide open: a detached HEAD (or any state
+// where RefCapture yields an EMPTY ref but a valid SHA). The old breaker
+// required a non-empty ref to gate, so the hot loop recurred unbounded — the
+// exact failure mode this PR exists to prevent. Keying on the SHA closes it.
+func TestReindexCircuitBreaker_DetachedHeadGatesBySHA(t *testing.T) {
+	var calls atomic.Int32
+
+	s := New(Config{
+		Workers: 1,
+		RefCapture: func(_ string) (string, string) {
+			// Detached HEAD: no branch name, but a perfectly good commit SHA.
+			return "", "detached-sha-1"
+		},
+		Index: func(_ context.Context, _ string, _ string) error {
+			calls.Add(1)
+			return errBoom5726
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	// First real attempt fails and arms the breaker keyed on the SHA.
+	s.Enqueue("/detached")
+	time.Sleep(150 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 real attempt for the first trigger, got %d", got)
+	}
+
+	// Rapid re-triggers with the same (empty ref, same SHA) must be skipped.
+	for i := 0; i < 10; i++ {
+		s.Enqueue("/detached")
+		time.Sleep(30 * time.Millisecond)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("detached-HEAD breaker did not gate by SHA: expected calls to stay at 1, got %d (empty ref must not disable the breaker)", got)
 	}
 }
 

--- a/internal/daemon/sched/circuitbreaker_5726_test.go
+++ b/internal/daemon/sched/circuitbreaker_5726_test.go
@@ -1,0 +1,72 @@
+package sched
+
+// Issue #5726 / epic #5729 — reindex circuit breaker.
+//
+// A repo genuinely over the FlatBuffers 2-GiB builder cap fails the SAME way
+// on every attempt at the SAME target commit: fbwriter's fail-soft path
+// (internal/graph/fbwriter/streaming.go) recovers the marshal panic and
+// leaves last-good graph.fb intact, but the scheduler's trigger conditions
+// (watcher fs events, git-HEAD poll) are input-driven and unaware of the
+// failure — any further churn at the same commit re-fires a doomed reindex
+// immediately. The original #5726 report showed the panic logged 74x in
+// daemon.err, evidence of exactly this hot loop.
+//
+// This test proves the breaker: N rapid same-ref re-triggers after a failure
+// collapse into 1 real attempt (the rest are skipped, serving last-good,
+// during the backoff window), and a target-commit CHANGE resets the guard so
+// the new commit always gets a real attempt.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestReindexCircuitBreaker_SameRefSkipsRepeatedFailures(t *testing.T) {
+	var calls atomic.Int32
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, _ string, _ string) error {
+			calls.Add(1)
+			return errBoom5726
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	// First trigger at commit "sha1": a real attempt, which fails and arms
+	// the breaker for ("/big", "sha1").
+	s.EnqueueRef("/big", "sha1")
+	time.Sleep(150 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 real attempt for the first trigger, got %d", got)
+	}
+
+	// N rapid re-triggers at the SAME ref while the failure is fresh (well
+	// inside the 30s base backoff window). Without the breaker, every one of
+	// these re-attempts the doomed marshal — the #5726 hot loop. With the
+	// breaker, they must all be skipped: calls stays at 1.
+	for i := 0; i < 10; i++ {
+		s.EnqueueRef("/big", "sha1")
+		time.Sleep(30 * time.Millisecond)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Errorf("breaker did not hold: expected calls to stay at 1 after 10 same-ref re-triggers, got %d (hot loop not bounded)", got)
+	}
+
+	// A trigger at a DIFFERENT ref (new commit / legitimately new content)
+	// must always get a fresh real attempt — the breaker resets per-commit,
+	// it does not permanently wedge the repo.
+	s.EnqueueRef("/big", "sha2")
+	time.Sleep(150 * time.Millisecond)
+	if got := calls.Load(); got != 2 {
+		t.Errorf("expected a commit change to reset the breaker and trigger exactly 1 more real attempt, got %d total calls", got)
+	}
+}
+
+var errBoom5726 = &staticErr{"fbwriter: graph too large to serialize: simulated 2-GiB marshal panic (#5726)"}
+
+type staticErr struct{ msg string }
+
+func (e *staticErr) Error() string { return e.msg }

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -64,12 +64,17 @@ import (
 // should fall back to gitmeta.Capture(repoPath) if they need it.
 type IndexFn func(ctx context.Context, repoPath string, ref string) error
 
-// RefCaptureFn returns the current HEAD ref for repoPath. Used to snapshot
-// the ref at Enqueue time so debounced batches index against the ref that
-// was active when the file-change event fired, not the ref at dispatch time.
-// May return "" for detached HEAD or non-git directories; IndexFn must
-// tolerate an empty ref.
-type RefCaptureFn func(repoPath string) string
+// RefCaptureFn returns the current HEAD ref AND commit SHA for repoPath. Used
+// to snapshot both at Enqueue time so debounced batches index against the ref
+// that was active when the file-change event fired, not the ref at dispatch
+// time. The commit SHA is the stable per-commit identity the #5726/#5729
+// reindex circuit breaker keys on (the branch NAME is not — a fix commit on
+// the same branch keeps the same name yet must reset the breaker, and a
+// detached HEAD has an empty name but a perfectly good SHA).
+//
+// ref may be "" for a detached HEAD or non-git directory; commit may be "" for
+// a non-git directory. IndexFn must tolerate an empty ref.
+type RefCaptureFn func(repoPath string) (ref, commit string)
 
 // LinksFn re-runs the cross-repo link passes for a group.
 type LinksFn func(ctx context.Context, group string) error
@@ -340,6 +345,7 @@ func reindexFailBackoff(n int) time.Duration {
 type enqueueRequest struct {
 	repoPath string
 	ref      string // captured at Enqueue time via RefCapture; "" = unknown
+	commit   string // commit SHA captured alongside ref; breaker identity (#5726)
 }
 
 // Scheduler is constructed once per daemon. It owns:
@@ -385,13 +391,14 @@ type Scheduler struct {
 	// no lost update (the marker is set AFTER the run snapshots its input, so
 	// a change landing mid-run still triggers the follow-up). N events during
 	// a reindex → 1 follow-up, not N. Guarded by mu.
-	dirty       map[string]bool
-	pendingRefs map[string]string // repo → ref captured at last Enqueue (overwritten on re-enqueue)
-	pendingQ    []string          // ordered admission queue
-	queueLen    int               // pending + admitted-but-not-yet-running
-	usedMB      int64             // sum of inflight MB
-	linkTimers  map[string]*time.Timer
-	linkPending map[string]bool
+	dirty          map[string]bool
+	pendingRefs    map[string]string // repo → ref captured at last Enqueue (overwritten on re-enqueue)
+	pendingCommits map[string]string // repo → commit SHA captured at last Enqueue (mirrors pendingRefs; breaker identity #5726)
+	pendingQ       []string          // ordered admission queue
+	queueLen       int               // pending + admitted-but-not-yet-running
+	usedMB         int64             // sum of inflight MB
+	linkTimers     map[string]*time.Timer
+	linkPending    map[string]bool
 	// Per-GROUP algorithm pass (#5349 A3). Mirrors the link timer machinery:
 	// debounce timer + pending flag + in-flight cancel func, all keyed by group.
 	// Replaces the old per-repo algo timers — algorithms now run once over the
@@ -436,6 +443,7 @@ type Scheduler struct {
 type jobToken struct {
 	repoPath    string
 	ref         string // git ref name captured at Enqueue time; "" = unknown
+	commit      string // commit SHA captured at Enqueue time; breaker identity (#5726); "" = non-git
 	predictedMB int64
 }
 
@@ -455,15 +463,18 @@ type repoStats struct {
 	// completes in this daemon's lifetime.
 	LastIndexedRef string
 
-	// FailRef/FailCount/FailBackoffUntil/FailLoggedAt implement the
-	// #5726/#5729 reindex circuit breaker. FailRef is the ref a same-target
-	// reindex attempt most recently failed at; FailCount counts consecutive
-	// failures at that ref (drives exponential backoff via
-	// reindexFailBackoff); FailBackoffUntil is when the breaker next allows a
-	// real attempt at FailRef; FailLoggedAt debounces the skip-log line to at
-	// most once per backoff window. A successful index, or a trigger for a
-	// DIFFERENT ref, resets all four fields.
-	FailRef          string
+	// FailCommit/FailCount/FailBackoffUntil/FailLoggedAt implement the
+	// #5726/#5729 reindex circuit breaker. FailCommit is the commit SHA a
+	// same-target reindex attempt most recently failed at (SHA, NOT branch
+	// name: a fix commit on the same branch keeps the branch name but changes
+	// the SHA, which must reset the breaker; a detached HEAD has no branch name
+	// but a valid SHA). FailCount counts consecutive failures at that commit
+	// (drives exponential backoff via reindexFailBackoff); FailBackoffUntil is
+	// when the breaker next allows a real attempt at FailCommit; FailLoggedAt
+	// debounces the skip-log line to at most once per backoff window. A
+	// successful index, or a trigger for a DIFFERENT commit, resets all four
+	// fields.
+	FailCommit       string
 	FailCount        int
 	FailBackoffUntil time.Time
 	FailLoggedAt     time.Time
@@ -544,6 +555,7 @@ func New(cfg Config) *Scheduler {
 		pendingIndex:     map[string]bool{},
 		dirty:            map[string]bool{},
 		pendingRefs:      map[string]string{},
+		pendingCommits:   map[string]string{},
 		linkTimers:       map[string]*time.Timer{},
 		linkPending:      map[string]bool{},
 		groupAlgoTimers:  map[string]*time.Timer{},
@@ -617,18 +629,29 @@ func (s *Scheduler) Stop() {
 // the ref is snapshotted at event-fire time, not at eventual dispatch time.
 // Safe to call from arbitrary goroutines.
 func (s *Scheduler) Enqueue(repoPath string) {
-	ref := ""
+	ref, commit := "", ""
 	if s.cfg.RefCapture != nil {
-		ref = s.cfg.RefCapture(repoPath)
+		ref, commit = s.cfg.RefCapture(repoPath)
 	}
-	s.EnqueueRef(repoPath, ref)
+	s.EnqueueRefCommit(repoPath, ref, commit)
 }
 
 // EnqueueRef requests a (debounced+deduped) reindex of repoPath at a
-// specific git ref. Called directly by the GitHeadPoller (branch-switch
-// events) where the new ref has already been observed — no extra git call
-// needed. Safe to call from arbitrary goroutines.
+// specific git ref, with no commit SHA. Retained for callers (and tests) that
+// only have a ref; the #5726 circuit breaker keys on the commit SHA, so an
+// EnqueueRef job carries an empty commit identity. Prefer EnqueueRefCommit on
+// paths where the SHA is known (the GitHeadPoller has it as ev.NewSHA).
 func (s *Scheduler) EnqueueRef(repoPath, ref string) {
+	s.EnqueueRefCommit(repoPath, ref, "")
+}
+
+// EnqueueRefCommit requests a (debounced+deduped) reindex of repoPath at a
+// specific git ref and commit SHA. Called directly by the GitHeadPoller
+// (branch-switch events) where both the new ref and SHA have already been
+// observed — no extra git call needed. The commit SHA is the identity the
+// #5726/#5729 reindex circuit breaker gates on. Safe to call from arbitrary
+// goroutines.
+func (s *Scheduler) EnqueueRefCommit(repoPath, ref, commit string) {
 	// Issue #3680: drop enqueues for linked worktrees of already-indexed
 	// primaries so they never become independent root index jobs (each of
 	// which would spawn its own ~100MB store and pressure the RSS budget).
@@ -637,7 +660,7 @@ func (s *Scheduler) EnqueueRef(repoPath, ref string) {
 		return
 	}
 	select {
-	case s.enq <- enqueueRequest{repoPath: repoPath, ref: ref}:
+	case s.enq <- enqueueRequest{repoPath: repoPath, ref: ref, commit: commit}:
 	case <-s.stop:
 	}
 }
@@ -675,20 +698,27 @@ func (s *Scheduler) dedupLoop() {
 				if req.ref != "" {
 					s.pendingRefs[p] = req.ref
 				}
+				if req.commit != "" {
+					s.pendingCommits[p] = req.commit
+				}
 				s.publishRepoStatesLocked() // #5433: repo just went dirty.
 				s.mu.Unlock()
 				continue
 			}
 			if s.pendingIndex[p] {
-				// Already pending: update the ref to the latest observed value.
+				// Already pending: update the ref/commit to the latest observed.
 				if req.ref != "" {
 					s.pendingRefs[p] = req.ref
+				}
+				if req.commit != "" {
+					s.pendingCommits[p] = req.commit
 				}
 				s.mu.Unlock()
 				continue
 			}
 			s.pendingIndex[p] = true
 			s.pendingRefs[p] = req.ref
+			s.pendingCommits[p] = req.commit
 			s.pendingQ = append(s.pendingQ, p)
 			s.queueLen++
 			// Start the dead-man clock if nothing is currently
@@ -786,9 +816,11 @@ func (s *Scheduler) checkDeadMan() {
 	}
 	repo := s.pendingQ[smallestIdx]
 	ref := s.pendingRefs[repo]
+	commit := s.pendingCommits[repo]
 	// Remove from queue (preserve order for remaining entries).
 	s.pendingQ = append(s.pendingQ[:smallestIdx], s.pendingQ[smallestIdx+1:]...)
 	delete(s.pendingRefs, repo)
+	delete(s.pendingCommits, repo)
 	s.inflight[repo] = smallestMB
 	s.publishIndexStateLocked()
 	s.usedMB += smallestMB
@@ -799,7 +831,7 @@ func (s *Scheduler) checkDeadMan() {
 	s.logger.Info("sched: dead-man: force-admitting",
 		"repo", repo, "predicted_mb", smallestMB, "stuck_for", stuckFor)
 
-	tok := jobToken{repoPath: repo, ref: ref, predictedMB: smallestMB}
+	tok := jobToken{repoPath: repo, ref: ref, commit: commit, predictedMB: smallestMB}
 	// Dispatch asynchronously so we don't hold the lock while blocking on
 	// the jobs channel. The worker pool is guaranteed to drain the channel
 	// because the pool size >= 1.
@@ -1056,6 +1088,7 @@ func (s *Scheduler) tryAdmit() {
 	for len(s.pendingQ) > 0 {
 		repo := s.pendingQ[0]
 		ref := s.pendingRefs[repo]
+		commit := s.pendingCommits[repo]
 		predicted := s.predictedFor(repo)
 		// Admission rule.
 		if s.cfg.BudgetMB > 0 {
@@ -1077,13 +1110,14 @@ func (s *Scheduler) tryAdmit() {
 		// Pop and dispatch.
 		s.pendingQ = s.pendingQ[1:]
 		delete(s.pendingRefs, repo)
+		delete(s.pendingCommits, repo)
 		s.inflight[repo] = predicted
 		s.publishIndexStateLocked()
 		s.usedMB += predicted
 		s.deadManAt = time.Time{} // job admitted — reset dead-man clock
 		s.logEventLocked("admit_ok", repo,
 			"predicted="+formatMB(predicted)+" used="+formatMB(s.usedMB)+" ref="+ref)
-		tok := jobToken{repoPath: repo, ref: ref, predictedMB: predicted}
+		tok := jobToken{repoPath: repo, ref: ref, commit: commit, predictedMB: predicted}
 		s.mu.Unlock()
 		// Block on jobs channel — workers are sized to drain this
 		// without deadlock because admission already ensures we are
@@ -1152,18 +1186,27 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	delete(s.dirty, repoPath)
 
 	// #5726/#5729 circuit breaker: a repo genuinely over the FlatBuffers
-	// 2-GiB cap fails the SAME way on every attempt at the SAME target ref —
-	// the fbwriter fail-soft path recovers the marshal panic but leaves the
-	// input state (watcher fs events, git-HEAD poll) unaware of the failure,
-	// so any further churn at the same commit re-fires a doomed reindex
-	// immediately. If the breaker is open for this exact ref, skip the real
-	// attempt (serve last-good graph.fb) instead of re-marshaling.
+	// 2-GiB cap fails the SAME way on every attempt at the SAME COMMIT — the
+	// fbwriter fail-soft path recovers the marshal panic but leaves the input
+	// state (watcher fs events, git-HEAD poll) unaware of the failure, so any
+	// further working-tree churn at the same commit re-fires a doomed reindex
+	// immediately. The breaker gates on the commit SHA (tok.commit), which is
+	// stable across same-commit churn (hot-loop bounded) yet changes on every
+	// new commit (a fix commit resets it immediately) and is present for a
+	// detached HEAD (the branch name is not). If the breaker is open for this
+	// exact commit, skip the real attempt (serve last-good graph.fb) instead
+	// of re-marshaling.
 	breakerStats := s.indexedRepos[repoPath]
 	now := time.Now()
-	skip := tok.ref != "" && breakerStats.FailRef == tok.ref && now.Before(breakerStats.FailBackoffUntil)
+	skip := breakerStats.FailCommit == tok.commit && now.Before(breakerStats.FailBackoffUntil)
 	shouldLogSkip := false
 	if skip {
-		shouldLogSkip = breakerStats.FailLoggedAt.IsZero() || now.Sub(breakerStats.FailLoggedAt) >= reindexFailBackoffBase
+		// Log at most once per backoff window (tracking the actual window for
+		// the current fail count, not a fixed interval), so a repo hot-looping
+		// at the cap produces a handful of lines instead of the 74x storm the
+		// breaker exists to prevent.
+		window := reindexFailBackoff(breakerStats.FailCount)
+		shouldLogSkip = breakerStats.FailLoggedAt.IsZero() || now.Sub(breakerStats.FailLoggedAt) >= window
 		if shouldLogSkip {
 			breakerStats.FailLoggedAt = now
 			s.indexedRepos[repoPath] = breakerStats
@@ -1177,13 +1220,13 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	var observedPeakMB int64
 
 	if skip {
-		err = fmt.Errorf("reindex circuit open: %d consecutive failure(s) at ref %q, retrying after backoff (#5726/#5729)", breakerStats.FailCount, tok.ref)
+		err = fmt.Errorf("reindex circuit open: %d consecutive failure(s) at commit %q, retrying after backoff (#5726/#5729)", breakerStats.FailCount, tok.commit)
 		if shouldLogSkip {
 			s.logEvent("index_circuit_skip", repoPath,
-				fmt.Sprintf("skipping reindex — %d consecutive failures at ref=%s, serving last-good graph, backoff until %s (#5726/#5729)",
-					breakerStats.FailCount, tok.ref, breakerStats.FailBackoffUntil.Format(time.RFC3339)))
+				fmt.Sprintf("skipping reindex — %d consecutive failures at commit=%s (ref=%s), serving last-good graph, backoff until %s (#5726/#5729)",
+					breakerStats.FailCount, tok.commit, tok.ref, breakerStats.FailBackoffUntil.Format(time.RFC3339)))
 			s.logger.Warn("sched: reindex circuit open — skipping repeated-failure reindex, serving last-good graph",
-				"repo", repoPath, "ref", tok.ref, "fail_count", breakerStats.FailCount,
+				"repo", repoPath, "commit", tok.commit, "ref", tok.ref, "fail_count", breakerStats.FailCount,
 				"backoff_until", breakerStats.FailBackoffUntil)
 		}
 	} else {
@@ -1291,12 +1334,12 @@ func (s *Scheduler) runIndex(tok jobToken) {
 		stats.LastErr = err.Error()
 		if !skip {
 			// A real attempt failed: bump (or start) the breaker for this
-			// ref and arm exponential backoff. A skip does not re-bump —
+			// commit and arm exponential backoff. A skip does not re-bump —
 			// the failure it reflects was already recorded.
-			if stats.FailRef == tok.ref {
+			if stats.FailCommit == tok.commit {
 				stats.FailCount++
 			} else {
-				stats.FailRef = tok.ref
+				stats.FailCommit = tok.commit
 				stats.FailCount = 1
 				stats.FailLoggedAt = time.Time{}
 			}
@@ -1305,9 +1348,9 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	} else {
 		stats.LastErr = ""
 		// Success resets the breaker entirely — including for a DIFFERENT
-		// ref than FailRef, which is already implied since a fresh ref
-		// never matched the open breaker in the first place.
-		stats.FailRef = ""
+		// commit than FailCommit, which is already implied since a fresh
+		// commit never matched the open breaker in the first place.
+		stats.FailCommit = ""
 		stats.FailCount = 0
 		stats.FailBackoffUntil = time.Time{}
 		stats.FailLoggedAt = time.Time{}
@@ -1331,19 +1374,26 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	if followUp {
 		delete(s.dirty, repoPath)
 	}
-	// Prefer the latest observed ref recorded while dirty; fall back to the
-	// ref this run used. dedupLoop overwrites pendingRefs[repoPath] on every
-	// mid-run enqueue, so it holds the most recent branch for the follow-up.
+	// Prefer the latest observed ref/commit recorded while dirty; fall back to
+	// the values this run used. dedupLoop overwrites pendingRefs/pendingCommits
+	// on every mid-run enqueue, so they hold the most recent branch + commit
+	// for the follow-up (the commit is the breaker identity, so it must ride
+	// along too — otherwise a same-commit follow-up would carry an empty commit
+	// and bypass the breaker).
 	followUpRef := tok.ref
 	if r, ok := s.pendingRefs[repoPath]; ok && r != "" {
 		followUpRef = r
+	}
+	followUpCommit := tok.commit
+	if c, ok := s.pendingCommits[repoPath]; ok && c != "" {
+		followUpCommit = c
 	}
 	s.mu.Unlock()
 
 	if followUp {
 		s.logEvent("reindex_coalesced_followup", repoPath,
 			"changes landed during in-flight reindex — scheduling single follow-up (#5138)")
-		s.EnqueueRef(repoPath, followUpRef)
+		s.EnqueueRefCommit(repoPath, followUpRef, followUpCommit)
 	}
 
 	// History persistence happens outside the lock (its own mutex +
@@ -1764,6 +1814,14 @@ func (s *Scheduler) MarkIndexed(repoPath string, err error) {
 		stats.LastErr = err.Error()
 	} else {
 		stats.LastErr = ""
+		// #5726/#5729: an explicit `grafel index` RPC that succeeds means the
+		// repo now serializes under the cap (e.g. the developer removed a huge
+		// vendored tree). Clear any scheduler-armed breaker so a subsequent
+		// watcher reindex is not skipped by a stale backoff window.
+		stats.FailCommit = ""
+		stats.FailCount = 0
+		stats.FailBackoffUntil = time.Time{}
+		stats.FailLoggedAt = time.Time{}
 	}
 	s.indexedRepos[repoPath] = stats
 }

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -298,6 +298,42 @@ const memReleaseDebounceDefault = 30 * time.Second
 // is fine; the actual FreeOSMemory call is gated by the debounce above.
 const memReleaseTick = 5 * time.Second
 
+// reindexFailBackoffBase and reindexFailBackoffMax bound the #5726/#5729
+// per-repo reindex circuit breaker. A repo genuinely over the FlatBuffers
+// 2-GiB builder cap fails the SAME way on every attempt at the SAME commit
+// (the fbwriter fail-soft path — internal/graph/fbwriter/streaming.go —
+// recovers the marshal panic and leaves last-good graph.fb intact, but the
+// trigger conditions (watcher fs events, git-HEAD poll) are input-driven and
+// unaware of the failure: any further churn at the same commit re-fires a
+// doomed reindex immediately, hot-looping the marshal attempt forever
+// (observed as the panic logged 74x in daemon.err in #5726). The breaker
+// skips same-ref re-attempts with exponential backoff instead, and resets the
+// moment the target ref changes (a new commit deserves a real try).
+const (
+	reindexFailBackoffBase = 30 * time.Second
+	reindexFailBackoffMax  = 5 * time.Minute
+)
+
+// reindexFailBackoff returns the backoff duration for the nth consecutive
+// same-ref index failure (n=1 is the first failure). Doubles each additional
+// failure, capped at reindexFailBackoffMax.
+func reindexFailBackoff(n int) time.Duration {
+	if n < 1 {
+		n = 1
+	}
+	d := reindexFailBackoffBase
+	for i := 1; i < n; i++ {
+		d *= 2
+		if d >= reindexFailBackoffMax {
+			return reindexFailBackoffMax
+		}
+	}
+	if d > reindexFailBackoffMax {
+		return reindexFailBackoffMax
+	}
+	return d
+}
+
 // enqueueRequest carries a repo path plus the ref snapshot taken at
 // Enqueue time. This is the unit flowing from public Enqueue → dedupLoop →
 // admitLoop → workerLoop.
@@ -418,6 +454,19 @@ type repoStats struct {
 	// than the process-global is_indexing flag. Empty until a first index
 	// completes in this daemon's lifetime.
 	LastIndexedRef string
+
+	// FailRef/FailCount/FailBackoffUntil/FailLoggedAt implement the
+	// #5726/#5729 reindex circuit breaker. FailRef is the ref a same-target
+	// reindex attempt most recently failed at; FailCount counts consecutive
+	// failures at that ref (drives exponential backoff via
+	// reindexFailBackoff); FailBackoffUntil is when the breaker next allows a
+	// real attempt at FailRef; FailLoggedAt debounces the skip-log line to at
+	// most once per backoff window. A successful index, or a trigger for a
+	// DIFFERENT ref, resets all four fields.
+	FailRef          string
+	FailCount        int
+	FailBackoffUntil time.Time
+	FailLoggedAt     time.Time
 }
 
 // LogEntry is a single structured event captured for /status. Kept in
@@ -1101,112 +1150,167 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	// it AFTER the run instead would race: a change landing between the
 	// snapshot and the clear would be silently dropped.
 	delete(s.dirty, repoPath)
+
+	// #5726/#5729 circuit breaker: a repo genuinely over the FlatBuffers
+	// 2-GiB cap fails the SAME way on every attempt at the SAME target ref —
+	// the fbwriter fail-soft path recovers the marshal panic but leaves the
+	// input state (watcher fs events, git-HEAD poll) unaware of the failure,
+	// so any further churn at the same commit re-fires a doomed reindex
+	// immediately. If the breaker is open for this exact ref, skip the real
+	// attempt (serve last-good graph.fb) instead of re-marshaling.
+	breakerStats := s.indexedRepos[repoPath]
+	now := time.Now()
+	skip := tok.ref != "" && breakerStats.FailRef == tok.ref && now.Before(breakerStats.FailBackoffUntil)
+	shouldLogSkip := false
+	if skip {
+		shouldLogSkip = breakerStats.FailLoggedAt.IsZero() || now.Sub(breakerStats.FailLoggedAt) >= reindexFailBackoffBase
+		if shouldLogSkip {
+			breakerStats.FailLoggedAt = now
+			s.indexedRepos[repoPath] = breakerStats
+		}
+	}
 	s.mu.Unlock()
 
 	t0 := time.Now()
-	s.logEvent("index_start", repoPath, "predicted="+formatMB(tok.predictedMB)+" ref="+tok.ref)
-	// Observability: log goroutine identity + ref so concurrent-indexer
-	// regressions are diagnosable without a pprof trace (#2141).
-	s.logger.Info("indexer: starting", "repo", repoPath, "ref", tok.ref, "goroutine_id", goroutineID())
-
-	// Spawn RSS sampler so we capture the peak the daemon hit during
-	// this job. Records into history on completion.
-	sampleStop := make(chan struct{})
-	var sampleWG sync.WaitGroup
-	var observedPeakMB int64
-	sampleWG.Add(1)
-	go func() {
-		defer sampleWG.Done()
-		t := time.NewTicker(5 * time.Second)
-		defer t.Stop()
-		baseline := currentProcessRSSMB()
-		for {
-			select {
-			case <-sampleStop:
-				return
-			case <-t.C:
-				now := currentProcessRSSMB()
-				delta := now - baseline
-				if delta > observedPeakMB {
-					observedPeakMB = delta
-				}
-			}
-		}
-	}()
-
-	// S3: attempt incremental file-level reindex before the full index.
-	// Only tried when the Incremental callback is configured AND the
-	// incremental toggle is active.
-	//
-	// Issue #2397: consult s.cfg.ExtractorConfig.IsIncrementalEnabled()
-	// (single source of truth) instead of the private incrementalEnabled()
-	// helper that read GRAFEL_INCREMENTAL_REINDEX directly. The nil-
-	// receiver method falls through to the env-var for backward compat.
-	//
-	// On success (res.Done=true) we skip the full reindex.
-	// On fallback (res.Done=false) we log the reason and fall through normally.
-	// Use shutdownCtx for all child-process-spawning calls so that when
-	// Stop() is called (daemon SIGTERM/SIGINT/Stop-RPC), any in-flight
-	// subprocess indexer receives SIGTERM via exec.CommandContext and the
-	// daemon can exit cleanly without leaving zombie processes (issue #2176).
-	jobCtx := s.shutdownCtx
 
 	var err error
-	incrementalDone := false
-	// Issue #5726 / epic #5729 — defense in depth. An index can panic for
-	// reasons the fbwriter fail-soft doesn't catch (e.g. a flatbuffers 2-GiB
-	// abort raised inside the streaming WriteEntity path, or any other bug in
-	// an extractor). A panic here would unwind through the worker goroutine and
-	// abort the ENTIRE daemon (launchd relaunches it → 60–90s reindex outage,
-	// every MCP bridge severed). Recover so ANY index panic becomes a normal
-	// error: the worker keeps serving, the reserved budget is released via the
-	// existing err path below, and we log a clear degraded-state message.
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				err = fmt.Errorf("index panicked (recovered): %v", r)
-				s.logEvent("index_panic", repoPath, fmt.Sprintf("recovered panic during index: %v", r))
-				s.logger.Error("sched: index panicked — recovered; daemon continues in degraded state (repo left at last-good graph)",
-					"repo", repoPath, "ref", tok.ref, "panic", r, "stack", string(debug.Stack()))
+	var observedPeakMB int64
+
+	if skip {
+		err = fmt.Errorf("reindex circuit open: %d consecutive failure(s) at ref %q, retrying after backoff (#5726/#5729)", breakerStats.FailCount, tok.ref)
+		if shouldLogSkip {
+			s.logEvent("index_circuit_skip", repoPath,
+				fmt.Sprintf("skipping reindex — %d consecutive failures at ref=%s, serving last-good graph, backoff until %s (#5726/#5729)",
+					breakerStats.FailCount, tok.ref, breakerStats.FailBackoffUntil.Format(time.RFC3339)))
+			s.logger.Warn("sched: reindex circuit open — skipping repeated-failure reindex, serving last-good graph",
+				"repo", repoPath, "ref", tok.ref, "fail_count", breakerStats.FailCount,
+				"backoff_until", breakerStats.FailBackoffUntil)
+		}
+	} else {
+		s.logEvent("index_start", repoPath, "predicted="+formatMB(tok.predictedMB)+" ref="+tok.ref)
+		// Observability: log goroutine identity + ref so concurrent-indexer
+		// regressions are diagnosable without a pprof trace (#2141).
+		s.logger.Info("indexer: starting", "repo", repoPath, "ref", tok.ref, "goroutine_id", goroutineID())
+
+		// Spawn RSS sampler so we capture the peak the daemon hit during
+		// this job. Records into history on completion.
+		sampleStop := make(chan struct{})
+		var sampleWG sync.WaitGroup
+		sampleWG.Add(1)
+		go func() {
+			defer sampleWG.Done()
+			t := time.NewTicker(5 * time.Second)
+			defer t.Stop()
+			baseline := currentProcessRSSMB()
+			for {
+				select {
+				case <-sampleStop:
+					return
+				case <-t.C:
+					now := currentProcessRSSMB()
+					delta := now - baseline
+					if delta > observedPeakMB {
+						observedPeakMB = delta
+					}
+				}
 			}
 		}()
 
-		if s.cfg.Incremental != nil && s.cfg.ExtractorConfig.IsIncrementalEnabled() {
-			res := s.cfg.Incremental(jobCtx, repoPath, tok.ref)
-			if res.Done {
-				incrementalDone = true
-				s.logEvent("incremental_ok", repoPath,
-					"changed_files="+itoa(int64(res.ChangedFiles)))
-			} else {
-				s.logEvent("incremental_fallback", repoPath,
-					"reason="+res.FallbackReason)
-				s.logger.Info("sched: incremental fallback", "repo", repoPath, "reason", res.FallbackReason)
+		// S3: attempt incremental file-level reindex before the full index.
+		// Only tried when the Incremental callback is configured AND the
+		// incremental toggle is active.
+		//
+		// Issue #2397: consult s.cfg.ExtractorConfig.IsIncrementalEnabled()
+		// (single source of truth) instead of the private incrementalEnabled()
+		// helper that read GRAFEL_INCREMENTAL_REINDEX directly. The nil-
+		// receiver method falls through to the env-var for backward compat.
+		//
+		// On success (res.Done=true) we skip the full reindex.
+		// On fallback (res.Done=false) we log the reason and fall through normally.
+		// Use shutdownCtx for all child-process-spawning calls so that when
+		// Stop() is called (daemon SIGTERM/SIGINT/Stop-RPC), any in-flight
+		// subprocess indexer receives SIGTERM via exec.CommandContext and the
+		// daemon can exit cleanly without leaving zombie processes (issue #2176).
+		jobCtx := s.shutdownCtx
+
+		incrementalDone := false
+		// Issue #5726 / epic #5729 — defense in depth. An index can panic for
+		// reasons the fbwriter fail-soft doesn't catch (e.g. a flatbuffers 2-GiB
+		// abort raised inside the streaming WriteEntity path, or any other bug in
+		// an extractor). A panic here would unwind through the worker goroutine and
+		// abort the ENTIRE daemon (launchd relaunches it → 60–90s reindex outage,
+		// every MCP bridge severed). Recover so ANY index panic becomes a normal
+		// error: the worker keeps serving, the reserved budget is released via the
+		// existing err path below, and we log a clear degraded-state message.
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("index panicked (recovered): %v", r)
+					s.logEvent("index_panic", repoPath, fmt.Sprintf("recovered panic during index: %v", r))
+					s.logger.Error("sched: index panicked — recovered; daemon continues in degraded state (repo left at last-good graph)",
+						"repo", repoPath, "ref", tok.ref, "panic", r, "stack", string(debug.Stack()))
+				}
+			}()
+
+			if s.cfg.Incremental != nil && s.cfg.ExtractorConfig.IsIncrementalEnabled() {
+				res := s.cfg.Incremental(jobCtx, repoPath, tok.ref)
+				if res.Done {
+					incrementalDone = true
+					s.logEvent("incremental_ok", repoPath,
+						"changed_files="+itoa(int64(res.ChangedFiles)))
+				} else {
+					s.logEvent("incremental_fallback", repoPath,
+						"reason="+res.FallbackReason)
+					s.logger.Info("sched: incremental fallback", "repo", repoPath, "reason", res.FallbackReason)
+				}
 			}
-		}
 
-		if !incrementalDone && s.cfg.Index != nil {
-			err = s.cfg.Index(jobCtx, repoPath, tok.ref)
-		}
-	}()
+			if !incrementalDone && s.cfg.Index != nil {
+				err = s.cfg.Index(jobCtx, repoPath, tok.ref)
+			}
+		}()
 
-	close(sampleStop)
-	sampleWG.Wait()
+		close(sampleStop)
+		sampleWG.Wait()
+	}
 
 	s.mu.Lock()
 	stats := s.indexedRepos[repoPath]
-	stats.LastIndex = time.Now()
-	stats.IndexCount++
-	stats.PredictedMB = tok.predictedMB
-	// #5433: record the ref this completed index ran against so
-	// grafel_index_status can report indexed_ref per repo.
-	stats.LastIndexedRef = tok.ref
-	if observedPeakMB > 0 {
-		stats.LastPeakMB = observedPeakMB
+	if !skip {
+		stats.LastIndex = time.Now()
+		stats.IndexCount++
+		stats.PredictedMB = tok.predictedMB
+		// #5433: record the ref this completed index ran against so
+		// grafel_index_status can report indexed_ref per repo.
+		stats.LastIndexedRef = tok.ref
+		if observedPeakMB > 0 {
+			stats.LastPeakMB = observedPeakMB
+		}
 	}
 	if err != nil {
 		stats.LastErr = err.Error()
+		if !skip {
+			// A real attempt failed: bump (or start) the breaker for this
+			// ref and arm exponential backoff. A skip does not re-bump —
+			// the failure it reflects was already recorded.
+			if stats.FailRef == tok.ref {
+				stats.FailCount++
+			} else {
+				stats.FailRef = tok.ref
+				stats.FailCount = 1
+				stats.FailLoggedAt = time.Time{}
+			}
+			stats.FailBackoffUntil = time.Now().Add(reindexFailBackoff(stats.FailCount))
+		}
 	} else {
 		stats.LastErr = ""
+		// Success resets the breaker entirely — including for a DIFFERENT
+		// ref than FailRef, which is already implied since a fresh ref
+		// never matched the open breaker in the first place.
+		stats.FailRef = ""
+		stats.FailCount = 0
+		stats.FailBackoffUntil = time.Time{}
+		stats.FailLoggedAt = time.Time{}
 	}
 	s.indexedRepos[repoPath] = stats
 	delete(s.inflight, repoPath)
@@ -1253,8 +1357,13 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	s.poke()
 
 	if err != nil {
-		s.logEvent("index_err", repoPath, err.Error())
-		s.logger.Error("sched: index failed", "repo", repoPath, "err", err, "took", time.Since(t0))
+		// A skip already logged its own (rate-limited) index_circuit_skip
+		// event above; logging index_err/"index failed" here too would
+		// reproduce the exact 74x-log storm the breaker exists to prevent.
+		if !skip {
+			s.logEvent("index_err", repoPath, err.Error())
+			s.logger.Error("sched: index failed", "repo", repoPath, "err", err, "took", time.Since(t0))
+		}
 		return
 	}
 	dur := time.Since(t0).Truncate(time.Millisecond)

--- a/internal/daemon/sched/scheduler_ref_test.go
+++ b/internal/daemon/sched/scheduler_ref_test.go
@@ -27,10 +27,10 @@ func TestSchedulerRef_EnqueueCapturesRef(t *testing.T) {
 
 	s := New(Config{
 		Workers: 1,
-		RefCapture: func(_ string) string {
+		RefCapture: func(_ string) (string, string) {
 			refMu.Lock()
 			defer refMu.Unlock()
-			return currentRef
+			return currentRef, ""
 		},
 		Index: func(_ context.Context, _ string, ref string) error {
 			mu.Lock()
@@ -85,8 +85,8 @@ func TestSchedulerRef_EnqueueRefPassesRefDirectly(t *testing.T) {
 	// RefCapture always returns "main" — but EnqueueRef bypasses it.
 	s := New(Config{
 		Workers: 1,
-		RefCapture: func(_ string) string {
-			return "main"
+		RefCapture: func(_ string) (string, string) {
+			return "main", ""
 		},
 		Index: func(_ context.Context, _ string, ref string) error {
 			mu.Lock()
@@ -125,8 +125,8 @@ func TestSchedulerRef_BranchSwitchAfterFirstIndex(t *testing.T) {
 
 	s := New(Config{
 		Workers: 1,
-		RefCapture: func(_ string) string {
-			return "feat/original"
+		RefCapture: func(_ string) (string, string) {
+			return "feat/original", ""
 		},
 		Index: func(_ context.Context, _ string, ref string) error {
 			// Block on the gate so we can enqueue the branch-switch while

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -413,8 +413,9 @@ func Run(ctx context.Context, cfg Config) error {
 			// PH1b: capture the HEAD ref at enqueue time so debounced
 			// batches index against the branch that was active when the
 			// file-change event fired, not the branch at dispatch time.
-			RefCapture: func(repoPath string) string {
-				return gitmeta.Capture(repoPath).Ref
+			RefCapture: func(repoPath string) (ref, commit string) {
+				info := gitmeta.Capture(repoPath)
+				return info.Ref, info.SHA
 			},
 			// #3680: drop enqueues for linked git worktrees of an
 			// already-indexed primary repo so they never become independent
@@ -504,7 +505,10 @@ func Run(ctx context.Context, cfg Config) error {
 				if cfg.BranchSwitchSink != nil {
 					cfg.BranchSwitchSink(ev.RepoPath, ev.OldRef)
 				}
-				scheduler.EnqueueRef(ev.RepoPath, ev.NewRef)
+				// #5726: carry the new commit SHA so the reindex circuit breaker
+				// keys on the commit (branch switches always change the SHA →
+				// the breaker resets and the new ref gets a real attempt).
+				scheduler.EnqueueRefCommit(ev.RepoPath, ev.NewRef, ev.NewSHA)
 			}, logger)
 			headPoller.Start()
 			defer headPoller.Stop()


### PR DESCRIPTION
Completes the v0.1.8 #5726 story alongside the merged part-1 fail-soft. (Part-2 fbwriter sharding is scoped to v0.1.9 — the largest real graph sits at ~44% of the 2 GiB FlatBuffers ceiling, so part-1 fail-soft + this breaker make v0.1.8 stable.)

**Problem:** after fbwriter fails soft on a >2 GiB graph (part-1: recover the marshal panic, keep last-good graph.fb), the fs-event watcher re-fires reindex on ANY working-tree write burst with no failure gating — so an oversized repo hot-loops the panic/recover forever (the original report logged it 74×).

**Fix:** a per-(repo, commit-SHA) circuit-breaker in the scheduler. On a reindex failure it arms an exponential backoff (30s→5m cap); subsequent triggers for the SAME repo at the SAME commit SKIP the re-marshal (serve last-good, no CPU burn), logging once per window. It resets immediately when the commit SHA changes (a fix-commit is tried at once) or on an explicit `grafel index` success. Keyed on the commit SHA (plumbed from `gitmeta.Info.SHA` through the enqueue/admit path), NOT the branch name — so same-branch fix-commits recover immediately and detached-HEAD/non-git repos are still gated. The skip is a true no-op on graph + status (no false 'indexed' claim; only a truthful 'circuit open' LastErr).

**Tests:** `circuitbreaker_5726_test.go` drives the real `Enqueue`→`RefCapture` production path (constant branch, changing SHA) asserting same-commit bounding + new-commit reset, plus a detached-HEAD-gates-by-SHA case. RED→GREEN; 651 tests, `-race` clean.

Two independent Opus reviews: first caught the breaker keying on branch-name (fixed → SHA); re-review of the SHA delta APPROVE (pending-map sync, token population, no race, back-compat all confirmed).

Refs #5726 #5729