### PR TITLE
docs: add Acknowledgments section + changelog entries for recent contributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ PR numbers link to https://github.com/cajasmota/grafel/pull/<N>.
 
 ## [Unreleased]
 
+### Added
+
+- **wizard: honor the selected indexing action (#5834)** — thanks @marcus555
+- **detect: recognize .NET repository roots (#5840)** — thanks @marcus555
+- **csharp: resolve file-scoped namespace imports (#5835)** — thanks @marcus555
+- **csharp: synthesize ABP conventional endpoints (#5836)** — thanks @marcus555
+- **daemon: configure memory limits via settings (#5838)** — thanks @marcus555
+
 ---
 
 ## [0.1.8.2] — 2026-07-17

--- a/README.md
+++ b/README.md
@@ -248,6 +248,16 @@ For code contributions, see [CONTRIBUTING.md](CONTRIBUTING.md). If you're an AI 
 
 ---
 
+## Acknowledgments
+
+Thanks to grafel's contributors:
+
+- [@marcus555](https://github.com/marcus555)
+- [@auxmedrano](https://github.com/auxmedrano)
+- [@walter-ajanel](https://github.com/walter-ajanel)
+
+---
+
 ## License
 
 MIT — see [LICENSE](LICENSE).


### PR DESCRIPTION
Adds an **Acknowledgments** section to the README thanking grafel's contributors ([@marcus555](https://github.com/marcus555), [@auxmedrano](https://github.com/auxmedrano), [@walter-ajanel](https://github.com/walter-ajanel)), and records the recently-merged external contributions in `CHANGELOG.md` under `[Unreleased]`:

- wizard: honor the selected indexing action (#5834)
- detect: recognize .NET repository roots (#5840)
- csharp: resolve file-scoped namespace imports (#5835)
- csharp: synthesize ABP conventional endpoints (#5836)
- daemon: configure memory limits via settings (#5838)

— all thanks to @marcus555.