### PR TITLE
perf(mcp): BM25 idle-eviction + lazy rebuild (−313 MB when idle)

### DIFF
--- a/internal/mcp/bm25_eviction_test.go
+++ b/internal/mcp/bm25_eviction_test.go
@@ -1,0 +1,305 @@
+package mcp
+
+// bm25_eviction_test.go — idle-eviction lifecycle for the lazily-built BM25
+// index (resident-graph memory epic #5850, BM25-evictable track).
+//
+// BM25 is the single largest lazy resident consumer (~313 MB warmed on the
+// corpus). It is built lazily on first search (getBM25) and, with this track,
+// dropped after an idle window so a session that has stopped searching does not
+// pin it — rebuilding transparently and single-flighted on the next search.
+//
+// These tests assert: (1) idle eviction actually nils the index and re-arms the
+// lazy build; (2) a not-yet-idle index is kept; (3) search results are identical
+// whether the index was freshly built, warm, or rebuilt-after-eviction; (4)
+// concurrent search during eviction is safe (run under -race); (5) the rebuild
+// after eviction is single-flighted (exactly one build under concurrent first
+// searches); (6) the State-level sweep evicts idle repos; (7) eviction composes
+// with reload's resetIndexes without a double-free.
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// hitKey renders a hit as a stable (entity-id, rounded-score) string so two
+// rankings can be compared for byte-identical results across build paths.
+func hitKey(h Hit) string {
+	id := ""
+	if h.Entity != nil {
+		id = h.Entity.ID
+	}
+	return fmt.Sprintf("%s|%.9f", id, h.Score)
+}
+
+func hitKeys(hits []Hit) []string {
+	out := make([]string, len(hits))
+	for i, h := range hits {
+		out[i] = hitKey(h)
+	}
+	return out
+}
+
+// TestBM25EvictIdleReleasesAndRebuilds asserts an idle index is dropped (field
+// nilled) and the next getBM25 transparently rebuilds a live index.
+func TestBM25EvictIdleReleasesAndRebuilds(t *testing.T) {
+	doc := buildSyntheticDoc(400)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+
+	if got := lr.getBM25(); got == nil {
+		t.Fatal("getBM25 returned nil for a repo with a Doc")
+	}
+	if lr.BM25 == nil {
+		t.Fatal("BM25 field not populated after getBM25")
+	}
+
+	// Age the last-use past the idle window and sweep.
+	last := lr.bm25LastUse
+	if !lr.evictBM25IfIdle(time.Minute, last.Add(2*time.Minute)) {
+		t.Fatal("evictBM25IfIdle returned false for an index idle past the window")
+	}
+	if lr.BM25 != nil {
+		t.Fatal("BM25 field not nilled after idle eviction")
+	}
+
+	// Rebuild-on-demand: next getBM25 must transparently rebuild.
+	if got := lr.getBM25(); got == nil {
+		t.Fatal("getBM25 did not rebuild after eviction")
+	}
+	if lr.BM25 == nil {
+		t.Fatal("BM25 field not repopulated after rebuild")
+	}
+}
+
+// TestBM25EvictNotIdleKept asserts a recently-used index is NOT evicted.
+func TestBM25EvictNotIdleKept(t *testing.T) {
+	doc := buildSyntheticDoc(200)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+	_ = lr.getBM25()
+	before := lr.BM25
+
+	// now is only 10s after last use, window is 5m → keep.
+	if lr.evictBM25IfIdle(5*time.Minute, lr.bm25LastUse.Add(10*time.Second)) {
+		t.Fatal("evictBM25IfIdle evicted an index that was used within the window")
+	}
+	if lr.BM25 != before {
+		t.Fatal("BM25 index changed despite being within the idle window")
+	}
+}
+
+// TestBM25EvictNeverBuiltNoop asserts eviction on a repo that never built BM25
+// is a safe no-op (guards the reload double-free / nil-deref path).
+func TestBM25EvictNeverBuiltNoop(t *testing.T) {
+	lr := &LoadedRepo{Repo: "corpus", Doc: buildSyntheticDoc(50)}
+	if lr.evictBM25IfIdle(time.Minute, time.Now().Add(time.Hour)) {
+		t.Fatal("evictBM25IfIdle reported an eviction for a never-built index")
+	}
+	// Disabled window (idle<=0) must also be a no-op even when built.
+	_ = lr.getBM25()
+	if lr.evictBM25IfIdle(0, time.Now().Add(time.Hour)) {
+		t.Fatal("evictBM25IfIdle evicted with a disabled (0) idle window")
+	}
+	if lr.BM25 == nil {
+		t.Fatal("disabled window must not drop the index")
+	}
+}
+
+// TestBM25SearchAfterEvictionIdenticalResults is the correctness guard: results
+// must be byte-identical whether BM25 was freshly built, warm, or rebuilt after
+// an eviction.
+func TestBM25SearchAfterEvictionIdenticalResults(t *testing.T) {
+	doc := buildSyntheticDoc(1200)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+	queries := []string{
+		"handleOrderRequest customer processor payload",
+		"order kafka fulfilment pipeline",
+		"premium checklistType 2",
+		"validating persisting entity",
+	}
+
+	warm := map[string][]string{}
+	for _, q := range queries {
+		warm[q] = hitKeys(lr.getBM25().Search(q, 10))
+	}
+
+	// Evict and rebuild.
+	if !lr.evictBM25IfIdle(time.Minute, lr.bm25LastUse.Add(2*time.Minute)) {
+		t.Fatal("expected eviction")
+	}
+	for _, q := range queries {
+		got := hitKeys(lr.getBM25().Search(q, 10))
+		want := warm[q]
+		if len(got) != len(want) {
+			t.Fatalf("query %q: result count changed after rebuild: got %d want %d", q, len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("query %q rank %d: rebuilt result differs\n got=%s\nwant=%s", q, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestBM25ConcurrentSearchDuringEviction runs many searches concurrently with a
+// racing eviction loop. Under -race this proves no use-after-free / data race:
+// an in-flight search completes on the pointer it borrowed even as the field is
+// nilled and rebuilt underneath it.
+func TestBM25ConcurrentSearchDuringEviction(t *testing.T) {
+	doc := buildSyntheticDoc(800)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+	_ = lr.getBM25() // warm once
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Searchers: continuously borrow-and-search.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				hits := lr.getBM25().Search("order kafka fulfilment premium", 10)
+				_ = hits
+			}
+		}()
+	}
+
+	// Evictor: aggressively evict (force by treating every borrow as idle).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// now far in the future so any built index is considered idle.
+			lr.evictBM25IfIdle(time.Nanosecond, time.Now().Add(time.Hour))
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+
+	time.Sleep(200 * time.Millisecond)
+	close(stop)
+	wg.Wait()
+}
+
+// TestBM25SingleFlightRebuild asserts the rebuild after eviction is single-
+// flighted: concurrent first-searches all observe exactly ONE built index
+// (identical pointer), never N independent builds.
+func TestBM25SingleFlightRebuild(t *testing.T) {
+	doc := buildSyntheticDoc(600)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+	_ = lr.getBM25()
+	if !lr.evictBM25IfIdle(time.Minute, lr.bm25LastUse.Add(2*time.Minute)) {
+		t.Fatal("expected eviction")
+	}
+
+	const n = 16
+	var wg sync.WaitGroup
+	ptrs := make([]*BM25Index, n)
+	start := make(chan struct{})
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			ptrs[i] = lr.getBM25()
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	first := ptrs[0]
+	if first == nil {
+		t.Fatal("rebuild produced a nil index")
+	}
+	for i, p := range ptrs {
+		if p != first {
+			t.Fatalf("single-flight violated: goroutine %d built a distinct index (%p != %p)", i, p, first)
+		}
+	}
+}
+
+// TestSweepIdleBM25 exercises the State-level sweep the server fires from
+// reloadBeforeCall: an idle repo is evicted, a fresh one is kept.
+func TestSweepIdleBM25(t *testing.T) {
+	idleDoc := buildSyntheticDoc(300)
+	idleDoc.Repo = "idle"
+	freshDoc := buildSyntheticDoc(300)
+	freshDoc.Repo = "fresh"
+	srv := newTestServer(t, idleDoc, freshDoc)
+
+	lg := srv.State.groups["test"]
+	idle := lg.Repos["idle"]
+	fresh := lg.Repos["fresh"]
+
+	// Warm both through the search path so bm25LastUse is stamped.
+	_ = idle.getBM25()
+	_ = fresh.getBM25()
+
+	// Backdate the idle repo's last-use well past the window.
+	idle.idxMu.Lock()
+	idle.bm25LastUse = time.Now().Add(-10 * time.Minute)
+	idle.idxMu.Unlock()
+
+	evicted := srv.State.SweepIdleBM25(5 * time.Minute)
+	if evicted != 1 {
+		t.Fatalf("SweepIdleBM25 evicted %d repos, want 1", evicted)
+	}
+	if idle.BM25 != nil {
+		t.Fatal("idle repo BM25 not evicted by sweep")
+	}
+	if fresh.BM25 == nil {
+		t.Fatal("fresh repo BM25 wrongly evicted by sweep")
+	}
+
+	// Disabled window is a no-op.
+	if got := srv.State.SweepIdleBM25(0); got != 0 {
+		t.Fatalf("SweepIdleBM25(0) evicted %d, want 0 (disabled)", got)
+	}
+}
+
+// TestBM25EvictionReloadInteraction asserts eviction composes with reload's
+// resetIndexes without a double-free: resetIndexes already nils BM25, so a
+// following eviction finds nil and no-ops, and getBM25 still rebuilds cleanly.
+func TestBM25EvictionReloadInteraction(t *testing.T) {
+	doc := buildSyntheticDoc(200)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc, LabelIndex: BuildLabelIndex(doc)}
+	_ = lr.getBM25()
+
+	// Simulate a reload swap invalidating the derived indexes.
+	lr.resetIndexes()
+	if lr.BM25 != nil {
+		t.Fatal("resetIndexes should have nilled BM25")
+	}
+	// Eviction after reset must be a safe no-op (nothing to free).
+	if lr.evictBM25IfIdle(time.Nanosecond, time.Now().Add(time.Hour)) {
+		t.Fatal("eviction reported a drop after resetIndexes already cleared BM25")
+	}
+	// Rebuild still works.
+	if lr.getBM25() == nil {
+		t.Fatal("getBM25 failed to rebuild after reset+evict")
+	}
+
+	// And a rebuilt index returns the same ranking as a plain fresh build.
+	fresh := BuildBM25(doc)
+	q := "order kafka premium checklistType"
+	got := hitKeys(lr.getBM25().Search(q, 10))
+	want := hitKeys(fresh.Search(q, 10))
+	if len(got) != len(want) {
+		t.Fatalf("result count mismatch after reload/rebuild: %d vs %d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("rank %d differs after reload/rebuild: %s vs %s", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/mcp/membaseline_test.go
+++ b/internal/mcp/membaseline_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/graph"
 )
@@ -193,4 +194,98 @@ func TestMemBaseline(t *testing.T) {
 	t.Logf("  bytes / record  (resident)  : %.1f", perRecordInuse)
 	t.Logf("  bytes / record  (on-disk)   : %.1f", perRecordOnDisk)
 	t.Logf("  resident / on-disk inflation: %.2fx", inflation)
+}
+
+// TestMemBaselineBM25Eviction is the measurement seam for the BM25-evictable
+// track (#5850). Unlike TestMemBaseline (which only measures the fully-warmed
+// state), this warms a served repo WITH BM25, evicts the BM25 index via the same
+// idle-sweep path the server uses, then rebuilds it on a search — reporting real
+// HeapAlloc in all three states so the evicted-state saving is measured, not
+// asserted:
+//
+//	(a) warmed WITH BM25              — the current resident baseline
+//	(b) after BM25 idle eviction      — target: ~313 MB lower on the corpus
+//	(c) after rebuild-on-search       — back to ~(a)
+//
+// Gated behind GRAFEL_MEM_BASELINE_FB exactly like TestMemBaseline.
+func TestMemBaselineBM25Eviction(t *testing.T) {
+	fbPath := os.Getenv("GRAFEL_MEM_BASELINE_FB")
+	if fbPath == "" {
+		t.Skip("set GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb to run the BM25-eviction memory seam")
+	}
+	fi, err := os.Stat(fbPath)
+	if err != nil {
+		t.Fatalf("stat graph.fb: %v", err)
+	}
+	if fi.IsDir() {
+		fbPath = filepath.Join(fbPath, "graph.fb")
+		if _, err = os.Stat(fbPath); err != nil {
+			t.Fatalf("stat graph.fb in dir: %v", err)
+		}
+	}
+	stateDir := filepath.Dir(fbPath)
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(doc.Entities) == 0 {
+		t.Fatalf("graph loaded 0 entities — wrong path?")
+	}
+
+	// Build the served repo the same way TestMemBaseline does, then warm every
+	// lazy derived index INCLUDING BM25 so state (a) is a fully-warmed repo.
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc, GraphFile: fbPath}
+	lr.LabelIndex = BuildLabelIndex(doc)
+	_ = lr.getByID()
+	_ = lr.getAdjacency()
+	_ = lr.getCallsAdj()
+	_ = lr.getStepAdj()
+	_ = lr.getTopKPageRank()
+
+	// Run a representative search so BM25 is built through the real borrow path
+	// (this also stamps bm25LastUse, matching production).
+	_ = lr.getBM25().Search("order handler request customer processor", 10)
+
+	readAlloc := func() uint64 {
+		runtime.GC()
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		return m.HeapAlloc
+	}
+
+	warmAlloc := readAlloc()
+	if lr.BM25 == nil {
+		t.Fatal("BM25 not warmed in state (a)")
+	}
+
+	// (b) Evict via the same idle path the server sweep uses. Force idleness by
+	// treating the borrow as arbitrarily old.
+	if !lr.evictBM25IfIdle(time.Nanosecond, lr.bm25LastUse.Add(time.Hour)) {
+		t.Fatal("evictBM25IfIdle did not evict the warmed BM25 index")
+	}
+	if lr.BM25 != nil {
+		t.Fatal("BM25 field not nilled after eviction")
+	}
+	evictedAlloc := readAlloc()
+
+	// (c) Rebuild transparently on the next search.
+	_ = lr.getBM25().Search("order handler request customer processor", 10)
+	if lr.BM25 == nil {
+		t.Fatal("BM25 not rebuilt on search in state (c)")
+	}
+	rebuiltAlloc := readAlloc()
+
+	runtime.KeepAlive(doc)
+	runtime.KeepAlive(lr)
+
+	freed := int64(warmAlloc) - int64(evictedAlloc)
+	regained := int64(rebuiltAlloc) - int64(evictedAlloc)
+	t.Logf("=== BM25 idle-eviction memory seam (HeapAlloc, numbers only) ===")
+	t.Logf("  (a) warmed WITH BM25        : %d (%.1f MB)", warmAlloc, mbf(warmAlloc))
+	t.Logf("  (b) after BM25 eviction     : %d (%.1f MB)", evictedAlloc, mbf(evictedAlloc))
+	t.Logf("  (c) after rebuild-on-search : %d (%.1f MB)", rebuiltAlloc, mbf(rebuiltAlloc))
+	t.Logf("  freed by eviction (a-b)     : %d (%.1f MB)", freed, float64(freed)/(1024*1024))
+	t.Logf("  regained by rebuild (c-b)   : %d (%.1f MB)", regained, float64(regained)/(1024*1024))
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -33,6 +33,32 @@ import (
 // (every call re-checks mtime); negative/garbage values fall back to default.
 const defaultReloadDebounceMS = 2000
 
+// defaultBM25IdleEvictionMS is the default idle window (milliseconds) after
+// which a repo's lazily-built BM25 index is dropped by the per-call idle sweep
+// (State.SweepIdleBM25, fired from reloadBeforeCall). BM25 is the single largest
+// lazy resident consumer (~313 MB warmed on the corpus); a session that has
+// stopped searching should not keep it pinned for the life of the process. The
+// next search rebuilds it transparently (getBM25 re-arms bm25Once on eviction).
+//
+// 5 minutes is deliberately generous: it survives a normal think/act/search loop
+// (an agent that searches, reads, edits, then searches again inside 5 min never
+// pays a rebuild) yet reclaims the arena for a session that has moved on. Env
+// override GRAFEL_MCP_BM25_IDLE_MS; 0 disables idle eviction; negative/garbage
+// falls back to the default.
+const defaultBM25IdleEvictionMS = 5 * 60 * 1000
+
+// resolveBM25IdleEviction returns the configured BM25 idle-eviction window,
+// reading GRAFEL_MCP_BM25_IDLE_MS once at server construction. A value of 0
+// (eviction disabled) is honoured and returned as a zero Duration.
+func resolveBM25IdleEviction() time.Duration {
+	if v := os.Getenv("GRAFEL_MCP_BM25_IDLE_MS"); v != "" {
+		if ms, err := strconv.Atoi(v); err == nil && ms >= 0 {
+			return time.Duration(ms) * time.Millisecond
+		}
+	}
+	return defaultBM25IdleEvictionMS * time.Millisecond
+}
+
 // resolveReloadDebounce returns the configured debounce window, reading the
 // env overrides once at server construction. A value of 0 (debounce disabled)
 // is honoured and returned as a zero Duration.
@@ -264,6 +290,13 @@ type Server struct {
 	reloadDebounceMu sync.Mutex
 	reloadLastAt     atomic.Int64 // Unix nano; 0 = never run
 	reloadDebounce   time.Duration
+
+	// bm25IdleEviction is the idle window after which reloadBeforeCall drops a
+	// repo's lazily-built BM25 index (State.SweepIdleBM25). Resolved once at
+	// construction from GRAFEL_MCP_BM25_IDLE_MS (see resolveBM25IdleEviction). A
+	// zero value disables idle eviction. No extra goroutine is spawned — the sweep
+	// piggybacks on the existing per-call reload hook.
+	bm25IdleEviction time.Duration
 }
 
 // SetActivityBroker wires the MCP activity broker into the server so that
@@ -350,7 +383,7 @@ func NewServer(cfg Config) (*Server, error) {
 		mcpsrv.WithToolCapabilities(true),
 		mcpsrv.WithInstructions(mcpInstructions))
 
-	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce()}
+	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce(), bm25IdleEviction: resolveBM25IdleEviction()}
 	s.registerTools()
 	return s, nil
 }
@@ -435,6 +468,14 @@ func (s *Server) reloadBeforeCall() {
 	n, surfaceChanged, _ := s.State.ReloadAndSurfaceChanged()
 	s.reloadLastAt.Store(time.Now().UnixNano())
 	s.Tel.MarkReload(n)
+
+	// Idle BM25 sweep — piggybacks on this existing per-call hook (no extra
+	// goroutine): drop the heavy BM25 index (~313 MB warmed on the corpus) for any
+	// repo that has not been searched within bm25IdleEviction, so a session that
+	// stopped searching stops pinning it. The next search rebuilds it via getBM25.
+	// Gated by the same debounce as the reload above, so it runs at most once per
+	// window rather than on every call. A zero window disables it.
+	s.State.SweepIdleBM25(s.bm25IdleEviction)
 	if surfaceChanged && s.MCP != nil {
 		// Best-effort: failures are silently ignored. The notification carries
 		// no payload — clients respond by re-issuing tools/list.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -314,6 +314,15 @@ type LoadedRepo struct {
 	stepAdj      map[string][]stepEdge    // STEP_IN_PROCESS forward adjacency (#2417)
 	byID         map[string]*graph.Entity // entity ID -> entity (#1656)
 	topKPageRank []string                 // entity IDs sorted descending by PageRank (#2304)
+	// bm25LastUse is the wall-clock time of the most recent getBM25() borrow (a
+	// search-tool use). idxMu-guarded — written under idxMu in getBM25 and read
+	// under idxMu in evictBM25IfIdle. The idle sweep (SweepIdleBM25) drops the
+	// heavy BM25 index once now-bm25LastUse exceeds the configured idle window so
+	// a session that has stopped searching does not keep ~313 MB (corpus) pinned;
+	// the next search rebuilds it transparently via getBM25. Zero value means the
+	// index has never been borrowed through getBM25 (e.g. a test that set BM25
+	// directly), in which case it is NOT eligible for idle eviction.
+	bm25LastUse time.Time
 	// mroInbound maps a DEFINING member's local id -> the inherited-stub ids
 	// that resolve to it via the MRO walk (#3834). It is the reverse of
 	// mroOutboundEdges, used by neighbors(in) so a base method surfaces the
@@ -563,7 +572,54 @@ func (lr *LoadedRepo) getBM25() *BM25Index {
 		}
 		lr.BM25 = BuildBM25(lr.Doc)
 	})
+	// Record the borrow time so the idle sweep can distinguish an actively-used
+	// index from one whose last search is older than the eviction window. Stamped
+	// under idxMu (same lock evictBM25IfIdle reads it under) so the sweep never
+	// observes a torn timestamp. The caller reads through the returned pointer for
+	// the duration of its Search; a concurrent eviction only nils lr.BM25, which —
+	// under Go's GC — merely drops one reference and can never free the index out
+	// from under this borrow (contrast F1's munmap, which needs a refcount drain).
+	lr.bm25LastUse = time.Now()
 	return lr.BM25
+}
+
+// evictBM25IfIdle drops the repo's BM25 index (and re-arms bm25Once so the next
+// getBM25 rebuilds it) iff it is currently built AND its last search borrow is
+// older than idle relative to now. Returns true when it evicted.
+//
+// Concurrency: runs under idxMu, exactly like getBM25 and resetIndexes, so it is
+// mutually excluded from a concurrent build and from the reload-time reset — the
+// three are the only writers of lr.BM25 / lr.bm25Once. Re-arming the sync.Once by
+// assignment is safe here for the same reason resetIndexes does it: no other
+// goroutine can be inside bm25Once.Do (it holds idxMu for the whole Do). Nilling
+// lr.BM25 does NOT free memory an in-flight search still reads — that search holds
+// its own live *BM25Index from getBM25, so Go's GC keeps the object alive until
+// the search returns; only after the last reference drops is the ~313 MB (corpus)
+// reclaimable. This is why a plain lock suffices and no F1-style refcount drain is
+// needed: BM25 is a pure heap object, not a manually-unmapped mmap region.
+//
+// Reload interaction: resetIndexes already nils lr.BM25 under idxMu on a graph
+// change, so a stale index for the new graph is dropped there; an eviction that
+// races a reload finds lr.BM25 already nil and no-ops (no double-free), and a
+// reload that races an eviction likewise just re-nils an already-nil field.
+func (lr *LoadedRepo) evictBM25IfIdle(idle time.Duration, now time.Time) bool {
+	if idle <= 0 {
+		return false
+	}
+	lr.idxMu.Lock()
+	defer lr.idxMu.Unlock()
+	if lr.BM25 == nil {
+		return false
+	}
+	// A never-borrowed index (bm25LastUse zero) is not idle-eligible: it was
+	// populated outside the search path (e.g. a test that set BM25 directly) and
+	// has no meaningful last-use to age out.
+	if lr.bm25LastUse.IsZero() || now.Sub(lr.bm25LastUse) < idle {
+		return false
+	}
+	lr.BM25 = nil
+	lr.bm25Once = sync.Once{}
+	return true
 }
 
 // getAdjacency returns the in/out neighbor index, building it on first use.
@@ -1222,6 +1278,35 @@ func (s *State) refreshGroupAlgoOverlayLocked(grp *LoadedGroup) {
 		}
 	}
 	applyGroupAlgoOverlay(grp)
+}
+
+// SweepIdleBM25 drops the BM25 index of every loaded repo whose last search
+// borrow is older than idle, returning how many were evicted. It is the idle
+// sweep the MCP server fires from its per-call reload hook (reloadBeforeCall):
+// a session that has stopped issuing searches releases the heavy BM25 index
+// (~313 MB warmed on the corpus) instead of pinning it for the life of the
+// process; the next search rebuilds it transparently and single-flighted via
+// getBM25. A non-positive idle disables the sweep (returns 0 without locking).
+//
+// Locking: takes s.mu once and calls evictBM25IfIdle (which takes idxMu) per
+// repo — the same s.mu -> idxMu order reload uses (reloadLocked -> resetIndexes),
+// so it cannot invert against any read-path getter (which only ever takes idxMu).
+func (s *State) SweepIdleBM25(idle time.Duration) int {
+	if idle <= 0 {
+		return 0
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	evicted := 0
+	for _, g := range s.groups {
+		for _, lr := range g.Repos {
+			if lr != nil && lr.evictBM25IfIdle(idle, now) {
+				evicted++
+			}
+		}
+	}
+	return evicted
 }
 
 // SnapshotGroups returns a stable list of loaded group pointers.


### PR DESCRIPTION
Refs #5850 (resident-graph memory program). The largest idle lever: BM25 is ~313 MB warmed and is the biggest lazy resident consumer.

## What
Makes the BM25 search index **evictable when idle** — dropped after an idle window, transparently rebuilt on the next search. A session not actively searching stops pinning ~313 MB.

## How
- **Idle sweep** hooked into the existing `Server.reloadBeforeCall()` (runs on every MCP call) — **zero new goroutines**. `SweepIdleBM25` drops `lr.BM25` when the last search is older than the idle window.
- **Lazy rebuild** via the existing `getBM25()` / `bm25Once` path — next search rebuilds; `bm25Once` re-arm makes concurrent first-searches single-flight (exactly one build).
- **Concurrency = plain `idxMu`, NOT an F1-style refcount drain** — and that's the correct call: BM25 is a pure GC'd heap object, so eviction only nils `lr.BM25` (drops one ref); any in-flight `Search` holds its own live `*BM25Index` from `getBM25`, which Go's GC keeps alive until that search returns. No manual free, no use-after-free (unlike mmap/munmap, which is exactly why F1 needed the drain). `SweepIdleBM25` takes `s.mu → idxMu` (same order as reload) — no inversion. `resetIndexes` nils BM25 first, so a racing evict finds nil and no-ops.
- **Config:** `defaultBM25IdleEvictionMS` = 5 min, `GRAFEL_MCP_BM25_IDLE_MS` override, `0` disables.

## Measured (corpus, `TestMemBaselineBM25Eviction` harness)
| State | HeapAlloc |
|---|---|
| warm WITH BM25 | 1,081.5 MB |
| **after eviction** | **768.6 MB (−312.9 MB)** |
| after rebuild-on-search | 1,081.5 MB (fully restored) |

The −312.9 MB matches the ~313 MB target. On current main (BM25-warm baseline 1,052 MB), an idle session drops to **~739 MB resident**.

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... -race -count=1` → 1120 passed. Tests (all `-race`): `TestBM25EvictIdleReleasesAndRebuilds`, `…EvictNotIdleKept`, `…EvictNeverBuiltNoop`, `TestBM25SearchAfterEvictionIdenticalResults`, `TestBM25ConcurrentSearchDuringEviction`, `TestBM25SingleFlightRebuild`, `TestSweepIdleBM25`, `TestBM25EvictionReloadInteraction`. No `fbversion` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o