### PR TITLE
test(daemon): de-flake rebuild/watchdog/sched timing tests for slow -race Windows CI

### DIFF
--- a/cmd/grafel/daemon_rebuild_test.go
+++ b/cmd/grafel/daemon_rebuild_test.go
@@ -172,7 +172,25 @@ func TestRebuildSemaphoreCapRespected(t *testing.T) {
 	}
 	group := setupTestGroup(t, "sem-cap-group", []string{"x1", "x2", "x3", "x4"})
 
-	var peakConc, current int64
+	// wantConc mirrors both the requested pool size (2) and the daemon-wide
+	// index gate cap (default 2), so exactly two workers can be in-flight at
+	// once. We prove peak concurrency ≥2 with a DETERMINISTIC 2-party
+	// rendezvous instead of a fixed time.Sleep window: the first two workers to
+	// reach the barrier block until BOTH have arrived, so they are provably
+	// inside indexFn simultaneously — no reliance on the scheduler happening to
+	// overlap two goroutines during a sleep (the source of the Windows-`-race`
+	// flake where peak was observed as 1). The peak is sampled while both are
+	// parked at the barrier, so the ≥2 observation is guaranteed by
+	// construction. The barrier has a generous timeout guard so a hypothetical
+	// single-slot regression fails via the peak assertion rather than hanging.
+	const wantConc = 2
+	var (
+		peakConc, current int64
+		barrierMu         sync.Mutex
+		arrived           int
+		proceed           = make(chan struct{})
+	)
+	barrierTimeout := time.After(30 * time.Second)
 	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
 		cur := atomic.AddInt64(&current, 1)
 		defer atomic.AddInt64(&current, -1)
@@ -182,7 +200,20 @@ func TestRebuildSemaphoreCapRespected(t *testing.T) {
 				break
 			}
 		}
-		time.Sleep(30 * time.Millisecond)
+		// Rendezvous: the first two workers park here until both have arrived,
+		// guaranteeing they overlap. Later workers (3rd, 4th) see proceed already
+		// closed and pass straight through — the gate keeps them from ever raising
+		// peak above wantConc.
+		barrierMu.Lock()
+		arrived++
+		if arrived == wantConc {
+			close(proceed)
+		}
+		barrierMu.Unlock()
+		select {
+		case <-proceed:
+		case <-barrierTimeout:
+		}
 		return nil
 	}
 
@@ -277,13 +308,17 @@ func TestDaemonRebuild_InvalidatesCacheExplicitly(t *testing.T) {
 // partial results.
 func TestRebuildPerRepoTimeoutSurfacesStalledRepo(t *testing.T) {
 	group := setupTestGroup(t, "stall-group", []string{"fast1", "stuck", "fast2"})
-	// Short per-repo timeout so the test is fast, but not so short that a
-	// "fast" mock repo can miss the window under load: a hardcoded 100ms
-	// raced real goroutine scheduling on a loaded/CI runner and could flake
-	// even though the mock fast1/fast2 index calls do essentially no work.
-	// 1.5s is still far below any real per-repo stall a human would tolerate,
-	// while giving the fast mocks generous headroom.
-	t.Setenv("GRAFEL_REBUILD_REPO_TIMEOUT", "1500ms")
+	// Per-repo timeout: the assertion is intrinsically wall-clock (the "stuck"
+	// repo must actually breach the watchdog), so this is one of the few places
+	// we tune a real constant rather than synchronize. It must satisfy two
+	// bounds simultaneously: long enough that the "fast" mock repos — whose only
+	// cost is per-repo bookkeeping (status-file flush, foreground claim, gate
+	// acquire), which balloons on a contended `-race` Windows runner — never
+	// falsely trip it; short enough that the whole test still finishes well
+	// under the 10s ceiling asserted below. A hardcoded 100ms flaked; 1.5s was
+	// still marginal under `-race`; 3s gives the fast mocks ~200× their real
+	// cost of headroom while keeping the stuck-repo wait to ~3s.
+	t.Setenv("GRAFEL_REBUILD_REPO_TIMEOUT", "3s")
 
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) }) // unblock the stuck goroutine at test end
@@ -304,7 +339,7 @@ func TestRebuildPerRepoTimeoutSurfacesStalledRepo(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// Must return promptly (well under any multi-minute wedge), bounded by the
-	// single 100ms per-repo timeout plus the two fast repos.
+	// single per-repo timeout (3s) plus the two fast repos.
 	if elapsed > 10*time.Second {
 		t.Fatalf("rebuild took %s — per-repo timeout did not unblock the group", elapsed)
 	}

--- a/cmd/grafel/daemon_rebuild_watchdog_visibility_test.go
+++ b/cmd/grafel/daemon_rebuild_watchdog_visibility_test.go
@@ -56,8 +56,16 @@ func repoPathForSlug(t *testing.T, group, slug string) string {
 // includes the FAILED line.
 func TestRebuildWatchdogFailure_PersistedAndSurfacedInStatus(t *testing.T) {
 	group := setupTestGroup(t, "watchdog-visibility-group", []string{"fast", "stuck"})
-	t.Setenv("GRAFEL_REBUILD_REPO_TIMEOUT", "300ms")
 
+	// Both repos share ONE rebuild call, hence ONE watchdog value: "stuck" must
+	// breach it while "fast" must not. That breach is intrinsically wall-clock,
+	// so this is a tuned constant (injected via RepoTimeout, which overrides the
+	// env). "stuck" blocks forever (released only at cleanup), so ANY finite
+	// value trips it; "fast" returns instantly and only pays per-repo bookkeeping
+	// (status flush + claim + gate), which can balloon on a `-race` Windows
+	// runner — the 300ms this test used flaked exactly there. 2s gives "fast"
+	// ample headroom while keeping the deliberate stuck-repo wait to ~2s.
+	const watchdog = "2s"
 	release := make(chan struct{})
 	t.Cleanup(func() { close(release) })
 
@@ -72,7 +80,7 @@ func TestRebuildWatchdogFailure_PersistedAndSurfacedInStatus(t *testing.T) {
 	// concurrency=2 so "fast" and "stuck" run in parallel: with concurrency=1
 	// "fast" would starve behind "stuck" on the single worker slot and get
 	// spuriously marked STALLED too, even though its indexFn returns instantly.
-	_, _, err := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
+	_, _, err := daemonRebuildFuncCore(2, proto.RebuildArgs{Group: group, RepoTimeout: watchdog}, mockIndexFn, noopLinksFn)
 	if err == nil || !strings.Contains(err.Error(), "stuck") || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected a timeout error naming the stuck repo, got: %v", err)
 	}
@@ -135,7 +143,6 @@ func TestRebuildWatchdogFailure_PersistedAndSurfacedInStatus(t *testing.T) {
 // must clear the marker set by an earlier failed attempt.
 func TestRebuildSuccess_ClearsPriorFailureMarker(t *testing.T) {
 	group := setupTestGroup(t, "watchdog-clear-group", []string{"flaky"})
-	t.Setenv("GRAFEL_REBUILD_REPO_TIMEOUT", "300ms")
 
 	release := make(chan struct{})
 	failFn := func(repoPath, _, slug string, _ []string, _, _ bool, _ ...IndexOption) error {
@@ -143,7 +150,11 @@ func TestRebuildSuccess_ClearsPriorFailureMarker(t *testing.T) {
 		return nil
 	}
 
-	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, failFn, noopLinksFn)
+	// First rebuild MUST time out. failFn blocks forever (until close(release)
+	// below), so the watchdog is the only completion path — it fires regardless
+	// of value, with no scheduler-timing race. A short-ish 1s keeps the test
+	// fast; the determinism comes from the infinite block, not the constant.
+	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group, RepoTimeout: "1s"}, failFn, noopLinksFn)
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("expected a timeout error on the first (failing) rebuild, got: %v", err)
 	}
@@ -155,11 +166,16 @@ func TestRebuildSuccess_ClearsPriorFailureMarker(t *testing.T) {
 		t.Fatalf("expected a persisted failure marker after the first rebuild, got err=%v marker=%v", sfErr, sf)
 	}
 
-	// Second rebuild: succeeds immediately.
+	// Second rebuild: succeeds immediately. Disable the watchdog entirely
+	// (RepoTimeout "0") for this "must succeed" path so a slow `-race` runner's
+	// per-repo bookkeeping overhead can never spuriously trip the timeout and
+	// turn a genuine success into a false STALLED failure (the observed Windows
+	// flake: an instant okFn "timed out after 300ms"). With the watchdog off,
+	// success is fully deterministic — no wall-clock dependence remains.
 	okFn := func(repoPath, _, slug string, _ []string, _, _ bool, _ ...IndexOption) error {
 		return nil
 	}
-	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, okFn, noopLinksFn)
+	rebuilt, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group, RepoTimeout: "0"}, okFn, noopLinksFn)
 	if err != nil {
 		t.Fatalf("second (successful) rebuild failed: %v", err)
 	}

--- a/internal/daemon/boot_watcher_async_test.go
+++ b/internal/daemon/boot_watcher_async_test.go
@@ -35,17 +35,22 @@ func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
 		t.Fatalf("ensure: %v", err)
 	}
 
-	// ReposToWatch blocks for 5s, simulating a stalled filesystem walk
-	// during watcher subscription. released is closed when it returns so
-	// the test can confirm the goroutine actually ran (and is off the
-	// critical path).
-	const stall = 5 * time.Second
+	// ReposToWatch blocks INDEFINITELY (until the test closes release),
+	// simulating a stalled filesystem walk during watcher subscription. Using an
+	// unblock-on-demand channel instead of a fixed time.Sleep removes the old
+	// 4s-serve-vs-5s-stall wall-clock race that flaked under `-race`: because the
+	// stall never clears on its own, the ONLY way the daemon can answer an RPC
+	// within the (now generous) deadline below is if watcher subscription is off
+	// the boot critical path. A synchronous regression would block here forever
+	// and never serve — caught deterministically, with no timing tuning. released
+	// is closed when the goroutine returns so the test can confirm it ran.
+	release := make(chan struct{})
 	released := make(chan struct{})
 	cfg := daemon.Config{
 		Layout: layout,
 		ReposToWatch: func() []string {
 			defer close(released)
-			time.Sleep(stall)
+			<-release // block until the test releases us (simulated stall)
 			return nil
 		},
 		GroupsForRepo:      func(_ string) []string { return nil },
@@ -59,7 +64,7 @@ func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
 	done := make(chan error, 1)
 	go func() { done <- daemon.Run(ctx, cfg) }()
 
-	// The daemon must SERVE RPC promptly — far sooner than the 5s stall.
+	// The daemon must SERVE RPC while the watcher subscription is still blocked.
 	// We assert a real Ping round-trip completes, not merely that the socket
 	// file exists: the socket is created early (transport.Listen) but the
 	// accept loop, dashboard goroutine, and "ready" log all sit AFTER the
@@ -67,12 +72,12 @@ func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
 	// the daemon binds the fd but never answers — exactly the live symptom
 	// (0% CPU, :47274 never serving).
 	//
-	// Budget bumped from 2s → 4s (#1797 / #937 investigation): under
-	// `go test -race` on shared CI runners the race detector adds ~2× overhead
-	// to goroutine scheduling; 2s was routinely too tight and caused
-	// sync.Cond-Wait to outlast the whole test-suite timeout (10 min).
-	// The boot path itself is sub-100ms on any tier of hardware so 4s is
-	// still a tight regression guard while being robust to CI noise.
+	// Because the stall is now an indefinite block (not a 5s sleep), the serve
+	// deadline no longer races a fixed stall duration and can be generous: it
+	// only needs to exceed worst-case boot time on a contended `-race` runner.
+	// The boot path itself is sub-100ms on any tier of hardware, so 10s is a
+	// robust regression guard — a synchronous stall would miss it by an infinity,
+	// not by a slim margin.
 	//
 	// pingOnce dials and Pings with a hard per-attempt timeout. net/rpc's
 	// Call blocks until the server's accept loop reads the request, so a
@@ -95,7 +100,7 @@ func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
 		}
 	}
 
-	servedDeadline := time.Now().Add(4 * time.Second)
+	servedDeadline := time.Now().Add(10 * time.Second)
 	served := false
 	for time.Now().Before(servedDeadline) {
 		if pingOnce(200 * time.Millisecond) {
@@ -105,17 +110,19 @@ func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
 		time.Sleep(20 * time.Millisecond)
 	}
 	if !served {
-		t.Fatalf("daemon did not answer an RPC within 4s while the watcher "+
-			"subscription was stalled for %s — watcher setup is blocking the "+
-			"boot critical path (#1456 regression)", stall)
+		t.Fatal("daemon did not answer an RPC within 10s while the watcher " +
+			"subscription was blocked — watcher setup is blocking the boot " +
+			"critical path (#1456 regression)")
 	}
 
-	// Sanity: the stalled subscription really was running concurrently and
-	// eventually returns (it is not silently skipped).
+	// The daemon served while ReposToWatch was still blocked, proving the
+	// subscription is off the critical path. Now release the simulated stall and
+	// confirm the goroutine really ran (it is not silently skipped) and unwinds.
+	close(release)
 	select {
 	case <-released:
-	case <-time.After(stall + 2*time.Second):
-		t.Fatalf("ReposToWatch never released — watcher goroutine not started")
+	case <-time.After(5 * time.Second):
+		t.Fatal("ReposToWatch never released — watcher goroutine not started")
 	}
 
 	cancel()

--- a/internal/daemon/sched/scheduler_test.go
+++ b/internal/daemon/sched/scheduler_test.go
@@ -151,7 +151,7 @@ func TestGroupAlgoReArmsOnNewLinkCompletion(t *testing.T) {
 	s := New(Config{
 		Workers:           2,
 		LinkDebounce:      30 * time.Millisecond,
-		GroupAlgoDebounce: 200 * time.Millisecond,
+		GroupAlgoDebounce: 2 * time.Second,
 		Index:             func(_ context.Context, _ string, _ string) error { return nil },
 		Links:             func(_ context.Context, _ string) error { return nil },
 		GroupAlgo: func(_ context.Context, _ string) error {
@@ -167,16 +167,22 @@ func TestGroupAlgoReArmsOnNewLinkCompletion(t *testing.T) {
 
 	// Timing here is structural, not wall-clock-fragile: the group-algo timer
 	// is *re-armed* (old timer cancelled) when /b's link pass completes, so the
-	// only way group-algo can fire is GroupAlgoDebounce (200ms) after the LAST
-	// link completion. The mid-window check below proves it did NOT fire early;
-	// the final check converges on the single eventual pass. The sleeps are
-	// kept SMALL relative to the 200ms debounce (re-arm happens at ~100ms, well
-	// before the first 200ms timer could elapse) so even a slow CI cannot make
-	// the first timer fire before the re-arm cancels it.
+	// only way group-algo can fire is GroupAlgoDebounce after the LAST link
+	// completion. The mid-window check below proves it did NOT fire early; the
+	// final check converges on the single eventual pass.
+	//
+	// GroupAlgoDebounce is deliberately LARGE (2s) relative to the test's coarse
+	// sleeps (100ms + 150ms) so the re-arm race is decided structurally, not by
+	// scheduler luck: /a's group-algo timer cannot fire until ~2s after /a's
+	// link completes, but /b is enqueued at ~100ms and — even on a heavily
+	// contended `-race` runner where goroutine scheduling lags several-fold — is
+	// processed and re-arms the timer far inside that 2s window. That is the fix
+	// for the full-suite parallel-load flake: with the old 200ms debounce a
+	// loaded runner could let /a's original timer fire before /b's re-arm landed.
 	s.Enqueue("/a")
-	time.Sleep(100 * time.Millisecond) // first link pass done, group-algo armed (200ms)
+	time.Sleep(100 * time.Millisecond) // first link pass done, group-algo armed (2s)
 	s.Enqueue("/b")                    // second burst → re-arms the group-algo timer
-	time.Sleep(150 * time.Millisecond) // first group-algo timer would have fired (~at 100+200) — but re-armed
+	time.Sleep(150 * time.Millisecond) // still deep inside the 2s window — nothing fired yet
 	mu.Lock()
 	mid := groupAlgoCalls
 	mu.Unlock()


### PR DESCRIPTION
Hardens the cluster of pre-existing timing-fragile daemon tests that flake on the slow, contended `-race` windows-latest CI runner (unrelated to the v0.1.9 memory epic — these are hardcoded-real-time-threshold tests). Surfaced across v0.1.9 acceptance CI runs. Refs #5850.

All 6 audited tests are **test-fragility, not product bugs** — product parallelism + watchdog behavior confirmed correct; full `-race` suite green throughout.

- `TestRebuildSemaphoreCapRespected`: replaced scheduler-luck overlap (`Sleep(30ms)`) with a deterministic 2-party barrier so `peak≥2` holds by construction; real semaphore still enforces `cap≤2`.
- `TestRebuildSuccess_ClearsPriorFailureMarker` (the run-#3 failure): success path now disables the watchdog (`RepoTimeout:"0"`), removing wall-clock dependence; the must-time-out path uses `failFn` that blocks forever (deterministic).
- `TestRebuildWatchdogFailure_...` / `TestRebuildPerRepoTimeoutSurfacesStalledRepo`: intrinsic-timeout thresholds inflated with generous headroom over per-repo bookkeeping cost (300ms→2s, 1.5s→3s), still under the asserted ceilings.
- `TestGroupAlgoReArmsOnNewLinkCompletion` (sched): debounce 200ms→2s so the re-arm is decided structurally, not by timer race.
- `TestBoot_WatcherSubscriptionDoesNotBlockBind`: replaced a `5s` sleep-stall with an indefinite channel block released only after the daemon serves — a synchronous regression now misses by infinity, not a slim margin.

Timing-dependence removed entirely where possible (barrier / disabled-watchdog / infinite-block); constants inflated only where the assertion is intrinsically wall-clock. Stability: `-race -count` up to 50 under `GOMAXPROCS=2` (2-core-runner sim), all green. `go test -race ./cmd/grafel/ ./internal/daemon/...` = 1070 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o