### PR TITLE
feat(mcp): route cold-tool Doc scans through forEach iterators (mmap flip Path P, PR2)

### DIFF
--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -392,14 +392,13 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 		repoErrors := 0
 		repoWarns := 0
 
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isDefinitionKind(e.Kind) {
-				continue
+				return true
 			}
 			// Exclude client-synthesis call-side entries.
 			if e.PropGet("pattern_type") == "http_endpoint_client_synthesis" {
-				continue
+				return true
 			}
 
 			repoTotal++
@@ -436,7 +435,7 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 			}
 
 			if onlyMissing && hasAuth {
-				continue
+				return true
 			}
 
 			endpoints = append(endpoints, EndpointRecord{
@@ -454,7 +453,8 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 				IDORRisk:       idorRisk,
 				SensitiveTerms: sensitiveMatch,
 			})
-		}
+			return true
+		})
 
 		if repoTotal == 0 {
 			continue

--- a/internal/mcp/auth_posture_diff_tool.go
+++ b/internal/mcp/auth_posture_diff_tool.go
@@ -225,14 +225,13 @@ func collectAuthEndpoints(lg *LoadedGroup) map[endpointJoinKey]authEndpoint {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isHTTPEndpointDefinition(e) {
-				continue
+				return true
 			}
 			verb, path := endpointVerbPath(e)
 			if path == "" {
-				continue
+				return true
 			}
 			key := newEndpointJoinKey(verb, path)
 			ae := authEndpoint{
@@ -243,10 +242,11 @@ func collectAuthEndpoints(lg *LoadedGroup) map[endpointJoinKey]authEndpoint {
 				ae.display = e.Name
 			}
 			if existing, ok := out[key]; ok && signalRichness(existing.signal) >= signalRichness(ae.signal) {
-				continue
+				return true
 			}
 			out[key] = ae
-		}
+			return true
+		})
 	}
 	return out
 }

--- a/internal/mcp/coverage_effectiveness_tool.go
+++ b/internal/mcp/coverage_effectiveness_tool.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 
 	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
@@ -78,13 +79,12 @@ func (s *Server) handleCoverageEffectiveness(_ context.Context, req mcpapi.CallT
 		if len(repoFilter) > 0 && !repoMatchesSlice(lr.Repo, repoFilter) {
 			continue
 		}
-		for i := range lr.Doc.Entities {
-			e := &lr.Doc.Entities[i]
+		lr.forEachEntity(func(e *graph.Entity) bool {
 			if e.PropLen() == 0 {
-				continue
+				return true
 			}
 			if _, ok := e.PropLookup(coverage.PropTestReachable); !ok {
-				continue
+				return true
 			}
 			stampedSeen = true
 			// The pure report reads only ID, SourceFile and Properties; build a
@@ -99,7 +99,8 @@ func (s *Server) handleCoverageEffectiveness(_ context.Context, req mcpapi.CallT
 				id: e.ID, name: e.Name, sourceFile: e.SourceFile,
 				startLine: e.StartLine, isEndpoint: isEndpointKind(e.Kind),
 			}
-		}
+			return true
+		})
 	}
 
 	if !stampedSeen {

--- a/internal/mcp/coverage_freshness.go
+++ b/internal/mcp/coverage_freshness.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/coverage"
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // coverageFreshness is the freshness verdict for a group's ingested
@@ -83,14 +84,13 @@ func computeCoverageFreshness(lg *LoadedGroup) coverageFreshness {
 		if g := lr.Doc.GeneratedAt; g.After(f.indexedAt) {
 			f.indexedAt = g
 		}
-		for i := range lr.Doc.Entities {
-			e := &lr.Doc.Entities[i]
+		lr.forEachEntity(func(e *graph.Entity) bool {
 			if e.PropLen() == 0 {
-				continue
+				return true
 			}
 			src := e.PropGet(coverage.PropCoverageSource)
 			if src == "" {
-				continue
+				return true
 			}
 			f.ingested = true
 			f.entities++
@@ -102,7 +102,8 @@ func computeCoverageFreshness(lg *LoadedGroup) coverageFreshness {
 			if at := e.PropGet(coverage.PropCoverageMeasAt); at > f.measuredAt {
 				f.measuredAt = at
 			}
-		}
+			return true
+		})
 	}
 
 	// Verdict only when both sides of the comparison exist.

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -103,8 +103,7 @@ func (s *Server) handleTopologyChannels(_ context.Context, req mcpapi.CallToolRe
 			}
 			set[handlerID] = true
 		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			switch rel.Kind {
 			case "PUBLISHES_TO":
 				pubCount[rel.ToID]++
@@ -113,11 +112,11 @@ func (s *Server) handleTopologyChannels(_ context.Context, req mcpapi.CallToolRe
 			case "DELIVERS_TO":
 				addConsumer(rel.FromID, rel.ToID) // topic=FromID, handler=ToID
 			}
-		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+			return true
+		})
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isTopic(e) {
-				continue
+				return true
 			}
 			out = append(out, channel{
 				TopicID:        prefixedID(r.Repo, e.ID),
@@ -127,7 +126,8 @@ func (s *Server) handleTopologyChannels(_ context.Context, req mcpapi.CallToolRe
 				ConsumerCount:  len(consumers[e.ID]),
 				SourceFile:     e.SourceFile,
 			})
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].TopicName != out[j].TopicName {
@@ -233,16 +233,15 @@ func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.Ca
 		}
 		// Build subscriber set: topics that appear on the ToID of a SUBSCRIBES_TO edge.
 		subscribers := map[string]bool{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind == "SUBSCRIBES_TO" {
 				subscribers[rel.ToID] = true
 			}
-		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+			return true
+		})
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isTopic(e) {
-				continue
+				return true
 			}
 			// Publisher: appears as ToID in a PUBLISHES_TO edge but never as ToID in SUBSCRIBES_TO.
 			if !subscribers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "PUBLISHES_TO") {
@@ -253,7 +252,8 @@ func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.Ca
 					SourceFile: e.SourceFile,
 				})
 			}
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].TopicName < out[j].TopicName })
 	return jsonResult(map[string]any{"orphan_publishers": out, "count": len(out)}), nil
@@ -281,16 +281,15 @@ func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.C
 			continue
 		}
 		publishers := map[string]bool{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind == "PUBLISHES_TO" {
 				publishers[rel.ToID] = true
 			}
-		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+			return true
+		})
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isTopic(e) {
-				continue
+				return true
 			}
 			if !publishers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "SUBSCRIBES_TO") {
 				out = append(out, item{
@@ -300,7 +299,8 @@ func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.C
 					SourceFile: e.SourceFile,
 				})
 			}
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].TopicName < out[j].TopicName })
 	return jsonResult(map[string]any{"orphan_subscribers": out, "count": len(out)}), nil
@@ -368,8 +368,7 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 		// Use the canonical entity ID for relationship matching.
 		canonID := topicEnt.ID
 		var publishers, subscribers []participant
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			switch rel.Kind {
 			case "PUBLISHES_TO":
 				if rel.ToID == canonID {
@@ -402,7 +401,8 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 					}
 				}
 			}
-		}
+			return true
+		})
 		resp := map[string]any{
 			"topic_id":    prefixedID(r.Repo, topicEnt.ID),
 			"topic_name":  topicEnt.Name,
@@ -448,21 +448,20 @@ func (s *Server) handleFlowDeadEnds(_ context.Context, req mcpapi.CallToolReques
 		byID := r.getByID()
 		// Build outbound CALLS set.
 		hasOutCalls := map[string]bool{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind == "CALLS" {
 				hasOutCalls[rel.FromID] = true
 			}
-		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+			return true
+		})
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != processEntityKind {
-				continue
+				return true
 			}
 			// Check if terminal_id exists and has outbound CALLS.
 			termID := e.PropGet("terminal_id")
 			if termID == "" {
-				continue
+				return true
 			}
 			if !hasOutCalls[termID] {
 				termEnt := byID[termID]
@@ -481,7 +480,8 @@ func (s *Server) handleFlowDeadEnds(_ context.Context, req mcpapi.CallToolReques
 					})
 				}
 			}
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ProcessName < out[j].ProcessName })
 	return jsonResult(map[string]any{"dead_ends": out, "count": len(out)}), nil
@@ -509,10 +509,9 @@ func (s *Server) handleFlowTruncated(_ context.Context, req mcpapi.CallToolReque
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != processEntityKind {
-				continue
+				return true
 			}
 			truncated := e.PropGet("truncated")
 			reason := e.PropGet("truncated_reason")
@@ -533,7 +532,8 @@ func (s *Server) handleFlowTruncated(_ context.Context, req mcpapi.CallToolReque
 					Reason:      reason,
 				})
 			}
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].ProcessName < out[j].ProcessName })
 	return jsonResult(map[string]any{"truncated_flows": out, "count": len(out)}), nil
@@ -568,12 +568,13 @@ func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest)
 		}
 		byID := r.getByID()
 		var procEnt *graph.Entity
-		for i := range r.Doc.Entities {
-			if r.Doc.Entities[i].Kind == processEntityKind && r.Doc.Entities[i].ID == target {
-				procEnt = &r.Doc.Entities[i]
-				break
+		r.forEachEntity(func(e *graph.Entity) bool {
+			if e.Kind == processEntityKind && e.ID == target {
+				procEnt = e
+				return false
 			}
-		}
+			return true
+		})
 		if procEnt == nil {
 			continue
 		}
@@ -593,8 +594,7 @@ func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest)
 			StepID     string `json:"step_id"`
 		}
 		var sideEffects []sideEffect
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if rel.Kind == "SIDE_EFFECT_OF" && stepSet[rel.ToID] {
 				fx := byID[rel.FromID]
 				if fx != nil {
@@ -606,7 +606,8 @@ func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest)
 					})
 				}
 			}
-		}
+			return true
+		})
 		return jsonResult(map[string]any{
 			"process_id":   prefixedID(r.Repo, procEnt.ID),
 			"process_name": procEnt.Name,
@@ -702,17 +703,16 @@ func (s *Server) handlePatternsListGraph(_ context.Context, req mcpapi.CallToolR
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern" {
-				continue
+				return true
 			}
 			status := e.PropGet("status")
 			if statusFilter != "" && !strings.EqualFold(status, statusFilter) {
-				continue
+				return true
 			}
 			if needsAttention && e.PropGet("needs_attention") != "true" {
-				continue
+				return true
 			}
 			conf := 0.0
 			if cs := e.PropGet("confidence"); cs != "" {
@@ -724,7 +724,7 @@ func (s *Server) handlePatternsListGraph(_ context.Context, req mcpapi.CallToolR
 				}
 			}
 			if conf < confidenceMin {
-				continue
+				return true
 			}
 			out = append(out, item{
 				PatternID:  prefixedID(r.Repo, e.ID),
@@ -734,7 +734,8 @@ func (s *Server) handlePatternsListGraph(_ context.Context, req mcpapi.CallToolR
 				Confidence: conf,
 				SourceFile: e.SourceFile,
 			})
-		}
+			return true
+		})
 	}
 	sort.Slice(out, func(i, j int) bool {
 		if out[i].Confidence != out[j].Confidence {
@@ -793,8 +794,7 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 			Kind       string `json:"kind"`
 		}
 		var exemplars []exemplar
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if (rel.Kind == "EXEMPLIFIES" || rel.Kind == "INSTANCE_OF") && rel.ToID == target {
 				if ex := byID[rel.FromID]; ex != nil {
 					exemplars = append(exemplars, exemplar{
@@ -804,7 +804,8 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 					})
 				}
 			}
-		}
+			return true
+		})
 		return jsonResult(map[string]any{
 			"pattern_id":  prefixedID(r.Repo, e.ID),
 			"name":        e.Name,
@@ -873,22 +874,21 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			// matchesKindFilter expands alias kinds (e.g. "http_endpoint" →
 			// [http_endpoint, http_endpoint_definition, http_endpoint_call]).
 			if !matchesKindFilter(e, kindFilter) {
-				continue
+				return true
 			}
 			// De-noise (#1712): Schema field members (SCOPE.Schema/field entities)
 			// are suppressed from default results — ~25 fields per serializer
 			// class clutter ranked output. Pass include_noise:true to recover them.
 			if !includeNoise && classifyNoise(e) == noiseSchemaField {
-				continue
+				return true
 			}
 			// #2769 Phase 1C: drop entities below the caller's confidence floor.
 			if !entityPassesConfidence(e, minConfidence) {
-				continue
+				return true
 			}
 			nameL := strings.ToLower(e.Name)
 			qnL := strings.ToLower(e.QualifiedName)
@@ -896,7 +896,7 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 			// Without a kind_filter, keep name-only matching. With a kind_filter,
 			// fold in every in-scope kind member (nameHit just drives ranking).
 			if !nameHit && !enumerateKind {
-				continue
+				return true
 			}
 			out = append(out, item{
 				EntityID:      prefixedID(r.Repo, e.ID),
@@ -908,7 +908,8 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 				StartLine:     e.StartLine,
 				nameHit:       nameHit,
 			})
-		}
+			return true
+		})
 	}
 	// Sort: name-substring hits first (kind enumeration only), then exact-name
 	// matches, then alphabetical. When kind_filter is empty every row is a

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -220,27 +220,27 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 			continue
 		}
 		adj := map[string][]string{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if !reachabilityEdgeKindsMCP[rel.Kind] {
-				continue
+				return true
 			}
 			adj[rel.FromID] = append(adj[rel.FromID], rel.ToID)
-		}
+			return true
+		})
 		seeds := map[string]bool{}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if frameworkEntryKindsMCP[e.Kind] || isFrameworkOrHandler(e) {
 				seeds[e.ID] = true
 			}
-		}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+			return true
+		})
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			switch rel.Kind {
 			case "HANDLES", "HANDLES_SIGNAL", "NAVIGATES_TO", "ROUTES_TO", "REGISTERS":
 				seeds[rel.ToID] = true
 			}
-		}
+			return true
+		})
 		reached := bfsLive(adj, seeds)
 		totalEntities += len(r.Doc.Entities)
 		reachable += len(reached)
@@ -248,19 +248,18 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 		if len(repoFilter) > 0 && !repoFilter[r.Repo] {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if reached[e.ID] {
-				continue
+				return true
 			}
 			if isStdlibEntity(e) {
-				continue
+				return true
 			}
 			if !isLiveCodeKind(e.Kind) {
-				continue
+				return true
 			}
 			if !matchesBareKind(e.Kind, kindFilter) {
-				continue
+				return true
 			}
 			out = append(out, deadCodeItem{
 				EntityID:   prefixedID(r.Repo, e.ID),
@@ -269,7 +268,8 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 				Repo:       r.Repo,
 				SourceFile: e.SourceFile,
 			})
-		}
+			return true
+		})
 	}
 	return
 }
@@ -299,13 +299,13 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 			continue
 		}
 		adj := map[string][]string{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if !reachabilityEdgeKindsMCP[rel.Kind] {
-				continue
+				return true
 			}
 			adj[rel.FromID] = append(adj[rel.FromID], rel.ToID)
-		}
+			return true
+		})
 		seeds := map[string]bool{local: true}
 		reached := bfsLive(adj, seeds)
 		totalEntities += len(r.Doc.Entities)
@@ -314,19 +314,18 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 		if len(repoFilter) > 0 && !repoFilter[r.Repo] {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if reached[e.ID] {
-				continue
+				return true
 			}
 			if isStdlibEntity(e) {
-				continue
+				return true
 			}
 			if !isLiveCodeKind(e.Kind) {
-				continue
+				return true
 			}
 			if !matchesBareKind(e.Kind, kindFilter) {
-				continue
+				return true
 			}
 			out = append(out, deadCodeItem{
 				EntityID:   prefixedID(r.Repo, e.ID),
@@ -335,7 +334,8 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 				Repo:       r.Repo,
 				SourceFile: e.SourceFile,
 			})
-		}
+			return true
+		})
 	}
 	return
 }

--- a/internal/mcp/docgen_repair_tools.go
+++ b/internal/mcp/docgen_repair_tools.go
@@ -148,11 +148,10 @@ func countEdgesForFidelity(r *LoadedRepo) (total, bugs int) {
 	if r == nil || r.Doc == nil {
 		return 0, 0
 	}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		// Scope: IMPORTS only — matches audit.AuditPath and health-history.bug_rate.
 		if rel.Kind != "IMPORTS" {
-			continue
+			return true
 		}
 		total++
 		// A relationship is "buggy" (unresolved) when its ToID still looks like
@@ -164,7 +163,8 @@ func countEdgesForFidelity(r *LoadedRepo) (total, bugs int) {
 		if resolve.IsBugEdgeToID(rel.ToID) {
 			bugs++
 		}
-	}
+		return true
+	})
 	return total, bugs
 }
 
@@ -329,14 +329,13 @@ func computeUnresolvedBreakdown(repos []*LoadedRepo, topN int) UnresolvedBreakdo
 			continue
 		}
 		byID := r.getByID()
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
+		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			// Scope: IMPORTS only — matches countEdgesForFidelity and audit.AuditPath.
 			if rel.Kind != "IMPORTS" {
-				continue
+				return true
 			}
 			if !resolve.IsBugEdgeToID(rel.ToID) {
-				continue
+				return true
 			}
 
 			disp := unresolvedImportDisposition(rel)
@@ -368,7 +367,8 @@ func computeUnresolvedBreakdown(repos []*LoadedRepo, topN int) UnresolvedBreakdo
 			}
 			rs.count++
 			rs.dispCounts[disp]++
-		}
+			return true
+		})
 	}
 
 	// Build sorted top-N list.

--- a/internal/mcp/docstate.go
+++ b/internal/mcp/docstate.go
@@ -19,6 +19,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // docStateCache memoizes ComputeDocState results to keep grafel_whoami off
@@ -240,26 +242,26 @@ func computeDocStateUncached(groupName string, lg *LoadedGroup) DocStateResult {
 
 		// Walk source files for this repo.
 		seen := map[string]bool{}
-		for i := range repo.Doc.Entities {
-			e := &repo.Doc.Entities[i]
+		repo.forEachEntity(func(e *graph.Entity) bool {
 			abs := e.SourceFile
 			if !filepath.IsAbs(abs) && repo.Path != "" {
 				abs = filepath.Join(repo.Path, e.SourceFile)
 			}
 			if seen[abs] {
-				continue
+				return true
 			}
 			seen[abs] = true
 
 			info, err := os.Stat(abs)
 			if err != nil {
-				continue
+				return true
 			}
 			if info.ModTime().After(repoDocgen) {
 				perRepoStale[repoName]++
 				totalStale++
 			}
-		}
+			return true
+		})
 	}
 
 	result := DocStateResult{

--- a/internal/mcp/effective_contract_express.go
+++ b/internal/mcp/effective_contract_express.go
@@ -60,18 +60,17 @@ func (x expressContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
-				continue
+				return true
 			}
 			if !isExpressEndpoint(e) {
-				continue
+				return true
 			}
 			handler := frameworkHandlerEntity(r, e)
 			grp := fastapiGroupLeaf(e, handler) // same flat-function grouping
 			if grp == "" || strings.ToLower(grp) != wantLeaf {
-				continue
+				return true
 			}
 			c := composeExpressContract(r, e, handler)
 			key := groupKey{repo: r.Repo, group: grp}
@@ -82,7 +81,8 @@ func (x expressContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-		}
+			return true
+		})
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_fastapi.go
+++ b/internal/mcp/effective_contract_fastapi.go
@@ -62,18 +62,17 @@ func (f fastAPIContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
-				continue
+				return true
 			}
 			if !isFastAPIEndpoint(e) {
-				continue
+				return true
 			}
 			handler := frameworkHandlerEntity(r, e)
 			grp := fastapiGroupLeaf(e, handler)
 			if grp == "" || strings.ToLower(grp) != wantLeaf {
-				continue
+				return true
 			}
 			c := composeFastAPIContract(r, e, handler)
 			key := groupKey{repo: r.Repo, group: grp}
@@ -84,7 +83,8 @@ func (f fastAPIContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-		}
+			return true
+		})
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_fw_common.go
+++ b/internal/mcp/effective_contract_fw_common.go
@@ -106,10 +106,9 @@ func dtoFieldsByProperty(r *LoadedRepo, dtoType string) []contractField {
 	}
 	prefix := dtoType + "."
 	var out []contractField
-	for i := range r.Doc.Entities {
-		e := &r.Doc.Entities[i]
+	r.forEachEntity(func(e *graph.Entity) bool {
 		if !strings.EqualFold(e.Kind, "SCOPE.Schema") || e.Subtype != "field" {
-			continue
+			return true
 		}
 		owner := strings.TrimSpace(e.PropGet("parent_class"))
 		if owner == "" {
@@ -124,13 +123,13 @@ func dtoFieldsByProperty(r *LoadedRepo, dtoType string) []contractField {
 				name = strings.TrimSuffix(strings.TrimPrefix(e.Name, prefix), "?")
 			}
 		default:
-			continue
+			return true
 		}
 		if name == "" {
 			name = strings.TrimSuffix(strings.TrimPrefix(e.Name, prefix), "?")
 		}
 		if name == "" {
-			continue
+			return true
 		}
 		typ := strings.TrimSpace(e.PropGet("field_type"))
 		if typ == "" {
@@ -142,7 +141,8 @@ func dtoFieldsByProperty(r *LoadedRepo, dtoType string) []contractField {
 			Required: fieldRequiredFromProps(e),
 			Source:   "dto_field",
 		})
-	}
+		return true
+	})
 	return out
 }
 

--- a/internal/mcp/effective_contract_nestjs.go
+++ b/internal/mcp/effective_contract_nestjs.go
@@ -55,18 +55,17 @@ func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
-				continue
+				return true
 			}
 			if !isNestJSEndpoint(e) {
-				continue
+				return true
 			}
 			handler := nestHandlerEntity(r, e)
 			controller := nestControllerLeaf(e, handler)
 			if controller == "" || strings.ToLower(controller) != wantLeaf {
-				continue
+				return true
 			}
 			c := composeNestContract(r, e, handler)
 			key := groupKey{repo: r.Repo, class: controller}
@@ -81,7 +80,8 @@ func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-		}
+			return true
+		})
 	}
 	if len(groups) == 0 {
 		return nil, false
@@ -277,13 +277,12 @@ func nestDTOFields(r *LoadedRepo, dtoType string) []contractField {
 	}
 	prefix := dtoType + "."
 	var out []contractField
-	for i := range r.Doc.Entities {
-		e := &r.Doc.Entities[i]
+	r.forEachEntity(func(e *graph.Entity) bool {
 		if !strings.EqualFold(e.Kind, "SCOPE.Schema") || e.Subtype != "field" {
-			continue
+			return true
 		}
 		if !strings.HasPrefix(e.Name, prefix) {
-			continue
+			return true
 		}
 		name := strings.TrimPrefix(e.Name, prefix)
 		required := true
@@ -296,7 +295,8 @@ func nestDTOFields(r *LoadedRepo, dtoType string) []contractField {
 			Type:     fieldTypeFromSignature(e.Signature),
 			Required: required,
 		})
-	}
+		return true
+	})
 	return out
 }
 

--- a/internal/mcp/effective_contract_spring.go
+++ b/internal/mcp/effective_contract_spring.go
@@ -58,18 +58,17 @@ func (s springContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
-				continue
+				return true
 			}
 			if !isSpringEndpoint(e) {
-				continue
+				return true
 			}
 			handler := frameworkHandlerEntity(r, e)
 			controller := frameworkControllerLeaf(e, handler)
 			if controller == "" || strings.ToLower(controller) != wantLeaf {
-				continue
+				return true
 			}
 			c := composeSpringContract(r, e, handler)
 			key := groupKey{repo: r.Repo, class: controller}
@@ -80,7 +79,8 @@ func (s springContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-		}
+			return true
+		})
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -184,18 +184,17 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isRouterExpandedRoute(e) {
-				continue
+				return true
 			}
 			vs := viewSetNameForRoute(e)
 			if vs == "" || strings.ToLower(vs) != wantVS {
-				continue
+				return true
 			}
 			c, ok := projectEffectiveContract(e)
 			if !ok {
-				continue
+				return true
 			}
 			// #3964 follow-up: when the route carries no stamped per-verb
 			// contract (effective_kind/effective_status absent because the
@@ -216,7 +215,8 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-		}
+			return true
+		})
 	}
 
 	// CLASS FALLBACK (deploy-9 item-4): when NO router-expanded route entities
@@ -348,17 +348,22 @@ func findViewSetClassEntity(r *LoadedRepo, wantVS string) *graph.Entity {
 		return nil
 	}
 	var fallback *graph.Entity
-	for i := range r.Doc.Entities {
-		e := &r.Doc.Entities[i]
+	var found *graph.Entity
+	r.forEachEntity(func(e *graph.Entity) bool {
 		if strings.ToLower(leafAfterDot(e.Name)) != wantVS {
-			continue
+			return true
 		}
 		if isClassEntity(e) {
-			return e
+			found = e
+			return false
 		}
 		if fallback == nil && len(extendsBases(r, e)) > 0 {
 			fallback = e
 		}
+		return true
+	})
+	if found != nil {
+		return found
 	}
 	return fallback
 }

--- a/internal/mcp/endpoint_posture.go
+++ b/internal/mcp/endpoint_posture.go
@@ -192,28 +192,28 @@ func (s *Server) endpointPostureScan(req mcpapi.CallToolRequest, repos []*Loaded
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			// Skip the synthetic convergence nodes themselves — they are the
 			// targets of the edges, never the subject of a posture query.
 			if strings.EqualFold(e.Kind, kindExceptionType) || strings.EqualFold(e.Kind, kindFeatureFlag) {
-				continue
+				return true
 			}
 			p := buildPosturePayload(r, e)
 			if !p.HasPosture {
-				continue
+				return true
 			}
 			if facet != "" && !postureHasFacet(p, facet) {
-				continue
+				return true
 			}
 			if pathContains != "" && !strings.Contains(strings.ToLower(p.Path), pathContains) {
-				continue
+				return true
 			}
 			if method != "" && !strings.EqualFold(p.Method, method) {
-				continue
+				return true
 			}
 			out = append(out, p)
-		}
+			return true
+		})
 	}
 
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/mcp/license_tools.go
+++ b/internal/mcp/license_tools.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/licenses"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
@@ -170,22 +171,22 @@ func collectExternalPackages(r *LoadedRepo) []map[string]string {
 		return nil
 	}
 	var out []map[string]string
-	for i := range r.Doc.Entities {
-		e := &r.Doc.Entities[i]
+	r.forEachEntity(func(e *graph.Entity) bool {
 		if e.Subtype != "external_dependency" {
-			continue
+			return true
 		}
 		pm := e.PropGet("package_manager")
 		ver := e.PropGet("version")
 		if pm == "" {
-			continue
+			return true
 		}
 		out = append(out, map[string]string{
 			"name":            e.Name,
 			"package_manager": pm,
 			"version":         ver,
 		})
-	}
+		return true
+	})
 	return out
 }
 

--- a/internal/mcp/literal_parity_derive.go
+++ b/internal/mcp/literal_parity_derive.go
@@ -76,27 +76,26 @@ func deriveDRFActionCodenames(lg *LoadedGroup, viewset string) (*graph.Entity, s
 		ownerVS := map[string]string{}
 		if wantVS != "" {
 			byID := r.getByID()
-			for i := range r.Doc.Relationships {
-				rel := &r.Doc.Relationships[i]
+			r.forEachRelationship(func(rel *graph.Relationship) bool {
 				if rel.Kind != "CONTAINS" {
-					continue
+					return true
 				}
 				parent, ok := byID[bareID(rel.FromID)]
 				if !ok {
 					parent, ok = byID[rel.FromID]
 				}
 				if !ok || !isViewSetLike(parent) {
-					continue
+					return true
 				}
 				ownerVS[bareID(rel.ToID)] = canonicalSetName(bareEntityName(parent))
 				ownerVS[rel.ToID] = canonicalSetName(bareEntityName(parent))
-			}
+				return true
+			})
 		}
 
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isDRFAction(e) {
-				continue
+				return true
 			}
 			if wantVS != "" {
 				vs, ok := ownerVS[e.ID]
@@ -104,16 +103,17 @@ func deriveDRFActionCodenames(lg *LoadedGroup, viewset string) (*graph.Entity, s
 					vs = ownerVS[bareID(e.ID)]
 				}
 				if vs != wantVS {
-					continue
+					return true
 				}
 			}
 			code := drfActionCodename(e)
 			if code == "" || seen[code] {
-				continue
+				return true
 			}
 			seen[code] = true
 			members = append(members, literalparity.Member{Key: code, Value: code, Line: e.StartLine})
-		}
+			return true
+		})
 	}
 
 	if len(members) == 0 {

--- a/internal/mcp/literal_parity_tool.go
+++ b/internal/mcp/literal_parity_tool.go
@@ -284,10 +284,9 @@ func matchEnumByNames(lg *LoadedGroup, candidates []string) *graph.Entity {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isValueSet(e) {
-				continue
+				return true
 			}
 			en := canonicalSetName(enumDisplayName(e))
 			for rank, nc := range normCands {
@@ -295,7 +294,8 @@ func matchEnumByNames(lg *LoadedGroup, candidates []string) *graph.Entity {
 					hits = append(hits, hit{ent: e, rank: rank})
 				}
 			}
-		}
+			return true
+		})
 	}
 	if len(hits) == 0 {
 		return nil

--- a/internal/mcp/messaging_related_5782.go
+++ b/internal/mcp/messaging_related_5782.go
@@ -103,11 +103,16 @@ func resolveTopicSeed(lg *LoadedGroup, entityID string) *topicSeed {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		var found *topicSeed
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if isMessageTopicEntity(e) && (e.Name == probe || e.QualifiedName == probe || e.Name == entityID) {
-				return &topicSeed{repo: r, id: e.ID, name: e.Name}
+				found = &topicSeed{repo: r, id: e.ID, name: e.Name}
+				return false
 			}
+			return true
+		})
+		if found != nil {
+			return found
 		}
 	}
 	return nil
@@ -170,10 +175,9 @@ func collectTopicNeighbors(lg *LoadedGroup, topicName, seedRepo string) (produce
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isMessageTopicEntity(e) || e.Name != topicName {
-				continue
+				return true
 			}
 			adj := r.getAdjacency()
 			for _, in := range adj.Incoming(e.ID) {
@@ -189,7 +193,8 @@ func collectTopicNeighbors(lg *LoadedGroup, topicName, seedRepo string) (produce
 					add(&handlers, seenHand, r, out.target, "DELIVERS_TO")
 				}
 			}
-		}
+			return true
+		})
 	}
 
 	// (b) Cross-repo topic joins. Matched to THIS topic by the link identifier
@@ -379,11 +384,16 @@ func resolveChannelBindingSeed(lg *LoadedGroup, entityID string) *channelBinding
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		var found *channelBindingSeed
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if isChannelBindingEntity(e) && (e.Name == probe || e.QualifiedName == probe || e.Name == entityID) {
-				return &channelBindingSeed{repo: r, id: e.ID, name: e.Name}
+				found = &channelBindingSeed{repo: r, id: e.ID, name: e.Name}
+				return false
 			}
+			return true
+		})
+		if found != nil {
+			return found
 		}
 	}
 	return nil
@@ -512,8 +522,7 @@ func collectChannelBindingTargets(r *LoadedRepo, binding *graph.Entity) (channel
 	}
 	byID := r.getByID()
 	seenCh, seenTop := map[string]bool{}, map[string]bool{}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		var list *[]topicNeighbor
 		var seen map[string]bool
 		var edgeKind string
@@ -523,14 +532,14 @@ func collectChannelBindingTargets(r *LoadedRepo, binding *graph.Entity) (channel
 		case string(types.RelationshipKindBindsTopic):
 			list, seen, edgeKind = &topics, seenTop, "BINDS_TOPIC"
 		default:
-			continue
+			return true
 		}
 		if !bindingMatchesEdge(binding, rel.FromID) {
-			continue
+			return true
 		}
 		e := byID[rel.ToID]
 		if e == nil || seen[e.ID] {
-			continue
+			return true
 		}
 		seen[e.ID] = true
 		*list = append(*list, topicNeighbor{
@@ -542,7 +551,8 @@ func collectChannelBindingTargets(r *LoadedRepo, binding *graph.Entity) (channel
 			Line:     e.StartLine,
 			EdgeKind: edgeKind,
 		})
-	}
+		return true
+	})
 	sortTopicNeighbors(channels)
 	sortTopicNeighbors(topics)
 	return channels, topics
@@ -603,8 +613,7 @@ func computeRepoImpact(r *LoadedRepo, target string, hops int) []impactAffected 
 	moduleCallerMap := map[string]int{}
 	totalDegreeMap := map[string]int{}
 	inboundTestsMap := map[string]int{}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		totalDegreeMap[rel.ToID]++
 		if rel.Kind == "TESTS" {
 			inboundTestsMap[rel.ToID]++
@@ -618,7 +627,8 @@ func computeRepoImpact(r *LoadedRepo, target string, hops int) []impactAffected 
 		} else {
 			namedCallerMap[rel.ToID]++
 		}
-	}
+		return true
+	})
 
 	adj := r.getAdjacency()
 	visited := map[string]int{target: 0}
@@ -671,10 +681,9 @@ func computeRepoImpact(r *LoadedRepo, target string, hops int) []impactAffected 
 func oneEntityImpact(r *LoadedRepo, e *graph.Entity, hop int) impactAffected {
 	byID := r.getByID()
 	named, module, total, tests := 0, 0, 0, 0
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		if rel.ToID != e.ID {
-			continue
+			return true
 		}
 		total++
 		if rel.Kind == "TESTS" {
@@ -685,7 +694,8 @@ func oneEntityImpact(r *LoadedRepo, e *graph.Entity, hop int) impactAffected {
 		} else {
 			named++
 		}
-	}
+		return true
+	})
 	hasTests := tests > 0
 	isSpec := isTestSpecEntity(e)
 	return impactAffected{
@@ -713,10 +723,9 @@ func (s *Server) impactRadiusForTopic(lg *LoadedGroup, seed *topicSeed, hops int
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isMessageTopicEntity(e) || e.Name != seed.name {
-				continue
+				return true
 			}
 			for _, a := range computeRepoImpact(r, e.ID, hops) {
 				if a.Kind == stripScopePrefix(string(types.EntityKindMessageTopic)) {
@@ -729,7 +738,8 @@ func (s *Server) impactRadiusForTopic(lg *LoadedGroup, seed *topicSeed, hops int
 				seen[a.EntityID] = true
 				results = append(results, a)
 			}
-		}
+			return true
+		})
 	}
 
 	// Fold cross-repo topic joins whose publisher/subscriber has no local topic

--- a/internal/mcp/patterns.go
+++ b/internal/mcp/patterns.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/cajasmota/grafel/internal/agentpatterns"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 	"math"
@@ -727,11 +728,12 @@ func repoLanguages(r *LoadedRepo) []string {
 		return nil
 	}
 	set := map[string]bool{}
-	for i := range r.Doc.Entities {
-		if lang := r.Doc.Entities[i].Language; lang != "" {
+	r.forEachEntity(func(e *graph.Entity) bool {
+		if lang := e.Language; lang != "" {
 			set[lang] = true
 		}
-	}
+		return true
+	})
 	return sortedKeys(set)
 }
 

--- a/internal/mcp/phase3_tools.go
+++ b/internal/mcp/phase3_tools.go
@@ -25,6 +25,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/types"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
@@ -512,18 +513,17 @@ func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) 
 				continue
 			}
 			byID := r.getByID()
-			for i := range r.Doc.Relationships {
-				rel := &r.Doc.Relationships[i]
+			r.forEachRelationship(func(rel *graph.Relationship) bool {
 				sinkKind, ok := dbSinkEdgeKinds[strings.ToUpper(rel.Kind)]
 				if !ok {
-					continue
+					return true
 				}
 				if !sinkKindMatchesDB(sinkKindFilter, sinkKind) {
-					continue
+					return true
 				}
 				fromID := prefixedID(repo, rel.FromID)
 				if entityFilter != "" && fromID != entityFilter {
-					continue
+					return true
 				}
 				toID := rel.ToID
 				if rprefix, _ := splitPrefixed(toID); rprefix == "" {
@@ -551,7 +551,8 @@ func (s *Server) handleDataFlows(_ context.Context, req mcpapi.CallToolRequest) 
 				}
 				out = append(out, rec)
 				graphProjected++
-			}
+				return true
+			})
 		}
 	}
 

--- a/internal/mcp/response_shape_diff_tool.go
+++ b/internal/mcp/response_shape_diff_tool.go
@@ -217,23 +217,23 @@ func collectContractTargets(lg *LoadedGroup) []contractTarget {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isHTTPEndpointDefinition(e) && !isRouterExpandedRoute(e) {
-				continue
+				return true
 			}
 			owner := endpointOwningClass(e)
 			if owner == "" {
-				continue
+				return true
 			}
 			verb, path := endpointVerbPath(e)
 			key := strings.ToLower(owner)
 			if seen[key] {
-				continue
+				return true
 			}
 			seen[key] = true
 			out = append(out, contractTarget{target: owner, verb: verb, path: path})
-		}
+			return true
+		})
 	}
 	return out
 }

--- a/internal/mcp/stub_detector_tool.go
+++ b/internal/mcp/stub_detector_tool.go
@@ -156,19 +156,18 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 		callsAdj := r.getCallsAdj()
 		byID := r.getByID()
 
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isDefinitionKind(e.Kind) {
-				continue
+				return true
 			}
 			if e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis {
-				continue
+				return true
 			}
 			method := strings.ToUpper(strings.TrimSpace(e.PropGet("verb")))
 			rawPath := e.PropGet("path")
 			key := newEndpointJoinKey(method, rawPath)
 			if filter != nil && (filter.method != key.method || filter.path != key.path) {
-				continue
+				return true
 			}
 
 			label := endpointLabel(method, rawPath)
@@ -176,7 +175,7 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 			oracleEntry, ok := oracleIdx[key]
 			if !ok {
 				unlinked = append(unlinked, label)
-				continue
+				return true
 			}
 
 			v3Eff := computeEndpointEffects(r.Repo, e, hres, callsAdj, byID, v3Effs, v3HasEffectData)
@@ -204,7 +203,8 @@ func (s *Server) handleStubDetector(_ context.Context, req mcpapi.CallToolReques
 			res.PartialStubSupported = supported
 
 			results = append(results, res)
-		}
+			return true
+		})
 	}
 
 	// Deterministic order: likely_stub first (highest confidence), then by
@@ -305,10 +305,9 @@ func buildStubHandlerResolution(r *LoadedRepo) *stubHandlerResolution {
 		e := byID[id]
 		return e != nil && !isDefinitionKind(e.Kind)
 	}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		if !stubHandlerResolveEdgeKinds[rel.Kind] {
-			continue
+			return true
 		}
 		switch {
 		case isDef(rel.ToID) && isHandler(rel.FromID): // handler --IMPLEMENTS--> def
@@ -316,7 +315,8 @@ func buildStubHandlerResolution(r *LoadedRepo) *stubHandlerResolution {
 		case isDef(rel.FromID) && isHandler(rel.ToID): // def --ROUTES_TO--> handler
 			res.handlerOf[rel.FromID] = appendUniqueStr(res.handlerOf[rel.FromID], rel.ToID)
 		}
-	}
+		return true
+	})
 	return res
 }
 
@@ -438,13 +438,12 @@ func buildEndpointEffectsIndex(lg *LoadedGroup, sidecar map[string]effectsSideca
 		hres := buildStubHandlerResolution(r)
 		callsAdj := r.getCallsAdj()
 		byID := r.getByID()
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isDefinitionKind(e.Kind) {
-				continue
+				return true
 			}
 			if e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis {
-				continue
+				return true
 			}
 			key := newEndpointJoinKey(e.PropGet("verb"), e.PropGet("path"))
 			eff := computeEndpointEffects(r.Repo, e, hres, callsAdj, byID, sidecar, groupHasEffectData)
@@ -453,7 +452,8 @@ func buildEndpointEffectsIndex(lg *LoadedGroup, sidecar map[string]effectsSideca
 			} else {
 				idx[key] = eff
 			}
-		}
+			return true
+		})
 	}
 	return idx
 }
@@ -502,11 +502,17 @@ func groupHasEffectProps(lg *LoadedGroup) bool {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			p := r.Doc.Entities[i].PropsSnapshot()
+		found := false
+		r.forEachEntity(func(e *graph.Entity) bool {
+			p := e.PropsSnapshot()
 			if p != nil && strings.TrimSpace(p["effects"]) != "" {
-				return true
+				found = true
+				return false
 			}
+			return true
+		})
+		if found {
+			return true
 		}
 	}
 	return false

--- a/internal/mcp/tautology_detector_tool.go
+++ b/internal/mcp/tautology_detector_tool.go
@@ -102,19 +102,18 @@ func (s *Server) handleContractTestEffectiveness(_ context.Context, req mcpapi.C
 			continue
 		}
 		linkage := buildTestLinkageTerms(r)
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isTautologyCandidate(e) {
-				continue
+				return true
 			}
 			pid := prefixedID(r.Repo, e.ID)
 			if entityFilter != "" && entityFilter != pid && entityFilter != e.Name && entityFilter != e.QualifiedName {
-				continue
+				return true
 			}
 
 			src, lang := readTautologySource(r, e)
 			if src == "" {
-				continue
+				return true
 			}
 
 			res := tautology.Analyze(tautology.Input{
@@ -126,7 +125,7 @@ func (s *Server) handleContractTestEffectiveness(_ context.Context, req mcpapi.C
 			if !res.Supported {
 				// Unsupported language — skip silently (honest-partial); these add
 				// no signal and would just be noise.
-				continue
+				return true
 			}
 			tautology.SortFindings(res.Findings)
 			analysed++
@@ -134,7 +133,7 @@ func (s *Server) handleContractTestEffectiveness(_ context.Context, req mcpapi.C
 				ineffective++
 			}
 			if onlyIneffective && res.Verdict != tautology.VerdictIneffective && !res.NoGoldenLinkage {
-				continue
+				return true
 			}
 
 			out = append(out, specRec{
@@ -144,7 +143,8 @@ func (s *Server) handleContractTestEffectiveness(_ context.Context, req mcpapi.C
 				language: lang,
 				res:      res,
 			})
-		}
+			return true
+		})
 	}
 
 	sort.SliceStable(out, func(i, j int) bool {
@@ -261,14 +261,13 @@ func specLabel(e *graph.Entity) string {
 func buildTestLinkageTerms(r *LoadedRepo) map[string][]string {
 	byID := r.getByID()
 	terms := map[string][]string{}
-	for i := range r.Doc.Relationships {
-		rel := &r.Doc.Relationships[i]
+	r.forEachRelationship(func(rel *graph.Relationship) bool {
 		if rel.Kind != "TESTS" {
-			continue
+			return true
 		}
 		target := byID[rel.ToID]
 		if target == nil {
-			continue
+			return true
 		}
 		set := terms[rel.FromID]
 		if target.Name != "" {
@@ -280,6 +279,7 @@ func buildTestLinkageTerms(r *LoadedRepo) map[string][]string {
 			}
 		}
 		terms[rel.FromID] = set
-	}
+		return true
+	})
 	return terms
 }


### PR DESCRIPTION
## What
PR2 of the mmap-cutover flip (Path P, #5870). Routes 57 direct `range Doc.Entities`/`Doc.Relationships` scans across 24 cold analysis/dashboard/docgen tool files through the merged PR1 `forEachEntity`/`forEachRelationship` iterators. Behavior-neutral flag-OFF (byte-identical to the inline loops); flag-ON reads the mmap Reader (dark until PR7). File-disjoint from PR4 (#5874).

Mechanical transform (`continue`→`return true`, `break`→`return false`, function-`return`→captured-var+`return false`+post-check). 3 candidate files had no such loop (skipped). `graph` import added to 6 files.

## Tests
The 4 non-trivial early-return conversions (`findViewSetClassEntity`, `groupHasEffectProps`, `resolveTopicSeed`, `resolveChannelBindingSeed`) are all exercised by existing sibling tests.

Independently opus-reviewed (APPROVE): all 4 early-return rewrites verified exactly equivalent (incl. per-repo-scoped result vars), zero index-`i` usages dropped, no defer/goto/retained-pointer traps, grep-gate 24 files → 0 residual, DO-NOT-TOUCH files empty diff. `go test ./internal/mcp/...` 1178 pass.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)