### PR TITLE
test(dashboard): quiesce background algo-sweep before TempDir cleanup (Windows CI)

### DIFF
--- a/internal/dashboard/handlers_ref_endpoints_test.go
+++ b/internal/dashboard/handlers_ref_endpoints_test.go
@@ -112,6 +112,11 @@ func buildRefEndpointFixture(t *testing.T) (ts *httptest.Server, groupName, repo
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
+	// Park the deferred Pass-4 sweep and release cache mmap readers before the
+	// t.TempDir RemoveAll teardown so a background graph-algo.json write can't
+	// leave refs/_unknown busy on Windows (v0.1.9 3-OS acceptance). See
+	// quiesceGraphCache.
+	quiesceGraphCache(t, srv)
 	ts = httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 	return ts, groupName, repoSlug

--- a/internal/dashboard/handlers_v2_diff_test.go
+++ b/internal/dashboard/handlers_v2_diff_test.go
@@ -70,6 +70,12 @@ func setupDiffTest(t *testing.T, groupName, repoSlug string, docA, docB *graph.D
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
 	}
+	// The diff endpoint loads both refs via GetGroupForRef, each of which
+	// schedules a background Pass-4 sweep that writes graph-algo.json into the
+	// per-ref temp state dir; park it (and release cache mmap readers) before the
+	// t.TempDir RemoveAll teardown so it can't leave a state dir busy on Windows.
+	// See quiesceGraphCache.
+	quiesceGraphCache(t, srv)
 	ts := httptest.NewServer(srv.routes())
 	t.Cleanup(ts.Close)
 	return ts.URL

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -30,6 +30,47 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
+// quiesceGraphCache makes a dashboard fixture whose graph state lives under
+// t.TempDir safe to auto-teardown on Windows. It defends the two ways a live
+// dashboard graph load leaves a file busy under the temp dir when Go's
+// automatic t.TempDir RemoveAll runs:
+//
+//  1. Deferred Pass-4 sweep. A cache load of a non-empty graph
+//     (GraphCache.loadGroupForRef → applyAlgorithmsOnLoad) schedules
+//     schedulePendingAlgo, which runs Pass-4 on a BACKGROUND goroutine and then
+//     writes graph-algo.json (via os.CreateTemp + rename) into the repo's state
+//     dir AFTER the triggering request already returned (Fix A#1, #50). When
+//     that state dir is a t.TempDir, the write races RemoveAll. On Windows a
+//     file created/opened concurrently with a directory removal makes RemoveAll
+//     fail with "unlinkat <...>\refs\_unknown: The directory is not empty"
+//     (v0.1.9 3-OS acceptance, windows-latest only). On Unix the race is benign
+//     (unlink-while-open is legal), which is why it only ever reddens Windows.
+//     Setting backgroundAlgoGate parks every scheduled sweep at the gate BEFORE
+//     it touches the filesystem, so no graph-algo.json (nor its temp handle) is
+//     ever created under the temp dir. The parked goroutine holds no OS handle
+//     and is reclaimed at process exit; the prior gate is restored on cleanup.
+//
+//  2. Held mmap reader. loadGroupForRef opens a zero-copy fbreader.Reader over
+//     graph.<gen>.fb and keeps it resident in the cache (#2159); with the
+//     mmap-default-on serve path a live mapping cannot be unlinked on Windows.
+//     InvalidateAll is the production eviction primitive (closes every reader
+//     via closeDashGroupReaders); running it before RemoveAll drops the mapping
+//     (#5893-class).
+//
+// Call this in a fixture, passing the server, BEFORE any request can trigger a
+// load (i.e. before the fixture hands the caller a live URL).
+func quiesceGraphCache(t *testing.T, srv *Server) {
+	t.Helper()
+	prev := backgroundAlgoGate
+	backgroundAlgoGate = make(chan struct{}) // never closed → sweeps park pre-write
+	t.Cleanup(func() {
+		backgroundAlgoGate = prev
+		if srv != nil && srv.graphs != nil {
+			srv.graphs.InvalidateAll()
+		}
+	})
+}
+
 // fakeStore is an in-memory RegistryStore. It removes the dependency on
 // ~/.grafel for tests so they stay hermetic and parallel-safe.
 type fakeStore struct {


### PR DESCRIPTION
Fixes the sole windows-latest failure in the v0.1.9 3-OS acceptance CI: `TestHandleRepoRelationships_NoRef` → `TempDir RemoveAll cleanup: ...refs\_unknown: The directory is not empty`. Refs #5850.

**Root cause (empirically confirmed — NOT mmap):** the ref-endpoint fixture is `graph.json`-only, so no memory mapping is ever held. The failure is a deferred **background algo-sweep goroutine** (`schedulePendingAlgo`) writing `graph-algo.json` into the state dir *after* the triggering HTTP request returns, racing Go's automatic `RemoveAll` of the `t.TempDir`. On Windows a file created concurrently with directory removal makes `RemoveAll` fail; on Unix unlink-while-open is legal, so it only reddens Windows. Timing-flake shared by ~20 fixture siblings; this one lost the race that run. Production state dirs are durable (never swept), so this is a test gap, not a product leak.

**Fix:** new `quiesceGraphCache(t, srv)` helper parks the sweep via the existing `backgroundAlgoGate` hook (no `graph-algo.json` written under the temp dir) and, in `t.Cleanup` (LIFO before RemoveAll), restores the gate + calls `srv.graphs.InvalidateAll()` (production reader-eviction, defense for the mmap-default-on path). Wired into `buildRefEndpointFixture` (the failing test + ~19 siblings) and `setupDiffTest` (second instance). Whole-`internal/dashboard` audit found no other fixture holds a reader or spawns the sweep over a temp dir.

Test-only; full suite 11547 pass. Real proof is the Windows CI re-run (can't red→green on macOS — Unix allows unlink-while-open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o