### PR TITLE
fix(install/mcpreg): systemic fail-closed guard against writing MCP config into real HOME during tests

### DIFF
--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -11,11 +11,22 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // newWizardTestServer builds a Server with an isolated GRAFEL_HOME, the
 // in-memory fakeStore (so CreateGroup/AddRepo don't touch ~/.grafel), and
 // an injected rebuildRunner so the index job completes without a live daemon.
+//
+// It deliberately does NOT redirect HOME itself — several callers (e.g. the
+// v2_fs_test.go home-listing tests, TestV2DetectMCPTools) call
+// testsupport.IsolateHome(t) themselves BEFORE invoking this helper to lay
+// down a specific home fixture, and a second, independent IsolateHome call
+// here would re-point HOME at a *different* TempDir and silently break them.
+// Tests that reach a code path capable of WRITING an MCP host config (e.g.
+// TestV2CreateGroupFromScan_CreatesAndIndexes, via registerWizardMCP) must
+// call testsupport.IsolateHome(t) themselves before calling this helper.
 func newWizardTestServer(t *testing.T, runner rebuildRunner) (*httptest.Server, *Server) {
 	t.Helper()
 	t.Setenv("GRAFEL_HOME", t.TempDir())
@@ -212,7 +223,17 @@ func TestV2ScanInspect_PrefersChildGitReposOverMonorepo(t *testing.T) {
 // TestV2CreateGroupFromScan_CreatesAndIndexes verifies the full wizard create
 // path: it creates the group, registers the repo, and enqueues an index job
 // that the runner drives to done.
+//
+// The handler under test (handleV2CreateGroupFromScan) synchronously calls
+// registerWizardMCP, which — with req.MCPTools == nil, as posted below —
+// registers the grafel MCP entry into EVERY detected MCP-capable tool. This
+// test used to only isolate GRAFEL_HOME, so that write resolved the
+// developer's REAL $HOME and clobbered live ~/.cursor/mcp.json / etc. on
+// every `go test` run. testsupport.IsolateHome(t) redirects HOME (belt and
+// braces alongside the systemic mcpreg fail-closed guard, see
+// internal/install/mcpreg/test_isolation_guard.go).
 func TestV2CreateGroupFromScan_CreatesAndIndexes(t *testing.T) {
+	testsupport.IsolateHome(t)
 	done := make(chan struct{}, 1)
 	runner := func(args proto.RebuildArgs) (proto.RebuildReply, error) {
 		if args.Group != "wiz" {
@@ -223,6 +244,15 @@ func TestV2CreateGroupFromScan_CreatesAndIndexes(t *testing.T) {
 	}
 	ts, _ := newWizardTestServer(t, runner)
 	repoDir := t.TempDir()
+
+	// Make Cursor "detected" so registerWizardMCP(nil) actually exercises an
+	// MCP write during this test — proving it lands under the isolated home,
+	// not the developer's real ~/.cursor/mcp.json (the exact leak this test
+	// used to cause; see internal/install/mcpreg/test_isolation_guard.go).
+	cursorDir := filepath.Join(os.Getenv("HOME"), ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o755); err != nil {
+		t.Fatalf("mkdir isolated .cursor dir: %v", err)
+	}
 
 	body := `{"name":"wiz","repos":[{"path":` + jsonQuote(repoDir) + `,"slug":"core"}]}`
 	resp, err := http.Post(ts.URL+"/api/v2/groups/from-scan", "application/json", strings.NewReader(body))
@@ -242,6 +272,15 @@ func TestV2CreateGroupFromScan_CreatesAndIndexes(t *testing.T) {
 	}
 	if !env.OK || env.Data.JobID == "" || env.Data.Group != "wiz" {
 		t.Fatalf("bad ack: %+v", env)
+	}
+
+	// The from-scan handler synchronously registers the grafel MCP entry
+	// (registerWizardMCP) before returning the ack above. Assert it landed
+	// under the isolated HOME, never under the developer's real one.
+	cursorMCPPath := filepath.Join(cursorDir, "mcp.json")
+	testsupport.AssertUnderHome(t, cursorMCPPath)
+	if !mcpreg.HasGrafelEntry(cursorMCPPath) {
+		t.Fatalf("expected grafel MCP entry registered at isolated %q", cursorMCPPath)
 	}
 
 	select {

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -435,6 +435,7 @@ func backupOnce(path string) error {
 // RestorePath. The merge is surgical: only mcpServers.grafel is added or
 // updated; every other key and sibling server is preserved.
 func RegisterPath(path, binPath string) (string, error) {
+	guardResolvedConfigPath(path, "MCP host config")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
@@ -481,6 +482,7 @@ func Unregister(tool Tool) error {
 // `{"mcpServers":{}}`. Returns nil if the file or entry doesn't exist
 // (idempotent). It NEVER overwrites foreign servers or resets the file to `{}`.
 func UnregisterPath(path string) error {
+	guardResolvedConfigPath(path, "MCP host config")
 	if isTOML(path) {
 		return unregisterTOML(path)
 	}
@@ -519,6 +521,7 @@ func UnregisterPath(path string) error {
 //
 // The sidecar backup is removed after a successful restore.
 func RestorePath(path string) error {
+	guardResolvedConfigPath(path, "MCP host config")
 	sidecar := sidecarBackupPath(path)
 	b, err := os.ReadFile(sidecar)
 	if err != nil {

--- a/internal/install/mcpreg/test_isolation_guard.go
+++ b/internal/install/mcpreg/test_isolation_guard.go
@@ -1,0 +1,86 @@
+package mcpreg
+
+// test_isolation_guard.go — fail-closed guard against the incident where a
+// test that forgot to isolate $HOME (e.g. the dashboard wizard test in
+// internal/dashboard/v2_wizard_test.go, which only isolated GRAFEL_HOME)
+// resolved the developer's REAL ~/.cursor/mcp.json (and potentially
+// ~/.claude.json, ~/.codeium, ~/.kiro) and REGISTERED the ephemeral
+// `dashboard.test` binary path into it — every `go test` run silently
+// rewrote the live editor MCP config.
+//
+// The opt-in TestMain guard (testsupport.GuardRealHomeMain) only fires when a
+// package wires it up AND GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1 is exported —
+// it is trivially skipped by a package (like internal/dashboard) that never
+// wires it in. This guard lives in the WRITE path of mcpreg's config writers
+// themselves, so it cannot be skipped: any test that is about to PERSIST a
+// grafel MCP entry (or delete/restore one) into a REAL host config file under
+// the REAL user home panics LOUDLY before a single byte is written.
+//
+// Why guard the writers and not homeDir()/SettingsPath(): a read-only path
+// resolution is harmless and extremely common (used to detect whether a tool
+// is installed); only a WRITE clobbers the developer's live editor config.
+// Guarding RegisterPath/UnregisterPath/RestorePath — BEFORE backupOnce, which
+// itself writes a `.grafel.bak` sidecar and an audit copy under
+// ~/.grafel/backups/mcpreg/ — catches every mutating entry point in this
+// package.
+//
+// It is inert outside tests (`testing.Testing()` is false in the shipping
+// binary) and inert inside tests that DID isolate (the write target no longer
+// lands under the real home, so the panic condition is never met).
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// realUserHomeAtInit is captured at package-init time, BEFORE any test has had a
+// chance to call t.Setenv("HOME", ...). It is the home we must never write to
+// from a test. Captured the same way internal/testsupport and internal/registry
+// capture it (kept independent to avoid an import cycle: testsupport is a test
+// helper package that must not be imported from non-test production code).
+var realUserHomeAtInit = func() string {
+	if h, err := os.UserHomeDir(); err == nil && h != "" {
+		return filepath.Clean(h)
+	}
+	if h := os.Getenv("HOME"); h != "" {
+		return filepath.Clean(h)
+	}
+	return ""
+}()
+
+// guardResolvedConfigPath panics if, while running under `go test`, the path we
+// are about to WRITE an MCP host config file to lands inside the REAL user
+// home directory. That can only happen when the test failed to redirect
+// HOME (and, for XDG-based hosts like Zed, XDG_CONFIG_HOME) into a TempDir —
+// i.e. the dashboard-wizard-leaking-into-~/.cursor/mcp.json bug.
+//
+// It is a no-op in the shipping binary (testing.Testing() == false) and a no-op
+// for any test that correctly isolated (the target path is then under a
+// TempDir, not the real home).
+func guardResolvedConfigPath(resolved, what string) {
+	if !testing.Testing() {
+		return
+	}
+	if realUserHomeAtInit == "" || resolved == "" {
+		return
+	}
+	abs := resolved
+	if a, err := filepath.Abs(resolved); err == nil {
+		abs = a
+	}
+	abs = filepath.Clean(abs)
+	home := realUserHomeAtInit
+	if abs == home || strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator)) {
+		panic(fmt.Sprintf(
+			"mcpreg: TEST SANDBOX ESCAPE — about to WRITE %s to %q, which is inside the "+
+				"REAL user home %q. This test would clobber the developer's live "+
+				"~/.cursor/mcp.json / ~/.claude.json / ~/.codeium / ~/.kiro MCP config. "+
+				"Call testsupport.IsolateHome(t) at the top of the test before registering, "+
+				"unregistering, or restoring any MCP host config file.",
+			what, abs, home,
+		))
+	}
+}

--- a/internal/install/mcpreg/test_isolation_guard_test.go
+++ b/internal/install/mcpreg/test_isolation_guard_test.go
@@ -1,0 +1,90 @@
+package mcpreg
+
+// test_isolation_guard_test.go — verifies the fail-closed guard against
+// leaking the test binary path into a REAL host MCP config: a write that
+// targets a path inside the REAL user home panics LOUDLY, while a write into
+// an isolated TempDir succeeds exactly as before.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestGuard_RegisterPathPanicsWhenWritingRealHome proves the guard fires when
+// RegisterPath's target lands inside the genuine user home — the exact
+// dashboard-wizard leak. We do NOT expect any file to be created; the guard
+// must panic before MkdirAll/backupOnce/writeSettings run.
+func TestGuard_RegisterPathPanicsWhenWritingRealHome(t *testing.T) {
+	if realUserHomeAtInit == "" {
+		t.Skip("no real user home captured; cannot exercise the escape path")
+	}
+
+	escape := filepath.Join(realUserHomeAtInit, ".cursor", "mcp.json.guardtest")
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatalf("expected guard panic when writing MCP config to real home %q, got none", escape)
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "TEST SANDBOX ESCAPE") || !strings.Contains(msg, "IsolateHome") {
+			t.Fatalf("panic message did not mention the guard / remediation: %q", msg)
+		}
+	}()
+
+	_, _ = RegisterPath(escape, "/bin/grafel")
+	t.Fatalf("RegisterPath returned without panicking — guard did not fire")
+}
+
+// TestGuard_UnregisterPathPanicsWhenWritingRealHome mirrors the above for the
+// uninstall path.
+func TestGuard_UnregisterPathPanicsWhenWritingRealHome(t *testing.T) {
+	if realUserHomeAtInit == "" {
+		t.Skip("no real user home captured")
+	}
+	escape := filepath.Join(realUserHomeAtInit, ".claude.json.guardtest")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected guard panic unregistering MCP config at real home %q", escape)
+		}
+	}()
+	_ = UnregisterPath(escape)
+	t.Fatalf("UnregisterPath returned without panicking — guard did not fire")
+}
+
+// TestGuard_RestorePathPanicsWhenWritingRealHome mirrors the above for the
+// rollback path.
+func TestGuard_RestorePathPanicsWhenWritingRealHome(t *testing.T) {
+	if realUserHomeAtInit == "" {
+		t.Skip("no real user home captured")
+	}
+	escape := filepath.Join(realUserHomeAtInit, ".kiro", "settings", "mcp.json.guardtest")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected guard panic restoring MCP config at real home %q", escape)
+		}
+	}()
+	_ = RestorePath(escape)
+	t.Fatalf("RestorePath returned without panicking — guard did not fire")
+}
+
+// TestGuard_AllowsWriteUnderIsolatedHome proves the guard is inert once the
+// target is under a TempDir (the isolated case), and the write actually lands
+// — i.e. it does not regress the ~38 existing isolated mcpreg tests.
+func TestGuard_AllowsWriteUnderIsolatedHome(t *testing.T) {
+	withHome(t)
+	path, err := Register(ClaudeCode, "/bin/grafel", "")
+	if err != nil {
+		t.Fatalf("Register under isolated home should succeed: %v", err)
+	}
+	if realUserHomeAtInit != "" {
+		abs, _ := filepath.Abs(path)
+		if strings.HasPrefix(filepath.Clean(abs)+string(filepath.Separator), realUserHomeAtInit+string(filepath.Separator)) {
+			t.Fatalf("isolated config path %q unexpectedly under real home %q", abs, realUserHomeAtInit)
+		}
+	}
+	if !HasGrafelEntry(path) {
+		t.Fatalf("expected grafel entry to be registered at isolated path %q", path)
+	}
+}


### PR DESCRIPTION
## What

The #5829 fix isolated HOME only in `internal/cli`. A **second** real leak surfaced from `internal/dashboard`: `TestV2CreateGroupFromScan_CreatesAndIndexes` wrote a live `~/.cursor/mcp.json` (command pointing at the ephemeral `dashboard.test` binary) into the developer's real home, because the wizard's `registerWizardMCP` path calls `os.Executable()` + `mcpreg.Register` and the test never redirected HOME.

Rather than another per-package HOME patch, this closes the class **at the write choke point**.

## Changes

- **New `internal/install/mcpreg/test_isolation_guard.go`** — mirrors the existing precedent `internal/registry/test_isolation_guard.go` (#5443): captures the real user home at package init, and (gated by `testing.Testing()`, so production is inert) panics if a resolved MCP-host-config write path lands at/under real home.
- Guard is wired as the **first statement** of the three write entry points — `RegisterPath`, `UnregisterPath`, `RestorePath` — *before* `backupOnce`/`MkdirAll`/`writeSettings`, so no test can leak or clobber a real editor config even if it forgets to isolate HOME.
- Belt-and-braces: `TestV2CreateGroupFromScan_CreatesAndIndexes` now calls `testsupport.IsolateHome(t)` and asserts the registered MCP entry lands under the tempdir.

## Review + tests

Independently reviewed → **APPROVE**. The reviewer executed a real RED→GREEN proof: neutering the guard body made the three escape tests fail (and leak a `.guardtest` file into the real home), restoring it made them pass; the developer's real `~/.cursor/mcp.json` was never touched.

Gate (green): `go build ./...`; `go vet ./internal/install/mcpreg/... ./internal/dashboard/...`; `go test` both packages → 1001 passed; `gofmt -l` on all 4 touched files → empty.

Follow-up to #5829.