### PR TITLE
fix(#5954): clamp auto-tuned AlgoCap to <=3 cores

### DIFF
--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -228,7 +228,9 @@ type Config struct {
 	// running N simultaneously on an N-core host saturates all cores and
 	// spikes RSS proportionally.
 	//
-	// 0 (or negative) means: auto = max(2, runtime.NumCPU()/2).
+	// 0 (or negative) means: auto = min(3, max(2, runtime.NumCPU()/2)),
+	// clamped to a hard ceiling of 3 cores so indexing/algo work never
+	// saturates the user's machine, even on large hosts.
 	// Set to 1 to fully serialise algo passes.
 	AlgoCap int
 
@@ -382,9 +384,10 @@ type Scheduler struct {
 	shutdownCancel context.CancelFunc
 
 	// algoSem limits the number of concurrent algorithm passes (#2141
-	// root-cause C / #2140 hyp-2). Capacity = max(2, NumCPU/2) unless
-	// Config.AlgoCap is set. Nil means unbounded (legacy; not used in
-	// production).
+	// root-cause C / #2140 hyp-2). Capacity = min(3, max(2, NumCPU/2))
+	// unless Config.AlgoCap is set — the auto path is hard-capped at 3
+	// cores so indexing never freezes the user's machine. Nil means
+	// unbounded (legacy; not used in production).
 	algoSem chan struct{}
 
 	mu           sync.Mutex
@@ -523,10 +526,11 @@ type LogEntry struct {
 const maxRecentLog = 32
 
 // resolveAlgoCap returns the effective concurrency cap for algorithm passes.
-// If cfg.AlgoCap > 0 it is returned as-is. Otherwise it is auto-tuned to
-// max(2, runtime.NumCPU()/2) so that on an 8-core machine only 4 algo
-// passes run in parallel, leaving headroom for the watcher, indexers, and
-// the Go runtime itself.
+// If cfg.AlgoCap > 0 it is returned as-is (an explicit operator override is
+// honored verbatim). Otherwise it is auto-tuned to
+// min(3, max(2, runtime.NumCPU()/2)): the project hard-caps indexing/algo
+// work at 3 concurrent cores regardless of host size, so a large box never
+// gets its CPU saturated and the user's machine stays responsive.
 func resolveAlgoCap(cap int) int {
 	if cap > 0 {
 		return cap
@@ -534,6 +538,9 @@ func resolveAlgoCap(cap int) int {
 	n := runtime.NumCPU() / 2
 	if n < 2 {
 		n = 2
+	}
+	if n > 3 {
+		n = 3
 	}
 	return n
 }

--- a/internal/daemon/sched/scheduler_algocap_test.go
+++ b/internal/daemon/sched/scheduler_algocap_test.go
@@ -1,0 +1,37 @@
+package sched
+
+import "testing"
+
+// TestResolveAlgoCap_ExplicitOverride asserts that an operator-supplied
+// AlgoCap > 0 is honored verbatim, with no clamping applied.
+func TestResolveAlgoCap_ExplicitOverride(t *testing.T) {
+	cases := []struct {
+		in, want int
+	}{
+		{1, 1},
+		{4, 4},
+		{6, 6},
+	}
+	for _, c := range cases {
+		if got := resolveAlgoCap(c.in); got != c.want {
+			t.Errorf("resolveAlgoCap(%d) = %d, want %d (explicit override must pass through unclamped)", c.in, got, c.want)
+		}
+	}
+}
+
+// TestResolveAlgoCap_AutoClampedTo3Cores asserts the project's hard
+// constraint: auto-tuned algo-pass concurrency must never exceed 3 cores,
+// regardless of host size, so indexing never saturates the user's machine.
+// It must also never fall below 2, to preserve minimal usable parallelism.
+//
+// This is intentionally an invariant test (not an exact-value test tied to
+// a specific host core count) per the task guidance: injecting NumCPU would
+// require restructuring resolveAlgoCap's signature, which is out of scope.
+// On this repo's 12-core dev/CI host, this test is RED against the
+// pre-fix implementation (returns 6, which is > 3) and GREEN after the fix.
+func TestResolveAlgoCap_AutoClampedTo3Cores(t *testing.T) {
+	got := resolveAlgoCap(0)
+	if got < 2 || got > 3 {
+		t.Fatalf("resolveAlgoCap(0) = %d, want value in [2,3] (auto-tuned cap must be clamped to the project's <=3-core ceiling)", got)
+	}
+}

--- a/internal/daemon/sched/scheduler_test.go
+++ b/internal/daemon/sched/scheduler_test.go
@@ -478,11 +478,15 @@ func TestResolveAlgoCap(t *testing.T) {
 		t.Errorf("resolveAlgoCap(1) = %d, want 1", got)
 	}
 
-	// Auto-tune: floor at 2.
+	// Auto-tune: floor at 2, ceil at 3 (project hard cap: indexing/algo
+	// work must never exceed 3 concurrent cores, regardless of host size).
 	auto := resolveAlgoCap(0)
 	expected := runtime.NumCPU() / 2
 	if expected < 2 {
 		expected = 2
+	}
+	if expected > 3 {
+		expected = 3
 	}
 	if auto != expected {
 		t.Errorf("resolveAlgoCap(0) = %d, want %d (NumCPU=%d)", auto, expected, runtime.NumCPU())


### PR DESCRIPTION
## What

Clamp the auto-tuned `resolveAlgoCap` result to `[2, 3]` so the concurrent algorithm-pass semaphore never exceeds the project's hard **≤3-core** ceiling (machine-responsiveness under load).

Before: auto = `max(2, NumCPU/2)` → **6** on a 12-core host.
After: auto = `min(3, max(2, NumCPU/2))` → **3**.

Explicit `cfg.AlgoCap > 0` overrides are still honored verbatim (provably unused in production today — the field has no env/flag/config surface; it exists only as a test determinism knob).

## Why

Part of #5954. The user constraint is that indexing/algorithm work must never saturate the machine. `algoSem` capacity is derived from `resolveAlgoCap`; on a 12-core dev box six CPU- and heap-intensive Louvain/PageRank/articulation passes could run at once.

## Tests

- `scheduler_algocap_test.go` (new): explicit override pass-through (1→1, 4→4, 6→6) + auto-path invariant `2 ≤ resolveAlgoCap(0) ≤ 3`. RED on this 12-core host pre-fix (returned 6), GREEN after.
- `scheduler_test.go::TestResolveAlgoCap` updated to the clamped formula.
- `go build ./... && go vet ./internal/daemon/sched/... && gofmt -l internal` clean; `go test ./internal/daemon/sched/... -count=1` → 116 passed.

## Follow-up (separate issue)

Independent review confirmed this closes only the **algo-pass** path. The larger, dominant CPU draw — the **extraction subprocess fanout** — still exceeds 3 cores (background ≈ 4×2 threads; interactive uncapped). Tracked separately; that fix trades against the reduce-indexing-time goal and needs an interpretation decision, so it is intentionally out of scope here.

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
