### PR TITLE
feat(engine): event-store-write Go producer recall for event knowledge graph (GAP-015 RC1)

### DIFF
--- a/internal/engine/event_type_edges.go
+++ b/internal/engine/event_type_edges.go
@@ -150,6 +150,7 @@ func applyEventTypeEdges(args DetectorPassArgs) DetectorPassResult {
 	switch lang {
 	case "go":
 		applyEventTypeProducerGo(src, emitEdge)
+		applyEventTypeProducerGoEventStore(src, emitEdge)
 	case "javascript", "typescript":
 		applyEventTypeProducerJSTS(src, emitEdge)
 	case "java":

--- a/internal/engine/event_type_edges_test.go
+++ b/internal/engine/event_type_edges_test.go
@@ -1244,6 +1244,269 @@ func TestEventType_FanOutCap(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Producer — Go — event-store write (GAP-015 RC1)
+// ---------------------------------------------------------------------------
+
+// TestEventType_GoProducer_EventStoreConstructorArg covers the dominant
+// event-store-write producer shape: a domain event is built via a
+// `New*Event*(...)` constructor whose event-type is a POSITIONAL string
+// literal (not a `key: "value"` field), then persisted via a semantic
+// event-store write call (`store.WriteEvent(...)`), NOT a broker publish.
+func TestEventType_GoProducer_EventStoreConstructorArg(t *testing.T) {
+	src := `package producer
+
+import "context"
+
+func RecordOrderSettled(ctx context.Context, store *EventStore, id string, payload []byte) error {
+	evt := NewOrderEvent(id, "OrderSettled", payload)
+	return store.WriteEvent(ctx, evt)
+}
+`
+	ents, rels := runEventTypeDetect(t, "go", "producer_store.go", src)
+
+	id := eventTypeID("OrderSettled")
+	requireEventTypeEntity(t, ents, id, "Go event-store constructor-arg producer")
+
+	fromID := "SCOPE.Function:RecordOrderSettled"
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store constructor-arg producer")
+
+	var edgeDetection string
+	for _, r := range rels {
+		if r.FromID == fromID && r.ToID == toID {
+			edgeDetection = r.Properties["detection"]
+		}
+	}
+	if edgeDetection != "event-store-constructor-arg" {
+		t.Errorf("expected detection=event-store-constructor-arg, got %q", edgeDetection)
+	}
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_PublishEvent covers a
+// second constructor/sink verb pair: `Make*Event*(...)` + `PublishEvent(...)`.
+func TestEventType_GoProducer_EventStoreConstructorArg_PublishEvent(t *testing.T) {
+	src := `package producer
+
+import "context"
+
+func RecordOrderPlaced(ctx context.Context, p []byte) error {
+	evt := MakeBillingEvent(ctx, "OrderPlaced", p)
+	return PublishEvent(evt)
+}
+`
+	ents, rels := runEventTypeDetect(t, "go", "producer_store2.go", src)
+
+	id := eventTypeID("OrderPlaced")
+	requireEventTypeEntity(t, ents, id, "Go event-store constructor-arg producer (PublishEvent)")
+
+	fromID := "SCOPE.Function:RecordOrderPlaced"
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store constructor-arg producer (PublishEvent)")
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_NoSink_NoEdge is the
+// CRITICAL negative guard: a constructor literal with NO event-store write
+// sink anywhere in the enclosing function must mint NOTHING.
+func TestEventType_GoProducer_EventStoreConstructorArg_NoSink_NoEdge(t *testing.T) {
+	src := `package producer
+
+func BuildOrderEvent(id string) *OrderEvent {
+	evt := NewOrderEvent(id, "OrderPlaced")
+	return evt
+}
+`
+	ents, _ := runEventTypeDetect(t, "go", "producer_store3.go", src)
+	requireNoEventTypeEntities(t, ents, "Go event-store constructor literal with no write sink")
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_RawPutItem_NoEdge is the
+// CRITICAL negative guard: raw DynamoDB PutItem is NOT a semantic event-store
+// write sink — it is far too generic (any DynamoDB write matches it) — so a
+// constructor literal in scope with only a raw PutItem call must mint
+// NOTHING.
+func TestEventType_GoProducer_EventStoreConstructorArg_RawPutItem_NoEdge(t *testing.T) {
+	src := `package producer
+
+import "context"
+
+func RecordOrderPlaced(ctx context.Context, dynamo *DynamoClient, id string) error {
+	evt := NewOrderEvent(id, "OrderPlaced")
+	input := toPutItemInput(evt)
+	_, err := dynamo.PutItem(ctx, input)
+	return err
+}
+`
+	ents, _ := runEventTypeDetect(t, "go", "producer_store4.go", src)
+	requireNoEventTypeEntities(t, ents, "Go event-store constructor literal with only raw PutItem sink")
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_Formatter_NoEdge is the
+// precision guard for a `%`-format-verb/template literal in the constructor
+// argument — never a stable wire contract, so no garbage node is minted even
+// though a real write sink is present.
+func TestEventType_GoProducer_EventStoreConstructorArg_Formatter_NoEdge(t *testing.T) {
+	src := `package producer
+
+import (
+	"context"
+	"fmt"
+)
+
+func RecordOrder(ctx context.Context, store *EventStore, id string) error {
+	evt := NewOrderEvent(id, fmt.Sprintf("order-%s-placed", id))
+	return store.WriteEvent(ctx, evt)
+}
+`
+	ents, _ := runEventTypeDetect(t, "go", "producer_store5.go", src)
+	requireNoEventTypeEntities(t, ents, "Go event-store constructor with formatter-templated literal")
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_MultiLiteralDrop is the
+// CRITICAL precision guard (review surface 6a/6c): when the constructor's
+// argument list carries MORE THAN ONE string literal, the FIRST-literal
+// heuristic cannot tell the event-name argument from a source/topic/region
+// argument or a nested-wrapper literal, so the whole binding is DROPPED
+// (ambiguous → no guess). Covers `NewOrderEvent(ctx, "orders-svc",
+// "OrderSettled", ...)` (source arg first) and the nested-wrapper
+// `NewOrderEvent(id, aws.String("region-us"), "OrderPlaced")` shape.
+func TestEventType_GoProducer_EventStoreConstructorArg_MultiLiteralDrop(t *testing.T) {
+	cases := []struct {
+		name string
+		src  string
+	}{
+		{
+			name: "source-arg-before-event-name",
+			src: `package producer
+
+import "context"
+
+func RecordOrderSettled(ctx context.Context, store *EventStore, id string, payload []byte) error {
+	evt := NewOrderEvent(ctx, "orders-svc", "OrderSettled", payload)
+	return store.WriteEvent(ctx, evt)
+}
+`,
+		},
+		{
+			name: "nested-wrapper-literal",
+			src: `package producer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func RecordOrderPlaced(ctx context.Context, store *EventStore, id string) error {
+	evt := NewOrderEvent(id, aws.String("region-us"), "OrderPlaced")
+	return store.WriteEvent(ctx, evt)
+}
+`,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ents, _ := runEventTypeDetect(t, "go", "producer_multi.go", tc.src)
+			requireNoEventTypeEntities(t, ents, "Go event-store constructor with >1 string literal (ambiguous drop)")
+		})
+	}
+}
+
+// TestEventType_GoProducer_EventStoreConstructorArg_IDLiteralDrop is the
+// precision guard for the event-sourcing idiom where the event TYPE lives in
+// the constructor NAME and the first (only) string literal is an
+// aggregate/ID (`NewOrderPlacedEvent("order-123", 42)`). An ID-shaped value
+// (lowercase-kebab/snake-with-digits, UUID-ish) is rejected rather than
+// minted as a poison node.
+func TestEventType_GoProducer_EventStoreConstructorArg_IDLiteralDrop(t *testing.T) {
+	src := `package producer
+
+import "context"
+
+func RecordOrderPlaced(ctx context.Context, store *EventStore) error {
+	evt := NewOrderPlacedEvent("order-123", 42)
+	return store.WriteEvent(ctx, evt)
+}
+`
+	ents, _ := runEventTypeDetect(t, "go", "producer_idlit.go", src)
+	requireNoEventTypeEntities(t, ents, "Go event-store constructor with ID-shaped literal (rejected)")
+}
+
+// TestEventType_GoProducer_EventStore_EventuallyNotSink is the CRITICAL sink
+// precision guard (review surface 1): `*Eventually(` calls (SaveEventually,
+// StoreEventually, WriteEventually, ...) share the `Event` substring but are
+// database consistency-mode helpers, NOT semantic event-store writes. The
+// sink regex must treat `Event` as a token, not a prefix of `Eventually`, so
+// none of these fire even with a valid constructor literal in scope.
+func TestEventType_GoProducer_EventStore_EventuallyNotSink(t *testing.T) {
+	verbs := []string{
+		"SaveEventually", "StoreEventually", "WriteEventually",
+		"PublishEventually", "AppendEventually", "StoreEventuallyConsistent",
+	}
+	for _, verb := range verbs {
+		t.Run(verb, func(t *testing.T) {
+			src := `package producer
+
+import "context"
+
+func RecordOrder(ctx context.Context, db *DB, orderID string) error {
+	evt := NewOrderEvent(orderID, "OrderPlaced")
+	return db.` + verb + `(ctx, evt)
+}
+`
+			ents, _ := runEventTypeDetect(t, "go", "producer_eventually.go", src)
+			requireNoEventTypeEntities(t, ents, "Go *Eventually call must not be an event-store sink ("+verb+")")
+		})
+	}
+}
+
+// TestEventType_GoProducer_EventStore_RecordEmitTelemetryDropped documents the
+// verb-set decision: `RecordEvent`/`EmitEvent` are dropped from the sink verb
+// set because they overwhelmingly denote ANALYTICS/telemetry emission, not a
+// domain event-store write contract. Even with a valid constructor literal in
+// scope, these must not mint a producer edge.
+func TestEventType_GoProducer_EventStore_RecordEmitTelemetryDropped(t *testing.T) {
+	for _, verb := range []string{"RecordEvent", "EmitEvent"} {
+		t.Run(verb, func(t *testing.T) {
+			src := `package producer
+
+func RecordOrder(analytics *Analytics, orderID string) error {
+	evt := NewOrderEvent(orderID, "OrderPlaced")
+	return analytics.` + verb + `(evt)
+}
+`
+			ents, _ := runEventTypeDetect(t, "go", "producer_telemetry.go", src)
+			requireNoEventTypeEntities(t, ents, "Go telemetry "+verb+" must not be an event-store sink")
+		})
+	}
+}
+
+// TestEventType_GoProducer_EventStore_EventSuffixVariantsStillMatch guards
+// against over-tightening the sink regex: the legitimate `WriteEvents(` /
+// `WriteEventBatch(` variants must STILL match after the `Eventually`
+// exclusion.
+func TestEventType_GoProducer_EventStore_EventSuffixVariantsStillMatch(t *testing.T) {
+	for _, verb := range []string{"WriteEvents", "WriteEventBatch", "PublishEvents"} {
+		t.Run(verb, func(t *testing.T) {
+			src := `package producer
+
+import "context"
+
+func RecordOrder(ctx context.Context, store *EventStore, orderID string) error {
+	evt := NewOrderEvent(orderID, "OrderSettled")
+	return store.` + verb + `(ctx, evt)
+}
+`
+			ents, rels := runEventTypeDetect(t, "go", "producer_variant.go", src)
+			id := eventTypeID("OrderSettled")
+			requireEventTypeEntity(t, ents, id, "Go event-store "+verb+" variant sink")
+			fromID := "SCOPE.Function:RecordOrder"
+			toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+			requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store "+verb+" variant sink")
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // No-op guards
 // ---------------------------------------------------------------------------
 

--- a/internal/engine/event_type_producers.go
+++ b/internal/engine/event_type_producers.go
@@ -438,6 +438,185 @@ func applyEventTypeProducerGo(
 }
 
 // ---------------------------------------------------------------------------
+// Producer — Go — event-store write (GAP-015 RC1)
+// ---------------------------------------------------------------------------
+//
+// The dominant Go event-producer family does NOT publish to a broker at all.
+// Instead it builds a domain event via a constructor whose event-type is a
+// POSITIONAL string-literal argument (not a `key: "value"` field), stashes it
+// in a struct, and persists that struct via an event-store write — a
+// semantic method like WriteEvent/PublishEvent/SaveEvent/AppendEvent whose
+// backing is commonly a DynamoDB table with Streams fan-out. Neither the
+// existing goPublishSiteRe (no broker call here) nor the allowlisted
+// key/literal extraction (the event name isn't in `key: "value"` form) sees
+// this shape, so today no producer edge exists for it.
+
+// goEventStoreWriteSiteRe matches a call to a SEMANTIC event-store write
+// function — the verb+Event shape (WriteEvent/PublishEvent/SaveEvent/
+// StoreEvent/AppendEvent and any `...Event(s)...` variant sharing one of
+// those verb prefixes, e.g. WriteEventBatch, WriteEvents,
+// PublishEventToStore). Matched on the METHOD/FUNCTION NAME only (\b-anchored,
+// so it fires for both a bare package-level call `WriteEvent(...)` and a
+// method call `store.WriteEvent(...)` — the leading `.` is not required, it
+// just naturally satisfies the \b boundary when present).
+//
+// `Event` is matched as a TOKEN, not a substring prefix. Go's regexp is RE2
+// (no lookahead), so the token boundary is expressed by the RE2-compatible
+// suffix group `(?:s|[A-Z0-9_]\w*)?` that must be immediately followed by
+// `\s*\(`: what follows `Event` is either nothing (call `(`), a pluralizing
+// `s` (`WriteEvents(`), or an uppercase/digit/underscore word start
+// (`WriteEventBatch(`) — but NEVER a lowercase-letter continuation. This is
+// what stops `*Eventually(` (Event + "ually" — a database consistency-mode
+// helper, review surface 1) from matching: `SaveEventually`/`StoreEventually`/
+// `WriteEventually`/`PublishEventually`/`AppendEventually`/
+// `StoreEventuallyConsistent` all have a LOWERCASE `u` after `Event`, so the
+// suffix group cannot bridge to the trailing `(` and the match fails.
+//
+// Verb set (review): `Record`/`Emit` were DROPPED — they overwhelmingly
+// denote analytics/telemetry emission (`analytics.RecordEvent(...)`,
+// `tracer.EmitEvent(...)`), NOT a domain event-store write contract.
+// Precision-first: event-store writes are overwhelmingly
+// Write/Publish/Save/Store/Append, so dropping the two telemetry-collision
+// verbs removes a confirmed end-to-end false-positive class at negligible
+// recall cost.
+//
+// Deliberately NOT matched: raw DynamoDB `PutItem`/`PutItemWithContext`. That
+// primitive is used for every DynamoDB write in a codebase (order tables,
+// user tables, config tables, ...) with zero relationship to event
+// publishing — gating on it would treat nearly any DynamoDB write beside an
+// event constructor as a producer edge, a massive false-positive source.
+// Only the SEMANTIC verb+Event call name is trusted as a sink.
+//
+// v1 residual (name-only matching, documented): `WriteEventLog(` (audit-log
+// writer) and a mock `SaveEventCalled(` still match — they are
+// indistinguishable by NAME from a legit `WriteEventBatch(` without dataflow.
+// Accepted as low-frequency residual; see the RC1 report.
+var goEventStoreWriteSiteRe = regexp.MustCompile(
+	`\b(?:Write|Publish|Save|Store|Append)\w*Event(?:s|[A-Z0-9_]\w*)?\s*\(`,
+)
+
+// goEventStoreConstructorCallRe matches an event-constructor call — the
+// New/Make/Build+Event shape (`NewOrderEvent(`, `MakeBillingEvent(`,
+// `BuildOrderEvent(`, `NewOrderPlacedEvent(`) — on the CONSTRUCTOR FUNCTION
+// NAME only, mirroring the sink regex's syntax-only matching (no
+// corpus-specific package/function name). Uses the same RE2 `Event`-token
+// boundary as the sink regex so `NewEventually(`-style helpers are not
+// mistaken for event constructors.
+var goEventStoreConstructorCallRe = regexp.MustCompile(
+	`\b(?:New|Make|Build)\w*Event(?:s|[A-Z0-9_]\w*)?\s*\(`,
+)
+
+// goQuotedStringRe matches a double-quoted string literal in a constructor
+// call's argument-list text. Go string literals in source are conventionally
+// double-quoted (backtick raw strings for a positional event-name argument
+// are not modeled in v1, matching the scope of this detector).
+var goQuotedStringRe = regexp.MustCompile(`"([^"\n\r]+)"`)
+
+// goIDLikeValueRe matches a value that looks like an identifier/UUID token
+// rather than an event-type contract name: an all-lowercase-alnum run,
+// optionally kebab/snake-segmented (`order-123`, `a1b2`,
+// `550e8400-e29b-41d4-a716-446655440000`). Combined with a digit-presence
+// check in isGoEventTypeNameShape, this rejects the event-sourcing idiom
+// where the event TYPE is in the constructor NAME and the first literal is an
+// aggregate/ID (review surface 6b). Dot-separated names (`order.placed`) are
+// deliberately NOT matched here (dot is not a segment separator in this
+// regex), so a legit lowercase dotted event name is NOT rejected.
+var goIDLikeValueRe = regexp.MustCompile(`^[a-z0-9]+(?:[-_][a-z0-9]+)*$`)
+
+// isGoEventTypeNameShape reports whether value is plausibly an event-type
+// contract token rather than an aggregate/ID. It rejects a value that is
+// ID-shaped (goIDLikeValueRe) AND carries a digit — the lowercase-kebab/
+// snake-with-digits and UUID-ish shapes. A PascalCase/dotted name
+// (`OrderPlaced`, `order.placed`) has an uppercase letter or a dot and so is
+// NOT matched by goIDLikeValueRe, and is kept. Precision-first: a rare
+// all-lowercase-with-digit legit event name (e.g. `orderv2placed`) is a
+// documented residual recall loss, not a false positive.
+func isGoEventTypeNameShape(value string) bool {
+	if goIDLikeValueRe.MatchString(value) && strings.ContainsAny(value, "0123456789") {
+		return false
+	}
+	return true
+}
+
+// nearestGoEventConstructorLiteral scans scope (function-scope text ending
+// right before the write-sink call) for event-constructor calls and returns
+// the event-name string literal of the LEXICALLY NEAREST one — i.e. the last
+// constructor match in scope, closest to the sink.
+//
+// Ambiguity handling (precision over recall):
+//   - Multiple constructors before one sink: only the nearest is considered;
+//     attributing EVERY constructor literal in scope to the one sink would
+//     risk a wrong edge for an earlier, unrelated construction.
+//   - MULTIPLE string literals inside the nearest constructor's args (review
+//     surface 6a/6c): the first-literal heuristic cannot tell an event-name
+//     argument from a source/topic/region argument or a nested-wrapper
+//     literal (`NewOrderEvent(ctx, "orders-svc", "OrderSettled")`,
+//     `NewOrderEvent(id, aws.String("region-us"), "OrderPlaced")`), so the
+//     whole binding is DROPPED. Only a SINGLE, unambiguous string literal is
+//     trusted.
+//   - The single literal is additionally gated through isEventTypeValueUsable
+//     (formatter/`%`-template — review MUST-FIX #2 parity) and
+//     isGoEventTypeNameShape (ID/UUID shape — review surface 6b).
+func nearestGoEventConstructorLiteral(scope string) (value string, ok bool) {
+	matches := goEventStoreConstructorCallRe.FindAllStringIndex(scope, -1)
+	if len(matches) == 0 {
+		return "", false
+	}
+	nearest := matches[len(matches)-1]
+	openParen := nearest[1] - 1 // regex ends in `\(`, so len-1 is the '(' index.
+	arg := extractBalancedParensEngine(scope, openParen)
+	lits := goQuotedStringRe.FindAllStringSubmatch(arg, -1)
+	// Precision: only a SINGLE unambiguous string literal is trusted. Zero
+	// literals (event name is a var/const — not resolved in v1) or more than
+	// one literal (ambiguous positional arg) both drop.
+	if len(lits) != 1 {
+		return "", false
+	}
+	v := lits[0][1]
+	if !isEventTypeValueUsable(v) || !isGoEventTypeNameShape(v) {
+		return "", false
+	}
+	return v, true
+}
+
+// applyEventTypeProducerGoEventStore scans Go source for event-store write
+// call-sites (goEventStoreWriteSiteRe) and, for each one, looks BACKWARD
+// within the enclosing function's body for the nearest preceding
+// event-constructor call carrying a positional string-literal event name
+// (goEventStoreConstructorCallRe + nearestGoEventConstructorLiteral). Both
+// the write sink AND the constructor literal must be present in the SAME
+// enclosing-function scope — mirrors applyEventTypeProducerGo's
+// enclosing-function-scope mechanism (enclosingGoFuncBodyStart). Emits
+// nothing when either is absent, or the recovered literal fails the
+// usability guard (formatter/`%`-template).
+//
+// v1 limitation: the constructor call must textually PRECEDE the write sink
+// within the function (the realistic "build then persist" order) — a
+// constructor call built inline as an argument to the sink call itself, or
+// one that lexically follows the sink, is not matched. See RC1 report for
+// the full v1-limitations list.
+func applyEventTypeProducerGoEventStore(
+	src string,
+	emitEdge func(fromID, verbatim, kind string, props map[string]string),
+) {
+	for _, m := range goEventStoreWriteSiteRe.FindAllStringIndex(src, -1) {
+		bodyStart := enclosingGoFuncBodyStart(src, m[0])
+		funcScope := src[bodyStart:m[0]]
+		value, ok := nearestGoEventConstructorLiteral(funcScope)
+		if !ok {
+			continue
+		}
+		caller := findEnclosingGoFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			value,
+			"PUBLISHES_TO",
+			map[string]string{"lang": "go", "detection": "event-store-constructor-arg"},
+		)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Producer — JS/TS
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Adds a Go **event-store-write** producer detector so services that emit domain events by *persisting* them (rather than calling a broker/`PutEvents`) are no longer dark in the event knowledge graph. Previously these producers had no `PUBLISHES_TO` edge, leaving their events one-sided (a consumer listens, but the graph shows nothing emitting them).

## How it works

Two co-located textual signals inside the **same enclosing function** mint a `SCOPE.EventType` node + `PUBLISHES_TO` edge:

1. A **semantic write sink** — a call whose name is an event-store write verb followed by an `Event` token:
   `\b(?:Write|Publish|Save|Store|Append)\w*Event(?:s|[A-Z0-9_]\w*)?\s*\(`
   (e.g. `store.WriteEvent(...)`, `repo.SaveEvent(...)`, `log.AppendEvents(...)`).
2. A nearby **event constructor** whose positional string literal names the event type:
   `\b(?:New|Make|Build)\w*Event(?:s|[A-Z0-9_]\w*)?\s*\(` → e.g. `NewOrderEvent("OrderPlaced")`.

`detection="event-store-constructor-arg"`.

## Precision-first design (this is the point)

A wrong event-name attribution poisons the graph (un-joinable garbage node or a wrong join to a real consumer), so recall is traded for precision throughout:

- **Raw datastore writes excluded.** Generic `PutItem`/`PutItemWithContext` are *not* sinks — they're used for every write and carry no event semantics. Only the verb+`Event` call name is trusted.
- **Both signals must share one function.** Scope is the enclosing function decl → sink call; the constructor search is bounded to that slice, so a sink and constructor in different functions never join.
- **Drop on ambiguity.** If the nearest constructor's arguments contain anything other than exactly **one** quoted string literal, no edge is minted (kills source-arg-first `NewOrderEvent(ctx, "orders-svc", "OrderSettled")` and wrapped `NewOrderEvent(id, aws.String("region-us"), "OrderPlaced")`).
- **ID-shape reject.** The single literal is rejected if it looks like an identifier/UUID (`^[a-z0-9]+(?:[-_][a-z0-9]+)*$` with a digit) — so `NewOrderPlacedEvent("order-123", 42)` (event type is in the *constructor name*, first literal is an aggregate id) mints nothing. PascalCase (`OrderPlaced`), dotted (`order.placed.v2`), and lowercase-kebab-without-digit (`order-placed`) names are kept.
- **Format-template reject.** Values containing `%`-format verbs are rejected (no `order.%s.placed` garbage).
- **`Event` is token-bounded**, so telemetry-adjacent `*Eventually(` calls are not mistaken for sinks. `Record`/`Emit` are excluded from the verb set (they denote analytics emission, not an event-store write contract).

## Scope (v1)

Monorepo / same-file case, matching the existing producer detectors. Cross-file constructors, variable-bound event names, plural-then-suffix sink names (`WriteEventsBatch(`), and other backends are tracked in the full-coverage follow-up (#5820).

## Tests

Synthetic fixtures only. Positives: `WriteEvent`+`NewOrderEvent`, `PublishEvent`+`MakeBillingEvent`, plural/suffix variants. Negatives (red→green): no-sink-in-scope, raw `PutItem`, `*Eventually(` non-sink, `Record`/`Emit` telemetry dropped, multi-literal drop (source-arg-first + nested-wrapper), ID-literal drop, `%`-format reject.

Local gate green: `go build ./...`, `go vet ./internal/engine/...`, `go test ./internal/engine/... -count=1` (2684 pass), `gofmt -l internal/engine` empty. Independently adversarially reviewed (two rounds; first round reproduced FPs on realistic Go, all eliminated in the merged revision).

Refs #5820

🤖 Generated with [Claude Code](https://claude.com/claude-code)
