### PR TITLE
fix(status): count SCOPE.Process entities in the process-flow stat (closes #5952)

### DIFF
--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -165,7 +166,7 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 						s.HTTPEndpoints++
 					}
 					// Check for process flows: SCOPE.Process or process kind.
-					if e.Kind == "process" || (len(e.Kind) > 14 && e.Kind[:6] == "SCOPE." && e.Kind[6:] == "Process") {
+					if e.Kind == "process" || strings.HasPrefix(e.Kind, "SCOPE.Process") {
 						s.ProcessFlows++
 					}
 				}

--- a/internal/cli/status_stats_test.go
+++ b/internal/cli/status_stats_test.go
@@ -292,6 +292,44 @@ func TestComputeStatusSummary_ColdIndexNoSidecar(t *testing.T) {
 	}
 }
 
+// TestComputeStatusSummary_ProcessFlows guards against regressing the
+// process-flow counter predicate: it must count both the bare "process" kind
+// and the real "SCOPE.Process" kind emitted by engine.RunProcessFlow (Pass 7).
+func TestComputeStatusSummary_ProcessFlows(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath := filepath.Join(tmpDir, "flowrepo")
+	os.MkdirAll(repoPath, 0o755)
+	stateDir := daemon.StateDirForRepo(repoPath)
+	os.MkdirAll(stateDir, 0o755)
+
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 3, Relationships: 0, Files: 1},
+		Entities: []graph.Entity{
+			{ID: "p1", Name: "P1", Kind: "SCOPE.Process", SourceFile: "a.go", Language: "go"},
+			{ID: "p2", Name: "P2", Kind: "process", SourceFile: "a.go", Language: "go"},
+			{ID: "f3", Name: "F3", Kind: "function", SourceFile: "a.go", Language: "go"},
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	repos := []registry.Repo{{Slug: "flowrepo", Path: repoPath}}
+	summary := ComputeStatusSummary("grp", repos)
+
+	if _, ok := summary.RepoStats["flowrepo"]; !ok {
+		t.Fatal("flowrepo not found in RepoStats")
+	}
+	if summary.ProcessFlows != 2 {
+		t.Errorf("ProcessFlows = %d, want 2 (one SCOPE.Process + one process)", summary.ProcessFlows)
+	}
+}
+
 // TestComputeStatusSummary_TrulyNeverIndexed asserts the negative case still
 // reports 0/never when there is no graph.fb at all.
 func TestComputeStatusSummary_TrulyNeverIndexed(t *testing.T) {


### PR DESCRIPTION
Fixes the broken length guard in `internal/cli/status_stats.go` that made `grafel status` always report 0 flows. One-line predicate fix matching the proven sibling in rebuild_summary.go. Golden test added. Closes #5952.