### PR TITLE
feat(mcp,graph): cutover PR1 — Reader-source primitive index builds + export materializers (ADR-0027)

### DIFF
--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -514,3 +514,45 @@ func fbRelToGraphRel(r *fb.Relationship, si *stringInterner) Relationship {
 	}
 	return rel
 }
+
+// MaterializeEntity decodes the i-th entity of the mmap'd Reader into a
+// single heap-safe graph.Entity, on demand. It is a thin exported wrapper
+// over the same fbEntityToGraphEntity conversion loadFBDocument uses per
+// row, so a MaterializeEntity(r, i) result is byte-identical to the
+// Document's Entities[i] for the same graph.fb.
+//
+// Every string field is COPIED out of the mmap region (see
+// fbEntityToGraphEntity), so the returned Entity is safe to retain after
+// the Reader is closed — no borrow of the underlying mapping is held.
+//
+// A fresh interner is used per call: interning only deduplicates repeated
+// substrings WITHIN one materialized row, and the copied-out strings are
+// independent of any Document-wide interner. Returns the zero Entity when
+// r is nil or i is out of range.
+func MaterializeEntity(r *fbreader.Reader, i int) Entity {
+	if r == nil {
+		return Entity{}
+	}
+	fbEnt := r.EntityAt(i)
+	if fbEnt == nil {
+		return Entity{}
+	}
+	return fbEntityToGraphEntity(fbEnt, newStringInterner())
+}
+
+// MaterializeRelationship decodes the i-th relationship of the mmap'd
+// Reader into a single heap-safe graph.Relationship, on demand. Thin
+// exported wrapper over fbRelToGraphRel — byte-identical to the Document's
+// Relationships[i] for the same graph.fb. All strings are copied out of
+// the mmap region, so the result outlives the Reader. Returns the zero
+// Relationship when r is nil or i is out of range.
+func MaterializeRelationship(r *fbreader.Reader, i int) Relationship {
+	if r == nil {
+		return Relationship{}
+	}
+	fbRel := r.RelationshipAt(i)
+	if fbRel == nil {
+		return Relationship{}
+	}
+	return fbRelToGraphRel(fbRel, newStringInterner())
+}

--- a/internal/graph/materialize_pr1_test.go
+++ b/internal/graph/materialize_pr1_test.go
@@ -1,0 +1,144 @@
+// ADR-0027 Cutover PR1: the exported per-row materializers
+// (MaterializeEntity / MaterializeRelationship) must produce a graph.Entity /
+// graph.Relationship byte-identical to the row loadFBDocument materializes for
+// the same graph.fb. This is the contract later PRs (loader flip) rely on when
+// they source rows from the mmap Reader on demand instead of the Document.
+package graph_test
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+func f64(v float64) *float64 { return &v }
+
+// materializeDoc exercises the fields the materializers copy: interned
+// id/kind/subtype/module/source_file/language, high-cardinality
+// name/qualified_name/signature, multi/empty/zero property sets, and the
+// Pass-4 pagerank scalar (present and absent).
+func materializeDoc() *graph.Document {
+	e0 := graph.Entity{
+		ID: "r::pkg.Foo", Name: "Foo", QualifiedName: "pkg.Foo", Kind: "type",
+		Subtype: "struct", SourceFile: "pkg/foo.go", Language: "go",
+		Signature: "type Foo struct{}", StartLine: 10, PageRank: f64(0.42),
+	}
+	e0.PropsReplace(map[string]string{"module": "pkg", "visibility": "public", "empty": ""})
+
+	// Empty signature/subtype, no module property, no pagerank (nil pointer).
+	e1 := graph.Entity{
+		ID: "r::pkg.bar", Name: "bar", QualifiedName: "pkg.bar", Kind: "func",
+		SourceFile: "pkg/bar.go", Language: "go",
+	}
+
+	// No properties at all.
+	e2 := graph.Entity{
+		ID: "r::pkg.Baz", Name: "Baz", QualifiedName: "pkg.Baz", Kind: "const",
+		SourceFile: "pkg/baz.go", Language: "go", PageRank: f64(0.01),
+	}
+
+	r0 := graph.Relationship{FromID: "r::pkg.Foo", ToID: "r::pkg.bar", Kind: "CALLS"}
+	r0.PropsReplace(map[string]string{"id": "edge-0001", "count": "3", "line": "12"})
+
+	// Relationship without an id property.
+	r1 := graph.Relationship{FromID: "r::pkg.bar", ToID: "r::pkg.Baz", Kind: "references"}
+
+	return &graph.Document{
+		Entities:      []graph.Entity{e0, e1, e2},
+		Relationships: []graph.Relationship{r0, r1},
+	}
+}
+
+// TestMaterializeEntityByteEqualsDocument_PR1 proves MaterializeEntity(r, i) is
+// reflect.DeepEqual to the loader's Document.Entities[i] for every row.
+func TestMaterializeEntityByteEqualsDocument_PR1(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, materializeDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	defer r.Close()
+
+	if got, want := r.EntityCount(), len(doc.Entities); got != want {
+		t.Fatalf("EntityCount %d != len(doc.Entities) %d", got, want)
+	}
+	for i := range doc.Entities {
+		got := graph.MaterializeEntity(r, i)
+		if !reflect.DeepEqual(got, doc.Entities[i]) {
+			t.Errorf("entity %d: MaterializeEntity != doc.Entities[i]\n got=%#v\nwant=%#v", i, got, doc.Entities[i])
+		}
+	}
+}
+
+// TestMaterializeRelationshipByteEqualsDocument_PR1 proves
+// MaterializeRelationship(r, i) is reflect.DeepEqual to
+// Document.Relationships[i] for every row.
+func TestMaterializeRelationshipByteEqualsDocument_PR1(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, materializeDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	defer r.Close()
+
+	if got, want := r.RelationshipCount(), len(doc.Relationships); got != want {
+		t.Fatalf("RelationshipCount %d != len(doc.Relationships) %d", got, want)
+	}
+	for i := range doc.Relationships {
+		got := graph.MaterializeRelationship(r, i)
+		if !reflect.DeepEqual(got, doc.Relationships[i]) {
+			t.Errorf("relationship %d: MaterializeRelationship != doc.Relationships[i]\n got=%#v\nwant=%#v", i, got, doc.Relationships[i])
+		}
+	}
+}
+
+// TestMaterializeOutOfRange_PR1 documents the nil-reader / out-of-range
+// contract: the zero value, never a panic.
+func TestMaterializeOutOfRange_PR1(t *testing.T) {
+	t.Parallel()
+	if got := graph.MaterializeEntity(nil, 0); !reflect.DeepEqual(got, graph.Entity{}) {
+		t.Errorf("MaterializeEntity(nil,0) = %#v, want zero", got)
+	}
+	if got := graph.MaterializeRelationship(nil, 0); !reflect.DeepEqual(got, graph.Relationship{}) {
+		t.Errorf("MaterializeRelationship(nil,0) = %#v, want zero", got)
+	}
+
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, materializeDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	defer r.Close()
+	if got := graph.MaterializeEntity(r, 9999); !reflect.DeepEqual(got, graph.Entity{}) {
+		t.Errorf("MaterializeEntity(r, oob) = %#v, want zero", got)
+	}
+	if got := graph.MaterializeRelationship(r, 9999); !reflect.DeepEqual(got, graph.Relationship{}) {
+		t.Errorf("MaterializeRelationship(r, oob) = %#v, want zero", got)
+	}
+}

--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -712,6 +712,67 @@ func TestLoadedRepo_testsEdgeCachePopulated(t *testing.T) {
 	}
 }
 
+// TestLoadedRepo_testsEdgeCacheFromReader_PR1 is the FB-backed twin of
+// TestLoadedRepo_testsEdgeCachePopulated. ADR-0027 Cutover PR1 re-sourced the
+// reload-loop TESTS-edge count off the freshly opened mmap Reader
+// (Reader.IterateRelationships reading Kind()), falling back to the Document
+// only when no graph.fb is mapped. The existing test writes graph.JSON only, so
+// its reload takes the newRdr==nil Document fallback and leaves the production
+// Reader-count branch uncovered. This test writes a real graph.fb (via
+// writeGraphFB) so reloadLocked opens a non-nil Reader and the production
+// Reader-count branch runs, then asserts against the REAL production cache
+// (lr.TestsEdgeCount) — not an inline reimplementation. Mutating the production
+// branch ("TESTS"->"TESTX" in state.go) must fail THIS test.
+func TestLoadedRepo_testsEdgeCacheFromReader_PR1(t *testing.T) {
+	tmp := t.TempDir()
+	setTestHome(t, tmp)
+	t.Setenv("GRAFEL_WHOAMI_NUDGE", "")
+
+	repoDir := filepath.Join(tmp, "repo-fb-cache")
+	doc := &graph.Document{
+		Repo: "repo-fb-cache",
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "Prod1", Kind: "function", SourceFile: "a.go", StartLine: 1, EndLine: 5},
+			{ID: "e2", Name: "Prod2", Kind: "function", SourceFile: "a.go", StartLine: 6, EndLine: 10},
+			{ID: "t1", Name: "TestProd1", Kind: "function", SourceFile: "a_test.go", StartLine: 1, EndLine: 5},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "e1", ToID: "e2", Kind: "CALLS"},
+			{ID: "r2", FromID: "t1", ToID: "e1", Kind: "TESTS"},
+			{ID: "r3", FromID: "t1", ToID: "e2", Kind: "TESTS"},
+		},
+	}
+	// graph.fb (NOT graph.json) so the reload opens a non-nil Reader and the
+	// production Reader-count branch actually executes.
+	writeGraphFB(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-fb-cache": repoDir},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	lg := srv.State.Group("g")
+	if lg == nil {
+		t.Fatal("group 'g' not found after NewServer")
+	}
+	lr := lg.Repos["repo-fb-cache"]
+	if lr == nil {
+		t.Fatal("repo-fb-cache not loaded")
+	}
+	// Guard: the repo MUST have taken the FB path, else this test would be
+	// silently exercising the Document fallback (same trap as the JSON test).
+	if lr.Reader == nil {
+		t.Fatal("lr.Reader is nil — repo did not load graph.fb, Reader-count branch not exercised")
+	}
+	// The production cache, populated by the Reader-count branch in reloadLocked.
+	if lr.TestsEdgeCount != 2 {
+		t.Errorf("LoadedRepo.TestsEdgeCount (Reader-sourced): got %d want 2", lr.TestsEdgeCount)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Fix #2 — whoami must honor explicit group= for index-state fields
 // ---------------------------------------------------------------------------

--- a/internal/mcp/reader_index_parity_pr1_test.go
+++ b/internal/mcp/reader_index_parity_pr1_test.go
@@ -1,0 +1,154 @@
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// ADR-0027 Cutover PR1: the primitive-only serve-side index builds
+// (adjacency, calls-adjacency, step-adjacency, top-K PageRank, TESTS-edge
+// count) were re-sourced to read off the resident mmap fbreader.Reader instead
+// of the materialized graph.Document. Because the Reader holds the same rows in
+// the same vector order the Document loader produces, the Reader-sourced build
+// MUST be byte-identical (reflect.DeepEqual) to the Document-sourced one. These
+// tests build BOTH over one real graph.fb and assert equality.
+
+func prPtr(v float64) *float64 { return &v }
+
+// parityIndexDoc exercises every kind the re-sourced builds branch on: CALLS
+// (calls-adjacency), STEP_IN_PROCESS with step_index (step-adjacency), TESTS
+// (edge count), plus the count/weight properties feeding edgeWeight and entity
+// pagerank scalars (present and absent) for the top-K build.
+func parityIndexDoc() *graph.Document {
+	mkEnt := func(id, name, kind string, pr *float64) graph.Entity {
+		return graph.Entity{
+			ID: id, Name: name, QualifiedName: "pkg." + name, Kind: kind,
+			SourceFile: "pkg/" + name + ".go", Language: "go", PageRank: pr,
+		}
+	}
+	ents := []graph.Entity{
+		mkEnt("id::a", "A", "FUNCTION", prPtr(0.9)),
+		mkEnt("id::b", "B", "FUNCTION", prPtr(0.1)),
+		mkEnt("id::c", "C", "FUNCTION", nil),
+		mkEnt("id::d", "D", "FUNCTION", prPtr(0.5)),
+		mkEnt("id::proc", "Proc", "PROCESS", nil),
+		mkEnt("id::t", "T", "TEST", nil),
+	}
+
+	mkRel := func(from, to, kind string, props map[string]string) graph.Relationship {
+		r := graph.Relationship{FromID: from, ToID: to, Kind: kind}
+		if props != nil {
+			r.PropsReplace(props)
+		}
+		return r
+	}
+	rels := []graph.Relationship{
+		mkRel("id::a", "id::b", "CALLS", map[string]string{"count": "3"}),
+		mkRel("id::a", "id::c", "CALLS", nil),
+		mkRel("id::b", "id::c", "CALLS", map[string]string{"weight": "2.5"}),
+		mkRel("id::a", "id::d", "REFERENCES", map[string]string{"count": "0"}), // count<=0 -> weight 1.0
+		mkRel("id::proc", "id::a", "STEP_IN_PROCESS", map[string]string{"step_index": "1"}),
+		mkRel("id::proc", "id::b", "STEP_IN_PROCESS", map[string]string{"step_index": "0"}),
+		mkRel("id::t", "id::a", "TESTS", nil),
+		mkRel("id::t", "id::b", "TESTS", nil),
+	}
+	return &graph.Document{Entities: ents, Relationships: rels}
+}
+
+// loadParityIndexFixture writes parityIndexDoc() to a temp graph.fb and returns
+// both the loader-materialized Document and an open Reader over the same file.
+func loadParityIndexFixture(t *testing.T) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, parityIndexDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+func TestAdjacencyReaderParity_PR1(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	want := buildAdjacency(doc, "repo")
+	got := buildAdjacencyFromReader(r, "repo")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("adjacency Reader-sourced != Document-sourced\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestCallsAdjacencyReaderParity_PR1(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	want := buildCallsAdjacency(doc)
+	got := buildCallsAdjacencyFromReader(r)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("callsAdjacency Reader-sourced != Document-sourced\n got=%#v\nwant=%#v", got, want)
+	}
+	// Spot-check the public Get contract too (sorted callee ids).
+	for _, id := range []string{"id::a", "id::b", "id::c"} {
+		if !reflect.DeepEqual(got.Get(id), want.Get(id)) {
+			t.Errorf("Get(%q): %v != %v", id, got.Get(id), want.Get(id))
+		}
+	}
+}
+
+func TestStepAdjacencyReaderParity_PR1(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	want := buildStepAdjacency(doc)
+	got := buildStepAdjacencyFromReader(r)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("stepAdjacency Reader-sourced != Document-sourced\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func TestTopKPageRankReaderParity_PR1(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	for _, k := range []int{1, 3, 64} {
+		want := buildTopKPageRank(doc, k)
+		got := buildTopKPageRankFromReader(r, k)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("topKPageRank(k=%d) Reader-sourced != Document-sourced\n got=%v\nwant=%v", k, got, want)
+		}
+	}
+}
+
+// TestTestsEdgeCountReaderParity_PR1 mirrors the reload-loop count: TESTS-kind
+// edges tallied off the Reader must equal the Document tally.
+func TestTestsEdgeCountReaderParity_PR1(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	want := 0
+	for i := range doc.Relationships {
+		if doc.Relationships[i].Kind == "TESTS" {
+			want++
+		}
+	}
+	got := 0
+	r.IterateRelationships(func(rel *fb.Relationship) bool {
+		if string(rel.Kind()) == "TESTS" {
+			got++
+		}
+		return true
+	})
+	if got != want {
+		t.Fatalf("TESTS-edge count Reader=%d Document=%d", got, want)
+	}
+}

--- a/internal/mcp/reader_index_parity_pr1_test.go
+++ b/internal/mcp/reader_index_parity_pr1_test.go
@@ -52,6 +52,11 @@ func parityIndexDoc() *graph.Document {
 		mkRel("id::a", "id::b", "CALLS", map[string]string{"count": "3"}),
 		mkRel("id::a", "id::c", "CALLS", nil),
 		mkRel("id::b", "id::c", "CALLS", map[string]string{"weight": "2.5"}),
+		// BOTH count and weight, DIFFERENT values — pins edgeWeightFB's
+		// count-before-weight precedence (weight must resolve to 7, not 9). A
+		// precedence swap in edgeWeightFB makes the Reader-sourced edge weight
+		// diverge here and fails TestAdjacencyReaderParity_PR1.
+		mkRel("id::b", "id::d", "CALLS", map[string]string{"count": "7", "weight": "9"}),
 		mkRel("id::a", "id::d", "REFERENCES", map[string]string{"count": "0"}), // count<=0 -> weight 1.0
 		mkRel("id::proc", "id::a", "STEP_IN_PROCESS", map[string]string{"step_index": "1"}),
 		mkRel("id::proc", "id::b", "STEP_IN_PROCESS", map[string]string{"step_index": "0"}),

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/embed"
 	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 )
@@ -688,7 +689,15 @@ func (lr *LoadedRepo) getAdjacency() *adjacency {
 			lr.adjacency = &adjacency{}
 			return
 		}
-		lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)
+		// ADR-0027 Cutover PR1: source the build from the resident mmap Reader
+		// when present (byte-identical to the Document build — same rows, same
+		// order). Falls back to the Document only when no graph.fb is mapped
+		// (JSON-only load / Open failure). Not flag-gated.
+		if lr.Reader != nil {
+			lr.adjacency = buildAdjacencyFromReader(lr.Reader, lr.Repo)
+		} else {
+			lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)
+		}
 	})
 	return lr.adjacency
 }
@@ -705,7 +714,12 @@ func (lr *LoadedRepo) getCallsAdj() *callsAdjacency {
 			lr.callsAdj = &callsAdjacency{}
 			return
 		}
-		lr.callsAdj = buildCallsAdjacency(lr.Doc)
+		// ADR-0027 Cutover PR1: prefer the resident mmap Reader (see getAdjacency).
+		if lr.Reader != nil {
+			lr.callsAdj = buildCallsAdjacencyFromReader(lr.Reader)
+		} else {
+			lr.callsAdj = buildCallsAdjacency(lr.Doc)
+		}
 	})
 	return lr.callsAdj
 }
@@ -719,7 +733,12 @@ func (lr *LoadedRepo) getStepAdj() map[string][]stepEdge {
 			lr.stepAdj = map[string][]stepEdge{}
 			return
 		}
-		lr.stepAdj = buildStepAdjacency(lr.Doc)
+		// ADR-0027 Cutover PR1: prefer the resident mmap Reader (see getAdjacency).
+		if lr.Reader != nil {
+			lr.stepAdj = buildStepAdjacencyFromReader(lr.Reader)
+		} else {
+			lr.stepAdj = buildStepAdjacency(lr.Doc)
+		}
 	})
 	return lr.stepAdj
 }
@@ -731,7 +750,14 @@ func (lr *LoadedRepo) getTopKPageRank() []string {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.pagerankOnce.Do(func() {
-		lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
+		// ADR-0027 Cutover PR1: prefer the resident mmap Reader; PageRank is
+		// read from the FB Pagerank() scalar (interface-absent field). Falls
+		// back to the Document only when no graph.fb is mapped.
+		if lr.Reader != nil {
+			lr.topKPageRank = buildTopKPageRankFromReader(lr.Reader, 64)
+		} else {
+			lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
+		}
 	})
 	return lr.topKPageRank
 }
@@ -1090,16 +1116,6 @@ func (s *State) reloadLocked() (int, bool, error) {
 					// is built on first use by its getter and cached until the next
 					// reload re-arms the Once here (#3367, #3377).
 					lr.resetIndexes()
-					// TESTS-edge count cached once per reload so grafel_whoami can
-					// return it in O(1) without rescanning all relationships. This is a
-					// cheap O(R) count with no allocation, so it stays eager (#3325).
-					testsCount := 0
-					for i := range doc.Relationships {
-						if doc.Relationships[i].Kind == "TESTS" {
-							testsCount++
-						}
-					}
-					lr.TestsEdgeCount = testsCount
 					// S8 (#2159): open the mmap reader alongside the Document.
 					// Best-effort: failures leave Reader nil; callers fall back to
 					// doc.Entities / doc.Relationships.
@@ -1116,6 +1132,30 @@ func (s *State) reloadLocked() (int, bool, error) {
 					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
 						newRdr = rdr
 					}
+					// TESTS-edge count cached once per reload so grafel_whoami can
+					// return it in O(1) without rescanning all relationships. This is a
+					// cheap O(R) count with no allocation, so it stays eager (#3325).
+					//
+					// ADR-0027 Cutover PR1: count TESTS-kind edges off the freshly
+					// opened mmap Reader (Kind() read directly) rather than the
+					// materialized Document. Byte-neutral (Reader == Document's rows);
+					// falls back to doc.Relationships only when no graph.fb is mapped.
+					testsCount := 0
+					if newRdr != nil {
+						newRdr.IterateRelationships(func(rel *fb.Relationship) bool {
+							if string(rel.Kind()) == "TESTS" {
+								testsCount++
+							}
+							return true
+						})
+					} else {
+						for i := range doc.Relationships {
+							if doc.Relationships[i].Kind == "TESTS" {
+								testsCount++
+							}
+						}
+					}
+					lr.TestsEdgeCount = testsCount
 					lr.setReader(newRdr)
 					reloaded++
 				}
@@ -1476,6 +1516,41 @@ func buildTopKPageRank(doc *graph.Document, k int) []string {
 		}
 		all = append(all, ranked{id: e.ID, pr: pr})
 	}
+	sort.Slice(all, func(i, j int) bool {
+		return all[i].pr > all[j].pr
+	})
+	if k > len(all) {
+		k = len(all)
+	}
+	out := make([]string, k)
+	for i := 0; i < k; i++ {
+		out[i] = all[i].id
+	}
+	return out
+}
+
+// buildTopKPageRankFromReader is the mmap-sourced twin of buildTopKPageRank,
+// reading Id/Pagerank directly off the fbreader.Reader. PageRank is an
+// interface-absent field (no EntityView accessor), so it MUST come from the
+// FB Pagerank() scalar. loadFBDocument sets Entity.PageRank to nil when
+// Pagerank()==0, so the Document build's pr==0 for those rows exactly matches
+// reading Pagerank()==0 here — and identical (id, pr) pairs in identical
+// vector order make sort.Slice produce a byte-identical top-K. Byte-identical
+// to buildTopKPageRank (proven by TestTopKPageRankReaderParity_PR1).
+// ADR-0027 Cutover PR1.
+func buildTopKPageRankFromReader(r *fbreader.Reader, k int) []string {
+	if r == nil || r.EntityCount() == 0 {
+		return nil
+	}
+	type ranked struct {
+		id string
+		pr float64
+	}
+	all := make([]ranked, 0, r.EntityCount())
+	r.IterateEntities(func(e *fb.Entity) bool {
+		all = append(all, ranked{id: string(e.Id()), pr: e.Pagerank()})
+		return true
+	})
 	sort.Slice(all, func(i, j int) bool {
 		return all[i].pr > all[j].pr
 	})

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
 // adjacency is a per-repo precomputed neighbor index (#5852: CSR layout).
@@ -205,6 +207,46 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 		weights[i] = float32(edgeWeight(r))
 	}
 
+	a.assembleCSR(n, fromCodes, toCodes, kindCodes, weights)
+	return a
+}
+
+// buildAdjacencyFromReader is the mmap-sourced twin of buildAdjacency: it
+// reads FromId/ToId/Kind (and the count/weight properties feeding edgeWeight)
+// directly off the resident fbreader.Reader instead of a materialized
+// graph.Document, then runs the IDENTICAL CSR assembly (assembleCSR). Because
+// the Reader holds the same rows in the same vector order as
+// loadFBDocument produces for Document.Relationships, the resulting adjacency
+// is byte-identical to buildAdjacency's (proven by TestAdjacencyReaderParity_PR1).
+// ADR-0027 Cutover PR1: behavior-neutral re-sourcing of this primitive-only build.
+func buildAdjacencyFromReader(r *fbreader.Reader, repo string) *adjacency {
+	a := &adjacency{}
+	a.nodes.code = make(map[string]int32, r.EntityCount())
+	a.kinds.code = make(map[string]uint16, 32)
+
+	n := r.RelationshipCount()
+	fromCodes := make([]int32, 0, n)
+	toCodes := make([]int32, 0, n)
+	kindCodes := make([]uint16, 0, n)
+	weights := make([]float32, 0, n)
+	r.IterateRelationships(func(rel *fb.Relationship) bool {
+		fromCodes = append(fromCodes, a.nodes.intern(string(rel.FromId())))
+		toCodes = append(toCodes, a.nodes.intern(string(rel.ToId())))
+		kindCodes = append(kindCodes, a.kinds.intern(string(rel.Kind())))
+		weights = append(weights, float32(edgeWeightFB(rel)))
+		return true
+	})
+
+	a.assembleCSR(len(fromCodes), fromCodes, toCodes, kindCodes, weights)
+	return a
+}
+
+// assembleCSR builds the out/in CSR rows from the per-relationship code +
+// weight arrays. Shared by buildAdjacency (Document-sourced) and
+// buildAdjacencyFromReader (Reader-sourced) so the CSR layout can never
+// diverge between the two paths — parity reduces to the collection loop
+// (#5852 two-pass scatter; see buildAdjacency doc).
+func (a *adjacency) assembleCSR(n int, fromCodes, toCodes []int32, kindCodes []uint16, weights []float32) {
 	numNodes := len(a.nodes.ids)
 	outDeg := make([]int32, numNodes)
 	inDeg := make([]int32, numNodes)
@@ -235,8 +277,39 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 		a.in.weight[ip] = w
 		a.in.relIdx[ip] = int32(i)
 	}
+}
 
-	return a
+// fbRelProp returns the value of relationship property key (and whether it
+// was present), reading directly off the mmap'd PropertyEntry vector. The
+// vector is written key-sorted by fbwriter and has unique keys, so a linear
+// scan returning the first key match is equivalent to graph.Relationship's
+// binary-search PropLookup. The returned string is copied out of the mmap.
+func fbRelProp(rel *fb.Relationship, key string) (string, bool) {
+	n := rel.PropertiesLength()
+	var pe fb.PropertyEntry
+	for i := 0; i < n; i++ {
+		if rel.Properties(&pe, i) && string(pe.Key()) == key {
+			return string(pe.Value()), true
+		}
+	}
+	return "", false
+}
+
+// edgeWeightFB is the fb.Relationship twin of edgeWeight: same "count" then
+// "weight" precedence, same <=0 / unparseable fallback to 1.0, reading the
+// properties off the mmap instead of a materialized graph.Relationship.
+func edgeWeightFB(rel *fb.Relationship) float64 {
+	if rel.PropertiesLength() == 0 {
+		return 1.0
+	}
+	for _, key := range []string{"count", "weight"} {
+		if v, ok := fbRelProp(rel, key); ok && v != "" {
+			if n, err := strconv.ParseFloat(v, 64); err == nil && n > 0 {
+				return n
+			}
+		}
+	}
+	return 1.0
 }
 
 // newCSRDir allocates a csrDir's row backing given per-node degree counts and
@@ -302,6 +375,29 @@ func buildStepAdjacency(doc *graph.Document) map[string][]stepEdge {
 		n, _ := strconv.Atoi(idxStr)
 		adj[r.FromID] = append(adj[r.FromID], stepEdge{toID: r.ToID, idx: n})
 	}
+	return adj
+}
+
+// buildStepAdjacencyFromReader is the mmap-sourced twin of buildStepAdjacency,
+// reading Kind/FromId/ToId and the step_index property directly off the
+// fbreader.Reader. Byte-identical to the Document-sourced build (same edge
+// order per FromID key; proven by TestStepAdjacencyReaderParity_PR1).
+// ADR-0027 Cutover PR1.
+func buildStepAdjacencyFromReader(r *fbreader.Reader) map[string][]stepEdge {
+	adj := make(map[string][]stepEdge)
+	r.IterateRelationships(func(rel *fb.Relationship) bool {
+		if string(rel.Kind()) != stepInProcessEdge {
+			return true
+		}
+		idxStr := ""
+		if v, ok := fbRelProp(rel, "step_index"); ok {
+			idxStr = v
+		}
+		n, _ := strconv.Atoi(idxStr)
+		from := string(rel.FromId())
+		adj[from] = append(adj[from], stepEdge{toID: string(rel.ToId()), idx: n})
+		return true
+	})
 	return adj
 }
 
@@ -372,6 +468,39 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		toCodes = append(toCodes, c.nodes.intern(r.ToID))
 	}
 
+	c.assembleCSR(fromCodes, toCodes)
+	return c
+}
+
+// buildCallsAdjacencyFromReader is the mmap-sourced twin of
+// buildCallsAdjacency, reading Kind/FromId/ToId directly off the
+// fbreader.Reader and running the IDENTICAL CSR assembly + per-row sort
+// (assembleCSR). Byte-identical to the Document-sourced build (proven by
+// TestCallsAdjacencyReaderParity_PR1). ADR-0027 Cutover PR1.
+func buildCallsAdjacencyFromReader(r *fbreader.Reader) *callsAdjacency {
+	c := &callsAdjacency{}
+	c.nodes.code = make(map[string]int32)
+
+	fromCodes := make([]int32, 0, r.RelationshipCount())
+	toCodes := make([]int32, 0, r.RelationshipCount())
+	r.IterateRelationships(func(rel *fb.Relationship) bool {
+		if string(rel.Kind()) != "CALLS" {
+			return true
+		}
+		fromCodes = append(fromCodes, c.nodes.intern(string(rel.FromId())))
+		toCodes = append(toCodes, c.nodes.intern(string(rel.ToId())))
+		return true
+	})
+
+	c.assembleCSR(fromCodes, toCodes)
+	return c
+}
+
+// assembleCSR builds the CALLS forward CSR rows from the per-edge from/to code
+// arrays and sorts each row by callee id. Shared by buildCallsAdjacency
+// (Document-sourced) and buildCallsAdjacencyFromReader (Reader-sourced) so the
+// two paths cannot diverge — parity reduces to the collection loop.
+func (c *callsAdjacency) assembleCSR(fromCodes, toCodes []int32) {
 	numNodes := len(c.nodes.ids)
 	numEdges := len(fromCodes)
 	deg := make([]int32, numNodes)
@@ -400,7 +529,6 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 
 	c.offsets = offsets
 	c.targets = targets
-	return c
 }
 
 // sortInt32ByStringID is an insertion sort of node-index codes by the string


### PR DESCRIPTION
Refs #5850 (mmap cutover, PR1/8). Behavior-neutral, additive. Removes the primitive-only serve index builds' dependence on the materialized `graph.Document` ahead of the loader flip (PR7).

## What
- **Exported per-row materializers** (`internal/graph/load.go`, thin wrappers over `fbEntityToGraphEntity`/`fbRelToGraphRel`, fresh interner per call, all strings COPIED out of mmap → heap-safe, zero-value on nil/OOB):
  - `func MaterializeEntity(r *fbreader.Reader, i int) Entity`
  - `func MaterializeRelationship(r *fbreader.Reader, i int) Relationship`
- **5 index builds re-sourced to the already-resident `lr.Reader`** (unconditional, nil-Reader → Document fallback for JSON/open-failure; NOT flag-gated — behavior-neutral because the Reader holds the same data as the Document):

| Build | Reader-sourced fn | Parity test |
|---|---|---|
| in/out adjacency | `buildAdjacencyFromReader` | `TestAdjacencyReaderParity_PR1` |
| CALLS adjacency | `buildCallsAdjacencyFromReader` | `TestCallsAdjacencyReaderParity_PR1` |
| STEP_IN_PROCESS adjacency | `buildStepAdjacencyFromReader` | `TestStepAdjacencyReaderParity_PR1` |
| top-K PageRank | `buildTopKPageRankFromReader` (reads `Id()`/`Pagerank()`) | `TestTopKPageRankReaderParity_PR1` |
| TESTS-edge count | inline `IterateRelationships` reading `Kind()` | `TestTestsEdgeCountReaderParity_PR1` |

Shared `assembleCSR` tail extracted so the Document and Reader paths cannot diverge in CSR layout; the Document-sourced functions stay byte-identical to origin/main and remain the nil-Reader fallback + parity baseline. `fbRelProp`/`edgeWeightFB` mirror `edgeWeight`'s count→weight precedence off the mmap.

## Tests
Per-build Reader-vs-Document parity (byte-identical CSR/results over a real `graph.fb`); materializer byte-equality (`TestMaterializeEntityByteEqualsDocument_PR1`, `…Relationship…`, `TestMaterializeOutOfRange_PR1`).

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` → 1394 passed / 10 packages. No fbversion bump. Does not touch FuseRRF/LabelIndex/getByID/BM25/loader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o