### PR TITLE
feat(mcp): F3 mmap zero-copy views + GRAFEL_SERVE_FROM_MMAP flag (ADR-0027)

### DIFF
--- a/internal/mcp/mmapview.go
+++ b/internal/mcp/mmapview.go
@@ -1,0 +1,209 @@
+// F3 of ADR-0027 (mmap + zero-copy resident graph): the mmap-backed read path.
+//
+// F1 gave us a lifetime-safe MapHandle (deferred-unmap refcount-drain); F2 gave
+// us the EntityView/RelationshipView seam plus a handle-keyed hot index whose
+// only inputs are (captured handle, entityViewSource). F3 supplies the OTHER
+// implementation of that seam: views that read ZERO-COPY straight out of the
+// FlatBuffers accessors — which alias the MapHandle's mmap — and an
+// entityViewSource that yields them from the FB reader instead of the heap
+// Document. A default-off flag (GRAFEL_SERVE_FROM_MMAP) selects which source the
+// hot-index build uses per repo load; OFF keeps F2's docEntityViewSource, so
+// default behaviour stays byte-identical to the heap path.
+//
+// LIFETIME (load-bearing). Every string these views return is an unsafe.String
+// aliasing the mmap bytes of the handle the owning call captured under s.mu
+// (the read-through-captured-handle invariant, ADR-0027 §Correctness). Such a
+// string is valid ONLY for the duration of that borrow. The hot index is keyed
+// off the captured handle, so its aliased keys/values live exactly as long as
+// the borrow — the last releaser's munmap runs only after the borrow drops.
+// A zero-copy string MUST NOT be stored past release(); doing so is a
+// use-after-unmap. This is exactly what the -race lifetime test guards.
+package mcp
+
+import (
+	"os"
+	"strings"
+	"unsafe"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+)
+
+// GRAFEL_SERVE_FROM_MMAP, when truthy, makes the hot-index build read through the
+// mmap (mmapEntityViewSource) instead of the heap Document (docEntityViewSource).
+// Default OFF: default serve behaviour is byte-identical to the pre-F3 heap path.
+// Read ONCE at package load (below), never per-query, per ADR-0027 §F3.
+var serveFromMMapEnabled = parseServeFromMMapFlag(os.Getenv("GRAFEL_SERVE_FROM_MMAP"))
+
+// parseServeFromMMapFlag interprets the env value. Pure and total so the flag
+// wiring is unit-testable without mutating process env. Truthy: 1/true/yes/on
+// (case-insensitive, trimmed); everything else — including "" — is OFF.
+func parseServeFromMMapFlag(v string) bool {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// serveFromMMap reports whether the mmap-backed read path is enabled. Reads the
+// cached flag value captured at load — no per-call env lookup.
+func serveFromMMap() bool { return serveFromMMapEnabled }
+
+// zeroCopyString aliases bv as a string WITHOUT copying, via unsafe.String over
+// the FlatBuffers ByteVector bytes (which alias the MapHandle's mmap). The
+// returned string is valid ONLY while the owning borrow is held.
+//
+// Empty-ByteVector guard (ADR-0027 §plan): unsafe.String(&bv[0], 0) evaluates
+// &bv[0], which indexes an empty slice and PANICS. It hits real data — an empty
+// Signature/Subtype/module is a zero-length (present) vector, and an absent
+// field is a nil vector. Both are len==0 → "". Guarded here, tested by
+// TestZeroCopyStringEmptyByteVector.
+func zeroCopyString(bv []byte) string {
+	if len(bv) == 0 {
+		return ""
+	}
+	return unsafe.String(&bv[0], len(bv))
+}
+
+// mmapEntityView is the F3 zero-copy EntityView: it wraps one *fb.Entity whose
+// _tab.Bytes alias the mmap, and returns cold string fields as unsafe.String
+// aliases over the FB ByteVector accessors. It holds its OWN *fb.Entity (the FB
+// reader hands out a fresh wrapper per EntityAt), so the hot index may retain it
+// for the borrow's lifetime.
+type mmapEntityView struct{ e *fb.Entity }
+
+func (v mmapEntityView) ID() string            { return zeroCopyString(v.e.Id()) }
+func (v mmapEntityView) Kind() string          { return zeroCopyString(v.e.Kind()) }
+func (v mmapEntityView) Name() string          { return zeroCopyString(v.e.Name()) }
+func (v mmapEntityView) QualifiedName() string { return zeroCopyString(v.e.QualifiedName()) }
+func (v mmapEntityView) Subtype() string       { return zeroCopyString(v.e.Subtype()) }
+func (v mmapEntityView) SourceFile() string    { return zeroCopyString(v.e.SourceFile()) }
+func (v mmapEntityView) Language() string      { return zeroCopyString(v.e.Language()) }
+func (v mmapEntityView) Signature() string     { return zeroCopyString(v.e.Signature()) }
+
+// Property returns the value for key and whether present, zero-copy.
+//
+// Parity with the materialized view (fbEntityToGraphEntity + PropLookup): the
+// writer stores `module` as a top-level FB scalar AND — via PropsSnapshot — in
+// the property vector, and the loader folds the scalar back in with PropSet
+// (scalar wins when present). We mirror that: for "module" the non-empty scalar
+// takes precedence; otherwise fall through to the property vector. All other
+// keys are a straight vector lookup.
+func (v mmapEntityView) Property(key string) (string, bool) {
+	if key == "module" {
+		if mod := v.e.Module(); len(mod) > 0 {
+			return zeroCopyString(mod), true
+		}
+	}
+	return lookupPropertyEntry(key, v.e.PropertiesLength(), func(pe *fb.PropertyEntry, i int) bool {
+		return v.e.Properties(pe, i)
+	})
+}
+
+// Properties returns a snapshot map of all properties, zero-copy in the values.
+// Parity: propsToMap returns nil for an empty set; the module scalar is folded
+// in (overriding, matching PropSet) when non-empty.
+func (v mmapEntityView) Properties() map[string]string {
+	n := v.e.PropertiesLength()
+	mod := v.e.Module()
+	if n == 0 && len(mod) == 0 {
+		return nil // parity: PropsSnapshot returns nil, not an empty map
+	}
+	out := make(map[string]string, n+1)
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if v.e.Properties(&pe, i) {
+			out[zeroCopyString(pe.Key())] = zeroCopyString(pe.Value())
+		}
+	}
+	if len(mod) > 0 {
+		out["module"] = zeroCopyString(mod)
+	}
+	return out
+}
+
+// mmapRelationshipView is the F3 zero-copy RelationshipView over one
+// *fb.Relationship aliasing the mmap.
+type mmapRelationshipView struct{ r *fb.Relationship }
+
+func (v mmapRelationshipView) FromID() string { return zeroCopyString(v.r.FromId()) }
+func (v mmapRelationshipView) ToID() string   { return zeroCopyString(v.r.ToId()) }
+func (v mmapRelationshipView) Kind() string   { return zeroCopyString(v.r.Kind()) }
+
+// ID mirrors fbRelToGraphRel: the relationship id is tunneled through the "id"
+// property (the writer stores it there), restored to rel.ID on load. "" when
+// absent.
+func (v mmapRelationshipView) ID() string {
+	if id, ok := v.Property("id"); ok {
+		return id
+	}
+	return ""
+}
+
+// Property returns the value for key and whether present, zero-copy — a straight
+// property-vector lookup, matching Relationship.PropLookup.
+func (v mmapRelationshipView) Property(key string) (string, bool) {
+	return lookupPropertyEntry(key, v.r.PropertiesLength(), func(pe *fb.PropertyEntry, i int) bool {
+		return v.r.Properties(pe, i)
+	})
+}
+
+// lookupPropertyEntry scans an FB PropertyEntry vector for key, returning its
+// zero-copy value. O(vector) — cold, run only on result serialization (O(results),
+// not O(graph)). Shared by the entity and relationship views.
+func lookupPropertyEntry(key string, n int, at func(pe *fb.PropertyEntry, i int) bool) (string, bool) {
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if at(&pe, i) && zeroCopyString(pe.Key()) == key {
+			return zeroCopyString(pe.Value()), true
+		}
+	}
+	return "", false
+}
+
+// mmapEntityViewSource is the F3 entityViewSource: it iterates entities from the
+// FB reader of the captured handle, yielding mmapEntityViews bound to that
+// handle's mapping. buildHotIndex(capturedHandle, mmapEntityViewSource{...})
+// then builds the hot index zero-copy, with no heap Document involved.
+//
+// The handle is the one the owning call captured under s.mu (via groupBorrow);
+// every view it yields aliases that handle's mmap and is valid only for the
+// borrow — satisfying the read-through-captured-handle invariant.
+type mmapEntityViewSource struct{ handle *MapHandle }
+
+func (s mmapEntityViewSource) forEachEntityView(yield func(graph.EntityView)) {
+	r := s.handle.Reader()
+	if r == nil {
+		return
+	}
+	n := r.EntityCount()
+	for i := 0; i < n; i++ {
+		// EntityAt allocates a fresh *fb.Entity per call, so each view owns its
+		// own wrapper and is safe for the index to retain.
+		e := r.EntityAt(i)
+		if e == nil {
+			continue
+		}
+		yield(mmapEntityView{e: e})
+	}
+}
+
+// entityViewSourceFor selects the hot-index build source for repo per the
+// GRAFEL_SERVE_FROM_MMAP flag: the mmap-backed source (over the captured handle)
+// when ON, else F2's heap-Document source. doc is the repo's captured Doc, used
+// only by the OFF path. The choice is per repo load — the same binary can A/B.
+func (b *groupBorrow) entityViewSourceFor(repo string, doc *graph.Document) entityViewSource {
+	if serveFromMMap() {
+		return mmapEntityViewSource{handle: b.Handle(repo)}
+	}
+	return docEntityViewSource{doc: doc}
+}
+
+// Compile-time assertions that the mmap views satisfy the F2 interfaces.
+var (
+	_ graph.EntityView       = mmapEntityView{}
+	_ graph.RelationshipView = mmapRelationshipView{}
+	_ entityViewSource       = mmapEntityViewSource{}
+)

--- a/internal/mcp/mmapview_test.go
+++ b/internal/mcp/mmapview_test.go
@@ -1,0 +1,390 @@
+package mcp
+
+import (
+	"path/filepath"
+	"runtime"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// F3 of ADR-0027: the mmap-backed zero-copy read path. These tests prove the
+// mmap views exist, are CORRECT (byte-identical to the heap path — the parity
+// test), guard the empty-ByteVector panic, and are lifetime-safe under -race
+// (no zero-copy string read after its handle is munmapped). They MUST run under
+// -race: unsafe aliasing + borrow lifetime is exactly what -race guards.
+
+// TestZeroCopyStringEmptyByteVector is the direct empty-ByteVector test
+// (ADR-0027 §plan): unsafe.String(&bv[0], 0) panics on a zero-length slice; the
+// len==0 guard must return "" for both a nil and a present-but-empty vector.
+func TestZeroCopyStringEmptyByteVector(t *testing.T) {
+	if got := zeroCopyString(nil); got != "" {
+		t.Errorf("zeroCopyString(nil) = %q, want \"\"", got)
+	}
+	if got := zeroCopyString([]byte{}); got != "" {
+		t.Errorf("zeroCopyString([]byte{}) = %q, want \"\"", got)
+	}
+	// A present, non-empty vector must alias its bytes verbatim.
+	if got := zeroCopyString([]byte("sig")); got != "sig" {
+		t.Errorf("zeroCopyString(\"sig\") = %q, want \"sig\"", got)
+	}
+}
+
+// parityDoc builds a Document exercising every field the views expose plus the
+// empty-ByteVector cases that WILL hit real data: an entity with empty
+// Signature and empty Subtype, an entity with no module, a relationship with
+// and without the tunneled "id" property, and multi/zero property sets.
+func parityDoc() *graph.Document {
+	e0 := graph.Entity{
+		ID: "r::pkg.Foo", Name: "Foo", QualifiedName: "pkg.Foo", Kind: "type",
+		Subtype: "struct", SourceFile: "pkg/foo.go", Language: "go",
+		Signature: "type Foo struct{}", StartLine: 10,
+	}
+	e0.PropsReplace(map[string]string{"module": "pkg", "visibility": "public"})
+
+	// Empty Signature AND empty Subtype — the zero-length (present) ByteVector
+	// path. No module property either.
+	e1 := graph.Entity{
+		ID: "r::pkg.bar", Name: "bar", QualifiedName: "pkg.bar", Kind: "func",
+		Subtype: "", SourceFile: "pkg/bar.go", Language: "go", Signature: "",
+	}
+
+	// No properties at all → Properties() must be nil on both sides.
+	e2 := graph.Entity{
+		ID: "r::pkg.Baz", Name: "Baz", QualifiedName: "pkg.Baz", Kind: "const",
+		SourceFile: "pkg/baz.go", Language: "go",
+	}
+
+	r0 := graph.Relationship{FromID: "r::pkg.Foo", ToID: "r::pkg.bar", Kind: "calls"}
+	r0.PropsReplace(map[string]string{"id": "edge-0001", "line": "12"})
+
+	// Relationship without an id property → ID() must be "" on both sides.
+	r1 := graph.Relationship{FromID: "r::pkg.bar", ToID: "r::pkg.Baz", Kind: "references"}
+
+	return &graph.Document{
+		Entities:      []graph.Entity{e0, e1, e2},
+		Relationships: []graph.Relationship{r0, r1},
+	}
+}
+
+// writeParityGraph writes parityDoc() to a temp graph.fb and returns its path.
+func writeParityGraph(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(path, parityDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	return path
+}
+
+// TestMMapViewParityWithHeap is the key F3 correctness test: build the hot index
+// both ways over the SAME graph.fb and assert byte-identical results for every
+// hot-index query (byID/byLabel/byQName) and every view accessor, for every
+// entity AND relationship. Runs the mmap zero-copy path under -race.
+func TestMMapViewParityWithHeap(t *testing.T) {
+	path := writeParityGraph(t)
+	dir := filepath.Dir(path)
+
+	// OFF side: the heap Document, loaded FROM the same graph.fb (so both sides
+	// go through the identical FB decode — a fair parity comparison).
+	heapDoc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+
+	// ON side: an mmap reader wrapped in a MapHandle, exactly as reload publishes.
+	rdr, err := fbreader.Open(path)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	handle := newMapHandle(rdr)
+	handle.repo = "r"
+	defer handle.closeOnce()
+
+	heapIdx := buildHotIndex(handle, docEntityViewSource{doc: heapDoc})
+	mmapIdx := buildHotIndex(handle, mmapEntityViewSource{handle: handle})
+
+	// Entity parity: for every entity id, both indexes resolve to a view whose
+	// every accessor is byte-identical.
+	for i := range heapDoc.Entities {
+		id := heapDoc.Entities[i].ID
+		hv, hok := heapIdx.entityByID(id)
+		mv, mok := mmapIdx.entityByID(id)
+		if !hok || !mok {
+			t.Fatalf("entity %q: byID present heap=%v mmap=%v", id, hok, mok)
+		}
+		assertEntityViewEqual(t, id, hv, mv)
+
+		// byQName parity (case-insensitive key).
+		qn := heapDoc.Entities[i].QualifiedName
+		hq, hqok := heapIdx.entityByQName(qn)
+		mq, mqok := mmapIdx.entityByQName(qn)
+		if hqok != mqok {
+			t.Fatalf("entity %q: byQName present heap=%v mmap=%v", id, hqok, mqok)
+		}
+		if hqok {
+			assertEntityViewEqual(t, id+"[qname]", hq, mq)
+		}
+	}
+
+	// byLabel parity (including the ambiguous-label multiplicity).
+	labels := map[string]bool{}
+	for i := range heapDoc.Entities {
+		labels[heapDoc.Entities[i].Name] = true
+	}
+	for lbl := range labels {
+		hl := idsOfViews(heapIdx.entitiesByLabel(lbl))
+		ml := idsOfViews(mmapIdx.entitiesByLabel(lbl))
+		if len(hl) != len(ml) {
+			t.Fatalf("byLabel %q: heap %v vs mmap %v", lbl, hl, ml)
+		}
+		for k := range hl {
+			if hl[k] != ml[k] {
+				t.Fatalf("byLabel %q: heap %v vs mmap %v", lbl, hl, ml)
+			}
+		}
+	}
+
+	// Relationship parity: iterate both readers/docs in vector order and compare
+	// every RelationshipView accessor.
+	if rdr.RelationshipCount() != len(heapDoc.Relationships) {
+		t.Fatalf("relationship count: mmap=%d heap=%d", rdr.RelationshipCount(), len(heapDoc.Relationships))
+	}
+	for i := range heapDoc.Relationships {
+		hv := graph.RelationshipViewOf(&heapDoc.Relationships[i])
+		mv := mmapRelationshipView{r: rdr.RelationshipAt(i)}
+		assertRelViewEqual(t, i, hv, mv)
+	}
+}
+
+func assertEntityViewEqual(t *testing.T, id string, want, got graph.EntityView) {
+	t.Helper()
+	if want.ID() != got.ID() {
+		t.Errorf("%s ID: heap %q mmap %q", id, want.ID(), got.ID())
+	}
+	if want.Kind() != got.Kind() {
+		t.Errorf("%s Kind: heap %q mmap %q", id, want.Kind(), got.Kind())
+	}
+	if want.Name() != got.Name() {
+		t.Errorf("%s Name: heap %q mmap %q", id, want.Name(), got.Name())
+	}
+	if want.QualifiedName() != got.QualifiedName() {
+		t.Errorf("%s QualifiedName: heap %q mmap %q", id, want.QualifiedName(), got.QualifiedName())
+	}
+	if want.Subtype() != got.Subtype() {
+		t.Errorf("%s Subtype: heap %q mmap %q", id, want.Subtype(), got.Subtype())
+	}
+	if want.SourceFile() != got.SourceFile() {
+		t.Errorf("%s SourceFile: heap %q mmap %q", id, want.SourceFile(), got.SourceFile())
+	}
+	if want.Language() != got.Language() {
+		t.Errorf("%s Language: heap %q mmap %q", id, want.Language(), got.Language())
+	}
+	if want.Signature() != got.Signature() {
+		t.Errorf("%s Signature: heap %q mmap %q", id, want.Signature(), got.Signature())
+	}
+	// Property parity across the union of keys plus a known-absent key.
+	wp, gp := want.Properties(), got.Properties()
+	if len(wp) != len(gp) {
+		t.Errorf("%s Properties len: heap %v mmap %v", id, wp, gp)
+	}
+	for k, wv := range wp {
+		if gv := gp[k]; gv != wv {
+			t.Errorf("%s Properties[%q]: heap %q mmap %q", id, k, wv, gv)
+		}
+	}
+	for _, k := range []string{"module", "visibility", "id", "__absent__"} {
+		wv, wok := want.Property(k)
+		gv, gok := got.Property(k)
+		if wok != gok || wv != gv {
+			t.Errorf("%s Property(%q): heap (%q,%v) mmap (%q,%v)", id, k, wv, wok, gv, gok)
+		}
+	}
+}
+
+func assertRelViewEqual(t *testing.T, i int, want, got graph.RelationshipView) {
+	t.Helper()
+	if want.ID() != got.ID() {
+		t.Errorf("rel[%d] ID: heap %q mmap %q", i, want.ID(), got.ID())
+	}
+	if want.FromID() != got.FromID() {
+		t.Errorf("rel[%d] FromID: heap %q mmap %q", i, want.FromID(), got.FromID())
+	}
+	if want.ToID() != got.ToID() {
+		t.Errorf("rel[%d] ToID: heap %q mmap %q", i, want.ToID(), got.ToID())
+	}
+	if want.Kind() != got.Kind() {
+		t.Errorf("rel[%d] Kind: heap %q mmap %q", i, want.Kind(), got.Kind())
+	}
+	for _, k := range []string{"id", "line", "__absent__"} {
+		wv, wok := want.Property(k)
+		gv, gok := got.Property(k)
+		if wok != gok || wv != gv {
+			t.Errorf("rel[%d] Property(%q): heap (%q,%v) mmap (%q,%v)", i, k, wv, wok, gv, gok)
+		}
+	}
+}
+
+func idsOfViews(vs []graph.EntityView) []string {
+	out := make([]string, 0, len(vs))
+	for _, v := range vs {
+		out = append(out, v.ID())
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestParseServeFromMMapFlag pins the flag parser (the flag is read once at load
+// from this pure function). Default OFF; only explicit truthy values enable.
+func TestParseServeFromMMapFlag(t *testing.T) {
+	for _, on := range []string{"1", "true", "TRUE", "yes", "on", " On "} {
+		if !parseServeFromMMapFlag(on) {
+			t.Errorf("parseServeFromMMapFlag(%q) = false, want true", on)
+		}
+	}
+	for _, off := range []string{"", "0", "false", "no", "off", "nope"} {
+		if parseServeFromMMapFlag(off) {
+			t.Errorf("parseServeFromMMapFlag(%q) = true, want false", off)
+		}
+	}
+}
+
+// TestEntityViewSourceForSelectsByFlag proves the flag routes the hot-index build
+// to the right source: mmap-backed when ON, heap-Document when OFF, per repo.
+func TestEntityViewSourceForSelectsByFlag(t *testing.T) {
+	path := writeParityGraph(t)
+	rdr, err := fbreader.Open(path)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	handle := newMapHandle(rdr)
+	handle.repo = "r"
+	defer handle.closeOnce()
+	b := &groupBorrow{handles: []*MapHandle{handle}}
+	doc := &graph.Document{}
+
+	prev := serveFromMMapEnabled
+	defer func() { serveFromMMapEnabled = prev }()
+
+	serveFromMMapEnabled = false
+	if _, ok := b.entityViewSourceFor("r", doc).(docEntityViewSource); !ok {
+		t.Errorf("flag OFF: source = %T, want docEntityViewSource", b.entityViewSourceFor("r", doc))
+	}
+	serveFromMMapEnabled = true
+	if _, ok := b.entityViewSourceFor("r", doc).(mmapEntityViewSource); !ok {
+		t.Errorf("flag ON: source = %T, want mmapEntityViewSource", b.entityViewSourceFor("r", doc))
+	}
+}
+
+// TestMMapHotIndexReadsAreLifetimeSafeUnderReload is the F3 lifetime-race test
+// (reuses the F1/F2 reload-loop harness shape). N borrowers each capture a REAL
+// mmap handle under s.mu, build a hot index over the mmap zero-copy source, and
+// READ zero-copy strings through it while a reloader retires handles in a tight
+// loop. Under -race it proves no zero-copy string is read after its handle is
+// munmapped: the captured handle stays mapped for the whole borrow (refs>0 →
+// deferred unmap), and every retired mapping is unmapped exactly once.
+func TestMMapHotIndexReadsAreLifetimeSafeUnderReload(t *testing.T) {
+	path := writeParityGraph(t)
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	// Each handle wraps a REAL mmap of the same graph.fb, so reads alias live
+	// mapped bytes; a premature munmap under -race is a use-after-unmap.
+	var closersMu sync.Mutex
+	var readers []*fbreader.Reader
+	newHandle := func() *MapHandle {
+		rdr, err := fbreader.Open(path)
+		if err != nil {
+			t.Errorf("fbreader.Open: %v", err)
+			return nil
+		}
+		closersMu.Lock()
+		readers = append(readers, rdr)
+		closersMu.Unlock()
+		h := newMapHandle(rdr)
+		h.releaseGap = runtime.Gosched // widen the rebound TOCTOU window
+		return h
+	}
+
+	s.mu.Lock()
+	lr.publishHandle(newHandle())
+	s.mu.Unlock()
+
+	var readFault atomic.Int64
+	stop := make(chan struct{})
+
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			h := newHandle()
+			if h == nil {
+				return
+			}
+			s.mu.Lock()
+			lr.publishHandle(h) // publishes successor, retires predecessor
+			s.mu.Unlock()
+		}
+	}()
+
+	var wgB sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 500; j++ {
+				b := s.borrowGroup("g")
+				if b == nil {
+					readFault.Add(1)
+					continue
+				}
+				// Build the hot index over the mmap zero-copy source, keyed off
+				// the captured handle, and READ zero-copy strings through it.
+				hi := b.buildHotIndex("r", mmapEntityViewSource{handle: b.Handle("r")})
+				v, ok := hi.entityByID("r::pkg.Foo")
+				if !ok {
+					readFault.Add(1)
+					b.Release()
+					continue
+				}
+				// Force actual reads of aliased mmap bytes (cold + hot fields).
+				if v.Name() != "Foo" || v.Signature() != "type Foo struct{}" ||
+					v.SourceFile() != "pkg/foo.go" {
+					readFault.Add(1)
+				}
+				if mod, _ := v.Property("module"); mod != "pkg" {
+					readFault.Add(1)
+				}
+				b.Release()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := readFault.Load(); f != 0 {
+		t.Fatalf("read faults (wrong result or use-after-unmap): %d", f)
+	}
+}


### PR DESCRIPTION
Refs #5850 (mmap zero-copy epic, ADR-0027). Builds on F1 (#5855) + F2 (#5857). Behavior-neutral, mmap read path behind a default-OFF flag.

## What
Adds the mmap-backed zero-copy implementation of the F2 view interfaces, behind `GRAFEL_SERVE_FROM_MMAP` (default OFF). This is the *enabling* infra — it does NOT deliver the memory win yet (the Document is still materialized until the C-series cutover stops building it). Two new files, no edits to existing code.

## How (`internal/mcp/mmapview.go`)
- `zeroCopyString(bv []byte) string` — `unsafe.String(&bv[0], len(bv))` with the mandated `len==0 → ""` guard (empty Signature/Subtype/module).
- `mmapEntityView{*fb.Entity}` / `mmapRelationshipView{*fb.Relationship}` — implement `graph.EntityView`/`RelationshipView`, cold strings aliased zero-copy from the FB accessors. Parity nuances matched to the materialized loader (`fbEntityToGraphEntity`): `module` scalar↔property precedence, relationship `ID()` tunneled via the `"id"` property, `Properties()` returns nil-when-empty.
- `mmapEntityViewSource{handle}` — F2's `entityViewSource` iterating `reader.EntityAt(i)` (fresh `*fb.Entity` per entity so the index may retain each view); `buildHotIndex(capturedHandle, mmapSource)` builds the hot index zero-copy.
- `GRAFEL_SERVE_FROM_MMAP` parsed once at load; `entityViewSourceFor` routes mmap-source when ON, else F2's `docEntityViewSource`. Inert in production (hot index not wired to reads yet).
- **Lifetime:** every returned string aliases the captured-handle mmap, valid only for the borrow; the index is keyed off that handle (F2), so aliases live exactly as long as the borrow (last-releaser munmap runs only after Release).

## Tests (all `-race`)
- `TestZeroCopyStringEmptyByteVector` — the empty-ByteVector guard (nil / zero-length / non-empty).
- `TestMMapViewParityWithHeap` — **key parity**: writes a real `graph.fb` (empty Signature/Subtype, no-module entity, id-tunneled + id-less rels), builds the hot index both ways, asserts byte-identical byID/byLabel/byQName + every accessor for every entity + relationship.
- `TestParseServeFromMMapFlag`, `TestEntityViewSourceForSelectsByFlag` — flag parse + ON/OFF routing.
- `TestMMapHotIndexReadsAreLifetimeSafeUnderReload` — lifetime-race: 8 borrowers read aliased zero-copy strings while a reloader retires real mmap handles in a tight loop (`releaseGap: runtime.Gosched`); proves no zero-copy string is read after munmap.

## Measured (honest — no win yet)
On a non-confidential corpus (37,232 entities): Document materialization +94.3 MB (still built both ways); hot index +10.4 MB (heap source) vs +11.6 MB (mmap source, marginally larger due to per-entity `*fb.Entity` wrapper). The Document drop lands only at cutover.

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` → 1372 passed / 10 packages. No fbversion bump. Behavior-neutral with flag OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o