### PR TITLE
feat(mcp): route residual MRO/traces/resolve Doc scans through forEach (mmap flip Path P, PR4b)

### DIFF
--- a/internal/mcp/enumerate_by_kind_pr4b_test.go
+++ b/internal/mcp/enumerate_by_kind_pr4b_test.go
@@ -1,0 +1,124 @@
+// enumerate_by_kind_pr4b_test.go — parity test for PR4b (ADR-0027 Path P,
+// memory epic #5850, residual read-migration): enumerateByKind's foldCap
+// early-return loop (tools.go) was converted from
+//
+//	for i := range r.Doc.Entities { if len(out) >= foldCap { return out }; ... }
+//
+// to an lr.forEachEntity yield with a captured `capReached` flag checked after
+// the callback returns, re-raising the function-level `return out` outside the
+// forEach call. This is exactly the class of conversion the PR4b brief flags as
+// needing a parity test (early-return whose control flow crosses a repo
+// boundary): the cap must stop enumeration of the CURRENT repo immediately
+// (mid-scan) AND must never spill into a later repo in the `repos` slice, in
+// both flag-OFF (Doc-sourced) and flag-ON (mmap Reader-sourced) forEachEntity
+// paths.
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// manyFunctionsDoc builds n "function"-kind entities (real bodies, non-noise,
+// default confidence) all named fN, qualified r.fN — every one matches
+// kindFilter="function" and clears the noise/confidence gates in
+// enumerateByKind.
+func manyFunctionsDoc(repo string, n int) *graph.Document {
+	doc := &graph.Document{Version: 1, Repo: repo}
+	for i := 0; i < n; i++ {
+		id := repo + "::f" + itoa(i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: id, Name: "f" + itoa(i), QualifiedName: repo + ".f" + itoa(i),
+			Kind: "function", SourceFile: "f" + itoa(i) + ".go", Language: "go",
+			StartLine: 1 + i, EndLine: 2 + i,
+		})
+	}
+	return doc
+}
+
+// runEnumerateByKindCap exercises enumerateByKind over two repos: r1 carries
+// more matching entities than foldCap (200, the floor for a small maxResults),
+// r2 carries a handful more. It returns the repo names present in the result,
+// in order, plus the total count — the assertions the caller makes are
+// (a) the result is capped at exactly foldCap and (b) it contains ONLY r1
+// entities (the cap must fire before r2 is ever scanned).
+func runEnumerateByKindCap(t *testing.T, mmapOn bool) []scored {
+	t.Helper()
+	forceServeFromMMap(t, mmapOn)
+
+	doc1 := manyFunctionsDoc("r1", 250)
+	doc2 := manyFunctionsDoc("r2", 5)
+
+	r1 := &LoadedRepo{Repo: "r1", Doc: doc1}
+	r2 := &LoadedRepo{Repo: "r2", Doc: doc2}
+
+	if mmapOn {
+		wireLoadedRepoReader(t, r1, doc1)
+		wireLoadedRepoReader(t, r2, doc2)
+	}
+
+	// maxResults=1 -> foldCap = max(1*4, 200) = 200.
+	out := enumerateByKind(nil, []*LoadedRepo{r1, r2}, "function", false, 0, 1)
+	return out
+}
+
+// wireLoadedRepoReader writes doc to a temp graph.fb, opens a real mmap Reader
+// over it, and publishes the handle on lr so lr.forEachEntity's flag-ON branch
+// sources rows from the mmap Reader instead of lr.Doc (mirrors the wiring in
+// mmap_readermu_sigbus_test.go / view_iter_test.go).
+func wireLoadedRepoReader(t *testing.T, lr *LoadedRepo, doc *graph.Document) {
+	t.Helper()
+	fbPath := t.TempDir() + "/graph.fb"
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	rdr, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	h := newMapHandle(rdr)
+	lr.publishHandle(h)
+}
+
+func TestEnumerateByKind_FoldCapStopsAtRepoBoundary_FlagOff(t *testing.T) {
+	out := runEnumerateByKindCap(t, false)
+	assertFoldCapCappedToR1(t, out)
+}
+
+func TestEnumerateByKind_FoldCapStopsAtRepoBoundary_FlagOn(t *testing.T) {
+	out := runEnumerateByKindCap(t, true)
+	assertFoldCapCappedToR1(t, out)
+}
+
+func assertFoldCapCappedToR1(t *testing.T, out []scored) {
+	t.Helper()
+	const foldCap = 200
+	if len(out) != foldCap {
+		t.Fatalf("enumerateByKind: got %d results, want exactly foldCap=%d", len(out), foldCap)
+	}
+	for i, sc := range out {
+		if sc.repo.Repo != "r1" {
+			t.Fatalf("result[%d]: repo=%q, want r1 only — cap must stop before r2 is scanned", i, sc.repo.Repo)
+		}
+	}
+}
+
+// TestEnumerateByKind_FlagOnOffParity asserts the exact same entity IDs, in the
+// same order, are returned whether forEachEntity sources from lr.Doc (flag-OFF)
+// or the mmap Reader (flag-ON) — the behavior-neutral guarantee PR4b requires
+// for every converted site.
+func TestEnumerateByKind_FlagOnOffParity(t *testing.T) {
+	off := runEnumerateByKindCap(t, false)
+	on := runEnumerateByKindCap(t, true)
+	if len(off) != len(on) {
+		t.Fatalf("flag-off yielded %d, flag-on yielded %d", len(off), len(on))
+	}
+	for i := range off {
+		if off[i].hit.Entity.ID != on[i].hit.Entity.ID {
+			t.Fatalf("result[%d]: flag-off ID=%q, flag-on ID=%q", i, off[i].hit.Entity.ID, on[i].hit.Entity.ID)
+		}
+	}
+}

--- a/internal/mcp/get_source_resolve.go
+++ b/internal/mcp/get_source_resolve.go
@@ -167,16 +167,16 @@ func suffixMatch(lg *LoadedGroup, keys []string) []sourceCandidate {
 			if r.Doc == nil {
 				continue
 			}
-			for i := range r.Doc.Entities {
-				e := &r.Doc.Entities[i]
+			r.forEachEntity(func(e *graph.Entity) bool {
 				qn := strings.ToLower(e.QualifiedName)
 				if qn == "" {
-					continue
+					return true
 				}
 				if qn == needle || strings.HasSuffix(qn, "."+needle) {
 					out = appendUniqueCandidate(out, sourceCandidate{ent: e, repo: r})
 				}
-			}
+				return true
+			})
 		}
 	}
 	return out
@@ -230,11 +230,11 @@ func didYouMean(lg *LoadedGroup, keys []string) string {
 			if r.Doc == nil {
 				continue
 			}
-			for i := range r.Doc.Entities {
-				e := &r.Doc.Entities[i]
+			r.forEachEntity(func(e *graph.Entity) bool {
 				consider(key, e.QualifiedName)
 				consider(leaf, e.Name)
-			}
+				return true
+			})
 		}
 	}
 	if best == nil {

--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -601,20 +601,22 @@ func classDeclaredMember(lr *LoadedRepo, cls *graph.Entity, member string) *grap
 	// stays file-scoped because it matches on a bare leaf+prefix (no globally
 	// unique key), so a cross-file scan could pull an unrelated same-named
 	// method; the ByQName path above already covers the cross-file case.
-	for i := range lr.Doc.Entities {
-		e := &lr.Doc.Entities[i]
+	var found *graph.Entity
+	lr.forEachEntity(func(e *graph.Entity) bool {
 		if e.SourceFile != cls.SourceFile || !isMemberEntity(e) || !hasRealBody(e) {
-			continue
+			return true
 		}
 		qn := e.QualifiedName
 		if qn == "" {
 			qn = e.Name
 		}
 		if leafAfterDot(qn) == member && prefixBeforeDot(qn) == clsLeaf {
-			return e
+			found = e
+			return false
 		}
-	}
-	return nil
+		return true
+	})
+	return found
 }
 
 // isMemberEntity reports whether e is a method/operation that can be a member

--- a/internal/mcp/mro_traverse.go
+++ b/internal/mcp/mro_traverse.go
@@ -191,10 +191,9 @@ func buildMROInbound(lr *LoadedRepo) map[string][]string {
 	if lr == nil || lr.Doc == nil {
 		return out
 	}
-	for i := range lr.Doc.Entities {
-		e := &lr.Doc.Entities[i]
+	lr.forEachEntity(func(e *graph.Entity) bool {
 		if !isMemberEntity(e) {
-			continue
+			return true
 		}
 		for _, me := range mroOutboundEdges(lr, e.ID) {
 			if me.External {
@@ -202,7 +201,8 @@ func buildMROInbound(lr *LoadedRepo) map[string][]string {
 			}
 			out[me.Target] = append(out[me.Target], e.ID)
 		}
-	}
+		return true
+	})
 	return out
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1043,8 +1043,7 @@ func pickFallback(repos []*LoadedRepo) *fallbackPick {
 			continue
 		}
 		// Slow path fallback (no cache — e.g. unit tests without buildTopKPageRank).
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			pr := 0.0
 			if e.PageRank != nil {
 				pr = *e.PageRank
@@ -1053,7 +1052,8 @@ func pickFallback(repos []*LoadedRepo) *fallbackPick {
 				bestPR = pr
 				best = &fallbackPick{repo: r, entity: e}
 			}
-		}
+			return true
+		})
 	}
 	return best
 }
@@ -1126,24 +1126,29 @@ func enumerateByKind(all []scored, repos []*LoadedRepo, kindFilter string, inclu
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
+		capReached := false
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if len(out) >= foldCap {
-				return out
+				capReached = true
+				return false
 			}
-			e := &r.Doc.Entities[i]
 			if !matchesKindFilter(e, kindFilter) {
-				continue
+				return true
 			}
 			if seen[r] != nil && seen[r][e.ID] {
-				continue
+				return true
 			}
 			if !includeNoise && isNoise(e) {
-				continue
+				return true
 			}
 			if !entityPassesConfidence(e, minConfidence) {
-				continue
+				return true
 			}
 			out = append(out, scored{repo: r, hit: Hit{Entity: e, Score: 0.0001, Source: "kind_filter"}})
+			return true
+		})
+		if capReached {
+			return out
 		}
 	}
 	return out
@@ -2433,12 +2438,18 @@ func normalizePrefixed(lg *LoadedGroup, s string) string {
 			if r.Doc == nil {
 				continue
 			}
-			for i := range r.Doc.Entities {
-				for _, me := range mroOutboundEdges(r, r.Doc.Entities[i].ID) {
+			found := false
+			r.forEachEntity(func(e *graph.Entity) bool {
+				for _, me := range mroOutboundEdges(r, e.ID) {
 					if me.External && me.Target == s {
-						return prefixedID(r.Repo, s)
+						found = true
+						return false
 					}
 				}
+				return true
+			})
+			if found {
+				return prefixedID(r.Repo, s)
 			}
 		}
 	}
@@ -2521,10 +2532,10 @@ func groupCommunities(lg *LoadedGroup, repoFilter []string, minSize, topLimit in
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			cid := r.Doc.Entities[i].CommunityID
+		r.forEachEntity(func(e *graph.Entity) bool {
+			cid := e.CommunityID
 			if cid == nil {
-				continue
+				return true
 			}
 			m := reposByCommunity[*cid]
 			if m == nil {
@@ -2532,7 +2543,8 @@ func groupCommunities(lg *LoadedGroup, repoFilter []string, minSize, topLimit in
 				reposByCommunity[*cid] = m
 			}
 			m[r.Repo] = struct{}{}
-		}
+			return true
+		})
 	}
 
 	// repo_filter membership: a community surfaces if any of its repos is named.
@@ -3264,13 +3276,14 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 				continue
 			}
 			seen := map[int]struct{}{}
-			for i := range r.Doc.Entities {
-				cid := r.Doc.Entities[i].CommunityID
+			r.forEachEntity(func(e *graph.Entity) bool {
+				cid := e.CommunityID
 				if cid == nil || *cid < 0 {
-					continue
+					return true
 				}
 				seen[*cid] = struct{}{}
-			}
+				return true
+			})
 			overlayCommByRepo[n] = len(seen)
 		}
 	}

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -96,20 +96,19 @@ func (s *Server) handleTracesList(_ context.Context, req mcpapi.CallToolRequest)
 		if r.Doc == nil {
 			continue
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != processEntityKind {
-				continue
+				return true
 			}
 			cs := e.PropGet("cross_stack") == "true"
 			if crossOnly && !cs {
-				continue
+				return true
 			}
 			sc, _ := strconv.Atoi(e.PropGet("step_count"))
 			// #1639 — exclude trivial short flows from the default list;
 			// cross-repo flows are exempt (meaningful even when short).
 			if sc < minSteps && !cs {
-				continue
+				return true
 			}
 			items = append(items, listItem{
 				ProcessID:   prefixedID(r.Repo, e.ID),
@@ -123,7 +122,8 @@ func (s *Server) handleTracesList(_ context.Context, req mcpapi.CallToolRequest)
 				ChainLabels: splitChainLabels(e.PropGet("chain_labels")),
 				SourceFile:  e.SourceFile,
 			})
-		}
+			return true
+		})
 	}
 
 	// Sort: cross-stack first, then by step_count desc, then by label.
@@ -192,10 +192,10 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 		if target == "" {
 			target = pid
 		}
-		for i := range r.Doc.Entities {
-			e := &r.Doc.Entities[i]
+		var result *mcpapi.CallToolResult
+		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != processEntityKind || e.ID != target {
-				continue
+				return true
 			}
 			// #1905 — bridge steps in cross-repo flows live in companion repos.
 			// Build a cross-repo lookup so bridge step entities are enriched with
@@ -203,7 +203,7 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 			// emitted as bare {id, node_id, step_index} stubs.
 			xrLookup := buildGroupCrossRepoLookup(lg, r.Repo)
 			steps := buildProcessStepsWithCrossRepo(r, e, xrLookup, verbose)
-			return jsonResult(map[string]any{
+			result = jsonResult(map[string]any{
 				"process_id":  prefixedID(r.Repo, e.ID),
 				"repo":        r.Repo,
 				"label":       e.Name,
@@ -213,7 +213,11 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 				"cross_stack": e.PropGet("cross_stack") == "true",
 				"steps":       steps,
 				"found":       true,
-			}), nil
+			})
+			return false
+		})
+		if result != nil {
+			return result, nil
 		}
 	}
 	return jsonResult(map[string]any{"found": false, "process_id": pid}), nil


### PR DESCRIPTION
## What
PR4b of the mmap-cutover flip (Path P, #5870) — the last non-infra read-migration. Converts 11 residual `range lr.Doc.Entities` scans across `get_source_resolve.go`, `mro.go`, `mro_traverse.go`, `tools.go`, `traces.go` to the merged `forEachEntity` iterator. Behavior-neutral flag-OFF; flag-ON reads the mmap Reader (dark until PR7).

## Deliberate skip
`enrichment.go:66` `applyResolutions` does in-place write-through (`e := &lr.Doc.Entities[i]; e.PropSet(...)`) — `forEach`'s flag-on heap copies can't preserve that, so it's left as-is. This is a **PR7 Doc-write blocker** to resolve when the slice empties.

## Tests
`enumerate_by_kind_pr4b_test.go` pins the riskiest conversion (`enumerateByKind` cross-repo foldCap): cap stops mid-repo without spilling into the next repo, flag-off==flag-on ID ordering. Mutation-proven (remove the cap guard → FAIL).

Independently opus-reviewed (APPROVE): control-flow equivalence at all 11 sites, `classDeclaredMember` callers confirmed no pointer-identity reliance, `appendUniqueCandidate` (repo,ID) dedup preserved, grep-gate 5 files → 0, remaining Doc-write sites enumerated for PR7. `go test ./internal/mcp/...` 1182 pass.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)