### PR TITLE
feat(daemon): serve supervises engine child process — fault isolation (ADR-0024 split PR2, refs #5729)

### DIFF
--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -1,0 +1,388 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/agentpatterns"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/daemon/watchreg"
+	"github.com/cajasmota/grafel/internal/daemon/worktree"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+)
+
+// enginePlane holds the engine-plane background runtime (scheduler, watcher,
+// git-HEAD poller, worktree discovery, reapers/sweepers, the status writer,
+// pattern-decay, and the docgen sweeper) together with its ordered teardown.
+//
+// ADR-0024 Phase 1 (epic #5729) carved this plane out of the monolithic
+// daemon.Run body so it can be started in exactly two places with identical
+// wiring: in-process (the flag-off monolith / today's daemon) and standalone
+// (RunEngine, the split-mode `grafel engine` child). The extraction is
+// behavior-preserving for the monolith: the same constructors run in the same
+// order, and shutdown() unwinds them LIFO — matching the defer-stack order the
+// inline code used before.
+type enginePlane struct {
+	stops []func()
+}
+
+// add registers a teardown closure. Closures are unwound LIFO by shutdown(),
+// so call add in the SAME order the original inline code used `defer`.
+func (e *enginePlane) add(stop func()) { e.stops = append(e.stops, stop) }
+
+// shutdown unwinds every registered teardown closure in LIFO order — the exact
+// order Go's defer stack used when these lived inline in Run.
+func (e *enginePlane) shutdown() {
+	for i := len(e.stops) - 1; i >= 0; i-- {
+		e.stops[i]()
+	}
+}
+
+// startEnginePlane brings up the engine plane and returns it (call shutdown()
+// to unwind). svc may be nil: the standalone engine (RunEngine) has no MCP
+// Service, so the scheduler/watcher are not published onto one; the monolith
+// passes its live *Service so Status can report scheduler/watcher state.
+//
+// This is a verbatim carve of the engine-plane blocks that used to live inline
+// in Run (ADR-0024 Phase 1). The only adaptations are: (a) `defer X` became
+// ep.add(X) so teardown is owned by the returned enginePlane rather than Run's
+// stack, and (b) the two svc field writes are nil-guarded.
+func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slog.Logger) *enginePlane {
+	ep := &enginePlane{}
+
+	// Phase B — bring up the scheduler + watcher when the caller
+	// supplied the four hooks. They are optional so tests can exercise
+	// the bare RPC surface without dragging the extractor into scope.
+	logger.Info("startup: scheduler-watcher begin", "enabled", cfg.SchedulerIndex != nil)
+	if cfg.SchedulerIndex != nil {
+		history := sched.LoadRSSHistory(cfg.RSSHistoryPath)
+		scheduler := sched.New(sched.Config{
+			Index:         cfg.SchedulerIndex,
+			Links:         cfg.SchedulerLinks,
+			GroupAlgo:     cfg.SchedulerGroupAlgo,
+			GroupsForRepo: cfg.GroupsForRepo,
+			// #5403: settled-group overlay-freshness sweep. Enabled when the
+			// caller wires SchedulerStaleGroups; the interval defaults from
+			// GRAFEL_OVERLAY_SWEEP_INTERVAL (10m; "0" disables).
+			StaleGroups: cfg.SchedulerStaleGroups,
+			Logger:      logger,
+			BudgetMB:    cfg.MaxRSSBudgetMB,
+			Predict:     sched.PredictRSS,
+			History:     history,
+			// PH1b: capture the HEAD ref at enqueue time so debounced
+			// batches index against the branch that was active when the
+			// file-change event fired, not the branch at dispatch time.
+			// #5726: also capture the commit SHA so the reindex circuit
+			// breaker can key on the commit.
+			RefCapture: func(repoPath string) (ref, commit string) {
+				info := gitmeta.Capture(repoPath)
+				return info.Ref, info.SHA
+			},
+			// #3680: drop enqueues for linked git worktrees of an
+			// already-indexed primary repo so they never become independent
+			// root index jobs (each spawning its own ~100MB full graph store
+			// and pressuring the RSS admission budget). The worktree subsystem
+			// still tracks such paths as ephemeral children with aggressive
+			// TTLs. The indexed-primary set is the boot-time ReposToWatch list.
+			SkipEnqueue: makeWorktreeEnqueueGate(cfg.ReposToWatch),
+			// S3 incremental file-level reindex (issue #2153). When nil
+			// the scheduler falls through to full reindex on every tick.
+			Incremental: cfg.SchedulerIncremental,
+			// #5710 follow-up: entities=N on the completion log.
+			EntityCount: cfg.SchedulerEntityCount,
+			// Issue #2397: single source of truth for the incremental toggle.
+			// The scheduler calls ExtractorConfig.IsIncrementalEnabled()
+			// rather than reading the env var directly.
+			ExtractorConfig: cfg.ExtractorConfig,
+		})
+		if cfg.MaxRSSBudgetMB > 0 {
+			logger.Info("scheduler: RSS-budget admission control enabled", "budget_mb", cfg.MaxRSSBudgetMB, "history", cfg.RSSHistoryPath)
+		}
+		scheduler.Start()
+		if svc != nil {
+			svc.scheduler = scheduler
+		}
+		ep.add(scheduler.Stop)
+
+		// #5725/#5729-W1: status-plane heartbeat file. startStatusWriter runs a
+		// SINGLE serialized writer goroutine that refreshes every known repo's
+		// on-disk status sidecar (internal/statusfile): promptly on each
+		// scheduler state transition (via a coalescing notify hook) and
+		// periodically on a heartbeat tick, so a reader can detect a
+		// wedged/crashed engine via a stale heartbeat. Serializing through one
+		// goroutine makes concurrent same-repo writes impossible (review #5734)
+		// and coalesces bursts. The returned stop func unregisters the hook and
+		// joins the goroutine; it unwinds alongside scheduler.Stop() above.
+		//
+		// Deliberately NOT cfg.ReposToWatch: that callback is invoked exactly
+		// once by the boot-path watcher-subscription goroutine below, and some
+		// callers (e.g. TestBoot_WatcherSubscriptionDoesNotBlockBind) construct
+		// it with one-shot side effects. knownRepoPathsForStatus is a
+		// side-effect-free repo lister safe to call on every tick/refresh.
+		statusRepos := func() []string { return knownRepoPathsForStatus(logger) }
+		stopStatusWriter := startStatusWriter(statusRepos, statusHeartbeatInterval(), logger)
+		ep.add(stopStatusWriter)
+
+		// #5690: hand a read-only warming accessor to the wiring layer so the
+		// MCP surface can report warming state. Closes over the live scheduler;
+		// no scheduling authority.
+		if cfg.OnSchedulerReady != nil {
+			cfg.OnSchedulerReady(func() WarmingSnapshot {
+				snap := scheduler.Snapshot()
+				return WarmingSnapshot{
+					IndexInFlight: len(snap.InFlight) > 0,
+					PendingAlgo:   len(snap.PendingAlgo),
+					PendingLinks:  len(snap.PendingLinks),
+				}
+			})
+		}
+
+		wcfg := cfg.WatcherConfig
+		watcher, werr := watch.NewWatcherConfig(wcfg, func(repo string, bulk bool) {
+			if bulk {
+				logger.Info("watcher: bulk trigger — enqueuing full reindex", "repo", repo)
+			}
+			scheduler.Enqueue(repo)
+		}, logger)
+		if werr != nil {
+			logger.Warn("watcher: disabled", "err", werr)
+		} else {
+			if svc != nil {
+				svc.watcher = watcher
+			}
+			ep.add(watcher.Stop)
+
+			// PH1b (Option B): start the .git/HEAD poller alongside the
+			// fsnotify watcher. .git/ remains in SkipDirs (no fsnotify
+			// noise from git internal object/pack writes), and the poller
+			// detects branch switches by reading gitmeta.Capture every 2s.
+			//
+			// When a branch switch is detected:
+			//   1. A synthetic EnqueueRef is sent to the scheduler with the
+			//      new ref captured at detection time.
+			//   2. The scheduler writes the new index into refs/<new-ref>/,
+			//      leaving the old ref's graph untouched on disk.
+			headPoller := watch.NewGitHeadPoller(0, func(ev watch.BranchSwitchEvent) {
+				logger.Info("branch-switch detected",
+					"repo", ev.RepoPath, "old_ref", ev.OldRef, "old_sha", ev.OldSHA, "new_ref", ev.NewRef, "new_sha", ev.NewSHA)
+				// Notify the MCP cross-link cache so stale (repo, oldRef)
+				// entries are evicted before the new-ref graph lands (#2224).
+				if cfg.BranchSwitchSink != nil {
+					cfg.BranchSwitchSink(ev.RepoPath, ev.OldRef)
+				}
+				// #5726: carry the new commit SHA so the reindex circuit breaker
+				// keys on the commit (branch switches always change the SHA →
+				// the breaker resets and the new ref gets a real attempt).
+				scheduler.EnqueueRefCommit(ev.RepoPath, ev.NewRef, ev.NewSHA)
+			}, logger)
+			headPoller.Start()
+			ep.add(headPoller.Stop)
+
+			// M2 (#2179): lazy fsnotify subscription — do NOT call watcher.AddRepo
+			// at boot. The daemon starts with zero fsnotify subscriptions. Repos
+			// are subscribed on the first MCP query for their group (via
+			// SubscribeGroupWatcher → watch.DefaultManager.SubscribeGroup →
+			// watcher.AddRepo). This eliminates per-repo directory-tree walks at
+			// startup, saving ~O(dirs×groups) inotify watch descriptors on idle daemons.
+			//
+			// We still call ReposToWatch (exactly once) to:
+			//   (a) register repos with the HEAD poller (branch-switch detection; no fd cost)
+			//   (b) run the case-collision store audit (#2086)
+			// Both happen off the critical boot path in a goroutine, same as before.
+			if cfg.ReposToWatch != nil {
+				capturedStore := StoreDir()
+				go func() {
+					t0 := time.Now()
+					repos := cfg.ReposToWatch()
+					for _, r := range repos {
+						// M2: skip watcher.AddRepo here — subscriptions are lazy.
+						// Register with the HEAD poller only (reads .git/HEAD; no
+						// fsnotify watch descriptors consumed).
+						headPoller.AddRepo(r)
+					}
+					logger.Info("watcher: boot-path registered with HEAD poller (fsnotify lazy — 0 AddRepo calls)",
+						"repos", len(repos), "took", time.Since(t0).Truncate(time.Millisecond).String())
+
+					// #2086: case-collision audit — unchanged.
+					if capturedStore != "" {
+						if dups := WarnCaseCollisions(capturedStore, repos); len(dups) > 0 {
+							for _, pair := range dups {
+								logger.Warn("store: detected case-collision dup — remove stale dir to avoid confusion (grafel cleanup --case-merge)",
+									"stale", pair[0], "canonical", pair[1])
+							}
+						}
+					}
+				}()
+			}
+			if cfg.OnWatcherReady != nil {
+				cfg.OnWatcherReady(watcher)
+			}
+
+			// #3353/#3354: linked-worktree discovery + working-tree watching.
+			// Gated on the fsnotify watcher being up (we reuse it to watch each
+			// worktree's working tree) and on a caller-supplied parents provider
+			// (non-nil only when some group opts into worktree tracking).
+			var wtStore *worktree.Store
+			if cfg.WorktreeParents != nil {
+				wtStorePath := filepath.Join(cfg.Layout.Root, "worktrees.json")
+				wtStore = worktree.NewStore(wtStorePath)
+				if err := wtStore.Load(); err != nil {
+					logger.Warn("worktree: failed to load store; starting empty", "path", wtStorePath, "err", err)
+				}
+				wtWatcher := worktree.NewWatcher(wtStore, cfg.WorktreeParents, logger)
+
+				// #5675: bound the fsnotify-subscription fan-out. Each
+				// watcher.AddRepo(child.Path) subscribes the worktree's ENTIRE
+				// working tree, costing ~1 fd per directory on Linux inotify —
+				// UNBOUNDED by the number of activated worktrees. A burst of
+				// activations could open a flood of fds at once and crash the
+				// daemon into a KeepAlive/Restart relaunch loop. This semaphore
+				// caps how many subscriptions can be opening concurrently. For
+				// the common case (activations are dispatched sequentially by
+				// poll, one at a time) the semaphore is always immediately
+				// available — zero behavior change. Overridable via
+				// GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY.
+				activateSem := make(chan struct{}, worktreeActivateConcurrency())
+
+				// On activation, subscribe the worktree's WORKING TREE to the
+				// fsnotify watcher so uncommitted edits trigger a reactive
+				// reindex, and enqueue one immediate reindex of its ref tier.
+				// scheduler.Enqueue captures the worktree's checked-out ref via
+				// RefCapture(worktreePath), so the graph lands in the correct
+				// per-ref dir keyed by the worktree path (multi-ref model).
+				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
+					activateSem <- struct{}{}
+					_, aerr := watcher.AddRepo(child.Path)
+					<-activateSem
+					if aerr != nil {
+						logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
+					}
+					scheduler.Enqueue(child.Path)
+					logger.Info("worktree: watching working tree + enqueued initial reindex",
+						"path", child.Path, "branch", child.Branch, "group", child.GroupName, "slug", child.ParentSlug, "locked", child.Locked)
+				}
+				// On expiry, unsubscribe the working tree from the watcher.
+				wtWatcher.OnExpire = func(child *worktree.WorktreeChild) {
+					watcher.RemoveRepo(child.Path)
+					logger.Info("worktree: unwatched expired working tree", "path", child.Path)
+				}
+
+				wtCtx, wtCancel := context.WithCancel(ctx)
+				go wtWatcher.Start(wtCtx)
+				ep.add(wtCancel)
+				logger.Info("worktree: discovery started",
+					"store", wtStorePath, "reconcile_env", "GRAFEL_WORKTREE_POLL_SECONDS")
+			}
+
+			// #3680: vanished-repo store reaper. Tracked repos (registered +
+			// active worktree children) whose directory no longer exists on
+			// disk have their store dir deleted and their fsnotify
+			// subscription dropped, reclaiming the orphaned ~100MB worktree
+			// stores that accumulated under ~/.grafel/store/.
+			trackedRepos := makeReaperTrackedRepos(cfg.ReposToWatch, wtStore)
+			// #5236: dead-ref / dead-worktree sweep. Reclaims store dirs +
+			// resident graphs for refs git no longer knows about, within
+			// still-present repos. Driven by the reaper on the shared cadence.
+			// Retention cap is env-tunable (GRAFEL_REF_RETENTION_CAP) so an
+			// operator can shrink the dead-ref footprint on a machine with
+			// heavy transient-ref churn (e.g. set it to 4). Resolved here so the
+			// effective value is logged; NewDeadRefSweeper would resolve the same
+			// value from a zero RetentionCap on its own.
+			refRetentionCap := EnvRefRetentionCap()
+			logger.Info("deadref: retention cap configured",
+				"cap", refRetentionCap, "env", RefRetentionCapEnv)
+			deadRefSweeper := NewDeadRefSweeper(DeadRefConfig{
+				TrackedRepos:   trackedRepos,
+				LiveRefs:       LiveGitRefs,
+				PrimaryRef:     PrimaryGitRef,
+				RefsDirForRepo: RefsDirForRepo,
+				DropReader:     cfg.DeadRefDropReader,
+				Tier:           cfg.DeadRefTier,
+				RetentionCap:   refRetentionCap,
+				Logger:         logger,
+			})
+			// #5263: orphan top-level store-root sweep. Reaps whole
+			// `<store>/<slug>-<hash>/` roots that map to a vanished source path
+			// and to no live group/primary — the gap between the vanished-repo
+			// GC (currently-tracked repos only) and the dead-ref GC (refs within
+			// still-tracked repos only). KnownSourcePaths includes EXPIRED
+			// worktrees so a now-gone path's root can still be attributed; roots
+			// attributable to no known path are kept (fail-closed).
+			orphanRootSweeper := NewOrphanRootSweeper(OrphanRootConfig{
+				KnownSourcePaths: makeKnownSourcePaths(cfg.ReposToWatch, wtStore),
+				// Tier / DropReaderForRoot are per-repo-path hooks; the daemon
+				// does not currently expose a whole-repo Forget here, and a
+				// reaped orphan root's source path is already GONE (no live
+				// slot to wake), so on-disk reclamation is the load-bearing
+				// effect. Any residual in-mem slot is dropped by the
+				// vanished-repo reaper / memory-pressure eviction.
+				Logger: logger,
+			})
+			reaper := NewReaper(ReaperConfig{
+				TrackedRepos:    trackedRepos,
+				StoreDirForRepo: repoBaseDir,
+				Untrack: func(repoPath string) {
+					watcher.RemoveRepo(repoPath)
+				},
+				// #5142: also reap stale/orphaned `grafel watch` PIDs that
+				// registered in the daemon-owned registry under the daemon root.
+				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
+				// #5632: also reap live `grafel watch` processes for managed
+				// repos that run from a STALE/foreign binary (version skew) or
+				// duplicate an existing watcher. ManagedRepo gates the sweep to
+				// the daemon's tracked repos only; the watcher's repo arg is
+				// matched (cleaned-absolute) against this set so unrelated
+				// processes are never touched.
+				ManagedRepo: makeManagedRepoPredicate(trackedRepos),
+				DeadRefs:    deadRefSweeper,
+				OrphanRoots: orphanRootSweeper,
+				Logger:      logger,
+			})
+			reaperStop := make(chan struct{})
+			reaper.Start(reaperStop)
+			ep.add(func() { close(reaperStop) })
+			logger.Info("reaper: vanished-repo store GC started", "interval", "5m")
+		}
+	}
+	logger.Info("startup: scheduler-watcher done")
+
+	// Pattern confidence time-decay scheduler — runs every 6 hours (or a
+	// caller-supplied interval for tests). Requires PatternGroupDirs to be
+	// non-nil; skipped gracefully when the caller has not provided it.
+	logger.Info("startup: pattern-decay begin", "enabled", cfg.PatternGroupDirs != nil)
+	if cfg.PatternGroupDirs != nil {
+		decayInterval := cfg.PatternDecayInterval
+		if decayInterval <= 0 {
+			decayInterval = 6 * time.Hour
+		}
+		decayJob := buildPatternDecayJob(cfg.PatternGroupDirs, logger)
+		decaySched := agentpatterns.NewDecayScheduler(decayInterval, decayJob)
+		decayCtx, decayCancel := context.WithCancel(ctx)
+		go decaySched.Run(decayCtx)
+		ep.add(decayCancel)
+		logger.Info("pattern decay scheduler started", "interval", decayInterval.String())
+	}
+	logger.Info("startup: pattern-decay done")
+
+	// Docgen background sweeper (issue #2216): removes stale staging runs and
+	// .previous-* backups every 24 h. Opt-in: nil = disabled (--no-auto-cleanup).
+	logger.Info("startup: docgen-sweeper begin", "enabled", cfg.DocgenSweep != nil)
+	if cfg.DocgenSweep != nil {
+		sweepCfg := *cfg.DocgenSweep
+		sweepCfg.Logger = logger
+		sweepStop := make(chan struct{})
+		StartDocgenSweeper(sweepCfg, sweepStop)
+		ep.add(func() { close(sweepStop) })
+		interval := sweepCfg.Interval
+		if interval <= 0 {
+			interval = 24 * time.Hour
+		}
+		logger.Info("docgen sweeper started", "interval", interval.String())
+	}
+	logger.Info("startup: docgen-sweeper done")
+
+	return ep
+}

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -35,6 +35,15 @@ type Layout struct {
 // freshly-built daemon at a tempdir without touching the real ~/.grafel.
 const EnvRoot = "GRAFEL_DAEMON_ROOT"
 
+// EnginePIDPath returns the split-mode engine child's pidfile path
+// (<root>/engine.pid), distinct from serve's daemon.pid so the two planes can
+// coexist under one daemon root without contending for a single pidfile
+// (ADR-0024, epic #5729). The supervising serve process owns daemon.pid; the
+// engine child writes engine.pid.
+func EnginePIDPath(root string) string {
+	return filepath.Join(root, "engine.pid")
+}
+
 // EnsureLayout creates the directories the daemon writes to. The socket
 // path itself is not created here — the listener does that. Permissions
 // are 0700/0600 because the daemon shares state across nothing and the

--- a/internal/daemon/serve_engine_split_test.go
+++ b/internal/daemon/serve_engine_split_test.go
@@ -2,6 +2,7 @@ package daemon_test
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -54,18 +55,29 @@ func TestRunServe_MatchesDaemonInProcessWiring(t *testing.T) {
 	}
 }
 
-// TestRunEngine_StandaloneNotYetImplemented documents the deliberate Phase 1
-// scope boundary: `grafel engine` is wired as a hidden cobra subcommand and
-// EngineConfig exists, but daemon.RunEngine does not yet run a serve-free
-// engine-only process — that lands with PR2's actual process split. This
-// pins the current, honest behavior (a clear error, not a silent duplicate
-// daemon) so a future change to it is a deliberate, reviewed decision.
-func TestRunEngine_StandaloneNotYetImplemented(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-	defer cancel()
-	err := daemon.RunEngine(ctx, daemon.EngineConfig{})
-	if err == nil {
-		t.Fatal("expected RunEngine to report standalone-not-yet-implemented, got nil error")
+// TestRunServe_FlagOff_SpawnsNoEngineChild is the ADR-0024 PR2 flag-OFF
+// regression (epic #5729): with GRAFEL_SPLIT_MODE unset (the default), RunServe
+// must run the whole daemon in-process and spawn NO engine child — so it must
+// never write engine.pid. This pins the critical invariant that split-mode is
+// strictly opt-in and the default running daemon is unchanged.
+func TestRunServe_FlagOff_SpawnsNoEngineChild(t *testing.T) {
+	layout := runServeForTest(t, func(args proto.IndexArgs) (string, string, error) {
+		return args.RepoPath + "/.grafel/graph.json", `{"ok":true}`, nil
+	}, nil)
+
+	// A fully-booted monolith serve answers RPC…
+	c, err := client.DialPath(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	if _, err := c.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+
+	// …and never spawned an engine child, so engine.pid must not exist.
+	if _, err := os.Stat(daemon.EnginePIDPath(layout.Root)); !os.IsNotExist(err) {
+		t.Fatalf("engine.pid exists in flag-OFF mode (err=%v) — an engine child was spawned; split-mode must be opt-in", err)
 	}
 }
 

--- a/internal/daemon/serve_split_e2e_test.go
+++ b/internal/daemon/serve_split_e2e_test.go
@@ -1,0 +1,165 @@
+//go:build darwin || linux
+
+package daemon_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// readEnginePIDE2E reads <root>/engine.pid (0 if absent/unreadable).
+func readEnginePIDE2E(root string) int {
+	b, err := os.ReadFile(daemon.EnginePIDPath(root))
+	if err != nil {
+		return 0
+	}
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return pid
+}
+
+func pidAliveE2E(pid int) bool {
+	return pid > 0 && syscall.Kill(pid, 0) == nil
+}
+
+func waitForE2E(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// TestRunServe_SplitMode_EngineFaultIsIsolated is the end-to-end fault-isolation
+// harness (ADR-0024 PR2, epic #5729): with GRAFEL_SPLIT_MODE ON, RunServe runs
+// the serve plane in-process and supervises a real `grafel engine` child
+// (here: the TestEngineChildHelper subprocess). It asserts:
+//
+//  1. serve spawns an engine child (engine.pid written).
+//  2. Fault isolation: SIGKILL the engine child, and (a) serve STAYS UP —
+//     MCP RPC keeps answering — and (b) serve RESTARTS the engine (a fresh,
+//     different, live child appears).
+//  3. Graceful drain: shutting down serve reaps the engine child (no orphan).
+//
+// index_status parity in split-mode is deliberately NOT asserted — that wiring
+// lands in PR3. This test only exercises RPC-read survival + process lifecycle.
+func TestRunServe_SplitMode_EngineFaultIsIsolated(t *testing.T) {
+	root := shortTempRoot(t)
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", root)
+	t.Setenv(daemon.EnvDisableSelfDefense, "1")
+	t.Setenv("GRAFEL_SPLIT_MODE", "1")
+	t.Setenv(daemon.EnvStatusHeartbeatSeconds, "1")
+
+	// Spawn the engine child as the in-binary helper subprocess rather than a
+	// real grafel binary.
+	restore := daemon.SetEngineChildCommandForTest(func(selfExe, root string) *exec.Cmd {
+		cmd := exec.Command(selfExe, "-test.run=TestEngineChildHelper", "-test.timeout=120s")
+		cmd.Env = append(os.Environ(),
+			"GRAFEL_ENGINE_CHILD_HELPER=1",
+			daemon.EnvRoot+"="+root,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		return cmd
+	})
+	defer restore()
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- daemon.RunServe(ctx, daemon.ServeConfig{Config: daemon.Config{
+			Layout: layout,
+			Index: func(a proto.IndexArgs) (string, string, error) {
+				return a.RepoPath + "/.grafel/graph.json", `{"ok":true}`, nil
+			},
+		}})
+	}()
+	stopped := false
+	t.Cleanup(func() {
+		if !stopped {
+			cancel()
+			select {
+			case <-done:
+			case <-time.After(10 * time.Second):
+				t.Log("RunServe did not exit within 10s")
+			}
+		}
+	})
+
+	// serve's MCP socket must come up (in-process serve plane).
+	waitDaemonReady(t, layout.SocketPath, 15*time.Second)
+
+	// (1) engine child spawned → engine.pid present + alive.
+	var pid1 int
+	if !waitForE2E(20*time.Second, func() bool {
+		pid1 = readEnginePIDE2E(root)
+		return pid1 > 0 && pidAliveE2E(pid1)
+	}) {
+		t.Fatalf("engine child never spawned (no live engine.pid at %s)", daemon.EnginePIDPath(root))
+	}
+
+	// (2) Fault: SIGKILL the engine child.
+	if err := syscall.Kill(pid1, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL engine child %d: %v", pid1, err)
+	}
+
+	// (2a) serve STAYS UP: MCP RPC keeps answering across the engine's death.
+	for i := 0; i < 6; i++ {
+		c, derr := client.DialPath(layout.SocketPath)
+		if derr != nil {
+			t.Fatalf("serve socket dropped after engine kill (iter %d): dial: %v", i, derr)
+		}
+		if _, perr := c.Ping(); perr != nil {
+			c.Close()
+			t.Fatalf("serve Ping failed after engine kill (iter %d): %v — engine fault was NOT isolated", i, perr)
+		}
+		c.Close()
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	// (2b) serve RESTARTS the engine: a fresh, different, live child appears.
+	if !waitForE2E(30*time.Second, func() bool {
+		p := readEnginePIDE2E(root)
+		return p > 0 && p != pid1 && pidAliveE2E(p)
+	}) {
+		t.Fatalf("engine child was not restarted after fault (still pid %d)", pid1)
+	}
+	lastPid := readEnginePIDE2E(root)
+	if pidAliveE2E(pid1) {
+		t.Errorf("killed engine child %d still alive", pid1)
+	}
+
+	// (3) Graceful drain: shutting down serve reaps the engine child.
+	cancel()
+	stopped = true
+	select {
+	case <-done:
+	case <-time.After(12 * time.Second):
+		t.Fatal("RunServe did not shut down within 12s")
+	}
+	if !waitForE2E(6*time.Second, func() bool { return !pidAliveE2E(lastPid) }) {
+		t.Fatalf("engine child %d orphaned after serve shutdown", lastPid)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -11,7 +11,6 @@ import (
 	"net/rpc/jsonrpc"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,10 +22,8 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/daemon/transport"
 	"github.com/cajasmota/grafel/internal/daemon/watch"
-	"github.com/cajasmota/grafel/internal/daemon/watchreg"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/extractor"
-	"github.com/cajasmota/grafel/internal/gitmeta"
 )
 
 // defaultActivateConcurrency bounds how many worktree working-tree fsnotify
@@ -299,43 +296,149 @@ type EngineConfig struct {
 	Config
 }
 
-// RunServe starts the serve plane: the MCP socket, the dashboard, and,
-// while SplitModeEnabled() is false (the default), the engine plane
-// in-process — byte-for-byte identical to Run. It is the implementation
-// behind both the `grafel serve` subcommand and the back-compat `grafel
-// daemon` shim, so an existing OS unit that still execs `daemon`
-// transparently becomes a serve process with zero client-visible change.
+// daemonPlaneMode selects which planes the shared run() body starts. It is an
+// internal (unexported) implementation detail of the ADR-0024 Phase 1 / PR2
+// carve; the public entrypoints (Run, RunServe, RunEngine) each pick a mode.
+type daemonPlaneMode int
+
+const (
+	// planeMonolith is today's single-process daemon: the serve plane (socket,
+	// dashboard, MCP dispatch) AND the engine plane (scheduler, watcher,
+	// fbwriter) both run in ONE process. This is the flag-off default and is
+	// byte-for-byte behavior-identical to the pre-split daemon.
+	planeMonolith daemonPlaneMode = iota
+	// planeServeOnly starts ONLY the serve plane; the engine plane is skipped
+	// because a supervised `grafel engine` child runs it in a separate process
+	// (split-mode ON). Used by RunServe when SplitModeEnabled().
+	planeServeOnly
+)
+
+// RunServe starts the serve plane: the MCP dispatch socket, the dashboard, and
+// the zero-copy graph_cache mmap reads.
 //
-// This PR (the ADR-0024 Phase 1 entrypoint/config carve) does not yet spawn
-// a child process on the SplitModeEnabled()==true branch — both branches
-// call Run today. PR2 will replace the true branch with starting only the
-// serve-plane pieces here and spawning/supervising a `grafel engine` child
-// for the rest, without changing RunServe's signature or callers.
+// While the serve/engine split capability flag is OFF (the default,
+// SplitModeEnabled()==false), RunServe runs the ENTIRE daemon in one process —
+// byte-for-byte identical to Run — so an existing OS unit that execs `serve`
+// (or the back-compat `daemon` shim) behaves exactly like today's daemon.
+//
+// When the flag is ON (ADR-0024 Phase 1 / PR2, epic #5729), RunServe starts
+// ONLY the serve plane in-process and spawns + supervises a separate
+// `grafel engine` child for the scheduler/watcher/extraction/fbwriter. The
+// supervisor keeps the engine child alive across crashes with exponential
+// backoff, exposes a status-file health gate, and gracefully drains (SIGTERM →
+// bounded wait → SIGKILL, reaped) the child when serve shuts down. serve never
+// exits for a degraded/dead engine — it keeps answering reads from the
+// last-good graph.fb — and returns non-zero only when the engine is
+// unkeepable (repeated crash-loop at the backoff ceiling), so the OS unit
+// recycles the whole thing.
 func RunServe(ctx context.Context, cfg ServeConfig) error {
-	if SplitModeEnabled() {
-		// PR2 seam: spawn/supervise a `grafel engine` child here instead of
-		// running the engine plane inline. Until that lands, behavior is
-		// identical to the flag-off path.
-		return Run(ctx, cfg.Config)
+	if !SplitModeEnabled() {
+		// Flag OFF (default): everything in one process, exactly as before.
+		return run(ctx, cfg.Config, planeMonolith)
 	}
-	return Run(ctx, cfg.Config)
+
+	// Flag ON: serve plane in-process + a supervised engine child process.
+	logger := cfg.Logger
+	if logger == nil {
+		logger = buildSlogLogger(os.Stderr)
+	}
+
+	serveCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	sup := newEngineSupervisor(cfg.Layout, logger)
+	if err := sup.start(serveCtx); err != nil {
+		return fmt.Errorf("serve: start engine supervisor: %w", err)
+	}
+	// Graceful drain of the engine child on serve shutdown (reaped, no orphan).
+	defer sup.stop()
+
+	// Bridge a supervisor "engine unkeepable" fatal into serve shutdown: cancel
+	// serveCtx so run() unwinds, then RunServe returns the fatal below.
+	go func() {
+		select {
+		case <-serveCtx.Done():
+		case <-sup.fatal():
+			logger.Error("serve: engine child unkeepable — shutting down serve so the OS unit recycles it")
+			cancel()
+		}
+	}()
+
+	err := run(serveCtx, cfg.Config, planeServeOnly)
+	if ferr := sup.fatalError(); ferr != nil {
+		return ferr
+	}
+	return err
 }
 
-// RunEngine starts the engine plane standalone: the scheduler, watcher,
-// extraction, and fbwriter, without the MCP socket or dashboard. ADR-0024
-// Phase 1 (this PR) wires the `grafel engine` entrypoint and the
-// EngineConfig type but does not yet carve Run's internals into a
-// serve-free engine-only code path — that lands with PR2's actual process
-// split. Until then, RunEngine deliberately refuses to run standalone
-// (rather than silently starting a full duplicate daemon under the
-// "engine" name), since SplitModeEnabled() is off by default and no
-// caller in this PR relies on RunEngine actually serving anything.
+// RunEngine starts the engine plane standalone (the split-mode `grafel engine`
+// child): the scheduler, file watcher, git-HEAD poller, worktree discovery,
+// reapers/sweepers, the status writer, pattern-decay, and the docgen sweeper —
+// with NO MCP socket, NO dashboard, and NO MCP dispatch (those are the serve
+// plane, owned by the supervising serve process).
+//
+// It writes its own engine.pid, publishes an engine-global liveness heartbeat
+// (statusfile keyed on the daemon root) so the supervising serve's health gate
+// can tell HEALTHY from DEGRADED, brings up the engine plane, then blocks until
+// ctx is cancelled or a SIGTERM/SIGINT arrives — at which point its defers
+// unwind the scheduler/watcher gracefully (ADR-0024, epic #5729, PR2).
 func RunEngine(ctx context.Context, cfg EngineConfig) error {
-	_ = ctx
-	_ = cfg
-	return fmt.Errorf("grafel engine: standalone engine process not yet implemented " +
-		"(ADR-0024 Phase 1 is the entrypoint/config carve only; the process split " +
-		"lands in PR2, epic #5729)")
+	logger := cfg.Logger
+	if logger == nil {
+		logger = buildSlogLogger(os.Stderr)
+	}
+
+	// #3648: match Run's conservative Go soft memory limit — the engine is the
+	// heavy plane (extraction/reindex/fbwriter), exactly the workload the cap
+	// bounds.
+	applyMemoryLimit(logger)
+
+	if err := EnsureLayout(cfg.Layout); err != nil {
+		return fmt.Errorf("engine: ensure layout: %w", err)
+	}
+
+	// Engine is the write plane, so it owns the one-time state-migration that
+	// normalises the on-disk store layout (mirrors Run). Non-fatal.
+	if storeDir := StoreDir(); storeDir != "" {
+		if err := MigrateToRefStore(storeDir); err != nil {
+			logger.Warn("engine startup: MigrateToRefStore (non-fatal)", "err", err)
+		}
+	}
+
+	// Engine pidfile (engine.pid) — distinct from serve's daemon.pid so both
+	// planes coexist under one daemon root without contending for a pidfile.
+	pidPath := EnginePIDPath(cfg.Layout.Root)
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())+"\n"), 0o600); err != nil {
+		return fmt.Errorf("engine: write pid file %s: %w", pidPath, err)
+	}
+	defer func() { _ = os.Remove(pidPath) }()
+
+	// Engine-global liveness heartbeat: a statusfile keyed on the daemon root
+	// (NOT any single repo) that stamps EnginePID + a fresh HeartbeatAt every
+	// tick. This is the signal serve's supervisor health gate reads to decide
+	// HEALTHY vs DEGRADED — independent of whether any fleet repo is registered
+	// yet (the per-repo status writer, started inside the engine plane, only
+	// covers registered repos).
+	stopHeartbeat := startEngineLivenessHeartbeat(cfg.Layout.Root, statusHeartbeatInterval(), logger)
+	defer stopHeartbeat()
+
+	// Bring up the engine plane (no *Service — engine has no MCP surface).
+	ep := startEnginePlane(ctx, cfg.Config, nil, logger)
+	defer ep.shutdown()
+
+	logger.Info("engine: ready", "pid", os.Getpid(), "root", cfg.Layout.Root)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	defer signal.Stop(sigCh)
+
+	select {
+	case <-ctx.Done():
+		logger.Info("engine: context cancelled — shutting down", "err", ctx.Err())
+	case sig := <-sigCh:
+		logger.Info("engine: signal received — shutting down", "signal", sig.String())
+	}
+	return nil
 }
 
 // Run starts the daemon. It blocks until either:
@@ -346,7 +449,20 @@ func RunEngine(ctx context.Context, cfg EngineConfig) error {
 // On exit it removes the socket file and pid file. The function is the
 // daemon's entire public surface — cmd/grafel just imports daemon
 // and calls Run.
+//
+// Run is the single-process monolith: it delegates to the shared run() body in
+// planeMonolith mode (serve plane + engine plane in one process). This is
+// byte-for-byte behavior-identical to the pre-ADR-0024 daemon.
 func Run(ctx context.Context, cfg Config) error {
+	return run(ctx, cfg, planeMonolith)
+}
+
+// run is the shared daemon body behind Run / RunServe / RunEngine. The plane
+// argument selects which planes start: planeMonolith runs everything (Run's
+// classic behavior), planeServeOnly skips the engine plane (split-mode serve,
+// whose engine runs in a supervised child). The engine-plane assembly itself
+// lives in startEnginePlane (engineplane.go).
+func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	// slogger is the structured logger used by the daemon itself (Run + Service)
 	// and all sub-packages. Handler selection is based on GRAFEL_DAEMON_LOG_JSON
 	// at startup — this encodes the choice in the handler so call sites never check
@@ -467,330 +583,18 @@ func Run(ctx context.Context, cfg Config) error {
 	StartCPUWatchdog(&svc.inFlight, logger)
 	logger.Info("startup: cpu-watchdog done")
 
-	// Phase B — bring up the scheduler + watcher when the caller
-	// supplied the four hooks. They are optional so tests can exercise
-	// the bare RPC surface without dragging the extractor into scope.
-	logger.Info("startup: scheduler-watcher begin", "enabled", cfg.SchedulerIndex != nil)
-	if cfg.SchedulerIndex != nil {
-		history := sched.LoadRSSHistory(cfg.RSSHistoryPath)
-		scheduler := sched.New(sched.Config{
-			Index:         cfg.SchedulerIndex,
-			Links:         cfg.SchedulerLinks,
-			GroupAlgo:     cfg.SchedulerGroupAlgo,
-			GroupsForRepo: cfg.GroupsForRepo,
-			// #5403: settled-group overlay-freshness sweep. Enabled when the
-			// caller wires SchedulerStaleGroups; the interval defaults from
-			// GRAFEL_OVERLAY_SWEEP_INTERVAL (10m; "0" disables).
-			StaleGroups: cfg.SchedulerStaleGroups,
-			Logger:      logger,
-			BudgetMB:    cfg.MaxRSSBudgetMB,
-			Predict:     sched.PredictRSS,
-			History:     history,
-			// PH1b: capture the HEAD ref at enqueue time so debounced
-			// batches index against the branch that was active when the
-			// file-change event fired, not the branch at dispatch time.
-			RefCapture: func(repoPath string) (ref, commit string) {
-				info := gitmeta.Capture(repoPath)
-				return info.Ref, info.SHA
-			},
-			// #3680: drop enqueues for linked git worktrees of an
-			// already-indexed primary repo so they never become independent
-			// root index jobs (each spawning its own ~100MB full graph store
-			// and pressuring the RSS admission budget). The worktree subsystem
-			// still tracks such paths as ephemeral children with aggressive
-			// TTLs. The indexed-primary set is the boot-time ReposToWatch list.
-			SkipEnqueue: makeWorktreeEnqueueGate(cfg.ReposToWatch),
-			// S3 incremental file-level reindex (issue #2153). When nil
-			// the scheduler falls through to full reindex on every tick.
-			Incremental: cfg.SchedulerIncremental,
-			// #5710 follow-up: entities=N on the completion log.
-			EntityCount: cfg.SchedulerEntityCount,
-			// Issue #2397: single source of truth for the incremental toggle.
-			// The scheduler calls ExtractorConfig.IsIncrementalEnabled()
-			// rather than reading the env var directly.
-			ExtractorConfig: cfg.ExtractorConfig,
-		})
-		if cfg.MaxRSSBudgetMB > 0 {
-			logger.Info("scheduler: RSS-budget admission control enabled", "budget_mb", cfg.MaxRSSBudgetMB, "history", cfg.RSSHistoryPath)
-		}
-		scheduler.Start()
-		svc.scheduler = scheduler
-		defer scheduler.Stop()
-
-		// #5725/#5729-W1: status-plane heartbeat file. startStatusWriter runs a
-		// SINGLE serialized writer goroutine that refreshes every known repo's
-		// on-disk status sidecar (internal/statusfile): promptly on each
-		// scheduler state transition (via a coalescing notify hook) and
-		// periodically on a heartbeat tick, so a reader can detect a
-		// wedged/crashed engine via a stale heartbeat. Serializing through one
-		// goroutine makes concurrent same-repo writes impossible (review #5734)
-		// and coalesces bursts. The returned stop func unregisters the hook and
-		// joins the goroutine; it defer-unwinds alongside scheduler.Stop() above.
-		//
-		// Deliberately NOT cfg.ReposToWatch: that callback is invoked exactly
-		// once by the boot-path watcher-subscription goroutine below, and some
-		// callers (e.g. TestBoot_WatcherSubscriptionDoesNotBlockBind) construct
-		// it with one-shot side effects. knownRepoPathsForStatus is a
-		// side-effect-free repo lister safe to call on every tick/refresh.
-		statusRepos := func() []string { return knownRepoPathsForStatus(logger) }
-		stopStatusWriter := startStatusWriter(statusRepos, statusHeartbeatInterval(), logger)
-		defer stopStatusWriter()
-
-		// #5690: hand a read-only warming accessor to the wiring layer so the
-		// MCP surface can report warming state. Closes over the live scheduler;
-		// no scheduling authority.
-		if cfg.OnSchedulerReady != nil {
-			cfg.OnSchedulerReady(func() WarmingSnapshot {
-				snap := scheduler.Snapshot()
-				return WarmingSnapshot{
-					IndexInFlight: len(snap.InFlight) > 0,
-					PendingAlgo:   len(snap.PendingAlgo),
-					PendingLinks:  len(snap.PendingLinks),
-				}
-			})
-		}
-
-		wcfg := cfg.WatcherConfig
-		watcher, werr := watch.NewWatcherConfig(wcfg, func(repo string, bulk bool) {
-			if bulk {
-				logger.Info("watcher: bulk trigger — enqueuing full reindex", "repo", repo)
-			}
-			scheduler.Enqueue(repo)
-		}, logger)
-		if werr != nil {
-			logger.Warn("watcher: disabled", "err", werr)
-		} else {
-			svc.watcher = watcher
-			defer watcher.Stop()
-
-			// PH1b (Option B): start the .git/HEAD poller alongside the
-			// fsnotify watcher. .git/ remains in SkipDirs (no fsnotify
-			// noise from git internal object/pack writes), and the poller
-			// detects branch switches by reading gitmeta.Capture every 2s.
-			//
-			// When a branch switch is detected:
-			//   1. A synthetic EnqueueRef is sent to the scheduler with the
-			//      new ref captured at detection time.
-			//   2. The scheduler writes the new index into refs/<new-ref>/,
-			//      leaving the old ref's graph untouched on disk.
-			headPoller := watch.NewGitHeadPoller(0, func(ev watch.BranchSwitchEvent) {
-				logger.Info("branch-switch detected",
-					"repo", ev.RepoPath, "old_ref", ev.OldRef, "old_sha", ev.OldSHA, "new_ref", ev.NewRef, "new_sha", ev.NewSHA)
-				// Notify the MCP cross-link cache so stale (repo, oldRef)
-				// entries are evicted before the new-ref graph lands (#2224).
-				if cfg.BranchSwitchSink != nil {
-					cfg.BranchSwitchSink(ev.RepoPath, ev.OldRef)
-				}
-				// #5726: carry the new commit SHA so the reindex circuit breaker
-				// keys on the commit (branch switches always change the SHA →
-				// the breaker resets and the new ref gets a real attempt).
-				scheduler.EnqueueRefCommit(ev.RepoPath, ev.NewRef, ev.NewSHA)
-			}, logger)
-			headPoller.Start()
-			defer headPoller.Stop()
-
-			// M2 (#2179): lazy fsnotify subscription — do NOT call watcher.AddRepo
-			// at boot. The daemon starts with zero fsnotify subscriptions. Repos
-			// are subscribed on the first MCP query for their group (via
-			// SubscribeGroupWatcher → watch.DefaultManager.SubscribeGroup →
-			// watcher.AddRepo). This eliminates per-repo directory-tree walks at
-			// startup, saving ~O(dirs×groups) inotify watch descriptors on idle daemons.
-			//
-			// We still call ReposToWatch (exactly once) to:
-			//   (a) register repos with the HEAD poller (branch-switch detection; no fd cost)
-			//   (b) run the case-collision store audit (#2086)
-			// Both happen off the critical boot path in a goroutine, same as before.
-			if cfg.ReposToWatch != nil {
-				capturedStore := StoreDir()
-				go func() {
-					t0 := time.Now()
-					repos := cfg.ReposToWatch()
-					for _, r := range repos {
-						// M2: skip watcher.AddRepo here — subscriptions are lazy.
-						// Register with the HEAD poller only (reads .git/HEAD; no
-						// fsnotify watch descriptors consumed).
-						headPoller.AddRepo(r)
-					}
-					logger.Info("watcher: boot-path registered with HEAD poller (fsnotify lazy — 0 AddRepo calls)",
-						"repos", len(repos), "took", time.Since(t0).Truncate(time.Millisecond).String())
-
-					// #2086: case-collision audit — unchanged.
-					if capturedStore != "" {
-						if dups := WarnCaseCollisions(capturedStore, repos); len(dups) > 0 {
-							for _, pair := range dups {
-								logger.Warn("store: detected case-collision dup — remove stale dir to avoid confusion (grafel cleanup --case-merge)",
-									"stale", pair[0], "canonical", pair[1])
-							}
-						}
-					}
-				}()
-			}
-			if cfg.OnWatcherReady != nil {
-				cfg.OnWatcherReady(watcher)
-			}
-
-			// #3353/#3354: linked-worktree discovery + working-tree watching.
-			// Gated on the fsnotify watcher being up (we reuse it to watch each
-			// worktree's working tree) and on a caller-supplied parents provider
-			// (non-nil only when some group opts into worktree tracking).
-			var wtStore *worktree.Store
-			if cfg.WorktreeParents != nil {
-				wtStorePath := filepath.Join(cfg.Layout.Root, "worktrees.json")
-				wtStore = worktree.NewStore(wtStorePath)
-				if err := wtStore.Load(); err != nil {
-					logger.Warn("worktree: failed to load store; starting empty", "path", wtStorePath, "err", err)
-				}
-				wtWatcher := worktree.NewWatcher(wtStore, cfg.WorktreeParents, logger)
-
-				// #5675: bound the fsnotify-subscription fan-out. Each
-				// watcher.AddRepo(child.Path) subscribes the worktree's ENTIRE
-				// working tree, costing ~1 fd per directory on Linux inotify —
-				// UNBOUNDED by the number of activated worktrees. A burst of
-				// activations could open a flood of fds at once and crash the
-				// daemon into a KeepAlive/Restart relaunch loop. This semaphore
-				// caps how many subscriptions can be opening concurrently. For
-				// the common case (activations are dispatched sequentially by
-				// poll, one at a time) the semaphore is always immediately
-				// available — zero behavior change. Overridable via
-				// GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY.
-				activateSem := make(chan struct{}, worktreeActivateConcurrency())
-
-				// On activation, subscribe the worktree's WORKING TREE to the
-				// fsnotify watcher so uncommitted edits trigger a reactive
-				// reindex, and enqueue one immediate reindex of its ref tier.
-				// scheduler.Enqueue captures the worktree's checked-out ref via
-				// RefCapture(worktreePath), so the graph lands in the correct
-				// per-ref dir keyed by the worktree path (multi-ref model).
-				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
-					activateSem <- struct{}{}
-					_, aerr := watcher.AddRepo(child.Path)
-					<-activateSem
-					if aerr != nil {
-						logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
-					}
-					scheduler.Enqueue(child.Path)
-					logger.Info("worktree: watching working tree + enqueued initial reindex",
-						"path", child.Path, "branch", child.Branch, "group", child.GroupName, "slug", child.ParentSlug, "locked", child.Locked)
-				}
-				// On expiry, unsubscribe the working tree from the watcher.
-				wtWatcher.OnExpire = func(child *worktree.WorktreeChild) {
-					watcher.RemoveRepo(child.Path)
-					logger.Info("worktree: unwatched expired working tree", "path", child.Path)
-				}
-
-				wtCtx, wtCancel := context.WithCancel(ctx)
-				go wtWatcher.Start(wtCtx)
-				defer wtCancel()
-				logger.Info("worktree: discovery started",
-					"store", wtStorePath, "reconcile_env", "GRAFEL_WORKTREE_POLL_SECONDS")
-			}
-
-			// #3680: vanished-repo store reaper. Tracked repos (registered +
-			// active worktree children) whose directory no longer exists on
-			// disk have their store dir deleted and their fsnotify
-			// subscription dropped, reclaiming the orphaned ~100MB worktree
-			// stores that accumulated under ~/.grafel/store/.
-			trackedRepos := makeReaperTrackedRepos(cfg.ReposToWatch, wtStore)
-			// #5236: dead-ref / dead-worktree sweep. Reclaims store dirs +
-			// resident graphs for refs git no longer knows about, within
-			// still-present repos. Driven by the reaper on the shared cadence.
-			// Retention cap is env-tunable (GRAFEL_REF_RETENTION_CAP) so an
-			// operator can shrink the dead-ref footprint on a machine with
-			// heavy transient-ref churn (e.g. set it to 4). Resolved here so the
-			// effective value is logged; NewDeadRefSweeper would resolve the same
-			// value from a zero RetentionCap on its own.
-			refRetentionCap := EnvRefRetentionCap()
-			logger.Info("deadref: retention cap configured",
-				"cap", refRetentionCap, "env", RefRetentionCapEnv)
-			deadRefSweeper := NewDeadRefSweeper(DeadRefConfig{
-				TrackedRepos:   trackedRepos,
-				LiveRefs:       LiveGitRefs,
-				PrimaryRef:     PrimaryGitRef,
-				RefsDirForRepo: RefsDirForRepo,
-				DropReader:     cfg.DeadRefDropReader,
-				Tier:           cfg.DeadRefTier,
-				RetentionCap:   refRetentionCap,
-				Logger:         logger,
-			})
-			// #5263: orphan top-level store-root sweep. Reaps whole
-			// `<store>/<slug>-<hash>/` roots that map to a vanished source path
-			// and to no live group/primary — the gap between the vanished-repo
-			// GC (currently-tracked repos only) and the dead-ref GC (refs within
-			// still-tracked repos only). KnownSourcePaths includes EXPIRED
-			// worktrees so a now-gone path's root can still be attributed; roots
-			// attributable to no known path are kept (fail-closed).
-			orphanRootSweeper := NewOrphanRootSweeper(OrphanRootConfig{
-				KnownSourcePaths: makeKnownSourcePaths(cfg.ReposToWatch, wtStore),
-				// Tier / DropReaderForRoot are per-repo-path hooks; the daemon
-				// does not currently expose a whole-repo Forget here, and a
-				// reaped orphan root's source path is already GONE (no live
-				// slot to wake), so on-disk reclamation is the load-bearing
-				// effect. Any residual in-mem slot is dropped by the
-				// vanished-repo reaper / memory-pressure eviction.
-				Logger: logger,
-			})
-			reaper := NewReaper(ReaperConfig{
-				TrackedRepos:    trackedRepos,
-				StoreDirForRepo: repoBaseDir,
-				Untrack: func(repoPath string) {
-					watcher.RemoveRepo(repoPath)
-				},
-				// #5142: also reap stale/orphaned `grafel watch` PIDs that
-				// registered in the daemon-owned registry under the daemon root.
-				WatchRegistry: watchreg.New(watchreg.DefaultPath(cfg.Layout.Root)),
-				// #5632: also reap live `grafel watch` processes for managed
-				// repos that run from a STALE/foreign binary (version skew) or
-				// duplicate an existing watcher. ManagedRepo gates the sweep to
-				// the daemon's tracked repos only; the watcher's repo arg is
-				// matched (cleaned-absolute) against this set so unrelated
-				// processes are never touched.
-				ManagedRepo: makeManagedRepoPredicate(trackedRepos),
-				DeadRefs:    deadRefSweeper,
-				OrphanRoots: orphanRootSweeper,
-				Logger:      logger,
-			})
-			reaperStop := make(chan struct{})
-			reaper.Start(reaperStop)
-			defer close(reaperStop)
-			logger.Info("reaper: vanished-repo store GC started", "interval", "5m")
-		}
+	// ADR-0024 Phase 1 / PR2 (epic #5729): the engine plane — scheduler,
+	// watcher, git-HEAD poller, worktree discovery, reapers/sweepers, the
+	// status writer, pattern-decay, and the docgen sweeper. In split-mode
+	// serve (planeServeOnly) a separate supervised `grafel engine` child runs
+	// this, so we skip it here; in the monolith (flag-off default) and the
+	// standalone engine it runs in-process. The assembly lives in
+	// startEnginePlane (engineplane.go); the extraction is behavior-preserving
+	// for the monolith (same constructors, same order, LIFO teardown).
+	if plane != planeServeOnly {
+		ep := startEnginePlane(ctx, cfg, svc, logger)
+		defer ep.shutdown()
 	}
-	logger.Info("startup: scheduler-watcher done")
-
-	// Pattern confidence time-decay scheduler — runs every 6 hours (or a
-	// caller-supplied interval for tests). Requires PatternGroupDirs to be
-	// non-nil; skipped gracefully when the caller has not provided it.
-	logger.Info("startup: pattern-decay begin", "enabled", cfg.PatternGroupDirs != nil)
-	if cfg.PatternGroupDirs != nil {
-		decayInterval := cfg.PatternDecayInterval
-		if decayInterval <= 0 {
-			decayInterval = 6 * time.Hour
-		}
-		decayJob := buildPatternDecayJob(cfg.PatternGroupDirs, logger)
-		decaySched := agentpatterns.NewDecayScheduler(decayInterval, decayJob)
-		decayCtx, decayCancel := context.WithCancel(ctx)
-		go decaySched.Run(decayCtx)
-		defer decayCancel()
-		logger.Info("pattern decay scheduler started", "interval", decayInterval.String())
-	}
-	logger.Info("startup: pattern-decay done")
-
-	// Docgen background sweeper (issue #2216): removes stale staging runs and
-	// .previous-* backups every 24 h. Opt-in: nil = disabled (--no-auto-cleanup).
-	logger.Info("startup: docgen-sweeper begin", "enabled", cfg.DocgenSweep != nil)
-	if cfg.DocgenSweep != nil {
-		sweepCfg := *cfg.DocgenSweep
-		sweepCfg.Logger = logger
-		sweepStop := make(chan struct{})
-		StartDocgenSweeper(sweepCfg, sweepStop)
-		defer close(sweepStop)
-		interval := sweepCfg.Interval
-		if interval <= 0 {
-			interval = 24 * time.Hour
-		}
-		logger.Info("docgen sweeper started", "interval", interval.String())
-	}
-	logger.Info("startup: docgen-sweeper done")
 
 	// Dashboard HTTP server — started in a goroutine so it does not
 	// block the RPC socket. Shuts down when the daemon context is done.

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"log/slog"
 	"os"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -155,6 +156,65 @@ func knownRepoPathsForStatus(logger *slog.Logger) []string {
 		out = append(out, abs)
 	}
 	return out
+}
+
+// engineLivenessStatusKey returns the statusfile key for the engine-global
+// liveness heartbeat (ADR-0024 / #5729 PR2). It is an ABSOLUTE path under the
+// daemon root (so statusfile.PathFor's filepath.Abs is idempotent and both the
+// engine writer and the serve-side supervisor reader compute the same hash
+// regardless of cwd). No file is created at this path — statusfile hashes it
+// into GRAFEL_HOME/status/<hash>.json. It intentionally does NOT collide with
+// any real repo's per-repo status file.
+//
+// Unlike the per-repo status files (which only exist for registered fleet
+// repos), this engine-global file is written unconditionally by RunEngine, so
+// serve's health gate has a liveness signal even on a machine with no repos
+// registered yet.
+func engineLivenessStatusKey(root string) string {
+	return filepath.Join(root, ".engine-liveness")
+}
+
+// startEngineLivenessHeartbeat launches a goroutine that stamps the
+// engine-global liveness statusfile (EnginePID + a fresh HeartbeatAt) once
+// immediately and then every interval, until the returned stop func is called
+// (which joins the goroutine). It is the engine → serve liveness contract the
+// supervisor's health gate reads (ADR-0024, epic #5729 PR2).
+func startEngineLivenessHeartbeat(root string, interval time.Duration, logger *slog.Logger) (stop func()) {
+	if interval <= 0 {
+		interval = defaultStatusHeartbeatInterval
+	}
+	key := engineLivenessStatusKey(root)
+	stopCh := make(chan struct{})
+	doneCh := make(chan struct{})
+	writeOnce := func() {
+		f := &statusfile.File{
+			EnginePID:   os.Getpid(),
+			HeartbeatAt: time.Now().UTC(),
+			Version:     version.String(),
+			RepoPath:    key,
+		}
+		if err := statusfile.Write(key, f); err != nil && logger != nil {
+			logger.Warn("engine liveness: statusfile write failed", "err", err)
+		}
+	}
+	go func() {
+		defer close(doneCh)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		writeOnce()
+		for {
+			select {
+			case <-stopCh:
+				return
+			case <-ticker.C:
+				writeOnce()
+			}
+		}
+	}()
+	return func() {
+		close(stopCh)
+		<-doneCh
+	}
 }
 
 // statusWriter owns the single goroutine that writes every repo's status-plane

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -1,0 +1,312 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// supervise.go is the serve-side engine supervisor (ADR-0024 Phase 1 / PR2,
+// epic #5729). When the serve/engine split is ON, the serve process spawns a
+// `grafel engine` child and keeps it alive: it health-gates the child via the
+// engine-global liveness statusfile, relaunches it on crash with exponential
+// backoff, gracefully drains it on serve shutdown (SIGTERM → bounded wait →
+// SIGKILL, reaped — no orphan), and only gives up (surfacing a fatal so the OS
+// unit recycles serve) when the child crash-loops at the backoff ceiling.
+//
+// serve NEVER exits merely because the engine is degraded or dead: it keeps
+// answering reads from the last-good graph.fb. The engine is a restartable
+// child whose death is a local event, not a service event.
+
+// Supervisor tuning. All are overridable per-instance (see newEngineSupervisor)
+// so tests can run the whole spawn/crash/restart loop in milliseconds.
+const (
+	defaultEngineBackoffInitial = 500 * time.Millisecond
+	defaultEngineBackoffMax     = 30 * time.Second
+	// defaultEngineHealthyUptime: a child that stays up at least this long is
+	// considered to have recovered, so the backoff + crash-loop counters reset.
+	defaultEngineHealthyUptime = 60 * time.Second
+	// defaultEngineMaxCeilingHits: how many consecutive relaunches AT the
+	// backoff ceiling are tolerated before serve declares the engine unkeepable.
+	defaultEngineMaxCeilingHits = 3
+	// defaultEngineDrainTimeout bounds the graceful SIGTERM→exit wait before the
+	// supervisor escalates to SIGKILL during drain.
+	defaultEngineDrainTimeout = 5 * time.Second
+	// engineHealthStaleMultiplier: a liveness heartbeat older than this many
+	// heartbeat intervals marks the engine DEGRADED.
+	engineHealthStaleMultiplier = 3
+)
+
+// engineChildCommand builds the exec.Cmd that launches the engine child. It is
+// a package var so tests can substitute a helper-process command (the standard
+// os/exec subprocess-testing pattern) instead of spawning a real grafel binary.
+// Production uses defaultEngineChildCommand.
+var engineChildCommand = defaultEngineChildCommand
+
+// defaultEngineChildCommand launches `grafel engine --foreground` from the
+// current executable, in its own process group, with the daemon root threaded
+// through the environment (so the child's DefaultLayout resolves the same root)
+// and stdio inherited so its logs land alongside serve's.
+func defaultEngineChildCommand(selfExe, root string) *exec.Cmd {
+	cmd := exec.Command(selfExe, "engine", "--foreground")
+	cmd.Env = append(os.Environ(), EnvRoot+"="+root)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.SysProcAttr = engineChildSysProcAttr()
+	return cmd
+}
+
+// SetEngineChildCommandForTest overrides how the supervisor spawns the engine
+// child for the duration of a test and returns a restore closure. Tests use it
+// to spawn a helper subprocess (re-invoking the test binary) rather than a real
+// grafel binary. Production code must never call this.
+func SetEngineChildCommandForTest(fn func(selfExe, root string) *exec.Cmd) (restore func()) {
+	prev := engineChildCommand
+	engineChildCommand = fn
+	return func() { engineChildCommand = prev }
+}
+
+// engineSupervisor spawns and supervises the split-mode engine child process.
+type engineSupervisor struct {
+	layout  Layout
+	logger  *slog.Logger
+	selfExe string
+
+	backoffInitial time.Duration
+	backoffMax     time.Duration
+	healthyUptime  time.Duration
+	maxCeilingHits int
+	drainTimeout   time.Duration
+
+	mu       sync.Mutex
+	childPID int
+	fatalErr error
+
+	stopCh   chan struct{}
+	stopOnce sync.Once
+	doneCh   chan struct{}
+	fatalCh  chan error
+}
+
+// newEngineSupervisor constructs a supervisor with production defaults.
+func newEngineSupervisor(layout Layout, logger *slog.Logger) *engineSupervisor {
+	if logger == nil {
+		logger = buildSlogLogger(os.Stderr)
+	}
+	return &engineSupervisor{
+		layout:         layout,
+		logger:         logger,
+		backoffInitial: defaultEngineBackoffInitial,
+		backoffMax:     defaultEngineBackoffMax,
+		healthyUptime:  defaultEngineHealthyUptime,
+		maxCeilingHits: defaultEngineMaxCeilingHits,
+		drainTimeout:   defaultEngineDrainTimeout,
+	}
+}
+
+// start resolves the self executable and launches the supervision goroutine.
+// It returns once the goroutine is running (the first spawn happens inside it).
+func (s *engineSupervisor) start(ctx context.Context) error {
+	exe, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve self executable: %w", err)
+	}
+	s.selfExe = exe
+	s.stopCh = make(chan struct{})
+	s.doneCh = make(chan struct{})
+	s.fatalCh = make(chan error, 1)
+	go s.run(ctx)
+	return nil
+}
+
+// fatal returns a receive-only channel that fires once (with a non-nil error)
+// if the supervisor gives up keeping the engine alive.
+func (s *engineSupervisor) fatal() <-chan error { return s.fatalCh }
+
+// fatalError returns the recorded fatal error (nil if none). Safe to call after
+// the run loop has exited.
+func (s *engineSupervisor) fatalError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.fatalErr
+}
+
+// stop requests shutdown (the run loop drains the current child) and blocks
+// until the run loop has exited and the child is reaped. Idempotent.
+func (s *engineSupervisor) stop() {
+	if s.stopCh == nil {
+		return // never started
+	}
+	s.stopOnce.Do(func() { close(s.stopCh) })
+	<-s.doneCh
+}
+
+func (s *engineSupervisor) setChildPID(pid int) {
+	s.mu.Lock()
+	s.childPID = pid
+	s.mu.Unlock()
+}
+
+func (s *engineSupervisor) getChildPID() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.childPID
+}
+
+// healthy reports whether the engine child is currently HEALTHY: a live child
+// is spawned AND the engine-global liveness statusfile names that exact child
+// pid AND its heartbeat is fresh. The second return value explains a false
+// (DEGRADED) verdict.
+func (s *engineSupervisor) healthy() (bool, string) {
+	pid := s.getChildPID()
+	if pid == 0 {
+		return false, "no engine child running"
+	}
+	f, err := statusfile.Read(engineLivenessStatusKey(s.layout.Root))
+	if err != nil {
+		return false, "engine liveness file missing"
+	}
+	if f.EnginePID != pid {
+		return false, fmt.Sprintf("liveness pid %d != spawned child pid %d", f.EnginePID, pid)
+	}
+	maxAge := time.Duration(engineHealthStaleMultiplier) * statusHeartbeatInterval()
+	if age := time.Since(f.HeartbeatAt); age > maxAge {
+		return false, fmt.Sprintf("stale heartbeat (%s old, max %s)", age.Truncate(time.Millisecond), maxAge)
+	}
+	return true, ""
+}
+
+// run is the supervision loop: spawn, wait, relaunch-with-backoff, and finally
+// drain on stop/ctx-cancel.
+func (s *engineSupervisor) run(ctx context.Context) {
+	defer close(s.doneCh)
+
+	backoff := s.backoffInitial
+	ceilingHits := 0
+
+	for {
+		// Bail before spawning if we've been asked to stop.
+		select {
+		case <-s.stopCh:
+			return
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		cmd := engineChildCommand(s.selfExe, s.layout.Root)
+		startedAt := time.Now()
+		if err := cmd.Start(); err != nil {
+			s.logger.Error("engine supervisor: spawn failed", "err", err)
+			// Treat a failed spawn like a crash: back off and retry.
+			if s.backoffAndMaybeGiveUp(ctx, &backoff, &ceilingHits) {
+				return
+			}
+			continue
+		}
+		pid := cmd.Process.Pid
+		s.setChildPID(pid)
+		s.logger.Info("engine supervisor: engine child started", "pid", pid, "exe", s.selfExe)
+
+		waitCh := make(chan error, 1)
+		go func() { waitCh <- cmd.Wait() }()
+
+		select {
+		case <-s.stopCh:
+			s.terminateChild(cmd, waitCh)
+			return
+		case <-ctx.Done():
+			s.terminateChild(cmd, waitCh)
+			return
+		case werr := <-waitCh:
+			s.setChildPID(0)
+			uptime := time.Since(startedAt)
+			s.logger.Warn("engine supervisor: engine child exited",
+				"pid", pid, "err", werr, "uptime", uptime.Truncate(time.Millisecond))
+			// A child that stayed up long enough counts as recovered: reset the
+			// crash-loop bookkeeping so a later, unrelated crash starts fresh.
+			if uptime >= s.healthyUptime {
+				backoff = s.backoffInitial
+				ceilingHits = 0
+			}
+			if s.backoffAndMaybeGiveUp(ctx, &backoff, &ceilingHits) {
+				return
+			}
+		}
+	}
+}
+
+// backoffAndMaybeGiveUp sleeps for the current backoff (waking early on
+// stop/ctx-cancel), grows it toward the ceiling, and counts consecutive
+// relaunches at the ceiling. It returns true when the run loop should exit —
+// either because shutdown was requested during the wait, or because the engine
+// is unkeepable (in which case it also records + signals the fatal).
+func (s *engineSupervisor) backoffAndMaybeGiveUp(ctx context.Context, backoff *time.Duration, ceilingHits *int) (done bool) {
+	if *backoff >= s.backoffMax {
+		*ceilingHits++
+		if *ceilingHits >= s.maxCeilingHits {
+			err := fmt.Errorf("engine child crash-looping: %d consecutive relaunches at the %s backoff ceiling",
+				*ceilingHits, s.backoffMax)
+			s.logger.Error("engine supervisor: giving up — engine unkeepable", "err", err)
+			s.mu.Lock()
+			s.fatalErr = err
+			s.mu.Unlock()
+			select {
+			case s.fatalCh <- err:
+			default:
+			}
+			return true
+		}
+	}
+
+	wait := *backoff
+	s.logger.Info("engine supervisor: relaunching engine after backoff", "backoff", wait)
+	timer := time.NewTimer(wait)
+	defer timer.Stop()
+	select {
+	case <-s.stopCh:
+		return true
+	case <-ctx.Done():
+		return true
+	case <-timer.C:
+	}
+
+	*backoff *= 2
+	if *backoff > s.backoffMax {
+		*backoff = s.backoffMax
+	}
+	return false
+}
+
+// terminateChild gracefully drains the running child: SIGTERM, wait up to
+// drainTimeout, then SIGKILL, always reaping via the existing waitCh (cmd.Wait
+// may be called only once, so the run loop's waitCh goroutine owns it and we
+// consume its result here). On return the child is reaped — no orphan, no
+// zombie.
+func (s *engineSupervisor) terminateChild(cmd *exec.Cmd, waitCh chan error) {
+	if cmd.Process == nil {
+		return
+	}
+	pid := cmd.Process.Pid
+	s.logger.Info("engine supervisor: draining engine child", "pid", pid)
+	_ = signalTerminate(cmd.Process)
+
+	timer := time.NewTimer(s.drainTimeout)
+	defer timer.Stop()
+	select {
+	case <-waitCh:
+		s.logger.Info("engine supervisor: engine child exited after SIGTERM", "pid", pid)
+	case <-timer.C:
+		s.logger.Warn("engine supervisor: engine child did not exit within drain window — SIGKILL",
+			"pid", pid, "timeout", s.drainTimeout)
+		_ = cmd.Process.Kill()
+		<-waitCh // reap
+	}
+	s.setChildPID(0)
+}

--- a/internal/daemon/supervise_test.go
+++ b/internal/daemon/supervise_test.go
@@ -1,0 +1,276 @@
+//go:build darwin || linux
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestEngineChildHelper is the subprocess entrypoint the supervisor tests spawn
+// in place of a real `grafel engine` binary (the standard os/exec
+// subprocess-testing pattern). It runs a genuine RunEngine — writing engine.pid,
+// publishing the engine-global liveness heartbeat, and blocking until SIGTERM —
+// so the supervisor's spawn/health/restart/drain paths exercise the real thing.
+// It is inert unless GRAFEL_ENGINE_CHILD_HELPER=1 is set by the spawner.
+func TestEngineChildHelper(t *testing.T) {
+	if os.Getenv("GRAFEL_ENGINE_CHILD_HELPER") != "1" {
+		return
+	}
+	root := os.Getenv(EnvRoot)
+	// A short heartbeat keeps the liveness file fresh so the parent's health
+	// gate flips to HEALTHY quickly.
+	_ = os.Setenv(EnvStatusHeartbeatSeconds, "1")
+	layout := layoutFromRoot(root, "")
+	// RunEngine blocks until SIGTERM/SIGINT; the supervisor delivers SIGTERM on
+	// drain, at which point this returns and the helper process exits 0.
+	if err := RunEngine(context.Background(), EngineConfig{Config: Config{Layout: layout}}); err != nil {
+		t.Fatalf("RunEngine (helper): %v", err)
+	}
+}
+
+// helperEngineCommand returns an engineChildCommand override that spawns the
+// TestEngineChildHelper subprocess instead of a real grafel binary.
+func helperEngineCommand() func(selfExe, root string) *exec.Cmd {
+	return func(selfExe, root string) *exec.Cmd {
+		cmd := exec.Command(selfExe, "-test.run=TestEngineChildHelper", "-test.timeout=120s")
+		cmd.Env = append(os.Environ(),
+			"GRAFEL_ENGINE_CHILD_HELPER=1",
+			EnvRoot+"="+root,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.SysProcAttr = engineChildSysProcAttr()
+		return cmd
+	}
+}
+
+// isolateSupervisorEnv points GRAFEL_DAEMON_ROOT and GRAFEL_HOME at a fresh
+// short temp dir (so both the engine.pid under the daemon root and the
+// statusfile under GRAFEL_HOME land in the sandbox) and disables self-defense.
+// Returns the root.
+func isolateSupervisorEnv(t *testing.T) string {
+	t.Helper()
+	root, err := os.MkdirTemp("/tmp", "archi-sup-")
+	if err != nil {
+		t.Fatalf("mktemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	t.Setenv(EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", root)
+	t.Setenv(EnvDisableSelfDefense, "1")
+	// Fast heartbeat so health gating and restart detection resolve quickly.
+	t.Setenv(EnvStatusHeartbeatSeconds, "1")
+	return root
+}
+
+// newTestSupervisor builds a supervisor tuned for millisecond-scale tests.
+func newTestSupervisor(t *testing.T, root string) *engineSupervisor {
+	t.Helper()
+	s := newEngineSupervisor(layoutFromRoot(root, ""), buildSlogLogger(os.Stderr))
+	s.backoffInitial = 150 * time.Millisecond
+	s.backoffMax = 400 * time.Millisecond
+	s.healthyUptime = 400 * time.Millisecond
+	s.drainTimeout = 3 * time.Second
+	return s
+}
+
+func pidAliveUnix(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitFor(t *testing.T, timeout time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+func readEnginePID(root string) int {
+	b, err := os.ReadFile(EnginePIDPath(root))
+	if err != nil {
+		return 0
+	}
+	pid, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return pid
+}
+
+// TestEngineSupervisor_SpawnsHealthyChildWritesPidAndHeartbeat covers harness
+// scenario 1: serve starts, spawns an engine child, engine.pid is written, and
+// the liveness statusfile shows a fresh EnginePID/HeartbeatAt matching the
+// spawned child. Then stop() reaps the child (no orphan).
+func TestEngineSupervisor_SpawnsHealthyChildWritesPidAndHeartbeat(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	defer SetEngineChildCommandForTest(helperEngineCommand())()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newTestSupervisor(t, root)
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+
+	if !waitFor(t, 30*time.Second, func() bool {
+		ok, _ := sup.healthy()
+		return ok
+	}) {
+		_, why := sup.healthy()
+		t.Fatalf("engine child never became HEALTHY: %s", why)
+	}
+
+	pid := sup.getChildPID()
+	if pid == 0 {
+		t.Fatal("supervisor reports no child pid despite HEALTHY")
+	}
+	if got := readEnginePID(root); got != pid {
+		t.Fatalf("engine.pid = %d, want spawned child pid %d", got, pid)
+	}
+
+	// Drain: stop() must reap the child — no orphan.
+	sup.stop()
+	if !waitFor(t, 6*time.Second, func() bool { return !pidAliveUnix(pid) }) {
+		t.Fatalf("engine child pid %d still alive after stop() — orphaned", pid)
+	}
+}
+
+// TestEngineSupervisor_FaultIsolationRestart covers harness scenario 2: kill the
+// engine child (SIGKILL) and assert (a) the supervisor reports DEGRADED (health
+// gate flips), and (b) it restarts the engine with a fresh, different child that
+// heartbeats and returns to HEALTHY.
+func TestEngineSupervisor_FaultIsolationRestart(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	defer SetEngineChildCommandForTest(helperEngineCommand())()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newTestSupervisor(t, root)
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	t.Cleanup(sup.stop)
+
+	if !waitFor(t, 30*time.Second, func() bool { ok, _ := sup.healthy(); return ok }) {
+		_, why := sup.healthy()
+		t.Fatalf("engine never HEALTHY initially: %s", why)
+	}
+	pid1 := sup.getChildPID()
+
+	// Fault: hard-kill the engine child.
+	if err := syscall.Kill(pid1, syscall.SIGKILL); err != nil {
+		t.Fatalf("SIGKILL engine child %d: %v", pid1, err)
+	}
+
+	// (a) serve must observe DEGRADED (health gate false) after the kill.
+	if !waitFor(t, 10*time.Second, func() bool { ok, _ := sup.healthy(); return !ok }) {
+		t.Fatal("supervisor never reported DEGRADED after engine child was killed")
+	}
+
+	// (b) serve must restart the engine: a DIFFERENT child pid becomes HEALTHY
+	// again with a fresh heartbeat.
+	if !waitFor(t, 30*time.Second, func() bool {
+		ok, _ := sup.healthy()
+		return ok && sup.getChildPID() != pid1
+	}) {
+		t.Fatalf("engine was not restarted to a fresh HEALTHY child (still pid %d)", pid1)
+	}
+	pid2 := sup.getChildPID()
+	if pid2 == pid1 || pid2 == 0 {
+		t.Fatalf("restarted child pid = %d, want a new non-zero pid (was %d)", pid2, pid1)
+	}
+	// The killed process must be gone; the replacement must be alive.
+	if pidAliveUnix(pid1) {
+		t.Errorf("killed engine child %d is still alive", pid1)
+	}
+	if !pidAliveUnix(pid2) {
+		t.Errorf("replacement engine child %d is not alive", pid2)
+	}
+}
+
+// TestEngineSupervisor_GracefulDrainReapsChild covers harness scenario 3: a
+// graceful stop SIGTERMs the child and reaps it — no orphan left behind.
+func TestEngineSupervisor_GracefulDrainReapsChild(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	defer SetEngineChildCommandForTest(helperEngineCommand())()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newTestSupervisor(t, root)
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+	if !waitFor(t, 30*time.Second, func() bool { ok, _ := sup.healthy(); return ok }) {
+		t.Fatal("engine never HEALTHY")
+	}
+	pid := sup.getChildPID()
+
+	sup.stop()
+
+	if pidAliveUnix(pid) {
+		// Give the OS a beat to finish reaping, then re-check.
+		if !waitFor(t, 3*time.Second, func() bool { return !pidAliveUnix(pid) }) {
+			t.Fatalf("engine child %d orphaned after graceful drain", pid)
+		}
+	}
+	// After a clean drain, no fatal should have been recorded.
+	if err := sup.fatalError(); err != nil {
+		t.Errorf("unexpected fatal after graceful drain: %v", err)
+	}
+}
+
+// TestEngineSupervisor_UnkeepableEngineIsFatal asserts the one path where serve
+// gives up: a child that cannot start at all (bad command) crash-loops at the
+// backoff ceiling until the supervisor records + signals a fatal, which is what
+// makes RunServe exit non-zero so the OS unit recycles it.
+func TestEngineSupervisor_UnkeepableEngineIsFatal(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	// Command that exits immediately (nonexistent subcommand → helper env unset
+	// → returns instantly), forcing a relentless crash loop.
+	defer SetEngineChildCommandForTest(func(selfExe, root string) *exec.Cmd {
+		cmd := exec.Command(selfExe, "-test.run=TestEngineChildHelper")
+		// NOTE: GRAFEL_ENGINE_CHILD_HELPER intentionally NOT set, so the helper
+		// returns immediately → the child exits ~instantly every time.
+		cmd.Env = append(os.Environ(), EnvRoot+"="+root)
+		cmd.SysProcAttr = engineChildSysProcAttr()
+		return cmd
+	})()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newEngineSupervisor(layoutFromRoot(root, ""), buildSlogLogger(os.Stderr))
+	// Tiny backoff + low ceiling so the fatal lands fast.
+	sup.backoffInitial = 20 * time.Millisecond
+	sup.backoffMax = 40 * time.Millisecond
+	sup.healthyUptime = 10 * time.Second // never "recovers"
+	sup.maxCeilingHits = 3
+	sup.drainTimeout = time.Second
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	t.Cleanup(sup.stop)
+
+	select {
+	case err := <-sup.fatal():
+		if err == nil {
+			t.Fatal("fatal channel fired with nil error")
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("supervisor never surfaced a fatal for an unkeepable engine")
+	}
+	if sup.fatalError() == nil {
+		t.Error("fatalError() nil after fatal fired")
+	}
+}

--- a/internal/daemon/supervise_unix.go
+++ b/internal/daemon/supervise_unix.go
@@ -1,0 +1,24 @@
+//go:build darwin || linux
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+// engineChildSysProcAttr puts the engine child in its OWN process group
+// (Setpgid) so a terminal signal to serve's foreground group does not race
+// serve's own graceful drain of the child, and so the supervisor is the single
+// authority over the child's lifecycle (mirrors the detach pattern in
+// internal/cli/detach_unix.go). It remains a child process, so cmd.Wait reaps
+// it normally.
+func engineChildSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{Setpgid: true}
+}
+
+// signalTerminate asks the engine child to shut down gracefully (SIGTERM). Its
+// RunEngine signal handler catches this and unwinds the scheduler/watcher.
+func signalTerminate(p *os.Process) error {
+	return p.Signal(syscall.SIGTERM)
+}

--- a/internal/daemon/supervise_windows.go
+++ b/internal/daemon/supervise_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+
+package daemon
+
+import (
+	"os"
+	"syscall"
+)
+
+// engineChildSysProcAttr requests a new process group on Windows so the child
+// is not sent console CTRL_C_EVENT alongside serve; the supervisor drives its
+// lifecycle explicitly.
+func engineChildSysProcAttr() *syscall.SysProcAttr {
+	return &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+}
+
+// signalTerminate on Windows cannot deliver a POSIX SIGTERM to another process;
+// os.Process.Signal only supports Kill/Interrupt and Interrupt is unsupported
+// for non-console children. Kill is the reliable terminate here — the engine's
+// defers do not run, but the supervised graph.fb writes are atomic (temp+rename)
+// so a killed engine never leaves a torn graph.
+func signalTerminate(p *os.Process) error {
+	return p.Kill()
+}


### PR DESCRIPTION
**PR2 of the serve/engine split (ADR-0024, epic #5729)** — the fault-isolation increment. Gated behind `GRAFEL_SPLIT_MODE` (default OFF = today's single-process behavior, byte-identical), so the running daemon is unaffected until a later PR flips the default.

When split-mode is ON: **serve** (MCP socket + dashboard + graph.fb mmap reads) spawns and supervises a **`grafel engine`** child (scheduler / watcher / git-HEAD poller / extraction / enrichment / fbwriter). An engine crash or an engine-only redeploy no longer drops the MCP socket — serve keeps answering reads from the last-good `graph.fb` and restarts the engine with backoff.

- **Supervisor** (`supervise.go`, +unix/windows): spawns `grafel engine --foreground` in its own process group; restart is **purely crash-driven** (on `cmd.Wait` return), exponential backoff 500ms→30s, healthy-uptime resets the counters, and serve only returns fatal (→ OS unit recycles) after `maxCeilingHits` consecutive ceiling relaunches. Graceful drain: SIGTERM → bounded wait → SIGKILL, reaped via a single `cmd.Wait` (no orphan). `stopCh` observed at every blocking point (no restart-vs-drain race).
- **`RunEngine`** (serve-free boot in `engineplane.go`): scheduler/watcher/poller/reapers/sweepers + status writer + fbwriter; writes `engine.pid`; runs the liveness heartbeat (`EnginePID`/`HeartbeatAt`); NO socket/dashboard/MCP.
- **`server.go`** carved: `Run`→`run(ctx,cfg,plane)`; `planeMonolith` (flag-off, in-process, unchanged) vs `planeServeOnly` (spawn engine). The engine block is a verbatim carve (each `defer X`→`ep.add(X)`, LIFO unwind).
- Rebased onto the #5726 circuit-breaker: its `RefCapture (ref,commit)` + poller `EnqueueRefCommit(ev.NewSHA)` carried into `engineplane.go`; `scheduler.go` net-diff empty (breaker intact).

Health is currently **observation-only** — a wedged-but-alive engine (process up, heartbeat stale) is reportable as DEGRADED but not auto-restarted (safer than health-gated restart, which risks killing a slow-starting engine). Wiring degraded-state into the Status RPC + a liveness-based restart are tracked for PR3 / a follow-up.

**Tests:** 8 split tests (supervisor spawn/health/pid+heartbeat, fault-isolation restart, graceful-drain reap, unkeepable→fatal, RunServe-matches-daemon, flag-OFF no-child, e2e split-mode fault isolation). 916 tests + `-race` clean; Windows cross-build clean; smoke-tested (2 processes, engine SIGKILL→serve survives+restarts, SIGTERM→no orphan). `index_status`/warming in split-mode deferred to PR3 (ordering guard: default not flipped until PR3 lands).

Independent Opus review APPROVE: no startup-grace loop, no orphan/double-Wait, flag-off identical, circuit-breaker SHA preserved.

Refs #5729 #5726