### PR TITLE
test(mcp): release mmap Reader before TempDir cleanup + sync eviction test barrier

### DIFF
--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -753,6 +753,9 @@ func TestLoadedRepo_testsEdgeCacheFromReader_PR1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
+	// Windows: release the mmap'd graph.fb Reader before t.TempDir() cleanup
+	// runs (unlink-while-mapped fails with "Access is denied" on Windows).
+	t.Cleanup(srv.Close)
 
 	lg := srv.State.Group("g")
 	if lg == nil {

--- a/internal/mcp/enumerate_by_kind_pr4b_test.go
+++ b/internal/mcp/enumerate_by_kind_pr4b_test.go
@@ -81,6 +81,11 @@ func wireLoadedRepoReader(t *testing.T, lr *LoadedRepo, doc *graph.Document) {
 	}
 	h := newMapHandle(rdr)
 	lr.publishHandle(h)
+	// Windows: a memory-mapped file cannot be unlinked while the mapping is
+	// live (ERROR_USER_MAPPED_FILE). t.Cleanup registered here runs (LIFO)
+	// BEFORE the t.TempDir() RemoveAll registered above, so the mmap is
+	// released before the temp dir is removed.
+	t.Cleanup(lr.retireHandle)
 }
 
 func TestEnumerateByKind_FoldCapStopsAtRepoBoundary_FlagOff(t *testing.T) {

--- a/internal/mcp/mem_watermark_evict_5872_pr3_test.go
+++ b/internal/mcp/mem_watermark_evict_5872_pr3_test.go
@@ -219,7 +219,19 @@ func TestSweepToMemoryBudget_ConcurrentQueryDuringSweep(t *testing.T) {
 	now := time.Now()
 	setLastAccess(st, "B", now.Add(-20*time.Minute))
 	setLastAccess(st, "C", now.Add(-30*time.Minute))
-	// A is queried continuously below (always the freshly-stamped max-lastAccess pin).
+	// Establish A as the active (max-lastAccess) group BEFORE the sweep loop starts.
+	// Without this synchronous touch, A's lastAccess is the zero value until the
+	// query goroutine below happens to run for the first time — a race against the
+	// sweep goroutine, which can start sweeping (and evict A as the oldest-lastAccess
+	// group) before that first touch lands. This is a test-harness synchronization
+	// gap, not a product bug: reproduced deterministically on macOS with
+	// GOMAXPROCS=1 (the sweep goroutine's first iteration ran before the query
+	// goroutine's), confirming the flake is scheduler-timing-dependent rather than a
+	// real pin/eviction defect. A is queried continuously below (always the
+	// freshly-stamped max-lastAccess pin, now that it has a non-zero baseline).
+	if grp := st.Group("A"); grp == nil {
+		t.Fatal("group A not resident after seeding")
+	}
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})


### PR DESCRIPTION
Fixes the 4 Windows-only test failures that blocked the v0.1.9 3-OS CI gate. Test-only changes; no product code touched. Refs #5850.

**3× mmap teardown (`TestEnumerateByKind_FlagOnOffParity`, `..._FoldCapStopsAtRepoBoundary_FlagOn`, `TestLoadedRepo_testsEdgeCacheFromReader_PR1`):** on Windows a memory-mapped file can't be unlinked while mapped (`ERROR_USER_MAPPED_FILE`), so `t.TempDir()`'s auto `RemoveAll` failed on the still-mapped `graph.fb`. Fix registers `t.Cleanup(lr.retireHandle)` / `t.Cleanup(srv.Close)` *after* `t.TempDir()`, so Go's LIFO cleanup munmaps before the temp-dir wipe. Uses existing production primitives; same pattern as ~10 sibling tests.

**1× eviction test (`TestSweepToMemoryBudget_ConcurrentQueryDuringSweep`):** proven test-harness synchronization gap, not a product bug — group A's `lastAccess` was the zero value (never routed) until first `Group("A")`, so the watermark sweep correctly evicted it as oldest. `Group()` stamps `lastAccess` under `s.mu` before returning and the sweep runs under the same lock, so no production window exists where an active group has zero `lastAccess`. Fix adds a synchronous `Group("A")` touch before the concurrent goroutines. Verified: reverting the touch fails deterministically (500/500) with **no `-race` DATA RACE**; applied → 500/500 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o