### PR TITLE
fix(#5928): 4 pre-existing flag-ON nested-rmu deadlocks in forEach scans

### DIFF
--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -379,42 +379,53 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 		}
 		// Use the canonical entity ID for relationship matching.
 		canonID := topicEnt.ID
-		var publishers, subscribers []participant
+		// #5928 collect-then-process: resolve()→getByIDOne re-locks the same
+		// readerMu the flag-ON forEachRelationship scan holds across its whole
+		// pass, so calling it INSIDE the closure self-deadlocks on the live-Reader
+		// path. Collect the matching FromIDs in-scan (rmu held); resolve them AFTER
+		// the scan returns (rmu released). Append order is preserved, so the
+		// resulting publisher/subscriber order is byte-identical to the old path.
+		var pubFromIDs, subFromIDs []string
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			switch rel.Kind {
 			case "PUBLISHES_TO":
 				if rel.ToID == canonID {
-					if src := resolve(rel.FromID); src != nil {
-						p := participant{
-							EntityID:   prefixedID(r.Repo, src.ID),
-							EntityName: src.Name,
-							Kind:       src.Kind,
-						}
-						if verbose {
-							p.Repo = r.Repo
-							p.SourceFile = src.SourceFile
-						}
-						publishers = append(publishers, p)
-					}
+					pubFromIDs = append(pubFromIDs, rel.FromID)
 				}
 			case "SUBSCRIBES_TO":
 				if rel.ToID == canonID {
-					if src := resolve(rel.FromID); src != nil {
-						p := participant{
-							EntityID:   prefixedID(r.Repo, src.ID),
-							EntityName: src.Name,
-							Kind:       src.Kind,
-						}
-						if verbose {
-							p.Repo = r.Repo
-							p.SourceFile = src.SourceFile
-						}
-						subscribers = append(subscribers, p)
-					}
+					subFromIDs = append(subFromIDs, rel.FromID)
 				}
 			}
 			return true
 		})
+		mkParticipant := func(fromID string) (participant, bool) {
+			src := resolve(fromID)
+			if src == nil {
+				return participant{}, false
+			}
+			p := participant{
+				EntityID:   prefixedID(r.Repo, src.ID),
+				EntityName: src.Name,
+				Kind:       src.Kind,
+			}
+			if verbose {
+				p.Repo = r.Repo
+				p.SourceFile = src.SourceFile
+			}
+			return p, true
+		}
+		var publishers, subscribers []participant
+		for _, fromID := range pubFromIDs {
+			if p, ok := mkParticipant(fromID); ok {
+				publishers = append(publishers, p)
+			}
+		}
+		for _, fromID := range subFromIDs {
+			if p, ok := mkParticipant(fromID); ok {
+				subscribers = append(subscribers, p)
+			}
+		}
 		resp := map[string]any{
 			"topic_id":    prefixedID(r.Repo, topicEnt.ID),
 			"topic_name":  topicEnt.Name,

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -818,19 +818,28 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 			EntityName string `json:"entity_name"`
 			Kind       string `json:"kind"`
 		}
-		var exemplars []exemplar
+		// #5928 collect-then-process: resolve()→getByIDOne re-locks the same
+		// readerMu the flag-ON forEachRelationship scan holds across its whole
+		// pass, so resolving INSIDE the closure self-deadlocks on the live-Reader
+		// path. Collect exemplar FromIDs in-scan (rmu held); resolve them AFTER the
+		// scan returns (rmu released). Append order is preserved byte-for-byte.
+		var exemplarFromIDs []string
 		r.forEachRelationship(func(rel *graph.Relationship) bool {
 			if (rel.Kind == "EXEMPLIFIES" || rel.Kind == "INSTANCE_OF") && rel.ToID == target {
-				if ex := resolve(rel.FromID); ex != nil {
-					exemplars = append(exemplars, exemplar{
-						EntityID:   prefixedID(r.Repo, ex.ID),
-						EntityName: ex.Name,
-						Kind:       ex.Kind,
-					})
-				}
+				exemplarFromIDs = append(exemplarFromIDs, rel.FromID)
 			}
 			return true
 		})
+		var exemplars []exemplar
+		for _, fromID := range exemplarFromIDs {
+			if ex := resolve(fromID); ex != nil {
+				exemplars = append(exemplars, exemplar{
+					EntityID:   prefixedID(r.Repo, ex.ID),
+					EntityName: ex.Name,
+					Kind:       ex.Kind,
+				})
+			}
+		}
 		return jsonResult(map[string]any{
 			"pattern_id":  prefixedID(r.Repo, e.ID),
 			"name":        e.Name,

--- a/internal/mcp/endpoint_posture.go
+++ b/internal/mcp/endpoint_posture.go
@@ -192,28 +192,41 @@ func (s *Server) endpointPostureScan(req mcpapi.CallToolRequest, repos []*Loaded
 		if r.Doc == nil {
 			continue
 		}
+		// #5928 collect-then-process: buildPosturePayload→resolveErrorFlow/
+		// resolveFeatureGates call r.getAdjacency()/r.getByIDOne, which re-lock the
+		// same readerMu the flag-ON forEachEntity scan holds across its whole pass —
+		// calling them INSIDE the closure self-deadlocks on the live-Reader path.
+		// Collect the candidate entities in-scan (rmu held); build each posture AFTER
+		// the scan returns (rmu released). forEachEntity materializes heap-safe entity
+		// copies flag-ON (and yields stable &Doc.Entities[i] flag-OFF), so retaining
+		// the pointers past the scan is safe. Visitation order is preserved, so the
+		// pre-sort `out` order (and therefore the final result) is byte-identical.
+		var candidates []*graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			// Skip the synthetic convergence nodes themselves — they are the
 			// targets of the edges, never the subject of a posture query.
 			if strings.EqualFold(e.Kind, kindExceptionType) || strings.EqualFold(e.Kind, kindFeatureFlag) {
 				return true
 			}
-			p := buildPosturePayload(r, e)
-			if !p.HasPosture {
-				return true
-			}
-			if facet != "" && !postureHasFacet(p, facet) {
-				return true
-			}
-			if pathContains != "" && !strings.Contains(strings.ToLower(p.Path), pathContains) {
-				return true
-			}
-			if method != "" && !strings.EqualFold(p.Method, method) {
-				return true
-			}
-			out = append(out, p)
+			candidates = append(candidates, e)
 			return true
 		})
+		for _, e := range candidates {
+			p := buildPosturePayload(r, e)
+			if !p.HasPosture {
+				continue
+			}
+			if facet != "" && !postureHasFacet(p, facet) {
+				continue
+			}
+			if pathContains != "" && !strings.Contains(strings.ToLower(p.Path), pathContains) {
+				continue
+			}
+			if method != "" && !strings.EqualFold(p.Method, method) {
+				continue
+			}
+			out = append(out, p)
+		}
 	}
 
 	sort.Slice(out, func(i, j int) bool {

--- a/internal/mcp/flagon_deadlock_5928_test.go
+++ b/internal/mcp/flagon_deadlock_5928_test.go
@@ -187,3 +187,27 @@ func TestEndpointPostureScan_flagON_noDeadlock_5928(t *testing.T) {
 		t.Fatalf("endpoint posture scan flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
 	}
 }
+
+// Site 4: handleTracesGet — buildProcessStepsWithCrossRepo→getStepAdj/getByIDOne
+// inside a forEachEntity scan.
+func TestTracesGet_flagON_noDeadlock_5928(t *testing.T) {
+	doc, r := loadDeadlock5928Fixture(t)
+	args := map[string]any{"group": "g", "process_id": "proc1"}
+
+	withServeFromMMap(t, false)
+	sOff := topologyServer(t, docFullRepo(doc))
+	want := callWithArgs(t, sOff, sOff.handleTracesGet, args)
+	if want == "" {
+		t.Fatal("fixture must produce a non-empty traces-get result flag-OFF")
+	}
+
+	withServeFromMMap(t, true)
+	sOn := topologyServer(t, readerEmptiedRepo(t, doc, r))
+	var got string
+	noHang(t, 5*time.Second, "handleTracesGet", func() {
+		got = callWithArgs(t, sOn, sOn.handleTracesGet, args)
+	})
+	if got != want {
+		t.Fatalf("traces get flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
+	}
+}

--- a/internal/mcp/flagon_deadlock_5928_test.go
+++ b/internal/mcp/flagon_deadlock_5928_test.go
@@ -1,0 +1,141 @@
+// flagon_deadlock_5928_test.go — #5928: the four PRE-EXISTING flag-ON nested-rmu
+// deadlocks on the default (GRAFEL_SERVE_FROM_MMAP) live-Reader read path.
+//
+// forEachEntity/forEachRelationship hold the repo's readerMu (rmu, a
+// non-reentrant sync.Mutex) across the ENTIRE scan on the flag-ON path
+// (Option-B, ADR-0027). Four handlers called an rmu-locking accessor
+// (getByIDOne→LabelIndex.at, getAdjacency, getStepAdj) from INSIDE a forEach*
+// closure, self-deadlocking whenever a Reader is mapped:
+//
+//  1. handleTopologyTopicDetail  — resolve()→getByIDOne in a forEachRelationship
+//  2. handlePatternsGetGraph     — resolve()→getByIDOne in a forEachRelationship
+//  3. endpointPostureScan        — buildPosturePayload→getAdjacency/getByIDOne in
+//     a forEachEntity
+//  4. handleTracesGet            — buildProcessStepsWithCrossRepo→getStepAdj/
+//     getByIDOne in a forEachEntity
+//
+// Each test runs the REAL handler flag-ON with a LIVE Reader and an EMPTIED Doc
+// (readerEmptiedRepo, the deretain-flip direction) under a hard timeout. Without
+// the collect-then-process fix the in-scan accessor re-locks rmu and the handler
+// HANGS (noHang → t.Fatal). With the fix it completes AND its output matches the
+// flag-OFF full-Doc result byte-for-byte. noHang / readerEmptiedRepo / docFullRepo
+// / topologyServer are shared with the PR7a guard suite.
+package mcp
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// deadlock5928Doc builds one fixture exercising all four #5928 sites:
+//   - a Topic with a PUBLISHES_TO and a SUBSCRIBES_TO edge (topic detail),
+//   - a Pattern with an EXEMPLIFIES edge (patterns get graph),
+//   - an http endpoint with a THROWS edge to an ExceptionType + a rate_limit
+//     property (endpoint posture scan),
+//   - a Process with a `chain` step property (traces get).
+func deadlock5928Doc() *graph.Document {
+	mkEnt := func(id, name, kind string) graph.Entity {
+		return graph.Entity{ID: id, Name: name, QualifiedName: name, Kind: kind, SourceFile: "src/" + id + ".go", Language: "go", StartLine: 1, EndLine: 5}
+	}
+
+	topic := graph.Entity{ID: "t_orders", Name: "orders.created", QualifiedName: "orders.created", Kind: "Topic", SourceFile: "events.go", Language: "go", StartLine: 1, EndLine: 2}
+	pubSvc := mkEnt("pubsvc", "OrderService", "SCOPE.Operation")
+	subSvc := mkEnt("subsvc", "ShipService", "SCOPE.Operation")
+
+	pattern := mkEnt("pat1", "RepositoryPattern", "SCOPE.Pattern")
+	exemplar := mkEnt("ex1", "UserRepo", "SCOPE.Component")
+
+	endpoint := graph.Entity{ID: "ep1", Name: "GET /orders", QualifiedName: "GET /orders", Kind: "http_endpoint_definition", SourceFile: "src/orders.go", Language: "go", StartLine: 10, EndLine: 12}
+	endpoint.PropSet("verb", "GET")
+	endpoint.PropSet("path", "/orders")
+	endpoint.PropSet("rate_limited", "true")
+	exc := mkEnt("exc1", "exception:NotFound", "SCOPE.ExceptionType")
+
+	proc := graph.Entity{ID: "proc1", Name: "OrderFlow", QualifiedName: "OrderFlow", Kind: "SCOPE.Process", SourceFile: "src/flow.go", Language: "go", StartLine: 1, EndLine: 9}
+	proc.PropSet("entry_id", "step1")
+	proc.PropSet("entry_name", "handleOrder")
+	proc.PropSet("chain", "step1")
+	step := mkEnt("step1", "handleOrder", "SCOPE.Operation")
+
+	ents := []graph.Entity{topic, pubSvc, subSvc, pattern, exemplar, endpoint, exc, proc, step}
+
+	mkRel := func(from, to, kind string) graph.Relationship {
+		return graph.Relationship{FromID: from, ToID: to, Kind: kind}
+	}
+	rels := []graph.Relationship{
+		mkRel("pubsvc", "t_orders", "PUBLISHES_TO"),
+		mkRel("subsvc", "t_orders", "SUBSCRIBES_TO"),
+		mkRel("ex1", "pat1", "EXEMPLIFIES"),
+		mkRel("ep1", "exc1", "THROWS"),
+	}
+	return &graph.Document{Repo: "corpus", Entities: ents, Relationships: rels}
+}
+
+func loadDeadlock5928Fixture(t *testing.T) (*graph.Document, *fbreader.Reader) {
+	t.Helper()
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, deadlock5928Doc()); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	doc, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	r, err := fbreader.Open(fbPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return doc, r
+}
+
+// callWithArgs drives a real MCP handler with the given argument map and returns
+// its first TextContent payload.
+func callWithArgs(t *testing.T, s *Server, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler err: %v", err)
+	}
+	if res == nil || len(res.Content) == 0 {
+		return ""
+	}
+	if tc, ok := res.Content[0].(mcpapi.TextContent); ok {
+		return tc.Text
+	}
+	return ""
+}
+
+// Site 1: handleTopologyTopicDetail — resolve()→getByIDOne inside a
+// forEachRelationship scan.
+func TestTopologyTopicDetail_flagON_noDeadlock_5928(t *testing.T) {
+	doc, r := loadDeadlock5928Fixture(t)
+	args := map[string]any{"group": "g", "topic_id": "t_orders"}
+
+	withServeFromMMap(t, false)
+	sOff := topologyServer(t, docFullRepo(doc))
+	want := callWithArgs(t, sOff, sOff.handleTopologyTopicDetail, args)
+	if want == "" {
+		t.Fatal("fixture must produce a non-empty topic-detail result flag-OFF")
+	}
+
+	withServeFromMMap(t, true)
+	sOn := topologyServer(t, readerEmptiedRepo(t, doc, r))
+	var got string
+	noHang(t, 5*time.Second, "handleTopologyTopicDetail", func() {
+		got = callWithArgs(t, sOn, sOn.handleTopologyTopicDetail, args)
+	})
+	if got != want {
+		t.Fatalf("topic detail flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
+	}
+}

--- a/internal/mcp/flagon_deadlock_5928_test.go
+++ b/internal/mcp/flagon_deadlock_5928_test.go
@@ -163,3 +163,27 @@ func TestPatternsGetGraph_flagON_noDeadlock_5928(t *testing.T) {
 		t.Fatalf("patterns get graph flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
 	}
 }
+
+// Site 3: endpointPostureScan — buildPosturePayload→getAdjacency/getByIDOne
+// inside a forEachEntity scan.
+func TestEndpointPostureScan_flagON_noDeadlock_5928(t *testing.T) {
+	doc, r := loadDeadlock5928Fixture(t)
+	args := map[string]any{"group": "g"} // no entity_id → repo-wide scan
+
+	withServeFromMMap(t, false)
+	sOff := topologyServer(t, docFullRepo(doc))
+	want := callWithArgs(t, sOff, sOff.handleEndpointPosture, args)
+	if want == "" {
+		t.Fatal("fixture must produce a non-empty endpoint-posture result flag-OFF")
+	}
+
+	withServeFromMMap(t, true)
+	sOn := topologyServer(t, readerEmptiedRepo(t, doc, r))
+	var got string
+	noHang(t, 5*time.Second, "handleEndpointPosture(scan)", func() {
+		got = callWithArgs(t, sOn, sOn.handleEndpointPosture, args)
+	})
+	if got != want {
+		t.Fatalf("endpoint posture scan flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
+	}
+}

--- a/internal/mcp/flagon_deadlock_5928_test.go
+++ b/internal/mcp/flagon_deadlock_5928_test.go
@@ -139,3 +139,27 @@ func TestTopologyTopicDetail_flagON_noDeadlock_5928(t *testing.T) {
 		t.Fatalf("topic detail flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
 	}
 }
+
+// Site 2: handlePatternsGetGraph — resolve()→getByIDOne inside a
+// forEachRelationship scan.
+func TestPatternsGetGraph_flagON_noDeadlock_5928(t *testing.T) {
+	doc, r := loadDeadlock5928Fixture(t)
+	args := map[string]any{"group": "g", "pattern_id": "pat1"}
+
+	withServeFromMMap(t, false)
+	sOff := topologyServer(t, docFullRepo(doc))
+	want := callWithArgs(t, sOff, sOff.handlePatternsGetGraph, args)
+	if want == "" {
+		t.Fatal("fixture must produce a non-empty pattern-graph result flag-OFF")
+	}
+
+	withServeFromMMap(t, true)
+	sOn := topologyServer(t, readerEmptiedRepo(t, doc, r))
+	var got string
+	noHang(t, 5*time.Second, "handlePatternsGetGraph", func() {
+		got = callWithArgs(t, sOn, sOn.handlePatternsGetGraph, args)
+	})
+	if got != want {
+		t.Fatalf("patterns get graph flag-ON(emptied Doc) != flag-OFF\n got=%s\nwant=%s", got, want)
+	}
+}

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -192,32 +192,41 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 		if target == "" {
 			target = pid
 		}
-		var result *mcpapi.CallToolResult
+		// #5928 collect-then-process: buildGroupCrossRepoLookup/
+		// buildProcessStepsWithCrossRepo call r.getStepAdj()/r.getByIDOne, which
+		// re-lock the same readerMu the flag-ON forEachEntity scan holds across its
+		// whole pass — calling them INSIDE the closure self-deadlocks on the
+		// live-Reader path. Capture the matched Process entity in-scan (rmu held) and
+		// stop the scan; build its steps AFTER the scan returns (rmu released).
+		// forEachEntity yields a heap-safe entity copy flag-ON (and a stable
+		// &Doc.Entities[i] flag-OFF), so using it past the scan is safe. Only the
+		// unique id-matched entity is retained, so the result is byte-identical.
+		var proc *graph.Entity
 		r.forEachEntity(func(e *graph.Entity) bool {
 			if e.Kind != processEntityKind || e.ID != target {
 				return true
 			}
+			proc = e
+			return false
+		})
+		if proc != nil {
 			// #1905 — bridge steps in cross-repo flows live in companion repos.
 			// Build a cross-repo lookup so bridge step entities are enriched with
 			// name/file/line/repo from the correct companion repo instead of being
 			// emitted as bare {id, node_id, step_index} stubs.
 			xrLookup := buildGroupCrossRepoLookup(lg, r.Repo)
-			steps := buildProcessStepsWithCrossRepo(r, e, xrLookup, verbose)
-			result = jsonResult(map[string]any{
-				"process_id":  prefixedID(r.Repo, e.ID),
+			steps := buildProcessStepsWithCrossRepo(r, proc, xrLookup, verbose)
+			return jsonResult(map[string]any{
+				"process_id":  prefixedID(r.Repo, proc.ID),
 				"repo":        r.Repo,
-				"label":       e.Name,
-				"entry_id":    e.PropGet("entry_id"),
-				"entry_name":  e.PropGet("entry_name"),
-				"terminal_id": e.PropGet("terminal_id"),
-				"cross_stack": e.PropGet("cross_stack") == "true",
+				"label":       proc.Name,
+				"entry_id":    proc.PropGet("entry_id"),
+				"entry_name":  proc.PropGet("entry_name"),
+				"terminal_id": proc.PropGet("terminal_id"),
+				"cross_stack": proc.PropGet("cross_stack") == "true",
 				"steps":       steps,
 				"found":       true,
-			})
-			return false
-		})
-		if result != nil {
-			return result, nil
+			}), nil
 		}
 	}
 	return jsonResult(map[string]any{"found": false, "process_id": pid}), nil


### PR DESCRIPTION
## What
Fixes 4 pre-existing flag-ON nested-`rmu` deadlocks — live MCP tool hangs on the default `GRAFEL_SERVE_FROM_MMAP` path. `forEachEntity`/`forEachRelationship` hold `lr.rmu()` (non-reentrant) across the whole scan; `getByIDOne`/`getAdjacency`/`getStepAdj` re-lock the same mutex → self-deadlock when called inside a `forEach*` closure.

## Sites (collect-then-process: collect ids/entities in-scan, resolve after rmu released)
- `handleTopologyTopicDetail` (dashboard_tools.go) — proven hang >4s pre-fix.
- `handlePatternsGetGraph` (dashboard_tools.go)
- `endpointPostureScan` (endpoint_posture.go)
- `handleTracesGet` (traces.go)

Order + results byte-identical.

## Verification (independent review — APPROVE)
- New `flagon_deadlock_5928_test.go`: 4 guard tests with proven teeth (revert resolve back in-scan → each hangs >5s RED; fixed → pass <0.05s).
- No remaining in-scan rmu-lock (all 4 traced); byte-identical non-empty results; pointer safety (heap copies flag-ON) confirmed.
- Full mcp+graph suite: 1629 passed.

Closes #5928