### PR TITLE
fix(daemon): single-flight group rebuild to bound engine memory (#5681)

### DIFF
--- a/cmd/grafel/daemon_tier_stale_test.go
+++ b/cmd/grafel/daemon_tier_stale_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestIsRepoDirtyAfter_FreshGraphDoesNotEnqueue locks in the P1 freshness gate
+// (#5681): the reactive-reindex path (tierReloadCallback -> isRepoDirtyAfter)
+// must NOT signal "dirty" — i.e. must NOT enqueue a reindex — when every source
+// file is OLDER than the on-disk graph.fb. Only a genuinely newer source file
+// makes the repo dirty. This prevents a boot/cold-wake reindex of a group whose
+// graph is already fresh, one of the overlap sources that piled concurrent
+// multi-GB index runs into the engine.
+func TestIsRepoDirtyAfter_FreshGraphDoesNotEnqueue(t *testing.T) {
+	repo := t.TempDir()
+
+	srcDir := filepath.Join(repo, "src")
+	if err := os.MkdirAll(srcDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	srcFile := filepath.Join(srcDir, "a.go")
+	if err := os.WriteFile(srcFile, []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The graph.fb stand-in — isRepoDirtyAfter only stats mtimes, not content.
+	refFile := filepath.Join(repo, "graph.fb")
+	if err := os.WriteFile(refFile, []byte("fb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	base := time.Now()
+	older := base.Add(-1 * time.Hour)
+	newer := base.Add(1 * time.Hour)
+
+	// Deterministic mtimes: source older than graph.fb == FRESH graph.
+	if err := os.Chtimes(srcFile, older, older); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(refFile, base, base); err != nil {
+		t.Fatal(err)
+	}
+
+	if isRepoDirtyAfter(repo, refFile) {
+		t.Fatal("fresh graph (all source older than graph.fb) must NOT be dirty — would enqueue a needless reindex on boot/cold-wake")
+	}
+
+	// Now make the source newer than graph.fb == STALE graph → must be dirty.
+	if err := os.Chtimes(srcFile, newer, newer); err != nil {
+		t.Fatal(err)
+	}
+	if !isRepoDirtyAfter(repo, refFile) {
+		t.Fatal("stale graph (source newer than graph.fb) MUST be dirty so the reindex is enqueued")
+	}
+}
+
+// TestIsRepoDirtyAfter_SkipDirsIgnored confirms a newer file under a skipped
+// directory (e.g. node_modules) does NOT mark the repo dirty — matching the
+// watcher's skip list — so vendored/build churn never triggers a reindex.
+func TestIsRepoDirtyAfter_SkipDirsIgnored(t *testing.T) {
+	repo := t.TempDir()
+
+	refFile := filepath.Join(repo, "graph.fb")
+	if err := os.WriteFile(refFile, []byte("fb"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Now()
+	if err := os.Chtimes(refFile, base, base); err != nil {
+		t.Fatal(err)
+	}
+
+	// A newer file, but inside node_modules (a skip dir).
+	skipDir := filepath.Join(repo, "node_modules", "pkg")
+	if err := os.MkdirAll(skipDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	vendored := filepath.Join(skipDir, "index.js")
+	if err := os.WriteFile(vendored, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(vendored, base.Add(1*time.Hour), base.Add(1*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	if isRepoDirtyAfter(repo, refFile) {
+		t.Fatal("a newer file under a skip dir (node_modules) must NOT mark the repo dirty")
+	}
+}

--- a/internal/daemon/rebuild_singleflight_test.go
+++ b/internal/daemon/rebuild_singleflight_test.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestRebuild_SingleFlight_NoConcurrentOverlap is the #5681 memory-safety
+// assertion: at most ONE in-process group rebuild may be alive at a time, even
+// when a prior Rebuild RPC times out and its heap-heavy worker goroutine is
+// left running (orphaned). A superseding same-group Rebuild must NOT start a
+// second concurrent rebuild — that overlap is what piled N multi-GB documents
+// into the engine and blew RSS to 3.1GB+ (measured overlap peak ≈ 2x single
+// run in internal/membench).
+//
+// Pre-fix (per-group *sync.Mutex released in the RPC handler's defer on
+// timeout): the orphaned worker keeps running while the mutex is released, so a
+// second same-group Rebuild acquires it and runs concurrently -> max concurrent
+// == 2 -> FAIL. Post-fix (capacity-1 semaphore released only from the worker on
+// real completion): the orphan holds the guard, the second Rebuild blocks and
+// times out without starting work -> max concurrent == 1 -> PASS.
+func TestRebuild_SingleFlight_NoConcurrentOverlap(t *testing.T) {
+	// Shrink the RPC timeout so the first rebuild "times out" quickly while its
+	// worker keeps running, and the second rebuild's acquire also times out
+	// quickly. Restored after the test.
+	prev := rebuildRPCTimeout
+	rebuildRPCTimeout = 120 * time.Millisecond
+	t.Cleanup(func() { rebuildRPCTimeout = prev })
+
+	var (
+		concurrent    int32
+		maxConcurrent int32
+	)
+	release := make(chan struct{}) // unblocks the in-flight rebuild worker
+	firstEntered := make(chan struct{}, 1)
+
+	rebuildFn := func(proto.RebuildArgs) ([]string, string, error) {
+		n := atomic.AddInt32(&concurrent, 1)
+		for {
+			m := atomic.LoadInt32(&maxConcurrent)
+			if n <= m || atomic.CompareAndSwapInt32(&maxConcurrent, m, n) {
+				break
+			}
+		}
+		select {
+		case firstEntered <- struct{}{}:
+		default:
+		}
+		<-release // hold the guard the way a heap-heavy rebuild would
+		atomic.AddInt32(&concurrent, -1)
+		return []string{"/repo/a"}, "", nil
+	}
+
+	svc := newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		rebuildFn,
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+			return proto.QualityAuditReply{}, nil
+		},
+		"/tmp/test.sock",
+		make(chan struct{}),
+		nil,
+		1,
+	)
+
+	// RPC #1: its worker enters rebuildFn and blocks on release. The RPC times
+	// out after rebuildRPCTimeout and returns, but the worker keeps holding the
+	// per-group guard.
+	done1 := make(chan error, 1)
+	go func() {
+		var reply proto.RebuildReply
+		done1 <- svc.Rebuild(&proto.RebuildArgs{Group: "g"}, &reply)
+	}()
+
+	// Wait until the first rebuild worker is actually running inside rebuildFn.
+	select {
+	case <-firstEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first rebuild worker never entered rebuildFn")
+	}
+
+	// RPC #1 should return a timeout error while its worker is still blocked.
+	select {
+	case err := <-done1:
+		if err == nil {
+			t.Fatal("expected RPC #1 to return a timeout error while its worker blocks")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RPC #1 did not return within timeout")
+	}
+
+	// RPC #2 for the SAME group arrives while #1's worker still holds the guard.
+	// It must NOT start a concurrent rebuild; it should block on acquisition and
+	// time out.
+	done2 := make(chan error, 1)
+	go func() {
+		var reply proto.RebuildReply
+		done2 <- svc.Rebuild(&proto.RebuildArgs{Group: "g"}, &reply)
+	}()
+
+	select {
+	case err := <-done2:
+		if err == nil {
+			t.Fatal("expected RPC #2 to time out waiting for the in-flight rebuild, not run concurrently")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("RPC #2 did not return within timeout")
+	}
+
+	// The memory-safety invariant: at no point did two rebuilds run at once.
+	if got := atomic.LoadInt32(&maxConcurrent); got != 1 {
+		t.Fatalf("max concurrent in-process rebuilds = %d, want 1 (overlap = engine RSS blow-up #5681)", got)
+	}
+
+	// Release the orphaned worker; a subsequent same-group rebuild must then be
+	// able to acquire the guard and run (guard was not leaked).
+	close(release)
+
+	// Give the orphan a moment to release the guard.
+	rebuildRPCTimeout = 2 * time.Second
+	release3 := make(chan struct{})
+	close(release3) // #3 returns immediately
+	// Re-point rebuildFn's release for #3 by using a fresh service-independent
+	// path: simplest is to assert a fresh acquire succeeds by calling Rebuild
+	// once more with an already-closed release. Reuse the same svc; its rebuildFn
+	// closes over `release`, already closed, so #3 completes promptly.
+	done3 := make(chan error, 1)
+	go func() {
+		var reply proto.RebuildReply
+		done3 <- svc.Rebuild(&proto.RebuildArgs{Group: "g"}, &reply)
+	}()
+	select {
+	case err := <-done3:
+		if err != nil {
+			t.Fatalf("post-release rebuild should succeed once guard is free, got: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("post-release rebuild blocked — guard was leaked by the orphaned worker")
+	}
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -31,7 +31,10 @@ import (
 // goroutines are abandoned (they will eventually complete or panic-recover and
 // be cleaned up). 2 hours is intentionally conservative — even a full cold
 // re-index of a large group should finish well under 30 minutes in practice.
-const rebuildRPCTimeout = 2 * time.Hour
+//
+// A var (not const) so tests can shrink it to exercise the timeout / single-
+// flight paths deterministically; production never reassigns it.
+var rebuildRPCTimeout = 2 * time.Hour
 
 // defaultStallWarnInterval is how long a Rebuild RPC may run without producing
 // a result before the dead-man detector logs a "possible stall" warning plus a
@@ -159,12 +162,17 @@ type Service struct {
 	// enables the worker pool introduced in #1276.
 	maxConcurrentGroups int
 
-	// groupRebuildMu prevents a concurrent double-rebuild of the same
-	// group. Keyed by group name. Each value is a *sync.Mutex; loaded-or-
-	// stored atomically via sync.Map to avoid the TOCTOU race that would
-	// arise with a plain map + RWMutex. Wired into Service.Rebuild in
-	// #2097 after the field was left as an unwired stub.
-	groupRebuildMu sync.Map // map[string]*sync.Mutex
+	// groupRebuildMu prevents a concurrent double-rebuild of the same group.
+	// Keyed by group name. Each value is a capacity-1 semaphore channel
+	// (chan struct{}), loaded-or-stored atomically via sync.Map to avoid the
+	// TOCTOU race a plain map + RWMutex would have. Wired into Service.Rebuild
+	// in #2097; converted from *sync.Mutex to a semaphore in #5681 so that (a)
+	// acquisition is timeout-aware and (b) the guard is RELEASED from the
+	// rebuild worker goroutine on real completion — not from the RPC handler —
+	// so an RPC-timed-out orphan keeps the guard and a superseding same-group
+	// rebuild cannot start a SECOND concurrent in-process rebuild (the engine
+	// RSS blow-up: N overlapping runs each holding a multi-GB doc).
+	groupRebuildMu sync.Map // map[string]chan struct{} (cap 1)
 
 	// rebuildInFlight counts Rebuild RPCs that are currently inside
 	// Service.Rebuild (i.e. past the per-group mutex acquisition). It is
@@ -519,13 +527,17 @@ func (s *Service) Index(args *proto.IndexArgs, reply *proto.IndexReply) error {
 // When args.ProgressToken is non-empty, per-repo progress is stored
 // so the CLI can poll it via IndexProgress while this call blocks.
 //
-// Concurrency guard (#2097): each group gets a per-group mutex
-// (groupRebuildMu) so only one Rebuild RPC per group runs at a time.
-// A second concurrent RPC for the same group blocks until the first
-// finishes — it does NOT race against the same output files. Combined
-// with a per-RPC wall-clock timeout (rebuildRPCTimeout) this prevents
-// the indefinite hang that was observed when in_flight=4 and all four
-// RPCs targeted the same group.
+// Concurrency guard (#2097 + #5681): each group gets a per-group
+// capacity-1 semaphore (groupRebuildMu) so only one Rebuild RPC per
+// group runs at a time. A second concurrent RPC for the same group
+// waits until the first finishes — it does NOT race against the same
+// output files, and (the #5681 fix) it does NOT start a second
+// concurrent in-process rebuild when the first RPC times out: the guard
+// is held by the worker goroutine until the heap-heavy rebuild really
+// completes, so overlapping runs can never pile multiple multi-GB
+// documents into the engine at once. Combined with a per-RPC wall-clock
+// timeout (rebuildRPCTimeout) this prevents the indefinite hang observed
+// when in_flight=4 and all four RPCs targeted the same group.
 func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) error {
 	if s.rebuild == nil {
 		return errors.New("rebuild entrypoint not configured")
@@ -577,19 +589,42 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 	atomic.AddInt64(&s.inFlight, 1)
 	defer atomic.AddInt64(&s.inFlight, -1)
 
-	// Per-group mutual exclusion: load-or-store a *sync.Mutex for this
-	// group so that concurrent Rebuild RPCs targeting the same group are
-	// serialised rather than racing on the same output files (#2097).
-	muVal, _ := s.groupRebuildMu.LoadOrStore(args.Group, &sync.Mutex{})
-	groupMu := muVal.(*sync.Mutex)
-	groupMu.Lock()
+	// Per-group single-flight (#2097 + #5681). Load-or-store a capacity-1
+	// semaphore for this group so concurrent Rebuild RPCs targeting the same
+	// group are serialised rather than racing on the same output files AND,
+	// crucially for the #5681 engine-RSS blow-up, so at most ONE in-process
+	// group rebuild is alive at a time even across the per-RPC timeout below.
+	//
+	// Acquisition is timeout-aware: if a prior same-group rebuild still holds
+	// the guard (including an RPC-timed-out orphan whose heap-heavy goroutine is
+	// still running), this RPC waits up to rebuildRPCTimeout and then returns a
+	// timeout — it does NOT start a second concurrent rebuild. The guard is
+	// released from the WORKER goroutine on the rebuild's real completion (see
+	// releaseGuard below), never from this handler's timeout path, so N
+	// re-triggered rebuilds can never coexist and pile up N multi-GB docs.
+	semVal, _ := s.groupRebuildMu.LoadOrStore(args.Group, make(chan struct{}, 1))
+	groupSem := semVal.(chan struct{})
+	acqTimer := time.NewTimer(rebuildRPCTimeout)
+	select {
+	case groupSem <- struct{}{}:
+		acqTimer.Stop()
+	case <-acqTimer.C:
+		return fmt.Errorf("rebuild group=%s timed out after %s waiting for an in-flight rebuild of the same group to finish", args.Group, rebuildRPCTimeout)
+	}
 	atomic.AddInt64(&s.groupsActiveCount, 1)
 	atomic.AddInt64(&s.rebuildInFlight, 1)
-	defer func() {
-		atomic.AddInt64(&s.groupsActiveCount, -1)
-		atomic.AddInt64(&s.rebuildInFlight, -1)
-		groupMu.Unlock()
-	}()
+	// releaseGuard releases the per-group semaphore + decrements the counters
+	// exactly once. It is called from the worker goroutine on real completion
+	// (normal or error), NOT from the RPC-timeout return path, so an orphaned
+	// rebuild keeps the guard until its heap is actually freed.
+	var releaseOnce sync.Once
+	releaseGuard := func() {
+		releaseOnce.Do(func() {
+			atomic.AddInt64(&s.groupsActiveCount, -1)
+			atomic.AddInt64(&s.rebuildInFlight, -1)
+			<-groupSem
+		})
+	}
 
 	if s.logger != nil {
 		s.logger.Info("rebuild: start",
@@ -621,6 +656,11 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 
 	rebuildStartTime := time.Now()
 	go func() {
+		// Release the per-group guard on REAL completion, even if this RPC
+		// handler already returned on timeout (#5681): the orphaned rebuild
+		// holds the guard until here so no superseding same-group rebuild can
+		// run concurrently and double the engine heap.
+		defer releaseGuard()
 		var repos []string
 		var warning string
 		var err error

--- a/internal/membench/fixture.go
+++ b/internal/membench/fixture.go
@@ -1,0 +1,175 @@
+// Package membench builds a large SYNTHETIC graph.Document (no corpus access
+// required) and measures the heap cost of the in-process post-extraction
+// pipeline — external.Synthesize + the group-scope graph-algorithm pass
+// (BuildGraph -> ComputeCommunities -> ComputeCentrality via
+// graph.RunAlgorithms) — that the split-mode ENGINE process runs per repo.
+//
+// It exists to reproduce and bound the RSS/CPU blow-up reported in #5681 on a
+// LARGE monorepo (287k entities / 1.3M relationships) WITHOUT touching the
+// off-limits corpus. The fixture is deterministic (fixed PRNG seed) so peak
+// numbers are comparable run-to-run.
+package membench
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// FixtureSpec controls the shape of the synthetic document.
+type FixtureSpec struct {
+	// Entities is the number of code entities (functions/methods/classes).
+	Entities int
+	// Files is the number of distinct SourceFile paths the entities spread
+	// across (each file also gets a SCOPE.Component file node that owns the
+	// IMPORTS edges, matching the post-#577 extractor shape).
+	Files int
+	// CallEdges is the number of CALLS relationships wired between entities
+	// (both endpoints are real entities so BuildGraph retains them).
+	CallEdges int
+	// ImportsPerFile is the average number of IMPORTS edges emitted per file
+	// component to bare external package names (Synthesize turns each unique
+	// name into an ext:<name> placeholder entity).
+	ImportsPerFile int
+	// ExternalPackages is the size of the external-package name pool the
+	// IMPORTS edges draw from (bounds how many ext: entities Synthesize adds).
+	ExternalPackages int
+	// Seed makes the fixture deterministic.
+	Seed int64
+}
+
+// DefaultLargeSpec approximates the #5681 monorepo scale: ~220k entities across
+// ~18k files with ~1.2M CALLS edges + ~360k IMPORTS edges. Well above the
+// 8000-node sampled-betweenness threshold (algorithms.go:605), so the sampled
+// path is exercised — guarding against an accidental exact-Brandes regression.
+func DefaultLargeSpec() FixtureSpec {
+	return FixtureSpec{
+		Entities:         220_000,
+		Files:            18_000,
+		CallEdges:        1_200_000,
+		ImportsPerFile:   20,
+		ExternalPackages: 4_000,
+		Seed:             0x5681,
+	}
+}
+
+// langs cycles a handful of realistic language tags so the Synthesize
+// classifier's per-language allowlists have something to chew on.
+var langs = []string{"go", "python", "typescript", "java", "kotlin"}
+
+// BuildSyntheticDocument assembles a graph.Document to the given spec. Every
+// entity carries populated Properties + Metadata maps (the live-object weight
+// that dominates the per-run heap on entity-dense repos). IMPORTS edges point
+// at bare external names so external.Synthesize has real work to do.
+func BuildSyntheticDocument(spec FixtureSpec) *graph.Document {
+	rng := rand.New(rand.NewSource(spec.Seed))
+
+	nFiles := spec.Files
+	if nFiles < 1 {
+		nFiles = 1
+	}
+
+	// File component entities (post-#577 IMPORTS FromID shape). One per file.
+	fileIDs := make([]string, nFiles)
+	entities := make([]graph.Entity, 0, spec.Entities+nFiles)
+	for f := 0; f < nFiles; f++ {
+		path := fmt.Sprintf("src/pkg%03d/module%05d.go", f%512, f)
+		id := graph.EntityID("mono", "SCOPE.Component", path, path)
+		fileIDs[f] = id
+		entities = append(entities, graph.Entity{
+			ID:         id,
+			Name:       fmt.Sprintf("module%05d", f),
+			Kind:       "SCOPE.Component",
+			Subtype:    "file",
+			SourceFile: path,
+			Language:   langs[f%len(langs)],
+			Properties: map[string]string{"path": path, "loc": fmt.Sprintf("%d", 100+rng.Intn(900))},
+			Metadata:   map[string]interface{}{"synthetic": true, "file_index": f},
+		})
+	}
+
+	// Code entities, each anchored to a file.
+	entIDs := make([]string, spec.Entities)
+	for i := 0; i < spec.Entities; i++ {
+		f := rng.Intn(nFiles)
+		path := entities[f].SourceFile
+		name := fmt.Sprintf("Func_%06d", i)
+		id := graph.EntityID("mono", "SCOPE.Function", name, path)
+		entIDs[i] = id
+		entities = append(entities, graph.Entity{
+			ID:            id,
+			Name:          name,
+			QualifiedName: fmt.Sprintf("pkg%03d.%s", f%512, name),
+			Kind:          "SCOPE.Function",
+			Subtype:       "function",
+			SourceFile:    path,
+			StartLine:     1 + rng.Intn(2000),
+			EndLine:       1 + rng.Intn(2000),
+			Language:      langs[f%len(langs)],
+			Signature:     fmt.Sprintf("func %s(ctx context.Context, id int) error", name),
+			Properties: map[string]string{
+				"visibility":     "public",
+				"receiver":       fmt.Sprintf("T%03d", i%256),
+				"callsite_count": fmt.Sprintf("%d", 1+rng.Intn(5)),
+			},
+			Metadata: map[string]interface{}{
+				"complexity": rng.Intn(30),
+				"synthetic":  true,
+			},
+		})
+	}
+
+	// External package name pool for IMPORTS targets.
+	extPkgs := make([]string, spec.ExternalPackages)
+	for p := range extPkgs {
+		extPkgs[p] = fmt.Sprintf("com.example.dep%04d", p)
+	}
+
+	nImports := nFiles * spec.ImportsPerFile
+	rels := make([]graph.Relationship, 0, spec.CallEdges+nImports)
+
+	// CALLS edges between real entities (retained by BuildGraph).
+	for e := 0; e < spec.CallEdges; e++ {
+		from := entIDs[rng.Intn(len(entIDs))]
+		to := entIDs[rng.Intn(len(entIDs))]
+		rels = append(rels, graph.Relationship{
+			ID:     graph.RelationshipID(from, to, "CALLS"),
+			FromID: from,
+			ToID:   to,
+			Kind:   "CALLS",
+			Properties: map[string]string{
+				"callsite_count": fmt.Sprintf("%d", 1+rng.Intn(4)),
+			},
+		})
+	}
+
+	// IMPORTS edges from file components to bare external names (Synthesize fuel).
+	for f := 0; f < nFiles; f++ {
+		for k := 0; k < spec.ImportsPerFile; k++ {
+			pkg := extPkgs[rng.Intn(len(extPkgs))]
+			rels = append(rels, graph.Relationship{
+				ID:     graph.RelationshipID(fileIDs[f], pkg, "IMPORTS"),
+				FromID: fileIDs[f],
+				ToID:   pkg, // bare, unresolved → Synthesize makes ext:<pkg>
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"source_module": pkg,
+					"imported_name": fmt.Sprintf("Sym%d", k),
+				},
+			})
+		}
+	}
+
+	return &graph.Document{
+		Version:       1,
+		Repo:          "mono",
+		Entities:      entities,
+		Relationships: rels,
+		Stats: graph.Stats{
+			Files:         nFiles,
+			Entities:      len(entities),
+			Relationships: len(rels),
+		},
+	}
+}

--- a/internal/membench/measure.go
+++ b/internal/membench/measure.go
@@ -1,0 +1,80 @@
+package membench
+
+import (
+	"runtime"
+	"sync"
+	"time"
+)
+
+// Sample is a heap measurement snapshot in bytes.
+type Sample struct {
+	HeapAlloc uint64 // bytes of allocated heap objects still reachable
+	HeapInuse uint64 // bytes in in-use heap spans (closer to RSS pressure)
+}
+
+// snapshot forces a GC then reads a settled heap sample. Used for
+// before/after (retained) measurements where we want the quiescent value.
+func snapshot() Sample {
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return Sample{HeapAlloc: m.HeapAlloc, HeapInuse: m.HeapInuse}
+}
+
+// peakSampler polls HeapInuse/HeapAlloc on an interval and records the maximum
+// observed, so we can capture the transient peak of a running pipeline that is
+// released before it returns.
+type peakSampler struct {
+	stop     chan struct{}
+	done     chan struct{}
+	mu       sync.Mutex
+	peakIn   uint64
+	peakAll  uint64
+	interval time.Duration
+}
+
+func startPeakSampler(interval time.Duration) *peakSampler {
+	p := &peakSampler{stop: make(chan struct{}), done: make(chan struct{}), interval: interval}
+	go p.run()
+	return p
+}
+
+func (p *peakSampler) observe() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	p.mu.Lock()
+	if m.HeapInuse > p.peakIn {
+		p.peakIn = m.HeapInuse
+	}
+	if m.HeapAlloc > p.peakAll {
+		p.peakAll = m.HeapAlloc
+	}
+	p.mu.Unlock()
+}
+
+func (p *peakSampler) run() {
+	defer close(p.done)
+	t := time.NewTicker(p.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-p.stop:
+			p.observe() // final read
+			return
+		case <-t.C:
+			p.observe()
+		}
+	}
+}
+
+// Stop halts sampling and returns the peak HeapInuse / HeapAlloc seen.
+func (p *peakSampler) Stop() (peakInuse, peakAlloc uint64) {
+	close(p.stop)
+	<-p.done
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.peakIn, p.peakAll
+}
+
+// mb converts bytes to whole megabytes for reporting.
+func mb(b uint64) uint64 { return b / (1024 * 1024) }

--- a/internal/membench/membench_test.go
+++ b/internal/membench/membench_test.go
@@ -1,0 +1,137 @@
+package membench
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/external"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// specFromEnv returns the fixture spec, scaled down by default so a plain
+// `go test ./internal/membench` runs in bounded time/heap, but overridable to
+// the full #5681 monorepo scale via GRAFEL_MEMBENCH_ENTITIES=220000 (and the
+// companion knobs) for the real measurement run.
+func specFromEnv() FixtureSpec {
+	s := FixtureSpec{
+		Entities:         40_000,
+		Files:            4_000,
+		CallEdges:        200_000,
+		ImportsPerFile:   16,
+		ExternalPackages: 2_000,
+		Seed:             0x5681,
+	}
+	if v := os.Getenv("GRAFEL_MEMBENCH_ENTITIES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			s = DefaultLargeSpec()
+			s.Entities = n
+			// Scale companion counts proportionally to keep a realistic density.
+			s.Files = n / 12
+			s.CallEdges = n * 5
+		}
+	}
+	return s
+}
+
+// runPipeline executes the in-process post-extraction pipeline the split-mode
+// engine runs per repo: external synthesis + the group-scope algorithm pass.
+func runPipeline(doc *graph.Document) *graph.AlgorithmResults {
+	external.Synthesize(doc)
+	return graph.RunAlgorithms(doc.Entities, doc.Relationships)
+}
+
+// TestSingleRunPeak measures the transient peak heap of ONE pipeline run and
+// whether memory is RELEASED (bounded) or RETAINED (leak) after the result is
+// dropped. It also asserts the sampled-betweenness path is taken so an
+// accidental regression back to exact O(V*E) Brandes is caught.
+func TestSingleRunPeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heavy memory bench in -short")
+	}
+	spec := specFromEnv()
+	doc := BuildSyntheticDocument(spec)
+
+	nEntities := len(doc.Entities)
+	if got, thr := nEntities, graph.BetweennessSampleThreshold(); got <= thr {
+		t.Fatalf("fixture too small to exercise sampled-betweenness path: entities=%d threshold=%d", got, thr)
+	}
+
+	base := snapshot() // settled heap holding just the fixture doc
+	sampler := startPeakSampler(2 * time.Millisecond)
+	res := runPipeline(doc)
+	if res == nil || len(res.PageRank) == 0 {
+		t.Fatalf("pipeline produced no results")
+	}
+	peakInuse, peakAlloc := sampler.Stop()
+
+	// Drop every live reference to the pipeline output + input and force GC,
+	// then measure what the process RETAINS. Bounded pipeline => retained ~=
+	// baseline; a leak => retained stays near peak.
+	res = nil
+	after := snapshot()
+
+	// Peak ATTRIBUTABLE to the pipeline (above the resting fixture heap).
+	pipelinePeak := int64(peakInuse) - int64(base.HeapInuse)
+	retainedDelta := int64(after.HeapInuse) - int64(base.HeapInuse)
+
+	t.Logf("SINGLE-RUN entities=%d rels=%d", nEntities, len(doc.Relationships))
+	t.Logf("  baseline  HeapInuse=%d MB HeapAlloc=%d MB", mb(base.HeapInuse), mb(base.HeapAlloc))
+	t.Logf("  PEAK      HeapInuse=%d MB HeapAlloc=%d MB", mb(peakInuse), mb(peakAlloc))
+	t.Logf("  after-GC  HeapInuse=%d MB HeapAlloc=%d MB", mb(after.HeapInuse), mb(after.HeapAlloc))
+	t.Logf("  pipeline-attributable peak = %d MB", pipelinePeak/(1024*1024))
+	t.Logf("  retained-after-run delta   = %d MB", retainedDelta/(1024*1024))
+
+	// Correctness/bounded assertion: the single run must RELEASE its heap.
+	// After dropping the result the retained delta must be a small fraction of
+	// the transient peak (allow generous slack for GC fragmentation).
+	if pipelinePeak > 0 && retainedDelta > pipelinePeak/2 {
+		t.Errorf("pipeline heap NOT released: retained=%d MB is >50%% of transient peak=%d MB (possible leak)",
+			retainedDelta/(1024*1024), pipelinePeak/(1024*1024))
+	}
+	runtime.KeepAlive(doc)
+}
+
+// TestOverlapPeak fires TWO concurrent pipeline runs on the same synthetic
+// input and measures peak heap. If the peak is ~2x a single run, it confirms
+// that OVERLAPPING (un-single-flighted) index runs are the unbounded RSS
+// driver: each coexisting run adds its full multi-GB heap. This is the
+// behaviour the P0 single-flight fix must prevent at the daemon level.
+func TestOverlapPeak(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heavy memory bench in -short")
+	}
+	spec := specFromEnv()
+
+	// Two independent docs so both runs hold live heap simultaneously (mirrors
+	// two coexisting engine index runs, each with its own assembled doc).
+	docA := BuildSyntheticDocument(spec)
+	docB := BuildSyntheticDocument(spec)
+
+	base := snapshot()
+	sampler := startPeakSampler(2 * time.Millisecond)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var rA, rB *graph.AlgorithmResults
+	go func() { defer wg.Done(); rA = runPipeline(docA) }()
+	go func() { defer wg.Done(); rB = runPipeline(docB) }()
+	wg.Wait()
+
+	peakInuse, peakAlloc := sampler.Stop()
+	if rA == nil || rB == nil {
+		t.Fatalf("concurrent pipelines produced nil results")
+	}
+	overlapPeak := int64(peakInuse) - int64(base.HeapInuse)
+
+	t.Logf("OVERLAP(2x) entities=%d each", len(docA.Entities))
+	t.Logf("  baseline HeapInuse=%d MB", mb(base.HeapInuse))
+	t.Logf("  PEAK     HeapInuse=%d MB HeapAlloc=%d MB", mb(peakInuse), mb(peakAlloc))
+	t.Logf("  overlap-attributable peak = %d MB", overlapPeak/(1024*1024))
+
+	runtime.KeepAlive(docA)
+	runtime.KeepAlive(docB)
+}


### PR DESCRIPTION
## What
Fixes #5681 — the split-mode engine memory blowup (RSS 0.9→3.1GB, historically 11GB) when a large monorepo (287k entities) is registered.

## Root cause (measured)
A single index run's post-extraction pipeline heap is **large-but-linear and fully released** (~10 MB / 1k entities → ~2.9 GB at 287k; retained ≈ 0). The **unbounded** growth came from **overlapping/re-triggered runs coexisting** in the long-lived engine (overlap peak ≈ 2× single). Not an O(N²) leak.

## Fix
- **P0 — single-flight per group.** `Service.Rebuild`'s per-group guard changed from a `*sync.Mutex` (released in the RPC handler defer, i.e. on timeout while the rebuild kept running → allowed a 2nd concurrent run) to a **capacity-1 semaphore released only from the worker goroutine on real completion**, with a timeout-aware acquire. A superseding same-group rebuild can no longer start a 2nd concurrent in-process pipeline. Acquire order is group-sem → repo-lock (consistent with repolock #5758; no deadlock).
- **P1 — boot/registration reindex is already freshness-gated** (mtime + content-hash); locked in with regression tests (`isRepoDirtyAfter`: fresh→no-enqueue, stale→enqueue).
- New `internal/membench/` harness (Short-gated) measures pipeline heap peak + retained-after-GC on synthetic graphs.

## Review
Independent adversarial review: APPROVE. Verified no deadlock, real red→green overlap test, clean acquire-timeout, no lost update (superseded change re-indexed via scheduler coalescing), monolith unchanged. Non-blocking follow-up tracked: bound `linksFn` / add a dead-man so a hung link pass can't hold the group semaphore indefinitely.

## Known follow-up
- **P2 (subprocess-isolate the single run):** deferred — a single 287k run (~2.9 GB) still exceeds the 2560 MB soft limit, so the heavy heap should live in a child that exits. Recommended next.

Refs #5681