### PR TITLE
fix(wizard): real per-module progress + completion in split mode (no fake instant Done, no false-fail)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1477,9 +1477,25 @@ func daemonRebuildFuncCore(
 		}
 	}
 
+	// flushRebuiltStatus synchronously writes each successful repo's status-plane
+	// sidecar (fresh graph_fb_mtime, Indexing=false) inline, BEFORE this function
+	// returns — i.e. before the split-mode drain writes the request ack. This
+	// closes the status-write-vs-ack race (#5729 blocker #5): a wizard keying
+	// completion on the rebuild-request ack then sees a FRESH GraphFBMtime on its
+	// first classify poll instead of a stale one for up to a heartbeat interval.
+	// Best-effort per repo; never affects the rebuild result.
+	flushRebuiltStatus := func(paths []string) {
+		for _, repoPath := range paths {
+			daemon.FlushRepoStatusFile(repoPath)
+		}
+	}
+
 	// Return a combined error if any repos failed. The rebuilt list still
 	// contains all repos that succeeded, so the caller can report partial results.
 	if len(errs) > 0 {
+		// Flush the SUCCESSFUL repos' fresh status before the (early) error
+		// return so the wizard classifies them as indexed-OK, not false-failed.
+		flushRebuiltStatus(rebuilt)
 		return rebuilt, "", fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
 
@@ -1517,6 +1533,11 @@ func daemonRebuildFuncCore(
 	for _, repoPath := range rebuilt {
 		invalidateAfterIndex(repoPath)
 	}
+
+	// Flush fresh per-repo status AFTER linksFn (which may rewrite graph.fb) and
+	// the cache invalidation, so the sidecar captures the newest graph_fb_mtime,
+	// BEFORE returning (and thus before the split-mode ack). See #5729 blocker #5.
+	flushRebuiltStatus(rebuilt)
 
 	// Persist a quality-metrics snapshot to health-history.jsonl (#1329).
 	// Best-effort: failure is logged but never blocks the caller.

--- a/cmd/grafel/daemon_rebuild_status_flush_test.go
+++ b/cmd/grafel/daemon_rebuild_status_flush_test.go
@@ -1,0 +1,59 @@
+package main
+
+// daemon_rebuild_status_flush_test.go — #5729 blocker #5 regression: the engine
+// direct-rebuild path must leave a FRESH per-repo status sidecar (advanced
+// graph_fb_mtime, Indexing=false) upon return, BEFORE the split-mode drain
+// writes the request ack, so a wizard keying completion on the ack classifies
+// the repo as indexed-OK instead of "produced no graph".
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestDaemonRebuild_FlushesFreshStatusBeforeReturn verifies daemonRebuildFuncCore
+// synchronously writes each rebuilt repo's status file with a fresh graph_fb_mtime
+// (> the pre-rebuild baseline, i.e. > 0 for a fresh group) and Indexing=false by
+// the time it returns.
+func TestDaemonRebuild_FlushesFreshStatusBeforeReturn(t *testing.T) {
+	group := setupTestGroup(t, "status-flush-group", []string{"alpha", "beta"})
+
+	// The index fn writes a real graph.fb into each repo's state dir (as the
+	// real indexer does) so FindGraphFile — which the status flush stats — sees
+	// a fresh mtime.
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		sd := daemon.StateDirForRepo(repoPath)
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			return err
+		}
+		// A <8-byte graph.fb: FindGraphFile still stats a fresh mtime, but the
+		// fb reader rejects it gracefully (too short) instead of parsing garbage
+		// — we only need the mtime to advance, not a valid graph.
+		return os.WriteFile(filepath.Join(sd, "graph.fb"), []byte("fb"), 0o644)
+	}
+
+	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
+	if err != nil {
+		t.Fatalf("rebuild failed: %v", err)
+	}
+	if len(rebuilt) != 2 {
+		t.Fatalf("rebuilt %d repos, want 2", len(rebuilt))
+	}
+
+	for _, rp := range rebuilt {
+		f, ok := daemon.RepoStatusFile(rp)
+		if !ok || f == nil {
+			t.Fatalf("no status file flushed for %s (the drain would ack before any status write)", rp)
+		}
+		if f.GraphFBMtime <= 0 {
+			t.Errorf("%s: GraphFBMtime = %d; want a fresh (>0) mtime flushed before return", rp, f.GraphFBMtime)
+		}
+		if f.Indexing {
+			t.Errorf("%s: Indexing = true; want false after the rebuild completed", rp)
+		}
+	}
+}

--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -1,0 +1,262 @@
+package cli
+
+// wizard_split_progress.go — split-mode completion detection for the wizard
+// index (#5751 follow-up / split-mode progress UX).
+//
+// THE BUG THIS FIXES: in split mode (SplitModeEnabled(), the default), the
+// daemon's Service.Rebuild ENQUEUES the rebuild onto the engine queue and
+// RETURNS IMMEDIATELY (fire-and-forget). The old wizard keyed completion on
+// that async RPC return, so the TUI jumped 0→100% "Done" in <1s while the
+// engine indexed for ~20min in the background, and no per-module rows rendered.
+//
+// THE FIX (this file): in split mode the wizard still enqueues the rebuild, but
+// it KEEPS forwarding SSE per-module progress events to the TUI while it polls
+// a LEVEL-TRIGGERED completion signal off the status plane (statusfile). The
+// RPC return no longer marks completion. Engine-liveness (the engine-liveness
+// heartbeat) is a failure backstop and an overall timeout bounds the wait, so a
+// dead/wedged engine surfaces a real error instead of a fake "Done".
+//
+// Monolith mode is UNCHANGED: there Service.Rebuild is synchronous (the RPC
+// return IS completion) and streamIndexWithSummary still uses
+// forwardBrokerToChannel with the RPC's own stats.
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/progress"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// runSplitIndex is the production split-mode driver invoked by
+// streamIndexWithSummary. It builds the status-plane probe for the group and an
+// enqueue closure that fires the async Rebuild RPC on its own goroutine (so a
+// slow serve never stalls the completion poll), then delegates to
+// runSplitIndexCore.
+func runSplitIndex(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	c *client.Client,
+	group, token string,
+	sseCh <-chan sseEvent,
+	evCh chan<- progress.Event,
+) rebuildOutcome {
+	probe, err := newStatusPlaneProbe(group)
+	if err != nil {
+		return rebuildOutcome{err: err}
+	}
+	trigger := func() {
+		go func() {
+			// Fire-and-forget: in split mode this enqueues onto the engine
+			// queue and returns immediately. Its reply carries no stats, so we
+			// ignore it — completion + stats come from the status-plane poll.
+			_, _ = c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
+		}()
+	}
+	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll())
+}
+
+// splitClock is the injectable time seam so completion-poll tests advance
+// virtual time instead of sleeping for real intervals.
+type splitClock interface {
+	Now() time.Time
+	Sleep(d time.Duration)
+}
+
+// realSplitClock is the production clock.
+type realSplitClock struct{}
+
+func (realSplitClock) Now() time.Time        { return time.Now() }
+func (realSplitClock) Sleep(d time.Duration) { time.Sleep(d) }
+
+// splitSnapshot is one level-triggered reading of a group's split-mode index
+// state, sourced from the status plane.
+type splitSnapshot struct {
+	// Indexed is true when EVERY repo in the group is freshly indexed
+	// (status file present, not indexing, entities>0). Level-triggered: it
+	// stays true once reached and is robust to dropped SSE events.
+	Indexed bool
+	// EngineAlive mirrors the engine-liveness heartbeat freshness. Used as a
+	// FAILURE backstop: if the engine was alive and then goes stale before the
+	// group finishes, the wait fails instead of hanging.
+	EngineAlive bool
+	// Entities / Rels are the summed status-plane counts across the group's
+	// repos — the source of the final summary stats (the async split RPC reply
+	// carries none).
+	Entities int64
+	Rels     int64
+	// ElapsedSec is wall time since the poll started.
+	ElapsedSec float64
+}
+
+// splitProbe polls the status plane for a group's completion snapshot. The
+// production implementation reads statusfiles; tests inject a fake.
+type splitProbe interface {
+	Snapshot() (splitSnapshot, error)
+}
+
+// splitPollConfig tunes the completion poll.
+type splitPollConfig struct {
+	interval time.Duration // between polls
+	timeout  time.Duration // overall bound; exceeding it is a failure
+}
+
+// defaultSplitPoll returns the production poll cadence: a 500ms interval and a
+// 45-minute overall timeout (comfortably above the observed ~20min large-repo
+// index, but bounded so a wedged engine never hangs the wizard forever).
+func defaultSplitPoll() splitPollConfig {
+	return splitPollConfig{interval: 500 * time.Millisecond, timeout: 45 * time.Minute}
+}
+
+// awaitSplitCompletion polls probe until the group is freshly indexed (success),
+// the engine-liveness heartbeat goes stale AFTER having been alive (failure
+// backstop), or the overall timeout elapses (failure). It NEVER returns success
+// on the RPC-enqueue instant — completion is decided solely by the level-
+// triggered status-plane signal.
+func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig) (splitSnapshot, error) {
+	start := clk.Now()
+	sawAlive := false
+	for {
+		snap, err := probe.Snapshot()
+		if err == nil {
+			if snap.Indexed {
+				return snap, nil
+			}
+			if snap.EngineAlive {
+				sawAlive = true
+			} else if sawAlive {
+				// The engine was alive and is now stale without the group
+				// having finished — a real failure, not a fake "Done".
+				return splitSnapshot{}, fmt.Errorf("index engine stopped responding before the group finished indexing")
+			}
+		}
+		if clk.Now().Sub(start) >= cfg.timeout {
+			return splitSnapshot{}, fmt.Errorf("timed out after %s waiting for group to finish indexing", cfg.timeout)
+		}
+		clk.Sleep(cfg.interval)
+	}
+}
+
+// forwardSSEUntilCancel forwards parsed progress.Events from the broker SSE
+// stream onto evCh until ctx is cancelled or the stream closes. It runs
+// CONCURRENTLY with the completion poll so the per-module bars render live
+// throughout the whole index (the bars come from SSE, completion from the poll).
+func forwardSSEUntilCancel(ctx context.Context, sseCh <-chan sseEvent, evCh chan<- progress.Event) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case ev, ok := <-sseCh:
+			if !ok {
+				return
+			}
+			if ev.name != "progress" || ev.data == "" {
+				continue
+			}
+			var e progress.Event
+			if jsonUnmarshalEvent(ev.data, &e) {
+				select {
+				case evCh <- e:
+				default:
+				}
+			}
+		}
+	}
+}
+
+// runSplitIndexCore drives the split-mode index: it enqueues the async rebuild,
+// forwards SSE events to the TUI CONCURRENTLY, and polls the status-plane probe
+// for real completion. The returned rebuildOutcome carries the status-sourced
+// stats on success, or a real error on engine-death/timeout — NEVER a fake Done.
+func runSplitIndexCore(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	triggerRebuild func(),
+	sseCh <-chan sseEvent,
+	evCh chan<- progress.Event,
+	probe splitProbe,
+	clk splitClock,
+	cfg splitPollConfig,
+) rebuildOutcome {
+	// 1. Enqueue the async rebuild. In split mode this returns almost
+	//    immediately (fire-and-forget) — we deliberately do NOT key completion
+	//    on it. The production closure spawns its own goroutine for the RPC, so
+	//    this call is non-blocking; completion is decided by the poll below.
+	triggerRebuild()
+
+	// 2. Forward SSE per-module events to the TUI CONCURRENTLY so the bars
+	//    render live for the whole index. Cancelled once completion is decided.
+	go forwardSSEUntilCancel(ctx, sseCh, evCh)
+
+	// 3. Poll the status plane for REAL, level-triggered completion.
+	snap, err := awaitSplitCompletion(probe, clk, cfg)
+	cancel() // stop the SSE forward goroutine
+	if err != nil {
+		return rebuildOutcome{err: err}
+	}
+	return rebuildOutcome{
+		entities: snap.Entities,
+		rels:     snap.Rels,
+		elapsed:  snap.ElapsedSec,
+	}
+}
+
+// statusPlaneProbe is the production splitProbe: it reads each group repo's
+// status-plane sidecar (entities / indexing) and the engine-liveness heartbeat.
+type statusPlaneProbe struct {
+	repoPaths []string
+	root      string
+	started   time.Time
+}
+
+// newStatusPlaneProbe builds a status-plane probe for group by loading its
+// registry config to enumerate repo paths and resolving the daemon layout root
+// for the engine-liveness sidecar.
+func newStatusPlaneProbe(group string) (*statusPlaneProbe, error) {
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		return nil, err
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return nil, err
+	}
+	paths := make([]string, 0, len(cfg.Repos))
+	for _, r := range cfg.Repos {
+		paths = append(paths, r.Path)
+	}
+	root := ""
+	if layout, lErr := daemon.DefaultLayout(); lErr == nil {
+		root = layout.Root
+	}
+	return &statusPlaneProbe{repoPaths: paths, root: root, started: time.Now()}, nil
+}
+
+// Snapshot reads the status plane once. Indexed is true only when every group
+// repo has a status file that is not indexing and has entities>0.
+func (p *statusPlaneProbe) Snapshot() (splitSnapshot, error) {
+	var ent, rels int64
+	allIndexed := len(p.repoPaths) > 0
+	for _, rp := range p.repoPaths {
+		f, ok := daemon.RepoStatusFile(rp)
+		if !ok || f == nil || f.Indexing || f.Entities == 0 {
+			allIndexed = false
+		}
+		if ok && f != nil {
+			ent += f.Entities
+			rels += f.Relationships
+		}
+	}
+	_, alive := daemon.EngineLivenessStatus(p.root)
+	return splitSnapshot{
+		Indexed:     allIndexed,
+		EngineAlive: alive,
+		Entities:    ent,
+		Rels:        rels,
+		ElapsedSec:  time.Since(p.started).Seconds(),
+	}, nil
+}

--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -9,12 +9,18 @@ package cli
 // that async RPC return, so the TUI jumped 0→100% "Done" in <1s while the
 // engine indexed for ~20min in the background, and no per-module rows rendered.
 //
-// THE FIX (this file): in split mode the wizard still enqueues the rebuild, but
-// it KEEPS forwarding SSE per-module progress events to the TUI while it polls
-// a LEVEL-TRIGGERED completion signal off the status plane (statusfile). The
-// RPC return no longer marks completion. Engine-liveness (the engine-liveness
-// heartbeat) is a failure backstop and an overall timeout bounds the wait, so a
-// dead/wedged engine surfaces a real error instead of a fake "Done".
+// COMPLETION SIGNAL: the engine finishing OUR group rebuild — observed as the
+// KindRebuild request we enqueued (identified by our ProgressToken) being
+// drained+acked, i.e. daemon.RebuildRequestPending going false. This is
+// authoritative and race-free (the enqueue RPC returns only after the request
+// is on disk, and we poll for ITS disappearance) and, crucially, it fires even
+// when a repo fails / is empty / is skipped — where a "every repo's graph.fb
+// advanced" predicate would hang until the overall timeout. graph_fb_mtime is
+// then used only to CLASSIFY the per-repo result once the rebuild is done.
+//
+// While polling we KEEP forwarding SSE per-module progress events so the bars
+// render live. Engine-liveness is a failure backstop (never-alive fast-fail +
+// alive→stale), and the overall timeout is a last-resort bound.
 //
 // Monolith mode is UNCHANGED: there Service.Rebuild is synchronous (the RPC
 // return IS completion) and streamIndexWithSummary still uses
@@ -23,6 +29,8 @@ package cli
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -34,10 +42,9 @@ import (
 )
 
 // runSplitIndex is the production split-mode driver invoked by
-// streamIndexWithSummary. It builds the status-plane probe for the group and an
-// enqueue closure that fires the async Rebuild RPC on its own goroutine (so a
-// slow serve never stalls the completion poll), then delegates to
-// runSplitIndexCore.
+// streamIndexWithSummary. It builds the status-plane probe for the group (which
+// captures the per-repo graph_fb_mtime baseline BEFORE the enqueue) and a
+// synchronous enqueue closure, then delegates to runSplitIndexCore.
 func runSplitIndex(
 	ctx context.Context,
 	cancel context.CancelFunc,
@@ -46,17 +53,18 @@ func runSplitIndex(
 	sseCh <-chan sseEvent,
 	evCh chan<- progress.Event,
 ) rebuildOutcome {
-	probe, err := newStatusPlaneProbe(group)
+	probe, err := newStatusPlaneProbe(group, token)
 	if err != nil {
 		return rebuildOutcome{err: err}
 	}
-	trigger := func() {
-		go func() {
-			// Fire-and-forget: in split mode this enqueues onto the engine
-			// queue and returns immediately. Its reply carries no stats, so we
-			// ignore it — completion + stats come from the status-plane poll.
-			_, _ = c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
-		}()
+	// Synchronous enqueue: in split mode Service.Rebuild writes the KindRebuild
+	// request to disk and returns immediately, so this is fast. Returning only
+	// after the RPC completes (a) race-free gates the request-ack poll below
+	// (the request exists before we look for its disappearance) and (b) fixes
+	// the goroutine-leak (N1) — nothing outlives c.Close on an early return.
+	trigger := func() error {
+		_, rErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
+		return rErr
 	}
 	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll())
 }
@@ -74,69 +82,84 @@ type realSplitClock struct{}
 func (realSplitClock) Now() time.Time        { return time.Now() }
 func (realSplitClock) Sleep(d time.Duration) { time.Sleep(d) }
 
-// splitSnapshot is one level-triggered reading of a group's split-mode index
-// state, sourced from the status plane.
-type splitSnapshot struct {
-	// Indexed is true when EVERY repo in the group is freshly indexed
-	// (status file present, not indexing, entities>0). Level-triggered: it
-	// stays true once reached and is robust to dropped SSE events.
-	Indexed bool
-	// EngineAlive mirrors the engine-liveness heartbeat freshness. Used as a
-	// FAILURE backstop: if the engine was alive and then goes stale before the
-	// group finishes, the wait fails instead of hanging.
+// splitPoll is one reading of the completion loop's inputs: whether our rebuild
+// request is still queued, and whether the engine is live.
+type splitPoll struct {
+	// RequestPending is true while our KindRebuild request is still on the
+	// engine queue. false == the engine drained+acked it == our group rebuild
+	// finished (success OR partial); the poll then stops and classifies.
+	RequestPending bool
+	// EngineAlive mirrors the engine-liveness heartbeat freshness (backstop).
 	EngineAlive bool
-	// Entities / Rels are the summed status-plane counts across the group's
-	// repos — the source of the final summary stats (the async split RPC reply
-	// carries none).
-	Entities int64
-	Rels     int64
-	// ElapsedSec is wall time since the poll started.
-	ElapsedSec float64
 }
 
-// splitProbe polls the status plane for a group's completion snapshot. The
-// production implementation reads statusfiles; tests inject a fake.
+// splitResult is the classified outcome, produced once the rebuild is done.
+type splitResult struct {
+	// Failed names the repos that did NOT produce a fresh graph (with a reason).
+	// Empty == every repo indexed OK.
+	Failed []string
+	// Entities / Rels are summed across the repos that DID index (status plane;
+	// may be 0 on the wizard path where the graph-stats sidecar isn't written).
+	Entities int64
+	Rels     int64
+}
+
+// splitProbe is the seam the completion loop polls. Poll is called repeatedly;
+// Classify is called exactly once, after Poll reports RequestPending==false.
 type splitProbe interface {
-	Snapshot() (splitSnapshot, error)
+	Poll() (splitPoll, error)
+	Classify() (splitResult, error)
 }
 
 // splitPollConfig tunes the completion poll.
 type splitPollConfig struct {
-	interval time.Duration // between polls
-	timeout  time.Duration // overall bound; exceeding it is a failure
+	interval      time.Duration // between polls
+	startupWindow time.Duration // fast-fail if the engine is never live within this (S1)
+	timeout       time.Duration // last-resort overall bound
 }
 
-// defaultSplitPoll returns the production poll cadence: a 500ms interval and a
-// 45-minute overall timeout (comfortably above the observed ~20min large-repo
-// index, but bounded so a wedged engine never hangs the wizard forever).
+// defaultSplitPoll returns the production poll cadence: a 500ms interval, a 30s
+// never-alive fast-fail window, and a 45-minute last-resort timeout (well above
+// the observed ~20min large-repo index, but bounded so a genuinely wedged
+// engine never hangs the wizard forever). With the request-ack signal the
+// timeout should essentially never be hit.
 func defaultSplitPoll() splitPollConfig {
-	return splitPollConfig{interval: 500 * time.Millisecond, timeout: 45 * time.Minute}
+	return splitPollConfig{
+		interval:      500 * time.Millisecond,
+		startupWindow: 30 * time.Second,
+		timeout:       45 * time.Minute,
+	}
 }
 
-// awaitSplitCompletion polls probe until the group is freshly indexed (success),
-// the engine-liveness heartbeat goes stale AFTER having been alive (failure
-// backstop), or the overall timeout elapses (failure). It NEVER returns success
-// on the RPC-enqueue instant — completion is decided solely by the level-
-// triggered status-plane signal.
-func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig) (splitSnapshot, error) {
+// awaitSplitCompletion polls probe until our group rebuild is drained+acked
+// (RequestPending==false → classify + return), or a failure fires: the engine
+// is never seen live within startupWindow (S1 fast-fail), the engine was live
+// and then went stale (backstop), or the overall timeout elapses (last resort).
+// It NEVER returns success on the enqueue instant — completion is the request
+// ack, not the RPC return.
+func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig) (splitResult, error) {
 	start := clk.Now()
 	sawAlive := false
 	for {
-		snap, err := probe.Snapshot()
+		p, err := probe.Poll()
 		if err == nil {
-			if snap.Indexed {
-				return snap, nil
+			if !p.RequestPending {
+				// The engine finished our rebuild — classify the per-repo result.
+				return probe.Classify()
 			}
-			if snap.EngineAlive {
+			if p.EngineAlive {
 				sawAlive = true
 			} else if sawAlive {
-				// The engine was alive and is now stale without the group
-				// having finished — a real failure, not a fake "Done".
-				return splitSnapshot{}, fmt.Errorf("index engine stopped responding before the group finished indexing")
+				return splitResult{}, fmt.Errorf("index engine stopped responding before the group rebuild finished")
 			}
 		}
-		if clk.Now().Sub(start) >= cfg.timeout {
-			return splitSnapshot{}, fmt.Errorf("timed out after %s waiting for group to finish indexing", cfg.timeout)
+		elapsed := clk.Now().Sub(start)
+		if !sawAlive && cfg.startupWindow > 0 && elapsed >= cfg.startupWindow {
+			// S1: the engine never came alive — fail fast, don't wait the full timeout.
+			return splitResult{}, fmt.Errorf("index engine never became live within %s; is the daemon/engine running?", cfg.startupWindow)
+		}
+		if elapsed >= cfg.timeout {
+			return splitResult{}, fmt.Errorf("timed out after %s waiting for the group rebuild to finish", cfg.timeout)
 		}
 		clk.Sleep(cfg.interval)
 	}
@@ -169,40 +192,49 @@ func forwardSSEUntilCancel(ctx context.Context, sseCh <-chan sseEvent, evCh chan
 	}
 }
 
-// runSplitIndexCore drives the split-mode index: it enqueues the async rebuild,
-// forwards SSE events to the TUI CONCURRENTLY, and polls the status-plane probe
-// for real completion. The returned rebuildOutcome carries the status-sourced
-// stats on success, or a real error on engine-death/timeout — NEVER a fake Done.
+// runSplitIndexCore drives the split-mode index: it forwards SSE events to the
+// TUI CONCURRENTLY, enqueues the async rebuild (synchronously, so the ack poll
+// is race-free), and polls until the engine finishes OUR rebuild, then
+// classifies. The returned rebuildOutcome carries the status-sourced stats on a
+// clean success, or a PROMPT error naming the repo(s) that did not index — and
+// on engine-death/timeout — NEVER a fake Done and NEVER a 45m hang on a partial
+// failure.
 func runSplitIndexCore(
 	ctx context.Context,
 	cancel context.CancelFunc,
-	triggerRebuild func(),
+	triggerRebuild func() error,
 	sseCh <-chan sseEvent,
 	evCh chan<- progress.Event,
 	probe splitProbe,
 	clk splitClock,
 	cfg splitPollConfig,
 ) rebuildOutcome {
-	// 1. Enqueue the async rebuild. In split mode this returns almost
-	//    immediately (fire-and-forget) — we deliberately do NOT key completion
-	//    on it. The production closure spawns its own goroutine for the RPC, so
-	//    this call is non-blocking; completion is decided by the poll below.
-	triggerRebuild()
-
-	// 2. Forward SSE per-module events to the TUI CONCURRENTLY so the bars
-	//    render live for the whole index. Cancelled once completion is decided.
+	// 1. Start forwarding SSE per-module events CONCURRENTLY so the bars render
+	//    live from the first moment (even during the enqueue).
 	go forwardSSEUntilCancel(ctx, sseCh, evCh)
 
-	// 3. Poll the status plane for REAL, level-triggered completion.
-	snap, err := awaitSplitCompletion(probe, clk, cfg)
+	// 2. Enqueue the rebuild synchronously. The RPC returns only once the
+	//    request is on disk, which race-free gates the ack poll below.
+	if err := triggerRebuild(); err != nil {
+		cancel()
+		return rebuildOutcome{err: fmt.Errorf("enqueue rebuild: %w", err)}
+	}
+
+	// 3. Poll for real completion (the request ack), then classify.
+	res, err := awaitSplitCompletion(probe, clk, cfg)
 	cancel() // stop the SSE forward goroutine
 	if err != nil {
 		return rebuildOutcome{err: err}
 	}
+	if len(res.Failed) > 0 {
+		// Partial failure: the engine finished, but some repos produced no
+		// graph. Surface a PROMPT, clear terminal error naming them — never a
+		// hang, never a silent fake success.
+		return rebuildOutcome{err: fmt.Errorf("index did not complete for %d repo(s): %s", len(res.Failed), strings.Join(res.Failed, "; "))}
+	}
 	return rebuildOutcome{
-		entities: snap.Entities,
-		rels:     snap.Rels,
-		elapsed:  snap.ElapsedSec,
+		entities: res.Entities,
+		rels:     res.Rels,
 	}
 }
 
@@ -212,23 +244,30 @@ type statusReader func(repoPath string) (*statusfile.File, bool)
 // livenessReader reads the engine-liveness heartbeat (mirrors daemon.EngineLivenessStatus).
 type livenessReader func(root string) (f *statusfile.File, fresh bool)
 
-// statusPlaneProbe is the production splitProbe: it reads each group repo's
-// status-plane sidecar (graph_fb_mtime / indexing) and the engine-liveness
-// heartbeat. It captures a per-repo graph_fb_mtime baseline at construction so
-// completion is "graph.fb was (re)written past the pre-enqueue mtime".
+// pendingReader reports whether our rebuild request is still queued (mirrors
+// daemon.RebuildRequestPending bound to this group + token).
+type pendingReader func() (bool, error)
+
+// statusPlaneProbe is the production splitProbe. Poll consults the request-ack
+// queue (completion) + engine-liveness (backstop); Classify inspects each group
+// repo's status file vs the pre-enqueue graph_fb_mtime baseline. Entities are
+// NOT part of the completion/classification gate (the wizard/rebuild path does
+// not write the graph-stats sidecar, so a successfully-indexed repo can report
+// entities:0) — graph_fb_mtime advancing is the "graph was written" signal.
 type statusPlaneProbe struct {
 	repoPaths    []string
 	root         string
 	baseline     map[string]int64 // per-repo graph_fb_mtime captured BEFORE enqueue
 	readStatus   statusReader
 	readLiveness livenessReader
-	started      time.Time
+	pending      pendingReader
 }
 
 // newStatusPlaneProbe builds a status-plane probe for group by loading its
 // registry config to enumerate repo paths and resolving the daemon layout root
-// for the engine-liveness sidecar.
-func newStatusPlaneProbe(group string) (*statusPlaneProbe, error) {
+// for the engine-liveness sidecar. token scopes the request-ack check to OUR
+// specific rebuild.
+func newStatusPlaneProbe(group, token string) (*statusPlaneProbe, error) {
 	cfgPath, err := registry.ConfigPathFor(group)
 	if err != nil {
 		return nil, err
@@ -245,22 +284,23 @@ func newStatusPlaneProbe(group string) (*statusPlaneProbe, error) {
 	if layout, lErr := daemon.DefaultLayout(); lErr == nil {
 		root = layout.Root
 	}
-	return newStatusPlaneProbeWith(paths, root, daemon.RepoStatusFile, daemon.EngineLivenessStatus), nil
+	pending := func() (bool, error) { return daemon.RebuildRequestPending(group, token) }
+	return newStatusPlaneProbeWith(paths, root, daemon.RepoStatusFile, daemon.EngineLivenessStatus, pending), nil
 }
 
-// newStatusPlaneProbeWith builds a probe with injected status/liveness readers
-// (production wires the real daemon funcs; tests inject fakes). It captures the
-// per-repo graph_fb_mtime BASELINE right now — BEFORE the rebuild is enqueued —
-// so completion can be detected as graph.fb being (re)written past this point.
-// For a fresh group the repos have no status file yet, so their baseline is 0.
-func newStatusPlaneProbeWith(paths []string, root string, rs statusReader, lr livenessReader) *statusPlaneProbe {
+// newStatusPlaneProbeWith builds a probe with injected readers (production wires
+// the real daemon funcs; tests inject fakes). It captures the per-repo
+// graph_fb_mtime BASELINE right now — BEFORE the rebuild is enqueued — so a
+// completed index is detected as graph.fb being (re)written past this point. For
+// a fresh group the repos have no status file yet, so their baseline is 0.
+func newStatusPlaneProbeWith(paths []string, root string, rs statusReader, lr livenessReader, pending pendingReader) *statusPlaneProbe {
 	p := &statusPlaneProbe{
 		repoPaths:    paths,
 		root:         root,
 		baseline:     make(map[string]int64, len(paths)),
 		readStatus:   rs,
 		readLiveness: lr,
-		started:      time.Now(),
+		pending:      pending,
 	}
 	for _, rp := range paths {
 		if f, ok := rs(rp); ok && f != nil {
@@ -270,32 +310,41 @@ func newStatusPlaneProbeWith(paths []string, root string, rs statusReader, lr li
 	return p
 }
 
-// Snapshot reads the status plane once. Indexed is true only when every group
-// repo has a status file that is not indexing and whose graph_fb_mtime has
-// ADVANCED past the pre-enqueue baseline (graph.fb was (re)written == index
-// completed). Entities/Relationships are NOT part of the completion predicate
-// because the wizard/rebuild code path does not write the graph-stats sidecar,
-// so Entities can stay 0 on a successful index (tracked as a separate bug); we
-// still surface whatever counts the status plane does have.
-func (p *statusPlaneProbe) Snapshot() (splitSnapshot, error) {
-	var ent, rels int64
-	allIndexed := len(p.repoPaths) > 0
-	for _, rp := range p.repoPaths {
-		f, ok := p.readStatus(rp)
-		if !ok || f == nil || f.Indexing || f.GraphFBMtime <= p.baseline[rp] {
-			allIndexed = false
-		}
-		if ok && f != nil {
-			ent += f.Entities
-			rels += f.Relationships
-		}
+// Poll reads the completion signal (our request still queued?) and engine
+// liveness in one shot.
+func (p *statusPlaneProbe) Poll() (splitPoll, error) {
+	pend, err := p.pending()
+	if err != nil {
+		return splitPoll{}, err
 	}
 	_, alive := p.readLiveness(p.root)
-	return splitSnapshot{
-		Indexed:     allIndexed,
-		EngineAlive: alive,
-		Entities:    ent,
-		Rels:        rels,
-		ElapsedSec:  time.Since(p.started).Seconds(),
-	}, nil
+	return splitPoll{RequestPending: pend, EngineAlive: alive}, nil
+}
+
+// Classify inspects each group repo AFTER the rebuild finished. A repo counts as
+// indexed-OK when its status file exists, is not indexing, and its
+// graph_fb_mtime advanced past the pre-enqueue baseline; otherwise it is listed
+// as failed (with LastErr if the status plane recorded one, else a generic
+// "produced no graph"). Stats are summed only over the OK repos.
+func (p *statusPlaneProbe) Classify() (splitResult, error) {
+	var res splitResult
+	for _, rp := range p.repoPaths {
+		f, ok := p.readStatus(rp)
+		if ok && f != nil && !f.Indexing && f.GraphFBMtime > p.baseline[rp] {
+			res.Entities += f.Entities
+			res.Rels += f.Relationships
+			continue
+		}
+		reason := "produced no graph"
+		if ok && f != nil {
+			switch {
+			case f.LastErr != "":
+				reason = f.LastErr
+			case f.Indexing:
+				reason = "still indexing when the rebuild acked"
+			}
+		}
+		res.Failed = append(res.Failed, fmt.Sprintf("%s (%s)", filepath.Base(rp), reason))
+	}
+	return res, nil
 }

--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
 // runSplitIndex is the production split-mode driver invoked by
@@ -205,12 +206,23 @@ func runSplitIndexCore(
 	}
 }
 
+// statusReader reads one repo's status-plane sidecar (mirrors daemon.RepoStatusFile).
+type statusReader func(repoPath string) (*statusfile.File, bool)
+
+// livenessReader reads the engine-liveness heartbeat (mirrors daemon.EngineLivenessStatus).
+type livenessReader func(root string) (f *statusfile.File, fresh bool)
+
 // statusPlaneProbe is the production splitProbe: it reads each group repo's
-// status-plane sidecar (entities / indexing) and the engine-liveness heartbeat.
+// status-plane sidecar (graph_fb_mtime / indexing) and the engine-liveness
+// heartbeat. It captures a per-repo graph_fb_mtime baseline at construction so
+// completion is "graph.fb was (re)written past the pre-enqueue mtime".
 type statusPlaneProbe struct {
-	repoPaths []string
-	root      string
-	started   time.Time
+	repoPaths    []string
+	root         string
+	baseline     map[string]int64 // per-repo graph_fb_mtime captured BEFORE enqueue
+	readStatus   statusReader
+	readLiveness livenessReader
+	started      time.Time
 }
 
 // newStatusPlaneProbe builds a status-plane probe for group by loading its
@@ -233,17 +245,44 @@ func newStatusPlaneProbe(group string) (*statusPlaneProbe, error) {
 	if layout, lErr := daemon.DefaultLayout(); lErr == nil {
 		root = layout.Root
 	}
-	return &statusPlaneProbe{repoPaths: paths, root: root, started: time.Now()}, nil
+	return newStatusPlaneProbeWith(paths, root, daemon.RepoStatusFile, daemon.EngineLivenessStatus), nil
+}
+
+// newStatusPlaneProbeWith builds a probe with injected status/liveness readers
+// (production wires the real daemon funcs; tests inject fakes). It captures the
+// per-repo graph_fb_mtime BASELINE right now — BEFORE the rebuild is enqueued —
+// so completion can be detected as graph.fb being (re)written past this point.
+// For a fresh group the repos have no status file yet, so their baseline is 0.
+func newStatusPlaneProbeWith(paths []string, root string, rs statusReader, lr livenessReader) *statusPlaneProbe {
+	p := &statusPlaneProbe{
+		repoPaths:    paths,
+		root:         root,
+		baseline:     make(map[string]int64, len(paths)),
+		readStatus:   rs,
+		readLiveness: lr,
+		started:      time.Now(),
+	}
+	for _, rp := range paths {
+		if f, ok := rs(rp); ok && f != nil {
+			p.baseline[rp] = f.GraphFBMtime
+		}
+	}
+	return p
 }
 
 // Snapshot reads the status plane once. Indexed is true only when every group
-// repo has a status file that is not indexing and has entities>0.
+// repo has a status file that is not indexing and whose graph_fb_mtime has
+// ADVANCED past the pre-enqueue baseline (graph.fb was (re)written == index
+// completed). Entities/Relationships are NOT part of the completion predicate
+// because the wizard/rebuild code path does not write the graph-stats sidecar,
+// so Entities can stay 0 on a successful index (tracked as a separate bug); we
+// still surface whatever counts the status plane does have.
 func (p *statusPlaneProbe) Snapshot() (splitSnapshot, error) {
 	var ent, rels int64
 	allIndexed := len(p.repoPaths) > 0
 	for _, rp := range p.repoPaths {
-		f, ok := daemon.RepoStatusFile(rp)
-		if !ok || f == nil || f.Indexing || f.Entities == 0 {
+		f, ok := p.readStatus(rp)
+		if !ok || f == nil || f.Indexing || f.GraphFBMtime <= p.baseline[rp] {
 			allIndexed = false
 		}
 		if ok && f != nil {
@@ -251,7 +290,7 @@ func (p *statusPlaneProbe) Snapshot() (splitSnapshot, error) {
 			rels += f.Relationships
 		}
 	}
-	_, alive := daemon.EngineLivenessStatus(p.root)
+	_, alive := p.readLiveness(p.root)
 	return splitSnapshot{
 		Indexed:     allIndexed,
 		EngineAlive: alive,

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -371,6 +371,103 @@ func TestStatusProbe_ClassifyWaitsForMtimeAdvancePastBaseline(t *testing.T) {
 	}
 }
 
+// pendingUntilThen is like pendingUntil, but invokes onAck exactly once on the
+// first call that reports "gone" (acked) — modeling the engine flushing fresh
+// per-repo status RIGHT BEFORE it writes the ack (blocker #5 ordering).
+func pendingUntilThen(n int, onAck func()) pendingReader {
+	var mu sync.Mutex
+	calls := 0
+	fired := false
+	return func() (bool, error) {
+		mu.Lock()
+		calls++
+		c := calls
+		doFire := c >= n && !fired
+		if doFire {
+			fired = true
+		}
+		mu.Unlock()
+		if c >= n {
+			if doFire && onAck != nil {
+				onAck()
+			}
+			return false, nil
+		}
+		return true, nil
+	}
+}
+
+// #10. SPLIT with NO dashboard (nil SSE channel): completion must STILL wait for
+// the request ack — never return instantly at the fire-and-forget enqueue. This
+// is the path that previously bypassed the whole fix when dashPort==0.
+func TestSplit_NoDashboard_WaitsForAck(t *testing.T) {
+	probe := &fakeProbe{
+		pollFn:   func(call int) splitPoll { return splitPoll{RequestPending: call < 5, EngineAlive: true} },
+		classify: splitResult{Entities: 7, Rels: 9},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sseCh <-chan sseEvent // nil: no dashboard, no live bars
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if probe.count() < 5 {
+		t.Fatalf("completed after %d polls with no dashboard; want >=5 (must wait for the ack, not the enqueue return)", probe.count())
+	}
+	if o.entities != 7 || o.rels != 9 {
+		t.Fatalf("stats = (%d,%d); want (7,9)", o.entities, o.rels)
+	}
+}
+
+// #5a. Status-write-vs-ack RACE: if a rebuilt repo's status is STILL stale
+// (graph_fb_mtime == baseline) at the instant the request acks, Classify
+// false-fails a repo that actually succeeded. Documents the race the engine-side
+// flush fixes.
+func TestSplit_StaleStatusAtAck_FalseFailsWithoutFlush(t *testing.T) {
+	const repo = "/repo/monorepo"
+	store := newFakeStatusStore()
+	// Pre-existing graph from a prior index → baseline captured at mtime 1000.
+	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1000})
+
+	// Engine acks WITHOUT flushing fresh status (status stays at 1000 == baseline).
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntil(3))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	if o.err == nil {
+		t.Fatal("expected a (false) failure when status is stale at ack — documents the race the flush closes")
+	}
+}
+
+// #5b. With the engine-side fix, fresh per-repo status is flushed BEFORE the ack
+// is written, so by the time the request goes !pending the status already shows
+// an advanced graph_fb_mtime and Classify passes.
+func TestSplit_FreshStatusFlushedBeforeAck_ClassifiesOK(t *testing.T) {
+	const repo = "/repo/monorepo"
+	store := newFakeStatusStore()
+	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1000}) // baseline 1000
+
+	// Model the fix: the engine flushes fresh status (mtime advances) RIGHT
+	// BEFORE it writes the ack that makes the request go !pending.
+	flush := func() {
+		store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 5000, Entities: 42, Relationships: 84})
+	}
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntilThen(3, flush))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	if o.err != nil {
+		t.Fatalf("fresh status flushed before ack should classify OK, got: %v", o.err)
+	}
+	if o.entities != 42 || o.rels != 84 {
+		t.Fatalf("stats = (%d,%d); want (42,84) from the freshly-flushed status", o.entities, o.rels)
+	}
+}
+
 // 5. MONOLITH: unchanged — completion is the RPC return, carrying the RPC's own
 // stats, and in-window SSE events still forward. Exercises the monolith path
 // (forwardBrokerToChannel), which the fix must leave byte-identical.

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -1,0 +1,224 @@
+package cli
+
+// wizard_split_progress_test.go — TDD coverage for split-mode wizard completion
+// detection. All fakes; no real daemon, no real index, no real sleeps.
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// fakeSplitClock advances virtual time on Sleep so the poll loop's timeout
+// accounting works without any real delay.
+type fakeSplitClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeSplitClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeSplitClock) Sleep(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+// fakeProbe returns a scripted sequence of snapshots. snapFn is called on every
+// Snapshot() with the (1-based) call count and returns the reading.
+type fakeProbe struct {
+	mu    sync.Mutex
+	calls int
+	fn    func(call int) splitSnapshot
+}
+
+func (p *fakeProbe) Snapshot() (splitSnapshot, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	fn := p.fn
+	p.mu.Unlock()
+	return fn(n), nil
+}
+
+func (p *fakeProbe) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func testPollCfg() splitPollConfig {
+	return splitPollConfig{interval: 10 * time.Millisecond, timeout: 5 * time.Minute}
+}
+
+func mkSSE(t *testing.T, e progress.Event) sseEvent {
+	t.Helper()
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return sseEvent{name: "progress", data: string(b)}
+}
+
+// 1. SPLIT: completion fires only AFTER the status transition, never at the
+// instant Rebuild returns.
+func TestSplit_CompletionWaitsForStatusTransition(t *testing.T) {
+	const wantEntities, wantRels = int64(4321), int64(8765)
+	// Not indexed (but engine alive) for the first 3 polls; indexed on the 4th.
+	probe := &fakeProbe{fn: func(call int) splitSnapshot {
+		if call < 4 {
+			return splitSnapshot{Indexed: false, EngineAlive: true}
+		}
+		return splitSnapshot{Indexed: true, EngineAlive: true, Entities: wantEntities, Rels: wantRels}
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sseCh := make(chan sseEvent) // never delivers
+	evCh := make(chan progress.Event, 8)
+	rebuildCalled := false
+
+	o := runSplitIndexCore(ctx, cancel, func() { rebuildCalled = true }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+
+	if !rebuildCalled {
+		t.Fatal("triggerRebuild was never called")
+	}
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if probe.count() < 4 {
+		t.Fatalf("completed after %d polls; want >=4 (must wait for the status transition, not the enqueue return)", probe.count())
+	}
+	if o.entities != wantEntities || o.rels != wantRels {
+		t.Fatalf("stats = (%d,%d); want (%d,%d)", o.entities, o.rels, wantEntities, wantRels)
+	}
+}
+
+// 2. SPLIT: per-module SSE events emitted during the indexing window ARE
+// forwarded to the TUI event channel (bars render), not cut off early.
+func TestSplit_ForwardsPerModuleEventsDuringWindow(t *testing.T) {
+	events := []progress.Event{
+		{GroupSlug: "g", RepoSlug: "backend", Phase: "scanning", FilesDone: 10, FilesTotal: 100},
+		{GroupSlug: "g", RepoSlug: "backend", Phase: "extracting_ast", FilesDone: 50, FilesTotal: 100},
+		{GroupSlug: "g", RepoSlug: "frontend", Phase: "resolving_refs", FilesDone: 90, FilesTotal: 100},
+	}
+	const n = 3
+	sseCh := make(chan sseEvent, n)
+	for _, e := range events {
+		sseCh <- mkSSE(t, e)
+	}
+	evCh := make(chan progress.Event, n)
+
+	// Complete only once all n events have been forwarded into evCh's buffer.
+	probe := &fakeProbe{fn: func(int) splitSnapshot {
+		if len(evCh) >= n {
+			return splitSnapshot{Indexed: true, EngineAlive: true, Entities: 1, Rels: 1}
+		}
+		return splitSnapshot{Indexed: false, EngineAlive: true}
+	}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, func() {}, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if got := len(evCh); got != n {
+		t.Fatalf("forwarded %d events; want %d (per-module bars must render throughout the window)", got, n)
+	}
+	// Sanity: the forwarded events parse back to the per-module payloads.
+	first := <-evCh
+	if first.RepoSlug != "backend" || first.Phase != "scanning" {
+		t.Fatalf("first forwarded event = %+v; want backend/scanning", first)
+	}
+}
+
+// 3. SPLIT: the final outcome carries the real stats sourced from the status
+// signal (entities=E, rels=R), not empty.
+func TestSplit_OutcomeCarriesStatusStats(t *testing.T) {
+	const E, R = int64(12345), int64(67890)
+	probe := &fakeProbe{fn: func(call int) splitSnapshot {
+		if call < 2 {
+			return splitSnapshot{Indexed: false, EngineAlive: true}
+		}
+		return splitSnapshot{Indexed: true, EngineAlive: true, Entities: E, Rels: R, ElapsedSec: 7}
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	oc := toIndexOutcome(o, wiztui.InstallSummary{})
+	if oc.Entities != E || oc.Rels != R {
+		t.Fatalf("IndexOutcome stats = (%d,%d); want (%d,%d)", oc.Entities, oc.Rels, E, R)
+	}
+	if oc.Err != nil {
+		t.Fatalf("IndexOutcome.Err = %v; want nil", oc.Err)
+	}
+}
+
+// 4. SPLIT + engine dies: the engine-liveness heartbeat goes stale after having
+// been alive and the group never completes → the outcome is a real ERROR, never
+// a fake Done.
+func TestSplit_EngineDiesSurfacesError(t *testing.T) {
+	probe := &fakeProbe{fn: func(call int) splitSnapshot {
+		if call <= 2 {
+			return splitSnapshot{Indexed: false, EngineAlive: true} // alive, working
+		}
+		return splitSnapshot{Indexed: false, EngineAlive: false} // engine died
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	if o.err == nil {
+		t.Fatal("engine died but outcome carried no error (fake Done)")
+	}
+	if o.entities != 0 {
+		t.Fatalf("failed outcome should carry no stats, got entities=%d", o.entities)
+	}
+}
+
+// 4b. SPLIT + never completes while alive: bounded timeout → real error.
+func TestSplit_TimeoutSurfacesError(t *testing.T) {
+	probe := &fakeProbe{fn: func(int) splitSnapshot {
+		return splitSnapshot{Indexed: false, EngineAlive: true} // alive forever, never done
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: time.Second, timeout: 3 * time.Second}
+	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	if o.err == nil {
+		t.Fatal("index never completed but no timeout error surfaced")
+	}
+}
+
+// 5. MONOLITH: unchanged — completion is the RPC return, carrying the RPC's own
+// stats, and in-window SSE events still forward. Exercises the monolith path
+// (forwardBrokerToChannel), which the fix must leave byte-identical.
+func TestMonolith_CompletesAtRPCReturnWithRPCStats(t *testing.T) {
+	sseCh := make(chan sseEvent, 2)
+	sseCh <- mkSSE(t, progress.Event{RepoSlug: "backend", Phase: "scanning"})
+	rpcCh := make(chan rebuildOutcome, 1)
+	rpcCh <- rebuildOutcome{entities: 111, rels: 222, elapsed: 3}
+	evCh := make(chan progress.Event, 4)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if o.entities != 111 || o.rels != 222 {
+		t.Fatalf("monolith stats = (%d,%d); want (111,222) from the RPC reply", o.entities, o.rels)
+	}
+}

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -6,6 +6,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -14,6 +15,70 @@ import (
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
+
+// fakeSplitClock advances virtual time on Sleep so the poll loop's timeout
+// accounting works without any real delay.
+type fakeSplitClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func (c *fakeSplitClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *fakeSplitClock) Sleep(d time.Duration) {
+	c.mu.Lock()
+	c.now = c.now.Add(d)
+	c.mu.Unlock()
+}
+
+// fakeProbe returns a scripted Poll sequence (by 1-based call count) and a fixed
+// Classify result.
+type fakeProbe struct {
+	mu       sync.Mutex
+	calls    int
+	pollFn   func(call int) splitPoll
+	classify splitResult
+}
+
+func (p *fakeProbe) Poll() (splitPoll, error) {
+	p.mu.Lock()
+	p.calls++
+	n := p.calls
+	fn := p.pollFn
+	p.mu.Unlock()
+	return fn(n), nil
+}
+
+func (p *fakeProbe) Classify() (splitResult, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.classify, nil
+}
+
+func (p *fakeProbe) count() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.calls
+}
+
+func testPollCfg() splitPollConfig {
+	return splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 5 * time.Minute}
+}
+
+func mkSSE(t *testing.T, e progress.Event) sseEvent {
+	t.Helper()
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatalf("marshal event: %v", err)
+	}
+	return sseEvent{name: "progress", data: string(b)}
+}
+
+func noTrigger() error { return nil }
 
 // fakeStatusStore is a mutable in-memory status plane for probe tests.
 type fakeStatusStore struct {
@@ -44,72 +109,30 @@ func (s *fakeStatusStore) set(rp string, f *statusfile.File) {
 
 func aliveLiveness(string) (*statusfile.File, bool) { return &statusfile.File{}, true }
 
-// fakeSplitClock advances virtual time on Sleep so the poll loop's timeout
-// accounting works without any real delay.
-type fakeSplitClock struct {
-	mu  sync.Mutex
-	now time.Time
-}
-
-func (c *fakeSplitClock) Now() time.Time {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return c.now
-}
-
-func (c *fakeSplitClock) Sleep(d time.Duration) {
-	c.mu.Lock()
-	c.now = c.now.Add(d)
-	c.mu.Unlock()
-}
-
-// fakeProbe returns a scripted sequence of snapshots. snapFn is called on every
-// Snapshot() with the (1-based) call count and returns the reading.
-type fakeProbe struct {
-	mu    sync.Mutex
-	calls int
-	fn    func(call int) splitSnapshot
-}
-
-func (p *fakeProbe) Snapshot() (splitSnapshot, error) {
-	p.mu.Lock()
-	p.calls++
-	n := p.calls
-	fn := p.fn
-	p.mu.Unlock()
-	return fn(n), nil
-}
-
-func (p *fakeProbe) count() int {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.calls
-}
-
-func testPollCfg() splitPollConfig {
-	return splitPollConfig{interval: 10 * time.Millisecond, timeout: 5 * time.Minute}
-}
-
-func mkSSE(t *testing.T, e progress.Event) sseEvent {
-	t.Helper()
-	b, err := json.Marshal(e)
-	if err != nil {
-		t.Fatalf("marshal event: %v", err)
+// pendingUntil returns a pendingReader that reports "pending" for the first
+// (n-1) calls, then "gone" (acked) from the n-th call onward.
+func pendingUntil(n int) pendingReader {
+	var mu sync.Mutex
+	calls := 0
+	return func() (bool, error) {
+		mu.Lock()
+		calls++
+		c := calls
+		mu.Unlock()
+		return c < n, nil
 	}
-	return sseEvent{name: "progress", data: string(b)}
 }
 
-// 1. SPLIT: completion fires only AFTER the status transition, never at the
-// instant Rebuild returns.
-func TestSplit_CompletionWaitsForStatusTransition(t *testing.T) {
+// 1. SPLIT: completion fires only AFTER the engine acks our rebuild request,
+// never at the instant Rebuild returns.
+func TestSplit_CompletionWaitsForRequestAck(t *testing.T) {
 	const wantEntities, wantRels = int64(4321), int64(8765)
-	// Not indexed (but engine alive) for the first 3 polls; indexed on the 4th.
-	probe := &fakeProbe{fn: func(call int) splitSnapshot {
-		if call < 4 {
-			return splitSnapshot{Indexed: false, EngineAlive: true}
-		}
-		return splitSnapshot{Indexed: true, EngineAlive: true, Entities: wantEntities, Rels: wantRels}
-	}}
+	probe := &fakeProbe{
+		pollFn: func(call int) splitPoll {
+			return splitPoll{RequestPending: call < 4, EngineAlive: true}
+		},
+		classify: splitResult{Entities: wantEntities, Rels: wantRels},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -117,7 +140,7 @@ func TestSplit_CompletionWaitsForStatusTransition(t *testing.T) {
 	evCh := make(chan progress.Event, 8)
 	rebuildCalled := false
 
-	o := runSplitIndexCore(ctx, cancel, func() { rebuildCalled = true }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, func() error { rebuildCalled = true; return nil }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
 
 	if !rebuildCalled {
 		t.Fatal("triggerRebuild was never called")
@@ -126,7 +149,7 @@ func TestSplit_CompletionWaitsForStatusTransition(t *testing.T) {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
 	if probe.count() < 4 {
-		t.Fatalf("completed after %d polls; want >=4 (must wait for the status transition, not the enqueue return)", probe.count())
+		t.Fatalf("completed after %d polls; want >=4 (must wait for the request ack, not the enqueue return)", probe.count())
 	}
 	if o.entities != wantEntities || o.rels != wantRels {
 		t.Fatalf("stats = (%d,%d); want (%d,%d)", o.entities, o.rels, wantEntities, wantRels)
@@ -148,24 +171,21 @@ func TestSplit_ForwardsPerModuleEventsDuringWindow(t *testing.T) {
 	}
 	evCh := make(chan progress.Event, n)
 
-	// Complete only once all n events have been forwarded into evCh's buffer.
-	probe := &fakeProbe{fn: func(int) splitSnapshot {
-		if len(evCh) >= n {
-			return splitSnapshot{Indexed: true, EngineAlive: true, Entities: 1, Rels: 1}
-		}
-		return splitSnapshot{Indexed: false, EngineAlive: true}
-	}}
+	// Ack (complete) only once all n events have been forwarded into evCh.
+	probe := &fakeProbe{
+		pollFn:   func(int) splitPoll { return splitPoll{RequestPending: len(evCh) < n, EngineAlive: true} },
+		classify: splitResult{Entities: 1, Rels: 1},
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, func() {}, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
 	if got := len(evCh); got != n {
 		t.Fatalf("forwarded %d events; want %d (per-module bars must render throughout the window)", got, n)
 	}
-	// Sanity: the forwarded events parse back to the per-module payloads.
 	first := <-evCh
 	if first.RepoSlug != "backend" || first.Phase != "scanning" {
 		t.Fatalf("first forwarded event = %+v; want backend/scanning", first)
@@ -173,18 +193,16 @@ func TestSplit_ForwardsPerModuleEventsDuringWindow(t *testing.T) {
 }
 
 // 3. SPLIT: the final outcome carries the real stats sourced from the status
-// signal (entities=E, rels=R), not empty.
-func TestSplit_OutcomeCarriesStatusStats(t *testing.T) {
+// classification (entities=E, rels=R).
+func TestSplit_OutcomeCarriesClassifiedStats(t *testing.T) {
 	const E, R = int64(12345), int64(67890)
-	probe := &fakeProbe{fn: func(call int) splitSnapshot {
-		if call < 2 {
-			return splitSnapshot{Indexed: false, EngineAlive: true}
-		}
-		return splitSnapshot{Indexed: true, EngineAlive: true, Entities: E, Rels: R, ElapsedSec: 7}
-	}}
+	probe := &fakeProbe{
+		pollFn:   func(call int) splitPoll { return splitPoll{RequestPending: call < 2, EngineAlive: true} },
+		classify: splitResult{Entities: E, Rels: R},
+	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -198,18 +216,17 @@ func TestSplit_OutcomeCarriesStatusStats(t *testing.T) {
 }
 
 // 4. SPLIT + engine dies: the engine-liveness heartbeat goes stale after having
-// been alive and the group never completes → the outcome is a real ERROR, never
-// a fake Done.
+// been alive and our request never acks → real ERROR, never a fake Done.
 func TestSplit_EngineDiesSurfacesError(t *testing.T) {
-	probe := &fakeProbe{fn: func(call int) splitSnapshot {
+	probe := &fakeProbe{pollFn: func(call int) splitPoll {
 		if call <= 2 {
-			return splitSnapshot{Indexed: false, EngineAlive: true} // alive, working
+			return splitPoll{RequestPending: true, EngineAlive: true}
 		}
-		return splitSnapshot{Indexed: false, EngineAlive: false} // engine died
+		return splitPoll{RequestPending: true, EngineAlive: false}
 	}}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
 	if o.err == nil {
 		t.Fatal("engine died but outcome carried no error (fake Done)")
 	}
@@ -218,69 +235,139 @@ func TestSplit_EngineDiesSurfacesError(t *testing.T) {
 	}
 }
 
-// 4b. SPLIT + never completes while alive: bounded timeout → real error.
+// 4b. SPLIT + never acks while alive: bounded last-resort timeout → real error.
 func TestSplit_TimeoutSurfacesError(t *testing.T) {
-	probe := &fakeProbe{fn: func(int) splitSnapshot {
-		return splitSnapshot{Indexed: false, EngineAlive: true} // alive forever, never done
+	probe := &fakeProbe{pollFn: func(int) splitPoll {
+		return splitPoll{RequestPending: true, EngineAlive: true} // alive forever, never acks
 	}}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	cfg := splitPollConfig{interval: time.Second, timeout: 3 * time.Second}
-	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	cfg := splitPollConfig{interval: time.Second, startupWindow: 0, timeout: 3 * time.Second}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
 	if o.err == nil {
-		t.Fatal("index never completed but no timeout error surfaced")
+		t.Fatal("rebuild never acked but no timeout error surfaced")
 	}
 }
 
-// 6. PROBE: a fresh-group first index whose status file shows Indexing:false and
-// an ADVANCED graph_fb_mtime but Entities==0 (the wizard/rebuild path does not
-// write the graph-stats sidecar) MUST complete — never spin to the timeout.
-// This is the exact live-daemon regression the coordinator flagged.
-func TestStatusProbe_CompletesOnMtimeAdvanceEvenWithZeroEntities(t *testing.T) {
+// S1. SPLIT + engine NEVER live: fail fast within the startup window, NOT after
+// the full 45m timeout.
+func TestSplit_NeverAliveEngineFailsFast(t *testing.T) {
+	probe := &fakeProbe{pollFn: func(int) splitPoll {
+		return splitPoll{RequestPending: true, EngineAlive: false} // never live
+	}}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: 100 * time.Millisecond, startupWindow: time.Second, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	if o.err == nil {
+		t.Fatal("engine never came alive but no error surfaced")
+	}
+	if !strings.Contains(o.err.Error(), "never became live") {
+		t.Fatalf("err = %v; want a fast never-live failure (not a 45m timeout)", o.err)
+	}
+	// Fast: it must have failed near the 1s startup window (~10 polls), not spin
+	// to the 45m timeout.
+	if probe.count() > 100 {
+		t.Fatalf("polled %d times before fast-failing; want ~10 (startup window, not the full timeout)", probe.count())
+	}
+}
+
+// B3. SPLIT multi-repo PARTIAL FAILURE: the engine acks the rebuild but repo B
+// never produced a graph. This is the exact case that hangs today. It must
+// reach a PROMPT terminal error naming B — not spin to the timeout. Uses the
+// REAL statusPlaneProbe (request-ack + mtime classification) with fake readers.
+func TestSplit_MultiRepoPartialFailure_PromptError(t *testing.T) {
+	const repoA, repoB = "/repo/backend", "/repo/frontend"
+	store := newFakeStatusStore() // both absent at construction → baseline 0
+
+	// Engine acks after 2 polls (drained our rebuild request).
+	probe := newStatusPlaneProbeWith([]string{repoA, repoB}, "/root", store.read, aliveLiveness, pendingUntil(3))
+
+	// The engine finished: A produced a graph (mtime advanced), B did NOT
+	// (no status file / no graph). Set A's completed state AFTER construction so
+	// its mtime is past the captured baseline.
+	store.set(repoA, &statusfile.File{Indexing: false, GraphFBMtime: 500, Entities: 1000, Relationships: 2000})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// Short interval + comfortably large timeout: a PROMPT terminal state must
+	// arrive from the ack, long before the timeout.
+	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+
+	if o.err == nil {
+		t.Fatal("partial failure (repo B never indexed) produced no error — this is the hang/fake-done regression")
+	}
+	if !strings.Contains(o.err.Error(), "frontend") {
+		t.Fatalf("err = %v; want it to name the repo that failed (frontend)", o.err)
+	}
+}
+
+// B3b. EMPTY REPO: a single repo that legitimately produces no graph → prompt
+// terminal state, not a hang.
+func TestSplit_EmptyRepo_PromptTerminal(t *testing.T) {
+	const repo = "/repo/docs-only"
+	store := newFakeStatusStore() // never produces a graph
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntil(2))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	if o.err == nil {
+		t.Fatal("empty repo produced no terminal error (would hang in production)")
+	}
+	if !strings.Contains(o.err.Error(), "docs-only") {
+		t.Fatalf("err = %v; want it to name the empty repo", o.err)
+	}
+}
+
+// PROBE: a fresh-group first index whose status file shows Indexing:false and an
+// ADVANCED graph_fb_mtime but Entities==0 (the wizard/rebuild path does not
+// write the graph-stats sidecar) MUST classify as indexed-OK (no Failed) — never
+// spin. This is the exact live-daemon regression the coordinator flagged.
+func TestStatusProbe_ClassifiesOKOnMtimeAdvanceEvenWithZeroEntities(t *testing.T) {
 	const repo = "/repo/monorepo"
 	store := newFakeStatusStore() // fresh group: no status file yet → baseline 0
-	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness)
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntil(1))
 
-	// Before the index finishes: not indexed yet.
-	if snap, _ := probe.Snapshot(); snap.Indexed {
-		t.Fatal("probe reported Indexed before any graph.fb was written")
-	}
 	// Index completes: graph.fb (re)written (mtime advances), but Entities stay
 	// 0 because the sidecar was never written on this path.
 	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1_000_000, Entities: 0, Relationships: 0})
 
-	snap, _ := probe.Snapshot()
-	if !snap.Indexed {
-		t.Fatal("probe did NOT complete on graph_fb_mtime advance with Entities==0 (would spin to timeout — worse than the original bug)")
+	res, _ := probe.Classify()
+	if len(res.Failed) != 0 {
+		t.Fatalf("Classify marked %v as failed on a graph_fb_mtime advance with Entities==0 (would surface a false failure)", res.Failed)
 	}
-	if snap.Entities != 0 {
-		t.Fatalf("Entities = %d; want 0 passed through untouched", snap.Entities)
+	if res.Entities != 0 {
+		t.Fatalf("Entities = %d; want 0 passed through untouched", res.Entities)
 	}
 }
 
-// 6b. PROBE: a repo whose status file ALREADY exists with an OLD graph_fb_mtime
-// and Indexing:false at poll-start must NOT be treated as immediately complete —
-// it must wait for the mtime to advance past the captured baseline (re-index
-// correctness).
-func TestStatusProbe_WaitsForMtimeToAdvancePastBaseline(t *testing.T) {
+// PROBE: a repo whose status file ALREADY exists with an OLD graph_fb_mtime and
+// Indexing:false must NOT be classified as freshly indexed until graph_fb_mtime
+// advances past the captured baseline (re-index correctness).
+func TestStatusProbe_ClassifyWaitsForMtimeAdvancePastBaseline(t *testing.T) {
 	const repo = "/repo/already-indexed"
 	store := newFakeStatusStore()
 	// Pre-existing graph from a prior index: mtime=1000, not indexing, has stats.
 	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1000, Entities: 500, Relationships: 900})
 
-	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness) // baseline=1000
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntil(1)) // baseline=1000
 
-	if snap, _ := probe.Snapshot(); snap.Indexed {
-		t.Fatal("probe treated a pre-existing OLD graph as immediately complete (no baseline advance)")
+	// Before the re-index rewrites graph.fb, the stale graph must be treated as
+	// NOT freshly indexed.
+	if res, _ := probe.Classify(); len(res.Failed) == 0 {
+		t.Fatal("classified a pre-existing OLD graph as freshly indexed (no baseline advance)")
 	}
 	// Re-index finishes: graph.fb rewritten, mtime advances past baseline.
 	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 2000, Entities: 550, Relationships: 950})
-	snap, _ := probe.Snapshot()
-	if !snap.Indexed {
-		t.Fatal("probe did not complete after graph_fb_mtime advanced past baseline")
+	res, _ := probe.Classify()
+	if len(res.Failed) != 0 {
+		t.Fatalf("still failed after graph_fb_mtime advanced past baseline: %v", res.Failed)
 	}
-	if snap.Entities != 550 || snap.Rels != 950 {
-		t.Fatalf("stats = (%d,%d); want (550,950)", snap.Entities, snap.Rels)
+	if res.Entities != 550 || res.Rels != 950 {
+		t.Fatalf("stats = (%d,%d); want (550,950)", res.Entities, res.Rels)
 	}
 }
 

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -12,7 +12,37 @@ import (
 
 	"github.com/cajasmota/grafel/internal/cli/wiztui"
 	"github.com/cajasmota/grafel/internal/progress"
+	"github.com/cajasmota/grafel/internal/statusfile"
 )
+
+// fakeStatusStore is a mutable in-memory status plane for probe tests.
+type fakeStatusStore struct {
+	mu    sync.Mutex
+	files map[string]*statusfile.File
+}
+
+func newFakeStatusStore() *fakeStatusStore {
+	return &fakeStatusStore{files: map[string]*statusfile.File{}}
+}
+
+func (s *fakeStatusStore) read(rp string) (*statusfile.File, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	f, ok := s.files[rp]
+	if !ok || f == nil {
+		return nil, false
+	}
+	cp := *f
+	return &cp, true
+}
+
+func (s *fakeStatusStore) set(rp string, f *statusfile.File) {
+	s.mu.Lock()
+	s.files[rp] = f
+	s.mu.Unlock()
+}
+
+func aliveLiveness(string) (*statusfile.File, bool) { return &statusfile.File{}, true }
 
 // fakeSplitClock advances virtual time on Sleep so the poll loop's timeout
 // accounting works without any real delay.
@@ -199,6 +229,58 @@ func TestSplit_TimeoutSurfacesError(t *testing.T) {
 	o := runSplitIndexCore(ctx, cancel, func() {}, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
 	if o.err == nil {
 		t.Fatal("index never completed but no timeout error surfaced")
+	}
+}
+
+// 6. PROBE: a fresh-group first index whose status file shows Indexing:false and
+// an ADVANCED graph_fb_mtime but Entities==0 (the wizard/rebuild path does not
+// write the graph-stats sidecar) MUST complete — never spin to the timeout.
+// This is the exact live-daemon regression the coordinator flagged.
+func TestStatusProbe_CompletesOnMtimeAdvanceEvenWithZeroEntities(t *testing.T) {
+	const repo = "/repo/monorepo"
+	store := newFakeStatusStore() // fresh group: no status file yet → baseline 0
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness)
+
+	// Before the index finishes: not indexed yet.
+	if snap, _ := probe.Snapshot(); snap.Indexed {
+		t.Fatal("probe reported Indexed before any graph.fb was written")
+	}
+	// Index completes: graph.fb (re)written (mtime advances), but Entities stay
+	// 0 because the sidecar was never written on this path.
+	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1_000_000, Entities: 0, Relationships: 0})
+
+	snap, _ := probe.Snapshot()
+	if !snap.Indexed {
+		t.Fatal("probe did NOT complete on graph_fb_mtime advance with Entities==0 (would spin to timeout — worse than the original bug)")
+	}
+	if snap.Entities != 0 {
+		t.Fatalf("Entities = %d; want 0 passed through untouched", snap.Entities)
+	}
+}
+
+// 6b. PROBE: a repo whose status file ALREADY exists with an OLD graph_fb_mtime
+// and Indexing:false at poll-start must NOT be treated as immediately complete —
+// it must wait for the mtime to advance past the captured baseline (re-index
+// correctness).
+func TestStatusProbe_WaitsForMtimeToAdvancePastBaseline(t *testing.T) {
+	const repo = "/repo/already-indexed"
+	store := newFakeStatusStore()
+	// Pre-existing graph from a prior index: mtime=1000, not indexing, has stats.
+	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1000, Entities: 500, Relationships: 900})
+
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness) // baseline=1000
+
+	if snap, _ := probe.Snapshot(); snap.Indexed {
+		t.Fatal("probe treated a pre-existing OLD graph as immediately complete (no baseline advance)")
+	}
+	// Re-index finishes: graph.fb rewritten, mtime advances past baseline.
+	store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 2000, Entities: 550, Relationships: 950})
+	snap, _ := probe.Snapshot()
+	if !snap.Indexed {
+		t.Fatal("probe did not complete after graph_fb_mtime advanced past baseline")
+	}
+	if snap.Entities != 550 || snap.Rels != 950 {
+		t.Fatalf("stats = (%d,%d); want (550,950)", snap.Entities, snap.Rels)
 	}
 }
 

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -23,6 +23,7 @@ import (
 	"golang.org/x/term"
 
 	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/install"
@@ -351,6 +352,17 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+			// SPLIT mode: the Rebuild RPC returns at ENQUEUE time (fire-and-
+			// forget), so it CANNOT signal real completion. Keep forwarding SSE
+			// per-module events while polling the status plane for a level-
+			// triggered done signal, with engine-liveness + a timeout backstop.
+			if daemon.SplitModeEnabled() {
+				o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh)
+				outCh <- toIndexOutcome(o, summary)
+				return
+			}
+			// MONOLITH mode: the Rebuild RPC is synchronous, so its return IS
+			// completion and its reply carries the stats. Unchanged.
 			rpcCh := triggerRebuild(c, group, token)
 			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
 			cancel()

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -343,26 +343,37 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 
 	token := progressToken()
 
-	// Establish the broker SSE subscription BEFORE triggering the Rebuild so no
-	// early per-repo extraction events are lost when the index runs fast (#5340).
-	// subscribeSSE connects synchronously (it returns only once the HTTP stream
-	// is open), so by the time we fire the Rebuild RPC the broker is listening
-	// and per-repo events (backend/frontend) are guaranteed to be delivered.
+	// SPLIT mode: the Rebuild RPC returns at ENQUEUE time (fire-and-forget), so
+	// it can NEVER signal real completion. Completion is keyed on the rebuild-
+	// request ack (runSplitIndex), REGARDLESS of whether a dashboard is up — a
+	// missing dashboard only means no live SSE bars, never a fake instant Done
+	// (#5729 blocker #10). We still establish the broker SSE subscription first
+	// (when a dashboard exists) so no early per-repo events are lost (#5340);
+	// with no dashboard sseCh stays nil and runSplitIndex simply forwards nothing.
+	if daemon.SplitModeEnabled() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		var sseCh <-chan sseEvent
+		if dashPort > 0 {
+			if ch, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+				sseCh = ch
+			}
+		}
+		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh)
+		outCh <- toIndexOutcome(o, summary)
+		return
+	}
+
+	// MONOLITH mode (unchanged): the Rebuild RPC is synchronous, so its return
+	// IS completion and its reply carries the stats. When a dashboard is up we
+	// forward broker SSE events until the RPC returns; otherwise we just wait on
+	// the RPC. subscribeSSE connects synchronously (it returns only once the HTTP
+	// stream is open), so by the time we fire the Rebuild RPC the broker is
+	// listening and per-repo events are guaranteed to be delivered.
 	if dashPort > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
-			// SPLIT mode: the Rebuild RPC returns at ENQUEUE time (fire-and-
-			// forget), so it CANNOT signal real completion. Keep forwarding SSE
-			// per-module events while polling the status plane for a level-
-			// triggered done signal, with engine-liveness + a timeout backstop.
-			if daemon.SplitModeEnabled() {
-				o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh)
-				outCh <- toIndexOutcome(o, summary)
-				return
-			}
-			// MONOLITH mode: the Rebuild RPC is synchronous, so its return IS
-			// completion and its reply carries the stats. Unchanged.
 			rpcCh := triggerRebuild(c, group, token)
 			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
 			cancel()

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -83,6 +83,34 @@ func WarmingFromStatusFile() WarmingSnapshot {
 	}
 }
 
+// FlushRepoStatusFile synchronously recomputes and writes repoPath's per-repo
+// status-plane sidecar from the CURRENT indexstate + the on-disk graph.fb, right
+// now — the same work the async statusWriter goroutine would do on its next
+// coalesced pass or 5s heartbeat, but ON DEMAND and inline.
+//
+// The engine's DIRECT group-rebuild path (cmd/grafel daemonRebuildFuncCore)
+// bypasses the scheduler, so it never triggers the statusWriter's
+// SetRepoStates→notify refresh; a rebuilt repo's status file can therefore carry
+// a STALE GraphFBMtime (== the pre-rebuild baseline) for up to a heartbeat
+// interval after the rebuild returns. In split mode the drain writes the
+// request ack the instant rebuildFn returns, so a wizard keying completion on
+// that ack (internal/cli RebuildRequestPending) would classify a repo that
+// actually succeeded as "produced no graph". daemonRebuildFuncCore calls this
+// for every rebuilt repo AFTER its graph.fb is written and BEFORE returning, so
+// !RequestPending implies the per-repo status is already fresh and the wizard's
+// first classify poll is correct (#5729 blocker #5).
+//
+// Sourced fields of note: GraphFBMtime is stat'd from the real graph.fb via
+// FindGraphFile (so this MUST be called after the graph.fb write to capture the
+// fresh mtime); Indexing comes from indexstate (false on the direct path, which
+// never registers the repo as indexing). Entities may still be 0 — the
+// graph-stats sidecar is a separate follow-up — and that is fine, the wizard's
+// classification uses graph_fb_mtime, not entities. Best-effort: a write failure
+// is swallowed (nil logger) and never fails the rebuild.
+func FlushRepoStatusFile(repoPath string) {
+	writeRepoStatusFile(repoPath, nil)
+}
+
 // WriteRepoStatusFileForTest synchronously computes and writes repoPath's
 // status-plane sidecar from the CURRENT indexstate — exactly what the
 // production statusWriter goroutine would do on its next coalesced pass, but

--- a/internal/daemon/rebuild_request_status.go
+++ b/internal/daemon/rebuild_request_status.go
@@ -1,0 +1,60 @@
+package daemon
+
+import (
+	"encoding/json"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+)
+
+// rebuild_request_status.go — exported read helper over the serve→engine
+// KindRebuild request queue (ADR-0024 PR6 / epic #5729). It lets an
+// out-of-process client (the wizard, internal/cli) detect when a split-mode
+// group rebuild it enqueued has been drained+acked by the engine — the
+// AUTHORITATIVE, race-free completion signal for a fire-and-forget Rebuild RPC.
+//
+// Why this and not "all repos' graph.fb advanced": a group rebuild can finish
+// with one repo failing / empty / skipped, whose graph.fb never advances. A
+// per-repo "all advanced" predicate would then never fire and the caller would
+// hang until its overall timeout. The request-ack signal fires the moment the
+// engine finishes OUR rebuild (success OR partial), so the caller stops
+// promptly and classifies the per-repo result from the status plane instead.
+
+// RebuildRequestPending reports whether a KindRebuild request carrying
+// progressToken is still queued for group (i.e. not yet drained+acked by the
+// engine). The token scopes the check to OUR specific rebuild — the same token
+// the caller passed as proto.RebuildArgs.ProgressToken — so a concurrent
+// rebuild of the same group (a different token) is never mistaken for ours.
+//
+// Semantics:
+//   - true  → our rebuild request is still on disk and unacked: the engine has
+//     not finished it yet.
+//   - false → no matching pending request: the engine has drained+acked it
+//     (ListPending excludes acked requests), so our group rebuild is DONE
+//     (whether every repo succeeded is a separate status-plane classification).
+//
+// A missing requests dir is not an error (ListPending returns nothing). Callers
+// MUST only rely on a false result AFTER the enqueue RPC has returned (the
+// request is on disk before the RPC replies), otherwise a poll that races ahead
+// of the write would see false spuriously.
+func RebuildRequestPending(group, progressToken string) (bool, error) {
+	recs, err := requests.ListPending(requestsDirForGroup(group))
+	if err != nil {
+		return false, err
+	}
+	for _, rec := range recs {
+		if rec.Kind != requests.KindRebuild {
+			continue
+		}
+		var args proto.RebuildArgs
+		if err := json.Unmarshal(rec.Payload, &args); err != nil {
+			// A torn/foreign payload we can't decode is not ours — skip it
+			// rather than failing the whole check.
+			continue
+		}
+		if args.ProgressToken == progressToken {
+			return true, nil
+		}
+	}
+	return false, nil
+}

--- a/internal/daemon/rebuild_request_status_test.go
+++ b/internal/daemon/rebuild_request_status_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/requests"
+)
+
+func writeRebuildRequest(t *testing.T, group, token string) string {
+	t.Helper()
+	payload, err := json.Marshal(proto.RebuildArgs{Group: group, ProgressToken: token})
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	id, err := requests.Write(requestsDirForGroup(group), requests.Record{
+		Kind:    requests.KindRebuild,
+		Payload: payload,
+	})
+	if err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+	return id
+}
+
+// TestRebuildRequestPending_TrueWhileQueued: our token's KindRebuild request is
+// pending until it is acked (drained by the engine).
+func TestRebuildRequestPending_TrueWhileQueued(t *testing.T) {
+	t.Setenv(EnvRoot, t.TempDir())
+	const group, token = "g", "tok-123"
+
+	if pending, err := RebuildRequestPending(group, token); err != nil || pending {
+		t.Fatalf("pending before write = (%v,%v); want (false,nil)", pending, err)
+	}
+
+	id := writeRebuildRequest(t, group, token)
+	if pending, err := RebuildRequestPending(group, token); err != nil || !pending {
+		t.Fatalf("pending after write = (%v,%v); want (true,nil)", pending, err)
+	}
+
+	// Ack it (as the engine does after draining) → no longer pending.
+	dir := requestsDirForGroup(group)
+	if err := requests.WriteAck(dir, id, requests.Ack{ID: id, Status: requests.StatusOK}); err != nil {
+		t.Fatalf("ack: %v", err)
+	}
+	if pending, err := RebuildRequestPending(group, token); err != nil || pending {
+		t.Fatalf("pending after ack = (%v,%v); want (false,nil)", pending, err)
+	}
+}
+
+// TestRebuildRequestPending_ScopedToOurToken: a concurrent rebuild of the SAME
+// group under a DIFFERENT token must not be mistaken for ours.
+func TestRebuildRequestPending_ScopedToOurToken(t *testing.T) {
+	t.Setenv(EnvRoot, t.TempDir())
+	const group = "g"
+	writeRebuildRequest(t, group, "other-token")
+
+	if pending, err := RebuildRequestPending(group, "ours"); err != nil || pending {
+		t.Fatalf("pending for our token = (%v,%v); want (false,nil) — a different token's request is not ours", pending, err)
+	}
+	if pending, err := RebuildRequestPending(group, "other-token"); err != nil || !pending {
+		t.Fatalf("pending for other token = (%v,%v); want (true,nil)", pending, err)
+	}
+}


### PR DESCRIPTION
## Problem
In split mode `Service.Rebuild` is fire-and-forget (returns at enqueue). The wizard keyed completion on that RPC return, so a large-monorepo first index showed a single bar snapping 0→100% "Done" in <1s while the engine actually indexed for minutes — no per-module bars, fake completion.

## Fix (split mode only; monolith byte-identical)
- **Completion = the engine acked OUR group rebuild**, detected via the request-ack queue: new `daemon.RebuildRequestPending(group, progressToken)` lists the group's request dir and reports whether our KindRebuild (matched by `ProgressToken`) is still pending. `ListPending` excludes acked requests, and the ack is written only AFTER `rebuildFn` fully completes — so `!pending` means the group rebuild finished. Race-free: the enqueue RPC returns only after the request is on disk, and the token scopes it to our rebuild.
- **Live per-module bars**: SSE progress events are forwarded concurrently with the poll (when a dashboard is up).
- **Classification, not gating**: once acked, each repo is classified via `graph_fb_mtime > baseline && !Indexing`. A repo that didn't index → prompt error naming it (+ statusfile LastErr), never a 45-min hang. Entities never gate (the wizard/rebuild path leaves entities:0 — separate follow-up).
- **#5 status-write-vs-ack race fixed engine-side**: `daemonRebuildFuncCore` now calls `daemon.FlushRepoStatusFile` for each rebuilt repo AFTER its graph.fb write and BEFORE returning (before the drain's ack), so `!pending` implies fresh per-repo status and the first classify poll is correct — critical for single-repo groups (a monorepo) where no sibling keeps the 5s heartbeat warm.
- **No-dashboard split path**: split mode now uses ack-keyed completion even when `dashPort==0` (previously fell through to the fake-instant path).
- Never-alive engine fast-fails in 30s; 45m last-resort timeout retained.

## Tests
Red→green for: fake-instant completion, partial-repo-failure (prompt error not 45m hang), empty repo, never-alive fast-fail, stale-status-at-ack false-failure (#5), no-dashboard waits for ack (#10), mtime-classification, and monolith byte-identical. Full `internal/cli` + `internal/daemon` + `cmd/grafel` rebuild tests pass `-race`.

Three rounds of independent adversarial review (each caught a real defect: entities:0 hang, partial-failure hang, status-write-vs-ack race).

Refs #5729 (split-mode progress UX). Part of v0.1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)