### PR TITLE
feat(graph,mcp): W2 widen EntityView/RelationshipView with read-only Prop* methods (ADR-0027)

### DIFF
--- a/internal/graph/view.go
+++ b/internal/graph/view.go
@@ -32,23 +32,46 @@ type EntityView interface {
 	SourceFile() string
 	Language() string
 	Signature() string
-	// Property returns the value for key and whether it was present. Storage-
-	// agnostic by contract (ADR-0027 §Interaction): compatible with both the
-	// map-backed and the in-flight []propKV backing, and later with values
-	// aliased straight out of the mmap.
-	Property(key string) (string, bool)
-	// Properties returns a snapshot copy of all properties. Kept storage-agnostic
-	// for the same reason as Property.
-	Properties() map[string]string
+
+	// The read-only property surface below is NAME- AND SIGNATURE-IDENTICAL to
+	// graph.Entity's own methods. That identity is the whole point of W2
+	// (ADR-0027): *graph.Entity satisfies these for free, so migrating a
+	// property-reading consumer to EntityView is a pure TYPE change — its
+	// PropGet/PropLookup/PropLen/PropRange/PropsSnapshot calls compile unchanged.
+	// The WRITE methods (PropSet/PropDelete) are deliberately EXCLUDED: writes are
+	// cut-set and stay on the concrete type. Storage-agnostic by contract
+	// (ADR-0027 §Interaction): compatible with the map-backed and []propKV
+	// backings and with values aliased straight out of the mmap.
+	//
+	// PropGet returns the value for key, or "" if absent.
+	PropGet(key string) string
+	// PropLookup returns the value for key and whether it was present.
+	PropLookup(key string) (string, bool)
+	// PropLen returns the number of properties.
+	PropLen() int
+	// PropRange calls f for every key/value pair in key-sorted order, stopping
+	// early if f returns false.
+	PropRange(f func(k, v string) bool)
+	// PropsSnapshot returns an independent copy of all properties as a map, or nil
+	// if there are none. The returned map (and its strings) are safe to retain
+	// past any borrow — an mmap-backed impl heap-copies the values.
+	PropsSnapshot() map[string]string
 }
 
-// RelationshipView is the read-only view of a graph relationship.
+// RelationshipView is the read-only view of a graph relationship. Its property
+// read surface is identical to graph.Relationship's, for the same reason as
+// EntityView's (see there).
 type RelationshipView interface {
 	ID() string
 	FromID() string
 	ToID() string
 	Kind() string
-	Property(key string) (string, bool)
+
+	PropGet(key string) string
+	PropLookup(key string) (string, bool)
+	PropLen() int
+	PropRange(f func(k, v string) bool)
+	PropsSnapshot() map[string]string
 }
 
 // materializedEntityView adapts a concrete *Entity (materialized on the heap) to
@@ -75,13 +98,14 @@ func (v materializedEntityView) SourceFile() string    { return v.e.SourceFile }
 func (v materializedEntityView) Language() string      { return v.e.Language }
 func (v materializedEntityView) Signature() string     { return v.e.Signature }
 
-func (v materializedEntityView) Property(key string) (string, bool) {
-	return v.e.PropLookup(key)
-}
-
-func (v materializedEntityView) Properties() map[string]string {
-	return v.e.PropsSnapshot()
-}
+// Property read surface: trivial pass-throughs to the wrapped *Entity's own
+// methods (identical names + signatures — the wrapper exists only for the
+// Name/Kind field-vs-method collision, not for these).
+func (v materializedEntityView) PropGet(key string) string            { return v.e.PropGet(key) }
+func (v materializedEntityView) PropLookup(key string) (string, bool) { return v.e.PropLookup(key) }
+func (v materializedEntityView) PropLen() int                         { return v.e.PropLen() }
+func (v materializedEntityView) PropRange(f func(k, v string) bool)   { v.e.PropRange(f) }
+func (v materializedEntityView) PropsSnapshot() map[string]string     { return v.e.PropsSnapshot() }
 
 // materializedRelationshipView adapts a concrete *Relationship to
 // RelationshipView. See materializedEntityView for the wrapper rationale.
@@ -101,9 +125,13 @@ func (v materializedRelationshipView) FromID() string { return v.r.FromID }
 func (v materializedRelationshipView) ToID() string   { return v.r.ToID }
 func (v materializedRelationshipView) Kind() string   { return v.r.Kind }
 
-func (v materializedRelationshipView) Property(key string) (string, bool) {
+func (v materializedRelationshipView) PropGet(key string) string { return v.r.PropGet(key) }
+func (v materializedRelationshipView) PropLookup(key string) (string, bool) {
 	return v.r.PropLookup(key)
 }
+func (v materializedRelationshipView) PropLen() int                       { return v.r.PropLen() }
+func (v materializedRelationshipView) PropRange(f func(k, v string) bool) { v.r.PropRange(f) }
+func (v materializedRelationshipView) PropsSnapshot() map[string]string   { return v.r.PropsSnapshot() }
 
 // Compile-time assertions that the materialized wrappers satisfy the interfaces.
 var (

--- a/internal/graph/view_test.go
+++ b/internal/graph/view_test.go
@@ -65,17 +65,57 @@ func TestMaterializedEntityViewReturnsUnderlyingFields(t *testing.T) {
 func TestMaterializedEntityViewProperties(t *testing.T) {
 	v := graph.EntityViewOf(newEntity())
 
-	got, ok := v.Property("module")
+	// W2 (ADR-0027): the view's read-only property surface is now name+signature
+	// identical to *graph.Entity's — PropGet/PropLookup/PropLen/PropRange/
+	// PropsSnapshot — so a property-reading consumer migrates by type change alone.
+	got, ok := v.PropLookup("module")
 	if !ok || got != "pkg" {
-		t.Errorf("Property(module) = (%q, %v), want (\"pkg\", true)", got, ok)
+		t.Errorf("PropLookup(module) = (%q, %v), want (\"pkg\", true)", got, ok)
 	}
-	if _, ok := v.Property("absent"); ok {
-		t.Error("Property(absent) reported present")
+	if _, ok := v.PropLookup("absent"); ok {
+		t.Error("PropLookup(absent) reported present")
 	}
-	if snap := v.Properties(); snap["module"] != "pkg" {
-		t.Errorf("Properties()[module] = %q, want %q", snap["module"], "pkg")
+	if got := v.PropGet("module"); got != "pkg" {
+		t.Errorf("PropGet(module) = %q, want %q", got, "pkg")
+	}
+	if got := v.PropGet("absent"); got != "" {
+		t.Errorf("PropGet(absent) = %q, want \"\"", got)
+	}
+	if n := v.PropLen(); n != 1 {
+		t.Errorf("PropLen() = %d, want 1", n)
+	}
+	seen := map[string]string{}
+	v.PropRange(func(k, val string) bool { seen[k] = val; return true })
+	if seen["module"] != "pkg" || len(seen) != 1 {
+		t.Errorf("PropRange collected %v, want map[module:pkg]", seen)
+	}
+	if snap := v.PropsSnapshot(); snap["module"] != "pkg" {
+		t.Errorf("PropsSnapshot()[module] = %q, want %q", snap["module"], "pkg")
 	}
 }
+
+// propReadSurface is EXACTLY graph.Entity's / Relationship's read-only property
+// method set (W2, ADR-0027). The assertions below prove two things at compile
+// time: (1) *graph.Entity and *graph.Relationship satisfy this surface for free
+// (the concrete methods already exist), and (2) EntityView / RelationshipView are
+// SUPERSETS of it (assignable to propReadSurface). Together that is the guarantee
+// the M-series relies on: a consumer's PropGet/PropLookup/PropLen/PropRange/
+// PropsSnapshot calls compile UNCHANGED whether it holds a *graph.Entity or an
+// EntityView — migration is a pure type change on the property read path.
+type propReadSurface interface {
+	PropGet(key string) string
+	PropLookup(key string) (string, bool)
+	PropLen() int
+	PropRange(f func(k, v string) bool)
+	PropsSnapshot() map[string]string
+}
+
+var (
+	_ propReadSurface = (*graph.Entity)(nil)
+	_ propReadSurface = (*graph.Relationship)(nil)
+	_ propReadSurface = graph.EntityView(nil)
+	_ propReadSurface = graph.RelationshipView(nil)
+)
 
 func TestEntityViewOfNilIsNil(t *testing.T) {
 	if v := graph.EntityViewOf(nil); v != nil {
@@ -105,8 +145,17 @@ func TestMaterializedRelationshipView(t *testing.T) {
 	if got := v.Kind(); got != r.Kind {
 		t.Errorf("Kind() = %q, want %q", got, r.Kind)
 	}
-	if got, ok := v.Property("call_site"); !ok || got != "42" {
-		t.Errorf("Property(call_site) = (%q, %v), want (\"42\", true)", got, ok)
+	if got, ok := v.PropLookup("call_site"); !ok || got != "42" {
+		t.Errorf("PropLookup(call_site) = (%q, %v), want (\"42\", true)", got, ok)
+	}
+	if got := v.PropGet("call_site"); got != "42" {
+		t.Errorf("PropGet(call_site) = %q, want %q", got, "42")
+	}
+	if n := v.PropLen(); n != 1 {
+		t.Errorf("PropLen() = %d, want 1", n)
+	}
+	if snap := v.PropsSnapshot(); snap["call_site"] != "42" {
+		t.Errorf("PropsSnapshot()[call_site] = %q, want %q", snap["call_site"], "42")
 	}
 }
 

--- a/internal/mcp/mmapview.go
+++ b/internal/mcp/mmapview.go
@@ -83,7 +83,14 @@ func (v mmapEntityView) SourceFile() string    { return zeroCopyString(v.e.Sourc
 func (v mmapEntityView) Language() string      { return zeroCopyString(v.e.Language()) }
 func (v mmapEntityView) Signature() string     { return zeroCopyString(v.e.Signature()) }
 
-// Property returns the value for key and whether present, zero-copy.
+// PropGet returns the value for key, or "" if absent — zero-copy. Mirrors
+// graph.Entity.PropGet.
+func (v mmapEntityView) PropGet(key string) string {
+	val, _ := v.PropLookup(key)
+	return val
+}
+
+// PropLookup returns the value for key and whether present, zero-copy.
 //
 // Parity with the materialized view (fbEntityToGraphEntity + PropLookup): the
 // writer stores `module` as a top-level FB scalar AND — via PropsSnapshot — in
@@ -91,7 +98,7 @@ func (v mmapEntityView) Signature() string     { return zeroCopyString(v.e.Signa
 // (scalar wins when present). We mirror that: for "module" the non-empty scalar
 // takes precedence; otherwise fall through to the property vector. All other
 // keys are a straight vector lookup.
-func (v mmapEntityView) Property(key string) (string, bool) {
+func (v mmapEntityView) PropLookup(key string) (string, bool) {
 	if key == "module" {
 		if mod := v.e.Module(); len(mod) > 0 {
 			return zeroCopyString(mod), true
@@ -102,10 +109,37 @@ func (v mmapEntityView) Property(key string) (string, bool) {
 	})
 }
 
-// Properties returns a snapshot map of all properties, zero-copy in the values.
-// Parity: propsToMap returns nil for an empty set; the module scalar is folded
-// in (overriding, matching PropSet) when non-empty.
-func (v mmapEntityView) Properties() map[string]string {
+// PropLen returns the number of properties. Parity: the writer always emits the
+// module scalar INTO the property vector too (buildEntity: PropsSnapshot()
+// includes "module"), so PropertiesLength already counts it — matching heap,
+// where fbEntityToGraphEntity's PropSet("module") updates the existing vector
+// entry in place rather than adding one.
+func (v mmapEntityView) PropLen() int { return v.e.PropertiesLength() }
+
+// PropRange calls f for every key/value pair in key-sorted order, zero-copy,
+// stopping early if f returns false. The FB property vector is written key-sorted
+// (fbwriter.buildPropertyVector), and the module fold updates its entry in place,
+// so iterating the vector reproduces heap PropRange's order and values exactly.
+// The yielded strings alias the mmap and are valid only for the borrow (same
+// contract as the cold accessors) — they must not be retained past release().
+func (v mmapEntityView) PropRange(f func(k, v string) bool) {
+	n := v.e.PropertiesLength()
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if v.e.Properties(&pe, i) {
+			if !f(zeroCopyString(pe.Key()), zeroCopyString(pe.Value())) {
+				return
+			}
+		}
+	}
+}
+
+// PropsSnapshot returns an independent snapshot map of all properties, HEAP-COPYING
+// keys and values so the result is safe to retain past the borrow (matching heap
+// PropsSnapshot's owned-string contract) — unlike the zero-copy scalar accessors.
+// Parity: returns nil for an empty set (propsToMap does), and folds the module
+// scalar in (overriding, matching PropSet) when non-empty.
+func (v mmapEntityView) PropsSnapshot() map[string]string {
 	n := v.e.PropertiesLength()
 	mod := v.e.Module()
 	if n == 0 && len(mod) == 0 {
@@ -115,11 +149,12 @@ func (v mmapEntityView) Properties() map[string]string {
 	var pe fb.PropertyEntry
 	for i := 0; i < n; i++ {
 		if v.e.Properties(&pe, i) {
-			out[zeroCopyString(pe.Key())] = zeroCopyString(pe.Value())
+			// string(...) copies out of the mmap — safe past release().
+			out[string(pe.Key())] = string(pe.Value())
 		}
 	}
 	if len(mod) > 0 {
-		out["module"] = zeroCopyString(mod)
+		out["module"] = string(mod)
 	}
 	return out
 }
@@ -136,18 +171,61 @@ func (v mmapRelationshipView) Kind() string   { return zeroCopyString(v.r.Kind()
 // property (the writer stores it there), restored to rel.ID on load. "" when
 // absent.
 func (v mmapRelationshipView) ID() string {
-	if id, ok := v.Property("id"); ok {
+	if id, ok := v.PropLookup("id"); ok {
 		return id
 	}
 	return ""
 }
 
-// Property returns the value for key and whether present, zero-copy — a straight
+// PropGet returns the value for key, or "" if absent — zero-copy. Mirrors
+// graph.Relationship.PropGet.
+func (v mmapRelationshipView) PropGet(key string) string {
+	val, _ := v.PropLookup(key)
+	return val
+}
+
+// PropLookup returns the value for key and whether present, zero-copy — a straight
 // property-vector lookup, matching Relationship.PropLookup.
-func (v mmapRelationshipView) Property(key string) (string, bool) {
+func (v mmapRelationshipView) PropLookup(key string) (string, bool) {
 	return lookupPropertyEntry(key, v.r.PropertiesLength(), func(pe *fb.PropertyEntry, i int) bool {
 		return v.r.Properties(pe, i)
 	})
+}
+
+// PropLen returns the number of properties (incl. the tunneled "id"), matching
+// heap Relationship.PropLen (fbRelToGraphRel leaves "id" in the property set).
+func (v mmapRelationshipView) PropLen() int { return v.r.PropertiesLength() }
+
+// PropRange calls f for every key/value pair in key-sorted order, zero-copy,
+// stopping early if f returns false. Same lifetime contract as the entity view's.
+func (v mmapRelationshipView) PropRange(f func(k, v string) bool) {
+	n := v.r.PropertiesLength()
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if v.r.Properties(&pe, i) {
+			if !f(zeroCopyString(pe.Key()), zeroCopyString(pe.Value())) {
+				return
+			}
+		}
+	}
+}
+
+// PropsSnapshot returns an independent snapshot map, HEAP-COPYING keys and values
+// so the result survives past the borrow (matching heap PropsSnapshot). Returns
+// nil for an empty set. No module fold — relationships have no module scalar.
+func (v mmapRelationshipView) PropsSnapshot() map[string]string {
+	n := v.r.PropertiesLength()
+	if n == 0 {
+		return nil
+	}
+	out := make(map[string]string, n)
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if v.r.Properties(&pe, i) {
+			out[string(pe.Key())] = string(pe.Value())
+		}
+	}
+	return out
 }
 
 // lookupPropertyEntry scans an FB PropertyEntry vector for key, returning its

--- a/internal/mcp/mmapview_test.go
+++ b/internal/mcp/mmapview_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -189,21 +190,66 @@ func assertEntityViewEqual(t *testing.T, id string, want, got graph.EntityView) 
 	if want.Signature() != got.Signature() {
 		t.Errorf("%s Signature: heap %q mmap %q", id, want.Signature(), got.Signature())
 	}
-	// Property parity across the union of keys plus a known-absent key.
-	wp, gp := want.Properties(), got.Properties()
-	if len(wp) != len(gp) {
-		t.Errorf("%s Properties len: heap %v mmap %v", id, wp, gp)
+	// W2 (ADR-0027): full read-only property surface parity — the mmap view's
+	// PropGet/PropLookup/PropLen/PropRange/PropsSnapshot must be byte-identical to
+	// the heap *graph.Entity's, incl. the module scalar/property fold.
+	assertPropReadParity(t, id, want, got, []string{"module", "visibility", "id", "__absent__"})
+}
+
+// propReader is the read-only property surface shared by graph.EntityView and
+// graph.RelationshipView (W2). Its method set is identical to graph.Entity's /
+// Relationship's, which is the whole point: parity is asserted method-for-method.
+type propReader interface {
+	PropGet(key string) string
+	PropLookup(key string) (string, bool)
+	PropLen() int
+	PropRange(f func(k, v string) bool)
+	PropsSnapshot() map[string]string
+}
+
+// assertPropReadParity asserts every read-only property method returns a
+// byte-identical result between the heap view (want) and the mmap view (got):
+// PropLen, PropsSnapshot (deep-equal incl. nil-when-empty), PropRange (same
+// key/value pairs in the same order), and PropGet/PropLookup over probeKeys.
+func assertPropReadParity(t *testing.T, tag string, want, got propReader, probeKeys []string) {
+	t.Helper()
+	if want.PropLen() != got.PropLen() {
+		t.Errorf("%s PropLen: heap %d mmap %d", tag, want.PropLen(), got.PropLen())
 	}
-	for k, wv := range wp {
-		if gv := gp[k]; gv != wv {
-			t.Errorf("%s Properties[%q]: heap %q mmap %q", id, k, wv, gv)
+	ws, gs := want.PropsSnapshot(), got.PropsSnapshot()
+	if (ws == nil) != (gs == nil) {
+		t.Errorf("%s PropsSnapshot nilness: heap nil=%v mmap nil=%v", tag, ws == nil, gs == nil)
+	}
+	if len(ws) != len(gs) {
+		t.Errorf("%s PropsSnapshot len: heap %v mmap %v", tag, ws, gs)
+	}
+	for k, wv := range ws {
+		if gv := gs[k]; gv != wv {
+			t.Errorf("%s PropsSnapshot[%q]: heap %q mmap %q", tag, k, wv, gv)
 		}
 	}
-	for _, k := range []string{"module", "visibility", "id", "__absent__"} {
-		wv, wok := want.Property(k)
-		gv, gok := got.Property(k)
+	// PropRange must visit the same pairs in the same (sorted-key) order.
+	type kv struct{ K, V string }
+	var wr, gr []kv
+	want.PropRange(func(k, v string) bool { wr = append(wr, kv{k, v}); return true })
+	got.PropRange(func(k, v string) bool { gr = append(gr, kv{k, v}); return true })
+	if len(wr) != len(gr) {
+		t.Errorf("%s PropRange len: heap %v mmap %v", tag, wr, gr)
+	} else {
+		for i := range wr {
+			if wr[i] != gr[i] {
+				t.Errorf("%s PropRange[%d]: heap %v mmap %v", tag, i, wr[i], gr[i])
+			}
+		}
+	}
+	for _, k := range probeKeys {
+		if want.PropGet(k) != got.PropGet(k) {
+			t.Errorf("%s PropGet(%q): heap %q mmap %q", tag, k, want.PropGet(k), got.PropGet(k))
+		}
+		wv, wok := want.PropLookup(k)
+		gv, gok := got.PropLookup(k)
 		if wok != gok || wv != gv {
-			t.Errorf("%s Property(%q): heap (%q,%v) mmap (%q,%v)", id, k, wv, wok, gv, gok)
+			t.Errorf("%s PropLookup(%q): heap (%q,%v) mmap (%q,%v)", tag, k, wv, wok, gv, gok)
 		}
 	}
 }
@@ -222,13 +268,9 @@ func assertRelViewEqual(t *testing.T, i int, want, got graph.RelationshipView) {
 	if want.Kind() != got.Kind() {
 		t.Errorf("rel[%d] Kind: heap %q mmap %q", i, want.Kind(), got.Kind())
 	}
-	for _, k := range []string{"id", "line", "__absent__"} {
-		wv, wok := want.Property(k)
-		gv, gok := got.Property(k)
-		if wok != gok || wv != gv {
-			t.Errorf("rel[%d] Property(%q): heap (%q,%v) mmap (%q,%v)", i, k, wv, wok, gv, gok)
-		}
-	}
+	// W2: full read-only property surface parity, incl. the id-tunneled "id"
+	// property (which also backs ID()).
+	assertPropReadParity(t, "rel["+strconv.Itoa(i)+"]", want, got, []string{"id", "line", "__absent__"})
 }
 
 func idsOfViews(vs []graph.EntityView) []string {
@@ -368,9 +410,19 @@ func TestMMapHotIndexReadsAreLifetimeSafeUnderReload(t *testing.T) {
 					v.SourceFile() != "pkg/foo.go" {
 					readFault.Add(1)
 				}
-				if mod, _ := v.Property("module"); mod != "pkg" {
+				if mod, _ := v.PropLookup("module"); mod != "pkg" {
 					readFault.Add(1)
 				}
+				if v.PropGet("module") != "pkg" || v.PropLen() != 2 {
+					readFault.Add(1)
+				}
+				// PropRange reads zero-copy value strings through the borrow.
+				v.PropRange(func(k, val string) bool {
+					if k == "module" && val != "pkg" {
+						readFault.Add(1)
+					}
+					return true
+				})
 				b.Release()
 			}
 		}()

--- a/internal/mcp/mmapview_test.go
+++ b/internal/mcp/mmapview_test.go
@@ -46,7 +46,12 @@ func parityDoc() *graph.Document {
 		Subtype: "struct", SourceFile: "pkg/foo.go", Language: "go",
 		Signature: "type Foo struct{}", StartLine: 10,
 	}
-	e0.PropsReplace(map[string]string{"module": "pkg", "visibility": "public"})
+	// "empty" is a present KEY with an empty ("") VALUE — a zero-length (present)
+	// ByteVector on the value path, exercising the zeroCopyString len==0 guard for
+	// values (distinct from the empty-scalar Signature/Subtype cases on e1). Its
+	// mmap-vs-heap PropGet/PropLookup/PropRange parity is asserted in
+	// assertEntityViewEqual's probe list.
+	e0.PropsReplace(map[string]string{"module": "pkg", "visibility": "public", "empty": ""})
 
 	// Empty Signature AND empty Subtype — the zero-length (present) ByteVector
 	// path. No module property either.
@@ -193,7 +198,7 @@ func assertEntityViewEqual(t *testing.T, id string, want, got graph.EntityView) 
 	// W2 (ADR-0027): full read-only property surface parity — the mmap view's
 	// PropGet/PropLookup/PropLen/PropRange/PropsSnapshot must be byte-identical to
 	// the heap *graph.Entity's, incl. the module scalar/property fold.
-	assertPropReadParity(t, id, want, got, []string{"module", "visibility", "id", "__absent__"})
+	assertPropReadParity(t, id, want, got, []string{"module", "visibility", "empty", "id", "__absent__"})
 }
 
 // propReader is the read-only property surface shared by graph.EntityView and
@@ -413,7 +418,7 @@ func TestMMapHotIndexReadsAreLifetimeSafeUnderReload(t *testing.T) {
 				if mod, _ := v.PropLookup("module"); mod != "pkg" {
 					readFault.Add(1)
 				}
-				if v.PropGet("module") != "pkg" || v.PropLen() != 2 {
+				if v.PropGet("module") != "pkg" || v.PropLen() != 3 {
 					readFault.Add(1)
 				}
 				// PropRange reads zero-copy value strings through the borrow.
@@ -438,5 +443,84 @@ func TestMMapHotIndexReadsAreLifetimeSafeUnderReload(t *testing.T) {
 
 	if f := readFault.Load(); f != 0 {
 		t.Fatalf("read faults (wrong result or use-after-unmap): %d", f)
+	}
+}
+
+// TestMMapPropsSnapshotSurvivesRelease is the load-bearing lifetime test for the
+// mmap*View.PropsSnapshot HEAP-COPY contract: the returned map (unlike the
+// zero-copy scalar/PropGet/PropRange accessors) must remain byte-correct AFTER
+// the borrow is released AND the underlying mmap is retired+munmapped. It retains
+// an entity AND a relationship snapshot under a real borrow, Release()s the
+// borrow, retireHandle()s the mapping (with refs drained, retire munmaps it NOW —
+// see MapHandle.retire), forces a GC, THEN reads the retained maps. If
+// PropsSnapshot aliased the mmap (zeroCopyString instead of string(...)) this is
+// a use-after-unmap: SIGBUS/SIGSEGV or garbage under -race. Heap-copied, it
+// survives. Adversarial — meant to run under -race -count=50.
+func TestMMapPropsSnapshotSurvivesRelease(t *testing.T) {
+	path := writeParityGraph(t)
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	rdr, err := fbreader.Open(path)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	s.mu.Lock()
+	lr.publishHandle(newMapHandle(rdr))
+	s.mu.Unlock()
+
+	// Capture the snapshots strictly UNDER the borrow (the only window in which
+	// the mmap is guaranteed mapped).
+	b := s.borrowGroup("g")
+	if b == nil {
+		t.Fatal("borrowGroup returned nil")
+	}
+	h := b.Handle("r")
+	if h == nil {
+		t.Fatal("Handle(r) returned nil")
+	}
+	hi := b.buildHotIndex("r", mmapEntityViewSource{handle: h})
+	ev, ok := hi.entityByID("r::pkg.Foo")
+	if !ok {
+		t.Fatal("entityByID(r::pkg.Foo) miss")
+	}
+	rv := mmapRelationshipView{r: h.Reader().RelationshipAt(0)}
+
+	entSnap := ev.PropsSnapshot()
+	relSnap := rv.PropsSnapshot()
+
+	// Drop the borrow, then retire the handle: refs is drained, so retire munmaps
+	// the mapping immediately. Any lingering alias into it is now use-after-unmap.
+	b.Release()
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	// Churn the heap so a stale alias is unlikely to still find intact bytes.
+	runtime.GC()
+
+	// The retained snapshots must still be byte-correct AFTER the munmap. Reading
+	// an aliased key/value here would fault; heap-copied strings are safe.
+	wantEnt := map[string]string{"module": "pkg", "visibility": "public", "empty": ""}
+	if len(entSnap) != len(wantEnt) {
+		t.Fatalf("entity snapshot = %v, want %v", entSnap, wantEnt)
+	}
+	for k, want := range wantEnt {
+		if got, ok := entSnap[k]; !ok || got != want {
+			t.Errorf("entity snapshot[%q] = (%q,%v) after munmap, want (%q,true) (use-after-unmap?)", k, got, ok, want)
+		}
+	}
+	wantRel := map[string]string{"id": "edge-0001", "line": "12"}
+	if len(relSnap) != len(wantRel) {
+		t.Fatalf("rel snapshot = %v, want %v", relSnap, wantRel)
+	}
+	for k, want := range wantRel {
+		if got, ok := relSnap[k]; !ok || got != want {
+			t.Errorf("rel snapshot[%q] = (%q,%v) after munmap, want (%q,true) (use-after-unmap?)", k, got, ok, want)
+		}
 	}
 }


### PR DESCRIPTION
Refs #5850 (mmap zero-copy epic, ADR-0027). Builds on F1/F2/F3/W1. Behavior-neutral, mmap path stays DARK. Unblocks the M-series by making property-reading migration a pure type change.

## Why
The `[]propKV` migration (#5853) made `graph.Entity`/`Relationship` read properties only via methods (`PropGet`/`PropLookup`/`PropLen`/`PropRange`/`PropsSnapshot`). F2's `EntityView` exposed only `Property`/`Properties`, so property-reading consumers couldn't migrate without a method-rename cascade (surfaced by the docgen pilot). W2 aligns the interface's property read-surface to `graph.Entity`'s exactly.

## What
- **`EntityView` + `RelationshipView` gain** (signatures identical to `graph.Entity`/`Relationship`): `PropGet(key) string`, `PropLookup(key) (string,bool)`, `PropLen() int`, `PropRange(func(k,v string) bool)`, `PropsSnapshot() map[string]string`. Write methods (`PropSet`/`PropDelete`) deliberately excluded (cut-set).
- **Dropped** the now-redundant `Property` (== `PropLookup`) and `Properties` (== `PropsSnapshot`) — grep-confirmed only one internal caller, migrated.
- **Compile-time assertions** (`view_test.go`): `*graph.Entity`/`*graph.Relationship` + both view interfaces satisfy the 5-method read surface for free.
- **`mmapEntityView`/`mmapRelationshipView`** implement all five zero-copy from the FB property vector. `PropGet`/`PropLookup`/`PropRange` values are borrow-scoped zero-copy aliases; `PropsSnapshot` heap-copies keys/values so its map survives past `release()` (matches heap's owned-string contract).

## Tests (`-race`)
- `TestMMapViewParityWithHeap` extended: `PropGet`/`PropLookup`/`PropLen`/`PropRange`/`PropsSnapshot` byte-identical mmap-vs-heap for 0/1/N props, empty-value props, `module` scalar/property fold, id-tunneled `"id"` property, nil-when-empty snapshot.
- `TestMMapHotIndexReadsAreLifetimeSafeUnderReload` now drives `PropGet`/`PropLen`/`PropRange` through the borrow under the reload-race harness; `PropsSnapshot` proven heap-safe past release.

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` → 1385 passed / 10 packages. No fbversion bump.

## Effect on M-series
A consumer calling `ent.PropGet(k)`/`PropLen()`/`PropRange(...)` on `*graph.Entity` compiles unchanged after its type switches to `graph.EntityView` — property access becomes pure type substitution (orthogonal to the `Name`/`Kind` field→method conversions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o