### PR TITLE
style(install): gofmt new test file to fix CI gofmt check

### DIFF
--- a/internal/install/installsh_restart_verify_test.go
+++ b/internal/install/installsh_restart_verify_test.go
@@ -123,10 +123,10 @@ func TestInstallSh_RestartDaemon_VerifiesRunningVersion(t *testing.T) {
 // TestInstallSh_RestartDaemon_HasHardRestartEscalation verifies the fallback
 // path: when the post-restart version check fails, restart_daemon must force
 // a HARD restart rather than silently leaving the stale daemon running.
-// - macOS: launchctl bootout (forces the OLD process to fully exit) before
-//   reloading (bootstrap or kickstart).
-// - Linux: systemctl --user stop, then start (a plain "restart" can race a
-//   unit that isn't actually reloading the new binary).
+//   - macOS: launchctl bootout (forces the OLD process to fully exit) before
+//     reloading (bootstrap or kickstart).
+//   - Linux: systemctl --user stop, then start (a plain "restart" can race a
+//     unit that isn't actually reloading the new binary).
 func TestInstallSh_RestartDaemon_HasHardRestartEscalation(t *testing.T) {
 	src := installShSource(t)
 	fn := extractFunc(t, src, "restart_daemon")


### PR DESCRIPTION
Follow-up to #5816. The new `installsh_restart_verify_test.go` wasn't gofmt-clean, failing the CI `gofmt` step on the v0.1.8.3 tag. Whitespace-only reformat; `go build`/`go test ./internal/install/...` green. The v0.1.8.3 release binaries are unaffected (gofmt does not change compiled output).

🤖 Generated with [Claude Code](https://claude.com/claude-code)