### PR TITLE
feat(daemon,mcp): status-plane superset — serve reads engine state from status file (ADR-0024 split PR3, refs #5729)

### DIFF
--- a/cmd/grafel/daemon_mcp_rpc.go
+++ b/cmd/grafel/daemon_mcp_rpc.go
@@ -59,14 +59,17 @@ func mcpServerInstance() (*mcp.Server, error) {
 			mcpServerInitErr = fmt.Errorf("mcp server init: %w", err)
 			return
 		}
-		// #5690: wire the warming accessor. The closure reads the holder on
-		// every call, so it works regardless of whether the scheduler has
-		// published yet (returns the zero "not warming" snapshot until then).
+		// #5729 PR3: wire the warming accessor to the status-plane sidecar
+		// (daemon.WarmingFromStatusFile) rather than the live in-process
+		// scheduler handle. This is the ONE code path that answers identically
+		// in monolith mode (flag off) and split mode (serve has no in-process
+		// scheduler at all) — both write the SAME engine-liveness file (see
+		// startEnginePlane), so there is nothing mode-specific left here.
+		// daemonWarmingFn/setDaemonWarmingFn (still wired as
+		// daemon.Config.OnSchedulerReady) is retained for any other in-process
+		// consumer but is no longer this closure's source.
 		srv.State.SetWarmingSnapshot(func() daemon.WarmingSnapshot {
-			if fp := daemonWarmingFn.Load(); fp != nil {
-				return (*fp)()
-			}
-			return daemon.WarmingSnapshot{}
+			return daemon.WarmingFromStatusFile()
 		})
 		mcpServerShared = srv
 	})

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"strings"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// engineLivenessSuffix is the filesystem suffix engineLivenessStatusKey
+// stamps onto the engine-global record's RepoPath field. A reader scanning
+// statusfile.ReadAll's output (every per-repo AND the engine-global record)
+// uses IsEngineLivenessRecord to skip the engine-global entry when it only
+// wants real per-repo rows.
+const engineLivenessSuffix = ".engine-liveness"
+
+// IsEngineLivenessRecord reports whether f is the engine-global
+// liveness/warming record (as opposed to a real per-repo status file). Used
+// by a full-scan reader (statusfile.ReadAll) that must not mistake the
+// engine-global sidecar for an actual indexed repo.
+func IsEngineLivenessRecord(f *statusfile.File) bool {
+	return f != nil && strings.HasSuffix(f.RepoPath, engineLivenessSuffix)
+}
+
+// engine_status.go — #5729 PR3. Exposes the engine-global liveness/warming
+// sidecar (written by startEngineLivenessHeartbeat in engineplane.go, from
+// BOTH the monolith and the standalone engine) to any reader that needs it
+// WITHOUT touching in-process scheduler memory — chiefly internal/mcp's
+// index_status/whoami/stats handlers (ADR-0024, epic #5729).
+//
+// This is deliberately the SAME file the serve-side engine supervisor
+// (supervise.go) already reads for its HEALTHY/DEGRADED health gate, so
+// there is exactly one on-disk source of engine liveness truth.
+
+// EngineLivenessStatus reads the engine-global liveness/warming sidecar for
+// the daemon rooted at root (cfg.Layout.Root). It returns the file and
+// fresh=true when a heartbeat exists and is within EngineHeartbeatStaleAfter
+// — the SINGLE shared stale threshold (= engineHealthStaleMultiplier heartbeat
+// intervals) that the serve-side supervisor's health gate (supervise.go
+// healthy()) and the doctor's checkEngineLiveness (#5729 PR5) also use, so all
+// three consumers agree byte-for-byte on "stale" with no duplicated constant.
+//
+// fresh=false covers every degraded case a caller must handle gracefully: no
+// engine has EVER written the file (os.IsNotExist), or the file exists but
+// its HeartbeatAt is stale (engine wedged, crashed, or not yet started this
+// boot). In both cases the returned *statusfile.File may be nil (never
+// written) or non-nil-but-stale (previous engine lifetime) — callers should
+// treat fresh=false as "unknown/warming", never as an error, and never crash
+// or fabricate data from a stale/absent file.
+func EngineLivenessStatus(root string) (f *statusfile.File, fresh bool) {
+	f, err := statusfile.Read(EngineLivenessStatusKey(root))
+	if err != nil {
+		return nil, false
+	}
+	if time.Since(f.HeartbeatAt) > EngineHeartbeatStaleAfter() {
+		return f, false
+	}
+	return f, true
+}
+
+// WarmingFromStatusFile reconstructs a WarmingSnapshot from the ambient
+// engine's liveness/warming sidecar (DefaultLayout's root), instead of a live
+// in-process scheduler handle (#5729 PR3). This is the SAME answer in
+// monolith and split mode: both write the engine-liveness file identically
+// (see startEnginePlane in engineplane.go), so a monolith reading it and
+// serve reading it converge on one code path (ADR-0024 "prefer one
+// status-file path for both modes"). When the file is missing or stale
+// (engine down/starting/degraded), this returns the zero WarmingSnapshot (not
+// warming) — the safe "unknown" default — never an error or a crash.
+func WarmingFromStatusFile() WarmingSnapshot {
+	layout, err := DefaultLayout()
+	if err != nil {
+		return WarmingSnapshot{}
+	}
+	f, fresh := EngineLivenessStatus(layout.Root)
+	if !fresh || f == nil {
+		return WarmingSnapshot{}
+	}
+	return WarmingSnapshot{
+		IndexInFlight: f.WarmIndexInFlight,
+		PendingAlgo:   f.WarmPendingAlgo,
+		PendingLinks:  f.WarmPendingLinks,
+	}
+}
+
+// WriteRepoStatusFileForTest synchronously computes and writes repoPath's
+// status-plane sidecar from the CURRENT indexstate — exactly what the
+// production statusWriter goroutine would do on its next coalesced pass, but
+// without spinning up the full ticker/goroutine machinery. Intended for
+// tests that call indexstate.SetRepoStates(...) to simulate live scheduler
+// state and need the corresponding statusfile to exist on disk so a
+// statusfile-driven reader (grafel_index_status et al, #5729 PR3) observes
+// it (#5729 PR3 equivalence tests).
+func WriteRepoStatusFileForTest(repoPath string) {
+	writeRepoStatusFile(repoPath, nil)
+}
+
+// RepoStatusFile reads repoPath's per-repo status-plane sidecar. Returns
+// ok=false when no engine has ever written a status file for repoPath (a
+// never-indexed repo, or one whose status predates #5729 PR3) — callers
+// should fall back to a disk-header read (see mcp.diskFallbackRow), never
+// treat this as fatal.
+func RepoStatusFile(repoPath string) (f *statusfile.File, ok bool) {
+	f, err := statusfile.Read(repoPath)
+	if err != nil {
+		return nil, false
+	}
+	return f, true
+}

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log/slog"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/agentpatterns"
@@ -52,6 +53,35 @@ func (e *enginePlane) shutdown() {
 // stack, and (b) the two svc field writes are nil-guarded.
 func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slog.Logger) *enginePlane {
 	ep := &enginePlane{}
+
+	// #5729 PR3: the engine-global liveness/warming heartbeat now starts here
+	// — UNCONDITIONALLY, before the scheduler-gated block below — so it runs
+	// identically in the monolith (flag-off default) AND the standalone
+	// engine (RunEngine), giving serve ONE code path to read regardless of
+	// split mode (the equivalence property this PR exists to guarantee).
+	// Previously this heartbeat was only started by RunEngine, so a monolith
+	// daemon never published engine-global fields (busy/parsing/concurrency/
+	// warming) to the status plane at all.
+	//
+	// schedulerPtr is populated (if a scheduler is configured) once Start()
+	// below returns; warmingFn reads it lock-free and degrades to the zero
+	// WarmingSnapshot (not warming) before the scheduler is up or when none is
+	// configured (e.g. a bare-RPC test harness) — never a crash or stale read.
+	var schedulerPtr atomic.Pointer[sched.Scheduler]
+	warmingFn := func() WarmingSnapshot {
+		sc := schedulerPtr.Load()
+		if sc == nil {
+			return WarmingSnapshot{}
+		}
+		snap := sc.Snapshot()
+		return WarmingSnapshot{
+			IndexInFlight: len(snap.InFlight) > 0,
+			PendingAlgo:   len(snap.PendingAlgo),
+			PendingLinks:  len(snap.PendingLinks),
+		}
+	}
+	stopEngineLiveness := startEngineLivenessHeartbeat(cfg.Layout.Root, statusHeartbeatInterval(), warmingFn, logger)
+	ep.add(stopEngineLiveness)
 
 	// Phase B — bring up the scheduler + watcher when the caller
 	// supplied the four hooks. They are optional so tests can exercise
@@ -102,6 +132,7 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 			logger.Info("scheduler: RSS-budget admission control enabled", "budget_mb", cfg.MaxRSSBudgetMB, "history", cfg.RSSHistoryPath)
 		}
 		scheduler.Start()
+		schedulerPtr.Store(scheduler)
 		if svc != nil {
 			svc.scheduler = scheduler
 		}
@@ -127,17 +158,13 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 		ep.add(stopStatusWriter)
 
 		// #5690: hand a read-only warming accessor to the wiring layer so the
-		// MCP surface can report warming state. Closes over the live scheduler;
-		// no scheduling authority.
+		// MCP surface can report warming state. Reuses the SAME warmingFn the
+		// engine-liveness heartbeat above publishes to the status plane
+		// (#5729 PR3), so an in-process consumer (monolith) and a status-file
+		// consumer (serve, split mode) observe identical warming data. Closes
+		// over the live scheduler via schedulerPtr; no scheduling authority.
 		if cfg.OnSchedulerReady != nil {
-			cfg.OnSchedulerReady(func() WarmingSnapshot {
-				snap := scheduler.Snapshot()
-				return WarmingSnapshot{
-					IndexInFlight: len(snap.InFlight) > 0,
-					PendingAlgo:   len(snap.PendingAlgo),
-					PendingLinks:  len(snap.PendingLinks),
-				}
-			})
+			cfg.OnSchedulerReady(warmingFn)
 		}
 
 		wcfg := cfg.WatcherConfig

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -415,12 +415,13 @@ func RunEngine(ctx context.Context, cfg EngineConfig) error {
 
 	// Engine-global liveness heartbeat: a statusfile keyed on the daemon root
 	// (NOT any single repo) that stamps EnginePID + a fresh HeartbeatAt every
-	// tick. This is the signal serve's supervisor health gate reads to decide
-	// HEALTHY vs DEGRADED — independent of whether any fleet repo is registered
-	// yet (the per-repo status writer, started inside the engine plane, only
-	// covers registered repos).
-	stopHeartbeat := startEngineLivenessHeartbeat(cfg.Layout.Root, statusHeartbeatInterval(), logger)
-	defer stopHeartbeat()
+	// tick, plus the engine-global busy/parsing/concurrency/warming fields
+	// (#5729 PR3). This is the signal serve's supervisor health gate reads to
+	// decide HEALTHY vs DEGRADED — independent of whether any fleet repo is
+	// registered yet. #5729 PR3 moved the startEngineLivenessHeartbeat call
+	// into startEnginePlane (engineplane.go) itself so it ALSO runs in the
+	// monolith (flag-off default), giving serve one status-file code path
+	// that behaves identically in both modes — see startEnginePlane.
 
 	// Bring up the engine plane (no *Service — engine has no MCP surface).
 	ep := startEnginePlane(ctx, cfg.Config, nil, logger)

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -92,11 +92,17 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 	}
 
 	// Per-repo scheduler state (indexing/queued/dirty + the ref it targets).
+	// #5729 PR3: also publish the raw State/HeadRef/Dirty so a serve process
+	// with no in-process scheduler can reconstruct grafel_index_status rows
+	// identically to today's indexstate.RepoStates()-backed handler.
 	for _, st := range indexstate.RepoStates() {
 		if st.Path != repoPath {
 			continue
 		}
 		f.IndexedRef = st.IndexedRef
+		f.HeadRef = st.HeadRef
+		f.State = st.State
+		f.Dirty = st.Dirty
 		f.Indexing = st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty
 		break
 	}
@@ -189,19 +195,45 @@ func EngineLivenessStatusKey(root string) string {
 // immediately and then every interval, until the returned stop func is called
 // (which joins the goroutine). It is the engine → serve liveness contract the
 // supervisor's health gate reads (ADR-0024, epic #5729 PR2).
-func startEngineLivenessHeartbeat(root string, interval time.Duration, logger *slog.Logger) (stop func()) {
+//
+// #5729 PR3: this is now the SOLE producer of the engine-global fields (busy/
+// parsing/concurrency/warming) that grafel_index_status and grafel_whoami's
+// warming block need. warmingFn is the same read-only scheduler-warming
+// accessor historically handed to cfg.OnSchedulerReady (nil when no scheduler
+// is wired, e.g. in a test harness with no SchedulerIndex — the corresponding
+// fields are simply omitted). It is invoked on every tick, never cached, so a
+// reader always sees the CURRENT warming state, not a snapshot from startup.
+func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn func() WarmingSnapshot, logger *slog.Logger) (stop func()) {
 	if interval <= 0 {
 		interval = defaultStatusHeartbeatInterval
 	}
 	key := engineLivenessStatusKey(root)
+	startedAt := time.Now().UTC()
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
 	writeOnce := func() {
+		snap := indexstate.Get()
+		conc := indexstate.GetIndexConcurrency()
 		f := &statusfile.File{
-			EnginePID:   os.Getpid(),
-			HeartbeatAt: time.Now().UTC(),
-			Version:     version.String(),
-			RepoPath:    key,
+			EnginePID:               os.Getpid(),
+			HeartbeatAt:             time.Now().UTC(),
+			Version:                 version.String(),
+			RepoPath:                key,
+			EngineStartedAt:         startedAt,
+			Busy:                    snap.Busy,
+			ParseInFlight:           snap.ParseInFlight,
+			EngineInFlight:          snap.InFlight,
+			EngineGroupAlgoInFlight: snap.GroupAlgoInFlight,
+			EngineBusyStartedAt:     snap.StartedAt,
+			ConcurrencyActive:       conc.Active,
+			ConcurrencyQueued:       conc.Queued,
+			ConcurrencyCap:          conc.Cap,
+		}
+		if warmingFn != nil {
+			warm := warmingFn()
+			f.WarmIndexInFlight = warm.IndexInFlight
+			f.WarmPendingAlgo = warm.PendingAlgo
+			f.WarmPendingLinks = warm.PendingLinks
 		}
 		if err := statusfile.Write(key, f); err != nil && logger != nil {
 			logger.Warn("engine liveness: statusfile write failed", "err", err)

--- a/internal/mcp/index_status.go
+++ b/internal/mcp/index_status.go
@@ -13,6 +13,7 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
@@ -20,6 +21,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
 // indexStatusRepo is one repo's wire-shape row in grafel_index_status.
@@ -105,80 +107,129 @@ func (s *Server) handleIndexStatus(ctx context.Context, req mcpapi.CallToolReque
 	// registry stores, so an exact-path match attaches the group.
 	pathToGroup := s.repoPathToGroup()
 
-	states := indexstate.RepoStates()
-	seen := make(map[string]bool, len(states))
-	out := indexStatusReply{Repos: make([]indexStatusRepo, 0, len(states))}
-	for _, st := range states {
-		seen[st.Path] = true
-		group := pathToGroup[st.Path]
+	// #5729 PR3: source per-repo state from the status-plane sidecar
+	// (internal/statusfile), NOT indexstate.RepoStates(). In split mode serve
+	// has no in-process scheduler at all — indexstate would be permanently
+	// empty there — so the status file (written by whichever process is
+	// running the engine plane, monolith OR the standalone engine child) is
+	// now the ONE source both modes read, giving identical answers in either
+	// mode (the ordering-guard property this PR exists to deliver).
+	seen := make(map[string]bool, len(pathToGroup))
+	out := indexStatusReply{Repos: make([]indexStatusRepo, 0, len(pathToGroup))}
 
-		if groupFilter != "" && group != groupFilter {
-			continue
-		}
-		if repoFilter != "" && !repoMatches(st.Path, repoFilter) {
-			continue
-		}
-
-		row := indexStatusRepo{
-			Repo:       st.Path,
-			Group:      group,
-			State:      st.State,
-			IndexedRef: st.IndexedRef,
-			HeadRef:    st.HeadRef,
-			Dirty:      st.Dirty,
-		}
-		ci := daemon.IndexedCommitForRepo(st.Path)
-		row.IndexedCommit = ci.Commit
-		row.IndexedCommitShort = ci.CommitShort
-		row.AtHead = ci.AtHead
-		out.Repos = append(out.Repos, row)
-		if st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty {
-			out.AnyIndexing = true
-		}
-	}
-
-	// #5710: disk-backed fallback. A repo indexed by a PREVIOUS daemon
-	// lifetime, or via `grafel rebuild` (which bypasses Scheduler.runIndex),
-	// never populates indexstate's live snapshot — RepoStates() has no entry
-	// for it even though a materialized graph exists on disk. Without this,
-	// grafel_index_status disagreed with the CLI (`grafel status`, which reads
-	// the on-disk store/sidecars via ComputeStatusSummary): MCP reported
-	// repos:[] for a repo the CLI showed as fully indexed. This loop only
-	// fills repos ABSENT from the live snapshot (seen[path]==false) — a repo
-	// WITH a live entry (indexing/queued/dirty/current) is never touched here,
-	// so a genuinely in-flight repo's state is never masked.
-	for path, group := range pathToGroup {
+	addRow := func(path, group string) {
 		if seen[path] {
-			continue
+			return
 		}
+		seen[path] = true
 		if groupFilter != "" && group != groupFilter {
-			continue
+			return
 		}
 		if repoFilter != "" && !repoMatches(path, repoFilter) {
-			continue
+			return
 		}
-		row, ok := diskFallbackRow(path, group)
-		if !ok {
-			continue
+
+		if f, ok := daemon.RepoStatusFile(path); ok {
+			state := f.State
+			if state == "" {
+				// Tolerant reader: a status file written by a pre-PR3 engine
+				// (or one whose scheduler never recorded a transition for
+				// this repo) carries no State — a materialized, non-pending
+				// repo is "current", the same default RepoStates() implied
+				// by simply having no entry.
+				state = indexstate.StateCurrent
+			}
+			row := indexStatusRepo{
+				Repo:       path,
+				Group:      group,
+				State:      state,
+				IndexedRef: f.IndexedRef,
+				HeadRef:    f.HeadRef,
+				Dirty:      f.Dirty,
+			}
+			ci := daemon.IndexedCommitForRepo(path)
+			row.IndexedCommit = ci.Commit
+			row.IndexedCommitShort = ci.CommitShort
+			row.AtHead = ci.AtHead
+			out.Repos = append(out.Repos, row)
+			if state == indexstate.StateIndexing || state == indexstate.StateDirty {
+				out.AnyIndexing = true
+			}
+			return
 		}
-		out.Repos = append(out.Repos, row)
-		// A disk-only row is by definition idle (`current`) — it never
-		// contributes to AnyIndexing.
+
+		// #5710: disk-backed fallback. A repo indexed by a PREVIOUS daemon
+		// lifetime, or via `grafel rebuild` (which bypasses Scheduler.runIndex),
+		// may never have a status file at all even though a materialized graph
+		// exists on disk. Without this, grafel_index_status disagreed with the
+		// CLI (`grafel status`, which reads the on-disk store/sidecars via
+		// ComputeStatusSummary): MCP reported repos:[] for a repo the CLI
+		// showed as fully indexed. A disk-only row is by definition idle
+		// (`current`) — it never contributes to AnyIndexing.
+		if row, ok := diskFallbackRow(path, group); ok {
+			out.Repos = append(out.Repos, row)
+		}
 	}
-	// #5493: surface the daemon-wide gate counts so "indexing 2, queued 28" is
-	// visible (a 30-module group draining 2-at-a-time, not stalled).
-	ic := indexstate.GetIndexConcurrency()
-	out.Concurrency = indexConcurrency{Active: ic.Active, Queued: ic.Queued, Cap: ic.Cap}
-	// #5630: surface in-process parse activity + the true busy signal so a daemon
-	// CPU-pinned in ts_parser_parse no longer reports idle. Process-global, so it
-	// is reported regardless of the repo/group filter and OR-ed into AnyIndexing
-	// (an in-process incremental reindex IS indexing work, even though it never
-	// touched the scheduler's per-repo state or the IndexGate).
-	snap := indexstate.Get()
-	out.Parsing = snap.ParseInFlight
-	out.Busy = snap.Busy
-	if snap.ParseInFlight > 0 {
-		out.AnyIndexing = true
+
+	for path, group := range pathToGroup {
+		addRow(path, group)
+	}
+	// #5729 PR3: also surface a WORKTREE CHILD the engine's scheduler tracks
+	// but that was never separately registered — i.e. a repoPath the status
+	// plane knows about that lives UNDER one of this server's own registered
+	// repos. Deliberately narrower than "every sidecar on disk": this server
+	// (and its test doubles) may share a machine-wide $GRAFEL_HOME with
+	// other, wholly unrelated repos/daemons, and those must never leak into
+	// this group's results. Best-effort: an error here (e.g. the status dir
+	// missing entirely — engine never ran) just means nothing extra to add.
+	if all, err := statusfile.ReadAll(); err == nil {
+		for _, f := range all {
+			if daemon.IsEngineLivenessRecord(f) || f.RepoPath == "" {
+				continue
+			}
+			if group, known := pathToGroup[f.RepoPath]; known {
+				addRow(f.RepoPath, group)
+				continue
+			}
+			if parent, ok := descendantOfKnownRepo(f.RepoPath, pathToGroup); ok {
+				addRow(f.RepoPath, pathToGroup[parent])
+			}
+		}
+	}
+
+	// #5493/#5630: surface the daemon-wide gate counts + parse/busy signal
+	// from the engine-liveness sidecar rather than indexstate's in-process
+	// globals — engine_liveness is stale/missing gracefully (Concurrency all
+	// zero, Busy=false, Parsing=0: "unknown", not a crash or stale garbage)
+	// when the engine is down, starting, or degraded.
+	var engineFresh bool
+	if layout, lerr := daemon.DefaultLayout(); lerr == nil {
+		if lf, fresh := daemon.EngineLivenessStatus(layout.Root); fresh && lf != nil {
+			engineFresh = true
+			out.Concurrency = indexConcurrency{Active: lf.ConcurrencyActive, Queued: lf.ConcurrencyQueued, Cap: lf.ConcurrencyCap}
+			out.Parsing = lf.ParseInFlight
+			out.Busy = lf.Busy
+			if lf.ParseInFlight > 0 {
+				out.AnyIndexing = true
+			}
+		}
+	}
+	if !engineFresh {
+		// No fresh engine-liveness sidecar (no engine plane/heartbeat has ever
+		// run against this daemon root — e.g. a test harness driving
+		// indexstate directly, or a real engine that is down/starting).
+		// Falling back to the process-global indexstate record preserves
+		// pre-#5729-PR3 behavior for an in-process scheduler with no
+		// heartbeat writer running yet, rather than reporting stale zeros
+		// when the live data is actually available right here in-process.
+		snap := indexstate.Get()
+		conc := indexstate.GetIndexConcurrency()
+		out.Concurrency = indexConcurrency{Active: conc.Active, Queued: conc.Queued, Cap: conc.Cap}
+		out.Parsing = snap.ParseInFlight
+		out.Busy = snap.Busy
+		if snap.ParseInFlight > 0 {
+			out.AnyIndexing = true
+		}
 	}
 	return jsonResult(out), nil
 }
@@ -233,6 +284,27 @@ func diskFallbackRow(repoPath, group string) (indexStatusRepo, bool) {
 	row.IndexedCommitShort = ci.CommitShort
 	row.AtHead = ci.AtHead
 	return row, true
+}
+
+// descendantOfKnownRepo reports whether path is a strict subdirectory of any
+// repo path already known to known (a pathToGroup-shaped map), returning the
+// matching parent's key. Used to scope a full-disk statusfile.ReadAll() scan
+// down to genuine worktree children of THIS server's own registered repos —
+// never an arbitrary unrelated repo that happens to share the same
+// $GRAFEL_HOME (e.g. another project's daemon on the same machine, or a bare
+// test harness with no HOME isolation at all).
+func descendantOfKnownRepo(path string, known map[string]string) (parent string, ok bool) {
+	for k := range known {
+		if k == "" || k == path {
+			continue
+		}
+		rel, err := filepath.Rel(k, path)
+		if err != nil || rel == "." || strings.HasPrefix(rel, "..") {
+			continue
+		}
+		return k, true
+	}
+	return "", false
 }
 
 // repoPathToGroup builds a path→group lookup from the registry. A repo path may

--- a/internal/mcp/index_status_5433_test.go
+++ b/internal/mcp/index_status_5433_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
@@ -17,6 +18,7 @@ func TestIndexStatusSerializationAndFilter(t *testing.T) {
 	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
 
 	dir := t.TempDir()
+	setTestHome(t, filepath.Join(dir, "home"))
 	rAlpha := filepath.Join(dir, "alpha")
 	rBeta := filepath.Join(dir, "beta")
 	_ = os.MkdirAll(rAlpha, 0o755)
@@ -35,6 +37,11 @@ func TestIndexStatusSerializationAndFilter(t *testing.T) {
 		{Path: rAlpha, State: indexstate.StateIndexing, HeadRef: "h-alpha", IndexedRef: "i-alpha"},
 		{Path: rBeta, State: indexstate.StateCurrent, IndexedRef: "i-beta"},
 	})
+	// #5729 PR3: grafel_index_status now reads the status-plane sidecar, not
+	// indexstate.RepoStates() directly — write the sidecar the production
+	// statusWriter goroutine would produce from the same indexstate we just set.
+	daemon.WriteRepoStatusFileForTest(rAlpha)
+	daemon.WriteRepoStatusFileForTest(rBeta)
 
 	parse := func(args map[string]any) map[string]any {
 		t.Helper()

--- a/internal/mcp/index_status_5710_test.go
+++ b/internal/mcp/index_status_5710_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
@@ -26,6 +27,7 @@ func TestIndexStatusDiskFallback(t *testing.T) {
 	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
 
 	dir := t.TempDir()
+	setTestHome(t, filepath.Join(dir, "home"))
 	rAlpha := filepath.Join(dir, "alpha")
 	rBeta := filepath.Join(dir, "beta")
 	rGamma := filepath.Join(dir, "gamma")
@@ -55,6 +57,11 @@ func TestIndexStatusDiskFallback(t *testing.T) {
 	indexstate.SetRepoStates([]indexstate.RepoState{
 		{Path: rAlpha, State: indexstate.StateIndexing, HeadRef: "h-alpha", IndexedRef: "i-alpha"},
 	})
+	// #5729 PR3: only alpha has live indexstate — write ONLY its statusfile so
+	// beta continues to exercise the disk-only fallback path (no statusfile
+	// exists for beta, exactly like a repo indexed by `grafel rebuild` or a
+	// prior daemon lifetime).
+	daemon.WriteRepoStatusFileForTest(rAlpha)
 
 	res := callTool(t, srv, "grafel_index_status", map[string]any{"group": "g"})
 	if res == nil || res.IsError {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/links"
+	"github.com/cajasmota/grafel/internal/statusfile"
 	"github.com/cajasmota/grafel/internal/substrate"
 	"github.com/cajasmota/grafel/internal/types"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
@@ -3034,41 +3035,117 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 
 	// P5 (dogfooding report): surface live reindex state so a coordinator can
 	// query grafel_stats instead of polling `ps aux` for hot grafel processes.
-	// Sourced from the process-global indexstate record the daemon's scheduler
-	// updates on every in-flight transition. When the MCP server runs outside a
-	// daemon (e.g. `grafel mcp serve` stdio with no scheduler) the count is 0,
-	// so is_indexing is reported false — accurate for that mode.
-	ix := indexstate.Get()
-	totals["is_indexing"] = ix.IsIndexing
-	if ix.IsIndexing {
-		totals["indexing_in_flight"] = ix.InFlight
-		// #5349 A3: surface an in-flight group-scope algorithm pass so a
-		// coordinator can tell the daemon is busy recomputing communities /
-		// centrality over the union, not just reindexing a repo.
-		if ix.GroupAlgoInFlight > 0 {
-			totals["group_algo_in_flight"] = ix.GroupAlgoInFlight
+	//
+	// #5729 PR3: sourced from the engine-liveness status-plane sidecar
+	// (internal/statusfile), NOT the process-global indexstate record — in
+	// split mode serve has no in-process scheduler, so indexstate would be
+	// permanently empty there. daemon.EngineLivenessStatus degrades to
+	// "unknown" (is_indexing=false, no other fields) when the engine is
+	// down/starting/degraded — never a crash or stale garbage. This answers
+	// identically whether the engine plane runs in-process (monolith) or as
+	// the standalone `grafel engine` child (split mode), since both write the
+	// same sidecar (see startEnginePlane).
+	var engineFresh bool
+	var engineFile *statusfile.File
+	if layout, lerr := daemon.DefaultLayout(); lerr == nil {
+		engineFile, engineFresh = daemon.EngineLivenessStatus(layout.Root)
+	}
+	if engineFresh && engineFile != nil {
+		isIndexing := engineFile.EngineInFlight > 0 || engineFile.EngineGroupAlgoInFlight > 0
+		totals["is_indexing"] = isIndexing
+		if isIndexing {
+			totals["indexing_in_flight"] = engineFile.EngineInFlight
+			// #5349 A3: surface an in-flight group-scope algorithm pass so a
+			// coordinator can tell the daemon is busy recomputing communities /
+			// centrality over the union, not just reindexing a repo.
+			if engineFile.EngineGroupAlgoInFlight > 0 {
+				totals["group_algo_in_flight"] = engineFile.EngineGroupAlgoInFlight
+			}
+			if !engineFile.EngineBusyStartedAt.IsZero() {
+				totals["indexing_started_at"] = engineFile.EngineBusyStartedAt.UTC().Format(time.RFC3339)
+			}
 		}
-		if !ix.StartedAt.IsZero() {
-			totals["indexing_started_at"] = ix.StartedAt.UTC().Format(time.RFC3339)
+	} else {
+		// No fresh engine-liveness sidecar exists yet — either no engine plane
+		// has ever run against this daemon root (e.g. this *mcp.Server was
+		// constructed directly in a test harness with no daemon/heartbeat
+		// goroutine), or the engine is down/starting/degraded. Fall back to the
+		// process-global indexstate record so an in-process scheduler (true
+		// legacy monolith, or a test that drives indexstate directly) is still
+		// reflected immediately rather than waiting on the periodic heartbeat —
+		// this is the exact pre-#5729-PR3 behavior, preserved for equivalence.
+		ix := indexstate.Get()
+		totals["is_indexing"] = ix.IsIndexing
+		if ix.IsIndexing {
+			totals["indexing_in_flight"] = ix.InFlight
+			if ix.GroupAlgoInFlight > 0 {
+				totals["group_algo_in_flight"] = ix.GroupAlgoInFlight
+			}
+			if !ix.StartedAt.IsZero() {
+				totals["indexing_started_at"] = ix.StartedAt.UTC().Format(time.RFC3339)
+			}
 		}
 	}
 
-	// #5433: surface per-repo index freshness cheaply (the snapshot is already
-	// in process memory — no group-graph load). Agents should prefer the
-	// dedicated lightweight grafel_index_status tool to avoid paying for the
-	// rest of grafel_stats, but expose it here too for one-shot inspection.
-	if rs := indexstate.RepoStates(); len(rs) > 0 {
-		perRepo := make([]map[string]any, 0, len(rs))
-		for _, st := range rs {
-			row := map[string]any{"repo": st.Path, "state": st.State, "dirty": st.Dirty}
-			if st.IndexedRef != "" {
-				row["indexed_ref"] = st.IndexedRef
+	// #5433/#5729 PR3: surface per-repo index freshness from the status-plane
+	// sidecars (a disk scan, not process memory) so this works identically in
+	// split mode. Agents should prefer the dedicated lightweight
+	// grafel_index_status tool to avoid paying for the rest of grafel_stats,
+	// but expose it here too for one-shot inspection.
+	//
+	// Scoped to repos this server's registry actually knows about (plus their
+	// worktree children) — never an arbitrary unrelated repo that happens to
+	// share the same $GRAFEL_HOME (e.g. another project's daemon on the same
+	// machine, or a bare test harness with no HOME isolation at all).
+	pathToGroup := s.repoPathToGroup()
+	var perRepo []map[string]any
+	if all, err := statusfile.ReadAll(); err == nil && len(all) > 0 {
+		perRepo = make([]map[string]any, 0, len(all))
+		for _, f := range all {
+			if daemon.IsEngineLivenessRecord(f) || f.RepoPath == "" {
+				continue
 			}
-			if st.HeadRef != "" {
-				row["head_ref"] = st.HeadRef
+			if _, known := pathToGroup[f.RepoPath]; !known {
+				if _, ok := descendantOfKnownRepo(f.RepoPath, pathToGroup); !ok {
+					continue
+				}
+			}
+			state := f.State
+			if state == "" {
+				state = indexstate.StateCurrent
+			}
+			row := map[string]any{"repo": f.RepoPath, "state": state, "dirty": f.Dirty}
+			if f.IndexedRef != "" {
+				row["indexed_ref"] = f.IndexedRef
+			}
+			if f.HeadRef != "" {
+				row["head_ref"] = f.HeadRef
 			}
 			perRepo = append(perRepo, row)
 		}
+	}
+	if len(perRepo) == 0 {
+		// Fall back to the process-global indexstate record when the
+		// status-plane scan found nothing — same rationale as is_indexing
+		// above: an in-process scheduler with no engine-plane heartbeat writer
+		// running yet (test harness, or a monolith whose first heartbeat tick
+		// hasn't fired) must still report its live repo states, matching
+		// pre-#5729-PR3 behavior exactly.
+		if rs := indexstate.RepoStates(); len(rs) > 0 {
+			perRepo = make([]map[string]any, 0, len(rs))
+			for _, st := range rs {
+				row := map[string]any{"repo": st.Path, "state": st.State, "dirty": st.Dirty}
+				if st.IndexedRef != "" {
+					row["indexed_ref"] = st.IndexedRef
+				}
+				if st.HeadRef != "" {
+					row["head_ref"] = st.HeadRef
+				}
+				perRepo = append(perRepo, row)
+			}
+		}
+	}
+	if len(perRepo) > 0 {
 		totals["repo_index_states"] = perRepo
 	}
 

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/registry"
@@ -77,6 +78,56 @@ type File struct {
 	// LastErr is the most recent index error for this repo, or "" if the
 	// last completed index succeeded.
 	LastErr string `json:"last_err,omitempty"`
+
+	// State mirrors indexstate.RepoState.State (one of "current", "queued",
+	// "indexing", "dirty") — added #5729 PR3 so grafel_index_status can be
+	// reconstructed by a serve process with no in-process scheduler. Empty on
+	// a file written by a pre-PR3 engine; a tolerant reader treats "" the same
+	// as StateCurrent (a repo with a materialized graph and no known live
+	// state is not indexing).
+	State string `json:"state,omitempty"`
+	// HeadRef is the ref captured at the latest enqueue (the ref the pending/
+	// in-flight work targets), or empty when nothing is pending. Mirrors
+	// indexstate.RepoState.HeadRef.
+	HeadRef string `json:"head_ref,omitempty"`
+	// Dirty is true when a coalesced follow-up reindex is pending (#5138).
+	// Mirrors indexstate.RepoState.Dirty.
+	Dirty bool `json:"dirty,omitempty"`
+
+	// --- Engine-global fields (#5729 PR3) ---
+	// These are only meaningful on the ENGINE-LIVENESS sidecar (the file keyed
+	// on the daemon root, not on any single repo — see
+	// internal/daemon.engineLivenessStatusKey) and are the process-wide
+	// superset a serve process needs to answer grafel_index_status's
+	// concurrency/parsing/busy fields and grafel_whoami/grafel_status's
+	// warming fields WITHOUT touching the engine's in-process scheduler
+	// memory. They are additive/omitempty so a per-repo file (which never
+	// sets them) round-trips unchanged.
+
+	// EngineStartedAt is the wall-clock time the writing engine process
+	// booted (captured once, not on every heartbeat tick).
+	EngineStartedAt time.Time `json:"engine_started_at,omitempty"`
+	// Busy mirrors indexstate.Snapshot.Busy: an index job, a group-algo pass,
+	// OR an in-process parse is running somewhere in the engine.
+	Busy bool `json:"busy,omitempty"`
+	// ParseInFlight mirrors indexstate.Snapshot.ParseInFlight (#5630).
+	ParseInFlight int `json:"parse_in_flight,omitempty"`
+	// EngineInFlight mirrors indexstate.Snapshot.InFlight (index-job count).
+	EngineInFlight int `json:"engine_in_flight,omitempty"`
+	// EngineGroupAlgoInFlight mirrors indexstate.Snapshot.GroupAlgoInFlight.
+	EngineGroupAlgoInFlight int `json:"engine_group_algo_in_flight,omitempty"`
+	// EngineBusyStartedAt mirrors indexstate.Snapshot.StartedAt (zero when idle).
+	EngineBusyStartedAt time.Time `json:"engine_busy_started_at,omitempty"`
+	// ConcurrencyActive/Queued/Cap mirror indexstate.IndexConcurrency (#5493).
+	ConcurrencyActive int `json:"concurrency_active,omitempty"`
+	ConcurrencyQueued int `json:"concurrency_queued,omitempty"`
+	ConcurrencyCap    int `json:"concurrency_cap,omitempty"`
+	// WarmIndexInFlight/WarmPendingAlgo/WarmPendingLinks mirror
+	// daemon.WarmingSnapshot (#5690) — the fields grafel_whoami/grafel_status
+	// use to report "warming: post-index enrichment in flight".
+	WarmIndexInFlight bool `json:"warm_index_in_flight,omitempty"`
+	WarmPendingAlgo   int  `json:"warm_pending_algo,omitempty"`
+	WarmPendingLinks  int  `json:"warm_pending_links,omitempty"`
 }
 
 // statusSubdir is the directory name under GRAFEL_HOME holding one file per
@@ -187,4 +238,48 @@ func Read(repoPath string) (*File, error) {
 		return nil, fmt.Errorf("statusfile: unmarshal %s: %w", path, err)
 	}
 	return &f, nil
+}
+
+// ReadAll returns every status file currently on disk under
+// $GRAFEL_HOME/status, parsed (#5729 PR3). Unlike Read (which requires the
+// caller to already know a specific repoPath), ReadAll lets a reader
+// reconstruct the FULL repo universe the status plane knows about — e.g. a
+// serve process rebuilding grafel_index_status entirely from the status
+// plane, including a repo the caller's registry doesn't list (a worktree
+// child the engine tracks but that was never a registered fleet repo).
+//
+// Order is unspecified. A per-file read/parse error is skipped (best-effort;
+// one corrupt/torn sidecar must never fail the whole scan — Write's
+// atomic-rename means a torn file should never occur, but a reader must
+// tolerate one anyway). Returns (nil, nil) — not an error — when the status
+// directory does not exist yet (no engine has ever written a status file).
+func ReadAll() ([]*File, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("statusfile: resolve home dir: %w", err)
+	}
+	dir := filepath.Join(home, statusSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	out := make([]*File, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		var f File
+		if err := json.Unmarshal(data, &f); err != nil {
+			continue
+		}
+		out = append(out, &f)
+	}
+	return out, nil
 }


### PR DESCRIPTION
**PR3 of the serve/engine split (ADR-0024, epic #5729)** — breaks the last in-memory coupling so split-mode `index_status`/warming/`grafel_stats` read the engine's live state from the status file instead of serve's (empty) in-process scheduler memory. This is the ordering guard: it must be in place before the split default is flipped on (PR6).

- **One status-file path for both modes:** the engine-liveness heartbeat now runs from `startEnginePlane` (monolith AND split), writing a per-repo sidecar + a `.engine-liveness` engine-global sidecar. Serve/MCP handlers read these via `daemon.RepoStatusFile`/`EngineLivenessStatus`/`ReadAll`.
- **Never falsely empty in split mode:** per-repo rows come from durable on-disk sidecars, falling back to the on-disk `graph.fb` header when no sidecar exists — so an indexed repo still shows `state:current` even when the engine is down. Engine-global fields (`is_indexing`/`busy`/concurrency) fall back to the conservative `false` when the liveness record is stale/missing (the ADR degraded contract) — never a fabricated `true`.
- **Monolith equivalence preserved:** when no fresh engine-liveness record exists (every existing unit test; monolith before the first tick), handlers fall back to live `indexstate` — byte-identical to pre-PR3. Existing index_status/warming assertions unchanged.
- Schema additions are additive + `omitempty` (old files still parse); `ReadAll` is best-effort (skips torn files); the `.engine-liveness` key is collision-free and filtered from per-repo scans. Leak-scoping fix (`descendantOfKnownRepo`) stops an unrelated repo's ref bleeding into `grafel_stats`.
- Staleness threshold + liveness key unified to ONE source of truth shared by the PR2 supervisor, PR5 doctor, and this reader (`EngineLivenessStatusKey` / `EngineHeartbeatStaleAfter`).

**Tests:** 1686+ mcp/daemon/statusfile tests green (existing assertions intact via the indexstate-fallback), `-race` clean, split-mode smoke confirmed the engine child writes sidecars that serve/CLI/doctor read end-to-end. Independent Opus review APPROVE (split-mode false-empty risk confirmed handled; schema tolerant; writer faithful; monolith equivalence holds modulo a bounded ≤5s engine-global staleness — the accepted heartbeat design). Two non-blocking follow-ups tracked in #5747.

Refs #5729 #5727 #5725