### PR TITLE
fix(#5915 J2 slice-2): segment-set-aware dashboard existence/freshness gates

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -216,11 +216,16 @@ func (g *DashGroup) diskUnchanged() bool {
 	return true
 }
 
-// statGraphMtime returns the modification time of the graph.fb in stateDir,
-// falling back to graph.json, or the zero time when neither exists.
+// statGraphMtime returns the modification time of the active graph in
+// stateDir (single-file .fb or segment-set manifest.json, via
+// graph.CurrentGraphMtime), falling back to graph.json, or the zero time
+// when neither exists. #5915 J2 slice-2: the old
+// os.Stat(graph.CurrentGraphPath(stateDir)) gate only ever resolved a flat
+// .fb path, so a segment-set repo (graph.<gen>/ dir + manifest.json, no flat
+// .fb) fell straight through to the zero time here.
 func statGraphMtime(stateDir string) time.Time {
-	if info, e := os.Stat(graph.CurrentGraphPath(stateDir)); e == nil { // #5891
-		return info.ModTime()
+	if mt, ok := graph.CurrentGraphMtime(stateDir); ok { // #5891, #5915 J2 slice-2
+		return mt
 	}
 	if info, e := os.Stat(filepath.Join(stateDir, "graph.json")); e == nil {
 		return info.ModTime()

--- a/internal/dashboard/graphstate_statmtime_segmentset_test.go
+++ b/internal/dashboard/graphstate_statmtime_segmentset_test.go
@@ -1,0 +1,67 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// TestStatGraphMtime_SegmentSet is the RED test for #5915 J2 slice-2:
+// statGraphMtime (the freshness signal behind DashGroup.diskUnchanged's
+// per-repo mtime-keyed cache, #50) must resolve a SEGMENT-SET stateDir
+// (graph.<gen>/ dir + manifest.json, no flat graph.fb) to the manifest.json
+// mtime, not the zero time. The pre-fix os.Stat(graph.CurrentGraphPath(dir))
+// gate only ever resolves a flat .fb path.
+func TestStatGraphMtime_SegmentSet(t *testing.T) {
+	stateDir := t.TempDir()
+	mtime := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	writeDashboardSegmentSetFixture(t, stateDir, 5, mtime)
+
+	got := statGraphMtime(stateDir)
+	if got.IsZero() {
+		t.Fatal("statGraphMtime(segment-set dir) = zero time, want the manifest.json mtime")
+	}
+	if !got.Equal(mtime) {
+		t.Fatalf("statGraphMtime(segment-set dir) = %v, want %v", got, mtime)
+	}
+}
+
+// TestStatGraphMtime_SingleFileParity guards the single-gen-file (and legacy
+// flat) case stays byte-identical to the pre-fix os.Stat behavior.
+func TestStatGraphMtime_SingleFileParity(t *testing.T) {
+	stateDir := t.TempDir()
+	doc := &graph.Document{Repo: "single", Entities: []graph.Entity{
+		{ID: "aaaa0001", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	fbPath := filepath.Join(stateDir, graph.GenFileName(1))
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(stateDir, graph.GenFileName(1)); err != nil {
+		t.Fatal(err)
+	}
+	want, err := os.Stat(fbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := statGraphMtime(stateDir)
+	if got.IsZero() {
+		t.Fatal("statGraphMtime(single-file dir) = zero time, want the .fb mtime (parity)")
+	}
+	if !got.Equal(want.ModTime()) {
+		t.Fatalf("statGraphMtime(single-file dir) = %v, want %v (parity)", got, want.ModTime())
+	}
+}
+
+// TestStatGraphMtime_Absent guards a never-indexed dir still reads zero.
+func TestStatGraphMtime_Absent(t *testing.T) {
+	stateDir := t.TempDir()
+	if got := statGraphMtime(stateDir); !got.IsZero() {
+		t.Fatalf("statGraphMtime(never-indexed dir) = %v, want zero", got)
+	}
+}

--- a/internal/dashboard/handlers_ref_endpoints.go
+++ b/internal/dashboard/handlers_ref_endpoints.go
@@ -634,17 +634,23 @@ func (s *Server) handleGroupRefs(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe)) // #5891
-			fi, ferr := os.Stat(fbPath)
-			if ferr != nil {
-				// No graph.fb — try graph.json.
+			// #5891, #5915 J2 slice-2: CurrentGraphMtime resolves the active
+			// graph's mtime segment-set aware (manifest.json), unlike
+			// os.Stat(graph.CurrentGraphPath(...)) which only ever resolved a
+			// flat .fb path and reported a segment-set ref as absent.
+			refDir := filepath.Join(refsDir, refSafe)
+			var mtime time.Time
+			if mt, ok := graph.CurrentGraphMtime(refDir); ok {
+				mtime = mt
+			} else {
+				// No active fb graph — try graph.json.
 				jsonPath := filepath.Join(refsDir, refSafe, "graph.json")
-				fi, ferr = os.Stat(jsonPath)
+				fi, ferr := os.Stat(jsonPath)
 				if ferr != nil {
 					continue
 				}
+				mtime = fi.ModTime()
 			}
-			mtime := fi.ModTime()
 
 			// Entity count from sidecar.
 			var entityCount int

--- a/internal/dashboard/handlers_ref_endpoints_test.go
+++ b/internal/dashboard/handlers_ref_endpoints_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
@@ -564,5 +565,84 @@ func TestRefEndpoints_CORSNotRegressed(t *testing.T) {
 				t.Errorf("CORS regression: OPTIONS %s returned 405", ep)
 			}
 		})
+	}
+}
+
+// TestHandleGroupRefs_SegmentSetRefIncluded is the RED test for #5915 J2
+// slice-2: a ref indexed as a SEGMENT-SET (graph.<gen>/ dir + manifest.json,
+// no flat graph.fb, no graph.json) must be aggregated into the GET
+// /api/groups/:g/refs response. The pre-fix
+// os.Stat(graph.CurrentGraphPath(refDir)) + graph.json fallback gate only
+// ever resolves a flat .fb path, so the segment-set-only ref was silently
+// skipped.
+func TestHandleGroupRefs_SegmentSetRefIncluded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	storeRoot := filepath.Join(home, "store")
+	t.Setenv("GRAFEL_DAEMON_ROOT", storeRoot)
+
+	groupName := "seggroup"
+	repoSlug := "segrepo"
+	repoPath := filepath.Join(home, "segrepo-src")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	cfg := &registry.GroupConfig{Name: groupName, Repos: []registry.Repo{{Slug: repoSlug, Path: repoPath}}}
+	cfgDir := filepath.Join(home, "groups")
+	_ = os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, groupName+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	_ = os.WriteFile(cfgPath, raw, 0o644)
+
+	regRaw, _ := json.Marshal(map[string]any{
+		"version": 1,
+		"groups":  []map[string]any{{"name": groupName, "config_path": cfgPath}},
+	})
+	_ = os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644)
+
+	segRefDir := daemon.StateDirForRepoRef(repoPath, "wip-seg")
+	if err := os.MkdirAll(segRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Now().Add(-1 * time.Hour).UTC().Truncate(time.Second)
+	writeDashboardSegmentSetFixture(t, segRefDir, 6, mtime)
+
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	quiesceGraphCache(t, srv)
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/groups/" + groupName + "/refs")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		Refs []struct {
+			Name          string  `json:"name"`
+			LastIndexedAt *string `json:"last_indexed_at"`
+		} `json:"refs"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	var found bool
+	for _, r := range body.Refs {
+		if r.Name == "wip-seg" {
+			found = true
+			if r.LastIndexedAt == nil {
+				t.Error("segment-set ref 'wip-seg' has nil last_indexed_at, want the manifest.json mtime")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("segment-set ref 'wip-seg' missing from refs=%v", body.Refs)
 	}
 }

--- a/internal/dashboard/handlers_v2_refs.go
+++ b/internal/dashboard/handlers_v2_refs.go
@@ -147,12 +147,16 @@ func (s *Server) handleV2GroupRefs(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			// Check for a graph.fb in this ref slot. #5891: resolve active gen.
-			fbPath := graph.CurrentGraphPath(filepath.Join(refsDir, refSafe))
+			// Check for an active graph in this ref slot. #5891: resolve active
+			// gen. #5915 J2 slice-2: graph.CurrentGraphMtime is segment-set aware
+			// (manifest.json mtime), unlike os.Stat(graph.CurrentGraphPath(...))
+			// which only ever resolved a flat .fb path and reported a segment-set
+			// slot (graph.<gen>/ dir + manifest.json, no flat .fb) as absent.
+			refDir := filepath.Join(refsDir, refSafe)
 			var indexedAt *time.Time
 			var entityCount int
-			if fi, ferr := os.Stat(fbPath); ferr == nil {
-				t := fi.ModTime()
+			if mt, ok := graph.CurrentGraphMtime(refDir); ok {
+				t := mt
 				indexedAt = &t
 				// Try to read entity count from graph-stats.json sidecar.
 				statsPath := filepath.Join(refsDir, refSafe, "graph-stats.json")
@@ -165,7 +169,7 @@ func (s *Server) handleV2GroupRefs(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 			} else {
-				// No graph.fb — slot may exist but graph was never written.
+				// No active graph — slot may exist but graph was never written.
 				continue
 			}
 

--- a/internal/dashboard/handlers_v2_refs_test.go
+++ b/internal/dashboard/handlers_v2_refs_test.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/registry"
 )
 
@@ -241,5 +243,97 @@ func TestHandleV2GroupRefs_EmptyRefsWhenNeverIndexed(t *testing.T) {
 	}
 	if len(body.Data.Repos[0].Refs) != 0 {
 		t.Errorf("want empty refs for never-indexed repo, got %d entries", len(body.Data.Repos[0].Refs))
+	}
+}
+
+// TestHandleV2GroupRefs_SegmentSetRef is the RED test for #5915 J2 slice-2: a
+// ref indexed as a SEGMENT-SET (graph.<gen>/ dir + manifest.json, no flat
+// graph.fb) must appear in the GET /api/v2/groups/:group/refs response with
+// a non-nil indexed_at. The pre-fix os.Stat(graph.CurrentGraphPath(refDir))
+// gate only ever resolves a flat .fb path, so the slot was silently dropped
+// ("graph was never written").
+func TestHandleV2GroupRefs_SegmentSetRef(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	storeRoot := filepath.Join(home, "store")
+	t.Setenv("GRAFEL_DAEMON_ROOT", storeRoot)
+
+	groupName := "seggroup"
+	repoPath := filepath.Join(home, "segrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	cfg := &registry.GroupConfig{Name: groupName, Repos: []registry.Repo{{Slug: "svc", Path: repoPath}}}
+	cfgDir := filepath.Join(home, "groups")
+	os.MkdirAll(cfgDir, 0o755)
+	cfgPath := filepath.Join(cfgDir, groupName+".fleet.json")
+	raw, _ := json.Marshal(cfg)
+	os.WriteFile(cfgPath, raw, 0o644)
+
+	regRaw, _ := json.Marshal(map[string]any{
+		"version": 1,
+		"groups":  []map[string]any{{"name": groupName, "config_path": cfgPath}},
+	})
+	os.WriteFile(filepath.Join(home, "registry.json"), regRaw, 0o644)
+
+	// Build a segment-set ref dir directly under the store: refs/<refSafe>/.
+	sentinel := daemon.StateDirForRepoRef(repoPath, "")
+	refsDir := filepath.Dir(sentinel)
+	segRefDir := filepath.Join(refsDir, "wip-seg")
+	if err := os.MkdirAll(segRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mtime := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	writeDashboardSegmentSetFixture(t, segRefDir, 4, mtime)
+
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	quiesceGraphCache(t, srv)
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/" + groupName + "/refs")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			Repos []struct {
+				Slug string `json:"slug"`
+				Refs []struct {
+					Ref       string  `json:"ref"`
+					IndexedAt *string `json:"indexed_at"`
+				} `json:"refs"`
+			} `json:"repos"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Fatal("want ok=true")
+	}
+	if len(body.Data.Repos) != 1 {
+		t.Fatalf("want 1 repo, got %d", len(body.Data.Repos))
+	}
+	var found bool
+	for _, ref := range body.Data.Repos[0].Refs {
+		if ref.Ref == "wip-seg" {
+			found = true
+			if ref.IndexedAt == nil {
+				t.Error("segment-set ref 'wip-seg' has nil indexed_at, want the manifest.json mtime")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("segment-set ref 'wip-seg' missing from refs=%v (dropped as 'graph never written')", body.Data.Repos[0].Refs)
 	}
 }

--- a/internal/dashboard/ref_helper.go
+++ b/internal/dashboard/ref_helper.go
@@ -100,10 +100,12 @@ func knownRefsForGroup(groupName string) []string {
 			// Only count refs that have an actual graph. #5891: resolve the
 			// active generation (graph.<gen>.fb via the `current` pointer); a
 			// fresh repo has no flat graph.fb, so the hardcoded stat dropped the
-			// ref → ?ref=<branch> 400s. Mirror allRefsForRepo; keep the graph.json
-			// fallback so a json-only ref dir is still included (CurrentGraphPath
-			// returns the non-existent flat graph.fb path for a json-only dir).
-			if _, ferr := os.Stat(graph.CurrentGraphPath(filepath.Join(refsDir, e.Name()))); ferr != nil {
+			// ref → ?ref=<branch> 400s. #5915 J2 slice-2: CurrentGraphDescriptor
+			// additionally recognises the segment-set layout (graph.<gen>/ dir +
+			// manifest.json, no flat .fb), which the old os.Stat(CurrentGraphPath)
+			// gate reported as absent. Mirror allRefsForRepo; keep the graph.json
+			// fallback so a json-only ref dir is still included.
+			if desc, derr := graph.CurrentGraphDescriptor(filepath.Join(refsDir, e.Name())); derr != nil || desc.Kind == graph.GraphAbsent {
 				if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
 					continue
 				}
@@ -140,7 +142,7 @@ func allRefsForRepo(repoPath string) []string {
 		if ref == "" {
 			continue
 		}
-		if _, ferr := os.Stat(graph.CurrentGraphPath(filepath.Join(refsDir, e.Name()))); ferr != nil { // #5891
+		if desc, derr := graph.CurrentGraphDescriptor(filepath.Join(refsDir, e.Name())); derr != nil || desc.Kind == graph.GraphAbsent { // #5891, #5915 J2 slice-2
 			if _, ferr2 := os.Stat(filepath.Join(refsDir, e.Name(), "graph.json")); ferr2 != nil {
 				continue
 			}

--- a/internal/dashboard/ref_helper_gen_test.go
+++ b/internal/dashboard/ref_helper_gen_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
@@ -102,5 +103,80 @@ func TestKnownRefsForGroup_GenOnlyRefIncluded(t *testing.T) {
 	}
 	if ref != "main" || isAll {
 		t.Fatalf("resolveRefParam(?ref=main) = (%q, isAll=%v), want (main, false)", ref, isAll)
+	}
+}
+
+// TestKnownRefsForGroup_SegmentSetRefIncluded is the RED test for #5915 J2
+// slice-2: a ref indexed as a SEGMENT-SET (graph.<gen>/ dir + manifest.json,
+// no flat graph.fb, no graph.json) must be reported present by
+// knownRefsForGroup. The pre-fix os.Stat(graph.CurrentGraphPath(refDir))
+// gate only ever resolves a flat .fb path, so it dropped the ref (400 on
+// ?ref=<branch>).
+func TestKnownRefsForGroup_SegmentSetRefIncluded(t *testing.T) {
+	const group, slug = "seggroup", "segrepo"
+	repoPath := registerRefFixture(t, group, slug)
+
+	segRefDir := daemon.StateDirForRepoRef(repoPath, "wip-seg")
+	if err := os.MkdirAll(segRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDashboardSegmentSetFixture(t, segRefDir, 3, time.Time{})
+	if _, err := os.Stat(filepath.Join(segRefDir, "graph.fb")); err == nil {
+		t.Fatal("precondition: a flat graph.fb exists -- segment-set layout must not create it")
+	}
+	if _, err := os.Stat(filepath.Join(segRefDir, "graph.json")); err == nil {
+		t.Fatal("precondition: a graph.json exists -- must not mask the segment-set-only case")
+	}
+
+	known := knownRefsForGroup(group)
+	has := func(want string) bool {
+		for _, k := range known {
+			if k == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has("wip-seg") {
+		t.Fatalf("segment-set ref 'wip-seg' dropped from knownRefsForGroup=%v (would 400 on ?ref=wip-seg)", known)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/groups/"+group+"/stats?ref=wip-seg", nil)
+	rec := httptest.NewRecorder()
+	ref, isAll, ok := resolveRefParam(rec, req, group)
+	if !ok {
+		t.Fatalf("resolveRefParam(?ref=wip-seg) rejected with %d (segment-set ref treated as invalid)", rec.Code)
+	}
+	if ref != "wip-seg" || isAll {
+		t.Fatalf("resolveRefParam(?ref=wip-seg) = (%q, isAll=%v), want (wip-seg, false)", ref, isAll)
+	}
+}
+
+// TestAllRefsForRepo_SegmentSetRefIncluded guards the allRefsForRepo sibling
+// (used by the group-refs aggregation path) against the same #5915 J2
+// slice-2 gap: a segment-set-only ref must be included.
+func TestAllRefsForRepo_SegmentSetRefIncluded(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, "store"))
+
+	repoPath := filepath.Join(home, "myrepo")
+	_ = os.MkdirAll(repoPath, 0o755)
+
+	segRefDir := daemon.StateDirForRepoRef(repoPath, "wip-seg")
+	if err := os.MkdirAll(segRefDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeDashboardSegmentSetFixture(t, segRefDir, 3, time.Time{})
+
+	refs := allRefsForRepo(repoPath)
+	found := false
+	for _, r := range refs {
+		if r == "wip-seg" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("segment-set ref 'wip-seg' dropped from allRefsForRepo=%v", refs)
 	}
 }

--- a/internal/dashboard/segmentset_fixture_test.go
+++ b/internal/dashboard/segmentset_fixture_test.go
@@ -1,0 +1,53 @@
+// segmentset_fixture_test.go — shared segment-set fixture builder for the
+// #5915 J2 slice-2 dashboard existence/freshness gate tests.
+//
+// A SEGMENT-SET repo has NO flat graph.fb: instead `current` points at a
+// graph.<gen>/ dir holding seg-NNNN.fb files + manifest.json. The pre-slice-2
+// dashboard gates hardcoded os.Stat(graph.CurrentGraphPath(dir)), which only
+// ever resolves a flat .fb path, so they silently reported such a repo as
+// "never indexed" / mtime-zero. Mirrors the fixture builders already used at
+// internal/daemon/state_path_graphfbexists_test.go,
+// internal/daemon/deadref_segmentset_test.go and internal/graph/segmentset_test.go.
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeDashboardSegmentSetFixture hand-builds a 1-segment gen dir
+// (graph.<gen>/ with seg-0000.fb + manifest.json) under dir, points
+// `current` at it, and stamps manifest.json (the segment-set's atomic commit
+// point) with mtime.
+func writeDashboardSegmentSetFixture(t *testing.T, dir string, gen uint64, mtime time.Time) {
+	t.Helper()
+	genDir := filepath.Join(dir, graph.GenDirName(gen))
+	doc := &graph.Document{Repo: "seg", Entities: []graph.Entity{
+		{ID: "aa1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+	}}
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities, EntityCount: 1,
+		MinKey: "aa1", MaxKey: "aa1",
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	manifestPath := filepath.Join(genDir, graph.ManifestFileName)
+	if !mtime.IsZero() {
+		if err := os.Chtimes(manifestPath, mtime, mtime); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := graph.WriteCurrentPointerRaw(dir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -96,15 +96,19 @@ func aggregateGroupStats(groupName string, repos []registry.Repo) (entityCount i
 						latest = ps.ComputedAt
 					}
 				default:
-					// No header timestamp — fall back to graph.fb mtime.
-					if info, e2 := os.Stat(graph.CurrentGraphPath(stateDir)); e2 == nil && info.ModTime().After(latest) {
-						latest = info.ModTime()
+					// No header timestamp — fall back to the active graph's
+					// mtime. #5915 J2 slice-2: CurrentGraphMtime is segment-set
+					// aware (manifest.json mtime), unlike
+					// os.Stat(CurrentGraphPath(stateDir)) which only ever resolves
+					// a flat .fb path.
+					if mt, ok := graph.CurrentGraphMtime(stateDir); ok && mt.After(latest) {
+						latest = mt
 					}
 				}
-			} else if info, e2 := os.Stat(graph.CurrentGraphPath(stateDir)); e2 == nil {
-				// graph.fb unreadable but present — fall back to its mtime.
-				if info.ModTime().After(latest) {
-					latest = info.ModTime()
+			} else if mt, ok := graph.CurrentGraphMtime(stateDir); ok {
+				// graph unreadable but present — fall back to its mtime.
+				if mt.After(latest) {
+					latest = mt
 				}
 			}
 			continue

--- a/internal/dashboard/store_coldstats_test.go
+++ b/internal/dashboard/store_coldstats_test.go
@@ -86,3 +86,64 @@ func TestAggregateGroupStats_TrulyNeverIndexed(t *testing.T) {
 		t.Errorf("lastIndexed = %v, want zero", lastIndexed)
 	}
 }
+
+// TestAggregateGroupStats_SegmentSetUnreadableHeader is the RED test for
+// #5915 J2 slice-2: a SEGMENT-SET repo (graph.<gen>/ dir + manifest.json,
+// no flat graph.fb) whose segment file cannot be opened as a FlatBuffers
+// graph (graph.PersistedStatsFromDir returns ok=false, mirroring a corrupt
+// single .fb file) must still fall back to the manifest.json mtime via
+// graph.CurrentGraphMtime as last-indexed -- not the zero time from the old
+// os.Stat(graph.CurrentGraphPath(stateDir)) gate, which only ever resolves a
+// flat .fb path and is therefore always absent for a segment-set repo.
+func TestAggregateGroupStats_SegmentSetUnreadableHeader(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+	registryStatsMu.Lock()
+	delete(registryStatsCache, "seggrp")
+	registryStatsMu.Unlock()
+
+	repoPath := filepath.Join(tmpDir, "segrepo")
+	os.MkdirAll(repoPath, 0o755)
+	stateDir := daemon.StateDirForRepo(repoPath)
+	os.MkdirAll(stateDir, 0o755)
+
+	mtime := time.Now().Add(-9 * time.Minute).UTC().Truncate(time.Second)
+	genDir := filepath.Join(stateDir, graph.GenDirName(7))
+	segName := graph.SegmentFileName(0)
+	// The manifest names a segment file that is never written -- opening it
+	// fails cleanly (no such file), so PersistedStatsFromDir returns ok=false
+	// even though the manifest + current pointer are otherwise valid.
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: segName, Kind: graph.SegmentEntities, EntityCount: 1,
+		MinKey: "aa1", MaxKey: "aa1",
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	manifestPath := filepath.Join(genDir, graph.ManifestFileName)
+	if err := os.Chtimes(manifestPath, mtime, mtime); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(7)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+	if _, ok := graph.PersistedStatsFromDir(stateDir); ok {
+		t.Fatal("precondition: PersistedStatsFromDir must fail to open the corrupt segment")
+	}
+	if _, err := os.Stat(filepath.Join(stateDir, "graph-stats.json")); !os.IsNotExist(err) {
+		t.Fatalf("expected no sidecar, stat err = %v", err)
+	}
+
+	repos := []registry.Repo{{Slug: "segrepo", Path: repoPath}}
+	_, lastIndexed := aggregateGroupStats("seggrp", repos)
+
+	if lastIndexed.IsZero() {
+		t.Fatal("lastIndexed is zero, want the segment-set manifest.json mtime")
+	}
+	if !lastIndexed.Equal(mtime) {
+		t.Errorf("lastIndexed = %v, want %v", lastIndexed, mtime)
+	}
+}


### PR DESCRIPTION
## What

The last flat-`graph.fb`-only existence/freshness gates — 5 dashboard sites — made segment-set-aware via `graph.CurrentGraphDescriptor` (existence) / `graph.CurrentGraphMtime` (freshness), preserving `graph.json` fallbacks and single-file parity. Completes the #5915 J2 gate sweep. Latent until `GRAFEL_STREAM_SEGMENTS` on; needed before the flip.

## Sites
- `store.go` `aggregateGroupStats` — both fallback mtime branches.
- `ref_helper.go` `knownRefsForGroup` + `allRefsForRepo` — existence (json fallback kept).
- `graphstate.go` `statGraphMtime` — freshness (NOT the :620-674 merge-hook/reader-open).
- `handlers_v2_refs.go` `handleV2GroupRefs` + `handlers_ref_endpoints.go` `handleGroupRefs` — existence+freshness.

## Verification (independent adversarial review — APPROVE)
- Each of the 5 gates proven load-bearing (per-site revert → its segment-set test RED).
- Single-file mtime byte-parity: nanosecond-identical to old `os.Stat(CurrentGraphPath)` (1s drift → RED).
- `graph.json` fallback proven preserved (removing it → json-only `TestHandleGroupRefs_OK` / `TestKnownRefsForGroup_GenOnlyRefIncluded` RED).
- Absent parity; Windows teardown via `quiesceGraphCache`.

## Follow-up (out of scope → #5924)
`graphstate.go:674` (`dr.Reader` open) + `v2_group_settings.go:267` `repoGitMeta` open the flat path to build a reader / read git header fields — segment-sets degrade (Doc fallback / zero git-metadata). Tracked in #5924, to land with #5912.

Refs #5915

🤖 Generated with [Claude Code](https://claude.com/claude-code)