### PR TITLE
fix(test): isolate Windows temp writes and daemon discovery

### DIFF
--- a/internal/dashboard/handlers_v2_mode_test.go
+++ b/internal/dashboard/handlers_v2_mode_test.go
@@ -28,6 +28,9 @@ func newModeTestServer(t *testing.T) (serverURL, daemonRoot string) {
 	if err := os.MkdirAll(daemonRoot, 0o700); err != nil {
 		t.Fatalf("mkdir daemonRoot: %v", err)
 	}
+	// Isolate daemon discovery as well as filesystem state. Without this, a
+	// mode-switch test can connect to and stop the developer's live daemon.
+	t.Setenv("GRAFEL_DAEMON_ROOT", daemonRoot)
 
 	st := newFakeStore()
 	srv, err := NewServer(DefaultConfig(), st)

--- a/internal/registry/test_isolation_guard.go
+++ b/internal/registry/test_isolation_guard.go
@@ -63,20 +63,41 @@ func guardResolvedConfigPath(resolved, what string) {
 	if realUserHomeAtInit == "" || resolved == "" {
 		return
 	}
-	abs := resolved
-	if a, err := filepath.Abs(resolved); err == nil {
-		abs = a
-	}
-	abs = filepath.Clean(abs)
-	home := realUserHomeAtInit
-	if abs == home || strings.HasPrefix(abs+string(filepath.Separator), home+string(filepath.Separator)) {
+	if isUnsafeTestWritePath(resolved, realUserHomeAtInit, os.TempDir()) {
 		panic(fmt.Sprintf(
 			"registry: TEST SANDBOX ESCAPE — about to WRITE %s to %q, which is inside the "+
 				"REAL user home %q. This test would clobber the developer's live "+
 				"~/.config/grafel/<group>.fleet.json / ~/.grafel/registry.json (see #5443). "+
 				"Call testsupport.IsolateHome(t) at the top of the test before writing any "+
 				"config/registry/fleet file.",
-			what, abs, home,
+			what, resolved, realUserHomeAtInit,
 		))
 	}
+}
+
+// isUnsafeTestWritePath reports whether path targets the real user home while
+// exempting the operating system's temp tree. On Windows, t.TempDir lives
+// below %USERPROFILE%\AppData\Local\Temp, so a raw "under real home" prefix
+// check falsely rejects correctly isolated tests.
+func isUnsafeTestWritePath(path, realHome, tempRoot string) bool {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	abs = filepath.Clean(abs)
+	if tempRoot != "" && pathWithin(abs, tempRoot) {
+		return false
+	}
+	return pathWithin(abs, realHome)
+}
+
+func pathWithin(path, root string) bool {
+	if path == "" || root == "" {
+		return false
+	}
+	rel, err := filepath.Rel(filepath.Clean(root), filepath.Clean(path))
+	if err != nil || filepath.IsAbs(rel) {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
 }

--- a/internal/registry/test_isolation_guard_test.go
+++ b/internal/registry/test_isolation_guard_test.go
@@ -46,12 +46,10 @@ func TestGuard_AllowsWriteUnderIsolatedHome(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Sanity: the resolved config path is NOT under the real home.
-	if realUserHomeAtInit != "" {
-		abs, _ := filepath.Abs(cfgPath)
-		if strings.HasPrefix(filepath.Clean(abs)+string(filepath.Separator), realUserHomeAtInit+string(filepath.Separator)) {
-			t.Fatalf("isolated config path %q unexpectedly under real home %q", abs, realUserHomeAtInit)
-		}
+	// On Windows t.TempDir is normally nested under %USERPROFILE%. The guard
+	// must still recognize the OS temp tree as an isolated destination.
+	if !pathWithin(cfgPath, dir) {
+		t.Fatalf("isolated config path %q is not under temp root %q", cfgPath, dir)
 	}
 
 	if err := SaveGroupConfig(cfgPath, &GroupConfig{Name: "isolated"}); err != nil {
@@ -62,6 +60,20 @@ func TestGuard_AllowsWriteUnderIsolatedHome(t *testing.T) {
 		t.Fatalf("roundtrip under isolated home failed: got=%+v err=%v", got, err)
 	}
 	_ = dir
+}
+
+func TestIsUnsafeTestWritePath_AllowsTempNestedUnderRealHome(t *testing.T) {
+	realHome := filepath.Join(t.TempDir(), "user")
+	tempRoot := filepath.Join(realHome, "AppData", "Local", "Temp")
+	isolated := filepath.Join(tempRoot, "TestGuard", "cfg", "grafel", "group.fleet.json")
+	live := filepath.Join(realHome, ".config", "grafel", "group.fleet.json")
+
+	if isUnsafeTestWritePath(isolated, realHome, tempRoot) {
+		t.Fatalf("isolated temp path %q was classified as a live-home write", isolated)
+	}
+	if !isUnsafeTestWritePath(live, realHome, tempRoot) {
+		t.Fatalf("live config path %q was not rejected", live)
+	}
 }
 
 // TestGuard_RegistrySaveAlsoGuarded proves saveTo (registry.json writer, used


### PR DESCRIPTION
## What changed

- Allow test writes beneath the operating system temp directory even when Windows places it under `%USERPROFILE%`.
- Keep rejecting writes to the developer's real config and registry paths.
- Isolate dashboard mode-switch tests from live daemon discovery with `GRAFEL_DAEMON_ROOT`.

## Why

The previous prefix check classified Windows temp directories as live-home writes. Mode-switch tests also isolated filesystem state without isolating daemon discovery, so they could contact a developer daemon.

## Validation

- `go test -p 1 ./internal/registry -run 'Test(Guard_|IsUnsafeTestWritePath_)' -count=1`
- `go test -p 1 ./internal/dashboard -run 'TestHandleV2(Get|Set)DaemonMode_' -count=1`
- `git diff --check`

A broader local dashboard run remains blocked on Windows by an existing symlink-privilege test and a separate `internal/install/mcpreg` isolation guard; the focused tests above pass.

## Closes / Refs

Closes #5944
