### PR TITLE
feat(engine): Java EventBridge producer detector for event knowledge graph (GAP-015 RC5)

### DIFF
--- a/internal/engine/event_type_edges.go
+++ b/internal/engine/event_type_edges.go
@@ -152,6 +152,8 @@ func applyEventTypeEdges(args DetectorPassArgs) DetectorPassResult {
 		applyEventTypeProducerGo(src, emitEdge)
 	case "javascript", "typescript":
 		applyEventTypeProducerJSTS(src, emitEdge)
+	case "java":
+		applyEventTypeProducerJava(src, emitEdge)
 	}
 
 	// Consumer side — IaC event-source-mapping FilterCriteria (GAP-003 fold-in).

--- a/internal/engine/event_type_edges_test.go
+++ b/internal/engine/event_type_edges_test.go
@@ -624,6 +624,96 @@ export async function publishOrderPlaced(client: KinesisClient, orderId: string)
 }
 
 // ---------------------------------------------------------------------------
+// Producer — Java (GAP-015 RC5)
+// ---------------------------------------------------------------------------
+
+// TestEventType_JavaProducer_BuilderChainPutEvents covers the dominant
+// EventBridge shape: the AWS SDK v2 builder chain nests
+// `.detailType("X")` INSIDE the `.putEvents(...)` call's own argument list
+// (PutEventsRequest.builder().entries(PutEventsRequestEntry.builder()...)).
+func TestEventType_JavaProducer_BuilderChainPutEvents(t *testing.T) {
+	src := `package producer;
+
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public class OrderEventPublisher {
+    private final EventBridgeClient eventBridgeClient;
+
+    public void publishOrderPlaced(String orderId) {
+        eventBridgeClient.putEvents(PutEventsRequest.builder()
+            .entries(PutEventsRequestEntry.builder()
+                .detailType("OrderPlaced")
+                .detail("{\"orderId\":\"" + orderId + "\"}")
+                .build())
+            .build());
+    }
+}
+`
+	ents, rels := runEventTypeDetect(t, "java", "OrderEventPublisher.java", src)
+
+	id := eventTypeID("OrderPlaced")
+	requireEventTypeEntity(t, ents, id, "Java producer (builder-chain putEvents)")
+
+	fromID := "SCOPE.Function:publishOrderPlaced"
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain putEvents)")
+}
+
+// TestEventType_JavaProducer_SetterFormFunctionScope covers the v1/setter
+// form `.setDetailType("X")`, built on a SEPARATE statement from the
+// `.publish(...)` call site — mirroring the Go/JS-TS function-scope-recall
+// widening (root-cause C) for Java.
+func TestEventType_JavaProducer_SetterFormFunctionScope(t *testing.T) {
+	src := `package producer;
+
+import com.amazonaws.services.eventbridge.AmazonEventBridge;
+import com.amazonaws.services.eventbridge.model.PutEventsRequest;
+import com.amazonaws.services.eventbridge.model.PutEventsRequestEntry;
+
+public class OrderShippedPublisher {
+    private final AmazonEventBridge client;
+
+    public void publishOrderShipped(String orderId) {
+        PutEventsRequestEntry entry = new PutEventsRequestEntry();
+        entry.setDetailType("OrderShipped");
+        entry.setDetail("{\"orderId\":\"" + orderId + "\"}");
+        client.publish(new PutEventsRequest().withEntries(entry));
+    }
+}
+`
+	ents, rels := runEventTypeDetect(t, "java", "OrderShippedPublisher.java", src)
+
+	id := eventTypeID("OrderShipped")
+	requireEventTypeEntity(t, ents, id, "Java producer (setDetailType, function-scope)")
+
+	fromID := "SCOPE.Function:publishOrderShipped"
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (setDetailType, function-scope)")
+}
+
+// TestEventType_JavaProducer_Precision_NoPublishSink verifies that a
+// `.detailType("X")` builder call with NO `.putEvents(`/`.publish(` sink
+// anywhere in the enclosing method never mints an edge — the heuristic must
+// stay gated on a real publish sink, not just the presence of the
+// detailType/setDetailType binding.
+func TestEventType_JavaProducer_Precision_NoPublishSink(t *testing.T) {
+	src := `package producer;
+
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public class NotAPublisher {
+    public String describe() {
+        return PutEventsRequestEntry.builder().detailType("X").build().toString();
+    }
+}
+`
+	ents, _ := runEventTypeDetect(t, "java", "NotAPublisher.java", src)
+	requireNoEventTypeEntities(t, ents, "Java detailType with no publish sink in scope")
+}
+
+// ---------------------------------------------------------------------------
 // Consumer — Terraform aws_lambda_event_source_mapping FilterCriteria
 // ---------------------------------------------------------------------------
 

--- a/internal/engine/event_type_edges_test.go
+++ b/internal/engine/event_type_edges_test.go
@@ -698,6 +698,41 @@ public class ShipmentPublisher {
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain second entry)")
 }
 
+// TestEventType_JavaProducer_UnbalancedParenInDetailString reproduces
+// review MEDIUM-1: the EventBridge `detail` payload is arbitrary JSON /
+// free-text, so an unbalanced `(` inside a string literal in the putEvents
+// argument (here a `:(` emoticon) must NOT desync paren-depth counting and
+// swallow the argument — the detailType must still bind.
+func TestEventType_JavaProducer_UnbalancedParenInDetailString(t *testing.T) {
+	src := `package producer;
+
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public class CancelPublisher {
+    private final EventBridgeClient eventBridgeClient;
+
+    public void publishOrderCancelled(String orderId) {
+        eventBridgeClient.putEvents(PutEventsRequest.builder()
+            .entries(PutEventsRequestEntry.builder()
+                .detailType("OrderCancelled")
+                .detail("{\"msg\":\"Sorry to see you go :(\"}")
+                .build())
+            .build());
+    }
+}
+`
+	ents, rels := runEventTypeDetect(t, "java", "CancelPublisher.java", src)
+
+	id := eventTypeID("OrderCancelled")
+	requireEventTypeEntity(t, ents, id, "Java producer (unbalanced paren in detail string)")
+
+	fromID := "SCOPE.Function:publishOrderCancelled"
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (unbalanced paren in detail string)")
+}
+
 // TestEventType_JavaProducer_Precision_NoPublishSink verifies that a
 // `.detailType("X")` builder call with NO `.putEvents(` sink co-located in
 // the same call argument never mints an edge — the heuristic must stay gated

--- a/internal/engine/event_type_edges_test.go
+++ b/internal/engine/event_type_edges_test.go
@@ -661,43 +661,47 @@ public class OrderEventPublisher {
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain putEvents)")
 }
 
-// TestEventType_JavaProducer_SetterFormFunctionScope covers the v1/setter
-// form `.setDetailType("X")`, built on a SEPARATE statement from the
-// `.publish(...)` call site — mirroring the Go/JS-TS function-scope-recall
-// widening (root-cause C) for Java.
-func TestEventType_JavaProducer_SetterFormFunctionScope(t *testing.T) {
+// TestEventType_JavaProducer_BuilderChainDetailTypeSecondEntry exercises a
+// second co-located builder-chain shape with a distinct synthetic event name
+// (multi-entry putEvents), confirming the detailType inside the putEvents
+// argument binds regardless of surrounding builder verbosity.
+func TestEventType_JavaProducer_BuilderChainDetailTypeSecondEntry(t *testing.T) {
 	src := `package producer;
 
-import com.amazonaws.services.eventbridge.AmazonEventBridge;
-import com.amazonaws.services.eventbridge.model.PutEventsRequest;
-import com.amazonaws.services.eventbridge.model.PutEventsRequestEntry;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
-public class OrderShippedPublisher {
-    private final AmazonEventBridge client;
+public class ShipmentPublisher {
+    private final EventBridgeClient eventBridgeClient;
 
     public void publishOrderShipped(String orderId) {
-        PutEventsRequestEntry entry = new PutEventsRequestEntry();
-        entry.setDetailType("OrderShipped");
-        entry.setDetail("{\"orderId\":\"" + orderId + "\"}");
-        client.publish(new PutEventsRequest().withEntries(entry));
+        eventBridgeClient.putEvents(
+            PutEventsRequest.builder()
+                .entries(
+                    PutEventsRequestEntry.builder()
+                        .source("orders.service")
+                        .detailType("OrderShipped")
+                        .detail("{\"orderId\":\"" + orderId + "\"}")
+                        .build())
+                .build());
     }
 }
 `
-	ents, rels := runEventTypeDetect(t, "java", "OrderShippedPublisher.java", src)
+	ents, rels := runEventTypeDetect(t, "java", "ShipmentPublisher.java", src)
 
 	id := eventTypeID("OrderShipped")
-	requireEventTypeEntity(t, ents, id, "Java producer (setDetailType, function-scope)")
+	requireEventTypeEntity(t, ents, id, "Java producer (builder-chain second entry)")
 
 	fromID := "SCOPE.Function:publishOrderShipped"
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
-	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (setDetailType, function-scope)")
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain second entry)")
 }
 
 // TestEventType_JavaProducer_Precision_NoPublishSink verifies that a
-// `.detailType("X")` builder call with NO `.putEvents(`/`.publish(` sink
-// anywhere in the enclosing method never mints an edge — the heuristic must
-// stay gated on a real publish sink, not just the presence of the
-// detailType/setDetailType binding.
+// `.detailType("X")` builder call with NO `.putEvents(` sink co-located in
+// the same call argument never mints an edge — the heuristic must stay gated
+// on a real EventBridge putEvents sink, not just the detailType binding.
 func TestEventType_JavaProducer_Precision_NoPublishSink(t *testing.T) {
 	src := `package producer;
 
@@ -710,7 +714,87 @@ public class NotAPublisher {
 }
 `
 	ents, _ := runEventTypeDetect(t, "java", "NotAPublisher.java", src)
-	requireNoEventTypeEntities(t, ents, "Java detailType with no publish sink in scope")
+	requireNoEventTypeEntities(t, ents, "Java detailType with no putEvents sink co-located")
+}
+
+// TestEventType_JavaProducer_Precision_UnrelatedPublish reproduces review
+// finding #1: a generic `.publish()` (Reactor/RxJava operator, custom bus)
+// merely co-existing in method scope with an unrelated `.detailType("X")`
+// must NOT associate them. The v1 detector keys ONLY on EventBridge
+// `putEvents` with a co-located detailType, so this mints nothing.
+func TestEventType_JavaProducer_Precision_UnrelatedPublish(t *testing.T) {
+	src := `package producer;
+
+public class AuditHandler {
+    public void handle() {
+        String label = builder.detailType("OrderPlaced").build();
+        flux.publish();
+    }
+}
+`
+	ents, _ := runEventTypeDetect(t, "java", "AuditHandler.java", src)
+	requireNoEventTypeEntities(t, ents, "unrelated reactor .publish() + stray detailType")
+}
+
+// TestEventType_JavaProducer_Precision_SinkInComment reproduces review
+// finding #2 (comment span): a `putEvents(` inside a `//` line comment or a
+// `/* */` block comment is not a real sink and must be stripped before
+// matching.
+func TestEventType_JavaProducer_Precision_SinkInComment(t *testing.T) {
+	src := `package producer;
+
+public class Commented {
+    public void handle() {
+        // eventBridgeClient.putEvents(PutEventsRequest.builder().entries(PutEventsRequestEntry.builder().detailType("OrderPlaced").build()).build());
+        /* eventBridgeClient.putEvents(builder().detailType("OrderShipped").build()); */
+        doNothing();
+    }
+}
+`
+	ents, _ := runEventTypeDetect(t, "java", "Commented.java", src)
+	requireNoEventTypeEntities(t, ents, "putEvents inside comment span")
+}
+
+// TestEventType_JavaProducer_Precision_SinkInStringLiteral reproduces review
+// finding #2 (string span): a `putEvents(` inside a string literal (e.g. a
+// log line) is not a real sink and must be stripped before matching.
+func TestEventType_JavaProducer_Precision_SinkInStringLiteral(t *testing.T) {
+	src := `package producer;
+
+public class Logged {
+    public void handle() {
+        logger.info("calling client.putEvents(request) with detailType OrderPlaced");
+    }
+}
+`
+	ents, _ := runEventTypeDetect(t, "java", "Logged.java", src)
+	requireNoEventTypeEntities(t, ents, "putEvents inside string literal")
+}
+
+// TestEventType_JavaProducer_Precision_ClassScopeNoCaller reproduces review
+// finding #3: a co-located putEvents+detailType in a static field
+// initializer (NOT inside any indexed method) has an empty enclosing-method
+// name, so fromID would be the bare `"SCOPE.Function:"` prefix — emission
+// must be rejected when the enclosing method name is empty.
+func TestEventType_JavaProducer_Precision_ClassScopeNoCaller(t *testing.T) {
+	src := `package producer;
+
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
+
+public class StaticInit {
+    private static final Object RESULT = eventBridgeClient.putEvents(
+        PutEventsRequest.builder()
+            .entries(PutEventsRequestEntry.builder().detailType("OrderPlaced").build())
+            .build());
+}
+`
+	_, rels := runEventTypeDetect(t, "java", "StaticInit.java", src)
+	for _, r := range rels {
+		if r.FromID == "SCOPE.Function:" {
+			t.Errorf("class-scope sink: expected NO edge with empty caller prefix, got %+v", r)
+		}
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/event_type_producers.go
+++ b/internal/engine/event_type_producers.go
@@ -498,6 +498,116 @@ func applyEventTypeProducerJSTS(
 }
 
 // ---------------------------------------------------------------------------
+// Producer — Java (GAP-015 RC5)
+// ---------------------------------------------------------------------------
+
+// javaPublishSiteRe matches common Java publish call-sites keyed on the SDK
+// method idiom (NOT on any corpus class/variable name): AWS SDK EventBridge
+// `.putEvents(` and SNS/generic `.publish(`.
+//
+// v1: only the EventBridge `.putEvents` and SNS/generic `.publish` sinks are
+// modeled. Other publish idioms — Kinesis `.putRecord(s)`, SQS
+// `.sendMessage`, Kafka `.send`, SNS `.publishBatch`, reactive
+// `Mono<PublishResponse>` variants — are deliberately deferred (see the v1
+// limitations section in the PR/report).
+var javaPublishSiteRe = regexp.MustCompile(`\.(?:putEvents|publish)\s*\(`)
+
+// javaDetailTypeRe matches the event-name binding keyed on the AWS SDK
+// idiom: the v2 fluent-builder `.detailType("X")` or the v1/setter form
+// `.setDetailType("X")`. Java string literals are always double-quoted, so
+// (unlike the Go/JS-TS allowlist regex) this doesn't need to handle
+// single/backtick quoting.
+//
+// v1: STRING-LITERAL argument only. A variable-bound or constant-bound
+// detail type (`.detailType(EVENT_NAME)`, `.detailType(evt.type())`) is a
+// follow-up — resolving it needs a symbol table, out of scope for v1.
+var javaDetailTypeRe = regexp.MustCompile(`\.(?:detailType|setDetailType)\s*\(\s*"([^"\n\r]+)"\s*\)`)
+
+// findJavaDetailType scans arg (a call's argument text, or a bounded
+// enclosing-method window) for the first `.detailType(...)`/
+// `.setDetailType(...)` string-literal binding. Returns ("", false) when
+// none is found.
+func findJavaDetailType(arg string) (value string, ok bool) {
+	m := javaDetailTypeRe.FindStringSubmatch(arg)
+	if m == nil {
+		return "", false
+	}
+	return m[1], true
+}
+
+// enclosingJavaMethodBodyStart returns the offset of the nearest preceding
+// Java method header (from methods, as built by indexJavaEnclosingMethods)
+// before pos — the "start of the enclosing method body" boundary used to
+// widen the producer-recall search (mirrors enclosingGoFuncBodyStart /
+// enclosingNodeFuncBodyStart). Returns 0 when pos precedes every method
+// header (no enclosing method found — the widened window degrades to "from
+// the top of the file", same fail-open behavior the Go/JS-TS lookback
+// windows have at file start).
+func enclosingJavaMethodBodyStart(methods []jsFuncSpan, pos int) int {
+	start := 0
+	for _, sp := range methods {
+		if sp.offset > pos {
+			break
+		}
+		start = sp.offset
+	}
+	return start
+}
+
+// applyEventTypeProducerJava mirrors applyEventTypeProducerGo /
+// applyEventTypeProducerJSTS for Java: detect a publish sink
+// (`.putEvents(`/`.publish(`) and bind the event name via the AWS SDK
+// `.detailType(...)`/`.setDetailType(...)` builder/setter forms.
+//
+// Precision boundary #1 (co-location, the dominant real-world shape): the
+// EventBridge builder chain nests `.detailType("X")` INSIDE the
+// `.putEvents(...)` call's own argument list —
+// `client.putEvents(PutEventsRequest.builder().entries(PutEventsRequestEntry.
+// builder().detailType("OrderPlaced").build()).build())` — so the
+// balanced-paren argument extraction finds it directly.
+//
+// Precision boundary #2 (enclosing-method-scope recall, mirroring the
+// Go/JS-TS root-cause-C fix): the v1/setter form frequently builds the entry
+// in a SEPARATE statement — `entry.setDetailType("X"); ...;
+// client.publish(new PutEventsRequest().withEntries(entry))` — so when the
+// call's own argument list has no match, widen to the rest of the enclosing
+// method's body (from the nearest preceding method header up to the call
+// site). This still requires a real publish sink in the SAME method, so a
+// bare `.detailType("X")` with no `.putEvents(`/`.publish(` call anywhere in
+// scope never mints an edge.
+func applyEventTypeProducerJava(
+	src string,
+	emitEdge func(fromID, verbatim, kind string, props map[string]string),
+) {
+	methods := indexJavaEnclosingMethods(src)
+	for _, m := range javaPublishSiteRe.FindAllStringIndex(src, -1) {
+		openParen := m[1] - 1 // regex ends in `\(`, so m[1]-1 is the '(' index.
+		arg := extractBalancedParensEngine(src, openParen)
+		value, ok := findJavaDetailType(arg)
+		detection := "publish-site-literal"
+		if !ok {
+			// v1: recall widens only to the enclosing method's body (same
+			// method as the sink). Cross-method / cross-file detail-type
+			// binding (entry built in a helper, published elsewhere) is a
+			// deferred follow-up — it would need call-graph resolution.
+			bodyStart := enclosingJavaMethodBodyStart(methods, m[0])
+			value, ok = findJavaDetailType(src[bodyStart:m[0]])
+			detection = "function-scope-struct-field"
+		}
+		if !ok {
+			continue
+		}
+		caller := enclosingJavaMethodAt(methods, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			value,
+			"PUBLISHES_TO",
+			map[string]string{"lang": "java", "key": "detailType", "detection": detection},
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Consumer — event-source-mapping FilterCriteria (GAP-003 fold-in)
 // ---------------------------------------------------------------------------
 

--- a/internal/engine/event_type_producers.go
+++ b/internal/engine/event_type_producers.go
@@ -528,12 +528,44 @@ var javaDetailTypeRe = regexp.MustCompile(`\.(?:detailType|setDetailType)\s*\(\s
 // findJavaDetailType scans arg (the balanced-paren argument text of a
 // putEvents call) for the first `.detailType(...)`/`.setDetailType(...)`
 // string-literal binding. Returns ("", false) when none is found.
+//
+// LOW-1 (v1): a single putEvents carrying two entries with distinct
+// detailType("A")/detailType("B") captures ONLY the first — findJavaDetailType
+// returns the first regex match. Multi-detailType fan-out per putEvents is a
+// follow-up.
 func findJavaDetailType(arg string) (value string, ok bool) {
 	m := javaDetailTypeRe.FindStringSubmatch(arg)
 	if m == nil {
 		return "", false
 	}
 	return m[1], true
+}
+
+// balancedParenArgBounds returns the [openParen+1, close) byte range of the
+// first balanced `(`…`)` starting at openParen (which must point at the `(`).
+// Returns ok=false when the parens never balance before EOF.
+//
+// Unlike extractBalancedParensEngine, this takes the depth count over a
+// caller-supplied (comment/string-MASKED) copy so that an unbalanced `(`
+// inside a string literal in the putEvents argument — e.g. a `:(` emoticon or
+// a URL in the free-text EventBridge `detail` JSON — does not desync the depth
+// counter and swallow the whole file (MEDIUM-1). The caller slices the value
+// from the ORIGINAL source using the returned offsets (offsets are identical
+// because the mask preserves length).
+func balancedParenArgBounds(masked string, openParen int) (start, end int, ok bool) {
+	depth := 0
+	for i := openParen; i < len(masked); i++ {
+		switch masked[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return openParen + 1, i, true
+			}
+		}
+	}
+	return 0, 0, false
 }
 
 // maskJavaCommentsAndStrings returns a copy of src with every `//` line
@@ -645,11 +677,16 @@ func applyEventTypeProducerJava(
 	masked := maskJavaCommentsAndStrings(src)
 	for _, m := range javaPutEventsSiteRe.FindAllStringIndex(masked, -1) {
 		openParen := m[1] - 1 // regex ends in `\(`, so m[1]-1 is the '(' index.
-		// Extract the argument from the ORIGINAL source (offsets are
-		// mask-preserved) so the detailType string literal — masked in the
-		// copy — is visible here.
-		arg := extractBalancedParensEngine(src, openParen)
-		value, ok := findJavaDetailType(arg)
+		// Balance the parens over the MASKED copy so an unbalanced `(` inside
+		// a string literal in the argument (e.g. a `:(` emoticon in the
+		// EventBridge `detail` JSON) can't swallow the file (MEDIUM-1); then
+		// slice the detailType value from the ORIGINAL source at the same
+		// offsets (mask preserves length) so the masked-out literal is visible.
+		start, end, ok := balancedParenArgBounds(masked, openParen)
+		if !ok {
+			continue
+		}
+		value, ok := findJavaDetailType(src[start:end])
 		if !ok {
 			continue
 		}
@@ -659,6 +696,12 @@ func applyEventTypeProducerJava(
 			// fromID would be the bare `SCOPE.Function:` prefix, which
 			// emitEdge's fromID=="" guard does not catch. Reject (review
 			// finding #3).
+			//
+			// LOW-2 (v1): a static-field-initializer putEvents placed AFTER a
+			// method attributes to that nearest-preceding method (shared
+			// enclosingJavaMethodAt limitation) rather than being rejected;
+			// only a putEvents with NO preceding method in the file is caught
+			// here. Precise class-vs-method scoping is a follow-up.
 			continue
 		}
 		emitEdge(

--- a/internal/engine/event_type_producers.go
+++ b/internal/engine/event_type_producers.go
@@ -501,16 +501,18 @@ func applyEventTypeProducerJSTS(
 // Producer — Java (GAP-015 RC5)
 // ---------------------------------------------------------------------------
 
-// javaPublishSiteRe matches common Java publish call-sites keyed on the SDK
-// method idiom (NOT on any corpus class/variable name): AWS SDK EventBridge
-// `.putEvents(` and SNS/generic `.publish(`.
+// javaPutEventsSiteRe matches the EventBridge publish sink keyed on the AWS
+// SDK method idiom (NOT on any corpus class/variable name): `.putEvents(`.
 //
-// v1: only the EventBridge `.putEvents` and SNS/generic `.publish` sinks are
-// modeled. Other publish idioms — Kinesis `.putRecord(s)`, SQS
-// `.sendMessage`, Kafka `.send`, SNS `.publishBatch`, reactive
-// `Mono<PublishResponse>` variants — are deliberately deferred (see the v1
-// limitations section in the PR/report).
-var javaPublishSiteRe = regexp.MustCompile(`\.(?:putEvents|publish)\s*\(`)
+// v1 deliberately keys ONLY on EventBridge `putEvents`. The generic
+// `.publish(` sink was DROPPED: it matches Reactor/RxJava `.publish()`
+// operators, `Optional`/stream chains, and arbitrary custom buses, and —
+// because SNS `.publish(` carries no `detailType` (it uses subject / message
+// attributes) — a detailType-gated `.publish(` only ever fired for
+// EventBridge-shaped code or false positives. SNS + other publish idioms
+// (Kinesis `.putRecord(s)`, SQS `.sendMessage`, Kafka `.send`) are deferred
+// to the follow-up (see the v1 limitations section in the report).
+var javaPutEventsSiteRe = regexp.MustCompile(`\.putEvents\s*\(`)
 
 // javaDetailTypeRe matches the event-name binding keyed on the AWS SDK
 // idiom: the v2 fluent-builder `.detailType("X")` or the v1/setter form
@@ -523,10 +525,9 @@ var javaPublishSiteRe = regexp.MustCompile(`\.(?:putEvents|publish)\s*\(`)
 // follow-up — resolving it needs a symbol table, out of scope for v1.
 var javaDetailTypeRe = regexp.MustCompile(`\.(?:detailType|setDetailType)\s*\(\s*"([^"\n\r]+)"\s*\)`)
 
-// findJavaDetailType scans arg (a call's argument text, or a bounded
-// enclosing-method window) for the first `.detailType(...)`/
-// `.setDetailType(...)` string-literal binding. Returns ("", false) when
-// none is found.
+// findJavaDetailType scans arg (the balanced-paren argument text of a
+// putEvents call) for the first `.detailType(...)`/`.setDetailType(...)`
+// string-literal binding. Returns ("", false) when none is found.
 func findJavaDetailType(arg string) (value string, ok bool) {
 	m := javaDetailTypeRe.FindStringSubmatch(arg)
 	if m == nil {
@@ -535,74 +536,136 @@ func findJavaDetailType(arg string) (value string, ok bool) {
 	return m[1], true
 }
 
-// enclosingJavaMethodBodyStart returns the offset of the nearest preceding
-// Java method header (from methods, as built by indexJavaEnclosingMethods)
-// before pos — the "start of the enclosing method body" boundary used to
-// widen the producer-recall search (mirrors enclosingGoFuncBodyStart /
-// enclosingNodeFuncBodyStart). Returns 0 when pos precedes every method
-// header (no enclosing method found — the widened window degrades to "from
-// the top of the file", same fail-open behavior the Go/JS-TS lookback
-// windows have at file start).
-func enclosingJavaMethodBodyStart(methods []jsFuncSpan, pos int) int {
-	start := 0
-	for _, sp := range methods {
-		if sp.offset > pos {
-			break
+// maskJavaCommentsAndStrings returns a copy of src with every `//` line
+// comment, `/* */` block comment, and `"..."` string-literal SPAN replaced by
+// spaces of equal length (newlines preserved). Byte offsets are therefore
+// identical to the original, so a regex match position in the masked copy
+// maps 1:1 back to src. This is what makes a `putEvents(` inside a comment or
+// a log-line string NOT count as a real sink (review finding #2). char
+// literals (`'x'`) are stepped over so an apostrophe-in-a-string edge does
+// not desync the scanner. Java text blocks (`"""..."""`) are not specially
+// handled — v1 masks them as a sequence of ordinary string tokens, which is
+// safe (over-masking, never under-masking).
+func maskJavaCommentsAndStrings(src string) string {
+	b := []byte(src)
+	out := make([]byte, len(b))
+	copy(out, b)
+	blank := func(i int) {
+		if b[i] != '\n' && b[i] != '\r' {
+			out[i] = ' '
 		}
-		start = sp.offset
 	}
-	return start
+	const (
+		normal = iota
+		lineComment
+		blockComment
+		str
+		charLit
+	)
+	state := normal
+	for i := 0; i < len(b); i++ {
+		c := b[i]
+		switch state {
+		case normal:
+			switch {
+			case c == '/' && i+1 < len(b) && b[i+1] == '/':
+				state = lineComment
+				blank(i)
+			case c == '/' && i+1 < len(b) && b[i+1] == '*':
+				state = blockComment
+				blank(i)
+			case c == '"':
+				state = str
+				blank(i)
+			case c == '\'':
+				state = charLit
+				blank(i)
+			}
+		case lineComment:
+			blank(i)
+			if c == '\n' {
+				state = normal
+			}
+		case blockComment:
+			blank(i)
+			if c == '*' && i+1 < len(b) && b[i+1] == '/' {
+				blank(i + 1)
+				i++
+				state = normal
+			}
+		case str:
+			blank(i)
+			if c == '\\' && i+1 < len(b) {
+				blank(i + 1)
+				i++
+			} else if c == '"' {
+				state = normal
+			}
+		case charLit:
+			blank(i)
+			if c == '\\' && i+1 < len(b) {
+				blank(i + 1)
+				i++
+			} else if c == '\'' {
+				state = normal
+			}
+		}
+	}
+	return string(out)
 }
 
-// applyEventTypeProducerJava mirrors applyEventTypeProducerGo /
-// applyEventTypeProducerJSTS for Java: detect a publish sink
-// (`.putEvents(`/`.publish(`) and bind the event name via the AWS SDK
-// `.detailType(...)`/`.setDetailType(...)` builder/setter forms.
-//
-// Precision boundary #1 (co-location, the dominant real-world shape): the
-// EventBridge builder chain nests `.detailType("X")` INSIDE the
-// `.putEvents(...)` call's own argument list —
+// applyEventTypeProducerJava detects a Java EventBridge producer keyed on the
+// AWS SDK idiom: an EventBridge `.putEvents(...)` sink whose builder-chain
+// argument CO-LOCATES a `.detailType("X")`/`.setDetailType("X")` string
+// literal —
 // `client.putEvents(PutEventsRequest.builder().entries(PutEventsRequestEntry.
-// builder().detailType("OrderPlaced").build()).build())` — so the
-// balanced-paren argument extraction finds it directly.
+// builder().detailType("OrderPlaced").build()).build())`. The detailType is
+// bound to the SAME call's balanced-paren argument, so unlike a loose
+// whole-method-scope co-existence check it cannot associate an unrelated
+// `.detailType(...)` with an unrelated publish (review finding #1).
 //
-// Precision boundary #2 (enclosing-method-scope recall, mirroring the
-// Go/JS-TS root-cause-C fix): the v1/setter form frequently builds the entry
-// in a SEPARATE statement — `entry.setDetailType("X"); ...;
-// client.publish(new PutEventsRequest().withEntries(entry))` — so when the
-// call's own argument list has no match, widen to the rest of the enclosing
-// method's body (from the nearest preceding method header up to the call
-// site). This still requires a real publish sink in the SAME method, so a
-// bare `.detailType("X")` with no `.putEvents(`/`.publish(` call anywhere in
-// scope never mints an edge.
+// Sinks inside comments or string literals are excluded: putEvents positions
+// are located in a comment/string-MASKED copy of the source (review finding
+// #2), then the argument is extracted from the ORIGINAL source at the same
+// offset (offsets are preserved by the mask).
+//
+// v1 narrowing (breadth deferred to the follow-up issue):
+//   - EventBridge `putEvents` sink ONLY — generic `.publish(`, SNS, SQS,
+//     Kinesis, Kafka sinks are not modeled.
+//   - detailType must be CO-LOCATED in the putEvents call argument — the
+//     v1/setter form built in a separate statement (`entry.setDetailType(
+//     "X"); client.putEvents(req)`) and any cross-method/cross-file binding
+//     is deferred (would need call-graph / dataflow resolution).
+//   - STRING-LITERAL detailType only (variable/constant-bound deferred).
 func applyEventTypeProducerJava(
 	src string,
 	emitEdge func(fromID, verbatim, kind string, props map[string]string),
 ) {
 	methods := indexJavaEnclosingMethods(src)
-	for _, m := range javaPublishSiteRe.FindAllStringIndex(src, -1) {
+	masked := maskJavaCommentsAndStrings(src)
+	for _, m := range javaPutEventsSiteRe.FindAllStringIndex(masked, -1) {
 		openParen := m[1] - 1 // regex ends in `\(`, so m[1]-1 is the '(' index.
+		// Extract the argument from the ORIGINAL source (offsets are
+		// mask-preserved) so the detailType string literal — masked in the
+		// copy — is visible here.
 		arg := extractBalancedParensEngine(src, openParen)
 		value, ok := findJavaDetailType(arg)
-		detection := "publish-site-literal"
-		if !ok {
-			// v1: recall widens only to the enclosing method's body (same
-			// method as the sink). Cross-method / cross-file detail-type
-			// binding (entry built in a helper, published elsewhere) is a
-			// deferred follow-up — it would need call-graph resolution.
-			bodyStart := enclosingJavaMethodBodyStart(methods, m[0])
-			value, ok = findJavaDetailType(src[bodyStart:m[0]])
-			detection = "function-scope-struct-field"
-		}
 		if !ok {
 			continue
 		}
 		caller := enclosingJavaMethodAt(methods, m[0])
+		if caller == "" {
+			// No enclosing method (e.g. a static field initializer): the
+			// fromID would be the bare `SCOPE.Function:` prefix, which
+			// emitEdge's fromID=="" guard does not catch. Reject (review
+			// finding #3).
+			continue
+		}
 		emitEdge(
 			fmt.Sprintf("SCOPE.Function:%s", caller),
 			value,
 			"PUBLISHES_TO",
-			map[string]string{"lang": "java", "key": "detailType", "detection": detection},
+			map[string]string{"lang": "java", "key": "detailType", "detection": "publish-site-literal"},
 		)
 	}
 }


### PR DESCRIPTION
## What

Adds a **Java EventBridge producer detector** to the event knowledge graph, completing the producer side for Java (previously 100% dark — the producer pass only dispatched go/javascript/typescript). `SCOPE.EventType` nodes join producers→consumers through a shared verbatim event-name string; Java-published events were consumed-by-only.

Detects a Java producer when a `detailType("OrderPlaced")` / `setDetailType("OrderPlaced")` binding is **co-located inside the argument of an EventBridge `.putEvents(...)` call**, and emits a `PUBLISHES_TO` edge from the enclosing method to `event:type:<name>`.

## Precision (this is where the review focused)

- **Co-location, not presence:** the `detailType` must live inside the `putEvents` call's own balanced-paren argument. An unrelated `.publish()` (Reactor/RxJava/custom bus) or a stray `detailType` elsewhere in the method can no longer form a spurious edge.
- **Comment/string-literal safe:** a length/offset-preserving mask blanks `//`, `/* */`, string and char literals before sink matching, so a `putEvents(` inside a comment or log string is never treated as a sink.
- **Balanced-paren bounds over the masked copy:** the argument is delimited by counting parens on the masked source (then the value is sliced from the original), so an unbalanced `(` inside the free-text `detail` JSON — a `:(` emoticon, a URL — cannot desync depth counting and swallow the event.
- **No empty-caller edges:** a sink outside any indexed method is rejected rather than minting a bare `SCOPE.Function:` producer.

## Scope (v1) — full-coverage follow-up tracked separately

Generic to the AWS-SDK Java idiom (no project-specific identifiers). Documented deferrals (code comments + follow-up issue): variable/const-bound detailType, cross-method/cross-file binding, separate-statement setter form, non-EventBridge sinks (SNS/Kafka/SQS/Kinesis/JMS/Spring), multi-entry fan-out (first detailType bound), reactive/async client shapes.

## Tests

Synthetic fixtures only (`OrderPlaced`/`OrderShipped`/`OrderCancelled`). Red→green verified. Positives: builder-chain putEvents, second-entry detailType, unbalanced-paren-in-detail. Precision negatives: unrelated `.publish()`, sink-in-comment, sink-in-string-literal, class-scope (no caller), no-publish-sink.

`go build ./...` · `go vet ./internal/engine/...` · `go test ./internal/engine/...` (rebased on main, all pass) · `gofmt -l internal/engine` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
