### PR TITLE
feat(daemon): serve→engine request queue for cross-process reindex (ADR-0024 split PR4, refs #5729)

### DIFF
--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -138,6 +138,17 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 		}
 		ep.add(scheduler.Stop)
 
+		// ADR-0024 PR4 (epic #5729): the serve→engine request-file queue
+		// consumer. Only meaningful in split mode — the monolith (flag off,
+		// the default) never has anything to drain because Service.Index's
+		// async fast path calls scheduler.Enqueue directly there (see
+		// service.go). Gating on SplitModeEnabled() keeps monolith behavior
+		// byte-identical: no extra goroutine, no directory globbing, when the
+		// flag is off.
+		if SplitModeEnabled() {
+			ep.add(startRequestsDrainLoop(scheduler, logger))
+		}
+
 		// #5725/#5729-W1: status-plane heartbeat file. startStatusWriter runs a
 		// SINGLE serialized writer goroutine that refreshes every known repo's
 		// on-disk status sidecar (internal/statusfile): promptly on each

--- a/internal/daemon/index_split_mode_test.go
+++ b/internal/daemon/index_split_mode_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+// Mutual-exclusion regression for ADR-0024 PR4 (epic #5729): Service.Index's
+// async fast path must use EXACTLY ONE of the two reindex-trigger paths —
+// never both, and never neither — depending on GRAFEL_SPLIT_MODE:
+//
+//   - flag OFF (monolith, the default): calls s.scheduler.Enqueue directly,
+//     in-process, exactly as before this PR. No requests/ file is written.
+//   - flag ON (split mode): writes a KindReindex request file instead of
+//     touching the scheduler at all (the scheduler is not even consulted —
+//     serve has no scheduler in real split-mode deployments; the field being
+//     non-nil here is only because the test harness wires one to prove it is
+//     NOT called).
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+)
+
+func TestIndexAsync_SplitModeOff_UsesSchedulerDirectly_NoRequestFile(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	enqueued := make(chan string, 1)
+	svc, cleanup := newAsyncTestService(t, func(args proto.IndexArgs) (string, string, error) {
+		t.Fatal("synchronous index entrypoint must not run on the async fast path")
+		return "", "", nil
+	}, func(ctx context.Context, repo, ref string) error {
+		enqueued <- repo
+		return nil
+	})
+	defer cleanup()
+
+	var reply proto.IndexReply
+	if err := svc.Index(&proto.IndexArgs{RepoPath: repoPath, Async: true}, &reply); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	select {
+	case repo := <-enqueued:
+		if repo != repoPath {
+			t.Fatalf("enqueued wrong repo: got %q want %q", repo, repoPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the scheduler to be enqueued directly (monolith path)")
+	}
+
+	dir := requestsDirForRepo(repoPath)
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Fatalf("split mode OFF must not create a requests/ dir; stat=%v", err)
+	}
+}
+
+func TestIndexAsync_SplitModeOn_WritesRequestFile_NeverTouchesScheduler(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	enqueued := make(chan string, 1)
+	svc, cleanup := newAsyncTestService(t, func(args proto.IndexArgs) (string, string, error) {
+		t.Fatal("synchronous index entrypoint must not run on the async fast path")
+		return "", "", nil
+	}, func(ctx context.Context, repo, ref string) error {
+		enqueued <- repo
+		return nil
+	})
+	defer cleanup()
+
+	var reply proto.IndexReply
+	if err := svc.Index(&proto.IndexArgs{RepoPath: repoPath, Async: true}, &reply); err != nil {
+		t.Fatalf("Index: %v", err)
+	}
+
+	select {
+	case repo := <-enqueued:
+		t.Fatalf("split mode ON must NOT call the scheduler directly, but got enqueue for %q", repo)
+	case <-time.After(300 * time.Millisecond):
+		// Expected: no direct enqueue.
+	}
+
+	dir := requestsDirForRepo(repoPath)
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected exactly 1 queued reindex request, got %d", len(recs))
+	}
+	if recs[0].Kind != requests.KindReindex || recs[0].RepoPath != repoPath {
+		t.Fatalf("unexpected record: %+v", recs[0])
+	}
+
+	// Mutual exclusion, end to end: draining it now must reach the SAME
+	// scheduler this test proved was never touched directly.
+	if err := drainRequestsOnce(requestsRoot(), extractSchedulerForTest(svc), nil); err != nil {
+		t.Fatalf("drainRequestsOnce: %v", err)
+	}
+	select {
+	case repo := <-enqueued:
+		if repo != repoPath {
+			t.Fatalf("drained enqueue for wrong repo: got %q want %q", repo, repoPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the drained request to reach the scheduler")
+	}
+}
+
+// extractSchedulerForTest exposes svc.scheduler (unexported) to this
+// same-package test file without adding a production-facing accessor.
+func extractSchedulerForTest(svc *Service) *sched.Scheduler {
+	return svc.scheduler
+}

--- a/internal/daemon/requests/requests.go
+++ b/internal/daemon/requests/requests.go
@@ -1,0 +1,309 @@
+// Package requests implements the serve→engine control-plane request-file
+// queue (ADR-0024 Phase 1 / PR4, epic #5729).
+//
+// In split mode (GRAFEL_SPLIT_MODE=1) serve holds the MCP surface but has no
+// scheduler — the engine child owns that. Mutating tools / reindex triggers
+// that today reach the scheduler via an in-process call cannot do so across
+// the process boundary. This package gives serve a durable, crash-safe way
+// to hand a mutation/trigger to the engine: serve drops a request record as
+// one JSON file under a repo's `requests/` directory (a sibling of
+// repair.json / enrichment-candidates.json under
+// internal/daemon.StateDirForRepo); the engine's drain loop periodically
+// lists pending requests, applies each via the SAME in-process logic that
+// already runs in monolith mode, writes an ack, and deletes the request.
+//
+// Crash-safety and exactly-once are both built from one primitive: atomic
+// write-to-tmp + fsync + rename (mirroring internal/mcp/repair.go's
+// writeRepairFile, the pattern this package generalizes). A request is
+// either fully written-and-renamed or entirely absent — never observed
+// half-written. A request that already has a matching ack is treated as
+// already handled, so a crash between "ack written" and "request deleted"
+// cannot cause a double-apply on redrain.
+package requests
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Kind enumerates the mutation/trigger classes that can be queued. Producers
+// gate on internal/daemon.SplitModeEnabled(); when it's false the existing
+// in-process/direct call path is used instead and no request is written
+// (mutually exclusive by construction — see internal/daemon/service.go's
+// Index method for the reference wiring).
+type Kind string
+
+const (
+	// KindReindex asks the engine to enqueue a (repo, ref, commit) onto its
+	// scheduler — the request-file equivalent of an in-process
+	// sched.Scheduler.EnqueueRefCommit call.
+	KindReindex Kind = "reindex"
+	// KindSubmitRepair mirrors internal/mcp's submit_repair tool. NOTE: as of
+	// PR4, submit_repair does NOT route through this queue in practice — it
+	// already writes repair.json directly (internal/mcp/repair.go
+	// writeRepairFile) and the engine picks up repair.json lazily on its next
+	// scheduled index pass, so it is already cross-process safe with no
+	// producer change required. The kind is defined here so the package is a
+	// complete, reusable primitive if a future need arises for an
+	// acknowledged (not just fire-and-forget) repair submission.
+	KindSubmitRepair Kind = "submit_repair"
+	// KindDocgenApply mirrors grafel_docgen_apply. Like KindSubmitRepair,
+	// today's handlers (handleApplyDocSemantics, handleApplyDocgenRepairs)
+	// already write their sidecars directly and are consumed lazily by the
+	// engine — no producer change required for PR4.
+	KindDocgenApply Kind = "docgen_apply"
+	// KindEnrichmentEnqueue mirrors grafel_enrichments submit/reject. Same
+	// note as above: internal/mcp/candidates.go's appendResolution /
+	// appendRejection already write directly and are consumed lazily.
+	KindEnrichmentEnqueue Kind = "enrichment_enqueue"
+)
+
+// Status is the terminal state an Ack records for a drained request.
+type Status string
+
+const (
+	StatusOK    Status = "ok"
+	StatusError Status = "error"
+)
+
+// requestSuffix / ackSuffix name the on-disk file extensions. Using a
+// distinct, unambiguous suffix (rather than bare ".json") keeps ListPending's
+// directory scan from ever mistaking an ack for a request or vice versa.
+const (
+	requestSuffix = ".request.json"
+	ackSuffix     = ".ack.json"
+)
+
+// Record is one queued serve→engine request.
+type Record struct {
+	ID        string          `json:"id"`
+	Kind      Kind            `json:"kind"`
+	RepoPath  string          `json:"repo_path"`
+	Ref       string          `json:"ref,omitempty"`
+	Commit    string          `json:"commit,omitempty"`
+	Payload   json.RawMessage `json:"payload,omitempty"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+// Ack is the small result sidecar the consumer (engine) writes after
+// applying a Record. serve polls for it with the same os.ReadFile model the
+// status plane already uses.
+type Ack struct {
+	ID        string    `json:"id"`
+	Status    Status    `json:"status"`
+	Err       string    `json:"err,omitempty"`
+	AppliedAt time.Time `json:"applied_at"`
+}
+
+// Write assigns rec.ID (if empty) and rec.CreatedAt (if zero), then persists
+// it to dir/<id>.request.json atomically: marshal → write to a unique tmp
+// file in dir → fsync → rename. A crash before the rename leaves only a
+// stray tmp file, which ListPending never observes as a request (it only
+// globs the *.request.json suffix, and a bare rename is atomic on the same
+// filesystem). Returns the (possibly newly-generated) ID.
+func Write(dir string, rec Record) (string, error) {
+	if dir == "" {
+		return "", fmt.Errorf("requests: dir is empty")
+	}
+	if rec.Kind == "" {
+		return "", fmt.Errorf("requests: kind is required")
+	}
+	if rec.ID == "" {
+		rec.ID = uuid.NewString()
+	}
+	if rec.CreatedAt.IsZero() {
+		rec.CreatedAt = time.Now().UTC()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	data, err := json.MarshalIndent(rec, "", "  ")
+	if err != nil {
+		return "", err
+	}
+	finalPath := filepath.Join(dir, rec.ID+requestSuffix)
+	if err := atomicWrite(dir, finalPath, data); err != nil {
+		return "", err
+	}
+	return rec.ID, nil
+}
+
+// atomicWrite writes data to a unique tmp file under dir, fsyncs it, closes
+// it, then renames it onto finalPath. Mirrors internal/mcp/repair.go's
+// writeRepairFile tmp+fsync+rename pattern verbatim.
+func atomicWrite(dir, finalPath string, data []byte) error {
+	tmp, err := os.CreateTemp(dir, filepath.Base(finalPath)+".tmp-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		// Best-effort cleanup on any error path; a no-op once renamed.
+		_ = os.Remove(tmpName)
+	}()
+	if _, err := io.WriteString(tmp, string(data)); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpName, finalPath)
+}
+
+// ackPath / requestPath compute the on-disk sidecar paths for an id.
+func ackPath(dir, id string) string     { return filepath.Join(dir, id+ackSuffix) }
+func requestPath(dir, id string) string { return filepath.Join(dir, id+requestSuffix) }
+
+// ListPending returns the requests in dir that are ready to be drained,
+// oldest (by CreatedAt) first. Two classes of file are deliberately
+// excluded, both non-fatal to the scan:
+//
+//   - Torn/invalid JSON (a request file that was never atomically written by
+//     Write — e.g. a test simulating a crash, or filesystem corruption): the
+//     entry is skipped and left on disk for operator inspection; it never
+//     causes ListPending to error or the drain to abort.
+//   - Already-acked requests (a matching <id>.ack.json exists): this is the
+//     exactly-once guard for a crash between ApplyAndAck's ack-write and its
+//     delete — the request is excluded from pending and (best-effort)
+//     the stale request file is removed so a later drain sees a clean dir.
+//
+// A missing dir is not an error — it simply has nothing pending.
+func ListPending(dir string) ([]Record, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	out := make([]Record, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if len(name) <= len(requestSuffix) || name[len(name)-len(requestSuffix):] != requestSuffix {
+			continue
+		}
+		id := name[:len(name)-len(requestSuffix)]
+
+		// Exactly-once guard: a matching ack means this request was already
+		// applied by a prior drain that crashed before deleting it.
+		if _, ok, ackErr := ReadAck(dir, id); ackErr == nil && ok {
+			_ = os.Remove(requestPath(dir, id)) // best-effort catch-up cleanup
+			continue
+		}
+
+		data, rerr := os.ReadFile(filepath.Join(dir, name))
+		if rerr != nil {
+			continue // removed between ReadDir and ReadFile — benign race
+		}
+		var rec Record
+		if err := json.Unmarshal(data, &rec); err != nil {
+			// Torn/invalid file — never act on it, never error the drain.
+			continue
+		}
+		if rec.ID == "" {
+			rec.ID = id
+		}
+		out = append(out, rec)
+	}
+
+	sort.SliceStable(out, func(i, j int) bool {
+		return out[i].CreatedAt.Before(out[j].CreatedAt)
+	})
+	return out, nil
+}
+
+// WriteAck persists ack atomically to dir/<id>.ack.json (same tmp+fsync+
+// rename discipline as Write). Stamps AppliedAt if zero.
+func WriteAck(dir, id string, ack Ack) error {
+	if dir == "" || id == "" {
+		return fmt.Errorf("requests: dir/id must not be empty")
+	}
+	ack.ID = id
+	if ack.AppliedAt.IsZero() {
+		ack.AppliedAt = time.Now().UTC()
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(ack, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicWrite(dir, ackPath(dir, id), data)
+}
+
+// ReadAck reads dir/<id>.ack.json. ok is false (with a nil error) when no ack
+// exists yet — the normal "still pending" case a poller checks in a loop.
+func ReadAck(dir, id string) (Ack, bool, error) {
+	data, err := os.ReadFile(ackPath(dir, id))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return Ack{}, false, nil
+		}
+		return Ack{}, false, err
+	}
+	var ack Ack
+	if err := json.Unmarshal(data, &ack); err != nil {
+		return Ack{}, false, fmt.Errorf("requests: parse ack %s: %w", id, err)
+	}
+	return ack, true, nil
+}
+
+// Delete removes dir/<id>.request.json. Absent file is not an error (it may
+// already have been removed by a prior partial ApplyAndAck or by
+// ListPending's stale-cleanup).
+func Delete(dir, id string) error {
+	if err := os.Remove(requestPath(dir, id)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ApplyAndAck is the standard consumer sequence: apply(rec) using the
+// existing in-process logic (e.g. sched.Scheduler.EnqueueRefCommit), then
+// write an ack recording the outcome, then delete the request file — in that
+// order, so a crash at any point leaves the on-disk state safely resumable:
+//
+//   - crash before apply returns: request still pending, unacked → redrained
+//     and re-applied (apply must be idempotent — true for Enqueue-style
+//     triggers, which already dedup/coalesce).
+//   - crash after ack write, before delete: ListPending's ack-guard excludes
+//     the request from the next drain — no double-apply.
+//   - crash after delete: fully done, nothing to redrain.
+//
+// A non-nil error from apply is recorded in the ack as StatusError (not
+// returned as a hard failure) so the request is still consumed exactly once;
+// ApplyAndAck itself only returns an error if writing the ack or deleting the
+// request fails (an on-disk problem, not an application-level one).
+func ApplyAndAck(dir string, rec Record, apply func(Record) error) error {
+	applyErr := apply(rec)
+
+	ack := Ack{Status: StatusOK}
+	if applyErr != nil {
+		ack.Status = StatusError
+		ack.Err = applyErr.Error()
+	}
+	if err := WriteAck(dir, rec.ID, ack); err != nil {
+		return fmt.Errorf("requests: write ack for %s: %w", rec.ID, err)
+	}
+	if err := Delete(dir, rec.ID); err != nil {
+		return fmt.Errorf("requests: delete request %s: %w", rec.ID, err)
+	}
+	return nil
+}

--- a/internal/daemon/requests/requests_test.go
+++ b/internal/daemon/requests/requests_test.go
@@ -1,0 +1,298 @@
+package requests
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestWrite_CreatesRequestFileAtomically covers the happy path: Write assigns
+// an ID when none is given, stamps CreatedAt, and produces a single
+// well-formed <id>.request.json file with no stray tmp file left behind
+// (ADR-0024 PR4, epic #5729).
+func TestWrite_CreatesRequestFileAtomically(t *testing.T) {
+	dir := t.TempDir()
+
+	id, err := Write(dir, Record{
+		Kind:     KindReindex,
+		RepoPath: "/repo",
+		Ref:      "main",
+		Commit:   "abc123",
+		Payload:  json.RawMessage(`{"async":true}`),
+	})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if id == "" {
+		t.Fatal("Write: expected a non-empty generated ID")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	var requestFiles, tmpFiles int
+	for _, e := range entries {
+		switch {
+		case filepath.Ext(e.Name()) == ".json" && !e.IsDir():
+			requestFiles++
+		default:
+			tmpFiles++
+		}
+	}
+	if requestFiles != 1 {
+		t.Fatalf("expected exactly 1 request file, got %d (entries=%v)", requestFiles, entries)
+	}
+	if tmpFiles != 0 {
+		t.Fatalf("expected no stray tmp/other files, got %d (entries=%v)", tmpFiles, entries)
+	}
+
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 pending record, got %d", len(recs))
+	}
+	if recs[0].ID != id {
+		t.Fatalf("ID mismatch: got %q want %q", recs[0].ID, id)
+	}
+	if recs[0].Kind != KindReindex {
+		t.Fatalf("Kind mismatch: got %q", recs[0].Kind)
+	}
+	if recs[0].RepoPath != "/repo" || recs[0].Ref != "main" || recs[0].Commit != "abc123" {
+		t.Fatalf("unexpected record: %+v", recs[0])
+	}
+	if recs[0].CreatedAt.IsZero() {
+		t.Fatal("expected CreatedAt to be stamped")
+	}
+}
+
+// TestListPending_SkipsTornRequestFile is the crash-safety regression: a
+// half-written request file (never atomically renamed into place by Write,
+// simulating a crash mid-write) must never be acted on. ListPending skips it
+// silently rather than erroring the whole drain.
+func TestListPending_SkipsTornRequestFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// A well-formed request, so we can prove the torn file doesn't poison the
+	// rest of the drain.
+	goodID, err := Write(dir, Record{Kind: KindReindex, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Simulate a crash mid-write: a request file with truncated/invalid JSON,
+	// written directly (bypassing Write's atomic tmp+rename).
+	tornPath := filepath.Join(dir, "torn-request.request.json")
+	if err := os.WriteFile(tornPath, []byte(`{"kind":"reindex","repo_p`), 0o644); err != nil {
+		t.Fatalf("write torn file: %v", err)
+	}
+
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending must not error on a torn file: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected exactly the 1 good record (torn file skipped), got %d", len(recs))
+	}
+	if recs[0].ID != goodID {
+		t.Fatalf("unexpected record survived: %+v", recs[0])
+	}
+
+	// The torn file itself is left alone (not deleted, not applied) so an
+	// operator can inspect it; it must simply never be treated as pending.
+	if _, err := os.Stat(tornPath); err != nil {
+		t.Fatalf("torn file should still exist untouched: %v", err)
+	}
+}
+
+// TestAck_WritesAtomicallyAndDeletesRequest covers the consumer side: Ack
+// writes <id>.ack.json atomically and Delete removes the original request
+// file. After both, ListPending no longer reports the request and ReadAck
+// reports the ack.
+func TestAck_WritesAtomicallyAndDeletesRequest(t *testing.T) {
+	dir := t.TempDir()
+	id, err := Write(dir, Record{Kind: KindSubmitRepair, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := WriteAck(dir, id, Ack{Status: StatusOK}); err != nil {
+		t.Fatalf("WriteAck: %v", err)
+	}
+	ack, ok, err := ReadAck(dir, id)
+	if err != nil {
+		t.Fatalf("ReadAck: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected ack to be found")
+	}
+	if ack.Status != StatusOK {
+		t.Fatalf("unexpected ack status: %+v", ack)
+	}
+	if ack.AppliedAt.IsZero() {
+		t.Fatal("expected AppliedAt to be stamped")
+	}
+
+	if err := Delete(dir, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 pending after delete, got %d", len(recs))
+	}
+}
+
+// TestListPending_SkipsAlreadyAckedRequest is the exactly-once /
+// crash-between-ack-and-delete regression: if the consumer crashes after
+// writing the ack but before deleting the request file, a second drain must
+// NOT re-apply the request. ListPending treats a request with a matching ack
+// as already handled and excludes it (best-effort cleans up the stale
+// request file too, so a THIRD drain sees a clean directory).
+func TestListPending_SkipsAlreadyAckedRequest(t *testing.T) {
+	dir := t.TempDir()
+	id, err := Write(dir, Record{Kind: KindReindex, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := WriteAck(dir, id, Ack{Status: StatusOK}); err != nil {
+		t.Fatalf("WriteAck: %v", err)
+	}
+	// Deliberately do NOT call Delete — simulates the crash window.
+
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected already-acked request to be excluded from pending, got %d: %+v", len(recs), recs)
+	}
+}
+
+// TestApplyAndAck_IdempotentUnderRedrain exercises the full consumer
+// helper: applying the same drained record twice (simulating a second drain
+// pass after a crash between apply and delete) must not re-run the apply
+// function once the first pass has acked, because the second ListPending
+// excludes the already-acked request.
+func TestApplyAndAck_IdempotentUnderRedrain(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Write(dir, Record{Kind: KindReindex, RepoPath: "/repo", Ref: "main", Commit: "sha1"}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	applyCount := 0
+	apply := func(rec Record) error {
+		applyCount++
+		return nil
+	}
+
+	// First drain: apply, ack, delete.
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected 1 pending record, got %d", len(recs))
+	}
+	if err := ApplyAndAck(dir, recs[0], apply); err != nil {
+		t.Fatalf("ApplyAndAck: %v", err)
+	}
+	if applyCount != 1 {
+		t.Fatalf("expected apply to run once, ran %d times", applyCount)
+	}
+
+	// Second drain over the same directory: nothing pending, apply not
+	// called again.
+	recs2, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending (2nd): %v", err)
+	}
+	if len(recs2) != 0 {
+		t.Fatalf("expected 0 pending on redrain, got %d", len(recs2))
+	}
+	if applyCount != 1 {
+		t.Fatalf("expected apply to still have run exactly once after redrain, ran %d times", applyCount)
+	}
+}
+
+// TestApplyAndAck_CrashBetweenAckAndDelete simulates the exactly-once guard
+// directly: after ApplyAndAck's ack write but before its delete, a second
+// caller draining the same directory must not see the request as pending
+// (guards double-apply if the consumer process dies mid-ApplyAndAck).
+func TestApplyAndAck_CrashBetweenAckAndDelete(t *testing.T) {
+	dir := t.TempDir()
+	id, err := Write(dir, Record{Kind: KindDocgenApply, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	// Manually reproduce the crash window: ack written, delete not yet run.
+	if err := WriteAck(dir, id, Ack{Status: StatusOK}); err != nil {
+		t.Fatalf("WriteAck: %v", err)
+	}
+
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("request must not be re-drained once acked, got %d pending", len(recs))
+	}
+}
+
+// TestWriteAck_ErrorStatusRoundTrips ensures a failed apply is reported
+// faithfully through the ack so the producer (serve) can surface the error
+// to the caller instead of silently treating it as success.
+func TestWriteAck_ErrorStatusRoundTrips(t *testing.T) {
+	dir := t.TempDir()
+	id, err := Write(dir, Record{Kind: KindEnrichmentEnqueue, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := WriteAck(dir, id, Ack{Status: StatusError, Err: "boom"}); err != nil {
+		t.Fatalf("WriteAck: %v", err)
+	}
+	ack, ok, err := ReadAck(dir, id)
+	if err != nil || !ok {
+		t.Fatalf("ReadAck: ok=%v err=%v", ok, err)
+	}
+	if ack.Status != StatusError || ack.Err != "boom" {
+		t.Fatalf("unexpected ack: %+v", ack)
+	}
+}
+
+// TestListPending_OrdersByCreatedAt guards a small but real usability
+// property: requests are drained oldest-first so a burst of enqueues is
+// processed in submission order.
+func TestListPending_OrdersByCreatedAt(t *testing.T) {
+	dir := t.TempDir()
+
+	older := Record{Kind: KindReindex, RepoPath: "/repo", CreatedAt: time.Now().Add(-time.Minute)}
+	newer := Record{Kind: KindReindex, RepoPath: "/repo", CreatedAt: time.Now()}
+
+	newerID, err := Write(dir, newer)
+	if err != nil {
+		t.Fatalf("Write newer: %v", err)
+	}
+	olderID, err := Write(dir, older)
+	if err != nil {
+		t.Fatalf("Write older: %v", err)
+	}
+
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 2 {
+		t.Fatalf("expected 2 records, got %d", len(recs))
+	}
+	if recs[0].ID != olderID || recs[1].ID != newerID {
+		t.Fatalf("expected oldest-first ordering, got %s then %s", recs[0].ID, recs[1].ID)
+	}
+}

--- a/internal/daemon/requests_drain.go
+++ b/internal/daemon/requests_drain.go
@@ -1,0 +1,140 @@
+package daemon
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+)
+
+// requestsDrainInterval is how often the engine's drain loop scans for
+// pending serve→engine request files (ADR-0024 PR4, epic #5729). Requests
+// are also fire-and-forget from serve's perspective (Service.Index returns
+// as soon as the file is written), so this interval bounds how long a
+// split-mode reindex trigger can sit before the engine notices it — kept
+// short since the scan itself is a cheap directory glob, not a full
+// filesystem walk.
+const requestsDrainInterval = 2 * time.Second
+
+// discoverRequestsDirs finds every `requests/` directory under the store
+// layout rooted at root (either GRAFEL_DAEMON_ROOT/state or
+// $GRAFEL_HOME/store — see StateDirForRepo/repoBaseDir). The engine has no
+// a priori registry of which repos have dropped a request, so discovery is
+// a glob over the known `<slug-or-hash>/refs/<ref>/requests` shape rather
+// than a per-repo lookup.
+func discoverRequestsDirs(root string) ([]string, error) {
+	if root == "" {
+		return nil, nil
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", "refs", "*", "requests"))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]string, 0, len(matches))
+	for _, m := range matches {
+		info, statErr := os.Stat(m)
+		if statErr != nil || !info.IsDir() {
+			continue
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}
+
+// requestsRoot resolves the store root the engine should glob for
+// requests/ directories: GRAFEL_DAEMON_ROOT/state when the isolated-daemon
+// env var is set (tests, parallel agents), else StoreDir() — mirroring
+// repoBaseDir's own resolution (state_path.go) so discovery always agrees
+// with where Service.Index (via requestsDirForRepo) actually wrote.
+func requestsRoot() string {
+	if root := os.Getenv(EnvRoot); root != "" {
+		return filepath.Join(root, "state")
+	}
+	return StoreDir()
+}
+
+// drainRequestsOnce performs a single pass: discover every requests/ dir
+// under root, list its pending records, and apply each via
+// requests.ApplyAndAck. Only KindReindex is understood as of PR4 — see
+// internal/daemon/requests's Kind doc comments for why KindSubmitRepair /
+// KindDocgenApply / KindEnrichmentEnqueue are defined but not (yet) produced
+// or consumed anywhere (their handlers already write their sidecars
+// directly and are picked up lazily by the next scheduled index pass, so
+// they are already cross-process safe with no engine-side action needed).
+//
+// logger may be nil (tests exercise the apply path without one).
+func drainRequestsOnce(root string, scheduler *sched.Scheduler, logger *slog.Logger) error {
+	dirs, err := discoverRequestsDirs(root)
+	if err != nil {
+		return fmt.Errorf("requests: discover dirs: %w", err)
+	}
+	for _, dir := range dirs {
+		recs, err := requests.ListPending(dir)
+		if err != nil {
+			if logger != nil {
+				logger.Warn("requests: list pending failed (skipping dir)", "dir", dir, "err", err)
+			}
+			continue
+		}
+		for _, rec := range recs {
+			rec := rec
+			applyErr := requests.ApplyAndAck(dir, rec, func(r requests.Record) error {
+				return applyRequest(scheduler, r)
+			})
+			if applyErr != nil && logger != nil {
+				logger.Warn("requests: apply/ack failed", "dir", dir, "id", rec.ID, "kind", rec.Kind, "err", applyErr)
+			}
+		}
+	}
+	return nil
+}
+
+// applyRequest dispatches a single drained Record to the same in-process
+// call the monolith/engine makes when it owns the scheduler directly. This
+// is the ONLY kind currently produced (see drainRequestsOnce's doc comment);
+// an unknown/future kind is reported as an error in the ack rather than
+// silently dropped, so the producer can observe the mismatch.
+func applyRequest(scheduler *sched.Scheduler, rec requests.Record) error {
+	switch rec.Kind {
+	case requests.KindReindex:
+		if scheduler == nil {
+			return fmt.Errorf("requests: reindex request for %s but no scheduler is attached", rec.RepoPath)
+		}
+		scheduler.Enqueue(rec.RepoPath)
+		return nil
+	default:
+		return fmt.Errorf("requests: unsupported kind %q", rec.Kind)
+	}
+}
+
+// startRequestsDrainLoop starts the periodic drain goroutine and returns a
+// stop func (ep.add-compatible) that halts it. Only meaningful when a
+// scheduler is attached and SplitModeEnabled() — see the call site in
+// startEnginePlane (engineplane.go), which gates on both.
+func startRequestsDrainLoop(scheduler *sched.Scheduler, logger *slog.Logger) (stop func()) {
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		ticker := time.NewTicker(requestsDrainInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				if err := drainRequestsOnce(requestsRoot(), scheduler, logger); err != nil && logger != nil {
+					logger.Warn("requests: drain pass failed", "err", err)
+				}
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-stopped
+	}
+}

--- a/internal/daemon/requests_drain_test.go
+++ b/internal/daemon/requests_drain_test.go
@@ -1,0 +1,150 @@
+package daemon
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+)
+
+// TestDiscoverRequestsDirs_FindsPerRefRequestsDirs is the engine-side
+// discovery regression (ADR-0024 PR4, epic #5729): the engine has no a
+// priori list of repos, so it must find every `requests/` directory under
+// the store's `<slug>-<hash>/refs/<ref>/` layout by globbing, not by asking
+// a specific repo for its state dir.
+func TestDiscoverRequestsDirs_FindsPerRefRequestsDirs(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	dir := requestsDirForRepo(repoPath)
+	if _, err := requests.Write(dir, requests.Record{Kind: requests.KindReindex, RepoPath: repoPath}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	dirs, err := discoverRequestsDirs(requestsRoot())
+	if err != nil {
+		t.Fatalf("discoverRequestsDirs: %v", err)
+	}
+	found := false
+	for _, d := range dirs {
+		if d == dir {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected %q among discovered dirs, got %v", dir, dirs)
+	}
+}
+
+// TestDrainRequestsOnce_ReindexEnqueuesOntoScheduler is the round-trip
+// regression for the MOST IMPORTANT producer/consumer pair named in epic
+// #5729: a KindReindex request dropped by serve's Service.Index (simulated
+// here directly via requests.Write, mirroring what service.go's Index method
+// does when SplitModeEnabled()) is drained by the engine and turned into a
+// real scheduler.Enqueue call — the same call the monolith/engine makes
+// in-process today.
+func TestDrainRequestsOnce_ReindexEnqueuesOntoScheduler(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	dir := requestsDirForRepo(repoPath)
+	id, err := requests.Write(dir, requests.Record{Kind: requests.KindReindex, RepoPath: repoPath})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	indexed := make(chan string, 1)
+	sc := sched.New(sched.Config{
+		Index: func(ctx context.Context, repo, ref string) error {
+			indexed <- repo
+			return nil
+		},
+	})
+	sc.Start()
+	defer sc.Stop()
+
+	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+		t.Fatalf("drainRequestsOnce: %v", err)
+	}
+
+	select {
+	case repo := <-indexed:
+		if repo != repoPath {
+			t.Fatalf("indexed wrong repo: got %q want %q", repo, repoPath)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for scheduler to index the enqueued repo")
+	}
+
+	ack, ok, err := requests.ReadAck(dir, id)
+	if err != nil {
+		t.Fatalf("ReadAck: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected an ack to have been written")
+	}
+	if ack.Status != requests.StatusOK {
+		t.Fatalf("unexpected ack status: %+v", ack)
+	}
+
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected the request to be consumed, still pending: %+v", recs)
+	}
+}
+
+// TestDrainRequestsOnce_SecondDrainDoesNotDoubleEnqueue is the
+// exactly-once / idempotency regression: draining twice in a row (as the
+// periodic loop does) must not enqueue the same already-consumed request a
+// second time.
+func TestDrainRequestsOnce_SecondDrainDoesNotDoubleEnqueue(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	dir := requestsDirForRepo(repoPath)
+	if _, err := requests.Write(dir, requests.Record{Kind: requests.KindReindex, RepoPath: repoPath}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var enqueueCount int
+	indexed := make(chan string, 4)
+	sc := sched.New(sched.Config{
+		Index: func(ctx context.Context, repo, ref string) error {
+			indexed <- repo
+			return nil
+		},
+	})
+	sc.Start()
+	defer sc.Stop()
+
+	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+		t.Fatalf("drainRequestsOnce (1st): %v", err)
+	}
+	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+		t.Fatalf("drainRequestsOnce (2nd): %v", err)
+	}
+
+	select {
+	case <-indexed:
+		enqueueCount++
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected at least one index call")
+	}
+	// Drain any further (unexpected) sends without blocking.
+	select {
+	case <-indexed:
+		enqueueCount++
+	case <-time.After(300 * time.Millisecond):
+	}
+	if enqueueCount != 1 {
+		t.Fatalf("expected exactly 1 index call across both drains, got %d", enqueueCount)
+	}
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/daemon/watch"
 	"github.com/cajasmota/grafel/internal/install/hooks"
@@ -413,6 +414,14 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	return nil
 }
 
+// requestsDirForRepo is the serve→engine control-plane drop directory for a
+// repo (ADR-0024 PR4, epic #5729): a `requests/` subdirectory sibling to
+// repair.json / enrichment-candidates.json under the same
+// StateDirForRepo(repoPath) root. See internal/daemon/requests.
+func requestsDirForRepo(repoPath string) string {
+	return filepath.Join(StateDirForRepo(repoPath), "requests")
+}
+
 // Index runs a single-repo index synchronously. Phase B adds the
 // MarkIndexed bookkeeping so an explicit RPC index updates the same
 // in-memory state that the watcher-driven path uses.
@@ -432,6 +441,30 @@ func (s *Service) Index(args *proto.IndexArgs, reply *proto.IndexReply) error {
 	// reindex instead of N back-to-back full reindexes. Used by git hooks
 	// so git writes never block on a reindex. Falls back to the synchronous
 	// path below when no scheduler is attached (e.g. a watcher-less daemon).
+	//
+	// ADR-0024 PR4 (epic #5729): in split mode this RPC is answered by the
+	// SERVE process, which has no scheduler at all (s.scheduler is always
+	// nil there — startEnginePlane, which assigns it, is skipped for
+	// planeServeOnly). Falling through to the "no scheduler" branch below
+	// would run the synchronous s.index(*args) call — a full reindex — IN
+	// THE SERVE PROCESS, exactly the blast-radius coupling the split exists
+	// to remove. So when SplitModeEnabled() and Async is requested, drop a
+	// KindReindex request file instead of touching the scheduler; the
+	// engine's drain loop (engineplane.go) picks it up and calls
+	// scheduler.Enqueue(repoPath) itself — the same call this function makes
+	// in monolith/engine mode. The two paths are mutually exclusive: split
+	// mode NEVER calls s.scheduler.Enqueue from here, and monolith/engine
+	// mode NEVER writes a request file.
+	if args.Async && SplitModeEnabled() {
+		if _, err := requests.Write(requestsDirForRepo(args.RepoPath), requests.Record{
+			Kind:     requests.KindReindex,
+			RepoPath: args.RepoPath,
+		}); err != nil {
+			return fmt.Errorf("queue reindex request: %w", err)
+		}
+		reply.RepoPath = args.RepoPath
+		return nil
+	}
 	if args.Async && s.scheduler != nil {
 		s.scheduler.Enqueue(args.RepoPath)
 		reply.RepoPath = args.RepoPath


### PR DESCRIPTION
**PR4 of the serve/engine split (ADR-0024, epic #5729)** — the serve→engine control channel. Grounding found submit_repair / enrichment_enqueue / docgen_apply are already file-based sidecars the engine consumes lazily (cross-process safe already), so the only path needing a new channel is the async **reindex** trigger (in split-mode serve has no scheduler).

- New `internal/daemon/requests` pkg: `Record{ID,Kind,RepoPath,Ref,Commit,Payload,CreatedAt}`, atomic `Write` (CreateTemp→Sync→same-dir Rename, mirrors `repair.go`), `ListPending` (skips torn/acked), `ApplyAndAck` (apply→ack→delete, ack-guarded idempotent redrain).
- `Service.Index`: async reindex routes to `requests.Write(KindReindex)` when `SplitModeEnabled()`, ahead of the existing direct-enqueue branch — mutually exclusive by construction.
- `requests_drain.go`: a single split-only drain loop (registered via `ep.add`, unwinds on ctx cancel) that applies each request via `scheduler.Enqueue` and acks; discovery glob matches the real `<store>/<slug>-<hash>/refs/<ref>/requests` layout.
- **Monolith byte-identical:** both producer and drain loop gated on `SplitModeEnabled()` — flag off writes zero queue files and starts no goroutine.

**Exactly-once:** apply is idempotent (scheduler dedup-coalesces a repo already pending/running); crash-after-ack is skipped by the ack-guard; a permanently-failing apply acks with error + deletes (no infinite retry, no drop).

**Tests:** 13 (crash-safety/torn-skip, write→drain→enqueue→ack→empty round-trip, idempotent redrain, mutual-exclusion both directions, error-status, ordering); `-race` clean. Independent Opus review APPROVE.

**Known follow-ups (tracked):** (1) `Service.Rebuild` (`grafel rebuild`) is NOT yet split-gated — in split mode it'd run a full rebuild in the serve process; **must be fixed before the PR6 default-flip** (not a PR4 regression — rebuild ran in-process before the split too). (2) Ack files accumulate (successful apply orphans `<id>.ack.json`) — a slow disk leak needing a cheap GC later. Both are follow-up items, not blockers for this PR.

Refs #5729 #5725