### PR TITLE
fix(daemon): set status-plane indexing=true during foreground rebuild (statusline + wizard live state)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1413,6 +1413,17 @@ func daemonRebuildFuncCore(
 			// the child subprocess lifetime.
 			releaseClaim := repolock.DefaultRegistry.ClaimForeground(rw.r.Path)
 			defer releaseClaim()
+			// Flush the status-plane sidecar immediately on claim acquisition so a
+			// reader (statusline widget, wizard live-progress) observes
+			// Indexing=true at index START instead of waiting up to a heartbeat
+			// interval (defaultStatusHeartbeatInterval, 5s) for the async
+			// statusWriter to notice the foreground claim via
+			// repolock.HasForegroundClaim. releaseClaim (deferred above) always
+			// runs, and flushRebuiltStatus/the error-path flush below always runs
+			// AFTER this closure returns (see indexOneInner), so the terminal
+			// flush reads the claim as already released and correctly reports
+			// Indexing=false.
+			daemon.FlushRepoStatusFile(rw.r.Path)
 
 			if sched.SubprocessIndexEnabled() {
 				// #5729 follow-up: route the per-repo index through the SAME

--- a/cmd/grafel/daemon_rebuild_foreground_indexing_test.go
+++ b/cmd/grafel/daemon_rebuild_foreground_indexing_test.go
@@ -1,0 +1,71 @@
+package main
+
+// daemon_rebuild_foreground_indexing_test.go — regression for the
+// foreground-indexing status-plane gap: writeRepoStatusFile's Indexing bit is
+// computed purely from indexstate.RepoStates(), which the FOREGROUND
+// rebuild/subprocess path (daemonRebuildFuncCore) never populates (it
+// deliberately bypasses the scheduler — see internal/repolock's package doc).
+// Without the repolock.HasForegroundClaim OR-in (internal/daemon/statuswriter.go)
+// and the start-of-index flush added alongside it (this file's ClaimForeground
+// call site in daemonRebuildFuncCore), a statusline widget or the wizard TUI
+// live-progress feature can never observe Indexing=true during a foreground
+// rebuild.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestDaemonRebuild_StartFlushSetsIndexingTrue verifies that by the time the
+// index function for a repo is actually running (i.e. after
+// repolock.ClaimForeground has been acquired and the start-of-index
+// FlushRepoStatusFile call has run), the repo's status-plane sidecar reports
+// Indexing=true — and that once the rebuild returns (the claim released, the
+// terminal flush run), it reports Indexing=false again.
+func TestDaemonRebuild_StartFlushSetsIndexingTrue(t *testing.T) {
+	group := setupTestGroup(t, "fg-indexing-group", []string{"alpha"})
+
+	var sawIndexingDuringRun bool
+	var repoPathSeen string
+	mockIndexFn := func(repoPath, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		repoPathSeen = repoPath
+		// The start-of-index flush (right after ClaimForeground acquires, in
+		// daemonRebuildFuncCore) must have already run by the time this
+		// function — which only runs INSIDE the claim — executes.
+		if f, ok := daemon.RepoStatusFile(repoPath); ok && f != nil {
+			sawIndexingDuringRun = f.Indexing
+		}
+
+		sd := daemon.StateDirForRepo(repoPath)
+		if err := os.MkdirAll(sd, 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(sd, "graph.fb"), []byte("fb"), 0o644)
+	}
+
+	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
+	if err != nil {
+		t.Fatalf("rebuild failed: %v", err)
+	}
+	if len(rebuilt) != 1 {
+		t.Fatalf("rebuilt %d repos, want 1", len(rebuilt))
+	}
+	if repoPathSeen == "" {
+		t.Fatal("mockIndexFn never ran")
+	}
+	if !sawIndexingDuringRun {
+		t.Error("Indexing should have been true during the index run — the start-of-index flush should have set it via repolock.HasForegroundClaim")
+	}
+
+	f, ok := daemon.RepoStatusFile(rebuilt[0])
+	if !ok || f == nil {
+		t.Fatalf("no status file for %s after rebuild returned", rebuilt[0])
+	}
+	if f.Indexing {
+		t.Errorf("Indexing = true after rebuild returned; want false (claim released, terminal flush ran)")
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/repolock"
 	"github.com/cajasmota/grafel/internal/statusfile"
 	"github.com/cajasmota/grafel/internal/version"
 )
@@ -107,6 +108,16 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 		f.Indexing = st.State == indexstate.StateIndexing || st.State == indexstate.StateDirty
 		break
 	}
+	// The FOREGROUND rebuild/subprocess path (cmd/grafel daemonRebuildFuncCore)
+	// deliberately bypasses the scheduler and never enters s.inflight, so the
+	// scheduler-derived f.Indexing above stays false throughout that path even
+	// though a real index is running. repolock.ClaimForeground is held for the
+	// exact lifetime of that index (keyed on the SAME repoPath the rebuild
+	// derives from the group config — see internal/repolock's package doc), so
+	// OR-ing in HasForegroundClaim closes the gap without touching the
+	// scheduler/watcher path's (already-correct) StateIndexing/StateDirty
+	// signal above.
+	f.Indexing = f.Indexing || repolock.DefaultRegistry.HasForegroundClaim(repoPath)
 	// Process-wide queue depth (#5493 concurrency gate) — the closest
 	// available proxy for "how much work is ahead of this repo" without
 	// threading per-repo queue position through the scheduler snapshot.

--- a/internal/daemon/statuswriter_5729_test.go
+++ b/internal/daemon/statuswriter_5729_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/repolock"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
@@ -49,6 +50,52 @@ func TestWriteRepoStatusFile_WritesReadableSchema(t *testing.T) {
 	}
 	if !got.Indexing {
 		t.Error("Indexing should be true — scheduler reports this repo as StateIndexing")
+	}
+}
+
+// TestWriteRepoStatusFile_ForegroundClaimSetsIndexing is the RED test for the
+// foreground-indexing status-plane gap: the FOREGROUND rebuild/subprocess
+// path (cmd/grafel daemonRebuildFuncCore) bypasses the scheduler entirely via
+// repolock.ClaimForeground, so indexstate.RepoStates() never reports it as
+// StateIndexing/StateDirty for that repo. writeRepoStatusFile must still
+// report Indexing=true while that foreground claim is held, by OR-ing in
+// repolock.DefaultRegistry.HasForegroundClaim(repoPath) — even though the
+// scheduler-derived signal alone says StateCurrent (not indexing).
+func TestWriteRepoStatusFile_ForegroundClaimSetsIndexing(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+
+	// Scheduler reports this repo as CURRENT (not indexing) — only the
+	// foreground claim signals an in-flight index.
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: repo, State: indexstate.StateCurrent, HeadRef: "main"},
+	})
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	release := repolock.DefaultRegistry.ClaimForeground(repo)
+	t.Cleanup(release)
+
+	writeRepoStatusFile(repo, nil)
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if !got.Indexing {
+		t.Error("Indexing should be true — a foreground claim is held for this repo path")
+	}
+
+	release()
+
+	writeRepoStatusFile(repo, nil)
+	got, err = statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if got.Indexing {
+		t.Error("Indexing should be false once the foreground claim releases and the scheduler reports StateCurrent")
 	}
 }
 

--- a/internal/repolock/repolock.go
+++ b/internal/repolock/repolock.go
@@ -115,6 +115,34 @@ func (r *Registry) ClaimForeground(key string) (release func()) {
 	}
 }
 
+// HasForegroundClaim reports whether a foreground claim is currently intended
+// or held for key — i.e. whether ClaimForeground has been called for key and
+// its release has not yet run. This is a pure in-memory read (no blocking, no
+// I/O), safe to call from any goroutine, including a status-plane writer that
+// must never block behind an in-flight index.
+//
+// The FOREGROUND rebuild/subprocess path (cmd/grafel daemonRebuildFuncCore)
+// bypasses the scheduler entirely, so indexstate never observes it as
+// StateIndexing. HasForegroundClaim is the seam that lets the status-plane
+// writer (internal/daemon/statuswriter.go) detect that case and still report
+// Indexing=true, without threading scheduler-shaped state through a path that
+// deliberately does not use the scheduler.
+func (r *Registry) HasForegroundClaim(key string) bool {
+	key = filepath.Clean(key)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	ks := r.st[key]
+	return ks != nil && ks.fgWant > 0
+}
+
+// HasForegroundClaim is the package-level convenience form of
+// Registry.HasForegroundClaim against DefaultRegistry, mirroring the
+// package's existing DefaultRegistry.<Method> call-site style (e.g.
+// repolock.DefaultRegistry.ClaimForeground in cmd/grafel/daemon.go).
+func HasForegroundClaim(key string) bool {
+	return DefaultRegistry.HasForegroundClaim(key)
+}
+
 // TryClaimBackground attempts to acquire the key for a background scheduler
 // index. It FAILS (ok=false) without blocking when either an index is already
 // running for the key OR a foreground claim is intended/held for it (yield to

--- a/internal/repolock/repolock_test.go
+++ b/internal/repolock/repolock_test.go
@@ -82,6 +82,67 @@ func TestReleaseIsIdempotent(t *testing.T) {
 	relBg()
 }
 
+// HasForegroundClaim must report false before a claim is acquired, true while
+// it is held (including the brief pre-hold "intended" window guarded by
+// fgWant), and false again after release. This is the read-only seam the
+// status-plane writer uses to detect a foreground rebuild that the scheduler
+// itself cannot see (#5729 follow-up: foreground-indexing status-plane gap).
+func TestHasForegroundClaim(t *testing.T) {
+	r := New()
+
+	if r.HasForegroundClaim("/repo/a") {
+		t.Fatal("must be false before any claim is acquired")
+	}
+
+	rel := r.ClaimForeground("/repo/a")
+	if !r.HasForegroundClaim("/repo/a") {
+		t.Fatal("must be true while a foreground claim is held")
+	}
+	// An unrelated key is unaffected.
+	if r.HasForegroundClaim("/repo/b") {
+		t.Fatal("must be false for an unrelated key")
+	}
+
+	rel()
+	if r.HasForegroundClaim("/repo/a") {
+		t.Fatal("must be false after the claim releases")
+	}
+}
+
+// HasForegroundClaim is a pure in-memory read safe to call concurrently with
+// ClaimForeground/TryClaimBackground under -race.
+func TestHasForegroundClaimConcurrentRace(t *testing.T) {
+	r := New()
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 50; i++ {
+			rel := r.ClaimForeground("/repo/a")
+			time.Sleep(time.Millisecond)
+			rel()
+		}
+		close(stop)
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				r.HasForegroundClaim("/repo/a")
+			}
+		}
+	}()
+
+	wg.Wait()
+}
+
 // Concurrent foreground claims for the same repo are serialised (never both
 // hold at once), exercised under -race.
 func TestForegroundClaimsSerialise(t *testing.T) {


### PR DESCRIPTION
The per-repo status-plane `File.Indexing` flag was never true during a foreground `grafel rebuild`/subprocess index. `writeRepoStatusFile` derived `Indexing` solely from `indexstate.RepoStates()`, which only the scheduler populates — but the rebuild path deliberately bypasses the scheduler (it holds a `repolock` foreground claim and indexes directly). So the statusline widget and the wizard TUI live-progress (`emitStatusPlaneRowEvents` → `PhaseIndexing`, #5774) had no "indexing" signal on that path — the true root cause of "no live Indexing… on rebuild".

**Fix (reuse existing state):** the rebuild path already holds `repolock.ClaimForeground(repoPath)` for the exact index lifetime. Add a read-only `repolock.HasForegroundClaim(key)` and OR it into the status writer's `Indexing` computation, plus a start-of-index `FlushRepoStatusFile` so it appears immediately (not up to 5s later). Single writer (parent daemon), no race, additive; scheduler/watcher path byte-identical when no foreground claim exists.

Independently reviewed (APPROVE): verified the repolock/status-writer key match, that `ClaimForeground` has exactly ONE caller (the index — no false positives), correct end-state=false ordering, and `-race` cleanliness. 1022 `-race` + 8973 full-repo tests pass.

Refs #5774, #5729.