### PR TITLE
fix(detect): recognize .NET repository roots

### DIFF
--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -44,6 +44,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -191,7 +192,7 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 		sr := v2SettingsRepo{
 			Slug:  r.Slug,
 			Path:  r.Path,
-			Stack: r.Stack.Primary(),
+			Stack: settingsRepoStack(r),
 			Files: files,
 		}
 		sr.Entities = entities
@@ -243,6 +244,17 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 		sg.Health = healthWarning
 	}
 	return sg, nil
+}
+
+func settingsRepoStack(r registry.Repo) string {
+	stack := r.Stack.Primary()
+	if stack != "" && stack != "unknown" {
+		return stack
+	}
+	if detected := detect.Stack(r.Path); detected != "" && detected != "unknown" {
+		return detected
+	}
+	return stack
 }
 
 // repoStats reads graph-stats.json for a repo's state dir and returns

--- a/internal/dashboard/v2_group_settings_test.go
+++ b/internal/dashboard/v2_group_settings_test.go
@@ -366,6 +366,17 @@ func TestV2GetGroup_RealFidelityViaServer(t *testing.T) {
 	}
 }
 
+func TestSettingsRepoStackFallsBackToDotnetDetector(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "Platform.slnx"), []byte(""), 0o644); err != nil {
+		t.Fatalf("write slnx: %v", err)
+	}
+	repo := registry.Repo{Slug: "platform", Path: dir, Stack: registry.StackList{"unknown"}}
+	if got := settingsRepoStack(repo); got != "dotnet" {
+		t.Fatalf("settingsRepoStack = %q, want dotnet", got)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // DELETE /api/v2/groups/{group} — per-repo state cleanup (#1635)
 // ---------------------------------------------------------------------------

--- a/internal/install/detect/detect.go
+++ b/internal/install/detect/detect.go
@@ -39,6 +39,9 @@ func Stack(repo string) string {
 	if exists(repo, "pom.xml") || exists(repo, "build.gradle") || exists(repo, "build.gradle.kts") {
 		return "jvm"
 	}
+	if hasFileWithExt(repo, ".csproj") || hasFileWithExt(repo, ".sln") || hasFileWithExt(repo, ".slnx") {
+		return "dotnet"
+	}
 	if exists(repo, "Gemfile") {
 		return "ruby"
 	}
@@ -496,6 +499,22 @@ func hasSourceFiles(dir string, maxDepth int) bool {
 func exists(dir, name string) bool {
 	_, err := os.Stat(filepath.Join(dir, name))
 	return err == nil
+}
+
+func hasFileWithExt(dir, ext string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if strings.EqualFold(filepath.Ext(e.Name()), ext) {
+			return true
+		}
+	}
+	return false
 }
 
 func isDir(p string) bool {

--- a/internal/install/detect/detect_test.go
+++ b/internal/install/detect/detect_test.go
@@ -66,6 +66,20 @@ func TestStack(t *testing.T) {
 			t.Fatalf("got %q", got)
 		}
 	})
+	t.Run("dotnet solution", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, filepath.Join(dir, "Assessment.slnx"), "")
+		if got := Stack(dir); got != "dotnet" {
+			t.Fatalf("got %q", got)
+		}
+	})
+	t.Run("dotnet project", func(t *testing.T) {
+		dir := t.TempDir()
+		write(t, filepath.Join(dir, "Assessment.HttpApi.Host.csproj"), "")
+		if got := Stack(dir); got != "dotnet" {
+			t.Fatalf("got %q", got)
+		}
+	})
 }
 
 func TestDetectMonorepoPNPM(t *testing.T) {


### PR DESCRIPTION
## Summary

- Recognize `.sln`, `.slnx`, and `.csproj` files as .NET repository markers.
- Match the marker extensions case-insensitively.
- Re-detect the Group settings stack for existing registry entries stored as `unknown`.
- Add focused detector and dashboard regression coverage.

## Closes / Refs

Closes #5839

## Testing

- [x] `go test -p 1 ./internal/install/detect ./internal/dashboard -run "Test(Stack|SettingsRepoStackFallsBackToDotnetDetector)$" -count=1`
- [x] `git diff --check main..HEAD`

## Notes

This changes stack metadata only; it does not alter C# extraction behavior.
