### PR TITLE
feat(mcp,graph): F2 EntityView/RelationshipView seam + handle-keyed hot index (ADR-0027)

### DIFF
--- a/internal/graph/view.go
+++ b/internal/graph/view.go
@@ -1,0 +1,112 @@
+package graph
+
+// F2 of ADR-0027 (mmap + zero-copy resident graph): the read-only view seam.
+//
+// EntityView / RelationshipView decouple the ~3,700 consumer read sites from the
+// concrete heap structs, so the migration (M-series) can move package-by-package
+// while the build stays green, and so F3 can drop in an mmap-backed impl of the
+// SAME interface without any consumer change. The method set is deliberately
+// MINIMAL for F2: the HOT accessors the resident hot index needs first
+// (ID/Kind/Name/QualifiedName, and From/To for relationships) plus the handful of
+// COLD accessors a pilot call site reads (Subtype/SourceFile/Language/Signature
+// and property access). Later M-PRs widen it one field at a time — it is additive.
+//
+// Why a wrapper and not methods on *Entity: a Go struct that has an exported
+// field `Name` cannot also expose a `Name()` method (name collision), and every
+// hot accessor collides with an existing exported field. Renaming the fields is
+// the whole M/C-series migration (it rewrites every consumer), which F2 must NOT
+// do. ADR-0027 blesses exactly this escape hatch: "each method returns the
+// corresponding struct field ... after a mechanical field rename, OR a thin
+// wrapper type." F2 takes the wrapper: materializedEntityView adapts the concrete
+// *Entity today; F3 adds mmapEntityView. Both satisfy the interface; the resident
+// hot index and every migrated consumer bind only to the interface.
+
+// EntityView is the read-only view of a graph entity. See package doc above for
+// the HOT/COLD rationale and why the concrete type is adapted via a wrapper.
+type EntityView interface {
+	ID() string
+	Kind() string
+	Name() string
+	QualifiedName() string
+	Subtype() string
+	SourceFile() string
+	Language() string
+	Signature() string
+	// Property returns the value for key and whether it was present. Storage-
+	// agnostic by contract (ADR-0027 §Interaction): compatible with both the
+	// map-backed and the in-flight []propKV backing, and later with values
+	// aliased straight out of the mmap.
+	Property(key string) (string, bool)
+	// Properties returns a snapshot copy of all properties. Kept storage-agnostic
+	// for the same reason as Property.
+	Properties() map[string]string
+}
+
+// RelationshipView is the read-only view of a graph relationship.
+type RelationshipView interface {
+	ID() string
+	FromID() string
+	ToID() string
+	Kind() string
+	Property(key string) (string, bool)
+}
+
+// materializedEntityView adapts a concrete *Entity (materialized on the heap) to
+// EntityView. Value-typed wrapper over a pointer: zero heap cost beyond the
+// interface box, and behavior-neutral — every method returns the underlying
+// field verbatim.
+type materializedEntityView struct{ e *Entity }
+
+// EntityViewOf wraps a concrete *Entity as an EntityView. Returns a nil interface
+// for a nil entity so callers can nil-check the result.
+func EntityViewOf(e *Entity) EntityView {
+	if e == nil {
+		return nil
+	}
+	return materializedEntityView{e: e}
+}
+
+func (v materializedEntityView) ID() string            { return v.e.ID }
+func (v materializedEntityView) Kind() string          { return v.e.Kind }
+func (v materializedEntityView) Name() string          { return v.e.Name }
+func (v materializedEntityView) QualifiedName() string { return v.e.QualifiedName }
+func (v materializedEntityView) Subtype() string       { return v.e.Subtype }
+func (v materializedEntityView) SourceFile() string    { return v.e.SourceFile }
+func (v materializedEntityView) Language() string      { return v.e.Language }
+func (v materializedEntityView) Signature() string     { return v.e.Signature }
+
+func (v materializedEntityView) Property(key string) (string, bool) {
+	return v.e.PropLookup(key)
+}
+
+func (v materializedEntityView) Properties() map[string]string {
+	return v.e.PropsSnapshot()
+}
+
+// materializedRelationshipView adapts a concrete *Relationship to
+// RelationshipView. See materializedEntityView for the wrapper rationale.
+type materializedRelationshipView struct{ r *Relationship }
+
+// RelationshipViewOf wraps a concrete *Relationship as a RelationshipView.
+// Returns a nil interface for a nil relationship.
+func RelationshipViewOf(r *Relationship) RelationshipView {
+	if r == nil {
+		return nil
+	}
+	return materializedRelationshipView{r: r}
+}
+
+func (v materializedRelationshipView) ID() string     { return v.r.ID }
+func (v materializedRelationshipView) FromID() string { return v.r.FromID }
+func (v materializedRelationshipView) ToID() string   { return v.r.ToID }
+func (v materializedRelationshipView) Kind() string   { return v.r.Kind }
+
+func (v materializedRelationshipView) Property(key string) (string, bool) {
+	return v.r.PropLookup(key)
+}
+
+// Compile-time assertions that the materialized wrappers satisfy the interfaces.
+var (
+	_ EntityView       = materializedEntityView{}
+	_ RelationshipView = materializedRelationshipView{}
+)

--- a/internal/graph/view_test.go
+++ b/internal/graph/view_test.go
@@ -1,0 +1,117 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// F2 of ADR-0027: the EntityView / RelationshipView interface seam. These tests
+// pin the behavior-neutral contract — the materialized view wrapping a concrete
+// *graph.Entity / *graph.Relationship returns exactly the underlying field, so
+// F3 can drop in an mmap-backed impl of the SAME interface without any consumer
+// change. (The wrapper exists because a struct with exported field `Name` cannot
+// also expose a `Name()` method; ADR-0027 blesses "a thin wrapper type".)
+
+func newEntity() *graph.Entity {
+	e := &graph.Entity{
+		ID:            "repo::pkg.Foo",
+		Name:          "Foo",
+		QualifiedName: "pkg.Foo",
+		Kind:          "type",
+		Subtype:       "struct",
+		SourceFile:    "pkg/foo.go",
+		Language:      "go",
+		Signature:     "type Foo struct{}",
+	}
+	e.PropSet("module", "pkg")
+	return e
+}
+
+func TestMaterializedEntityViewSatisfiesInterface(t *testing.T) {
+	var _ graph.EntityView = graph.EntityViewOf(newEntity())
+}
+
+func TestMaterializedEntityViewReturnsUnderlyingFields(t *testing.T) {
+	e := newEntity()
+	v := graph.EntityViewOf(e)
+
+	if got := v.ID(); got != e.ID {
+		t.Errorf("ID() = %q, want %q", got, e.ID)
+	}
+	if got := v.Name(); got != e.Name {
+		t.Errorf("Name() = %q, want %q", got, e.Name)
+	}
+	if got := v.QualifiedName(); got != e.QualifiedName {
+		t.Errorf("QualifiedName() = %q, want %q", got, e.QualifiedName)
+	}
+	if got := v.Kind(); got != e.Kind {
+		t.Errorf("Kind() = %q, want %q", got, e.Kind)
+	}
+	if got := v.Subtype(); got != e.Subtype {
+		t.Errorf("Subtype() = %q, want %q", got, e.Subtype)
+	}
+	if got := v.SourceFile(); got != e.SourceFile {
+		t.Errorf("SourceFile() = %q, want %q", got, e.SourceFile)
+	}
+	if got := v.Language(); got != e.Language {
+		t.Errorf("Language() = %q, want %q", got, e.Language)
+	}
+	if got := v.Signature(); got != e.Signature {
+		t.Errorf("Signature() = %q, want %q", got, e.Signature)
+	}
+}
+
+func TestMaterializedEntityViewProperties(t *testing.T) {
+	v := graph.EntityViewOf(newEntity())
+
+	got, ok := v.Property("module")
+	if !ok || got != "pkg" {
+		t.Errorf("Property(module) = (%q, %v), want (\"pkg\", true)", got, ok)
+	}
+	if _, ok := v.Property("absent"); ok {
+		t.Error("Property(absent) reported present")
+	}
+	if snap := v.Properties(); snap["module"] != "pkg" {
+		t.Errorf("Properties()[module] = %q, want %q", snap["module"], "pkg")
+	}
+}
+
+func TestEntityViewOfNilIsNil(t *testing.T) {
+	if v := graph.EntityViewOf(nil); v != nil {
+		t.Errorf("EntityViewOf(nil) = %v, want nil", v)
+	}
+}
+
+func TestMaterializedRelationshipView(t *testing.T) {
+	r := &graph.Relationship{
+		ID:     "e1",
+		FromID: "repo::a",
+		ToID:   "repo::b",
+		Kind:   "CALLS",
+	}
+	r.PropSet("call_site", "42")
+
+	var v graph.RelationshipView = graph.RelationshipViewOf(r)
+	if got := v.ID(); got != r.ID {
+		t.Errorf("ID() = %q, want %q", got, r.ID)
+	}
+	if got := v.FromID(); got != r.FromID {
+		t.Errorf("FromID() = %q, want %q", got, r.FromID)
+	}
+	if got := v.ToID(); got != r.ToID {
+		t.Errorf("ToID() = %q, want %q", got, r.ToID)
+	}
+	if got := v.Kind(); got != r.Kind {
+		t.Errorf("Kind() = %q, want %q", got, r.Kind)
+	}
+	if got, ok := v.Property("call_site"); !ok || got != "42" {
+		t.Errorf("Property(call_site) = (%q, %v), want (\"42\", true)", got, ok)
+	}
+}
+
+func TestRelationshipViewOfNilIsNil(t *testing.T) {
+	if v := graph.RelationshipViewOf(nil); v != nil {
+		t.Errorf("RelationshipViewOf(nil) = %v, want nil", v)
+	}
+}

--- a/internal/mcp/hotindex.go
+++ b/internal/mcp/hotindex.go
@@ -1,0 +1,141 @@
+package mcp
+
+// F2 of ADR-0027 (mmap + zero-copy resident graph): the handle-keyed hot index.
+//
+// The resident hot index (id / label / qualified-name lookups over the HOT
+// accessors) is what queries filter against — never per-entity view dispatch.
+// The blocking F2 criterion is that this index is BUILT FROM and KEYED OFF the
+// MapHandle a call captured under s.mu in borrowGroup — NOT a live lr.Doc /
+// lr.handle re-deref at read time. Reload mutates *LoadedRepo in place
+// (repointing lr.handle to a successor this call never borrow()-incremented), so
+// keying the index off the captured handle is exactly the read-through-captured-
+// handle invariant (ADR-0027 §Correctness): the handle the index carries stays
+// mapped for the whole call because the borrow deferred its munmap.
+//
+// The builder depends ONLY on a (handle, entityViewSource) seam. In F2 the sole
+// source is the heap Document (docEntityViewSource); F3 adds an mmap-backed
+// source that reads through the SAME captured handle, without touching the
+// builder or its consumers. The index stores graph.EntityView values, so it is
+// agnostic to whether the backing entity is materialized or mmap-aliased.
+//
+// This index is a NEW structure ALONGSIDE the existing LabelIndex / getByID /
+// getCallsAdj internals (which a parallel Tier-2b PR owns) — it never re-keys or
+// re-backs them. It is inert in F2 (no production query reads it yet), like F1's
+// borrow protocol; it exists to be exercised under test and to be lit up by F3.
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// entityViewSource yields the EntityViews a hot index is built from. It is the
+// storage seam that lets the builder be fed by the heap Document today and by an
+// mmap-backed reader in F3, without either knowing about the other.
+type entityViewSource interface {
+	// forEachEntityView invokes yield once per entity view. Implementations must
+	// tolerate a nil receiver-held document and simply yield nothing.
+	forEachEntityView(yield func(graph.EntityView))
+}
+
+// docEntityViewSource adapts a captured *graph.Document into an entityViewSource
+// by wrapping each entity as a materialized graph.EntityView. This is F2's only
+// source; F3 replaces it (per repo load, behind GRAFEL_SERVE_FROM_MMAP) with an
+// mmap-backed source over the same captured handle.
+type docEntityViewSource struct{ doc *graph.Document }
+
+func (s docEntityViewSource) forEachEntityView(yield func(graph.EntityView)) {
+	if s.doc == nil {
+		return
+	}
+	for i := range s.doc.Entities {
+		yield(graph.EntityViewOf(&s.doc.Entities[i]))
+	}
+}
+
+// hotIndex is the handle-keyed resident hot index over EntityViews: exact-ID,
+// case-insensitive label (Name), and case-insensitive qualified-name lookups.
+// handle is the MapHandle the owning call captured under s.mu; it is the read
+// cursor the index binds to for its whole lifetime. The lookup maps mirror
+// LabelIndex's key semantics (lowercased label/qname) but are an independent,
+// additive structure — they never alias or re-key LabelIndex's maps.
+type hotIndex struct {
+	handle  *MapHandle
+	byID    map[string]graph.EntityView
+	byLabel map[string][]graph.EntityView
+	byQName map[string]graph.EntityView
+}
+
+// buildHotIndex builds a hot index from the views yielded by src, KEYED OFF the
+// captured handle h. It never dereferences a live lr.Doc / lr.handle — the only
+// inputs are the captured handle and the view source, which is the property F3
+// relies on to feed the same builder from the mmap. A nil src yields an empty
+// index that still carries the captured handle.
+func buildHotIndex(h *MapHandle, src entityViewSource) *hotIndex {
+	hi := &hotIndex{
+		handle:  h,
+		byID:    map[string]graph.EntityView{},
+		byLabel: map[string][]graph.EntityView{},
+		byQName: map[string]graph.EntityView{},
+	}
+	if src == nil {
+		return hi
+	}
+	src.forEachEntityView(func(v graph.EntityView) {
+		if v == nil {
+			return
+		}
+		hi.byID[v.ID()] = v
+		lbl := strings.ToLower(v.Name())
+		hi.byLabel[lbl] = append(hi.byLabel[lbl], v)
+		if qn := v.QualifiedName(); qn != "" {
+			hi.byQName[strings.ToLower(qn)] = v
+		}
+	})
+	return hi
+}
+
+// Handle returns the MapHandle this index is keyed off — the handle captured
+// under s.mu by the owning call's borrowGroup snapshot.
+func (hi *hotIndex) Handle() *MapHandle {
+	if hi == nil {
+		return nil
+	}
+	return hi.handle
+}
+
+// entityByID returns the view for an exact entity ID.
+func (hi *hotIndex) entityByID(id string) (graph.EntityView, bool) {
+	if hi == nil {
+		return nil, false
+	}
+	v, ok := hi.byID[id]
+	return v, ok
+}
+
+// entitiesByLabel returns every view whose Name matches label, case-insensitively.
+func (hi *hotIndex) entitiesByLabel(label string) []graph.EntityView {
+	if hi == nil {
+		return nil
+	}
+	return hi.byLabel[strings.ToLower(label)]
+}
+
+// entityByQName returns the view for a qualified name, case-insensitively.
+func (hi *hotIndex) entityByQName(qname string) (graph.EntityView, bool) {
+	if hi == nil {
+		return nil, false
+	}
+	v, ok := hi.byQName[strings.ToLower(qname)]
+	return v, ok
+}
+
+// buildHotIndex builds a handle-keyed hot index for repo from this per-call
+// snapshot: it pairs the handle borrowed (captured) under s.mu with the view
+// source. The handle comes from the snapshot — never a live lr.handle re-deref —
+// so the resulting index satisfies the read-through-captured-handle invariant.
+// In F2 the caller passes a docEntityViewSource over the repo's heap Document;
+// F3 passes an mmap-backed source over the same captured handle.
+func (b *groupBorrow) buildHotIndex(repo string, src entityViewSource) *hotIndex {
+	return buildHotIndex(b.Handle(repo), src)
+}

--- a/internal/mcp/hotindex_test.go
+++ b/internal/mcp/hotindex_test.go
@@ -1,0 +1,215 @@
+package mcp
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// F2 of ADR-0027: the handle-keyed hot index. These tests actually RUN the
+// handle-fed builder (build the index from a captured MapHandle, query it, get
+// correct results) and prove the read-through-captured-handle invariant: the
+// index is keyed off the handle captured under s.mu in borrowGroup, and stays
+// valid (never munmapped) across a concurrent reload while a borrow is held.
+
+func newDocRepoState(doc *graph.Document, c readerCloser) (*State, *LoadedRepo) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+	s.mu.Lock()
+	lr.publishHandle(&MapHandle{closer: c})
+	s.mu.Unlock()
+	return s, lr
+}
+
+func sampleDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "r::pkg.Foo", Name: "Foo", QualifiedName: "pkg.Foo", Kind: "type"},
+			{ID: "r::pkg.Bar", Name: "Bar", QualifiedName: "pkg.Bar", Kind: "func"},
+			{ID: "r::pkg.foo2", Name: "Foo", QualifiedName: "pkg.Foo2", Kind: "func"},
+		},
+	}
+}
+
+// TestBuildHotIndexFromCapturedHandle runs the handle-fed builder end to end: it
+// captures a handle under s.mu via borrowGroup, feeds the builder a view source,
+// and asserts (a) the index is keyed off the captured handle and (b) byID /
+// byLabel / byQName return the correct EntityViews.
+func TestBuildHotIndexFromCapturedHandle(t *testing.T) {
+	s, _ := newDocRepoState(sampleDoc(), &countingCloser{})
+
+	b := s.borrowGroup("g")
+	if b == nil {
+		t.Fatal("borrowGroup returned nil")
+	}
+	defer b.Release()
+
+	captured := b.Handle("r")
+	if captured == nil {
+		t.Fatal("no handle captured for repo r")
+	}
+
+	hi := b.buildHotIndex("r", docEntityViewSource{doc: b.Group.Repos["r"].Doc})
+	if hi == nil {
+		t.Fatal("buildHotIndex returned nil")
+	}
+
+	// Blocking F2 criterion: the hot index is keyed off the SAME handle the call
+	// borrowed under s.mu, not a live lr.handle re-deref.
+	if hi.Handle() != captured {
+		t.Fatalf("hot index handle = %p, want captured handle %p", hi.Handle(), captured)
+	}
+
+	v, ok := hi.entityByID("r::pkg.Bar")
+	if !ok {
+		t.Fatal("entityByID(r::pkg.Bar) missing")
+	}
+	if v.Name() != "Bar" || v.Kind() != "func" {
+		t.Errorf("byID view = (%q,%q), want (Bar,func)", v.Name(), v.Kind())
+	}
+
+	q, ok := hi.entityByQName("pkg.foo2") // qname lookup is case-insensitive
+	if !ok || q.ID() != "r::pkg.foo2" {
+		t.Errorf("entityByQName(pkg.foo2) = %v/%v, want r::pkg.foo2", q, ok)
+	}
+
+	// "Foo" is an ambiguous label (two entities share Name=="Foo").
+	foos := hi.entitiesByLabel("foo") // label lookup is case-insensitive
+	if len(foos) != 2 {
+		t.Fatalf("entitiesByLabel(foo) returned %d, want 2", len(foos))
+	}
+	ids := map[string]bool{}
+	for _, e := range foos {
+		ids[e.ID()] = true
+	}
+	if !ids["r::pkg.Foo"] || !ids["r::pkg.foo2"] {
+		t.Errorf("entitiesByLabel(foo) ids = %v, want both Foo entities", ids)
+	}
+}
+
+// TestBuildHotIndexIsHandleAgnosticSource proves the builder depends only on the
+// (handle, view-source) seam — a nil source yields an empty index still keyed
+// off the captured handle. This is what lets F3 swap an mmap-backed source in
+// without touching the builder or its consumers.
+func TestBuildHotIndexEmptySourceKeepsHandle(t *testing.T) {
+	s, _ := newDocRepoState(sampleDoc(), &countingCloser{})
+	b := s.borrowGroup("g")
+	defer b.Release()
+
+	hi := buildHotIndex(b.Handle("r"), nil)
+	if hi.Handle() != b.Handle("r") {
+		t.Fatal("empty-source index lost its captured handle")
+	}
+	if _, ok := hi.entityByID("r::pkg.Foo"); ok {
+		t.Error("empty-source index returned an entity")
+	}
+}
+
+// TestHotIndexReadsBindToCapturedHandleAcrossReload is the F2 captured-handle
+// race test (reuses F1's reload-loop harness shape). N borrowers each capture a
+// handle under s.mu, build a hot index KEYED OFF that captured handle, and read
+// through the index while a reloader repoints lr.handle in a tight loop. Under
+// -race it asserts: the captured handle is never munmapped while its borrow is
+// held (reads bind to the captured handle, not a live lr.handle re-deref), the
+// index answers correctly, and every retired mapping is unmapped exactly once.
+func TestHotIndexReadsBindToCapturedHandleAcrossReload(t *testing.T) {
+	doc := sampleDoc()
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	var closersMu sync.Mutex
+	var closers []*refCheckCloser
+	newHandle := func() *MapHandle {
+		c := &refCheckCloser{}
+		h := &MapHandle{closer: c, releaseGap: runtime.Gosched}
+		c.h = h
+		closersMu.Lock()
+		closers = append(closers, c)
+		closersMu.Unlock()
+		return h
+	}
+
+	s.mu.Lock()
+	lr.publishHandle(newHandle())
+	s.mu.Unlock()
+
+	var readFault atomic.Int64
+	stop := make(chan struct{})
+
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s.mu.Lock()
+			lr.publishHandle(newHandle())
+			s.mu.Unlock()
+		}
+	}()
+
+	var wgB sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 2000; j++ {
+				b := s.borrowGroup("g")
+				if b == nil {
+					readFault.Add(1)
+					continue
+				}
+				// Build the hot index keyed off the captured handle and read
+				// through it. The view source is the stable Doc; the load-bearing
+				// assertion is that the index's handle stays mapped for the read.
+				hi := b.buildHotIndex("r", docEntityViewSource{doc: b.Group.Repos["r"].Doc})
+				h := hi.Handle()
+				v, ok := hi.entityByID("r::pkg.Foo")
+				if !ok || v.Name() != "Foo" {
+					readFault.Add(1)
+				}
+				if rc, isRC := h.closer.(*refCheckCloser); isRC && rc.n.Load() > 0 {
+					// The captured handle was munmapped while we still hold the
+					// borrow and read through its index — a use-after-unmap.
+					readFault.Add(1)
+				}
+				b.Release()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := readFault.Load(); f != 0 {
+		t.Fatalf("read faults (captured handle munmapped under borrow, or wrong result): %d", f)
+	}
+	closersMu.Lock()
+	defer closersMu.Unlock()
+	for i, c := range closers {
+		if got := c.n.Load(); got != 1 {
+			t.Fatalf("handle %d: munmap count = %d, want exactly 1 (leak or double-munmap)", i, got)
+		}
+		if bad := c.badWhileRefs.Load(); bad != 0 {
+			t.Fatalf("handle %d: munmap observed refs>0 %d times, want 0", i, bad)
+		}
+	}
+}


### PR DESCRIPTION
Refs #5850 (mmap zero-copy epic, ADR-0027). Builds on F1 (#5855). Behavior-neutral; mmap read path stays DARK.

## What
Introduces the `EntityView`/`RelationshipView` interface seam + a handle-keyed hot index, so the ~3,700 consumer sites can migrate bite-sized (M-series) while the build stays green, and so F3 can drop a mmap-backed view behind the same interface.

## How
- **`internal/graph/view.go`** — `EntityView` (HOT: `ID/Kind/Name/QualifiedName`; COLD pilot: `Subtype/SourceFile/Language/Signature/Property(key)/Properties()`) and `RelationshipView` (`ID/FromID/ToID/Kind/Property`). Minimal + additive — only what the hot index + a pilot site need; M-PRs widen one field at a time. `Property`/`Properties` are storage-agnostic (compatible with map, `[]propKV`, and future mmap-aliased values).
- **Wrapper, not struct methods:** `graph.Entity` has exported fields (`Name`, `Kind`, `ID`) that collide with the interface method names (Go forbids field+method same name). Per ADR §escape-hatch, F2 uses zero-cost value wrappers `materializedEntityView`/`materializedRelationshipView` via `graph.EntityViewOf`/`RelationshipViewOf`. The field-rename that lets the concrete type satisfy the interface directly is deferred to the M/C-series (it rewrites every consumer); F3 adds `mmapEntityView` behind the same interface.
- **`internal/mcp/hotindex.go`** — `hotIndex{handle, byID, byLabel, byQName}` over `graph.EntityView`, built by `buildHotIndex(h *MapHandle, src entityViewSource)`. The builder takes a CAPTURED handle + a view-source seam, never a live `lr.Doc` (satisfies the read-through-captured-handle invariant). F2's only source is the heap `Document`; F3 swaps a mmap source over the same captured handle. Keyed off `b.Handle(repo)` captured under `s.mu`. New structure ALONGSIDE `LabelIndex`/`getByID` — does not re-key or re-back them (respects the Tier-2b mop-up boundary).

## Tests (under `-race`)
- Handle-fed builder exercised (ADR F2 criterion): `TestBuildHotIndexFromCapturedHandle` (builds from captured handle, asserts `hi.Handle()==captured`, queries byID/byLabel-ambiguous/byQName case-insensitively) + `TestBuildHotIndexEmptySourceKeepsHandle`.
- Captured-handle race: `TestHotIndexReadsBindToCapturedHandleAcrossReload` (8 borrowers build+query a hot index keyed off their captured handle while a reloader repoints `lr.handle`; zero read faults, captured handle never munmapped under borrow, each retired mapping unmapped exactly once).
- Seam contract: `TestMaterializedEntityViewSatisfiesInterface`/`ReturnsUnderlyingFields`/`Properties`, nil-guards, relationship equivalents.

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` all ok.

## Deferred
- Consumer migration (M1-M16) and the field-rename that removes the wrapper — later PRs.
- mmap-backed `mmapEntityView` — F3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o