### PR TITLE
fix(dashboard): restore persisted group algorithm overlay

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/graph/flows"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -679,6 +680,22 @@ func (c *GraphCache) loadGroupForRef(groupName, ref string) (*DashGroup, error) 
 		grp.Repos[r.Slug] = dr
 	}
 
+	// Group-scope algorithms are computed by the daemon after indexing and
+	// persisted as an overlay. A dashboard cold wake should restore that
+	// authoritative cross-repo result instead of scheduling redundant
+	// per-repo Pass-4 sweeps.
+	//
+	// The overlay currently represents HEAD. Explicit refs retain the
+	// algorithm attributes carried by their own graph and never consume the
+	// HEAD overlay accidentally.
+	if ref == "" {
+		if sourceMtimes, mtimesErr := groupalgo.CurrentSourceMtimes(groupName); mtimesErr == nil {
+			if path, pathErr := groupalgo.OverlayPath(groupName); pathErr == nil {
+				restoreGroupAlgorithmOverlay(grp, path, sourceMtimes)
+			}
+		}
+	}
+
 	// Load cross-repo links file.  The file can be either a bare array of
 	// CrossRepoLink objects or the wrapper format {"version":N,"links":[...]}.
 	// Both forms are accepted; the wrapper form is written by the link pass.
@@ -695,6 +712,86 @@ func (c *GraphCache) loadGroupForRef(groupName, ref string) (*DashGroup, error) 
 	grp.Search = buildSearchIndex(grp)
 
 	return grp, nil
+}
+
+func restoreGroupAlgorithmOverlay(grp *DashGroup, path string, sourceMtimes map[string]int64) bool {
+	ov, ok := groupalgo.ReadOverlay(path, sourceMtimes)
+	if !ok {
+		return false
+	}
+	applyGroupAlgorithmOverlay(grp, ov)
+	grp.pendingAlgo = nil
+	return true
+}
+
+// applyGroupAlgorithmOverlay projects the persisted group-scope result back
+// into each dashboard repo while preserving group-global community IDs.
+func applyGroupAlgorithmOverlay(grp *DashGroup, ov *groupalgo.Overlay) {
+	if grp == nil || ov == nil {
+		return
+	}
+
+	communityByID := make(map[int]graph.CommunityResult, len(ov.Communities))
+	for _, community := range ov.Communities {
+		communityByID[community.ID] = community
+	}
+
+	for _, repo := range grp.Repos {
+		if repo == nil || repo.Doc == nil {
+			continue
+		}
+		repo.Doc.Communities = nil
+		members := map[int][]*graph.Entity{}
+		for i := range repo.Doc.Entities {
+			entity := &repo.Doc.Entities[i]
+			result, ok := ov.Results[entity.ID]
+			if !ok {
+				continue
+			}
+			cid, pageRank, centrality := result.CommunityID, result.PageRank, result.Centrality
+			entity.CommunityID = &cid
+			entity.PageRank = &pageRank
+			entity.Centrality = &centrality
+			entity.IsGodNode = result.IsGodNode
+			entity.IsArticulationPt = result.IsArticulationPoint
+			if cid >= 0 {
+				members[cid] = append(members[cid], entity)
+			}
+		}
+
+		communityIDs := make([]int, 0, len(members))
+		for cid := range members {
+			communityIDs = append(communityIDs, cid)
+		}
+		sort.Ints(communityIDs)
+		for _, cid := range communityIDs {
+			entities := members[cid]
+			sort.SliceStable(entities, func(i, j int) bool {
+				return entityPageRank(entities[i]) > entityPageRank(entities[j])
+			})
+			summary := communityByID[cid]
+			summary.ID = cid
+			summary.Size = len(entities)
+			topCount := 3
+			if len(entities) < topCount {
+				topCount = len(entities)
+			}
+			summary.TopEntities = make([]string, topCount)
+			for i := 0; i < topCount; i++ {
+				summary.TopEntities[i] = entities[i].ID
+			}
+			repo.Doc.Communities = append(repo.Doc.Communities, summary)
+		}
+		stats := ov.Stats
+		repo.Doc.AlgorithmStats = &stats
+	}
+}
+
+func entityPageRank(entity *graph.Entity) float64 {
+	if entity == nil || entity.PageRank == nil {
+		return 0
+	}
+	return *entity.PageRank
 }
 
 // normalizeLinkEndpoints rewrites the "<repo-slug>::<entity-id>" endpoints of

--- a/internal/dashboard/graphstate_group_overlay_test.go
+++ b/internal/dashboard/graphstate_group_overlay_test.go
@@ -1,0 +1,90 @@
+package dashboard
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
+
+func TestApplyGroupAlgorithmOverlay(t *testing.T) {
+	grp := &DashGroup{Repos: map[string]*DashRepo{
+		"api": {Doc: &graph.Document{Entities: []graph.Entity{
+			{ID: "api:a", Name: "A"},
+			{ID: "api:b", Name: "B"},
+		}}},
+		"web": {Doc: &graph.Document{Entities: []graph.Entity{
+			{ID: "web:c", Name: "C"},
+		}}},
+	}}
+	ov := &groupalgo.Overlay{
+		Results: map[string]groupalgo.EntityOverlay{
+			"api:a": {CommunityID: 7, PageRank: 0.8, Centrality: 0.4, IsGodNode: true},
+			"api:b": {CommunityID: 7, PageRank: 0.2},
+			"web:c": {CommunityID: 7, PageRank: 0.6, IsArticulationPoint: true},
+		},
+		Communities: []graph.CommunityResult{{ID: 7, Size: 3, AutoName: "shared-core"}},
+		Stats:       graph.AlgorithmStats{NumCommunities: 1, NumGodNodes: 1},
+	}
+
+	applyGroupAlgorithmOverlay(grp, ov)
+
+	a := grp.Repos["api"].Doc.Entities[0]
+	if a.CommunityID == nil || *a.CommunityID != 7 || a.PageRank == nil || *a.PageRank != 0.8 || !a.IsGodNode {
+		t.Fatalf("api:a overlay not restored: %+v", a)
+	}
+	c := grp.Repos["web"].Doc.Entities[0]
+	if c.Centrality == nil || !c.IsArticulationPt {
+		t.Fatalf("web:c overlay not restored: %+v", c)
+	}
+	if got := grp.Repos["api"].Doc.Communities; len(got) != 1 || got[0].Size != 2 || got[0].AutoName != "shared-core" {
+		t.Fatalf("api community projection wrong: %+v", got)
+	}
+	if got := grp.Repos["web"].Doc.Communities; len(got) != 1 || got[0].Size != 1 || got[0].TopEntities[0] != "web:c" {
+		t.Fatalf("web community projection wrong: %+v", got)
+	}
+	if got := grp.Repos["api"].Doc.AlgorithmStats; got == nil || got.NumCommunities != 1 {
+		t.Fatalf("algorithm stats not restored: %+v", got)
+	}
+}
+
+func TestRestorePersistedGroupAlgorithmOverlay(t *testing.T) {
+	mtimes := map[string]int64{"repo": 42}
+	ov := &groupalgo.Overlay{
+		Group:        "cold-overlay",
+		SourceMtimes: mtimes,
+		Results: map[string]groupalgo.EntityOverlay{
+			"service:a": {CommunityID: 4, PageRank: 0.91, Centrality: 0.72, IsGodNode: true},
+		},
+		Communities: []graph.CommunityResult{{ID: 4, Size: 1, AutoName: "service-core"}},
+		Stats:       graph.AlgorithmStats{NumCommunities: 1},
+	}
+	path := filepath.Join(t.TempDir(), "overlay.json")
+	if err := groupalgo.WriteOverlayTo(path, ov); err != nil {
+		t.Fatal(err)
+	}
+
+	grp := &DashGroup{
+		Repos: map[string]*DashRepo{
+			"repo": {Doc: &graph.Document{Entities: []graph.Entity{{ID: "service:a", Name: "ServiceA"}}}},
+		},
+		pendingAlgo: []pendingAlgoRepo{{}},
+	}
+	if !restoreGroupAlgorithmOverlay(grp, path, mtimes) {
+		t.Fatal("fresh persisted overlay was not restored")
+	}
+	entity := grp.Repos["repo"].Doc.Entities[0]
+	if entity.PageRank == nil || *entity.PageRank != 0.91 || entity.CommunityID == nil || *entity.CommunityID != 4 {
+		t.Fatalf("persisted overlay not restored: %+v", entity)
+	}
+	if got := grp.Repos["repo"].Doc.Communities; len(got) != 1 || got[0].AutoName != "service-core" {
+		t.Fatalf("persisted communities not restored: %+v", got)
+	}
+	if len(grp.pendingAlgo) != 0 {
+		t.Fatalf("authoritative group overlay left redundant pending sweeps: %+v", grp.pendingAlgo)
+	}
+	if restoreGroupAlgorithmOverlay(grp, path, map[string]int64{"repo": 43}) {
+		t.Fatal("stale persisted overlay was accepted")
+	}
+}


### PR DESCRIPTION
## What changed

- Restore the daemon's persisted group-algorithm overlay during a cold dashboard load for HEAD.
- Project global community IDs, PageRank, centrality, god-node, and articulation-point results into each dashboard repository.
- Rebuild per-repository community summaries while preserving group-global IDs.
- Leave explicit historical refs untouched and skip stale overlays through source-mtime validation.

## Why

After a dashboard restart, the authoritative group-scoped overlay was not restored. The dashboard therefore lost cross-repository algorithm attributes and could schedule redundant per-repository algorithm work.

## Validation

- `go test -p 1 ./internal/dashboard -run 'Test(ApplyGroupAlgorithmOverlay|RestorePersistedGroupAlgorithmOverlay)$' -count=1`
- `git diff --check`

## Closes / Refs

Closes #5946
