### PR TITLE
feat(mcp): source group-algo overlay + getTopKPageRank from Reader/side-table (mmap flip Path P, PR5)

### DIFF
--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -223,6 +223,86 @@ func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
 	}
 }
 
+// TestOverlaySideTable_BuiltFromReaderNotDoc is the flip-readiness guard for
+// applyGroupAlgoOverlay (PR5). Post-PR7 lr.Doc.Entities is EMPTY, so a side-table
+// build that iterates lr.Doc would come out empty. This test simulates the flip:
+// after a normal flag-ON reload (side-table populated), it EMPTIES
+// lr.Doc.Entities, forces a re-stamp, and asserts the side-table is STILL fully
+// populated — which is only possible if the build sourced its entity iteration
+// from the mmap Reader, not lr.Doc.
+//
+// Mutation proof: reverting buildOverlayTableFromReader back to iterating
+// lr.Doc.Entities makes the post-empty re-stamp produce an EMPTY table → the
+// "still populated" assertions FAIL.
+func TestOverlaySideTable_BuiltFromReaderNotDoc(t *testing.T) {
+	forceServeFromMMap(t, true)
+	st, overlayPath, cur, ids := setupSideTableParity(t)
+
+	alpha, bravo := ids[0], ids[1] // charlie (ids[2]) deliberately un-overlaid
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			alpha: {CommunityID: 39, PageRank: 0.0065, Centrality: 10415.99, IsGodNode: true},
+			bravo: {CommunityID: 80, PageRank: 0.0012, Centrality: 6706.5, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{
+			{ID: 39, Size: 1, AutoName: "alpha-cluster"},
+			{ID: 80, Size: 1, AutoName: "bravo-cluster"},
+		},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	grp := st.Group("acme")
+	lr := grp.Repos["svc"]
+	if lr == nil || lr.Reader == nil || lr.LabelIndex == nil {
+		t.Fatalf("svc repo not loaded with a resident Reader + LabelIndex")
+	}
+
+	// Snapshot the side-table built the normal way (Doc still populated).
+	before := lr.LabelIndex.overlay
+	if len(before) != 2 {
+		t.Fatalf("expected 2 overlaid entities in side-table, got %d: %#v", len(before), before)
+	}
+
+	// Simulate the PR7 flip: empty lr.Doc.Entities. A Doc-sourced side-table
+	// build would now produce an empty table.
+	lr.Doc.Entities = nil
+	// Force a re-stamp (grp.algoApplied=false → overlayChanged=true).
+	grp.algoApplied = false
+	applyGroupAlgoOverlay(grp)
+
+	after := lr.LabelIndex.overlay
+	if len(after) != len(before) {
+		t.Fatalf("side-table not rebuilt from Reader after Doc emptied: got %d entries, want %d\nafter=%#v",
+			len(after), len(before), after)
+	}
+	if !reflect.DeepEqual(after, before) {
+		t.Fatalf("Reader-sourced side-table differs from the pre-flip table:\n before=%#v\n after=%#v", before, after)
+	}
+	// Spot-check the values survived (sourced from the overlay, keyed by index).
+	var alphaPR, bravoPR float64
+	for _, eo := range after {
+		if eo.PageRank == nil {
+			t.Fatalf("side-table row has nil PageRank after Reader rebuild: %#v", eo)
+		}
+		switch *eo.PageRank {
+		case 0.0065:
+			alphaPR = *eo.PageRank
+		case 0.0012:
+			bravoPR = *eo.PageRank
+		}
+	}
+	if alphaPR != 0.0065 || bravoPR != 0.0012 {
+		t.Fatalf("Reader-sourced side-table lost overlay PageRank values: alpha=%v bravo=%v", alphaPR, bravoPR)
+	}
+}
+
 // TestOverlaySideTable_FlagOffBuildsNoSideTableAndReadsDoc is the safety guard
 // for the DEFAULT (GRAFEL_SERVE_FROM_MMAP OFF) path: applyGroupAlgoOverlay must
 // NOT build the side-table (no resident cost pre-flip) and the read path must

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -821,21 +821,28 @@ func (lr *LoadedRepo) getTopKPageRank() []string {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
 	lr.pagerankOnce.Do(func() {
-		// ALWAYS source from lr.Doc, never the Reader/mmap. Per-repo Pass-4 (the
-		// per-repo PageRank/CommunityID/Centrality/god/articulation compute) was
-		// removed when the group-scope algo pass (A1-A3, #5349) replaced it, so
-		// graph.fb's Pagerank() scalar is now a PERMANENT sentinel (0) for every
-		// entity — it is never populated by the indexer. The one authoritative
-		// source of real PageRank is applyGroupAlgoOverlay, which stamps the
-		// <group>-algo.json overlay onto lr.Doc.Entities[i].PageRank IN PLACE
-		// (state.go) — it never touches the mmap'd graph.fb bytes the Reader
-		// serves. Reading PageRank off the Reader (buildTopKPageRankFromReader)
-		// therefore always sees the sentinel and collapses top-K to id order,
-		// which silently corrupts pickFallback's entity choice (regression
-		// introduced by ADR-0027 Cutover PR1, #5865 — fixed here). See
-		// buildTopKPageRankFromReader's doc comment for why that function is
-		// kept but no longer called from here.
-		lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
+		// Real PageRank is NEVER in graph.fb: per-repo Pass-4 (the per-repo
+		// PageRank/CommunityID/Centrality/god/articulation compute) was removed
+		// when the group-scope algo pass (A1-A3, #5349) replaced it, so graph.fb's
+		// Pagerank() scalar is a PERMANENT sentinel (0) for every entity. The one
+		// authoritative source of real PageRank is applyGroupAlgoOverlay, from the
+		// <group>-algo.json overlay.
+		//
+		//   - Flag-OFF (default): the overlay is stamped IN PLACE onto
+		//     lr.Doc.Entities[i].PageRank, so source from lr.Doc. This is
+		//     byte-identical to the pre-PR5 behavior.
+		//   - Flag-ON (flip-ready): lr.Doc is (post-PR7) empty; the real PageRank
+		//     lives in the overlay SIDE-TABLE. buildTopKPageRankFromSideTable reads
+		//     the entity ids from the Reader (vector order) and PageRank from the
+		//     side-table (overlay[i].PageRank) — it MUST NOT read the Reader's
+		//     Pagerank() scalar (the permanent sentinel), which would collapse
+		//     top-K to id order and corrupt pickFallback (the reverted PR1 #5866
+		//     bug — see buildTopKPageRankFromReader's BLOCKED doc comment).
+		if serveFromMMap() {
+			lr.topKPageRank = lr.buildTopKPageRankFromSideTable(64)
+		} else {
+			lr.topKPageRank = buildTopKPageRank(lr.Doc, 64)
+		}
 	})
 	return lr.topKPageRank
 }
@@ -1695,6 +1702,60 @@ func buildTopKPageRankFromReader(r *fbreader.Reader, k int) []string {
 	return out
 }
 
+// buildTopKPageRankFromSideTable is the flip-ready (GRAFEL_SERVE_FROM_MMAP ON)
+// top-K builder. It sources entity IDS from the resident mmap Reader in vector
+// order and PageRank VALUES from the group-algo overlay SIDE-TABLE
+// (lr.LabelIndex.overlay[i].PageRank) — NOT the Reader's Pagerank() scalar,
+// which is the permanent sentinel (0) and would collapse top-K to id order
+// (the reverted PR1 #5866 bug). An entity with no overlay entry ranks at 0,
+// exactly as an un-stamped lr.Doc row (nil PageRank) does under
+// buildTopKPageRank, so this is byte-identical to the flag-off Doc-sourced
+// top-K for the same overlay data.
+//
+// Falls back to the Doc-sourced buildTopKPageRank when no mmap Reader is
+// resident or the mapping was retired (mirrors at()/forEachEntity). readerMu
+// guards the mmap dereference (SIGBUS-safety, memory epic #5850).
+func (lr *LoadedRepo) buildTopKPageRankFromSideTable(k int) []string {
+	lr.readerMu.Lock()
+	rdr := lr.Reader
+	if rdr == nil || (lr.handle != nil && lr.handle.readRetired) {
+		lr.readerMu.Unlock()
+		return buildTopKPageRank(lr.Doc, k) // Reader gone → Doc fallback
+	}
+	var overlay map[int32]entityOverlay
+	if lr.LabelIndex != nil {
+		overlay = lr.LabelIndex.overlay
+	}
+	type ranked struct {
+		id string
+		pr float64
+	}
+	all := make([]ranked, 0, rdr.EntityCount())
+	var i int32
+	rdr.IterateEntities(func(e *fb.Entity) bool {
+		pr := 0.0
+		if ov, ok := overlay[i]; ok && ov.PageRank != nil {
+			pr = *ov.PageRank
+		}
+		all = append(all, ranked{id: string(e.Id()), pr: pr})
+		i++
+		return true
+	})
+	lr.readerMu.Unlock()
+
+	sort.Slice(all, func(a, b int) bool {
+		return all[a].pr > all[b].pr
+	})
+	if k > len(all) {
+		k = len(all)
+	}
+	out := make([]string, k)
+	for j := 0; j < k; j++ {
+		out[j] = all[j].id
+	}
+	return out
+}
+
 // repoIndexedRef returns the git ref that was active when lr was last indexed.
 // Falls back to "_unknown" for graphs produced before PH1a (#2088).
 func repoIndexedRef(lr *LoadedRepo) string {
@@ -1825,20 +1886,11 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			continue
 		}
 		ents := lr.Doc.Entities
-		// ADR-0027 overlay SIDE-TABLE (built ONLY when GRAFEL_SERVE_FROM_MMAP is
-		// ON): a fresh entity-INDEX-keyed table of the 5 overlay fields alongside
-		// the (transitional) in-place Doc stamp, so the Reader-materialized read
-		// path (LabelIndex.at/getByID) can merge them without depending on lr.Doc
-		// for VALUES. Keyed by vector index i (== the LabelIndex/Reader position),
-		// resolved here because this loop already visits every entity by index and
-		// matches it to the overlay by ID. On the flag-off default path the table
-		// is left nil — the read path reads the overlaid Doc — so no resident cost
-		// is paid pre-flip.
-		buildSideTable := serveFromMMap()
-		var table map[int32]entityOverlay
-		if buildSideTable {
-			table = make(map[int32]entityOverlay)
-		}
+		// In-place Doc stamp: the flag-OFF read path (LabelIndex.at / forEachEntity
+		// / buildTopKPageRank) reads these values directly, and the flag-ON path
+		// still reads them PRE-FLIP while lr.Doc.Entities is populated. Kept
+		// byte-identical to the original; a no-op once PR7 empties lr.Doc.Entities
+		// (the side-table below then carries the values on the flag-ON path).
 		for i := range ents {
 			eo, has := ov.Results[ents[i].ID]
 			if !has {
@@ -1852,36 +1904,41 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 			ents[i].Centrality = &cen
 			ents[i].IsGodNode = eo.IsGodNode
 			ents[i].IsArticulationPt = eo.IsArticulationPoint
-			if buildSideTable {
-				// Independent heap copies (distinct pointers from the Doc stamp
-				// above) so the side-table remains valid after the PR7 Doc drop.
-				tcid := eo.CommunityID
-				tpr := eo.PageRank
-				tcen := eo.Centrality
-				table[int32(i)] = entityOverlay{
-					CommunityID:      &tcid,
-					PageRank:         &tpr,
-					Centrality:       &tcen,
-					IsGodNode:        eo.IsGodNode,
-					IsArticulationPt: eo.IsArticulationPoint,
-				}
+		}
+		// ADR-0027 overlay SIDE-TABLE (built ONLY when GRAFEL_SERVE_FROM_MMAP is
+		// ON): a fresh entity-INDEX-keyed table of the 5 overlay fields so the
+		// Reader-materialized read path (LabelIndex.at/getByID/forEachEntity) can
+		// merge them WITHOUT depending on lr.Doc for VALUES. Sourced by iterating
+		// the resident mmap Reader (not lr.Doc) so it is populated even after PR7
+		// empties lr.Doc.Entities — flip-readiness is the whole point of this PR.
+		// Keyed by vector index i (== the LabelIndex/Reader position, the same
+		// order BuildLabelIndexFromReader assigns). Falls back to the Doc ONLY when
+		// no Reader is resident (JSON-only / no graph.fb), where the read path also
+		// reads the Doc, so the side-table is never consulted there anyway. On the
+		// flag-off default path the table is left nil — no resident cost pre-flip.
+		//
+		// ADR-0027 SIGBUS-safety (memory epic #5850, Path P): readerMu guards BOTH
+		// the mmap iteration (buildOverlayTableFromReader dereferences the mapping)
+		// AND the publish onto the current LabelIndex generation, mirroring
+		// forEachEntity/at() — which read lr.LabelIndex.overlay under readerMu, so
+		// this re-stamp must not race them. handle.readRetired is checked so a
+		// retired mapping falls back to the Doc instead of dereferencing freed
+		// memory. Publish happens BEFORE resetIndexes below; resetIndexes does NOT
+		// touch LabelIndex, so the table persists for this generation's life and is
+		// reassigned on the next re-stamp.
+		if serveFromMMap() {
+			lr.readerMu.Lock()
+			var table map[int32]entityOverlay
+			if rdr := lr.Reader; rdr != nil && !(lr.handle != nil && lr.handle.readRetired) {
+				table = buildOverlayTableFromReader(rdr, ov)
+			} else {
+				table = buildOverlayTableFromDoc(lr.Doc, ov)
 			}
+			if lr.LabelIndex != nil {
+				lr.LabelIndex.overlay = table
+			}
+			lr.readerMu.Unlock()
 		}
-		// Publish the side-table onto the current LabelIndex generation BEFORE
-		// re-arming the lazy indexes below, so the next getByID build merges it.
-		// resetIndexes does NOT touch LabelIndex, so the table persists for the
-		// life of this generation and is reassigned on the next re-stamp. Only on
-		// the flag-on path; flag-off leaves lr.LabelIndex.overlay nil.
-		// ADR-0027 SIGBUS-safety (memory epic #5850, Path P PR1 / view_iter.go):
-		// same readerMu-guarded field-assignment discipline as the LabelIndex
-		// publish above — forEachEntity's flag-on scan reads lr.LabelIndex.
-		// overlay under readerMu across the whole scan, so this re-stamp must
-		// not race it.
-		lr.readerMu.Lock()
-		if buildSideTable && lr.LabelIndex != nil {
-			lr.LabelIndex.overlay = table
-		}
-		lr.readerMu.Unlock()
 		// Re-arm lazy derived indexes (TopKPageRank etc.) so they rebuild
 		// against the freshly-stamped group values rather than stale per-repo
 		// ones (mirrors the resetIndexes() call after a reparse).
@@ -1891,6 +1948,64 @@ func applyGroupAlgoOverlay(grp *LoadedGroup) {
 
 	grp.algoMt = fi.ModTime()
 	grp.algoApplied = true
+}
+
+// newEntityOverlay heap-copies a groupalgo.EntityOverlay into an entityOverlay
+// side-table row. The three pointer fields are INDEPENDENT copies (distinct from
+// the in-place Doc stamp's pointers) so the side-table remains a valid value
+// source after PR7 drops lr.Doc.Entities.
+func newEntityOverlay(eo groupalgo.EntityOverlay) entityOverlay {
+	cid := eo.CommunityID
+	pr := eo.PageRank
+	cen := eo.Centrality
+	return entityOverlay{
+		CommunityID:      &cid,
+		PageRank:         &pr,
+		Centrality:       &cen,
+		IsGodNode:        eo.IsGodNode,
+		IsArticulationPt: eo.IsArticulationPoint,
+	}
+}
+
+// buildOverlayTableFromReader builds the entity-INDEX-keyed overlay side-table
+// by iterating the resident mmap Reader (NOT lr.Doc), matching each entity to
+// the overlay by ID. The int32 key is the vector index i in Reader iteration
+// order — identical to the order BuildLabelIndexFromReader assigns and the order
+// at()/materializeFromReader/forEachEntity look the table up by. Only entities
+// WITH an overlay entry are inserted; a miss leaves the fb sentinel on the read
+// path. Callers MUST hold the owning LoadedRepo's readerMu (the mmap is
+// dereferenced here via IterateEntities).
+func buildOverlayTableFromReader(r *fbreader.Reader, ov *groupalgo.Overlay) map[int32]entityOverlay {
+	table := make(map[int32]entityOverlay)
+	if r == nil || ov == nil {
+		return table
+	}
+	var i int32
+	r.IterateEntities(func(e *fb.Entity) bool {
+		if eo, has := ov.Results[string(e.Id())]; has {
+			table[i] = newEntityOverlay(eo)
+		}
+		i++
+		return true
+	})
+	return table
+}
+
+// buildOverlayTableFromDoc is the Doc-sourced twin used ONLY when no mmap Reader
+// is resident (JSON-only / no graph.fb) on the flag-on path. Keyed by the same
+// vector index i as the Reader path. The read path reads the Doc directly when
+// the Reader is absent, so this table is a belt-and-braces parity fallback.
+func buildOverlayTableFromDoc(doc *graph.Document, ov *groupalgo.Overlay) map[int32]entityOverlay {
+	table := make(map[int32]entityOverlay)
+	if doc == nil || ov == nil {
+		return table
+	}
+	for i := range doc.Entities {
+		if eo, has := ov.Results[doc.Entities[i].ID]; has {
+			table[int32(i)] = newEntityOverlay(eo)
+		}
+	}
+	return table
 }
 
 // defaultLinksFile is the conventional path for cross-repo links.

--- a/internal/mcp/topk_pagerank_overlay_test.go
+++ b/internal/mcp/topk_pagerank_overlay_test.go
@@ -30,11 +30,13 @@ package mcp
 
 import (
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 )
 
 // overlayAwareTopKDoc returns a Document whose entities all carry a nil
@@ -181,4 +183,85 @@ func TestGetTopKPageRank_OverlayOrder_ReaderSourcedWouldBeWrong(t *testing.T) {
 		t.Fatalf("Reader-sourced top-1 unexpectedly matched the overlay winner (id::charlie); " +
 			"this fixture is supposed to prove the Reader CANNOT see the overlay (sentinel-only fb)")
 	}
+}
+
+// TestGetTopKPageRank_FlagOnOffParity_SideTableNotSentinel is the load-bearing
+// PR5 parity + sentinel-trap guard. It runs the SAME overlaid fixture under
+// GRAFEL_SERVE_FROM_MMAP off and on and asserts getTopKPageRank returns the
+// IDENTICAL top-K list + order.
+//
+// The overlay assigns PageRank in an order that DIFFERS from graph.fb vector
+// order (Charlie, the LAST entity, gets the highest PageRank), so:
+//   - Doc-sourced (flag-off) and side-table-sourced (flag-on) both yield the
+//     overlay order (Charlie, Alpha, Bravo) and MUST match.
+//   - The sentinel trap: if the flag-on build read the Reader's Pagerank()
+//     scalar (permanent 0) instead of the side-table, every entity ties at 0
+//     and top-K collapses to vector order (Alpha, Bravo, Charlie) — DIFFERENT
+//     from the flag-off order, so this test FAILS. (Verified by mutation:
+//     swapping overlay[i].PageRank for e.Pagerank() in
+//     buildTopKPageRankFromSideTable makes the flag-on order (Alpha,Bravo,
+//     Charlie) diverge from flag-off (Charlie,Alpha,Bravo).)
+func TestGetTopKPageRank_FlagOnOffParity_SideTableNotSentinel(t *testing.T) {
+	run := func(t *testing.T, mmap bool) []string {
+		forceServeFromMMap(t, mmap)
+		st, overlayPath, cur, ids := setupSideTableParity(t)
+		// ids = {svc:Alpha, svc:Bravo, svc:Charlie} in graph.fb vector order.
+		// Assign PageRank so the ranked order (Charlie > Alpha > Bravo) is the
+		// REVERSE-ish of vector order, so a sentinel-collapse is detectable.
+		ov := &groupalgo.Overlay{
+			Group:        "acme",
+			SourceMtimes: cur,
+			Results: map[string]groupalgo.EntityOverlay{
+				ids[2]: {CommunityID: 1, PageRank: 0.9}, // Charlie (last in vector)
+				ids[0]: {CommunityID: 2, PageRank: 0.5}, // Alpha  (first in vector)
+				ids[1]: {CommunityID: 3, PageRank: 0.1}, // Bravo
+			},
+			Communities: []graph.CommunityResult{
+				{ID: 1, Size: 1}, {ID: 2, Size: 1}, {ID: 3, Size: 1},
+			},
+		}
+		if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+			t.Fatalf("write overlay: %v", err)
+		}
+		if _, err := st.Reload(); err != nil {
+			t.Fatalf("reload: %v", err)
+		}
+		lr := st.Group("acme").Repos["svc"]
+		if lr == nil {
+			t.Fatalf("svc repo not loaded")
+		}
+		if mmap && lr.Reader == nil {
+			t.Fatalf("flag-on run requires a resident Reader")
+		}
+		return lr.getTopKPageRank()
+	}
+
+	var off, on []string
+	t.Run("flag-off", func(t *testing.T) { off = run(t, false) })
+	t.Run("flag-on", func(t *testing.T) { on = run(t, true) })
+
+	wantPrefix := []string{"svc:Charlie", "svc:Alpha", "svc:Bravo"}
+	for i, id := range wantPrefix {
+		if i >= len(off) || off[i] != id {
+			t.Fatalf("flag-OFF top-K[%d] = %v, want %q (overlay order)\nfull=%v", i, safeIdx(off, i), id, off)
+		}
+	}
+	// The parity assertion: flag-on order must equal flag-off order over the
+	// distinct-PageRank prefix. A sentinel-sourced flag-on build fails HERE.
+	for i := range wantPrefix {
+		if i >= len(on) || on[i] != off[i] {
+			t.Fatalf("flag-ON/OFF top-K divergence at [%d]: on=%v off=%v\non=%v\noff=%v",
+				i, safeIdx(on, i), off[i], on, off)
+		}
+	}
+	if !reflect.DeepEqual(on[:len(wantPrefix)], off[:len(wantPrefix)]) {
+		t.Fatalf("flag-on/off top-K prefix mismatch:\n on=%v\noff=%v", on, off)
+	}
+}
+
+func safeIdx(s []string, i int) string {
+	if i < 0 || i >= len(s) {
+		return "<none>"
+	}
+	return s[i]
 }


### PR DESCRIPTION
## What
PR5 of the mmap-cutover flip (Path P, #5870). Makes the two remaining group-algo-overlay consumers flip-ready — they sourced the 5 overlay fields (PageRank/CommunityID/Centrality/IsGodNode/IsArticulationPt) from `lr.Doc`, which PR7 empties.

- **`applyGroupAlgoOverlay`**: flag-OFF unchanged (stamp `Doc.Entities` in place). Flag-ON builds the `entityOverlay` side-table from the mmap Reader (`buildOverlayTableFromReader`, under `readerMu`) instead of the Doc, keyed by the same vector index the read paths use.
- **`getTopKPageRank`**: flag-OFF unchanged. Flag-ON reads PageRank from the side-table (`buildTopKPageRankFromSideTable`), **never** the Reader's sentinel `Pagerank()` scalar (the PR1 #5866 trap).

All new Reader/side-table reads gated behind `serveFromMMap()`; Doc fallback on nil/retired Reader.

## Tests (mutation-proven)
- `TestOverlaySideTable_BuiltFromReaderNotDoc` — flag-on, Doc emptied → side-table still fully populated from Reader. (Doc-source mutation → 0 entries → FAIL.)
- `TestGetTopKPageRank_FlagOnOffParity_SideTableNotSentinel` — overlay PageRank order deliberately differs from graph.fb vector order; top-K identical flag-on/off. (Sentinel-read mutation → wrong order → FAIL.)

Independently opus-reviewed (APPROVE): keying consistency proven (write + all reads share the `IterateEntities` index space), flag-off byte-identical, `readerMu` strictly-innermost, both traps mutation-failed. `go test ./internal/mcp/...` 1188 pass.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)