### PR TITLE
feat(#5870 PR7bc): deretain flip — drop heap lr.Doc for reader-present repos (serve holds the graph ONCE)

### DIFF
--- a/internal/mcp/deretain_flip_5870_pr7bc_test.go
+++ b/internal/mcp/deretain_flip_5870_pr7bc_test.go
@@ -1,0 +1,341 @@
+package mcp
+
+// deretain_flip_5870_pr7bc_test.go — #5870 PR7bc, the deretain flip DROP.
+//
+// PR7a proved every read primitive serves correctly from the resident mmap
+// Reader with an EMPTIED lr.Doc (header-only). PR7bc makes reloadLocked itself do
+// the emptying for a reader-present, flag-ON repo (skeletonizeDocRows), so serve
+// holds the graph ONCE (mmap) instead of twice (mmap + heap Doc). These tests are
+// the moment of truth: the emptying is done by reloadLocked in production, not by
+// the test harness.
+
+import (
+	"os"
+	"reflect"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// reloadReaderRepoPR7bc writes a real single-file graph.fb, wires a State +
+// registry + LoadedRepo exactly like production, and drives st.reloadLocked() —
+// the SAME path the daemon takes. Returns the reloaded repo (reader-present,
+// flag-ON, so skeletonizeDocRows has already run).
+func reloadReaderRepoPR7bc(t *testing.T, doc *graph.Document) (*State, *LoadedRepo) {
+	t.Helper()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "0") // force the flat single-file writer/reader
+	repoDir := t.TempDir()
+	stateDir := daemon.StateDirForRepo(repoDir)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	gp, err := fbwriter.WriteGraphGen(stateDir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	lr := &LoadedRepo{Repo: "r", Path: repoDir, GraphFile: gp}
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{"r": lr}}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reloadLocked: %v", err)
+	}
+	return st, lr
+}
+
+// fullDocRefRepo builds a flag-independent reference: a full Document with a
+// Doc-sourced LabelIndex (reader==nil), which serves every read from the Doc
+// regardless of the serveFromMMap() flag (at()/getBM25/getAdjacency all short-
+// circuit to the Doc when reader==nil). This is the oracle the skeletonized,
+// reader-sourced subject must match row-for-row.
+func fullDocRefRepo(doc *graph.Document) *LoadedRepo {
+	ref := &LoadedRepo{Repo: "r", Doc: doc}
+	ref.LabelIndex = BuildLabelIndex(doc)
+	return ref
+}
+
+// TestDeretainFlip_ReaderRepoSkeletonized_PR7bc is the production moment of truth:
+// after reloadLocked over a mapped graph.fb with the flag ON, lr.Doc.Entities /
+// Relationships are dropped to nil (the flip), the header survives on the still-
+// non-nil Doc, and a representative read surface returns CORRECT results sourced
+// from the Reader — identical to a full-Doc oracle over the same graph.
+func TestDeretainFlip_ReaderRepoSkeletonized_PR7bc(t *testing.T) {
+	forceServeFromMMap(t, true)
+	const n = 300
+	doc := buildSyntheticDoc(n)
+	doc.Version = 3
+	doc.Repo = "r"
+
+	st, lr := reloadReaderRepoPR7bc(t, doc)
+	_ = st
+
+	// (A) The flip actually happened: a resident Reader is present and the Doc row
+	// bulk is gone, but the Doc itself stays non-nil.
+	if lr.Reader == nil {
+		t.Fatal("reader-present repo left lr.Reader nil (no mmap → nothing to skeletonize against)")
+	}
+	if lr.Doc == nil {
+		t.Fatal("lr.Doc went nil — the skeleton MUST keep a non-nil header Document")
+	}
+	if len(lr.Doc.Entities) != 0 {
+		t.Fatalf("lr.Doc.Entities len=%d after reload, want 0 (skeletonized)", len(lr.Doc.Entities))
+	}
+	if len(lr.Doc.Relationships) != 0 {
+		t.Fatalf("lr.Doc.Relationships len=%d after reload, want 0 (skeletonized)", len(lr.Doc.Relationships))
+	}
+	if len(lr.Doc.Communities) != 0 || len(lr.Doc.SurpriseEdges) != 0 {
+		t.Fatalf("lr.Doc row-bulk (Communities/SurpriseEdges) not skeletonized: %d/%d",
+			len(lr.Doc.Communities), len(lr.Doc.SurpriseEdges))
+	}
+
+	// (B) Header metadata survives on the skeleton (Stats counts are sourced from
+	// the graph.fb header; Version/Repo round-trip through the fb).
+	if lr.Doc.Stats.Entities != n {
+		t.Errorf("skeleton Stats.Entities=%d, want %d (header count must survive)", lr.Doc.Stats.Entities, n)
+	}
+	if lr.Reader.EntityCount() != n {
+		t.Fatalf("reader EntityCount=%d, want %d", lr.Reader.EntityCount(), n)
+	}
+	if repoIndexedRef(lr) == "" {
+		t.Error("repoIndexedRef returned empty on the skeleton (header read regressed)")
+	}
+
+	// Oracle: a full-Doc repo over the same graph. Reads run under the flag-ON
+	// subject; the ref serves from its Doc (reader==nil) either way.
+	ref := fullDocRefRepo(doc)
+
+	// (C1) entity-by-id.
+	for _, id := range []string{"ent-000000", "ent-000150", "ent-000299"} {
+		gotE, gotOK := lr.getByIDOne(id)
+		wantE, wantOK := ref.getByIDOne(id)
+		if gotOK != wantOK {
+			t.Fatalf("getByIDOne(%q) ok mismatch: subject=%v ref=%v", id, gotOK, wantOK)
+		}
+		if gotOK && (gotE.ID != wantE.ID || gotE.Name != wantE.Name || gotE.QualifiedName != wantE.QualifiedName ||
+			gotE.Kind != wantE.Kind || gotE.SourceFile != wantE.SourceFile) {
+			t.Errorf("getByIDOne(%q) mismatch:\n subject=%+v\n ref    =%+v", id, gotE, wantE)
+		}
+	}
+	if _, ok := lr.getByIDOne("nope"); ok {
+		t.Error("getByIDOne(missing) returned ok=true on the skeleton")
+	}
+
+	// (C2) by-kind scan (the enumerate-by-kind substrate: LabelIndex.byKind → at()).
+	for _, kind := range []string{"function", "http_endpoint"} {
+		got := sortedIDsForKind(lr.LabelIndex, kind)
+		want := sortedIDsForKind(ref.LabelIndex, kind)
+		if len(got) == 0 {
+			t.Errorf("by-kind scan %q returned 0 ids on the skeleton (fell back to empty Doc?)", kind)
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("by-kind scan %q mismatch:\n subject=%v\n ref    =%v", kind, got, want)
+		}
+	}
+
+	// (C3) full-set scan (coverage/topology/cycles substrate: forEachEntity).
+	gotN := 0
+	lr.forEachEntity(func(*graph.Entity) bool { gotN++; return true })
+	if gotN != n {
+		t.Errorf("forEachEntity counted %d on the skeleton, want %d (Reader-sourced scan)", gotN, n)
+	}
+
+	// (C4) BM25 search — same ranked ids, and the index was built FROM the Reader.
+	query := "handleOrderRequest customer processor kafka fulfilment pipeline"
+	gotHits := hitIDs(lr.getBM25().Search(query, 10))
+	wantHits := hitIDs(ref.getBM25().Search(query, 10))
+	if len(gotHits) == 0 {
+		t.Error("BM25 search returned no hits on the skeleton — index likely built from the empty Doc")
+	}
+	if !reflect.DeepEqual(gotHits, wantHits) {
+		t.Errorf("BM25 search mismatch:\n subject=%v\n ref    =%v", gotHits, wantHits)
+	}
+
+	// (C5) adjacency / traces substrate — outgoing neighbor sets must match.
+	gotAdj := lr.getAdjacency()
+	refAdj := ref.getAdjacency()
+	for _, id := range []string{"ent-000000", "ent-000050", "ent-000200"} {
+		if !reflect.DeepEqual(sortedEdgeTargets(gotAdj.Outgoing(id)), sortedEdgeTargets(refAdj.Outgoing(id))) {
+			t.Errorf("adjacency Outgoing(%q) mismatch on the skeleton", id)
+		}
+	}
+
+	// (C6) getTopKPageRank — same ordered id list.
+	if !reflect.DeepEqual(lr.getTopKPageRank(), ref.getTopKPageRank()) {
+		t.Error("getTopKPageRank mismatch on the skeleton")
+	}
+}
+
+// TestDeretainFlip_JSONOnlyRepoKeepsFullDoc_PR7bc pins the split: a JSON-only
+// repo (no graph.fb → nil Reader) is NEVER skeletonized — its Doc is the only
+// read source, so reloadLocked must leave it FULL.
+func TestDeretainFlip_JSONOnlyRepoKeepsFullDoc_PR7bc(t *testing.T) {
+	forceServeFromMMap(t, true) // flag ON, yet a nil-reader repo must keep its Doc
+	const n = 120
+	doc := buildSyntheticDoc(n)
+
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	repoDir := t.TempDir()
+	jsonPath := writeGraph(t, repoDir, doc) // writes graph.json (NO graph.fb)
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	lr := &LoadedRepo{Repo: "r", Path: repoDir, GraphFile: jsonPath}
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{"r": lr}}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reloadLocked: %v", err)
+	}
+
+	if lr.Reader != nil {
+		t.Fatal("JSON-only repo opened a Reader — expected nil (no graph.fb)")
+	}
+	if lr.Doc == nil || len(lr.Doc.Entities) != n {
+		t.Fatalf("JSON-only Doc must stay FULL: Doc=%v Entities=%d, want %d", lr.Doc, len(lr.Doc.Entities), n)
+	}
+	if len(lr.Doc.Relationships) == 0 {
+		t.Fatal("JSON-only repo lost its Relationships (must NOT be skeletonized)")
+	}
+	// Reads still work, served from the full Doc.
+	if e, ok := lr.getByIDOne("ent-000010"); !ok || e.ID != "ent-000010" {
+		t.Fatalf("JSON-only getByIDOne(ent-000010) = %#v, ok=%v", e, ok)
+	}
+}
+
+// TestDeretainFlip_SkeletonizeDocRows_HeaderSurvives is the direct unit contract
+// for the helper: row-bulk slices go nil, the Document stays non-nil, and every
+// header field is preserved.
+func TestDeretainFlip_SkeletonizeDocRows_HeaderSurvives(t *testing.T) {
+	pr := 0.5
+	doc := &graph.Document{
+		Version:        7,
+		Repo:           "acme",
+		IndexerVersion: "1.2.3",
+		Stats:          graph.Stats{Files: 4, Entities: 2, Relationships: 1},
+		IndexedRef:     "refs/heads/main",
+		IndexedSHA:     "deadbeef",
+		IsWorktree:     true,
+		CoverageStatus: "partial",
+		AlgorithmStats: &graph.AlgorithmStats{},
+		Entities:       []graph.Entity{{ID: "a", PageRank: &pr}, {ID: "b"}},
+		Relationships:  []graph.Relationship{{FromID: "a", ToID: "b", Kind: "CALLS"}},
+		Communities:    []graph.CommunityResult{{}},
+		SurpriseEdges:  []graph.SurpriseEdge{{}},
+	}
+	gen := doc.GeneratedAt
+
+	skeletonizeDocRows(doc)
+
+	if doc == nil {
+		t.Fatal("skeletonizeDocRows nil'd the Document itself")
+	}
+	if doc.Entities != nil || doc.Relationships != nil || doc.Communities != nil || doc.SurpriseEdges != nil {
+		t.Fatalf("row-bulk not fully dropped: e=%v r=%v c=%v s=%v",
+			doc.Entities, doc.Relationships, doc.Communities, doc.SurpriseEdges)
+	}
+	if doc.Version != 7 || doc.Repo != "acme" || doc.IndexerVersion != "1.2.3" ||
+		doc.IndexedRef != "refs/heads/main" || doc.IndexedSHA != "deadbeef" || !doc.IsWorktree ||
+		doc.CoverageStatus != "partial" || doc.AlgorithmStats == nil || !doc.GeneratedAt.Equal(gen) {
+		t.Fatalf("header field lost after skeleton: %+v", doc)
+	}
+	if doc.Stats.Entities != 2 || doc.Stats.Relationships != 1 || doc.Stats.Files != 4 {
+		t.Fatalf("Stats lost after skeleton: %+v", doc.Stats)
+	}
+
+	// nil-safe.
+	skeletonizeDocRows(nil)
+}
+
+// TestDeretainFlip_ConcurrentReloadSkeletonRace_PR7bc drives repeated
+// reloadLocked (each skeletonizing lr.Doc) while readers hammer the mmap read
+// path. Under -race it must finish with no read-after-munmap SIGBUS/race and no
+// wrong data.
+func TestDeretainFlip_ConcurrentReloadSkeletonRace_PR7bc(t *testing.T) {
+	forceServeFromMMap(t, true)
+	const n = 200
+	doc := buildSyntheticDoc(n)
+	st, lr := reloadReaderRepoPR7bc(t, doc)
+
+	if len(lr.Doc.Entities) != 0 {
+		t.Fatalf("first reload did not skeletonize: Entities=%d", len(lr.Doc.Entities))
+	}
+
+	stop := make(chan struct{})
+	var faults atomic.Int64
+	var wg sync.WaitGroup
+
+	// Reloader: re-run reloadLocked in a loop. The content-hash skip means the
+	// graph.fb bytes are identical so most iterations no-op, but each genuine
+	// reload re-opens the reader, rebuilds the LabelIndex, and re-skeletonizes —
+	// exercising the publish/retire path under load.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 60; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, _, err := st.reloadLocked(); err != nil {
+				faults.Add(1)
+				return
+			}
+		}
+	}()
+
+	for g := 0; g < 6; g++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 400; j++ {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				if e, ok := lr.getByIDOne("ent-000100"); ok && (e == nil || e.ID != "ent-000100") {
+					faults.Add(1)
+				}
+				_ = lr.getBM25().Search("kafka fulfilment", 5)
+				_ = lr.getAdjacency()
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(stop)
+
+	if f := faults.Load(); f != 0 {
+		t.Fatalf("concurrent reload+skeleton produced %d faults (wrong data / reload error)", f)
+	}
+}
+
+// sortedIDsForKind resolves every vector index registered under kind in the
+// LabelIndex to its entity id via at(), returning them sorted. A skeletonized,
+// reader-sourced index must resolve these off the Reader.
+func sortedIDsForKind(li *LabelIndex, kind string) []string {
+	idxs := li.byKind[kind]
+	out := make([]string, 0, len(idxs))
+	for _, i := range idxs {
+		if e := li.at(i); e != nil {
+			out = append(out, e.ID)
+		}
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/mcp/getbyid_deretain_5850_pathp_test.go
+++ b/internal/mcp/getbyid_deretain_5850_pathp_test.go
@@ -449,7 +449,10 @@ func TestGetByIDOneParity_FlagOnVsFlagOff_PathP(t *testing.T) {
 // TestGetByIDOneReloadRace_PathP runs getByIDOne concurrently with a reload that
 // retires+munmaps the mapping the resident LabelIndex points at. Under -race it
 // must finish with no SIGBUS: getByIDOne resolves the single index via the
-// readerMu-guarded at(), so a retired lookup falls back to the Doc.
+// readerMu-guarded at(). Post-#5870 PR7bc at() returns nil for a retired
+// generation (no Doc fallback), so getByIDOne reports (nil,false) — a graceful
+// miss — once the retire lands; the invariant is "no freed-region deref, never
+// WRONG data", so a present result must be correct and a miss is acceptable.
 func TestGetByIDOneReloadRace_PathP(t *testing.T) {
 	forceServeFromMMap(t, true)
 
@@ -486,7 +489,7 @@ func TestGetByIDOneReloadRace_PathP(t *testing.T) {
 			<-start
 			for j := 0; j < 600; j++ {
 				e, ok := lr.getByIDOne("e5")
-				if !ok || e == nil || e.ID != "e5" || e.QualifiedName != "r.e5" {
+				if ok && (e == nil || e.ID != "e5" || e.QualifiedName != "r.e5") {
 					faults.Add(1)
 				}
 			}

--- a/internal/mcp/getbyid_deretain_5850_pathp_test.go
+++ b/internal/mcp/getbyid_deretain_5850_pathp_test.go
@@ -194,8 +194,14 @@ func TestGetByIDFlagOnEmptiedDoc_PathP(t *testing.T) {
 // TestGetByIDReloadRace_PathP runs getByID concurrently with a reload that
 // retires+munmaps the mapping the resident LabelIndex points at. Under -race it
 // must finish with no SIGBUS/SIGSEGV: getByID resolves via the readerMu-guarded
-// at(), so a lookup whose mapping was retired falls back to the Doc (correct
-// data) instead of dereferencing the freed region.
+// at(), so a lookup whose mapping was retired takes a safe non-mmap path instead
+// of dereferencing the freed region. Post-#5870 PR7bc that safe path is a
+// graceful MISS (at() returns nil for a retired generation, no Doc fallback), so
+// a retired-generation entity may be ABSENT — never wrong, never a freed-region
+// deref. In production reload also reassigns lr.LabelIndex to the fresh
+// generation; this test pins the field to the retired index on purpose to
+// exercise at()'s retired branch, so absence here is the expected steady state
+// after the retire lands.
 func TestGetByIDReloadRace_PathP(t *testing.T) {
 	forceServeFromMMap(t, true)
 
@@ -229,8 +235,10 @@ func TestGetByIDReloadRace_PathP(t *testing.T) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 
-	// Readers: hammer getByID; every returned entity must be correct (mmap OR the
-	// Doc fallback after retire — both carry identical content).
+	// Readers: hammer getByID. e5 is either PRESENT and correct (pre-retire mmap
+	// read) or ABSENT (post-retire graceful miss — at() returns nil for the retired
+	// generation). The invariant is "never wrong data, never a freed-region deref";
+	// a present entry that is nil or mismatched is a fault, absence is not.
 	for g := 0; g < 8; g++ {
 		wg.Add(1)
 		go func() {
@@ -238,7 +246,7 @@ func TestGetByIDReloadRace_PathP(t *testing.T) {
 			<-start
 			for j := 0; j < 600; j++ {
 				m := lr.getByID()
-				if e, ok := m["e5"]; !ok || e == nil || e.ID != "e5" || e.QualifiedName != "r.e5" {
+				if e, ok := m["e5"]; ok && (e == nil || e.ID != "e5" || e.QualifiedName != "r.e5") {
 					faults.Add(1)
 				}
 			}

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -291,13 +291,22 @@ func (l *LabelIndex) at(idx int32) *graph.Entity {
 			l.readerMu.Lock()
 			if l.handle != nil && l.handle.readRetired {
 				l.readerMu.Unlock()
-				// Doc fallback — mapping is gone, so the Doc row count is the only
-				// valid bound left (memory epic #5850 Path P PR6).
-				if int(idx) >= len(l.doc.Entities) {
-					return nil
-				}
-				e := l.doc.Entities[idx]
-				return &e
+				// Retired generation → return nil, do NOT fall back to
+				// l.doc.Entities. This branch fires only for a STALE captured
+				// *LabelIndex (e.g. the lock-free BM25 resolver closure) whose
+				// generation was retired+munmapped by a concurrent reload. Two
+				// reasons the Doc row is no longer a valid source here:
+				//   1. Post-deretain-flip (#5870 PR7bc), reloadLocked skeletonizes
+				//      lr.Doc for reader-present repos — doc.Entities is length 0,
+				//      so indexing it would be an out-of-range panic (and even the
+				//      len-guarded fallback would report every index "not found").
+				//   2. A retired generation's index is stale against the reindexed
+				//      successor generation anyway — a Doc-sourced row from the
+				//      superseded graph is not a meaningful answer.
+				// Callers that resolve indices lock-free (BM25 Search via
+				// idx.resolve → at()) already tolerate a nil entity by skipping
+				// that result row (see scoring.go Search: `if ent == nil { continue }`).
+				return nil
 			}
 			// PR6: the bound is the RESIDENT READER's row count, not
 			// len(l.doc.Entities) — a PR7 Doc-emptying leaves doc.Entities at 0

--- a/internal/mcp/mmap_readermu_sigbus_test.go
+++ b/internal/mcp/mmap_readermu_sigbus_test.go
@@ -12,8 +12,12 @@
 //     mapping can never interleave.
 //   - MapHandle.readRetired: set true UNDER readerMu immediately BEFORE the
 //     munmap. A choke point holding a mapping retired out from under it (a stale
-//     captured *LabelIndex) sees readRetired==true and falls back to the Doc path
-//     instead of dereferencing the freed region.
+//     captured *LabelIndex) sees readRetired==true and takes a safe non-mmap path
+//     instead of dereferencing the freed region — the adjacency builders fall back
+//     to the Doc, while at() returns nil (post-#5870 PR7bc deretain flip: a
+//     reader-present repo's Doc is skeletonized, so the retired generation has no
+//     valid Doc row to hand back, and its index is stale against the successor
+//     generation anyway).
 //
 // These tests run flag-ON with -race and must complete with NO SIGBUS/SIGSEGV/
 // panic and correct data.
@@ -123,6 +127,14 @@ func TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS(t *testing.T) {
 	// Readers: hammer all 4 choke points. LabelIndex.at via a pointer snapshotted
 	// under s.mu (race-free vs the reloader's write); the 3 adjacency builders read
 	// lr.Reader/lr.handle under readerMu inside their getters.
+	//
+	// The snapshotted li may be retired by the reloader BETWEEN the snapshot and the
+	// ByID call (publishHandle retires the predecessor generation). Post-#5870
+	// PR7bc, at() on a retired generation returns nil (a graceful miss) rather than
+	// falling back to the Doc, so ByID may legitimately return nil here. The
+	// load-bearing invariant this test pins is "no read-after-munmap SIGBUS (run
+	// -race) and never WRONG data" — a non-nil entity must be the correct one;
+	// absence for a mid-flight-retired generation is expected, not a fault.
 	var wgB sync.WaitGroup
 	for g := 0; g < 6; g++ {
 		wgB.Add(1)
@@ -132,7 +144,7 @@ func TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS(t *testing.T) {
 				s.mu.Lock()
 				li := lr.LabelIndex
 				s.mu.Unlock()
-				if e := li.ByID("e5"); e == nil || e.ID != "e5" {
+				if e := li.ByID("e5"); e != nil && e.ID != "e5" {
 					faults.Add(1)
 				}
 				_ = lr.getAdjacency()
@@ -151,16 +163,19 @@ func TestServeFromMMapOn_ConcurrentReloadRaceNoSIGBUS(t *testing.T) {
 	s.mu.Unlock()
 
 	if f := faults.Load(); f != 0 {
-		t.Fatalf("choke-point read faults (wrong/nil entity): %d", f)
+		t.Fatalf("choke-point read faults (wrong entity from a live generation): %d", f)
 	}
 }
 
-// TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc is the load-bearing
-// test for the readRetired flag. It captures a *LabelIndex BEFORE a reload, the
-// reload retires+munmaps that generation's mapping, and then a lookup on the
-// STALE captured index must still return the correct entity via the Doc fallback
-// (NOT a SIGBUS on the freed region, NOT wrong data).
-func TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc(t *testing.T) {
+// TestServeFromMMapOn_StaleCapturedLabelIndexAtReturnsNil is the load-bearing
+// test for the readRetired flag AFTER the #5870 PR7bc deretain flip. It captures
+// a *LabelIndex BEFORE a reload, the reload retires+munmaps that generation's
+// mapping, and then a lookup on the STALE captured index must return nil — NOT a
+// SIGBUS on the freed region, and NOT an out-of-range panic when the Doc has been
+// skeletonized (Entities dropped to length 0 by reloadLocked). Before the flip
+// at() fell back to the Doc row; now the retired generation's Doc is empty and
+// its index is stale against the successor, so nil (skip-the-row) is the contract.
+func TestServeFromMMapOn_StaleCapturedLabelIndexAtReturnsNil(t *testing.T) {
 	forceServeFromMMap(t, true)
 
 	doc := sigbusFixtureDoc(8)
@@ -204,17 +219,85 @@ func TestServeFromMMapOn_StaleCapturedLabelIndexFallsBackToDoc(t *testing.T) {
 		t.Fatalf("predecessor handle not marked readRetired after reload")
 	}
 
-	// The stale captured index MUST now fall back to the Doc (its mapping is gone).
-	// Correct entity, no SIGBUS.
-	for _, tc := range []struct{ id, qn string }{{"e0", "r.e0"}, {"e3", "r.e3"}, {"e7", "r.e7"}} {
-		got := stale.ByID(tc.id)
-		if got == nil || got.ID != tc.id || got.QualifiedName != tc.qn {
-			t.Fatalf("stale.ByID(%s) after retire = %#v, want id=%s qn=%s (Doc fallback)", tc.id, got, tc.id, tc.qn)
+	// The retired-generation Doc is now skeletonized in production; emulate that
+	// here so at()'s retired branch is exercised against an EMPTY Entities slice —
+	// the branch must NOT index l.doc.Entities (out-of-range panic) and must NOT
+	// fall back to Doc rows. It returns nil.
+	stale.doc.Entities = nil
+
+	for _, id := range []string{"e0", "e3", "e7"} {
+		if got := stale.ByID(id); got != nil {
+			t.Fatalf("stale.ByID(%s) after retire+skeleton = %#v, want nil", id, got)
 		}
 	}
-	// at() via LookupAll on the stale index also uses the Doc fallback.
-	if got := stale.Lookup("e5"); got == nil || got.ID != "e5" {
-		t.Fatalf("stale.Lookup(e5) after retire = %#v", got)
+	// Direct at() with an in-range-for-the-old-generation index must also return
+	// nil (no out-of-range on the emptied Doc, no freed-region deref).
+	if got := stale.at(5); got != nil {
+		t.Fatalf("stale.at(5) after retire+skeleton = %#v, want nil", got)
+	}
+
+	s.mu.Lock()
+	lr.retireHandle()
+	s.mu.Unlock()
+}
+
+// TestServeFromMMapOn_BM25ResolverRetiredRowsSkipped proves the BM25 search
+// result assembly tolerates at() returning nil for a retired generation: with the
+// resolver wired to a STALE (retired-mapping, skeletonized-Doc) LabelIndex, every
+// row resolves to nil and Search drops them all — no panic, no nil-deref — while a
+// LIVE resolver over the same index shape returns the rows. This is the caller
+// side of COMMIT 1 (scoring.go Search: `if ent == nil { continue }`).
+func TestServeFromMMapOn_BM25ResolverRetiredRowsSkipped(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	doc := sigbusFixtureDoc(8)
+	fbPath := filepath.Join(t.TempDir(), "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	open := func() *fbreader.Reader {
+		r, err := fbreader.Open(fbPath)
+		if err != nil {
+			t.Fatalf("open reader: %v", err)
+		}
+		return r
+	}
+
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{"g": {Repos: map[string]RegistryRepo{}}}})
+	lr := &LoadedRepo{Repo: "r", Doc: doc}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	s.mu.Lock()
+	h0 := newMapHandle(open())
+	stale := wireReaderLabelIndex(lr, h0.reader, h0, doc)
+	lr.LabelIndex = stale
+	lr.publishHandle(h0)
+
+	// A BM25 index over the SAME mmap, resolver captured against the stale index
+	// (exactly as getBM25 wires idx.resolve = func(vi){ return li.at(vi) }).
+	bm := BuildBM25FromReader(h0.reader)
+	bm.resolve = func(vi int32) *graph.Entity { return stale.at(vi) }
+	s.mu.Unlock()
+
+	// Live: the resolver returns rows, so a query matching every entity name (all
+	// entities are "eN", sharing no token; query each id) resolves.
+	if hits := bm.Search("e3", 10); len(hits) == 0 {
+		t.Fatalf("pre-retire BM25 Search(e3) returned no hits; resolver should be live")
+	}
+
+	// Retire the generation the resolver's captured index holds, and skeletonize
+	// its Doc — every at() now returns nil.
+	s.mu.Lock()
+	nh := newMapHandle(open())
+	lr.LabelIndex = wireReaderLabelIndex(lr, nh.reader, nh, doc)
+	lr.publishHandle(nh)
+	s.mu.Unlock()
+	stale.doc.Entities = nil
+
+	// Search must not panic and must skip every retired-resolved row → empty slice.
+	hits := bm.Search("e3", 10)
+	if len(hits) != 0 {
+		t.Fatalf("post-retire BM25 Search(e3) = %d hits, want 0 (all rows retired → nil → skipped)", len(hits))
 	}
 
 	s.mu.Lock()

--- a/internal/mcp/segment_serve_5912h_test.go
+++ b/internal/mcp/segment_serve_5912h_test.go
@@ -367,8 +367,12 @@ func TestSegmentSet_ReloadRetireDrainNoRace_5912h(t *testing.T) {
 				li := lr.LabelIndex
 				s.mu.Unlock()
 				// e00000123 lives past the first segment boundary → exercises
-				// cross-segment materialization under the concurrent munmap.
-				if e := li.ByID("ent-00000123"); e == nil || e.ID != "ent-00000123" {
+				// cross-segment materialization under the concurrent munmap. The
+				// snapshotted li may be retired between snapshot and ByID; post-#5870
+				// PR7bc at() returns nil for a retired generation (graceful miss, no
+				// Doc fallback), so a nil result is acceptable — only WRONG data (a
+				// non-nil mismatch) or a freed-region deref is a fault.
+				if e := li.ByID("ent-00000123"); e != nil && e.ID != "ent-00000123" {
 					faults.Add(1)
 				}
 				_ = lr.getAdjacency()

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1292,6 +1292,28 @@ func (s *State) reloadLocked() (int, bool, error) {
 	return s.reloadAllLocked()
 }
 
+// skeletonizeDocRows drops the row-bulk slices of a Document to nil while keeping
+// the Document itself non-nil and every header field intact. This is the #5870
+// PR7bc deretain flip: for a reader-present, flag-ON repo the row bulk (Entities
+// / Relationships / Communities / SurpriseEdges) is redundant — the resident mmap
+// Reader holds every row and the LabelIndex + BM25/adjacency/getByID + overlay
+// side-tables all source from it — so retaining the heap copy doubles the graph's
+// resident footprint. The header fields (Version, GeneratedAt, Repo,
+// IndexerVersion, IsWorktree, CoverageStatus, IndexedRef, IndexedSHA, Stats,
+// AlgorithmStats) are NOT touched: repoIndexedRef, the semantic-sidecar guard,
+// the algo-stamp staleness check, and grafel_whoami keep reading them off the
+// non-nil skeleton. Callers MUST hold s.mu (reload) and must have already run
+// every eager doc-row build (BuildLabelIndexFromReader, reader-sourced counts).
+func skeletonizeDocRows(doc *graph.Document) {
+	if doc == nil {
+		return
+	}
+	doc.Entities = nil
+	doc.Relationships = nil
+	doc.Communities = nil
+	doc.SurpriseEdges = nil
+}
+
 // reloadAllLocked is the reload body; the caller MUST already hold s.mu. Split
 // out of reloadLocked (memory epic #5850 PR1) so the eviction revive path can
 // reload from disk while already holding s.mu (Group -> reviveEvictedLocked)
@@ -1568,6 +1590,30 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 					}
 					lr.TestsEdgeCount = testsCount
 					lr.publishHandle(newHandle)
+					// #5870 PR7bc — the deretain flip DROP. For a reader-present repo
+					// with the flag ON, every row is now served from the resident mmap
+					// Reader (LabelIndex.*FromReader builders + at()/forEach materialize
+					// from the Reader; BM25/adjacency/getByID source int32 indices, not
+					// Doc pointers; the group-algo + description overlays build their
+					// side-tables from the Reader — see applyGroupAlgoOverlay /
+					// applyDescriptionOverlay below). Nothing on this path reads the Doc
+					// row bulk anymore, so drop it: serve holds the graph ONCE (mmap),
+					// not twice. This is the read-RSS win.
+					//
+					// Placement: strictly AFTER BuildLabelIndexFromReader (above) and
+					// AFTER the reader-sourced testsCount — the only eager consumers of
+					// doc rows in this loop iteration; the lazy BM25/adjacency getters
+					// build FromReader. The post-loop overlays run later and, on the ON
+					// path, iterate the Reader (their in-place Doc stamp becomes a no-op
+					// over the emptied slices). GATED on serveFromMMap() as well as
+					// newRdr!=nil: with the flag forced OFF a reader may still be
+					// resident, but at()/getBM25/view-materialize serve from the Doc,
+					// so emptying it there would break serving. The nil-reader
+					// (JSON-only / graph-absent) branch NEVER skeletonizes — its Doc is
+					// the only source.
+					if newRdr != nil && serveFromMMap() {
+						skeletonizeDocRows(lr.Doc)
+					}
 					reloaded++
 				}
 			}


### PR DESCRIPTION
## What
The deretain-flip DROP: serve no longer retains the full heap `lr.Doc` alongside the mmap Reader — it holds the graph ONCE (reclaimable mmap page cache) instead of twice (anonymous heap Document + mmap). This lands the read-side RSS win that v0.1.9's mmap serve was built toward but never switched on.

## How (2 commits)
1. `LabelIndex.at()` retired-generation branch returns `nil` (was: read `l.doc.Entities[idx]`). Fires only for a stale captured `*LabelIndex` (the lock-free BM25 resolver) whose generation was retired+munmapped by a concurrent reload; the row is gone and its index is stale against the successor. BM25 Search already skips nil.
2. `skeletonizeDocRows(doc)` nils `Entities`/`Relationships`/`Communities`/`SurpriseEdges` (keeps Doc NON-nil + header fields), called in `reloadAllLocked` after `publishHandle`, gated `newRdr != nil && serveFromMMap()`. Reader-present repos serve every row from the mmap Reader; **json-only (nil-reader) repos are NEVER skeletonized** (keep full Doc — their only source). flag-off never skeletonizes (Doc-served).

Prerequisites already merged: PR7a (#5927, tools migrated off raw slices), #5928 (#5929, forEach-scan deadlocks fixed).

## Verification (independent adversarial review — APPROVE)
- Relaxed concurrent-retire tests proven to still bite: deref-munmapped → SIGSEGV caught; wrong-entity → REDs every relaxed test (only absence tolerated).
- `BuildLabelIndexFromReader` retains no `doc.Entities` pointer → in-place nil safe (no use-after-free).
- json-only guard, flag-off guard, non-nil skeleton all proven load-bearing (remove → RED).
- **Full mcp+graph suite green with skeletonization ACTIVE** (1634 passed); `-race ×5` on retire/deretain = 35/35, no SIGBUS.
- Heap release confirmed: old backing arrays unreferenced post-skeleton → GC-reclaimable. RSS win real.

Refs #5870