### PR TITLE
ci: align setup-go pins to 1.26 (match go.mod) for tag-build robustness (refs #5729)

### DIFF
--- a/.github/workflows/coverage-docs.yml
+++ b/.github/workflows/coverage-docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
       - name: Validate schema + cites
         run: go run ./tools/coverage validate
       - name: Guard against incomplete grouped records (#2971)

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
           cache: true
       - name: gofmt
         run: |

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
           cache: true
       - run: go mod download
       - name: Build grafel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.26'
           cache: true
 
       - run: go mod download

--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.26"
           cache: true
 
       - name: go mod download


### PR DESCRIPTION
CI tag-hardening: 5 workflows pinned `actions/setup-go` to `'1.22'` while `go.mod` declares `go 1.26.0`. A 1.22 toolchain reading that go.mod requires `GOTOOLCHAIN=auto` to network-fetch 1.26 at build time — a latent failure mode if the Go proxy is unreachable on a runner. Pinning setup-go to `1.26` installs it directly and removes that dependency.

Changed (only the `go-version:` line, 1 each): `pre-merge.yml`, `coverage-docs.yml`, `test.yml`, `quality.yml`, `windows-cgo-experiment.yml`. (`acceptance.yml` already resolves to 1.26 via `env.GO_VERSION`; `release.yml`/`windows.yml` already inline `'1.26'`.) All setup-go pins now uniformly 1.26-series.

YAML parses clean; actionlint reports only pre-existing unrelated shellcheck notices (none on the touched lines). No product code, no go.mod/go.sum change.

Refs #5729