### PR TITLE
fix(mcp-bridge): fail-fast dead serve vs ride-out engine restart + ctx-cancel retries (ADR-0024 split PR7, refs #5717)

### DIFF
--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -258,11 +258,28 @@ const bridgeMaxRetries = 20
 // longer capped by this smaller budget — the outer bridgeMaxRetries governs,
 // since a serve we've already spoken to this call is presumed genuinely up.
 //
-// Sized so a normal serve restart during a deploy (down for a few seconds
-// while it rebinds its socket) still rides out and auto-recovers — do not
-// regress #5717 — while a permanently-dead serve fails in ~10s instead of
-// silently hanging for the full ~30-60s bridgeMaxRetries ride-out window.
-const bridgeMaxConnectRetries = 8
+// Sizing (must NOT regress #5717): a NORMAL serve restart during a deploy is
+// itself a dial failure (the socket is gone until the replacement rebinds),
+// so it is charged against THIS budget, not the ride-out one. The socket-down
+// window on a real deploy can be substantial:
+//   - .claude/dev/dev-deploy.sh tolerates up to 25s of graceful daemon
+//     shutdown before it even swaps the binary; and
+//   - daemon startup does synchronous work BEFORE transport.Listen binds
+//     (MigrateToRefStore, PruneStaleGenerations, pidfile acquisition,
+//     canonicalizePath — a documented past startup-stall source; see
+//     internal/daemon/server.go), so the listener may not appear for several
+//     more seconds on a slow/loaded start.
+//
+// At the production backoff (bridgeRetryBackoff=150ms base, doubling, capped
+// at bridgeRetryMaxBackoff=3s), bridgeMaxConnectRetries=16 spans ~34.65s of
+// wall-clock before giving up (sum of bridgeBackoffForAttempt(1..15) — see
+// TestBridgeConnectBudget_SurvivalWindow). That COMFORTABLY exceeds the 25s
+// deploy graceful-exit window plus a startup margin, so a normal deploy still
+// auto-recovers (#5717 preserved), while a permanently-dead serve fails in
+// ~35s — meaningfully faster than, and with a clearer errDaemonUnreachable
+// signal than, silently hanging out the full ~49s bridgeMaxRetries ride-out
+// window.
+const bridgeMaxConnectRetries = 16
 
 // errDaemonUnreachable is a sentinel wrapped into the error callDaemon
 // returns when the bridgeMaxConnectRetries connect-only budget is exhausted

--- a/internal/cli/mcp_bridge.go
+++ b/internal/cli/mcp_bridge.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -236,6 +237,40 @@ func (b *bridge) resetRPCClient() {
 // up and surfacing a structured tool error to the MCP client.
 const bridgeMaxRetries = 20
 
+// bridgeMaxConnectRetries is the SMALLER budget used to fail fast on a
+// truly-dead `grafel serve` process, as distinct from bridgeMaxRetries which
+// rides out an ENGINE restart (#5729 split: serve supervises engine; the
+// engine churns on reindex/upgrade, serve itself rarely restarts once up).
+//
+// The two failure shapes look different on the wire:
+//   - Dead/absent serve: the UDS connect itself fails (socket file missing,
+//     ECONNREFUSED, named-pipe-not-found on Windows) — getRPCClient never
+//     succeeds. No RPC is ever in flight to retry.
+//   - Engine mid-restart: the UDS connect SUCCEEDS (serve is up and
+//     listening), but the RPC call fails with a retryable transient error
+//     (rpc.ErrShutdown / io.EOF / the daemon's drain sentinel — see
+//     isRetryableRPCErr) because the in-process engine handling the call
+//     dropped the connection or is mid-reload.
+//
+// callDaemon tracks these separately: bridgeMaxConnectRetries only counts
+// consecutive dial failures that have occurred with NO successful connect
+// yet in this call. The moment a dial succeeds once, dial failures are no
+// longer capped by this smaller budget — the outer bridgeMaxRetries governs,
+// since a serve we've already spoken to this call is presumed genuinely up.
+//
+// Sized so a normal serve restart during a deploy (down for a few seconds
+// while it rebinds its socket) still rides out and auto-recovers — do not
+// regress #5717 — while a permanently-dead serve fails in ~10s instead of
+// silently hanging for the full ~30-60s bridgeMaxRetries ride-out window.
+const bridgeMaxConnectRetries = 8
+
+// errDaemonUnreachable is a sentinel wrapped into the error callDaemon
+// returns when the bridgeMaxConnectRetries connect-only budget is exhausted
+// with no successful dial — i.e. `grafel serve` looks dead, not merely
+// mid-restart. Callers use errors.Is to give this case a clearer, faster
+// signal than a generic exhausted-retries error (#5729).
+var errDaemonUnreachable = errors.New("grafel daemon is not reachable")
+
 // bridgeRetryBackoff is the pause before the FIRST reconnect attempt after a
 // transient failure. Each subsequent attempt doubles the previous pause
 // (exponential backoff — see bridgeBackoffForAttempt), capped at
@@ -300,10 +335,27 @@ func isRetryableRPCErr(err error) bool {
 // The final error after exhausting retries is returned to the caller, which
 // renders it as a structured MCP error.
 //
+// Dead-serve vs engine-restart (#5729): consecutive dial (connect) failures
+// that occur before ANY successful connect in this call are capped by the
+// smaller bridgeMaxConnectRetries budget, not the full bridgeMaxRetries —
+// see the doc comment on bridgeMaxConnectRetries for the rationale. Once a
+// dial has succeeded at least once, subsequent failures (dial or RPC) are
+// governed only by the outer bridgeMaxRetries loop, since we know serve was
+// genuinely up at some point during this call.
+//
+// ctx cancellation is honored between attempts: an abandoned/cancelled
+// request stops retrying immediately instead of sleeping out the remaining
+// backoff. A nil ctx is treated as context.Background().
+//
 // reply must be a pointer; it is reused across attempts (net/rpc overwrites it
 // on each Call, and a failed Call leaves it at its zero value).
-func (b *bridge) callDaemon(method string, args, reply any) error {
+func (b *bridge) callDaemon(ctx context.Context, method string, args, reply any) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	var lastErr error
+	dialSucceeded := false
+	connectFailures := 0
 	for attempt := 0; attempt <= bridgeMaxRetries; attempt++ {
 		if attempt > 0 {
 			// Transient failure on the previous attempt: drop the dead client
@@ -312,17 +364,34 @@ func (b *bridge) callDaemon(method string, args, reply any) error {
 			// socket and finish reloading.
 			b.resetRPCClient()
 			backoff := bridgeBackoffForAttempt(attempt)
-			time.Sleep(backoff)
+			timer := time.NewTimer(backoff)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
 			b.log("retrying %s after transient error (attempt %d/%d, backoff %s): %v",
 				method, attempt, bridgeMaxRetries, backoff, lastErr)
 		}
 		rpcClient, err := b.getRPCClient()
 		if err != nil {
-			// Could not even dial — treat as retryable (the replacement daemon
-			// may not have rebound yet) but remember the error.
+			// Could not even dial. If we have never successfully connected in
+			// this call, this counts against the smaller dead-serve budget
+			// (#5729) so a permanently-absent serve fails fast rather than
+			// burning the full ride-out window. Once we've connected at least
+			// once, dial failures fall back to the generous outer budget.
 			lastErr = err
+			if !dialSucceeded {
+				connectFailures++
+				if connectFailures >= bridgeMaxConnectRetries {
+					return fmt.Errorf("%w after %d connect attempts: %v",
+						errDaemonUnreachable, connectFailures, err)
+				}
+			}
 			continue
 		}
+		dialSucceeded = true
 		callErr := rpcClient.Call(method, args, reply)
 		if callErr == nil {
 			return nil
@@ -500,12 +569,14 @@ func (b *bridge) handleInitialize(req rpc2Request) *rpc2Response {
 // so Claude Code always sees _some_ tools and can display a useful error.
 func (b *bridge) handleToolsList(req rpc2Request) *rpc2Response {
 	var reply MCPToolListReply
-	if err := b.callDaemon("Daemon.MCPToolList", MCPToolListArgs{CWD: b.startupCWD}, &reply); err != nil {
+	if err := b.callDaemon(context.Background(), "Daemon.MCPToolList", MCPToolListArgs{CWD: b.startupCWD}, &reply); err != nil {
 		b.log("Daemon.MCPToolList: %v", err)
 		// callDaemon already reconnected+retried on transient
-		// connection-shutdown (#5633). A persistent failure here means the
-		// daemon is unreachable or pre-Phase D — return the static list so
-		// Claude Code keeps working in the interim.
+		// connection-shutdown (#5633), and fails fast on a dead serve rather
+		// than burning the full ride-out budget (#5729, errDaemonUnreachable).
+		// Either way, a persistent failure here means the daemon is
+		// unreachable or pre-Phase D — return the static list so Claude Code
+		// keeps working in the interim.
 		return b.offlineToolList(req.ID)
 	}
 
@@ -553,13 +624,6 @@ func (b *bridge) handleToolsCall(req rpc2Request) *rpc2Response {
 		cwd = b.startupCWD
 	}
 
-	// Fast path: if we cannot even dial the daemon, surface the clean
-	// "daemon not running" guidance rather than a retry storm.
-	if _, err := b.getRPCClient(); err != nil {
-		b.log("daemon not reachable (%v)", err)
-		return b.daemonError(req.ID, "grafel daemon is not running — run 'grafel start' or 'grafel install'")
-	}
-
 	args := MCPToolCallArgs{
 		Name:      params.Name,
 		Arguments: params.Arguments,
@@ -567,10 +631,22 @@ func (b *bridge) handleToolsCall(req rpc2Request) *rpc2Response {
 	}
 	var reply MCPToolCallReply
 	// callDaemon reconnects+retries on a transient connection-shutdown so a
-	// daemon restart mid-call does not hard-fail the MCP client (#5633). Only a
-	// persistent failure (or a genuine tool/protocol error) reaches here.
-	if err := b.callDaemon("Daemon.MCPToolCall", args, &reply); err != nil {
+	// daemon restart mid-call does not hard-fail the MCP client (#5633). It
+	// distinguishes a dead serve (errDaemonUnreachable, fails fast on the
+	// smaller bridgeMaxConnectRetries budget) from an engine mid-restart
+	// (rides out the full bridgeMaxRetries budget) — see callDaemon (#5729).
+	// Only a persistent failure (or a genuine tool/protocol error) reaches
+	// here.
+	if err := b.callDaemon(context.Background(), "Daemon.MCPToolCall", args, &reply); err != nil {
 		b.log("Daemon.MCPToolCall %s: %v", params.Name, err)
+		if errors.Is(err, errDaemonUnreachable) {
+			// The serve process itself looks dead (repeated connect
+			// failures, never a successful dial) — surface the clean
+			// "daemon not running" guidance as a JSON-RPC protocol error
+			// rather than a structured tool error, so it reads distinctly
+			// from a genuine tool/RPC failure.
+			return b.daemonError(req.ID, "grafel daemon is not reachable — run 'grafel start' or 'grafel install'")
+		}
 		// Return a structured MCP tool error so Claude sees the message.
 		toolErr := mcpToolCallResult{
 			IsError: true,

--- a/internal/cli/mcp_bridge_retry_test.go
+++ b/internal/cli/mcp_bridge_retry_test.go
@@ -89,6 +89,66 @@ func TestBridgeRetryBudget_SurvivalWindow(t *testing.T) {
 	}
 }
 
+// TestBridgeConnectBudget_SurvivalWindow asserts the dead-serve connect-only
+// budget, evaluated at the PRODUCTION backoff defaults, spans a wall-clock
+// window that comfortably covers a real deploy's serve-down window — so a
+// normal serve restart still auto-recovers rather than fail-fasting
+// (#5717 regression guard) — while still being meaningfully shorter than the
+// full bridgeMaxRetries ride-out window (so the fail-fast + clearer
+// errDaemonUnreachable signal remain a real improvement) (#5729).
+//
+// callDaemon bails the connect budget after applying the backoffs for
+// attempts 1..(bridgeMaxConnectRetries-1) (attempt 0 dials with no backoff;
+// each subsequent dial failure pays bridgeBackoffForAttempt(attempt) before
+// the next try, and the (bridgeMaxConnectRetries)th failure returns without a
+// further sleep). The sum of those backoffs is the worst-case wall-clock
+// window a never-reachable serve blocks for.
+func TestBridgeConnectBudget_SurvivalWindow(t *testing.T) {
+	const (
+		prodInitial = 150 * time.Millisecond
+		prodCap     = 3 * time.Second
+		// dev-deploy.sh tolerates up to 25s of graceful daemon shutdown before
+		// swapping the binary; startup work before transport.Listen adds more.
+		// The connect budget must cover this whole window so a deploy restart
+		// (a dial failure) still rides out instead of fail-fasting (#5717).
+		deployGracefulWindow = 25 * time.Second
+	)
+	saved, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = saved, savedMax }()
+	bridgeRetryBackoff = prodInitial
+	bridgeRetryMaxBackoff = prodCap
+
+	var connectWindow time.Duration
+	for attempt := 1; attempt <= bridgeMaxConnectRetries-1; attempt++ {
+		connectWindow += bridgeBackoffForAttempt(attempt)
+	}
+
+	// Lower bound: must comfortably exceed the deploy graceful-exit window so a
+	// normal serve restart auto-recovers (#5717). "Comfortably" = a startup
+	// margin on top of the 25s graceful window for the pre-Listen work.
+	if connectWindow < deployGracefulWindow {
+		t.Fatalf("connect-budget window = %v, want >= the %v deploy graceful-exit window "+
+			"(a normal serve restart is a dial failure charged against this budget — "+
+			"undersizing it regresses #5717 auto-recovery)", connectWindow, deployGracefulWindow)
+	}
+	if margin := connectWindow - deployGracefulWindow; margin < 5*time.Second {
+		t.Fatalf("connect-budget window = %v leaves only %v over the %v deploy window; "+
+			"want a comfortable startup margin (pre-Listen work can take several seconds)",
+			connectWindow, margin, deployGracefulWindow)
+	}
+
+	// Upper bound: must stay shorter than the full ride-out window, otherwise
+	// the dead-serve fail-fast is no faster than just riding out (#5729 intent).
+	var rideOutWindow time.Duration
+	for attempt := 1; attempt <= bridgeMaxRetries; attempt++ {
+		rideOutWindow += bridgeBackoffForAttempt(attempt)
+	}
+	if connectWindow >= rideOutWindow {
+		t.Fatalf("connect-budget window = %v is not shorter than the ride-out window %v — "+
+			"the dead-serve fail-fast provides no earlier signal", connectWindow, rideOutWindow)
+	}
+}
+
 // TestIsRetryableRPCErr covers the classifier that decides whether the bridge
 // reconnects+retries vs surfaces an error (#5633).
 func TestIsRetryableRPCErr(t *testing.T) {

--- a/internal/cli/mcp_bridge_retry_test.go
+++ b/internal/cli/mcp_bridge_retry_test.go
@@ -1,10 +1,12 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/rpc"
 	"net/rpc/jsonrpc"
 	"os"
@@ -268,5 +270,200 @@ func TestBridge_ToolsCall_PersistentFailureSurfaces(t *testing.T) {
 	}
 	if !result.IsError {
 		t.Fatalf("expected IsError=true for an exhausted-retry failure, got %+v", result)
+	}
+}
+
+// ── #5729: dead-serve fail-fast + ctx-cancel ────────────────────────────────
+
+// TestCallDaemon_CtxCancel_ReturnsPromptly asserts that an already-cancelled
+// context makes callDaemon return immediately (via ctx.Err()) instead of
+// sleeping out the backoff before the next retry attempt. bridgeRetryBackoff
+// is temporarily widened so the difference between "slept the backoff" and
+// "returned promptly on cancel" is unambiguous.
+func TestCallDaemon_CtxCancel_ReturnsPromptly(t *testing.T) {
+	savedBackoff, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = savedBackoff, savedMax }()
+	bridgeRetryBackoff = 2 * time.Second
+	bridgeRetryMaxBackoff = 2 * time.Second
+
+	// Always-retryable-erroring mock so the first Call attempt fails and the
+	// loop reaches the backoff-then-retry branch, where ctx cancellation must
+	// short-circuit the sleep.
+	socketPath, stop := startFlakyDaemon(t, 1000)
+	defer stop()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call even starts
+
+	b := &bridge{socketPath: socketPath}
+	var reply MCPToolListReply
+	start := time.Now()
+	err := b.callDaemon(ctx, "Daemon.MCPToolList", MCPToolListArgs{}, &reply)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("callDaemon with cancelled ctx: got err %v, want context.Canceled", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("callDaemon with cancelled ctx took %v, want well under the %v backoff (should not sleep it out)",
+			elapsed, bridgeRetryBackoff)
+	}
+}
+
+// TestCallDaemon_CtxDeadlineExceeded_ReturnsPromptly is the deadline-exceeded
+// variant of the cancellation test: a context whose deadline is already in
+// the past behaves the same as an explicitly cancelled one.
+func TestCallDaemon_CtxDeadlineExceeded_ReturnsPromptly(t *testing.T) {
+	savedBackoff, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = savedBackoff, savedMax }()
+	bridgeRetryBackoff = 2 * time.Second
+	bridgeRetryMaxBackoff = 2 * time.Second
+
+	socketPath, stop := startFlakyDaemon(t, 1000)
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), -1*time.Millisecond)
+	defer cancel()
+
+	b := &bridge{socketPath: socketPath}
+	var reply MCPToolListReply
+	start := time.Now()
+	err := b.callDaemon(ctx, "Daemon.MCPToolList", MCPToolListArgs{}, &reply)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("callDaemon with expired deadline: got err %v, want context.DeadlineExceeded", err)
+	}
+	if elapsed > 200*time.Millisecond {
+		t.Fatalf("callDaemon with expired deadline took %v, want well under the %v backoff", elapsed, bridgeRetryBackoff)
+	}
+}
+
+// TestCallDaemon_DeadServe_FailsFast asserts that when the UDS connect fails
+// outright and NEVER succeeds (socket file missing — simulating a serve
+// process that is not running at all, as opposed to an engine mid-restart),
+// callDaemon gives up on the smaller bridgeMaxConnectRetries budget instead
+// of burning the full bridgeMaxRetries ride-out window (#5729).
+//
+// Retry attempts are counted via the bridge's logger (each retry emits one
+// "retrying ..." line) rather than wall-clock timing, so the assertion is
+// deterministic regardless of machine speed.
+func TestCallDaemon_DeadServe_FailsFast(t *testing.T) {
+	var logBuf strings.Builder
+	b := &bridge{
+		socketPath: unreachableAddr(),
+		logger:     log.New(&logBuf, "", 0),
+	}
+	var reply MCPToolListReply
+	err := b.callDaemon(context.Background(), "Daemon.MCPToolList", MCPToolListArgs{}, &reply)
+
+	if !errors.Is(err, errDaemonUnreachable) {
+		t.Fatalf("callDaemon against a never-reachable socket: got err %v, want wrapped errDaemonUnreachable", err)
+	}
+
+	retryLines := strings.Count(logBuf.String(), "retrying ")
+	if retryLines >= bridgeMaxRetries {
+		t.Fatalf("dead-serve path logged %d retries, want fewer than the full bridgeMaxRetries=%d ride-out budget (log: %s)",
+			retryLines, bridgeMaxRetries, logBuf.String())
+	}
+	if retryLines > bridgeMaxConnectRetries {
+		t.Fatalf("dead-serve path logged %d retries, want at most bridgeMaxConnectRetries=%d",
+			retryLines, bridgeMaxConnectRetries)
+	}
+}
+
+// TestCallDaemon_RideOutPreserved asserts that once the UDS connect succeeds
+// at least once, subsequent RPC-transient errors (simulating an engine
+// mid-restart, not a dead serve) are still retried up to the full generous
+// bridgeMaxRetries budget — not truncated to bridgeMaxConnectRetries — and
+// recover once the transient condition clears (#5729, must not regress
+// #5717).
+func TestCallDaemon_RideOutPreserved(t *testing.T) {
+	if bridgeMaxRetries <= bridgeMaxConnectRetries+2 {
+		t.Fatalf("test assumes bridgeMaxRetries (%d) comfortably exceeds bridgeMaxConnectRetries (%d)",
+			bridgeMaxRetries, bridgeMaxConnectRetries)
+	}
+	// Fail more times than the connect-only budget would tolerate, but fewer
+	// than the full retry budget, then recover.
+	fails := int32(bridgeMaxConnectRetries + 2)
+	socketPath, stop := startFlakyDaemon(t, fails)
+	defer stop()
+
+	b := &bridge{socketPath: socketPath}
+	var reply MCPToolListReply
+	err := b.callDaemon(context.Background(), "Daemon.MCPToolList", MCPToolListArgs{}, &reply)
+	if err != nil {
+		t.Fatalf("expected recovery within the full ride-out budget, got: %v", err)
+	}
+	if len(reply.Tools) != 1 || reply.Tools[0].Description != "ok" {
+		t.Fatalf("expected the real tool list after riding out the transient errors, got %+v", reply.Tools)
+	}
+}
+
+// TestCallDaemon_5717_RestartWindowRecovers is a regression guard: a serve
+// that is down for a brief window (connect fails a few times) and then comes
+// back up (as in a normal deploy restart) must still auto-recover via
+// callDaemon, exactly as #5717 established — the smaller dead-serve budget
+// introduced by #5729 must not make a normal restart window fail fast.
+func TestCallDaemon_5717_RestartWindowRecovers(t *testing.T) {
+	savedBackoff, savedMax := bridgeRetryBackoff, bridgeRetryMaxBackoff
+	defer func() { bridgeRetryBackoff, bridgeRetryMaxBackoff = savedBackoff, savedMax }()
+	bridgeRetryBackoff = 10 * time.Millisecond
+	bridgeRetryMaxBackoff = 50 * time.Millisecond
+
+	var tmp string
+	var socketPath string
+	if runtime.GOOS == "windows" {
+		socketPath = fmt.Sprintf(`\\.\pipe\agbr-%d`, stubPipeSeq(t))
+	} else {
+		var err error
+		tmp, err = os.MkdirTemp("", "agbr")
+		if err != nil {
+			t.Fatalf("MkdirTemp: %v", err)
+		}
+		socketPath = filepath.Join(tmp, "d.sock")
+	}
+	if tmp != "" {
+		defer os.RemoveAll(tmp)
+	}
+
+	// Simulate the restart window: nothing is listening on socketPath yet, so
+	// the bridge's early dial attempts fail exactly like a serve that has not
+	// rebound its socket after a deploy restart. The listener comes up after
+	// a short delay, well inside the connect-only budget's window given the
+	// backoff above.
+	mock := &mockDaemonService{}
+	srv := rpc.NewServer()
+	if err := srv.RegisterName("Daemon", mock); err != nil {
+		t.Fatalf("register mock: %v", err)
+	}
+	listenerUp := make(chan struct{})
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		l, lerr := transport.Listen(socketPath)
+		if lerr != nil {
+			t.Errorf("delayed listen %s: %v", socketPath, lerr)
+			close(listenerUp)
+			return
+		}
+		close(listenerUp)
+		for {
+			conn, aerr := l.Accept()
+			if aerr != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+
+	b := &bridge{socketPath: socketPath}
+	var reply MCPToolListReply
+	err := b.callDaemon(context.Background(), "Daemon.MCPToolList", MCPToolListArgs{}, &reply)
+	<-listenerUp
+	if err != nil {
+		t.Fatalf("expected auto-recovery once the restart window closed (#5717 regression), got: %v", err)
+	}
+	if len(reply.Tools) != 1 || reply.Tools[0].Name != "grafel_whoami" {
+		t.Fatalf("unexpected reply after recovery: %+v", reply.Tools)
 	}
 }


### PR DESCRIPTION
**PR7 of the serve/engine split (ADR-0024, epic #5729)** — client-side MCP bridge follow-ups for #5717.

With the split, serve is the stable anchor (only the engine churns), so the bridge now distinguishes two failure shapes:
- **Dead serve** (dial/connect fails, no RPC in flight) → fail-fast against `bridgeMaxConnectRetries=16` (real-backoff span **~34.65s**), returning a clear `errDaemonUnreachable`.
- **Engine mid-restart** (dial SUCCEEDS, then RPC returns retryable EOF/ErrShutdown) → rides out the original generous `bridgeMaxRetries=20` (~49.65s). A per-call `dialSucceeded` latch switches from the connect budget to the ride-out budget on first successful dial.

The connect-budget span (34.65s) is deliberately sized to **exceed dev-deploy.sh's 25s graceful-exit window** (with ~9.65s headroom for synchronous pre-`transport.Listen` startup work — MigrateToRefStore/PruneStaleGenerations/pidfile/canonicalizePath), so an ordinary deploy restart (a dial-failure) still auto-recovers — **preserving #5717** — while a permanently-dead serve fails in ~35s with a clearer signal than the old blind ~49.65s.

Also threads `context.Context` into `callDaemon` and replaces the blocking `time.Sleep` backoff with `select{ctx.Done()/timer}` (infrastructure for future per-request cancellation; call sites pass `context.Background()` today).

**Tests:** dead-serve fail-fast bounded, ride-out preserved, ctx-cancel promptness, #5717 restart-window recovery, and a new `TestBridgeConnectBudget_SurvivalWindow` that asserts the connect span at PRODUCTION backoff constants ≥ the 25s deploy window (+≥5s margin, < ride-out). `-race` clean; external JSON-RPC contract preserved. Two independent reviews (dead-serve/engine-restart shapes; connect-budget deploy-window sizing → widened 8→16).

Refs #5717 #5729