### PR TITLE
fix(php,enrichment): Lumen framework attribution + Slim group/map exclusion test + enrichment orphan-temp cleanup (refs #5739)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -406,6 +406,13 @@ type indexerStats struct {
 // restore it afterward.
 var enrichmentOrderHook = func(stage string) {}
 
+// enrichmentEmittersForBG returns the CandidateEmitter set used by
+// runPass6EmitEnrichmentCandidatesBG. Test-only override seam (defaults to
+// enrichment.DefaultEmitters): tests can swap this to inject a panicking
+// emitter and assert the background trickle path cleans up its temp file
+// even when it never reaches Close() (#5739 item d).
+var enrichmentEmittersForBG = enrichment.DefaultEmitters
+
 func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, jsonStats bool, opts ...IndexOption) error {
 	absRepo, err := filepath.Abs(repoPath)
 	if err != nil {
@@ -2864,9 +2871,18 @@ func (i *Indexer) runPass6EmitEnrichmentCandidatesBG(ctx context.Context, doc *g
 		fmt.Fprintf(os.Stderr, "grafel: enrichment (bg) appender init failed: %v\n", err)
 		return
 	}
+	// Safety net for a panic mid-trickle (#5739 item d, refs #5736 review):
+	// the explicit Abort() calls below cover every known error/cancellation
+	// path, but a panic unwinds past all of them and would otherwise leave an
+	// orphaned enrichment-candidates.json.trickle.tmp-* in the state dir with
+	// no sweep to reclaim it. Abort() is idempotent with Close() (both set
+	// a.closed and no-op if already set), so on the normal success path below
+	// — where Close() already committed the rename — this deferred Abort() is
+	// a harmless no-op, not a second write.
+	defer appender.Abort()
 
 	rej := enrichment.ReadRejections(grafelDir)
-	err = enrichment.CollectAndAppendTrickle(ctx, doc, enrichment.DefaultEmitters(), rej, appender, enrichment.TrickleOptions{})
+	err = enrichment.CollectAndAppendTrickle(ctx, doc, enrichmentEmittersForBG(), rej, appender, enrichment.TrickleOptions{})
 	if err != nil {
 		// Cancelled (superseded) or failed mid-stream — never publish a
 		// partial file over whatever was there before.

--- a/cmd/grafel/index_enrichment_bg_test.go
+++ b/cmd/grafel/index_enrichment_bg_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/enrichment"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
@@ -140,6 +141,65 @@ func TestIndex_LargeGraphDefersEnrichmentToBackground(t *testing.T) {
 	candPath := filepath.Join(daemon.StateDirForRepo(absRepo), "enrichment-candidates.json")
 	if _, err := os.Stat(candPath); err != nil {
 		t.Fatalf("expected enrichment-candidates.json to eventually appear after the background worker completes: %v", err)
+	}
+}
+
+// panickyEmitter is a CandidateEmitter that panics on the first entity it
+// sees — used to simulate a bug in a real emitter panicking mid-trickle.
+type panickyEmitter struct{}
+
+func (panickyEmitter) Name() string { return "panicky_test_emitter" }
+func (panickyEmitter) EmitFor(entity *graph.Entity, doc *graph.Document) []enrichment.Candidate {
+	panic("boom: simulated emitter panic mid-trickle")
+}
+
+// TestRunPass6EmitEnrichmentCandidatesBG_PanicLeavesNoOrphanTemp is the
+// RED-before-fix test for #5739 item d (refs #5736 review): before the fix,
+// a panic raised by CollectAndAppendTrickle (e.g. a pathological emitter)
+// unwound past every explicit appender.Abort() call in
+// runPass6EmitEnrichmentCandidatesBG, leaving an orphaned
+// enrichment-candidates.json.trickle.tmp-* file in the state dir with no
+// glob sweep to reclaim it. The fix adds `defer appender.Abort()` right
+// after the appender is created, so a panic still removes the temp file.
+func TestRunPass6EmitEnrichmentCandidatesBG_PanicLeavesNoOrphanTemp(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	prevEmitters := enrichmentEmittersForBG
+	enrichmentEmittersForBG = func() []enrichment.CandidateEmitter {
+		return []enrichment.CandidateEmitter{panickyEmitter{}}
+	}
+	defer func() { enrichmentEmittersForBG = prevEmitters }()
+
+	absRepo, err := filepath.Abs(filepath.Join(t.TempDir(), "panic-repo"))
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	grafelDir := daemon.StateDirForRepo(absRepo)
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{{ID: "e1", Kind: "SCOPE.Operation", Name: "f", SourceFile: "f.go"}},
+	}
+
+	idx := &Indexer{skipPasses: map[string]bool{}}
+
+	func() {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Fatalf("expected runPass6EmitEnrichmentCandidatesBG to panic (via the injected emitter) — test setup is wrong")
+			}
+		}()
+		idx.runPass6EmitEnrichmentCandidatesBG(context.Background(), doc, absRepo)
+	}()
+
+	matches, err := filepath.Glob(filepath.Join(grafelDir, "enrichment-candidates.json.trickle.tmp-*"))
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Fatalf("expected no orphaned trickle temp files after a panic, found: %v", matches)
+	}
+	if _, err := os.Stat(filepath.Join(grafelDir, "enrichment-candidates.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no published candidates file after an aborted (panicked) run, stat err=%v", err)
 	}
 }
 

--- a/internal/engine/http_endpoint_php_producer.go
+++ b/internal/engine/http_endpoint_php_producer.go
@@ -622,8 +622,13 @@ var slimRouteVerbRe = regexp.MustCompile(
 		`(?:"([^"]{1,500})"|'([^']{1,500})')`,
 )
 
-// phpHasAnySlimRoute is the fast-path gate mirroring phpHasAnyLaravelRoute:
-// no-op on any PHP file that isn't wiring up Slim routes.
+// phpHasAnySlimRoute is the fast-path gate mirroring phpHasAnyLaravelRoute.
+// NOTE: despite the name, this is NOT a no-op on non-Slim PHP files — the
+// $app->verb('/path', ...) idiom it matches is IDENTICAL to the one Lumen
+// uses (see reLumenRoute in internal/custom/php/frameworks.go), so a Lumen
+// app trips this gate too. synthesizeSlim below still emits endpoints for
+// both (that's a net gain either way); phpIsLumenSource is what tells the
+// two apart for the "framework" attribute.
 func phpHasAnySlimRoute(content string) bool {
 	return strings.Contains(content, "$app->get(") ||
 		strings.Contains(content, "$app->post(") ||
@@ -632,6 +637,21 @@ func phpHasAnySlimRoute(content string) bool {
 		strings.Contains(content, "$app->delete(") ||
 		strings.Contains(content, "$app->options(") ||
 		strings.Contains(content, "$app->any(")
+}
+
+// phpLumenMarkerRe matches source-level markers that identify a file as part
+// of a Lumen application rather than a Slim one — the composer package name
+// or the framework's root namespace. Lumen's own extractor (frameworks.go)
+// recognizes the identical $app->verb(...) idiom as Slim's, so without a
+// marker check the two frameworks are textually indistinguishable at the
+// route-call level.
+var phpLumenMarkerRe = regexp.MustCompile(`Laravel\\Lumen|laravel/lumen`)
+
+// phpIsLumenSource reports whether content carries an explicit Lumen
+// framework marker (refs #5739 item b, follow-up to #5738 review: a Lumen
+// app's $app->get(...) routes were being mislabeled framework="slim").
+func phpIsLumenSource(content string) bool {
+	return phpLumenMarkerRe.MatchString(content)
 }
 
 // synthesizeSlim scans a PHP source file for Slim route registrations
@@ -650,9 +670,18 @@ func phpHasAnySlimRoute(content string) bool {
 // convention — there is no reliable static handler reference to forward.
 // This mirrors the closure-handler case in synthesizeLaravel (empty
 // handlerKind/handlerName).
+//
+// framework attribution: the $app->verb(...) idiom matched here is shared
+// verbatim with Lumen (refs #5739 item b). A file carrying a Lumen marker
+// (phpIsLumenSource) is stamped framework="lumen" instead of "slim" — the
+// endpoints are still emitted either way, only the attribute changes.
 func synthesizeSlim(content string, emit emitFn) {
 	if !phpHasAnySlimRoute(content) {
 		return
+	}
+	framework := "slim"
+	if phpIsLumenSource(content) {
+		framework = "lumen"
 	}
 	for _, m := range slimRouteVerbRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 4 {
@@ -671,6 +700,6 @@ func synthesizeSlim(content string, emit emitFn) {
 		}
 
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
-		emit(verb, canonical, "slim", "", "")
+		emit(verb, canonical, framework, "", "")
 	}
 }

--- a/internal/engine/http_endpoint_php_producer_slim_test.go
+++ b/internal/engine/http_endpoint_php_producer_slim_test.go
@@ -152,3 +152,79 @@ $app->any('/webhook', function () {});
 		t.Fatalf("expected 1 ANY match, got %+v", matches)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// group()/map() exclusion (#5739 item c, refs #5738 review): slimRouteVerbRe
+// intentionally excludes group/map — they register a route SET or dispatch by
+// method-list, they are not themselves an HTTP-verb route — but that was only
+// ever asserted implicitly via the compiled verb alternation. Pin it down
+// explicitly so a future edit to the verb list can't silently reintroduce
+// group/map as if they were routes.
+// ---------------------------------------------------------------------------
+
+func TestSynthSlim_GroupNotEmitted(t *testing.T) {
+	src := `<?php
+$app->group('/admin', function () {
+    $this->get('/users', function () {});
+});
+`
+	ids := collectSlimSynthetics(src)
+	if len(ids) != 0 {
+		t.Errorf("expected $app->group(...) to yield 0 http_endpoint_definition synthetics, got %v", ids)
+	}
+}
+
+func TestSynthSlim_MapNotEmitted(t *testing.T) {
+	src := `<?php
+$app->map(['GET', 'POST'], '/both', function () {});
+`
+	ids := collectSlimSynthetics(src)
+	if len(ids) != 0 {
+		t.Errorf("expected $app->map(...) to yield 0 http_endpoint_definition synthetics, got %v", ids)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Lumen vs Slim framework attribution (#5739 item b, refs #5738 review):
+// Lumen's $app->verb(...) idiom is identical to Slim's, so synthesizeSlim
+// used to stamp every Lumen endpoint framework="slim". A Lumen marker in the
+// source now relabels those endpoints framework="lumen"; a genuine Slim
+// source is unaffected.
+// ---------------------------------------------------------------------------
+
+func TestSynthSlim_LumenSourceLabeledLumen(t *testing.T) {
+	src := `<?php
+// bootstrap/app.php
+$app = new Laravel\Lumen\Application(
+    dirname(__DIR__)
+);
+
+$app->get('/users', function () {});
+$app->post('/users', 'UserController@store');
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 2 {
+		t.Fatalf("expected 2 matches, got %d: %+v", len(matches), matches)
+	}
+	for _, m := range matches {
+		if m.framework != "lumen" {
+			t.Errorf("expected framework=lumen for Lumen-marked source, got %q for %+v", m.framework, m)
+		}
+	}
+}
+
+func TestSynthSlim_SlimSourceStillLabeledSlim(t *testing.T) {
+	src := `<?php
+use Slim\Factory\AppFactory;
+
+$app = AppFactory::create();
+$app->get('/users', function () {});
+`
+	matches := collectSlimMatches(src)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].framework != "slim" {
+		t.Errorf("expected framework=slim, got %q", matches[0].framework)
+	}
+}

--- a/internal/engine/http_endpoint_php_producer_slim_test.go
+++ b/internal/engine/http_endpoint_php_producer_slim_test.go
@@ -163,25 +163,48 @@ $app->any('/webhook', function () {});
 // ---------------------------------------------------------------------------
 
 func TestSynthSlim_GroupNotEmitted(t *testing.T) {
+	// A genuine verb route ($app->get) sits alongside the $app->group call so
+	// phpHasAnySlimRoute trips and synthesizeSlim actually reaches
+	// slimRouteVerbRe — otherwise the fast-path gate would short-circuit and
+	// this would be a trivially-passing duplicate of the no-routes test.
 	src := `<?php
+$app->get('/real', function () {});
 $app->group('/admin', function () {
     $this->get('/users', function () {});
 });
 `
 	ids := collectSlimSynthetics(src)
-	if len(ids) != 0 {
-		t.Errorf("expected $app->group(...) to yield 0 http_endpoint_definition synthetics, got %v", ids)
+	want := []string{"http:GET:/real"}
+	if !equalStringSlices(ids, want) {
+		t.Errorf("expected exactly the /real verb route emitted and NO synthetic for the group path, got %v", ids)
 	}
 }
 
 func TestSynthSlim_MapNotEmitted(t *testing.T) {
+	// See TestSynthSlim_GroupNotEmitted: the $app->get('/real', ...) is what
+	// gets synthesizeSlim past the fast-path gate so slimRouteVerbRe runs and
+	// the $app->map exclusion is genuinely exercised.
 	src := `<?php
+$app->get('/real', function () {});
 $app->map(['GET', 'POST'], '/both', function () {});
 `
 	ids := collectSlimSynthetics(src)
-	if len(ids) != 0 {
-		t.Errorf("expected $app->map(...) to yield 0 http_endpoint_definition synthetics, got %v", ids)
+	want := []string{"http:GET:/real"}
+	if !equalStringSlices(ids, want) {
+		t.Errorf("expected exactly the /real verb route emitted and NO synthetic for the map path, got %v", ids)
 	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/enrichment/trickle_test.go
+++ b/internal/enrichment/trickle_test.go
@@ -235,6 +235,45 @@ func TestCandidateAppender_Abort(t *testing.T) {
 	}
 }
 
+// TestCandidateAppender_AbortAfterCloseIsNoop pins down the invariant the
+// cmd/grafel background enrichment worker relies on for its "always defer
+// appender.Abort() as a panic safety net" fix (#5739 item d): once Close()
+// has already committed the rename, a subsequent Abort() (e.g. from a
+// deferred call that runs on every return path, success included) must be a
+// harmless no-op — it must NOT remove the just-published candidates file or
+// otherwise disturb it.
+func TestCandidateAppender_AbortAfterCloseIsNoop(t *testing.T) {
+	dir := t.TempDir()
+
+	appender, err := NewCandidateAppender(dir)
+	if err != nil {
+		t.Fatalf("NewCandidateAppender: %v", err)
+	}
+	if err := appender.AppendChunk([]Candidate{{ID: "one", Kind: "describe_entity", SubjectID: "e1"}}); err != nil {
+		t.Fatalf("AppendChunk: %v", err)
+	}
+	if err := appender.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	published, err := os.ReadFile(candidatesPath(dir))
+	if err != nil {
+		t.Fatalf("read published file after Close: %v", err)
+	}
+
+	// Simulate the deferred safety-net call that now always runs, even on the
+	// success path, after Close() already committed.
+	appender.Abort()
+
+	after, err := os.ReadFile(candidatesPath(dir))
+	if err != nil {
+		t.Fatalf("read published file after post-Close Abort: %v", err)
+	}
+	if string(after) != string(published) {
+		t.Fatalf("expected Abort-after-Close to be a no-op, published file changed:\nbefore=%s\nafter=%s", published, after)
+	}
+}
+
 // TestCandidateAppender_UniqueTmpPath is the RED-before-fix test for the
 // #5736 review follow-up: two CandidateAppenders opened concurrently for the
 // SAME repo (e.g. the daemon's background worker plus a manually-triggered


### PR DESCRIPTION
Closes items (b), (c), (d) of #5739 (non-blocking follow-ups from the #5738 PHP-endpoints and #5736 enrichment-bg reviews). Item (a) — the SCOPE.Operation prune golden — remains tracked in #5739.

**(b) Lumen mis-attribution (from #5738):** `synthesizeSlim` keyed on the `$app->verb(...)` idiom that Lumen shares with Slim, so Lumen endpoints were stamped `framework="slim"`. Now a `Laravel\\Lumen` / `laravel/lumen` marker labels them `framework="lumen"` instead — endpoints still emitted for both, only the attribute changes; verb/path/canonicalization untouched (byte-identical output for non-Lumen sources). Corrected the inaccurate `phpHasAnySlimRoute` doc comment. (Known heuristic limit, non-regression: a Lumen app whose routes and Lumen marker live in different files can still mislabel the routes file — the comments don't overclaim.)

**(c) group/map exclusion test (from #5738):** added explicit tests that `$app->group(...)` / `$app->map(...)` are NOT emitted as endpoints. Fixtures include a real `$app->get('/real')` so `phpHasAnySlimRoute` trips and the exclusion is exercised through `slimRouteVerbRe` (RED-confirmed: adding `group` to the verb regex fails the test).

**(d) enrichment recovered-panic orphan-temp (from #5736):** `runPass6EmitEnrichmentCandidatesBG` now `defer appender.Abort()` — a mid-trickle panic removes the unique temp; a normal run's `Close()` renames+commits first and sets the `closed` guard, so the deferred `Abort()` no-ops (verified it never deletes committed output). Added a panic-leaves-no-orphan test (via an emitter test seam) + an Abort-after-Close-noop guard test.

TDD RED→GREEN throughout; 3245 tests + `-race` clean. Independent review APPROVE on (b)/(d), REQUEST-CHANGES on (c) test triviality → fixed + re-verified.

Refs #5739 #5738 #5736 #5733