### PR TITLE
obs(index): opt-in memory-trace for the index-internal subprocess (closes #5956)

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/jobs"
 	"github.com/cajasmota/grafel/internal/mcp"
+	"github.com/cajasmota/grafel/internal/memtrace"
 	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/quality"
@@ -664,6 +665,25 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 	// ADR-0016 flip-day (#808): log the active graph format mode so users
 	// can confirm the daemon is running in the expected configuration.
 	logger.Info("graph format: fb-default (json-fallback enabled) — graph.fb written on every index; --skip-json opt-in drops graph.json")
+
+	// #5956 memtrace M3: whole-machine rollup. This process self-samples
+	// into the SAME GRAFEL_MEMTRACE_DIR the index-internal child writes into
+	// (inherited automatically — RunSubprocessIndex builds the child's env
+	// from os.Environ(), so setting this var before starting the daemon is
+	// enough for both the engine/serve process AND every child it forks to
+	// trace). No phase concept applies to the long-running engine/serve
+	// plane, so phaseFn is nil (every sample's phase is ""). Inert by
+	// default: Start returns nil (no goroutine, no file) when
+	// GRAFEL_MEMTRACE_DIR is unset. Runs for the lifetime of the process —
+	// no Stop() call needed, matching other fire-and-forget daemon-startup
+	// singletons (e.g. installCapReloadHandler above).
+	memtraceRole := "serve"
+	if runMode == daemonRunModeEngine {
+		memtraceRole = "engine"
+	}
+	memtrace.Start(memtraceRole, nil, func(format string, args ...any) {
+		logger.Warn(fmt.Sprintf("memtrace: "+format, args...))
+	})
 
 	// Resolve dashboard port: env var > default. A future
 	// ~/.config/grafel/daemon.toml can add more overrides.

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -38,6 +38,7 @@ import (
 	idiff "github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/ingest"
 	"github.com/cajasmota/grafel/internal/install/detect"
+	"github.com/cajasmota/grafel/internal/memtrace"
 	"github.com/cajasmota/grafel/internal/module"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/resolve"
@@ -70,6 +71,20 @@ const (
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 	PassTestsWalkUp   = "tests-walkup"   // Pass 3.5: derive TESTS edges via helper walk-up
 )
+
+// memtraceLogOnce guards memtraceLogf so a chatty failure mode (e.g. a
+// GRAFEL_MEMTRACE_DIR that goes unwritable partway through a long index)
+// logs at most once, matching the best-effort contract in internal/memtrace.
+var memtraceLogOnce sync.Once
+
+// memtraceLogf is the best-effort logger passed to memtrace.Start: a single
+// stderr line, at most once per process, never a fatal error. memtrace is
+// purely diagnostic and must never affect the index result.
+func memtraceLogf(format string, args ...any) {
+	memtraceLogOnce.Do(func() {
+		fmt.Fprintf(os.Stderr, "grafel: "+format+"\n", args...)
+	})
+}
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
@@ -859,6 +874,15 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	trk := progress.NewTracker(pub, i.groupSlug, repoSlug)
 	trk.SetRunToken(i.runToken)
+
+	// #5956 memtrace M1/M2: opt-in phase-tagged memstats sampler + heap
+	// profiles, gated entirely behind GRAFEL_MEMTRACE_DIR. Start returns nil
+	// (no goroutine, no file) when the env var is unset, so this is zero
+	// overhead by default. The phase comes from trk.CurrentPhase — the SAME
+	// state the UI already reports — so the trace cannot drift from progress
+	// events. Best-effort: no error from memtrace can reach the index result.
+	memSampler := memtrace.Start("child", trk.CurrentPhase, memtraceLogf)
+	defer memSampler.Stop()
 
 	// M4 sparse-checkout (#2181): probe the repo BEFORE the walk so the
 	// walker can filter out files that are not present locally. The result is

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -351,7 +351,10 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	cmd := exec.CommandContext(ctx, binary, args...)
 	// Daemon's state dirs are inherited via the env (GRAFEL_DAEMON_ROOT,
 	// GRAFEL_HOME). Start from the daemon's full environment so the child
-	// resolves the same state dirs and caps.
+	// resolves the same state dirs and caps. This is also how #5956
+	// GRAFEL_MEMTRACE_DIR (+ GRAFEL_MEMTRACE_INTERVAL) reaches the
+	// index-internal child: no dedicated flag is needed because the child
+	// already inherits the parent's complete environment here.
 	cmd.Env = os.Environ()
 	// Resolve the child-process GOMAXPROCS. resolveChildGOMAXPROCS dispatches on
 	// interactive-vs-background:

--- a/internal/memtrace/memtrace.go
+++ b/internal/memtrace/memtrace.go
@@ -1,0 +1,305 @@
+// Package memtrace is opt-in memory-trace instrumentation for the index
+// pipeline (#5956, Phase 0 of the write-side bounded-memory epic #5890). It
+// is PURELY ADDITIVE and inert unless GRAFEL_MEMTRACE_DIR is set:
+//
+//   - M1: a goroutine samples runtime.ReadMemStats + process RSS on a
+//     ticker, tags each sample with the currently-active phase (read from
+//     the existing progress.Tracker via a caller-supplied phaseFn — no
+//     parallel phase state), and appends one NDJSON line per sample.
+//   - M2: a runtime/pprof heap profile is written at each phase transition
+//     and once at the observed peak heap_inuse.
+//   - M3: the engine and serve processes call Start with role "engine" /
+//     "serve" (no phase — nil phaseFn) so a single trace directory can be
+//     merged, on ts, into a whole-machine curve alongside the child's
+//     "child" role.
+//
+// Hard constraints (see docs/superpowers/specs/2026-07-24-index-memory-
+// observability-design.md):
+//   - Inert by default: GRAFEL_MEMTRACE_DIR unset => Start starts no
+//     goroutine and creates no file.
+//   - Never affects the index: every failure path (dir not writable,
+//     profile write fails) disables the sampler silently and returns nil;
+//     no error from this package ever propagates to a caller's index
+//     result. Mirrors internal/cli/watch.go's "registry write failure must
+//     never stop the watcher" precedent.
+//   - Numeric memstats + symbol names only; profiles are written only under
+//     the operator-specified directory, never to logs or telemetry.
+package memtrace
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"runtime/pprof"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// DirEnv is the single opt-in gate for the entire package. Unset (the
+// default) means fully inert: Start returns nil immediately, before any
+// goroutine, ticker, or file is created.
+const DirEnv = "GRAFEL_MEMTRACE_DIR"
+
+// IntervalEnv overrides the sampling interval (Go duration syntax, e.g.
+// "500ms"). Invalid or non-positive values fall back to DefaultInterval.
+const IntervalEnv = "GRAFEL_MEMTRACE_INTERVAL"
+
+// DefaultInterval is the sampling cadence when IntervalEnv is unset/invalid.
+const DefaultInterval = 250 * time.Millisecond
+
+// Record is one NDJSON line. Field set matches the design doc exactly:
+// numeric memstats + RSS + role, tagged with the phase active at sample
+// time. All memory fields are bytes; NumGC is the cumulative GC count.
+type Record struct {
+	TS          int64  `json:"ts"`
+	Phase       string `json:"phase"`
+	HeapAlloc   uint64 `json:"heap_alloc"`
+	HeapInuse   uint64 `json:"heap_inuse"`
+	HeapSys     uint64 `json:"heap_sys"`
+	HeapObjects uint64 `json:"heap_objects"`
+	StackInuse  uint64 `json:"stack_inuse"`
+	NextGC      uint64 `json:"next_gc"`
+	NumGC       uint32 `json:"num_gc"`
+	RSSBytes    uint64 `json:"rss_bytes"`
+	Role        string `json:"role"`
+}
+
+// Sampler owns the background goroutine, the open NDJSON file, and the
+// best-effort heap-profile writer. Obtain one via Start; nil is a valid,
+// safe-to-use "disabled" value (Stop on a nil *Sampler is a no-op).
+type Sampler struct {
+	role     string
+	phaseFn  func() string
+	interval time.Duration
+	runDir   string
+
+	mu       sync.Mutex // guards f and disabled; sampleOnce runs on one goroutine but Stop may race it
+	f        *os.File
+	disabled bool
+
+	lastPhase     string
+	heapSeq       int
+	peakHeapInuse uint64
+
+	logf func(format string, args ...any) // best-effort logger; nil = silent
+
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	doneCh   chan struct{}
+}
+
+// Start begins sampling if and only if GRAFEL_MEMTRACE_DIR is set and the
+// run directory + NDJSON file can be created. role identifies the emitting
+// process ("child", "engine", "serve"). phaseFn is polled once per tick to
+// tag the sample; pass nil for processes with no phase concept (engine,
+// serve) — the sample's phase field is then always "".
+//
+// On any setup failure (dir not writable, file open fails), Start logs at
+// most once via logf (which may be nil for silent) and returns nil. Callers
+// should treat a nil *Sampler as "disabled" — Stop is safe to call on nil.
+func Start(role string, phaseFn func() string, logf func(format string, args ...any)) *Sampler {
+	dir := os.Getenv(DirEnv)
+	if dir == "" {
+		// Inert by default: no goroutine, no ticker, no file.
+		return nil
+	}
+	interval := DefaultInterval
+	if v := os.Getenv(IntervalEnv); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			interval = d
+		}
+	}
+	if phaseFn == nil {
+		phaseFn = func() string { return "" }
+	}
+
+	runID := newRunID(role)
+	runDir := filepath.Join(dir, runID)
+	if err := os.MkdirAll(runDir, 0o755); err != nil {
+		logOnce(logf, "memtrace: disabled (mkdir %s: %v)", runDir, err)
+		return nil
+	}
+	fpath := filepath.Join(runDir, role+".ndjson")
+	f, err := os.OpenFile(fpath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		logOnce(logf, "memtrace: disabled (open %s: %v)", fpath, err)
+		return nil
+	}
+
+	s := &Sampler{
+		role:     role,
+		phaseFn:  phaseFn,
+		interval: interval,
+		runDir:   runDir,
+		f:        f,
+		logf:     logf,
+		stopCh:   make(chan struct{}),
+		doneCh:   make(chan struct{}),
+	}
+	go s.loop()
+	return s
+}
+
+// Dir returns the run directory this sampler writes into (empty for a nil
+// or disabled Sampler). Exposed mainly for tests.
+func (s *Sampler) Dir() string {
+	if s == nil {
+		return ""
+	}
+	return s.runDir
+}
+
+// Stop halts the sampling goroutine and closes the NDJSON file. Safe to
+// call on a nil *Sampler (no-op) and safe to call more than once.
+func (s *Sampler) Stop() {
+	if s == nil {
+		return
+	}
+	s.stopOnce.Do(func() {
+		close(s.stopCh)
+		<-s.doneCh
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		if s.f != nil {
+			_ = s.f.Close()
+			s.f = nil
+		}
+	})
+}
+
+func (s *Sampler) loop() {
+	defer close(s.doneCh)
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case <-ticker.C:
+			s.sampleOnce()
+		}
+	}
+}
+
+// sampleOnce reads runtime.MemStats + process RSS, tags with the current
+// phase, appends one NDJSON line, and best-effort writes a heap profile on
+// a phase transition or a new observed peak heap_inuse. Every failure here
+// is swallowed (at most one log line) — this subsystem must never affect
+// the index.
+func (s *Sampler) sampleOnce() {
+	s.mu.Lock()
+	if s.disabled {
+		s.mu.Unlock()
+		return
+	}
+	s.mu.Unlock()
+
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	rss, _ := process.RSSBytes(os.Getpid()) // best-effort: 0 on error, never fatal
+
+	phase := s.phaseFn()
+	rec := Record{
+		TS:          time.Now().UnixMilli(),
+		Phase:       phase,
+		HeapAlloc:   ms.HeapAlloc,
+		HeapInuse:   ms.HeapInuse,
+		HeapSys:     ms.HeapSys,
+		HeapObjects: ms.HeapObjects,
+		StackInuse:  ms.StackInuse,
+		NextGC:      ms.NextGC,
+		NumGC:       ms.NumGC,
+		RSSBytes:    rss,
+		Role:        s.role,
+	}
+
+	s.writeRecord(rec)
+
+	// M2: heap profile at phase transition + new peak. Best-effort, never
+	// blocks or errors out to the caller.
+	phaseChanged := phase != s.lastPhase
+	s.lastPhase = phase
+	if phaseChanged {
+		s.writeHeapProfile(phase, true)
+	}
+	if ms.HeapInuse > s.peakHeapInuse {
+		s.peakHeapInuse = ms.HeapInuse
+		// "peak" is overwritten in place (fixed filename, no growing seq):
+		// heap_inuse tends to climb monotonically through most of a phase,
+		// so treating every new high-water mark as its own numbered file
+		// would produce one profile per sample during ramp-up. Overwriting
+		// keeps exactly one profile on disk reflecting the LATEST observed
+		// peak, which is what the design doc asks for ("once at the
+		// observed peak") without the file-count blowup.
+		s.writeHeapProfile("peak", false)
+	}
+}
+
+func (s *Sampler) writeRecord(rec Record) {
+	b, err := json.Marshal(rec)
+	if err != nil {
+		return // cannot happen for this struct, but never propagate regardless
+	}
+	b = append(b, '\n')
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.disabled || s.f == nil {
+		return
+	}
+	if _, err := s.f.Write(b); err != nil {
+		// Best-effort: disable silently rather than let a write failure
+		// (e.g. disk full, dir removed underneath us) ever surface into the
+		// index. Log at most once.
+		logOnce(s.logf, "memtrace: disabling sampler (write %s: %v)", s.f.Name(), err)
+		_ = s.f.Close()
+		s.f = nil
+		s.disabled = true
+	}
+}
+
+// writeHeapProfile writes a pprof heap snapshot named heap-<tag>-<seq>.pprof.
+// When numbered is false the file name omits a per-call seq and is instead
+// overwritten in place on every call (used for the "peak" tag — see caller).
+func (s *Sampler) writeHeapProfile(tag string, numbered bool) {
+	var name string
+	if numbered {
+		s.heapSeq++
+		name = fmt.Sprintf("heap-%s-%d.pprof", tag, s.heapSeq)
+	} else {
+		name = fmt.Sprintf("heap-%s.pprof", tag)
+	}
+	path := filepath.Join(s.runDir, name)
+	f, err := os.Create(path)
+	if err != nil {
+		return // best-effort; a missing profile never affects the index
+	}
+	defer f.Close()
+	_ = pprof.WriteHeapProfile(f) // best-effort: ignore write errors
+}
+
+// newRunID derives a directory name unique to this process invocation so
+// concurrent index jobs (and concurrent engine/serve processes) never
+// collide on the same NDJSON file. Prefixed with role so a directory
+// listing under GRAFEL_MEMTRACE_DIR is self-describing at a glance.
+func newRunID(role string) string {
+	return role + "-" + strconv.FormatInt(time.Now().UnixNano(), 36) + "-" + strconv.Itoa(os.Getpid())
+}
+
+// logOnce calls logf at most once per process for a given message shape by
+// simply calling it — callers pass a logf that is already itself cheap/rare
+// (phase transitions + setup failures are infrequent), so no additional
+// dedup bookkeeping is needed. A nil logf is silent, matching the "log at
+// most once" best-effort contract without forcing every caller to supply a
+// logger.
+func logOnce(logf func(format string, args ...any), format string, args ...any) {
+	if logf == nil {
+		return
+	}
+	logf(format, args...)
+}

--- a/internal/memtrace/memtrace.go
+++ b/internal/memtrace/memtrace.go
@@ -172,8 +172,28 @@ func (s *Sampler) Stop() {
 	})
 }
 
+// sampleFn is the seam loop() invokes on every tick. It is a package-level
+// var (rather than a direct s.sampleOnce() call) purely so a test can
+// substitute a panicking implementation to exercise the recover() below
+// without needing OS-level fault injection. Production code never
+// reassigns it — do not use this for anything but the panic-containment
+// test.
+var sampleFn = func(s *Sampler) { s.sampleOnce() }
+
 func (s *Sampler) loop() {
 	defer close(s.doneCh)
+	// Defense-in-depth: the package contract is "must NEVER affect the
+	// index." No path in sampleOnce is known to panic today (CurrentPhase is
+	// an atomic load, process.RSSBytes returns an error rather than
+	// panicking, pprof errors are ignored) — but a panic anywhere on this
+	// goroutine must never crash the host process. Recover, log at most
+	// once, and let the goroutine exit; a persistently panicking sampler
+	// disables itself rather than spinning or retrying.
+	defer func() {
+		if r := recover(); r != nil {
+			logOnce(s.logf, "memtrace: sampler goroutine panicked, disabling (role=%s): %v", s.role, r)
+		}
+	}()
 	ticker := time.NewTicker(s.interval)
 	defer ticker.Stop()
 	for {
@@ -181,7 +201,7 @@ func (s *Sampler) loop() {
 		case <-s.stopCh:
 			return
 		case <-ticker.C:
-			s.sampleOnce()
+			sampleFn(s)
 		}
 	}
 }

--- a/internal/memtrace/memtrace_test.go
+++ b/internal/memtrace/memtrace_test.go
@@ -1,0 +1,191 @@
+package memtrace
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestStart_InertWhenEnvUnset is the load-bearing test: with
+// GRAFEL_MEMTRACE_DIR unset, Start must not start a goroutine or create any
+// file. We assert this by checking Start returns nil and that no files
+// exist in a scratch dir we point elsewhere (nothing to create there since
+// the dir env itself is unset).
+func TestMemtraceSampler_InertWhenEnvUnset(t *testing.T) {
+	t.Setenv(DirEnv, "")
+	os.Unsetenv(DirEnv)
+
+	s := Start("child", nil, nil)
+	if s != nil {
+		t.Fatalf("Start() = %+v, want nil when %s is unset", s, DirEnv)
+	}
+
+	// Extra assurance: a Stop on the nil result must not panic.
+	s.Stop()
+}
+
+// TestStart_WritesNDJSON verifies the sampler writes well-formed NDJSON with
+// every expected field once GRAFEL_MEMTRACE_DIR is set.
+func TestMemtraceSampler_WritesNDJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(DirEnv, dir)
+	t.Setenv(IntervalEnv, "10ms")
+
+	s := Start("child", func() string { return "extracting_ast" }, nil)
+	if s == nil {
+		t.Fatal("Start() = nil, want a live sampler when GRAFEL_MEMTRACE_DIR is set")
+	}
+	// Let a handful of ticks fire.
+	time.Sleep(60 * time.Millisecond)
+	s.Stop()
+
+	path := filepath.Join(s.Dir(), "child.ndjson")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open %s: %v", path, err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	lines := 0
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var rec Record
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("line %d: not valid JSON: %v (%q)", lines, err, line)
+		}
+		if rec.TS == 0 {
+			t.Errorf("line %d: ts is zero", lines)
+		}
+		if rec.Phase != "extracting_ast" {
+			t.Errorf("line %d: phase = %q, want extracting_ast", lines, rec.Phase)
+		}
+		if rec.Role != "child" {
+			t.Errorf("line %d: role = %q, want child", lines, rec.Role)
+		}
+		if rec.HeapSys == 0 {
+			t.Errorf("line %d: heap_sys is zero, want a real memstat", lines)
+		}
+		lines++
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if lines == 0 {
+		t.Fatal("no NDJSON lines written")
+	}
+}
+
+// TestStart_NonWritableDirDisablesSilently verifies that when the run
+// directory cannot be created (a regular file sits where a directory is
+// expected), Start disables itself and returns nil rather than erroring or
+// panicking.
+func TestMemtraceSampler_NonWritableDirDisablesSilently(t *testing.T) {
+	base := t.TempDir()
+	// Create a FILE at the path memtrace would need to MkdirAll as a
+	// directory, so MkdirAll fails deterministically on every OS.
+	blocker := filepath.Join(base, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	dirEnv := filepath.Join(blocker, "sub") // parent "blocker" is a file, not a dir
+	t.Setenv(DirEnv, dirEnv)
+
+	var loggedCount int32
+	logf := func(format string, args ...any) {
+		atomic.AddInt32(&loggedCount, 1)
+	}
+
+	s := Start("child", nil, logf)
+	if s != nil {
+		t.Fatalf("Start() = %+v, want nil when the run dir cannot be created", s)
+	}
+	if atomic.LoadInt32(&loggedCount) == 0 {
+		t.Error("expected at least one best-effort log line on setup failure")
+	}
+	// Must not panic.
+	s.Stop()
+}
+
+// TestPhaseFollowsTracker feeds a sequence of phases through a phaseFn (as
+// the real caller wires progress.Tracker.CurrentPhase) and asserts the
+// recorded trace observes them in order, with no parallel phase state.
+func TestMemtraceSampler_PhaseFollowsTracker(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(DirEnv, dir)
+	t.Setenv(IntervalEnv, "5ms")
+
+	phases := []string{"scanning", "extracting_ast", "resolving_refs", "writing_graph"}
+	var idx int32
+
+	s := Start("child", func() string {
+		i := atomic.LoadInt32(&idx)
+		if int(i) >= len(phases) {
+			i = int32(len(phases) - 1)
+		}
+		return phases[i]
+	}, nil)
+	if s == nil {
+		t.Fatal("Start() = nil, want a live sampler")
+	}
+
+	for i := 1; i < len(phases); i++ {
+		time.Sleep(20 * time.Millisecond)
+		atomic.StoreInt32(&idx, int32(i))
+	}
+	time.Sleep(20 * time.Millisecond)
+	s.Stop()
+
+	path := filepath.Join(s.Dir(), "child.ndjson")
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer f.Close()
+
+	var seen []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		var rec Record
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			t.Fatalf("bad line: %v", err)
+		}
+		if len(seen) == 0 || seen[len(seen)-1] != rec.Phase {
+			seen = append(seen, rec.Phase)
+		}
+	}
+
+	if len(seen) == 0 {
+		t.Fatal("no phases observed")
+	}
+	// The observed distinct-phase sequence must be a subsequence of the fed
+	// phases, in order, with no phase out of place (this is what would catch
+	// drift between the tracker's phase and the trace).
+	pi := 0
+	for _, ph := range seen {
+		found := false
+		for pi < len(phases) {
+			if phases[pi] == ph {
+				found = true
+				pi++
+				break
+			}
+			pi++
+		}
+		if !found {
+			t.Errorf("observed phase %q not found in expected order %v (already consumed up to %d)", ph, phases, pi)
+		}
+	}
+}

--- a/internal/memtrace/memtrace_test.go
+++ b/internal/memtrace/memtrace_test.go
@@ -189,3 +189,51 @@ func TestMemtraceSampler_PhaseFollowsTracker(t *testing.T) {
 		}
 	}
 }
+
+// TestMemtraceSampler_PanicInSampleRecovered is the panic-containment test:
+// it substitutes sampleFn with a panicking implementation and asserts (a)
+// the process/test does not crash, (b) the sampler goroutine terminates
+// (doneCh closes) rather than spinning or crashing the process, and (c) the
+// best-effort logger is invoked at most once — mirroring the "must NEVER
+// affect the index" contract for a caller that would otherwise be sitting
+// on the other side of this goroutine doing real indexing work.
+func TestMemtraceSampler_PanicInSampleRecovered(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(DirEnv, dir)
+	t.Setenv(IntervalEnv, "5ms")
+
+	orig := sampleFn
+	sampleFn = func(s *Sampler) { panic("injected test panic: simulated sampler fault") }
+	defer func() { sampleFn = orig }()
+
+	var logCount int32
+	logf := func(format string, args ...any) {
+		atomic.AddInt32(&logCount, 1)
+	}
+
+	s := Start("child", nil, logf)
+	if s == nil {
+		t.Fatal("Start() = nil, want a live sampler")
+	}
+
+	// (b) the goroutine must terminate — recover() + return, not a crash and
+	// not an infinite re-panic/retry spin.
+	select {
+	case <-s.doneCh:
+		// recovered and exited cleanly
+	case <-time.After(2 * time.Second):
+		t.Fatal("sampler goroutine did not terminate after a panic in sampleFn — recover() missing or broken")
+	}
+
+	// Stop must be safe to call even though the goroutine already exited on
+	// its own (closed stopCh/doneCh should not block or panic).
+	s.Stop()
+
+	// (a) reaching this line at all — in the same test process, un-recovered
+	// from any runtime crash — is itself the proof the panic never escaped
+	// the goroutine. (c) exactly one best-effort log line, per the
+	// log-at-most-once contract.
+	if got := atomic.LoadInt32(&logCount); got != 1 {
+		t.Errorf("logf called %d times, want exactly 1 (log-once on panic recovery)", got)
+	}
+}

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -18,6 +18,7 @@ package progress
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -251,7 +252,7 @@ type Tracker struct {
 	runToken         string
 	filesTotal       int
 	phaseStartedAtMS int64
-	currentPhase     string
+	currentPhase     atomic.Value // string; read cross-goroutine by CurrentPhase (#5956)
 
 	// moduleResolver maps a repo-relative file path to a package-root module
 	// label. When set (monorepo indexing), Tick stamps Event.Module so the UI
@@ -269,6 +270,22 @@ type Tracker struct {
 // reindexes — which leaves RunToken empty on every event, exactly as today.
 func (t *Tracker) SetRunToken(tok string) {
 	t.runToken = tok
+}
+
+// CurrentPhase returns the phase most recently stamped by PhaseStart or Phase
+// (empty string before either has been called). Exported so out-of-band
+// observers — e.g. the memtrace sampler (#5956) — can tag their own samples
+// with the SAME phase the tracker reports to the UI, without introducing a
+// second, driftable copy of the phase state. currentPhase is stored in an
+// atomic.Value specifically so CurrentPhase is safe to call from a sampler
+// goroutine concurrently with PhaseStart/Phase running on the indexer's own
+// goroutine (verified under -race); the reader may observe a one-tick-stale
+// phase, which is within the tolerance already implicit in a polling sampler.
+func (t *Tracker) CurrentPhase() string {
+	if v, ok := t.currentPhase.Load().(string); ok {
+		return v
+	}
+	return ""
 }
 
 // SetModuleResolver installs a function that maps a repo-relative file path to
@@ -314,7 +331,7 @@ func (t *Tracker) SetFilesTotal(n int) {
 
 // PhaseStart emits a phase-entry event and records the start timestamp.
 func (t *Tracker) PhaseStart(phase string, filesDone int, entitiesSoFar int) {
-	t.currentPhase = phase
+	t.currentPhase.Store(phase)
 	t.phaseStartedAtMS = nowMS()
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,
@@ -381,7 +398,7 @@ func (t *Tracker) TickModule(phase, module string, moduleDone, moduleTotal int, 
 // tail (communities, centrality, links, flows, write) in the CLI and wizard.
 // The pass runs after all files are processed, so FilesDone == FilesTotal.
 func (t *Tracker) Phase(phase, passName string, entitiesSoFar int) {
-	t.currentPhase = phase
+	t.currentPhase.Store(phase)
 	t.phaseStartedAtMS = nowMS()
 	t.pub.Publish(Event{
 		GroupSlug:        t.groupSlug,

--- a/internal/progress/event_test.go
+++ b/internal/progress/event_test.go
@@ -165,6 +165,39 @@ func TestTracker_EmptyRunTokenUnaffected(t *testing.T) {
 	}
 }
 
+// TestTracker_CurrentPhase verifies CurrentPhase reflects the last phase
+// stamped by PhaseStart/Phase (#5956 memtrace) — the memtrace sampler reads
+// this instead of keeping a second, driftable copy of phase state.
+func TestTracker_CurrentPhase(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+
+	if got := trk.CurrentPhase(); got != "" {
+		t.Errorf("CurrentPhase() before any phase = %q, want empty", got)
+	}
+
+	trk.PhaseStart(progress.PhaseScan, 0, 0)
+	if got := trk.CurrentPhase(); got != progress.PhaseScan {
+		t.Errorf("CurrentPhase() after PhaseStart(scan) = %q, want %q", got, progress.PhaseScan)
+	}
+
+	// Tick does not change the phase-boundary state.
+	trk.Tick(progress.PhaseScan, 5, 0, "a.go", 0)
+	if got := trk.CurrentPhase(); got != progress.PhaseScan {
+		t.Errorf("CurrentPhase() after Tick = %q, want unchanged %q", got, progress.PhaseScan)
+	}
+
+	trk.PhaseStart(progress.PhaseExtractAST, 0, 0)
+	if got := trk.CurrentPhase(); got != progress.PhaseExtractAST {
+		t.Errorf("CurrentPhase() after PhaseStart(extract) = %q, want %q", got, progress.PhaseExtractAST)
+	}
+
+	trk.Phase(progress.PhaseWriteGraph, "graph.fb", 100)
+	if got := trk.CurrentPhase(); got != progress.PhaseWriteGraph {
+		t.Errorf("CurrentPhase() after Phase(writing_graph) = %q, want %q", got, progress.PhaseWriteGraph)
+	}
+}
+
 // TestTracker_Fail verifies that Fail emits a PhaseError event with the
 // error message.
 func TestTracker_Fail(t *testing.T) {


### PR DESCRIPTION
Adds `internal/memtrace` — phase-tagged memstats sampler + heap profiles + engine/serve/child rollup, opt-in behind `GRAFEL_MEMTRACE_DIR`, fully inert when unset. `Tracker.CurrentPhase()` via atomic.Value (race-free, only on phase transitions, not the tick hot path). Child inherits the env via os.Environ. Sampler goroutine has a recover() so it can never crash the index. Adversarially reviewed: APPROVE (inert-default + atomic race/nil-panic proven); recover() hardening added after review. Enables ranked byte-attribution for the Phase 3 RSS wins. No format/scheduling change. Closes #5956. Part of #5954.