### PR TITLE
fix(mcp): re-key FuseRRF by entity ID instead of pointer identity (ADR-0027 cutover prep)

### DIFF
--- a/internal/mcp/rrf_test.go
+++ b/internal/mcp/rrf_test.go
@@ -142,3 +142,96 @@ func TestFuseRRF_BothSourcesRankFusedHigher(t *testing.T) {
 		t.Fatalf("a Source should be bm25+semantic, got %q", fused[0].Source)
 	}
 }
+
+// TestFuseRRF_DistinctPointersSameID_FuseIntoOne proves the ID-keyed re-key
+// (ADR-0027 mmap zero-copy cutover): once ranker hits are materialized
+// independently, BM25 and semantic search can hand back two *graph.Entity
+// values that are separate allocations (distinct pointers) but describe the
+// same logical entity (same ID). A pointer-keyed byEntity map treats those as
+// two different results and never fuses them — this test fails against that
+// old impl. Keying by Entity.ID instead correctly folds them into one Hit
+// with the summed RRF contribution from both rankers.
+func TestFuseRRF_DistinctPointersSameID_FuseIntoOne(t *testing.T) {
+	t.Parallel()
+	// Two independently-allocated *graph.Entity values sharing ID "shared-1".
+	// Pointer identity differs (p1 != p2); logical identity (ID) is the same.
+	p1 := &graph.Entity{ID: "shared-1", Name: "HandleAuth"}
+	p2 := &graph.Entity{ID: "shared-1", Name: "HandleAuth"}
+	if p1 == p2 {
+		t.Fatal("test setup invalid: p1 and p2 must be distinct pointers")
+	}
+	other := &graph.Entity{ID: "other-1", Name: "Unrelated"}
+
+	bm25 := []Hit{{Entity: p1, Score: 1}, {Entity: other, Score: 0.1}}
+	sem := []Hit{{Entity: p2, Score: 1}}
+
+	fused := FuseRRF(bm25, sem)
+
+	var shared *Hit
+	count := 0
+	for i := range fused {
+		if fused[i].Entity.ID == "shared-1" {
+			shared = &fused[i]
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one fused hit for ID shared-1 (distinct pointers, same ID), got %d in %+v", count, fused)
+	}
+	if shared.Source != "bm25+semantic" {
+		t.Fatalf("shared-1 should be sourced from both rankers, got %q", shared.Source)
+	}
+	wantScore := 1.0/(rrfK+1) + 1.0/(rrfK+1) // rank 0 in both bm25 and semantic
+	if diff := shared.Score - wantScore; diff > 1e-9 || diff < -1e-9 {
+		t.Fatalf("shared-1 fused score = %v, want %v (summed RRF contribution)", shared.Score, wantScore)
+	}
+}
+
+// TestFuseRRF_OrderingAndScoreParity locks down the exact fused order and
+// scores for a normal multi-ranker fixture (all pointers pre-materialized
+// once and shared across ranker inputs, as today), so the ID-keyed re-key is
+// verified byte-identical to the prior pointer-keyed behavior in the common
+// case.
+func TestFuseRRF_OrderingAndScoreParity(t *testing.T) {
+	t.Parallel()
+	a := &graph.Entity{ID: "a", Name: "AuthCheck"}
+	b := &graph.Entity{ID: "b", Name: "AuthVerify"}
+	c := &graph.Entity{ID: "c", Name: "LogoutHandler"}
+	d := &graph.Entity{ID: "d", Name: "SessionStore"}
+
+	bm25 := []Hit{{Entity: a, Score: 5}, {Entity: c, Score: 3}, {Entity: d, Score: 1}}
+	sem := []Hit{{Entity: b, Score: 0.9}, {Entity: a, Score: 0.6}, {Entity: c, Score: 0.2}}
+
+	fused := FuseRRF(bm25, sem)
+
+	wantIDs := []string{"a", "c", "b", "d"}
+	if len(fused) != len(wantIDs) {
+		t.Fatalf("fused length = %d, want %d (%+v)", len(fused), len(wantIDs), fused)
+	}
+	for i, id := range wantIDs {
+		if fused[i].Entity.ID != id {
+			t.Fatalf("fused[%d].Entity.ID = %q, want %q (full: %+v)", i, fused[i].Entity.ID, id, fused)
+		}
+	}
+
+	wantScores := map[string]float64{
+		"a": 1.0/(rrfK+1) + 1.0/(rrfK+2), // rank 1 in bm25, rank 2 in semantic
+		"c": 1.0/(rrfK+2) + 1.0/(rrfK+3), // rank 2 in bm25, rank 3 in semantic
+		"b": 1.0 / (rrfK + 1),            // rank 1 in semantic only
+		"d": 1.0 / (rrfK + 3),            // rank 3 in bm25 only
+	}
+	wantSources := map[string]string{
+		"a": "bm25+semantic",
+		"c": "bm25+semantic",
+		"b": "semantic",
+		"d": "bm25",
+	}
+	for _, h := range fused {
+		if diff := h.Score - wantScores[h.Entity.ID]; diff > 1e-9 || diff < -1e-9 {
+			t.Fatalf("%s score = %v, want %v", h.Entity.ID, h.Score, wantScores[h.Entity.ID])
+		}
+		if h.Source != wantSources[h.Entity.ID] {
+			t.Fatalf("%s source = %q, want %q", h.Entity.ID, h.Source, wantSources[h.Entity.ID])
+		}
+	}
+}

--- a/internal/mcp/scoring.go
+++ b/internal/mcp/scoring.go
@@ -319,8 +319,11 @@ const rrfK = 60.0
 
 // FuseRRF combines a BM25 ranking and a semantic ranking into a single ranked
 // list via Reciprocal Rank Fusion. Rankings are passed already sorted best
-// first. Entities are matched by pointer identity (both rankers index the same
-// repo Doc). The returned hits carry the fused score and a Source tag.
+// first. Entities are matched by ID (not pointer identity): the two rankers
+// may hand back distinct *graph.Entity allocations for the same logical
+// entity (e.g. once mmap-backed hits are materialized independently per
+// ranker, ADR-0027), so keying on Entity.ID is what keeps them fusing into a
+// single result. The returned hits carry the fused score and a Source tag.
 func FuseRRF(bm25, semantic []Hit) []Hit {
 	type agg struct {
 		entity *graph.Entity
@@ -328,14 +331,14 @@ func FuseRRF(bm25, semantic []Hit) []Hit {
 		inBM25 bool
 		inSem  bool
 	}
-	order := []*graph.Entity{}
-	byEntity := map[*graph.Entity]*agg{}
+	order := []string{}
+	byEntity := map[string]*agg{}
 	get := func(e *graph.Entity) *agg {
-		a, ok := byEntity[e]
+		a, ok := byEntity[e.ID]
 		if !ok {
 			a = &agg{entity: e}
-			byEntity[e] = a
-			order = append(order, e)
+			byEntity[e.ID] = a
+			order = append(order, e.ID)
 		}
 		return a
 	}
@@ -350,8 +353,8 @@ func FuseRRF(bm25, semantic []Hit) []Hit {
 		a.inSem = true
 	}
 	out := make([]Hit, 0, len(order))
-	for _, e := range order {
-		a := byEntity[e]
+	for _, id := range order {
+		a := byEntity[id]
 		src := "bm25"
 		switch {
 		case a.inBM25 && a.inSem:


### PR DESCRIPTION
Refs #5850 (mmap cutover). Behavior-neutral now, correct after cutover.

## Why
`FuseRRF` (reciprocal-rank fusion of BM25 + semantic rankers) matched hits by `*graph.Entity` POINTER identity (`map[*graph.Entity]*agg`). Under the upcoming materialize-on-hit cutover, the two rankers produce DIFFERENT pointers for the same entity → silent no-match (fusion stops working). Re-keying by `entity.ID` fixes it now and after cutover.

## What
- `byEntity map[*graph.Entity]*agg` → `map[string]*agg` keyed on `e.ID`.
- `order []*graph.Entity` → `order []string` (still first-seen → ordering/tie-break byte-identical).
- `a.entity` still stores the first-seen `*graph.Entity`, returned in the output `Hit` (existing pointer assertions hold when inputs share pointers, as today).
- `tools.go:689` caller unchanged.

## Tests
- `TestFuseRRF_DistinctPointersSameID_FuseIntoOne` — two distinct `*graph.Entity` with the same ID (one per ranker) fuse into ONE hit with summed RRF score. **Mutation-proven**: fails on the old pointer-keyed impl (2 hits), passes on the fix.
- `TestFuseRRF_OrderingAndScoreParity` — 4-entity/2-ranker fixture locking exact fused order, per-entity RRF scores, and Source tags vs pre-refactor behavior.

## Gate
`go build ./...` ok · `go vet ./internal/mcp/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... -race -count=1` → 1145 passed. No fbversion bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o