### PR TITLE
fix(mcp): TopKPageRank must read overlaid Doc PageRank, not the graph.fb sentinel (regression from #5865)

### DIFF
--- a/internal/mcp/reader_index_parity_pr1_test.go
+++ b/internal/mcp/reader_index_parity_pr1_test.go
@@ -123,6 +123,15 @@ func TestStepAdjacencyReaderParity_PR1(t *testing.T) {
 	}
 }
 
+// TestTopKPageRankReaderParity_PR1 proves buildTopKPageRankFromReader is
+// byte-identical to buildTopKPageRank for whatever PageRank values are baked
+// directly into this fixture's graph.fb — it does NOT prove production
+// parity, because getTopKPageRank no longer calls the Reader-sourced builder
+// (see buildTopKPageRankFromReader's doc comment and the post-PR1 regression
+// fix in getTopKPageRank / state.go). In production the FB Pagerank() scalar
+// is a permanent sentinel; real PageRank only ever reaches lr.Doc via the
+// group-algo overlay. TestGetTopKPageRank_OverlayOrder_NotReaderSentinel
+// (topk_pagerank_overlay_test.go) covers that overlay-aware production path.
 func TestTopKPageRankReaderParity_PR1(t *testing.T) {
 	t.Parallel()
 	doc, r := loadParityIndexFixture(t)

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -750,14 +750,21 @@ func (lr *LoadedRepo) getTopKPageRank() []string {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.pagerankOnce.Do(func() {
-		// ADR-0027 Cutover PR1: prefer the resident mmap Reader; PageRank is
-		// read from the FB Pagerank() scalar (interface-absent field). Falls
-		// back to the Document only when no graph.fb is mapped.
-		if lr.Reader != nil {
-			lr.topKPageRank = buildTopKPageRankFromReader(lr.Reader, 64)
-		} else {
-			lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
-		}
+		// ALWAYS source from lr.Doc, never the Reader/mmap. Per-repo Pass-4 (the
+		// per-repo PageRank/CommunityID/Centrality/god/articulation compute) was
+		// removed when the group-scope algo pass (A1-A3, #5349) replaced it, so
+		// graph.fb's Pagerank() scalar is now a PERMANENT sentinel (0) for every
+		// entity — it is never populated by the indexer. The one authoritative
+		// source of real PageRank is applyGroupAlgoOverlay, which stamps the
+		// <group>-algo.json overlay onto lr.Doc.Entities[i].PageRank IN PLACE
+		// (state.go) — it never touches the mmap'd graph.fb bytes the Reader
+		// serves. Reading PageRank off the Reader (buildTopKPageRankFromReader)
+		// therefore always sees the sentinel and collapses top-K to id order,
+		// which silently corrupts pickFallback's entity choice (regression
+		// introduced by ADR-0027 Cutover PR1, #5865 — fixed here). See
+		// buildTopKPageRankFromReader's doc comment for why that function is
+		// kept but no longer called from here.
+		lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
 	})
 	return lr.topKPageRank
 }
@@ -1530,13 +1537,29 @@ func buildTopKPageRank(doc *graph.Document, k int) []string {
 }
 
 // buildTopKPageRankFromReader is the mmap-sourced twin of buildTopKPageRank,
-// reading Id/Pagerank directly off the fbreader.Reader. PageRank is an
-// interface-absent field (no EntityView accessor), so it MUST come from the
-// FB Pagerank() scalar. loadFBDocument sets Entity.PageRank to nil when
-// Pagerank()==0, so the Document build's pr==0 for those rows exactly matches
-// reading Pagerank()==0 here — and identical (id, pr) pairs in identical
-// vector order make sort.Slice produce a byte-identical top-K. Byte-identical
-// to buildTopKPageRank (proven by TestTopKPageRankReaderParity_PR1).
+// reading Id/Pagerank directly off the fbreader.Reader.
+//
+// BLOCKED — NOT CALLED (post-PR1 regression fix, see getTopKPageRank): the FB
+// Pagerank() scalar this reads is a permanent sentinel (0) for every entity.
+// Per-repo Pass-4 (the code that used to compute + persist real per-entity
+// PageRank into graph.fb) was removed when the group-scope algo pass (A1-A3,
+// #5349) replaced it. The only place real PageRank now lives is the
+// <group>-algo.json overlay, which applyGroupAlgoOverlay stamps onto
+// lr.Doc.Entities[i].PageRank in memory — it is never written back into
+// graph.fb, so the Reader can never see it. Calling this from
+// getTopKPageRank silently collapsed top-K to id order and corrupted
+// pickFallback's entity choice; that regression is why getTopKPageRank now
+// always sources from lr.Doc via buildTopKPageRank instead.
+//
+// This function is kept — with TestTopKPageRankReaderParity_PR1 still
+// exercising it — because it correctly proves byte-identical top-K
+// extraction logic between the Reader path and the Document path for
+// whatever PageRank values are actually baked into a given graph.fb (the
+// parity test writes real values directly into its fixture, bypassing the
+// production sentinel). A follow-up PR can re-enable calling this once a
+// side-table lets the overlay's real PageRank reach the Reader seam (the
+// overlay's per-entity map keyed by ID, applied at Reader-borrow time rather
+// than only onto lr.Doc), at which point this comment should be replaced.
 // ADR-0027 Cutover PR1.
 func buildTopKPageRankFromReader(r *fbreader.Reader, k int) []string {
 	if r == nil || r.EntityCount() == 0 {

--- a/internal/mcp/topk_pagerank_overlay_test.go
+++ b/internal/mcp/topk_pagerank_overlay_test.go
@@ -1,0 +1,184 @@
+package mcp
+
+// topk_pagerank_overlay_test.go — overlay-aware regression test for the
+// getTopKPageRank live bug introduced by ADR-0027 Cutover PR1 (#5865).
+//
+// Per-repo Pass-4 (the code that used to compute + persist real per-entity
+// PageRank into graph.fb) was removed when the group-scope algo pass
+// (A1-A3, #5349) replaced it. graph.fb's PageRank/CommunityID/Centrality/
+// god/articulation fields are now PERMANENT SENTINELS — never populated by
+// the indexer. The one authoritative source of real PageRank is the
+// <group>-algo.json overlay, which applyGroupAlgoOverlay (state.go) stamps
+// onto lr.Doc.Entities[i] IN PLACE at load. It never touches the mmap'd
+// graph.fb bytes the Reader serves.
+//
+// PR1 re-sourced getTopKPageRank to read lr.Reader's Pagerank() scalar
+// whenever a Reader is present — which is always true for a live-indexed
+// repo. Since that scalar is a permanent sentinel (0), top-K collapsed to
+// id order, silently handing pickFallback the wrong entity. The Document-
+// sourced parity test PR1 shipped with (TestTopKPageRankReaderParity_PR1)
+// missed this because its fixture bakes real PageRank directly into
+// graph.fb via fbwriter — bypassing the sentinel entirely, so both sides
+// read the same (non-zero) values and parity trivially holds.
+//
+// This test instead reproduces the REAL production shape: a graph.fb with
+// sentinel (zero) PageRank for every entity, PLUS a Doc-only overlay stamp
+// (the applyGroupAlgoOverlay data path) that sets distinct real PageRank
+// values on lr.Doc.Entities. It asserts getTopKPageRank returns entities in
+// overlay-PageRank order — which is only possible when the Doc, not the
+// Reader, is the source of truth.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// overlayAwareTopKDoc returns a Document whose entities all carry a nil
+// PageRank (graph.fb's sentinel shape post-Pass-4-removal): none of them are
+// algo-annotated, mirroring what a freshly-indexed repo looks like today.
+func overlayAwareTopKDoc() *graph.Document {
+	mk := func(id, name string) graph.Entity {
+		return graph.Entity{
+			ID: id, Name: name, QualifiedName: "pkg." + name, Kind: "FUNCTION",
+			SourceFile: "pkg/" + name + ".go", Language: "go", PageRank: nil,
+		}
+	}
+	return &graph.Document{
+		Entities: []graph.Entity{
+			mk("id::alpha", "Alpha"),
+			mk("id::bravo", "Bravo"),
+			mk("id::charlie", "Charlie"),
+			mk("id::delta", "Delta"),
+			mk("id::echo", "Echo"),
+		},
+	}
+}
+
+// buildOverlayAwareLoadedRepo writes overlayAwareTopKDoc() to a real graph.fb
+// (sentinel PageRank throughout, exactly as a live-indexed repo's fb would be
+// post-Pass-4-removal), loads it back into a Document AND opens an mmap
+// Reader over the same bytes (both sentinel), then applies the
+// applyGroupAlgoOverlay DATA PATH — the exact field-stamp
+// (`ents[i].PageRank = &pr`) that function performs — directly onto the
+// loaded Doc's entities with distinct, non-sentinel values. The Reader is
+// left untouched (as production always leaves it): it keeps serving the
+// sentinel graph.fb bytes.
+func buildOverlayAwareLoadedRepo(t *testing.T) *LoadedRepo {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, overlayAwareTopKDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	// Sanity: confirm the freshly loaded Doc really does carry the sentinel
+	// shape (PageRank nil for every entity) before we overlay-stamp it — this
+	// pins the precondition the whole test depends on.
+	for i := range doc.Entities {
+		if doc.Entities[i].PageRank != nil {
+			t.Fatalf("precondition: entity %s has non-nil PageRank before overlay stamp: %v",
+				doc.Entities[i].ID, *doc.Entities[i].PageRank)
+		}
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+
+	// applyGroupAlgoOverlay's data path: stamp distinct PageRank pointers onto
+	// lr.Doc.Entities[i] by ID, exactly as the <group>-algo.json overlay apply
+	// loop does (state.go applyGroupAlgoOverlay). Deliberately distinct,
+	// strictly descending values so top-K order is unambiguous. "id::echo" is
+	// left un-stamped (stays at the graph.fb sentinel) to mirror an entity the
+	// group-algo pass never covered.
+	overlay := map[string]float64{
+		"id::charlie": 0.9,
+		"id::alpha":   0.5,
+		"id::delta":   0.2,
+		"id::bravo":   0.05,
+	}
+	for i := range doc.Entities {
+		pr, ok := overlay[doc.Entities[i].ID]
+		if !ok {
+			continue
+		}
+		v := pr
+		doc.Entities[i].PageRank = &v
+	}
+
+	return &LoadedRepo{Repo: "repo", Doc: doc, Reader: r}
+}
+
+// TestGetTopKPageRank_OverlayOrder_NotReaderSentinel is the regression test
+// for the ADR-0027 Cutover PR1 live bug (#5865): getTopKPageRank must return
+// entities in the OVERLAY-stamped PageRank order (Doc-sourced), not
+// id/sentinel order (which is what a Reader-sourced build produces because
+// the FB Pagerank() scalar is a permanent sentinel).
+//
+// This test FAILS against the pre-fix getTopKPageRank (which prefers
+// buildTopKPageRankFromReader whenever lr.Reader != nil): every entity's FB
+// Pagerank() scalar is 0, so the Reader-sourced top-K collapses to
+// insertion/id order (alpha, bravo, charlie, delta, echo) instead of the
+// overlay order (charlie, alpha, delta, bravo, ...).
+func TestGetTopKPageRank_OverlayOrder_NotReaderSentinel(t *testing.T) {
+	lr := buildOverlayAwareLoadedRepo(t)
+
+	got := lr.getTopKPageRank()
+
+	want := []string{"id::charlie", "id::alpha", "id::delta", "id::bravo"}
+	if len(got) < len(want) {
+		t.Fatalf("getTopKPageRank returned too few entities: got %v, want at least %v", got, want)
+	}
+	for i, id := range want {
+		if got[i] != id {
+			t.Fatalf("getTopKPageRank()[%d] = %q, want %q (overlay-PageRank order)\nfull got=%v",
+				i, got[i], id, got)
+		}
+	}
+
+	// The un-stamped entity (id::echo, still at the graph.fb sentinel) must
+	// rank below every overlay-stamped entity.
+	echoPos, wantPos := -1, -1
+	for i, id := range got {
+		if id == "id::echo" {
+			echoPos = i
+		}
+		if id == "id::delta" {
+			wantPos = i
+		}
+	}
+	if echoPos == -1 || wantPos == -1 || echoPos < wantPos {
+		t.Fatalf("expected id::echo (un-stamped sentinel) to rank below id::delta (overlay-stamped); got=%v", got)
+	}
+}
+
+// TestGetTopKPageRank_OverlayOrder_ReaderSourcedWouldBeWrong documents (via a
+// direct comparison, not a getTopKPageRank call) exactly why
+// buildTopKPageRankFromReader must not be used here: reading the same
+// graph.fb's Pagerank() scalar sees only the sentinel and cannot reproduce
+// the overlay order the Doc-sourced build correctly returns.
+func TestGetTopKPageRank_OverlayOrder_ReaderSourcedWouldBeWrong(t *testing.T) {
+	lr := buildOverlayAwareLoadedRepo(t)
+
+	docOrder := buildTopKPageRank(lr.Doc, 64)
+	readerOrder := buildTopKPageRankFromReader(lr.Reader, 64)
+
+	if len(docOrder) == 0 || len(readerOrder) == 0 {
+		t.Fatalf("expected non-empty top-K on both sides: doc=%v reader=%v", docOrder, readerOrder)
+	}
+	if docOrder[0] != "id::charlie" {
+		t.Fatalf("Doc-sourced top-1 = %q, want id::charlie (overlay PageRank 0.9)", docOrder[0])
+	}
+	if readerOrder[0] == "id::charlie" {
+		t.Fatalf("Reader-sourced top-1 unexpectedly matched the overlay winner (id::charlie); " +
+			"this fixture is supposed to prove the Reader CANNOT see the overlay (sentinel-only fb)")
+	}
+}


### PR DESCRIPTION
Refs #5850. Fixes a LIVE regression introduced by cutover PR1 (#5865), independent of `GRAFEL_SERVE_FROM_MMAP`.

## Bug
PR1 made `getTopKPageRank` prefer `buildTopKPageRankFromReader`, reading `e.Pagerank()` off the mmap Reader. But per-repo Pass-4 was removed (A1-A3, #5349), so **graph.fb's PageRank is a permanent sentinel (0)** for every entity. Real PageRank only lands on `lr.Doc.Entities[i]` via `applyGroupAlgoOverlay` (from `<group>-algo.json`, never in the mmap). So top-K collapsed to id-order in production, corrupting `pickFallback`. PR1's parity test missed it — its fixture baked real PageRank into the fb (no sentinel/overlay), so both sides trivially agreed.

## Fix
`getTopKPageRank` now unconditionally uses `buildTopKPageRank(lr.Doc, 64)` (the overlaid Doc has the real values). The adjacency / calls-adj / step-adj / TESTS-edge Reader-sourced builds from PR1 are **untouched** — they read real `FromId`/`ToId`/`Kind` fb data, not sentinel algo fields. `buildTopKPageRankFromReader` is kept but marked BLOCKED/not-called until a future overlay side-table lets the overlay reach the Reader seam (the PR7 flip precondition).

## Test (the overlay-aware oracle PR1 lacked)
`TestGetTopKPageRank_OverlayOrder_NotReaderSentinel` — real `graph.fb` with sentinel PageRank, loads Doc + Reader, stamps distinct PageRank onto `Doc.Entities` (mirroring `applyGroupAlgoOverlay`), asserts overlay order. **Mutation-proven**: FAILS on the old Reader-sourced path (`got id::alpha, want id::charlie` — id order) and passes on the fix. Plus `TestGetTopKPageRank_OverlayOrder_ReaderSourcedWouldBeWrong` contrasting the two builders.

## Gate
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` green (10 packages). No fbversion bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o