### PR TITLE
feat(mcp): memory-watermark group eviction — one-victim-per-sweep (#5872 PR3)

### DIFF
--- a/internal/mcp/mem_watermark_evict_5872_pr3_test.go
+++ b/internal/mcp/mem_watermark_evict_5872_pr3_test.go
@@ -1,0 +1,286 @@
+// mem_watermark_evict_5872_pr3_test.go — tests for the memory-watermark eviction
+// TRIGGER (memory epic #5850, issue #5872 PR3): State.SweepToMemoryBudget sheds the
+// single oldest-lastAccess non-pinned group (LRU victim) per sweep under memory
+// pressure, PINNING the active (max-lastAccess) group exactly as PR2's idle sweep
+// does, and converging across successive reloadBeforeCall sweeps. Companion to
+// idle_group_evict_5872_pr2_test.go (the TIME trigger) and evict_group_5872_test.go
+// (the PR1 primitive).
+//
+// The sampler models the PRODUCTION HeapAlloc hazard: the sample does NOT drop the
+// instant a group is evicted — the freed heap is only reflected after a GC, and under
+// keepReader=true the evict itself allocates a fresh cold shell (transiently RAISING
+// HeapAlloc). A fixed over-budget sampler that never falls is therefore the exact
+// condition a buggy "re-sample after each evict and keep going" loop would mishandle:
+// it would shed EVERY non-pinned group in one sweep (a thundering-herd revive storm).
+// These tests assert the correct one-victim-per-sweep behaviour under that hazard —
+// which a count-based sampler that magically dropped on delete() would have hidden.
+package mcp
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// fixedSampler installs a memSampler that always returns v, independent of how many
+// groups remain resident — modelling GC lag / keepReader shell allocation where the
+// sample does not fall when a group is evicted. Set under s.mu, the same lock
+// SweepToMemoryBudget samples under.
+func fixedSampler(st *State, v uint64) {
+	st.mu.Lock()
+	st.memSampler = func() uint64 { return v }
+	st.mu.Unlock()
+}
+
+const overBudget = uint64(1 << 40)  // 1 TiB — always over any test budget
+const testBudget = uint64(1 << 30)  // 1 GiB
+const underBudget = uint64(1 << 20) // 1 MiB — always under testBudget
+
+// Criterion (the CRUX — catches the GC-lag/over-evict bug): with the sample stuck
+// OVER budget (as production HeapAlloc is until GC runs), a single sweep evicts
+// EXACTLY ONE group — the LRU (oldest) non-pinned group — NOT every non-pinned group.
+// The old re-sample-mid-loop code evicted all non-pinned groups here (thundering herd);
+// this asserts the graduated one-victim-per-sweep contract.
+func TestSweepToMemoryBudget_OneVictimPerSweepNoThunderingHerd(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"oldest": lazyTestDoc(),
+		"middle": lazyTestDoc(),
+		"newest": lazyTestDoc(),
+	})
+	fixedSampler(st, overBudget) // never falls under budget within a sweep
+	now := time.Now()
+	setLastAccess(st, "oldest", now.Add(-30*time.Minute))
+	setLastAccess(st, "middle", now.Add(-20*time.Minute))
+	setLastAccess(st, "newest", now.Add(-1*time.Minute)) // active pin
+
+	n := st.SweepToMemoryBudget(testBudget, true)
+	if n != 1 {
+		t.Fatalf("expected EXACTLY 1 eviction per sweep (no thundering herd), got %d", n)
+	}
+	if st.groupResident("oldest") {
+		t.Error("LRU (oldest) group was not the victim")
+	}
+	if !st.groupResident("middle") || !st.groupResident("newest") {
+		t.Error("over-evicted: only the single oldest group may go in one sweep")
+	}
+	if !st.gated("oldest") {
+		t.Error("evicted group not recorded in the cold-gate")
+	}
+}
+
+// Criterion (LRU order + convergence + termination): successive sweeps — each the real
+// entry-sampled decision reloadBeforeCall would make once GC reflects prior frees —
+// shed groups OLDEST-FIRST, one per sweep, and STOP once only the pinned group remains
+// (never evicting the active set). Sampler stays over budget throughout.
+func TestSweepToMemoryBudget_ConvergesAcrossSweepsLRUOrder(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"g_old": lazyTestDoc(),
+		"g_mid": lazyTestDoc(),
+		"g_new": lazyTestDoc(), // active pin (newest)
+	})
+	fixedSampler(st, overBudget)
+	now := time.Now()
+	setLastAccess(st, "g_old", now.Add(-30*time.Minute))
+	setLastAccess(st, "g_mid", now.Add(-20*time.Minute))
+	setLastAccess(st, "g_new", now.Add(-1*time.Minute))
+
+	// Sweep 1 → oldest.
+	if n := st.SweepToMemoryBudget(testBudget, true); n != 1 {
+		t.Fatalf("sweep 1: want 1 eviction, got %d", n)
+	}
+	if st.groupResident("g_old") || !st.groupResident("g_mid") || !st.groupResident("g_new") {
+		t.Fatal("sweep 1 must evict only the oldest (g_old)")
+	}
+	// Sweep 2 → next-oldest.
+	if n := st.SweepToMemoryBudget(testBudget, true); n != 1 {
+		t.Fatalf("sweep 2: want 1 eviction, got %d", n)
+	}
+	if st.groupResident("g_mid") || !st.groupResident("g_new") {
+		t.Fatal("sweep 2 must evict the next-oldest (g_mid), keeping the pin")
+	}
+	// Sweep 3 → only the pinned active group remains: evict NOTHING, converged.
+	if n := st.SweepToMemoryBudget(testBudget, true); n != 0 {
+		t.Fatalf("sweep 3: only the pin remains, want 0 evictions, got %d", n)
+	}
+	if !st.groupResident("g_new") {
+		t.Fatal("PIN VIOLATED: the active group was evicted once alone under pressure")
+	}
+	// Idempotent thereafter — never sacrifices the active set no matter how over budget.
+	if n := st.SweepToMemoryBudget(testBudget, true); n != 0 {
+		t.Fatalf("post-convergence sweep must stay 0, got %d", n)
+	}
+}
+
+// Criterion: already under budget → zero evictions, no residency change, even with
+// ancient groups a positive idle window would evict.
+func TestSweepToMemoryBudget_UnderBudgetNoEvictions(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"a": lazyTestDoc(),
+		"b": lazyTestDoc(),
+	})
+	fixedSampler(st, underBudget)
+	old := time.Now().Add(-24 * time.Hour)
+	setLastAccess(st, "a", old)
+	setLastAccess(st, "b", old)
+
+	if n := st.SweepToMemoryBudget(testBudget, true); n != 0 {
+		t.Fatalf("under-budget sweep must evict nothing, got %d", n)
+	}
+	if !st.groupResident("a") || !st.groupResident("b") {
+		t.Fatal("under-budget sweep changed residency")
+	}
+}
+
+// Criterion (the pin CRUX): the active (max-lastAccess) group is PINNED even under
+// sustained extreme pressure — repeated sweeps with the sample permanently over budget
+// shed every OTHER group one at a time but never the active one.
+func TestSweepToMemoryBudget_PinsActiveGroupUnderPressure(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"A_active": lazyTestDoc(),
+		"B":        lazyTestDoc(),
+		"C":        lazyTestDoc(),
+	})
+	fixedSampler(st, overBudget)
+	now := time.Now()
+	setLastAccess(st, "A_active", now.Add(-1*time.Minute)) // newest → active pin
+	setLastAccess(st, "B", now.Add(-10*time.Minute))
+	setLastAccess(st, "C", now.Add(-20*time.Minute))
+
+	total := 0
+	for i := 0; i < 10; i++ { // far more sweeps than groups
+		total += st.SweepToMemoryBudget(testBudget, true)
+	}
+	if total != 2 {
+		t.Fatalf("expected exactly the 2 non-pinned groups shed across sweeps, got %d", total)
+	}
+	if !st.groupResident("A_active") {
+		t.Fatal("PIN VIOLATED: the active group was evicted under sustained pressure")
+	}
+	if st.groupResident("B") || st.groupResident("C") {
+		t.Error("non-pinned groups B/C should both be shed under sustained pressure")
+	}
+}
+
+// Criterion: disabled (budget 0) → no-op, byte-identical residency, and NO sample is
+// even taken (a sampler that fails the test if called proves the early-out).
+func TestSweepToMemoryBudget_DisabledIsNoOp(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"a": lazyTestDoc(),
+		"b": lazyTestDoc(),
+	})
+	st.mu.Lock()
+	st.memSampler = func() uint64 {
+		t.Error("memSampler called with budget 0 — must early-out before sampling")
+		return overBudget
+	}
+	st.mu.Unlock()
+	old := time.Now().Add(-24 * time.Hour)
+	setLastAccess(st, "a", old)
+	setLastAccess(st, "b", old)
+
+	if n := st.SweepToMemoryBudget(0, true); n != 0 {
+		t.Fatalf("budget 0 must evict nothing, got %d", n)
+	}
+	if !st.groupResident("a") || !st.groupResident("b") {
+		t.Fatal("disabled sweep changed residency — must be byte-identical no-op")
+	}
+
+	// Resolver contract: unset env → OFF (0); malformed → OFF; explicit 0 → OFF;
+	// positive → bytes.
+	t.Setenv("GRAFEL_MCP_GROUP_RSS_BUDGET_MB", "")
+	if got := resolveGroupRSSBudget(); got != 0 {
+		t.Errorf("unset GRAFEL_MCP_GROUP_RSS_BUDGET_MB: want 0 (OFF), got %d", got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_RSS_BUDGET_MB", "garbage")
+	if got := resolveGroupRSSBudget(); got != 0 {
+		t.Errorf("malformed budget: want 0 (OFF), got %d", got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_RSS_BUDGET_MB", "0")
+	if got := resolveGroupRSSBudget(); got != 0 {
+		t.Errorf("explicit 0: want 0 (OFF), got %d", got)
+	}
+	t.Setenv("GRAFEL_MCP_GROUP_RSS_BUDGET_MB", "512")
+	if got := resolveGroupRSSBudget(); got != 512*1024*1024 {
+		t.Errorf("512MB budget: want %d bytes, got %d", 512*1024*1024, got)
+	}
+}
+
+// Criterion (-race): a query to the active group A concurrent with watermark sweeps
+// that shed the LRU tail (B, C) — no fault, A always survives. Run under `go test -race`.
+func TestSweepToMemoryBudget_ConcurrentQueryDuringSweep(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"A": lazyTestDoc(),
+		"B": lazyTestDoc(),
+		"C": lazyTestDoc(),
+	})
+	fixedSampler(st, overBudget) // permanent pressure
+	now := time.Now()
+	setLastAccess(st, "B", now.Add(-20*time.Minute))
+	setLastAccess(st, "C", now.Add(-30*time.Minute))
+	// A is queried continuously below (always the freshly-stamped max-lastAccess pin).
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				if grp := st.Group("A"); grp == nil {
+					t.Error("query to active group A returned nil during watermark sweep")
+					return
+				}
+			}
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			st.SweepToMemoryBudget(testBudget, true)
+		}
+		close(stop)
+	}()
+
+	wg.Wait()
+	if !st.groupResident("A") {
+		t.Fatal("active group A was evicted by a concurrent watermark sweep")
+	}
+}
+
+// End-to-end: the trigger fires through the real reloadBeforeCall slow path when the
+// GRAFEL_MCP_GROUP_RSS_BUDGET_MB knob is set, shedding ONE LRU group and pinning the
+// just-routed active group.
+func TestSweepToMemoryBudget_WiredThroughReloadBeforeCall(t *testing.T) {
+	st := seedGroupsOnDisk(t, map[string]*graph.Document{
+		"A": lazyTestDoc(),
+		"B": lazyTestDoc(),
+	})
+	fixedSampler(st, overBudget)
+	now := time.Now()
+	setLastAccess(st, "B", now.Add(-20*time.Minute))
+	setLastAccess(st, "A", now.Add(-1*time.Minute)) // active
+
+	srv := &Server{
+		State:           st,
+		Tel:             NewTelemetry(0),
+		groupRSSBudget:  512 * 1024 * 1024, // any positive budget; sample is over it
+		groupKeepReader: true,
+		reloadDebounce:  0, // force the slow path every call
+	}
+	srv.reloadBeforeCall()
+
+	if !st.groupResident("A") {
+		t.Fatal("PIN VIOLATED via reloadBeforeCall: active group A evicted under watermark")
+	}
+	if st.groupResident("B") {
+		t.Error("idle LRU group B was not shed by the wired watermark sweep")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,6 +103,28 @@ func resolveGroupKeepReader() bool {
 	}
 }
 
+// resolveGroupRSSBudget returns the configured whole-group MEMORY-WATERMARK budget
+// in BYTES, reading GRAFEL_MCP_GROUP_RSS_BUDGET_MB once at server construction (memory
+// epic #5850, issue #5872 PR3). When resident memory exceeds this budget,
+// reloadBeforeCall evicts LRU groups (State.SweepToMemoryBudget) until back under it.
+//
+// The daemon RSS budget (daemon.ConfiguredRSSBudgetMB) is admission control for the
+// INDEXER scheduler and does not flow into the serve/MCP process (see the PR3
+// grounding doc §1), so this is a dedicated serve-side knob. OPT-IN: default 0
+// (disabled → SweepToMemoryBudget no-ops, behaviour 100% unchanged). A negative or
+// malformed value also disables it. The env value is MB; the returned budget is bytes.
+func resolveGroupRSSBudget() uint64 {
+	v := os.Getenv("GRAFEL_MCP_GROUP_RSS_BUDGET_MB")
+	if v == "" {
+		return 0 // default OFF — opt-in only.
+	}
+	mb, err := strconv.Atoi(v)
+	if err != nil || mb <= 0 {
+		return 0 // disabled / malformed.
+	}
+	return uint64(mb) * 1024 * 1024
+}
+
 // resolveReloadDebounce returns the configured debounce window, reading the
 // env overrides once at server construction. A value of 0 (debounce disabled)
 // is honoured and returned as a zero Duration.
@@ -355,6 +377,16 @@ type Server struct {
 	// mmap Reader mapped (default ON; re-materialize the heap on revive without a
 	// disk re-read) or fully munmaps it. Resolved once from GRAFEL_MCP_GROUP_KEEP_READER.
 	groupKeepReader bool
+
+	// groupRSSBudget is the whole-group MEMORY-WATERMARK budget in BYTES (memory epic
+	// #5850, issue #5872 PR3). When resident memory exceeds it, reloadBeforeCall's slow
+	// path evicts LRU groups (State.SweepToMemoryBudget) — oldest lastAccess first,
+	// pinning the active group — until back under budget, bounding total fleet RSS
+	// regardless of the idle window. Resolved once at construction from
+	// GRAFEL_MCP_GROUP_RSS_BUDGET_MB (see resolveGroupRSSBudget). A zero value disables
+	// it (default OFF — opt-in), making the trigger behaviour-neutral. Stacks with
+	// groupIdleEviction; shares the same debounced slow path (no extra goroutine).
+	groupRSSBudget uint64
 }
 
 // SetActivityBroker wires the MCP activity broker into the server so that
@@ -441,7 +473,7 @@ func NewServer(cfg Config) (*Server, error) {
 		mcpsrv.WithToolCapabilities(true),
 		mcpsrv.WithInstructions(mcpInstructions))
 
-	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce(), bm25IdleEviction: resolveBM25IdleEviction(), groupIdleEviction: resolveGroupIdleEviction(), groupKeepReader: resolveGroupKeepReader()}
+	s := &Server{State: st, Tel: tel, SessMet: sessMet, MCP: srv, cfg: cfg, reloadDebounce: resolveReloadDebounce(), bm25IdleEviction: resolveBM25IdleEviction(), groupIdleEviction: resolveGroupIdleEviction(), groupKeepReader: resolveGroupKeepReader(), groupRSSBudget: resolveGroupRSSBudget()}
 	s.registerTools()
 	return s, nil
 }
@@ -542,6 +574,15 @@ func (s *Server) reloadBeforeCall() {
 	// same debounce, so it runs at most once per window. Stacks with the BM25 sweep
 	// above: a group idle long enough loses BM25 first, then the whole graph.
 	s.State.SweepIdleGroups(s.groupIdleEviction, s.groupKeepReader)
+
+	// Memory-watermark WHOLE-GROUP sweep (issue #5872 PR3) — same debounced slow-path
+	// piggyback: when resident memory exceeds groupRSSBudget, evict LRU groups (oldest
+	// lastAccess first, pinning the active group) until back under budget, bounding
+	// total fleet RSS regardless of the idle window above. Opt-in (default 0 → no-op,
+	// byte-identical behaviour). Fires after the idle sweep so an already-idle group is
+	// reclaimed by the cheaper time trigger first, and only genuine pressure on the
+	// still-resident LRU tail drives this one. Reuses groupKeepReader for symmetry.
+	s.State.SweepToMemoryBudget(s.groupRSSBudget, s.groupKeepReader)
 	if surfaceChanged && s.MCP != nil {
 		// Best-effort: failures are silently ignored. The notification carries
 		// no payload — clients respond by re-issuing tools/list.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"sync"
 	"time"
@@ -1052,6 +1053,13 @@ type State struct {
 	// case Warming() reports "not warming / unknown" gracefully. Read-only — it
 	// never affects scheduling.
 	warmingFn func() daemon.WarmingSnapshot
+
+	// memSampler is the resident-memory sampler used by the memory-watermark
+	// eviction trigger (SweepToMemoryBudget, memory epic #5850, issue #5872 PR3).
+	// Nil in production → heapAllocSample (runtime.ReadMemStats().HeapAlloc, the
+	// metric group eviction actually reclaims — see the PR3 grounding doc). Tests
+	// inject a deterministic closure. Read under s.mu inside SweepToMemoryBudget.
+	memSampler func() uint64
 }
 
 // SetWarmingSnapshot wires a read-only scheduler warming accessor into the
@@ -1933,6 +1941,119 @@ func (s *State) SweepIdleGroups(idle time.Duration, keepReader bool) int {
 		}
 	}
 	return evicted
+}
+
+// heapAllocSample is the production resident-memory sampler: the current Go heap
+// allocation (runtime.ReadMemStats().HeapAlloc). No syscall (a brief STW only), and
+// it reports precisely the arena that whole-group eviction reclaims to GC — the
+// derived-index heap (LabelIndex/adjacency/BM25/overlay), which is what
+// evictGroupLocked drops. Under the default keepReader=true the mmap stays mapped,
+// so the mapped-file portion of RSS is NOT this lever's to release; HeapAlloc is
+// therefore both cheaper AND the metric the watermark trigger actually moves. See
+// .grafel/research/eviction-pr3-grounding.md §3 for the full metric justification.
+//
+// Caveat handled by SweepToMemoryBudget: HeapAlloc is LAGGY — freed heap is reflected
+// only after a GC, and a keepReader evict transiently RAISES it (fresh cold shell). So
+// the watermark trigger samples this ONCE per sweep and sheds a single group, never
+// re-sampling mid-loop (which would misread the lag as "still over budget" and evict
+// every non-pinned group at once).
+func heapAllocSample() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.HeapAlloc
+}
+
+// sampleResidentMem returns the current resident-memory sample, using the injected
+// s.memSampler when present (tests) and heapAllocSample otherwise (production).
+// Caller holds s.mu.
+func (s *State) sampleResidentMem() uint64 {
+	if s.memSampler != nil {
+		return s.memSampler()
+	}
+	return heapAllocSample()
+}
+
+// SweepToMemoryBudget is the MEMORY-PRESSURE eviction trigger (memory epic #5850,
+// issue #5872 PR3): when resident memory exceeds budgetBytes it evicts the SINGLE
+// oldest-lastAccess non-pinned group (LRU victim) and returns how many it evicted
+// (0 or 1). It bounds total fleet RSS regardless of the idle window (PR2's trigger)
+// and stacks with it: SweepIdleGroups reclaims groups a session has paused on; this
+// sheds the LRU tail under real memory pressure even when nothing has been idle long
+// enough.
+//
+// budgetBytes == 0 DISABLES the trigger (returns 0 before locking or sampling), so
+// it is 100% behaviour-neutral when the knob is unset — no sample, no lock, no evict.
+//
+// ONE VICTIM PER SWEEP — and why we do NOT re-sample mid-loop. HeapAlloc (the sample)
+// does not drop the instant a group is evicted: the freed heap is only reflected
+// after a GC, and under the default keepReader=true the evict itself ALLOCATES a fresh
+// cold shell, transiently RAISING HeapAlloc. A loop that re-sampled after each evict
+// would therefore never see the sample fall under budget within one sweep and would
+// evict EVERY non-pinned group on the first breach — a thundering-herd revive storm,
+// the opposite of graduated shedding. Instead we take a single ENTRY sample, shed the
+// one oldest non-pinned group, and return. Successive reloadBeforeCall sweeps — each
+// grounded in a fresh entry sample once GC has reflected the prior frees — shed more
+// if still over budget, converging across windows. reloadBeforeCall fires frequently,
+// so convergence is prompt; and forcing a runtime.GC() here (to make an in-sweep
+// re-sample honest) is deliberately avoided as STW-expensive on the hot-ish path.
+//
+// PIN (same load-bearing safety rule as PR2). The active group — the MAX-lastAccess
+// group the fleet is servicing RIGHT NOW — is NEVER the victim, even under memory
+// pressure: it is the newest by definition, so the oldest-non-pin victim is never it.
+// A flag-on in-flight read on an evicted group would otherwise observe an empty graph.
+// When only the pinned group remains, the sweep evicts nothing (returns 0) — the
+// active working set is never sacrificed no matter how far over budget we are.
+//
+// Locking: takes s.mu once and evicts via evictGroupLocked (the EvictGroup body) —
+// same s.mu → readerMu order the primitive, reload, and the idle sweep use, so no
+// in-flight borrow is unmapped. keepReader is threaded straight to evictGroupLocked.
+func (s *State) SweepToMemoryBudget(budgetBytes uint64, keepReader bool) int {
+	if budgetBytes == 0 {
+		return 0 // disabled — behaviour-neutral, no sample/lock/evict.
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Single ENTRY sample — the only sample this sweep takes. Nothing to do if we are
+	// already under budget (see the doc comment for why we never re-sample mid-loop).
+	if s.sampleResidentMem() <= budgetBytes {
+		return 0
+	}
+
+	// Identify the PIN: the active (max-lastAccess) group, excluded as a victim so the
+	// group the fleet is currently servicing is never evicted — even under memory
+	// pressure (the same hard rule as SweepIdleGroups).
+	pin := ""
+	var pinAt time.Time
+	for name, g := range s.groups {
+		if g == nil {
+			continue
+		}
+		if pin == "" || g.lastAccess.After(pinAt) {
+			pin, pinAt = name, g.lastAccess
+		}
+	}
+
+	// Pick the LRU victim: the oldest-lastAccess group that is NOT the pin. Name is
+	// the deterministic tie-break so equal timestamps evict in a stable order.
+	victim := ""
+	var victimAt time.Time
+	for name, g := range s.groups {
+		if g == nil || name == pin {
+			continue
+		}
+		if victim == "" || g.lastAccess.Before(victimAt) ||
+			(g.lastAccess.Equal(victimAt) && name < victim) {
+			victim, victimAt = name, g.lastAccess
+		}
+	}
+	if victim == "" {
+		return 0 // only the pinned group remains — never sacrifice the active set.
+	}
+	if s.evictGroupLocked(victim, keepReader) {
+		return 1
+	}
+	return 0
 }
 
 // SnapshotGroups returns a stable list of loaded group pointers.


### PR DESCRIPTION
## What
PR3 of per-group eviction (#5872) — a memory-pressure trigger on top of PR2's idle-time eviction. When resident memory exceeds a budget, evict the LRU group; bounds fleet RSS. Default OFF.

- `SweepToMemoryBudget(budgetBytes, keepReader)` (state.go), fired from `reloadBeforeCall`: single entry-sample of `HeapAlloc` (via injectable `memSampler`); if over budget, evict the **single oldest-lastAccess non-pinned group** and return. Convergence is graduated **across** successive sweeps (each grounded in a fresh entry sample after GC reflects prior frees) — NOT within one sweep.
- Knob `GRAFEL_MCP_GROUP_RSS_BUDGET_MB` (default 0/OFF).
- Pin (max-lastAccess/active group) structurally excluded from victim selection.

## Why one-per-sweep (not evict-until-under-budget)
Review caught that `HeapAlloc` doesn't drop until a GC runs — and under the default `keepReader` an evict *allocates* a fresh cold-shell, transiently *raising* HeapAlloc. A mid-loop re-sample would therefore never see the free and would **evict every non-pinned group on the first breach** (a thundering-herd revive storm). One-victim-per-sweep + entry-sample-only avoids that with no forced GC and no per-group byte estimate.

## Tests (mutation-proven)
- `OneVictimPerSweepNoThunderingHerd` + `ConvergesAcrossSweepsLRUOrder` use a `fixedSampler` that stays over-budget regardless of residency (models the GC-lag). Mutation: revert to the mid-loop evict-until-under → both FAIL (`got 2 want 1`, thundering herd).
- Pin-under-pressure (10 sweeps, active survives), disabled=byte-identical (sampler never called), concurrent-query-during-sweep (`-race`).

Independently reviewed twice (the first caught the over-eviction; this fix re-reviewed APPROVE, mutation confirmed). `go test ./internal/mcp/...` 1243 pass, `-race` clean.

Refs #5872

🤖 Generated with [Claude Code](https://claude.com/claude-code)