### PR TITLE
feat(install): retarget OS service unit daemon→serve + monolith-aware doctor + safe engine reaper (ADR-0024 split PR5, refs #5729)

### DIFF
--- a/internal/daemon/service/install_test.go
+++ b/internal/daemon/service/install_test.go
@@ -39,19 +39,24 @@ func TestGeneratePlist_BinPath(t *testing.T) {
 	}
 }
 
-// TestGeneratePlist_DaemonSubcmd verifies the plist invokes
-// `grafel daemon` — the hidden long-running mode. launchd owns
-// the process lifecycle, so no `start` sub-subcommand is needed.
-func TestGeneratePlist_DaemonSubcmd(t *testing.T) {
+// TestGeneratePlist_ServeSubcmd verifies the plist invokes
+// `grafel serve` — the hidden long-running mode. PR5 (ADR-0024, epic #5729)
+// retargets the OS unit from the back-compat `daemon` shim to `serve`
+// directly. launchd owns the process lifecycle, so no `start`
+// sub-subcommand is needed.
+func TestGeneratePlist_ServeSubcmd(t *testing.T) {
 	plist := renderPlist(t)
-	if !strings.Contains(plist, "<string>daemon</string>") {
-		t.Errorf("plist missing daemon subcommand:\n%s", plist)
+	if !strings.Contains(plist, "<string>serve</string>") {
+		t.Errorf("plist missing serve subcommand:\n%s", plist)
 	}
-	// Plist must NOT contain a 'start' argument — the old
-	// watcher_ctl start command forks the binary with its own
-	// already-running check that would exit 0 under launchd.
+	// Plist must NOT contain the legacy 'daemon' argument or a 'start'
+	// argument — the old watcher_ctl start command forks the binary with its
+	// own already-running check that would exit 0 under launchd.
+	if strings.Contains(plist, "<string>daemon</string>") {
+		t.Errorf("plist must not contain 'daemon' argument (retargeted to 'serve'):\n%s", plist)
+	}
 	if strings.Contains(plist, "<string>start</string>") {
-		t.Errorf("plist must not contain 'start' argument (use 'grafel daemon' directly):\n%s", plist)
+		t.Errorf("plist must not contain 'start' argument (use 'grafel serve' directly):\n%s", plist)
 	}
 }
 
@@ -134,12 +139,17 @@ func TestGeneratePlist_ValidXML(t *testing.T) {
 // --- Linux systemd unit tests --------------------------------------------
 
 // TestGenerateUnit_ExecStart verifies the ExecStart line invokes
-// `grafel daemon` — the hidden long-running mode. systemd owns
-// the process lifecycle; no sub-subcommand is required.
+// `grafel serve` — the hidden long-running mode. PR5 (ADR-0024, epic #5729)
+// retargets the OS unit from the back-compat `daemon` shim to `serve`
+// directly. systemd owns the process lifecycle; no sub-subcommand is
+// required.
 func TestGenerateUnit_ExecStart(t *testing.T) {
 	unit := renderUnit(t)
-	if !strings.Contains(unit, "ExecStart=/usr/local/bin/grafel daemon") {
+	if !strings.Contains(unit, "ExecStart=/usr/local/bin/grafel serve") {
 		t.Errorf("unit missing ExecStart:\n%s", unit)
+	}
+	if strings.Contains(unit, "ExecStart=/usr/local/bin/grafel daemon") {
+		t.Errorf("unit must not exec the legacy 'daemon' shim (retargeted to 'serve'):\n%s", unit)
 	}
 }
 

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -36,7 +36,7 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <key>ProgramArguments</key>
     <array>
         <string>{{.BinPath}}</string>
-        <string>daemon</string>
+        <string>serve</string>
     </array>
 
     <key>RunAtLoad</key>

--- a/internal/daemon/service/launchd_rewrite_darwin_test.go
+++ b/internal/daemon/service/launchd_rewrite_darwin_test.go
@@ -1,0 +1,94 @@
+//go:build darwin
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyDaemonPlist is a snapshot of the pre-PR5 rendered plist (invokes
+// `grafel daemon`, the back-compat shim) — what an existing install's
+// on-disk LaunchAgent plist looks like before the next `grafel update` /
+// `grafel install` re-renders it.
+const legacyDaemonPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.grafel.daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/local/bin/grafel</string>
+        <string>daemon</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+</dict>
+</plist>
+`
+
+// TestWriteUnit_RewritesLegacyDaemonUnitToServe verifies the idempotent
+// re-render contract PR5 (ADR-0024, epic #5729) relies on: an existing
+// install whose plist still literally execs `daemon` gets rewritten to
+// `serve` the next time service.Install (WriteUnit) runs — no separate
+// migration code, it falls out of GeneratePlist always rendering the
+// current template.
+func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	plistDir := filepath.Join(home, "Library", "LaunchAgents")
+	if err := os.MkdirAll(plistDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(plistDir, launchLabel+".plist")
+	if err := os.WriteFile(path, []byte(legacyDaemonPlist), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{
+		BinPath:    "/usr/local/bin/grafel",
+		SocketPath: filepath.Join(home, ".grafel", "sockets", "daemon.sock"),
+		LogDir:     filepath.Join(home, ".grafel", "logs"),
+	}
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (rewrite pass): %v", err)
+	}
+
+	rewritten, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten plist: %v", err)
+	}
+	if !strings.Contains(string(rewritten), "<string>serve</string>") {
+		t.Errorf("rewritten plist missing 'serve' argument:\n%s", rewritten)
+	}
+	if strings.Contains(string(rewritten), "<string>daemon</string>") {
+		t.Errorf("rewritten plist still contains legacy 'daemon' argument:\n%s", rewritten)
+	}
+
+	// Idempotency: a second WriteUnit pass must produce byte-identical output.
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (second pass): %v", err)
+	}
+	again, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read twice-written plist: %v", err)
+	}
+	if string(again) != string(rewritten) {
+		t.Errorf("WriteUnit is not idempotent:\nfirst:\n%s\nsecond:\n%s", rewritten, again)
+	}
+}

--- a/internal/daemon/service/schtasks_rewrite_windows_test.go
+++ b/internal/daemon/service/schtasks_rewrite_windows_test.go
@@ -1,0 +1,86 @@
+//go:build windows
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyDaemonTaskXML is a snapshot of the pre-PR5 rendered Task Scheduler XML
+// (execs `grafel daemon`, the back-compat shim) — what an existing install's
+// on-disk task XML looks like before the next `grafel update` / `grafel
+// install` re-renders it.
+const legacyDaemonTaskXML = `<?xml version="1.0" encoding="UTF-16"?>
+<Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
+  <RegistrationInfo>
+    <Description>grafel knowledge-graph daemon — managed by grafel install/uninstall</Description>
+    <URI>\com.grafel.daemon</URI>
+  </RegistrationInfo>
+  <Actions>
+    <Exec>
+      <Command>C:\Program Files\grafel\grafel.exe</Command>
+      <Arguments>daemon</Arguments>
+    </Exec>
+  </Actions>
+</Task>
+`
+
+// TestWriteUnit_RewritesLegacyDaemonUnitToServe verifies the idempotent
+// re-render contract PR5 (ADR-0024, epic #5729) relies on: an existing
+// install whose task XML still literally execs `daemon` gets rewritten to
+// `serve` the next time service.Install (WriteUnit) runs — no separate
+// migration code, it falls out of GenerateTaskXML always rendering the
+// current template.
+func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+
+	taskDir := filepath.Join(localAppData, "grafel", "tasks")
+	if err := os.MkdirAll(taskDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(taskDir, taskName+".xml")
+	if err := os.WriteFile(path, []byte(legacyDaemonTaskXML), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{
+		BinPath:    `C:\Program Files\grafel\grafel.exe`,
+		SocketPath: `\\.\pipe\grafel-daemon-testuser`,
+		LogDir:     filepath.Join(localAppData, "grafel", "logs"),
+	}
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (rewrite pass): %v", err)
+	}
+
+	rewritten, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten task XML: %v", err)
+	}
+	if !strings.Contains(string(rewritten), "<Arguments>serve</Arguments>") {
+		t.Errorf("rewritten task XML missing 'serve' argument:\n%s", rewritten)
+	}
+	if strings.Contains(string(rewritten), "<Arguments>daemon</Arguments>") {
+		t.Errorf("rewritten task XML still contains legacy 'daemon' argument:\n%s", rewritten)
+	}
+
+	// Idempotency: a second WriteUnit pass must produce byte-identical output.
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (second pass): %v", err)
+	}
+	again, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read twice-written task XML: %v", err)
+	}
+	if string(again) != string(rewritten) {
+		t.Errorf("WriteUnit is not idempotent:\nfirst:\n%s\nsecond:\n%s", rewritten, again)
+	}
+}

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -68,7 +68,7 @@ const daemonTaskXMLTemplate = `<?xml version="1.0" encoding="UTF-16"?>
   <Actions>
     <Exec>
       <Command>{{.BinPath}}</Command>
-      <Arguments>daemon</Arguments>
+      <Arguments>serve</Arguments>
     </Exec>
   </Actions>
 </Task>

--- a/internal/daemon/service/schtasks_windows_test.go
+++ b/internal/daemon/service/schtasks_windows_test.go
@@ -87,20 +87,26 @@ func TestGenerateTaskXML_BinPath(t *testing.T) {
 	}
 }
 
-// TestGenerateTaskXML_DaemonArgument verifies the task passes "daemon" as
-// the argument to the binary — not "start" or "run". Task Scheduler owns
-// the process lifecycle so we invoke grafel daemon directly.
-func TestGenerateTaskXML_DaemonArgument(t *testing.T) {
+// TestGenerateTaskXML_ServeArgument verifies the task passes "serve" as
+// the argument to the binary — not "daemon", "start", or "run". PR5
+// (ADR-0024, epic #5729) retargets the OS unit from the back-compat `daemon`
+// shim to `serve` directly. Task Scheduler owns the process lifecycle so we
+// invoke grafel serve directly.
+func TestGenerateTaskXML_ServeArgument(t *testing.T) {
 	xml, err := service.GenerateTaskXML(windowsOpts())
 	if err != nil {
 		t.Fatalf("GenerateTaskXML: %v", err)
 	}
 	s := string(xml)
-	if !strings.Contains(s, "<Arguments>daemon</Arguments>") {
-		t.Errorf("task XML missing <Arguments>daemon</Arguments>:\n%s", s)
+	if !strings.Contains(s, "<Arguments>serve</Arguments>") {
+		t.Errorf("task XML missing <Arguments>serve</Arguments>:\n%s", s)
 	}
-	// Must NOT contain "start" as an argument — that would fork a separate
+	// Must NOT contain "daemon" or "start" as an argument — "daemon" is the
+	// legacy back-compat shim entrypoint, and "start" would fork a separate
 	// process and shadow the scheduler-managed instance.
+	if strings.Contains(s, "<Arguments>daemon</Arguments>") {
+		t.Errorf("task XML must not use 'daemon' argument (retargeted to 'serve'):\n%s", s)
+	}
 	if strings.Contains(s, "<Arguments>start</Arguments>") {
 		t.Errorf("task XML must not use 'start' argument:\n%s", s)
 	}

--- a/internal/daemon/service/service.go
+++ b/internal/daemon/service/service.go
@@ -97,10 +97,11 @@ func Uninstall(opts Options) error {
 	}
 	if layout, lerr := daemon.DefaultLayout(); lerr == nil {
 		sweepOrphanEngine(sweepOrphanEngineDeps{
-			root:    layout.Root,
-			readPID: defaultReadEnginePID,
-			isAlive: process.IsAlive,
-			kill:    process.Kill,
+			root:     layout.Root,
+			readPID:  defaultReadEnginePID,
+			isAlive:  process.IsAlive,
+			isGrafel: process.PidIsGrafel,
+			kill:     process.Kill,
 		})
 	}
 	return nil
@@ -109,10 +110,11 @@ func Uninstall(opts Options) error {
 // sweepOrphanEngineDeps abstracts the orphan-engine sweep's I/O so it can be
 // unit-tested without touching real processes or a real daemon root.
 type sweepOrphanEngineDeps struct {
-	root    string
-	readPID func(path string) (int, error)
-	isAlive func(pid int) bool
-	kill    func(pid int) error
+	root     string
+	readPID  func(path string) (int, error)
+	isAlive  func(pid int) bool
+	isGrafel func(pid int) (bool, error)
+	kill     func(pid int) error
 }
 
 // sweepOrphanEngine implements the belt-and-suspenders orphan-engine sweep
@@ -120,6 +122,14 @@ type sweepOrphanEngineDeps struct {
 // read/parse engine.pid (including the common case — it does not exist,
 // because split mode is off or the engine already exited) is treated as
 // "nothing to do", never an error.
+//
+// PID-reuse safety (review #5729): a stale engine.pid can name a pid the OS
+// has since recycled to an unrelated process (the engine was SIGKILLed or the
+// box crashed, so its `defer os.Remove(pidPath)` never ran). Before signaling,
+// confirm the pid is actually a grafel process; treat isGrafel returning an
+// error (e.g. a platform that can't enumerate processes) OR false as "not
+// ours" and skip the kill — we never signal a process we cannot positively
+// confirm is grafel.
 func sweepOrphanEngine(deps sweepOrphanEngineDeps) {
 	if deps.root == "" {
 		return
@@ -130,6 +140,9 @@ func sweepOrphanEngine(deps sweepOrphanEngineDeps) {
 		return
 	}
 	if !deps.isAlive(pid) {
+		return
+	}
+	if ok, gerr := deps.isGrafel(pid); gerr != nil || !ok {
 		return
 	}
 	_ = deps.kill(pid)

--- a/internal/daemon/service/service.go
+++ b/internal/daemon/service/service.go
@@ -18,9 +18,13 @@ import (
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/process"
 )
 
 // Options carries install-time parameters. All fields that are empty
@@ -73,11 +77,77 @@ func Install(opts Options) (StatusInfo, error) {
 
 // Uninstall stops and removes the OS service registration. Idempotent:
 // if the service is not installed it returns immediately without error.
+//
+// After tearing down the serve unit, it also runs a belt-and-suspenders
+// orphan-engine sweep (ADR-0024 PR5, epic #5729): in split mode, serve's own
+// graceful drain already SIGTERMs its supervised `grafel engine` child before
+// exiting, so under normal shutdown there is nothing left to sweep. But
+// Unload can also hard-stop serve (launchctl bootout / systemctl disable
+// --now / schtasks /end) without giving its drain defers time to run, which
+// could orphan the engine child. The sweep reads engine.pid and, if it names
+// a still-live process, terminates it directly. It is a safe no-op in
+// monolith mode (no engine.pid exists) or when the engine was already
+// reaped.
 func Uninstall(opts Options) error {
 	if err := resolveOptions(&opts); err != nil {
 		return fmt.Errorf("resolve options: %w", err)
 	}
-	return uninstall(opts)
+	if err := uninstall(opts); err != nil {
+		return err
+	}
+	if layout, lerr := daemon.DefaultLayout(); lerr == nil {
+		sweepOrphanEngine(sweepOrphanEngineDeps{
+			root:    layout.Root,
+			readPID: defaultReadEnginePID,
+			isAlive: process.IsAlive,
+			kill:    process.Kill,
+		})
+	}
+	return nil
+}
+
+// sweepOrphanEngineDeps abstracts the orphan-engine sweep's I/O so it can be
+// unit-tested without touching real processes or a real daemon root.
+type sweepOrphanEngineDeps struct {
+	root    string
+	readPID func(path string) (int, error)
+	isAlive func(pid int) bool
+	kill    func(pid int) error
+}
+
+// sweepOrphanEngine implements the belt-and-suspenders orphan-engine sweep
+// documented on Uninstall. It is intentionally conservative: any failure to
+// read/parse engine.pid (including the common case — it does not exist,
+// because split mode is off or the engine already exited) is treated as
+// "nothing to do", never an error.
+func sweepOrphanEngine(deps sweepOrphanEngineDeps) {
+	if deps.root == "" {
+		return
+	}
+	pidPath := daemon.EnginePIDPath(deps.root)
+	pid, err := deps.readPID(pidPath)
+	if err != nil || pid <= 0 {
+		return
+	}
+	if !deps.isAlive(pid) {
+		return
+	}
+	_ = deps.kill(pid)
+}
+
+// defaultReadEnginePID reads and parses an engine.pid file. Returns an error
+// (including os.IsNotExist) when the file is absent or unparseable — the
+// caller treats any error as "no orphan to sweep".
+func defaultReadEnginePID(path string) (int, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil {
+		return 0, err
+	}
+	return pid, nil
 }
 
 // Status reports whether the service is installed and/or running.

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -33,7 +33,7 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart={{.BinPath}} daemon
+ExecStart={{.BinPath}} serve
 Restart=on-failure
 RestartSec=3s
 Environment=HOME={{.Home}}

--- a/internal/daemon/service/systemd_rewrite_linux_test.go
+++ b/internal/daemon/service/systemd_rewrite_linux_test.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// legacyDaemonUnit is a snapshot of the pre-PR5 rendered systemd unit
+// (execs `grafel daemon`, the back-compat shim) — what an existing install's
+// on-disk unit looks like before the next `grafel update` / `grafel install`
+// re-renders it.
+const legacyDaemonUnit = `[Unit]
+Description=grafel knowledge-graph daemon
+Documentation=https://github.com/cajasmota/grafel
+After=network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/grafel daemon
+Restart=on-failure
+RestartSec=3s
+Environment=HOME=/home/testuser
+LimitNOFILE=65536
+
+[Install]
+WantedBy=default.target
+`
+
+// TestWriteUnit_RewritesLegacyDaemonUnitToServe verifies the idempotent
+// re-render contract PR5 (ADR-0024, epic #5729) relies on: an existing
+// install whose unit file still literally execs `daemon` gets rewritten to
+// `serve` the next time service.Install (WriteUnit) runs — no separate
+// migration code, it falls out of GenerateUnit always rendering the current
+// template.
+func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	unitDir := filepath.Join(home, ".config", "systemd", "user")
+	if err := os.MkdirAll(unitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(unitDir, unitName+".service")
+	if err := os.WriteFile(path, []byte(legacyDaemonUnit), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	opts := Options{
+		BinPath:    "/usr/local/bin/grafel",
+		SocketPath: filepath.Join(home, ".grafel", "sockets", "daemon.sock"),
+		LogDir:     filepath.Join(home, ".grafel", "logs"),
+	}
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (rewrite pass): %v", err)
+	}
+
+	rewritten, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read rewritten unit: %v", err)
+	}
+	if !strings.Contains(string(rewritten), "ExecStart=/usr/local/bin/grafel serve") {
+		t.Errorf("rewritten unit missing 'serve' ExecStart:\n%s", rewritten)
+	}
+	if strings.Contains(string(rewritten), "ExecStart=/usr/local/bin/grafel daemon") {
+		t.Errorf("rewritten unit still contains legacy 'daemon' ExecStart:\n%s", rewritten)
+	}
+
+	// Idempotency: a second WriteUnit pass must produce byte-identical output.
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit (second pass): %v", err)
+	}
+	again, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read twice-written unit: %v", err)
+	}
+	if string(again) != string(rewritten) {
+		t.Errorf("WriteUnit is not idempotent:\nfirst:\n%s\nsecond:\n%s", rewritten, again)
+	}
+}

--- a/internal/daemon/service/uninstall_sweep_test.go
+++ b/internal/daemon/service/uninstall_sweep_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/process"
 )
 
 // TestSweepOrphanEngine_LiveEngineTerminated verifies that when engine.pid
@@ -15,9 +16,10 @@ func TestSweepOrphanEngine_LiveEngineTerminated(t *testing.T) {
 	var killedPID int
 	killCalled := false
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    t.TempDir(),
-		readPID: func(string) (int, error) { return 4242, nil },
-		isAlive: func(pid int) bool { return pid == 4242 },
+		root:     t.TempDir(),
+		readPID:  func(string) (int, error) { return 4242, nil },
+		isAlive:  func(pid int) bool { return pid == 4242 },
+		isGrafel: func(int) (bool, error) { return true, nil },
 		kill: func(pid int) error {
 			killCalled = true
 			killedPID = pid
@@ -38,10 +40,11 @@ func TestSweepOrphanEngine_LiveEngineTerminated(t *testing.T) {
 func TestSweepOrphanEngine_NoEnginePID_NoOp(t *testing.T) {
 	killCalled := false
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    t.TempDir(),
-		readPID: func(string) (int, error) { return 0, os.ErrNotExist },
-		isAlive: func(int) bool { return true },
-		kill:    func(int) error { killCalled = true; return nil },
+		root:     t.TempDir(),
+		readPID:  func(string) (int, error) { return 0, os.ErrNotExist },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
 	})
 	if killCalled {
 		t.Error("kill must not be called when engine.pid is absent (monolith mode)")
@@ -54,10 +57,11 @@ func TestSweepOrphanEngine_NoEnginePID_NoOp(t *testing.T) {
 func TestSweepOrphanEngine_DeadPID_NoOp(t *testing.T) {
 	killCalled := false
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    t.TempDir(),
-		readPID: func(string) (int, error) { return 4242, nil },
-		isAlive: func(int) bool { return false },
-		kill:    func(int) error { killCalled = true; return nil },
+		root:     t.TempDir(),
+		readPID:  func(string) (int, error) { return 4242, nil },
+		isAlive:  func(int) bool { return false },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
 	})
 	if killCalled {
 		t.Error("kill must not be called when the recorded pid is no longer alive")
@@ -69,10 +73,11 @@ func TestSweepOrphanEngine_DeadPID_NoOp(t *testing.T) {
 func TestSweepOrphanEngine_EmptyRoot_NoOp(t *testing.T) {
 	killCalled := false
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    "",
-		readPID: func(string) (int, error) { return 4242, nil },
-		isAlive: func(int) bool { return true },
-		kill:    func(int) error { killCalled = true; return nil },
+		root:     "",
+		readPID:  func(string) (int, error) { return 4242, nil },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
 	})
 	if killCalled {
 		t.Error("kill must not be called with an empty root")
@@ -91,10 +96,11 @@ func TestSweepOrphanEngine_ReadsRealPIDFile(t *testing.T) {
 
 	var killedPID int
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    root,
-		readPID: defaultReadEnginePID,
-		isAlive: func(pid int) bool { return pid == 777 },
-		kill:    func(pid int) error { killedPID = pid; return nil },
+		root:     root,
+		readPID:  defaultReadEnginePID,
+		isAlive:  func(pid int) bool { return pid == 777 },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(pid int) error { killedPID = pid; return nil },
 	})
 	if killedPID != 777 {
 		t.Errorf("killed pid = %d, want 777 (read from %s)", killedPID, pidPath)
@@ -113,12 +119,51 @@ func TestSweepOrphanEngine_NoRealPIDFile_NoOp(t *testing.T) {
 
 	killCalled := false
 	sweepOrphanEngine(sweepOrphanEngineDeps{
-		root:    root,
-		readPID: defaultReadEnginePID,
-		isAlive: func(int) bool { return true },
-		kill:    func(int) error { killCalled = true; return nil },
+		root:     root,
+		readPID:  defaultReadEnginePID,
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
 	})
 	if killCalled {
 		t.Error("kill must not be called when no real engine.pid file exists")
+	}
+}
+
+// TestSweepOrphanEngine_RecycledPID_NotGrafel_NoOp is the PID-reuse safety
+// case (review #5729): engine.pid is stale (the engine was SIGKILLed / the box
+// crashed, so its deferred pidfile removal never ran) and the OS has recycled
+// that pid to an unrelated, innocent process. The pid IS live, so the isAlive
+// guard passes — but the identity check (PidIsGrafel) returns false, and the
+// sweep MUST NOT signal it.
+func TestSweepOrphanEngine_RecycledPID_NotGrafel_NoOp(t *testing.T) {
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, error) { return 4242, nil },
+		isAlive:  func(int) bool { return true },                // pid was recycled → it IS live
+		isGrafel: func(int) (bool, error) { return false, nil }, // …but it is NOT grafel
+		kill:     func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called when the live pid is not a grafel process (recycled pid)")
+	}
+}
+
+// TestSweepOrphanEngine_IdentityUnverifiable_NoOp confirms the fail-safe:
+// when the identity check can't determine whether the pid is grafel (e.g. a
+// platform that cannot enumerate processes returns an error), the sweep skips
+// the kill rather than risk signaling a process it can't confirm is ours.
+func TestSweepOrphanEngine_IdentityUnverifiable_NoOp(t *testing.T) {
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, error) { return 4242, nil },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return false, process.ErrUnsupported },
+		kill:     func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called when grafel-identity cannot be confirmed")
 	}
 }

--- a/internal/daemon/service/uninstall_sweep_test.go
+++ b/internal/daemon/service/uninstall_sweep_test.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// TestSweepOrphanEngine_LiveEngineTerminated verifies that when engine.pid
+// names a still-live process, the sweep terminates it (ADR-0024 PR5, epic
+// #5729's belt-and-suspenders orphan-engine sweep on Uninstall).
+func TestSweepOrphanEngine_LiveEngineTerminated(t *testing.T) {
+	var killedPID int
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    t.TempDir(),
+		readPID: func(string) (int, error) { return 4242, nil },
+		isAlive: func(pid int) bool { return pid == 4242 },
+		kill: func(pid int) error {
+			killCalled = true
+			killedPID = pid
+			return nil
+		},
+	})
+	if !killCalled {
+		t.Fatal("kill was not called for a live engine.pid")
+	}
+	if killedPID != 4242 {
+		t.Errorf("killed pid = %d, want 4242", killedPID)
+	}
+}
+
+// TestSweepOrphanEngine_NoEnginePID_NoOp verifies the sweep is a safe no-op
+// when no engine.pid exists — the monolith-mode default (SplitMode off) has
+// no separate engine process, so there is nothing to sweep.
+func TestSweepOrphanEngine_NoEnginePID_NoOp(t *testing.T) {
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    t.TempDir(),
+		readPID: func(string) (int, error) { return 0, os.ErrNotExist },
+		isAlive: func(int) bool { return true },
+		kill:    func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called when engine.pid is absent (monolith mode)")
+	}
+}
+
+// TestSweepOrphanEngine_DeadPID_NoOp verifies the sweep is a safe no-op when
+// engine.pid names a pid that is no longer alive (the engine already exited
+// — e.g. serve's own graceful drain already reaped it).
+func TestSweepOrphanEngine_DeadPID_NoOp(t *testing.T) {
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    t.TempDir(),
+		readPID: func(string) (int, error) { return 4242, nil },
+		isAlive: func(int) bool { return false },
+		kill:    func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called when the recorded pid is no longer alive")
+	}
+}
+
+// TestSweepOrphanEngine_EmptyRoot_NoOp verifies the sweep never dereferences
+// an unresolved root (e.g. daemon.DefaultLayout failed).
+func TestSweepOrphanEngine_EmptyRoot_NoOp(t *testing.T) {
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    "",
+		readPID: func(string) (int, error) { return 4242, nil },
+		isAlive: func(int) bool { return true },
+		kill:    func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called with an empty root")
+	}
+}
+
+// TestSweepOrphanEngine_ReadsRealPIDFile exercises defaultReadEnginePID end
+// to end against a real engine.pid file at daemon.EnginePIDPath(root),
+// confirming the sweep reads the SAME path RunEngine writes.
+func TestSweepOrphanEngine_ReadsRealPIDFile(t *testing.T) {
+	root := t.TempDir()
+	pidPath := daemon.EnginePIDPath(root)
+	if err := os.WriteFile(pidPath, []byte("777\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var killedPID int
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    root,
+		readPID: defaultReadEnginePID,
+		isAlive: func(pid int) bool { return pid == 777 },
+		kill:    func(pid int) error { killedPID = pid; return nil },
+	})
+	if killedPID != 777 {
+		t.Errorf("killed pid = %d, want 777 (read from %s)", killedPID, pidPath)
+	}
+}
+
+// TestSweepOrphanEngine_NoRealPIDFile_NoOp confirms defaultReadEnginePID
+// against a directory with no engine.pid (monolith mode) results in no kill,
+// using the REAL isAlive/readPID production functions end to end (kill is
+// still faked so the test never signals a real process).
+func TestSweepOrphanEngine_NoRealPIDFile_NoOp(t *testing.T) {
+	root := t.TempDir() // no engine.pid written
+	if _, err := os.Stat(filepath.Join(root, "engine.pid")); !os.IsNotExist(err) {
+		t.Fatalf("test setup: engine.pid unexpectedly exists in %s", root)
+	}
+
+	killCalled := false
+	sweepOrphanEngine(sweepOrphanEngineDeps{
+		root:    root,
+		readPID: defaultReadEnginePID,
+		isAlive: func(int) bool { return true },
+		kill:    func(int) error { killCalled = true; return nil },
+	})
+	if killCalled {
+		t.Error("kill must not be called when no real engine.pid file exists")
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -174,6 +174,16 @@ func engineLivenessStatusKey(root string) string {
 	return filepath.Join(root, ".engine-liveness")
 }
 
+// EngineLivenessStatusKey is the exported form of engineLivenessStatusKey for
+// callers outside package daemon — specifically `grafel doctor`'s
+// monolith-aware engine-liveness check (ADR-0024 PR5, epic #5729) — that need
+// to read the SAME engine-global liveness statusfile the serve-side
+// supervisor's own health gate reads, without duplicating (and risking
+// drifting from) the key-derivation format.
+func EngineLivenessStatusKey(root string) string {
+	return engineLivenessStatusKey(root)
+}
+
 // startEngineLivenessHeartbeat launches a goroutine that stamps the
 // engine-global liveness statusfile (EnginePID + a fresh HeartbeatAt) once
 // immediately and then every interval, until the returned stop func is called

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -182,6 +182,16 @@ func (s *engineSupervisor) healthy() (bool, string) {
 	return true, ""
 }
 
+// EngineHeartbeatStaleAfter returns the max age a liveness heartbeat may be
+// before it is considered stale — the SAME threshold engineSupervisor.healthy
+// uses (engineHealthStaleMultiplier heartbeat intervals). Exported for
+// external readers (`grafel doctor`'s engine-liveness check, ADR-0024 PR5,
+// epic #5729) that need the identical staleness definition without
+// duplicating the constant.
+func EngineHeartbeatStaleAfter() time.Duration {
+	return time.Duration(engineHealthStaleMultiplier) * statusHeartbeatInterval()
+}
+
 // run is the supervision loop: spawn, wait, relaunch-with-backoff, and finally
 // drain on stop/ctx-cancel.
 func (s *engineSupervisor) run(ctx context.Context) {

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -29,13 +29,17 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/service"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/rulesfiles"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
 // DoctorSchemaVersion is the JSON schema version for DoctorReport.
@@ -188,6 +192,21 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 
 	// ── Check 2: Daemon /healthz ────────────────────────────────────────────
 	report.Checks = append(report.Checks, checkDaemon(state, opts.DaemonPort, opts.DaemonTimeout))
+
+	// ── Check 2b: Engine liveness + version skew (ADR-0024 PR5, epic #5729) ──
+	// Monolith-aware: in the DEFAULT config (GRAFEL_SPLIT_MODE off) there is no
+	// separate engine process, so this must never warn "engine down" — see
+	// checkEngineLiveness's doc comment for the monolith/split detection logic.
+	report.Checks = append(report.Checks, checkEngineLiveness(state, defaultEngineLivenessDeps()))
+
+	// ── Check 2c: Pre-split OS service unit (ADR-0024 PR5, epic #5729) ───────
+	// Purely informational: an existing install's unit may still literally
+	// exec `grafel daemon` until the next `grafel update`/`grafel install`
+	// re-renders it to `grafel serve` (behavior-identical while the split flag
+	// is off — see service.Install's WriteUnit re-render contract).
+	if preSplit := checkPreSplitUnit(); preSplit != nil {
+		report.Checks = append(report.Checks, *preSplit)
+	}
 
 	// ── Check 3: Skills per-file SHA manifests (COPY) or symlink targets (DEV) ─
 	for skillName, skillRecord := range state.Skills {
@@ -791,6 +810,197 @@ func checkStaleStagingDirs(statePath string) *CheckResult {
 		OK:       false,
 		Severity: SeverityInfo,
 		Drift:    drift,
+	}
+	return &cr
+}
+
+// ── Engine liveness + version skew (ADR-0024 PR5, epic #5729) ─────────────────
+
+// engineLivenessDeps abstracts the I/O checkEngineLiveness needs so tests can
+// drive monolith-mode / split-mode / fresh-heartbeat / stale-heartbeat /
+// version-skew scenarios without a real daemon root, a real engine.pid, or a
+// real statusfile on disk.
+type engineLivenessDeps struct {
+	// root resolves the daemon root directory. Mirrors daemon.DefaultLayout.
+	root func() (string, error)
+	// readEnginePID reads and parses engine.pid at the given path. Any error
+	// (including os.IsNotExist — the common monolith-mode case) means "no
+	// engine.pid": split mode is off, or the engine already exited and was
+	// reaped. Mirrors internal/daemon/service.defaultReadEnginePID.
+	readEnginePID func(path string) (int, error)
+	// readLiveness reads the engine-global liveness statusfile at key.
+	// Mirrors statusfile.Read(daemon.EngineLivenessStatusKey(root)).
+	readLiveness func(key string) (*statusfile.File, error)
+	// staleAfter returns the max heartbeat age before it's stale. Mirrors
+	// daemon.EngineHeartbeatStaleAfter — the SAME threshold the serve-side
+	// supervisor's own health gate uses.
+	staleAfter func() time.Duration
+}
+
+// defaultEngineLivenessDeps wires engineLivenessDeps to the real daemon /
+// statusfile packages.
+func defaultEngineLivenessDeps() engineLivenessDeps {
+	return engineLivenessDeps{
+		root: func() (string, error) {
+			layout, err := daemon.DefaultLayout()
+			if err != nil {
+				return "", err
+			}
+			return layout.Root, nil
+		},
+		readEnginePID: func(path string) (int, error) {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return 0, err
+			}
+			pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+			if err != nil {
+				return 0, err
+			}
+			return pid, nil
+		},
+		readLiveness: statusfile.Read,
+		staleAfter:   daemon.EngineHeartbeatStaleAfter,
+	}
+}
+
+// checkEngineLiveness reports the health of the `grafel engine` child
+// process — but ONLY when the serve/engine split is actually active.
+//
+// ADR-0024's split is opt-in via GRAFEL_SPLIT_MODE, default OFF. In that
+// default (monolith) configuration there is NO separate engine process at
+// all — serve does all indexing in-process, exactly like the pre-split
+// `grafel daemon`. Mode detection here does NOT read SplitModeEnabled()
+// directly (that reflects THIS process's environment, not necessarily the
+// installed service's); instead it uses the observable artifact split mode
+// produces: an engine.pid file. No engine.pid means either split mode is off,
+// or a split-mode engine child already exited and was reaped (serve's own
+// graceful drain, or service.Uninstall's orphan sweep) — either way there is
+// no live engine to be "down", so this reports healthy/in-process rather than
+// warning.
+//
+// Only when engine.pid is present (split mode is/was active) do the
+// liveness-freshness and version-skew checks apply, mirroring the exact
+// staleness definition and pid-matching the serve-side supervisor's own
+// health gate uses (see internal/daemon/supervise.go's engineSupervisor.healthy).
+func checkEngineLiveness(state *State, deps engineLivenessDeps) CheckResult {
+	cr := CheckResult{Surface: "engine", OK: true}
+
+	root, err := deps.root()
+	if err != nil {
+		// Can't resolve a daemon root at all — not an engine-liveness
+		// problem per se (checkDaemon already covers daemon reachability);
+		// report info rather than a false "engine down".
+		cr.Severity = SeverityInfo
+		cr.Drift = []string{fmt.Sprintf("cannot resolve daemon root: %v", err)}
+		return cr
+	}
+
+	pidPath := daemon.EnginePIDPath(root)
+	pid, err := deps.readEnginePID(pidPath)
+	if err != nil || pid <= 0 {
+		// No engine.pid — monolith mode (the default), or the engine child
+		// already exited and was reaped. There is no separate engine process
+		// to be down. Healthy, in-process.
+		cr.Drift = []string{"monolith mode: no separate engine process (GRAFEL_SPLIT_MODE off)"}
+		cr.Severity = SeverityInfo
+		return cr
+	}
+
+	// engine.pid exists — split mode is (or was) active. Validate the
+	// engine-global liveness heartbeat the same way serve's own supervisor
+	// does.
+	f, ferr := deps.readLiveness(daemon.EngineLivenessStatusKey(root))
+	if ferr != nil {
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf("engine degraded: liveness statusfile unreadable: %v", ferr)}
+		return cr
+	}
+
+	if f.EnginePID != pid {
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf("engine degraded: liveness pid %d != engine.pid %d", f.EnginePID, pid)}
+		return cr
+	}
+
+	if age := time.Since(f.HeartbeatAt); age > deps.staleAfter() {
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf("engine degraded: stale heartbeat (%s old, max %s)", age.Truncate(time.Second), deps.staleAfter())}
+		return cr
+	}
+
+	// Version skew: serve's own recorded binary_version (install.json,
+	// refreshed from /healthz on restart — see checkDaemon) vs the engine
+	// child's self-reported version in the liveness statusfile. Only
+	// meaningful in split mode (we already know engine.pid is present here);
+	// in monolith mode there's a single binary so this branch is unreachable.
+	if state != nil && state.DaemonVersion != "" && f.Version != "" && state.DaemonVersion != f.Version {
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf("version skew: serve=%s engine=%s (restart the engine child to pick up the new build)", state.DaemonVersion, f.Version)}
+		return cr
+	}
+
+	return cr
+}
+
+// preSplitUnitTokens are the literal legacy-argument markers left behind in
+// an OS service unit rendered before PR5 retargeted the templates from
+// `daemon` to `serve` (launchd plist / systemd unit / Windows Task Scheduler
+// XML respectively). Behavior-identical either way while split mode is off —
+// this is purely informational.
+var preSplitUnitTokens = []string{
+	"<string>daemon</string>",       // launchd ProgramArguments
+	"<Arguments>daemon</Arguments>", // Windows Task Scheduler
+}
+
+// looksLikePreSplitUnit reports whether unit content still literally execs
+// the legacy `daemon` argument instead of `serve`.
+func looksLikePreSplitUnit(content string) bool {
+	for _, tok := range preSplitUnitTokens {
+		if strings.Contains(content, tok) {
+			return true
+		}
+	}
+	// systemd's ExecStart is a single line ending in the argument, e.g.
+	// "ExecStart=/usr/local/bin/grafel daemon" — check line-by-line rather
+	// than a single substring so we don't false-match "daemon" appearing
+	// elsewhere (e.g. Description=grafel knowledge-graph daemon).
+	for _, line := range strings.Split(content, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "ExecStart=") && strings.HasSuffix(line, " daemon") {
+			return true
+		}
+	}
+	return false
+}
+
+// checkPreSplitUnit reports (as SeverityInfo) when the installed OS service
+// unit still literally execs the legacy `daemon` argument. Returns nil when
+// no unit is installed, the unit can't be determined/read, or the unit
+// already execs `serve` — this is advisory-only noise we don't want to add
+// when there's nothing to say (mirrors checkStaleStagingDirs' nil-when-clean
+// pattern).
+func checkPreSplitUnit() *CheckResult {
+	st, err := service.Status(service.Options{})
+	if err != nil || st.UnitFile == "" {
+		return nil
+	}
+	data, err := os.ReadFile(st.UnitFile)
+	if err != nil {
+		return nil
+	}
+	if !looksLikePreSplitUnit(string(data)) {
+		return nil
+	}
+	cr := CheckResult{
+		Surface:  "service-unit",
+		OK:       false,
+		Severity: SeverityInfo,
+		Drift:    []string{fmt.Sprintf("%s still execs the legacy 'daemon' shim — it will retarget to 'serve' on the next `grafel update`/`grafel install`", st.UnitFile)},
 	}
 	return &cr
 }

--- a/internal/install/doctor_engine_test.go
+++ b/internal/install/doctor_engine_test.go
@@ -1,0 +1,238 @@
+package install
+
+// doctor_engine_test.go — whitebox tests for checkEngineLiveness (ADR-0024
+// PR5, epic #5729). These exercise checkEngineLiveness directly via an
+// injected engineLivenessDeps so they never touch a real daemon root, a real
+// engine.pid file, or a real statusfile on disk, and never depend on whether
+// GRAFEL_SPLIT_MODE happens to be set in the test environment.
+//
+// Scenarios (per the PR5 TDD requirement):
+//   (a) monolith mode (no engine.pid)      → NO "engine down" warning
+//   (b) split mode, fresh heartbeat         → healthy
+//   (c) split mode, stale heartbeat         → "engine degraded"
+//   (d) split mode, version skew            → "engine degraded" / version skew
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+func fakeEngineLivenessDeps(t *testing.T, pid int, pidErr error, f *statusfile.File, fErr error, stale time.Duration) engineLivenessDeps {
+	t.Helper()
+	return engineLivenessDeps{
+		root: func() (string, error) { return t.TempDir(), nil },
+		readEnginePID: func(string) (int, error) {
+			if pidErr != nil {
+				return 0, pidErr
+			}
+			return pid, nil
+		},
+		readLiveness: func(string) (*statusfile.File, error) {
+			if fErr != nil {
+				return nil, fErr
+			}
+			return f, nil
+		},
+		staleAfter: func() time.Duration { return stale },
+	}
+}
+
+// (a) monolith mode: no engine.pid at all — must be OK, Info severity, and
+// must NOT say "engine down"/"degraded".
+func TestCheckEngineLiveness_MonolithMode_NoEngineDownWarning(t *testing.T) {
+	deps := fakeEngineLivenessDeps(t, 0, os.ErrNotExist, nil, nil, 15*time.Second)
+	cr := checkEngineLiveness(&State{}, deps)
+
+	if !cr.OK {
+		t.Fatalf("monolith mode must report OK=true, got drift=%v", cr.Drift)
+	}
+	if cr.Severity != SeverityInfo {
+		t.Errorf("monolith mode severity = %q, want info", cr.Severity)
+	}
+	for _, d := range cr.Drift {
+		if containsFold(d, "engine down") || containsFold(d, "degraded") {
+			t.Errorf("monolith mode must never say engine down/degraded, got: %q", d)
+		}
+	}
+}
+
+// (b) split mode, fresh heartbeat, matching pid, matching version → healthy.
+func TestCheckEngineLiveness_SplitMode_FreshHeartbeat_Healthy(t *testing.T) {
+	f := &statusfile.File{
+		EnginePID:   4242,
+		HeartbeatAt: time.Now(),
+		Version:     "v9.9.9",
+	}
+	deps := fakeEngineLivenessDeps(t, 4242, nil, f, nil, 15*time.Second)
+	state := &State{DaemonVersion: "v9.9.9"}
+	cr := checkEngineLiveness(state, deps)
+
+	if !cr.OK {
+		t.Fatalf("fresh heartbeat + matching pid + matching version must be OK, got drift=%v", cr.Drift)
+	}
+}
+
+// (c) split mode, stale heartbeat → "engine degraded".
+func TestCheckEngineLiveness_SplitMode_StaleHeartbeat_Degraded(t *testing.T) {
+	f := &statusfile.File{
+		EnginePID:   4242,
+		HeartbeatAt: time.Now().Add(-1 * time.Hour),
+		Version:     "v9.9.9",
+	}
+	deps := fakeEngineLivenessDeps(t, 4242, nil, f, nil, 15*time.Second)
+	state := &State{DaemonVersion: "v9.9.9"}
+	cr := checkEngineLiveness(state, deps)
+
+	if cr.OK {
+		t.Fatal("stale heartbeat must not be OK")
+	}
+	if cr.Severity != SeverityWarning {
+		t.Errorf("stale heartbeat severity = %q, want warning", cr.Severity)
+	}
+	if len(cr.Drift) == 0 || !containsFold(cr.Drift[0], "degraded") {
+		t.Errorf("stale heartbeat drift = %v, want mention of 'degraded'", cr.Drift)
+	}
+}
+
+// split mode, liveness pid mismatch (stale liveness file from a since-reaped
+// engine, before a new one has stamped fresh liveness) → degraded.
+func TestCheckEngineLiveness_SplitMode_PIDMismatch_Degraded(t *testing.T) {
+	f := &statusfile.File{
+		EnginePID:   9999, // doesn't match engine.pid below
+		HeartbeatAt: time.Now(),
+		Version:     "v9.9.9",
+	}
+	deps := fakeEngineLivenessDeps(t, 4242, nil, f, nil, 15*time.Second)
+	cr := checkEngineLiveness(&State{}, deps)
+
+	if cr.OK {
+		t.Fatal("pid mismatch must not be OK")
+	}
+	if cr.Severity != SeverityWarning {
+		t.Errorf("pid mismatch severity = %q, want warning", cr.Severity)
+	}
+}
+
+// (d) split mode, version skew (serve's recorded binary_version differs from
+// the engine child's self-reported version) → degraded / version-skew note.
+func TestCheckEngineLiveness_SplitMode_VersionSkew_Degraded(t *testing.T) {
+	f := &statusfile.File{
+		EnginePID:   4242,
+		HeartbeatAt: time.Now(),
+		Version:     "v1.0.0-old-engine",
+	}
+	deps := fakeEngineLivenessDeps(t, 4242, nil, f, nil, 15*time.Second)
+	state := &State{DaemonVersion: "v2.0.0-new-serve"}
+	cr := checkEngineLiveness(state, deps)
+
+	if cr.OK {
+		t.Fatal("version skew must not be OK")
+	}
+	if len(cr.Drift) == 0 || !containsFold(cr.Drift[0], "version skew") {
+		t.Errorf("version-skew drift = %v, want mention of 'version skew'", cr.Drift)
+	}
+}
+
+// Liveness statusfile unreadable while engine.pid IS present (split mode
+// active but the liveness file vanished/corrupted) → degraded, not a panic,
+// not a false "healthy".
+func TestCheckEngineLiveness_SplitMode_LivenessUnreadable_Degraded(t *testing.T) {
+	deps := fakeEngineLivenessDeps(t, 4242, nil, nil, os.ErrNotExist, 15*time.Second)
+	cr := checkEngineLiveness(&State{}, deps)
+
+	if cr.OK {
+		t.Fatal("unreadable liveness file while engine.pid is present must not be OK")
+	}
+	if cr.Severity != SeverityWarning {
+		t.Errorf("severity = %q, want warning", cr.Severity)
+	}
+}
+
+// Cannot resolve daemon root at all → Info, not a crash, not "engine down".
+func TestCheckEngineLiveness_RootResolutionFails_Info(t *testing.T) {
+	deps := engineLivenessDeps{
+		root:          func() (string, error) { return "", os.ErrPermission },
+		readEnginePID: func(string) (int, error) { return 0, os.ErrNotExist },
+		readLiveness:  func(string) (*statusfile.File, error) { return nil, os.ErrNotExist },
+		staleAfter:    func() time.Duration { return 15 * time.Second },
+	}
+	cr := checkEngineLiveness(&State{}, deps)
+	if cr.Severity != SeverityInfo {
+		t.Errorf("severity = %q, want info", cr.Severity)
+	}
+}
+
+// ── looksLikePreSplitUnit ──────────────────────────────────────────────────
+
+func TestLooksLikePreSplitUnit_LaunchdLegacy(t *testing.T) {
+	if !looksLikePreSplitUnit("<string>daemon</string>") {
+		t.Error("must detect legacy launchd daemon argument")
+	}
+}
+
+func TestLooksLikePreSplitUnit_LaunchdCurrent(t *testing.T) {
+	if looksLikePreSplitUnit("<string>serve</string>") {
+		t.Error("must not flag current 'serve' plist as pre-split")
+	}
+}
+
+func TestLooksLikePreSplitUnit_SystemdLegacy(t *testing.T) {
+	unit := "Description=grafel knowledge-graph daemon\nExecStart=/usr/local/bin/grafel daemon\n"
+	if !looksLikePreSplitUnit(unit) {
+		t.Error("must detect legacy systemd ExecStart ...daemon")
+	}
+}
+
+func TestLooksLikePreSplitUnit_SystemdCurrent(t *testing.T) {
+	unit := "Description=grafel knowledge-graph daemon\nExecStart=/usr/local/bin/grafel serve\n"
+	if looksLikePreSplitUnit(unit) {
+		t.Error("must not flag current systemd unit as pre-split (Description containing 'daemon' must not false-positive)")
+	}
+}
+
+func TestLooksLikePreSplitUnit_WindowsLegacy(t *testing.T) {
+	if !looksLikePreSplitUnit("<Arguments>daemon</Arguments>") {
+		t.Error("must detect legacy Windows Task Scheduler daemon argument")
+	}
+}
+
+func TestLooksLikePreSplitUnit_WindowsCurrent(t *testing.T) {
+	if looksLikePreSplitUnit("<Arguments>serve</Arguments>") {
+		t.Error("must not flag current Windows task XML as pre-split")
+	}
+}
+
+// containsFold is a tiny case-insensitive substring helper local to this test
+// file (avoids importing strings.Contains + strings.ToLower boilerplate at
+// every call site above).
+func containsFold(s, substr string) bool {
+	return len(s) >= len(substr) && indexFold(s, substr) >= 0
+}
+
+func indexFold(s, substr string) int {
+	sl := []rune(s)
+	bl := []rune(substr)
+	for i := 0; i+len(bl) <= len(sl); i++ {
+		match := true
+		for j := range bl {
+			a, b := sl[i+j], bl[j]
+			if 'A' <= a && a <= 'Z' {
+				a += 'a' - 'A'
+			}
+			if 'A' <= b && b <= 'Z' {
+				b += 'a' - 'A'
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
+}


### PR DESCRIPTION
**PR5 of the serve/engine split (ADR-0024, epic #5729).** Makes install/update/uninstall/doctor split-aware while keeping single-operation UX and staying behavior-safe with the split default still OFF (`grafel serve` monolith ≡ old `grafel daemon`).

- **Retarget the OS unit `daemon`→`serve`** in all three real templates (launchd/systemd/schtasks) — only the exec target changed; KeepAlive/Restart/triggers/labels/env unchanged. Safe pre-flag-flip because serve-monolith is byte-identical to daemon.
- **Self-heal on update:** `service.Install`→`WriteUnit` re-renders unconditionally, so an existing `daemon`-literal unit becomes `serve` on the next `grafel update` — no migration code. Idempotent-rewrite tests (seed a legacy unit, assert `serve` + byte-identical second pass) on all three platforms. Old un-updated units keep working via the `grafel daemon`→`RunServe` shim (PR1).
- **Monolith-aware doctor:** `checkEngineLiveness` reports "monolith mode" (Info/OK, never a warning) when there's no `engine.pid` — so a healthy default install is never alarmed. Only in split mode (engine.pid present) does it check heartbeat freshness + PID match + version skew. `checkPreSplitUnit` is an advisory Info note. Exported `EngineLivenessStatusKey`/`EngineHeartbeatStaleAfter` reuse the exact key/threshold the PR2 supervisor's `healthy()` gate uses.
- **Safe engine reaper on uninstall:** `sweepOrphanEngine` SIGTERMs a live `engine.pid` ONLY after `process.PidIsGrafel(pid)` confirms it's actually a grafel process (fail-safe: error/false → skip) — so a stale pidfile + recycled PID can't signal an innocent process. No-op in monolith (no engine.pid).

**Tests:** template + idempotent-rewrite + doctor (monolith/split/stale/version-skew) + reaper (live/dead/absent/recycled-PID/unverifiable-identity). 373 service+install tests pass, `-race` clean, cross-compile (linux/windows) clean. Independent Opus review APPROVE after adding the PID-identity guard (only defect found; everything else — templates, self-heal, monolith-safe doctor, matching constants — confirmed correct).

Refs #5729 #5727