### PR TITLE
fix(daemon): serialize foreground group-rebuild with scheduler per-repo (split-mode wizard runaway) (#5729)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cajasmota/grafel/internal/quality"
 	"github.com/cajasmota/grafel/internal/quality/audit"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/repolock"
 	"github.com/cajasmota/grafel/internal/resolve"
 )
 
@@ -1335,6 +1336,22 @@ func daemonRebuildFuncCore(
 			// the throttled background cap. This appears AFTER indexFn's prepended
 			// default so it is the effective WithInteractive value.
 			opts = append(opts, WithInteractive(foreground))
+			// Cross-path mutual exclusion (#5729 concurrency bug): this rebuild
+			// indexes the repo DIRECTLY and never touches the engine scheduler,
+			// so the scheduler's per-repo in-flight guard cannot see it. Without
+			// a shared claim, a scheduler-enqueued reindex of the same repo (e.g.
+			// from the wizard-installed `grafel watch` process, a git-HEAD switch,
+			// or a drained KindReindex request) races this rebuild, both
+			// rewriting the same graph.fb — the runaway re-index the live daemon
+			// exhibited. ClaimForeground takes PRIORITY: the scheduler yields the
+			// repo while we own it; we only block on a background index already
+			// mid-write. Acquired/released INSIDE this index goroutine so the
+			// claim tracks the index's real completion — a rebuild whose outer
+			// per-repo timeout fires but whose goroutine keeps running still holds
+			// the claim until the write finishes, and the release is idempotent
+			// (safe alongside the panic-recovery defer above).
+			releaseClaim := repolock.DefaultRegistry.ClaimForeground(rw.r.Path)
+			defer releaseClaim()
 			// #1576: tag the graph with the CONFIG slug (not the on-disk
 			// directory basename) so doc.Repo matches the slug the dashboard
 			// keys nodes by and the slug the cross-repo link pass emits as the

--- a/cmd/grafel/daemon_rebuild_sched_mutex_test.go
+++ b/cmd/grafel/daemon_rebuild_sched_mutex_test.go
@@ -120,5 +120,15 @@ func TestRebuildAndSchedulerDoNotIndexSameRepoConcurrently(t *testing.T) {
 	if got := atomic.LoadInt32(&maxActive); got != 1 {
 		t.Fatalf("rebuild and scheduler indexed the same repo concurrently: maxActive=%d, want 1", got)
 	}
+
+	// Guard against a false pass where maxActive stayed 1 only because the
+	// scheduler never admitted the repo at all: on the fixed code it yields
+	// during the rebuild (no Index call) and retries after yieldRetryDelay, so
+	// its Index hook must fire shortly after the rebuild releases its claim.
+	select {
+	case <-schedRan:
+	case <-time.After(6 * time.Second):
+		t.Fatal("scheduler never admitted/ran the enqueued repo (no yield-retry observed)")
+	}
 	wg.Wait()
 }

--- a/cmd/grafel/daemon_rebuild_sched_mutex_test.go
+++ b/cmd/grafel/daemon_rebuild_sched_mutex_test.go
@@ -1,0 +1,124 @@
+package main
+
+// daemon_rebuild_sched_mutex_test.go — regression for the split-mode rebuild ⇄
+// scheduler concurrency bug: a wizard-triggered FOREGROUND group rebuild and
+// the engine SCHEDULER both indexed the SAME repo at once, unserialized, both
+// rewriting <store>/<repo>/refs/<ref>/graph.fb. The rebuild's post-index
+// cross-repo link pass then never converged against a file being rewritten
+// beneath it, so the rebuild never returned and its KindRebuild request was
+// never acked — runaway re-indexing that only stopped on a manual daemon kill.
+//
+// The rebuild path (daemonRebuildFuncCore → indexFn → Index) never touches the
+// scheduler, so the scheduler's per-repo in-flight guard did not know the repo
+// was being rebuilt. This test wires a REAL sched.Scheduler whose Index hook
+// shares a max-concurrency counter with the rebuild's indexFn, enqueues repo R
+// on the scheduler while running the rebuild against the SAME R, and asserts
+// the two never overlap (max concurrent index of R == 1).
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// setupSingleRepoGroup registers a group with exactly one repo and returns the
+// group name and that repo's on-disk path (the key both the rebuild and the
+// scheduler index against).
+func setupSingleRepoGroup(t *testing.T, groupName, slug string) (group, repoPath string) {
+	t.Helper()
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+	repoBase := t.TempDir()
+	repoPath = repoBase + "/" + slug
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := tmpHome + "/" + groupName + ".fleet.json"
+	cfg := &registry.GroupConfig{Name: groupName, Repos: []registry.Repo{{Slug: slug, Path: repoPath}}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(groupName, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	return groupName, repoPath
+}
+
+func TestRebuildAndSchedulerDoNotIndexSameRepoConcurrently(t *testing.T) {
+	group, repoPath := setupSingleRepoGroup(t, "mutex-group", "only")
+
+	const hold = 250 * time.Millisecond
+
+	// Shared concurrency tracker: every index of repoPath (from EITHER the
+	// scheduler hook or the rebuild indexFn) enters, records the running-max,
+	// holds briefly so any second concurrent entry is observable, then leaves.
+	var active, maxActive int32
+	enterLeave := func() {
+		cur := atomic.AddInt32(&active, 1)
+		for {
+			m := atomic.LoadInt32(&maxActive)
+			if cur <= m || atomic.CompareAndSwapInt32(&maxActive, m, cur) {
+				break
+			}
+		}
+		time.Sleep(hold)
+		atomic.AddInt32(&active, -1)
+	}
+
+	// Real scheduler whose Index hook shares the tracker.
+	schedRan := make(chan struct{}, 8)
+	scheduler := sched.New(sched.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Index: func(_ context.Context, rp, _ string) error {
+			if rp == repoPath {
+				enterLeave()
+			}
+			schedRan <- struct{}{}
+			return nil
+		},
+	})
+	scheduler.Start()
+	defer scheduler.Stop()
+
+	// Rebuild indexFn shares the SAME tracker for the SAME repo.
+	rebuildIndexFn := func(rp, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		if rp == repoPath {
+			enterLeave()
+		}
+		return nil
+	}
+
+	// Kick off the FOREGROUND rebuild first so it registers its claim, then
+	// enqueue the SAME repo onto the scheduler so the two race for graph.fb.
+	rebuildDone := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, _, _ = daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group, Interactive: true}, rebuildIndexFn, noopLinksFn)
+		close(rebuildDone)
+	}()
+
+	// Let the rebuild reach its index hook, then enqueue the scheduler reindex
+	// of the same repo — the exact concurrent-write race from the live daemon.
+	time.Sleep(30 * time.Millisecond)
+	scheduler.Enqueue(repoPath)
+
+	<-rebuildDone
+	// Grace for any concurrently-admitted scheduler run to have recorded itself.
+	time.Sleep(50 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&maxActive); got != 1 {
+		t.Fatalf("rebuild and scheduler indexed the same repo concurrently: maxActive=%d, want 1", got)
+	}
+	wg.Wait()
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -52,6 +52,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/repolock"
 )
 
 // IndexFn re-indexes a single repo at a specific git ref. The scheduler
@@ -289,6 +290,13 @@ type Config struct {
 // job. This is the relief valve for admission-control wedge scenarios
 // (e.g. inflated RSS history predictions that exceed the budget).
 const deadManTimeout = 2 * time.Minute
+
+// yieldRetryDelay is how long the scheduler waits before re-enqueuing a repo it
+// skipped because a foreground group-rebuild owned it (see runIndex). It bounds
+// the retry rate so the scheduler cannot busy-loop against a still-running
+// rebuild, while remaining short enough that the repo is promptly reindexed
+// once the rebuild releases its claim.
+const yieldRetryDelay = 3 * time.Second
 
 // memReleaseDebounceDefault is how long the scheduler must be fully idle
 // (no in-flight index, empty queue, no pending algo/link passes) before it
@@ -1219,6 +1227,29 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	var err error
 	var observedPeakMB int64
 
+	// Cross-path mutual exclusion (foreground group-rebuild ⇄ scheduler): the
+	// foreground rebuild path in cmd/grafel indexes a repo directly, bypassing
+	// this scheduler's per-repo in-flight guard, and both write the same
+	// graph.fb. Yield to a foreground rebuild that owns (or intends to own) this
+	// repo: skip THIS attempt without racing its write, and schedule a single
+	// delayed retry so the repo is still reindexed once the rebuild releases.
+	// A background claim also serialises the scheduler against a concurrent
+	// rebuild that has not yet marked foreground intent.
+	yielded := false
+	backgroundRelease := func() {}
+	if !skip {
+		if rel, ok := repolock.DefaultRegistry.TryClaimBackground(repoPath); ok {
+			backgroundRelease = rel
+		} else {
+			yielded = true
+			s.logEvent("index_yield_foreground", repoPath,
+				"foreground group-rebuild owns this repo — skipping concurrent reindex, retrying after backoff")
+			s.logger.Info("sched: yielding repo to foreground group-rebuild (avoids concurrent graph.fb rewrite)",
+				"repo", repoPath, "ref", tok.ref)
+		}
+	}
+	defer backgroundRelease()
+
 	if skip {
 		err = fmt.Errorf("reindex circuit open: %d consecutive failure(s) at commit %q, retrying after backoff (#5726/#5729)", breakerStats.FailCount, tok.commit)
 		if shouldLogSkip {
@@ -1229,7 +1260,7 @@ func (s *Scheduler) runIndex(tok jobToken) {
 				"repo", repoPath, "commit", tok.commit, "ref", tok.ref, "fail_count", breakerStats.FailCount,
 				"backoff_until", breakerStats.FailBackoffUntil)
 		}
-	} else {
+	} else if !yielded {
 		s.logEvent("index_start", repoPath, "predicted="+formatMB(tok.predictedMB)+" ref="+tok.ref)
 		// Observability: log goroutine identity + ref so concurrent-indexer
 		// regressions are diagnosable without a pprof trace (#2141).
@@ -1319,7 +1350,7 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 	s.mu.Lock()
 	stats := s.indexedRepos[repoPath]
-	if !skip {
+	if !skip && !yielded {
 		stats.LastIndex = time.Now()
 		stats.IndexCount++
 		stats.PredictedMB = tok.predictedMB
@@ -1345,7 +1376,7 @@ func (s *Scheduler) runIndex(tok jobToken) {
 			}
 			stats.FailBackoffUntil = time.Now().Add(reindexFailBackoff(stats.FailCount))
 		}
-	} else {
+	} else if !yielded {
 		stats.LastErr = ""
 		// Success resets the breaker entirely — including for a DIFFERENT
 		// commit than FailCommit, which is already implied since a fresh
@@ -1390,7 +1421,18 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	}
 	s.mu.Unlock()
 
-	if followUp {
+	if yielded {
+		// Do NOT re-enqueue immediately: the foreground rebuild that owns this
+		// repo is still running, so an instant retry would busy-loop (yield →
+		// re-enqueue → admit → yield). Retry once after a bounded backoff; the
+		// rebuild will have released its claim by then in the common case, and
+		// EnqueueRefCommit dedups so overlapping retries coalesce into one.
+		s.logEvent("reindex_yield_retry", repoPath,
+			"scheduling delayed reindex retry after foreground rebuild backoff")
+		time.AfterFunc(yieldRetryDelay, func() {
+			s.EnqueueRefCommit(repoPath, followUpRef, followUpCommit)
+		})
+	} else if followUp {
 		s.logEvent("reindex_coalesced_followup", repoPath,
 			"changes landed during in-flight reindex — scheduling single follow-up (#5138)")
 		s.EnqueueRefCommit(repoPath, followUpRef, followUpCommit)
@@ -1405,6 +1447,12 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 	// Wake admission — capacity has freed.
 	s.poke()
+
+	if yielded {
+		// Nothing was indexed (we yielded to a foreground rebuild). Do not log a
+		// completion nor arm the cross-repo link pass — the rebuild owns those.
+		return
+	}
 
 	if err != nil {
 		// A skip already logged its own (rate-limited) index_circuit_skip

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1346,6 +1346,19 @@ func (s *Scheduler) runIndex(tok jobToken) {
 
 		close(sampleStop)
 		sampleWG.Wait()
+
+		// Release the cross-path claim the INSTANT the graph.fb write is done —
+		// BEFORE the stats/follow-up/poke section below. The background claim
+		// only needs to cover the write; the scheduler already serialises
+		// against itself via inflight[repoPath]. Releasing at end-of-function
+		// (defer) instead would leave the claim held while this run re-enqueues
+		// its own #5138 coalesced follow-up and pokes admission — a second
+		// worker could then admit that follow-up, have TryClaimBackground fail
+		// against our not-yet-released claim, and wrongly "yield to a foreground
+		// rebuild" against the scheduler's OWN just-completed run (delaying the
+		// no-lost-update follow-up up to yieldRetryDelay + phantom logs). The
+		// idempotent defer below still covers the skip/yield/early-return paths.
+		backgroundRelease()
 	}
 
 	s.mu.Lock()

--- a/internal/repolock/repolock.go
+++ b/internal/repolock/repolock.go
@@ -23,6 +23,12 @@
 // retries later) instead of racing. A foreground claim still BLOCKS on a
 // background index that is already running for the repo — it must not corrupt a
 // write already in progress.
+//
+// Boundary: this is an in-process (in-memory) lock. It serialises the daemon's
+// own foreground-rebuild and scheduler paths only. A directly-invoked
+// `grafel index` CLI runs in a SEPARATE OS process and is NOT covered by this
+// registry — that pre-existing hazard (two processes writing one store) is out
+// of scope here and would need a filesystem lock to close.
 package repolock
 
 import (

--- a/internal/repolock/repolock.go
+++ b/internal/repolock/repolock.go
@@ -1,0 +1,139 @@
+// Package repolock serializes indexing of a single repo across the two
+// independent code paths that both write the same
+// <store>/<repo>/refs/<ref>/graph.fb:
+//
+//   - the FOREGROUND group-rebuild path in cmd/grafel (daemonRebuildFuncCore →
+//     Index), which calls the extractor directly and never touches the
+//     scheduler, and
+//   - the BACKGROUND scheduler in internal/daemon/sched, whose per-repo
+//     in-flight guard only protects the scheduler against itself.
+//
+// Before this package existed, a wizard-triggered foreground rebuild and a
+// scheduler-enqueued reindex of the SAME repo could run concurrently, both
+// rewriting graph.fb under each other. The rebuild's post-index cross-repo link
+// pass then never converged against a file being rewritten beneath it, so the
+// rebuild call never returned and its request was never acked — runaway
+// re-indexing that only stopped on a manual daemon kill.
+//
+// The claim is keyed on the repo path (filepath.Clean-normalised). Both callers
+// derive that path from the SAME registry group config, so the strings match.
+//
+// Priority: the foreground rebuild wins. While a foreground claim is intended or
+// held for a repo, the scheduler's TryClaimBackground fails (it yields and
+// retries later) instead of racing. A foreground claim still BLOCKS on a
+// background index that is already running for the repo — it must not corrupt a
+// write already in progress.
+package repolock
+
+import (
+	"path/filepath"
+	"sync"
+)
+
+// Registry tracks per-repo index claims. The zero value is not usable; call
+// New. A process-wide DefaultRegistry is provided for the daemon, since the
+// foreground rebuild (cmd/grafel) and the scheduler (internal/daemon/sched) do
+// not share any object reference through which a non-global registry could be
+// threaded.
+type Registry struct {
+	mu   sync.Mutex
+	cond *sync.Cond
+	st   map[string]*keyState
+}
+
+type keyState struct {
+	held   bool // an index (foreground OR background) is currently running
+	fgWant int  // foreground claimants that intend to hold or are holding
+}
+
+// New returns an empty Registry.
+func New() *Registry {
+	r := &Registry{st: map[string]*keyState{}}
+	r.cond = sync.NewCond(&r.mu)
+	return r
+}
+
+// DefaultRegistry is the process-wide registry used by the live daemon.
+var DefaultRegistry = New()
+
+func (r *Registry) stateOf(key string) *keyState {
+	ks := r.st[key]
+	if ks == nil {
+		ks = &keyState{}
+		r.st[key] = ks
+	}
+	return ks
+}
+
+// gcLocked drops a keyState once it carries no state, so the map does not grow
+// unboundedly across the process lifetime. Caller must hold r.mu.
+func (r *Registry) gcLocked(key string, ks *keyState) {
+	if !ks.held && ks.fgWant == 0 {
+		delete(r.st, key)
+	}
+}
+
+// ClaimForeground acquires the key for a foreground (priority) index. It first
+// records foreground intent — so any concurrent TryClaimBackground immediately
+// yields — then blocks until no index is running for the key, marks it held,
+// and returns an idempotent release.
+//
+// The returned release MUST be called from the goroutine that actually runs the
+// index (not from a timeout/orphan supervisor), so the claim is released on the
+// index's real completion. A rebuild whose outer per-repo timeout fires but
+// whose index goroutine keeps running still holds the claim until that
+// goroutine finishes — which is correct: the file is still being written. The
+// release is idempotent, so wiring it as a defer is safe even alongside panic
+// recovery.
+func (r *Registry) ClaimForeground(key string) (release func()) {
+	key = filepath.Clean(key)
+	r.mu.Lock()
+	ks := r.stateOf(key)
+	ks.fgWant++
+	for ks.held {
+		r.cond.Wait()
+	}
+	ks.held = true
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			ks.held = false
+			ks.fgWant--
+			r.gcLocked(key, ks)
+			r.cond.Broadcast()
+			r.mu.Unlock()
+		})
+	}
+}
+
+// TryClaimBackground attempts to acquire the key for a background scheduler
+// index. It FAILS (ok=false) without blocking when either an index is already
+// running for the key OR a foreground claim is intended/held for it (yield to
+// the rebuild). On success it marks the key held and returns an idempotent
+// release.
+func (r *Registry) TryClaimBackground(key string) (release func(), ok bool) {
+	key = filepath.Clean(key)
+	r.mu.Lock()
+	ks := r.stateOf(key)
+	if ks.held || ks.fgWant > 0 {
+		r.gcLocked(key, ks)
+		r.mu.Unlock()
+		return nil, false
+	}
+	ks.held = true
+	r.mu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			r.mu.Lock()
+			ks.held = false
+			r.gcLocked(key, ks)
+			r.cond.Broadcast()
+			r.mu.Unlock()
+		})
+	}, true
+}

--- a/internal/repolock/repolock_test.go
+++ b/internal/repolock/repolock_test.go
@@ -1,0 +1,114 @@
+package repolock
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+// A background claim must yield (fail) while a foreground claim is held, and
+// succeed again once it is released.
+func TestBackgroundYieldsToForeground(t *testing.T) {
+	r := New()
+
+	relFg := r.ClaimForeground("/repo/a")
+	if _, ok := r.TryClaimBackground("/repo/a"); ok {
+		t.Fatal("background claim must fail while a foreground claim is held")
+	}
+	// A different repo is unaffected.
+	if rel, ok := r.TryClaimBackground("/repo/b"); !ok {
+		t.Fatal("background claim for an unrelated repo must succeed")
+	} else {
+		rel()
+	}
+	relFg()
+	if rel, ok := r.TryClaimBackground("/repo/a"); !ok {
+		t.Fatal("background claim must succeed after the foreground claim releases")
+	} else {
+		rel()
+	}
+}
+
+// A background claim also excludes a second background claim (mutual exclusion),
+// and a foreground claim blocks until the background one releases.
+func TestForegroundBlocksOnRunningBackground(t *testing.T) {
+	r := New()
+
+	relBg, ok := r.TryClaimBackground("/repo/a")
+	if !ok {
+		t.Fatal("first background claim must succeed")
+	}
+	if _, ok := r.TryClaimBackground("/repo/a"); ok {
+		t.Fatal("a second concurrent background claim must fail")
+	}
+
+	acquired := make(chan struct{})
+	go func() {
+		rel := r.ClaimForeground("/repo/a") // blocks until relBg fires
+		close(acquired)
+		rel()
+	}()
+
+	select {
+	case <-acquired:
+		t.Fatal("foreground claim acquired while a background index was still running")
+	case <-time.After(50 * time.Millisecond):
+	}
+	relBg()
+	select {
+	case <-acquired:
+	case <-time.After(time.Second):
+		t.Fatal("foreground claim did not acquire after the background release")
+	}
+}
+
+// Release must be idempotent — the orphaned-rebuild path may invoke it more
+// than once, and a double release must not corrupt the ledger.
+func TestReleaseIsIdempotent(t *testing.T) {
+	r := New()
+	rel := r.ClaimForeground("/repo/a")
+	rel()
+	rel() // must not panic nor wrongly free a fresh claim
+
+	relBg, ok := r.TryClaimBackground("/repo/a")
+	if !ok {
+		t.Fatal("claim must be free after release")
+	}
+	// A stale second call to the FIRST release must not clear this new claim.
+	rel()
+	if _, ok := r.TryClaimBackground("/repo/a"); ok {
+		t.Fatal("stale release wrongly freed a live claim")
+	}
+	relBg()
+}
+
+// Concurrent foreground claims for the same repo are serialised (never both
+// hold at once), exercised under -race.
+func TestForegroundClaimsSerialise(t *testing.T) {
+	r := New()
+	var active, max int32
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			rel := r.ClaimForeground("/repo/a")
+			mu.Lock()
+			active++
+			if active > max {
+				max = active
+			}
+			mu.Unlock()
+			time.Sleep(2 * time.Millisecond)
+			mu.Lock()
+			active--
+			mu.Unlock()
+			rel()
+		}()
+	}
+	wg.Wait()
+	if max != 1 {
+		t.Fatalf("foreground claims overlapped: max concurrent = %d, want 1", max)
+	}
+}


### PR DESCRIPTION
## Problem (found via manual wizard TUI test on a large monorepo)
In split mode (default-on), a wizard-triggered **foreground group rebuild** and the engine **scheduler** indexed the *same repo concurrently*, both writing the same `refs/main/graph.fb` with nothing serializing them. Observed on a real daemon: two simultaneous `discovered N candidate files`, every extraction pipeline stage printed twice/interleaved, engine pegged 100–292% CPU. The rebuild's per-repo index completed but its deferred `rebuild exit` never printed — the post-index link pass never converged against a `graph.fb` being rewritten under it, so the rebuild call never returned and its `KindRebuild` request was never acked. Net effect: runaway re-indexing that only stopped on manual daemon kill.

## Root cause
The foreground rebuild path (`daemonRebuildFuncCore` → in-process `Index()`) calls the extractor directly and **never touches the scheduler**, so the scheduler's per-repo in-flight guard (`inflight[repoPath]`) has no idea the repo is being rebuilt. A reactive `scheduler.Enqueue` for the same repo (wizard-installed `grafel watch` → `Service.Index` async → engine drain loop, and the git-HEAD poller) then runs a second concurrent index. The two callers share no state, so coalescing the enqueue can't help — they need a shared claim primitive.

## Fix
- New leaf package `internal/repolock`: process-wide claim registry keyed on `filepath.Clean(repoPath)`. `ClaimForeground` (priority, blocking, idempotent release) + `TryClaimBackground` (non-blocking; yields while a foreground claim is intended/held).
- Rebuild (`cmd/grafel/daemon.go` `indexOneInner`) takes `ClaimForeground`, released inside the index goroutine so it spans the full write incl. the orphan-timeout path.
- Scheduler (`internal/daemon/sched/scheduler.go` `runIndex`) does non-blocking `TryClaimBackground`; on failure it yields (skips the write, breaker/stats untouched) and schedules one dedup-coalesced retry (`yieldRetryDelay=3s`). The claim is released the instant the `graph.fb` write completes — before the #5138 coalesced-follow-up/poke section — so the scheduler never yields to its own just-completed run.

Foreground wins: the scheduler yields while the rebuild owns the repo; the rebuild only blocks on a background index already mid-write.

## Tests
- `cmd/grafel/daemon_rebuild_sched_mutex_test.go` — concurrent rebuild+scheduler on one repo, asserts only one indexes at a time (red→green; also asserts the scheduler actually admitted via yield-retry).
- `internal/repolock/repolock_test.go` — 4 unit tests (yield, blocking, idempotent release, concurrent-foreground serialise).
- `go build`/`vet` clean; `-race` clean incl. 5× repeats of the previously-flaky coalesce tests.

## Review
Independent adversarial review verified claim-span, cross-process correctness (all graph.fb writers run in the one engine process), deadlock-freedom, TOCTOU, and release-on-all-paths. It caught one self-yield regression (background claim released too late) — fixed here (release right after the write). In-memory-lock boundary is documented (a separately-invoked `grafel index` CLI process is not covered — pre-existing).

Refs #5729