### PR TITLE
fix(#5915 J2 slice-1): segment-set-aware graph-existence/freshness gates (non-dashboard)

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -415,8 +415,12 @@ func checkRepo(w io.Writer, r registry.Repo) {
 		fmt.Fprintf(w, "  %s repo %s (%s)\n", statusOK, r.Slug, r.Stack.String())
 	}
 	jsonPath := daemon.GraphPathForRepo(r.Path)
-	fbPath := daemon.GraphFBPathForRepo(r.Path)
-	hasFB := func() bool { _, e := os.Stat(fbPath); return e == nil }()
+	// #5915 J2 P2: GraphFBExistsForRepo is segment-set aware.
+	// os.Stat(daemon.GraphFBPathForRepo(r.Path)) — the pattern this replaces —
+	// only ever resolves a flat .fb path, which is absent for a segment-set
+	// repo (graph.<gen>/ dir + manifest.json, no flat .fb), so a fully-indexed
+	// segmented repo would wrongly report "no graph found".
+	hasFB := daemon.GraphFBExistsForRepo(r.Path)
 	hasJSON := func() bool { _, e := os.Stat(jsonPath); return e == nil }()
 	switch {
 	case hasFB && hasJSON:

--- a/internal/cli/doctor_segmentset_test.go
+++ b/internal/cli/doctor_segmentset_test.go
@@ -1,0 +1,68 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// writeSegmentSetFixtureForDoctorTest hand-builds a 1-segment gen dir
+// (graph.<gen>/ with seg-0000.fb + manifest.json) under stateDir and points
+// `current` at it — same shape as internal/graph/segmentset_test.go.
+func writeSegmentSetFixtureForDoctorTest(t *testing.T, stateDir string, gen uint64) {
+	t.Helper()
+	doc := &graph.Document{Repo: "seg", Entities: []graph.Entity{
+		{ID: "aa1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	genDir := filepath.Join(stateDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	ids := []string{"aa1"}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities, EntityCount: 1,
+		MinKey: ids[0], MaxKey: ids[0],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}
+
+// TestCheckRepo_SegmentSet is the RED test for #5915 J2 P2 slice 1: checkRepo
+// must report a segment-set repo (graph.<gen>/ dir + manifest.json, no flat
+// graph.fb) as having a graph, not "no graph found". Before the fix,
+// checkRepo's hasFB stat'd daemon.GraphFBPathForRepo(r.Path) — the flat .fb
+// path, absent for a segment-set.
+func TestCheckRepo_SegmentSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath := filepath.Join(tmpDir, "seg-repo")
+	mustMkdir(t, filepath.Join(repoPath, ".git"))
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	mustMkdir(t, stateDir)
+	writeSegmentSetFixtureForDoctorTest(t, stateDir, 6)
+
+	var buf bytes.Buffer
+	checkRepo(&buf, registry.Repo{Slug: "seg-repo", Path: repoPath, Stack: registry.StackList{"go"}})
+	out := buf.String()
+	if strings.Contains(out, "no graph found") {
+		t.Fatalf("checkRepo(segment-set repo) reported 'no graph found':\n%s", out)
+	}
+	if !strings.Contains(out, "graph.fb present") {
+		t.Errorf("checkRepo(segment-set repo) did not report graph.fb present:\n%s", out)
+	}
+}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -199,8 +199,14 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 					continue // skip the hot ref
 				}
 				// Only include slots that actually have a graph.
-				fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe)) // #5891
-				if _, statErr := os.Stat(fbPath); statErr == nil {
+				// #5915 J2 P2: resolve via the segment-aware descriptor.
+				// os.Stat(graph.CurrentGraphPath(...)) — the pattern this
+				// replaces — only ever resolves a flat .fb path, which is
+				// absent for a segment-set ref (graph.<gen>/ dir +
+				// manifest.json, no flat .fb), so a fully-indexed segmented
+				// cold ref would be silently omitted from ColdRefs.
+				refStateDir := filepath.Join(refsDir, refSafe)
+				if desc, dErr := graph.CurrentGraphDescriptor(refStateDir); dErr == nil && desc.Kind != graph.GraphAbsent {
 					rs.ColdRefs = append(rs.ColdRefs, daemon.RefSafeDecode(refSafe))
 				}
 			}

--- a/internal/cli/status_stats_segmentset_test.go
+++ b/internal/cli/status_stats_segmentset_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// writeSegmentSetFixtureForColdRef hand-builds a 1-segment gen dir
+// (graph.<gen>/ with seg-0000.fb + manifest.json) under refDir and points
+// `current` at it — same fixture shape used elsewhere in this slice.
+func writeSegmentSetFixtureForColdRef(t *testing.T, refDir string, gen uint64) {
+	t.Helper()
+	doc := &graph.Document{Repo: "seg", Entities: []graph.Entity{
+		{ID: "aa1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	genDir := filepath.Join(refDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	ids := []string{"aa1"}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities, EntityCount: 1,
+		MinKey: ids[0], MaxKey: ids[0],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(refDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}
+
+// TestComputeStatusSummary_ColdRefs_SegmentSet is the RED test for #5915 J2
+// P2 slice 1: a cold ref slot backed by a segment-set (graph.<gen>/ dir +
+// manifest.json, no flat graph.fb) must still be reported as a cold ref.
+// Before the fix, the gate stat'd graph.CurrentGraphPath(refDir) — the flat
+// .fb path, absent for a segment-set — so the cold ref was silently dropped.
+func TestComputeStatusSummary_ColdRefs_SegmentSet(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath := filepath.Join(tmpDir, "myrepo-seg")
+	os.MkdirAll(repoPath, 0o755)
+
+	hotStateDir := daemon.StateDirForRepo(repoPath)
+	os.MkdirAll(hotStateDir, 0o755)
+
+	side := graph.GraphStatsSidecar{
+		Version:       1,
+		ComputedAt:    time.Now().Add(-2 * time.Minute),
+		TotalEntities: 100,
+	}
+	sideData, _ := json.Marshal(side)
+	os.WriteFile(filepath.Join(hotStateDir, "graph-stats.json"), sideData, 0o644)
+
+	// Cold ref slot backed by a SEGMENT-SET (no flat graph.fb).
+	refsDir := filepath.Dir(hotStateDir)
+	coldRefDir := filepath.Join(refsDir, "develop-seg")
+	os.MkdirAll(coldRefDir, 0o755)
+	writeSegmentSetFixtureForColdRef(t, coldRefDir, 8)
+
+	repos := []registry.Repo{{Slug: "myrepo-seg", Path: repoPath}}
+	summary := ComputeStatusSummary("grp", repos)
+
+	rs, ok := summary.RepoStats["myrepo-seg"]
+	if !ok {
+		t.Fatal("myrepo-seg not found in RepoStats")
+	}
+	found := false
+	for _, r := range rs.ColdRefs {
+		if r == "develop-seg" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("ColdRefs = %v, want to include develop-seg (segment-set cold ref)", rs.ColdRefs)
+	}
+}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -457,8 +457,26 @@ func GraphPathForRepo(repoPath string) string {
 // the per-repo state directory. #5891: this resolves the `current` generation
 // pointer (graph.<gen>.fb), falling back to the legacy flat graph.fb for repos
 // that have not been reindexed since the gen-layout migration.
+//
+// NOTE: this ALWAYS resolves to a single .fb path (or the absent flat
+// fallback) — it is absent for a segment-set repo (graph.<gen>/ dir +
+// manifest.json, no flat .fb). Callers that only need an EXISTENCE check
+// ("does this repo have an FB graph at all?") should use GraphFBExistsForRepo
+// instead, which is segment-set aware; this path-returning form remains for
+// callers that genuinely need the literal single-file path.
 func GraphFBPathForRepo(repoPath string) string {
 	return graph.CurrentGraphPath(StateDirForRepo(repoPath))
+}
+
+// GraphFBExistsForRepo reports whether repoPath's current-ref state dir has
+// ANY active FlatBuffers graph — single-file or segment-set — recognised via
+// graph.CurrentGraphDescriptor. #5915 J2 P2: unlike
+// os.Stat(GraphFBPathForRepo(repoPath)), which only ever resolves a flat .fb
+// path and is therefore absent for a segment-set repo (graph.<gen>/ dir +
+// manifest.json, no flat .fb), this correctly reports true for both shapes.
+func GraphFBExistsForRepo(repoPath string) bool {
+	desc, err := graph.CurrentGraphDescriptor(StateDirForRepo(repoPath))
+	return err == nil && desc.Kind != graph.GraphAbsent
 }
 
 // findGraphFileInDir checks dir for graph.fb / graph.json and returns the

--- a/internal/daemon/state_path_graphfbexists_test.go
+++ b/internal/daemon/state_path_graphfbexists_test.go
@@ -1,0 +1,90 @@
+package daemon
+
+import (
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeSegmentSetFixtureForExistsTest hand-builds a 1-segment gen dir
+// (graph.<gen>/ with seg-0000.fb + manifest.json) under stateDir and points
+// `current` at it, mirroring the fixture builders already used at
+// internal/graph/segmentset_test.go and
+// internal/daemon/mcp/graph_cache_segmentset_test.go.
+func writeSegmentSetFixtureForExistsTest(t *testing.T, stateDir string, gen uint64) {
+	t.Helper()
+	doc := &graph.Document{Repo: "seg", Entities: []graph.Entity{
+		{ID: "aa1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	genDir := filepath.Join(stateDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	ids := []string{"aa1"}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities, EntityCount: 1,
+		MinKey: ids[0], MaxKey: ids[0],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}
+
+// TestGraphFBExistsForRepo_SegmentSet is the RED test for #5915 J2 P2 slice 1:
+// a segment-set repo (graph.<gen>/ dir + manifest.json, no flat graph.fb)
+// must be reported as HAVING an FB graph. The old call site
+// (os.Stat(GraphFBPathForRepo(repoPath))) would find nothing.
+func TestGraphFBExistsForRepo_SegmentSet(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	stateDir := StateDirForRepo(repoPath)
+	writeSegmentSetFixtureForExistsTest(t, stateDir, 4)
+
+	if !GraphFBExistsForRepo(repoPath) {
+		t.Fatal("GraphFBExistsForRepo(segment-set repo) = false, want true")
+	}
+}
+
+// TestGraphFBExistsForRepo_SingleFileParity guards that the single-gen-file
+// (and legacy flat) case is byte-identical to the pre-fix os.Stat behavior.
+func TestGraphFBExistsForRepo_SingleFileParity(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	stateDir := StateDirForRepo(repoPath)
+	doc := &graph.Document{Repo: "single", Entities: []graph.Entity{
+		{ID: "aaaa0001", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, graph.GenFileName(1)), doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(stateDir, graph.GenFileName(1)); err != nil {
+		t.Fatal(err)
+	}
+	if !GraphFBExistsForRepo(repoPath) {
+		t.Fatal("GraphFBExistsForRepo(single-file repo) = false, want true (parity)")
+	}
+}
+
+// TestGraphFBExistsForRepo_Absent guards a never-indexed repo still reads
+// absent.
+func TestGraphFBExistsForRepo_Absent(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	repoPath := t.TempDir()
+	if GraphFBExistsForRepo(repoPath) {
+		t.Fatal("GraphFBExistsForRepo(never-indexed repo) = true, want false")
+	}
+}

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -177,18 +177,20 @@ func AssembleGroupGraph(group string) (entities []graph.Entity, rels []graph.Rel
 	for _, r := range cfg.Repos {
 		stateDir := daemon.StateDirForRepo(r.Path)
 
-		// Record the graph.fb mtime when present. A repo that was never indexed
-		// has neither graph.fb nor graph.json — skip it (not an error): the
+		// Record the graph mtime when present. A repo that was never indexed
+		// has neither a graph nor graph.json — skip it (not an error): the
 		// union of the remaining repos is still valid.
 		// #5891: resolve the active generation so the recorded mtime is the
 		// gen file's — otherwise the overlay staleness check below (which reads
 		// the same resolved mtime via CurrentSourceMtimes) would see a frozen
 		// legacy graph.fb mtime and treat a fresh overlay as permanently stale.
-		fbPath := graph.CurrentGraphPath(stateDir)
+		// #5915 J2 P2: graphSourceMtime is segment-set aware — a segment-set
+		// repo (graph.<gen>/ dir + manifest.json, no flat .fb) would otherwise
+		// stat the absent flat path and be wrongly treated as never-indexed.
 		jsonPath := filepath.Join(stateDir, "graph.json")
 		fbExists := false
-		if fi, statErr := os.Stat(fbPath); statErr == nil {
-			srcMtimes[r.Slug] = fi.ModTime().UnixNano()
+		if mt, ok := graphSourceMtime(stateDir); ok {
+			srcMtimes[r.Slug] = mt
 			fbExists = true
 		}
 		if !fbExists {
@@ -347,4 +349,39 @@ func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
 		NumRepos:     numRepos,
 		InputHash:    inputHash,
 	}, nil
+}
+
+// graphSourceMtime resolves a repo's freshness mtime for its current-ref
+// stateDir, segment-set aware (#5915 J2 P2). os.Stat(graph.CurrentGraphPath(
+// stateDir)) — the pattern this replaces — only ever names a flat .fb path,
+// which is ABSENT for a segment-set repo (graph.<gen>/ dir + manifest.json,
+// no flat .fb), so that stat would report the repo as never-indexed and
+// silently drop it from the union / freeze its overlay-staleness signal.
+//
+// Resolution:
+//   - GraphSingleFile (including the legacy flat fallback): the resolved
+//     .fb file's own mtime — byte-identical to the pre-fix behavior.
+//   - GraphSegmentSet: the manifest.json mtime, the atomic flip point for a
+//     segment-set rebuild (mirrors #5915 J1's cmd/grafel/daemon_tier.go
+//     tierReloadCallback, which uses the same signal for cold-wake staleness).
+//   - GraphAbsent, or a resolved path whose stat fails: ok=false.
+func graphSourceMtime(stateDir string) (mtimeNanos int64, ok bool) {
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		return 0, false
+	}
+	var path string
+	switch desc.Kind {
+	case graph.GraphSingleFile:
+		path = desc.Path
+	case graph.GraphSegmentSet:
+		path = filepath.Join(desc.GenDir, graph.ManifestFileName)
+	default:
+		return 0, false
+	}
+	fi, statErr := os.Stat(path)
+	if statErr != nil {
+		return 0, false
+	}
+	return fi.ModTime().UnixNano(), true
 }

--- a/internal/graph/groupalgo/groupalgo_segmentset_test.go
+++ b/internal/graph/groupalgo/groupalgo_segmentset_test.go
@@ -1,0 +1,147 @@
+package groupalgo
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// writeFixtureSegmentSetRepo hand-builds a 1-segment gen dir (graph.<gen>/
+// with seg-0000.fb + manifest.json) in repoPath's daemon state dir and points
+// `current` at it — the same fixture shape used at
+// internal/graph/segmentset_test.go / internal/daemon/mcp/graph_cache_segmentset_test.go.
+// No producer emits this yet (#5901 dark read substrate), hence the direct
+// construction. Returns the registry.Repo entry.
+func writeFixtureSegmentSetRepo(t *testing.T, slug, repoPath string, doc *graph.Document, gen uint64) registry.Repo {
+	t.Helper()
+	stateDir := daemon.StateDirForRepo(repoPath)
+	genDir := filepath.Join(stateDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	ids := make([]string, 0, len(doc.Entities))
+	for _, e := range doc.Entities {
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities,
+		EntityCount: len(doc.Entities), RelCount: len(doc.Relationships),
+		MinKey: ids[0], MaxKey: ids[len(ids)-1],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}
+
+func segmentSetTestDoc(slug string) *graph.Document {
+	mk := func(name string) graph.Entity {
+		return graph.Entity{ID: slug + ":" + name, Name: name, Kind: "function", SourceFile: slug + "/" + name + ".go", Language: "go"}
+	}
+	return &graph.Document{Version: 1, Repo: slug, Entities: []graph.Entity{mk("A"), mk("B")},
+		Relationships: []graph.Relationship{{ID: slug + ":A->B", FromID: slug + ":A", ToID: slug + ":B", Kind: "CALLS"}}}
+}
+
+// TestAssembleGroupGraph_SegmentSet is the RED test for #5915 J2 P2 slice 1:
+// AssembleGroupGraph must record a segment-set repo's mtime and load its
+// entities/relationships, instead of skipping it as "never indexed" because
+// os.Stat(graph.CurrentGraphPath(stateDir)) finds no flat .fb.
+func TestAssembleGroupGraph_SegmentSet(t *testing.T) {
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoPath := filepath.Join(root, "repoSeg")
+	doc := segmentSetTestDoc("seg")
+	r := writeFixtureSegmentSetRepo(t, "seg", repoPath, doc, 5)
+
+	cfgPath, err := registry.ConfigPathFor("segacme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "segacme", Repos: []registry.Repo{r}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("segacme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	ents, rels, entityRepo, srcMtimes, err := AssembleGroupGraph("segacme")
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	if len(ents) != len(doc.Entities) {
+		t.Fatalf("union entities=%d, want %d (segment-set repo wrongly skipped as never-indexed)", len(ents), len(doc.Entities))
+	}
+	if len(rels) != len(doc.Relationships) {
+		t.Errorf("union rels=%d, want %d", len(rels), len(doc.Relationships))
+	}
+	if entityRepo["seg:A"] != "seg" {
+		t.Errorf("seg:A attributed to repo %q, want seg", entityRepo["seg:A"])
+	}
+	if _, ok := srcMtimes["seg"]; !ok {
+		t.Fatal("srcMtimes missing seg (segment-set) mtime")
+	}
+}
+
+// TestCurrentSourceMtimes_SegmentSet mirrors the above for CurrentSourceMtimes
+// (the overlay.go sibling gate).
+func TestCurrentSourceMtimes_SegmentSet(t *testing.T) {
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoPath := filepath.Join(root, "repoSeg2")
+	doc := segmentSetTestDoc("seg2")
+	r := writeFixtureSegmentSetRepo(t, "seg2", repoPath, doc, 9)
+
+	cfgPath, err := registry.ConfigPathFor("segacme2")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "segacme2", Repos: []registry.Repo{r}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("segacme2", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	mtimes, err := CurrentSourceMtimes("segacme2")
+	if err != nil {
+		t.Fatalf("CurrentSourceMtimes: %v", err)
+	}
+	if _, ok := mtimes["seg2"]; !ok {
+		t.Fatal("CurrentSourceMtimes missing seg2 (segment-set) mtime")
+	}
+
+	// Sanity: the recorded mtime must match the manifest.json mtime (the
+	// atomic flip point for a segment-set), not some other file.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	desc, dErr := graph.CurrentGraphDescriptor(stateDir)
+	if dErr != nil || desc.Kind != graph.GraphSegmentSet {
+		t.Fatalf("descriptor not segment-set: kind=%v err=%v", desc.Kind, dErr)
+	}
+	fi, statErr := os.Stat(filepath.Join(desc.GenDir, graph.ManifestFileName))
+	if statErr != nil {
+		t.Fatal(statErr)
+	}
+	if mtimes["seg2"] != fi.ModTime().UnixNano() {
+		t.Errorf("mtime=%d, want manifest.json mtime=%d", mtimes["seg2"], fi.ModTime().UnixNano())
+	}
+}

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -288,9 +288,13 @@ func CurrentSourceMtimes(group string) (map[string]int64, error) {
 	out := map[string]int64{}
 	for _, r := range cfg.Repos {
 		stateDir := daemon.StateDirForRepo(r.Path)
-		fbPath := graph.CurrentGraphPath(stateDir) // #5891: resolve active gen
-		if fi, statErr := os.Stat(fbPath); statErr == nil {
-			out[r.Slug] = fi.ModTime().UnixNano()
+		// #5915 J2 P2: graphSourceMtime resolves the segment-set case too — a
+		// plain os.Stat(graph.CurrentGraphPath(stateDir)) would find nothing
+		// for a segment-set repo (graph.<gen>/ dir + manifest.json, no flat
+		// .fb), silently dropping it from the map and permanently flagging
+		// its overlay as stale.
+		if mt, ok := graphSourceMtime(stateDir); ok {
+			out[r.Slug] = mt
 		}
 	}
 	return out, nil

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -204,9 +204,14 @@ func HasGraph(dir string) bool {
 // Renamed from hasGraphJSON for ADR-0016 flip-day (#808).
 func hasGraphJSON(dir string) bool {
 	stateDir := daemon.StateDirForRepo(dir)
-	// #5891: resolve the active generation (flat graph.fb fallback) so a
-	// gen-layout repo is still detected as "has a graph".
-	if _, err := os.Stat(graph.CurrentGraphPath(stateDir)); err == nil {
+	// #5915 J2 P2: resolve via the segment-aware descriptor instead of
+	// os.Stat(CurrentGraphPath(...)). CurrentGraphPath only ever names a flat
+	// .fb file, which is ABSENT for a segment-set repo (graph.<gen>/ dir +
+	// manifest.json, no flat .fb) — that os.Stat would wrongly report the
+	// repo as having no graph. CurrentGraphDescriptor recognises both shapes;
+	// GraphSingleFile (including the legacy flat fallback) is byte-identical
+	// to the pre-fix behavior.
+	if desc, err := graph.CurrentGraphDescriptor(stateDir); err == nil && desc.Kind != graph.GraphAbsent {
 		return true
 	}
 	if _, err := os.Stat(filepath.Join(stateDir, "graph.json")); err == nil {

--- a/internal/quality/audit/hasgraph_segmentset_test.go
+++ b/internal/quality/audit/hasgraph_segmentset_test.go
@@ -1,0 +1,109 @@
+package audit
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeSegmentSetFixture hand-builds a 1-segment gen dir (graph.<gen>/ with
+// seg-0000.fb + manifest.json) under stateDir and points `current` at it. This
+// mirrors the fixture builders already used at internal/graph/segmentset_test.go
+// and internal/daemon/mcp/graph_cache_segmentset_test.go (no producer emits
+// this shape yet — #5901 dark read substrate — so the test constructs it
+// directly).
+func writeSegmentSetFixture(t *testing.T, stateDir string, gen uint64) string {
+	t.Helper()
+	doc := &graph.Document{Repo: "seg", Entities: []graph.Entity{
+		{ID: "aa1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+		{ID: "aa2", QualifiedName: "p.B", Kind: "struct", Name: "B"},
+	}, Relationships: []graph.Relationship{{FromID: "aa1", ToID: "aa2", Kind: "CALLS"}}}
+
+	genDir := filepath.Join(stateDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	ids := make([]string, 0, len(doc.Entities))
+	for _, e := range doc.Entities {
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities,
+		EntityCount: len(doc.Entities), RelCount: len(doc.Relationships),
+		MinKey: ids[0], MaxKey: ids[len(ids)-1],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	return genDir
+}
+
+// TestHasGraphJSON_SegmentSet is the RED test for #5915 J2 P2 slice 1: a
+// segment-set repo (graph.<gen>/ dir + manifest.json, no flat graph.fb) must
+// be seen as HAVING a graph. Before the fix, hasGraphJSON stat'd
+// CurrentGraphPath(stateDir) — the flat .fb path, which is absent for a
+// segment-set — so this reported false.
+func TestHasGraphJSON_SegmentSet(t *testing.T) {
+	repoDir := t.TempDir()
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	stateDir := daemon.StateDirForRepo(repoDir)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeSegmentSetFixture(t, stateDir, 3)
+
+	if !hasGraphJSON(repoDir) {
+		t.Fatal("hasGraphJSON(segment-set repo) = false, want true")
+	}
+	if !HasGraph(repoDir) {
+		t.Fatal("HasGraph(segment-set repo) = false, want true")
+	}
+}
+
+// TestHasGraphJSON_SingleFileParity guards that the flat/single-gen-file case
+// is byte-identical to before the fix.
+func TestHasGraphJSON_SingleFileParity(t *testing.T) {
+	repoDir := t.TempDir()
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	stateDir := daemon.StateDirForRepo(repoDir)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := &graph.Document{Repo: "single", Entities: []graph.Entity{
+		{ID: "aaaa0001", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, graph.GenFileName(1)), doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(stateDir, graph.GenFileName(1)); err != nil {
+		t.Fatal(err)
+	}
+	if !hasGraphJSON(repoDir) {
+		t.Fatal("hasGraphJSON(single-file repo) = false, want true (parity)")
+	}
+}
+
+// TestHasGraphJSON_Absent guards that a never-indexed repo still reads absent.
+func TestHasGraphJSON_Absent(t *testing.T) {
+	repoDir := t.TempDir()
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	if hasGraphJSON(repoDir) {
+		t.Fatal("hasGraphJSON(never-indexed repo) = true, want false")
+	}
+}


### PR DESCRIPTION
## What

6 non-dashboard gates that decide "does this repo have a graph / is it fresh" were flat-`graph.fb`-only (`os.Stat(graph.CurrentGraphPath(dir))`) and would read a **segment-set** repo (`current` + `graph.<gen>/` dir, no flat `.fb`) as absent / mtime-0. #5915 **J2** slice 1. Latent today (`GRAFEL_STREAM_SEGMENTS` OFF — no production writer emits segment-sets yet); must land before the flip.

## Sites
- `internal/quality/audit/audit.go` `hasGraphJSON` — existence → `CurrentGraphDescriptor(dir).Kind != GraphAbsent`.
- `internal/graph/groupalgo/groupalgo.go` `AssembleGroupGraph` + `overlay.go` `CurrentSourceMtimes` — new shared `graphSourceMtime` helper: single-file stats `desc.Path`; segment-set stats `GenDir/manifest.json` (mirrors J1 tier-reload freshness).
- `internal/daemon/state_path.go` new `GraphFBExistsForRepo` + `internal/cli/doctor.go` `checkRepo` caller.
- `internal/cli/status_stats.go` `ColdRefs` discovery.

## Verification (independent adversarial review — APPROVE)
- Each of the 6 gates proven load-bearing (per-site revert → its segment-set test RED).
- **Single-file mtime byte-parity**: identical to old `os.Stat(CurrentGraphPath)` across all layouts incl. #5891 `current`→flat; +1ns drift → RED.
- **manifest.json freshness correct**: verified 728µs newer than newest segment vs real `WriteGraphGenSegmented` (order segments→manifest→pointer flip; `GCStaleGens` never rewrites current gen).
- Graceful `(_,false)`/no-panic on absent/corrupt-manifest/missing-gen; absent parity; `GraphFBPathForRepo` has zero remaining existence-probe callers.

## Follow-up (slice-3, out of scope)
`branches.go:239`, `cleanup.go:146`, `algo/cache.go:163/198`, and — **highest priority** — `deadref.go:371/390` (`recentlyIndexed`/`refGraphMtime`): a freshly-indexed segment-set ref with no coexisting `graph.json` reads mtime-0 → not grace-protected → **premature reaping (data loss)**. Must land before `GRAFEL_STREAM_SEGMENTS` is ever enabled.

Refs #5915

🤖 Generated with [Claude Code](https://claude.com/claude-code)