### PR TITLE
feat(mcp): mmap-cutover header-only loader — opt-in flip (ADR-0027 PR7)

### DIFF
--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -151,6 +151,28 @@ func LoadGraphFromDir(dir string) (*Document, error) {
 	}
 }
 
+// LoadGraphHeaderOnlyFromDir loads a HEADER-ONLY graph.Document from dir: all
+// meta/Stats/community/algo fields are populated but the Entities and
+// Relationships slices are left EMPTY (non-nil). It is the serve-side mmap-
+// cutover load path (ADR-0027 PR7, memory epic #5850, opt-in via
+// GRAFEL_SERVE_FROM_MMAP) — serve pairs the returned Doc with a resident
+// fbreader.Reader and serves every row from the mmap, so the ~608 MB of
+// entity/relationship rows is never materialized on the Go heap.
+//
+// Header-only is only meaningful for graph.fb (the mmap-backed format). When
+// only graph.json is present there is no mmap Reader to serve from, so this
+// falls back to the full LoadGraphFromDir (JSON) load — correctness over the
+// (absent) memory win. Callers that need a full Document (every CLI/full-Doc
+// consumer) must keep using LoadGraphFromDir.
+func LoadGraphHeaderOnlyFromDir(dir string) (*Document, error) {
+	fbPath := filepath.Join(dir, "graph.fb")
+	if _, err := os.Stat(fbPath); err == nil {
+		return loadFBDocumentHeaderOnly(fbPath)
+	}
+	// No graph.fb — no mmap to serve from; full load (graph.json or error).
+	return LoadGraphFromDir(dir)
+}
+
 // PersistedStats is a cheap, on-disk view of a repo's index size and
 // freshness, read from the graph.fb header WITHOUT materializing the
 // entity/relationship vectors. Used by the dashboard group overview and
@@ -266,7 +288,42 @@ func (si *stringInterner) intern(b []byte) string {
 // FlatBuffers view into an in-memory *Document by iterating the entity
 // and relationship vectors. This is O(N) but allocates far fewer
 // intermediate objects than JSON unmarshal.
+//
+// This is the SHARED full-materialize loader used by every full-Doc consumer
+// (CLI docgen/dashboard/links/status, xrepo-verify, group-algo, etc.). It is
+// NOT gated on any serve env flag and always returns a fully-populated
+// Document. The header-only serve variant lives in loadFBDocumentHeaderOnly.
 func loadFBDocument(path string) (*Document, error) {
+	return loadFBDoc(path, false)
+}
+
+// loadFBDocumentHeaderOnly decodes a graph.fb file into a *Document that
+// carries all header/meta/Stats/community/algo information but leaves the
+// Entities and Relationships slices EMPTY (non-nil, len 0).
+//
+// ADR-0027 mmap-cutover PR7 (memory epic #5850): this is the serve-side,
+// opt-in (GRAFEL_SERVE_FROM_MMAP) load path. serve opens its OWN resident
+// fbreader.Reader alongside this Doc and routes every read through the Reader
+// (forEachEntity/at/getByIDOne/BM25/adjacency/overlay), so the ~608 MB of
+// materialized entity/relationship rows is never allocated on the Go heap.
+// The Doc stays NON-NIL (the "loaded" sentinel every lazy getter checks) with
+// populated Stats counts so reporting reads the true entity/relationship
+// totals. It is NEVER called by the shared full-Doc CLI path.
+func loadFBDocumentHeaderOnly(path string) (*Document, error) {
+	return loadFBDoc(path, true)
+}
+
+// loadFBDoc is the shared core behind loadFBDocument (headerOnly=false, the
+// full-materialize path used by every CLI/full-Doc consumer) and
+// loadFBDocumentHeaderOnly (headerOnly=true, the serve mmap-cutover path).
+//
+// When headerOnly is true the two O(N) materialize loops that build the
+// Entities and Relationships slices are SKIPPED — the slices stay empty
+// (non-nil) — but meta, communities, AlgorithmStats and the Stats counts are
+// populated identically. Everything else is byte-identical to the full path,
+// so a full load and a header-only load of the same graph.fb agree on every
+// field except the (intentionally empty) Entities/Relationships slices.
+func loadFBDoc(path string, headerOnly bool) (*Document, error) {
 	r, err := fbreader.Open(path)
 	if err != nil {
 		return nil, fmt.Errorf("graph.loadFBDocument: open %s: %w", path, err)
@@ -293,22 +350,36 @@ func loadFBDocument(path string) (*Document, error) {
 	// the same backing array as the entity ids they reference.
 	si := newStringInterner()
 
-	entities := make([]Entity, 0, nEnts)
-	for i := 0; i < nEnts; i++ {
-		fbEnt := r.EntityAt(i)
-		if fbEnt == nil {
-			continue
-		}
-		entities = append(entities, fbEntityToGraphEntity(fbEnt, si))
+	// Header-only: leave Entities/Relationships EMPTY (non-nil) and allocate no
+	// per-record backing array. serve serves these rows from its resident mmap
+	// Reader; the ~608 MB heap materialization is exactly what we are dropping.
+	entCap := nEnts
+	relCap := nRels
+	if headerOnly {
+		entCap = 0
+		relCap = 0
 	}
 
-	rels := make([]Relationship, 0, nRels)
-	for i := 0; i < nRels; i++ {
-		fbRel := r.RelationshipAt(i)
-		if fbRel == nil {
-			continue
+	entities := make([]Entity, 0, entCap)
+	if !headerOnly {
+		for i := 0; i < nEnts; i++ {
+			fbEnt := r.EntityAt(i)
+			if fbEnt == nil {
+				continue
+			}
+			entities = append(entities, fbEntityToGraphEntity(fbEnt, si))
 		}
-		rels = append(rels, fbRelToGraphRel(fbRel, si))
+	}
+
+	rels := make([]Relationship, 0, relCap)
+	if !headerOnly {
+		for i := 0; i < nRels; i++ {
+			fbRel := r.RelationshipAt(i)
+			if fbRel == nil {
+				continue
+			}
+			rels = append(rels, fbRelToGraphRel(fbRel, si))
+		}
 	}
 
 	// Restore the aggregate Pass-4 community list + corpus stats (#1620).
@@ -327,6 +398,18 @@ func loadFBDocument(path string) (*Document, error) {
 		}
 	}
 
+	// Stats reports the record counts. On the full path use len(entities)/
+	// len(rels) (byte-identical to before; may differ from nEnts/nRels if a
+	// vector slot decoded to nil and was skipped). Header-only skips the loops,
+	// so source the counts straight off the Reader header — reporting
+	// (len(lr.Doc.Entities) is 0 header-only) reads Stats for the true totals.
+	statsEnts := len(entities)
+	statsRels := len(rels)
+	if headerOnly {
+		statsEnts = nEnts
+		statsRels = nRels
+	}
+
 	doc := &Document{
 		// Preserve SchemaVersion (JSON schema = 1) rather than the FB
 		// binary format version (2) so callers that check Version == 1
@@ -338,8 +421,8 @@ func loadFBDocument(path string) (*Document, error) {
 		Relationships: rels,
 		Communities:   communities,
 		Stats: Stats{
-			Entities:      len(entities),
-			Relationships: len(rels),
+			Entities:      statsEnts,
+			Relationships: statsRels,
 		},
 		// Phase 0 git metadata (#2088). Defaults to "" / false for graphs
 		// written before these fields were added.

--- a/internal/mcp/membaseline_test.go
+++ b/internal/mcp/membaseline_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
 // rssFromPS reads the current process RSS via `ps -o rss= -p <pid>`, which
@@ -194,6 +195,150 @@ func TestMemBaseline(t *testing.T) {
 	t.Logf("  bytes / record  (resident)  : %.1f", perRecordInuse)
 	t.Logf("  bytes / record  (on-disk)   : %.1f", perRecordOnDisk)
 	t.Logf("  resident / on-disk inflation: %.2fx", inflation)
+}
+
+// warmServedRepo warms a served LoadedRepo the same way TestMemBaseline /
+// reloadLocked do — eager LabelIndex plus every lazy derived index (byID,
+// adjacency, calls/step adjacency, top-K PageRank, BM25) — so the measured
+// footprint reflects a fully-warmed served repo, not a cold one. It is used by
+// the flag-OFF/flag-ON cutover measurement below. The caller keeps lr alive
+// across the measurement.
+func warmServedRepo(lr *LoadedRepo) {
+	_ = lr.getByID()
+	_ = lr.getAdjacency()
+	_ = lr.getCallsAdj()
+	_ = lr.getStepAdj()
+	_ = lr.getTopKPageRank()
+	_ = lr.getBM25().Search("order handler request customer processor", 10)
+}
+
+// TestMemBaselineMMapCutover is the load-bearing PR7 measurement: it warms a
+// served repo over the SAME graph.fb in BOTH modes and reports the resident
+// (no query load) delta.
+//
+//	flag-OFF : full graph.Document materialized (~608 MB of entity/rel rows on
+//	           the Go heap) + resident Reader + all served indexes — the current
+//	           baseline.
+//	flag-ON  : HEADER-ONLY Document (empty Entities/Relationships) + resident
+//	           Reader + all served indexes — the target. The mmap Reader pages
+//	           are disk-backed (RSS, not Go heap), so the Doc materialization is
+//	           dropped from HeapInuse/HeapAlloc.
+//
+// It measures HeapInuse/HeapAlloc (after forced GCs) with NO query load beyond
+// the single index-warming pass, so the number is the RESIDENT footprint of the
+// graph, not a query-time peak. Gated behind GRAFEL_MEM_BASELINE_FB like the
+// other seams; point it at the corpus graph.fb via:
+//
+//	GRAFEL_MEM_BASELINE_FB=$(ls -d ~/.grafel/store/*monorepos-main-*/refs/main/graph.fb) \
+//	  go test ./internal/mcp/ -run TestMemBaselineMMapCutover -v -count=1 -timeout 30m
+func TestMemBaselineMMapCutover(t *testing.T) {
+	fbPath := os.Getenv("GRAFEL_MEM_BASELINE_FB")
+	if fbPath == "" {
+		t.Skip("set GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb to run the mmap-cutover resident-memory delta")
+	}
+	fi, err := os.Stat(fbPath)
+	if err != nil {
+		t.Fatalf("stat graph.fb: %v", err)
+	}
+	if fi.IsDir() {
+		fbPath = filepath.Join(fbPath, "graph.fb")
+		if fi, err = os.Stat(fbPath); err != nil {
+			t.Fatalf("stat graph.fb in dir: %v", err)
+		}
+	}
+	onDisk := uint64(fi.Size())
+	stateDir := filepath.Dir(fbPath)
+
+	readHeap := func() (inuse, alloc uint64) {
+		runtime.GC()
+		runtime.GC()
+		var m runtime.MemStats
+		runtime.ReadMemStats(&m)
+		return m.HeapInuse, m.HeapAlloc
+	}
+
+	// measure runs one mode start-to-finish in its OWN scope so the previous
+	// mode's Doc/indexes are unreferenced (and reclaimed by the settling GCs)
+	// before the next mode is built — the two modes never coexist on the heap.
+	measure := func(headerOnly bool) (inuse, alloc, rss uint64, nEnt, nRel int) {
+		baseInuse, baseAlloc := readHeap()
+
+		var doc *graph.Document
+		if headerOnly {
+			doc, err = graph.LoadGraphHeaderOnlyFromDir(stateDir)
+		} else {
+			doc, err = graph.LoadGraphFromDir(stateDir)
+		}
+		if err != nil {
+			t.Fatalf("load (headerOnly=%v): %v", headerOnly, err)
+		}
+		nEnt = doc.Stats.Entities
+		nRel = doc.Stats.Relationships
+
+		// Open the resident Reader (both modes hold it; it is the flag-ON data
+		// source and, flag-OFF, the S8 zero-copy reader a served repo also keeps).
+		r, rErr := fbreader.Open(fbPath)
+		if rErr != nil {
+			t.Fatalf("fbreader.Open: %v", rErr)
+		}
+		defer r.Close()
+
+		lr := &LoadedRepo{Repo: "corpus", Doc: doc, GraphFile: fbPath, Reader: r}
+		if headerOnly {
+			// Flag-ON wiring: Reader-sourced LabelIndex + published handle, as
+			// reloadLocked does when serveFromMMap() is on.
+			li := BuildLabelIndexFromReader(r, doc)
+			li.readerMu = &lr.readerMu
+			h := newMapHandle(r)
+			li.handle = h
+			lr.LabelIndex = li
+			lr.publishHandle(h)
+		} else {
+			lr.LabelIndex = BuildLabelIndex(doc)
+		}
+		warmServedRepo(lr)
+
+		inuse, alloc = readHeap()
+		rss = rssBytes(t)
+		runtime.KeepAlive(doc)
+		runtime.KeepAlive(lr)
+		return inuse - baseInuse, alloc - baseAlloc, rss, nEnt, nRel
+	}
+
+	// Flag-OFF (full Doc) FIRST, then Flag-ON (header-only). Toggle the package
+	// flag around each measurement so the getters take the correct path.
+	serveFromMMapEnabled = false
+	offInuse, offAlloc, offRSS, nEnt, nRel := measure(false)
+
+	serveFromMMapEnabled = true
+	onInuse, onAlloc, onRSS, _, _ := measure(true)
+
+	serveFromMMapEnabled = false // restore default for the rest of the suite
+
+	deltaInuse := int64(offInuse) - int64(onInuse)
+	deltaAlloc := int64(offAlloc) - int64(onAlloc)
+
+	t.Logf("=== ADR-0027 PR7 mmap-cutover resident-memory delta (numbers only) ===")
+	t.Logf("on-disk graph.fb bytes        : %d (%.1f MB)", onDisk, mbf(onDisk))
+	t.Logf("entities / relationships      : %d / %d", nEnt, nRel)
+	t.Logf("--- flag-OFF (full Doc materialized) resident above process base ---")
+	t.Logf("  HeapInuse                   : %d (%.1f MB)", offInuse, mbf(offInuse))
+	t.Logf("  HeapAlloc                   : %d (%.1f MB)", offAlloc, mbf(offAlloc))
+	if offRSS > 0 {
+		t.Logf("  process RSS (warmed)        : %.1f MB", mbf(offRSS))
+	}
+	t.Logf("--- flag-ON (header-only Doc + resident Reader) resident above base ---")
+	t.Logf("  HeapInuse                   : %d (%.1f MB)", onInuse, mbf(onInuse))
+	t.Logf("  HeapAlloc                   : %d (%.1f MB)", onAlloc, mbf(onAlloc))
+	if onRSS > 0 {
+		t.Logf("  process RSS (warmed)        : %.1f MB", mbf(onRSS))
+	}
+	t.Logf("--- HEADLINE: resident Go-heap saved by the flip (OFF - ON) ---")
+	t.Logf("  HeapInuse saved             : %d (%.1f MB)", deltaInuse, float64(deltaInuse)/(1024*1024))
+	t.Logf("  HeapAlloc saved             : %d (%.1f MB)", deltaAlloc, float64(deltaAlloc)/(1024*1024))
+	if nEnt+nRel > 0 {
+		t.Logf("  saved / record (HeapInuse)  : %.1f bytes", float64(deltaInuse)/float64(nEnt+nRel))
+	}
 }
 
 // TestMemBaselineBM25Eviction is the measurement seam for the BM25-evictable

--- a/internal/mcp/mmap_cutover_flip_pr7_test.go
+++ b/internal/mcp/mmap_cutover_flip_pr7_test.go
@@ -1,0 +1,296 @@
+package mcp
+
+// ADR-0027 mmap-cutover PR7 (memory epic #5850): the opt-in flip.
+//
+// These tests prove that a HEADER-ONLY loaded Document (Entities/Relationships
+// left empty) paired with a resident fbreader.Reader serves reads END-TO-END
+// byte-identically to the full-Doc (flag-OFF) path — i.e. the whole read
+// surface (getByIDOne / forEachEntity / LabelIndex ByID+Lookup / adjacency /
+// BM25 / topK PageRank / overlay field) routes through the Reader and never
+// silently collapses to the (now empty) Doc slices. This is the correctness
+// proof behind the flip; the perf follow-up (by-Kind indexed scanners) is a
+// SEPARATE PR.
+
+import (
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeSyntheticFB writes a synthetic graph.fb (buildSyntheticDoc) to a temp
+// dir and returns the dir and the graph.fb path.
+func writeSyntheticFB(t *testing.T, nEnt int) (dir, fbPath string) {
+	t.Helper()
+	dir = t.TempDir()
+	fbPath = filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, buildSyntheticDoc(nEnt)); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	return dir, fbPath
+}
+
+// TestLoadGraphHeaderOnlyFromDir_ShapeAndCounts pins the header-only contract:
+// the returned Document is non-nil (the "loaded" sentinel), its Entities and
+// Relationships slices are EMPTY, yet Stats carries the true record counts read
+// off the graph.fb header — and every other field matches a full load.
+func TestLoadGraphHeaderOnlyFromDir_ShapeAndCounts(t *testing.T) {
+	dir, _ := writeSyntheticFB(t, 500)
+
+	full, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	hdr, err := graph.LoadGraphHeaderOnlyFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphHeaderOnlyFromDir: %v", err)
+	}
+
+	if hdr == nil {
+		t.Fatal("header-only Doc is nil — it MUST stay non-nil (the loaded sentinel)")
+	}
+	if len(hdr.Entities) != 0 {
+		t.Fatalf("header-only Entities len=%d, want 0 (empty slice)", len(hdr.Entities))
+	}
+	if len(hdr.Relationships) != 0 {
+		t.Fatalf("header-only Relationships len=%d, want 0 (empty slice)", len(hdr.Relationships))
+	}
+	// Stats carries the TRUE counts (sourced from the header), matching a full load.
+	if hdr.Stats.Entities != full.Stats.Entities {
+		t.Errorf("header-only Stats.Entities=%d, want %d (full)", hdr.Stats.Entities, full.Stats.Entities)
+	}
+	if hdr.Stats.Relationships != full.Stats.Relationships {
+		t.Errorf("header-only Stats.Relationships=%d, want %d (full)", hdr.Stats.Relationships, full.Stats.Relationships)
+	}
+	if hdr.Stats.Entities != len(full.Entities) {
+		t.Errorf("header-only Stats.Entities=%d, want full materialized count %d", hdr.Stats.Entities, len(full.Entities))
+	}
+	// Meta/version parity.
+	if hdr.Version != full.Version || hdr.Repo != full.Repo || !hdr.GeneratedAt.Equal(full.GeneratedAt) {
+		t.Errorf("header-only meta mismatch: version %d/%d repo %q/%q genAt %v/%v",
+			hdr.Version, full.Version, hdr.Repo, full.Repo, hdr.GeneratedAt, full.GeneratedAt)
+	}
+}
+
+// newHeaderOnlyReaderRepo builds the flag-ON served-repo shape: a HEADER-ONLY
+// Document (empty Entities/Relationships) paired with a resident Reader, its
+// Reader-sourced LabelIndex, and a published MapHandle — exactly how
+// reloadLocked wires a repo when serveFromMMap() is on.
+func newHeaderOnlyReaderRepo(t *testing.T, dir, fbPath string) *LoadedRepo {
+	t.Helper()
+	hdr, err := graph.LoadGraphHeaderOnlyFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphHeaderOnlyFromDir: %v", err)
+	}
+	if len(hdr.Entities) != 0 {
+		t.Fatalf("header-only Doc unexpectedly materialized %d entities", len(hdr.Entities))
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+
+	lr := &LoadedRepo{Repo: "corpus", Doc: hdr, GraphFile: fbPath, Reader: r}
+	li := BuildLabelIndexFromReader(r, hdr)
+	li.readerMu = &lr.readerMu
+	h := newMapHandle(r)
+	li.handle = h
+	lr.LabelIndex = li
+	lr.publishHandle(h)
+	return lr
+}
+
+// newFullDocRepo builds the flag-OFF reference: a fully materialized Document
+// with a Doc-sourced LabelIndex.
+func newFullDocRepo(t *testing.T, dir string) *LoadedRepo {
+	t.Helper()
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc}
+	lr.LabelIndex = BuildLabelIndex(doc)
+	return lr
+}
+
+// TestMMapCutoverFlip_ReadParity_PR7 is the end-to-end correctness proof: with
+// GRAFEL_SERVE_FROM_MMAP ON and a header-only Doc + resident Reader, every read
+// primitive returns the SAME answer as the flag-OFF full-Doc path over the same
+// graph.fb. If any read silently fell back to the (empty) header-only Doc, its
+// flag-ON result would be empty/nil and diverge here.
+func TestMMapCutoverFlip_ReadParity_PR7(t *testing.T) {
+	const nEnt = 600
+	dir, fbPath := writeSyntheticFB(t, nEnt)
+
+	// --- Flag-OFF reference (full Doc). ---
+	withServeFromMMap(t, false)
+	off := newFullDocRepo(t, dir)
+
+	// --- Flag-ON subject (header-only Doc + resident Reader). ---
+	withServeFromMMap(t, true)
+	on := newHeaderOnlyReaderRepo(t, dir, fbPath)
+
+	wantCount := int(on.Reader.EntityCount())
+	if wantCount != len(off.Doc.Entities) {
+		t.Fatalf("fixture sanity: reader EntityCount=%d != full doc entity count=%d", wantCount, len(off.Doc.Entities))
+	}
+
+	// (1) getByIDOne — single-materialize accessor.
+	for _, id := range []string{"ent-000000", "ent-000123", "ent-000599"} {
+		onE, onOK := on.getByIDOne(id)
+		offE, offOK := off.getByIDOne(id)
+		if onOK != offOK {
+			t.Fatalf("getByIDOne(%q) ok mismatch: on=%v off=%v", id, onOK, offOK)
+		}
+		if !onOK {
+			continue
+		}
+		if onE.ID != offE.ID || onE.Name != offE.Name || onE.QualifiedName != offE.QualifiedName ||
+			onE.Kind != offE.Kind || onE.SourceFile != offE.SourceFile {
+			t.Errorf("getByIDOne(%q) mismatch:\n on = %+v\n off= %+v", id, onE, offE)
+		}
+	}
+	if _, ok := on.getByIDOne("does-not-exist"); ok {
+		t.Error("getByIDOne(missing) flag-ON returned ok=true")
+	}
+
+	// (2) forEachEntity count == reader EntityCount().
+	onN := 0
+	on.forEachEntity(func(*graph.Entity) bool { onN++; return true })
+	if onN != wantCount {
+		t.Errorf("flag-ON forEachEntity counted %d, want EntityCount=%d", onN, wantCount)
+	}
+	offN := 0
+	off.forEachEntity(func(*graph.Entity) bool { offN++; return true })
+	if onN != offN {
+		t.Errorf("forEachEntity count mismatch: on=%d off=%d", onN, offN)
+	}
+
+	// (3) LabelIndex ByID + Lookup.
+	for _, id := range []string{"ent-000010", "ent-000400"} {
+		onE := on.LabelIndex.ByID(id)
+		offE := off.LabelIndex.ByID(id)
+		if onE == nil || offE == nil {
+			t.Fatalf("LabelIndex.ByID(%q): on=%v off=%v", id, onE, offE)
+		}
+		if onE.ID != offE.ID || onE.Name != offE.Name {
+			t.Errorf("LabelIndex.ByID(%q) mismatch: on=%+v off=%+v", id, onE, offE)
+		}
+		// Lookup by (unique) qualified name resolves to the same entity.
+		onL := on.LabelIndex.Lookup(offE.QualifiedName)
+		if onL == nil || onL.ID != offE.ID {
+			t.Errorf("LabelIndex.Lookup(%q): on=%v want id=%q", offE.QualifiedName, onL, offE.ID)
+		}
+	}
+
+	// (4) adjacency / expand — outgoing neighbor sets must match.
+	onAdj := on.getAdjacency()
+	offAdj := off.getAdjacency()
+	for _, id := range []string{"ent-000000", "ent-000050", "ent-000300"} {
+		onTargets := sortedEdgeTargets(onAdj.Outgoing(id))
+		offTargets := sortedEdgeTargets(offAdj.Outgoing(id))
+		if !reflect.DeepEqual(onTargets, offTargets) {
+			t.Errorf("adjacency Outgoing(%q) mismatch:\n on = %v\n off= %v", id, onTargets, offTargets)
+		}
+	}
+
+	// (5) BM25 search — same ranked entity IDs.
+	query := "handleOrderRequest customer processor kafka fulfilment pipeline"
+	onHits := hitIDs(on.getBM25().Search(query, 10))
+	offHits := hitIDs(off.getBM25().Search(query, 10))
+	if !reflect.DeepEqual(onHits, offHits) {
+		t.Errorf("BM25 search mismatch:\n on = %v\n off= %v", onHits, offHits)
+	}
+	if len(onHits) == 0 {
+		t.Error("BM25 search returned no hits flag-ON — index likely built from the empty Doc")
+	}
+	// The flag-ON BM25 index must have been built FROM the Reader (one slot per row).
+	if on.BM25 == nil || on.BM25.resolve == nil {
+		t.Error("flag-ON getBM25 produced no resolver — not built from the Reader")
+	} else if len(on.BM25.entities) != wantCount {
+		t.Errorf("flag-ON BM25 entities len=%d, want reader EntityCount=%d", len(on.BM25.entities), wantCount)
+	}
+
+	// (6) getTopKPageRank — same ordered id list (identical input order + algo).
+	onTopK := on.getTopKPageRank()
+	offTopK := off.getTopKPageRank()
+	if !reflect.DeepEqual(onTopK, offTopK) {
+		t.Errorf("getTopKPageRank mismatch:\n on = %v\n off= %v", onTopK, offTopK)
+	}
+	if len(onTopK) == 0 {
+		t.Error("getTopKPageRank returned empty flag-ON")
+	}
+}
+
+// TestMMapCutoverFlip_OverlayFieldRead_PR7 proves an overlay field (PageRank/
+// CommunityID) stamped into the flag-ON LabelIndex side-table is read back
+// through the Reader-materialized accessors (getByIDOne / forEachEntity),
+// byte-identical to the same overlay stamped onto a full-Doc row flag-OFF.
+func TestMMapCutoverFlip_OverlayFieldRead_PR7(t *testing.T) {
+	const nEnt = 200
+	dir, fbPath := writeSyntheticFB(t, nEnt)
+	const targetIdx = 42
+	targetID := "ent-000042"
+	wantPR := 0.875
+	wantCID := 7
+
+	// --- Flag-OFF: overlay stamped directly onto the Doc row. ---
+	withServeFromMMap(t, false)
+	off := newFullDocRepo(t, dir)
+	for i := range off.Doc.Entities {
+		if off.Doc.Entities[i].ID == targetID {
+			off.Doc.Entities[i].PageRank = &wantPR
+			off.Doc.Entities[i].CommunityID = &wantCID
+		}
+	}
+
+	// --- Flag-ON: overlay carried in the LabelIndex side-table. ---
+	withServeFromMMap(t, true)
+	on := newHeaderOnlyReaderRepo(t, dir, fbPath)
+	on.LabelIndex.overlay = map[int32]entityOverlay{
+		targetIdx: {PageRank: &wantPR, CommunityID: &wantCID},
+	}
+
+	onE, ok := on.getByIDOne(targetID)
+	if !ok {
+		t.Fatalf("getByIDOne(%q) flag-ON not found", targetID)
+	}
+	offE, ok := off.getByIDOne(targetID)
+	if !ok {
+		t.Fatalf("getByIDOne(%q) flag-OFF not found", targetID)
+	}
+	if onE.PageRank == nil || offE.PageRank == nil || *onE.PageRank != *offE.PageRank {
+		t.Errorf("overlay PageRank mismatch: on=%v off=%v", onE.PageRank, offE.PageRank)
+	}
+	if onE.CommunityID == nil || offE.CommunityID == nil || *onE.CommunityID != *offE.CommunityID {
+		t.Errorf("overlay CommunityID mismatch: on=%v off=%v", onE.CommunityID, offE.CommunityID)
+	}
+
+	// The same overlay field must also surface through a forEachEntity scan.
+	var scanned *graph.Entity
+	on.forEachEntity(func(e *graph.Entity) bool {
+		if e.ID == targetID {
+			cp := *e
+			scanned = &cp
+			return false
+		}
+		return true
+	})
+	if scanned == nil || scanned.PageRank == nil || *scanned.PageRank != wantPR {
+		t.Errorf("forEachEntity overlay PageRank read: got %v, want %v", scanned, wantPR)
+	}
+}
+
+func sortedEdgeTargets(edges []edge) []string {
+	out := make([]string, 0, len(edges))
+	for _, e := range edges {
+		out = append(out, e.target)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -119,6 +119,38 @@ func setupSideTableParity(t *testing.T) (st *State, overlayPath string, cur map[
 	return st, overlayPath, cur, [3]string{"svc:Alpha", "svc:Bravo", "svc:Charlie"}
 }
 
+// overlaidGroundTruthByID reconstructs the flag-OFF "overlaid Doc" ground truth
+// for a repo whose in-memory Doc is HEADER-ONLY under the PR7 flip (empty
+// Entities, so it can no longer be the ground-truth source). It FULL-loads the
+// repo's graph.fb (base fields via the same fbEntityToGraphEntity path the
+// pre-flip flag-ON reload used) and stamps the 5 group-algo overlay fields from
+// ov byte-identically to applyGroupAlgoOverlay's in-place Doc stamp — so the
+// returned rows are exactly what lr.Doc.Entities held before the flip. This is
+// the value source the Reader+side-table read path must byte-match.
+func overlaidGroundTruthByID(t *testing.T, stateDir string, ov *groupalgo.Overlay) map[string]*graph.Entity {
+	t.Helper()
+	full, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("full load for ground truth: %v", err)
+	}
+	out := make(map[string]*graph.Entity, len(full.Entities))
+	for i := range full.Entities {
+		e := full.Entities[i]
+		if eo, has := ov.Results[e.ID]; has {
+			cid := eo.CommunityID
+			pr := eo.PageRank
+			cen := eo.Centrality
+			e.CommunityID = &cid
+			e.PageRank = &pr
+			e.Centrality = &cen
+			e.IsGodNode = eo.IsGodNode
+			e.IsArticulationPt = eo.IsArticulationPoint
+		}
+		out[e.ID] = &e
+	}
+	return out
+}
+
 // TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc is the mandatory
 // overlay-aware parity guard. It applies an overlay setting DISTINCT
 // CommunityID/PageRank/Centrality/god/articulation on two of three entities
@@ -163,12 +195,11 @@ func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
 		t.Fatalf("svc repo has nil LabelIndex")
 	}
 
-	// Ground truth: the overlaid live Doc rows (what today's queries return).
-	docByID := map[string]*graph.Entity{}
-	for i := range lr.Doc.Entities {
-		e := lr.Doc.Entities[i]
-		docByID[e.ID] = &e
-	}
+	// Ground truth: the overlaid Doc rows (what the flag-OFF path returns). Under
+	// the PR7 flip lr.Doc is header-only (empty), so rebuild the overlaid rows
+	// from a full load + the known overlay — byte-identical to the pre-flip
+	// in-place-stamped lr.Doc.Entities the Reader+side-table path must match.
+	docByID := overlaidGroundTruthByID(t, filepath.Dir(lr.GraphFile), ov)
 
 	byIDMap := lr.getByID()
 

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1673,6 +1673,17 @@ func (s *State) Close() {
 // readDocumentFromDir is a package var (not a plain func) so tests can wrap it
 // with a parse counter to assert the #3377 content-hash skip avoids reparsing.
 var readDocumentFromDir = func(stateDir string) (*graph.Document, error) {
+	// ADR-0027 mmap-cutover PR7 (memory epic #5850): when serving from mmap is
+	// enabled (opt-in, GRAFEL_SERVE_FROM_MMAP; DEFAULT OFF), load a HEADER-ONLY
+	// Document — meta/Stats/counts populated, Entities/Relationships left empty
+	// — because reloadLocked opens a resident fbreader.Reader right after this
+	// call and every read path (forEachEntity/at/getByIDOne/BM25/adjacency/
+	// overlay) serves from that Reader. The Doc stays non-nil (the "loaded"
+	// sentinel), so the ~608 MB entity/relationship materialization is dropped
+	// from the Go heap. DEFAULT OFF ⇒ full materialization, 100% unchanged.
+	if serveFromMMap() {
+		return graph.LoadGraphHeaderOnlyFromDir(stateDir)
+	}
 	return graph.LoadGraphFromDir(stateDir)
 }
 

--- a/internal/mcp/view_iter_test.go
+++ b/internal/mcp/view_iter_test.go
@@ -106,12 +106,12 @@ func TestForEachEntity_FlagOnParityWithOverlay(t *testing.T) {
 		t.Fatalf("svc repo not fully wired for mmap")
 	}
 
-	// Ground truth: overlaid Doc rows, by ID.
-	wantByID := map[string]*graph.Entity{}
-	for i := range lr.Doc.Entities {
-		e := lr.Doc.Entities[i]
-		wantByID[e.ID] = &e
-	}
+	// Ground truth: overlaid Doc rows, by ID. Under the PR7 flip lr.Doc is
+	// header-only (empty), so rebuild the overlaid rows from a full load + the
+	// known overlay — byte-identical to the pre-flip in-place-stamped
+	// lr.Doc.Entities the Reader+side-table forEachEntity scan must match.
+	wantByID := overlaidGroundTruthByID(t, filepath.Dir(lr.GraphFile), ov)
+	wantCount := int(lr.Reader.EntityCount())
 
 	var gotByID = map[string]*graph.Entity{}
 	count := 0
@@ -121,8 +121,8 @@ func TestForEachEntity_FlagOnParityWithOverlay(t *testing.T) {
 		return true
 	})
 
-	if count != len(lr.Doc.Entities) {
-		t.Fatalf("forEachEntity flag-on yielded %d entities, want %d", count, len(lr.Doc.Entities))
+	if count != wantCount {
+		t.Fatalf("forEachEntity flag-on yielded %d entities, want %d", count, wantCount)
 	}
 	for id, want := range wantByID {
 		got := gotByID[id]
@@ -433,7 +433,9 @@ func TestForEachEntity_RealReloadOverlayRestampRace(t *testing.T) {
 	if graphFile == "" {
 		t.Fatalf("lr.GraphFile empty — cannot drive a real reparse")
 	}
-	wantEnts := len(lr.Doc.Entities)
+	// Under the PR7 flip lr.Doc is header-only (empty), so the expected scan
+	// length is the resident Reader's row count, not len(lr.Doc.Entities).
+	wantEnts := int(lr.Reader.EntityCount())
 
 	stop := make(chan struct{})
 	var faults atomic.Int64


### PR DESCRIPTION
## What
ADR-0027 PR7 — the mmap-cutover flip, **OPT-IN (default OFF, production unchanged)**. When `GRAFEL_SERVE_FROM_MMAP` is set, serve loads a **header-only** `graph.Document` (non-nil, empty Entities/Relationships, populated meta/Stats/counts) and serves all reads from the already-resident mmap `fbreader.Reader`. Every read path (forEach/at/getByIDOne/BM25-from-Reader/overlay/adjacency/topK) was wired for this in the preceding PRs.

- `graph/load.go`: shared `loadFBDoc(path, headerOnly)`; `loadFBDocument` = full (byte-identical, all 60+ CLI/dashboard/docgen callers untouched); new `loadFBDocumentHeaderOnly` skips the two materialize loops.
- `state.go`: serve's `readDocumentFromDir` uses the header-only path ONLY when `serveFromMMap()`.

## Measured (corpus, same harness, no query load)
`TestMemBaselineMMapCutover`: flag-OFF **1114.5 MB** HeapInuse → flag-ON **427.9 MB** → **−686.5 MB Go heap** (628 MB HeapAlloc). The entity data moves from pinned Go heap to disk-backed, OS-reclaimable mmap page cache.

**Honest caveat:** in the fully-warmed measurement (all pages faulted) process RSS is *higher* flag-ON (1896 vs 1540 MB) — the win is Go-heap/GC-pressure reduction + reclaimability, not a raw fully-warmed-RSS drop. Realistic partial-access RSS and the default-on decision are deferred to a follow-up measurement (paired with the by-Kind perf gate + eviction).

## Correctness
`mmap_cutover_flip_pr7_test.go`: flag-ON header-only + resident Reader, all reads (getByIDOne, forEachEntity==EntityCount, LabelIndex, adjacency, BM25 search, topK, overlay) byte-identical vs flag-OFF. 3 pre-flip parity guards rerouted to full-load-derived ground truth (Doc now empty by design) — mutation-verified NOT weakened (readerMu revert still races; overlay break still fails).

Independently opus-reviewed (APPROVE): guards mutation-proven intact, measurement re-run, shared loader byte-identical, default OFF confirmed. `go test ./internal/graph/... ./internal/mcp/...` all pass, `-race` clean.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)