### PR TITLE
feat(progress): NDJSON progress-sidecar data-plane (split-mode bridge foundation) (#5729)

### DIFF
--- a/internal/progress/sidecar.go
+++ b/internal/progress/sidecar.go
@@ -1,0 +1,488 @@
+package progress
+
+// Progress sidecar data-plane (ADR-0024 split-mode progress bridge).
+//
+// In split mode the engine and serve run as separate processes, each with its
+// own in-memory Broker, so live index progress emitted by the engine never
+// reaches serve's dashboard SSE. This file is the reusable, process-boundary-
+// crossing primitive that a later PR will wire in to bridge them: the engine
+// tees its Broker into a SidecarWriter that appends a per-group NDJSON file
+// under GRAFEL_HOME/progress; serve tails that file with a SidecarReader and
+// republishes into its own Broker.
+//
+// This package builds ONLY the library pieces + tests. Nothing here is wired
+// into cmd/grafel or internal/daemon yet — it is intentionally dead code until
+// the follow-up.
+//
+// Design mirrors internal/progress.BufferedPublisher (non-blocking, drop-oldest)
+// and internal/statusfile (deterministic GRAFEL_HOME-derived, hashed path so a
+// reader needs zero coordination with the writer).
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+const (
+	// progressSubdir is the directory under GRAFEL_HOME holding one NDJSON file
+	// per group.
+	progressSubdir = "progress"
+
+	// defaultFlushInterval is how often the background goroutine flushes the
+	// coalesced latest-state map. It bounds writes to ~run_duration/interval
+	// regardless of event volume — a 19k-file monorepo must not produce 19k
+	// fsyncs.
+	defaultFlushInterval = 200 * time.Millisecond
+
+	// defaultSidecarMaxBytes is the size cap at which the writer compacts the
+	// group file (coalesce to latest-per-key + retained terminals). Overridable
+	// via GRAFEL_PROGRESS_SIDECAR_MAX_BYTES.
+	defaultSidecarMaxBytes int64 = 4 << 20 // 4 MiB
+
+	// defaultSidecarBuffer is the buffered-channel capacity between Publish and
+	// the flush goroutine. Drop-oldest applies once full.
+	defaultSidecarBuffer = 256
+)
+
+// SidecarLine is the on-disk NDJSON schema for one progress notification — a
+// thin superset of the fields of Event that a live dashboard needs. One JSON
+// object per line. Fields are additive; a reader tolerates older/newer files.
+type SidecarLine struct {
+	// Seq is a per-file monotonic sequence number assigned at flush time. It
+	// lets a reader detect gaps and lets compaction preserve write order.
+	Seq int64 `json:"seq"`
+
+	GroupSlug string `json:"group_slug"`
+	RepoSlug  string `json:"repo_slug"`
+	Module    string `json:"module,omitempty"`
+
+	Phase      string `json:"phase"`
+	FilesDone  int    `json:"files_done"`
+	FilesTotal int    `json:"files_total"`
+	Entities   int    `json:"entities"`
+
+	CurrentFile string `json:"current_file,omitempty"`
+
+	TS int64 `json:"ts"`
+
+	// Done is true for a terminal (PhaseDone / PhaseError) line — a cheap bool
+	// so a reader can flag completion without re-classifying Phase. Phase
+	// remains authoritative on reconstruction.
+	Done  bool   `json:"done"`
+	Error string `json:"error,omitempty"`
+}
+
+// lineFromEvent projects an Event onto the sidecar wire schema.
+func lineFromEvent(e Event) SidecarLine {
+	return SidecarLine{
+		GroupSlug:   e.GroupSlug,
+		RepoSlug:    e.RepoSlug,
+		Module:      e.Module,
+		Phase:       e.Phase,
+		FilesDone:   e.FilesDone,
+		FilesTotal:  e.FilesTotal,
+		Entities:    e.EntitiesSoFar,
+		CurrentFile: e.CurrentFile,
+		TS:          e.TS,
+		Done:        isTerminalPhase(e.Phase),
+		Error:       e.Error,
+	}
+}
+
+// toEvent reconstructs the Event carried by a sidecar line. Only the fields the
+// line schema carries are recovered; the rest are zero.
+func (l SidecarLine) toEvent() Event {
+	return Event{
+		GroupSlug:     l.GroupSlug,
+		RepoSlug:      l.RepoSlug,
+		Module:        l.Module,
+		Phase:         l.Phase,
+		FilesDone:     l.FilesDone,
+		FilesTotal:    l.FilesTotal,
+		EntitiesSoFar: l.Entities,
+		CurrentFile:   l.CurrentFile,
+		TS:            l.TS,
+		Error:         l.Error,
+	}
+}
+
+// coalesceKey is the (repo, module) identity a line coalesces on: within a
+// flush interval only the latest line per key survives.
+func (l SidecarLine) coalesceKey() string {
+	return l.RepoSlug + "|" + l.Module
+}
+
+// isTerminal reports whether a line is a terminal (done/error) line.
+func (l SidecarLine) isTerminal() bool {
+	return l.Done || isTerminalPhase(l.Phase)
+}
+
+// SidecarPath returns the deterministic on-disk NDJSON path for groupSlug,
+// GRAFEL_HOME/progress/<sha256(groupSlug)[:16]>.ndjson. It hashes the slug with
+// the SAME scheme internal/statusfile.PathFor uses to hash repo paths (sha256,
+// hex, first 16 chars) and resolves GRAFEL_HOME via the same registry.HomeDir
+// helper, so a future reader derives the identical path with zero coordination.
+func SidecarPath(groupSlug string) (string, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return "", fmt.Errorf("progress: resolve home dir: %w", err)
+	}
+	sum := sha256.Sum256([]byte(groupSlug))
+	hash := hex.EncodeToString(sum[:])[:16]
+	return filepath.Join(home, progressSubdir, hash+".ndjson"), nil
+}
+
+// sidecarMaxBytes returns the effective compaction size cap, overridable via
+// GRAFEL_PROGRESS_SIDECAR_MAX_BYTES.
+func sidecarMaxBytes() int64 {
+	if v := os.Getenv("GRAFEL_PROGRESS_SIDECAR_MAX_BYTES"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultSidecarMaxBytes
+}
+
+// SidecarOption configures a SidecarWriter.
+type SidecarOption func(*SidecarWriter)
+
+// WithFlushInterval overrides the coalescing flush interval.
+func WithFlushInterval(d time.Duration) SidecarOption {
+	return func(w *SidecarWriter) {
+		if d > 0 {
+			w.flushInterval = d
+		}
+	}
+}
+
+// WithMaxBytes overrides the compaction size cap.
+func WithMaxBytes(n int64) SidecarOption {
+	return func(w *SidecarWriter) {
+		if n > 0 {
+			w.maxBytes = n
+		}
+	}
+}
+
+// WithBufferSize overrides the Publish→flush channel capacity.
+func WithBufferSize(n int) SidecarOption {
+	return func(w *SidecarWriter) {
+		if n > 0 {
+			w.bufSize = n
+		}
+	}
+}
+
+// SidecarWriter is a non-blocking progress.Publisher that appends coalesced
+// NDJSON lines to a per-group file. Publish pushes to a buffered channel
+// (drop-oldest when full, mirroring BufferedPublisher); a single background
+// goroutine coalesces same-key events, flushes on a ticker, flushes terminal
+// events immediately, assigns a monotonic seq per line, and compacts the file
+// when it crosses the size cap. Publish never blocks the indexer.
+type SidecarWriter struct {
+	groupSlug     string
+	path          string
+	flushInterval time.Duration
+	maxBytes      int64
+	bufSize       int
+
+	ch chan Event
+
+	closeOnce sync.Once
+	quit      chan struct{}
+	stopped   chan struct{}
+
+	// seq is touched only by the flush goroutine.
+	seq int64
+}
+
+// NewSidecarWriter constructs a writer for groupSlug and TRUNCATES the group
+// file so a new run starts a fresh stream (rotation). The background flush
+// goroutine starts immediately.
+func NewSidecarWriter(groupSlug string, opts ...SidecarOption) (*SidecarWriter, error) {
+	path, err := SidecarPath(groupSlug)
+	if err != nil {
+		return nil, err
+	}
+	w := &SidecarWriter{
+		groupSlug:     groupSlug,
+		path:          path,
+		flushInterval: defaultFlushInterval,
+		maxBytes:      sidecarMaxBytes(),
+		bufSize:       defaultSidecarBuffer,
+		quit:          make(chan struct{}),
+		stopped:       make(chan struct{}),
+	}
+	for _, opt := range opts {
+		opt(w)
+	}
+	w.ch = make(chan Event, w.bufSize)
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("progress: mkdir %s: %w", filepath.Dir(path), err)
+	}
+	// Truncate on a new run (rotation/retention): the previous run's lines are
+	// discarded so a tailing reader starting at offset 0 sees only this run.
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		return nil, fmt.Errorf("progress: truncate %s: %w", path, err)
+	}
+
+	go w.run()
+	return w, nil
+}
+
+// Path returns the on-disk NDJSON path this writer appends to.
+func (w *SidecarWriter) Path() string { return w.path }
+
+// Publish enqueues e without blocking. If the buffer is full the oldest queued
+// event is discarded before enqueuing the new one (drop-oldest), matching
+// BufferedPublisher's backpressure discipline so the indexer never stalls.
+func (w *SidecarWriter) Publish(e Event) {
+	select {
+	case w.ch <- e:
+	default:
+		select {
+		case <-w.ch:
+		default:
+		}
+		select {
+		case w.ch <- e:
+		default:
+		}
+	}
+}
+
+// Reset truncates the group file, starting a fresh stream without tearing down
+// the goroutine. Safe to call between runs that reuse the same writer.
+func (w *SidecarWriter) Reset() error {
+	return os.WriteFile(w.path, nil, 0o600)
+}
+
+// Close flushes any buffered/coalesced state and stops the background
+// goroutine, joining it before returning (no goroutine leak).
+func (w *SidecarWriter) Close() error {
+	w.closeOnce.Do(func() { close(w.quit) })
+	<-w.stopped
+	return nil
+}
+
+// run is the single flush goroutine. It owns all file writes and the seq
+// counter, so Publish (channel send only) is race-free against it.
+func (w *SidecarWriter) run() {
+	defer close(w.stopped)
+
+	ticker := time.NewTicker(w.flushInterval)
+	defer ticker.Stop()
+
+	latest := make(map[string]SidecarLine)
+	var terminals []SidecarLine
+
+	flush := func() {
+		w.flush(latest, terminals)
+		latest = make(map[string]SidecarLine)
+		terminals = terminals[:0]
+	}
+
+	ingest := func(e Event) {
+		l := lineFromEvent(e)
+		if l.isTerminal() {
+			terminals = append(terminals, l)
+			// Terminal events flush immediately (also carrying any pending
+			// coalesced non-terminal state) so completion is never delayed by
+			// the ticker.
+			flush()
+			return
+		}
+		latest[l.coalesceKey()] = l
+	}
+
+	for {
+		select {
+		case e := <-w.ch:
+			ingest(e)
+		case <-ticker.C:
+			flush()
+		case <-w.quit:
+			// Drain anything still buffered, then flush and exit.
+			for {
+				select {
+				case e := <-w.ch:
+					ingest(e)
+				default:
+					flush()
+					return
+				}
+			}
+		}
+	}
+}
+
+// flush appends the coalesced latest-per-key lines (in stable key order)
+// followed by the pending terminal lines, assigning a monotonic seq to each.
+// It then compacts the file if it has grown past the size cap.
+func (w *SidecarWriter) flush(latest map[string]SidecarLine, terminals []SidecarLine) {
+	if len(latest) == 0 && len(terminals) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(latest))
+	for k := range latest {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var buf bytes.Buffer
+	emit := func(l SidecarLine) {
+		w.seq++
+		l.Seq = w.seq
+		b, err := json.Marshal(l)
+		if err != nil {
+			return
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	for _, k := range keys {
+		emit(latest[k])
+	}
+	for _, l := range terminals {
+		emit(l)
+	}
+	if buf.Len() == 0 {
+		return
+	}
+
+	f, err := os.OpenFile(w.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return
+	}
+	_, _ = f.Write(buf.Bytes())
+	_ = f.Close()
+
+	if st, err := os.Stat(w.path); err == nil && st.Size() > w.maxBytes {
+		// Best-effort: a failed compaction just leaves the (still-correct,
+		// larger) file in place.
+		_ = compactSidecarFile(w.path)
+	}
+}
+
+// compactSidecarFile rewrites path in place (tmp+rename) coalescing it to the
+// latest line per (repo, module) key plus every terminal line, preserving seq
+// order. This bounds a long run's file to O(#keys) regardless of tick volume.
+// A torn last line is tolerated (skipped). Non-existent file is a no-op.
+func compactSidecarFile(path string) error {
+	lines, _, err := readSidecarLines(path, 0)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+
+	latest := make(map[string]SidecarLine)   // non-terminal, latest per key
+	terminal := make(map[string]SidecarLine) // terminal, latest per key
+	for _, l := range lines {
+		if l.isTerminal() {
+			terminal[l.coalesceKey()] = l
+		} else {
+			latest[l.coalesceKey()] = l
+		}
+	}
+
+	kept := make([]SidecarLine, 0, len(latest)+len(terminal))
+	for k, l := range latest {
+		// A terminal line for the same key supersedes a non-terminal one.
+		if _, done := terminal[k]; done {
+			continue
+		}
+		kept = append(kept, l)
+	}
+	for _, l := range terminal {
+		kept = append(kept, l)
+	}
+	// Preserve seq (write) order.
+	sort.Slice(kept, func(i, j int) bool { return kept[i].Seq < kept[j].Seq })
+
+	var buf bytes.Buffer
+	for _, l := range kept {
+		b, err := json.Marshal(l)
+		if err != nil {
+			continue
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+
+	dir := filepath.Dir(path)
+	tmpf, err := os.CreateTemp(dir, filepath.Base(path)+".compact-*")
+	if err != nil {
+		return err
+	}
+	tmp := tmpf.Name()
+	if _, err := tmpf.Write(buf.Bytes()); err != nil {
+		_ = tmpf.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := tmpf.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// PruneTerminalSidecars deletes group files whose stream has terminated (last
+// complete line is a terminal event) AND whose mtime is older than maxAge. A
+// live (non-terminal) or fresh file is left untouched. Returns the number of
+// files deleted. Best-effort: a single unreadable file is skipped, not fatal.
+func PruneTerminalSidecars(maxAge time.Duration) (int, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return 0, fmt.Errorf("progress: resolve home dir: %w", err)
+	}
+	dir := filepath.Join(home, progressSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	cutoff := time.Now().Add(-maxAge)
+	deleted := 0
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".ndjson" {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		info, err := e.Info()
+		if err != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		lines, _, err := readSidecarLines(full, 0)
+		if err != nil || len(lines) == 0 {
+			continue
+		}
+		if !lines[len(lines)-1].isTerminal() {
+			continue
+		}
+		if err := os.Remove(full); err == nil {
+			deleted++
+		}
+	}
+	return deleted, nil
+}

--- a/internal/progress/sidecar.go
+++ b/internal/progress/sidecar.go
@@ -185,11 +185,21 @@ func WithBufferSize(n int) SidecarOption {
 }
 
 // SidecarWriter is a non-blocking progress.Publisher that appends coalesced
-// NDJSON lines to a per-group file. Publish pushes to a buffered channel
-// (drop-oldest when full, mirroring BufferedPublisher); a single background
-// goroutine coalesces same-key events, flushes on a ticker, flushes terminal
-// events immediately, assigns a monotonic seq per line, and compacts the file
-// when it crosses the size cap. Publish never blocks the indexer.
+// NDJSON lines to a per-group file. Non-terminal events push to a buffered
+// channel (drop-oldest when full, mirroring BufferedPublisher); terminal events
+// take a separate guaranteed path (see Publish) so they are never lost to a
+// buffer eviction. A single background goroutine coalesces same-key events,
+// flushes on a ticker, flushes terminal events immediately, assigns a monotonic
+// seq per line, and compacts the file when it crosses the size cap. Publish
+// never blocks the indexer.
+//
+// STICKY-TERMINAL contract for the consumer: a terminal (done/error) line is
+// sticky per (repo, module) key — compaction lets a terminal supersede a
+// non-terminal for the same key. A stale non-terminal event arriving AFTER a
+// terminal (e.g. a slow repo's late tick) can still transiently flush a
+// post-terminal non-terminal line; that is safe ONLY because the tailer's fold
+// is monotonic — a consumer must treat a key it has already seen terminate as
+// done and ignore any later non-terminal line for it.
 type SidecarWriter struct {
 	groupSlug     string
 	path          string
@@ -198,6 +208,21 @@ type SidecarWriter struct {
 	bufSize       int
 
 	ch chan Event
+
+	// pendingTerm holds terminal (done/error) lines routed OUTSIDE the lossy
+	// drop-oldest channel. A terminal is emitted exactly once per repo and must
+	// never be lost to a buffer eviction (a stuck wizard bar is the whole bug
+	// this feature fixes), so Publish appends it here under mu and pokes wake;
+	// the flush goroutine drains it on every flush. Guaranteed delivery.
+	mu          sync.Mutex
+	pendingTerm []SidecarLine
+	wake        chan struct{}
+
+	// reset carries a Reset request into the flush goroutine so the goroutine
+	// (sole owner of the file, seq, and coalescing maps) performs truncation
+	// and clears its in-memory pending state — no cross-goroutine data race and
+	// a genuinely fresh stream.
+	reset chan chan error
 
 	closeOnce sync.Once
 	quit      chan struct{}
@@ -221,6 +246,8 @@ func NewSidecarWriter(groupSlug string, opts ...SidecarOption) (*SidecarWriter, 
 		flushInterval: defaultFlushInterval,
 		maxBytes:      sidecarMaxBytes(),
 		bufSize:       defaultSidecarBuffer,
+		wake:          make(chan struct{}, 1),
+		reset:         make(chan chan error),
 		quit:          make(chan struct{}),
 		stopped:       make(chan struct{}),
 	}
@@ -245,10 +272,34 @@ func NewSidecarWriter(groupSlug string, opts ...SidecarOption) (*SidecarWriter, 
 // Path returns the on-disk NDJSON path this writer appends to.
 func (w *SidecarWriter) Path() string { return w.path }
 
-// Publish enqueues e without blocking. If the buffer is full the oldest queued
-// event is discarded before enqueuing the new one (drop-oldest), matching
-// BufferedPublisher's backpressure discipline so the indexer never stalls.
+// Publish enqueues e without blocking.
+//
+// Terminal events (PhaseDone / PhaseError) take a GUARANTEED path: they are
+// appended to a mutex-guarded pending slice the flush goroutine always drains,
+// never the lossy channel. This is the fix for the terminal-drop bug — a
+// terminal that became the FIFO head could otherwise be evicted by drop-oldest
+// once >bufSize newer events piled up behind a stalled goroutine (e.g. a fast
+// repo finishing while slow repos keep streaming), leaving the wizard bar stuck
+// forever.
+//
+// Non-terminal events go through the buffered channel with drop-oldest when
+// full, matching BufferedPublisher's backpressure discipline so the indexer
+// never stalls. (Coalescing means a dropped mid-stream tick is harmless — the
+// next tick carries the latest state.)
 func (w *SidecarWriter) Publish(e Event) {
+	if isTerminalPhase(e.Phase) {
+		l := lineFromEvent(e)
+		w.mu.Lock()
+		w.pendingTerm = append(w.pendingTerm, l)
+		w.mu.Unlock()
+		// Poke the goroutine to flush promptly; non-blocking because wake has a
+		// capacity of 1 and a pending poke already guarantees a wake-up.
+		select {
+		case w.wake <- struct{}{}:
+		default:
+		}
+		return
+	}
 	select {
 	case w.ch <- e:
 	default:
@@ -263,10 +314,21 @@ func (w *SidecarWriter) Publish(e Event) {
 	}
 }
 
-// Reset truncates the group file, starting a fresh stream without tearing down
-// the goroutine. Safe to call between runs that reuse the same writer.
+// Reset truncates the group file and clears the flush goroutine's in-memory
+// coalescing state and seq counter, starting a genuinely fresh stream without
+// tearing down the goroutine. The truncation and state clear happen INSIDE the
+// goroutine (which solely owns the file, seq, and maps) so there is no data
+// race and no stale pending line leaks into the new run. Safe to call between
+// runs that reuse the same writer.
 func (w *SidecarWriter) Reset() error {
-	return os.WriteFile(w.path, nil, 0o600)
+	done := make(chan error, 1)
+	select {
+	case w.reset <- done:
+		return <-done
+	case <-w.stopped:
+		// Goroutine already gone (post-Close): truncate directly as a fallback.
+		return os.WriteFile(w.path, nil, 0o600)
+	}
 }
 
 // Close flushes any buffered/coalesced state and stops the background
@@ -286,35 +348,85 @@ func (w *SidecarWriter) run() {
 	defer ticker.Stop()
 
 	latest := make(map[string]SidecarLine)
-	var terminals []SidecarLine
 
+	// flush drains the guaranteed pending-terminal slice (populated by Publish
+	// under mu) together with the coalesced latest-per-key state and writes them
+	// in one append.
 	flush := func() {
-		w.flush(latest, terminals)
+		w.mu.Lock()
+		terms := w.pendingTerm
+		w.pendingTerm = nil
+		w.mu.Unlock()
+		w.flush(latest, terms)
 		latest = make(map[string]SidecarLine)
-		terminals = terminals[:0]
 	}
 
 	ingest := func(e Event) {
 		l := lineFromEvent(e)
 		if l.isTerminal() {
-			terminals = append(terminals, l)
-			// Terminal events flush immediately (also carrying any pending
-			// coalesced non-terminal state) so completion is never delayed by
-			// the ticker.
+			// Terminals normally arrive via pendingTerm (Publish routes them
+			// there); tolerate one that reached the channel anyway and give it
+			// the same guaranteed, flush-now treatment.
+			w.mu.Lock()
+			w.pendingTerm = append(w.pendingTerm, l)
+			w.mu.Unlock()
 			flush()
 			return
 		}
 		latest[l.coalesceKey()] = l
 	}
 
+	// drainChannel ingests every event currently buffered on the channel
+	// (non-blocking). Used before a terminal flush so the terminal frame
+	// includes the non-terminal ticks published just before it, and on quit.
+	drainChannel := func() {
+		for {
+			select {
+			case e := <-w.ch:
+				ingest(e)
+			default:
+				return
+			}
+		}
+	}
+
 	for {
 		select {
 		case e := <-w.ch:
 			ingest(e)
+		case <-w.wake:
+			// A terminal was routed through pendingTerm. Drain any non-terminals
+			// buffered before it so they share the terminal's flush, then flush
+			// immediately so completion is never delayed by the ticker.
+			drainChannel()
+			flush()
+		case done := <-w.reset:
+			// Truncate + clear ALL in-memory state inside the goroutine that
+			// owns the file, seq, and maps: a genuinely fresh stream. This
+			// includes draining any still-buffered non-terminal events from the
+			// channel — otherwise events queued before Reset would ingest after
+			// it and leak stale state into the new run.
+		drain:
+			for {
+				select {
+				case <-w.ch:
+				default:
+					break drain
+				}
+			}
+			err := os.WriteFile(w.path, nil, 0o600)
+			latest = make(map[string]SidecarLine)
+			w.mu.Lock()
+			w.pendingTerm = nil
+			w.mu.Unlock()
+			w.seq = 0
+			done <- err
 		case <-ticker.C:
 			flush()
 		case <-w.quit:
-			// Drain anything still buffered, then flush and exit.
+			// Drain anything still buffered, then flush and exit. The final
+			// flush also drains any pending terminal so a Done published just
+			// before Close is never lost.
 			for {
 				select {
 				case e := <-w.ch:

--- a/internal/progress/sidecar_reader.go
+++ b/internal/progress/sidecar_reader.go
@@ -1,0 +1,112 @@
+package progress
+
+// SidecarReader is the serve-side tail primitive for a group's progress NDJSON
+// file. It reads all COMPLETE lines from a byte offset, reconstructs Events,
+// and reports the new offset so it can be called repeatedly (append-aware) to
+// pick up newly-appended lines. It tolerates a torn/partial trailing line — the
+// classic crash-safety hazard of an append-only file being read concurrently.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+)
+
+// SidecarReader reads a single group's progress sidecar file.
+type SidecarReader struct {
+	path string
+}
+
+// NewSidecarReader constructs a reader for groupSlug, deriving the identical
+// on-disk path a SidecarWriter for the same slug writes to.
+func NewSidecarReader(groupSlug string) (*SidecarReader, error) {
+	path, err := SidecarPath(groupSlug)
+	if err != nil {
+		return nil, err
+	}
+	return &SidecarReader{path: path}, nil
+}
+
+// Path returns the on-disk NDJSON path this reader tails.
+func (r *SidecarReader) Path() string { return r.path }
+
+// ReadFrom reads every complete line starting at byte offset, reconstructs the
+// Events, and returns the offset to resume from next time. Only whole lines
+// (terminated by '\n') are consumed: a trailing partial line — a writer's
+// in-flight append or a torn crash tail — is left unconsumed so the returned
+// offset points just past the last complete line, and a later call picks the
+// rest up once it is completed. A complete line that fails json.Unmarshal is
+// discarded (and its bytes skipped) rather than failing the whole read.
+//
+// A non-existent file is not an error: it yields (nil, offset, nil), the normal
+// "writer hasn't started yet" state for a poll-safe tailer.
+func (r *SidecarReader) ReadFrom(offset int64) ([]Event, int64, error) {
+	lines, newOffset, err := readSidecarLines(r.path, offset)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, offset, nil
+		}
+		return nil, offset, err
+	}
+	if len(lines) == 0 {
+		return nil, newOffset, nil
+	}
+	events := make([]Event, 0, len(lines))
+	for _, l := range lines {
+		events = append(events, l.toEvent())
+	}
+	return events, newOffset, nil
+}
+
+// ReadAll reads the whole file from the start.
+func (r *SidecarReader) ReadAll() ([]Event, error) {
+	evs, _, err := r.ReadFrom(0)
+	return evs, err
+}
+
+// readSidecarLines is the shared low-level parse: open path, read from offset,
+// split into complete newline-terminated lines, json.Unmarshal each into a
+// SidecarLine (skipping any that fail), and return the parsed lines plus the
+// offset just past the last complete line consumed. The trailing partial line
+// (no newline) is NOT consumed and NOT included in newOffset.
+func readSidecarLines(path string, offset int64) ([]SidecarLine, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, offset, err
+	}
+	defer f.Close()
+
+	if offset > 0 {
+		if _, err := f.Seek(offset, 0); err != nil {
+			return nil, offset, err
+		}
+	}
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return nil, offset, err
+	}
+
+	// Only bytes up to and including the final newline form complete lines.
+	lastNL := bytes.LastIndexByte(data, '\n')
+	if lastNL < 0 {
+		// No complete line available from this offset (only a partial tail).
+		return nil, offset, nil
+	}
+	complete := data[:lastNL+1]
+	newOffset := offset + int64(len(complete))
+
+	var out []SidecarLine
+	for _, raw := range bytes.Split(complete, []byte{'\n'}) {
+		if len(bytes.TrimSpace(raw)) == 0 {
+			continue
+		}
+		var l SidecarLine
+		if err := json.Unmarshal(raw, &l); err != nil {
+			// Discard a corrupt/torn complete line, continue (crash-safety).
+			continue
+		}
+		out = append(out, l)
+	}
+	return out, newOffset, nil
+}

--- a/internal/progress/sidecar_reader.go
+++ b/internal/progress/sidecar_reader.go
@@ -39,6 +39,17 @@ func (r *SidecarReader) Path() string { return r.path }
 // rest up once it is completed. A complete line that fails json.Unmarshal is
 // discarded (and its bytes skipped) rather than failing the whole read.
 //
+// TRUNCATION / SHRINK HANDLING: if the file is now SMALLER than offset — the
+// writer truncated it for a new run (NewSidecarWriter / Reset) or rewrote it
+// via compaction — the read transparently restarts from offset 0 and returns
+// the whole current file. This is surfaced to the caller: the returned offset
+// will be LESS than the offset passed in, which signals "the stream reset;
+// discard any prior fold state and re-seed from these events." Replay-from-0 is
+// safe because the fold the tailer applies is monotonic/idempotent — re-reading
+// the current file re-derives the current dashboard state. Without this a
+// tailer holding a stale large offset would seek past EOF forever, miss the
+// entire new run, then resume mid-line on garbage once the file regrew.
+//
 // A non-existent file is not an error: it yields (nil, offset, nil), the normal
 // "writer hasn't started yet" state for a poll-safe tailer.
 func (r *SidecarReader) ReadFrom(offset int64) ([]Event, int64, error) {
@@ -77,6 +88,16 @@ func readSidecarLines(path string, offset int64) ([]SidecarLine, int64, error) {
 	}
 	defer f.Close()
 
+	// Detect truncation/compaction: if the file is now smaller than the caller's
+	// saved offset, the writer reset the stream (new run) or compacted it below
+	// our position. Restart from 0 and replay the whole current file — the fold
+	// is idempotent so this re-derives current state. Returning a smaller offset
+	// than we were given is the caller's signal to discard prior fold state.
+	if offset > 0 {
+		if st, statErr := f.Stat(); statErr == nil && offset > st.Size() {
+			offset = 0
+		}
+	}
 	if offset > 0 {
 		if _, err := f.Seek(offset, 0); err != nil {
 			return nil, offset, err

--- a/internal/progress/sidecar_test.go
+++ b/internal/progress/sidecar_test.go
@@ -1,0 +1,592 @@
+package progress
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// setHome points GRAFEL_HOME at a fresh temp dir for the duration of a test so
+// sidecar files never touch the real ~/.grafel.
+func setHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GRAFEL_HOME", dir)
+	return dir
+}
+
+// drainReader reads every complete line currently on disk for a group and
+// returns the reconstructed events.
+func drainReader(t *testing.T, groupSlug string) []Event {
+	t.Helper()
+	r, err := NewSidecarReader(groupSlug)
+	if err != nil {
+		t.Fatalf("NewSidecarReader: %v", err)
+	}
+	evs, _, err := r.ReadFrom(0)
+	if err != nil {
+		t.Fatalf("ReadFrom: %v", err)
+	}
+	return evs
+}
+
+func projectFields(e Event) Event {
+	// Only the fields the sidecar line carries survive a round-trip.
+	return Event{
+		GroupSlug:     e.GroupSlug,
+		RepoSlug:      e.RepoSlug,
+		Module:        e.Module,
+		Phase:         e.Phase,
+		FilesDone:     e.FilesDone,
+		FilesTotal:    e.FilesTotal,
+		EntitiesSoFar: e.EntitiesSoFar,
+		CurrentFile:   e.CurrentFile,
+		TS:            e.TS,
+		Error:         e.Error,
+	}
+}
+
+// TestSidecarPathDerivation asserts the group file lives under
+// GRAFEL_HOME/progress and is deterministically derived (writer and a future
+// reader agree with zero coordination).
+func TestSidecarPathDerivation(t *testing.T) {
+	home := setHome(t)
+	p1, err := SidecarPath("group-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	p2, err := SidecarPath("group-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p1 != p2 {
+		t.Fatalf("path not deterministic: %q vs %q", p1, p2)
+	}
+	wantDir := filepath.Join(home, "progress")
+	if filepath.Dir(p1) != wantDir {
+		t.Fatalf("path dir = %q, want %q", filepath.Dir(p1), wantDir)
+	}
+	if !strings.HasSuffix(p1, ".ndjson") {
+		t.Fatalf("path %q does not end in .ndjson", p1)
+	}
+	pOther, err := SidecarPath("group-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pOther == p1 {
+		t.Fatal("distinct groups mapped to the same file")
+	}
+}
+
+// TestWriteReadRoundTripTwoGroups writes events across two groups and multiple
+// modules, then asserts each group file contains only its own events and that
+// events reconstruct via the reader.
+func TestWriteReadRoundTripTwoGroups(t *testing.T) {
+	setHome(t)
+
+	wA, err := NewSidecarWriter("grp-a", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wB, err := NewSidecarWriter("grp-b", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	aEvents := []Event{
+		{GroupSlug: "grp-a", RepoSlug: "repo1", Module: "services/auth", Phase: PhaseExtractAST, FilesDone: 3, FilesTotal: 10, EntitiesSoFar: 5, CurrentFile: "a.go", TS: 100},
+		{GroupSlug: "grp-a", RepoSlug: "repo1", Module: "packages/ui", Phase: PhaseExtractAST, FilesDone: 1, FilesTotal: 4, TS: 101},
+		{GroupSlug: "grp-a", RepoSlug: "repo2", Module: "", Phase: PhaseDone, FilesDone: 10, FilesTotal: 10, EntitiesSoFar: 42, TS: 102},
+	}
+	bEvents := []Event{
+		{GroupSlug: "grp-b", RepoSlug: "svc", Module: "cmd", Phase: PhaseScan, FilesTotal: 7, TS: 200},
+	}
+	for _, e := range aEvents {
+		wA.Publish(e)
+	}
+	for _, e := range bEvents {
+		wB.Publish(e)
+	}
+	if err := wA.Close(); err != nil {
+		t.Fatalf("close wA: %v", err)
+	}
+	if err := wB.Close(); err != nil {
+		t.Fatalf("close wB: %v", err)
+	}
+
+	gotA := drainReader(t, "grp-a")
+	if len(gotA) != len(aEvents) {
+		t.Fatalf("group a: got %d lines, want %d: %+v", len(gotA), len(aEvents), gotA)
+	}
+	// Terminal + two distinct-module non-terminal lines, all present.
+	for i, e := range aEvents {
+		want := projectFields(e)
+		found := false
+		for _, g := range gotA {
+			if projectFields(g) == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("group a event %d not reconstructed: %+v", i, want)
+		}
+	}
+	gotB := drainReader(t, "grp-b")
+	if len(gotB) != 1 {
+		t.Fatalf("group b: got %d lines, want 1", len(gotB))
+	}
+	if projectFields(gotB[0]) != projectFields(bEvents[0]) {
+		t.Errorf("group b round-trip mismatch:\n got %+v\nwant %+v", projectFields(gotB[0]), projectFields(bEvents[0]))
+	}
+
+	// seq must be assigned and strictly increasing within a group file.
+	assertSeqAscending(t, "grp-a")
+}
+
+func assertSeqAscending(t *testing.T, groupSlug string) {
+	t.Helper()
+	p, err := SidecarPath(groupSlug)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var last int64
+	for _, ln := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+		if ln == "" {
+			continue
+		}
+		var l SidecarLine
+		if err := json.Unmarshal([]byte(ln), &l); err != nil {
+			t.Fatalf("bad line %q: %v", ln, err)
+		}
+		if l.Seq <= last {
+			t.Fatalf("seq not ascending: %d after %d", l.Seq, last)
+		}
+		last = l.Seq
+	}
+	if last == 0 {
+		t.Fatal("no seq assigned")
+	}
+}
+
+// TestCoalescing feeds many rapid ticks for the same (repo,module) within a
+// single flush interval and asserts the flushed line count is far below the
+// event count, and the latest state wins.
+func TestCoalescing(t *testing.T) {
+	setHome(t)
+	// A very long flush interval means the only flush is the one Close forces:
+	// a single interval => a single line per (repo,module).
+	w, err := NewSidecarWriter("coal", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	const n = 2000
+	for i := 0; i < n; i++ {
+		w.Publish(Event{
+			GroupSlug: "coal", RepoSlug: "r", Module: "m",
+			Phase: PhaseExtractAST, FilesDone: i, FilesTotal: n,
+			CurrentFile: "f.go", TS: int64(i),
+		})
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainReader(t, "coal")
+	if len(got) != 1 {
+		t.Fatalf("coalescing failed: got %d lines for %d events, want 1", len(got), n)
+	}
+	if got[0].FilesDone != n-1 {
+		t.Fatalf("latest state did not win: FilesDone=%d, want %d", got[0].FilesDone, n-1)
+	}
+}
+
+// TestTerminalFlushesPromptly asserts a terminal event is flushed without
+// waiting for the ticker, even under a long flush interval.
+func TestTerminalFlushesPromptly(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("term", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	w.Publish(Event{GroupSlug: "term", RepoSlug: "r", Phase: PhaseDone, FilesDone: 9, FilesTotal: 9, EntitiesSoFar: 3, TS: 1})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		got := drainReader(t, "term")
+		if len(got) == 1 && got[0].Phase == PhaseDone {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("terminal event was not flushed promptly")
+}
+
+// TestTerminalSurvivesCoalescing asserts that a terminal event coexists with a
+// coalesced non-terminal line for a different module and is never dropped.
+func TestTerminalSurvivesCoalescing(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("mix", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 500; i++ {
+		w.Publish(Event{GroupSlug: "mix", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+	}
+	w.Publish(Event{GroupSlug: "mix", RepoSlug: "r", Module: "m2", Phase: PhaseError, Error: "boom", TS: 999})
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainReader(t, "mix")
+	var sawTerminal bool
+	for _, e := range got {
+		if e.Phase == PhaseError && e.Error == "boom" {
+			sawTerminal = true
+		}
+	}
+	if !sawTerminal {
+		t.Fatalf("terminal event lost among %d lines", len(got))
+	}
+}
+
+// TestPartialLastLineTolerated asserts the reader skips a torn trailing line
+// and returns the complete lines before it.
+func TestPartialLastLineTolerated(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("torn", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Publish(Event{GroupSlug: "torn", RepoSlug: "r", Module: "m", Phase: PhaseScan, FilesTotal: 5, TS: 1})
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	p, err := SidecarPath("torn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Append a truncated (no trailing newline, invalid JSON) line.
+	f, err := os.OpenFile(p, os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"seq":99,"group_slug":"torn","phase":"extr`); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	r, err := NewSidecarReader("torn")
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, off, err := r.ReadFrom(0)
+	if err != nil {
+		t.Fatalf("ReadFrom tolerating torn line: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d events, want 1 (torn line must be skipped)", len(got))
+	}
+	// Offset must stop before the torn line so a later append completing it is
+	// picked up on the next read.
+	st, _ := os.Stat(p)
+	if off >= st.Size() {
+		t.Fatalf("offset %d should be before EOF %d (torn tail not yet consumed)", off, st.Size())
+	}
+}
+
+// TestReaderAppendAware asserts ReadFrom can be called repeatedly to pick up
+// newly-appended lines from the reported offset.
+func TestReaderAppendAware(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("tail", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w.Publish(Event{GroupSlug: "tail", RepoSlug: "r", Module: "m", Phase: PhaseScan, TS: 1})
+	// Publish a terminal for a different module to force an immediate flush of
+	// the pending non-terminal line too.
+	w.Publish(Event{GroupSlug: "tail", RepoSlug: "r", Module: "z", Phase: PhaseDone, TS: 2})
+
+	r, err := NewSidecarReader("tail")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var off int64
+	var total int
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) && total < 2 {
+		evs, newOff, err := r.ReadFrom(off)
+		if err != nil {
+			t.Fatal(err)
+		}
+		total += len(evs)
+		off = newOff
+		if total < 2 {
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if total != 2 {
+		t.Fatalf("append-aware read got %d events, want 2", total)
+	}
+	// A further read from the same offset yields nothing new.
+	evs, _, err := r.ReadFrom(off)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 0 {
+		t.Fatalf("re-read from tail offset returned %d events, want 0", len(evs))
+	}
+	w.Close()
+}
+
+// TestTruncateOnNewRun asserts a second writer for the same group starts a
+// fresh stream (the old run's lines are gone).
+func TestTruncateOnNewRun(t *testing.T) {
+	setHome(t)
+	w1, err := NewSidecarWriter("run", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 5; i++ {
+		w1.Publish(Event{GroupSlug: "run", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+	}
+	w1.Publish(Event{GroupSlug: "run", RepoSlug: "r", Phase: PhaseDone, TS: 9})
+	w1.Close()
+
+	before := drainReader(t, "run")
+	if len(before) == 0 {
+		t.Fatal("expected first run to write lines")
+	}
+
+	w2, err := NewSidecarWriter("run", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Immediately after construction (before any publish) the file must be
+	// empty — the new run truncated it.
+	mid := drainReader(t, "run")
+	if len(mid) != 0 {
+		t.Fatalf("new run did not truncate: %d stale lines remain", len(mid))
+	}
+	w2.Publish(Event{GroupSlug: "run", RepoSlug: "r", Module: "m", Phase: PhaseScan, FilesTotal: 3, TS: 100})
+	w2.Close()
+	after := drainReader(t, "run")
+	if len(after) != 1 {
+		t.Fatalf("second run: got %d lines, want 1", len(after))
+	}
+	if after[0].TS != 100 {
+		t.Fatalf("second run did not start fresh: TS=%d", after[0].TS)
+	}
+}
+
+// TestCompactionShrinksAndRetains crafts a file with many duplicate-key lines
+// plus terminals, runs compaction, and asserts the file shrinks while the
+// latest-per-key and terminal lines survive in seq order.
+func TestCompactionShrinksAndRetains(t *testing.T) {
+	setHome(t)
+	p, err := SidecarPath("comp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seq int64
+	writeLine := func(l SidecarLine) {
+		seq++
+		l.Seq = seq
+		b, _ := json.Marshal(l)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	// 100 updates to two live keys.
+	for i := 0; i < 100; i++ {
+		writeLine(SidecarLine{GroupSlug: "comp", RepoSlug: "r", Module: "m1", Phase: PhaseExtractAST, FilesDone: i})
+		writeLine(SidecarLine{GroupSlug: "comp", RepoSlug: "r", Module: "m2", Phase: PhaseExtractAST, FilesDone: i})
+	}
+	// A terminal line that must be retained.
+	writeLine(SidecarLine{GroupSlug: "comp", RepoSlug: "r", Module: "m3", Phase: PhaseDone, FilesDone: 1, Done: true})
+	f.Close()
+
+	stBefore, _ := os.Stat(p)
+
+	if err := compactSidecarFile(p); err != nil {
+		t.Fatalf("compactSidecarFile: %v", err)
+	}
+
+	stAfter, _ := os.Stat(p)
+	if stAfter.Size() >= stBefore.Size() {
+		t.Fatalf("compaction did not shrink: before=%d after=%d", stBefore.Size(), stAfter.Size())
+	}
+
+	got := drainReader(t, "comp")
+	// Expect exactly 3 lines: latest of m1, latest of m2, terminal m3.
+	if len(got) != 3 {
+		t.Fatalf("compacted line count = %d, want 3: %+v", len(got), got)
+	}
+	byMod := map[string]Event{}
+	for _, e := range got {
+		byMod[e.Module] = e
+	}
+	if byMod["m1"].FilesDone != 99 || byMod["m2"].FilesDone != 99 {
+		t.Fatalf("latest-per-key not retained: %+v", byMod)
+	}
+	if byMod["m3"].Phase != PhaseDone {
+		t.Fatal("terminal line not retained after compaction")
+	}
+	assertSeqAscending(t, "comp")
+}
+
+// TestWriterCompactsAtSizeCap asserts the running writer compacts its own file
+// once it crosses the configured byte cap, keeping latest-per-key + terminal.
+func TestWriterCompactsAtSizeCap(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("cap",
+		WithFlushInterval(5*time.Millisecond),
+		WithMaxBytes(700),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p, _ := SidecarPath("cap")
+	// Keep updating a single key across many flush intervals so the file
+	// accumulates duplicate lines and eventually crosses the cap.
+	for i := 0; i < 400; i++ {
+		w.Publish(Event{GroupSlug: "cap", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+		if i%20 == 0 {
+			time.Sleep(6 * time.Millisecond)
+		}
+	}
+	w.Publish(Event{GroupSlug: "cap", RepoSlug: "r", Phase: PhaseDone, FilesDone: 400, TS: 400})
+	w.Close()
+
+	st, err := os.Stat(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// After compaction the file must be well under a pathological unbounded size.
+	if st.Size() > 5000 {
+		t.Fatalf("file not compacted under cap pressure: size=%d", st.Size())
+	}
+	got := drainReader(t, "cap")
+	var sawDone bool
+	for _, e := range got {
+		if e.Phase == PhaseDone {
+			sawDone = true
+		}
+	}
+	if !sawDone {
+		t.Fatal("terminal lost after cap compaction")
+	}
+}
+
+// TestDropOldestUnderFullBuffer floods the writer far faster than the (blocked)
+// flush loop can drain and asserts Publish never blocks and Close still joins.
+func TestDropOldestUnderFullBuffer(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("flood",
+		WithFlushInterval(time.Hour), // never ticks during the test
+		WithBufferSize(4),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 100000; i++ {
+			w.Publish(Event{GroupSlug: "flood", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Publish blocked under a full buffer (drop-oldest failed)")
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("Close did not join cleanly: %v", err)
+	}
+}
+
+// TestPruneTerminalSidecars asserts stale terminal'd files are deleted while a
+// live (non-terminal, fresh) file is kept.
+func TestPruneTerminalSidecars(t *testing.T) {
+	setHome(t)
+
+	// A terminated, old file.
+	wOld, err := NewSidecarWriter("old", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wOld.Publish(Event{GroupSlug: "old", RepoSlug: "r", Phase: PhaseDone, TS: 1})
+	wOld.Close()
+	oldPath, _ := SidecarPath("old")
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(oldPath, past, past); err != nil {
+		t.Fatal(err)
+	}
+
+	// A live, non-terminal, fresh file.
+	wLive, err := NewSidecarWriter("live", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	wLive.Publish(Event{GroupSlug: "live", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: 1, TS: 2})
+	wLive.Close()
+	livePath, _ := SidecarPath("live")
+
+	n, err := PruneTerminalSidecars(time.Minute)
+	if err != nil {
+		t.Fatalf("PruneTerminalSidecars: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pruned %d files, want 1", n)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatal("stale terminal'd file was not deleted")
+	}
+	if _, err := os.Stat(livePath); err != nil {
+		t.Fatal("live file was wrongly deleted")
+	}
+}
+
+// TestLineFromEventRoundTrip exercises the marshal/unmarshal helpers directly.
+func TestLineFromEventRoundTrip(t *testing.T) {
+	e := Event{
+		GroupSlug: "g", RepoSlug: "r", Module: "m",
+		Phase: PhaseExtractAST, FilesDone: 7, FilesTotal: 9,
+		EntitiesSoFar: 11, CurrentFile: "x.go", TS: 123,
+	}
+	l := lineFromEvent(e)
+	b, err := json.Marshal(l)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var l2 SidecarLine
+	if err := json.Unmarshal(b, &l2); err != nil {
+		t.Fatal(err)
+	}
+	if got := l2.toEvent(); projectFields(got) != projectFields(e) {
+		t.Fatalf("round-trip mismatch:\n got %+v\nwant %+v", projectFields(got), projectFields(e))
+	}
+	// A terminal event marks Done.
+	term := lineFromEvent(Event{GroupSlug: "g", Phase: PhaseDone})
+	if !term.Done {
+		t.Fatal("terminal event did not set Done")
+	}
+	// Verify the on-the-wire JSON keys match the documented schema.
+	if !strings.Contains(string(b), `"files_done"`) || !strings.Contains(string(b), `"entities"`) {
+		t.Fatalf("unexpected JSON schema: %s", b)
+	}
+}

--- a/internal/progress/sidecar_test.go
+++ b/internal/progress/sidecar_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -558,6 +559,246 @@ func TestPruneTerminalSidecars(t *testing.T) {
 	}
 	if _, err := os.Stat(livePath); err != nil {
 		t.Fatal("live file was wrongly deleted")
+	}
+}
+
+// TestTerminalSurvivesBufferEviction is the B1 regression: a terminal event
+// published BEFORE a flood of >bufSize newer events must reach disk. Before the
+// fix the terminal rode the lossy drop-oldest channel and, once it became the
+// FIFO head, was silently evicted by the flood — leaving sawTerminal=false and
+// a wizard bar stuck forever.
+func TestTerminalSurvivesBufferEviction(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("evict",
+		WithFlushInterval(time.Hour), // ticker never fires; only wake/quit flush
+		WithBufferSize(8),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Fast repo finishes first...
+	w.Publish(Event{GroupSlug: "evict", RepoSlug: "fast", Phase: PhaseDone, FilesDone: 5, FilesTotal: 5, TS: 1})
+	// ...then slow repos bury it under far more than bufSize newer events.
+	for i := 0; i < 50000; i++ {
+		w.Publish(Event{GroupSlug: "evict", RepoSlug: "slow", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i + 2)})
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainReader(t, "evict")
+	var sawTerminal bool
+	for _, e := range got {
+		if e.RepoSlug == "fast" && e.Phase == PhaseDone {
+			sawTerminal = true
+		}
+	}
+	if !sawTerminal {
+		t.Fatalf("terminal evicted under buffer pressure (B1): %d lines on disk, none terminal", len(got))
+	}
+}
+
+// TestTerminalSurvivesConcurrentProducers is the harder B1 variant: many
+// goroutines (as a TeePublisher fan-out would drive) hammer the writer while a
+// terminal is in flight. The terminal must still land.
+func TestTerminalSurvivesConcurrentProducers(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("evict2",
+		WithFlushInterval(time.Hour),
+		WithBufferSize(4),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func(id int) {
+			defer wg.Done()
+			for i := 0; i < 20000; i++ {
+				w.Publish(Event{GroupSlug: "evict2", RepoSlug: "slow", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+			}
+		}(g)
+	}
+	// Publish the terminal concurrently with the flood.
+	w.Publish(Event{GroupSlug: "evict2", RepoSlug: "fast", Phase: PhaseError, Error: "kaboom", TS: 999})
+	wg.Wait()
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainReader(t, "evict2")
+	var sawTerminal bool
+	for _, e := range got {
+		if e.Phase == PhaseError && e.Error == "kaboom" {
+			sawTerminal = true
+		}
+	}
+	if !sawTerminal {
+		t.Fatalf("terminal lost under concurrent producers (B1): %d lines on disk", len(got))
+	}
+}
+
+// TestReadFromAfterTruncate is the B2 regression: a reader holding a stale
+// offset from run 1 must pick up run 2 after NewSidecarWriter truncates the
+// file. Before the fix ReadFrom seeked past EOF and returned nothing forever.
+func TestReadFromAfterTruncate(t *testing.T) {
+	setHome(t)
+	// Run 1: write several lines so the reader carries a non-trivial offset.
+	w1, err := NewSidecarWriter("re", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 6; i++ {
+		w1.Publish(Event{GroupSlug: "re", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+	}
+	w1.Publish(Event{GroupSlug: "re", RepoSlug: "r", Phase: PhaseDone, TS: 9})
+	w1.Close()
+
+	r, err := NewSidecarReader("re")
+	if err != nil {
+		t.Fatal(err)
+	}
+	evs1, off1, err := r.ReadFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs1) == 0 || off1 == 0 {
+		t.Fatalf("run 1 read got %d events at offset %d", len(evs1), off1)
+	}
+
+	// Run 2: a fresh writer truncates the file and writes a distinct run.
+	w2, err := NewSidecarWriter("re", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	w2.Publish(Event{GroupSlug: "re", RepoSlug: "r", Module: "m", Phase: PhaseScan, FilesTotal: 3, TS: 100})
+	w2.Publish(Event{GroupSlug: "re", RepoSlug: "r", Phase: PhaseDone, TS: 101})
+	w2.Close()
+
+	// Reading from the carried (now-stale, too-large) offset must reset and
+	// return run 2 in full.
+	evs2, off2, err := r.ReadFrom(off1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs2) != 2 {
+		t.Fatalf("post-truncate read got %d events, want 2 (B2 reset failed)", len(evs2))
+	}
+	if off2 >= off1 {
+		t.Fatalf("reset not surfaced: new offset %d should be < stale offset %d", off2, off1)
+	}
+	// The run-2 fresh-start marker must be present.
+	var sawScan bool
+	for _, e := range evs2 {
+		if e.Phase == PhaseScan && e.TS == 100 {
+			sawScan = true
+		}
+	}
+	if !sawScan {
+		t.Fatal("post-truncate read did not return the new run's opening event")
+	}
+}
+
+// TestReadFromAfterCompaction is the second B2 case: compaction shrinks the file
+// below the reader's saved offset. The reader must reset and replay.
+func TestReadFromAfterCompaction(t *testing.T) {
+	setHome(t)
+	p, err := SidecarPath("rc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seq int64
+	writeLine := func(l SidecarLine) {
+		seq++
+		l.Seq = seq
+		b, _ := json.Marshal(l)
+		f.Write(b)
+		f.Write([]byte("\n"))
+	}
+	for i := 0; i < 200; i++ {
+		writeLine(SidecarLine{GroupSlug: "rc", RepoSlug: "r", Module: "m", Phase: PhaseExtractAST, FilesDone: i})
+	}
+	writeLine(SidecarLine{GroupSlug: "rc", RepoSlug: "r", Module: "done", Phase: PhaseDone, Done: true})
+	f.Close()
+
+	r, err := NewSidecarReader("rc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, offBig, err := r.ReadFrom(0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := compactSidecarFile(p); err != nil {
+		t.Fatal(err)
+	}
+	st, _ := os.Stat(p)
+	if st.Size() >= offBig {
+		t.Fatalf("precondition: compacted file (%d) must be smaller than saved offset (%d)", st.Size(), offBig)
+	}
+
+	// Reading from the stale offset must reset and return the compacted content
+	// (latest m + terminal done = 2 lines).
+	evs, offNew, err := r.ReadFrom(offBig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(evs) != 2 {
+		t.Fatalf("post-compaction read got %d events, want 2 (B2 reset failed)", len(evs))
+	}
+	if offNew >= offBig {
+		t.Fatalf("reset not surfaced after compaction: new offset %d should be < %d", offNew, offBig)
+	}
+}
+
+// TestResetClearsPendingState is the medium fix: Reset must produce a genuinely
+// fresh stream — seq restarts and no stale coalesced/terminal state leaks in.
+func TestResetClearsPendingState(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("rs", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Bury some non-terminal state that has NOT been flushed yet.
+	for i := 0; i < 100; i++ {
+		w.Publish(Event{GroupSlug: "rs", RepoSlug: "r", Module: "old", Phase: PhaseExtractAST, FilesDone: i, TS: int64(i)})
+	}
+	if err := w.Reset(); err != nil {
+		t.Fatalf("Reset: %v", err)
+	}
+	// After Reset the file is empty and the buried "old" state is gone.
+	if got := drainReader(t, "rs"); len(got) != 0 {
+		t.Fatalf("Reset did not clear stream: %d lines remain", len(got))
+	}
+	// A fresh event flushes with seq restarting at 1.
+	w.Publish(Event{GroupSlug: "rs", RepoSlug: "r", Module: "new", Phase: PhaseScan, FilesTotal: 4, TS: 500})
+	w.Close()
+
+	pth, _ := SidecarPath("rs")
+	data, err := os.ReadFile(pth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimRight(string(data), "\n"), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("fresh stream got %d lines, want 1: %q", len(lines), string(data))
+	}
+	var l SidecarLine
+	if err := json.Unmarshal([]byte(lines[0]), &l); err != nil {
+		t.Fatal(err)
+	}
+	if l.Seq != 1 {
+		t.Fatalf("seq did not restart after Reset: got %d, want 1", l.Seq)
+	}
+	if l.Module != "new" {
+		t.Fatalf("stale pre-Reset state leaked: module=%q", l.Module)
 	}
 }
 

--- a/internal/progress/tee.go
+++ b/internal/progress/tee.go
@@ -1,0 +1,31 @@
+package progress
+
+// TeePublisher fans one Publish out to N wrapped publishers so a caller can, in
+// a later PR, tee the engine's in-memory Broker AND a SidecarWriter from a
+// single Publisher handed to the indexer. Non-blocking semantics are preserved:
+// each child is itself a non-blocking Publisher (Broker drops-on-full,
+// SidecarWriter drops-oldest), so a straight sequential fan-out cannot stall
+// one child behind another — the simplest correct approach.
+type TeePublisher struct {
+	children []Publisher
+}
+
+// NewTeePublisher returns a Publisher that forwards every event to each of pubs
+// in order. A nil child is tolerated and skipped.
+func NewTeePublisher(pubs ...Publisher) *TeePublisher {
+	return &TeePublisher{children: pubs}
+}
+
+// Publish forwards e to every wrapped publisher. Safe for concurrent use so
+// long as the children are (Broker and SidecarWriter both are).
+func (t *TeePublisher) Publish(e Event) {
+	if t == nil {
+		return
+	}
+	for _, p := range t.children {
+		if p == nil {
+			continue
+		}
+		p.Publish(e)
+	}
+}

--- a/internal/progress/tee_test.go
+++ b/internal/progress/tee_test.go
@@ -1,0 +1,62 @@
+package progress
+
+import (
+	"sync"
+	"testing"
+)
+
+// blockingPublisher blocks forever on the first Publish unless released. It is
+// used to prove a TeePublisher does not stall siblings on a slow child (the
+// contract holds because children are themselves non-blocking; this guards
+// against a future regression that fans out synchronously into a blocking sink).
+type countingPublisher struct {
+	mu     sync.Mutex
+	events []Event
+}
+
+func (c *countingPublisher) Publish(e Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *countingPublisher) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+// TestTeeFanOut asserts every child receives every published event.
+func TestTeeFanOut(t *testing.T) {
+	a := &countingPublisher{}
+	b := &countingPublisher{}
+	c := &countingPublisher{}
+	tee := NewTeePublisher(a, b, c)
+
+	for i := 0; i < 10; i++ {
+		tee.Publish(Event{GroupSlug: "g", RepoSlug: "r", Phase: PhaseExtractAST, FilesDone: i})
+	}
+	for name, p := range map[string]*countingPublisher{"a": a, "b": b, "c": c} {
+		if got := p.count(); got != 10 {
+			t.Fatalf("child %s got %d events, want 10", name, got)
+		}
+	}
+}
+
+// TestTeeNilChildIgnored asserts a nil child in the list is skipped rather than
+// panicking (defensive fan-out).
+func TestTeeNilChildIgnored(t *testing.T) {
+	a := &countingPublisher{}
+	tee := NewTeePublisher(a, nil)
+	tee.Publish(Event{GroupSlug: "g", Phase: PhaseDone})
+	if a.count() != 1 {
+		t.Fatalf("child a got %d events, want 1", a.count())
+	}
+}
+
+// TestTeeImplementsPublisher asserts TeePublisher satisfies the Publisher
+// interface (compile-time + can wrap a broker + sidecar writer).
+func TestTeeImplementsPublisher(t *testing.T) {
+	var _ Publisher = NewTeePublisher()
+	var _ Publisher = (*TeePublisher)(nil)
+}


### PR DESCRIPTION
## What
Pure library foundation for bridging index progress across the split-mode serve↔engine process boundary (the engine will write these sidecars; serve will tail them into its SSE broker). No daemon wiring in this PR — dead code until the follow-up.

- `internal/progress/sidecar.go`: `SidecarWriter` (implements `progress.Publisher`) — non-blocking drop-oldest for non-terminals, a **separate guaranteed path for terminal events** (mutex-guarded `pendingTerm` + wake), single flush goroutine coalescing `map[repo|module]` on a ticker (one append batch per interval, not per tick — bounds a 19k-file monorepo to tens of writes), size-cap compaction (latest-per-key + terminals, seq-ordered, tmp+rename), `Reset` routed through the goroutine.
- `internal/progress/sidecar_reader.go`: append-aware tail reader; `Stat`s the file and **replays from offset 0 on shrink** (new-run truncate OR compaction), surfacing `newOffset < inputOffset` so a tailer can re-seed. Torn-last-line tolerant.
- `internal/progress/tee.go`: fan-out `Publisher`.
- Path parity with `internal/statusfile.PathFor` (sha256 slug → GRAFEL_HOME/progress/<hash>.ndjson) so writer/reader agree with zero coordination.

## Review
Independent adversarial review found two blocking bugs — B1 (terminal droppable at the channel drop-oldest boundary → stuck bar) and B2 (reader never detected truncation/shrink → broke on every re-index/compaction). Both fixed here with regression tests (buried-terminal, concurrent-producer flood, read-after-truncate, read-after-compaction, reset-clears-state). `go test -race -count=5 ./internal/progress/` clean.

Refs #5729, #5721