### PR TITLE
feat(wiztui): freeze index timer at 'Done' + secondary background-enhancement bar

### DIFF
--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -59,6 +59,32 @@ type indexView struct {
 	startedAt  time.Time
 	finishedAt time.Time
 
+	// queryableAt is stamped the instant the interim ("graph queryable")
+	// outcome lands (see Model's outcomeMsg handling). Two things key off it:
+	// (1) the MAIN header elapsed (elapsedText) freezes at startedAt..
+	// queryableAt instead of continuing to grow while only the background
+	// enhancement pass is still running — a still-ticking "Done · 1m14s…" reads
+	// as "indexing is stuck" when the graph is actually ready; (2) the
+	// secondary background-enhancement bar's own elapsed (bgElapsedText) counts
+	// up from this moment, clearly attributing the running time to background
+	// work rather than stalled indexing. Zero until the interim outcome lands.
+	queryableAt time.Time
+
+	// bgBar is the secondary progress bar shown only in the interim/queryable
+	// sub-state, rendered below the queryable banner (reuses bar's gradient
+	// styling — see newIndexView). The background enhancement pass (relationship
+	// linking / enrichment) doesn't report a percentage to the wizard, so this
+	// is driven as an INDETERMINATE animated sweep via bgPct/bgAnimDir rather
+	// than a fabricated determinate percentage.
+	bgBar progress.Model
+	// bgPct is the current fill fraction [0,1] of the indeterminate sweep,
+	// advanced by advanceBgAnim on each bgAnimMsg tick (see model.go). It
+	// bounces between 0 and 1 (a "breathing" gradient) rather than monotonically
+	// filling, since there is no real percentage to represent.
+	bgPct float64
+	// bgAnimDir is the current direction (+1 or -1) of the bgPct sweep.
+	bgAnimDir float64
+
 	// rssMB / cpuPct are the engine process's live CPU/RAM readout (wizard
 	// CPU/RAM readout — see internal/statusfile.File's RSSMB/CPUPct doc),
 	// polled periodically from the engine-liveness status-plane sidecar via
@@ -78,6 +104,12 @@ func newIndexView(group string, expectedRepos int) indexView {
 		progress.WithScaledGradient("#5FB0FF", "#2FD6A6"),
 		progress.WithoutPercentage(),
 	)
+	// bgBar mirrors the main bar's gradient styling so the secondary
+	// background-enhancement bar reads as visually part of the same system.
+	bg := progress.New(
+		progress.WithScaledGradient("#5FB0FF", "#2FD6A6"),
+		progress.WithoutPercentage(),
+	)
 	s := spinner.New()
 	s.Spinner = g.Spinner()
 	s.Style = lipgloss.NewStyle().Foreground(colAccent)
@@ -86,7 +118,26 @@ func newIndexView(group string, expectedRepos int) indexView {
 		expectedRepos: expectedRepos,
 		rows:          map[string]Row{},
 		bar:           b,
+		bgBar:         bg,
+		bgAnimDir:     1,
 		spin:          s,
+	}
+}
+
+// advanceBgAnim advances the indeterminate secondary bar's sweep by one tick,
+// bouncing bgPct between 0 and 1 (a "breathing" gradient) rather than filling
+// monotonically — there is no real percentage for the background enhancement
+// pass to report (see bgBar's doc), so an honest indeterminate sweep is used
+// instead of a fabricated one.
+func (v *indexView) advanceBgAnim() {
+	const step = 0.055
+	v.bgPct += step * v.bgAnimDir
+	if v.bgPct >= 1 {
+		v.bgPct = 1
+		v.bgAnimDir = -1
+	} else if v.bgPct <= 0 {
+		v.bgPct = 0
+		v.bgAnimDir = 1
 	}
 }
 
@@ -332,16 +383,45 @@ func (v indexView) metricSuffix() string {
 // startIndex) returns "" so the header renders exactly as before this
 // feature. While indexing it is computed against time.Now() (so it advances
 // every ~1s tick — see Model's timerMsg handling); once done() it freezes at
-// finishedAt-startedAt so it stops growing with wall-clock time.
+// finishedAt-startedAt so it stops growing with wall-clock time. In the
+// split-mode interim/queryable sub-state (graph queryable, background
+// enhancement still running, not yet terminal) it ALSO freezes — at
+// queryableAt-startedAt — so the header doesn't read as "stuck" while only
+// optional background work remains; see bgElapsedText for the secondary
+// timer that keeps counting for that background work.
 func (v indexView) elapsedText() string {
 	if v.startedAt.IsZero() {
+		return ""
+	}
+	end := time.Now()
+	switch {
+	case v.done() && !v.finishedAt.IsZero():
+		end = v.finishedAt
+	case v.queryable && !v.queryableAt.IsZero():
+		end = v.queryableAt
+	}
+	return fmtElapsed(end.Sub(v.startedAt))
+}
+
+// bgElapsedText renders the secondary bar's own elapsed segment ("1m02s"),
+// counting up from the moment the graph became queryable (queryableAt) rather
+// than from startedAt — so the running time is clearly attributed to the
+// background enhancement pass, not indexing itself. Returns "" before
+// queryableAt is stamped. Freezes at finishedAt once done(), mirroring
+// elapsedText, so it doesn't keep growing after the screen finishes.
+func (v indexView) bgElapsedText() string {
+	if v.queryableAt.IsZero() {
 		return ""
 	}
 	end := time.Now()
 	if v.done() && !v.finishedAt.IsZero() {
 		end = v.finishedAt
 	}
-	return fmtElapsed(end.Sub(v.startedAt))
+	d := end.Sub(v.queryableAt)
+	if d < 0 {
+		d = 0
+	}
+	return fmtElapsed(d)
 }
 
 // view renders the full indexing body (overall bar + per-repo rows + summary).
@@ -350,9 +430,11 @@ func (v indexView) view() string {
 
 	rows := SortRows(v.rows)
 
-	// Overall progress bar + label.
+	// Overall progress bar + label. In the interim/queryable sub-state the
+	// graph is already usable, so the MAIN bar reads 100% too — only the
+	// secondary bar (below) represents the still-running background work.
 	pct := AggregateProgress(v.rows, v.expectedRepos)
-	if v.terminal {
+	if v.terminal || v.queryable {
 		pct = 1
 	}
 	label := v.overallLabel()
@@ -404,7 +486,40 @@ func (v indexView) view() string {
 	} else if v.queryable {
 		b.WriteString("\n")
 		b.WriteString(v.queryableBanner())
+		b.WriteString("\n\n")
+		b.WriteString(v.bgProgressBlock())
 	}
+
+	return b.String()
+}
+
+// bgProgressBlock renders the secondary background-enhancement bar shown only
+// in the interim/queryable sub-state (queryable && !terminal): a label with
+// its own independently-running elapsed timer, followed by an indeterminate
+// animated bar (bgPct, advanced by advanceBgAnim on each bgAnimMsg tick — see
+// model.go). It is indeterminate rather than a fabricated percentage because
+// the background enhancement pass genuinely reports no progress signal to the
+// wizard (runSplitIndex just awaits completion; see wizard_tui_run.go).
+func (v indexView) bgProgressBlock() string {
+	var b strings.Builder
+
+	label := "Enhancing relationships in the background"
+	if e := v.bgElapsedText(); e != "" {
+		label += "  " + g.MidDot + " +" + e
+	}
+	b.WriteString(rowCountStyle.Render(label))
+	b.WriteString("\n")
+
+	width := v.width - 4
+	if width < 20 {
+		width = 20
+	}
+	if width > 80 {
+		width = 80
+	}
+	bar := v.bgBar
+	bar.Width = width
+	b.WriteString(bar.ViewAs(v.bgPct))
 
 	return b.String()
 }

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -434,7 +434,7 @@ func (v indexView) view() string {
 	// graph is already usable, so the MAIN bar reads 100% too — only the
 	// secondary bar (below) represents the still-running background work.
 	pct := AggregateProgress(v.rows, v.expectedRepos)
-	if v.terminal || v.queryable {
+	if (v.terminal || v.queryable) && !v.failed {
 		pct = 1
 	}
 	label := v.overallLabel()

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -107,6 +107,94 @@ func TestIndexView_QueryableBanner_ShownWhenQueryableNotTerminal(t *testing.T) {
 	}
 }
 
+// TestIndexView_HeaderFreezesElapsedAtQueryableMoment: once the graph becomes
+// queryable (interim outcome landed), the main header elapsed FREEZES at the
+// queryable moment (startedAt..queryableAt) instead of continuing to grow with
+// wall-clock time while the background enhancement pass keeps running.
+func TestIndexView_HeaderFreezesElapsedAtQueryableMoment(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.startedAt = time.Now().Add(-10 * time.Minute)   // indexing "started" long ago
+	v.queryableAt = v.startedAt.Add(74 * time.Second) // became queryable at 1m14s
+	v.queryable = true
+
+	out := v.view()
+	if !strings.Contains(out, "1m14s") {
+		t.Errorf("header missing elapsed frozen at the queryable moment \"1m14s\":\n%s", out)
+	}
+	if strings.Contains(out, "10m00s") {
+		t.Errorf("header shows live wall-clock elapsed instead of freezing at the queryable moment:\n%s", out)
+	}
+}
+
+// TestIndexView_BgElapsed_StartsAtQueryableMomentAndAdvancesIndependently: the
+// secondary "enhancing in background" elapsed is computed from queryableAt,
+// independent of (and later-starting than) the main startedAt-based elapsed.
+func TestIndexView_BgElapsed_StartsAtQueryableMomentAndAdvancesIndependently(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.startedAt = time.Now().Add(-5 * time.Minute)
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseDone, TS: 1})
+	v.queryable = true
+	v.queryableAt = time.Now().Add(-30 * time.Second)
+
+	out := v.view()
+	if !strings.Contains(out, "0m30s") {
+		t.Errorf("secondary bar missing its own elapsed timer \"0m30s\":\n%s", out)
+	}
+}
+
+// TestIndexView_SecondaryBar_OnlyRendersInInterimState: the background
+// enhancement bar is present only while queryable && !terminal — absent
+// before queryable, and absent again once terminal.
+func TestIndexView_SecondaryBar_OnlyRendersInInterimState(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, TS: 1})
+
+	out := v.view()
+	if strings.Contains(out, "Enhancing relationships in the background") {
+		t.Errorf("secondary bar rendered before the graph is queryable:\n%s", out)
+	}
+
+	v.queryable = true
+	v.queryableAt = time.Now()
+	out = v.view()
+	if !strings.Contains(out, "Enhancing relationships in the background") {
+		t.Errorf("secondary bar missing while queryable and not terminal:\n%s", out)
+	}
+
+	v.terminal = true
+	out = v.view()
+	if strings.Contains(out, "Enhancing relationships in the background") {
+		t.Errorf("secondary bar still rendered after the outcome went terminal:\n%s", out)
+	}
+}
+
+// TestIndexView_AdvanceBgAnim_MovesAndBounces: the indeterminate animation
+// driver advances bgPct forward each tick and bounces back within [0,1]
+// instead of running away or going negative.
+func TestIndexView_AdvanceBgAnim_MovesAndBounces(t *testing.T) {
+	v := newIndexView("grp", 1)
+	if v.bgPct != 0 {
+		t.Fatalf("initial bgPct = %v, want 0", v.bgPct)
+	}
+	prev := v.bgPct
+	for i := 0; i < 5; i++ {
+		v.advanceBgAnim()
+		if v.bgPct <= prev {
+			t.Fatalf("bgPct did not advance forward on tick %d: prev=%v now=%v", i, prev, v.bgPct)
+		}
+		prev = v.bgPct
+	}
+	for i := 0; i < 40; i++ {
+		v.advanceBgAnim()
+		if v.bgPct > 1 || v.bgPct < 0 {
+			t.Fatalf("bgPct out of [0,1] bounds after tick %d: %v", i, v.bgPct)
+		}
+	}
+}
+
 // TestIndexView_DoneSummary_Commafied asserts doneSummary formats entities and
 // relationships with thousands separators.
 func TestIndexView_DoneSummary_Commafied(t *testing.T) {

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -171,6 +171,32 @@ func TestIndexView_SecondaryBar_OnlyRendersInInterimState(t *testing.T) {
 	}
 }
 
+// TestIndexView_QueryableThenFailed_MainBarNotFull: if a run becomes
+// queryable and THEN the final ack surfaces a failure (engine died/timeout),
+// the main bar must NOT force to 100% beside the "Failed" label, and the
+// secondary background bar must be suppressed.
+func TestIndexView_QueryableThenFailed_MainBarNotFull(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	// A repo mid-flight (well under 100%), then queryable, then failed.
+	v.foldEvent(progress.Event{RepoSlug: "backend", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 10, TS: 1})
+	v.queryable = true
+	v.queryableAt = time.Now()
+	v.failed = true
+	v.errMsg = "engine died"
+
+	out := v.view()
+	if !strings.Contains(out, "Failed") {
+		t.Errorf("failed run missing the \"Failed\" label:\n%s", out)
+	}
+	if strings.Contains(out, "100%") {
+		t.Errorf("main bar forced to 100%% beside a Failed label (queryable-then-failed glitch):\n%s", out)
+	}
+	if strings.Contains(out, "Enhancing relationships in the background") {
+		t.Errorf("secondary bg bar rendered on a failed run (should be suppressed):\n%s", out)
+	}
+}
+
 // TestIndexView_AdvanceBgAnim_MovesAndBounces: the indeterminate animation
 // driver advances bgPct forward each tick and bounces back within [0,1]
 // instead of running away or going negative.

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -237,6 +237,27 @@ func timerTick() tea.Cmd {
 	})
 }
 
+// bgAnimMsg drives the secondary (background-enhancement) bar's indeterminate
+// sweep animation (see indexView.advanceBgAnim). Scheduled only while the
+// model is in the interim/queryable sub-state (see the outcomeMsg Interim
+// branch and the bgAnimMsg case in Update) and deliberately NOT rescheduled
+// once that state ends (terminal outcome lands, or the user finishes early) —
+// so the ticker never leaks into the background after the screen is done.
+type bgAnimMsg time.Time
+
+// bgAnimTickInterval is the cadence of the indeterminate sweep. Faster than
+// timerTickInterval (which only needs to redraw a 1s-resolution clock) since
+// this drives a visibly moving/pulsing bar — smooth motion needs a shorter
+// period.
+const bgAnimTickInterval = 90 * time.Millisecond
+
+// bgAnimTick schedules the next background-animation tick as a tea.Cmd.
+func bgAnimTick() tea.Cmd {
+	return tea.Tick(bgAnimTickInterval, func(t time.Time) tea.Msg {
+		return bgAnimMsg(t)
+	})
+}
+
 // Model is the full-screen Bubble Tea wizard model.
 type Model struct {
 	drv   Driver
@@ -368,7 +389,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// updateKey's scrIndex case) can still overlay real per-repo counts
 			// instead of leaving a silent repo at "Done · 0 entities".
 			m.idx.interimRepoStats = o.RepoStats
-			return m, waitOutcome(m.outCh)
+			// Stamp the queryable moment (freezes the main header elapsed there,
+			// and anchors the secondary bar's own elapsed — see elapsedText /
+			// bgElapsedText) and kick off the indeterminate sweep animation. At
+			// most one interim outcome is ever sent, so queryableAt is only ever
+			// stamped once, but guard IsZero defensively anyway.
+			if m.idx.queryableAt.IsZero() {
+				m.idx.queryableAt = time.Now()
+			}
+			return m, tea.Batch(waitOutcome(m.outCh), bgAnimTick())
 		}
 		m.idx.summaryEntities = o.Entities
 		m.idx.summaryRels = o.Rels
@@ -403,6 +432,17 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// doesn't run forever in the background.
 		if m.scr == scrIndex && !m.idx.done() {
 			return m, timerTick()
+		}
+		return m, nil
+
+	case bgAnimMsg:
+		// Secondary bar's indeterminate sweep: advance one frame and reschedule
+		// only while still in the interim/queryable sub-state. Once terminal (the
+		// background pass finished, or the user finished early) this simply stops
+		// rescheduling — no goroutine/ticker leak.
+		if m.idx.queryable && !m.idx.terminal {
+			m.idx.advanceBgAnim()
+			return m, bgAnimTick()
 		}
 		return m, nil
 

--- a/internal/cli/wiztui/model.go
+++ b/internal/cli/wiztui/model.go
@@ -392,12 +392,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			// Stamp the queryable moment (freezes the main header elapsed there,
 			// and anchors the secondary bar's own elapsed — see elapsedText /
 			// bgElapsedText) and kick off the indeterminate sweep animation. At
-			// most one interim outcome is ever sent, so queryableAt is only ever
-			// stamped once, but guard IsZero defensively anyway.
+			// most one interim outcome is ever sent, so this normally runs once;
+			// gate BOTH the stamp and the tick-start on IsZero so a (spurious)
+			// second interim outcome can't spawn a second concurrent tick chain.
+			cmds := []tea.Cmd{waitOutcome(m.outCh)}
 			if m.idx.queryableAt.IsZero() {
 				m.idx.queryableAt = time.Now()
+				cmds = append(cmds, bgAnimTick())
 			}
-			return m, tea.Batch(waitOutcome(m.outCh), bgAnimTick())
+			return m, tea.Batch(cmds...)
 		}
 		m.idx.summaryEntities = o.Entities
 		m.idx.summaryRels = o.Rels

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -401,6 +401,30 @@ func TestModel_BgAnimMsg_AdvancesBgPctWhileInterim(t *testing.T) {
 	}
 }
 
+// TestModel_SecondInterim_DoesNotSpawnSecondTickChain: only one interim
+// outcome is ever sent in practice, but a spurious second one must NOT stamp a
+// new queryableAt nor kick a second concurrent bgAnimTick chain. The first
+// interim returns a Batch that includes the tick; a second interim returns
+// only the re-armed waitOutcome (no additional tick).
+func TestModel_SecondInterim_DoesNotSpawnSecondTickChain(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100}))
+	firstQueryableAt := m.idx.queryableAt
+	if firstQueryableAt.IsZero() {
+		t.Fatal("first interim did not stamp queryableAt")
+	}
+
+	// A spurious second interim: queryableAt must be unchanged (guarded on
+	// IsZero), so no second bgAnimTick chain is kicked (the tick-start is gated
+	// on the same IsZero as the stamp). The still-running first chain also
+	// self-limits — it only advances while queryable && !terminal (see the
+	// bgAnimMsg handler) — so there is exactly one advancing chain regardless.
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 200}))
+	if !m.idx.queryableAt.Equal(firstQueryableAt) {
+		t.Errorf("second interim re-stamped queryableAt: was %v now %v", firstQueryableAt, m.idx.queryableAt)
+	}
+}
+
 // TestModel_BgAnimMsg_StopsAfterTerminal: once the final outcome lands (the
 // background-completes-on-its-own path), the anim tick must NOT reschedule —
 // otherwise it leaks a ticker running forever after the screen is done.

--- a/internal/cli/wiztui/model_test.go
+++ b/internal/cli/wiztui/model_test.go
@@ -2,6 +2,7 @@ package wiztui
 
 import (
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -363,6 +364,75 @@ func TestModel_InterimOutcome_EntersQueryableAndKeepsWaiting(t *testing.T) {
 	}
 	if !m.idx.install.Applied {
 		t.Error("interim outcome's Install summary not captured")
+	}
+}
+
+// TestModel_InterimOutcome_StampsQueryableAt: an interim outcome stamps
+// idx.queryableAt at the moment it lands, so the main header can freeze there
+// and the secondary bar's elapsed can start counting from it.
+func TestModel_InterimOutcome_StampsQueryableAt(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	before := time.Now()
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100}))
+	if m.idx.queryableAt.IsZero() {
+		t.Fatal("queryableAt not stamped after an interim outcome")
+	}
+	if m.idx.queryableAt.Before(before) {
+		t.Errorf("queryableAt = %v, want at/after %v (the interim moment)", m.idx.queryableAt, before)
+	}
+}
+
+// TestModel_BgAnimMsg_AdvancesBgPctWhileInterim: the background animation tick
+// advances idx.bgPct and reschedules itself while still in the interim
+// (queryable, not terminal) sub-state.
+func TestModel_BgAnimMsg_AdvancesBgPctWhileInterim(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100}))
+	before := m.idx.bgPct
+
+	nm, cmd := m.Update(bgAnimMsg(time.Now()))
+	m = nm.(Model)
+
+	if m.idx.bgPct <= before {
+		t.Errorf("bgPct did not advance on tick: before=%v after=%v", before, m.idx.bgPct)
+	}
+	if cmd == nil {
+		t.Error("expected the bg anim tick to reschedule itself while still interim")
+	}
+}
+
+// TestModel_BgAnimMsg_StopsAfterTerminal: once the final outcome lands (the
+// background-completes-on-its-own path), the anim tick must NOT reschedule —
+// otherwise it leaks a ticker running forever after the screen is done.
+func TestModel_BgAnimMsg_StopsAfterTerminal(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100}))
+	m = m.update(outcomeMsg(IndexOutcome{Entities: 500, Rels: 10}))
+	if !m.idx.terminal {
+		t.Fatal("expected terminal after the final outcome")
+	}
+
+	nm, cmd := m.Update(bgAnimMsg(time.Now()))
+	m = nm.(Model)
+	if cmd != nil {
+		t.Error("expected the bg anim tick to stop rescheduling after terminal (ticker leak)")
+	}
+}
+
+// TestModel_EnterEarly_StopsBgAnimTick: finishing early via enter (before the
+// final outcome lands) must also stop the anim tick from rescheduling.
+func TestModel_EnterEarly_StopsBgAnimTick(t *testing.T) {
+	m := driveToIndexScreen(t, nilIndex)
+	m = m.update(outcomeMsg(IndexOutcome{Interim: true, Entities: 100}))
+	m = m.update(key("enter")) // finish early
+	if !m.idx.terminal {
+		t.Fatal("expected terminal after finishing early")
+	}
+
+	nm, cmd := m.Update(bgAnimMsg(time.Now()))
+	m = nm.(Model)
+	if cmd != nil {
+		t.Error("expected the bg anim tick to stop rescheduling after finishing early (ticker leak)")
 	}
 }
 


### PR DESCRIPTION
In the split-mode "graph queryable" interim state, the header showed "Done" but the elapsed timer kept running (looked like a stuck index) because the background enhancement (relationship linking / enrichment passes) was still going.

**Fix:** freeze the main header elapsed at the graph-queryable moment ("Done · <indexing time>", main bar 100%), and add a SECOND indeterminate animated bar below — with its own independent "+MM:SS" timer — labeled "enhancing relationships in the background", shown only while queryable and not yet terminal. It completes/disappears on the final (background-complete) outcome or when the user presses Enter to finish early. The background passes surface no percentage to the wizard, so the bar is honestly indeterminate (a bouncing sweep), not a fabricated number.

Now "indexing done, background still running" is unmistakable, and the running time is correctly attributed to background work.

Independently reviewed (APPROVE); two nits folded in (no 100%-next-to-Failed; duplicate-interim can't spawn a second animation chain). 485 tests + 86 `-race`; vet + gofmt clean. Monolith path unchanged.

Refs #5774, #5729.