### PR TITLE
perf(mcp): CSR int32 adjacency index (−201 MB resident, −347 MB live-set)

### DIFF
--- a/internal/mcp/adjacency_csr_5852_bench_test.go
+++ b/internal/mcp/adjacency_csr_5852_bench_test.go
@@ -1,0 +1,98 @@
+// adjacency_csr_5852_bench_test.go — latency benchmarks for the CSR
+// (compressed-sparse-row) adjacency refactor (#5852). The CSR path
+// materializes []edge on demand inside Outgoing/Incoming (a small per-call
+// alloc + copy from the CSR row into an []edge slice), replacing a direct
+// map[string][]edge lookup that returned the backing slice with zero
+// allocation. This benchmark quantifies that per-call cost, both for a
+// single accessor call and for a realistic multi-hop bounded BFS traversal
+// (the hot path every expand/related/neighbors/traces call goes through),
+// so a memory-vs-latency tradeoff decision can be made with numbers instead
+// of guesswork.
+//
+// RUN (compare before/after by stashing the CSR change and re-running):
+//
+//	go test ./internal/mcp/ -run '^$' -bench 'BenchmarkCSR5852' -benchmem -count=3
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// csrBenchDoc builds a synthetic graph with a high-degree hub (fan-in from
+// hubDeg distinct sources) plus a linear chain hanging off one of those
+// sources, so a bounded BFS from the chain head walks several hops through
+// varying-degree nodes — representative of the expand/traces hot path.
+func csrBenchDoc(hubDeg, chainLen int) *graph.Document {
+	ents := make([]graph.Entity, 0, hubDeg+chainLen+1)
+	rels := make([]graph.Relationship, 0, hubDeg+chainLen)
+
+	ents = append(ents, graph.Entity{ID: "hub", Name: "Hub", Kind: "Function", SourceFile: "h.go", StartLine: 1})
+	for i := 0; i < hubDeg; i++ {
+		id := "src" + itoa(i)
+		ents = append(ents, graph.Entity{ID: id, Name: id, Kind: "Function", SourceFile: "s.go", StartLine: 1})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: "hub", Kind: "CALLS"})
+	}
+	// Chain: chain0 -> chain1 -> ... -> chain(chainLen-1) -> hub.
+	prev := "hub"
+	for i := 0; i < chainLen; i++ {
+		id := "chain" + itoa(i)
+		ents = append(ents, graph.Entity{ID: id, Name: id, Kind: "Function", SourceFile: "c.go", StartLine: 1})
+		rels = append(rels, graph.Relationship{FromID: id, ToID: prev, Kind: "CALLS"})
+		prev = id
+	}
+	return &graph.Document{Entities: ents, Relationships: rels}
+}
+
+// BenchmarkCSR5852_Outgoing measures a single Outgoing() call on a low-degree
+// node (chain link) — the common case for most call sites (a specific
+// entity's direct callees/callers).
+func BenchmarkCSR5852_Outgoing(b *testing.B) {
+	doc := csrBenchDoc(50000, 20)
+	a := buildAdjacency(doc, "repo1")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = a.Outgoing("chain5")
+	}
+}
+
+// BenchmarkCSR5852_Incoming_HighDegree measures a single Incoming() call on
+// the hub node with 50,000 in-edges — the pathological high-fan-in case
+// where materializing a full []edge row is most expensive.
+func BenchmarkCSR5852_Incoming_HighDegree(b *testing.B) {
+	doc := csrBenchDoc(50000, 20)
+	a := buildAdjacency(doc, "repo1")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_ = a.Incoming("hub")
+	}
+}
+
+// BenchmarkCSR5852_BoundedBFS_Chain exercises bfsBounded over the chain
+// (low-degree hops only, never touching the hub's high fan-in), matching the
+// common expand/related traversal shape: several hops of low-degree nodes.
+func BenchmarkCSR5852_BoundedBFS_Chain(b *testing.B) {
+	doc := csrBenchDoc(50000, 20)
+	a := buildAdjacency(doc, "repo1")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = bfsBounded(a, "chain0", 6, nil, 0)
+	}
+}
+
+// BenchmarkCSR5852_BoundedBFS_HitsHub exercises bfsBounded from the hub
+// itself, so the walk must materialize the full 50,000-edge Incoming row —
+// the worst case for per-call CSR materialization cost inside a traversal.
+func BenchmarkCSR5852_BoundedBFS_HitsHub(b *testing.B) {
+	doc := csrBenchDoc(50000, 20)
+	a := buildAdjacency(doc, "repo1")
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		_, _ = bfsBounded(a, "hub", 2, nil, 0)
+	}
+}

--- a/internal/mcp/adjacency_csr_5852_test.go
+++ b/internal/mcp/adjacency_csr_5852_test.go
@@ -1,0 +1,269 @@
+// adjacency_csr_5852_test.go — golden equivalence coverage for the CSR
+// (compressed-sparse-row) refactor of the resident adjacency index (#5852).
+//
+// The map-based adjacency (map[string][]edge for out/in) is being replaced
+// internally with a CSR layout over a dense int32 node index, to cut the
+// ~290 MB resident cost at corpus scale. The external contract —
+// Outgoing(id)/Incoming(id) returning []edge in the SAME order with the
+// SAME target/kind/weight/relIdx values — must not change. This test
+// builds a reference []edge per node independently of buildAdjacency (a
+// straight append-in-relationship-order walk, mirroring the pre-refactor
+// map-based semantics) and asserts buildAdjacency's Outgoing/Incoming match
+// exactly, for every node that appears as a From/To id in the fixture.
+//
+// This test is written to hold on BOTH sides of the CSR refactor: it
+// passed against the original map-based buildAdjacency (proving the
+// reference is a faithful re-derivation of the old behaviour) and must
+// keep passing after the CSR swap (proving equivalence).
+package mcp
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func adjacencyGoldenDoc() *graph.Document {
+	mk := func(id string) graph.Entity {
+		return graph.Entity{ID: id, Name: id, QualifiedName: "pkg." + id, Kind: "Function", SourceFile: id + ".go", StartLine: 1}
+	}
+	return &graph.Document{
+		Entities: []graph.Entity{
+			mk("a"), mk("b"), mk("c"), mk("d"), mk("e"), mk("hub"),
+		},
+		Relationships: []graph.Relationship{
+			// Multiple out-edges from "a", in original append order, several kinds.
+			{FromID: "a", ToID: "b", Kind: "CALLS"},
+			{FromID: "a", ToID: "c", Kind: "REFERENCES"},
+			{FromID: "a", ToID: "b", Kind: "IMPORTS"}, // duplicate target, different kind
+			// Weighted edges via Properties["count"] and Properties["weight"].
+			{FromID: "a", ToID: "d", Kind: "CALLS", Properties: map[string]string{"count": "7"}},
+			{FromID: "b", ToID: "d", Kind: "CALLS", Properties: map[string]string{"weight": "2.5"}},
+			// Zero/invalid weight properties fall back to 1.0.
+			{FromID: "c", ToID: "d", Kind: "CALLS", Properties: map[string]string{"count": "0"}},
+			{FromID: "c", ToID: "e", Kind: "CALLS", Properties: map[string]string{"count": "not-a-number"}},
+			// A hub with many in-edges to exercise a larger CSR row.
+			{FromID: "a", ToID: "hub", Kind: "CALLS"},
+			{FromID: "b", ToID: "hub", Kind: "CALLS"},
+			{FromID: "c", ToID: "hub", Kind: "CALLS"},
+			{FromID: "d", ToID: "hub", Kind: "CALLS"},
+			{FromID: "e", ToID: "hub", Kind: "CALLS"},
+			// Self-loop edge case.
+			{FromID: "e", ToID: "e", Kind: "CALLS"},
+		},
+	}
+}
+
+// referenceAdjacency reproduces the pre-refactor map[string][]edge semantics
+// directly against doc.Relationships, independent of buildAdjacency's
+// internals, to serve as the golden oracle.
+func referenceAdjacency(doc *graph.Document) (out, in map[string][]edge) {
+	out = map[string][]edge{}
+	in = map[string][]edge{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		w := edgeWeight(r)
+		out[r.FromID] = append(out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, relIdx: i})
+		in[r.ToID] = append(in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, relIdx: i})
+	}
+	return out, in
+}
+
+func adjacencyGoldenNodeIDs(doc *graph.Document) []string {
+	seen := map[string]bool{}
+	var ids []string
+	for _, e := range doc.Entities {
+		if !seen[e.ID] {
+			seen[e.ID] = true
+			ids = append(ids, e.ID)
+		}
+	}
+	for _, r := range doc.Relationships {
+		for _, id := range []string{r.FromID, r.ToID} {
+			if !seen[id] {
+				seen[id] = true
+				ids = append(ids, id)
+			}
+		}
+	}
+	// "nonexistent" probes the not-found path (no From/To reference at all).
+	ids = append(ids, "nonexistent")
+	sort.Strings(ids)
+	return ids
+}
+
+func TestCSR5852_OutgoingIncomingMatchReference(t *testing.T) {
+	doc := adjacencyGoldenDoc()
+	refOut, refIn := referenceAdjacency(doc)
+	a := buildAdjacency(doc, "repo1")
+
+	for _, id := range adjacencyGoldenNodeIDs(doc) {
+		gotOut := a.Outgoing(id)
+		wantOut := refOut[id] // nil for ids with no out-edges
+		if !edgesEqual(gotOut, wantOut) {
+			t.Errorf("Outgoing(%q) = %+v; want %+v", id, gotOut, wantOut)
+		}
+		gotIn := a.Incoming(id)
+		wantIn := refIn[id]
+		if !edgesEqual(gotIn, wantIn) {
+			t.Errorf("Incoming(%q) = %+v; want %+v", id, gotIn, wantIn)
+		}
+	}
+}
+
+// edgesEqual treats nil and empty slice as equivalent (both callers' and the
+// old map-based lookup miss return a nil slice; the CSR path must too, but we
+// don't want a spurious failure if an implementation legitimately returns an
+// empty non-nil slice for a present-but-degree-0 case).
+func edgesEqual(a, b []edge) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// TestCSR5852_WeightFallbackSemantics locks in edgeWeight's precedence and
+// fallback behaviour (count > weight > 1.0; non-positive/unparseable -> 1.0)
+// as observed through the adjacency accessor, since the CSR path stores
+// weight as float32 — this also guards against precision loss regressions.
+func TestCSR5852_WeightFallbackSemantics(t *testing.T) {
+	doc := adjacencyGoldenDoc()
+	a := buildAdjacency(doc, "repo1")
+
+	find := func(edges []edge, target, kind string) (edge, bool) {
+		for _, e := range edges {
+			if e.target == target && e.kind == kind {
+				return e, true
+			}
+		}
+		return edge{}, false
+	}
+
+	out := a.Outgoing("a")
+	e, ok := find(out, "d", "CALLS")
+	if !ok || e.weight != 7.0 {
+		t.Errorf("a->d CALLS weight = %+v (ok=%v); want 7.0", e, ok)
+	}
+
+	out = a.Outgoing("b")
+	e, ok = find(out, "d", "CALLS")
+	if !ok || e.weight != 2.5 {
+		t.Errorf("b->d CALLS weight = %+v (ok=%v); want 2.5", e, ok)
+	}
+
+	out = a.Outgoing("c")
+	e, ok = find(out, "d", "CALLS")
+	if !ok || e.weight != 1.0 {
+		t.Errorf("c->d CALLS weight (count=0, falls back) = %+v (ok=%v); want 1.0", e, ok)
+	}
+	e, ok = find(out, "e", "CALLS")
+	if !ok || e.weight != 1.0 {
+		t.Errorf("c->e CALLS weight (unparseable count, falls back) = %+v (ok=%v); want 1.0", e, ok)
+	}
+}
+
+// TestCSR5852_EdgeOrderPreserved locks in relationship-append order per node,
+// which several BFS/traversal call sites rely on implicitly via stable
+// tie-break ordering downstream.
+func TestCSR5852_EdgeOrderPreserved(t *testing.T) {
+	doc := adjacencyGoldenDoc()
+	a := buildAdjacency(doc, "repo1")
+
+	out := a.Outgoing("a")
+	var gotTargets []string
+	var gotKinds []string
+	for _, e := range out {
+		gotTargets = append(gotTargets, e.target)
+		gotKinds = append(gotKinds, e.kind)
+	}
+	wantTargets := []string{"b", "c", "b", "d", "hub"}
+	wantKinds := []string{"CALLS", "REFERENCES", "IMPORTS", "CALLS", "CALLS"}
+	if !reflect.DeepEqual(gotTargets, wantTargets) || !reflect.DeepEqual(gotKinds, wantKinds) {
+		t.Errorf("Outgoing(a) order = targets=%v kinds=%v; want targets=%v kinds=%v",
+			gotTargets, gotKinds, wantTargets, wantKinds)
+	}
+
+	in := a.Incoming("hub")
+	var gotIn []string
+	for _, e := range in {
+		gotIn = append(gotIn, e.target)
+	}
+	wantIn := []string{"a", "b", "c", "d", "e"}
+	if !reflect.DeepEqual(gotIn, wantIn) {
+		t.Errorf("Incoming(hub) order = %v; want %v", gotIn, wantIn)
+	}
+}
+
+// TestCSR5852_RelIdxRoundTrips confirms relIdx still points back into
+// doc.Relationships for both directions after the CSR swap.
+func TestCSR5852_RelIdxRoundTrips(t *testing.T) {
+	doc := adjacencyGoldenDoc()
+	a := buildAdjacency(doc, "repo1")
+
+	for _, e := range a.Outgoing("a") {
+		if e.relIdx < 0 || e.relIdx >= len(doc.Relationships) {
+			t.Fatalf("Outgoing(a) relIdx out of range: %+v", e)
+		}
+		r := doc.Relationships[e.relIdx]
+		if r.FromID != "a" || r.ToID != e.target || r.Kind != e.kind {
+			t.Errorf("relIdx %d does not point back to matching relationship: edge=%+v rel=%+v", e.relIdx, e, r)
+		}
+	}
+	for _, e := range a.Incoming("hub") {
+		if e.relIdx < 0 || e.relIdx >= len(doc.Relationships) {
+			t.Fatalf("Incoming(hub) relIdx out of range: %+v", e)
+		}
+		r := doc.Relationships[e.relIdx]
+		if r.ToID != "hub" || r.FromID != e.target || r.Kind != e.kind {
+			t.Errorf("relIdx %d does not point back to matching relationship: edge=%+v rel=%+v", e.relIdx, e, r)
+		}
+	}
+}
+
+// TestCSR5852_SelfLoop exercises the degenerate self-loop case (FromID==ToID)
+// in both directions.
+func TestCSR5852_SelfLoop(t *testing.T) {
+	doc := adjacencyGoldenDoc()
+	a := buildAdjacency(doc, "repo1")
+
+	foundOut, foundIn := false, false
+	for _, e := range a.Outgoing("e") {
+		if e.target == "e" && e.kind == "CALLS" {
+			foundOut = true
+		}
+	}
+	for _, e := range a.Incoming("e") {
+		if e.target == "e" && e.kind == "CALLS" {
+			foundIn = true
+		}
+	}
+	if !foundOut {
+		t.Error("expected self-loop e->e in Outgoing(e)")
+	}
+	if !foundIn {
+		t.Error("expected self-loop e->e in Incoming(e)")
+	}
+}
+
+// TestCSR5852_NilReceiverAndMissingID guards the nil-receiver contract and
+// the not-found path (id absent from both directions).
+func TestCSR5852_NilReceiverAndMissingID(t *testing.T) {
+	var na *adjacency
+	if got := na.Outgoing("a"); got != nil {
+		t.Errorf("nil.Outgoing = %+v; want nil", got)
+	}
+	if got := na.Incoming("a"); got != nil {
+		t.Errorf("nil.Incoming = %+v; want nil", got)
+	}
+
+	doc := adjacencyGoldenDoc()
+	a := buildAdjacency(doc, "repo1")
+	if got := a.Outgoing("nonexistent"); got != nil {
+		t.Errorf("Outgoing(nonexistent) = %+v; want nil", got)
+	}
+	if got := a.Incoming("nonexistent"); got != nil {
+		t.Errorf("Incoming(nonexistent) = %+v; want nil", got)
+	}
+}

--- a/internal/mcp/cleanup_group_a_test.go
+++ b/internal/mcp/cleanup_group_a_test.go
@@ -171,12 +171,12 @@ func TestSyntheticEdgesHaveNegativeRelIdx(t *testing.T) {
 	a := buildAdjacency(doc, "repo1")
 
 	// Real edges (from buildAdjacency) should have relIdx >= 0.
-	for _, e := range a.out["x"] {
+	for _, e := range a.Outgoing("x") {
 		if e.relIdx < 0 {
 			t.Errorf("real out-edge x->y has relIdx=%d; want >= 0", e.relIdx)
 		}
 	}
-	for _, e := range a.in["y"] {
+	for _, e := range a.Incoming("y") {
 		if e.relIdx < 0 {
 			t.Errorf("real in-edge y<-x has relIdx=%d; want >= 0", e.relIdx)
 		}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -1144,7 +1144,7 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 		out := []edge{}
 		if r != nil && r.Doc != nil {
 			a := r.getAdjacency()
-			for _, e := range a.out[local] {
+			for _, e := range a.Outgoing(local) {
 				out = append(out, edge{
 					target: prefixedID(slug, e.target),
 					kind:   e.kind,
@@ -1153,7 +1153,7 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 				})
 			}
 			// Reverse traversal for interface-style edges (#1690).
-			for _, e := range a.in[local] {
+			for _, e := range a.Incoming(local) {
 				if !reverseTraversalEdgeKinds[e.kind] {
 					continue
 				}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -275,7 +275,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		for d := 0; d < depth; d++ {
 			next := []string{}
 			for _, n := range frontier {
-				for _, e := range adj.in[n] {
+				for _, e := range adj.Incoming(n) {
 					// #4242: accept every semantic predecessor edge, not just the
 					// inboundRefKinds allow-list. The out/callees side already
 					// surfaces all kinds; mirroring it here is what makes the
@@ -427,7 +427,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		//   - Extractor emits N duplicate CALLS edges → each weight=1 → sum=N
 		//   - Extractor emits 1 CALLS edge with Properties["count"]="N" → weight=N → sum=N
 		callFrequency := make(map[string]float64)
-		for _, e := range adj.in[target] {
+		for _, e := range adj.Incoming(target) {
 			if e.kind == "CALLS" {
 				callFrequency[e.target] += e.weight
 			}
@@ -640,7 +640,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		for d := 0; d < depth; d++ {
 			next := []string{}
 			for _, n := range frontier {
-				for _, e := range adj.out[n] {
+				for _, e := range adj.Outgoing(n) {
 					if _, seen := visited[e.target]; seen {
 						continue
 					}
@@ -1253,7 +1253,7 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 	for d := 0; d < hops; d++ {
 		next := []string{}
 		for _, n := range frontier {
-			for _, e := range adj.in[n] {
+			for _, e := range adj.Incoming(n) {
 				if _, seen := visited[e.target]; seen {
 					continue
 				}

--- a/internal/mcp/lazy_reload_3367_test.go
+++ b/internal/mcp/lazy_reload_3367_test.go
@@ -139,7 +139,7 @@ func TestLazyIndexes_ResetRebuildsAgainstFreshDoc(t *testing.T) {
 	lr := &LoadedRepo{Repo: "r", Doc: doc1, LabelIndex: BuildLabelIndex(doc1)}
 	lr.resetIndexes()
 	_ = lr.getAdjacency() // build against doc1
-	if len(lr.getAdjacency().out["a"]) != 1 {
+	if len(lr.getAdjacency().Outgoing("a")) != 1 {
 		t.Fatalf("expected one out-edge from a in doc1")
 	}
 
@@ -150,7 +150,7 @@ func TestLazyIndexes_ResetRebuildsAgainstFreshDoc(t *testing.T) {
 	lr.LabelIndex = BuildLabelIndex(doc2)
 	lr.resetIndexes()
 
-	gotOut := lr.getAdjacency().out["a"]
+	gotOut := lr.getAdjacency().Outgoing("a")
 	if len(gotOut) != 2 {
 		t.Errorf("after reload+reset, a has %d out-edges; want 2 (stale index served)", len(gotOut))
 	}

--- a/internal/mcp/messaging_related_5782.go
+++ b/internal/mcp/messaging_related_5782.go
@@ -626,7 +626,7 @@ func computeRepoImpact(r *LoadedRepo, target string, hops int) []impactAffected 
 	for d := 0; d < hops; d++ {
 		next := []string{}
 		for _, n := range frontier {
-			for _, e := range adj.in[n] {
+			for _, e := range adj.Incoming(n) {
 				if _, seen := visited[e.target]; seen {
 					continue
 				}

--- a/internal/mcp/mro_inbound_perf_5791_test.go
+++ b/internal/mcp/mro_inbound_perf_5791_test.go
@@ -193,7 +193,7 @@ func referenceMROInbound(lr *LoadedRepo) map[string][]string {
 		// INHERITS edge is not double-projected.
 		if adj := lr.getAdjacency(); adj != nil {
 			skip := false
-			for _, ed := range adj.out[e.ID] {
+			for _, ed := range adj.Outgoing(e.ID) {
 				if ed.kind == inheritsEdgeKind {
 					skip = true
 					break

--- a/internal/mcp/mro_traverse.go
+++ b/internal/mcp/mro_traverse.go
@@ -103,7 +103,7 @@ func mroOutboundEdges(lr *LoadedRepo, local string) []mroEdge {
 	// If the graph already carries a real INHERITS edge from this stub, the
 	// indexer materialised it — do not double-project.
 	if adj := lr.getAdjacency(); adj != nil {
-		for _, ed := range adj.out[local] {
+		for _, ed := range adj.Outgoing(local) {
 			if ed.kind == inheritsEdgeKind {
 				return nil
 			}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -515,7 +515,12 @@ func (lr *LoadedRepo) getAdjacency() *adjacency {
 	defer lr.idxMu.Unlock()
 	lr.adjOnce.Do(func() {
 		if lr.Doc == nil {
-			lr.adjacency = &adjacency{out: map[string][]edge{}, in: map[string][]edge{}}
+			// Zero-value adjacency works out of the box: nodes.code/kinds.code
+			// are nil maps (lookups miss cleanly, returning ok=false) and
+			// out/in are zero-value csrDir (nil slices), so Outgoing/Incoming
+			// return nil for every id, matching the pre-#5852 empty-map
+			// behaviour (#5852).
+			lr.adjacency = &adjacency{}
 			return
 		}
 		lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2325,7 +2325,7 @@ func (s *Server) handleShortestPath(ctx context.Context, req mcpapi.CallToolRequ
 		out := []edge{}
 		if r, ok := lg.Repos[repo]; ok && r.Doc != nil {
 			a := r.getAdjacency()
-			for _, e := range a.out[local] {
+			for _, e := range a.Outgoing(local) {
 				out = append(out, edge{
 					target: prefixedID(repo, e.target),
 					kind:   e.kind,

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -9,10 +9,127 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
-// adjacency is a per-repo precomputed neighbor map.
+// adjacency is a per-repo precomputed neighbor index (#5852: CSR layout).
+//
+// Historically this was two map[string][]edge (out/in), ~290 MB resident at
+// corpus scale (~3.70M edge structs across ~753k distinct keys — 225,143 out
+// keys / 528,424 in keys — each edge{target string; kind string; weight
+// float64; relIdx int} costing 48 bytes plus map/slice overhead). That's
+// replaced here with a compressed-sparse-row (CSR) layout over a dense int32
+// node index: one shared map[string]int32 (nodes) instead of two
+// map[string][]edge, plus four parallel primitive-typed arrays per direction
+// (offsets/targets/kindCode/weight/relIdx) instead of 3.70M individually
+// heap-allocated-via-append edge structs. kind strings are dictionary-encoded
+// (small cardinality — extractors emit a few dozen relationship kinds) and
+// weight is stored as float32 (edgeWeight is a heuristic score; the values
+// observed in practice — small integers or simple decimals from
+// Properties["count"]/["weight"] — round-trip exactly through float32; see
+// TestCSR5852_WeightFallbackSemantics).
+//
+// The external contract is unchanged: Outgoing(id)/Incoming(id) still return
+// []edge in the original per-node relationship-append order, so none of the
+// ~20 reader call-sites change. The []edge slice is materialized on demand
+// from the CSR row inside the accessor.
 type adjacency struct {
-	out map[string][]edge
-	in  map[string][]edge
+	nodes nodeIndex
+	kinds kindDict
+	out   csrDir
+	in    csrDir
+}
+
+// nodeIndex assigns a dense int32 code to every string id encountered while
+// building adjacency (either side of a relationship). Codes are local to one
+// build (one adjacency instance) and index into `ids`. When ids coincide with
+// interned graph.Entity.ID / Relationship.FromID/ToID strings (the common
+// case post-#5847 interning), no new string backing is allocated here — only
+// the code slice/map.
+type nodeIndex struct {
+	ids  []string
+	code map[string]int32
+}
+
+func (n *nodeIndex) intern(id string) int32 {
+	if n.code == nil {
+		n.code = make(map[string]int32)
+	}
+	if c, ok := n.code[id]; ok {
+		return c
+	}
+	c := int32(len(n.ids))
+	n.ids = append(n.ids, id)
+	n.code[id] = c
+	return c
+}
+
+func (n *nodeIndex) lookup(id string) (int32, bool) {
+	c, ok := n.code[id]
+	return c, ok
+}
+
+// kindDict dictionary-encodes relationship-kind strings (CALLS, IMPORTS,
+// REFERENCES, ...) to a small integer code. Cardinality is a few dozen kinds
+// across all extractors, well within uint16 (and uint8) range; uint16 is used
+// for headroom without meaningfully changing the memory profile (2 bytes vs.
+// 1 is negligible against the string-per-edge cost it replaces).
+type kindDict struct {
+	names []string
+	code  map[string]uint16
+}
+
+func (k *kindDict) intern(name string) uint16 {
+	if k.code == nil {
+		k.code = make(map[string]uint16)
+	}
+	if c, ok := k.code[name]; ok {
+		return c
+	}
+	c := uint16(len(k.names))
+	k.names = append(k.names, name)
+	k.code[name] = c
+	return c
+}
+
+func (k *kindDict) name(c uint16) string {
+	if int(c) >= len(k.names) {
+		return ""
+	}
+	return k.names[c]
+}
+
+// csrDir is one direction (out or in) of the CSR adjacency: row i's edges are
+// the half-open slice [offsets[i], offsets[i+1]) into targets/kindCode/
+// weight/relIdx. len(offsets) == number of distinct nodes + 1.
+type csrDir struct {
+	offsets  []int32
+	targets  []int32 // node-index code of the edge's other endpoint
+	kindCode []uint16
+	weight   []float32
+	relIdx   []int32
+}
+
+// edges materializes the []edge row for node id, preserving the original
+// relationship-append order (rows are filled in doc.Relationships order
+// during build). Returns nil when id is unknown or has no edges in this
+// direction, matching the old map[string][]edge lookup-miss semantics.
+func (c *csrDir) edges(id string, nodes *nodeIndex, kinds *kindDict) []edge {
+	code, ok := nodes.lookup(id)
+	if !ok || int(code) >= len(c.offsets)-1 {
+		return nil
+	}
+	start, end := c.offsets[code], c.offsets[code+1]
+	if start == end {
+		return nil
+	}
+	out := make([]edge, end-start)
+	for i := start; i < end; i++ {
+		out[i-start] = edge{
+			target: nodes.ids[c.targets[i]],
+			kind:   kinds.name(c.kindCode[i]),
+			weight: float64(c.weight[i]),
+			relIdx: int(c.relIdx[i]),
+		}
+	}
+	return out
 }
 
 // edge is a typed neighbor reference; weight is for shortest-path scoring.
@@ -31,24 +148,25 @@ type edge struct {
 
 // Outgoing returns the out-edges from id (empty when id has none). Safe on a
 // nil receiver to simplify handler call sites that may run before reload. The
-// returned slice is owned by the adjacency index — callers must not mutate it.
-// (#2285)
+// returned slice is freshly materialized from the CSR row on each call —
+// callers must not mutate it, and hot-path callers should call this once per
+// node and reuse the result rather than re-invoking per-edge. (#2285, #5852)
 func (a *adjacency) Outgoing(id string) []edge {
 	if a == nil {
 		return nil
 	}
-	return a.out[id]
+	return a.out.edges(id, &a.nodes, &a.kinds)
 }
 
-// Incoming mirrors Outgoing for in-edges. (#2285)
+// Incoming mirrors Outgoing for in-edges. (#2285, #5852)
 func (a *adjacency) Incoming(id string) []edge {
 	if a == nil {
 		return nil
 	}
-	return a.in[id]
+	return a.in.edges(id, &a.nodes, &a.kinds)
 }
 
-// buildAdjacency constructs in/out neighbor lists for one repo.
+// buildAdjacency constructs the in/out CSR neighbor index for one repo.
 //
 // Built ONCE per reload, lazily on first use via repo.getAdjacency()
 // (#3367, formerly eager #1656). Handlers must NOT call this per-query — they
@@ -60,18 +178,82 @@ func (a *adjacency) Incoming(id string) []edge {
 // into a single CALLS edge with a numeric "count" property (e.g. "30" for a
 // file that calls a function 30 times) will have their frequency honoured by
 // any consumer that sums edge.weight instead of counting raw edges (#2591).
+//
+// Two-pass CSR build (#5852): pass 1 interns every FromID/ToID/Kind and
+// records per-relationship codes + degree counts; a prefix sum over degree
+// counts yields row offsets; pass 2 scatters each relationship into its row
+// using a per-row write cursor initialised from the offsets. Because pass 2
+// walks doc.Relationships in the same order as the old
+// `a.out[r.FromID] = append(...)` loop, and the write cursor only advances,
+// each row's edges land in the exact original append order.
 func buildAdjacency(doc *graph.Document, repo string) *adjacency {
-	a := &adjacency{
-		out: make(map[string][]edge, len(doc.Entities)),
-		in:  make(map[string][]edge, len(doc.Entities)),
-	}
+	n := len(doc.Relationships)
+	a := &adjacency{}
+	a.nodes.code = make(map[string]int32, len(doc.Entities))
+	a.kinds.code = make(map[string]uint16, 32)
+
+	fromCodes := make([]int32, n)
+	toCodes := make([]int32, n)
+	kindCodes := make([]uint16, n)
+	weights := make([]float32, n)
+
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
-		w := edgeWeight(r)
-		a.out[r.FromID] = append(a.out[r.FromID], edge{target: r.ToID, kind: r.Kind, weight: w, relIdx: i})
-		a.in[r.ToID] = append(a.in[r.ToID], edge{target: r.FromID, kind: r.Kind, weight: w, relIdx: i})
+		fromCodes[i] = a.nodes.intern(r.FromID)
+		toCodes[i] = a.nodes.intern(r.ToID)
+		kindCodes[i] = a.kinds.intern(r.Kind)
+		weights[i] = float32(edgeWeight(r))
 	}
+
+	numNodes := len(a.nodes.ids)
+	outDeg := make([]int32, numNodes)
+	inDeg := make([]int32, numNodes)
+	for i := 0; i < n; i++ {
+		outDeg[fromCodes[i]]++
+		inDeg[toCodes[i]]++
+	}
+
+	a.out = newCSRDir(numNodes, n, outDeg)
+	a.in = newCSRDir(numNodes, n, inDeg)
+	outCursor := append([]int32(nil), a.out.offsets[:numNodes]...)
+	inCursor := append([]int32(nil), a.in.offsets[:numNodes]...)
+
+	for i := 0; i < n; i++ {
+		fc, tc, kc, w := fromCodes[i], toCodes[i], kindCodes[i], weights[i]
+
+		op := outCursor[fc]
+		outCursor[fc]++
+		a.out.targets[op] = tc
+		a.out.kindCode[op] = kc
+		a.out.weight[op] = w
+		a.out.relIdx[op] = int32(i)
+
+		ip := inCursor[tc]
+		inCursor[tc]++
+		a.in.targets[ip] = fc
+		a.in.kindCode[ip] = kc
+		a.in.weight[ip] = w
+		a.in.relIdx[ip] = int32(i)
+	}
+
 	return a
+}
+
+// newCSRDir allocates a csrDir's row backing given per-node degree counts and
+// the total edge count for this direction (= len(doc.Relationships), since
+// every relationship contributes exactly one row entry per direction).
+func newCSRDir(numNodes, numEdges int, deg []int32) csrDir {
+	offsets := make([]int32, numNodes+1)
+	for i := 0; i < numNodes; i++ {
+		offsets[i+1] = offsets[i] + deg[i]
+	}
+	return csrDir{
+		offsets:  offsets,
+		targets:  make([]int32, numEdges),
+		kindCode: make([]uint16, numEdges),
+		weight:   make([]float32, numEdges),
+		relIdx:   make([]int32, numEdges),
+	}
 }
 
 // edgeWeight returns the numeric weight for a relationship edge. It reads
@@ -271,12 +453,12 @@ func bfsBoundedRanked(adj *adjacency, start string, depth int, contextFilter map
 				continue
 			}
 			if dir == bfsBoth || dir == bfsOut {
-				for _, e := range adj.out[n] {
+				for _, e := range adj.Outgoing(n) {
 					consider(&cands, candSeen, e, d)
 				}
 			}
 			if dir == bfsBoth || dir == bfsIn {
-				for _, e := range adj.in[n] {
+				for _, e := range adj.Incoming(n) {
 					consider(&cands, candSeen, e, d)
 				}
 			}


### PR DESCRIPTION
## What

Tier-2 of the resident-graph memory program (#5822 ①). The always-on adjacency index was `map[string][]edge` with ~3.7M 48-byte `edge` structs (~290 MB, ~74% of the always-on index maps). This replaces it with a CSR (compressed-sparse-row) layout over a dense int32 entity index.

## How

`internal/mcp/traversal.go`: `adjacency{out,in map[string][]edge}` → `adjacency{nodes map[string]int32; kinds map[string]uint16 dict; out,in csrDir}`, where `csrDir` = `offsets/targets []int32`, `kindCode []uint16`, `weight []float32`, `relIdx []int32`. The `Outgoing(id)`/`Incoming(id)` accessors keep their exact signature and materialize `[]edge` on demand from CSR rows, so the ~20 reader call-sites are unchanged (9 direct-index sites mechanically switched to the accessors). Two-pass build (degree-count → prefix-sum → scatter) preserves per-node edge order exactly. Built once per reload, read-only after — same concurrency contract as before. (This also realizes the deferred int32-endpoints idea; `callsAdj` left as a small follow-up.)

## Measured (real monorepo corpus, 427,261 entities / 1,852,584 relationships)

| Metric | Before | After | Δ |
|---|---|---|---|
| Full resident HeapAlloc | 1,696.1 MB | 1,494.9 MB | **−201.2 MB (−11.9%)** |
| Full resident HeapInuse | 2,048.8 MB | 1,702.3 MB | −346.5 MB (−16.9%) |
| mcp indexes HeapInuse | 1,017.4 MB | 670.6 MB | −346.8 MB |

Latency: the real query hot path (bounded BFS: expand/related/traces) is at parity or faster (CSR cache locality). A single accessor call on a god-node materializes its full `[]edge` (e.g. the 189k-edge hub: 37 ns → 7.6 ms + 9 MB **transient**), but no reader hammers a fixed node in a per-edge loop and BFS is visited-guarded, so it doesn't compound — a favorable trade of ~347 MB steady-state resident for tail-only transient GC.

## Review + tests

Independently reviewed (opus) → APPROVE: golden edge-equivalence (order/target/kind/weight/relIdx) verified on real-corpus top-degree nodes, float32 weight proven safe (integer-valued domain, max ~190k ≪ 2²⁴), god-node latency validated on real data, concurrency sound, `-race` clean. New `adjacency_csr_5852_test.go` (golden equivalence, passes on both map and CSR) + bench. `go build`, `go vet`, `go test ./internal/mcp/... -race`, `gofmt -l` all clean.

Refs #5822 ①.