### PR TITLE
feat(mcp): default mmap serving ON (platform-conditional: macOS/Linux on, Windows opt-in) — ADR-0027

### DIFF
--- a/internal/mcp/group_algo_overlay_apply_5354_test.go
+++ b/internal/mcp/group_algo_overlay_apply_5354_test.go
@@ -126,6 +126,13 @@ func entityByID(grp *LoadedGroup, id string) *graph.Entity {
 // TestApplyOverlay_GroupValuesAppliedAtLoad: with a fresh overlay present, a
 // cross-repo entity reads the GROUP community_id + pagerank after Reload.
 func TestApplyOverlay_GroupValuesAppliedAtLoad(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): this test verifies the
+	// applyGroupAlgoOverlay Doc-STAMP mechanism by reading lr.Doc.Entities through
+	// entityByID. Under GRAFEL_SERVE_FROM_MMAP=on the Doc is header-only-empty by
+	// design (overlay values live in the Reader + overlay side-table, surfaced via
+	// LabelIndex.at), so entityByID sees nothing. The flag-ON side-table equivalent
+	// is covered by overlay_sidetable_parity_test.go — this test owns the Doc path.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, serviceID, leafID := setupApplyGroup(t)
 
 	ov := &groupalgo.Overlay{
@@ -176,6 +183,10 @@ func TestApplyOverlay_GroupValuesAppliedAtLoad(t *testing.T) {
 // TestApplyOverlay_AbsentIsNoop: with no overlay, entities keep their graph.fb
 // values (here: nil/unset). No panic, no group values.
 func TestApplyOverlay_AbsentIsNoop(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): asserts entities keep their
+	// graph.fb (nil) values via entityByID → lr.Doc.Entities. Flag-ON the Doc is
+	// header-only-empty by design, so this Doc-stamp assertion is OFF-path only.
+	forceServeFromMMap(t, false)
 	st, overlayPath, _, serviceID, _ := setupApplyGroup(t)
 	// Ensure no overlay exists.
 	_ = os.Remove(overlayPath)
@@ -205,6 +216,10 @@ func TestApplyOverlay_AbsentIsNoop(t *testing.T) {
 // TestApplyOverlay_StaleNotApplied: an overlay whose recorded source mtime no
 // longer matches the current graph.fb mtime is treated as stale → not applied.
 func TestApplyOverlay_StaleNotApplied(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the stale-overlay-not-applied
+	// staleness gate is flag-independent, but the assertion reads lr.Doc.Entities
+	// via entityByID, which is header-only-empty under flag-ON by design.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
 
 	// Record DELIBERATELY-WRONG source mtimes so the overlay is stale vs the
@@ -241,6 +256,10 @@ func TestApplyOverlay_StaleNotApplied(t *testing.T) {
 // overlay (different values, fresh mtimes) and reloading picks up v2 without a
 // graph.fb change.
 func TestApplyOverlay_MidSessionSwap(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the mid-session overlay swap +
+	// re-apply logic is flag-independent, but the v1/v2 assertions read the stamped
+	// values from lr.Doc.Entities via entityByID — header-only-empty under flag-ON.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
 
 	write := func(pr float64) {

--- a/internal/mcp/group_algo_overlay_readpath_5729_test.go
+++ b/internal/mcp/group_algo_overlay_readpath_5729_test.go
@@ -71,6 +71,12 @@ func chtimes5729(t *testing.T, path string, mt time.Time) {
 // re-stamp that repo back to its overlay community, because applyGroupAlgoOverlay
 // is memoized PER REPO, not just by the overlay file's mtime.
 func TestGroupReadPath_ReStampsStaleRepoWithoutOverlayFileChange(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the read-path per-repo
+	// re-stamp trigger is flag-independent, but this test drives it by MUTATING
+	// mobLR.Doc.Entities[i].CommunityID and reading the result via entityByID.
+	// Under flag-ON the Doc is header-only-empty by design (values flow through the
+	// Reader + overlay side-table), so both the mutation and the read are no-ops.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, beID, feID, mobID, _, _ := setupThreeRepoApplyGroup(t)
 
 	ov := buildOverlayFor5729(cur, beID, feID, mobID)
@@ -132,6 +138,10 @@ func TestGroupReadPath_ReStampsStaleRepoWithoutOverlayFileChange(t *testing.T) {
 // must fall through to applyGroupAlgoOverlay ONLY when some repo is actually
 // stale, not on every call.
 func TestGroupReadPath_SteadyStateDoesNotReApplyWhenNothingStale(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the steady-state no-op guard
+	// (grp.algoMt must not advance) is flag-independent, but the final community
+	// assertion reads lr.Doc.Entities via entityByID — header-only-empty flag-ON.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, beID, feID, mobID, _, _ := setupThreeRepoApplyGroup(t)
 
 	ov := buildOverlayFor5729(cur, beID, feID, mobID)

--- a/internal/mcp/group_algo_overlay_reapply_5403_test.go
+++ b/internal/mcp/group_algo_overlay_reapply_5403_test.go
@@ -26,6 +26,12 @@ import (
 // cached group reflects the NEW overlay without a Reload. It also asserts the
 // cheap path (unchanged mtime → no re-apply) and absence-tolerance.
 func TestGroupReapplyOverlayOnMtimeAdvance(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the mtime-advance re-apply
+	// trigger (State.Group re-stamps when the overlay file mtime moves) is
+	// flag-independent, but every community/pagerank assertion reads lr.Doc.Entities
+	// via entityByID — header-only-empty under flag-ON by design, values then live
+	// in the Reader + overlay side-table (covered by overlay_sidetable_parity_test).
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, beID, feID, mobID, _, _ := setupThreeRepoApplyGroup(t)
 
 	// --- v1 overlay: mobile → community 80.

--- a/internal/mcp/group_algo_overlay_restamp_5400_test.go
+++ b/internal/mcp/group_algo_overlay_restamp_5400_test.go
@@ -123,6 +123,12 @@ func setupThreeRepoApplyGroup(t *testing.T) (st *State, overlayPath string, cur 
 // Without the per-repo re-stamp fix, the mobile entity reverts to community_id:-1
 // and inspect/stats/clusters drop it. With the fix it keeps overlay community 80.
 func TestApplyOverlay_ReStampsReparsedMobileRepo(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): the re-stamp-on-reparse logic is
+	// flag-independent, but this test asserts the stamped community by reading
+	// lr.Doc.Entities via entityByID and re-writing the mobile repo's graph.fb to
+	// force a reparse. Under flag-ON the Doc is header-only-empty by design (overlay
+	// values surface through the Reader + side-table), so the Doc read is empty.
+	forceServeFromMMap(t, false)
 	st, overlayPath, cur, beID, feID, mobID, mobStateDir, mobDoc := setupThreeRepoApplyGroup(t)
 
 	// Overlay assigns the mobile module to a real cross-repo community (80),

--- a/internal/mcp/mmapview.go
+++ b/internal/mcp/mmapview.go
@@ -22,6 +22,7 @@ package mcp
 
 import (
 	"os"
+	"runtime"
 	"strings"
 	"unsafe"
 
@@ -29,21 +30,44 @@ import (
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
 )
 
-// GRAFEL_SERVE_FROM_MMAP, when truthy, makes the hot-index build read through the
-// mmap (mmapEntityViewSource) instead of the heap Document (docEntityViewSource).
-// Default OFF: default serve behaviour is byte-identical to the pre-F3 heap path.
-// Read ONCE at package load (below), never per-query, per ADR-0027 §F3.
+// GRAFEL_SERVE_FROM_MMAP makes the hot-index build read through the mmap
+// (mmapEntityViewSource) instead of the heap Document (docEntityViewSource).
+//
+// Default is PLATFORM-CONDITIONAL (ADR-0027 mmap cutover, epic #5850):
+//   - macOS / Linux: default ON (validated). unset/""/malformed → mmap read path.
+//   - Windows: default OFF (opt-in). A memory-mapped graph.fb blocks the
+//     reindex-while-serving rewrite — os.Rename over a mapped file fails with
+//     ERROR_USER_MAPPED_FILE — so serving from a resident mmap Reader by default
+//     is unsafe there until a Windows-safe reindex strategy lands (tracked
+//     separately). The read path itself works on Windows; only the
+//     resident-reader-vs-reindex file-locking interaction is the blocker, so a
+//     Windows user can still explicitly opt IN via GRAFEL_SERVE_FROM_MMAP=1.
+//
+// An explicit token overrides the platform default on EVERY OS: 0/false/no/off
+// force OFF, 1/true/yes/on force ON. Read ONCE at package load (below), never
+// per-query, per ADR-0027 §F3.
 var serveFromMMapEnabled = parseServeFromMMapFlag(os.Getenv("GRAFEL_SERVE_FROM_MMAP"))
 
+// defaultServeFromMMapForOS returns the platform default when the env flag is
+// unset/""/malformed: ON everywhere except Windows, where the mmap'd graph.fb
+// blocks the reindex rewrite (ERROR_USER_MAPPED_FILE on os.Rename). Testable so
+// the per-OS default is unit-verifiable without depending on runtime.GOOS.
+func defaultServeFromMMapForOS(goos string) bool { return goos != "windows" }
+
 // parseServeFromMMapFlag interprets the env value. Pure and total so the flag
-// wiring is unit-testable without mutating process env. Truthy: 1/true/yes/on
-// (case-insensitive, trimmed); everything else — including "" — is OFF.
+// wiring is unit-testable without mutating process env. An explicit off token —
+// 0/false/no/off (case-insensitive, trimmed) — forces OFF and an explicit truthy
+// token — 1/true/yes/on — forces ON, on every platform (opt-out / opt-in work
+// everywhere). unset/""/malformed falls back to the platform default
+// (defaultServeFromMMapForOS): ON on macOS/Linux, OFF on Windows.
 func parseServeFromMMapFlag(v string) bool {
 	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "0", "false", "no", "off":
+		return false
 	case "1", "true", "yes", "on":
 		return true
 	default:
-		return false
+		return defaultServeFromMMapForOS(runtime.GOOS)
 	}
 }
 

--- a/internal/mcp/mmapview_test.go
+++ b/internal/mcp/mmapview_test.go
@@ -287,17 +287,43 @@ func idsOfViews(vs []graph.EntityView) []string {
 	return out
 }
 
+// TestDefaultServeFromMMapForOS pins the platform default (ADR-0027 mmap cutover,
+// epic #5850): ON everywhere except Windows, where a mapped graph.fb blocks the
+// reindex rewrite (ERROR_USER_MAPPED_FILE on os.Rename).
+func TestDefaultServeFromMMapForOS(t *testing.T) {
+	if defaultServeFromMMapForOS("windows") {
+		t.Errorf("defaultServeFromMMapForOS(windows) = true, want false (opt-in on Windows)")
+	}
+	for _, goos := range []string{"linux", "darwin"} {
+		if !defaultServeFromMMapForOS(goos) {
+			t.Errorf("defaultServeFromMMapForOS(%q) = false, want true (default ON)", goos)
+		}
+	}
+}
+
 // TestParseServeFromMMapFlag pins the flag parser (the flag is read once at load
-// from this pure function). Default OFF; only explicit truthy values enable.
+// from this pure function). Explicit tokens force ON/OFF on every platform;
+// unset/""/malformed fall back to the platform default (defaultServeFromMMapForOS).
 func TestParseServeFromMMapFlag(t *testing.T) {
+	// Explicit truthy tokens force ON regardless of platform (Windows opt-in).
 	for _, on := range []string{"1", "true", "TRUE", "yes", "on", " On "} {
 		if !parseServeFromMMapFlag(on) {
 			t.Errorf("parseServeFromMMapFlag(%q) = false, want true", on)
 		}
 	}
-	for _, off := range []string{"", "0", "false", "no", "off", "nope"} {
+	// Explicit off tokens force OFF regardless of platform (opt-out everywhere).
+	for _, off := range []string{"0", "false", "FALSE", "no", "off", " Off "} {
 		if parseServeFromMMapFlag(off) {
 			t.Errorf("parseServeFromMMapFlag(%q) = true, want false", off)
+		}
+	}
+	// unset/""/malformed follow the current platform's default, so this assertion
+	// stays correct on whatever OS CI runs it (ON on darwin/linux, OFF on Windows).
+	want := defaultServeFromMMapForOS(runtime.GOOS)
+	for _, def := range []string{"", "   ", "nope", "maybe"} {
+		if got := parseServeFromMMapFlag(def); got != want {
+			t.Errorf("parseServeFromMMapFlag(%q) = %v, want %v (platform default for %s)",
+				def, got, want, runtime.GOOS)
 		}
 	}
 }

--- a/internal/mcp/reader_index_parity_pr2_test.go
+++ b/internal/mcp/reader_index_parity_pr2_test.go
@@ -185,7 +185,16 @@ func TestLabelIndexMaterializesFreshPointers_PR2(t *testing.T) {
 // id->*Entity map (values fixed for the reload) sourced from the Reader, so its
 // consumers are insulated from the per-lookup pointer instability above.
 func TestGetByIDMaterializesStableMap_PR2(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel: forceServeFromMMap mutates the package-global flag, which is
+	// only -race-safe when the test runs to completion before any parallel test
+	// reads the flag (see forceServeFromMMap's doc).
+	// OFF-path pin (ADR-0027 mmap default-on flip): getByID pointer STABILITY across
+	// calls is an OFF-path property. Flag-ON (Reader present) getByID resolves each
+	// id through LabelIndex.at, which MATERIALIZES a fresh heap copy per call by
+	// design — so two calls return DISTINCT pointers (the intended instability the
+	// PR2 audit gates PR7 on, see TestLabelIndexMaterializesFreshPointers_PR2). The
+	// stable-map contract only holds on the memoized Doc-backed path.
+	forceServeFromMMap(t, false)
 	doc, r := loadParityIndexFixture(t)
 	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
 
@@ -240,7 +249,17 @@ func docEntityByID(doc *graph.Document, id string) *graph.Entity {
 // surfaces the graph.fb sentinel CommunityID, not the stamped 80 — proving the
 // Doc value-source is load-bearing for the flag-off path.
 func TestLabelIndexSurfacesOverlayStampedFields_PR2(t *testing.T) {
-	t.Parallel()
+	// NOT t.Parallel: forceServeFromMMap mutates the package-global flag (see below).
+	//
+	// OFF-path pin (ADR-0027 mmap default-on flip): as this test's own doc states,
+	// it is the invariant test for "values come from the overlaid Doc, NEVER the
+	// Reader" on the DEFAULT (GRAFEL_SERVE_FROM_MMAP OFF) serve path. The fixture
+	// stamps overlay-only fields onto lr.Doc.Entities directly and never populates
+	// the flag-ON side-table (lr.LabelIndex.overlay), so under flag-ON LabelIndex.at
+	// materializes from the Reader + empty side-table and correctly surfaces the
+	// graph.fb sentinel (nil CommunityID). The flag-ON Reader+side-table surfacing
+	// path is covered separately by TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc.
+	forceServeFromMMap(t, false)
 	doc, r := loadParityIndexFixture(t)
 	lr := &LoadedRepo{Repo: "repo", Doc: doc, Reader: r, LabelIndex: BuildLabelIndexFromReader(r, doc)}
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3068,6 +3068,12 @@ func writeGraphFB(t *testing.T, repoDir string, doc *graph.Document) string {
 // State.Reload() must load repos that have only graph.fb (no graph.json).
 // Previously the stat-guard pointed at graph.json → ENOENT → repo silently dropped.
 func TestReloadFBOnlyRepo(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): this test counts materialized
+	// entities via len(lr.Doc.Entities)==4. Under GRAFEL_SERVE_FROM_MMAP=on the
+	// fb-backed repos load a HEADER-ONLY Document by design (entities served from
+	// the resident Reader, not the heap Doc), so len(Doc.Entities)==0 for the fb
+	// repos. The flag-ON entity-count path is exercised via the Reader elsewhere.
+	forceServeFromMMap(t, false)
 	dir := t.TempDir()
 
 	// Three repos: one with graph.json only, one with graph.fb only, one with both.

--- a/internal/mcp/topk_pagerank_overlay_test.go
+++ b/internal/mcp/topk_pagerank_overlay_test.go
@@ -131,6 +131,17 @@ func buildOverlayAwareLoadedRepo(t *testing.T) *LoadedRepo {
 // insertion/id order (alpha, bravo, charlie, delta, echo) instead of the
 // overlay order (charlie, alpha, delta, bravo, ...).
 func TestGetTopKPageRank_OverlayOrder_NotReaderSentinel(t *testing.T) {
+	// OFF-path pin (ADR-0027 mmap default-on flip): this is the PR1 Doc-SOURCING
+	// regression guard — its own doc states the asserted overlay order "is only
+	// possible when the Doc, not the Reader, is the source of truth." The fixture
+	// (buildOverlayAwareLoadedRepo) stamps PageRank onto lr.Doc.Entities only and
+	// builds NO LabelIndex / overlay side-table, so under flag-ON getTopKPageRank
+	// routes to buildTopKPageRankFromSideTable and reads an empty side-table →
+	// sentinel (id) order. The flag-ON side-table path is a DIFFERENT code path,
+	// correct and separately covered by
+	// TestGetTopKPageRank_FlagOnOffParity_SideTableNotSentinel (which builds the
+	// side-table via st.Reload → applyGroupAlgoOverlay and passes flag-on).
+	forceServeFromMMap(t, false)
 	lr := buildOverlayAwareLoadedRepo(t)
 
 	got := lr.getTopKPageRank()


### PR DESCRIPTION
## What
Flips the `GRAFEL_SERVE_FROM_MMAP` default to **ON on macOS/Linux**, **opt-in (OFF) on Windows** — the read-side memory epic's (#5850) production default. Serve now defaults to lazy mmap serving (compact resident index + materialize-on-demand) instead of the full-heap Document.

- `parseServeFromMMapFlag`: explicit `0/false/no/off` → OFF and `1/true/yes/on` → ON on **every** platform (opt-out / opt-in work everywhere); unset/malformed → `defaultServeFromMMapForOS(runtime.GOOS)` (ON darwin/linux, OFF windows).
- **Windows is opt-in** because a memory-mapped `graph.fb` blocks the reindex rewrite (`ERROR_USER_MAPPED_FILE` on `os.Rename`) — a pre-existing, flag-independent interaction (resident reader since v0.1.8.3 / S8 #2159), tracked as **#5891**. With the default OFF on Windows, Windows runs the same serve path as v0.1.8.3 → no new Windows risk.

## Test triage (12 failures the full-suite-under-default-ON run surfaced)
Flipping the process-wide default exposed 12 tests that silently assumed flag-OFF (read `Doc.Entities` directly / assert Doc-pointer stability / build overlay via Doc-stamp only — all header-only-empty or side-table-empty flag-ON *by design*). Each was triaged (not blanket-pinned) and classified (a) OFF-path-specific or (b) fixture-assumes-Doc-stamp, then pinned `forceServeFromMMap(t,false)` with justification. **Zero real product bugs.**

## Reviews
- **Coverage-hole review (APPROVE):** confirmed the 4 flag-ON behaviors the pinned tests covered are independently verified by tests that RUN flag-ON and assert the real properties (overlay values via `TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc`, topk order via the PR5 sentinel-trap parity test, `getByID` overlay surfacing, header-only-Doc resolution via the PR7 flip tests). No hidden bug, no coverage hole.
- **Cross-platform grounding:** mmap reads work on all 3 OSes; `readerMu` protection is signal-agnostic; the Windows reindex risk is pre-existing (#5891), not a v0.1.9 regression.

`go test ./internal/mcp/... ./internal/graph/...` 1491 pass on darwin (default ON); `-race` clean on the safety families.

Refs #5850
Refs #5891

🤖 Generated with [Claude Code](https://claude.com/claude-code)