### PR TITLE
fix(daemon): reap orphaned engine on unclean serve death — parent-death watchdog + startup reap (ADR-0024, refs #5729)

### DIFF
--- a/internal/daemon/engine_parentwatch.go
+++ b/internal/daemon/engine_parentwatch.go
@@ -1,0 +1,72 @@
+package daemon
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// defaultParentWatchInterval is the poll interval the engine's parent-death
+// watchdog uses in production. A short interval keeps the "orphan window"
+// (the time between the parent dying and the engine self-terminating) small
+// without meaningfully taxing the engine — this is a single getppid() call
+// per tick, effectively free.
+const defaultParentWatchInterval = time.Second
+
+// startParentDeathWatchdog is the PRIMARY layer of the orphan-engine
+// hardening (ADR-0024, epic #5729): it detects when the engine's original
+// serve parent has died UNCLEANLY (SIGKILL / crash / OOM / `launchctl
+// kickstart -k`) — the case where serve's own graceful drain never had a
+// chance to SIGTERM the engine child — and self-terminates the engine so it
+// never lingers as a reparented orphan writing the store alongside a freshly
+// spawned replacement engine.
+//
+// Design: it polls getppid() (the caller-supplied observer, so RunEngine can
+// pass a real os.Getppid-backed function and tests can inject a fake one)
+// every interval and compares the result against originalParent — the pid
+// recorded ONCE at engine startup via os.Getppid(). The FIRST poll that
+// returns a value different from originalParent means this process has been
+// reparented: on Unix/macOS an orphaned child is adopted by init (ppid
+// becomes 1), so any divergence from the recorded original is a reliable,
+// portable signal that the original parent is gone — deliberately compared
+// against the ORIGINAL parent pid rather than hardcoded to ==1, since the
+// adopting pid can vary by platform/container (e.g. a pid-namespaced init
+// that isn't 1).
+//
+// On divergence, onParentDeath is invoked exactly once (typically the
+// engine's own context-cancel func, triggering the SAME graceful shutdown
+// path a SIGTERM would: the deferred engine-plane shutdown unwinds the
+// scheduler/watcher and removes engine.pid) and the watchdog goroutine
+// exits.
+//
+// The watchdog also exits cleanly — WITHOUT ever calling onParentDeath — when
+// ctx is cancelled (normal engine shutdown: ctx.Done() or a real SIGTERM).
+// The returned done channel closes when the goroutine has exited, so callers
+// (and tests) can assert there is no goroutine leak.
+func startParentDeathWatchdog(ctx context.Context, originalParent int, getppid func() int, interval time.Duration, onParentDeath func(), logger *slog.Logger) (done <-chan struct{}) {
+	doneCh := make(chan struct{})
+	if interval <= 0 {
+		interval = defaultParentWatchInterval
+	}
+	go func() {
+		defer close(doneCh)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				if cur := getppid(); cur != originalParent {
+					if logger != nil {
+						logger.Warn("engine: reparented — original parent is gone, self-terminating to avoid an orphaned engine",
+							"original_parent", originalParent, "current_parent", cur)
+					}
+					onParentDeath()
+					return
+				}
+			}
+		}
+	}()
+	return doneCh
+}

--- a/internal/daemon/engine_parentwatch_test.go
+++ b/internal/daemon/engine_parentwatch_test.go
@@ -1,0 +1,109 @@
+package daemon
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestParentDeathWatchdog_FiresOnReparent verifies that when the observed
+// parent pid diverges from the pid recorded at startup (the engine has been
+// reparented — its original serve parent died uncleanly: SIGKILL, crash,
+// OOM), the watchdog invokes onParentDeath exactly once (ADR-0024 orphan-
+// engine hardening, epic #5729).
+func TestParentDeathWatchdog_FiresOnReparent(t *testing.T) {
+	const originalParent = 4242
+	var current int32 = originalParent
+
+	var fired int32
+	fireCh := make(chan struct{})
+	onParentDeath := func() {
+		if atomic.AddInt32(&fired, 1) == 1 {
+			close(fireCh)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := startParentDeathWatchdog(ctx, originalParent, func() int {
+		return int(atomic.LoadInt32(&current))
+	}, time.Millisecond, onParentDeath, nil)
+
+	// Simulate reparenting: the original parent is gone, init (or a
+	// substitute) has adopted this process.
+	atomic.StoreInt32(&current, 1)
+
+	select {
+	case <-fireCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("onParentDeath was not called after the observed parent pid diverged")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog goroutine did not exit after firing")
+	}
+
+	if got := atomic.LoadInt32(&fired); got != 1 {
+		t.Errorf("onParentDeath called %d times, want exactly 1", got)
+	}
+}
+
+// TestParentDeathWatchdog_NoFireWhileParentUnchanged verifies the watchdog
+// never fires while the observed parent pid keeps matching the original —
+// the common case (serve is alive and well) must never trigger a spurious
+// self-termination.
+func TestParentDeathWatchdog_NoFireWhileParentUnchanged(t *testing.T) {
+	const originalParent = 777
+
+	var fired int32
+	onParentDeath := func() { atomic.AddInt32(&fired, 1) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := startParentDeathWatchdog(ctx, originalParent, func() int {
+		return originalParent
+	}, time.Millisecond, onParentDeath, nil)
+
+	// Let several poll intervals elapse with the parent unchanged.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&fired); got != 0 {
+		t.Fatalf("onParentDeath called %d times while parent was unchanged, want 0", got)
+	}
+
+	// Normal shutdown: cancel ctx — the goroutine must exit cleanly (no
+	// leak) WITHOUT ever having called onParentDeath.
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog goroutine did not exit after ctx cancellation")
+	}
+
+	if got := atomic.LoadInt32(&fired); got != 0 {
+		t.Errorf("onParentDeath called %d times after ctx cancel, want 0 (must not fire on normal shutdown)", got)
+	}
+}
+
+// TestParentDeathWatchdog_ExitsOnCtxCancel_NoLeak is a focused leak check:
+// the watchdog goroutine must terminate promptly when ctx is cancelled, even
+// if the parent pid never diverges — this is the "normal engine shutdown"
+// path and must never leave a goroutine running.
+func TestParentDeathWatchdog_ExitsOnCtxCancel_NoLeak(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := startParentDeathWatchdog(ctx, 1234, func() int { return 1234 }, time.Millisecond, func() {}, nil)
+
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watchdog goroutine leaked past ctx cancellation")
+	}
+}

--- a/internal/daemon/engine_parentwatch_unix.go
+++ b/internal/daemon/engine_parentwatch_unix.go
@@ -1,0 +1,15 @@
+//go:build darwin || linux
+
+package daemon
+
+import "os"
+
+// parentWatchGetppid returns the parent-pid observer the engine's
+// parent-death watchdog polls on Unix/macOS: os.Getppid directly. When the
+// original serve parent dies uncleanly, the OS reparents this process to
+// init (or an equivalent pid-namespace init), so os.Getppid()'s return value
+// changes — the exact signal startParentDeathWatchdog compares against the
+// recorded original parent pid.
+func parentWatchGetppid() func() int {
+	return os.Getppid
+}

--- a/internal/daemon/engine_parentwatch_windows.go
+++ b/internal/daemon/engine_parentwatch_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+
+package daemon
+
+import "os"
+
+// parentWatchGetppid returns the parent-pid observer the engine's
+// parent-death watchdog polls on Windows.
+//
+// IMPORTANT Windows caveat: unlike Unix, Windows has no orphan-reparent-to-
+// init semantics — when a parent process dies, a still-running child's
+// recorded parent pid is NOT reassigned to a live adopting process. Win32
+// process-creation APIs stamp the parent pid at CreateProcess time and never
+// update it; os.Getppid() on Windows will therefore typically keep returning
+// the ORIGINAL (now-dead, and possibly already recycled to an unrelated
+// process) parent pid even after that parent is gone. This means the
+// getppid-divergence signal this watchdog relies on rarely — if ever — fires
+// on Windows.
+//
+// This is a documented, INTENTIONAL best-effort for v0.1.8 (ADR-0024, epic
+// #5729): we still wire the same portable watchdog rather than special-
+// casing Windows out entirely (it is harmless and free — one Getppid() call
+// per tick — and self-corrects if a future Go runtime or platform change
+// makes Getppid observe reparenting). The SECONDARY layer — the
+// serve-startup reap in supervise.go (reapStaleEngine) — is what actually
+// guards Windows: it detects and SIGTERMs (TerminateProcess) any lingering
+// engine.pid-recorded process before serve spawns a new engine child, which
+// bounds orphan accumulation to "at most one extra engine between serve
+// restarts" even though the parent-death watchdog itself is not reliable
+// here.
+func parentWatchGetppid() func() int {
+	return os.Getppid
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -440,22 +440,50 @@ func RunEngine(ctx context.Context, cfg EngineConfig) error {
 	// monolith (escape-hatch GRAFEL_SPLIT_MODE=0), giving serve one status-file code path
 	// that behaves identically in both modes — see startEnginePlane.
 
+	// Parent-death watchdog (ADR-0024 orphan-engine hardening, epic #5729,
+	// PRIMARY layer): record the parent pid we were started under, then poll
+	// for reparenting (the original serve parent died uncleanly — SIGKILL,
+	// crash, OOM — and this process was adopted by init) so the engine
+	// self-terminates GRACEFULLY instead of lingering as an orphan that keeps
+	// writing the store alongside a freshly spawned replacement engine. See
+	// startParentDeathWatchdog's doc for the full design and per-platform
+	// notes (engine_parentwatch.go / _unix.go / _windows.go).
+	//
+	// engineCtx derives from ctx so a normal shutdown (ctx cancelled, or the
+	// SIGTERM/SIGINT case below) ALSO stops the watchdog goroutine (no leak);
+	// the watchdog itself cancels engineCtx on reparenting, which the select
+	// below observes as a normal graceful-shutdown trigger.
+	originalParent := os.Getppid()
+	engineCtx, cancelEngine := context.WithCancel(ctx)
+	defer cancelEngine()
+	watchdogDone := startParentDeathWatchdog(engineCtx, originalParent, parentWatchGetppid(), defaultParentWatchInterval, cancelEngine, logger)
+	defer func() { <-watchdogDone }()
+
 	// Bring up the engine plane (no *Service — engine has no MCP surface).
-	ep := startEnginePlane(ctx, cfg.Config, nil, logger)
+	// Uses engineCtx (not ctx) so the watchdog's self-cancel also propagates
+	// into the scheduler/watcher/etc., unwinding them the same way a real
+	// SIGTERM would.
+	ep := startEnginePlane(engineCtx, cfg.Config, nil, logger)
 	defer ep.shutdown()
 
-	logger.Info("engine: ready", "pid", os.Getpid(), "root", cfg.Layout.Root)
+	logger.Info("engine: ready", "pid", os.Getpid(), "ppid", originalParent, "root", cfg.Layout.Root)
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
 	defer signal.Stop(sigCh)
 
 	select {
-	case <-ctx.Done():
-		logger.Info("engine: context cancelled — shutting down", "err", ctx.Err())
+	case <-engineCtx.Done():
+		logger.Info("engine: context cancelled — shutting down", "err", engineCtx.Err())
 	case sig := <-sigCh:
 		logger.Info("engine: signal received — shutting down", "signal", sig.String())
 	}
+	// Explicitly cancel (idempotent alongside the deferred cancelEngine())
+	// BEFORE the deferred ep.shutdown()/watchdogDone-wait unwind below: defers
+	// run LIFO, so without this explicit call ep.shutdown() would fire before
+	// cancelEngine() on the SIGTERM/SIGINT path, leaving engineCtx (and any
+	// child contexts derived from it) live during teardown.
+	cancelEngine()
 	return nil
 }
 

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
@@ -135,19 +136,109 @@ func newEngineSupervisor(layout Layout, logger *slog.Logger) *engineSupervisor {
 	}
 }
 
-// start resolves the self executable and launches the supervision goroutine.
-// It returns once the goroutine is running (the first spawn happens inside it).
+// start resolves the self executable, reaps any stale engine left behind by a
+// previous unclean serve death (SECONDARY orphan-engine hardening layer, see
+// reapStaleEngine), and launches the supervision goroutine. It returns once
+// the goroutine is running (the first spawn happens inside it).
 func (s *engineSupervisor) start(ctx context.Context) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("resolve self executable: %w", err)
 	}
 	s.selfExe = exe
+
+	// SECONDARY layer (ADR-0024 orphan-engine hardening, epic #5729): before
+	// spawning OUR engine child, reap any pre-existing one. This catches an
+	// orphan left by a previous serve that died UNCLEANLY (SIGKILL / crash /
+	// OOM / `launchctl kickstart -k`) before its own graceful drain (this
+	// supervisor's terminateChild) or the engine's own parent-death watchdog
+	// (the PRIMARY layer, engine_parentwatch.go) had a chance to reap it.
+	// Without this, the about-to-be-spawned NEW engine child would run
+	// alongside the still-live orphan, both writing graph.fb and clobbering
+	// each other's engine-liveness heartbeat (false "engine degraded" in
+	// doctor). Safe no-op when engine.pid is absent/dead/not-grafel.
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     s.layout.Root,
+		readPID:  readPID,
+		isAlive:  process.IsAlive,
+		isGrafel: process.PidIsGrafel,
+		kill:     process.Kill,
+		waitDead: waitPIDDead,
+	})
+
 	s.stopCh = make(chan struct{})
 	s.doneCh = make(chan struct{})
 	s.fatalCh = make(chan error, 1)
 	go s.run(ctx)
 	return nil
+}
+
+// reapStaleEngineDeps abstracts the pre-spawn stale-engine reap's I/O so it
+// can be unit-tested without touching real processes or a real daemon root.
+// Mirrors service.sweepOrphanEngineDeps (the analogous Uninstall-time sweep)
+// but keys off readPID's (int, bool) signature — the SAME helper RunEngine's
+// own pidfile plumbing already uses in this package — rather than
+// introducing a second (int, error) convention.
+type reapStaleEngineDeps struct {
+	root     string
+	readPID  func(path string) (int, bool)
+	isAlive  func(pid int) bool
+	isGrafel func(pid int) (bool, error)
+	kill     func(pid int) error
+	waitDead func(pid int) // blocks briefly for pid to exit; may no-op in tests
+}
+
+// reapStaleEngine implements the SECONDARY belt-and-suspenders orphan-engine
+// hardening (ADR-0024, epic #5729): serve reaps a stale/lingering engine on
+// STARTUP, before spawning its own. It is intentionally conservative: any
+// failure to find a live, verified-grafel pid in engine.pid (including the
+// common case — it does not exist) is treated as "nothing to do", never an
+// error.
+//
+// PID-reuse safety (mirrors sweepOrphanEngine's #5729 review fix): a stale
+// engine.pid can name a pid the OS has since recycled to an unrelated
+// process. Before signaling, confirm the pid is actually a grafel process;
+// treat isGrafel returning an error OR false as "not ours" and skip the
+// kill.
+func reapStaleEngine(deps reapStaleEngineDeps) {
+	if deps.root == "" {
+		return
+	}
+	pidPath := EnginePIDPath(deps.root)
+	pid, ok := deps.readPID(pidPath)
+	if !ok || pid <= 0 {
+		return
+	}
+	if !deps.isAlive(pid) {
+		return
+	}
+	if grafelOK, gerr := deps.isGrafel(pid); gerr != nil || !grafelOK {
+		return
+	}
+	_ = deps.kill(pid)
+	if deps.waitDead != nil {
+		deps.waitDead(pid)
+	}
+}
+
+// reapStaleEngineWait bounds how long the SECONDARY reap waits for a
+// SIGTERM'd stale engine to actually exit before serve proceeds to spawn its
+// own engine child — long enough for a normal graceful shutdown, short
+// enough to not meaningfully delay serve startup.
+const reapStaleEngineWait = 2 * time.Second
+
+// waitPIDDead polls process.IsAlive(pid) until it reports dead or
+// reapStaleEngineWait elapses. Production implementation for
+// reapStaleEngineDeps.waitDead; tests inject a no-op instead so they never
+// sleep on a fake pid that (correctly) never goes dead.
+func waitPIDDead(pid int) {
+	deadline := time.Now().Add(reapStaleEngineWait)
+	for time.Now().Before(deadline) {
+		if !process.IsAlive(pid) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 }
 
 // fatal returns a receive-only channel that fires once (with a non-nil error)

--- a/internal/daemon/supervise_reap_test.go
+++ b/internal/daemon/supervise_reap_test.go
@@ -1,0 +1,174 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// TestReapStaleEngine_LiveGrafelEngineTerminated verifies that when
+// engine.pid names a still-live grafel process, the serve-startup reap
+// (ADR-0024 orphan-engine hardening, epic #5729, SECONDARY belt-and-
+// suspenders layer) SIGTERMs it before serve spawns its own engine child.
+// This catches an orphan left behind by a previous unclean serve death
+// (SIGKILL / crash / OOM) whose engine.pid is still on disk.
+func TestReapStaleEngine_LiveGrafelEngineTerminated(t *testing.T) {
+	var killedPID int
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, bool) { return 4242, true },
+		isAlive:  func(pid int) bool { return pid == 4242 },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill: func(pid int) error {
+			killCalled = true
+			killedPID = pid
+			return nil
+		},
+		waitDead: func(pid int) {}, // no-op: skip the real wait in tests
+	})
+	if !killCalled {
+		t.Fatal("kill was not called for a live grafel engine.pid")
+	}
+	if killedPID != 4242 {
+		t.Errorf("killed pid = %d, want 4242", killedPID)
+	}
+}
+
+// TestReapStaleEngine_NoEnginePID_NoOp confirms the reap is a safe no-op when
+// no engine.pid exists (fresh daemon root, or monolith mode never wrote one).
+func TestReapStaleEngine_NoEnginePID_NoOp(t *testing.T) {
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, bool) { return 0, false },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called when engine.pid is absent")
+	}
+}
+
+// TestReapStaleEngine_DeadPID_NoOp confirms the reap is a safe no-op when
+// engine.pid names a pid that is no longer alive (the previous engine
+// already exited cleanly and its own defer removed the pidfile, or a prior
+// reap already handled it).
+func TestReapStaleEngine_DeadPID_NoOp(t *testing.T) {
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, bool) { return 4242, true },
+		isAlive:  func(int) bool { return false },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called when the recorded pid is no longer alive")
+	}
+}
+
+// TestReapStaleEngine_EmptyRoot_NoOp verifies the reap never dereferences an
+// unresolved root.
+func TestReapStaleEngine_EmptyRoot_NoOp(t *testing.T) {
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     "",
+		readPID:  func(string) (int, bool) { return 4242, true },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called with an empty root")
+	}
+}
+
+// TestReapStaleEngine_RecycledPID_NotGrafel_NoOp is the PID-reuse safety
+// case: engine.pid is stale and the OS has recycled that pid to an
+// unrelated, innocent process. isAlive passes but PidIsGrafel returns false
+// — the reap MUST NOT signal it.
+func TestReapStaleEngine_RecycledPID_NotGrafel_NoOp(t *testing.T) {
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, bool) { return 4242, true },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return false, nil },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called when the live pid is not a grafel process (recycled pid)")
+	}
+}
+
+// TestReapStaleEngine_IdentityUnverifiable_NoOp confirms the fail-safe: when
+// grafel-identity cannot be confirmed (e.g. a platform that cannot enumerate
+// processes), the reap skips the kill.
+func TestReapStaleEngine_IdentityUnverifiable_NoOp(t *testing.T) {
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     t.TempDir(),
+		readPID:  func(string) (int, bool) { return 4242, true },
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return false, process.ErrUnsupported },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called when grafel-identity cannot be confirmed")
+	}
+}
+
+// TestReapStaleEngine_ReadsRealPIDFile exercises the reap end to end against
+// a real engine.pid file at EnginePIDPath(root), confirming it reads the
+// SAME path RunEngine writes.
+func TestReapStaleEngine_ReadsRealPIDFile(t *testing.T) {
+	root := t.TempDir()
+	pidPath := EnginePIDPath(root)
+	if err := os.WriteFile(pidPath, []byte("777\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var killedPID int
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     root,
+		readPID:  readPID,
+		isAlive:  func(pid int) bool { return pid == 777 },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(pid int) error { killedPID = pid; return nil },
+		waitDead: func(int) {},
+	})
+	if killedPID != 777 {
+		t.Errorf("killed pid = %d, want 777 (read from %s)", killedPID, pidPath)
+	}
+}
+
+// TestReapStaleEngine_NoRealPIDFile_NoOp confirms a directory with no
+// engine.pid results in no kill, using the real readPID production function.
+func TestReapStaleEngine_NoRealPIDFile_NoOp(t *testing.T) {
+	root := t.TempDir()
+	if _, err := os.Stat(filepath.Join(root, "engine.pid")); !os.IsNotExist(err) {
+		t.Fatalf("test setup: engine.pid unexpectedly exists in %s", root)
+	}
+
+	killCalled := false
+	reapStaleEngine(reapStaleEngineDeps{
+		root:     root,
+		readPID:  readPID,
+		isAlive:  func(int) bool { return true },
+		isGrafel: func(int) (bool, error) { return true, nil },
+		kill:     func(int) error { killCalled = true; return nil },
+		waitDead: func(int) {},
+	})
+	if killCalled {
+		t.Error("kill must not be called when no real engine.pid file exists")
+	}
+}


### PR DESCRIPTION
Hardens the now-default-ON serve/engine split against orphaned engines. Found by validating the shipped default on the real daemon: when serve dies UNCLEANLY (SIGKILL/crash/OOM — normal graceful SIGTERM already reaps the engine via PR2), its `grafel engine` child was reparented to init and kept running (scheduler/watcher/fbwriter writing the store), so the next serve spawned a SECOND engine → two engines racing `graph.fb` + a clobbered engine-liveness file (false 'degraded' in doctor).

**Two layers:**
- **Primary — engine parent-death watchdog** (`engine_parentwatch.go`, unix + windows build-tagged): the engine records its parent pid at startup and polls `getppid()` every 1s; on reparenting (serve gone → ppid diverges from the recorded original) it cancels the engine ctx → graceful shutdown → `engine.pid` removed. Compares to the recorded original (not hardcoded `==1`) so it's correct in pid-namespaced containers and never false-fires while serve is alive. Windows relies on the secondary layer (documented).
- **Secondary — serve-startup reap** (`supervise.go reapStaleEngine`): before spawning its engine, serve SIGTERMs any live `engine.pid` that `process.PidIsGrafel` confirms is a grafel engine (bounded 2s wait; PID-reuse-safe; no-op if absent/dead/not-grafel).

**Tests:** watchdog (fires-on-reparent, no-fire-while-unchanged, exits-on-cancel/no-leak) + reap (live-grafel, absent, dead, recycled-not-grafel, unverifiable) — RED→GREEN. 972 tests, `-race` clean (260 in internal/daemon incl. 11 new). **Smoke reproduced the exact bug:** `kill -9` serve → engine self-terminated within ~1s ("reparented — self-terminating"), `engine.pid` removed, no orphan; a planted stale-pid orphan was reaped on the next serve startup.

Independent Opus review APPROVE — no false-positive self-termination, fire-once + idempotent + no leak, reap can't kill an unrelated/own pid or hang startup, normal restart unaffected. Refs #5729