### PR TITLE
perf(graph): loader-side string interning for resident Document (−197 MB, −10.4% resident)

### DIFF
--- a/internal/graph/intern_test.go
+++ b/internal/graph/intern_test.go
@@ -1,0 +1,245 @@
+// Tests for LOADER-SIDE string interning during graph.Document
+// materialization (Tier-1b of grafel's resident-graph memory program).
+//
+// Tier-1a (fbwriter CreateSharedString, see fbwriter/sharedstring_test.go)
+// shrinks the ON-DISK graph.fb by sharing identical string offsets at write
+// time. That optimization is invisible to the LOADER: loadFBDocument calls
+// string(fbBytes) once per field per record, which always allocates a fresh
+// backing array — so N on-disk-shared occurrences of the same string still
+// materialize as N independent heap allocations once loaded into a
+// graph.Document. This test proves the loader itself dedupes high-duplication
+// string fields (entity id/kind/subtype/module/source_file/language/property
+// keys, relationship from_id/to_id/kind) through a per-load interner so that
+// equal-valued strings share ONE backing array in the resident *Document.
+package graph_test
+
+import (
+	"path/filepath"
+	"testing"
+	"unsafe"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// samePointer reports whether two strings share the same backing array by
+// comparing their unsafe.StringData pointers. Empty strings are excluded by
+// callers since Go may point all zero-length strings at a shared runtime
+// symbol regardless of interning.
+func samePointer(a, b string) bool {
+	return unsafe.StringData(a) == unsafe.StringData(b)
+}
+
+// buildInternFixture builds a Document with many relationships that all
+// share the same two from_id/to_id endpoints and many entities that share
+// common kind/source_file/language/module values — the maximally-duplicated
+// shape the loader interner should collapse (mirroring the ~8.7x average
+// endpoint degree observed on the real corpus).
+func buildInternFixture(nRels, nEnts int) *graph.Document {
+	doc := &graph.Document{
+		Repo: "intern-fixture",
+	}
+	for i := 0; i < nEnts; i++ {
+		id := "entShared0000000A"
+		if i%2 == 1 {
+			id = "entShared0000000B"
+		}
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:            id + itoaSuffix(i),
+			Name:          "Entity" + itoaSuffix(i), // high-cardinality, must NOT dedupe entities themselves
+			QualifiedName: "pkg.Entity" + itoaSuffix(i),
+			Kind:          "FUNCTION",
+			Subtype:       "method",
+			SourceFile:    "shared/pkg/file.go",
+			Language:      "go",
+			Properties:    map[string]string{"module": "pkg/shared"},
+		})
+	}
+	// Two "anchor" entities that every relationship in this fixture points at.
+	doc.Entities = append(doc.Entities,
+		graph.Entity{ID: "anchorA00000000001", Name: "AnchorA", Kind: "FUNCTION", SourceFile: "anchor.go", Language: "go"},
+		graph.Entity{ID: "anchorB00000000002", Name: "AnchorB", Kind: "FUNCTION", SourceFile: "anchor.go", Language: "go"},
+	)
+	for i := 0; i < nRels; i++ {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			FromID: "anchorA00000000001",
+			ToID:   "anchorB00000000002",
+			Kind:   "CALLS",
+		})
+	}
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+	return doc
+}
+
+// itoaSuffix avoids importing strconv just for a handful of test fixture IDs.
+func itoaSuffix(i int) string {
+	digits := "0123456789"
+	if i == 0 {
+		return "0"
+	}
+	var b []byte
+	for i > 0 {
+		b = append([]byte{digits[i%10]}, b...)
+		i /= 10
+	}
+	return string(b)
+}
+
+// TestLoaderIntern_RoundtripCorrectness asserts that interning never drops or
+// corrupts a field: every entity and relationship must read back with its
+// exact original field values after passing through the loader interner.
+func TestLoaderIntern_RoundtripCorrectness(t *testing.T) {
+	doc := buildInternFixture(20, 10)
+	dir := t.TempDir()
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(got.Entities) != len(doc.Entities) {
+		t.Fatalf("entity count: got %d want %d", len(got.Entities), len(doc.Entities))
+	}
+	if len(got.Relationships) != len(doc.Relationships) {
+		t.Fatalf("relationship count: got %d want %d", len(got.Relationships), len(doc.Relationships))
+	}
+
+	byID := make(map[string]graph.Entity, len(got.Entities))
+	for _, e := range got.Entities {
+		byID[e.ID] = e
+	}
+	for _, want := range doc.Entities {
+		gotEnt, ok := byID[want.ID]
+		if !ok {
+			t.Fatalf("entity %q missing after load", want.ID)
+		}
+		if gotEnt.Name != want.Name {
+			t.Errorf("entity %q Name: got %q want %q", want.ID, gotEnt.Name, want.Name)
+		}
+		if gotEnt.QualifiedName != want.QualifiedName {
+			t.Errorf("entity %q QualifiedName: got %q want %q", want.ID, gotEnt.QualifiedName, want.QualifiedName)
+		}
+		if gotEnt.Kind != want.Kind {
+			t.Errorf("entity %q Kind: got %q want %q", want.ID, gotEnt.Kind, want.Kind)
+		}
+		if gotEnt.Subtype != want.Subtype {
+			t.Errorf("entity %q Subtype: got %q want %q", want.ID, gotEnt.Subtype, want.Subtype)
+		}
+		if gotEnt.SourceFile != want.SourceFile {
+			t.Errorf("entity %q SourceFile: got %q want %q", want.ID, gotEnt.SourceFile, want.SourceFile)
+		}
+		if gotEnt.Language != want.Language {
+			t.Errorf("entity %q Language: got %q want %q", want.ID, gotEnt.Language, want.Language)
+		}
+		for k, v := range want.Properties {
+			if gotEnt.Properties[k] != v {
+				t.Errorf("entity %q Properties[%q]: got %q want %q", want.ID, k, gotEnt.Properties[k], v)
+			}
+		}
+	}
+
+	for i, want := range doc.Relationships {
+		gotRel := got.Relationships[i]
+		if gotRel.FromID != want.FromID || gotRel.ToID != want.ToID || gotRel.Kind != want.Kind {
+			t.Errorf("relationship %d: got {%q %q %q} want {%q %q %q}",
+				i, gotRel.FromID, gotRel.ToID, gotRel.Kind, want.FromID, want.ToID, want.Kind)
+		}
+	}
+}
+
+// TestLoaderIntern_SharesBackingArray is the RED/GREEN proof: it verifies
+// that repeated occurrences of the same string VALUE in the loaded Document
+// share ONE backing array (same unsafe.StringData pointer), rather than each
+// occurrence carrying its own independently-allocated copy. This is the
+// resident-memory win a loader-side interner delivers on top of Tier-1a's
+// on-disk CreateSharedString (which only shrinks graph.fb, not the RAM
+// footprint of the materialized Document — the loader deep-copies every
+// string out of the mmap'd bytes regardless of on-disk sharing).
+func TestLoaderIntern_SharesBackingArray(t *testing.T) {
+	const nRels = 200
+	const nEnts = 50
+	doc := buildInternFixture(nRels, nEnts)
+	dir := t.TempDir()
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(got.Relationships) != nRels {
+		t.Fatalf("relationship count: got %d want %d", len(got.Relationships), nRels)
+	}
+
+	// (1) Every relationship's FromID must share backing storage with every
+	// other relationship's FromID (all equal to "anchorA00000000001") — the
+	// single biggest resident win: N endpoint references collapse to one
+	// backing array instead of N independent copies.
+	first := got.Relationships[0]
+	for i := 1; i < len(got.Relationships); i++ {
+		rel := got.Relationships[i]
+		if !samePointer(first.FromID, rel.FromID) {
+			t.Fatalf("relationship[%d].FromID does not share backing storage with relationship[0].FromID — from_id values are not interned", i)
+		}
+		if !samePointer(first.ToID, rel.ToID) {
+			t.Fatalf("relationship[%d].ToID does not share backing storage with relationship[0].ToID — to_id values are not interned", i)
+		}
+		if !samePointer(first.Kind, rel.Kind) {
+			t.Fatalf("relationship[%d].Kind does not share backing storage with relationship[0].Kind — relationship kind values are not interned", i)
+		}
+	}
+
+	// (2) Critical case: a relationship endpoint (FromID/ToID) MUST share
+	// backing storage with the corresponding entity's ID field — proving the
+	// interner is a single shared map across entity and relationship
+	// construction within one load, not two independent per-type interners.
+	var anchorA, anchorB *graph.Entity
+	for i := range got.Entities {
+		switch got.Entities[i].ID {
+		case "anchorA00000000001":
+			anchorA = &got.Entities[i]
+		case "anchorB00000000002":
+			anchorB = &got.Entities[i]
+		}
+	}
+	if anchorA == nil || anchorB == nil {
+		t.Fatalf("anchor entities missing after load")
+	}
+	if !samePointer(anchorA.ID, first.FromID) {
+		t.Error("entity anchorA.ID does not share backing storage with relationship FromID referencing it — entity id and relationship endpoint strings are not interned through the same map")
+	}
+	if !samePointer(anchorB.ID, first.ToID) {
+		t.Error("entity anchorB.ID does not share backing storage with relationship ToID referencing it — entity id and relationship endpoint strings are not interned through the same map")
+	}
+
+	// (3) Entity-side high-duplication fields (Kind/SourceFile/Language and
+	// property keys) must also share backing storage across entities.
+	var sample []graph.Entity
+	for _, e := range got.Entities {
+		if e.SourceFile == "shared/pkg/file.go" {
+			sample = append(sample, e)
+		}
+	}
+	if len(sample) < 2 {
+		t.Fatalf("expected at least 2 fixture entities with the shared source file, got %d", len(sample))
+	}
+	for i := 1; i < len(sample); i++ {
+		if !samePointer(sample[0].Kind, sample[i].Kind) {
+			t.Errorf("entity[%d].Kind does not share backing storage with entity[0].Kind", i)
+		}
+		if !samePointer(sample[0].SourceFile, sample[i].SourceFile) {
+			t.Errorf("entity[%d].SourceFile does not share backing storage with entity[0].SourceFile", i)
+		}
+		if !samePointer(sample[0].Language, sample[i].Language) {
+			t.Errorf("entity[%d].Language does not share backing storage with entity[0].Language", i)
+		}
+		// Name is genuinely unique per entity in this fixture and must NOT be
+		// forced to share storage — the interner must not touch high-cardinality
+		// fields (this would just bloat the interner map for no benefit).
+		if samePointer(sample[0].Name, sample[i].Name) {
+			t.Errorf("entity[%d].Name unexpectedly shares backing storage with entity[0].Name — Name is high-cardinality and must not be interned", i)
+		}
+	}
+}

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -129,6 +129,62 @@ func PersistedStatsFromDir(dir string) (PersistedStats, bool) {
 	return ps, true
 }
 
+// stringInterner canonicalizes repeated string VALUES seen during a single
+// loadFBDocument call so that N occurrences of an equal string share ONE Go
+// backing array in the resulting *Document, instead of each occurrence
+// paying for its own independently-allocated copy.
+//
+// This is the RESIDENT-memory counterpart to fbwriter's CreateSharedString
+// (Tier-1a, #5846): that optimization dedupes strings ON DISK, but the
+// loader still calls string(fbBytes) once per field per record, which always
+// allocates a fresh backing array regardless of on-disk sharing — so Tier-1a
+// alone shrinks graph.fb but not the loaded Document's heap footprint. The
+// interner closes that gap for the loader's own materialization.
+//
+// Only apply this to HIGH-DUPLICATION fields (entity id/kind/subtype/module/
+// source_file/language and property keys; relationship from_id/to_id/kind).
+// Do NOT intern genuinely-unique/high-cardinality fields (name,
+// qualified_name, signature, property VALUES) — interning those would only
+// grow the interner map with no dedup benefit.
+//
+// Concurrency: loadFBDocument builds every entity and relationship
+// SEQUENTIALLY in a single goroutine (the for-loops below run in program
+// order, no goroutines are spawned), so a plain, unsynchronized map is safe
+// here. If this loop is ever parallelized, this type must be guarded (mutex
+// or sharded) or replaced with a sync.Map to avoid a data race.
+//
+// Critically, ONE interner instance is shared across BOTH entity and
+// relationship construction within a single load (see loadFBDocument below),
+// so a relationship's from_id/to_id canonicalizes to the SAME backing array
+// as the referenced entity's id — the biggest win, since on the real corpus
+// each entity id is referenced by relationship endpoints ~8.7x on average
+// (mean node degree).
+type stringInterner struct {
+	m map[string]string
+}
+
+func newStringInterner() *stringInterner {
+	return &stringInterner{m: make(map[string]string)}
+}
+
+// intern returns the canonical copy of the string represented by b, sharing
+// backing storage with any prior call that saw byte-identical content. The
+// initial lookup uses the b-as-map-key form (m[string(b)]) directly as the
+// index expression so the Go compiler's built-in optimization avoids
+// allocating a string on the (common, high-duplication) hit path; only a
+// miss pays for one allocation to create the canonical copy.
+func (si *stringInterner) intern(b []byte) string {
+	if len(b) == 0 {
+		return ""
+	}
+	if v, ok := si.m[string(b)]; ok {
+		return v
+	}
+	s := string(b)
+	si.m[s] = s
+	return s
+}
+
 // loadFBDocument decodes a graph.fb file into a *Document. It opens the
 // file with fbreader (mmap + single bulk read), then converts the lazy
 // FlatBuffers view into an in-memory *Document by iterating the entity
@@ -158,13 +214,18 @@ func loadFBDocument(path string) (*Document, error) {
 	nEnts := r.EntityCount()
 	nRels := r.RelationshipCount()
 
+	// Shared across both entity and relationship construction below (see
+	// stringInterner doc comment) so relationship endpoints canonicalize to
+	// the same backing array as the entity ids they reference.
+	si := newStringInterner()
+
 	entities := make([]Entity, 0, nEnts)
 	for i := 0; i < nEnts; i++ {
 		fbEnt := r.EntityAt(i)
 		if fbEnt == nil {
 			continue
 		}
-		entities = append(entities, fbEntityToGraphEntity(fbEnt))
+		entities = append(entities, fbEntityToGraphEntity(fbEnt, si))
 	}
 
 	rels := make([]Relationship, 0, nRels)
@@ -173,7 +234,7 @@ func loadFBDocument(path string) (*Document, error) {
 		if fbRel == nil {
 			continue
 		}
-		rels = append(rels, fbRelToGraphRel(fbRel))
+		rels = append(rels, fbRelToGraphRel(fbRel, si))
 	}
 
 	// Restore the aggregate Pass-4 community list + corpus stats (#1620).
@@ -252,28 +313,34 @@ func loadJSONDocument(path string) (*Document, error) {
 // the canonical graph.Entity struct. All string fields are copied out
 // of the mmap'd bytes so the returned struct is safe to use after the
 // Reader is closed.
-func fbEntityToGraphEntity(e *fb.Entity) Entity {
+//
+// High-duplication fields (Id/Kind/Subtype/Module/SourceFile/Language and
+// property keys) are canonicalized through si so repeated values across
+// entities (and, for Id, across relationship endpoints referencing it) share
+// one backing array. Name/QualifiedName/Signature/property VALUES are
+// genuinely high-cardinality and are intentionally NOT interned.
+func fbEntityToGraphEntity(e *fb.Entity, si *stringInterner) Entity {
 	props := make(map[string]string, e.PropertiesLength())
 	var pe fb.PropertyEntry
 	for i := 0; i < e.PropertiesLength(); i++ {
 		if e.Properties(&pe, i) {
-			props[string(pe.Key())] = string(pe.Value())
+			props[si.intern(pe.Key())] = string(pe.Value())
 		}
 	}
 	ent := Entity{
-		ID:            string(e.Id()),
+		ID:            si.intern(e.Id()),
 		Name:          string(e.Name()),
 		QualifiedName: string(e.QualifiedName()),
-		Kind:          string(e.Kind()),
-		Subtype:       string(e.Subtype()),
-		SourceFile:    string(e.SourceFile()),
+		Kind:          si.intern(e.Kind()),
+		Subtype:       si.intern(e.Subtype()),
+		SourceFile:    si.intern(e.SourceFile()),
 		StartLine:     int(e.SourceLine()),
 		Properties:    props,
 	}
 	// The Module field is stored as a top-level FB scalar by the writer
 	// (see fbwriter.buildEntity). Restore it into Properties["module"]
 	// so callers that read props["module"] continue to work.
-	if mod := string(e.Module()); mod != "" {
+	if mod := si.intern(e.Module()); mod != "" {
 		if props == nil {
 			props = map[string]string{}
 		}
@@ -282,7 +349,7 @@ func fbEntityToGraphEntity(e *fb.Entity) Entity {
 	}
 	// Issue #2370 — Language is read directly from the dedicated FB slot.
 	// The PR #2365 property-tunnel restore (props["language"]) is retired.
-	if lang := string(e.Language()); lang != "" {
+	if lang := si.intern(e.Language()); lang != "" {
 		ent.Language = lang
 	}
 	// Issue #4881 — restore the entity Signature from its dedicated FB slot.
@@ -335,18 +402,23 @@ func fbCommunityToResult(c *fb.Community) CommunityResult {
 
 // fbRelToGraphRel converts one lazy FlatBuffers Relationship view into
 // the canonical graph.Relationship struct.
-func fbRelToGraphRel(r *fb.Relationship) Relationship {
+//
+// FromID/ToID/Kind and property keys are canonicalized through si — the SAME
+// interner instance used for entity ids (see loadFBDocument) — so an
+// endpoint string shares backing storage with the entity.ID it references
+// rather than allocating its own copy.
+func fbRelToGraphRel(r *fb.Relationship, si *stringInterner) Relationship {
 	props := make(map[string]string, r.PropertiesLength())
 	var pe fb.PropertyEntry
 	for i := 0; i < r.PropertiesLength(); i++ {
 		if r.Properties(&pe, i) {
-			props[string(pe.Key())] = string(pe.Value())
+			props[si.intern(pe.Key())] = string(pe.Value())
 		}
 	}
 	rel := Relationship{
-		FromID:     string(r.FromId()),
-		ToID:       string(r.ToId()),
-		Kind:       string(r.Kind()),
+		FromID:     si.intern(r.FromId()),
+		ToID:       si.intern(r.ToId()),
+		Kind:       si.intern(r.Kind()),
 		Properties: props,
 	}
 	// Restore the ID from Properties if the writer stored it.

--- a/internal/mcp/membaseline_test.go
+++ b/internal/mcp/membaseline_test.go
@@ -1,0 +1,196 @@
+package mcp
+
+// Reusable before/after resident-memory measurement harness for grafel's
+// served graph. Given a path to a graph.fb, it loads the graph through the
+// SAME code path the daemon/MCP uses to build the resident structure —
+// graph.LoadGraphFromDir -> graph.Document, then the mcp-side LoadedRepo with
+// its eager LabelIndex and the lazily-built derived indexes (byID, adjacency,
+// calls/step adjacency, top-K PageRank) that a served repo materializes — then
+// reports on-disk size, resident HeapInuse/HeapAlloc (after forced GCs), the
+// process RSS, entity/relationship counts, and the derived per-record and
+// inflation ratios.
+//
+// It is GATED behind the GRAFEL_MEM_BASELINE_FB env var so it never runs in a
+// normal `go test ./...`; it only executes when explicitly pointed at a
+// graph.fb. This makes it re-runnable against a "before" and later an "after"
+// graph.fb for an apples-to-apples delta.
+//
+// RUN (point GRAFEL_MEM_BASELINE_FB at any graph.fb):
+//
+//	GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb \
+//	  go test ./internal/mcp/ -run TestMemBaseline -v -count=1 -timeout 30m
+//
+// Output is numeric aggregates only (sizes, counts, MB, per-record bytes).
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// rssFromPS reads the current process RSS via `ps -o rss= -p <pid>`, which
+// reports resident-set size in KiB on darwin/BSD/linux. Returns 0 on failure.
+func rssFromPS() uint64 {
+	out, err := exec.Command("ps", "-o", "rss=", "-p", strconv.Itoa(os.Getpid())).Output()
+	if err != nil {
+		return 0
+	}
+	kib, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return kib * 1024
+}
+
+// rssBytes returns the current process resident-set size in bytes, or 0 if it
+// cannot be read on this platform. macOS/BSD `ps -o rss=` reports KiB; Linux
+// /proc/self/statm reports pages. We prefer /proc when present (Linux) and fall
+// back to a self-contained rusage read that works on darwin.
+func rssBytes(t *testing.T) uint64 {
+	// Linux: /proc/self/statm — field 2 is resident pages.
+	if b, err := os.ReadFile("/proc/self/statm"); err == nil {
+		var size, resident uint64
+		if _, serr := fmt.Sscanf(string(b), "%d %d", &size, &resident); serr == nil {
+			return resident * uint64(os.Getpagesize())
+		}
+	}
+	// Darwin/BSD: getrusage ru_maxrss is in BYTES on darwin, KiB on linux.
+	// We already handled linux above; on darwin ru_maxrss is bytes. Use it via
+	// a tiny syscall-free path through runtime is not possible, so shell out to
+	// `ps` which is universally available and reports RSS in KiB on darwin.
+	if v := rssFromPS(); v > 0 {
+		return v
+	}
+	return 0
+}
+
+func mbf(b uint64) float64 { return float64(b) / (1024 * 1024) }
+
+func TestMemBaseline(t *testing.T) {
+	fbPath := os.Getenv("GRAFEL_MEM_BASELINE_FB")
+	if fbPath == "" {
+		t.Skip("set GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb to run the resident-memory baseline harness")
+	}
+
+	fi, err := os.Stat(fbPath)
+	if err != nil {
+		t.Fatalf("stat graph.fb: %v", err)
+	}
+	if fi.IsDir() {
+		fbPath = filepath.Join(fbPath, "graph.fb")
+		if fi, err = os.Stat(fbPath); err != nil {
+			t.Fatalf("stat graph.fb in dir: %v", err)
+		}
+	}
+	onDisk := uint64(fi.Size())
+	stateDir := filepath.Dir(fbPath)
+
+	// --- Baseline heap: settle the process before we load anything. ---
+	runtime.GC()
+	runtime.GC()
+	var mBase runtime.MemStats
+	runtime.ReadMemStats(&mBase)
+
+	// --- Stage 1: materialize graph.Document via the real loader. ---
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	nEnt := len(doc.Entities)
+	nRel := len(doc.Relationships)
+	if nEnt == 0 {
+		t.Fatalf("graph loaded 0 entities — wrong path?")
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var mDoc runtime.MemStats
+	runtime.ReadMemStats(&mDoc)
+
+	// --- Stage 2: build the mcp-side resident structures a served repo holds.
+	// LabelIndex is built eagerly at reload (state.go reloadLocked); the derived
+	// traversal indexes are built lazily on first tool use — we force them all
+	// so the number reflects a fully-warmed served repo, not a cold one. ---
+	lr := &LoadedRepo{
+		Repo:      "corpus",
+		Doc:       doc,
+		GraphFile: fbPath,
+	}
+	lr.LabelIndex = BuildLabelIndex(doc) // eager, as in reloadLocked
+	// Force every lazy derived index the served repo materializes on use.
+	_ = lr.getByID()
+	_ = lr.getAdjacency()
+	_ = lr.getCallsAdj()
+	_ = lr.getStepAdj()
+	_ = lr.getTopKPageRank()
+	// BM25 is the heavy search index also held resident once search is used.
+	bm25 := lr.getBM25()
+
+	// Drop transient garbage from index construction, settle, and measure the
+	// fully-warmed resident footprint.
+	runtime.GC()
+	runtime.GC()
+	var mFull runtime.MemStats
+	runtime.ReadMemStats(&mFull)
+
+	rss := rssBytes(t)
+
+	// Keep everything alive across the measurement so GC can't reclaim it.
+	runtime.KeepAlive(doc)
+	runtime.KeepAlive(lr)
+	runtime.KeepAlive(bm25)
+
+	// --- Derived aggregates. ---
+	// Resident heap attributable to Document alone (stage1 - baseline).
+	docHeapInuse := int64(mDoc.HeapInuse) - int64(mBase.HeapInuse)
+	docHeapAlloc := int64(mDoc.HeapAlloc) - int64(mBase.HeapAlloc)
+	// Resident heap attributable to the mcp index maps (stage2 - stage1).
+	idxHeapInuse := int64(mFull.HeapInuse) - int64(mDoc.HeapInuse)
+	idxHeapAlloc := int64(mFull.HeapAlloc) - int64(mDoc.HeapAlloc)
+	// Full resident (Document + all served indexes), above the empty-process base.
+	fullHeapInuse := int64(mFull.HeapInuse) - int64(mBase.HeapInuse)
+	fullHeapAlloc := int64(mFull.HeapAlloc) - int64(mBase.HeapAlloc)
+
+	nRecords := nEnt + nRel
+	perEntInuse := float64(fullHeapInuse) / float64(nEnt)
+	perRelInuse := float64(fullHeapInuse) / float64(nRel)
+	perRecordInuse := float64(fullHeapInuse) / float64(nRecords)
+	perRecordOnDisk := float64(onDisk) / float64(nRecords)
+	inflation := float64(fullHeapInuse) / float64(onDisk)
+
+	t.Logf("=== grafel resident-memory baseline (numbers only) ===")
+	t.Logf("on-disk graph.fb bytes        : %d (%.1f MB)", onDisk, mbf(onDisk))
+	t.Logf("entities                      : %d", nEnt)
+	t.Logf("relationships                 : %d", nRel)
+	t.Logf("records (ent+rel)             : %d", nRecords)
+	t.Logf("--- absolute MemStats snapshots (HeapInuse / HeapAlloc, MB) ---")
+	t.Logf("  empty-process baseline      : %.1f / %.1f MB", mbf(mBase.HeapInuse), mbf(mBase.HeapAlloc))
+	t.Logf("  after Document load         : %.1f / %.1f MB", mbf(mDoc.HeapInuse), mbf(mDoc.HeapAlloc))
+	t.Logf("  after full LoadedRepo warm  : %.1f / %.1f MB", mbf(mFull.HeapInuse), mbf(mFull.HeapAlloc))
+	t.Logf("--- attributable resident deltas (bytes / MB) ---")
+	t.Logf("  Document alone   HeapInuse  : %d (%.1f MB)", docHeapInuse, float64(docHeapInuse)/(1024*1024))
+	t.Logf("  Document alone   HeapAlloc  : %d (%.1f MB)", docHeapAlloc, float64(docHeapAlloc)/(1024*1024))
+	t.Logf("  mcp indexes only HeapInuse  : %d (%.1f MB)", idxHeapInuse, float64(idxHeapInuse)/(1024*1024))
+	t.Logf("  mcp indexes only HeapAlloc  : %d (%.1f MB)", idxHeapAlloc, float64(idxHeapAlloc)/(1024*1024))
+	t.Logf("  FULL resident    HeapInuse  : %d (%.1f MB)", fullHeapInuse, float64(fullHeapInuse)/(1024*1024))
+	t.Logf("  FULL resident    HeapAlloc  : %d (%.1f MB)", fullHeapAlloc, float64(fullHeapAlloc)/(1024*1024))
+	t.Logf("--- process RSS ---")
+	if rss > 0 {
+		t.Logf("  process RSS (warmed)        : %d (%.1f MB)", rss, mbf(rss))
+	} else {
+		t.Logf("  process RSS (warmed)        : unavailable on this platform")
+	}
+	t.Logf("--- derived per-record (resident FULL HeapInuse basis) ---")
+	t.Logf("  bytes / entity  (resident)  : %.1f", perEntInuse)
+	t.Logf("  bytes / rel     (resident)  : %.1f", perRelInuse)
+	t.Logf("  bytes / record  (resident)  : %.1f", perRecordInuse)
+	t.Logf("  bytes / record  (on-disk)   : %.1f", perRecordOnDisk)
+	t.Logf("  resident / on-disk inflation: %.2fx", inflation)
+}


### PR DESCRIPTION
## What

Tier-1b of the resident-graph memory program (#5822 ①). Tier-1a (#5846) interned strings in the *writer* — that shrank `graph.fb` on disk 43.7% but did nothing for RAM, because the loader deep-copies every string when materializing the native `graph.Document`. This adds a per-load string interner so that N references to the same value share one Go backing array instead of N copies.

Also lands the reusable env-gated memory baseline harness (`internal/mcp/membaseline_test.go`, skipped unless `GRAFEL_MEM_BASELINE_FB` is set) used to measure every tier.

## How

`internal/graph/load.go`: a `stringInterner` (`map[string]string`) built once per `loadFBDocument`, shared across entity + relationship construction, discarded after the load returns. Interns high-duplication fields — entity `id`/`kind`/`subtype`/`module`/`source_file`/`language` + property keys, and relationship `from_id`/`to_id`/`kind` + property keys — with endpoints interned through the **same** map as entity `id`, so a `from_id`/`to_id` shares backing with its target entity's `ID` (the biggest win: ~8.7 endpoint refs per id at corpus node degree). Genuinely-unique fields (`name`, `qualified_name`, `signature`, property values) are left alone. Load is single-goroutine, so the plain map needs no synchronization. Safe because Go strings are immutable — value-keyed sharing can never corrupt.

## Measured (real corpus graph.fb, 427,261 entities / 1,852,584 relationships)

| Metric | Before | After | Δ |
|---|---|---|---|
| Full resident HeapAlloc | 1,893.3 MB | 1,696.1 MB | **−197.3 MB (−10.42%)** |
| Document-alone HeapAlloc | 1,188.9 MB | 991.7 MB | −197.2 MB (−16.6%) |

Realized on the next daemon **load** — no reindex required (loader change, not writer).

## Review + tests

Independently reviewed → APPROVE, with the ~197 MB reproduced almost exactly (206,845,016 B) on the real corpus and field-by-field wiring + per-load scope + no-mutation-aliasing verified. Tests: `TestLoaderIntern_RoundtripCorrectness` and `TestLoaderIntern_SharesBackingArray` (pointer-identity proof via `unsafe.StringData`, RED→GREEN). `go build ./...`, `go vet`, `go test ./internal/graph/... ./internal/mcp/... -race` (all pass), `gofmt -l` clean.

Refs #5822 ①.