### PR TITLE
fix(walk): inherit parent .grafelignore rules

### DIFF
--- a/internal/daemon/walk/gitignore_test.go
+++ b/internal/daemon/walk/gitignore_test.go
@@ -2,6 +2,7 @@ package walk
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -274,6 +275,69 @@ func TestWalkRepo_GrafelIgnore(t *testing.T) {
 	}
 	if !fileSet["src/main.go"] {
 		t.Errorf("expected src/main.go in files")
+	}
+}
+
+func TestWalkRepo_InheritsParentGrafelIgnoreForMonorepoChild(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+
+	mkfile(t, root, ".grafelignore", "**/wwwroot/libs/\nsrc/generated/\n")
+	mkfile(t, root, "src/Assessment.HttpApi.Host/wwwroot/libs/datatables.net/js/dataTables.min.js", "generated")
+	mkfile(t, root, "src/generated/out.go", "generated")
+	mkfile(t, root, "src/Assessment.HttpApi.Host/Program.cs", "class Program {}")
+
+	files, skipped, err := WalkRepo(filepath.Join(root, "src"), nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+
+	fileSet := make(map[string]bool)
+	for _, f := range files {
+		fileSet[f] = true
+	}
+	if fileSet["Assessment.HttpApi.Host/wwwroot/libs/datatables.net/js/dataTables.min.js"] {
+		t.Fatalf("parent .grafelignore did not skip wwwroot libs; files=%v skipped=%v", files, skipped)
+	}
+	if fileSet["generated/out.go"] {
+		t.Fatalf("parent .grafelignore did not rewrite src/generated for child root; files=%v skipped=%v", files, skipped)
+	}
+	if !fileSet["Assessment.HttpApi.Host/Program.cs"] {
+		t.Fatalf("source file missing after inherited ignore filtering; files=%v skipped=%v", files, skipped)
+	}
+}
+
+func TestWalkRepo_InheritsNestedGrafelIgnoreRelativeToItsDirectory(t *testing.T) {
+	root := t.TempDir()
+	runGit(t, root, "init", "-q")
+
+	mkfile(t, root, ".grafelignore", "apps/**/dist/\n")
+	mkfile(t, root, "apps/.grafelignore", "admin/generated/\n")
+	mkfile(t, root, "apps/admin/dist/bundle.js", "generated")
+	mkfile(t, root, "apps/admin/generated/client.ts", "generated")
+	mkfile(t, root, "apps/admin/src/main.ts", "source")
+
+	files, skipped, err := WalkRepo(filepath.Join(root, "apps", "admin"), nil)
+	if err != nil {
+		t.Fatalf("WalkRepo: %v", err)
+	}
+	fileSet := make(map[string]bool)
+	for _, f := range files {
+		fileSet[f] = true
+	}
+	if fileSet["dist/bundle.js"] || fileSet["generated/client.ts"] {
+		t.Fatalf("nested inherited ignores were not applied; files=%v skipped=%v", files, skipped)
+	}
+	if !fileSet["src/main.ts"] {
+		t.Fatalf("source file missing; files=%v skipped=%v", files, skipped)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
 	}
 }
 

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -269,6 +269,9 @@ func inheritedGrafelIgnores(root string) []*IgnoreFile {
 	if err != nil {
 		return nil
 	}
+	if resolved, err := filepath.EvalSymlinks(rootAbs); err == nil {
+		rootAbs = resolved
+	}
 	top = filepath.Clean(top)
 	rootAbs = filepath.Clean(rootAbs)
 	if samePath(top, rootAbs) {

--- a/internal/daemon/walk/walker.go
+++ b/internal/daemon/walk/walker.go
@@ -15,12 +15,14 @@ package walk
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -96,7 +98,13 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 	// igStack tracks .gitignore/.grafelignore files as we descend.
 	var igStack IgnoreStack
 
-	// Load the root-level .gitignore and .grafelignore.
+	// Load inherited .grafelignore files from git ancestors first, then the
+	// root-level .gitignore and .grafelignore. This matters when a monorepo is
+	// registered as package roots (for example <repo>/src): the top-level
+	// .grafelignore should still govern those child roots.
+	for _, parent := range inheritedGrafelIgnores(root) {
+		igStack.Push(parent)
+	}
 	rootGit, _ := ParseIgnoreFile("", filepath.Join(root, ".gitignore"), ".gitignore")
 	rootArchi, _ := ParseIgnoreFile("", filepath.Join(root, ".grafelignore"), ".grafelignore")
 	igStack.Push(rootGit)
@@ -246,6 +254,110 @@ func WalkRepo(root string, opts *Options) ([]string, []SkipEntry, error) {
 	})
 
 	return files, skipped, err
+}
+
+func inheritedGrafelIgnores(root string) []*IgnoreFile {
+	meta := gitmeta.Capture(root)
+	if meta.TopLevel == "" {
+		return nil
+	}
+	top, err := filepath.Abs(meta.TopLevel)
+	if err != nil {
+		return nil
+	}
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return nil
+	}
+	top = filepath.Clean(top)
+	rootAbs = filepath.Clean(rootAbs)
+	if samePath(top, rootAbs) {
+		return nil
+	}
+	relRoot, err := filepath.Rel(top, rootAbs)
+	if err != nil || relRoot == "." || strings.HasPrefix(relRoot, "..") {
+		return nil
+	}
+	var out []*IgnoreFile
+	dir := top
+	for !samePath(dir, rootAbs) {
+		relFromDir, err := filepath.Rel(dir, rootAbs)
+		if err != nil || relFromDir == "." || strings.HasPrefix(relFromDir, "..") {
+			return nil
+		}
+		ig := parseInheritedGrafelIgnore(dir, filepath.ToSlash(relFromDir))
+		if ig != nil && len(ig.patterns) > 0 {
+			out = append(out, ig)
+		}
+		first, _, _ := strings.Cut(filepath.ToSlash(relFromDir), "/")
+		dir = filepath.Join(dir, filepath.FromSlash(first))
+	}
+	return out
+}
+
+func parseInheritedGrafelIgnore(dir, relRoot string) *IgnoreFile {
+	path := filepath.Join(dir, ".grafelignore")
+	b, err := os.ReadFile(path)
+	if err != nil || len(b) == 0 {
+		return nil
+	}
+	rewritten := rewriteInheritedIgnore(b, relRoot)
+	ig, err := parseIgnoreReader("", ".grafelignore", bytes.NewReader(rewritten))
+	if err != nil {
+		return nil
+	}
+	return ig
+}
+
+func rewriteInheritedIgnore(b []byte, relRoot string) []byte {
+	var out strings.Builder
+	sc := bufio.NewScanner(bytes.NewReader(b))
+	for sc.Scan() {
+		line := sc.Text()
+		out.WriteString(rewriteInheritedIgnoreLine(line, relRoot))
+		out.WriteByte('\n')
+	}
+	return []byte(out.String())
+}
+
+func rewriteInheritedIgnoreLine(line, relRoot string) string {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+		return line
+	}
+	prefix := ""
+	body := line
+	if strings.HasPrefix(body, "!") {
+		prefix = "!"
+		body = strings.TrimPrefix(body, "!")
+	}
+	leadingSlash := strings.HasPrefix(body, "/")
+	body = strings.TrimPrefix(body, "/")
+	trailingSlash := strings.HasSuffix(body, "/")
+	body = strings.TrimSuffix(body, "/")
+
+	if body == relRoot {
+		body = "**"
+	} else if strings.HasPrefix(body, relRoot+"/") {
+		body = strings.TrimPrefix(body, relRoot+"/")
+		leadingSlash = false
+	}
+	if trailingSlash && !strings.HasSuffix(body, "/") {
+		body += "/"
+	}
+	if leadingSlash {
+		body = "/" + body
+	}
+	return prefix + body
+}
+
+func samePath(a, b string) bool {
+	a = filepath.Clean(a)
+	b = filepath.Clean(b)
+	if runtime.GOOS == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 // hardcodedSkip reports whether a directory basename is on the extended


### PR DESCRIPTION
## Summary

- Load ancestor `.grafelignore` files when walking a monorepo child root.
- Translate path-relative rules from each ignore file's directory to the selected root.
- Preserve root-local ignore precedence and platform-correct path comparison.
- Add regression coverage for top-level and nested ancestor ignores.

## Closes / Refs

Closes #5841

## Testing

- [x] `go test -p 1 ./internal/daemon/walk -run "TestWalkRepo_(GrafelIgnore|Inherits.*GrafelIgnore)" -count=1`
- [x] `git diff --check main..HEAD`

## Notes

The change is limited to `.grafelignore`; Git's own ignore discovery remains unchanged.
