### PR TITLE
feat(status): detect graph-format-version mismatch → reindex-required state (reindex-on-update PR1/3)

### DIFF
--- a/internal/cli/status_json_test.go
+++ b/internal/cli/status_json_test.go
@@ -144,6 +144,69 @@ func TestRunStatusJSON_ReadsFileNotSocket(t *testing.T) {
 	}
 }
 
+// TestRunStatusJSON_ReindexRequiredRoundTrips is the RED test for the
+// "reindex-required after graph-format change" epic, PR1: `grafel status
+// --json` must surface reindex_required/reindex_reason verbatim from the
+// on-disk statusfile.File — the same additive-JSON pass-through as every
+// other statusfile field, so this repo's incompatible-format state is never
+// hidden from a poll-safe reader (the "silent-green lie" this epic exists to
+// fix). statusJSONResult embeds *statusfile.File, so no derived/overridden
+// "status" logic is needed here: the raw fields simply appear in the output.
+func TestRunStatusJSON_ReindexRequiredRoundTrips(t *testing.T) {
+	tmpHome := t.TempDir()
+	t.Setenv("GRAFEL_HOME", tmpHome)
+
+	repoRoot := t.TempDir()
+	configDir := filepath.Join(tmpHome, ".config", "grafel")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(configDir, "g.fleet.json")
+	cfg := &registry.GroupConfig{
+		Name:  "g",
+		Repos: []registry.Repo{{Slug: "r", Path: repoRoot}},
+	}
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg := &registry.Registry{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: "g", ConfigPath: cfgPath}},
+	}
+	if err := registry.Save(reg); err != nil {
+		t.Fatal(err)
+	}
+
+	want := &statusfile.File{
+		EnginePID:       12345,
+		HeartbeatAt:     time.Now().UTC(),
+		Version:         "test-version",
+		RepoPath:        repoRoot,
+		ReindexRequired: true,
+		ReindexReason:   "graph format v2 incompatible with v4 — reindex required",
+	}
+	if err := statusfile.Write(repoRoot, want); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runStatusJSON(&buf, repoRoot); err != nil {
+		t.Fatalf("runStatusJSON: %v", err)
+	}
+
+	var got statusfile.File
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output not valid JSON: %v\n%s", err, buf.String())
+	}
+	if !got.ReindexRequired {
+		t.Error("ReindexRequired should round-trip as true")
+	}
+	if got.ReindexReason != want.ReindexReason {
+		t.Errorf("ReindexReason = %q, want %q", got.ReindexReason, want.ReindexReason)
+	}
+}
+
 // TestRunStatusJSON_UnknownFallback confirms a repo with no status file yet
 // (engine never touched it, or is down) returns a well-formed "unknown"
 // result rather than an error/hang.

--- a/internal/cli/statusline.go
+++ b/internal/cli/statusline.go
@@ -24,8 +24,8 @@ whichever example segment fits your setup into your own statusline script
 or config.
 
 --snippet prints ONLY the icon-based bash segment (state precedence: engine
-down > error > indexing > idle > not indexed), suitable for piping straight
-into a file.`,
+down > indexing > reindex required > error > idle > not indexed), suitable
+for piping straight into a file.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if snippetOnly {
 				_, err := cmd.OutOrStdout().Write([]byte(statuslineIconSnippet()))
@@ -70,15 +70,37 @@ fi
 `
 
 // statuslineIconSnippet is example 3b: the canonical icon-state segment.
-// State precedence: engine down (heartbeat >15s stale) > last_err set >
-// indexing > idle (graph_fb_mtime>0, "X ago") > not indexed (graph_fb_mtime
-// == 0). Prints nothing if this isn't a grafel-indexed repo (no status
-// file). Self-contained: no external color/helper dependency, works when
-// piped or run non-interactively.
+//
+// State precedence: engine down (heartbeat >15s stale) > indexing >
+// reindex_required > last_err set > idle (graph_fb_mtime>0, "X ago") >
+// not indexed (graph_fb_mtime == 0).
+//
+// reindex_required sits between indexing and last_err (#reindex-required
+// PR1) — this is the fix for the "silent-green lie": before this field
+// existed, a repo whose on-disk graph.fb was an incompatible old format
+// version rendered as a plain green "✓ 3m ago" (graph_fb_mtime was still
+// stamped from the last successful index at the OLD format), even though
+// grafel can no longer actually read that graph. Placement rationale:
+//   - BELOW indexing: an index currently in flight (possibly the user's own
+//     remediation, e.g. they just ran `grafel index`) is more temporally
+//     relevant right now than a static flag that is about to self-clear the
+//     moment that very index completes.
+//   - ABOVE last_err: reindex_required is recomputed FRESH from the actual
+//     graph.fb bytes on every ~5s heartbeat (internal/daemon/statuswriter.go,
+//     writeRepoStatusFile -> graph.ReindexRequiredReason), so it is always
+//     the current, authoritative truth about whether THIS repo's graph is
+//     servable. last_err is a snapshot of the most recently COMPLETED index
+//     attempt — potentially stale (e.g. a transient failure hours ago that a
+//     later successful index superseded, if last_err is ever not cleared on
+//     success) — so a live, freshly-recomputed signal outranks a snapshot.
+//
+// Prints nothing if this isn't a grafel-indexed repo (no status file).
+// Self-contained: no external color/helper dependency, works when piped or
+// run non-interactively.
 func statuslineIconSnippet() string {
 	return `#!/usr/bin/env bash
 # grafel statusline segment — icon states
-# Precedence: engine down > error > indexing > idle (age) > not indexed.
+# Precedence: engine down > indexing > reindex required > error > idle (age) > not indexed.
 # Prints nothing if this isn't a grafel-indexed repo.
 c_red=$'\033[31m'; c_yellow=$'\033[33m'; c_green=$'\033[32m'; c_dim=$'\033[2m'; c_reset=$'\033[0m'
 
@@ -90,6 +112,7 @@ g_sfile="${GRAFEL_HOME:-$HOME/.grafel}/status/$g_hash.json"
 
 g_json=$(cat "$g_sfile")
 indexing=$(printf '%s' "$g_json" | jq -r '.indexing // false')
+reindex_required=$(printf '%s' "$g_json" | jq -r '.reindex_required // false')
 err=$(printf '%s' "$g_json" | jq -r '.last_err // empty')
 hb=$(printf '%s' "$g_json" | jq -r '.heartbeat_at // empty')
 mtime_ns=$(printf '%s' "$g_json" | jq -r '.graph_fb_mtime // 0')
@@ -106,10 +129,12 @@ fi
 
 if [ "$down" = "1" ]; then
   echo "${c_red}⚠ down${c_reset}"
-elif [ -n "$err" ]; then
-  echo "${c_red}✗ error${c_reset}"
 elif [ "$indexing" = "true" ]; then
   echo "${c_yellow}⟳ indexing${c_reset}"
+elif [ "$reindex_required" = "true" ]; then
+  echo "${c_yellow}⟲ reindex required${c_reset}"
+elif [ -n "$err" ]; then
+  echo "${c_red}✗ error${c_reset}"
 elif [ "$mtime_ns" != "0" ] && [ -n "$mtime_ns" ]; then
   mtime=$((mtime_ns / 1000000000))
   age=$((now - mtime))
@@ -202,6 +227,20 @@ Key fields:
   indexing         bool     true while an index is running right now
   queue_len        int      jobs queued behind this repo (omitempty)
   last_err         string   most recent index error, if any (omitempty)
+  reindex_required bool     true when the on-disk graph.fb this repo is
+                            SERVING was written by an older grafel build
+                            than this engine's format version supports
+                            (omitempty). Recomputed fresh from the actual
+                            graph.fb bytes on every heartbeat — this is
+                            what a repo looks like when it needs a
+                            ` + "`grafel index <repo>`" + ` re-run before grafel can
+                            trust what it's serving. Detection-only in
+                            this release: nothing auto-reindexes or
+                            prompts you yet.
+  reindex_reason   string   human-readable explanation set whenever
+                            reindex_required is true, naming both the
+                            found and required graph.fb format versions
+                            (omitempty)
 
 2. Two ways to read it
 -----------------------

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -119,6 +119,19 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 		if graphPath, mtimeNano := FindGraphFile(repoPath); graphPath != "" {
 			f.GraphFBMtime = mtimeNano
 		}
+		// #reindex-required PR1: recompute FRESH on every heartbeat, directly
+		// from the on-disk graph.fb bytes, rather than trusting any prior
+		// write or a serve-side in-process observation. This is the
+		// authoritative, race-free source of truth for ReindexRequired: the
+		// engine is documented as the SOLE writer of this statusfile (see the
+		// package doc above), and this File struct is rebuilt from scratch on
+		// every call, so recomputing here means the flag is always correct —
+		// it self-clears the instant a fresh reindex lands, and it can never
+		// be silently overwritten stale by this same writer's next tick (the
+		// cross-process race a one-shot flag set from internal/mcp's reload
+		// loop would be exposed to under ADR-0024 split mode). Detection only:
+		// this never triggers a reindex.
+		f.ReindexRequired, f.ReindexReason = graph.ReindexRequiredReason(stateDir)
 	}
 
 	// Split the single "indexing" signal into indexing (extraction, graph not

--- a/internal/daemon/statuswriter_reindex_required_test.go
+++ b/internal/daemon/statuswriter_reindex_required_test.go
@@ -1,0 +1,121 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// writeOldFormatGraphFBAt builds a minimal valid graph.fb via fbwriter.Marshal,
+// then patches the on-disk Graph.version scalar down to oldVersion (mirrors
+// internal/graph/reindex_required_test.go's writeOldFormatGraphFB) so this
+// test can fabricate a graph.fb written by an older grafel build without an
+// actual old binary. dir is the repo's state dir (daemon.StateDirForRepo).
+func writeOldFormatGraphFBAt(t *testing.T, dir string, oldVersion int) {
+	t.Helper()
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-old-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	buf, err := fbwriter.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	root := fb.GetRootAsGraph(buf, 0)
+	if !root.MutateVersion(int32(oldVersion)) {
+		t.Fatalf("MutateVersion(%d) returned false — slot missing?", oldVersion)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), buf, 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// TestWriteRepoStatusFile_ReindexRequired is the RED test for the
+// "reindex-required after graph-format change" epic, PR1 (detection + state
+// only — no auto-reindex, no prompt). writeRepoStatusFile is the SOLE
+// statusfile writer (per package doc); it must independently recompute
+// ReindexRequired/ReindexReason from the actual on-disk graph.fb bytes on
+// every call, so an old-format graph is reflected in the persisted status
+// even though nothing here triggers a reindex.
+func TestWriteRepoStatusFile_ReindexRequired(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	stateDir := StateDirForRepo(repo)
+	writeOldFormatGraphFBAt(t, stateDir, 2)
+
+	writeRepoStatusFile(repo, nil)
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if !got.ReindexRequired {
+		t.Fatal("expected ReindexRequired=true for a repo whose graph.fb is an old format version")
+	}
+	if got.ReindexReason == "" {
+		t.Fatal("expected a non-empty ReindexReason")
+	}
+}
+
+// TestWriteRepoStatusFile_ReindexRequired_CurrentVersionRegression is the
+// regression guard: a repo whose graph.fb is at the current format version
+// (or has no graph.fb at all) must never be flagged ReindexRequired.
+func TestWriteRepoStatusFile_ReindexRequired_CurrentVersionRegression(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	stateDir := StateDirForRepo(repo)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-current-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir stateDir: %v", err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	writeRepoStatusFile(repo, nil)
+
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if got.ReindexRequired {
+		t.Errorf("expected ReindexRequired=false for a current-version graph.fb, got reason %q", got.ReindexReason)
+	}
+
+	// A repo with no graph.fb at all (never indexed) must also not be flagged.
+	repo2 := t.TempDir()
+	writeRepoStatusFile(repo2, nil)
+	got2, err := statusfile.Read(repo2)
+	if err != nil {
+		t.Fatalf("statusfile.Read repo2: %v", err)
+	}
+	if got2.ReindexRequired {
+		t.Errorf("expected ReindexRequired=false for a never-indexed repo, got reason %q", got2.ReindexReason)
+	}
+}

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -29,6 +29,82 @@ import (
 // package shared with fbwriter — so drift becomes a compile-time error.
 const minSupportedFBFormatVersion = fbversion.Version
 
+// FormatVersionError is returned (wrapped, via %w) by loadFBDocument when an
+// on-disk graph.fb was stamped with a FormatVersion older than this binary
+// requires. It exists as a typed error — rather than forcing callers to
+// string-match the human-readable message below — so a caller like
+// internal/mcp's reload loop can detect "this specific repo's on-disk graph
+// is version-incompatible" via errors.As and record durable state (e.g. a
+// statusfile ReindexRequired flag), instead of only stashing the opaque error
+// string and silently continuing (the "silent-green lie" this type exists to
+// let callers fix).
+type FormatVersionError struct {
+	// Found is the FormatVersion actually stamped on the rejected graph.fb.
+	Found int
+	// Required is the minimum FormatVersion this binary accepts
+	// (fbversion.Version at build time).
+	Required int
+}
+
+// Error implements the error interface. The wording is part of the loader's
+// user-facing contract (internal/graph/fbwriter/writer_test.go asserts on
+// substrings of it verbatim) and must keep pointing the user at `grafel
+// index <repo>`.
+func (e *FormatVersionError) Error() string {
+	return fmt.Sprintf(
+		"graph.fb format version %d is older than required version %d — please reindex (run: grafel index <repo>)",
+		e.Found, e.Required,
+	)
+}
+
+// ReindexRequiredReason performs a cheap, header-only check of dir's
+// graph.fb (no entity/relationship materialization — just an mmap open plus
+// one scalar read) and reports whether it was written by an older grafel
+// build than this binary supports.
+//
+// required is false — the overwhelmingly common case — when graph.fb is
+// absent, unreadable, or already at/above minSupportedFBFormatVersion; a
+// caller must not treat that as an error, only as "nothing to report".
+// required is true only when the on-disk FormatVersion is strictly below
+// what this binary accepts, in which case reason names both versions and
+// points at the fix, mirroring FormatVersionError's wording so a human sees
+// one consistent message whether they hit it via a failed MCP reload or via
+// the persisted status-plane sidecar.
+//
+// This is deliberately independent of any single load attempt: it is safe
+// to call on every status-plane heartbeat (see internal/daemon's
+// writeRepoStatusFile) so the persisted ReindexRequired flag is always
+// freshly recomputed from the ACTUAL bytes on disk, never a one-shot flag
+// that could go stale or get clobbered by a later write from a different
+// writer.
+func ReindexRequiredReason(dir string) (required bool, reason string) {
+	fbPath := filepath.Join(dir, "graph.fb")
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		return false, ""
+	}
+	defer r.Close()
+	v := r.Version()
+	if v >= minSupportedFBFormatVersion {
+		return false, ""
+	}
+	return true, FormatVersionReason(v, minSupportedFBFormatVersion)
+}
+
+// FormatVersionReason renders the shared human-readable "reindex required"
+// explanation naming both the found and required graph.fb format versions.
+// Exported so every caller that detects a *FormatVersionError (the header-only
+// ReindexRequiredReason check above, and internal/mcp's reload loop reacting
+// to a failed LoadGraphFromDir) renders the IDENTICAL wording — one consistent
+// message regardless of which code path first observed the incompatibility.
+func FormatVersionReason(found, required int) string {
+	fvErr := &FormatVersionError{Found: found, Required: required}
+	return fmt.Sprintf(
+		"graph format v%d incompatible with v%d — reindex required (%s)",
+		found, required, fvErr.Error(),
+	)
+}
+
 // LoadGraphFromDir loads a graph.Document from dir, where dir is the
 // .grafel state directory for a repo (the directory that contains
 // graph.fb / graph.json).
@@ -202,10 +278,8 @@ func loadFBDocument(path string) (*Document, error) {
 	// rerun `grafel index <repo>` to regenerate graph.fb against the
 	// current schema.
 	if v := r.Version(); v < minSupportedFBFormatVersion {
-		return nil, fmt.Errorf(
-			"graph.loadFBDocument: graph.fb format version %d is older than required version %d — please reindex (run: grafel index <repo>)",
-			v, minSupportedFBFormatVersion,
-		)
+		return nil, fmt.Errorf("graph.loadFBDocument: %w",
+			&FormatVersionError{Found: v, Required: minSupportedFBFormatVersion})
 	}
 
 	meta := r.LoadGraphMeta()

--- a/internal/graph/reindex_required_test.go
+++ b/internal/graph/reindex_required_test.go
@@ -1,0 +1,130 @@
+// Tests for the reindex-required detection primitive added to
+// internal/graph/load.go (PR1 of the "reindex-required after graph-format
+// change" epic). This slice is detection + state ONLY — no auto-reindex.
+package graph_test
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbversion"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeOldFormatGraphFB builds a minimal valid graph.fb via fbwriter.Marshal,
+// then patches the on-disk Graph.version scalar down to oldVersion (mirrors
+// the technique in internal/graph/fbwriter/writer_test.go's
+// TestLoaderRejectsOldFormatVersion) so tests can fabricate a graph.fb
+// written by an older grafel build without needing an actual old binary.
+func writeOldFormatGraphFB(t *testing.T, dir string, oldVersion int) {
+	t.Helper()
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-old-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	buf, err := fbwriter.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	root := fb.GetRootAsGraph(buf, 0)
+	if !root.MutateVersion(int32(oldVersion)) {
+		t.Fatalf("MutateVersion(%d) returned false — slot missing?", oldVersion)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), buf, 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// TestLoadGraphFromDir_OldFormatVersion_ReturnsTypedError is the RED test
+// proving the loader rejects an old-format graph.fb AND that the rejection
+// is detectable via errors.As(&graph.FormatVersionError{}) — not just a
+// human-readable string — so a caller (internal/mcp's reload loop) can
+// record durable ReindexRequired state instead of only stashing an opaque
+// error and silently continuing.
+func TestLoadGraphFromDir_OldFormatVersion_ReturnsTypedError(t *testing.T) {
+	dir := t.TempDir()
+	writeOldFormatGraphFB(t, dir, 2)
+
+	_, err := graph.LoadGraphFromDir(dir)
+	if err == nil {
+		t.Fatal("expected an error for an old-format graph.fb, got nil")
+	}
+
+	var fvErr *graph.FormatVersionError
+	if !errors.As(err, &fvErr) {
+		t.Fatalf("expected errors.As to find a *graph.FormatVersionError in %v", err)
+	}
+	if fvErr.Found != 2 {
+		t.Errorf("FormatVersionError.Found = %d, want 2", fvErr.Found)
+	}
+	if fvErr.Required != fbversion.Version {
+		t.Errorf("FormatVersionError.Required = %d, want %d", fvErr.Required, fbversion.Version)
+	}
+}
+
+// TestReindexRequiredReason_OldFormatVersion is the RED test for the cheap
+// header-only detection helper: given a directory whose graph.fb is stamped
+// with a version below fbversion.Version, ReindexRequiredReason must report
+// required=true with a reason naming BOTH the found and required versions.
+func TestReindexRequiredReason_OldFormatVersion(t *testing.T) {
+	dir := t.TempDir()
+	writeOldFormatGraphFB(t, dir, 2)
+
+	required, reason := graph.ReindexRequiredReason(dir)
+	if !required {
+		t.Fatal("expected required=true for an old-format graph.fb")
+	}
+	if reason == "" {
+		t.Fatal("expected a non-empty reason")
+	}
+	wantSubstrs := []string{fmt.Sprintf("v%d", 2), fmt.Sprintf("v%d", fbversion.Version), "reindex"}
+	for _, want := range wantSubstrs {
+		if !strings.Contains(strings.ToLower(reason), strings.ToLower(want)) {
+			t.Errorf("reason %q missing expected substring %q", reason, want)
+		}
+	}
+}
+
+// TestReindexRequiredReason_CurrentVersion_NotRequired is the regression
+// guard: a graph.fb written at the CURRENT fbversion.Version must never be
+// flagged, and a directory with no graph.fb at all must never be flagged
+// either (both are "nothing to report", not an error).
+func TestReindexRequiredReason_CurrentVersion_NotRequired(t *testing.T) {
+	dir := t.TempDir()
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-current-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	if required, reason := graph.ReindexRequiredReason(dir); required {
+		t.Errorf("expected required=false for a current-version graph.fb, got reason %q", reason)
+	}
+
+	emptyDir := t.TempDir()
+	if required, reason := graph.ReindexRequiredReason(emptyDir); required {
+		t.Errorf("expected required=false for a directory with no graph.fb, got reason %q", reason)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -18,6 +18,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"io"
@@ -347,6 +348,18 @@ type LoadedRepo struct {
 	// first successful load.
 	contentHash uint64
 	loadErr     string // populated when last reload failed; doc may be stale
+
+	// reindexRequired / reindexReason record whether the LAST reload attempt
+	// for this repo failed specifically because its on-disk graph.fb format
+	// version is older than this binary supports (#reindex-required PR1:
+	// detection + observability only — nothing reads these fields to trigger
+	// a reindex or a user prompt yet). The authoritative, always-fresh,
+	// race-free ReindexRequired/ReindexReason surfaced to the statusline and
+	// `grafel status --json` is recomputed independently by the engine's
+	// status writer directly from graph.fb bytes (see readDocumentFromDir's
+	// call site above for why serve-side state is not the source of truth).
+	reindexRequired bool
+	reindexReason   string
 
 	// algoStampedMt is the lr.mtime value at which applyGroupAlgoOverlay last
 	// stamped the group overlay (CommunityID/PageRank/Centrality/god/articulation)
@@ -858,8 +871,34 @@ func (s *State) reloadLocked() (int, bool, error) {
 					doc, err := readDocumentFromDir(stateDir)
 					if err != nil {
 						lr.loadErr = err.Error()
+						// #reindex-required PR1: detect (not act on) a graph.fb
+						// format-version incompatibility. errors.As lets us tell
+						// "this repo's on-disk graph.fb was written by an older
+						// grafel build than this process supports" apart from any
+						// other load failure (corrupt file, permission error,
+						// etc.), without string-matching err.Error(). Recorded
+						// here for observability on the in-memory LoadedRepo; the
+						// DURABLE, authoritative ReindexRequired/ReindexReason
+						// truth served to the statusline and `grafel status
+						// --json` is (re)computed independently, per on-disk
+						// graph.fb bytes, by the engine's status writer
+						// (internal/daemon/statuswriter.go, writeRepoStatusFile ->
+						// graph.ReindexRequiredReason) on every heartbeat — NOT
+						// written from here — because in ADR-0024 split mode this
+						// mcp/state.go reload loop runs in the separate `serve`
+						// process, whose write here could be silently clobbered by
+						// the engine process's own periodic heartbeat write to the
+						// same statusfile.File. This slice is detection + state
+						// ONLY: no reindex is triggered.
+						var fvErr *graph.FormatVersionError
+						if errors.As(err, &fvErr) {
+							lr.reindexRequired = true
+							lr.reindexReason = graph.FormatVersionReason(fvErr.Found, fvErr.Required)
+						}
 						continue
 					}
+					lr.reindexRequired = false
+					lr.reindexReason = ""
 					// S8 (#2159): close the previous reader before replacing it so
 					// we don't leak mmap fds across reloads.
 					if lr.Reader != nil {

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -123,6 +123,14 @@ type Event struct {
 	// Error is non-empty only when Phase == PhaseError.
 	Error string `json:"error,omitempty"`
 
+	// Reason carries a human-readable explanation for why this event was
+	// emitted, beyond what Phase/Error already convey — e.g. distinguishing
+	// "reindex triggered because the on-disk graph.fb format is older than
+	// this build supports" from an ordinary scheduled/watcher-triggered
+	// reindex. Additive; empty when no producer has anything extra to say.
+	// (#reindex-required PR1: field only — no producer sets it yet.)
+	Reason string `json:"reason,omitempty"`
+
 	// TS is the Unix timestamp in milliseconds when the event was created.
 	TS int64 `json:"ts"`
 

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -90,6 +90,27 @@ type File struct {
 	// last completed index succeeded.
 	LastErr string `json:"last_err,omitempty"`
 
+	// ReindexRequired is true when the on-disk graph.fb this repo is CURRENTLY
+	// SERVING was written by an older grafel build than this engine's
+	// fbversion.Version supports (see graph.ReindexRequiredReason). Unlike
+	// LastErr (a snapshot of the most recent completed index ATTEMPT, which
+	// can go stale — the field isn't proactively cleared by the passage of
+	// time), this is recomputed fresh from the actual graph.fb bytes on EVERY
+	// status-plane write, so it is always the authoritative, up-to-the-second
+	// answer to "is the graph this repo is serving right now trustworthy?".
+	//
+	// #(reindex-required PR1): detection + state ONLY. Nothing in this slice
+	// auto-reindexes or prompts the user — a reader (statusline, `grafel
+	// status --json`) must render this as an explicit, non-green state
+	// instead of silently reporting "current"/idle, so the incompatibility is
+	// never hidden. Populating the prompt/auto-reindex flow is a later PR.
+	ReindexRequired bool `json:"reindex_required,omitempty"`
+	// ReindexReason is a human-readable explanation set whenever
+	// ReindexRequired is true — names both the found and required graph.fb
+	// format versions and points at the fix (`grafel index <repo>`). Empty
+	// when ReindexRequired is false.
+	ReindexReason string `json:"reindex_reason,omitempty"`
+
 	// LastRebuildFailure records the most recent FAILED `grafel rebuild` for
 	// this repo — e.g. the per-repo watchdog SIGKILL (#5143's
 	// defaultPerRepoRebuildTimeout) or any other hard rebuild failure — so a


### PR DESCRIPTION
## What

Foundational slice of the reindex-on-update feature (#72): detect when an on-disk `graph.fb` is an incompatible (older) format than the running binary, record a `reindex_required` state, and stop the statusline from lying green about it. **Detection + state only — no reindex is triggered here** (that's the follow-on prompt/executor PRs). This is "prompt first" at the data layer: nothing fires automatically.

## Changes

- `internal/statusfile/statusfile.go`: additive `File.ReindexRequired bool` + `File.ReindexReason string` (omitempty, backward-compatible).
- `internal/progress/event.go`: additive `Event.Reason string` (no producer yet).
- `internal/graph/load.go`: typed `FormatVersionError{Found,Required}` (preserves the exact prior error text), `ReindexRequiredReason(dir)` (cheap header-only version check via `fbreader.Open`), and a shared `FormatVersionReason` renderer.
- Detection wired in two places: `internal/mcp/state.go` reload path sets in-memory `LoadedRepo.reindexRequired`/`reason` (serve side, no statusfile write — avoids a split-mode race), and `internal/daemon/statuswriter.go` `writeRepoStatusFile` (the sole statusfile writer) recomputes the flag fresh from graph.fb bytes each ~5s heartbeat (authoritative, race-free).
- `internal/cli/statusline.go`: precedence becomes engine-down > indexing > **reindex_required** > last_err > idle(green) > not-indexed, so an incompatible graph never renders green. `grafel status --json` passes the fields through automatically.

## Review + tests

Independently reviewed (opus) → APPROVE across all six axes: detection accuracy (header-only, no false-positive on current/missing/corrupt graphs), the split-mode sole-writer race claim verified (`writeRepoStatusFile` is the only per-repo status writer; serve side is in-memory-only under the `LoadedRepo` mutex), the silent-green fix works, backward-compat (omitempty + no `DisallowUnknownFields`), header-only perf is negligible, and scope discipline (grep confirms zero rebuild/enqueue/prompt calls). Tests added for detection, statuswriter wiring, and status-json round-trip. `go build`, `go vet`, `go test -race` (2653 across 33 pkgs), `gofmt -l` all clean.

Known follow-up (non-blocking): if a user's remediation reindex itself fails, status stays reindex-required (yellow) and masks the fresh `last_err` — still non-green/actionable.

Refs #72 (PR 1 of 3).