### PR TITLE
feat(mcp): cutover PR2 — LabelIndex holds int32 indices + materialize-on-hit + retained-pointer audit (ADR-0027)

### DIFF
--- a/internal/mcp/control_flow_tool.go
+++ b/internal/mcp/control_flow_tool.go
@@ -98,7 +98,7 @@ func (s *Server) handleControlFlow(_ context.Context, req mcpapi.CallToolRequest
 func resolveFunctionEntity(lg *LoadedGroup, repos []*LoadedRepo, key string) (*LoadedRepo, *graph.Entity, map[string]any, bool) {
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
-			if ent, ok := r.LabelIndex.ByID[local]; ok {
+			if ent := r.LabelIndex.ByID(local); ent != nil {
 				return r, ent, nil, true
 			}
 		}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -1077,7 +1077,7 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 	canonicalize := func(s string) string {
 		if rPref, lid := splitPrefixed(s); rPref != "" {
 			if slug, r := lookupRepo(aliases, rPref); r != nil {
-				if _, ok := r.LabelIndex.ByID[lid]; ok {
+				if r.LabelIndex.HasID(lid) {
 					return prefixedID(slug, lid)
 				}
 				// id may be a label/qname within this repo
@@ -1218,7 +1218,7 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 		}
 		st := step{EntityID: pid, Repo: slug}
 		if r != nil && r.Doc != nil {
-			if e := r.LabelIndex.ByID[local]; e != nil {
+			if e := r.LabelIndex.ByID(local); e != nil {
 				st.Name = e.Name
 				st.Kind = e.Kind
 			}

--- a/internal/mcp/effects_tool.go
+++ b/internal/mcp/effects_tool.go
@@ -135,7 +135,7 @@ func (s *Server) handleEffects(_ context.Context, req mcpapi.CallToolRequest) (*
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
-			if e, ok := r.LabelIndex.ByID[local]; ok {
+			if e := r.LabelIndex.ByID(local); e != nil {
 				out := buildEffectsPayload(r.Repo, e, sidecar)
 				attachBranchesFacet(out, r, e, wantBranches)
 				attachEffectContextsFacet(out, r, e, wantEffectCtx)

--- a/internal/mcp/endpoint_posture.go
+++ b/internal/mcp/endpoint_posture.go
@@ -131,7 +131,7 @@ func (s *Server) handleEndpointPosture(_ context.Context, req mcpapi.CallToolReq
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
-			if e, ok := r.LabelIndex.ByID[local]; ok {
+			if e := r.LabelIndex.ByID(local); e != nil {
 				return jsonResult(buildPosturePayload(r, e)), nil
 			}
 		}

--- a/internal/mcp/enrichment.go
+++ b/internal/mcp/enrichment.go
@@ -46,15 +46,32 @@ func readResolutions(repoPath string) []EnrichmentResolution {
 
 // applyResolutions merges resolutions into entity Properties (non-destructive,
 // resolution-side wins). Used by tools that need post-enrichment views.
+//
+// ADR-0027 Cutover PR2: this MUTATES entities in place, so it must resolve the
+// id against the authoritative Doc.Entities slice (a stable, addressable
+// pointer), NOT via LabelIndex.ByID — which now materializes a throwaway heap
+// copy per lookup, so a PropSet through it would be lost. Building a one-shot
+// id→index over Doc keeps the write-through semantics intact and independent of
+// the (now pointer-unstable) index. (This helper currently has no callers; the
+// retarget keeps it correct for when one is wired.)
 func applyResolutions(repoPath string, lr *LoadedRepo) {
 	if lr == nil || lr.Doc == nil {
 		return
 	}
-	for _, r := range readResolutions(repoPath) {
-		e, ok := lr.LabelIndex.ByID[r.NodeID]
+	res := readResolutions(repoPath)
+	if len(res) == 0 {
+		return
+	}
+	pos := make(map[string]int, len(lr.Doc.Entities))
+	for i := range lr.Doc.Entities {
+		pos[lr.Doc.Entities[i].ID] = i
+	}
+	for _, r := range res {
+		i, ok := pos[r.NodeID]
 		if !ok {
 			continue
 		}
+		e := &lr.Doc.Entities[i]
 		if e.PropLen() == 0 {
 			e.PropsReplace(map[string]string{})
 		}

--- a/internal/mcp/get_source_resolve.go
+++ b/internal/mcp/get_source_resolve.go
@@ -82,7 +82,7 @@ func resolveSourceEntity(lg *LoadedGroup, nodeID string) sourceResolution {
 	// same-named entity.
 	if rp != "" {
 		if r, ok := lg.Repos[rp]; ok && r.Doc != nil && r.LabelIndex != nil {
-			if e := r.LabelIndex.ByID[local]; e != nil {
+			if e := r.LabelIndex.ByID(local); e != nil {
 				return sourceResolution{entity: e, repo: r}
 			}
 			for _, key := range keys {
@@ -138,9 +138,15 @@ func ambiguousFrom(hits []*graph.Entity, r *LoadedRepo) sourceResolution {
 	return sourceResolution{ambiguous: cands}
 }
 
+// appendUniqueCandidate appends c unless an equivalent candidate is already
+// present. Equivalence is keyed by (repo, entity ID), NOT by *graph.Entity
+// pointer identity: ADR-0027 Cutover PR2 made LabelIndex.LookupAll materialize
+// a fresh copy per hit, so the same entity resolved via two candidate keys now
+// yields two DISTINCT pointers. Dedup by ID keeps a single logical match from
+// being mis-reported as ambiguous (PR2 retained-pointer audit fix).
 func appendUniqueCandidate(cands []sourceCandidate, c sourceCandidate) []sourceCandidate {
 	for _, x := range cands {
-		if x.ent == c.ent {
+		if x.repo == c.repo && x.ent.ID == c.ent.ID {
 			return cands
 		}
 	}

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
 // LabelIndex is an inverted index for O(1) lookups by:
@@ -12,11 +14,38 @@ import (
 //   - exact label (lowercased)
 //   - exact qualified-name (lowercased)
 //
-// All maps point into the underlying Document.Entities slice — never copy.
+// ADR-0027 Cutover PR2: the index holds ENTITY INDICES (int32 positions in the
+// graph.fb / Document entity vector) — NOT *graph.Entity pointers ALIASING
+// Document.Entities. A lookup MATERIALIZES a fresh heap-copy graph.Entity on
+// each hit, so the index no longer PINS live pointers into the Document backing
+// array. Two lookups of the same id therefore return DIFFERENT pointers.
+//
+// POINTER INSTABILITY (audit-critical for PR7): consumers MUST NOT compare
+// returned pointers by identity, use them as a map key, or cache one across
+// calls expecting stability — dedup by entity ID instead. FuseRRF's
+// pointer-identity was fixed in #5864; the PR2 audit swept the remaining
+// consumers (get_source_resolve.appendUniqueCandidate + enrichment.applyResolutions).
+//
+// Value-materialization SOURCE — deliberately the live Document, not the mmap
+// Reader (see the PR2 report): applyGroupAlgoOverlay stamps
+// CommunityID/PageRank/Centrality/god/articulation onto Doc.Entities IN PLACE
+// after load (the values live in the <group>-algo.json overlay, NOT in
+// graph.fb). Materializing values from the Reader would silently drop those
+// stamps — a behavior regression (TestApplyOverlay_ReStampsReparsedMobileRepo).
+// So at() copies the LIVE Doc row, keeping PR2 byte-identical/behavior-neutral.
+// The int32 index MAP is still built Reader-first (BuildLabelIndexFromReader),
+// proving the index no longer needs Doc.Entities to be *constructed*; flipping
+// the value source to the Reader is a PR7 concern gated on re-plumbing the
+// overlay off the in-place Doc mutation.
 type LabelIndex struct {
-	ByID    map[string]*graph.Entity
-	ByLabel map[string][]*graph.Entity
-	ByQName map[string]*graph.Entity
+	// doc is the value-materialization source: at() copies doc.Entities[idx].
+	// It is the LIVE per-repo Document, so lookups observe post-load in-place
+	// overlay stamps (behavior-neutral, see the type doc).
+	doc *graph.Document
+
+	byID    map[string]int32
+	byLabel map[string][]int32
+	byQName map[string]int32
 }
 
 // keyInterner canonicalizes repeated map-key strings built during a single
@@ -25,7 +54,7 @@ type LabelIndex struct {
 // entities sharing an equal lowercased Name/QualifiedName (extremely common —
 // "Get", "String", "Equals", "New", accessor/overload names repeat across
 // hundreds of classes on the real corpus) share ONE backing array for that
-// key string instead of each ByLabel/ByQName insertion paying for its own
+// key string instead of each byLabel/byQName insertion paying for its own
 // independently-allocated strings.ToLower() copy.
 //
 // strings.ToLower already returns the ORIGINAL string (no allocation, shared
@@ -33,13 +62,13 @@ type LabelIndex struct {
 // interner only ever pays for a map probe on that fast path; it earns its
 // keep exactly on the case-folding path, where ToLower must allocate a fresh
 // copy that would otherwise duplicate across every entity with the same
-// label. One interner instance is shared across BOTH ByLabel and ByQName
+// label. One interner instance is shared across BOTH byLabel and byQName
 // keys (mirroring Tier-1b's single from_id/to_id/id interner) so a label and
 // a qualified name that happen to lowercase to the same text also share
 // storage.
 //
-// Built and discarded within a single BuildLabelIndex call; not retained on
-// LabelIndex, so it adds no resident cost of its own beyond its own build.
+// Built and discarded within a single build call; not retained on LabelIndex,
+// so it adds no resident cost of its own beyond its own build.
 type keyInterner struct {
 	m map[string]string
 }
@@ -57,56 +86,164 @@ func (ki *keyInterner) intern(s string) string {
 	return s
 }
 
-// BuildLabelIndex constructs a fresh LabelIndex from a graph document.
-func BuildLabelIndex(doc *graph.Document) *LabelIndex {
-	idx := &LabelIndex{
-		ByID:    make(map[string]*graph.Entity, len(doc.Entities)),
-		ByLabel: make(map[string][]*graph.Entity, len(doc.Entities)),
-		ByQName: make(map[string]*graph.Entity, len(doc.Entities)),
+// newLabelIndex allocates an empty index sized for n entities plus its shared
+// key interner. Both build paths funnel through add() so the keying
+// (lowercased label with ambiguity list; last-write-wins lowercased qname
+// skipped when empty) can never diverge between the Reader- and
+// Document-sourced builds.
+func newLabelIndex(n int) (*LabelIndex, *keyInterner) {
+	if n < 0 {
+		n = 0
 	}
-	var ki keyInterner
+	return &LabelIndex{
+		byID:    make(map[string]int32, n),
+		byLabel: make(map[string][]int32, n),
+		byQName: make(map[string]int32, n),
+	}, &keyInterner{}
+}
+
+// add records the i-th entity's (id, name, qname) into the index maps. Keying
+// mirrors the pre-PR2 pointer build exactly: byID by raw id, byLabel by
+// lowercased name (appended → ambiguity list in vector order), byQName by
+// lowercased qname (last-write-wins, skipped when empty).
+func (l *LabelIndex) add(ki *keyInterner, i int32, id, name, qname string) {
+	l.byID[id] = i
+	lbl := ki.intern(strings.ToLower(name))
+	l.byLabel[lbl] = append(l.byLabel[lbl], i)
+	if qname != "" {
+		l.byQName[ki.intern(strings.ToLower(qname))] = i
+	}
+}
+
+// BuildLabelIndex constructs a fresh Document-sourced LabelIndex. Lookups
+// materialize a heap copy out of doc.Entities. This is the nil-Reader fallback
+// (JSON-only load / no graph.fb) and the parity baseline for the Reader-sourced
+// build.
+func BuildLabelIndex(doc *graph.Document) *LabelIndex {
+	idx, ki := newLabelIndex(len(doc.Entities))
+	idx.doc = doc
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
-		idx.ByID[e.ID] = e
-		lbl := ki.intern(strings.ToLower(e.Name))
-		idx.ByLabel[lbl] = append(idx.ByLabel[lbl], e)
-		if e.QualifiedName != "" {
-			idx.ByQName[ki.intern(strings.ToLower(e.QualifiedName))] = e
-		}
+		idx.add(ki, int32(i), e.ID, e.Name, e.QualifiedName)
 	}
 	return idx
 }
 
+// BuildLabelIndexFromReader constructs a fresh LabelIndex whose int32 index
+// maps are built by iterating the resident mmap Reader (ADR-0027 Cutover PR2) —
+// reading Id/Name/QualifiedName off each fb.Entity in vector order, the SAME
+// order the Document loader produces. This proves the index can be CONSTRUCTED
+// without touching Doc.Entities. The int32 maps are byte-identical to
+// BuildLabelIndex(doc) over the same graph.fb (TestLabelIndex*ReaderParity_PR2).
+//
+// doc is retained as the value-materialization source (at() copies from it) so
+// lookups stay behavior-neutral against in-place overlay stamps — see the
+// LabelIndex type doc for why values are NOT read back from the Reader in PR2.
+func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIndex {
+	idx, ki := newLabelIndex(r.EntityCount())
+	idx.doc = doc
+	var i int32
+	r.IterateEntities(func(e *fb.Entity) bool {
+		idx.add(ki, i, string(e.Id()), string(e.Name()), string(e.QualifiedName()))
+		i++
+		return true
+	})
+	return idx
+}
+
+// at materializes a fresh heap-copy entity for the given vector index by copying
+// the LIVE doc.Entities[idx] row. Each call returns a DISTINCT pointer (see the
+// LabelIndex pointer-instability contract). Only ever called with an index that
+// came from one of the maps, so the bounds/nil guards are defensive.
+func (l *LabelIndex) at(idx int32) *graph.Entity {
+	if l == nil || l.doc == nil || idx < 0 || int(idx) >= len(l.doc.Entities) {
+		return nil
+	}
+	e := l.doc.Entities[idx] // heap copy — a fresh pointer, not an alias into Doc
+	return &e
+}
+
+// ByID returns a freshly materialized entity for the exact id, or nil when the
+// id is unknown. Replaces the pre-PR2 `LabelIndex.ByID[id]` map access; the
+// returned pointer is NOT stable across calls (see the pointer-instability
+// contract). Use HasID for a presence check that avoids materializing.
+func (l *LabelIndex) ByID(id string) *graph.Entity {
+	if l == nil {
+		return nil
+	}
+	idx, ok := l.byID[id]
+	if !ok {
+		return nil
+	}
+	return l.at(idx)
+}
+
+// HasID reports whether the exact id is present WITHOUT materializing the
+// entity — the presence-check replacement for `_, ok := LabelIndex.ByID[id]`.
+func (l *LabelIndex) HasID(id string) bool {
+	if l == nil {
+		return false
+	}
+	_, ok := l.byID[id]
+	return ok
+}
+
+// ByQName returns a freshly materialized entity for the exact qualified name
+// (case-insensitive), or nil. Replaces the pre-PR2
+// `LabelIndex.ByQName[strings.ToLower(qn)]` map access — callers now pass the
+// raw qname and the lowering happens here.
+func (l *LabelIndex) ByQName(qname string) *graph.Entity {
+	if l == nil {
+		return nil
+	}
+	idx, ok := l.byQName[strings.ToLower(qname)]
+	if !ok {
+		return nil
+	}
+	return l.at(idx)
+}
+
 // Lookup finds an entity by ID, qualified name (case-insensitive), or label
 // (case-insensitive). Label matches return the first hit if there are multiple.
-// Returns nil if nothing matched.
+// Returns nil if nothing matched. The returned entity is freshly materialized.
 func (l *LabelIndex) Lookup(s string) *graph.Entity {
-	if e, ok := l.ByID[s]; ok {
-		return e
+	if l == nil {
+		return nil
+	}
+	if idx, ok := l.byID[s]; ok {
+		return l.at(idx)
 	}
 	low := strings.ToLower(s)
-	if e, ok := l.ByQName[low]; ok {
-		return e
+	if idx, ok := l.byQName[low]; ok {
+		return l.at(idx)
 	}
-	if es, ok := l.ByLabel[low]; ok && len(es) > 0 {
-		return es[0]
+	if idxs, ok := l.byLabel[low]; ok && len(idxs) > 0 {
+		return l.at(idxs[0])
 	}
 	return nil
 }
 
 // LookupAll returns every entity matching s by ID, qualified name, or label.
 // Used by get_source/inspect to surface a clarifier list when a label is
-// ambiguous within a repo (#1650).
+// ambiguous within a repo (#1650). Each returned entity is freshly materialized
+// — dedup callers MUST key by entity ID, not pointer identity (PR2 audit).
 func (l *LabelIndex) LookupAll(s string) []*graph.Entity {
-	if e, ok := l.ByID[s]; ok {
-		return []*graph.Entity{e}
+	if l == nil {
+		return nil
+	}
+	if idx, ok := l.byID[s]; ok {
+		return []*graph.Entity{l.at(idx)}
 	}
 	low := strings.ToLower(s)
-	if e, ok := l.ByQName[low]; ok {
-		return []*graph.Entity{e}
+	if idx, ok := l.byQName[low]; ok {
+		return []*graph.Entity{l.at(idx)}
 	}
-	if es, ok := l.ByLabel[low]; ok && len(es) > 0 {
-		return es
+	if idxs, ok := l.byLabel[low]; ok && len(idxs) > 0 {
+		out := make([]*graph.Entity, 0, len(idxs))
+		for _, idx := range idxs {
+			out = append(out, l.at(idx))
+		}
+		return out
 	}
 	return nil
 }

--- a/internal/mcp/labelindex_interning_5850_test.go
+++ b/internal/mcp/labelindex_interning_5850_test.go
@@ -40,23 +40,25 @@ func TestLabelIndexInterning_ByLabelByteCorrect(t *testing.T) {
 	doc := labelIndexInterningDoc()
 	idx := BuildLabelIndex(doc)
 
-	getEntries := idx.ByLabel["get"]
+	// ADR-0027 Cutover PR2: byLabel now holds []int32 entity indices; materialize
+	// via at() to read the entity's ID.
+	getEntries := idx.byLabel["get"]
 	if len(getEntries) != 3 {
-		t.Fatalf("ByLabel[get] has %d entries; want 3 (e1,e2,e3)", len(getEntries))
+		t.Fatalf("byLabel[get] has %d entries; want 3 (e1,e2,e3)", len(getEntries))
 	}
 	gotIDs := map[string]bool{}
-	for _, e := range getEntries {
-		gotIDs[e.ID] = true
+	for _, i := range getEntries {
+		gotIDs[idx.at(i).ID] = true
 	}
 	for _, want := range []string{"e1", "e2", "e3"} {
 		if !gotIDs[want] {
-			t.Errorf("ByLabel[get] missing entity %q; got %v", want, gotIDs)
+			t.Errorf("byLabel[get] missing entity %q; got %v", want, gotIDs)
 		}
 	}
 
-	mixed := idx.ByLabel["mixedcase"]
-	if len(mixed) != 1 || mixed[0].ID != "e4" {
-		t.Errorf("ByLabel[mixedcase] = %v; want [e4]", mixed)
+	mixed := idx.byLabel["mixedcase"]
+	if len(mixed) != 1 || idx.at(mixed[0]).ID != "e4" {
+		t.Errorf("byLabel[mixedcase] = %v; want [e4]", mixed)
 	}
 }
 
@@ -64,23 +66,23 @@ func TestLabelIndexInterning_ByQNameByteCorrect(t *testing.T) {
 	doc := labelIndexInterningDoc()
 	idx := BuildLabelIndex(doc)
 
-	if e, ok := idx.ByQName["pkg.a.get"]; !ok || e.ID != "e1" {
-		t.Errorf("ByQName[pkg.a.get] = %+v (ok=%v); want e1", e, ok)
+	if i, ok := idx.byQName["pkg.a.get"]; !ok || idx.at(i).ID != "e1" {
+		t.Errorf("byQName[pkg.a.get] = %v (ok=%v); want e1", i, ok)
 	}
-	if e, ok := idx.ByQName["pkg.d.mixedcase"]; !ok || e.ID != "e4" {
-		t.Errorf("ByQName[pkg.d.mixedcase] = %+v (ok=%v); want e4", e, ok)
+	if i, ok := idx.byQName["pkg.d.mixedcase"]; !ok || idx.at(i).ID != "e4" {
+		t.Errorf("byQName[pkg.d.mixedcase] = %v (ok=%v); want e4", i, ok)
 	}
 	// Label/qname collision after lowering: "widget" is both e5's Name and
 	// e6's QualifiedName (uppercased on the entity, lowered as the key). Both
 	// entities intern the SAME "widget" key string (that's the point of the
 	// shared interner), but ByQName is a single-value map so the later
 	// entity (e6) wins the last-write.
-	if e, ok := idx.ByQName["widget"]; !ok || e.ID != "e6" {
-		t.Errorf("ByQName[widget] = %+v (ok=%v); want e6 (last write wins)", e, ok)
+	if i, ok := idx.byQName["widget"]; !ok || idx.at(i).ID != "e6" {
+		t.Errorf("byQName[widget] = %v (ok=%v); want e6 (last write wins)", i, ok)
 	}
-	entries := idx.ByLabel["widget"]
-	if len(entries) != 1 || entries[0].ID != "e5" {
-		t.Errorf("ByLabel[widget] = %v; want [e5]", entries)
+	entries := idx.byLabel["widget"]
+	if len(entries) != 1 || idx.at(entries[0]).ID != "e5" {
+		t.Errorf("byLabel[widget] = %v; want [e5]", entries)
 	}
 }
 
@@ -127,18 +129,20 @@ func TestLabelIndexInterning_KeysByteIdenticalToLowered(t *testing.T) {
 	doc := labelIndexInterningDoc()
 	idx := BuildLabelIndex(doc)
 
-	for lbl, entries := range idx.ByLabel {
-		for _, e := range entries {
+	for lbl, entries := range idx.byLabel {
+		for _, i := range entries {
+			e := idx.at(i)
 			want := strings.ToLower(e.Name)
 			if lbl != want {
-				t.Errorf("ByLabel key %q does not match strings.ToLower(%q) = %q", lbl, e.Name, want)
+				t.Errorf("byLabel key %q does not match strings.ToLower(%q) = %q", lbl, e.Name, want)
 			}
 		}
 	}
-	for qn, e := range idx.ByQName {
+	for qn, i := range idx.byQName {
+		e := idx.at(i)
 		want := strings.ToLower(e.QualifiedName)
 		if qn != want {
-			t.Errorf("ByQName key %q does not match strings.ToLower(%q) = %q", qn, e.QualifiedName, want)
+			t.Errorf("byQName key %q does not match strings.ToLower(%q) = %q", qn, e.QualifiedName, want)
 		}
 	}
 }

--- a/internal/mcp/lazy_reload_3367_test.go
+++ b/internal/mcp/lazy_reload_3367_test.go
@@ -102,12 +102,18 @@ func TestLazyIndexes_MatchEagerBuild(t *testing.T) {
 		t.Errorf("getStepAdj = %v; want %v", got, want)
 	}
 
-	// ByID.
+	// ByID. ADR-0027 Cutover PR2: getByID values are now INDEPENDENT heap copies
+	// of the Document rows (byte-equal), NOT pointers aliasing the Doc backing
+	// array — the pointer-decoupling that lets PR7 drop Doc.Entities.
 	byID := lr.getByID()
 	for i := range doc.Entities {
 		id := doc.Entities[i].ID
-		if byID[id] != &doc.Entities[i] {
-			t.Errorf("getByID[%q] does not point at the Document entity", id)
+		e := byID[id]
+		if e == nil || !reflect.DeepEqual(*e, doc.Entities[i]) {
+			t.Errorf("getByID[%q] not a byte-equal copy of the Document entity", id)
+		}
+		if e == &doc.Entities[i] {
+			t.Errorf("getByID[%q] aliases the Document backing array; want an independent copy (PR2)", id)
 		}
 	}
 

--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -443,7 +443,7 @@ func extendsBases(lr *LoadedRepo, c *graph.Entity) []baseRef {
 		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
 			name = rels[ed.relIdx].PropGet("base_name")
 		}
-		target := lr.LabelIndex.ByID[ed.target]
+		target := lr.LabelIndex.ByID(ed.target)
 		if name == "" {
 			if target != nil && target.QualifiedName != "" {
 				name = target.QualifiedName
@@ -591,7 +591,7 @@ func classDeclaredMember(lr *LoadedRepo, cls *graph.Entity, member string) *grap
 		// in another file, or a Java class implementing an interface whose
 		// default method body lives in the interface's own file, must still
 		// resolve to that out-of-file body (#3839).
-		if e := lr.LabelIndex.ByQName[strings.ToLower(qn)]; e != nil &&
+		if e := lr.LabelIndex.ByQName(qn); e != nil &&
 			isMemberEntity(e) && hasRealBody(e) {
 			return e
 		}

--- a/internal/mcp/mro_method_override_4890_test.go
+++ b/internal/mcp/mro_method_override_4890_test.go
@@ -118,7 +118,7 @@ func TestResolveMember_OverriddenMethod_IsExplicit(t *testing.T) {
 	srv.State.groups["test"].Repos["repo1"].Path = dir
 	lr := srv.State.groups["test"].Repos["repo1"]
 
-	e := lr.LabelIndex.ByID["op_create"]
+	e := lr.LabelIndex.ByID("op_create")
 	if e == nil {
 		t.Fatal("op_create entity not found")
 	}
@@ -167,7 +167,7 @@ func TestResolveMember_TrulyInheritedMethod_StaysInherited(t *testing.T) {
 	srv := newTestServer(t, trulyInheritedMethodDoc())
 	lr := srv.State.groups["test"].Repos["repo1"]
 
-	e := lr.LabelIndex.ByID["op_create"]
+	e := lr.LabelIndex.ByID("op_create")
 	if e == nil {
 		t.Fatal("op_create entity not found")
 	}

--- a/internal/mcp/mro_traverse.go
+++ b/internal/mcp/mro_traverse.go
@@ -96,7 +96,7 @@ func mroOutboundEdges(lr *LoadedRepo, local string) []mroEdge {
 	if lr == nil || lr.Doc == nil {
 		return nil
 	}
-	e := lr.LabelIndex.ByID[local]
+	e := lr.LabelIndex.ByID(local)
 	if e == nil {
 		return nil
 	}
@@ -232,7 +232,7 @@ func defUseMRORetarget(lg *LoadedGroup, entityFilter string) (definingID, defini
 		if r == nil || r.Doc == nil {
 			return "", ""
 		}
-		e := r.LabelIndex.ByID[id]
+		e := r.LabelIndex.ByID(id)
 		if e == nil {
 			return "", ""
 		}

--- a/internal/mcp/patterns.go
+++ b/internal/mcp/patterns.go
@@ -541,18 +541,18 @@ func deriveScopeFromExemplars(exemplars []string, lg *LoadedGroup) agentpatterns
 				if r.Doc == nil {
 					continue
 				}
-				if e := r.LabelIndex.ByID[local]; e != nil {
+				if e := r.LabelIndex.ByID(local); e != nil {
 					infos = append(infos, eInfo{repo: r.Repo, srcFile: e.SourceFile, language: e.Language})
 					break
 				}
-				if e := r.LabelIndex.ByID[eid]; e != nil {
+				if e := r.LabelIndex.ByID(eid); e != nil {
 					infos = append(infos, eInfo{repo: r.Repo, srcFile: e.SourceFile, language: e.Language})
 					break
 				}
 			}
 		} else {
 			if r, ok := lg.Repos[rName]; ok && r.Doc != nil {
-				if e := r.LabelIndex.ByID[local]; e != nil {
+				if e := r.LabelIndex.ByID(local); e != nil {
 					infos = append(infos, eInfo{repo: rName, srcFile: e.SourceFile, language: e.Language})
 				}
 			}

--- a/internal/mcp/reader_index_parity_pr2_test.go
+++ b/internal/mcp/reader_index_parity_pr2_test.go
@@ -1,0 +1,219 @@
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ADR-0027 Cutover PR2: the LabelIndex holds ENTITY INDICES (int32) and
+// MATERIALIZES a fresh heap-copy entity per lookup, instead of pinning
+// *graph.Entity pointers ALIASING Document.Entities. The int32 index MAPS are
+// built by iterating the resident mmap Reader (BuildLabelIndexFromReader); the
+// per-lookup VALUE copy is taken from the live Document (behavior-neutral vs the
+// post-load in-place group-algo overlay — see the LabelIndex type doc).
+//
+// These tests assert:
+//   1. MAP PARITY — the Reader-built int32 maps equal the Document-built maps
+//      over the SAME real graph.fb (Reader iteration order == loader order).
+//   2. VALUE PARITY — ByID / ByQName / Lookup / LookupAll return byte-equal
+//      results on the Reader-built and Document-built index.
+//   3. POINTER INSTABILITY — two lookups of the same id return DISTINCT pointers
+//      (the property the PR2 retained-pointer audit gates PR7 on) yet byte-equal
+//      VALUES; getByID by contrast returns a stable per-reload map of copies.
+//
+// The fixture (parityIndexDoc / loadParityIndexFixture) is shared with the PR1
+// parity tests in reader_index_parity_pr1_test.go.
+
+// labelIndexIDs returns every entity id in the fixture, in Document order.
+func labelIndexIDs(doc *graph.Document) []string {
+	ids := make([]string, 0, len(doc.Entities))
+	for i := range doc.Entities {
+		ids = append(ids, doc.Entities[i].ID)
+	}
+	return ids
+}
+
+// TestLabelIndexMapsReaderParity_PR2 asserts the int32 index MAPS built by
+// iterating the Reader are identical to those built from the Document — i.e. the
+// Reader iteration order and keying exactly match the loader's. This is the
+// core "index can be built from the Reader, no Doc.Entities needed" guarantee.
+func TestLabelIndexMapsReaderParity_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	wantIdx := BuildLabelIndex(doc)
+	gotIdx := BuildLabelIndexFromReader(r, doc)
+
+	if !reflect.DeepEqual(gotIdx.byID, wantIdx.byID) {
+		t.Errorf("byID map Reader-built != Document-built\n got=%v\nwant=%v", gotIdx.byID, wantIdx.byID)
+	}
+	if !reflect.DeepEqual(gotIdx.byLabel, wantIdx.byLabel) {
+		t.Errorf("byLabel map Reader-built != Document-built\n got=%v\nwant=%v", gotIdx.byLabel, wantIdx.byLabel)
+	}
+	if !reflect.DeepEqual(gotIdx.byQName, wantIdx.byQName) {
+		t.Errorf("byQName map Reader-built != Document-built\n got=%v\nwant=%v", gotIdx.byQName, wantIdx.byQName)
+	}
+}
+
+func TestLabelIndexByIDReaderParity_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	wantIdx := BuildLabelIndex(doc)             // Document-sourced (nil-Reader) baseline
+	gotIdx := BuildLabelIndexFromReader(r, doc) // Reader-sourced
+
+	for _, id := range labelIndexIDs(doc) {
+		want := wantIdx.ByID(id)
+		got := gotIdx.ByID(id)
+		if want == nil || got == nil {
+			t.Fatalf("ByID(%q): want=%v got=%v (neither may be nil)", id, want, got)
+		}
+		if !reflect.DeepEqual(*got, *want) {
+			t.Errorf("ByID(%q) Reader-sourced != Document-sourced\n got=%#v\nwant=%#v", id, *got, *want)
+		}
+	}
+	// Unknown id resolves to nil on both branches.
+	if gotIdx.ByID("nope::x") != nil || wantIdx.ByID("nope::x") != nil {
+		t.Errorf("ByID(unknown) must be nil on both branches")
+	}
+	// HasID must not materialize and must agree with membership.
+	if !gotIdx.HasID("id::a") || gotIdx.HasID("nope::x") {
+		t.Errorf("HasID contract broken: HasID(id::a)=%v HasID(nope)=%v",
+			gotIdx.HasID("id::a"), gotIdx.HasID("nope::x"))
+	}
+}
+
+func TestLabelIndexByQNameReaderParity_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	wantIdx := BuildLabelIndex(doc)
+	gotIdx := BuildLabelIndexFromReader(r, doc)
+
+	for i := range doc.Entities {
+		qn := doc.Entities[i].QualifiedName
+		if qn == "" {
+			continue
+		}
+		want := wantIdx.ByQName(qn)
+		got := gotIdx.ByQName(qn)
+		if want == nil || got == nil {
+			t.Fatalf("ByQName(%q): want=%v got=%v", qn, want, got)
+		}
+		if !reflect.DeepEqual(*got, *want) {
+			t.Errorf("ByQName(%q) Reader-sourced != Document-sourced\n got=%#v\nwant=%#v", qn, *got, *want)
+		}
+		// Case-insensitivity: an all-upper qname must resolve identically.
+		if gotIdx.ByQName(qn) == nil {
+			t.Errorf("ByQName(%q) case-insensitive lookup returned nil", qn)
+		}
+	}
+}
+
+func TestLabelIndexLookupReaderParity_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	wantIdx := BuildLabelIndex(doc)
+	gotIdx := BuildLabelIndexFromReader(r, doc)
+
+	// Lookup by id, by qname, and by label; plus LookupAll on every label.
+	probes := []string{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		probes = append(probes, e.ID, e.Name, e.QualifiedName)
+	}
+	for _, s := range probes {
+		if s == "" {
+			continue
+		}
+		want := wantIdx.Lookup(s)
+		got := gotIdx.Lookup(s)
+		switch {
+		case want == nil && got == nil:
+			// both miss — fine
+		case want == nil || got == nil:
+			t.Errorf("Lookup(%q): want=%v got=%v (branch disagreement)", s, want, got)
+		default:
+			if !reflect.DeepEqual(*got, *want) {
+				t.Errorf("Lookup(%q) Reader != Document\n got=%#v\nwant=%#v", s, *got, *want)
+			}
+		}
+
+		wantAll := wantIdx.LookupAll(s)
+		gotAll := gotIdx.LookupAll(s)
+		if len(wantAll) != len(gotAll) {
+			t.Fatalf("LookupAll(%q) len: want=%d got=%d", s, len(wantAll), len(gotAll))
+		}
+		for i := range wantAll {
+			if !reflect.DeepEqual(*gotAll[i], *wantAll[i]) {
+				t.Errorf("LookupAll(%q)[%d] Reader != Document\n got=%#v\nwant=%#v",
+					s, i, *gotAll[i], *wantAll[i])
+			}
+		}
+	}
+}
+
+// TestLabelIndexMaterializesFreshPointers_PR2 locks in the pointer-instability
+// contract the PR7 flip depends on: two lookups of the same id return DISTINCT
+// *graph.Entity pointers (fresh heap copies) whose VALUES are byte-equal. A
+// consumer that dedups/compares by pointer identity would break — which is why
+// the PR2 audit swept them.
+func TestLabelIndexMaterializesFreshPointers_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+
+	for _, idx := range []*LabelIndex{BuildLabelIndexFromReader(r, doc), BuildLabelIndex(doc)} {
+		a := idx.ByID("id::a")
+		b := idx.ByID("id::a")
+		if a == nil || b == nil {
+			t.Fatalf("ByID(id::a) returned nil")
+		}
+		if a == b {
+			t.Errorf("expected DISTINCT pointers from two lookups; got the same pointer %p", a)
+		}
+		if !reflect.DeepEqual(*a, *b) {
+			t.Errorf("materialized copies must be byte-equal:\n a=%#v\n b=%#v", *a, *b)
+		}
+		// Mutating one copy must not affect a subsequent lookup (no aliasing).
+		a.Name = "MUTATED"
+		if c := idx.ByID("id::a"); c == nil || c.Name == "MUTATED" {
+			t.Errorf("materialized copy aliased the index source (mutation leaked): %#v", c)
+		}
+	}
+}
+
+// TestGetByIDMaterializesStableMap_PR2 asserts getByID still returns a stable
+// id->*Entity map (values fixed for the reload) sourced from the Reader, so its
+// consumers are insulated from the per-lookup pointer instability above.
+func TestGetByIDMaterializesStableMap_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
+
+	m1 := lr.getByID()
+	m2 := lr.getByID()
+	for _, id := range labelIndexIDs(doc) {
+		e1, ok1 := m1[id]
+		e2, ok2 := m2[id]
+		if !ok1 || !ok2 {
+			t.Fatalf("getByID missing id %q (ok1=%v ok2=%v)", id, ok1, ok2)
+		}
+		// Same cached map => stable pointer across calls.
+		if e1 != e2 {
+			t.Errorf("getByID(%q) pointer not stable across calls", id)
+		}
+		// Byte-equal to the Document row.
+		want := docEntityByID(doc, id)
+		if want == nil || !reflect.DeepEqual(*e1, *want) {
+			t.Errorf("getByID(%q) != Document row\n got=%#v\nwant=%#v", id, e1, want)
+		}
+	}
+}
+
+func docEntityByID(doc *graph.Document, id string) *graph.Entity {
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == id {
+			return &doc.Entities[i]
+		}
+	}
+	return nil
+}

--- a/internal/mcp/reader_index_parity_pr2_test.go
+++ b/internal/mcp/reader_index_parity_pr2_test.go
@@ -217,3 +217,75 @@ func docEntityByID(doc *graph.Document, id string) *graph.Entity {
 	}
 	return nil
 }
+
+// TestLabelIndexSurfacesOverlayStampedFields_PR2 is the load-bearing invariant
+// test for "values come from the overlaid Doc, NEVER the Reader".
+//
+// The other PR2 value-parity tests compare two DOC-sourced indexes over a
+// fixture that stamps NO overlay-only fields, so they would pass even if at()
+// were (wrongly) flipped to read the mmap Reader for values. This test closes
+// that blind spot — the EXACT regression class that bit PR1.
+//
+// It stamps overlay-ONLY fields (CommunityID / Centrality / IsGodNode) onto
+// Doc.Entities the way applyGroupAlgoOverlay does — those values live in the
+// <group>-algo.json overlay, NOT in graph.fb, so the resident Reader carries
+// only sentinels/zero for them — then asserts LabelIndex.ByID / Lookup / getByID
+// SURFACE the stamped values. Mutation check (verified once, then reverted):
+// flipping LabelIndex.at() to materialize from the Reader
+// (graph.MaterializeEntity(l.reader, idx)) makes this test FAIL — ByID(id::a)
+// surfaces the graph.fb sentinel CommunityID, not the stamped 80 — proving the
+// Doc value-source is load-bearing.
+func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
+	t.Parallel()
+	doc, r := loadParityIndexFixture(t)
+	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
+
+	const wantCID = 80
+	const wantCen = 0.4242
+	stamp := func(id string, cid int, cen float64, god bool) {
+		e := docEntityByID(doc, id)
+		if e == nil {
+			t.Fatalf("fixture missing entity %q", id)
+		}
+		c, ce := cid, cen
+		e.CommunityID = &c
+		e.Centrality = &ce
+		e.IsGodNode = god
+	}
+	stamp("id::a", wantCID, wantCen, true)
+	stamp("id::b", 7, 0.99, false)
+	// Mirror the overlay's post-stamp index re-arm so getByID rebuilds off the
+	// stamped Doc (LabelIndex reads Doc live, so it needs no rebuild).
+	lr.resetIndexes()
+
+	// LabelIndex.ByID surfaces the stamped overlay-only fields.
+	a := lr.LabelIndex.ByID("id::a")
+	if a == nil {
+		t.Fatal("LabelIndex.ByID(id::a) = nil")
+	}
+	if a.CommunityID == nil || *a.CommunityID != wantCID {
+		t.Fatalf("LabelIndex.ByID(id::a).CommunityID = %+v; want %d — overlay stamp not surfaced; "+
+			"values MUST come from the overlaid Doc, not the Reader", a.CommunityID, wantCID)
+	}
+	if a.Centrality == nil || *a.Centrality != wantCen {
+		t.Errorf("LabelIndex.ByID(id::a).Centrality = %+v; want %v (overlay stamp)", a.Centrality, wantCen)
+	}
+	if !a.IsGodNode {
+		t.Error("LabelIndex.ByID(id::a).IsGodNode = false; want true (overlay stamp)")
+	}
+
+	// Lookup (by label) routes through the same at() materialization path.
+	if l := lr.LabelIndex.Lookup("A"); l == nil || l.CommunityID == nil || *l.CommunityID != wantCID {
+		t.Errorf("Lookup(A).CommunityID = %+v; want %d (overlay stamp)", l, wantCID)
+	}
+
+	// getByID surfaces the stamps too (map of copies built off the stamped Doc).
+	if g := lr.getByID()["id::a"]; g == nil || g.CommunityID == nil || *g.CommunityID != wantCID {
+		t.Errorf("getByID[id::a].CommunityID = %+v; want %d (overlay stamp)", g, wantCID)
+	}
+
+	// Sanity: the second stamped entity carries its own distinct value.
+	if b := lr.LabelIndex.ByID("id::b"); b == nil || b.CommunityID == nil || *b.CommunityID != 7 {
+		t.Errorf("LabelIndex.ByID(id::b).CommunityID = %+v; want 7", b)
+	}
+}

--- a/internal/mcp/reload_cost_3377_test.go
+++ b/internal/mcp/reload_cost_3377_test.go
@@ -244,7 +244,7 @@ func TestContentHashSkip_ChangedContentReparses(t *testing.T) {
 		t.Errorf("changed content: expected exactly 1 reparse, got %d", *parses)
 	}
 	// The fresh Doc must contain the new entity.
-	if _, ok := lr.LabelIndex.ByID["z"]; !ok {
+	if !lr.LabelIndex.HasID("z") {
 		t.Error("reparse did not pick up the new entity 'z'")
 	}
 }

--- a/internal/mcp/security_findings_tool.go
+++ b/internal/mcp/security_findings_tool.go
@@ -160,7 +160,7 @@ func resolveEntityByPrefixed(lg *LoadedGroup, key string) *graph.Entity {
 	if r.LabelIndex == nil {
 		return nil
 	}
-	if e, ok := r.LabelIndex.ByID[local]; ok {
+	if e := r.LabelIndex.ByID(local); e != nil {
 		return e
 	}
 	return nil

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -559,23 +559,30 @@ func (lr *LoadedRepo) getMROInbound() map[string][]string {
 }
 
 // getByID returns the entity-ID → *Entity map, building it on first use.
-// Reuses LabelIndex.ByID when present (the LabelIndex is built eagerly at
-// reload and carries an identical map), avoiding a second O(N) pass.
+//
+// ADR-0027 Cutover PR2: the map's values are now INDEPENDENT heap copies of the
+// Document rows rather than pointers ALIASING lr.Doc.Entities' backing array —
+// so getByID no longer pins live pointers into Doc, the prerequisite for the
+// PR7 flip that drops Doc.Entities. It no longer reuses LabelIndex.ByID, which
+// is now an int32 index map, not a *graph.Entity map. Values are copied from
+// the LIVE Doc (not the mmap Reader) so post-load in-place overlay stamps stay
+// visible — behavior-neutral; see the LabelIndex type doc for the rationale.
+// Built once per reload and cached, so the map's values are INTERNALLY STABLE
+// for the life of the reload: getByID consumers (which index the map by id and
+// never compare value pointers) are insulated from the per-lookup pointer
+// instability of LabelIndex.ByID/Lookup.
 func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.byIDOnce.Do(func() {
-		if lr.LabelIndex != nil && lr.LabelIndex.ByID != nil {
-			lr.byID = lr.LabelIndex.ByID
-			return
-		}
 		if lr.Doc == nil {
 			lr.byID = map[string]*graph.Entity{}
 			return
 		}
 		m := make(map[string]*graph.Entity, len(lr.Doc.Entities))
 		for i := range lr.Doc.Entities {
-			m[lr.Doc.Entities[i].ID] = &lr.Doc.Entities[i]
+			ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
+			m[ent.ID] = &ent
 		}
 		lr.byID = m
 	})
@@ -1109,7 +1116,24 @@ func (s *State) reloadLocked() (int, bool, error) {
 					lr.mtime = fileMtime
 					lr.contentHash = newHash // 0 on hash failure → next reload re-parses
 					lr.loadErr = ""
-					lr.LabelIndex = BuildLabelIndex(doc)
+					// ADR-0027 Cutover PR2: open the mmap Reader BEFORE building the
+					// LabelIndex so the index sources entity indices (int32 positions)
+					// and MATERIALIZES each lookup from the resident mmap — byte-
+					// identical to the Document rows (PR1) — instead of pinning
+					// *graph.Entity pointers into Doc.Entities (the PR7 flip removes
+					// Doc.Entities entirely). Best-effort: Open failure leaves newRdr
+					// nil and the index falls back to the Document (JSON-only path).
+					// The SAME reader is published via setReader below (F1 protocol).
+					fbPath := filepath.Join(stateDir, "graph.fb")
+					var newRdr *fbreader.Reader
+					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
+						newRdr = rdr
+					}
+					if newRdr != nil {
+						lr.LabelIndex = BuildLabelIndexFromReader(newRdr, doc)
+					} else {
+						lr.LabelIndex = BuildLabelIndex(doc)
+					}
 					// BM25 is NO LONGER built eagerly here (#3377). It tokenizes every
 					// entity (name, path, docstring, discriminators) and dominated
 					// reload cost (~85%); it is now built lazily on first search-tool
@@ -1123,22 +1147,15 @@ func (s *State) reloadLocked() (int, bool, error) {
 					// is built on first use by its getter and cached until the next
 					// reload re-arms the Once here (#3367, #3377).
 					lr.resetIndexes()
-					// S8 (#2159): open the mmap reader alongside the Document.
-					// Best-effort: failures leave Reader nil; callers fall back to
-					// doc.Entities / doc.Relationships.
-					//
-					// F1 (ADR-0027): publish the successor through the deferred-unmap
-					// protocol instead of a bare Close() of the old reader. setReader
-					// repoints lr.handle/lr.Reader to the new mapping FIRST, then
-					// retires the predecessor — which unmaps it now iff it has already
-					// drained, else the last in-flight release() unmaps it. Reload
-					// never waits on borrows and never munmaps in place. Passing nil on
-					// Open failure retires the stale predecessor and leaves Reader nil.
-					fbPath := filepath.Join(stateDir, "graph.fb")
-					var newRdr *fbreader.Reader
-					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
-						newRdr = rdr
-					}
+					// S8 (#2159) + F1 (ADR-0027): publish the successor (newRdr, opened
+					// above alongside the LabelIndex) through the deferred-unmap protocol
+					// instead of a bare Close() of the old reader. setReader repoints
+					// lr.handle/lr.Reader to the new mapping FIRST, then retires the
+					// predecessor — which unmaps it now iff it has already drained, else
+					// the last in-flight release() unmaps it. Reload never waits on
+					// borrows and never munmaps in place. Passing nil on Open failure
+					// retires the stale predecessor and leaves Reader nil; callers then
+					// fall back to doc.Entities / doc.Relationships.
 					// TESTS-edge count cached once per reload so grafel_whoami can
 					// return it in O(1) without rescanning all relationships. This is a
 					// cheap O(R) count with no allocation, so it stays eager (#3325).

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -904,7 +904,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 					expandTruncated = true
 					break
 				}
-				if e, ok := sc.repo.LabelIndex.ByID[nid]; ok {
+				if e := sc.repo.LabelIndex.ByID(nid); e != nil {
 					add(sc.repo.Repo, e, sc.hit.Score/float64(d+1))
 				}
 			}
@@ -918,7 +918,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 					expandTruncated = true
 					break
 				}
-				from := sc.repo.LabelIndex.ByID[nid]
+				from := sc.repo.LabelIndex.ByID(nid)
 				if from == nil {
 					continue
 				}
@@ -933,7 +933,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 					if !seen[prefixedID(sc.repo.Repo, e.target)] {
 						continue
 					}
-					to := sc.repo.LabelIndex.ByID[e.target]
+					to := sc.repo.LabelIndex.ByID(e.target)
 					if to == nil {
 						continue
 					}
@@ -1276,7 +1276,7 @@ func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) 
 	// Cross-repo prefixed ID? Resolve repo first for unambiguous lookup.
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
-			if e, ok := r.LabelIndex.ByID[local]; ok {
+			if e := r.LabelIndex.ByID(local); e != nil {
 				scopeIsOne := len(repos) == 1
 				out := serializeEntity(r.Repo, e, scopeIsOne, verbose)
 				if includeAlgo {
@@ -2180,7 +2180,7 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 	var startRepo *LoadedRepo
 	if rprefix, local := splitPrefixed(key); rprefix != "" {
 		if r, ok := lg.Repos[rprefix]; ok && r.Doc != nil {
-			start = r.LabelIndex.ByID[local]
+			start = r.LabelIndex.ByID(local)
 			startRepo = r
 		}
 	}
@@ -2216,7 +2216,7 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 		if nid == start.ID {
 			continue
 		}
-		e := startRepo.LabelIndex.ByID[nid]
+		e := startRepo.LabelIndex.ByID(nid)
 		if e == nil {
 			continue
 		}
@@ -2409,7 +2409,7 @@ func (s *Server) handleShortestPath(ctx context.Context, req mcpapi.CallToolRequ
 func normalizePrefixed(lg *LoadedGroup, s string) string {
 	if r, l := splitPrefixed(s); r != "" {
 		if rr, ok := lg.Repos[r]; ok && rr.Doc != nil {
-			if _, ok := rr.LabelIndex.ByID[l]; ok {
+			if rr.LabelIndex.HasID(l) {
 				return s
 			}
 		}

--- a/internal/mcp/w1_views_test.go
+++ b/internal/mcp/w1_views_test.go
@@ -3,7 +3,6 @@ package mcp
 import (
 	"runtime"
 	"sort"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -70,7 +69,7 @@ func TestW1EntityViewGetterParity(t *testing.T) {
 			continue
 		}
 		got, ok := b.entityViewByQName("r", e.QualifiedName)
-		want := lr.LabelIndex.ByQName[strings.ToLower(e.QualifiedName)]
+		want := lr.LabelIndex.ByQName(e.QualifiedName)
 		if !ok || want == nil || got.ID() != want.ID {
 			t.Errorf("entityViewByQName(%q) = %v/%v, want %v", e.QualifiedName, got, ok, want)
 		}
@@ -78,14 +77,15 @@ func TestW1EntityViewGetterParity(t *testing.T) {
 
 	// byLabel parity against LabelIndex.ByLabel, including ambiguous labels and
 	// order (both are built in Doc order).
-	for lbl, wantEs := range lr.LabelIndex.ByLabel {
+	for lbl, wantIdxs := range lr.LabelIndex.byLabel {
 		gotVs := b.entityViewsByLabel("r", lbl)
-		if len(gotVs) != len(wantEs) {
-			t.Fatalf("entityViewsByLabel(%q) len = %d, want %d", lbl, len(gotVs), len(wantEs))
+		if len(gotVs) != len(wantIdxs) {
+			t.Fatalf("entityViewsByLabel(%q) len = %d, want %d", lbl, len(gotVs), len(wantIdxs))
 		}
-		for i := range wantEs {
-			if gotVs[i].ID() != wantEs[i].ID {
-				t.Errorf("entityViewsByLabel(%q)[%d] = %q, want %q", lbl, i, gotVs[i].ID(), wantEs[i].ID)
+		for i := range wantIdxs {
+			wantID := lr.LabelIndex.at(wantIdxs[i]).ID
+			if gotVs[i].ID() != wantID {
+				t.Errorf("entityViewsByLabel(%q)[%d] = %q, want %q", lbl, i, gotVs[i].ID(), wantID)
 			}
 		}
 	}


### PR DESCRIPTION
Refs #5850 (mmap cutover, PR2/8). Behavior-neutral, INTERIM (values still sourced from live Doc — see below). Decouples index pointers from `Doc.Entities` and lands the retained-pointer audit that gates the PR7 flip.

## What
- **`LabelIndex` holds indices, not pointers:** `byID map[string]int32`, `byLabel map[string][]int32`, `byQName map[string]int32` (entity-vector positions). `ByID`/`ByQName`/`Lookup`/`LookupAll` are now methods returning a freshly-materialized `*graph.Entity` per hit (two lookups of the same id → distinct pointers); `HasID` for non-materializing presence checks. `BuildLabelIndexFromReader` builds the int32 maps from the resident mmap Reader (no longer needs `Doc.Entities` constructed); `BuildLabelIndex(doc)` stays as the Document-sourced parity baseline + nil-Reader fallback. ~23 direct `LabelIndex.ByID[...]`/`.ByQName[...]` field accesses in mcp handlers converted to the method calls (mechanical, semantics-preserving).
- **INTERIM value source = live Doc, not Reader.** Deliberate: `applyGroupAlgoOverlay` stamps CommunityID/PageRank/Centrality/god/articulation onto `Doc.Entities` in place after load (from `<group>-algo.json`, NOT graph.fb — those fb fields are sentinels since per-repo Pass-4 was removed). Reader-value materialization would DROP the overlay (TDD caught it). PR2 materializes from the overlaid Doc → byte-identical, pointer-decoupled. **The Reader value-source flip is unblocked by the overlay side-table (next PR), the PR7 flip precondition.**

## Retained-pointer audit (gates PR7) — clean except 2 fixed in-scope
Swept every consumer of `getByID`/`LabelIndex.Lookup/ByID/ByLabel/ByQName` for pointer `==`, `map[*graph.Entity]` keys, cross-call pointer caching:
- `get_source_resolve.appendUniqueCandidate` — deduped by pointer identity → **fixed:** dedup by `(repo, entity ID)`.
- `enrichment.applyResolutions` (dead code) — mutated through the `ByID` pointer (write-through-to-Doc) → **fixed:** retarget to resolve against `Doc.Entities` directly.
- No `map[*graph.Entity]` keys, no other pointer-identity, no cross-call caching. FuseRRF already fixed (#5864).

## Tests (`-race`)
`TestLabelIndexMapsReaderParity_PR2`, `…ByIDReaderParity…`, `…ByQNameReaderParity…`, `…LookupReaderParity…` (Reader-built == Document-built, byte-equal + nil-Reader fallback), `TestLabelIndexMaterializesFreshPointers_PR2` (distinct pointers, byte-equal values), `TestGetByIDMaterializesStableMap_PR2`.

## Gate (local, post-rebase on the TopKPageRank hotfix)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` green. No fbversion bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o