### PR TITLE
fix(mcp): gate ALL handler-path mmap reads behind GRAFEL_SERVE_FROM_MMAP (fixes live #5865 SIGBUS) + overlay side-table (dark)

### DIFF
--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -38,14 +38,51 @@ import (
 // the value source to the Reader is a PR7 concern gated on re-plumbing the
 // overlay off the in-place Doc mutation.
 type LabelIndex struct {
-	// doc is the value-materialization source: at() copies doc.Entities[idx].
-	// It is the LIVE per-repo Document, so lookups observe post-load in-place
-	// overlay stamps (behavior-neutral, see the type doc).
+	// doc is retained as the JSON-only (nil-reader) value-materialization source
+	// and the bounds oracle. When reader != nil, at() materializes the BASE
+	// entity from the mmap Reader (graph.MaterializeEntity) instead and merges
+	// the 5 group-algo overlay fields from the side-table below — so the index
+	// path no longer depends on doc.Entities for VALUES (the PR7 prerequisite).
 	doc *graph.Document
+
+	// reader is the resident mmap Reader whose entity rows back this index
+	// generation (set by BuildLabelIndexFromReader). Nil on the JSON-only /
+	// no-graph.fb fallback, where at() reads doc.Entities directly. Reads happen
+	// on the same s.mu-serialized read path that today reads lr.Doc; a reload
+	// rebuilds the whole LabelIndex (fresh reader), so at() never dereferences a
+	// reader across its own generation.
+	reader *fbreader.Reader
+
+	// overlay is the ADR-0027 overlay SIDE-TABLE: entity INDEX (int32 vector
+	// position) -> the 5 group-algo values that are NOT authoritative in graph.fb
+	// (per-repo Pass-4 was removed, so graph.fb carries permanent sentinels for
+	// them). Populated by applyGroupAlgoOverlay from the SAME <group>-algo.json
+	// data it stamps onto lr.Doc, keyed by resolving each overlay entity ID to
+	// its vector index via byID. at() merges these onto the Reader-materialized
+	// base so a lookup is byte-equal to today's overlaid Doc row. nil until an
+	// overlay is applied (absent/stale overlay → the graph.fb sentinels stand,
+	// exactly as on the un-stamped Doc). Only entities WITH an overlay entry are
+	// present; a miss leaves the fb sentinel. Rebuilt/invalidated with the
+	// LabelIndex itself on every reload and reassigned on every overlay re-stamp.
+	overlay map[int32]entityOverlay
 
 	byID    map[string]int32
 	byLabel map[string][]int32
 	byQName map[string]int32
+}
+
+// entityOverlay holds the 5 group-algo fields that live in the
+// <group>-algo.json overlay rather than in graph.fb (CommunityID / PageRank /
+// Centrality are pointers so nil distinguishes "no overlay value" from a real
+// zero, matching graph.Entity's own representation; the two flags are plain
+// bools). Independent heap copies (distinct from the Doc stamp's pointers) so
+// the table remains a valid source after the PR7 Doc drop.
+type entityOverlay struct {
+	CommunityID      *int
+	PageRank         *float64
+	Centrality       *float64
+	IsGodNode        bool
+	IsArticulationPt bool
 }
 
 // keyInterner canonicalizes repeated map-key strings built during a single
@@ -142,6 +179,7 @@ func BuildLabelIndex(doc *graph.Document) *LabelIndex {
 func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIndex {
 	idx, ki := newLabelIndex(r.EntityCount())
 	idx.doc = doc
+	idx.reader = r
 	var i int32
 	r.IterateEntities(func(e *fb.Entity) bool {
 		idx.add(ki, i, string(e.Id()), string(e.Name()), string(e.QualifiedName()))
@@ -151,13 +189,33 @@ func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIn
 	return idx
 }
 
-// at materializes a fresh heap-copy entity for the given vector index by copying
-// the LIVE doc.Entities[idx] row. Each call returns a DISTINCT pointer (see the
-// LabelIndex pointer-instability contract). Only ever called with an index that
-// came from one of the maps, so the bounds/nil guards are defensive.
+// at materializes a fresh heap-copy entity for the given vector index. Each call
+// returns a DISTINCT pointer (see the LabelIndex pointer-instability contract).
+// Only ever called with an index that came from one of the maps, so the
+// bounds/nil guards are defensive.
+//
+// When a mmap Reader backs this index generation, the BASE entity is decoded
+// from the resident graph.fb via graph.MaterializeEntity (byte-identical to the
+// Document row for the same bytes) and the 5 group-algo overlay fields are then
+// merged from the side-table — so the value source is the Reader + side-table,
+// NOT lr.Doc. This is byte-equal to today's overlaid Doc row (the parity guard
+// TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc). The nil-Reader
+// fallback (JSON-only / no graph.fb) copies the LIVE doc.Entities[idx] row,
+// which already carries the in-place overlay stamp.
 func (l *LabelIndex) at(idx int32) *graph.Entity {
 	if l == nil || l.doc == nil || idx < 0 || int(idx) >= len(l.doc.Entities) {
 		return nil
+	}
+	if l.reader != nil {
+		e := graph.MaterializeEntity(l.reader, int(idx))
+		if ov, ok := l.overlay[idx]; ok {
+			e.CommunityID = ov.CommunityID
+			e.PageRank = ov.PageRank
+			e.Centrality = ov.Centrality
+			e.IsGodNode = ov.IsGodNode
+			e.IsArticulationPt = ov.IsArticulationPt
+		}
+		return &e
 	}
 	e := l.doc.Entities[idx] // heap copy — a fresh pointer, not an alias into Doc
 	return &e

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -59,11 +59,15 @@ type LabelIndex struct {
 	// them). Populated by applyGroupAlgoOverlay from the SAME <group>-algo.json
 	// data it stamps onto lr.Doc, keyed by resolving each overlay entity ID to
 	// its vector index via byID. at() merges these onto the Reader-materialized
-	// base so a lookup is byte-equal to today's overlaid Doc row. nil until an
-	// overlay is applied (absent/stale overlay → the graph.fb sentinels stand,
-	// exactly as on the un-stamped Doc). Only entities WITH an overlay entry are
-	// present; a miss leaves the fb sentinel. Rebuilt/invalidated with the
-	// LabelIndex itself on every reload and reassigned on every overlay re-stamp.
+	// base so a lookup is byte-equal to today's overlaid Doc row. Only entities
+	// WITH an overlay entry are present; a miss leaves the fb sentinel.
+	//
+	// Built ONLY when GRAFEL_SERVE_FROM_MMAP is ON — the flag-off default path
+	// reads the overlaid Doc and never consults this table, so the ~single-digit
+	// MB of resident memory is not paid until the flip is enabled. Rebuilt/
+	// invalidated with the LabelIndex itself on every reload and reassigned on
+	// every overlay re-stamp. nil on the flag-off path and until an overlay is
+	// applied.
 	overlay map[int32]entityOverlay
 
 	byID    map[string]int32
@@ -194,19 +198,28 @@ func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIn
 // Only ever called with an index that came from one of the maps, so the
 // bounds/nil guards are defensive.
 //
-// When a mmap Reader backs this index generation, the BASE entity is decoded
-// from the resident graph.fb via graph.MaterializeEntity (byte-identical to the
-// Document row for the same bytes) and the 5 group-algo overlay fields are then
-// merged from the side-table — so the value source is the Reader + side-table,
-// NOT lr.Doc. This is byte-equal to today's overlaid Doc row (the parity guard
-// TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc). The nil-Reader
-// fallback (JSON-only / no graph.fb) copies the LIVE doc.Entities[idx] row,
-// which already carries the in-place overlay stamp.
+// Value source is gated by GRAFEL_SERVE_FROM_MMAP (default OFF; read once at
+// package load, per ADR-0027 §F3):
+//
+//   - OFF (default / production): copy the LIVE doc.Entities[idx] row, exactly as
+//     PR2 does — GC-safe, byte-identical, and with NO handler-path mmap read. The
+//     mmap Reader is NOT dereferenced here on the OFF path.
+//   - ON (the PR7 flip, DARK until the F1/F2/F3 borrow protocol is wired into the
+//     read path): decode the BASE entity from the resident graph.fb via
+//     graph.MaterializeEntity (byte-identical to the Document row for the same
+//     bytes) and merge the 5 group-algo overlay fields from the side-table — so
+//     the value source is the Reader + side-table, NOT lr.Doc. Byte-equal to
+//     today's overlaid Doc row (TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc).
+//
+// The ON path reads the mmap on the handler path; it MUST NOT be enabled in
+// production until a borrow is held across the read (else a concurrent reload's
+// munmap is a read-after-unmap). That wiring + flipping the flag is a later step.
+// The nil-Reader case (JSON-only / no graph.fb) always uses the Doc copy.
 func (l *LabelIndex) at(idx int32) *graph.Entity {
 	if l == nil || l.doc == nil || idx < 0 || int(idx) >= len(l.doc.Entities) {
 		return nil
 	}
-	if l.reader != nil {
+	if l.reader != nil && serveFromMMap() {
 		e := graph.MaterializeEntity(l.reader, int(idx))
 		if ov, ok := l.overlay[idx]; ok {
 			e.CommunityID = ov.CommunityID

--- a/internal/mcp/mmap_gating_safety_test.go
+++ b/internal/mcp/mmap_gating_safety_test.go
@@ -1,0 +1,117 @@
+// mmap_gating_safety_test.go — ADR-0027 cutover safety guard.
+//
+// ALL handler-path mmap reads (LabelIndex.at / getByID / getAdjacency /
+// getCallsAdj / getStepAdj) are gated behind GRAFEL_SERVE_FROM_MMAP (default
+// OFF). With the flag OFF, none of them may dereference lr.Reader's mmap — the
+// handler path must read only the GC-safe Document, so a concurrent reload can
+// retire()+munmap the Reader without a read-after-unmap SIGBUS (the latent PR1
+// #5865 hazard).
+//
+// This test proves that observationally and deterministically (no race repro):
+// the LoadedRepo's Reader is loaded from a graph.fb whose content DIVERGES from
+// its Document (different entity ids, no relationships). With the flag OFF every
+// read path must return the DOCUMENT's content — if any of them sourced from the
+// Reader instead, the result would carry the Reader's divergent content and the
+// assertion fails. The Reader is a valid open mapping throughout, so the test
+// itself can build the Reader-sourced structures for the negative comparison.
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// TestServeFromMMapOff_HandlerPathsNeverDereferenceReader is the cutover safety
+// guard: flag OFF ⇒ at/getByID/getAdjacency/getCallsAdj/getStepAdj are all
+// Document-sourced and never touch lr.Reader's mmap.
+func TestServeFromMMapOff_HandlerPathsNeverDereferenceReader(t *testing.T) {
+	forceServeFromMMap(t, false) // production default
+
+	// Document: entities A,B with a CALLS and a STEP_IN_PROCESS edge A->B.
+	doc := &graph.Document{Version: 1, Repo: "svc"}
+	doc.Entities = []graph.Entity{
+		{ID: "A", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+		{ID: "B", Name: "B", Kind: "function", SourceFile: "b.go", Language: "go"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{FromID: "A", ToID: "B", Kind: "CALLS"},
+		{FromID: "A", ToID: "B", Kind: "STEP_IN_PROCESS"},
+	}
+
+	// DIVERGENT graph.fb backing the Reader: entities X,Y, NO relationships. If a
+	// flag-off read path touched the Reader, it would surface X/Y / empty edges.
+	rdrDoc := &graph.Document{Version: 1, Repo: "svc"}
+	rdrDoc.Entities = []graph.Entity{
+		{ID: "X", Name: "X", Kind: "function", SourceFile: "x.go", Language: "go"},
+		{ID: "Y", Name: "Y", Kind: "function", SourceFile: "y.go", Language: "go"},
+	}
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, rdrDoc); err != nil {
+		t.Fatalf("write divergent graph.fb: %v", err)
+	}
+	rdr, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { _ = rdr.Close() })
+
+	lr := &LoadedRepo{Repo: "svc", Doc: doc, Reader: rdr, LabelIndex: BuildLabelIndexFromReader(rdr, doc)}
+
+	// --- LabelIndex.at / getByID: must surface the Document's ids, not the
+	// Reader's divergent X/Y.
+	if a := lr.LabelIndex.at(0); a == nil || a.ID != "A" {
+		t.Fatalf("flag-off at(0) sourced from Reader (got %v); must be Document entity A", a)
+	}
+	byID := lr.getByID()
+	if _, ok := byID["A"]; !ok {
+		t.Fatalf("flag-off getByID missing Document id A (keys=%v)", entityMapKeys(byID))
+	}
+	if _, ok := byID["X"]; ok {
+		t.Fatalf("flag-off getByID surfaced Reader id X — it dereferenced the mmap")
+	}
+
+	// --- adjacency ×3: flag-off must equal the Document build and differ from the
+	// Reader build (the two diverge, so equality to Doc proves Doc-sourcing).
+	wantAdj := buildAdjacency(doc, "svc")
+	rdrAdj := buildAdjacencyFromReader(rdr, "svc")
+	gotAdj := lr.getAdjacency()
+	if !reflect.DeepEqual(gotAdj, wantAdj) {
+		t.Fatalf("flag-off getAdjacency != Document build (Reader-sourced?)")
+	}
+	if reflect.DeepEqual(gotAdj, rdrAdj) {
+		t.Fatalf("flag-off getAdjacency == Reader build — it dereferenced the mmap")
+	}
+
+	wantCalls := buildCallsAdjacency(doc)
+	rdrCalls := buildCallsAdjacencyFromReader(rdr)
+	gotCalls := lr.getCallsAdj()
+	if !reflect.DeepEqual(gotCalls, wantCalls) {
+		t.Fatalf("flag-off getCallsAdj != Document build (Reader-sourced?)")
+	}
+	if reflect.DeepEqual(gotCalls, rdrCalls) {
+		t.Fatalf("flag-off getCallsAdj == Reader build — it dereferenced the mmap")
+	}
+
+	wantStep := buildStepAdjacency(doc)
+	rdrStep := buildStepAdjacencyFromReader(rdr)
+	gotStep := lr.getStepAdj()
+	if !reflect.DeepEqual(gotStep, wantStep) {
+		t.Fatalf("flag-off getStepAdj != Document build (Reader-sourced?)")
+	}
+	if reflect.DeepEqual(gotStep, rdrStep) {
+		t.Fatalf("flag-off getStepAdj == Reader build — it dereferenced the mmap")
+	}
+}
+
+func entityMapKeys(m map[string]*graph.Entity) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -1,0 +1,211 @@
+// overlay_sidetable_parity_test.go — ADR-0027 mmap cutover (overlay side-table,
+// precondition for the PR7 loader flip).
+//
+// The side-table is a resident, entity-INDEX-keyed map holding the 5 group-algo
+// overlay fields (CommunityID/PageRank/Centrality/IsGodNode/IsArticulationPt)
+// that are NOT authoritative in graph.fb (per-repo Pass-4 was removed, so
+// graph.fb's copies are permanent sentinels). LabelIndex.at()/getByID now
+// MATERIALIZE the base entity from the mmap Reader (graph.MaterializeEntity) and
+// merge the 5 fields from the side-table — removing the read path's dependence
+// on the in-place-stamped lr.Doc for VALUES.
+//
+// This test is the behavior-neutral guard: with a real graph.fb (sentinel algo
+// fields) + an applied group-algo overlay, the Reader+side-table materialized
+// entity (via LabelIndex.at / getByID) must be byte-equal (reflect.DeepEqual) to
+// the overlaid lr.Doc.Entities[idx] — ALL fields, including the 5 overlay fields
+// AND non-view/non-overlay fields (StartLine/Subtype/Signature/QualifiedName).
+//
+// Mutation proof (performed during development, reverted): dropping the
+// side-table merge in LabelIndex.at makes the 5 fields regress to the graph.fb
+// sentinel, so the DeepEqual-vs-overlaid-Doc assertions FAIL.
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// richFixtureDoc builds a one-repo graph whose entities carry DISTINCT
+// non-view/non-overlay fields (StartLine/Subtype/Signature/QualifiedName) so the
+// parity assertion exercises fields beyond the 8 view fields + 5 overlay fields.
+// The algo fields are left at the sentinel (nil / -2 community) so anything that
+// shows up on the read path came from the overlay side-table, not graph.fb.
+func richFixtureDoc(slug string, names ...string) *graph.Document {
+	doc := &graph.Document{Version: 1, Repo: slug}
+	for i, n := range names {
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:            slug + ":" + n,
+			Name:          n,
+			QualifiedName: slug + "." + n,
+			Kind:          "function",
+			Subtype:       "handler",
+			SourceFile:    slug + "/" + n + ".go",
+			StartLine:     10 + i*7,
+			Language:      "go",
+			Signature:     "func " + n + "(ctx context.Context) error",
+		})
+	}
+	return doc
+}
+
+// setupSideTableParity writes a single on-disk graph.fb repo with rich entities,
+// registers the group, and returns the State + resolved overlay path + source
+// mtimes + the three entity ids.
+func setupSideTableParity(t *testing.T) (st *State, overlayPath string, cur map[string]int64, ids [3]string) {
+	t.Helper()
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	pathA := filepath.Join(root, "svc")
+	doc := richFixtureDoc("svc", "Alpha", "Bravo", "Charlie")
+
+	stateDir := daemon.StateDirForRepo(pathA)
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{{Slug: "svc", Path: pathA}}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	inMem := &Registry{
+		Path: filepath.Join(home, "registry.json"),
+		Groups: map[string]RegistryGroup{
+			"acme": {Repos: map[string]RegistryRepo{"svc": {Path: pathA}}},
+		},
+	}
+	st = NewState(inMem)
+	t.Cleanup(st.Close)
+
+	overlayPath, err = groupalgo.OverlayPath("acme")
+	if err != nil {
+		t.Fatalf("overlay path: %v", err)
+	}
+	cur, err = groupalgo.CurrentSourceMtimes("acme")
+	if err != nil {
+		t.Fatalf("current mtimes: %v", err)
+	}
+	return st, overlayPath, cur, [3]string{"svc:Alpha", "svc:Bravo", "svc:Charlie"}
+}
+
+// TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc is the mandatory
+// overlay-aware parity guard. It applies an overlay setting DISTINCT
+// CommunityID/PageRank/Centrality/god/articulation on two of three entities
+// (the third is left un-overlaid to prove the "no overlay entry → graph.fb
+// values survive" path), then asserts the Reader+side-table materialized entity
+// equals the overlaid Doc row for EVERY entity, via BOTH LabelIndex.at and
+// getByID.
+func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
+	st, overlayPath, cur, ids := setupSideTableParity(t)
+
+	alpha, bravo := ids[0], ids[1] // charlie (ids[2]) deliberately un-overlaid
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			alpha: {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+			bravo: {CommunityID: 80, PageRank: 0.0012, Centrality: 6706.5, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{
+			{ID: 39, Size: 1, AutoName: "alpha-cluster"},
+			{ID: 80, Size: 1, AutoName: "bravo-cluster"},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	grp := st.Group("acme")
+	lr := grp.Repos["svc"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatalf("svc repo not loaded")
+	}
+	if lr.Reader == nil {
+		t.Fatalf("svc repo has nil Reader — the parity test requires the mmap read path")
+	}
+	if lr.LabelIndex == nil {
+		t.Fatalf("svc repo has nil LabelIndex")
+	}
+
+	// Ground truth: the overlaid live Doc rows (what today's queries return).
+	docByID := map[string]*graph.Entity{}
+	for i := range lr.Doc.Entities {
+		e := lr.Doc.Entities[i]
+		docByID[e.ID] = &e
+	}
+
+	byIDMap := lr.getByID()
+
+	for _, id := range ids {
+		idx, ok := lr.LabelIndex.byID[id]
+		if !ok {
+			t.Fatalf("id %s not in LabelIndex", id)
+		}
+		want := docByID[id]
+		if want == nil {
+			t.Fatalf("id %s not in Doc", id)
+		}
+
+		// Non-view/non-overlay fields must survive the Reader materialization
+		// (proves MaterializeEntity carries them, not just the empty default).
+		gotAt := lr.LabelIndex.at(idx)
+		if gotAt == nil {
+			t.Fatalf("at(%d) returned nil for %s", idx, id)
+		}
+		if gotAt.StartLine != want.StartLine || gotAt.StartLine == 0 {
+			t.Fatalf("%s StartLine: got %d want %d (must be non-zero)", id, gotAt.StartLine, want.StartLine)
+		}
+		if gotAt.Subtype != "handler" || gotAt.Signature == "" || gotAt.QualifiedName == "" {
+			t.Fatalf("%s non-view fields dropped by Reader materialize: subtype=%q sig=%q qname=%q",
+				id, gotAt.Subtype, gotAt.Signature, gotAt.QualifiedName)
+		}
+
+		// Full byte-equality: Reader+side-table == overlaid Doc row.
+		if !reflect.DeepEqual(gotAt, want) {
+			t.Fatalf("LabelIndex.at parity mismatch for %s:\n got=%#v\nwant=%#v", id, gotAt, want)
+		}
+		if got := byIDMap[id]; !reflect.DeepEqual(got, want) {
+			t.Fatalf("getByID parity mismatch for %s:\n got=%#v\nwant=%#v", id, got, want)
+		}
+	}
+
+	// Explicit spot-checks on the 5 overlay fields sourced from the side-table.
+	if a := byIDMap[alpha]; a == nil || a.CommunityID == nil || *a.CommunityID != 39 ||
+		a.PageRank == nil || *a.PageRank != 0.0065 || a.Centrality == nil || *a.Centrality != 10415.99 ||
+		!a.IsGodNode || a.IsArticulationPt {
+		t.Fatalf("alpha overlay fields not sourced from side-table: %#v", a)
+	}
+	if b := byIDMap[bravo]; b == nil || b.CommunityID == nil || *b.CommunityID != 80 ||
+		!b.IsArticulationPt || b.IsGodNode {
+		t.Fatalf("bravo overlay fields not sourced from side-table: %#v", b)
+	}
+	// Charlie has no overlay entry: the 5 fields must equal the graph.fb sentinel
+	// (nil pointers / false flags), identical to the un-stamped Doc row.
+	if c := byIDMap[ids[2]]; c == nil || c.CommunityID != nil || c.PageRank != nil ||
+		c.Centrality != nil || c.IsGodNode || c.IsArticulationPt {
+		t.Fatalf("charlie (un-overlaid) leaked overlay values: %#v", c)
+	}
+}

--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -59,6 +59,18 @@ func richFixtureDoc(slug string, names ...string) *graph.Document {
 // setupSideTableParity writes a single on-disk graph.fb repo with rich entities,
 // registers the group, and returns the State + resolved overlay path + source
 // mtimes + the three entity ids.
+// forceServeFromMMap overrides the package-cached GRAFEL_SERVE_FROM_MMAP flag for
+// the duration of a test and restores it. serveFromMMapEnabled is captured once
+// at package load, so t.Setenv is too late — the cached var must be set directly.
+// Safe under -race: callers are NOT t.Parallel(), so they run to completion
+// (restoring the flag) before any parallel test that reads the flag is resumed.
+func forceServeFromMMap(t *testing.T, v bool) {
+	t.Helper()
+	prev := serveFromMMapEnabled
+	serveFromMMapEnabled = v
+	t.Cleanup(func() { serveFromMMapEnabled = prev })
+}
+
 func setupSideTableParity(t *testing.T) (st *State, overlayPath string, cur map[string]int64, ids [3]string) {
 	t.Helper()
 	testsupport.IsolateHome(t)
@@ -115,6 +127,7 @@ func setupSideTableParity(t *testing.T) (st *State, overlayPath string, cur map[
 // equals the overlaid Doc row for EVERY entity, via BOTH LabelIndex.at and
 // getByID.
 func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
+	forceServeFromMMap(t, true) // exercise the flip path (default is OFF)
 	st, overlayPath, cur, ids := setupSideTableParity(t)
 
 	alpha, bravo := ids[0], ids[1] // charlie (ids[2]) deliberately un-overlaid
@@ -207,5 +220,56 @@ func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
 	if c := byIDMap[ids[2]]; c == nil || c.CommunityID != nil || c.PageRank != nil ||
 		c.Centrality != nil || c.IsGodNode || c.IsArticulationPt {
 		t.Fatalf("charlie (un-overlaid) leaked overlay values: %#v", c)
+	}
+}
+
+// TestOverlaySideTable_FlagOffBuildsNoSideTableAndReadsDoc is the safety guard
+// for the DEFAULT (GRAFEL_SERVE_FROM_MMAP OFF) path: applyGroupAlgoOverlay must
+// NOT build the side-table (no resident cost pre-flip) and the read path must
+// source the overlay values from the in-place-stamped Doc — never the mmap
+// Reader — so there is no handler-path mmap read to race a reload's munmap.
+func TestOverlaySideTable_FlagOffBuildsNoSideTableAndReadsDoc(t *testing.T) {
+	forceServeFromMMap(t, false) // the production default
+	st, overlayPath, cur, ids := setupSideTableParity(t)
+
+	alpha := ids[0]
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			alpha: {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+		},
+		Communities: []graph.CommunityResult{{ID: 39, Size: 1, AutoName: "alpha-cluster"}},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	grp := st.Group("acme")
+	lr := grp.Repos["svc"]
+	if lr == nil || lr.Doc == nil || lr.LabelIndex == nil {
+		t.Fatalf("svc repo not loaded")
+	}
+
+	// No side-table built on the flag-off path → no resident memory paid.
+	if lr.LabelIndex.overlay != nil {
+		t.Fatalf("flag-off built a side-table (len=%d); it must stay nil pre-flip", len(lr.LabelIndex.overlay))
+	}
+
+	// Values still surface — sourced from the in-place-stamped Doc, not the Reader.
+	if a := lr.LabelIndex.ByID(alpha); a == nil || a.CommunityID == nil || *a.CommunityID != 39 ||
+		a.PageRank == nil || *a.PageRank != 0.0065 || !a.IsGodNode {
+		t.Fatalf("flag-off ByID did not surface the overlaid Doc values: %#v", a)
+	}
+	// The Doc-sourced result must byte-equal the overlaid Doc row.
+	for i := range lr.Doc.Entities {
+		want := lr.Doc.Entities[i]
+		got := lr.LabelIndex.ByID(want.ID)
+		if !reflect.DeepEqual(got, &want) {
+			t.Fatalf("flag-off ByID(%s) != overlaid Doc row:\n got=%#v\nwant=%#v", want.ID, got, &want)
+		}
 	}
 }

--- a/internal/mcp/reader_index_parity_pr2_test.go
+++ b/internal/mcp/reader_index_parity_pr2_test.go
@@ -219,31 +219,33 @@ func docEntityByID(doc *graph.Document, id string) *graph.Entity {
 }
 
 // TestLabelIndexSurfacesOverlayStampedFields_PR2 is the load-bearing invariant
-// test for "the 5 group-algo overlay fields surface on the index path".
+// test for "values come from the overlaid Doc, NEVER the Reader" on the DEFAULT
+// (GRAFEL_SERVE_FROM_MMAP OFF) serve path — which is what production runs and
+// what the ADR-0027 overlay side-table leaves byte-identical until PR7 turns the
+// flag on. (The flag-ON Reader+side-table flip path is covered separately by
+// TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc.)
 //
-// ADR-0027 overlay side-table (PR7 precondition): LabelIndex.at() now
-// MATERIALIZES the base entity from the mmap Reader (graph.MaterializeEntity)
-// and merges the 5 overlay-only fields (CommunityID / PageRank / Centrality /
-// IsGodNode / IsArticulationPt) from the resident side-table — those values live
-// in the <group>-algo.json overlay, NOT in graph.fb, so the Reader carries only
-// sentinels/zero for them. applyGroupAlgoOverlay stamps BOTH the (transitional)
-// in-place Doc AND the side-table; this test mirrors that by stamping the Doc
-// and populating lr.LabelIndex.overlay by entity index, then asserts
-// LabelIndex.ByID / Lookup / getByID SURFACE the overlay values.
+// The other PR2 value-parity tests compare two DOC-sourced indexes over a
+// fixture that stamps NO overlay-only fields, so they would pass even if at()
+// were (wrongly) flipped to read the mmap Reader for values. This test closes
+// that blind spot — the EXACT regression class that bit PR1.
 //
-// Mutation check (verified once, then reverted): dropping the side-table merge
-// in LabelIndex.at() makes this test FAIL — ByID(id::a) surfaces the graph.fb
-// sentinel CommunityID, not the overlay's 80 — proving the side-table
-// value-source is load-bearing now that the base comes from the Reader.
+// It stamps overlay-ONLY fields (CommunityID / Centrality / IsGodNode) onto
+// Doc.Entities the way applyGroupAlgoOverlay does — those values live in the
+// <group>-algo.json overlay, NOT in graph.fb, so the resident Reader carries
+// only sentinels/zero for them — then asserts LabelIndex.ByID / Lookup / getByID
+// SURFACE the stamped values. Mutation check (verified once, then reverted):
+// flipping the DEFAULT LabelIndex.at() path to materialize from the Reader
+// (graph.MaterializeEntity(l.reader, idx)) makes this test FAIL — ByID(id::a)
+// surfaces the graph.fb sentinel CommunityID, not the stamped 80 — proving the
+// Doc value-source is load-bearing for the flag-off path.
 func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
 	t.Parallel()
 	doc, r := loadParityIndexFixture(t)
-	li := BuildLabelIndexFromReader(r, doc)
-	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: li}
+	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
 
 	const wantCID = 80
 	const wantCen = 0.4242
-	overlay := map[int32]entityOverlay{}
 	stamp := func(id string, cid int, cen float64, god bool) {
 		e := docEntityByID(doc, id)
 		if e == nil {
@@ -253,20 +255,11 @@ func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
 		e.CommunityID = &c
 		e.Centrality = &ce
 		e.IsGodNode = god
-		// Mirror applyGroupAlgoOverlay's side-table population (distinct pointers,
-		// keyed by the entity's vector index).
-		idx, ok := li.byID[id]
-		if !ok {
-			t.Fatalf("fixture id %q missing from LabelIndex", id)
-		}
-		tc, tce := cid, cen
-		overlay[idx] = entityOverlay{CommunityID: &tc, Centrality: &tce, IsGodNode: god}
 	}
 	stamp("id::a", wantCID, wantCen, true)
 	stamp("id::b", 7, 0.99, false)
-	li.overlay = overlay
 	// Mirror the overlay's post-stamp index re-arm so getByID rebuilds off the
-	// Reader + side-table.
+	// stamped Doc (LabelIndex reads Doc live, so it needs no rebuild).
 	lr.resetIndexes()
 
 	// LabelIndex.ByID surfaces the stamped overlay-only fields.

--- a/internal/mcp/reader_index_parity_pr2_test.go
+++ b/internal/mcp/reader_index_parity_pr2_test.go
@@ -219,29 +219,31 @@ func docEntityByID(doc *graph.Document, id string) *graph.Entity {
 }
 
 // TestLabelIndexSurfacesOverlayStampedFields_PR2 is the load-bearing invariant
-// test for "values come from the overlaid Doc, NEVER the Reader".
+// test for "the 5 group-algo overlay fields surface on the index path".
 //
-// The other PR2 value-parity tests compare two DOC-sourced indexes over a
-// fixture that stamps NO overlay-only fields, so they would pass even if at()
-// were (wrongly) flipped to read the mmap Reader for values. This test closes
-// that blind spot — the EXACT regression class that bit PR1.
+// ADR-0027 overlay side-table (PR7 precondition): LabelIndex.at() now
+// MATERIALIZES the base entity from the mmap Reader (graph.MaterializeEntity)
+// and merges the 5 overlay-only fields (CommunityID / PageRank / Centrality /
+// IsGodNode / IsArticulationPt) from the resident side-table — those values live
+// in the <group>-algo.json overlay, NOT in graph.fb, so the Reader carries only
+// sentinels/zero for them. applyGroupAlgoOverlay stamps BOTH the (transitional)
+// in-place Doc AND the side-table; this test mirrors that by stamping the Doc
+// and populating lr.LabelIndex.overlay by entity index, then asserts
+// LabelIndex.ByID / Lookup / getByID SURFACE the overlay values.
 //
-// It stamps overlay-ONLY fields (CommunityID / Centrality / IsGodNode) onto
-// Doc.Entities the way applyGroupAlgoOverlay does — those values live in the
-// <group>-algo.json overlay, NOT in graph.fb, so the resident Reader carries
-// only sentinels/zero for them — then asserts LabelIndex.ByID / Lookup / getByID
-// SURFACE the stamped values. Mutation check (verified once, then reverted):
-// flipping LabelIndex.at() to materialize from the Reader
-// (graph.MaterializeEntity(l.reader, idx)) makes this test FAIL — ByID(id::a)
-// surfaces the graph.fb sentinel CommunityID, not the stamped 80 — proving the
-// Doc value-source is load-bearing.
+// Mutation check (verified once, then reverted): dropping the side-table merge
+// in LabelIndex.at() makes this test FAIL — ByID(id::a) surfaces the graph.fb
+// sentinel CommunityID, not the overlay's 80 — proving the side-table
+// value-source is load-bearing now that the base comes from the Reader.
 func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
 	t.Parallel()
 	doc, r := loadParityIndexFixture(t)
-	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
+	li := BuildLabelIndexFromReader(r, doc)
+	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: li}
 
 	const wantCID = 80
 	const wantCen = 0.4242
+	overlay := map[int32]entityOverlay{}
 	stamp := func(id string, cid int, cen float64, god bool) {
 		e := docEntityByID(doc, id)
 		if e == nil {
@@ -251,11 +253,20 @@ func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
 		e.CommunityID = &c
 		e.Centrality = &ce
 		e.IsGodNode = god
+		// Mirror applyGroupAlgoOverlay's side-table population (distinct pointers,
+		// keyed by the entity's vector index).
+		idx, ok := li.byID[id]
+		if !ok {
+			t.Fatalf("fixture id %q missing from LabelIndex", id)
+		}
+		tc, tce := cid, cen
+		overlay[idx] = entityOverlay{CommunityID: &tc, Centrality: &tce, IsGodNode: god}
 	}
 	stamp("id::a", wantCID, wantCen, true)
 	stamp("id::b", 7, 0.99, false)
+	li.overlay = overlay
 	// Mirror the overlay's post-stamp index re-arm so getByID rebuilds off the
-	// stamped Doc (LabelIndex reads Doc live, so it needs no rebuild).
+	// Reader + side-table.
 	lr.resetIndexes()
 
 	// LabelIndex.ByID surfaces the stamped overlay-only fields.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -580,14 +580,19 @@ func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 			return
 		}
 		m := make(map[string]*graph.Entity, len(lr.Doc.Entities))
+		// ADR-0027: only when GRAFEL_SERVE_FROM_MMAP is ON does getByID source each
+		// row from the Reader + overlay side-table via LabelIndex.at (byte-equal to
+		// the overlaid Doc row), removing the Doc VALUE dependence. On the flag-off
+		// default path this stays the PR2 live-Doc heap copy — GC-safe, with NO
+		// handler-path mmap read. mmapSourced also short-circuits to the Doc copy
+		// whenever at() cannot serve an index (nil LabelIndex/Reader, JSON load).
+		mmapSourced := serveFromMMap() && lr.LabelIndex != nil
 		for i := range lr.Doc.Entities {
-			// ADR-0027: source each row from the Reader + overlay side-table via
-			// LabelIndex.at (byte-equal to the overlaid Doc row) so getByID no
-			// longer depends on lr.Doc for VALUES. Falls back to a live-Doc heap
-			// copy when no LabelIndex/Reader backs this repo (JSON-only load).
-			if ent := lr.LabelIndex.at(int32(i)); ent != nil {
-				m[ent.ID] = ent
-				continue
+			if mmapSourced {
+				if ent := lr.LabelIndex.at(int32(i)); ent != nil {
+					m[ent.ID] = ent
+					continue
+				}
 			}
 			ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
 			m[ent.ID] = &ent
@@ -1742,13 +1747,20 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			continue
 		}
 		ents := lr.Doc.Entities
-		// ADR-0027 overlay SIDE-TABLE: build a fresh entity-INDEX-keyed table of
-		// the 5 overlay fields alongside the (transitional) in-place Doc stamp, so
-		// the Reader-materialized read path (LabelIndex.at/getByID) can merge them
-		// without depending on lr.Doc for VALUES. Keyed by vector index i (== the
-		// LabelIndex/Reader position), resolved here because this loop already
-		// visits every entity by index and matches it to the overlay by ID.
-		table := make(map[int32]entityOverlay)
+		// ADR-0027 overlay SIDE-TABLE (built ONLY when GRAFEL_SERVE_FROM_MMAP is
+		// ON): a fresh entity-INDEX-keyed table of the 5 overlay fields alongside
+		// the (transitional) in-place Doc stamp, so the Reader-materialized read
+		// path (LabelIndex.at/getByID) can merge them without depending on lr.Doc
+		// for VALUES. Keyed by vector index i (== the LabelIndex/Reader position),
+		// resolved here because this loop already visits every entity by index and
+		// matches it to the overlay by ID. On the flag-off default path the table
+		// is left nil — the read path reads the overlaid Doc — so no resident cost
+		// is paid pre-flip.
+		buildSideTable := serveFromMMap()
+		var table map[int32]entityOverlay
+		if buildSideTable {
+			table = make(map[int32]entityOverlay)
+		}
 		for i := range ents {
 			eo, has := ov.Results[ents[i].ID]
 			if !has {
@@ -1762,24 +1774,27 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			ents[i].Centrality = &cen
 			ents[i].IsGodNode = eo.IsGodNode
 			ents[i].IsArticulationPt = eo.IsArticulationPoint
-			// Independent heap copies (distinct pointers from the Doc stamp above)
-			// so the side-table remains valid after the PR7 Doc drop.
-			tcid := eo.CommunityID
-			tpr := eo.PageRank
-			tcen := eo.Centrality
-			table[int32(i)] = entityOverlay{
-				CommunityID:      &tcid,
-				PageRank:         &tpr,
-				Centrality:       &tcen,
-				IsGodNode:        eo.IsGodNode,
-				IsArticulationPt: eo.IsArticulationPoint,
+			if buildSideTable {
+				// Independent heap copies (distinct pointers from the Doc stamp
+				// above) so the side-table remains valid after the PR7 Doc drop.
+				tcid := eo.CommunityID
+				tpr := eo.PageRank
+				tcen := eo.Centrality
+				table[int32(i)] = entityOverlay{
+					CommunityID:      &tcid,
+					PageRank:         &tpr,
+					Centrality:       &tcen,
+					IsGodNode:        eo.IsGodNode,
+					IsArticulationPt: eo.IsArticulationPoint,
+				}
 			}
 		}
 		// Publish the side-table onto the current LabelIndex generation BEFORE
 		// re-arming the lazy indexes below, so the next getByID build merges it.
 		// resetIndexes does NOT touch LabelIndex, so the table persists for the
-		// life of this generation and is reassigned on the next re-stamp.
-		if lr.LabelIndex != nil {
+		// life of this generation and is reassigned on the next re-stamp. Only on
+		// the flag-on path; flag-off leaves lr.LabelIndex.overlay nil.
+		if buildSideTable && lr.LabelIndex != nil {
 			lr.LabelIndex.overlay = table
 		}
 		// Re-arm lazy derived indexes (TopKPageRank etc.) so they rebuild

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -581,6 +581,14 @@ func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 		}
 		m := make(map[string]*graph.Entity, len(lr.Doc.Entities))
 		for i := range lr.Doc.Entities {
+			// ADR-0027: source each row from the Reader + overlay side-table via
+			// LabelIndex.at (byte-equal to the overlaid Doc row) so getByID no
+			// longer depends on lr.Doc for VALUES. Falls back to a live-Doc heap
+			// copy when no LabelIndex/Reader backs this repo (JSON-only load).
+			if ent := lr.LabelIndex.at(int32(i)); ent != nil {
+				m[ent.ID] = ent
+				continue
+			}
 			ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
 			m[ent.ID] = &ent
 		}
@@ -1734,6 +1742,13 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			continue
 		}
 		ents := lr.Doc.Entities
+		// ADR-0027 overlay SIDE-TABLE: build a fresh entity-INDEX-keyed table of
+		// the 5 overlay fields alongside the (transitional) in-place Doc stamp, so
+		// the Reader-materialized read path (LabelIndex.at/getByID) can merge them
+		// without depending on lr.Doc for VALUES. Keyed by vector index i (== the
+		// LabelIndex/Reader position), resolved here because this loop already
+		// visits every entity by index and matches it to the overlay by ID.
+		table := make(map[int32]entityOverlay)
 		for i := range ents {
 			eo, has := ov.Results[ents[i].ID]
 			if !has {
@@ -1747,6 +1762,25 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			ents[i].Centrality = &cen
 			ents[i].IsGodNode = eo.IsGodNode
 			ents[i].IsArticulationPt = eo.IsArticulationPoint
+			// Independent heap copies (distinct pointers from the Doc stamp above)
+			// so the side-table remains valid after the PR7 Doc drop.
+			tcid := eo.CommunityID
+			tpr := eo.PageRank
+			tcen := eo.Centrality
+			table[int32(i)] = entityOverlay{
+				CommunityID:      &tcid,
+				PageRank:         &tpr,
+				Centrality:       &tcen,
+				IsGodNode:        eo.IsGodNode,
+				IsArticulationPt: eo.IsArticulationPoint,
+			}
+		}
+		// Publish the side-table onto the current LabelIndex generation BEFORE
+		// re-arming the lazy indexes below, so the next getByID build merges it.
+		// resetIndexes does NOT touch LabelIndex, so the table persists for the
+		// life of this generation and is reassigned on the next re-stamp.
+		if lr.LabelIndex != nil {
+			lr.LabelIndex.overlay = table
 		}
 		// Re-arm lazy derived indexes (TopKPageRank etc.) so they rebuild
 		// against the freshly-stamped group values rather than stale per-repo

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -711,9 +711,14 @@ func (lr *LoadedRepo) getAdjacency() *adjacency {
 		}
 		// ADR-0027 Cutover PR1: source the build from the resident mmap Reader
 		// when present (byte-identical to the Document build — same rows, same
-		// order). Falls back to the Document only when no graph.fb is mapped
-		// (JSON-only load / Open failure). Not flag-gated.
-		if lr.Reader != nil {
+		// order), ELSE the Document. Gated behind GRAFEL_SERVE_FROM_MMAP (default
+		// OFF): this getter runs on the HANDLER path (idxMu only), and a
+		// concurrent reload retire()s+munmaps the old Reader WITHOUT idxMu (F1's
+		// borrow protocol is inert → refs==0 → immediate munmap), so an
+		// unconditional Reader iteration here is a read-after-unmap SIGBUS (latent
+		// PR1 #5865). OFF → the GC-safe Document build; ON is DARK until the borrow
+		// protocol is wired into the read path. Nil-Reader always uses the Document.
+		if lr.Reader != nil && serveFromMMap() {
 			lr.adjacency = buildAdjacencyFromReader(lr.Reader, lr.Repo)
 		} else {
 			lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)
@@ -734,8 +739,10 @@ func (lr *LoadedRepo) getCallsAdj() *callsAdjacency {
 			lr.callsAdj = &callsAdjacency{}
 			return
 		}
-		// ADR-0027 Cutover PR1: prefer the resident mmap Reader (see getAdjacency).
-		if lr.Reader != nil {
+		// ADR-0027 Cutover PR1: prefer the resident mmap Reader when ON, else the
+		// Document. Flag-gated (default OFF) for the same handler-path munmap
+		// SIGBUS reason as getAdjacency.
+		if lr.Reader != nil && serveFromMMap() {
 			lr.callsAdj = buildCallsAdjacencyFromReader(lr.Reader)
 		} else {
 			lr.callsAdj = buildCallsAdjacency(lr.Doc)
@@ -753,8 +760,10 @@ func (lr *LoadedRepo) getStepAdj() map[string][]stepEdge {
 			lr.stepAdj = map[string][]stepEdge{}
 			return
 		}
-		// ADR-0027 Cutover PR1: prefer the resident mmap Reader (see getAdjacency).
-		if lr.Reader != nil {
+		// ADR-0027 Cutover PR1: prefer the resident mmap Reader when ON, else the
+		// Document. Flag-gated (default OFF) for the same handler-path munmap
+		// SIGBUS reason as getAdjacency.
+		if lr.Reader != nil && serveFromMMap() {
 			lr.stepAdj = buildStepAdjacencyFromReader(lr.Reader)
 		} else {
 			lr.stepAdj = buildStepAdjacency(lr.Doc)
@@ -1175,10 +1184,12 @@ func (s *State) reloadLocked() (int, bool, error) {
 					//
 					// ADR-0027 Cutover PR1: count TESTS-kind edges off the freshly
 					// opened mmap Reader (Kind() read directly) rather than the
-					// materialized Document. Byte-neutral (Reader == Document's rows);
-					// falls back to doc.Relationships only when no graph.fb is mapped.
+					// materialized Document. Byte-neutral (Reader == Document's rows).
+					// Gated behind GRAFEL_SERVE_FROM_MMAP (default OFF) so the whole
+					// cutover shares ONE switch and no mmap read happens off the flag;
+					// falls back to doc.Relationships when OFF or no graph.fb is mapped.
 					testsCount := 0
-					if newRdr != nil {
+					if newRdr != nil && serveFromMMap() {
 						newRdr.IterateRelationships(func(rel *fb.Relationship) bool {
 							if string(rel.Kind()) == "TESTS" {
 								testsCount++


### PR DESCRIPTION
Refs #5850 (mmap cutover). **Fixes a LIVE read-after-munmap SIGBUS introduced by PR1 (#5865)** and lands the overlay side-table + Reader-value flip machinery DARK behind the default-off flag.

## The bug being fixed (live on main)
PR1 made `getAdjacency`/`getCallsAdj`/`getStepAdj` + the TESTS-edge count read the mmap `fbreader.Reader` at HANDLER-query time, unconditionally. A concurrent reload (`reloadLocked`, under `s.mu`) synchronously `retire()`s+`munmap`s the old Reader (F1 borrow protocol is inert → refs==0 → immediate munmap), on a different lock than the `idxMu`-held handler build → read-after-munmap SIGBUS. Confirmed reachable on every reparsing reload concurrent with a query (watchers-on / agent-fleet workload). `.grafel/research/mmap-handler-read-safety.md`.

## Fix: gate every handler-path mmap read behind `GRAFEL_SERVE_FROM_MMAP` (default OFF)
Flag OFF (default, production): `at()`/`getByID`/adjacency×3/TESTS-count all source from the GC-safe `lr.Doc` (the existing Document-sourced builds / nil-Reader fallback). **No handler-path code dereferences `lr.Reader`'s mmap** → reload may munmap freely, no SIGBUS. Byte-identical to current main, no new resident memory.
Flag ON: the Reader-sourced builds + overlay side-table + Reader-value materialization (the flip behavior) — DARK until the borrow protocol is wired into the read path (the remaining precondition) + PR7 turns the flag on.

Swept all non-test `lr.Reader` derefs: `at`/`getByID`/`getAdjacency`/`getCallsAdj`/`getStepAdj`/TESTS-count → gated; `mmapEntityViewSource` → already gated (F3); `buildTopKPageRankFromReader` → no production caller; `BuildLabelIndexFromReader`'s iterate → reload-time only, under `s.mu`, on the just-opened `newRdr` (not yet published/retired → no munmap race). **Zero flag-off handler-path mmap derefs.**

## Overlay side-table (dark)
`entityOverlay{CommunityID/PageRank/Centrality/IsGodNode/IsArticulationPt}` keyed by entity index, built (flag-on only) in `applyGroupAlgoOverlay` from `<group>-algo.json` (the sole source — graph.fb algo fields are sentinels since per-repo Pass-4 was removed). Merged at the materialize seam so the flip path reproduces the overlaid entity. ~8.7 MB/100K entities (paid only when flag on). Field-coverage verified: every `graph.Entity` field is reproducible from fb or the side-table — nothing lost at the flip.

## Tests (`-race`)
- **Safety:** `TestServeFromMMapOff_HandlerPathsNeverDereferenceReader` — Reader loaded from a graph.fb that DIVERGES from its Doc; flag off, asserts `at`/`getByID`/adjacency×3 read the Doc, not the Reader. Mutation-proven (un-gate `getAdjacency` → fails).
- **Flip parity (flag on):** `TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc` (Reader+side-table byte-equals overlaid Doc, mutation-proven) + `…FlagOffBuildsNoSideTableAndReadsDoc`.
- Existing PR1/PR2 reader-parity tests remain green.

## Gate (local)
`go build ./...` ok · `go vet ./internal/mcp/... ./internal/graph/...` ok · `gofmt -l` clean · `go test ./internal/mcp/... ./internal/graph/... -race -count=1` → 1409 passed / 10 packages. No fbversion bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o