### PR TITLE
feat(extract/fastapi): fold APIRouter(prefix=) mount prefix into routes (#5688 structural slice 1)

### DIFF
--- a/cmd/grafel/issue2678_audit_python_test.go
+++ b/cmd/grafel/issue2678_audit_python_test.go
@@ -85,12 +85,14 @@ func TestPythonEndpointAttribution_FastAPI(t *testing.T) {
 
 	// `def health` is on L16, `async def create_item` on L21, `def
 	// delete_user` on L26. Keep these in sync with the fixture file.
+	// create_item is registered on `router = APIRouter(prefix="/v1")`, so
+	// its route path is folded to /v1/items (see #5688).
 	cases := []struct {
 		id       string
 		wantLine int
 	}{
 		{"http:GET:/health", 16},
-		{"http:POST:/items", 21},
+		{"http:POST:/v1/items", 21},
 		{"http:DELETE:/users/{user_id}", 26},
 	}
 	for _, tc := range cases {

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2422,14 +2422,18 @@ func matchBalancedParen(content string, open int) int {
 // function name is captured from the next `def` line. We accept anything
 // up to a bare `)` followed by end-of-line because Flask decorators may
 // carry trailing kwargs (defaults={}, strict_slashes=False, etc.).
-var flaskRouteVerbDecoratorRe = regexp.MustCompile(`@\w+\.(get|post|put|patch|delete)\s*\(\s*["']([^"'\n\r]+)["'][^\n\r]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*def\s+(\w+)`)
+// Group 1 captures the receiver so #5688's FastAPI-APIRouter exclusion
+// (below) can recognise and skip a receiver that is actually a same-file
+// `APIRouter(...)` variable rather than a Flask app/Blueprint.
+var flaskRouteVerbDecoratorRe = regexp.MustCompile(`@(\w+)\.(get|post|put|patch|delete)\s*\(\s*["']([^"'\n\r]+)["'][^\n\r]*\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*def\s+(\w+)`)
 
 // flaskRouteRe captures the generic @<obj>.route("/path", ...) form and
 // the handler function name. The trailing kwargs (including a
 // methods=[...] or methods=(...) argument) are captured for parseFlaskMethods.
 // We tolerate one level of nested parens / brackets in the kwargs by
 // matching greedily up to the end of the line that closes the decorator.
-var flaskRouteRe = regexp.MustCompile(`@\w+\.route\s*\(\s*["']([^"'\n\r]+)["']([^\n\r]*)\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*def\s+(\w+)`)
+// Group 1 captures the receiver (see flaskRouteVerbDecoratorRe above).
+var flaskRouteRe = regexp.MustCompile(`@(\w+)\.route\s*\(\s*["']([^"'\n\r]+)["']([^\n\r]*)\)[ \t]*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*def\s+(\w+)`)
 
 // flaskMethodsArgRe extracts the list of HTTP methods from a
 // `methods=["GET", "POST"]` or `methods=("GET", "POST")` keyword argument
@@ -2560,30 +2564,54 @@ func synthesizeFlask(content string, emit emitDefFn) {
 	// or app.add_url_rule('/x', 'endpoint', UserView.as_view('x')). Works for
 	// blueprint receivers (bp.add_url_rule) identically.
 	synthesizeFlaskAddURLRule(content, emit)
+
+	// #5688 — Flask's generic `@<obj>.<verb>(...)` decorator shape overlaps
+	// FastAPI's, and Flask's regexes accept ANY receiver name (they predate
+	// FastAPI's named-router convention). Without this guard, a receiver that
+	// is actually a same-file FastAPI `APIRouter(prefix=...)` variable would
+	// be double-matched here with the BARE (unfolded) path, producing a
+	// phantom sibling endpoint alongside the correctly prefix-folded FastAPI
+	// synthetic (whose canonical path differs once a prefix is folded in, so
+	// the two no longer collide via ID-based dedup as they did pre-fold).
+	// Skip any receiver recognised as an APIRouter variable so only the
+	// FastAPI synthesizer emits for it.
+	var fastapiRouterRecvs map[string]string
+	if strings.Contains(content, "APIRouter") {
+		fastapiRouterRecvs = fastapiRouterPrefixes(content)
+	}
+
 	// Shorthand verbs first — they have an unambiguous verb. Use the
 	// SubmatchIndex variant so we can derive the 1-based line of the
-	// handler `def` (capture group 3) for issue #2678 attribution.
+	// handler `def` (capture group 4) for issue #2678 attribution.
 	for _, idx := range flaskRouteVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(idx) < 8 {
+		if len(idx) < 10 {
 			continue
 		}
-		verb := strings.ToUpper(content[idx[2]:idx[3]])
-		raw := content[idx[4]:idx[5]]
-		handler := content[idx[6]:idx[7]]
+		recv := content[idx[2]:idx[3]]
+		if _, isFastAPIRouter := fastapiRouterRecvs[recv]; isFastAPIRouter {
+			continue
+		}
+		verb := strings.ToUpper(content[idx[4]:idx[5]])
+		raw := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkFlask, raw)
-		defLine := lineOfOffset(content, idx[6])
+		defLine := lineOfOffset(content, idx[8])
 		emit(verb, canonical, "flask", "Controller", handler, defLine)
 	}
 	// Generic .route(...) form.
 	for _, idx := range flaskRouteRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(idx) < 8 {
+		if len(idx) < 10 {
 			continue
 		}
-		raw := content[idx[2]:idx[3]]
-		extras := content[idx[4]:idx[5]]
-		handler := content[idx[6]:idx[7]]
+		recv := content[idx[2]:idx[3]]
+		if _, isFastAPIRouter := fastapiRouterRecvs[recv]; isFastAPIRouter {
+			continue
+		}
+		raw := content[idx[4]:idx[5]]
+		extras := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
 		canonical := httproutes.Canonicalize(httproutes.FrameworkFlask, raw)
-		defLine := lineOfOffset(content, idx[6])
+		defLine := lineOfOffset(content, idx[8])
 		methods := parseFlaskMethods(extras)
 		if len(methods) == 0 {
 			// Flask's default: no `methods` kwarg means GET only.
@@ -2687,14 +2715,65 @@ func parseFlaskMethods(args string) []string {
 // ---------------------------------------------------------------------------
 
 // fastapiVerbDecoratorRe captures @app.<verb>("/path") and
-// @router.<verb>("/path") forms. The handler function follows on the next
+// @<recv>.<verb>("/path") forms (recv is typically `router`/`api`/a
+// `*_router`-suffixed variable, but any receiver name is accepted so a
+// same-file `APIRouter(prefix=...)` mount-prefix fold (#5688) can be applied
+// regardless of naming convention). The handler function follows on the next
 // `def`/`async def` line; intermediate decorators (e.g. @app.middleware,
 // @Depends) are allowed.
 // The decorator argument tail tolerates ONE level of nested parens so a
 // `dependencies=[Depends(verify_token)]` / `response_model=Foo()` kwarg does not
 // terminate the match prematurely (the inner `)` previously aborted the scan,
 // dropping the whole endpoint — #3628).
-var fastapiVerbDecoratorRe = regexp.MustCompile(`@(?:app|router|api|\w+_router)\.(get|post|put|patch|delete|head|options|trace)\s*\(\s*["']([^"'\n\r]+)["'](?:[^()]*(?:\([^()]*\)[^()]*)*)\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
+//
+// Capture groups: 1 = receiver, 2 = verb, 3 = path, 4 = handler name.
+var fastapiVerbDecoratorRe = regexp.MustCompile(`@(\w+)\.(get|post|put|patch|delete|head|options|trace)\s*\(\s*["']([^"'\n\r]+)["'](?:[^()]*(?:\([^()]*\)[^()]*)*)\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
+
+// fastapiApiRouteDecoratorRe captures the generic `@<recv>.api_route("/path",
+// methods=[...])` decorator form. FastAPI's `api_route` differs from the
+// single-verb shorthands (`.get`/`.post`/...) in that the HTTP verb(s) are
+// declared via a `methods=[...]` kwarg rather than the method name itself.
+//
+// Capture groups: 1 = receiver, 2 = path, 3 = kwargs tail, 4 = handler name.
+var fastapiApiRouteDecoratorRe = regexp.MustCompile(`@(\w+)\.api_route\s*\(\s*["']([^"'\n\r]+)["']((?:[^()]*(?:\([^()]*\)[^()]*)*))\)\s*[\r\n]+(?:\s*@[^\n\r]*[\r\n]+)*\s*(?:async\s+)?def\s+(\w+)`)
+
+// fastapiRouterConstructorRe captures a same-file `<var> = APIRouter(...)`
+// constructor call (#5688). Group 1 is the receiver variable, group 2 is the
+// constructor argument tail (which may or may not carry a `prefix=` kwarg).
+// One level of nested parens is tolerated so kwargs like
+// `dependencies=[Depends(x)]` don't abort the match early.
+var fastapiRouterConstructorRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_]\w*)\s*=\s*APIRouter\s*\(((?:[^()]*(?:\([^()]*\)[^()]*)*))\)`,
+)
+
+// fastapiRouterPrefixKwargRe extracts a `prefix="/x"` (or single-quoted)
+// STRING-LITERAL kwarg from an APIRouter constructor tail. Non-literal
+// prefixes (env vars, config, string concatenation) are intentionally left
+// unmatched — those routes fall back to the unprefixed path, which the
+// byPath linker normalises (v0.1.9 follow-up).
+var fastapiRouterPrefixKwargRe = regexp.MustCompile(`\bprefix\s*=\s*["']([^"'\n\r]*)["']`)
+
+// fastapiRouterPrefixes builds a same-file map of {APIRouter receiver
+// variable → mount prefix} from every `<var> = APIRouter(...)` constructor in
+// the file (#5688). A router with no `prefix=` kwarg (or a non-literal one)
+// maps to "" so it is still recognised as a router receiver, but composes as
+// a no-op — this keeps the fold regression-safe for the dominant
+// no-prefix-router convention.
+func fastapiRouterPrefixes(content string) map[string]string {
+	prefixes := map[string]string{}
+	for _, m := range fastapiRouterConstructorRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		recv := m[1]
+		if pm := fastapiRouterPrefixKwargRe.FindStringSubmatch(m[2]); len(pm) >= 2 {
+			prefixes[recv] = strings.TrimRight(pm[1], "/")
+		} else {
+			prefixes[recv] = ""
+		}
+	}
+	return prefixes
+}
 
 func synthesizeFastAPI(content string, emit emitDefFn) {
 	if !strings.Contains(content, "FastAPI") && !strings.Contains(content, "APIRouter") &&
@@ -2705,18 +2784,52 @@ func synthesizeFastAPI(content string, emit emitDefFn) {
 	// #4383 — programmatic registration: app.add_api_route('/items', get_items,
 	// methods=['GET']) / router.add_api_route(...).
 	synthesizeFastAPIAddRoute(content, emit)
+
+	// #5688 — same-file APIRouter(prefix="/x") mount-prefix fold. Build the
+	// receiver → prefix map once and compose it into every decorator route
+	// registered on that receiver. Receivers absent from the map (e.g. `app`,
+	// the FastAPI application itself) compose as a no-op.
+	prefixes := fastapiRouterPrefixes(content)
+	compose := func(recv, raw string) string {
+		if pfx, ok := prefixes[recv]; ok && pfx != "" {
+			return joinPathFragments(pfx, raw)
+		}
+		return raw
+	}
+
 	// SubmatchIndex variant so the 1-based line of the handler `def`
-	// (capture group 3) can be recovered for issue #2678 attribution.
+	// (capture group 4) can be recovered for issue #2678 attribution.
 	for _, idx := range fastapiVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
-		if len(idx) < 8 {
+		if len(idx) < 10 {
 			continue
 		}
-		verb := strings.ToUpper(content[idx[2]:idx[3]])
-		raw := content[idx[4]:idx[5]]
-		handler := content[idx[6]:idx[7]]
-		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, raw)
-		defLine := lineOfOffset(content, idx[6])
+		recv := content[idx[2]:idx[3]]
+		verb := strings.ToUpper(content[idx[4]:idx[5]])
+		raw := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, compose(recv, raw))
+		defLine := lineOfOffset(content, idx[8])
 		emit(verb, canonical, "fastapi", "Controller", handler, defLine)
+	}
+
+	// Generic @<recv>.api_route("/path", methods=[...]) form.
+	for _, idx := range fastapiApiRouteDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(idx) < 10 {
+			continue
+		}
+		recv := content[idx[2]:idx[3]]
+		raw := content[idx[4]:idx[5]]
+		tail := content[idx[6]:idx[7]]
+		handler := content[idx[8]:idx[9]]
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, compose(recv, raw))
+		defLine := lineOfOffset(content, idx[8])
+		methods := parseFlaskMethods(tail) // same methods=[...] shape
+		if len(methods) == 0 {
+			methods = []string{"GET"}
+		}
+		for _, verb := range methods {
+			emit(verb, canonical, "fastapi", "Controller", handler, defLine)
+		}
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2715,12 +2715,13 @@ func parseFlaskMethods(args string) []string {
 // ---------------------------------------------------------------------------
 
 // fastapiVerbDecoratorRe captures @app.<verb>("/path") and
-// @<recv>.<verb>("/path") forms (recv is typically `router`/`api`/a
-// `*_router`-suffixed variable, but any receiver name is accepted so a
+// @<recv>.<verb>("/path") forms. The receiver is captured unrestricted so a
 // same-file `APIRouter(prefix=...)` mount-prefix fold (#5688) can be applied
-// regardless of naming convention). The handler function follows on the next
-// `def`/`async def` line; intermediate decorators (e.g. @app.middleware,
-// @Depends) are allowed.
+// regardless of naming convention; synthesizeFastAPI then gates each match on
+// recognizedRecv so a receiver that is NOT a same-file app/router (e.g.
+// `@feature_flags.options(...)`) is not emitted as a phantom endpoint. The
+// handler function follows on the next `def`/`async def` line; intermediate
+// decorators (e.g. @app.middleware, @Depends) are allowed.
 // The decorator argument tail tolerates ONE level of nested parens so a
 // `dependencies=[Depends(verify_token)]` / `response_model=Foo()` kwarg does not
 // terminate the match prematurely (the inner `)` previously aborted the scan,
@@ -2752,6 +2753,29 @@ var fastapiRouterConstructorRe = regexp.MustCompile(
 // unmatched — those routes fall back to the unprefixed path, which the
 // byPath linker normalises (v0.1.9 follow-up).
 var fastapiRouterPrefixKwargRe = regexp.MustCompile(`\bprefix\s*=\s*["']([^"'\n\r]*)["']`)
+
+// fastapiAppConstructorRe captures a same-file `<var> = FastAPI(...)`
+// application instance. Group 1 is the receiver variable. Used together with
+// fastapiRouterPrefixes to gate decorator synthesis to receivers that are
+// actually a recognised app/router in this file (#5688), so a non-router
+// decorator such as `@feature_flags.options("some-key")` cannot synthesise a
+// phantom endpoint.
+var fastapiAppConstructorRe = regexp.MustCompile(
+	`(?m)^[ \t]*([A-Za-z_]\w*)\s*=\s*FastAPI\s*\(`,
+)
+
+// fastapiAppInstances returns the set of same-file `<var> = FastAPI(...)`
+// application-instance variable names.
+func fastapiAppInstances(content string) map[string]struct{} {
+	apps := map[string]struct{}{}
+	for _, m := range fastapiAppConstructorRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		apps[m[1]] = struct{}{}
+	}
+	return apps
+}
 
 // fastapiRouterPrefixes builds a same-file map of {APIRouter receiver
 // variable → mount prefix} from every `<var> = APIRouter(...)` constructor in
@@ -2797,6 +2821,28 @@ func synthesizeFastAPI(content string, emit emitDefFn) {
 		return raw
 	}
 
+	// #5688 — the verb/api_route decorator regexes capture an unrestricted
+	// receiver name so any router variable is supported regardless of naming
+	// convention. That must be scoped to receivers that are actually a router
+	// or the FastAPI app in THIS file, otherwise a non-router decorator such as
+	// `@feature_flags.options("some-key")` or `@mock.head(...)` in a file that
+	// merely contains a FastAPI marker would synthesise a phantom endpoint —
+	// and head/options/trace are FastAPI-only verbs, so no other synthesizer
+	// masks them. Recognised = the conventional app-instance names (`app`,
+	// `api`), any same-file `<var> = FastAPI(...)`, or any same-file
+	// `<var> = APIRouter(...)`.
+	appInstances := fastapiAppInstances(content)
+	recognizedRecv := func(recv string) bool {
+		if recv == "app" || recv == "api" {
+			return true
+		}
+		if _, ok := prefixes[recv]; ok {
+			return true
+		}
+		_, ok := appInstances[recv]
+		return ok
+	}
+
 	// SubmatchIndex variant so the 1-based line of the handler `def`
 	// (capture group 4) can be recovered for issue #2678 attribution.
 	for _, idx := range fastapiVerbDecoratorRe.FindAllStringSubmatchIndex(content, -1) {
@@ -2804,6 +2850,9 @@ func synthesizeFastAPI(content string, emit emitDefFn) {
 			continue
 		}
 		recv := content[idx[2]:idx[3]]
+		if !recognizedRecv(recv) {
+			continue
+		}
 		verb := strings.ToUpper(content[idx[4]:idx[5]])
 		raw := content[idx[6]:idx[7]]
 		handler := content[idx[8]:idx[9]]
@@ -2818,6 +2867,9 @@ func synthesizeFastAPI(content string, emit emitDefFn) {
 			continue
 		}
 		recv := content[idx[2]:idx[3]]
+		if !recognizedRecv(recv) {
+			continue
+		}
 		raw := content[idx[4]:idx[5]]
 		tail := content[idx[6]:idx[7]]
 		handler := content[idx[8]:idx[9]]

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -2741,10 +2741,13 @@ var fastapiApiRouteDecoratorRe = regexp.MustCompile(`@(\w+)\.api_route\s*\(\s*["
 // fastapiRouterConstructorRe captures a same-file `<var> = APIRouter(...)`
 // constructor call (#5688). Group 1 is the receiver variable, group 2 is the
 // constructor argument tail (which may or may not carry a `prefix=` kwarg).
-// One level of nested parens is tolerated so kwargs like
-// `dependencies=[Depends(x)]` don't abort the match early.
+// An optional PEP-526 type annotation between the identifier and `=` is
+// tolerated so the idiomatic typed form `router: APIRouter = APIRouter(...)`
+// (used in FastAPI's own docs) is recognised and prefix-folded. One level of
+// nested parens is tolerated so kwargs like `dependencies=[Depends(x)]` don't
+// abort the match early.
 var fastapiRouterConstructorRe = regexp.MustCompile(
-	`(?m)^[ \t]*([A-Za-z_]\w*)\s*=\s*APIRouter\s*\(((?:[^()]*(?:\([^()]*\)[^()]*)*))\)`,
+	`(?m)^[ \t]*([A-Za-z_]\w*)\s*(?::\s*[\w\[\]., ]+?)?\s*=\s*APIRouter\s*\(((?:[^()]*(?:\([^()]*\)[^()]*)*))\)`,
 )
 
 // fastapiRouterPrefixKwargRe extracts a `prefix="/x"` (or single-quoted)
@@ -2824,16 +2827,24 @@ func synthesizeFastAPI(content string, emit emitDefFn) {
 	// #5688 — the verb/api_route decorator regexes capture an unrestricted
 	// receiver name so any router variable is supported regardless of naming
 	// convention. That must be scoped to receivers that are actually a router
-	// or the FastAPI app in THIS file, otherwise a non-router decorator such as
+	// or the FastAPI app, otherwise a non-router decorator such as
 	// `@feature_flags.options("some-key")` or `@mock.head(...)` in a file that
 	// merely contains a FastAPI marker would synthesise a phantom endpoint —
 	// and head/options/trace are FastAPI-only verbs, so no other synthesizer
-	// masks them. Recognised = the conventional app-instance names (`app`,
-	// `api`), any same-file `<var> = FastAPI(...)`, or any same-file
-	// `<var> = APIRouter(...)`.
+	// masks them. Recognised =
+	//   - the conventional app-instance names (`app`, `api`);
+	//   - the conventional router names (`router`, or any `*_router`) — these
+	//     are accepted BY NAME regardless of construction so an imported router
+	//     (`from .deps import router` + `@router.get(...)`, constructed in
+	//     another file) is still recognised, matching the pre-#5688 allowlist;
+	//   - any same-file `<var> = FastAPI(...)` instance;
+	//   - any same-file `<var> = APIRouter(...)` variable (also carries its
+	//     mount prefix for folding).
+	// `@feature_flags.options(...)` / `@mock.head(...)` match none of these, so
+	// the phantom-endpoint fix stays intact.
 	appInstances := fastapiAppInstances(content)
 	recognizedRecv := func(recv string) bool {
-		if recv == "app" || recv == "api" {
+		if recv == "app" || recv == "api" || recv == "router" || strings.HasSuffix(recv, "_router") {
 			return true
 		}
 		if _, ok := prefixes[recv]; ok {

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -131,10 +131,11 @@ def delete_user(user_id: int):
     return None
 `
 	got, _ := runDetect(t, "python", "main.py", src)
+	// #5688 — router's `prefix="/v1"` folds into its own route.
 	want := []string{
 		"http:DELETE:/users/{user_id}",
 		"http:GET:/users/{user_id}",
-		"http:POST:/items",
+		"http:POST:/v1/items",
 	}
 	requireContains(t, got, want, "FastAPI")
 }
@@ -822,12 +823,13 @@ def update_user(user_id: int):
 	got, res := runDetect(t, "python", "main.py", src)
 
 	// All of these must be present — and with the specific verb.
+	// #5688 — router's `prefix="/v1"` folds into its own route.
 	want := []string{
 		"http:DELETE:/users/{user_id}",
 		"http:GET:/users",
 		"http:GET:/users/{user_id}",
 		"http:PATCH:/users/{user_id}",
-		"http:POST:/items",
+		"http:POST:/v1/items",
 	}
 	requireContains(t, got, want, "FastAPI verb-specific")
 
@@ -836,7 +838,7 @@ def update_user(user_id: int):
 	anyVerbPaths := []string{
 		"http:ANY:/users",
 		"http:ANY:/users/{user_id}",
-		"http:ANY:/items",
+		"http:ANY:/v1/items",
 	}
 	for _, forbidden := range anyVerbPaths {
 		for _, id := range got {
@@ -890,10 +892,12 @@ async def get_user(user_id: int):
     return {}
 `
 	got, _ := runDetect(t, "python", "routers/items.py", src)
+	// #5688 — same-file APIRouter(prefix=...) mount-prefix fold: each
+	// router's prefix is folded into its own routes before canonicalisation.
 	want := []string{
-		"http:GET:/",
-		"http:POST:/",
-		"http:GET:/{user_id}",
+		"http:GET:/items",
+		"http:POST:/items",
+		"http:GET:/users/{user_id}",
 	}
 	requireContains(t, got, want, "FastAPI named router verb-specific")
 
@@ -903,6 +907,168 @@ async def get_user(user_id: int):
 			t.Errorf("unexpected ANY-verb entity %q from FastAPI named router (#748)", id)
 		}
 	}
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_Basic is the base RED->GREEN case for
+// #5688: a single `APIRouter(prefix="/users")` folds into every route
+// registered on that router, including a canonicalised path parameter.
+func TestSynth_FastAPI_RouterPrefixFold_Basic(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter(prefix="/users")
+
+@router.get("/{id}")
+async def get_user(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/users.py", src)
+	want := []string{"http:GET:/users/{id}"}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold — basic")
+	requireNotContains(t, got, []string{"http:GET:/{id}"}, "FastAPI APIRouter prefix fold — basic (unfolded regression)")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_MultipleRouters verifies that each of
+// several same-file routers folds ONLY its own prefix into its own routes
+// (#5688) — no cross-contamination between router variables.
+func TestSynth_FastAPI_RouterPrefixFold_MultipleRouters(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+users_router = APIRouter(prefix="/users")
+orders_router = APIRouter(prefix="/orders")
+
+@users_router.get("/{id}")
+async def get_user(id: int):
+    return {}
+
+@orders_router.post("/{id}/cancel")
+async def cancel_order(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/multi.py", src)
+	want := []string{
+		"http:GET:/users/{id}",
+		"http:POST:/orders/{id}/cancel",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold — multiple routers")
+	requireNotContains(t, got, []string{
+		"http:GET:/orders/{id}",
+		"http:POST:/users/{id}/cancel",
+	}, "FastAPI APIRouter prefix fold — multiple routers (cross-contamination)")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_NoPrefixRegression is the regression
+// guard for #5688: a router constructed WITHOUT a `prefix=` kwarg behaves
+// exactly as before — its routes emit the bare in-router path, unchanged.
+func TestSynth_FastAPI_RouterPrefixFold_NoPrefixRegression(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter()
+
+@router.get("/items")
+async def list_items():
+    return []
+`
+	got, _ := runDetect(t, "python", "routers/items.py", src)
+	want := []string{"http:GET:/items"}
+	requireContains(t, got, want, "FastAPI APIRouter no-prefix regression")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_AppDirectUnchanged verifies that routes
+// registered directly on the `app` object (no router, no prefix) are
+// unaffected by the #5688 fold.
+func TestSynth_FastAPI_RouterPrefixFold_AppDirectUnchanged(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter(prefix="/users")
+
+@app.get("/health")
+async def health():
+    return "ok"
+
+@router.get("/{id}")
+async def get_user(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "main.py", src)
+	want := []string{
+		"http:GET:/health",
+		"http:GET:/users/{id}",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter app-direct unchanged")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_QuoteStylesAndKwargOrder covers (#5688):
+//   - a single-quoted `prefix='/v2'` kwarg
+//   - `prefix=` appearing AFTER other kwargs (tags=[...]) in the constructor
+func TestSynth_FastAPI_RouterPrefixFold_QuoteStylesAndKwargOrder(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+single_quoted = APIRouter(prefix='/v2')
+after_kwargs = APIRouter(tags=["items"], prefix="/items", dependencies=[])
+
+@single_quoted.get("/ping")
+async def ping():
+    return "pong"
+
+@after_kwargs.get("/{id}")
+async def get_item(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/mixed.py", src)
+	want := []string{
+		"http:GET:/v2/ping",
+		"http:GET:/items/{id}",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter quote styles + kwarg ordering")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_NoDoubleSlashOnRoot ensures a router
+// prefix composed with a bare-root sub-route ("/") never produces a
+// double-slash `/users//` and instead composes to a clean `/users` (#5688).
+func TestSynth_FastAPI_RouterPrefixFold_NoDoubleSlashOnRoot(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter(prefix="/users")
+
+@router.get("/")
+async def list_users():
+    return []
+`
+	got, _ := runDetect(t, "python", "routers/users.py", src)
+	for _, id := range got {
+		if strings.Contains(id, "//") {
+			t.Errorf("FastAPI APIRouter prefix fold produced a double-slash path: %q", id)
+		}
+	}
+	want := []string{"http:GET:/users"}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold — no double slash on root")
+}
+
+// TestSynth_FastAPI_RouterPrefixFold_ApiRouteDecorator covers the generic
+// `@router.api_route("/path", methods=[...])` decorator form composing the
+// same-file router prefix (#5688).
+func TestSynth_FastAPI_RouterPrefixFold_ApiRouteDecorator(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router = APIRouter(prefix="/items")
+
+@router.api_route("/{id}", methods=["GET", "PUT"])
+async def item(id: int):
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/items.py", src)
+	want := []string{
+		"http:GET:/items/{id}",
+		"http:PUT:/items/{id}",
+	}
+	requireContains(t, got, want, "FastAPI APIRouter prefix fold — api_route decorator")
 }
 
 // TestSynth_FastAPI_YamlDrivenRouteNotSynthesized_Unit is a direct unit test

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -1071,6 +1071,41 @@ async def item(id: int):
 	requireContains(t, got, want, "FastAPI APIRouter prefix fold — api_route decorator")
 }
 
+// TestSynth_FastAPI_NonRouterReceiverNotSynthesized guards against phantom
+// endpoints from decorators whose receiver is NOT a same-file app/router
+// (#5688). Widening the verb-decorator receiver capture to support arbitrary
+// router names must stay scoped to recognised receivers — otherwise an
+// unrelated decorator such as `@feature_flags.options(...)` or `@mock.head(...)`
+// in a file that merely contains a FastAPI marker synthesises a false endpoint.
+// head/options/trace are FastAPI-only verbs (no other synthesizer masks them),
+// so this is the exact new false-positive surface the receiver gate closes.
+func TestSynth_FastAPI_NonRouterReceiverNotSynthesized(t *testing.T) {
+	src := `from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+@feature_flags.options("some-flag-key")
+def toggle_flag():
+    return {}
+
+@mock.head("/internal/probe")
+def probe():
+    return {}
+`
+	got, _ := runDetect(t, "python", "app/main.py", src)
+	requireContains(t, got, []string{"http:GET:/health"},
+		"FastAPI real @app route still synthesised")
+	requireNotContains(t, got, []string{
+		"http:OPTIONS:/some-flag-key",
+		"http:OPTIONS:some-flag-key",
+		"http:HEAD:/internal/probe",
+	}, "FastAPI non-router receiver must not synthesise a phantom endpoint")
+}
+
 // TestSynth_FastAPI_YamlDrivenRouteNotSynthesized_Unit is a direct unit test
 // of synthesizeDjangoFromComposed — it feeds it a yaml_driven Route entity
 // (the kind that the Django YAML path() pattern would produce for a FastAPI

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -1106,6 +1106,48 @@ def probe():
 	}, "FastAPI non-router receiver must not synthesise a phantom endpoint")
 }
 
+// TestSynth_FastAPI_AnnotatedRouterConstruction covers the idiomatic PEP-526
+// typed construction `router: APIRouter = APIRouter(prefix="/v1")` (used in
+// FastAPI's own docs). The type annotation between the identifier and `=` must
+// not defeat router recognition — the router must be both recognised (so its
+// routes are emitted) AND prefix-folded (#5688).
+func TestSynth_FastAPI_AnnotatedRouterConstruction(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+
+app = FastAPI()
+router: APIRouter = APIRouter(prefix="/v1")
+
+@router.get("/x")
+def handler():
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/annotated.py", src)
+	requireContains(t, got, []string{"http:GET:/v1/x"},
+		"FastAPI annotated APIRouter construction — recognised and prefix-folded")
+	requireNotContains(t, got, []string{"http:GET:/x"},
+		"FastAPI annotated APIRouter construction — unfolded path must not leak")
+}
+
+// TestSynth_FastAPI_ImportedRouterByName covers a router imported from another
+// module (`from .deps import router`) and used via `@router.get(...)` with NO
+// same-file `= APIRouter()` construction. It must still be recognised by the
+// conventional `router` / `*_router` name (matching the pre-#5688 allowlist),
+// with no prefix since none is discoverable in this file.
+func TestSynth_FastAPI_ImportedRouterByName(t *testing.T) {
+	src := `from fastapi import FastAPI
+from .deps import router
+
+app = FastAPI()
+
+@router.get("/y")
+def handler():
+    return {}
+`
+	got, _ := runDetect(t, "python", "routers/imported.py", src)
+	requireContains(t, got, []string{"http:GET:/y"},
+		"FastAPI imported router recognised by conventional name")
+}
+
 // TestSynth_FastAPI_YamlDrivenRouteNotSynthesized_Unit is a direct unit test
 // of synthesizeDjangoFromComposed — it feeds it a yaml_driven Route entity
 // (the kind that the Django YAML path() pattern would produce for a FastAPI


### PR DESCRIPTION
First slice of the #5688 structural endpoint-mount work: FastAPI `APIRouter(prefix="/x")` routes were emitted with only the bare in-router path, losing the mount prefix — so a client call `GET /api/v2/users` failed to join a server endpoint stored as bare `/users` (orphan/mis-join).

**Fix (emit-side only; join side `http_pass.go` untouched):** parse same-file `<var> = APIRouter(prefix="/x")` (incl. PEP-526 annotated `router: APIRouter = APIRouter(...)`) into a var→prefix map, and fold the prefix into each `@<var>.<verb>(...)` / `@<var>.api_route(...)` route before canonicalization (mirrors the existing Flask-Blueprint `url_prefix` handling). Multiple routers per file each fold their own prefix; `@app.<verb>` and no-prefix routers unchanged; non-literal prefixes (`prefix=settings.X`) left bare (deferred to v0.1.9).

**Receiver-gated** to avoid phantom endpoints: a decorator only synthesizes when its receiver is a recognized router/app — `app`/`api`, the conventional `router`/`*_router` names, a same-file `= FastAPI(...)` instance, or a same-file `= APIRouter(...)` var. So `@feature_flags.options(...)` / `@mock.head(...)` no longer emit phantom endpoints (a bug the initial widening introduced for the FastAPI-only verbs head/options/trace).

Also fixes a latent Flask/FastAPI dedup collision (Flask synthesizer skips same-file `APIRouter`-var receivers).

**Tests:** fold correctness, multi-router no-cross-contamination, no-prefix/app-direct unchanged, quote/kwarg-order robustness, no-double-slash-on-root, api_route decorator, annotated construction, imported router-by-name, and the phantom-negative — all RED→GREEN. Full repo green (2874 engine+cmd tests). Two independent reviews (phantom-endpoint gating → fixed; receiver-gate blast-radius annotated/imported regressions → fixed).

Remaining #5688-structural slices (follow-ups): FastAPI cross-file `include_router(prefix=)`, Express cross-file router mount, chi `.Mount()`.

Refs #5688