### PR TITLE
feat(daemon): split-gate Service.Rebuild through the request queue + GC ack files (ADR-0024, refs #5729)

### DIFF
--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -146,7 +146,12 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 		// byte-identical: no extra goroutine, no directory globbing, when the
 		// flag is off.
 		if SplitModeEnabled() {
-			ep.add(startRequestsDrainLoop(scheduler, logger))
+			// PR6 prerequisite (epic #5729): cfg.Rebuild is threaded through
+			// so a drained KindRebuild request invokes the SAME RebuildFunc
+			// the monolith/engine calls in-process from Service.Rebuild —
+			// see requests_drain.go's applyRequest and service.go's
+			// Rebuild split-mode branch.
+			ep.add(startRequestsDrainLoop(scheduler, cfg.Rebuild, logger))
 		}
 
 		// #5725/#5729-W1: status-plane heartbeat file. startStatusWriter runs a

--- a/internal/daemon/index_split_mode_test.go
+++ b/internal/daemon/index_split_mode_test.go
@@ -101,7 +101,7 @@ func TestIndexAsync_SplitModeOn_WritesRequestFile_NeverTouchesScheduler(t *testi
 
 	// Mutual exclusion, end to end: draining it now must reach the SAME
 	// scheduler this test proved was never touched directly.
-	if err := drainRequestsOnce(requestsRoot(), extractSchedulerForTest(svc), nil); err != nil {
+	if err := drainRequestsOnce(requestsRoot(), extractSchedulerForTest(svc), nil, nil); err != nil {
 		t.Fatalf("drainRequestsOnce: %v", err)
 	}
 	select {

--- a/internal/daemon/rebuild_split_mode_test.go
+++ b/internal/daemon/rebuild_split_mode_test.go
@@ -1,0 +1,201 @@
+package daemon
+
+// Mutual-exclusion + round-trip regression for the ADR-0024 PR6 prerequisite
+// (epic #5729, gap #1 from the PR4 review): Service.Rebuild must use EXACTLY
+// ONE of the two rebuild-trigger paths — never both, never neither —
+// depending on GRAFEL_SPLIT_MODE:
+//
+//   - flag OFF (monolith, the default): calls s.rebuild(*args) directly,
+//     in-process, exactly as before this change. No requests/ file is
+//     written.
+//   - flag ON (split mode): writes a KindRebuild request file instead of
+//     ever calling s.rebuild in-serve (s.rebuild is deliberately wired
+//     non-nil in this test harness, mirroring the real split-mode serve
+//     process — see service.go's Rebuild doc comment — to prove it is NOT
+//     invoked).
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+)
+
+func TestRebuild_SplitModeOff_CallsRebuildDirectly_NoRequestFile(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	rebuilt := make(chan string, 1)
+	svc := newService(nil, func(args proto.RebuildArgs) ([]string, string, error) {
+		rebuilt <- args.Group
+		return []string{"/some/repo"}, "", nil
+	}, nil, "", make(chan struct{}, 1), nil, 1)
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup"}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	select {
+	case group := <-rebuilt:
+		if group != "mygroup" {
+			t.Fatalf("rebuilt wrong group: got %q want %q", group, "mygroup")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected s.rebuild to be called directly (monolith path)")
+	}
+	if len(reply.Repos) != 1 || reply.Repos[0] != "/some/repo" {
+		t.Fatalf("expected synchronous reply to carry the rebuilt repos, got %+v", reply)
+	}
+
+	dir := requestsDirForGroup("mygroup")
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("split mode OFF must not queue a rebuild request; got %d pending", len(recs))
+	}
+}
+
+func TestRebuild_SplitModeOn_WritesRequestFile_NeverCallsRebuildDirectly(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	rebuilt := make(chan string, 1)
+	svc := newService(nil, func(args proto.RebuildArgs) ([]string, string, error) {
+		rebuilt <- args.Group
+		return []string{"/some/repo"}, "", nil
+	}, nil, "", make(chan struct{}, 1), nil, 1)
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup", Wipe: true}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	select {
+	case group := <-rebuilt:
+		t.Fatalf("split mode ON must NOT call s.rebuild directly, but got a call for group %q", group)
+	case <-time.After(300 * time.Millisecond):
+		// Expected: no direct call.
+	}
+
+	dir := requestsDirForGroup("mygroup")
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 1 {
+		t.Fatalf("expected exactly 1 queued rebuild request, got %d", len(recs))
+	}
+	if recs[0].Kind != requests.KindRebuild {
+		t.Fatalf("unexpected record kind: %+v", recs[0])
+	}
+	var gotArgs proto.RebuildArgs
+	if err := json.Unmarshal(recs[0].Payload, &gotArgs); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	if gotArgs.Group != "mygroup" || !gotArgs.Wipe {
+		t.Fatalf("unexpected rebuild args in payload: %+v", gotArgs)
+	}
+}
+
+// TestRebuild_SplitModeOn_DrainInvokesEngineRebuildLogic is the round-trip
+// regression: a KindRebuild request written by Service.Rebuild in split mode
+// (simulated end-to-end via the real RPC call) is drained by the engine and
+// turned into a real call to the SAME RebuildFunc the monolith/engine calls
+// in-process today — via drainRequestsOnce/applyRequest (requests_drain.go).
+func TestRebuild_SplitModeOn_DrainInvokesEngineRebuildLogic(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	rebuilt := make(chan proto.RebuildArgs, 1)
+	rebuildFn := func(args proto.RebuildArgs) ([]string, string, error) {
+		rebuilt <- args
+		return []string{"/some/repo"}, "", nil
+	}
+
+	svc := newService(nil, rebuildFn, nil, "", make(chan struct{}, 1), nil, 1)
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup", Incremental: true}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	dir := requestsDirForGroup("mygroup")
+	if err := drainRequestsOnce(requestsRoot(), nil, rebuildFn, nil); err != nil {
+		t.Fatalf("drainRequestsOnce: %v", err)
+	}
+
+	select {
+	case args := <-rebuilt:
+		if args.Group != "mygroup" || !args.Incremental {
+			t.Fatalf("engine rebuild invoked with unexpected args: %+v", args)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("expected the drained request to invoke the engine's rebuild logic")
+	}
+
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected the rebuild request to be consumed, still pending: %+v", recs)
+	}
+
+	// Ack-GC: no orphaned ack file should remain after a successful drain
+	// (PR6 prerequisite gap #2).
+	entries, err := os.ReadDir(dir)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".ack.json") {
+			t.Fatalf("expected no orphaned ack files after successful drain, found %q", e.Name())
+		}
+	}
+}
+
+// TestRebuild_SplitModeOn_RedrainedRebuildIsHarmless proves a rebuild
+// redrained after a simulated crash (ack written, request not yet deleted)
+// does not double-apply: draining twice must invoke the engine rebuild logic
+// at most once for the same request.
+func TestRebuild_SplitModeOn_RedrainedRebuildIsHarmless(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	var calls int
+	rebuildFn := func(args proto.RebuildArgs) ([]string, string, error) {
+		calls++
+		return []string{"/some/repo"}, "", nil
+	}
+
+	dir := requestsDirForGroup("mygroup")
+	payload, err := json.Marshal(proto.RebuildArgs{Group: "mygroup"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := requests.Write(dir, requests.Record{Kind: requests.KindRebuild, Payload: payload}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := drainRequestsOnce(requestsRoot(), nil, rebuildFn, nil); err != nil {
+		t.Fatalf("drainRequestsOnce (1st): %v", err)
+	}
+	if err := drainRequestsOnce(requestsRoot(), nil, rebuildFn, nil); err != nil {
+		t.Fatalf("drainRequestsOnce (2nd): %v", err)
+	}
+
+	if calls != 1 {
+		t.Fatalf("expected the rebuild to run exactly once across both drains (ack-guard), got %d", calls)
+	}
+}

--- a/internal/daemon/requests/requests.go
+++ b/internal/daemon/requests/requests.go
@@ -63,6 +63,16 @@ const (
 	// note as above: internal/mcp/candidates.go's appendResolution /
 	// appendRejection already write directly and are consumed lazily.
 	KindEnrichmentEnqueue Kind = "enrichment_enqueue"
+	// KindRebuild asks the engine to force-rebuild a whole GROUP (the
+	// request-file equivalent of an in-process daemon.RebuildFunc call —
+	// see Service.Rebuild in internal/daemon/service.go). Unlike KindReindex
+	// (single repo, keyed by RepoPath), a rebuild targets a group name, so
+	// the full proto.RebuildArgs (Group/Slug/Wipe/Incremental/…) travels in
+	// Payload as JSON; RepoPath/Ref/Commit are unused for this kind. Added
+	// as the PR6 prerequisite (epic #5729) that closes the gap where
+	// Service.Rebuild ran a full group rebuild IN THE SERVE PROCESS even in
+	// split mode.
+	KindRebuild Kind = "rebuild"
 )
 
 // Status is the terminal state an Ack records for a drained request.
@@ -277,20 +287,39 @@ func Delete(dir, id string) error {
 
 // ApplyAndAck is the standard consumer sequence: apply(rec) using the
 // existing in-process logic (e.g. sched.Scheduler.EnqueueRefCommit), then
-// write an ack recording the outcome, then delete the request file — in that
-// order, so a crash at any point leaves the on-disk state safely resumable:
+// write an ack recording the outcome, then delete the request file, then
+// delete the (now load-bearing-for-nothing) ack file — in that order, so a
+// crash at any point leaves the on-disk state safely resumable:
 //
 //   - crash before apply returns: request still pending, unacked → redrained
 //     and re-applied (apply must be idempotent — true for Enqueue-style
-//     triggers, which already dedup/coalesce).
-//   - crash after ack write, before delete: ListPending's ack-guard excludes
-//     the request from the next drain — no double-apply.
-//   - crash after delete: fully done, nothing to redrain.
+//     triggers, which already dedup/coalesce, and for KindRebuild, which
+//     rebuilds a group from scratch).
+//   - crash after ack write, before request delete: ListPending's ack-guard
+//     excludes the request from the next drain (and best-effort removes the
+//     stale request file itself) — no double-apply.
+//   - crash after request delete, before ack delete: the ack is orphaned
+//     (see the GC note below) but harmless — ListPending only globs
+//     *.request.json, and that file is already gone, so nothing is
+//     re-applied.
+//   - crash after ack delete: fully done, nothing to redrain, nothing left
+//     on disk.
 //
 // A non-nil error from apply is recorded in the ack as StatusError (not
 // returned as a hard failure) so the request is still consumed exactly once;
 // ApplyAndAck itself only returns an error if writing the ack or deleting the
 // request fails (an on-disk problem, not an application-level one).
+//
+// Ack GC (PR6 prerequisite gap #2, epic #5729): the ack's ONLY purpose is to
+// guard the crash window between "ack written" and "request deleted" above.
+// Once the request file is confirmed deleted, that window is closed for
+// good — a crash from this point on leaves no request file for ListPending
+// to find, so the ack can no longer influence anything. Removing it here
+// (best-effort; a failure is not surfaced as an error, matching Delete's own
+// on-disk best-effort semantics) prevents the ~150-byte ack files from
+// accumulating unboundedly on a busy split repo, without reopening the
+// double-apply hole: the guard the ack provides is dead the instant the
+// request file it was guarding is gone.
 func ApplyAndAck(dir string, rec Record, apply func(Record) error) error {
 	applyErr := apply(rec)
 
@@ -304,6 +333,15 @@ func ApplyAndAck(dir string, rec Record, apply func(Record) error) error {
 	}
 	if err := Delete(dir, rec.ID); err != nil {
 		return fmt.Errorf("requests: delete request %s: %w", rec.ID, err)
+	}
+	_ = deleteAck(dir, rec.ID) // best-effort GC; see doc comment above
+	return nil
+}
+
+// deleteAck removes dir/<id>.ack.json. Absent file is not an error.
+func deleteAck(dir, id string) error {
+	if err := os.Remove(ackPath(dir, id)); err != nil && !os.IsNotExist(err) {
+		return err
 	}
 	return nil
 }

--- a/internal/daemon/requests/requests_test.go
+++ b/internal/daemon/requests/requests_test.go
@@ -246,6 +246,46 @@ func TestApplyAndAck_CrashBetweenAckAndDelete(t *testing.T) {
 	}
 }
 
+// TestApplyAndAck_DeletesAckAfterSuccess is the ack-GC regression (PR6
+// prerequisite gap #2, epic #5729): a successful ApplyAndAck must not leave
+// the <id>.ack.json sidecar behind once the request file it was guarding is
+// gone, otherwise a busy split repo accumulates ~150-byte ack files
+// unboundedly. This does not reopen the crash-between-ack-and-delete hole
+// (see TestApplyAndAck_CrashBetweenAckAndDelete): the ack only needs to
+// exist between the ack write and the request delete, both of which have
+// already happened by the time ApplyAndAck deletes it.
+func TestApplyAndAck_DeletesAckAfterSuccess(t *testing.T) {
+	dir := t.TempDir()
+	id, err := Write(dir, Record{Kind: KindReindex, RepoPath: "/repo"})
+	if err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	if err := ApplyAndAck(dir, Record{ID: id, Kind: KindReindex, RepoPath: "/repo"}, func(Record) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("ApplyAndAck: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, id+ackSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("expected ack file to be removed after successful apply, stat err=%v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, id+requestSuffix)); !os.IsNotExist(err) {
+		t.Fatalf("expected request file to be removed after successful apply, stat err=%v", err)
+	}
+
+	// A redrain over the now-empty dir must not error and must find nothing
+	// pending — the whole point of Delete-then-deleteAck is that no residue
+	// (request OR ack) can trip up the next drain pass.
+	recs, err := ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected 0 pending after ack-GC, got %d", len(recs))
+	}
+}
+
 // TestWriteAck_ErrorStatusRoundTrips ensures a failed apply is reported
 // faithfully through the ack so the producer (serve) can surface the error
 // to the caller instead of silently treating it as success.

--- a/internal/daemon/requests_drain.go
+++ b/internal/daemon/requests_drain.go
@@ -1,12 +1,14 @@
 package daemon
 
 import (
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/daemon/requests"
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 )
@@ -59,15 +61,21 @@ func requestsRoot() string {
 
 // drainRequestsOnce performs a single pass: discover every requests/ dir
 // under root, list its pending records, and apply each via
-// requests.ApplyAndAck. Only KindReindex is understood as of PR4 — see
-// internal/daemon/requests's Kind doc comments for why KindSubmitRepair /
-// KindDocgenApply / KindEnrichmentEnqueue are defined but not (yet) produced
-// or consumed anywhere (their handlers already write their sidecars
-// directly and are picked up lazily by the next scheduled index pass, so
-// they are already cross-process safe with no engine-side action needed).
+// requests.ApplyAndAck. KindReindex (PR4) and KindRebuild (PR6 prerequisite,
+// epic #5729) are understood — see internal/daemon/requests's Kind doc
+// comments for why KindSubmitRepair / KindDocgenApply / KindEnrichmentEnqueue
+// are defined but not (yet) produced or consumed anywhere (their handlers
+// already write their sidecars directly and are picked up lazily by the next
+// scheduled index pass, so they are already cross-process safe with no
+// engine-side action needed).
+//
+// rebuildFn is the engine's in-process rebuild entrypoint (cfg.Rebuild — the
+// SAME RebuildFunc Service.Rebuild calls directly in monolith/engine mode);
+// may be nil (a KindRebuild request then acks as an error, same shape as a
+// reindex request arriving with no scheduler attached).
 //
 // logger may be nil (tests exercise the apply path without one).
-func drainRequestsOnce(root string, scheduler *sched.Scheduler, logger *slog.Logger) error {
+func drainRequestsOnce(root string, scheduler *sched.Scheduler, rebuildFn RebuildFunc, logger *slog.Logger) error {
 	dirs, err := discoverRequestsDirs(root)
 	if err != nil {
 		return fmt.Errorf("requests: discover dirs: %w", err)
@@ -83,7 +91,7 @@ func drainRequestsOnce(root string, scheduler *sched.Scheduler, logger *slog.Log
 		for _, rec := range recs {
 			rec := rec
 			applyErr := requests.ApplyAndAck(dir, rec, func(r requests.Record) error {
-				return applyRequest(scheduler, r)
+				return applyRequest(scheduler, rebuildFn, r)
 			})
 			if applyErr != nil && logger != nil {
 				logger.Warn("requests: apply/ack failed", "dir", dir, "id", rec.ID, "kind", rec.Kind, "err", applyErr)
@@ -94,11 +102,11 @@ func drainRequestsOnce(root string, scheduler *sched.Scheduler, logger *slog.Log
 }
 
 // applyRequest dispatches a single drained Record to the same in-process
-// call the monolith/engine makes when it owns the scheduler directly. This
-// is the ONLY kind currently produced (see drainRequestsOnce's doc comment);
-// an unknown/future kind is reported as an error in the ack rather than
-// silently dropped, so the producer can observe the mismatch.
-func applyRequest(scheduler *sched.Scheduler, rec requests.Record) error {
+// call the monolith/engine makes when it owns the scheduler/rebuild
+// entrypoint directly. An unknown/future kind is reported as an error in the
+// ack rather than silently dropped, so the producer can observe the
+// mismatch.
+func applyRequest(scheduler *sched.Scheduler, rebuildFn RebuildFunc, rec requests.Record) error {
 	switch rec.Kind {
 	case requests.KindReindex:
 		if scheduler == nil {
@@ -106,6 +114,24 @@ func applyRequest(scheduler *sched.Scheduler, rec requests.Record) error {
 		}
 		scheduler.Enqueue(rec.RepoPath)
 		return nil
+	case requests.KindRebuild:
+		if rebuildFn == nil {
+			return fmt.Errorf("requests: rebuild request %s but no rebuild entrypoint is attached", rec.ID)
+		}
+		var args proto.RebuildArgs
+		if err := json.Unmarshal(rec.Payload, &args); err != nil {
+			return fmt.Errorf("requests: decode rebuild payload for %s: %w", rec.ID, err)
+		}
+		// Idempotency (PR6 prerequisite, epic #5729): a rebuild rebuilds its
+		// group FROM SCRATCH — the same call daemon.Service.Rebuild makes
+		// synchronously in monolith/engine mode. A redrain after a crash
+		// mid-apply (before the ack was written) simply reruns the same
+		// full rebuild a second time; it is not additive/incremental, so
+		// there is no double-effect to guard against beyond the normal
+		// wasted-work cost, which ApplyAndAck's ack-before-delete ordering
+		// already keeps to "at most once more", never unboundedly.
+		_, _, err := rebuildFn(args)
+		return err
 	default:
 		return fmt.Errorf("requests: unsupported kind %q", rec.Kind)
 	}
@@ -114,8 +140,9 @@ func applyRequest(scheduler *sched.Scheduler, rec requests.Record) error {
 // startRequestsDrainLoop starts the periodic drain goroutine and returns a
 // stop func (ep.add-compatible) that halts it. Only meaningful when a
 // scheduler is attached and SplitModeEnabled() — see the call site in
-// startEnginePlane (engineplane.go), which gates on both.
-func startRequestsDrainLoop(scheduler *sched.Scheduler, logger *slog.Logger) (stop func()) {
+// startEnginePlane (engineplane.go), which gates on both. rebuildFn is
+// threaded through to applyRequest for KindRebuild dispatch (may be nil).
+func startRequestsDrainLoop(scheduler *sched.Scheduler, rebuildFn RebuildFunc, logger *slog.Logger) (stop func()) {
 	done := make(chan struct{})
 	stopped := make(chan struct{})
 	go func() {
@@ -127,7 +154,7 @@ func startRequestsDrainLoop(scheduler *sched.Scheduler, logger *slog.Logger) (st
 			case <-done:
 				return
 			case <-ticker.C:
-				if err := drainRequestsOnce(requestsRoot(), scheduler, logger); err != nil && logger != nil {
+				if err := drainRequestsOnce(requestsRoot(), scheduler, rebuildFn, logger); err != nil && logger != nil {
 					logger.Warn("requests: drain pass failed", "err", err)
 				}
 			}

--- a/internal/daemon/requests_drain_test.go
+++ b/internal/daemon/requests_drain_test.go
@@ -67,7 +67,7 @@ func TestDrainRequestsOnce_ReindexEnqueuesOntoScheduler(t *testing.T) {
 	sc.Start()
 	defer sc.Stop()
 
-	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+	if err := drainRequestsOnce(requestsRoot(), sc, nil, nil); err != nil {
 		t.Fatalf("drainRequestsOnce: %v", err)
 	}
 
@@ -80,15 +80,17 @@ func TestDrainRequestsOnce_ReindexEnqueuesOntoScheduler(t *testing.T) {
 		t.Fatal("timed out waiting for scheduler to index the enqueued repo")
 	}
 
-	ack, ok, err := requests.ReadAck(dir, id)
-	if err != nil {
+	// Ack-GC (PR6 prerequisite gap #2, epic #5729): ApplyAndAck now deletes
+	// the ack file immediately after a successful apply+request-delete —
+	// its only purpose was guarding the crash window between "ack written"
+	// and "request deleted", which is closed the instant the request file
+	// is confirmed gone. So a fully-succeeded drain leaves NEITHER the
+	// request NOR the ack behind (see requests.TestApplyAndAck_DeletesAckAfterSuccess
+	// for the focused regression); this is exactly what we assert here.
+	if _, ok, err := requests.ReadAck(dir, id); err != nil {
 		t.Fatalf("ReadAck: %v", err)
-	}
-	if !ok {
-		t.Fatal("expected an ack to have been written")
-	}
-	if ack.Status != requests.StatusOK {
-		t.Fatalf("unexpected ack status: %+v", ack)
+	} else if ok {
+		t.Fatal("expected the ack to have been GC'd after a successful drain, but it still exists")
 	}
 
 	recs, err := requests.ListPending(dir)
@@ -125,10 +127,10 @@ func TestDrainRequestsOnce_SecondDrainDoesNotDoubleEnqueue(t *testing.T) {
 	sc.Start()
 	defer sc.Stop()
 
-	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+	if err := drainRequestsOnce(requestsRoot(), sc, nil, nil); err != nil {
 		t.Fatalf("drainRequestsOnce (1st): %v", err)
 	}
-	if err := drainRequestsOnce(requestsRoot(), sc, nil); err != nil {
+	if err := drainRequestsOnce(requestsRoot(), sc, nil, nil); err != nil {
 		t.Fatalf("drainRequestsOnce (2nd): %v", err)
 	}
 

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -422,6 +422,31 @@ func requestsDirForRepo(repoPath string) string {
 	return filepath.Join(StateDirForRepo(repoPath), "requests")
 }
 
+// requestsDirForGroup is the serve→engine control-plane drop directory for a
+// GROUP-level request (ADR-0024 PR6 prerequisite, epic #5729 — KindRebuild).
+// A rebuild targets a group name (proto.RebuildArgs.Group), not a single
+// repo path, so requestsDirForRepo's StateDirForRepo(repoPath) hashing
+// doesn't apply directly — there is no repoPath to hash. Rather than teach
+// discoverRequestsDirs a second directory shape, this synthesizes a stable
+// per-group key ("group:<name>", which can never collide with a real
+// absolute repo path's hash) and reuses the exact same repoBaseDir +
+// refs/<ref-safe>/requests layout requestsDirForRepo produces, with the
+// "_unknown" ref sentinel (a group has no git ref of its own). The result
+// still matches discoverRequestsDirs' existing `root/*/refs/*/requests` glob
+// verbatim, so the engine finds it with zero discovery-side changes.
+//
+// This intentionally does NOT resolve the group to its member repos here:
+// proto.RebuildArgs.Group is resolved to repos lazily, INSIDE the RebuildFunc
+// itself (see cmd/grafel's daemonRebuildFuncCore, which loads the group from
+// the registry and iterates cfg.Repos), exactly as it already does when
+// Service.Rebuild calls s.rebuild(*args) directly in monolith/engine mode.
+// So one group-level request (not one-per-repo) is both simplest and
+// correct: the engine drains it and calls the SAME RebuildFunc, which does
+// its own group→repos expansion identically to today.
+func requestsDirForGroup(group string) string {
+	return filepath.Join(repoBaseDir("group:"+group), "refs", RefSafeEncode(""), "requests")
+}
+
 // Index runs a single-repo index synchronously. Phase B adds the
 // MarkIndexed bookkeeping so an explicit RPC index updates the same
 // in-memory state that the watcher-driven path uses.
@@ -508,6 +533,47 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 	if args == nil || args.Group == "" {
 		return errors.New("group is required")
 	}
+
+	// ADR-0024 PR6 prerequisite (epic #5729): in split mode this RPC is
+	// answered by the SERVE process. Unlike Service.Index (whose split-mode
+	// fast path is gated by s.scheduler being nil there), s.rebuild here is
+	// assigned unconditionally by newService regardless of plane (see
+	// server.go) — so it is NON-NIL in split-mode serve, and the nil check
+	// above never trips. Falling through to the synchronous s.rebuild(*args)
+	// call below would run a FULL GROUP REBUILD IN THE SERVE PROCESS,
+	// exactly the blast-radius coupling the split exists to remove. So when
+	// SplitModeEnabled(), drop a KindRebuild request (the full RebuildArgs,
+	// JSON-encoded, as Payload — see requests.KindRebuild) into a
+	// group-scoped requests dir instead, and return immediately; the
+	// engine's drain loop (requests_drain.go's applyRequest) picks it up and
+	// calls the SAME RebuildFunc this method calls directly below in
+	// monolith/engine mode. The two paths are mutually exclusive by
+	// construction: split mode NEVER reaches the s.rebuild(*args) call
+	// below, and monolith/engine mode NEVER writes a request file.
+	//
+	// Fire-and-forget, mirroring Index's async fast path: the reply carries
+	// no repo/stat/progress data because the rebuild hasn't happened yet by
+	// the time this RPC returns. In particular args.ProgressToken-based
+	// polling (IndexProgress) is NOT bridged across the process boundary —
+	// s.progress lives in serve's memory, but the rebuild itself runs in the
+	// engine process, so nothing here would ever mark that session done.
+	// That is a known, documented limitation of this fire-and-forget queue
+	// hop (not one of the two PR6-prerequisite gaps this change closes) and
+	// is left for a follow-up if split-mode progress UX is needed.
+	if SplitModeEnabled() {
+		payload, err := json.Marshal(*args)
+		if err != nil {
+			return fmt.Errorf("encode rebuild request: %w", err)
+		}
+		if _, err := requests.Write(requestsDirForGroup(args.Group), requests.Record{
+			Kind:    requests.KindRebuild,
+			Payload: payload,
+		}); err != nil {
+			return fmt.Errorf("queue rebuild request: %w", err)
+		}
+		return nil
+	}
+
 	atomic.AddInt64(&s.inFlight, 1)
 	defer atomic.AddInt64(&s.inFlight, -1)
 


### PR DESCRIPTION
The PR6-flip prerequisite from the PR4 review. Two gaps that had to close before `GRAFEL_SPLIT_MODE` can default ON:

**Gap 1 (flip blocker): `Service.Rebuild` was not split-gated.** `s.rebuild` is non-nil even in split-mode serve, so `grafel rebuild` ran a full GROUP-level rebuild IN THE SERVE PROCESS — defeating the split. Now, when `SplitModeEnabled()`, `Service.Rebuild` marshals `proto.RebuildArgs` into a `KindRebuild` request (group-scoped dir `group:<name>-<hash>/refs/.../requests`) and returns; the engine's drain loop decodes it and invokes the same `RebuildFunc` the monolith calls in-process. One group-level request (the RebuildFunc expands group→repos itself). Monolith byte-identical (flag off → direct `s.rebuild`, zero queue writes). Fire-and-forget: the progress token doesn't cross the split (documented limitation).

**Gap 2: ack-file leak.** `ApplyAndAck` now deletes `<id>.ack.json` strictly AFTER the request file is deleted — closing the unbounded ack accumulation without weakening the crash-guard (the ack only guards the ack-written→request-deleted window; once the request is gone the guard is moot).

**Tests:** 4 new rebuild tests (mutual-exclusion both directions, drain-invokes-RebuildFunc via real RPC round-trip, redrain-harmless) + ack-GC test; existing crash-window test unchanged. `-race` clean. Smoke: in split mode the engine child performed the rebuild (1.67s CPU) while serve stayed idle (0.33s), the group requests/ drained with no orphan ack.

Independent Opus review APPROVE — verified the group-request dir is genuinely discovered+drained (not silently dropped) and ack-GC preserves exactly-once. Closes the PR6-flip blocker.

Refs #5729 #5725