### PR TITLE
feat(wiztui): one progress row per module for monorepos (#5721)

### DIFF
--- a/internal/cli/wiztui/fold.go
+++ b/internal/cli/wiztui/fold.go
@@ -2,11 +2,13 @@
 //
 // fold.go is a Go port of the dashboard's per-repo progress folding
 // (webui-v2/src/lib/index-progress-fold.ts). It collapses the broker's
-// firehose of progress.Event records into exactly ONE row per repo, keyed by
-// repo_slug, with a monotonic phase so a stale lower phase never regresses a
-// more-advanced one. This is the model that fixes the dropped-repo display bug
-// in the CLI indexing view: instead of overwriting a single carriage-return
-// line (which dropped all-but-one repo), every repo renders as its own row.
+// firehose of progress.Event records into exactly ONE row per repo — or, for
+// a monorepo, one row per module — keyed by rowKey(repo_slug, module), with a
+// monotonic phase so a stale lower phase never regresses a more-advanced one.
+// This is the model that fixes the dropped-repo display bug in the CLI
+// indexing view: instead of overwriting a single carriage-return line (which
+// dropped all-but-one repo), every repo (or monorepo module) renders as its
+// own row.
 package wiztui
 
 import (
@@ -89,16 +91,30 @@ func (r Row) Terminal() bool {
 	return r.Phase == progress.PhaseDone || r.Phase == progress.PhaseError
 }
 
-// Fold collapses progress events into one row per repo. It is a value-semantics
-// fold: callers hold a map[string]Row keyed by repo slug and call Fold per
-// event. Stale (older-ts) events and lower-ordered phases never regress an
-// existing row; terminal rows are never pulled back to an in-flight phase by a
-// late module-scoped event. A faithful port of fold() in index-progress-fold.ts.
+// rowKey computes the row map key for an event: repoSlug alone for a plain
+// repo / whole-repo event (module == "" or module == repoSlug, e.g. fleet
+// indexing or a monorepo's repo-level phases), or "repoSlug/module" for a
+// true per-module event (monorepo per-file attribution) so each module gets
+// its own row instead of collapsing into the repo's row.
+func rowKey(repoSlug, module string) string {
+	if module == "" || module == repoSlug {
+		return repoSlug
+	}
+	return repoSlug + "/" + module
+}
+
+// Fold collapses progress events into one row per repo (or, for a monorepo,
+// one row per module). It is a value-semantics fold: callers hold a
+// map[string]Row keyed by rowKey(repoSlug, module) and call Fold per event.
+// Stale (older-ts) events and lower-ordered phases never regress an existing
+// row; terminal rows are never pulled back to an in-flight phase by a late
+// module-scoped event. A faithful port of fold() in index-progress-fold.ts,
+// extended with module-aware keying (#5751 monorepo one-row-per-module).
 func Fold(rows map[string]Row, e progress.Event) map[string]Row {
 	if rows == nil {
 		rows = map[string]Row{}
 	}
-	key := e.RepoSlug
+	key := rowKey(e.RepoSlug, e.Module)
 	existing, had := rows[key]
 
 	// Ignore stale events that predate what we already have for this row.

--- a/internal/cli/wiztui/fold_test.go
+++ b/internal/cli/wiztui/fold_test.go
@@ -10,6 +10,20 @@ func ev(slug, phase string, ts int64) progress.Event {
 	return progress.Event{RepoSlug: slug, Phase: phase, TS: ts}
 }
 
+// evMod builds a module-scoped progress event (monorepo per-file attribution).
+func evMod(slug, module, phase string, ts int64) progress.Event {
+	return progress.Event{RepoSlug: slug, Module: module, Phase: phase, TS: ts}
+}
+
+// rowKeys returns the map keys of rows, for failure messages.
+func rowKeys(rows map[string]Row) []string {
+	out := make([]string, 0, len(rows))
+	for k := range rows {
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestFold_MultipleReposManyRows is the dropped-repo regression: events for two
 // repos must yield two rows, not one. This is the core bug #5340 fixes.
 func TestFold_MultipleReposManyRows(t *testing.T) {
@@ -121,6 +135,82 @@ func TestRowsTerminal_GatesOnExpected(t *testing.T) {
 	}
 	if RowsTerminal(rows, 0) {
 		t.Error("terminal with unknown expected count — should defer")
+	}
+}
+
+// TestFold_MonorepoModulesGetSeparateRows is the monorepo module-collapse bug:
+// events for the SAME repo slug but DIFFERENT modules must yield one row PER
+// MODULE, not a single row for the whole repo (the bug this change fixes).
+func TestFold_MonorepoModulesGetSeparateRows(t *testing.T) {
+	rows := map[string]Row{}
+	for i, mod := range []string{"a", "b", "c"} {
+		rows = Fold(rows, evMod("mono", mod, progress.PhaseExtractAST, int64(i+1)))
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (one per module) — monorepo module-collapse bug: %v", len(rows), rowKeys(rows))
+	}
+	for _, mod := range []string{"a", "b", "c"} {
+		key := "mono/" + mod
+		r, ok := rows[key]
+		if !ok {
+			t.Fatalf("row %q missing; got keys %v", key, rowKeys(rows))
+		}
+		if r.RepoSlug != "mono" || r.Module != mod {
+			t.Errorf("row %q = {RepoSlug:%q Module:%q}, want {mono %q}", key, r.RepoSlug, r.Module, mod)
+		}
+	}
+}
+
+// TestFold_MonorepoModulesAdvanceIndependently: each module row's phase
+// advances on its own timeline — one module's phase must not bleed into
+// another's.
+func TestFold_MonorepoModulesAdvanceIndependently(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, evMod("mono", "a", progress.PhaseWriteGraph, 1))
+	rows = Fold(rows, evMod("mono", "b", progress.PhaseScan, 2))
+	if rows["mono/a"].Phase != progress.PhaseWriteGraph {
+		t.Errorf("module a phase = %q, want %q", rows["mono/a"].Phase, progress.PhaseWriteGraph)
+	}
+	if rows["mono/b"].Phase != progress.PhaseScan {
+		t.Errorf("module b phase = %q, want %q", rows["mono/b"].Phase, progress.PhaseScan)
+	}
+}
+
+// TestFold_MonorepoModuleStaleTSIgnoredIndependently: monotonic/stale-TS
+// guarantees hold PER MODULE KEY, and don't cross-contaminate sibling modules.
+func TestFold_MonorepoModuleStaleTSIgnoredIndependently(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, evMod("mono", "a", progress.PhaseExtractAST, 10))
+	before := rows["mono/a"]
+	rows = Fold(rows, evMod("mono", "a", progress.PhaseScan, 5)) // stale ts for module a
+	if rows["mono/a"] != before {
+		t.Errorf("stale module event mutated row: %+v -> %+v", before, rows["mono/a"])
+	}
+	rows = Fold(rows, evMod("mono", "b", progress.PhaseScan, 6))
+	if rows["mono/b"].Phase != progress.PhaseScan {
+		t.Errorf("module b phase = %q, want %q", rows["mono/b"].Phase, progress.PhaseScan)
+	}
+}
+
+// TestFold_FleetRepoRowsUnaffectedByModuleKeying is the CRITICAL regression
+// guard: a multi-repo fleet stream (Module == "" or Module == RepoSlug — no
+// true sub-module reporting) must still collapse to exactly one row per repo.
+// The existing fleet UX this change must not disturb.
+func TestFold_FleetRepoRowsUnaffectedByModuleKeying(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, evMod("frontend", "", progress.PhaseScan, 1))
+	rows = Fold(rows, evMod("backend", "backend", progress.PhaseScan, 2)) // Module==RepoSlug variant
+	rows = Fold(rows, evMod("mobile", "", progress.PhaseScan, 3))
+	rows = Fold(rows, evMod("frontend", "", progress.PhaseExtractAST, 4))
+	rows = Fold(rows, evMod("backend", "backend", progress.PhaseExtractAST, 5))
+
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (frontend, backend, mobile) — fleet regression: %v", len(rows), rowKeys(rows))
+	}
+	for _, slug := range []string{"frontend", "backend", "mobile"} {
+		if _, ok := rows[slug]; !ok {
+			t.Errorf("fleet row %q missing (keyed wrong): %v", slug, rowKeys(rows))
+		}
 	}
 }
 

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -57,12 +57,16 @@ func newIndexView(group string, expectedRepos int) indexView {
 	}
 }
 
-// foldEvent folds a single broker event into the per-repo rows. A group-scoped
-// event (RepoSlug == group, the cross-repo links/flows pass) is NOT a repo: it
-// updates the overall group phase instead of spawning a spurious group row
-// (#5340). Per-repo events (backend, frontend, …) always fold into rows.
+// foldEvent folds a single broker event into the per-repo (or, for a
+// monorepo, per-module) rows. A group-scoped event (RepoSlug == group and no
+// Module, the cross-repo links/flows pass) is NOT a repo: it updates the
+// overall group phase instead of spawning a spurious group row (#5340).
+// Per-repo events (backend, frontend, …) and per-module monorepo events
+// always fold into rows — the Module check keeps a monorepo whose single
+// repo shares its slug with the group name (a common case) from having its
+// module ticks misrouted into the group-phase guard.
 func (v *indexView) foldEvent(e prog.Event) {
-	if v.group != "" && e.RepoSlug == v.group {
+	if v.group != "" && e.RepoSlug == v.group && e.Module == "" {
 		// Monotonic: never regress the group phase to a coarser one.
 		if phaseRank(e.Phase) >= phaseRank(v.groupPhase) {
 			v.groupPhase = e.Phase
@@ -151,7 +155,11 @@ var (
 func (v indexView) renderRow(r Row, spinnerFrame string) string {
 	const slugW = 22
 
-	name := truncate(r.RepoSlug, slugW)
+	label := r.RepoSlug
+	if r.Module != "" {
+		label = r.RepoSlug + "/" + r.Module
+	}
+	name := truncate(label, slugW)
 	name = rowSlugStyle.Render(fmt.Sprintf("%-*s", slugW, name))
 
 	var glyph, phase string

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -135,6 +135,49 @@ func TestIndexView_GroupEventFoldedRegardlessOfOrder(t *testing.T) {
 	}
 }
 
+// TestIndexView_MonorepoModulesRenderSeparateRows exercises the module-row fix
+// end-to-end through indexView: a monorepo emits Module-stamped events under
+// the SAME RepoSlug, and the view must render one row per module (not one
+// collapsed repo row) — the monorepo counterpart of
+// TestIndexView_RendersOneRowPerRepo.
+func TestIndexView_MonorepoModulesRenderSeparateRows(t *testing.T) {
+	v := newIndexView("mono", 3)
+	v.width = 100
+	for _, mod := range []string{"a", "b", "c"} {
+		v.foldEvent(progress.Event{RepoSlug: "mono", Module: mod, Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10, TS: 1})
+	}
+	if len(v.rows) != 3 {
+		t.Fatalf("got %d rows, want 3 (one per module): %v", len(v.rows), keysOf(v.rows))
+	}
+	out := v.view()
+	for _, mod := range []string{"a", "b", "c"} {
+		if !strings.Contains(out, "mono/"+mod) {
+			t.Errorf("module row %q missing from view:\n%s", mod, out)
+		}
+	}
+	pct := AggregateProgress(v.rows, v.expectedRepos)
+	if pct <= 0 || pct > 1 {
+		t.Errorf("aggregate progress out of range: %v", pct)
+	}
+}
+
+// TestIndexView_MonorepoFinalizeRowsMarksAllModulesDone asserts finalizeRows
+// advances EVERY module row to Done, not just a single collapsed repo row.
+func TestIndexView_MonorepoFinalizeRowsMarksAllModulesDone(t *testing.T) {
+	v := newIndexView("mono", 2)
+	v.foldEvent(progress.Event{RepoSlug: "mono", Module: "a", Phase: progress.PhaseBuildCommunities, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: "mono", Module: "b", Phase: progress.PhaseDone, TS: 2})
+
+	v.finalizeRows()
+
+	for _, mod := range []string{"a", "b"} {
+		r := v.rows["mono/"+mod]
+		if r.Phase != progress.PhaseDone {
+			t.Errorf("module %q phase = %q, want Done after finalizeRows", mod, r.Phase)
+		}
+	}
+}
+
 func keysOf(rows map[string]Row) []string {
 	out := make([]string, 0, len(rows))
 	for k := range rows {


### PR DESCRIPTION
## What
Renders one wizard progress **row per module** for a monorepo, mirroring the one-row-per-repo behavior a multi-repo fleet already shows.

## Change
- `internal/cli/wiztui/fold.go`: `Fold` now keys the row map on a composite `rowKey(repoSlug, module)` — `repoSlug` for plain-repo/fleet/whole-repo events (`module==""` or `module==repoSlug`, so fleet behavior is byte-identical), else `repoSlug/module` for a true per-module row. Monotonic/stale-TS/terminal guarantees preserved per-key.
- `internal/cli/wiztui/indexview.go`: `renderRow` labels module rows `repo/module`; group-scoped-event guard tightened to `RepoSlug==group && Module==""` — fixes a latent bug where a solo monorepo whose repo slug equals the group name had its per-module ticks misrouted into the group-phase path and never became rows.

## Review
Independent adversarial review APPROVED. Verified: the group-guard change cannot regress the cross-repo links/flows pass (only `Tick` ever stamps `Module`, and that pass emits only `Phase`/`Done`/`Fail`), so #5340's group-row exclusion is intact; denominator/terminal can't stall (completion is RPC-driven via `finalizeRows`); fleet path byte-identical. Tests red→green, `-race` clean (49 tests).

## Known follow-ups (non-blocking, tracked)
- Module rows advance during the extraction phase; later resolve/write phases aren't module-attributed yet (aggregate sits then jumps). Strictly better than today (main shows zero rows). To be smoothed in the emission work.
- `rowKey` slash-composite is theoretically ambiguous for slugs/modules containing `/` (contrived; slugs are basenames).

Refs #5721, #5729