### PR TITLE
feat(mcp): route hot query-handler Doc scans through forEach iterators (mmap flip Path P, PR4)

### DIFF
--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -259,13 +259,13 @@ func newEndpointResolution(repos []*LoadedRepo, lg *LoadedGroup, orphanOnly bool
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if isDefinitionKind(e.Kind) && e.PropGet("pattern_type") != patternTypeHTTPEndpointClientSynthesis {
 				defIDs[prefixedID(r.Repo, e.ID)] = true
 				defIDs[e.ID] = true
 			}
-		}
+			return true
+		})
 	}
 
 	linkedSrc := make(map[string]bool, len(lg.Links))
@@ -511,17 +511,16 @@ func collectNavigationRoutes(repos []*LoadedRepo, pathContains string) []navigat
 		}
 		// Build a quick local-id → entity map for sample-file/line resolution.
 		byID := r.getByID()
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind != "NAVIGATES_TO" {
-				continue
+				return true
 			}
 			route := ""
 			if rel.PropLen() > 0 {
 				route = rel.PropGet("route")
 			}
 			if pathContains != "" && !strings.Contains(strings.ToLower(route), pathContains) {
-				continue
+				return true
 			}
 			a, ok := byTo[rel.ToID]
 			if !ok {
@@ -564,7 +563,8 @@ func collectNavigationRoutes(repos []*LoadedRepo, pathContains string) []navigat
 				}
 				a.sampleSeen = true
 			}
-		}
+			return true
+		})
 	}
 
 	out := make([]navigationRouteItem, 0, len(byTo))
@@ -726,24 +726,23 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isDefinitionKind(e.Kind) {
-				continue
+				return true
 			}
 			if e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis {
-				continue
+				return true
 			}
 			p := e.PropGet("path")
 			m := e.PropGet("verb")
 			if pathContains != "" && !strings.Contains(strings.ToLower(p), pathContains) {
-				continue
+				return true
 			}
 			if method != "" && !strings.EqualFold(m, method) {
-				continue
+				return true
 			}
 			if orphanOnly && !isOrphanDefinition(r, e.ID, res) {
-				continue
+				return true
 			}
 			// #2811 — endpoint effect closure from the sidecar.
 			var effs []string
@@ -751,7 +750,7 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 				effs = entry.Effects
 			}
 			if effectFilter != "" && !containsFold(effs, effectFilter) {
-				continue
+				return true
 			}
 			it := endpointDefItem{
 				EntityID:   prefixedID(r.Repo, e.ID),
@@ -773,7 +772,8 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 				it.Properties = dedupeEndpointProperties(e.PropsSnapshot())
 			}
 			out = append(out, it)
-		}
+			return true
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -1025,10 +1025,9 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind != kindFETCHES {
-				continue
+				return true
 			}
 			key := prefixedID(r.Repo, rel.FromID)
 			if _, exists := callerToTarget[key]; !exists {
@@ -1038,7 +1037,8 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 				}
 				callerToTarget[key] = fe
 			}
-		}
+			return true
+		})
 	}
 
 	var out []endpointCallItem
@@ -1046,21 +1046,20 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			// Accept explicit call kind OR client-synthesis http_endpoint.
 			isCall := isCallKind(e.Kind) ||
 				(isDefinitionKind(e.Kind) && e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis)
 			if !isCall {
-				continue
+				return true
 			}
 			p := e.PropGet("path")
 			m := e.PropGet("verb")
 			if pathContains != "" && !strings.Contains(strings.ToLower(p), pathContains) {
-				continue
+				return true
 			}
 			if method != "" && !strings.EqualFold(m, method) {
-				continue
+				return true
 			}
 
 			eid := prefixedID(r.Repo, e.ID)
@@ -1094,7 +1093,7 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 			}
 
 			if orphanOnly && orphanHint == "" {
-				continue
+				return true
 			}
 
 			it := endpointCallItem{
@@ -1116,7 +1115,8 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 				it.Properties = dedupeEndpointProperties(e.PropsSnapshot())
 			}
 			out = append(out, it)
-		}
+			return true
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -1352,8 +1352,7 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 		}
 		rs := repoStats{Repo: r.Repo}
 
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			fw := e.PropGet("framework")
 			xm := e.PropGet("extraction_method") // #5527 per-entity AST provenance
 			switch classifyEndpointKind(e.Kind) {
@@ -1374,7 +1373,8 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 					bumpFramework(fw, xm, true)
 				}
 			}
-		}
+			return true
+		})
 
 		// Count orphan call-sites and cross-repo-resolved call-sites.
 		//
@@ -1396,20 +1396,19 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 		// their callerID in linkedSources, so we also check whether a link
 		// source in the same repo covers the entity via the FETCHES ToID.
 		seenCallers := map[string]bool{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind != kindFETCHES {
-				continue
+				return true
 			}
 			// Deduplicate: tally each FromID only once per repo (#2571).
 			if seenCallers[rel.FromID] {
-				continue
+				return true
 			}
 			seenCallers[rel.FromID] = true
 
 			resolvedIntra := res.definitionIDs[rel.ToID] || res.definitionIDs[prefixedID(r.Repo, rel.ToID)]
 			if resolvedIntra {
-				continue
+				return true
 			}
 			srcPrefixed := prefixedID(r.Repo, rel.FromID)
 			// #2573: check both the FETCHES FromID (the call synthetic) AND
@@ -1421,10 +1420,11 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 			tgtPrefixed := prefixedID(r.Repo, rel.ToID)
 			if res.linkedSources[srcPrefixed] || res.linkedSources[tgtPrefixed] {
 				rs.CrossRepoResolved++
-				continue
+				return true
 			}
 			rs.OrphanCalls++
-		}
+			return true
+		})
 
 		totalDefs += rs.Definitions
 		totalCalls += rs.Calls

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -942,8 +942,7 @@ func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Name == target || e.QualifiedName == target {
 				hits = append(hits, hit{repo: r, id: e.ID})
 				byName = append(byName, impactCandidate{
@@ -954,7 +953,8 @@ func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
 					SourceFile: e.SourceFile,
 				})
 			}
-		}
+			return true
+		})
 	}
 	switch {
 	case len(hits) == 1:
@@ -1034,15 +1034,14 @@ func fuzzyMatchEntities(repos []*LoadedRepo, probe string) fuzzyMatchResult {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if isNoise(e) {
-				continue
+				return true
 			}
 			nameL := strings.ToLower(e.Name)
 			qnL := strings.ToLower(e.QualifiedName)
 			if !strings.Contains(nameL, ql) && !strings.Contains(qnL, ql) {
-				continue
+				return true
 			}
 			cand := impactCandidate{
 				EntityID:   prefixedID(r.Repo, e.ID),
@@ -1054,11 +1053,12 @@ func fuzzyMatchEntities(repos []*LoadedRepo, probe string) fuzzyMatchResult {
 			if nameL == ql || qnL == ql {
 				exact = append(exact, fuzzyHit{repo: r, id: e.ID})
 				exactC = append(exactC, cand)
-				continue
+				return true
 			}
 			sub = append(sub, fuzzyHit{repo: r, id: e.ID})
 			subC = append(subC, cand)
-		}
+			return true
+		})
 	}
 	// A unique exact-(case-insensitive) name/qualified-name match wins outright,
 	// even if substrings also matched — this mirrors grafel_find floating the
@@ -1225,8 +1225,7 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 	// with ≥1 inbound TESTS edge has genuine test linkage and must not be
 	// labelled "no test coverage" regardless of its test_coverage property.
 	inboundTestsMap := map[string]int{}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		totalDegreeMap[rel.ToID]++
 		if rel.Kind == "TESTS" {
 			inboundTestsMap[rel.ToID]++
@@ -1241,7 +1240,8 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 			// Source not in byID — treat as named to avoid under-counting.
 			namedCallerMap[rel.ToID]++
 		}
-	}
+		return true
+	})
 
 	// Impact radius = entities that transitively depend on `target`.
 	// We walk the INBOUND graph from target: callers of callers. The walk is
@@ -2144,10 +2144,9 @@ func buildImportedNameSet(repos []*LoadedRepo) map[string]bool {
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind != "IMPORTS" {
-				continue
+				return true
 			}
 			if n := rel.PropGet("imported_name"); n != "" {
 				set[n] = true
@@ -2155,7 +2154,8 @@ func buildImportedNameSet(repos []*LoadedRepo) map[string]bool {
 			if n := rel.PropGet("local_name"); n != "" {
 				set[n] = true
 			}
-		}
+			return true
+		})
 	}
 	return set
 }
@@ -2273,15 +2273,15 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 		// pass.
 		projectEntities := map[string]bool{}
 		testEntity := map[string]bool{}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isStdlibEntity(e) {
 				projectEntities[e.ID] = true
 			}
 			if isTestFileMCP(e.SourceFile) {
 				testEntity[e.ID] = true
 			}
-		}
+			return true
+		})
 
 		// Count inbound *reference* edges (the usage signal) per entity. An
 		// operation with any inbound CALLS/REFERENCES/TESTS/ROUTES_TO/etc. is
@@ -2298,13 +2298,12 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 		// production-dead-but-test-covered: the `test_only_referenced` class.
 		inRef := map[string]int{}
 		inRefProd := map[string]int{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if !projectEntities[rel.FromID] || !projectEntities[rel.ToID] {
-				continue
+				return true
 			}
 			if rel.Kind == "CONTAINS" {
-				continue
+				return true
 			}
 			if inboundRefKinds[rel.Kind] {
 				inRef[rel.ToID]++
@@ -2315,19 +2314,19 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 					inRefProd[rel.ToID]++
 				}
 			}
-		}
+			return true
+		})
 
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if isStdlibEntity(e) {
-				continue
+				return true
 			}
 			if !matchesKindFilter(e, kindFilter) {
-				continue
+				return true
 			}
 			// #2769 Phase 1C: drop entities below the caller's confidence floor.
 			if !entityPassesConfidence(e, minConfidence) {
-				continue
+				return true
 			}
 
 			// Dead-code analysis applies ONLY to callable operations
@@ -2337,11 +2336,11 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			// destroys precision on real per-repo graphs (where cross-repo
 			// usage lives in the group links file, not in per-repo edges).
 			if !isOperationKind(e) {
-				continue
+				return true
 			}
 			// Exclude non-code "operation" entities (Dockerfile CMD, SQL DDL).
 			if nonCodeLanguages[strings.ToLower(e.Language)] {
-				continue
+				return true
 			}
 			// The TARGET being a test entity is never dead production code — a
 			// test helper called only by other tests is wired-as-intended. We
@@ -2349,7 +2348,7 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			// test_only_referenced class require the target to live in
 			// production code.
 			if testEntity[e.ID] || strings.Contains(strings.ToLower(e.SourceFile), "test") {
-				continue
+				return true
 			}
 			// Route handlers, framework lifecycle hooks, event listeners, and
 			// constructors are reachable without an explicit call edge. These
@@ -2357,11 +2356,11 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 			// reflectively / by the framework / as an entry point is not dead
 			// even with zero in-graph production callers.
 			if isFrameworkOrHandler(e) {
-				continue
+				return true
 			}
 			// Imported by another repo → live public API surface.
 			if isExternallyConsumed(e, imported) {
-				continue
+				return true
 			}
 
 			leaf := e.Name
@@ -2403,7 +2402,7 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 				// rather than in per-repo edges) is NOT flagged, keeping false
 				// positives near zero.
 				if !deadMarkerRe.MatchString(leaf) {
-					continue
+					return true
 				}
 				out = append(out, item{
 					EntityID:   prefixedID(r.Repo, e.ID),
@@ -2416,7 +2415,8 @@ func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolReques
 					Confidence: 0.85,
 				})
 			}
-		}
+			return true
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -2462,10 +2462,16 @@ func entityExistsAnywhere(lg *LoadedGroup, id string) bool {
 		if _, ok := r.getByID()[probe]; ok {
 			return true
 		}
-		for i := range r.Doc.Entities {
-			if r.Doc.Entities[i].Name == probe {
-				return true
+		found := false
+		r.forEachEntity(func(e *graph.Entity) bool {
+			if e.Name == probe {
+				found = true
+				return false
 			}
+			return true
+		})
+		if found {
+			return true
 		}
 	}
 	return false
@@ -2502,10 +2508,9 @@ func (s *Server) tryFindCallersByRoute(req mcpapi.CallToolRequest, lg *LoadedGro
 			continue
 		}
 		byID := r.getByID()
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind != "NAVIGATES_TO" {
-				continue
+				return true
 			}
 			match := rel.ToID == wantToID
 			if !match && rel.PropLen() > 0 {
@@ -2516,7 +2521,7 @@ func (s *Server) tryFindCallersByRoute(req mcpapi.CallToolRequest, lg *LoadedGro
 				}
 			}
 			if !match {
-				continue
+				return true
 			}
 			line := 0
 			route := routeLit
@@ -2545,7 +2550,8 @@ func (s *Server) tryFindCallersByRoute(req mcpapi.CallToolRequest, lg *LoadedGro
 				rc.SourceFile = e.SourceFile
 			}
 			callers = append(callers, rc)
-		}
+			return true
+		})
 	}
 	if len(callers) == 0 {
 		return nil

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -2109,3 +2109,45 @@ func TestFindCallers_ProductionDroppedWarnsExplicitly(t *testing.T) {
 		t.Errorf("note should warn that production callers were dropped: %q", note)
 	}
 }
+
+// TestEntityExistsAnywhere_PR4Parity is the load-bearing guard for the PR4
+// mmap-cutover migration of entityExistsAnywhere's `range r.Doc.Entities` scan
+// to lr.forEachEntity (view_iter.go). The scan matches an entity by EXACT-CASE
+// Name (e.Name == probe) — a semantic the case-insensitive LabelIndex byLabel
+// map does NOT preserve, which is precisely why this site converted to
+// forEachEntity rather than an indexed LookupAll. This test pins:
+//   - a Name hit returns true (exercises the found-flag early-exit that
+//     replaced the in-loop `return true`),
+//   - a miss returns false (full scan, found stays false),
+//   - a case-folded probe does NOT match (exact-case semantics preserved —
+//     the exact risk an indexed lookup would have silently introduced).
+func TestEntityExistsAnywhere_PR4Parity(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "id-1", Name: "OrderService", Kind: "class"},
+		{ID: "id-2", Name: "PaymentService", Kind: "class"},
+	}
+	lg := &LoadedGroup{
+		Name:  "g",
+		Repos: map[string]*LoadedRepo{"r": {Repo: "r", Doc: doc}},
+	}
+
+	// Name hit (exercises the found-flag early exit).
+	if !entityExistsAnywhere(lg, "OrderService") {
+		t.Error("expected exact-Name match OrderService to exist")
+	}
+	// ID hit (getByID path, untouched by the migration but kept as a control).
+	if !entityExistsAnywhere(lg, "id-2") {
+		t.Error("expected id-2 to exist via getByID")
+	}
+	// Miss → full scan, found stays false.
+	if entityExistsAnywhere(lg, "NoSuchSymbol") {
+		t.Error("did not expect NoSuchSymbol to exist")
+	}
+	// Case-folded probe MUST NOT match: the scan is exact-case, and the
+	// migration must not have leaked case-insensitivity.
+	if entityExistsAnywhere(lg, "orderservice") {
+		t.Error("case-folded probe must not match exact-case Name (semantics drift)")
+	}
+}

--- a/internal/mcp/navigates_tools.go
+++ b/internal/mcp/navigates_tools.go
@@ -44,6 +44,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/graph"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -115,12 +116,12 @@ func (s *Server) handleNavigates(_ context.Context, req mcpapi.CallToolRequest) 
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			pid := prefixedID(r.Repo, e.ID)
 			entityByPrefixed[pid] = navigatesEntityMeta{name: e.Name, sourceFile: e.SourceFile, repo: r.Repo}
 			entityByPrefixed[e.ID] = navigatesEntityMeta{name: e.Name, sourceFile: e.SourceFile, repo: r.Repo}
-		}
+			return true
+		})
 	}
 
 	var edges []navigatesEdgeItem
@@ -186,10 +187,9 @@ func collectNavigatesEdges(
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if !strings.EqualFold(rel.Kind, kindNAVIGATES_TO) {
-				continue
+				return true
 			}
 
 			// Apply entity_id filter (direction-aware).
@@ -198,12 +198,12 @@ func collectNavigatesEdges(
 				case "outgoing":
 					// entity_id is the FROM entity; match by local or prefixed ID.
 					if rel.FromID != entityID && prefixedID(r.Repo, rel.FromID) != entityID {
-						continue
+						return true
 					}
 				case "incoming":
 					// entity_id is the TO route / destination entity.
 					if rel.ToID != entityID {
-						continue
+						return true
 					}
 				}
 			}
@@ -217,7 +217,7 @@ func collectNavigatesEdges(
 
 			// Apply route filter (contains, case-insensitive).
 			if routeFilter != "" && !strings.Contains(strings.ToLower(route), strings.ToLower(routeFilter)) {
-				continue
+				return true
 			}
 
 			// Apply with_param filter: params is comma-separated key names.
@@ -230,7 +230,7 @@ func collectNavigatesEdges(
 					}
 				}
 				if !found {
-					continue
+					return true
 				}
 			}
 
@@ -257,7 +257,8 @@ func collectNavigatesEdges(
 				Line:       line,
 				SourceFile: meta.sourceFile,
 			})
-		}
+			return true
+		})
 	}
 	return out
 }
@@ -292,10 +293,9 @@ func collectNavigatesFlow(
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if !strings.EqualFold(rel.Kind, kindNAVIGATES_TO) {
-				continue
+				return true
 			}
 			route, params, line := "", "", 0
 			if rel.PropLen() > 0 {
@@ -317,7 +317,8 @@ func collectNavigatesFlow(
 			// Also key by bare ID so that ToID lookups (which may be bare)
 			// can find subsequent hops.
 			navAdj[rel.FromID] = append(navAdj[rel.FromID], ne)
-		}
+			return true
+		})
 	}
 
 	// Determine BFS start set.

--- a/internal/mcp/reachability_tools.go
+++ b/internal/mcp/reachability_tools.go
@@ -80,14 +80,13 @@ func (s *Server) handleTestReachability(ctx context.Context, req mcpapi.CallTool
 		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
 			continue
 		}
-		for i := range lr.Doc.Entities {
-			e := &lr.Doc.Entities[i]
+		lr.forEachEntity(func(e *graph.Entity) bool {
 			if e.PropLen() == 0 {
-				continue
+				return true
 			}
 			val, ok := e.PropLookup(coverage.PropTestReachable)
 			if !ok {
-				continue // not a reachability-considered production entity
+				return true // not a reachability-considered production entity
 			}
 			stampedSeen = true
 
@@ -107,16 +106,17 @@ func (s *Server) handleTestReachability(ctx context.Context, req mcpapi.CallTool
 
 			// row-level filters.
 			if entityID != "" && row.id != entityID {
-				continue
+				return true
 			}
 			if endpointsOnly && !row.isEndpoint {
-				continue
+				return true
 			}
 			if untestedOnly && row.reachable {
-				continue
+				return true
 			}
 			rows = append(rows, row)
-		}
+			return true
+		})
 	}
 
 	// ── honesty gate: nothing stamped → tell the agent to reindex ─────────────
@@ -282,20 +282,20 @@ func endpointRollup(lg *LoadedGroup, repoFilter []string) (total, reachable int)
 		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
 			continue
 		}
-		for i := range lr.Doc.Entities {
-			e := &lr.Doc.Entities[i]
+		lr.forEachEntity(func(e *graph.Entity) bool {
 			if e.PropLen() == 0 || !isEndpointKind(e.Kind) {
-				continue
+				return true
 			}
 			val, ok := e.PropLookup(coverage.PropTestReachable)
 			if !ok {
-				continue
+				return true
 			}
 			total++
 			if r, _ := strconv.ParseBool(val); r {
 				reachable++
 			}
-		}
+			return true
+		})
 	}
 	return total, reachable
 }


### PR DESCRIPTION
## What
PR4 of the mmap-cutover flip (Path P, #5870). Routes all 21 direct `range Doc.Entities`/`Doc.Relationships` scans in the hot query handlers — `endpoint_tools.go`(7), `flow_tools.go`(9), `navigates_tools.go`(3), `reachability_tools.go`(2) — through the merged PR1 `forEachEntity`/`forEachRelationship` iterators. Behavior-neutral flag-OFF (byte-identical to the inline loops); flag-ON reads the mmap Reader (dark until PR7).

## forEach at every site (no indexed conversions) — deliberate
The `LabelIndex` keys only byID/byName/byQName (both lowercased → case-insensitive). All 21 sites filter on `Kind`, a substring, a stamped property, or an **exact-case** Name/QName match — none is a safe `LabelIndex.LookupAll`/`ByQName` conversion (which would silently introduce case-insensitivity + precedence). So `forEach` preserves today's full-scan semantics exactly.

Follow-up (tracked separately): a by-Kind `LabelIndex` would let the Kind-filtered hot handlers materialize only matches flag-ON instead of all entities — a PR7 prerequisite, not this PR.

## Tests
`TestEntityExistsAnywhere_PR4Parity` pins the riskiest rewrite (function-`return` → found-flag): Name-hit / ID-hit / miss + the load-bearing **case-folded-probe-must-not-match** assertion (mutation-proven: `EqualFold` → FAIL).

Independently opus-reviewed (APPROVE): control-flow equivalence verified at all 21 sites, no retained-pointer escape flag-ON, grep-gate 21→0, scope = 4 files + 1 test. `go test ./internal/mcp/...` 1179 pass.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)