### PR TITLE
test(cmd/grafel): strictly advance cpu.json mtime in writeCPUJSON (Windows caps-store flake)

### DIFF
--- a/cmd/grafel/daemon_caps_reload_test.go
+++ b/cmd/grafel/daemon_caps_reload_test.go
@@ -44,16 +44,35 @@ func TestResolveDaemonGOMAXPROCSWith(t *testing.T) {
 	}
 }
 
-// writeCPUJSON writes cpu.json into dir and bumps its mtime forward so the
-// caps.Store's (mtime,size) cache key changes deterministically.
+// writeCPUJSON writes cpu.json into dir and advances its mtime so the
+// caps.Store's (mtime,size) cache key changes on every successive call.
+//
+// This must be deterministic across platforms. cpu.json payloads that differ
+// only in a single digit ({"daemon_gomaxprocs": 2} vs 5) have IDENTICAL byte
+// size, so mtime is the ONLY discriminator in the store's (mtime,size) key. A
+// naive `time.Now().Add(2s)` applied to every write is not enough: on Windows
+// the wall clock is coarse (~15ms) and two rapid writes can observe the same
+// time.Now(), so the constant offset cancels out, both writes land on the same
+// mtime, and the store serves the STALE cached parse (the #5137 windows flake).
+//
+// Anchoring the new mtime to the PREVIOUS file's mtime + 2s (falling back to now
+// for the first write) makes each successive write strictly newer regardless of
+// clock resolution, so the cache key always changes.
 func writeCPUJSON(t *testing.T, dir, content string) string {
 	t.Helper()
 	path := filepath.Join(dir, caps.FileName)
+	next := time.Now()
+	if fi, err := os.Stat(path); err == nil {
+		if bumped := fi.ModTime().Add(2 * time.Second); bumped.After(next) {
+			next = bumped
+		}
+	}
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write cpu.json: %v", err)
 	}
-	future := time.Now().Add(2 * time.Second)
-	_ = os.Chtimes(path, future, future)
+	if err := os.Chtimes(path, next, next); err != nil {
+		t.Fatalf("chtimes cpu.json: %v", err)
+	}
 	return path
 }
 


### PR DESCRIPTION
Fixes the sole windows-latest failure in v0.1.9 acceptance CI #2: `TestApplyDaemonGOMAXPROCSFromCaps` → `raise: got (n=2, prev=2, changed=false), want (5, 2, true)`. Pre-existing Windows flake, unrelated to the memory epic (this test passed on the prior CI run that already contained every epic change). Refs #5850.

**Root cause (test artifact, not product):** `caps.Store.Load()` caches the parsed `cpu.json` on a `(mtime, size)` key — a deliberate stat-only hot-path optimization (avoids re-parsing JSON on the reindex hot path). The test's `writeCPUJSON` stamped both back-to-back writes with the same `now+2s`, and the two step-3 payloads (`{"daemon_gomaxprocs": 2}` / `5`) are byte-identical in size, so `size` can't discriminate and mtime is the sole key. On Windows's coarse (~15ms) wall clock the two rapid writes get the identical mtime, the key never advances, and `Load()` returns the stale parse (2). Unix's finer mtime distinguishes them → Unix-green, Windows-flaky.

**Fix:** `writeCPUJSON` anchors the new mtime to `max(now, prevFileMtime + 2s)` (stat-before-overwrite), so each successive write is strictly newer regardless of clock resolution and the `(mtime, size)` key always advances. Deterministic on all platforms; macOS stays green. Store left unchanged — hardening it to a content-hash key would force a `ReadFile` on every `Load()`, regressing exactly the stat-only cheapness it was built for, for a same-mtime-same-size collision that can't occur with real seconds-apart operator edits.

Class scan: the sibling caps tests (`caps_test.go`) already Chtimes only the second write, so they're safe; `writeCPUJSON` was the sole symmetric-offset instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o