### PR TITLE
chore(mcp): delete dead applyResolutions + fix polluted one-process RSS measurement test

### DIFF
--- a/internal/mcp/enrichment.go
+++ b/internal/mcp/enrichment.go
@@ -1,13 +1,5 @@
 package mcp
 
-import (
-	"encoding/json"
-	"os"
-	"path/filepath"
-
-	"github.com/cajasmota/grafel/internal/daemon"
-)
-
 // EnrichmentResolution is one resolved enrichment entry stored under a repo's
 // .grafel/enrichment-resolutions.json. Keys here align with the candidate
 // pipeline output.
@@ -18,65 +10,4 @@ type EnrichmentResolution struct {
 	Value       string  `json:"value"`
 	Confidence  float64 `json:"confidence,omitempty"`
 	Reason      string  `json:"reason,omitempty"`
-}
-
-// readResolutions reads enrichment-resolutions.json (array form) for a repo.
-func readResolutions(repoPath string) []EnrichmentResolution {
-	if repoPath == "" {
-		return nil
-	}
-	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-resolutions.json")
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil
-	}
-	var out []EnrichmentResolution
-	if err := json.Unmarshal(data, &out); err != nil {
-		// tolerate {"resolutions":[...]} form too
-		var alt struct {
-			Resolutions []EnrichmentResolution `json:"resolutions"`
-		}
-		if err := json.Unmarshal(data, &alt); err != nil {
-			return nil
-		}
-		return alt.Resolutions
-	}
-	return out
-}
-
-// applyResolutions merges resolutions into entity Properties (non-destructive,
-// resolution-side wins). Used by tools that need post-enrichment views.
-//
-// ADR-0027 Cutover PR2: this MUTATES entities in place, so it must resolve the
-// id against the authoritative Doc.Entities slice (a stable, addressable
-// pointer), NOT via LabelIndex.ByID — which now materializes a throwaway heap
-// copy per lookup, so a PropSet through it would be lost. Building a one-shot
-// id→index over Doc keeps the write-through semantics intact and independent of
-// the (now pointer-unstable) index. (This helper currently has no callers; the
-// retarget keeps it correct for when one is wired.)
-func applyResolutions(repoPath string, lr *LoadedRepo) {
-	if lr == nil || lr.Doc == nil {
-		return
-	}
-	res := readResolutions(repoPath)
-	if len(res) == 0 {
-		return
-	}
-	pos := make(map[string]int, len(lr.Doc.Entities))
-	for i := range lr.Doc.Entities {
-		pos[lr.Doc.Entities[i].ID] = i
-	}
-	for _, r := range res {
-		i, ok := pos[r.NodeID]
-		if !ok {
-			continue
-		}
-		e := &lr.Doc.Entities[i]
-		if e.PropLen() == 0 {
-			e.PropsReplace(map[string]string{})
-		}
-		if r.Kind != "" {
-			e.PropSet(r.Kind, r.Value)
-		}
-	}
 }

--- a/internal/mcp/membaseline_test.go
+++ b/internal/mcp/membaseline_test.go
@@ -212,29 +212,14 @@ func warmServedRepo(lr *LoadedRepo) {
 	_ = lr.getBM25().Search("order handler request customer processor", 10)
 }
 
-// TestMemBaselineMMapCutover is the load-bearing PR7 measurement: it warms a
-// served repo over the SAME graph.fb in BOTH modes and reports the resident
-// (no query load) delta.
-//
-//	flag-OFF : full graph.Document materialized (~608 MB of entity/rel rows on
-//	           the Go heap) + resident Reader + all served indexes — the current
-//	           baseline.
-//	flag-ON  : HEADER-ONLY Document (empty Entities/Relationships) + resident
-//	           Reader + all served indexes — the target. The mmap Reader pages
-//	           are disk-backed (RSS, not Go heap), so the Doc materialization is
-//	           dropped from HeapInuse/HeapAlloc.
-//
-// It measures HeapInuse/HeapAlloc (after forced GCs) with NO query load beyond
-// the single index-warming pass, so the number is the RESIDENT footprint of the
-// graph, not a query-time peak. Gated behind GRAFEL_MEM_BASELINE_FB like the
-// other seams; point it at the corpus graph.fb via:
-//
-//	GRAFEL_MEM_BASELINE_FB=$(ls -d ~/.grafel/store/*monorepos-main-*/refs/main/graph.fb) \
-//	  go test ./internal/mcp/ -run TestMemBaselineMMapCutover -v -count=1 -timeout 30m
-func TestMemBaselineMMapCutover(t *testing.T) {
-	fbPath := os.Getenv("GRAFEL_MEM_BASELINE_FB")
+// mmapCutoverOpen resolves GRAFEL_MEM_BASELINE_FB to a concrete graph.fb path,
+// or skips the test if the env var is unset. Shared by both single-mode
+// mmap-cutover tests below.
+func mmapCutoverOpen(t *testing.T) (fbPath string, onDisk uint64, stateDir string) {
+	t.Helper()
+	fbPath = os.Getenv("GRAFEL_MEM_BASELINE_FB")
 	if fbPath == "" {
-		t.Skip("set GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb to run the mmap-cutover resident-memory delta")
+		t.Skip("set GRAFEL_MEM_BASELINE_FB=/path/to/graph.fb to run the mmap-cutover resident-memory measurement")
 	}
 	fi, err := os.Stat(fbPath)
 	if err != nil {
@@ -246,98 +231,143 @@ func TestMemBaselineMMapCutover(t *testing.T) {
 			t.Fatalf("stat graph.fb in dir: %v", err)
 		}
 	}
-	onDisk := uint64(fi.Size())
-	stateDir := filepath.Dir(fbPath)
+	onDisk = uint64(fi.Size())
+	stateDir = filepath.Dir(fbPath)
+	return fbPath, onDisk, stateDir
+}
 
-	readHeap := func() (inuse, alloc uint64) {
-		runtime.GC()
-		runtime.GC()
-		var m runtime.MemStats
-		runtime.ReadMemStats(&m)
-		return m.HeapInuse, m.HeapAlloc
+func mmapCutoverReadHeap() (inuse, alloc uint64) {
+	runtime.GC()
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapInuse, m.HeapAlloc
+}
+
+// mmapCutoverMeasure loads graph.fb in the given mode (flag-OFF full Doc vs.
+// flag-ON header-only Doc), warms a served repo over it, and returns the
+// resident deltas above an empty-process baseline captured just before load.
+//
+// HeapInuse/HeapAlloc ARE reliable per-mode numbers even when both modes run
+// in the same process, because the baseline is re-captured (after two forced
+// GCs) immediately before each mode's load — Go's heap accounting reflects
+// spans actually in use, not a process high-water mark. Process RSS does NOT
+// have this property: the OS does not reliably shrink RSS when Go frees heap
+// spans back to the scavenger, so an RSS reading taken after a prior mode ran
+// in the same process reflects that prior mode's high-water mark, not the
+// current mode alone. That is why the two modes are split into separate top-
+// level tests below (each its own `go test -run` invocation / process) rather
+// than measured back-to-back in one test — this is what makes the RSS number
+// each test reports trustworthy as a clean per-mode figure instead of the
+// polluted one an earlier combined version of this test produced (a real
+// misread: flag-ON looked like ~1896 MB in-process vs. ~1456 MB measured
+// cleanly in its own process).
+func mmapCutoverMeasure(t *testing.T, stateDir, fbPath string, headerOnly bool) (inuse, alloc, rss uint64, nEnt, nRel int) {
+	t.Helper()
+	baseInuse, baseAlloc := mmapCutoverReadHeap()
+
+	var doc *graph.Document
+	var err error
+	if headerOnly {
+		doc, err = graph.LoadGraphHeaderOnlyFromDir(stateDir)
+	} else {
+		doc, err = graph.LoadGraphFromDir(stateDir)
 	}
-
-	// measure runs one mode start-to-finish in its OWN scope so the previous
-	// mode's Doc/indexes are unreferenced (and reclaimed by the settling GCs)
-	// before the next mode is built — the two modes never coexist on the heap.
-	measure := func(headerOnly bool) (inuse, alloc, rss uint64, nEnt, nRel int) {
-		baseInuse, baseAlloc := readHeap()
-
-		var doc *graph.Document
-		if headerOnly {
-			doc, err = graph.LoadGraphHeaderOnlyFromDir(stateDir)
-		} else {
-			doc, err = graph.LoadGraphFromDir(stateDir)
-		}
-		if err != nil {
-			t.Fatalf("load (headerOnly=%v): %v", headerOnly, err)
-		}
-		nEnt = doc.Stats.Entities
-		nRel = doc.Stats.Relationships
-
-		// Open the resident Reader (both modes hold it; it is the flag-ON data
-		// source and, flag-OFF, the S8 zero-copy reader a served repo also keeps).
-		r, rErr := fbreader.Open(fbPath)
-		if rErr != nil {
-			t.Fatalf("fbreader.Open: %v", rErr)
-		}
-		defer r.Close()
-
-		lr := &LoadedRepo{Repo: "corpus", Doc: doc, GraphFile: fbPath, Reader: r}
-		if headerOnly {
-			// Flag-ON wiring: Reader-sourced LabelIndex + published handle, as
-			// reloadLocked does when serveFromMMap() is on.
-			li := BuildLabelIndexFromReader(r, doc)
-			li.readerMu = &lr.readerMu
-			h := newMapHandle(r)
-			li.handle = h
-			lr.LabelIndex = li
-			lr.publishHandle(h)
-		} else {
-			lr.LabelIndex = BuildLabelIndex(doc)
-		}
-		warmServedRepo(lr)
-
-		inuse, alloc = readHeap()
-		rss = rssBytes(t)
-		runtime.KeepAlive(doc)
-		runtime.KeepAlive(lr)
-		return inuse - baseInuse, alloc - baseAlloc, rss, nEnt, nRel
+	if err != nil {
+		t.Fatalf("load (headerOnly=%v): %v", headerOnly, err)
 	}
+	nEnt = doc.Stats.Entities
+	nRel = doc.Stats.Relationships
 
-	// Flag-OFF (full Doc) FIRST, then Flag-ON (header-only). Toggle the package
-	// flag around each measurement so the getters take the correct path.
+	// Open the resident Reader (both modes hold it; it is the flag-ON data
+	// source and, flag-OFF, the S8 zero-copy reader a served repo also keeps).
+	r, rErr := fbreader.Open(fbPath)
+	if rErr != nil {
+		t.Fatalf("fbreader.Open: %v", rErr)
+	}
+	defer r.Close()
+
+	lr := &LoadedRepo{Repo: "corpus", Doc: doc, GraphFile: fbPath, Reader: r}
+	if headerOnly {
+		// Flag-ON wiring: Reader-sourced LabelIndex + published handle, as
+		// reloadLocked does when serveFromMMap() is on.
+		li := BuildLabelIndexFromReader(r, doc)
+		li.readerMu = &lr.readerMu
+		h := newMapHandle(r)
+		li.handle = h
+		lr.LabelIndex = li
+		lr.publishHandle(h)
+	} else {
+		lr.LabelIndex = BuildLabelIndex(doc)
+	}
+	warmServedRepo(lr)
+
+	inuse, alloc = mmapCutoverReadHeap()
+	rss = rssBytes(t)
+	runtime.KeepAlive(doc)
+	runtime.KeepAlive(lr)
+	return inuse - baseInuse, alloc - baseAlloc, rss, nEnt, nRel
+}
+
+// TestMemBaselineMMapCutoverOff is the flag-OFF half of the load-bearing PR7
+// measurement: full graph.Document materialized (~608 MB of entity/rel rows on
+// the Go heap) + resident Reader + all served indexes — the current baseline.
+//
+// Run in ISOLATION (its own process) so process RSS is a clean per-mode
+// figure — do not run together with TestMemBaselineMMapCutoverOn in the same
+// `go test` invocation, or the RSS this test reports will be uncontaminated
+// but the OTHER test's RSS will inherit this mode's high-water mark. See
+// mmapCutoverMeasure's doc comment for why HeapInuse/HeapAlloc don't have this
+// problem but RSS does.
+//
+//	GRAFEL_MEM_BASELINE_FB=$(ls -d ~/.grafel/store/*monorepos-main-*/refs/main/graph.fb) \
+//	  go test ./internal/mcp/ -run '^TestMemBaselineMMapCutoverOff$' -v -count=1 -timeout 30m
+func TestMemBaselineMMapCutoverOff(t *testing.T) {
+	fbPath, onDisk, stateDir := mmapCutoverOpen(t)
 	serveFromMMapEnabled = false
-	offInuse, offAlloc, offRSS, nEnt, nRel := measure(false)
+	inuse, alloc, rss, nEnt, nRel := mmapCutoverMeasure(t, stateDir, fbPath, false)
 
-	serveFromMMapEnabled = true
-	onInuse, onAlloc, onRSS, _, _ := measure(true)
-
-	serveFromMMapEnabled = false // restore default for the rest of the suite
-
-	deltaInuse := int64(offInuse) - int64(onInuse)
-	deltaAlloc := int64(offAlloc) - int64(onAlloc)
-
-	t.Logf("=== ADR-0027 PR7 mmap-cutover resident-memory delta (numbers only) ===")
+	t.Logf("=== ADR-0027 PR7 mmap-cutover resident-memory: flag-OFF (numbers only) ===")
 	t.Logf("on-disk graph.fb bytes        : %d (%.1f MB)", onDisk, mbf(onDisk))
 	t.Logf("entities / relationships      : %d / %d", nEnt, nRel)
-	t.Logf("--- flag-OFF (full Doc materialized) resident above process base ---")
-	t.Logf("  HeapInuse                   : %d (%.1f MB)", offInuse, mbf(offInuse))
-	t.Logf("  HeapAlloc                   : %d (%.1f MB)", offAlloc, mbf(offAlloc))
-	if offRSS > 0 {
-		t.Logf("  process RSS (warmed)        : %.1f MB", mbf(offRSS))
+	t.Logf("HeapInuse                     : %d (%.1f MB)", inuse, mbf(inuse))
+	t.Logf("HeapAlloc                     : %d (%.1f MB)", alloc, mbf(alloc))
+	if rss > 0 {
+		t.Logf("process RSS (warmed, clean — this mode ran alone in this process) : %.1f MB", mbf(rss))
+	} else {
+		t.Logf("process RSS (warmed)         : unavailable on this platform")
 	}
-	t.Logf("--- flag-ON (header-only Doc + resident Reader) resident above base ---")
-	t.Logf("  HeapInuse                   : %d (%.1f MB)", onInuse, mbf(onInuse))
-	t.Logf("  HeapAlloc                   : %d (%.1f MB)", onAlloc, mbf(onAlloc))
-	if onRSS > 0 {
-		t.Logf("  process RSS (warmed)        : %.1f MB", mbf(onRSS))
-	}
-	t.Logf("--- HEADLINE: resident Go-heap saved by the flip (OFF - ON) ---")
-	t.Logf("  HeapInuse saved             : %d (%.1f MB)", deltaInuse, float64(deltaInuse)/(1024*1024))
-	t.Logf("  HeapAlloc saved             : %d (%.1f MB)", deltaAlloc, float64(deltaAlloc)/(1024*1024))
-	if nEnt+nRel > 0 {
-		t.Logf("  saved / record (HeapInuse)  : %.1f bytes", float64(deltaInuse)/float64(nEnt+nRel))
+}
+
+// TestMemBaselineMMapCutoverOn is the flag-ON half of the load-bearing PR7
+// measurement: HEADER-ONLY Document (empty Entities/Relationships) + resident
+// Reader + all served indexes — the target. The mmap Reader pages are
+// disk-backed (RSS, not Go heap), so the Doc materialization is dropped from
+// HeapInuse/HeapAlloc.
+//
+// Run in ISOLATION (its own process) — see TestMemBaselineMMapCutoverOff's doc
+// comment for why. To get the headline "saved by the flip" number, run both
+// tests as separate invocations and diff the printed HeapInuse/HeapAlloc (and,
+// if desired, RSS — each is clean because each test only ever runs one mode
+// per process).
+//
+//	GRAFEL_MEM_BASELINE_FB=$(ls -d ~/.grafel/store/*monorepos-main-*/refs/main/graph.fb) \
+//	  go test ./internal/mcp/ -run '^TestMemBaselineMMapCutoverOn$' -v -count=1 -timeout 30m
+func TestMemBaselineMMapCutoverOn(t *testing.T) {
+	fbPath, onDisk, stateDir := mmapCutoverOpen(t)
+	serveFromMMapEnabled = true
+	defer func() { serveFromMMapEnabled = false }() // restore default for the rest of the suite
+	inuse, alloc, rss, nEnt, nRel := mmapCutoverMeasure(t, stateDir, fbPath, true)
+
+	t.Logf("=== ADR-0027 PR7 mmap-cutover resident-memory: flag-ON (numbers only) ===")
+	t.Logf("on-disk graph.fb bytes        : %d (%.1f MB)", onDisk, mbf(onDisk))
+	t.Logf("entities / relationships      : %d / %d", nEnt, nRel)
+	t.Logf("HeapInuse                     : %d (%.1f MB)", inuse, mbf(inuse))
+	t.Logf("HeapAlloc                     : %d (%.1f MB)", alloc, mbf(alloc))
+	if rss > 0 {
+		t.Logf("process RSS (warmed, clean — this mode ran alone in this process) : %.1f MB", mbf(rss))
+	} else {
+		t.Logf("process RSS (warmed)         : unavailable on this platform")
 	}
 }
 


### PR DESCRIPTION
## What
Two small behavior-neutral cleanups from the memory epic (#5850).

1. **Delete dead code** (`enrichment.go`): `applyResolutions` + orphaned `readResolutions` — zero callers (build proves it), superseded by the index-time `internal/enrichment.ApplyResolutions`. Kept the still-live `EnrichmentResolution` type. Would have been an mmap-flip footgun (in-place Doc write) if ever wired.

2. **Fix the misleading measurement** (`membaseline_test.go`): `TestMemBaselineMMapCutover` ran both flag modes in ONE process and reported process RSS for each — but RSS is a high-water mark, so the flag-ON reading was polluted by the flag-OFF peak (the ~1896 vs clean ~1456 misread). Split into `TestMemBaselineMMapCutoverOff`/`On` so each mode's RSS is a clean per-process figure; the HeapInuse deltas (already per-mode-accurate via forced GC) are kept, with comments explaining why RSS needs process isolation.

`go build ./...` clean, `go vet` clean, `gofmt -l` clean, `go test ./internal/mcp/...` 1236 pass (both membaseline tests compile + skip cleanly without the env). Scope = 2 files.

Refs #5850

🤖 Generated with [Claude Code](https://claude.com/claude-code)