### PR TITLE
fix(watch): HEAD-gate the watch poll so unchanged repos no-op (stops perpetual re-index loop)

### DIFF
--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -95,6 +95,14 @@ var indexRPCFunc = func(args proto.IndexArgs) (proto.IndexReply, error) {
 // full synchronous index — it enqueues onto the daemon's debounced/
 // coalescing scheduler (service.go's Async fast-paths) and returns as
 // soon as the request is queued, exactly like the git-hooks path (#3366).
+//
+// TRADEOFF (intentional, not a bug): the error returned here now reflects
+// only whether the ENQUEUE was ACCEPTED, not whether the index actually
+// completed. An async index that fails INSIDE the daemon is therefore no
+// longer surfaced as `grafel watch: index failed (N/10)` on this path —
+// failure reporting for the reindex itself now belongs to the daemon
+// scheduler (mirrors the git-hooks async path #3366). See the matching
+// note in maybeTriggerIndex where lastSHA is cached on enqueue-accepted.
 func indexViaDaemon(repo string) error {
 	_, err := indexRPCFunc(proto.IndexArgs{RepoPath: repo, Async: true})
 	if err != nil {
@@ -143,6 +151,13 @@ type watchTickState struct {
 // The cache is updated only after a SUCCESSFUL trigger, so a failed index
 // (daemon down, RPC error) does not get treated as "up to date" and does
 // not suppress a retry on the next tick.
+//
+// NOTE (watch-head-gate tradeoff): "successful trigger" here means the
+// async ENQUEUE was ACCEPTED (see indexViaDaemon), NOT that the reindex
+// itself completed. So lastSHA is cached — and this SHA no longer
+// re-triggers — as soon as the daemon accepts the request; a failure
+// DURING the async index is owned by the daemon scheduler, not re-reported
+// by the watcher. Intentional, mirrors the git-hooks async path (#3366).
 //
 // triggered reports whether the index RPC was invoked at all (regardless
 // of whether it returned an error), so callers can distinguish "skipped by

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
+	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -72,20 +73,91 @@ func (c watchBackoffConfig) shouldDie(failures int) bool {
 	return c.maxConsecutive > 0 && failures >= c.maxConsecutive
 }
 
+// indexRPCFunc issues the daemon's Index RPC. It is a var (not a direct
+// client.Dial + c.Index call) so tests can stub it and assert on the
+// IndexArgs the watcher builds (e.g. Async) without a live daemon
+// connection.
+var indexRPCFunc = func(args proto.IndexArgs) (proto.IndexReply, error) {
+	c, err := client.Dial()
+	if err != nil {
+		return proto.IndexReply{}, err
+	}
+	defer c.Close()
+	return c.Index(args)
+}
+
 // indexViaDaemon calls the daemon's Index RPC for one repo. Returns
 // the canonical "daemon not running" error so the watcher loop's log
 // line is identical to what `grafel index` would print.
+//
+// Async is set (#5140-followup / watch-head-gate): a tick that DOES need
+// to reindex (HEAD moved) must not itself block the watcher loop on a
+// full synchronous index — it enqueues onto the daemon's debounced/
+// coalescing scheduler (service.go's Async fast-paths) and returns as
+// soon as the request is queued, exactly like the git-hooks path (#3366).
 func indexViaDaemon(repo string) error {
-	c, err := client.Dial()
+	_, err := indexRPCFunc(proto.IndexArgs{RepoPath: repo, Async: true})
 	if err != nil {
 		if errors.Is(err, client.ErrDaemonNotRunning) {
 			return errDaemonNotRunning
 		}
 		return err
 	}
-	defer c.Close()
-	_, err = c.Index(proto.IndexArgs{RepoPath: repo})
-	return err
+	return nil
+}
+
+// indexTriggerFunc is the function each watch tick calls to trigger an
+// index. It defaults to indexViaDaemon; tests substitute a counting stub
+// so invocation counts can be asserted without a live daemon.
+var indexTriggerFunc = indexViaDaemon
+
+// resolveHeadSHA returns the repo's current git HEAD SHA, or "" when it
+// cannot be determined (non-git directory, git not on PATH, etc.). It is a
+// var (not a direct gitmeta.Capture call) so tests can stub a controllable
+// SHA sequence without needing a real git repository.
+var resolveHeadSHA = func(repo string) string {
+	return gitmeta.Capture(repo).SHA
+}
+
+// watchTickState carries the per-tick state that must persist across
+// polling ticks for the unchanged-HEAD no-op gate (defect b, watch-head-gate):
+// which SHA was in effect the last time an index was successfully
+// triggered, and whether any trigger has happened yet at all.
+type watchTickState struct {
+	haveTriggered bool
+	lastSHA       string
+}
+
+// maybeTriggerIndex implements the unchanged-HEAD no-op gate. It resolves
+// repo's current HEAD SHA and skips the index RPC entirely when it matches
+// the SHA recorded at the last SUCCESSFUL trigger — the per-repo `grafel
+// watch` poll loop previously triggered a full reindex on every tick even
+// when nothing had changed, which on a large repo produced a perpetual
+// rebuild loop that never settled to idle.
+//
+// The very first call always triggers (st.haveTriggered starts false), and
+// an unresolvable SHA (resolveHeadSHA returns "") always triggers too —
+// fail open rather than silently stop reindexing a repo the poller can't
+// read HEAD for.
+//
+// The cache is updated only after a SUCCESSFUL trigger, so a failed index
+// (daemon down, RPC error) does not get treated as "up to date" and does
+// not suppress a retry on the next tick.
+//
+// triggered reports whether the index RPC was invoked at all (regardless
+// of whether it returned an error), so callers can distinguish "skipped by
+// the gate" from "attempted and failed" for backoff bookkeeping.
+func maybeTriggerIndex(repo string, st *watchTickState) (triggered bool, err error) {
+	sha := resolveHeadSHA(repo)
+	if st.haveTriggered && sha != "" && sha == st.lastSHA {
+		return false, nil
+	}
+	if err := indexTriggerFunc(repo); err != nil {
+		return true, err
+	}
+	st.haveTriggered = true
+	st.lastSHA = sha
+	return true, nil
 }
 
 // newWatchCmd is the long-lived watcher daemon. The actual fsnotify-
@@ -165,6 +237,7 @@ func runWatch(repo, group string, interval time.Duration) error {
 
 	backoff := activeWatchBackoff()
 	consecutiveFailures := 0
+	tickState := &watchTickState{}
 
 	for {
 		select {
@@ -175,7 +248,15 @@ func runWatch(repo, group string, interval time.Duration) error {
 			// indexer runs inside the daemon — `watch` becomes a thin
 			// RPC client. Phase B will retire this subcommand entirely
 			// once the daemon's fsnotify loop is wired in.
-			if err := indexViaDaemon(repo); err != nil {
+			//
+			// maybeTriggerIndex gates the RPC on the repo's git HEAD SHA
+			// (watch-head-gate): a tick whose HEAD is unchanged since the
+			// last successful trigger is a cheap no-op instead of a full
+			// reindex, which previously ran unconditionally on every tick
+			// and, on a large repo, produced a perpetual rebuild loop that
+			// never settled to idle.
+			triggered, err := maybeTriggerIndex(repo, tickState)
+			if err != nil {
 				consecutiveFailures++
 				fmt.Fprintf(os.Stderr, "grafel watch: index failed (%d/%d): %v\n",
 					consecutiveFailures, backoff.maxConsecutive, err)
@@ -195,7 +276,9 @@ func runWatch(repo, group string, interval time.Duration) error {
 				}
 				continue
 			}
-			consecutiveFailures = 0
+			if triggered {
+				consecutiveFailures = 0
+			}
 			// 2. Detect any cross-repo graph.json mtime changes and
 			// re-run link passes for the affected groups. (Staleness
 			// signal only — see the note above; this does not re-trigger

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -225,5 +226,108 @@ func TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable(t *testing.T) {
 		}
 	case <-time.After(30 * time.Second):
 		t.Fatal("runWatch did not exit after repeated daemon-unreachable failures (issue #5140 regression)")
+	}
+}
+
+// TestMaybeTriggerIndex_UnchangedHeadSkipsSecondTick proves the
+// unchanged-HEAD no-op gate (defect b): when the stubbed HEAD SHA does
+// not move between two ticks, the index RPC must fire on the first tick
+// only (the initial trigger) and be skipped entirely on the second.
+// Before the fix, maybeTriggerIndex does not exist and every tick blindly
+// invokes the index RPC regardless of HEAD movement.
+func TestMaybeTriggerIndex_UnchangedHeadSkipsSecondTick(t *testing.T) {
+	prevSHA, prevTrigger := resolveHeadSHA, indexTriggerFunc
+	t.Cleanup(func() { resolveHeadSHA, indexTriggerFunc = prevSHA, prevTrigger })
+
+	resolveHeadSHA = func(repo string) string { return "abc123" }
+	calls := 0
+	indexTriggerFunc = func(repo string) error {
+		calls++
+		return nil
+	}
+
+	st := &watchTickState{}
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatalf("first tick: unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("first tick (no cached SHA) should always trigger: got %d calls, want 1", calls)
+	}
+
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatalf("second tick: unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("second tick with unchanged HEAD must NOT re-trigger the index RPC: got %d calls, want 1", calls)
+	}
+}
+
+// TestMaybeTriggerIndex_HeadAdvanceRetriggers proves the companion half
+// of the gate: once the stubbed HEAD SHA advances, the very next tick
+// must fire the index RPC again.
+func TestMaybeTriggerIndex_HeadAdvanceRetriggers(t *testing.T) {
+	prevSHA, prevTrigger := resolveHeadSHA, indexTriggerFunc
+	t.Cleanup(func() { resolveHeadSHA, indexTriggerFunc = prevSHA, prevTrigger })
+
+	sha := "sha-1"
+	resolveHeadSHA = func(repo string) string { return sha }
+	calls := 0
+	indexTriggerFunc = func(repo string) error {
+		calls++
+		return nil
+	}
+
+	st := &watchTickState{}
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 1 {
+		t.Fatalf("unchanged HEAD across two more ticks should not retrigger: got %d calls, want 1", calls)
+	}
+
+	// HEAD advances.
+	sha = "sha-2"
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("tick after HEAD advance must retrigger the index RPC: got %d calls, want 2", calls)
+	}
+
+	// And settles again at the new SHA.
+	if _, err := maybeTriggerIndex("/repo", st); err != nil {
+		t.Fatal(err)
+	}
+	if calls != 2 {
+		t.Fatalf("tick with HEAD unchanged at the new SHA should not retrigger: got %d calls, want 2", calls)
+	}
+}
+
+// TestIndexViaDaemon_SetsAsyncTrue proves indexViaDaemon requests the
+// daemon's async/coalescing fast path (service.go's Async fast-paths at
+// ~:491/:501) instead of a blocking synchronous full index, so a
+// HEAD-changed tick does not itself become a multi-minute stall on a
+// large repo.
+func TestIndexViaDaemon_SetsAsyncTrue(t *testing.T) {
+	prev := indexRPCFunc
+	t.Cleanup(func() { indexRPCFunc = prev })
+
+	var gotArgs proto.IndexArgs
+	indexRPCFunc = func(args proto.IndexArgs) (proto.IndexReply, error) {
+		gotArgs = args
+		return proto.IndexReply{RepoPath: args.RepoPath}, nil
+	}
+
+	if err := indexViaDaemon("/repo"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !gotArgs.Async {
+		t.Fatal("indexViaDaemon must set IndexArgs.Async = true")
+	}
+	if gotArgs.RepoPath != "/repo" {
+		t.Fatalf("RepoPath = %q, want /repo", gotArgs.RepoPath)
 	}
 }


### PR DESCRIPTION
## Problem
The per-repo `grafel watch` service polls every 30s and triggered a **full re-index on every tick regardless of whether git HEAD changed**. On a large monorepo (hundreds of thousands of entities, full index = many minutes) the poll re-triggers far faster than an index completes, so the daemon never settles to idle — a perpetual rebuild loop pinning multiple cores.

Root cause: the unchanged-HEAD no-op lives only in the daemon's `GitHeadPoller`; the standalone `grafel watch` CLI path calls `client.Index` **synchronously with `Async` unset**, so it falls through both coalescing fast-paths in `Service.Index` straight into a full in-process extraction, with no freshness gate.

## Fix (`internal/cli/watch.go`)
- Gate each tick on the repo's git HEAD SHA (via the existing `gitmeta.Capture` helper). Skip the RPC when HEAD is unchanged since the last successful trigger. First tick and unresolvable SHA **fail open** (still trigger), preserving existing backoff/die behavior on non-git dirs.
- Set `Async:true` on `IndexArgs` so a *real* HEAD change coalesces via the daemon scheduler instead of a blocking synchronous full index.
- Cache the SHA only on a successful trigger, so a failed index retries next tick.

Tradeoff (commented in-code): the watcher now keys its cache on enqueue-accepted, not index-completed — async index failures are reported by the daemon scheduler (`scheduler.go` `index_err` event + `slog.Error`), not re-surfaced on the watch path. Intentional, mirrors the git-hooks async path.

## Tests
New unit tests in `watch_test.go`: unchanged HEAD across two ticks ⇒ one trigger (not two); HEAD advance ⇒ re-trigger; `Async:true` asserted. Red before the fix (gate didn't exist), green after. Full repo suite green (8861 tests); `-race` clean on `./internal/cli/`.

Independent adversarial review: APPROVE.

Refs #5710 (same incremental no-op-on-unchanged-HEAD subsystem, watch-CLI path). Part of the corpus-usability / v0.1.8 stabilization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)