### PR TITLE
feat(#5907): surface reindex-after-upgrade in dashboard + doctor + update

### DIFF
--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -135,5 +135,12 @@ func runSelfUpdate(out io.Writer, opts install.UpdateOptions) error {
 			fmt.Fprintf(out, "  daemon:   %s\n", result.InstallResult.DaemonVersion)
 		}
 	}
+	// #5907 FIX4: surface the auto-reindex-on-upgrade the engine has already
+	// (loop-guarded) enqueued, so it reads as "reindexing after upgrade"
+	// rather than a silent multi-minute stall right after `grafel update`
+	// returns. Report-only — nothing here triggers or duplicates the reindex.
+	if result.ReposNeedingReindex > 0 {
+		fmt.Fprintf(out, "  reindex:  %d repo(s) reindexing after upgrade\n", result.ReposNeedingReindex)
+	}
 	return nil
 }

--- a/internal/dashboard/handlers_index_status.go
+++ b/internal/dashboard/handlers_index_status.go
@@ -20,7 +20,9 @@ package dashboard
 //	    "repos": [
 //	      { "repo_slug": "<slug>", "indexing": <bool>, "enhancing": <bool>,
 //	        "entities": <int64>, "relationships": <int64>,
-//	        "graph_fb_mtime": <int64-ns> }
+//	        "graph_fb_mtime": <int64-ns>,
+//	        "reindex_required": <bool>, "reindex_reason": <string>,
+//	        "status": "<idle|indexing|enhancing|reindex-required|reindexing-after-upgrade>" }
 //	    ]
 //	  }
 //	}
@@ -35,6 +37,18 @@ package dashboard
 // exactly that "unknown" case. Missing/stale engine-liveness similarly
 // degrades to a zero engine block rather than failing the whole response.
 // This endpoint is read-only: no writes, no index trigger.
+//
+// #5907 SURFACING slice: before this change, ReindexRequired/ReindexReason
+// (internal/statusfile.File, set by the engine's FIX2 auto-reindex-on-upgrade
+// arm — internal/daemon/stale_reindex.go) were dropped when building
+// indexStatusRepo, so a repo whose on-disk graph.fb was stamped by an older
+// grafel build read as idle to the web dashboard — a silent multi-minute
+// stall from the frontend's point of view, even though the engine had
+// already loop-guard-enqueued a reindex. Those fields are now surfaced
+// verbatim, plus a derived `status` string (see deriveIndexStatus) so the
+// frontend can render a "reindexing after upgrade" badge instead of nothing
+// at all. This mirrors internal/cli/statusline.go's shell-side
+// `⟲ reindex required` rendering of the same statusfile fields.
 
 import (
 	"net/http"
@@ -56,6 +70,49 @@ type indexStatusRepo struct {
 	Entities      int64  `json:"entities"`
 	Relationships int64  `json:"relationships"`
 	GraphFBMtime  int64  `json:"graph_fb_mtime"`
+
+	// ReindexRequired/ReindexReason mirror internal/statusfile.File's fields
+	// of the same name (#5907 FIX1/FIX2): true when the on-disk graph.fb this
+	// repo is CURRENTLY SERVING was written by an older grafel build than
+	// this engine's fbversion.Version supports. The engine has already
+	// loop-guard-enqueued a reindex by the time this is observed true — it is
+	// never a "please click something" prompt, only a visibility signal.
+	ReindexRequired bool   `json:"reindex_required"`
+	ReindexReason   string `json:"reindex_reason,omitempty"`
+
+	// Status is a derived, frontend-friendly single-word summary of the row
+	// (see deriveIndexStatus), so the dashboard can render one badge instead
+	// of re-deriving the same precedence from four booleans client-side.
+	Status string `json:"status"`
+}
+
+// deriveIndexStatus collapses a repo's raw statusfile flags into a single
+// human-facing status string, in priority order:
+//
+//  1. "reindexing-after-upgrade" — ReindexRequired AND the auto-enqueued
+//     reindex is actively running (Indexing=true). This is the state #5907
+//     exists to surface: without it, a post-upgrade reindex reads as a
+//     generic "indexing" row indistinguishable from a normal reindex.
+//  2. "reindex-required" — ReindexRequired but the auto-enqueued reindex
+//     hasn't started running yet (still queued behind other work, or the
+//     engine hasn't drained the request yet). Before this slice, THIS was
+//     the silent-stall window: the repo looked idle from the dashboard.
+//  3. "indexing" — the ordinary extraction-phase state.
+//  4. "enhancing" — queryable, background enrichment tail still running.
+//  5. "idle" — none of the above.
+func deriveIndexStatus(reindexRequired, indexing, enhancing bool) string {
+	switch {
+	case reindexRequired && indexing:
+		return "reindexing-after-upgrade"
+	case reindexRequired:
+		return "reindex-required"
+	case indexing:
+		return "indexing"
+	case enhancing:
+		return "enhancing"
+	default:
+		return "idle"
+	}
 }
 
 // indexStatusReply is the payload for GET /api/v2/groups/{group}/index-status.
@@ -98,7 +155,10 @@ func (s *Server) handleV2IndexStatus(w http.ResponseWriter, r *http.Request) {
 			row.Entities = f.Entities
 			row.Relationships = f.Relationships
 			row.GraphFBMtime = f.GraphFBMtime
+			row.ReindexRequired = f.ReindexRequired
+			row.ReindexReason = f.ReindexReason
 		}
+		row.Status = deriveIndexStatus(row.ReindexRequired, row.Indexing, row.Enhancing)
 		reply.Repos = append(reply.Repos, row)
 	}
 

--- a/internal/dashboard/handlers_index_status_test.go
+++ b/internal/dashboard/handlers_index_status_test.go
@@ -76,6 +76,23 @@ func writeIndexStatusFixture(t *testing.T, repoPath string, indexing, enhancing 
 	}
 }
 
+// writeIndexStatusReindexFixture writes a per-repo statusfile.File with
+// ReindexRequired/ReindexReason set (#5907 FIX1/FIX2's fields), optionally
+// while an auto-enqueued reindex is actively running (indexing=true).
+func writeIndexStatusReindexFixture(t *testing.T, repoPath string, indexing bool, reason string) {
+	t.Helper()
+	f := &statusfile.File{
+		RepoPath:        repoPath,
+		HeartbeatAt:     time.Now().UTC(),
+		Indexing:        indexing,
+		ReindexRequired: true,
+		ReindexReason:   reason,
+	}
+	if err := statusfile.Write(repoPath, f); err != nil {
+		t.Fatalf("write reindex status fixture for %s: %v", repoPath, err)
+	}
+}
+
 // writeEngineLivenessFixture writes the engine-global liveness sidecar with
 // the given CPU%/RSS, using the SAME (daemon.DefaultLayout + EngineLivenessStatusKey)
 // derivation the production writer/reader use, so the handler under test
@@ -112,12 +129,15 @@ type indexStatusReplyWire struct {
 		RSSMB  int64   `json:"rss_mb"`
 	} `json:"engine"`
 	Repos []struct {
-		RepoSlug      string `json:"repo_slug"`
-		Indexing      bool   `json:"indexing"`
-		Enhancing     bool   `json:"enhancing"`
-		Entities      int64  `json:"entities"`
-		Relationships int64  `json:"relationships"`
-		GraphFBMtime  int64  `json:"graph_fb_mtime"`
+		RepoSlug        string `json:"repo_slug"`
+		Indexing        bool   `json:"indexing"`
+		Enhancing       bool   `json:"enhancing"`
+		Entities        int64  `json:"entities"`
+		Relationships   int64  `json:"relationships"`
+		GraphFBMtime    int64  `json:"graph_fb_mtime"`
+		ReindexRequired bool   `json:"reindex_required"`
+		ReindexReason   string `json:"reindex_reason"`
+		Status          string `json:"status"`
 	} `json:"repos"`
 }
 
@@ -212,6 +232,67 @@ func TestIndexStatusEndpoint_MissingStatusFileYieldsZeroRow(t *testing.T) {
 	}
 	if r.Indexing || r.Enhancing || r.Entities != 0 || r.Relationships != 0 || r.GraphFBMtime != 0 {
 		t.Errorf("untouched repo should be zero/false row, got %+v", r)
+	}
+	if r.ReindexRequired {
+		t.Errorf("untouched repo should have reindex_required=false, got true")
+	}
+	if r.Status != "idle" {
+		t.Errorf("untouched repo status = %q, want %q", r.Status, "idle")
+	}
+}
+
+// TestIndexStatusEndpoint_ReindexRequired_Surfaced is the FIX3 (#5907) RED
+// test: before this change, ReindexRequired/ReindexReason were dropped when
+// building indexStatusRepo, so a repo whose graph.fb needed a reindex after a
+// format upgrade read as an idle row to the web dashboard — a silent stall.
+// This proves the fields are surfaced verbatim, plus the derived `status`:
+// "reindexing-after-upgrade" once the auto-enqueued reindex is actively
+// running, "reindex-required" while it's still queued.
+func TestIndexStatusEndpoint_ReindexRequired_Surfaced(t *testing.T) {
+	paths := seedIndexStatusRegistry(t, "demo", "queued", "running")
+	writeIndexStatusReindexFixture(t, paths["queued"], false, "graph format v2 incompatible with v3 — reindex required")
+	writeIndexStatusReindexFixture(t, paths["running"], true, "graph format v2 incompatible with v3 — reindex required")
+
+	url, done := newIndexStatusServer(t)
+	defer done()
+
+	resp, err := http.Get(url + "/api/v2/groups/demo/index-status")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var env indexStatusEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	byBlug := map[string]int{}
+	for i, r := range env.Data.Repos {
+		byBlug[r.RepoSlug] = i
+	}
+
+	queued := env.Data.Repos[byBlug["queued"]]
+	if !queued.ReindexRequired {
+		t.Error("queued repo: expected reindex_required=true")
+	}
+	if queued.ReindexReason == "" {
+		t.Error("queued repo: expected a non-empty reindex_reason")
+	}
+	if queued.Status != "reindex-required" {
+		t.Errorf("queued repo status = %q, want %q", queued.Status, "reindex-required")
+	}
+
+	running := env.Data.Repos[byBlug["running"]]
+	if !running.ReindexRequired {
+		t.Error("running repo: expected reindex_required=true")
+	}
+	if !running.Indexing {
+		t.Error("running repo: expected indexing=true")
+	}
+	if running.Status != "reindexing-after-upgrade" {
+		t.Errorf("running repo status = %q, want %q", running.Status, "reindexing-after-upgrade")
 	}
 }
 

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -12,6 +12,7 @@
 //   - Conventions per-file SHA manifests (Warning)
 //   - .gitignore contains /.grafel/ in tracked repos (Warning)
 //   - Stale staging directories older than 7 days (Info)
+//   - Repos whose on-disk graph needs a reindex after a format upgrade (Info)
 //
 // JSON schema is pinned at schema_version=1.  Bump SchemaVersion when
 // the shape of DoctorReport changes in a backward-incompatible way.
@@ -35,6 +36,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/service"
+	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/rulesfiles"
 	"github.com/cajasmota/grafel/internal/install/skilllink"
@@ -247,6 +249,15 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	// ── Check 8: Stale staging dirs ─────────────────────────────────────────
 	if staleCheck := checkStaleStagingDirs(opts.StatePath); staleCheck != nil {
 		report.Checks = append(report.Checks, *staleCheck)
+	}
+
+	// ── Check 9: Reindex required after a format upgrade (issue #5907 FIX4) ──
+	// Report-only: the engine's FIX2 (internal/daemon/stale_reindex.go) already
+	// auto-enqueues a loop-guarded reindex for a repo in this state, so doctor
+	// need not (and must not) trigger anything here — it only makes the
+	// otherwise-silent post-upgrade reindex visible in `grafel doctor`.
+	if reindexCheck := checkReindexRequired(opts); reindexCheck != nil {
+		report.Checks = append(report.Checks, *reindexCheck)
 	}
 
 	// Determine overall OK: all Critical checks must pass.
@@ -814,6 +825,69 @@ func checkStaleStagingDirs(statePath string) *CheckResult {
 		Drift:    drift,
 	}
 	return &cr
+}
+
+// checkReindexRequired scans every registered repo (across every grafel
+// group) for an on-disk graph.fb written by an older grafel build than this
+// binary supports (graph.ReindexRequiredReason, issue #5907 FIX1/FIX2).
+//
+// This is REPORT-ONLY. By the time a repo is observed in this state the
+// engine's stale-format auto-reindex arm (internal/daemon/stale_reindex.go's
+// loop-guarded maybeEnqueue) has already enqueued a reindex on its own — this
+// check exists purely so that in-flight reindex is VISIBLE in `grafel doctor`
+// instead of the repo silently looking idle/current for the several minutes
+// the reindex takes. Doctor must never enqueue anything itself here: the
+// engine already owns that decision, and a second enqueuer would risk racing
+// or duplicating the loop-guard's own bookkeeping.
+//
+// Severity is Info, mirroring checkStaleStagingDirs: this is advisory
+// visibility, not a broken install — the engine is already fixing it.
+//
+// Returns nil when no groups are registered or no repo currently needs a
+// reindex (avoids adding a check with no content).
+func checkReindexRequired(opts DoctorOptions) *CheckResult {
+	groupsFn := opts.groupsFn
+	if groupsFn == nil {
+		groupsFn = registry.Groups
+	}
+	loadGroupFn := opts.loadGroupFn
+	if loadGroupFn == nil {
+		loadGroupFn = registry.LoadGroupConfig
+	}
+
+	groups, err := groupsFn()
+	if err != nil || len(groups) == 0 {
+		return nil
+	}
+
+	var drift []string
+	for _, g := range groups {
+		cfg, lerr := loadGroupFn(g.ConfigPath)
+		if lerr != nil || cfg == nil {
+			continue
+		}
+		for _, repo := range cfg.Repos {
+			stateDir := daemon.StateDirForRepo(repo.Path)
+			if stateDir == "" {
+				continue
+			}
+			if required, reason := graph.ReindexRequiredReason(stateDir); required {
+				drift = append(drift, fmt.Sprintf("%s: %s", repo.Path, reason))
+			}
+		}
+	}
+
+	if len(drift) == 0 {
+		return nil
+	}
+
+	summary := fmt.Sprintf("%d repo(s) need reindex after a format upgrade", len(drift))
+	return &CheckResult{
+		Surface:  "reindex-required",
+		OK:       false,
+		Severity: SeverityInfo,
+		Drift:    append([]string{summary}, drift...),
+	}
 }
 
 // ── Engine liveness + version skew (ADR-0024 PR5, epic #5729) ─────────────────

--- a/internal/install/reindex_required_test.go
+++ b/internal/install/reindex_required_test.go
@@ -1,0 +1,166 @@
+package install
+
+// reindex_required_test.go — #5907 FIX4: proves `grafel doctor` REPORTS
+// (never enqueues) when a registered repo's on-disk graph.fb was written by
+// an older grafel build than this binary supports. The enqueue itself is
+// already owned by the engine's loop-guarded stale-reindex arm
+// (internal/daemon/stale_reindex.go) — this check is purely a visibility
+// surface so the auto-reindex isn't silent in doctor output either.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// writeOldFormatGraphFBAt mirrors internal/graph/reindex_required_test.go's
+// writeOldFormatGraphFB: builds a minimal valid graph.fb via fbwriter.Marshal,
+// then patches the on-disk Graph.version scalar down to oldVersion so the
+// test can fabricate a stale-format graph.fb without an actual old binary.
+func writeOldFormatGraphFBAt(t *testing.T, dir string, oldVersion int) {
+	t.Helper()
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-old-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	buf, err := fbwriter.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	root := fb.GetRootAsGraph(buf, 0)
+	if !root.MutateVersion(int32(oldVersion)) {
+		t.Fatalf("MutateVersion(%d) returned false — slot missing?", oldVersion)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), buf, 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// TestCheckReindexRequired_StaleFormat_Reports proves doctor reports a stale
+// repo's format mismatch, naming the repo path and both format versions, and
+// that the summary line names the affected repo count.
+func TestCheckReindexRequired_StaleFormat_Reports(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := daemon.StateDirForRepo(repo)
+	writeOldFormatGraphFBAt(t, stateDir, 2)
+
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Repos: []registry.Repo{{Slug: "repo", Path: repo}},
+	}
+	groupsFn, loadFn := fakeGroups(cfg)
+
+	opts := DoctorOptions{groupsFn: groupsFn, loadGroupFn: loadFn}
+	cr := checkReindexRequired(opts)
+	if cr == nil {
+		t.Fatal("expected a non-nil CheckResult for a stale-format repo")
+	}
+	if cr.OK {
+		t.Error("expected OK=false")
+	}
+	if cr.Severity != SeverityInfo {
+		t.Errorf("severity = %v, want %v (report-only, engine already fixes it)", cr.Severity, SeverityInfo)
+	}
+	if len(cr.Drift) < 2 {
+		t.Fatalf("expected at least a summary line + one per-repo line, got %v", cr.Drift)
+	}
+	if got := cr.Drift[0]; got != "1 repo(s) need reindex after a format upgrade" {
+		t.Errorf("summary = %q, want %q", got, "1 repo(s) need reindex after a format upgrade")
+	}
+	found := false
+	for _, d := range cr.Drift[1:] {
+		if d == repo+": "+mustReindexReason(t, stateDir) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected a drift line naming repo %s with the reindex reason, got %v", repo, cr.Drift)
+	}
+}
+
+// mustReindexReason recomputes the reason string directly, so the test
+// doesn't hardcode wording that belongs to graph.FormatVersionReason.
+func mustReindexReason(t *testing.T, stateDir string) string {
+	t.Helper()
+	_, reason := graph.ReindexRequiredReason(stateDir)
+	if reason == "" {
+		t.Fatal("expected a non-empty reindex reason for the stale fixture")
+	}
+	return reason
+}
+
+// TestCheckReindexRequired_CurrentFormat_NoReport is the regression guard: a
+// repo on the current graph.fb format version must never be reported.
+func TestCheckReindexRequired_CurrentFormat_NoReport(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	repo := filepath.Join(home, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	stateDir := daemon.StateDirForRepo(repo)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-current-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	cfg := &registry.GroupConfig{
+		Name:  "g1",
+		Repos: []registry.Repo{{Slug: "repo", Path: repo}},
+	}
+	groupsFn, loadFn := fakeGroups(cfg)
+
+	opts := DoctorOptions{groupsFn: groupsFn, loadGroupFn: loadFn}
+	if cr := checkReindexRequired(opts); cr != nil {
+		t.Errorf("expected nil CheckResult for a current-format repo, got %+v", cr)
+	}
+}
+
+// TestCheckReindexRequired_NoGroups_NoReport ensures a fresh machine (no
+// registered groups) isn't reported as broken.
+func TestCheckReindexRequired_NoGroups_NoReport(t *testing.T) {
+	opts := DoctorOptions{
+		groupsFn:    func() ([]registry.GroupRef, error) { return nil, nil },
+		loadGroupFn: func(string) (*registry.GroupConfig, error) { return nil, nil },
+	}
+	if cr := checkReindexRequired(opts); cr != nil {
+		t.Errorf("expected nil CheckResult when no groups are registered, got %+v", cr)
+	}
+}

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -27,6 +27,10 @@ import (
 	"runtime"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 const (
@@ -116,6 +120,18 @@ type UpdateResult struct {
 
 	// Skipped is true when the binary was already at the target version.
 	Skipped bool
+
+	// ReposNeedingReindex is the number of registered repos whose on-disk
+	// graph.fb was written by an older grafel build than THIS (just-updated)
+	// binary's fbversion.Version supports (issue #5907 FIX4). This is
+	// REPORT-ONLY — the engine's own auto-reindex arm
+	// (internal/daemon/stale_reindex.go's loop-guarded maybeEnqueue) already
+	// owns enqueueing the fix once the newly restarted daemon's next
+	// heartbeat observes the mismatch; RunUpdate never enqueues anything
+	// itself. It exists purely so `grafel update` can print "N repos
+	// reindexing after upgrade" instead of the reindex silently starting in
+	// the background right after the command returns.
+	ReposNeedingReindex int
 }
 
 func (o *UpdateOptions) applyDefaults() error {
@@ -269,12 +285,54 @@ func RunUpdate(opts UpdateOptions) (*UpdateResult, error) {
 	}
 	result.InstallResult = installResult
 
+	// ── surface reindex-after-upgrade (issue #5907 FIX4) ───────────────────────
+	// After the daemon restart + version probe above (RunCopy), the running
+	// daemon is now the just-updated binary. Report-only: never enqueue here —
+	// the engine's own loop-guarded auto-reindex arm already does that on its
+	// next heartbeat once it observes the format mismatch.
+	if !opts.DryRun {
+		result.ReposNeedingReindex = countReposNeedingReindex()
+	}
+
 	// ── remove stash on success ───────────────────────────────────────────────
 	if !opts.DryRun {
 		_ = os.Remove(stashPath)
 	}
 
 	return result, nil
+}
+
+// countReposNeedingReindex scans every registered repo (across every grafel
+// group) and counts how many currently need a reindex after a format
+// upgrade — i.e. graph.ReindexRequiredReason(daemon.StateDirForRepo(path))
+// reports required=true (issue #5907 FIX4). Mirrors
+// internal/install/doctor.go's checkReindexRequired, but returns a bare
+// count since `grafel update`'s summary line only needs "N repos", not a
+// per-repo drift list. A registry read failure or an empty registry (fresh
+// machine, or update running before any group is registered) is silently 0 —
+// never an error, since this is advisory-only.
+func countReposNeedingReindex() int {
+	groups, err := registry.Groups()
+	if err != nil || len(groups) == 0 {
+		return 0
+	}
+	n := 0
+	for _, g := range groups {
+		cfg, lerr := registry.LoadGroupConfig(g.ConfigPath)
+		if lerr != nil || cfg == nil {
+			continue
+		}
+		for _, repo := range cfg.Repos {
+			stateDir := daemon.StateDirForRepo(repo.Path)
+			if stateDir == "" {
+				continue
+			}
+			if required, _ := graph.ReindexRequiredReason(stateDir); required {
+				n++
+			}
+		}
+	}
+	return n
 }
 
 // ── GitHub release helpers ────────────────────────────────────────────────────

--- a/internal/install/update_reindex_test.go
+++ b/internal/install/update_reindex_test.go
@@ -1,0 +1,184 @@
+package install_test
+
+// update_reindex_test.go — #5907 FIX4: proves `grafel update` surfaces
+// (report-only) the count of registered repos that need a reindex after a
+// format upgrade, without itself enqueueing anything (the engine's own
+// loop-guarded stale-reindex arm, internal/daemon/stale_reindex.go, owns
+// that).
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// writeOldFormatGraphFBForUpdate mirrors internal/graph/reindex_required_test.go's
+// writeOldFormatGraphFB: builds a minimal valid graph.fb via fbwriter.Marshal,
+// then patches the on-disk Graph.version scalar down to oldVersion.
+func writeOldFormatGraphFBForUpdate(t *testing.T, dir string, oldVersion int) {
+	t.Helper()
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-old-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	buf, err := fbwriter.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	root := fb.GetRootAsGraph(buf, 0)
+	if !root.MutateVersion(int32(oldVersion)) {
+		t.Fatalf("MutateVersion(%d) returned false — slot missing?", oldVersion)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph.fb"), buf, 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// registerFakeGroupWithRepo writes a minimal registry.json + group config so
+// registry.Groups()/registry.LoadGroupConfig resolve one repo, using the SAME
+// GRAFEL_HOME/XDG_CONFIG_HOME env vars newTestEnv already set.
+func registerFakeGroupWithRepo(t *testing.T, group, repoPath string) {
+	t.Helper()
+	home, err := registry.HomeDir()
+	if err != nil {
+		t.Fatalf("registry.HomeDir: %v", err)
+	}
+	cfgDir, err := registry.ConfigDir()
+	if err != nil {
+		t.Fatalf("registry.ConfigDir: %v", err)
+	}
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	cfg := registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: "repo", Path: repoPath}}}
+	cfgData, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, cfgData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	reg := registry.Registry{Version: 1, Groups: []registry.GroupRef{{Name: group, ConfigPath: cfgPath}}}
+	regData, _ := json.MarshalIndent(reg, "", "  ")
+	if err := os.WriteFile(filepath.Join(home, "registry.json"), regData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunUpdate_ReportsReposNeedingReindex proves RunUpdate's
+// ReposNeedingReindex counts a registered repo whose on-disk graph.fb is
+// stale-format, without enqueueing a reindex itself (there is no reindex
+// request plumbing wired into RunUpdate — a passing test here that doesn't
+// hang/error already demonstrates no side channel was invoked).
+func TestRunUpdate_ReportsReposNeedingReindex(t *testing.T) {
+	env := newTestEnv(t)
+
+	repo := filepath.Join(t.TempDir(), "stale-repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repo)
+	writeOldFormatGraphFBForUpdate(t, stateDir, 2)
+	registerFakeGroupWithRepo(t, "demo", repo)
+
+	newContent := []byte("#!/bin/sh\necho new-grafel")
+	newBinPath := filepath.Join(t.TempDir(), "new-grafel")
+	if err := os.WriteFile(newBinPath, newContent, 0o755); err != nil {
+		t.Fatalf("write new binary: %v", err)
+	}
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.2-test",
+		DownloadBinary: func(_ *http.Client, _, _, _, destPath string) error {
+			return copyTestFile(newBinPath, destPath)
+		},
+	}
+
+	result, err := install.RunUpdate(opts)
+	if err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+	if result.ReposNeedingReindex != 1 {
+		t.Errorf("ReposNeedingReindex = %d, want 1", result.ReposNeedingReindex)
+	}
+}
+
+// TestRunUpdate_NoReposNeedingReindex_WhenCurrent is the regression guard: a
+// registered repo on the current graph.fb format is never counted.
+func TestRunUpdate_NoReposNeedingReindex_WhenCurrent(t *testing.T) {
+	env := newTestEnv(t)
+
+	repo := filepath.Join(t.TempDir(), "current-repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repo)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "fixture-current-version",
+		Entities: []graph.Entity{
+			{ID: "ent0000000000000a", Name: "foo", Kind: "function", SourceFile: "a.go"},
+		},
+	}
+	doc.Stats.Entities = 1
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	registerFakeGroupWithRepo(t, "demo", repo)
+
+	newContent := []byte("#!/bin/sh\necho new-grafel")
+	newBinPath := filepath.Join(t.TempDir(), "new-grafel")
+	if err := os.WriteFile(newBinPath, newContent, 0o755); err != nil {
+		t.Fatalf("write new binary: %v", err)
+	}
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.3-test",
+		DownloadBinary: func(_ *http.Client, _, _, _, destPath string) error {
+			return copyTestFile(newBinPath, destPath)
+		},
+	}
+
+	result, err := install.RunUpdate(opts)
+	if err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+	if result.ReposNeedingReindex != 0 {
+		t.Errorf("ReposNeedingReindex = %d, want 0 for a current-format repo", result.ReposNeedingReindex)
+	}
+}

--- a/webui-v2/src/components/chrome/index-progress-feed.tsx
+++ b/webui-v2/src/components/chrome/index-progress-feed.tsx
@@ -11,10 +11,13 @@
    Each row shows its phase, a files-done/total bar, entity count, and the file
    currently being processed. A row that is `enhancing` (graph queryable,
    background enrichment still running) shows an "enhancing" badge — it is
-   success, never "Failed".
+   success, never "Failed". A row whose on-disk graph.fb needs a reindex after
+   a format upgrade (`reindexRequired`, #5907) shows a "reindexing after
+   upgrade" / "reindex required" badge instead of looking idle — the engine
+   has already loop-guard-enqueued the reindex by the time this is observed.
    ============================================================ */
 
-import { CheckCircle2, AlertTriangle, Loader2, Sparkles } from "lucide-react";
+import { CheckCircle2, AlertTriangle, Loader2, Sparkles, RefreshCw } from "lucide-react";
 
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/utils";
@@ -47,6 +50,16 @@ function PhaseIcon({ phase }: { phase: ProgressPhase }) {
   if (phase === "done") return <CheckCircle2 size={13} className="text-success" />;
   if (phase === "error") return <AlertTriangle size={13} className="text-danger" />;
   return <Loader2 size={13} className="animate-spin text-accent-strong" />;
+}
+
+/**
+ * "Reindex required" / "reindexing after upgrade" badge label (#5907). While
+ * the auto-enqueued reindex is actively indexing this repo, name it as such —
+ * otherwise it's still queued behind the loop-guarded enqueue, which is the
+ * silent-stall window this badge exists to surface.
+ */
+function reindexBadgeLabel(indexing: boolean): string {
+  return indexing ? "reindexing after upgrade" : "reindex required";
 }
 
 /** One progress row body (used both flat and as a nested monorepo child). */
@@ -82,6 +95,11 @@ function ProgressRowItem({ row, nested }: { row: ProgressRow; nested?: boolean }
           {row.enhancing && (
             <Badge tone="accent" className="shrink-0" data-testid="row-enhancing-badge">
               <Sparkles size={10} className="mr-0.5" /> enhancing
+            </Badge>
+          )}
+          {row.reindexRequired && (
+            <Badge tone="warning" className="shrink-0" data-testid="row-reindex-required-badge">
+              <RefreshCw size={10} className="mr-0.5" /> {reindexBadgeLabel(!!row.indexing)}
             </Badge>
           )}
         </div>
@@ -135,6 +153,11 @@ function MonorepoGroupItem({ group }: { group: ProgressGroup }) {
           {group.enhancing && (
             <Badge tone="accent" className="shrink-0">
               <Sparkles size={10} className="mr-0.5" /> enhancing
+            </Badge>
+          )}
+          {group.reindexRequired && (
+            <Badge tone="warning" className="shrink-0" data-testid="group-reindex-required-badge">
+              <RefreshCw size={10} className="mr-0.5" /> reindex required
             </Badge>
           )}
         </div>

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1536,6 +1536,17 @@ export interface ProgressRow {
   enhancing?: boolean;
   /** Relationship count from the status plane (SSE only carries entities). */
   relationships?: number;
+  /**
+   * True when this repo's on-disk graph.fb was written by an older grafel
+   * build than the engine now requires (#5907). The engine has already
+   * loop-guard-enqueued a reindex by the time this is observed true — never
+   * a "please click something" prompt, only a visibility signal so a
+   * post-upgrade reindex reads as "reindexing after upgrade" instead of a
+   * silent stall.
+   */
+  reindexRequired?: boolean;
+  /** Human-readable reason paired with reindexRequired, or undefined. */
+  reindexReason?: string;
 }
 
 /* ------------------------------------------------------------------ *
@@ -1560,6 +1571,17 @@ export interface IndexStatusRepo {
   relationships: number;
   /** Graph flatbuffer mtime in ns; 0 when never indexed by this engine. */
   graph_fb_mtime: number;
+  /**
+   * True when the on-disk graph.fb was written by an older grafel build
+   * (#5907). Optional here (rather than required) only so existing test
+   * fixtures that predate this field keep type-checking; the backend always
+   * sends it.
+   */
+  reindex_required?: boolean;
+  /** Human-readable reason paired with reindex_required, or "". */
+  reindex_reason?: string;
+  /** Derived single-word summary (backend: deriveIndexStatus). */
+  status?: "idle" | "indexing" | "enhancing" | "reindex-required" | "reindexing-after-upgrade";
 }
 
 /** Payload for GET /api/v2/groups/{group}/index-status. */
@@ -1610,6 +1632,8 @@ export interface ProgressGroup {
   children: ProgressRow[];
   /** True when any child/row is still enhancing in the background. */
   enhancing?: boolean;
+  /** True when any child/row needs a reindex after a format upgrade (#5907). */
+  reindexRequired?: boolean;
 }
 
 /** POST /api/v2/maintenance/cleanup result. */

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -459,6 +459,7 @@ export function nestRows(
         row,
         children: [],
         enhancing: row.enhancing,
+        reindexRequired: row.reindexRequired,
       });
     }
   }
@@ -474,6 +475,7 @@ export function nestRows(
       phase,
       children,
       enhancing: bucket.children.some((c) => c.enhancing),
+      reindexRequired: bucket.children.some((c) => c.reindexRequired),
     });
   }
 

--- a/webui-v2/src/lib/index-status-join.ts
+++ b/webui-v2/src/lib/index-status-join.ts
@@ -42,6 +42,8 @@ export function joinIndexStatus(
       relationships: s.relationships,
       // Never regress a higher live SSE entity count with a lagging status count.
       entitiesSoFar: Math.max(row.entitiesSoFar, s.entities),
+      reindexRequired: s.reindex_required,
+      reindexReason: s.reindex_reason,
     };
   });
   return changed ? next : rows;
@@ -50,6 +52,16 @@ export function joinIndexStatus(
 /** True when at least one repo is still enhancing in the background. */
 export function groupEnhancing(status: IndexStatusReply | undefined): boolean {
   return !!status && status.repos.some((r) => r.enhancing);
+}
+
+/**
+ * True when at least one repo needs a reindex after a format upgrade (#5907)
+ * — the engine has already loop-guard-enqueued the reindex; this only drives
+ * the "reindexing after upgrade" / "reindex required" badge so the state is
+ * never silent from the web dashboard.
+ */
+export function groupReindexRequired(status: IndexStatusReply | undefined): boolean {
+  return !!status && status.repos.some((r) => r.reindex_required);
 }
 
 /**


### PR DESCRIPTION
Surfacing slice of #5907 — makes the stale-format auto-reindex (engine core merged in #5910) VISIBLE instead of a silent multi-minute stall. Report/display only; no engine/trigger logic touched.

**FIX3 — web dashboard:** `indexStatusRepo` now carries `ReindexRequired`/`ReindexReason` (previously dropped) + a derived `Status` (`idle`/`indexing`/`enhancing`/`reindex-required`/`reindexing-after-upgrade`). webui-v2 threads it through and shows a warning-tone badge per-repo + on the monorepo group header, mirroring the existing "enhancing" badge.
**FIX4 — doctor:** new report-only Check 9 (`checkReindexRequired`) scanning registered repos via `graph.ReindexRequiredReason`.
**FIX4 — update:** `UpdateResult.ReposNeedingReindex` populated post-restart; CLI prints "N repo(s) reindexing after upgrade" (FIX2 already enqueues — this is report-only, no duplicate trigger).

Skipped the optional `FormatUpgradeReason` — the derived `Status` already distinguishes reindex-required vs reindexing-after-upgrade without touching load.go.

Verified: display/report-only (no engine/trigger files touched), `deriveIndexStatus` precedence correct, gofmt/build/vet clean, dashboard+install+cli tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017quGgaqK7NRoxGT6BTqV2o