### PR TITLE
fix(install): isolate HOME in daemon-guard uninstall tests (follow-up to #5843)

### DIFF
--- a/internal/install/daemon_guard_test.go
+++ b/internal/install/daemon_guard_test.go
@@ -4,6 +4,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // writeMinimalState writes a valid install.json into dir and returns its path,
@@ -128,6 +130,7 @@ func TestEvaluateDaemonStop_DecisionTable(t *testing.T) {
 // the stop hook is NEVER called and a WARN is emitted — without any real
 // launchctl/systemctl invocation.
 func TestRunUninstall_GuardSkipsForeignDaemon(t *testing.T) {
+	testsupport.IsolateHome(t)
 	dir := t.TempDir()
 	statePath := writeMinimalState(t, dir)
 
@@ -165,6 +168,7 @@ func TestRunUninstall_GuardSkipsForeignDaemon(t *testing.T) {
 // TestRunUninstall_GuardStopsOwnDaemon asserts the normal path: a matching root
 // still stops the daemon.
 func TestRunUninstall_GuardStopsOwnDaemon(t *testing.T) {
+	testsupport.IsolateHome(t)
 	dir := t.TempDir()
 	statePath := writeMinimalState(t, dir)
 


### PR DESCRIPTION
## What

The systemic mcpreg test-isolation guard from #5843 caught a **third** un-isolated test that writes MCP host-config into the developer's real `\$HOME` — this time in `internal/install`. `TestRunUninstall_GuardSkipsForeignDaemon` (and its sibling `TestRunUninstall_GuardStopsOwnDaemon`) call `RunUninstall`, whose Step-2b tool-sweep resolves the **real** grafel registry (nil `groupsFn` defaults to `registry.Groups`, reading real HOME) and then calls `mcpreg.Unregister` → about to WRITE to the developer's real `~/.claude.json`. The guard correctly panicked (`TEST SANDBOX ESCAPE`) instead of letting the leak happen.

This is the guard working as designed — same class as #5829 (internal/cli) and #5843 (internal/dashboard).

## Fix

Add `testsupport.IsolateHome(t)` as the first line of both tests in `internal/install/daemon_guard_test.go`. The tests' real assertions are unaffected — `registeredRootFn`/`targetRootFn`/`stopDaemonFn`/`warnFn` are injected mocks; isolation only redirects where the default registry/mcpreg hooks resolve paths. A package sweep confirmed only these two tests lacked isolation; all other install-package tests already isolate HOME or mock the tool hooks.

## Tests

- RED reproduced: the two tests panicked on the guard before the fix.
- `go build ./...`, `go vet ./internal/install/...`, `go test ./internal/install/... -race` (all 10 packages ok), `gofmt -l` empty.

Follow-up to #5843.