### PR TITLE
fix(settings): preserve discovered package state

### DIFF
--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -39,6 +39,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -190,10 +191,11 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 		}
 		totalEntities += entities
 
+		repoStack := settingsRepoStack(r)
 		sr := v2SettingsRepo{
 			Slug:  r.Slug,
 			Path:  r.Path,
-			Stack: settingsRepoStack(r),
+			Stack: repoStack,
 			Files: files,
 		}
 		sr.Entities = entities
@@ -204,20 +206,8 @@ func loadV2SettingsGroup(groupName, histRoot string) (*v2SettingsGroup, error) {
 		// Phase 0 git metadata (#2088) + M4 sparse badge (#2181). Read cheaply
 		// from graph.fb header — no entity decode required.
 		sr.IndexedRef, sr.IndexedSHA, sr.IsWorktree, sr.CoverageStatus = repoGitMeta(stateDir)
-		// Monorepo: if the repo has Modules, surface them as a stub MonorepoInfo.
-		if len(r.Modules) > 0 {
-			pkgs := make([]v2MonorepoPkg, 0, len(r.Modules))
-			for _, mod := range r.Modules {
-				pkgs = append(pkgs, v2MonorepoPkg{
-					Path:    mod,
-					Stack:   r.Stack.Primary(),
-					Indexed: true,
-				})
-			}
-			sr.Monorepo = &v2MonorepoInfo{
-				Detector: "modules",
-				Packages: pkgs,
-			}
+		if mono := settingsMonorepoInfo(r, repoStack); mono != nil {
+			sr.Monorepo = mono
 		}
 		sg.Repos = append(sg.Repos, sr)
 	}
@@ -258,8 +248,54 @@ func settingsRepoStack(r registry.Repo) string {
 	return stack
 }
 
+func settingsMonorepoInfo(r registry.Repo, repoStack string) *v2MonorepoInfo {
+	selected := make(map[string]struct{}, len(r.Modules))
+	for _, mod := range r.Modules {
+		mod = filepath.ToSlash(strings.TrimSpace(mod))
+		if mod != "" {
+			selected[mod] = struct{}{}
+		}
+	}
+
+	candidates := make(map[string]struct{}, len(selected))
+	detector := "modules"
+	if mono, err := detect.DetectMonorepo(r.Path); err == nil && mono.Kind != detect.KindNone {
+		detector = string(mono.Kind)
+		for _, mod := range mono.Packages {
+			mod = filepath.ToSlash(strings.TrimSpace(mod))
+			if mod != "" {
+				candidates[mod] = struct{}{}
+			}
+		}
+	}
+	for mod := range selected {
+		candidates[mod] = struct{}{}
+	}
+	if len(candidates) == 0 {
+		return nil
+	}
+
+	paths := make([]string, 0, len(candidates))
+	for mod := range candidates {
+		paths = append(paths, mod)
+	}
+	sort.Strings(paths)
+
+	pkgs := make([]v2MonorepoPkg, 0, len(paths))
+	for _, mod := range paths {
+		stack := detect.Stack(filepath.Join(r.Path, filepath.FromSlash(mod)))
+		if stack == "" || stack == "unknown" {
+			stack = repoStack
+		}
+		_, indexed := selected[mod]
+		pkgs = append(pkgs, v2MonorepoPkg{Path: mod, Stack: stack, Indexed: indexed})
+	}
+	return &v2MonorepoInfo{Detector: detector, Packages: pkgs}
+}
+
 // repoStats reads graph-stats.json for a repo's state dir and returns
-// (files, entities, lastIndexed). Zero values on any read error.
+// (files, entities, lastIndexed). When the sidecar is absent or unusable, it
+// falls back to the persisted graph metadata so indexed repos remain visible.
 // repoGitMeta reads the Phase-0 git metadata and M4 coverage status from
 // graph.fb cheaply via fbreader (no entity/relationship decode). Returns zero
 // values for non-git repos or graphs written before these fields were added.
@@ -282,11 +318,22 @@ func repoStats(stateDir string) (files, entities int, lastIndexed time.Time) {
 	}
 	b, err := os.ReadFile(filepath.Join(stateDir, "graph-stats.json"))
 	if err != nil {
+		if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			return 0, ps.Entities, ps.ComputedAt
+		}
 		return
 	}
 	var s statsShape
 	if json.Unmarshal(b, &s) != nil {
+		if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			return 0, ps.Entities, ps.ComputedAt
+		}
 		return
+	}
+	if s.TotalEntities == 0 && s.ComputedAt.IsZero() {
+		if ps, ok := graph.PersistedStatsFromDir(stateDir); ok {
+			return 0, ps.Entities, ps.ComputedAt
+		}
 	}
 	return s.TotalFiles, s.TotalEntities, s.ComputedAt
 }

--- a/internal/dashboard/v2_group_settings_test.go
+++ b/internal/dashboard/v2_group_settings_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	"github.com/cajasmota/grafel/internal/quality"
 	"github.com/cajasmota/grafel/internal/registry"
 )
@@ -366,6 +368,34 @@ func TestV2GetGroup_RealFidelityViaServer(t *testing.T) {
 	}
 }
 
+func TestRepoStatsFallsBackToGraphFBWhenSidecarMissing(t *testing.T) {
+	stateDir := t.TempDir()
+	indexedAt := time.Now().Add(-3 * time.Minute).UTC().Truncate(time.Second)
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: indexedAt,
+		Stats:       graph.Stats{Entities: 2, Relationships: 1, Files: 7},
+		Entities: []graph.Entity{
+			{ID: "a", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "b", Name: "B", Kind: "function", SourceFile: "b.go", Language: "go"},
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	files, entities, gotIndexedAt := repoStats(stateDir)
+	if files != 0 {
+		t.Errorf("files = %d, want 0 without graph-stats sidecar", files)
+	}
+	if entities != 2 {
+		t.Errorf("entities = %d, want 2 from graph.fb", entities)
+	}
+	if !gotIndexedAt.Equal(indexedAt) {
+		t.Errorf("indexedAt = %v, want %v", gotIndexedAt, indexedAt)
+	}
+}
+
 func TestSettingsRepoStackFallsBackToDotnetDetector(t *testing.T) {
 	dir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(dir, "Platform.slnx"), []byte(""), 0o644); err != nil {
@@ -374,6 +404,37 @@ func TestSettingsRepoStackFallsBackToDotnetDetector(t *testing.T) {
 	repo := registry.Repo{Slug: "platform", Path: dir, Stack: registry.StackList{"unknown"}}
 	if got := settingsRepoStack(repo); got != "dotnet" {
 		t.Fatalf("settingsRepoStack = %q, want dotnet", got)
+	}
+}
+
+func TestSettingsMonorepoInfoKeepsUnselectedDetectedPackages(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - 'apps/*'\n"), 0o644); err != nil {
+		t.Fatalf("write workspace: %v", err)
+	}
+	for _, p := range []string{"apps/admin/package.json", "apps/platform/package.json"} {
+		if err := os.MkdirAll(filepath.Dir(filepath.Join(dir, p)), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, p), []byte(`{"name":"x"}`), 0o644); err != nil {
+			t.Fatalf("write %s: %v", p, err)
+		}
+	}
+
+	repo := registry.Repo{Slug: "assessment", Path: dir, Stack: registry.StackList{"node"}, Modules: []string{"apps/admin"}}
+	mono := settingsMonorepoInfo(repo, "node")
+	if mono == nil {
+		t.Fatal("settingsMonorepoInfo returned nil")
+	}
+	got := map[string]bool{}
+	for _, p := range mono.Packages {
+		got[p.Path] = p.Indexed
+	}
+	if !got["apps/admin"] {
+		t.Fatalf("apps/admin indexed = false, want true; packages=%+v", mono.Packages)
+	}
+	if indexed, ok := got["apps/platform"]; !ok || indexed {
+		t.Fatalf("apps/platform state = (%v, %v), want (false, true); packages=%+v", indexed, ok, mono.Packages)
 	}
 }
 


### PR DESCRIPTION
## What changed

- Re-detect monorepo packages when loading Group Settings and preserve both selected and unselected package state.
- Mark only configured modules as indexed while retaining the full discovered package list.
- Fall back to persisted `graph.fb` metadata when `graph-stats.json` is missing, invalid, or empty.

## Why

The settings response treated the selected module list as the complete monorepo inventory, so unselected packages disappeared from the UI. Repositories could also appear unindexed when the optional statistics sidecar was unavailable even though a valid graph existed.

## Validation

- `go test -p 1 ./internal/dashboard -run 'Test(RepoStatsFallsBackToGraphFBWhenSidecarMissing|SettingsMonorepoInfoKeepsUnselectedDetectedPackages)$' -count=1`
- `git diff --check`

## Closes / Refs

Closes #5945
