### PR TITLE
fix(daemon): bound crash-resume rebuild retries + engine-side single-flight (split mode)

### DIFF
--- a/internal/daemon/requests/requests.go
+++ b/internal/daemon/requests/requests.go
@@ -100,6 +100,16 @@ type Record struct {
 	Commit    string          `json:"commit,omitempty"`
 	Payload   json.RawMessage `json:"payload,omitempty"`
 	CreatedAt time.Time       `json:"created_at"`
+
+	// Attempts counts how many times a consumer has CLAIMED this request for
+	// application (incremented and persisted BEFORE apply runs — see
+	// ApplyAndAckBounded). It exists so a request whose apply keeps crashing
+	// mid-flight (the process dies before an ack is ever written, so the
+	// request is never removed) is re-applied a BOUNDED number of times across
+	// engine restarts rather than forever. Persisted durably in the request
+	// file precisely so the count survives a crash/restart; an in-memory
+	// counter would reset to zero on every restart and re-open the loop.
+	Attempts int `json:"attempts,omitempty"`
 }
 
 // Ack is the small result sidecar the consumer (engine) writes after
@@ -336,6 +346,116 @@ func ApplyAndAck(dir string, rec Record, apply func(Record) error) error {
 	}
 	_ = deleteAck(dir, rec.ID) // best-effort GC; see doc comment above
 	return nil
+}
+
+// Outcome classifies how ApplyAndAckBounded resolved a single request, so the
+// caller (the engine drain) can log/observe crash-recovery vs dead-lettering.
+type Outcome int
+
+const (
+	// OutcomeApplied: apply returned nil; request was acked (ok) and deleted.
+	OutcomeApplied Outcome = iota
+	// OutcomeAppliedError: apply returned a non-nil error; request was acked
+	// (error) and deleted — consumed exactly once, NOT retried (a returned
+	// error is a completed application, not an interruption).
+	OutcomeAppliedError
+	// OutcomeCrashed: apply panicked — the in-process analogue of the engine
+	// being killed mid-apply. The request is LEFT PENDING (its incremented
+	// attempt claim already persisted) so a later drain retries it, bounded by
+	// maxAttempts.
+	OutcomeCrashed
+	// OutcomeDeadLettered: the attempt budget was exhausted; the request was
+	// acked (error) and deleted so it will never be re-applied again.
+	OutcomeDeadLettered
+)
+
+// ApplyAndAckBounded is the crash-resume-bounded consumer sequence for
+// expensive, non-incremental requests (KindRebuild). It differs from
+// ApplyAndAck in exactly one way: it makes re-application AT-MOST-N rather than
+// at-least-once-forever, so a rebuild that keeps getting interrupted mid-apply
+// (memlimit/reaper/crash/RPC EOF — the process dies before an ack is ever
+// written, so the request is never removed) does NOT re-run on every drain
+// tick / every engine restart.
+//
+// The mechanism is a DURABLE attempt claim:
+//
+//  1. If rec.Attempts has already reached maxAttempts, dead-letter: write an
+//     error ack, delete the request, GC the ack. This TERMINATES the loop —
+//     the request is gone, no future drain can re-apply it.
+//  2. Otherwise persist rec.Attempts+1 to the request file (atomically, same
+//     path) BEFORE calling apply. This is the load-bearing step: the claim is
+//     on disk, so if the process dies at ANY point during apply, the next
+//     drain (even after a full engine restart) reads the HIGHER count and
+//     converges toward the dead-letter — an in-memory counter would reset and
+//     re-open the loop.
+//  3. Run apply, recovering a panic as a "crash": on crash the request is left
+//     pending (the claim is already persisted) for a bounded redrain retry; a
+//     real SIGKILL takes the same on-disk path minus the recover, since the
+//     claim was persisted in step 2 regardless.
+//  4. On normal completion (apply returned, with or without error) ack + delete
+//     + GC exactly as ApplyAndAck does — consumed exactly once.
+//
+// maxAttempts <= 0 disables the cap (unbounded, i.e. ApplyAndAck semantics for
+// the crash case) and is not used by the engine.
+func ApplyAndAckBounded(dir string, rec Record, maxAttempts int, apply func(Record) error) (Outcome, error) {
+	if maxAttempts > 0 && rec.Attempts >= maxAttempts {
+		ack := Ack{
+			Status: StatusError,
+			Err:    fmt.Sprintf("requests: dead-lettered %s after %d attempts without completing", rec.ID, maxAttempts),
+		}
+		if err := WriteAck(dir, rec.ID, ack); err != nil {
+			return OutcomeDeadLettered, fmt.Errorf("requests: write dead-letter ack for %s: %w", rec.ID, err)
+		}
+		if err := Delete(dir, rec.ID); err != nil {
+			return OutcomeDeadLettered, fmt.Errorf("requests: delete dead-lettered request %s: %w", rec.ID, err)
+		}
+		_ = deleteAck(dir, rec.ID)
+		return OutcomeDeadLettered, nil
+	}
+
+	// Durable claim BEFORE apply (see doc comment step 2). Write targets the
+	// SAME dir/<id>.request.json path (rec.ID is set), so this atomically
+	// overwrites the record in place with the incremented count.
+	rec.Attempts++
+	if _, err := Write(dir, rec); err != nil {
+		return OutcomeCrashed, fmt.Errorf("requests: persist attempt claim for %s: %w", rec.ID, err)
+	}
+
+	applyErr, crashed := safeApply(apply, rec)
+	if crashed {
+		// Leave the request pending; the persisted claim bounds redrain.
+		return OutcomeCrashed, nil
+	}
+
+	ack := Ack{Status: StatusOK}
+	if applyErr != nil {
+		ack.Status = StatusError
+		ack.Err = applyErr.Error()
+	}
+	if err := WriteAck(dir, rec.ID, ack); err != nil {
+		return OutcomeApplied, fmt.Errorf("requests: write ack for %s: %w", rec.ID, err)
+	}
+	if err := Delete(dir, rec.ID); err != nil {
+		return OutcomeApplied, fmt.Errorf("requests: delete request %s: %w", rec.ID, err)
+	}
+	_ = deleteAck(dir, rec.ID)
+	if applyErr != nil {
+		return OutcomeAppliedError, nil
+	}
+	return OutcomeApplied, nil
+}
+
+// safeApply runs apply(rec), converting a panic into (err, crashed=true) so a
+// crashing apply leaves the request pending for a bounded redrain rather than
+// unwinding the whole drain loop.
+func safeApply(apply func(Record) error, rec Record) (err error, crashed bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			crashed = true
+			err = fmt.Errorf("requests: apply panicked: %v", r)
+		}
+	}()
+	return apply(rec), false
 }
 
 // deleteAck removes dir/<id>.ack.json. Absent file is not an error.

--- a/internal/daemon/requests_drain.go
+++ b/internal/daemon/requests_drain.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
@@ -21,6 +22,43 @@ import (
 // short since the scan itself is a cheap directory glob, not a full
 // filesystem walk.
 const requestsDrainInterval = 2 * time.Second
+
+// maxRebuildAttempts bounds how many times a single KindRebuild request may be
+// (re-)applied across drains/engine-restarts before it is dead-lettered
+// (epic #5729, defect d). A group rebuild is multi-minute and, if the engine
+// is killed mid-apply (memlimit/reaper/crash/RPC EOF) before the ack is
+// written, the request is never removed — so a naive drain re-applies it on
+// EVERY 2s tick and EVERY engine restart, an unbounded full-group-rebuild
+// loop. Bounding attempts (persisted durably in the request file, so the count
+// survives a restart) turns at-least-once-forever into at-most-N with a
+// terminating dead-letter.
+const maxRebuildAttempts = 3
+
+// engineGroupRebuildGuard serialises KindRebuild applications per group on the
+// ENGINE side — where rebuildFn actually executes (epic #5729, defect c).
+//
+// Service.groupRebuildMu (service.go) is the analogous capacity-1 guard, but in
+// split mode it guards nothing: Service.Rebuild returns after merely WRITING
+// the request file, never reaching that guard, and the engine drain calls
+// rebuildFn directly here with no such serialisation. This guard puts the
+// single-flight on the live path, so two concurrent KindRebuild applications
+// for the SAME group run one rebuildFn at a time (the second waits), while
+// DIFFERENT groups still proceed concurrently.
+var engineGroupRebuildGuard groupRebuildGuard
+
+// groupRebuildGuard is a per-group capacity-1 semaphore keyed by group name.
+type groupRebuildGuard struct {
+	sems sync.Map // group name -> chan struct{} (cap 1)
+}
+
+// acquire blocks until this group's slot is free and returns a release func
+// that must be called (defer) once the guarded rebuild completes.
+func (g *groupRebuildGuard) acquire(group string) (release func()) {
+	v, _ := g.sems.LoadOrStore(group, make(chan struct{}, 1))
+	ch := v.(chan struct{})
+	ch <- struct{}{}
+	return func() { <-ch }
+}
 
 // discoverRequestsDirs finds every `requests/` directory under the store
 // layout rooted at root (either GRAFEL_DAEMON_ROOT/state or
@@ -90,9 +128,31 @@ func drainRequestsOnce(root string, scheduler *sched.Scheduler, rebuildFn Rebuil
 		}
 		for _, rec := range recs {
 			rec := rec
-			applyErr := requests.ApplyAndAck(dir, rec, func(r requests.Record) error {
+			apply := func(r requests.Record) error {
 				return applyRequest(scheduler, rebuildFn, r)
-			})
+			}
+			// KindRebuild is the multi-minute, non-incremental path: route it
+			// through the crash-resume-bounded consumer so an apply that keeps
+			// getting killed mid-flight is re-applied at most maxRebuildAttempts
+			// times (persisted across engine restarts) and then dead-lettered,
+			// instead of re-running on every drain tick forever (defect d).
+			// Cheap/idempotent kinds (KindReindex) keep the plain at-least-once
+			// ApplyAndAck — re-enqueuing is harmless and coalesces.
+			if rec.Kind == requests.KindRebuild {
+				outcome, applyErr := requests.ApplyAndAckBounded(dir, rec, maxRebuildAttempts, apply)
+				if logger != nil {
+					switch {
+					case applyErr != nil:
+						logger.Warn("requests: rebuild apply/ack failed", "dir", dir, "id", rec.ID, "attempts", rec.Attempts, "err", applyErr)
+					case outcome == requests.OutcomeCrashed:
+						logger.Warn("requests: rebuild apply crashed mid-flight; will retry (bounded)", "dir", dir, "id", rec.ID, "attempt", rec.Attempts+1, "max", maxRebuildAttempts)
+					case outcome == requests.OutcomeDeadLettered:
+						logger.Error("requests: rebuild dead-lettered after max attempts; giving up (not re-running)", "dir", dir, "id", rec.ID, "max", maxRebuildAttempts)
+					}
+				}
+				continue
+			}
+			applyErr := requests.ApplyAndAck(dir, rec, apply)
 			if applyErr != nil && logger != nil {
 				logger.Warn("requests: apply/ack failed", "dir", dir, "id", rec.ID, "kind", rec.Kind, "err", applyErr)
 			}
@@ -122,14 +182,19 @@ func applyRequest(scheduler *sched.Scheduler, rebuildFn RebuildFunc, rec request
 		if err := json.Unmarshal(rec.Payload, &args); err != nil {
 			return fmt.Errorf("requests: decode rebuild payload for %s: %w", rec.ID, err)
 		}
-		// Idempotency (PR6 prerequisite, epic #5729): a rebuild rebuilds its
-		// group FROM SCRATCH — the same call daemon.Service.Rebuild makes
-		// synchronously in monolith/engine mode. A redrain after a crash
-		// mid-apply (before the ack was written) simply reruns the same
-		// full rebuild a second time; it is not additive/incremental, so
-		// there is no double-effect to guard against beyond the normal
-		// wasted-work cost, which ApplyAndAck's ack-before-delete ordering
-		// already keeps to "at most once more", never unboundedly.
+		// Engine-side single-flight (defect c, epic #5729): serialise rebuilds
+		// of the SAME group so at most one rebuildFn runs at a time on the live
+		// (engine drain) path — the split-mode analogue of Service.groupRebuildMu,
+		// which guards nothing here because Service.Rebuild returns before
+		// reaching it. Different groups are keyed separately and still overlap.
+		// The guard wraps ONLY the rebuild call and is released even if
+		// rebuildFn panics (defer), so a crash cannot leak the slot.
+		release := engineGroupRebuildGuard.acquire(args.Group)
+		defer release()
+		// Bounded-idempotency (defect d) is handled one layer up by
+		// ApplyAndAckBounded, which persists an attempt claim before this runs;
+		// a crash mid-rebuild is retried at most maxRebuildAttempts times across
+		// engine restarts, then dead-lettered — never an unbounded redrain loop.
 		_, _, err := rebuildFn(args)
 		return err
 	default:

--- a/internal/daemon/requests_drain_resume_test.go
+++ b/internal/daemon/requests_drain_resume_test.go
@@ -1,0 +1,183 @@
+package daemon
+
+// Regression tests for the two engine-side rebuild-drain defects (epic #5729,
+// split mode ON):
+//
+//   (d) A KindRebuild that keeps getting interrupted mid-apply (memlimit /
+//       reaper / crash / RPC EOF) must NOT re-run unboundedly on every 2s
+//       drain tick / every engine restart. Bounded recovery, then dead-letter.
+//   (c) The per-group single-flight guard must live on the ENGINE side (where
+//       rebuildFn actually runs), so two concurrent KindRebuild applications
+//       for the SAME group serialise — while DIFFERENT groups still overlap.
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+)
+
+// (d): a rebuild whose apply crashes mid-flight (simulated by a panicking
+// rebuildFn — the in-process analogue of a SIGKILL that dies before the ack is
+// written) must be re-applied AT MOST maxRebuildAttempts times across repeated
+// drains, then dead-lettered — never once-per-drain-tick forever.
+//
+// Old behaviour (no persisted attempt claim / no bounded recovery): each drain
+// re-applies the never-acked request, so the call count climbs with every
+// drain pass (here: 8) — this test fails, proving the unbounded loop.
+func TestDrain_KindRebuild_CrashLoopIsBounded(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	const group = "d-crashloop-group"
+	dir := requestsDirForGroup(group)
+	payload, err := json.Marshal(proto.RebuildArgs{Group: group})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if _, err := requests.Write(dir, requests.Record{Kind: requests.KindRebuild, Payload: payload}); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var calls int32
+	rebuildFn := func(proto.RebuildArgs) ([]string, string, error) {
+		atomic.AddInt32(&calls, 1)
+		panic("simulated memlimit SIGKILL mid-rebuild")
+	}
+
+	// Simulate 8 engine restarts / drain ticks. The outer recover models the
+	// process dying and being restarted: with the OLD code drainRequestsOnce
+	// itself panics (no per-record recovery) and the request is never acked,
+	// so every iteration re-applies. With the fix, the drain recovers the
+	// crash internally, persists a bounded attempt count, and dead-letters.
+	const drains = 8
+	for i := 0; i < drains; i++ {
+		func() {
+			defer func() { _ = recover() }()
+			_ = drainRequestsOnce(requestsRoot(), nil, rebuildFn, nil)
+		}()
+	}
+
+	got := atomic.LoadInt32(&calls)
+	if got < 1 {
+		t.Fatalf("expected the rebuild to be attempted at least once, got %d", got)
+	}
+	if got > maxRebuildAttempts {
+		t.Fatalf("rebuild re-applied %d times across %d drains — unbounded loop; want at most %d (bounded recovery)", got, drains, maxRebuildAttempts)
+	}
+
+	// After the attempt budget is exhausted the request must be gone
+	// (dead-lettered), so further drains never re-run it.
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	if len(recs) != 0 {
+		t.Fatalf("expected the request to be dead-lettered (removed) after the attempt budget, still pending: %+v", recs)
+	}
+}
+
+// (c): two concurrent KindRebuild applications for the SAME group must be
+// serialised — rebuildFn is never in-flight more than once at a time.
+//
+// Old behaviour (single-flight guard on the dead serve side, none on the
+// engine drain side): the two applyRequest calls run rebuildFn concurrently,
+// peak concurrency reaches 2 — this test fails.
+func TestApplyRequest_KindRebuild_SameGroupSerialised(t *testing.T) {
+	const group = "c-same-group"
+	payload, err := json.Marshal(proto.RebuildArgs{Group: group})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	rec := requests.Record{ID: "same-1", Kind: requests.KindRebuild, Payload: payload}
+
+	var inFlight int32
+	var peak int32
+	rebuildFn := func(proto.RebuildArgs) ([]string, string, error) {
+		n := atomic.AddInt32(&inFlight, 1)
+		for {
+			p := atomic.LoadInt32(&peak)
+			if n <= p || atomic.CompareAndSwapInt32(&peak, p, n) {
+				break
+			}
+		}
+		time.Sleep(30 * time.Millisecond)
+		atomic.AddInt32(&inFlight, -1)
+		return []string{"/repo"}, "", nil
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := applyRequest(nil, rebuildFn, rec); err != nil {
+				t.Errorf("applyRequest: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+
+	if p := atomic.LoadInt32(&peak); p > 1 {
+		t.Fatalf("peak concurrent rebuildFn executions for the same group = %d, want 1 (engine-side single-flight)", p)
+	}
+}
+
+// (c) preserved behaviour: DIFFERENT groups may rebuild concurrently. Each
+// rebuildFn waits (bounded) for the other to arrive; if the guard wrongly
+// serialised across groups the first would block forever waiting for a second
+// that can never start, and the barrier would time out.
+func TestApplyRequest_KindRebuild_DifferentGroupsConcurrent(t *testing.T) {
+	mkRec := func(group, id string) requests.Record {
+		payload, err := json.Marshal(proto.RebuildArgs{Group: group})
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		return requests.Record{ID: id, Kind: requests.KindRebuild, Payload: payload}
+	}
+
+	arrived := make(chan struct{}, 2)
+	proceed := make(chan struct{})
+	bothConcurrent := int32(0)
+	rebuildFn := func(proto.RebuildArgs) ([]string, string, error) {
+		arrived <- struct{}{}
+		select {
+		case <-proceed:
+			atomic.AddInt32(&bothConcurrent, 1)
+		case <-time.After(2 * time.Second):
+		}
+		return []string{"/repo"}, "", nil
+	}
+
+	var wg sync.WaitGroup
+	for _, g := range []struct{ group, id string }{{"c-diff-a", "a-1"}, {"c-diff-b", "b-1"}} {
+		rec := mkRec(g.group, g.id)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := applyRequest(nil, rebuildFn, rec); err != nil {
+				t.Errorf("applyRequest: %v", err)
+			}
+		}()
+	}
+
+	// Wait for both rebuildFns to arrive concurrently, then release them.
+	for i := 0; i < 2; i++ {
+		select {
+		case <-arrived:
+		case <-time.After(2 * time.Second):
+			t.Fatal("different-group rebuilds did not run concurrently (guard over-serialised across groups)")
+		}
+	}
+	close(proceed)
+	wg.Wait()
+
+	if atomic.LoadInt32(&bothConcurrent) != 2 {
+		t.Fatalf("expected both different-group rebuilds to be in-flight concurrently, got %d", atomic.LoadInt32(&bothConcurrent))
+	}
+}


### PR DESCRIPTION
## Problem
Two engine-side defects in the split-mode rebuild drain, both able to produce a perpetual full-rebuild loop on a large monorepo:

**(d) A rebuild that outlives the engine re-runs forever.** `ApplyAndAck` runs the multi-minute `rebuildFn` synchronously and deletes the request only *after* it returns. If the engine is killed mid-apply (memlimit reaper, crash, RPC EOF), the request is never acked, so the 2s drain re-applies it on **every** engine restart — unbounded. Observed: one `grafel rebuild` produced 3+ back-to-back full extractions, request file never removed.

**(c) The single-flight guard is on the dead side of the split.** PR #5763's `Service.groupRebuildMu` is acquired only *after* `Service.Rebuild` returns — but in split mode `Service.Rebuild` returns after merely *writing* the request, and the engine drain calls `rebuildFn` directly, unguarded.

## Fix
**(d) Durable bounded attempt-claim** (`requests.ApplyAndAckBounded`): the attempt count is a field **persisted to the request file** (via existing `atomicWrite` = tmp+fsync+rename), incremented *before* apply. In-memory recovery state would be lost on the very restart we must survive, so it must be on disk. At `Attempts >= maxRebuildAttempts (3)` the request is dead-lettered (error-ack + delete → loop terminates). A crash/panic leaves it pending with the higher count already durable, converging to the dead-letter; a *returned* error still acks+deletes exactly once. At-most-N with bounded recovery, never at-least-once-forever.

**(c) Engine-side per-group guard** (`engineGroupRebuildGuard`): capacity-1 semaphore keyed on group, around `rebuildFn` inside `applyRequest`, released via defer (panic-safe) — the split-mode live analogue of `groupRebuildMu`. Different groups still proceed concurrently.

## Tests (red→green, `-race` clean)
- `TestDrain_KindRebuild_CrashLoopIsBounded`: rebuildFn panics each apply; old code re-applies 8×/8 restarts, new caps at 3 then dead-letters (0 pending).
- `TestApplyRequest_KindRebuild_SameGroupSerialised`: peak concurrent rebuildFn == 1 (was 2).
- `TestApplyRequest_KindRebuild_DifferentGroupsConcurrent`: parallelism preserved.
- Existing ack/GC + redrain-harmless tests unchanged and green (276 pass).

Independent adversarial review: APPROVE.

Follow-ups (tracked, non-blocking, degraded-path only): surface dead-letter to the status plane / `doctor` (currently log-only); add inter-attempt backoff so a transient reaper kill doesn't burn the 3-attempt budget in ~6s.

Refs #5681 (corpus-usability / split-mode rebuild stability). Part of v0.1.8 stabilization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)