### PR TITLE
fix(feedback): correct Schema/Component orphan + zero-field miscount

### DIFF
--- a/internal/feedback/render.go
+++ b/internal/feedback/render.go
@@ -122,6 +122,19 @@ func Render(w io.Writer, r *Report) error {
 			fmt.Fprintf(w, "_None — all kinds with >= 10 entities have orphan rate <= 30%%._\n")
 		}
 		fmt.Fprintf(w, "\n")
+
+		// Expected/terminal orphans: container-terminal Components and
+		// field-leaf terminals are not defects — routed here instead of the
+		// defect table above so the raw signal is not silently dropped.
+		if len(r.OrphanTerminalByKind) > 0 {
+			fmt.Fprintf(w, "**Expected/terminal orphans** (container-terminal by design, not defects):\n\n")
+			fmt.Fprintf(w, "| Kind | Total | Terminal orphan | Terminal orphan %% |\n|---|---|---|---|\n")
+			for _, kind := range sortedKindStatsKeys(r.OrphanTerminalByKind) {
+				tks := r.OrphanTerminalByKind[kind]
+				fmt.Fprintf(w, "| %s | %d | %d | %.1f%% |\n", kind, tks.Total, tks.OrphanCount, tks.OrphanPct)
+			}
+			fmt.Fprintf(w, "\n")
+		}
 	}
 
 	// Section 3 — Resolution Disposition

--- a/internal/feedback/report.go
+++ b/internal/feedback/report.go
@@ -81,7 +81,13 @@ type Report struct {
 	}
 
 	// Section 2 — Orphan Rate
-	OrphanByKind map[string]KindStats // kind → orphan stats (kinds with N < 10 suppressed)
+	OrphanByKind map[string]KindStats // kind → DEFECT orphan stats (kinds with N < 10 suppressed)
+	// OrphanTerminalByKind holds the same shape for orphans classified as
+	// expected/terminal by construction (container Components, field leaves
+	// anchored by an inbound CONTAINS edge) — see classifyOrphan. These are
+	// NOT defects and are reported separately so the raw signal survives
+	// instead of being silently dropped.
+	OrphanTerminalByKind map[string]KindStats
 
 	// Section 3 — Resolution Disposition
 	Resolution      ResolutionVector
@@ -114,12 +120,13 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	}
 
 	r := &Report{
-		GeneratedAt:        time.Now().UTC(),
-		GroupName:          opts.GroupName,
-		Version:            opts.Version,
-		EntitiesByLanguage: make(map[string]int),
-		OrphanByKind:       make(map[string]KindStats),
-		FrameworkHits:      make(map[string]int),
+		GeneratedAt:          time.Now().UTC(),
+		GroupName:            opts.GroupName,
+		Version:              opts.Version,
+		EntitiesByLanguage:   make(map[string]int),
+		OrphanByKind:         make(map[string]KindStats),
+		OrphanTerminalByKind: make(map[string]KindStats),
+		FrameworkHits:        make(map[string]int),
 	}
 
 	// Merge all docs into aggregate structures.
@@ -136,9 +143,21 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 	}
 	entityEdges := make(map[string]*edgeSummary)
 
-	// Index of entity ID → kind for the orphan lookup pass.
+	// Index of entity ID → kind/subtype for the orphan lookup pass.
 	entityKind := make(map[string]string)
 	entityLang := make(map[string]string)
+	entitySubtype := make(map[string]string)
+
+	// classCandidate records a class-like entity (Subtype != "field") that is
+	// eligible for the field-extraction metric, along with its raw
+	// Properties["field_count"] (empty if the extractor never set it — true
+	// for the dominant Go/Java/Python producers, which emit fields as child
+	// entities instead; see fieldChildCount below).
+	type classCandidate struct {
+		id            string
+		fieldCountRaw string
+	}
+	var classCandidates []classCandidate
 
 	// Resolution disposition counters.
 	var (
@@ -152,9 +171,11 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 	annotated := 0
 	totalAnnotated := 0
-	classCount := 0
-	classZeroFields := 0
 
+	// Pass 1: entities. Populates all per-entity indices used by pass 2
+	// (relationships) below. Kept as a separate pass — rather than
+	// interleaved per-doc like before — so cross-doc relationships can
+	// reliably look up entity kind/subtype regardless of doc order.
 	for _, doc := range docs {
 		if doc == nil {
 			continue
@@ -180,6 +201,7 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 
 			entityKind[e.ID] = kind
 			entityLang[e.ID] = lang
+			entitySubtype[e.ID] = e.Subtype
 
 			// Initialise edge summary so even no-edge entities appear.
 			if _, ok := entityEdges[e.ID]; !ok {
@@ -210,13 +232,17 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			// entities found" against production data. Match case-insensitively on
 			// the namespace-stripped tail (see kindTail, mirroring
 			// internal/graph/coverage.go) and include schema.
-			if isClassLikeKind(kind) {
-				classCount++
-				// Fields are typically emitted as child entities; we use
-				// Properties["field_count"] when available.
-				if e.Properties["field_count"] == "0" || e.Properties["field_count"] == "" {
-					classZeroFields++
-				}
+			//
+			// A Subtype == "field" entity is itself a field LEAF, not a
+			// class/model container — classLikeKindTails includes "schema"
+			// which also matches these leaves (SCOPE.Schema/field), so they
+			// must be excluded here or every field would double as a "class"
+			// and guarantee a 100% zero-fields rate.
+			if isClassLikeKind(kind) && e.Subtype != "field" {
+				classCandidates = append(classCandidates, classCandidate{
+					id:            e.ID,
+					fieldCountRaw: e.Properties["field_count"],
+				})
 			}
 		}
 
@@ -229,16 +255,39 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			}
 		}
 		r.FrameworkFilesDetected += len(frameworkFilesSeen)
+	}
 
-		// Process relationships.
+	// Pass 2: relationships. fieldChildCount and hasInboundStructural are
+	// built here (over ALL docs) before any orphan/field-extraction
+	// classification happens, so it doesn't matter which doc emitted the
+	// child entity vs. the structural edge pointing at it.
+	fieldChildCount := make(map[string]int)       // parent entity ID → count of field children
+	hasInboundStructural := make(map[string]bool) // entity ID → has an inbound CONTAINS/DECLARES edge
+
+	for _, doc := range docs {
+		if doc == nil {
+			continue
+		}
 		for i := range doc.Relationships {
 			rel := &doc.Relationships[i]
 
-			// Semantic edge tracking for orphan detection.
-			if !isStructuralEdge(rel.Kind) {
-				if es, ok := entityEdges[rel.FromID]; ok {
-					es.semanticOut++
+			if isStructuralEdge(rel.Kind) {
+				// Fields are extracted as CHILD entities (Kind tail "schema",
+				// Subtype "field") linked to their parent by a structural
+				// CONTAINS/DECLARES edge (internal/extractor/structural_ref.go
+				// BuildSchemaFieldStructuralRef) — never via a
+				// Properties["field_count"] on the parent. Count the real
+				// children so the field-extraction metric reflects the graph
+				// instead of reading a property the dominant extractors never
+				// write.
+				hasInboundStructural[rel.ToID] = true
+				if entitySubtype[rel.ToID] == "field" {
+					fieldChildCount[rel.FromID]++
 				}
+			} else if es, ok := entityEdges[rel.FromID]; ok {
+				// Semantic edge tracking for orphan detection. CONTAINS/
+				// DECLARES edges do NOT reduce orphan count (handled above).
+				es.semanticOut++
 			}
 
 			// Resolution disposition, derived STRUCTURALLY from the edge ToID shape
@@ -264,12 +313,54 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 		}
 	}
 
-	// Compute orphan counts per kind.
-	for id, es := range entityEdges {
-		if es.semanticOut == 0 {
-			kind := entityKind[id]
-			kindOrphans[kind]++
+	// Finalise the field-extraction metric: honor Properties["field_count"]
+	// when the (niche) extractor set it, otherwise fall back to the real
+	// field-child count, which is the source of truth for the dominant
+	// Go/Java/Python producers.
+	classCount := len(classCandidates)
+	classZeroFields := 0
+	for _, c := range classCandidates {
+		if c.fieldCountRaw != "" {
+			if c.fieldCountRaw == "0" {
+				classZeroFields++
+			}
+			continue
 		}
+		if fieldChildCount[c.id] == 0 {
+			classZeroFields++
+		}
+	}
+
+	// Compute orphan counts per kind, split into DEFECT vs expected/terminal.
+	kindTerminalOrphans := make(map[string]int)
+	for id, es := range entityEdges {
+		if es.semanticOut != 0 {
+			continue
+		}
+		kind := entityKind[id]
+		subtype := entitySubtype[id]
+
+		// Fix 2: a field LEAF's semantic anchor is its inbound CONTAINS edge
+		// from the parent, not an outbound edge — it never sources
+		// REFERENCES/CALLS/etc. by construction. Not a defect.
+		if subtype == "field" && hasInboundStructural[id] {
+			continue
+		}
+
+		// Fix 3: pure-container SCOPE.Component terminals (one per source file,
+		// module/import stubs, pattern-detector terminals — see
+		// terminalComponentSubtypes) never source an outbound semantic edge, so
+		// being orphan is expected, not an extractor/resolver bug. Route these
+		// to a separate bucket instead of the defect count. Note the exemption
+		// deliberately EXCLUDES class/struct/interface/view/service subtypes:
+		// those DO source EXTENDS/DEPENDS_ON in real graphs, so a zero-edge one
+		// is a genuine defect and stays in kindOrphans below.
+		if isComponentKind(kind) && terminalComponentSubtypes[subtype] {
+			kindTerminalOrphans[kind]++
+			continue
+		}
+
+		kindOrphans[kind]++
 	}
 
 	// Build OrphanByKind (suppress kinds with N < 10).
@@ -286,6 +377,15 @@ func Generate(_ context.Context, docs []*graph.Document, opts Opts) (*Report, er
 			Total:       total,
 			OrphanCount: orphans,
 			OrphanPct:   pct,
+		}
+
+		if terminal := kindTerminalOrphans[kind]; terminal > 0 {
+			tpct := 100.0 * float64(terminal) / float64(total)
+			r.OrphanTerminalByKind[kind] = KindStats{
+				Total:       total,
+				OrphanCount: terminal,
+				OrphanPct:   tpct,
+			}
 		}
 	}
 
@@ -403,6 +503,57 @@ var classLikeKindTails = map[string]bool{
 // kind, matched case-insensitively on the namespace-stripped tail.
 func isClassLikeKind(kind string) bool {
 	return classLikeKindTails[kindTail(kind)]
+}
+
+// isComponentKind reports whether kind is the generic AST container/target
+// kind (SCOPE.Component — internal/types/kinds.go), matched
+// case-insensitively on the namespace-stripped tail.
+func isComponentKind(kind string) bool {
+	return kindTail(kind) == "component"
+}
+
+// terminalComponentSubtypes lists SCOPE.Component subtypes that are genuine
+// pure containers / terminal nodes: a single per-source-file node ("file"),
+// module containers, import stubs, and the pattern-detector terminal nodes
+// (column_schema/middleware/…). No pass ever emits an outbound
+// REFERENCES/CALLS/DEPENDS_ON/EXTENDS edge FROM one of these, so a zero-edge
+// "orphan" verdict reflects intended graph shape rather than an extractor or
+// resolver defect — they are reported in the separate expected/terminal
+// bucket instead of the defect orphan count.
+//
+// This list is feedback-local policy: it is deliberately NOT the audit
+// taxonomy. internal/quality/audit/heuristics.go takes the OPPOSITE stance on
+// construct kinds — it buckets class/struct/interface as CauseRealConstructBug
+// (genuine defects) — so we do not mirror it and must not claim to. We also do
+// not import it (that would pull the internal/quality/audit → internal/daemon
+// dependency chain into this lean package for a taxonomy that does not map
+// onto "terminal vs defect").
+//
+// Crucially, class/struct/interface/view/service subtypes are EXCLUDED here.
+// Those Components DO source outbound semantic edges in real graphs — Python
+// classes emit EXTENDS (internal/extractors/python/crossfile.go
+// extractBaseClasses; classes are SCOPE.Component/class per
+// python/references.go), and framework class/view/service/controller/
+// repository Components source DEPENDS_ON (internal/docgen/tier0.go). A
+// class-subtype Component only reaches the zero-outbound-edge state when those
+// edges FAILED to resolve — i.e. exactly the extractor/resolver regression the
+// orphan-rate sanity gate exists to catch. Exempting them would silently
+// reclassify a real defect as "expected/terminal", so they MUST stay in the
+// defect OrphanByKind bucket.
+var terminalComponentSubtypes = map[string]bool{
+	// Pure containers / stubs: one per source file, module containers, import
+	// placeholders. These never source an outbound semantic edge.
+	"file":   true,
+	"module": true,
+	"import": true,
+	// Pattern-detector terminal subtypes.
+	"column_schema":     true,
+	"middleware":        true,
+	"type_alias":        true,
+	"database_index":    true,
+	"orm":               true,
+	"cross_cutting":     true,
+	"schema_validation": true,
 }
 
 // bucketCount maps a raw count to a privacy-preserving range bucket.

--- a/internal/feedback/report_golden_test.go
+++ b/internal/feedback/report_golden_test.go
@@ -71,14 +71,18 @@ func TestGenerate_GoldenFB(t *testing.T) {
 	if r.FieldExtractionRate.ClassTotal == 0 {
 		t.Errorf("D2: field-extraction found no class/model entities in a graph with Model + SCOPE.Schema kinds")
 	}
+	// Field LEAVES (Subtype == "field") are themselves class/model/schema-tail
+	// kinds (SCOPE.Schema) but are not class/model CONTAINERS — they must be
+	// excluded from the class-like count (Fix 1), or every field doubles as a
+	// "class" and the zero-fields rate is guaranteed to read 100%.
 	wantClassLike := 0
 	for i := range doc.Entities {
-		if isClassLikeKind(doc.Entities[i].Kind) {
+		if isClassLikeKind(doc.Entities[i].Kind) && doc.Entities[i].Subtype != "field" {
 			wantClassLike++
 		}
 	}
 	if r.FieldExtractionRate.ClassTotal != wantClassLike {
-		t.Errorf("D2: ClassTotal=%d, want %d (class/model/schema-like kinds)",
+		t.Errorf("D2: ClassTotal=%d, want %d (class/model/schema-like kinds, excluding field leaves)",
 			r.FieldExtractionRate.ClassTotal, wantClassLike)
 	}
 

--- a/internal/feedback/report_test.go
+++ b/internal/feedback/report_test.go
@@ -41,6 +41,14 @@ func makeDoc(entities []graph.Entity, rels []graph.Relationship) *graph.Document
 	}
 }
 
+// withSubtype returns a copy of e with Subtype set — used to build the
+// field-leaf / container-terminal fixtures for the orphan/field-extraction
+// classification tests.
+func withSubtype(e graph.Entity, subtype string) graph.Entity {
+	e.Subtype = subtype
+	return e
+}
+
 // repeat produces n copies of e with unique IDs.
 func repeat(e graph.Entity, n int) []graph.Entity {
 	out := make([]graph.Entity, n)
@@ -322,6 +330,126 @@ func TestRender_FullReport(t *testing.T) {
 	// Framework hits.
 	if !strings.Contains(out, "gin") {
 		t.Error("expected framework 'gin' in output")
+	}
+}
+
+// TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly is the
+// regression guard for the feedback-collector "orphan rate" / "zero fields"
+// measurement bug (issue #5823 grounding, Fixes 1-3): the dominant Go/Java/
+// Python producers emit fields as CHILD entities (Kind tail "schema",
+// Subtype "field") linked to their parent by a structural CONTAINS edge —
+// they never write Properties["field_count"] — and pure-container SCOPE.Component
+// terminals (one per source file, module/import stubs, pattern-detector nodes)
+// never source outbound semantic edges. Those were miscounted as defects
+// (100% zero-fields, 100% orphan) before the fix.
+//
+// It ALSO guards the opposite direction: a class-subtype SCOPE.Component with
+// zero outbound edges is NOT exempt — classes DO source EXTENDS/DEPENDS_ON in
+// real graphs (python/crossfile.go, docgen/tier0.go), so a zero-edge class is
+// a genuine resolver/extractor defect and must stay in the DEFECT OrphanByKind
+// bucket where the sanity gate can catch it.
+func TestGenerate_FieldChildrenAndContainerTerminalsClassifiedCorrectly(t *testing.T) {
+	widget := makeEntity("widget", "Widget", "SCOPE.Class", "go", "widget.go", 10)
+	field1 := withSubtype(makeEntity("widget.name", "Widget.name", "SCOPE.Schema", "go", "widget.go", 11), "field")
+	field2 := withSubtype(makeEntity("widget.price", "Widget.price", "SCOPE.Schema", "go", "widget.go", 12), "field")
+	fileComp := withSubtype(makeEntity("file1", "widget.go", "SCOPE.Component", "go", "widget.go", 1), "file")
+	// A class-subtype Component with zero outbound edges — the masking-regression
+	// canary. It must land in the DEFECT bucket, never the terminal bucket.
+	classComp := withSubtype(makeEntity("class1", "OrderPlaced", "SCOPE.Component", "python", "order.py", 1), "class")
+
+	entities := []graph.Entity{widget, field1, field2, fileComp, classComp}
+	// Pad past the 50-entity / 10-per-kind reporting floors with orphan
+	// SCOPE.Function entities that carry no structural or semantic edges —
+	// they must NOT be affected by the field/container classification.
+	entities = append(entities, repeat(makeEntity("fn", "DoWork", "SCOPE.Function", "go", "a.go", 1), 50)...)
+
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "widget", ToID: "widget.name", Kind: "CONTAINS"},
+		{ID: "r2", FromID: "widget", ToID: "widget.price", Kind: "CONTAINS"},
+	}
+	// Pad SCOPE.Class, SCOPE.Component (file subtype), and SCOPE.Schema past
+	// the N>=10 suppression floor with additional non-orphan instances so the
+	// kinds under test appear in OrphanByKind/OrphanTerminalByKind.
+	for i := 0; i < 10; i++ {
+		w := makeEntity(fmt.Sprintf("w%d", i), "OtherWidget", "SCOPE.Class", "go", "w.go", 1)
+		f := withSubtype(makeEntity(fmt.Sprintf("w%df", i), "OtherWidget.x", "SCOPE.Schema", "go", "w.go", 2), "field")
+		fc := withSubtype(makeEntity(fmt.Sprintf("fc%d", i), "w.go", "SCOPE.Component", "go", "w.go", 1), "file")
+		entities = append(entities, w, f, fc)
+		rels = append(rels, graph.Relationship{
+			ID: fmt.Sprintf("cr%d", i), FromID: w.ID, ToID: f.ID, Kind: "CONTAINS",
+		})
+	}
+
+	doc := makeDoc(entities, rels)
+	r, err := Generate(context.Background(), []*graph.Document{doc}, Opts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+
+	// --- Fix 1: field-extraction rate reflects real field CHILDREN, not the
+	// (never-set) Properties["field_count"] property. 11 classes, all with
+	// >=1 field child → 0% zero-fields, not 100%.
+	if r.FieldExtractionRate.ClassTotal != 11 {
+		t.Errorf("ClassTotal = %d, want 11 (field-leaf terminals excluded from the class count)", r.FieldExtractionRate.ClassTotal)
+	}
+	if r.FieldExtractionRate.ZeroFieldsPct != 0.0 {
+		t.Errorf("ZeroFieldsPct = %.1f%%, want 0.0%% (every class has >=1 real field child)", r.FieldExtractionRate.ZeroFieldsPct)
+	}
+
+	// --- Fix 2: field-leaf terminals (Subtype=="field") anchored by an
+	// inbound CONTAINS edge are not orphans, even though they have zero
+	// outbound edges.
+	if ks, ok := r.OrphanByKind["SCOPE.Schema"]; ok && ks.OrphanCount != 0 {
+		t.Errorf("SCOPE.Schema defect orphans = %d, want 0 (field leaves anchored by inbound CONTAINS)", ks.OrphanCount)
+	}
+
+	// --- Fix 3: only PURE-container SCOPE.Component subtypes (file/module/
+	// import + pattern terminals) route to the expected/terminal bucket.
+	// file1 + 10 padding file-subtype Components = 11 terminal orphans.
+	tks, ok := r.OrphanTerminalByKind["SCOPE.Component"]
+	if !ok {
+		t.Fatal("expected OrphanTerminalByKind[SCOPE.Component] to be populated")
+	}
+	if tks.OrphanCount != 11 {
+		t.Errorf("SCOPE.Component terminal orphans = %d, want 11 (file-subtype only)", tks.OrphanCount)
+	}
+
+	// --- Masking guard: the class-subtype Component with zero outbound edges
+	// MUST be a DEFECT orphan (classes source EXTENDS/DEPENDS_ON in real
+	// graphs; a zero-edge class is a resolver/extractor regression). It must
+	// NOT be swallowed by the terminal bucket.
+	cks, ok := r.OrphanByKind["SCOPE.Component"]
+	if !ok {
+		t.Fatal("expected OrphanByKind[SCOPE.Component] to be populated")
+	}
+	if cks.OrphanCount != 1 {
+		t.Errorf("SCOPE.Component defect orphans = %d, want 1 (the zero-edge class-subtype Component)", cks.OrphanCount)
+	}
+}
+
+func TestRender_ExpectedTerminalOrphansSection(t *testing.T) {
+	r := &Report{
+		TotalEntities: 100,
+		GeneratedAt:   mustParseTime("2026-05-27T00:00:00Z"),
+		GroupName:     "test-group",
+		OrphanByKind:  map[string]KindStats{"SCOPE.Component": {Total: 20, OrphanCount: 0, OrphanPct: 0.0}},
+		OrphanTerminalByKind: map[string]KindStats{
+			"SCOPE.Component": {Total: 20, OrphanCount: 20, OrphanPct: 100.0},
+		},
+		FrameworkHits: map[string]int{},
+		SanityResults: []SanityResult{{Name: "minimum-entity-count", Passed: true}},
+		Confidence:    100,
+	}
+	var sb strings.Builder
+	if err := Render(&sb, r); err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	out := sb.String()
+	if !strings.Contains(out, "Expected/terminal orphans") {
+		t.Error("expected 'Expected/terminal orphans' section when OrphanTerminalByKind is populated")
+	}
+	if !strings.Contains(out, "SCOPE.Component") {
+		t.Error("expected SCOPE.Component row in the terminal-orphans table")
 	}
 }
 

--- a/internal/feedback/sanity_test.go
+++ b/internal/feedback/sanity_test.go
@@ -147,6 +147,38 @@ func TestRunSanityChecks_FrameworkFilesNoHits(t *testing.T) {
 	}
 }
 
+// TestRunSanityChecks_ContainerTerminalKindNoFalseFailure is the sanity-check
+// parity guard for Fix 4: the orphan-rate-not-100pct check must be evaluated
+// against the POST-classification DEFECT orphan set (r.OrphanByKind), not the
+// raw pre-classification orphan count. A SCOPE.Component kind that is 100%
+// container-terminal (every instance routed to OrphanTerminalByKind by report.go's
+// Fix 3 classification) reports 0% in OrphanByKind and must NOT trip
+// orphan-rate-not-100pct.
+func TestRunSanityChecks_ContainerTerminalKindNoFalseFailure(t *testing.T) {
+	r := &Report{
+		TotalEntities:      200,
+		EntitiesByLanguage: map[string]int{"go": 200},
+		// Every SCOPE.Component instance was classified as container-terminal
+		// (Fix 3), so the DEFECT orphan count/pct is zero even though all 20
+		// instances are orphan by the raw semanticOut==0 test.
+		OrphanByKind: map[string]KindStats{
+			"SCOPE.Component": {Total: 20, OrphanCount: 0, OrphanPct: 0.0},
+		},
+		OrphanTerminalByKind: map[string]KindStats{
+			"SCOPE.Component": {Total: 20, OrphanCount: 20, OrphanPct: 100.0},
+		},
+		ResolutionTotal: 0,
+		FrameworkHits:   map[string]int{},
+	}
+
+	results, _ := runSanityChecks(r)
+	for _, res := range results {
+		if res.Name == "orphan-rate-not-100pct[SCOPE.Component]" && !res.Passed {
+			t.Errorf("orphan-rate-not-100pct[SCOPE.Component] should PASS for a 100%%-container-terminal kind (defect pct is 0%%), note: %s", res.Note)
+		}
+	}
+}
+
 func TestRunSanityChecks_ConfidenceFormula(t *testing.T) {
 	// 1 passing check out of 1 total = 100%
 	r := &Report{


### PR DESCRIPTION
The feedback collector over-reported Schema zero-field rate and Schema/Component orphan rate — a measurement artifact, not a real graph defect. This PR fixes the measurement:

- Field count is now derived by walking CONTAINS/DECLARES edges to field-subtype children (two-pass), instead of trusting a possibly-absent `Properties["field_count"]`; field-leaf entities no longer get miscounted as zero-field classes.
- Field-subtype entities with an inbound structural anchor are excluded from the defect-orphan numerator (they are child leaves, not orphans).
- Genuine pure-container/terminal Component subtypes (file, module, import + pattern-detector terminals) route to an expected-orphan bucket; class/struct/interface/view/service stay in the defect bucket so real resolver/extractor regressions still trip the orphan-rate sanity gate.

This change was independently adversarially reviewed and APPROVED, with the full local gate green: `go build`, `go vet`, `go test ./internal/feedback/... ./internal/cli/...` (539 pass), and `gofmt` clean.

Closes #5823