### PR TITLE
fix(csharp): resolve file-scoped namespace imports

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1674,6 +1674,16 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		return name, subtype, true
 	}
 
+	// #4704 — .NET/C# (nuget/BCL) external-package catch-all. Run before the
+	// generic dotted-root branch so C# using directives keep module+leaf
+	// identity (ext:System.Collections:Generic) instead of collapsing to
+	// ext:System, which the import-health audit treats as unqualified.
+	if lang == "csharp" && relKind == string(types.RelationshipKindImports) {
+		if pkg, ok := csharpExternalPackageRoot(stub, relProps, internal.csharp); ok {
+			return pkg, "package", true
+		}
+	}
+
 	// Dotted path → first segment is what we canonicalise to. Common
 	// shape for Python imports ("django.db.models" -> "django") or
 	// JS submodules ("lodash.debounce" -> "lodash").
@@ -1792,21 +1802,6 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 	// lang==rust.
 	if lang == "rust" && relKind == string(types.RelationshipKindImports) {
 		if pkg, ok := rustExternalPackageRoot(stub, relProps, internal.rust); ok {
-			return pkg, "package", true
-		}
-	}
-
-	// #4704 — .NET/C# (nuget/BCL) external-package catch-all. A `using
-	// Namespace;` whose root namespace is NOT owned by this repo (root ∉
-	// internalCsharpRoots) AND either matches a known BCL/common-nuget root
-	// (System, Microsoft, Newtonsoft, …) or is otherwise a non-internal
-	// dotted namespace is an external dependency. C# is the hardest case (no
-	// import-vs-namespace marker), so this DELIBERATELY under-flags: when a
-	// root is neither known-BCL nor provably external, it falls through and
-	// keeps its bug disposition rather than masking a possibly-internal
-	// namespace. Internal roots STAY a bug. Gated to IMPORTS + lang==csharp.
-	if lang == "csharp" && relKind == string(types.RelationshipKindImports) {
-		if pkg, ok := csharpExternalPackageRoot(stub, relProps, internal.csharp); ok {
 			return pkg, "package", true
 		}
 	}
@@ -3275,9 +3270,10 @@ var csharpBclRoots = map[string]bool{
 	"npgsql":           true,
 	"restsharp":        true,
 	"grpc":             true,
+	"volo":             true, // Volo.Abp.*
 }
 
-// csharpExternalPackageRoot derives the canonical nuget/BCL root for a C#
+// csharpExternalPackageRoot derives the canonical nuget/BCL namespace for a C#
 // `using Namespace;` IMPORTS edge (#4704). The raw namespace is read from
 // relProps["import_path"] / relProps["source_module"] when present and falls
 // back to the dotted stub.
@@ -3287,11 +3283,14 @@ var csharpBclRoots = map[string]bool{
 //   - root segment ∈ internalCsharpRoots                        → reject
 //     (genuinely-internal namespace that failed to resolve — STILL a bug).
 //   - root ∈ csharpBclRoots                                     → external.
-//   - any other root                                            → reject
-//     (ambiguous; keep the bug rather than mask a possibly-internal namespace).
+//   - any other root                                            → reject.
 func csharpExternalPackageRoot(stub string, relProps map[string]string, internalCsharpRoots map[string]bool) (string, bool) {
 	spec := stub
+	sourceModule := ""
+	importedName := ""
 	if relProps != nil {
+		sourceModule = strings.TrimSpace(relProps["source_module"])
+		importedName = strings.TrimSpace(relProps["imported_name"])
 		for _, key := range []string{"import_path", "source_module"} {
 			if v := strings.TrimSpace(relProps[key]); v != "" {
 				spec = v
@@ -3329,12 +3328,22 @@ func csharpExternalPackageRoot(stub string, relProps map[string]string, internal
 			return "", false
 		}
 	}
-	// Only fire for a known BCL/nuget root. Everything else is ambiguous and
-	// deliberately left as a bug (under-flag, never mask).
-	if csharpBclRoots[lower] {
-		return lower, true
+	if !csharpBclRoots[lower] {
+		return "", false
 	}
-	return "", false
+	if sourceModule == "" || importedName == "" {
+		if dot := strings.LastIndexByte(spec, '.'); dot > 0 {
+			sourceModule = spec[:dot]
+			importedName = spec[dot+1:]
+		} else {
+			sourceModule = spec
+			importedName = root
+		}
+	}
+	if sourceModule == "" || importedName == "" {
+		return "", false
+	}
+	return sourceModule + ":" + importedName, true
 }
 
 // isCsharpNamespaceSegment reports whether s is a legal C# namespace segment

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -806,8 +806,8 @@ func TestSynthesize_RustKeywordStillBug(t *testing.T) {
 }
 
 // TestSynthesize_CsharpExternalPackages_Fixture is Fixture A for #4704: BCL /
-// nuget `using` directives (System.*, Microsoft.*, Newtonsoft.Json) must route
-// to ext:<root> and none may be a fidelity bug.
+// nuget `using` directives (System.*, Microsoft.*, Newtonsoft.Json, Volo.Abp)
+// must route to ext:<module>:<leaf> and none may be a fidelity bug.
 func TestSynthesize_CsharpExternalPackages_Fixture(t *testing.T) {
 	doc := &graph.Document{
 		Entities: []graph.Entity{
@@ -821,18 +821,22 @@ func TestSynthesize_CsharpExternalPackages_Fixture(t *testing.T) {
 				Properties: map[string]string{"language": "csharp", "import_path": "Microsoft.AspNetCore.Mvc"}},
 			{ID: "rel-3", FromID: "aaaaaaaaaaaaaaaa", ToID: "Newtonsoft.Json", Kind: "IMPORTS",
 				Properties: map[string]string{"language": "csharp", "import_path": "Newtonsoft.Json"}},
+			{ID: "rel-4", FromID: "aaaaaaaaaaaaaaaa", ToID: "Volo.Abp.Application.Dtos", Kind: "IMPORTS",
+				Properties: map[string]string{
+					"language":      "csharp",
+					"source_module": "Volo.Abp.Application",
+					"imported_name": "Dtos",
+				}},
 		},
 	}
 	Synthesize(doc)
-	// System / Microsoft are on the pre-existing static allowlist and are
-	// externalised verbatim (PascalCase) by the dotted-path branch before the
-	// #4704 catch-all. Newtonsoft is NOT on the static list — it is the real
-	// #4704 win, routed to a lowercased nuget placeholder by the catch-all.
-	// All three are external (not fidelity bugs), which is the issue's goal.
+	// C# IMPORTS preserve module + leaf so the quality audit classifies the
+	// external as ext_qualified instead of ext_bare.
 	want := map[string]string{
-		"rel-1": "ext:System",
-		"rel-2": "ext:Microsoft",
-		"rel-3": "ext:newtonsoft",
+		"rel-1": "ext:System.Collections:Generic",
+		"rel-2": "ext:Microsoft.AspNetCore:Mvc",
+		"rel-3": "ext:Newtonsoft:Json",
+		"rel-4": "ext:Volo.Abp.Application:Dtos",
 	}
 	for _, r := range doc.Relationships {
 		if exp, ok := want[r.ID]; ok && r.ToID != exp {

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -75,7 +75,7 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	// aliases, `using static` types) used to bind qualified cross-namespace
 	// calls to a concrete (namespace, type, leaf) for the resolver.
 	cross := buildCrossCtx(root, file.Content)
-	walk(root, file, "", "", nil, imports, cross, &entities)
+	walk(root, file, "", fileScopedNamespace(root, file.Content), nil, imports, cross, &entities)
 	// Issue #3641 (epic #3625) — config-key consumption edges
 	// (Configuration["X"] / GetValue / GetConnectionString /
 	// Environment.GetEnvironmentVariable) → shared SCOPE.Config config_key nodes.
@@ -90,6 +90,22 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	extractor.TagRelationshipsLanguage(entities, "csharp")
 	extractor.TagEntitiesLanguage(entities, "csharp")
 	return entities, nil
+}
+
+func fileScopedNamespace(root ts.Node, src []byte) string {
+	if root == nil {
+		return ""
+	}
+	for i := range root.ChildCount() {
+		ch := root.Child(int(i))
+		if ch == nil || ch.Type() != "file_scoped_namespace_declaration" {
+			continue
+		}
+		if nf := ch.ChildByFieldName("name"); nf != nil {
+			return strings.TrimSpace(nodeText(nf, src))
+		}
+	}
+	return ""
 }
 
 // classCtx carries the resolution context for cross-file receiver
@@ -453,6 +469,7 @@ func buildImport(node ts.Node, file extractor.FileInput) (types.EntityRecord, bo
 		leaf = raw[dot+1:]
 		mod = raw[:dot]
 	}
+	props["language"] = "csharp"
 	props["source_module"] = mod
 	props["imported_name"] = leaf
 	if alias != "" {

--- a/internal/extractors/csharp/issue4374_crossns_test.go
+++ b/internal/extractors/csharp/issue4374_crossns_test.go
@@ -86,6 +86,8 @@ func is16Hex(s string) bool {
 }
 
 func runCSharpResolve(merged []types.EntityRecord) int {
+	importTbl := resolve.BuildImportTable(merged)
+	resolve.ResolveImports(merged, importTbl)
 	idx := resolve.BuildIndex(merged)
 	n := idx.ResolveCSharpCrossNamespaceCalls(merged)
 	resolve.ReferencesEmbedded(merged, idx)
@@ -119,6 +121,64 @@ func entID(merged []types.EntityRecord, srcFile, name string) string {
 		}
 	}
 	return ""
+}
+
+func importEdge(merged []types.EntityRecord, srcFile, target string) (string, map[string]string, bool) {
+	for k := range merged {
+		if merged[k].SourceFile != srcFile {
+			continue
+		}
+		for _, r := range merged[k].Relationships {
+			if r.Kind == "IMPORTS" && r.ToID == target {
+				return r.ToID, r.Properties, true
+			}
+		}
+	}
+	return "", nil, false
+}
+
+func TestCSharpImportsResolveViaNamespaceProperty(t *testing.T) {
+	files := map[string]string{
+		"src/Domain/Order.cs": "" +
+			"namespace Acme.Shop.Domain;\n" +
+			"public class Order {}\n",
+		"src/App/Handler.cs": "" +
+			"using Acme.Shop.Domain;\n" +
+			"namespace Acme.Shop.App;\n" +
+			"public class Handler {}\n",
+	}
+	merged := extractCSharpProjectForTest(t, files)
+	before, props, ok := importEdge(merged, "src/App/Handler.cs", "Acme.Shop.Domain")
+	if !ok {
+		t.Fatalf("missing C# IMPORTS edge before resolve")
+	}
+	if props["language"] != "csharp" {
+		t.Fatalf("C# IMPORTS edge missing language property: ToID=%q props=%v", before, props)
+	}
+
+	importTbl := resolve.BuildImportTable(merged)
+	stats := resolve.ResolveImports(merged, importTbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 C# IMPORTS rewrite, got %d/%d", stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	want := entID(merged, "src/Domain/Order.cs", "Order")
+	if want == "" {
+		t.Fatal("missing Order entity")
+	}
+	found := false
+	for _, e := range merged {
+		if e.SourceFile != "src/App/Handler.cs" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" && r.ToID == want {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("C# IMPORTS edge was not rewritten to Order entity %q", want)
+	}
 }
 
 // colliding callee namespaces: App.Services.Orders.OrderService.Place AND

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -329,6 +329,11 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 		}
 
 		modules := modulesForFile(normalizePath(e.SourceFile))
+		if e.Language == "csharp" && e.Properties != nil {
+			if ns := strings.TrimSpace(e.Properties["csharp_namespace"]); ns != "" {
+				modules = append(modules, ns)
+			}
+		}
 
 		// Refs #44 — Python module-level IMPORTS resolution. When the
 		// extractor emits `from users import views` it produces an IMPORTS
@@ -1530,6 +1535,16 @@ func (t ImportTable) ResolvePythonModuleImport(dotted string) (string, bool) {
 	return id, true
 }
 
+func isCSharpImportSource(entityLang, callerFile string, props map[string]string) bool {
+	if props != nil && props["language"] == "csharp" {
+		return true
+	}
+	if entityLang == "csharp" {
+		return true
+	}
+	return strings.HasSuffix(strings.ToLower(callerFile), ".cs")
+}
+
 // ResolveDottedImportTargetForJS performs the same (module, leaf) lookup
 // as ResolveDottedImportTarget, plus a JS/TS-specific default-export
 // fallback (PLT #537). React / React Native source files commonly emit a
@@ -2139,6 +2154,9 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 					id, ok = tbl.ResolveDottedImportTargetForJS(normalized)
 				} else {
 					id, ok = tbl.ResolveDottedImportTarget(normalized)
+					if !ok && isCSharpImportSource(e.Language, callerFile, rel.Properties) {
+						id, ok = tbl.resolveNamespaceTarget(normalized)
+					}
 					// Issue #778 — Java FQCN ambiguity tie-break.
 					// When the generic dotted-import lookup fails because
 					// (module, name) is ambiguous AND the edge carries explicit

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -423,6 +423,75 @@ func TestResolveImports_DottedImportEdgePackageInit(t *testing.T) {
 	}
 }
 
+func TestResolveImports_CSharpTypeImportUsesNamespaceProperty(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("src/App/Handler.cs", "Acme.Shop.Domain.Order", map[string]string{
+			"language":      "csharp",
+			"local_name":    "Order",
+			"source_module": "Acme.Shop.Domain",
+			"imported_name": "Order",
+		}),
+		{
+			ID:         "aaaaaaaaaaaaaaaa",
+			Name:       "Order",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Domain/Order.cs",
+			Language:   "csharp",
+			Properties: map[string]string{"csharp_namespace": "Acme.Shop.Domain"},
+		},
+	}
+
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 C# IMPORTS rewrite, got %d (considered=%d)", stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	if got := records[0].Relationships[0].ToID; got != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("expected C# IMPORTS ToID rewritten to class entity, got %q", got)
+	}
+}
+
+func TestResolveImports_CSharpNamespaceImportBindsRepresentativeEntity(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID:         "cccccccccccccccc",
+			Name:       "Acme.Shop.Domain",
+			Kind:       "SCOPE.Component",
+			SourceFile: "src/App/Handler.cs",
+			Language:   "csharp",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "src/App/Handler.cs",
+				ToID:   "Acme.Shop.Domain",
+				Kind:   importRelKind,
+				Properties: map[string]string{
+					"local_name":    "Domain",
+					"source_module": "Acme.Shop",
+					"imported_name": "Domain",
+				},
+			}},
+		},
+		{
+			ID:         "bbbbbbbbbbbbbbbb",
+			Name:       "Order",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Domain/Order.cs",
+			Language:   "csharp",
+			Properties: map[string]string{"csharp_namespace": "Acme.Shop.Domain"},
+		},
+	}
+
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 C# namespace IMPORTS rewrite, got %d (considered=%d)", stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	if got := records[0].Relationships[0].ToID; got != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("expected C# namespace IMPORTS ToID rewritten to representative entity, got %q", got)
+	}
+}
+
 // TestResolveImports_DottedImportEdgeExternalLeftAlone covers
 // `from marshmallow import Schema` where marshmallow is NOT in the
 // corpus. The dotted ToID "marshmallow.Schema" must be left alone so


### PR DESCRIPTION
## Summary

- Detect file-scoped namespaces at the C# compilation-unit root.
- Carry the active namespace into root-level extraction without changing block-scoped namespace behavior.
- Resolve namespace imports and external synthesis across files.
- Add regression coverage for file-scoped and cross-namespace cases.

## Closes / Refs

Closes #5832

## Testing

- [x] `go test -p 1 ./internal/extractors/csharp ./internal/resolve ./internal/external`
- [x] `git diff --check main..HEAD`

## Notes

The focused test command uses `-p 1` to avoid unbounded parallel test binaries on constrained development machines.
