### PR TITLE
fix(wiztui): drive live per-repo row progress from the status plane (no more queued→jump)

### DIFF
--- a/internal/cli/wizard_split_progress.go
+++ b/internal/cli/wizard_split_progress.go
@@ -59,6 +59,7 @@ func runSplitIndex(
 	group, token string,
 	sseCh <-chan sseEvent,
 	evCh chan<- progress.Event,
+	perRepoRows bool,
 	onQueryable onQueryableFunc,
 ) rebuildOutcome {
 	probe, err := newStatusPlaneProbe(group, token)
@@ -74,7 +75,7 @@ func runSplitIndex(
 		_, rErr := c.Rebuild(proto.RebuildArgs{Group: group, ProgressToken: token, Interactive: true})
 		return rErr
 	}
-	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll(), onQueryable)
+	return runSplitIndexCore(ctx, cancel, trigger, sseCh, evCh, probe, realSplitClock{}, defaultSplitPoll(), perRepoRows, onQueryable)
 }
 
 // splitClock is the injectable time seam so completion-poll tests advance
@@ -110,6 +111,35 @@ type splitPoll struct {
 	// read keeps it false — no false-success. When any repo fails/empties it never
 	// becomes true, so completion falls through to the ack backstop (RequestPending).
 	AllAdvanced bool
+	// RepoStatuses is a per-repo snapshot of THIS poll's status-plane read,
+	// one entry per group repo (same order as statusPlaneProbe.repoPaths).
+	// It is the seam awaitSplitCompletion uses to drive per-repo TUI rows
+	// live from the status plane (emitStatusPlaneRowEvents), independent of
+	// whether any SSE progress event has ever arrived for that repo. A
+	// fakeProbe-backed test that doesn't set this simply yields no events —
+	// harmless, since those tests only assert SSE forwarding / completion.
+	RepoStatuses []repoStatusSnapshot
+}
+
+// repoStatusSnapshot is one repo's status-plane reading for a single poll —
+// the minimal shape emitStatusPlaneRowEvents needs to synthesize a
+// progress.Event for that repo's TUI row.
+type repoStatusSnapshot struct {
+	// Slug matches registry.Repo.Slug / the RepoSlug real progress.Events
+	// carry (filepath.Base of the repo path), so a synthesized event FOLDS
+	// INTO the seeded/real row instead of creating a duplicate.
+	Slug string
+	// Indexing mirrors statusfile.File.Indexing — true while THIS poll
+	// observed the repo mid-(re)index.
+	Indexing bool
+	// Entities is the status plane's running entity count (statusfile.File.
+	// Entities), forwarded as the synthesized event's EntitiesSoFar.
+	Entities int64
+	// Advanced mirrors repoAdvanced(f, baseline) — true once the repo is
+	// genuinely graph-queryable (not indexing AND graph_fb_mtime advanced
+	// past the pre-enqueue baseline). Only an Advanced snapshot is allowed
+	// to synthesize a PhaseDone row event — never a stale/mid-index read.
+	Advanced bool
 }
 
 // splitResult is the classified outcome, produced once the rebuild is done.
@@ -188,13 +218,66 @@ func defaultSplitPoll() splitPollConfig {
 // !RequestPending land in the SAME poll (the rebuild was already fully done),
 // the ack check runs first, so no interim fires — straight to the terminal
 // return, matching the pre-existing fast/failure-path behavior.
-func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig, onQueryable onQueryableFunc) (splitResult, error) {
+// emitStatusPlaneRowEvents translates one poll's per-repo status snapshots
+// into synthetic progress.Events on evCh, keyed by the SAME slug (see
+// repoStatusSnapshot.Slug) that seeded rows and real SSE events use — so they
+// FOLD INTO the existing row (wiztui.Fold is monotonic: a coarse status event
+// never regresses a finer SSE phase already shown) instead of creating a
+// duplicate row.
+//
+// This is the reliable floor when SSE never arrives (no dashboard up, or a
+// fast/warm re-index that finishes before any SSE tick is delivered) — the
+// bug this whole file's status-plane-driven-rows change fixes: rows used to
+// sit at "Queued…" the entire index and only resolve at the terminal
+// classify, looking like a hang.
+//
+//   - Indexing==true (and not yet Advanced) → PhaseIndexing ("Indexing…"),
+//     carrying the status plane's running entity count.
+//   - Advanced==true → PhaseDone, carrying the final entity count. Gated on
+//     repoAdvanced (never-indexing AND graph_fb_mtime advanced) so a coarse
+//     status read can never mark a row Done before the repo genuinely is.
+//   - Neither → no event (leaves the seeded PhaseQueued row untouched; the
+//     repo hasn't started yet as far as the status plane can tell).
+//
+// Sends are best-effort/non-blocking (mirrors forwardSSEUntilCancel) so a
+// full evCh never stalls the completion poll loop.
+func emitStatusPlaneRowEvents(evCh chan<- progress.Event, statuses []repoStatusSnapshot) {
+	if evCh == nil {
+		return
+	}
+	now := time.Now().UnixMilli()
+	for _, s := range statuses {
+		var e progress.Event
+		switch {
+		case s.Advanced:
+			e = progress.Event{RepoSlug: s.Slug, Phase: progress.PhaseDone, EntitiesSoFar: int(s.Entities), TS: now}
+		case s.Indexing:
+			e = progress.Event{RepoSlug: s.Slug, Phase: progress.PhaseIndexing, EntitiesSoFar: int(s.Entities), TS: now}
+		default:
+			continue
+		}
+		select {
+		case evCh <- e:
+		default:
+		}
+	}
+}
+
+func awaitSplitCompletion(probe splitProbe, clk splitClock, cfg splitPollConfig, evCh chan<- progress.Event, perRepoRows bool, onQueryable onQueryableFunc) (splitResult, error) {
 	start := clk.Now()
 	sawAlive := false
 	queryableFired := false
 	for {
 		p, err := probe.Poll()
 		if err == nil {
+			// Drive per-repo TUI rows live from the status plane, gated to
+			// flat (non-monorepo) repos — see makeIndexFunc's perRepoRows
+			// doc: a monorepo's status plane has ONE repo-root entry while
+			// the display is per-MODULE, so emitting it here would
+			// resurrect the spurious repo-level row #5773 removed.
+			if perRepoRows {
+				emitStatusPlaneRowEvents(evCh, p.RepoStatuses)
+			}
 			if !p.RequestPending {
 				// The engine drained+acked our rebuild request — real completion,
 				// checked FIRST so an AllAdvanced-and-acked poll never fires an
@@ -270,6 +353,7 @@ func runSplitIndexCore(
 	probe splitProbe,
 	clk splitClock,
 	cfg splitPollConfig,
+	perRepoRows bool,
 	onQueryable onQueryableFunc,
 ) rebuildOutcome {
 	// 1. Start forwarding SSE per-module events CONCURRENTLY so the bars render
@@ -283,9 +367,11 @@ func runSplitIndexCore(
 		return rebuildOutcome{err: fmt.Errorf("enqueue rebuild: %w", err)}
 	}
 
-	// 3. Poll for real completion (the request ack), then classify. onQueryable
-	//    may fire once, mid-poll, on the AllAdvanced-while-pending checkpoint.
-	res, err := awaitSplitCompletion(probe, clk, cfg, onQueryable)
+	// 3. Poll for real completion (the request ack), then classify. Each poll
+	//    also drives per-repo TUI rows live from the status plane (perRepoRows-
+	//    gated — see emitStatusPlaneRowEvents), and onQueryable may fire once,
+	//    mid-poll, on the AllAdvanced-while-pending checkpoint.
+	res, err := awaitSplitCompletion(probe, clk, cfg, evCh, perRepoRows, onQueryable)
 	cancel() // stop the SSE forward goroutine
 	if err != nil {
 		return rebuildOutcome{err: err}
@@ -396,14 +482,21 @@ func (p *statusPlaneProbe) Poll() (splitPoll, error) {
 	}
 	_, alive := p.readLiveness(p.root)
 	allAdvanced := len(p.repoPaths) > 0
+	statuses := make([]repoStatusSnapshot, 0, len(p.repoPaths))
 	for _, rp := range p.repoPaths {
 		f, ok := p.readStatus(rp)
-		if !ok || !repoAdvanced(f, p.baseline[rp]) {
+		adv := ok && repoAdvanced(f, p.baseline[rp])
+		if !adv {
 			allAdvanced = false
-			break
 		}
+		snap := repoStatusSnapshot{Slug: filepath.Base(rp), Advanced: adv}
+		if ok && f != nil {
+			snap.Indexing = f.Indexing
+			snap.Entities = f.Entities
+		}
+		statuses = append(statuses, snap)
 	}
-	return splitPoll{RequestPending: pend, EngineAlive: alive, AllAdvanced: allAdvanced}, nil
+	return splitPoll{RequestPending: pend, EngineAlive: alive, AllAdvanced: allAdvanced, RepoStatuses: statuses}, nil
 }
 
 // Classify inspects each group repo AFTER the rebuild finished. A repo counts as

--- a/internal/cli/wizard_split_progress_test.go
+++ b/internal/cli/wizard_split_progress_test.go
@@ -144,7 +144,7 @@ func TestSplit_CompletionWaitsForRequestAck(t *testing.T) {
 	evCh := make(chan progress.Event, 8)
 	rebuildCalled := false
 
-	o := runSplitIndexCore(ctx, cancel, func() error { rebuildCalled = true; return nil }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, func() error { rebuildCalled = true; return nil }, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 
 	if !rebuildCalled {
 		t.Fatal("triggerRebuild was never called")
@@ -183,7 +183,7 @@ func TestSplit_ForwardsPerModuleEventsDuringWindow(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -206,7 +206,7 @@ func TestSplit_OutcomeCarriesClassifiedStats(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -230,7 +230,7 @@ func TestSplit_EngineDiesSurfacesError(t *testing.T) {
 	}}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err == nil {
 		t.Fatal("engine died but outcome carried no error (fake Done)")
 	}
@@ -247,7 +247,7 @@ func TestSplit_TimeoutSurfacesError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: time.Second, startupWindow: 0, timeout: 3 * time.Second}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, nil)
 	if o.err == nil {
 		t.Fatal("rebuild never acked but no timeout error surfaced")
 	}
@@ -262,7 +262,7 @@ func TestSplit_NeverAliveEngineFailsFast(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 100 * time.Millisecond, startupWindow: time.Second, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, nil)
 	if o.err == nil {
 		t.Fatal("engine never came alive but no error surfaced")
 	}
@@ -297,7 +297,7 @@ func TestSplit_MultiRepoPartialFailure_PromptError(t *testing.T) {
 	// Short interval + comfortably large timeout: a PROMPT terminal state must
 	// arrive from the ack, long before the timeout.
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, nil)
 
 	if o.err == nil {
 		t.Fatal("partial failure (repo B never indexed) produced no error — this is the hang/fake-done regression")
@@ -317,7 +317,7 @@ func TestSplit_EmptyRepo_PromptTerminal(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, nil)
 	if o.err == nil {
 		t.Fatal("empty repo produced no terminal error (would hang in production)")
 	}
@@ -413,7 +413,7 @@ func TestSplit_NoDashboard_WaitsForAck(t *testing.T) {
 	defer cancel()
 
 	var sseCh <-chan sseEvent // nil: no dashboard, no live bars
-	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -440,7 +440,7 @@ func TestSplit_StaleStatusAtAck_FalseFailsWithoutFlush(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err == nil {
 		t.Fatal("expected a (false) failure when status is stale at ack — documents the race the flush closes")
 	}
@@ -463,7 +463,7 @@ func TestSplit_FreshStatusFlushedBeforeAck_ClassifiesOK(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err != nil {
 		t.Fatalf("fresh status flushed before ack should classify OK, got: %v", o.err)
 	}
@@ -502,7 +502,7 @@ func TestSplit_AllReposAdvance_FiresQueryableThenWaitsForAck(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, onQueryable)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -544,7 +544,7 @@ func TestSplit_OneRepoNeverAdvances_AckBackstopPromptError(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, nil)
 	if o.err == nil {
 		t.Fatal("repo B never advanced but completion reported success (AllAdvanced early false-success or hang)")
 	}
@@ -596,7 +596,7 @@ func TestSplit_StaleStatus_QueryableFiresOnceThenWaitsForAck(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, onQueryable)
 	if o.err != nil {
 		t.Fatalf("should complete once the ack lands, got: %v", o.err)
 	}
@@ -624,7 +624,7 @@ func TestSplit_FastPath_AllAdvancedAndAckedSamePoll_NoInterim(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), onQueryable)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, onQueryable)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -652,7 +652,7 @@ func TestSplit_FastAck_NeverAllAdvanced_NoInterim(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), onQueryable)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, onQueryable)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -677,7 +677,7 @@ func TestSplit_PartialFailure_NoInterim(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	cfg := splitPollConfig{interval: 10 * time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, onQueryable)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, cfg, true, onQueryable)
 	if o.err == nil {
 		t.Fatal("expected a partial-failure error naming the non-advanced repo")
 	}
@@ -807,7 +807,7 @@ func TestRunSplitIndexCore_ThreadsPerRepoStatsIntoOutcome(t *testing.T) {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), nil)
+	o := runSplitIndexCore(ctx, cancel, noTrigger, make(chan sseEvent), make(chan progress.Event, 4), probe, &fakeSplitClock{}, testPollCfg(), true, nil)
 	if o.err != nil {
 		t.Fatalf("unexpected error: %v", o.err)
 	}
@@ -917,5 +917,177 @@ func TestMakeIndexFunc_MonorepoDoesNotSeedQueuedRows(t *testing.T) {
 
 	if seeded != 0 {
 		t.Fatalf("monorepo emitted %d PhaseQueued seed events; want 0 (a bare repo-level seed row doubles the entity total)", seeded)
+	}
+}
+
+// --- Live status-plane row driving (#liverows: fast/warm re-index rows must
+// not sit at "Queued…" the whole time and jump to Done all at once) ---
+
+// LIVE-1. SPLIT status-plane row driving: a flat-group repo whose status goes
+// indexing→done with NO SSE events at all must drive its row queued→active→
+// Done LIVE during the poll, not sit at "Queued…" until the terminal
+// classify. This is the exact live-daemon symptom: on a fast/warm re-index
+// (or whenever no dashboard SSE is delivering), the seeded row used to render
+// 0% the entire time and then jump straight to Done at the very end.
+func TestSplit_StatusPlaneDrivesRowLiveWithNoSSE(t *testing.T) {
+	const repo = "/repo/backend"
+	wantSlug := filepath.Base(repo)
+
+	var mu sync.Mutex
+	calls := 0
+	read := func(string) (*statusfile.File, bool) {
+		mu.Lock()
+		calls++
+		c := calls
+		mu.Unlock()
+		if c <= 3 {
+			return &statusfile.File{Indexing: true, Entities: 0}, true // actively indexing
+		}
+		return &statusfile.File{Indexing: false, GraphFBMtime: 1000, Entities: 4242}, true // done
+	}
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", read, aliveLiveness, pendingUntil(8))
+
+	var sseCh <-chan sseEvent // nil: NEVER delivers — no dashboard / fast-path race
+	evCh := make(chan progress.Event, 64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, cfg, true, nil)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+
+	rows := map[string]wiztui.Row{}
+	sawActive := false
+	n := len(evCh)
+	if n == 0 {
+		t.Fatal("no status-plane row events were forwarded onto evCh — row would sit at Queued the whole index")
+	}
+	for i := 0; i < n; i++ {
+		e := <-evCh
+		rows = wiztui.Fold(rows, e)
+		if rows[wantSlug].Phase == progress.PhaseIndexing {
+			sawActive = true
+		}
+	}
+	if !sawActive {
+		t.Fatal("row never passed through the PhaseIndexing active phase — it would appear stuck at Queued until the terminal classify")
+	}
+	final := rows[wantSlug]
+	if final.Phase != progress.PhaseDone {
+		t.Fatalf("final row phase = %q, want %q (done)", final.Phase, progress.PhaseDone)
+	}
+	if final.EntitiesSoFar != 4242 {
+		t.Fatalf("final row EntitiesSoFar = %d, want 4242 (from the status plane)", final.EntitiesSoFar)
+	}
+}
+
+// LIVE-2. The aggregate progress bar must LEAVE 0% as soon as a repo goes
+// active/done via the status plane — not sit at 0 until the terminal
+// classify (the same live symptom viewed through AggregateProgress, which
+// drives the wizard's overall progress bar).
+func TestSplit_StatusPlaneAggregateProgressAdvances(t *testing.T) {
+	const repo = "/repo/backend"
+	wantSlug := filepath.Base(repo)
+
+	var mu sync.Mutex
+	calls := 0
+	read := func(string) (*statusfile.File, bool) {
+		mu.Lock()
+		calls++
+		c := calls
+		mu.Unlock()
+		if c <= 3 {
+			return &statusfile.File{Indexing: true, Entities: 100}, true
+		}
+		return &statusfile.File{Indexing: false, GraphFBMtime: 1000, Entities: 500}, true
+	}
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", read, aliveLiveness, pendingUntil(8))
+
+	var sseCh <-chan sseEvent
+	evCh := make(chan progress.Event, 64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, cfg, true, nil)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+
+	rows := map[string]wiztui.Row{}
+	sawPositiveBeforeDone := false
+	n := len(evCh)
+	for i := 0; i < n; i++ {
+		e := <-evCh
+		rows = wiztui.Fold(rows, e)
+		if rows[wantSlug].Phase != progress.PhaseDone && wiztui.AggregateProgress(rows, 1) > 0 {
+			sawPositiveBeforeDone = true
+		}
+	}
+	if !sawPositiveBeforeDone {
+		t.Fatal("AggregateProgress stayed at 0 until the terminal Done event — the overall bar would look hung")
+	}
+}
+
+// LIVE-3. Monotonic merge: a status-plane event (coarse PhaseIndexing) must
+// NOT regress a row that a real, finer-grained SSE event already advanced
+// past it, and it must fold into the SAME row (no duplicate) rather than
+// creating a second entry keyed differently.
+func TestSplit_StatusPlaneEventMergesMonotonicWithFinerSSEPhase(t *testing.T) {
+	rows := map[string]wiztui.Row{}
+	// A real SSE tick already reported a finer, more-advanced phase.
+	rows = wiztui.Fold(rows, progress.Event{RepoSlug: "backend", Phase: progress.PhaseResolveRefs, TS: 1})
+
+	// A later status-plane poll observes the repo still Indexing and
+	// synthesizes the coarse PhaseIndexing event.
+	evCh := make(chan progress.Event, 4)
+	emitStatusPlaneRowEvents(evCh, []repoStatusSnapshot{{Slug: "backend", Indexing: true, Entities: 77}})
+	if len(evCh) != 1 {
+		t.Fatalf("emitStatusPlaneRowEvents sent %d events, want 1", len(evCh))
+	}
+	statusEvent := <-evCh
+	statusEvent.TS = 2 // later than the SSE event, still must not regress the phase
+	rows = wiztui.Fold(rows, statusEvent)
+
+	if len(rows) != 1 {
+		t.Fatalf("len(rows) = %d, want 1 (status-plane event must merge into the existing row, not duplicate it)", len(rows))
+	}
+	got := rows["backend"]
+	if got.Phase != progress.PhaseResolveRefs {
+		t.Fatalf("row phase regressed to %q; want it to stay at the finer SSE phase %q", got.Phase, progress.PhaseResolveRefs)
+	}
+}
+
+// LIVE-4. Monorepo gate: for a monorepo (perRepoRows=false), the completion
+// poll must emit ZERO status-plane row events — the status plane has ONE
+// entry for the whole repo root while the display is per-MODULE, so emitting
+// a repo-level event here would resurrect the spurious repo-level row #5773
+// removed and double-count against the per-module rows.
+func TestSplit_Monorepo_NoStatusPlaneRowEmitted(t *testing.T) {
+	const repo = "/repo/monorepo-root"
+	store := newFakeStatusStore()
+	// Repo actively indexing, then advances (flushed right before the ack,
+	// same pattern as pendingUntilThen elsewhere in this file) — exactly the
+	// sequence that would fire row events for a flat repo.
+	store.set(repo, &statusfile.File{Indexing: true})
+	flush := func() {
+		store.set(repo, &statusfile.File{Indexing: false, GraphFBMtime: 1000, Entities: 999})
+	}
+	probe := newStatusPlaneProbeWith([]string{repo}, "/root", store.read, aliveLiveness, pendingUntilThen(4, flush))
+
+	var sseCh <-chan sseEvent
+	evCh := make(chan progress.Event, 64)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cfg := splitPollConfig{interval: time.Millisecond, startupWindow: 0, timeout: 45 * time.Minute}
+	o := runSplitIndexCore(ctx, cancel, noTrigger, sseCh, evCh, probe, &fakeSplitClock{}, cfg, false /* monorepo: perRepoRows=false */, nil)
+	if o.err != nil {
+		t.Fatalf("unexpected error: %v", o.err)
+	}
+	if got := len(evCh); got != 0 {
+		t.Fatalf("evCh got %d status-plane row event(s) for a monorepo; want 0 (perRepoRows=false must suppress them)", got)
 	}
 }

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -421,7 +421,7 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 				RepoStats: toWiztuiRepoStats(stats),
 			}
 		}
-		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh, onQueryable)
+		o := runSplitIndex(ctx, cancel, c, group, token, sseCh, evCh, perRepoRows, onQueryable)
 		if !perRepoRows {
 			o.repoStats = nil // monorepo: suppress the aggregate-as-repo-row overlay
 		}

--- a/internal/cli/wiztui/fold.go
+++ b/internal/cli/wiztui/fold.go
@@ -36,6 +36,7 @@ const PhaseQueued = "queued"
 
 var phaseLabel = map[string]string{
 	PhaseQueued:                     "Queued…",
+	progress.PhaseIndexing:          "Indexing…",
 	progress.PhaseScan:              "Scanning…",
 	progress.PhaseExtractAST:        "Extracting AST…",
 	progress.PhaseResolveRefs:       "Resolving references…",
@@ -53,6 +54,17 @@ var phaseLabel = map[string]string{
 // phaseOrder is the monotonic phase ranking, mirroring the backend's real
 // emission sequence so a later, finer phase never regresses to a coarse one.
 var phaseOrder = map[string]int{
+	// PhaseIndexing is the coarse status-plane-derived "active" FLOOR (see
+	// wizard_split_progress.go's emitStatusPlaneRowEvents), used only when no
+	// fine-grained SSE event has arrived. Its rank here is consulted ONLY by
+	// rowFraction (a non-zero rank of 1 makes a status-plane-only run visibly
+	// leave 0% on AggregateProgress the moment a repo goes active). The
+	// phase-ADVANCE decision for PhaseIndexing does NOT use this rank — Fold
+	// special-cases it as a floor that only lifts a still-PhaseQueued row and
+	// never overwrites a real SSE phase (and conversely any real SSE phase
+	// always replaces the floor), so the numeric tie with PhaseExtractAST is
+	// deliberately harmless.
+	progress.PhaseIndexing:          1,
 	progress.PhaseScan:              0,
 	progress.PhaseExtractAST:        1,
 	progress.PhaseResolveRefs:       2,
@@ -140,6 +152,24 @@ func Fold(rows map[string]Row, e progress.Event) map[string]Row {
 	// Don't let a late, lower-ordered phase event overwrite a more-advanced
 	// phase already shown for this repo (the dropped/stale-row symptom #5326).
 	advance := !had || phaseRank(e.Phase) >= phaseRank(existing.Phase)
+
+	// PhaseIndexing is the coarse status-plane "active" FLOOR (see
+	// wizard_split_progress.go's emitStatusPlaneRowEvents), synthesized every
+	// ~500ms poll whether or not a dashboard is delivering SSE. It must ONLY
+	// lift a row that has no real phase yet (still PhaseQueued/unknown) — never
+	// overwrite a genuine SSE phase. Otherwise a status tick would clobber live
+	// PhaseScan/PhaseExtractAST progress (a `>=` rank TIE overwrites, and the
+	// coarse event lacks FilesTotal, so the ExtractAST file-bonus in rowFraction
+	// is lost → the label flips "Extracting AST…"→"Indexing…" and the bar
+	// stutters backward every poll for the whole AST phase). Conversely, a real
+	// SSE phase always REPLACES the coarse floor.
+	switch {
+	case e.Phase == progress.PhaseIndexing:
+		advance = !had || phaseRank(existing.Phase) < 0
+	case had && existing.Phase == progress.PhaseIndexing && phaseRank(e.Phase) >= 0:
+		advance = true
+	}
+
 	phase := e.Phase
 	if !advance {
 		phase = existing.Phase

--- a/internal/cli/wiztui/fold_test.go
+++ b/internal/cli/wiztui/fold_test.go
@@ -223,3 +223,63 @@ func TestSortRows_StableBySlug(t *testing.T) {
 		t.Errorf("sort order = %v, want [alpha zeta]", []string{got[0].RepoSlug, got[1].RepoSlug})
 	}
 }
+
+// TestFold_PhaseIndexingFloor_DoesNotClobberLiveSSEExtractAST is the
+// dashboard-up (SSE-active) regression guard: the coarse status-plane
+// PhaseIndexing floor (synthesized every ~500ms poll) must NEVER overwrite a
+// live, finer SSE phase. Here a real PhaseExtractAST event with file progress
+// (40/100) lands first; a later PhaseIndexing status tick (no FilesTotal) must
+// leave the label at "Extracting AST…" and NOT regress rowFraction — otherwise
+// the bar stutters backward for the whole (longest, most-watched) AST phase.
+func TestFold_PhaseIndexingFloor_DoesNotClobberLiveSSEExtractAST(t *testing.T) {
+	rows := map[string]Row{}
+	// Live SSE tick: extracting AST, 40/100 files.
+	rows = Fold(rows, progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, FilesDone: 40, FilesTotal: 100, TS: 1})
+	before := rowFraction(rows["backend"])
+	if PhaseLabel(rows["backend"].Phase) != "Extracting AST…" {
+		t.Fatalf("setup: label = %q, want Extracting AST…", PhaseLabel(rows["backend"].Phase))
+	}
+
+	// A later status-plane poll synthesizes the coarse PhaseIndexing floor
+	// (repo still Indexing, no FilesTotal, carries a status-plane entity count).
+	rows = Fold(rows, progress.Event{RepoSlug: "backend", Phase: progress.PhaseIndexing, EntitiesSoFar: 77, TS: 2})
+
+	if PhaseLabel(rows["backend"].Phase) != "Extracting AST…" {
+		t.Fatalf("PhaseIndexing floor clobbered the live SSE phase: label = %q, want Extracting AST…", PhaseLabel(rows["backend"].Phase))
+	}
+	if after := rowFraction(rows["backend"]); after < before {
+		t.Fatalf("rowFraction regressed %v -> %v when the coarse floor arrived (backward stutter)", before, after)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1 (floor must merge into the SSE row, not duplicate)", len(rows))
+	}
+}
+
+// TestFold_PhaseIndexingFloor_LiftsQueuedRow: the floor's intended job — it
+// DOES advance a still-PhaseQueued (seeded) row that has no real phase yet, so
+// the no-SSE live path (fast/warm re-index, no dashboard) leaves "Queued…".
+func TestFold_PhaseIndexingFloor_LiftsQueuedRow(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, ev("backend", PhaseQueued, 1)) // seeded row
+	rows = Fold(rows, progress.Event{RepoSlug: "backend", Phase: progress.PhaseIndexing, EntitiesSoFar: 5, TS: 2})
+
+	if rows["backend"].Phase != progress.PhaseIndexing {
+		t.Fatalf("PhaseIndexing did not lift a bare PhaseQueued row: phase = %q", rows["backend"].Phase)
+	}
+	if rowFraction(rows["backend"]) <= 0 {
+		t.Fatalf("rowFraction = %v, want > 0 once the floor lifts a queued row (bar must leave 0%%)", rowFraction(rows["backend"]))
+	}
+}
+
+// TestFold_RealPhaseReplacesIndexingFloor: the converse — once the coarse floor
+// is showing, a genuine SSE phase (even the earliest, PhaseScan) must REPLACE
+// it, so a row that briefly showed "Indexing…" before the first SSE tick
+// advances into the real pipeline phases rather than sticking at the floor.
+func TestFold_RealPhaseReplacesIndexingFloor(t *testing.T) {
+	rows := map[string]Row{}
+	rows = Fold(rows, progress.Event{RepoSlug: "backend", Phase: progress.PhaseIndexing, TS: 1})
+	rows = Fold(rows, ev("backend", progress.PhaseScan, 2)) // first real SSE tick
+	if rows["backend"].Phase != progress.PhaseScan {
+		t.Fatalf("real PhaseScan did not replace the coarse Indexing floor: phase = %q", rows["backend"].Phase)
+	}
+}

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -75,6 +75,15 @@ const (
 
 	// PhaseError is emitted when the indexer encounters a fatal error.
 	PhaseError = "error"
+
+	// PhaseIndexing is a coarse "actively being indexed" signal, distinct
+	// from the fine-grained pipeline phases above. It is synthesized (not
+	// emitted by the indexer itself) from the status-plane sidecar file when
+	// no fine-grained SSE progress event is available for a repo yet — e.g.
+	// no dashboard is running, or a fast/warm re-index completes before any
+	// SSE tick is delivered. See wizard_split_progress.go's
+	// emitStatusPlaneRowEvents (grafel wizard split-mode index).
+	PhaseIndexing = "indexing"
 )
 
 // TickEveryNFiles is the default file-tick interval for the AST extraction


### PR DESCRIPTION
On a fast/warm re-index the wizard's seeded rows sat at "Queued…" with a 0% bar the whole time, then jumped to Done — looking like a hang. Root cause: `awaitSplitCompletion` already polls each repo's status file every 500ms but only used it to CLASSIFY at the end; rows were never updated during indexing (repos finished at ~4s but rows resolved at the ~1m17s terminal outcome).

**Fix:** each poll tick, emit synthetic `progress.Event`s from the already-polled status-plane data so rows advance queued→**Indexing…**→Done live and the aggregate bar climbs — even when no dashboard SSE is delivering. `PhaseIndexing` is a **floor**: it only lifts a still-queued row and never overwrites a live SSE phase (so the dashboard-up path keeps its fine-grained "Extracting AST… X/Y files" progress). Gated to non-monorepo (monorepo modules keep their existing per-module rendering).

Independently reviewed twice (caught + fixed a rank-tie clobber of live SSE before merge). 513 tests incl. `-race` and interleaving regression tests; vet + gofmt clean.

Refs #5773, #5729.