### PR TITLE
fix(#5937): token-filtered SSE progress — restore per-module wizard rows

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1261,9 +1261,13 @@ func rebuildWorkerPool(conc int, work []repoWork, workFn func(idx int, rw repoWo
 // rebuildSubprocessParams carries the per-repo inputs the subprocess rebuild
 // path forwards to the `grafel index-internal` child.
 type rebuildSubprocessParams struct {
-	RepoPath            string
-	RepoSlug            string
-	GroupSlug           string
+	RepoPath  string
+	RepoSlug  string
+	GroupSlug string
+	// RunToken is the rebuild's per-run identity (RebuildArgs.ProgressToken,
+	// #5937), forwarded to the child so every republished progress.Event
+	// carries Event.RunToken. Empty for rebuilds with no token.
+	RunToken            string
 	ProgressPub         progress.Publisher
 	Interactive         bool
 	IncrementalStateDir string
@@ -1283,6 +1287,7 @@ var runRebuildSubprocess = func(ctx context.Context, p rebuildSubprocessParams) 
 		ProgressPub:         p.ProgressPub,
 		GroupSlug:           p.GroupSlug,
 		RepoSlug:            p.RepoSlug,
+		RunToken:            p.RunToken,
 		Interactive:         p.Interactive,
 		IncrementalStateDir: p.IncrementalStateDir,
 	}, slog.Default())
@@ -1479,6 +1484,7 @@ func daemonRebuildFuncCore(
 					RepoPath:            rw.r.Path,
 					RepoSlug:            rw.r.Slug,
 					GroupSlug:           args.Group,
+					RunToken:            args.ProgressToken,
 					ProgressPub:         progressPub,
 					Interactive:         foreground,
 					IncrementalStateDir: incrementalStateDir,
@@ -1494,7 +1500,8 @@ func daemonRebuildFuncCore(
 			// WebUI Index step renders live rows + file counters (#1531).
 			opts = append(opts,
 				WithPublisher(progressPub),
-				WithProgressSlugs(args.Group, rw.r.Slug))
+				WithProgressSlugs(args.Group, rw.r.Slug),
+				WithRunToken(args.ProgressToken))
 			// #5328: run at the foreground (higher) CPU cap only for human-awaited
 			// rebuilds; an automatic watcher/git-hook-triggered rebuild stays at
 			// the throttled background cap. This appears AFTER indexFn's prepended
@@ -1693,6 +1700,7 @@ func daemonRebuildFuncCore(
 	// The phantom-edge pass re-runs process-flow inside linksFn, so the same
 	// phase also covers the group-level flow recompute.
 	linkTrk := progress.NewTracker(progressPub, args.Group, args.Group)
+	linkTrk.SetRunToken(args.ProgressToken)
 	linkTrk.Phase(progress.PhaseDetectLinks, "cross-repo links", 0)
 
 	// Cross-repo link passes run after every member is indexed. Skip them

--- a/cmd/grafel/daemon_rebuild_runtoken_test.go
+++ b/cmd/grafel/daemon_rebuild_runtoken_test.go
@@ -1,0 +1,108 @@
+package main
+
+// daemon_rebuild_runtoken_test.go — #5937 chunk 1: RebuildArgs.ProgressToken
+// must thread all the way into every progress.Event this rebuild emits, on
+// BOTH the in-process indexFn path and the subprocess (`grafel index-internal`
+// child) reroute, so a subscriber can key events to THIS run rather than a
+// stale prior run.
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// TestRebuild_InProcess_ForwardsProgressToken verifies that args.ProgressToken
+// reaches the in-process indexFn's IndexOption list as WithRunToken, so the
+// Indexer's Tracker stamps RunToken on every event it emits.
+func TestRebuild_InProcess_ForwardsProgressToken(t *testing.T) {
+	group := setupTestGroup(t, "runtoken-inprocess-group", []string{"r1"})
+
+	var gotRunToken string
+	var calls int32
+	inProcessIndexFn := func(_, _, _ string, _ []string, _, _ bool, opts ...IndexOption) error {
+		atomic.AddInt32(&calls, 1)
+		var i Indexer
+		for _, opt := range opts {
+			opt(&i)
+		}
+		gotRunToken = i.runToken
+		return nil
+	}
+	linksFn := func(_ context.Context, _ string) error { return nil }
+
+	const tok = "wizard-run-tok-1"
+	_, warning, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, ProgressToken: tok}, inProcessIndexFn, linksFn)
+	if err != nil {
+		t.Fatalf("rebuild: %v (warning=%q)", err, warning)
+	}
+	if atomic.LoadInt32(&calls) != 1 {
+		t.Fatalf("indexFn called %d times, want 1", calls)
+	}
+	if gotRunToken != tok {
+		t.Errorf("Indexer.runToken = %q, want %q", gotRunToken, tok)
+	}
+}
+
+// TestRebuild_InProcess_EmptyProgressTokenUnaffected verifies a rebuild with no
+// ProgressToken (the background/watcher case) leaves the Indexer's runToken
+// empty — additive only, no behaviour change for untokened runs.
+func TestRebuild_InProcess_EmptyProgressTokenUnaffected(t *testing.T) {
+	group := setupTestGroup(t, "runtoken-inprocess-empty-group", []string{"r1"})
+
+	var gotRunToken string
+	sawRunToken := false
+	inProcessIndexFn := func(_, _, _ string, _ []string, _, _ bool, opts ...IndexOption) error {
+		var i Indexer
+		for _, opt := range opts {
+			opt(&i)
+		}
+		gotRunToken = i.runToken
+		sawRunToken = true
+		return nil
+	}
+	linksFn := func(_ context.Context, _ string) error { return nil }
+
+	_, warning, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group}, inProcessIndexFn, linksFn)
+	if err != nil {
+		t.Fatalf("rebuild: %v (warning=%q)", err, warning)
+	}
+	if !sawRunToken {
+		t.Fatal("indexFn was never called")
+	}
+	if gotRunToken != "" {
+		t.Errorf("Indexer.runToken = %q, want empty for a rebuild with no ProgressToken", gotRunToken)
+	}
+}
+
+// TestRebuild_SubprocessReroute_ForwardsProgressToken verifies that
+// args.ProgressToken reaches rebuildSubprocessParams.RunToken (and from there
+// SubprocessIndexOptions.RunToken / the child's --run-token flag — covered
+// byte-faithfully by the sched package's own round-trip coverage) on the
+// subprocess reroute.
+func TestRebuild_SubprocessReroute_ForwardsProgressToken(t *testing.T) {
+	group := setupTestGroup(t, "runtoken-subproc-group", []string{"r1"})
+	forceSubprocessRebuild(t)
+
+	calls := stubChildSpawn(t)
+
+	inProcessIndexFn := failIfCalledIndexFn(t)
+	linksFn := func(_ context.Context, _ string) error { return nil }
+
+	const tok = "wizard-run-tok-2"
+	_, warning, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, ProgressToken: tok}, inProcessIndexFn, linksFn)
+	if err != nil {
+		t.Fatalf("rebuild: %v (warning=%q)", err, warning)
+	}
+	if len(*calls) != 1 {
+		t.Fatalf("child spawned %d times, want 1", len(*calls))
+	}
+	if got := (*calls)[0].RunToken; got != tok {
+		t.Errorf("rebuildSubprocessParams.RunToken = %q, want %q", got, tok)
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -166,6 +166,7 @@ type Indexer struct {
 	publisher progress.Publisher
 	groupSlug string // forwarded to every Event.GroupSlug
 	repoSlug  string // forwarded to every Event.RepoSlug; defaults to repoTag
+	runToken  string // forwarded to every Event.RunToken (#5937); "" = no per-run token
 
 	// Statistics — populated as passes run, surfaced in the final summary.
 	stats indexerStats
@@ -313,6 +314,16 @@ func WithProgressSlugs(groupSlug, repoSlug string) IndexOption {
 		i.groupSlug = groupSlug
 		i.repoSlug = repoSlug
 	}
+}
+
+// WithRunToken sets the per-run identity (RebuildArgs.ProgressToken, when the
+// caller has one) forwarded to Event.RunToken on every progress event this
+// indexer's Tracker emits (#5937). Call alongside WithPublisher/
+// WithProgressSlugs; the default "" leaves RunToken empty on every event,
+// matching pre-#5937 behaviour for runs with no token (e.g. background/
+// watcher reindexes).
+func WithRunToken(tok string) IndexOption {
+	return func(i *Indexer) { i.runToken = tok }
 }
 
 // WithIncremental enables diff-aware re-indexing (issue #1339). The indexer
@@ -847,6 +858,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		repoSlug = i.repoTag
 	}
 	trk := progress.NewTracker(pub, i.groupSlug, repoSlug)
+	trk.SetRunToken(i.runToken)
 
 	// M4 sparse-checkout (#2181): probe the repo BEFORE the walk so the
 	// walker can filter out files that are not present locally. The result is

--- a/cmd/grafel/index_internal.go
+++ b/cmd/grafel/index_internal.go
@@ -39,6 +39,7 @@ func runIndexInternal(argv []string) int {
 		ingestDocs   = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md and *.pdf files as Document/Section nodes + exact-mention links (no LLM, no network)")
 		emitProgress = fs.Bool("emit-progress", false, "stream per-module progress.Event JSON lines on stdout for the parent to republish (rebuild / wizard first-index)")
 		groupSlug    = fs.String("group-slug", "", "group slug stamped on progress events when --emit-progress is set")
+		runToken     = fs.String("run-token", "", "per-run identity (RebuildArgs.ProgressToken) stamped on progress events when --emit-progress is set (#5937)")
 		interactive  = fs.Bool("interactive", false, "run at the foreground GRAFEL_REBUILD_GOMAXPROCS extract cap (human-awaited rebuild) instead of the background cap")
 		incremental  = fs.String("incremental", "", "state dir enabling diff-aware re-indexing (matches WithIncremental); empty = full index")
 	)
@@ -80,7 +81,8 @@ func runIndexInternal(argv []string) int {
 	if *emitProgress {
 		opts = append(opts,
 			WithPublisher(sched.NewStdoutProgressPublisher(os.Stdout)),
-			WithProgressSlugs(*groupSlug, *repoTag))
+			WithProgressSlugs(*groupSlug, *repoTag),
+			WithRunToken(*runToken))
 	}
 	// Foreground rebuild: run the extract sub-subprocesses at the higher
 	// GRAFEL_REBUILD_GOMAXPROCS cap. Background reactive reindexes leave this off

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -248,7 +248,7 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		sseCh, sseErr := subscribeSSE(ctx, dashPort, group)
+		sseCh, sseErr := subscribeSSE(ctx, dashPort, group, token)
 		if sseErr == nil {
 			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, plain, jsonProgress)
 			cancel()
@@ -486,7 +486,7 @@ func indexGroupWithProgress(w, errW io.Writer, group string) error {
 	if dashPort > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group, token); sseErr == nil {
 			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, false, false)
 			cancel()
 			if outcome.err != nil {

--- a/internal/cli/repair_broker.go
+++ b/internal/cli/repair_broker.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"strings"
 	"time"
 
@@ -51,8 +52,20 @@ type sseEvent struct {
 // the given group and feeds parsed events onto the returned channel. It
 // returns an error if the initial HTTP connection fails (e.g. dashboard not
 // running). The caller must cancel ctx when done — that closes the channel.
-func subscribeSSE(ctx context.Context, dashPort int, group string) (<-chan sseEvent, error) {
+//
+// token is the caller's RebuildArgs.ProgressToken (see progressToken()), if
+// any. When non-empty it is sent as the `token` query param so the daemon's
+// SSE handler can distinguish OUR run's retained/live terminal event from a
+// prior run's stale corpse (#5937) — a subscriber that supplies a token never
+// gets a mismatched-token terminal replayed on connect, and a mismatched-token
+// terminal arriving live never closes its stream. Pass "" for callers with no
+// per-run token (e.g. background/legacy callers); the handler then falls back
+// to today's tokenless behaviour (replay+close whatever is retained, #5326).
+func subscribeSSE(ctx context.Context, dashPort int, group, token string) (<-chan sseEvent, error) {
 	url := fmt.Sprintf("http://127.0.0.1:%d/api/index-progress/%s", dashPort, group)
+	if token != "" {
+		url += "?token=" + neturl.QueryEscape(token)
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err

--- a/internal/cli/wizard_tui_run.go
+++ b/internal/cli/wizard_tui_run.go
@@ -378,7 +378,7 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 		defer cancel()
 		var sseCh <-chan sseEvent
 		if dashPort > 0 {
-			if ch, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+			if ch, sseErr := subscribeSSE(ctx, dashPort, group, token); sseErr == nil {
 				sseCh = ch
 			}
 		}
@@ -417,7 +417,7 @@ func streamIndexWithSummary(evCh chan<- progress.Event, outCh chan<- wiztui.Inde
 	if dashPort > 0 {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
-		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group); sseErr == nil {
+		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group, token); sseErr == nil {
 			rpcCh := triggerRebuild(c, group, token)
 			o := forwardBrokerToChannel(ctx, sseCh, rpcCh, evCh)
 			cancel()

--- a/internal/cli/wiztui/indexview.go
+++ b/internal/cli/wiztui/indexview.go
@@ -465,7 +465,7 @@ func (v indexView) view() string {
 	}
 	b.WriteString("\n\n")
 
-	if len(rows) == 0 && !v.done() {
+	if len(rows) == 0 && !v.done() && !v.queryable {
 		b.WriteString(rowCountStyle.Render("waiting for the indexer to report" + g.Ellipsis))
 		return b.String()
 	}

--- a/internal/cli/wiztui/indexview_test.go
+++ b/internal/cli/wiztui/indexview_test.go
@@ -107,6 +107,35 @@ func TestIndexView_QueryableBanner_ShownWhenQueryableNotTerminal(t *testing.T) {
 	}
 }
 
+// TestIndexView_QueryableNeverShowsWaitingPlaceholder is the #5937 cosmetic
+// backstop: a zero-row screen (e.g. the group-scoped SSE event routed to
+// groupPhase created no per-repo/per-module row — the failure mode this issue
+// is about) must never render "waiting for the indexer to report…" once the
+// graph is queryable, even though !v.done() is still true (queryable sets
+// neither v.terminal nor v.failed). Reaching 100%/queryable with zero rows and
+// the placeholder is exactly the "reads as hung" bug from #5937.
+func TestIndexView_QueryableNeverShowsWaitingPlaceholder(t *testing.T) {
+	v := newIndexView("grp", 1)
+	v.width = 100
+	// Only a group-scoped event folds in — no per-repo/per-module row is ever
+	// created (mirrors the monorepo failure chain in #5937).
+	v.foldEvent(progress.Event{RepoSlug: "grp", GroupSlug: "grp", Phase: progress.PhaseDone, TS: 1})
+	v.queryable = true
+	v.summaryEntities = 4200
+
+	if len(v.rows) != 0 {
+		t.Fatalf("test setup invalid: expected zero rows, got %d", len(v.rows))
+	}
+	if v.done() {
+		t.Fatalf("test setup invalid: expected !v.done() while only queryable, got done()==true")
+	}
+
+	out := v.view()
+	if strings.Contains(out, "waiting for the indexer to report") {
+		t.Errorf("placeholder rendered on a zero-row queryable screen:\n%s", out)
+	}
+}
+
 // TestIndexView_HeaderFreezesElapsedAtQueryableMoment: once the graph becomes
 // queryable (interim outcome landed), the main header elapsed FREEZES at the
 // queryable moment (startedAt..queryableAt) instead of continuing to grow with

--- a/internal/daemon/progress_tailer.go
+++ b/internal/daemon/progress_tailer.go
@@ -125,6 +125,41 @@ func isGroupTerminal(e progress.Event) bool {
 		(e.Phase == progress.PhaseDone || e.Phase == progress.PhaseError)
 }
 
+// seedIfAlreadyTerminal peeks at st's sidecar from the start and, if it
+// already contains a group-scoped terminal (isGroupTerminal), advances st's
+// offset past that content and marks st.terminal — WITHOUT publishing any of
+// the events read. Returns true when it seeded (the caller should skip
+// further processing of this group for the current tick); false when the
+// sidecar is not yet terminal, in which case st is left untouched so the
+// caller falls through to the normal read-and-publish path (a run that was
+// already in progress when this tailer first saw the group is still live and
+// its current state should be surfaced immediately).
+//
+// Only called on first sight of a group (st freshly constructed, offset 0);
+// see #5937.
+func (t *sidecarTailer) seedIfAlreadyTerminal(st *groupTailState) bool {
+	events, newOffset, err := st.reader.ReadFrom(0)
+	if err != nil {
+		if t.logger != nil {
+			t.logger.Warn("progress tailer: read failed", "group", st.reader.Path(), "err", err)
+		}
+		return false
+	}
+	terminal := false
+	for _, e := range events {
+		if isGroupTerminal(e) {
+			terminal = true
+			break
+		}
+	}
+	if !terminal {
+		return false
+	}
+	st.offset = newOffset
+	st.terminal = true
+	return true
+}
+
 // shrank reports whether the on-disk sidecar is now smaller than the offset we
 // consumed to — the signal that a NEW run truncated it (NewSidecarWriter /
 // Reset) or it was compacted. Used to decide whether to RESUME a group we
@@ -152,6 +187,20 @@ func (t *sidecarTailer) tick() {
 			}
 			st = &groupTailState{reader: r}
 			t.states[slug] = st
+
+			// #5937 — first-sight terminal seeding. This is the FIRST time this
+			// tailer instance has looked at slug (e.g. serve just started). If
+			// the sidecar's tail is already a group-scoped terminal, those
+			// events belong to a run that ended before serve (and this tailer)
+			// existed — republishing them would poison the broker's retained
+			// terminal (internal/progress.Broker.terminal) and close every SSE
+			// subscriber before any live event for the CURRENT run arrives
+			// (#5937). Seed the cursor/terminal flag WITHOUT publishing; normal
+			// live tailing (including the offset-reset/shrink-resume path
+			// below) still applies to everything that happens afterward.
+			if t.seedIfAlreadyTerminal(st) {
+				continue
+			}
 		}
 
 		// Once a group reached its group-scoped terminal we stop republishing —

--- a/internal/daemon/progress_tailer_test.go
+++ b/internal/daemon/progress_tailer_test.go
@@ -60,13 +60,46 @@ func writeSidecarFixture(t *testing.T, slug string, lines []progress.SidecarLine
 	}
 }
 
-// TestSidecarTailer_RepublishesMultiGroup writes two group sidecars — each with
-// per-module extraction events and a group-scoped terminal — and asserts the
-// tailer republishes every event (per-module included), preserves order, marks
-// each group terminal, and republishes NOTHING further after the terminal.
+// TestSidecarTailer_RepublishesMultiGroup writes two group sidecars — each
+// mid-run (NOT yet terminal) on first sight, so the tailer's normal live-tail
+// path applies (the #5937 first-sight-already-terminal seeding case is
+// covered separately by
+// TestSidecarTailer_FirstSightAlreadyTerminalSeedsWithoutPublishing) — then
+// appends each group's group-scoped terminal as a genuinely NEW, live event
+// and asserts the tailer republishes every event (per-module included),
+// preserves order, marks each group terminal, and republishes NOTHING further
+// after the terminal.
 func TestSidecarTailer_RepublishesMultiGroup(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 
+	// First sight: both groups mid-run, no terminal yet.
+	writeSidecarFixture(t, "grp-a", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-x", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10},
+		{Seq: 2, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-y", Phase: progress.PhaseExtractAST, FilesDone: 3, FilesTotal: 8},
+	})
+	writeSidecarFixture(t, "grp-b", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "grp-b", RepoSlug: "svc", Module: "mod-z", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 4},
+	})
+
+	pub := &collectPub{}
+	tl := newSidecarTailer(pub, time.Hour, nil)
+	tl.groupsFn = func() []string { return []string{"grp-a", "grp-b"} }
+
+	tl.tick()
+	got := pub.snapshot()
+	if len(got) != 3 {
+		t.Fatalf("first tick republished %d events, want 3: %+v", len(got), got)
+	}
+	if st := tl.states["grp-a"]; st == nil || st.terminal {
+		t.Error("grp-a unexpectedly marked terminal on first (non-terminal) tick")
+	}
+	if st := tl.states["grp-b"]; st == nil || st.terminal {
+		t.Error("grp-b unexpectedly marked terminal on first (non-terminal) tick")
+	}
+
+	// Each group's run now reaches its group-scoped terminal — appended live,
+	// growing the file, so this is genuinely new content the tailer must
+	// republish (distinct from the first-sight-already-terminal case).
 	writeSidecarFixture(t, "grp-a", []progress.SidecarLine{
 		{Seq: 1, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-x", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10},
 		{Seq: 2, GroupSlug: "grp-a", RepoSlug: "repo1", Module: "mod-y", Phase: progress.PhaseExtractAST, FilesDone: 3, FilesTotal: 8},
@@ -77,33 +110,62 @@ func TestSidecarTailer_RepublishesMultiGroup(t *testing.T) {
 		{Seq: 2, GroupSlug: "grp-b", RepoSlug: "grp-b", Phase: progress.PhaseDone, Done: true},
 	})
 
-	pub := &collectPub{}
-	tl := newSidecarTailer(pub, time.Hour, nil)
-	tl.groupsFn = func() []string { return []string{"grp-a", "grp-b"} }
-
 	tl.tick()
-	got := pub.snapshot()
+	got = pub.snapshot()
 
-	// Every fixture line for both groups must be republished.
+	// Every fixture line for both groups must be republished across both ticks.
 	if len(got) != 5 {
 		t.Fatalf("republished %d events, want 5: %+v", len(got), got)
 	}
 
-	// Ordering: grp-a's three (in seq order) then grp-b's two.
-	wantOrder := []struct {
-		group, repo, module, phase string
-	}{
-		{"grp-a", "repo1", "mod-x", progress.PhaseExtractAST},
-		{"grp-a", "repo1", "mod-y", progress.PhaseExtractAST},
-		{"grp-a", "grp-a", "", progress.PhaseDone},
-		{"grp-b", "svc", "mod-z", progress.PhaseExtractAST},
-		{"grp-b", "grp-b", "", progress.PhaseDone},
+	// Ordering: the tailer processes groups independently (groupsFn order per
+	// tick), and this test spans two ticks (partial content on tick 1, each
+	// group's terminal appended for tick 2) — so cross-group interleaving of
+	// the flat sequence is NOT a guarantee the tailer makes; grp-a's and
+	// grp-b's events land in whichever tick produced them. What IS guaranteed,
+	// and what actually matters, is that each group's OWN events arrive in
+	// strict seq order with no gaps and no reordering relative to its sidecar.
+	// So partition by group and assert per-group ordering.
+	var grpAEvents, grpBEvents []progress.Event
+	for _, e := range got {
+		switch e.GroupSlug {
+		case "grp-a":
+			grpAEvents = append(grpAEvents, e)
+		case "grp-b":
+			grpBEvents = append(grpBEvents, e)
+		default:
+			t.Fatalf("republished event for unexpected group: %+v", e)
+		}
 	}
-	for i, w := range wantOrder {
-		e := got[i]
-		if e.GroupSlug != w.group || e.RepoSlug != w.repo || e.Module != w.module || e.Phase != w.phase {
-			t.Errorf("event[%d] = {g:%q r:%q m:%q p:%q}, want {g:%q r:%q m:%q p:%q}",
-				i, e.GroupSlug, e.RepoSlug, e.Module, e.Phase, w.group, w.repo, w.module, w.phase)
+
+	wantA := []struct{ repo, module, phase string }{
+		{"repo1", "mod-x", progress.PhaseExtractAST},
+		{"repo1", "mod-y", progress.PhaseExtractAST},
+		{"grp-a", "", progress.PhaseDone},
+	}
+	if len(grpAEvents) != len(wantA) {
+		t.Fatalf("grp-a republished %d events, want %d: %+v", len(grpAEvents), len(wantA), grpAEvents)
+	}
+	for i, w := range wantA {
+		e := grpAEvents[i]
+		if e.RepoSlug != w.repo || e.Module != w.module || e.Phase != w.phase {
+			t.Errorf("grp-a event[%d] = {r:%q m:%q p:%q}, want {r:%q m:%q p:%q}",
+				i, e.RepoSlug, e.Module, e.Phase, w.repo, w.module, w.phase)
+		}
+	}
+
+	wantB := []struct{ repo, module, phase string }{
+		{"svc", "mod-z", progress.PhaseExtractAST},
+		{"grp-b", "", progress.PhaseDone},
+	}
+	if len(grpBEvents) != len(wantB) {
+		t.Fatalf("grp-b republished %d events, want %d: %+v", len(grpBEvents), len(wantB), grpBEvents)
+	}
+	for i, w := range wantB {
+		e := grpBEvents[i]
+		if e.RepoSlug != w.repo || e.Module != w.module || e.Phase != w.phase {
+			t.Errorf("grp-b event[%d] = {r:%q m:%q p:%q}, want {r:%q m:%q p:%q}",
+				i, e.RepoSlug, e.Module, e.Phase, w.repo, w.module, w.phase)
 		}
 	}
 
@@ -170,15 +232,86 @@ func TestSidecarTailer_OffsetResetReplay(t *testing.T) {
 	}
 }
 
+// TestSidecarTailer_FirstSightAlreadyTerminalSeedsWithoutPublishing verifies
+// the #5937 fix: when the tailer sees a group for the FIRST time (e.g. right
+// after serve starts) and that group's sidecar tail is already a group-scoped
+// terminal, it must seed its offset/terminal state WITHOUT publishing any of
+// those events. Those events belong to a run that ended before serve (and
+// this tailer) existed; republishing them poisons the broker's retained
+// terminal and closes every SSE subscriber before any live event for the
+// CURRENT run arrives. Subsequently appended live events for a NEW run (after
+// the file shrinks/truncates) must still be published normally.
+func TestSidecarTailer_FirstSightAlreadyTerminalSeedsWithoutPublishing(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	// The sidecar already contains a full PRIOR run, terminated, before the
+	// tailer ever looks at it.
+	writeSidecarFixture(t, "prior-run", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "prior-run", RepoSlug: "repo1", Module: "mod-x", Phase: progress.PhaseExtractAST, FilesDone: 5, FilesTotal: 10},
+		{Seq: 2, GroupSlug: "prior-run", RepoSlug: "prior-run", Phase: progress.PhaseDone, Done: true},
+	})
+
+	pub := &collectPub{}
+	tl := newSidecarTailer(pub, time.Hour, nil)
+	tl.groupsFn = func() []string { return []string{"prior-run"} }
+
+	// First sight: must seed state but publish NOTHING.
+	tl.tick()
+	if n := len(pub.snapshot()); n != 0 {
+		t.Fatalf("first sight of an already-terminal sidecar republished %d events, want 0: %+v", n, pub.snapshot())
+	}
+	st := tl.states["prior-run"]
+	if st == nil {
+		t.Fatal("tailer did not seed state for prior-run")
+	}
+	if !st.terminal {
+		t.Error("tailer did not mark prior-run terminal on first sight")
+	}
+	if st.offset <= 0 {
+		t.Errorf("tailer did not advance offset past the prior run's content: got %d", st.offset)
+	}
+
+	// A subsequent tick with no file changes still republishes nothing.
+	tl.tick()
+	if n := len(pub.snapshot()); n != 0 {
+		t.Errorf("second tick (no new run) republished %d events, want 0", n)
+	}
+
+	// Now a NEW run starts: the file is truncated/rewritten smaller, with live
+	// (non-terminal) events. These SHOULD be published — normal live tailing
+	// resumes for a genuinely new run.
+	writeSidecarFixture(t, "prior-run", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "prior-run", RepoSlug: "repo1", Module: "mod-x", Phase: progress.PhaseScan, FilesDone: 1, FilesTotal: 3},
+	})
+	if fi, _ := os.Stat(st.reader.Path()); fi.Size() >= st.offset {
+		t.Fatalf("new run file not smaller than prior offset (%d >= %d); test cannot exercise shrink", fi.Size(), st.offset)
+	}
+
+	tl.tick()
+	got := pub.snapshot()
+	if len(got) != 1 {
+		t.Fatalf("new run's live event not republished; got %d events: %+v", len(got), got)
+	}
+	if got[0].Phase != progress.PhaseScan || got[0].FilesDone != 1 {
+		t.Errorf("unexpected republished event for new run: %+v", got[0])
+	}
+	if tl.states["prior-run"].terminal {
+		t.Error("tailer still marked terminal after new run started")
+	}
+}
+
 // TestSidecarTailer_StartStopLifecycle exercises the goroutine start/stop path:
 // startSidecarTailer's returned stop func must join the goroutine, and a
-// running tailer must republish a fixture's events end-to-end.
+// running tailer must republish a fixture's events end-to-end. The fixture
+// starts mid-run (no terminal yet) on first sight so this exercises normal
+// live tailing rather than the #5937 first-sight-already-terminal seeding
+// case (covered separately); the terminal is appended afterward as a
+// genuinely new, live event.
 func TestSidecarTailer_StartStopLifecycle(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 
 	writeSidecarFixture(t, "live", []progress.SidecarLine{
 		{Seq: 1, GroupSlug: "live", RepoSlug: "r", Module: "m", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 2},
-		{Seq: 2, GroupSlug: "live", RepoSlug: "live", Phase: progress.PhaseDone, Done: true},
 	})
 
 	pub := &collectPub{}
@@ -188,7 +321,7 @@ func TestSidecarTailer_StartStopLifecycle(t *testing.T) {
 
 	deadline := time.After(2 * time.Second)
 	for {
-		if len(pub.snapshot()) >= 2 {
+		if len(pub.snapshot()) >= 1 {
 			break
 		}
 		select {
@@ -197,17 +330,31 @@ func TestSidecarTailer_StartStopLifecycle(t *testing.T) {
 		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	// stop must join cleanly.
-	tl.shutdown()
 
-	// Terminal delivered.
-	var sawTerminal bool
-	for _, e := range pub.snapshot() {
-		if e.Phase == progress.PhaseDone {
-			sawTerminal = true
+	// Append the group-scoped terminal as new, live content.
+	writeSidecarFixture(t, "live", []progress.SidecarLine{
+		{Seq: 1, GroupSlug: "live", RepoSlug: "r", Module: "m", Phase: progress.PhaseExtractAST, FilesDone: 1, FilesTotal: 2},
+		{Seq: 2, GroupSlug: "live", RepoSlug: "live", Phase: progress.PhaseDone, Done: true},
+	})
+
+	deadline = time.After(2 * time.Second)
+	for {
+		var sawTerminal bool
+		for _, e := range pub.snapshot() {
+			if e.Phase == progress.PhaseDone {
+				sawTerminal = true
+			}
+		}
+		if sawTerminal {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("terminal event never republished; got %d events", len(pub.snapshot()))
+		case <-time.After(10 * time.Millisecond):
 		}
 	}
-	if !sawTerminal {
-		t.Error("terminal event never republished")
-	}
+
+	// stop must join cleanly.
+	tl.shutdown()
 }

--- a/internal/daemon/rebuild_terminal_invalidation_test.go
+++ b/internal/daemon/rebuild_terminal_invalidation_test.go
@@ -1,0 +1,102 @@
+package daemon
+
+// #5937 — run-scoped retained-terminal invalidation.
+//
+// internal/dashboard's SSE handler replays whatever terminal (PhaseDone /
+// PhaseError) the progress.Broker retains for a group on connect (the #5326
+// guarantee). Before this fix nothing ever cleared that retained terminal, so
+// a stale entry from a PRIOR run could be replayed to a client watching a NEW
+// run and the stream closed before any live event for that new run arrived.
+//
+// The fix invalidates at the single choke point every rebuild trigger passes
+// through in this process, in EITHER mode: Service.Rebuild. These tests prove
+// that Rebuild clears a group's retained terminal at the very start of the
+// call, in both split mode (where the actual work is enqueued for a separate
+// engine process) and monolith mode (where s.rebuild runs in-process
+// synchronously) — mirroring the existing split/monolith mutual-exclusion
+// tests in rebuild_split_mode_test.go.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+func TestRebuild_ClearsRetainedTerminal_MonolithMode(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "0")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	broker := progress.NewBroker()
+	// Simulate a PRIOR run's retained terminal for this group, as if it had
+	// completed before this Rebuild call.
+	broker.Publish(progress.Event{GroupSlug: "mygroup", RepoSlug: "mygroup", Phase: progress.PhaseDone})
+	if _, ok := broker.LastTerminal("mygroup"); !ok {
+		t.Fatal("setup: expected a retained terminal before Rebuild")
+	}
+
+	svc := newService(nil, func(args proto.RebuildArgs) ([]string, string, error) {
+		return []string{"/some/repo"}, "", nil
+	}, nil, "", make(chan struct{}, 1), nil, 1)
+	svc.SetProgressBroker(broker)
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup"}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	if _, ok := broker.LastTerminal("mygroup"); ok {
+		t.Error("Rebuild (monolith mode) did not clear the group's retained terminal at run start")
+	}
+}
+
+func TestRebuild_ClearsRetainedTerminal_SplitMode(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "1")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	broker := progress.NewBroker()
+	broker.Publish(progress.Event{GroupSlug: "mygroup", RepoSlug: "mygroup", Phase: progress.PhaseDone})
+	if _, ok := broker.LastTerminal("mygroup"); !ok {
+		t.Fatal("setup: expected a retained terminal before Rebuild")
+	}
+
+	// s.rebuild is wired non-nil (mirroring the real split-mode serve process
+	// per service.go's Rebuild doc comment) but must NOT be invoked directly —
+	// split mode only enqueues a request file. See
+	// TestRebuild_SplitModeOn_WritesRequestFile_NeverCallsRebuildDirectly for
+	// the existing mutual-exclusion assertion this test complements.
+	svc := newService(nil, func(args proto.RebuildArgs) ([]string, string, error) {
+		return []string{"/some/repo"}, "", nil
+	}, nil, "", make(chan struct{}, 1), nil, 1)
+	svc.SetProgressBroker(broker)
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup"}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+
+	if _, ok := broker.LastTerminal("mygroup"); ok {
+		t.Error("Rebuild (split mode enqueue) did not clear the group's retained terminal at run start")
+	}
+}
+
+// TestRebuild_NilProgressBroker_DoesNotPanic guards the nil-safety of the
+// ClearTerminal call: test wiring (and any serve process without a dashboard)
+// leaves progressBroker unset, and Rebuild must tolerate that silently.
+func TestRebuild_NilProgressBroker_DoesNotPanic(t *testing.T) {
+	t.Setenv(SplitModeEnvVar, "0")
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	svc := newService(nil, func(args proto.RebuildArgs) ([]string, string, error) {
+		return []string{"/some/repo"}, "", nil
+	}, nil, "", make(chan struct{}, 1), nil, 1)
+	// svc.progressBroker deliberately left nil (no SetProgressBroker call).
+
+	var reply proto.RebuildReply
+	if err := svc.Rebuild(&proto.RebuildArgs{Group: "mygroup"}, &reply); err != nil {
+		t.Fatalf("Rebuild: %v", err)
+	}
+}

--- a/internal/daemon/sched/subprocess_ipc.go
+++ b/internal/daemon/sched/subprocess_ipc.go
@@ -155,6 +155,16 @@ type SubprocessIndexOptions struct {
 	GroupSlug string
 	RepoSlug  string
 
+	// RunToken, when non-empty, is the per-run identity (RebuildArgs.
+	// ProgressToken) forwarded to the child as --run-token so every
+	// progress.Event it republishes over stdout carries Event.RunToken
+	// (#5937). Threaded through unconditionally alongside GroupSlug/RepoSlug
+	// so a subscriber can distinguish THIS run's terminal from a prior run's
+	// retained corpse. Empty for runs with no token (e.g. background/watcher
+	// reindexes, which never populate SubprocessIndexOptions at all) — the
+	// child then stamps no RunToken, exactly as before this field existed.
+	RunToken string
+
 	// Interactive marks a human-awaited foreground rebuild: the child runs its
 	// extract sub-subprocesses at the foreground GRAFEL_REBUILD_GOMAXPROCS cap
 	// (--interactive) AND the parent sets the child process GOMAXPROCS to the

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -331,6 +331,14 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 			if opts.GroupSlug != "" {
 				args = append(args, "--group-slug="+opts.GroupSlug)
 			}
+			// #5937: forward the per-run identity so every republished
+			// progress.Event carries RunToken. Only meaningful alongside
+			// --emit-progress (no publisher, no point tagging events nobody
+			// reads); empty RunToken (no ProgressToken on this run) adds
+			// nothing, matching --group-slug's own emptiness guard.
+			if opts.RunToken != "" {
+				args = append(args, "--run-token="+opts.RunToken)
+			}
 		}
 		if opts.IncrementalStateDir != "" {
 			args = append(args, "--incremental="+opts.IncrementalStateDir)

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -63,7 +63,12 @@ type Config struct {
 	// NDJSON sidecars and republishes each event into THIS broker. nil disables
 	// the tailer (monolith carries everything in-process; tests without a
 	// dashboard leave it unset). ADR-0024 / epic #5729.
-	ProgressBroker progress.Publisher
+	//
+	// Also wired into Service (SetProgressBroker, below) so Rebuild can call
+	// ClearTerminal at the start of every new run (#5937) — the concrete
+	// *progress.Broker type (rather than the narrower progress.Publisher
+	// interface used pre-#5937) is required for that method.
+	ProgressBroker *progress.Broker
 
 	// Phase B optional wiring. When all four are non-nil the daemon
 	// starts the fsnotify watcher + scheduler and registers every
@@ -619,6 +624,10 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	logger.Info("startup: service-init begin")
 	stopReq := make(chan struct{})
 	svc := newService(cfg.Index, cfg.Rebuild, cfg.QualityAudit, cfg.Layout.SocketPath, stopReq, logger, cfg.MaxConcurrentGroups)
+	// #5937 — wire the broker so Rebuild can invalidate a group's retained
+	// terminal at the start of every new run. Safe when nil (test wiring with
+	// no dashboard): Rebuild's ClearTerminal call is itself nil-guarded.
+	svc.SetProgressBroker(cfg.ProgressBroker)
 	svc.mcpListTools = cfg.MCPListTools
 	svc.mcpCallTool = cfg.MCPCallTool
 	if cfg.DashboardPort > 0 {

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/perf"
 	"github.com/cajasmota/grafel/internal/process"
+	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
 	"github.com/cajasmota/grafel/internal/version"
@@ -202,6 +203,14 @@ type Service struct {
 	progressMu sync.RWMutex
 	progress   map[string]*rebuildSession
 
+	// progressBroker is the serve-plane indexer progress bus (the SAME
+	// *progress.Broker the dashboard SSE subscribes to; see
+	// daemon.Config.ProgressBroker / SetProgressBroker). Rebuild uses it to
+	// invalidate a group's retained terminal event the instant a NEW rebuild
+	// is triggered (#5937) — see the ClearTerminal call in Rebuild. nil in
+	// test wiring that does not construct a dashboard/broker.
+	progressBroker *progress.Broker
+
 	// Phase D — MCP RPC surface (ADR-0017 #832).
 	// Both fields are injected from cmd/grafel to avoid the import
 	// cycle that would arise from importing internal/mcp here.
@@ -265,6 +274,16 @@ func newService(idx IndexFunc, rb RebuildFunc, qa QualityAuditFunc, socketPath s
 		logger:              logger,
 		maxConcurrentGroups: maxConcurrentGroups,
 	}
+}
+
+// SetProgressBroker wires the shared indexer progress broker into the
+// service so Rebuild can invalidate a group's retained terminal event at the
+// start of a new run (#5937). Mirrors dashboard.Server.SetProgressBroker.
+// Optional: leaving it unset (nil, the default) simply means Rebuild skips
+// the ClearTerminal call — used by tests that exercise the RPC surface
+// without a dashboard/broker.
+func (s *Service) SetProgressBroker(b *progress.Broker) {
+	s.progressBroker = b
 }
 
 // beginDrain marks the service as draining so newly-arriving MCP RPCs are
@@ -547,6 +566,25 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 	}
 	if args == nil || args.Group == "" {
 		return errors.New("group is required")
+	}
+
+	// #5937 — run-scoped terminal invalidation. Service.Rebuild is the SINGLE
+	// choke point every rebuild trigger passes through in THIS process
+	// (whichever mode): in split mode it enqueues the KindRebuild request
+	// below and returns, in monolith/engine mode it calls s.rebuild(*args)
+	// directly further down — either way this is the earliest point at which
+	// serve becomes aware a NEW run for args.Group is starting. Clear the
+	// broker's retained terminal for this group HERE, before any new-run
+	// event can be published, so a client that connects/reconnects to the SSE
+	// stream mid-run never sees a PRIOR run's terminal replayed at it
+	// (handlers_progress.go's emitTerminalIfReady has no way to distinguish
+	// "stale corpse from an old run" from "legitimate late reconnect" by
+	// timestamp alone — see that file's comment). Once THIS run's own
+	// terminal is published (live, in monolith; or via the sidecar tailer, in
+	// split), it repopulates the map with a value that is unambiguously
+	// current until the NEXT Rebuild call clears it again.
+	if s.progressBroker != nil {
+		s.progressBroker.ClearTerminal(args.Group)
 	}
 
 	// ADR-0024 PR6 prerequisite (epic #5729): in split mode this RPC is

--- a/internal/dashboard/handlers_progress.go
+++ b/internal/dashboard/handlers_progress.go
@@ -120,15 +120,35 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 	// In both cases we then emit `close`, so the UI always reaches a terminal
 	// render rather than silently freezing.
 	//
-	// #5937 — freshness gate. Broker.terminal is never cleared, and the
-	// serve-start sidecar tailer republishes an entire pre-existing sidecar
-	// (including a PRIOR run's terminal line) into the broker before any wizard
-	// connects. Without a staleness check, (1) above replays that previous run's
-	// corpse and immediately closes the stream, so the wizard never sees any
-	// live event for the run it is actually watching. Only treat the retained
-	// terminal as replayable when it is NOT older than this subscription — a
-	// terminal that fires during the subscription is still guaranteed via the
-	// live path below and the heartbeat re-assert.
+	// #5937 — this replay is only safe because retained-terminal invalidation
+	// is now RUN-SCOPED, not subscriber-scoped. Broker.terminal used to be
+	// cleared NEVER, and the serve-start sidecar tailer republished an entire
+	// pre-existing sidecar (including a PRIOR run's terminal line) into the
+	// broker before any wizard connected — so (1) above would replay that
+	// previous run's corpse and immediately close the stream, and the wizard
+	// would never see a live event for the run it was actually watching.
+	//
+	// A wall-clock check here (`te.TS < subscribedAt`) cannot fix that: by
+	// construction, ANY already-retained terminal was published before this
+	// subscription's subscribedAt, INCLUDING the legitimate case branch (1)
+	// exists for — a client that connects/reconnects after the CURRENT run's
+	// rebuild already finished. Gating on that comparison does not narrow the
+	// bug, it deletes the guarantee outright (verified: publish a terminal at
+	// real `now`, subscribe immediately — the old gate withheld it forever,
+	// heartbeats only, since re-checking the same comparison on every tick
+	// never turns true).
+	//
+	// The actual fix is upstream: daemon.Service.Rebuild calls
+	// Broker.ClearTerminal(group) at the START of every new run (the single
+	// choke point every rebuild trigger passes through, in both split and
+	// monolith mode — see that method's comment). That means whatever this
+	// handler finds retained here can only be EITHER this group's own most
+	// recent completed run (replay it — this is the #5326 guarantee) OR
+	// nothing at all (a run is in flight or has never completed since the
+	// last clear) — never a stale cross-run corpse. So once retained, replay
+	// it unconditionally; a terminal that fires while this handler is already
+	// attached is still delivered via the live path below and the heartbeat
+	// re-assert.
 	var terminalSent bool
 	emitTerminalIfReady := func() (done bool) {
 		if group == sseWildcardGroup || terminalSent {
@@ -136,12 +156,6 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 		}
 		te, ok := s.progressBroker.LastTerminal(group)
 		if !ok {
-			return false
-		}
-		if te.TS < subscribedAt {
-			// Stale terminal from a run that already ended before this
-			// subscription started (or before serve even started). Do not
-			// replay, and do not close — stay attached for live events.
 			return false
 		}
 		if data, err := json.Marshal(te); err == nil {

--- a/internal/dashboard/handlers_progress.go
+++ b/internal/dashboard/handlers_progress.go
@@ -119,6 +119,16 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 	//      it if we have not already (covers the in-flight drop-on-full case).
 	// In both cases we then emit `close`, so the UI always reaches a terminal
 	// render rather than silently freezing.
+	//
+	// #5937 — freshness gate. Broker.terminal is never cleared, and the
+	// serve-start sidecar tailer republishes an entire pre-existing sidecar
+	// (including a PRIOR run's terminal line) into the broker before any wizard
+	// connects. Without a staleness check, (1) above replays that previous run's
+	// corpse and immediately closes the stream, so the wizard never sees any
+	// live event for the run it is actually watching. Only treat the retained
+	// terminal as replayable when it is NOT older than this subscription — a
+	// terminal that fires during the subscription is still guaranteed via the
+	// live path below and the heartbeat re-assert.
 	var terminalSent bool
 	emitTerminalIfReady := func() (done bool) {
 		if group == sseWildcardGroup || terminalSent {
@@ -126,6 +136,12 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 		}
 		te, ok := s.progressBroker.LastTerminal(group)
 		if !ok {
+			return false
+		}
+		if te.TS < subscribedAt {
+			// Stale terminal from a run that already ended before this
+			// subscription started (or before serve even started). Do not
+			// replay, and do not close — stay attached for live events.
 			return false
 		}
 		if data, err := json.Marshal(te); err == nil {

--- a/internal/dashboard/handlers_progress.go
+++ b/internal/dashboard/handlers_progress.go
@@ -83,6 +83,44 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 	w.Header().Set("Connection", "keep-alive")
 	w.WriteHeader(http.StatusOK)
 
+	// subscriberToken is the caller's RebuildArgs.ProgressToken (see
+	// internal/cli's progressToken()/subscribeSSE), passed as the `token` query
+	// param — the same param name subscribeSSE writes and the one field name
+	// callers already know the token by (ProgressToken / "progress_token" on the
+	// job/onboard/maintenance JSON handlers). Empty for tokenless callers (e.g. a
+	// dashboard late-reconnect with no run in flight), which preserves today's
+	// behaviour exactly (#5326).
+	//
+	// #5937 chunk 2 — RUN-IDENTITY matching. Chunk 1 stamped every progress.Event
+	// (including the retained terminal) with RunToken. This handler now uses
+	// that to close BOTH failure modes a prior review found in the
+	// subscribe-then-clear (ClearTerminal) design:
+	//
+	//   F1 (deterministic): the wizard subscribes to SSE BEFORE it triggers its
+	//   own rebuild (see wizard_tui_run.go / wizard_split_progress.go). So by the
+	//   time this handler's connect-time emitTerminalIfReady() call below runs,
+	//   daemon.Service.Rebuild — and therefore its ClearTerminal(group) call —
+	//   has NOT fired yet. A previous run's retained terminal is still sitting in
+	//   the broker and gets replayed+closed immediately, before the new run has
+	//   even started. ClearTerminal cannot fix this: it is called too late,
+	//   inside Rebuild, which the wizard invokes only AFTER subscribing.
+	//
+	//   F2 (race): even once ClearTerminal has fired, a PREVIOUS run's terminal
+	//   can still be delivered to this subscriber via the live fan-out path
+	//   (case e := <-ch below) if it was already in that subscriber's channel
+	//   buffer, or arrives from a late/retried Publish shortly after connect
+	//   (observed up to ~120ms after a new subscriber attaches via the serve-
+	//   start sidecar tailer). The old code treated ANY terminal-phase event on
+	//   the live path as THIS subscriber's terminal and closed the stream —
+	//   re-poisoning a brand-new subscription with a dead run's outcome.
+	//
+	// Token matching closes both: replay-on-connect only fires when the
+	// retained terminal's RunToken matches (or the subscriber is tokenless), and
+	// the live-forward path below applies the identical check so a foreign-run
+	// terminal is silently dropped instead of closing the stream. See
+	// emitTerminalIfReady and the live-path check in the event loop below.
+	subscriberToken := r.URL.Query().Get("token")
+
 	// Subscribe to the broker. For the wildcard endpoint we subscribe to
 	// every group key by using an empty string; the broker treats that as its
 	// own group bucket, which is fine for heartbeat-only — but to receive
@@ -158,6 +196,14 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 		if !ok {
 			return false
 		}
+		// Token mismatch: the retained terminal belongs to a DIFFERENT run than
+		// the one this subscriber is watching (#5937 F1). Do not replay it and do
+		// not close — stay attached so the subscriber's own run's live events can
+		// still arrive. A tokenless subscriber (subscriberToken == "") always
+		// matches, preserving the #5326 late-reconnect guarantee unchanged.
+		if subscriberToken != "" && te.RunToken != subscriberToken {
+			return false
+		}
 		if data, err := json.Marshal(te); err == nil {
 			writeSSEEvent(w, "progress", string(data))
 			writeSSEEvent(w, "close", "{}")
@@ -190,6 +236,17 @@ func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) 
 				writeSSEEvent(w, "close", "{}")
 				flusher.Flush()
 				return
+			}
+			// #5937 F2 — a terminal event arriving on the LIVE path (not just the
+			// connect-time replay above) can belong to a DIFFERENT run than the one
+			// this subscriber asked for: e.g. a prior run's Publish landing a few
+			// ms after this subscriber attached. Drop it silently — do not forward
+			// it as progress and do not close the stream — so this subscriber stays
+			// attached to receive its OWN run's live events. A tokenless subscriber
+			// always matches (preserves pre-#5937 behaviour for callers that don't
+			// disambiguate by run).
+			if isTerminalEventPhase(e.Phase) && subscriberToken != "" && e.RunToken != subscriberToken {
+				continue
 			}
 			data, err := json.Marshal(e)
 			if err != nil {

--- a/internal/dashboard/handlers_progress_test.go
+++ b/internal/dashboard/handlers_progress_test.go
@@ -587,6 +587,210 @@ func TestSSE_TerminalAtRealNow_ReplayedAndClosed(t *testing.T) {
 	}
 }
 
+// TestSSE_TokenMismatch_TerminalNotReplayedOnConnect is the #5937 chunk 2 F1
+// regression test: a subscriber that supplies its OWN run token (T2) must NOT
+// have a DIFFERENT run's retained terminal (T1) replayed to it on connect —
+// and, crucially, the stream must stay open so T2's own live events can still
+// arrive afterwards. This is exactly the wizard's subscribe-then-trigger
+// ordering: it attaches before its rebuild starts, so whatever the broker has
+// retained at that instant is necessarily a PRIOR run's terminal, never its
+// own.
+func TestSSE_TokenMismatch_TerminalNotReplayedOnConnect(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	// A previous run (token T1) already completed and its terminal is retained.
+	broker.Publish(progress.Event{
+		GroupSlug:     "tok-group",
+		Phase:         progress.PhaseDone,
+		RunToken:      "T1",
+		EntitiesSoFar: 99,
+		TS:            time.Now().UnixMilli(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/tok-group?token=T2", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event. If the stale T1 terminal were (incorrectly)
+	// replayed+closed, it would show up as the very next data line instead of
+	// the live T2 event below — the assertions after prove it didn't.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// T2's own run now produces a live (non-terminal) event.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Publish(progress.Event{
+			GroupSlug: "tok-group",
+			Phase:     "extracting_ast",
+			RunToken:  "T2",
+			Module:    "mod-y",
+			TS:        time.Now().UnixMilli(),
+		})
+	}()
+
+	lines := readSSEUntil(t, reader, 5*time.Second, func(lines []string) bool {
+		return strings.Contains(strings.Join(lines, "\n"), "extracting_ast")
+	})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "extracting_ast") {
+		t.Fatalf("T2's own live event never delivered after the mismatched T1 terminal was correctly withheld: %v", lines)
+	}
+	if strings.Contains(joined, `"phase":"done"`) {
+		t.Errorf("mismatched-token (T1) terminal was replayed to the T2 subscriber before its own live event: %s", joined)
+	}
+	if strings.Contains(joined, "event: close") {
+		t.Errorf("stream was closed on a mismatched-token (T1) terminal before T2's live event arrived: %s", joined)
+	}
+}
+
+// TestSSE_TokenMismatch_LiveTerminalDoesNotClose is the #5937 chunk 2 F2
+// regression test — the subtle race: a DIFFERENT run's terminal (T1) arrives
+// on the LIVE path (not the connect-time replay) AFTER this subscriber (T2)
+// has already attached with no retained terminal present at connect time. The
+// handler must not treat T1's terminal as this subscriber's own: it must not
+// close the stream, and T2's subsequent live event must still be delivered.
+func TestSSE_TokenMismatch_LiveTerminalDoesNotClose(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/race-group?token=T2", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event — no terminal is retained yet, so nothing else
+	// should arrive from the replay-on-connect path.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// A PRIOR run's (T1) terminal arrives LIVE, shortly after this subscriber
+	// attached — the exact race the tailer can produce (~up to 120ms after
+	// subscribe).
+	go func() {
+		time.Sleep(30 * time.Millisecond)
+		broker.Publish(progress.Event{
+			GroupSlug:     "race-group",
+			Phase:         progress.PhaseDone,
+			RunToken:      "T1",
+			EntitiesSoFar: 5,
+			TS:            time.Now().UnixMilli(),
+		})
+		// Immediately after, T2's OWN live (non-terminal) event fires — this must
+		// still reach the subscriber, proving the stream was not closed by T1's
+		// terminal above.
+		time.Sleep(30 * time.Millisecond)
+		broker.Publish(progress.Event{
+			GroupSlug: "race-group",
+			Phase:     "extracting_ast",
+			RunToken:  "T2",
+			Module:    "mod-z",
+			TS:        time.Now().UnixMilli(),
+		})
+	}()
+
+	lines := readSSEUntil(t, reader, 5*time.Second, func(lines []string) bool {
+		return strings.Contains(strings.Join(lines, "\n"), "extracting_ast")
+	})
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "extracting_ast") {
+		t.Fatalf("T2's live event never arrived — the live-path mismatched-token (T1) terminal incorrectly closed the stream: %v", lines)
+	}
+	if strings.Contains(joined, `"phase":"done"`) {
+		t.Errorf("mismatched-token (T1) live terminal was forwarded to the T2 subscriber: %s", joined)
+	}
+	if strings.Contains(joined, "event: close") {
+		t.Errorf("stream was closed by a mismatched-token (T1) live terminal event: %s", joined)
+	}
+}
+
+// TestSSE_TokenMatch_TerminalReplayedAndClosed verifies requirement (iii): a
+// subscriber whose supplied token matches the retained terminal's RunToken
+// gets it replayed and the stream closed, exactly like the tokenless #5326
+// case — token matching must not regress the positive case.
+func TestSSE_TokenMatch_TerminalReplayedAndClosed(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	broker.Publish(progress.Event{
+		GroupSlug:     "match-group",
+		Phase:         progress.PhaseDone,
+		RunToken:      "T3",
+		EntitiesSoFar: 17,
+		TS:            time.Now().UnixMilli(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/match-group?token=T3", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	lines := readSSERaw(t, reader, 6, 3*time.Second)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, progress.PhaseDone) {
+		t.Errorf("expected matching-token terminal replayed on connect, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "event: close") {
+		t.Errorf("expected close event after matching-token terminal replay, got:\n%s", joined)
+	}
+}
+
+// TestSSE_Tokenless_TerminalStillReplayedAndClosed verifies requirement (iv):
+// a subscriber that supplies NO token (subscriberToken == "") still gets
+// whatever terminal is retained replayed+closed — the #5326 late-reconnect
+// guarantee is unaffected by the #5937 chunk 2 token-matching change.
+func TestSSE_Tokenless_TerminalStillReplayedAndClosed(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	broker.Publish(progress.Event{
+		GroupSlug:     "tokenless-group",
+		Phase:         progress.PhaseDone,
+		RunToken:      "T4",
+		EntitiesSoFar: 3,
+		TS:            time.Now().UnixMilli(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	// No ?token= query param at all.
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/tokenless-group", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	lines := readSSERaw(t, reader, 6, 3*time.Second)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, progress.PhaseDone) {
+		t.Errorf("expected tokenless subscriber to still get the retained terminal replayed (#5326), got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "event: close") {
+		t.Errorf("expected close event after tokenless terminal replay, got:\n%s", joined)
+	}
+}
+
 // TestSSE_TerminalReassertedOnHeartbeat verifies that when the live terminal
 // event is dropped (slow subscriber buffer full at the moment it fires), the
 // handler re-asserts the retained terminal state on the next heartbeat so the

--- a/internal/dashboard/handlers_progress_test.go
+++ b/internal/dashboard/handlers_progress_test.go
@@ -434,17 +434,17 @@ func TestSSE_TerminalReplayedOnConnect(t *testing.T) {
 	ts := newTestServerWithBroker(t, broker)
 	defer ts.Close()
 
-	// Rebuild already completed before the client connects. The TS is stamped
-	// comfortably in the future relative to "now" so it is guaranteed to be >=
-	// whatever subscribedAt the handler captures a moment later — this is the
-	// #5937 freshness gate's boundary: a terminal that is NOT older than the
-	// subscription must still be replayed+closed (see
-	// TestSSE_StaleTerminalNotReplayed for the opposite, now-corrected case).
+	// Rebuild already completed before the client connects — TS is real "now",
+	// exactly the scenario the #5326 guarantee exists for (and the case the
+	// #5937 fix must not break: see this file's package doc / handlers_progress.go
+	// for why invalidation is run-scoped via Broker.ClearTerminal, called from
+	// daemon.Service.Rebuild at the start of every new run, rather than gated
+	// on a wall-clock comparison here).
 	broker.Publish(progress.Event{
 		GroupSlug:     "late-group",
 		Phase:         progress.PhaseDone,
 		EntitiesSoFar: 123,
-		TS:            time.Now().Add(1 * time.Hour).UnixMilli(),
+		TS:            time.Now().UnixMilli(),
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -467,27 +467,35 @@ func TestSSE_TerminalReplayedOnConnect(t *testing.T) {
 	}
 }
 
-// TestSSE_StaleTerminalNotReplayed verifies the #5937 fix: when the broker's
-// retained terminal for a group predates the subscription (e.g. it belongs to
-// a previous run whose sidecar was replayed by the serve-start tailer), the
-// handler must NOT replay it and must NOT close the stream — the wizard has to
-// stay attached to actually see the NEW run's live events.
-func TestSSE_StaleTerminalNotReplayed(t *testing.T) {
+// TestSSE_ClearedTerminalNotReplayed verifies the #5937 fix's ACTUAL mechanism:
+// a terminal retained from a PREVIOUS run must not be replayed to a subscriber
+// watching a NEW run. Under the corrected, run-scoped design this is expressed
+// as "invalidate on run start (ClearTerminal — what daemon.Service.Rebuild
+// calls at the top of every Rebuild), then subscribe" — no timestamp trickery,
+// because the handler no longer compares against subscribedAt at all (see
+// handlers_progress.go's emitTerminalIfReady comment for why a wall-clock
+// comparison there cannot distinguish "stale corpse" from "legitimate late
+// reconnect" and would break the #5326 guarantee outright).
+func TestSSE_ClearedTerminalNotReplayed(t *testing.T) {
 	broker := progress.NewBroker()
 	ts := newTestServerWithBroker(t, broker)
 	defer ts.Close()
 
-	// A stale terminal from a run that finished well before this subscription.
+	// A previous run's terminal, retained by the broker...
 	broker.Publish(progress.Event{
-		GroupSlug:     "stale-group",
+		GroupSlug:     "cleared-group",
 		Phase:         progress.PhaseDone,
 		EntitiesSoFar: 42,
-		TS:            time.Now().Add(-1 * time.Hour).UnixMilli(),
+		TS:            time.Now().UnixMilli(),
 	})
+	// ...then a NEW run starts. This is what daemon.Service.Rebuild does at the
+	// top of every Rebuild call (see internal/daemon/rebuild_terminal_invalidation_test.go
+	// for the RPC-level assertion that Rebuild actually calls this).
+	broker.ClearTerminal("cleared-group")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/stale-group", nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/cleared-group", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
@@ -498,55 +506,70 @@ func TestSSE_StaleTerminalNotReplayed(t *testing.T) {
 	// Consume the connected event.
 	readSSELines(t, reader, 1, 2*time.Second)
 
-	// Nothing else should arrive for a bounded window: no replayed terminal, no
-	// close. (A heartbeat is fine/expected but must not carry "done" or "close".)
-	extra := readSSERaw(t, reader, 1, 1500*time.Millisecond)
-	joined := strings.Join(extra, "\n")
-	if strings.Contains(joined, progress.PhaseDone) {
-		t.Errorf("stale terminal was replayed even though its TS predates subscribedAt: %s", joined)
-	}
-	if strings.Contains(joined, "event: close") {
-		t.Errorf("stream was closed on a stale terminal: %s", joined)
-	}
+	// Publish a LIVE event on the same group (the new run's own progress)
+	// shortly after subscribing.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Publish(progress.Event{
+			GroupSlug: "cleared-group",
+			Phase:     "extracting_ast",
+			Module:    "mod-x",
+			TS:        time.Now().UnixMilli(),
+		})
+	}()
 
-	// Now publish a LIVE event on the same group to prove the stream is still
-	// attached and functioning (this is the whole point of the fix).
-	broker.Publish(progress.Event{
-		GroupSlug: "stale-group",
-		Phase:     "extracting_ast",
-		Module:    "mod-x",
-		TS:        time.Now().UnixMilli(),
-	})
-	live := readSSEUntil(t, reader, 3*time.Second, func(lines []string) bool {
+	// Read continuously (a SINGLE call, avoiding the leaked-goroutine race a
+	// timed-out readSSERaw followed by another read call on the same
+	// bufio.Reader would create) until the live event appears. This both
+	// proves the stream stayed open long enough to deliver it (the whole
+	// point of the fix — the wizard keeps receiving events for the run it is
+	// watching) AND, by inspecting everything collected up to that point,
+	// proves no replayed terminal / close preceded it.
+	lines := readSSEUntil(t, reader, 5*time.Second, func(lines []string) bool {
 		return strings.Contains(strings.Join(lines, "\n"), "extracting_ast")
 	})
-	if !strings.Contains(strings.Join(live, "\n"), "extracting_ast") {
-		t.Fatalf("live event never delivered after stale-terminal was correctly withheld: %v", live)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, "extracting_ast") {
+		t.Fatalf("live event for the new run never delivered after the stale terminal was correctly withheld: %v", lines)
+	}
+	// NOTE: matching on the literal `"phase":"done"` JSON field rather than the
+	// bare progress.PhaseDone ("done") constant — the latter is ALSO a
+	// substring of the unrelated "files_done" field present on the live
+	// extracting_ast event itself, which would make this a false positive.
+	if strings.Contains(joined, `"phase":"done"`) {
+		t.Errorf("cleared (previous-run) terminal was replayed to the new run's subscriber before its live event: %s", joined)
+	}
+	if strings.Contains(joined, "event: close") {
+		t.Errorf("stream was closed (on a cleared previous-run terminal) before the new run's live event: %s", joined)
 	}
 }
 
-// TestSSE_FreshTerminalStillReplayedOnConnect is the companion #5326-regression
-// guard: a terminal whose TS is AT/AFTER subscribedAt (i.e. genuinely belongs
-// to the run the client is watching, or arrived in the tiny race window right
-// at connect) must still be replayed and the stream must still close.
-func TestSSE_FreshTerminalStillReplayedOnConnect(t *testing.T) {
+// TestSSE_TerminalAtRealNow_ReplayedAndClosed is the realistic-boundary
+// regression guard the #5937 review asked for: a terminal published at real
+// wall-clock `now`, immediately followed by a subscribe (the actual timing
+// every genuine late-reconnect-after-completion case has — there is no
+// artificial "comfortably fresh" timestamp here), must still be replayed and
+// the stream must still close. This is the #5326 guarantee at the timing that
+// actually occurs in production, proving the corrected design (replay-
+// whatever's-retained, invalidated only by ClearTerminal at run start) holds
+// it — where the old subscribedAt-comparison gate provably did not (any
+// retained terminal necessarily predates the subsequent subscribedAt stamp,
+// so that gate withheld replay unconditionally).
+func TestSSE_TerminalAtRealNow_ReplayedAndClosed(t *testing.T) {
 	broker := progress.NewBroker()
 	ts := newTestServerWithBroker(t, broker)
 	defer ts.Close()
 
-	// Publish the terminal event slightly in the future relative to "now" so it
-	// is guaranteed to be >= whatever subscribedAt the handler stamps a moment
-	// later — simulating a terminal that fired during/at the subscription.
 	broker.Publish(progress.Event{
-		GroupSlug:     "fresh-group",
+		GroupSlug:     "realtime-group",
 		Phase:         progress.PhaseDone,
-		EntitiesSoFar: 99,
-		TS:            time.Now().Add(1 * time.Hour).UnixMilli(),
+		EntitiesSoFar: 7,
+		TS:            time.Now().UnixMilli(),
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/fresh-group", nil)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/realtime-group", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET: %v", err)
@@ -557,10 +580,10 @@ func TestSSE_FreshTerminalStillReplayedOnConnect(t *testing.T) {
 	lines := readSSERaw(t, reader, 6, 3*time.Second)
 	joined := strings.Join(lines, "\n")
 	if !strings.Contains(joined, progress.PhaseDone) {
-		t.Errorf("expected fresh terminal replayed on connect, got:\n%s", joined)
+		t.Errorf("expected terminal replayed on connect at the realistic now/immediate-subscribe boundary, got:\n%s", joined)
 	}
 	if !strings.Contains(joined, "event: close") {
-		t.Errorf("expected close event after fresh terminal replay, got:\n%s", joined)
+		t.Errorf("expected close event after terminal replay, got:\n%s", joined)
 	}
 }
 

--- a/internal/dashboard/handlers_progress_test.go
+++ b/internal/dashboard/handlers_progress_test.go
@@ -434,12 +434,17 @@ func TestSSE_TerminalReplayedOnConnect(t *testing.T) {
 	ts := newTestServerWithBroker(t, broker)
 	defer ts.Close()
 
-	// Rebuild already completed before the client connects.
+	// Rebuild already completed before the client connects. The TS is stamped
+	// comfortably in the future relative to "now" so it is guaranteed to be >=
+	// whatever subscribedAt the handler captures a moment later — this is the
+	// #5937 freshness gate's boundary: a terminal that is NOT older than the
+	// subscription must still be replayed+closed (see
+	// TestSSE_StaleTerminalNotReplayed for the opposite, now-corrected case).
 	broker.Publish(progress.Event{
 		GroupSlug:     "late-group",
 		Phase:         progress.PhaseDone,
 		EntitiesSoFar: 123,
-		TS:            time.Now().UnixMilli(),
+		TS:            time.Now().Add(1 * time.Hour).UnixMilli(),
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -459,6 +464,103 @@ func TestSSE_TerminalReplayedOnConnect(t *testing.T) {
 	}
 	if !strings.Contains(joined, "event: close") {
 		t.Errorf("expected close event after terminal replay, got:\n%s", joined)
+	}
+}
+
+// TestSSE_StaleTerminalNotReplayed verifies the #5937 fix: when the broker's
+// retained terminal for a group predates the subscription (e.g. it belongs to
+// a previous run whose sidecar was replayed by the serve-start tailer), the
+// handler must NOT replay it and must NOT close the stream — the wizard has to
+// stay attached to actually see the NEW run's live events.
+func TestSSE_StaleTerminalNotReplayed(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	// A stale terminal from a run that finished well before this subscription.
+	broker.Publish(progress.Event{
+		GroupSlug:     "stale-group",
+		Phase:         progress.PhaseDone,
+		EntitiesSoFar: 42,
+		TS:            time.Now().Add(-1 * time.Hour).UnixMilli(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/stale-group", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// Nothing else should arrive for a bounded window: no replayed terminal, no
+	// close. (A heartbeat is fine/expected but must not carry "done" or "close".)
+	extra := readSSERaw(t, reader, 1, 1500*time.Millisecond)
+	joined := strings.Join(extra, "\n")
+	if strings.Contains(joined, progress.PhaseDone) {
+		t.Errorf("stale terminal was replayed even though its TS predates subscribedAt: %s", joined)
+	}
+	if strings.Contains(joined, "event: close") {
+		t.Errorf("stream was closed on a stale terminal: %s", joined)
+	}
+
+	// Now publish a LIVE event on the same group to prove the stream is still
+	// attached and functioning (this is the whole point of the fix).
+	broker.Publish(progress.Event{
+		GroupSlug: "stale-group",
+		Phase:     "extracting_ast",
+		Module:    "mod-x",
+		TS:        time.Now().UnixMilli(),
+	})
+	live := readSSEUntil(t, reader, 3*time.Second, func(lines []string) bool {
+		return strings.Contains(strings.Join(lines, "\n"), "extracting_ast")
+	})
+	if !strings.Contains(strings.Join(live, "\n"), "extracting_ast") {
+		t.Fatalf("live event never delivered after stale-terminal was correctly withheld: %v", live)
+	}
+}
+
+// TestSSE_FreshTerminalStillReplayedOnConnect is the companion #5326-regression
+// guard: a terminal whose TS is AT/AFTER subscribedAt (i.e. genuinely belongs
+// to the run the client is watching, or arrived in the tiny race window right
+// at connect) must still be replayed and the stream must still close.
+func TestSSE_FreshTerminalStillReplayedOnConnect(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	// Publish the terminal event slightly in the future relative to "now" so it
+	// is guaranteed to be >= whatever subscribedAt the handler stamps a moment
+	// later — simulating a terminal that fired during/at the subscription.
+	broker.Publish(progress.Event{
+		GroupSlug:     "fresh-group",
+		Phase:         progress.PhaseDone,
+		EntitiesSoFar: 99,
+		TS:            time.Now().Add(1 * time.Hour).UnixMilli(),
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/fresh-group", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	lines := readSSERaw(t, reader, 6, 3*time.Second)
+	joined := strings.Join(lines, "\n")
+	if !strings.Contains(joined, progress.PhaseDone) {
+		t.Errorf("expected fresh terminal replayed on connect, got:\n%s", joined)
+	}
+	if !strings.Contains(joined, "event: close") {
+		t.Errorf("expected close event after fresh terminal replay, got:\n%s", joined)
 	}
 }
 

--- a/internal/progress/broker.go
+++ b/internal/progress/broker.go
@@ -74,6 +74,27 @@ func (b *Broker) LastTerminal(group string) (Event, bool) {
 	return e, ok
 }
 
+// ClearTerminal removes any retained terminal (done/error) event for group.
+//
+// Invalidation is RUN-SCOPED: the caller (daemon.Service.Rebuild) calls this
+// at the very start of every new rebuild for group — the single choke point
+// every rebuild trigger passes through, in both split and monolith mode —
+// so a terminal retained here can only ever be either (a) nothing, because no
+// run has completed since the last clear, or (b) the group's own most
+// recently completed run, never a PRIOR run's stale corpse (#5937). This is
+// deliberately NOT a wall-clock/TTL-based expiry: a subscriber's connect time
+// has no principled relationship to "is this terminal from the run I am
+// watching" — any retained terminal is, by construction, always published
+// before a given subscriber's subscribedAt, so gating replay on that
+// comparison would make the legitimate late-reconnect-after-completion case
+// (the whole point of retaining it, #5326) permanently unreachable. Safe to
+// call even when no terminal is retained for group.
+func (b *Broker) ClearTerminal(group string) {
+	b.mu.Lock()
+	delete(b.terminal, group)
+	b.mu.Unlock()
+}
+
 // wildcardGroup is the internal key used to register subscribers that want
 // events from every group. It must not be a valid group slug (group slugs are
 // non-empty URL path segments).

--- a/internal/progress/broker_test.go
+++ b/internal/progress/broker_test.go
@@ -351,3 +351,35 @@ func TestBroker_TerminalDeliveredDespiteFullBuffer(t *testing.T) {
 		t.Fatalf("terminal event lost despite retention: ok=%v got=%+v", ok, got)
 	}
 }
+
+// TestBroker_ClearTerminal verifies the #5937 run-scoped invalidation
+// primitive: ClearTerminal removes a group's retained terminal so a later
+// LastTerminal lookup finds nothing, without disturbing other groups'
+// retained terminals or requiring a subscriber. Also asserts it is a safe
+// no-op when nothing is retained for the group.
+func TestBroker_ClearTerminal(t *testing.T) {
+	b := NewBroker()
+
+	// Safe no-op: nothing retained yet.
+	b.ClearTerminal("g")
+	if _, ok := b.LastTerminal("g"); ok {
+		t.Fatal("expected no terminal event after clearing an empty group")
+	}
+
+	b.Publish(makeEvent("g", "r", PhaseDone))
+	b.Publish(makeEvent("other", "r", PhaseDone))
+
+	if _, ok := b.LastTerminal("g"); !ok {
+		t.Fatal("setup: expected retained terminal for g before clearing")
+	}
+
+	b.ClearTerminal("g")
+
+	if _, ok := b.LastTerminal("g"); ok {
+		t.Error("terminal for g still retained after ClearTerminal")
+	}
+	// Other groups must be unaffected.
+	if _, ok := b.LastTerminal("other"); !ok {
+		t.Error("ClearTerminal(\"g\") incorrectly cleared a different group's retained terminal")
+	}
+}

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -102,6 +102,13 @@ type Event struct {
 	GroupSlug string `json:"group_slug"`
 	RepoSlug  string `json:"repo_slug"`
 
+	// RunToken carries the per-run identity from RebuildArgs.ProgressToken; it
+	// lets a subscriber distinguish THIS run's terminal from a prior run's
+	// retained corpse (#5937). Empty when the caller supplied no token — e.g.
+	// a background/watcher reindex, which has no ProgressToken and no
+	// dashboard subscriber to disambiguate for.
+	RunToken string `json:"run_token,omitempty"`
+
 	// Phase is the current pipeline stage (one of the Phase* constants).
 	Phase string `json:"phase"`
 
@@ -241,6 +248,7 @@ type Tracker struct {
 	pub              Publisher
 	groupSlug        string
 	repoSlug         string
+	runToken         string
 	filesTotal       int
 	phaseStartedAtMS int64
 	currentPhase     string
@@ -250,6 +258,17 @@ type Tracker struct {
 	// can render per-module rows. Decoupled via a func so the progress package
 	// stays free of an internal/module dependency.
 	moduleResolver func(currentFile string) string
+}
+
+// SetRunToken installs the per-run identity (RebuildArgs.ProgressToken, when
+// the caller has one) that every subsequently-emitted Event stamps into
+// RunToken (#5937). Follows the same post-construction setter pattern as
+// SetModuleResolver rather than a NewTracker parameter, so existing
+// NewTracker(pub, groupSlug, repoSlug) call sites are unaffected. Pass "" (the
+// default) for runs with no per-run token — e.g. background/watcher
+// reindexes — which leaves RunToken empty on every event, exactly as today.
+func (t *Tracker) SetRunToken(tok string) {
+	t.runToken = tok
 }
 
 // SetModuleResolver installs a function that maps a repo-relative file path to
@@ -300,6 +319,7 @@ func (t *Tracker) PhaseStart(phase string, filesDone int, entitiesSoFar int) {
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            phase,
 		FilesDone:        filesDone,
 		FilesTotal:       t.filesTotal,
@@ -315,6 +335,7 @@ func (t *Tracker) Tick(phase string, filesDone int, bytesSeen int64, currentFile
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            phase,
 		FilesDone:        filesDone,
 		FilesTotal:       t.filesTotal,
@@ -340,6 +361,7 @@ func (t *Tracker) TickModule(phase, module string, moduleDone, moduleTotal int, 
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            phase,
 		FilesDone:        moduleDone,
 		FilesTotal:       moduleTotal,
@@ -364,6 +386,7 @@ func (t *Tracker) Phase(phase, passName string, entitiesSoFar int) {
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            phase,
 		FilesTotal:       t.filesTotal,
 		FilesDone:        t.filesTotal,
@@ -379,6 +402,7 @@ func (t *Tracker) AlgorithmEvent(name string, entitiesSoFar int) {
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            PhaseAlgorithms,
 		FilesTotal:       t.filesTotal,
 		FilesDone:        t.filesTotal, // algorithms run after all files are processed
@@ -394,6 +418,7 @@ func (t *Tracker) Done(filesDone, entitiesSoFar int) {
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            PhaseDone,
 		FilesDone:        filesDone,
 		FilesTotal:       t.filesTotal,
@@ -408,6 +433,7 @@ func (t *Tracker) Fail(errMsg string) {
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
 		RepoSlug:         t.repoSlug,
+		RunToken:         t.runToken,
 		Phase:            PhaseError,
 		FilesTotal:       t.filesTotal,
 		FilesDone:        0,

--- a/internal/progress/event_test.go
+++ b/internal/progress/event_test.go
@@ -121,6 +121,50 @@ func TestTracker_Done(t *testing.T) {
 	}
 }
 
+// TestTracker_RunToken verifies that a Tracker constructed with SetRunToken
+// stamps RunToken on every event it emits (#5937), and that a Tracker with no
+// run token leaves RunToken empty on every event — a background/watcher
+// reindex (no ProgressToken) must behave exactly as before this change.
+func TestTracker_RunToken(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+	trk.SetRunToken("run-tok-42")
+	trk.SetFilesTotal(10)
+
+	trk.PhaseStart(progress.PhaseScan, 0, 0)
+	trk.Tick(progress.PhaseExtractAST, 1, 100, "a.go", 0)
+	trk.TickModule(progress.PhaseExtractAST, "mod", 1, 2, 50, "b.go", 0)
+	trk.Phase(progress.PhaseDetectLinks, "cross-repo links", 0)
+	trk.AlgorithmEvent("PageRank", 5)
+	trk.Done(10, 20)
+	trk.Fail("boom")
+
+	if len(col.Events) != 7 {
+		t.Fatalf("expected 7 events, got %d", len(col.Events))
+	}
+	for i, e := range col.Events {
+		if e.RunToken != "run-tok-42" {
+			t.Errorf("event[%d] (phase=%s) RunToken = %q, want %q", i, e.Phase, e.RunToken, "run-tok-42")
+		}
+	}
+}
+
+// TestTracker_EmptyRunTokenUnaffected verifies a Tracker with no SetRunToken
+// call (the default, e.g. a background/watcher reindex) emits events with an
+// empty RunToken — additive-only, no behaviour change for untokened runs.
+func TestTracker_EmptyRunTokenUnaffected(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+	trk.Done(1, 1)
+
+	if len(col.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(col.Events))
+	}
+	if got := col.Events[0].RunToken; got != "" {
+		t.Errorf("RunToken = %q, want empty for a Tracker with no run token set", got)
+	}
+}
+
 // TestTracker_Fail verifies that Fail emits a PhaseError event with the
 // error message.
 func TestTracker_Fail(t *testing.T) {

--- a/internal/progress/sidecar.go
+++ b/internal/progress/sidecar.go
@@ -67,6 +67,13 @@ type SidecarLine struct {
 	RepoSlug  string `json:"repo_slug"`
 	Module    string `json:"module,omitempty"`
 
+	// RunToken carries Event.RunToken (#5937) — the per-run identity from
+	// RebuildArgs.ProgressToken — across the process boundary so a split-mode
+	// dashboard reader can distinguish THIS run's terminal from a prior run's
+	// retained corpse. Empty for runs with no per-run token (background/
+	// watcher reindexes), preserving today's behaviour byte-for-byte.
+	RunToken string `json:"run_token,omitempty"`
+
 	Phase      string `json:"phase"`
 	FilesDone  int    `json:"files_done"`
 	FilesTotal int    `json:"files_total"`
@@ -89,6 +96,7 @@ func lineFromEvent(e Event) SidecarLine {
 		GroupSlug:   e.GroupSlug,
 		RepoSlug:    e.RepoSlug,
 		Module:      e.Module,
+		RunToken:    e.RunToken,
 		Phase:       e.Phase,
 		FilesDone:   e.FilesDone,
 		FilesTotal:  e.FilesTotal,
@@ -107,6 +115,7 @@ func (l SidecarLine) toEvent() Event {
 		GroupSlug:     l.GroupSlug,
 		RepoSlug:      l.RepoSlug,
 		Module:        l.Module,
+		RunToken:      l.RunToken,
 		Phase:         l.Phase,
 		FilesDone:     l.FilesDone,
 		FilesTotal:    l.FilesTotal,

--- a/internal/progress/sidecar_test.go
+++ b/internal/progress/sidecar_test.go
@@ -40,6 +40,7 @@ func projectFields(e Event) Event {
 		GroupSlug:     e.GroupSlug,
 		RepoSlug:      e.RepoSlug,
 		Module:        e.Module,
+		RunToken:      e.RunToken,
 		Phase:         e.Phase,
 		FilesDone:     e.FilesDone,
 		FilesTotal:    e.FilesTotal,
@@ -847,7 +848,7 @@ func TestResetClearsPendingState(t *testing.T) {
 // TestLineFromEventRoundTrip exercises the marshal/unmarshal helpers directly.
 func TestLineFromEventRoundTrip(t *testing.T) {
 	e := Event{
-		GroupSlug: "g", RepoSlug: "r", Module: "m",
+		GroupSlug: "g", RepoSlug: "r", Module: "m", RunToken: "run-tok-1",
 		Phase: PhaseExtractAST, FilesDone: 7, FilesTotal: 9,
 		EntitiesSoFar: 11, CurrentFile: "x.go", TS: 123,
 	}
@@ -871,5 +872,57 @@ func TestLineFromEventRoundTrip(t *testing.T) {
 	// Verify the on-the-wire JSON keys match the documented schema.
 	if !strings.Contains(string(b), `"files_done"`) || !strings.Contains(string(b), `"entities"`) {
 		t.Fatalf("unexpected JSON schema: %s", b)
+	}
+	if !strings.Contains(string(b), `"run_token":"run-tok-1"`) {
+		t.Fatalf("RunToken missing from wire JSON: %s", b)
+	}
+	// Empty RunToken is omitted (omitempty) — no field bloat for the common
+	// no-token background/watcher-reindex case.
+	noTokLine := lineFromEvent(Event{GroupSlug: "g", Phase: PhaseScan})
+	noTokB, err := json.Marshal(noTokLine)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(noTokB), "run_token") {
+		t.Fatalf("empty RunToken should be omitted from wire JSON: %s", noTokB)
+	}
+}
+
+// TestSidecarWriterRunTokenRoundTrip verifies RunToken survives a real
+// write-then-read across the SidecarWriter/SidecarReader process boundary
+// (#5937): a subscriber reading the group's NDJSON file must see the same
+// per-run token the producer's Tracker stamped.
+func TestSidecarWriterRunTokenRoundTrip(t *testing.T) {
+	setHome(t)
+	group := "run-token-group"
+	w, err := NewSidecarWriter(group, WithFlushInterval(5*time.Millisecond))
+	if err != nil {
+		t.Fatalf("NewSidecarWriter: %v", err)
+	}
+	defer w.Close()
+
+	w.Publish(Event{GroupSlug: group, RepoSlug: "r1", Phase: PhaseExtractAST, RunToken: "tok-abc"})
+	w.Publish(Event{GroupSlug: group, RepoSlug: "r1", Phase: PhaseDone, RunToken: "tok-abc"})
+
+	// The terminal (PhaseDone) event takes the guaranteed pending-terminal
+	// path and flushes promptly (see SidecarWriter.Publish), but the flush
+	// goroutine still runs asynchronously — poll with a deadline rather than
+	// reading once immediately, mirroring TestTerminalFlushesPromptly.
+	deadline := time.Now().Add(2 * time.Second)
+	var evs []Event
+	for time.Now().Before(deadline) {
+		evs = drainReader(t, group)
+		if len(evs) >= 2 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if len(evs) == 0 {
+		t.Fatal("no events read back from sidecar")
+	}
+	for _, e := range evs {
+		if e.RunToken != "tok-abc" {
+			t.Errorf("event %+v: RunToken = %q, want %q", e, e.RunToken, "tok-abc")
+		}
 	}
 }


### PR DESCRIPTION
## Problem

`grafel wizard`'s per-module progress rows never rendered: the detail pane stayed
on `waiting for the indexer to report…` for the entire index and persisted at
100%. Cause: the SSE handler replayed a STALE retained terminal (from a PREVIOUS
run) on connect and closed the stream before any live event reached the client.
The producer and the wiztui fold were both intact — this was purely a transport
bug.

## Why previous approaches failed (kept in history for context)

- A wall-clock freshness gate (`te.TS < subscribedAt`) makes the #5326
  replay-on-connect guarantee unreachable by construction.
- Clearing the broker terminal at `Service.Rebuild` fires AFTER the wizard has
  already subscribed (F1), and cannot exclude a prior run's terminal arriving
  ~120ms later via the tailer (F2).

Both failed because the handler could not tell "this run" from "a prior run."

## Fix: run-identity matching

The clients already generate a per-run `ProgressToken` and pass it to the sibling
`/api/index-progress` poll API. This threads that identity into the progress
stream so the SSE handler can match it.

**Chunk 1 — token end-to-end into events.** `progress.Event.RunToken` (+ sidecar
projection), stamped by the Tracker (including `Done`/`Fail`), carried into the
engine child via `SubprocessIndexOptions.RunToken` → `--run-token`, and threaded
from `RebuildArgs.ProgressToken` in `daemonRebuildFuncCore` (in-process, subprocess,
and the group-level `linkTrk`). Additive: an empty token behaves exactly as today.

**Chunk 2 — token-filtered SSE.** `serveSSE` reads `?token=`. A retained or live
terminal is replayed/forwarded only when its `RunToken` matches the subscriber's
token; on mismatch it is withheld and the stream stays open for live events. Both
the replay-on-connect path (F1) and the live-forward path (F2) are guarded. A
tokenless subscriber is byte-for-byte unchanged (preserves the #5326 late-reconnect
guarantee). The wizard passes its existing token to `subscribeSSE`.

Also included (independently reviewed earlier): the tailer `seedIfAlreadyTerminal`
hunk (stops serve-start re-poisoning) and the `indexview.go` `!v.queryable` guard.

## Review

Three independent adversarial reviews across the redesigns; the final one verified
the crux against real code: in split mode the FINAL group-scoped terminal
(`linkTrk.Done`, the tailer's stop condition) carries the token, and `Done`/`Fail`
stamp it on per-repo children too. Mutation-tested: neutering either guard fails
its test; the F2 test publishes the mismatched terminal LIVE 30ms after subscribe
(genuine live-path coverage). Completion is driven by the request-ack probe, not
the SSE terminal, so even a hypothetically-dropped token cannot hang the wizard —
no inverse regression is reachable.

## Verification

Full affected-package suites green (dashboard, progress, all daemon subpackages,
cli, cli/wiztui, cmd/grafel); `-race` clean; `gofmt`/`vet` clean.

## Known-redundant

`Broker.ClearTerminal` + its `Service.Rebuild` call are left wired as harmless
defense-in-depth (token matching is the load-bearing fix). Removing them is
cleanup, not correctness.

Closes #5937
