### PR TITLE
feat(wiztui): readable module labels, live timer, commafied counts, queryable/Enter-or-wait completion

### DIFF
--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -45,6 +45,13 @@ import (
 // streamIndexWithSummary. It builds the status-plane probe for the group (which
 // captures the per-repo graph_fb_mtime baseline BEFORE the enqueue) and a
 // synchronous enqueue closure, then delegates to runSplitIndexCore.
+// onQueryable is invoked AT MOST ONCE, mid-poll, the first time the group
+// becomes graph-queryable (AllAdvanced) while the background enhancement pass
+// is still running (RequestPending still true). It carries the classified
+// queryable-time stats. nil is fine — it simply means "no interim checkpoint
+// wanted" (the caller only cares about the terminal outcome).
+type onQueryableFunc func(splitResult)
+
 func runSplitIndex(
 	ctx context.Context,
 	cancel context.CancelFunc,
@@ -52,6 +59,7 @@ func runSplitIndex(
 	group, token string,
 	sseCh <-chan sseEvent,
 	evCh chan<- progress.Event,
+	onQueryable onQueryableFunc,
 ) rebuildOutcome {
 	probe, err := newStatusPlaneProbe(group, token)
 	if err != nil {
@@ -66,7 +74,7 @@ func runSplitIndex(
 		_, rErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
 		return rErr
 	}
-	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll())
+	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll(), onQueryable)
 }
 
 // splitClock is the injectable time seam so completion-poll tests advance
@@ -148,20 +156,36 @@ func defaultSplitPoll() splitPollConfig {
 // and then went stale (backstop), or the overall timeout elapses (last resort).
 // It NEVER returns success on the enqueue instant — completion is the request
 // ack, not the RPC return.
-func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig) (splitResult, error) {
+//
+// QUERYABLE CHECKPOINT: when every repo becomes graph-queryable (AllAdvanced)
+// while the request is STILL pending (the background linksFn tail hasn't
+// acked yet), the loop does NOT return early anymore — it invokes onQueryable
+// (at most once, with the classified queryable-time stats) and keeps polling
+// for the real ack, so the TUI can offer "queryable, enhancing in the
+// background" instead of collapsing straight to Done. If AllAdvanced and
+// !RequestPending land in the SAME poll (the rebuild was already fully done),
+// the ack check runs first, so no interim fires — straight to the terminal
+// return, matching the pre-existing fast/failure-path behavior.
+func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig, onQueryable onQueryableFunc) (splitResult, error) {
 	start := clk.Now()
 	sawAlive := false
+	queryableFired := false
 	for {
 		p, err := probe.Poll()
 		if err == nil {
-			if p.AllAdvanced || !p.RequestPending {
-				// Complete when EITHER every repo is already graph-queryable
-				// (AllAdvanced — the ~6-min early success, engine still running the
-				// background linksFn tail) OR the engine drained+acked our rebuild
-				// request (!RequestPending — the failure/backstop path). Classify is
-				// unchanged: on the ack path it still lists any non-advanced repo as
-				// Failed; on the AllAdvanced path every repo advanced so it is clean.
+			if !p.RequestPending {
+				// The engine drained+acked our rebuild request — real completion,
+				// checked FIRST so an AllAdvanced-and-acked poll never fires an
+				// interim (nothing left to wait for).
 				return probe.Classify()
+			}
+			if p.AllAdvanced && !queryableFired {
+				queryableFired = true
+				if onQueryable != nil {
+					if res, cErr := probe.Classify(); cErr == nil {
+						onQueryable(res)
+					}
+				}
 			}
 			if p.EngineAlive {
 				sawAlive = true
@@ -224,6 +248,7 @@ func runSplitIndexCore(
 	probe splitProbe,
 	clk splitClock,
 	cfg splitPollConfig,
+	onQueryable onQueryableFunc,
 ) rebuildOutcome {
 	// 1. Start forwarding SSE per-module events CONCURRENTLY so the bars render
 	//    live from the first moment (even during the enqueue).
@@ -236,8 +261,9 @@ func runSplitIndexCore(
 		return rebuildOutcome{err: fmt.Errorf("enqueue rebuild: %w", err)}
 	}
 
-	// 3. Poll for real completion (the request ack), then classify.
-	res, err := awaitSplitCompletion(probe, clk, cfg)
+	// 3. Poll for real completion (the request ack), then classify. onQueryable
+	//    may fire once, mid-poll, on the AllAdvanced-while-pending checkpoint.
+	res, err := awaitSplitCompletion(probe, clk, cfg, onQueryable)
 	cancel() // stop the SSE forward goroutine
 	if err != nil {
 		return rebuildOutcome{err: err}

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -140,7 +140,7 @@ func TestSplit_CompletionWaitsForRequestAck(t *testing.T) {
 	evCh := make(chan progress.Event, 8)
 	rebuildCalled := false
 
-	o := runSplitIndexCore(ctx, cancel, func() error { rebuildCalled = true; return nil }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, func() error { rebuildCalled = true; return nil }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), nil)
 
 	if !rebuildCalled {
 		t.Fatal("triggerRebuild was never called")
@@ -179,7 +179,7 @@ func TestSplit_ForwardsPerModuleEventsDuringWindow(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -202,7 +202,7 @@ func TestSplit_OutcomeCarriesClassifiedStats(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -226,7 +226,7 @@ func TestSplit_EngineDiesSurfacesError(t *testing.T) {
 	}}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err == nil {
 		t.Fatal("engine died but outcome carried no error (fake Done)")
 	}
@@ -243,7 +243,7 @@ func TestSplit_TimeoutSurfacesError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: time.Second, startupWindow: 0, timeout: 3 * time.Second}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
 	if o.err == nil {
 		t.Fatal("rebuild never acked but no timeout error surfaced")
 	}
@@ -258,7 +258,7 @@ func TestSplit_NeverAliveEngineFailsFast(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 100 * time.Millisecond, startupWindow: time.Second, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
 	if o.err == nil {
 		t.Fatal("engine never came alive but no error surfaced")
 	}
@@ -293,7 +293,7 @@ func TestSplit_MultiRepoPartialFailure_PromptError(t *testing.T) {
 	// Short interval + comfortably large timeout: a PROMPT terminal state must
 	// arrive from the ack, long before the timeout.
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
 
 	if o.err == nil {
 		t.Fatal("partial failure (repo B never indexed) produced no error — this is the hang/fake-done regression")
@@ -313,7 +313,7 @@ func TestSplit_EmptyRepo_PromptTerminal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
 	if o.err == nil {
 		t.Fatal("empty repo produced no terminal error (would hang in production)")
 	}
@@ -409,7 +409,7 @@ func TestSplit_NoDashboard_WaitsForAck(t *testing.T) {
 	defer cancel()
 
 	var sseCh <-chan sseEvent // nil: no dashboard, no live bars
-	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -436,7 +436,7 @@ func TestSplit_StaleStatusAtAck_FalseFailsWithoutFlush(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err == nil {
 		t.Fatal("expected a (false) failure when status is stale at ack — documents the race the flush closes")
 	}
@@ -459,7 +459,7 @@ func TestSplit_FreshStatusFlushedBeforeAck_ClassifiesOK(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg())
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
 	if o.err != nil {
 		t.Fatalf("fresh status flushed before ack should classify OK, got: %v", o.err)
 	}
@@ -469,32 +469,50 @@ func TestSplit_FreshStatusFlushedBeforeAck_ClassifiesOK(t *testing.T) {
 }
 
 // HYBRID-1. SPLIT: every repo becomes graph-queryable (graph_fb_mtime advanced,
-// !Indexing) while our rebuild request is STILL pending → completion fires EARLY
-// (success) via the AllAdvanced predicate, without waiting for the ack. Modeled
-// by a pendingReader that NEVER acks: the only way this can succeed is the early
-// AllAdvanced path. Fails today (waits for the ack → hits the timeout → error).
-func TestSplit_AllReposAdvance_CompletesEarlyBeforeAck(t *testing.T) {
+// !Indexing) while our rebuild request is STILL pending. Per the queryable-state
+// UX (the graph is queryable, but background enhancement — the linksFn tail —
+// is still running), this must NOT complete early anymore: it fires
+// onQueryable EXACTLY ONCE with the queryable-time stats, then keeps polling
+// until the real ack, returning the (here, identical) final stats.
+func TestSplit_AllReposAdvance_FiresQueryableThenWaitsForAck(t *testing.T) {
 	const repoA, repoB = "/repo/backend", "/repo/frontend"
 	store := newFakeStatusStore() // both absent at construction → baseline 0
-	neverAck := func() (bool, error) { return true, nil }
-	probe := newStatusPlaneProbeWith([]string{repoA, repoB}, "/root", store.read, aliveLiveness, neverAck)
+	pending := pendingUntil(6)    // acks well after AllAdvanced first goes true
+	probe := newStatusPlaneProbeWith([]string{repoA, repoB}, "/root", store.read, aliveLiveness, pending)
 
 	// Both repos produce a fresh graph (mtime advanced past baseline 0) while the
 	// request is still pending — the ~6-min "graph queryable" moment.
 	store.set(repoA, &statusfile.File{Indexing: false, GraphFBMtime: 100, Entities: 5, Relationships: 6})
 	store.set(repoB, &statusfile.File{Indexing: false, GraphFBMtime: 200, Entities: 7, Relationships: 8})
 
+	var qmu sync.Mutex
+	fired := 0
+	var interim splitResult
+	onQueryable := func(res splitResult) {
+		qmu.Lock()
+		fired++
+		interim = res
+		qmu.Unlock()
+	}
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	// Generous timeout: if completion needed the (never-coming) ack this would
-	// spin to the timeout and error. Early success proves the AllAdvanced path.
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
 	if o.err != nil {
-		t.Fatalf("all repos graph-queryable but no early completion (waited for the ack): %v", o.err)
+		t.Fatalf("unexpected error: %v", o.err)
 	}
 	if o.entities != 12 || o.rels != 14 {
-		t.Fatalf("stats = (%d,%d); want (12,14) summed across the advanced repos", o.entities, o.rels)
+		t.Fatalf("final stats = (%d,%d); want (12,14) summed across the advanced repos", o.entities, o.rels)
+	}
+	qmu.Lock()
+	gotFired, gotInterim := fired, interim
+	qmu.Unlock()
+	if gotFired != 1 {
+		t.Fatalf("onQueryable fired %d times; want exactly 1", gotFired)
+	}
+	if gotInterim.Entities != 12 || gotInterim.Rels != 14 {
+		t.Fatalf("interim stats = (%d,%d); want (12,14)", gotInterim.Entities, gotInterim.Rels)
 	}
 }
 
@@ -522,7 +540,7 @@ func TestSplit_OneRepoNeverAdvances_AckBackstopPromptError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
 	if o.err == nil {
 		t.Fatal("repo B never advanced but completion reported success (AllAdvanced early false-success or hang)")
 	}
@@ -539,11 +557,11 @@ func TestSplit_OneRepoNeverAdvances_AckBackstopPromptError(t *testing.T) {
 }
 
 // HYBRID-3. FALSE-FAILURE guard: while a repo's status is STALE (graph_fb_mtime
-// == baseline) the AllAdvanced predicate stays false — no early completion on a
-// stale read. Only once graph_fb_mtime genuinely advances does the early path
-// fire. Modeled with a never-acking pendingReader so the ONLY route to success is
-// a real mtime advance, and a status reader that stays stale for the first polls.
-func TestSplit_StaleStatus_NoEarlyComplete_AdvanceCompletes(t *testing.T) {
+// == baseline) the AllAdvanced predicate stays false, so onQueryable must NOT
+// fire on a stale read — only once graph_fb_mtime genuinely advances. It still
+// waits for the real ack to complete (queryable-state UX), firing onQueryable
+// exactly once at the advance.
+func TestSplit_StaleStatus_QueryableFiresOnceThenWaitsForAck(t *testing.T) {
 	const repo = "/repo/monorepo"
 	var mu sync.Mutex
 	calls := 0
@@ -560,26 +578,110 @@ func TestSplit_StaleStatus_NoEarlyComplete_AdvanceCompletes(t *testing.T) {
 		}
 		return &statusfile.File{Indexing: false, GraphFBMtime: 2000, Entities: 11, Relationships: 22}, true
 	}
-	neverAck := func() (bool, error) { return true, nil } // only AllAdvanced can complete
-	probe := newStatusPlaneProbeWith([]string{repo}, "/root", read, aliveLiveness, neverAck)
+	pending := pendingUntil(10) // acks well after the advance
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", read, aliveLiveness, pending)
+
+	var qmu sync.Mutex
+	fired := 0
+	onQueryable := func(splitResult) {
+		qmu.Lock()
+		fired++
+		qmu.Unlock()
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
 	if o.err != nil {
-		t.Fatalf("should complete once mtime advances past baseline, got: %v", o.err)
+		t.Fatalf("should complete once the ack lands, got: %v", o.err)
 	}
 	if o.entities != 11 || o.rels != 22 {
 		t.Fatalf("stats = (%d,%d); want (11,22) from the advanced status", o.entities, o.rels)
 	}
-	// It must NOT have early-completed on a stale read: at least the stale polls
-	// happened before the advance at call 5.
-	mu.Lock()
-	total := calls
-	mu.Unlock()
-	if total < 5 {
-		t.Fatalf("only %d status reads; want >=5 (early-completed on a stale read == false-failure race)", total)
+	qmu.Lock()
+	gotFired := fired
+	qmu.Unlock()
+	if gotFired != 1 {
+		t.Fatalf("onQueryable fired %d times; want exactly 1 (must not fire on a stale read)", gotFired)
+	}
+}
+
+// QUERYABLE-0a. Fast path (AllAdvanced and the ack land in the SAME poll —
+// i.e. the rebuild was already fully done by the time we first noticed): no
+// interim is emitted, straight to the terminal return.
+func TestSplit_FastPath_AllAdvancedAndAckedSamePoll_NoInterim(t *testing.T) {
+	probe := &fakeProbe{
+		pollFn:   func(int) splitPoll { return splitPoll{RequestPending: false, AllAdvanced: true, EngineAlive: true} },
+		classify: splitResult{Entities: 42, Rels: 7},
+	}
+	fired := 0
+	onQueryable := func(splitResult) { fired++ }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), onQueryable)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if fired != 0 {
+		t.Fatalf("onQueryable fired %d times; want 0 (AllAdvanced and ack landed in the same poll — nothing left to wait for)", fired)
+	}
+	if o.entities != 42 || o.rels != 7 {
+		t.Fatalf("stats = (%d,%d); want (42,7)", o.entities, o.rels)
+	}
+}
+
+// QUERYABLE-0b. Ordinary fast path (small index: never even observed
+// AllAdvanced before the ack lands): no interim, unchanged from the pre-#queryable
+// behavior — mirrors TestSplit_CompletionWaitsForRequestAck but asserts the
+// callback specifically.
+func TestSplit_FastAck_NeverAllAdvanced_NoInterim(t *testing.T) {
+	probe := &fakeProbe{
+		pollFn: func(call int) splitPoll {
+			return splitPoll{RequestPending: call < 3, EngineAlive: true} // never AllAdvanced
+		},
+		classify: splitResult{Entities: 9, Rels: 3},
+	}
+	fired := 0
+	onQueryable := func(splitResult) { fired++ }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), onQueryable)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if fired != 0 {
+		t.Fatalf("onQueryable fired %d times; want 0 (AllAdvanced never observed)", fired)
+	}
+}
+
+// QUERYABLE-0c. Partial-failure path: AllAdvanced never becomes true (one repo
+// never advances) and the ack eventually surfaces the classification failure —
+// no interim, error classification unchanged from the pre-#queryable behavior.
+func TestSplit_PartialFailure_NoInterim(t *testing.T) {
+	const repoA, repoB = "/repo/backend", "/repo/frontend"
+	store := newFakeStatusStore()
+	probe := newStatusPlaneProbeWith([]string{repoA, repoB}, "/root", store.read, aliveLiveness, pendingUntil(3))
+	store.set(repoA, &statusfile.File{Indexing: false, GraphFBMtime: 500, Entities: 1000, Relationships: 2000})
+	// repoB never produces a graph → AllAdvanced never true.
+
+	fired := 0
+	onQueryable := func(splitResult) { fired++ }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
+	if o.err == nil {
+		t.Fatal("expected a partial-failure error naming the non-advanced repo")
+	}
+	if !strings.Contains(o.err.Error(), "frontend") {
+		t.Fatalf("err = %v; want it to name frontend", o.err)
+	}
+	if fired != 0 {
+		t.Fatalf("onQueryable fired %d times; want 0 on a partial-failure path", fired)
 	}
 }
 

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -359,7 +359,20 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 				sseCh = ch
 			}
 		}
-		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh)
+		// Interim "graph queryable" checkpoint (at most once, see
+		// awaitSplitCompletion): surface it on outCh so the TUI can offer
+		// finish-now-or-wait instead of collapsing straight to Done. Install is
+		// already complete by this point (makeIndexFunc runs it before
+		// streamIndexWithSummary), so it's safe to attach the same summary here.
+		onQueryable := func(res splitResult) {
+			outCh <- wiztui.IndexOutcome{
+				Interim:  true,
+				Entities: res.Entities,
+				Rels:     res.Rels,
+				Install:  summary,
+			}
+		}
+		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh, onQueryable)
 		outCh <- toIndexOutcome(o, summary)
 		return
 	}

--- a/internal/cli/wiztui/chrome.go
+++ b/internal/cli/wiztui/chrome.go
@@ -188,3 +188,22 @@ func truncate(s string, max int) string {
 	}
 	return strings.TrimRight(string(runes), " ") + g.Ellipsis
 }
+
+// truncateLeft shortens s to max display columns by eliding from the FRONT
+// (leading ellipsis), keeping the TAIL — the distinguishing suffix of a
+// slug/module label — visible. Used where a shared, long common prefix (e.g. a
+// monorepo's RepoSlug) would otherwise swallow the whole column and make every
+// row render identically (see renderRow).
+func truncateLeft(s string, max int) string {
+	if max <= 1 {
+		return ""
+	}
+	if lipgloss.Width(s) <= max {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) > max-1 {
+		runes = runes[len(runes)-(max-1):]
+	}
+	return g.Ellipsis + strings.TrimLeft(string(runes), " ")
+}

--- a/internal/cli/wiztui/format.go
+++ b/internal/cli/wiztui/format.go
@@ -1,0 +1,56 @@
+package wiztui
+
+import (
+	"strconv"
+	"strings"
+	"time"
+)
+
+// commafy formats n with thousands separators (e.g. 3686488 -> "3,686,488"),
+// so large entity/relationship/file counts stay readable on the index screen.
+// Negative numbers keep their sign in front of the grouped digits.
+func commafy(n int64) string {
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	s := strconv.FormatInt(n, 10)
+	l := len(s)
+	var b strings.Builder
+	b.Grow(l + l/3 + 1)
+	for i, c := range s {
+		if i > 0 && (l-i)%3 == 0 {
+			b.WriteByte(',')
+		}
+		b.WriteRune(c)
+	}
+	if neg {
+		return "-" + b.String()
+	}
+	return b.String()
+}
+
+// fmtElapsed formats a duration as a compact "MmSSs" string (e.g. "2m14s",
+// "0m08s") for the live index-screen timer. Unlike internal/cli's fmtDuration
+// (which omits the minutes segment under a minute), this always shows both
+// segments — a stable width reads better in a ticking header. Negative
+// durations (e.g. a clock hiccup) clamp to zero rather than ever displaying a
+// negative timer.
+func fmtElapsed(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	d = d.Truncate(time.Second)
+	total := int(d.Seconds())
+	m := total / 60
+	s := total % 60
+	return strconv.Itoa(m) + "m" + pad2(s) + "s"
+}
+
+// pad2 zero-pads n to at least two digits (n is always in [0,60)).
+func pad2(n int) string {
+	if n < 10 {
+		return "0" + strconv.Itoa(n)
+	}
+	return strconv.Itoa(n)
+}

--- a/internal/cli/wiztui/format_test.go
+++ b/internal/cli/wiztui/format_test.go
@@ -1,0 +1,47 @@
+package wiztui
+
+import (
+	"testing"
+	"time"
+)
+
+// TestCommafy covers the small table the coordinator asked for: 0, 999, 1000,
+// a large real-world relationship count, and the negative-sign guard.
+func TestCommafy(t *testing.T) {
+	cases := []struct {
+		in   int64
+		want string
+	}{
+		{0, "0"},
+		{999, "999"},
+		{1000, "1,000"},
+		{3686488, "3,686,488"},
+		{-3686488, "-3,686,488"},
+		{-1, "-1"},
+		{-999, "-999"},
+	}
+	for _, c := range cases {
+		if got := commafy(c.in); got != c.want {
+			t.Errorf("commafy(%d) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestFmtElapsed covers the compact "MmSSs" duration format used by the live
+// index-screen timer.
+func TestFmtElapsed(t *testing.T) {
+	cases := []struct {
+		in   time.Duration
+		want string
+	}{
+		{0, "0m00s"},
+		{8 * time.Second, "0m08s"},
+		{2*time.Minute + 14*time.Second, "2m14s"},
+		{-5 * time.Second, "0m00s"}, // negative guard: never a negative timer
+	}
+	for _, c := range cases {
+		if got := fmtElapsed(c.in); got != c.want {
+			t.Errorf("fmtElapsed(%v) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -3,6 +3,7 @@ package wiztui
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/bubbles/progress"
 	"github.com/charmbracelet/bubbles/spinner"
@@ -36,6 +37,19 @@ type indexView struct {
 	elapsed         string
 	daemonDown      bool           // group registered but not indexed
 	install         InstallSummary // captured applyGroupConfig output (fix C)
+
+	// queryable marks the split-mode "graph queryable, background enhancement
+	// still running" sub-state: an interim IndexOutcome landed but the terminal
+	// one hasn't yet (or the user hasn't pressed enter to finish early). See
+	// Model's outcomeMsg handling and the scrIndex enter key case.
+	queryable bool
+
+	// startedAt / finishedAt bound the live elapsed timer shown in the index
+	// header. startedAt is stamped when the index screen begins (startIndex);
+	// finishedAt is stamped once terminal/failed so the header FREEZES at the
+	// real elapsed instead of continuing to grow with wall-clock time.
+	startedAt  time.Time
+	finishedAt time.Time
 
 	// rssMB / cpuPct are the engine process's live CPU/RAM readout (wizard
 	// CPU/RAM readout — see internal/statusfile.File's RSSMB/CPUPct doc),
@@ -161,16 +175,35 @@ var (
 	overallLblStyle = lipgloss.NewStyle().Foreground(colAccent2).Bold(true)
 )
 
+// rowLabel derives the primary display label for a row. For a monorepo
+// module (r.Module != ""), the MODULE — not the shared repo-slug prefix — is
+// the distinguishing part, so it is the label (its basename, if it happens to
+// carry path separators). Using "RepoSlug/Module" here regressed to every
+// module row rendering identically once RepoSlug alone filled the whole slug
+// column (e.g. a long monorepo slug like "some-example-monorepo-main") — see
+// renderRow's slugW.
+// A plain group repo (Module=="") keeps RepoSlug, which is already a short
+// basename.
+func rowLabel(r Row) string {
+	if r.Module == "" {
+		return r.RepoSlug
+	}
+	m := r.Module
+	if i := strings.LastIndexAny(m, `/\`); i >= 0 && i < len(m)-1 {
+		m = m[i+1:]
+	}
+	return m
+}
+
 // renderRow renders one repo row: name · phase · files done/total · entities ·
 // a spinner glyph while active.
 func (v indexView) renderRow(r Row, spinnerFrame string) string {
-	const slugW = 22
+	const slugW = 30
 
-	label := r.RepoSlug
-	if r.Module != "" {
-		label = r.RepoSlug + "/" + r.Module
-	}
-	name := truncate(label, slugW)
+	// Elide from the LEFT on overflow (keep the distinguishing tail) rather
+	// than the right — a long label's differentiating suffix matters more than
+	// its common prefix.
+	name := truncateLeft(rowLabel(r), slugW)
 	name = rowSlugStyle.Render(fmt.Sprintf("%-*s", slugW, name))
 
 	var glyph, phase string
@@ -192,10 +225,10 @@ func (v indexView) renderRow(r Row, spinnerFrame string) string {
 
 	var extra []string
 	if r.FilesTotal > 0 && !r.Terminal() {
-		extra = append(extra, fmt.Sprintf("%d/%d files", r.FilesDone, r.FilesTotal))
+		extra = append(extra, fmt.Sprintf("%s/%s files", commafy(int64(r.FilesDone)), commafy(int64(r.FilesTotal))))
 	}
 	if r.EntitiesSoFar > 0 {
-		extra = append(extra, fmt.Sprintf("%d entities", r.EntitiesSoFar))
+		extra = append(extra, fmt.Sprintf("%s entities", commafy(int64(r.EntitiesSoFar))))
 	}
 	tail := ""
 	if len(extra) > 0 {
@@ -231,6 +264,23 @@ func (v indexView) metricSuffix() string {
 	return "  " + rowCountStyle.Render(text)
 }
 
+// elapsedText renders the live/frozen elapsed segment for the index header
+// ("2m14s"). Absent (startedAt zero, e.g. a headless test that never called
+// startIndex) returns "" so the header renders exactly as before this
+// feature. While indexing it is computed against time.Now() (so it advances
+// every ~1s tick — see Model's timerMsg handling); once done() it freezes at
+// finishedAt-startedAt so it stops growing with wall-clock time.
+func (v indexView) elapsedText() string {
+	if v.startedAt.IsZero() {
+		return ""
+	}
+	end := time.Now()
+	if v.done() && !v.finishedAt.IsZero() {
+		end = v.finishedAt
+	}
+	return fmtElapsed(end.Sub(v.startedAt))
+}
+
 // view renders the full indexing body (overall bar + per-repo rows + summary).
 func (v indexView) view() string {
 	var b strings.Builder
@@ -257,7 +307,11 @@ func (v indexView) view() string {
 	bar := v.bar
 	bar.Width = width
 
-	b.WriteString(overallLblStyle.Render(fmt.Sprintf("Indexing %s — %s", v.group, label)))
+	head := fmt.Sprintf("Indexing %s — %s", v.group, label)
+	if e := v.elapsedText(); e != "" {
+		head += "  " + g.MidDot + " " + e
+	}
+	b.WriteString(overallLblStyle.Render(head))
 	b.WriteString("\n")
 	b.WriteString(bar.ViewAs(pct))
 	b.WriteString(fmt.Sprintf("  %3d%%", int(pct*100)))
@@ -277,15 +331,34 @@ func (v indexView) view() string {
 		b.WriteString("\n")
 	}
 
-	// Done / error summary.
+	// Done / error / queryable summary.
 	if v.failed {
 		b.WriteString("\n")
 		b.WriteString(rowErrStyle.Render("Index failed: " + v.errMsg))
 	} else if v.terminal {
 		b.WriteString("\n")
 		b.WriteString(v.doneSummary())
+	} else if v.queryable {
+		b.WriteString("\n")
+		b.WriteString(v.queryableBanner())
 	}
 
+	return b.String()
+}
+
+// queryableBanner renders the split-mode "graph queryable, background
+// enhancement still running" sub-state: a checkmark line naming the
+// queryable-time entity count, and a two-choice hint (finish now vs. wait for
+// the full background pass). Shown instead of the Done summary while
+// v.queryable is true and v.terminal is still false.
+func (v indexView) queryableBanner() string {
+	var b strings.Builder
+	b.WriteString(rowDoneStyle.Render(fmt.Sprintf(
+		"%s Graph queryable (%s entities) %s enhancing relationships in the background",
+		g.Check, commafy(v.summaryEntities), g.MidDot)))
+	b.WriteString("\n")
+	b.WriteString(rowCountStyle.Render(
+		"press enter to finish now (safe) " + g.MidDot + " or wait for background to complete"))
 	return b.String()
 }
 
@@ -303,10 +376,10 @@ func (v indexView) doneSummary() string {
 	}
 	parts := []string{head}
 	if v.summaryEntities > 0 {
-		parts = append(parts, fmt.Sprintf("%d entities", v.summaryEntities))
+		parts = append(parts, fmt.Sprintf("%s entities", commafy(v.summaryEntities)))
 	}
 	if v.summaryRels > 0 {
-		parts = append(parts, fmt.Sprintf("%d relationships", v.summaryRels))
+		parts = append(parts, fmt.Sprintf("%s relationships", commafy(v.summaryRels)))
 	}
 	if v.elapsed != "" {
 		parts = append(parts, v.elapsed)

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -1,0 +1,138 @@
+package wiztui
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// TestRenderRow_DistinctModulesRenderDistinctLabels is the RED test for the
+// readable-label bug: a monorepo's RepoSlug (e.g. "some-example-monorepo-main",
+// 26 chars) filled the whole slug column, so truncate() cut every module row
+// down to an identical truncated prefix — the distinguishing Module name was
+// truncated away. Two rows sharing the same (long) RepoSlug but different
+// Modules must render VISIBLY DIFFERENT labels.
+func TestRenderRow_DistinctModulesRenderDistinctLabels(t *testing.T) {
+	v := newIndexView("example", 2)
+	rowA := Row{RepoSlug: "some-example-monorepo-main", Module: "billing-service", Phase: progress.PhaseExtractAST}
+	rowB := Row{RepoSlug: "some-example-monorepo-main", Module: "billing-worker", Phase: progress.PhaseExtractAST}
+
+	spinner := "*"
+	lineA := v.renderRow(rowA, spinner)
+	lineB := v.renderRow(rowB, spinner)
+
+	if lineA == lineB {
+		t.Fatalf("rows with the same RepoSlug but different Module rendered identically:\n%s", lineA)
+	}
+	if !strings.Contains(lineA, "billing-service") {
+		t.Errorf("row A missing its distinguishing module name:\n%s", lineA)
+	}
+	if !strings.Contains(lineB, "billing-worker") {
+		t.Errorf("row B missing its distinguishing module name:\n%s", lineB)
+	}
+}
+
+// TestRenderRow_PlainRepoUsesRepoSlug asserts a plain group repo (Module=="")
+// still labels itself with RepoSlug, unaffected by the module-label fix.
+func TestRenderRow_PlainRepoUsesRepoSlug(t *testing.T) {
+	v := newIndexView("grp", 1)
+	row := Row{RepoSlug: "backend", Phase: progress.PhaseExtractAST}
+	line := v.renderRow(row, "*")
+	if !strings.Contains(line, "backend") {
+		t.Errorf("plain repo row missing RepoSlug label:\n%s", line)
+	}
+}
+
+// TestIndexView_HeaderShowsElapsedWhileIndexing: while indexing (not done),
+// the header includes a live elapsed segment computed from startedAt to now.
+func TestIndexView_HeaderShowsElapsedWhileIndexing(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.startedAt = time.Now().Add(-(2*time.Minute + 5*time.Second))
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, TS: 1})
+
+	out := v.view()
+	if !strings.Contains(out, "2m05s") {
+		t.Errorf("header missing live elapsed segment \"2m05s\":\n%s", out)
+	}
+}
+
+// TestIndexView_HeaderFreezesElapsedOnDone: once terminal, the header shows
+// the FROZEN elapsed (startedAt..finishedAt), not a value that keeps growing
+// with wall-clock time.
+func TestIndexView_HeaderFreezesElapsedOnDone(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.startedAt = time.Now().Add(-10 * time.Minute)  // long ago
+	v.finishedAt = v.startedAt.Add(65 * time.Second) // but it only took 1m05s
+	v.terminal = true
+
+	out := v.view()
+	if !strings.Contains(out, "1m05s") {
+		t.Errorf("header missing frozen elapsed \"1m05s\":\n%s", out)
+	}
+	if strings.Contains(out, "10m00s") {
+		t.Errorf("header shows live wall-clock elapsed instead of the frozen finishedAt-startedAt value:\n%s", out)
+	}
+}
+
+// TestIndexView_QueryableBanner_ShownWhenQueryableNotTerminal: once the graph
+// is queryable but the background enhancement pass hasn't acked yet, the view
+// shows the "graph queryable" banner + the press-enter-or-wait hint instead of
+// jumping straight to the Done summary.
+func TestIndexView_QueryableBanner_ShownWhenQueryableNotTerminal(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseDone, TS: 1})
+	v.queryable = true
+	v.summaryEntities = 4200
+
+	out := v.view()
+	if !strings.Contains(out, "Graph queryable") {
+		t.Errorf("queryable banner missing:\n%s", out)
+	}
+	if !strings.Contains(out, "4,200 entities") {
+		t.Errorf("queryable banner missing commafied entity count:\n%s", out)
+	}
+	if !strings.Contains(out, "enhancing relationships in the background") {
+		t.Errorf("queryable banner missing background-enhancement note:\n%s", out)
+	}
+	if !strings.Contains(out, "press enter to finish now") {
+		t.Errorf("queryable hint missing:\n%s", out)
+	}
+	if strings.Contains(out, "installed") { // doneSummary's install line must NOT render pre-terminal
+		t.Errorf("Done summary rendered while only queryable (not terminal):\n%s", out)
+	}
+}
+
+// TestIndexView_DoneSummary_Commafied asserts doneSummary formats entities and
+// relationships with thousands separators.
+func TestIndexView_DoneSummary_Commafied(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.terminal = true
+	v.summaryEntities = 3686488
+	v.summaryRels = 1000
+	out := v.doneSummary()
+	if !strings.Contains(out, "3,686,488 entities") {
+		t.Errorf("doneSummary missing commafied entities:\n%s", out)
+	}
+	if !strings.Contains(out, "1,000 relationships") {
+		t.Errorf("doneSummary missing commafied relationships:\n%s", out)
+	}
+}
+
+// TestRenderRow_FilesCountCommafied asserts the per-row files-done/total and
+// entities-so-far counters render with thousands separators.
+func TestRenderRow_FilesCountCommafied(t *testing.T) {
+	v := newIndexView("grp", 1)
+	row := Row{RepoSlug: "backend", Phase: progress.PhaseExtractAST, FilesDone: 4100, FilesTotal: 19450, EntitiesSoFar: 12345}
+	line := v.renderRow(row, "*")
+	if !strings.Contains(line, "4,100/19,450 files") {
+		t.Errorf("renderRow missing commafied files count:\n%s", line)
+	}
+	if !strings.Contains(line, "12,345 entities") {
+		t.Errorf("renderRow missing commafied entities count:\n%s", line)
+	}
+}

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -79,7 +79,14 @@ type Driver interface {
 // by the model once the user confirms; the model only renders what flows back.
 type IndexFunc func(r Result) (<-chan prog.Event, <-chan IndexOutcome)
 
-// IndexOutcome is the terminal result of indexing.
+// IndexOutcome is the terminal result of indexing — OR, when Interim is true,
+// an intermediate "graph queryable" checkpoint (#split-mode queryable state):
+// the group's graph is already queryable but the background enhancement pass
+// (linksFn tail) is still running. An interim outcome carries the
+// queryable-time Entities/Rels + the Install summary (install always finishes
+// before indexing starts, so it is safe/complete at interim time too); the
+// model stays on the index screen and keeps waiting for the FINAL
+// (Interim==false) outcome, unless the user presses enter to finish early.
 type IndexOutcome struct {
 	Entities int64
 	Rels     int64
@@ -92,6 +99,10 @@ type IndexOutcome struct {
 	// any non-fatal watcher warnings, captured so the TUI can render them inside
 	// the Done screen instead of letting raw stdout scatter over the alt-screen.
 	Install InstallSummary
+	// Interim marks a non-terminal "graph queryable, background enhancement
+	// still running" checkpoint. At most one interim outcome is ever sent,
+	// always followed by exactly one terminal (Interim==false) outcome.
+	Interim bool
 }
 
 // InstallSummary is the captured, structured outcome of applyGroupConfig's
@@ -184,6 +195,24 @@ func metricsTick(fn MetricsFunc) tea.Cmd {
 	}
 	return tea.Tick(metricsPollInterval, func(time.Time) tea.Msg {
 		return metricsMsg(fn())
+	})
+}
+
+// timerMsg is a no-payload tick used only to force a re-render of the index
+// screen's live elapsed timer (see indexView.elapsedText). The elapsed value
+// itself is computed from indexView.startedAt at render time; this message
+// carries nothing but a "wake up and redraw" signal.
+type timerMsg time.Time
+
+// timerTickInterval is how often the index screen re-renders to advance the
+// live elapsed timer. 1s matches the compact "MmSSs" display's resolution —
+// any faster would waste CPU on a value that can't visibly change.
+const timerTickInterval = 1 * time.Second
+
+// timerTick schedules the next timer tick as a tea.Cmd.
+func timerTick() tea.Cmd {
+	return tea.Tick(timerTickInterval, func(t time.Time) tea.Msg {
+		return timerMsg(t)
 	})
 }
 
@@ -286,7 +315,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case indexStartedMsg:
 		m.evCh = msg.events
 		m.outCh = msg.outcome
-		return m, tea.Batch(m.idx.spin.Tick, waitEvent(m.evCh), waitOutcome(m.outCh), metricsTick(m.metricsFn))
+		return m, tea.Batch(m.idx.spin.Tick, waitEvent(m.evCh), waitOutcome(m.outCh), metricsTick(m.metricsFn), timerTick())
 
 	case progressMsg:
 		m.idx.foldEvent(prog.Event(msg))
@@ -304,6 +333,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case outcomeMsg:
 		o := IndexOutcome(msg)
+		if o.Interim {
+			// Graph queryable, background enhancement still running: capture the
+			// queryable-time stats + install summary, enter the queryable
+			// sub-state, and KEEP waiting — outCh still owes us the final
+			// outcome. Never transitions to scrDone on its own (the user can
+			// press enter to finish early; see updateKey's scrIndex case).
+			m.idx.summaryEntities = o.Entities
+			m.idx.summaryRels = o.Rels
+			m.idx.install = o.Install
+			m.idx.queryable = true
+			return m, waitOutcome(m.outCh)
+		}
 		m.idx.summaryEntities = o.Entities
 		m.idx.summaryRels = o.Rels
 		m.idx.elapsed = o.Elapsed
@@ -320,8 +361,18 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// have arrived after the RPC returned and been dropped (#5340).
 			m.idx.finalizeRows()
 		}
+		m.idx.finishedAt = time.Now()
 		m.scr = scrDone
 		m.step = StepDone
+		return m, nil
+
+	case timerMsg:
+		// Live elapsed timer: re-render at ~1s cadence while the index screen is
+		// active; stop scheduling once it's done (Done/Failed) so the ticker
+		// doesn't run forever in the background.
+		if m.scr == scrIndex && !m.idx.done() {
+			return m, timerTick()
+		}
 		return m, nil
 
 	default:
@@ -352,7 +403,19 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case scrMCP:
 		return m.updateMCP(msg)
 	case scrIndex:
-		// Index screen: only ctrl-c (handled globally) interrupts.
+		// Index screen: ctrl-c (handled globally) interrupts. Once the graph is
+		// queryable but the background enhancement pass hasn't acked yet, enter
+		// also finishes the wizard immediately as SUCCESS using the
+		// already-captured interim stats — the alternative to just waiting for
+		// the final outcome to land on its own.
+		if msg.String() == "enter" && m.idx.queryable && !m.idx.terminal {
+			m.idx.terminal = true
+			m.idx.finalizeRows()
+			m.idx.finishedAt = time.Now()
+			m.scr = scrDone
+			m.step = StepDone
+			return m, nil
+		}
 		return m, nil
 	case scrDone:
 		switch msg.String() {
@@ -594,6 +657,7 @@ func (m Model) startIndex() (tea.Model, tea.Cmd) {
 	}
 	m.idx = newIndexView(name, len(m.res.Repos))
 	m.idx.width = m.width
+	m.idx.startedAt = time.Now()
 	res := m.res
 	start := func() tea.Msg {
 		ev, out := m.index(res)

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -317,6 +317,115 @@ func TestDocsInputAcceptsKeystrokes(t *testing.T) {
 	}
 }
 
+// driveToIndexScreen walks a fresh model through action→select→name→docs to
+// land on scrIndex, for tests that only care about outcome/queryable handling.
+func driveToIndexScreen(t *testing.T, idx IndexFunc) Model {
+	t.Helper()
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/a", Value: "/a", Selected: true},
+	}}
+	m := newTestModel(d, idx)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex", m.scr)
+	}
+	return m
+}
+
+// TestModel_InterimOutcome_EntersQueryableAndKeepsWaiting: an Interim outcome
+// must NOT transition to scrDone — it enters the queryable sub-state, captures
+// the interim stats, and re-arms waitOutcome so the (still-pending) final
+// outcome is not missed.
+func TestModel_InterimOutcome_EntersQueryableAndKeepsWaiting(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+
+	m = m.update(outcomeMsg(IndexOutcome{
+		Interim:  true,
+		Entities: 4200,
+		Rels:     100,
+		Install:  InstallSummary{Applied: true, Hooks: 1},
+	}))
+
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex (interim must not finish the wizard)", m.scr)
+	}
+	if !m.idx.queryable {
+		t.Error("idx.queryable not set after an interim outcome")
+	}
+	if m.idx.terminal {
+		t.Error("idx.terminal set by an interim outcome")
+	}
+	if m.idx.summaryEntities != 4200 || m.idx.summaryRels != 100 {
+		t.Errorf("interim stats not captured: entities=%d rels=%d", m.idx.summaryEntities, m.idx.summaryRels)
+	}
+	if !m.idx.install.Applied {
+		t.Error("interim outcome's Install summary not captured")
+	}
+}
+
+// TestModel_EnterInQueryableState_FinishesWithInterimStats: pressing enter
+// while queryable (but not yet terminal) finishes the wizard immediately as
+// SUCCESS, using the already-captured interim stats.
+func TestModel_EnterInQueryableState_FinishesWithInterimStats(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 777, Rels: 33}))
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex after interim", m.scr)
+	}
+
+	m = m.update(key("enter"))
+
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone after enter in queryable state", m.scr)
+	}
+	if !m.idx.terminal {
+		t.Error("idx.terminal not set after finishing early from queryable")
+	}
+	if m.idx.summaryEntities != 777 || m.idx.summaryRels != 33 {
+		t.Errorf("Done summary lost the interim stats: entities=%d rels=%d", m.idx.summaryEntities, m.idx.summaryRels)
+	}
+}
+
+// TestModel_EnterBeforeQueryable_NoOp: pressing enter on the index screen
+// BEFORE any interim/terminal outcome has landed is a no-op (matches the old
+// ctrl-c-only behavior; a bare enter must not skip the wait).
+func TestModel_EnterBeforeQueryable_NoOp(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(key("enter"))
+	if m.scr != scrIndex {
+		t.Errorf("scr = %v, want scrIndex (enter with no queryable/terminal state must be a no-op)", m.scr)
+	}
+}
+
+// TestModel_FinalOutcomeAfterInterim_ReachesDoneWithFinalStats: the sequence
+// interim → final (the normal background-completes-on-its-own path) lands on
+// scrDone carrying the FINAL stats (which may differ from the interim ones).
+func TestModel_FinalOutcomeAfterInterim_ReachesDoneWithFinalStats(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100, Rels: 10}))
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex after interim", m.scr)
+	}
+
+	m = m.update(outcomeMsg(IndexOutcome{Entities: 500, Rels: 90, Elapsed: "5m00s"}))
+
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone after the final outcome", m.scr)
+	}
+	if !m.idx.terminal {
+		t.Error("idx.terminal not set by the final outcome")
+	}
+	if m.idx.summaryEntities != 500 || m.idx.summaryRels != 90 {
+		t.Errorf("final stats not applied: entities=%d rels=%d", m.idx.summaryEntities, m.idx.summaryRels)
+	}
+	if m.idx.elapsed != "5m00s" {
+		t.Errorf("final elapsed not applied: %q", m.idx.elapsed)
+	}
+}
+
 func nilIndex(Result) (<-chan progress.Event, <-chan IndexOutcome) {
 	ev := make(chan progress.Event)
 	out := make(chan IndexOutcome)

--- a/internal/cli/wiztui/view_test.go
+++ b/internal/cli/wiztui/view_test.go
@@ -151,7 +151,9 @@ func TestIndexView_MonorepoModulesRenderSeparateRows(t *testing.T) {
 	}
 	out := v.view()
 	for _, mod := range []string{"a", "b", "c"} {
-		if !strings.Contains(out, "mono/"+mod) {
+		// The MODULE is the primary per-row label (not "repo/module") — see
+		// TestRenderRow_DistinctModulesRenderDistinctLabels for the bug this fixes.
+		if !strings.Contains(out, mod) {
 			t.Errorf("module row %q missing from view:\n%s", mod, out)
 		}
 	}
@@ -227,7 +229,7 @@ func TestDoneScreen_RendersCapturedSummary(t *testing.T) {
 	withGlyphs(unicodeGlyphs, func() {
 		v := m.View()
 		for _, want := range []string{
-			"1234 entities",
+			"1,234 entities",
 			"56 relationships",
 			"installed 2 hooks " + g.MidDot + " 1 watchers " + g.MidDot + " 3 MCP",
 			g.Warn + " watcher for X not activated",


### PR DESCRIPTION
Wizard indexing TUI polish from live re-testing.

**1. Readable per-module labels** — `renderRow` used `RepoSlug + "/" + Module` truncated to 22 cols, so every monorepo module row rendered identically (the distinguishing name got cut). Now uses the Module basename as the primary label (plain repos keep RepoSlug), column widened to 30, overflow elides from the left to keep the distinguishing tail.

**2. Live elapsed timer** — header shows elapsed time ticking (1s) while indexing, frozen at final on Done.

**3. Thousands-separator counts** — entities/relationships/files render as `3,686,488` instead of `3686488` in rows and the Done summary.

**4. Queryable → "enhancing in background" → Enter-or-wait completion** — split-mode no longer collapses to Done the instant the graph is queryable while the background linksFn/enrichment tail is still running. It shows "Graph queryable · enhancing in background" and lets the user press Enter to finish immediately (safe — the daemon rebuild is unaffected) or wait for the full ack to auto-finish.

Strict TDD; independently reviewed (APPROVE, no blocking issues). All `internal/cli/...` + `wiztui` tests green, `go vet` clean.

Refs #5770, #5729.