### PR TITLE
feat(#5904 PR-b): flow enrichment side-table — phantom-edge writeback stops rewriting graph.fb (#5915)

### DIFF
--- a/internal/cli/export.go
+++ b/internal/cli/export.go
@@ -10,6 +10,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/export"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -182,6 +183,14 @@ func loadGroupGraphForExport(cmd *cobra.Command, group, ref string) (*graph.Docu
 			fmt.Fprintf(w, "warning: skipping repo %s (graph not found: %v)\n", repo.Slug, err)
 			continue
 		}
+		// Flow side-table (#5904 PR-b): REPLACE-merge the per-repo
+		// <stateDir>/flows.json so an offline export (GraphML/Cypher/SVG/HTML) — a
+		// primary debugging surface — carries the CROSS-REPO-AWARE flows the
+		// phantom pass produced, not the index-baked intra-repo flows. The phantom
+		// writeback no longer bakes them into graph.fb/graph.json; MergeInto
+		// suppresses the baked flows and substitutes the sidecar's (absence/stale →
+		// baked intra flows survive, never doubled).
+		flows.MergeInto(stateDir, doc)
 		merged.Entities = append(merged.Entities, doc.Entities...)
 		merged.Relationships = append(merged.Relationships, doc.Relationships...)
 		loadedRepos++

--- a/internal/cli/export_flows_test.go
+++ b/internal/cli/export_flows_test.go
@@ -1,0 +1,111 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// setupExportFlowGroup writes a group whose repo has a BAKED intra-repo
+// SCOPE.Process flow in graph.json, and returns the group name + the repo state
+// dir (so the caller can drop a flows.json sidecar).
+func setupExportFlowGroup(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	xdg := t.TempDir()
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv(daemon.EnvRoot, root)
+
+	const group = "expflow"
+	repoPath := filepath.Join(root, "repoA")
+	if err := os.MkdirAll(filepath.Join(repoPath, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	doc := graph.Document{
+		Version: graph.SchemaVersion, Repo: "repoA",
+		Entities: []graph.Entity{
+			{ID: "fn1", Name: "handleSubmit", Kind: "Function", SourceFile: "a.go", StartLine: 1},
+			{ID: "fn2", Name: "callService", Kind: "Function", SourceFile: "a.go", StartLine: 6},
+			graph.Entity{ID: "baked-proc", Name: "BakedIntraFlow", Kind: "SCOPE.Process", SourceFile: "a.go", StartLine: 1}.
+				WithProperties(map[string]string{"step_count": "2", "cross_stack": "false"}),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+			graph.Relationship{ID: "s1", FromID: "baked-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+			graph.Relationship{ID: "s2", FromID: "baked-proc", ToID: "fn2", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "1"}),
+		},
+	}
+	data, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: "repoA", Path: repoPath, Stack: registry.StackList{"go"}}}}
+	if err := registry.SaveGroupConfig(cfgPath, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	return group, stateDir
+}
+
+// TestExport_FlowSidecarReplacesBakedFlow: the offline export (a primary
+// debugging surface) must carry the CROSS-REPO-AWARE flow from the flow
+// side-table, REPLACING the baked intra flow — not doubling it (#5904 PR-b).
+func TestExport_FlowSidecarReplacesBakedFlow(t *testing.T) {
+	group, stateDir := setupExportFlowGroup(t)
+
+	// Drop a fresh flow sidecar: a cross-repo SCOPE.Process replacing the baked one.
+	ents := []graph.Entity{
+		graph.Entity{ID: "xrepo-proc", Name: "CrossRepoFlow", Kind: "SCOPE.Process", SourceFile: "a.go", StartLine: 1}.
+			WithProperties(map[string]string{"step_count": "3", "cross_stack": "true"}),
+	}
+	rels := []graph.Relationship{
+		graph.Relationship{ID: "xs0", FromID: "xrepo-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+		graph.Relationship{ID: "ph1", FromID: "fn2", ToID: "remote::ep", Kind: "CALLS"}.WithProperties(map[string]string{"cross_repo": "true", "target_repo": "remote"}),
+	}
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert flows sidecar: %v", err)
+	}
+
+	out, err := runExport(t, group, "cypher")
+	if err != nil {
+		t.Fatalf("export cypher: %v", err)
+	}
+	if !strings.Contains(out, "CrossRepoFlow") {
+		t.Errorf("export missing the cross-repo-aware flow: %s", out)
+	}
+	if strings.Contains(out, "BakedIntraFlow") {
+		t.Errorf("export leaked the baked intra flow (REPLACE violated / double-count): %s", out)
+	}
+}
+
+// TestExport_NoSidecar_KeepsBakedFlow: with no sidecar the export shows the
+// baked intra flow exactly as today (single-repo parity / graceful degradation).
+func TestExport_NoSidecar_KeepsBakedFlow(t *testing.T) {
+	group, _ := setupExportFlowGroup(t)
+	out, err := runExport(t, group, "cypher")
+	if err != nil {
+		t.Fatalf("export cypher: %v", err)
+	}
+	if !strings.Contains(out, "BakedIntraFlow") {
+		t.Errorf("no-sidecar export must keep the baked intra flow: %s", out)
+	}
+}

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -359,9 +359,14 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 	if err != nil {
 		return 0, fmt.Errorf("phantom-edge pass: load links: %w", err)
 	}
-	if len(allLinks) == 0 {
-		return 0, nil // nothing to promote
-	}
+	// NOTE (#5904 PR-b): do NOT early-return on len(allLinks)==0. When the LAST
+	// cross-repo link is removed the links file goes empty, and this pass — the
+	// sole writer of the flow side-table — must still run so the clear-stale loop
+	// below wipes every loaded repo's now-obsolete flows.json. An early return
+	// here would leave a repo's cross-repo flows serving fresh forever (its
+	// source_key still matches until the repo is next reindexed). With no links
+	// there is simply nothing to promote (added stays 0) and affectedRepos is
+	// empty, so every loaded repo falls into the cleanup path.
 
 	// Load each repo's graph.Document. Prefer graph.fb when available
 	// (ADR-0016 flip-day #808); fall back to graph.json via LoadGraphFromDir.

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/engine"
 	"github.com/cajasmota/grafel/internal/graph"
-	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/links"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -451,11 +451,8 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 		// a full re-index.
 		_ = engine.ApplyAsyncTriggerEdges(doc)
 
-		// Update stats.
-		doc.Stats.Entities = len(doc.Entities)
-		doc.Stats.Relationships = len(doc.Relationships)
-
-		// Sort entities + relationships for determinism (mirrors index.go).
+		// Sort entities + relationships for determinism (mirrors index.go) so the
+		// side-table delta is stable run-to-run.
 		sort.SliceStable(doc.Entities, func(a, b int) bool {
 			return doc.Entities[a].ID < doc.Entities[b].ID
 		})
@@ -470,29 +467,77 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 			return ra.Kind < rb.Kind
 		})
 
-		// Write atomically — both graph.fb (canonical binary) and graph.json
-		// must be updated together so that LoadGraphFromDir and any tool that
-		// reads graph.json directly see the same entity set (fixes #1702).
+		// #5904 PR-b: repoint the SINK from a whole-graph rewrite onto the per-repo
+		// flow SIDE-TABLE. The re-synthesised cross-repo-aware flow entities + their
+		// step/entry/seed edges + the phantom cross_repo CALLS edges are the DELTA
+		// over the index-baked graph; write ONLY that delta to <stateDir>/flows.json
+		// via flows.Upsert. graph.fb / graph.json are NOT rewritten.
+		//
+		// This removes the #5915 P1 hazard: for a #5901 segment-set the resident
+		// Document is a COLLAPSED union of every segment, so re-serialising it as one
+		// flat graph.<gen>.fb re-materialised the whole graph in memory (OOM) and
+		// discarded the segmented layout. The side-table leaves the graph untouched;
+		// the read overlay (flows.MergeInto / MCP applyFlowOverlay) REPLACE-merges the
+		// baked intra-repo flows with this delta at read time.
 		stateDir := filepath.Dir(graphPaths[slug])
-		// #5891: gen write + pointer flip (no rename-over a mapped graph.fb).
-		fbPath, fbErr := fbwriter.WriteGraphGen(stateDir, doc)
-		if fbErr != nil {
-			return added, fmt.Errorf("phantom-edge pass: write graph.fb %s: %w", slug, fbErr)
+		flowEnts, flowRels := extractFlowDelta(doc)
+		if err := flows.Upsert(stateDir, flowEnts, flowRels); err != nil {
+			return added, fmt.Errorf("phantom-edge pass: write flow side-table %s: %w", slug, err)
 		}
-		p := graphPaths[slug]
-		if werr := graph.WriteAtomic(p, doc, false); werr != nil {
-			return added, fmt.Errorf("phantom-edge pass: write graph.json %s: %w", slug, werr)
-		}
-		// Stamp identical mtime so the two encodings of the same data are
-		// never mistaken for a partial write (#1626 pattern).
-		now := time.Now()
-		_ = os.Chtimes(fbPath, now, now)
-		_ = os.Chtimes(p, now, now)
 		fmt.Fprintf(os.Stderr,
-			"grafel: phantom-edge pass group=%s repo=%s phantom_edges=%d\n",
-			group, slug, added)
+			"grafel: phantom-edge pass group=%s repo=%s phantom_edges=%d flow_entities=%d (side-table)\n",
+			group, slug, added, len(flowEnts))
+	}
+
+	// Repos that were loaded but are NOT (or no longer) affected by cross-repo
+	// links must not keep a stale flows.json from a previous run — otherwise the
+	// read overlay would resurrect old cross-repo flows for a repo whose links
+	// were removed (without a reindex to invalidate the source_key). The phantom
+	// pass is the sole writer of the flow side-table, so it owns this cleanup.
+	for slug := range docs {
+		if affectedRepos[slug] {
+			continue
+		}
+		stateDir := filepath.Dir(graphPaths[slug])
+		if err := os.Remove(flows.Path(stateDir)); err != nil && !os.IsNotExist(err) {
+			fmt.Fprintf(os.Stderr, "grafel: phantom-edge pass: clear stale flow side-table %s: %v\n", slug, err)
+		}
 	}
 	return added, nil
+}
+
+// extractFlowDelta returns the FLOW side-table delta from a re-synthesised
+// document (#5904 PR-b): every SCOPE.Process / SCOPE.EventFlow entity, their
+// STEP_IN_* / ENTRY_POINT_OF / SEED_OF_EVENT_FLOW structural edges, and the
+// phantom cross_repo CALLS edges. This is exactly the set the read overlay
+// SUBSTITUTES for the index-baked flows (flows.Apply strips the baked flows +
+// their structural edges, then appends this delta) plus the phantom CALLS edges
+// (which are never baked). Ordinary entities/edges are excluded — they already
+// live in graph.fb and are not rewritten.
+func extractFlowDelta(doc *graph.Document) ([]graph.Entity, []graph.Relationship) {
+	var ents []graph.Entity
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == string(engine.EntityKindProcess) ||
+			doc.Entities[i].Kind == engine.EntityKindEventFlow {
+			ents = append(ents, doc.Entities[i])
+		}
+	}
+	var rels []graph.Relationship
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		switch r.Kind {
+		case string(engine.RelationshipKindStepInProcess),
+			string(engine.RelationshipKindEntryPointOf),
+			engine.RelationshipKindStepInEventFlow,
+			engine.RelationshipKindSeedOfEventFlow:
+			rels = append(rels, *r)
+		case "CALLS":
+			if r.PropGet("cross_repo") == "true" {
+				rels = append(rels, *r)
+			}
+		}
+	}
+	return ents, rels
 }
 
 // stripProcessEntities returns new entity and relationship slices with all

--- a/internal/cli/links_processflow_fb_test.go
+++ b/internal/cli/links_processflow_fb_test.go
@@ -1,21 +1,19 @@
-// links_processflow_fb_test.go — regression lock for the flow-invisibility
-// bug (Refs #1893, #1702).
+// links_processflow_fb_test.go — the #5904 PR-b side-table write-back contract
+// (supersedes the #1893/#1702 fb-write lock).
 //
-// THE BUG (pre-fix): runPhantomEdgePass re-runs RunProcessFlowWithCompanions
-// + RunEventFlow after promoting cross-repo phantom CALLS edges, but post
-// ADR-0016 (flip-day #808) the daemon serves the canonical graph.fb while
-// the pass historically wrote only graph.json. So recomputed Process/Event
-// flow entities never reached the daemon or dashboard — live proof was
-// graph.json holding 30+32 SCOPE.Process entities while `grafel status`
-// reported "0 flows".
+// runPhantomEdgePass re-runs RunProcessFlowWithCompanions + RunEventFlow after
+// promoting cross-repo phantom CALLS edges. Under #5904 PR-b the SINK is no
+// longer a whole-graph rewrite (fbwriter.WriteGraphGen + graph.WriteAtomic) —
+// which for a #5901 segment-set collapsed the whole graph in memory (the #5915
+// P1 OOM). Instead the cross-repo-aware flow DELTA is written to the per-repo
+// <stateDir>/flows.json side-table and REPLACE-merged at read time.
 //
-// THE LOCK: build a two-repo fixture group with a cross-repo HTTP call
-// (client repo "fe" → server route in "be"), write each repo's fixture as
-// graph.fb, run the phantom-edge pass, then DELETE the affected repo's
-// graph.json and load graph.fb (LoadGraphFromDir can now only read fb).
-// Assert SCOPE.Process flow entities are present (count > 0). If the write
-// path ever regresses to graph.json-only, the fb load returns zero Process
-// entities and this test fails.
+// THE CONTRACT (this file): a two-repo fixture group with a cross-repo HTTP call
+// (client "fe" → route in "be"), run the phantom-edge pass, then assert:
+//   - the flow side-table holds the re-synthesised SCOPE.Process flows + the
+//     phantom cross_repo CALLS edge (the DELTA is durable);
+//   - graph.fb / graph.json are NOT rewritten (byte-identical mtime — the
+//     no-graph-rewrite guard mirroring PR-a's TestWriteback_success).
 package cli
 
 import (
@@ -23,11 +21,13 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/engine"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/links"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -63,11 +63,10 @@ func countProcessEntities(doc *graph.Document) int {
 	return n
 }
 
-// TestPhantomEdgePass_WritesFlowsToFB locks the fb-write of recomputed
-// cross-repo process flows (the primary fix). It exercises the real
-// runPhantomEdgePass write path and asserts the flows land in graph.fb,
-// not just graph.json.
-func TestPhantomEdgePass_WritesFlowsToFB(t *testing.T) {
+// TestPhantomEdgePass_WritesFlowsToSideTable asserts the #5904 PR-b contract:
+// the re-synthesised cross-repo process flows are written to the flow SIDE-TABLE
+// (flows.json), and graph.fb / graph.json are NOT rewritten.
+func TestPhantomEdgePass_WritesFlowsToSideTable(t *testing.T) {
 	// Isolate all daemon/state paths into a tempdir.
 	daemonRoot := t.TempDir()
 	t.Setenv(daemon.EnvRoot, daemonRoot)
@@ -145,6 +144,14 @@ func TestPhantomEdgePass_WritesFlowsToFB(t *testing.T) {
 		t.Fatalf("write links file: %v", err)
 	}
 
+	// Capture graph.fb / graph.json mtimes BEFORE the pass so we can prove the
+	// pass does NOT rewrite the graph (the #5915 P1 no-collapse guarantee).
+	feState := daemon.StateDirForRepo(fePath)
+	fbPath := filepath.Join(feState, "graph.fb")
+	jsonPath := filepath.Join(feState, "graph.json")
+	fbBefore := mustModTime(t, fbPath)
+	jsonBefore := mustModTime(t, jsonPath)
+
 	// Run the production phantom-edge pass.
 	added, err := runPhantomEdgePass("fixtgrp", cfg, linksPath)
 	if err != nil {
@@ -154,28 +161,50 @@ func TestPhantomEdgePass_WritesFlowsToFB(t *testing.T) {
 		t.Fatalf("expected ≥1 phantom edge promoted, got 0")
 	}
 
-	// PRIMARY ASSERTION: the recomputed process flows must be in graph.fb.
-	// Force a pure-fb read by deleting graph.json for the affected repo, then
-	// load via LoadGraphFromDir (which now can only read graph.fb).
-	feState := daemon.StateDirForRepo(fePath)
-	fbPath := filepath.Join(feState, "graph.fb")
-	jsonPath := filepath.Join(feState, "graph.json")
-	if _, statErr := os.Stat(fbPath); statErr != nil {
-		t.Fatalf("graph.fb missing for fe after pass: %v", statErr)
+	// NO-GRAPH-REWRITE GUARD: graph.fb + graph.json must be byte-for-byte
+	// untouched (same mtime). If the write-back ever regresses to rewriting the
+	// graph, these mtimes advance and the segment-set collapse hazard returns.
+	if got := mustModTime(t, fbPath); !got.Equal(fbBefore) {
+		t.Errorf("graph.fb was rewritten by the phantom pass (mtime %v -> %v) — must use the flow side-table", fbBefore, got)
 	}
-	if err := os.Remove(jsonPath); err != nil {
-		t.Fatalf("remove graph.json to force fb read: %v", err)
+	if got := mustModTime(t, jsonPath); !got.Equal(jsonBefore) {
+		t.Errorf("graph.json was rewritten by the phantom pass (mtime %v -> %v) — must use the flow side-table", jsonBefore, got)
 	}
 
-	loaded, err := graph.LoadGraphFromDir(feState)
-	if err != nil {
-		t.Fatalf("load graph.fb after pass: %v", err)
+	// PRIMARY ASSERTION: the recomputed cross-repo process flows land in the flow
+	// side-table (flows.json), fresh + non-stale.
+	sc, ok := flows.Read(feState)
+	if !ok {
+		t.Fatalf("flow side-table not written / not fresh for affected repo fe")
 	}
-	got := countProcessEntities(loaded)
+	got := 0
+	for i := range sc.Entities {
+		if sc.Entities[i].Kind == engine.EntityKindProcess {
+			got++
+		}
+	}
 	if got == 0 {
-		t.Fatalf("REGRESSION: graph.fb has 0 SCOPE.Process flow entities after phantom-edge pass — "+
-			"flows were written to graph.json only and never reach the daemon (ADR-0016). "+
-			"entities=%d relationships=%d", len(loaded.Entities), len(loaded.Relationships))
+		t.Fatalf("flow side-table has 0 SCOPE.Process flow entities after phantom-edge pass "+
+			"(entities=%d relationships=%d)", len(sc.Entities), len(sc.Relationships))
 	}
-	t.Logf("graph.fb has %d SCOPE.Process flow entities after phantom-edge pass (added=%d)", got, added)
+	// The phantom cross_repo CALLS edge must be part of the delta.
+	var phantom int
+	for i := range sc.Relationships {
+		if sc.Relationships[i].Kind == "CALLS" && sc.Relationships[i].PropGet("cross_repo") == "true" {
+			phantom++
+		}
+	}
+	if phantom == 0 {
+		t.Errorf("flow side-table missing the phantom cross_repo CALLS edge: %+v", sc.Relationships)
+	}
+	t.Logf("flow side-table: %d SCOPE.Process flows, %d phantom CALLS (added=%d)", got, phantom, added)
+}
+
+func mustModTime(t *testing.T, path string) time.Time {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.ModTime()
 }

--- a/internal/cli/links_processflow_fb_test.go
+++ b/internal/cli/links_processflow_fb_test.go
@@ -208,3 +208,70 @@ func mustModTime(t *testing.T, path string) time.Time {
 	}
 	return fi.ModTime()
 }
+
+// TestPhantomEdgePass_EmptyLinksClearsStaleSidecar is the #5904 PR-b total-link-
+// removal guard. A repo "fe" carries a valid cross-repo flows.json (source_key
+// still matches its un-reindexed graph). The last cross-repo link is then removed
+// — the links file is now EMPTY. The pass MUST still clear fe's obsolete sidecar;
+// otherwise flows.Read serves the stale cross-repo flows forever (until fe is
+// next reindexed). Regression: an early return on empty links skips the cleanup
+// and this test fails (the sidecar survives).
+func TestPhantomEdgePass_EmptyLinksClearsStaleSidecar(t *testing.T) {
+	daemonRoot := t.TempDir()
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	fePath := filepath.Join(t.TempDir(), "fe")
+	if err := os.MkdirAll(fePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fe := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+			{ID: "fe_loadData", Name: "fetchSummary", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_r1", FromID: "fe_entry", ToID: "fe_loadData", Kind: "CALLS"},
+		},
+	}
+	writeFixtureFB(t, fePath, fe)
+	feState := daemon.StateDirForRepo(fePath)
+
+	// Pre-seed a valid cross-repo flow sidecar for fe (as a prior link run would).
+	seedEnts := []graph.Entity{
+		graph.Entity{ID: "fe_xrepo_proc", Name: "CrossRepoFlow", Kind: engine.EntityKindProcess}.
+			WithProperties(map[string]string{"cross_stack": "true", "step_count": "2"}),
+	}
+	seedRels := []graph.Relationship{
+		graph.Relationship{ID: "fe_xs0", FromID: "fe_xrepo_proc", ToID: "fe_loadData", Kind: engine.RelationshipKindStepInProcess}.WithProperties(map[string]string{"step_index": "0"}),
+		graph.Relationship{ID: "fe_ph", FromID: "fe_loadData", ToID: "be::x", Kind: "CALLS"}.WithProperties(map[string]string{"cross_repo": "true"}),
+	}
+	if err := flows.Upsert(feState, seedEnts, seedRels); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+	if _, ok := flows.Read(feState); !ok {
+		t.Fatal("precondition: seeded sidecar must read fresh")
+	}
+
+	cfg := &registry.GroupConfig{Name: "fixtgrp", Repos: []registry.Repo{{Slug: "fe", Path: fePath}}}
+
+	// EMPTY links file — the last cross-repo link was removed.
+	linksDoc := links.Document{Version: 1, Links: []links.Link{}}
+	linksPath := filepath.Join(t.TempDir(), "fixtgrp-links.json")
+	b, _ := json.Marshal(linksDoc)
+	if err := os.WriteFile(linksPath, b, 0o644); err != nil {
+		t.Fatalf("write links file: %v", err)
+	}
+
+	if _, err := runPhantomEdgePass("fixtgrp", cfg, linksPath); err != nil {
+		t.Fatalf("runPhantomEdgePass: %v", err)
+	}
+
+	// The obsolete sidecar must be gone → flows.Read falls back to baked intra.
+	if sc, ok := flows.Read(feState); ok {
+		t.Fatalf("stale flows.json NOT cleared after total link removal: %+v", sc)
+	}
+	if _, statErr := os.Stat(flows.Path(feState)); !os.IsNotExist(statErr) {
+		t.Fatalf("flows.json still present after total link removal (stat err=%v)", statErr)
+	}
+}

--- a/internal/dashboard/flows_overlay_test.go
+++ b/internal/dashboard/flows_overlay_test.go
@@ -124,6 +124,83 @@ func TestDashFlowOverlay_ReplaceNotDoubled(t *testing.T) {
 	}
 }
 
+// TestDashFlowOverlay_EventFlowReplace: the dashboard load seam REPLACE-merges
+// SCOPE.EventFlow entities too — a baked event flow (+ its SEED/STEP edges) is
+// suppressed and substituted by the sidecar's cross-repo event flow, so the
+// event-flow handler (which loops Doc.Entities by Kind==SCOPE.EventFlow) sees the
+// merged set, not doubled or dangling.
+func TestDashFlowOverlay_EventFlowReplace(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, "store"))
+	group := "efgrp"
+	repoPath := filepath.Join(home, "myrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+	cfg := &registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: "svc", Path: repoPath}}}
+	cfgDir := filepath.Join(home, "groups")
+	_ = os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	_ = os.WriteFile(cfgPath, raw, 0o644)
+	regRaw, _ := json.Marshal(map[string]any{"version": 1, "groups": []map[string]any{{"name": group, "config_path": cfgPath}}})
+	_ = os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644)
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	_ = os.MkdirAll(stateDir, 0o755)
+	doc := &graph.Document{
+		Version: 1, Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "chan1", Name: "orders.topic", Kind: "message_channel"},
+			{ID: "consumer1", Name: "onOrder", Kind: "Function"},
+			graph.Entity{ID: "baked-ef", Name: "BakedEventFlow", Kind: "SCOPE.EventFlow"}.
+				WithProperties(map[string]string{"cross_stack": "false"}),
+		},
+		Relationships: []graph.Relationship{
+			graph.Relationship{ID: "seed-b", FromID: "chan1", ToID: "baked-ef", Kind: "SEED_OF_EVENT_FLOW"}.WithProperties(map[string]string{}),
+			graph.Relationship{ID: "efs-b", FromID: "baked-ef", ToID: "consumer1", Kind: "STEP_IN_EVENT_FLOW"}.WithProperties(map[string]string{"step_index": "0"}),
+		},
+	}
+	data, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sidecar: a cross-repo SCOPE.EventFlow replacing the baked one.
+	ents := []graph.Entity{
+		graph.Entity{ID: "xrepo-ef", Name: "CrossRepoEventFlow", Kind: "SCOPE.EventFlow"}.
+			WithProperties(map[string]string{"cross_stack": "true"}),
+	}
+	rels := []graph.Relationship{
+		graph.Relationship{ID: "seed-x", FromID: "chan1", ToID: "xrepo-ef", Kind: "SEED_OF_EVENT_FLOW"}.WithProperties(map[string]string{}),
+		graph.Relationship{ID: "efs-x", FromID: "xrepo-ef", ToID: "consumer1", Kind: "STEP_IN_EVENT_FLOW"}.WithProperties(map[string]string{"step_index": "0"}),
+	}
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	c := NewGraphCache(60 * time.Second)
+	grp, err := c.loadGroupForRef(group, "")
+	if err != nil {
+		t.Fatalf("loadGroupForRef: %v", err)
+	}
+	d := grp.Repos["svc"].Doc
+	var efs []string
+	for i := range d.Entities {
+		if d.Entities[i].Kind == "SCOPE.EventFlow" {
+			efs = append(efs, d.Entities[i].ID)
+		}
+	}
+	if len(efs) != 1 || efs[0] != "xrepo-ef" {
+		t.Fatalf("event-flow REPLACE violated on dashboard seam: want [xrepo-ef], got %v", efs)
+	}
+	for i := range d.Relationships {
+		r := &d.Relationships[i]
+		if r.FromID == "baked-ef" || r.ToID == "baked-ef" {
+			t.Errorf("dangling baked event-flow edge survived on dashboard seam: %s %s->%s", r.Kind, r.FromID, r.ToID)
+		}
+	}
+}
+
 // TestDashFlowOverlay_NoSidecarParity: no sidecar → baked intra flow shown as-is.
 func TestDashFlowOverlay_NoSidecarParity(t *testing.T) {
 	group, _ := buildFlowDashFixture(t)

--- a/internal/dashboard/flows_overlay_test.go
+++ b/internal/dashboard/flows_overlay_test.go
@@ -1,0 +1,139 @@
+// flows_overlay_test.go — FLOW side-table read-merge on the dashboard load seam
+// (#5904 PR-b). loadGroupForRef REPLACE-merges <stateDir>/flows.json onto each
+// repo's dr.Doc so the flow handlers (handlers_flows / handlers_event_flows /
+// v2_flows), which loop dr.Doc.Entities/Relationships by Kind, see the
+// cross-repo-aware flows — not doubled, not intra-only.
+package dashboard
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// buildFlowDashFixture registers a one-repo group whose graph.json carries a
+// BAKED intra-repo SCOPE.Process, and returns the group name + repo state dir.
+func buildFlowDashFixture(t *testing.T) (group, stateDir string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, "store"))
+
+	group = "flowgrp"
+	repoPath := filepath.Join(home, "myrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	cfg := &registry.GroupConfig{Name: group, Repos: []registry.Repo{{Slug: "svc", Path: repoPath}}}
+	cfgDir := filepath.Join(home, "groups")
+	_ = os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, group+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	_ = os.WriteFile(cfgPath, raw, 0o644)
+	regRaw, _ := json.Marshal(map[string]any{
+		"version": 1,
+		"groups":  []map[string]any{{"name": group, "config_path": cfgPath}},
+	})
+	_ = os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644)
+
+	stateDir = daemon.StateDirForRepo(repoPath)
+	_ = os.MkdirAll(stateDir, 0o755)
+	doc := &graph.Document{
+		Version: 1, Repo: "svc",
+		Entities: []graph.Entity{
+			{ID: "fn1", Name: "handleSubmit", Kind: "Function"},
+			{ID: "fn2", Name: "callService", Kind: "Function"},
+			graph.Entity{ID: "baked-proc", Name: "BakedIntraFlow", Kind: "SCOPE.Process"}.
+				WithProperties(map[string]string{"step_count": "2", "cross_stack": "false"}),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+			graph.Relationship{ID: "s1", FromID: "baked-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+			graph.Relationship{ID: "s2", FromID: "baked-proc", ToID: "fn2", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "1"}),
+		},
+	}
+	data, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return group, stateDir
+}
+
+func procKinds(doc *graph.Document) []string {
+	var out []string
+	for i := range doc.Entities {
+		if doc.Entities[i].Kind == "SCOPE.Process" {
+			out = append(out, doc.Entities[i].ID)
+		}
+	}
+	return out
+}
+
+// TestDashFlowOverlay_ReplaceNotDoubled: with a fresh sidecar the loaded dr.Doc
+// (what the flow handlers loop over) shows exactly ONE SCOPE.Process — the
+// cross-repo one — replacing the baked intra flow.
+func TestDashFlowOverlay_ReplaceNotDoubled(t *testing.T) {
+	group, stateDir := buildFlowDashFixture(t)
+	ents := []graph.Entity{
+		graph.Entity{ID: "xrepo-proc", Name: "CrossRepoFlow", Kind: "SCOPE.Process"}.
+			WithProperties(map[string]string{"step_count": "3", "cross_stack": "true"}),
+	}
+	rels := []graph.Relationship{
+		graph.Relationship{ID: "xs0", FromID: "xrepo-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+		graph.Relationship{ID: "ph1", FromID: "fn2", ToID: "remote::ep", Kind: "CALLS"}.WithProperties(map[string]string{"cross_repo": "true"}),
+	}
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	c := NewGraphCache(60 * time.Second)
+	grp, err := c.loadGroupForRef(group, "")
+	if err != nil {
+		t.Fatalf("loadGroupForRef: %v", err)
+	}
+	dr := grp.Repos["svc"]
+	if dr == nil || dr.Doc == nil {
+		t.Fatal("svc repo not loaded")
+	}
+	procs := procKinds(dr.Doc)
+	if len(procs) != 1 || procs[0] != "xrepo-proc" {
+		t.Fatalf("REPLACE violated: want exactly [xrepo-proc], got %v", procs)
+	}
+	// The phantom CALLS edge must be present (added), the baked step edges gone.
+	var phantom, bakedStep int
+	for i := range dr.Doc.Relationships {
+		r := &dr.Doc.Relationships[i]
+		if r.Kind == "CALLS" && r.PropGet("cross_repo") == "true" {
+			phantom++
+		}
+		if r.Kind == "STEP_IN_PROCESS" && r.FromID == "baked-proc" {
+			bakedStep++
+		}
+	}
+	if phantom != 1 {
+		t.Errorf("want 1 phantom CALLS edge, got %d", phantom)
+	}
+	if bakedStep != 0 {
+		t.Errorf("baked STEP edges survived REPLACE: %d", bakedStep)
+	}
+}
+
+// TestDashFlowOverlay_NoSidecarParity: no sidecar → baked intra flow shown as-is.
+func TestDashFlowOverlay_NoSidecarParity(t *testing.T) {
+	group, _ := buildFlowDashFixture(t)
+	c := NewGraphCache(60 * time.Second)
+	grp, err := c.loadGroupForRef(group, "")
+	if err != nil {
+		t.Fatalf("loadGroupForRef: %v", err)
+	}
+	procs := procKinds(grp.Repos["svc"].Doc)
+	if len(procs) != 1 || procs[0] != "baked-proc" {
+		t.Fatalf("parity: want the baked intra flow [baked-proc], got %v", procs)
+	}
+}

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -651,6 +652,16 @@ func (c *GraphCache) loadGroupForRef(groupName, ref string) (*DashGroup, error) 
 					}
 				}
 			}
+			// Flow side-table (#5904 PR-b): REPLACE-merge the per-repo
+			// <stateDir>/flows.json onto this repo's Document so the flow handlers
+			// (handlers_flows / handlers_event_flows / v2_flows), which loop
+			// r.Doc.Entities/Relationships by Kind, see the cross-repo-aware flows
+			// the phantom pass produced instead of the index-baked intra-repo ones.
+			// MergeInto SUPPRESSES the baked SCOPE.Process/SCOPE.EventFlow entities +
+			// their STEP/ENTRY/SEED edges and substitutes the sidecar's (never
+			// additive → never doubled). Absence/corrupt/stale → no-op, leaving the
+			// baked intra-repo flows (correct degraded state).
+			flows.MergeInto(stateDir, doc)
 			// S8 (#2159): open a zero-copy mmap reader alongside the Document
 			// so handlers that only need to iterate entities/relationships can
 			// avoid materialising the full heap slice. Best-effort: failures

--- a/internal/graph/flows/atomicrename_other.go
+++ b/internal/graph/flows/atomicrename_other.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package flows
+
+import "os"
+
+// atomicRename performs the temp→dest swap that finalizes a sidecar write.
+//
+// On Unix, os.Rename over an existing destination is a single atomic syscall
+// even while concurrent readers hold the destination open (open files are
+// referenced by inode, not by directory entry), so one attempt is correct. The
+// retrying variant lives in atomicrename_windows.go, where renaming over a file
+// a reader still has open can transiently fail with a sharing violation.
+func atomicRename(tmp, dst string) error {
+	return os.Rename(tmp, dst)
+}

--- a/internal/graph/flows/atomicrename_windows.go
+++ b/internal/graph/flows/atomicrename_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package flows
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+// atomicRenameRetries / atomicRenameRetryDelay bound the Windows rename-over
+// retry loop. On Windows, rename-over-existing fails with
+// ERROR_SHARING_VIOLATION / ERROR_ACCESS_DENIED while ANY process still holds
+// the destination open — including a concurrent reader mid os.ReadFile. The
+// sidecar's real reader opens, reads, and closes the file in a single brief
+// operation, so a short bounded backoff rides out that window. Variables (not
+// consts) so a future test can shrink the delay.
+var (
+	atomicRenameRetries    = 40
+	atomicRenameRetryDelay = 5 * time.Millisecond
+)
+
+// atomicRename performs the temp→dest swap that finalizes a sidecar write,
+// retrying on the transient Windows sharing/access violation raised when a
+// concurrent reader still has the destination open. A persistent lock still
+// surfaces the genuine error after the bounded loop exhausts.
+func atomicRename(tmp, dst string) error {
+	var err error
+	for i := 0; i < atomicRenameRetries; i++ {
+		err = os.Rename(tmp, dst)
+		if err == nil {
+			return nil
+		}
+		if !isSharingOrAccessError(err) {
+			return err
+		}
+		time.Sleep(atomicRenameRetryDelay)
+	}
+	return err
+}
+
+// isSharingOrAccessError reports whether err is the transient Windows lock
+// raised when renaming over a destination another handle still has open.
+func isSharingOrAccessError(err error) bool {
+	if errors.Is(err, fs.ErrPermission) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case windows.ERROR_ACCESS_DENIED,
+			windows.ERROR_SHARING_VIOLATION,
+			windows.ERROR_LOCK_VIOLATION:
+			return true
+		}
+	}
+	return false
+}

--- a/internal/graph/flows/flows.go
+++ b/internal/graph/flows/flows.go
@@ -1,0 +1,296 @@
+// Package flows implements the per-repo FLOW side-table (#5904 PR-b, the #5915
+// companion to the description side-table in internal/graph/descriptions).
+//
+// # Why this exists
+//
+// The cross-repo link pass (internal/cli.runPhantomEdgePass) enriches a group's
+// flows: it injects phantom cross_repo CALLS edges, STRIPS the index-baked
+// intra-repo SCOPE.Process / SCOPE.EventFlow entities, and re-synthesises
+// cross-repo-AWARE flow entities in their place. Historically it then PERSISTED
+// that result by REWRITING the whole graph to disk (fbwriter.WriteGraphGen +
+// graph.WriteAtomic). For a single-file graph that is merely wasteful; for a
+// #5901 SEGMENT-SET graph it is a correctness hazard: the resident Document is a
+// COLLAPSED union of every segment, so re-serialising it as one flat
+// graph.<gen>.fb re-materialises the whole graph in memory (the #5915 P1 OOM)
+// and silently discards the segmented layout.
+//
+// This side-table removes the whole-graph rewrite from the flow path. The
+// cross-repo-aware flow DELTA is written to a small per-repo sidecar:
+//
+//	<stateDir>/flows.json
+//
+// and merged back onto the graph at READ time. The graph file / generation is
+// never touched, so a segment-set stays a segment-set and no collapse/OOM can
+// occur.
+//
+// # REPLACE, not additive (the critical subtlety)
+//
+// Flow entities have TWO producers. The NORMAL INDEX bakes INTRA-repo flows into
+// graph.fb; the phantom pass STRIPS those and RE-EMITS cross-repo-aware ones.
+// After this change graph.fb STILL contains the index-baked intra-repo flows,
+// and the sidecar holds the cross-repo-aware flows. Therefore the read overlay
+// is REPLACE, not additive: when a fresh flow sidecar exists it must SUPPRESS
+// the baked SCOPE.Process / SCOPE.EventFlow entities + their STEP_IN_* / entry /
+// seed edges and substitute the sidecar's, AND ADD the phantom cross_repo CALLS
+// edges (which are not baked). A naive additive merge would DOUBLE every flow.
+// Apply() enforces this.
+//
+// # Staleness / graceful degradation
+//
+// The sidecar records a SOURCE-FRESHNESS KEY derived from
+// graph.CurrentGraphDescriptor(stateDir) at write time (never CurrentGraphPath —
+// a segment-set's freshness derives from the gen dir / manifest, the #5915 P2
+// discipline). A read whose stored source_key no longer equals the current key
+// is STALE and treated as absent. On absence/corruption/staleness MergeInto is a
+// no-op and the graph's own BAKED intra-repo flows are shown — a correct
+// degraded state (valid, just not cross-repo-enriched, until the link pass
+// re-runs). Never doubled, never empty.
+package flows
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// FileName is the fixed basename of the per-repo flow sidecar.
+const FileName = "flows.json"
+
+// currentVersion is the on-disk schema version stamped into every write.
+const currentVersion = 1
+
+// Flow entity + edge kinds. Duplicated as literals (not imported from
+// internal/engine) to keep this low-level graph sidecar free of the engine
+// dependency; they mirror engine.EntityKindProcess / EntityKindEventFlow and the
+// STEP/ENTRY/SEED relationship kinds exactly.
+const (
+	kindProcess   = "SCOPE.Process"
+	kindEventFlow = "SCOPE.EventFlow"
+
+	edgeStepInProcess   = "STEP_IN_PROCESS"
+	edgeEntryPointOf    = "ENTRY_POINT_OF"
+	edgeStepInEventFlow = "STEP_IN_EVENT_FLOW"
+	edgeSeedOfEventFlow = "SEED_OF_EVENT_FLOW"
+)
+
+// Sidecar is the on-disk <stateDir>/flows.json document. It holds the cross-repo
+// aware flow DELTA the phantom pass produced: the re-synthesised flow entities,
+// their step/entry/seed edges, and the phantom cross_repo CALLS edges.
+type Sidecar struct {
+	// Version is the on-disk schema version.
+	Version int `json:"version"`
+	// ComputedAt is when the sidecar was last written (informational).
+	ComputedAt time.Time `json:"computed_at"`
+	// SourceKey is the graph-freshness key (see CurrentSourceKey) at write time.
+	// A read whose SourceKey differs from the current key is stale → ignored.
+	SourceKey string `json:"source_key"`
+	// Entities are the cross-repo-aware SCOPE.Process / SCOPE.EventFlow entities
+	// (with ALL their props: step_count, entry_id/name, terminal_id,
+	// chain_labels, cross_stack, entry_kind, channel_count, …).
+	Entities []graph.Entity `json:"entities"`
+	// Relationships are the STEP_IN_PROCESS / STEP_IN_EVENT_FLOW (+ entry/seed)
+	// edges of those flows PLUS the phantom cross_repo CALLS edges.
+	Relationships []graph.Relationship `json:"relationships"`
+}
+
+// Path returns the sidecar path for a repo state dir.
+func Path(stateDir string) string {
+	return filepath.Join(stateDir, FileName)
+}
+
+// CurrentSourceKey computes the graph-freshness key for a repo state dir from
+// its ACTIVE graph descriptor. The key changes whenever the underlying graph
+// changes (a reindex writes a new generation / segment-set), which is exactly
+// when a previously-written flow delta must be considered stale. Mirrors
+// descriptions.CurrentSourceKey (same #5915 P2 discipline).
+func CurrentSourceKey(stateDir string) string {
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		return ""
+	}
+	switch desc.Kind {
+	case graph.GraphSingleFile:
+		if fi, statErr := os.Stat(desc.Path); statErr == nil {
+			return fmt.Sprintf("single:%s:%d", filepath.Base(desc.Path), fi.ModTime().UnixNano())
+		}
+		return ""
+	case graph.GraphSegmentSet:
+		manifest := filepath.Join(desc.GenDir, graph.ManifestFileName)
+		if fi, statErr := os.Stat(manifest); statErr == nil {
+			return fmt.Sprintf("seg:%s:%d", filepath.Base(desc.GenDir), fi.ModTime().UnixNano())
+		}
+		if fi, statErr := os.Stat(desc.GenDir); statErr == nil {
+			return fmt.Sprintf("seg:%s:%d", filepath.Base(desc.GenDir), fi.ModTime().UnixNano())
+		}
+		return ""
+	default: // GraphAbsent
+		if fi, statErr := os.Stat(filepath.Join(stateDir, "graph.json")); statErr == nil {
+			return fmt.Sprintf("json:%d", fi.ModTime().UnixNano())
+		}
+		return ""
+	}
+}
+
+// readRaw loads and unmarshals the sidecar WITHOUT the staleness check. Returns
+// nil on absent / unreadable / corrupt.
+func readRaw(stateDir string) *Sidecar {
+	data, err := os.ReadFile(Path(stateDir))
+	if err != nil {
+		return nil
+	}
+	var sc Sidecar
+	if err := json.Unmarshal(data, &sc); err != nil {
+		return nil
+	}
+	return &sc
+}
+
+// Read loads the sidecar and returns (sidecar, true) ONLY when it is present,
+// well-formed, non-stale (its stored source_key still equals the current graph
+// key), and non-empty. Absent, corrupt, stale, and empty all collapse to
+// (nil, false) so the read path falls back to the baked intra-repo flows.
+func Read(stateDir string) (*Sidecar, bool) {
+	sc := readRaw(stateDir)
+	if sc == nil {
+		return nil, false
+	}
+	if sc.SourceKey != CurrentSourceKey(stateDir) {
+		return nil, false // stale: written for a different graph generation
+	}
+	if len(sc.Entities) == 0 {
+		return nil, false
+	}
+	return sc, true
+}
+
+// Upsert writes the cross-repo-aware flow delta (entities + relationships) into
+// the sidecar via an atomic tmp+rename. The stored source_key is stamped to the
+// CURRENT graph key. This is a full REPLACE of the delta (the phantom pass
+// re-computes the whole flow layer each run), so no read-modify-merge is needed.
+// The graph file / generation is NEVER touched.
+func Upsert(stateDir string, entities []graph.Entity, relationships []graph.Relationship) error {
+	sc := &Sidecar{
+		Version:       currentVersion,
+		SourceKey:     CurrentSourceKey(stateDir),
+		ComputedAt:    time.Now().UTC(),
+		Entities:      entities,
+		Relationships: relationships,
+	}
+	return WriteTo(Path(stateDir), sc)
+}
+
+// IsFlowEntityKind reports whether kind is a flow entity kind
+// (SCOPE.Process / SCOPE.EventFlow) — the kinds a fresh flow sidecar SUPPRESSES
+// from the baked graph and substitutes. Exported so read-time consumers (the MCP
+// forEach iterators) can apply the same REPLACE suppression without duplicating
+// the literals.
+func IsFlowEntityKind(kind string) bool {
+	return kind == kindProcess || kind == kindEventFlow
+}
+
+// isFlowStructuralEdge reports whether kind is a flow STRUCTURAL edge (step /
+// entry / seed) — the edges that bind a flow entity to its steps. These are
+// suppressed alongside the baked flow entities on REPLACE. Ordinary CALLS edges
+// are NOT in this set (they are real graph edges, never stripped).
+func isFlowStructuralEdge(kind string) bool {
+	switch kind {
+	case edgeStepInProcess, edgeEntryPointOf, edgeStepInEventFlow, edgeSeedOfEventFlow:
+		return true
+	}
+	return false
+}
+
+// StripBakedFlows returns copies of doc's entity/relationship slices with every
+// baked SCOPE.Process / SCOPE.EventFlow entity removed, plus every flow
+// STRUCTURAL edge (STEP_IN_* / ENTRY_POINT_OF / SEED_OF_EVENT_FLOW) that touches
+// a removed flow entity. Ordinary edges (CALLS, IMPORTS, …) survive untouched.
+// This mirrors internal/cli.stripProcessEntities — the same suppression the
+// phantom pass performs before re-synthesising, now reused at read time.
+func StripBakedFlows(entities []graph.Entity, relationships []graph.Relationship) ([]graph.Entity, []graph.Relationship) {
+	dropped := make(map[string]bool)
+	for i := range entities {
+		if IsFlowEntityKind(entities[i].Kind) {
+			dropped[entities[i].ID] = true
+		}
+	}
+	if len(dropped) == 0 {
+		return entities, relationships
+	}
+	outEnts := make([]graph.Entity, 0, len(entities))
+	for i := range entities {
+		if !dropped[entities[i].ID] {
+			outEnts = append(outEnts, entities[i])
+		}
+	}
+	outRels := make([]graph.Relationship, 0, len(relationships))
+	for i := range relationships {
+		r := &relationships[i]
+		if (dropped[r.FromID] || dropped[r.ToID]) && isFlowStructuralEdge(r.Kind) {
+			continue
+		}
+		outRels = append(outRels, *r)
+	}
+	return outEnts, outRels
+}
+
+// Apply performs the REPLACE merge of a flow sidecar onto doc IN PLACE: it
+// SUPPRESSES the baked flow entities + their structural edges (StripBakedFlows),
+// then SUBSTITUTES the sidecar's cross-repo-aware flow entities + edges (which
+// also carry the phantom cross_repo CALLS edges). A nil sidecar is a no-op.
+//
+// The result is the exact set the phantom pass would have baked, without ever
+// rewriting graph.fb. Because the baked flows are removed first, the merge is
+// never additive — no flow is doubled.
+func Apply(doc *graph.Document, sc *Sidecar) {
+	if doc == nil || sc == nil {
+		return
+	}
+	ents, rels := StripBakedFlows(doc.Entities, doc.Relationships)
+	doc.Entities = append(ents, sc.Entities...)
+	doc.Relationships = append(rels, sc.Relationships...)
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+}
+
+// MergeInto reads the flow sidecar for stateDir and, when it is fresh, Apply-s
+// the REPLACE merge onto doc, returning true. On absence / corruption /
+// staleness it is a no-op and returns false, leaving doc's baked intra-repo
+// flows intact (the correct degraded state). This is the shared read-time seam
+// for the Doc-path consumers (dashboard load, JSON export, MCP flag-OFF).
+func MergeInto(stateDir string, doc *graph.Document) bool {
+	sc, ok := Read(stateDir)
+	if !ok {
+		return false
+	}
+	Apply(doc, sc)
+	return true
+}
+
+// WriteTo atomically writes the sidecar to path via a temp-file + rename
+// (single-syscall swap on Unix; a bounded sharing-violation retry on Windows,
+// atomicrename_windows.go). A nil sidecar is a no-op.
+func WriteTo(path string, sc *Sidecar) error {
+	if sc == nil {
+		return nil
+	}
+	data, err := json.Marshal(sc)
+	if err != nil {
+		return fmt.Errorf("marshal flows: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdirall: %w", err)
+	}
+	tmp := fmt.Sprintf("%s.tmp.%d", path, os.Getpid())
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := atomicRename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}

--- a/internal/graph/flows/flows_test.go
+++ b/internal/graph/flows/flows_test.go
@@ -141,6 +141,77 @@ func TestApply_ReplaceSemantics(t *testing.T) {
 	}
 }
 
+// TestApply_ReplaceSemantics_EventFlow guards the SCOPE.EventFlow half of the
+// REPLACE machinery: a baked SCOPE.EventFlow + its SEED_OF_EVENT_FLOW /
+// STEP_IN_EVENT_FLOW edges must be SUPPRESSED (no dangling baked edge) and
+// SUBSTITUTED by the sidecar's cross-repo event flow. FAILS if either event-flow
+// edge kind is dropped from the strip set (the baked SEED/STEP edge would then
+// survive as a dangling edge pointing at the removed baked entity).
+func TestApply_ReplaceSemantics_EventFlow(t *testing.T) {
+	doc := &graph.Document{Repo: "r", Entities: []graph.Entity{
+		{ID: "chan1", Kind: "message_channel", Name: "orders.topic"},
+		{ID: "consumer1", Kind: "function", Name: "onOrder"},
+		ent("baked-ef", "SCOPE.EventFlow", "orders.topic -> onOrder",
+			map[string]string{"channel_count": "1", "cross_stack": "false"}),
+	}, Relationships: []graph.Relationship{
+		rel("seed-b", "chan1", "baked-ef", "SEED_OF_EVENT_FLOW", map[string]string{}),
+		rel("efs-b", "baked-ef", "consumer1", "STEP_IN_EVENT_FLOW", map[string]string{"step_index": "0"}),
+	}}
+	sc := &flows.Sidecar{
+		Entities: []graph.Entity{
+			ent("xrepo-ef", "SCOPE.EventFlow", "orders.topic -> onOrder -> remoteSink",
+				map[string]string{"channel_count": "2", "cross_stack": "true"}),
+		},
+		Relationships: []graph.Relationship{
+			rel("seed-x", "chan1", "xrepo-ef", "SEED_OF_EVENT_FLOW", map[string]string{}),
+			rel("efs-x0", "xrepo-ef", "consumer1", "STEP_IN_EVENT_FLOW", map[string]string{"step_index": "0"}),
+			rel("efs-x1", "xrepo-ef", "remote::sink", "STEP_IN_EVENT_FLOW", map[string]string{"step_index": "1"}),
+		},
+	}
+
+	flows.Apply(doc, sc)
+
+	// Exactly ONE SCOPE.EventFlow, the cross-repo one.
+	var efs []string
+	for _, e := range doc.Entities {
+		if e.Kind == "SCOPE.EventFlow" {
+			efs = append(efs, e.ID)
+		}
+	}
+	if len(efs) != 1 || efs[0] != "xrepo-ef" {
+		t.Fatalf("event-flow REPLACE violated: want [xrepo-ef], got %v", efs)
+	}
+	// No baked SEED/STEP edges survive (they would dangle at removed baked-ef).
+	for _, r := range doc.Relationships {
+		if r.FromID == "baked-ef" || r.ToID == "baked-ef" {
+			t.Errorf("dangling baked event-flow edge survived Apply: %s %s->%s", r.Kind, r.FromID, r.ToID)
+		}
+	}
+	// Substituted edges present: 1 seed + 2 steps for xrepo-ef.
+	var seed, step int
+	for _, r := range doc.Relationships {
+		if r.Kind == "SEED_OF_EVENT_FLOW" && r.ToID == "xrepo-ef" {
+			seed++
+		}
+		if r.Kind == "STEP_IN_EVENT_FLOW" && r.FromID == "xrepo-ef" {
+			step++
+		}
+	}
+	if seed != 1 || step != 2 {
+		t.Errorf("event-flow substitution wrong: seed=%d step=%d, want 1/2", seed, step)
+	}
+	// The ordinary channel/consumer entities survive.
+	var plain int
+	for _, e := range doc.Entities {
+		if e.Kind == "message_channel" || e.Kind == "function" {
+			plain++
+		}
+	}
+	if plain != 2 {
+		t.Errorf("ordinary entities must survive Apply, got %d", plain)
+	}
+}
+
 // TestMergeInto_FreshReplaces: a fresh sidecar drives REPLACE via MergeInto.
 func TestMergeInto_FreshReplaces(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/graph/flows/flows_test.go
+++ b/internal/graph/flows/flows_test.go
@@ -1,0 +1,292 @@
+package flows_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+)
+
+// writeSingleFileGen writes graph.1.fb + points current at it.
+func writeSingleFileGen(t *testing.T, dir string) {
+	t.Helper()
+	doc := bakedDoc()
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, graph.GenFileName(1)), doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(dir, graph.GenFileName(1)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// bakedDoc models a graph.fb as the index bakes it: one intra-repo SCOPE.Process
+// flow + its STEP_IN_PROCESS edges, plus some ordinary entities.
+func ent(id, kind, name string, props map[string]string) graph.Entity {
+	return graph.Entity{ID: id, Kind: kind, Name: name}.WithProperties(props)
+}
+
+func rel(id, from, to, kind string, props map[string]string) graph.Relationship {
+	return graph.Relationship{ID: id, FromID: from, ToID: to, Kind: kind}.WithProperties(props)
+}
+
+func bakedDoc() *graph.Document {
+	return &graph.Document{Repo: "r", Entities: []graph.Entity{
+		{ID: "fn1", Kind: "function", Name: "Handler"},
+		{ID: "fn2", Kind: "function", Name: "Service"},
+		ent("baked-proc", "SCOPE.Process", "Handler -> Service",
+			map[string]string{"step_count": "2", "entry_id": "fn1", "cross_stack": "false"}),
+	}, Relationships: []graph.Relationship{
+		{ID: "c1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+		rel("s1", "baked-proc", "fn1", "STEP_IN_PROCESS", map[string]string{"step_index": "0"}),
+		rel("s2", "baked-proc", "fn2", "STEP_IN_PROCESS", map[string]string{"step_index": "1"}),
+	}}
+}
+
+// crossRepoDelta models the phantom-pass output: a re-synthesized cross-repo
+// SCOPE.Process (new id, cross_stack=true) + its steps + a phantom CALLS edge.
+func crossRepoDelta() ([]graph.Entity, []graph.Relationship) {
+	ents := []graph.Entity{
+		ent("xrepo-proc", "SCOPE.Process", "Handler -> Service -> RemoteAPI",
+			map[string]string{"step_count": "3", "entry_id": "fn1", "cross_stack": "true"}),
+	}
+	rels := []graph.Relationship{
+		rel("xs0", "xrepo-proc", "fn1", "STEP_IN_PROCESS", map[string]string{"step_index": "0"}),
+		rel("xs1", "xrepo-proc", "fn2", "STEP_IN_PROCESS", map[string]string{"step_index": "1"}),
+		rel("xs2", "xrepo-proc", "remote::ep", "STEP_IN_PROCESS", map[string]string{"step_index": "2"}),
+		rel("ph1", "fn2", "remote::ep", "CALLS", map[string]string{
+			"cross_repo": "true", "target_repo": "remote", "link_method": "http", "via": "phantom_edge_pass_#769",
+		}),
+	}
+	return ents, rels
+}
+
+func TestUpsertRead_SingleFileRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	writeSingleFileGen(t, dir)
+	ents, rels := crossRepoDelta()
+	if err := flows.Upsert(dir, ents, rels); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	sc, ok := flows.Read(dir)
+	if !ok {
+		t.Fatal("Read returned not-ok for a fresh sidecar")
+	}
+	if len(sc.Entities) != 1 || sc.Entities[0].ID != "xrepo-proc" {
+		t.Errorf("Entities = %+v", sc.Entities)
+	}
+	if len(sc.Relationships) != 4 {
+		t.Errorf("Relationships len = %d, want 4", len(sc.Relationships))
+	}
+	if sc.SourceKey == "" {
+		t.Error("SourceKey should be non-empty for a single-file graph")
+	}
+}
+
+// TestApply_ReplaceSemantics is the core double-count guard: applying the
+// sidecar must SUPPRESS the baked intra flow and its STEP edges, SUBSTITUTE the
+// cross-repo flow, and ADD the phantom CALLS edge — never additively double.
+func TestApply_ReplaceSemantics(t *testing.T) {
+	doc := bakedDoc()
+	ents, rels := crossRepoDelta()
+	sc := &flows.Sidecar{Entities: ents, Relationships: rels}
+
+	flows.Apply(doc, sc)
+
+	// Exactly ONE SCOPE.Process, and it is the cross-repo one (not the baked).
+	var procs []string
+	for _, e := range doc.Entities {
+		if e.Kind == "SCOPE.Process" {
+			procs = append(procs, e.ID)
+		}
+	}
+	if len(procs) != 1 || procs[0] != "xrepo-proc" {
+		t.Fatalf("after Apply want exactly [xrepo-proc], got %v (DOUBLE-COUNT or wrong flow)", procs)
+	}
+	// The baked STEP edges must be gone; only the cross-repo steps remain.
+	var stepFroms []string
+	var phantom int
+	for _, r := range doc.Relationships {
+		if r.Kind == "STEP_IN_PROCESS" {
+			stepFroms = append(stepFroms, r.FromID)
+		}
+		if r.Kind == "CALLS" && r.PropGet("cross_repo") == "true" {
+			phantom++
+		}
+	}
+	for _, f := range stepFroms {
+		if f == "baked-proc" {
+			t.Errorf("baked STEP_IN_PROCESS edge survived Apply (should be suppressed): %v", stepFroms)
+		}
+	}
+	if len(stepFroms) != 3 {
+		t.Errorf("want 3 cross-repo step edges, got %d: %v", len(stepFroms), stepFroms)
+	}
+	if phantom != 1 {
+		t.Errorf("want exactly 1 phantom CALLS edge added, got %d", phantom)
+	}
+	// The ordinary CALLS edge and plain entities survive.
+	var funcs int
+	for _, e := range doc.Entities {
+		if e.Kind == "function" {
+			funcs++
+		}
+	}
+	if funcs != 2 {
+		t.Errorf("ordinary entities must survive Apply, got %d functions", funcs)
+	}
+}
+
+// TestMergeInto_FreshReplaces: a fresh sidecar drives REPLACE via MergeInto.
+func TestMergeInto_FreshReplaces(t *testing.T) {
+	dir := t.TempDir()
+	writeSingleFileGen(t, dir)
+	ents, rels := crossRepoDelta()
+	if err := flows.Upsert(dir, ents, rels); err != nil {
+		t.Fatal(err)
+	}
+	doc := bakedDoc()
+	if !flows.MergeInto(dir, doc) {
+		t.Fatal("MergeInto should report applied for a fresh sidecar")
+	}
+	var procs int
+	for _, e := range doc.Entities {
+		if e.Kind == "SCOPE.Process" {
+			procs++
+		}
+	}
+	if procs != 1 {
+		t.Errorf("want 1 process after MergeInto, got %d", procs)
+	}
+}
+
+// TestMergeInto_StaleFallsBackToBaked: after a reindex the sidecar is stale;
+// MergeInto is a no-op and the baked intra flow survives unchanged (degraded
+// but valid — never empty, never doubled).
+func TestMergeInto_StaleFallsBackToBaked(t *testing.T) {
+	dir := t.TempDir()
+	writeSingleFileGen(t, dir)
+	ents, rels := crossRepoDelta()
+	if err := flows.Upsert(dir, ents, rels); err != nil {
+		t.Fatal(err)
+	}
+	// Reindex: new generation → source_key mismatch.
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, graph.GenFileName(2)), bakedDoc()); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(dir, graph.GenFileName(2)); err != nil {
+		t.Fatal(err)
+	}
+	doc := bakedDoc()
+	if flows.MergeInto(dir, doc) {
+		t.Fatal("MergeInto should be a no-op for a stale sidecar")
+	}
+	// Baked intra flow survives.
+	var procs []string
+	for _, e := range doc.Entities {
+		if e.Kind == "SCOPE.Process" {
+			procs = append(procs, e.ID)
+		}
+	}
+	if len(procs) != 1 || procs[0] != "baked-proc" {
+		t.Errorf("stale fallback must show the baked intra flow, got %v", procs)
+	}
+}
+
+// TestMergeInto_AbsentNoOp: no sidecar → baked flows shown exactly as today.
+func TestMergeInto_AbsentNoOp(t *testing.T) {
+	dir := t.TempDir()
+	writeSingleFileGen(t, dir)
+	doc := bakedDoc()
+	if flows.MergeInto(dir, doc) {
+		t.Fatal("MergeInto should be a no-op when no sidecar exists")
+	}
+	if len(doc.Entities) != 3 {
+		t.Errorf("single-repo parity: entity set must be untouched, got %d", len(doc.Entities))
+	}
+}
+
+func TestRead_Corrupt(t *testing.T) {
+	dir := t.TempDir()
+	writeSingleFileGen(t, dir)
+	if err := os.WriteFile(flows.Path(dir), []byte("{ not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if sc, ok := flows.Read(dir); ok || sc != nil {
+		t.Errorf("corrupt sidecar: want (nil,false), got (%v,%v)", sc, ok)
+	}
+}
+
+func TestUpsertRead_SegmentSetRoundtrip(t *testing.T) {
+	dir := t.TempDir()
+	writeSegmentSet(t, dir, 3)
+	ents, rels := crossRepoDelta()
+	if err := flows.Upsert(dir, ents, rels); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	sc, ok := flows.Read(dir)
+	if !ok {
+		t.Fatal("Read not-ok for segment-set sidecar")
+	}
+	if len(sc.SourceKey) < 4 || sc.SourceKey[:4] != "seg:" {
+		t.Errorf("segment-set SourceKey = %q, want seg: prefix", sc.SourceKey)
+	}
+}
+
+func writeSegmentSet(t *testing.T, dir string, gen uint64) {
+	t.Helper()
+	genDirName := graph.GenDirName(gen)
+	genDir := filepath.Join(dir, genDirName)
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	docs := []*graph.Document{
+		{Repo: "seg", Entities: []graph.Entity{{ID: "a", Kind: "function", Name: "A"}}},
+		{Repo: "seg", Entities: []graph.Entity{{ID: "m", Kind: "function", Name: "M"}}},
+	}
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion}
+	for i, doc := range docs {
+		name := graph.SegmentFileName(i)
+		if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		seg := graph.SegmentMeta{File: name, Kind: graph.SegmentEntities, EntityCount: len(doc.Entities)}
+		ids := make([]string, 0, len(doc.Entities))
+		for _, e := range doc.Entities {
+			ids = append(ids, e.ID)
+		}
+		sort.Strings(ids)
+		seg.MinKey, seg.MaxKey = ids[0], ids[len(ids)-1]
+		m.Segments = append(m.Segments, seg)
+	}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(dir, genDirName); err != nil {
+		t.Fatalf("write current pointer: %v", err)
+	}
+}
+
+func TestWriteTo_Roundtrip(t *testing.T) {
+	dir := t.TempDir()
+	ents, rels := crossRepoDelta()
+	sc := &flows.Sidecar{Version: 1, SourceKey: "k", Entities: ents, Relationships: rels}
+	if err := flows.WriteTo(flows.Path(dir), sc); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(flows.Path(dir))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got flows.Sidecar
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("written file is not valid JSON: %v", err)
+	}
+	if len(got.Entities) != 1 || got.Entities[0].ID != "xrepo-proc" {
+		t.Errorf("roundtrip Entities = %+v", got.Entities)
+	}
+}

--- a/internal/mcp/flows_overlay_test.go
+++ b/internal/mcp/flows_overlay_test.go
@@ -1,0 +1,311 @@
+// flows_overlay_test.go — FLOW side-table read-merge (#5904 PR-b).
+//
+// applyFlowOverlay REPLACE-merges <stateDir>/flows.json onto a loaded group: the
+// forEach* iterators suppress the baked SCOPE.Process/SCOPE.EventFlow entities
+// and inject the sidecar's cross-repo-aware ones; getStepAdj rebuilds from the
+// sidecar's step edges. These tests DRIVE THE REAL grafel_traces tool and prove:
+//
+//   - grouped/cross-repo: the flow list shows the CROSS-REPO-AWARE flow, NOT
+//     doubled (exact count) and NOT intra-only — the #1 failure mode;
+//   - a double-count guard that FAILS if the overlay were additive;
+//   - single-repo parity: no sidecar → baked intra flow shown exactly as today;
+//   - staleness fallback: a stale sidecar → baked intra flow (never empty/doubled);
+//   - the mmap (flag-ON) read path applies the same REPLACE;
+//   - concurrent reads vs sidecar re-publish are race-free (-race).
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+)
+
+// bakedFlowDoc models graph.fb as the index bakes it: an INTRA-repo SCOPE.Process
+// "baked-proc" (cross_stack=false) with its STEP_IN_PROCESS chain, plus the
+// ordinary functions it links.
+func bakedFlowDoc(repo string) *graph.Document {
+	return &graph.Document{
+		Version: 1, GeneratedAt: time.Now(), Repo: repo,
+		Entities: []graph.Entity{
+			{ID: "fn1", Name: "handleSubmit", Kind: "SCOPE.Function", SourceFile: "a.go", StartLine: 1, EndLine: 5},
+			{ID: "fn2", Name: "callService", Kind: "SCOPE.Function", SourceFile: "a.go", StartLine: 6, EndLine: 9},
+			graph.Entity{ID: "baked-proc", Name: "handleSubmit -> callService", Kind: "SCOPE.Process",
+				SourceFile: "a.go", StartLine: 1, EndLine: 5}.WithProperties(map[string]string{
+				"entry_id": "fn1", "entry_name": "handleSubmit", "terminal_id": "fn2",
+				"step_count": "2", "cross_stack": "false",
+				"chain_labels": "handleSubmit -> callService",
+			}),
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+			graph.Relationship{ID: "s1", FromID: "baked-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+			graph.Relationship{ID: "s2", FromID: "baked-proc", ToID: "fn2", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "1"}),
+			{ID: "e1", FromID: "fn1", ToID: "baked-proc", Kind: "ENTRY_POINT_OF"},
+		},
+	}
+}
+
+// crossRepoFlowDelta is the phantom-pass output: a re-synthesised CROSS-REPO
+// SCOPE.Process "xrepo-proc" (cross_stack=true, 3 steps into a remote endpoint)
+// with its step edges + the phantom cross_repo CALLS edge. It REPLACES the baked
+// intra flow at read time.
+func crossRepoFlowDelta() ([]graph.Entity, []graph.Relationship) {
+	ents := []graph.Entity{
+		graph.Entity{ID: "xrepo-proc", Name: "handleSubmit -> callService -> remoteEndpoint", Kind: "SCOPE.Process",
+			SourceFile: "a.go", StartLine: 1, EndLine: 5}.WithProperties(map[string]string{
+			"entry_id": "fn1", "entry_name": "handleSubmit", "terminal_id": "remote::ep",
+			"step_count": "3", "cross_stack": "true",
+			"chain_labels": "handleSubmit -> callService -> remoteEndpoint",
+		}),
+	}
+	rels := []graph.Relationship{
+		graph.Relationship{ID: "xs0", FromID: "xrepo-proc", ToID: "fn1", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "0"}),
+		graph.Relationship{ID: "xs1", FromID: "xrepo-proc", ToID: "fn2", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "1"}),
+		graph.Relationship{ID: "xs2", FromID: "xrepo-proc", ToID: "remote::ep", Kind: "STEP_IN_PROCESS"}.WithProperties(map[string]string{"step_index": "2"}),
+		graph.Relationship{ID: "ph1", FromID: "fn2", ToID: "remote::ep", Kind: "CALLS"}.WithProperties(map[string]string{
+			"cross_repo": "true", "target_repo": "remote", "link_method": "http", "via": "phantom_edge_pass_#769",
+		}),
+	}
+	return ents, rels
+}
+
+// newFlowServer registers a one-repo group "g" whose baked graph is written by
+// writeGraph into the repo state dir, and returns the Server + that state dir.
+func newFlowServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, bakedFlowDoc("r1"))
+	stateDir := daemon.StateDirForRepo(repo)
+	reg := Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{"r1": {Path: repo}}},
+	}}
+	regPath := filepath.Join(dir, "registry.json")
+	d, _ := json.MarshalIndent(reg, "", "  ")
+	_ = os.WriteFile(regPath, d, 0o644)
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv, stateDir
+}
+
+func listAll(t *testing.T, srv *Server) string {
+	t.Helper()
+	res := callTool(t, srv, "grafel_traces", map[string]any{"action": "list", "min_steps": 0})
+	return resultText(res)
+}
+
+// TestFlowOverlay_List_ReplaceNotDoubled is the core grouped/cross-repo guard:
+// with a fresh flow sidecar the list shows exactly ONE process — the cross-repo
+// one — not two (double-count) and not the intra-only baked one.
+func TestFlowOverlay_List_ReplaceNotDoubled(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, stateDir := newFlowServer(t)
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	txt := listAll(t, srv)
+
+	if !strings.Contains(txt, `"count":1`) {
+		t.Fatalf("REPLACE violated: want count=1 (cross-repo flow), got: %s", txt)
+	}
+	if strings.Contains(txt, "baked-proc") {
+		t.Errorf("baked intra flow leaked through overlay (should be suppressed): %s", txt)
+	}
+	if !strings.Contains(txt, "remoteEndpoint") {
+		t.Errorf("cross-repo flow missing from list: %s", txt)
+	}
+	// The double-count fingerprint: the baked process_id present alongside the
+	// overlay one. (count=1 above already guards this; asserted explicitly here.)
+	if strings.Contains(txt, `"process_id":"r1::baked-proc"`) {
+		t.Errorf("DOUBLE-COUNT: baked flow present alongside overlay: %s", txt)
+	}
+}
+
+// TestFlowOverlay_DoubleCountGuard fails if the overlay were made ADDITIVE: it
+// asserts the baked SCOPE.Process is not present ALONGSIDE the cross-repo one.
+func TestFlowOverlay_DoubleCountGuard(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, stateDir := newFlowServer(t)
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	txt := listAll(t, srv)
+	hasBaked := strings.Contains(txt, "baked-proc")
+	hasXrepo := strings.Contains(txt, "xrepo-proc")
+	if hasBaked && hasXrepo {
+		t.Fatalf("ADDITIVE double-count detected: both baked + overlay flows present: %s", txt)
+	}
+	if !hasXrepo {
+		t.Fatalf("cross-repo flow missing (intra-only regression): %s", txt)
+	}
+}
+
+// TestFlowOverlay_Get_CrossRepoChain: `get` on the injected cross-repo process
+// returns its full 3-step chain assembled from the sidecar's STEP edges.
+func TestFlowOverlay_Get_CrossRepoChain(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, stateDir := newFlowServer(t)
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	res := callTool(t, srv, "grafel_traces", map[string]any{"action": "get", "process_id": "xrepo-proc"})
+	txt := resultText(res)
+	if !strings.Contains(txt, `"found":true`) {
+		t.Fatalf("cross-repo process not found via get: %s", txt)
+	}
+	if !strings.Contains(txt, `"cross_stack":true`) {
+		t.Errorf("cross_stack not surfaced: %s", txt)
+	}
+	// Steps come from the sidecar's STEP_IN_PROCESS adjacency (REPLACE).
+	if !strings.Contains(txt, "handleSubmit") || !strings.Contains(txt, "callService") {
+		t.Errorf("cross-repo chain steps missing: %s", txt)
+	}
+}
+
+// TestFlowOverlay_SingleRepoParity_NoSidecar: with NO sidecar the baked intra
+// flow is shown exactly as today (parity).
+func TestFlowOverlay_SingleRepoParity_NoSidecar(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, _ := newFlowServer(t)
+	txt := listAll(t, srv)
+	if !strings.Contains(txt, `"count":1`) {
+		t.Fatalf("single-repo parity: want the baked intra flow (count=1), got: %s", txt)
+	}
+	if !strings.Contains(txt, "baked-proc") {
+		t.Errorf("single-repo parity: baked intra flow must be shown unchanged: %s", txt)
+	}
+}
+
+// TestFlowOverlay_StaleFallback: a sidecar written for an older graph generation
+// is stale (source-key mismatch) after a reindex and must NOT be applied — the
+// baked intra flow is shown (never empty, never doubled).
+func TestFlowOverlay_StaleFallback(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, stateDir := newFlowServer(t)
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	// Prime: the fresh overlay is applied.
+	if txt := listAll(t, srv); !strings.Contains(txt, "xrepo-proc") {
+		t.Fatalf("precondition: fresh overlay must be applied, got: %s", txt)
+	}
+	// Simulate a reindex: rewrite graph.json with a strictly-newer mtime so the
+	// json: source key changes (sidecar goes stale) AND the repo reparses on
+	// Reload (advancing lr.mtime → applyFlowOverlay re-evaluates the sidecar).
+	future := time.Now().Add(2 * time.Second)
+	if err := os.Chtimes(filepath.Join(stateDir, "graph.json"), future, future); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+	if _, err := srv.State.Reload(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	txt := listAll(t, srv)
+	if !strings.Contains(txt, "baked-proc") {
+		t.Fatalf("stale fallback must show baked intra flow, got: %s", txt)
+	}
+	if strings.Contains(txt, "xrepo-proc") {
+		t.Errorf("stale sidecar was applied: %s", txt)
+	}
+}
+
+// TestFlowOverlay_MmapPath_Replace: the REPLACE merge also holds on the flag-ON
+// mmap read path (baked flow in graph.fb, cross-repo flow in the sidecar).
+func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
+	forceServeFromMMap(t, true)
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	stateDir := daemon.StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Flat graph.fb so the MCP loader opens a resident mmap Reader.
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), bakedFlowDoc("r1")); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	reg := Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{"r1": {Path: repo}}}}}
+	regPath := filepath.Join(dir, "registry.json")
+	d, _ := json.MarshalIndent(reg, "", "  ")
+	_ = os.WriteFile(regPath, d, 0o644)
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	txt := listAll(t, srv)
+	if !strings.Contains(txt, `"count":1`) || !strings.Contains(txt, "xrepo-proc") {
+		t.Fatalf("mmap REPLACE failed: want single cross-repo flow, got: %s", txt)
+	}
+	if strings.Contains(txt, "baked-proc") {
+		t.Errorf("mmap path leaked baked flow: %s", txt)
+	}
+}
+
+// TestFlowOverlay_RaceConcurrentRebuild exercises concurrent tool reads against
+// a sidecar that is re-published mid-flight (fresh mtime forces re-apply on the
+// Group() serving path). Run with -race.
+func TestFlowOverlay_RaceConcurrentRebuild(t *testing.T) {
+	forceServeFromMMap(t, false)
+	srv, stateDir := newFlowServer(t)
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	// Writers: keep bumping the sidecar mtime so Group() re-applies the overlay.
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = flows.Upsert(stateDir, ents, rels)
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}()
+	}
+	// Readers: drive the real tool concurrently.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				_ = listAll(t, srv)
+			}
+		}()
+	}
+	// Let readers finish, then stop writers.
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+		close(done)
+	}()
+	<-done
+	wg.Wait()
+}

--- a/internal/mcp/flows_overlay_test.go
+++ b/internal/mcp/flows_overlay_test.go
@@ -261,6 +261,51 @@ func TestFlowOverlay_MmapPath_Replace(t *testing.T) {
 	}
 }
 
+// TestFlowOverlay_StepAdjReplace_Mmap proves getStepAdj is REPLACE (not ADD) on
+// the flag-ON mmap path: when the sidecar is applied, the baked SCOPE.Process's
+// STEP_IN_PROCESS adjacency must be GONE and only the sidecar's step edges
+// present. An ADD-instead-of-REPLACE regression leaves the baked "baked-proc"
+// key in the adjacency and this test fails.
+func TestFlowOverlay_StepAdjReplace_Mmap(t *testing.T) {
+	forceServeFromMMap(t, true)
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	stateDir := daemon.StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), bakedFlowDoc("r1")); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	reg := Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{"r1": {Path: repo}}}}}
+	regPath := filepath.Join(dir, "registry.json")
+	d, _ := json.MarshalIndent(reg, "", "  ")
+	_ = os.WriteFile(regPath, d, 0o644)
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ents, rels := crossRepoFlowDelta()
+	if err := flows.Upsert(stateDir, ents, rels); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	lr := srv.State.Group("g").Repos["r1"]
+	if lr == nil {
+		t.Fatal("repo r1 not loaded")
+	}
+	if lr.Reader == nil {
+		t.Fatal("precondition: flag-ON mmap requires a resident Reader")
+	}
+	adj := lr.getStepAdj()
+	if _, present := adj["baked-proc"]; present {
+		t.Errorf("REPLACE violated: baked-proc step adjacency survived (ADD instead of REPLACE): %#v", adj)
+	}
+	if steps := adj["xrepo-proc"]; len(steps) != 3 {
+		t.Errorf("want 3 sidecar step edges for xrepo-proc, got %d: %#v", len(steps), adj["xrepo-proc"])
+	}
+}
+
 // TestFlowOverlay_RaceConcurrentRebuild exercises concurrent tool reads against
 // a sidecar that is re-published mid-flight (fresh mtime forces re-apply on the
 // Group() serving path). Run with -race.

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 )
 
@@ -458,6 +459,20 @@ type LoadedRepo struct {
 	descStampedMt time.Time
 	descFileMt    time.Time
 	descApplied   bool
+
+	// flowOverlay / flowStampedMt / flowFileMt / flowApplied memoize the FLOW
+	// side-table apply (#5904 PR-b), mirroring descApplied for the per-repo
+	// <stateDir>/flows.json sidecar. flowOverlay is the fresh cross-repo-aware
+	// flow DELTA (nil when the sidecar is absent/corrupt/stale). When non-nil the
+	// read path applies REPLACE semantics: the forEach* iterators SUPPRESS the
+	// baked SCOPE.Process/SCOPE.EventFlow entities and INJECT the sidecar's, and
+	// getStepAdj/getCallsAdj rebuild against the sidecar's step/phantom edges.
+	// Re-stamped when EITHER the repo reparsed (lr.mtime advanced) OR the sidecar
+	// file mtime changed. Zero values ("never stamped") always force a (re-)stamp.
+	flowOverlay   *flows.Sidecar
+	flowStampedMt time.Time
+	flowFileMt    time.Time
+	flowApplied   bool
 }
 
 // resetIndexes re-arms every lazy-index sync.Once and clears the cached
@@ -935,12 +950,21 @@ func (lr *LoadedRepo) getCallsAdj() *callsAdjacency {
 		lr.rmu().Lock()
 		rdr := lr.Reader
 		h := lr.handle
+		fo := lr.flowOverlay
 		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
 			lr.callsAdj = buildCallsAdjacencyFromReader(rdr)
 			lr.rmu().Unlock()
 		} else {
 			lr.rmu().Unlock()
 			lr.callsAdj = buildCallsAdjacency(lr.Doc)
+		}
+		// Flow side-table (#5904 PR-b): ADD the sidecar's phantom cross_repo CALLS
+		// edges (which are NOT baked into graph.fb once the write-back stopped
+		// rewriting the graph) so a query-time CALLS walk (traces follow) still sees
+		// the cross-repo terminal steps it saw pre-PR. Additive is safe: phantom
+		// edges are never in the baked set, so no CALLS edge is doubled.
+		if fo != nil {
+			lr.callsAdj.setExtraFromRels(fo.Relationships)
 		}
 	})
 	return lr.callsAdj
@@ -962,12 +986,21 @@ func (lr *LoadedRepo) getStepAdj() map[string][]stepEdge {
 		lr.rmu().Lock()
 		rdr := lr.Reader
 		h := lr.handle
+		fo := lr.flowOverlay
 		if rdr != nil && serveFromMMap() && (h == nil || !h.readRetired) {
 			lr.stepAdj = buildStepAdjacencyFromReader(rdr)
 			lr.rmu().Unlock()
 		} else {
 			lr.rmu().Unlock()
 			lr.stepAdj = buildStepAdjacency(lr.Doc)
+		}
+		// Flow side-table (#5904 PR-b): REPLACE. When a fresh cross-repo flow
+		// overlay is present, the baked STEP_IN_PROCESS adjacency is DISCARDED and
+		// rebuilt purely from the sidecar's step edges — the baked flow entities are
+		// suppressed by forEach*, so their step rows are never queried, and the
+		// cross-repo flows' steps come solely from the sidecar (no doubling).
+		if fo != nil {
+			lr.stepAdj = buildStepAdjacencyFromRels(fo.Relationships)
 		}
 	})
 	return lr.stepAdj
@@ -1575,6 +1608,11 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 		// <stateDir>/descriptions.json onto the group's entities. Absence-tolerant
 		// and per-repo memoized, exactly like the group-algo overlay above.
 		applyDescriptionOverlay(grp)
+		// Flow side-table (#5904 PR-b): REPLACE-stamp any <stateDir>/flows.json —
+		// suppress the baked SCOPE.Process/SCOPE.EventFlow entities + STEP edges and
+		// substitute the cross-repo-aware sidecar's. Absence/stale → no-op (baked
+		// intra flows served). Per-repo memoized like applyDescriptionOverlay.
+		applyFlowOverlay(grp)
 	}
 	// Recompute the tool-surface signature. If it differs from the previous
 	// value the caller will emit notifications/tools/list_changed (#1772).
@@ -1630,6 +1668,10 @@ func (s *State) Group(name string) *LoadedGroup {
 		// per-repo memo inside applyDescriptionOverlay keeps the steady state a
 		// cheap stat-and-skip.
 		applyDescriptionOverlay(grp)
+		// Re-check the per-repo flow side-table on the serving path so a phantom
+		// write-back that advanced <stateDir>/flows.json mid-session takes effect
+		// (REPLACE) without a full Reload. Per-repo memoized → cheap stat-and-skip.
+		applyFlowOverlay(grp)
 	}
 	return grp
 }
@@ -2738,6 +2780,85 @@ func applyDescriptionOverlay(grp *LoadedGroup) {
 		lr.descFileMt = fileMt
 		lr.descApplied = true
 	}
+}
+
+// applyFlowOverlay stamps the per-repo FLOW side-table (#5904 PR-b) onto a
+// loaded group's repos with REPLACE semantics. For each repo it reads
+// <stateDir>/flows.json (absence/corrupt/stale-tolerant) and publishes the
+// cross-repo-aware flow DELTA into lr.flowOverlay. When set, the read path:
+//
+//   - forEach* iterators SUPPRESS the baked SCOPE.Process/SCOPE.EventFlow
+//     entities (from Doc OR Reader) and INJECT the sidecar's cross-repo-aware
+//     ones (flowFilteredYield + injectFlowEntities in view_iter.go).
+//   - getStepAdj REPLACES the STEP_IN_PROCESS adjacency with the sidecar's step
+//     edges; getCallsAdj ADDS the sidecar's phantom cross_repo CALLS edges.
+//
+// This is REPLACE, not additive: graph.fb still carries the index-baked
+// intra-repo flows, so an additive merge would DOUBLE every flow. On
+// absence/stale (ok==false) the overlay is cleared to nil and the baked
+// intra-repo flows are served unchanged (correct degraded state).
+//
+// Memoized PER REPO exactly like applyDescriptionOverlay: re-stamp when the repo
+// reparsed (lr.mtime advanced) OR the sidecar file mtime changed. Publishing the
+// overlay pointer under readerMu (the flag-ON forEach scans read it under the
+// same lock) + re-arming stepOnce/callsOnce under idxMu (so the adjacencies
+// rebuild against the REPLACE set) mirrors resetIndexes' invalidation. Caller
+// holds s.mu.
+func applyFlowOverlay(grp *LoadedGroup) {
+	if grp == nil {
+		return
+	}
+	for _, lr := range grp.Repos {
+		if lr == nil || lr.Doc == nil || lr.Path == "" {
+			continue
+		}
+		stateDir := daemon.StateDirForRepo(lr.Path)
+		var fileMt time.Time
+		if fi, err := os.Stat(flows.Path(stateDir)); err == nil {
+			fileMt = fi.ModTime()
+		}
+		if lr.flowApplied && lr.mtime.Equal(lr.flowStampedMt) && fileMt.Equal(lr.flowFileMt) {
+			continue
+		}
+
+		var next *flows.Sidecar
+		if sc, ok := flows.Read(stateDir); ok {
+			next = sc
+		}
+
+		// Publish under readerMu (read by the flag-ON forEach scans + the adjacency
+		// builders under the same lock).
+		lr.rmu().Lock()
+		lr.flowOverlay = next
+		lr.rmu().Unlock()
+
+		// Re-arm the step/calls adjacencies so the next getStepAdj/getCallsAdj
+		// rebuild against the REPLACE set (mirrors resetIndexes, under idxMu).
+		lr.idxMu.Lock()
+		lr.stepOnce = sync.Once{}
+		lr.stepAdj = nil
+		lr.callsOnce = sync.Once{}
+		lr.callsAdj = nil
+		lr.idxMu.Unlock()
+
+		lr.flowStampedMt = lr.mtime
+		lr.flowFileMt = fileMt
+		lr.flowApplied = true
+	}
+}
+
+// flowOverlaySnapshot returns the repo's current flow overlay pointer, read
+// under readerMu so it is race-safe against a concurrent applyFlowOverlay
+// publish. The sidecar it points at is immutable after publish, so callers may
+// use the returned pointer lock-free.
+func (lr *LoadedRepo) flowOverlaySnapshot() *flows.Sidecar {
+	if lr == nil {
+		return nil
+	}
+	lr.rmu().Lock()
+	fo := lr.flowOverlay
+	lr.rmu().Unlock()
+	return fo
 }
 
 // buildDescTableFromReader builds the entity-INDEX-keyed description side-table

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -362,9 +362,17 @@ type stepEdge struct {
 // Doc.Relationships that the function previously paid on every
 // process-flow query.
 func buildStepAdjacency(doc *graph.Document) map[string][]stepEdge {
+	return buildStepAdjacencyFromRels(doc.Relationships)
+}
+
+// buildStepAdjacencyFromRels builds the STEP_IN_PROCESS forward adjacency from a
+// bare relationship slice. Shared by buildStepAdjacency (Doc-sourced) and the
+// #5904 PR-b flow-overlay REPLACE path (getStepAdj), which rebuilds the
+// adjacency purely from the flow sidecar's cross-repo-aware step edges.
+func buildStepAdjacencyFromRels(rels []graph.Relationship) map[string][]stepEdge {
 	adj := make(map[string][]stepEdge)
-	for i := range doc.Relationships {
-		r := &doc.Relationships[i]
+	for i := range rels {
+		r := &rels[i]
 		if r.Kind != stepInProcessEdge {
 			continue
 		}
@@ -417,6 +425,37 @@ type callsAdjacency struct {
 	nodes   nodeIndex
 	offsets []int32
 	targets []int32 // node-index code of the callee
+	// extra holds ADD-only CALLS edges layered on top of the CSR core — the
+	// #5904 PR-b flow-overlay phantom cross_repo CALLS edges, which are no longer
+	// baked into graph.fb. Keyed by FromID → sorted callee ids. Get merges them
+	// with the CSR row. Never overlaps the CSR set (phantom edges are new), so no
+	// callee is doubled.
+	extra map[string][]string
+}
+
+// setExtraFromRels populates the ADD-only phantom CALLS layer from a flow
+// sidecar's relationship slice (#5904 PR-b). Only CALLS edges are taken; each
+// FromID row is sorted for followCallsBFS determinism.
+func (c *callsAdjacency) setExtraFromRels(rels []graph.Relationship) {
+	if c == nil {
+		return
+	}
+	extra := make(map[string][]string)
+	for i := range rels {
+		r := &rels[i]
+		if r.Kind != "CALLS" {
+			continue
+		}
+		extra[r.FromID] = append(extra[r.FromID], r.ToID)
+	}
+	for k := range extra {
+		sort.Strings(extra[k])
+	}
+	if len(extra) == 0 {
+		c.extra = nil
+		return
+	}
+	c.extra = extra
 }
 
 // Get returns the sorted list of callee ids for id (nil when id is unknown or
@@ -427,17 +466,28 @@ func (c *callsAdjacency) Get(id string) []string {
 	if c == nil {
 		return nil
 	}
-	code, ok := c.nodes.lookup(id)
-	if !ok || int(code) >= len(c.offsets)-1 {
-		return nil
+	var out []string
+	if code, ok := c.nodes.lookup(id); ok && int(code) < len(c.offsets)-1 {
+		start, end := c.offsets[code], c.offsets[code+1]
+		if start != end {
+			out = make([]string, end-start)
+			for i := start; i < end; i++ {
+				out[i-start] = c.nodes.ids[c.targets[i]]
+			}
+		}
 	}
-	start, end := c.offsets[code], c.offsets[code+1]
-	if start == end {
-		return nil
-	}
-	out := make([]string, end-start)
-	for i := start; i < end; i++ {
-		out[i-start] = c.nodes.ids[c.targets[i]]
+	// #5904 PR-b: merge the ADD-only phantom CALLS layer (never overlaps the CSR
+	// core). Re-sort when both sources contribute so followCallsBFS's branching
+	// cap stays deterministic.
+	if c.extra != nil {
+		if ex := c.extra[id]; len(ex) > 0 {
+			if out == nil {
+				out = append([]string(nil), ex...)
+			} else {
+				out = append(out, ex...)
+				sort.Strings(out)
+			}
+		}
 	}
 	return out
 }

--- a/internal/mcp/view_iter.go
+++ b/internal/mcp/view_iter.go
@@ -14,6 +14,7 @@ package mcp
 import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/flows"
 )
 
 // forEachEntity calls yield for every entity in lr, in index order. yield
@@ -48,9 +49,23 @@ func (lr *LoadedRepo) forEachEntity(yield func(*graph.Entity) bool) {
 	if lr == nil {
 		return
 	}
+	// Flow side-table (#5904 PR-b): REPLACE. When a fresh cross-repo flow overlay
+	// is present, SUPPRESS baked SCOPE.Process/SCOPE.EventFlow entities from the
+	// base source (flowFilteredYield) and INJECT the sidecar's cross-repo-aware
+	// flow entities after the base scan (injectFlowEntities). fo==nil → unchanged.
+	fo := lr.flowOverlaySnapshot()
+	if !lr.forEachEntityBase(flowFilteredYield(fo, yield)) {
+		return // base scan stopped early; do not inject
+	}
+	injectFlowEntities(fo, nil, yield)
+}
+
+// forEachEntityBase is the base entity source (Doc or mmap Reader) for
+// forEachEntity — the pre-#5904-PR-b body. It returns false iff yield stopped
+// the scan early (so the caller skips flow injection).
+func (lr *LoadedRepo) forEachEntityBase(yield func(*graph.Entity) bool) bool {
 	if !serveFromMMap() {
-		lr.forEachDocEntity(yield)
-		return
+		return lr.forEachDocEntity(yield)
 	}
 
 	// Flag-ON: strictly-innermost readerMu held across the WHOLE scan (Option-B
@@ -60,8 +75,7 @@ func (lr *LoadedRepo) forEachEntity(yield func(*graph.Entity) bool) {
 	h := lr.handle
 	if rdr == nil || (h != nil && h.readRetired) {
 		lr.rmu().Unlock()
-		lr.forEachDocEntity(yield)
-		return
+		return lr.forEachDocEntity(yield)
 	}
 	defer lr.rmu().Unlock()
 
@@ -75,9 +89,45 @@ func (lr *LoadedRepo) forEachEntity(yield func(*graph.Entity) bool) {
 	for i := 0; i < n; i++ {
 		e := materializeEntityOverlay(rdr, overlay, descOverlay, int32(i))
 		if !yield(e) {
-			return
+			return false
 		}
 	}
+	return true
+}
+
+// flowFilteredYield wraps yield so that, when a flow overlay is active, baked
+// flow entities (SCOPE.Process / SCOPE.EventFlow) are SKIPPED from the base
+// source — they are substituted by injectFlowEntities (REPLACE). fo==nil returns
+// yield unchanged (zero overhead on the no-overlay path).
+func flowFilteredYield(fo *flows.Sidecar, yield func(*graph.Entity) bool) func(*graph.Entity) bool {
+	if fo == nil {
+		return yield
+	}
+	return func(e *graph.Entity) bool {
+		if flows.IsFlowEntityKind(e.Kind) {
+			return true // suppress baked flow entity; substituted below
+		}
+		return yield(e)
+	}
+}
+
+// injectFlowEntities yields each overlay flow entity whose kind satisfies pred
+// (nil pred = every overlay entity). Returns false if yield stopped early. A nil
+// overlay is a no-op.
+func injectFlowEntities(fo *flows.Sidecar, pred func(kind string) bool, yield func(*graph.Entity) bool) bool {
+	if fo == nil {
+		return true
+	}
+	for i := range fo.Entities {
+		e := &fo.Entities[i]
+		if pred != nil && !pred(e.Kind) {
+			continue
+		}
+		if !yield(e) {
+			return false
+		}
+	}
+	return true
 }
 
 // forEachEntityOfKinds is the by-Kind analogue of forEachEntity (memory epic
@@ -106,38 +156,52 @@ func (lr *LoadedRepo) forEachEntityOfKinds(pred func(kind string) bool, yield fu
 	if lr == nil || pred == nil {
 		return
 	}
+	// Flow side-table (#5904 PR-b): REPLACE. Suppress baked flow entities from the
+	// base by-Kind scan (only relevant when pred matches a flow kind) and inject
+	// the sidecar's cross-repo-aware flow entities that also satisfy pred.
+	fo := lr.flowOverlaySnapshot()
+	if !lr.forEachEntityOfKindsBase(pred, flowFilteredYield(fo, yield)) {
+		return
+	}
+	injectFlowEntities(fo, pred, yield)
+}
+
+// forEachEntityOfKindsBase is the base by-Kind entity source (the pre-#5904-PR-b
+// body). Returns false iff yield stopped the scan early.
+func (lr *LoadedRepo) forEachEntityOfKindsBase(pred func(kind string) bool, yield func(*graph.Entity) bool) bool {
 	li := lr.LabelIndex
 	if li == nil || li.byKind == nil {
 		// No by-Kind index — preserve output via a filtered full scan (no
-		// selective materialization on this fallback).
-		lr.forEachEntity(func(e *graph.Entity) bool {
+		// selective materialization on this fallback). forEachEntityBase (not the
+		// public forEachEntity) so flow suppression/injection is applied exactly
+		// once, by the public forEachEntityOfKinds wrapper.
+		return lr.forEachEntityBase(func(e *graph.Entity) bool {
 			if !pred(e.Kind) {
 				return true
 			}
 			return yield(e)
 		})
-		return
 	}
 	idxs := li.indicesForKinds(pred)
 	if len(idxs) == 0 {
-		return
+		return true
 	}
 
 	if !serveFromMMap() {
 		// Flag-OFF: Doc-sourced, same &Doc.Entities[idx] pointer semantics as
 		// forEachEntity's flag-off branch.
 		if lr.Doc == nil {
-			return
+			return true
 		}
 		for _, idx := range idxs {
 			if int(idx) >= len(lr.Doc.Entities) {
 				continue
 			}
 			if !yield(&lr.Doc.Entities[idx]) {
-				return
+				return false
 			}
 		}
-		return
+		return true
 	}
 
 	// Flag-ON: strictly-innermost readerMu held across the WHOLE scan (Option-B
@@ -147,8 +211,7 @@ func (lr *LoadedRepo) forEachEntityOfKinds(pred func(kind string) bool, yield fu
 	h := lr.handle
 	if rdr == nil || (h != nil && h.readRetired) {
 		lr.rmu().Unlock()
-		lr.forEachDocEntityOfIdxs(idxs, yield)
-		return
+		return lr.forEachDocEntityOfIdxs(idxs, yield)
 	}
 	defer lr.rmu().Unlock()
 
@@ -165,40 +228,44 @@ func (lr *LoadedRepo) forEachEntityOfKinds(pred func(kind string) bool, yield fu
 		}
 		e := materializeEntityOverlay(rdr, overlay, descOverlay, idx)
 		if !yield(e) {
-			return
+			return false
 		}
 	}
+	return true
 }
 
 // forEachDocEntityOfIdxs yields &lr.Doc.Entities[idx] for each index in idxs (in
 // the given order), the Doc-sourced path shared by forEachEntityOfKinds's flag-ON
 // retired/nil-Reader fallback. Callers must NOT hold readerMu (this touches only
 // the Doc).
-func (lr *LoadedRepo) forEachDocEntityOfIdxs(idxs []int32, yield func(*graph.Entity) bool) {
+func (lr *LoadedRepo) forEachDocEntityOfIdxs(idxs []int32, yield func(*graph.Entity) bool) bool {
 	if lr.Doc == nil {
-		return
+		return true
 	}
 	for _, idx := range idxs {
 		if int(idx) >= len(lr.Doc.Entities) {
 			continue
 		}
 		if !yield(&lr.Doc.Entities[idx]) {
-			return
+			return false
 		}
 	}
+	return true
 }
 
 // forEachDocEntity is the Doc-sourced path shared by forEachEntity's flag-off
-// branch and its flag-on retired/nil-Reader fallback.
-func (lr *LoadedRepo) forEachDocEntity(yield func(*graph.Entity) bool) {
+// branch and its flag-on retired/nil-Reader fallback. Returns false iff yield
+// stopped the scan early.
+func (lr *LoadedRepo) forEachDocEntity(yield func(*graph.Entity) bool) bool {
 	if lr.Doc == nil {
-		return
+		return true
 	}
 	for i := range lr.Doc.Entities {
 		if !yield(&lr.Doc.Entities[i]) {
-			return
+			return false
 		}
 	}
+	return true
 }
 
 // materializeEntityOverlay decodes the i-th entity from the mmap Reader and


### PR DESCRIPTION
## What

Moves the cross-repo **phantom-edge / flow-entity** enrichment (the last #5915 graph-rewriting writeback) off `graph.fb` and onto a per-repo **side-table** (`<stateDir>/flows.json`), merged at read time with **REPLACE semantics** across all consumer seams. Companion to PR-a (descriptions). **Option C** (store the synthesized entities; cheap uniform merge) — chosen over recompute-at-read because the flows are read through **three** seams.

## Why REPLACE (not additive)
Flow entities have two producers: the normal index bakes INTRA-repo `SCOPE.Process`/`SCOPE.EventFlow` into `graph.fb`; the phantom pass re-synthesizes cross-repo-AWARE ones. So `graph.fb` keeps the baked intra flows and the overlay must **suppress** them + **substitute** the sidecar's + **add** the phantom `cross_repo` CALLS — a naive additive merge would double every flow. Enforced at one point: `flows.Apply` = `StripBakedFlows` (removes `SCOPE.Process`/`SCOPE.EventFlow` + `ENTRY_POINT_OF`/`STEP_IN_PROCESS`/`SEED_OF_EVENT_FLOW`/`STEP_IN_EVENT_FLOW`) → substitute → add phantom CALLS.

## Three seams (all covered)
- **MCP** — `flowOverlay` on `LoadedRepo` (memoized, under `readerMu`); `view_iter.go` suppress+inject on Doc AND mmap paths; `getStepAdj` REPLACE; `getCallsAdj` ADD phantom CALLS.
- **Dashboard** — `flows.MergeInto` at the `graphstate.go` load point (after PR-a's description merge).
- **JSON/offline export** — `loadGroupGraphForExport` merges per-repo; v2 zip ships `flows.json`.

## Writeback
`runPhantomEdgePass` computation unchanged; sink swapped from `WriteGraphGen`/`WriteAtomic` to `extractFlowDelta`+`flows.Upsert`. `graph.fb` never rewritten. The pass (sole writer) clears stale sidecars for no-longer-affected repos, including the total-link-removal case.

## Verification (independent adversarial review — APPROVE, incl. a REQUEST-CHANGES round)
- Doubling guarded at all 5 seams (additive mutation → RED on Doc + mmap, driving the real `grafel_traces` tool).
- Strip exactness: over-strip (drops real `function`s) → RED; strip set matches the synthesizer's emitted kinds exactly.
- 3 seams independently wired; staleness→baked fallback; no-graph-rewrite (`WriteAtomic` reinsert → RED); composition with PR-a descOverlay; `-race` clean.
- Round-2 fixes: empty-links stale-sidecar leak closed (reinstate early-return → RED); full `SCOPE.EventFlow` REPLACE coverage added (drop event-flow strip kind → RED with dangling baked edges); getStepAdj REPLACE mmap test.

Segment-set mmap serving is Doc-path-only until #5912 (noted).

Refs #5904
Refs #5915

🤖 Generated with [Claude Code](https://claude.com/claude-code)