### PR TITLE
fix(#5933): stop split-mode reaper from reaping every live watcher (5-min reindex treadmill)

### DIFF
--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -380,9 +380,16 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				// matched (cleaned-absolute) against this set so unrelated
 				// processes are never touched.
 				ManagedRepo: makeManagedRepoPredicate(trackedRepos),
-				DeadRefs:    deadRefSweeper,
-				OrphanRoots: orphanRootSweeper,
-				Logger:      logger,
+				// #5933: this reaper runs inside the ENGINE process, not the
+				// daemon/serve process that stamps watcher entries'
+				// OwnerDaemonPID (internal/cli/watch.go's liveDaemonPID), so
+				// os.Getpid() here is never the right comparison. Resolve the
+				// daemon/serve pidfile instead so orphan detection compares
+				// against the right process.
+				LiveDaemonPID: func() int { return ReadPIDFile(cfg.Layout.PIDPath) },
+				DeadRefs:      deadRefSweeper,
+				OrphanRoots:   orphanRootSweeper,
+				Logger:        logger,
 			})
 			reaperStop := make(chan struct{})
 			reaper.Start(reaperStop)

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -278,14 +278,17 @@ func (r *Reaper) sweepWatchers() int {
 	if r.cfg.WatchRegistry == nil {
 		return 0
 	}
-	liveDaemonPID := r.cfg.LiveDaemonPID
-	if liveDaemonPID == nil {
-		liveDaemonPID = os.Getpid
-	}
+	// #5933: an unset LiveDaemonPID must fail CLOSED, not default to
+	// os.Getpid(). In split mode (ADR-0024) this sweep runs in the ENGINE
+	// process, which is never the daemon/serve process that stamps watcher
+	// entries — defaulting to os.Getpid() here made every live watcher look
+	// orphaned and killed it every cycle. Leaving LiveDaemonPID nil disables
+	// the orphan-kill branch entirely (watchreg.Sweep treats live==0 as "no
+	// ownership check"); dead-PID reaping is unaffected.
 	res, err := r.cfg.WatchRegistry.Sweep(watchreg.SweepDeps{
 		Alive:         pidAliveProbe,
 		Kill:          sigtermPID,
-		LiveDaemonPID: liveDaemonPID,
+		LiveDaemonPID: r.cfg.LiveDaemonPID,
 	})
 	if err != nil {
 		r.logger.Warn("reaper: watcher PID registry sweep failed (non-fatal)", "err", err)

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -100,8 +100,15 @@ type ReaperConfig struct {
 	// touching real processes.
 	KillWatchProc func(pid int) error
 
-	// LiveDaemonPID returns the PID of the currently-live daemon, used to detect
-	// orphaned watchers. nil → os.Getpid (the running daemon owns the sweep).
+	// LiveDaemonPID returns the PID of the currently-live daemon/serve process,
+	// used to detect orphaned watchers (their OwnerDaemonPID is stamped from
+	// that same pidfile — see internal/cli/watch.go's liveDaemonPID). nil →
+	// the orphan-kill branch is skipped entirely (fail-closed): the reaper
+	// that owns this sweep does not necessarily run in the daemon/serve
+	// process (in split mode, ADR-0024, it runs in the ENGINE process), so
+	// os.Getpid() here is never a safe stand-in — comparing against it would
+	// misclassify every live watcher as orphaned and kill it (#5933). Dead-PID
+	// reaping is unaffected by this field either way.
 	LiveDaemonPID func() int
 
 	// DeadRefs, when non-nil, is the dead-ref / dead-worktree store sweep
@@ -285,10 +292,24 @@ func (r *Reaper) sweepWatchers() int {
 	// orphaned and killed it every cycle. Leaving LiveDaemonPID nil disables
 	// the orphan-kill branch entirely (watchreg.Sweep treats live==0 as "no
 	// ownership check"); dead-PID reaping is unaffected.
+	//
+	// Resolve (and pin) it once up front so a single sweep is internally
+	// consistent, and so a resolved-but-empty pidfile (live == 0 — the
+	// daemon/serve process is still starting, or its pidfile was just removed
+	// by shutdown) is visible to an operator instead of silently degrading
+	// the sweep with no signal (#5933).
+	liveDaemonPID := r.cfg.LiveDaemonPID
+	if liveDaemonPID != nil {
+		live := liveDaemonPID()
+		if live == 0 {
+			r.logger.Debug("reaper: LiveDaemonPID resolved to 0 this sweep — orphan-kill branch skipped (daemon/serve pidfile absent: startup race or shutdown truncation?)")
+		}
+		liveDaemonPID = func() int { return live }
+	}
 	res, err := r.cfg.WatchRegistry.Sweep(watchreg.SweepDeps{
 		Alive:         pidAliveProbe,
 		Kill:          sigtermPID,
-		LiveDaemonPID: r.cfg.LiveDaemonPID,
+		LiveDaemonPID: liveDaemonPID,
 	})
 	if err != nil {
 		r.logger.Warn("reaper: watcher PID registry sweep failed (non-fatal)", "err", err)

--- a/internal/daemon/reaper_watch_test.go
+++ b/internal/daemon/reaper_watch_test.go
@@ -1,7 +1,10 @@
 package daemon
 
 import (
+	"os"
+	"os/exec"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
@@ -43,5 +46,65 @@ func TestReaper_watchSweepDisabledWhenNil(t *testing.T) {
 	r := NewReaper(ReaperConfig{})
 	if res := r.Sweep(); res != (ReapResult{}) {
 		t.Fatalf("nil WatchRegistry + nil TrackedRepos should yield zero result, got %+v", res)
+	}
+}
+
+// TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed is the #5933 regression
+// test.
+//
+// In split mode (ADR-0024) the watcher stamps OwnerDaemonPID from the
+// daemon/serve pidfile (internal/cli/watch.go), but the Reaper that performs
+// the sweep runs inside the ENGINE process — a different PID. Before this fix,
+// an unset ReaperConfig.LiveDaemonPID fell back to os.Getpid() (the ENGINE's
+// own pid), which can never equal the daemon pidfile's pid, so every live
+// watcher was misclassified as orphaned and SIGTERM'd on every sweep.
+//
+// This test simulates exactly that shape: the watcher entry is a genuinely
+// alive (but disposable) child process, stamped with an OwnerDaemonPID
+// standing in for the daemon pidfile's PID — a value guaranteed to differ
+// from this test process's own os.Getpid() (the stand-in for the engine's
+// pid, per the real sweepWatchers default). With LiveDaemonPID left unset
+// (today's engineplane.go wiring), the fix requires the sweep to fail CLOSED
+// (skip the orphan-kill branch) rather than default to os.Getpid(), so the
+// entry — and the process behind it — must survive.
+func TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed(t *testing.T) {
+	reg := watchreg.New(filepath.Join(t.TempDir(), watchreg.FileName))
+
+	// A real, disposable child process so the sweep's hardcoded liveness
+	// probe (signal-0) sees a genuinely alive PID without touching this test
+	// process itself (which the buggy pre-fix path would SIGTERM).
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start watcher stand-in process: %v", err)
+	}
+	watcherPID := cmd.Process.Pid
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	// A daemon pidfile PID that is guaranteed to differ from this test
+	// process's own PID (the stand-in for the engine's os.Getpid()).
+	daemonPID := os.Getpid() + 1
+
+	if err := reg.Register(watchreg.Entry{PID: watcherPID, Repo: "/live", OwnerDaemonPID: daemonPID}); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	r := NewReaper(ReaperConfig{
+		WatchRegistry: reg,
+		// LiveDaemonPID intentionally left nil — reproduces engineplane.go's
+		// pre-fix wiring (#5933).
+	})
+	res := r.Sweep()
+	if res.WatchersReaped != 0 {
+		t.Fatalf("WatchersReaped = %d, want 0 (live watcher must survive when LiveDaemonPID is unset)", res.WatchersReaped)
+	}
+	got, _ := reg.List()
+	if len(got) != 1 || got[0].PID != watcherPID {
+		t.Fatalf("live watcher entry should still be registered, got %v", got)
+	}
+	if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+		t.Fatalf("watcher stand-in process should still be alive, signal-0 probe: %v", err)
 	}
 }

--- a/internal/daemon/reaper_watch_test.go
+++ b/internal/daemon/reaper_watch_test.go
@@ -2,9 +2,8 @@ package daemon
 
 import (
 	"os"
-	"os/exec"
 	"path/filepath"
-	"syscall"
+	"strconv"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
@@ -60,28 +59,21 @@ func TestReaper_watchSweepDisabledWhenNil(t *testing.T) {
 // watcher was misclassified as orphaned and SIGTERM'd on every sweep.
 //
 // This test simulates exactly that shape: the watcher entry is a genuinely
-// alive (but disposable) child process, stamped with an OwnerDaemonPID
-// standing in for the daemon pidfile's PID — a value guaranteed to differ
-// from this test process's own os.Getpid() (the stand-in for the engine's
-// pid, per the real sweepWatchers default). With LiveDaemonPID left unset
-// (today's engineplane.go wiring), the fix requires the sweep to fail CLOSED
-// (skip the orphan-kill branch) rather than default to os.Getpid(), so the
-// entry — and the process behind it — must survive.
+// alive (but disposable) child process — spawned via the package's existing
+// portable helper (spawnLiveChild, internal/daemon/pidfile_test.go) so this
+// runs cleanly on the Windows leg of the release matrix, not just
+// darwin/linux — stamped with an OwnerDaemonPID standing in for the daemon
+// pidfile's PID: a value guaranteed to differ from this test process's own
+// os.Getpid() (the stand-in for the engine's pid, per the real sweepWatchers
+// default). With LiveDaemonPID left unset (today's engineplane.go wiring),
+// the fix requires the sweep to fail CLOSED (skip the orphan-kill branch)
+// rather than default to os.Getpid(), so the entry — and the process behind
+// it — must survive.
 func TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed(t *testing.T) {
 	reg := watchreg.New(filepath.Join(t.TempDir(), watchreg.FileName))
 
-	// A real, disposable child process so the sweep's hardcoded liveness
-	// probe (signal-0) sees a genuinely alive PID without touching this test
-	// process itself (which the buggy pre-fix path would SIGTERM).
-	cmd := exec.Command("sleep", "30")
-	if err := cmd.Start(); err != nil {
-		t.Fatalf("start watcher stand-in process: %v", err)
-	}
-	watcherPID := cmd.Process.Pid
-	defer func() {
-		_ = cmd.Process.Kill()
-		_ = cmd.Wait()
-	}()
+	watcherPID, cleanup := spawnLiveChild(t)
+	defer cleanup()
 
 	// A daemon pidfile PID that is guaranteed to differ from this test
 	// process's own PID (the stand-in for the engine's os.Getpid()).
@@ -104,7 +96,53 @@ func TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed(t *testing.T) {
 	if len(got) != 1 || got[0].PID != watcherPID {
 		t.Fatalf("live watcher entry should still be registered, got %v", got)
 	}
-	if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
-		t.Fatalf("watcher stand-in process should still be alive, signal-0 probe: %v", err)
+}
+
+// TestReaper_sweepWatchers_LiveDaemonPIDFromPidfile is the #5933 positive-case
+// companion to the fail-closed test above: it proves the OTHER half of the
+// contract — that a correctly-resolving LiveDaemonPID (the same shape
+// engineplane.go wires: a closure reading the daemon/serve pidfile via
+// ReadPIDFile) both (a) KEEPS a live watcher whose OwnerDaemonPID matches the
+// pidfile's contents, and (b) still REAPS a live watcher whose OwnerDaemonPID
+// does not — i.e. genuine orphan detection still works once the wiring is
+// correct. Without this, only the "everything survives" half of #5933 would
+// be covered, and a regression that wires LiveDaemonPID to the WRONG pid (or
+// removes it) would not necessarily be caught.
+func TestReaper_sweepWatchers_LiveDaemonPIDFromPidfile(t *testing.T) {
+	reg := watchreg.New(filepath.Join(t.TempDir(), watchreg.FileName))
+
+	// A real on-disk pidfile, written the same way AcquirePIDFile does, so the
+	// closure below exercises the actual ReadPIDFile parse path — not a faked
+	// int — mirroring engineplane.go's `func() int { return
+	// ReadPIDFile(cfg.Layout.PIDPath) }` wiring exactly.
+	pidPath := filepath.Join(t.TempDir(), "daemon.pid")
+	const daemonPID = 424242
+	if err := os.WriteFile(pidPath, []byte(strconv.Itoa(daemonPID)+"\n"), 0o600); err != nil {
+		t.Fatalf("write fake daemon pidfile: %v", err)
+	}
+
+	survivorPID, survivorCleanup := spawnLiveChild(t)
+	defer survivorCleanup()
+	orphanPID, orphanCleanup := spawnLiveChild(t)
+	defer orphanCleanup()
+
+	if err := reg.Register(watchreg.Entry{PID: survivorPID, Repo: "/kept", OwnerDaemonPID: daemonPID}); err != nil {
+		t.Fatalf("register survivor: %v", err)
+	}
+	if err := reg.Register(watchreg.Entry{PID: orphanPID, Repo: "/reaped", OwnerDaemonPID: daemonPID + 1}); err != nil {
+		t.Fatalf("register orphan: %v", err)
+	}
+
+	r := NewReaper(ReaperConfig{
+		WatchRegistry: reg,
+		LiveDaemonPID: func() int { return ReadPIDFile(pidPath) },
+	})
+	res := r.Sweep()
+	if res.WatchersReaped != 1 {
+		t.Fatalf("WatchersReaped = %d, want 1 (only the mismatched-owner watcher)", res.WatchersReaped)
+	}
+	got, _ := reg.List()
+	if len(got) != 1 || got[0].PID != survivorPID {
+		t.Fatalf("registry after sweep = %v, want only survivor pid %d kept", got, survivorPID)
 	}
 }


### PR DESCRIPTION
## Problem

In split mode (ADR-0024) the Reaper's watcher-orphan sweep compared a watcher's
recorded owner PID against `os.Getpid()` of the **engine** process, while watchers
stamp their owner from the **daemon/serve** pidfile. Those can never match, so
every live watcher was declared orphaned and SIGTERM'd on every 5-minute sweep,
respawned by launchd `KeepAlive`, and re-registered with the same mismatch —
forever. Each respawn's registration triggered a full reindex.

Measured on a 427k-entity / 1.85M-relationship group: 12 reaper sweeps in ~1h,
each reporting a different orphan PID, with a full index pass ~30s after each one,
all reporting an identical `entities=427303` because nothing had changed. It also
cancelled the group link/data-flow pass mid-flight each cycle
(`sched: links failed ... context canceled`), leaving the group with 0 flows,
0 communities, and no `<group>-links-*.json` artifacts.

Pre-split, the reaper and the pidfile owner were the same process, so the
`os.Getpid` default was correct. The serve/engine split moved the reaper into the
engine plane without updating it. Monolith mode (`GRAFEL_SPLIT_MODE=0`) is
unaffected.

## Change

- `engineplane.go`: wire `LiveDaemonPID: func() int { return ReadPIDFile(cfg.Layout.PIDPath) }`
  so the engine-process reaper compares against the daemon/serve pidfile the
  watcher actually stamped.
- `reaper.go`: remove the `os.Getpid` fallback so an unset `LiveDaemonPID` **fails
  closed** — the orphan-kill branch is skipped entirely rather than defaulting to a
  comparison that kills everything. Dead-PID reaping is unaffected. Also log at
  Debug when the resolver yields 0 (pidfile absent: startup race or shutdown
  truncation) so a degraded sweep is observable rather than silent.
- Corrected the `LiveDaemonPID` field doc, which still documented the old
  `nil → os.Getpid` behaviour.

## Tests

- `TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed` — a live watcher survives
  when `LiveDaemonPID` is unset.
- `TestReaper_sweepWatchers_LiveDaemonPIDFromPidfile` — writes a real pidfile and
  uses the same closure shape `engineplane.go` wires: a watcher whose
  `OwnerDaemonPID` matches survives, a mismatched one is still reaped.

Both use the existing portable `spawnLiveChild` helper so they run on Windows.

## Review

Independently reviewed (adversarial, mutation-based). The reviewer verified the
production logic against: other-caller regression from dropping the default,
`ReadPIDFile` returning 0, the startup race (self-healing — the closure is
re-invoked every sweep), shutdown truncation (fails safe), path identity across
`GRAFEL_DAEMON_ROOT`, monolith behaviour preservation, and whether
`sweepForeignWatchers` (#5632) has an analogous bug (it does not). First round was
REQUEST-CHANGES on test portability, the stale field doc, and coverage; all
addressed here.

## Known gap (tracked)

No test detects deletion of the `engineplane.go` wiring line itself — the reaper's
30s startup delay and non-injectable interval put a real end-to-end assertion out
of scope for this fix. Tracked as #5935. A pre-existing Windows liveness-probe
defect found during review is tracked as #5934.

Closes #5933
