### PR TITLE
fix(groupalgo): in-memory compute-once memo guard for group Pass-4 (bounds persist-failure recompute spin)

### DIFF
--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -24,11 +24,72 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/registry"
 )
+
+// memoMu guards the process-local compute-once guard below. All access to the
+// shared maps goes through it.
+var (
+	memoMu      sync.Mutex
+	memoHashes  = map[string]string{}                  // memoKey -> input hash of the last full compute
+	memoResults = map[string]*graph.AlgorithmResults{} // memoKey -> that full compute's result (read-only after store)
+)
+
+// memoKeyFor returns the process-local guard key for a group. It keys on the
+// resolved overlay path (which embeds GRAFEL_HOME) so distinct daemons / test
+// homes never collide, falling back to the bare group name if the path cannot
+// be resolved.
+func memoKeyFor(group string) string {
+	if p, err := OverlayPath(group); err == nil && p != "" {
+		return p
+	}
+	return "group:" + group
+}
+
+// loadMemoizedGroupResult returns the last full-computed result for group IFF it
+// was computed against the SAME group-version (inputHash). The returned pointer
+// is shared and MUST be treated read-only by callers (same contract as the disk
+// overlay reconstitution — consumers only read it).
+func loadMemoizedGroupResult(group, inputHash string) (*graph.AlgorithmResults, bool) {
+	memoMu.Lock()
+	defer memoMu.Unlock()
+	k := memoKeyFor(group)
+	if memoHashes[k] == inputHash {
+		if res, ok := memoResults[k]; ok && res != nil {
+			return res, true
+		}
+	}
+	return nil, false
+}
+
+// storeMemoizedGroupResult records that group's inputHash version has been fully
+// computed this process, keeping the result so a later reload for the SAME
+// version can reuse it even if the disk overlay never persisted. Recorded BEFORE
+// the caller attempts to write the overlay, so a persist failure cannot reopen
+// the recompute→persist-fail→recompute spin.
+func storeMemoizedGroupResult(group, inputHash string, res *graph.AlgorithmResults) {
+	if res == nil {
+		return
+	}
+	memoMu.Lock()
+	defer memoMu.Unlock()
+	k := memoKeyFor(group)
+	memoHashes[k] = inputHash
+	memoResults[k] = res
+}
+
+// resetGroupAlgoMemo clears the process-local guard. Test-only seam so cases can
+// assert first-compute behaviour deterministically.
+func resetGroupAlgoMemo() {
+	memoMu.Lock()
+	defer memoMu.Unlock()
+	memoHashes = map[string]string{}
+	memoResults = map[string]*graph.AlgorithmResults{}
+}
 
 // GroupAlgoResult wraps the single group-scope algorithm pass.
 //
@@ -247,8 +308,35 @@ func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
 		}
 	}
 
+	// Process-local compute-once guard. The disk overlay skip above is the fast
+	// path, but it only fires when the overlay could be PERSISTED. If the overlay
+	// is absent because a prior WriteOverlayFromResult FAILED (read-only
+	// ~/.grafel/groups, disk-full, EPERM) — the "sidecars=0" symptom — the disk
+	// skip can never engage, and without this guard every trigger re-ran the full
+	// ~O(V·E) betweenness over the whole group union, pinning the daemon (the
+	// group-scope analog of the per-repo #50 compute→evict spin). This guard makes
+	// the heavy pass run at most once per group-version in a process regardless of
+	// whether the overlay reached disk; a real re-index bumps the input hash and
+	// falls through to exactly one recompute (correctness preserved).
+	if res, ok := loadMemoizedGroupResult(group, inputHash); ok {
+		return &GroupAlgoResult{
+			Group:        group,
+			Results:      res,
+			EntityRepo:   entityRepo,
+			SourceMtimes: srcMtimes,
+			NumEntities:  len(entities),
+			NumRels:      len(rels),
+			NumRepos:     numRepos,
+			InputHash:    inputHash,
+			Skipped:      true,
+		}, nil
+	}
+
 	// Full deterministic recompute (input changed, or no usable prior overlay).
 	res := graph.RunAlgorithms(entities, rels)
+	// Record BEFORE returning (and thus before the caller's overlay write), so a
+	// persist failure cannot cause a re-run for this same version.
+	storeMemoizedGroupResult(group, inputHash, res)
 	return &GroupAlgoResult{
 		Group:        group,
 		Results:      res,

--- a/internal/graph/groupalgo/incremental_communities_5309_test.go
+++ b/internal/graph/groupalgo/incremental_communities_5309_test.go
@@ -16,6 +16,7 @@ import (
 // incremental path.
 func setupIncrGroup(t *testing.T) (group, pathA, pathB, serviceID string) {
 	t.Helper()
+	resetGroupAlgoMemo()
 	testsupport.IsolateHome(t)
 	root := t.TempDir()
 	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))

--- a/internal/graph/groupalgo/incremental_memo_guard_test.go
+++ b/internal/graph/groupalgo/incremental_memo_guard_test.go
@@ -1,0 +1,175 @@
+package groupalgo
+
+// incremental_memo_guard_test.go — group-level in-memory compute-once guard.
+//
+// The disk overlay (input-hash keyed) is the FAST reuse path for the group-scope
+// Pass-4 sweep, but it only helps when the overlay can be PERSISTED. If
+// WriteOverlayFromResult fails (read-only ~/.grafel/groups, disk-full, EPERM) or
+// the overlay is otherwise absent, RunGroupAlgorithmsIncremental had nothing to
+// fall back on and re-ran the full RunAlgorithms (Louvain + PageRank + O(V·E)
+// betweenness over the whole ~32k-node group union) on EVERY trigger — the
+// group-scope analog of the per-repo #50 compute→evict CPU spin.
+//
+// These tests pin the fix: an in-memory guard keyed on the group-version
+// (community input hash) makes the heavy pass run at most ONCE per version in a
+// process, regardless of whether the overlay ever reached disk. A genuine
+// structural change bumps the hash and triggers exactly one recompute.
+//
+// The group is modeled as ≥2 repos (setupIncrGroup: svc + web) so the combined
+// union path is exercised, matching the real corpus symptom.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestIncremental_MemoGuard_ComputesOncePerVersion proves the guard: with the
+// overlay never persisted (simulating a persist failure — the sidecar can't be
+// written), repeated group-graph loads must reuse the first in-process compute
+// instead of re-running the full sweep each time.
+func TestIncremental_MemoGuard_ComputesOncePerVersion(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+
+	first, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("first incremental run: %v", err)
+	}
+	if first.Skipped {
+		t.Fatal("first run must NOT skip (nothing computed yet)")
+	}
+
+	// Deliberately do NOT WriteOverlayFromResult — models a persist failure /
+	// absent overlay. Every subsequent load hits the same graph.fb version.
+	for i := 0; i < 3; i++ {
+		got, err := RunGroupAlgorithmsIncremental(group)
+		if err != nil {
+			t.Fatalf("reload %d: %v", i, err)
+		}
+		if !got.Skipped {
+			t.Fatalf("reload %d recomputed the full group Pass-4 (Skipped=false) — the compute-once-per-version guard is missing; this is the ~32k-node betweenness CPU spin", i)
+		}
+		if got.InputHash != first.InputHash {
+			t.Fatalf("reload %d input hash drifted: %s != %s", i, got.InputHash, first.InputHash)
+		}
+	}
+
+	// Parity: the reused result equals a from-scratch full recompute.
+	full, err := RunGroupAlgorithms(group)
+	if err != nil {
+		t.Fatalf("full reference: %v", err)
+	}
+	reused, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("reused run: %v", err)
+	}
+	resultsEqual(t, full.Results, reused.Results)
+}
+
+// TestIncremental_MemoGuard_PersistFailureDoesNotRecomputeForever mirrors the
+// per-repo TestSchedulePendingAlgo_PersistFailureDoesNotRecomputeForever at
+// group scope: when the overlay directory is read-only so WriteOverlayFromResult
+// genuinely fails, the next incremental run must still be served from the
+// in-memory guard (Skipped=true), never a fresh full sweep.
+func TestIncremental_MemoGuard_PersistFailureDoesNotRecomputeForever(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+
+	first, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("first incremental run: %v", err)
+	}
+	if first.Skipped {
+		t.Fatal("first run must NOT skip")
+	}
+
+	// Force the overlay write to fail: make the groups/ directory read-only so
+	// the temp-file create inside WriteOverlayTo returns EPERM (best-effort,
+	// swallowed by the caller in prod).
+	path, perr := OverlayPath(group)
+	if perr != nil {
+		t.Fatalf("overlay path: %v", perr)
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir groups: %v", err)
+	}
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod groups ro: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o755) })
+
+	if werr := WriteOverlayFromResult(first); werr == nil {
+		t.Skip("overlay write unexpectedly succeeded on a read-only dir (running as root?) — cannot exercise the persist-failure path")
+	}
+	// Precondition: no overlay on disk, so the disk-skip path cannot engage.
+	if _, ok := ReadOverlay(path, nil); ok {
+		t.Fatal("test precondition broken: overlay present despite failed write")
+	}
+
+	got, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("post-persist-failure run: %v", err)
+	}
+	if !got.Skipped {
+		t.Fatal("full group Pass-4 recomputed after a persist failure — the in-memory guard does NOT bound the recompute (CPU spin)")
+	}
+}
+
+// TestIncremental_MemoGuard_RecomputesOnVersionChange proves correctness is
+// preserved: a structural change (new tightly-connected cluster) bumps the
+// group-version hash, so the guard misses and exactly one recompute runs; the
+// next load for the NEW version is then reused.
+func TestIncremental_MemoGuard_RecomputesOnVersionChange(t *testing.T) {
+	group, pathA, _, serviceID := setupIncrGroup(t)
+
+	first, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("first incremental run: %v", err)
+	}
+
+	// Structural change in repo-A (new cluster + edge into Service) — a real
+	// re-index. This bumps graph.fb and, crucially, the community input hash.
+	repoA, _, _ := fixtureGraphs()
+	mkEnt := func(name string) graph.Entity {
+		return graph.Entity{ID: "svc:" + name, Name: name, Kind: "function", SourceFile: "svc/" + name + ".go", Language: "go"}
+	}
+	mkRel := func(from, to string) graph.Relationship {
+		return graph.Relationship{ID: from + "->" + to, FromID: from, ToID: to, Kind: "CALLS"}
+	}
+	cluster := []string{"g1", "g2", "g3", "g4", "g5", "g6"}
+	for _, n := range cluster {
+		repoA.Entities = append(repoA.Entities, mkEnt(n))
+	}
+	for i := 0; i < len(cluster); i++ {
+		for j := i + 1; j < len(cluster); j++ {
+			repoA.Relationships = append(repoA.Relationships, mkRel("svc:"+cluster[i], "svc:"+cluster[j]))
+		}
+	}
+	repoA.Relationships = append(repoA.Relationships, mkRel("svc:g1", serviceID))
+	writeFixtureRepo(t, "svc", pathA, repoA)
+
+	changed, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("post-change run: %v", err)
+	}
+	if changed.Skipped {
+		t.Fatal("structural change must NOT be skipped (correctness: a re-index must recompute)")
+	}
+	if changed.InputHash == first.InputHash {
+		t.Fatal("input hash unchanged after a structural re-index")
+	}
+
+	// The NEW version is now memoized: a subsequent load reuses it.
+	reused, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("reused post-change run: %v", err)
+	}
+	if !reused.Skipped {
+		t.Fatal("second load of the new version recomputed instead of reusing the guard")
+	}
+	if reused.InputHash != changed.InputHash {
+		t.Fatalf("reused hash %s != changed hash %s", reused.InputHash, changed.InputHash)
+	}
+}


### PR DESCRIPTION
Recovered from an abandoned prior-session branch (verified genuinely unmerged, not subsumed by the existing disk-overlay guard). Refs #5850.

**The failure mode it fixes:** main's group Pass-4 recompute-avoidance is entirely disk-overlay-gated (`readOverlayUnconditional`/`OverlayNeedsRecompute`, keyed on `InputHash`). When the overlay can't persist — read-only `~/.grafel/groups`, disk-full, EPERM (the "sidecars=0" symptom) — the overlay never lands, so *every* trigger falls through to a full `graph.RunAlgorithms` (O(V·E) betweenness over the ~32k-node group union). This adds an in-memory memo (`memoMu`) layered **below** the disk-overlay skip: it fires only when the disk skip did not, closing that recompute spin. It's the group-scope analog of the already-merged per-repo in-memory guard.

**Reviewed (independent, mutation-proven):**
- Strict parity — keyed on `CommunityInputHash` (full node set + weighted edges); stores the literal `*AlgorithmResults`; deep-equal-verified. A structural change invalidates the key (mutation confirmed).
- Exactly-once recompute on version change; persist-failure bounds recompute to once (store-before-overlay-write; mutation confirmed).
- Concurrency clean: `-race -count=20` → 60 pass; `memoMu` sole lock, no lock-order cycle; **map bounded to one entry per group** (replaced on version change), no leak.
- Composition correct (disk skip first); default subprocess path unaffected (memo cold, discarded per fork).

Process-local by design → helps the in-process path (`GRAFEL_SUBPROCESS_INDEXER=0`); the default subprocess path retains nothing. Bounded per-group retention on that path is the deliberate CPU-spin-vs-RAM tradeoff (possible follow-up: free the memo entry after a successful overlay write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o