### PR TITLE
feat(mcp): W1 wire hot index into reads + relationship view source (ADR-0027 M-series linchpin)

### DIFF
--- a/internal/mcp/hotindex.go
+++ b/internal/mcp/hotindex.go
@@ -53,6 +53,34 @@ func (s docEntityViewSource) forEachEntityView(yield func(graph.EntityView)) {
 	}
 }
 
+// relationshipViewSource is the relationship analogue of entityViewSource: it
+// yields the RelationshipViews a hot index is built from. W1 (ADR-0027) adds it
+// to fill the gap F2 left — F2 had no relationship view source at all. Same seam
+// shape as entityViewSource so F3 can later feed relationships from the mmap
+// without touching the builder or its consumers.
+//
+// The int32 CSR adjacency (traversal.go) is deliberately NOT routed through this
+// seam: graph traversal stays on primitive arrays for hot-path perf (ADR-0027
+// §Risk). This source feeds only by-id lookup and full-scan iteration.
+type relationshipViewSource interface {
+	forEachRelationshipView(yield func(graph.RelationshipView))
+}
+
+// docRelationshipViewSource adapts a captured *graph.Document into a
+// relationshipViewSource by wrapping each relationship as a materialized
+// graph.RelationshipView. W1's only source; F3 later feeds this from mmap over
+// the same captured handle.
+type docRelationshipViewSource struct{ doc *graph.Document }
+
+func (s docRelationshipViewSource) forEachRelationshipView(yield func(graph.RelationshipView)) {
+	if s.doc == nil {
+		return
+	}
+	for i := range s.doc.Relationships {
+		yield(graph.RelationshipViewOf(&s.doc.Relationships[i]))
+	}
+}
+
 // hotIndex is the handle-keyed resident hot index over EntityViews: exact-ID,
 // case-insensitive label (Name), and case-insensitive qualified-name lookups.
 // handle is the MapHandle the owning call captured under s.mu; it is the read
@@ -64,6 +92,14 @@ type hotIndex struct {
 	byID    map[string]graph.EntityView
 	byLabel map[string][]graph.EntityView
 	byQName map[string]graph.EntityView
+	// ents is the ordered entity views (Doc order) for full scans. W1 (ADR-0027)
+	// keeps this alongside byID so forEachEntity yields a deterministic order
+	// matching Doc.Entities, which byID's map iteration cannot.
+	ents []graph.EntityView
+	// relByID / rels are the W1 relationship seam: exact-id lookup + ordered
+	// (Doc order) full-scan iteration. nil until addRelationships is called.
+	relByID map[string]graph.RelationshipView
+	rels    []graph.RelationshipView
 }
 
 // buildHotIndex builds a hot index from the views yielded by src, KEYED OFF the
@@ -91,6 +127,31 @@ func buildHotIndex(h *MapHandle, src entityViewSource) *hotIndex {
 		if qn := v.QualifiedName(); qn != "" {
 			hi.byQName[strings.ToLower(qn)] = v
 		}
+		hi.ents = append(hi.ents, v)
+	})
+	return hi
+}
+
+// addRelationships populates the hot index's relationship seam (relByID + the
+// ordered rels slice) from src and returns the index for chaining. W1 keeps this
+// SEPARATE from buildHotIndex so F2's entity-only builder signature is unchanged
+// (dual-API, additive). A nil src yields an empty (non-nil) relByID so a lookup
+// misses cleanly instead of panicking on a nil map read... which maps already
+// tolerate, but the non-nil map also marks the seam as populated.
+func (hi *hotIndex) addRelationships(src relationshipViewSource) *hotIndex {
+	if hi == nil {
+		return hi
+	}
+	hi.relByID = map[string]graph.RelationshipView{}
+	if src == nil {
+		return hi
+	}
+	src.forEachRelationshipView(func(v graph.RelationshipView) {
+		if v == nil {
+			return
+		}
+		hi.relByID[v.ID()] = v
+		hi.rels = append(hi.rels, v)
 	})
 	return hi
 }
@@ -130,6 +191,36 @@ func (hi *hotIndex) entityByQName(qname string) (graph.EntityView, bool) {
 	return v, ok
 }
 
+// forEachEntity invokes yield once per entity view, in Doc order. Nil-safe.
+func (hi *hotIndex) forEachEntity(yield func(graph.EntityView)) {
+	if hi == nil {
+		return
+	}
+	for _, v := range hi.ents {
+		yield(v)
+	}
+}
+
+// relationshipByID returns the view for an exact relationship ID.
+func (hi *hotIndex) relationshipByID(id string) (graph.RelationshipView, bool) {
+	if hi == nil {
+		return nil, false
+	}
+	v, ok := hi.relByID[id]
+	return v, ok
+}
+
+// forEachRelationship invokes yield once per relationship view, in Doc order.
+// Nil-safe.
+func (hi *hotIndex) forEachRelationship(yield func(graph.RelationshipView)) {
+	if hi == nil {
+		return
+	}
+	for _, v := range hi.rels {
+		yield(v)
+	}
+}
+
 // buildHotIndex builds a handle-keyed hot index for repo from this per-call
 // snapshot: it pairs the handle borrowed (captured) under s.mu with the view
 // source. The handle comes from the snapshot — never a live lr.handle re-deref —
@@ -138,4 +229,74 @@ func (hi *hotIndex) entityByQName(qname string) (graph.EntityView, bool) {
 // F3 passes an mmap-backed source over the same captured handle.
 func (b *groupBorrow) buildHotIndex(repo string, src entityViewSource) *hotIndex {
 	return buildHotIndex(b.Handle(repo), src)
+}
+
+// hotIndexFor returns the memoized hot index for repo, built lazily off THIS
+// call's captured handle and reused across borrows of that same handle (W1,
+// ADR-0027). It is the production entry point the view getters below share.
+//
+// The build is memoized on the LoadedRepo keyed by the captured handle's
+// identity (LoadedRepo.hotIndexFor): the first view-getter use for a given
+// handle builds the index; later borrows of the SAME handle reuse it; a reload
+// (which publishes a successor handle and clears the memo under s.mu) forces the
+// next borrow to rebuild against the fresh handle. The index is never built
+// eagerly on borrow — only when a consumer first calls a view getter — so the
+// hot index adds zero cost until something reads it.
+//
+// The source is the heap Document (docEntityViewSource / docRelationshipView-
+// Source over lr.Doc): the views wrap the SAME &lr.Doc.Entities[i] /
+// &lr.Doc.Relationships[i] pointers the legacy LabelIndex / getByID path returns,
+// so this is behavior-neutral. F3 swaps in an mmap-backed source at cutover.
+func (b *groupBorrow) hotIndexFor(repo string) *hotIndex {
+	if b == nil || b.Group == nil {
+		return nil
+	}
+	lr := b.Group.Repos[repo]
+	if lr == nil {
+		return nil
+	}
+	h := b.Handle(repo)
+	return lr.hotIndexFor(h, func(handle *MapHandle) *hotIndex {
+		doc := lr.Doc
+		return buildHotIndex(handle, docEntityViewSource{doc: doc}).
+			addRelationships(docRelationshipViewSource{doc: doc})
+	})
+}
+
+// entityViewByID resolves an exact entity ID to a graph.EntityView through the
+// memoized hot index. Additive production surface (W1): behavior-parity with
+// LoadedRepo.getByID()/LabelIndex.ByID, but view-typed and handle-keyed.
+func (b *groupBorrow) entityViewByID(repo, id string) (graph.EntityView, bool) {
+	return b.hotIndexFor(repo).entityByID(id)
+}
+
+// entityViewsByLabel returns every entity view whose Name matches label,
+// case-insensitively — the view-typed analogue of LabelIndex.ByLabel.
+func (b *groupBorrow) entityViewsByLabel(repo, label string) []graph.EntityView {
+	return b.hotIndexFor(repo).entitiesByLabel(label)
+}
+
+// entityViewByQName resolves a qualified name (case-insensitive) to a view — the
+// view-typed analogue of LabelIndex.ByQName.
+func (b *groupBorrow) entityViewByQName(repo, qname string) (graph.EntityView, bool) {
+	return b.hotIndexFor(repo).entityByQName(qname)
+}
+
+// forEachEntityView invokes yield once per entity view for repo, in Doc order —
+// the view-typed full-scan analogue of iterating lr.Doc.Entities.
+func (b *groupBorrow) forEachEntityView(repo string, yield func(graph.EntityView)) {
+	b.hotIndexFor(repo).forEachEntity(yield)
+}
+
+// relationshipViewByID resolves an exact relationship ID to a
+// graph.RelationshipView through the memoized hot index (W1 relationship seam).
+func (b *groupBorrow) relationshipViewByID(repo, id string) (graph.RelationshipView, bool) {
+	return b.hotIndexFor(repo).relationshipByID(id)
+}
+
+// forEachRelationshipView invokes yield once per relationship view for repo, in
+// Doc order — the view-typed full-scan analogue of iterating lr.Doc.Relationships.
+// Traversal/adjacency consumers keep the int32 CSR (traversal.go), NOT this seam.
+func (b *groupBorrow) forEachRelationshipView(repo string, yield func(graph.RelationshipView)) {
+	b.hotIndexFor(repo).forEachRelationship(yield)
 }

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -352,6 +352,20 @@ type LoadedRepo struct {
 	suffixIndex        map[string][]string
 	suffixIndexPartial bool
 
+	// hotIdx is the W1 (ADR-0027) memoized handle-keyed hot index (id/label/
+	// qname entity lookups + the relationship view seam) built lazily on the
+	// FIRST view-getter use for a given captured MapHandle and reused across
+	// borrows of that handle. It is guarded by its own leaf mutex hotIdxMu (never
+	// nested under idxMu / mroMu / baseChainMu) because the build takes no other
+	// index lock. The memo is keyed by the captured handle's identity: a reload
+	// publishes a successor handle, so the next borrow's captured handle no longer
+	// matches lr.hotIdx.Handle() and the index rebuilds. resetIndexes also clears
+	// it under s.mu on every Doc replacement, covering the degenerate no-mmap
+	// (nil-handle) reload where the handle identity is unchanged. Nil until the
+	// first view-getter use. See LoadedRepo.hotIndexFor and hotindex.go.
+	hotIdxMu sync.Mutex
+	hotIdx   *hotIndex
+
 	semMtime time.Time
 	mtime    time.Time
 	// contentHash is the FNV-1a hash of the graph.fb bytes last parsed into
@@ -421,6 +435,16 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.baseChainCache = nil
 	lr.baseChainHash = 0
 	lr.baseChainMu.Unlock()
+
+	// W1 (ADR-0027): drop the memoized hot index so the next view-getter use
+	// rebuilds against the fresh Doc. Handle-identity keying already rebuilds when
+	// reload publishes a successor handle, but a no-mmap reload (nil handle both
+	// before and after) leaves the identity unchanged, so the explicit clear here
+	// — under s.mu, on every Doc replacement — is the load-bearing invalidation
+	// for that case. Its own leaf mutex, taken independently (never nested).
+	lr.hotIdxMu.Lock()
+	lr.hotIdx = nil
+	lr.hotIdxMu.Unlock()
 
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
@@ -555,6 +579,34 @@ func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 		lr.byID = m
 	})
 	return lr.byID
+}
+
+// hotIndexFor returns the memoized W1 (ADR-0027) hot index for this repo built
+// off the captured handle h, building it via build(h) exactly once per distinct
+// captured handle and reusing it across borrows of that same handle.
+//
+// Memoization + invalidation contract:
+//   - Reuse iff a memoized index exists AND it is keyed off the SAME captured
+//     handle h (lr.hotIdx.Handle() == h). This is the read-through-captured-
+//     handle invariant (F1/F2): the returned index's handle always equals the
+//     caller's captured handle, never a live lr.handle re-deref.
+//   - A reload publishes a successor handle, so a subsequent borrow captures a
+//     different h and this rebuilds. resetIndexes additionally nils lr.hotIdx
+//     under s.mu on every Doc replacement, so even a nil-handle (no-mmap) reload
+//     invalidates. The index is therefore never read across a reload.
+//
+// build is invoked ONLY on a memo miss (the first getter use for a handle, or
+// after invalidation), so the hot index costs nothing until a consumer reads it.
+// Guarded by hotIdxMu, a leaf lock: build must not acquire any other LoadedRepo
+// index lock (docEntityViewSource/docRelationshipViewSource read only lr.Doc).
+func (lr *LoadedRepo) hotIndexFor(h *MapHandle, build func(*MapHandle) *hotIndex) *hotIndex {
+	lr.hotIdxMu.Lock()
+	defer lr.hotIdxMu.Unlock()
+	if lr.hotIdx != nil && lr.hotIdx.Handle() == h {
+		return lr.hotIdx
+	}
+	lr.hotIdx = build(h)
+	return lr.hotIdx
 }
 
 // getBM25 returns the per-repo BM25 index, building it on first search-tool

--- a/internal/mcp/w1_views_test.go
+++ b/internal/mcp/w1_views_test.go
@@ -1,0 +1,351 @@
+package mcp
+
+import (
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// W1 of ADR-0027: light up the F2 hot index on the production borrow snapshot
+// (memoized per repo per captured MapHandle), fill the relationship view seam
+// F2 left, and expose additive view getters. These tests assert the new getters
+// are behavior-neutral (parity with the existing *graph.Entity seam), the hot
+// index builds exactly once per handle (memoization), and a reload invalidates
+// the memo (no read across a reload).
+
+// w1RelDoc is a doc with both entities and relationships for the relationship
+// seam / iterator parity tests (sampleDoc carries entities only).
+func w1RelDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "r::pkg.A", Name: "A", QualifiedName: "pkg.A", Kind: "type"},
+			{ID: "r::pkg.B", Name: "B", QualifiedName: "pkg.B", Kind: "func"},
+			{ID: "r::pkg.C", Name: "C", QualifiedName: "pkg.C", Kind: "func"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel1", FromID: "r::pkg.B", ToID: "r::pkg.A", Kind: "CALLS"},
+			{ID: "rel2", FromID: "r::pkg.C", ToID: "r::pkg.A", Kind: "REFERENCES"},
+			{ID: "rel3", FromID: "r::pkg.C", ToID: "r::pkg.B", Kind: "CALLS"},
+		},
+	}
+}
+
+// TestW1EntityViewGetterParity asserts the additive view getters return the same
+// entities as the existing LabelIndex / getByID seam over the same graph — the
+// behavior-neutral guarantee. The views wrap the same &Doc.Entities[i] pointers.
+func TestW1EntityViewGetterParity(t *testing.T) {
+	doc := sampleDoc()
+	s, lr := newDocRepoState(doc, &countingCloser{})
+	lr.LabelIndex = BuildLabelIndex(doc)
+
+	b := s.borrowGroup("g")
+	if b == nil {
+		t.Fatal("borrowGroup returned nil")
+	}
+	defer b.Release()
+
+	// byID parity against LabelIndex.ByID (and getByID) for every entity.
+	byID := lr.getByID()
+	for id, want := range byID {
+		got, ok := b.entityViewByID("r", id)
+		if !ok {
+			t.Fatalf("entityViewByID(%q) missing; want %q", id, want.ID)
+		}
+		if got.ID() != want.ID || got.Name() != want.Name ||
+			got.Kind() != want.Kind || got.QualifiedName() != want.QualifiedName {
+			t.Errorf("entityViewByID(%q) = (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+				id, got.ID(), got.Name(), got.Kind(), got.QualifiedName(),
+				want.ID, want.Name, want.Kind, want.QualifiedName)
+		}
+	}
+
+	// byQName parity against LabelIndex.ByQName (case-insensitive).
+	for _, e := range doc.Entities {
+		if e.QualifiedName == "" {
+			continue
+		}
+		got, ok := b.entityViewByQName("r", e.QualifiedName)
+		want := lr.LabelIndex.ByQName[strings.ToLower(e.QualifiedName)]
+		if !ok || want == nil || got.ID() != want.ID {
+			t.Errorf("entityViewByQName(%q) = %v/%v, want %v", e.QualifiedName, got, ok, want)
+		}
+	}
+
+	// byLabel parity against LabelIndex.ByLabel, including ambiguous labels and
+	// order (both are built in Doc order).
+	for lbl, wantEs := range lr.LabelIndex.ByLabel {
+		gotVs := b.entityViewsByLabel("r", lbl)
+		if len(gotVs) != len(wantEs) {
+			t.Fatalf("entityViewsByLabel(%q) len = %d, want %d", lbl, len(gotVs), len(wantEs))
+		}
+		for i := range wantEs {
+			if gotVs[i].ID() != wantEs[i].ID {
+				t.Errorf("entityViewsByLabel(%q)[%d] = %q, want %q", lbl, i, gotVs[i].ID(), wantEs[i].ID)
+			}
+		}
+	}
+
+	// forEachEntityView parity against Doc.Entities, in order.
+	var gotIDs []string
+	b.forEachEntityView("r", func(v graph.EntityView) { gotIDs = append(gotIDs, v.ID()) })
+	if len(gotIDs) != len(doc.Entities) {
+		t.Fatalf("forEachEntityView yielded %d, want %d", len(gotIDs), len(doc.Entities))
+	}
+	for i := range doc.Entities {
+		if gotIDs[i] != doc.Entities[i].ID {
+			t.Errorf("forEachEntityView[%d] = %q, want %q", i, gotIDs[i], doc.Entities[i].ID)
+		}
+	}
+}
+
+// TestW1RelationshipViewSourceParity asserts the W1 relationship seam
+// (docRelationshipViewSource + relationshipViewByID + forEachRelationshipView)
+// is byte-identical to iterating Doc.Relationships — the gap F2 left.
+func TestW1RelationshipViewSourceParity(t *testing.T) {
+	doc := w1RelDoc()
+	s, _ := newDocRepoState(doc, &countingCloser{})
+
+	b := s.borrowGroup("g")
+	defer b.Release()
+
+	// by-id parity.
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		got, ok := b.relationshipViewByID("r", r.ID)
+		if !ok {
+			t.Fatalf("relationshipViewByID(%q) missing", r.ID)
+		}
+		if got.ID() != r.ID || got.FromID() != r.FromID || got.ToID() != r.ToID || got.Kind() != r.Kind {
+			t.Errorf("relationshipViewByID(%q) = (%q,%q,%q,%q), want (%q,%q,%q,%q)",
+				r.ID, got.ID(), got.FromID(), got.ToID(), got.Kind(),
+				r.ID, r.FromID, r.ToID, r.Kind)
+		}
+	}
+
+	// full-scan iteration parity, in Doc order.
+	var gotIDs []string
+	b.forEachRelationshipView("r", func(v graph.RelationshipView) { gotIDs = append(gotIDs, v.ID()) })
+	if len(gotIDs) != len(doc.Relationships) {
+		t.Fatalf("forEachRelationshipView yielded %d, want %d", len(gotIDs), len(doc.Relationships))
+	}
+	for i := range doc.Relationships {
+		if gotIDs[i] != doc.Relationships[i].ID {
+			t.Errorf("forEachRelationshipView[%d] = %q, want %q", i, gotIDs[i], doc.Relationships[i].ID)
+		}
+	}
+
+	// docRelationshipViewSource directly: yields every relationship, in order.
+	var srcIDs []string
+	docRelationshipViewSource{doc: doc}.forEachRelationshipView(func(v graph.RelationshipView) {
+		srcIDs = append(srcIDs, v.ID())
+	})
+	sort.Strings(srcIDs)
+	if len(srcIDs) != len(doc.Relationships) {
+		t.Fatalf("docRelationshipViewSource yielded %d, want %d", len(srcIDs), len(doc.Relationships))
+	}
+
+	// nil-doc source yields nothing.
+	got := false
+	docRelationshipViewSource{doc: nil}.forEachRelationshipView(func(graph.RelationshipView) { got = true })
+	if got {
+		t.Error("docRelationshipViewSource{nil} yielded a relationship")
+	}
+}
+
+// TestW1HotIndexMemoizedPerHandle asserts the hot index builds EXACTLY ONCE per
+// captured handle: repeated view-getter uses for the same handle reuse the same
+// *hotIndex (build func invoked once); a distinct handle rebuilds.
+func TestW1HotIndexMemoizedPerHandle(t *testing.T) {
+	doc := sampleDoc()
+	s, lr := newDocRepoState(doc, &countingCloser{})
+
+	b := s.borrowGroup("g")
+	defer b.Release()
+	h := b.Handle("r")
+
+	var builds int32
+	build := func(hi *MapHandle) *hotIndex {
+		atomic.AddInt32(&builds, 1)
+		return buildHotIndex(hi, docEntityViewSource{doc: doc})
+	}
+
+	i1 := lr.hotIndexFor(h, build)
+	i2 := lr.hotIndexFor(h, build)
+	i3 := lr.hotIndexFor(h, build)
+	if got := atomic.LoadInt32(&builds); got != 1 {
+		t.Fatalf("build count = %d after 3 same-handle lookups, want 1 (memoization)", got)
+	}
+	if i1 != i2 || i2 != i3 {
+		t.Fatalf("memoized index pointers differ: %p %p %p", i1, i2, i3)
+	}
+	if i1.Handle() != h {
+		t.Fatalf("memoized index handle = %p, want captured %p", i1.Handle(), h)
+	}
+
+	// The production borrow getters share the same memoized index.
+	if p := b.hotIndexFor("r"); p == nil {
+		t.Fatal("b.hotIndexFor returned nil")
+	} else if p2 := b.hotIndexFor("r"); p != p2 {
+		t.Fatalf("borrow hotIndexFor rebuilt: %p vs %p", p, p2)
+	}
+}
+
+// TestW1ReloadInvalidatesHotIndex asserts a reload (publishing a successor
+// handle) invalidates the memo: the next lookup rebuilds against the fresh
+// handle, and the index is never read across the reload. Covers both the
+// handle-identity rebuild and the resetIndexes explicit clear.
+func TestW1ReloadInvalidatesHotIndex(t *testing.T) {
+	doc := sampleDoc()
+	s, lr := newDocRepoState(doc, &countingCloser{})
+
+	b1 := s.borrowGroup("g")
+	first := b1.hotIndexFor("r")
+	h1 := b1.Handle("r")
+	if first == nil || first.Handle() != h1 {
+		t.Fatalf("first index handle = %v, want %p", first, h1)
+	}
+	b1.Release()
+
+	// Reload: publish a successor handle (mirrors the F1/F2 reload swap).
+	s.mu.Lock()
+	lr.publishHandle(&MapHandle{closer: &countingCloser{}})
+	s.mu.Unlock()
+
+	b2 := s.borrowGroup("g")
+	defer b2.Release()
+	second := b2.hotIndexFor("r")
+	h2 := b2.Handle("r")
+	if h2 == h1 {
+		t.Fatal("reload did not change the captured handle")
+	}
+	if second == first {
+		t.Fatal("hot index was reused across a reload (stale handle)")
+	}
+	if second.Handle() != h2 {
+		t.Fatalf("rebuilt index handle = %p, want fresh %p", second.Handle(), h2)
+	}
+
+	// resetIndexes (Doc replacement) also clears the memo, independent of the
+	// handle-identity check — the load-bearing invalidation for a no-mmap reload.
+	_ = lr.hotIndexFor(h2, func(h *MapHandle) *hotIndex {
+		return buildHotIndex(h, docEntityViewSource{doc: doc})
+	})
+	lr.resetIndexes()
+	lr.hotIdxMu.Lock()
+	cleared := lr.hotIdx == nil
+	lr.hotIdxMu.Unlock()
+	if !cleared {
+		t.Fatal("resetIndexes did not clear the memoized hot index")
+	}
+}
+
+// TestW1ViewGettersBindToCapturedHandleAcrossReload is the W1 captured-handle
+// race test (reuses F2's reload-loop harness shape, now driving the MEMOIZED
+// production view getters). N borrowers each capture a handle under s.mu, resolve
+// ids through the borrow's view getters while a reloader repoints lr.handle in a
+// tight loop. Under -race it asserts: the captured handle is never munmapped
+// while its borrow is held, the getters answer correctly, and every retired
+// mapping is unmapped exactly once.
+func TestW1ViewGettersBindToCapturedHandleAcrossReload(t *testing.T) {
+	doc := w1RelDoc()
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	var closersMu sync.Mutex
+	var closers []*refCheckCloser
+	newHandle := func() *MapHandle {
+		c := &refCheckCloser{}
+		h := &MapHandle{closer: c, releaseGap: runtime.Gosched}
+		c.h = h
+		closersMu.Lock()
+		closers = append(closers, c)
+		closersMu.Unlock()
+		return h
+	}
+
+	s.mu.Lock()
+	lr.publishHandle(newHandle())
+	s.mu.Unlock()
+
+	var readFault atomic.Int64
+	stop := make(chan struct{})
+
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			s.mu.Lock()
+			lr.publishHandle(newHandle())
+			s.mu.Unlock()
+		}
+	}()
+
+	var wgB sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 2000; j++ {
+				b := s.borrowGroup("g")
+				if b == nil {
+					readFault.Add(1)
+					continue
+				}
+				captured := b.Handle("r")
+				// Resolve through the memoized production getters; the index is
+				// keyed off the captured handle, which stays mapped for the read.
+				v, ok := b.entityViewByID("r", "r::pkg.A")
+				if !ok || v.Name() != "A" {
+					readFault.Add(1)
+				}
+				rv, rok := b.relationshipViewByID("r", "rel1")
+				if !rok || rv.FromID() != "r::pkg.B" {
+					readFault.Add(1)
+				}
+				if hi := b.hotIndexFor("r"); hi.Handle() != captured {
+					readFault.Add(1)
+				}
+				if rc, isRC := captured.closer.(*refCheckCloser); isRC && rc.n.Load() > 0 {
+					readFault.Add(1)
+				}
+				b.Release()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := readFault.Load(); f != 0 {
+		t.Fatalf("read faults (captured handle munmapped under borrow, wrong result, or handle mismatch): %d", f)
+	}
+	closersMu.Lock()
+	defer closersMu.Unlock()
+	for i, c := range closers {
+		if got := c.n.Load(); got != 1 {
+			t.Fatalf("handle %d: munmap count = %d, want exactly 1 (leak or double-munmap)", i, got)
+		}
+		if bad := c.badWhileRefs.Load(); bad != 0 {
+			t.Fatalf("handle %d: munmap observed refs>0 %d times, want 0", i, bad)
+		}
+	}
+}


### PR DESCRIPTION
Refs #5850 (mmap zero-copy epic, ADR-0027). Builds on F1/F2/F3. The M-series linchpin — behavior-neutral, additive (dual-API), no consumer migrated yet.

## What
Lights up F2's (previously inert) handle-keyed hot index on the per-call borrow snapshot, fills the F2 relationship-view gap, and exposes view-based getters so the M1-M16 consumer migration has something to migrate *to*. Existing `getByID`/`LabelIndex.ByID/Lookup/LookupAll` stay untouched (dual-API).

## How
- **Lazy per-handle memoization:** `LoadedRepo.hotIdx` + `hotIdxMu`; `hotIndexFor(h, build)` reuses iff `hotIdx.Handle()==h` (captured-handle identity), else builds once. Costs nothing until a consumer reads a view. Leaf lock (build touches only `lr.Doc`).
- **Dual invalidation:** (1) reload → `publishHandle` successor handle → identity mismatch → rebuild; (2) `resetIndexes` nils `hotIdx` under `hotIdxMu` — the load-bearing clear for the degenerate nil-handle (no-mmap) reload where handle identity is unchanged. Never read across a reload.
- **Heap-backed source** (`docEntityViewSource{lr.Doc}` + new `docRelationshipViewSource{lr.Doc}`) → views wrap the same `&Doc.Entities[i]`/`&Doc.Relationships[i]` pointers as the legacy seam → **behavior-neutral**. Int32 CSR adjacency deliberately kept OUT of `RelationshipView` (hot-path perf).
- **F2 gap filled:** `relationshipViewSource` + `docRelationshipViewSource` + `hotIndex.addRelationships` (relByID + ordered rels) + ordered `hotIndex.ents` for deterministic scans.
- **New getters:** `entityViewByID`, `entityViewsByLabel`, `entityViewByQName`, `forEachEntityView`, `relationshipViewByID`, `forEachRelationshipView` (on `groupBorrow`, keyed off the captured handle).

## Tests (`-race`)
`TestW1EntityViewGetterParity` (getters vs `getByID`/`LabelIndex`), `TestW1RelationshipViewSourceParity` (vs `Doc.Relationships` + nil-doc), `TestW1HotIndexMemoizedPerHandle` (build count == 1 + pointer identity), `TestW1ReloadInvalidatesHotIndex` (successor handle rebuilds; `resetIndexes` clears), `TestW1ViewGettersBindToCapturedHandleAcrossReload` (reload-loop race on the production getters).

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` → 1380 passed / 10 packages. No fbversion bump. Behavior-neutral (new getters used by nobody yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o