### PR TITLE
perf(rebuild): route wizard/rebuild first-index through the subprocess-indexer (fast, flat daemon heap, per-module bars preserved)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1233,6 +1233,36 @@ func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWo
 	return results
 }
 
+// rebuildSubprocessParams carries the per-repo inputs the subprocess rebuild
+// path forwards to the `grafel index-internal` child.
+type rebuildSubprocessParams struct {
+	RepoPath            string
+	RepoSlug            string
+	GroupSlug           string
+	ProgressPub         progress.Publisher
+	Interactive         bool
+	IncrementalStateDir string
+}
+
+// runRebuildSubprocess indexes one repo for a rebuild via the subprocess indexer
+// (`grafel index-internal` child), republishing the child's per-module progress
+// into p.ProgressPub. It is a package var so a test can stub the child spawn
+// without exec'ing a real binary; production points it at the sched runner.
+//
+// Unlike the scheduler's reactive reindex it passes NO --skip-pass, so the
+// rebuild produces the full graph (including the graph-algo pass) exactly as the
+// in-process rebuild path does, and forwards ref="" so the child resolves HEAD
+// via gitmeta just like the in-process indexer.
+var runRebuildSubprocess = func(ctx context.Context, p rebuildSubprocessParams) error {
+	return sched.RunSubprocessIndex(ctx, p.RepoPath, "", nil, &sched.SubprocessIndexOptions{
+		ProgressPub:         p.ProgressPub,
+		GroupSlug:           p.GroupSlug,
+		RepoSlug:            p.RepoSlug,
+		Interactive:         p.Interactive,
+		IncrementalStateDir: p.IncrementalStateDir,
+	}, slog.Default())
+}
+
 // daemonRebuildFuncCore is the testable inner implementation of the rebuild
 // logic. concurrency is supplied by the caller (captured in the closure
 // returned by makeDaemonRebuildFunc, or set directly in tests). indexFn and
@@ -1357,9 +1387,56 @@ func daemonRebuildFuncCore(
 			if args.Wipe {
 				_ = os.RemoveAll(daemon.StateDirForRepo(rw.r.Path))
 			}
-			var opts []IndexOption
+			var incrementalStateDir string
 			if args.Incremental && !args.Wipe {
-				opts = append(opts, WithIncremental(daemon.StateDirForRepo(rw.r.Path)))
+				incrementalStateDir = daemon.StateDirForRepo(rw.r.Path)
+			}
+			// Cross-path mutual exclusion (#5729 concurrency bug): this rebuild
+			// indexes the repo DIRECTLY (in-process OR via the subprocess child)
+			// and never touches the engine scheduler, so the scheduler's per-repo
+			// in-flight guard cannot see it. Without a shared claim, a
+			// scheduler-enqueued reindex of the same repo (e.g. from the
+			// wizard-installed `grafel watch` process, a git-HEAD switch, or a
+			// drained KindReindex request) races this rebuild, both rewriting the
+			// same graph.fb — the runaway re-index the live daemon exhibited.
+			// ClaimForeground takes PRIORITY: the scheduler yields the repo while
+			// we own it; we only block on a background index already mid-write.
+			// Acquired/released INSIDE this index goroutine so the claim tracks the
+			// index's real completion — a rebuild whose outer per-repo timeout
+			// fires but whose goroutine keeps running still holds the claim until
+			// the write finishes, and the release is idempotent (safe alongside the
+			// panic-recovery defer above). Held across BOTH paths so it also spans
+			// the child subprocess lifetime.
+			releaseClaim := repolock.DefaultRegistry.ClaimForeground(rw.r.Path)
+			defer releaseClaim()
+
+			if sched.SubprocessIndexEnabled() {
+				// #5729 follow-up: route the per-repo index through the SAME
+				// short-lived `grafel index-internal` child the scheduler uses, so
+				// the index runs in a fresh near-empty-heap process (no GC
+				// contention with the daemon's resident serving graphs). The child
+				// republishes per-module progress over stdout into progressPub (so
+				// the wizard bars are preserved), runs at the foreground CPU cap for
+				// human-awaited rebuilds, and a child index_error surfaces here as a
+				// per-repo failure — identical partial-failure semantics to an
+				// in-process error. The PARENT still owns everything around the
+				// index: the repolock claim above, the group-level linksFn, and the
+				// status-before-ack FlushRepoStatusFile. When the toggle is OFF the
+				// in-process path below runs unchanged.
+				indexErr = runRebuildSubprocess(context.Background(), rebuildSubprocessParams{
+					RepoPath:            rw.r.Path,
+					RepoSlug:            rw.r.Slug,
+					GroupSlug:           args.Group,
+					ProgressPub:         progressPub,
+					Interactive:         foreground,
+					IncrementalStateDir: incrementalStateDir,
+				})
+				return
+			}
+
+			var opts []IndexOption
+			if incrementalStateDir != "" {
+				opts = append(opts, WithIncremental(incrementalStateDir))
 			}
 			// Publish granular per-repo progress into the shared broker so the
 			// WebUI Index step renders live rows + file counters (#1531).
@@ -1371,22 +1448,6 @@ func daemonRebuildFuncCore(
 			// the throttled background cap. This appears AFTER indexFn's prepended
 			// default so it is the effective WithInteractive value.
 			opts = append(opts, WithInteractive(foreground))
-			// Cross-path mutual exclusion (#5729 concurrency bug): this rebuild
-			// indexes the repo DIRECTLY and never touches the engine scheduler,
-			// so the scheduler's per-repo in-flight guard cannot see it. Without
-			// a shared claim, a scheduler-enqueued reindex of the same repo (e.g.
-			// from the wizard-installed `grafel watch` process, a git-HEAD switch,
-			// or a drained KindReindex request) races this rebuild, both
-			// rewriting the same graph.fb — the runaway re-index the live daemon
-			// exhibited. ClaimForeground takes PRIORITY: the scheduler yields the
-			// repo while we own it; we only block on a background index already
-			// mid-write. Acquired/released INSIDE this index goroutine so the
-			// claim tracks the index's real completion — a rebuild whose outer
-			// per-repo timeout fires but whose goroutine keeps running still holds
-			// the claim until the write finishes, and the release is idempotent
-			// (safe alongside the panic-recovery defer above).
-			releaseClaim := repolock.DefaultRegistry.ClaimForeground(rw.r.Path)
-			defer releaseClaim()
 			// #1576: tag the graph with the CONFIG slug (not the on-disk
 			// directory basename) so doc.Repo matches the slug the dashboard
 			// keys nodes by and the slug the cross-repo link pass emits as the

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1368,8 +1368,12 @@ func daemonRebuildFuncCore(
 	// indexOne executes the index function for a single repo and returns its
 	// result. It is shared by both the serial and parallel paths so the logic
 	// (panic recovery, wipe, incremental opts, progress slugs, slug tag) stays
-	// in one place.
-	indexOneInner := func(idx int, rw repoWork) repoResult {
+	// in one place. ctx bounds the SUBPROCESS child's lifetime: indexOne cancels
+	// it on the per-repo timeout (and on normal completion), so a wedged child is
+	// killed and the repolock claim released rather than leaking as a live
+	// process. The in-process indexFn takes no context, so its "orphaned
+	// goroutine finishes in the background" semantics are unchanged.
+	indexOneInner := func(ctx context.Context, idx int, rw repoWork) repoResult {
 		t0 := time.Now()
 		var indexErr error
 		func() {
@@ -1423,7 +1427,7 @@ func daemonRebuildFuncCore(
 				// index: the repolock claim above, the group-level linksFn, and the
 				// status-before-ack FlushRepoStatusFile. When the toggle is OFF the
 				// in-process path below runs unchanged.
-				indexErr = runRebuildSubprocess(context.Background(), rebuildSubprocessParams{
+				indexErr = runRebuildSubprocess(ctx, rebuildSubprocessParams{
 					RepoPath:            rw.r.Path,
 					RepoSlug:            rw.r.Slug,
 					GroupSlug:           args.Group,
@@ -1472,18 +1476,29 @@ func daemonRebuildFuncCore(
 	// in the background (matching the existing RPC-timeout semantics) rather
 	// than killed mid-write.
 	indexOne := func(idx int, rw repoWork) repoResult {
+		// Per-repo cancellable context. Cancelling it (on timeout below, or on
+		// normal completion via defer) SIGKILLs a wedged subprocess child so its
+		// parent goroutine unblocks from cmd.Wait and releases the repolock claim
+		// — no process/claim leak. The in-process path ignores ctx.
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		if perRepoTimeout <= 0 {
-			return indexOneInner(idx, rw)
+			return indexOneInner(ctx, idx, rw)
 		}
 		t0 := time.Now()
 		done := make(chan repoResult, 1)
-		go func() { done <- indexOneInner(idx, rw) }()
+		go func() { done <- indexOneInner(ctx, idx, rw) }()
 		timer := time.NewTimer(perRepoTimeout)
 		defer timer.Stop()
 		select {
 		case res := <-done:
 			return res
 		case <-timer.C:
+			// Cancel the child so it is killed now and the goroutine + claim are
+			// reclaimed promptly (defer cancel() also covers this, but doing it
+			// explicitly documents intent). The in-process path's goroutine still
+			// finishes in the background — ctx cancellation is a no-op for it.
+			cancel()
 			fmt.Fprintf(os.Stderr,
 				"grafel: rebuild %s STALLED — no result after %s; surfacing as timeout and continuing with remaining repos (group=%s)\n",
 				rw.r.Slug, perRepoTimeout, args.Group)

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1036,7 +1036,7 @@ func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) erro
 	var err error
 	if sched.SubprocessIndexEnabled() {
 		// S5 path: fork-exec `grafel index-internal` for memory isolation.
-		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, slog.Default())
+		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, nil, slog.Default())
 	} else {
 		// In-process path (opt-out via GRAFEL_SUBPROCESS_INDEXER=0).
 		// ADR-0016 flip-day (#808): graph.fb is always written by default now.

--- a/cmd/grafel/daemon_parallel_test.go
+++ b/cmd/grafel/daemon_parallel_test.go
@@ -19,6 +19,7 @@ func TestDaemonRebuildParallel(t *testing.T) {
 	if testing.Short() {
 		t.Skip("parallel-rebuild timing test skipped in short mode")
 	}
+	forceInProcessRebuild(t)
 
 	// Build a temporary registry with a synthetic group containing 4 repos.
 	tmpHome := t.TempDir()
@@ -121,6 +122,7 @@ func TestDaemonRebuildParallel(t *testing.T) {
 // TestDaemonRebuildSerial verifies the serial path (concurrency=1)
 // indexes all repos without error and produces one result per repo.
 func TestDaemonRebuildSerial(t *testing.T) {
+	forceInProcessRebuild(t)
 	tmpHome := t.TempDir()
 	t.Setenv("GRAFEL_HOME", tmpHome)
 
@@ -159,6 +161,7 @@ func TestDaemonRebuildSerial(t *testing.T) {
 // TestDaemonRebuildFailureIsolation confirms that a failing repo does not
 // prevent other repos in the group from completing.
 func TestDaemonRebuildFailureIsolation(t *testing.T) {
+	forceInProcessRebuild(t)
 	tmpHome := t.TempDir()
 	t.Setenv("GRAFEL_HOME", tmpHome)
 

--- a/cmd/grafel/daemon_rebuild_sched_mutex_test.go
+++ b/cmd/grafel/daemon_rebuild_sched_mutex_test.go
@@ -54,6 +54,11 @@ func setupSingleRepoGroup(t *testing.T, groupName, slug string) (group, repoPath
 }
 
 func TestRebuildAndSchedulerDoNotIndexSameRepoConcurrently(t *testing.T) {
+	// This test observes the rebuild⇄scheduler repolock serialisation through a
+	// mock indexFn, so it must run the in-process rebuild path (with the toggle
+	// ON the rebuild would fork a child and never call the mock). The repolock
+	// claim it guards is held across BOTH paths, so the invariant is unchanged.
+	forceInProcessRebuild(t)
 	group, repoPath := setupSingleRepoGroup(t, "mutex-group", "only")
 
 	const hold = 250 * time.Millisecond

--- a/cmd/grafel/daemon_rebuild_subprocess_test.go
+++ b/cmd/grafel/daemon_rebuild_subprocess_test.go
@@ -1,0 +1,220 @@
+package main
+
+// daemon_rebuild_subprocess_test.go — #5729 follow-up: the rebuild path routes
+// per-repo indexing through the subprocess indexer when the toggle is ON, WHILE
+// preserving the wizard's per-module progress bars, the status-before-ack flush,
+// the group-level link pass, and the repolock claim.
+//
+// The child spawn (runRebuildSubprocess) is stubbed so the test does not exec a
+// real binary (in a `go test` process os.Executable is the test binary, not
+// grafel). The cross-process IPC fidelity itself is covered byte-faithfully by
+// the sched package's round-trip test; here we assert the daemon-side WIRING:
+// the reroute is taken, the child receives the right params, its republished
+// progress reaches the split-mode sidecar bridge, and the parent still owns the
+// completion/ack path.
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// errChildIndex simulates a child index_error propagated by RunSubprocessIndex.
+var errChildIndex = errors.New("index bad: child exit: extractor failed")
+
+// failIfCalledIndexFn is an in-process indexFn that fails the test if invoked —
+// the subprocess reroute must never fall through to it.
+func failIfCalledIndexFn(t *testing.T) func(string, string, string, []string, bool, bool, ...IndexOption) error {
+	return func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		t.Errorf("in-process indexFn must not be called on the subprocess reroute")
+		return nil
+	}
+}
+
+// stubChildSpawn replaces runRebuildSubprocess for the duration of a test,
+// recording the params it was called with and simulating the child: it
+// republishes two per-module progress events into the parent's publisher and
+// writes a graph.fb so the status flush observes a fresh mtime. Restored on
+// cleanup.
+func stubChildSpawn(t *testing.T) *[]rebuildSubprocessParams {
+	t.Helper()
+	orig := runRebuildSubprocess
+	t.Cleanup(func() { runRebuildSubprocess = orig })
+
+	var mu sync.Mutex
+	calls := &[]rebuildSubprocessParams{}
+	runRebuildSubprocess = func(_ context.Context, p rebuildSubprocessParams) error {
+		mu.Lock()
+		*calls = append(*calls, p)
+		mu.Unlock()
+		// Simulate the child republishing per-module progress over stdout — the
+		// parent handed us its real progressPub (broker / split-mode tee).
+		if p.ProgressPub != nil {
+			now := time.Now().UnixMilli()
+			p.ProgressPub.Publish(progress.Event{
+				GroupSlug: p.GroupSlug, RepoSlug: p.RepoSlug, Module: "mod-a",
+				Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 2, TS: now,
+			})
+			p.ProgressPub.Publish(progress.Event{
+				GroupSlug: p.GroupSlug, RepoSlug: p.RepoSlug, Module: "mod-b",
+				Phase: progress.PhaseExtractAST, FilesDone: 2, FilesTotal: 2, TS: now,
+			})
+		}
+		// Simulate the child writing graph.fb so FlushRepoStatusFile sees a fresh
+		// mtime, as a real index-internal child would.
+		writeStubGraphFB(t, p.RepoPath)
+		return nil
+	}
+	return calls
+}
+
+func writeStubGraphFB(t *testing.T, repoPath string) {
+	t.Helper()
+	sd := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(sd, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	if err := os.WriteFile(sd+"/graph.fb", []byte("fb"), 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// TestRebuild_SubprocessReroute_RepublishesProgressAndCompletes drives the whole
+// rebuild through the subprocess path (toggle ON) in split mode and asserts:
+//   - the child is invoked once per repo with the correct slugs + interactive flag
+//   - the child's per-module progress reaches the split-mode sidecar bridge
+//   - each repo's status is flushed fresh (Indexing=false) before return
+//   - the group-level link pass runs exactly once
+//   - the in-process indexFn is NEVER called (the reroute bypasses it)
+func TestRebuild_SubprocessReroute_RepublishesProgressAndCompletes(t *testing.T) {
+	t.Setenv(daemon.SplitModeEnvVar, "1") // split ON so the sidecar bridge exists
+	group := setupTestGroup(t, "subproc-group", []string{"r1", "r2"})
+	forceSubprocessRebuild(t) // override setupTestGroup's in-process pin
+
+	calls := stubChildSpawn(t)
+
+	var indexFnCalls int32
+	inProcessIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		atomic.AddInt32(&indexFnCalls, 1)
+		return nil
+	}
+	var linkCalls int32
+	linksFn := func(_ string) error { atomic.AddInt32(&linkCalls, 1); return nil }
+
+	rebuilt, warning, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, inProcessIndexFn, linksFn)
+	if err != nil {
+		t.Fatalf("rebuild: %v (warning=%q)", err, warning)
+	}
+	if len(rebuilt) != 2 {
+		t.Fatalf("rebuilt %d repos, want 2", len(rebuilt))
+	}
+	if got := atomic.LoadInt32(&indexFnCalls); got != 0 {
+		t.Errorf("in-process indexFn called %d times; the subprocess reroute must bypass it", got)
+	}
+	if got := atomic.LoadInt32(&linkCalls); got != 1 {
+		t.Errorf("linksFn ran %d times, want exactly 1 (group-level, after all repos)", got)
+	}
+
+	// Child invoked once per repo, with the rebuild's slugs + interactive flag and
+	// a live publisher.
+	if len(*calls) != 2 {
+		t.Fatalf("child spawned %d times, want 2", len(*calls))
+	}
+	for _, c := range *calls {
+		if c.GroupSlug != group {
+			t.Errorf("child GroupSlug = %q, want %q", c.GroupSlug, group)
+		}
+		if c.RepoSlug != "r1" && c.RepoSlug != "r2" {
+			t.Errorf("child RepoSlug = %q, want r1|r2", c.RepoSlug)
+		}
+		if !c.Interactive {
+			t.Errorf("child Interactive = false; a human-awaited rebuild must forward the foreground cap")
+		}
+		if c.ProgressPub == nil {
+			t.Errorf("child ProgressPub is nil; per-module bars would be lost")
+		}
+	}
+
+	// The child's republished per-module progress must reach the split-mode
+	// sidecar (the wizard's SSE bridge).
+	r, err := progress.NewSidecarReader(group)
+	if err != nil {
+		t.Fatalf("sidecar reader: %v", err)
+	}
+	events, err := r.ReadAll()
+	if err != nil {
+		t.Fatalf("sidecar readall: %v", err)
+	}
+	sawModA, sawModB := false, false
+	for _, e := range events {
+		if e.Module == "mod-a" {
+			sawModA = true
+		}
+		if e.Module == "mod-b" {
+			sawModB = true
+		}
+	}
+	if !sawModA || !sawModB {
+		t.Errorf("per-module republished progress missing from sidecar (mod-a=%v mod-b=%v); events=%+v",
+			sawModA, sawModB, events)
+	}
+
+	// Status flushed fresh before return (status-before-ack), for each repo.
+	for _, rp := range rebuilt {
+		f, ok := daemon.RepoStatusFile(rp)
+		if !ok || f == nil {
+			t.Fatalf("no status file flushed for %s (drain would ack before any status write)", rp)
+		}
+		if f.GraphFBMtime <= 0 {
+			t.Errorf("%s: GraphFBMtime = %d, want fresh (>0) before return", rp, f.GraphFBMtime)
+		}
+		if f.Indexing {
+			t.Errorf("%s: Indexing = true, want false after completion", rp)
+		}
+	}
+}
+
+// TestRebuild_SubprocessReroute_ChildErrorIsPerRepoFailure verifies a child
+// index_error surfaces as that repo's failure with the same partial-failure
+// semantics as an in-process error: the group returns an error naming the repo,
+// the healthy repo is still rebuilt, and successful repos' status is flushed.
+func TestRebuild_SubprocessReroute_ChildErrorIsPerRepoFailure(t *testing.T) {
+	group := setupTestGroup(t, "subproc-fail-group", []string{"good", "bad"})
+	forceSubprocessRebuild(t)
+
+	orig := runRebuildSubprocess
+	t.Cleanup(func() { runRebuildSubprocess = orig })
+	runRebuildSubprocess = func(_ context.Context, p rebuildSubprocessParams) error {
+		if p.RepoSlug == "bad" {
+			return errChildIndex
+		}
+		writeStubGraphFB(t, p.RepoPath)
+		return nil
+	}
+
+	rebuilt, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, failIfCalledIndexFn(t), noopLinksFn)
+	if err == nil {
+		t.Fatal("expected an error because one child failed, got nil")
+	}
+	if !contains(err.Error(), "bad") {
+		t.Errorf("error %q should name the failed repo 'bad'", err.Error())
+	}
+	if len(rebuilt) != 1 || rebuilt[0] == "" {
+		t.Fatalf("partial rebuilt = %v, want exactly the healthy repo", rebuilt)
+	}
+	// The healthy repo's status must still be flushed on the error-return path.
+	f, ok := daemon.RepoStatusFile(rebuilt[0])
+	if !ok || f == nil || f.GraphFBMtime <= 0 {
+		t.Errorf("healthy repo status not flushed before the (partial-failure) return")
+	}
+}

--- a/cmd/grafel/daemon_rebuild_subprocess_test.go
+++ b/cmd/grafel/daemon_rebuild_subprocess_test.go
@@ -183,6 +183,59 @@ func TestRebuild_SubprocessReroute_RepublishesProgressAndCompletes(t *testing.T)
 	}
 }
 
+// TestRebuild_SubprocessReroute_TimeoutCancelsChild is the leak guard: a child
+// that would outlive the per-repo deadline must be cancelled (its ctx killed) so
+// the parent goroutine unblocks and the repolock claim releases, instead of
+// leaking a live subprocess with the parent stuck in Wait. The stub stands in
+// for a wedged child that only returns when its ctx is cancelled — proving the
+// reroute threads a cancellable, timeout-bounded ctx into the child (not
+// context.Background()).
+func TestRebuild_SubprocessReroute_TimeoutCancelsChild(t *testing.T) {
+	group := setupTestGroup(t, "subproc-timeout-group", []string{"wedged"})
+	forceSubprocessRebuild(t)
+	t.Setenv("GRAFEL_REBUILD_REPO_TIMEOUT", "100ms") // tiny per-repo deadline
+
+	orig := runRebuildSubprocess
+	t.Cleanup(func() { runRebuildSubprocess = orig })
+
+	childReturned := make(chan struct{})
+	var sawCancel bool
+	runRebuildSubprocess = func(ctx context.Context, _ rebuildSubprocessParams) error {
+		<-ctx.Done() // a wedged child: only unblocks when the ctx is cancelled/killed
+		sawCancel = ctx.Err() != nil
+		close(childReturned)
+		return ctx.Err()
+	}
+
+	// The rebuild must return promptly (bounded by the 100ms per-repo timeout),
+	// never blocking on the wedged child.
+	rebuildDone := make(chan error, 1)
+	go func() {
+		_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group, Interactive: true}, failIfCalledIndexFn(t), noopLinksFn)
+		rebuildDone <- err
+	}()
+
+	select {
+	case err := <-rebuildDone:
+		if err == nil || !contains(err.Error(), "wedged") || !contains(err.Error(), "timed out") {
+			t.Fatalf("expected a timeout error naming the wedged repo, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("rebuild did not return — the wedged child was not cancelled on timeout (leak)")
+	}
+
+	// The child goroutine must have been released via ctx cancellation (not left
+	// leaked): its ctx was cancelled and it returned.
+	select {
+	case <-childReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("child goroutine never returned — ctx was not cancelled (process/claim leak)")
+	}
+	if !sawCancel {
+		t.Error("child observed ctx.Err()==nil; the reroute must pass a cancellable ctx, not context.Background()")
+	}
+}
+
 // TestRebuild_SubprocessReroute_ChildErrorIsPerRepoFailure verifies a child
 // index_error surfaces as that repo's failure with the same partial-failure
 // semantics as an in-process error: the group returns an error naming the repo,

--- a/cmd/grafel/daemon_rebuild_test.go
+++ b/cmd/grafel/daemon_rebuild_test.go
@@ -19,14 +19,38 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
+// forceInProcessRebuild pins the rebuild path to the in-process indexFn for the
+// duration of a test by turning the subprocess-indexer toggle OFF (restored on
+// cleanup). The rebuild-iteration tests (panic recovery, semaphore cap, per-repo
+// timeout, status flush, sidecar) inject a mock indexFn and assert it runs, so
+// they must exercise the flag-OFF in-process path; with the toggle ON the
+// rebuild would fork a real `index-internal` child and never call the mock.
+func forceInProcessRebuild(t *testing.T) {
+	t.Helper()
+	prev := sched.SetSubprocessIndexEnabled(false)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prev) })
+}
+
+// forceSubprocessRebuild pins the rebuild path to the subprocess reroute (toggle
+// ON), for the test that exercises the reroute wiring. Restored on cleanup.
+func forceSubprocessRebuild(t *testing.T) {
+	t.Helper()
+	prev := sched.SetSubprocessIndexEnabled(true)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prev) })
+}
+
 // setupTestGroup creates a temporary GRAFEL_HOME, registers a group with
 // n repos whose paths are subdirectories of repoBase, and returns the group
-// name. t.Cleanup removes everything.
+// name. t.Cleanup removes everything. It also pins the rebuild to the in-process
+// path (forceInProcessRebuild) since every caller injects a mock indexFn; the
+// one subprocess-reroute test re-enables the toggle explicitly.
 func setupTestGroup(t *testing.T, groupName string, slugs []string) string {
 	t.Helper()
+	forceInProcessRebuild(t)
 	tmpHome := t.TempDir()
 	t.Setenv("GRAFEL_HOME", tmpHome)
 	repoBase := t.TempDir()

--- a/cmd/grafel/index_internal.go
+++ b/cmd/grafel/index_internal.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 )
 
 // runIndexInternal is the entrypoint for the hidden `grafel index --internal`
@@ -28,13 +30,17 @@ func runIndexInternal(argv []string) int {
 	fs.SetOutput(os.Stderr)
 
 	var (
-		repo       = fs.String("repo", "", "absolute path of the repository to index (required)")
-		ref        = fs.String("ref", "", "git ref captured at enqueue time; passed as hint only (may be empty)")
-		out        = fs.String("out", "", "output directory for graph.fb; defaults to daemon store layout")
-		repoTag    = fs.String("repo-tag", "", "slug written into every graph entity (defaults to dir basename)")
-		skipPasses = fs.String("skip-pass", "", "comma-separated list of pass names to skip")
-		exportJSON = fs.Bool("export-json", false, "also emit graph.json alongside graph.fb")
-		ingestDocs = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md and *.pdf files as Document/Section nodes + exact-mention links (no LLM, no network)")
+		repo         = fs.String("repo", "", "absolute path of the repository to index (required)")
+		ref          = fs.String("ref", "", "git ref captured at enqueue time; passed as hint only (may be empty)")
+		out          = fs.String("out", "", "output directory for graph.fb; defaults to daemon store layout")
+		repoTag      = fs.String("repo-tag", "", "slug written into every graph entity (defaults to dir basename)")
+		skipPasses   = fs.String("skip-pass", "", "comma-separated list of pass names to skip")
+		exportJSON   = fs.Bool("export-json", false, "also emit graph.json alongside graph.fb")
+		ingestDocs   = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md and *.pdf files as Document/Section nodes + exact-mention links (no LLM, no network)")
+		emitProgress = fs.Bool("emit-progress", false, "stream per-module progress.Event JSON lines on stdout for the parent to republish (rebuild / wizard first-index)")
+		groupSlug    = fs.String("group-slug", "", "group slug stamped on progress events when --emit-progress is set")
+		interactive  = fs.Bool("interactive", false, "run at the foreground GRAFEL_REBUILD_GOMAXPROCS extract cap (human-awaited rebuild) instead of the background cap")
+		incremental  = fs.String("incremental", "", "state dir enabling diff-aware re-indexing (matches WithIncremental); empty = full index")
 	)
 
 	if err := fs.Parse(argv); err != nil {
@@ -63,6 +69,28 @@ func runIndexInternal(argv []string) int {
 	opts := []IndexOption{
 		WithExportJSON(*exportJSON),
 		WithIngestDocs(*ingestDocs),
+	}
+	// Rebuild / wizard first-index (#5729 follow-up): stream per-module progress
+	// on stdout so the parent RunSubprocessIndex can republish it into the
+	// rebuild's broker / split-mode sidecar. The publisher marshals each
+	// progress.Event verbatim; WithProgressSlugs stamps the group/repo identity so
+	// republished rows key the SAME (group, repo, module) the in-process path uses
+	// (repoSlug == --repo-tag, mirroring the in-process WithProgressSlugs(group,
+	// slug) where repoTag is also the slug).
+	if *emitProgress {
+		opts = append(opts,
+			WithPublisher(sched.NewStdoutProgressPublisher(os.Stdout)),
+			WithProgressSlugs(*groupSlug, *repoTag))
+	}
+	// Foreground rebuild: run the extract sub-subprocesses at the higher
+	// GRAFEL_REBUILD_GOMAXPROCS cap. Background reactive reindexes leave this off
+	// and stay at the throttled GRAFEL_EXTRACT_GOMAXPROCS default.
+	if *interactive {
+		opts = append(opts, WithInteractive(true))
+	}
+	// Diff-aware re-indexing when the rebuild path requested it.
+	if *incremental != "" {
+		opts = append(opts, WithIncremental(*incremental))
 	}
 
 	// Emit a JSON start line so the daemon IPC reader can log the start event

--- a/internal/daemon/sched/subprocess_gomaxprocs_test.go
+++ b/internal/daemon/sched/subprocess_gomaxprocs_test.go
@@ -1,0 +1,78 @@
+package sched
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestForegroundReindexGOMAXPROCS verifies the foreground cap resolver honours
+// GRAFEL_REBUILD_GOMAXPROCS and otherwise defaults to the host core count (the
+// human is waiting, so the first index runs at host speed).
+func TestForegroundReindexGOMAXPROCS(t *testing.T) {
+	t.Run("env override", func(t *testing.T) {
+		t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "7")
+		if got := ForegroundReindexGOMAXPROCS(); got != 7 {
+			t.Errorf("ForegroundReindexGOMAXPROCS() = %d, want 7", got)
+		}
+	})
+	t.Run("default host cores", func(t *testing.T) {
+		t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+		want := runtime.NumCPU()
+		if want < 1 {
+			want = 1
+		}
+		if got := ForegroundReindexGOMAXPROCS(); got != want {
+			t.Errorf("ForegroundReindexGOMAXPROCS() = %d, want %d (host cores)", got, want)
+		}
+	})
+	t.Run("invalid falls back to default", func(t *testing.T) {
+		t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "0")
+		want := runtime.NumCPU()
+		if want < 1 {
+			want = 1
+		}
+		if got := ForegroundReindexGOMAXPROCS(); got != want {
+			t.Errorf("ForegroundReindexGOMAXPROCS() = %d, want %d", got, want)
+		}
+	})
+}
+
+// TestResolveChildGOMAXPROCS_Interactive verifies a human-awaited rebuild runs
+// its child at the FOREGROUND cap, not the throttled background reindex budget —
+// the fix so a first-index through the subprocess path is not slower than the
+// old in-process rebuild.
+func TestResolveChildGOMAXPROCS_Interactive(t *testing.T) {
+	// Explicit cap wins verbatim.
+	if n, _ := resolveChildGOMAXPROCS(true, 5); n != 5 {
+		t.Errorf("interactive explicit cap: got %d, want 5", n)
+	}
+	// Unset explicit cap → resolve GRAFEL_REBUILD_GOMAXPROCS.
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "9")
+	if n, _ := resolveChildGOMAXPROCS(true, 0); n != 9 {
+		t.Errorf("interactive default cap: got %d, want 9 (foreground cap)", n)
+	}
+}
+
+// TestResolveChildGOMAXPROCS_BackgroundUnchanged verifies the scheduler
+// (non-interactive) path is byte-identical to before: with no foreground index
+// active it uses the daemon-wide reindex budget, and while a foreground index is
+// active it yields.
+func TestResolveChildGOMAXPROCS_BackgroundUnchanged(t *testing.T) {
+	t.Run("no foreground active → reindex budget", func(t *testing.T) {
+		indexstate.SetIndexConcurrency(0, 0, 2, 0) // foregroundActive=0
+		want := ReindexGraphPhaseGOMAXPROCS()
+		if n, _ := resolveChildGOMAXPROCS(false, 0); n != want {
+			t.Errorf("background (no fg): got %d, want %d (daemon-wide reindex budget)", n, want)
+		}
+	})
+	t.Run("foreground active → yield", func(t *testing.T) {
+		indexstate.SetIndexConcurrency(1, 0, 2, 1) // foregroundActive=1
+		t.Cleanup(func() { indexstate.SetIndexConcurrency(0, 0, 2, 0) })
+		want := BackgroundYieldGOMAXPROCS()
+		if n, _ := resolveChildGOMAXPROCS(false, 0); n != want {
+			t.Errorf("background (fg active): got %d, want %d (yield)", n, want)
+		}
+	})
+}

--- a/internal/daemon/sched/subprocess_ipc.go
+++ b/internal/daemon/sched/subprocess_ipc.go
@@ -118,6 +118,21 @@ func parseSubprocessStdout(r io.Reader, progressPub progress.Publisher, pid int,
 			logger.Info("subprocess-indexer: event", "event", last.Event, "repo", last.Repo, "ref", last.Ref)
 		}
 	}
+	// CRITICAL (hang guard): a Scanner error — most importantly bufio.ErrTooLong
+	// for a single line above the 1 MiB cap — makes Scan() return false EARLY,
+	// while the child is still writing. If the drain goroutine returned here the
+	// child would block on its full stdout pipe and cmd.Wait() would hang forever
+	// — the exact failure class the subprocess indexer exists to kill. So on a
+	// scanner error we surface it (never silently swallowed) and then keep
+	// draining the pipe to EOF with io.Copy(io.Discard): a pathological oversized
+	// line degrades to dropped progress, not a deadlock.
+	if err := sc.Err(); err != nil {
+		if logger != nil {
+			logger.Warn("subprocess-indexer: stdout scan aborted; draining remainder to avoid child stall",
+				"err", err, "pid", pid)
+		}
+		_, _ = io.Copy(io.Discard, r)
+	}
 	return last
 }
 

--- a/internal/daemon/sched/subprocess_ipc.go
+++ b/internal/daemon/sched/subprocess_ipc.go
@@ -1,0 +1,157 @@
+package sched
+
+// Per-module progress over the subprocess-indexer stdout IPC (#5729 follow-up).
+//
+// The reindex/rebuild child (`grafel index-internal`) already streams three
+// coarse lifecycle lines on stdout — index_start / index_done / index_error —
+// which the parent (RunSubprocessIndex) drains for logging and exit-status. That
+// is enough for a background reactive reindex, but the human-awaited rebuild /
+// wizard first-index needs the SAME per-module progress bars the in-process path
+// produces (one row per package, live file counters, phase transitions).
+//
+// This file adds a second, tagged stdout line type that carries a full
+// progress.Event verbatim so the parent can REPUBLISH it into the rebuild's own
+// progress.Publisher (the broker / split-mode sidecar tee). The wire shape is
+// progress.Event itself (it already has json tags) — we do NOT invent a new
+// schema and we do NOT go through the lossy SidecarLine projection, so every
+// Event field survives the process boundary byte-faithfully.
+//
+//	child  Indexer --WithPublisher--> StdoutProgressPublisher --stdout--> parent
+//	parent parseSubprocessStdout --republish--> progressPub (broker / sidecar)
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// progressIPCTag is the discriminator value on the "t" field of a stdout IPC
+// line that carries a republished progress.Event. Lifecycle lines
+// (index_start / index_done / index_error) have no "t" field, so the parent can
+// tell the two line types apart with a single field probe.
+const progressIPCTag = "progress"
+
+// progressIPCLine is one stdout IPC line carrying a per-module progress.Event
+// from the index-internal child to its parent RunSubprocessIndex. The full
+// Event is nested under "ev" so all of its fields (module, file counters, phase,
+// bytes, current file, …) round-trip with zero loss.
+type progressIPCLine struct {
+	T  string         `json:"t"`
+	Ev progress.Event `json:"ev"`
+}
+
+// StdoutProgressPublisher is the progress.Publisher the index-internal child
+// wires via WithPublisher when the parent asked for live progress
+// (SubprocessIndexOptions.ProgressPub != nil). Each published Event is marshalled
+// to a tagged JSON line and written to w (the child's os.Stdout). Writes are
+// serialised under a mutex so concurrent extraction-worker Publish calls never
+// interleave a partial line on the shared pipe.
+type StdoutProgressPublisher struct {
+	mu sync.Mutex
+	w  io.Writer
+}
+
+// NewStdoutProgressPublisher returns a publisher that streams progress events to
+// w as tagged newline-delimited JSON. w is typically os.Stdout in the child.
+func NewStdoutProgressPublisher(w io.Writer) *StdoutProgressPublisher {
+	return &StdoutProgressPublisher{w: w}
+}
+
+// Publish marshals e to a tagged IPC line and writes it atomically. A marshal
+// failure drops the single event (progress is advisory — never fail the index
+// over a dropped tick). Never blocks the extraction hot loop beyond the single
+// serialised Write.
+func (p *StdoutProgressPublisher) Publish(e progress.Event) {
+	b, err := json.Marshal(progressIPCLine{T: progressIPCTag, Ev: e})
+	if err != nil {
+		return
+	}
+	b = append(b, '\n')
+	p.mu.Lock()
+	_, _ = p.w.Write(b)
+	p.mu.Unlock()
+}
+
+// parseSubprocessStdout drains the child's stdout, republishing every tagged
+// progress line into progressPub (when non-nil) and returning the LAST lifecycle
+// event seen (index_start / index_done / index_error) so the caller can classify
+// the child's exit. Non-JSON lines and unrecognised shapes are ignored. It reads
+// until r hits EOF (the child closes stdout on exit), mirroring the previous
+// inline scanner.
+func parseSubprocessStdout(r io.Reader, progressPub progress.Publisher, pid int, logger *slog.Logger) ipcEvent {
+	var last ipcEvent
+	sc := bufio.NewScanner(r)
+	// A progress line for a deep monorepo path can exceed bufio's 64 KiB default
+	// token cap; raise the ceiling so a long CurrentFile never truncates a line
+	// into unparseable halves (which would drop that tick).
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	for sc.Scan() {
+		var line struct {
+			T     string          `json:"t"`
+			Event string          `json:"event"`
+			Repo  string          `json:"repo"`
+			Ref   string          `json:"ref"`
+			Error string          `json:"error"`
+			Ev    json.RawMessage `json:"ev"`
+		}
+		if err := json.Unmarshal(sc.Bytes(), &line); err != nil {
+			continue // not a JSON line (e.g. stray child output) — ignore
+		}
+		if line.T == progressIPCTag {
+			if progressPub != nil && len(line.Ev) > 0 {
+				var ev progress.Event
+				if json.Unmarshal(line.Ev, &ev) == nil {
+					progressPub.Publish(ev)
+				}
+			}
+			continue
+		}
+		if line.Event == "" {
+			continue // neither a progress line nor a lifecycle line
+		}
+		last = ipcEvent{Event: line.Event, Repo: line.Repo, Ref: line.Ref, Error: line.Error}
+		if logger != nil {
+			logger.Info("subprocess-indexer: event", "event", last.Event, "repo", last.Repo, "ref", last.Ref)
+		}
+	}
+	return last
+}
+
+// SubprocessIndexOptions carries the extra parameters a human-awaited rebuild /
+// wizard first-index needs from RunSubprocessIndex, over and above the coarse
+// background reindex the scheduler drives. All fields are optional; the nil
+// *SubprocessIndexOptions (the scheduler path) preserves the exact prior
+// behaviour byte-for-byte.
+type SubprocessIndexOptions struct {
+	// ProgressPub, when non-nil, receives every per-module progress.Event the
+	// child republishes over stdout. The child only STREAMS progress when this
+	// is set (the parent passes --emit-progress), so a background reindex never
+	// pays the IPC cost. nil → progress lines are simply never emitted.
+	ProgressPub progress.Publisher
+
+	// GroupSlug / RepoSlug stamp the child's progress Tracker (WithProgressSlugs)
+	// so republished events key the SAME (group, repo, module) rows the
+	// in-process rebuild path emits. RepoSlug is also forwarded as the child's
+	// --repo-tag so graph entities carry the config slug (not the dir basename).
+	GroupSlug string
+	RepoSlug  string
+
+	// Interactive marks a human-awaited foreground rebuild: the child runs its
+	// extract sub-subprocesses at the foreground GRAFEL_REBUILD_GOMAXPROCS cap
+	// (--interactive) AND the parent sets the child process GOMAXPROCS to the
+	// foreground cap instead of the throttled background reindex budget, so the
+	// user is not left waiting on a background-throttled first index.
+	Interactive bool
+
+	// ForegroundGOMAXPROCS overrides the child-process GOMAXPROCS when
+	// Interactive is set. 0 → resolve the GRAFEL_REBUILD_GOMAXPROCS default.
+	ForegroundGOMAXPROCS int
+
+	// IncrementalStateDir, when non-empty, enables diff-aware re-indexing in the
+	// child (--incremental=<dir>), matching the in-process WithIncremental path.
+	IncrementalStateDir string
+}

--- a/internal/daemon/sched/subprocess_ipc_test.go
+++ b/internal/daemon/sched/subprocess_ipc_test.go
@@ -2,9 +2,11 @@ package sched
 
 import (
 	"bytes"
+	"log/slog"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/progress"
 )
@@ -84,6 +86,55 @@ func TestParseSubprocessStdout_ErrorEvent(t *testing.T) {
 	last := parseSubprocessStdout(strings.NewReader(stream), nil, 0, nil)
 	if last.Event != "index_error" || last.Error != "boom" {
 		t.Errorf("lastEvent = %+v, want index_error with error=boom", last)
+	}
+}
+
+// TestParseSubprocessStdout_OversizedLineDrainsToEOF is the hang guard: a single
+// stdout line above the 1 MiB scanner cap makes Scan() abort early
+// (bufio.ErrTooLong). The drain MUST NOT return while the child is still
+// writing — it must (a) surface the scanner error (never silently swallowed) and
+// (b) keep consuming the pipe to EOF so the child never blocks on a full stdout
+// pipe (which would wedge cmd.Wait forever). A pathological oversized line
+// degrades to dropped progress, not a deadlock.
+func TestParseSubprocessStdout_OversizedLineDrainsToEOF(t *testing.T) {
+	var stream bytes.Buffer
+	// A valid lifecycle line first.
+	stream.WriteString(`{"event":"index_start","repo":"/r"}` + "\n")
+	// An oversized line (> 1 MiB, no interior newline) → bufio.ErrTooLong.
+	stream.Write(bytes.Repeat([]byte("x"), 1500*1024))
+	stream.WriteByte('\n')
+	// More bytes AFTER the oversized line — these represent the child still
+	// writing. If the drain returned early they would stay unread and the child
+	// would block. The drain must consume them.
+	tail := `{"event":"index_done","repo":"/r"}` + "\n"
+	stream.WriteString(tail)
+
+	r := bytes.NewReader(stream.Bytes())
+
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// Guard against a real hang: run the drain with a hard deadline.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = parseSubprocessStdout(r, nil, 1234, logger)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("parseSubprocessStdout did not return — oversized line caused a hang")
+	}
+
+	// The whole stream was consumed to EOF (no early return leaving the child
+	// blocked): the reader must be fully drained.
+	if r.Len() != 0 {
+		t.Errorf("reader not drained to EOF: %d bytes remain (child would block on a full pipe)", r.Len())
+	}
+	// The scanner error must be surfaced, not swallowed.
+	logged := logBuf.String()
+	if !strings.Contains(logged, "scan aborted") || !strings.Contains(logged, "too long") {
+		t.Errorf("scanner error not surfaced in log; got: %q", logged)
 	}
 }
 

--- a/internal/daemon/sched/subprocess_ipc_test.go
+++ b/internal/daemon/sched/subprocess_ipc_test.go
@@ -1,0 +1,103 @@
+package sched
+
+import (
+	"bytes"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// TestStdoutProgressPublisher_RoundTrip is the make-or-break fidelity test for
+// the wizard bars: a sequence of per-module progress events marshalled by the
+// child's StdoutProgressPublisher must round-trip through parseSubprocessStdout
+// into the parent's publisher byte-faithfully — every Event field preserved,
+// per module.
+func TestStdoutProgressPublisher_RoundTrip(t *testing.T) {
+	in := []progress.Event{
+		{GroupSlug: "g", RepoSlug: "svc", Phase: progress.PhaseExtractAST, Module: "services/auth", FilesDone: 3, FilesTotal: 10, EntitiesSoFar: 42, BytesSeen: 999, CurrentFile: "services/auth/login.go", PhaseStartedAtMS: 111, TS: 1000},
+		{GroupSlug: "g", RepoSlug: "svc", Phase: progress.PhaseExtractAST, Module: "packages/ui", FilesDone: 7, FilesTotal: 7, EntitiesSoFar: 88, CurrentFile: "packages/ui/button.tsx", PhaseStartedAtMS: 222, TS: 1001},
+		{GroupSlug: "g", RepoSlug: "svc", Phase: progress.PhaseComputeCentrality, AlgorithmName: "PageRank", FilesDone: 10, FilesTotal: 10, EntitiesSoFar: 90, TS: 1002},
+		{GroupSlug: "g", RepoSlug: "svc", Phase: progress.PhaseDone, FilesDone: 10, FilesTotal: 10, EntitiesSoFar: 90, TS: 1003},
+	}
+
+	var buf bytes.Buffer
+	pub := NewStdoutProgressPublisher(&buf)
+	for _, e := range in {
+		pub.Publish(e)
+	}
+
+	got := &progress.SliceCollector{}
+	last := parseSubprocessStdout(&buf, got, 0, nil)
+
+	if len(got.Events) != len(in) {
+		t.Fatalf("republished %d events, want %d", len(got.Events), len(in))
+	}
+	for i := range in {
+		if !reflect.DeepEqual(got.Events[i], in[i]) {
+			t.Errorf("event %d not byte-faithful:\n got  %+v\n want %+v", i, got.Events[i], in[i])
+		}
+	}
+	// Progress lines are not lifecycle events — lastEvent stays zero-valued.
+	if last.Event != "" {
+		t.Errorf("lastEvent.Event = %q, want empty (progress lines are not lifecycle events)", last.Event)
+	}
+}
+
+// TestParseSubprocessStdout_MixedStream verifies the parent correctly demuxes a
+// realistic interleaved stream: lifecycle lines drive the returned lastEvent,
+// progress lines are republished, junk is ignored.
+func TestParseSubprocessStdout_MixedStream(t *testing.T) {
+	// Build the stream the way the child does: start line, two module ticks, a
+	// non-JSON stray line, then the done line.
+	var buf bytes.Buffer
+	buf.WriteString(`{"event":"index_start","repo":"/r","ref":"main"}` + "\n")
+	pub := NewStdoutProgressPublisher(&buf)
+	pub.Publish(progress.Event{RepoSlug: "svc", Module: "a", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 2})
+	pub.Publish(progress.Event{RepoSlug: "svc", Module: "b", Phase: progress.PhaseExtractAST, FilesDone: 2, FilesTotal: 2})
+	buf.WriteString("not json at all\n")
+	buf.WriteString(`{"event":"index_done","repo":"/r","ref":"main"}` + "\n")
+
+	got := &progress.SliceCollector{}
+	last := parseSubprocessStdout(&buf, got, 0, nil)
+
+	if last.Event != "index_done" || last.Repo != "/r" || last.Ref != "main" {
+		t.Errorf("lastEvent = %+v, want index_done for /r@main", last)
+	}
+	if len(got.Events) != 2 {
+		t.Fatalf("republished %d progress events, want 2", len(got.Events))
+	}
+	if got.Events[0].Module != "a" || got.Events[1].Module != "b" {
+		t.Errorf("per-module order lost: got %q,%q want a,b", got.Events[0].Module, got.Events[1].Module)
+	}
+}
+
+// TestParseSubprocessStdout_ErrorEvent verifies a child index_error line is
+// surfaced as the returned lastEvent so RunSubprocessIndex can return it.
+func TestParseSubprocessStdout_ErrorEvent(t *testing.T) {
+	stream := strings.Join([]string{
+		`{"event":"index_start","repo":"/r"}`,
+		`{"event":"index_error","repo":"/r","error":"boom"}`,
+	}, "\n") + "\n"
+
+	last := parseSubprocessStdout(strings.NewReader(stream), nil, 0, nil)
+	if last.Event != "index_error" || last.Error != "boom" {
+		t.Errorf("lastEvent = %+v, want index_error with error=boom", last)
+	}
+}
+
+// TestParseSubprocessStdout_NilPublisherDropsProgress verifies the scheduler
+// path (ProgressPub nil) tolerates progress lines without panicking and still
+// tracks lifecycle events.
+func TestParseSubprocessStdout_NilPublisherDropsProgress(t *testing.T) {
+	var buf bytes.Buffer
+	pub := NewStdoutProgressPublisher(&buf)
+	pub.Publish(progress.Event{RepoSlug: "svc", Module: "a", Phase: progress.PhaseExtractAST})
+	buf.WriteString(`{"event":"index_done","repo":"/r"}` + "\n")
+
+	last := parseSubprocessStdout(&buf, nil, 0, nil)
+	if last.Event != "index_done" {
+		t.Errorf("lastEvent = %+v, want index_done", last)
+	}
+}

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -3,7 +3,6 @@ package sched
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -16,6 +15,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/executil"
 	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/progress"
 )
 
 // backgroundYieldGOMAXPROCSDefault is the per-child GOMAXPROCS a BACKGROUND
@@ -248,7 +248,7 @@ type ipcEvent struct {
 // Cancellation: ctx.Done() sends SIGTERM to the child. The child is
 // expected to exit on SIGTERM; if it does not, the parent waits and the
 // context timeout (if any) will eventually unblock the caller.
-func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, logger *slog.Logger) error {
+func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, opts *SubprocessIndexOptions, logger *slog.Logger) error {
 	binary, err := os.Executable()
 	if err != nil {
 		return fmt.Errorf("subprocess-indexer: resolve binary: %w", err)
@@ -261,6 +261,31 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	}
 	if len(skipPasses) > 0 {
 		args = append(args, "--skip-pass="+strings.Join(skipPasses, ","))
+	}
+	// Progress-republish channel (rebuild / wizard first-index). When the caller
+	// supplies a Publisher the child is told to STREAM per-module progress on
+	// stdout (--emit-progress) and to stamp events with the rebuild's group/repo
+	// slugs so republished rows key the same (group, repo, module) identity the
+	// in-process path emits. A nil opts (the scheduler background reindex) adds
+	// none of these flags, so its child args are byte-identical to before.
+	var progressPub progress.Publisher
+	if opts != nil {
+		progressPub = opts.ProgressPub
+		if opts.RepoSlug != "" {
+			args = append(args, "--repo-tag="+opts.RepoSlug)
+		}
+		if opts.ProgressPub != nil {
+			args = append(args, "--emit-progress")
+			if opts.GroupSlug != "" {
+				args = append(args, "--group-slug="+opts.GroupSlug)
+			}
+		}
+		if opts.IncrementalStateDir != "" {
+			args = append(args, "--incremental="+opts.IncrementalStateDir)
+		}
+		if opts.Interactive {
+			args = append(args, "--interactive")
+		}
 	}
 
 	cmd := exec.CommandContext(ctx, binary, args...)
@@ -337,22 +362,16 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 		}
 	}()
 
-	// Drain child stdout for IPC events.
+	// Drain child stdout for IPC events. parseSubprocessStdout demuxes the two
+	// line types: coarse lifecycle events (index_start/done/error → lastEvent for
+	// exit classification) and tagged per-module progress lines, which it
+	// republishes into progressPub so the rebuild's broker / split-mode sidecar
+	// sees the same live rows the in-process indexer would have published.
 	var lastEvent ipcEvent
 	stdoutDone := make(chan struct{})
 	go func() {
 		defer close(stdoutDone)
-		sc := bufio.NewScanner(stdoutPipe)
-		for sc.Scan() {
-			var ev ipcEvent
-			if jerr := json.Unmarshal([]byte(sc.Text()), &ev); jerr != nil {
-				continue // not a JSON line — ignore
-			}
-			lastEvent = ev
-			if logger != nil {
-				logger.Info("subprocess-indexer: event", "event", ev.Event, "repo", ev.Repo, "ref", ev.Ref)
-			}
-		}
+		lastEvent = parseSubprocessStdout(stdoutPipe, progressPub, pid, logger)
 	}()
 
 	// Wait for both pipe goroutines and the process itself.

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -264,6 +264,15 @@ func SubprocessIndexEnabled() bool {
 	return subprocessIndexerEnabled.Load()
 }
 
+// SetSubprocessIndexEnabled overrides the toggle at runtime and returns the
+// previous value so a caller can restore it. Exposed for tests that need to
+// force one path or the other (the rebuild reroute is gated on this toggle, so
+// the in-process iteration tests force it OFF and the subprocess-reroute test
+// forces it ON, each restoring the prior value on cleanup).
+func SetSubprocessIndexEnabled(v bool) (previous bool) {
+	return subprocessIndexerEnabled.Swap(v)
+}
+
 // ipcEvent is one JSON line emitted by the child process on stdout.
 type ipcEvent struct {
 	Event string `json:"event"`

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -150,6 +150,49 @@ func ReindexGraphPhaseGOMAXPROCS() int {
 	return n
 }
 
+// ForegroundReindexGOMAXPROCS resolves the child-process GOMAXPROCS a
+// human-awaited (interactive) rebuild / wizard first-index runs under. Because a
+// user is actively waiting on it, it runs at host speed rather than the
+// throttled background reindex budget: GRAFEL_REBUILD_GOMAXPROCS wins (a
+// strictly-positive integer), otherwise the host core count. It mirrors the
+// extract coordinator's rebuildGOMAXPROCS() default so the child process ceiling
+// (graph-wide phases + GC) matches the foreground extract cap the child spawns
+// its sub-subprocesses at.
+func ForegroundReindexGOMAXPROCS() int {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_REBUILD_GOMAXPROCS")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	n := runtime.NumCPU()
+	if n < 1 {
+		n = 1
+	}
+	return n
+}
+
+// resolveChildGOMAXPROCS decides the GOMAXPROCS the index-internal child process
+// runs under, and a short reason string for the daemon log.
+//
+//   - interactive (human-awaited rebuild): the FOREGROUND cap so the child's
+//     graph-wide phases + GC run at host speed. foregroundCap wins when > 0,
+//     else ForegroundReindexGOMAXPROCS(). The #5328 yield / #5602 budget only
+//     apply to BACKGROUND reindexes, never to the index the user is waiting on.
+//   - background reindex: unchanged — the #5328 foreground-yield cap while a
+//     foreground index is active, otherwise the #5602 daemon-wide budget-per-slot.
+func resolveChildGOMAXPROCS(interactive bool, foregroundCap int) (n int, reason string) {
+	if interactive {
+		if foregroundCap <= 0 {
+			foregroundCap = ForegroundReindexGOMAXPROCS()
+		}
+		return foregroundCap, "foreground rebuild"
+	}
+	if y, yield := backgroundYieldGOMAXPROCS(); yield {
+		return y, "yielding to foreground index"
+	}
+	return ReindexGraphPhaseGOMAXPROCS(), "daemon-wide reindex CPU ceiling"
+}
+
 // groupAlgoGOMAXPROCSDefault is the per-child CPU cap (Go GOMAXPROCS) for the
 // background group-algorithm subprocess. The pass (Louvain + PageRank +
 // betweenness over the whole group union) is the heaviest analytics job the
@@ -293,36 +336,24 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	// GRAFEL_HOME). Start from the daemon's full environment so the child
 	// resolves the same state dirs and caps.
 	cmd.Env = os.Environ()
-	// #5328: if a FOREGROUND (interactive) index is running right now, make this
-	// BACKGROUND reindex yield its core share to it by capping the child's Go
-	// runtime to BackgroundYieldGOMAXPROCS() cores (default 1). GOMAXPROCS is
-	// appended last so it wins over any inherited value; it is omitted entirely
-	// when no foreground index is active, so the child falls back to its normal
-	// background cap (GRAFEL_EXTRACT_GOMAXPROCS, default 2). This is re-evaluated
-	// per subprocess launch, so background concurrency restores automatically the
-	// moment the foreground index finishes. fg preempts bg's share rather than
-	// adding to it, keeping fg+bg within the machine's core budget.
-	if n, yield := backgroundYieldGOMAXPROCS(); yield {
-		cmd.Env = append(cmd.Env, "GOMAXPROCS="+strconv.Itoa(n))
-		if logger != nil {
-			logger.Info("subprocess-indexer: yielding to foreground index",
-				"gomaxprocs", n, "repo", repoPath)
-		}
-	} else {
-		// #5602: daemon-wide reindex CPU ceiling. The child runs the in-process
-		// graph-wide phases (resolution / links / flow / buildIndex) at ITS
-		// GOMAXPROCS; without this it inherits the host core count, so N
-		// concurrent reindexes admitted by the IndexGate draw N × hostCores and
-		// blow past the intended ceiling (the live 200–1011%, #5602). Cap the
-		// child at the budget-per-slot share so the SUM across all concurrent
-		// reindexes stays under one daemon-wide budget. GOMAXPROCS is appended
-		// last so it wins over any inherited value.
-		n := ReindexGraphPhaseGOMAXPROCS()
-		cmd.Env = append(cmd.Env, "GOMAXPROCS="+strconv.Itoa(n))
-		if logger != nil {
-			logger.Info("subprocess-indexer: daemon-wide reindex CPU ceiling",
-				"gomaxprocs", n, "repo", repoPath)
-		}
+	// Resolve the child-process GOMAXPROCS. resolveChildGOMAXPROCS dispatches on
+	// interactive-vs-background:
+	//   - interactive (human-awaited rebuild / wizard first-index): the FOREGROUND
+	//     cap (GRAFEL_REBUILD_GOMAXPROCS / host cores) so the child's graph-wide
+	//     phases + GC run at host speed and the user is not throttled to the
+	//     background reindex budget.
+	//   - background reindex: unchanged — the #5328 foreground-yield cap while a
+	//     foreground index is active, else the #5602 daemon-wide budget-per-slot.
+	// GOMAXPROCS is appended last so it wins over any inherited value.
+	interactive := opts != nil && opts.Interactive
+	var foregroundCap int
+	if opts != nil {
+		foregroundCap = opts.ForegroundGOMAXPROCS
+	}
+	gmp, reason := resolveChildGOMAXPROCS(interactive, foregroundCap)
+	cmd.Env = append(cmd.Env, "GOMAXPROCS="+strconv.Itoa(gmp))
+	if logger != nil {
+		logger.Info("subprocess-indexer: "+reason, "gomaxprocs", gmp, "repo", repoPath)
 	}
 	// On Windows, prevent a console window from flashing when the daemon
 	// (running as a Task Scheduler task) spawns this subprocess.

--- a/internal/daemon/sched/subprocess_runner_test.go
+++ b/internal/daemon/sched/subprocess_runner_test.go
@@ -73,7 +73,7 @@ func TestRunSubprocessIndexMissingBinary(t *testing.T) {
 	// Point to a directory that looks like a binary but is not — on Linux/macOS
 	// exec will return "permission denied" or "not a file". We just want a
 	// non-zero exit.
-	err := RunSubprocessIndex(ctx, tmpDir, "", nil, slog.Default())
+	err := RunSubprocessIndex(ctx, tmpDir, "", nil, nil, slog.Default())
 	// Any error is correct here — non-existent binary OR index failure on tmpDir.
 	if err == nil {
 		t.Fatal("expected an error for non-repo tmpDir but got nil")


### PR DESCRIPTION
## Why
The `grafel rebuild` / wizard first-index ran the index IN-PROCESS, allocating its full working set on top of the daemon's resident serving graphs → Go GC pacing scales with live heap → GC-assist stalls throttle the index (~4× slower + high daemon RSS). The scheduler already indexes via an isolated `grafel index-internal` subprocess (fresh near-empty heap, cheap GC, OS-reclaimed on exit). This routes the rebuild through that same subprocess.

## What (flag-gated behind `GRAFEL_SUBPROCESS_INDEXER`, default ON; OFF → in-process path byte-identical)
- **Per-module progress over the subprocess IPC**: the child streams full `progress.Event`s as tagged stdout lines; the parent demuxes + republishes into the rebuild's publisher (broker / split-mode sidecar) — so the wizard per-module bars work unchanged through the fresh-process index. Round-trip is byte-faithful; stdout drained to EOF in an independent goroutine before `Wait` (no pipe deadlock), non-blocking republish at every layer, scanner-error drain guard so an oversized line degrades to dropped-progress not a hang.
- **Foreground CPU cap forwarded** for the human-awaited first-index (`resolveChildGOMAXPROCS`); background reindex keeps its budget.
- **Reroute in `indexOneInner`**: `repolock.ClaimForeground` spans the child lifetime; `linksFn` (group-level, once) + `FlushRepoStatusFile` (status-before-ack #5729) stay in the parent — completion/ack ordering preserved. Child index_error = per-repo partial failure (no 45m hang). Child bounded by a cancellable per-repo-timeout ctx (reaped on timeout, no leaked process/claim).

## Verification
Independent adversarial review: APPROVE (deadlock + ack-ordering explicitly confirmed safe). Per-commit TDD; `-race` clean on sched + cmd/grafel + cli + daemon; flag-OFF byte-identical.

Net: corpus first-index runs in a fresh process (~4× faster, flat daemon RAM) with per-module bars + live CPU/RAM + clean completion. Refs #5729. Part of v0.1.8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)