### PR TITLE
fix(daemon): engine child must inherit serve's exact env — store-root divergence (ADR-0024 PR6 blocker, refs #5729)

### DIFF
--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -50,12 +50,37 @@ const (
 var engineChildCommand = defaultEngineChildCommand
 
 // defaultEngineChildCommand launches `grafel engine --foreground` from the
-// current executable, in its own process group, with the daemon root threaded
-// through the environment (so the child's DefaultLayout resolves the same root)
-// and stdio inherited so its logs land alongside serve's.
+// current executable, in its own process group, with stdio inherited so its
+// logs land alongside serve's.
+//
+// Store-root invariant (production-divergence fix, ADR-0024 PR6 blocker, epic
+// #5729): the engine child inherits serve's environment UNCHANGED. It must NOT
+// synthesize GRAFEL_DAEMON_ROOT. That env var is the isolated-daemon switch that
+// flips the on-disk store layout from the production StoreDir()
+// (~/.grafel|$GRAFEL_HOME/store) to <root>/state — see repoBaseDir/requestsRoot/
+// StoreRootBase in state_path.go + requests_drain.go, all of which key off
+// os.Getenv(EnvRoot), not off Layout.Root.
+//
+// Serve resolves its own root from that SAME env: DefaultLayout uses
+// GRAFEL_DAEMON_ROOT when set (isolated/tests), else ~/.grafel (production, where
+// launchd/systemd do NOT set it). So plain os.Environ() inheritance makes the
+// child observe the IDENTICAL EnvRoot state serve saw:
+//
+//   - production (serve has no GRAFEL_DAEMON_ROOT): the child also sees it unset
+//     → both resolve StoreDir(). Force-appending EnvRoot=layout.Root (=~/.grafel)
+//     here is what broke this: it flipped the child to ~/.grafel/state while serve
+//     kept using ~/.grafel/store, so serve-written reindex/rebuild requests were
+//     silently dropped and engine-written graph.fb landed where serve never read.
+//   - isolated (serve has GRAFEL_DAEMON_ROOT=<tmp>): it is already in os.Environ()
+//     and inherited verbatim → both resolve <tmp>/state.
+//
+// root is retained in the signature (it is Layout.Root, threaded from the
+// supervisor) for the test seam and future non-layout-switching uses, but is
+// deliberately NOT written into the child env.
 func defaultEngineChildCommand(selfExe, root string) *exec.Cmd {
+	_ = root // intentionally not exported to the child env; see doc comment.
 	cmd := exec.Command(selfExe, "engine", "--foreground")
-	cmd.Env = append(os.Environ(), EnvRoot+"="+root)
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.SysProcAttr = engineChildSysProcAttr()

--- a/internal/daemon/supervise_storeroot_test.go
+++ b/internal/daemon/supervise_storeroot_test.go
@@ -1,0 +1,143 @@
+//go:build darwin || linux
+
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// effectiveEnvRoot returns the value of GRAFEL_DAEMON_ROOT the child process
+// would observe from env, honouring exec's last-occurrence-wins semantics.
+// The bool reports whether the child sees it set to a NON-EMPTY value (the
+// state that flips the on-disk store layout to <root>/state).
+func effectiveEnvRoot(env []string) (val string, setNonEmpty bool) {
+	prefix := EnvRoot + "="
+	for _, kv := range env {
+		if strings.HasPrefix(kv, prefix) {
+			val = strings.TrimPrefix(kv, prefix)
+		}
+	}
+	return val, val != ""
+}
+
+// withEnvRoot applies (or clears) GRAFEL_DAEMON_ROOT for the duration of fn,
+// then restores it — so we can compute what store root the child WOULD resolve
+// under its inherited env, using the real repoBaseDir/requestsRoot/StoreRootBase
+// helpers rather than re-deriving the path shape in the test.
+func withEnvRoot(t *testing.T, childVal string, setNonEmpty bool, fn func()) {
+	t.Helper()
+	prev, had := os.LookupEnv(EnvRoot)
+	if setNonEmpty {
+		_ = os.Setenv(EnvRoot, childVal)
+	} else {
+		_ = os.Unsetenv(EnvRoot)
+	}
+	defer func() {
+		if had {
+			_ = os.Setenv(EnvRoot, prev)
+		} else {
+			_ = os.Unsetenv(EnvRoot)
+		}
+	}()
+	fn()
+}
+
+// TestEngineChildResolvesSameStoreRootAsServe is the production-divergence
+// regression (epic #5729, ADR-0024 PR6 blocker). It builds the REAL production
+// engine-child command (defaultEngineChildCommand) and asserts the engine child
+// resolves the IDENTICAL store root as serve for every root-determining env
+// combination:
+//
+//   - production: serve has NO GRAFEL_DAEMON_ROOT → the child must ALSO see it
+//     unset, so both resolve StoreDir() (~/.grafel|$GRAFEL_HOME/store) — NOT the
+//     isolated <root>/state layout. Before the fix the supervisor force-set
+//     GRAFEL_DAEMON_ROOT=<layout.Root> on the child, flipping it to /state while
+//     serve stayed on /store: reindex/rebuild requests were silently dropped and
+//     engine-written graph.fb landed where serve never read it.
+//   - isolated: serve HAS GRAFEL_DAEMON_ROOT=<tmp> → the child inherits the SAME
+//     value → both resolve <tmp>/state.
+func TestEngineChildResolvesSameStoreRootAsServe(t *testing.T) {
+	// Pin GRAFEL_HOME so StoreDir() is deterministic and isolated from the real
+	// ~/.grafel regardless of scenario.
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+
+	const repo = "/some/abs/repo/path"
+
+	t.Run("production_no_daemon_root", func(t *testing.T) {
+		// Serve has NO GRAFEL_DAEMON_ROOT (launchd/systemd production).
+		prev, had := os.LookupEnv(EnvRoot)
+		_ = os.Unsetenv(EnvRoot)
+		defer func() {
+			if had {
+				_ = os.Setenv(EnvRoot, prev)
+			}
+		}()
+
+		// Serve's OWN resolution (production layout → StoreDir()).
+		serveRequests := requestsRoot()
+		serveRepoBase := repoBaseDir(repo)
+		serveStoreBase := StoreRootBase()
+		if want := filepath.Join(home, "store"); serveRequests != want {
+			t.Fatalf("precondition: serve requestsRoot()=%q, want %q", serveRequests, want)
+		}
+
+		// Serve's layout.Root in production is ~/.grafel (a NON-empty path). The
+		// old code force-set GRAFEL_DAEMON_ROOT=layout.Root on the child.
+		serveLayoutRoot := filepath.Join(home, ".grafel-layout-root")
+		cmd := defaultEngineChildCommand("/self/grafel", serveLayoutRoot)
+
+		childVal, childSetNonEmpty := effectiveEnvRoot(cmd.Env)
+		if childSetNonEmpty {
+			t.Fatalf("production divergence: engine child sees GRAFEL_DAEMON_ROOT=%q "+
+				"(serve has it UNSET). This flips the child to <root>/state while serve "+
+				"uses StoreDir()/store — a total serve↔engine disconnect.", childVal)
+		}
+
+		// The child, under its inherited env, must resolve the SAME store root.
+		withEnvRoot(t, childVal, childSetNonEmpty, func() {
+			if got := requestsRoot(); got != serveRequests {
+				t.Errorf("engine requestsRoot()=%q, want serve's %q", got, serveRequests)
+			}
+			if got := repoBaseDir(repo); got != serveRepoBase {
+				t.Errorf("engine repoBaseDir()=%q, want serve's %q", got, serveRepoBase)
+			}
+			if got := StoreRootBase(); got != serveStoreBase {
+				t.Errorf("engine StoreRootBase()=%q, want serve's %q", got, serveStoreBase)
+			}
+		})
+	})
+
+	t.Run("isolated_with_daemon_root", func(t *testing.T) {
+		root := t.TempDir()
+		t.Setenv(EnvRoot, root)
+
+		serveRequests := requestsRoot()
+		serveRepoBase := repoBaseDir(repo)
+		serveStoreBase := StoreRootBase()
+		if want := filepath.Join(root, "state"); serveRequests != want {
+			t.Fatalf("precondition: isolated serve requestsRoot()=%q, want %q", serveRequests, want)
+		}
+
+		cmd := defaultEngineChildCommand("/self/grafel", root)
+		childVal, childSetNonEmpty := effectiveEnvRoot(cmd.Env)
+		if !childSetNonEmpty || childVal != root {
+			t.Fatalf("isolated mode: engine child must inherit GRAFEL_DAEMON_ROOT=%q, got %q (set=%v)",
+				root, childVal, childSetNonEmpty)
+		}
+		withEnvRoot(t, childVal, childSetNonEmpty, func() {
+			if got := requestsRoot(); got != serveRequests {
+				t.Errorf("isolated engine requestsRoot()=%q, want serve's %q", got, serveRequests)
+			}
+			if got := repoBaseDir(repo); got != serveRepoBase {
+				t.Errorf("isolated engine repoBaseDir()=%q, want serve's %q", got, serveRepoBase)
+			}
+			if got := StoreRootBase(); got != serveStoreBase {
+				t.Errorf("isolated engine StoreRootBase()=%q, want serve's %q", got, serveStoreBase)
+			}
+		})
+	})
+}


### PR DESCRIPTION
**Blocks the ADR-0024 split PR6 default-flip.** Found by pre-flip validation on the real daemon: in split mode a `grafel rebuild` silently did nothing.

**Root cause:** the supervisor spawned the engine child with `cmd.Env = append(os.Environ(), GRAFEL_DAEMON_ROOT+"="+root)` — force-setting `GRAFEL_DAEMON_ROOT` even when serve didn't have it. But `GRAFEL_DAEMON_ROOT` is the isolated-daemon env var that switches the on-disk store layout from the production `StoreDir()` (`~/.grafel/store`) to `<root>/state`. In production launchd/systemd don't set it for serve, so serve wrote requests + read graph.fb under `/store` while the engine (force-fed `GRAFEL_DAEMON_ROOT=~/.grafel`) scanned + wrote `/state` — a total serve↔engine disconnect: reindex/rebuild requests silently dropped, engine's graph.fb invisible to serve. Masked in all prior split tests because they set `GRAFEL_DAEMON_ROOT` on BOTH processes to the same temp root, so they agreed.

**Fix (one line):** `supervise.go` → `cmd.Env = os.Environ()`. The engine now observes serve's identical `GRAFEL_DAEMON_ROOT` state (serve derives its own root from that same env), guaranteeing both resolve the same `StoreDir()`/`repoBaseDir()`/`requestsRoot()`/graph.fb location across all combos: production (neither set → both `/store`) and isolated (serve set → engine inherits → both `<tmp>/state`).

**Tests:** `TestEngineChildResolvesSameStoreRootAsServe` reproduces the production divergence — RED on old code (`production_no_daemon_root` fails: child sees `GRAFEL_DAEMON_ROOT` while serve doesn't), GREEN after; isolated-mode subtest stays green. Full `internal/daemon`+`cmd/grafel` suites + `-race` green.

**Cross-process smoke** (isolated temp HOME, no `GRAFEL_DAEMON_ROOT`, split mode): serve + engine env now agree (neither has `GRAFEL_DAEMON_ROOT`); `grafel rebuild` wrote the request under `/store`, the engine drained it within one 2s cycle, wrote graph.fb under the SAME store, accrued CPU (`rebuild mini took 797ms`) — the silent-drop is gone.

Refs #5729