### PR TITLE
perf(mcp): by-Kind LabelIndex + selective hot-scanner materialization (mmap flip default-on latency gate)

### DIFF
--- a/internal/mcp/bykind_labelindex_5870_test.go
+++ b/internal/mcp/bykind_labelindex_5870_test.go
@@ -1,0 +1,319 @@
+// bykind_labelindex_5870_test.go — memory epic #5850 / mmap-flip #5870:
+// by-Kind LabelIndex + forEachEntityOfKinds selective materialization.
+//
+// These tests pin the three load-bearing properties of the by-Kind flip:
+//
+//  1. byKind BUILD PARITY — the Reader-built byKind map is byte-identical
+//     (reflect.DeepEqual) to the Document-built one, exactly like byID/byLabel/
+//     byQName, and each per-kind list is the exact set of vector indices with
+//     that raw Kind, in ascending index order.
+//
+//  2. forEachEntityOfKinds OUTPUT PARITY (set + ORDER) — for every predicate the
+//     converted endpoint/flow/dashboard scanners use, forEachEntityOfKinds yields
+//     EXACTLY the entities a forEachEntity full-scan + in-loop Kind filter would,
+//     in the SAME (ascending vector-index) order, on BOTH the flag-OFF and flag-ON
+//     read paths. Dropping the merge/sort in indicesForKinds makes the order
+//     diverge from the vector order (map-iteration order is nondeterministic) and
+//     fails the ordered-index assertion + the parity DeepEqual.
+//
+//  3. SELECTIVE MATERIALIZATION (flag-ON) — a converted scan materializes ONLY the
+//     predicate-matching entities, NOT the whole set. Routing forEachEntityOfKinds
+//     through the whole-scan forEach-all path (the mutation) makes the materialize
+//     counter equal EntityCount and fails the selectivity assertion.
+package mcp
+
+import (
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// mixedKindDoc fabricates a Document whose entities cycle through every raw Kind
+// the converted scanners branch on — endpoint definition/call/legacy, topic,
+// process, pattern, plus plain code kinds — INTERLEAVED in vector order so a
+// multi-kind predicate's index union must be MERGED (not concatenated) to stay
+// ascending. This is what makes the order-preservation property observable.
+func mixedKindDoc(n int) *graph.Document {
+	kinds := []string{
+		"http_endpoint_definition", // isDefinitionKind, isHTTPEndpointKind
+		"http_endpoint_call",       // isCallKind, isHTTPEndpointKind
+		"http_endpoint",            // legacy → isDefinitionKind, isHTTPEndpointKind
+		"SCOPE.topic",              // isTopicKind
+		"SCOPE.Process",            // processEntityKind
+		"SCOPE.Pattern",            // pattern
+		"FUNCTION",                 // none of the above
+		"class",                    // none of the above
+	}
+	ents := make([]graph.Entity, n)
+	for i := 0; i < n; i++ {
+		k := kinds[i%len(kinds)]
+		ents[i] = graph.Entity{
+			ID:            fmt.Sprintf("e%04d", i),
+			Name:          fmt.Sprintf("Name%d", i),
+			QualifiedName: fmt.Sprintf("pkg.Name%d", i),
+			Kind:          k,
+			SourceFile:    fmt.Sprintf("src/f%d.go", i),
+			Language:      "go",
+			StartLine:     i,
+			EndLine:       i + 3,
+		}
+	}
+	return &graph.Document{Entities: ents}
+}
+
+// loadMixedKindFixture writes mixedKindDoc(n) to a temp graph.fb and returns the
+// loader-materialized Document plus an open Reader over the same file.
+func loadMixedKindFixture(t *testing.T, n int) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, mixedKindDoc(n)); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+// mixedKindRepo builds a Reader-backed LoadedRepo with the readerMu-wired
+// Reader-sourced LabelIndex — the shape the flag-ON read path exercises.
+func mixedKindRepo(t *testing.T, n int) (*LoadedRepo, *graph.Document, *fbreader.Reader) {
+	t.Helper()
+	doc, r := loadMixedKindFixture(t, n)
+	lr := &LoadedRepo{Repo: "r", Doc: doc, Reader: r}
+	li := BuildLabelIndexFromReader(r, doc)
+	li.readerMu = &lr.readerMu
+	lr.LabelIndex = li
+	return lr, doc, r
+}
+
+// convertedScannerPreds are the exact Kind predicates the converted endpoint /
+// dashboard scanners pass to forEachEntityOfKinds. Running the parity + order
+// tests over THESE is the primitive-level correctness oracle for every converted
+// call site (each site's only change is forEachEntity+`if !pred{skip}` →
+// forEachEntityOfKinds(pred, ...)).
+func convertedScannerPreds() []struct {
+	name string
+	pred func(string) bool
+} {
+	return []struct {
+		name string
+		pred func(string) bool
+	}{
+		{"isDefinitionKind", isDefinitionKind},
+		{"callOrDefinition", func(k string) bool { return isCallKind(k) || isDefinitionKind(k) }},
+		{"isHTTPEndpointKind", isHTTPEndpointKind},
+		{"isTopicKind", isTopicKind},
+		{"process", func(k string) bool { return k == processEntityKind }},
+		{"pattern", func(k string) bool { return k == "SCOPE.Pattern" || k == "Pattern" }},
+		{"noMatch", func(k string) bool { return k == "does-not-exist" }},
+		{"all", func(k string) bool { return true }},
+	}
+}
+
+// TestLabelIndexByKind_ReaderDocParity_5870 pins byKind build parity (property 1).
+func TestLabelIndexByKind_ReaderDocParity_5870(t *testing.T) {
+	t.Parallel()
+	doc, r := loadMixedKindFixture(t, 200)
+	wantIdx := BuildLabelIndex(doc)
+	gotIdx := BuildLabelIndexFromReader(r, doc)
+
+	if !reflect.DeepEqual(gotIdx.byKind, wantIdx.byKind) {
+		t.Fatalf("byKind map Reader-built != Document-built\n got=%v\nwant=%v", gotIdx.byKind, wantIdx.byKind)
+	}
+
+	// Every per-kind list is EXACTLY the vector indices with that raw kind, in
+	// ascending order; and every entity appears exactly once across byKind.
+	total := 0
+	for kind, idxs := range gotIdx.byKind {
+		var exp []int32
+		for i := range doc.Entities {
+			if doc.Entities[i].Kind == kind {
+				exp = append(exp, int32(i))
+			}
+		}
+		if !reflect.DeepEqual(idxs, exp) {
+			t.Errorf("byKind[%q] = %v, want %v (exact vector indices, ascending)", kind, idxs, exp)
+		}
+		for j := 1; j < len(idxs); j++ {
+			if idxs[j] <= idxs[j-1] {
+				t.Errorf("byKind[%q] not strictly ascending at %d: %v", kind, j, idxs)
+			}
+		}
+		total += len(idxs)
+	}
+	if total != len(doc.Entities) {
+		t.Fatalf("byKind covers %d indices, want %d (one kind per entity, no gaps/dupes)", total, len(doc.Entities))
+	}
+}
+
+// collectIDsForEach returns the entity IDs a forEachEntity full-scan yields for
+// the entities matching pred, in visitation (vector) order — the pre-conversion
+// forEach+filter oracle.
+func collectIDsForEach(lr *LoadedRepo, pred func(string) bool) []string {
+	var ids []string
+	lr.forEachEntity(func(e *graph.Entity) bool {
+		if pred(e.Kind) {
+			ids = append(ids, e.ID)
+		}
+		return true
+	})
+	return ids
+}
+
+// collectIDsForKinds returns the entity IDs forEachEntityOfKinds yields, in
+// visitation order.
+func collectIDsForKinds(lr *LoadedRepo, pred func(string) bool) []string {
+	var ids []string
+	lr.forEachEntityOfKinds(pred, func(e *graph.Entity) bool {
+		ids = append(ids, e.ID)
+		return true
+	})
+	return ids
+}
+
+// TestForEachEntityOfKinds_Parity_FlagOff_5870 pins output parity (set + ORDER)
+// vs forEachEntity+filter on the DEFAULT flag-off path, for every converted-
+// scanner predicate.
+func TestForEachEntityOfKinds_Parity_FlagOff_5870(t *testing.T) {
+	withServeFromMMap(t, false)
+	lr, _, _ := mixedKindRepo(t, 200)
+
+	for _, tc := range convertedScannerPreds() {
+		want := collectIDsForEach(lr, tc.pred)
+		got := collectIDsForKinds(lr, tc.pred)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("[flag-off %s] forEachEntityOfKinds != forEachEntity+filter\n got=%v\nwant=%v", tc.name, got, want)
+		}
+	}
+}
+
+// TestForEachEntityOfKinds_Parity_FlagOn_5870 pins the SAME output parity on the
+// flag-ON (resident Reader) read path — where forEachEntityOfKinds materializes
+// through the readerMu-guarded mmap path.
+func TestForEachEntityOfKinds_Parity_FlagOn_5870(t *testing.T) {
+	withServeFromMMap(t, true)
+	lr, _, _ := mixedKindRepo(t, 200)
+
+	for _, tc := range convertedScannerPreds() {
+		want := collectIDsForEach(lr, tc.pred)
+		got := collectIDsForKinds(lr, tc.pred)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("[flag-on %s] forEachEntityOfKinds != forEachEntity+filter\n got=%v\nwant=%v", tc.name, got, want)
+		}
+	}
+}
+
+// TestForEachEntityOfKinds_AscendingOrder_5870 is the ORDER-preservation
+// mutation guard. indicesForKinds must return the union of the matching kinds'
+// index lists in ASCENDING order. The multi-kind predicates (callOrDefinition,
+// isHTTPEndpointKind) span interleaved kinds, so a build that merely CONCATENATES
+// the per-kind lists (dropping the sort in indicesForKinds) produces a
+// non-ascending, map-iteration-order-dependent sequence — caught here.
+func TestForEachEntityOfKinds_AscendingOrder_5870(t *testing.T) {
+	t.Parallel()
+	doc, r := loadMixedKindFixture(t, 200)
+	li := BuildLabelIndexFromReader(r, doc)
+
+	for _, tc := range convertedScannerPreds() {
+		idxs := li.indicesForKinds(tc.pred)
+		// Strictly ascending.
+		for j := 1; j < len(idxs); j++ {
+			if idxs[j] <= idxs[j-1] {
+				t.Fatalf("[%s] indicesForKinds not strictly ascending at %d: %v (merge/sort dropped?)", tc.name, j, idxs)
+			}
+		}
+		// Exactly the vector indices whose kind matches pred.
+		var exp []int32
+		for i := range doc.Entities {
+			if tc.pred(doc.Entities[i].Kind) {
+				exp = append(exp, int32(i))
+			}
+		}
+		if !reflect.DeepEqual(idxs, exp) {
+			t.Fatalf("[%s] indicesForKinds = %v, want %v (ascending union of matching kinds)", tc.name, idxs, exp)
+		}
+		// Independent sanity: exp is itself already sorted (vector order).
+		if !sort.SliceIsSorted(idxs, func(a, b int) bool { return idxs[a] < idxs[b] }) {
+			t.Fatalf("[%s] result not sorted", tc.name)
+		}
+	}
+}
+
+// TestForEachEntityOfKinds_SelectiveMaterialization_5870 pins property 3: flag-ON,
+// a forEachEntityOfKinds scan materializes ONLY the predicate-matching entities,
+// NOT the whole set. Mutation: routing forEachEntityOfKinds through the whole-scan
+// forEach-all path makes the counter equal EntityCount and this FAILs.
+func TestForEachEntityOfKinds_SelectiveMaterialization_5870(t *testing.T) {
+	withServeFromMMap(t, true)
+	lr, doc, r := mixedKindRepo(t, 240)
+
+	// Expected number of definition-kind (endpoint) entities.
+	wantDef := 0
+	for i := range doc.Entities {
+		if isDefinitionKind(doc.Entities[i].Kind) {
+			wantDef++
+		}
+	}
+	if wantDef == 0 || wantDef == len(doc.Entities) {
+		t.Fatalf("fixture sanity: definition-kind count=%d of %d (must be a proper subset)", wantDef, len(doc.Entities))
+	}
+
+	var count atomic.Int64
+	atMaterializeHook = func() { count.Add(1) }
+	t.Cleanup(func() { atMaterializeHook = nil })
+
+	// Converted endpoint scan: materialize count == definition-kind count.
+	count.Store(0)
+	visited := 0
+	lr.forEachEntityOfKinds(isDefinitionKind, func(e *graph.Entity) bool {
+		visited++
+		return true
+	})
+	if visited != wantDef {
+		t.Fatalf("forEachEntityOfKinds visited %d, want %d", visited, wantDef)
+	}
+	if got := count.Load(); got != int64(wantDef) {
+		t.Fatalf("forEachEntityOfKinds materialized %d entities, want exactly %d (matching-kind count) — NOT EntityCount %d (whole-scan path?)",
+			got, wantDef, r.EntityCount())
+	}
+
+	// Contrast: a forEach-all scan materializes EVERY row — proves the counter is
+	// live and that the by-Kind path is genuinely narrower.
+	count.Store(0)
+	lr.forEachEntity(func(e *graph.Entity) bool { return true })
+	if got := count.Load(); got != int64(r.EntityCount()) {
+		t.Fatalf("forEachEntity materialized %d entities, want all %d", got, r.EntityCount())
+	}
+}
+
+// TestForEachEntityOfKinds_NoByKindFallback_5870 pins that a repo whose
+// LabelIndex has no byKind index (directly-constructed / JSON-only) still yields
+// output-identical results via the filtered full-scan fallback.
+func TestForEachEntityOfKinds_NoByKindFallback_5870(t *testing.T) {
+	withServeFromMMap(t, false)
+	doc := mixedKindDoc(120)
+	lr := &LoadedRepo{Repo: "r", Doc: doc} // no LabelIndex → fallback path
+
+	for _, tc := range convertedScannerPreds() {
+		want := collectIDsForEach(lr, tc.pred)
+		got := collectIDsForKinds(lr, tc.pred)
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("[fallback %s] forEachEntityOfKinds != forEachEntity+filter\n got=%v\nwant=%v", tc.name, got, want)
+		}
+	}
+}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -114,10 +114,8 @@ func (s *Server) handleTopologyChannels(_ context.Context, req mcpapi.CallToolRe
 			}
 			return true
 		})
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if !isTopic(e) {
-				return true
-			}
+		// #5870: scan only topic-kind entities (selective materialization flag-ON).
+		r.forEachEntityOfKinds(isTopicKind, func(e *graph.Entity) bool {
 			out = append(out, channel{
 				TopicID:        prefixedID(r.Repo, e.ID),
 				TopicName:      e.Name,
@@ -239,10 +237,10 @@ func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.Ca
 			}
 			return true
 		})
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if !isTopic(e) {
-				return true
-			}
+		// #5870: topic-kind gate hoisted into the visitation predicate (selective
+		// materialization flag-ON); the residual edge-based publisher filter is
+		// unchanged.
+		r.forEachEntityOfKinds(isTopicKind, func(e *graph.Entity) bool {
 			// Publisher: appears as ToID in a PUBLISHES_TO edge but never as ToID in SUBSCRIBES_TO.
 			if !subscribers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "PUBLISHES_TO") {
 				out = append(out, item{
@@ -287,10 +285,10 @@ func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.C
 			}
 			return true
 		})
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if !isTopic(e) {
-				return true
-			}
+		// #5870: topic-kind gate hoisted into the visitation predicate (selective
+		// materialization flag-ON); the residual edge-based subscriber filter is
+		// unchanged.
+		r.forEachEntityOfKinds(isTopicKind, func(e *graph.Entity) bool {
 			if !publishers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "SUBSCRIBES_TO") {
 				out = append(out, item{
 					TopicID:    prefixedID(r.Repo, e.ID),
@@ -455,10 +453,9 @@ func (s *Server) handleFlowDeadEnds(_ context.Context, req mcpapi.CallToolReques
 			}
 			return true
 		})
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if e.Kind != processEntityKind {
-				return true
-			}
+		// #5870: process-kind gate hoisted into the visitation predicate (selective
+		// materialization flag-ON); the residual terminal_id checks are unchanged.
+		r.forEachEntityOfKinds(func(k string) bool { return k == processEntityKind }, func(e *graph.Entity) bool {
 			// Check if terminal_id exists and has outbound CALLS.
 			termID := e.PropGet("terminal_id")
 			if termID == "" {
@@ -510,10 +507,10 @@ func (s *Server) handleFlowTruncated(_ context.Context, req mcpapi.CallToolReque
 		if r.Doc == nil {
 			continue
 		}
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if e.Kind != processEntityKind {
-				return true
-			}
+		// #5870: process-kind gate hoisted into the visitation predicate (selective
+		// materialization flag-ON); the residual truncated-property checks are
+		// unchanged.
+		r.forEachEntityOfKinds(func(k string) bool { return k == processEntityKind }, func(e *graph.Entity) bool {
 			truncated := e.PropGet("truncated")
 			reason := e.PropGet("truncated_reason")
 			if truncated == "true" || reason != "" {
@@ -569,8 +566,10 @@ func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest)
 		}
 		byID := r.getByID()
 		var procEnt *graph.Entity
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if e.Kind == processEntityKind && e.ID == target {
+		// #5870: process-kind gate hoisted into the visitation predicate (scan only
+		// process-kind entities); the residual exact-ID match is unchanged.
+		r.forEachEntityOfKinds(func(k string) bool { return k == processEntityKind }, func(e *graph.Entity) bool {
+			if e.ID == target {
 				procEnt = e
 				return false
 			}
@@ -704,10 +703,10 @@ func (s *Server) handlePatternsListGraph(_ context.Context, req mcpapi.CallToolR
 		if r.Doc == nil {
 			continue
 		}
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern" {
-				return true
-			}
+		// #5870: pattern-kind gate hoisted into the visitation predicate (selective
+		// materialization flag-ON); the residual status/needs_attention/confidence
+		// filters are unchanged.
+		r.forEachEntityOfKinds(func(k string) bool { return k == "SCOPE.Pattern" || k == "Pattern" }, func(e *graph.Entity) bool {
 			status := e.PropGet("status")
 			if statusFilter != "" && !strings.EqualFold(status, statusFilter) {
 				return true
@@ -1253,8 +1252,13 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 // scans. dead_code.go (frameworkEntryKindsMCP) and denoise.go
 // (isStructuralLineless) already treat SCOPE.MessageTopic / messagetopic as
 // topic-like; this restores consistency with them.
-func isTopic(e *graph.Entity) bool {
-	k := strings.ToLower(e.Kind)
+func isTopic(e *graph.Entity) bool { return isTopicKind(e.Kind) }
+
+// isTopicKind is the Kind-string form of isTopic, so the topology scanners can
+// pass it to forEachEntityOfKinds (#5870). isTopic is a PURE Kind predicate — it
+// reads only e.Kind — so this split is behavior-neutral.
+func isTopicKind(kind string) bool {
+	k := strings.ToLower(kind)
 	return k == "topic" || k == "scope.topic" || k == "queue" || k == "scope.queue" ||
 		k == "messagetopic" || k == "scope.messagetopic" ||
 		strings.HasSuffix(k, ".topic") || strings.HasSuffix(k, ".queue") ||

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -259,8 +259,12 @@ func newEndpointResolution(repos []*LoadedRepo, lg *LoadedGroup, orphanOnly bool
 		if r.Doc == nil {
 			continue
 		}
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if isDefinitionKind(e.Kind) && e.PropGet("pattern_type") != patternTypeHTTPEndpointClientSynthesis {
+		// #5870: scan only definition-kind entities (selective materialization
+		// flag-ON) instead of forEach-filtering the whole entity set. The kind gate
+		// (isDefinitionKind) is hoisted into the visitation predicate; the residual
+		// pattern_type property filter stays in the body, so output is unchanged.
+		r.forEachEntityOfKinds(isDefinitionKind, func(e *graph.Entity) bool {
+			if e.PropGet("pattern_type") != patternTypeHTTPEndpointClientSynthesis {
 				defIDs[prefixedID(r.Repo, e.ID)] = true
 				defIDs[e.ID] = true
 			}
@@ -726,10 +730,10 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		if r.Doc == nil {
 			continue
 		}
-		r.forEachEntity(func(e *graph.Entity) bool {
-			if !isDefinitionKind(e.Kind) {
-				return true
-			}
+		// #5870: definition-kind gate hoisted into the visitation predicate — scan
+		// only definition-kind entities (selective materialization flag-ON). The
+		// residual property/path/method/orphan/effect filters below are unchanged.
+		r.forEachEntityOfKinds(isDefinitionKind, func(e *graph.Entity) bool {
 			if e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis {
 				return true
 			}
@@ -1046,7 +1050,12 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 		if r.Doc == nil {
 			continue
 		}
-		r.forEachEntity(func(e *graph.Entity) bool {
+		// #5870: a call-site is either an explicit call kind OR a definition kind
+		// (client-synthesis http_endpoint). Hoist that pure-Kind union into the
+		// visitation predicate so only call/definition-kind entities are
+		// materialized flag-ON; the residual pattern_type/path/method refinement
+		// stays in the body unchanged.
+		r.forEachEntityOfKinds(func(k string) bool { return isCallKind(k) || isDefinitionKind(k) }, func(e *graph.Entity) bool {
 			// Accept explicit call kind OR client-synthesis http_endpoint.
 			isCall := isCallKind(e.Kind) ||
 				(isDefinitionKind(e.Kind) && e.PropGet("pattern_type") == patternTypeHTTPEndpointClientSynthesis)
@@ -1352,7 +1361,12 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 		}
 		rs := repoStats{Repo: r.Repo}
 
-		r.forEachEntity(func(e *graph.Entity) bool {
+		// #5870: only HTTP-endpoint kinds contribute to the per-repo stats — a
+		// non-endpoint entity falls through the switch untouched. Hoist that pure
+		// kind selection (classifyEndpointKind != none) into the visitation
+		// predicate so only endpoint-kind entities are materialized flag-ON; the
+		// framework/extraction_method reads and the category switch are unchanged.
+		r.forEachEntityOfKinds(isHTTPEndpointKind, func(e *graph.Entity) bool {
 			fw := e.PropGet("framework")
 			xm := e.PropGet("extraction_method") // #5527 per-entity AST provenance
 			switch classifyEndpointKind(e.Kind) {

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"sort"
 	"strings"
 	"sync"
 
@@ -87,6 +88,20 @@ type LabelIndex struct {
 	byID    map[string]int32
 	byLabel map[string][]int32
 	byQName map[string]int32
+
+	// byKind maps an entity's RAW Kind string -> its vector indices, in the SAME
+	// index space as byID (the IterateEntities / range counter both build paths
+	// share). Each list is index-sorted (appended in vector order). Keys are the
+	// RAW kind (NOT lowered/scope-stripped) because the hot Kind-predicate
+	// scanners classify raw kinds themselves (isDefinitionKind / classifyEndpoint-
+	// Kind lower+strip internally; isTopic lowers; the process/pattern scanners
+	// compare exact raw kinds). memory epic #5850 / mmap-flip #5870: it lets a
+	// Kind-filtered scanner (forEachEntityOfKinds) materialize ONLY the entities
+	// whose Kind matches its predicate — dozens of kinds vs 427k entities —
+	// instead of forEach-materializing the whole set per query. Populated by the
+	// SAME add() both build paths funnel through, so the Doc-built and Reader-
+	// built maps are DeepEqual, exactly like byID/byLabel/byQName.
+	byKind map[string][]int32
 }
 
 // entityOverlay holds the 5 group-algo fields that live in the
@@ -154,20 +169,26 @@ func newLabelIndex(n int) (*LabelIndex, *keyInterner) {
 		byID:    make(map[string]int32, n),
 		byLabel: make(map[string][]int32, n),
 		byQName: make(map[string]int32, n),
+		byKind:  make(map[string][]int32),
 	}, &keyInterner{}
 }
 
-// add records the i-th entity's (id, name, qname) into the index maps. Keying
-// mirrors the pre-PR2 pointer build exactly: byID by raw id, byLabel by
+// add records the i-th entity's (id, name, qname, kind) into the index maps.
+// Keying mirrors the pre-PR2 pointer build exactly: byID by raw id, byLabel by
 // lowercased name (appended → ambiguity list in vector order), byQName by
-// lowercased qname (last-write-wins, skipped when empty).
-func (l *LabelIndex) add(ki *keyInterner, i int32, id, name, qname string) {
+// lowercased qname (last-write-wins, skipped when empty). byKind appends the
+// index under the RAW kind (interned — kinds repeat heavily across entities, so
+// one backing string per distinct kind), preserving vector order so each list
+// stays index-sorted.
+func (l *LabelIndex) add(ki *keyInterner, i int32, id, name, qname, kind string) {
 	l.byID[id] = i
 	lbl := ki.intern(strings.ToLower(name))
 	l.byLabel[lbl] = append(l.byLabel[lbl], i)
 	if qname != "" {
 		l.byQName[ki.intern(strings.ToLower(qname))] = i
 	}
+	k := ki.intern(kind)
+	l.byKind[k] = append(l.byKind[k], i)
 }
 
 // BuildLabelIndex constructs a fresh Document-sourced LabelIndex. Lookups
@@ -179,7 +200,7 @@ func BuildLabelIndex(doc *graph.Document) *LabelIndex {
 	idx.doc = doc
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
-		idx.add(ki, int32(i), e.ID, e.Name, e.QualifiedName)
+		idx.add(ki, int32(i), e.ID, e.Name, e.QualifiedName, e.Kind)
 	}
 	return idx
 }
@@ -200,7 +221,7 @@ func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIn
 	idx.reader = r
 	var i int32
 	r.IterateEntities(func(e *fb.Entity) bool {
-		idx.add(ki, i, string(e.Id()), string(e.Name()), string(e.QualifiedName()))
+		idx.add(ki, i, string(e.Id()), string(e.Name()), string(e.QualifiedName()), string(e.Kind()))
 		i++
 		return true
 	})
@@ -391,4 +412,31 @@ func (l *LabelIndex) LookupAll(s string) []*graph.Entity {
 		return out
 	}
 	return nil
+}
+
+// indicesForKinds returns the union of vector indices for every byKind KEY that
+// satisfies pred, in ASCENDING INDEX ORDER — i.e. the SAME order the entities
+// occupy in the entity vector, so a scanner that iterates the result visits them
+// in exactly the order a forEachEntity full-scan + Kind filter would (memory epic
+// #5850 / mmap-flip #5870, order-preservation is load-bearing for the ordered
+// scanners).
+//
+// It iterates byKind's KEYS (dozens of kinds, not 427k entities) and applies pred
+// to each raw kind string; only the matching kinds' index lists are gathered. An
+// entity has exactly ONE kind, so the gathered lists are disjoint — no dedup is
+// needed. Each per-kind list is already index-sorted, but map iteration order over
+// the keys is nondeterministic, so the merged union is sorted ascending before
+// return; dropping that sort is what the order-mutation test detects.
+func (l *LabelIndex) indicesForKinds(pred func(kind string) bool) []int32 {
+	if l == nil || l.byKind == nil || pred == nil {
+		return nil
+	}
+	var out []int32
+	for k, idxs := range l.byKind {
+		if pred(k) {
+			out = append(out, idxs...)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+	return out
 }

--- a/internal/mcp/view_iter.go
+++ b/internal/mcp/view_iter.go
@@ -78,6 +78,112 @@ func (lr *LoadedRepo) forEachEntity(yield func(*graph.Entity) bool) {
 	}
 }
 
+// forEachEntityOfKinds is the by-Kind analogue of forEachEntity (memory epic
+// #5850 / mmap-flip #5870): it calls yield only for the entities whose Kind
+// satisfies pred, in vector-index order. yield returning false stops iteration
+// early. It is the seam the hot Kind-predicate scanners (endpoint / flow /
+// dashboard tools) route through instead of forEachEntity + an in-loop Kind
+// filter, so — flag-ON — they materialize ONLY the predicate-matching entities
+// (dozens-of-kinds → matching subset) rather than the whole 427k-entity set.
+//
+// ORDER is byte-identical to forEachEntity + `if !pred(e.Kind) { skip }`: the
+// visited indices come from LabelIndex.indicesForKinds, which returns the union
+// of the matching kinds' index lists sorted ASCENDING — the same order the entity
+// vector (and therefore forEachEntity) uses.
+//
+// Sourcing mirrors forEachEntity exactly:
+//   - No by-Kind index available (LabelIndex or byKind nil — directly-constructed
+//     test indexes / JSON-only fallback): degrade to forEachEntity + an in-loop
+//     pred filter. Output-identical; simply NOT selectively-materializing.
+//   - Flag-OFF (default): yield &lr.Doc.Entities[idx] for each matching index —
+//     the same pointer semantics as forEachEntity's flag-off path.
+//   - Flag-ON: lr.readerMu held across the WHOLE scan (Option-B), retired/nil
+//     Reader falls back to the Doc, else materialize each matching index via the
+//     SAME graph.MaterializeEntity + overlay merge forEachEntity uses.
+func (lr *LoadedRepo) forEachEntityOfKinds(pred func(kind string) bool, yield func(*graph.Entity) bool) {
+	if lr == nil || pred == nil {
+		return
+	}
+	li := lr.LabelIndex
+	if li == nil || li.byKind == nil {
+		// No by-Kind index — preserve output via a filtered full scan (no
+		// selective materialization on this fallback).
+		lr.forEachEntity(func(e *graph.Entity) bool {
+			if !pred(e.Kind) {
+				return true
+			}
+			return yield(e)
+		})
+		return
+	}
+	idxs := li.indicesForKinds(pred)
+	if len(idxs) == 0 {
+		return
+	}
+
+	if !serveFromMMap() {
+		// Flag-OFF: Doc-sourced, same &Doc.Entities[idx] pointer semantics as
+		// forEachEntity's flag-off branch.
+		if lr.Doc == nil {
+			return
+		}
+		for _, idx := range idxs {
+			if int(idx) >= len(lr.Doc.Entities) {
+				continue
+			}
+			if !yield(&lr.Doc.Entities[idx]) {
+				return
+			}
+		}
+		return
+	}
+
+	// Flag-ON: strictly-innermost readerMu held across the WHOLE scan (Option-B
+	// tradeoff, identical to forEachEntity).
+	lr.readerMu.Lock()
+	rdr := lr.Reader
+	h := lr.handle
+	if rdr == nil || (h != nil && h.readRetired) {
+		lr.readerMu.Unlock()
+		lr.forEachDocEntityOfIdxs(idxs, yield)
+		return
+	}
+	defer lr.readerMu.Unlock()
+
+	var overlay map[int32]entityOverlay
+	if lr.LabelIndex != nil {
+		overlay = lr.LabelIndex.overlay
+	}
+	n := rdr.EntityCount()
+	for _, idx := range idxs {
+		if int(idx) >= n {
+			continue
+		}
+		e := materializeEntityOverlay(rdr, overlay, idx)
+		if !yield(e) {
+			return
+		}
+	}
+}
+
+// forEachDocEntityOfIdxs yields &lr.Doc.Entities[idx] for each index in idxs (in
+// the given order), the Doc-sourced path shared by forEachEntityOfKinds's flag-ON
+// retired/nil-Reader fallback. Callers must NOT hold readerMu (this touches only
+// the Doc).
+func (lr *LoadedRepo) forEachDocEntityOfIdxs(idxs []int32, yield func(*graph.Entity) bool) {
+	if lr.Doc == nil {
+		return
+	}
+	for _, idx := range idxs {
+		if int(idx) >= len(lr.Doc.Entities) {
+			continue
+		}
+		if !yield(&lr.Doc.Entities[idx]) {
+			return
+		}
+	}
+}
+
 // forEachDocEntity is the Doc-sourced path shared by forEachEntity's flag-off
 // branch and its flag-on retired/nil-Reader fallback.
 func (lr *LoadedRepo) forEachDocEntity(yield func(*graph.Entity) bool) {
@@ -98,6 +204,14 @@ func (lr *LoadedRepo) forEachDocEntity(yield func(*graph.Entity) bool) {
 // Callers MUST hold the owning LoadedRepo's readerMu — the mmap dereference
 // happens here.
 func materializeEntityOverlay(r *fbreader.Reader, overlay map[int32]entityOverlay, idx int32) *graph.Entity {
+	// Test-only observability seam (memory epic #5850 Path P): count each mmap
+	// entity materialization so the selective-materialization tests can assert a
+	// forEachEntityOfKinds scan materializes ONLY its matching-Kind subset, not the
+	// whole set. Nil in production — one predictable nil-check, shared with
+	// LabelIndex.materializeFromReader.
+	if atMaterializeHook != nil {
+		atMaterializeHook()
+	}
 	e := graph.MaterializeEntity(r, int(idx))
 	if ov, ok := overlay[idx]; ok {
 		e.CommunityID = ov.CommunityID


### PR DESCRIPTION
## What
The flip's default-ON latency gate (#5870). Flag-ON, hot Kind-filtered handlers used to `forEachEntity`+filter = materialize all 427k entities per query. This adds a by-Kind index so they materialize only matching-Kind entities.

- **`LabelIndex.byKind map[string][]int32`** (raw Kind → index-sorted vector indices) built in both `BuildLabelIndex` (Doc) and `BuildLabelIndexFromReader` (Reader), same index space as byID.
- **`indicesForKinds(pred)`** — union of matching kinds' indices, sorted ascending = vector order (order-preservation is load-bearing).
- **`forEachEntityOfKinds(pred, yield)`** — readerMu-guarded scan seam materializing only matching indices (flag-ON) / `&Doc.Entities[idx]` (flag-OFF); no-byKind → filtered full-scan fallback.
- Converted 11 pure-Kind scanners in `endpoint_tools.go` + `dashboard_tools.go`; left name/property/substring-filtered loops as `forEach`.

## Tests (mutation-proven)
- Order preservation: descending sort → order + parity tests FAIL.
- Selective materialization: converted scan materializes matching count (60), not EntityCount (240); route through forEach-all → FAIL.
- Per-predicate output+order parity vs old filter, flag-OFF and flag-ON; byKind Doc==Reader DeepEqual.

Independently opus-reviewed (APPROVE): all 3 crux checks mutation-proven, 11 converted scanners verified byte-equal to their old Kind filters, left-as-forEach confirmed non-Kind-filterable. `go test ./internal/mcp/...` 1226 pass, `-race` clean.

Refs #5870

🤖 Generated with [Claude Code](https://claude.com/claude-code)