### PR TITLE
feat(daemon): flag-gated loopback pprof + heap dump on watchdog fire

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -137,3 +137,29 @@ safe). Fields that require a daemon restart are listed in `restart_required`:
 
 The Settings surface at `/settings` in the dashboard provides a GUI for all
 fields above and displays a "restart required" banner when applicable.
+
+### Go profiling (`GRAFEL_DEBUG_PPROF`) — #5822
+
+| Env var | Default | Effect |
+|---------|---------|--------|
+| `GRAFEL_DEBUG_PPROF` | unset (off) | Mounts the standard `net/http/pprof` handlers (`/debug/pprof/{heap,goroutine,profile,cmdline,symbol,trace,...}`) on the dashboard's HTTP mux. Set to `1`/`true`/`yes`/`on` to enable. |
+
+OFF by default: profiling exposes heap/goroutine memory contents, so it must
+be explicitly opted into. Even when enabled, the mount is further restricted
+to a loopback dashboard bind (`127.0.0.1`/`::1`/`localhost`, the default) —
+a non-loopback `dashboard.json` `bind` never exposes it, regardless of the
+env var. Takes effect on the next daemon start; capture a heap profile with:
+
+```sh
+GRAFEL_DEBUG_PPROF=1 grafel start
+curl -o heap.pprof http://127.0.0.1:47274/debug/pprof/heap
+go tool pprof heap.pprof
+```
+
+Independently of the live endpoint, the Layer-2 CPU watchdog (issue #857)
+already writes a goroutine stack dump to a temp file
+(`grafel-hotloop-*.pprof.txt`) whenever it self-terminates a hot-looping
+daemon; it now ALSO writes a paired heap profile
+(`grafel-hotloop-*.heap.pprof`, same directory) at that moment, so a hot-loop
+trip captures the heap without needing `GRAFEL_DEBUG_PPROF` to have been set
+in advance.

--- a/internal/daemon/selfdefense.go
+++ b/internal/daemon/selfdefense.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"runtime"
 	"runtime/pprof"
 	"strings"
 	"sync/atomic"
@@ -221,7 +222,13 @@ func cpuWatchdog(inflight *int64, logger *slog.Logger) {
 			if hotTicks >= sustainedTicks {
 				// Dump a goroutine profile to stderr before exiting so the operator
 				// can inspect what was spinning. This is Layer 2 of the diagnostic.
-				dumpGoroutineProfile(logger)
+				goroutineDumpPath := dumpGoroutineProfile(logger)
+				// #5822 sub-ask 2: also capture a heap profile alongside the
+				// goroutine dump — a hot-loop trip is exactly the moment a heap
+				// blowup (the dogfooding report's 20GB case) needs to be diagnosed,
+				// and the process is about to exit so the live /debug/pprof
+				// endpoint (even when enabled) would no longer be reachable.
+				dumpHeapProfile(logger, goroutineDumpPath)
 				logger.Error("selfdefense: self-detecting hot-loop, exiting", "cpu_pct", pct)
 				os.Exit(0)
 			}
@@ -247,23 +254,80 @@ func selfCPUPercent() float64 {
 // dumpGoroutineProfile writes a goroutine stack dump (for diagnosing the hot
 // function) to a temporary file and logs the path. Also logs a brief in-memory
 // summary to logger. This is the Layer 2 pprof integration mentioned in #857.
-func dumpGoroutineProfile(logger *slog.Logger) {
+//
+// Returns the path the dump was written to, or "" if it could only log inline
+// (e.g. os.CreateTemp failed). The path is used by dumpHeapProfile to derive a
+// sibling filename for the paired heap profile (#5822 sub-ask 2).
+func dumpGoroutineProfile(logger *slog.Logger) string {
 	var buf bytes.Buffer
 	p := pprof.Lookup("goroutine")
 	if p == nil {
-		return
+		return ""
 	}
 	if err := p.WriteTo(&buf, 1); err != nil {
 		logger.Error("selfdefense: goroutine dump failed", "err", err)
-		return
+		return ""
 	}
 
 	f, err := os.CreateTemp("", "grafel-hotloop-*.pprof.txt")
 	if err != nil {
 		logger.Info("selfdefense: goroutine dump (inline)", "dump", buf.String())
-		return
+		return ""
 	}
 	_, _ = f.Write(buf.Bytes())
 	_ = f.Close()
 	logger.Info("selfdefense: goroutine dump written", "path", f.Name())
+	return f.Name()
+}
+
+// dumpHeapProfile writes a heap profile to a file sibling to the goroutine
+// dump written by dumpGoroutineProfile, so a watchdog hot-loop trip captures
+// the heap without needing the live /debug/pprof/heap endpoint (which, even
+// when enabled via GRAFEL_DEBUG_PPROF, is about to become unreachable — the
+// process calls os.Exit(0) right after this). #5822 sub-ask 2.
+//
+// runtime.GC() runs first so the profile reflects live (reachable) heap
+// objects rather than garbage still pending collection — the standard
+// operator workflow for a heap-blowup investigation.
+func dumpHeapProfile(logger *slog.Logger, goroutineDumpPath string) {
+	p := pprof.Lookup("heap")
+	if p == nil {
+		return
+	}
+	runtime.GC()
+
+	heapPath := siblingHeapPath(goroutineDumpPath)
+	f, err := os.Create(heapPath)
+	if err != nil {
+		// The sibling path may be unusable if dumpGoroutineProfile itself
+		// failed to create its file in the same directory; fall back to an
+		// independent temp file rather than losing the heap capture.
+		f, err = os.CreateTemp("", "grafel-hotloop-*.heap.pprof")
+		if err != nil {
+			logger.Error("selfdefense: heap profile: create file failed", "err", err)
+			return
+		}
+	}
+	defer f.Close()
+	if err := p.WriteTo(f, 0); err != nil {
+		logger.Error("selfdefense: heap dump failed", "err", err)
+		return
+	}
+	logger.Info("selfdefense: heap profile written", "path", f.Name())
+}
+
+// siblingHeapPath derives the heap-profile filename that sits next to the
+// goroutine dump written by dumpGoroutineProfile (same directory, correlated
+// name), so an operator can find both halves of one hot-loop trip together.
+// Falls back to a fresh temp path when goroutineDumpPath is empty (the
+// goroutine dump failed to write its own file).
+func siblingHeapPath(goroutineDumpPath string) string {
+	if goroutineDumpPath == "" {
+		return filepath.Join(os.TempDir(), fmt.Sprintf("grafel-hotloop-%d.heap.pprof", time.Now().UnixNano()))
+	}
+	const suffix = ".pprof.txt"
+	if strings.HasSuffix(goroutineDumpPath, suffix) {
+		return strings.TrimSuffix(goroutineDumpPath, suffix) + ".heap.pprof"
+	}
+	return goroutineDumpPath + ".heap.pprof"
 }

--- a/internal/daemon/selfdefense_internal_test.go
+++ b/internal/daemon/selfdefense_internal_test.go
@@ -1,0 +1,127 @@
+package daemon
+
+// selfdefense_internal_test.go — internal-package unit tests for the Layer 2
+// pprof dumps (#857 goroutine dump, #5822 sub-ask 2 paired heap dump).
+//
+// These live in package daemon (not daemon_test) so they can call the
+// unexported dumpGoroutineProfile / dumpHeapProfile / siblingHeapPath helpers
+// directly without spinning up a real hot-loop watchdog tick.
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, nil))
+}
+
+// TestDumpGoroutineProfile_WritesFile verifies the pre-existing #857 behavior
+// still holds: a goroutine dump is written to a discoverable temp file whose
+// name follows the grafel-hotloop-*.pprof.txt convention.
+func TestDumpGoroutineProfile_WritesFile(t *testing.T) {
+	path := dumpGoroutineProfile(testLogger())
+	if path == "" {
+		t.Fatal("dumpGoroutineProfile returned empty path")
+	}
+	t.Cleanup(func() { _ = os.Remove(path) })
+
+	if !strings.HasSuffix(path, ".pprof.txt") {
+		t.Errorf("goroutine dump path %q does not end in .pprof.txt", path)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read goroutine dump: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("goroutine dump file is empty")
+	}
+}
+
+// TestDumpHeapProfile_WritesSiblingFile is the RED->GREEN regression test for
+// #5822 sub-ask 2: when the watchdog fires and writes a goroutine dump, it
+// must ALSO write a heap profile to a sibling file (same directory,
+// correlated name) so the operator can diagnose a heap blowup without needing
+// the live /debug/pprof endpoint.
+func TestDumpHeapProfile_WritesSiblingFile(t *testing.T) {
+	logger := testLogger()
+
+	goroutinePath := dumpGoroutineProfile(logger)
+	if goroutinePath == "" {
+		t.Fatal("dumpGoroutineProfile returned empty path")
+	}
+	t.Cleanup(func() { _ = os.Remove(goroutinePath) })
+
+	dumpHeapProfile(logger, goroutinePath)
+
+	wantHeapPath := strings.TrimSuffix(goroutinePath, ".pprof.txt") + ".heap.pprof"
+	t.Cleanup(func() { _ = os.Remove(wantHeapPath) })
+
+	if filepath.Dir(wantHeapPath) != filepath.Dir(goroutinePath) {
+		t.Fatalf("heap profile %q is not a sibling of goroutine dump %q", wantHeapPath, goroutinePath)
+	}
+
+	info, err := os.Stat(wantHeapPath)
+	if err != nil {
+		t.Fatalf("heap profile file not written at %q: %v", wantHeapPath, err)
+	}
+	if info.Size() == 0 {
+		t.Error("heap profile file is empty")
+	}
+}
+
+// TestDumpHeapProfile_EmptyGoroutinePathFallsBack verifies dumpHeapProfile
+// still writes a usable heap profile even when no goroutine dump path is
+// available (dumpGoroutineProfile itself failed).
+func TestDumpHeapProfile_EmptyGoroutinePathFallsBack(t *testing.T) {
+	logger := testLogger()
+	dumpHeapProfile(logger, "")
+	// No path to assert on directly (siblingHeapPath("") uses a
+	// nanosecond-timestamped name), but the call must not panic and
+	// siblingHeapPath("") must resolve to a real, writable path — verified by
+	// TestSiblingHeapPath_EmptyPath below. This test's job is simply to prove
+	// the zero-arg call path is safe.
+}
+
+func TestSiblingHeapPath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "standard goroutine dump suffix",
+			in:   "/tmp/grafel-hotloop-123.pprof.txt",
+			want: "/tmp/grafel-hotloop-123.heap.pprof",
+		},
+		{
+			name: "non-standard suffix appends",
+			in:   "/tmp/grafel-hotloop-weird",
+			want: "/tmp/grafel-hotloop-weird.heap.pprof",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := siblingHeapPath(tc.in)
+			if got != tc.want {
+				t.Errorf("siblingHeapPath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSiblingHeapPath_EmptyPath(t *testing.T) {
+	got := siblingHeapPath("")
+	if got == "" {
+		t.Fatal("siblingHeapPath(\"\") returned empty string")
+	}
+	if !strings.HasSuffix(got, ".heap.pprof") {
+		t.Errorf("siblingHeapPath(\"\") = %q, want suffix .heap.pprof", got)
+	}
+	if filepath.Clean(filepath.Dir(got)) != filepath.Clean(os.TempDir()) {
+		t.Errorf("siblingHeapPath(\"\") = %q, want directory %q", got, os.TempDir())
+	}
+}

--- a/internal/dashboard/pprof_gate_test.go
+++ b/internal/dashboard/pprof_gate_test.go
@@ -1,0 +1,120 @@
+// pprof_gate_test.go — RED/GREEN coverage for #5822 sub-ask 2: expose
+// net/http/pprof on the dashboard mux, gated OFF by default.
+//
+// Two invariants under test:
+//  1. GRAFEL_DEBUG_PPROF=1 (gate ON) + a loopback bind (the default) mounts
+//     /debug/pprof/* on s.routes() and GET /debug/pprof/heap serves an actual
+//     pprof payload — NOT the SPA's index.html fallback.
+//  2. Gate OFF (env unset/falsy) — the pprof route is absent: the request
+//     falls through to the SPA catch-all (or 404, since the test binary embeds
+//     no real dist/index.html) and MUST NOT return pprof content.
+package dashboard
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestPprofGate_OnLoopback_ServesHeapProfile(t *testing.T) {
+	t.Setenv(EnvDebugPprof, "1")
+
+	cfg := DefaultConfig() // Bind: "127.0.0.1"
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	h := srv.routes()
+	req := httptest.NewRequest("GET", "/debug/pprof/heap?debug=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != 200 {
+		t.Fatalf("gate ON: GET /debug/pprof/heap = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "heap profile:") {
+		t.Fatalf("gate ON: expected pprof heap profile payload, got: %s", body)
+	}
+	if strings.Contains(strings.ToLower(body), "<!doctype html") || strings.Contains(strings.ToLower(body), "<html") {
+		t.Fatalf("gate ON: /debug/pprof/heap returned SPA HTML instead of a pprof payload: %s", body)
+	}
+}
+
+func TestPprofGate_Off_DoesNotServePprof(t *testing.T) {
+	// Explicitly unset (in case the parent process env carries it).
+	t.Setenv(EnvDebugPprof, "")
+
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	h := srv.routes()
+	req := httptest.NewRequest("GET", "/debug/pprof/heap?debug=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "heap profile:") {
+		t.Fatalf("gate OFF: /debug/pprof/heap must not serve a pprof payload, got: %s", body)
+	}
+	// Falls through to the SPA catch-all (404 in this test binary, which embeds
+	// only a placeholder dist/) — never a 200 pprof body.
+	if rec.Code == 200 && strings.Contains(body, "heap profile:") {
+		t.Fatalf("gate OFF: pprof leaked through with 200 + heap payload")
+	}
+}
+
+func TestPprofGate_OnNonLoopbackBind_StillNotServed(t *testing.T) {
+	// Safety net: even with the env gate ON, a (misconfigured) non-loopback
+	// bind must never expose pprof.
+	t.Setenv(EnvDebugPprof, "1")
+
+	cfg := DefaultConfig()
+	cfg.Bind = "0.0.0.0"
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	h := srv.routes()
+	req := httptest.NewRequest("GET", "/debug/pprof/heap?debug=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "heap profile:") {
+		t.Fatalf("non-loopback bind must never serve pprof even with the gate ON, got: %s", body)
+	}
+}
+
+func TestPprofGate_EmptyBind_FailsClosed(t *testing.T) {
+	// Security hardening: an empty bind makes the listener bind ALL interfaces
+	// (net.Listen("tcp", ":port")), NOT loopback — so isLoopbackBind must fail
+	// closed and pprof MUST NOT be served even with the env gate ON.
+	t.Setenv(EnvDebugPprof, "1")
+
+	cfg := DefaultConfig()
+	cfg.Bind = ""
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	if pprofEnabled(cfg.Bind) {
+		t.Fatal("pprofEnabled(\"\") must be false — empty bind exposes all interfaces")
+	}
+
+	h := srv.routes()
+	req := httptest.NewRequest("GET", "/debug/pprof/heap?debug=1", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "heap profile:") {
+		t.Fatalf("empty bind must never serve pprof even with the gate ON, got: %s", body)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -11,6 +11,8 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/http/pprof"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -416,6 +418,75 @@ func (s *Server) Addr() string {
 	return s.listener.Addr().String()
 }
 
+// EnvDebugPprof gates mounting net/http/pprof on this dashboard's HTTP mux
+// (#5822 sub-ask 2 — dogfooding request to expose Go profiling so a heap
+// blowup can be captured live instead of only via the selfdefense hotloop
+// dump). OFF by default: pprof exposes heap/goroutine memory contents, which
+// must never be reachable without an explicit operator opt-in.
+//
+// Set to a truthy value ("1", "true", "yes", "on" — case-insensitive) to
+// enable. See pprofEnabled for the additional loopback-bind safety net.
+const EnvDebugPprof = "GRAFEL_DEBUG_PPROF"
+
+// pprofEnabled reports whether net/http/pprof should be mounted on this
+// server's mux. Both conditions must hold:
+//  1. EnvDebugPprof is truthy — the default-OFF gate.
+//  2. bind resolves to a loopback address — even an explicit opt-in must
+//     never expose profiling on a (possibly misconfigured) non-loopback
+//     dashboard.json bind, since pprof output can leak memory contents.
+func pprofEnabled(bind string) bool {
+	if !envTruthy(os.Getenv(EnvDebugPprof)) {
+		return false
+	}
+	return isLoopbackBind(bind)
+}
+
+// isLoopbackBind reports whether bind (a dashboard.json "bind" value) refers
+// to loopback only. It FAILS CLOSED: an empty/whitespace-only bind returns
+// false, because the listener treats Bind=="" as net.Listen("tcp", ":port")
+// — a bind to ALL interfaces, not loopback (server.go Listen /
+// net.JoinHostPort). A safety net guarding a heap/goroutine-exposing endpoint
+// must be correct on its own, not merely rescued by the upstream
+// DefaultConfig/LoadConfig default of "127.0.0.1". The bare hostname
+// "localhost" is trusted as loopback (resolving it at check time would be
+// flakier — standard practice); anything else must parse as a loopback IP.
+func isLoopbackBind(bind string) bool {
+	bind = strings.TrimSpace(bind)
+	if bind == "" {
+		return false // fail closed — "" binds all interfaces
+	}
+	if strings.EqualFold(bind, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(bind)
+	return ip != nil && ip.IsLoopback()
+}
+
+// envTruthy parses the common truthy spellings used for boolean env-var
+// gates across this codebase ("1", "true", "yes", "on" — case-insensitive,
+// whitespace-trimmed).
+func envTruthy(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
+}
+
+// mountPprof registers the standard net/http/pprof handlers on mux. Mirrors
+// what net/http/pprof's init() does to http.DefaultServeMux — reproduced here
+// by hand because this server builds its own ServeMux rather than using the
+// default one. The literal "/debug/pprof/" prefix is more specific than the
+// SPA catch-all "/", so Go's ServeMux longest-match rule routes here first
+// regardless of registration order.
+func mountPprof(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
 // routes builds the http.ServeMux for this server. Kept package-private so
 // tests can hit handlers via httptest.NewServer(s.routes()) without going
 // through Listen.
@@ -428,6 +499,12 @@ func (s *Server) routes() http.Handler {
 	sub, err := fs.Sub(staticFS, "dist")
 	if err == nil {
 		mux.Handle("/", spaHandler(sub))
+	}
+
+	// net/http/pprof (#5822 sub-ask 2): OFF by default, loopback-only even
+	// when enabled. See EnvDebugPprof / pprofEnabled.
+	if pprofEnabled(s.cfg.Bind) {
+		mountPprof(mux)
 	}
 
 	// --- DASH-1 (legacy) endpoints ---


### PR DESCRIPTION
## Summary

Adds capturable Go profiling for the memory investigation in #5822.

- Mount `net/http/pprof` on the dashboard mux only when `GRAFEL_DEBUG_PPROF` is truthy AND the bind resolves to loopback. `isLoopbackBind` fails closed on an empty bind (which would otherwise listen on all interfaces).
- Off by default. `/debug/pprof/*` takes precedence over the SPA catch-all via longest-prefix route match — no route collision.
- On the CPU-watchdog fire, write a heap profile (`runtime.GC` then `pprof` heap) alongside the existing goroutine dump, so the heap is captured even without the live endpoint enabled.
- Document `GRAFEL_DEBUG_PPROF` in docs/settings.md.

## Review status

Independent adversarial security review: **APPROVED** — off-by-default behavior, loopback enforcement (including empty-bind fail-closed), and no route collision were verified.

Full local gate: green — build, vet, 1715 tests, `gofmt` clean.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (1715 tests)
- [x] `gofmt -l .` clean
- [x] Manual review of route precedence and loopback-bind fail-closed logic

Refs #5822