### PR TITLE
fix(install): verify daemon restarts onto the new version; escalate on stale

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -131,12 +131,57 @@ update_path_fish() {
   } >> "$rc_file"
 }
 
+# wait_for_daemon_version polls the JUST-INSTALLED binary's `grafel status`
+# output until the RUNNING daemon reports $1 (the just-installed version,
+# without the leading 'v') or ~10s elapse. `grafel status` dials the daemon's
+# RPC socket directly — the same reliable, non-HTTP channel `grafel install`'s
+# Go-side version probe uses (internal/install/copy.go's
+# defaultDaemonVersionProbe) — rather than any dashboard HTTP route. The
+# dashboard has no dedicated /healthz-style version endpoint: an unmatched GET
+# falls through to the SPA catch-all and returns an HTML document instead of a
+# version string (#5596), so an HTTP-based check here would risk the exact
+# HTML-shadowing hazard this fix is guarding against. Echoes the LAST version
+# observed (possibly empty/stale) on stdout; returns non-zero if it never
+# matched $1 within budget.
+wait_for_daemon_version() {
+  want=$1
+  seen=""
+  i=0
+  while [ "$i" -lt 20 ]; do
+    seen=$("$BIN_DIR/grafel" status 2>/dev/null | awk '/^  version:/ {print $2; exit}')
+    if [ -n "$seen" ] && [ "$seen" = "$want" ]; then
+      echo "$seen"
+      return 0
+    fi
+    i=$((i + 1))
+    sleep 0.5
+  done
+  echo "$seen"
+  return 1
+}
+
 # restart_daemon restarts an already-registered grafel daemon so it runs the
-# freshly-installed binary. It is best-effort: a missing tool or a failed
-# restart prints a hint and returns non-zero, but never aborts the installer.
-# Echoes "restarted" on stdout when a registered daemon was restarted.
+# freshly-installed binary, then VERIFIES the running daemon actually reports
+# the newly-installed version before declaring success (#5850: a stale
+# daemon that stayed bound to the socket through a kickstart/restart was
+# previously reported as a successful restart just because the OS-level
+# restart command exited 0). If the first restart leaves a stale daemon
+# running, it escalates to a HARD restart — macOS: `launchctl bootout`
+# (forces the old process to fully exit; a bootout of an already-unloaded
+# label is a harmless no-op) followed by bootstrap/kickstart; Linux:
+# `systemctl --user stop` then `start` (a plain "restart" can race a unit
+# that never actually reloaded the new binary) — and re-checks.
+#
+# It is best-effort: a missing tool, a failed restart, or a daemon that is
+# STILL stale after escalation prints a warning/hint and returns non-zero,
+# but never aborts the installer (no call to the fatal err() helper).
+# Echoes "restarted" on stdout only when the running daemon was CONFIRMED to
+# report the just-installed version; echoes "stale" when a daemon is running
+# but never reached that version, so the caller can print an accurate final
+# message.
 restart_daemon() {
   os=$1
+  want_version=$2
   hint="re-run 'grafel install' or restart the daemon to finish the update"
 
   case "$os" in
@@ -144,17 +189,16 @@ restart_daemon() {
       command -v launchctl >/dev/null 2>&1 || return 1
       uid=$(id -u)
       target="gui/${uid}/com.grafel.daemon"
+      plist="$HOME/Library/LaunchAgents/com.grafel.daemon.plist"
       # Detect a registered launchd agent (print, falling back to list).
-      if launchctl print "$target" >/dev/null 2>&1 ||
-         launchctl list 2>/dev/null | grep -q "com.grafel.daemon"; then
-        if launchctl kickstart -k "$target" >/dev/null 2>&1; then
-          echo "restarted"
-          return 0
-        fi
+      if ! launchctl print "$target" >/dev/null 2>&1 &&
+         ! launchctl list 2>/dev/null | grep -q "com.grafel.daemon"; then
+        return 1
+      fi
+      if ! launchctl kickstart -k "$target" >/dev/null 2>&1; then
         info "warning: failed to restart the grafel daemon; $hint" >&2
         return 1
       fi
-      return 1
       ;;
     linux)
       command -v systemctl >/dev/null 2>&1 || return 1
@@ -162,17 +206,46 @@ restart_daemon() {
       unit=$(systemctl --user list-unit-files 2>/dev/null \
         | awk '/grafel/ {print $1; exit}')
       [ -n "$unit" ] || return 1
-      if systemctl --user restart "$unit" >/dev/null 2>&1; then
-        echo "restarted"
-        return 0
+      if ! systemctl --user restart "$unit" >/dev/null 2>&1; then
+        info "warning: failed to restart the grafel daemon; $hint" >&2
+        return 1
       fi
-      info "warning: failed to restart the grafel daemon; $hint" >&2
-      return 1
       ;;
     *)
       return 1
       ;;
   esac
+
+  # The OS-level restart command exited 0 — that only proves SOME daemon is
+  # now bound to the socket, not that it is the one we just installed.
+  # Verify, and escalate to a hard restart if it's still stale.
+  running=$(wait_for_daemon_version "$want_version") || {
+    info "note: daemon restarted but still reports version '${running:-unknown}' (want '$want_version'); forcing a hard restart" >&2
+    case "$os" in
+      macos)
+        # bootout forces the currently-loaded (possibly stale) daemon to
+        # fully exit before we reload it, unlike kickstart alone.
+        launchctl bootout "$target" >/dev/null 2>&1 || true
+        if [ -f "$plist" ]; then
+          launchctl bootstrap "gui/${uid}" "$plist" >/dev/null 2>&1 ||
+            launchctl kickstart -k "$target" >/dev/null 2>&1 || true
+        else
+          launchctl kickstart -k "$target" >/dev/null 2>&1 || true
+        fi
+        ;;
+      linux)
+        systemctl --user stop "$unit" >/dev/null 2>&1 || true
+        systemctl --user start "$unit" >/dev/null 2>&1 || true
+        ;;
+    esac
+    running=$(wait_for_daemon_version "$want_version") || {
+      info "warning: daemon still running version '${running:-unknown}' after a hard restart (want '$want_version'); $hint" >&2
+      echo "stale"
+      return 1
+    }
+  }
+  echo "restarted"
+  return 0
 }
 
 configure_path() {
@@ -252,15 +325,24 @@ main() {
   fi
 
   # If a daemon is already registered, restart it so it picks up the new
-  # binary. Best-effort: restart_daemon never aborts the installer.
-  daemon_restarted=$(restart_daemon "$os" || true)
+  # binary, and CONFIRM the running daemon actually reports the
+  # just-installed version before calling it done (#5850) — a daemon that
+  # merely answers the socket is not proof it is the new binary. Best-effort:
+  # restart_daemon never aborts the installer.
+  daemon_restarted=$(restart_daemon "$os" "$version_no_v" || true)
 
   info ""
-  if [ "$daemon_restarted" = "restarted" ]; then
-    info "grafel updated and daemon restarted."
-  else
-    info "grafel installed. Run \"grafel wizard\" to set up your first group."
-  fi
+  case "$daemon_restarted" in
+    restarted)
+      info "grafel updated and daemon restarted (confirmed running $version_no_v)."
+      ;;
+    stale)
+      info "grafel installed, but the daemon still running the old version — run 'grafel install' to finish."
+      ;;
+    *)
+      info "grafel installed. Run \"grafel wizard\" to set up your first group."
+      ;;
+  esac
   info "(restart your shell or 'source' your rc file so PATH picks up $BIN_DIR)"
 }
 

--- a/install.sh
+++ b/install.sh
@@ -131,9 +131,37 @@ update_path_fish() {
   } >> "$rc_file"
 }
 
+# normalize_version strips a single leading 'v' so a v-prefixed version
+# ("v0.1.9") compares equal to a bare one ("0.1.9"). This matters because
+# `grafel status` prints the daemon version VERBATIM, WITH the leading 'v'
+# (version.Version is baked as ${GITHUB_REF_NAME}, e.g. "v0.1.9"), whereas the
+# installer's wanted version is the bare tag ($version_no_v). Without this the
+# compare was always "v0.1.9" = "0.1.9" → false, so every correct update
+# escalated needlessly and warned "still old version" forever (#5850).
+normalize_version() {
+  printf '%s' "${1#v}"
+}
+
+# parse_status_version extracts the daemon version token from `grafel status`
+# output supplied on stdin (the "  version:" line). Echoes the raw token (with
+# whatever prefix the daemon printed) or nothing if not present.
+parse_status_version() {
+  awk '/^  version:/ {print $2; exit}'
+}
+
+# status_version_matches reports (exit 0) whether the `grafel status` output in
+# $1 names a running daemon version equivalent to the wanted version $2,
+# tolerating the leading-'v' difference between the daemon's v-prefixed print
+# and the installer's bare wanted version. Extracted as its own helper so it is
+# unit-testable without a live daemon (see installsh_restart_verify_test.go).
+status_version_matches() {
+  _seen=$(printf '%s\n' "$1" | parse_status_version)
+  [ -n "$_seen" ] && [ "$(normalize_version "$_seen")" = "$(normalize_version "$2")" ]
+}
+
 # wait_for_daemon_version polls the JUST-INSTALLED binary's `grafel status`
-# output until the RUNNING daemon reports $1 (the just-installed version,
-# without the leading 'v') or ~10s elapse. `grafel status` dials the daemon's
+# output until the RUNNING daemon reports a version equivalent to $1 (the
+# just-installed version) or ~10s elapse. `grafel status` dials the daemon's
 # RPC socket directly — the same reliable, non-HTTP channel `grafel install`'s
 # Go-side version probe uses (internal/install/copy.go's
 # defaultDaemonVersionProbe) — rather than any dashboard HTTP route. The
@@ -141,15 +169,18 @@ update_path_fish() {
 # falls through to the SPA catch-all and returns an HTML document instead of a
 # version string (#5596), so an HTTP-based check here would risk the exact
 # HTML-shadowing hazard this fix is guarding against. Echoes the LAST version
-# observed (possibly empty/stale) on stdout; returns non-zero if it never
-# matched $1 within budget.
+# observed (possibly empty/stale, normalized) on stdout; returns non-zero if it
+# never matched $1 within budget.
 wait_for_daemon_version() {
   want=$1
   seen=""
+  status=""
   i=0
   while [ "$i" -lt 20 ]; do
-    seen=$("$BIN_DIR/grafel" status 2>/dev/null | awk '/^  version:/ {print $2; exit}')
-    if [ -n "$seen" ] && [ "$seen" = "$want" ]; then
+    status=$("$BIN_DIR/grafel" status 2>/dev/null || true)
+    seen=$(printf '%s\n' "$status" | parse_status_version)
+    seen=$(normalize_version "$seen")
+    if [ -n "$seen" ] && status_version_matches "$status" "$want"; then
       echo "$seen"
       return 0
     fi
@@ -346,4 +377,9 @@ main() {
   info "(restart your shell or 'source' your rc file so PATH picks up $BIN_DIR)"
 }
 
-main "$@"
+# Only auto-run when executed directly. Sourcing with GRAFEL_INSTALL_SH_LIB=1
+# (e.g. from installsh_restart_verify_test.go) exposes the helper functions for
+# unit testing WITHOUT running the full installer.
+if [ "${GRAFEL_INSTALL_SH_LIB:-0}" != "1" ]; then
+  main "$@"
+fi

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -229,10 +229,23 @@ func verifyDaemonVersion(installed string, probe DaemonVersionProbeFunc) (string
 		return "", fmt.Errorf("could not verify running daemon version (installed %q): %w", installed, err)
 	}
 	running = strings.TrimSpace(running)
-	if installed != "" && running != installed {
+	// Defensive normalization: compare with any single leading 'v' stripped so
+	// a v-prefixed release tag ("v0.1.9") and a bare version ("0.1.9") — or the
+	// reverse — are treated as the same release. In practice the release build
+	// bakes version.Version = ${GITHUB_REF_NAME} (v-prefixed) and update.go
+	// threads the v-prefixed tag through, so they already match exactly; this
+	// just guards against either side drifting on the 'v'. We still RETURN the
+	// running string verbatim so the recorded/printed version is unmodified.
+	if installed != "" && !versionsEquivalent(running, installed) {
 		return "", fmt.Errorf("daemon is running stale version %q, installed version is %q", running, installed)
 	}
 	return running, nil
+}
+
+// versionsEquivalent reports whether two version strings name the same release,
+// tolerating a single leading 'v' on either side.
+func versionsEquivalent(a, b string) bool {
+	return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
 }
 
 // CopyOptions is the input to RunCopy. All fields have sensible defaults;

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/service"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
+	"github.com/cajasmota/grafel/internal/version"
 )
 
 // defaultInstallHealthTimeout is the wait budget for step-4 daemon readiness.
@@ -163,6 +164,77 @@ func defaultDaemonRestart(binPath string, port int, timeout time.Duration) (stri
 // the daemon could not be restarted or did not become healthy in time.
 type DaemonRestartFunc func(binPath string, healthzPort int, timeout time.Duration) (version string, err error)
 
+// DaemonVersionProbeFunc queries the CURRENTLY RUNNING daemon's version via a
+// reliable source (the RPC socket, not the HTML-shadowable dashboard route)
+// so step 4 can detect a daemon that stayed bound to the socket through a
+// restart that fast-pathed to a no-op (#5850). Injectable so tests never dial
+// a real socket.
+type DaemonVersionProbeFunc func() (version string, err error)
+
+// defaultDaemonVersionProbe is the production version-probe: dial the RPC
+// socket directly (the same liveness/version channel `grafel status` uses,
+// NOT the dashboard /healthz route, which can be shadowed by the SPA
+// catch-all and return an HTML document instead of a version — see
+// looksLikeVersion). The result is guarded by looksLikeVersion so an
+// implausible response is reported as an error ("version unknown") rather
+// than silently treated as a match.
+func defaultDaemonVersionProbe() (string, error) {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon layout: %w", err)
+	}
+	v, err := defaultSocketPing(layout.SocketPath)
+	if err != nil {
+		return "", err
+	}
+	if !looksLikeVersion(v) {
+		return "", fmt.Errorf("daemon reported an implausible version %q", v)
+	}
+	return strings.TrimSpace(v), nil
+}
+
+// defaultDaemonEscalateRestart is the production HARD-restart used when the
+// normal (idempotent) RestartDaemon path leaves a stale daemon bound to the
+// socket. Unlike service.Install — which fast-paths to a no-op when the
+// service already appears loaded and connectable — service.Restart always
+// forces unload→load (on macOS: launchctl bootout, then bootstrap/kickstart)
+// so the OLD process fully exits before a fresh one is started.
+func defaultDaemonEscalateRestart(binPath string, port int, timeout time.Duration) (string, error) {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return "", fmt.Errorf("resolve daemon layout: %w", err)
+	}
+	svcOpts := service.Options{
+		BinPath:    binPath,
+		SocketPath: layout.SocketPath,
+		LogDir:     layout.LogDir,
+	}
+	if _, err := service.Restart(svcOpts); err != nil {
+		return "", fmt.Errorf("service restart (escalation): %w", err)
+	}
+	return waitForDaemonReady(layout.SocketPath, port, installHealthTimeout(timeout), defaultSocketPing, defaultHealthzGet)
+}
+
+// verifyDaemonVersion probes the running daemon and compares it against
+// installed. It returns the confirmed version on a match, or an error naming
+// both versions (or "unknown" when the probe failed / returned an implausible
+// value) on mismatch. An empty installed value skips the comparison (treated
+// as "nothing to verify against").
+func verifyDaemonVersion(installed string, probe DaemonVersionProbeFunc) (string, error) {
+	running, err := probe()
+	if err == nil && !looksLikeVersion(running) {
+		err = fmt.Errorf("implausible version %q", running)
+	}
+	if err != nil {
+		return "", fmt.Errorf("could not verify running daemon version (installed %q): %w", installed, err)
+	}
+	running = strings.TrimSpace(running)
+	if installed != "" && running != installed {
+		return "", fmt.Errorf("daemon is running stale version %q, installed version is %q", running, installed)
+	}
+	return running, nil
+}
+
 // CopyOptions is the input to RunCopy. All fields have sensible defaults;
 // callers only need to set overrides.
 type CopyOptions struct {
@@ -207,6 +279,26 @@ type CopyOptions struct {
 	// production implementation (service.Install + waitForHealthz) is used.
 	// Inject a stub in tests to avoid calling launchctl/systemctl.
 	RestartDaemon DaemonRestartFunc
+
+	// ProbeDaemonVersion is the injectable post-restart version probe used to
+	// detect a stale daemon left bound to the socket (#5850). When nil, the
+	// production implementation dials the RPC socket directly. Inject a stub
+	// in tests to avoid a real socket dial.
+	ProbeDaemonVersion DaemonVersionProbeFunc
+
+	// EscalateDaemonRestart is the injectable HARD-restart function used when
+	// ProbeDaemonVersion disagrees with InstalledVersion after the normal
+	// restart. When nil, the production implementation forces the OS service
+	// through unload→load (service.Restart) rather than the idempotent
+	// service.Install used by RestartDaemon. Inject a stub in tests to avoid
+	// calling launchctl/systemctl.
+	EscalateDaemonRestart DaemonRestartFunc
+
+	// InstalledVersion is the version the running daemon is expected to
+	// report after step 4. Defaults to version.Version (the build this
+	// install/update process itself was compiled from). Tests can override it
+	// to simulate a specific target version.
+	InstalledVersion string
 
 	// NoHooks skips automatic git hook installation (step 7).
 	// Equivalent to passing --no-hooks on the CLI.
@@ -432,10 +524,40 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 		if restartFn == nil {
 			restartFn = defaultDaemonRestart
 		}
-		daemonVersion, err := restartFn(opts.BinPath, opts.DaemonPort, opts.HealthzTimeout)
-		if err != nil {
+		probeFn := opts.ProbeDaemonVersion
+		if probeFn == nil {
+			probeFn = defaultDaemonVersionProbe
+		}
+		escalateFn := opts.EscalateDaemonRestart
+		if escalateFn == nil {
+			escalateFn = defaultDaemonEscalateRestart
+		}
+
+		if _, err := restartFn(opts.BinPath, opts.DaemonPort, opts.HealthzTimeout); err != nil {
 			rollback(4)
 			return nil, fmt.Errorf("step 4 – daemon restart: %w", err)
+		}
+
+		// #5850: a restart succeeding (the RPC socket answers) does NOT prove
+		// the daemon answering is the newly-installed binary — service.Install
+		// is idempotent and fast-paths to a no-op if a daemon (any daemon) is
+		// already bound to the socket. Verify the running version explicitly;
+		// on mismatch (or an unverifiable/HTML-shadowed response), escalate to
+		// a hard restart that forces the OLD process to fully exit, then
+		// re-verify before declaring step 4 successful.
+		daemonVersion, verr := verifyDaemonVersion(opts.InstalledVersion, probeFn)
+		if verr != nil {
+			fmt.Fprintf(os.Stderr,
+				"grafel install: step 4 warning – %v; forcing a hard daemon restart\n", verr)
+			if _, eerr := escalateFn(opts.BinPath, opts.DaemonPort, opts.HealthzTimeout); eerr != nil {
+				rollback(4)
+				return nil, fmt.Errorf("step 4 – daemon restart: escalation failed: %w", eerr)
+			}
+			daemonVersion, verr = verifyDaemonVersion(opts.InstalledVersion, probeFn)
+			if verr != nil {
+				rollback(4)
+				return nil, fmt.Errorf("step 4 – daemon restart: %w", verr)
+			}
 		}
 		state.DaemonVersion = daemonVersion
 		result.DaemonVersion = daemonVersion
@@ -528,6 +650,9 @@ func (o *CopyOptions) applyDefaults() error {
 	}
 	if o.DaemonPort == 0 {
 		o.DaemonPort = 47274
+	}
+	if o.InstalledVersion == "" {
+		o.InstalledVersion = version.Version
 	}
 	return nil
 }

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -479,6 +480,11 @@ func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 			restartCalled = true
 			return "test-daemon-v0", nil
 		},
+		// Step 4 now re-verifies the running daemon's version against the
+		// installed version (#5850); stub both so this test keeps exercising
+		// only the skills-fallback behavior it was written for.
+		ProbeDaemonVersion: func() (string, error) { return "test-daemon-v0", nil },
+		InstalledVersion:   "test-daemon-v0",
 	}
 
 	result, err := install.RunCopy(opts)
@@ -521,6 +527,215 @@ func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 		if _, serr := os.Stat(filepath.Join(skillsDest, name, "SKILL.md")); serr != nil {
 			t.Errorf("embedded skill %s/SKILL.md missing after install: %v", name, serr)
 		}
+	}
+}
+
+// ── step 4: post-restart version verification (#5850) ──────────────────────
+//
+// `grafel install`/`update` previously restarted the daemon and gated success
+// only on the RPC socket answering Ping — never on whether the daemon that
+// answered was actually the NEWLY-installed version. A stale daemon that
+// stayed bound to the socket (e.g. because service.Install fast-pathed to a
+// no-op since it was already "connectable") was reported as a successful
+// restart. These tests exercise the fix: after RestartDaemon, RunCopy probes
+// the running daemon's version and compares it to InstalledVersion; on
+// mismatch it escalates to a hard restart (EscalateDaemonRestart) and
+// re-verifies before declaring success.
+
+// TestRunCopy_DaemonVersionMatch_NoEscalation verifies that when the
+// post-restart probe already reports the installed version, step 4 succeeds
+// without ever calling the escalation path.
+func TestRunCopy_DaemonVersionMatch_NoEscalation(t *testing.T) {
+	env := newTestEnv(t)
+
+	escalateCalled := false
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		InstalledVersion:  "1.2.3",
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "1.2.3", nil
+		},
+		ProbeDaemonVersion: func() (string, error) {
+			return "1.2.3", nil
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			escalateCalled = true
+			return "1.2.3", nil
+		},
+	}
+
+	result, err := install.RunCopy(opts)
+	if err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+	if result.DaemonVersion != "1.2.3" {
+		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "1.2.3")
+	}
+	if escalateCalled {
+		t.Error("escalation must NOT run when the post-restart probe already matches the installed version")
+	}
+}
+
+// TestRunCopy_DaemonVersionMismatch_EscalatesThenSucceeds is the core repro
+// for #5850: the post-restart probe first reports a STALE version (the old
+// daemon stayed bound to the socket through an idempotent restart). RunCopy
+// must escalate to a hard restart and, once the re-probe reports the
+// installed version, succeed.
+func TestRunCopy_DaemonVersionMismatch_EscalatesThenSucceeds(t *testing.T) {
+	env := newTestEnv(t)
+
+	probeCalls := 0
+	escalateCalled := false
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		InstalledVersion:  "2.0.0",
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			// The (idempotent) restart succeeds but the daemon answering is
+			// still the stale one — RestartDaemon has no way to know that on
+			// its own, which is exactly the #5850 gap.
+			return "0.9.0", nil
+		},
+		ProbeDaemonVersion: func() (string, error) {
+			probeCalls++
+			if probeCalls == 1 {
+				return "0.9.0", nil // stale daemon still on the socket
+			}
+			return "2.0.0", nil // post-escalation: fresh daemon
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			escalateCalled = true
+			return "2.0.0", nil
+		},
+	}
+
+	result, err := install.RunCopy(opts)
+	if err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+	if !escalateCalled {
+		t.Error("expected escalation to run when the initial probe reports a stale version")
+	}
+	if probeCalls < 2 {
+		t.Errorf("expected the probe to be called again after escalation, got %d calls", probeCalls)
+	}
+	if result.DaemonVersion != "2.0.0" {
+		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "2.0.0")
+	}
+}
+
+// TestRunCopy_DaemonStillStaleAfterEscalation_ReturnsError verifies that when
+// the daemon is STILL reporting a stale version even after the hard-restart
+// escalation, RunCopy fails with a clear error naming both the running and
+// the installed version (rather than reporting a misleading success).
+func TestRunCopy_DaemonStillStaleAfterEscalation_ReturnsError(t *testing.T) {
+	env := newTestEnv(t)
+
+	escalateCalled := false
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		InstalledVersion:  "3.5.0",
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "3.4.0", nil
+		},
+		ProbeDaemonVersion: func() (string, error) {
+			// Always reports the stale version, even after escalation.
+			return "3.4.0", nil
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			escalateCalled = true
+			return "3.4.0", nil
+		},
+	}
+
+	_, err := install.RunCopy(opts)
+	if err == nil {
+		t.Fatal("expected RunCopy to fail when the daemon is still stale after escalation")
+	}
+	if !escalateCalled {
+		t.Error("expected escalation to have been attempted before failing")
+	}
+	if !strings.Contains(err.Error(), "3.4.0") {
+		t.Errorf("expected error to name the running (stale) version 3.4.0, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "3.5.0") {
+		t.Errorf("expected error to name the installed version 3.5.0, got: %v", err)
+	}
+
+	// The install must be rolled back and recorded as partial, exactly like
+	// any other step-4 failure.
+	state := readState(t, env.statePath)
+	if state == nil {
+		t.Fatal("install.json was not written after rollback")
+	}
+	if !state.PartialInstall {
+		t.Error("install.json: partial_install should be true after a still-stale-after-escalation failure")
+	}
+}
+
+// TestRunCopy_DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation
+// guards against the dashboard SPA-shadowing bug (#5596): if the reliable
+// version-probe channel ever returns an HTML body (e.g. because someone wires
+// ProbeDaemonVersion to the dashboard route by mistake, or the RPC channel
+// degrades), looksLikeVersion must reject it as "unknown" — never treated as
+// a match — which drives the same escalation path as a real mismatch.
+func TestRunCopy_DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation(t *testing.T) {
+	env := newTestEnv(t)
+
+	// looksLikeVersion (internal_test.go / readiness_test.go) already asserts
+	// directly that this exact HTML body is rejected; here we assert the
+	// resulting BEHAVIOR — RunCopy must treat it as "unknown" and escalate.
+	const htmlBody = "<!doctype html><html><head><title>grafel</title></head><body></body></html>"
+
+	probeCalls := 0
+	escalateCalled := false
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		InstalledVersion:  "4.1.0",
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "4.1.0", nil
+		},
+		ProbeDaemonVersion: func() (string, error) {
+			probeCalls++
+			if probeCalls == 1 {
+				return htmlBody, nil // SPA-fallback garbage, must count as "unknown"
+			}
+			return "4.1.0", nil
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			escalateCalled = true
+			return "4.1.0", nil
+		},
+	}
+
+	result, err := install.RunCopy(opts)
+	if err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+	if !escalateCalled {
+		t.Error("expected an HTML/garbage version probe to be treated as unknown and trigger escalation")
+	}
+	if result.DaemonVersion != "4.1.0" {
+		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "4.1.0")
 	}
 }
 

--- a/internal/install/installsh_restart_verify_test.go
+++ b/internal/install/installsh_restart_verify_test.go
@@ -1,0 +1,185 @@
+// installsh_restart_verify_test.go asserts, structurally, that install.sh's
+// restart_daemon function actually VERIFIES the running daemon's version
+// after restarting it, and escalates to a hard restart when the running
+// daemon is still stale.
+//
+// Background (#5850): `grafel install`, `grafel update`, and this curl
+// installer all previously "restarted" the daemon by kickstarting/restarting
+// the OS service unit and declaring success on exit 0 — never confirming the
+// daemon that answered afterward was actually running the NEWLY-installed
+// binary. A daemon that stayed bound to the socket (because launchctl
+// kickstart / systemctl restart raced, or the unit didn't actually reload the
+// binary path) was silently reported as "restarted" while still serving the
+// old version.
+//
+// We cannot execute install.sh directly in CI (no real launchd/systemd, no
+// network), so — mirroring installscript_version_test.go's approach for
+// install.bat — we assert on the SHAPE of the script: the restart_daemon
+// function must (a) verify the post-restart version against the
+// just-installed binary via a reliable, non-HTML-shadowable channel, and (b)
+// fall back to a hard-restart escalation (launchctl bootout on macOS,
+// systemctl stop+start on Linux) when that verification fails.
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// installShSource locates and reads install.sh relative to this test file's
+// package directory (internal/install/../../install.sh at the repo root).
+func installShSource(t *testing.T) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve test file path")
+	}
+	// internal/install/installsh_restart_verify_test.go -> repo root is two
+	// directories up.
+	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	path := filepath.Join(repoRoot, "install.sh")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read install.sh at %s: %v", path, err)
+	}
+	return string(data)
+}
+
+// extractFunc pulls the body of a POSIX-shell `name() { ... }` function out
+// of src by matching balanced braces starting at the function's opening
+// brace. It fails the test if the function cannot be found.
+func extractFunc(t *testing.T, src, name string) string {
+	t.Helper()
+	re := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\(\)\s*\{`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		t.Fatalf("function %s() not found in install.sh", name)
+	}
+	depth := 0
+	start := loc[1] - 1 // index of the opening '{'
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start : i+1]
+			}
+		}
+	}
+	t.Fatalf("function %s() has no matching closing brace", name)
+	return ""
+}
+
+// TestInstallSh_RestartDaemon_VerifiesRunningVersion is the RED test for
+// #5850 on the shell side: restart_daemon must not declare "restarted" purely
+// because the kickstart/systemctl-restart command exited 0. It must probe the
+// just-installed binary's reported daemon version and compare it against what
+// is actually running before claiming success.
+func TestInstallSh_RestartDaemon_VerifiesRunningVersion(t *testing.T) {
+	src := installShSource(t)
+	fn := extractFunc(t, src, "restart_daemon")
+
+	// restart_daemon must call out to a version-verification step (whether
+	// inline or via a helper it invokes) before declaring success.
+	if !strings.Contains(fn, "wait_for_daemon_version") {
+		t.Error("restart_daemon must call a post-restart version-verification step (e.g. wait_for_daemon_version) before declaring success")
+	}
+
+	// The verification helper itself must run the JUST-INSTALLED binary (not
+	// rely on the dashboard HTTP route, which can be shadowed by the SPA
+	// catch-all and return HTML instead of a version — see looksLikeVersion
+	// in copy.go) to determine what the running daemon reports.
+	verifyFn := extractFunc(t, src, "wait_for_daemon_version")
+	if !strings.Contains(verifyFn, `"$BIN_DIR/grafel"`) {
+		t.Error(`wait_for_daemon_version must invoke "$BIN_DIR/grafel" (the newly-installed binary) to verify the running daemon's version`)
+	}
+
+	// It must not fetch a bare HTTP path as its version source (the
+	// HTML-shadowing hazard this task explicitly calls out).
+	if strings.Contains(verifyFn, "curl") && strings.Contains(verifyFn, "/healthz") {
+		t.Error("wait_for_daemon_version must not use the HTML-shadowable /healthz HTTP route as its version-verification channel")
+	}
+
+	// Some form of version comparison must be present: either a loop/poll
+	// construct or an explicit compare against the target version.
+	hasVersionSignal := strings.Contains(fn, "version") // covers "version:", "--version", "$want_version" etc.
+	if !hasVersionSignal {
+		t.Error("restart_daemon must reference a version check after restarting the daemon")
+	}
+}
+
+// TestInstallSh_RestartDaemon_HasHardRestartEscalation verifies the fallback
+// path: when the post-restart version check fails, restart_daemon must force
+// a HARD restart rather than silently leaving the stale daemon running.
+// - macOS: launchctl bootout (forces the OLD process to fully exit) before
+//   reloading (bootstrap or kickstart).
+// - Linux: systemctl --user stop, then start (a plain "restart" can race a
+//   unit that isn't actually reloading the new binary).
+func TestInstallSh_RestartDaemon_HasHardRestartEscalation(t *testing.T) {
+	src := installShSource(t)
+	fn := extractFunc(t, src, "restart_daemon")
+
+	if !strings.Contains(fn, "launchctl bootout") {
+		t.Error(`restart_daemon must escalate to "launchctl bootout" on macOS when the post-restart version check fails`)
+	}
+	if !strings.Contains(fn, "systemctl --user stop") {
+		t.Error(`restart_daemon must escalate to "systemctl --user stop" (then start) on Linux when the post-restart version check fails`)
+	}
+}
+
+// TestInstallSh_Main_ReportsAccurateFinalMessage verifies main() no longer
+// unconditionally prints "daemon restarted" just because restart_daemon's
+// underlying kickstart/systemctl command exited 0 — it must distinguish a
+// CONFIRMED-fresh restart from a still-stale one and warn accordingly,
+// telling the user to run `grafel install` to finish.
+func TestInstallSh_Main_ReportsAccurateFinalMessage(t *testing.T) {
+	src := installShSource(t)
+
+	if !strings.Contains(src, "still running the old version") &&
+		!strings.Contains(src, "still running an old version") {
+		t.Error(`main() must print an explicit warning (e.g. "daemon still running the old version") when post-restart verification fails, instead of always claiming success`)
+	}
+	if !strings.Contains(src, "grafel install") {
+		t.Error(`the stale-daemon warning must point the user at "grafel install" to finish`)
+	}
+}
+
+// TestInstallSh_RestartDaemon_StaysBestEffort verifies restart_daemon and its
+// escalation path never call `set -e`-fatal `exit` with a nonzero code that
+// would abort the WHOLE installer — restart_daemon returning non-zero (which
+// main() already treats as best-effort via `|| true`) is fine, but the
+// function body itself must not call the top-level `err` helper (which calls
+// `exit 1`) purely because verification failed.
+func TestInstallSh_RestartDaemon_StaysBestEffort(t *testing.T) {
+	src := installShSource(t)
+	fn := extractFunc(t, src, "restart_daemon")
+
+	// err() is install.sh's fatal helper (printf + exit 1). restart_daemon
+	// must stay best-effort and never invoke it.
+	if regexp.MustCompile(`(^|[^_a-zA-Z])err\s`).MatchString(fn) {
+		t.Error("restart_daemon must remain best-effort and never call the fatal err() helper")
+	}
+}
+
+// TestInstallSh_ShellcheckClean is a lightweight guard that requires no shell
+// interpreter: it just confirms the script still declares `set -eu` (the
+// baseline strict-mode this installer relies on) so a future edit can't
+// accidentally drop it while adding the verification/escalation logic. Full
+// shellcheck linting is run separately (`shellcheck install.sh`) as part of
+// the definition of done; this test keeps a cheap regression guard in CI
+// where shellcheck may not be installed.
+func TestInstallSh_ShellcheckClean(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("install.sh targets macOS/Linux only")
+	}
+	src := installShSource(t)
+	if !strings.Contains(src, "set -eu") {
+		t.Error("install.sh must keep `set -eu` at the top")
+	}
+}

--- a/internal/install/installsh_restart_verify_test.go
+++ b/internal/install/installsh_restart_verify_test.go
@@ -23,6 +23,7 @@ package install
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -30,9 +31,9 @@ import (
 	"testing"
 )
 
-// installShSource locates and reads install.sh relative to this test file's
-// package directory (internal/install/../../install.sh at the repo root).
-func installShSource(t *testing.T) string {
+// installShPath resolves the absolute path to install.sh at the repo root,
+// relative to this test file's location (internal/install/../../install.sh).
+func installShPath(t *testing.T) string {
 	t.Helper()
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
@@ -40,8 +41,13 @@ func installShSource(t *testing.T) string {
 	}
 	// internal/install/installsh_restart_verify_test.go -> repo root is two
 	// directories up.
-	repoRoot := filepath.Join(filepath.Dir(thisFile), "..", "..")
-	path := filepath.Join(repoRoot, "install.sh")
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "install.sh")
+}
+
+// installShSource locates and reads install.sh at the repo root.
+func installShSource(t *testing.T) string {
+	t.Helper()
+	path := installShPath(t)
 	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("read install.sh at %s: %v", path, err)
@@ -165,6 +171,65 @@ func TestInstallSh_RestartDaemon_StaysBestEffort(t *testing.T) {
 	if regexp.MustCompile(`(^|[^_a-zA-Z])err\s`).MatchString(fn) {
 		t.Error("restart_daemon must remain best-effort and never call the fatal err() helper")
 	}
+}
+
+// TestInstallSh_StatusVersionMatches_ToleratesVPrefix is the RUNTIME
+// regression guard for the HIGH #5850 shell bug: `grafel status` prints the
+// daemon version VERBATIM, WITH the leading 'v' (e.g. "  version: v0.1.8"),
+// while the installer's wanted version is the bare tag ("0.1.8"). A naive
+// string compare ("v0.1.8" = "0.1.8") is ALWAYS false, so every correct
+// curl-update escalated needlessly and warned "still old version" forever.
+// The string-contains structural tests can't catch this — this one actually
+// runs the extracted parse+compare helper against a realistic status line.
+func TestInstallSh_StatusVersionMatches_ToleratesVPrefix(t *testing.T) {
+	// A realistic multi-line `grafel status` block (see internal/cli/status.go:
+	// the daemon version is printed on a "  version:" line, v-prefixed).
+	const status = "Daemon: running  pid=42  uptime=3s  rss=50MB  in_flight=0\n" +
+		"  version: v0.1.8\n" +
+		"  socket:  /home/u/.grafel/daemon.sock\n"
+
+	// Positive: a v-prefixed running version must match the bare wanted version.
+	if code, out := runStatusVersionMatches(t, status, "0.1.8"); code != 0 {
+		t.Errorf("status_version_matches must MATCH a v-prefixed running version (v0.1.8) against bare wanted (0.1.8); got exit %d, output %q", code, out)
+	}
+
+	// Symmetry: a bare running version must also match a v-prefixed wanted.
+	const bareStatus = "  version: 0.1.8\n"
+	if code, out := runStatusVersionMatches(t, bareStatus, "v0.1.8"); code != 0 {
+		t.Errorf("status_version_matches must MATCH a bare running version against v-prefixed wanted; got exit %d, output %q", code, out)
+	}
+
+	// Negative: a genuinely different version must NOT match (the check still
+	// catches a real stale daemon, so escalation isn't suppressed wrongly).
+	if code, out := runStatusVersionMatches(t, status, "0.2.0"); code == 0 {
+		t.Errorf("status_version_matches must NOT match a genuinely stale version (running v0.1.8 vs wanted 0.2.0); got exit 0, output %q", out)
+	}
+
+	// Negative: no version line at all must NOT match.
+	if code, _ := runStatusVersionMatches(t, "Daemon: not running\n", "0.1.8"); code == 0 {
+		t.Error("status_version_matches must NOT match when the status has no version line")
+	}
+}
+
+// runStatusVersionMatches sources install.sh as a library and invokes
+// status_version_matches with the given status text and wanted version,
+// passing them via argv to avoid any quoting/newline hazards.
+func runStatusVersionMatches(t *testing.T, status, want string) (exitCode int, output string) {
+	t.Helper()
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; skipping install.sh runtime test")
+	}
+	script := `set -eu; GRAFEL_INSTALL_SH_LIB=1 . "$1"; status_version_matches "$2" "$3"`
+	cmd := exec.Command(bash, "-c", script, "bash", installShPath(t), status, want)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return ee.ExitCode(), string(out)
+		}
+		t.Fatalf("running status_version_matches failed to launch: %v (output: %s)", err, out)
+	}
+	return 0, string(out)
 }
 
 // TestInstallSh_ShellcheckClean is a lightweight guard that requires no shell

--- a/internal/install/readiness_test.go
+++ b/internal/install/readiness_test.go
@@ -93,6 +93,10 @@ func TestLooksLikeVersion(t *testing.T) {
 		{strings.Repeat("a", 65), false}, // too long
 		{"{\"version\":\"1.0\"}", true},  // short JSON is tolerated (no angle brackets / newline)
 		{"<svg>", false},                 // angle brackets
+		// #5850: exact SPA-fallback body a shadowed version-probe channel could
+		// return; must be rejected so a stale-daemon check never treats this as
+		// a version match.
+		{"<!doctype html><html><head><title>grafel</title></head><body></body></html>", false},
 	}
 	for _, c := range cases {
 		if got := looksLikeVersion(c.in); got != c.want {

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -78,6 +78,17 @@ type UpdateOptions struct {
 	// RestartDaemon is the injectable daemon restart function.
 	RestartDaemon DaemonRestartFunc
 
+	// ProbeDaemonVersion is the injectable post-restart version probe (#5850).
+	// Threaded through to the re-install so `grafel update` verifies the
+	// running daemon reports the TARGET release version. When nil, the
+	// production RPC-socket probe is used.
+	ProbeDaemonVersion DaemonVersionProbeFunc
+
+	// EscalateDaemonRestart is the injectable hard-restart used when the
+	// running daemon is still stale after the normal restart (#5850). When
+	// nil, the production service.Restart-based escalation is used.
+	EscalateDaemonRestart DaemonRestartFunc
+
 	// HTTPClient is the HTTP client to use for downloading. When nil the
 	// production client (defaultUpdateHTTPClient) is used.
 	HTTPClient *http.Client
@@ -238,6 +249,17 @@ func RunUpdate(opts UpdateOptions) (*UpdateResult, error) {
 		DryRun:            opts.DryRun,
 		SkipDaemonRestart: opts.SkipDaemonRestart,
 		RestartDaemon:     opts.RestartDaemon,
+		// #5850: the daemon we just restarted runs the DOWNLOADED release, not
+		// the in-process (old) binary that RunUpdate itself is executing as.
+		// The release build bakes version.Version = ${GITHUB_REF_NAME}, i.e.
+		// the (v-prefixed) release tag, so the restarted daemon reports exactly
+		// `tag`. We must therefore verify against `tag` — NOT let RunCopy
+		// default InstalledVersion to this running process's version.Version
+		// (the OLD binary), which would guarantee a spurious mismatch and roll
+		// every real-version update back to the old binary.
+		InstalledVersion:      tag,
+		ProbeDaemonVersion:    opts.ProbeDaemonVersion,
+		EscalateDaemonRestart: opts.EscalateDaemonRestart,
 	}
 
 	installResult, err := RunCopy(installOpts)

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -182,6 +182,87 @@ func TestRunUpdate_RollbackOnInstallFailure(t *testing.T) {
 	}
 }
 
+// TestRunUpdate_VerifiesAgainstTargetTag_NotRunningVersion is the regression
+// guard for the CRITICAL #5850 update inversion: RunUpdate replaces the binary
+// IN-PROCESS (no re-exec), so this process keeps reporting the OLD binary's
+// version.Version. The daemon it restarts, however, runs the DOWNLOADED release
+// and reports the TARGET tag. If RunUpdate lets RunCopy default
+// InstalledVersion to the running (old) version.Version, the post-restart
+// version check mismatches on EVERY real update → escalate → still mismatch →
+// error → rollback to the old binary. This test drives the update path with a
+// stubbed daemon that reports the TARGET tag and asserts success WITHOUT
+// setting InstalledVersion explicitly — proving update.go threads the tag.
+//
+// Without the fix (InstalledVersion defaulting to version.Version, e.g.
+// "0.0.0-dev" in the test binary), the probe returns the tag, the versions
+// mismatch, escalation runs, the re-probe still returns the tag, and RunUpdate
+// returns an error — so this test fails red until update.go sets
+// InstalledVersion: tag.
+func TestRunUpdate_VerifiesAgainstTargetTag_NotRunningVersion(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A "new" binary distinct from the current one so the update proceeds past
+	// the identical-SHA fast-path.
+	newContent := []byte("#!/bin/sh\necho new-release-binary")
+	newBinPath := filepath.Join(t.TempDir(), "new-grafel")
+	if err := os.WriteFile(newBinPath, newContent, 0o755); err != nil {
+		t.Fatalf("write new binary: %v", err)
+	}
+
+	const tag = "v9.9.9-tagtest" // deliberately != this test binary's version.Version
+
+	escalateCalled := false
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: false, // exercise the real step-4 version check
+		Tag:               tag,
+		DownloadBinary: func(_ *http.Client, _, _, _, destPath string) error {
+			return copyTestFile(newBinPath, destPath)
+		},
+		// The restarted daemon runs the downloaded release and reports the tag.
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return tag, nil
+		},
+		ProbeDaemonVersion: func() (string, error) {
+			return tag, nil
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			escalateCalled = true
+			return tag, nil
+		},
+		// NOTE: InstalledVersion intentionally NOT set — the fix must make
+		// update.go default it to the target tag.
+	}
+
+	result, err := install.RunUpdate(opts)
+	if err != nil {
+		t.Fatalf("RunUpdate must succeed when the daemon reports the target tag (#5850 update inversion): %v", err)
+	}
+	if escalateCalled {
+		t.Error("escalation must NOT run when the restarted daemon already reports the target tag")
+	}
+	if result.InstallResult == nil {
+		t.Fatal("InstallResult is nil after a successful update")
+	}
+	if result.InstallResult.DaemonVersion != tag {
+		t.Errorf("recorded daemon version = %q, want the target tag %q",
+			result.InstallResult.DaemonVersion, tag)
+	}
+
+	// The binary must be the new one (i.e. no rollback happened).
+	got, err := os.ReadFile(env.fakeBin)
+	if err != nil {
+		t.Fatalf("read binary after update: %v", err)
+	}
+	if string(got) != string(newContent) {
+		t.Error("binary was rolled back to the old version — the update was spuriously inverted")
+	}
+}
+
 // ── helpers ──────────────────────────────────────────────────────────────────
 
 func copyTestFile(src, dst string) error {


### PR DESCRIPTION
## What

`grafel install` / `update` / the `install.sh` curl one-liner now **verify the daemon actually restarted onto the newly-installed version**, instead of trusting that the RPC socket answered.

Previously both paths reported a successful restart as soon as the daemon's socket responded to `Ping` — never confirming the responding daemon was the *new* build. A stale daemon left bound to the socket was silently accepted, which (a) kept the dashboard on the old version and (b) let a stale daemon orchestrate new on-disk subprocesses, producing spurious failures (e.g. a `group-algo` call erroring `unknown group` that surfaced as a false "index failed" in the wizard).

Closes #5815

## Changes

**Go — `internal/install/copy.go`, `internal/install/update.go`**
- New injectable `DaemonVersionProbeFunc` + `defaultDaemonVersionProbe` (dials the RPC socket directly; guarded by `looksLikeVersion` so an HTML/SPA response never counts as a match).
- `defaultDaemonEscalateRestart` (uses `service.Restart` unload→load) for a genuine hard restart, distinct from the idempotent `service.Install`.
- `verifyDaemonVersion` compares probed vs. installed version (leading-`v` tolerant via `versionsEquivalent`) and names both versions on failure.
- `RunCopy` step 4: restart → probe → on mismatch/unknown escalate → re-probe → on still-stale, error.
- `RunUpdate` now sets `InstalledVersion: tag` (the resolved release tag) and threads the probe/escalate hooks, so the self-update path verifies against the *target* version, not the running (old, in-process) `version.Version`.

**Shell — `install.sh`**
- `restart_daemon` polls `grafel status`'s version line (RPC-backed, not the shadowable dashboard route) until it matches the target or ~10s elapse; on mismatch it escalates (`launchctl bootout`+`bootstrap` / `systemctl stop`+`start`) and re-verifies.
- Version comparison normalized for the leading `v` on both sides.
- `main` prints an explicit "still running the old version — run 'grafel install' to finish" warning instead of always claiming success, while staying best-effort (never `exit`s non-zero on this path).

## Review + tests

Independently reviewed; the review caught two false-negatives that the first cut shipped — both fixed here:
1. **`grafel update` would always fail + roll back** because `InstalledVersion` defaulted to the running (old) process version → every real version change mismatched. Fixed by verifying against the resolved target tag.
2. **`install.sh` never matched** because it stripped the leading `v` from the wanted version but `grafel status` reports it with the `v`. Fixed by normalizing both sides.

New regression tests (red→green verified):
- `TestRunUpdate_VerifiesAgainstTargetTag_NotRunningVersion`
- `TestRunCopy_DaemonVersionMatch_NoEscalation`, `..._DaemonVersionMismatch_EscalatesThenSucceeds`, `..._DaemonStillStaleAfterEscalation_ReturnsError`, `..._DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation`
- `TestInstallSh_StatusVersionMatches_ToleratesVPrefix` (+ structural install.sh assertions)

`go build ./...`, `go vet ./internal/install/...`, `go test ./internal/install/...` (356 pass), `shellcheck install.sh` all green.

## Out of scope (follow-ups)

`RunDev`'s duplicate restart path; the dashboard version-endpoint HTML-shadowing at source; Windows `install.bat`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
