### PR TITLE
feat(mcp): F1 deferred-unmap MapHandle lifetime (ADR-0027 keystone)

### DIFF
--- a/docs/adrs/0027-mmap-zerocopy-resident-graph.md
+++ b/docs/adrs/0027-mmap-zerocopy-resident-graph.md
@@ -236,8 +236,21 @@ type MapHandle struct {
 func (h *MapHandle) borrow() { h.refs.Add(1) }
 
 // release runs LOCK-FREE after the handler returns.
+//
+// The refs.Load()==0 RE-CHECK after observing retired is load-bearing, NOT
+// redundant: refs.Add(-1)==0 is a CACHED read. While this handle is still
+// PUBLISHED (not yet retired), a concurrent goroutine can legally borrow it,
+// rebounding refs 0→1 AFTER our decrement but BEFORE we read retired. A naive
+// `Add(-1)==0 && retired.Load()` would then munmap on the stale n==0 while
+// refs==1 → use-after-unmap. Re-reading refs AFTER retired is safe because
+// retired is only observable once the handle is unpublished, from which point
+// refs is monotonically non-increasing (no new borrow can target it), so a
+// Load()==0 there is authoritative. See "No munmap while borrowed" below.
 func (h *MapHandle) release() {
-    if h.refs.Add(-1) == 0 && h.retired.Load() {
+    if h.refs.Add(-1) != 0 {
+        return
+    }
+    if h.retired.Load() && h.refs.Load() == 0 {
         h.closeOnce()   // may race reload's close below — dedup'd by closeOnce
     }
 }
@@ -290,16 +303,21 @@ tight loop while borrowers read, asserting no fault and no handle leak.
 eventually unmapped (no leak), and (ii) it is unmapped *exactly once* (no
 double-munmap).
 
-*No leak.* Reload and the last releaser cross-check two atomics in opposite
+*No leak.* Reload and the *last* releaser cross-check two atomics in opposite
 order: reload does `retired.Store(true)` **then** `refs.Load()`; a releaser does
-`refs.Add(-1)` **then** `retired.Load()`. Under Go's sequentially-consistent
-atomics, whichever of the two performs its *second* operation last observes the
-other's *first*, so at least one of them sees `refs==0 && retired` and calls
-`closeOnce`. The only interleavings are: (a) reload reads `refs>=1` → reload
-defers; the decrementing releaser then reads `retired==true` → releaser closes.
-(b) A releaser reads `retired==false` (before reload's store) → releaser defers;
-reload then reads `refs==0` → reload closes. There is **no interleaving where
-neither closes**.
+`refs.Add(-1)` **then** `retired.Load()` **then** re-reads `refs.Load()`. Under
+Go's sequentially-consistent atomics, whichever of the two performs its *second*
+operation last observes the other's *first*, so at least one of them sees a
+retired handle with a globally-drained refcount and calls `closeOnce`. The
+interleavings are: (a) reload reads `refs>=1` → reload defers; the releaser that
+finally drains the handle reads `retired==true` and re-confirms `refs==0` →
+releaser closes. (b) A releaser reads `retired==false` (before reload's store) →
+releaser defers; reload then reads `refs==0` → reload closes. (c) A releaser
+reads `retired==true` but its re-check sees `refs>0` (a borrow rebounded — see
+below) → it defers; the *later* releaser that drains that rebounded borrow, or a
+reload that reads `refs==0`, closes. There is **no interleaving where neither
+closes** — the handle that is retired and truly at `refs==0` is always seen so
+by whichever party acts last.
 
 *Exactly once — and NOT by unique observation.* The reviewer-flagged subtlety:
 **both** reload and the last releaser CAN observe `refs==0 && retired`
@@ -317,6 +335,28 @@ retired the predecessor (step 2). So once a handle is retired it can never gain
 a new borrow — there is no negative-`refs` sentinel because there is nothing to
 guard against; the structural ordering is the guarantee. Thus no
 `unsafe.String` alias can be created against, or outlive, an unmapped mapping.
+
+*No munmap while borrowed — the refcount-rebound TOCTOU (adversarial-review
+fix).* The subtlety the "no re-borrow" invariant does **not** cover: a borrow
+taken while the handle is *still published* (before it is retired) is perfectly
+legal, and can rebound `refs` `0→1` in the window **after** a concurrent
+releaser's `refs.Add(-1)→0` but **before** that releaser reads `retired`.
+Concretely: releaser R decrements to 0 on the still-live handle (retired still
+false); borrower B then legally borrows it (`refs 0→1`); reload retires it and,
+seeing `refs==1`, defers; R now reads `retired==true`. A naive release that
+closed on R's *cached* `n==0` would munmap while B still holds the mapping →
+use-after-unmap. The fix is the `refs.Load()==0` **re-check after** `retired` in
+`release()` (above): once `retired` is observed, the handle is already
+unpublished, so `refs` is monotonically non-increasing from there and the
+re-read is authoritative — R sees `refs==1`, defers, and B's later `release()`
+performs the single munmap. `retire()` is unaffected: it always runs after the
+successor is published, so its `refs.Load()` cannot be undercut by a new borrow.
+This is a blocking F1 acceptance criterion, proven deterministically (no `-cpu`
+sweep needed) by `TestMapHandleReleaseRefcountReboundDoesNotUnmap` and
+`TestBorrowGroupReleaseDoesNotUnmapOnRefcountRebound`, which park a releaser in a
+test-only seam between the decrement and the close decision, inject the
+rebounding borrow + retire, and assert the mapping is never unmapped while
+`refs>0`.
 
 ### Option B — epoch / generation reclaim
 

--- a/internal/mcp/maphandle.go
+++ b/internal/mcp/maphandle.go
@@ -1,0 +1,123 @@
+// F1 of ADR-0027 (mmap + zero-copy resident graph): the deferred-unmap
+// MapHandle lifetime. This is the safety keystone the whole epic rests on.
+//
+// Today the serve read path is lock-free by construction: State.Group() copies
+// the *LoadedGroup pointer under s.mu and releases the lock, after which a
+// handler reads the derived state for the whole tool call without holding any
+// lock. That is safe ONLY because the materialized heap *graph.Document stays
+// GC-reachable through the in-flight goroutine's pointers. Once queries alias
+// bytes straight out of the mmap (F3, behind GRAFEL_SERVE_FROM_MMAP), GC
+// reachability no longer covers them — a concurrent reload that munmaps while a
+// query still aliases the mapping is a use-after-unmap → SIGSEGV/SIGBUS.
+//
+// MapHandle replaces GC-reachability with an explicit refcount-drain protocol
+// (ADR-0027 §Lifetime design, Option A): reload never munmaps in place; it
+// publishes the successor, retires the predecessor, and the LAST releaser of a
+// retired handle performs the munmap. In F1 the read path is still DARK
+// (handlers read the heap Doc); this file only makes the unmap safe to defer
+// and rewires the existing munmap sites through the drain. The borrow protocol
+// is present but INERT — nothing aliases the mapping for reads yet.
+package mcp
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+)
+
+// readerCloser is the narrow close surface MapHandle drives. *fbreader.Reader
+// satisfies it; tests substitute a fake that counts munmaps so the exactly-once
+// and no-leak invariants can be asserted without a real mapping.
+type readerCloser interface {
+	Close() error
+}
+
+// MapHandle wraps one open mmap (an *fbreader.Reader) with the deferred-unmap
+// lifetime from ADR-0027 §Lifetime design (Option A — refcount-drain).
+//
+//	refs    — number of in-flight borrows (queries aliasing this mapping).
+//	retired — set once reload/evict/Close has published a successor; the
+//	          mapping must be unmapped as soon as refs drains to 0.
+//	closed  — the idempotent munmap guard. EXACTLY-ONCE rests ENTIRELY here,
+//	          NOT on unique observation: both reload (via retire) and the last
+//	          releaser (via release) CAN observe refs==0 && retired at the same
+//	          time and both call closeOnce — sync.Once is what dedups the
+//	          munmap. A plain non-atomic `if !closed` flag has a real
+//	          double-munmap window and is a bug (proven by
+//	          TestMapHandleCloseIsExactlyOnceUnderContention).
+type MapHandle struct {
+	// repo is the registry slug of the repo this mapping belongs to, set by
+	// LoadedRepo.publishHandle so a groupBorrow snapshot can look a borrow up by
+	// repo. Immutable after publish.
+	repo    string
+	reader  *fbreader.Reader
+	closer  readerCloser
+	refs    atomic.Int64
+	retired atomic.Bool
+	closed  sync.Once
+}
+
+// newMapHandle wraps a freshly-opened reader for the production path. Called
+// only with a non-nil reader (reloadLocked guards on fbreader.Open success).
+func newMapHandle(r *fbreader.Reader) *MapHandle {
+	return &MapHandle{reader: r, closer: r}
+}
+
+// Reader returns the wrapped reader (the future F3 read cursor). Nil-safe so a
+// caller can chain h.Reader() on a repo with no mmap.
+func (h *MapHandle) Reader() *fbreader.Reader {
+	if h == nil {
+		return nil
+	}
+	return h.reader
+}
+
+// borrow increments the refcount and returns the handle for reads.
+//
+// borrow runs UNDER s.mu (from the group borrow), so it cannot race reload's
+// publish+retire. It deliberately needs NO "refuse retired" check and there is
+// NO negative sentinel: reload repoints the published handle to the successor
+// BEFORE it retires the predecessor (see LoadedRepo.publishHandle), and a fresh
+// borrow only ever targets the currently-published handle (the
+// read-through-captured-handle invariant). So a retired handle can never gain a
+// new borrow — the structural ordering is the guarantee, not a runtime guard.
+func (h *MapHandle) borrow() *MapHandle {
+	h.refs.Add(1)
+	return h
+}
+
+// release drops one borrow. If it drains the last borrow of a retired handle,
+// it performs the munmap. Runs LOCK-FREE after the handler returns. The close
+// here may race reload's close in retire() — closeOnce dedups them.
+func (h *MapHandle) release() {
+	if h.refs.Add(-1) == 0 && h.retired.Load() {
+		h.closeOnce()
+	}
+}
+
+// retire marks this handle superseded and, if no borrow is outstanding,
+// unmaps it now; otherwise the last release() unmaps it. This is the
+// reload/evict/Close side of the drain. Runs UNDER s.mu.
+//
+// No-leak cross-check (ADR-0027 §Correctness): retire does retired.Store THEN
+// refs.Load; release does refs.Add(-1) THEN retired.Load. Under Go's
+// sequentially-consistent atomics whichever performs its second op last
+// observes the other's first, so at least one side sees refs==0 && retired and
+// calls closeOnce — there is no interleaving where neither closes.
+func (h *MapHandle) retire() {
+	h.retired.Store(true)
+	if h.refs.Load() == 0 {
+		h.closeOnce()
+	}
+}
+
+// closeOnce performs the munmap exactly once, however many callers reach it.
+// The sync.Once is load-bearing — see the MapHandle.closed doc comment.
+func (h *MapHandle) closeOnce() {
+	h.closed.Do(func() {
+		if h.closer != nil {
+			_ = h.closer.Close()
+		}
+	})
+}

--- a/internal/mcp/maphandle.go
+++ b/internal/mcp/maphandle.go
@@ -56,6 +56,15 @@ type MapHandle struct {
 	refs    atomic.Int64
 	retired atomic.Bool
 	closed  sync.Once
+
+	// releaseGap, when non-nil, is invoked inside release() in the window
+	// BETWEEN the refcount decrement and the close decision. It is a test-only
+	// scheduling seam used to force the stale-refcount rebound interleaving
+	// deterministically (see TestMapHandleReleaseRefcountReboundDoesNotUnmap);
+	// nil in production, so release() pays only a nil check. Set once at
+	// construction, before the handle is published/borrowed — never mutated
+	// concurrently, so it needs no atomic.
+	releaseGap func()
 }
 
 // newMapHandle wraps a freshly-opened reader for the production path. Called
@@ -90,8 +99,32 @@ func (h *MapHandle) borrow() *MapHandle {
 // release drops one borrow. If it drains the last borrow of a retired handle,
 // it performs the munmap. Runs LOCK-FREE after the handler returns. The close
 // here may race reload's close in retire() — closeOnce dedups them.
+//
+// Stale-refcount TOCTOU (the bug the adversarial review caught): a naive
+//
+//	if h.refs.Add(-1) == 0 && h.retired.Load() { h.closeOnce() }
+//
+// acts on a CACHED n==0. While this handle is still PUBLISHED (not yet retired),
+// a concurrent goroutine may legally borrow it, rebounding refs 0→1 AFTER our
+// decrement but BEFORE we read retired. If reload then retires (sees refs==1 →
+// defers) and we re-read retired==true, the naive form munmaps on the stale
+// n==0 while refs==1 → use-after-unmap. The "no re-borrow of a retired handle"
+// invariant does NOT cover this: the rebounding borrow hit the handle while it
+// was still LIVE, which is legal.
+//
+// Fix: re-check refs AFTER observing retired. Once retired is visible the handle
+// is already unpublished (retire runs strictly after publishHandle repoints
+// lr.handle to the successor), so no new borrow can target it and refs is
+// monotonically non-increasing from there — a Load()==0 after retired==true is
+// authoritative.
 func (h *MapHandle) release() {
-	if h.refs.Add(-1) == 0 && h.retired.Load() {
+	if h.refs.Add(-1) != 0 {
+		return
+	}
+	if h.releaseGap != nil {
+		h.releaseGap()
+	}
+	if h.retired.Load() && h.refs.Load() == 0 {
 		h.closeOnce()
 	}
 }

--- a/internal/mcp/maphandle_test.go
+++ b/internal/mcp/maphandle_test.go
@@ -1,0 +1,142 @@
+package mcp
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// countingCloser is a fake readerCloser that counts munmaps so the exactly-once
+// and no-leak invariants can be asserted without a real mapping.
+type countingCloser struct{ n atomic.Int64 }
+
+func (c *countingCloser) Close() error { c.n.Add(1); return nil }
+
+// refCheckCloser additionally flags any close that happens while a borrow is
+// still outstanding (refs>0) — the "never munmap while borrowed" invariant.
+type refCheckCloser struct {
+	h            *MapHandle
+	n            atomic.Int64
+	badWhileRefs atomic.Int64
+}
+
+func (c *refCheckCloser) Close() error {
+	if c.h != nil && c.h.refs.Load() > 0 {
+		c.badWhileRefs.Add(1)
+	}
+	c.n.Add(1)
+	return nil
+}
+
+func newTestHandle(c readerCloser) *MapHandle { return &MapHandle{closer: c} }
+
+// Criterion 1: exactly-once close is idempotent, NOT unique-observation. Both
+// reload (via retire) and the last releaser (via release) can observe
+// refs==0 && retired and both reach closeOnce; the sync.Once is what dedups.
+//
+// Each iteration seeds one outstanding borrow (refs=1, retired=false) and fires
+// retire() and release() simultaneously. retire does retired.Store THEN
+// refs.Load; release does refs.Add(-1) THEN retired.Load. The interleaving
+// where BOTH observe refs==0 && retired (release drops to 0 and sees retired
+// already stored; retire's refs.Load reads the post-decrement 0) is exactly the
+// double-munmap window the sync.Once must close. A plain non-atomic
+// `if !closed` flag both data-races here (caught under -race) and can count 2.
+func TestMapHandleCloseIsExactlyOnceUnderContention(t *testing.T) {
+	t.Parallel()
+	const iters = 5000
+	for i := 0; i < iters; i++ {
+		cc := &countingCloser{}
+		h := newTestHandle(cc)
+		h.refs.Store(1) // one in-flight borrow
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; h.retire() }()  // reload side
+		go func() { defer wg.Done(); <-start; h.release() }() // last-releaser side
+		close(start)
+		wg.Wait()
+		if got := cc.n.Load(); got != 1 {
+			t.Fatalf("iter %d: munmap count = %d, want exactly 1", i, got)
+		}
+		// The handle is retired and fully drained: refs must be 0.
+		if r := h.refs.Load(); r != 0 {
+			t.Fatalf("iter %d: refs = %d after drain, want 0", i, r)
+		}
+	}
+}
+
+// Criterion 2 (borrow-wins): a borrow taken before retire keeps the mapping
+// alive; retire must DEFER the munmap, and the draining release performs it —
+// exactly once, and never while refs>0.
+func TestMapHandleBorrowWinsDefersUnmap(t *testing.T) {
+	t.Parallel()
+	cc := &refCheckCloser{}
+	h := newTestHandle(cc)
+	cc.h = h
+
+	h.borrow() // refs=1
+	h.retire() // retired, but refs>0 → must NOT unmap now
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("retire munmapped while borrowed: count=%d, want 0", got)
+	}
+	h.release() // refs→0 on a retired handle → unmap now
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("munmap count after drain = %d, want 1", got)
+	}
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("munmap observed refs>0 %d times, want 0", bad)
+	}
+}
+
+// Criterion 2 (reload-wins): with no borrow outstanding, retire unmaps
+// immediately (the common reload/evict/Close case), and a second retire is a
+// no-op — the sync.Once makes closeOnce idempotent.
+func TestMapHandleReloadWinsClosesImmediatelyAndIsIdempotent(t *testing.T) {
+	t.Parallel()
+	cc := &refCheckCloser{}
+	h := newTestHandle(cc)
+	cc.h = h
+
+	h.retire() // refs==0 → unmap now
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("retire with no borrows: count=%d, want 1", got)
+	}
+	h.retire() // idempotent
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("second retire re-munmapped: count=%d, want 1", got)
+	}
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("munmap observed refs>0 %d times, want 0", bad)
+	}
+}
+
+// Criterion 2 (no-leak cross-check, randomized interleave): a borrow taken just
+// before vs just after retire, run under -race, must ALWAYS end unmapped
+// exactly once and NEVER unmapped while refs>0. This exercises the sequential-
+// consistency argument that at least one of {retire, release} observes
+// refs==0 && retired.
+func TestMapHandleNoLeakUnderRacingBorrowAndRetire(t *testing.T) {
+	t.Parallel()
+	const iters = 5000
+	for i := 0; i < iters; i++ {
+		cc := &refCheckCloser{}
+		h := newTestHandle(cc)
+		cc.h = h
+		h.borrow() // the in-flight borrow that will race retire
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() { defer wg.Done(); <-start; h.retire() }()  // reload
+		go func() { defer wg.Done(); <-start; h.release() }() // handler returns
+		close(start)
+		wg.Wait()
+
+		if got := cc.n.Load(); got != 1 {
+			t.Fatalf("iter %d: munmap count = %d, want exactly 1 (no leak, no double)", i, got)
+		}
+		if bad := cc.badWhileRefs.Load(); bad != 0 {
+			t.Fatalf("iter %d: munmap observed refs>0 (%d), want 0", i, bad)
+		}
+	}
+}

--- a/internal/mcp/maphandle_test.go
+++ b/internal/mcp/maphandle_test.go
@@ -30,6 +30,74 @@ func (c *refCheckCloser) Close() error {
 
 func newTestHandle(c readerCloser) *MapHandle { return &MapHandle{closer: c} }
 
+// closerFunc adapts a func to readerCloser for the ordering-guard test.
+type closerFunc func() error
+
+func (f closerFunc) Close() error { return f() }
+
+// Criterion 1/2 (regression): stale-refcount TOCTOU in release(). The adversarial
+// review found that a releaser observing its own Add(-1)→0 does NOT imply refs is
+// globally 0 — while the handle is still PUBLISHED a concurrent borrow can rebound
+// refs 0→1 before the releaser reads retired. If the releaser then closes on that
+// stale n==0, it munmaps while refs>0 (use-after-unmap).
+//
+// This test forces that exact interleaving DETERMINISTICALLY via the releaseGap
+// seam (no -cpu sweep, default scheduling): it parks the releaser between its
+// decrement and the close decision, injects a rebounding borrow + a retire, then
+// resumes the releaser. It FAILS on the naive `Add(-1)==0 && retired.Load()`
+// release (munmap while refs==1) and PASSES on the re-check-after-retired fix.
+func TestMapHandleReleaseRefcountReboundDoesNotUnmap(t *testing.T) {
+	cc := &refCheckCloser{}
+	h := newTestHandle(cc)
+	cc.h = h
+
+	gapEntered := make(chan struct{})
+	gapProceed := make(chan struct{})
+	var armed atomic.Bool
+	armed.Store(true)
+	h.releaseGap = func() {
+		// Fire the seam exactly once — only for the first releaser (R). Later
+		// releases (the drain at the end) proceed without parking.
+		if armed.CompareAndSwap(true, false) {
+			close(gapEntered)
+			<-gapProceed
+		}
+	}
+
+	h.borrow() // refs=1: R's outstanding borrow
+	done := make(chan struct{})
+	go func() { defer close(done); h.release() }() // R: Add(-1)→0, then parks in the gap
+
+	<-gapEntered // R is parked between the decrement and reading retired
+	// A concurrent goroutine legally borrows the STILL-PUBLISHED (live) handle,
+	// rebounding refs 0→1, then reload retires it (sees refs==1 → defers).
+	h.borrow() // refs 0→1 on the still-live handle
+	h.retire() // retired=true, refs==1 → defer, no close
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("retire munmapped while borrowed: count=%d, want 0", got)
+	}
+	close(gapProceed) // resume R's close decision
+	<-done
+
+	// Buggy release() would munmap here on the stale n==0 while refs==1.
+	// Fixed release() re-reads refs.Load()==1 and does NOT close.
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("release munmapped while refs>0 (stale-refcount TOCTOU): %d faults", bad)
+	}
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("mapping unmapped while still borrowed: count=%d, want 0", got)
+	}
+
+	// Drain the rebounding borrow: the last releaser now unmaps exactly once.
+	h.release()
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("final munmap count = %d, want 1", got)
+	}
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("munmap observed refs>0 %d times, want 0", bad)
+	}
+}
+
 // Criterion 1: exactly-once close is idempotent, NOT unique-observation. Both
 // reload (via retire) and the last releaser (via release) can observe
 // refs==0 && retired and both reach closeOnce; the sync.Once is what dedups.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -267,11 +267,18 @@ func (l CrossRepoLink) EdgeConfidence() string {
 // transient field-decode wrapper. Reader is nil when graph.fb is not
 // present (JSON-only fallback or old index format).
 type LoadedRepo struct {
-	Repo       string
-	Path       string
-	GraphFile  string
-	Doc        *graph.Document
-	Reader     *fbreader.Reader // mmap zero-copy reader (S8, #2159); nil when unavailable
+	Repo      string
+	Path      string
+	GraphFile string
+	Doc       *graph.Document
+	Reader    *fbreader.Reader // mmap zero-copy reader (S8, #2159); nil when unavailable
+	// handle is the F1 (ADR-0027) deferred-unmap wrapper that OWNS the lifetime
+	// of Reader's mapping. Reader is the (still-dark) read accessor; handle is
+	// what reload/evict/Close route the munmap through so an in-flight borrow can
+	// drain first. Invariant: handle == nil iff Reader == nil, and when both are
+	// non-nil handle.reader == Reader. Mutated only under State.mu via
+	// publishHandle / retireHandle. Nil when graph.fb is unavailable.
+	handle     *MapHandle
 	LabelIndex *LabelIndex
 	BM25       *BM25Index
 	Semantic   *embed.Store // per-repo vector index (nil when no embeddings.bin)
@@ -423,6 +430,56 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.topKPageRank = nil
 	lr.suffixIndex = nil
 	lr.suffixIndexPartial = false
+}
+
+// publishHandle installs nh as the repo's live mmap handle under the F1
+// (ADR-0027) deferred-unmap protocol and retires the predecessor. The ordering
+// is load-bearing: the successor is published (lr.handle / lr.Reader repointed)
+// BEFORE the old handle is retired, so a fresh borrow — which only ever targets
+// the currently-published lr.handle — can never re-borrow the retired
+// predecessor (§Correctness "no re-borrow of a retired handle"). retire() then
+// unmaps the predecessor immediately iff it has already drained (refs==0);
+// otherwise the last in-flight release() unmaps it. NEVER an in-place Close().
+//
+// nh may be nil (JSON-only fallback / no graph.fb). Caller MUST hold State.mu.
+func (lr *LoadedRepo) publishHandle(nh *MapHandle) {
+	old := lr.handle
+	if nh != nil {
+		nh.repo = lr.Repo
+		lr.Reader = nh.reader
+	} else {
+		lr.Reader = nil
+	}
+	lr.handle = nh
+	if old != nil {
+		old.retire()
+	}
+}
+
+// setReader wraps a freshly-opened reader (or nil) in a MapHandle and publishes
+// it via publishHandle. This is the reload swap: it replaces the old bare
+// lr.Reader.Close() so a reload never munmaps a mapping an in-flight borrow
+// still aliases. Caller MUST hold State.mu.
+func (lr *LoadedRepo) setReader(newRdr *fbreader.Reader) {
+	var nh *MapHandle
+	if newRdr != nil {
+		nh = newMapHandle(newRdr)
+	}
+	lr.publishHandle(nh)
+}
+
+// retireHandle retires the repo's current mmap handle (repo eviction and server
+// Close), routing the munmap through the F1 drain instead of a bare
+// lr.Reader.Close() — same munmap-while-borrowed hazard as reload. The mapping
+// is unmapped now iff it has drained, else by the last release(). Caller MUST
+// hold State.mu.
+func (lr *LoadedRepo) retireHandle() {
+	old := lr.handle
+	lr.handle = nil
+	lr.Reader = nil
+	if old != nil {
+		old.retire()
+	}
 }
 
 // getSuffixIndex returns the source-file suffix index (basename -> repo-relative
@@ -904,12 +961,6 @@ func (s *State) reloadLocked() (int, bool, error) {
 					}
 					lr.reindexRequired = false
 					lr.reindexReason = ""
-					// S8 (#2159): close the previous reader before replacing it so
-					// we don't leak mmap fds across reloads.
-					if lr.Reader != nil {
-						_ = lr.Reader.Close()
-						lr.Reader = nil
-					}
 					lr.Doc = doc
 					lr.mtime = fileMtime
 					lr.contentHash = newHash // 0 on hash failure → next reload re-parses
@@ -941,10 +992,20 @@ func (s *State) reloadLocked() (int, bool, error) {
 					// S8 (#2159): open the mmap reader alongside the Document.
 					// Best-effort: failures leave Reader nil; callers fall back to
 					// doc.Entities / doc.Relationships.
+					//
+					// F1 (ADR-0027): publish the successor through the deferred-unmap
+					// protocol instead of a bare Close() of the old reader. setReader
+					// repoints lr.handle/lr.Reader to the new mapping FIRST, then
+					// retires the predecessor — which unmaps it now iff it has already
+					// drained, else the last in-flight release() unmaps it. Reload
+					// never waits on borrows and never munmaps in place. Passing nil on
+					// Open failure retires the stale predecessor and leaves Reader nil.
 					fbPath := filepath.Join(stateDir, "graph.fb")
+					var newRdr *fbreader.Reader
 					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
-						lr.Reader = rdr
+						newRdr = rdr
 					}
+					lr.setReader(newRdr)
 					reloaded++
 				}
 			}
@@ -965,12 +1026,13 @@ func (s *State) reloadLocked() (int, bool, error) {
 			}
 		}
 		// Drop repos no longer in the registry.
-		// S8 (#2159): close the mmap reader when evicting a repo entry.
+		// S8 (#2159) + F1 (ADR-0027): route the mmap munmap through the deferred-
+		// unmap protocol (retireHandle) rather than a bare Reader.Close(), so an
+		// in-flight borrow of an evicted repo's mapping drains before the unmap.
 		for rName, lr := range grp.Repos {
 			if !seen[rName] {
-				if lr != nil && lr.Reader != nil {
-					_ = lr.Reader.Close()
-					lr.Reader = nil
+				if lr != nil {
+					lr.retireHandle()
 				}
 				delete(grp.Repos, rName)
 			}
@@ -1034,6 +1096,82 @@ func (s *State) Group(name string) *LoadedGroup {
 		s.refreshGroupAlgoOverlayLocked(grp)
 	}
 	return grp
+}
+
+// groupBorrow is the immutable per-call snapshot returned by borrowGroup — the
+// F1 (ADR-0027) read-through-captured-handle seam. It captures the group pointer
+// AND a borrow on every repo's current MapHandle in one critical section under
+// State.mu. A caller reads through the captured handles for the whole call and
+// MUST NEVER live-re-dereference lr.handle / lr.Reader / lr.Doc at read time:
+// reload mutates *LoadedRepo in place (repointing lr.handle to a successor this
+// call never borrow()-incremented), so a live re-deref could hand a reader a
+// mapping a concurrent reload is free to unmap → SIGSEGV. The captured handle is
+// the read cursor for the entire call; Release() drops every borrow on return.
+//
+// In F1 the read path is DARK — no handler calls this yet (the borrow protocol
+// is inert). It establishes the seam and lifetime guarantee that F2's hot index
+// and F3's mmap read path bind to.
+type groupBorrow struct {
+	Group   *LoadedGroup
+	handles []*MapHandle
+}
+
+// Handle returns the borrowed MapHandle captured for repo slug, or nil when the
+// repo had no mmap mapping at borrow time. The returned handle is the immutable
+// read cursor for this call — it stays valid (not munmapped) until Release,
+// even across a concurrent reload that retires it.
+func (b *groupBorrow) Handle(repo string) *MapHandle {
+	if b == nil {
+		return nil
+	}
+	for _, h := range b.handles {
+		if h != nil && h.repo == repo {
+			return h
+		}
+	}
+	return nil
+}
+
+// Release drops every borrow captured by this snapshot. The last releaser of a
+// retired handle performs its munmap. Idempotent: safe to call once per borrow.
+func (b *groupBorrow) Release() {
+	if b == nil {
+		return
+	}
+	for _, h := range b.handles {
+		if h != nil {
+			h.release()
+		}
+	}
+	b.handles = nil
+}
+
+// borrowGroup returns an immutable per-call snapshot of a group with a borrow
+// held on each repo's current MapHandle. The group lookup, overlay refresh, and
+// every borrow happen in ONE critical section under s.mu, so the borrow cannot
+// race reload's publish+retire (which also runs under s.mu): a call either
+// borrows before retire (refs>=1 → reload defers the unmap to this call's
+// Release) or borrows the already-published successor. The caller MUST defer
+// snapshot.Release(). Returns nil when the group is unknown.
+//
+// F1: inert — no production caller yet. Wired here so the seam and its race
+// safety are proven (TestBorrowGroupSurvivesReload) before F3 lights the read
+// path.
+func (s *State) borrowGroup(name string) *groupBorrow {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	grp := s.groups[name]
+	if grp == nil {
+		return nil
+	}
+	s.refreshGroupAlgoOverlayLocked(grp)
+	b := &groupBorrow{Group: grp}
+	for _, lr := range grp.Repos {
+		if lr != nil && lr.handle != nil {
+			b.handles = append(b.handles, lr.handle.borrow())
+		}
+	}
+	return b
 }
 
 // refreshGroupAlgoOverlayLocked re-applies the group-algo overlay to an
@@ -1103,9 +1241,12 @@ func (s *State) Close() {
 	defer s.mu.Unlock()
 	for _, g := range s.groups {
 		for _, lr := range g.Repos {
-			if lr != nil && lr.Reader != nil {
-				_ = lr.Reader.Close()
-				lr.Reader = nil
+			if lr != nil {
+				// F1 (ADR-0027): retire (not bare Close) so any in-flight borrow
+				// drains before the mapping is unmapped — same munmap-while-borrowed
+				// hazard as reload/eviction. When nothing is borrowed (the common
+				// shutdown case) retire unmaps immediately, matching prior behavior.
+				lr.retireHandle()
 			}
 		}
 	}

--- a/internal/mcp/state_maphandle_test.go
+++ b/internal/mcp/state_maphandle_test.go
@@ -1,0 +1,222 @@
+package mcp
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// newStateWithHandle builds a State with a single group "g" holding one repo
+// "r" whose mmap handle wraps c, installed through publishHandle (the real F1
+// publish path) so lifetime is driven exactly as production does.
+func newStateWithHandle(c readerCloser) (*State, *LoadedRepo) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}}, // empty → reload evicts "r"
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{
+		Name:  "g",
+		Repos: map[string]*LoadedRepo{"r": lr},
+	}
+	s.mu.Lock()
+	lr.publishHandle(&MapHandle{closer: c})
+	s.mu.Unlock()
+	return s, lr
+}
+
+// Criterion 4: server Close() routes the munmap through retire()+conditional
+// close, NOT a bare Reader.Close(). An in-flight borrow must drain before the
+// mapping is unmapped.
+func TestCloseDefersUnmapWhileBorrowed(t *testing.T) {
+	cc := &countingCloser{}
+	s, _ := newStateWithHandle(cc)
+
+	b := s.borrowGroup("g") // borrow the handle (refs=1)
+	if b == nil {
+		t.Fatal("borrowGroup returned nil")
+	}
+	s.Close() // must retire, not munmap-in-place, because refs>0
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("Close munmapped while borrowed: count=%d, want 0", got)
+	}
+	b.Release() // last releaser of the retired handle unmaps it
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("munmap count after Release = %d, want 1", got)
+	}
+}
+
+// Criterion 4: repo eviction (the reload drop-loop for repos no longer in the
+// registry) routes through retireHandle, deferring the munmap under a borrow.
+func TestEvictionDefersUnmapWhileBorrowed(t *testing.T) {
+	cc := &countingCloser{}
+	s, _ := newStateWithHandle(cc)
+
+	b := s.borrowGroup("g") // refs=1 on the repo's handle
+	if b == nil {
+		t.Fatal("borrowGroup returned nil")
+	}
+	// Registry group "g" has no repos, so Reload evicts "r".
+	if _, err := s.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("eviction munmapped while borrowed: count=%d, want 0", got)
+	}
+	b.Release()
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("munmap count after Release = %d, want 1", got)
+	}
+}
+
+// Criterion 4 (baseline, no borrow): Close unmaps immediately when nothing is
+// borrowed — behavior-identical to the pre-F1 bare Close().
+func TestCloseUnmapsImmediatelyWhenIdle(t *testing.T) {
+	cc := &countingCloser{}
+	s, _ := newStateWithHandle(cc)
+	s.Close()
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("idle Close munmap count = %d, want 1", got)
+	}
+}
+
+// Criterion 3: read-through-captured-handle. A borrow taken before a reload
+// binds to the handle it captured and stays valid (not munmapped) across the
+// reload, until the borrower releases. Stress: N borrowers reading through
+// their captured handles while a reloader repoints lr.handle in a tight loop.
+// Under -race, asserts zero faults (no munmap while borrowed, no double-munmap)
+// and zero handle leaks (every retired mapping eventually unmapped exactly once).
+func TestBorrowGroupSurvivesReload(t *testing.T) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	var closersMu sync.Mutex
+	var closers []*refCheckCloser
+	newHandle := func() *MapHandle {
+		c := &refCheckCloser{}
+		h := &MapHandle{closer: c}
+		c.h = h
+		closersMu.Lock()
+		closers = append(closers, c)
+		closersMu.Unlock()
+		return h
+	}
+
+	s.mu.Lock()
+	lr.publishHandle(newHandle())
+	s.mu.Unlock()
+
+	var readFault atomic.Int64
+	stop := make(chan struct{})
+
+	// Reloader: publish-then-retire in a tight loop, always under s.mu (the same
+	// lock borrowGroup takes), matching reloadLocked's discipline.
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s.mu.Lock()
+			lr.publishHandle(newHandle())
+			s.mu.Unlock()
+		}
+	}()
+
+	// Borrowers: capture a handle under the borrow, read through the captured
+	// reference (never a live lr.handle re-deref), and assert it is not
+	// munmapped while the borrow is held.
+	var wgB sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 3000; j++ {
+				b := s.borrowGroup("g")
+				if b == nil {
+					readFault.Add(1)
+					continue
+				}
+				h := b.Handle("r")
+				if h != nil {
+					// Dark read: the captured handle must still be mapped. Its
+					// counting closer must not have fired while we hold the borrow.
+					if rc, ok := h.closer.(*refCheckCloser); ok && rc.n.Load() > 0 {
+						readFault.Add(1)
+					}
+				}
+				b.Release()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	// Retire the final still-published handle so every created mapping is retired
+	// and should now be drained+unmapped exactly once.
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := readFault.Load(); f != 0 {
+		t.Fatalf("read faults (handle munmapped under an outstanding borrow): %d", f)
+	}
+	closersMu.Lock()
+	defer closersMu.Unlock()
+	for i, c := range closers {
+		if got := c.n.Load(); got != 1 {
+			t.Fatalf("handle %d: munmap count = %d, want exactly 1 (leak or double-munmap)", i, got)
+		}
+		if bad := c.badWhileRefs.Load(); bad != 0 {
+			t.Fatalf("handle %d: munmap observed refs>0 %d times, want 0", i, bad)
+		}
+	}
+}
+
+// Criterion 5: serve (internal/mcp) must never vend/borrow a Reader from the
+// unsafe internal/daemon/mcp LRU (graph_cache.go closes without draining refs).
+// This is enforced today by the non-import; guard it so a future refactor
+// cannot silently re-enter the close-without-drain path through serve's query
+// surface. Serve's mmap handles come only from reloadLocked's own fbreader.Open
+// under the F1 MapHandle protocol.
+func TestServeDoesNotImportUnsafeDaemonMCPLRU(t *testing.T) {
+	const forbidden = "github.com/cajasmota/grafel/internal/daemon/mcp"
+	fset := token.NewFileSet()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("glob: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no .go files found in package dir")
+	}
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		af, err := parser.ParseFile(fset, f, src, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		for _, imp := range af.Imports {
+			p := strings.Trim(imp.Path.Value, `"`)
+			if p == forbidden || strings.HasPrefix(p, forbidden+"/") {
+				t.Fatalf("%s imports %q — serve must not source a Reader from the "+
+					"unsafe daemon/mcp LRU (close-without-drain); see ADR-0027 invariant", f, p)
+			}
+		}
+	}
+}

--- a/internal/mcp/state_maphandle_test.go
+++ b/internal/mcp/state_maphandle_test.go
@@ -5,6 +5,7 @@ import (
 	"go/token"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -84,6 +85,70 @@ func TestCloseUnmapsImmediatelyWhenIdle(t *testing.T) {
 	}
 }
 
+// Regression (deterministic, borrow-path): the stale-refcount TOCTOU in
+// release(), forced through the REAL borrowGroup / publishHandle / release path
+// (not just the bare MapHandle). A first borrow is released to refs==0 while the
+// handle is STILL PUBLISHED; parked in the releaseGap seam, a second borrowGroup
+// legally re-borrows the same live handle (refs 0→1) and a reload then retires
+// it (sees refs==1 → defers). When the parked releaser resumes, a naive
+// `Add(-1)==0 && retired.Load()` release munmaps on its stale n==0 while refs==1
+// → use-after-unmap. This FAILS on the buggy release() and PASSES on the
+// re-check-after-retired fix — deterministically, at default -cpu, -count=1.
+func TestBorrowGroupReleaseDoesNotUnmapOnRefcountRebound(t *testing.T) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	cc := &refCheckCloser{}
+	gapEntered := make(chan struct{})
+	gapProceed := make(chan struct{})
+	var armed atomic.Bool
+	armed.Store(true)
+	H := &MapHandle{closer: cc, releaseGap: func() {
+		if armed.CompareAndSwap(true, false) {
+			close(gapEntered)
+			<-gapProceed
+		}
+	}}
+	cc.h = H
+	s.mu.Lock()
+	lr.publishHandle(H)
+	s.mu.Unlock()
+
+	b1 := s.borrowGroup("g") // borrows H (refs=1)
+	done := make(chan struct{})
+	go func() { defer close(done); b1.Release() }() // H.release(): Add(-1)→0, parks in gap
+
+	<-gapEntered
+	// H is still lr.handle (published): a second borrow legally rebounds refs
+	// 0→1, then a reload publishes a successor and retires H (defers, refs==1).
+	b2 := s.borrowGroup("g")
+	s.mu.Lock()
+	lr.publishHandle(&MapHandle{closer: &countingCloser{}})
+	s.mu.Unlock()
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("reload munmapped H while borrowed: count=%d, want 0", got)
+	}
+	close(gapProceed)
+	<-done
+
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("release munmapped H while refs>0 (rebound TOCTOU): %d faults", bad)
+	}
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("H unmapped while still borrowed by b2: count=%d, want 0", got)
+	}
+	b2.Release() // drains H → unmap exactly once
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("H final munmap count = %d, want 1", got)
+	}
+	if bad := cc.badWhileRefs.Load(); bad != 0 {
+		t.Fatalf("munmap observed refs>0 %d times, want 0", bad)
+	}
+}
+
 // Criterion 3: read-through-captured-handle. A borrow taken before a reload
 // binds to the handle it captured and stays valid (not munmapped) across the
 // reload, until the borrower releases. Stress: N borrowers reading through
@@ -101,7 +166,14 @@ func TestBorrowGroupSurvivesReload(t *testing.T) {
 	var closers []*refCheckCloser
 	newHandle := func() *MapHandle {
 		c := &refCheckCloser{}
-		h := &MapHandle{closer: c}
+		// releaseGap = runtime.Gosched yields inside release() in the exact window
+		// between the refcount decrement and the close decision, widening the
+		// stale-refcount rebound window for broad -race / -cpu-sweep coverage.
+		// This is the stochastic stress catcher (many handles, N borrowers, tight
+		// reload loop); the DETERMINISTIC, default-scheduling guarantee for the
+		// rebound TOCTOU lives in TestMapHandleReleaseRefcountReboundDoesNotUnmap
+		// and TestBorrowGroupReleaseDoesNotUnmapOnRefcountRebound.
+		h := &MapHandle{closer: c, releaseGap: runtime.Gosched}
 		c.h = h
 		closersMu.Lock()
 		closers = append(closers, c)
@@ -183,6 +255,38 @@ func TestBorrowGroupSurvivesReload(t *testing.T) {
 		if bad := c.badWhileRefs.Load(); bad != 0 {
 			t.Fatalf("handle %d: munmap observed refs>0 %d times, want 0", i, bad)
 		}
+	}
+}
+
+// Guard (F2-facing): publishHandle must repoint lr.handle to the SUCCESSOR
+// before it retires the predecessor. This ordering is what guarantees a fresh
+// borrow can never target a retired handle. It is currently REDUNDANT in F1
+// (s.mu serializes borrow-vs-publish), but becomes load-bearing in F2 when
+// release()/reads move off s.mu — so guard it now. We observe the ordering at
+// the exact instant the predecessor is unmapped: lr.handle must already be the
+// successor.
+func TestPublishHandlePublishesSuccessorBeforeRetiringPredecessor(t *testing.T) {
+	lr := &LoadedRepo{Repo: "r"}
+	var successor *MapHandle
+	closedPredecessor := false
+	old := &MapHandle{closer: closerFunc(func() error {
+		closedPredecessor = true
+		if lr.handle != successor {
+			t.Errorf("predecessor unmapped before successor published: lr.handle=%p, want successor %p",
+				lr.handle, successor)
+		}
+		return nil
+	})}
+	lr.handle = old
+	successor = &MapHandle{closer: closerFunc(func() error { return nil })}
+
+	lr.publishHandle(successor) // publishes successor, then retires+closes old (idle → immediate)
+
+	if !closedPredecessor {
+		t.Fatal("publishHandle did not retire/close the predecessor")
+	}
+	if lr.handle != successor {
+		t.Fatalf("after publishHandle lr.handle=%p, want successor %p", lr.handle, successor)
 	}
 }
 


### PR DESCRIPTION
Refs #5850 (mmap zero-copy epic, ADR-0027 #5854). F1 of the F1→F3→migrate→cutover build.

## What
Adds the refcount-drain `MapHandle` deferred-unmap lifetime — the safety keystone that lets serve swap/evict/close a mmap'd `graph.fb` while queries still alias it, without munmap-while-borrowed (SIGBUS). **The mmap read path stays DARK** in F1: no handler borrows yet, borrows are inert (refs always 0 → `retire()` closes immediately), so behavior is byte-identical to today's in-place close. This is pure lifetime scaffolding + rewiring the existing munmap sites to be borrow-safe.

## How
- **`internal/mcp/maphandle.go`** — `MapHandle{ repo, reader, closer, refs atomic.Int64, retired atomic.Bool, closed sync.Once }` with `borrow()`/`release()`/`retire()`/`closeOnce()`. Publish-then-defer: reload repoints `lr.handle` to the successor before retiring the predecessor. Exactly-once close rests entirely on the `sync.Once` (both reload and the last releaser can observe `refs==0 && retired` — NOT unique observation). No negative sentinel (documented: a fresh borrow only targets the currently-published handle).
- **`internal/mcp/state.go`** — `LoadedRepo.handle` owns the mapping lifetime; `publishHandle`/`setReader`/`retireHandle` rewire all three munmap sites (reload swap, eviction drop-loop, server `Close()`) from bare `lr.Reader.Close()` to `retire()`+conditional `closeOnce()`. `State.borrowGroup` returns an immutable per-call snapshot capturing a borrow per repo handle under `s.mu` (the read-through-captured-handle seam; inert in F1).

## Tests (all under `-race`) — one per blocking review criterion
1. `TestMapHandleCloseIsExactlyOnceUnderContention` — forces the two-observer interleaving, munmap count == 1 over 5000 iters.
2. `TestMapHandleBorrowWinsDefersUnmap` / `…ReloadWinsClosesImmediatelyAndIsIdempotent` / `…NoLeakUnderRacingBorrowAndRetire` — borrow-wins vs reload-wins; never closed while refs>0; exactly once.
3. `TestBorrowGroupSurvivesReload` — 8 borrowers on captured handles + tight publish/retire reload loop; zero faults, each retired mapping unmapped exactly once, none while borrowed.
4. `TestCloseDefersUnmapWhileBorrowed` / `TestEvictionDefersUnmapWhileBorrowed` / `TestCloseUnmapsImmediatelyWhenIdle`.
5. `TestServeDoesNotImportUnsafeDaemonMCPLRU` — parses every `internal/mcp/*.go` import; fails on any `internal/daemon/mcp` import.

## Gate (local; CI reserved for releases)
`go build ./...` clean · `go vet ./internal/mcp/... ./internal/graph/...` clean · `gofmt -l internal/mcp/` empty · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` — 1337 passed / 10 packages.

## Deferred (intentional, not in F1's safety scope)
- Lifetime **metrics** (open-mappings / retired-not-drained / max-borrow-age) → **F2**, where borrows become real and there's something to observe (in F1 borrows are inert, so the counters would be untested dead surface).
- **Windows** reload-under-borrow smoke test (`ERROR_SHARING_VIOLATION` on rename) → must run in Windows CI when gated; handle lifetime is OS-independent and covered here, Windows unmap goes through the same `closeOnce`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o