### PR TITLE
feat(#5891): generation-file graph layout + pointer resolution (reindex-while-serving safe on Windows)

### DIFF
--- a/cmd/grafel/daemon_mcp_cache.go
+++ b/cmd/grafel/daemon_mcp_cache.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"path/filepath"
-
 	"github.com/cajasmota/grafel/internal/daemon"
 	daemonalgo "github.com/cajasmota/grafel/internal/daemon/algo"
 	daemonmcp "github.com/cajasmota/grafel/internal/daemon/mcp"
@@ -13,15 +11,9 @@ import (
 //
 // The cache is constructed once at startup with the default capacity
 // (10 mmap'd graph.fb handles). The scheduler-wrapping IndexFn hooks
-// below call Invalidate after a successful index pass so the next MCP
-// query reopens the freshly written file.
+// below call InvalidateDir after a successful index pass so the next MCP
+// query reopens the freshly written generation.
 var daemonMCPCache = daemonmcp.NewCache(daemonmcp.DefaultCapacity)
-
-// repoGraphFBPath is the canonical on-disk location of a repo's
-// FlatBuffers graph, matching the path used in Index().
-func repoGraphFBPath(repoPath string) string {
-	return filepath.Join(daemon.StateDirForRepo(repoPath), "graph.fb")
-}
 
 // invalidateAfterIndex is the post-index hook: it drops any cached
 // reader for repoPath's graph.fb so the next MCP query re-mmap's the
@@ -29,9 +21,13 @@ func repoGraphFBPath(repoPath string) string {
 // so the next rank-sensitive MCP query triggers a fresh algorithm pass.
 // Safe to call on the error path too.
 func invalidateAfterIndex(repoPath string) {
-	daemonMCPCache.Invalidate(repoGraphFBPath(repoPath))
+	// #5891: evict by state dir, not by a fixed graph.fb path. The reindex just
+	// wrote a NEW graph.<gen>.fb and flipped the pointer, so the resident handle
+	// is keyed by the superseded gen path; InvalidateDir drops it regardless of
+	// gen number so the next MCP query re-mmaps the freshly written generation.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	daemonMCPCache.InvalidateDir(stateDir)
 	// S2: invalidate the on-demand algo cache so ranking tools recompute
 	// against the newly written graph.fb on next query.
-	stateDir := daemon.StateDirForRepo(repoPath)
 	_ = daemonalgo.Invalidate(stateDir) // non-fatal; log is inside Invalidate
 }

--- a/cmd/grafel/daemon_tier.go
+++ b/cmd/grafel/daemon_tier.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/tier"
 	"github.com/cajasmota/grafel/internal/daemon/watch"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -149,9 +150,9 @@ func registerKnownGroupsCold(logger *slog.Logger) {
 				if ref == "_unknown" {
 					continue // sentinel — skip per ErrUnknownRef semantics
 				}
-				fbPath := filepath.Join(refsDir, ref, "graph.fb")
+				fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, ref)) // #5891
 				if _, statErr := os.Stat(fbPath); statErr != nil {
-					continue // no graph.fb yet
+					continue // no graph yet (gen or legacy flat)
 				}
 				isPinned := tier.IsDefaultBranch(repoPath, ref)
 				kind := tier.SlotKindBranchFeature
@@ -360,10 +361,11 @@ func groupsForRepoPath(repoPath string) []string {
 // mmap'd graph.fb on disk is the source of truth, so dropping them is safe and
 // they rebuild lazily on the next dashboard request for the group.
 func tierEvictCallback(key tier.SlotKey) {
-	// Invalidate the mmap'd fbreader in the MCP graph cache.
+	// Invalidate the mmap'd fbreader in the MCP graph cache. #5891: evict by
+	// state dir so whichever graph.<gen>.fb (or legacy flat graph.fb) is
+	// resident for this slot is dropped, regardless of generation number.
 	stateDir := daemon.StateDirForRepoRef(key.RepoPath, key.Ref)
-	fbPath := filepath.Join(stateDir, "graph.fb")
-	daemonMCPCache.Invalidate(fbPath)
+	daemonMCPCache.InvalidateDir(stateDir)
 
 	// #5238: drop the dashboard GraphCache's materialised state for this repo's
 	// group(s) so its derived heap is reclaimed promptly on idle rather than
@@ -393,7 +395,7 @@ func tierEvictCallback(key tier.SlotKey) {
 // is safe even when the subscription is already active.
 func tierReloadCallback(key tier.SlotKey) error {
 	stateDir := daemon.StateDirForRepoRef(key.RepoPath, key.Ref)
-	fbPath := filepath.Join(stateDir, "graph.fb")
+	fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active generation
 	// Prime the cache by opening and immediately releasing the reader.
 	_, release, err := daemonMCPCache.Get(fbPath)
 	if err != nil {

--- a/cmd/grafel/fb_default_test.go
+++ b/cmd/grafel/fb_default_test.go
@@ -28,7 +28,7 @@ func TestIndex_FBOnlyByDefault(t *testing.T) {
 	}
 
 	// graph.fb MUST be written.
-	fbPath := filepath.Join(tmp, "graph.fb")
+	fbPath := graph.CurrentGraphPath(tmp) // #5891: resolve active gen (graph.<gen>.fb)
 	info, err := os.Stat(fbPath)
 	if err != nil {
 		t.Fatalf("graph.fb not written (ADR-0016 flip-day regression): %v", err)
@@ -66,7 +66,7 @@ func TestIndex_ExportJSON(t *testing.T) {
 	}
 
 	// graph.fb MUST also be present.
-	fbPath := filepath.Join(tmp, "graph.fb")
+	fbPath := graph.CurrentGraphPath(tmp) // #5891: resolve active gen (graph.<gen>.fb)
 	if _, err := os.Stat(fbPath); err != nil {
 		t.Fatalf("graph.fb not written with --export-json: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestIndex_ExportFBDeprecatedNoOp(t *testing.T) {
 	}
 
 	// graph.fb must exist (always-on since #808).
-	fbPath := filepath.Join(tmp, "graph.fb")
+	fbPath := graph.CurrentGraphPath(tmp) // #5891: resolve active gen (graph.<gen>.fb)
 	if _, err := os.Stat(fbPath); err != nil {
 		t.Fatalf("graph.fb not written even with deprecated --export-fb: %v", err)
 	}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -572,9 +572,12 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 
 		// ADR-0016 flip-day (#808): always emit graph.fb first.
 		// graph.json is emitted alongside unless --skip-json was passed.
-		fbPath := filepath.Join(filepath.Dir(outPath), "graph.fb")
-		if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
-			fmt.Fprintf(os.Stderr, "grafel: graph.fb write failed: %v\n", err)
+		// #5891 gen layout: write a NEW graph.<gen>.fb + flip the `current`
+		// pointer instead of overwriting a fixed graph.fb. fbPath is the gen
+		// file actually written (used below for the identical-mtime stamp).
+		fbPath, fbErr := fbwriter.WriteGraphGen(filepath.Dir(outPath), doc)
+		if fbErr != nil {
+			fmt.Fprintf(os.Stderr, "grafel: graph.fb write failed: %v\n", fbErr)
 			// Non-fatal — we still try to write graph.json so the system
 			// remains functional. If both fail, the error from graph.json
 			// propagates below.

--- a/cmd/grafel/index_enrichment_bg_test.go
+++ b/cmd/grafel/index_enrichment_bg_test.go
@@ -46,7 +46,7 @@ func TestIndex_GraphWrittenBeforeEnrichment(t *testing.T) {
 		t.Fatalf("Index: %v", err)
 	}
 
-	fbPath := filepath.Join(tmp, "graph.fb")
+	fbPath := graph.CurrentGraphPath(tmp) // #5891: resolve active gen (graph.<gen>.fb)
 	if _, err := os.Stat(fbPath); err != nil {
 		t.Fatalf("graph.fb not written: %v", err)
 	}

--- a/internal/cli/branches.go
+++ b/internal/cli/branches.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/tier"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -235,7 +236,7 @@ func repoBaseForSlug(storeRoot string, repo registry.Repo) string {
 // without requiring a live daemon. It reads the graph.fb mtime and maps it
 // to HOT/WARM/COLD/EXPIRED using the default TTL windows.
 func inferTierFromDisk(stateDir string) (tierStr string, lastSeen time.Time) {
-	fbPath := filepath.Join(stateDir, "graph.fb")
+	fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 	jsonPath := filepath.Join(stateDir, "graph.json")
 
 	var mtime time.Time

--- a/internal/cli/cleanup.go
+++ b/internal/cli/cleanup.go
@@ -6,7 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -137,7 +136,14 @@ func collectActiveEmbeddingHashes() (map[string]bool, error) {
 		if d.IsDir() {
 			return nil
 		}
-		if !strings.HasSuffix(path, "graph.fb") {
+		// #5891: recognise generation files (graph.<gen>.fb), and process each
+		// state dir exactly once — only when this path is the ACTIVE generation
+		// resolved by the pointer (or the legacy flat graph.fb) — so a dir with
+		// current+previous gens isn't walked twice.
+		if !graph.IsGraphFileName(filepath.Base(path)) {
+			return nil
+		}
+		if path != graph.CurrentGraphPath(filepath.Dir(path)) {
 			return nil
 		}
 		doc, loadErr := graph.LoadGraphFromDir(filepath.Dir(path))

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -224,7 +224,7 @@ func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
 	for _, r := range cfg.Repos {
 		stateDir := daemon.StateDirForRepo(r.Path)
 		jsonSrc := daemon.GraphPathForRepo(r.Path)
-		fbSrc := filepath.Join(stateDir, "graph.fb")
+		fbSrc := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 
 		hasFB := func() bool { _, e := os.Stat(fbSrc); return e == nil }()
 		hasJSON := func() bool { _, e := os.Stat(jsonSrc); return e == nil }()
@@ -319,7 +319,7 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 	graphPaths := make(map[string]string, len(cfg.Repos)) // slug → graph.json path for WriteAtomic
 	for _, r := range cfg.Repos {
 		stateDir := daemon.StateDirForRepo(r.Path)
-		fbPath := filepath.Join(stateDir, "graph.fb")
+		fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 		jsonPath := daemon.GraphPathForRepo(r.Path)
 		// Check that at least one graph file exists before attempting load.
 		hasFB := func() bool { _, e := os.Stat(fbPath); return e == nil }()
@@ -417,8 +417,9 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 		// must be updated together so that LoadGraphFromDir and any tool that
 		// reads graph.json directly see the same entity set (fixes #1702).
 		stateDir := filepath.Dir(graphPaths[slug])
-		fbPath := filepath.Join(stateDir, "graph.fb")
-		if fbErr := fbwriter.WriteAtomic(fbPath, doc); fbErr != nil {
+		// #5891: gen write + pointer flip (no rename-over a mapped graph.fb).
+		fbPath, fbErr := fbwriter.WriteGraphGen(stateDir, doc)
+		if fbErr != nil {
 			return added, fmt.Errorf("phantom-edge pass: write graph.fb %s: %w", slug, fbErr)
 		}
 		p := graphPaths[slug]

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -199,7 +199,7 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 					continue // skip the hot ref
 				}
 				// Only include slots that actually have a graph.
-				fbPath := filepath.Join(refsDir, refSafe, "graph.fb")
+				fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe)) // #5891
 				if _, statErr := os.Stat(fbPath); statErr == nil {
 					rs.ColdRefs = append(rs.ColdRefs, daemon.RefSafeDecode(refSafe))
 				}

--- a/internal/daemon/algo/cache.go
+++ b/internal/daemon/algo/cache.go
@@ -23,6 +23,8 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 const cacheFileName = "algo_results.fb"
@@ -158,7 +160,7 @@ func cacheKey(stateDir string) string { return stateDir }
 // staleness.
 func readFromDisk(stateDir string) (*Results, bool) {
 	cachePath := filepath.Join(stateDir, cacheFileName)
-	graphPath := filepath.Join(stateDir, "graph.fb")
+	graphPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 
 	cacheInfo, err := os.Stat(cachePath)
 	if err != nil {
@@ -193,7 +195,7 @@ func readFromDisk(stateDir string) (*Results, bool) {
 // writeToDisk atomically writes the results to <stateDir>/algo_results.fb.
 // Uses a temp-file + rename for crash-safety.
 func writeToDisk(stateDir string, r *Results) error {
-	graphPath := filepath.Join(stateDir, "graph.fb")
+	graphPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 	graphInfo, err := os.Stat(graphPath)
 	if err != nil {
 		return fmt.Errorf("stat graph.fb: %w", err)

--- a/internal/daemon/deadref.go
+++ b/internal/daemon/deadref.go
@@ -59,6 +59,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // RefForgetter is the narrow slice of tier.Manager the dead-ref sweeper needs:
@@ -365,8 +366,10 @@ func (s *DeadRefSweeper) reapRef(repo, ref, refDir string, res *DeadRefResult, c
 // retention cap (oldest evicted first).
 func refGraphMtime(refDir string) time.Time {
 	var newest time.Time
-	for _, name := range []string{"graph.fb", "graph.json"} {
-		fi, err := os.Stat(filepath.Join(refDir, name))
+	// #5891: resolve the active generation (flat graph.fb fallback) so a
+	// gen-layout ref reports its real freshness, not mtime-zero.
+	for _, p := range []string{graph.CurrentGraphPath(refDir), filepath.Join(refDir, "graph.json")} {
+		fi, err := os.Stat(p)
 		if err != nil {
 			continue
 		}
@@ -381,8 +384,11 @@ func refGraphMtime(refDir string) time.Time {
 // whose mtime is at/after cutoff — i.e. it was indexed inside the grace window.
 // A missing graph file is treated as NOT recent (eligible for reaping).
 func recentlyIndexed(refDir string, cutoff time.Time) bool {
-	for _, name := range []string{"graph.fb", "graph.json"} {
-		fi, err := os.Stat(filepath.Join(refDir, name))
+	// #5891: resolve the active generation so a freshly-indexed gen-layout ref
+	// is correctly protected by the grace window (a fixed graph.fb no longer
+	// exists after migration).
+	for _, p := range []string{graph.CurrentGraphPath(refDir), filepath.Join(refDir, "graph.json")} {
+		fi, err := os.Stat(p)
 		if err != nil {
 			continue
 		}

--- a/internal/daemon/mcp/graph_cache.go
+++ b/internal/daemon/mcp/graph_cache.go
@@ -25,6 +25,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
@@ -256,7 +257,11 @@ func (c *Cache) GetForRepoRef(repoPath, ref string) (*fbreader.Reader, func(), e
 	if strings.Contains(filepath.ToSlash(stateDir), "/refs/_unknown") {
 		return nil, func() {}, ErrUnknownRef
 	}
-	fbPath := filepath.Join(stateDir, "graph.fb")
+	// #5891: resolve the active generation via the `current` pointer (flat
+	// graph.fb fallback for un-migrated repos). The cache key remains the
+	// absolute resolved path, so hit/miss semantics are unchanged; a gen swap
+	// yields a new key → cache miss → fresh mmap of the new generation.
+	fbPath := graph.CurrentGraphPath(stateDir)
 	r, release, err := c.Get(fbPath)
 	if err == nil {
 		c.fireAccessHook(repoPath, ref)
@@ -269,8 +274,37 @@ func (c *Cache) GetForRepoRef(repoPath, ref string) (*fbreader.Reader, func(), e
 // know the ref should prefer this over Invalidate(path).
 func (c *Cache) InvalidateForRepoRef(repoPath, ref string) bool {
 	stateDir := daemon.StateDirForRepoRef(repoPath, ref)
-	fbPath := filepath.Join(stateDir, "graph.fb")
-	return c.Invalidate(fbPath)
+	// #5891: under the gen layout the resident handle may be keyed by any
+	// graph.<gen>.fb (or the legacy flat graph.fb), and after a reindex flips
+	// the pointer to a NEW gen the OLD gen's entry is keyed by a path we can no
+	// longer reconstruct from the current pointer. Evict every handle whose
+	// parent dir is this state dir so the stale generation's mmap is reclaimed
+	// promptly (the low-RSS invariant) rather than lingering until LRU.
+	return c.InvalidateDir(stateDir) > 0
+}
+
+// InvalidateDir evicts every cached reader whose file lives directly in dir
+// (i.e. filepath.Dir(path) == dir), returning the count removed. It is the
+// gen-layout-safe invalidation entry point (#5891): a reindex writes a new
+// graph.<gen>.fb and flips the pointer, so the previously-resident handle is
+// keyed by a now-superseded gen path; evicting by directory drops it without
+// needing to know the exact old gen number. Safe to call on a closed cache
+// (returns 0).
+func (c *Cache) InvalidateDir(dir string) int {
+	if c.closed.Load() {
+		return 0
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	n := 0
+	for p, elem := range c.entries {
+		if filepath.Dir(p) == dir {
+			c.removeLocked(elem)
+			c.stats.Invalidates++
+			n++
+		}
+	}
+	return n
 }
 
 // Invalidate forces removal of the cached handle for path. Called by

--- a/internal/daemon/orphanroot.go
+++ b/internal/daemon/orphanroot.go
@@ -52,6 +52,8 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // OrphanRootConfig wires the orphan top-level store-root sweep. All hooks are
@@ -432,7 +434,9 @@ func newestArtifactMTime(root string) (time.Time, bool) {
 			return nil
 		}
 		name := d.Name()
-		if name != "graph.fb" && name != "graph.json" {
+		// #5891: recognise generation files (graph.<gen>.fb) as graph artifacts
+		// so an orphan-root's newest-mtime attribution sees the gen layout.
+		if name != "graph.json" && !graph.IsGraphFileName(name) {
 			return nil
 		}
 		fi, ferr := d.Info()

--- a/internal/daemon/state_gen_test.go
+++ b/internal/daemon/state_gen_test.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestFindGraphFileInDir_ResolvesGenAndAdvances is the PROGRESS linchpin
+// (#5891): because writers stop bumping a fixed graph.fb, findGraphFileInDir —
+// the source of statuswriter's GraphFBMtime — MUST stat the resolved gen file
+// so a completed rebuild's mtime keeps advancing. If it froze, the status-plane
+// completion classifier (GraphFBMtime >= fgStart) would misclassify a finished
+// rebuild as "produced no graph" (the wizard false-Failed regression).
+func TestFindGraphFileInDir_ResolvesGenAndAdvances(t *testing.T) {
+	dir := t.TempDir()
+
+	gen1, err := graph.WriteGenGraph(dir, []byte("gen-one-bytes"))
+	if err != nil {
+		t.Fatalf("write gen1: %v", err)
+	}
+	// Pin gen1's mtime to a known-old value so the advance is unambiguous even
+	// on coarse-granularity filesystems.
+	old := time.Now().Add(-2 * time.Hour)
+	if err := os.Chtimes(gen1, old, old); err != nil {
+		t.Fatalf("chtimes gen1: %v", err)
+	}
+
+	p1, m1 := findGraphFileInDir(dir)
+	if p1 != gen1 {
+		t.Fatalf("findGraphFileInDir p1 = %q, want gen1 %q", p1, gen1)
+	}
+	if m1 != old.UnixNano() {
+		t.Fatalf("findGraphFileInDir m1 = %d, want gen1 mtime %d", m1, old.UnixNano())
+	}
+
+	gen2, err := graph.WriteGenGraph(dir, []byte("gen-two-bytes-longer"))
+	if err != nil {
+		t.Fatalf("write gen2: %v", err)
+	}
+	p2, m2 := findGraphFileInDir(dir)
+	if p2 != gen2 {
+		t.Fatalf("findGraphFileInDir p2 = %q, want gen2 %q", p2, gen2)
+	}
+	if m2 < m1 {
+		t.Fatalf("GraphFBMtime went backwards: m2=%d < m1=%d", m2, m1)
+	}
+	if m2 == old.UnixNano() {
+		t.Fatal("GraphFBMtime froze at the previous generation's mtime — wizard would false-Fail")
+	}
+}
+
+// TestFindGraphFileInDir_FlatFallback: a legacy flat graph.fb with no pointer
+// still resolves (compat), so a never-migrated repo keeps reporting its mtime.
+func TestFindGraphFileInDir_FlatFallback(t *testing.T) {
+	dir := t.TempDir()
+	flat := filepath.Join(dir, "graph.fb")
+	if err := os.WriteFile(flat, []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	p, m := findGraphFileInDir(dir)
+	if p != flat {
+		t.Fatalf("findGraphFileInDir = %q, want flat %q", p, flat)
+	}
+	if m == 0 {
+		t.Fatal("flat graph.fb mtime resolved to 0")
+	}
+}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -59,6 +59,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // canonicalCache caches (inputPath → canonicalPath) resolutions so that
@@ -452,16 +453,23 @@ func GraphPathForRepo(repoPath string) string {
 	return filepath.Join(StateDirForRepo(repoPath), "graph.json")
 }
 
-// GraphFBPathForRepo returns the path to graph.fb (FlatBuffers binary format)
-// inside the per-repo state directory.
+// GraphFBPathForRepo returns the path to the active FlatBuffers graph inside
+// the per-repo state directory. #5891: this resolves the `current` generation
+// pointer (graph.<gen>.fb), falling back to the legacy flat graph.fb for repos
+// that have not been reindexed since the gen-layout migration.
 func GraphFBPathForRepo(repoPath string) string {
-	return filepath.Join(StateDirForRepo(repoPath), "graph.fb")
+	return graph.CurrentGraphPath(StateDirForRepo(repoPath))
 }
 
 // findGraphFileInDir checks dir for graph.fb / graph.json and returns the
 // path + modtime of the newest one. Returns ("", 0) if neither exists.
 func findGraphFileInDir(dir string) (path string, modtime int64) {
-	fbPath := filepath.Join(dir, "graph.fb")
+	// #5891: resolve the active generation via the `current` pointer (falling
+	// back to the legacy flat graph.fb for un-migrated repos). This is the
+	// linchpin: because writers stop bumping a fixed graph.fb, FindGraphFile /
+	// FindGraphFileAnyRef — and therefore statuswriter's GraphFBMtime — MUST
+	// stat the resolved gen file so a completed rebuild's mtime keeps advancing.
+	fbPath := graph.CurrentGraphPath(dir)
 	jsonPath := filepath.Join(dir, "graph.json")
 
 	fbInfo, fbErr := os.Stat(fbPath)

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -217,7 +217,7 @@ func (g *DashGroup) diskUnchanged() bool {
 // statGraphMtime returns the modification time of the graph.fb in stateDir,
 // falling back to graph.json, or the zero time when neither exists.
 func statGraphMtime(stateDir string) time.Time {
-	if info, e := os.Stat(filepath.Join(stateDir, "graph.fb")); e == nil {
+	if info, e := os.Stat(graph.CurrentGraphPath(stateDir)); e == nil { // #5891
 		return info.ModTime()
 	}
 	if info, e := os.Stat(filepath.Join(stateDir, "graph.json")); e == nil {
@@ -641,7 +641,7 @@ func (c *GraphCache) loadGroupForRef(groupName, ref string) (*DashGroup, error) 
 			// so handlers that only need to iterate entities/relationships can
 			// avoid materialising the full heap slice. Best-effort: failures
 			// leave Reader nil and callers fall back to doc.Entities.
-			fbPath := filepath.Join(stateDir, "graph.fb")
+			fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 			if rdr, rerr := fbreader.Open(fbPath); rerr == nil {
 				dr.Reader = rdr
 			}

--- a/internal/dashboard/handlers_enrichment_writeback.go
+++ b/internal/dashboard/handlers_enrichment_writeback.go
@@ -205,15 +205,20 @@ func (s *Server) handleEnrichmentWriteback(w http.ResponseWriter, r *http.Reques
 	// format leaves the other stale, causing ghost entity IDs for direct
 	// graph.json readers (fixes #1702).
 	stateDir := daemon.StateDirForRepo(found.repoPath)
-	fbPath := filepath.Join(stateDir, "graph.fb")
 	graphPath := daemon.GraphPathForRepo(found.repoPath)
 
-	if err := fbwriter.WriteAtomic(fbPath, found.doc); err != nil {
+	// #5891: write a NEW graph.<gen>.fb + flip the `current` pointer rather
+	// than overwriting graph.fb — this writeback path is executed by the serve
+	// process while the same graph.fb may be mmap'd, exactly the Windows
+	// ERROR_USER_MAPPED_FILE hazard the gen layout removes. fbPath is the gen
+	// file written (used for the identical-mtime stamp below).
+	fbPath, ferr := fbwriter.WriteGraphGen(stateDir, found.doc)
+	if ferr != nil {
 		s.auditor.Err("enrichment_writeback", group, map[string]any{
 			"subject_id": subjectID,
 			"kind":       req.Kind,
-		}, "write graph.fb: "+err.Error())
-		writeErr(w, http.StatusInternalServerError, "persist graph.fb: "+err.Error())
+		}, "write graph.fb: "+ferr.Error())
+		writeErr(w, http.StatusInternalServerError, "persist graph.fb: "+ferr.Error())
 		return
 	}
 	if err := graph.WriteAtomic(graphPath, found.doc, false); err != nil {

--- a/internal/dashboard/handlers_ref_endpoints.go
+++ b/internal/dashboard/handlers_ref_endpoints.go
@@ -634,7 +634,7 @@ func (s *Server) handleGroupRefs(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			fbPath := filepath.Join(refsDir, refSafe, "graph.fb")
+			fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe)) // #5891
 			fi, ferr := os.Stat(fbPath)
 			if ferr != nil {
 				// No graph.fb — try graph.json.

--- a/internal/dashboard/handlers_v2_refs.go
+++ b/internal/dashboard/handlers_v2_refs.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -146,8 +147,8 @@ func (s *Server) handleV2GroupRefs(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			// Check for a graph.fb in this ref slot.
-			fbPath := filepath.Join(refsDir, refSafe, "graph.fb")
+			// Check for a graph.fb in this ref slot. #5891: resolve active gen.
+			fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe))
 			var indexedAt *time.Time
 			var entityCount int
 			if fi, ferr := os.Stat(fbPath); ferr == nil {

--- a/internal/dashboard/ref_helper.go
+++ b/internal/dashboard/ref_helper.go
@@ -97,8 +97,13 @@ func knownRefsForGroup(groupName string) []string {
 			if ref == "" {
 				continue // skip _unknown sentinel
 			}
-			// Only count refs that have an actual graph.
-			if _, ferr := os.Stat(filepath.Join(refsDir, e.Name(), "graph.fb")); ferr != nil {
+			// Only count refs that have an actual graph. #5891: resolve the
+			// active generation (graph.<gen>.fb via the `current` pointer); a
+			// fresh repo has no flat graph.fb, so the hardcoded stat dropped the
+			// ref → ?ref=<branch> 400s. Mirror allRefsForRepo; keep the graph.json
+			// fallback so a json-only ref dir is still included (CurrentGraphPath
+			// returns the non-existent flat graph.fb path for a json-only dir).
+			if _, ferr := os.Stat(graph.CurrentGraphPath(filepath.Join(refsDir, e.Name()))); ferr != nil {
 				if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
 					continue
 				}

--- a/internal/dashboard/ref_helper.go
+++ b/internal/dashboard/ref_helper.go
@@ -20,6 +20,7 @@ import (
 	"sort"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -134,7 +135,7 @@ func allRefsForRepo(repoPath string) []string {
 		if ref == "" {
 			continue
 		}
-		if _, ferr := os.Stat(filepath.Join(refsDir, e.Name(), "graph.fb")); ferr != nil {
+		if _, ferr := os.Stat(graph.CurrentGraphPath(filepath.Join(refsDir, e.Name()))); ferr != nil { // #5891
 			if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
 				continue
 			}

--- a/internal/dashboard/ref_helper_gen_test.go
+++ b/internal/dashboard/ref_helper_gen_test.go
@@ -1,0 +1,106 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// registerRefFixture wires GRAFEL_HOME + GRAFEL_DAEMON_ROOT, a one-repo group,
+// and returns the repo path so the caller can populate per-ref state dirs.
+func registerRefFixture(t *testing.T, groupName, repoSlug string) (repoPath string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, "store"))
+
+	repoPath = filepath.Join(home, "myrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	cfg := &registry.GroupConfig{
+		Name:  groupName,
+		Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}},
+	}
+	cfgDir := filepath.Join(home, "groups")
+	_ = os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, groupName+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	if err := os.WriteFile(cfgPath, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	regRaw, _ := json.Marshal(map[string]any{
+		"version": 1,
+		"groups":  []map[string]any{{"name": groupName, "config_path": cfgPath}},
+	})
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return repoPath
+}
+
+// TestKnownRefsForGroup_GenOnlyRefIncluded is the #5891 regression for the
+// missed reader in knownRefsForGroup: a ref indexed under the gen layout has
+// `current` + graph.<gen>.fb and NO flat graph.fb (and, by default, no
+// graph.json). The pre-fix hardcoded os.Stat(graph.fb) dropped such a ref, so
+// resolveRefParam(?ref=<branch>) returned HTTP 400 and the branch vanished from
+// `available`. Assert the gen-only ref (and a json-only ref) are BOTH included.
+func TestKnownRefsForGroup_GenOnlyRefIncluded(t *testing.T) {
+	const group, slug = "gengroup", "genrepo"
+	repoPath := registerRefFixture(t, group, slug)
+
+	// Ref "main": gen-only layout (current pointer + graph.<gen>.fb, NO flat
+	// graph.fb, NO graph.json).
+	genRefDir := daemon.StateDirForRepoRef(repoPath, "main")
+	if err := os.MkdirAll(genRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := graph.WriteGenGraph(genRefDir, []byte("gen-bytes")); err != nil {
+		t.Fatalf("WriteGenGraph: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(genRefDir, "graph.fb")); err == nil {
+		t.Fatal("precondition: a flat graph.fb exists — gen layout must not create it")
+	}
+
+	// Ref "feat/json-only": json-only layout (no fb of any kind).
+	jsonRefDir := daemon.StateDirForRepoRef(repoPath, "feat/json-only")
+	if err := os.MkdirAll(jsonRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(jsonRefDir, "graph.json"), []byte(`{"entities":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	known := knownRefsForGroup(group)
+	has := func(want string) bool {
+		for _, k := range known {
+			if k == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("main") {
+		t.Fatalf("gen-only ref 'main' dropped from knownRefsForGroup=%v (would 400 on ?ref=main)", known)
+	}
+	if !has("feat/json-only") {
+		t.Fatalf("json-only ref dropped from knownRefsForGroup=%v", known)
+	}
+
+	// End-to-end: resolveRefParam must accept ?ref=main (ok=true, no 400).
+	req := httptest.NewRequest(http.MethodGet, "/api/groups/"+group+"/stats?ref=main", nil)
+	rec := httptest.NewRecorder()
+	ref, isAll, ok := resolveRefParam(rec, req, group)
+	if !ok {
+		t.Fatalf("resolveRefParam(?ref=main) rejected with %d (gen-only ref treated as invalid)", rec.Code)
+	}
+	if ref != "main" || isAll {
+		t.Fatalf("resolveRefParam(?ref=main) = (%q, isAll=%v), want (main, false)", ref, isAll)
+	}
+}

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -97,11 +97,11 @@ func aggregateGroupStats(groupName string, repos []registry.Repo) (entityCount i
 					}
 				default:
 					// No header timestamp — fall back to graph.fb mtime.
-					if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil && info.ModTime().After(latest) {
+					if info, e2 := os.Stat(graph.CurrentGraphPath(stateDir)); e2 == nil && info.ModTime().After(latest) {
 						latest = info.ModTime()
 					}
 				}
-			} else if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil {
+			} else if info, e2 := os.Stat(graph.CurrentGraphPath(stateDir)); e2 == nil {
 				// graph.fb unreadable but present — fall back to its mtime.
 				if info.ModTime().After(latest) {
 					latest = info.ModTime()

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -43,6 +43,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/watchers"
@@ -263,7 +264,7 @@ func settingsRepoStack(r registry.Repo) string {
 // graph.fb cheaply via fbreader (no entity/relationship decode). Returns zero
 // values for non-git repos or graphs written before these fields were added.
 func repoGitMeta(stateDir string) (ref, sha string, isWorktree bool, coverageStatus string) {
-	fbPath := filepath.Join(stateDir, "graph.fb")
+	fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 	r, err := fbreader.Open(fbPath)
 	if err != nil {
 		return "", "", false, ""

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -662,8 +662,12 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	sortGraphDocumentForEmission(doc)
 
-	fbPath := filepath.Join(stateDir, "graph.fb")
-	if writeErr := fbwriter.WriteAtomic(fbPath, doc); writeErr != nil {
+	// #5891 gen layout: write graph.<gen>.fb + flip the `current` pointer
+	// instead of overwriting graph.fb. This never renames over a possibly-
+	// mapped graph.fb (Windows ERROR_USER_MAPPED_FILE). fbPath is the gen
+	// file written, passed to the directory-keyed sidecar writer below.
+	fbPath, writeErr := fbwriter.WriteGraphGen(stateDir, doc)
+	if writeErr != nil {
 		return fallback(t0, "write-graph-fb: "+writeErr.Error())
 	}
 

--- a/internal/graph/fbwriter/gen_write_test.go
+++ b/internal/graph/fbwriter/gen_write_test.go
@@ -1,0 +1,208 @@
+package fbwriter_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbversion"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// smallDoc builds a minimal, valid graph.Document for the gen-layout tests.
+func smallDoc(repo string) *graph.Document {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+		Repo:        repo,
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go", StartLine: 10},
+			{ID: "ent0000000000000b", Name: "bar", Kind: "function", SourceFile: "b.go", StartLine: 20},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel000000000000aa", FromID: "ent0000000000000a", ToID: "ent0000000000000b", Kind: "calls"},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+	return doc
+}
+
+// TestWriteGraphGen_EmitsGenAndPointer: the writer emits graph.<gen>.fb + a
+// `current` pointer, the central resolver returns the gen file, and the shared
+// loader loads it back with the expected entity/relationship counts.
+func TestWriteGraphGen_EmitsGenAndPointer(t *testing.T) {
+	dir := t.TempDir()
+	genPath, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini"))
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	if filepath.Base(genPath) != "graph.1.fb" {
+		t.Fatalf("first gen file = %q, want graph.1.fb", filepath.Base(genPath))
+	}
+	// A `current` pointer must exist.
+	if _, err := os.Stat(filepath.Join(dir, "current")); err != nil {
+		t.Fatalf("current pointer missing: %v", err)
+	}
+	// The central resolver returns the gen file.
+	if got := graph.CurrentGraphPath(dir); got != genPath {
+		t.Fatalf("CurrentGraphPath = %q, want %q", got, genPath)
+	}
+	// The shared loader loads it.
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if loaded.Stats.Entities != 2 || loaded.Stats.Relationships != 1 {
+		t.Fatalf("loaded stats = %d ents / %d rels, want 2/1",
+			loaded.Stats.Entities, loaded.Stats.Relationships)
+	}
+}
+
+// TestGen_NoFlatGraphFile: WriteGraphGen must NOT create a legacy flat
+// graph.fb — the whole point is to stop overwriting a fixed (possibly mapped)
+// file.
+func TestGen_NoFlatGraphFile(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini")); err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "graph.fb")); err == nil {
+		t.Fatal("a flat graph.fb was written — gen layout must never create it")
+	}
+}
+
+// TestCompat_LegacyFlatGraphNoPointer: a dir with ONLY the legacy flat graph.fb
+// and NO pointer must keep working untouched — the resolver returns the flat
+// path, the loader loads it, ReindexRequiredReason is false, and
+// PersistedStatsFromDir reports ok==true. This is the lazy-migration contract:
+// NO reindex is triggered for an existing flat-file repo.
+func TestCompat_LegacyFlatGraphNoPointer(t *testing.T) {
+	dir := t.TempDir()
+	flat := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(flat, smallDoc("legacy-mini")); err != nil {
+		t.Fatalf("WriteAtomic flat: %v", err)
+	}
+	// No pointer exists.
+	if _, err := os.Stat(filepath.Join(dir, "current")); err == nil {
+		t.Fatal("unexpected pointer for a legacy flat-file repo")
+	}
+	if got := graph.CurrentGraphPath(dir); got != flat {
+		t.Fatalf("CurrentGraphPath = %q, want flat %q", got, flat)
+	}
+	if _, err := graph.LoadGraphFromDir(dir); err != nil {
+		t.Fatalf("LoadGraphFromDir(flat): %v", err)
+	}
+	if required, reason := graph.ReindexRequiredReason(dir); required {
+		t.Fatalf("ReindexRequiredReason=true for a current-version flat graph: %s", reason)
+	}
+	if _, ok := graph.PersistedStatsFromDir(dir); !ok {
+		t.Fatal("PersistedStatsFromDir ok=false for a legacy flat graph — would falsely look never-indexed")
+	}
+}
+
+// TestNoReindexLoop_GenOnlyDir: a dir holding ONLY a gen file (no flat
+// graph.fb) must resolve through the pointer so PersistedStatsFromDir reports
+// ok==true AND LoadGraphFromDir succeeds. If either resolved to the absent flat
+// path, the incremental poller's absent-graph guard (incremental.go:331) and
+// base-load (incremental.go:383) would force a full reindex on EVERY no-op
+// poll — an infinite reindex loop. This asserts the guards are pointer-aware.
+func TestNoReindexLoop_GenOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini")); err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	// Precondition: no flat graph.fb.
+	if _, err := os.Stat(filepath.Join(dir, "graph.fb")); err == nil {
+		t.Fatal("precondition failed: flat graph.fb exists")
+	}
+	// incremental.go:331 path — absent-graph guard reads this.
+	if _, ok := graph.PersistedStatsFromDir(dir); !ok {
+		t.Fatal("PersistedStatsFromDir ok=false on a gen-only dir → would force full reindex every poll")
+	}
+	// incremental.go:383 path — incremental base load reads this.
+	if _, err := graph.LoadGraphFromDir(dir); err != nil {
+		t.Fatalf("LoadGraphFromDir on a gen-only dir: %v → would force full reindex", err)
+	}
+	// And the version gate must NOT demand a reindex.
+	if required, reason := graph.ReindexRequiredReason(dir); required {
+		t.Fatalf("ReindexRequiredReason=true on a fresh gen graph: %s", reason)
+	}
+}
+
+// TestNoFbversionBump: the gen layout must NOT bump the on-disk FB format
+// version — bumping it would force-reindex every existing repo. Assert the
+// constant is still 4 and that a freshly-written gen file's header is v4.
+func TestNoFbversionBump(t *testing.T) {
+	if fbversion.Version != 4 {
+		t.Fatalf("fbversion.Version = %d, want 4 (a bump force-reindexes the whole corpus)", fbversion.Version)
+	}
+	dir := t.TempDir()
+	genPath, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini"))
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	r, err := fbreader.Open(genPath)
+	if err != nil {
+		t.Fatalf("open gen file: %v", err)
+	}
+	defer r.Close()
+	if v := r.Version(); v != 4 {
+		t.Fatalf("gen file header version = %d, want 4", v)
+	}
+}
+
+// TestGen_PreviousGenSurvivesOpenHandleAcrossWrite: holding an open mmap reader
+// on the previous generation across a new write must NOT break the write, and
+// the previous gen must survive (the GC keep-window retains current+previous so
+// serve can still map the previous during a reload overlap). This is the Unix
+// analogue of the Windows fail-soft: the previous gen is never a GC target, so
+// an in-use previous gen is never at risk.
+func TestGen_PreviousGenSurvivesOpenHandleAcrossWrite(t *testing.T) {
+	dir := t.TempDir()
+	prevPath, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini")) // gen 1
+	if err != nil {
+		t.Fatalf("write gen1: %v", err)
+	}
+	// Hold gen 1 open (simulating serve still mapping the previous gen).
+	held, err := fbreader.Open(prevPath)
+	if err != nil {
+		t.Fatalf("open prev gen: %v", err)
+	}
+	defer held.Close()
+
+	// Write gen 2 while gen 1 is held open — must succeed.
+	if _, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini")); err != nil {
+		t.Fatalf("write gen2 while prev held open: %v", err)
+	}
+	// gen 1 (previous) must survive the GC keep-window and stay readable.
+	if held.EntityCount() != 2 {
+		t.Fatalf("held prev-gen reader broke: EntityCount=%d, want 2", held.EntityCount())
+	}
+	if _, err := os.Stat(prevPath); err != nil {
+		t.Fatalf("previous gen was GC'd while still current-1: %v", err)
+	}
+}
+
+// TestGen_OldGensCollected: after several writes only the current + previous
+// gen files remain on disk (older ones are best-effort unlinked).
+func TestGen_OldGensCollected(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 4; i++ {
+		if _, err := fbwriter.WriteGraphGen(dir, smallDoc("gen-mini")); err != nil {
+			t.Fatalf("write %d: %v", i, err)
+		}
+	}
+	// gens 1..4 written → keep 4 and 3, drop 1 and 2.
+	for gen := uint64(1); gen <= 4; gen++ {
+		p := filepath.Join(dir, graph.GenFileName(gen))
+		_, err := os.Stat(p)
+		wantExists := gen >= 3
+		if (err == nil) != wantExists {
+			t.Fatalf("gen %d exists=%v, want %v", gen, err == nil, wantExists)
+		}
+	}
+}

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -58,6 +58,28 @@ func WriteAtomic(outPath string, doc *graph.Document) error {
 	return nil
 }
 
+// WriteGraphGen serializes doc and writes it as a NEW generation file
+// graph.<gen>.fb inside stateDir, then atomically flips the <stateDir>/current
+// pointer at it and best-effort GCs stale generations (issue #5891). It is the
+// gen-layout replacement for WriteAtomic(<dir>/graph.fb, doc) on the producer
+// paths (full-index + incremental): critically, it NEVER renames over an
+// existing (possibly memory-mapped) graph.fb, removing the Windows
+// ERROR_USER_MAPPED_FILE hazard.
+//
+// Like WriteAtomic it marshals the whole buffer up-front (fail-softing an
+// oversized-graph panic into an error) BEFORE touching the filesystem, so a
+// marshal failure leaves the previously-active generation and pointer fully
+// intact. Returns the absolute path of the gen file written — callers pass it
+// to the directory-keyed sidecar writer (graph.WriteSidecar keys on
+// filepath.Dir), so graph-stats.json still lands beside the graph.
+func WriteGraphGen(stateDir string, doc *graph.Document) (genPath string, err error) {
+	buf, err := Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("fbwriter: marshal: %w", err)
+	}
+	return graph.WriteGenGraph(stateDir, buf)
+}
+
 // Marshal serializes doc into a FlatBuffers byte slice. Exported so the
 // indexer and tests can drive it without touching the filesystem.
 //

--- a/internal/graph/genpath.go
+++ b/internal/graph/genpath.go
@@ -1,0 +1,257 @@
+// Package graph — genpath.go implements the generation-file + pointer layout
+// for the on-disk FlatBuffers graph (issue #5891, "Approach A").
+//
+// # Why this exists
+//
+// Historically every reindex overwrote a single fixed file, <dir>/graph.fb,
+// via a tmp+rename. On Windows renaming OVER a file that another process still
+// has memory-mapped fails with ERROR_USER_MAPPED_FILE — precisely the case for
+// grafel's serve/MCP zero-copy reader, which keeps graph.fb mmap'd while agents
+// query it. That hazard forced the mmap serve path OFF by default on Windows.
+//
+// The generation layout removes the rename-over-a-mapped-file entirely:
+//
+//   - Each write emits a BRAND-NEW file graph.<gen>.fb (gen = monotonically
+//     increasing integer) and then atomically writes a tiny `current` pointer
+//     file naming the active generation. No existing (possibly mapped) file is
+//     ever renamed over.
+//   - Readers resolve the active file through CurrentGraphPath: read `current`
+//     → return <dir>/graph.<gen>.fb; if the pointer is absent (a legacy repo
+//     that has not been reindexed since the migration) fall back to the flat
+//     <dir>/graph.fb. This makes the migration LAZY: existing flat-file repos
+//     keep working untouched and pick up the gen layout only on their next
+//     naturally-triggered reindex. There is NO forced reindex and NO
+//     fbversion bump.
+//
+// The `.fb` suffix is preserved on gen files (graph.<gen>.fb) so existing
+// strings.HasSuffix(path, ".fb") checks keep working unchanged.
+package graph
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// currentPointerName is the tiny pointer file naming the active generation.
+const currentPointerName = "current"
+
+// flatGraphName is the legacy fixed graph filename used before the gen layout
+// and still used as the resolver's fallback for un-migrated repos.
+const flatGraphName = "graph.fb"
+
+// genFileRe matches a generation graph file: graph.<digits>.fb.
+var genFileRe = regexp.MustCompile(`^graph\.(\d+)\.fb$`)
+
+// GenFileName renders the on-disk filename for a given generation.
+func GenFileName(gen uint64) string {
+	return fmt.Sprintf("graph.%d.fb", gen)
+}
+
+// IsGraphFileName reports whether base (a bare filename, not a path) is a
+// FlatBuffers graph file recognised by the gen layout: the legacy flat
+// "graph.fb" or a generation file "graph.<gen>.fb". Enumeration/GC callers use
+// this so a directory walk that previously matched only "graph.fb" also sees
+// the generation files.
+func IsGraphFileName(base string) bool {
+	if base == flatGraphName {
+		return true
+	}
+	_, ok := parseGen(base)
+	return ok
+}
+
+// parseGen returns the generation integer encoded in a bare filename
+// (graph.<gen>.fb) and whether it matched.
+func parseGen(name string) (uint64, bool) {
+	m := genFileRe.FindStringSubmatch(name)
+	if m == nil {
+		return 0, false
+	}
+	v, err := strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return v, true
+}
+
+// readPointer returns the gen filename named by <dir>/current, validated
+// against the graph.<gen>.fb shape so a corrupt/hostile pointer can never
+// escape dir via path traversal. ok is false when the pointer is absent,
+// unreadable, or malformed.
+func readPointer(dir string) (name string, ok bool) {
+	data, err := os.ReadFile(filepath.Join(dir, currentPointerName))
+	if err != nil {
+		return "", false
+	}
+	name = strings.TrimSpace(string(data))
+	if _, valid := parseGen(name); !valid {
+		return "", false
+	}
+	return name, true
+}
+
+// CurrentGraphPath resolves the active graph file for a state dir. It is the
+// single central resolver every reader routes through:
+//
+//  1. If <dir>/current names an existing graph.<gen>.fb, return that path.
+//  2. Otherwise fall back to the legacy flat <dir>/graph.fb path.
+//
+// The flat path is returned even when it does not exist on disk — callers stat
+// or open it and handle absence, exactly as they did before the gen layout.
+// This preserves the pre-existing "graph absent" semantics for a brand-new,
+// never-indexed repo (no pointer, no flat file).
+func CurrentGraphPath(dir string) string {
+	if dir == "" {
+		return ""
+	}
+	if name, ok := readPointer(dir); ok {
+		p := filepath.Join(dir, name)
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+		// Pointer names a missing gen file (torn write / manual deletion) —
+		// fall through to the flat fallback rather than returning a
+		// guaranteed-ENOENT gen path.
+	}
+	return filepath.Join(dir, flatGraphName)
+}
+
+// NextGen returns the next generation integer to write in dir: one greater
+// than the maximum generation observed among the `current` pointer and every
+// graph.<gen>.fb already present. Returns 1 for a dir that has never held a
+// gen file. Scanning the directory (not merely trusting the pointer) keeps the
+// sequence monotonic even if the pointer was manually deleted while gen files
+// remain, so a stale reader never resolves a freshly-written gen to an older
+// file.
+func NextGen(dir string) uint64 {
+	var maxGen uint64
+	if name, ok := readPointer(dir); ok {
+		if v, _ := parseGen(name); v > maxGen {
+			maxGen = v
+		}
+	}
+	if ents, err := os.ReadDir(dir); err == nil {
+		for _, e := range ents {
+			if e.IsDir() {
+				continue
+			}
+			if v, ok := parseGen(e.Name()); ok && v > maxGen {
+				maxGen = v
+			}
+		}
+	}
+	return maxGen + 1
+}
+
+// pointerFlipRetries / pointerFlipRetryDelay bound the pointer-rename retry
+// loop. On Unix the rename-over succeeds on the first try. On Windows, a
+// concurrent resolver mid os.ReadFile of `current` can briefly hold it open
+// and make the rename fail transiently with a sharing violation — the pointer
+// is a tiny file read in microseconds, so a short bounded backoff rides that
+// window out. This is NOT the mmap hazard (the pointer is never mapped); it is
+// only the same brief open/read/close race the overlay swap already tolerates.
+var (
+	pointerFlipRetries    = 40
+	pointerFlipRetryDelay = 5 * time.Millisecond
+)
+
+// WriteCurrentPointer atomically points <dir>/current at genName (a bare
+// graph.<gen>.fb filename) via a sibling .tmp + rename. The pointer file is
+// tiny and NEVER memory-mapped, so this rename-over is safe on every platform
+// (it is not the ERROR_USER_MAPPED_FILE hazard the gen layout removes); a
+// bounded retry absorbs the transient Windows reader-open race.
+func WriteCurrentPointer(dir, genName string) error {
+	if _, ok := parseGen(genName); !ok {
+		return fmt.Errorf("graph.WriteCurrentPointer: invalid gen name %q", genName)
+	}
+	tmp := filepath.Join(dir, currentPointerName+".tmp")
+	if err := os.WriteFile(tmp, []byte(genName+"\n"), 0o644); err != nil {
+		return fmt.Errorf("graph.WriteCurrentPointer: write tmp: %w", err)
+	}
+	dst := filepath.Join(dir, currentPointerName)
+	var err error
+	for i := 0; i < pointerFlipRetries; i++ {
+		if err = os.Rename(tmp, dst); err == nil {
+			return nil
+		}
+		time.Sleep(pointerFlipRetryDelay)
+	}
+	os.Remove(tmp)
+	return fmt.Errorf("graph.WriteCurrentPointer: rename: %w", err)
+}
+
+// GCStaleGens best-effort unlinks generation files older than the
+// immediately-previous generation, keeping the current gen and the one before
+// it. The previous gen is retained because serve/MCP may still have it mapped
+// during a reload overlap (it swaps to the new gen on its next mtime-drift
+// poll); deleting it out from under an active mmap would be unsafe on Unix and
+// impossible on Windows.
+//
+// This is STRICTLY best-effort and MUST NOT affect the caller's success: a
+// still-mapped gen on Windows fails to delete with a sharing violation, which
+// is silently ignored and swept on a later write. A GC error never propagates.
+// Returns the list of gen files actually removed (for tests/observability).
+func GCStaleGens(dir string, currentGen uint64) []string {
+	if currentGen <= 1 {
+		return nil // nothing older than the immediately-previous gen exists
+	}
+	keepFrom := currentGen - 1 // keep currentGen and currentGen-1
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var removed []string
+	for _, e := range ents {
+		if e.IsDir() {
+			continue
+		}
+		v, ok := parseGen(e.Name())
+		if !ok || v >= keepFrom {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, e.Name())); err == nil {
+			removed = append(removed, e.Name())
+		}
+		// On failure (e.g. Windows ERROR_SHARING_VIOLATION on a still-mapped
+		// gen) swallow the error and try again on the next write. Never fail.
+	}
+	return removed
+}
+
+// WriteGenGraph writes buf as a NEW generation file in dir, flips the `current`
+// pointer to it, and best-effort GCs stale generations. It is the single
+// producer primitive behind every writer (full-index and incremental): it
+// never renames over an existing (possibly mapped) file — the gen filename is
+// freshly allocated by NextGen, so its tmp+rename lands on a name nothing has
+// open. Returns the absolute path of the gen file written, which callers pass
+// to directory-keyed sidecar writers (WriteSidecar keys on filepath.Dir).
+//
+// The `current` pointer is flipped only AFTER the gen file is durably renamed
+// into place, so a reader never resolves the pointer to a half-written file.
+// A GC failure after the flip does not fail the write (see GCStaleGens).
+func WriteGenGraph(dir string, buf []byte) (genPath string, err error) {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", fmt.Errorf("graph.WriteGenGraph: mkdir %s: %w", dir, err)
+	}
+	gen := NextGen(dir)
+	name := GenFileName(gen)
+	genPath = filepath.Join(dir, name)
+	tmp := genPath + ".tmp"
+	if err := os.WriteFile(tmp, buf, 0o644); err != nil {
+		return "", fmt.Errorf("graph.WriteGenGraph: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, genPath); err != nil {
+		os.Remove(tmp)
+		return "", fmt.Errorf("graph.WriteGenGraph: rename gen: %w", err)
+	}
+	if err := WriteCurrentPointer(dir, name); err != nil {
+		return "", fmt.Errorf("graph.WriteGenGraph: flip pointer: %w", err)
+	}
+	GCStaleGens(dir, gen) // best-effort; never fails the write
+	return genPath, nil
+}

--- a/internal/graph/genpath_test.go
+++ b/internal/graph/genpath_test.go
@@ -1,0 +1,190 @@
+package graph
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCurrentGraphPath_FlatFallback: a dir with ONLY the legacy flat graph.fb
+// and no `current` pointer must resolve to the flat path (lazy-migration
+// compat: existing repos keep working untouched).
+func TestCurrentGraphPath_FlatFallback(t *testing.T) {
+	dir := t.TempDir()
+	flat := filepath.Join(dir, "graph.fb")
+	if err := os.WriteFile(flat, []byte("legacy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := CurrentGraphPath(dir); got != flat {
+		t.Fatalf("CurrentGraphPath = %q, want flat %q", got, flat)
+	}
+}
+
+// TestCurrentGraphPath_NeverIndexed: a brand-new empty dir resolves to the
+// (non-existent) flat path — preserving the pre-gen "graph absent" semantics.
+func TestCurrentGraphPath_NeverIndexed(t *testing.T) {
+	dir := t.TempDir()
+	want := filepath.Join(dir, "graph.fb")
+	if got := CurrentGraphPath(dir); got != want {
+		t.Fatalf("CurrentGraphPath = %q, want %q", got, want)
+	}
+}
+
+// TestCurrentGraphPath_ResolvesPointer: after a gen write the resolver returns
+// the gen file, NOT the flat path (even if a stale flat file also exists).
+func TestCurrentGraphPath_ResolvesPointer(t *testing.T) {
+	dir := t.TempDir()
+	// A stale legacy flat file that must be IGNORED once a pointer exists.
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), []byte("stale"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	genPath, err := WriteGenGraph(dir, []byte("gen1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := CurrentGraphPath(dir); got != genPath {
+		t.Fatalf("CurrentGraphPath = %q, want gen %q", got, genPath)
+	}
+	if filepath.Base(genPath) != "graph.1.fb" {
+		t.Fatalf("first gen file = %q, want graph.1.fb", filepath.Base(genPath))
+	}
+}
+
+// TestCurrentGraphPath_MissingGenFallsBack: a pointer naming a gen file that no
+// longer exists on disk must fall back to the flat path, never return ENOENT.
+func TestCurrentGraphPath_MissingGenFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), []byte("flat"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteCurrentPointer(dir, "graph.7.fb"); err != nil {
+		t.Fatal(err)
+	}
+	// graph.7.fb does not exist.
+	want := filepath.Join(dir, "graph.fb")
+	if got := CurrentGraphPath(dir); got != want {
+		t.Fatalf("CurrentGraphPath = %q, want flat fallback %q", got, want)
+	}
+}
+
+// TestCurrentGraphPath_RejectsHostilePointer: a pointer whose content is not a
+// valid graph.<gen>.fb name (path traversal / junk) is ignored.
+func TestCurrentGraphPath_RejectsHostilePointer(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, currentPointerName), []byte("../../etc/passwd"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(dir, "graph.fb")
+	if got := CurrentGraphPath(dir); got != want {
+		t.Fatalf("hostile pointer not rejected: got %q, want %q", got, want)
+	}
+}
+
+// TestNextGen_Monotonic: generations increase by one per write, and a manually
+// deleted pointer (with gen files remaining) still advances monotonically.
+func TestNextGen_Monotonic(t *testing.T) {
+	dir := t.TempDir()
+	if g := NextGen(dir); g != 1 {
+		t.Fatalf("first NextGen = %d, want 1", g)
+	}
+	for i := uint64(1); i <= 3; i++ {
+		p, err := WriteGenGraph(dir, []byte{byte(i)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if filepath.Base(p) != GenFileName(i) {
+			t.Fatalf("write %d produced %q, want %q", i, filepath.Base(p), GenFileName(i))
+		}
+	}
+	// Delete the pointer; NextGen must still exceed the max on-disk gen (3).
+	if err := os.Remove(filepath.Join(dir, currentPointerName)); err != nil {
+		t.Fatal(err)
+	}
+	if g := NextGen(dir); g != 4 {
+		t.Fatalf("NextGen after pointer deletion = %d, want 4 (scan gen files)", g)
+	}
+}
+
+// TestGCStaleGens_KeepsCurrentAndPrevious: after N writes only the current and
+// immediately-previous gen files remain; older ones are unlinked.
+func TestGCStaleGens_KeepsCurrentAndPrevious(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		if _, err := WriteGenGraph(dir, []byte{byte(i)}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// gens 1..5 written; GC after the 5th keeps 5 and 4.
+	for gen := uint64(1); gen <= 5; gen++ {
+		p := filepath.Join(dir, GenFileName(gen))
+		_, err := os.Stat(p)
+		exists := err == nil
+		wantExists := gen >= 4
+		if exists != wantExists {
+			t.Fatalf("gen %d exists=%v, want %v", gen, exists, wantExists)
+		}
+	}
+}
+
+// TestGCStaleGens_FailSoft: a gen older than previous that CANNOT be removed
+// (simulated by making the dir un-writable is platform-fragile; instead we
+// assert GCStaleGens never panics/propagates and that keeping the previous gen
+// means an in-use previous gen is never targeted). Here we assert the
+// keep-window: GCStaleGens(dir, currentGen) must not remove currentGen or
+// currentGen-1 even when told to sweep.
+func TestGCStaleGens_KeepWindow(t *testing.T) {
+	dir := t.TempDir()
+	for gen := uint64(1); gen <= 3; gen++ {
+		if err := os.WriteFile(filepath.Join(dir, GenFileName(gen)), []byte{byte(gen)}, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed := GCStaleGens(dir, 3)
+	if len(removed) != 1 || removed[0] != "graph.1.fb" {
+		t.Fatalf("GCStaleGens removed %v, want [graph.1.fb]", removed)
+	}
+	// current (3) and previous (2) must survive.
+	for _, keep := range []uint64{2, 3} {
+		if _, err := os.Stat(filepath.Join(dir, GenFileName(keep))); err != nil {
+			t.Fatalf("gen %d was removed but should be kept", keep)
+		}
+	}
+}
+
+// TestWriteGenGraph_RoundTrip: the bytes written are readable back at the
+// resolved path.
+func TestWriteGenGraph_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("hello-gen")
+	genPath, err := WriteGenGraph(dir, want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := os.ReadFile(CurrentGraphPath(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("round-trip: got %q, want %q", got, want)
+	}
+	// No stray .tmp left behind.
+	if _, err := os.Stat(genPath + ".tmp"); err == nil {
+		t.Fatalf("leftover tmp file at %s", genPath+".tmp")
+	}
+}
+
+// TestWriteCurrentPointer_Atomic: the pointer content is exactly the gen name
+// (trimmed) and never a torn/partial value.
+func TestWriteCurrentPointer_Atomic(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteCurrentPointer(dir, "graph.42.fb"); err != nil {
+		t.Fatal(err)
+	}
+	name, ok := readPointer(dir)
+	if !ok || name != "graph.42.fb" {
+		t.Fatalf("readPointer = %q ok=%v, want graph.42.fb", name, ok)
+	}
+	if err := WriteCurrentPointer(dir, "not-a-gen"); err == nil {
+		t.Fatal("WriteCurrentPointer accepted an invalid gen name")
+	}
+}

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -119,7 +119,11 @@ func AssembleGroupGraph(group string) (entities []graph.Entity, rels []graph.Rel
 		// Record the graph.fb mtime when present. A repo that was never indexed
 		// has neither graph.fb nor graph.json — skip it (not an error): the
 		// union of the remaining repos is still valid.
-		fbPath := filepath.Join(stateDir, "graph.fb")
+		// #5891: resolve the active generation so the recorded mtime is the
+		// gen file's — otherwise the overlay staleness check below (which reads
+		// the same resolved mtime via CurrentSourceMtimes) would see a frozen
+		// legacy graph.fb mtime and treat a fresh overlay as permanently stale.
+		fbPath := graph.CurrentGraphPath(stateDir)
 		jsonPath := filepath.Join(stateDir, "graph.json")
 		fbExists := false
 		if fi, statErr := os.Stat(fbPath); statErr == nil {

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -288,7 +288,7 @@ func CurrentSourceMtimes(group string) (map[string]int64, error) {
 	out := map[string]int64{}
 	for _, r := range cfg.Repos {
 		stateDir := daemon.StateDirForRepo(r.Path)
-		fbPath := filepath.Join(stateDir, "graph.fb")
+		fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
 		if fi, statErr := os.Stat(fbPath); statErr == nil {
 			out[r.Slug] = fi.ModTime().UnixNano()
 		}

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -78,7 +78,7 @@ func (e *FormatVersionError) Error() string {
 // that could go stale or get clobbered by a later write from a different
 // writer.
 func ReindexRequiredReason(dir string) (required bool, reason string) {
-	fbPath := filepath.Join(dir, "graph.fb")
+	fbPath := CurrentGraphPath(dir)
 	r, err := fbreader.Open(fbPath)
 	if err != nil {
 		return false, ""
@@ -117,7 +117,7 @@ func FormatVersionReason(found, required int) string {
 //  3. If only graph.json exists, fall back to JSON.
 //  4. If neither exists, return a non-nil error.
 func LoadGraphFromDir(dir string) (*Document, error) {
-	fbPath := filepath.Join(dir, "graph.fb")
+	fbPath := CurrentGraphPath(dir)
 	jsonPath := filepath.Join(dir, "graph.json")
 
 	fbInfo, fbErr := os.Stat(fbPath)
@@ -165,7 +165,7 @@ func LoadGraphFromDir(dir string) (*Document, error) {
 // (absent) memory win. Callers that need a full Document (every CLI/full-Doc
 // consumer) must keep using LoadGraphFromDir.
 func LoadGraphHeaderOnlyFromDir(dir string) (*Document, error) {
-	fbPath := filepath.Join(dir, "graph.fb")
+	fbPath := CurrentGraphPath(dir)
 	if _, err := os.Stat(fbPath); err == nil {
 		return loadFBDocumentHeaderOnly(fbPath)
 	}
@@ -208,7 +208,7 @@ type PersistedStats struct {
 // Returns ok=false when graph.fb is absent or cannot be opened (in which case
 // callers should treat the repo as genuinely never-indexed via graph.fb).
 func PersistedStatsFromDir(dir string) (PersistedStats, bool) {
-	fbPath := filepath.Join(dir, "graph.fb")
+	fbPath := CurrentGraphPath(dir)
 	r, err := fbreader.Open(fbPath)
 	if err != nil {
 		return PersistedStats{}, false

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -683,7 +683,7 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 				return nil
 			}
 			base := filepath.Base(p)
-			if base == "graph.json" || base == "graph.fb" {
+			if base == "graph.json" || graph.IsGraphFileName(base) { // #5891 gen files
 				dirSet[filepath.Dir(p)] = true
 			}
 			return nil

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1392,10 +1392,23 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 					// Doc.Entities entirely). Best-effort: Open failure leaves newRdr
 					// nil and the index falls back to the Document (JSON-only path).
 					// The SAME reader is published via setReader below (F1 protocol).
-					fbPath := filepath.Join(stateDir, "graph.fb")
+					// #5891: open the SAME resolved graph file that was
+					// discovered above (lr.GraphFile, via CurrentGraphPath in
+					// FindGraphFileAnyRef), NOT a re-derived flat graph.fb —
+					// under the gen layout the flat path may not exist, and
+					// re-deriving it would open a stale/absent file. Guard on the
+					// .fb extension exactly as the old hardcoded graph.fb path did
+					// implicitly: lr.GraphFile may be a graph.json (json-only
+					// repo), and handing JSON bytes to fbreader.Open crashes with
+					// an out-of-range slice — the mmap-reader is only meaningful
+					// for the FlatBuffers format (gen graph.<gen>.fb or flat
+					// graph.fb), so a json-only repo correctly leaves newRdr nil.
+					fbPath := lr.GraphFile
 					var newRdr *fbreader.Reader
-					if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
-						newRdr = rdr
+					if filepath.Ext(fbPath) == ".fb" {
+						if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
+							newRdr = rdr
+						}
 					}
 					// ADR-0027 SIGBUS-safety (memory epic #5850): build the successor
 					// MapHandle up front so the reader-sourced LabelIndex is FULLY wired

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -204,7 +204,9 @@ func HasGraph(dir string) bool {
 // Renamed from hasGraphJSON for ADR-0016 flip-day (#808).
 func hasGraphJSON(dir string) bool {
 	stateDir := daemon.StateDirForRepo(dir)
-	if _, err := os.Stat(filepath.Join(stateDir, "graph.fb")); err == nil {
+	// #5891: resolve the active generation (flat graph.fb fallback) so a
+	// gen-layout repo is still detected as "has a graph".
+	if _, err := os.Stat(graph.CurrentGraphPath(stateDir)); err == nil {
 		return true
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "graph.json")); err == nil {


### PR DESCRIPTION
PR-A of the Windows default-on fix. Reindex writers now emit `graph.<gen>.fb` (monotonic int) + an atomic `current` pointer instead of overwriting a fixed `graph.fb`; readers resolve the pointer via `graph.CurrentGraphPath(dir)` with a legacy flat-`graph.fb` fallback. **No rename-over-a-mapped-file ever occurs**, which is what blocked serve's mmap path on Windows (`ERROR_USER_MAPPED_FILE`). Refs #5891.

**Lazy migration, no forced reindex:** `fbversion.Version` stays 4 (the sole hard reindex invalidator), so existing flat-`graph.fb` repos stay valid and keep working via the fallback. The gen layout appears only on a repo's next naturally-triggered reindex — never a migration sweep (a monorepo corpus reindex is minutes).

**Highlights (independently adversarially reviewed, mutation-verified):**
- Central resolver `internal/graph/genpath.go` (`CurrentGraphPath`/`NextGen`/`WriteCurrentPointer`/`GCStaleGens`/`WriteGenGraph`), anchored path-traversal guard on the pointer.
- Both reindex-loop sites fixed with the writer switch (`incremental.go` PersistedStatsFromDir + LoadGraphFromDir resolve the pointer) — a gen-only dir never force-reindexes.
- `FindGraphFile` returns the **gen** file's mtime, so `GraphFBMtime` advances → the TUI/wizard indexing-completion classifier (`statuswriter.go`) is preserved (mutation-proven load-bearing).
- New `Cache.InvalidateDir` evicts the old-gen mmap promptly on reindex — **closes an RSS leak** the old path-keyed invalidation had (a gen swap didn't match the flat-path key). RSS improves, not regresses.
- Best-effort `GCStaleGens` (keeps current+previous; fail-soft on a still-mapped gen — Windows delete-while-mapped never blocks a write).
- `defaultServeFromMMapForOS` unchanged (Windows default flip is the follow-up PR-B).

Full suite green (9242 pass). SSE progress + directory-keyed `graph-stats.json` sidecar untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o