### PR TITLE
refactor(#5870 PR7a): migrate raw-slice tool reads onto Reader seams (deretain-flip prep)

### DIFF
--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -375,17 +375,17 @@ func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolReques
 		// Build a file -> []auth_policy_entity index for this repo.
 		// auth_policy entities are emitted by the patterns/auth_endpoint_linker
 		// as SCOPE.Config entities with subtype "auth_policy".
-		authPoliciesByFile := buildAuthPoliciesByFile(r.Doc)
+		authPoliciesByFile := buildAuthPoliciesByFile(r)
 
 		// Build set of entity IDs reachable via TAGGED_AS edges to auth_policy.
-		taggedAuthIDs := buildTaggedAuthIDs(r.Doc)
+		taggedAuthIDs := buildTaggedAuthIDs(r)
 
 		// Issue #2816 — DRF class-level authorisation index: per source file,
 		// the line-range posture of every ViewSet/APIView carrying
 		// permission_classes / get_permissions, plus the repo-wide DRF default
 		// permission policy harvested from the settings REST_FRAMEWORK dict.
-		drfAuthByFile := buildDRFClassAuthByFile(r.Doc)
-		drfDefaultProtected, drfDefaultEvidence := repoDRFDefaultPolicy(r.Doc)
+		drfAuthByFile := buildDRFClassAuthByFile(r)
+		drfDefaultProtected, drfDefaultEvidence := repoDRFDefaultPolicy(r)
 
 		repoTotal := 0
 		repoCovered := 0
@@ -600,16 +600,19 @@ func capAuthByBudget(recs []EndpointRecord, maxBytes int, verbose bool) []Endpoi
 
 // buildAuthPoliciesByFile builds a map from source file path → set of auth
 // evidence strings for auth_policy entities found in that file.
-func buildAuthPoliciesByFile(doc *graph.Document) map[string][]string {
+// #5870 PR7a: iterates via forEachEntityBase (Reader flag-ON / Doc flag-OFF)
+// instead of raw doc.Entities, so it survives a future slice-drop. forEachEntityBase
+// (not the public forEachEntity) keeps it byte-identical to the raw-slice read.
+func buildAuthPoliciesByFile(lr *LoadedRepo) map[string][]string {
 	result := make(map[string][]string)
-	for i := range doc.Entities {
-		e := &doc.Entities[i]
+	lr.forEachEntityBase(func(e *graph.Entity) bool {
 		if !isAuthPolicyEntity(e) {
-			continue
+			return true
 		}
 		evidence := authEntityEvidence(e)
 		result[e.SourceFile] = append(result[e.SourceFile], evidence)
-	}
+		return true
+	})
 	return result
 }
 
@@ -654,23 +657,24 @@ func authEntityEvidence(e *graph.Entity) string {
 
 // buildTaggedAuthIDs returns the set of entity IDs that have a TAGGED_AS
 // relationship pointing to an auth_policy entity.
-func buildTaggedAuthIDs(doc *graph.Document) map[string]bool {
+// #5870 PR7a: forEachEntityBase/forEachRelationship instead of raw doc slices.
+func buildTaggedAuthIDs(lr *LoadedRepo) map[string]bool {
 	// Collect auth-policy entity IDs first.
 	authIDs := map[string]bool{}
-	for i := range doc.Entities {
-		e := &doc.Entities[i]
+	lr.forEachEntityBase(func(e *graph.Entity) bool {
 		if isAuthPolicyEntity(e) {
 			authIDs[e.ID] = true
 		}
-	}
+		return true
+	})
 
 	tagged := map[string]bool{}
-	for i := range doc.Relationships {
-		rel := &doc.Relationships[i]
+	lr.forEachRelationship(func(rel *graph.Relationship) bool {
 		if rel.Kind == "TAGGED_AS" && authIDs[rel.ToID] {
 			tagged[rel.FromID] = true
 		}
-	}
+		return true
+	})
 	return tagged
 }
 
@@ -868,17 +872,17 @@ func rangeSize(c drfClassAuth) int {
 // DRF class-level authorisation property, grouped by source file. These
 // properties are stamped by the python extractor's applyDRFPermissionProperties
 // pass (issue #2816).
-func buildDRFClassAuthByFile(doc *graph.Document) map[string][]drfClassAuth {
+// #5870 PR7a: forEachEntityBase instead of raw doc.Entities.
+func buildDRFClassAuthByFile(lr *LoadedRepo) map[string][]drfClassAuth {
 	out := make(map[string][]drfClassAuth)
-	for i := range doc.Entities {
-		e := &doc.Entities[i]
+	lr.forEachEntityBase(func(e *graph.Entity) bool {
 		if e.PropLen() == 0 {
-			continue
+			return true
 		}
 		_, hasAttr := e.PropLookup("has_permission_classes")
 		_, hasGet := e.PropLookup("has_get_permissions")
 		if !hasAttr && !hasGet {
-			continue
+			return true
 		}
 		out[e.SourceFile] = append(out[e.SourceFile], drfClassAuth{
 			startLine:         e.StartLine,
@@ -888,7 +892,8 @@ func buildDRFClassAuthByFile(doc *graph.Document) map[string][]drfClassAuth {
 			hasGetPermissions: hasGet,
 			getPermClasses:    e.PropGet("get_permissions_classes"),
 		})
-	}
+		return true
+	})
 	return out
 }
 
@@ -897,23 +902,28 @@ func buildDRFClassAuthByFile(doc *graph.Document) map[string][]drfClassAuth {
 // python config_module extractor, issue #2816) and reports whether the global
 // default protects endpoints. When the key is absent DRF's built-in default is
 // AllowAny → not protected.
-func repoDRFDefaultPolicy(doc *graph.Document) (protected bool, evidence string) {
-	for i := range doc.Entities {
-		e := &doc.Entities[i]
+// #5870 PR7a: forEachEntityBase instead of raw doc.Entities. Iteration stops
+// early (yield false) on the first protective default, preserving the original
+// first-match-wins semantics byte-identically.
+func repoDRFDefaultPolicy(lr *LoadedRepo) (protected bool, evidence string) {
+	lr.forEachEntityBase(func(e *graph.Entity) bool {
 		if e.PropLen() == 0 {
-			continue
+			return true
 		}
 		if e.PropGet("drf_default_permission_present") != "true" {
-			continue
+			return true
 		}
 		if prot, name := isProtectivePermissionList(e.PropGet("drf_default_permission_classes")); prot {
-			return true, "DRF default permission: " + name
+			protected = true
+			evidence = "DRF default permission: " + name
+			return false // stop at the first protective default
 		}
 		// Present but AllowAny/empty default → explicitly open. A later
 		// settings module won't override an explicit open default, so keep
 		// scanning only for a protective one.
-	}
-	return false, ""
+		return true
+	})
+	return protected, evidence
 }
 
 // isSensitiveOperation reports whether an endpoint name or path suggests a

--- a/internal/mcp/auth_coverage_migrate_5870_pr7a_test.go
+++ b/internal/mcp/auth_coverage_migrate_5870_pr7a_test.go
@@ -1,0 +1,59 @@
+// auth_coverage_migrate_5870_pr7a_test.go — deretain-flip PR7a (#5870).
+//
+// Result-equivalence for the auth-coverage builders, migrated from taking
+// *graph.Document (raw doc.Entities/Relationships iteration) to taking
+// *LoadedRepo and iterating via forEachEntityBase/forEachRelationship. Each
+// asserts the migrated builder on a flag-ON emptied-Doc repo (Reader-sourced)
+// is byte-identical to the flag-OFF full-Doc result, plus retired-Reader
+// Doc fallback.
+package mcp
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestAuthBuilders_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	type authOut struct {
+		policies map[string][]string
+		tagged   map[string]bool
+		drf      map[string][]drfClassAuth
+		defProt  bool
+		defEv    string
+	}
+	compute := func(lr *LoadedRepo) authOut {
+		prot, ev := repoDRFDefaultPolicy(lr)
+		return authOut{
+			policies: buildAuthPoliciesByFile(lr),
+			tagged:   buildTaggedAuthIDs(lr),
+			drf:      buildDRFClassAuthByFile(lr),
+			defProt:  prot,
+			defEv:    ev,
+		}
+	}
+
+	withServeFromMMap(t, false)
+	want := compute(docFullRepo(doc))
+	// Fixture must exercise the builders.
+	if len(want.policies) == 0 {
+		t.Fatal("fixture must contain an auth_policy entity")
+	}
+	if !want.tagged["ep"] {
+		t.Fatal("fixture must contain a TAGGED_AS edge to the auth policy")
+	}
+	if len(want.drf) == 0 || !want.defProt {
+		t.Fatal("fixture must exercise DRF class-auth + default policy")
+	}
+
+	withServeFromMMap(t, true)
+	got := compute(readerEmptiedRepo(t, doc, r))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("auth builders flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+
+	if fb := compute(readerFullRepoRetired(t, doc, r)); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("auth builders retired-Reader fallback != flag-OFF")
+	}
+}

--- a/internal/mcp/counts_migrate_5870_pr7a_test.go
+++ b/internal/mcp/counts_migrate_5870_pr7a_test.go
@@ -1,0 +1,35 @@
+// counts_migrate_5870_pr7a_test.go — deretain-flip PR7a (#5870).
+//
+// The whoami/dashboard/stats/dead-code/license entity+relationship COUNTS now
+// source from lr.entityCount()/lr.relCount() (Reader flag-ON, Doc len flag-OFF)
+// instead of len(lr.Doc.Entities)/len(lr.Doc.Relationships), so they stay
+// correct after a future slice empties lr.Doc. This exercises the real
+// count-consumer seam groupIndexCounts across both flag paths.
+package mcp
+
+import "testing"
+
+func TestGroupIndexCounts_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	lgOff := &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"corpus": docFullRepo(doc)}}
+	wantE, wantR, _ := groupIndexCounts(lgOff)
+	if wantE != len(doc.Entities) || wantR != len(doc.Relationships) {
+		t.Fatalf("flag-OFF counts e=%d r=%d, want %d/%d", wantE, wantR, len(doc.Entities), len(doc.Relationships))
+	}
+
+	withServeFromMMap(t, true)
+	lgOn := &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"corpus": readerEmptiedRepo(t, doc, r)}}
+	gotE, gotR, _ := groupIndexCounts(lgOn)
+	if gotE != wantE || gotR != wantR {
+		t.Fatalf("flag-ON(emptied Doc) counts e=%d r=%d, want %d/%d (len(Doc.*) would be 0)", gotE, gotR, wantE, wantR)
+	}
+
+	// Retired-Reader fallback → Doc len.
+	lgRet := &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"corpus": readerFullRepoRetired(t, doc, r)}}
+	fbE, fbR, _ := groupIndexCounts(lgRet)
+	if fbE != wantE || fbR != wantR {
+		t.Fatalf("retired-Reader counts e=%d r=%d, want %d/%d", fbE, fbR, wantE, wantR)
+	}
+}

--- a/internal/mcp/coverage_tools.go
+++ b/internal/mcp/coverage_tools.go
@@ -74,7 +74,10 @@ func (s *Server) handleTestCoverage(ctx context.Context, req mcpapi.CallToolRequ
 			continue
 		}
 
-		report := graph.ComputeCoverage(rd.Doc)
+		// #5870 PR7a: feed a transient Document built from the Reader-served
+		// materialize seam instead of the raw rd.Doc (ComputeCoverage reads only
+		// Entities/Relationships). Byte-identical; survives a future slice-drop.
+		report := graph.ComputeCoverage(materializedDoc(rd))
 		totalProd += report.TotalProduction
 		coveredProd += report.CoveredProduction
 		totalTests += report.TotalTests
@@ -209,7 +212,8 @@ func (s *Server) handleTestCoverageEntity(lg *LoadedGroup, entityID string) (*mc
 			continue
 		}
 
-		result, found := graph.ComputeEntityCoverage(rd.Doc, entityID)
+		// #5870 PR7a: transient Document from the Reader-served materialize seam.
+		result, found := graph.ComputeEntityCoverage(materializedDoc(rd), entityID)
 		if !found {
 			continue
 		}

--- a/internal/mcp/cycles_tools.go
+++ b/internal/mcp/cycles_tools.go
@@ -55,10 +55,16 @@ func (s *Server) handleQualityCycles(_ context.Context, req mcpapi.CallToolReque
 			continue
 		}
 
-		// Build PageRank map from entity attributes (Pass 4 output).
-		pr := buildPageRankMap(r.Doc)
+		// #5870 PR7a: source the whole entity/relationship set via the
+		// Reader-served materialize seam (transient copy) rather than the raw
+		// lr.Doc.* slices, so this heavy/rare pass survives a future slice-drop.
+		ents := materializeAllEntities(r)
+		rels := materializeAllRelationships(r)
 
-		cycles := graph.FindImportCycles(r.Doc.Entities, r.Doc.Relationships, pr)
+		// Build PageRank map from entity attributes (Pass 4 output).
+		pr := buildPageRankMap(ents)
+
+		cycles := graph.FindImportCycles(ents, rels, pr)
 		if len(cycles) == 0 {
 			continue
 		}
@@ -202,12 +208,14 @@ func buildServiceCycles(lg *LoadedGroup, repoFilter []string) []graph.ServiceCyc
 	return graph.FindServiceCycles(links)
 }
 
-// buildPageRankMap extracts per-entity PageRank scores from a loaded Document.
+// buildPageRankMap extracts per-entity PageRank scores from an entity slice.
 // Entities without a PageRank attribute (pre-Pass-4 graphs) return an empty map.
-func buildPageRankMap(doc *graph.Document) map[string]float64 {
-	pr := make(map[string]float64, len(doc.Entities))
-	for i := range doc.Entities {
-		e := &doc.Entities[i]
+// #5870 PR7a: takes []graph.Entity (fed the Reader-served materialize slice)
+// rather than *graph.Document, so it no longer reads the raw lr.Doc.Entities.
+func buildPageRankMap(entities []graph.Entity) map[string]float64 {
+	pr := make(map[string]float64, len(entities))
+	for i := range entities {
+		e := &entities[i]
 		if e.PageRank != nil {
 			pr[e.ID] = *e.PageRank
 		}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -657,8 +657,8 @@ func (s *Server) handleDiagnostics(_ context.Context, req mcpapi.CallToolRequest
 			GraphFile: lr.GraphFile,
 		}
 		if lr.Doc != nil {
-			rh.Entities = len(lr.Doc.Entities)
-			rh.Relationships = len(lr.Doc.Relationships)
+			rh.Entities = lr.entityCount()   // #5870 PR7a
+			rh.Relationships = lr.relCount() // #5870 PR7a
 		}
 		repos = append(repos, rh)
 	}

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -229,11 +229,18 @@ func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.Ca
 		if r.Doc == nil {
 			continue
 		}
-		// Build subscriber set: topics that appear on the ToID of a SUBSCRIBES_TO edge.
-		subscribers := map[string]bool{}
+		// #5870 PR7a: snapshot BOTH edge-target sets in ONE pre-scan relationship
+		// pass, so the topic scan below reads local maps — never r.Doc raw (which
+		// empties after the flip) nor an rmu-locking helper INSIDE the
+		// forEachEntityOfKinds scan (would self-deadlock flag-ON).
+		subscribers := map[string]bool{} // topics that are a SUBSCRIBES_TO target
+		publishedTo := map[string]bool{} // topics that are a PUBLISHES_TO target
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if rel.Kind == "SUBSCRIBES_TO" {
+			switch rel.Kind {
+			case "SUBSCRIBES_TO":
 				subscribers[rel.ToID] = true
+			case "PUBLISHES_TO":
+				publishedTo[rel.ToID] = true
 			}
 			return true
 		})
@@ -242,7 +249,7 @@ func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.Ca
 		// unchanged.
 		r.forEachEntityOfKinds(isTopicKind, func(e *graph.Entity) bool {
 			// Publisher: appears as ToID in a PUBLISHES_TO edge but never as ToID in SUBSCRIBES_TO.
-			if !subscribers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "PUBLISHES_TO") {
+			if !subscribers[e.ID] && publishedTo[e.ID] {
 				out = append(out, item{
 					TopicID:    prefixedID(r.Repo, e.ID),
 					TopicName:  e.Name,
@@ -278,10 +285,16 @@ func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.C
 		if r.Doc == nil {
 			continue
 		}
-		publishers := map[string]bool{}
+		// #5870 PR7a: snapshot BOTH edge-target sets in one pre-scan pass (see the
+		// orphan-publishers handler for the rationale).
+		publishers := map[string]bool{}   // topics that are a PUBLISHES_TO target
+		subscribedTo := map[string]bool{} // topics that are a SUBSCRIBES_TO target
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
-			if rel.Kind == "PUBLISHES_TO" {
+			switch rel.Kind {
+			case "PUBLISHES_TO":
 				publishers[rel.ToID] = true
+			case "SUBSCRIBES_TO":
+				subscribedTo[rel.ToID] = true
 			}
 			return true
 		})
@@ -289,7 +302,7 @@ func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.C
 		// materialization flag-ON); the residual edge-based subscriber filter is
 		// unchanged.
 		r.forEachEntityOfKinds(isTopicKind, func(e *graph.Entity) bool {
-			if !publishers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "SUBSCRIBES_TO") {
+			if !publishers[e.ID] && subscribedTo[e.ID] {
 				out = append(out, item{
 					TopicID:    prefixedID(r.Repo, e.ID),
 					TopicName:  e.Name,
@@ -1269,16 +1282,6 @@ func isTopicKind(kind string) bool {
 func hasRelationshipFrom(doc *graph.Document, fromID, edgeKind string) bool {
 	for i := range doc.Relationships {
 		if doc.Relationships[i].FromID == fromID && doc.Relationships[i].Kind == edgeKind {
-			return true
-		}
-	}
-	return false
-}
-
-// hasRelationshipTo returns true if doc has any edge of edgeKind to toID.
-func hasRelationshipTo(doc *graph.Document, toID, edgeKind string) bool {
-	for i := range doc.Relationships {
-		if doc.Relationships[i].ToID == toID && doc.Relationships[i].Kind == edgeKind {
 			return true
 		}
 	}

--- a/internal/mcp/dead_code.go
+++ b/internal/mcp/dead_code.go
@@ -242,7 +242,7 @@ func computeDeadCodeLive(lg *LoadedGroup, repoFilter map[string]bool, kindFilter
 			return true
 		})
 		reached := bfsLive(adj, seeds)
-		totalEntities += len(r.Doc.Entities)
+		totalEntities += r.entityCount() // #5870 PR7a: Reader-sourced count
 		reachable += len(reached)
 		entryPoints += len(seeds)
 		if len(repoFilter) > 0 && !repoFilter[r.Repo] {
@@ -295,7 +295,7 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 		}
 		if _, ok := r.getByIDOne(local); !ok {
 			// Entry not in this repo; skip without contributing.
-			totalEntities += len(r.Doc.Entities)
+			totalEntities += r.entityCount() // #5870 PR7a: Reader-sourced count
 			continue
 		}
 		adj := map[string][]string{}
@@ -308,7 +308,7 @@ func computeDeadCodeFromEntry(lg *LoadedGroup, fromID string, repoFilter map[str
 		})
 		seeds := map[string]bool{local: true}
 		reached := bfsLive(adj, seeds)
-		totalEntities += len(r.Doc.Entities)
+		totalEntities += r.entityCount() // #5870 PR7a: Reader-sourced count
 		reachable += len(reached)
 		entryPoints += len(seeds)
 		if len(repoFilter) > 0 && !repoFilter[r.Repo] {

--- a/internal/mcp/doc_semantics_tools.go
+++ b/internal/mcp/doc_semantics_tools.go
@@ -98,9 +98,10 @@ func (s *Server) handleApplyDocSemantics(ctx context.Context, req mcpapi.CallToo
 		}
 
 		// Current code entities for target-existence validation.
+		// #5870 PR7a: Reader-served materialize seam instead of raw r.Doc.Entities.
 		var codeEntities []graph.Entity
 		if r.Doc != nil {
-			codeEntities = r.Doc.Entities
+			codeEntities = materializeAllEntities(r)
 		}
 
 		var sidecar docSemanticsSidecar

--- a/internal/mcp/effective_contract_express.go
+++ b/internal/mcp/effective_contract_express.go
@@ -60,6 +60,10 @@ func (x expressContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 		if r.Doc == nil {
 			continue
 		}
+		// #5870 PR7a: collect-then-process — the rmu-locking resolution/compose runs
+		// AFTER the forEach scan releases readerMu (see the nestjs handler for the
+		// full rationale). Vector-index order preserved → identical grouping.
+		var eps []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
 				return true
@@ -67,10 +71,14 @@ func (x expressContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 			if !isExpressEndpoint(e) {
 				return true
 			}
+			eps = append(eps, e)
+			return true
+		})
+		for _, e := range eps {
 			handler := frameworkHandlerEntity(r, e)
 			grp := fastapiGroupLeaf(e, handler) // same flat-function grouping
 			if grp == "" || strings.ToLower(grp) != wantLeaf {
-				return true
+				continue
 			}
 			c := composeExpressContract(r, e, handler)
 			key := groupKey{repo: r.Repo, group: grp}
@@ -81,8 +89,7 @@ func (x expressContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-			return true
-		})
+		}
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_fastapi.go
+++ b/internal/mcp/effective_contract_fastapi.go
@@ -62,6 +62,12 @@ func (f fastAPIContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 		if r.Doc == nil {
 			continue
 		}
+		// #5870 PR7a: collect-then-process — the rmu-locking resolution/compose
+		// (frameworkHandlerEntity→getByIDOne) runs AFTER the forEach releases
+		// readerMu, or it self-deadlocks on the flag-ON default path. Vector-index
+		// order preserved → identical grouping. (Pre-existing hazard, fixed for
+		// family consistency with the nestjs/express handlers.)
+		var eps []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
 				return true
@@ -69,10 +75,14 @@ func (f fastAPIContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 			if !isFastAPIEndpoint(e) {
 				return true
 			}
+			eps = append(eps, e)
+			return true
+		})
+		for _, e := range eps {
 			handler := frameworkHandlerEntity(r, e)
 			grp := fastapiGroupLeaf(e, handler)
 			if grp == "" || strings.ToLower(grp) != wantLeaf {
-				return true
+				continue
 			}
 			c := composeFastAPIContract(r, e, handler)
 			key := groupKey{repo: r.Repo, group: grp}
@@ -83,8 +93,7 @@ func (f fastAPIContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf strin
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-			return true
-		})
+		}
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_nestjs.go
+++ b/internal/mcp/effective_contract_nestjs.go
@@ -55,6 +55,14 @@ func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 		if r.Doc == nil {
 			continue
 		}
+		// #5870 PR7a: collect endpoints under the (pure, rmu-free) filters INSIDE
+		// the forEach scan, then do the rmu-locking resolution/compose AFTER the
+		// scan returns. On the flag-ON default path forEachEntity holds the repo's
+		// readerMu across the WHOLE scan (Option-B, ADR-0027); nestHandlerEntity
+		// (getByIDOne→LabelIndex.at) and composeNestContract (relationshipAt) both
+		// re-lock that same mutex, so calling them in-scan self-deadlocks. Order is
+		// preserved (vector-index order → same grouping), so output is identical.
+		var eps []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
 				return true
@@ -62,10 +70,14 @@ func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 			if !isNestJSEndpoint(e) {
 				return true
 			}
+			eps = append(eps, e)
+			return true
+		})
+		for _, e := range eps {
 			handler := nestHandlerEntity(r, e)
 			controller := nestControllerLeaf(e, handler)
 			if controller == "" || strings.ToLower(controller) != wantLeaf {
-				return true
+				continue
 			}
 			c := composeNestContract(r, e, handler)
 			key := groupKey{repo: r.Repo, class: controller}
@@ -80,8 +92,7 @@ func (n nestJSContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-			return true
-		})
+		}
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_nestjs.go
+++ b/internal/mcp/effective_contract_nestjs.go
@@ -450,13 +450,15 @@ func nestHandlerSource(r *LoadedRepo, handler *graph.Entity) string {
 	return src
 }
 
-// relPropsFor returns the Properties map of the relationship at relIdx in r's
-// Doc, or nil when relIdx is synthetic (-1) or out of range.
+// relPropsFor returns the Properties map of the relationship at relIdx, or nil
+// when relIdx is synthetic (-1) or out of range. #5870 PR7a: sources via
+// relationshipAt (Reader flag-ON / Doc flag-OFF) rather than raw r.Doc.
 func relPropsFor(r *LoadedRepo, relIdx int) map[string]string {
-	if r.Doc == nil || relIdx < 0 || relIdx >= len(r.Doc.Relationships) {
+	rel := r.relationshipAt(relIdx)
+	if rel == nil {
 		return nil
 	}
-	return r.Doc.Relationships[relIdx].PropsSnapshot()
+	return rel.PropsSnapshot()
 }
 
 // appendIntUnique appends v to s only when absent.

--- a/internal/mcp/effective_contract_spring.go
+++ b/internal/mcp/effective_contract_spring.go
@@ -58,6 +58,11 @@ func (s springContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 		if r.Doc == nil {
 			continue
 		}
+		// #5870 PR7a: collect-then-process — rmu-locking resolution/compose runs
+		// AFTER the forEach releases readerMu (see the nestjs handler). Vector-index
+		// order preserved → identical grouping. (Pre-existing hazard, fixed for
+		// family consistency.)
+		var eps []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isServerEndpointDefinition(e) {
 				return true
@@ -65,10 +70,14 @@ func (s springContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 			if !isSpringEndpoint(e) {
 				return true
 			}
+			eps = append(eps, e)
+			return true
+		})
+		for _, e := range eps {
 			handler := frameworkHandlerEntity(r, e)
 			controller := frameworkControllerLeaf(e, handler)
 			if controller == "" || strings.ToLower(controller) != wantLeaf {
-				return true
+				continue
 			}
 			c := composeSpringContract(r, e, handler)
 			key := groupKey{repo: r.Repo, class: controller}
@@ -79,8 +88,7 @@ func (s springContractResolver) Resolve(lg *LoadedGroup, target, wantLeaf string
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-			return true
-		})
+		}
 	}
 	if len(groups) == 0 {
 		return nil, false

--- a/internal/mcp/effective_contract_tool.go
+++ b/internal/mcp/effective_contract_tool.go
@@ -184,6 +184,14 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 		if r.Doc == nil {
 			continue
 		}
+		// #5870 PR7a: collect matching routes under the pure filters INSIDE the
+		// scan, then run the rmu-locking MRO backfill AFTER the forEach releases
+		// readerMu. backfillEffectiveContractFromMRO→resolveMember re-locks the
+		// repo readerMu (extendsBases→relationshipAt) AND runs a nested
+		// forEachEntity (classDeclaredMember), both of which self-deadlock in-scan
+		// on the flag-ON default path. Vector-index order preserved → identical
+		// grouping/output.
+		var routes []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if !isRouterExpandedRoute(e) {
 				return true
@@ -192,9 +200,14 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 			if vs == "" || strings.ToLower(vs) != wantVS {
 				return true
 			}
+			routes = append(routes, e)
+			return true
+		})
+		for _, e := range routes {
+			vs := viewSetNameForRoute(e)
 			c, ok := projectEffectiveContract(e)
 			if !ok {
-				return true
+				continue
 			}
 			// #3964 follow-up: when the route carries no stamped per-verb
 			// contract (effective_kind/effective_status absent because the
@@ -215,8 +228,7 @@ func computeEffectiveContract(lg *LoadedGroup, target string) effectiveContractR
 				order = append(order, key)
 			}
 			g.Handlers = append(g.Handlers, c)
-			return true
-		})
+		}
 	}
 
 	// CLASS FALLBACK (deploy-9 item-4): when NO router-expanded route entities
@@ -347,8 +359,14 @@ func findViewSetClassEntity(r *LoadedRepo, wantVS string) *graph.Entity {
 	if r.Doc == nil {
 		return nil
 	}
-	var fallback *graph.Entity
 	var found *graph.Entity
+	// #5870 PR7a: collect name-matching candidates INSIDE the scan; run the
+	// rmu-locking extendsBases (→relationshipAt) AFTER the forEach releases
+	// readerMu (in-scan it self-deadlocks on the flag-ON default path). The
+	// isClassEntity short-circuit is pure so it stays in-scan (byte-identical
+	// first-match-wins). The fallback is the FIRST name-matching non-class entity
+	// with an EXTENDS/IMPLEMENTS edge — same as the original.
+	var candidates []*graph.Entity
 	r.forEachEntity(func(e *graph.Entity) bool {
 		if strings.ToLower(leafAfterDot(e.Name)) != wantVS {
 			return true
@@ -357,15 +375,18 @@ func findViewSetClassEntity(r *LoadedRepo, wantVS string) *graph.Entity {
 			found = e
 			return false
 		}
-		if fallback == nil && len(extendsBases(r, e)) > 0 {
-			fallback = e
-		}
+		candidates = append(candidates, e)
 		return true
 	})
 	if found != nil {
 		return found
 	}
-	return fallback
+	for _, e := range candidates {
+		if len(extendsBases(r, e)) > 0 {
+			return e
+		}
+	}
+	return nil
 }
 
 // classFramework reports the route framework leaf for a ViewSet class entity,

--- a/internal/mcp/flagon_deadlock_5870_pr7a_test.go
+++ b/internal/mcp/flagon_deadlock_5870_pr7a_test.go
@@ -1,0 +1,251 @@
+// flagon_deadlock_5870_pr7a_test.go — deretain-flip PR7a (#5870), review round 2.
+//
+// The flag-ON default read path (serveFromMMap()==true with a LIVE Reader) holds
+// the repo's readerMu across the ENTIRE forEach* scan (Option-B, ADR-0027). Any
+// rmu-locking accessor called from INSIDE a forEach callback — relationshipAt
+// (PR7a), getByIDOne/LabelIndex.at (pre-existing), or a NESTED forEach — re-locks
+// that non-reentrant mutex and self-deadlocks. The suite previously only ran
+// these tools flag-OFF (Doc-only repos take the unlocked fallback), so the
+// deadlock was invisible.
+//
+// These tests run the affected tools flag-ON with a LIVE Reader and an EMPTIED
+// Doc (simulating the future slice-drop), each under a hard timeout: without the
+// collect-then-process fixes they HANG (fail); with them they complete AND match
+// the flag-OFF full-Doc result.
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// noHang runs fn in a goroutine and fails if it does not return within d — the
+// deadlock guard. Returns only after fn completes (or the test has failed).
+func noHang(t *testing.T, d time.Duration, what string, fn func()) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() { defer close(done); fn() }()
+	select {
+	case <-done:
+	case <-time.After(d):
+		t.Fatalf("DEADLOCK: %s hung >%s on the flag-ON live-Reader path", what, d)
+	}
+}
+
+// contractMroTopoDoc builds one fixture exercising the flag-ON deadlock sites:
+// a NestJS endpoint+handler+VALIDATES (composeNestContract→relPropsFor), an
+// Express endpoint+handler+VALIDATES, a DRF ViewSet class + members + EXTENDS
+// (findViewSetClassEntity / buildMROInbound), and Topic entities with
+// PUBLISHES_TO / SUBSCRIBES_TO edges (topology orphan pub/sub).
+func contractMroTopoDoc() *graph.Document {
+	mkEnt := func(id, name, kind string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, QualifiedName: name, Kind: kind, SourceFile: "src/" + id + ".ts", Language: "typescript", StartLine: 1, EndLine: 5}
+	}
+	nestEp := graph.Entity{ID: "nestep", Name: "POST /users", Kind: "http_endpoint_definition", SourceFile: "src/users.controller.ts", Language: "typescript", StartLine: 10, EndLine: 12}
+	nestEp.PropSet("framework", "nestjs")
+	nestEp.PropSet("verb", "POST")
+	nestEp.PropSet("path", "/users")
+	nestHandler := mkEnt("nesthandler", "UsersController.create", "SCOPE.Operation")
+	nestDto := mkEnt("nestdto", "CreateUserDto", "SCOPE.Component")
+
+	expEp := graph.Entity{ID: "expep", Name: "GET /items", Kind: "http_endpoint_definition", SourceFile: "src/items.ts", Language: "javascript", StartLine: 20, EndLine: 22}
+	expEp.PropSet("framework", "express")
+	expEp.PropSet("verb", "GET")
+	expEp.PropSet("path", "/items")
+	expHandler := mkEnt("exphandler", "getItems", "SCOPE.Operation")
+	expHandler.SourceFile = "src/items.js"
+	expDto := mkEnt("expdto", "itemSchema", "SCOPE.Component")
+
+	// DRF ViewSet class + member (MRO).
+	vs := graph.Entity{ID: "vs", Name: "UserViewSet", QualifiedName: "UserViewSet", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "api/views.py", Language: "python", StartLine: 1, EndLine: 30}
+	member := graph.Entity{ID: "vsmember", Name: "UserViewSet.list", QualifiedName: "UserViewSet.list", Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "api/views.py", Language: "python", StartLine: 5, EndLine: 9}
+	member.PropSet("has_real_body", "true")
+
+	// Topics + pub/sub edges.
+	topicPub := graph.Entity{ID: "t_orders", Name: "orders.created", Kind: "Topic", SourceFile: "events.py", Language: "python"}
+	topicSub := graph.Entity{ID: "t_ships", Name: "ships.done", Kind: "Topic", SourceFile: "events.py", Language: "python"}
+	pubSvc := mkEnt("pubsvc", "OrderService", "SCOPE.Operation")
+	subSvc := mkEnt("subsvc", "ShipService", "SCOPE.Operation")
+
+	ents := []graph.Entity{nestEp, nestHandler, nestDto, expEp, expHandler, expDto, vs, member, topicPub, topicSub, pubSvc, subSvc}
+
+	mkRel := func(from, to, kind string, props map[string]string) graph.Relationship {
+		r := graph.Relationship{FromID: from, ToID: to, Kind: kind}
+		if props != nil {
+			r.PropsReplace(props)
+		}
+		return r
+	}
+	rels := []graph.Relationship{
+		mkRel("nesthandler", "nestep", "IMPLEMENTS", nil),
+		mkRel("nesthandler", "nestdto", "VALIDATES", map[string]string{"dto": "CreateUserDto", "method": "body"}),
+		mkRel("exphandler", "expep", "IMPLEMENTS", nil),
+		mkRel("exphandler", "expdto", "VALIDATES", map[string]string{"dto": "itemSchema", "method": "query"}),
+		mkRel("vs", "ModelViewSet", "EXTENDS", map[string]string{"base_name": "rest_framework.viewsets.ModelViewSet"}),
+		mkRel("vs", "vsmember", "CONTAINS", nil),
+		mkRel("pubsvc", "t_orders", "PUBLISHES_TO", nil),
+		mkRel("subsvc", "t_ships", "SUBSCRIBES_TO", nil),
+	}
+	return &graph.Document{Repo: "corpus", Entities: ents, Relationships: rels}
+}
+
+func loadContractMroTopoFixture(t *testing.T) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, contractMroTopoDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+// lgWith builds a single-repo LoadedGroup around lr.
+func lgWith(lr *LoadedRepo) *LoadedGroup {
+	return &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"corpus": lr}}
+}
+
+func TestEffectiveContractNestJS_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	withServeFromMMap(t, false)
+	wantGroups, wantOK := nestJSContractResolver{}.Resolve(lgWith(docFullRepo(doc)), "UsersController", "userscontroller")
+	if !wantOK || len(wantGroups) == 0 {
+		t.Fatalf("fixture must yield a NestJS contract (ok=%v groups=%d)", wantOK, len(wantGroups))
+	}
+
+	withServeFromMMap(t, true)
+	var gotGroups []effectiveContractGroup
+	var gotOK bool
+	noHang(t, 5*time.Second, "nestJSContractResolver.Resolve", func() {
+		gotGroups, gotOK = nestJSContractResolver{}.Resolve(lgWith(readerEmptiedRepo(t, doc, r)), "UsersController", "userscontroller")
+	})
+	if gotOK != wantOK || !reflect.DeepEqual(gotGroups, wantGroups) {
+		t.Fatalf("NestJS contract flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", gotGroups, wantGroups)
+	}
+}
+
+func TestEffectiveContractExpress_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	withServeFromMMap(t, false)
+	wantGroups, wantOK := expressContractResolver{}.Resolve(lgWith(docFullRepo(doc)), "getItems", "getitems")
+
+	withServeFromMMap(t, true)
+	var gotGroups []effectiveContractGroup
+	var gotOK bool
+	noHang(t, 5*time.Second, "expressContractResolver.Resolve", func() {
+		gotGroups, gotOK = expressContractResolver{}.Resolve(lgWith(readerEmptiedRepo(t, doc, r)), "getItems", "getitems")
+	})
+	if gotOK != wantOK || !reflect.DeepEqual(gotGroups, wantGroups) {
+		t.Fatalf("Express contract flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", gotGroups, wantGroups)
+	}
+}
+
+func TestFindViewSetClassEntity_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	withServeFromMMap(t, false)
+	want := findViewSetClassEntity(docFullRepo(doc), "userviewset")
+	if want == nil {
+		t.Fatal("fixture must contain a UserViewSet class entity with an EXTENDS edge")
+	}
+
+	withServeFromMMap(t, true)
+	var got *graph.Entity
+	noHang(t, 5*time.Second, "findViewSetClassEntity", func() {
+		got = findViewSetClassEntity(readerEmptiedRepo(t, doc, r), "userviewset")
+	})
+	if got == nil || got.ID != want.ID {
+		t.Fatalf("findViewSetClassEntity flag-ON(emptied Doc) got=%v want id=%s", got, want.ID)
+	}
+}
+
+func TestBuildMROInbound_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	withServeFromMMap(t, false)
+	want := buildMROInbound(docFullRepo(doc))
+
+	withServeFromMMap(t, true)
+	var got map[string][]string
+	noHang(t, 5*time.Second, "buildMROInbound", func() {
+		got = buildMROInbound(readerEmptiedRepo(t, doc, r))
+	})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("buildMROInbound flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+}
+
+func topologyServer(t *testing.T, lr *LoadedRepo) *Server {
+	t.Helper()
+	reg := &Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{"corpus": {Path: t.TempDir()}}}}}
+	st := NewState(reg)
+	st.mu.Lock()
+	st.groups["g"] = lgWith(lr)
+	st.mu.Unlock()
+	return &Server{State: st, Tel: NewTelemetry(0)}
+}
+
+func callTopology(t *testing.T, s *Server, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error)) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if res == nil || len(res.Content) == 0 {
+		return ""
+	}
+	if tc, ok := res.Content[0].(mcpapi.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+func TestTopologyOrphans_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	withServeFromMMap(t, false)
+	sOff := topologyServer(t, docFullRepo(doc))
+	wantPub := callTopology(t, sOff, sOff.handleTopologyOrphanPublishers)
+	wantSub := callTopology(t, sOff, sOff.handleTopologyOrphanSubscribers)
+
+	withServeFromMMap(t, true)
+	sOn := topologyServer(t, readerEmptiedRepo(t, doc, r))
+	var gotPub, gotSub string
+	noHang(t, 5*time.Second, "handleTopologyOrphanPublishers", func() {
+		gotPub = callTopology(t, sOn, sOn.handleTopologyOrphanPublishers)
+	})
+	noHang(t, 5*time.Second, "handleTopologyOrphanSubscribers", func() {
+		gotSub = callTopology(t, sOn, sOn.handleTopologyOrphanSubscribers)
+	})
+	if gotPub != wantPub {
+		t.Fatalf("orphan publishers flag-ON != flag-OFF\n got=%s\nwant=%s", gotPub, wantPub)
+	}
+	if gotSub != wantSub {
+		t.Fatalf("orphan subscribers flag-ON != flag-OFF\n got=%s\nwant=%s", gotSub, wantSub)
+	}
+	// Teeth: the fixture has exactly one orphan publisher (orders.created) and one
+	// orphan subscriber (ships.done).
+	if wantPub == "" || wantSub == "" {
+		t.Fatal("fixture must produce a non-empty topology result")
+	}
+}

--- a/internal/mcp/flagon_deadlock_5870_pr7a_test.go
+++ b/internal/mcp/flagon_deadlock_5870_pr7a_test.go
@@ -64,6 +64,20 @@ func contractMroTopoDoc() *graph.Document {
 	expHandler.SourceFile = "src/items.js"
 	expDto := mkEnt("expdto", "itemSchema", "SCOPE.Component")
 
+	faEp := graph.Entity{ID: "faep", Name: "GET /things", Kind: "http_endpoint_definition", SourceFile: "app/api.py", Language: "python", StartLine: 30, EndLine: 32}
+	faEp.PropSet("framework", "fastapi")
+	faEp.PropSet("verb", "GET")
+	faEp.PropSet("path", "/things")
+	faHandler := mkEnt("fahandler", "get_thing", "SCOPE.Operation")
+	faHandler.SourceFile = "app/api.py"
+
+	spEp := graph.Entity{ID: "spep", Name: "GET /accounts", Kind: "http_endpoint_definition", SourceFile: "src/AccountController.java", Language: "java", StartLine: 40, EndLine: 42}
+	spEp.PropSet("framework", "spring")
+	spEp.PropSet("verb", "GET")
+	spEp.PropSet("path", "/accounts")
+	spHandler := mkEnt("sphandler", "AccountController.list", "SCOPE.Operation")
+	spHandler.SourceFile = "src/AccountController.java"
+
 	// DRF ViewSet class + member (MRO).
 	vs := graph.Entity{ID: "vs", Name: "UserViewSet", QualifiedName: "UserViewSet", Kind: "SCOPE.Component", Subtype: "class", SourceFile: "api/views.py", Language: "python", StartLine: 1, EndLine: 30}
 	member := graph.Entity{ID: "vsmember", Name: "UserViewSet.list", QualifiedName: "UserViewSet.list", Kind: "SCOPE.Operation", Subtype: "method", SourceFile: "api/views.py", Language: "python", StartLine: 5, EndLine: 9}
@@ -75,7 +89,7 @@ func contractMroTopoDoc() *graph.Document {
 	pubSvc := mkEnt("pubsvc", "OrderService", "SCOPE.Operation")
 	subSvc := mkEnt("subsvc", "ShipService", "SCOPE.Operation")
 
-	ents := []graph.Entity{nestEp, nestHandler, nestDto, expEp, expHandler, expDto, vs, member, topicPub, topicSub, pubSvc, subSvc}
+	ents := []graph.Entity{nestEp, nestHandler, nestDto, expEp, expHandler, expDto, faEp, faHandler, spEp, spHandler, vs, member, topicPub, topicSub, pubSvc, subSvc}
 
 	mkRel := func(from, to, kind string, props map[string]string) graph.Relationship {
 		r := graph.Relationship{FromID: from, ToID: to, Kind: kind}
@@ -89,6 +103,8 @@ func contractMroTopoDoc() *graph.Document {
 		mkRel("nesthandler", "nestdto", "VALIDATES", map[string]string{"dto": "CreateUserDto", "method": "body"}),
 		mkRel("exphandler", "expep", "IMPLEMENTS", nil),
 		mkRel("exphandler", "expdto", "VALIDATES", map[string]string{"dto": "itemSchema", "method": "query"}),
+		mkRel("fahandler", "faep", "IMPLEMENTS", nil),
+		mkRel("sphandler", "spep", "IMPLEMENTS", nil),
 		mkRel("vs", "ModelViewSet", "EXTENDS", map[string]string{"base_name": "rest_framework.viewsets.ModelViewSet"}),
 		mkRel("vs", "vsmember", "CONTAINS", nil),
 		mkRel("pubsvc", "t_orders", "PUBLISHES_TO", nil),
@@ -155,6 +171,41 @@ func TestEffectiveContractExpress_flagON_noDeadlock_PR7a(t *testing.T) {
 	})
 	if gotOK != wantOK || !reflect.DeepEqual(gotGroups, wantGroups) {
 		t.Fatalf("Express contract flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", gotGroups, wantGroups)
+	}
+}
+
+// TestEffectiveContractFastAPISpring_flagON_noDeadlock_PR7a covers the sibling
+// frameworks (fastapi + spring), whose forEach scans have the SAME pre-existing
+// frameworkHandlerEntity→getByIDOne in-scan hazard, fixed for family consistency.
+func TestEffectiveContractFastAPISpring_flagON_noDeadlock_PR7a(t *testing.T) {
+	doc, r := loadContractMroTopoFixture(t)
+
+	cases := []struct {
+		name    string
+		resolve func(lg *LoadedGroup) ([]effectiveContractGroup, bool)
+	}{
+		{"fastapi", func(lg *LoadedGroup) ([]effectiveContractGroup, bool) {
+			return fastAPIContractResolver{}.Resolve(lg, "get_thing", "get_thing")
+		}},
+		{"spring", func(lg *LoadedGroup) ([]effectiveContractGroup, bool) {
+			return springContractResolver{}.Resolve(lg, "AccountController", "accountcontroller")
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			withServeFromMMap(t, false)
+			wantG, wantOK := tc.resolve(lgWith(docFullRepo(doc)))
+
+			withServeFromMMap(t, true)
+			var gotG []effectiveContractGroup
+			var gotOK bool
+			noHang(t, 5*time.Second, tc.name+"ContractResolver.Resolve", func() {
+				gotG, gotOK = tc.resolve(lgWith(readerEmptiedRepo(t, doc, r)))
+			})
+			if gotOK != wantOK || !reflect.DeepEqual(gotG, wantG) {
+				t.Fatalf("%s contract flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", tc.name, gotG, wantG)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/license_tools.go
+++ b/internal/mcp/license_tools.go
@@ -87,7 +87,7 @@ func (s *Server) handleLicenseAudit(_ context.Context, req mcpapi.CallToolReques
 			continue
 		}
 
-		result, err := licenses.ScanRepoLicenses(r.Path, packageList, len(r.Doc.Entities))
+		result, err := licenses.ScanRepoLicenses(r.Path, packageList, r.entityCount()) // #5870 PR7a
 		if err != nil {
 			continue
 		}

--- a/internal/mcp/module_gds_tools.go
+++ b/internal/mcp/module_gds_tools.go
@@ -40,7 +40,9 @@ func computeModuleAnalysis(repos []*LoadedRepo) []moduleAnalysisResult {
 		if r.Doc == nil {
 			continue
 		}
-		res := graph.RunModuleAlgorithms(r.Doc.Entities, r.Doc.Relationships)
+		// #5870 PR7a: Reader-served materialize seam (transient copy) instead of
+		// the raw lr.Doc.* slices — heavy/rare pass, transient copy acceptable.
+		res := graph.RunModuleAlgorithms(materializeAllEntities(r), materializeAllRelationships(r))
 		out = append(out, moduleAnalysisResult{Repo: r.Repo, Res: res})
 	}
 	return out

--- a/internal/mcp/mro.go
+++ b/internal/mcp/mro.go
@@ -433,15 +433,15 @@ type baseRef struct {
 // and falls back to the ToID leaf / target entity name.
 func extendsBases(lr *LoadedRepo, c *graph.Entity) []baseRef {
 	adj := lr.getAdjacency()
-	rels := lr.Doc.Relationships
 	var out []baseRef
 	for _, ed := range adj.Outgoing(c.ID) {
 		if ed.kind != "EXTENDS" && ed.kind != "IMPLEMENTS" {
 			continue
 		}
 		name := ""
-		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
-			name = rels[ed.relIdx].PropGet("base_name")
+		// #5870 PR7a: relationshipAt replaces the raw lr.Doc.Relationships lookup.
+		if rel := lr.relationshipAt(ed.relIdx); rel != nil {
+			name = rel.PropGet("base_name")
 		}
 		target := lr.LabelIndex.ByID(ed.target)
 		if name == "" {

--- a/internal/mcp/mro_traverse.go
+++ b/internal/mcp/mro_traverse.go
@@ -191,18 +191,27 @@ func buildMROInbound(lr *LoadedRepo) map[string][]string {
 	if lr == nil || lr.Doc == nil {
 		return out
 	}
+	// #5870 PR7a: collect member entities INSIDE the scan, then resolve their MRO
+	// edges AFTER the forEach releases readerMu. mroOutboundEdges→resolveMember
+	// runs a NESTED forEachEntity (classDeclaredMember) and — post-PR7a —
+	// extendsBases→relationshipAt, both of which re-lock the repo readerMu and
+	// self-deadlock in-scan on the flag-ON default path. Vector-index order
+	// preserved → identical out map.
+	var members []*graph.Entity
 	lr.forEachEntity(func(e *graph.Entity) bool {
-		if !isMemberEntity(e) {
-			return true
+		if isMemberEntity(e) {
+			members = append(members, e)
 		}
+		return true
+	})
+	for _, e := range members {
 		for _, me := range mroOutboundEdges(lr, e.ID) {
 			if me.External {
 				continue
 			}
 			out[me.Target] = append(out[me.Target], e.ID)
 		}
-		return true
-	})
+	}
 	return out
 }
 

--- a/internal/mcp/relaccess_migrate_5870_pr7a_test.go
+++ b/internal/mcp/relaccess_migrate_5870_pr7a_test.go
@@ -1,0 +1,103 @@
+// relaccess_migrate_5870_pr7a_test.go — deretain-flip PR7a (#5870).
+//
+// Result-equivalence for the relationship random-access migrations: the
+// adjacency-relIdx property lookups (inspect discriminators/semantic edges,
+// mro extendsBases, effective-contract relPropsFor) now source the backing
+// relationship via lr.relationshipAt instead of the raw lr.Doc.Relationships
+// slice. Each asserts the migrated function on a flag-ON emptied-Doc repo
+// (Reader-sourced) is byte-identical to the flag-OFF full-Doc result.
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func entByID(doc *graph.Document, id string) *graph.Entity {
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == id {
+			return &doc.Entities[i]
+		}
+	}
+	return nil
+}
+
+func TestExtendsBases_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+	fa := entByID(doc, "fa")
+
+	withServeFromMMap(t, false)
+	want := extendsBases(docFullRepo(doc), fa)
+	if len(want) == 0 {
+		t.Fatal("fixture must have an EXTENDS base for fa")
+	}
+
+	withServeFromMMap(t, true)
+	got := extendsBases(readerEmptiedRepo(t, doc, r), fa)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("extendsBases flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+	if fb := extendsBases(readerFullRepoRetired(t, doc, r), fa); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("extendsBases retired-Reader fallback != flag-OFF")
+	}
+}
+
+func TestRelPropsFor_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, true)
+	lrOn := readerEmptiedRepo(t, doc, r)
+	withServeFromMMap(t, false)
+	lrOff := docFullRepo(doc)
+
+	for i := range doc.Relationships {
+		withServeFromMMap(t, false)
+		want := relPropsFor(lrOff, i)
+		withServeFromMMap(t, true)
+		got := relPropsFor(lrOn, i)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("relPropsFor(%d) flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", i, got, want)
+		}
+	}
+	// Synthetic index -> nil on both paths.
+	withServeFromMMap(t, true)
+	if relPropsFor(lrOn, -1) != nil {
+		t.Fatal("relPropsFor(-1) must be nil")
+	}
+}
+
+func TestInspectDiscriminators_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+	fa := entByID(doc, "fa")
+
+	withServeFromMMap(t, false)
+	want := inspectDiscriminators(docFullRepo(doc), fa, true)
+
+	withServeFromMMap(t, true)
+	got := inspectDiscriminators(readerEmptiedRepo(t, doc, r), fa, true)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("inspectDiscriminators flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+	if fb := inspectDiscriminators(readerFullRepoRetired(t, doc, r), fa, true); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("inspectDiscriminators retired-Reader fallback != flag-OFF")
+	}
+}
+
+func TestInspectSemanticEdges_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+	fa := entByID(doc, "fa")
+
+	withServeFromMMap(t, false)
+	want := inspectSemanticEdges(docFullRepo(doc), fa, true, isSemanticEdgeKind)
+
+	withServeFromMMap(t, true)
+	got := inspectSemanticEdges(readerEmptiedRepo(t, doc, r), fa, true, isSemanticEdgeKind)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("inspectSemanticEdges flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+	if fb := inspectSemanticEdges(readerFullRepoRetired(t, doc, r), fa, true, isSemanticEdgeKind); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("inspectSemanticEdges retired-Reader fallback != flag-OFF")
+	}
+}

--- a/internal/mcp/repair_verify.go
+++ b/internal/mcp/repair_verify.go
@@ -119,19 +119,26 @@ func VerifyRepairSubmit(
 }
 
 // buildVerifyContext extracts the from_entity_id and the CONTAINS-parent
-// map from the loaded graph document. Used by handleSubmitRepair to
-// populate VerifyRepairSubmit's context arguments.
-func buildVerifyContext(doc *graph.Document) (map[string]*graph.Entity, map[string]map[string]bool) {
-	if doc == nil {
+// map from the loaded graph. Used by handleSubmitRepair to populate
+// VerifyRepairSubmit's context arguments.
+//
+// #5870 PR7a: sources the whole entity/relationship set via the Reader-served
+// materialize seam (transient snapshot) instead of the raw lr.Doc slices, so it
+// survives a future slice-drop. byID points into the snapshot slice (stable for
+// the caller's lifetime). Not called inside a forEach scan, so the per-call rmu
+// acquisitions inside materializeAll* are sequential and safe.
+func buildVerifyContext(lr *LoadedRepo) (map[string]*graph.Entity, map[string]map[string]bool) {
+	if lr == nil || lr.Doc == nil {
 		return nil, nil
 	}
-	byID := make(map[string]*graph.Entity, len(doc.Entities))
-	for i := range doc.Entities {
-		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	ents := materializeAllEntities(lr)
+	byID := make(map[string]*graph.Entity, len(ents))
+	for i := range ents {
+		byID[ents[i].ID] = &ents[i]
 	}
 	// Build transitive CONTAINS-parent map for R4.
 	directParents := make(map[string]map[string]bool)
-	for _, r := range doc.Relationships {
+	for _, r := range materializeAllRelationships(lr) {
 		if r.Kind != "CONTAINS" {
 			continue
 		}

--- a/internal/mcp/repair_verify_test.go
+++ b/internal/mcp/repair_verify_test.go
@@ -167,7 +167,7 @@ func TestBuildVerifyContext_BasicGraph(t *testing.T) {
 			{FromID: "bbbbbbbbbbbbbbbb", ToID: "aaaaaaaaaaaaaaaa", Kind: "CONTAINS"},
 		},
 	}
-	ents, parents := buildVerifyContext(doc)
+	ents, parents := buildVerifyContext(&LoadedRepo{Doc: doc})
 	if len(ents) != 2 {
 		t.Fatalf("ents len=%d want 2", len(ents))
 	}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -420,8 +420,8 @@ func groupIndexCounts(lg *LoadedGroup) (entities, relationships, testsEdges int)
 		if r == nil || r.Doc == nil {
 			continue
 		}
-		entities += len(r.Doc.Entities)
-		relationships += len(r.Doc.Relationships)
+		entities += r.entityCount()   // #5870 PR7a
+		relationships += r.relCount() // #5870 PR7a
 		testsEdges += r.TestsEdgeCount
 	}
 	return
@@ -3296,8 +3296,8 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 			unavailable = append(unavailable, name+": "+r.loadErr)
 			continue
 		}
-		totalE += len(r.Doc.Entities)
-		totalR += len(r.Doc.Relationships)
+		totalE += r.entityCount() // #5870 PR7a
+		totalR += r.relCount()    // #5870 PR7a
 		rImport, rBug := countEdgesForFidelity(r)
 		totalImport += rImport
 		totalBug += rBug
@@ -3307,8 +3307,8 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 		}
 		repoStats = append(repoStats, map[string]any{
 			"repo":          name,
-			"entities":      len(r.Doc.Entities),
-			"relationships": len(r.Doc.Relationships),
+			"entities":      r.entityCount(),
+			"relationships": r.relCount(),
 			"communities":   commCount,
 		})
 		loadedRepos = append(loadedRepos, r)

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2667,7 +2667,9 @@ func (s *Server) handleOrient(ctx context.Context, req mcpapi.CallToolRequest) (
 		if r.Doc == nil {
 			continue
 		}
-		res := graph.AnalyzeOrientation(r.Doc.Entities, r.Doc.Relationships, opts)
+		// #5870 PR7a: Reader-served materialize seam (transient copy) instead of
+		// the raw lr.Doc.* slices — heavy/rare pass, transient copy acceptable.
+		res := graph.AnalyzeOrientation(materializeAllEntities(r), materializeAllRelationships(r), opts)
 		analyzed = append(analyzed, &res)
 		names = append(names, r.Repo)
 		for _, n := range []int{len(res.KeyEntities), len(res.CrossCutEdges), len(res.Questions)} {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2433,16 +2433,27 @@ func normalizePrefixed(lg *LoadedGroup, s string) string {
 			if r.Doc == nil {
 				continue
 			}
-			found := false
+			// #5870 PR7a: collect entity IDs INSIDE the scan, resolve MRO edges
+			// AFTER it releases readerMu. mroOutboundEdges→resolveMember runs a
+			// nested forEachEntity + extendsBases→relationshipAt, both of which
+			// re-lock the repo readerMu and self-deadlock in-scan flag-ON.
+			var ids []string
 			r.forEachEntity(func(e *graph.Entity) bool {
-				for _, me := range mroOutboundEdges(r, e.ID) {
-					if me.External && me.Target == s {
-						found = true
-						return false
-					}
-				}
+				ids = append(ids, e.ID)
 				return true
 			})
+			found := false
+			for _, id := range ids {
+				for _, me := range mroOutboundEdges(r, id) {
+					if me.External && me.Target == s {
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
 			if found {
 				return prefixedID(r.Repo, s)
 			}
@@ -3798,7 +3809,7 @@ func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.Ca
 
 	// ── Trust-model R1-R7 ────────────────────────────────────────────────
 	// Build verify context from the loaded graph document.
-	docEnts, containsParents := buildVerifyContext(target.Doc)
+	docEnts, containsParents := buildVerifyContext(target)
 	edgeIDSet := candidateEdgeIDSet(candidates)
 	fromEntityID := fromEntityIDForEdge(candidates, edgeID)
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1423,12 +1423,13 @@ func agentResolvedEdgesForEntity(lr *LoadedRepo, entityID string, scopeIsOne boo
 	// underlying Relationship to read Properties (kind/target alone would not
 	// suffice for the agent-repair filter).
 	out := []map[string]any(nil)
-	rels := lr.Doc.Relationships
+	// #5870 PR7a: relationshipAt (Reader flag-ON / Doc flag-OFF) replaces the
+	// raw lr.Doc.Relationships random-access by relIdx.
 	for _, e := range lr.getAdjacency().Outgoing(entityID) {
-		if e.relIdx < 0 || e.relIdx >= len(rels) {
+		r := lr.relationshipAt(e.relIdx)
+		if r == nil {
 			continue
 		}
-		r := &rels[e.relIdx]
 		if r.PropGet("resolved_by") != "agent-repair" {
 			continue
 		}
@@ -1504,7 +1505,6 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, incl
 		return []map[string]any{}
 	}
 	out := []map[string]any{}
-	rels := lr.Doc.Relationships
 	for _, ed := range lr.getAdjacency().Outgoing(e.ID) {
 		if !strings.EqualFold(ed.kind, "CALLS") {
 			continue
@@ -1532,15 +1532,15 @@ func inspectOutboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, incl
 		if unresolved && !includeUnresolved {
 			continue
 		}
-		// Line number from relationship properties.
+		// Line number from relationship properties. #5870 PR7a: relationshipAt.
 		lineNum := 0
-		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
-			if v := rels[ed.relIdx].PropGet("line"); v != "" {
+		if rel := lr.relationshipAt(ed.relIdx); rel != nil {
+			if v := rel.PropGet("line"); v != "" {
 				if n, err := strconv.Atoi(v); err == nil {
 					lineNum = n
 				}
 			}
-			if v := rels[ed.relIdx].PropGet("via"); v != "" {
+			if v := rel.PropGet("via"); v != "" {
 				entry["via"] = v
 			}
 		}
@@ -1623,7 +1623,6 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 	lineCache := map[string][]string{}
 
 	out := []map[string]any{}
-	rels := lr.Doc.Relationships
 	for _, ed := range lr.getAdjacency().Incoming(e.ID) {
 		// #5686: besides direct CALLS callers, surface the async trigger of an
 		// event-driven handler. A DELIVERS_TO edge (topic → handler) is the
@@ -1659,8 +1658,8 @@ func inspectInboundCalls(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []map
 		}
 
 		lineNum := 0
-		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
-			if v := rels[ed.relIdx].PropGet("line"); v != "" {
+		if rel := lr.relationshipAt(ed.relIdx); rel != nil {
+			if v := rel.PropGet("line"); v != "" {
 				if n, err := strconv.Atoi(v); err == nil {
 					lineNum = n
 				}
@@ -1708,12 +1707,12 @@ func inspectDiscriminators(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool) []m
 		return nil
 	}
 	out := []map[string]any{}
-	rels := lr.Doc.Relationships
 	emit := func(ed edge, otherIsTarget bool) {
-		if ed.relIdx < 0 || ed.relIdx >= len(rels) {
+		// #5870 PR7a: relationshipAt replaces the raw lr.Doc.Relationships lookup.
+		r := lr.relationshipAt(ed.relIdx)
+		if r == nil {
 			return
 		}
-		r := &rels[ed.relIdx]
 		line := 0
 		if v := r.PropGet("line"); v != "" {
 			if n, err := strconv.Atoi(v); err == nil {
@@ -1875,7 +1874,6 @@ func inspectSemanticEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, acce
 		return nil
 	}
 	out := []map[string]any{}
-	rels := lr.Doc.Relationships
 	emit := func(ed edge, direction string) {
 		other := ed.target
 		if !scopeIsOne {
@@ -1889,8 +1887,8 @@ func inspectSemanticEdges(lr *LoadedRepo, e *graph.Entity, scopeIsOne bool, acce
 			"other":     other,
 			"line":      0,
 		}
-		if ed.relIdx >= 0 && ed.relIdx < len(rels) {
-			if v := rels[ed.relIdx].PropGet("line"); v != "" {
+		if rel := lr.relationshipAt(ed.relIdx); rel != nil {
+			if v := rel.PropGet("line"); v != "" {
 				if n, err := strconv.Atoi(v); err == nil {
 					entry["line"] = n
 				}

--- a/internal/mcp/view_materialize.go
+++ b/internal/mcp/view_materialize.go
@@ -65,6 +65,19 @@ func materializeAllRelationships(lr *LoadedRepo) []graph.Relationship {
 	return out
 }
 
+// materializedDoc builds a TRANSIENT *graph.Document whose Entities and
+// Relationships are the Reader-served materialize copies of lr's full set. It is
+// the adapter for the analytical graph.* functions that take a *graph.Document
+// but read ONLY doc.Entities/doc.Relationships (ComputeCoverage /
+// ComputeEntityCoverage). Byte-identical to passing lr.Doc pre-flip; the future
+// slice-drop is invisible because the slices come from the Reader flag-ON.
+func materializedDoc(lr *LoadedRepo) *graph.Document {
+	return &graph.Document{
+		Entities:      materializeAllEntities(lr),
+		Relationships: materializeAllRelationships(lr),
+	}
+}
+
 // relationshipAt returns a *graph.Relationship for vector index idx, or nil when
 // idx is synthetic (<0) or out of range. It is the random-access companion to
 // forEachRelationship for the adjacency-relIdx property lookups.

--- a/internal/mcp/view_materialize.go
+++ b/internal/mcp/view_materialize.go
@@ -1,0 +1,155 @@
+// view_materialize.go — ADR-0027 mmap-cutover (memory epic #5850), deretain-flip
+// PR7a (#5870). Behavior-neutral read-seam migration prep.
+//
+// The tools in this package that need the WHOLE entity/relationship set as a
+// slice — the heavy/rare analytical passes (import cycles, module algorithms,
+// orientation, coverage, auth coverage, doc-semantics validation) — historically
+// read the RAW resident slices lr.Doc.Entities / lr.Doc.Relationships directly.
+// Those raw reads touch no mmap and have NO Reader fallback, so a LATER slice
+// that empties lr.Doc (to stop holding the graph twice — once in mmap, once in
+// heap) would silently make every one of them return EMPTY.
+//
+// This file adds the small transient-materialize + random-access + count seams
+// those consumers route through instead, so the future slice-drop is invisible
+// to them:
+//
+//   - materializeAllEntities / materializeAllRelationships copy the whole set out
+//     via the SAME flag-gated forEach* path (Reader flag-ON, Doc flag-OFF), a
+//     transient per-call slice replacing what used to be a PERMANENT heap alias.
+//   - relationshipAt is the random-access companion to forEachRelationship for
+//     the adjacency-relIdx property lookups (inspect / mro / effective-contract).
+//   - entityCount / relCount source the count from the Reader flag-ON (so they
+//     stay correct after lr.Doc is emptied) and the Doc slice length flag-OFF.
+//
+// Every path here reuses the existing rmu()/readRetired SIGBUS guard; none adds
+// new locking discipline. All are byte-identical to the raw-slice reads they
+// replace: flag-OFF they resolve to the same &lr.Doc.* rows; flag-ON they
+// materialize the identical rows from the mmap Reader.
+package mcp
+
+import "github.com/cajasmota/grafel/internal/graph"
+
+// materializeAllEntities copies EVERY entity of lr into a fresh transient slice,
+// in vector-index order, via forEachEntityBase — the base entity source
+// (Reader flag-ON, Doc flag-OFF) WITHOUT the cross-repo flow-overlay
+// suppression/injection the public forEachEntity applies. Using the BASE source
+// (not the public wrapper) is deliberate: it is byte-identical to the raw
+// lr.Doc.Entities read this helper replaces, which never saw the flow overlay.
+// Flag-ON, each yielded *graph.Entity is a heap-safe MaterializeEntity copy, so
+// the returned slice is safe past the scan.
+func materializeAllEntities(lr *LoadedRepo) []graph.Entity {
+	if lr == nil {
+		return nil
+	}
+	out := make([]graph.Entity, 0, lr.entityCount())
+	lr.forEachEntityBase(func(e *graph.Entity) bool {
+		out = append(out, *e)
+		return true
+	})
+	return out
+}
+
+// materializeAllRelationships copies EVERY relationship of lr into a fresh
+// transient slice, in vector-index order, via forEachRelationship (Reader
+// flag-ON, Doc flag-OFF). forEachRelationship carries no overlay, so this is
+// byte-identical to the raw lr.Doc.Relationships read it replaces.
+func materializeAllRelationships(lr *LoadedRepo) []graph.Relationship {
+	if lr == nil {
+		return nil
+	}
+	out := make([]graph.Relationship, 0, lr.relCount())
+	lr.forEachRelationship(func(r *graph.Relationship) bool {
+		out = append(out, *r)
+		return true
+	})
+	return out
+}
+
+// relationshipAt returns a *graph.Relationship for vector index idx, or nil when
+// idx is synthetic (<0) or out of range. It is the random-access companion to
+// forEachRelationship for the adjacency-relIdx property lookups.
+//
+// Flag-OFF (default): returns &lr.Doc.Relationships[idx] — the exact pointer
+// semantics of the `rels := lr.Doc.Relationships; &rels[relIdx]` reads it
+// replaces. Flag-ON: materializes the row from the mmap Reader under the SAME
+// rmu()/readRetired guard forEachRelationship uses, falling back to the Doc when
+// the mapping is retired/nil. The flag-ON return is a heap-safe copy.
+func (lr *LoadedRepo) relationshipAt(idx int) *graph.Relationship {
+	if lr == nil || idx < 0 {
+		return nil
+	}
+	if !serveFromMMap() {
+		return lr.docRelationshipAt(idx)
+	}
+	lr.rmu().Lock()
+	rdr := lr.Reader
+	h := lr.handle
+	if rdr == nil || (h != nil && h.readRetired) {
+		lr.rmu().Unlock()
+		return lr.docRelationshipAt(idx)
+	}
+	defer lr.rmu().Unlock()
+	if idx >= rdr.RelationshipCount() {
+		return nil
+	}
+	rel := graph.MaterializeRelationship(rdr, idx)
+	return &rel
+}
+
+// docRelationshipAt is the Doc-sourced path shared by relationshipAt's flag-OFF
+// branch and its flag-ON retired/nil-Reader fallback. Callers must NOT hold
+// readerMu (this touches only the Doc).
+func (lr *LoadedRepo) docRelationshipAt(idx int) *graph.Relationship {
+	if lr.Doc == nil || idx < 0 || idx >= len(lr.Doc.Relationships) {
+		return nil
+	}
+	return &lr.Doc.Relationships[idx]
+}
+
+// entityCount returns the number of entities in lr, sourced from the mmap Reader
+// when the flag-on read path is active (so it stays correct after a later slice
+// empties lr.Doc.Entities) else the Doc slice length. Byte-identical to
+// len(lr.Doc.Entities) pre-flip (the Reader mirrors the Doc entity set). Mirrors
+// how TestsEdgeCount / the *FromReader builders pick their source.
+func (lr *LoadedRepo) entityCount() int {
+	if lr == nil {
+		return 0
+	}
+	if serveFromMMap() {
+		lr.rmu().Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && (h == nil || !h.readRetired) {
+			n := rdr.EntityCount()
+			lr.rmu().Unlock()
+			return n
+		}
+		lr.rmu().Unlock()
+	}
+	if lr.Doc == nil {
+		return 0
+	}
+	return len(lr.Doc.Entities)
+}
+
+// relCount is the relationship analogue of entityCount.
+func (lr *LoadedRepo) relCount() int {
+	if lr == nil {
+		return 0
+	}
+	if serveFromMMap() {
+		lr.rmu().Lock()
+		rdr := lr.Reader
+		h := lr.handle
+		if rdr != nil && (h == nil || !h.readRetired) {
+			n := rdr.RelationshipCount()
+			lr.rmu().Unlock()
+			return n
+		}
+		lr.rmu().Unlock()
+	}
+	if lr.Doc == nil {
+		return 0
+	}
+	return len(lr.Doc.Relationships)
+}

--- a/internal/mcp/view_materialize_5870_pr7a_test.go
+++ b/internal/mcp/view_materialize_5870_pr7a_test.go
@@ -89,9 +89,10 @@ func loadPR7aFixture(t *testing.T) (*graph.Document, *fbreader.Reader) {
 	return doc, r
 }
 
-// docFullRepo builds a flag-OFF-style repo holding only the Doc.
+// docFullRepo builds a flag-OFF-style repo holding the full Doc plus its
+// Doc-sourced LabelIndex (production flag-OFF repos always have one).
 func docFullRepo(doc *graph.Document) *LoadedRepo {
-	return &LoadedRepo{Repo: "corpus", Path: "corpus", Doc: doc}
+	return &LoadedRepo{Repo: "corpus", Path: "corpus", Doc: doc, LabelIndex: BuildLabelIndex(doc)}
 }
 
 // readerEmptiedRepo builds a flag-ON-style repo: a live Reader + LabelIndex, but

--- a/internal/mcp/view_materialize_5870_pr7a_test.go
+++ b/internal/mcp/view_materialize_5870_pr7a_test.go
@@ -1,0 +1,227 @@
+// view_materialize_5870_pr7a_test.go — deretain-flip PR7a (#5870).
+//
+// These tests are the byte-identity gate for the raw-slice → Reader-seam
+// migration. The core simulation mirrors TestLabelIndexAt_ReaderSourcedBound_PR6:
+// a flag-ON repo whose lr.Doc has been EMPTIED (the future slice-drop) must
+// still produce the SAME result a full-Doc flag-OFF repo produces, sourcing the
+// data from the mmap Reader instead of the now-empty raw slices. A helper or
+// tool that still reads lr.Doc.Entities / lr.Doc.Relationships directly returns
+// EMPTY here and fails — that is exactly the silent-empty regression this slice
+// removes. A separate retired-Reader case proves the existing readRetired→Doc
+// fallback still works unchanged.
+package mcp
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+func prPtrPR7a(f float64) *float64 { return &f }
+
+// pr7aFixtureDoc builds one rich Document exercising every migrated tool:
+//   - an IMPORTS cycle m1→m2→m3→m1 (FindImportCycles)
+//   - Kind="Module" containers with member functions (RunModuleAlgorithms)
+//   - production http_endpoint_definition + a test function + TESTS edge (coverage)
+//   - an auth_policy entity + TAGGED_AS edge (auth coverage)
+//   - CALLS/EXTENDS/DISCRIMINATES_ON edges carrying properties (relationshipAt)
+func pr7aFixtureDoc() *graph.Document {
+	ents := []graph.Entity{
+		{ID: "m1", Name: "modA", Kind: "Module", SourceFile: "a/mod.go", Language: "go", PageRank: prPtrPR7a(0.9)},
+		{ID: "m2", Name: "modB", Kind: "Module", SourceFile: "b/mod.go", Language: "go", PageRank: prPtrPR7a(0.5)},
+		{ID: "m3", Name: "modC", Kind: "Module", SourceFile: "c/mod.go", Language: "go", PageRank: prPtrPR7a(0.2)},
+		{ID: "fa", Name: "FnA", QualifiedName: "a.FnA", Kind: "SCOPE.Operation", SourceFile: "a/a.go", Language: "go", StartLine: 10, EndLine: 20, PageRank: prPtrPR7a(0.7)},
+		{ID: "fb", Name: "FnB", QualifiedName: "b.FnB", Kind: "SCOPE.Operation", SourceFile: "b/b.go", Language: "go", StartLine: 5, EndLine: 15, PageRank: prPtrPR7a(0.3)},
+		{ID: "ep", Name: "GetThing", Kind: "http_endpoint_definition", SourceFile: "a/api.go", Language: "go", StartLine: 30, EndLine: 40},
+		{ID: "tf", Name: "TestFnA", Kind: "SCOPE.Operation", SourceFile: "a/a_test.go", Language: "go", StartLine: 1, EndLine: 8},
+	}
+	// module membership + auth policy props
+	ents[3].PropSet("module", "modA")
+	ents[4].PropSet("module", "modB")
+	auth := graph.Entity{ID: "authp", Name: "RequireAuth", Kind: "SCOPE.Config", Subtype: "auth_policy", SourceFile: "a/api.go", Language: "go", StartLine: 28, EndLine: 28}
+	ents = append(ents, auth)
+
+	mkRel := func(from, to, kind string, props map[string]string) graph.Relationship {
+		r := graph.Relationship{FromID: from, ToID: to, Kind: kind}
+		if props != nil {
+			r.PropsReplace(props)
+		}
+		return r
+	}
+	rels := []graph.Relationship{
+		mkRel("m1", "m2", "IMPORTS", nil),
+		mkRel("m2", "m3", "IMPORTS", nil),
+		mkRel("m3", "m1", "IMPORTS", nil),
+		mkRel("fa", "fb", "CALLS", map[string]string{"line": "12", "resolved_by": "agent-repair", "resolved_by_agent": "bot"}),
+		mkRel("fb", "fa", "CALLS", map[string]string{"line": "7"}),
+		mkRel("tf", "ep", "TESTS", nil),
+		mkRel("tf", "fa", "CALLS", nil),
+		mkRel("ep", "authp", "TAGGED_AS", nil),
+		mkRel("fa", "fb", "EXTENDS", map[string]string{"base_name": "b.FnB"}),
+		mkRel("fa", "fb", "DISCRIMINATES_ON", map[string]string{"line": "12", "literal": "x"}),
+	}
+	return &graph.Document{Entities: ents, Relationships: rels}
+}
+
+// loadPR7aFixture writes the fixture and returns the loader-materialized Document
+// plus an open Reader over the SAME file (so Reader-materialized rows are
+// reflect.DeepEqual to the Document rows).
+func loadPR7aFixture(t *testing.T) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, pr7aFixtureDoc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+// docFullRepo builds a flag-OFF-style repo holding only the Doc.
+func docFullRepo(doc *graph.Document) *LoadedRepo {
+	return &LoadedRepo{Repo: "corpus", Path: "corpus", Doc: doc}
+}
+
+// readerEmptiedRepo builds a flag-ON-style repo: a live Reader + LabelIndex, but
+// an EMPTIED Doc — the future slice-drop the migration must survive.
+func readerEmptiedRepo(t *testing.T, doc *graph.Document, r *fbreader.Reader) *LoadedRepo {
+	t.Helper()
+	lr := &LoadedRepo{Repo: "corpus", Path: "corpus", Doc: doc, Reader: r}
+	li := BuildLabelIndexFromReader(r, doc)
+	li.readerMu = &lr.readerMu
+	lr.LabelIndex = li
+	lr.Doc = &graph.Document{} // emptied skeleton — Entities/Relationships nil
+	return lr
+}
+
+// readerFullRepoRetired builds a flag-ON repo whose Reader is RETIRED (mapping
+// unmapped) and whose Doc is FULL — the readRetired→Doc fallback must still work.
+func readerFullRepoRetired(t *testing.T, doc *graph.Document, r *fbreader.Reader) *LoadedRepo {
+	t.Helper()
+	lr := &LoadedRepo{Repo: "corpus", Path: "corpus", Doc: doc, Reader: r}
+	li := BuildLabelIndexFromReader(r, doc)
+	li.readerMu = &lr.readerMu
+	lr.LabelIndex = li
+	lr.handle = &MapHandle{readRetired: true}
+	return lr
+}
+
+func TestMaterializeAllEntities_ReaderSourced_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	wantEnts := materializeAllEntities(docFullRepo(doc))
+	if !reflect.DeepEqual(wantEnts, doc.Entities) {
+		t.Fatalf("flag-OFF materializeAllEntities != raw Doc.Entities")
+	}
+
+	withServeFromMMap(t, true)
+	lr := readerEmptiedRepo(t, doc, r)
+	got := materializeAllEntities(lr)
+	if len(got) != len(doc.Entities) {
+		t.Fatalf("flag-ON emptied-Doc materializeAllEntities len=%d, want %d (raw-slice read would be 0)", len(got), len(doc.Entities))
+	}
+	if !reflect.DeepEqual(got, doc.Entities) {
+		t.Fatalf("flag-ON emptied-Doc materializeAllEntities != raw Doc.Entities\n got=%#v\nwant=%#v", got, doc.Entities)
+	}
+}
+
+func TestMaterializeAllRelationships_ReaderSourced_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	if got := materializeAllRelationships(docFullRepo(doc)); !reflect.DeepEqual(got, doc.Relationships) {
+		t.Fatalf("flag-OFF materializeAllRelationships != raw Doc.Relationships")
+	}
+
+	withServeFromMMap(t, true)
+	lr := readerEmptiedRepo(t, doc, r)
+	got := materializeAllRelationships(lr)
+	if !reflect.DeepEqual(got, doc.Relationships) {
+		t.Fatalf("flag-ON emptied-Doc materializeAllRelationships != raw Doc.Relationships (len got=%d want=%d)", len(got), len(doc.Relationships))
+	}
+}
+
+func TestRelationshipAt_ReaderSourced_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, true)
+	lr := readerEmptiedRepo(t, doc, r)
+	for i := range doc.Relationships {
+		got := lr.relationshipAt(i)
+		if got == nil {
+			t.Fatalf("relationshipAt(%d) nil on emptied-Doc flag-ON repo (raw-slice read would be nil)", i)
+		}
+		want := &doc.Relationships[i]
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("relationshipAt(%d) mismatch\n got=%#v\nwant=%#v", i, got, want)
+		}
+	}
+	// Out-of-range and synthetic indices → nil.
+	if lr.relationshipAt(len(doc.Relationships)) != nil {
+		t.Fatal("relationshipAt(len) should be nil")
+	}
+	if lr.relationshipAt(-1) != nil {
+		t.Fatal("relationshipAt(-1) should be nil")
+	}
+}
+
+func TestEntityRelCount_ReaderSourced_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	if got := docFullRepo(doc).entityCount(); got != len(doc.Entities) {
+		t.Fatalf("flag-OFF entityCount=%d want %d", got, len(doc.Entities))
+	}
+	if got := docFullRepo(doc).relCount(); got != len(doc.Relationships) {
+		t.Fatalf("flag-OFF relCount=%d want %d", got, len(doc.Relationships))
+	}
+
+	withServeFromMMap(t, true)
+	lr := readerEmptiedRepo(t, doc, r)
+	if got := lr.entityCount(); got != len(doc.Entities) {
+		t.Fatalf("flag-ON emptied-Doc entityCount=%d want %d (len(Doc.Entities) would be 0)", got, len(doc.Entities))
+	}
+	if got := lr.relCount(); got != len(doc.Relationships) {
+		t.Fatalf("flag-ON emptied-Doc relCount=%d want %d (len(Doc.Relationships) would be 0)", got, len(doc.Relationships))
+	}
+}
+
+// TestReaderSeams_RetiredFallback_PR7a proves the existing readRetired→Doc
+// fallback is untouched: with a retired Reader and a FULL Doc, every seam falls
+// back to the Doc and produces the full result.
+func TestReaderSeams_RetiredFallback_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+	withServeFromMMap(t, true)
+	lr := readerFullRepoRetired(t, doc, r)
+
+	if got := materializeAllEntities(lr); !reflect.DeepEqual(got, doc.Entities) {
+		t.Fatalf("retired-Reader materializeAllEntities did not fall back to Doc (len got=%d want=%d)", len(got), len(doc.Entities))
+	}
+	if got := materializeAllRelationships(lr); !reflect.DeepEqual(got, doc.Relationships) {
+		t.Fatalf("retired-Reader materializeAllRelationships did not fall back to Doc")
+	}
+	if got := lr.entityCount(); got != len(doc.Entities) {
+		t.Fatalf("retired-Reader entityCount=%d want %d (must use Doc len)", got, len(doc.Entities))
+	}
+	if got := lr.relCount(); got != len(doc.Relationships) {
+		t.Fatalf("retired-Reader relCount=%d want %d", got, len(doc.Relationships))
+	}
+	for i := range doc.Relationships {
+		if got := lr.relationshipAt(i); !reflect.DeepEqual(got, &doc.Relationships[i]) {
+			t.Fatalf("retired-Reader relationshipAt(%d) did not fall back to Doc", i)
+		}
+	}
+}

--- a/internal/mcp/view_materialize_5870_pr7a_test.go
+++ b/internal/mcp/view_materialize_5870_pr7a_test.go
@@ -43,6 +43,13 @@ func pr7aFixtureDoc() *graph.Document {
 	ents[3].PropSet("module", "modA")
 	ents[4].PropSet("module", "modB")
 	auth := graph.Entity{ID: "authp", Name: "RequireAuth", Kind: "SCOPE.Config", Subtype: "auth_policy", SourceFile: "a/api.go", Language: "go", StartLine: 28, EndLine: 28}
+	// DRF class-auth + repo default-policy props (exercises buildDRFClassAuthByFile
+	// + repoDRFDefaultPolicy). Kind SCOPE.Config is not a coverage/module/test
+	// kind, so these props do not perturb the other tools' fixtures.
+	auth.PropSet("has_permission_classes", "true")
+	auth.PropSet("permission_classes", "IsAuthenticated")
+	auth.PropSet("drf_default_permission_present", "true")
+	auth.PropSet("drf_default_permission_classes", "IsAuthenticated")
 	ents = append(ents, auth)
 
 	mkRel := func(from, to, kind string, props map[string]string) graph.Relationship {

--- a/internal/mcp/wholeslice_migrate_5870_pr7a_test.go
+++ b/internal/mcp/wholeslice_migrate_5870_pr7a_test.go
@@ -1,0 +1,134 @@
+// wholeslice_migrate_5870_pr7a_test.go — deretain-flip PR7a (#5870).
+//
+// Result-equivalence for the whole-slice analytical migrations (import cycles,
+// module algorithms, orientation, coverage, doc-semantics). Each asserts the
+// migrated computation on a flag-ON repo with an EMPTIED Doc (Reader-sourced,
+// simulating the future slice-drop) is byte-identical to the flag-OFF full-Doc
+// result — and non-trivial (the fixture exercises the tool). A raw-slice
+// regression returns EMPTY on the emptied-Doc repo and fails.
+package mcp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestImportCycles_ReaderParity_PR7a exercises the cycles_tools.go migration:
+// FindImportCycles + buildPageRankMap fed the materialize seam.
+func TestImportCycles_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	compute := func(lr *LoadedRepo) []graph.ImportCycle {
+		ents := materializeAllEntities(lr)
+		rels := materializeAllRelationships(lr)
+		return graph.FindImportCycles(ents, rels, buildPageRankMap(ents))
+	}
+
+	withServeFromMMap(t, false)
+	want := compute(docFullRepo(doc))
+	if len(want) == 0 {
+		t.Fatal("fixture must contain an import cycle")
+	}
+
+	withServeFromMMap(t, true)
+	got := compute(readerEmptiedRepo(t, doc, r))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("import cycles flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+
+	// Retired-Reader fallback: same result via the Doc.
+	if fb := compute(readerFullRepoRetired(t, doc, r)); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("import cycles retired-Reader fallback != flag-OFF")
+	}
+}
+
+// TestModuleAlgorithms_ReaderParity_PR7a exercises computeModuleAnalysis (the
+// real handler seam) across both flag paths.
+func TestModuleAlgorithms_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	want := computeModuleAnalysis([]*LoadedRepo{docFullRepo(doc)})
+	if len(want) == 0 || want[0].Res == nil || len(want[0].Res.ModuleIDs) == 0 {
+		t.Fatal("fixture must contain modules")
+	}
+
+	withServeFromMMap(t, true)
+	got := computeModuleAnalysis([]*LoadedRepo{readerEmptiedRepo(t, doc, r)})
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("module algorithms flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+	if fb := computeModuleAnalysis([]*LoadedRepo{readerFullRepoRetired(t, doc, r)}); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("module algorithms retired-Reader fallback != flag-OFF")
+	}
+}
+
+// TestOrientation_ReaderParity_PR7a exercises the tools.go AnalyzeOrientation
+// migration.
+func TestOrientation_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+	opts := graph.OrientationOptions{}
+
+	compute := func(lr *LoadedRepo) graph.OrientationResult {
+		return graph.AnalyzeOrientation(materializeAllEntities(lr), materializeAllRelationships(lr), opts)
+	}
+
+	withServeFromMMap(t, false)
+	want := compute(docFullRepo(doc))
+
+	withServeFromMMap(t, true)
+	got := compute(readerEmptiedRepo(t, doc, r))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("orientation flag-ON(emptied Doc) != flag-OFF")
+	}
+	if len(want.KeyEntities) == 0 {
+		t.Fatal("fixture must produce orientation key entities")
+	}
+	if fb := compute(readerFullRepoRetired(t, doc, r)); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("orientation retired-Reader fallback != flag-OFF")
+	}
+}
+
+// TestCoverage_ReaderParity_PR7a exercises the coverage_tools.go migration via
+// the materializedDoc adapter (ComputeCoverage + ComputeEntityCoverage).
+func TestCoverage_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, false)
+	want := graph.ComputeCoverage(materializedDoc(docFullRepo(doc)))
+	if want.TotalProduction == 0 {
+		t.Fatal("fixture must contain production entities for coverage")
+	}
+
+	withServeFromMMap(t, true)
+	got := graph.ComputeCoverage(materializedDoc(readerEmptiedRepo(t, doc, r)))
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("coverage flag-ON(emptied Doc) != flag-OFF\n got=%#v\nwant=%#v", got, want)
+	}
+	if fb := graph.ComputeCoverage(materializedDoc(readerFullRepoRetired(t, doc, r))); !reflect.DeepEqual(fb, want) {
+		t.Fatalf("coverage retired-Reader fallback != flag-OFF")
+	}
+
+	// Entity coverage on the tested production endpoint.
+	withServeFromMMap(t, false)
+	wantEC, wantFound := graph.ComputeEntityCoverage(materializedDoc(docFullRepo(doc)), "ep")
+	withServeFromMMap(t, true)
+	gotEC, gotFound := graph.ComputeEntityCoverage(materializedDoc(readerEmptiedRepo(t, doc, r)), "ep")
+	if gotFound != wantFound || !reflect.DeepEqual(gotEC, wantEC) {
+		t.Fatalf("entity coverage flag-ON(emptied Doc) != flag-OFF")
+	}
+}
+
+// TestDocSemanticsEntities_ReaderParity_PR7a exercises doc_semantics_tools.go:
+// the codeEntities set used for target-existence validation.
+func TestDocSemanticsEntities_ReaderParity_PR7a(t *testing.T) {
+	doc, r := loadPR7aFixture(t)
+
+	withServeFromMMap(t, true)
+	got := materializeAllEntities(readerEmptiedRepo(t, doc, r))
+	if !reflect.DeepEqual(got, doc.Entities) {
+		t.Fatalf("doc-semantics codeEntities flag-ON(emptied Doc) != raw Doc.Entities")
+	}
+}


### PR DESCRIPTION
## What
Behavior-neutral prep for the deretain flip (dropping resident heap `lr.Doc` so serve holds the graph ONCE in mmap). Migrates ~20 tools that read raw `r.Doc.Entities`/`.Relationships` slices onto Reader-served `forEach*`/materialize seams, so a later slice can empty those slices without breaking tools. No `lr.Doc` drop, no `readRetired` fallback change — zero behavior change today.

## Seams (`view_materialize.go`)
`materializeAllEntities`/`materializeAllRelationships` (overlay-free transient copies, byte-identical to raw reads), `materializedDoc`, `relationshipAt` (Reader + Doc fallback), `entityCount`/`relCount`.

## Review (independent, incl. a REQUEST-CHANGES round)
- Completeness grep-proven; equivalence tests use emptied-`lr.Doc` flag-on == flag-off full-Doc (revert a migration → RED).
- Fixed a flag-on nested-`rmu` deadlock (`relPropsFor`/`extendsBases` + fastapi/spring contract scans called rmu-locking `relationshipAt` inside a `forEach` scan) via collect-then-process; new deadlock-guard tests (revert → 5.01s hang RED). `hasRelationshipTo` topology silent-empty migrated to a pre-scan snapshot (revert → empty RED).

## Follow-up (pre-existing, NOT in this diff — tracked separately)
4 pre-existing flag-on nested-`rmu` deadlock sites on main (`getByIDOne`-in-`forEach`): topology-topic-detail (proven hang), pattern-exemplars, endpoint-posture, traces. Same collect-then-process fix needed.

Refs #5870