### PR TITLE
feat(mcp): de-retain lr.byID + getByIDOne single-entity resolver (mmap flip Path P)

### DIFF
--- a/internal/mcp/dashboard_api.go
+++ b/internal/mcp/dashboard_api.go
@@ -67,8 +67,7 @@ func EndpointPostureForEntity(group string, docs map[string]*graph.Document, slu
 	if !ok || r.Doc == nil {
 		return PosturePayload{}, false
 	}
-	byID := r.getByID()
-	e, ok := byID[entityID]
+	e, ok := r.getByIDOne(entityID)
 	if !ok || e == nil {
 		return PosturePayload{}, false
 	}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -356,9 +356,10 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 		if lookup == "" {
 			lookup = topicID
 		}
-		byID := r.getByID()
-		topicEnt, ok := byID[lookup]
-		if !ok {
+		// Path P (#5850): materialize only the topic + its matched participants.
+		resolve := memoRepoResolver(r)
+		topicEnt := resolve(lookup)
+		if topicEnt == nil {
 			// Fall back: resolve by entity name or qualified name.
 			topicEnt = r.LabelIndex.Lookup(lookup)
 			if topicEnt == nil {
@@ -372,7 +373,7 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 			switch rel.Kind {
 			case "PUBLISHES_TO":
 				if rel.ToID == canonID {
-					if src, ok2 := byID[rel.FromID]; ok2 {
+					if src := resolve(rel.FromID); src != nil {
 						p := participant{
 							EntityID:   prefixedID(r.Repo, src.ID),
 							EntityName: src.Name,
@@ -387,7 +388,7 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 				}
 			case "SUBSCRIBES_TO":
 				if rel.ToID == canonID {
-					if src, ok2 := byID[rel.FromID]; ok2 {
+					if src := resolve(rel.FromID); src != nil {
 						p := participant{
 							EntityID:   prefixedID(r.Repo, src.ID),
 							EntityName: src.Name,
@@ -782,9 +783,10 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 		if target == "" {
 			target = patternID
 		}
-		byID := r.getByID()
-		e, ok := byID[target]
-		if !ok || (e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern") {
+		// Path P (#5850): materialize only the pattern + its matched exemplars.
+		resolve := memoRepoResolver(r)
+		e := resolve(target)
+		if e == nil || (e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern") {
 			continue
 		}
 		// Collect exemplar entities.
@@ -796,7 +798,7 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 		var exemplars []exemplar
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if (rel.Kind == "EXEMPLIFIES" || rel.Kind == "INSTANCE_OF") && rel.ToID == target {
-				if ex := byID[rel.FromID]; ex != nil {
+				if ex := resolve(rel.FromID); ex != nil {
 					exemplars = append(exemplars, exemplar{
 						EntityID:   prefixedID(r.Repo, ex.ID),
 						EntityName: ex.Name,

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -293,7 +293,7 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		if _, ok := r.getByID()[local]; !ok {
+		if _, ok := r.getByIDOne(local); !ok {
 			// Entry not in this repo; skip without contributing.
 			totalEntities += len(r.Doc.Entities)
 			continue

--- a/internal/mcp/effective_contract_fw_common.go
+++ b/internal/mcp/effective_contract_fw_common.go
@@ -50,12 +50,11 @@ import (
 // nestHandlerEntity but is framework-neutral.
 func frameworkHandlerEntity(r *LoadedRepo, ep *graph.Entity) *graph.Entity {
 	adj := r.getAdjacency()
-	byID := r.getByID()
 	for _, ed := range adj.Incoming(ep.ID) {
 		if !strings.EqualFold(ed.kind, "IMPLEMENTS") {
 			continue
 		}
-		if h := byID[ed.target]; h != nil {
+		if h, _ := r.getByIDOne(ed.target); h != nil {
 			return h
 		}
 	}

--- a/internal/mcp/effective_contract_nestjs.go
+++ b/internal/mcp/effective_contract_nestjs.go
@@ -128,12 +128,11 @@ func isNestJSEndpoint(e *graph.Entity) bool {
 // unresolved (honest-partial: the resolver degrades to endpoint props).
 func nestHandlerEntity(r *LoadedRepo, ep *graph.Entity) *graph.Entity {
 	adj := r.getAdjacency()
-	byID := r.getByID()
 	for _, ed := range adj.Incoming(ep.ID) {
 		if !strings.EqualFold(ed.kind, "IMPLEMENTS") {
 			continue
 		}
-		if h := byID[ed.target]; h != nil {
+		if h, _ := r.getByIDOne(ed.target); h != nil {
 			return h
 		}
 	}

--- a/internal/mcp/endpoint_posture.go
+++ b/internal/mcp/endpoint_posture.go
@@ -312,7 +312,6 @@ func buildPosturePayload(r *LoadedRepo, e *graph.Entity) posturePayload {
 // sorted for stable output.
 func resolveErrorFlow(r *LoadedRepo, localID string) errorFlow {
 	adj := r.getAdjacency()
-	byID := r.getByID()
 	throws := map[string]bool{}
 	catches := map[string]bool{}
 	for _, ed := range adj.Outgoing(localID) {
@@ -325,7 +324,8 @@ func resolveErrorFlow(r *LoadedRepo, localID string) errorFlow {
 		default:
 			continue
 		}
-		name := exceptionTypeName(byID[ed.target], ed.target)
+		tgtEnt, _ := r.getByIDOne(ed.target)
+		name := exceptionTypeName(tgtEnt, ed.target)
 		if name != "" {
 			bucket[name] = true
 		}
@@ -349,13 +349,13 @@ func exceptionTypeName(e *graph.Entity, rawTarget string) string {
 // synthetic id/name prefix). De-duplicated and sorted.
 func resolveFeatureGates(r *LoadedRepo, localID string) []string {
 	adj := r.getAdjacency()
-	byID := r.getByID()
 	keys := map[string]bool{}
 	for _, ed := range adj.Outgoing(localID) {
 		if !strings.EqualFold(ed.kind, edgeGatedBy) {
 			continue
 		}
-		key := featureFlagKey(byID[ed.target], ed.target)
+		tgtEnt, _ := r.getByIDOne(ed.target)
+		key := featureFlagKey(tgtEnt, ed.target)
 		if key != "" {
 			keys[key] = true
 		}

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -248,8 +248,10 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 		if target == "" {
 			target = entityID
 		}
-		byID := r.getByID()
-		if _, ok := byID[target]; !ok {
+		// Path P (#5850): on-demand memoizing resolver — find_callers materializes
+		// only its inbound BFS closure, not the whole repo's entity set.
+		resolve := memoRepoResolver(r)
+		if resolve(target) == nil {
 			continue
 		}
 
@@ -323,7 +325,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			// It is a legitimate caller of the base member, so it must survive
 			// the shadow/container noise filter exactly like a file-ref edge.
 			isInheritsEdge := dk == inheritsEdgeKind
-			e := byID[id]
+			e := resolve(id)
 			if e == nil {
 				// #2015: previously a nil byID lookup silently dropped the
 				// caller. In production this hides legitimate file-level
@@ -465,7 +467,7 @@ func (s *Server) findCallersStructured(_ context.Context, req mcpapi.CallToolReq
 			return callers[i].Name < callers[j].Name
 		})
 
-		root := byID[target]
+		root := resolve(target)
 		rootName := target
 		if root != nil {
 			rootName = root.Name
@@ -614,8 +616,10 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 		if target == "" {
 			target = entityID
 		}
-		byID := r.getByID()
-		if _, ok := byID[target]; !ok {
+		// Path P (#5850): on-demand memoizing resolver — find_callees materializes
+		// only its outbound BFS closure, not the whole repo's entity set.
+		resolve := memoRepoResolver(r)
+		if resolve(target) == nil {
 			continue
 		}
 
@@ -676,7 +680,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 			if id == target {
 				continue
 			}
-			e := byID[id]
+			e := resolve(id)
 			if e == nil {
 				e = mroExternal[id]
 			}
@@ -740,7 +744,7 @@ func (s *Server) findCalleesStructured(_ context.Context, req mcpapi.CallToolReq
 			return callees[i].Name < callees[j].Name
 		})
 
-		root := byID[target]
+		root := resolve(target)
 		rootName := target
 		if root != nil {
 			rootName = root.Name
@@ -925,7 +929,7 @@ func resolveImpactTarget(repos []*LoadedRepo, target string) impactResolution {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		if _, ok := r.getByID()[target]; ok {
+		if _, ok := r.getByIDOne(target); ok {
 			return impactResolution{repo: r, localID: target}
 		}
 	}
@@ -1192,7 +1196,7 @@ func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolReques
 	// joins (lg.Links, method="topic") so cross-repo publishers + subscribers
 	// appear with correct per-repo attribution. The non-topic (code entity) path
 	// below is entirely unchanged.
-	if e := resolution.repo.getByID()[resolution.localID]; isMessageTopicEntity(e) {
+	if e, _ := resolution.repo.getByIDOne(resolution.localID); isMessageTopicEntity(e) {
 		return s.impactRadiusForTopic(lg, &topicSeed{repo: resolution.repo, id: resolution.localID, name: e.Name}, hops), nil
 	}
 
@@ -1530,10 +1534,28 @@ func subgraphModulePrefix(path string) string {
 //
 // A target is a hub when its precomputed IsGodNode flag is set or its total
 // degree exceeds subgraphHubDegree.
-func newSubgraphRanker(adj *adjacency, byID map[string]*graph.Entity, root *graph.Entity) *bfsRanker {
+// memoRepoResolver returns an entity-by-id resolver backed by getByIDOne,
+// memoizing each result (including nil) so a BOUNDED subgraph walk materializes
+// each visited entity at most ONCE on the flag-ON mmap path — instead of
+// getByID materializing the whole repo's entity set for a maxNodes-bounded walk
+// (memory epic #5850 Path P). Not safe for concurrent use; each call site builds
+// its own.
+func memoRepoResolver(r *LoadedRepo) func(string) *graph.Entity {
+	cache := make(map[string]*graph.Entity)
+	return func(id string) *graph.Entity {
+		if e, ok := cache[id]; ok {
+			return e
+		}
+		e, _ := r.getByIDOne(id)
+		cache[id] = e
+		return e
+	}
+}
+
+func newSubgraphRanker(adj *adjacency, resolve func(string) *graph.Entity, root *graph.Entity) *bfsRanker {
 	degree := func(id string) int { return len(adj.Outgoing(id)) + len(adj.Incoming(id)) }
 	isHub := func(id string) bool {
-		if e := byID[id]; e != nil && e.IsGodNode {
+		if e := resolve(id); e != nil && e.IsGodNode {
 			return true
 		}
 		return degree(id) >= subgraphHubDegree
@@ -1551,7 +1573,7 @@ func newSubgraphRanker(adj *adjacency, byID map[string]*graph.Entity, root *grap
 			if ha != hb {
 				return !ha // non-hub first
 			}
-			ea, eb := byID[a.target], byID[b.target]
+			ea, eb := resolve(a.target), resolve(b.target)
 			fa, fb := ea != nil && ea.SourceFile == rootFile, eb != nil && eb.SourceFile == rootFile
 			if fa != fb {
 				return fa // same file first
@@ -1573,14 +1595,14 @@ func newSubgraphRanker(adj *adjacency, byID map[string]*graph.Entity, root *grap
 // subgraphHubNote renders the hub-boundary annotation shared by the raw and
 // markdown subgraph paths (#5691): human names + degree for each hub the walk
 // stopped at, and the id->display map for structured output.
-func subgraphHubNote(hubIDs []string, byID map[string]*graph.Entity, adj *adjacency) []string {
+func subgraphHubNote(hubIDs []string, resolve func(string) *graph.Entity, adj *adjacency) []string {
 	if len(hubIDs) == 0 {
 		return nil
 	}
 	names := make([]string, 0, len(hubIDs))
 	for _, id := range hubIDs {
 		name := id
-		if e := byID[id]; e != nil && e.Name != "" {
+		if e := resolve(id); e != nil && e.Name != "" {
 			name = e.Name
 		}
 		deg := len(adj.Outgoing(id)) + len(adj.Incoming(id))
@@ -1650,16 +1672,19 @@ func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpa
 		if target == "" {
 			target = entityID
 		}
-		byID := r.getByID()
-		if _, ok := byID[target]; !ok {
+		// Path P (#5850): resolve entities on demand via a memoizing resolver so a
+		// maxNodes-bounded walk materializes only the visited entities, not the
+		// whole repo (which the flag-ON whole-map getByID would).
+		resolve := memoRepoResolver(r)
+		root := resolve(target)
+		if root == nil {
 			continue
 		}
 		adj := r.getAdjacency()
-		byID2 := r.getByID()
 		// Locality-first, hub-aware bounded expansion (#5691): rank the frontier
 		// by locality so local structure survives truncation, and stop at
 		// high-degree hubs instead of inheriting their fan-out.
-		ranker := newSubgraphRanker(adj, byID2, byID[target])
+		ranker := newSubgraphRanker(adj, resolve, root)
 		visited, nodesTruncated, hubIDs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsBoth)
 		type nodeOut struct {
 			EntityID   string `json:"entity_id"`
@@ -1677,7 +1702,7 @@ func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpa
 		var nodes []nodeOut
 		nodeSet := map[string]bool{}
 		for id, d := range visited {
-			if e := byID2[id]; e != nil {
+			if e := resolve(id); e != nil {
 				nodes = append(nodes, nodeOut{
 					EntityID:   prefixedID(r.Repo, e.ID),
 					Name:       e.Name,
@@ -1741,7 +1766,7 @@ func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpa
 		}
 		// Hub boundaries: the walk stopped at these high-degree hubs rather than
 		// inheriting their fan-out. Surface them so the caller can narrow (#5691).
-		hubNames := subgraphHubNote(hubIDs, byID2, adj)
+		hubNames := subgraphHubNote(hubIDs, resolve, adj)
 		truncated := nodesTruncated || len(hubNames) > 0
 		out["truncated"] = truncated
 		var notes []string
@@ -1805,9 +1830,11 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 		if target == "" {
 			target = entityID
 		}
-		byID := r.getByID()
-		root, ok := byID[target]
-		if !ok {
+		// Path P (#5850): memoizing on-demand resolver — materialize only the
+		// bounded walk's visited entities, not the whole repo.
+		resolve := memoRepoResolver(r)
+		root := resolve(target)
+		if root == nil {
 			continue
 		}
 
@@ -1815,7 +1842,7 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 		// Locality-first, hub-aware, BOUNDED walk in each direction (#5691).
 		// bfsBoundedRanked includes the start node at depth 0; the caller lists
 		// exclude it below.
-		ranker := newSubgraphRanker(adj, byID, root)
+		ranker := newSubgraphRanker(adj, resolve, root)
 		inVisited, _, inHubs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsIn)
 		outVisited, _, outHubs := bfsBoundedRanked(adj, target, depth, nil, maxNodes, ranker, bfsOut)
 
@@ -1831,7 +1858,7 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 			if id == target {
 				continue // bfsBoundedRanked includes the start node at depth 0
 			}
-			if e := byID[id]; e != nil {
+			if e := resolve(id); e != nil {
 				callers = append(callers, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
 			}
 		}
@@ -1847,7 +1874,7 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 			if id == target {
 				continue // bfsBoundedRanked includes the start node at depth 0
 			}
-			if e := byID[id]; e != nil {
+			if e := resolve(id); e != nil {
 				callees = append(callees, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
 			}
 		}
@@ -1919,7 +1946,7 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 				hubIDs = append(hubIDs, id)
 			}
 		}
-		if names := subgraphHubNote(hubIDs, byID, adj); len(names) > 0 {
+		if names := subgraphHubNote(hubIDs, resolve, adj); len(names) > 0 {
 			b.WriteString(fmt.Sprintf(
 				"## Hub boundaries\n\n_Expanded into hub(s) [%s] and stopped there to avoid inheriting "+
 					"their fan-out. Pass an entity_kind or module filter to narrow._\n\n",
@@ -2459,7 +2486,7 @@ func entityExistsAnywhere(lg *LoadedGroup, id string) bool {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		if _, ok := r.getByID()[probe]; ok {
+		if _, ok := r.getByIDOne(probe); ok {
 			return true
 		}
 		found := false

--- a/internal/mcp/getbyid_deretain_5850_pathp_test.go
+++ b/internal/mcp/getbyid_deretain_5850_pathp_test.go
@@ -1,0 +1,507 @@
+// getbyid_deretain_5850_pathp_test.go — memory epic #5850, mmap-flip Path P.
+//
+// De-retain LoadedRepo.byID: on the GRAFEL_SERVE_FROM_MMAP-ON path the resident
+// getByID cache must hold NO *graph.Entity — it stores only the entity-ID ->
+// vector-INDEX map (map[string]int32) and resolves each entity ON DEMAND via the
+// readerMu-guarded LabelIndex.at. Retaining the ~608 MB entity set here (as the
+// pre-Path-P build did, `lr.byID[id] = ent`) would re-pin the whole Document
+// flag-ON and defeat the mmap flip (Doc is emptied post-flip). This mirrors the
+// BM25 no-retention prerequisite (TestBM25FromReaderNoEntityRetention_PR3b, L4).
+//
+// The flag-OFF default path is unchanged/byte-identical: it still memoizes a
+// Doc-backed map[string]*graph.Entity in lr.byID, because Doc is retained
+// flag-OFF anyway so pointer retention there is free.
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// overlayForIdx is the deterministic overlay rule used by the parity test: every
+// third entity gets a distinct CommunityID/PageRank; the rest stay at the
+// graph.fb sentinel (nil) so BOTH flag paths must agree on the "no overlay" case.
+func overlayForIdx(i int) (community *int, pr *float64) {
+	if i%3 != 0 {
+		return nil, nil
+	}
+	c := 1000 + i%50
+	p := float64(i) * 0.001
+	return &c, &p
+}
+
+// TestGetByIDNoEntityRetention_PathP is the load-bearing no-retention assertion:
+// after getByID populates the cache flag-ON (resident Reader), the resident
+// LoadedRepo cache holds only the map[string]int32 vector-index map — NO
+// *graph.Entity. Mutation: reverting getByID flag-ON to store the materialized
+// entities in lr.byID (map[string]*graph.Entity) makes byID non-nil and this
+// test FAILs.
+func TestGetByIDNoEntityRetention_PathP(t *testing.T) {
+	withServeFromMMap(t, true)
+	lr := newReaderBackedRepo(t, 400)
+
+	// Populate the cache via the public getter (materialize-on-demand path).
+	got := lr.getByID()
+	if len(got) != lr.Reader.EntityCount() {
+		t.Fatalf("getByID returned %d entities, want reader EntityCount=%d", len(got), lr.Reader.EntityCount())
+	}
+
+	// The RESIDENT flag-ON cache field must be a map[string]int32 (vector index),
+	// populated one slot per reader row — proving it learned ID->index.
+	if lr.byIDIdx == nil {
+		t.Fatal("flag-ON getByID left byIDIdx nil — the int32 index cache was not built")
+	}
+	if _, ok := interface{}(lr.byIDIdx).(map[string]int32); !ok {
+		t.Fatalf("byIDIdx is %T, want map[string]int32", lr.byIDIdx)
+	}
+	if len(lr.byIDIdx) != lr.Reader.EntityCount() {
+		t.Fatalf("byIDIdx has %d entries, want reader EntityCount=%d", len(lr.byIDIdx), lr.Reader.EntityCount())
+	}
+
+	// The *graph.Entity resident cache MUST stay nil on the flag-ON path — no
+	// entity pointers pinned resident (this is the whole memory point).
+	if lr.byID != nil {
+		t.Fatalf("flag-ON getByID retained a resident map[string]*graph.Entity (len=%d) — it must hold no entities", len(lr.byID))
+	}
+
+	// Structural sweep of the two cache fields: neither resident cache may be a
+	// map/slice of *graph.Entity while populated on the flag-ON path. (byID is the
+	// flag-OFF field and must be nil here; byIDIdx must be the int32 map.)
+	entityPtrType := reflect.TypeOf((*graph.Entity)(nil))
+	v := reflect.ValueOf(lr).Elem()
+	if f := v.FieldByName("byIDIdx"); f.Type().Kind() == reflect.Map && f.Type().Elem() == entityPtrType {
+		t.Fatal("byIDIdx is a map to *graph.Entity — the flag-ON cache must not retain entities")
+	}
+}
+
+// TestGetByIDParity_FlagOnVsFlagOff_PathP proves getByID returns entities with
+// identical fields (ID/Name/QualifiedName/SourceFile + overlay PageRank/
+// CommunityID) on BOTH flags, over an overlaid fixture. The flag-ON path
+// resolves via LabelIndex.at (Reader base + overlay side-table); the flag-OFF
+// path copies from the overlay-stamped live Doc. They must agree field-for-field.
+func TestGetByIDParity_FlagOnVsFlagOff_PathP(t *testing.T) {
+	const n = 300
+
+	// --- Flag-OFF result: overlay stamped directly onto the Doc rows. ---
+	var offMap map[string]*graph.Entity
+	func() {
+		withServeFromMMap(t, false)
+		doc, _ := loadBM25RichFixture(t, n)
+		for i := range doc.Entities {
+			c, p := overlayForIdx(i)
+			doc.Entities[i].CommunityID = c
+			doc.Entities[i].PageRank = p
+		}
+		lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+		offMap = lr.getByID()
+	}()
+
+	// --- Flag-ON result: overlay carried in the LabelIndex side-table. ---
+	withServeFromMMap(t, true)
+	lr := newReaderBackedRepo(t, n)
+	table := make(map[int32]entityOverlay)
+	for id, idx := range lr.LabelIndex.byID {
+		_ = id
+		c, p := overlayForIdx(int(idx))
+		if c == nil && p == nil {
+			continue // no overlay entry → reader sentinel (nil) survives
+		}
+		table[idx] = entityOverlay{CommunityID: c, PageRank: p}
+	}
+	lr.LabelIndex.overlay = table
+	onMap := lr.getByID()
+
+	if len(onMap) != len(offMap) {
+		t.Fatalf("map length differs: flag-on=%d flag-off=%d", len(onMap), len(offMap))
+	}
+
+	derefI := func(p *int) string {
+		if p == nil {
+			return "<nil>"
+		}
+		return itoa(*p)
+	}
+	derefF := func(p *float64) float64 {
+		if p == nil {
+			return -1
+		}
+		return *p
+	}
+
+	for id, off := range offMap {
+		on, ok := onMap[id]
+		if !ok {
+			t.Fatalf("flag-on getByID missing id %q", id)
+		}
+		if on.ID != off.ID || on.Name != off.Name || on.QualifiedName != off.QualifiedName || on.SourceFile != off.SourceFile {
+			t.Fatalf("base-field mismatch for %q:\n on={ID:%q Name:%q QN:%q SF:%q}\noff={ID:%q Name:%q QN:%q SF:%q}",
+				id, on.ID, on.Name, on.QualifiedName, on.SourceFile, off.ID, off.Name, off.QualifiedName, off.SourceFile)
+		}
+		if derefI(on.CommunityID) != derefI(off.CommunityID) {
+			t.Fatalf("CommunityID mismatch for %q: on=%s off=%s", id, derefI(on.CommunityID), derefI(off.CommunityID))
+		}
+		if derefF(on.PageRank) != derefF(off.PageRank) {
+			t.Fatalf("PageRank mismatch for %q: on=%v off=%v", id, derefF(on.PageRank), derefF(off.PageRank))
+		}
+	}
+}
+
+// TestGetByIDFlagOnEmptiedDoc_PathP is the post-flip-shape test: flag-ON, a
+// resident Reader, and an EMPTIED lr.Doc.Entities. getByID must still resolve
+// every valid id (bound + resolved via the Reader, not the empty Doc) and return
+// nil for an unknown id. Mutation: bounding/resolving getByID against lr.Doc
+// instead of the Reader collapses the map to empty → this FAILs.
+func TestGetByIDFlagOnEmptiedDoc_PathP(t *testing.T) {
+	withServeFromMMap(t, true)
+
+	full := newReaderBackedRepo(t, 250)
+	wantIDs := make([]string, 0, full.Reader.EntityCount())
+	for id := range full.LabelIndex.byID {
+		wantIDs = append(wantIDs, id)
+	}
+
+	// Simulate the PR7 Doc-emptying: drop every Doc row while the Reader keeps
+	// them. at() reads l.doc, so keep it consistent with the emptied lr.Doc.
+	full.Doc = emptiedParityDoc(full.Doc)
+	full.LabelIndex.doc = full.Doc
+
+	got := full.getByID()
+	if len(got) != len(wantIDs) {
+		t.Fatalf("getByID with emptied Doc: got %d entities, want %d (must bind against the Reader)", len(got), len(wantIDs))
+	}
+	for _, id := range wantIDs {
+		e, ok := got[id]
+		if !ok || e == nil {
+			t.Fatalf("getByID missing id %q with emptied Doc", id)
+			continue
+		}
+		if e.ID != id {
+			t.Errorf("getByID[%q].ID = %q", id, e.ID)
+		}
+	}
+	if _, ok := got["this-id-does-not-exist"]; ok {
+		t.Fatal("getByID returned an entry for an unknown id")
+	}
+}
+
+// TestGetByIDReloadRace_PathP runs getByID concurrently with a reload that
+// retires+munmaps the mapping the resident LabelIndex points at. Under -race it
+// must finish with no SIGBUS/SIGSEGV: getByID resolves via the readerMu-guarded
+// at(), so a lookup whose mapping was retired falls back to the Doc (correct
+// data) instead of dereferencing the freed region.
+func TestGetByIDReloadRace_PathP(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	doc := sigbusFixtureDoc(24)
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	open := func() *fbreader.Reader {
+		r, err := fbreader.Open(fbPath)
+		if err != nil {
+			t.Fatalf("open reader: %v", err)
+		}
+		return r
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	// Install a single generation; getByID reads lr.LabelIndex, which stays fixed
+	// for the whole test (the reloader retires the handle it points at, it does not
+	// reassign the field — avoiding an unrelated field race).
+	s.mu.Lock()
+	h0 := newMapHandle(open())
+	lr.LabelIndex = wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.publishHandle(h0)
+	s.mu.Unlock()
+
+	var faults atomic.Int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: hammer getByID; every returned entity must be correct (mmap OR the
+	// Doc fallback after retire — both carry identical content).
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 600; j++ {
+				m := lr.getByID()
+				if e, ok := m["e5"]; !ok || e == nil || e.ID != "e5" || e.QualifiedName != "r.e5" {
+					faults.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Reloader: retire+munmap the mapping mid-flight (once), racing in-flight
+	// getByID resolutions. publishHandle sets readRetired under readerMu before the
+	// munmap, so at() sees it and falls back.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		nh := newMapHandle(open())
+		s.mu.Lock()
+		lr.publishHandle(nh) // retire+munmap h0 (the generation lr.LabelIndex holds)
+		s.mu.Unlock()
+	}()
+
+	close(start)
+	wg.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("getByID returned wrong/nil entity under concurrent retire: %d faults", f)
+	}
+}
+
+// TestGetByIDFlagOffByteIdentical_PathP pins that the flag-OFF default path is
+// unchanged: getByID memoizes a Doc-backed map[string]*graph.Entity in lr.byID
+// (byIDIdx stays nil), returns every Doc row, and the returned pointers are
+// distinct heap copies (not aliases into Doc.Entities' backing array).
+func TestGetByIDFlagOffByteIdentical_PathP(t *testing.T) {
+	withServeFromMMap(t, false)
+
+	doc, _ := loadBM25RichFixture(t, 200)
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+
+	got := lr.getByID()
+	if len(got) != len(doc.Entities) {
+		t.Fatalf("flag-off getByID: got %d entities, want %d", len(got), len(doc.Entities))
+	}
+	if lr.byID == nil {
+		t.Fatal("flag-off getByID did not memoize the *graph.Entity map in lr.byID")
+	}
+	if lr.byIDIdx != nil {
+		t.Fatalf("flag-off getByID built the int32 index cache (len=%d); it must stay nil off-flip", len(lr.byIDIdx))
+	}
+	// Second call returns the SAME memoized map (stable within a reload).
+	if got2 := lr.getByID(); reflect.ValueOf(got2).Pointer() != reflect.ValueOf(got).Pointer() {
+		t.Fatal("flag-off getByID is not memoized: two calls returned different maps")
+	}
+	for i := range doc.Entities {
+		want := &doc.Entities[i]
+		e, ok := got[want.ID]
+		if !ok || e.ID != want.ID {
+			t.Fatalf("flag-off getByID[%q] = %+v", want.ID, e)
+		}
+		if e == want {
+			t.Fatalf("flag-off getByID[%q] aliases Doc.Entities backing array (must be a heap copy)", want.ID)
+		}
+	}
+}
+
+// TestGetByIDOneSingleMaterialization_PathP is the load-bearing perf test for
+// getByIDOne: on the flag-ON mmap path it must materialize EXACTLY ONE entity
+// (the requested id), never the whole set. Mutation: routing getByIDOne through
+// the whole-map getByID() (return getByID()[id]) materializes every row → the
+// count assertion FAILs. Guards against the 62%-of-callers per-call whole-repo
+// materialization the reviewer flagged.
+func TestGetByIDOneSingleMaterialization_PathP(t *testing.T) {
+	withServeFromMMap(t, true)
+	lr := newReaderBackedRepo(t, 500)
+
+	var someID string
+	for id := range lr.LabelIndex.byID {
+		someID = id
+		break
+	}
+
+	var count atomic.Int64
+	atMaterializeHook = func() { count.Add(1) }
+	t.Cleanup(func() { atMaterializeHook = nil })
+
+	// Warm the int32 index cache first so its build (which materializes nothing)
+	// is not conflated with the single resolve we measure.
+	_, _ = lr.getByIDOne(someID)
+	if lr.byIDIdx == nil {
+		t.Fatal("getByIDOne did not build the int32 index cache")
+	}
+
+	count.Store(0)
+	e, ok := lr.getByIDOne(someID)
+	if !ok || e == nil || e.ID != someID {
+		t.Fatalf("getByIDOne(%q) = (%v, %v)", someID, e, ok)
+	}
+	if got := count.Load(); got != 1 {
+		t.Fatalf("getByIDOne materialized %d entities, want exactly 1 (whole-map path?)", got)
+	}
+
+	// A whole-map getByID by contrast materializes every row — proves the counter
+	// is live and that the two paths differ.
+	count.Store(0)
+	_ = lr.getByID()
+	if got := count.Load(); got != int64(lr.Reader.EntityCount()) {
+		t.Fatalf("getByID materialized %d entities, want all %d", got, lr.Reader.EntityCount())
+	}
+
+	// getByIDOne must not build the flag-OFF whole-entity resident cache.
+	if lr.byID != nil {
+		t.Fatalf("getByIDOne built the whole-map resident cache lr.byID")
+	}
+}
+
+// TestGetByIDOneParity_FlagOnVsFlagOff_PathP proves getByIDOne returns an entity
+// with identical fields (base + overlay PageRank/CommunityID) on both flags for
+// a given id — the per-id analogue of the whole-map parity test.
+func TestGetByIDOneParity_FlagOnVsFlagOff_PathP(t *testing.T) {
+	const n = 300
+
+	// Flag-OFF: overlay stamped onto the Doc rows.
+	var offRepo *LoadedRepo
+	var offIDs []string
+	func() {
+		withServeFromMMap(t, false)
+		doc, _ := loadBM25RichFixture(t, n)
+		for i := range doc.Entities {
+			c, p := overlayForIdx(i)
+			doc.Entities[i].CommunityID = c
+			doc.Entities[i].PageRank = p
+			offIDs = append(offIDs, doc.Entities[i].ID)
+		}
+		offRepo = &LoadedRepo{Repo: "corpus", Doc: doc}
+	}()
+	offVals := make(map[string]*graph.Entity, len(offIDs))
+	withServeFromMMap(t, false)
+	for _, id := range offIDs {
+		e, ok := offRepo.getByIDOne(id)
+		if !ok {
+			t.Fatalf("flag-off getByIDOne missing %q", id)
+		}
+		offVals[id] = e
+	}
+
+	// Flag-ON: same overlay carried in the LabelIndex side-table.
+	withServeFromMMap(t, true)
+	lr := newReaderBackedRepo(t, n)
+	table := make(map[int32]entityOverlay)
+	for _, idx := range lr.LabelIndex.byID {
+		c, p := overlayForIdx(int(idx))
+		if c == nil && p == nil {
+			continue
+		}
+		table[idx] = entityOverlay{CommunityID: c, PageRank: p}
+	}
+	lr.LabelIndex.overlay = table
+
+	derefI := func(p *int) string {
+		if p == nil {
+			return "<nil>"
+		}
+		return itoa(*p)
+	}
+	derefF := func(p *float64) float64 {
+		if p == nil {
+			return -1
+		}
+		return *p
+	}
+	for _, id := range offIDs {
+		on, ok := lr.getByIDOne(id)
+		if !ok {
+			t.Fatalf("flag-on getByIDOne missing %q", id)
+		}
+		off := offVals[id]
+		if on.ID != off.ID || on.Name != off.Name || on.QualifiedName != off.QualifiedName || on.SourceFile != off.SourceFile {
+			t.Fatalf("base-field mismatch for %q: on=%+v off=%+v", id, on, off)
+		}
+		if derefI(on.CommunityID) != derefI(off.CommunityID) {
+			t.Fatalf("CommunityID mismatch for %q: on=%s off=%s", id, derefI(on.CommunityID), derefI(off.CommunityID))
+		}
+		if derefF(on.PageRank) != derefF(off.PageRank) {
+			t.Fatalf("PageRank mismatch for %q: on=%v off=%v", id, derefF(on.PageRank), derefF(off.PageRank))
+		}
+	}
+
+	// Unknown id → (nil, false) on both flags.
+	if e, ok := lr.getByIDOne("no-such-id"); ok || e != nil {
+		t.Fatalf("flag-on getByIDOne(unknown) = (%v, %v), want (nil, false)", e, ok)
+	}
+	withServeFromMMap(t, false)
+	if e, ok := offRepo.getByIDOne("no-such-id"); ok || e != nil {
+		t.Fatalf("flag-off getByIDOne(unknown) = (%v, %v), want (nil, false)", e, ok)
+	}
+}
+
+// TestGetByIDOneReloadRace_PathP runs getByIDOne concurrently with a reload that
+// retires+munmaps the mapping the resident LabelIndex points at. Under -race it
+// must finish with no SIGBUS: getByIDOne resolves the single index via the
+// readerMu-guarded at(), so a retired lookup falls back to the Doc.
+func TestGetByIDOneReloadRace_PathP(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	doc := sigbusFixtureDoc(24)
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	open := func() *fbreader.Reader {
+		r, err := fbreader.Open(fbPath)
+		if err != nil {
+			t.Fatalf("open reader: %v", err)
+		}
+		return r
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	s.mu.Lock()
+	h0 := newMapHandle(open())
+	lr.LabelIndex = wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.publishHandle(h0)
+	s.mu.Unlock()
+
+	var faults atomic.Int64
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for g := 0; g < 8; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for j := 0; j < 600; j++ {
+				e, ok := lr.getByIDOne("e5")
+				if !ok || e == nil || e.ID != "e5" || e.QualifiedName != "r.e5" {
+					faults.Add(1)
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		nh := newMapHandle(open())
+		s.mu.Lock()
+		lr.publishHandle(nh)
+		s.mu.Unlock()
+	}()
+
+	close(start)
+	wg.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("getByIDOne returned wrong/nil entity under concurrent retire: %d faults", f)
+	}
+}

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -283,11 +283,20 @@ func (l *LabelIndex) at(idx int32) *graph.Entity {
 	return &e
 }
 
+// atMaterializeHook, when non-nil, is invoked once per Reader entity
+// materialization. Test-only observability for single-materialization perf
+// assertions (memory epic #5850 Path P: getByIDOne must materialize exactly one
+// entity, not the whole set). Nil in production — one predictable nil-check.
+var atMaterializeHook func()
+
 // materializeFromReader decodes the base entity from the mmap Reader and merges
 // the group-algo overlay side-table. Callers on the wired path MUST hold
 // readerMu (the mmap dereference happens here); MaterializeEntity copies every
 // string out to the heap, so the returned entity is safe to use past release.
 func (l *LabelIndex) materializeFromReader(idx int32) *graph.Entity {
+	if atMaterializeHook != nil {
+		atMaterializeHook()
+	}
 	e := graph.MaterializeEntity(l.reader, int(idx))
 	if ov, ok := l.overlay[idx]; ok {
 		e.CommunityID = ov.CommunityID

--- a/internal/mcp/literal_parity_tool.go
+++ b/internal/mcp/literal_parity_tool.go
@@ -249,9 +249,8 @@ func findEnumByID(lg *LoadedGroup, id string) *graph.Entity {
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		byID := r.getByID()
 		for _, cand := range []string{id, bare} {
-			if e, ok := byID[cand]; ok && isValueSet(e) {
+			if e, ok := r.getByIDOne(cand); ok && isValueSet(e) {
 				return e
 			}
 		}

--- a/internal/mcp/messaging_related_5782.go
+++ b/internal/mcp/messaging_related_5782.go
@@ -90,7 +90,7 @@ func resolveTopicSeed(lg *LoadedGroup, entityID string) *topicSeed {
 		if repoHint != "" && r.Repo != repoHint {
 			continue
 		}
-		if e := r.getByID()[probe]; isMessageTopicEntity(e) {
+		if e, _ := r.getByIDOne(probe); isMessageTopicEntity(e) {
 			return &topicSeed{repo: r, id: e.ID, name: e.Name}
 		}
 	}
@@ -149,7 +149,7 @@ func collectTopicNeighbors(lg *LoadedGroup, topicName, seedRepo string) (produce
 		if r == nil || r.Doc == nil {
 			return
 		}
-		e := r.getByID()[localID]
+		e, _ := r.getByIDOne(localID)
 		if e == nil {
 			return
 		}
@@ -376,7 +376,7 @@ func resolveChannelBindingSeed(lg *LoadedGroup, entityID string) *channelBinding
 		if repoHint != "" && r.Repo != repoHint {
 			continue
 		}
-		if e := r.getByID()[probe]; isChannelBindingEntity(e) {
+		if e, _ := r.getByIDOne(probe); isChannelBindingEntity(e) {
 			return &channelBindingSeed{repo: r, id: e.ID, name: e.Name}
 		}
 	}
@@ -565,7 +565,8 @@ func collectChannelBindingTargets(r *LoadedRepo, binding *graph.Entity) (channel
 // it binds — so no lg.Links join is needed.
 func channelBindingNeighborsStructured(seed *channelBindingSeed) map[string]any {
 	r := seed.repo
-	channels, topics := collectChannelBindingTargets(r, r.getByID()[seed.id])
+	seedEnt, _ := r.getByIDOne(seed.id)
+	channels, topics := collectChannelBindingTargets(r, seedEnt)
 
 	return map[string]any{
 		"entity_id": prefixedID(r.Repo, seed.id),
@@ -755,7 +756,7 @@ func (s *Server) impactRadiusForTopic(lg *LoadedGroup, seed *topicSeed, hops int
 			if r == nil || r.Doc == nil {
 				continue
 			}
-			e := r.getByID()[id]
+			e, _ := r.getByIDOne(id)
 			if e == nil {
 				continue
 			}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -326,8 +326,17 @@ type LoadedRepo struct {
 	adjacency    *adjacency               // in/out neighbor lists (#1656)
 	callsAdj     *callsAdjacency          // CALLS-only forward adjacency, CSR layout (#1656, #5850)
 	stepAdj      map[string][]stepEdge    // STEP_IN_PROCESS forward adjacency (#2417)
-	byID         map[string]*graph.Entity // entity ID -> entity (#1656)
-	topKPageRank []string                 // entity IDs sorted descending by PageRank (#2304)
+	byID         map[string]*graph.Entity // entity ID -> entity, flag-OFF resident cache (#1656)
+	// byIDIdx is the FLAG-ON resident getByID cache (memory epic #5850 Path P): it
+	// maps entity ID -> vector INDEX and holds NO *graph.Entity, so it cannot
+	// re-pin the ~608 MB entity set that the mmap flip moves out of the Go heap.
+	// getByID resolves each index to an entity ON DEMAND via the readerMu-guarded
+	// LabelIndex.at (Reader base + overlay side-table). Built once per reload under
+	// byIDOnce, cleared by resetIndexes. Nil on the flag-OFF default path (which
+	// keeps byID above — Doc is retained flag-OFF anyway, so pointer retention
+	// there is free). Mirrors the BM25 int32-index no-retention build (PR3b L4).
+	byIDIdx      map[string]int32
+	topKPageRank []string // entity IDs sorted descending by PageRank (#2304)
 	// bm25LastUse is the wall-clock time of the most recent getBM25() borrow (a
 	// search-tool use). idxMu-guarded — written under idxMu in getBM25 and read
 	// under idxMu in evictBM25IfIdle. The idle sweep (SweepIdleBM25) drops the
@@ -474,6 +483,7 @@ func (lr *LoadedRepo) resetIndexes() {
 	lr.callsAdj = nil
 	lr.stepAdj = nil
 	lr.byID = nil
+	lr.byIDIdx = nil
 	lr.topKPageRank = nil
 	lr.suffixIndex = nil
 	lr.suffixIndexPartial = false
@@ -576,61 +586,122 @@ func (lr *LoadedRepo) getMROInbound() map[string][]string {
 	return lr.mroInbound
 }
 
-// getByID returns the entity-ID → *Entity map, building it on first use.
+// getByID returns the entity-ID → *Entity map, building the cache on first use.
 //
-// ADR-0027 Cutover PR2: the map's values are now INDEPENDENT heap copies of the
-// Document rows rather than pointers ALIASING lr.Doc.Entities' backing array —
-// so getByID no longer pins live pointers into Doc, the prerequisite for the
-// PR7 flip that drops Doc.Entities. It no longer reuses LabelIndex.ByID, which
-// is now an int32 index map, not a *graph.Entity map. Values are copied from
-// the LIVE Doc (not the mmap Reader) so post-load in-place overlay stamps stay
-// visible — behavior-neutral; see the LabelIndex type doc for the rationale.
-// Built once per reload and cached, so the map's values are INTERNALLY STABLE
-// for the life of the reload: getByID consumers (which index the map by id and
-// never compare value pointers) are insulated from the per-lookup pointer
-// instability of LabelIndex.ByID/Lookup.
+// Memory epic #5850 Path P — de-retain byID. The resident cache is gated by
+// GRAFEL_SERVE_FROM_MMAP so the flag-ON path pins NO entity pointers (the flip
+// prerequisite; post-flip lr.Doc is emptied and a retained entity map here would
+// re-pin the whole ~608 MB entity set in the Go heap, defeating the flip):
+//
+//   - Flag-ON (Reader resident): the resident cache is lr.byIDIdx — ID → vector
+//     INDEX (map[string]int32), learned once from the LabelIndex's own int32 map.
+//     getByID resolves each index to an entity ON DEMAND via the readerMu-guarded
+//     LabelIndex.at (Reader base + overlay side-table, byte-equal to the overlaid
+//     Doc row) and returns a TRANSIENT map[string]*graph.Entity that the caller
+//     drops after use — nothing entity-shaped stays resident. The bound is the
+//     Reader's row count (EntityCount), so a PR7 Doc-emptying does not collapse
+//     the result. Mirrors the BM25 int32-index no-retention build (PR3b L4).
+//   - Flag-OFF (default): the resident cache is lr.byID — INDEPENDENT heap copies
+//     of the live Doc rows (ADR-0027 PR2), so post-load in-place overlay stamps
+//     stay visible, GC-safe, with NO handler-path mmap read. Doc is retained
+//     flag-OFF anyway, so this pointer retention is free. Built once and cached,
+//     so the values are INTERNALLY STABLE for the life of the reload.
+//
+// The mmap path short-circuits to the flag-OFF Doc build whenever at() cannot
+// serve an index (nil LabelIndex/Reader, JSON load). getByID consumers index the
+// returned map by id and never compare value pointers across calls, so they are
+// insulated from the per-lookup pointer instability of LabelIndex.at.
 func (lr *LoadedRepo) getByID() map[string]*graph.Entity {
 	lr.idxMu.Lock()
 	defer lr.idxMu.Unlock()
+	lr.buildByIDCacheLocked()
+
+	if lr.byIDIdx != nil {
+		// Flag-ON: resolve every cached index to an entity ON DEMAND via the
+		// readerMu-guarded LabelIndex.at (Reader base + overlay side-table). The
+		// returned map is transient — the caller drops it, so no entity stays
+		// resident. A retired mapping falls back to the Doc inside at() (nil when
+		// Doc is emptied), never a read-after-munmap.
+		//
+		// This whole-map build materializes the ENTIRE entity set per call, so it
+		// is reserved for genuine iterate-many callers (lookup tables built across
+		// forEachEntity/forEachRelationship). Single/few-id callers MUST use
+		// getByIDOne, which materializes exactly one entity.
+		out := make(map[string]*graph.Entity, len(lr.byIDIdx))
+		for id, i := range lr.byIDIdx {
+			if ent := lr.LabelIndex.at(i); ent != nil {
+				out[id] = ent
+			}
+		}
+		return out
+	}
+	return lr.byID
+}
+
+// getByIDOne resolves a SINGLE entity by id, materializing exactly one entity on
+// the flag-ON path (never the whole entity set) — the accessor for the single/
+// few-lookup callers (memory epic #5850 Path P). It returns (entity, true) when
+// present, (nil, false) when the id is unknown OR the mmap mapping was retired
+// out from under a lookup (at() returns nil). Byte-identical to today's
+// getByID()[id] / `_, ok := getByID()[id]` on the flag-OFF path.
+//
+// Flag-ON it looks up the resident int32 index cache (lr.byIDIdx, built/reused
+// under the same byIDOnce/idxMu as getByID) and resolves the ONE index via the
+// readerMu-guarded LabelIndex.at. Flag-OFF it indexes the memoized Doc-backed
+// map (lr.byID). Sharing byIDOnce means getByID and getByIDOne never build the
+// cache twice for a repo.
+func (lr *LoadedRepo) getByIDOne(id string) (*graph.Entity, bool) {
+	lr.idxMu.Lock()
+	defer lr.idxMu.Unlock()
+	lr.buildByIDCacheLocked()
+
+	if lr.byIDIdx != nil {
+		idx, ok := lr.byIDIdx[id]
+		if !ok {
+			return nil, false
+		}
+		ent := lr.LabelIndex.at(idx)
+		if ent == nil {
+			return nil, false // retired mapping / out-of-range — graceful miss
+		}
+		return ent, true
+	}
+	e, ok := lr.byID[id]
+	return e, ok
+}
+
+// buildByIDCacheLocked populates the reload-scoped getByID cache exactly once
+// (guarded by byIDOnce). Caller MUST hold idxMu. Flag-ON it builds lr.byIDIdx
+// (ID → vector index, NO entities retained); flag-OFF it builds the Doc-backed
+// lr.byID map. Shared by getByID and getByIDOne.
+func (lr *LoadedRepo) buildByIDCacheLocked() {
 	lr.byIDOnce.Do(func() {
+		mmapSourced := serveFromMMap() && lr.LabelIndex != nil && lr.LabelIndex.reader != nil
+		if mmapSourced {
+			// Learn ID → vector index once, retaining ONLY the int32 map. The
+			// LabelIndex already holds the exact ID → index mapping (built from the
+			// Reader in vector order); copy it into an independent resident cache so
+			// getByID's lifetime is decoupled from LabelIndex churn. No *graph.Entity
+			// is materialized or retained here.
+			idxMap := make(map[string]int32, len(lr.LabelIndex.byID))
+			for id, i := range lr.LabelIndex.byID {
+				idxMap[id] = i
+			}
+			lr.byIDIdx = idxMap
+			return
+		}
+		// Flag-OFF: memoize the Doc-backed *graph.Entity map (unchanged, PR2).
 		if lr.Doc == nil {
 			lr.byID = map[string]*graph.Entity{}
 			return
 		}
-		// ADR-0027: only when GRAFEL_SERVE_FROM_MMAP is ON does getByID source each
-		// row from the Reader + overlay side-table via LabelIndex.at (byte-equal to
-		// the overlaid Doc row), removing the Doc VALUE dependence. On the flag-off
-		// default path this stays the PR2 live-Doc heap copy — GC-safe, with NO
-		// handler-path mmap read. mmapSourced also short-circuits to the Doc copy
-		// whenever at() cannot serve an index (nil LabelIndex/Reader, JSON load).
-		mmapSourced := serveFromMMap() && lr.LabelIndex != nil && lr.LabelIndex.reader != nil
-		// PR6 (memory epic #5850 Path P): the loop BOUND is Reader-sourced on the
-		// mmap path — l.reader.EntityCount(), not len(lr.Doc.Entities) — so a PR7
-		// Doc-emptying (doc.Entities dropping to length 0 while the reader still
-		// holds every row) does not silently collapse getByID to an empty map.
-		// EntityCount() is a cached int set once at Reader construction, so it is
-		// safe to read here without readerMu (no mmap dereference). The flag-off
-		// path is unchanged: count stays len(lr.Doc.Entities).
-		count := len(lr.Doc.Entities)
-		if mmapSourced {
-			count = lr.LabelIndex.reader.EntityCount()
-		}
-		m := make(map[string]*graph.Entity, count)
-		for i := 0; i < count; i++ {
-			if mmapSourced {
-				if ent := lr.LabelIndex.at(int32(i)); ent != nil {
-					m[ent.ID] = ent
-					continue
-				}
-			}
-			if i < len(lr.Doc.Entities) {
-				ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
-				m[ent.ID] = &ent
-			}
+		m := make(map[string]*graph.Entity, len(lr.Doc.Entities))
+		for i := range lr.Doc.Entities {
+			ent := lr.Doc.Entities[i] // heap copy — a fresh pointer, not an alias into Doc
+			m[ent.ID] = &ent
 		}
 		lr.byID = m
 	})
-	return lr.byID
 }
 
 // hotIndexFor returns the memoized W1 (ADR-0027) hot index for this repo built

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -680,9 +680,8 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 			if qHave && len(qVec) == r.Semantic.Dims {
 				semIDs := r.Semantic.Search(qVec, 10)
 				semHits := make([]Hit, 0, len(semIDs))
-				byID := r.getByID()
 				for _, s := range semIDs {
-					if e, ok := byID[s.ID]; ok {
+					if e, ok := r.getByIDOne(s.ID); ok {
 						semHits = append(semHits, Hit{Entity: e, Score: s.Score, Source: "semantic"})
 					}
 				}
@@ -1028,7 +1027,7 @@ func pickFallback(repos []*LoadedRepo) *fallbackPick {
 		// Fast path: use pre-sorted cache (built lazily on first ranking use).
 		if topK := r.getTopKPageRank(); len(topK) > 0 {
 			topID := topK[0]
-			e := r.getByID()[topID]
+			e, _ := r.getByIDOne(topID)
 			if e == nil {
 				continue
 			}
@@ -1506,7 +1505,6 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, incl
 	}
 	out := []map[string]any{}
 	rels := lr.Doc.Relationships
-	byID := lr.getByID()
 	for _, ed := range lr.getAdjacency().Outgoing(e.ID) {
 		if !strings.EqualFold(ed.kind, "CALLS") {
 			continue
@@ -1520,7 +1518,7 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, incl
 			"target_path": "",
 		}
 		// Resolve target path from entity index.
-		if tgt := byID[ed.target]; tgt != nil {
+		if tgt, _ := lr.getByIDOne(ed.target); tgt != nil {
 			entry["target_path"] = tgt.SourceFile
 			entry["target"] = tgt.Name
 			if !scopeIsOne {
@@ -1626,7 +1624,6 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 
 	out := []map[string]any{}
 	rels := lr.Doc.Relationships
-	byID := lr.getByID()
 	for _, ed := range lr.getAdjacency().Incoming(e.ID) {
 		// #5686: besides direct CALLS callers, surface the async trigger of an
 		// event-driven handler. A DELIVERS_TO edge (topic → handler) is the
@@ -1640,7 +1637,7 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 			continue
 		}
 		callerID := ed.target // Incoming: ed.target is the FromID (the caller)
-		callerEntity := byID[callerID]
+		callerEntity, _ := lr.getByIDOne(callerID)
 
 		sourceID := callerID
 		sourcePath := ""

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -265,8 +265,8 @@ func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolReques
 		}
 		// #1656: O(1) lookup via cached ByID instead of an O(N) scan over
 		// every entity in the repo to find the entry point.
-		byID := r.getByID()
-		entryEnt := byID[target]
+		resolve := memoRepoResolver(r)
+		entryEnt := resolve(target)
 		if entryEnt == nil {
 			continue
 		}
@@ -284,7 +284,7 @@ func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolReques
 					"step_index": i,
 					"node_id":    prefID,
 				}
-				if e, ok := byID[id]; ok {
+				if e := resolve(id); e != nil {
 					step["name"] = e.Name
 					step["file"] = e.SourceFile
 					if e.StartLine > 0 {
@@ -336,22 +336,26 @@ type crossRepoLookup func(id string) (repoSlug string, e *graph.Entity)
 // handles bridge steps whose entities live elsewhere in the group.
 func buildGroupCrossRepoLookup(lg *LoadedGroup, seedRepo string) crossRepoLookup {
 	// Pre-collect companion repos in sorted order for determinism.
+	// Path P (#5850): hold the repo, NOT its whole entity map. This resolver is
+	// long-lived (returned to the caller); storing getByID() per companion would
+	// retain every companion repo's entire entity set on the flag-ON path. Each
+	// lookup materializes exactly one entity via getByIDOne instead.
 	type companion struct {
 		slug string
-		byID map[string]*graph.Entity
+		repo *LoadedRepo
 	}
 	var companions []companion
 	for slug, r := range lg.Repos {
 		if slug == seedRepo || r == nil || r.Doc == nil {
 			continue
 		}
-		companions = append(companions, companion{slug, r.getByID()})
+		companions = append(companions, companion{slug, r})
 	}
 	sort.Slice(companions, func(i, j int) bool { return companions[i].slug < companions[j].slug })
 
 	return func(id string) (string, *graph.Entity) {
 		for _, c := range companions {
-			if e, ok := c.byID[id]; ok {
+			if e, ok := c.repo.getByIDOne(id); ok {
 				return c.slug, e
 			}
 		}
@@ -388,7 +392,6 @@ func buildProcessSteps(r *LoadedRepo, proc *graph.Entity, verbose ...bool) []map
 func buildProcessStepsWithCrossRepo(r *LoadedRepo, proc *graph.Entity, crossRepo crossRepoLookup, verbose ...bool) []map[string]any {
 	wantVerbose := len(verbose) > 0 && verbose[0]
 	repo := r.Repo
-	byID := r.getByID()
 	type indexed struct {
 		idx int
 		id  string
@@ -416,7 +419,7 @@ func buildProcessStepsWithCrossRepo(r *LoadedRepo, proc *graph.Entity, crossRepo
 		// companion's slug for the prefixed id field, not the seed repo slug.
 		stepRepo := repo
 		var ent *graph.Entity
-		if e, ok := byID[o.id]; ok {
+		if e, ok := r.getByIDOne(o.id); ok {
 			ent = e
 		} else if crossRepo != nil {
 			// Not found in the seed repo — look across companion repos.


### PR DESCRIPTION
## What
Clears the SOLE remaining retention blocker for the mmap flip (Path P, #5870). `lr.byID` (`map[string]*graph.Entity`) would re-pin all 427k entities flag-ON on the first structural query after any reload (~608 MB), silently nullifying the flip.

- **`lr.byIDIdx map[string]int32`** — flag-ON cache holds ID→vector-index only, no `*graph.Entity`. Flag-OFF unchanged (memoized Doc-backed `lr.byID`).
- **`getByIDOne(id) (*graph.Entity, bool)`** — resolves a SINGLE index via `LabelIndex.at` (materializes exactly one entity), for the 62% of callers that need one/a-few. Whole-map `getByID()` reserved for the 16 genuine iterate-many sites.
- **`memoRepoResolver`** — per-call memoizing wrapper for bounded-walk callers (BFS/subgraph/filtered); nothing retained on `lr`.
- Migrated 29 single/few-lookup callers off the whole-map path (round-1 review found they'd otherwise materialize the whole repo — or group, inside per-repo loops — per query flag-ON). Also fixed a **cross-repo retention leak** at `traces.go` (a companion resolver stored whole maps in a long-lived closure).

## Tests (mutation-proven)
- `TestGetByIDOneSingleMaterialization_PathP` — `getByIDOne`→1 materialize vs `getByID()`→EntityCount(). (Route getByIDOne through whole-map → FAIL.)
- No-retention (`byIDIdx` int32, `byID` nil flag-ON), flag-on/off parity (incl. overlay), emptied-Doc resolution, reload-race (`-race`).

Independently opus-reviewed twice (round-1 quantified the perf blocker; round-2 APPROVE): all 29 migrations verified behavior-neutral site-by-site, memoResolver/leak-fix confirmed no new retention, signature change correct, flag-OFF byte-identical. `go test ./internal/mcp/...` 1200 pass, `-race` clean.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)