### PR TITLE
perf(dashboard): persist payload cache across restarts

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -236,8 +236,18 @@ v1 tier-1 payload deliberately omits `pagerank` + `source_file` to keep its wire
 shape tight, but the cosmos.gl renderer needs both (node sizing + the "module"
 group-by). A clean v2 endpoint keeps the two UIs independent. Like v1, it shares
 the server-side payload cache + strong ETag/304 + mux-level gzip (cache keys are
-namespaced with a `v2:` prefix). Entity detail for the inspector still uses the
-v1 `GET /api/graph/{group}/entity/{id}` (unchanged, raw JSON).
+namespaced with a `v2:` prefix). Pre-serialised payloads are also persisted as
+immutable, checksummed artifacts under
+`~/.grafel/cache/dashboard/v1/<group-hash>/<source-hash>/`. The source hash
+covers the group config, each repo's active graph generation (single-file or
+segment-set), description and flow sidecars, the group algorithm overlay and
+the cross-repo links file. A matching artifact can therefore be served after a
+daemon restart without first materialising the graph; any watched source
+change naturally selects a new source hash. Corrupt or unknown cache files are
+treated as misses and rebuilt asynchronously after the live response is
+generated. Retention is bounded to eight source versions per group and 64
+parameter variants per source version. Entity detail for the inspector still
+uses the v1 `GET /api/graph/{group}/entity/{id}` (unchanged, raw JSON).
 
 ---
 

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -46,25 +46,38 @@ import (
 // (filterKind, filterRepo, repos, includeExternal, includeModules).
 //
 // Invalidation: any call to graphPayloadCache.InvalidateGroup(group) drops
-// ALL entries whose key starts with "<group>::".  This is called from
-// GraphCache.Invalidate / InvalidateAll so the two caches are always in sync.
+// the v1 and v2 in-memory entries for that group. Disk artifacts are immutable
+// and source-versioned, so changed inputs select a different path instead of
+// requiring eager deletion during watcher or memory-pressure events.
 
 // payloadEntry is one cached response.
 type payloadEntry struct {
-	body []byte // raw JSON bytes (not compressed — withGzip compresses on write)
-	etag string // strong ETag value, including the surrounding quotes
+	body          []byte // raw JSON bytes (not compressed — withGzip compresses on write)
+	etag          string // strong ETag value, including the surrounding quotes
+	sourceVersion string // empty for legacy in-memory-only entries
 }
 
 // graphPayloadCache is a concurrency-safe store of pre-serialised graph
-// payloads.  It is intentionally separate from GraphCache so the two caches
-// can be invalidated together without circular dependencies.
+// payloads backed by an optional immutable disk cache.
 type graphPayloadCache struct {
 	mu      sync.RWMutex
 	entries map[string]*payloadEntry // cache key → entry
+	disk    *diskPayloadCache
 }
 
 func newGraphPayloadCache() *graphPayloadCache {
-	return &graphPayloadCache{entries: map[string]*payloadEntry{}}
+	home, err := registry.HomeDir()
+	if err != nil {
+		return &graphPayloadCache{entries: map[string]*payloadEntry{}}
+	}
+	return newGraphPayloadCacheAt(filepath.Join(home, "cache", "dashboard", "v1"))
+}
+
+func newGraphPayloadCacheAt(root string) *graphPayloadCache {
+	return &graphPayloadCache{
+		entries: map[string]*payloadEntry{},
+		disk:    newDiskPayloadCache(root),
+	}
 }
 
 // payloadCacheKey returns a stable, collision-resistant key for the given
@@ -87,33 +100,58 @@ func payloadCacheKey(group, filterKind, filterRepo, reposParam string, includeEx
 
 // Get returns the cached entry and true when a valid entry exists,
 // or nil and false on a miss.
-func (c *graphPayloadCache) Get(key string) (*payloadEntry, bool) {
+func (c *graphPayloadCache) Get(key string, sourceVersion ...string) (*payloadEntry, bool) {
 	c.mu.RLock()
 	e, ok := c.entries[key]
 	c.mu.RUnlock()
-	return e, ok
+	if ok && (len(sourceVersion) == 0 || sourceVersion[0] == "" || e.sourceVersion == sourceVersion[0]) {
+		return e, true
+	}
+	if c.disk == nil || len(sourceVersion) == 0 || sourceVersion[0] == "" {
+		return nil, false
+	}
+	e, ok = c.disk.Get(key, sourceVersion[0])
+	if !ok {
+		return nil, false
+	}
+	c.mu.Lock()
+	c.entries[key] = e
+	c.mu.Unlock()
+	return e, true
 }
 
 // Set stores (or replaces) a payload entry.
-func (c *graphPayloadCache) Set(key string, body []byte, etag string) {
+func (c *graphPayloadCache) Set(key string, body []byte, etag string, sourceVersion ...string) {
+	version := ""
+	if len(sourceVersion) > 0 {
+		version = sourceVersion[0]
+	}
+	e := &payloadEntry{body: body, etag: etag, sourceVersion: version}
 	c.mu.Lock()
-	c.entries[key] = &payloadEntry{body: body, etag: etag}
+	c.entries[key] = e
 	c.mu.Unlock()
+	if c.disk != nil && len(sourceVersion) > 0 && sourceVersion[0] != "" {
+		c.disk.SetAsync(key, sourceVersion[0], e)
+	}
 }
 
-// InvalidateGroup drops all entries whose key begins with "<group>::".
+// InvalidateGroup drops all v1 and v2 in-memory entries for group. Valid disk
+// entries remain reusable after RAM eviction; source changes cannot hit them.
 func (c *graphPayloadCache) InvalidateGroup(group string) {
-	prefix := group + "::"
+	prefixes := []string{group + "::", "v2:" + group + "::"}
 	c.mu.Lock()
 	for k := range c.entries {
-		if strings.HasPrefix(k, prefix) {
-			delete(c.entries, k)
+		for _, prefix := range prefixes {
+			if strings.HasPrefix(k, prefix) {
+				delete(c.entries, k)
+				break
+			}
 		}
 	}
 	c.mu.Unlock()
 }
 
-// InvalidateAll drops every entry.
+// InvalidateAll drops every in-memory entry. Versioned disk artifacts remain.
 func (c *graphPayloadCache) InvalidateAll() {
 	c.mu.Lock()
 	c.entries = map[string]*payloadEntry{}
@@ -183,6 +221,10 @@ type DashGroup struct {
 	// fresh sidecar), so the full sweep is computed OFF the request after this
 	// group is published (schedulePendingAlgo, #50). Read-only after load.
 	pendingAlgo []pendingAlgoRepo
+
+	// sourceVersion fingerprints every disk artifact used to materialise this
+	// group. Payload snapshots are restored only when this value matches.
+	sourceVersion string
 }
 
 // diskUnchanged reports whether the graph.fb (or graph.json fallback) for every
@@ -382,6 +424,17 @@ func (c *GraphCache) GetGroupCached(groupName string) (*DashGroup, bool) {
 
 // GetGroupCachedForRef is the ref-scoped variant of GetGroupCached (PH1c).
 func (c *GraphCache) GetGroupCachedForRef(groupName, ref string) (*DashGroup, bool) {
+	grp, ok := c.peekGroupCachedForRef(groupName, ref)
+	if !ok {
+		go func() { _, _ = c.GetGroupForRef(groupName, ref) }()
+	}
+	return grp, ok
+}
+
+// peekGroupCachedForRef returns a fresh warm entry without starting a disk
+// load on a miss. The graph handlers use it before probing the durable payload
+// cache so a valid snapshot remains a true graph-materialisation bypass.
+func (c *GraphCache) peekGroupCachedForRef(groupName, ref string) (*DashGroup, bool) {
 	cacheKey := groupName
 	if ref != "" {
 		cacheKey = groupName + "@" + ref
@@ -396,9 +449,6 @@ func (c *GraphCache) GetGroupCachedForRef(groupName, ref string) (*DashGroup, bo
 	if ok && ent.group.diskUnchanged() {
 		return ent.group, true
 	}
-	// Not warm (or the file changed): trigger an async warm so the next caller
-	// is fast, but return immediately so we never block first paint.
-	go func() { _, _ = c.GetGroupForRef(groupName, ref) }()
 	return nil, false
 }
 
@@ -705,6 +755,9 @@ func (c *GraphCache) loadGroupForRef(groupName, ref string) (*DashGroup, error) 
 			grp.Links = normalizeLinkEndpoints(links, grp.Repos)
 		}
 	}
+	if version, versionErr := dashboardSourceVersion(groupName, ref); versionErr == nil {
+		grp.sourceVersion = version
+	}
 
 	// Build the in-memory search index once at load time so that
 	// /api/search/{group} does not need to scan all entities on every request
@@ -792,6 +845,76 @@ func entityPageRank(entity *graph.Entity) float64 {
 		return 0
 	}
 	return *entity.PageRank
+}
+
+// dashboardSourceVersion fingerprints the files that define a dashboard group
+// without loading graph.fb. Handlers use it to validate disk payloads before
+// materialising the graph, making a valid snapshot a true cold-start fast path.
+func dashboardSourceVersion(groupName, ref string) (string, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return "", err
+	}
+	var cfgPath string
+	for _, group := range groups {
+		if group.Name == groupName {
+			cfgPath = group.ConfigPath
+			break
+		}
+	}
+	if cfgPath == "" {
+		return "", fmt.Errorf("group %q not registered", groupName)
+	}
+	cfg, err := registry.LoadGroupConfig(cfgPath)
+	if err != nil {
+		return "", err
+	}
+	repos := append([]registry.Repo(nil), cfg.Repos...)
+	sort.Slice(repos, func(i, j int) bool { return repos[i].Slug < repos[j].Slug })
+
+	h := sha256.New()
+	_, _ = fmt.Fprintf(h, "dashboard-payload-v2\x00%s\x00%s\x00", groupName, ref)
+	hashDashboardArtifact(h, "config", cfgPath)
+	for _, repo := range repos {
+		stateDir := daemon.StateDirForRepo(repo.Path)
+		if ref != "" {
+			stateDir = daemon.StateDirForRepoRef(repo.Path, ref)
+		}
+		_, _ = fmt.Fprintf(h, "repo\x00%s\x00%s\x00", repo.Slug, stateDir)
+		hashDashboardRepoArtifacts(h, stateDir)
+	}
+	if ref == "" {
+		if overlayPath, pathErr := groupalgo.OverlayPath(groupName); pathErr == nil {
+			hashDashboardArtifact(h, "overlay", overlayPath)
+		}
+	}
+	hashDashboardArtifact(h, "links", defaultLinksFile(groupName))
+	return fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func hashDashboardRepoArtifacts(h interface{ Write([]byte) (int, error) }, stateDir string) {
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	switch {
+	case err != nil:
+		_, _ = fmt.Fprintf(h, "graph\x00%s\x00invalid\x00", stateDir)
+	case desc.Kind == graph.GraphSingleFile:
+		hashDashboardArtifact(h, "graph", desc.Path)
+	case desc.Kind == graph.GraphSegmentSet:
+		hashDashboardArtifact(h, "graph-manifest", filepath.Join(desc.GenDir, graph.ManifestFileName))
+	default:
+		hashDashboardArtifact(h, "graph-json", filepath.Join(stateDir, "graph.json"))
+	}
+	hashDashboardArtifact(h, "descriptions", descriptions.Path(stateDir))
+	hashDashboardArtifact(h, "flows", flows.Path(stateDir))
+}
+
+func hashDashboardArtifact(h interface{ Write([]byte) (int, error) }, kind, path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		_, _ = fmt.Fprintf(h, "%s\x00%s\x00missing\x00", kind, path)
+		return
+	}
+	_, _ = fmt.Fprintf(h, "%s\x00%s\x00%d\x00%d\x00", kind, path, info.Size(), info.ModTime().UnixNano())
 }
 
 // normalizeLinkEndpoints rewrites the "<repo-slug>::<entity-id>" endpoints of

--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -153,10 +153,27 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 	includeModules := r.URL.Query().Get("view") == "modules" ||
 		r.URL.Query().Get("include") == "modules"
 
-	grp, err := s.graphs.GetGroup(group)
-	if err != nil {
-		writeErr(w, http.StatusNotFound, err.Error())
-		return
+	cacheKey := payloadCacheKey(group, filterKind, filterRepo, reposParam, includeExternal, includeModules)
+	grp, warm := s.graphs.peekGroupCachedForRef(group, "")
+	if warm {
+		if entry, hit := s.graphs.Payloads.Get(cacheKey, grp.sourceVersion); hit {
+			writeGraphPayloadCacheEntry(w, r, entry)
+			return
+		}
+	} else if sourceVersion, versionErr := dashboardSourceVersion(group, ""); versionErr == nil {
+		if entry, hit := s.graphs.Payloads.Get(cacheKey, sourceVersion); hit {
+			writeGraphPayloadCacheEntry(w, r, entry)
+			return
+		}
+	}
+
+	if !warm {
+		var err error
+		grp, err = s.graphs.GetGroup(group)
+		if err != nil {
+			writeErr(w, http.StatusNotFound, err.Error())
+			return
+		}
 	}
 
 	// ── Payload cache + ETag/304 ─────────────────────────────────────────────
@@ -168,9 +185,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 	// The cache key covers all query params that change the output.  The cache
 	// entry is invalidated by GraphCache.Invalidate(group) which is called on
 	// every re-index event and enrichment write-back.
-	cacheKey := payloadCacheKey(group, filterKind, filterRepo, reposParam, includeExternal, includeModules)
-
-	if entry, hit := s.graphs.Payloads.Get(cacheKey); hit {
+	if entry, hit := s.graphs.Payloads.Get(cacheKey, grp.sourceVersion); hit {
 		// Strong ETag — allows the browser to short-circuit the full
 		// response body on repeat visits.
 		w.Header().Set("ETag", entry.etag)
@@ -214,6 +229,18 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 	}
 
 	s.serveGraphDense(w, r, grp, repos, filterKind, includeExternal, includeModules, cacheKey)
+}
+
+func writeGraphPayloadCacheEntry(w http.ResponseWriter, r *http.Request, entry *payloadEntry) {
+	w.Header().Set("ETag", entry.etag)
+	w.Header().Set("Vary", "Accept-Encoding")
+	if r.Header.Get("If-None-Match") == entry.etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(entry.body)
 }
 
 // externalKindSuffix is the trailing portion of the SCOPE.External kind after
@@ -445,7 +472,7 @@ func (s *Server) serveGraphDense(w http.ResponseWriter, r *http.Request, grp *Da
 	etag := fmt.Sprintf(`"%x"`, sum[:8])
 
 	// Store in the payload cache for future requests.
-	s.graphs.Payloads.Set(cacheKey, body, etag)
+	s.graphs.Payloads.Set(cacheKey, body, etag, grp.sourceVersion)
 
 	// Set ETag and Vary so proxies and browsers can cache correctly.
 	w.Header().Set("ETag", etag)

--- a/internal/dashboard/payload_disk_cache.go
+++ b/internal/dashboard/payload_disk_cache.go
@@ -1,0 +1,205 @@
+package dashboard
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+const (
+	diskPayloadMagic             = "GFPAY01\n"
+	diskPayloadMaxBody           = 1 << 30
+	diskPayloadHeader            = len(diskPayloadMagic) + 4 + 4 + 8 + sha256.Size
+	diskPayloadVersionsPerGroup  = 8
+	diskPayloadVariantsPerSource = 64
+)
+
+// diskPayloadCache stores immutable pre-serialised HTTP responses. The source
+// version is part of the path and the file header, so memory-pressure eviction
+// never destroys a reusable snapshot and a changed graph can never hit an old
+// response. Corrupt or unknown files are treated as ordinary cache misses.
+type diskPayloadCache struct {
+	root    string
+	writes  sync.Map // artifact path -> struct{}; coalesces concurrent persistence
+	pruneMu sync.Mutex
+}
+
+func (c *diskPayloadCache) SetAsync(key, sourceVersion string, entry *payloadEntry) {
+	path, ok := c.path(key, sourceVersion)
+	if !ok {
+		return
+	}
+	if _, loaded := c.writes.LoadOrStore(path, struct{}{}); loaded {
+		return
+	}
+	go func() {
+		defer c.writes.Delete(path)
+		_ = c.Set(key, sourceVersion, entry)
+	}()
+}
+
+func newDiskPayloadCache(root string) *diskPayloadCache {
+	if root == "" {
+		return nil
+	}
+	return &diskPayloadCache{root: root}
+}
+
+func (c *diskPayloadCache) Get(key, sourceVersion string) (*payloadEntry, bool) {
+	path, ok := c.path(key, sourceVersion)
+	if !ok {
+		return nil, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) < diskPayloadHeader {
+		return nil, false
+	}
+	if string(data[:len(diskPayloadMagic)]) != diskPayloadMagic {
+		return nil, false
+	}
+	off := len(diskPayloadMagic)
+	keyLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
+	off += 4
+	etagLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
+	off += 4
+	bodyLen := binary.LittleEndian.Uint64(data[off : off+8])
+	off += 8
+	checksum := data[off : off+sha256.Size]
+	off += sha256.Size
+	if keyLen < 1 || keyLen > 1<<20 || etagLen < 1 || etagLen > 1<<20 || bodyLen > diskPayloadMaxBody {
+		return nil, false
+	}
+	wantLen := uint64(off) + uint64(keyLen) + uint64(etagLen) + bodyLen
+	if uint64(len(data)) != wantLen {
+		return nil, false
+	}
+	storedKey := string(data[off : off+keyLen])
+	off += keyLen
+	etag := string(data[off : off+etagLen])
+	off += etagLen
+	body := data[off:]
+	if storedKey != key {
+		return nil, false
+	}
+	sum := sha256.Sum256(body)
+	if !bytes.Equal(checksum, sum[:]) {
+		return nil, false
+	}
+	return &payloadEntry{body: body, etag: etag, sourceVersion: sourceVersion}, true
+}
+
+func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) error {
+	if entry == nil || len(entry.body) > diskPayloadMaxBody || len(key) > 1<<20 || len(entry.etag) > 1<<20 {
+		return nil
+	}
+	path, ok := c.path(key, sourceVersion)
+	if !ok {
+		return nil
+	}
+	if _, err := os.Stat(path); err == nil {
+		return nil // immutable artifact already exists
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("dashboard payload cache mkdir: %w", err)
+	}
+
+	sum := sha256.Sum256(entry.body)
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".payload-*.tmp")
+	if err != nil {
+		return fmt.Errorf("dashboard payload cache temp: %w", err)
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+	header := make([]byte, 0, diskPayloadHeader)
+	header = append(header, diskPayloadMagic...)
+	header = binary.LittleEndian.AppendUint32(header, uint32(len(key)))
+	header = binary.LittleEndian.AppendUint32(header, uint32(len(entry.etag)))
+	header = binary.LittleEndian.AppendUint64(header, uint64(len(entry.body)))
+	header = append(header, sum[:]...)
+	for _, chunk := range [][]byte{header, []byte(key), []byte(entry.etag), entry.body} {
+		if _, err = tmp.Write(chunk); err != nil {
+			_ = tmp.Close()
+			return fmt.Errorf("dashboard payload cache write: %w", err)
+		}
+	}
+	if err = tmp.Sync(); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("dashboard payload cache sync: %w", err)
+	}
+	if err = tmp.Close(); err != nil {
+		return fmt.Errorf("dashboard payload cache close: %w", err)
+	}
+	if err = os.Rename(tmpPath, path); err != nil {
+		if _, statErr := os.Stat(path); statErr == nil {
+			return nil // another request won the immutable write race
+		}
+		return fmt.Errorf("dashboard payload cache rename: %w", err)
+	}
+	c.prune(path)
+	return nil
+}
+
+func (c *diskPayloadCache) prune(currentPath string) {
+	c.pruneMu.Lock()
+	defer c.pruneMu.Unlock()
+
+	sourceDir := filepath.Dir(currentPath)
+	pruneOldCacheEntries(sourceDir, diskPayloadVariantsPerSource, currentPath, false)
+	groupDir := filepath.Dir(sourceDir)
+	pruneOldCacheEntries(groupDir, diskPayloadVersionsPerGroup, sourceDir, true)
+}
+
+type cachePathInfo struct {
+	path    string
+	modTime int64
+}
+
+func pruneOldCacheEntries(dir string, keep int, preserve string, directories bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	paths := make([]cachePathInfo, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() != directories {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		if path == preserve {
+			continue
+		}
+		info, infoErr := entry.Info()
+		if infoErr != nil {
+			continue
+		}
+		paths = append(paths, cachePathInfo{path: path, modTime: info.ModTime().UnixNano()})
+	}
+	// preserve is an additional retained entry when it exists.
+	removeCount := len(paths) + 1 - keep
+	if removeCount <= 0 {
+		return
+	}
+	sort.Slice(paths, func(i, j int) bool { return paths[i].modTime < paths[j].modTime })
+	for i := 0; i < removeCount && i < len(paths); i++ {
+		_ = os.RemoveAll(paths[i].path)
+	}
+}
+
+func (c *diskPayloadCache) path(key, sourceVersion string) (string, bool) {
+	group, _, ok := strings.Cut(key, "::")
+	if !ok || group == "" || sourceVersion == "" {
+		return "", false
+	}
+	return filepath.Join(c.root, shortPayloadHash(group), shortPayloadHash(sourceVersion), shortPayloadHash(key)+".gpc"), true
+}
+
+func shortPayloadHash(value string) string {
+	sum := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%x", sum[:16])
+}

--- a/internal/dashboard/payload_disk_cache_test.go
+++ b/internal/dashboard/payload_disk_cache_test.go
@@ -1,0 +1,261 @@
+package dashboard
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph/descriptions"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+func TestDashboardRepoArtifactsTrackSegmentGenerationAndSidecars(t *testing.T) {
+	stateDir := t.TempDir()
+	digest := func() string {
+		h := sha256.New()
+		hashDashboardRepoArtifacts(h, stateDir)
+		return string(h.Sum(nil))
+	}
+
+	writeDashboardSegmentSetFixture(t, stateDir, 5, time.Now().Add(-time.Hour))
+	gen5 := digest()
+	writeDashboardSegmentSetFixture(t, stateDir, 6, time.Now().Add(-time.Hour))
+	gen6 := digest()
+	if gen6 == gen5 {
+		t.Fatal("segment generation change did not invalidate the payload source version")
+	}
+
+	if err := os.WriteFile(descriptions.Path(stateDir), []byte(`{"version":1}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	withDescriptions := digest()
+	if withDescriptions == gen6 {
+		t.Fatal("description sidecar change did not invalidate the payload source version")
+	}
+
+	if err := os.WriteFile(flows.Path(stateDir), []byte(`{"version":1,"flows":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if withFlows := digest(); withFlows == withDescriptions {
+		t.Fatal("flow sidecar change did not invalidate the payload source version")
+	}
+}
+
+func BenchmarkDiskPayloadCacheGet8MiB(b *testing.B) {
+	cache := newDiskPayloadCache(b.TempDir())
+	const (
+		key     = "v2:assessment::default"
+		version = "graph-v1"
+	)
+	body := bytes.Repeat([]byte("grafel-cache"), (8<<20)/len("grafel-cache"))
+	entry := &payloadEntry{body: body, etag: `"etag-1"`, sourceVersion: version}
+	if err := cache.Set(key, version, entry); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(body)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got, ok := cache.Get(key, version)
+		if !ok || len(got.body) != len(body) {
+			b.Fatal("disk payload cache miss")
+		}
+	}
+}
+
+func TestGraphPayloadCacheRestoresDiskSnapshot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "dashboard-cache")
+	first := newGraphPayloadCacheAt(root)
+	key := "v2:assessment::default"
+	version := "graph-v1"
+	entry := &payloadEntry{body: []byte(`{"ok":true}`), etag: `"etag-1"`, sourceVersion: version}
+	if err := first.disk.Set(key, version, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	second := newGraphPayloadCacheAt(root)
+	entry, ok := second.Get(key, version)
+	if !ok {
+		t.Fatal("expected disk-backed payload hit after in-memory cache restart")
+	}
+	if got := string(entry.body); got != `{"ok":true}` {
+		t.Fatalf("body = %q", got)
+	}
+	if entry.etag != `"etag-1"` || entry.sourceVersion != version {
+		t.Fatalf("metadata not restored: %+v", entry)
+	}
+}
+
+func TestGraphPayloadCacheRejectsStaleSourceVersion(t *testing.T) {
+	cache := newGraphPayloadCacheAt(t.TempDir())
+	t.Cleanup(func() { waitForDiskPayloadWrites(t, cache.disk) })
+	key := "assessment::default"
+	cache.Set(key, []byte(`{"version":1}`), `"etag-1"`, "graph-v1")
+
+	if _, ok := cache.Get(key, "graph-v2"); ok {
+		t.Fatal("stale in-memory or disk payload was served for a changed graph")
+	}
+}
+
+func waitForDiskPayloadWrites(t *testing.T, cache *diskPayloadCache) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		pending := false
+		cache.writes.Range(func(_, _ any) bool {
+			pending = true
+			return false
+		})
+		if !pending {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Error("timed out waiting for asynchronous payload-cache write")
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestGraphPayloadCacheInvalidatesV1AndV2MemoryEntries(t *testing.T) {
+	cache := newGraphPayloadCacheAt(t.TempDir())
+	cache.Set("assessment::default", []byte("v1"), `"v1"`)
+	cache.Set("v2:assessment::default", []byte("v2"), `"v2"`)
+	cache.Set("v2:other::default", []byte("other"), `"other"`)
+
+	cache.InvalidateGroup("assessment")
+	if _, ok := cache.Get("assessment::default"); ok {
+		t.Fatal("v1 entry survived group invalidation")
+	}
+	if _, ok := cache.Get("v2:assessment::default"); ok {
+		t.Fatal("v2 entry survived group invalidation")
+	}
+	if _, ok := cache.Get("v2:other::default"); !ok {
+		t.Fatal("unrelated group was invalidated")
+	}
+}
+
+func TestGraphPayloadCacheTreatsCorruptionAsMiss(t *testing.T) {
+	root := t.TempDir()
+	cache := newGraphPayloadCacheAt(root)
+	key := "assessment::default"
+	version := "graph-v1"
+	entry := &payloadEntry{body: []byte(`{"ok":true}`), etag: `"etag-1"`, sourceVersion: version}
+	if err := cache.disk.Set(key, version, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	path, ok := cache.disk.path(key, version)
+	if !ok {
+		t.Fatal("expected cache path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	data[len(data)-1] ^= 0xff
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := newGraphPayloadCacheAt(root)
+	if _, ok := restarted.Get(key, version); ok {
+		t.Fatal("corrupt disk payload must degrade to a cache miss")
+	}
+}
+
+func TestDiskPayloadCachePrunesOldSourceVersions(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	key := "assessment::default"
+	entry := &payloadEntry{body: []byte(`{"ok":true}`), etag: `"etag"`}
+	for i := 0; i < diskPayloadVersionsPerGroup+2; i++ {
+		version := "graph-v" + string(rune('a'+i))
+		if err := cache.Set(key, version, entry); err != nil {
+			t.Fatal(err)
+		}
+	}
+	groupDir := filepath.Join(cache.root, shortPayloadHash("assessment"))
+	dirs, err := os.ReadDir(groupDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != diskPayloadVersionsPerGroup {
+		t.Fatalf("retained source versions = %d, want %d", len(dirs), diskPayloadVersionsPerGroup)
+	}
+}
+
+func TestV2GraphRestoresDiskPayloadBeforeLoadingGraph(t *testing.T) {
+	// On Windows the process temp directory can live under the real user home,
+	// which the registry write guard correctly rejects even after HOME is
+	// redirected. Point t.TempDir at this worktree before isolating the test.
+	workDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", workDir)
+	t.Setenv("TEMP", workDir)
+	t.Setenv("TMP", workDir)
+	root := testsupport.IsolateHome(t)
+	repoPath := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.StateDirForRepoRef(repoPath, "")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Deliberately invalid graph bytes: the request can only succeed if the
+	// persisted HTTP payload is served before graph materialisation.
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.fb"), []byte("not-a-graph"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	const group = "cold-disk-payload"
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.SaveGroupConfig(cfgPath, &registry.GroupConfig{
+		Name:  group,
+		Repos: []registry.Repo{{Slug: "repo", Path: repoPath}},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatal(err)
+	}
+	version, err := dashboardSourceVersion(group, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	key := "v2:" + payloadCacheKey(group, "", "", "", false, false, "") + ":lod="
+	body := []byte(`{"ok":true,"data":{"nodes":[]}}` + "\n")
+	first := NewGraphCache(0)
+	entry := &payloadEntry{body: body, etag: `"cold-etag"`, sourceVersion: version}
+	if err := first.Payloads.disk.Set(key, version, entry); err != nil {
+		t.Fatal(err)
+	}
+
+	restarted := NewGraphCache(0)
+	server := &Server{graphs: restarted}
+	req := httptest.NewRequest(http.MethodGet, "/api/v2/graph/"+group, nil)
+	req.SetPathValue("group", group)
+	rec := httptest.NewRecorder()
+	server.handleV2Graph(rec, req)
+
+	if rec.Code != http.StatusOK || rec.Body.String() != string(body) {
+		t.Fatalf("cold disk response = status %d body %q", rec.Code, rec.Body.String())
+	}
+	if len(restarted.entries) != 0 {
+		t.Fatal("graph was materialised even though a valid disk payload existed")
+	}
+}

--- a/internal/dashboard/v2_graph.go
+++ b/internal/dashboard/v2_graph.go
@@ -111,18 +111,36 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 	// PH1c: optional ref parameter.
 	refParam := r.URL.Query().Get("ref")
 
-	grp, err := s.graphs.GetGroupForRef(group, refParam)
-	if err != nil {
-		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
-		return
+	// A valid disk payload can be served before graph.fb is materialised. The
+	// cheap source fingerprint is based only on artifact paths, sizes and mtimes.
+	cacheKey := "v2:" + payloadCacheKey(group, filterKind, "", reposParam, includeExternal, includeModules, refParam) + ":lod=" + lodParam
+	grp, warm := s.graphs.peekGroupCachedForRef(group, refParam)
+	if warm {
+		if entry, hit := s.graphs.Payloads.Get(cacheKey, grp.sourceVersion); hit {
+			writeGraphPayloadCacheEntry(w, r, entry)
+			return
+		}
+	} else if sourceVersion, versionErr := dashboardSourceVersion(group, refParam); versionErr == nil {
+		if entry, hit := s.graphs.Payloads.Get(cacheKey, sourceVersion); hit {
+			writeGraphPayloadCacheEntry(w, r, entry)
+			return
+		}
+	}
+
+	if !warm {
+		var err error
+		grp, err = s.graphs.GetGroupForRef(group, refParam)
+		if err != nil {
+			writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+			return
+		}
 	}
 
 	// Payload cache + strong ETag/304. A "v2:" prefix keeps the v2 payload
 	// cache entries distinct from v1's for the same (group, params) tuple.
 	// The lod suffix is appended so each LoD level has its own cache entry.
 	// PH1c: refParam is included via the variadic payloadCacheKey overload.
-	cacheKey := "v2:" + payloadCacheKey(group, filterKind, "", reposParam, includeExternal, includeModules, refParam) + ":lod=" + lodParam
-	if entry, hit := s.graphs.Payloads.Get(cacheKey); hit {
+	if entry, hit := s.graphs.Payloads.Get(cacheKey, grp.sourceVersion); hit {
 		w.Header().Set("ETag", entry.etag)
 		w.Header().Set("Vary", "Accept-Encoding")
 		if r.Header.Get("If-None-Match") == entry.etag {
@@ -166,7 +184,7 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 	body := buf.Bytes()
 	sum := sha256.Sum256(body)
 	etag := fmt.Sprintf(`"%x"`, sum[:8])
-	s.graphs.Payloads.Set(cacheKey, body, etag)
+	s.graphs.Payloads.Set(cacheKey, body, etag, grp.sourceVersion)
 
 	w.Header().Set("ETag", etag)
 	w.Header().Set("Vary", "Accept-Encoding")


### PR DESCRIPTION
## What changed

- Add a versioned, checksummed disk cache for serialized dashboard graph payloads.
- Fingerprint graph segments and relevant sidecars so stale payloads are not served.
- Restore valid payloads across dashboard restarts before materializing `graph.fb`.
- Treat corrupt entries as misses and bound retained variants/source versions.
- Document the disk-backed cache behavior in the v2 API notes.

## Why

The existing payload cache was memory-only. A dashboard restart discarded fully serialized responses and forced graph loading and serialization again even when the source artifacts had not changed.

## Validation

- `go test -p 1 ./internal/dashboard -run 'Test(DashboardRepoArtifactsTrackSegmentGenerationAndSidecars|GraphPayloadCacheRestoresDiskSnapshot|GraphPayloadCacheRejectsStaleSourceVersion|GraphPayloadCacheInvalidatesV1AndV2MemoryEntries|GraphPayloadCacheTreatsCorruptionAsMiss|DiskPayloadCachePrunesOldSourceVersions|V2GraphRestoresDiskPayloadBeforeLoadingGraph)$' -count=1`
- `git diff --check`

## Closes / Refs

Closes #5947
