### PR TITLE
fix(wizard): honor group terminal progress events

### DIFF
--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -54,7 +54,12 @@ import {
 } from "@/hooks/use-wizard";
 import { useIndexProgress } from "@/hooks/use-index-progress";
 import { useIndexStatus } from "@/hooks/use-index-status";
-import { aggregateProgress, nestRows, overallPhaseLabel } from "@/lib/index-progress-fold";
+import {
+  aggregateProgress,
+  nestRows,
+  overallPhaseLabel,
+  streamTerminal,
+} from "@/lib/index-progress-fold";
 import {
   engineStats,
   groupEnhancing,
@@ -388,7 +393,11 @@ export function ScanWizard(props: ScanWizardProps) {
   // #5327 broker fix), so we also treat "every repo row done/error" as terminal.
   // Either source flipping is enough to reach "Done".
   const jobTerminal = jobStatus === "done" || jobStatus === "failed";
-  const feedTerminal = indexProgress.terminal;
+  const feedTerminal = streamTerminal(
+    indexProgress.rows,
+    expectedRepos,
+    indexProgress.groupPhase,
+  );
   const feedFailed = indexProgress.rows.some((r) => r.phase === "error");
   const terminal = jobTerminal || feedTerminal;
   // Effective display status drives the icon, label and bar. The job poller is

--- a/webui-v2/src/lib/index-progress-fold.test.ts
+++ b/webui-v2/src/lib/index-progress-fold.test.ts
@@ -13,6 +13,7 @@ import {
   seedRows,
   sortRows,
   statusRank,
+  streamTerminal,
 } from "./index-progress-fold";
 import type { ProgressEvent, ProgressRow, RepoNesting } from "@/data/types";
 
@@ -190,6 +191,30 @@ describe("rowsTerminal — expected-repo-count gate (#5326 multi-repo regression
       ev({ repo_slug: "shared", phase: "done", ts: 5 }),
     ]);
     expect(rowsTerminal(rows, 2)).toBe(true);
+  });
+});
+
+describe("streamTerminal — group-scoped terminal fallback", () => {
+  it("treats group done as terminal even when a repo row is stuck mid-phase", () => {
+    expect(
+      streamTerminal(
+        [row({ repoSlug: "backend", phase: "extracting_ast", ts: 1 })],
+        2,
+        "done",
+      ),
+    ).toBe(true);
+  });
+
+  it("falls back to per-repo terminal when no group terminal is available", () => {
+    expect(
+      streamTerminal(
+        [
+          row({ repoSlug: "backend", phase: "done", ts: 1 }),
+          row({ repoSlug: "frontend", phase: "done", ts: 2 }),
+        ],
+        2,
+      ),
+    ).toBe(true);
   });
 });
 

--- a/webui-v2/src/lib/index-progress-fold.ts
+++ b/webui-v2/src/lib/index-progress-fold.ts
@@ -205,6 +205,20 @@ export function rowsTerminal(rows: ProgressRow[], expectedRepos?: number): boole
   return rows.every((r) => r.phase === "done" || r.phase === "error");
 }
 
+/**
+ * Terminal state for the whole progress stream. The daemon's group-scoped
+ * terminal event is authoritative even when a per-repo terminal event was
+ * dropped and left one row frozen in an intermediate phase.
+ */
+export function streamTerminal(
+  rows: ProgressRow[],
+  expectedRepos?: number,
+  groupPhaseValue?: ProgressRow["phase"],
+): boolean {
+  if (groupPhaseValue === "done" || groupPhaseValue === "error") return true;
+  return rowsTerminal(rows, expectedRepos);
+}
+
 /* ------------------------------------------------------------------
    Aggregate progress + phase label (#5332).
 


### PR DESCRIPTION
## What changed

- Treat the daemon's group-scoped `done` or `error` progress event as authoritative for the indexing stream.
- Preserve the existing per-repository terminal fallback when no group terminal event is available.
- Add regression coverage for a dropped per-repository terminal event that leaves a row frozen mid-phase.

## Why

The scan wizard only trusted per-repository terminal rows. If one terminal event was dropped but the group completed, the wizard could remain stuck even though indexing had finished.

## Validation

- `npm test -- src/lib/index-progress-fold.test.ts` — 308 tests passed
- `npm run lint`
- `git diff --check`

## Closes / Refs

Refs #5326
