### PR TITLE
feat(mcp): Reader-source getByID/at index bounds (mmap flip Path P, PR6)

### DIFF
--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -229,8 +229,14 @@ func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIn
 // production until a borrow is held across the read (else a concurrent reload's
 // munmap is a read-after-unmap). That wiring + flipping the flag is a later step.
 // The nil-Reader case (JSON-only / no graph.fb) always uses the Doc copy.
+//
+// Bound source (memory epic #5850 Path P PR6): the OFF/Doc-fallback paths
+// bound idx against len(l.doc.Entities); the ON/resident-reader path bounds
+// idx against l.reader.EntityCount() instead, so a PR7 Doc-emptying (which
+// drops doc.Entities to length 0 while the reader still holds every row)
+// cannot turn every valid index into a false "not found".
 func (l *LabelIndex) at(idx int32) *graph.Entity {
-	if l == nil || l.doc == nil || idx < 0 || int(idx) >= len(l.doc.Entities) {
+	if l == nil || l.doc == nil || idx < 0 {
 		return nil
 	}
 	if l.reader != nil && serveFromMMap() {
@@ -245,14 +251,33 @@ func (l *LabelIndex) at(idx int32) *graph.Entity {
 			l.readerMu.Lock()
 			if l.handle != nil && l.handle.readRetired {
 				l.readerMu.Unlock()
-				e := l.doc.Entities[idx] // Doc fallback — mapping is gone
+				// Doc fallback — mapping is gone, so the Doc row count is the only
+				// valid bound left (memory epic #5850 Path P PR6).
+				if int(idx) >= len(l.doc.Entities) {
+					return nil
+				}
+				e := l.doc.Entities[idx]
 				return &e
+			}
+			// PR6: the bound is the RESIDENT READER's row count, not
+			// len(l.doc.Entities) — a PR7 Doc-emptying leaves doc.Entities at 0
+			// while the reader still holds every row, so a Doc-sourced bound would
+			// wrongly report every index out of range.
+			if int(idx) >= l.reader.EntityCount() {
+				l.readerMu.Unlock()
+				return nil
 			}
 			e := l.materializeFromReader(idx)
 			l.readerMu.Unlock()
 			return e
 		}
+		if int(idx) >= l.reader.EntityCount() {
+			return nil
+		}
 		return l.materializeFromReader(idx)
+	}
+	if int(idx) >= len(l.doc.Entities) {
+		return nil
 	}
 	e := l.doc.Entities[idx] // heap copy — a fresh pointer, not an alias into Doc
 	return &e

--- a/internal/mcp/reader_index_bounds_pr6_test.go
+++ b/internal/mcp/reader_index_bounds_pr6_test.go
@@ -1,0 +1,160 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Memory epic #5850, Path P PR6: getByID / LabelIndex.at MUST bound their
+// vector-index lookups against the RESIDENT READER's row count on the
+// GRAFEL_SERVE_FROM_MMAP-ON path, not len(Doc.Entities) — a PR7 Doc-emptying
+// drops doc.Entities to length 0 while the reader still holds every row, and
+// a Doc-sourced bound would wrongly report every valid index out of range.
+//
+// These tests simulate the post-PR7 shape by handing the index a Document
+// whose Entities slice has been emptied, while the reader over the SAME
+// underlying graph.fb still has every row resident — exactly the split PR7
+// introduces.
+
+// emptiedParityDoc returns a shallow copy of doc with Entities zeroed out —
+// simulating the PR7 Doc-emptying while leaving everything else (used only
+// for logging/asserts, not read by the reader path) intact.
+func emptiedParityDoc(doc *graph.Document) *graph.Document {
+	cp := *doc
+	cp.Entities = nil
+	return &cp
+}
+
+func withServeFromMMap(t *testing.T, v bool) {
+	t.Helper()
+	prev := serveFromMMapEnabled
+	serveFromMMapEnabled = v
+	t.Cleanup(func() { serveFromMMapEnabled = prev })
+}
+
+// TestLabelIndexAt_ReaderSourcedBound_PR6 is the mutation-catching test: with
+// GRAFEL_SERVE_FROM_MMAP ON, a resident reader, and an EMPTIED Doc, at() must
+// still resolve every valid reader-vector index (and correctly report nil for
+// an out-of-range one) using the reader's own EntityCount as the bound — not
+// len(doc.Entities), which is 0 here. A regression back to
+// `len(l.doc.Entities)` on the ON path makes this fail: every idx >= 0 would
+// be rejected as out-of-range and this test would see nil for every valid id.
+func TestLabelIndexAt_ReaderSourcedBound_PR6(t *testing.T) {
+	withServeFromMMap(t, true)
+
+	doc, r := loadParityIndexFixture(t)
+	if len(doc.Entities) == 0 {
+		t.Fatalf("fixture setup: doc.Entities is unexpectedly empty")
+	}
+	full := BuildLabelIndexFromReader(r, doc)
+	full.doc = emptiedParityDoc(doc) // simulate PR7's Doc-emptying
+
+	if got := int(r.EntityCount()); got != len(doc.Entities) {
+		t.Fatalf("fixture sanity: reader EntityCount=%d != doc entity count=%d", got, len(doc.Entities))
+	}
+
+	// Every valid vector index must still resolve to the correct entity ID,
+	// sourced from the reader (Doc is empty, so a Doc-sourced value would be a
+	// zero-value/garbage entity, not a nil pointer — the failure mode this test
+	// pins is a wrong BOUND, not a wrong value source, which PR2 already covers).
+	for i, want := range doc.Entities {
+		got := full.at(int32(i))
+		if got == nil {
+			t.Fatalf("at(%d): got nil, want entity id=%q (reader-sourced bound should admit this index)", i, want.ID)
+		}
+		if got.ID != want.ID {
+			t.Errorf("at(%d): got id=%q, want id=%q", i, got.ID, want.ID)
+		}
+	}
+
+	// Out-of-range must still correctly report not-found via the reader bound.
+	oob := int32(len(doc.Entities))
+	if got := full.at(oob); got != nil {
+		t.Errorf("at(%d) out-of-range: got %+v, want nil", oob, got)
+	}
+	if got := full.at(-1); got != nil {
+		t.Errorf("at(-1): got %+v, want nil", got)
+	}
+}
+
+// TestLabelIndexAt_FlagOff_DocSourcedBound_Unchanged_PR6 pins that the
+// flag-OFF path is byte-identical to pre-PR6: it still bounds against
+// len(doc.Entities) and therefore correctly treats an emptied Doc as having
+// zero valid indices (there is no reader fallback on the OFF path).
+func TestLabelIndexAt_FlagOff_DocSourcedBound_Unchanged_PR6(t *testing.T) {
+	withServeFromMMap(t, false)
+
+	doc, r := loadParityIndexFixture(t)
+	full := BuildLabelIndexFromReader(r, doc)
+
+	// With the real (non-emptied) Doc, every valid index still resolves.
+	for i, want := range doc.Entities {
+		got := full.at(int32(i))
+		if got == nil || got.ID != want.ID {
+			t.Fatalf("at(%d) flag-off: got %+v, want id=%q", i, got, want.ID)
+		}
+	}
+
+	// Emptying the Doc on the flag-OFF path must now correctly find nothing —
+	// there is no reader fallback here by design (OFF never dereferences mmap).
+	full.doc = emptiedParityDoc(doc)
+	if got := full.at(0); got != nil {
+		t.Errorf("at(0) flag-off with emptied Doc: got %+v, want nil (no reader fallback on OFF)", got)
+	}
+}
+
+// TestGetByID_ReaderSourcedBound_PR6 is the getByID counterpart: with the
+// flag ON, a resident LabelIndex+reader, and an emptied Doc, getByID must
+// still return every entity — the loop bound must come from the reader's
+// EntityCount, not len(lr.Doc.Entities) (which is 0 here and would silently
+// collapse the map to empty).
+func TestGetByID_ReaderSourcedBound_PR6(t *testing.T) {
+	withServeFromMMap(t, true)
+
+	doc, r := loadParityIndexFixture(t)
+	idx := BuildLabelIndexFromReader(r, doc)
+
+	lr := &LoadedRepo{
+		Repo:       "repo",
+		Doc:        emptiedParityDoc(doc), // simulate PR7's Doc-emptying
+		Reader:     r,
+		LabelIndex: idx,
+	}
+	idx.doc = lr.Doc // at() reads l.doc; keep it consistent with lr.Doc
+
+	got := lr.getByID()
+	if len(got) != len(doc.Entities) {
+		t.Fatalf("getByID with emptied Doc + resident reader: got %d entities, want %d (reader-sourced bound should visit every row)", len(got), len(doc.Entities))
+	}
+	for _, want := range doc.Entities {
+		e, ok := got[want.ID]
+		if !ok {
+			t.Errorf("getByID: missing entity id=%q", want.ID)
+			continue
+		}
+		if e.ID != want.ID {
+			t.Errorf("getByID[%q]: got id=%q", want.ID, e.ID)
+		}
+	}
+}
+
+// TestGetByID_FlagOff_Unchanged_PR6 pins flag-OFF getByID is unaffected by
+// PR6: still sources the count and every value straight off the live Doc.
+func TestGetByID_FlagOff_Unchanged_PR6(t *testing.T) {
+	withServeFromMMap(t, false)
+
+	doc, _ := loadParityIndexFixture(t)
+	lr := &LoadedRepo{Repo: "repo", Doc: doc}
+
+	got := lr.getByID()
+	if len(got) != len(doc.Entities) {
+		t.Fatalf("getByID flag-off: got %d entities, want %d", len(got), len(doc.Entities))
+	}
+	for _, want := range doc.Entities {
+		e, ok := got[want.ID]
+		if !ok || e.ID != want.ID {
+			t.Errorf("getByID[%q] flag-off: got %+v", want.ID, e)
+		}
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -597,23 +597,36 @@ func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 			lr.byID = map[string]*graph.Entity{}
 			return
 		}
-		m := make(map[string]*graph.Entity, len(lr.Doc.Entities))
 		// ADR-0027: only when GRAFEL_SERVE_FROM_MMAP is ON does getByID source each
 		// row from the Reader + overlay side-table via LabelIndex.at (byte-equal to
 		// the overlaid Doc row), removing the Doc VALUE dependence. On the flag-off
 		// default path this stays the PR2 live-Doc heap copy — GC-safe, with NO
 		// handler-path mmap read. mmapSourced also short-circuits to the Doc copy
 		// whenever at() cannot serve an index (nil LabelIndex/Reader, JSON load).
-		mmapSourced := serveFromMMap() && lr.LabelIndex != nil
-		for i := range lr.Doc.Entities {
+		mmapSourced := serveFromMMap() && lr.LabelIndex != nil && lr.LabelIndex.reader != nil
+		// PR6 (memory epic #5850 Path P): the loop BOUND is Reader-sourced on the
+		// mmap path — l.reader.EntityCount(), not len(lr.Doc.Entities) — so a PR7
+		// Doc-emptying (doc.Entities dropping to length 0 while the reader still
+		// holds every row) does not silently collapse getByID to an empty map.
+		// EntityCount() is a cached int set once at Reader construction, so it is
+		// safe to read here without readerMu (no mmap dereference). The flag-off
+		// path is unchanged: count stays len(lr.Doc.Entities).
+		count := len(lr.Doc.Entities)
+		if mmapSourced {
+			count = lr.LabelIndex.reader.EntityCount()
+		}
+		m := make(map[string]*graph.Entity, count)
+		for i := 0; i < count; i++ {
 			if mmapSourced {
 				if ent := lr.LabelIndex.at(int32(i)); ent != nil {
 					m[ent.ID] = ent
 					continue
 				}
 			}
-			ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
-			m[ent.ID] = &ent
+			if i < len(lr.Doc.Entities) {
+				ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
+				m[ent.ID] = &ent
+			}
 		}
 		lr.byID = m
 	})


### PR DESCRIPTION
## What
PR6 of the mmap-cutover flip (Path P, #5870). Two index-bound sites used `len(lr.Doc.Entities)`, which PR7 zeroes — they would collapse the index flag-on. Now Reader-sourced:
- `LabelIndex.at()` (`index.go`) — flag-ON resident-reader bound is `l.reader.EntityCount()`.
- `LoadedRepo.getByID()` (`state.go`) — flag-ON loop bound + capacity from `EntityCount()`.

Flag-OFF / nil-reader / retired-mapping paths keep `len(Doc.Entities)` (byte-identical). `EntityCount()`/`RelationshipCount()` are scalars cached at Reader construction (`reader.go:94`, `r.nEnts`) — no mmap deref, safe lock-free. `getByID`'s flag-on materialization runs once per reload (memoized under `byIDOnce`/`idxMu`), not per call.

## Tests
`reader_index_bounds_pr6_test.go` simulates the post-flip shape (resident reader + emptied `Doc.Entities`): valid indices/IDs resolve via the Reader bound, out-of-range nil. Mutation-proven (revert either bound to `len(Doc.Entities)` → the ON-path test fails).

Independently opus-reviewed (APPROVE): `EntityCount` cached-scalar confirmed, bounds cleanly separated (no Doc-bound/Reader-index cross-wiring), memoization confirmed, flag-off byte-identical, both mutations fail. `go test ./internal/mcp/...` 1192 pass.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)