### PR TITLE
feat(daemon): configure memory limits via settings

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -143,6 +143,9 @@ const defaultDashboardPort = 47274
 // it (delta-based accounting).  See internal/daemon/sched for the admission
 // logic.
 func defaultRSSBudgetMB() int64 {
+	if configured := daemon.ConfiguredRSSBudgetMB(); configured > 0 {
+		return configured
+	}
 	sysMB := systemTotalMemoryMB()
 	if sysMB <= 0 {
 		return 500 // safe fallback when sysinfo is unavailable

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,7 +32,8 @@ fall back to the defaults below.
 | `update_channel` | string | `"stable"` | `"stable"` \| `"dev"` | `"dev"` includes release candidates |
 | `refresh_schedule` | string | `""` | cron expression or `""` | Empty = manual-only refresh; e.g. `"0 3 * * *"` for 03:00 daily |
 | `telemetry_enabled` | bool | `false` | `true` \| `false` | Opt-in anonymous usage metrics |
-| `daemon_rss_budget_mb` | int | `512` | 100–2000 | Maximum RSS the daemon may use before it sheds loaded graphs. **Requires daemon restart.** |
+| `daemon_rss_budget_mb` | int | `512` | 100–32768 | Admission budget, in MB, for predicted concurrent index-job RSS. **Requires daemon restart.** |
+| `daemon_go_memory_limit_mb` | int | automatic | 100–32768 | Optional Go runtime soft memory limit. When omitted, Grafel uses the upstream fraction-of-RAM formula and clamps it to 2048–2560 MB. **Requires daemon restart.** |
 | `watcher_debounce_secs` | int | `2` | 1–60 | How long to wait after a file change before triggering a re-index |
 | `indexer_parallelism` | int | `4` | 1–32 | Number of parallel goroutines used during indexing. **Requires daemon restart.** |
 | `log_level` | string | `"info"` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | Daemon log verbosity |
@@ -99,11 +100,34 @@ still read once at process start and cannot change in a running daemon —
   (`kill -HUP <daemon-pid>`): the daemon re-reads `cpu.json` and calls
   `runtime.GOMAXPROCS` immediately. Clearing the cap restores the host default.
 
-The remaining knobs in this doc (`daemon_rss_budget_mb`, `indexer_parallelism`,
+The remaining knobs in this doc (`daemon_rss_budget_mb`, `daemon_go_memory_limit_mb`, `indexer_parallelism`,
 `GRAFEL_REBUILD_CONCURRENCY`, the `GRAFEL_MAX_*` budgets) are still
 **read at daemon start** and require `grafel restart` to apply.
 
 ## API endpoints
+
+### Memory precedence
+
+Grafel uses two independent memory controls. `daemon_rss_budget_mb` limits the
+predicted incremental RSS admitted for concurrently running index jobs; it is
+not a process RSS cap. `daemon_go_memory_limit_mb` sets Go's soft runtime memory
+limit, which increases GC pressure near the configured value but may be
+exceeded transiently.
+
+The Go soft-limit precedence is `GOMEMLIMIT` >
+`GRAFEL_DAEMON_MEMLIMIT_MB` > `daemon_go_memory_limit_mb` > the built-in
+fraction-of-RAM default. Omitting the JSON key therefore preserves upstream
+behavior exactly.
+
+For example, a workstation can opt into an 8 GB admission budget and an 8 GB
+Go soft limit while leaving all other settings unchanged:
+
+```json
+{
+  "daemon_rss_budget_mb": 8192,
+  "daemon_go_memory_limit_mb": 8192
+}
+```
 
 | Method | Path | Description |
 |--------|------|-------------|

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -44,7 +44,7 @@ Use 'grafel dashboard' to open the dashboard in your browser.`,
 		},
 	}
 	cmd.Flags().Int64Var(&maxRSSBudget, "max-rss-budget", 0,
-		"max predicted RSS (MB) for concurrent index jobs (0 = use daemon default of 500)")
+		"max predicted RSS (MB) for concurrent index jobs; persists to settings.json (0 = configured/auto)")
 	cmd.Flags().BoolVar(&noAutoCleanup, "no-auto-cleanup", false,
 		"disable the background docgen cleanup sweeper (default: enabled)")
 	return cmd
@@ -226,6 +226,11 @@ func runDaemonStartOpts(out io.Writer, maxRSSBudgetMB int64, noAutoCleanup bool)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		return err
+	}
+	if maxRSSBudgetMB > 0 {
+		if err := daemon.PersistConfiguredRSSBudgetMB(maxRSSBudgetMB); err != nil {
+			return fmt.Errorf("persist --max-rss-budget: %w", err)
+		}
 	}
 	// Already running? net.Dial succeeds → check for binary mismatch (#855).
 	if c, err := client.DialPath(layout.SocketPath); err == nil {

--- a/internal/daemon/memlimit.go
+++ b/internal/daemon/memlimit.go
@@ -57,7 +57,8 @@ const memLimitFloorMB int64 = 2048
 //  1. If the standard GOMEMLIMIT env var is already set, the Go runtime has
 //     already honored it — we do nothing and log that we deferred to it.
 //  2. GRAFEL_DAEMON_MEMLIMIT_MB (MB; "off"/"0"/negative disables).
-//  3. Default: memLimitFraction of total system RAM, clamped to
+//  3. daemon_go_memory_limit_mb from settings.json.
+//  4. Default: memLimitFraction of total system RAM, clamped to
 //     [memLimitFloorMB, memLimitCeilingMB]. If total RAM is unknown (0), we
 //     fall back to the floor.
 //
@@ -101,8 +102,11 @@ func resolveMemLimitMB() (int64, string) {
 			}
 			return mb, memLimitEnv
 		}
-		// Unparseable override: fall through to the RAM-fraction default
-		// rather than guessing.
+		// Unparseable override: fall through to settings/default rather than
+		// guessing.
+	}
+	if mb := ConfiguredGoMemoryLimitMB(); mb > 0 {
+		return mb, "settings.json:daemon_go_memory_limit_mb"
 	}
 
 	totalMB := process.TotalMemoryMB()
@@ -134,7 +138,8 @@ func ResolveMemLimitMB() (int64, string) {
 // MemLimitSummary returns the effective Go soft memory limit the daemon
 // would apply, honoring the same precedence as applyMemoryLimit:
 //
-//	explicit GOMEMLIMIT > GRAFEL_DAEMON_MEMLIMIT_MB > fraction-of-RAM default.
+//	explicit GOMEMLIMIT > GRAFEL_DAEMON_MEMLIMIT_MB > settings.json >
+//	fraction-of-RAM default.
 //
 // It returns the limit in MB (<=0 means disabled / unbounded) and a short
 // source tag. When an explicit GOMEMLIMIT is set, mb is reported as 0 with

--- a/internal/daemon/memlimit_test.go
+++ b/internal/daemon/memlimit_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"os"
+	"path/filepath"
 	"runtime/debug"
 	"strings"
 	"testing"
@@ -36,6 +38,7 @@ func TestResolveMemLimitMB_Disabled(t *testing.T) {
 // big-RAM hosts (#5237); the floor protects tiny hosts.
 func TestResolveMemLimitMB_DefaultClamped(t *testing.T) {
 	t.Setenv(memLimitEnv, "") // ensure no override
+	t.Setenv("GRAFEL_HOME", t.TempDir())
 	mb, src := resolveMemLimitMB()
 	if mb < memLimitFloorMB {
 		t.Errorf("default limit %d below floor %d (src=%s)", mb, memLimitFloorMB, src)
@@ -56,6 +59,25 @@ func TestResolveMemLimitMB_DefaultClamped(t *testing.T) {
 			t.Errorf("default limit: want %d (%.0f%% of %dMB, clamped to [%d,%d]) got %d",
 				want, memLimitFraction*100, total, memLimitFloorMB, memLimitCeilingMB, mb)
 		}
+	}
+}
+
+func TestResolveMemLimitMB_SettingsOverride(t *testing.T) {
+	t.Setenv(memLimitEnv, "")
+	t.Setenv("GOMEMLIMIT", "")
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	if err := os.WriteFile(filepath.Join(home, "settings.json"), []byte(`{"daemon_go_memory_limit_mb":8192}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mb, src := resolveMemLimitMB()
+	if mb != 8192 || src != "settings.json:daemon_go_memory_limit_mb" {
+		t.Fatalf("settings override: got mb=%d src=%q", mb, src)
+	}
+
+	t.Setenv(memLimitEnv, "4096")
+	if mb, src := resolveMemLimitMB(); mb != 4096 || src != memLimitEnv {
+		t.Fatalf("env must win over settings: got mb=%d src=%q", mb, src)
 	}
 }
 

--- a/internal/daemon/rss_budget_settings.go
+++ b/internal/daemon/rss_budget_settings.go
@@ -1,0 +1,138 @@
+package daemon
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+const (
+	MinConfiguredRSSBudgetMB     = 100
+	MaxConfiguredRSSBudgetMB     = 32768
+	MinConfiguredGoMemoryLimitMB = 100
+	MaxConfiguredGoMemoryLimitMB = 32768
+)
+
+type daemonMemorySettings struct {
+	DaemonRSSBudgetMB     int64 `json:"daemon_rss_budget_mb"`
+	DaemonGoMemoryLimitMB int64 `json:"daemon_go_memory_limit_mb"`
+}
+
+func settingsJSONPath() (string, error) {
+	home, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "settings.json"), nil
+}
+
+// ConfiguredRSSBudgetMB reads daemon_rss_budget_mb from settings.json.
+// It returns 0 when no valid configured value exists.
+func ConfiguredRSSBudgetMB() int64 {
+	raw, ok := configuredMemorySettings()
+	if !ok {
+		return 0
+	}
+	if raw.DaemonRSSBudgetMB < MinConfiguredRSSBudgetMB || raw.DaemonRSSBudgetMB > MaxConfiguredRSSBudgetMB {
+		return 0
+	}
+	return raw.DaemonRSSBudgetMB
+}
+
+// ConfiguredGoMemoryLimitMB reads daemon_go_memory_limit_mb from settings.json.
+// It returns 0 when the key is absent or invalid, allowing the upstream
+// fraction-of-RAM default to remain authoritative.
+func ConfiguredGoMemoryLimitMB() int64 {
+	raw, ok := configuredMemorySettings()
+	if !ok {
+		return 0
+	}
+	if raw.DaemonGoMemoryLimitMB < MinConfiguredGoMemoryLimitMB || raw.DaemonGoMemoryLimitMB > MaxConfiguredGoMemoryLimitMB {
+		return 0
+	}
+	return raw.DaemonGoMemoryLimitMB
+}
+
+func configuredMemorySettings() (daemonMemorySettings, bool) {
+	var raw daemonMemorySettings
+	p, err := settingsJSONPath()
+	if err != nil {
+		return raw, false
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		return raw, false
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return raw, false
+	}
+	return raw, true
+}
+
+// PersistConfiguredRSSBudgetMB writes daemon_rss_budget_mb into settings.json
+// while preserving unrelated settings keys.
+func PersistConfiguredRSSBudgetMB(mb int64) error {
+	if mb < MinConfiguredRSSBudgetMB || mb > MaxConfiguredRSSBudgetMB {
+		return fmt.Errorf("daemon_rss_budget_mb must be %d-%d; got %d",
+			MinConfiguredRSSBudgetMB, MaxConfiguredRSSBudgetMB, mb)
+	}
+	p, err := settingsJSONPath()
+	if err != nil {
+		return err
+	}
+	settings := map[string]any{}
+	if b, err := os.ReadFile(p); err == nil && len(b) > 0 {
+		if err := json.Unmarshal(b, &settings); err != nil {
+			return fmt.Errorf("settings.json: %w", err)
+		}
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("settings.json: %w", err)
+	}
+	settings["daemon_rss_budget_mb"] = mb
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		return err
+	}
+	b, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(p), ".settings.json.tmp-*")
+	if err != nil {
+		return err
+	}
+	tmp := f.Name()
+	if _, err := f.Write(b); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := renameReplace(tmp, p); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func renameReplace(src, dst string) error {
+	const (
+		attempts  = 20
+		pollEvery = 5 * time.Millisecond
+	)
+	var err error
+	for i := 0; i < attempts; i++ {
+		if err = os.Rename(src, dst); err == nil {
+			return nil
+		}
+		time.Sleep(pollEvery)
+	}
+	return err
+}

--- a/internal/daemon/rss_budget_settings_test.go
+++ b/internal/daemon/rss_budget_settings_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestConfiguredMemorySettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	p := filepath.Join(home, "settings.json")
+	if err := os.WriteFile(p, []byte(`{
+  "daemon_rss_budget_mb": 8192,
+  "daemon_go_memory_limit_mb": 6144,
+  "unrelated": true
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := ConfiguredRSSBudgetMB(); got != 8192 {
+		t.Fatalf("RSS budget = %d, want 8192", got)
+	}
+	if got := ConfiguredGoMemoryLimitMB(); got != 6144 {
+		t.Fatalf("Go memory limit = %d, want 6144", got)
+	}
+}
+
+func TestConfiguredGoMemoryLimitMB_AbsentOrInvalidUsesAuto(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	p := filepath.Join(home, "settings.json")
+
+	for _, body := range []string{
+		`{"daemon_rss_budget_mb":8192}`,
+		`{"daemon_go_memory_limit_mb":99}`,
+		`{"daemon_go_memory_limit_mb":32769}`,
+		`not-json`,
+	} {
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if got := ConfiguredGoMemoryLimitMB(); got != 0 {
+			t.Fatalf("ConfiguredGoMemoryLimitMB(%q) = %d, want 0", body, got)
+		}
+	}
+}
+
+func TestPersistConfiguredRSSBudgetMBPreservesOtherSettings(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	p := filepath.Join(home, "settings.json")
+	if err := os.WriteFile(p, []byte(`{"theme":"dark","daemon_go_memory_limit_mb":6144}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := PersistConfiguredRSSBudgetMB(8192); err != nil {
+		t.Fatal(err)
+	}
+
+	var got map[string]any
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+	if got["theme"] != "dark" || got["daemon_go_memory_limit_mb"] != float64(6144) {
+		t.Fatalf("unrelated settings were not preserved: %#v", got)
+	}
+	if got["daemon_rss_budget_mb"] != float64(8192) {
+		t.Fatalf("daemon_rss_budget_mb = %#v, want 8192", got["daemon_rss_budget_mb"])
+	}
+}
+
+func TestPersistConfiguredRSSBudgetMBRejectsOutOfRange(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	for _, mb := range []int64{99, 32769} {
+		if err := PersistConfiguredRSSBudgetMB(mb); err == nil {
+			t.Fatalf("PersistConfiguredRSSBudgetMB(%d) succeeded, want error", mb)
+		}
+	}
+}

--- a/internal/dashboard/handlers_settings.go
+++ b/internal/dashboard/handlers_settings.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/notifications"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -30,9 +31,10 @@ type AppSettings struct {
 	TelemetryEnabled bool `json:"telemetry_enabled"` // default false
 
 	// Performance — changing these requires a daemon restart
-	DaemonRSSBudgetMB   int `json:"daemon_rss_budget_mb"`  // 100–2000
-	WatcherDebounceSecs int `json:"watcher_debounce_secs"` // 1–60
-	IndexerParallelism  int `json:"indexer_parallelism"`   // 1–32
+	DaemonRSSBudgetMB     int  `json:"daemon_rss_budget_mb"`                // 100–32768
+	DaemonGoMemoryLimitMB *int `json:"daemon_go_memory_limit_mb,omitempty"` // nil = upstream auto
+	WatcherDebounceSecs   int  `json:"watcher_debounce_secs"`               // 1–60
+	IndexerParallelism    int  `json:"indexer_parallelism"`                 // 1–32
 
 	// PerfBudgets holds configurable threshold values used by the performance
 	// budget monitor (#1319). Keys are metric names (e.g. "index_wall_ms");
@@ -149,8 +151,13 @@ func validateSettings(s AppSettings) error {
 	default:
 		return fmt.Errorf("log_level must be debug, info, warn, or error; got %q", s.LogLevel)
 	}
-	if s.DaemonRSSBudgetMB < 100 || s.DaemonRSSBudgetMB > 2000 {
-		return fmt.Errorf("daemon_rss_budget_mb must be 100–2000; got %d", s.DaemonRSSBudgetMB)
+	if s.DaemonRSSBudgetMB < daemon.MinConfiguredRSSBudgetMB || s.DaemonRSSBudgetMB > daemon.MaxConfiguredRSSBudgetMB {
+		return fmt.Errorf("daemon_rss_budget_mb must be %d–%d; got %d",
+			daemon.MinConfiguredRSSBudgetMB, daemon.MaxConfiguredRSSBudgetMB, s.DaemonRSSBudgetMB)
+	}
+	if s.DaemonGoMemoryLimitMB != nil && (*s.DaemonGoMemoryLimitMB < daemon.MinConfiguredGoMemoryLimitMB || *s.DaemonGoMemoryLimitMB > daemon.MaxConfiguredGoMemoryLimitMB) {
+		return fmt.Errorf("daemon_go_memory_limit_mb must be %d–%d; got %d",
+			daemon.MinConfiguredGoMemoryLimitMB, daemon.MaxConfiguredGoMemoryLimitMB, *s.DaemonGoMemoryLimitMB)
 	}
 	if s.WatcherDebounceSecs < 1 || s.WatcherDebounceSecs > 60 {
 		return fmt.Errorf("watcher_debounce_secs must be 1–60; got %d", s.WatcherDebounceSecs)
@@ -213,6 +220,9 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 	if current.DaemonRSSBudgetMB != previous.DaemonRSSBudgetMB {
 		restartKeys = append(restartKeys, "daemon_rss_budget_mb")
 	}
+	if !equalOptionalInt(current.DaemonGoMemoryLimitMB, previous.DaemonGoMemoryLimitMB) {
+		restartKeys = append(restartKeys, "daemon_go_memory_limit_mb")
+	}
 	if current.IndexerParallelism != previous.IndexerParallelism {
 		restartKeys = append(restartKeys, "indexer_parallelism")
 	}
@@ -229,6 +239,13 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 		Defaults:        DefaultAppSettings(),
 		RestartRequired: restartKeys,
 	})
+}
+
+func equalOptionalInt(a, b *int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return *a == *b
 }
 
 // handleResetSettings — POST /api/settings/reset

--- a/internal/dashboard/handlers_settings_test.go
+++ b/internal/dashboard/handlers_settings_test.go
@@ -96,12 +96,56 @@ func TestHandlePutSettings_rssOutOfRange(t *testing.T) {
 	srv, cleanup := setupSettingsServer(t)
 	defer cleanup()
 
-	patch := map[string]any{"daemon_rss_budget_mb": 9999}
+	patch := map[string]any{"daemon_rss_budget_mb": 40000}
 	body, _ := json.Marshal(patch)
 	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
 	w := httptest.NewRecorder()
 	srv.handlePutSettings(w, req)
 
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("want 422, got %d; body: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePutSettings_goMemoryLimit(t *testing.T) {
+	srv, cleanup := setupSettingsServer(t)
+	defer cleanup()
+
+	patch := map[string]any{"daemon_go_memory_limit_mb": 8192}
+	body, _ := json.Marshal(patch)
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handlePutSettings(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d; body: %s", w.Code, w.Body.String())
+	}
+	var reply settingsReply
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatal(err)
+	}
+	if reply.Settings.DaemonGoMemoryLimitMB == nil || *reply.Settings.DaemonGoMemoryLimitMB != 8192 {
+		t.Fatalf("want daemon_go_memory_limit_mb=8192, got %v", reply.Settings.DaemonGoMemoryLimitMB)
+	}
+	found := false
+	for _, key := range reply.RestartRequired {
+		if key == "daemon_go_memory_limit_mb" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected daemon_go_memory_limit_mb in restart_required, got %v", reply.RestartRequired)
+	}
+}
+
+func TestHandlePutSettings_goMemoryLimitOutOfRange(t *testing.T) {
+	srv, cleanup := setupSettingsServer(t)
+	defer cleanup()
+
+	body, _ := json.Marshal(map[string]any{"daemon_go_memory_limit_mb": 99})
+	req := httptest.NewRequest(http.MethodPut, "/api/settings", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handlePutSettings(w, req)
 	if w.Code != http.StatusUnprocessableEntity {
 		t.Fatalf("want 422, got %d; body: %s", w.Code, w.Body.String())
 	}


### PR DESCRIPTION
## Summary

- Make `daemon_rss_budget_mb` authoritative before the automatic admission-budget default.
- Persist explicit `--max-rss-budget` values to `settings.json` without dropping unrelated keys.
- Add optional `daemon_go_memory_limit_mb` support while preserving environment-variable precedence and automatic fallback.
- Extend settings validation, restart reporting, documentation, and focused regression coverage.

## Closes / Refs

Closes #5837

## Testing

- [x] `go test -p 1 ./internal/daemon -run "Test(ConfiguredMemorySettings|ConfiguredGoMemoryLimitMB|PersistConfiguredRSSBudgetMB|ResolveMemLimitMB|MemLimitClampBoundaries|MemLimitSummary|ApplyMemoryLimit)" -count=1`
- [x] `go test -p 1 ./internal/dashboard -run "TestHandle(Get|Put|Reset)Settings" -count=1`
- [x] `go test -p 1 ./internal/cli ./cmd/grafel -run "^$"`
- [x] `git diff --check main..HEAD`

## Notes

The JSON keys remain optional. Omitting them retains Grafel's current automatic formulas.
