### PR TITLE
feat(#5912): zero-copy mmap serve for segment-set graphs (MultiReader cutover)

### DIFF
--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -689,7 +689,7 @@ func fbRelToGraphRel(r *fb.Relationship, si *stringInterner) Relationship {
 // substrings WITHIN one materialized row, and the copied-out strings are
 // independent of any Document-wide interner. Returns the zero Entity when
 // r is nil or i is out of range.
-func MaterializeEntity(r *fbreader.Reader, i int) Entity {
+func MaterializeEntity(r fbreader.GraphView, i int) Entity {
 	if r == nil {
 		return Entity{}
 	}
@@ -706,7 +706,7 @@ func MaterializeEntity(r *fbreader.Reader, i int) Entity {
 // Relationships[i] for the same graph.fb. All strings are copied out of
 // the mmap region, so the result outlives the Reader. Returns the zero
 // Relationship when r is nil or i is out of range.
-func MaterializeRelationship(r *fbreader.Reader, i int) Relationship {
+func MaterializeRelationship(r fbreader.GraphView, i int) Relationship {
 	if r == nil {
 		return Relationship{}
 	}

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -53,7 +53,12 @@ type LabelIndex struct {
 	// on the same s.mu-serialized read path that today reads lr.Doc; a reload
 	// rebuilds the whole LabelIndex (fresh reader), so at() never dereferences a
 	// reader across its own generation.
-	reader *fbreader.Reader
+	//
+	// #5912 (h): typed fbreader.GraphView, not the concrete *Reader, so a
+	// segment-set repo backs this index with a *MultiReader (N segment mmaps,
+	// global-index at()/EntityAt resolution) transparently — every at()/count
+	// call below is a GraphView method already implemented identically on both.
+	reader fbreader.GraphView
 
 	// overlay is the ADR-0027 overlay SIDE-TABLE: entity INDEX (int32 vector
 	// position) -> the 5 group-algo values that are NOT authoritative in graph.fb
@@ -229,7 +234,7 @@ func BuildLabelIndex(doc *graph.Document) *LabelIndex {
 // doc is retained as the value-materialization source (at() copies from it) so
 // lookups stay behavior-neutral against in-place overlay stamps — see the
 // LabelIndex type doc for why values are NOT read back from the Reader in PR2.
-func BuildLabelIndexFromReader(r *fbreader.Reader, doc *graph.Document) *LabelIndex {
+func BuildLabelIndexFromReader(r fbreader.GraphView, doc *graph.Document) *LabelIndex {
 	idx, ki := newLabelIndex(r.EntityCount())
 	idx.doc = doc
 	idx.reader = r

--- a/internal/mcp/maphandle.go
+++ b/internal/mcp/maphandle.go
@@ -26,9 +26,17 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
 
-// readerCloser is the narrow close surface MapHandle drives. *fbreader.Reader
-// satisfies it; tests substitute a fake that counts munmaps so the exactly-once
+// readerCloser is the narrow close surface MapHandle drives. Both
+// *fbreader.Reader (one mmap) and *fbreader.MultiReader (N segment mmaps)
+// satisfy it; tests substitute a fake that counts munmaps so the exactly-once
 // and no-leak invariants can be asserted without a real mapping.
+//
+// #5912 (h): a MultiReader owns N segment mmaps but is ONE readerCloser — its
+// Close munmaps ALL N (multireader.go). The whole MultiReader is therefore
+// retired/drained as ONE atomic unit: one handle, N mappings, one refcount,
+// one closeOnce → one Close() call → all N segments munmapped together. The
+// refcount-drain and readRetired discipline below are UNCHANGED by segment
+// count — they gate a single *MapHandle, not per-segment.
 type readerCloser interface {
 	Close() error
 }
@@ -50,8 +58,12 @@ type MapHandle struct {
 	// repo is the registry slug of the repo this mapping belongs to, set by
 	// LoadedRepo.publishHandle so a groupBorrow snapshot can look a borrow up by
 	// repo. Immutable after publish.
-	repo    string
-	reader  *fbreader.Reader
+	repo string
+	// reader is the resident read view this handle owns the lifetime of. #5912
+	// (h): typed fbreader.GraphView so it is a *Reader (single mmap) or a
+	// *MultiReader (N segment mmaps) transparently — Close() releases whichever
+	// set of mappings it owns, and this handle drains them as one unit.
+	reader  fbreader.GraphView
 	closer  readerCloser
 	refs    atomic.Int64
 	retired atomic.Bool
@@ -79,14 +91,16 @@ type MapHandle struct {
 }
 
 // newMapHandle wraps a freshly-opened reader for the production path. Called
-// only with a non-nil reader (reloadLocked guards on fbreader.Open success).
-func newMapHandle(r *fbreader.Reader) *MapHandle {
+// only with a non-nil reader (reloadLocked guards on ReaderForDir success). The
+// reader is a *Reader for a single-file graph or a *MultiReader for a
+// segment-set; either way this handle owns and drains its mapping(s).
+func newMapHandle(r fbreader.GraphView) *MapHandle {
 	return &MapHandle{reader: r, closer: r}
 }
 
-// Reader returns the wrapped reader (the future F3 read cursor). Nil-safe so a
-// caller can chain h.Reader() on a repo with no mmap.
-func (h *MapHandle) Reader() *fbreader.Reader {
+// Reader returns the wrapped read view (the future F3 read cursor). Nil-safe so
+// a caller can chain h.Reader() on a repo with no mmap.
+func (h *MapHandle) Reader() fbreader.GraphView {
 	if h == nil {
 		return nil
 	}

--- a/internal/mcp/mmap_readermu_sigbus_test.go
+++ b/internal/mcp/mmap_readermu_sigbus_test.go
@@ -56,7 +56,7 @@ func sigbusFixtureDoc(n int) *graph.Document {
 
 // wireReaderLabelIndex builds a fully-wired reader-sourced LabelIndex for lr's
 // readerMu + the given handle, exactly as reloadLocked does in production.
-func wireReaderLabelIndex(lr *LoadedRepo, rdr *fbreader.Reader, h *MapHandle, doc *graph.Document) *LabelIndex {
+func wireReaderLabelIndex(lr *LoadedRepo, rdr fbreader.GraphView, h *MapHandle, doc *graph.Document) *LabelIndex {
 	li := BuildLabelIndexFromReader(rdr, doc)
 	li.readerMu = &lr.readerMu
 	li.handle = h

--- a/internal/mcp/scoring.go
+++ b/internal/mcp/scoring.go
@@ -233,7 +233,7 @@ func BuildBM25(doc *graph.Document) *BM25Index {
 // Callers on the wired handler path MUST hold the owning repo's readerMu around
 // this call (the mmap is dereferenced per row), exactly like
 // buildAdjacencyFromReader in getAdjacency.
-func BuildBM25FromReader(r *fbreader.Reader) *BM25Index {
+func BuildBM25FromReader(r fbreader.GraphView) *BM25Index {
 	n := 0
 	if r != nil {
 		n = r.EntityCount()

--- a/internal/mcp/segment_serve_5912h_test.go
+++ b/internal/mcp/segment_serve_5912h_test.go
@@ -1,0 +1,461 @@
+// segment_serve_5912h_test.go — #5912 (h): the HARD FLIP GATE. The zero-copy
+// mmap serve path must serve a SEGMENT-SET (graph.<gen>/ dir of N seg-NNNN.fb +
+// manifest.json) DIRECTLY from fbreader.MultiReader, instead of collapsing it
+// into a materialized graph.Document. Until this lands a large segment-set graph
+// regresses read-RSS (the whole v0.1.9 mmap win) because the reload open branch
+// left newRdr nil for a no-.fb-ext gen dir → Doc collapse.
+//
+// These tests drive the real reloadLocked open branch over an on-disk segment
+// set and assert:
+//   - lr.Reader is a *fbreader.MultiReader (served from segments, NOT Doc-collapsed);
+//   - entity-by-id, by-kind scan, BM25 search, and adjacency all resolve correctly
+//     across segments, INCLUDING a cross-segment edge (rel in seg A → id in seg B);
+//   - the single-file path is byte-identical (served via the same ReaderForDir seam);
+//   - reload/retire munmaps all N segment mmaps as ONE atomic drain, race-free.
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/descriptions"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
+
+// segFixtureDoc builds a graph with n entities (zero-padded sortable ids, each
+// padded so a small threshold forces MANY segments) and a CALLS chain
+// ent[i]->ent[i+1] — so at least one relationship crosses a segment boundary.
+func segFixtureDoc(repo string, n int) *graph.Document {
+	doc := &graph.Document{Version: 1, Repo: repo}
+	doc.Entities = make([]graph.Entity, 0, n)
+	for i := 0; i < n; i++ {
+		e := graph.Entity{
+			ID:            fmt.Sprintf("ent-%08d", i),
+			Name:          fmt.Sprintf("sym_%08d", i),
+			QualifiedName: fmt.Sprintf("%s.sym_%08d", repo, i),
+			Kind:          "function",
+			SourceFile:    fmt.Sprintf("pkg/file_%04d.go", i),
+			Language:      "go",
+			StartLine:     1 + i,
+		}
+		e.PropSet("visibility", "public")
+		e.PropSet("padding", fmt.Sprintf("payload-%08d-xxxxxxxxxxxxxxxxxxxxxxxxxxxx", i))
+		doc.Entities = append(doc.Entities, e)
+	}
+	for i := 0; i+1 < n; i++ {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     fmt.Sprintf("rel-%08d", i),
+			FromID: fmt.Sprintf("ent-%08d", i),
+			ToID:   fmt.Sprintf("ent-%08d", i+1),
+			Kind:   "CALLS",
+		})
+	}
+	return doc
+}
+
+// writeSegmentSet writes doc as a segment-set (forced via a tiny threshold) into
+// the daemon state dir for a fresh temp repo and returns (repoDir, stateDir,
+// genDir, descriptor). It fails the test if the fixture did NOT split into a
+// multi-segment set (the whole point of the test).
+func writeSegmentSet(t *testing.T, doc *graph.Document) (repoDir, stateDir, genDir string, desc graph.GraphDescriptor) {
+	t.Helper()
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "1")
+	t.Setenv("GRAFEL_SEGMENT_BYTES", "65536") // 64 KB — forces many segments
+	repoDir = t.TempDir()
+	stateDir = daemon.StateDirForRepo(repoDir)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	gp, err := fbwriter.WriteGraphGen(stateDir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	genDir = gp
+	desc, err = graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		t.Fatalf("CurrentGraphDescriptor: %v", err)
+	}
+	if desc.Kind != graph.GraphSegmentSet {
+		t.Fatalf("fixture did not produce a segment-set (kind=%v) — raise entity count / lower threshold", desc.Kind)
+	}
+	if len(desc.Manifest.Segments) < 3 {
+		t.Fatalf("fixture produced only %d segments; need multiple entity segments for a cross-segment edge", len(desc.Manifest.Segments))
+	}
+	return repoDir, stateDir, genDir, desc
+}
+
+// reloadSegmentRepo builds a State whose sole repo points at a segment-set gen
+// dir, runs the real reloadLocked, and returns the resident LoadedRepo. The flag
+// is forced ON so the mmap serve path is exercised.
+func reloadSegmentRepo(t *testing.T, doc *graph.Document) (*State, *LoadedRepo, graph.GraphDescriptor) {
+	t.Helper()
+	forceServeFromMMap(t, true)
+	repoDir, _, genDir, desc := writeSegmentSet(t, doc)
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	// Pre-seed GraphFile = the gen dir so reload's short-circuit stats it directly
+	// (no git subprocesses); Doc nil + zero mtime forces the reparse+open branch.
+	lr := &LoadedRepo{Repo: "r", Path: repoDir, GraphFile: genDir}
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{"r": lr}}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reloadLocked: %v", err)
+	}
+	return st, lr, desc
+}
+
+// TestSegmentSet_ServedFromMultiReaderNotDocCollapsed is THE flip-gate test.
+func TestSegmentSet_ServedFromMultiReaderNotDocCollapsed(t *testing.T) {
+	const n = 600
+	doc := segFixtureDoc("r", n)
+	_, lr, desc := reloadSegmentRepo(t, doc)
+
+	// (1) Served from a MultiReader — NOT the newRdr-nil Doc-collapse branch.
+	if lr.Reader == nil {
+		t.Fatal("lr.Reader is nil — segment-set was Doc-collapsed (the RSS regression this gate blocks)")
+	}
+	mr, ok := lr.Reader.(*fbreader.MultiReader)
+	if !ok {
+		t.Fatalf("lr.Reader is %T, want *fbreader.MultiReader (segment-set must serve from segments)", lr.Reader)
+	}
+	if mr.SegmentCount() < 2 {
+		t.Fatalf("MultiReader has %d segments; want the multi-segment set", mr.SegmentCount())
+	}
+	if lr.handle == nil || lr.handle.Reader() != lr.Reader {
+		t.Fatal("handle invariant broken: handle==nil or handle.Reader() != lr.Reader")
+	}
+	if got := lr.Reader.EntityCount(); got != n {
+		t.Fatalf("EntityCount across segments = %d, want %d", got, n)
+	}
+
+	// (2) entity-by-id resolves across segments via the reader-backed LabelIndex.
+	for _, i := range []int{0, 1, n / 2, n - 2, n - 1} {
+		id := fmt.Sprintf("ent-%08d", i)
+		e := lr.LabelIndex.ByID(id)
+		if e == nil || e.ID != id || e.QualifiedName != fmt.Sprintf("r.sym_%08d", i) {
+			t.Fatalf("LabelIndex.ByID(%s) = %#v; want id/qname for entity %d (cross-segment resolve failed)", id, e, i)
+		}
+	}
+
+	// (3) by-kind scan: every entity is "function" and the flag-ON scan visits all.
+	kindCount := 0
+	lr.forEachEntityOfKinds(func(k string) bool { return k == "function" }, func(e *graph.Entity) bool {
+		kindCount++
+		return true
+	})
+	if kindCount != n {
+		t.Fatalf("by-kind scan visited %d entities, want %d", kindCount, n)
+	}
+	if fk := lr.Reader.FilterEntitiesByKind("function"); len(fk) != n {
+		t.Fatalf("Reader.FilterEntitiesByKind(function) = %d, want %d", len(fk), n)
+	}
+
+	// (4) BM25 search resolves a specific symbol off the segment-backed index.
+	hits := lr.getBM25().Search("sym_00000042", 5)
+	foundBM := false
+	for _, h := range hits {
+		if h.Entity != nil && h.Entity.ID == "ent-00000042" {
+			foundBM = true
+		}
+	}
+	if !foundBM {
+		t.Fatalf("BM25 search over segment-set did not resolve ent-00000042; hits=%d", len(hits))
+	}
+
+	// (5) adjacency + CROSS-SEGMENT edge. The first entity segment's MaxKey entity
+	// has a CALLS edge to the first entity of the next segment (ids are the
+	// contiguous sorted chain), so from and to live in DIFFERENT segments.
+	fromID, toID := crossSegmentEdge(t, desc)
+	adj := lr.getAdjacency()
+	if adj == nil {
+		t.Fatal("getAdjacency returned nil")
+	}
+	// The reader-sourced adjacency must be byte-identical to a direct
+	// reader-sourced build (proves it is served from the MultiReader, not the Doc).
+	if !reflect.DeepEqual(adj, buildAdjacencyFromReader(lr.Reader, "r")) {
+		t.Fatal("getAdjacency (flag-on) != buildAdjacencyFromReader — not served from the segment reader")
+	}
+	if !hasOutNeighbor(adj, fromID, toID) {
+		t.Fatalf("cross-segment edge %s->%s missing from out-adjacency", fromID, toID)
+	}
+	// The cross-segment endpoint resolves by id through the MultiReader (seg B).
+	if e := lr.Reader.LookupEntityByID(toID); e == nil || string(e.Id()) != toID {
+		t.Fatalf("cross-segment LookupEntityByID(%s) failed — segment routing broken", toID)
+	}
+}
+
+// crossSegmentEdge returns a (fromID,toID) CALLS edge whose endpoints are in two
+// DIFFERENT entity segments: the last id of entity-segment 0 and its chain
+// successor (the first id of entity-segment 1).
+func crossSegmentEdge(t *testing.T, desc graph.GraphDescriptor) (fromID, toID string) {
+	t.Helper()
+	var firstEntSeg *graph.SegmentMeta
+	for i := range desc.Manifest.Segments {
+		s := &desc.Manifest.Segments[i]
+		if s.Kind == graph.SegmentEntities && s.EntityCount > 0 {
+			firstEntSeg = s
+			break
+		}
+	}
+	if firstEntSeg == nil {
+		t.Fatal("no entity segment in manifest")
+	}
+	// MaxKey is ent-XXXXXXXX; its chain successor is ent-(XXXXXXXX+1), which — being
+	// the next id in sorted order past this segment's max — lives in the next segment.
+	var idx int
+	if _, err := fmt.Sscanf(firstEntSeg.MaxKey, "ent-%08d", &idx); err != nil {
+		t.Fatalf("parse MaxKey %q: %v", firstEntSeg.MaxKey, err)
+	}
+	return fmt.Sprintf("ent-%08d", idx), fmt.Sprintf("ent-%08d", idx+1)
+}
+
+func hasOutNeighbor(adj *adjacency, fromID, toID string) bool {
+	for _, e := range adj.Outgoing(fromID) {
+		if e.target == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSingleFile_ServedViaReaderForDirParity_5912h pins the non-negotiable
+// single-file parity: a single-file repo, served through the SAME ReaderForDir
+// open seam, resolves to a *fbreader.Reader (NOT a MultiReader) and its reads
+// are byte-identical to a direct reader-sourced build — the byte-for-byte
+// preservation of the single-file mmap serve path.
+func TestSingleFile_ServedViaReaderForDirParity_5912h(t *testing.T) {
+	forceServeFromMMap(t, true)
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0") // force the flat single-file writer
+	const n = 40
+	doc := segFixtureDoc("s", n)
+
+	repoDir := t.TempDir()
+	stateDir := daemon.StateDirForRepo(repoDir)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	gp, err := fbwriter.WriteGraphGen(stateDir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		t.Fatalf("CurrentGraphDescriptor: %v", err)
+	}
+	if desc.Kind != graph.GraphSingleFile {
+		t.Fatalf("expected GraphSingleFile, got %v", desc.Kind)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	lr := &LoadedRepo{Repo: "r", Path: repoDir, GraphFile: gp}
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{"r": lr}}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reloadLocked: %v", err)
+	}
+
+	if lr.Reader == nil {
+		t.Fatal("single-file repo left lr.Reader nil (regressed mmap serve)")
+	}
+	if _, isMulti := lr.Reader.(*fbreader.MultiReader); isMulti {
+		t.Fatal("single-file repo resolved to a *MultiReader — must be a single-file *Reader")
+	}
+	if _, isSingle := lr.Reader.(*fbreader.Reader); !isSingle {
+		t.Fatalf("single-file repo lr.Reader is %T, want *fbreader.Reader", lr.Reader)
+	}
+	if got := lr.Reader.EntityCount(); got != n {
+		t.Fatalf("single-file EntityCount = %d, want %d", got, n)
+	}
+	for _, i := range []int{0, n / 2, n - 1} {
+		id := fmt.Sprintf("ent-%08d", i)
+		if e := lr.LabelIndex.ByID(id); e == nil || e.ID != id {
+			t.Fatalf("single-file ByID(%s) = %#v", id, e)
+		}
+	}
+	if !reflect.DeepEqual(lr.getAdjacency(), buildAdjacencyFromReader(lr.Reader, "s")) {
+		t.Fatal("single-file getAdjacency (flag-on) != reader build — parity broken")
+	}
+}
+
+// TestSegmentSet_ReloadRetireDrainNoRace_5912h is the concurrency drain proof:
+// a reloader repeatedly opens a fresh N-segment MultiReader, publishes it, and
+// retires the predecessor (munmapping ALL N segment mmaps as ONE atomic drain)
+// while goroutines hammer the flag-ON read choke points. Under -race it must
+// finish with NO read-after-munmap SIGBUS/SIGSEGV/race and correct data — the
+// whole-MultiReader-as-one-retire-unit invariant.
+func TestSegmentSet_ReloadRetireDrainNoRace_5912h(t *testing.T) {
+	forceServeFromMMap(t, true)
+	const n = 500
+	doc := segFixtureDoc("r", n)
+	_, stateDir, _, desc := writeSegmentSet(t, doc)
+	if len(desc.Segments) < 3 {
+		t.Fatalf("need a multi-segment set for the N-segment drain, got %d segments", len(desc.Segments))
+	}
+
+	openMulti := func() *fbreader.MultiReader {
+		v, err := graph.ReaderForDir(stateDir)
+		if err != nil {
+			t.Fatalf("ReaderForDir: %v", err)
+		}
+		mr, ok := v.(*fbreader.MultiReader)
+		if !ok {
+			t.Fatalf("ReaderForDir returned %T, want *fbreader.MultiReader", v)
+		}
+		return mr
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	s.mu.Lock()
+	h0 := newMapHandle(openMulti())
+	lr.LabelIndex = wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.publishHandle(h0)
+	s.mu.Unlock()
+
+	stop := make(chan struct{})
+	var faults atomic.Int64
+
+	var wgR sync.WaitGroup
+	wgR.Add(1)
+	go func() {
+		defer wgR.Done()
+		for i := 0; i < 200; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			nh := newMapHandle(openMulti())
+			li := wireReaderLabelIndex(lr, nh.reader, nh, doc)
+			s.mu.Lock()
+			lr.resetIndexes()
+			lr.LabelIndex = li
+			lr.publishHandle(nh) // retire+munmap all N segments of the predecessor
+			s.mu.Unlock()
+		}
+	}()
+
+	var wgB sync.WaitGroup
+	for g := 0; g < 6; g++ {
+		wgB.Add(1)
+		go func() {
+			defer wgB.Done()
+			for j := 0; j < 400; j++ {
+				s.mu.Lock()
+				li := lr.LabelIndex
+				s.mu.Unlock()
+				// e00000123 lives past the first segment boundary → exercises
+				// cross-segment materialization under the concurrent munmap.
+				if e := li.ByID("ent-00000123"); e == nil || e.ID != "ent-00000123" {
+					faults.Add(1)
+				}
+				_ = lr.getAdjacency()
+				_ = lr.getCallsAdj()
+				_ = lr.getStepAdj()
+			}
+		}()
+	}
+
+	wgB.Wait()
+	close(stop)
+	wgR.Wait()
+
+	s.mu.Lock()
+	lr.retireHandle() // munmap the final generation's N segments
+	s.mu.Unlock()
+
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("choke-point read faults across the segment-set drain: %d", f)
+	}
+}
+
+// TestSegmentSet_OverlayMergeOverMultiReader_5912h asserts the desc + group-algo
+// side-table overlays still merge correctly on the segment-set mmap path — they
+// key on the SAME global concat index the MultiReader assigns (EntityAt /
+// IterateEntities order), so an overlay entry for an entity in segment B is
+// surfaced at that entity's global index just like a single-file graph.
+func TestSegmentSet_OverlayMergeOverMultiReader_5912h(t *testing.T) {
+	const n = 500
+	doc := segFixtureDoc("r", n)
+	_, stateDir, _, desc := writeSegmentSet(t, doc)
+
+	v, err := graph.ReaderForDir(stateDir)
+	if err != nil {
+		t.Fatalf("ReaderForDir: %v", err)
+	}
+	mr, ok := v.(*fbreader.MultiReader)
+	if !ok {
+		t.Fatalf("ReaderForDir returned %T", v)
+	}
+	defer mr.Close()
+
+	// A cross-segment pair: from in segment A, to (its chain successor) in segment
+	// B. ids are the dense sorted chain, so the global concat index == the numeric
+	// suffix (MultiReader concatenates segments in sorted manifest order).
+	fromID, toID := crossSegmentEdge(t, desc)
+	var fromIdx, toIdx int
+	fmt.Sscanf(fromID, "ent-%08d", &fromIdx)
+	fmt.Sscanf(toID, "ent-%08d", &toIdx)
+	if toIdx != fromIdx+1 {
+		t.Fatalf("cross-segment pair not contiguous: %d,%d", fromIdx, toIdx)
+	}
+
+	ov := &groupalgo.Overlay{Results: map[string]groupalgo.EntityOverlay{
+		fromID: {CommunityID: 111, Centrality: 0.5, IsGodNode: true},
+		toID:   {CommunityID: 222},
+	}}
+	sc := &descriptions.Sidecar{Results: map[string]string{
+		fromID: "desc-from",
+		toID:   "desc-to",
+	}}
+
+	otab := buildOverlayTableFromReader(mr, ov)
+	dtab := buildDescTableFromReader(mr, sc)
+
+	// The side-tables key on the global concat index across segments.
+	if eo, has := otab[int32(fromIdx)]; !has || eo.CommunityID == nil || *eo.CommunityID != 111 || !eo.IsGodNode {
+		t.Fatalf("overlay table missing/incorrect at cross-segment index %d: %#v (has=%v)", fromIdx, eo, has)
+	}
+	if dtab[int32(fromIdx)] != "desc-from" || dtab[int32(toIdx)] != "desc-to" {
+		t.Fatalf("desc table not keyed on concat index: [%d]=%q [%d]=%q", fromIdx, dtab[int32(fromIdx)], toIdx, dtab[int32(toIdx)])
+	}
+
+	// materializeEntityOverlay merges base (mmap) + overlays at the concat index —
+	// byte-identical to a single-file at() lookup for the same entity.
+	efrom := materializeEntityOverlay(mr, otab, dtab, int32(fromIdx))
+	if efrom == nil || efrom.ID != fromID {
+		t.Fatalf("materializeEntityOverlay(%d) = %#v, want %s", fromIdx, efrom, fromID)
+	}
+	if efrom.CommunityID == nil || *efrom.CommunityID != 111 || !efrom.IsGodNode {
+		t.Fatalf("overlay not merged onto segment-B entity: %#v", efrom)
+	}
+	if d := efrom.PropGet("description"); d != "desc-from" {
+		t.Fatalf("desc overlay not merged: PropGet(description)=%q, want desc-from", d)
+	}
+	eto := materializeEntityOverlay(mr, otab, dtab, int32(toIdx))
+	if eto == nil || eto.ID != toID || eto.CommunityID == nil || *eto.CommunityID != 222 {
+		t.Fatalf("cross-segment successor overlay wrong: %#v", eto)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -275,7 +275,7 @@ type LoadedRepo struct {
 	Path      string
 	GraphFile string
 	Doc       *graph.Document
-	Reader    *fbreader.Reader // mmap zero-copy reader (S8, #2159); nil when unavailable
+	Reader    fbreader.GraphView // mmap zero-copy reader (S8, #2159); nil when unavailable. #5912 (h): a *Reader for single-file, a *MultiReader for a segment-set (N segment mmaps behind one GraphView).
 	// handle is the F1 (ADR-0027) deferred-unmap wrapper that OWNS the lifetime
 	// of Reader's mapping. Reader is the (still-dark) read accessor; handle is
 	// what reload/evict/Close route the munmap through so an in-flight borrow can
@@ -2366,7 +2366,7 @@ func buildTopKPageRank(doc *graph.Document, k int) []string {
 // overlay's per-entity map keyed by ID, applied at Reader-borrow time rather
 // than only onto lr.Doc), at which point this comment should be replaced.
 // ADR-0027 Cutover PR1.
-func buildTopKPageRankFromReader(r *fbreader.Reader, k int) []string {
+func buildTopKPageRankFromReader(r fbreader.GraphView, k int) []string {
 	if r == nil || r.EntityCount() == 0 {
 		return nil
 	}
@@ -2665,7 +2665,7 @@ func newEntityOverlay(eo groupalgo.EntityOverlay) entityOverlay {
 // WITH an overlay entry are inserted; a miss leaves the fb sentinel on the read
 // path. Callers MUST hold the owning LoadedRepo's readerMu (the mmap is
 // dereferenced here via IterateEntities).
-func buildOverlayTableFromReader(r *fbreader.Reader, ov *groupalgo.Overlay) map[int32]entityOverlay {
+func buildOverlayTableFromReader(r fbreader.GraphView, ov *groupalgo.Overlay) map[int32]entityOverlay {
 	table := make(map[int32]entityOverlay)
 	if r == nil || ov == nil {
 		return table
@@ -2867,7 +2867,7 @@ func (lr *LoadedRepo) flowOverlaySnapshot() *flows.Sidecar {
 // order — identical to the order BuildLabelIndexFromReader assigns and the order
 // materializeFromReader looks the table up by. Callers MUST hold the owning
 // LoadedRepo's readerMu (the mmap is dereferenced here via IterateEntities).
-func buildDescTableFromReader(r *fbreader.Reader, sc *descriptions.Sidecar) map[int32]string {
+func buildDescTableFromReader(r fbreader.GraphView, sc *descriptions.Sidecar) map[int32]string {
 	table := make(map[int32]string)
 	if r == nil || sc == nil {
 		return table

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1463,10 +1463,29 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 					// segment-set is READABLE (via the Doc), never mis-mmapped as a
 					// single file. filepath.Ext of a gen dir is "" so the guard
 					// below already excludes it; the single-file path is unchanged.
+					// #5912 (h): open the resident mmap read substrate for BOTH graph
+					// layouts through ONE seam — graph.ReaderForDir resolves the
+					// descriptor under stateDir and returns a single-file *Reader
+					// (byte-identical to today's fbreader.Open — the single-file serve
+					// path is preserved) or an N-segment *MultiReader for a segment-set
+					// gen dir. This is the HARD FLIP: before this a no-.fb-ext gen dir
+					// left newRdr nil and the repo was Doc-collapsed (materialized the
+					// whole segment-set onto the heap — the read-RSS regression). The
+					// MultiReader resolves its EntityAt/RelationshipAt/LookupEntityByID
+					// over a global concatenated index → (segment, local) internally, so
+					// every downstream FromReader builder (LabelIndex/BM25/adjacency)
+					// sources rows straight from the segment mmaps.
+					//
+					// A json-only repo (lr.GraphFile is graph.json) has NO FlatBuffers
+					// graph: guard on the .json extension so we never hand JSON bytes to
+					// fbreader.Open (an out-of-range slice crash) — newRdr stays nil and
+					// the repo is served from the materialized Document, exactly as the
+					// old `.fb`-only guard did. (ReaderForDir on a graph-absent dir would
+					// also fail-soft to nil, but the explicit guard keeps intent local.)
 					fbPath := lr.GraphFile
-					var newRdr *fbreader.Reader
-					if filepath.Ext(fbPath) == ".fb" {
-						if rdr, rErr := fbreader.Open(fbPath); rErr == nil {
+					var newRdr fbreader.GraphView
+					if filepath.Ext(fbPath) != ".json" {
+						if rdr, rErr := graph.ReaderForDir(stateDir); rErr == nil {
 							newRdr = rdr
 						}
 					}

--- a/internal/mcp/traversal.go
+++ b/internal/mcp/traversal.go
@@ -219,7 +219,7 @@ func buildAdjacency(doc *graph.Document, repo string) *adjacency {
 // loadFBDocument produces for Document.Relationships, the resulting adjacency
 // is byte-identical to buildAdjacency's (proven by TestAdjacencyReaderParity_PR1).
 // ADR-0027 Cutover PR1: behavior-neutral re-sourcing of this primitive-only build.
-func buildAdjacencyFromReader(r *fbreader.Reader, repo string) *adjacency {
+func buildAdjacencyFromReader(r fbreader.GraphView, repo string) *adjacency {
 	a := &adjacency{}
 	a.nodes.code = make(map[string]int32, r.EntityCount())
 	a.kinds.code = make(map[string]uint16, 32)
@@ -391,7 +391,7 @@ func buildStepAdjacencyFromRels(rels []graph.Relationship) map[string][]stepEdge
 // fbreader.Reader. Byte-identical to the Document-sourced build (same edge
 // order per FromID key; proven by TestStepAdjacencyReaderParity_PR1).
 // ADR-0027 Cutover PR1.
-func buildStepAdjacencyFromReader(r *fbreader.Reader) map[string][]stepEdge {
+func buildStepAdjacencyFromReader(r fbreader.GraphView) map[string][]stepEdge {
 	adj := make(map[string][]stepEdge)
 	r.IterateRelationships(func(rel *fb.Relationship) bool {
 		if string(rel.Kind()) != stepInProcessEdge {
@@ -527,7 +527,7 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 // fbreader.Reader and running the IDENTICAL CSR assembly + per-row sort
 // (assembleCSR). Byte-identical to the Document-sourced build (proven by
 // TestCallsAdjacencyReaderParity_PR1). ADR-0027 Cutover PR1.
-func buildCallsAdjacencyFromReader(r *fbreader.Reader) *callsAdjacency {
+func buildCallsAdjacencyFromReader(r fbreader.GraphView) *callsAdjacency {
 	c := &callsAdjacency{}
 	c.nodes.code = make(map[string]int32)
 

--- a/internal/mcp/view_iter.go
+++ b/internal/mcp/view_iter.go
@@ -274,7 +274,7 @@ func (lr *LoadedRepo) forEachDocEntity(yield func(*graph.Entity) bool) bool {
 // is byte-identical to a LabelIndex.at()-based lookup for the same index.
 // Callers MUST hold the owning LoadedRepo's readerMu — the mmap dereference
 // happens here.
-func materializeEntityOverlay(r *fbreader.Reader, overlay map[int32]entityOverlay, descOverlay map[int32]string, idx int32) *graph.Entity {
+func materializeEntityOverlay(r fbreader.GraphView, overlay map[int32]entityOverlay, descOverlay map[int32]string, idx int32) *graph.Entity {
 	// Test-only observability seam (memory epic #5850 Path P): count each mmap
 	// entity materialization so the selective-materialization tests can assert a
 	// forEachEntityOfKinds scan materializes ONLY its matching-Kind subset, not the


### PR DESCRIPTION
## What

The mmap serve path now serves a SEGMENT-SET graph (`graph.<gen>/` dir of N `seg-NNNN.fb` + manifest) directly from `fbreader.MultiReader`, removing the segment-set-specific Document-collapse fork. Segment-sets ride the SAME Reader-backed serve path as single-file — the read-side flip gate for #5890.

## How
1. **Type-widen ~15 sites** `*fbreader.Reader` → `fbreader.GraphView` (`MaterializeEntity`/`MaterializeRelationship`; `LoadedRepo.Reader`, `LabelIndex.reader`; `Build*FromReader`; `build{Adjacency,Step,Calls,TopK,Overlay,Desc}FromReader`; `materializeEntityOverlay`). Mechanical — `*Reader` already satisfies `GraphView`; every body calls only interface methods.
2. **N-segment `MapHandle` drain** — a MultiReader owns N mmaps but is ONE `MapHandle` (one refcount, one `readRetired`, one `closeOnce`→`Close()` munmapping all N). The whole MultiReader retires atomically under `readerMu`, preserving #5850 SIGBUS-safety.
3. **Open-branch swap** (`state.go reloadLocked`) — `.fb`-ext-only `fbreader.Open` → `graph.ReaderForDir(stateDir)` (→ `*Reader` single-file / `*MultiReader` segment-set / Doc for json-only).

BM25 global-index resolution and id-based adjacency were already MultiReader-correct (`EntityAt`/`RelationshipAt` resolve global→(seg,local); cross-segment edges resolve by stable string id via `LookupEntityByID`). No new indexing indirection.

## Scope (accurate framing)
This is **parity, not a new RSS win** — it removes the fork so segment-sets aren't *worse* than single-file. `lr.Doc` materialization is unchanged; the heap win from dropping `lr.Doc` is a separate pre-existing dark lever.

## Verification (independent adversarial review — APPROVE)
- **N-segment munmap-under-read drain**: `-race -count=30` clean; dropping `readRetired` → RED (14–39 faults) — one atomic retire unit.
- **Cross-segment id routing**: seg-0-only lookup → RED at mcp + fbreader; missing-id no-false-hit covered.
- **BM25/overlay global-index consistency**: reverse-order mutation → RED (wrong entity).
- Single-file byte-parity; Doc-collapse fork removed (segment-set → `*MultiReader`, non-nil); json-only fail-soft.

Refs #5912
Refs #5890

🤖 Generated with [Claude Code](https://claude.com/claude-code)