### PR TITLE
fix(index): always write graph-stats sidecar counts (kill stale-count divergence)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -656,27 +656,25 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		// along in the stats sidecar and a WARN line is logged on a spike.
 		canaryRaw, canarySpiked := idx.buildParseErrorCanary()
 
-		// Sidecar: corpus-level metrics for `grafel doctor` and the future
-		// MCP `graph_stats` tool. Only written when Pass 4 actually ran.
-		if doc.AlgorithmStats != nil {
-			side := &graph.GraphStatsSidecar{
-				Version:            1,
-				ComputedAt:         deterministicGeneratedAt(),
-				TotalFiles:         doc.Stats.Files,
-				TotalEntities:      doc.Stats.Entities,
-				TotalRelationships: doc.Stats.Relationships,
-				Communities:        doc.AlgorithmStats.NumCommunities,
-				Modularity:         doc.AlgorithmStats.LouvainModularity,
-				GodNodes:           doc.AlgorithmStats.NumGodNodes,
-				ArticulationPoints: doc.AlgorithmStats.NumArticulationPts,
-				RuntimeMS:          doc.AlgorithmStats.RuntimeMS,
-				ExtractMS:          extractMS,
-				ParseErrorCanary:   canaryRaw,
-				ParseErrorSpike:    canarySpiked,
-			}
-			if err := graph.WriteSidecar(outPath, side, pretty); err != nil {
-				fmt.Fprintf(os.Stderr, "grafel: sidecar write failed: %v\n", err)
-			}
+		// Sidecar: corpus-level metrics for `grafel doctor` and the MCP
+		// `graph_stats` tool. Written on EVERY build, not just when Pass 4
+		// (graph-algo) ran (#task-31 / count-drift bug): the daemon's
+		// reactive/rebuild reindex always runs with --skip-pass=graph-algo,
+		// so doc.AlgorithmStats is nil on that path. Gating the whole
+		// sidecar write behind AlgorithmStats != nil meant graph.fb was
+		// rewritten with fresh counts but graph-stats.json kept an
+		// arbitrarily stale count forever — silently diverging from the
+		// graph it's supposed to summarise. The counts (+ extract timing +
+		// parse-error canary) are now always refreshed from this build; the
+		// algorithm-derived fields (communities/modularity/god
+		// nodes/articulation points/runtime) are read-merged from the prior
+		// sidecar when Pass 4 didn't run, so a skip-graph-algo reindex can
+		// never zero out real algorithm data that a previous full build
+		// computed.
+		prior, _ := graph.LoadSidecar(filepath.Dir(outPath))
+		side := buildStatsSidecar(doc, extractMS, canaryRaw, canarySpiked, prior, deterministicGeneratedAt())
+		if err := graph.WriteSidecar(outPath, side, pretty); err != nil {
+			fmt.Fprintf(os.Stderr, "grafel: sidecar write failed: %v\n", err)
 		}
 	}
 

--- a/cmd/grafel/sidecar_build.go
+++ b/cmd/grafel/sidecar_build.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// buildStatsSidecar constructs the graph-stats.json payload for the index
+// pass that just produced doc. It is a pure function (no I/O) so the
+// count-drift regression (#task-31: graph.fb rewritten with fresh counts
+// while graph-stats.json kept an arbitrarily stale count because the whole
+// sidecar write was gated behind doc.AlgorithmStats != nil) can be covered
+// by unit tests without touching the filesystem.
+//
+// Counts (TotalFiles/TotalEntities/TotalRelationships), ExtractMS, and the
+// parse-error canary are ALWAYS taken from the fresh build — they must never
+// be allowed to diverge from graph.fb.
+//
+// The algorithm-derived fields (Communities/Modularity/GodNodes/
+// ArticulationPoints/RuntimeMS) come from doc.AlgorithmStats when Pass 4
+// (graph-algo) ran. When it was skipped (doc.AlgorithmStats == nil — the
+// daemon's reactive/rebuild reindex path always skips it), those fields are
+// carried forward from prior (the previously-written sidecar, or nil if
+// none exists yet) rather than zeroed, so a skip-graph-algo reindex never
+// wipes out real algorithm data computed by an earlier full build.
+func buildStatsSidecar(
+	doc *graph.Document,
+	extractMS int64,
+	canaryRaw json.RawMessage,
+	canarySpiked bool,
+	prior *graph.GraphStatsSidecar,
+	computedAt time.Time,
+) *graph.GraphStatsSidecar {
+	side := &graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         computedAt,
+		TotalFiles:         doc.Stats.Files,
+		TotalEntities:      doc.Stats.Entities,
+		TotalRelationships: doc.Stats.Relationships,
+		ExtractMS:          extractMS,
+		ParseErrorCanary:   canaryRaw,
+		ParseErrorSpike:    canarySpiked,
+	}
+
+	if doc.AlgorithmStats != nil {
+		side.Communities = doc.AlgorithmStats.NumCommunities
+		side.Modularity = doc.AlgorithmStats.LouvainModularity
+		side.GodNodes = doc.AlgorithmStats.NumGodNodes
+		side.ArticulationPoints = doc.AlgorithmStats.NumArticulationPts
+		side.RuntimeMS = doc.AlgorithmStats.RuntimeMS
+	} else if prior != nil {
+		side.Communities = prior.Communities
+		side.Modularity = prior.Modularity
+		side.GodNodes = prior.GodNodes
+		side.ArticulationPoints = prior.ArticulationPoints
+		side.RuntimeMS = prior.RuntimeMS
+	}
+
+	return side
+}

--- a/cmd/grafel/sidecar_build_test.go
+++ b/cmd/grafel/sidecar_build_test.go
@@ -1,0 +1,130 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestBuildStatsSidecar_AlgoNil_CountsAlwaysWritten is the regression guard
+// for the bug where the daemon's reactive/rebuild reindex runs with
+// --skip-pass=graph-algo (AlgorithmStats == nil), which previously skipped
+// the sidecar write entirely and left graph-stats.json holding a stale
+// count while graph.fb held the fresh one. The sidecar must now always be
+// built (and thus written) with the fresh counts, regardless of whether
+// Pass 4 ran.
+func TestBuildStatsSidecar_AlgoNil_CountsAlwaysWritten(t *testing.T) {
+	doc := &graph.Document{
+		Stats: graph.Stats{Files: 10, Entities: 200, Relationships: 66000},
+	}
+	side := buildStatsSidecar(doc, 1500, nil, false, nil, time.Unix(1000, 0).UTC())
+
+	if side == nil {
+		t.Fatalf("buildStatsSidecar returned nil; sidecar must always be built so it can be written")
+	}
+	if side.TotalFiles != 10 || side.TotalEntities != 200 || side.TotalRelationships != 66000 {
+		t.Errorf("counts not carried from fresh doc.Stats: %+v", side)
+	}
+	if side.ExtractMS != 1500 {
+		t.Errorf("extract_ms: got %d, want 1500", side.ExtractMS)
+	}
+	if side.Version != 1 {
+		t.Errorf("version: got %d, want 1", side.Version)
+	}
+}
+
+// TestBuildStatsSidecar_AlgoNil_PreservesPriorAlgoFields verifies that when
+// Pass 4 (graph-algo) was skipped, any pre-existing algorithm-derived fields
+// (communities, modularity, god nodes, articulation points, runtime) are
+// carried forward from the prior sidecar rather than zeroed out, while the
+// counts are refreshed to the new build's values.
+func TestBuildStatsSidecar_AlgoNil_PreservesPriorAlgoFields(t *testing.T) {
+	doc := &graph.Document{
+		Stats: graph.Stats{Files: 12, Entities: 300, Relationships: 500},
+	}
+	prior := &graph.GraphStatsSidecar{
+		Version:            1,
+		TotalEntities:      999999, // stale — must NOT leak through
+		TotalRelationships: 3561346,
+		Communities:        7,
+		Modularity:         0.42,
+		GodNodes:           3,
+		ArticulationPoints: 5,
+		RuntimeMS:          8800,
+	}
+
+	side := buildStatsSidecar(doc, 2000, nil, false, prior, time.Unix(2000, 0).UTC())
+
+	if side.TotalEntities != 300 || side.TotalRelationships != 500 || side.TotalFiles != 12 {
+		t.Errorf("counts must be refreshed from fresh doc.Stats, not carried from prior: %+v", side)
+	}
+	if side.Communities != 7 || side.Modularity != 0.42 || side.GodNodes != 3 ||
+		side.ArticulationPoints != 5 || side.RuntimeMS != 8800 {
+		t.Errorf("algorithm fields must be carried forward from prior sidecar: %+v", side)
+	}
+}
+
+// TestBuildStatsSidecar_AlgoNil_NoPriorSidecar verifies that when Pass 4 was
+// skipped AND there is no pre-existing sidecar (first-ever index, or one
+// deleted), the algorithm fields simply default to zero rather than erroring.
+func TestBuildStatsSidecar_AlgoNil_NoPriorSidecar(t *testing.T) {
+	doc := &graph.Document{
+		Stats: graph.Stats{Files: 1, Entities: 5, Relationships: 4},
+	}
+	side := buildStatsSidecar(doc, 10, nil, false, nil, time.Unix(3000, 0).UTC())
+
+	if side.TotalEntities != 5 || side.TotalRelationships != 4 {
+		t.Errorf("counts: %+v", side)
+	}
+	if side.Communities != 0 || side.Modularity != 0 || side.GodNodes != 0 ||
+		side.ArticulationPoints != 0 || side.RuntimeMS != 0 {
+		t.Errorf("algorithm fields must default to zero with no prior sidecar: %+v", side)
+	}
+}
+
+// TestBuildStatsSidecar_AlgoPresent_AllFieldsFromFreshBuild verifies that
+// when Pass 4 DID run, all fields (counts + algorithm) come from the fresh
+// build, exactly as before this fix — even if a prior sidecar with
+// different algorithm values is passed in (it must be ignored in favor of
+// the fresh AlgorithmStats).
+func TestBuildStatsSidecar_AlgoPresent_AllFieldsFromFreshBuild(t *testing.T) {
+	doc := &graph.Document{
+		Stats: graph.Stats{Files: 20, Entities: 400, Relationships: 900},
+		AlgorithmStats: &graph.AlgorithmStats{
+			NumCommunities:     11,
+			LouvainModularity:  0.55,
+			NumGodNodes:        2,
+			NumArticulationPts: 6,
+			RuntimeMS:          4321,
+		},
+	}
+	prior := &graph.GraphStatsSidecar{
+		Communities:        999,
+		Modularity:         0.01,
+		GodNodes:           999,
+		ArticulationPoints: 999,
+		RuntimeMS:          999,
+	}
+	canary := json.RawMessage(`{"spiked":false}`)
+
+	side := buildStatsSidecar(doc, 777, canary, true, prior, time.Unix(4000, 0).UTC())
+
+	if side.TotalFiles != 20 || side.TotalEntities != 400 || side.TotalRelationships != 900 {
+		t.Errorf("counts: %+v", side)
+	}
+	if side.Communities != 11 || side.Modularity != 0.55 || side.GodNodes != 2 ||
+		side.ArticulationPoints != 6 || side.RuntimeMS != 4321 {
+		t.Errorf("algorithm fields must come from fresh AlgorithmStats, not prior: %+v", side)
+	}
+	if side.ExtractMS != 777 {
+		t.Errorf("extract_ms: got %d, want 777", side.ExtractMS)
+	}
+	if !side.ParseErrorSpike {
+		t.Errorf("parse_error_spike: got false, want true")
+	}
+	if string(side.ParseErrorCanary) != string(canary) {
+		t.Errorf("parse_error_canary not carried through: %s", side.ParseErrorCanary)
+	}
+}


### PR DESCRIPTION
The `graph-stats.json` sidecar (read by the wizard, `grafel status`, dashboard, `doctor`) was written only when the graph-algo pass ran (`doc.AlgorithmStats != nil`). The daemon reindex runs `--skip-pass=graph-algo`, so every daemon rebuild rewrote `graph.fb` with fresh counts but left a **stale count** in the sidecar — surfacing wildly wrong figures (a user saw 3.56M relationships for a graph that actually had ~66k) and the entities:0/relationships:0 status-plane report.

**Fix:** always write the sidecar. New pure helper `buildStatsSidecar` sets counts/extract-time/parse-canary unconditionally from the fresh build; the 5 algorithm-derived fields (communities/modularity/god-nodes/articulation-points/runtime) come from the fresh graph-algo pass when it ran, else are carried forward from the prior sidecar (via `graph.LoadSidecar`) so they're never clobbered with zeros. Counts can no longer diverge from `graph.fb`.

Does NOT touch the commit-coupling edge pass (the underlying full-build-only magnitude is a separate, deferred item).

Strict TDD (4 helper tests covering all branches); independently reviewed (APPROVE). Build/vet clean; 6000+ tests pass incl. golden.

Closes #31.