### PR TITLE
fix(mcp): SIGBUS-safe flag-on mmap reads via strictly-innermost readerMu + retired flag (ADR-0027)

### DIFF
--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"strings"
+	"sync"
 
 	"github.com/cajasmota/grafel/internal/graph"
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
@@ -69,6 +70,19 @@ type LabelIndex struct {
 	// every overlay re-stamp. nil on the flag-off path and until an overlay is
 	// applied.
 	overlay map[int32]entityOverlay
+
+	// readerMu points at the owning LoadedRepo.readerMu — the strictly-innermost
+	// ADR-0027 SIGBUS-safety mutex (memory epic #5850, "Option B"). Wired by
+	// reloadLocked; nil for the Doc-only build and directly-constructed indexes
+	// (tests), where at() takes the legacy unlocked reader/Doc path. When non-nil,
+	// at() dereferences the mmap ONLY under this mutex and ONLY after checking
+	// handle.readRetired, so a lookup on a *LabelIndex captured before a reload —
+	// whose mapping the reload retired+munmapped — falls back to the Doc instead of
+	// dereferencing the freed region.
+	readerMu *sync.Mutex
+	// handle is this index generation's MapHandle (its reader == reader above).
+	// at() checks handle.readRetired under readerMu. Set together with readerMu.
+	handle *MapHandle
 
 	byID    map[string]int32
 	byLabel map[string][]int32
@@ -220,17 +234,43 @@ func (l *LabelIndex) at(idx int32) *graph.Entity {
 		return nil
 	}
 	if l.reader != nil && serveFromMMap() {
-		e := graph.MaterializeEntity(l.reader, int(idx))
-		if ov, ok := l.overlay[idx]; ok {
-			e.CommunityID = ov.CommunityID
-			e.PageRank = ov.PageRank
-			e.Centrality = ov.Centrality
-			e.IsGodNode = ov.IsGodNode
-			e.IsArticulationPt = ov.IsArticulationPt
+		// ADR-0027 SIGBUS-safety (memory epic #5850): when wired (production), take
+		// the strictly-innermost readerMu around the mmap dereference. If this
+		// generation's mapping was retired+munmapped by a concurrent reload (a stale
+		// captured *LabelIndex), readRetired is set true under this same readerMu, so
+		// fall back to the GC-safe Doc copy instead of dereferencing the freed
+		// region. Unwired indexes (readerMu==nil: tests / direct construction) keep
+		// the legacy unlocked reader path — no reload retires them.
+		if l.readerMu != nil {
+			l.readerMu.Lock()
+			if l.handle != nil && l.handle.readRetired {
+				l.readerMu.Unlock()
+				e := l.doc.Entities[idx] // Doc fallback — mapping is gone
+				return &e
+			}
+			e := l.materializeFromReader(idx)
+			l.readerMu.Unlock()
+			return e
 		}
-		return &e
+		return l.materializeFromReader(idx)
 	}
 	e := l.doc.Entities[idx] // heap copy — a fresh pointer, not an alias into Doc
+	return &e
+}
+
+// materializeFromReader decodes the base entity from the mmap Reader and merges
+// the group-algo overlay side-table. Callers on the wired path MUST hold
+// readerMu (the mmap dereference happens here); MaterializeEntity copies every
+// string out to the heap, so the returned entity is safe to use past release.
+func (l *LabelIndex) materializeFromReader(idx int32) *graph.Entity {
+	e := graph.MaterializeEntity(l.reader, int(idx))
+	if ov, ok := l.overlay[idx]; ok {
+		e.CommunityID = ov.CommunityID
+		e.PageRank = ov.PageRank
+		e.Centrality = ov.Centrality
+		e.IsGodNode = ov.IsGodNode
+		e.IsArticulationPt = ov.IsArticulationPt
+	}
 	return &e
 }
 

--- a/internal/mcp/maphandle.go
+++ b/internal/mcp/maphandle.go
@@ -57,6 +57,17 @@ type MapHandle struct {
 	retired atomic.Bool
 	closed  sync.Once
 
+	// readRetired is the ADR-0027 read-side SIGBUS-safety flag (memory epic
+	// #5850, "Option B"), DISTINCT from the F1 refcount-drain `retired` atomic
+	// above. It is set true — ALWAYS under the owning LoadedRepo.readerMu — in
+	// publishHandle/retireHandle immediately BEFORE this handle's mapping is
+	// munmapped. The GRAFEL_SERVE_FROM_MMAP flag-on read choke points check it
+	// under that SAME readerMu: a stale captured *LabelIndex whose mapping was
+	// retired out from under it reads readRetired==true and falls back to the
+	// GC-safe Doc path instead of dereferencing the freed region. Plain bool
+	// (not atomic): every read and write is serialized by readerMu.
+	readRetired bool
+
 	// releaseGap, when non-nil, is invoked inside release() in the window
 	// BETWEEN the refcount decrement and the close decision. It is a test-only
 	// scheduling seam used to force the stale-refcount rebound interleaving

--- a/internal/mcp/mmap_readermu_sigbus_test.go
+++ b/internal/mcp/mmap_readermu_sigbus_test.go
@@ -1,0 +1,285 @@
+// mmap_readermu_sigbus_test.go — ADR-0027 SIGBUS-safety (memory epic #5850,
+// Option B) for the GRAFEL_SERVE_FROM_MMAP flag-ON read path.
+//
+// When the flag is ON the 4 read choke points (LabelIndex.at /
+// buildAdjacencyFromReader / buildCallsAdjacencyFromReader /
+// buildStepAdjacencyFromReader) dereference the mmap fbreader.Reader. A
+// concurrent reload's synchronous munmap can race an in-flight read → read-after-
+// munmap SIGBUS. The load-bearing mechanism guarded here is:
+//
+//   - LoadedRepo.readerMu (STRICTLY INNERMOST): every choke-point mmap deref and
+//     every reload/evict munmap holds it, so a deref and the munmap of that same
+//     mapping can never interleave.
+//   - MapHandle.readRetired: set true UNDER readerMu immediately BEFORE the
+//     munmap. A choke point holding a mapping retired out from under it (a stale
+//     captured *LabelIndex) sees readRetired==true and falls back to the Doc path
+//     instead of dereferencing the freed region.
+//
+// These tests run flag-ON with -race and must complete with NO SIGBUS/SIGSEGV/
+// panic and correct data.
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// sigbusFixtureDoc builds a small graph with n entities and CALLS +
+// STEP_IN_PROCESS edges so all three adjacency builders (and at()) iterate real
+// mmap-backed rows.
+func sigbusFixtureDoc(n int) *graph.Document {
+	doc := &graph.Document{Version: 1, Repo: "r"}
+	for i := 0; i < n; i++ {
+		id := "e" + itoa(i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: id, Name: id, QualifiedName: "r." + id,
+			Kind: "function", SourceFile: id + ".go", Language: "go",
+			StartLine: 1 + i,
+		})
+	}
+	for i := 0; i+1 < n; i++ {
+		from, to := "e"+itoa(i), "e"+itoa(i+1)
+		doc.Relationships = append(doc.Relationships,
+			graph.Relationship{FromID: from, ToID: to, Kind: "CALLS"},
+			graph.Relationship{FromID: from, ToID: to, Kind: "STEP_IN_PROCESS"},
+		)
+	}
+	return doc
+}
+
+// wireReaderLabelIndex builds a fully-wired reader-sourced LabelIndex for lr's
+// readerMu + the given handle, exactly as reloadLocked does in production.
+func wireReaderLabelIndex(lr *LoadedRepo, rdr *fbreader.Reader, h *MapHandle, doc *graph.Document) *LabelIndex {
+	li := BuildLabelIndexFromReader(rdr, doc)
+	li.readerMu = &lr.readerMu
+	li.handle = h
+	return li
+}
+
+// TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS is THE SIGBUS test: flag-ON,
+// many goroutines hammer all 4 choke points while a reloader repeatedly swaps the
+// reader (open a fresh real mmap, publish the successor, retire+munmap the
+// predecessor). Run with -race it must finish without a read-after-munmap
+// SIGBUS/SIGSEGV/panic. Without readerMu, a choke-point deref races the munmap.
+func TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	doc := sigbusFixtureDoc(24)
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	open := func() *fbreader.Reader {
+		r, err := fbreader.Open(fbPath)
+		if err != nil {
+			t.Fatalf("open reader: %v", err)
+		}
+		return r
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	// Install the first generation.
+	s.mu.Lock()
+	h0 := newMapHandle(open())
+	lr.LabelIndex = wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.publishHandle(h0)
+	s.mu.Unlock()
+
+	stop := make(chan struct{})
+	var faults atomic.Int64
+
+	// Reloader: swap the reader in a tight loop, always under s.mu, retiring the
+	// predecessor (real munmap) via publishHandle.
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for i := 0; i < 400; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			nh := newMapHandle(open())
+			li := wireReaderLabelIndex(lr, nh.reader, nh, doc)
+			s.mu.Lock()
+			lr.resetIndexes() // re-arm the adjacency Once so the next getter rebuilds from the new reader
+			lr.LabelIndex = li
+			lr.publishHandle(nh) // retire+munmap predecessor under readerMu
+			s.mu.Unlock()
+		}
+	}()
+
+	// Readers: hammer all 4 choke points. LabelIndex.at via a pointer snapshotted
+	// under s.mu (race-free vs the reloader's write); the 3 adjacency builders read
+	// lr.Reader/lr.handle under readerMu inside their getters.
+	var wgB sync.WaitGroup
+	for g := 0; g < 6; g++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 800; j++ {
+				s.mu.Lock()
+				li := lr.LabelIndex
+				s.mu.Unlock()
+				if e := li.ByID("e5"); e == nil || e.ID != "e5" {
+					faults.Add(1)
+				}
+				_ = lr.getAdjacency()
+				_ = lr.getCallsAdj()
+				_ = lr.getStepAdj()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle() // munmap the final generation
+	s.mu.Unlock()
+
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("choke-point read faults (wrong/nil entity): %d", f)
+	}
+}
+
+// TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc is the load-bearing
+// test for the readRetired flag. It captures a *LabelIndex BEFORE a reload, the
+// reload retires+munmaps that generation's mapping, and then a lookup on the
+// STALE captured index must still return the correct entity via the Doc fallback
+// (NOT a SIGBUS on the freed region, NOT wrong data).
+func TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	doc := sigbusFixtureDoc(8)
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	open := func() *fbreader.Reader {
+		r, err := fbreader.Open(fbPath)
+		if err != nil {
+			t.Fatalf("open reader: %v", err)
+		}
+		return r
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	s.mu.Lock()
+	h0 := newMapHandle(open())
+	stale := wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.LabelIndex = stale
+	lr.publishHandle(h0)
+	s.mu.Unlock()
+
+	// Sanity: before the reload the stale index reads through the mmap correctly.
+	if e := stale.ByID("e3"); e == nil || e.ID != "e3" || e.QualifiedName != "r.e3" {
+		t.Fatalf("pre-reload stale.ByID(e3) = %#v", e)
+	}
+
+	// Reload: publish a fresh generation and retire+munmap the mapping the stale
+	// index still holds.
+	s.mu.Lock()
+	nh := newMapHandle(open())
+	lr.LabelIndex = wireReaderLabelIndex(lr, nh.reader, nh, doc)
+	lr.publishHandle(nh) // retires h0 → munmap the region `stale` points at
+	s.mu.Unlock()
+
+	if h0.readRetired != true {
+		t.Fatalf("predecessor handle not marked readRetired after reload")
+	}
+
+	// The stale captured index MUST now fall back to the Doc (its mapping is gone).
+	// Correct entity, no SIGBUS.
+	for _, tc := range []struct{ id, qn string }{{"e0", "r.e0"}, {"e3", "r.e3"}, {"e7", "r.e7"}} {
+		got := stale.ByID(tc.id)
+		if got == nil || got.ID != tc.id || got.QualifiedName != tc.qn {
+			t.Fatalf("stale.ByID(%s) after retire = %#v, want id=%s qn=%s (Doc fallback)", tc.id, got, tc.id, tc.qn)
+		}
+	}
+	// at() via LookupAll on the stale index also uses the Doc fallback.
+	if got := stale.Lookup("e5"); got == nil || got.ID != "e5" {
+		t.Fatalf("stale.Lookup(e5) after retire = %#v", got)
+	}
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+}
+
+// TestServeFromMMapOff_ReaderMuWiredStillReadsDoc guards that wiring readerMu +
+// a live handle does NOT change flag-OFF behavior: with the flag OFF every read
+// path is Document-sourced and byte-identical, even though the readerMu machinery
+// is present. The graph.fb backing the reader DIVERGES from the Doc, so any
+// Reader sourcing would be observable.
+func TestServeFromMMapOff_ReaderMuWiredStillReadsDoc(t *testing.T) {
+	forceServeFromMMap(t, false)
+
+	doc := &graph.Document{Version: 1, Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "A", Name: "A", QualifiedName: "r.A", Kind: "function", SourceFile: "a.go", Language: "go", StartLine: 3},
+		{ID: "B", Name: "B", QualifiedName: "r.B", Kind: "function", SourceFile: "b.go", Language: "go", StartLine: 4},
+	}
+	doc.Relationships = []graph.Relationship{{FromID: "A", ToID: "B", Kind: "CALLS"}}
+
+	// Divergent graph.fb: different ids, no relationships.
+	rdrDoc := &graph.Document{Version: 1, Repo: "r"}
+	rdrDoc.Entities = []graph.Entity{
+		{ID: "X", Name: "X", QualifiedName: "r.X", Kind: "function", SourceFile: "x.go", Language: "go"},
+		{ID: "Y", Name: "Y", QualifiedName: "r.Y", Kind: "function", SourceFile: "y.go", Language: "go"},
+	}
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, rdrDoc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	rdr, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { _ = rdr.Close() })
+
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	h := newMapHandle(rdr)
+	lr.LabelIndex = wireReaderLabelIndex(lr, rdr, h, doc)
+	lr.publishHandle(h)
+
+	// at(idx): must surface the Document rows (A/B), not the Reader's divergent
+	// X/Y — even though a handle + readerMu are wired, flag-off stays Doc-sourced.
+	// (byID is reader-keyed, so index the rows directly like the gating test.)
+	if a := lr.LabelIndex.at(0); a == nil || a.ID != "A" {
+		t.Fatalf("flag-off wired at(0) = %#v; must be Document entity A (Reader-sourced?)", a)
+	}
+	if b := lr.LabelIndex.at(1); b == nil || b.ID != "B" {
+		t.Fatalf("flag-off wired at(1) = %#v; must be Document entity B (Reader-sourced?)", b)
+	}
+	// adjacency must equal the Document build and differ from the Reader build
+	// (the two diverge), proving Doc-sourcing.
+	got := lr.getAdjacency()
+	if !reflect.DeepEqual(got, buildAdjacency(doc, "r")) {
+		t.Fatalf("flag-off wired getAdjacency != Document build (Reader-sourced?)")
+	}
+	if reflect.DeepEqual(got, buildAdjacencyFromReader(rdr, "r")) {
+		t.Fatalf("flag-off wired getAdjacency == Reader build — it dereferenced the mmap")
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -279,7 +279,20 @@ type LoadedRepo struct {
 	// drain first. Invariant: handle == nil iff Reader == nil, and when both are
 	// non-nil handle.reader == Reader. Mutated only under State.mu via
 	// publishHandle / retireHandle. Nil when graph.fb is unavailable.
-	handle     *MapHandle
+	handle *MapHandle
+	// readerMu is the ADR-0027 read-side SIGBUS-safety mutex (memory epic #5850,
+	// "Option B") that gates the GRAFEL_SERVE_FROM_MMAP flag-on read path. It is
+	// STRICTLY INNERMOST: nothing else is acquired while it is held. The 4 flag-on
+	// read choke points (LabelIndex.at + the three build*AdjacencyFromReader
+	// getters) hold it around their mmap dereference; publishHandle/retireHandle
+	// hold it around the predecessor's munmap (setting handle.readRetired true
+	// first). Because it sits below idxMu in the order (read: idxMu->readerMu, or
+	// bare readerMu at at()) and reload already holds s.mu (reload:
+	// s.mu->...->readerMu), a deref and the munmap of that same mapping can never
+	// interleave and no lock inversion is possible. Its zero value is usable, so a
+	// LoadedRepo needs no explicit init. The wired *LabelIndex holds &readerMu so a
+	// lookup on a pre-reload-captured index locks the SAME mutex.
+	readerMu   sync.Mutex
 	LabelIndex *LabelIndex
 	BM25       *BM25Index
 	Semantic   *embed.Store // per-repo vector index (nil when no embeddings.bin)
@@ -477,6 +490,15 @@ func (lr *LoadedRepo) resetIndexes() {
 //
 // nh may be nil (JSON-only fallback / no graph.fb). Caller MUST hold State.mu.
 func (lr *LoadedRepo) publishHandle(nh *MapHandle) {
+	// ADR-0027 SIGBUS-safety (memory epic #5850): the whole swap runs under the
+	// strictly-innermost readerMu so a flag-on read choke point sees a consistent
+	// (lr.Reader/lr.handle) pair and never derefs a mapping being munmapped here.
+	// The predecessor is flagged readRetired BEFORE its munmap so a stale captured
+	// *LabelIndex checking readRetired (under this same readerMu) falls back to the
+	// Doc instead of dereferencing the freed region. readerMu is innermost: the
+	// only thing done while holding it is field assignment + old.retire()'s munmap
+	// syscall — no other grafel lock is acquired.
+	lr.readerMu.Lock()
 	old := lr.handle
 	if nh != nil {
 		nh.repo = lr.Repo
@@ -486,20 +508,10 @@ func (lr *LoadedRepo) publishHandle(nh *MapHandle) {
 	}
 	lr.handle = nh
 	if old != nil {
+		old.readRetired = true
 		old.retire()
 	}
-}
-
-// setReader wraps a freshly-opened reader (or nil) in a MapHandle and publishes
-// it via publishHandle. This is the reload swap: it replaces the old bare
-// lr.Reader.Close() so a reload never munmaps a mapping an in-flight borrow
-// still aliases. Caller MUST hold State.mu.
-func (lr *LoadedRepo) setReader(newRdr *fbreader.Reader) {
-	var nh *MapHandle
-	if newRdr != nil {
-		nh = newMapHandle(newRdr)
-	}
-	lr.publishHandle(nh)
+	lr.readerMu.Unlock()
 }
 
 // retireHandle retires the repo's current mmap handle (repo eviction and server
@@ -508,12 +520,18 @@ func (lr *LoadedRepo) setReader(newRdr *fbreader.Reader) {
 // is unmapped now iff it has drained, else by the last release(). Caller MUST
 // hold State.mu.
 func (lr *LoadedRepo) retireHandle() {
+	// Same readerMu discipline as publishHandle: flag readRetired then munmap, all
+	// under the strictly-innermost readerMu, so a concurrent flag-on read choke
+	// point cannot deref this mapping while (or after) it is unmapped.
+	lr.readerMu.Lock()
 	old := lr.handle
 	lr.handle = nil
 	lr.Reader = nil
 	if old != nil {
+		old.readRetired = true
 		old.retire()
 	}
+	lr.readerMu.Unlock()
 }
 
 // getSuffixIndex returns the source-file suffix index (basename -> repo-relative
@@ -716,11 +734,23 @@ func (lr *LoadedRepo) getAdjacency() *adjacency {
 		// concurrent reload retire()s+munmaps the old Reader WITHOUT idxMu (F1's
 		// borrow protocol is inert → refs==0 → immediate munmap), so an
 		// unconditional Reader iteration here is a read-after-unmap SIGBUS (latent
-		// PR1 #5865). OFF → the GC-safe Document build; ON is DARK until the borrow
-		// protocol is wired into the read path. Nil-Reader always uses the Document.
-		if lr.Reader != nil && serveFromMMap() {
-			lr.adjacency = buildAdjacencyFromReader(lr.Reader, lr.Repo)
+		// PR1 #5865). OFF → the GC-safe Document build. Nil-Reader always uses the
+		// Document.
+		//
+		// ADR-0027 SIGBUS-safety (memory epic #5850): read lr.Reader/lr.handle and
+		// run the mmap build UNDER the strictly-innermost readerMu, so a concurrent
+		// reload's munmap (also under readerMu) cannot free the mapping mid-scan.
+		// readRetired is checked for uniformity with at() (lr.handle here is always
+		// the current, non-retired generation). Lock order: idxMu (held) -> readerMu;
+		// the Doc build takes no mmap so readerMu is dropped before it.
+		lr.readerMu.Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
+			lr.adjacency = buildAdjacencyFromReader(rdr, lr.Repo)
+			lr.readerMu.Unlock()
 		} else {
+			lr.readerMu.Unlock()
 			lr.adjacency = buildAdjacency(lr.Doc, lr.Repo)
 		}
 	})
@@ -741,10 +771,16 @@ func (lr *LoadedRepo) getCallsAdj() *callsAdjacency {
 		}
 		// ADR-0027 Cutover PR1: prefer the resident mmap Reader when ON, else the
 		// Document. Flag-gated (default OFF) for the same handler-path munmap
-		// SIGBUS reason as getAdjacency.
-		if lr.Reader != nil && serveFromMMap() {
-			lr.callsAdj = buildCallsAdjacencyFromReader(lr.Reader)
+		// SIGBUS reason as getAdjacency. ADR-0027 SIGBUS-safety (#5850): the mmap
+		// read + reload munmap are serialized by the strictly-innermost readerMu.
+		lr.readerMu.Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
+			lr.callsAdj = buildCallsAdjacencyFromReader(rdr)
+			lr.readerMu.Unlock()
 		} else {
+			lr.readerMu.Unlock()
 			lr.callsAdj = buildCallsAdjacency(lr.Doc)
 		}
 	})
@@ -762,10 +798,16 @@ func (lr *LoadedRepo) getStepAdj() map[string][]stepEdge {
 		}
 		// ADR-0027 Cutover PR1: prefer the resident mmap Reader when ON, else the
 		// Document. Flag-gated (default OFF) for the same handler-path munmap
-		// SIGBUS reason as getAdjacency.
-		if lr.Reader != nil && serveFromMMap() {
-			lr.stepAdj = buildStepAdjacencyFromReader(lr.Reader)
+		// SIGBUS reason as getAdjacency. ADR-0027 SIGBUS-safety (#5850): the mmap
+		// read + reload munmap are serialized by the strictly-innermost readerMu.
+		lr.readerMu.Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
+			lr.stepAdj = buildStepAdjacencyFromReader(rdr)
+			lr.readerMu.Unlock()
 		} else {
+			lr.readerMu.Unlock()
 			lr.stepAdj = buildStepAdjacency(lr.Doc)
 		}
 	})
@@ -1151,8 +1193,20 @@ func (s *State) reloadLocked() (int, bool, error) {
 					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
 						newRdr = rdr
 					}
+					// ADR-0027 SIGBUS-safety (memory epic #5850): build the successor
+					// MapHandle up front so the reader-sourced LabelIndex is FULLY wired
+					// (readerMu + this generation's retirement handle) BEFORE it is
+					// published to lr.LabelIndex — a handler live-reading lr.LabelIndex
+					// never sees a half-wired index, and at()'s mmap deref is serialized
+					// (its stale-capture fallback armed) against this handle's later
+					// munmap. publishHandle below installs this SAME handle.
+					var newHandle *MapHandle
 					if newRdr != nil {
-						lr.LabelIndex = BuildLabelIndexFromReader(newRdr, doc)
+						newHandle = newMapHandle(newRdr)
+						li := BuildLabelIndexFromReader(newRdr, doc)
+						li.readerMu = &lr.readerMu
+						li.handle = newHandle
+						lr.LabelIndex = li
 					} else {
 						lr.LabelIndex = BuildLabelIndex(doc)
 					}
@@ -1204,7 +1258,7 @@ func (s *State) reloadLocked() (int, bool, error) {
 						}
 					}
 					lr.TestsEdgeCount = testsCount
-					lr.setReader(newRdr)
+					lr.publishHandle(newHandle)
 					reloaded++
 				}
 			}


### PR DESCRIPTION
## What

Makes the `GRAFEL_SERVE_FROM_MMAP` flag-ON handler read path SIGBUS-safe, the precondition for the mmap cutover flip (memory epic #5850, ADR-0027). Flag-OFF (production default) is unchanged — byte-identical Doc path.

The complete flag-on mmap-read surface is a **4-function funnel**: `LabelIndex.at()` + `getAdjacency`/`getCallsAdj`/`getStepAdj`'s `build*AdjacencyFromReader`. A concurrent reload's synchronous `munmap` could race/precede an in-flight read of that mapping = read-after-munmap SIGBUS.

## Mechanism (Option B)

Two load-bearing guards, both proven by mutation:
- **`readerMu`** — a new per-repo, strictly-innermost lock (`s.mu → mroMu → baseChainMu → idxMu → readerMu`) held around the 4 choke-point mmap derefs AND around reload's `munmap`. Mutual exclusion between reads and the unmap.
- **`readRetired` flag + Doc fallback** — handlers hold `*LabelIndex` across a reload boundary; a bare mutex does not protect a stale captured pointer whose mapping was already munmapped. `at()` checks `readRetired` under `readerMu` and falls back to the heap Doc.

`reloadLocked` now builds + fully wires the successor `MapHandle`/`LabelIndex` before publishing (no half-wired window). The inert F1/F2/F3 borrow seam is left untouched (eventual "Option A" end-state).

## Tests

- `TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS` — 6 goroutines hammer all 4 choke points vs a reloader swapping+munmapping real mappings; `-race`, no SIGBUS.
- `TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc` — stale captured `*LabelIndex`, mapping retired+munmapped, reads fall back to Doc.
- `TestServeFromMMapOff_ReaderMuWiredStillReadsDoc` — flag-off byte-identical (divergent fixture).

Independently adversarial-reviewed (opus): surface re-derived, lock order audited, both guards mutation-tested to failure (SIGSEGV without the fallback, DATA RACE without `readerMu`). `go test ./internal/mcp/` = 1160 pass; `-race -count=10` clean.

Refs #5850

🤖 Generated with [Claude Code](https://claude.com/claude-code)