### PR TITLE
perf(dashboard): project LOD before allocating graph edges

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -224,7 +224,12 @@ Returns the full dependency graph for the WebUI v2 hero surface, wrapped in a
 ```
 
 Query params (mirror the v1 `/api/graph` handler): `repos=slug1,slug2`,
-`filter_kind=`, `include_external=true`, `view=modules`.
+`filter_kind=`, `include_external=true`, `view=modules`, and
+`lod=overview|normal|full` (`low|mid|high` remain accepted aliases). Capped LoD
+requests select their connected node set through compact integer adjacency and
+only then materialise response edges. The server therefore does not allocate a
+full wire-edge payload merely to discard most of it for overview or normal
+rendering.
 
 This is a NEW endpoint, not a reuse of v1 `/api/graph/{group}`. Rationale: the
 v1 tier-1 payload deliberately omits `pagerank` + `source_file` to keep its wire

--- a/internal/dashboard/v2_graph.go
+++ b/internal/dashboard/v2_graph.go
@@ -150,30 +150,8 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 		repos = filtered
 	}
 
-	resp := s.buildV2Graph(repos, grp, filterKind, includeExternal, includeModules)
-
-	// Apply LoD thinning: cap nodes by pagerank, then drop orphaned edges.
-	// total_node_count is preserved as the un-thinned count so the UI badge
-	// can read "500 / 12 000" even after thinning.
-	totalBeforeThin := resp.TotalNodeCount
 	nodeCap := lodNodeCap(lodParam)
-	if nodeCap > 0 && len(resp.Nodes) > nodeCap {
-		resp.Nodes = thinByPagerankConnected(resp.Nodes, resp.Edges, nodeCap)
-		keptIDs := make(map[string]bool, len(resp.Nodes))
-		for _, n := range resp.Nodes {
-			keptIDs[n.ID] = true
-		}
-		pruned := resp.Edges[:0]
-		for _, e := range resp.Edges {
-			if keptIDs[e.Source] && keptIDs[e.Target] {
-				pruned = append(pruned, e)
-			}
-		}
-		resp.Edges = pruned
-		// Degree must reflect the post-thin edge set, not the full payload.
-		recomputeServedDegree(resp.Nodes, resp.Edges)
-	}
-	resp.TotalNodeCount = totalBeforeThin
+	resp := s.buildV2GraphWithNodeCap(repos, grp, filterKind, includeExternal, includeModules, nodeCap)
 
 	if resp.TotalNodeCount > softNodeWarnThreshold {
 		w.Header().Set("X-Graph-Warning", "large-graph: node count exceeds 50k; consider filtering by repo or kind")
@@ -202,6 +180,14 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 // which nodes/edges exist; adds pagerank + source_file + repo/community color
 // indices that the cosmos.gl canvas needs.
 func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind string, includeExternal, includeModules bool) v2GraphResponse {
+	return s.buildV2GraphWithNodeCap(repos, grp, filterKind, includeExternal, includeModules, 0)
+}
+
+// buildV2GraphWithNodeCap applies LoD before allocating wire edges. For large
+// groups this avoids materialising millions of v2GraphEdge values that would be
+// discarded immediately. A compact integer adjacency preserves the connected
+// thinning contract at a fraction of the memory cost.
+func (s *Server) buildV2GraphWithNodeCap(repos []*DashRepo, grp *DashGroup, filterKind string, includeExternal, includeModules bool, nodeCap int) v2GraphResponse {
 	totalEntities, totalRels, totalCommunities := 0, 0, 0
 	for _, rp := range repos {
 		if rp.Doc == nil {
@@ -213,10 +199,10 @@ func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind stri
 	}
 
 	nodes := make([]v2GraphNode, 0, totalEntities)
-	edges := make([]v2GraphEdge, 0, totalRels)
 	communities := make([]v2GraphCommunity, 0, totalCommunities)
 	reposOut := make([]v2GraphRepo, 0, len(repos))
-	visible := make(map[string]bool, totalEntities)
+	visible := make(map[string]int, totalEntities)
+	visibleLocal := make(map[string]map[string]int, len(repos))
 
 	// Stable 1-based repo color index (alphabetical, matching sortedRepos order).
 	repoColorIdx := make(map[string]int, len(repos))
@@ -238,6 +224,8 @@ func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind stri
 			Language:   lang,
 			ColorIndex: repoColorIdx[rp.Slug],
 		})
+		local := make(map[string]int, len(rp.Doc.Entities))
+		visibleLocal[rp.Slug] = local
 
 		for _, c := range rp.Doc.Communities {
 			label := c.AutoName
@@ -266,10 +254,9 @@ func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind stri
 				continue
 			}
 			pid := dashPrefixedID(rp.Slug, e.ID)
-			if visible[pid] {
+			if _, exists := visible[pid]; exists {
 				continue
 			}
-			visible[pid] = true
 			pr := 0.0
 			if e.PageRank != nil {
 				pr = *e.PageRank
@@ -293,28 +280,68 @@ func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind stri
 			if e.CommunityID != nil {
 				node.CommunityID = e.CommunityID
 			}
+			idx := len(nodes)
 			nodes = append(nodes, node)
+			visible[pid] = idx
+			local[e.ID] = idx
 		}
 	}
 
-	for _, rp := range repos {
-		if rp.Doc == nil {
-			continue
+	visitEdges := func(yield func(from, to int, kind string)) {
+		for _, rp := range repos {
+			if rp.Doc == nil {
+				continue
+			}
+			local := visibleLocal[rp.Slug]
+			for _, rel := range rp.Doc.Relationships {
+				from, fromOK := local[rel.FromID]
+				to, toOK := local[rel.ToID]
+				if fromOK && toOK {
+					yield(from, to, rel.Kind)
+				}
+			}
 		}
-		for _, rel := range rp.Doc.Relationships {
-			from := dashPrefixedID(rp.Slug, rel.FromID)
-			to := dashPrefixedID(rp.Slug, rel.ToID)
-			if visible[from] && visible[to] {
-				edges = append(edges, v2GraphEdge{Source: from, Target: to, Kind: rel.Kind})
+		for _, link := range grp.Links {
+			from, fromOK := visible[link.Source]
+			to, toOK := visible[link.Target]
+			if fromOK && toOK {
+				yield(from, to, link.Kind)
 			}
 		}
 	}
-	for _, l := range grp.Links {
-		if visible[l.Source] && visible[l.Target] {
-			edges = append(edges, v2GraphEdge{Source: l.Source, Target: l.Target, Kind: l.Kind})
-		}
-	}
 
+	totalNodeCount := len(nodes)
+	var edges []v2GraphEdge
+	if nodeCap > 0 && len(nodes) > nodeCap {
+		degrees := make([]int, len(nodes))
+		visitEdges(func(from, to int, _ string) {
+			degrees[from]++
+			degrees[to]++
+		})
+		adjacency := make([][]int, len(nodes))
+		for i, degree := range degrees {
+			nodes[i].Degree = degree
+			adjacency[i] = make([]int, 0, degree)
+		}
+		visitEdges(func(from, to int, _ string) {
+			adjacency[from] = append(adjacency[from], to)
+			adjacency[to] = append(adjacency[to], from)
+		})
+		originalNodes := nodes
+		var kept []bool
+		nodes, kept = thinByPagerankConnectedIndices(nodes, adjacency, nodeCap)
+		edges = make([]v2GraphEdge, 0, nodeCap*4)
+		visitEdges(func(from, to int, kind string) {
+			if kept[from] && kept[to] {
+				edges = append(edges, v2GraphEdge{Source: originalNodes[from].ID, Target: originalNodes[to].ID, Kind: kind})
+			}
+		})
+	} else {
+		edges = make([]v2GraphEdge, 0, totalRels)
+		visitEdges(func(from, to int, kind string) {
+			edges = append(edges, v2GraphEdge{Source: nodes[from].ID, Target: nodes[to].ID, Kind: kind})
+		})
+	}
 	recomputeServedDegree(nodes, edges)
 
 	return v2GraphResponse{
@@ -322,7 +349,7 @@ func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind stri
 		Edges:          edges,
 		Communities:    communities,
 		Repos:          reposOut,
-		TotalNodeCount: len(nodes),
+		TotalNodeCount: totalNodeCount,
 	}
 }
 
@@ -499,6 +526,86 @@ func thinByPagerankConnected(nodes []v2GraphNode, edges []v2GraphEdge, cap int) 
 		}
 	}
 	return out
+}
+
+// thinByPagerankConnectedIndices is the compact-adjacency equivalent used by
+// the HTTP LoD path. kept is indexed by the original nodes slice so callers can
+// emit only surviving edges without allocating the full wire edge set first.
+func thinByPagerankConnectedIndices(nodes []v2GraphNode, adjacency [][]int, cap int) ([]v2GraphNode, []bool) {
+	kept := make([]bool, len(nodes))
+	if cap == 0 || len(nodes) <= cap {
+		for i := range kept {
+			kept[i] = true
+		}
+		return nodes, kept
+	}
+
+	ranked := make([]int, len(nodes))
+	for i := range ranked {
+		ranked[i] = i
+	}
+	sort.Slice(ranked, func(i, j int) bool {
+		left, right := nodes[ranked[i]], nodes[ranked[j]]
+		if left.PageRank != right.PageRank {
+			return left.PageRank > right.PageRank
+		}
+		return left.Degree > right.Degree
+	})
+	rankPosition := make([]int, len(nodes))
+	for pos, idx := range ranked {
+		rankPosition[idx] = pos
+	}
+	for i := 0; i < cap; i++ {
+		kept[ranked[i]] = true
+	}
+
+	connectedWithin := func(idx int) bool {
+		for _, neighbor := range adjacency[idx] {
+			if kept[neighbor] {
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i < cap; i++ {
+		idx := ranked[i]
+		if !kept[idx] || len(adjacency[idx]) == 0 || connectedWithin(idx) {
+			continue
+		}
+		best := -1
+		for _, neighbor := range adjacency[idx] {
+			if kept[neighbor] {
+				continue
+			}
+			if best == -1 || rankPosition[neighbor] < rankPosition[best] {
+				best = neighbor
+			}
+		}
+		if best == -1 {
+			continue
+		}
+		victim := -1
+		for j := cap - 1; j >= 0; j-- {
+			candidate := ranked[j]
+			if kept[candidate] && candidate != idx && candidate != best {
+				victim = candidate
+				break
+			}
+		}
+		if victim == -1 {
+			continue
+		}
+		kept[victim] = false
+		kept[best] = true
+	}
+
+	out := make([]v2GraphNode, 0, cap)
+	for _, idx := range ranked {
+		if kept[idx] {
+			out = append(out, nodes[idx])
+		}
+	}
+	return out, kept
 }
 
 // dominantLanguage returns the most frequent non-empty Language across the

--- a/internal/dashboard/v2_graph_lod_compact_test.go
+++ b/internal/dashboard/v2_graph_lod_compact_test.go
@@ -1,0 +1,105 @@
+package dashboard
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func TestBuildV2GraphWithNodeCapMatchesLegacyThinning(t *testing.T) {
+	grp := makeCompactLODFixture(120, 900)
+	server := &Server{}
+	repos := sortedRepos(grp)
+	full := server.buildV2Graph(repos, grp, "", false, false)
+	const cap = 30
+	wantNodes := thinByPagerankConnected(full.Nodes, full.Edges, cap)
+	kept := make(map[string]bool, len(wantNodes))
+	for _, node := range wantNodes {
+		kept[node.ID] = true
+	}
+	wantEdges := make([]v2GraphEdge, 0)
+	for _, edge := range full.Edges {
+		if kept[edge.Source] && kept[edge.Target] {
+			wantEdges = append(wantEdges, edge)
+		}
+	}
+	recomputeServedDegree(wantNodes, wantEdges)
+
+	got := server.buildV2GraphWithNodeCap(repos, grp, "", false, false, cap)
+	if got.TotalNodeCount != full.TotalNodeCount || len(got.Nodes) != len(wantNodes) || len(got.Edges) != len(wantEdges) {
+		t.Fatalf("compact LoD counts = total:%d nodes:%d edges:%d, want %d/%d/%d",
+			got.TotalNodeCount, len(got.Nodes), len(got.Edges), full.TotalNodeCount, len(wantNodes), len(wantEdges))
+	}
+	for i := range wantNodes {
+		if got.Nodes[i] != wantNodes[i] {
+			t.Fatalf("node %d differs: got %+v want %+v", i, got.Nodes[i], wantNodes[i])
+		}
+	}
+	for i := range wantEdges {
+		if got.Edges[i] != wantEdges[i] {
+			t.Fatalf("edge %d differs: got %+v want %+v", i, got.Edges[i], wantEdges[i])
+		}
+	}
+}
+
+var benchmarkV2Response v2GraphResponse
+
+func BenchmarkBuildV2GraphLOD20K300K(b *testing.B) {
+	grp := makeCompactLODFixture(20_000, 300_000)
+	server := &Server{}
+	repos := sortedRepos(grp)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		benchmarkV2Response = server.buildV2GraphWithNodeCap(repos, grp, "", false, false, 3_000)
+	}
+}
+
+func BenchmarkBuildV2GraphLegacy20K300K(b *testing.B) {
+	grp := makeCompactLODFixture(20_000, 300_000)
+	server := &Server{}
+	repos := sortedRepos(grp)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		resp := server.buildV2Graph(repos, grp, "", false, false)
+		resp.Nodes = thinByPagerankConnected(resp.Nodes, resp.Edges, 3_000)
+		kept := make(map[string]bool, len(resp.Nodes))
+		for _, node := range resp.Nodes {
+			kept[node.ID] = true
+		}
+		edges := resp.Edges[:0]
+		for _, edge := range resp.Edges {
+			if kept[edge.Source] && kept[edge.Target] {
+				edges = append(edges, edge)
+			}
+		}
+		resp.Edges = edges
+		recomputeServedDegree(resp.Nodes, resp.Edges)
+		benchmarkV2Response = resp
+	}
+}
+
+func makeCompactLODFixture(entityCount, relationshipCount int) *DashGroup {
+	entities := make([]graph.Entity, entityCount)
+	for i := range entities {
+		rank := float64(entityCount - i)
+		entities[i] = graph.Entity{ID: fmt.Sprintf("entity-%05d", i), Name: fmt.Sprintf("Entity %d", i), Kind: "function", PageRank: &rank}
+	}
+	relationships := make([]graph.Relationship, relationshipCount)
+	for i := range relationships {
+		from := i % entityCount
+		to := (i*17 + 1) % entityCount
+		if from == to {
+			to = (to + 1) % entityCount
+		}
+		relationships[i] = graph.Relationship{FromID: entities[from].ID, ToID: entities[to].ID, Kind: "CALLS"}
+	}
+	return &DashGroup{
+		Name: "lod-benchmark",
+		Repos: map[string]*DashRepo{
+			"repo": {Slug: "repo", Doc: &graph.Document{Entities: entities, Relationships: relationships}},
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- project capped LOD through compact integer adjacency before allocating response edges
- preserve connected PageRank thinning and full/unlimited behavior
- add parity coverage and allocation benchmarks
- document the v2 graph LOD allocation behavior

## Closes / Refs

Closes #5778

## Testing

- [ ] All tests pass: `go test ./...` (deferred to `ci:full`; the local full suite is unsafe on this Windows checkout because an unrelated restart test recursively spawns test processes)
- [x] Targeted dashboard LOD tests pass
- [x] LOD parity test passes
- [x] Targeted race test passes
- [x] `go build ./cmd/grafel` passes
- [x] `git diff --check` passes

### Benchmark

Windows amd64, AMD Ryzen 7 8845HS; 20,000 nodes / 300,000 relationships, cap 3,000:

| path | bytes/op | allocs/op |
|---|---:|---:|
| legacy full-edge materialization | ~44,919,000 | ~140,363 |
| compact LOD projection | 13,964,856 | 40,154 |

This reduces bytes/op by about 69% and allocations/op by about 71%.

## Notes

The unlimited/full path remains unchanged. Capped output is verified against the legacy connected-thinning result. Please apply the `ci:full` label so the complete three-platform suite runs.