### PR TITLE
feat(mcp): idle-group LRU eviction policy + pin-active-group (#5872 PR2)

### DIFF
--- a/internal/mcp/idle_group_evict_5872_pr2_test.go
+++ b/internal/mcp/idle_group_evict_5872_pr2_test.go
@@ -1,0 +1,368 @@
+// idle_group_evict_5872_pr2_test.go — tests for the idle-group LRU eviction
+// POLICY (memory epic #5850, issue #5872 PR2): State.SweepIdleGroups (the
+// production wiring of the EvictGroup primitive), its active-group PIN, the
+// keepReader knob, the disabled=no-op contract, and its composition with the
+// BM25 idle sweep. Companion to evict_group_5872_test.go (the PR1 primitive).
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// seedGroupsOnDisk writes one repo per named group to disk (graph.fb under the
+// repo's daemon state dir, mtime/hash primed so reload is a no-op skip) and
+// returns a State with every group resident. Mirrors seedRepoOnDisk for the
+// multi-group case so an evict-then-revive round-trip can reconstruct from disk.
+func seedGroupsOnDisk(t *testing.T, docs map[string]*graph.Document) *State {
+	t.Helper()
+	regGroups := map[string]RegistryGroup{}
+	loaded := map[string]*LoadedGroup{}
+	for gname, doc := range docs {
+		repoDir := t.TempDir()
+		stateDir := daemon.StateDirForRepo(repoDir)
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+		fbPath := filepath.Join(stateDir, "graph.fb")
+		if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+			t.Fatalf("write fb: %v", err)
+		}
+		fi, err := os.Stat(fbPath)
+		if err != nil {
+			t.Fatalf("stat fb: %v", err)
+		}
+		hash, err := hashGraphFile(fbPath)
+		if err != nil {
+			t.Fatalf("hash fb: %v", err)
+		}
+		regGroups[gname] = RegistryGroup{Repos: map[string]RegistryRepo{"r": {Path: repoDir}}}
+		lr := &LoadedRepo{
+			Repo:        "r",
+			Path:        repoDir,
+			GraphFile:   fbPath,
+			Doc:         doc,
+			LabelIndex:  BuildLabelIndex(doc),
+			mtime:       fi.ModTime(),
+			contentHash: hash,
+		}
+		loaded[gname] = &LoadedGroup{Name: gname, Repos: map[string]*LoadedRepo{"r": lr}}
+	}
+	st := NewState(&Registry{Groups: regGroups})
+	st.mu.Lock()
+	for gname, lg := range loaded {
+		st.groups[gname] = lg
+	}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+	return st
+}
+
+// setLastAccess stamps a group's lastAccess under s.mu (the same lock the sweep
+// reads it under) so tests never race a torn timestamp.
+func setLastAccess(st *State, name string, at time.Time) {
+	st.mu.Lock()
+	st.groups[name].lastAccess = at
+	st.mu.Unlock()
+}
+
+// Criterion 1: a group idle past the window IS evicted by SweepIdleGroups; a
+// group accessed within the window is NOT.
+func TestSweepIdleGroups_EvictsIdleKeepsRecent(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"active": lazyTestDoc(),
+		"idle":   lazyTestDoc(),
+	})
+	window := 5 * time.Minute
+	now := time.Now()
+	// active: touched 1min ago (within window) AND the most recent → doubly safe.
+	setLastAccess(st, "active", now.Add(-1*time.Minute))
+	// idle: touched 10min ago (past window) and not the most recent → evictable.
+	setLastAccess(st, "idle", now.Add(-10*time.Minute))
+
+	n := st.SweepIdleGroups(window, true)
+	if n != 1 {
+		t.Fatalf("expected exactly 1 group evicted, got %d", n)
+	}
+	if !st.groupResident("active") {
+		t.Error("within-window group was evicted — must be kept")
+	}
+	if st.groupResident("idle") {
+		t.Error("past-window group was NOT evicted")
+	}
+	if !st.gated("idle") {
+		t.Error("evicted group not recorded in the cold-gate")
+	}
+	// Revive round-trip: an explicit access brings the idle group back.
+	if grp := st.Group("idle"); grp == nil {
+		t.Fatal("evicted group did not revive on access")
+	}
+}
+
+// Criterion 2 (the CRUX): the active group — the max-lastAccess group the fleet
+// is servicing RIGHT NOW — is NEVER evicted even when it is itself past the idle
+// window and the sweep runs. Proven both at the SweepIdleGroups level and end to
+// end through the real reloadBeforeCall hook.
+func TestSweepIdleGroups_PinsActiveGroupPastWindow(t *testing.T) {
+	t.Run("direct sweep pins the max-lastAccess group", func(t *testing.T) {
+		st := seedGroupsOnDisk(t, map[string]*graph.Document{
+			"A": lazyTestDoc(),
+			"B": lazyTestDoc(),
+		})
+		window := 5 * time.Minute
+		now := time.Now()
+		// A is the ACTIVE group (most recent access) but is itself PAST the window.
+		setLastAccess(st, "A", now.Add(-8*time.Minute))
+		// B is even older — a genuinely idle group.
+		setLastAccess(st, "B", now.Add(-20*time.Minute))
+
+		n := st.SweepIdleGroups(window, true)
+		if n != 1 {
+			t.Fatalf("expected exactly 1 eviction (B), got %d", n)
+		}
+		if !st.groupResident("A") {
+			t.Fatal("PIN VIOLATED: the active (max-lastAccess) group A was evicted")
+		}
+		if st.groupResident("B") {
+			t.Error("idle group B was not evicted")
+		}
+	})
+
+	t.Run("reloadBeforeCall→sweep never evicts the just-routed group", func(t *testing.T) {
+		st := seedGroupsOnDisk(t, map[string]*graph.Document{
+			"A": lazyTestDoc(),
+			"B": lazyTestDoc(),
+		})
+		srv := &Server{
+			State:             st,
+			Tel:               NewTelemetry(0),
+			groupIdleEviction: 5 * time.Minute,
+			groupKeepReader:   true,
+			reloadDebounce:    0, // force the slow path (and thus the sweep) every call
+		}
+		now := time.Now()
+		// Simulate: B was queried a while ago, then A was queried last (A is active)
+		// — both stamps are now past the window (the session paused between calls).
+		setLastAccess(st, "B", now.Add(-30*time.Minute))
+		setLastAccess(st, "A", now.Add(-8*time.Minute))
+
+		// A new tool call for A fires reloadBeforeCall, which runs the sweep BEFORE
+		// the handler re-routes to A. A is the active group and must survive.
+		srv.reloadBeforeCall()
+
+		if !st.groupResident("A") {
+			t.Fatal("PIN VIOLATED via reloadBeforeCall: active group A evicted mid-call")
+		}
+		if st.groupResident("B") {
+			t.Error("idle group B was not evicted by the wired sweep")
+		}
+	})
+}
+
+// Criterion 3: the keepReader knob is honored — true keeps the mmap Reader mapped
+// on a cold shell (no munmap), false fully munmaps exactly once.
+func TestSweepIdleGroups_KeepReaderKnob(t *testing.T) {
+	// build makes a 2-group State: target (idle, evictable) holds a counting
+	// closer; pin (more recent) keeps target from being the max-lastAccess pin.
+	build := func(cc readerCloser) *State {
+		st := NewState(&Registry{Groups: map[string]RegistryGroup{
+			"target": {Repos: map[string]RegistryRepo{"r": {}}},
+			"pin":    {Repos: map[string]RegistryRepo{"r": {}}},
+		}})
+		lr := &LoadedRepo{Repo: "r"}
+		st.mu.Lock()
+		st.groups["target"] = &LoadedGroup{Name: "target", Repos: map[string]*LoadedRepo{"r": lr}}
+		st.groups["pin"] = &LoadedGroup{Name: "pin", Repos: map[string]*LoadedRepo{"r": {Repo: "r"}}}
+		lr.publishHandle(&MapHandle{closer: cc})
+		st.mu.Unlock()
+		now := time.Now()
+		setLastAccess(st, "target", now.Add(-30*time.Minute)) // idle, non-pin
+		setLastAccess(st, "pin", now.Add(-6*time.Minute))     // more recent → pin
+		return st
+	}
+
+	t.Run("keepReader=true keeps it mapped", func(t *testing.T) {
+		cc := &countingCloser{}
+		st := build(cc)
+		if n := st.SweepIdleGroups(5*time.Minute, true); n != 1 {
+			t.Fatalf("expected 1 eviction, got %d", n)
+		}
+		if got := cc.n.Load(); got != 0 {
+			t.Fatalf("keepReader=true munmapped the reader: count=%d, want 0", got)
+		}
+		st.mu.Lock()
+		shell := st.evicted["target"]
+		st.mu.Unlock()
+		if shell == nil || shell.Repos["r"] == nil || shell.Repos["r"].handle == nil {
+			t.Fatal("keepReader=true did not retain a cold shell with the handle")
+		}
+	})
+
+	t.Run("keepReader=false munmaps once", func(t *testing.T) {
+		cc := &countingCloser{}
+		st := build(cc)
+		if n := st.SweepIdleGroups(5*time.Minute, false); n != 1 {
+			t.Fatalf("expected 1 eviction, got %d", n)
+		}
+		if got := cc.n.Load(); got != 1 {
+			t.Fatalf("keepReader=false munmap count = %d, want 1", got)
+		}
+		st.mu.Lock()
+		shell, gated := st.evicted["target"]
+		st.mu.Unlock()
+		if !gated {
+			t.Fatal("full evict did not record the cold-gate")
+		}
+		if shell != nil {
+			t.Fatal("full evict retained a shell; want nil (fully cold)")
+		}
+	})
+}
+
+// Criterion 4: disabled (idle <= 0) → SweepIdleGroups no-ops, zero evictions,
+// behaviour 100% unchanged. Also covers the resolver defaults (unset env = OFF).
+func TestSweepIdleGroups_DisabledIsNoOp(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"a": lazyTestDoc(),
+		"b": lazyTestDoc(),
+	})
+	// Both groups are ancient — under any positive window they would evict.
+	old := time.Now().Add(-24 * time.Hour)
+	setLastAccess(st, "a", old)
+	setLastAccess(st, "b", old)
+
+	if n := st.SweepIdleGroups(0, true); n != 0 {
+		t.Fatalf("idle=0 must evict nothing, got %d", n)
+	}
+	if n := st.SweepIdleGroups(-time.Minute, true); n != 0 {
+		t.Fatalf("negative idle must evict nothing, got %d", n)
+	}
+	if !st.groupResident("a") || !st.groupResident("b") {
+		t.Fatal("disabled sweep changed residency — must be byte-identical no-op")
+	}
+
+	// Resolver contract: unset env → OFF (0); malformed → OFF; positive-but-tiny →
+	// clamped up to the BM25 floor; keepReader default ON.
+	t.Setenv("GRAFEL_MCP_GROUP_IDLE_MS", "")
+	if got := resolveGroupIdleEviction(); got != 0 {
+		t.Errorf("unset GRAFEL_MCP_GROUP_IDLE_MS: want 0 (OFF), got %v", got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_IDLE_MS", "garbage")
+	if got := resolveGroupIdleEviction(); got != 0 {
+		t.Errorf("malformed window: want 0 (OFF), got %v", got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_IDLE_MS", "1000") // below the ~5min BM25 floor
+	floor := time.Duration(defaultBM25IdleEvictionMS) * time.Millisecond
+	if got := resolveGroupIdleEviction(); got != floor {
+		t.Errorf("sub-floor window not clamped: want %v, got %v", floor, got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_KEEP_READER", "")
+	if !resolveGroupKeepReader() {
+		t.Error("keepReader default should be ON")
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_KEEP_READER", "false")
+	if resolveGroupKeepReader() {
+		t.Error("GRAFEL_MCP_GROUP_KEEP_READER=false should disable keepReader")
+	}
+}
+
+// Criterion 5 (-race): a query to group A concurrent with a sweep that evicts
+// idle group B — no fault, A unaffected. Run under `go test -race`.
+func TestSweepIdleGroups_ConcurrentQueryDuringSweep(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"A": lazyTestDoc(),
+		"B": lazyTestDoc(),
+	})
+	window := 5 * time.Minute
+	// B starts idle-past-window; A is queried continuously below (so it is always
+	// the freshly-stamped max-lastAccess pin).
+	setLastAccess(st, "B", time.Now().Add(-30*time.Minute))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Continuous queries to A (each State.Group stamps A's lastAccess).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if grp := st.Group("A"); grp == nil {
+					t.Error("query to active group A returned nil during sweep")
+					return
+				}
+			}
+		}
+	}()
+
+	// Repeated sweeps racing the queries.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			st.SweepIdleGroups(window, true)
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+	if !st.groupResident("A") {
+		t.Fatal("active group A was evicted by a concurrent sweep")
+	}
+}
+
+// Criterion 6: a long-idle group that ALREADY lost its BM25 (short-window sweep)
+// evicts cleanly at the whole-group window — the two idle sweeps compose.
+func TestSweepIdleGroups_ComposesWithBM25Eviction(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"active": lazyTestDoc(),
+		"idle":   lazyTestDoc(),
+	})
+	now := time.Now()
+	setLastAccess(st, "active", now.Add(-1*time.Minute))
+	setLastAccess(st, "idle", now.Add(-20*time.Minute))
+
+	// Warm then BM25-evict the idle group first (the short 5-min window), so the
+	// whole-group sweep later meets a group whose BM25 heap is already gone.
+	st.mu.Lock()
+	idleRepo := st.groups["idle"].Repos["r"]
+	st.mu.Unlock()
+	_ = idleRepo.getBM25() // build it
+	idleRepo.bm25LastUse = now.Add(-20 * time.Minute)
+	if evicted := st.SweepIdleBM25(5 * time.Minute); evicted == 0 {
+		t.Fatal("precondition: BM25 idle sweep evicted nothing")
+	}
+	if idleRepo.BM25 != nil {
+		t.Fatal("precondition: idle repo's BM25 was not dropped")
+	}
+
+	// Now the whole-group sweep at the longer window must evict the idle group
+	// cleanly despite its BM25 already being nil.
+	if n := st.SweepIdleGroups(10*time.Minute, true); n != 1 {
+		t.Fatalf("expected the BM25-already-evicted idle group to evict cleanly, got %d", n)
+	}
+	if st.groupResident("idle") {
+		t.Error("BM25-already-evicted idle group was not whole-group evicted")
+	}
+	if !st.groupResident("active") {
+		t.Error("active group must survive the composed sweep")
+	}
+	// Revive still reconstructs a working search index from disk.
+	grp := st.Group("idle")
+	if grp == nil {
+		t.Fatal("composed-evicted group did not revive")
+	}
+	if hits := grp.Repos["r"].getBM25().Search("Proc", 10); len(hits) == 0 {
+		t.Error("revived group's BM25 search returned no hits — index not rebuilt")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"runtime/debug"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -57,6 +58,49 @@ func resolveBM25IdleEviction() time.Duration {
 		}
 	}
 	return defaultBM25IdleEvictionMS * time.Millisecond
+}
+
+// resolveGroupIdleEviction returns the configured WHOLE-GROUP idle-eviction
+// window, reading GRAFEL_MCP_GROUP_IDLE_MS once at server construction (memory
+// epic #5850, issue #5872 PR2). Whole-group revive is heavy (a full re-load from
+// disk, or at best a heap re-materialization from the retained mmap), so this is
+// OPT-IN: the default is 0 (disabled → SweepIdleGroups no-ops, behaviour 100%
+// unchanged). A negative/garbage value also disables it.
+//
+// When enabled, a sane FLOOR is enforced: the group window must be at least the
+// BM25 idle window (defaultBM25IdleEvictionMS, ~5 min). Evicting a whole group is
+// strictly more disruptive than dropping its BM25 index, so it never makes sense
+// to evict the group before its BM25 would have gone; a smaller requested value
+// is clamped up to the floor.
+func resolveGroupIdleEviction() time.Duration {
+	v := os.Getenv("GRAFEL_MCP_GROUP_IDLE_MS")
+	if v == "" {
+		return 0 // default OFF — opt-in only.
+	}
+	ms, err := strconv.Atoi(v)
+	if err != nil || ms <= 0 {
+		return 0 // disabled / malformed.
+	}
+	if ms < defaultBM25IdleEvictionMS {
+		ms = defaultBM25IdleEvictionMS // floor: never below the BM25 window.
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+// resolveGroupKeepReader returns whether whole-group idle eviction keeps each
+// repo's mmap Reader mapped (re-materializing the dropped heap on revive without a
+// disk re-read) versus fully munmapping it. Reads GRAFEL_MCP_GROUP_KEEP_READER
+// once at construction. Default ON (true) per design: keeping the ~mmap mapped
+// makes revive dramatically cheaper (no fbreader.Open, no disk re-read) while
+// still reclaiming the heavy derived-index heap. Set to "0"/"false" to force a
+// full munmap. Only an explicit falsy value disables it.
+func resolveGroupKeepReader() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GRAFEL_MCP_GROUP_KEEP_READER"))) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 // resolveReloadDebounce returns the configured debounce window, reading the
@@ -297,6 +341,20 @@ type Server struct {
 	// zero value disables idle eviction. No extra goroutine is spawned — the sweep
 	// piggybacks on the existing per-call reload hook.
 	bm25IdleEviction time.Duration
+
+	// groupIdleEviction is the WHOLE-GROUP idle window after which reloadBeforeCall
+	// evicts an idle group's entire resident graph (State.SweepIdleGroups), the
+	// production wiring of the EvictGroup primitive (issue #5872 PR2). Resolved once
+	// at construction from GRAFEL_MCP_GROUP_IDLE_MS (see resolveGroupIdleEviction).
+	// A zero value disables it (default OFF — opt-in; whole-group revive is heavy),
+	// making the whole feature behaviour-neutral. Stacks with bm25IdleEviction: a
+	// group idle long enough first loses its BM25, then the whole graph. Piggybacks
+	// on the existing per-call reload hook — no extra goroutine.
+	groupIdleEviction time.Duration
+	// groupKeepReader controls whether whole-group idle eviction keeps each repo's
+	// mmap Reader mapped (default ON; re-materialize the heap on revive without a
+	// disk re-read) or fully munmaps it. Resolved once from GRAFEL_MCP_GROUP_KEEP_READER.
+	groupKeepReader bool
 }
 
 // SetActivityBroker wires the MCP activity broker into the server so that
@@ -383,7 +441,7 @@ func NewServer(cfg Config) (*Server, error) {
 		mcpsrv.WithToolCapabilities(true),
 		mcpsrv.WithInstructions(mcpInstructions))
 
-	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce(), bm25IdleEviction: resolveBM25IdleEviction()}
+	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce(), bm25IdleEviction: resolveBM25IdleEviction(), groupIdleEviction: resolveGroupIdleEviction(), groupKeepReader: resolveGroupKeepReader()}
 	s.registerTools()
 	return s, nil
 }
@@ -476,6 +534,14 @@ func (s *Server) reloadBeforeCall() {
 	// Gated by the same debounce as the reload above, so it runs at most once per
 	// window rather than on every call. A zero window disables it.
 	s.State.SweepIdleBM25(s.bm25IdleEviction)
+
+	// Idle WHOLE-GROUP sweep (issue #5872 PR2) — same piggyback, one window later:
+	// evict the entire resident graph of any group idle past groupIdleEviction,
+	// EXCEPT the active (max-lastAccess) group, reclaiming its full RSS in an agent
+	// fleet. Opt-in (default OFF → no-op, byte-identical behaviour) and gated by the
+	// same debounce, so it runs at most once per window. Stacks with the BM25 sweep
+	// above: a group idle long enough loses BM25 first, then the whole graph.
+	s.State.SweepIdleGroups(s.groupIdleEviction, s.groupKeepReader)
 	if surfaceChanged && s.MCP != nil {
 		// Best-effort: failures are silently ignored. The notification carries
 		// no payload — clients respond by re-issuing tools/list.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -981,6 +981,18 @@ type LoadedGroup struct {
 	algoFile    string
 	algoMt      time.Time
 	algoApplied bool
+
+	// lastAccess is the wall-clock time of the most recent State.Group(name)
+	// routing decision for this group — the per-call choke point every tool call
+	// passes through to resolve its target group. s.mu-guarded (written in
+	// State.Group, read in SweepIdleGroups, both under s.mu). It is the idle-group
+	// LRU signal AND the PIN signal (memory epic #5850, issue #5872 PR2): the idle
+	// sweep evicts a whole group whose now-lastAccess exceeds the configured window
+	// but NEVER the currently-active group (the max-lastAccess group — the working
+	// set the fleet is servicing). Zero value means the group has been loaded but
+	// never routed to through State.Group (e.g. eager startup warm never queried):
+	// mirroring bm25LastUse, such a group is NOT idle-eligible until first access.
+	lastAccess time.Time
 }
 
 // WorktreeLookup is the narrow interface ResolveCWD uses to query the PH3
@@ -1521,6 +1533,13 @@ func (s *State) Group(name string) *LoadedGroup {
 		}
 	}
 	if grp != nil {
+		// Stamp the LRU/PIN signal on every routing decision (issue #5872 PR2).
+		// This is the per-call choke point, so the group with the newest lastAccess
+		// is definitionally the active working set — SweepIdleGroups pins it. It is
+		// also why a group queried within the idle window is never idle-evicted, and
+		// why a revive (below) immediately re-arms the signal for the freshly
+		// re-materialized group.
+		grp.lastAccess = time.Now()
 		s.refreshGroupAlgoOverlayLocked(grp)
 	}
 	return grp
@@ -1554,6 +1573,14 @@ func (s *State) Group(name string) *LoadedGroup {
 func (s *State) EvictGroup(name string, keepReader bool) bool {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	return s.evictGroupLocked(name, keepReader)
+}
+
+// evictGroupLocked is EvictGroup's body with the lock already held. Extracted
+// (issue #5872 PR2) so the idle-group sweep (SweepIdleGroups) can evict several
+// idle groups inside ONE s.mu critical section without re-entrant locking.
+// Caller MUST hold s.mu.
+func (s *State) evictGroupLocked(name string, keepReader bool) bool {
 	grp := s.groups[name]
 	if grp == nil {
 		return false
@@ -1825,6 +1852,84 @@ func (s *State) SweepIdleBM25(idle time.Duration) int {
 			if lr != nil && lr.evictBM25IfIdle(idle, now) {
 				evicted++
 			}
+		}
+	}
+	return evicted
+}
+
+// SweepIdleGroups evicts the whole resident graph of every group whose last
+// State.Group routing is older than idle, EXCEPT the currently-active group,
+// returning how many groups were evicted. It is the production wiring of the
+// EvictGroup primitive (memory epic #5850, issue #5872 PR2) — the lever that
+// makes idle-group RSS reclamation actually happen in an agent fleet — fired from
+// the MCP server's per-call reload hook (reloadBeforeCall) alongside
+// SweepIdleBM25. A non-positive idle disables the sweep (returns 0 without
+// locking), so it is behaviour-neutral when the knob is unset.
+//
+// PIN (the load-bearing safety requirement). The group being serviced RIGHT NOW
+// must NEVER be evicted — a flag-on in-flight read on an evicted group would
+// otherwise observe an empty graph. The pin is the MAX-lastAccess group: State.Group
+// stamps lastAccess on every routing decision, so the newest-stamped group is the
+// active working set the fleet is currently querying, and it is always skipped
+// regardless of its absolute age. Reinforcing the pin:
+//   - The idle window itself: any group touched within idle (now-lastAccess <= idle)
+//     is skipped, so a group queried concurrently mid-sweep is safe.
+//   - Never-routed groups (lastAccess zero — loaded but never queried through
+//     State.Group) are NOT idle-eligible, mirroring bm25LastUse's zero semantics.
+//   - The revive-on-access backstop in State.Group: even a group this sweep does
+//     evict is transparently re-materialized on its very next State.Group, so a
+//     pin miss degrades to an extra evict+revive, never an empty read.
+//
+// Composition with SweepIdleBM25: BM25 evicts at the short window (~5 min); the
+// whole group evicts at the longer group window — they stack. A group idle long
+// enough first loses its BM25 (heap already dropped, bm25Once re-armed) and then,
+// still idle, loses the whole graph — evicting a group whose BM25 was already
+// evicted is a plain no-op interaction (EvictGroup drops whatever heap remains).
+//
+// Locking: takes s.mu once and evicts via evictGroupLocked (the EvictGroup body),
+// which routes every munmap through the F1 retireHandle drain — same s.mu ->
+// readerMu order the primitive and reload use, so no in-flight borrow is unmapped.
+// keepReader is threaded straight to evictGroupLocked (keep the mmap mapped and
+// re-materialize on revive vs. full munmap + disk re-read).
+func (s *State) SweepIdleGroups(idle time.Duration, keepReader bool) int {
+	if idle <= 0 {
+		return 0
+	}
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Identify the PIN: the active (max-lastAccess) group. Skipped unconditionally
+	// below so the group the fleet is currently servicing is never the victim.
+	pin := ""
+	var pinAt time.Time
+	for name, g := range s.groups {
+		if g == nil {
+			continue
+		}
+		if pin == "" || g.lastAccess.After(pinAt) {
+			pin, pinAt = name, g.lastAccess
+		}
+	}
+
+	// Collect eligible names first — evictGroupLocked mutates s.groups, so we must
+	// not delete while ranging it.
+	var idleNames []string
+	for name, g := range s.groups {
+		if g == nil || name == pin {
+			continue
+		}
+		// Never-routed (zero lastAccess) → not idle-eligible (mirrors bm25LastUse).
+		if g.lastAccess.IsZero() || now.Sub(g.lastAccess) <= idle {
+			continue
+		}
+		idleNames = append(idleNames, name)
+	}
+
+	evicted := 0
+	for _, name := range idleNames {
+		if s.evictGroupLocked(name, keepReader) {
+			evicted++
 		}
 	}
 	return evicted


### PR DESCRIPTION
## What
PR2 of per-group LRU eviction (#5872) — the production policy on the merged `EvictGroup` primitive. Reclaims a whole idle group's RSS automatically; revives on next access.

- `LoadedGroup.lastAccess` stamped in `State.Group` (per-call routing choke point).
- `SweepIdleGroups(idle, keepReader)` (mirrors `SweepIdleBM25`, fired from `reloadBeforeCall`): evicts groups idle past the window via `evictGroupLocked` under one `s.mu`.
- **Pin:** the max-`lastAccess` group is never evicted; reinforced by the idle-window skip (any group touched < idle ago) + revive-on-access backstop.
- Knobs: `GRAFEL_MCP_GROUP_IDLE_MS` (default **0/OFF** — whole-group revive is heavy; clamped up to the BM25 window when set) + `GRAFEL_MCP_GROUP_KEEP_READER` (default **ON** — keep the mmap mapped, re-materialize on revive with no disk re-read).

## Tests (10, incl. pin crux + `-race`)
Idle-evict + revive round-trip; **pin** (active max-lastAccess group survives even past-window, end-to-end via real `reloadBeforeCall`); keepReader knob; disabled=no-op (byte-identical); concurrent query-during-sweep (`-race`, 2000 sweeps); BM25-composition (already-BM25-evicted group evicts + revives with working Search).

Independently opus-reviewed (APPROVE): pin verified; disabled byte-identical; `evictGroupLocked` extraction neutral. Residual (noted for PR4): a >5-min single call on a non-active group under `GRAFEL_MCP_GROUP_IDLE_MS`-on **+** `keepReader=false` (non-default) **+** flag-ON could get an empty in-flight read — unreachable in default config; PR4 adds a borrow-based read (the inert `borrowGroup` seam) to close it.

`go test ./internal/mcp/...` 1230 pass, `-race` clean.

Refs #5872

🤖 Generated with [Claude Code](https://claude.com/claude-code)