### PR TITLE
fix(wiztui): seed a row for every selected repo so an indexed repo can't render invisibly

### DIFF
--- a/internal/cli/repair_broker.go
+++ b/internal/cli/repair_broker.go
@@ -380,4 +380,10 @@ type rebuildOutcome struct {
 	entities int64
 	rels     int64
 	err      error
+	// repoStats carries the split-mode status-plane classify's per-repo final
+	// stats (see splitResult.Repos), threaded to the wiztui model so a repo
+	// that emitted zero progress events still shows its real count on
+	// completion (#seed-rows dropped-row fix). nil in monolith mode (the RPC
+	// reply has no per-repo breakdown).
+	repoStats []splitRepoResult
 }

--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -121,6 +121,28 @@ type splitResult struct {
 	// may be 0 on the wizard path where the graph-stats sidecar isn't written).
 	Entities int64
 	Rels     int64
+	// Repos carries the PER-REPO classified result (slug, entities, rels,
+	// advanced-vs-failed) for every repo in the group config, one entry each —
+	// the same repos summed into Entities/Rels above, individually broken out.
+	// Threaded to the wiztui model (via rebuildOutcome.repoStats →
+	// IndexOutcome.RepoStats) so a repo whose progress SSE events never
+	// arrived still gets its real final count and Done/Error state on the
+	// completion screen instead of staying blank/queued (#seed-rows dropped-
+	// row fix — the live bug where a 3-repo group's per-repo rows summed to
+	// less than the reported aggregate total).
+	Repos []splitRepoResult
+}
+
+// splitRepoResult is one repo's classified final result (see
+// splitResult.Repos). Slug matches registry.Repo.Slug / the progress.Event
+// RepoSlug the same repo's SSE ticks carry, so it overlays the correct wiztui
+// row rather than creating a duplicate.
+type splitRepoResult struct {
+	Slug     string
+	Entities int64
+	Rels     int64
+	Failed   bool
+	Reason   string // non-empty only when Failed
 }
 
 // splitProbe is the seam the completion loop polls. Poll is called repeatedly;
@@ -275,8 +297,9 @@ func runSplitIndexCore(
 		return rebuildOutcome{err: fmt.Errorf("index did not complete for %d repo(s): %s", len(res.Failed), strings.Join(res.Failed, "; "))}
 	}
 	return rebuildOutcome{
-		entities: res.Entities,
-		rels:     res.Rels,
+		entities:  res.Entities,
+		rels:      res.Rels,
+		repoStats: res.Repos,
 	}
 }
 
@@ -391,10 +414,12 @@ func (p *statusPlaneProbe) Poll() (splitPoll, error) {
 func (p *statusPlaneProbe) Classify() (splitResult, error) {
 	var res splitResult
 	for _, rp := range p.repoPaths {
+		slug := filepath.Base(rp)
 		f, ok := p.readStatus(rp)
 		if ok && repoAdvanced(f, p.baseline[rp]) {
 			res.Entities += f.Entities
 			res.Rels += f.Relationships
+			res.Repos = append(res.Repos, splitRepoResult{Slug: slug, Entities: f.Entities, Rels: f.Relationships})
 			continue
 		}
 		reason := "produced no graph"
@@ -406,7 +431,8 @@ func (p *statusPlaneProbe) Classify() (splitResult, error) {
 				reason = "still indexing when the rebuild acked"
 			}
 		}
-		res.Failed = append(res.Failed, fmt.Sprintf("%s (%s)", filepath.Base(rp), reason))
+		res.Failed = append(res.Failed, fmt.Sprintf("%s (%s)", slug, reason))
+		res.Repos = append(res.Repos, splitRepoResult{Slug: slug, Failed: true, Reason: reason})
 	}
 	return res, nil
 }

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -883,3 +883,39 @@ func TestMakeIndexFunc_SeedsQueuedRowForEverySelectedRepo(t *testing.T) {
 		t.Fatalf("seeded slugs = %v, want both %q and %q", seeded, wantA, wantB)
 	}
 }
+
+// TestMakeIndexFunc_MonorepoDoesNotSeedQueuedRows is the BLOCKING-regression
+// guard: for a MONOREPO action, reposForResult collapses to ONE registry.Repo
+// (root slug, packages in .Modules) but real progress is PER-MODULE (#5751),
+// so seeding a bare repo-level row would neither merge with the per-module
+// event keys nor be suppressed by the repo-row guard — producing a spurious
+// repo-level row that doubles the visible entity total. The IndexFunc must
+// therefore emit ZERO PhaseQueued events for a monorepo.
+func TestMakeIndexFunc_MonorepoDoesNotSeedQueuedRows(t *testing.T) {
+	dir := testsupport.IsolateHome(t)
+	monorepo := t.TempDir()
+
+	var out, errOut bytes.Buffer
+	class, _ := detect.ClassifyPath(monorepo)
+	opts := wizardOptions{NoIndex: true, RunInstall: false}
+	idxFn := makeIndexFunc(&out, &errOut, class, opts, nil)
+
+	res := wiztui.Result{
+		Action:    wiztui.ActionMonorepo,
+		Repos:     []string{"services/auth", "packages/ui"}, // chosen packages → Modules
+		GroupName: "mono-test-group-" + filepath.Base(dir),
+	}
+
+	evCh, outCh := idxFn(res)
+	seeded := 0
+	for e := range evCh {
+		if e.Phase == wiztui.PhaseQueued {
+			seeded++
+		}
+	}
+	<-outCh
+
+	if seeded != 0 {
+		t.Fatalf("monorepo emitted %d PhaseQueued seed events; want 0 (a bare repo-level seed row doubles the entity total)", seeded)
+	}
+}

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -4,16 +4,20 @@ package cli
 // detection. All fakes; no real daemon, no real index, no real sleeps.
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/cli/wiztui"
+	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/statusfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // fakeSplitClock advances virtual time on Sleep so the poll loop's timeout
@@ -703,5 +707,179 @@ func TestMonolith_CompletesAtRPCReturnWithRPCStats(t *testing.T) {
 	}
 	if o.entities != 111 || o.rels != 222 {
 		t.Fatalf("monolith stats = (%d,%d); want (111,222) from the RPC reply", o.entities, o.rels)
+	}
+}
+
+// --- Per-repo classify stats (#seed-rows dropped-row fix, part 2) ---
+
+// TestStatusProbe_ClassifyPopulatesPerRepoStats: Classify must return a
+// splitRepoResult per group repo (slug/entities/rels/advanced-vs-failed), not
+// just the aggregate — this is what lets the wiztui model populate a row for
+// a repo that emitted zero progress events, sourced from the status plane
+// rather than folded SSE ticks.
+func TestStatusProbe_ClassifyPopulatesPerRepoStats(t *testing.T) {
+	const repoA, repoB, repoC = "/repo/core-mobile", "/repo/upvate_core", "/repo/upvate_core_frontend"
+	store := newFakeStatusStore()
+	probe := newStatusPlaneProbeWith([]string{repoA, repoB, repoC}, "/root", store.read, aliveLiveness, pendingUntil(1))
+
+	// All three advance past baseline (0) — including repoC, which never
+	// reported a single progress tick over SSE (the live bug scenario).
+	store.set(repoA, &statusfile.File{Indexing: false, GraphFBMtime: 100, Entities: 8383, Relationships: 9000})
+	store.set(repoB, &statusfile.File{Indexing: false, GraphFBMtime: 100, Entities: 6039, Relationships: 7000})
+	store.set(repoC, &statusfile.File{Indexing: false, GraphFBMtime: 100, Entities: 17270, Relationships: 18000})
+
+	res, err := probe.Classify()
+	if err != nil {
+		t.Fatalf("Classify: %v", err)
+	}
+	if len(res.Repos) != 3 {
+		t.Fatalf("len(Repos) = %d, want 3 (one per group repo, even one with zero progress events)", len(res.Repos))
+	}
+	byslug := map[string]splitRepoResult{}
+	for _, r := range res.Repos {
+		byslug[r.Slug] = r
+	}
+	c, ok := byslug["upvate_core_frontend"]
+	if !ok {
+		t.Fatal("silent repo (upvate_core_frontend) missing from Classify's per-repo stats")
+	}
+	if c.Failed {
+		t.Error("silent-but-advanced repo incorrectly marked Failed")
+	}
+	if c.Entities != 17270 || c.Rels != 18000 {
+		t.Errorf("silent repo stats = (%d,%d), want (17270,18000)", c.Entities, c.Rels)
+	}
+
+	var sum int64
+	for _, r := range res.Repos {
+		sum += r.Entities
+	}
+	if sum != res.Entities {
+		t.Errorf("sum of per-repo Entities = %d, want %d (must match the aggregate)", sum, res.Entities)
+	}
+}
+
+// TestStatusProbe_ClassifyPerRepoStats_MarksFailedRepo: a repo that never
+// advances is reported in Repos as Failed with a reason, alongside the
+// existing aggregate Failed slice.
+func TestStatusProbe_ClassifyPerRepoStats_MarksFailedRepo(t *testing.T) {
+	const repoOK, repoBad = "/repo/backend", "/repo/docs-only"
+	store := newFakeStatusStore()
+	probe := newStatusPlaneProbeWith([]string{repoOK, repoBad}, "/root", store.read, aliveLiveness, pendingUntil(1))
+	store.set(repoOK, &statusfile.File{Indexing: false, GraphFBMtime: 100, Entities: 10})
+	// repoBad never produces a graph.
+
+	res, _ := probe.Classify()
+	var bad splitRepoResult
+	found := false
+	for _, r := range res.Repos {
+		if r.Slug == "docs-only" {
+			bad = r
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("failed repo missing from per-repo Repos")
+	}
+	if !bad.Failed {
+		t.Error("Failed = false, want true")
+	}
+	if bad.Reason == "" {
+		t.Error("Reason empty for a failed repo")
+	}
+}
+
+// TestRunSplitIndexCore_ThreadsPerRepoStatsIntoOutcome: a successful split
+// index's rebuildOutcome carries the classify's per-repo breakdown, and
+// toIndexOutcome maps it through to wiztui.IndexOutcome.RepoStats so the
+// model can populate a silent repo's row.
+func TestRunSplitIndexCore_ThreadsPerRepoStatsIntoOutcome(t *testing.T) {
+	probe := &fakeProbe{
+		pollFn: func(call int) splitPoll { return splitPoll{RequestPending: call < 2, EngineAlive: true} },
+		classify: splitResult{
+			Entities: 31692, Rels: 40000,
+			Repos: []splitRepoResult{
+				{Slug: "core-mobile", Entities: 8383, Rels: 9000},
+				{Slug: "upvate_core", Entities: 6039, Rels: 7000},
+				{Slug: "upvate_core_frontend", Entities: 17270, Rels: 24000},
+			},
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if len(o.repoStats) != 3 {
+		t.Fatalf("len(o.repoStats) = %d, want 3", len(o.repoStats))
+	}
+
+	oc := toIndexOutcome(o, wiztui.InstallSummary{})
+	if len(oc.RepoStats) != 3 {
+		t.Fatalf("len(IndexOutcome.RepoStats) = %d, want 3", len(oc.RepoStats))
+	}
+	found := false
+	for _, rs := range oc.RepoStats {
+		if rs.Slug == "upvate_core_frontend" {
+			found = true
+			if rs.Entities != 17270 {
+				t.Errorf("silent repo Entities = %d, want 17270", rs.Entities)
+			}
+			if rs.Failed {
+				t.Error("silent-but-advanced repo incorrectly Failed")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("silent repo missing from mapped IndexOutcome.RepoStats")
+	}
+}
+
+// TestMakeIndexFunc_SeedsQueuedRowForEverySelectedRepo: the IndexFunc must
+// emit a PhaseQueued progress event for every repo in the selection BEFORE
+// any real indexing work — the fix for the dropped-row bug where a repo with
+// no real progress events never got a row at all. Uses --no-index so the
+// test never touches a real daemon; group registration still runs against a
+// throwaway GRAFEL_HOME.
+func TestMakeIndexFunc_SeedsQueuedRowForEverySelectedRepo(t *testing.T) {
+	dir := testsupport.IsolateHome(t)
+
+	repoA := t.TempDir()
+	repoB := t.TempDir()
+
+	var out, errOut bytes.Buffer
+	class, _ := detect.ClassifyPath(repoA)
+	opts := wizardOptions{NoIndex: true, RunInstall: false}
+	idxFn := makeIndexFunc(&out, &errOut, class, opts, nil)
+
+	res := wiztui.Result{
+		Action:    wiztui.ActionGroup,
+		Repos:     []string{repoA, repoB},
+		GroupName: "seed-test-group-" + filepath.Base(dir),
+	}
+
+	evCh, outCh := idxFn(res)
+
+	var seeded []string
+	for e := range evCh {
+		if e.Phase == wiztui.PhaseQueued {
+			seeded = append(seeded, e.RepoSlug)
+		}
+	}
+	<-outCh // drain to let the goroutine finish cleanly
+
+	wantA, wantB := filepath.Base(repoA), filepath.Base(repoB)
+	gotA, gotB := false, false
+	for _, s := range seeded {
+		if s == wantA {
+			gotA = true
+		}
+		if s == wantB {
+			gotB = true
+		}
+	}
+	if !gotA || !gotB {
+		t.Fatalf("seeded slugs = %v, want both %q and %q", seeded, wantA, wantB)
 	}
 }

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -259,6 +259,23 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 
 			repos := reposForResult(class, r)
 
+			// perRepoRows gates BOTH the up-front row seeding AND the
+			// classify-sourced per-repo stat overlay to the FLAT-REPO actions
+			// (single / group / add-to-group), where every repo emits
+			// repo-level progress events (Module=="") keyed by its slug and the
+			// status-plane classify returns one aggregate per repo. A MONOREPO
+			// is deliberately excluded: reposForResult collapses it to ONE
+			// registry.Repo (root slug, packages in .Modules), but its real
+			// progress is PER-MODULE (#5751 — events carry Module="pkg/x", keyed
+			// monorepoSlug/pkg/x) and Classify returns a single whole-repo
+			// aggregate. Seeding a bare repo-level row (key monorepoSlug, no
+			// module) would neither merge with the per-module events NOR be
+			// suppressed by the #5340/#5751 repo-row guard, and stamping the
+			// whole-repo aggregate onto it would DOUBLE the visible entity total
+			// (spurious repo row + N module rows). Monorepo modules already
+			// render via SSE + finalizeRows, so we leave that path untouched.
+			perRepoRows := r.Action != wiztui.ActionMonorepo
+
 			// Seed a "queued" row for every selected repo BEFORE any real work
 			// starts (fix part 1, #seed-rows dropped-row bug): per-repo rows
 			// used to be created ONLY when a broker/SSE progress event arrived,
@@ -266,13 +283,17 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 			// racing the forwarder, a dropped batch, a subprocess-IPC gap)
 			// never got a row at all — even though it indexed successfully and
 			// its watcher was installed. Seeding with repo.Slug (the SAME slug
-			// real progress.Event.RepoSlug values carry — see repoFromPath /
-			// monorepoRepoForChosen) guarantees the seed row MERGES with real
-			// events for that repo instead of duplicating (see
-			// indexView.foldEvent's PhaseQueued bypass). Buffered generously
-			// (64-cap evCh), so this never blocks even for a large group.
-			for _, repo := range repos {
-				evCh <- progress.Event{RepoSlug: repo.Slug, Phase: wiztui.PhaseQueued}
+			// real progress.Event.RepoSlug values carry — see repoFromPath)
+			// guarantees the seed row MERGES with real events for that repo
+			// instead of duplicating (see indexView.foldEvent's PhaseQueued
+			// bypass). These sends run on THIS index goroutine while the model
+			// drains evCh (it starts reading once indexStartedMsg lands), so a
+			// group larger than evCh's 64-slot buffer simply back-pressures this
+			// goroutine briefly rather than dropping seeds or deadlocking.
+			if perRepoRows {
+				for _, repo := range repos {
+					evCh <- progress.Event{RepoSlug: repo.Slug, Phase: wiztui.PhaseQueued}
+				}
 			}
 
 			// Resolve the MCP-tools selection (#5344): the picker screen sets
@@ -294,7 +315,7 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 					outCh <- wiztui.IndexOutcome{Err: err}
 					return
 				}
-				streamIndexWithSummary(evCh, outCh, r.AddToGroup, opts.NoIndex, wiztui.InstallSummary{})
+				streamIndexWithSummary(evCh, outCh, r.AddToGroup, opts.NoIndex, wiztui.InstallSummary{}, perRepoRows)
 				return
 			}
 
@@ -306,7 +327,7 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 				outCh <- wiztui.IndexOutcome{Err: err}
 				return
 			}
-			streamIndexWithSummary(evCh, outCh, cfg.Name, opts.NoIndex, installSummary(res))
+			streamIndexWithSummary(evCh, outCh, cfg.Name, opts.NoIndex, installSummary(res), perRepoRows)
 		}()
 
 		return evCh, outCh
@@ -335,7 +356,14 @@ func installSummary(res *install.Result) wiztui.InstallSummary {
 // progress events onto evCh, then sends the terminal outcome on outCh — with the
 // captured install summary attached so the Done screen renders it. A down daemon
 // or --no-index is a soft completion (DaemonDown), not an error.
-func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, group string, noIndex bool, summary wiztui.InstallSummary) {
+//
+// perRepoRows gates whether the split-mode classify's per-repo stats are
+// forwarded to the model as IndexOutcome.RepoStats: true for flat-repo actions
+// (single/group/add-group, one repo-level row per repo), false for a monorepo
+// (whose one aggregate classify entry must NOT be stamped onto a spurious
+// repo-level row — see makeIndexFunc's perRepoRows doc). It has no effect in
+// monolith mode, which never produces per-repo classify stats.
+func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.IndexOutcome, group string, noIndex bool, summary wiztui.InstallSummary, perRepoRows bool) {
 	if noIndex {
 		outCh <- wiztui.IndexOutcome{DaemonDown: true, Install: summary}
 		return
@@ -381,15 +409,22 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 		// already complete by this point (makeIndexFunc runs it before
 		// streamIndexWithSummary), so it's safe to attach the same summary here.
 		onQueryable := func(res splitResult) {
+			stats := res.Repos
+			if !perRepoRows {
+				stats = nil // monorepo: no per-repo row overlay (avoids the double-count)
+			}
 			outCh <- wiztui.IndexOutcome{
 				Interim:   true,
 				Entities:  res.Entities,
 				Rels:      res.Rels,
 				Install:   summary,
-				RepoStats: toWiztuiRepoStats(res.Repos),
+				RepoStats: toWiztuiRepoStats(stats),
 			}
 		}
 		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh, onQueryable)
+		if !perRepoRows {
+			o.repoStats = nil // monorepo: suppress the aggregate-as-repo-row overlay
+		}
 		outCh <- toIndexOutcome(o, summary)
 		return
 	}

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -259,6 +259,22 @@ func makeIndexFunc(out, errOut io.Writer, class detect.Classification, opts wiza
 
 			repos := reposForResult(class, r)
 
+			// Seed a "queued" row for every selected repo BEFORE any real work
+			// starts (fix part 1, #seed-rows dropped-row bug): per-repo rows
+			// used to be created ONLY when a broker/SSE progress event arrived,
+			// so a repo whose events were missed/dropped/raced (a fast repo
+			// racing the forwarder, a dropped batch, a subprocess-IPC gap)
+			// never got a row at all — even though it indexed successfully and
+			// its watcher was installed. Seeding with repo.Slug (the SAME slug
+			// real progress.Event.RepoSlug values carry — see repoFromPath /
+			// monorepoRepoForChosen) guarantees the seed row MERGES with real
+			// events for that repo instead of duplicating (see
+			// indexView.foldEvent's PhaseQueued bypass). Buffered generously
+			// (64-cap evCh), so this never blocks even for a large group.
+			for _, repo := range repos {
+				evCh <- progress.Event{RepoSlug: repo.Slug, Phase: wiztui.PhaseQueued}
+			}
+
 			// Resolve the MCP-tools selection (#5344): the picker screen sets
 			// r.MCPTools; when a flag preset the choice the screen was skipped
 			// and r.MCPTools is nil, so fall back to opts.MCPTools.
@@ -366,10 +382,11 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 		// streamIndexWithSummary), so it's safe to attach the same summary here.
 		onQueryable := func(res splitResult) {
 			outCh <- wiztui.IndexOutcome{
-				Interim:  true,
-				Entities: res.Entities,
-				Rels:     res.Rels,
-				Install:  summary,
+				Interim:   true,
+				Entities:  res.Entities,
+				Rels:      res.Rels,
+				Install:   summary,
+				RepoStats: toWiztuiRepoStats(res.Repos),
 			}
 		}
 		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh, onQueryable)
@@ -502,11 +519,32 @@ func toIndexOutcome(o rebuildOutcome, summary wiztui.InstallSummary) wiztui.Inde
 		elapsed = fmtDuration(time.Duration(o.elapsed * float64(time.Second)))
 	}
 	return wiztui.IndexOutcome{
-		Entities: o.entities,
-		Rels:     o.rels,
-		Elapsed:  elapsed,
-		Install:  summary,
+		Entities:  o.entities,
+		Rels:      o.rels,
+		Elapsed:   elapsed,
+		Install:   summary,
+		RepoStats: toWiztuiRepoStats(o.repoStats),
 	}
+}
+
+// toWiztuiRepoStats maps the split-mode classify's per-repo results to the
+// wiztui model's RepoStat shape, keeping wiztui decoupled from the cli
+// package's internal splitRepoResult type.
+func toWiztuiRepoStats(repos []splitRepoResult) []wiztui.RepoStat {
+	if len(repos) == 0 {
+		return nil
+	}
+	out := make([]wiztui.RepoStat, 0, len(repos))
+	for _, r := range repos {
+		out = append(out, wiztui.RepoStat{
+			Slug:     r.Slug,
+			Entities: r.Entities,
+			Rels:     r.Rels,
+			Failed:   r.Failed,
+			Error:    r.Reason,
+		})
+	}
+	return out
 }
 
 // addReposToExistingGroupNoIndex appends repos to an existing group and applies

--- a/internal/cli/wiztui/fold.go
+++ b/internal/cli/wiztui/fold.go
@@ -20,7 +20,22 @@ import (
 // Phase labels, kept in lock-step with the dashboard PHASE_LABEL and the CLI
 // renderer so all three surfaces speak the same human phrase for the same
 // phase (#5334).
+// PhaseQueued is the synthetic seed phase folded into a row for every
+// selected repo the moment indexing starts, BEFORE any real broker/SSE
+// progress event has arrived for it. Rows are keyed by repo slug (see
+// rowKey), so a queued row created with this phase MERGES with the real
+// progress events that follow for the same repo instead of duplicating —
+// Fold's monotonic-phase rule (phaseRank(PhaseQueued) is unknown → -1, lower
+// than every real phase) guarantees the first real event always advances
+// past it. This closes the dropped-row bug where a repo whose progress
+// events were missed/dropped/raced never got a row at all: seeding
+// unconditionally guarantees one row per selected repo up front, and
+// indexView.applyRepoStats backstops the final count/state from the
+// split-mode classify even if no real event ever arrived.
+const PhaseQueued = "queued"
+
 var phaseLabel = map[string]string{
+	PhaseQueued:                     "Queued…",
 	progress.PhaseScan:              "Scanning…",
 	progress.PhaseExtractAST:        "Extracting AST…",
 	progress.PhaseResolveRefs:       "Resolving references…",

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -44,6 +44,14 @@ type indexView struct {
 	// Model's outcomeMsg handling and the scrIndex enter key case.
 	queryable bool
 
+	// interimRepoStats holds the per-repo classify stats carried by the interim
+	// (queryable) outcome, stashed so that if the user presses enter to FINISH
+	// EARLY (before the terminal outcome lands) the enter-early finalize can
+	// still overlay real per-repo counts onto the rows — otherwise a repo that
+	// emitted zero progress events would show "Done · 0 entities" on early
+	// finish. Empty in monolith mode / when no interim carried stats.
+	interimRepoStats []RepoStat
+
 	// startedAt / finishedAt bound the live elapsed timer shown in the index
 	// header. startedAt is stamped when the index screen begins (startIndex);
 	// finishedAt is stamped once terminal/failed so the header FREEZES at the
@@ -126,15 +134,26 @@ func (v *indexView) applyRepoStats(stats []RepoStat) {
 		if !had {
 			row = Row{Key: key, RepoSlug: s.Slug}
 		}
-		row.EntitiesSoFar = int(s.Entities)
 		if s.Failed {
+			// Never DOWNGRADE a row that already reported Done over SSE to
+			// Error via the classify overlay: the live SSE stream saw the repo
+			// finish, which is more authoritative than a status-plane classify
+			// that (e.g. on a mtime/ack race) transiently reads it as
+			// not-advanced. Trust the row that actually reported success and
+			// leave it as-is.
+			if had && row.Phase == prog.PhaseDone {
+				continue
+			}
 			row.Phase = prog.PhaseError
 			if s.Error != "" {
 				row.Error = s.Error
 			}
-		} else {
-			row.Phase = prog.PhaseDone
+			v.rows[key] = row
+			continue
 		}
+		// Success: overlay the authoritative final entity count and mark Done.
+		row.EntitiesSoFar = int(s.Entities)
+		row.Phase = prog.PhaseDone
 		v.rows[key] = row
 	}
 }

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -91,7 +91,12 @@ func newIndexView(group string, expectedRepos int) indexView {
 // repo shares its slug with the group name (a common case) from having its
 // module ticks misrouted into the group-phase guard.
 func (v *indexView) foldEvent(e prog.Event) {
-	if v.group != "" && e.RepoSlug == v.group && e.Module == "" {
+	// A PhaseQueued seed event is UNAMBIGUOUSLY a per-repo placeholder (never
+	// emitted for the group-scoped cross-repo pass), so it always folds into a
+	// row — bypassing the group-slug-collision guard below. This matters for a
+	// solo repo whose slug happens to equal the group name (the common
+	// single-repo default), which would otherwise never get a seeded row.
+	if e.Phase != PhaseQueued && v.group != "" && e.RepoSlug == v.group && e.Module == "" {
 		// Monotonic: never regress the group phase to a coarser one.
 		if phaseRank(e.Phase) >= phaseRank(v.groupPhase) {
 			v.groupPhase = e.Phase
@@ -99,6 +104,39 @@ func (v *indexView) foldEvent(e prog.Event) {
 		return
 	}
 	v.rows = Fold(v.rows, e)
+}
+
+// applyRepoStats overlays the split-mode classify's authoritative per-repo
+// final stats onto rows keyed by slug (rowKey(s.Slug, "")). This is the fix
+// for the dropped-row bug: a repo that emitted ZERO progress events (a fast
+// repo racing the SSE forwarder, a dropped batch, a subprocess-IPC gap) still
+// gets its real entity count and terminal Done/Error state here, sourced from
+// the status-plane classify rather than folded SSE ticks. Creates the row
+// defensively if it is somehow still missing (should not happen once seeding
+// runs, but never silently drops a repo). Call this BEFORE finalizeRows,
+// which remains the fallback for any row this doesn't cover (e.g. monolith
+// mode, which has no per-repo classify).
+func (v *indexView) applyRepoStats(stats []RepoStat) {
+	if v.rows == nil {
+		v.rows = map[string]Row{}
+	}
+	for _, s := range stats {
+		key := rowKey(s.Slug, "")
+		row, had := v.rows[key]
+		if !had {
+			row = Row{Key: key, RepoSlug: s.Slug}
+		}
+		row.EntitiesSoFar = int(s.Entities)
+		if s.Failed {
+			row.Phase = prog.PhaseError
+			if s.Error != "" {
+				row.Error = s.Error
+			}
+		} else {
+			row.Phase = prog.PhaseDone
+		}
+		v.rows[key] = row
+	}
 }
 
 // done reports whether the indexing screen has fully completed.
@@ -218,6 +256,12 @@ func (v indexView) renderRow(r Row, spinnerFrame string) string {
 	case r.Phase == prog.PhaseDone:
 		glyph = rowDoneStyle.Render(g.Check)
 		phase = rowDoneStyle.Render("Done")
+	case r.Phase == PhaseQueued:
+		// Queued-but-not-started: a muted static marker, NOT the spinner — the
+		// spinner reads as "actively working," which a seeded-but-unreported
+		// repo is not (yet).
+		glyph = rowCountStyle.Render(g.MidDot)
+		phase = rowCountStyle.Render(PhaseLabel(PhaseQueued))
 	default:
 		glyph = spinnerFrame
 		phase = rowPhaseStyle.Render(PhaseLabel(r.Phase))

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -277,3 +277,64 @@ func TestApplyRepoStats_FailedRepoRendersError(t *testing.T) {
 		t.Errorf("Error = %q, want %q", row.Error, "produced no graph")
 	}
 }
+
+// TestApplyRepoStats_DoesNotDowngradeDoneRowToError: a repo that already
+// reported Done over SSE must NOT be flipped to Error by a classify overlay
+// that (e.g. on a status-plane mtime/ack race) transiently reports it failed.
+// The live SSE stream that saw it finish is more authoritative.
+func TestApplyRepoStats_DoesNotDowngradeDoneRowToError(t *testing.T) {
+	v := newIndexView("grp", 1)
+	// The repo reported Done via SSE, with a real entity count.
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseDone, EntitiesSoFar: 4200, TS: 1})
+	// A racy classify claims it failed.
+	v.applyRepoStats([]RepoStat{{Slug: "backend", Failed: true, Error: "produced no graph"}})
+
+	row := v.rows["backend"]
+	if row.Phase != progress.PhaseDone {
+		t.Errorf("Phase = %q, want Done (must not downgrade an SSE-reported Done to Error)", row.Phase)
+	}
+	if row.Error != "" {
+		t.Errorf("Error = %q, want empty (no error stamped on a Done row)", row.Error)
+	}
+	if row.EntitiesSoFar != 4200 {
+		t.Errorf("EntitiesSoFar = %d, want 4200 (preserved from the SSE Done)", row.EntitiesSoFar)
+	}
+}
+
+// TestMonorepo_PerModuleRowsSumToAggregate_NoSpuriousRepoRow documents the
+// intended monorepo rendering the cli-layer gate protects: per-module rows
+// (keyed monorepoSlug/module) render individually, finalizeRows flips them to
+// Done, and NO bare repo-level row (key == monorepoSlug) is ever created — so
+// the visible rows sum to the aggregate exactly ONCE, never 2×. applyRepoStats
+// is intentionally NOT called here (the cli layer passes nil RepoStats for a
+// monorepo).
+func TestMonorepo_PerModuleRowsSumToAggregate_NoSpuriousRepoRow(t *testing.T) {
+	const mono = "some-monorepo"
+	v := newIndexView("some-monorepo-group", 1)
+	// Per-module progress (the #5751 model): distinct Module, shared RepoSlug.
+	v.foldEvent(progress.Event{RepoSlug: mono, Module: "services/auth", Phase: progress.PhaseDone, EntitiesSoFar: 1200, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: mono, Module: "packages/ui", Phase: progress.PhaseDone, EntitiesSoFar: 800, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: mono, Module: "services/billing", Phase: progress.PhaseExtractAST, EntitiesSoFar: 0, TS: 1})
+
+	// Monorepo path passes NO RepoStats — the aggregate lives only in the header.
+	v.applyRepoStats(nil)
+	v.finalizeRows()
+	v.terminal = true
+
+	if _, spurious := v.rows[mono]; spurious {
+		t.Fatalf("a spurious bare repo-level row (key %q) was created — this doubles the entity total", mono)
+	}
+	if len(v.rows) != 3 {
+		t.Fatalf("len(rows) = %d, want 3 (one per module, no repo-level row)", len(v.rows))
+	}
+	var sum int
+	for _, r := range v.rows {
+		if r.Phase != progress.PhaseDone {
+			t.Errorf("module row %q not finalized to Done: %q", r.Key, r.Phase)
+		}
+		sum += r.EntitiesSoFar
+	}
+	if sum != 2000 {
+		t.Errorf("sum of module rows = %d, want 2000 (aggregate counted exactly once, not doubled)", sum)
+	}
+}

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -136,3 +136,144 @@ func TestRenderRow_FilesCountCommafied(t *testing.T) {
 		t.Errorf("renderRow missing commafied entities count:\n%s", line)
 	}
 }
+
+// --- Dropped-row regression coverage (#seed-rows fix) ---
+//
+// Live bug: a 3-repo group completed with only 2 rows ever rendered because
+// per-repo rows were created ONLY when a progress event for that repo
+// arrived. A repo whose events were missed/dropped/raced never got a row,
+// even though it indexed successfully and its watcher was installed. The fix
+// is two-part: (1) seed a "queued" row for every selected repo up front via a
+// PhaseQueued event that merges-by-slug with real events, and (2) overlay the
+// split-mode classify's authoritative per-repo stats on completion so a
+// silent repo still shows its true count + Done.
+
+// TestFoldEvent_SeededQueuedRowRendersDistinctly: a PhaseQueued seed event
+// creates a row immediately, rendered as a muted "Queued…" — not the active
+// spinner (which would misleadingly suggest work in progress).
+func TestFoldEvent_SeededQueuedRowRendersDistinctly(t *testing.T) {
+	v := newIndexView("grp", 3)
+	v.foldEvent(progress.Event{RepoSlug: "core-mobile", Phase: PhaseQueued, TS: 0})
+
+	row, ok := v.rows["core-mobile"]
+	if !ok {
+		t.Fatal("seeded PhaseQueued event did not create a row")
+	}
+	line := v.renderRow(row, "*SPINNER*")
+	if !strings.Contains(line, "Queued") {
+		t.Errorf("queued row missing the Queued label:\n%s", line)
+	}
+	if strings.Contains(line, "*SPINNER*") {
+		t.Errorf("queued row rendered the active spinner (should be suppressed):\n%s", line)
+	}
+}
+
+// TestFoldEvent_SeededRowMergesWithRealEvent: a seeded row and a subsequent
+// real progress event for the SAME slug fold into ONE row (no duplicate),
+// and the row advances past PhaseQueued.
+func TestFoldEvent_SeededRowMergesWithRealEvent(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: PhaseQueued, TS: 0})
+	if len(v.rows) != 1 {
+		t.Fatalf("after seed: len(rows) = %d, want 1", len(v.rows))
+	}
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10, TS: 1})
+
+	if len(v.rows) != 1 {
+		t.Fatalf("after real event: len(rows) = %d, want 1 (no duplicate row)", len(v.rows))
+	}
+	row := v.rows["backend"]
+	if row.Phase != progress.PhaseExtractAST {
+		t.Errorf("Phase = %q, want %q (real event must advance past queued)", row.Phase, progress.PhaseExtractAST)
+	}
+	if row.FilesDone != 5 {
+		t.Errorf("FilesDone = %d, want 5", row.FilesDone)
+	}
+}
+
+// TestFoldEvent_SeededRowSurvivesGroupSlugCollision: when a repo's slug
+// equals the group name (the common single-repo-group default), the
+// PhaseQueued seed must still create a row — it must NOT be swallowed by the
+// group-scoped-event guard the way a same-named real event would be.
+func TestFoldEvent_SeededRowSurvivesGroupSlugCollision(t *testing.T) {
+	v := newIndexView("myrepo", 1) // group name == repo slug
+	v.foldEvent(progress.Event{RepoSlug: "myrepo", Phase: PhaseQueued, TS: 0})
+
+	if _, ok := v.rows["myrepo"]; !ok {
+		t.Fatal("seeded row for a repo whose slug matches the group name was swallowed by the group-scope guard")
+	}
+	if v.groupPhase != "" {
+		t.Errorf("groupPhase = %q, want empty (a seed event must never be treated as a group-scoped event)", v.groupPhase)
+	}
+}
+
+// TestApplyRepoStats_PopulatesRowThatNeverReportedProgress is the exact
+// regression for the live bug: a selected repo that emits ZERO progress
+// events must still end up with its real entity count and a Done row once
+// applyRepoStats runs — sourced from the classify, not from folded SSE.
+func TestApplyRepoStats_PopulatesRowThatNeverReportedProgress(t *testing.T) {
+	v := newIndexView("grp", 3)
+	// Seed all three (part 1) — only two ever report real progress.
+	for _, slug := range []string{"core-mobile", "upvate_core", "upvate_core_frontend"} {
+		v.foldEvent(progress.Event{RepoSlug: slug, Phase: PhaseQueued, TS: 0})
+	}
+	v.foldEvent(progress.Event{RepoSlug: "core-mobile", Phase: progress.PhaseDone, EntitiesSoFar: 8383, TS: 1})
+	v.foldEvent(progress.Event{RepoSlug: "upvate_core", Phase: progress.PhaseDone, EntitiesSoFar: 6039, TS: 1})
+	// upvate_core_frontend NEVER reports — stays queued until the classify lands.
+
+	if len(v.rows) != 3 {
+		t.Fatalf("len(rows) = %d, want 3 (a row must exist for every selected repo)", len(v.rows))
+	}
+	frozen := v.rows["upvate_core_frontend"]
+	if frozen.Phase != PhaseQueued {
+		t.Fatalf("precondition: silent repo's row should still be queued before the classify lands, got phase %q", frozen.Phase)
+	}
+
+	// Part 2: the split-mode classify's authoritative stats land on completion.
+	v.applyRepoStats([]RepoStat{
+		{Slug: "core-mobile", Entities: 8383},
+		{Slug: "upvate_core", Entities: 6039},
+		{Slug: "upvate_core_frontend", Entities: 17270},
+	})
+	v.finalizeRows()
+	v.terminal = true
+
+	row, ok := v.rows["upvate_core_frontend"]
+	if !ok {
+		t.Fatal("silent repo's row disappeared instead of being populated")
+	}
+	if row.Phase != progress.PhaseDone {
+		t.Errorf("Phase = %q, want Done", row.Phase)
+	}
+	if row.EntitiesSoFar != 17270 {
+		t.Errorf("EntitiesSoFar = %d, want 17270 (the repo's TRUE count, sourced from classify)", row.EntitiesSoFar)
+	}
+
+	// The Done summary aggregate must equal the sum of the per-repo rows — no
+	// silent shortfall (the exact live symptom: rows summed to 14,422 but the
+	// reported total was 31,692).
+	var sum int64
+	for _, r := range v.rows {
+		sum += int64(r.EntitiesSoFar)
+	}
+	const wantTotal = 8383 + 6039 + 17270
+	if sum != wantTotal {
+		t.Errorf("sum of per-repo EntitiesSoFar = %d, want %d (matches the aggregate total)", sum, wantTotal)
+	}
+}
+
+// TestApplyRepoStats_FailedRepoRendersError: a classify-reported failure
+// marks the row Error/failed rather than a false Done.
+func TestApplyRepoStats_FailedRepoRendersError(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.foldEvent(progress.Event{RepoSlug: "docs-only", Phase: PhaseQueued, TS: 0})
+	v.applyRepoStats([]RepoStat{{Slug: "docs-only", Failed: true, Error: "produced no graph"}})
+
+	row := v.rows["docs-only"]
+	if row.Phase != progress.PhaseError {
+		t.Errorf("Phase = %q, want Error", row.Phase)
+	}
+	if row.Error != "produced no graph" {
+		t.Errorf("Error = %q, want %q", row.Error, "produced no graph")
+	}
+}

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -103,6 +103,27 @@ type IndexOutcome struct {
 	// still running" checkpoint. At most one interim outcome is ever sent,
 	// always followed by exactly one terminal (Interim==false) outcome.
 	Interim bool
+	// RepoStats carries the split-mode status-plane classify's per-repo final
+	// stats (slug, entities, rels, advanced-vs-failed), sourced independently
+	// of the folded SSE progress rows. The model applies these over the
+	// seeded/folded rows on the terminal outcome (see applyRepoStats) so a
+	// repo that emitted ZERO progress events still shows its real entity count
+	// and Done state instead of remaining blank/queued (the dropped-row bug).
+	// nil/empty in monolith mode, which has no per-repo classify — rows there
+	// fall back entirely to finalizeRows.
+	RepoStats []RepoStat
+}
+
+// RepoStat is one selected repo's final classified result (see
+// IndexOutcome.RepoStats). Slug must match the same repo-slug keying used by
+// progress.Event.RepoSlug / Row.RepoSlug (rowKey) so it overlays the correct
+// row rather than creating a duplicate.
+type RepoStat struct {
+	Slug     string
+	Entities int64
+	Rels     int64
+	Failed   bool
+	Error    string
 }
 
 // InstallSummary is the captured, structured outcome of applyGroupConfig's
@@ -356,6 +377,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.res.indexErr = o.Err
 		} else {
 			m.idx.terminal = true
+			// Overlay the classify's authoritative per-repo stats FIRST (fixes
+			// the dropped-row bug: a repo with zero folded progress events still
+			// gets its real count + Done here), then finalizeRows as the
+			// fallback for anything applyRepoStats didn't cover (e.g. monolith
+			// mode, or a row somehow still non-terminal after the overlay).
+			m.idx.applyRepoStats(o.RepoStats)
 			// The whole index succeeded, so every repo is done. Force any row
 			// still on an intermediate phase to Done — its final SSE events may
 			// have arrived after the RPC returned and been dropped (#5340).

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -364,6 +364,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.idx.summaryRels = o.Rels
 			m.idx.install = o.Install
 			m.idx.queryable = true
+			// Stash the interim per-repo stats so an enter-early finalize (see
+			// updateKey's scrIndex case) can still overlay real per-repo counts
+			// instead of leaving a silent repo at "Done · 0 entities".
+			m.idx.interimRepoStats = o.RepoStats
 			return m, waitOutcome(m.outCh)
 		}
 		m.idx.summaryEntities = o.Entities
@@ -437,6 +441,11 @@ func (m Model) updateKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// the final outcome to land on its own.
 		if msg.String() == "enter" && m.idx.queryable && !m.idx.terminal {
 			m.idx.terminal = true
+			// Overlay the interim classify's per-repo stats FIRST (so a repo
+			// that emitted no progress events shows its real count, not 0),
+			// then finalizeRows as the fallback — mirrors the terminal-outcome
+			// path so finishing early is consistent with waiting.
+			m.idx.applyRepoStats(m.idx.interimRepoStats)
 			m.idx.finalizeRows()
 			m.idx.finishedAt = time.Now()
 			m.scr = scrDone

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -389,6 +389,47 @@ func TestModel_EnterInQueryableState_FinishesWithInterimStats(t *testing.T) {
 	}
 }
 
+// TestModel_EnterEarlyAppliesInterimRepoStats: when the user finishes early
+// from the queryable state, the interim outcome's per-repo classify stats must
+// be overlaid onto the rows — otherwise a repo that emitted zero progress
+// events would show "Done · 0 entities" on early finish. Regression for the
+// review's "enter-early drops classify stats" finding.
+func TestModel_EnterEarlyAppliesInterimRepoStats(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	// Seed a queued row for a repo that will NEVER report a progress event.
+	m = m.update(progressMsg(progress.Event{RepoSlug: "silent-repo", Phase: PhaseQueued}))
+
+	// Interim (queryable) outcome carries the classify's per-repo stats.
+	m = m.update(outcomeMsg(IndexOutcome{
+		Interim:   true,
+		Entities:  9000,
+		RepoStats: []RepoStat{{Slug: "silent-repo", Entities: 9000}},
+	}))
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex after interim", m.scr)
+	}
+	if got := m.idx.rows["silent-repo"].EntitiesSoFar; got != 0 {
+		t.Fatalf("precondition: silent repo should still be 0 before finishing early, got %d", got)
+	}
+
+	// User presses enter to finish early.
+	m = m.update(key("enter"))
+
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone", m.scr)
+	}
+	row, ok := m.idx.rows["silent-repo"]
+	if !ok {
+		t.Fatal("silent repo's row missing after early finish")
+	}
+	if row.Phase != progress.PhaseDone {
+		t.Errorf("Phase = %q, want Done", row.Phase)
+	}
+	if row.EntitiesSoFar != 9000 {
+		t.Errorf("EntitiesSoFar = %d, want 9000 (interim classify stats must be applied on early finish, not 0)", row.EntitiesSoFar)
+	}
+}
+
 // TestModel_EnterBeforeQueryable_NoOp: pressing enter on the index screen
 // BEFORE any interim/terminal outcome has landed is a no-op (matches the old
 // ctrl-c-only behavior; a bare enter must not skip the wait).

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -426,6 +426,143 @@ func TestModel_FinalOutcomeAfterInterim_ReachesDoneWithFinalStats(t *testing.T) 
 	}
 }
 
+// TestModel_SilentRepoStillRendersRowAndCompletes is the model-level
+// regression for the live dropped-row bug: a 3-repo group where the third
+// repo's progress events never arrive must still render a row for it
+// throughout indexing, and the completion screen must show its REAL entity
+// count and Done state (sourced from IndexOutcome.RepoStats), never
+// missing/blank — with the aggregate matching the sum of the rows.
+func TestModel_SilentRepoStillRendersRowAndCompletes(t *testing.T) {
+	slugs := []string{"core-mobile", "upvate_core", "upvate_core_frontend"}
+	idx := func(Result) (<-chan progress.Event, <-chan IndexOutcome) {
+		ev := make(chan progress.Event, 8)
+		out := make(chan IndexOutcome, 1)
+		// Seed a row for every selected repo up front (mirrors what the cli
+		// layer's makeIndexFunc does before the real index starts).
+		for _, s := range slugs {
+			ev <- progress.Event{RepoSlug: s, Phase: PhaseQueued, TS: 0}
+		}
+		// Only two of the three ever report real progress — the third (the
+		// exact live symptom) emits nothing.
+		ev <- progress.Event{RepoSlug: "core-mobile", Phase: progress.PhaseDone, EntitiesSoFar: 8383, TS: 1}
+		ev <- progress.Event{RepoSlug: "upvate_core", Phase: progress.PhaseDone, EntitiesSoFar: 6039, TS: 1}
+		close(ev)
+		out <- IndexOutcome{
+			Entities: 31692,
+			RepoStats: []RepoStat{
+				{Slug: "core-mobile", Entities: 8383},
+				{Slug: "upvate_core", Entities: 6039},
+				{Slug: "upvate_core_frontend", Entities: 17270},
+			},
+		}
+		close(out)
+		return ev, out
+	}
+
+	d := fakeDriver{suggested: ActionGroup, cands: []Candidate{
+		{Label: "/core-mobile", Value: "/core-mobile", Selected: true},
+		{Label: "/upvate_core", Value: "/upvate_core", Selected: true},
+		{Label: "/upvate_core_frontend", Value: "/upvate_core_frontend", Selected: true},
+	}}
+	m := newTestModel(d, idx)
+	m = m.update(key("enter")) // action → select (all pre-selected)
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index
+	if m.scr != scrIndex {
+		t.Fatalf("scr = %v, want scrIndex", m.scr)
+	}
+
+	evc, outc := m.index(m.res)
+	m = m.update(indexStartedMsg{events: evc, outcome: outc})
+	// Drain every buffered progress event synchronously (the test channels are
+	// pre-filled and closed, so waitEvent resolves immediately each time).
+	for i := 0; i < 5; i++ {
+		e, ok := <-evc
+		if !ok {
+			break
+		}
+		m = m.update(progressMsg(e))
+	}
+	if len(m.idx.rows) != 3 {
+		t.Fatalf("mid-index: len(rows) = %d, want 3 (a row for every selected repo, even one with zero events)", len(m.idx.rows))
+	}
+	o := <-outc
+	m = m.update(outcomeMsg(o))
+
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone", m.scr)
+	}
+	if len(m.idx.rows) != 3 {
+		t.Fatalf("final: len(rows) = %d, want 3 (the silent repo's row must never disappear)", len(m.idx.rows))
+	}
+	row, ok := m.idx.rows["upvate_core_frontend"]
+	if !ok {
+		t.Fatal("silent repo's row is missing from the completion screen")
+	}
+	if row.Phase != progress.PhaseDone {
+		t.Errorf("silent repo's Phase = %q, want Done", row.Phase)
+	}
+	if row.EntitiesSoFar != 17270 {
+		t.Errorf("silent repo's EntitiesSoFar = %d, want 17270 (its real count from the classify)", row.EntitiesSoFar)
+	}
+
+	var sum int64
+	for _, r := range m.idx.rows {
+		sum += int64(r.EntitiesSoFar)
+	}
+	if sum != m.idx.summaryEntities {
+		t.Errorf("sum of per-repo rows = %d, but Done summary reports %d entities — silent shortfall", sum, m.idx.summaryEntities)
+	}
+	if m.idx.summaryEntities != 31692 {
+		t.Errorf("summaryEntities = %d, want 31692", m.idx.summaryEntities)
+	}
+}
+
+// TestModel_MonolithMode_StillRendersAndCompletes: a terminal IndexOutcome
+// with NO RepoStats (the monolith path, which has no per-repo classify) must
+// still complete cleanly via the finalizeRows fallback — no regression.
+func TestModel_MonolithMode_StillRendersAndCompletes(t *testing.T) {
+	idx := func(Result) (<-chan progress.Event, <-chan IndexOutcome) {
+		ev := make(chan progress.Event, 2)
+		out := make(chan IndexOutcome, 1)
+		ev <- progress.Event{RepoSlug: "monolith-repo", Phase: progress.PhaseExtractAST, FilesDone: 3, FilesTotal: 10, TS: 1}
+		close(ev)
+		out <- IndexOutcome{Entities: 999, Rels: 50, Elapsed: "10s"}
+		close(out)
+		return ev, out
+	}
+	d := fakeDriver{suggested: ActionSingle, cands: []Candidate{
+		{Label: "/monolith-repo", Value: "/monolith-repo", Selected: true},
+	}}
+	m := newTestModel(d, idx)
+	m = m.update(key("enter")) // action → select
+	m = m.update(key("enter")) // select → name
+	m = m.update(key("enter")) // name → docs
+	m = m.update(key("enter")) // docs → index
+
+	evc, outc := m.index(m.res)
+	m = m.update(indexStartedMsg{events: evc, outcome: outc})
+	e := <-evc
+	m = m.update(progressMsg(e))
+	o := <-outc
+	m = m.update(outcomeMsg(o))
+
+	if m.scr != scrDone {
+		t.Fatalf("scr = %v, want scrDone", m.scr)
+	}
+	row, ok := m.idx.rows["monolith-repo"]
+	if !ok {
+		t.Fatal("monolith repo's row missing")
+	}
+	if row.Phase != progress.PhaseDone {
+		t.Errorf("Phase = %q, want Done (finalizeRows fallback with no RepoStats)", row.Phase)
+	}
+	if m.idx.summaryEntities != 999 {
+		t.Errorf("summaryEntities = %d, want 999", m.idx.summaryEntities)
+	}
+}
+
 func nilIndex(Result) (<-chan progress.Event, <-chan IndexOutcome) {
 	ev := make(chan progress.Event)
 	out := make(chan IndexOutcome)


### PR DESCRIPTION
A repo that indexed successfully could render **no per-repo row** in the wizard TUI, because rows were created only when a progress event for that repo arrived — a missed/raced/dropped event meant the repo was silently invisible. Live evidence: a 3-repo group finished showing 2 rows summing to 14,422 entities while the Done summary reported 31,692 (the third repo, ~17,270, indexed but had no row).

**Fix (two parts):**
1. **Seed a "queued" row per selected repo at index start**, keyed to the same slug real progress events carry (`filepath.Base`), so seeds merge with real events (no duplicates) and every selected repo is visible from t=0.
2. **Source final per-repo counts from the completion classify**, so a repo that emitted no progress events still shows its real entity/rel count + Done on completion.

Monorepo mode is explicitly gated OUT of both (its modules already render per-module via the existing SSE path; seeding a module-less row there would double-count). Enter-early now applies interim per-repo stats; a Done row is never downgraded to Error by a racy classify.

Independently reviewed twice (caught + fixed a monorepo double-count regression before merge). 468 tests incl. a regression reproducing the exact 3-repo live case; `go vet` clean.

Refs #5771, #5729.