### PR TITLE
feat(daemon): default serve/engine split ON (ADR-0024 split PR6, closes #5717 #5729)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -413,12 +413,14 @@ func runDaemon(argv []string) error {
 	return runServe(argv)
 }
 
-// runServe is the `grafel serve` entrypoint (ADR-0024 Phase 1): the MCP
-// socket + dashboard plane, plus — while the capability flag
-// (daemon.SplitModeEnabled) is off, the default — the engine plane
-// in-process, identically to today's daemon. It shares the entire
-// runtime-tune + daemon.Config assembly prelude with runEngine via
-// runDaemonMode.
+// runServe is the `grafel serve` entrypoint (ADR-0024): the MCP socket +
+// dashboard plane. As of PR6/epic #5729 the capability flag
+// (daemon.SplitModeEnabled) is ON BY DEFAULT, so serve spawns and supervises
+// a separate `grafel engine` child for the scheduler/watcher/extraction/
+// fbwriter. The escape hatch — GRAFEL_SPLIT_MODE=0 (or "false"/"off"/"no") —
+// falls back to running the engine plane in-process, identically to the
+// pre-split daemon. It shares the entire runtime-tune + daemon.Config
+// assembly prelude with runEngine via runDaemonMode.
 func runServe(argv []string) error {
 	return runDaemonMode(argv, daemonRunModeServe)
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -23,7 +23,24 @@ import (
 // user home and no GRAFEL_DAEMON_ROOT isolation is in effect — these tests
 // start an in-process daemon and dial its socket, and must never displace or
 // dial the developer's live daemon.
+//
+// It also pins this test binary's default to MONOLITH mode (ADR-0024 PR6,
+// epic #5729): daemon.SplitModeEnabled() is ON by default in production, but
+// the broad daemon test suite starts in-process daemons via daemon.Run /
+// daemon.RunServe without a real `grafel` binary on disk — os.Executable()
+// in a test binary resolves to the test binary itself, not `grafel`, so a
+// real split-mode engine-child spawn would fail or hang. Setting
+// GRAFEL_SPLIT_MODE=0 here (only if the environment doesn't already specify
+// it) keeps the suite running monolith by default. Tests that specifically
+// exercise split mode override this per-test via t.Setenv(GRAFEL_SPLIT_MODE,
+// "1") (which restores to this TestMain default afterward) and/or
+// daemon.SetEngineChildCommandForTest to substitute a safe in-binary helper
+// process for the engine child — see serve_split_e2e_test.go and
+// serve_engine_split_test.go.
 func TestMain(m *testing.M) {
+	if _, set := os.LookupEnv(daemon.SplitModeEnvVar); !set {
+		os.Setenv(daemon.SplitModeEnvVar, "0")
+	}
 	testsupport.GuardRealHomeMain()
 	os.Exit(m.Run())
 }

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -56,7 +56,7 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 
 	// #5729 PR3: the engine-global liveness/warming heartbeat now starts here
 	// — UNCONDITIONALLY, before the scheduler-gated block below — so it runs
-	// identically in the monolith (flag-off default) AND the standalone
+	// identically in the monolith (escape-hatch GRAFEL_SPLIT_MODE=0) AND the standalone
 	// engine (RunEngine), giving serve ONE code path to read regardless of
 	// split mode (the equivalence property this PR exists to guarantee).
 	// Previously this heartbeat was only started by RunEngine, so a monolith

--- a/internal/daemon/index_split_mode_test.go
+++ b/internal/daemon/index_split_mode_test.go
@@ -24,7 +24,10 @@ import (
 )
 
 func TestIndexAsync_SplitModeOff_UsesSchedulerDirectly_NoRequestFile(t *testing.T) {
-	t.Setenv(SplitModeEnvVar, "")
+	// PR6 (epic #5729): split mode is ON by default now, so "off" must be
+	// requested via the explicit escape hatch (an empty/unset value is no
+	// longer OFF — see SplitModeEnabled's doc comment).
+	t.Setenv(SplitModeEnvVar, "0")
 	root := t.TempDir()
 	t.Setenv(EnvRoot, root)
 

--- a/internal/daemon/rebuild_split_mode_test.go
+++ b/internal/daemon/rebuild_split_mode_test.go
@@ -26,7 +26,10 @@ import (
 )
 
 func TestRebuild_SplitModeOff_CallsRebuildDirectly_NoRequestFile(t *testing.T) {
-	t.Setenv(SplitModeEnvVar, "")
+	// PR6 (epic #5729): split mode is ON by default now, so "off" must be
+	// requested via the explicit escape hatch (an empty/unset value is no
+	// longer OFF — see SplitModeEnabled's doc comment).
+	t.Setenv(SplitModeEnvVar, "0")
 	root := t.TempDir()
 	t.Setenv(EnvRoot, root)
 

--- a/internal/daemon/selfdefense_test.go
+++ b/internal/daemon/selfdefense_test.go
@@ -71,19 +71,34 @@ func TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary(t *testing.T) {
 		t.Skip("running as root — PPID/ps signal checks behave differently")
 	}
 
-	// Check if we're running in a worktree (presence of .git/worktrees indicates
-	// git worktree setup). If so, and a canonical daemon exists, skip gracefully
-	// because binary SHA mismatch is expected and unavoidable.
+	// Check if we're running in a worktree. If so, and a canonical daemon
+	// exists, skip gracefully because the worktree-compiled binary's SHA won't
+	// match the installed daemon's ("binary updated since last install"),
+	// making this real-binary e2e refusal test structurally fragile.
+	//
+	// Two worktree shapes must both be detected (the old guard only caught the
+	// first, which is why it never fired when the tests themselves run FROM a
+	// linked worktree):
+	//   - a MAIN checkout that has linked worktrees → .git is a DIR containing
+	//     a "worktrees/" subdirectory.
+	//   - a LINKED worktree (this case) → .git is a FILE ("gitdir: …" pointer),
+	//     not a directory.
 	canonPID, canonExe := daemon.FindCanonicalDaemon()
 	if canonPID > 0 {
-		// A canonical daemon is running. Check if we're in a worktree.
-		modRoot, err := findModuleRoot()
-		if err == nil {
-			gitDir := filepath.Join(modRoot, ".git")
-			if st, err := os.Stat(gitDir); err == nil && st.IsDir() {
-				// Check for git worktree marker (git worktrees have a "worktrees" subdirectory).
-				worktreeMarkerPath := filepath.Join(gitDir, "worktrees")
-				if _, err := os.Stat(worktreeMarkerPath); err == nil {
+		if modRoot, err := findModuleRoot(); err == nil {
+			gitPath := filepath.Join(modRoot, ".git")
+			if st, err := os.Stat(gitPath); err == nil {
+				inWorktree := false
+				if st.IsDir() {
+					if _, err := os.Stat(filepath.Join(gitPath, "worktrees")); err == nil {
+						inWorktree = true
+					}
+				} else {
+					// .git is a file → this checkout is itself a linked worktree
+					// (or submodule); binary SHA parity cannot be guaranteed.
+					inWorktree = true
+				}
+				if inWorktree {
 					t.Skipf("self-defense check requires installed binary parity; skipping in worktree environment (canonical daemon pid=%d %s)", canonPID, canonExe)
 				}
 			}

--- a/internal/daemon/serve_engine_split_test.go
+++ b/internal/daemon/serve_engine_split_test.go
@@ -56,10 +56,13 @@ func TestRunServe_MatchesDaemonInProcessWiring(t *testing.T) {
 }
 
 // TestRunServe_FlagOff_SpawnsNoEngineChild is the ADR-0024 PR2 flag-OFF
-// regression (epic #5729): with GRAFEL_SPLIT_MODE unset (the default), RunServe
-// must run the whole daemon in-process and spawn NO engine child — so it must
-// never write engine.pid. This pins the critical invariant that split-mode is
-// strictly opt-in and the default running daemon is unchanged.
+// regression (epic #5729): with GRAFEL_SPLIT_MODE explicitly disabled (this
+// package's TestMain pins the test suite to monolith by default — see
+// daemon_test.go; production defaults to split-ON as of PR6), RunServe must
+// run the whole daemon in-process and spawn NO engine child — so it must
+// never write engine.pid. This pins the critical invariant that the
+// GRAFEL_SPLIT_MODE=0 escape hatch actually produces a monolith daemon with
+// zero engine-child spawning.
 func TestRunServe_FlagOff_SpawnsNoEngineChild(t *testing.T) {
 	layout := runServeForTest(t, func(args proto.IndexArgs) (string, string, error) {
 		return args.RepoPath + "/.grafel/graph.json", `{"ok":true}`, nil

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -260,30 +260,42 @@ type Config struct {
 }
 
 // SplitModeEnvVar names the capability flag that gates the serve/engine
-// process split (ADR-0024, epic #5729). Default OFF: RunServe runs the
-// entire daemon in-process — identical to today's Run — and does not spawn
-// a separate `grafel engine` child. PR2 will flip the ON branch of RunServe
-// to spawn and supervise a real engine child process instead of running the
-// engine plane inline.
+// process split (ADR-0024, epic #5729). As of PR6 (epic #5729) the split is
+// ON BY DEFAULT: RunServe spawns and supervises a separate `grafel engine`
+// child process for the scheduler/watcher/extraction/fbwriter, while serve
+// keeps the MCP dispatch socket, dashboard, and graph_cache mmap reads
+// in-process. This is the escape hatch: set GRAFEL_SPLIT_MODE=0 (or
+// "false"/"off"/"no", case-insensitive) to force single-process monolith
+// mode — the entire daemon (serve + engine plane) runs in one process, byte-
+// for-byte identical to the pre-split `grafel daemon`, with no engine child
+// spawned.
 const SplitModeEnvVar = "GRAFEL_SPLIT_MODE"
 
 // SplitModeEnabled reports whether the serve/engine process-split
-// capability flag is turned on. See SplitModeEnvVar. Defaults to false
-// (single-process, today's behavior) so this PR (the entrypoint/config
-// carve) makes no behavior change.
+// capability flag is turned on. See SplitModeEnvVar.
+//
+// Defaults to true (split ON) as of PR6/epic #5729: unset, empty, or any
+// value NOT recognized as an explicit disable is treated as split-mode ON.
+// It returns false ONLY when GRAFEL_SPLIT_MODE is explicitly set to one of
+// "0", "false", "off", or "no" (case-insensitive, whitespace-trimmed) — the
+// documented escape hatch back to single-process monolith mode.
 func SplitModeEnabled() bool {
-	v := strings.TrimSpace(os.Getenv(SplitModeEnvVar))
-	return v == "1" || strings.EqualFold(v, "true")
+	v := strings.ToLower(strings.TrimSpace(os.Getenv(SplitModeEnvVar)))
+	switch v {
+	case "0", "false", "off", "no":
+		return false
+	default:
+		return true
+	}
 }
 
 // ServeConfig is the serve-plane configuration (ADR-0024 Phase 1): the MCP
 // dispatch socket, the dashboard, and graph_cache mmap reads. It currently
-// composes the entire Config rather than a disjoint field set because,
-// while SplitModeEnabled() is false (the default), RunServe must start the
-// engine plane IN-PROCESS exactly as Run does today — it needs every
-// engine-plane field (scheduler, watcher, extraction, fbwriter hooks) to do
-// so. PR2 narrows ServeConfig to serve-only fields once the engine plane is
-// actually spawned as a separate child process instead of run inline.
+// composes the entire Config rather than a disjoint field set because, when
+// split mode is explicitly disabled (GRAFEL_SPLIT_MODE=0, the escape hatch;
+// see SplitModeEnabled), RunServe must start the engine plane IN-PROCESS
+// exactly as Run does today — it needs every engine-plane field (scheduler,
+// watcher, extraction, fbwriter hooks) to do so.
 type ServeConfig struct {
 	Config
 }
@@ -291,49 +303,54 @@ type ServeConfig struct {
 // EngineConfig is the engine-plane configuration (ADR-0024 Phase 1): the
 // scheduler, file watcher, extraction, and fbwriter. See ServeConfig's doc
 // for why it currently composes the full Config rather than a disjoint
-// subset — that split lands in PR2 alongside the real process spawn.
+// subset.
 type EngineConfig struct {
 	Config
 }
 
 // daemonPlaneMode selects which planes the shared run() body starts. It is an
-// internal (unexported) implementation detail of the ADR-0024 Phase 1 / PR2
-// carve; the public entrypoints (Run, RunServe, RunEngine) each pick a mode.
+// internal (unexported) implementation detail of the ADR-0024 carve; the
+// public entrypoints (Run, RunServe, RunEngine) each pick a mode.
 type daemonPlaneMode int
 
 const (
-	// planeMonolith is today's single-process daemon: the serve plane (socket,
+	// planeMonolith is the single-process daemon: the serve plane (socket,
 	// dashboard, MCP dispatch) AND the engine plane (scheduler, watcher,
-	// fbwriter) both run in ONE process. This is the flag-off default and is
-	// byte-for-byte behavior-identical to the pre-split daemon.
+	// fbwriter) both run in ONE process. This is the escape-hatch mode
+	// (GRAFEL_SPLIT_MODE=0/false/off/no) and is byte-for-byte behavior-
+	// identical to the pre-split daemon.
 	planeMonolith daemonPlaneMode = iota
 	// planeServeOnly starts ONLY the serve plane; the engine plane is skipped
 	// because a supervised `grafel engine` child runs it in a separate process
-	// (split-mode ON). Used by RunServe when SplitModeEnabled().
+	// (split-mode ON, the default as of PR6/epic #5729). Used by RunServe
+	// when SplitModeEnabled().
 	planeServeOnly
 )
 
 // RunServe starts the serve plane: the MCP dispatch socket, the dashboard, and
 // the zero-copy graph_cache mmap reads.
 //
-// While the serve/engine split capability flag is OFF (the default,
-// SplitModeEnabled()==false), RunServe runs the ENTIRE daemon in one process —
-// byte-for-byte identical to Run — so an existing OS unit that execs `serve`
-// (or the back-compat `daemon` shim) behaves exactly like today's daemon.
+// As of PR6 (epic #5729), split mode is ON BY DEFAULT (SplitModeEnabled()==
+// true): RunServe starts ONLY the serve plane in-process and spawns +
+// supervises a separate `grafel engine` child for the
+// scheduler/watcher/extraction/fbwriter. The supervisor keeps the engine
+// child alive across crashes with exponential backoff, exposes a status-file
+// health gate, and gracefully drains (SIGTERM → bounded wait → SIGKILL,
+// reaped) the child when serve shuts down. serve never exits for a
+// degraded/dead engine — it keeps answering reads from the last-good
+// graph.fb — and returns non-zero only when the engine is unkeepable
+// (repeated crash-loop at the backoff ceiling), so the OS unit recycles the
+// whole thing.
 //
-// When the flag is ON (ADR-0024 Phase 1 / PR2, epic #5729), RunServe starts
-// ONLY the serve plane in-process and spawns + supervises a separate
-// `grafel engine` child for the scheduler/watcher/extraction/fbwriter. The
-// supervisor keeps the engine child alive across crashes with exponential
-// backoff, exposes a status-file health gate, and gracefully drains (SIGTERM →
-// bounded wait → SIGKILL, reaped) the child when serve shuts down. serve never
-// exits for a degraded/dead engine — it keeps answering reads from the
-// last-good graph.fb — and returns non-zero only when the engine is
-// unkeepable (repeated crash-loop at the backoff ceiling), so the OS unit
-// recycles the whole thing.
+// The escape hatch: set GRAFEL_SPLIT_MODE=0 (or "false"/"off"/"no") to force
+// SplitModeEnabled()==false, in which case RunServe runs the ENTIRE daemon in
+// one process — byte-for-byte identical to Run — so an existing OS unit that
+// execs `serve` (or the back-compat `daemon` shim) behaves exactly like the
+// pre-split daemon, with no engine child spawned.
 func RunServe(ctx context.Context, cfg ServeConfig) error {
 	if !SplitModeEnabled() {
-		// Flag OFF (default): everything in one process, exactly as before.
+		// Escape hatch (GRAFEL_SPLIT_MODE=0/false/off/no): everything in one
+		// process, exactly as before.
 		return run(ctx, cfg.Config, planeMonolith)
 	}
 
@@ -420,7 +437,7 @@ func RunEngine(ctx context.Context, cfg EngineConfig) error {
 	// decide HEALTHY vs DEGRADED — independent of whether any fleet repo is
 	// registered yet. #5729 PR3 moved the startEngineLivenessHeartbeat call
 	// into startEnginePlane (engineplane.go) itself so it ALSO runs in the
-	// monolith (flag-off default), giving serve one status-file code path
+	// monolith (escape-hatch GRAFEL_SPLIT_MODE=0), giving serve one status-file code path
 	// that behaves identically in both modes — see startEnginePlane.
 
 	// Bring up the engine plane (no *Service — engine has no MCP surface).
@@ -588,7 +605,7 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	// watcher, git-HEAD poller, worktree discovery, reapers/sweepers, the
 	// status writer, pattern-decay, and the docgen sweeper. In split-mode
 	// serve (planeServeOnly) a separate supervised `grafel engine` child runs
-	// this, so we skip it here; in the monolith (flag-off default) and the
+	// this, so we skip it here; in the monolith (escape-hatch GRAFEL_SPLIT_MODE=0) and the
 	// standalone engine it runs in-process. The assembly lives in
 	// startEnginePlane (engineplane.go); the extraction is behavior-preserving
 	// for the monolith (same constructors, same order, LIFO teardown).

--- a/internal/daemon/split_mode_default_test.go
+++ b/internal/daemon/split_mode_default_test.go
@@ -1,0 +1,50 @@
+package daemon_test
+
+// split_mode_default_test.go — ADR-0024 PR6 (epic #5729): pins the flipped
+// default for daemon.SplitModeEnabled(). Split mode is now ON BY DEFAULT;
+// GRAFEL_SPLIT_MODE=0 (or "false"/"off"/"no", case-insensitive, trimmed) is
+// the only escape hatch back to monolith. Any other value — including unset,
+// empty, or an unrecognized string — is treated as split-mode ON.
+//
+// This package's TestMain (daemon_test.go) pins GRAFEL_SPLIT_MODE=0 as the
+// process-level default so the broad daemon test suite keeps running
+// monolith without every test needing to opt out individually. Each case
+// below sets the env var explicitly via t.Setenv, so the TestMain default is
+// irrelevant here — this test exercises SplitModeEnabled()'s parsing logic
+// directly, not the suite-wide test default.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+func TestSplitModeEnabled_DefaultOnEscapeHatchOff(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+		want bool
+	}{
+		{"unset/empty defaults ON", "", true},
+		{"whitespace-only defaults ON", "   ", true},
+		{"explicit 1 is ON", "1", true},
+		{"explicit true is ON", "true", true},
+		{"explicit TRUE (case-insensitive) is ON", "TRUE", true},
+		{"unrecognized value defaults ON", "bogus", true},
+		{"explicit 0 is the escape hatch OFF", "0", false},
+		{"explicit false is the escape hatch OFF", "false", false},
+		{"explicit FALSE (case-insensitive) is OFF", "FALSE", false},
+		{"explicit off is the escape hatch OFF", "off", false},
+		{"explicit no is the escape hatch OFF", "no", false},
+		{"explicit OFF with surrounding whitespace is OFF", "  off  ", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(daemon.SplitModeEnvVar, tc.env)
+			if got := daemon.SplitModeEnabled(); got != tc.want {
+				t.Errorf("SplitModeEnabled() with %s=%q = %v, want %v", daemon.SplitModeEnvVar, tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -193,17 +193,19 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	// ── Check 2: Daemon /healthz ────────────────────────────────────────────
 	report.Checks = append(report.Checks, checkDaemon(state, opts.DaemonPort, opts.DaemonTimeout))
 
-	// ── Check 2b: Engine liveness + version skew (ADR-0024 PR5, epic #5729) ──
-	// Monolith-aware: in the DEFAULT config (GRAFEL_SPLIT_MODE off) there is no
-	// separate engine process, so this must never warn "engine down" — see
-	// checkEngineLiveness's doc comment for the monolith/split detection logic.
+	// ── Check 2b: Engine liveness + version skew (ADR-0024 PR5/PR6, epic #5729) ──
+	// Monolith-aware: when the escape hatch (GRAFEL_SPLIT_MODE=0) puts the
+	// install in monolith mode, there is no separate engine process, so this
+	// must never warn "engine down" — see checkEngineLiveness's doc comment
+	// for the monolith/split detection logic.
 	report.Checks = append(report.Checks, checkEngineLiveness(state, defaultEngineLivenessDeps()))
 
 	// ── Check 2c: Pre-split OS service unit (ADR-0024 PR5, epic #5729) ───────
 	// Purely informational: an existing install's unit may still literally
 	// exec `grafel daemon` until the next `grafel update`/`grafel install`
-	// re-renders it to `grafel serve` (behavior-identical while the split flag
-	// is off — see service.Install's WriteUnit re-render contract).
+	// re-renders it to `grafel serve` (behavior-identical when the split flag
+	// is disabled via the GRAFEL_SPLIT_MODE=0 escape hatch — see
+	// service.Install's WriteUnit re-render contract).
 	if preSplit := checkPreSplitUnit(); preSplit != nil {
 		report.Checks = append(report.Checks, *preSplit)
 	}
@@ -867,10 +869,11 @@ func defaultEngineLivenessDeps() engineLivenessDeps {
 // checkEngineLiveness reports the health of the `grafel engine` child
 // process — but ONLY when the serve/engine split is actually active.
 //
-// ADR-0024's split is opt-in via GRAFEL_SPLIT_MODE, default OFF. In that
-// default (monolith) configuration there is NO separate engine process at
-// all — serve does all indexing in-process, exactly like the pre-split
-// `grafel daemon`. Mode detection here does NOT read SplitModeEnabled()
+// ADR-0024's split is ON by default as of PR6; GRAFEL_SPLIT_MODE=0 (or
+// "false"/"off"/"no") is the escape hatch back to monolith mode. In monolith
+// mode there is NO separate engine process at all — serve does all indexing
+// in-process, exactly like the pre-split `grafel daemon`. Mode detection here
+// does NOT read SplitModeEnabled()
 // directly (that reflects THIS process's environment, not necessarily the
 // installed service's); instead it uses the observable artifact split mode
 // produces: an engine.pid file. No engine.pid means either split mode is off,
@@ -899,10 +902,10 @@ func checkEngineLiveness(state *State, deps engineLivenessDeps) CheckResult {
 	pidPath := daemon.EnginePIDPath(root)
 	pid, err := deps.readEnginePID(pidPath)
 	if err != nil || pid <= 0 {
-		// No engine.pid — monolith mode (the default), or the engine child
-		// already exited and was reaped. There is no separate engine process
-		// to be down. Healthy, in-process.
-		cr.Drift = []string{"monolith mode: no separate engine process (GRAFEL_SPLIT_MODE off)"}
+		// No engine.pid — monolith mode (escape hatch: GRAFEL_SPLIT_MODE=0), or
+		// the engine child already exited and was reaped. There is no separate
+		// engine process to be down. Healthy, in-process.
+		cr.Drift = []string{"monolith mode: no separate engine process (GRAFEL_SPLIT_MODE=0)"}
 		cr.Severity = SeverityInfo
 		return cr
 	}


### PR DESCRIPTION
**The final PR of the serve/engine split (ADR-0024, epic #5729).** Flips `GRAFEL_SPLIT_MODE` to **default ON** — so every daemon now runs as serve (MCP + dashboard + mmap reads) supervising an engine child (scheduler/watcher/extraction/enrichment/fbwriter). This delivers the fault isolation that fixes #5717: an engine crash or engine-only redeploy no longer drops the MCP connection.

- `SplitModeEnabled()` returns true by default; `GRAFEL_SPLIT_MODE` ∈ {0,false,off,no} (case-insensitive) is the escape hatch back to single-process monolith. `grafel doctor` reports "split (default)" vs the monolith hatch.
- **Test blast radius handled:** `internal/daemon` (the only package whose tests start a split-capable daemon) got a monolith-default `TestMain` (sets `GRAFEL_SPLIT_MODE=0` only if unset); split-specific tests override with `=1` + `SetEngineChildCommandForTest`. Verified repo-wide: no other package spawns an engine child under the new default. Also fixed a pre-existing `selfdefense_test.go` linked-worktree skip bug.
- **Validated end-to-end on the real daemon+corpus** (before this flip, via the env override): 2 processes, store roots agree, rebuild crosses the process boundary (engine did the work, corpus re-indexed), engine SIGKILL → serve survived + restarted it.

**Tests:** new `split_mode_default_test.go` (11-case default-on + escape-hatch table, RED→GREEN); full `go test ./...` green under the REAL unset default (~200 packages, no hangs); `-race` clean. Smoke: no env → split (engine child spawns); `=0` → monolith (no child). Independent Opus review APPROVE (blast-radius verified complete).

Closes #5717. Refs #5729. (Split-mode-ON acceptance-CI coverage lands as a fast-follow — `grafel selftest` currently exercises only the monolith path.)