### PR TITLE
feat(daemon): bridge split-mode index progress engine→serve (sidecar tailer) for live wizard/dashboard bars (#5729)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -665,6 +665,12 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 		Rebuild:      makeDaemonRebuildFunc(maxConcurrentGroups),
 		QualityAudit: daemonQualityAuditFunc,
 
+		// Split-mode progress bridge (ADR-0024 / epic #5729): the SAME broker the
+		// dashboard SSE subscribes to (srv.SetProgressBroker below). In split mode
+		// the serve plane's sidecarTailer republishes the engine's per-group
+		// progress sidecars into it.
+		ProgressBroker: daemonProgressBroker,
+
 		// Phase B — wire the watcher + scheduler. The fast reactive
 		// reindex skips Pass 4 (graph algorithms) so a freshly-saved
 		// file becomes queryable as soon as the basic graph lands;
@@ -1272,6 +1278,35 @@ func daemonRebuildFuncCore(
 		resolve.RegisterExtraStdlibFilter(lang, names)
 	}
 
+	// Split-mode progress bridge — WRITE side (ADR-0024 / epic #5729). In SPLIT
+	// mode this rebuild runs inside the ENGINE process; the dashboard/wizard SSE
+	// lives in the separate SERVE process reading serve's own broker, so events
+	// published only into daemonProgressBroker here never reach it. Bridge them
+	// by teeing the broker with a per-GROUP NDJSON SidecarWriter that serve's
+	// sidecarTailer tails and republishes. progressPub is handed to BOTH the
+	// per-repo indexer publisher AND the group link tracker so per-module Tick
+	// events and the group-phase (cross-repo link) events all reach the sidecar.
+	//
+	// In MONOLITH mode (escape hatch GRAFEL_SPLIT_MODE=0) the publisher stays the
+	// broker directly — no sidecar is created and nothing is written under
+	// GRAFEL_HOME/progress, so monolith behavior is byte-for-byte unchanged.
+	var progressPub progress.Publisher = daemonProgressBroker
+	if daemon.SplitModeEnabled() {
+		sidecarWriter, swErr := progress.NewSidecarWriter(args.Group)
+		if swErr != nil {
+			// Best-effort: a sidecar-writer failure must never fail the rebuild.
+			// Fall back to the broker-only publisher (the split-mode dashboard
+			// simply won't see live progress for this run).
+			fmt.Fprintf(os.Stderr,
+				"grafel: rebuild: progress sidecar writer for group=%s failed: %v (dashboard progress bridge disabled for this run)\n",
+				args.Group, swErr)
+		} else {
+			// Flush the terminal + join the goroutine at the end of the rebuild.
+			defer sidecarWriter.Close()
+			progressPub = progress.NewTeePublisher(daemonProgressBroker, sidecarWriter)
+		}
+	}
+
 	// Collect repos to index, respecting the optional single-slug filter.
 	var work []repoWork
 	for _, r := range cfg.Repos {
@@ -1329,7 +1364,7 @@ func daemonRebuildFuncCore(
 			// Publish granular per-repo progress into the shared broker so the
 			// WebUI Index step renders live rows + file counters (#1531).
 			opts = append(opts,
-				WithPublisher(daemonProgressBroker),
+				WithPublisher(progressPub),
 				WithProgressSlugs(args.Group, rw.r.Slug))
 			// #5328: run at the foreground (higher) CPU cap only for human-awaited
 			// rebuilds; an automatic watcher/git-hook-triggered rebuild stays at
@@ -1456,7 +1491,7 @@ func daemonRebuildFuncCore(
 	// label and the CLI's live line advance to "Detecting cross-repo links…".
 	// The phantom-edge pass re-runs process-flow inside linksFn, so the same
 	// phase also covers the group-level flow recompute.
-	linkTrk := progress.NewTracker(daemonProgressBroker, args.Group, args.Group)
+	linkTrk := progress.NewTracker(progressPub, args.Group, args.Group)
 	linkTrk.Phase(progress.PhaseDetectLinks, "cross-repo links", 0)
 
 	// Cross-repo link passes run after every member is indexed.

--- a/cmd/grafel/daemon_progress_sidecar_test.go
+++ b/cmd/grafel/daemon_progress_sidecar_test.go
@@ -1,0 +1,100 @@
+package main
+
+// daemon_progress_sidecar_test.go — split-mode progress bridge, WRITE side
+// (ADR-0024 / epic #5729). Asserts daemonRebuildFuncCore tees the progress
+// broker into a per-group NDJSON sidecar ONLY in split mode, and leaves the
+// monolith path byte-for-byte unchanged (no progress/ files written).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// progressDir returns GRAFEL_HOME/progress and whether it exists with any
+// .ndjson sidecar inside.
+func progressSidecarFiles(t *testing.T) []string {
+	t.Helper()
+	home := os.Getenv("GRAFEL_HOME")
+	dir := filepath.Join(home, "progress")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		t.Fatalf("readdir %s: %v", dir, err)
+	}
+	var out []string
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".ndjson" {
+			out = append(out, filepath.Join(dir, e.Name()))
+		}
+	}
+	return out
+}
+
+// TestRebuild_MonolithWritesNoSidecar asserts that with split mode DISABLED the
+// rebuild path creates NO progress sidecar files — monolith behavior is
+// byte-for-byte unchanged.
+func TestRebuild_MonolithWritesNoSidecar(t *testing.T) {
+	t.Setenv(daemon.SplitModeEnvVar, "0") // escape hatch: monolith
+	group := setupTestGroup(t, "mono-group", []string{"r1", "r2"})
+
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
+
+	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	if files := progressSidecarFiles(t); len(files) != 0 {
+		t.Errorf("monolith rebuild wrote %d progress sidecar file(s), want 0: %v", len(files), files)
+	}
+}
+
+// TestRebuild_SplitModeWritesSidecar asserts that with split mode ENABLED the
+// rebuild tees the broker into a per-group sidecar carrying the group-scoped
+// terminal (the link tracker's Done), so serve's tailer can bridge it.
+func TestRebuild_SplitModeWritesSidecar(t *testing.T) {
+	t.Setenv(daemon.SplitModeEnvVar, "1") // split ON
+	group := setupTestGroup(t, "split-group", []string{"r1", "r2"})
+
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
+
+	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	// Exactly one sidecar (this group) must exist at the deterministic path.
+	path, err := progress.SidecarPath(group)
+	if err != nil {
+		t.Fatalf("SidecarPath: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected sidecar at %s: %v", path, err)
+	}
+
+	// Read it back: the group-scoped terminal (RepoSlug == group, done) from the
+	// link tracker must be present, proving the group link tracker flows through
+	// the tee.
+	r, err := progress.NewSidecarReader(group)
+	if err != nil {
+		t.Fatalf("reader: %v", err)
+	}
+	events, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("readall: %v", err)
+	}
+	var sawGroupTerminal bool
+	for _, e := range events {
+		if e.GroupSlug == group && e.RepoSlug == group && e.Phase == progress.PhaseDone {
+			sawGroupTerminal = true
+		}
+	}
+	if !sawGroupTerminal {
+		t.Errorf("group-scoped terminal not found in sidecar; events=%+v", events)
+	}
+}

--- a/internal/daemon/progress_tailer.go
+++ b/internal/daemon/progress_tailer.go
@@ -1,0 +1,237 @@
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/progress"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// Split-mode progress bridge — READ side (ADR-0024 / epic #5729).
+//
+// In split mode serve and engine are separate OS processes, each with its own
+// in-memory progress.Broker. The engine's rebuild tees its per-repo indexer
+// publisher AND the group link tracker into a per-group NDJSON sidecar under
+// GRAFEL_HOME/progress (see cmd/grafel/daemon.go's WithPublisher /
+// NewTracker wiring, gated on SplitModeEnabled). Serve, which owns the Broker
+// the dashboard/wizard SSE subscribes to, has no way to see those events —
+// they were published into the engine's Broker, in another process.
+//
+// sidecarTailer closes that gap: started ONLY in the serve plane, it polls the
+// per-group sidecars, tails each with a progress.SidecarReader, and republishes
+// every reconstructed progress.Event into serve's Broker. The dashboard SSE
+// then renders live per-repo / per-module rows exactly as it does in monolith
+// mode — with NO handler change (the same /api/index-progress and the
+// dashboard web-onboard Rebuild path both read serve's Broker).
+//
+// It MUST NOT run in the engine plane: the engine is the WRITER; tailing its
+// own writes would pointlessly re-publish into a Broker no SSE client reads.
+// The lifecycle mirrors startStatusWriter (statuswriter.go): a start func that
+// launches one goroutine and returns a stop func that joins it on shutdown.
+
+const (
+	// defaultSidecarTailPoll is how often the tailer rescans the known groups
+	// and tails each group's sidecar for newly-appended lines. Kept tight
+	// (~poll cadence of the SSE heartbeat) so the dashboard feels live without
+	// busy-spinning.
+	defaultSidecarTailPoll = 120 * time.Millisecond
+
+	// defaultSidecarPruneEvery bounds how often PruneTerminalSidecars runs so a
+	// long-lived serve process does not accumulate terminated group files.
+	defaultSidecarPruneEvery = 5 * time.Minute
+
+	// defaultSidecarPruneMaxAge is the age past which a TERMINATED (done/error)
+	// group sidecar is eligible for deletion. A live or fresh file is always
+	// retained (see progress.PruneTerminalSidecars).
+	defaultSidecarPruneMaxAge = 6 * time.Hour
+)
+
+// groupTailState is the tailer's per-group cursor: the reader, the byte offset
+// consumed so far, and whether the group has reached a group-scoped terminal.
+type groupTailState struct {
+	reader   *progress.SidecarReader
+	offset   int64
+	terminal bool
+}
+
+// sidecarTailer tails every known group's progress sidecar and republishes the
+// events into a serve-side progress.Publisher (the Broker feeding the dashboard
+// SSE). Single-goroutine: all state (states map, lastPrune) is touched only by
+// tick(), which run() calls serially, so no internal locking is needed.
+type sidecarTailer struct {
+	pub    progress.Publisher
+	logger *slog.Logger
+
+	interval    time.Duration
+	pruneEvery  time.Duration
+	pruneMaxAge time.Duration
+
+	// groupsFn returns the group slugs to tail. Defaults to the registered
+	// fleet groups; injectable in tests. Re-evaluated every tick so a group
+	// registered mid-session (its sidecar appearing under GRAFEL_HOME/progress)
+	// is picked up by the next rescan.
+	groupsFn func() []string
+
+	states    map[string]*groupTailState
+	lastPrune time.Time
+
+	stop chan struct{}
+	done chan struct{}
+}
+
+// newSidecarTailer constructs a tailer that republishes into pub every interval.
+// logger may be nil (best-effort read failures are then swallowed).
+func newSidecarTailer(pub progress.Publisher, interval time.Duration, logger *slog.Logger) *sidecarTailer {
+	if interval <= 0 {
+		interval = defaultSidecarTailPoll
+	}
+	return &sidecarTailer{
+		pub:         pub,
+		logger:      logger,
+		interval:    interval,
+		pruneEvery:  defaultSidecarPruneEvery,
+		pruneMaxAge: defaultSidecarPruneMaxAge,
+		groupsFn:    registryGroupSlugs,
+		states:      make(map[string]*groupTailState),
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+	}
+}
+
+// registryGroupSlugs returns the slug for every registered fleet group. The
+// slug is the group Name — identical to the args.Group the engine's
+// SidecarWriter is keyed on — so progress.SidecarReader(name) derives the same
+// hashed on-disk path the writer appended to.
+func registryGroupSlugs() []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	out := make([]string, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, g.Name)
+	}
+	return out
+}
+
+// isGroupTerminal reports whether e is the GROUP-scoped terminal (the link
+// tracker's Done/Fail, emitted with RepoSlug == GroupSlug). Per-repo terminals
+// (RepoSlug != GroupSlug) do not stop tailing — other repos and the group link
+// pass are still to come.
+func isGroupTerminal(e progress.Event) bool {
+	return e.RepoSlug == e.GroupSlug &&
+		(e.Phase == progress.PhaseDone || e.Phase == progress.PhaseError)
+}
+
+// shrank reports whether the on-disk sidecar is now smaller than the offset we
+// consumed to — the signal that a NEW run truncated it (NewSidecarWriter /
+// Reset) or it was compacted. Used to decide whether to RESUME a group we
+// previously saw terminate.
+func (t *sidecarTailer) shrank(st *groupTailState) bool {
+	fi, err := os.Stat(st.reader.Path())
+	if err != nil {
+		return false
+	}
+	return fi.Size() < st.offset
+}
+
+// tick performs one poll pass: for each known group, tail newly-appended lines
+// and republish them. Idempotent and safe to call repeatedly.
+func (t *sidecarTailer) tick() {
+	for _, slug := range t.groupsFn() {
+		st := t.states[slug]
+		if st == nil {
+			r, err := progress.NewSidecarReader(slug)
+			if err != nil {
+				if t.logger != nil {
+					t.logger.Warn("progress tailer: reader init failed", "group", slug, "err", err)
+				}
+				continue
+			}
+			st = &groupTailState{reader: r}
+			t.states[slug] = st
+		}
+
+		// Once a group reached its group-scoped terminal we stop republishing —
+		// there is nothing new until a fresh run. But a fresh run REUSES the same
+		// file (truncate), so keep watching for a shrink and resume when one
+		// appears (the offset-reset/replay path below then re-seeds from 0).
+		if st.terminal {
+			if !t.shrank(st) {
+				continue
+			}
+			st.terminal = false
+		}
+
+		events, newOffset, err := st.reader.ReadFrom(st.offset)
+		if err != nil {
+			if t.logger != nil {
+				t.logger.Warn("progress tailer: read failed", "group", slug, "err", err)
+			}
+			continue
+		}
+		// OFFSET-RESET HANDLING: when ReadFrom returns newOffset < st.offset the
+		// file shrank (new run / compaction) and `events` is a full replay from
+		// 0. We must NOT skip them — the dashboard fold is idempotent, so
+		// republishing re-derives the current run's state. Saving newOffset
+		// (smaller) re-seeds the cursor onto the new run.
+		st.offset = newOffset
+		for _, e := range events {
+			t.pub.Publish(e)
+			if isGroupTerminal(e) {
+				st.terminal = true
+			}
+		}
+	}
+	t.maybePrune()
+}
+
+// maybePrune runs PruneTerminalSidecars at most once per pruneEvery so
+// terminated group files do not accumulate over a long serve lifetime.
+func (t *sidecarTailer) maybePrune() {
+	if t.pruneEvery <= 0 {
+		return
+	}
+	if time.Since(t.lastPrune) < t.pruneEvery {
+		return
+	}
+	t.lastPrune = time.Now()
+	if _, err := progress.PruneTerminalSidecars(t.pruneMaxAge); err != nil && t.logger != nil {
+		t.logger.Warn("progress tailer: prune failed", "err", err)
+	}
+}
+
+// run is the single tailer goroutine: tail once immediately (so a reconnecting
+// dashboard sees current state promptly), then on every tick until stopped.
+func (t *sidecarTailer) run() {
+	defer close(t.done)
+	ticker := time.NewTicker(t.interval)
+	defer ticker.Stop()
+	t.tick()
+	for {
+		select {
+		case <-t.stop:
+			return
+		case <-ticker.C:
+			t.tick()
+		}
+	}
+}
+
+// shutdown stops the tailer goroutine and joins it. Call exactly once.
+func (t *sidecarTailer) shutdown() {
+	close(t.stop)
+	<-t.done
+}
+
+// startSidecarTailer launches the serve-side progress-sidecar tailer and
+// returns a stop func that joins the goroutine on shutdown. Mirrors
+// startStatusWriter's lifecycle contract. Started ONLY in the serve plane (see
+// run() in server.go) — never in the engine, which is the writer.
+func startSidecarTailer(pub progress.Publisher, interval time.Duration, logger *slog.Logger) (stop func()) {
+	t := newSidecarTailer(pub, interval, logger)
+	go t.run()
+	return t.shutdown
+}

--- a/internal/daemon/progress_tailer_test.go
+++ b/internal/daemon/progress_tailer_test.go
@@ -1,0 +1,213 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// collectPub is a thread-safe progress.Publisher that records every event so a
+// test can assert what the tailer republished, in order.
+type collectPub struct {
+	mu     sync.Mutex
+	events []progress.Event
+}
+
+func (c *collectPub) Publish(e progress.Event) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.events = append(c.events, e)
+}
+
+func (c *collectPub) snapshot() []progress.Event {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]progress.Event, len(c.events))
+	copy(out, c.events)
+	return out
+}
+
+// writeSidecarFixture hand-writes an NDJSON sidecar for slug at its
+// deterministic on-disk path (the same path progress.NewSidecarReader(slug)
+// reads). Overwrites (truncates) so it doubles as the "new run" rotation used
+// by the offset-reset test.
+func writeSidecarFixture(t *testing.T, slug string, lines []progress.SidecarLine) {
+	t.Helper()
+	path, err := progress.SidecarPath(slug)
+	if err != nil {
+		t.Fatalf("SidecarPath(%q): %v", slug, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	var buf bytes.Buffer
+	for _, l := range lines {
+		b, err := json.Marshal(l)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		buf.Write(b)
+		buf.WriteByte('\n')
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+}
+
+// TestSidecarTailer_RepublishesMultiGroup writes two group sidecars — each with
+// per-module extraction events and a group-scoped terminal — and asserts the
+// tailer republishes every event (per-module included), preserves order, marks
+// each group terminal, and republishes NOTHING further after the terminal.
+func TestSidecarTailer_RepublishesMultiGroup(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	writeSidecarFixture(t, "grp-a", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-x", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10},
+		{Seq: 2, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-y", Phase: progress.PhaseExtractAST, FilesDone: 3, FilesTotal: 8},
+		{Seq: 3, GroupSlug: "grp-a", RepoSlug: "grp-a", Phase: progress.PhaseDone, Done: true},
+	})
+	writeSidecarFixture(t, "grp-b", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp-b", RepoSlug: "svc", Module: "mod-z", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 4},
+		{Seq: 2, GroupSlug: "grp-b", RepoSlug: "grp-b", Phase: progress.PhaseDone, Done: true},
+	})
+
+	pub := &collectPub{}
+	tl := newSidecarTailer(pub, time.Hour, nil)
+	tl.groupsFn = func() []string { return []string{"grp-a", "grp-b"} }
+
+	tl.tick()
+	got := pub.snapshot()
+
+	// Every fixture line for both groups must be republished.
+	if len(got) != 5 {
+		t.Fatalf("republished %d events, want 5: %+v", len(got), got)
+	}
+
+	// Ordering: grp-a's three (in seq order) then grp-b's two.
+	wantOrder := []struct {
+		group, repo, module, phase string
+	}{
+		{"grp-a", "repo1", "mod-x", progress.PhaseExtractAST},
+		{"grp-a", "repo1", "mod-y", progress.PhaseExtractAST},
+		{"grp-a", "grp-a", "", progress.PhaseDone},
+		{"grp-b", "svc", "mod-z", progress.PhaseExtractAST},
+		{"grp-b", "grp-b", "", progress.PhaseDone},
+	}
+	for i, w := range wantOrder {
+		e := got[i]
+		if e.GroupSlug != w.group || e.RepoSlug != w.repo || e.Module != w.module || e.Phase != w.phase {
+			t.Errorf("event[%d] = {g:%q r:%q m:%q p:%q}, want {g:%q r:%q m:%q p:%q}",
+				i, e.GroupSlug, e.RepoSlug, e.Module, e.Phase, w.group, w.repo, w.module, w.phase)
+		}
+	}
+
+	// Both groups marked terminal (group-scoped done seen).
+	if st := tl.states["grp-a"]; st == nil || !st.terminal {
+		t.Error("grp-a not marked terminal")
+	}
+	if st := tl.states["grp-b"]; st == nil || !st.terminal {
+		t.Error("grp-b not marked terminal")
+	}
+
+	// A subsequent tick republishes NOTHING — tailer stops on terminal.
+	tl.tick()
+	if n := len(pub.snapshot()); n != 5 {
+		t.Errorf("after terminal, republished more events: got %d, want 5", n)
+	}
+}
+
+// TestSidecarTailer_OffsetResetReplay verifies that after the tailer consumes a
+// run, truncating + rewriting the sidecar for a NEW (smaller) run is detected as
+// a shrink and replayed from 0 — no stale-offset stall.
+func TestSidecarTailer_OffsetResetReplay(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	// Run 1: two lines, no terminal (still tailing).
+	writeSidecarFixture(t, "grp", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp", RepoSlug: "r", Module: "m", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 20},
+		{Seq: 2, GroupSlug: "grp", RepoSlug: "r", Module: "m", Phase: progress.PhaseExtractAST, FilesDone: 15, FilesTotal: 20},
+	})
+
+	pub := &collectPub{}
+	tl := newSidecarTailer(pub, time.Hour, nil)
+	tl.groupsFn = func() []string { return []string{"grp"} }
+
+	tl.tick()
+	if n := len(pub.snapshot()); n != 2 {
+		t.Fatalf("run 1 republished %d events, want 2", n)
+	}
+	off := tl.states["grp"].offset
+	if off <= 0 {
+		t.Fatalf("offset not advanced: %d", off)
+	}
+
+	// Run 2: a single, SHORTER line — the file is now smaller than off, so the
+	// reader must detect the shrink and replay from 0.
+	writeSidecarFixture(t, "grp", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp", RepoSlug: "r", Module: "m", Phase: progress.PhaseScan, FilesDone: 2, FilesTotal: 6},
+	})
+	if fi, _ := os.Stat(tl.states["grp"].reader.Path()); fi.Size() >= off {
+		t.Fatalf("run 2 file not smaller than prior offset (%d >= %d); test cannot exercise shrink", fi.Size(), off)
+	}
+
+	tl.tick()
+	got := pub.snapshot()
+	// The new run's event must have been republished (not stalled behind the
+	// stale large offset).
+	last := got[len(got)-1]
+	if last.Phase != progress.PhaseScan || last.FilesDone != 2 {
+		t.Errorf("new-run event not republished; last = %+v", last)
+	}
+	// Offset re-seeded to the (smaller) new-run size.
+	if tl.states["grp"].offset >= off {
+		t.Errorf("offset not re-seeded after shrink: got %d, prior %d", tl.states["grp"].offset, off)
+	}
+}
+
+// TestSidecarTailer_StartStopLifecycle exercises the goroutine start/stop path:
+// startSidecarTailer's returned stop func must join the goroutine, and a
+// running tailer must republish a fixture's events end-to-end.
+func TestSidecarTailer_StartStopLifecycle(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	writeSidecarFixture(t, "live", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "live", RepoSlug: "r", Module: "m", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 2},
+		{Seq: 2, GroupSlug: "live", RepoSlug: "live", Phase: progress.PhaseDone, Done: true},
+	})
+
+	pub := &collectPub{}
+	tl := newSidecarTailer(pub, 15*time.Millisecond, nil)
+	tl.groupsFn = func() []string { return []string{"live"} }
+	go tl.run()
+
+	deadline := time.After(2 * time.Second)
+	for {
+		if len(pub.snapshot()) >= 2 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("tailer did not republish fixture in time; got %d", len(pub.snapshot()))
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+	// stop must join cleanly.
+	tl.shutdown()
+
+	// Terminal delivered.
+	var sawTerminal bool
+	for _, e := range pub.snapshot() {
+		if e.Phase == progress.PhaseDone {
+			sawTerminal = true
+		}
+	}
+	if !sawTerminal {
+		t.Error("terminal event never republished")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/watch"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/progress"
 )
 
 // defaultActivateConcurrency bounds how many worktree working-tree fsnotify
@@ -53,6 +54,16 @@ type Config struct {
 	// Logger is the *slog.Logger used by daemon-internal code and all sub-packages.
 	// When nil, Run constructs a default stderr slog.Logger.
 	Logger *slog.Logger
+
+	// ProgressBroker is the serve-plane indexer progress bus the dashboard SSE
+	// subscribes to (the cmd/grafel daemonProgressBroker). In SPLIT mode the
+	// engine indexes in a separate process and publishes progress into ITS own
+	// broker, so serve's dashboard would otherwise see nothing; the serve-side
+	// sidecarTailer (started only in planeServeOnly) tails the engine's per-group
+	// NDJSON sidecars and republishes each event into THIS broker. nil disables
+	// the tailer (monolith carries everything in-process; tests without a
+	// dashboard leave it unset). ADR-0024 / epic #5729.
+	ProgressBroker progress.Publisher
 
 	// Phase B optional wiring. When all four are non-nil the daemon
 	// starts the fsnotify watcher + scheduler and registers every
@@ -640,6 +651,19 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	if plane != planeServeOnly {
 		ep := startEnginePlane(ctx, cfg, svc, logger)
 		defer ep.shutdown()
+	}
+
+	// Split-mode progress bridge — READ side (ADR-0024 / epic #5729). ONLY the
+	// serve plane tails the engine's per-group progress sidecars and republishes
+	// them into serve's broker so the dashboard/wizard SSE renders live per-repo
+	// / per-module rows even though the engine indexed in a separate process. It
+	// must NOT run in the engine plane (the engine is the WRITER) nor in the
+	// monolith (planeServeOnly is only ever selected under SplitModeEnabled, and
+	// the in-process broker already carries everything). Gated on a wired broker
+	// so a serve process with no dashboard (tests) is a no-op.
+	if plane == planeServeOnly && SplitModeEnabled() && cfg.ProgressBroker != nil {
+		stopTailer := startSidecarTailer(cfg.ProgressBroker, defaultSidecarTailPoll, logger)
+		defer stopTailer()
 	}
 
 	// Dashboard HTTP server — started in a goroutine so it does not


### PR DESCRIPTION
## What
Makes index progress visible across the split-mode serve↔engine process boundary — the piece that lets the wizard (and dashboard onboarding) show **live per-module progress bars** in split mode instead of a fake instant 0→100.

- **Engine write:** `daemonRebuildFuncCore` tees the progress publisher with a per-group `progress.SidecarWriter` when `SplitModeEnabled()`; per-repo indexer + group link tracker both flow through the tee. Monolith path unchanged (bare broker, no sidecar files).
- **Serve read:** new `internal/daemon/progress_tailer.go` — a tailer (serve plane only) polls registered groups every 120ms, tails each group's NDJSON sidecar via `SidecarReader`, and republishes events into serve's `daemonProgressBroker` (the instance feeding `/api/index-progress/{group}` SSE). Handles offset-reset replay; prunes terminal'd files.
- Also fixes the dashboard web-onboard progress for free (same Rebuild RPC → same broker → same SSE).

## Review
Independent adversarial review APPROVED. Verified airtight: first-index group pickup (tailer re-enumerates the registry every tick; group registered before the Rebuild RPC), terminal delivery to the SSE broker instance, offset-reset/compaction handling, monolith byte-identical (zero progress/ files), hot-path non-blocking, no goroutine leak. Confirmed `TestDaemonRebuildParallel` timing flakiness is pre-existing on main (not a regression). `-race` suite green (563 tests).

Non-blocking follow-ups (tracked): switch shrink-detection from size to inode/generation; sync.Once-guard shutdown(); add a real-broker/subscriber + terminal-resume test.

Refs #5729, #5721