### PR TITLE
feat(mcp): EvictGroup primitive — per-group whole-graph reclamation (#5872 PR1)

### DIFF
--- a/internal/mcp/evict_group_5872_test.go
+++ b/internal/mcp/evict_group_5872_test.go
@@ -1,0 +1,429 @@
+// evict_group_5872_test.go — tests for the per-group whole-graph eviction
+// PRIMITIVE (memory epic #5850, issue #5872 PR1): State.EvictGroup + the
+// reload cold-gate. No policy/LRU/knobs are exercised here — only the
+// primitive's swap-out + retireHandle + keepReader + cold-gate + Close drain.
+package mcp
+
+import (
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
+
+// entityIDs returns the sorted entity-ID set a repo currently resolves, used to
+// prove an evict-then-revive round-trip reconstructs the identical graph.
+func entityIDs(lr *LoadedRepo) []string {
+	ids := make([]string, 0)
+	for id := range lr.getByID() {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+// groupResident reports whether name is currently in s.groups (i.e. NOT evicted),
+// read under s.mu so it never races an eviction.
+func (s *State) groupResident(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.groups[name]
+	return ok
+}
+
+func (s *State) gated(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.evicted[name]
+	return ok
+}
+
+// Criterion 1 + 5: EvictGroup(g,false) removes the group from s.groups (heap
+// released to GC), and the next State.Group(g) re-loads it FROM DISK with the
+// identical entity set and working search.
+func TestEvictGroup_FullEvictThenAccessRematerializes(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+
+	before := entityIDs(lr)
+	if len(before) == 0 {
+		t.Fatal("fixture has no entities")
+	}
+
+	if !st.EvictGroup("test", false) {
+		t.Fatal("EvictGroup returned false for a resident group")
+	}
+	// Criterion 5: the group is gone from the resident registry (heap dropped).
+	if st.groupResident("test") {
+		t.Fatal("group still resident in s.groups after full evict")
+	}
+	if !st.gated("test") {
+		t.Fatal("group not recorded in the cold-gate after evict")
+	}
+
+	// Criterion 1: an explicit access re-materializes the group from disk.
+	grp := st.Group("test")
+	if grp == nil {
+		t.Fatal("Group returned nil after evict — revive failed")
+	}
+	if st.gated("test") {
+		t.Fatal("cold-gate not cleared after revive")
+	}
+	lr2 := grp.Repos["r"]
+	if lr2 == nil {
+		t.Fatal("revived group has no repo r")
+	}
+	after := entityIDs(lr2)
+	if len(after) != len(before) {
+		t.Fatalf("entity count changed across evict/revive: before=%d after=%d", len(before), len(after))
+	}
+	for i := range before {
+		if before[i] != after[i] {
+			t.Fatalf("entity set changed across evict/revive at %d: %q vs %q", i, before[i], after[i])
+		}
+	}
+	// Search must work against the freshly re-materialized index.
+	if hits := lr2.getBM25().Search("Proc", 10); len(hits) == 0 {
+		t.Error("BM25 search returned no hits after revive — index not rebuilt")
+	}
+}
+
+// Criterion 2: after an evict, a reload that is NOT targeting the group does NOT
+// resurrect it — it stays evicted until explicitly accessed.
+func TestEvictGroup_ReloadDoesNotResurrect(t *testing.T) {
+	doc := lazyTestDoc()
+	st, _, _ := seedRepoOnDisk(t, doc)
+
+	if !st.EvictGroup("test", false) {
+		t.Fatal("EvictGroup returned false")
+	}
+
+	// A plain reload (the per-call reloadBeforeCall hook drives exactly this) must
+	// leave the evicted group cold — no eager resurrection.
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if st.groupResident("test") {
+		t.Fatal("reload eagerly resurrected an evicted group")
+	}
+	if !st.gated("test") {
+		t.Fatal("reload cleared the cold-gate without an explicit access")
+	}
+
+	// Only an explicit access revives it.
+	if grp := st.Group("test"); grp == nil {
+		t.Fatal("explicit access did not revive the evicted group")
+	}
+}
+
+// Criterion 3: keepReader=true keeps the mmap RESIDENT (handle not retired,
+// no munmap); keepReader=false munmaps exactly once. Uses fake counting closers
+// so the retire behavior is asserted without a real mapping.
+func TestEvictGroup_KeepReaderControlsMunmap(t *testing.T) {
+	newState := func(cc readerCloser) (*State, *LoadedRepo) {
+		s := NewState(&Registry{Groups: map[string]RegistryGroup{
+			"g": {Repos: map[string]RegistryRepo{"r": {}}},
+		}})
+		lr := &LoadedRepo{Repo: "r"}
+		s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+		s.mu.Lock()
+		lr.publishHandle(&MapHandle{closer: cc})
+		s.mu.Unlock()
+		return s, lr
+	}
+
+	t.Run("keepReader keeps it mapped", func(t *testing.T) {
+		cc := &countingCloser{}
+		s, _ := newState(cc)
+		if !s.EvictGroup("g", true) {
+			t.Fatal("EvictGroup(keepReader) returned false")
+		}
+		if got := cc.n.Load(); got != 0 {
+			t.Fatalf("keepReader munmapped the reader: count=%d, want 0", got)
+		}
+		// The mapping lives on the cold shell, not retired.
+		s.mu.Lock()
+		shell := s.evicted["g"]
+		s.mu.Unlock()
+		if shell == nil {
+			t.Fatal("keepReader did not retain a cold shell")
+		}
+		lrShell := shell.Repos["r"]
+		if lrShell == nil || lrShell.handle == nil {
+			t.Fatal("cold shell dropped the handle")
+		}
+		if lrShell.handle.readRetired {
+			t.Error("cold shell handle marked readRetired under keepReader")
+		}
+	})
+
+	t.Run("full evict munmaps once", func(t *testing.T) {
+		cc := &countingCloser{}
+		s, _ := newState(cc)
+		if !s.EvictGroup("g", false) {
+			t.Fatal("EvictGroup returned false")
+		}
+		if got := cc.n.Load(); got != 1 {
+			t.Fatalf("full evict munmap count = %d, want 1", got)
+		}
+		s.mu.Lock()
+		shell := s.evicted["g"]
+		_, gated := s.evicted["g"]
+		s.mu.Unlock()
+		if !gated {
+			t.Fatal("full evict did not record the cold-gate")
+		}
+		if shell != nil {
+			t.Fatal("full evict retained a shell; want nil (fully cold)")
+		}
+	})
+}
+
+// Criterion 3 (real reader): keepReader keeps the SAME *fbreader.Reader mapped and
+// revive re-materializes the LabelIndex from it — no fbreader.Open, no disk read.
+func TestEvictGroup_KeepReaderSkipsReopen(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+
+	// Force a reparse so reloadLocked opens a real mmap Reader (seedRepoOnDisk
+	// primes mtime==file mtime, which the reload skips).
+	st.mu.Lock()
+	lr.mtime = time.Time{}
+	lr.contentHash = 0 // force a real reparse (bypass the no-op content-hash skip)
+	_, _, err := st.reloadAllLocked()
+	st.mu.Unlock()
+	if err != nil {
+		t.Fatalf("reload to open reader: %v", err)
+	}
+	readerPtr := lr.Reader
+	if readerPtr == nil {
+		t.Fatal("expected a resident mmap Reader after reparse")
+	}
+
+	if !st.EvictGroup("test", true) {
+		t.Fatal("EvictGroup(keepReader) returned false")
+	}
+	grp := st.Group("test")
+	if grp == nil {
+		t.Fatal("revive returned nil")
+	}
+	lr2 := grp.Repos["r"]
+	if lr2.Reader != readerPtr {
+		t.Errorf("keepReader revive re-Opened the reader: got %p want same %p (no re-Open expected)", lr2.Reader, readerPtr)
+	}
+	if lr2.LabelIndex == nil || !lr2.LabelIndex.HasID("a") {
+		t.Error("LabelIndex not re-materialized from the retained reader on revive")
+	}
+}
+
+// Criterion 4: evict under concurrent read — a reader hammering the group while
+// another goroutine evicts+revives it must not SIGBUS / nil-deref. Run under
+// -race. The in-flight reader holds its own repo pointer and finishes safely.
+func TestEvictGroup_ConcurrentReadNoFault(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+	// Open a real reader once so the read path exercises the mmap fallback under
+	// retire (Doc fallback on the flag-off default path).
+	st.mu.Lock()
+	lr.mtime = time.Time{}
+	lr.contentHash = 0
+	_, _, _ = st.reloadAllLocked()
+	st.mu.Unlock()
+
+	var faults atomic.Int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	// Readers: capture the group, then read derived state lock-free (exactly the
+	// production seam). A revive may have swapped the group out from under a prior
+	// capture; the captured pointers must still resolve without a fault.
+	for i := 0; i < 6; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				grp := st.Group("test")
+				if grp == nil {
+					continue // transiently mid-evict; revive on the next spin
+				}
+				r := grp.Repos["r"]
+				if r == nil {
+					faults.Add(1)
+					continue
+				}
+				_ = r.getByID()
+				_ = r.getBM25().Search("A", 5)
+				_ = r.getAdjacency()
+			}
+		}()
+	}
+
+	// Evictor: alternate full and keepReader evictions, reviving via Group.
+	go func() {
+		defer close(stop)
+		for i := 0; i < 400; i++ {
+			st.EvictGroup("test", i%2 == 0)
+			st.Group("test") // revive
+		}
+	}()
+
+	wg.Wait()
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("concurrent evict/read produced %d faults", f)
+	}
+}
+
+// Guard: EvictGroup on an unknown group is a no-op returning false, and does not
+// create a phantom cold-gate entry.
+func TestEvictGroup_UnknownGroupNoop(t *testing.T) {
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{}})
+	if st.EvictGroup("nope", false) {
+		t.Fatal("EvictGroup returned true for an unknown group")
+	}
+	if st.gated("nope") {
+		t.Fatal("EvictGroup gated an unknown group")
+	}
+}
+
+// Guard: a non-evicted group is completely untouched by EvictGroup activity on a
+// DIFFERENT group — no cross-group behavior change (the PR1 invariant).
+func TestEvictGroup_LeavesOtherGroupsUntouched(t *testing.T) {
+	a := lazyTestDoc()
+	a.Repo = "a"
+	b := lazyTestDoc()
+	b.Repo = "b"
+	srv := newTestServer(t, a) // group "test", repo "a"
+	st := srv.State
+	// Add a second in-memory group "other".
+	st.mu.Lock()
+	st.groups["other"] = &LoadedGroup{Name: "other", Repos: map[string]*LoadedRepo{
+		"b": {Repo: "b", Doc: b, LabelIndex: BuildLabelIndex(b)},
+	}}
+	st.mu.Unlock()
+
+	otherBefore := st.Group("other")
+	if !st.EvictGroup("test", false) {
+		t.Fatal("EvictGroup(test) returned false")
+	}
+	otherAfter := st.Group("other")
+	if otherBefore != otherAfter {
+		t.Fatal("evicting 'test' swapped the 'other' group pointer")
+	}
+	if !st.groupResident("other") {
+		t.Fatal("evicting 'test' disturbed residency of 'other'")
+	}
+	if _, ok := otherAfter.Repos["b"]; !ok {
+		t.Fatal("evicting 'test' mutated 'other' repos")
+	}
+}
+
+// TestEvictGroup_CloseDrainsKeptReaderShell proves Close() drains the mmap of a
+// kept-reader cold shell — the mapping lives on s.evicted (NOT s.groups), so the
+// Close loop over s.groups alone would leak it.
+//
+// MUTATION ORACLE: delete the `for _, g := range s.evicted { ... }` drain loop in
+// State.Close() → this test fails (munmap count 0, leaked mapping).
+func TestEvictGroup_CloseDrainsKeptReaderShell(t *testing.T) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{"r": {}}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+	cc := &countingCloser{}
+	s.mu.Lock()
+	lr.publishHandle(&MapHandle{closer: cc})
+	s.mu.Unlock()
+
+	if !s.EvictGroup("g", true) {
+		t.Fatal("EvictGroup(keepReader) returned false")
+	}
+	if got := cc.n.Load(); got != 0 {
+		t.Fatalf("keepReader munmapped before Close: count=%d, want 0", got)
+	}
+
+	s.Close()
+	if got := cc.n.Load(); got != 1 {
+		t.Fatalf("Close did not drain the kept-reader cold shell: munmap count=%d, want 1 (leaked mapping)", got)
+	}
+}
+
+// TestEvictGroup_ReviveKeepsOverlay proves a keepReader evict+revive preserves the
+// group-algo overlay. Flag-ON, so the overlay lives ONLY in the LabelIndex
+// side-table (dropped with the heap on evict) — the revive must re-apply it.
+//
+// MUTATION ORACLE: set the cold shell's algoApplied=true in EvictGroup (so revive
+// skips refreshGroupAlgoOverlayLocked's re-apply) → this test fails (overlay lost:
+// PageRank/CommunityID revert to the graph.fb sentinel).
+func TestEvictGroup_ReviveKeepsOverlay(t *testing.T) {
+	forceServeFromMMap(t, true)
+	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
+
+	ov := &groupalgo.Overlay{
+		Group:        "acme",
+		SourceMtimes: cur,
+		Results: map[string]groupalgo.EntityOverlay{
+			serviceID: {CommunityID: 42, PageRank: 0.77, Centrality: 0.5, IsGodNode: true},
+		},
+		Communities: []graph.CommunityResult{{ID: 42, Size: 1, AutoName: "core"}},
+	}
+	if err := groupalgo.WriteOverlayTo(overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+	if _, err := st.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	// Read the overlaid entity through the flag-ON path (LabelIndex.at merges the
+	// side-table); Doc is header-only under flag-ON so entityByID cannot be used.
+	svcRepo := func(grp *LoadedGroup) *LoadedRepo {
+		for _, lr := range grp.Repos {
+			if lr != nil {
+				if _, ok := lr.getByIDOne(serviceID); ok {
+					return lr
+				}
+			}
+		}
+		return nil
+	}
+
+	grp := st.Group("acme")
+	lr := svcRepo(grp)
+	if lr == nil {
+		t.Fatalf("%s not resolvable pre-evict", serviceID)
+	}
+	before, _ := lr.getByIDOne(serviceID)
+	if before.PageRank == nil || *before.PageRank != 0.77 || before.CommunityID == nil || *before.CommunityID != 42 {
+		t.Fatalf("overlay not applied pre-evict: pr=%v cid=%v", before.PageRank, before.CommunityID)
+	}
+
+	if !st.EvictGroup("acme", true) {
+		t.Fatal("EvictGroup(keepReader) returned false")
+	}
+	grp2 := st.Group("acme")
+	if grp2 == nil {
+		t.Fatal("revive returned nil")
+	}
+	lr2 := svcRepo(grp2)
+	if lr2 == nil {
+		t.Fatalf("%s not resolvable post-revive", serviceID)
+	}
+	after, _ := lr2.getByIDOne(serviceID)
+	if after.PageRank == nil || *after.PageRank != 0.77 {
+		t.Errorf("overlay PageRank lost across keepReader evict/revive: got %v want 0.77", after.PageRank)
+	}
+	if after.CommunityID == nil || *after.CommunityID != 42 {
+		t.Errorf("overlay CommunityID lost across keepReader evict/revive: got %v want 42", after.CommunityID)
+	}
+	if !after.IsGodNode {
+		t.Error("overlay IsGodNode lost across keepReader evict/revive")
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1012,6 +1012,21 @@ type State struct {
 	// that a cwd inside a linked worktree returns the worktree-specific entry.
 	worktreeLookup WorktreeLookup
 
+	// evicted is the per-group whole-graph LRU-eviction cold-gate (memory epic
+	// #5850, issue #5872 PR1). A group name present here has been reclaimed by
+	// EvictGroup and swapped OUT of s.groups; the gate keeps reloadAllLocked from
+	// eagerly resurrecting it before it is explicitly accessed again.
+	//
+	//   - value nil  → full evict (keepReader=false): the mmap was munmapped and
+	//     the whole heavy group dropped; revive reloads from disk.
+	//   - value !nil → keepReader evict: a lightweight COLD SHELL whose repos kept
+	//     their mmap Readers resident (LabelIndex/derived-index heap dropped);
+	//     revive re-materializes the heap from those Readers with no re-Open.
+	//
+	// Mutated only under s.mu. Nil until the first EvictGroup call. No policy
+	// lives here in PR1 — this is the eviction PRIMITIVE's bookkeeping only.
+	evicted map[string]*LoadedGroup
+
 	// CrossLinkCache is the ref-keyed in-memory cache for cross-repo link
 	// candidates (issue #2224). Keyed by (repoA, refA, repoB, refB); the
 	// secondary index allows O(affected-entries) invalidation on ref-switch.
@@ -1176,10 +1191,28 @@ func (s *State) ReloadAndSurfaceChanged() (int, bool, error) {
 func (s *State) reloadLocked() (int, bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.reloadAllLocked()
+}
+
+// reloadAllLocked is the reload body; the caller MUST already hold s.mu. Split
+// out of reloadLocked (memory epic #5850 PR1) so the eviction revive path can
+// reload from disk while already holding s.mu (Group -> reviveEvictedLocked)
+// without re-taking the lock.
+func (s *State) reloadAllLocked() (int, bool, error) {
 	prevSig := s.registrySignature
 	registryChanged := s.refreshRegistryFromDisk()
 	reloaded := 0
 	for gName, gEntry := range s.registry.Groups {
+		// Cold-gate (memory epic #5850, issue #5872 PR1): a group EvictGroup put
+		// in s.evicted is intentionally NOT resident. Skip it so reload does not
+		// eagerly resurrect every registered group before it is touched — an
+		// evicted group stays evicted until an explicit State.Group access revives
+		// it (reviveEvictedLocked). Without this gate the loop below would recreate
+		// the LoadedGroup and reload every repo from disk on the very next reload,
+		// defeating the eviction.
+		if _, gated := s.evicted[gName]; gated {
+			continue
+		}
 		grp, ok := s.groups[gName]
 		if !ok {
 			grp = &LoadedGroup{
@@ -1478,10 +1511,171 @@ func (s *State) Group(name string) *LoadedGroup {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	grp := s.groups[name]
+	if grp == nil {
+		// Cold-gate revive (memory epic #5850, issue #5872 PR1): a group EvictGroup
+		// reclaimed is absent from s.groups and pinned in s.evicted. An explicit
+		// access is exactly the "touch" that ends the eviction — bring it back on
+		// demand (re-materialize from the retained Reader, or reload from disk).
+		if cold, gated := s.evicted[name]; gated {
+			grp = s.reviveEvictedLocked(name, cold)
+		}
+	}
 	if grp != nil {
 		s.refreshGroupAlgoOverlayLocked(grp)
 	}
 	return grp
+}
+
+// EvictGroup reclaims the resident graph of group name — the per-group whole-graph
+// LRU-eviction PRIMITIVE (memory epic #5850, issue #5872 PR1). It is the clean
+// RSS-reclamation lever for an idle group in an agent fleet. Returns true when a
+// resident group was evicted, false when name was not resident.
+//
+// PR1 is the primitive + cold-gate ONLY — no policy, LRU bookkeeping, watermark,
+// or knobs, and no production caller (tests only). Those are PR2/PR3.
+//
+// Safety (the load-bearing part). The serve read path is lock-free: a handler that
+// already called State.Group holds its own *LoadedGroup / *LoadedRepo pointers and
+// dereferences their fields WITHOUT any lock. So eviction MUST NOT nil live fields
+// on a struct such a reader might still hold — instead it SWAPS the whole group out
+// of s.groups (delete below): new lookups miss immediately, existing holders finish
+// against the still-valid old struct, and the heavy heap is reclaimed by GC once
+// they drop it. The mmap is always released through the F1 retireHandle drain, never
+// a raw munmap, so an in-flight borrow drains first.
+//
+//   - keepReader=false → full evict: each repo's Reader is retired (munmapped via the
+//     safe drain) and the whole old group is discarded. A later access reloads the
+//     group from disk.
+//   - keepReader=true → keep the mmap mapped: a lightweight COLD SHELL takes over each
+//     repo's Reader/handle (transferred, NOT retired — the file stays mapped) while
+//     the heavy old group (LabelIndex + adjacency/BM25/byIDIdx/overlay/… heap) is
+//     dropped to GC. A later access re-materializes the heap from the already-mapped
+//     Readers with no fbreader.Open and no disk re-read.
+func (s *State) EvictGroup(name string, keepReader bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	grp := s.groups[name]
+	if grp == nil {
+		return false
+	}
+	// Swap the whole group out FIRST: new State.Group / borrowGroup lookups miss
+	// from here on, while any lock-free reader mid-handler keeps its own pointers.
+	delete(s.groups, name)
+	if s.evicted == nil {
+		s.evicted = map[string]*LoadedGroup{}
+	}
+
+	if !keepReader {
+		// Full evict: munmap every repo's mapping through the F1 drain (defers if a
+		// borrow is live) and drop the heavy group entirely. Revive reloads from disk.
+		for _, lr := range grp.Repos {
+			if lr != nil {
+				lr.retireHandle()
+			}
+		}
+		s.evicted[name] = nil
+		return true
+	}
+
+	// keepReader: transfer each repo's live mapping to a fresh cold shell that
+	// carries ONLY the fields a re-materialization needs; the heavy old group is
+	// left untouched (safe for in-flight readers) and becomes garbage. The mmap is
+	// NOT retired — it stays mapped, owned henceforth by the shell.
+	shell := &LoadedGroup{
+		Name:      grp.Name,
+		Repos:     make(map[string]*LoadedRepo, len(grp.Repos)),
+		Links:     grp.Links,
+		LinksFile: grp.LinksFile,
+		linksMt:   grp.linksMt,
+		MemoryDir: grp.MemoryDir,
+		// Overlay re-application is FORCED on revive (algoApplied=false) so the
+		// freshly rebuilt LabelIndex re-acquires its group-algo values / side-table.
+		algoFile: grp.algoFile,
+	}
+	for rName, lr := range grp.Repos {
+		if lr == nil {
+			continue
+		}
+		shell.Repos[rName] = coldShellRepo(lr)
+	}
+	s.evicted[name] = shell
+	return true
+}
+
+// coldShellRepo builds the keepReader cold-shell twin of lr: a fresh *LoadedRepo
+// that takes over lr's mmap Reader/handle and header/meta but carries NONE of the
+// dropped heap (LabelIndex nil, every lazy derived index zero). The mapping is
+// transferred (not retired), so a revive re-materializes the heap from it with no
+// fbreader.Open. The old lr is left fully intact for any lock-free reader still
+// holding it and is otherwise unreferenced (GC reclaims its heap); it has no
+// finalizer, so it never munmaps — only the shell (or a later full evict/Close)
+// ever retires the shared handle, and no borrow is outstanding on the dark read
+// path, so the transfer cannot double-free.
+func coldShellRepo(lr *LoadedRepo) *LoadedRepo {
+	return &LoadedRepo{
+		Repo:           lr.Repo,
+		Path:           lr.Path,
+		GraphFile:      lr.GraphFile,
+		Doc:            lr.Doc,
+		Reader:         lr.Reader,
+		handle:         lr.handle,
+		Semantic:       lr.Semantic,
+		semMtime:       lr.semMtime,
+		TestsEdgeCount: lr.TestsEdgeCount,
+		mtime:          lr.mtime,
+		contentHash:    lr.contentHash,
+		// algoStampedMt is PRESERVED (not zeroed): the graph did not reparse during
+		// eviction, so the per-repo overlay-staleness check must stay "not stale".
+		// The single load-bearing trigger that forces revive to re-apply the overlay
+		// (rebuilding the LabelIndex side-table dropped with the heap) is the shell
+		// group's algoApplied=false, set in EvictGroup — not a spurious stale mtime.
+		algoStampedMt: lr.algoStampedMt,
+	}
+}
+
+// reviveEvictedLocked ends the eviction of name and returns the now-resident group.
+// Caller MUST hold s.mu. cold is the s.evicted[name] value (nil for a full evict, a
+// cold shell for a keepReader evict).
+func (s *State) reviveEvictedLocked(name string, cold *LoadedGroup) *LoadedGroup {
+	delete(s.evicted, name)
+	if cold != nil {
+		// keepReader: re-materialize each repo's dropped heap from its retained,
+		// still-mapped Reader — no fbreader.Open, no disk re-read — then reinstall.
+		for _, lr := range cold.Repos {
+			if lr != nil {
+				lr.rematerializeFromReaderLocked()
+			}
+		}
+		s.groups[name] = cold
+		return cold
+	}
+	// Full evict: the group is gone from both maps and the gate is now clear, so
+	// reloadAllLocked recreates it and loads it from disk. Other still-gated groups
+	// stay skipped; already-resident groups mtime/hash-skip, so this is targeted.
+	_, _, _ = s.reloadAllLocked()
+	return s.groups[name]
+}
+
+// rematerializeFromReaderLocked rebuilds the heap indexes dropped by a keepReader
+// eviction from this repo's retained mmap Reader, mirroring reloadLocked's
+// LabelIndex wiring. Caller MUST hold s.mu. No fbreader.Open and no disk read: the
+// Reader is the same mapping the eviction kept resident. The lazy derived indexes
+// (adjacency/BM25/byID/…) are left for their getters to rebuild on first use
+// (resetIndexes re-arms the Once guards). The group-algo overlay side-table is
+// re-applied by the caller's refreshGroupAlgoOverlayLocked (forced via the shell's
+// algoApplied=false).
+func (lr *LoadedRepo) rematerializeFromReaderLocked() {
+	lr.readerMu.Lock()
+	if lr.Reader != nil {
+		li := BuildLabelIndexFromReader(lr.Reader, lr.Doc)
+		li.readerMu = &lr.readerMu
+		li.handle = lr.handle
+		lr.LabelIndex = li
+	} else {
+		lr.LabelIndex = BuildLabelIndex(lr.Doc)
+	}
+	lr.readerMu.Unlock()
+	lr.resetIndexes()
 }
 
 // groupBorrow is the immutable per-call snapshot returned by borrowGroup — the
@@ -1661,6 +1855,21 @@ func (s *State) Close() {
 				// drains before the mapping is unmapped — same munmap-while-borrowed
 				// hazard as reload/eviction. When nothing is borrowed (the common
 				// shutdown case) retire unmaps immediately, matching prior behavior.
+				lr.retireHandle()
+			}
+		}
+	}
+	// Drain kept-reader cold shells too (memory epic #5850, issue #5872 PR1). A
+	// keepReader EvictGroup leaves a group's mmap RESIDENT on a shell in s.evicted
+	// (not in s.groups), so the loop above would miss it and leak the mapping on
+	// shutdown. Retire each shell's handle through the same F1 drain. Full-evict
+	// entries are nil (already munmapped at eviction) and skipped.
+	for _, g := range s.evicted {
+		if g == nil {
+			continue
+		}
+		for _, lr := range g.Repos {
+			if lr != nil {
 				lr.retireHandle()
 			}
 		}


### PR DESCRIPTION
## What
PR1 of per-group whole-graph LRU eviction (#5872, epic #5850) — the `EvictGroup(name, keepReader) bool` PRIMITIVE (no policy/knobs yet). This is the clean RSS-reclamation lever for idle fleet groups: drop a group's entire resident graph on demand, revive on access.

- **Swap-out, never nil live fields:** `delete(s.groups, name)` first so new lookups miss while an in-flight lock-free reader finishes against its own GC-alive `*LoadedRepo`.
- **Safe munmap:** full-evict routes each repo through `retireHandle` (readRetired + munmap under `readerMu`, defers if a borrow is live) — the same substrate the reload race uses.
- **keepReader:** transfers the mmap Reader/handle to a lightweight `coldShellRepo` (keeps the mapping resident, drops LabelIndex/adjacency/BM25/byIDIdx/overlay heap); revive rebuilds the LabelIndex from the retained Reader (no re-Open, no disk read).
- **Cold-gate:** `reloadAllLocked` skips evicted names → no eager resurrection; `State.Group` revives on explicit access; `Close()` drains kept-reader shells (no leak).

## Tests (11, incl. mutation-proven oracles)
- Evict-under-concurrent-read (6 readers × 400 evict/revive) under `-race` — no fault. Mutation: raw munmap bypassing `readerMu` → DATA RACE.
- `Close()`-drain leak — mutation: remove drain → munmap count 0 (leak) FAIL.
- Revive-keeps-overlay (flag-ON) — mutation: `algoApplied=true` skips re-apply → PageRank/CommunityID lost FAIL.
- keepReader skips re-Open (same Reader pointer survives), no-eager-resurrection, cross-group untouched.

No production caller yet (test-only). Independently opus-reviewed (APPROVE); the 2 coverage gaps it flagged are now closed with the mutation oracles above.

**PR2 requirement (noted):** the LRU policy MUST pin the currently-querying group — flag-ON in-flight reads on an evicted group return empty.

Refs #5872

🤖 Generated with [Claude Code](https://claude.com/claude-code)