### PR TITLE
feat(mcp): BuildBM25FromReader + drop retained entity pointers (mmap flip Path P / #5871 L4)

### DIFF
--- a/internal/mcp/bm25_postings_3923_test.go
+++ b/internal/mcp/bm25_postings_3923_test.go
@@ -71,7 +71,9 @@ func (b *BM25Index) bruteSearch(query string, limit int) []Hit {
 	}
 	out := make([]Hit, len(res))
 	for i, r := range res {
-		out[i] = Hit{Entity: b.entities[r.di], Score: r.score}
+		// #5871 L4: entities holds vector indices, resolved to *graph.Entity
+		// via b.resolve (set by BuildBM25 to a live-Document heap-copy closure).
+		out[i] = Hit{Entity: b.resolve(b.entities[r.di]), Score: r.score}
 	}
 	return out
 }
@@ -103,7 +105,10 @@ func TestBM25SearchMatchesBruteForce(t *testing.T) {
 				t.Fatalf("q=%q lim=%d length mismatch: got=%d want=%d", q, lim, len(got), len(want))
 			}
 			for i := range got {
-				if got[i].Entity != want[i].Entity {
+				// #5871 L4: entities are resolved to FRESH heap copies on demand
+				// (b.resolve), so identity is by ID, not pointer — every resolve
+				// call returns a distinct *graph.Entity for the same logical row.
+				if got[i].Entity.ID != want[i].Entity.ID {
 					t.Fatalf("q=%q lim=%d pos=%d entity mismatch: got=%s want=%s",
 						q, lim, i, got[i].Entity.ID, want[i].Entity.ID)
 				}

--- a/internal/mcp/bm25_reader_build_5871_pr3b_test.go
+++ b/internal/mcp/bm25_reader_build_5871_pr3b_test.go
@@ -1,0 +1,289 @@
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// Memory epic #5850, Path P PR3b / issue #5871 L4: BuildBM25FromReader builds
+// the (already L1-compacted) BM25 index by iterating the resident mmap Reader
+// instead of lr.Doc.Entities, and the index retains NO *graph.Entity — only the
+// int32 vector index per doc, resolved to an entity on demand at Search-return
+// time. This is the FLIP PREREQUISITE: post-flip lr.Doc is emptied, so
+// BuildBM25(lr.Doc) would build an EMPTY index; the Reader still holds every row.
+//
+// These tests build BOTH the Document-sourced and Reader-sourced indexes over
+// one real graph.fb and prove they are byte-equal (postings / docLen / tokens)
+// and produce the same ranked search results.
+
+// loadBM25RichFixture writes a BM25-rich synthetic Document (names, source
+// files, docstrings, discriminators) to a graph.fb, loads it back, and opens a
+// Reader over the SAME file — so the Document rows and the Reader rows are
+// byte-identical and in the same vector order.
+func loadBM25RichFixture(t *testing.T, nEnt int) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, buildSyntheticDoc(nEnt)); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+// TestBM25ReaderBuildParity_PR3b is the load-bearing parity test: the index
+// built from the Reader is byte-equal to the index built from the Document
+// (same postings / docLen / avgLen / totalDocs), and yields the SAME ranked
+// search results (entity-ID order + scores) on the same fixture.
+func TestBM25ReaderBuildParity_PR3b(t *testing.T) {
+	doc, r := loadBM25RichFixture(t, 1500)
+
+	idxDoc := BuildBM25(doc)         // flag-OFF / baseline path
+	idxRdr := BuildBM25FromReader(r) // flag-ON build path
+
+	// --- Structural byte-parity: postings / docLen / avgLen / totalDocs ---
+	if idxRdr.totalDocs != idxDoc.totalDocs {
+		t.Fatalf("totalDocs: reader=%d doc=%d", idxRdr.totalDocs, idxDoc.totalDocs)
+	}
+	if idxRdr.avgLen != idxDoc.avgLen {
+		t.Fatalf("avgLen: reader=%v doc=%v", idxRdr.avgLen, idxDoc.avgLen)
+	}
+	if !reflect.DeepEqual(idxRdr.docLen, idxDoc.docLen) {
+		t.Fatalf("docLen slices differ between reader-build and doc-build")
+	}
+	if !reflect.DeepEqual(idxRdr.entities, idxDoc.entities) {
+		t.Fatalf("entities (vector-index) slices differ between reader-build and doc-build")
+	}
+	// postings maps: same terms, each with the same {doc, tf} list in the same
+	// order (both are appended in ascending doc order). This is the tokens +
+	// weighted-tf byte-parity assertion.
+	if len(idxRdr.postings) != len(idxDoc.postings) {
+		t.Fatalf("postings term count: reader=%d doc=%d", len(idxRdr.postings), len(idxDoc.postings))
+	}
+	if !reflect.DeepEqual(idxRdr.postings, idxDoc.postings) {
+		// Narrow down the first divergent term for a useful failure message.
+		for term, dlist := range idxDoc.postings {
+			rlist, ok := idxRdr.postings[term]
+			if !ok {
+				t.Fatalf("term %q present in doc-build, absent in reader-build", term)
+			}
+			if !reflect.DeepEqual(rlist, dlist) {
+				t.Fatalf("term %q postings differ: reader=%v doc=%v", term, rlist, dlist)
+			}
+		}
+		t.Fatalf("postings maps differ (reader-build has terms doc-build lacks)")
+	}
+
+	// --- Search parity: same ranked entity IDs + scores ---
+	// Wire the reader-built index's resolver to a Reader-sourced LabelIndex.at
+	// (the production flag-ON resolution path); the doc-built index already has
+	// its live-Document resolver from BuildBM25.
+	li := BuildLabelIndexFromReader(r, doc)
+	idxRdr.resolve = func(vi int32) *graph.Entity { return li.at(vi) }
+
+	queries := []string{
+		"handleOrderRequest customer processor payload",
+		"order kafka fulfilment pipeline",
+		"premium checklistType 2",
+		"validating persisting entity",
+		"handleOrderRequestForCustomer42Processor",
+		"1234",
+		"nonexistent zzzz",
+		"order order order",
+		"orders service handler go",
+		"downstream event asynchronously",
+	}
+	for _, q := range queries {
+		for _, lim := range []int{0, 5, 10, 50} {
+			gotR := idxRdr.Search(q, lim)
+			gotD := idxDoc.Search(q, lim)
+			if len(gotR) != len(gotD) {
+				t.Fatalf("q=%q lim=%d length: reader=%d doc=%d", q, lim, len(gotR), len(gotD))
+			}
+			for i := range gotR {
+				if gotR[i].Entity.ID != gotD[i].Entity.ID {
+					t.Fatalf("q=%q lim=%d pos=%d ranked-order mismatch: reader=%s doc=%s",
+						q, lim, i, gotR[i].Entity.ID, gotD[i].Entity.ID)
+				}
+				if gotR[i].Score != gotD[i].Score {
+					t.Fatalf("q=%q lim=%d pos=%d score mismatch: reader=%v doc=%v",
+						q, lim, i, gotR[i].Score, gotD[i].Score)
+				}
+			}
+		}
+	}
+}
+
+// TestBM25FromReaderNoEntityRetention_PR3b is the no-retention assertion: the
+// resident BM25Index holds only []int32 vector indices — NOT []*graph.Entity.
+// Retaining 427k live entity pointers here would re-pin ~the whole Document
+// (~608 MB on the corpus) and defeat the ADR-0027 mmap flip; the materialized
+// entities in BuildBM25FromReader must be transient (tokenize, then GC'd).
+func TestBM25FromReaderNoEntityRetention_PR3b(t *testing.T) {
+	_, r := loadBM25RichFixture(t, 400)
+	idx := BuildBM25FromReader(r)
+
+	// The entities field is []int32 (vector indices), not []*graph.Entity.
+	if _, ok := interface{}(idx.entities).([]int32); !ok {
+		t.Fatalf("entities is %T, want []int32", idx.entities)
+	}
+
+	// Structural sweep: no field of the resident index may be a []*graph.Entity
+	// (or any slice/array/map of *graph.Entity) — the assertion that the index
+	// retains no materialized entities.
+	entityPtrType := reflect.TypeOf((*graph.Entity)(nil))
+	v := reflect.ValueOf(idx).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		ft := v.Type().Field(i).Type
+		switch ft.Kind() {
+		case reflect.Slice, reflect.Array:
+			if ft.Elem() == entityPtrType {
+				t.Fatalf("field %q is a slice of *graph.Entity — the index must not retain entities", v.Type().Field(i).Name)
+			}
+		case reflect.Map:
+			if ft.Elem() == entityPtrType {
+				t.Fatalf("field %q is a map to *graph.Entity — the index must not retain entities", v.Type().Field(i).Name)
+			}
+		}
+	}
+
+	// Sanity: the index still resolves entities on demand once a resolver is set
+	// (it is not simply empty). entities length must equal the reader row count.
+	if len(idx.entities) != r.EntityCount() {
+		t.Fatalf("entities len=%d, want reader EntityCount=%d", len(idx.entities), r.EntityCount())
+	}
+}
+
+// newReaderBackedRepo builds a LoadedRepo wired for the flag-ON path: a resident
+// Reader, a Reader-sourced LabelIndex with readerMu wired (so at() takes the
+// SIGBUS-safety mutex and materializes on demand), and a live Doc. handle is
+// left nil (a fresh, never-retired generation), which the getBM25 flag-ON gate
+// admits (h == nil || !h.readRetired).
+func newReaderBackedRepo(t *testing.T, nEnt int) *LoadedRepo {
+	t.Helper()
+	doc, r := loadBM25RichFixture(t, nEnt)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc, Reader: r}
+	li := BuildLabelIndexFromReader(r, doc)
+	li.readerMu = &lr.readerMu
+	lr.LabelIndex = li
+	return lr
+}
+
+// TestBM25EvictionRebuild_BothFlags_PR3b proves getBM25's idle-eviction +
+// transparent rebuild works on BOTH paths: flag-OFF (rebuild from the Doc) and
+// flag-ON (rebuild from the Reader). Results must be byte-identical across the
+// warm build and the post-eviction rebuild, and the flag-ON rebuild must source
+// from the Reader (not silently collapse to the flag-OFF Doc path).
+func TestBM25EvictionRebuild_BothFlags_PR3b(t *testing.T) {
+	queries := []string{
+		"handleOrderRequest customer processor payload",
+		"order kafka fulfilment pipeline",
+		"premium checklistType 2",
+		"validating persisting entity",
+	}
+
+	run := func(t *testing.T, lr *LoadedRepo, flagOn bool) {
+		warm := map[string][]string{}
+		for _, q := range queries {
+			warm[q] = hitKeys(lr.getBM25().Search(q, 10))
+		}
+		// On the flag-ON path the built index must have a resolver and one
+		// vector-index slot per Reader row (proves it built FROM the Reader).
+		if flagOn {
+			if lr.BM25 == nil || lr.BM25.resolve == nil {
+				t.Fatal("flag-ON getBM25 produced no resolver")
+			}
+			if len(lr.BM25.entities) != lr.Reader.EntityCount() {
+				t.Fatalf("flag-ON index entities len=%d, want reader EntityCount=%d",
+					len(lr.BM25.entities), lr.Reader.EntityCount())
+			}
+		}
+		// Evict (force idle) and rebuild.
+		if !lr.evictBM25IfIdle(time.Minute, lr.bm25LastUse.Add(2*time.Minute)) {
+			t.Fatal("expected eviction")
+		}
+		if lr.BM25 != nil {
+			t.Fatal("evicted index field must be nil")
+		}
+		for _, q := range queries {
+			got := hitKeys(lr.getBM25().Search(q, 10))
+			want := warm[q]
+			if len(got) != len(want) {
+				t.Fatalf("q=%q result count changed after rebuild: got %d want %d", q, len(got), len(want))
+			}
+			for i := range got {
+				if got[i] != want[i] {
+					t.Fatalf("q=%q rank %d rebuilt result differs\n got=%s\nwant=%s", q, i, got[i], want[i])
+				}
+			}
+		}
+	}
+
+	t.Run("flag-off/doc", func(t *testing.T) {
+		withServeFromMMap(t, false)
+		doc, _ := loadBM25RichFixture(t, 1000)
+		lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+		run(t, lr, false)
+	})
+
+	t.Run("flag-on/reader", func(t *testing.T) {
+		withServeFromMMap(t, true)
+		lr := newReaderBackedRepo(t, 1000)
+		run(t, lr, true)
+	})
+}
+
+// TestBM25FlagOnReaderMatchesFlagOffDoc_PR3b proves the end-to-end getBM25
+// results are identical whether served from the Reader (flag-ON) or the Doc
+// (flag-OFF) — the search-parity property at the getter level, not just the
+// builder level.
+func TestBM25FlagOnReaderMatchesFlagOffDoc_PR3b(t *testing.T) {
+	queries := []string{
+		"handleOrderRequest customer processor payload",
+		"order kafka fulfilment pipeline",
+		"premium checklistType 2",
+		"orders service handler go",
+	}
+
+	// Flag-OFF, Doc-backed repo.
+	docWant := func() map[string][]string {
+		withServeFromMMap(t, false)
+		doc, _ := loadBM25RichFixture(t, 1200)
+		lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+		out := map[string][]string{}
+		for _, q := range queries {
+			out[q] = hitKeys(lr.getBM25().Search(q, 10))
+		}
+		return out
+	}()
+
+	// Flag-ON, Reader-backed repo.
+	withServeFromMMap(t, true)
+	lr := newReaderBackedRepo(t, 1200)
+	for _, q := range queries {
+		got := hitKeys(lr.getBM25().Search(q, 10))
+		want := docWant[q]
+		if len(got) != len(want) {
+			t.Fatalf("q=%q length: reader=%d doc=%d", q, len(got), len(want))
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Fatalf("q=%q rank %d: reader=%s doc=%s", q, i, got[i], want[i])
+			}
+		}
+	}
+}

--- a/internal/mcp/scoring.go
+++ b/internal/mcp/scoring.go
@@ -8,6 +8,7 @@ import (
 	"unicode"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -64,7 +65,28 @@ type posting struct {
 
 // BM25Index is a per-repo BM25 index over entities, with multi-source weights.
 type BM25Index struct {
-	entities  []*graph.Entity
+	// entities maps a doc index (postings/docLen position) to the entity's
+	// VECTOR INDEX — the int32 position of that entity in the graph.fb / Document
+	// vector order (memory epic #5850, Path P PR3b / issue #5871 L4). It is the
+	// identity permutation today (doc index i == vector index i, since every
+	// entity is indexed with no skips), but is stored explicitly so Search never
+	// assumes identity and so the index retains NO `*graph.Entity`. Retaining
+	// 427k live entity pointers here would re-pin ~the whole Document (~608 MB on
+	// the corpus) and defeat the ADR-0027 mmap flip; the vector index is 4 bytes
+	// and resolves to an entity on demand at Search-return time via resolve.
+	entities []int32
+	// resolve turns a doc's vector index into a freshly materialized
+	// *graph.Entity at Search-return time (never a retained pointer). It is set by
+	// the builder/getter, NOT stored per-doc, so it costs one closure regardless
+	// of corpus size:
+	//   - flag-OFF / nil / retired Reader: BuildBM25 wires a closure over the live
+	//     Document that heap-copies doc.Entities[i] (GC-safe, no mmap read).
+	//   - flag-ON (resident, non-retired Reader): getBM25 wires it to the repo's
+	//     readerMu-guarded LabelIndex.at, which materializes the base entity from
+	//     the mmap Reader + merges the group-algo overlay side-table on demand.
+	// A nil resolve yields no entities (defensive; every production/build path
+	// sets it).
+	resolve   func(vectorIdx int32) *graph.Entity
 	docLen    []float32 // per-doc |d| (sum of weighted frequencies), by doc index
 	avgLen    float64
 	totalDocs int
@@ -81,17 +103,23 @@ type BM25Index struct {
 	postings map[string][]posting
 }
 
-// BuildBM25 builds a BM25 index for a single graph document.
+// BuildBM25 builds a BM25 index for a single graph document. This is the
+// flag-OFF / nil-Reader / retired-Reader path (getBM25); it is also the parity
+// baseline the Reader-sourced BuildBM25FromReader must match byte-for-byte
+// (same postings / docLen / tokens). It stores only the per-doc vector index
+// (idx.entities[i] == i) and wires resolve to a live-Document heap-copy closure,
+// so it retains NO `*graph.Entity` of its own — the Document it closes over is
+// lr.Doc, already retained on the flag-OFF path (issue #5871 L4).
 func BuildBM25(doc *graph.Document) *BM25Index {
 	idx := &BM25Index{
-		entities: make([]*graph.Entity, len(doc.Entities)),
+		entities: make([]int32, len(doc.Entities)),
 		docLen:   make([]float32, len(doc.Entities)),
 		postings: make(map[string][]posting),
 	}
 	totalLen := 0.0
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
-		idx.entities[i] = e
+		idx.entities[i] = int32(i) // doc index == vector index (identity, no skips)
 		// buildDocTerms produces a TRANSIENT weighted bag (a per-doc map); we
 		// fold it into the postings index and let it be GC'd — only the postings
 		// list (with tf inline) and the scalar docLen survive as resident state.
@@ -110,6 +138,74 @@ func BuildBM25(doc *graph.Document) *BM25Index {
 	idx.totalDocs = len(idx.entities)
 	if idx.totalDocs > 0 {
 		idx.avgLen = totalLen / float64(idx.totalDocs)
+	}
+	// Resolve a vector index to a fresh heap copy of the live Document row. The
+	// closure captures doc (== lr.Doc, retained anyway on the flag-OFF path), NOT
+	// a slice of entity pointers — so the index adds no per-entity retention. The
+	// returned pointer is a fresh heap copy (like getByID/LabelIndex.at), so
+	// callers keying on Entity.ID are behavior-neutral vs the old aliased pointer.
+	idx.resolve = func(vi int32) *graph.Entity {
+		if vi < 0 || int(vi) >= len(doc.Entities) {
+			return nil
+		}
+		e := doc.Entities[vi] // heap copy — a fresh pointer, not an alias into Doc
+		return &e
+	}
+	return idx
+}
+
+// BuildBM25FromReader builds a BM25 index by iterating the resident mmap Reader
+// instead of a materialized graph.Document (memory epic #5850, Path P PR3b /
+// issue #5871 L4). This is the FLIP PREREQUISITE: post-flip lr.Doc is emptied,
+// so BuildBM25(lr.Doc) would build an EMPTY index; the Reader still holds every
+// row, so we tokenize from it.
+//
+// Byte-parity with BuildBM25(doc): the Reader holds the same rows in the same
+// vector order the Document loader produces, and graph.MaterializeEntity decodes
+// each row byte-identically to the Document's entity. Feeding the materialized
+// entity through the SAME buildDocTerms yields the SAME weighted bag, so the
+// postings (doc, tf), docLen, avgLen and totalDocs are byte-equal to the
+// Document-sourced build over the same graph.fb (TestBM25ReaderBuildParity_PR3b).
+//
+// No-retention contract: each entity is materialized ONLY to tokenize it and is
+// discarded at the end of the loop iteration — it is a local value, never stored
+// in the index. The index keeps only the int32 vector index per doc, so building
+// from the Reader does NOT re-pin the ~608 MB of entities the flip is dropping.
+// resolve is NOT set here (this function does not know the repo's
+// readerMu/LabelIndex); getBM25 wires resolve to the readerMu-guarded
+// LabelIndex.at after this returns.
+//
+// Callers on the wired handler path MUST hold the owning repo's readerMu around
+// this call (the mmap is dereferenced per row), exactly like
+// buildAdjacencyFromReader in getAdjacency.
+func BuildBM25FromReader(r *fbreader.Reader) *BM25Index {
+	n := 0
+	if r != nil {
+		n = r.EntityCount()
+	}
+	idx := &BM25Index{
+		entities: make([]int32, n),
+		docLen:   make([]float32, n),
+		postings: make(map[string][]posting),
+	}
+	totalLen := 0.0
+	for i := 0; i < n; i++ {
+		// Materialize the entity TRANSIENTLY: buildDocTerms reads Name /
+		// SourceFile / PropLookup(docstring, discriminators) / Kind to tokenize.
+		// e is a local value that goes out of scope (and becomes GC-eligible) at
+		// the end of this iteration — it is never retained by the index.
+		e := graph.MaterializeEntity(r, i)
+		idx.entities[i] = int32(i) // doc index == reader vector index (identity)
+		d := buildDocTerms(&e)
+		idx.docLen[i] = float32(d.length)
+		totalLen += d.length
+		for term, tf := range d.tf {
+			idx.postings[term] = append(idx.postings[term], posting{doc: int32(i), tf: float32(tf)})
+		}
+	}
+	idx.totalDocs = n
+	if n > 0 {
+		idx.avgLen = totalLen / float64(n)
 	}
 	return idx
 }
@@ -444,12 +540,27 @@ func (b *BM25Index) Search(query string, limit int) []Hit {
 		}
 		return scored[i].di < scored[j].di
 	})
-	hits := make([]Hit, len(scored))
-	for i, sd := range scored {
-		hits[i] = Hit{Entity: b.entities[sd.di], Score: sd.score}
-	}
-	if limit > 0 && len(hits) > limit {
-		hits = hits[:limit]
+	// Resolve each ranked doc index -> vector index -> *graph.Entity at RETURN
+	// time via b.resolve (issue #5871 L4). The index retains no entity pointers;
+	// resolve materializes on demand — a fresh Document heap copy on the flag-OFF
+	// path, or the readerMu-guarded LabelIndex.at (mmap Reader + overlay
+	// side-table) on the flag-ON path. A nil resolve (defensive) or an
+	// unresolvable index (e.g. a retired mapping falling back to an emptied Doc)
+	// is skipped, so hits may be shorter than scored — apply limit AFTER
+	// resolution so the returned slice honors the requested cap.
+	hits := make([]Hit, 0, len(scored))
+	for _, sd := range scored {
+		if b.resolve == nil {
+			break
+		}
+		ent := b.resolve(b.entities[sd.di])
+		if ent == nil {
+			continue
+		}
+		hits = append(hits, Hit{Entity: ent, Score: sd.score})
+		if limit > 0 && len(hits) >= limit {
+			break
+		}
 	}
 	return hits
 }

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -674,7 +674,36 @@ func (lr *LoadedRepo) getBM25() *BM25Index {
 		if lr.Doc == nil {
 			return
 		}
-		lr.BM25 = BuildBM25(lr.Doc)
+		// ADR-0027 Cutover / issue #5871 L4 (memory epic #5850, Path P PR3b):
+		// build the BM25 index from the resident mmap Reader when ON, else the
+		// Document. This is the FLIP PREREQUISITE — post-flip lr.Doc is emptied,
+		// so BuildBM25(lr.Doc) would build an EMPTY index; the Reader still holds
+		// every row. Flag-gated (default OFF) for the same handler-path munmap
+		// SIGBUS reason as getAdjacency. ADR-0027 SIGBUS-safety (#5850): the mmap
+		// read (BuildBM25FromReader materializes every row) + a concurrent
+		// reload's munmap are serialized by the strictly-innermost readerMu, so
+		// the mapping cannot be freed mid-scan. Lock order: idxMu (held) ->
+		// readerMu; the Doc build takes no mmap so readerMu is dropped first.
+		lr.readerMu.Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
+			idx := BuildBM25FromReader(rdr)
+			// Search resolves each ranked vector index -> *graph.Entity at return
+			// time via the readerMu-guarded, materialize-on-demand LabelIndex.at
+			// (mmap Reader base + group-algo overlay side-table) — NOT a retained
+			// pointer slice. Capture the current LabelIndex generation so the
+			// resolver stays byte-consistent with the graph.fb this index was
+			// built from; at() takes readerMu itself and falls back to the Doc if
+			// the mapping is retired, so it is safe to call lock-free from Search.
+			li := lr.LabelIndex
+			idx.resolve = func(vi int32) *graph.Entity { return li.at(vi) }
+			lr.BM25 = idx
+			lr.readerMu.Unlock()
+		} else {
+			lr.readerMu.Unlock()
+			lr.BM25 = BuildBM25(lr.Doc)
+		}
 	})
 	// Record the borrow time so the idle sweep can distinguish an actively-used
 	// index from one whose last search is older than the eviction window. Stamped


### PR DESCRIPTION
## What
The last correctness gate before the mmap flip (Path P, #5870) + #5871 L4. Post-flip `lr.Doc` empties, so BM25 must build from the Reader and must not re-pin ~608 MB via retained `*graph.Entity`.

- **`BuildBM25FromReader(r)`** — materializes each entity transiently (tokenize via unchanged `buildDocTerms`, then discard), folds into the L1-compacted postings/docLen. Byte-parity with `BuildBM25(doc)` over the same graph.fb.
- **L4** — `entities []*graph.Entity` → `entities []int32` + a `resolve func(int32) *graph.Entity`. `Search` resolves each hit at return time (flag-ON via `LabelIndex.at`, materialize-on-demand under `readerMu`; flag-OFF closes over `lr.Doc`). No per-entity pointer slice retained.
- **`getBM25`** — flag-ON builds from Reader under `readerMu` + wires `resolve = li.at`; flag-OFF unchanged (Doc build).

## Load-bearing tests (all mutation-proven)
- `TestBM25ReaderBuildParity_PR3b` — `reflect.DeepEqual` postings/docLen/entities + ranked-ID/score parity across 10 queries × 4 limits. (tf+1 mutation → FAIL.)
- `TestBM25FromReaderNoEntityRetention_PR3b` — reflective sweep proves no `[]*graph.Entity` field. (retention mutation → FAIL.)
- `TestBM25FlagOnReaderMatchesFlagOffDoc_PR3b`, `TestBM25EvictionRebuild_BothFlags_PR3b` — parity + evict/rebuild both flags.

Search resolves after ranking (limit applied post-resolution; a reload-retired mapping drops a hit gracefully, never crashes). Flag-OFF byte-identical (FuseRRF already keys on ID).

Independently opus-reviewed (APPROVE): byte-parity + no-retention mutation-proven, resolution + readerMu correct, race graceful. `go test ./internal/mcp/...` 1198 pass, `-race` clean.

Refs #5870
Refs #5871

🤖 Generated with [Claude Code](https://claude.com/claude-code)