### PR TITLE
feat(wizard): live engine CPU%/RSS readout on the index TUI (right of the progress bar)

### DIFF
--- a/internal/cli/wizard_metrics.go
+++ b/internal/cli/wizard_metrics.go
@@ -1,0 +1,58 @@
+package cli
+
+// wizard_metrics.go — the wizard index screen's live CPU/RAM readout (wizard
+// CPU/RAM readout). Motivation: a large-monorepo rebuild has a multi-minute
+// enrichment phase AFTER the core index where the overall progress bar sits
+// near 100% and looks stuck; a live "CPU 412% · 2.3 GB" readout next to the
+// bar reassures the user the engine is still doing real work.
+//
+// Split mode is the DEFAULT (ADR-0024): the ENGINE child process does the
+// indexing, not the wizard's own (serve-side) process, so the CPU/RAM to show
+// is the engine's — surfaced via the SAME status-plane engine-liveness
+// sidecar the split-mode completion probe already reads (see
+// wizard_split_progress.go's livenessReader / daemon.EngineLivenessStatus).
+// Monolith mode (split disabled) writes the identical sidecar from the one
+// daemon process that both serves and indexes, so this reads unchanged in
+// either mode — no branching required here.
+
+import (
+	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// engineMetricsReader mirrors daemon.EngineLivenessStatus — injectable so
+// engineMetricsFuncWith is testable without a live engine process.
+type engineMetricsReader func(root string) (f *statusfile.File, fresh bool)
+
+// engineMetricsFuncWith builds a wiztui.MetricsFunc bound to root using the
+// injected reader. Never errors: a missing or stale sidecar (engine not
+// started yet, monolith mode with no split, an old engine binary predating
+// RSSMB/CPUPct) yields the zero wiztui.Metrics, which wiztui's index view
+// renders as "no readout" rather than a misleading 0%/0.0 GB — see
+// indexView.metricSuffix's doc.
+func engineMetricsFuncWith(root string, read engineMetricsReader) wiztui.MetricsFunc {
+	return func() wiztui.Metrics {
+		f, fresh := read(root)
+		if !fresh || f == nil {
+			return wiztui.Metrics{}
+		}
+		return wiztui.Metrics{RSSMB: f.RSSMB, CPUPct: f.CPUPct}
+	}
+}
+
+// wizardMetricsFunc is the production MetricsFunc wired into the wizard's
+// index screen. Resolves the daemon layout root ONCE (cheap, no I/O beyond
+// resolving GRAFEL_HOME) and reads daemon.EngineLivenessStatus — the exact
+// same on-disk sidecar the split-mode completion probe polls — on every tick.
+// Returns nil (readout disabled outright) only when the layout itself cannot
+// be resolved, a hard environment failure distinct from "engine not running
+// yet" (which EngineLivenessStatus already reports as fresh=false, degrading
+// to an empty readout rather than disabling the poll).
+func wizardMetricsFunc() wiztui.MetricsFunc {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return nil
+	}
+	return engineMetricsFuncWith(layout.Root, daemon.EngineLivenessStatus)
+}

--- a/internal/cli/wizard_metrics_test.go
+++ b/internal/cli/wizard_metrics_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestEngineMetricsFuncWith_ReturnsFreshRSSAndCPU is the RED test for the
+// wizard CPU/RAM readout's cli-side reader: given a fresh engine-liveness
+// sidecar carrying RSSMB/CPUPct, the built wiztui.MetricsFunc must surface
+// them unchanged.
+func TestEngineMetricsFuncWith_ReturnsFreshRSSAndCPU(t *testing.T) {
+	fake := func(root string) (*statusfile.File, bool) {
+		if root != "/fake/root" {
+			t.Fatalf("root = %q, want /fake/root", root)
+		}
+		return &statusfile.File{RSSMB: 2355, CPUPct: 412}, true
+	}
+	fn := engineMetricsFuncWith("/fake/root", fake)
+
+	got := fn()
+	if got.RSSMB != 2355 {
+		t.Errorf("RSSMB = %d, want 2355", got.RSSMB)
+	}
+	if got.CPUPct != 412 {
+		t.Errorf("CPUPct = %v, want 412", got.CPUPct)
+	}
+}
+
+// TestEngineMetricsFuncWith_MissingOrStaleReturnsZero proves the reader
+// degrades gracefully — never panics, never errors — when no engine has ever
+// written the sidecar, or the last write is stale: the TUI must never break
+// because the metric is unavailable, it must simply omit the readout.
+func TestEngineMetricsFuncWith_MissingOrStaleReturnsZero(t *testing.T) {
+	missing := func(root string) (*statusfile.File, bool) { return nil, false }
+	fn := engineMetricsFuncWith("/fake/root", missing)
+
+	got := fn()
+	if got.RSSMB != 0 || got.CPUPct != 0 {
+		t.Errorf("got = %+v, want zero Metrics on missing status file", got)
+	}
+
+	stale := func(root string) (*statusfile.File, bool) {
+		return &statusfile.File{RSSMB: 999, CPUPct: 50}, false // fresh=false
+	}
+	fn2 := engineMetricsFuncWith("/fake/root", stale)
+	got2 := fn2()
+	if got2.RSSMB != 0 || got2.CPUPct != 0 {
+		t.Errorf("got = %+v, want zero Metrics on stale status file", got2)
+	}
+}

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -190,7 +190,7 @@ func runInteractiveTUI(out, errOut io.Writer, opts wizardOptions) (wiztui.Result
 	if opts.MCPTools == nil {
 		mcpOpts = mcpToolOptions()
 	}
-	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks, mcpOpts)
+	m := wiztui.New(drv, idxFn, opts.Watchers, opts.GitHooks, mcpOpts, wizardMetricsFunc())
 
 	// Switch the console to UTF-8 (Windows) before the alt-screen starts so the
 	// wizard's glyphs render instead of mojibake; restore on exit (#5340).

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -36,6 +36,17 @@ type indexView struct {
 	elapsed         string
 	daemonDown      bool           // group registered but not indexed
 	install         InstallSummary // captured applyGroupConfig output (fix C)
+
+	// rssMB / cpuPct are the engine process's live CPU/RAM readout (wizard
+	// CPU/RAM readout — see internal/statusfile.File's RSSMB/CPUPct doc),
+	// polled periodically from the engine-liveness status-plane sidecar via
+	// Model's metricsFn (see model.go). Zero/absent means "unknown or not yet
+	// polled" and the readout is omitted entirely — never rendered as a
+	// misleading 0%/0.0 GB. rssMB is the must-have signal (it shows the
+	// multi-GB enrichment-phase peak); cpuPct is best-effort and independently
+	// omittable.
+	rssMB  int64
+	cpuPct float64
 }
 
 func newIndexView(group string, expectedRepos int) indexView {
@@ -194,6 +205,32 @@ func (v indexView) renderRow(r Row, spinnerFrame string) string {
 	return fmt.Sprintf("%s %s  %s%s", glyph, name, phase, tail)
 }
 
+// metricSuffix renders the live "CPU / RAM" readout that appears to the right
+// of the overall progress bar's percentage — reassurance that a large-monorepo
+// rebuild's multi-minute post-index enrichment phase (where the bar sits near
+// 100% for a long stretch) is still doing real work, not stuck (motivation for
+// this whole feature).
+//
+// Omits gracefully: an absent/zero rssMB (old status file predating this
+// field, engine metric read failed, or no poll has landed yet) returns "" and
+// the bar renders exactly as it did before this feature — no dangling
+// separator, no misleading "0.0 GB". cpuPct is independently optional: a
+// positive rssMB with cpuPct==0 renders RAM only (matches the spec's
+// "best-effort CPU%" contract — RSS is the must-have signal).
+func (v indexView) metricSuffix() string {
+	if v.rssMB <= 0 {
+		return ""
+	}
+	gb := float64(v.rssMB) / 1024.0
+	var text string
+	if v.cpuPct > 0 {
+		text = fmt.Sprintf("%s CPU %.0f%% %s %.1f GB", g.MidDot, v.cpuPct, g.MidDot, gb)
+	} else {
+		text = fmt.Sprintf("%s %.1f GB", g.MidDot, gb)
+	}
+	return "  " + rowCountStyle.Render(text)
+}
+
 // view renders the full indexing body (overall bar + per-repo rows + summary).
 func (v indexView) view() string {
 	var b strings.Builder
@@ -223,7 +260,11 @@ func (v indexView) view() string {
 	b.WriteString(overallLblStyle.Render(fmt.Sprintf("Indexing %s — %s", v.group, label)))
 	b.WriteString("\n")
 	b.WriteString(bar.ViewAs(pct))
-	b.WriteString(fmt.Sprintf("  %3d%%\n\n", int(pct*100)))
+	b.WriteString(fmt.Sprintf("  %3d%%", int(pct*100)))
+	if suffix := v.metricSuffix(); suffix != "" {
+		b.WriteString(suffix)
+	}
+	b.WriteString("\n\n")
 
 	if len(rows) == 0 && !v.done() {
 		b.WriteString(rowCountStyle.Render("waiting for the indexer to report" + g.Ellipsis))

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -2,6 +2,7 @@ package wiztui
 
 import (
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
@@ -137,10 +138,63 @@ type indexStartedMsg struct {
 	outcome <-chan IndexOutcome
 }
 
+// Metrics is a single live-process reading — the engine's CPU/RAM at the
+// moment of the poll — surfaced to the right of the index screen's overall
+// progress bar (wizard CPU/RAM readout). Both fields are independently
+// omittable: RSSMB<=0 hides the whole readout (the must-have signal is
+// absent, so the CPU% alone would be misleading); CPUPct<=0 with a positive
+// RSSMB renders the RAM portion only (CPU% is best-effort).
+type Metrics struct {
+	RSSMB  int64
+	CPUPct float64
+}
+
+// MetricsFunc polls the live engine process metrics (RSS/CPU) for the CPU/RAM
+// readout. It is called on a periodic tea.Tick while the index screen is
+// active (see metricsTick) — implemented by the cli package, which reads the
+// engine-liveness status-plane sidecar (internal/daemon.EngineLivenessStatus)
+// so wiztui itself stays decoupled from the daemon package. Must be cheap and
+// non-blocking (a single disk read) and must NEVER panic or hang: a missing/
+// stale status file (old engine, not-yet-started engine, monolith mode with
+// no split) is a completely normal "unknown" case and should return the zero
+// Metrics, not an error — there is no error return, by design, so a caller
+// cannot forget to handle one and wedge the TUI. nil is a valid MetricsFunc:
+// New leaves the ticker command it feeds unscheduled to skip and the readout
+// simply never appears.
+type MetricsFunc func() Metrics
+
+// metricsMsg carries one MetricsFunc poll result into Update.
+type metricsMsg Metrics
+
+// metricsPollInterval is how often the index screen polls MetricsFunc.
+// Deliberately loose — this only feeds a "still alive" readout, not a
+// precision meter — so it costs nothing noticeable against the heartbeat
+// writer's own ~5-30s cadence (see internal/daemon's
+// defaultStatusHeartbeatInterval): a value close to that cadence would just
+// re-read the same on-disk sample repeatedly.
+const metricsPollInterval = 1500 * time.Millisecond
+
+// metricsTick schedules the next MetricsFunc poll as a tea.Cmd. Returns nil
+// (no-op Cmd) when fn is nil, so a caller with no metrics wiring (e.g. a test
+// model, or a build where the cli package chose not to supply one) never
+// starts a ticker at all.
+func metricsTick(fn MetricsFunc) tea.Cmd {
+	if fn == nil {
+		return nil
+	}
+	return tea.Tick(metricsPollInterval, func(time.Time) tea.Msg {
+		return metricsMsg(fn())
+	})
+}
+
 // Model is the full-screen Bubble Tea wizard model.
 type Model struct {
 	drv   Driver
 	index IndexFunc
+	// metricsFn polls the live engine CPU/RAM readout during the index screen
+	// (wizard CPU/RAM readout). nil disables the readout entirely — see
+	// MetricsFunc's doc.
+	metricsFn MetricsFunc
 
 	width, height int
 
@@ -176,13 +230,17 @@ type Model struct {
 // not re-prompt for them). mcpTools are the detected MCP-capable tools offered
 // on the "Configure MCP for which tools?" screen (#5344); pass nil/empty to
 // skip that screen entirely (e.g. a flag preset the selection, or ≤1 detected).
-func New(drv Driver, index IndexFunc, watchers, gitHooks bool, mcpTools []MCPToolOption) Model {
+// metricsFn polls the live engine CPU/RAM readout (wizard CPU/RAM readout) —
+// pass nil to disable the readout entirely (e.g. a test model, or a caller
+// that has no status-plane wiring). See MetricsFunc's doc.
+func New(drv Driver, index IndexFunc, watchers, gitHooks bool, mcpTools []MCPToolOption, metricsFn MetricsFunc) Model {
 	m := Model{
-		drv:      drv,
-		index:    index,
-		scr:      scrAction,
-		step:     StepAction,
-		mcpTools: mcpTools,
+		drv:       drv,
+		index:     index,
+		metricsFn: metricsFn,
+		scr:       scrAction,
+		step:      StepAction,
+		mcpTools:  mcpTools,
 	}
 	m.res.Watchers = watchers
 	m.res.GitHooks = gitHooks
@@ -228,11 +286,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case indexStartedMsg:
 		m.evCh = msg.events
 		m.outCh = msg.outcome
-		return m, tea.Batch(m.idx.spin.Tick, waitEvent(m.evCh), waitOutcome(m.outCh))
+		return m, tea.Batch(m.idx.spin.Tick, waitEvent(m.evCh), waitOutcome(m.outCh), metricsTick(m.metricsFn))
 
 	case progressMsg:
 		m.idx.foldEvent(prog.Event(msg))
 		return m, waitEvent(m.evCh)
+
+	case metricsMsg:
+		m.idx.rssMB = msg.RSSMB
+		m.idx.cpuPct = msg.CPUPct
+		if m.idx.done() {
+			// Index screen is finished (Done/Failed) — stop polling rather
+			// than ticking forever in the background.
+			return m, nil
+		}
+		return m, metricsTick(m.metricsFn)
 
 	case outcomeMsg:
 		o := IndexOutcome(msg)

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -48,14 +48,14 @@ func send(m tea.Model, msg tea.Msg) tea.Model {
 }
 
 func newTestModel(d Driver, idx IndexFunc) Model {
-	m := New(d, idx, true, true, nil)
+	m := New(d, idx, true, true, nil, nil)
 	return m.update(tea.WindowSizeMsg{Width: 100, Height: 40})
 }
 
 // newTestModelMCP builds a model WITH detected MCP tools so the
 // "Configure MCP for which tools?" screen is exercised (#5344).
 func newTestModelMCP(d Driver, idx IndexFunc, mcp []MCPToolOption) Model {
-	m := New(d, idx, true, true, mcp)
+	m := New(d, idx, true, true, mcp, nil)
 	return m.update(tea.WindowSizeMsg{Width: 100, Height: 40})
 }
 

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -371,3 +371,46 @@ func TestDoneScreen_DaemonDownNote(t *testing.T) {
 		}
 	})
 }
+
+// TestIndexView_MetricSuffix_PresentAndAbsent is the RED test for the wizard
+// CPU/RAM readout: with rssMB/cpuPct set, view() must render the "GB" (and
+// "CPU" when cpuPct>0) readout to the right of the overall bar's percentage;
+// with the metric unset (zero), the readout must be ABSENT and the bar's
+// existing percentage rendering must be unchanged (additive-only feature).
+func TestIndexView_MetricSuffix_PresentAndAbsent(t *testing.T) {
+	base := newIndexView("grp", 1)
+	base.width = 100
+	base.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 10, TS: 1})
+
+	// No metric set: readout absent, but the percentage still renders.
+	withoutMetric := base.view()
+	if strings.Contains(withoutMetric, "GB") {
+		t.Errorf("readout should be absent when rssMB==0:\n%s", withoutMetric)
+	}
+	if !strings.Contains(withoutMetric, "%") {
+		t.Errorf("bar percentage missing even without the metric:\n%s", withoutMetric)
+	}
+
+	// RSS only (CPU best-effort unavailable): GB present, no "CPU" text.
+	rssOnly := base
+	rssOnly.rssMB = 2355 // ~2.3 GB
+	rssOnlyOut := rssOnly.view()
+	if !strings.Contains(rssOnlyOut, "2.3 GB") {
+		t.Errorf("expected \"2.3 GB\" in output:\n%s", rssOnlyOut)
+	}
+	if strings.Contains(rssOnlyOut, "CPU") {
+		t.Errorf("CPU text should be absent when cpuPct==0:\n%s", rssOnlyOut)
+	}
+
+	// RSS + CPU: both present.
+	both := base
+	both.rssMB = 2355
+	both.cpuPct = 412
+	bothOut := both.view()
+	if !strings.Contains(bothOut, "CPU 412%") {
+		t.Errorf("expected \"CPU 412%%\" in output:\n%s", bothOut)
+	}
+	if !strings.Contains(bothOut, "2.3 GB") {
+		t.Errorf("expected \"2.3 GB\" in output:\n%s", bothOut)
+	}
+}

--- a/internal/daemon/engine_liveness_metrics_test.go
+++ b/internal/daemon/engine_liveness_metrics_test.go
@@ -28,6 +28,56 @@ func TestPopulateProcessMetrics_ReportsCurrentProcessRSS(t *testing.T) {
 	}
 }
 
+// TestCPUSampler_ObserveComputesBoundedDelta is the RED test for the
+// Linux-correct CPU% fix: the sampler must turn CUMULATIVE CPU-seconds into a
+// bounded instantaneous PERCENTAGE via a delta across successive heartbeat
+// writes — NOT stamp the raw ever-rising cumulative value (which on Linux
+// would render "CPU 9843%" and climbing).
+func TestCPUSampler_ObserveComputesBoundedDelta(t *testing.T) {
+	var s cpuSampler
+	t0 := time.Unix(1_000_000, 0)
+
+	// First sample: baseline only, no interval to divide by → 0 (readout omits CPU).
+	if pct := s.observe(10.0, t0); pct != 0 {
+		t.Errorf("first observe = %v, want 0 (baseline only)", pct)
+	}
+
+	// Second sample: 4 CPU-seconds burned over 1 wall-second → 400% (a real,
+	// multi-core-capable percentage), NOT the raw cumulative 14.
+	pct := s.observe(14.0, t0.Add(1*time.Second))
+	if pct == 14.0 {
+		t.Fatalf("observe returned the raw cumulative value %v — must be a delta percentage", pct)
+	}
+	if got, want := pct, 400.0; got != want {
+		t.Errorf("observe = %v%%, want %v%% (Δ4 cpu-sec / 1 wall-sec)", got, want)
+	}
+
+	// Third sample: 0.5 CPU-seconds over 2 wall-seconds → 25%.
+	if got := s.observe(14.5, t0.Add(3*time.Second)); got != 25.0 {
+		t.Errorf("observe = %v%%, want 25%%", got)
+	}
+}
+
+// TestCPUSampler_GuardsFirstSampleAndZeroInterval covers the degrade-to-zero
+// guards: a zero/negative wall interval and a counter reset both yield 0 (so
+// the readout omits CPU that tick) rather than a divide-by-zero or a negative %.
+func TestCPUSampler_GuardsFirstSampleAndZeroInterval(t *testing.T) {
+	var s cpuSampler
+	t0 := time.Unix(2_000_000, 0)
+	_ = s.observe(5.0, t0) // baseline
+
+	// Same wall-clock instant → zero interval → guard returns 0.
+	if got := s.observe(9.0, t0); got != 0 {
+		t.Errorf("zero-interval observe = %v, want 0", got)
+	}
+	// Note: the previous call still advanced the baseline to (9.0, t0). A CPU
+	// counter reset (cpuSeconds < prev) over a positive interval → negative
+	// delta → guard returns 0.
+	if got := s.observe(1.0, t0.Add(1*time.Second)); got != 0 {
+		t.Errorf("counter-reset observe = %v, want 0", got)
+	}
+}
+
 // TestStartEngineLivenessHeartbeat_PopulatesRSS proves the production
 // heartbeat writer (not just the helper in isolation) publishes RSSMB>0 onto
 // the on-disk engine-liveness sidecar, so a wizard TUI reading

--- a/internal/daemon/engine_liveness_metrics_test.go
+++ b/internal/daemon/engine_liveness_metrics_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestPopulateProcessMetrics_ReportsCurrentProcessRSS is the RED test for the
+// wizard CPU/RAM readout: the engine-liveness heartbeat writer must stamp its
+// OWN process's RSS (in MB) onto the statusfile.File it writes. RSS is the
+// must-have signal (it shows the multi-GB enrichment-phase peak); CPU% is
+// best-effort and may legitimately be 0 on a platform/measurement hiccup, so
+// only RSSMB is asserted strictly here.
+func TestPopulateProcessMetrics_ReportsCurrentProcessRSS(t *testing.T) {
+	f := &statusfile.File{EnginePID: os.Getpid()}
+	populateProcessMetrics(f)
+
+	if f.RSSMB <= 0 {
+		t.Fatalf("RSSMB = %d, want > 0 for the current (live) process", f.RSSMB)
+	}
+	// CPUPct must never be negative — best-effort zero is fine, but a negative
+	// value would indicate a broken sample rather than "unavailable".
+	if f.CPUPct < 0 {
+		t.Errorf("CPUPct = %v, want >= 0", f.CPUPct)
+	}
+}
+
+// TestStartEngineLivenessHeartbeat_PopulatesRSS proves the production
+// heartbeat writer (not just the helper in isolation) publishes RSSMB>0 onto
+// the on-disk engine-liveness sidecar, so a wizard TUI reading
+// EngineLivenessStatus sees the metric with no further wiring.
+func TestStartEngineLivenessHeartbeat_PopulatesRSS(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	root := t.TempDir()
+
+	stop := startEngineLivenessHeartbeat(root, 0, nil, nil)
+	t.Cleanup(stop)
+
+	// The writer's first write happens inside its own goroutine (fired right
+	// after startup, before the ticker loop) — poll briefly rather than racing
+	// it, matching the pattern in TestOnRepoStatesChanged_TriggersStatusFileRefresh.
+	deadline := time.Now().Add(2 * time.Second)
+	var f *statusfile.File
+	var fresh bool
+	for time.Now().Before(deadline) {
+		f, fresh = EngineLivenessStatus(root)
+		if fresh && f != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !fresh || f == nil {
+		t.Fatalf("EngineLivenessStatus: fresh=%v f=%v", fresh, f)
+	}
+	if f.RSSMB <= 0 {
+		t.Errorf("RSSMB = %d, want > 0", f.RSSMB)
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -191,35 +191,94 @@ func EngineLivenessStatusKey(root string) string {
 	return engineLivenessStatusKey(root)
 }
 
-// populateProcessMetrics stamps f.RSSMB and f.CPUPct from the CURRENT
-// process's own stats (wizard CPU/RAM readout — see statusfile.File's
-// RSSMB/CPUPct doc). Called once per heartbeat write, from whichever process
-// is running the index: the standalone `grafel engine` child in split mode
-// (the DEFAULT), or the monolith daemon process itself when split mode is
-// disabled — both call startEngineLivenessHeartbeat identically (see
-// startEnginePlane in engineplane.go), so the readout works unchanged in
-// either mode.
+// populateProcessMetrics stamps f.RSSMB from the CURRENT process's own
+// resident-set size (wizard CPU/RAM readout — see statusfile.File's RSSMB
+// doc). RSS is the must-have signal (it shows the multi-GB enrichment-phase
+// peak) and is a stateless single reading, so it lives here; the CPU%
+// portion needs a delta across successive writes and is therefore owned by
+// the stateful cpuSampler in the heartbeat writer (see cpuSampler.observe),
+// NOT computed here.
+//
+// Called once per heartbeat write, from whichever process is running the
+// index: the standalone `grafel engine` child in split mode (the DEFAULT), or
+// the monolith daemon process itself when split mode is disabled — both call
+// startEngineLivenessHeartbeat identically (see startEnginePlane in
+// engineplane.go), so the readout works unchanged in either mode.
 //
 // Cheap and non-blocking: RSSBytes is a single /proc read (Linux) or `ps`
-// shell-out (macOS); CPUPercent is likewise a single `ps` shell-out on macOS
-// or a /proc read on Linux — both return in low-single-digit milliseconds, so
-// calling this on every ~5-30s heartbeat tick is negligible overhead. Neither
-// call blocks on an interval sample (no "measure twice, subtract" dance): the
-// OS/toolchain (ps %cpu, or /proc's own accounting) already computes the
-// instantaneous percentage.
-//
-// Best-effort: a measurement failure (unsupported platform, transient ps
-// error) silently leaves the corresponding field at its current value (zero
-// on a fresh *statusfile.File) rather than erroring — RSS/CPU are an
-// observability nicety, never load-bearing for indexing itself.
+// shell-out (macOS), low-single-digit milliseconds — negligible on the ~5-30s
+// heartbeat cadence. Best-effort: a measurement failure (unsupported platform,
+// transient ps error) silently leaves RSSMB at zero rather than erroring — the
+// readout is an observability nicety, never load-bearing for indexing itself.
 func populateProcessMetrics(f *statusfile.File) {
 	pid := os.Getpid()
 	if rss, err := process.RSSBytes(pid); err == nil && rss > 0 {
 		f.RSSMB = int64(rss / (1024 * 1024))
 	}
-	if pct, err := process.CPUPercent(pid); err == nil && pct > 0 {
-		f.CPUPct = pct
+}
+
+// cpuSampler derives an instantaneous-ish CPU percentage for the wizard's
+// CPU/RAM readout by diffing the process's CUMULATIVE CPU-seconds
+// (process.CPUTimeSeconds — identical semantics on linux and darwin) across
+// successive heartbeat writes. This is the ONLY correct way to get a
+// percentage on BOTH platforms: process.CPUPercent is platform-inconsistent
+// (instantaneous % on darwin, cumulative seconds on linux), so feeding it
+// straight into CPUPct would render meaningless unbounded numbers on a Linux
+// engine ("CPU 9843%" and climbing). The heartbeat writer already runs on a
+// fixed interval, so it is the natural home for the (lastCPUSeconds, lastWall)
+// state the delta needs.
+//
+// A single cpuSampler is owned by each startEngineLivenessHeartbeat goroutine
+// and is therefore only ever touched from that one goroutine — no locking
+// needed.
+type cpuSampler struct {
+	lastCPUSeconds float64
+	lastWall       time.Time
+	primed         bool // false until the first observe() records a baseline
+}
+
+// observe records a new cumulative CPU-seconds reading taken at wall-clock
+// time now and returns the CPU percentage since the previous reading. It is a
+// PURE function of its inputs + prior state (the actual process read happens in
+// the caller), so it is fully unit-testable with a stubbed rising cpuSeconds +
+// advancing clock.
+//
+// Returns 0 — so the caller omits the CPU portion of the readout that tick —
+// on the FIRST call (baseline only, no interval to divide by), on a
+// non-positive wall interval (clock didn't advance / went backwards), or on a
+// negative computed delta (CPU counter reset). Otherwise returns
+// 100*(ΔcpuSeconds/Δwall), which can legitimately exceed 100% for a
+// multi-core/multi-threaded index (the large-monorepo enrichment phase hits
+// ~400%, which is intended).
+func (s *cpuSampler) observe(cpuSeconds float64, now time.Time) float64 {
+	prevCPU, prevWall, primed := s.lastCPUSeconds, s.lastWall, s.primed
+	s.lastCPUSeconds = cpuSeconds
+	s.lastWall = now
+	s.primed = true
+	if !primed {
+		return 0 // first sample: establish the baseline, no percentage yet
 	}
+	wall := now.Sub(prevWall).Seconds()
+	if wall <= 0 {
+		return 0
+	}
+	pct := 100 * (cpuSeconds - prevCPU) / wall
+	if pct < 0 {
+		return 0
+	}
+	return pct
+}
+
+// sample reads the current process's cumulative CPU time and folds it through
+// observe, returning the CPU% since the last heartbeat write (0 when
+// unavailable — first tick, unsupported platform, or a transient read error —
+// so the caller omits the CPU portion of the readout).
+func (s *cpuSampler) sample(pid int, now time.Time) float64 {
+	cpuSec, err := process.CPUTimeSeconds(pid)
+	if err != nil {
+		return 0
+	}
+	return s.observe(cpuSec, now)
 }
 
 // startEngineLivenessHeartbeat launches a goroutine that stamps the
@@ -243,6 +302,9 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 	startedAt := time.Now().UTC()
 	stopCh := make(chan struct{})
 	doneCh := make(chan struct{})
+	// cpuSampler holds the (lastCPUSeconds, lastWall) state the CPU-delta needs;
+	// it is only ever touched by writeOnce, which runs on this single goroutine.
+	sampler := &cpuSampler{}
 	writeOnce := func() {
 		snap := indexstate.Get()
 		conc := indexstate.GetIndexConcurrency()
@@ -262,6 +324,11 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 			ConcurrencyCap:          conc.Cap,
 		}
 		populateProcessMetrics(f)
+		// CPU% is a delta across successive heartbeat writes (the first tick
+		// establishes the baseline and reports 0 → readout omits CPU that tick).
+		if pct := sampler.sample(os.Getpid(), time.Now()); pct > 0 {
+			f.CPUPct = pct
+		}
 		if warmingFn != nil {
 			warm := warmingFn()
 			f.WarmIndexInFlight = warm.IndexInFlight

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
 	"github.com/cajasmota/grafel/internal/version"
@@ -190,6 +191,37 @@ func EngineLivenessStatusKey(root string) string {
 	return engineLivenessStatusKey(root)
 }
 
+// populateProcessMetrics stamps f.RSSMB and f.CPUPct from the CURRENT
+// process's own stats (wizard CPU/RAM readout — see statusfile.File's
+// RSSMB/CPUPct doc). Called once per heartbeat write, from whichever process
+// is running the index: the standalone `grafel engine` child in split mode
+// (the DEFAULT), or the monolith daemon process itself when split mode is
+// disabled — both call startEngineLivenessHeartbeat identically (see
+// startEnginePlane in engineplane.go), so the readout works unchanged in
+// either mode.
+//
+// Cheap and non-blocking: RSSBytes is a single /proc read (Linux) or `ps`
+// shell-out (macOS); CPUPercent is likewise a single `ps` shell-out on macOS
+// or a /proc read on Linux — both return in low-single-digit milliseconds, so
+// calling this on every ~5-30s heartbeat tick is negligible overhead. Neither
+// call blocks on an interval sample (no "measure twice, subtract" dance): the
+// OS/toolchain (ps %cpu, or /proc's own accounting) already computes the
+// instantaneous percentage.
+//
+// Best-effort: a measurement failure (unsupported platform, transient ps
+// error) silently leaves the corresponding field at its current value (zero
+// on a fresh *statusfile.File) rather than erroring — RSS/CPU are an
+// observability nicety, never load-bearing for indexing itself.
+func populateProcessMetrics(f *statusfile.File) {
+	pid := os.Getpid()
+	if rss, err := process.RSSBytes(pid); err == nil && rss > 0 {
+		f.RSSMB = int64(rss / (1024 * 1024))
+	}
+	if pct, err := process.CPUPercent(pid); err == nil && pct > 0 {
+		f.CPUPct = pct
+	}
+}
+
 // startEngineLivenessHeartbeat launches a goroutine that stamps the
 // engine-global liveness statusfile (EnginePID + a fresh HeartbeatAt) once
 // immediately and then every interval, until the returned stop func is called
@@ -229,6 +261,7 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 			ConcurrencyQueued:       conc.Queued,
 			ConcurrencyCap:          conc.Cap,
 		}
+		populateProcessMetrics(f)
 		if warmingFn != nil {
 			warm := warmingFn()
 			f.WarmIndexInFlight = warm.IndexInFlight

--- a/internal/process/cputime_darwin_test.go
+++ b/internal/process/cputime_darwin_test.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package process
+
+import (
+	"math"
+	"os"
+	"testing"
+)
+
+// TestParseCPUTime covers every `ps -o cputime` shape the darwin
+// CPUTimeSeconds reader must handle: MM:SS[.ss], HH:MM:SS, and DD-HH:MM:SS.
+func TestParseCPUTime(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"0:00.00", 0},
+		{"0:00.42", 0.42},
+		{"12:34", 12*60 + 34},
+		{"1:02:03", 1*3600 + 2*60 + 3},
+		{"1-02:03:04", 1*86400 + 2*3600 + 3*60 + 4},
+	}
+	for _, c := range cases {
+		got, err := parseCPUTime(c.in)
+		if err != nil {
+			t.Errorf("parseCPUTime(%q): %v", c.in, err)
+			continue
+		}
+		if math.Abs(got-c.want) > 1e-6 {
+			t.Errorf("parseCPUTime(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+// TestCPUTimeSeconds_CurrentProcess smoke-tests that the darwin reader returns
+// a non-negative cumulative time for the live process.
+func TestCPUTimeSeconds_CurrentProcess(t *testing.T) {
+	secs, err := CPUTimeSeconds(os.Getpid())
+	if err != nil {
+		t.Fatalf("CPUTimeSeconds: %v", err)
+	}
+	if secs < 0 {
+		t.Errorf("CPUTimeSeconds = %v, want >= 0", secs)
+	}
+}

--- a/internal/process/process.go
+++ b/internal/process/process.go
@@ -7,7 +7,17 @@
 //	FindByName(name) — returns all running processes whose command name
 //	                    contains the given string (case-insensitive).
 //	Kill(pid)         — sends SIGTERM on unix; calls TerminateProcess on windows.
-//	CPUPercent(pid)   — returns the instantaneous CPU percent for pid.
+//	CPUPercent(pid)   — PLATFORM-INCONSISTENT, avoid for new code: on darwin
+//	                    it returns instantaneous %cpu (`ps -o %cpu`); on linux
+//	                    it returns CUMULATIVE cpu-seconds since start (from
+//	                    /proc stat), NOT a percentage; unsupported elsewhere.
+//	                    Kept only for the existing hot-loop watchdog. New
+//	                    callers that want a real percentage should sample
+//	                    CPUTimeSeconds twice and diff over wall-clock.
+//	CPUTimeSeconds(pid)— returns pid's CUMULATIVE CPU time (user+system) in
+//	                    seconds since start, with IDENTICAL semantics on linux
+//	                    and darwin (unsupported elsewhere). Diff two readings
+//	                    over a wall-clock interval to get an instantaneous %.
 //	RSSBytes(pid)     — returns the resident-set size of pid in bytes.
 //	FootprintBytes()  — returns the best honest physical-memory number for
 //	                    the CURRENT process plus a label describing what it

--- a/internal/process/process_darwin.go
+++ b/internal/process/process_darwin.go
@@ -70,6 +70,72 @@ func CPUPercent(pid int) (float64, error) {
 	return pct, nil
 }
 
+// CPUTimeSeconds returns pid's CUMULATIVE CPU time (user+system) in seconds
+// since the process started, via `ps -o cputime= -p <pid>`. It is the uniform
+// cross-platform primitive a caller diffs over a wall-clock interval to derive
+// an instantaneous CPU percentage (mirrors the linux /proc-stat reader's
+// semantics). Deliberately NOT a percentage — see the linux implementation's
+// doc for why the cumulative form is the portable contract.
+//
+// `ps -o cputime` prints `[[DD-]HH:]MM:SS[.ss]` (e.g. "0:00.42", "12:34",
+// "1-02:03:04"); parseCPUTime handles every shape. Returns 0 + error on any
+// shell-out or parse failure.
+func CPUTimeSeconds(pid int) (float64, error) {
+	out, err := exec.Command("ps", "-o", "cputime=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return 0, fmt.Errorf("ps -o cputime= -p %d: %w", pid, err)
+	}
+	secs, perr := parseCPUTime(strings.TrimSpace(string(out)))
+	if perr != nil {
+		return 0, fmt.Errorf("parse cputime %q: %w", strings.TrimSpace(string(out)), perr)
+	}
+	return secs, nil
+}
+
+// parseCPUTime parses the `ps -o cputime` duration format
+// `[[DD-]HH:]MM:SS[.ss]` into total seconds. The days segment (if present) is
+// separated from the clock by a '-'; the clock has 2 (MM:SS) or 3 (HH:MM:SS)
+// colon-separated components, the last of which may carry a fractional part.
+func parseCPUTime(s string) (float64, error) {
+	if s == "" {
+		return 0, fmt.Errorf("empty cputime")
+	}
+	var days float64
+	clock := s
+	if dash := strings.IndexByte(s, '-'); dash >= 0 {
+		d, err := strconv.ParseFloat(s[:dash], 64)
+		if err != nil {
+			return 0, fmt.Errorf("bad days %q: %w", s[:dash], err)
+		}
+		days = d
+		clock = s[dash+1:]
+	}
+	parts := strings.Split(clock, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0, fmt.Errorf("unexpected clock %q", clock)
+	}
+	var hours, mins, secs float64
+	if len(parts) == 3 {
+		h, err := strconv.ParseFloat(parts[0], 64)
+		if err != nil {
+			return 0, fmt.Errorf("bad hours %q: %w", parts[0], err)
+		}
+		hours = h
+		parts = parts[1:]
+	}
+	m, err := strconv.ParseFloat(parts[0], 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad minutes %q: %w", parts[0], err)
+	}
+	mins = m
+	sc, err := strconv.ParseFloat(parts[1], 64)
+	if err != nil {
+		return 0, fmt.Errorf("bad seconds %q: %w", parts[1], err)
+	}
+	secs = sc
+	return days*86400 + hours*3600 + mins*60 + secs, nil
+}
+
 // RSSBytes returns the resident-set size of pid in bytes via `ps -o rss= -p <pid>`.
 func RSSBytes(pid int) (uint64, error) {
 	out, err := exec.Command("ps", "-o", "rss=", "-p", strconv.Itoa(pid)).Output()

--- a/internal/process/process_linux.go
+++ b/internal/process/process_linux.go
@@ -70,13 +70,14 @@ func ForceKill(pid int) error {
 	return nil
 }
 
-// CPUPercent returns the instantaneous CPU usage of pid as a percentage
-// by reading /proc/<pid>/stat and computing user+sys ticks / clock ticks.
-// On Linux this is derived from two samples; for a single-shot reading it
-// returns the kernel's accumulated time as a rough proxy. Returns 0 on error.
-//
-// Note: for the hot-loop watchdog the daemon computes a delta itself;
-// this provides the raw ticks for that calculation.
+// CPUPercent on Linux does NOT return a percentage despite its name — it
+// returns pid's CUMULATIVE CPU-seconds since start ((utime+stime)/clk_tck from
+// /proc/<pid>/stat). This is the platform inconsistency documented on the
+// package-level API surface: darwin's CPUPercent returns instantaneous %cpu,
+// linux's returns cumulative seconds. It is kept ONLY for the existing
+// hot-loop watchdog, which caches and diffs it itself. New callers wanting a
+// real, portable percentage must use CPUTimeSeconds (identical semantics on
+// both platforms) and diff over wall-clock. Returns 0 on error.
 func CPUPercent(pid int) (float64, error) {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	if err != nil {
@@ -102,6 +103,38 @@ func CPUPercent(pid int) (float64, error) {
 	// a delta over a wall-clock interval. For the single-call watchdog use
 	// case this is the accumulated value; callers should cache and diff.
 	return totalSec, nil
+}
+
+// CPUTimeSeconds returns pid's CUMULATIVE CPU time (user+system) in seconds
+// since the process started, read from /proc/<pid>/stat. This is the uniform
+// cross-platform primitive a caller diffs over a wall-clock interval to derive
+// an instantaneous CPU percentage (see the darwin/other implementations for
+// the matching semantics). It is deliberately NOT a percentage — the whole
+// point of the type is that its meaning is identical on every platform, unlike
+// CPUPercent (which is instantaneous %cpu on darwin but cumulative-ish on
+// linux and unsupported elsewhere). Returns 0 + error on any read/parse
+// failure.
+func CPUTimeSeconds(pid int) (float64, error) {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return 0, fmt.Errorf("read /proc/%d/stat: %w", pid, err)
+	}
+	// Format: pid (comm) state ppid ... utime stime cutime cstime ...
+	// comm may contain spaces AND parentheses; split at the LAST ')' so the
+	// numeric fields after it align regardless of the comm's contents.
+	raw := string(data)
+	rp := strings.LastIndex(raw, ")")
+	if rp < 0 {
+		return 0, fmt.Errorf("malformed /proc/%d/stat", pid)
+	}
+	fields := strings.Fields(raw[rp+2:])
+	if len(fields) < 13 {
+		return 0, fmt.Errorf("not enough fields in /proc/%d/stat", pid)
+	}
+	utime, _ := strconv.ParseFloat(fields[11], 64)
+	stime, _ := strconv.ParseFloat(fields[12], 64)
+	const clkTck = float64(100) // sysconf(_SC_CLK_TCK) — 100 on virtually all Linux
+	return (utime + stime) / clkTck, nil
 }
 
 // RSSBytes returns the resident-set size of pid in bytes by reading

--- a/internal/process/process_other.go
+++ b/internal/process/process_other.go
@@ -31,6 +31,13 @@ func CPUPercent(_ int) (float64, error) {
 	return 0, fmt.Errorf("process.CPUPercent: unsupported platform %s", runtime.GOOS)
 }
 
+// CPUTimeSeconds is not implemented on this platform. A caller (e.g. the
+// engine-liveness heartbeat's CPU-delta sampler) treats the error as "CPU%
+// unavailable" and simply omits the CPU portion of its readout.
+func CPUTimeSeconds(_ int) (float64, error) {
+	return 0, fmt.Errorf("process.CPUTimeSeconds: unsupported platform %s", runtime.GOOS)
+}
+
 // RSSBytes is not implemented on this platform.
 func RSSBytes(_ int) (uint64, error) {
 	return 0, fmt.Errorf("process.RSSBytes: unsupported platform %s", runtime.GOOS)

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -87,6 +87,14 @@ func CPUPercent(_ int) (float64, error) {
 	return 0, fmt.Errorf("process.CPUPercent: unsupported platform windows")
 }
 
+// CPUTimeSeconds is not implemented on Windows. A caller (e.g. the
+// engine-liveness heartbeat's CPU-delta sampler) treats the error as "CPU%
+// unavailable" and simply omits the CPU portion of its readout — RSS is still
+// reported via RSSBytes.
+func CPUTimeSeconds(_ int) (float64, error) {
+	return 0, fmt.Errorf("process.CPUTimeSeconds: unsupported platform windows")
+}
+
 // processMemoryCounters mirrors the Win32 PROCESS_MEMORY_COUNTERS struct
 // (psapi.h). WorkingSetSize is the resident set — the bytes the process
 // currently has in physical RAM — which is the honest Windows analogue of

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -128,6 +128,31 @@ type File struct {
 	WarmIndexInFlight bool `json:"warm_index_in_flight,omitempty"`
 	WarmPendingAlgo   int  `json:"warm_pending_algo,omitempty"`
 	WarmPendingLinks  int  `json:"warm_pending_links,omitempty"`
+
+	// --- Process metrics (wizard CPU/RAM readout) ---
+	// These are only meaningful on the ENGINE-LIVENESS sidecar (same scope as
+	// the Engine-global fields above): RSS/CPU are per-PROCESS, not per-repo,
+	// so a per-repo status file never sets them. Populated by whichever
+	// process actually runs the index — the standalone `grafel engine` child
+	// in split mode (the DEFAULT), or the monolith daemon process itself when
+	// split mode is disabled — from its OWN process stats
+	// (internal/process.RSSBytes / CPUPercent) on every heartbeat write. A
+	// reader (e.g. the wizard's index-progress TUI) uses these to show a live
+	// "CPU / RAM" readout during a long enrichment phase so the overall
+	// progress bar sitting near 100% doesn't look stuck. Both are
+	// best-effort: a platform/measurement failure leaves them at zero, and a
+	// tolerant reader must omit the readout entirely rather than render a
+	// misleading "0%" / "0.0 GB".
+
+	// RSSMB is the writing process's resident-set size in megabytes.
+	RSSMB int64 `json:"rss_mb,omitempty"`
+	// CPUPct is the writing process's instantaneous CPU percent (per
+	// internal/process.CPUPercent — can exceed 100% on a multi-threaded
+	// process using more than one core, matching `ps`/Activity Monitor
+	// convention). Best-effort: 0 when unavailable (e.g. no platform
+	// implementation) — a reader must not treat 0 as "idle", only as
+	// "unknown", and should omit the CPU portion of the readout when zero.
+	CPUPct float64 `json:"cpu_pct,omitempty"`
 }
 
 // statusSubdir is the directory name under GRAFEL_HOME holding one file per

--- a/internal/statusfile/statusfile_metrics_test.go
+++ b/internal/statusfile/statusfile_metrics_test.go
@@ -1,0 +1,61 @@
+package statusfile_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// TestWriteRead_RSSAndCPURoundtrip is the RED test for the wizard CPU/RAM
+// readout (engine-liveness sidecar): RSSMB and CPUPct must round-trip through
+// Write/Read unchanged so the wizard TUI's periodic metrics reader can surface
+// them without any daemon RPC.
+func TestWriteRead_RSSAndCPURoundtrip(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repo := "/some/engine-liveness/key"
+	want := &statusfile.File{
+		EnginePID: 4242,
+		RepoPath:  repo,
+		RSSMB:     2355,
+		CPUPct:    412.5,
+	}
+
+	if err := statusfile.Write(repo, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.RSSMB != want.RSSMB {
+		t.Errorf("RSSMB = %d, want %d", got.RSSMB, want.RSSMB)
+	}
+	if got.CPUPct != want.CPUPct {
+		t.Errorf("CPUPct = %v, want %v", got.CPUPct, want.CPUPct)
+	}
+}
+
+// TestWriteRead_RSSAndCPUOmittedWhenZero asserts a status file written by an
+// older engine (or one that failed to sample process metrics) round-trips
+// RSSMB/CPUPct as zero, not an error — the field is omitempty so an old file
+// on disk simply lacks the key, and Read must tolerate that transparently.
+func TestWriteRead_RSSAndCPUOmittedWhenZero(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repo := "/some/other/repo"
+	want := &statusfile.File{EnginePID: 1, RepoPath: repo}
+
+	if err := statusfile.Write(repo, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.RSSMB != 0 || got.CPUPct != 0 {
+		t.Errorf("RSSMB/CPUPct = %d/%v, want 0/0", got.RSSMB, got.CPUPct)
+	}
+}


### PR DESCRIPTION
Shows the engine's live RSS (+ CPU%) next to the wizard's main progress bar (e.g. `... 26%  · CPU 412% · 2.3 GB`) — reassures the user work is ongoing during long/enrichment phases. Engine stamps its own process RSS/CPU into the engine-liveness status plane; wizard polls it (1.5s) and renders. Additive only — the split-mode completion/progress logic is untouched (verified: wizard_split_progress.go diff empty). Degrades cleanly (RSS<=0 → omitted; CPU<=0 → RAM-only; missing/stale liveness → omitted, never blocks the TUI). CPU% is a proper cross-platform delta (new process.CPUTimeSeconds + stateful sampler; correct on macOS + Linux, >100% intended for multi-core). Independent review APPROVE after the Linux-CPU% fix. Follow-up DX; does not gate v0.1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)