### PR TITLE
fix(index): emit independent per-module extraction progress ticks (#5721)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -820,6 +820,15 @@ func moduleForFile(currentFile string, pkgRoots []string, markers module.MarkerS
 	return module.Derive(f, markers)
 }
 
+// moduleRowWorthy reports whether a resolved module label deserves its own
+// per-module progress bar. Empty (no resolver) and the repo-root sentinel
+// (module.RootLabel — stray files at the repo root that belong to no package)
+// get no independent row: the wizard has no meaningful bar to show them in, and
+// a "_root" row is noise next to the real packages.
+func moduleRowWorthy(mod string) bool {
+	return mod != "" && mod != module.RootLabel
+}
+
 // Run executes the orchestrated pipeline. Each pass is a named method so
 // callers (and tests) can reason about per-pass output independently.
 func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, error) {
@@ -2997,13 +3006,6 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 		classified []classifiedFile
 	)
 
-	publishTick := func(filesDone int, bytesSeen int64, currentFile string) {
-		if trk == nil {
-			return
-		}
-		trk.Tick(progress.PhaseExtractAST, filesDone, bytesSeen, currentFile, 0)
-	}
-
 	// Per-module tick cadence (per-module progress bars). The bare global
 	// fileCounter gate — tick only when the GLOBAL count hits a multiple of
 	// TickEveryNFiles — emitted ZERO per-module ticks for a monorepo with fewer
@@ -3011,28 +3013,50 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 	// module got a row only if one of its files happened to land on a global
 	// multiple of 20). We instead track each module and emit on its FIRST file
 	// (prompt per-module row), on its own N-file cadence (liveness within a big
-	// module), or on the global N-file cadence (aggregate liveness); a final
-	// per-module flush after the workers join guarantees every package has a
-	// fresh row. Guarded by pmMu; only active when a tracker is present.
+	// module), or on its LAST file (a module smaller than N still reaches its
+	// own 100% mid-run); a final per-module flush after the workers join
+	// guarantees every package reaches
+	// 100%. Each tick carries the MODULE's own done/total (via TickModule), so
+	// the bars advance INDEPENDENTLY like the per-repo fleet bars rather than in
+	// lockstep on the aggregate. Guarded by pmMu; only active with a tracker.
+	//
+	// Precompute per-module TOTALS once from the (post-incremental-filter) file
+	// list so each bar knows its own denominator. Files with no meaningful
+	// module (repo-root strays → module.RootLabel, or no resolver) are excluded:
+	// they get no independent bar (the wizard has no row to show them in).
 	var (
 		pmMu           sync.Mutex
 		moduleCount    = map[string]int{}
 		moduleLastFile = map[string]string{}
+		moduleTotal    = map[string]int{}
 	)
-	recordAndMaybeTick := func(filesDone int, bytesSeen int64, currentFile string) {
+	if trk != nil {
+		for _, rel := range files {
+			if m := trk.ResolveModule(rel); moduleRowWorthy(m) {
+				moduleTotal[m]++
+			}
+		}
+	}
+	recordAndMaybeTick := func(bytesSeen int64, currentFile string) {
 		if trk == nil {
 			return
 		}
 		mod := trk.ResolveModule(currentFile)
+		if !moduleRowWorthy(mod) {
+			return
+		}
 		pmMu.Lock()
 		moduleCount[mod]++
 		c := moduleCount[mod]
+		total := moduleTotal[mod]
 		moduleLastFile[mod] = currentFile
 		pmMu.Unlock()
 		// Coalescing downstream collapses volume, so over-emitting is cheap and
 		// safe: prefer guaranteed per-module coverage over minimal event count.
-		if c == 1 || c%progress.TickEveryNFiles == 0 || filesDone%progress.TickEveryNFiles == 0 {
-			publishTick(filesDone, bytesSeen, currentFile)
+		// Emit on this module's FIRST file, its own N-file cadence, or its last
+		// file (so a module smaller than N still reaches its own 100% mid-run).
+		if c == 1 || c%progress.TickEveryNFiles == 0 || c == total {
+			trk.TickModule(progress.PhaseExtractAST, mod, c, total, bytesSeen, currentFile, 0)
 		}
 	}
 
@@ -3051,8 +3075,8 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					mu.Lock()
 					i.stats.skipped++
 					mu.Unlock()
-					n := int(atomic.AddInt64(&fileCounter, 1))
-					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					atomic.AddInt64(&fileCounter, 1)
+					recordAndMaybeTick(atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3061,8 +3085,8 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					mu.Lock()
 					i.stats.failed++
 					mu.Unlock()
-					n := int(atomic.AddInt64(&fileCounter, 1))
-					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					atomic.AddInt64(&fileCounter, 1)
+					recordAndMaybeTick(atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3120,8 +3144,8 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					mu.Lock()
 					classified = append(classified, cf)
 					mu.Unlock()
-					n := int(atomic.AddInt64(&fileCounter, 1))
-					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					atomic.AddInt64(&fileCounter, 1)
+					recordAndMaybeTick(atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3148,20 +3172,21 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				classified = append(classified, cf)
 				mu.Unlock()
 
-				n := int(atomic.AddInt64(&fileCounter, 1))
-				if n%progress.TickEveryNFiles == 0 {
-					publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
-				}
+				atomic.AddInt64(&fileCounter, 1)
+				recordAndMaybeTick(atomic.LoadInt64(&byteCounter), t.relPath)
 			}
 		}()
 	}
 	wg.Wait()
 
-	// Final per-module flush: guarantee at least one fresh extracting_ast line
-	// per module at end-of-extraction so every package's row survives downstream
-	// coalescing even for fast/small repos where no periodic tick fired.
+	// Final per-module flush: emit each module at its OWN 100% (moduleTotal /
+	// moduleTotal) at end-of-extraction so every package's row reaches complete
+	// and survives downstream coalescing even for fast/small repos where no
+	// periodic tick fired. NOTE: a monorepo with >256 distinct modules can burst
+	// past the sidecar's 256-event buffer here — acceptable: the sidecar
+	// coalesces to latest-per-(repo,module) on disk so every module's row still
+	// survives, though a dropped final tick may leave a row a hair under 100%.
 	if trk != nil {
-		total := int(atomic.LoadInt64(&fileCounter))
 		bytesSeen := atomic.LoadInt64(&byteCounter)
 		pmMu.Lock()
 		mods := make([]string, 0, len(moduleLastFile))
@@ -3170,7 +3195,8 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 		}
 		sort.Strings(mods)
 		for _, m := range mods {
-			publishTick(total, bytesSeen, moduleLastFile[m])
+			total := moduleTotal[m]
+			trk.TickModule(progress.PhaseExtractAST, m, total, total, bytesSeen, moduleLastFile[m], 0)
 		}
 		pmMu.Unlock()
 	}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -3004,6 +3004,38 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 		trk.Tick(progress.PhaseExtractAST, filesDone, bytesSeen, currentFile, 0)
 	}
 
+	// Per-module tick cadence (per-module progress bars). The bare global
+	// fileCounter gate — tick only when the GLOBAL count hits a multiple of
+	// TickEveryNFiles — emitted ZERO per-module ticks for a monorepo with fewer
+	// than TickEveryNFiles files, and only incidental coverage otherwise (a
+	// module got a row only if one of its files happened to land on a global
+	// multiple of 20). We instead track each module and emit on its FIRST file
+	// (prompt per-module row), on its own N-file cadence (liveness within a big
+	// module), or on the global N-file cadence (aggregate liveness); a final
+	// per-module flush after the workers join guarantees every package has a
+	// fresh row. Guarded by pmMu; only active when a tracker is present.
+	var (
+		pmMu           sync.Mutex
+		moduleCount    = map[string]int{}
+		moduleLastFile = map[string]string{}
+	)
+	recordAndMaybeTick := func(filesDone int, bytesSeen int64, currentFile string) {
+		if trk == nil {
+			return
+		}
+		mod := trk.ResolveModule(currentFile)
+		pmMu.Lock()
+		moduleCount[mod]++
+		c := moduleCount[mod]
+		moduleLastFile[mod] = currentFile
+		pmMu.Unlock()
+		// Coalescing downstream collapses volume, so over-emitting is cheap and
+		// safe: prefer guaranteed per-module coverage over minimal event count.
+		if c == 1 || c%progress.TickEveryNFiles == 0 || filesDone%progress.TickEveryNFiles == 0 {
+			publishTick(filesDone, bytesSeen, currentFile)
+		}
+	}
+
 	var wg sync.WaitGroup
 	for w := 0; w < i.workers; w++ {
 		wg.Add(1)
@@ -3020,9 +3052,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					i.stats.skipped++
 					mu.Unlock()
 					n := int(atomic.AddInt64(&fileCounter, 1))
-					if n%progress.TickEveryNFiles == 0 {
-						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
-					}
+					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3032,9 +3062,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					i.stats.failed++
 					mu.Unlock()
 					n := int(atomic.AddInt64(&fileCounter, 1))
-					if n%progress.TickEveryNFiles == 0 {
-						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
-					}
+					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3093,9 +3121,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					classified = append(classified, cf)
 					mu.Unlock()
 					n := int(atomic.AddInt64(&fileCounter, 1))
-					if n%progress.TickEveryNFiles == 0 {
-						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
-					}
+					recordAndMaybeTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
 
@@ -3130,6 +3156,25 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 		}()
 	}
 	wg.Wait()
+
+	// Final per-module flush: guarantee at least one fresh extracting_ast line
+	// per module at end-of-extraction so every package's row survives downstream
+	// coalescing even for fast/small repos where no periodic tick fired.
+	if trk != nil {
+		total := int(atomic.LoadInt64(&fileCounter))
+		bytesSeen := atomic.LoadInt64(&byteCounter)
+		pmMu.Lock()
+		mods := make([]string, 0, len(moduleLastFile))
+		for m := range moduleLastFile {
+			mods = append(mods, m)
+		}
+		sort.Strings(mods)
+		for _, m := range mods {
+			publishTick(total, bytesSeen, moduleLastFile[m])
+		}
+		pmMu.Unlock()
+	}
+
 	// Issue #481 — worker-pool outputs accumulate in goroutine-scheduling
 	// order. Sort by canonical fields so downstream passes (BuildIndex
 	// first-writer-wins, dedup) see a stable slice and graph.json is

--- a/cmd/grafel/progress_permodule_test.go
+++ b/cmd/grafel/progress_permodule_test.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// writeJSMonorepo builds a synthetic npm-workspaces monorepo under dir with the
+// given packages, each populated with filesPerPkg trivial .js files. It returns
+// the repo-relative package roots (e.g. "packages/alpha"). The layout is a real
+// TRUE monorepo: a package.json workspaces manifest AND a packages/ container,
+// so detect.DetectMonorepo classifies it with >=2 package roots.
+func writeJSMonorepo(t *testing.T, dir string, pkgs []string, filesPerPkg int) []string {
+	t.Helper()
+	root := `{"name":"root","private":true,"workspaces":["packages/*"]}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(root), 0o644); err != nil {
+		t.Fatalf("write root package.json: %v", err)
+	}
+	roots := make([]string, 0, len(pkgs))
+	for _, p := range pkgs {
+		pkgDir := filepath.Join(dir, "packages", p)
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", pkgDir, err)
+		}
+		manifest := fmt.Sprintf(`{"name":"@scope/%s","version":"1.0.0"}`, p)
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(manifest), 0o644); err != nil {
+			t.Fatalf("write %s package.json: %v", p, err)
+		}
+		for f := 0; f < filesPerPkg; f++ {
+			src := fmt.Sprintf("export function %s_fn%d(a, b) {\n  return a + b + %d;\n}\n", p, f, f)
+			name := fmt.Sprintf("mod%d.js", f)
+			if err := os.WriteFile(filepath.Join(pkgDir, name), []byte(src), 0o644); err != nil {
+				t.Fatalf("write %s/%s: %v", p, name, err)
+			}
+		}
+		roots = append(roots, "packages/"+p)
+	}
+	return roots
+}
+
+// TestPerModuleExtractTicks_SmallMonorepo is the STEP-1 experiment turned
+// regression test. It runs a REAL index over a synthetic JS-workspaces monorepo
+// through a RECORDING publisher (not the coalescing sidecar) and asserts that
+// per-file extracting_ast Ticks with a NON-EMPTY, correct Module are published
+// for EVERY package — even when each package has only a handful of files (well
+// under progress.TickEveryNFiles).
+//
+// Before the fix, extraction ticks were gated solely on the GLOBAL file counter
+// hitting a multiple of TickEveryNFiles (20) with no final flush, so a monorepo
+// whose total file count is < 20 (or whose per-module files never coincide with
+// a global multiple of 20) emitted ZERO per-module ticks. This reproduces the
+// deployed-daemon evidence: only post-extraction Phase() events reached the
+// sidecar, no per-module rows.
+func TestPerModuleExtractTicks_SmallMonorepo(t *testing.T) {
+	dir := t.TempDir()
+	// 3 files/pkg * 2 pkgs = 6 project .js files — deliberately < TickEveryNFiles
+	// so the old global-counter gate emits nothing.
+	roots := writeJSMonorepo(t, dir, []string{"alpha", "beta"}, 3)
+
+	// Sanity: the fixture must be a TRUE monorepo with >=2 packages, else the
+	// resolver installs a single per-repo label and the test proves nothing.
+	mono, err := detect.DetectMonorepo(dir)
+	if err != nil {
+		t.Fatalf("DetectMonorepo: %v", err)
+	}
+	if mono.Kind == detect.KindNone {
+		t.Fatalf("fixture not detected as a monorepo (Kind=%q); packages=%v", mono.Kind, mono.Packages)
+	}
+	if len(mono.Packages) < 2 {
+		t.Fatalf("expected >=2 packages, got %d: %v", len(mono.Packages), mono.Packages)
+	}
+
+	col := &progress.SliceCollector{}
+	idx := newTestIndexer(t, "jsmono", nil, "")
+	idx.publisher = col
+	idx.repoSlug = "jsmono"
+
+	if _, err := idx.Run(context.Background(), dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	// Collect the set of modules that received an extracting_ast tick.
+	modTicks := map[string]int{}
+	for _, e := range col.Events {
+		if e.Phase == progress.PhaseExtractAST && e.Module != "" {
+			modTicks[e.Module]++
+		}
+	}
+
+	for _, want := range roots {
+		if modTicks[want] == 0 {
+			t.Errorf("no per-module extracting_ast tick for module %q (got module ticks: %v)", want, modTicks)
+		}
+	}
+}
+
+// TestPerModuleExtractTicks_LargerMonorepo asserts full per-module coverage even
+// when total file count exceeds TickEveryNFiles: EVERY package must get at least
+// one tick, not just whichever package happened to own a file landing on a
+// global multiple of 20. Three packages of 8 files each = 24 total; under the
+// old global gate only the single file at global index 20 would tick, covering
+// at most one package.
+func TestPerModuleExtractTicks_LargerMonorepo(t *testing.T) {
+	dir := t.TempDir()
+	roots := writeJSMonorepo(t, dir, []string{"alpha", "beta", "gamma"}, 8)
+
+	col := &progress.SliceCollector{}
+	idx := newTestIndexer(t, "jsmono3", nil, "")
+	idx.publisher = col
+	idx.repoSlug = "jsmono3"
+
+	if _, err := idx.Run(context.Background(), dir); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	modTicks := map[string]int{}
+	for _, e := range col.Events {
+		if e.Phase == progress.PhaseExtractAST && e.Module != "" {
+			modTicks[e.Module]++
+		}
+	}
+	for _, want := range roots {
+		if modTicks[want] == 0 {
+			t.Errorf("no per-module extracting_ast tick for module %q (got: %v)", want, modTicks)
+		}
+	}
+}

--- a/cmd/grafel/progress_permodule_test.go
+++ b/cmd/grafel/progress_permodule_test.go
@@ -5,66 +5,61 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/progress"
 )
 
-// writeJSMonorepo builds a synthetic npm-workspaces monorepo under dir with the
-// given packages, each populated with filesPerPkg trivial .js files. It returns
-// the repo-relative package roots (e.g. "packages/alpha"). The layout is a real
-// TRUE monorepo: a package.json workspaces manifest AND a packages/ container,
-// so detect.DetectMonorepo classifies it with >=2 package roots.
-func writeJSMonorepo(t *testing.T, dir string, pkgs []string, filesPerPkg int) []string {
+// pkgSpec describes one synthetic monorepo package.
+type pkgSpec struct {
+	name         string
+	files        int  // number of extractable .js source files
+	withManifest bool // whether to write a package.json (a classifier-SKIPPED file)
+}
+
+// writeJSMonorepo builds a synthetic npm-workspaces monorepo under dir. The root
+// carries a package.json `workspaces` manifest AND a packages/ container, so
+// detect.DetectMonorepo classifies it as a TRUE monorepo. Each package gets
+// spec.files trivial .js files; a manifest is written only when requested — a
+// manifest-less package has NO classifier-skipped file, so its per-module bar
+// can only be driven by extracted SOURCE (the B1 regression guard). Returns the
+// repo-relative package roots (e.g. "packages/alpha").
+func writeJSMonorepo(t *testing.T, dir string, specs []pkgSpec) []string {
 	t.Helper()
 	root := `{"name":"root","private":true,"workspaces":["packages/*"]}`
 	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(root), 0o644); err != nil {
 		t.Fatalf("write root package.json: %v", err)
 	}
-	roots := make([]string, 0, len(pkgs))
-	for _, p := range pkgs {
-		pkgDir := filepath.Join(dir, "packages", p)
+	roots := make([]string, 0, len(specs))
+	for _, s := range specs {
+		pkgDir := filepath.Join(dir, "packages", s.name)
 		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
 			t.Fatalf("mkdir %s: %v", pkgDir, err)
 		}
-		manifest := fmt.Sprintf(`{"name":"@scope/%s","version":"1.0.0"}`, p)
-		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(manifest), 0o644); err != nil {
-			t.Fatalf("write %s package.json: %v", p, err)
-		}
-		for f := 0; f < filesPerPkg; f++ {
-			src := fmt.Sprintf("export function %s_fn%d(a, b) {\n  return a + b + %d;\n}\n", p, f, f)
-			name := fmt.Sprintf("mod%d.js", f)
-			if err := os.WriteFile(filepath.Join(pkgDir, name), []byte(src), 0o644); err != nil {
-				t.Fatalf("write %s/%s: %v", p, name, err)
+		if s.withManifest {
+			manifest := fmt.Sprintf(`{"name":"@scope/%s","version":"1.0.0"}`, s.name)
+			if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(manifest), 0o644); err != nil {
+				t.Fatalf("write %s package.json: %v", s.name, err)
 			}
 		}
-		roots = append(roots, "packages/"+p)
+		for f := 0; f < s.files; f++ {
+			src := fmt.Sprintf("export function %s_fn%d(a, b) {\n  return a + b + %d;\n}\n", s.name, f, f)
+			name := fmt.Sprintf("mod%d.js", f)
+			if err := os.WriteFile(filepath.Join(pkgDir, name), []byte(src), 0o644); err != nil {
+				t.Fatalf("write %s/%s: %v", s.name, name, err)
+			}
+		}
+		roots = append(roots, "packages/"+s.name)
 	}
 	return roots
 }
 
-// TestPerModuleExtractTicks_SmallMonorepo is the STEP-1 experiment turned
-// regression test. It runs a REAL index over a synthetic JS-workspaces monorepo
-// through a RECORDING publisher (not the coalescing sidecar) and asserts that
-// per-file extracting_ast Ticks with a NON-EMPTY, correct Module are published
-// for EVERY package — even when each package has only a handful of files (well
-// under progress.TickEveryNFiles).
-//
-// Before the fix, extraction ticks were gated solely on the GLOBAL file counter
-// hitting a multiple of TickEveryNFiles (20) with no final flush, so a monorepo
-// whose total file count is < 20 (or whose per-module files never coincide with
-// a global multiple of 20) emitted ZERO per-module ticks. This reproduces the
-// deployed-daemon evidence: only post-extraction Phase() events reached the
-// sidecar, no per-module rows.
-func TestPerModuleExtractTicks_SmallMonorepo(t *testing.T) {
-	dir := t.TempDir()
-	// 3 files/pkg * 2 pkgs = 6 project .js files — deliberately < TickEveryNFiles
-	// so the old global-counter gate emits nothing.
-	roots := writeJSMonorepo(t, dir, []string{"alpha", "beta"}, 3)
-
-	// Sanity: the fixture must be a TRUE monorepo with >=2 packages, else the
-	// resolver installs a single per-repo label and the test proves nothing.
+// runMonorepoIndex indexes dir through a recording publisher and returns the
+// captured events, asserting the fixture is a real monorepo first.
+func runMonorepoIndex(t *testing.T, dir, repoSlug string) []progress.Event {
+	t.Helper()
 	mono, err := detect.DetectMonorepo(dir)
 	if err != nil {
 		t.Fatalf("DetectMonorepo: %v", err)
@@ -77,50 +72,124 @@ func TestPerModuleExtractTicks_SmallMonorepo(t *testing.T) {
 	}
 
 	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "jsmono", nil, "")
+	idx := newTestIndexer(t, repoSlug, nil, "")
 	idx.publisher = col
-	idx.repoSlug = "jsmono"
-
+	idx.repoSlug = repoSlug
 	if _, err := idx.Run(context.Background(), dir); err != nil {
 		t.Fatalf("Run: %v", err)
 	}
+	return col.Events
+}
 
-	// Collect the set of modules that received an extracting_ast tick.
-	modTicks := map[string]int{}
-	for _, e := range col.Events {
-		if e.Phase == progress.PhaseExtractAST && e.Module != "" {
-			modTicks[e.Module]++
+// TestPerModuleExtractTicks_SmallMonorepo is the STEP-1 experiment turned
+// regression test. It runs a REAL index over a synthetic JS-workspaces monorepo
+// through a RECORDING publisher (not the coalescing sidecar) and asserts that
+// per-file extracting_ast Ticks with a NON-EMPTY, correct Module are published
+// for EVERY package — even when each package has only a handful of files (well
+// under progress.TickEveryNFiles) and even for a package with NO manifest
+// (source files must drive the tick — the B1 guard).
+func TestPerModuleExtractTicks_SmallMonorepo(t *testing.T) {
+	dir := t.TempDir()
+	// alpha/beta carry manifests; gamma is manifest-less (source-only), so its
+	// per-module tick can ONLY come from extracted .js — this fails pre-fix,
+	// when only classifier-skipped files populated the per-module maps.
+	roots := writeJSMonorepo(t, dir, []pkgSpec{
+		{name: "alpha", files: 3, withManifest: true},
+		{name: "beta", files: 3, withManifest: true},
+		{name: "gamma", files: 4, withManifest: false},
+	})
+
+	events := runMonorepoIndex(t, dir, "jsmono")
+
+	// Every module must receive an extracting_ast tick whose CurrentFile is a
+	// .js SOURCE file (not a skipped package.json) — proving source drives it.
+	srcTickSeen := map[string]bool{}
+	for _, e := range events {
+		if e.Phase != progress.PhaseExtractAST || e.Module == "" {
+			continue
+		}
+		if strings.HasSuffix(e.CurrentFile, ".js") {
+			srcTickSeen[e.Module] = true
 		}
 	}
-
 	for _, want := range roots {
-		if modTicks[want] == 0 {
-			t.Errorf("no per-module extracting_ast tick for module %q (got module ticks: %v)", want, modTicks)
+		if !srcTickSeen[want] {
+			t.Errorf("module %q: no extracting_ast tick with a .js source CurrentFile (source did not drive the per-module tick)", want)
 		}
 	}
 }
 
-// TestPerModuleExtractTicks_LargerMonorepo asserts full per-module coverage even
-// when total file count exceeds TickEveryNFiles: EVERY package must get at least
-// one tick, not just whichever package happened to own a file landing on a
-// global multiple of 20. Three packages of 8 files each = 24 total; under the
-// old global gate only the single file at global index 20 would tick, covering
-// at most one package.
-func TestPerModuleExtractTicks_LargerMonorepo(t *testing.T) {
+// TestPerModuleExtractTicks_IndependentProgress is the B2 guard: two packages of
+// DIFFERENT sizes must produce per-module ticks with DIFFERENT FilesDone/
+// FilesTotal (distinct denominators / percentages), i.e. the bars advance
+// independently rather than in lockstep on the shared aggregate. It also asserts
+// each module's final tick reaches its OWN 100% (FilesDone == FilesTotal) and
+// that no bogus "_root" row is emitted.
+func TestPerModuleExtractTicks_IndependentProgress(t *testing.T) {
 	dir := t.TempDir()
-	roots := writeJSMonorepo(t, dir, []string{"alpha", "beta", "gamma"}, 8)
+	// Distinct source-file counts → distinct per-module totals. Manifest-less so
+	// FilesTotal reflects source files exactly (no +1 for a skipped manifest).
+	writeJSMonorepo(t, dir, []pkgSpec{
+		{name: "small", files: 3, withManifest: false},
+		{name: "large", files: 9, withManifest: false},
+	})
 
-	col := &progress.SliceCollector{}
-	idx := newTestIndexer(t, "jsmono3", nil, "")
-	idx.publisher = col
-	idx.repoSlug = "jsmono3"
+	events := runMonorepoIndex(t, dir, "jsmono2")
 
-	if _, err := idx.Run(context.Background(), dir); err != nil {
-		t.Fatalf("Run: %v", err)
+	// Track, per module, the FilesTotal seen and the max FilesDone.
+	totals := map[string]int{}
+	maxDone := map[string]int{}
+	for _, e := range events {
+		if e.Phase != progress.PhaseExtractAST || e.Module == "" {
+			continue
+		}
+		if e.Module == "_root" {
+			t.Errorf("bogus _root per-module row emitted: %+v", e)
+		}
+		totals[e.Module] = e.FilesTotal
+		if e.FilesDone > maxDone[e.Module] {
+			maxDone[e.Module] = e.FilesDone
+		}
 	}
 
+	small := "packages/small"
+	large := "packages/large"
+	if totals[small] == 0 || totals[large] == 0 {
+		t.Fatalf("missing per-module ticks: small total=%d large total=%d (all: %v)", totals[small], totals[large], totals)
+	}
+	// Independent denominators — NOT the shared aggregate.
+	if totals[small] == totals[large] {
+		t.Errorf("per-module bars are in lockstep: small FilesTotal=%d == large FilesTotal=%d (expected distinct per-module totals)", totals[small], totals[large])
+	}
+	if totals[small] != 3 || totals[large] != 9 {
+		t.Errorf("per-module FilesTotal not the module's own file count: small=%d (want 3) large=%d (want 9)", totals[small], totals[large])
+	}
+	// Each module reaches its OWN 100%.
+	if maxDone[small] != totals[small] {
+		t.Errorf("small never reached 100%%: maxDone=%d total=%d", maxDone[small], totals[small])
+	}
+	if maxDone[large] != totals[large] {
+		t.Errorf("large never reached 100%%: maxDone=%d total=%d", maxDone[large], totals[large])
+	}
+}
+
+// TestPerModuleExtractTicks_LargerMonorepo asserts full per-module coverage even
+// when total file count exceeds TickEveryNFiles: EVERY package gets at least one
+// tick, not just whichever package owned a file landing on a global multiple of
+// 20. Three packages of 8 files each = 24 total; under the old global gate only
+// the file at global index 20 would tick, covering at most one package.
+func TestPerModuleExtractTicks_LargerMonorepo(t *testing.T) {
+	dir := t.TempDir()
+	roots := writeJSMonorepo(t, dir, []pkgSpec{
+		{name: "alpha", files: 8, withManifest: true},
+		{name: "beta", files: 8, withManifest: true},
+		{name: "gamma", files: 8, withManifest: true},
+	})
+
+	events := runMonorepoIndex(t, dir, "jsmono3")
+
 	modTicks := map[string]int{}
-	for _, e := range col.Events {
+	for _, e := range events {
 		if e.Phase == progress.PhaseExtractAST && e.Module != "" {
 			modTicks[e.Module]++
 		}

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -243,6 +243,15 @@ func (t *Tracker) module(currentFile string) string {
 	return t.moduleResolver(currentFile)
 }
 
+// ResolveModule returns the module label Tick would stamp for currentFile, or
+// "" when no resolver is installed or currentFile is empty. It is exported so
+// the extraction loop can drive per-module tick cadence (first-seen + final
+// flush) consistently with the Module field Tick emits. Pure/read-only: safe
+// to call from concurrent extraction workers.
+func (t *Tracker) ResolveModule(currentFile string) string {
+	return t.module(currentFile)
+}
+
 // NewTracker constructs a Tracker for one indexing job. pub must not be nil;
 // use NoOpPublisher{} for a no-op sink.
 func NewTracker(pub Publisher, groupSlug, repoSlug string) *Tracker {

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -16,7 +16,10 @@
 //     the UI extra detail without requiring the broker or frontend to land.
 package progress
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // Phase labels emitted during indexing. The set deliberately mirrors the
 // user-visible pipeline stages rather than the internal pass numbers so the
@@ -194,15 +197,21 @@ func (b *BufferedPublisher) Publish(e Event) {
 	}
 }
 
-// SliceCollector collects every published event into a slice. It is
-// intended for unit tests only; it holds a mutex so it is goroutine-safe.
+// SliceCollector collects every published event into a slice. It is intended
+// for unit tests only. Publish holds a mutex so it is goroutine-safe: the
+// indexer's extraction workers publish per-module ticks concurrently, so an
+// unsynchronised append would race. Read Events only after the run's producers
+// have joined (e.g. after Indexer.Run returns).
 type SliceCollector struct {
+	mu     sync.Mutex
 	Events []Event
 }
 
 // Publish appends e to Events. Safe for concurrent use.
 func (s *SliceCollector) Publish(e Event) {
+	s.mu.Lock()
 	s.Events = append(s.Events, e)
+	s.mu.Unlock()
 }
 
 // Tracker is the per-indexing-job helper that constructs and publishes
@@ -296,6 +305,31 @@ func (t *Tracker) Tick(phase string, filesDone int, bytesSeen int64, currentFile
 		BytesSeen:        bytesSeen,
 		CurrentFile:      currentFile,
 		Module:           t.module(currentFile),
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// TickModule emits a within-phase progress event for a SPECIFIC module,
+// carrying that module's OWN file progress (moduleDone / moduleTotal) and an
+// explicit module label rather than the repo-wide FilesDone/FilesTotal that
+// Tick derives from the tracker's global counters. This lets a monorepo render
+// one progress bar PER PACKAGE that advances independently — each bar reflects
+// its own module's completion, not the shared aggregate, matching the per-repo
+// fleet bars. currentFile should belong to module so the UI's "extracting: X"
+// label stays consistent; the Module field is stamped verbatim (no resolver
+// round-trip) so the caller controls attribution.
+func (t *Tracker) TickModule(phase, module string, moduleDone, moduleTotal int, bytesSeen int64, currentFile string, entitiesSoFar int) {
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            phase,
+		FilesDone:        moduleDone,
+		FilesTotal:       moduleTotal,
+		EntitiesSoFar:    entitiesSoFar,
+		BytesSeen:        bytesSeen,
+		CurrentFile:      currentFile,
+		Module:           module,
 		PhaseStartedAtMS: t.phaseStartedAtMS,
 		TS:               nowMS(),
 	})

--- a/internal/progress/sidecar_test.go
+++ b/internal/progress/sidecar_test.go
@@ -208,6 +208,48 @@ func TestCoalescing(t *testing.T) {
 	}
 }
 
+// TestPerModuleCoalescingPreservesEveryModule asserts that a burst of
+// interleaved per-module extraction ticks — all landing in a SINGLE flush
+// window — survives coalescing as ONE line per distinct module. This is the
+// downstream half of the per-module-progress fix: even when a small monorepo
+// finishes extraction inside one 200ms window, each package's row must reach
+// the sidecar (coalescing collapses volume PER (repo,module) key, never across
+// modules).
+func TestPerModuleCoalescingPreservesEveryModule(t *testing.T) {
+	setHome(t)
+	w, err := NewSidecarWriter("permod", WithFlushInterval(time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	modules := []string{"packages/alpha", "packages/beta", "packages/gamma"}
+	// Interleave several ticks per module, as concurrent extraction workers
+	// would, all within the (single, Close-forced) flush window.
+	for round := 0; round < 5; round++ {
+		for _, m := range modules {
+			w.Publish(Event{
+				GroupSlug: "permod", RepoSlug: "r", Module: m,
+				Phase: PhaseExtractAST, FilesDone: round, FilesTotal: 15,
+				CurrentFile: m + "/mod.js", TS: int64(round),
+			})
+		}
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+	got := drainReader(t, "permod")
+	seen := map[string]int{}
+	for _, e := range got {
+		if e.Phase == PhaseExtractAST {
+			seen[e.Module]++
+		}
+	}
+	for _, m := range modules {
+		if seen[m] != 1 {
+			t.Errorf("module %q: got %d coalesced lines, want exactly 1 (all modules: %v)", m, seen[m], seen)
+		}
+	}
+}
+
 // TestTerminalFlushesPromptly asserts a terminal event is flushed without
 // waiting for the ticker, even under a long flush interval.
 func TestTerminalFlushesPromptly(t *testing.T) {


### PR DESCRIPTION
## What
Makes the wizard's per-module progress bars actually populate **and advance independently** during a monorepo index.

## Bugs fixed
1. **Per-file extraction ticks only fired on a GLOBAL file counter hitting a multiple of 20, with no final flush** — so a small monorepo emitted zero extraction ticks (no per-module rows at all), and large ones only ticked whichever module owned file #20/#40 (whole modules silently skipped). Found via an end-to-end smoke test (5-file monorepo → empty progress).
2. **Lockstep bars** — every tick stamped the global file count, so all module rows rendered the same aggregate %.

## Fix (`cmd/grafel/index.go`, `internal/progress/event.go`)
- All four extraction paths (extract / skip / read-error / non-extract) now call `recordAndMaybeTick`, so real source files drive per-module bookkeeping (not just classifier-skipped manifests).
- New `Tracker.TickModule(phase, module, moduleDone, moduleTotal, …)` stamps the **module's own** `FilesDone/FilesTotal`. `moduleTotal[mod]` is precomputed once from the scanned file list; each tick (first-file, per-module N-cadence, last-file) and the final per-module flush carry per-module counts → rows advance independently and each reaches its own 100%.
- `moduleRowWorthy` excludes empty / repo-root-stray labels (no bogus `_root` row).

## Review
Independent adversarial review across two rounds. Round 1 caught that the initial fix wired only the skip/error paths (worked by coincidence on JS `package.json` manifests) and that bars were lockstep — both fixed here. Race + hot-path perf verified clean (mutex guards only ~2 map ops; never held across resolver/Publish). Tests: `TestPerModuleExtractTicks_SmallMonorepo` (manifest-less `gamma` package → asserts `.js` CurrentFile, fails pre-fix), `TestPerModuleExtractTicks_IndependentProgress` (3-file vs 9-file modules → distinct denominators, each own 100%). Also fixed a `-race`-caught mutex gap in a test-only collector. `go test -race` green (cmd/grafel 266, progress 114).

Known follow-up (non-blocking): module labels come from `DetectMonorepo` package roots, not `registry.Repo.Modules` (matching them exactly = a later refinement; doesn't affect populate/advance).

Refs #5721, #5729