### PR TITLE
feat(cli): grafel statusline — explainer for surfacing index status in a statusline (no auto-install)

### DIFF
--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -78,6 +78,7 @@ func newRoot() *cobra.Command {
 		newBenchCaptureCmd(),
 		newPersonasCmd(),
 		newFeedbackCmd(),
+		newStatuslineCmd(),
 		newHelpCmd(),
 	)
 
@@ -221,4 +222,9 @@ Personas (cross-platform wrappers):
   personas render --target <target> [--output <dir>] [--personas-dir <dir>]
                                   Render platform-specific wrappers from canonical persona files
                                   Targets: claude-code, windsurf, cursor, codex
+
+Statusline:
+  statusline                     Explain how to surface live index status in a shell/editor
+                                  statusline; prints example segments + wiring guide (installs nothing)
+  statusline --snippet           Print only the icon-based bash segment (copy/pipe-ready)
 `

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -1,0 +1,243 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newStatuslineCmd returns the cobra command for `grafel statusline`.
+//
+// This command INSTALLS NOTHING and edits no files — it only prints an
+// explainer + copy-paste bash snippets to stdout so a user can wire
+// grafel's live status-plane (internal/statusfile) into their own shell
+// prompt or editor statusline by hand. See internal/statusfine.go doc
+// comment for the on-disk schema this command documents.
+func newStatuslineCmd() *cobra.Command {
+	var snippetOnly bool
+	cmd := &cobra.Command{
+		Use:   "statusline [--snippet]",
+		Short: "Explain how to surface grafel's live status in a shell/editor statusline (prints only; installs nothing)",
+		Long: `Print a guide to grafel's live per-repo status-plane file and ready-to-copy
+example statusline segments.
+
+This command does not install or edit anything — it only prints. Copy
+whichever example segment fits your setup into your own statusline script
+or config.
+
+--snippet prints ONLY the icon-based bash segment (state precedence: engine
+down > error > indexing > idle > not indexed), suitable for piping straight
+into a file.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if snippetOnly {
+				_, err := cmd.OutOrStdout().Write([]byte(statuslineIconSnippet()))
+				return err
+			}
+			_, err := cmd.OutOrStdout().Write([]byte(statuslineGuideText()))
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&snippetOnly, "snippet", false,
+		"print only the icon-based bash segment (no prose)")
+	return cmd
+}
+
+// statuslineMinimalSnippet is example 3a: the smallest possible segment —
+// just "grafel <freshness>". Self-contained: resolves the repo root, hashes
+// it, reads the status file, and prints nothing if the repo isn't indexed.
+const statuslineMinimalSnippet = `# grafel statusline segment — minimal ("grafel 3m ago")
+g_root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$g_root" ] && g_root=$(pwd)
+g_hash=$(printf '%s' "$g_root" | shasum -a 256 | cut -c1-16)
+g_sfile="${GRAFEL_HOME:-$HOME/.grafel}/status/$g_hash.json"
+[ -f "$g_sfile" ] || exit 0
+g_json=$(cat "$g_sfile")
+g_mtime_ns=$(printf '%s' "$g_json" | jq -r '.graph_fb_mtime // 0')
+if [ "$g_mtime_ns" = "0" ]; then
+  echo "grafel not indexed"
+  exit 0
+fi
+g_mtime=$((g_mtime_ns / 1000000000))
+g_now=$(date +%s)
+g_age=$((g_now - g_mtime))
+if [ "$g_age" -lt 60 ]; then
+  echo "grafel just now"
+elif [ "$g_age" -lt 3600 ]; then
+  echo "grafel $((g_age / 60))m ago"
+elif [ "$g_age" -lt 86400 ]; then
+  echo "grafel $((g_age / 3600))h ago"
+else
+  echo "grafel $((g_age / 86400))d ago"
+fi
+`
+
+// statuslineIconSnippet is example 3b: the canonical icon-state segment.
+// State precedence: engine down (heartbeat >90s stale) > last_err set >
+// indexing > idle (graph_fb_mtime>0, "X ago") > not indexed (graph_fb_mtime
+// == 0). Prints nothing if this isn't a grafel-indexed repo (no status
+// file). Self-contained: no external color/helper dependency, works when
+// piped or run non-interactively.
+func statuslineIconSnippet() string {
+	return `#!/usr/bin/env bash
+# grafel statusline segment — icon states
+# Precedence: engine down > error > indexing > idle (age) > not indexed.
+# Prints nothing if this isn't a grafel-indexed repo.
+c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_green=$'\033[32m'; c_dim=$'\033[2m'; c_reset=$'\033[0m'
+
+g_root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$g_root" ] && g_root=$(pwd)
+g_hash=$(printf '%s' "$g_root" | shasum -a 256 | cut -c1-16)
+g_sfile="${GRAFEL_HOME:-$HOME/.grafel}/status/$g_hash.json"
+[ -f "$g_sfile" ] || exit 0
+
+g_json=$(cat "$g_sfile")
+indexing=$(printf '%s' "$g_json" | jq -r '.indexing // false')
+err=$(printf '%s' "$g_json" | jq -r '.last_err // empty')
+hb=$(printf '%s' "$g_json" | jq -r '.heartbeat_at // empty')
+mtime_ns=$(printf '%s' "$g_json" | jq -r '.graph_fb_mtime // 0')
+now=$(date +%s)
+
+down=0
+if [ -n "$hb" ]; then
+  # BSD/macOS date parsing. On GNU/Linux, replace this line with:
+  #   hbep=$(date -d "$hb" +%s 2>/dev/null)
+  hbep=$(date -j -u -f "%Y-%m-%dT%H:%M:%S" "${hb%%.*}" +%s 2>/dev/null)
+  [ -n "$hbep" ] && [ $((now - hbep)) -gt 90 ] && down=1
+fi
+
+if [ "$down" = "1" ]; then
+  echo "${c_red}⚠ down${c_reset}"
+elif [ -n "$err" ]; then
+  echo "${c_red}✗ error${c_reset}"
+elif [ "$indexing" = "true" ]; then
+  echo "${c_yellow}⟳ indexing${c_reset}"
+elif [ "$mtime_ns" != "0" ] && [ -n "$mtime_ns" ]; then
+  mtime=$((mtime_ns / 1000000000))
+  age=$((now - mtime))
+  if [ "$age" -lt 60 ]; then
+    ago="just now"
+  elif [ "$age" -lt 3600 ]; then
+    ago="$((age / 60))m ago"
+  elif [ "$age" -lt 86400 ]; then
+    ago="$((age / 3600))h ago"
+  else
+    ago="$((age / 86400))d ago"
+  fi
+  echo "${c_green}✓ ${ago}${c_reset}"
+else
+  echo "${c_dim}○ not indexed${c_reset}"
+fi
+`
+}
+
+// statuslineDetailedSnippet is example 3c: adds the indexed commit (and,
+// with a caveat, entity count) to the freshness line.
+const statuslineDetailedSnippet = `# grafel statusline segment — detailed ("grafel ✓ 3m ago @ a1b2c3d")
+g_root=$(git rev-parse --show-toplevel 2>/dev/null)
+[ -z "$g_root" ] && g_root=$(pwd)
+g_hash=$(printf '%s' "$g_root" | shasum -a 256 | cut -c1-16)
+g_sfile="${GRAFEL_HOME:-$HOME/.grafel}/status/$g_hash.json"
+[ -f "$g_sfile" ] || exit 0
+g_json=$(cat "$g_sfile")
+g_mtime_ns=$(printf '%s' "$g_json" | jq -r '.graph_fb_mtime // 0')
+g_commit=$(printf '%s' "$g_json" | jq -r '.indexed_commit // empty')
+g_entities=$(printf '%s' "$g_json" | jq -r '.entities // 0')
+if [ "$g_mtime_ns" = "0" ]; then
+  echo "grafel ○ not indexed"
+  exit 0
+fi
+g_mtime=$((g_mtime_ns / 1000000000))
+g_now=$(date +%s)
+g_age=$((g_now - g_mtime))
+if [ "$g_age" -lt 60 ]; then g_ago="just now"
+elif [ "$g_age" -lt 3600 ]; then g_ago="$((g_age / 60))m ago"
+elif [ "$g_age" -lt 86400 ]; then g_ago="$((g_age / 3600))h ago"
+else g_ago="$((g_age / 86400))d ago"
+fi
+g_short=${g_commit:0:7}
+# NOTE: entities can be 0 for repos indexed via the wizard/rebuild path (a
+# known separate limitation — the graph-stats sidecar isn't written there),
+# so don't rely on it as a freshness signal; graph_fb_mtime already is one.
+if [ -n "$g_short" ]; then
+  echo "grafel ✓ ${g_ago} @ ${g_short}"
+else
+  echo "grafel ✓ ${g_ago}"
+fi
+`
+
+// statuslineGuideText assembles the full printed guide.
+func statuslineGuideText() string {
+	return `grafel statusline — surface live index status in your shell/editor
+
+This command installs and edits NOTHING. It only prints. Copy whatever
+fits your setup into your own statusline script or config.
+
+1. What's available
+--------------------
+grafel's daemon writes a small per-repo JSON status file as it indexes, so
+a statusline can read live index state cheaply (no daemon RPC needed):
+
+  File:  ${GRAFEL_HOME:-$HOME/.grafel}/status/<sha256(abs_repo_root)[:16]>.json
+
+The filename is the first 16 hex characters of sha256(absolute repo root
+path) — a statusline resolves the repo root (git rev-parse --show-toplevel),
+hashes it the same way, and reads that file directly.
+
+Key fields:
+  engine_pid       int      pid of the daemon that wrote this file
+  heartbeat_at     RFC3339  rewritten every ~15-30s, even when idle —
+                            older than ~90s means the engine is DOWN
+  version          string   engine's self-reported version
+  repo_path        string   absolute path this file describes
+  indexed_ref      string   git ref the on-disk graph reflects
+  indexed_commit   string   commit SHA the on-disk graph reflects
+  entities         int64    NOTE: 0 for repos indexed via the wizard/rebuild
+                            path (a known limitation) — don't rely on this
+                            for freshness
+  relationships    int64    same caveat as entities
+  graph_fb_mtime   int64    nanoseconds since epoch the graph was last
+                            written — THE reliable freshness signal
+                            ("indexed X ago"); divide by 1e9 for unix secs
+  indexing         bool     true while an index is running right now
+  queue_len        int      jobs queued behind this repo (omitempty)
+  last_err         string   most recent index error, if any (omitempty)
+
+2. Two ways to read it
+-----------------------
+  a) Direct file read (recommended for statuslines): a few milliseconds,
+     no process spawn. Resolve the repo root, hash it, read the JSON with
+     jq. See the example segments below.
+  b) grafel status --json: poll-safe, cwd-scoped, doesn't dial the daemon,
+     but spawns the grafel binary (~200ms) — fine for scripts, on the slow
+     side for a per-render statusline.
+
+3. Example segments (copy any)
+-------------------------------
+
+--- 3a. Minimal ("grafel 3m ago") ---
+` + statuslineMinimalSnippet + `
+--- 3b. Icon states (recommended) ---
+` + statuslineIconSnippet() + `
+--- 3c. Detailed (with commit) ---
+` + statuslineDetailedSnippet + `
+4. Wiring it in
+----------------
+This command does not wire anything automatically — pick whichever applies:
+
+  Claude Code:
+    - If you already have ~/.claude/statusline.sh, paste one of the
+      segments above into it (or call it from there).
+    - Otherwise, set statusLine.command in ~/.claude/settings.json, e.g.:
+        "statusLine": {"type": "command", "command": "~/.grafel/statusline-segment.sh"}
+      pointing at a script containing one of the segments above.
+
+  Generic shell prompt / editor statusline:
+    - Any prompt/statusline that can run a shell command and capture its
+      stdout can call grafel status --json, or read the status file
+      directly as shown above.
+
+  Shortcut:
+    grafel statusline --snippet
+      prints ONLY the icon-based segment (3b) so you can pipe or copy it
+      straight into a file, e.g.:
+        grafel statusline --snippet > ~/.grafel/statusline-segment.sh
+`
+}

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -9,7 +9,7 @@ import (
 // This command INSTALLS NOTHING and edits no files — it only prints an
 // explainer + copy-paste bash snippets to stdout so a user can wire
 // grafel's live status-plane (internal/statusfile) into their own shell
-// prompt or editor statusline by hand. See internal/statusfine.go doc
+// prompt or editor statusline by hand. See internal/statusfile.go doc
 // comment for the on-disk schema this command documents.
 func newStatuslineCmd() *cobra.Command {
 	var snippetOnly bool
@@ -70,7 +70,7 @@ fi
 `
 
 // statuslineIconSnippet is example 3b: the canonical icon-state segment.
-// State precedence: engine down (heartbeat >90s stale) > last_err set >
+// State precedence: engine down (heartbeat >15s stale) > last_err set >
 // indexing > idle (graph_fb_mtime>0, "X ago") > not indexed (graph_fb_mtime
 // == 0). Prints nothing if this isn't a grafel-indexed repo (no status
 // file). Self-contained: no external color/helper dependency, works when
@@ -100,7 +100,8 @@ if [ -n "$hb" ]; then
   # BSD/macOS date parsing. On GNU/Linux, replace this line with:
   #   hbep=$(date -d "$hb" +%s 2>/dev/null)
   hbep=$(date -j -u -f "%Y-%m-%dT%H:%M:%S" "${hb%%.*}" +%s 2>/dev/null)
-  [ -n "$hbep" ] && [ $((now - hbep)) -gt 90 ] && down=1
+  # 15s = grafel's EngineHeartbeatStaleAfter (3 × 5s heartbeat); matches 'grafel doctor'
+  [ -n "$hbep" ] && [ $((now - hbep)) -gt 15 ] && down=1
 fi
 
 if [ "$down" = "1" ]; then
@@ -183,8 +184,10 @@ hashes it the same way, and reads that file directly.
 
 Key fields:
   engine_pid       int      pid of the daemon that wrote this file
-  heartbeat_at     RFC3339  rewritten every ~15-30s, even when idle —
-                            older than ~90s means the engine is DOWN
+  heartbeat_at     RFC3339  rewritten every ~5s, even when idle — older
+                            than 15s (3 missed = grafel's
+                            EngineHeartbeatStaleAfter, same threshold
+                            'grafel doctor' uses) means the engine is DOWN
   version          string   engine's self-reported version
   repo_path        string   absolute path this file describes
   indexed_ref      string   git ref the on-disk graph reflects

--- a/internal/cli/statusline_test.go
+++ b/internal/cli/statusline_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// TestStatuslineGuide_ContainsCoreFacts asserts the full guide (no flags)
+// documents the status-file path scheme, the key field names a statusline
+// author needs, and all three example snippets plus the wiring section.
+func TestStatuslineGuide_ContainsCoreFacts(t *testing.T) {
+	guide := statuslineGuideText()
+
+	mustContain := []string{
+		"status/",                     // path scheme: $GRAFEL_HOME/status/<hash>.json
+		"graph_fb_mtime",              // freshness signal
+		"indexing",                    // indexing bool
+		"heartbeat_at",                // engine liveness
+		"grafel 3m ago",               // minimal snippet (3a)
+		"⟳ indexing",                  // icon snippet (3b)
+		"not indexed",                 // detailed snippet (3c) mentions caveat / not-indexed state
+		"Wiring it in",                // wiring section header
+		"statusLine.command",          // Claude Code wiring mention
+		"grafel statusline --snippet", // self-reference
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(guide, s) {
+			t.Errorf("guide missing expected substring %q", s)
+		}
+	}
+}
+
+// TestStatuslineSnippet_IconOnly asserts --snippet emits ONLY the icon-based
+// bash segment: no prose section headers, but the load-bearing bits of the
+// icon logic (graph_fb_mtime read + the sha256/status/ path construction).
+func TestStatuslineSnippet_IconOnly(t *testing.T) {
+	snippet := statuslineIconSnippet()
+
+	mustContain := []string{
+		"graph_fb_mtime",
+		"status/",
+		"shasum -a 256",
+	}
+	for _, s := range mustContain {
+		if !strings.Contains(snippet, s) {
+			t.Errorf("snippet missing expected substring %q", s)
+		}
+	}
+
+	mustNotContain := []string{
+		"Wiring it in",
+		"Available data",
+		"Example segments",
+	}
+	for _, s := range mustNotContain {
+		if strings.Contains(snippet, s) {
+			t.Errorf("snippet unexpectedly contains prose header %q", s)
+		}
+	}
+}
+
+// TestStatuslineSnippet_ValidBash pipes the emitted snippet through `bash -n`
+// (syntax check only, no execution) to guarantee it's valid, standalone
+// bash a user can paste as-is.
+func TestStatuslineSnippet_ValidBash(t *testing.T) {
+	if _, err := exec.LookPath("bash"); err != nil {
+		t.Skip("bash not available in PATH")
+	}
+	snippet := statuslineIconSnippet()
+
+	cmd := exec.Command("bash", "-n")
+	cmd.Stdin = strings.NewReader(snippet)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("bash -n reported a syntax error: %v\nstderr:\n%s\nsnippet:\n%s", err, stderr.String(), snippet)
+	}
+}
+
+// TestStatuslineCmd_NoArgs_PrintsFullGuide exercises the cobra wiring: no
+// args prints the full guide and exits 0.
+func TestStatuslineCmd_NoArgs_PrintsFullGuide(t *testing.T) {
+	var out bytes.Buffer
+	cmd := newStatuslineCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(nil)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("grafel statusline returned error: %v", err)
+	}
+	if !strings.Contains(out.String(), "Wiring it in") {
+		t.Errorf("expected full guide in output, got:\n%s", out.String())
+	}
+}
+
+// TestStatuslineCmd_SnippetFlag exercises the cobra wiring for --snippet.
+func TestStatuslineCmd_SnippetFlag(t *testing.T) {
+	var out bytes.Buffer
+	cmd := newStatuslineCmd()
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--snippet"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("grafel statusline --snippet returned error: %v", err)
+	}
+	if strings.Contains(out.String(), "Wiring it in") {
+		t.Errorf("--snippet output should not contain prose sections, got:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "graph_fb_mtime") {
+		t.Errorf("--snippet output missing graph_fb_mtime, got:\n%s", out.String())
+	}
+}


### PR DESCRIPTION
Adds `grafel statusline`: prints available status-plane fields, three copy-ready example segments (minimal / icon-states / detailed), and manual wiring instructions for Claude Code + generic statuslines. `--snippet` prints just the icon-state block. Print-only — installs/edits nothing (verified: no os writes, no daemon dial). Down-detection uses grafel's canonical 15s stale threshold (EngineHeartbeatStaleAfter = 3×5s), matching `grafel doctor`. Independent review APPROVE after threshold+typo fix. Follow-up DX; does not gate v0.1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)