### PR TITLE
fix(event-identity): resolve producer-edge FromID + drop DynamoDB-Streams reserved values (RC-A, RC-B-1)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -4661,6 +4661,11 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)
 	embStats := resolve.ReferencesEmbeddedWithAllowlist(merged, idx, allow)
 	standStats := resolve.ReferencesWithAllowlist(pass2Rels, idx, allow)
+	// RC-A safety net: drop any PUBLISHES_TO edge whose producer-side FromID
+	// failed to resolve to a real entity above, rather than letting a
+	// dangling/stub source reach the final document (#5751-adjacent event-
+	// identity precision fix).
+	pass2Rels = resolve.DropUnresolvedPublishesTo(pass2Rels)
 	totalStats := resolve.Stats{
 		Rewritten:     embStats.Rewritten + standStats.Rewritten,
 		Ambiguous:     embStats.Ambiguous + standStats.Ambiguous,

--- a/internal/engine/event_type_edges.go
+++ b/internal/engine/event_type_edges.go
@@ -149,12 +149,12 @@ func applyEventTypeEdges(args DetectorPassArgs) DetectorPassResult {
 	// Producer side — Go + JS/TS only for MVP.
 	switch lang {
 	case "go":
-		applyEventTypeProducerGo(src, emitEdge)
-		applyEventTypeProducerGoEventStore(src, emitEdge)
+		applyEventTypeProducerGo(path, src, emitEdge)
+		applyEventTypeProducerGoEventStore(path, src, emitEdge)
 	case "javascript", "typescript":
-		applyEventTypeProducerJSTS(src, emitEdge)
+		applyEventTypeProducerJSTS(lang, path, src, emitEdge)
 	case "java":
-		applyEventTypeProducerJava(src, emitEdge)
+		applyEventTypeProducerJava(path, src, emitEdge)
 	}
 
 	// Consumer side — IaC event-source-mapping FilterCriteria (GAP-003 fold-in).

--- a/internal/engine/event_type_edges_test.go
+++ b/internal/engine/event_type_edges_test.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -81,7 +82,7 @@ func PublishOrderPlaced(ctx context.Context, client *kinesis.Client, orderID str
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "Go producer")
 
-	fromID := "SCOPE.Function:PublishOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer.go", "PublishOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go producer")
 }
@@ -131,7 +132,7 @@ func PublishOrderPlaced(ctx context.Context, client *kinesis.Client, orderID str
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "Go producer (function-scope struct field)")
 
-	fromID := "SCOPE.Function:PublishOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer.go", "PublishOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go producer (function-scope struct field)")
 }
@@ -195,7 +196,7 @@ func PublishOrderPlaced(ctx context.Context, client *eventbridge.Client, orderID
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "Go EventBridge PutEvents producer")
 
-	fromID := "SCOPE.Function:PublishOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer.go", "PublishOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go EventBridge PutEvents producer")
 }
@@ -230,7 +231,7 @@ func PublishOrderShipped(ctx context.Context, client *eventbridge.EventBridge, o
 	id := eventTypeID("OrderShipped")
 	requireEventTypeEntity(t, ents, id, "Go EventBridge PutEventsWithContext producer")
 
-	fromID := "SCOPE.Function:PublishOrderShipped"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_v1.go", "PublishOrderShipped")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go EventBridge PutEventsWithContext producer")
 }
@@ -265,7 +266,7 @@ func PublishOrderSettled(ctx context.Context, client *eventbridge.Client) error 
 	id := eventTypeID("OrderSettled")
 	requireEventTypeEntity(t, ents, id, "Go EventBridge aws.String wrapper producer")
 
-	fromID := "SCOPE.Function:PublishOrderSettled"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_wrapper.go", "PublishOrderSettled")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go EventBridge aws.String wrapper producer")
 }
@@ -305,7 +306,7 @@ func PublishOrderShipped(ctx context.Context, client *eventbridge.Client, orderI
 	id := eventTypeID("OrderShipped")
 	requireEventTypeEntity(t, ents, id, "Go EventBridge const-bound DetailType producer")
 
-	fromID := "SCOPE.Function:PublishOrderShipped"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_const.go", "PublishOrderShipped")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go EventBridge const-bound DetailType producer")
 
@@ -408,8 +409,9 @@ func B(ctx context.Context, detail string, client *eventbridge.Client) error {
 `
 	ents, rels := runEventTypeDetect(t, "go", "producer_crossfn.go", src)
 	requireNoEventTypeEntities(t, ents, "cross-function local must not resolve at param site")
+	bFromID := extractor.BuildOperationStructuralRef("go", "producer_crossfn.go", "B")
 	for _, r := range rels {
-		if r.FromID == "SCOPE.Function:B" {
+		if r.FromID == bFromID {
 			t.Errorf("expected no PUBLISHES_TO edge from B; got edge to %q", r.ToID)
 		}
 	}
@@ -513,8 +515,10 @@ func Outer(ctx context.Context, c *eventbridge.Client) {
 `
 	ents, rels := runEventTypeDetect(t, "go", "producer_closure.go", src)
 	requireNoEventTypeEntities(t, ents, "closure param shadows package const — must not resolve to const literal")
+	outerFromID := extractor.BuildOperationStructuralRef("go", "producer_closure.go", "Outer")
+	hFromID := extractor.BuildOperationStructuralRef("go", "producer_closure.go", "h")
 	for _, r := range rels {
-		if r.FromID == "SCOPE.Function:Outer" || r.FromID == "SCOPE.Function:h" {
+		if r.FromID == outerFromID || r.FromID == hFromID {
 			t.Errorf("expected no PUBLISHES_TO edge from closure/outer; got edge to %q", r.ToID)
 		}
 	}
@@ -583,7 +587,7 @@ func PublishOrderShipped(ctx context.Context, client *eventbridge.Client, orderI
 	id := eventTypeID("OrderShipped")
 	requireEventTypeEntity(t, ents, id, "Go EventBridge grouped-const DetailType producer")
 
-	fromID := "SCOPE.Function:PublishOrderShipped"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_grouped_const.go", "PublishOrderShipped")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go EventBridge grouped-const DetailType producer")
 
@@ -618,7 +622,7 @@ export async function publishOrderPlaced(client: KinesisClient, orderId: string)
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "JS/TS producer")
 
-	fromID := "SCOPE.Function:publishOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("typescript", "producer.ts", "publishOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "JS/TS producer")
 }
@@ -656,7 +660,7 @@ public class OrderEventPublisher {
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "Java producer (builder-chain putEvents)")
 
-	fromID := "SCOPE.Function:publishOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("java", "OrderEventPublisher.java", "publishOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain putEvents)")
 }
@@ -693,7 +697,7 @@ public class ShipmentPublisher {
 	id := eventTypeID("OrderShipped")
 	requireEventTypeEntity(t, ents, id, "Java producer (builder-chain second entry)")
 
-	fromID := "SCOPE.Function:publishOrderShipped"
+	fromID := extractor.BuildOperationStructuralRef("java", "ShipmentPublisher.java", "publishOrderShipped")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (builder-chain second entry)")
 }
@@ -728,7 +732,7 @@ public class CancelPublisher {
 	id := eventTypeID("OrderCancelled")
 	requireEventTypeEntity(t, ents, id, "Java producer (unbalanced paren in detail string)")
 
-	fromID := "SCOPE.Function:publishOrderCancelled"
+	fromID := extractor.BuildOperationStructuralRef("java", "CancelPublisher.java", "publishOrderCancelled")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Java producer (unbalanced paren in detail string)")
 }
@@ -809,8 +813,8 @@ public class Logged {
 // TestEventType_JavaProducer_Precision_ClassScopeNoCaller reproduces review
 // finding #3: a co-located putEvents+detailType in a static field
 // initializer (NOT inside any indexed method) has an empty enclosing-method
-// name, so fromID would be the bare `"SCOPE.Function:"` prefix — emission
-// must be rejected when the enclosing method name is empty.
+// name, so fromID would be an empty structural-ref — emission must be
+// rejected when the enclosing method name is empty.
 func TestEventType_JavaProducer_Precision_ClassScopeNoCaller(t *testing.T) {
 	src := `package producer;
 
@@ -826,8 +830,8 @@ public class StaticInit {
 `
 	_, rels := runEventTypeDetect(t, "java", "StaticInit.java", src)
 	for _, r := range rels {
-		if r.FromID == "SCOPE.Function:" {
-			t.Errorf("class-scope sink: expected NO edge with empty caller prefix, got %+v", r)
+		if r.Kind == "PUBLISHES_TO" && r.FromID == "" {
+			t.Errorf("class-scope sink: expected NO edge with empty caller, got %+v", r)
 		}
 	}
 }
@@ -1267,7 +1271,7 @@ func RecordOrderSettled(ctx context.Context, store *EventStore, id string, paylo
 	id := eventTypeID("OrderSettled")
 	requireEventTypeEntity(t, ents, id, "Go event-store constructor-arg producer")
 
-	fromID := "SCOPE.Function:RecordOrderSettled"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_store.go", "RecordOrderSettled")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store constructor-arg producer")
 
@@ -1299,7 +1303,7 @@ func RecordOrderPlaced(ctx context.Context, p []byte) error {
 	id := eventTypeID("OrderPlaced")
 	requireEventTypeEntity(t, ents, id, "Go event-store constructor-arg producer (PublishEvent)")
 
-	fromID := "SCOPE.Function:RecordOrderPlaced"
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_store2.go", "RecordOrderPlaced")
 	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store constructor-arg producer (PublishEvent)")
 }
@@ -1499,11 +1503,104 @@ func RecordOrder(ctx context.Context, store *EventStore, orderID string) error {
 			ents, rels := runEventTypeDetect(t, "go", "producer_variant.go", src)
 			id := eventTypeID("OrderSettled")
 			requireEventTypeEntity(t, ents, id, "Go event-store "+verb+" variant sink")
-			fromID := "SCOPE.Function:RecordOrder"
+			fromID := extractor.BuildOperationStructuralRef("go", "producer_variant.go", "RecordOrder")
 			toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
 			requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go event-store "+verb+" variant sink")
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Producer — Go — RC-B-1: DynamoDB-Streams reserved-value denylist
+// ---------------------------------------------------------------------------
+
+// TestEventType_GoProducer_DynamoDBStreamsReservedValue_NotMinted is the
+// red->green regression for defect RC-B-1: DynamoDB Streams stamps a fixed
+// `EventName` field (one of INSERT/MODIFY/REMOVE) on every stream record,
+// and "eventName" is a legitimate allowlisted event-envelope key. A stream
+// handler that inspects `rec.EventName` in the SAME function scope as a
+// real publish call (the function-scope-recall widening covered by
+// TestEventType_GoProducer_FunctionScopeStructField) previously minted a
+// bogus event:type:INSERT/MODIFY/REMOVE node purely from that plumbing
+// field. None of the three reserved values may ever mint a node, checked
+// case-insensitively; verified per-value with t.Run subtests.
+func TestEventType_GoProducer_DynamoDBStreamsReservedValue_NotMinted(t *testing.T) {
+	for _, reserved := range []string{"INSERT", "MODIFY", "REMOVE", "insert", "Modify"} {
+		t.Run(reserved, func(t *testing.T) {
+			src := `package producer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+)
+
+type StreamRecord struct {
+	EventName string
+}
+
+func HandleStreamRecord(ctx context.Context, client *kinesis.Client, orderID string) error {
+	rec := StreamRecord{
+		EventName: "` + reserved + `",
+	}
+	_ = rec
+	_, err := client.PutRecord(ctx, &kinesis.PutRecordInput{
+		StreamName:   aws.String("orders-stream"),
+		PartitionKey: aws.String(orderID),
+	})
+	return err
+}
+`
+			ents, _ := runEventTypeDetect(t, "go", "stream_handler.go", src)
+			for _, want := range []string{"INSERT", "MODIFY", "REMOVE"} {
+				id := eventTypeID(want)
+				if eventTypeEntityByID(ents, id) != nil {
+					t.Errorf("EventName:%q must never mint %s; got %v", reserved, id, entNames(ents))
+				}
+			}
+		})
+	}
+}
+
+// TestEventType_GoProducer_EventNameSyntheticDomainName_StillMinted is the
+// companion positive guard: the RC-B-1 denylist must be scoped to the exact
+// DynamoDB-Streams reserved vocabulary — a legitimate synthetic domain event
+// name carried in the SAME "eventName" key shape must still mint normally.
+func TestEventType_GoProducer_EventNameSyntheticDomainName_StillMinted(t *testing.T) {
+	src := `package producer
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+)
+
+type OrderEvent struct {
+	EventName string
+}
+
+func PublishOrderPlaced(ctx context.Context, client *kinesis.Client, orderID string) error {
+	evt := OrderEvent{
+		EventName: "OrderPlaced",
+	}
+	_ = evt
+	_, err := client.PutRecord(ctx, &kinesis.PutRecordInput{
+		StreamName:   aws.String("orders-stream"),
+		PartitionKey: aws.String(orderID),
+	})
+	return err
+}
+`
+	ents, rels := runEventTypeDetect(t, "go", "producer_eventname.go", src)
+
+	id := eventTypeID("OrderPlaced")
+	requireEventTypeEntity(t, ents, id, "Go producer (legitimate eventName)")
+
+	fromID := extractor.BuildOperationStructuralRef("go", "producer_eventname.go", "PublishOrderPlaced")
+	toID := fmt.Sprintf("%s:%s", eventTypeKind, id)
+	requireEdgeFromTo(t, rels, fromID, toID, "PUBLISHES_TO", "Go producer (legitimate eventName)")
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/event_type_producers.go
+++ b/internal/engine/event_type_producers.go
@@ -6,7 +6,67 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/extractor"
 )
+
+// ---------------------------------------------------------------------------
+// Shared: producer-source structural-ref (RC-A precision fix)
+// ---------------------------------------------------------------------------
+
+// eventTypeProducerSentinelCallers are the enclosing-function-not-found
+// fallback values findEnclosingGoFunctionName / findEnclosingNodeFunctionName
+// return when no real function/method could be located (see those helpers in
+// serverless_edges.go). Neither is a real symbol name, so a structural-ref
+// built from it can never resolve via byLocation — treat it the same as an
+// empty caller and drop the edge outright (RC-A fix part 2, drop-on-unresolved
+// safety net) rather than emit a doomed stub.
+var eventTypeProducerSentinelCallers = map[string]bool{
+	"package": true, // Go: no enclosing func decl found in the lookback window
+	"module":  true, // JS/TS: no enclosing func/arrow found in the lookback window
+}
+
+// producerSourceRef builds the location-qualified structural-ref FromID for a
+// PUBLISHES_TO producer edge (RC-A precision fix). Every producer detector in
+// this file previously stamped the FromID as a bare-leaf-name symbolic stub —
+// `fmt.Sprintf("SCOPE.Function:%s", caller)` — which fails resolution for
+// three independent reasons (see the RC-A root-cause writeup at the top of
+// this file's package doc / the task description):
+//
+//  1. The stub claims kind "SCOPE.Function", but the tree-sitter extractors
+//     emit real Go/JS/Java functions and methods as SCOPE.Operation, so the
+//     precise kind+name resolver tier never hits.
+//  2. The stub carries no source-file context (it's a standalone
+//     Relationship, and the SCOPE.EventType ToID node is minted with
+//     SourceFile: "" too), so the resolver's same-file/same-package locality
+//     tie-break (rewriteOneWithCaller) never engages.
+//  3. A repeated leaf name across files/packages (e.g. two different
+//     "Handler" functions) collides in the bare-name index, so even when the
+//     kind is fixed the lookup is ambiguous.
+//
+// This helper instead emits the canonical Format-A structural-ref
+// `scope:operation:method:<lang>:<file>:<name>` — the SAME convention
+// internal/extractor.BuildOperationStructuralRef centralizes for class→method
+// CONTAINS edges and the Go/JS/TS bare-call CALLS path (Refs #44) — which the
+// central resolver (internal/resolve.Index.lookupStructural) binds
+// deterministically via byLocation[file][name] (same-file, the dominant case)
+// with a same-package fallback for Go (byPackageOperation).
+//
+// Returns "" — signalling the caller should not emit an edge at all — when
+// path or caller is empty, or caller is a known non-resolving sentinel
+// ("package"/"module"). This is the belt half of the RC-A fix: a caller name
+// that could never structurally resolve is dropped at the source rather than
+// handed to the resolver as a doomed stub. The suspenders half (dropping a
+// stub that DOES look like a real name but still fails to resolve against the
+// graph) is enforced downstream by resolve.DropUnresolvedPublishesTo, which
+// runs after the central resolver and removes any surviving PUBLISHES_TO edge
+// whose FromID never became a real (16-char hex) entity id.
+func producerSourceRef(lang, path, caller string) string {
+	if path == "" || caller == "" || eventTypeProducerSentinelCallers[caller] {
+		return ""
+	}
+	return extractor.BuildOperationStructuralRef(lang, path, caller)
+}
 
 // ---------------------------------------------------------------------------
 // Shared: allowlisted event-type key extraction
@@ -78,12 +138,40 @@ func isEventTypeWrapperFormatter(wrapper string) bool {
 	return eventTypeFormatterFuncs[base]
 }
 
+// eventTypeReservedValues denylists values that pattern-match the allowlisted
+// {eventName: "X"} shape (findAllowlistedEventType's own precision gate) but
+// are NEVER a domain event-type contract (defect RC-B-1). "eventName" is a
+// legitimate domain-event-envelope key (order-service `EventName:
+// "OrderPlaced"`), but it is ALSO the literal field name DynamoDB Streams
+// stamps on every stream record to carry the record's CRUD operation type —
+// `event.Records[i].EventName` is always exactly one of INSERT / MODIFY /
+// REMOVE. A DynamoDB-Streams Lambda handler that also happens to
+// republish/forward events elsewhere in the SAME function scope (the
+// realistic real-world shape — this pass's function-scope recall widening
+// doesn't require co-location with the actual publish call) previously mined
+// a bogus `event:type:INSERT` node from the record's plumbing field. These
+// three values are DynamoDB Streams' fixed vocabulary, never a domain event
+// name, so they are rejected case-insensitively regardless of which
+// allowlisted key produced them.
+var eventTypeReservedValues = map[string]bool{
+	"INSERT": true,
+	"MODIFY": true,
+	"REMOVE": true,
+}
+
 // isEventTypeValueUsable rejects a captured value that cannot be a stable wire
 // contract: one carrying a `%` format verb (a `fmt.Sprintf` template such as
 // `order.%s.placed`), which never verbatim-joins a consumer (review
-// MUST-FIX #2).
+// MUST-FIX #2), or one matching the DynamoDB-Streams record-operation-type
+// denylist (defect RC-B-1, eventTypeReservedValues).
 func isEventTypeValueUsable(value string) bool {
-	return !strings.Contains(value, "%")
+	if strings.Contains(value, "%") {
+		return false
+	}
+	if eventTypeReservedValues[strings.ToUpper(value)] {
+		return false
+	}
+	return true
 }
 
 // eventTypeAllowlistKeyIdentRe mirrors eventTypeAllowlistKeyRe but matches a
@@ -392,7 +480,7 @@ func enclosingGoFuncBodyStart(src string, offset int) int {
 // path (GAP-005) and is newly reachable for EventBridge via the RC2 PutEvents
 // sink; tightening it to per-payload co-location is a follow-up.
 func applyEventTypeProducerGo(
-	src string,
+	path, src string,
 	emitEdge func(fromID, verbatim, kind string, props map[string]string),
 ) {
 	bindings := buildGoStringBindingTable(src)
@@ -429,7 +517,7 @@ func applyEventTypeProducerGo(
 		}
 		caller := findEnclosingGoFunctionName(src, m[0])
 		emitEdge(
-			fmt.Sprintf("SCOPE.Function:%s", caller),
+			producerSourceRef("go", path, caller),
 			value,
 			"PUBLISHES_TO",
 			map[string]string{"lang": "go", "key": key, "detection": detection},
@@ -596,7 +684,7 @@ func nearestGoEventConstructorLiteral(scope string) (value string, ok bool) {
 // one that lexically follows the sink, is not matched. See RC1 report for
 // the full v1-limitations list.
 func applyEventTypeProducerGoEventStore(
-	src string,
+	path, src string,
 	emitEdge func(fromID, verbatim, kind string, props map[string]string),
 ) {
 	for _, m := range goEventStoreWriteSiteRe.FindAllStringIndex(src, -1) {
@@ -608,7 +696,7 @@ func applyEventTypeProducerGoEventStore(
 		}
 		caller := findEnclosingGoFunctionName(src, m[0])
 		emitEdge(
-			fmt.Sprintf("SCOPE.Function:%s", caller),
+			producerSourceRef("go", path, caller),
 			value,
 			"PUBLISHES_TO",
 			map[string]string{"lang": "go", "detection": "event-store-constructor-arg"},
@@ -650,7 +738,7 @@ func enclosingNodeFuncBodyStart(src string, offset int) int {
 // including the function-scope recall widening (GAP-005 root-cause C) for
 // the `const evt = {eventType:"X"}; ...; client.send(evt)` shape.
 func applyEventTypeProducerJSTS(
-	src string,
+	lang, path, src string,
 	emitEdge func(fromID, verbatim, kind string, props map[string]string),
 ) {
 	for _, m := range jstsPublishSiteRe.FindAllStringIndex(src, -1) {
@@ -668,7 +756,7 @@ func applyEventTypeProducerJSTS(
 		}
 		caller := findEnclosingNodeFunctionName(src, m[0])
 		emitEdge(
-			fmt.Sprintf("SCOPE.Function:%s", caller),
+			producerSourceRef(lang, path, caller),
 			value,
 			"PUBLISHES_TO",
 			map[string]string{"lang": "javascript", "key": key, "detection": detection},
@@ -849,7 +937,7 @@ func maskJavaCommentsAndStrings(src string) string {
 //     is deferred (would need call-graph / dataflow resolution).
 //   - STRING-LITERAL detailType only (variable/constant-bound deferred).
 func applyEventTypeProducerJava(
-	src string,
+	path, src string,
 	emitEdge func(fromID, verbatim, kind string, props map[string]string),
 ) {
 	methods := indexJavaEnclosingMethods(src)
@@ -884,7 +972,7 @@ func applyEventTypeProducerJava(
 			continue
 		}
 		emitEdge(
-			fmt.Sprintf("SCOPE.Function:%s", caller),
+			producerSourceRef("java", path, caller),
 			value,
 			"PUBLISHES_TO",
 			map[string]string{"lang": "java", "key": "detailType", "detection": "publish-site-literal"},

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1554,7 +1554,7 @@ var (
 //
 // Honest scoping: edge kinds whose BOTH endpoints are synthetic stubs
 // (helm BINDS template→values_key, MODIFIES_TABLE/ACCESSES_TABLE/QUERIES →
-// table key, PUBLISHES_TO/SUBSCRIBES_TO → MessageTopic, JOINS_COLLECTION →
+// table key, SUBSCRIBES_TO → MessageTopic, JOINS_COLLECTION →
 // collection key, DEPENDS_ON_CONFIG → SCOPE.Config, SHARES_DATA →
 // Module, TRANSITIONS_TO → SCOPE.State, GATED_BY's flag end) are NOT hinted
 // here for the stub side — those resolve via byQualifiedName / structural
@@ -1563,6 +1563,16 @@ var (
 // is dual-use (Helm + DI); the Helm `helm_values:<path>` stub matches by
 // QualifiedName first, so the component hint only ever affects the DI
 // token→impl class case, which is exactly the target.
+//
+// PUBLISHES_TO is the one exception to "both endpoints are stubs": its ToID
+// (synthetic EventType/MessageTopic) is a stub resolved by QualifiedName,
+// but its FromID (the producer call-site's enclosing function) is a REAL
+// operation-shaped endpoint since the RC-A precision fix — emitted as a
+// location-qualified structural-ref (extractor.BuildOperationStructuralRef)
+// rather than a bare unqualified name. It is hinted below alongside CALLS so
+// an ambiguous bare producer name still narrows to the operation family;
+// SUBSCRIBES_TO is intentionally NOT included — its FromID remains a bare
+// caller name with no per-file qualification.
 //
 // Tie-break note (#3936): preferring the real source-bearing entity over a
 // synthetic/spec stub is handled by lookupByKindHint's tier-1
@@ -1575,7 +1585,7 @@ func hintKinds(relKind string) []string {
 	switch strings.ToUpper(relKind) {
 	case "EXTENDS", "IMPLEMENTS":
 		return componentKindFamily
-	case "CALLS":
+	case "CALLS", "PUBLISHES_TO":
 		return operationKindFamily
 	// #3930: component-shaped semantic edges — both real endpoints are
 	// classes/components (DI provider/consumer, graph @Node owner/target,
@@ -5594,6 +5604,37 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 
 	stats.finalizeDispositions()
 	return stats
+}
+
+// DropUnresolvedPublishesTo is the RC-A safety net: it removes any
+// PUBLISHES_TO relationship whose FromID (the producer call-site's
+// enclosing-function endpoint) is non-empty but failed to resolve to a
+// 16-char hex entity ID after References/ReferencesWithAllowlist has run.
+//
+// Callers must invoke this AFTER resolution (References /
+// ReferencesWithAllowlist mutate rels in place and cannot themselves drop
+// entries — many callers depend on their "same length in, same length out,
+// mutate in place" contract). This is a separate, explicit post-pass so a
+// PUBLISHES_TO edge whose source could not be pinned to a real operation
+// (e.g. the enclosing function genuinely doesn't exist in the graph, or the
+// producerSourceRef helper's own sentinel-caller guard already dropped it to
+// "") never survives into the final document with a dangling/stub source —
+// independent of how good or bad the structural-ref resolution itself is.
+//
+// Edges with an EMPTY FromID are left alone here (that shape means "no
+// caller could be identified at all" and is handled by the emitter itself
+// refusing to emit); this pass only targets the case where a FromID was
+// populated (a structural-ref or bare name was emitted) but resolution
+// still failed to land on a real entity.
+func DropUnresolvedPublishesTo(rels []types.RelationshipRecord) []types.RelationshipRecord {
+	out := rels[:0]
+	for _, r := range rels {
+		if r.Kind == "PUBLISHES_TO" && r.FromID != "" && !isHexID(r.FromID) {
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
 }
 
 // isHexID reports whether s is a 16-char lower-hex string — the shape of

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -2393,3 +2393,97 @@ func TestIssue2060_TestmapShortForm_AmbiguousNameNotResolved(t *testing.T) {
 	}
 	_ = stats
 }
+
+// RC-A precision fix (event-driven producer-edge modeling): PUBLISHES_TO's
+// FromID (the producer call-site's enclosing function) must be emitted as a
+// location-qualified structural-ref (extractor.BuildOperationStructuralRef)
+// rather than a bare unqualified caller name — so two same-named enclosing
+// functions in DIFFERENT files each resolve to their OWN per-file operation
+// entity, not to each other or to an ambiguous/dangling stub.
+func TestReferences_PublishesToStructuralRef_PerFileNotCrossBound(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Operation", "Publish", "orders/producer.go"),
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Operation", "Publish", "shipping/producer.go"),
+	}
+	rels := []types.RelationshipRecord{
+		{
+			FromID: "scope:operation:method:go:orders/producer.go:Publish",
+			ToID:   "event:type:OrderPlaced",
+			Kind:   "PUBLISHES_TO",
+		},
+		{
+			FromID: "scope:operation:method:go:shipping/producer.go:Publish",
+			ToID:   "event:type:OrderShipped",
+			Kind:   "PUBLISHES_TO",
+		},
+	}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].FromID != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("orders/producer.go Publish: FromID=%s, want aaaaaaaaaaaaaaaa (per-file resolution)", rels[0].FromID)
+	}
+	if rels[1].FromID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("shipping/producer.go Publish: FromID=%s, want bbbbbbbbbbbbbbbb (per-file resolution)", rels[1].FromID)
+	}
+	if rels[0].FromID == rels[1].FromID {
+		t.Fatalf("both same-named producers resolved to the SAME entity — cross-file binding bug: %s", rels[0].FromID)
+	}
+	if stats.FromRewritten != 2 {
+		t.Fatalf("expected FromRewritten=2, got %+v", stats)
+	}
+}
+
+// RC-A precision fix, safety-net half: DropUnresolvedPublishesTo must strip
+// any PUBLISHES_TO edge whose FromID failed to resolve to a real 16-char hex
+// entity ID (e.g. the enclosing function genuinely doesn't exist anywhere in
+// the graph), rather than letting a dangling/stub source ship in the final
+// document. A legitimate, resolvable PUBLISHES_TO edge must survive the pass
+// untouched, and non-PUBLISHES_TO relationships must never be touched.
+func TestDropUnresolvedPublishesTo(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Operation", "Publish", "orders/producer.go"),
+	}
+	rels := []types.RelationshipRecord{
+		{
+			// Resolves — must survive.
+			FromID: "scope:operation:method:go:orders/producer.go:Publish",
+			ToID:   "event:type:OrderPlaced",
+			Kind:   "PUBLISHES_TO",
+		},
+		{
+			// Enclosing function "Ghost" is not indexed anywhere — genuinely
+			// unresolvable. Must be dropped, not kept with a dangling source.
+			FromID: "scope:operation:method:go:orders/nowhere.go:Ghost",
+			ToID:   "event:type:OrderCancelled",
+			Kind:   "PUBLISHES_TO",
+		},
+		{
+			// Unrelated relationship kind — must be left alone even though its
+			// ToID never resolves either.
+			FromID: "0000000000000000",
+			ToID:   "scope:operation:method:go:orders/nowhere.go:Ghost",
+			Kind:   "CALLS",
+		},
+	}
+	idx := BuildIndex(entities)
+	References(rels, idx)
+
+	filtered := DropUnresolvedPublishesTo(rels)
+
+	var publishesToCount int
+	for _, r := range filtered {
+		if r.Kind != "PUBLISHES_TO" {
+			continue
+		}
+		publishesToCount++
+		if !isHexID(r.FromID) {
+			t.Fatalf("unresolved PUBLISHES_TO source survived drop pass: %+v", r)
+		}
+	}
+	if publishesToCount != 1 {
+		t.Fatalf("expected exactly 1 surviving PUBLISHES_TO edge, got %d (filtered=%+v)", publishesToCount, filtered)
+	}
+	if len(filtered) != 2 {
+		t.Fatalf("expected 2 total relationships to survive (1 PUBLISHES_TO + 1 CALLS), got %d: %+v", len(filtered), filtered)
+	}
+}


### PR DESCRIPTION
## What

Fixes the producer side of the event knowledge graph's `PUBLISHES_TO` edges, which were being emitted with an **unresolvable symbolic source** — the enclosing function's bare leaf name (`SCOPE.Function:Handler`, `Function:module`, …) instead of a real entity id. On a large real corpus this left the majority of producer edges dangling on the source side: a producer→event edge whose producer end never joined to a code node, so no two-sided producer↔consumer journey could form.

Also fixes a producer false-positive: DynamoDB-Streams record literals (`EventName: "INSERT"|"MODIFY"|"REMOVE"`) were minting bogus `event:type:INSERT` nodes.

Precision-first: where the source resolves we now bind it correctly; where it genuinely can't resolve we **drop** the edge rather than leave a corrupt half-edge.

## Root cause (RC-A)

Every producer detector stamped the edge `FromID` as `fmt.Sprintf("SCOPE.Function:%s", caller)` where `caller` is only the enclosing function's leaf name. That stub then failed resolution for four compounding reasons:
1. **Wrong kind** — real Go/JS/Java functions extract as `SCOPE.Operation`, not `SCOPE.Function`, so the precise kind+name resolver tier never hit and it degraded to bare-name.
2. **Locality disabled** — the same-file tie-breaker only runs with a non-empty caller file, but these standalone edges carried none.
3. **No operation bias** — `hintKinds` had no `PUBLISHES_TO` case (it predated producer edges having a real code source).
4. **No drop** — an unresolved (non-hex) `FromID` was kept verbatim, leaving a dangling half-edge.

The handful that resolved did so only because their enclosing name happened to be globally unique — resolution by luck, unsafe across a multi-repo group where names collide.

## Changes

- **`internal/engine/event_type_producers.go`** — shared `producerSourceRef()` helper emits a location-qualified structural ref (`scope:operation:method:<lang>:<file>:<name>` via `extractor.BuildOperationStructuralRef`) so the source binds deterministically per-file; wired into all four producer emitters (generic Go, RC1 event-store, JS/TS, Java). Sentinel-caller guard. `eventTypeReservedValues` denylist `{INSERT,MODIFY,REMOVE}` (case-insensitive) added to `isEventTypeValueUsable`.
- **`internal/engine/event_type_edges.go`** — dispatch threads `path`/`lang` into the producer emitters.
- **`internal/resolve/refs.go`** — `hintKinds` gains a `PUBLISHES_TO` → operation-family case; new `DropUnresolvedPublishesTo` safety net.
- **`cmd/grafel/index.go`** — runs `DropUnresolvedPublishesTo` after `ReferencesWithAllowlist` over the standalone-relationship stream.

`DropUnresolvedPublishesTo` operates globally over pass-2 relationships, so it also covers the older `event_bus_edges.go`/`kafka_edges.go`/inngest/bullmq producer emitters that share the same bare-stub shape — dangling `PUBLISHES_TO` goes to zero graph-wide, not just for the four fixed detectors.

## Tests (red→green, verified)

- `TestReferences_PublishesToStructuralRef_PerFileNotCrossBound` — two same-named `Publish` functions in different files resolve to distinct per-file hex operation ids (real `BuildIndex`+`References`, not a stub).
- `TestDropUnresolvedPublishesTo` — a resolvable producer edge survives, an unindexed source drops, an unrelated `CALLS` edge is untouched.
- `TestEventType_GoProducer_DynamoDBStreamsReservedValue_NotMinted` + `..._EventNameSyntheticDomainName_StillMinted` — INSERT/MODIFY/REMOVE never mint; a legitimate synthetic `eventName:"OrderPlaced"` still does.

All fixtures use synthetic event names.

## Review

Independently reviewed (adversarial): **APPROVE-WITH-FOLLOWUP**, no blocking defects. Confirmed per-language structural-ref matching (including the Go receiver-method danger case), bounded over-drop (embedded/synthetic-source producers flow through a different stream and are untouched), negligible `hintKinds` blast radius, and non-tautological tests. Two follow-ups filed: (1) port `producerSourceRef` into `event_bus_edges.go`/`kafka_edges.go` to *recover* deferred-path producer edges rather than rely on the global drop (recall, not correctness); (2) optionally scope the INSERT denylist to the `eventName` key.

## Gate

`go build ./...`, `go vet ./internal/engine/... ./internal/resolve/...`, `go test ./internal/engine/... ./internal/resolve/...` (4659 pass, +9 new), `gofmt -l` on all touched files (clean).

Refs #5820 #5823

🤖 Generated with [Claude Code](https://claude.com/claude-code)
