### PR TITLE
perf(#5954): compact resolver Index inner maps (kindIDs) — cut BuildIndex peak heap

### DIFF
--- a/internal/resolve/django_fk.go
+++ b/internal/resolve/django_fk.go
@@ -58,13 +58,13 @@ func (idx Index) lookupUniqueModelByName(name string) (string, bool) {
 		return "", false
 	}
 	realBucket := idx.nameKindsReal[name]
-	if len(realBucket) == 0 {
+	if realBucket.len() == 0 {
 		return "", false
 	}
 	// nameKindsReal[name][kind] = "" sentinel means ambiguous (>=2
 	// entities share that name+kind pair); a non-empty value is the
 	// unique entity ID for that pair.
-	id, ok := realBucket[string(types.EntityKindModel)]
+	id, ok := realBucket.get(string(types.EntityKindModel))
 	if !ok || id == "" {
 		return "", false
 	}

--- a/internal/resolve/kindids_equiv_test.go
+++ b/internal/resolve/kindids_equiv_test.go
@@ -1,0 +1,260 @@
+// Package resolve — equivalence battery for the kindIDs compaction (#5954).
+//
+// The compaction replaced the innermost map[string]string (kind -> id) buckets
+// in nameKinds / nameKindsReal / byLocationKind / byLocationKindReal with the
+// compact kindIDs. This file proves the swap is BEHAVIOURALLY INVISIBLE:
+//
+//  1. map-oracle parity — an INDEPENDENT replay of BuildIndex's exact write
+//     rules over a real multi-language fixture reconstructs a reference
+//     map[name]map[kind]id (and the 3-level location variants). We assert the
+//     live kindIDs buckets enumerate an IDENTICAL (kind,id) set for every key.
+//  2. entry-point battery — every method that READS these four buckets is
+//     probed and asserted against known-correct output, including the #525
+//     real-Component-vs-SCOPE.Component-placeholder collision (the gate case).
+package resolve
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---- oracle replays (independent of kindIDs) --------------------------------
+
+func kindsOf(e types.EntityRecord) []string {
+	kinds := []string{e.Kind}
+	if t := strings.TrimPrefix(e.Kind, scopeKindPrefix); t != e.Kind && t != "" {
+		kinds = append(kinds, t)
+	}
+	return kinds
+}
+
+func setOracle(m map[string]string, kind, id string) {
+	if kind == "" {
+		return
+	}
+	if ex, ok := m[kind]; ok && ex != id {
+		m[kind] = ""
+	} else {
+		m[kind] = id
+	}
+}
+
+func oracleNameKinds(ents []types.EntityRecord) map[string]map[string]string {
+	m := map[string]map[string]string{}
+	for _, e := range ents {
+		b := m[e.Name]
+		if b == nil {
+			b = map[string]string{}
+			m[e.Name] = b
+		}
+		for _, k := range kindsOf(e) {
+			setOracle(b, k, e.ID)
+		}
+	}
+	return m
+}
+
+func oracleNameKindsReal(ents []types.EntityRecord) map[string]map[string]string {
+	m := map[string]map[string]string{}
+	for _, e := range ents {
+		if e.Kind == "" {
+			continue
+		}
+		b := m[e.Name]
+		if b == nil {
+			b = map[string]string{}
+			m[e.Name] = b
+		}
+		setOracle(b, e.Kind, e.ID)
+	}
+	return m
+}
+
+func oracleLocKind(ents []types.EntityRecord, realOnly bool) map[string]map[string]map[string]string {
+	m := map[string]map[string]map[string]string{}
+	for _, e := range ents {
+		sf := normalizePath(e.SourceFile)
+		if sf == "" {
+			continue
+		}
+		if realOnly && e.Kind == "" {
+			continue
+		}
+		fb := m[sf]
+		if fb == nil {
+			fb = map[string]map[string]string{}
+			m[sf] = fb
+		}
+		nb := fb[e.Name]
+		if nb == nil {
+			nb = map[string]string{}
+			fb[e.Name] = nb
+		}
+		if realOnly {
+			setOracle(nb, e.Kind, e.ID)
+		} else {
+			for _, k := range kindsOf(e) {
+				setOracle(nb, k, e.ID)
+			}
+		}
+	}
+	return m
+}
+
+// liveNameKinds materialises a kindIDs map back into a plain map for comparison.
+func liveNameKinds(m map[string]kindIDs) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	for name, kid := range m {
+		b := map[string]string{}
+		kid.each(func(k, id string) { b[k] = id })
+		out[name] = b
+	}
+	return out
+}
+
+func liveLocKind(m LocationKindIndex) map[string]map[string]map[string]string {
+	out := map[string]map[string]map[string]string{}
+	for file, fb := range m {
+		of := map[string]map[string]string{}
+		for name, kid := range fb {
+			b := map[string]string{}
+			kid.each(func(k, id string) { b[k] = id })
+			of[name] = b
+		}
+		out[file] = of
+	}
+	return out
+}
+
+// ---- fixture ----------------------------------------------------------------
+
+// equivFixture = the multi-language representativeFixture() PLUS the #525
+// real-Component-vs-SCOPE.Component collision and a schema-field entity, so the
+// oracle parity covers every bucket-populating shape.
+func equivFixture() []types.EntityRecord {
+	ents := representativeFixture()
+	ents = append(ents,
+		// #525 gate: real Component "Widget" AND SCOPE.Component "Widget"
+		// share the SAME (file, name). The real one must win tier-1.
+		entAt("00000000000005a1", "Component", "Widget", "app/widget.py"),
+		entAt("00000000000005a2", "SCOPE.Component", "Widget", "app/widget.py"),
+		// Force ambigName on Widget so the bare/global path can't resolve it,
+		// exercising the nameKindsReal tier-1 preference.
+		entAt("00000000000005a3", "Function", "Widget", "other/w.py"),
+		// A unique schema field for lookupUniqueSchemaFieldByName.
+		entAt("00000000000006f1", "SCOPE.Schema", "Base.parentField", "app/base.java"),
+		// A unique Model for lookupUniqueModelByName (Django strategy-3).
+		entAt("00000000000007d1", string(types.EntityKindModel), "Building", "app/models.py"),
+	)
+	return ents
+}
+
+// ---- 1. map-oracle parity ---------------------------------------------------
+
+func TestKindIDs_IndexMapParity(t *testing.T) {
+	ents := equivFixture()
+	idx := BuildIndex(ents)
+
+	if got, want := liveNameKinds(idx.nameKinds), oracleNameKinds(ents); !reflect.DeepEqual(got, want) {
+		t.Fatalf("nameKinds diverges from oracle:\n live=%v\noracle=%v", got, want)
+	}
+	if got, want := liveNameKinds(idx.nameKindsReal), oracleNameKindsReal(ents); !reflect.DeepEqual(got, want) {
+		t.Fatalf("nameKindsReal diverges from oracle:\n live=%v\noracle=%v", got, want)
+	}
+	if got, want := liveLocKind(idx.byLocationKind), oracleLocKind(ents, false); !reflect.DeepEqual(got, want) {
+		t.Fatalf("byLocationKind diverges from oracle:\n live=%v\noracle=%v", got, want)
+	}
+	if got, want := liveLocKind(idx.byLocationKindReal), oracleLocKind(ents, true); !reflect.DeepEqual(got, want) {
+		t.Fatalf("byLocationKindReal diverges from oracle:\n live=%v\noracle=%v", got, want)
+	}
+}
+
+// ---- 2. entry-point battery -------------------------------------------------
+
+func TestKindIDs_EntryPointBattery(t *testing.T) {
+	idx := BuildIndex(equivFixture())
+
+	// lookupByKindHint via LookupStatusHint — #525 gate: EXTENDS "Widget"
+	// must bind to the REAL Component (5a1), never the SCOPE.Component
+	// placeholder (5a2), even though Widget is ambiguous globally.
+	if id, st := idx.LookupStatusHint("Widget", "EXTENDS"); id != "00000000000005a1" || st != statusRewritten {
+		t.Fatalf("#525 lookupByKindHint(Widget,EXTENDS) = (%q,%d), want (5a1,rewritten)", id, st)
+	}
+
+	// lookupLocationKind — same-file (file,name) kind-disambiguated real
+	// preference (#525): structural EXTENDS to the class in its own file.
+	if id, ok := idx.lookupLocationKind("app/widget.py", "Widget", componentKindFamily); !ok || id != "00000000000005a1" {
+		t.Fatalf("#525 lookupLocationKind = (%q,%v), want (5a1,true)", id, ok)
+	}
+
+	// lookupStructural — Format A structural ref resolving to the real class.
+	stub := "scope:component:class:python:app/widget.py:Widget"
+	if id, st, handled := idx.lookupStructural(stub); !handled || id != "00000000000005a1" || st != statusRewritten {
+		t.Fatalf("#525 lookupStructural(%s) = (%q,%d,handled=%v), want (5a1,rewritten,true)", stub, id, st, handled)
+	}
+
+	// lookupUniqueRealComponentByName — unique real component by bare name.
+	if id, ok := idx.lookupUniqueRealComponentByName("Widget"); !ok || id != "00000000000005a1" {
+		t.Fatalf("lookupUniqueRealComponentByName(Widget) = (%q,%v), want (5a1,true)", id, ok)
+	}
+
+	// lookupUniqueSchemaFieldByName — unique SCOPE.Schema leaf.
+	if id, ok := idx.lookupUniqueSchemaFieldByName("parentField"); !ok || id != "00000000000006f1" {
+		t.Fatalf("lookupUniqueSchemaFieldByName(parentField) = (%q,%v), want (6f1,true)", id, ok)
+	}
+
+	// lookupUniqueModelByName — unique SCOPE.Model by bare name (Django).
+	if id, ok := idx.lookupUniqueModelByName("Building"); !ok || id != "00000000000007d1" {
+		t.Fatalf("lookupUniqueModelByName(Building) = (%q,%v), want (7d1,true)", id, ok)
+	}
+
+	// nameExists — must find every name that has any kind bucket.
+	for _, n := range []string{"Widget", "Run", "Config", "Building", "Base.parentField"} {
+		if !idx.nameExists(n) {
+			t.Fatalf("nameExists(%q) = false, want true", n)
+		}
+	}
+	if idx.nameExists("NoSuchNameEver") {
+		t.Fatalf("nameExists(absent) = true, want false")
+	}
+
+	// DiagnoseBugResolver — KindsPresent must enumerate the kinds registered
+	// under a name (drawn from the nameKinds bucket via each()).
+	diag := idx.DiagnoseBugResolver("Widget:Widget", "EXTENDS")
+	kp := map[string]bool{}
+	for _, k := range diag.KindsPresent {
+		kp[k] = true
+	}
+	for _, want := range []string{"Component", "SCOPE.Component", "Function"} {
+		if !kp[want] {
+			t.Fatalf("DiagnoseBugResolver KindsPresent missing %q; got %v", want, diag.KindsPresent)
+		}
+	}
+}
+
+// TestKindIDs_CollisionSentinelPreserved proves that a genuine (name,kind)
+// collision blanks to the "" sentinel and that a hint over that name yields no
+// false bind — the ambiguity semantics the resolver depends on.
+func TestKindIDs_CollisionSentinelPreserved(t *testing.T) {
+	// Two DIFFERENT entities share (name=Dup, kind=Function) => blank sentinel.
+	ents := []types.EntityRecord{
+		ent("aaaaaaaaaaaaaaaa", "Function", "Dup"),
+		ent("bbbbbbbbbbbbbbbb", "Function", "Dup"),
+	}
+	idx := BuildIndex(ents)
+	// nameKinds[Dup][Function] must be present-but-blank.
+	id, present := idx.nameKinds["Dup"].get("Function")
+	if !present {
+		t.Fatalf("collision entry absent; want present blank sentinel")
+	}
+	if id != "" {
+		t.Fatalf("collision entry = %q, want blank sentinel", id)
+	}
+	// A CALLS hint over the ambiguous name must NOT bind.
+	if bindID, st := idx.LookupStatusHint("Dup", "CALLS"); st == statusRewritten {
+		t.Fatalf("ambiguous Dup bound to %q (status rewritten); want no bind", bindID)
+	}
+}

--- a/internal/resolve/kindids_test.go
+++ b/internal/resolve/kindids_test.go
@@ -1,0 +1,195 @@
+// Package resolve — unit parity tests for the compact kindIDs type (#5954).
+//
+// kindIDs replaces the innermost map[string]string (kind -> entity_id) buckets
+// in the resolver Index's four dominant inner maps (nameKinds, nameKindsReal,
+// byLocationKind, byLocationKindReal). It MUST be byte-for-byte behaviourally
+// identical to the map it replaces under the resolver's exact write/read rules:
+//
+//   - first-writer-wins per (kind);
+//   - a SECOND writer with a different id blanks the entry to "" (the
+//     ambiguous-within-kind sentinel);
+//   - a present-but-blank ("") entry is DISTINCT from an absent entry:
+//     get returns ("", true) for blank, ("", false) for absent.
+//
+// These tests pin that contract against a reference map oracle.
+package resolve
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// mapOracle replays the EXACT write rule the resolver uses today on a real
+// map[string]string, so we can assert kindIDs matches it entry-for-entry.
+func mapOracleSet(m map[string]string, kind, id string) {
+	if existing, ok := m[kind]; ok && existing != id {
+		m[kind] = ""
+	} else {
+		m[kind] = id
+	}
+}
+
+// applyWrites runs the same write sequence through both a kindIDs and the map
+// oracle and asserts get/len/each agree for every kind touched.
+func applyWrites(t *testing.T, writes [][2]string) {
+	t.Helper()
+	var kid kindIDs
+	oracle := map[string]string{}
+	for _, w := range writes {
+		kid.set(w[0], w[1])
+		mapOracleSet(oracle, w[0], w[1])
+	}
+	// len parity.
+	if kid.len() != len(oracle) {
+		t.Fatalf("len mismatch: kindIDs=%d oracle=%d (writes=%v)", kid.len(), len(oracle), writes)
+	}
+	// get parity for every kind in the oracle (present, possibly blank).
+	for k, want := range oracle {
+		gotID, gotPresent := kid.get(k)
+		if !gotPresent {
+			t.Fatalf("get(%q): kindIDs reports ABSENT but oracle has it (=%q); writes=%v", k, want, writes)
+		}
+		if gotID != want {
+			t.Fatalf("get(%q): kindIDs=%q oracle=%q; writes=%v", k, gotID, want, writes)
+		}
+	}
+	// each() must enumerate the identical (kind,id) set.
+	eachSet := map[string]string{}
+	kid.each(func(kind, id string) { eachSet[kind] = id })
+	if !reflect.DeepEqual(eachSet, oracle) {
+		t.Fatalf("each() set mismatch:\n each=%v\noracle=%v\nwrites=%v", eachSet, oracle, writes)
+	}
+}
+
+func TestKindIDs_EmptyIsAbsent(t *testing.T) {
+	var kid kindIDs
+	if kid.len() != 0 {
+		t.Fatalf("empty len = %d, want 0", kid.len())
+	}
+	if id, present := kid.get("Function"); present || id != "" {
+		t.Fatalf("empty get = (%q,%v), want (\"\",false)", id, present)
+	}
+	// each on empty must not call the callback.
+	kid.each(func(kind, id string) { t.Fatalf("each on empty called with (%q,%q)", kind, id) })
+}
+
+func TestKindIDs_SingleEntry(t *testing.T) {
+	applyWrites(t, [][2]string{{"Function", "aaaa"}})
+}
+
+func TestKindIDs_TwoDistinctKinds(t *testing.T) {
+	applyWrites(t, [][2]string{{"Function", "aaaa"}, {"Method", "bbbb"}})
+}
+
+func TestKindIDs_ThreeDistinctKinds(t *testing.T) {
+	applyWrites(t, [][2]string{
+		{"SCOPE.Component", "aaaa"},
+		{"Component", "aaaa"},
+		{"SCOPE.Operation", "bbbb"},
+	})
+}
+
+func TestKindIDs_FirstWriterWins_SameID_NoBlank(t *testing.T) {
+	// Re-writing the SAME id must NOT blank (mirrors the map's else-branch).
+	var kid kindIDs
+	kid.set("Function", "aaaa")
+	kid.set("Function", "aaaa")
+	id, present := kid.get("Function")
+	if !present || id != "aaaa" {
+		t.Fatalf("get after same-id rewrite = (%q,%v), want (aaaa,true)", id, present)
+	}
+	applyWrites(t, [][2]string{{"Function", "aaaa"}, {"Function", "aaaa"}})
+}
+
+func TestKindIDs_CollisionBlanks(t *testing.T) {
+	// A second, DIFFERENT id blanks the entry to "" — present but ambiguous.
+	var kid kindIDs
+	kid.set("Function", "aaaa")
+	kid.set("Function", "bbbb")
+	id, present := kid.get("Function")
+	if !present {
+		t.Fatalf("blanked entry must remain PRESENT; got absent")
+	}
+	if id != "" {
+		t.Fatalf("blanked entry id = %q, want \"\"", id)
+	}
+	applyWrites(t, [][2]string{{"Function", "aaaa"}, {"Function", "bbbb"}})
+}
+
+func TestKindIDs_CollisionInSpill(t *testing.T) {
+	// Collision on a spilled (rest) entry, not just the inline slot.
+	applyWrites(t, [][2]string{
+		{"Function", "aaaa"},
+		{"Method", "bbbb"},
+		{"Method", "cccc"}, // collision on the spilled key -> blank
+	})
+}
+
+func TestKindIDs_BlankThenSameKindStaysBlank(t *testing.T) {
+	// Once blanked, a further different writer keeps it blank (map: existing=""
+	// != newID -> stays "").
+	applyWrites(t, [][2]string{
+		{"Function", "aaaa"},
+		{"Function", "bbbb"}, // -> ""
+		{"Function", "cccc"}, // existing "" != cccc -> stays ""
+	})
+}
+
+// TestKindIDs_ExhaustiveVsOracle fuzzes many write sequences drawn from a small
+// alphabet of kinds and ids and asserts full parity with the map oracle.
+func TestKindIDs_ExhaustiveVsOracle(t *testing.T) {
+	kindsAlpha := []string{"K1", "K2", "K3"}
+	idsAlpha := []string{"x", "y", "z"}
+	// Enumerate all sequences of length up to 3.
+	var gen func(prefix [][2]string, depth int)
+	gen = func(prefix [][2]string, depth int) {
+		applyWrites(t, prefix)
+		if depth == 0 {
+			return
+		}
+		for _, k := range kindsAlpha {
+			for _, id := range idsAlpha {
+				gen(append(append([][2]string(nil), prefix...), [2]string{k, id}), depth-1)
+			}
+		}
+	}
+	gen(nil, 3)
+}
+
+// TestKindIDs_EachDeterministicOrder pins that each()/insertion is inline-first
+// then spill order — mirrors the insertion order the resolver replays so the M5
+// parity harness (reflect.DeepEqual) stays valid.
+func TestKindIDs_EachDeterministicOrder(t *testing.T) {
+	var kid kindIDs
+	kid.set("first", "1")
+	kid.set("second", "2")
+	kid.set("third", "3")
+	var order []string
+	kid.each(func(kind, id string) { order = append(order, kind) })
+	want := []string{"first", "second", "third"}
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("each order = %v, want %v", order, want)
+	}
+	// sanity: sorted set identity independent of order
+	sort.Strings(order)
+	sort.Strings(want)
+	if !reflect.DeepEqual(order, want) {
+		t.Fatalf("each key set = %v, want %v", order, want)
+	}
+}
+
+// TestKindIDs_SingleEntryZeroAlloc proves the ~1-cardinality common case never
+// touches the heap — the entire point of the compaction.
+func TestKindIDs_SingleEntryZeroAlloc(t *testing.T) {
+	allocs := testing.AllocsPerRun(1000, func() {
+		var kid kindIDs
+		kid.set("Function", "aaaaaaaaaaaaaaaa")
+		if id, ok := kid.get("Function"); !ok || id == "" {
+			t.Fatalf("unexpected get result")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("single-entry set+get did %v heap allocs, want 0", allocs)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -399,7 +399,7 @@ type Index struct {
 	// name. A blank string sentinel means two entities share that
 	// (name, kind) tuple — i.e. the kind itself is ambiguous for this
 	// name and the kind hint cannot disambiguate via this family.
-	nameKinds map[string]map[string]string
+	nameKinds map[string]kindIDs
 
 	// nameKindsReal[name][kind] = entity_id, indexed under the entity's
 	// ORIGINAL kind only (no SCOPE.* dual-indexing). Used by
@@ -409,7 +409,7 @@ type Index struct {
 	// string sentinel marks (name, kind) collisions; identical
 	// semantics to nameKinds but without the cross-tier ambiguity that
 	// dual-indexing introduces.
-	nameKindsReal map[string]map[string]string
+	nameKindsReal map[string]kindIDs
 
 	// byLocation[file_path][name] = entity_id, retained only when unique
 	// within the file. Used by structural-ref Format A resolution.
@@ -542,7 +542,100 @@ type LocationIndex map[string]map[string]string
 // kind-aware structural-ref / location resolver path to disambiguate
 // same-file (file, name) collisions when the relationship supplies a kind
 // hint. A blank string value is the ambiguous-within-kind sentinel.
-type LocationKindIndex map[string]map[string]map[string]string
+//
+// The innermost kind->id level is a compact kindIDs rather than a
+// map[string]string: these buckets almost always hold a SINGLE (kind, id)
+// entry, and paying full Go-map overhead (~300B heap) per 1-entry map made
+// the four kind->id inner maps 32% of the index-internal peak heap (#5954).
+// kindIDs stores the first entry inline (zero heap in the common case).
+type LocationKindIndex map[string]map[string]kindIDs
+
+// kindID is one (kind, entity_id) pair inside a kindIDs.
+type kindID struct{ kind, id string }
+
+// kindIDs is a heap-frugal replacement for map[string]string (kind -> id) in
+// the resolver Index's four dominant inner buckets (nameKinds, nameKindsReal,
+// byLocationKind, byLocationKindReal). The first entry lives inline (k0/v0);
+// additional kinds spill to rest. Since these buckets carry ~1 entry each, the
+// inline path never touches the heap — that is the entire point of the type.
+//
+// Semantics MUST match the map it replaces exactly (#5954):
+//   - kind keys are never "" (the writers skip empty kinds), so k0 == "" is a
+//     reliable "inline slot empty" sentinel.
+//   - a VALUE of "" is the ambiguous-within-kind sentinel: a present-but-blank
+//     entry is DISTINCT from an absent one. get returns ("", true) for a
+//     blanked entry and ("", false) for an absent one — callers rely on this.
+type kindIDs struct {
+	k0, v0 string   // first (kind, id) entry, inline — zero heap for cardinality 1
+	rest   []kindID // spill for the rare >1-kind case
+}
+
+// get returns the id registered under kind and whether the kind is present.
+// A present-but-blank entry returns ("", true); an absent kind ("", false).
+func (b kindIDs) get(kind string) (string, bool) {
+	if b.k0 == "" {
+		return "", false // inline slot empty => whole bucket empty
+	}
+	if b.k0 == kind {
+		return b.v0, true
+	}
+	for i := range b.rest {
+		if b.rest[i].kind == kind {
+			return b.rest[i].id, true
+		}
+	}
+	return "", false
+}
+
+// set applies the resolver's exact write rule: first writer wins per kind; a
+// second writer with a DIFFERENT id blanks the entry to "" (ambiguous-within-
+// kind sentinel); re-writing the same id is a no-op; a blanked entry stays
+// blank. Callers never pass an empty kind.
+func (b *kindIDs) set(kind, id string) {
+	if existing, ok := b.get(kind); ok {
+		if existing != id {
+			b.put(kind, "") // collision => blank sentinel
+		}
+		return
+	}
+	b.put(kind, id)
+}
+
+// put unconditionally upserts (kind, val). Internal helper for set.
+func (b *kindIDs) put(kind, val string) {
+	if b.k0 == "" || b.k0 == kind {
+		b.k0, b.v0 = kind, val
+		return
+	}
+	for i := range b.rest {
+		if b.rest[i].kind == kind {
+			b.rest[i].id = val
+			return
+		}
+	}
+	b.rest = append(b.rest, kindID{kind, val})
+}
+
+// len reports how many (kind, id) entries are stored, including blanked ones.
+func (b kindIDs) len() int {
+	if b.k0 == "" {
+		return 0
+	}
+	return 1 + len(b.rest)
+}
+
+// each calls fn for every stored (kind, id) entry, inline slot first then spill
+// in insertion order. Blanked entries (id == "") are enumerated too, matching
+// map-range semantics.
+func (b kindIDs) each(fn func(kind, id string)) {
+	if b.k0 == "" {
+		return
+	}
+	fn(b.k0, b.v0)
+	for i := range b.rest {
+		fn(b.rest[i].kind, b.rest[i].id)
+	}
+}
 
 // Stats reports how many relationship endpoints the resolver rewrote and how
 // many it left as stubs because of ambiguity / missing matches. Surfaced via
@@ -726,8 +819,8 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]map[string]string),
-		nameKindsReal:      make(map[string]map[string]string),
+		nameKinds:          make(map[string]kindIDs),
+		nameKindsReal:      make(map[string]kindIDs),
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
@@ -904,24 +997,19 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// disambiguate when byName flips to ambiguous. The plain entity
 		// kind is enough here; SCOPE.* kinds are tracked under both forms
 		// to mirror the byKind dual-indexing above.
+		// First writer wins per kind; if a second entity shares the
+		// (name, kind) we mark the kind ambiguous for that name by
+		// blanking the entry so the hint falls through. kindIDs.set
+		// encapsulates that rule; the value is stored back since kindIDs
+		// lives inline in the map (no per-entry heap in the 1-kind case).
 		nameKindBucket := idx.nameKinds[e.Name]
-		if nameKindBucket == nil {
-			nameKindBucket = make(map[string]string)
-			idx.nameKinds[e.Name] = nameKindBucket
-		}
 		for _, kind := range kinds {
 			if kind == "" {
 				continue
 			}
-			// First writer wins per kind; if a second entity shares the
-			// (name, kind) we mark the kind ambiguous for that name by
-			// blanking the entry so the hint falls through.
-			if existing, ok := nameKindBucket[kind]; ok && existing != e.ID {
-				nameKindBucket[kind] = ""
-			} else {
-				nameKindBucket[kind] = e.ID
-			}
+			nameKindBucket.set(kind, e.ID)
 		}
+		idx.nameKinds[e.Name] = nameKindBucket
 
 		// nameKindsReal — single-pass under the entity's original kind
 		// only. Used by lookupByKindHint's tier-1 real-entity pass
@@ -931,15 +1019,8 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// the same original kind.
 		if e.Kind != "" {
 			realBucket := idx.nameKindsReal[e.Name]
-			if realBucket == nil {
-				realBucket = make(map[string]string)
-				idx.nameKindsReal[e.Name] = realBucket
-			}
-			if existing, ok := realBucket[e.Kind]; ok && existing != e.ID {
-				realBucket[e.Kind] = ""
-			} else {
-				realBucket[e.Kind] = e.ID
-			}
+			realBucket.set(e.Kind, e.ID)
+			idx.nameKindsReal[e.Name] = realBucket
 		}
 
 		// Location index — (file_path, name) -> entity_id. Same logic as
@@ -951,24 +1032,17 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			// trimmed kinds to mirror byKind.
 			fileKindBucket := idx.byLocationKind[sourceFile]
 			if fileKindBucket == nil {
-				fileKindBucket = make(map[string]map[string]string)
+				fileKindBucket = make(map[string]kindIDs)
 				idx.byLocationKind[sourceFile] = fileKindBucket
 			}
 			nameKindBucketLoc := fileKindBucket[e.Name]
-			if nameKindBucketLoc == nil {
-				nameKindBucketLoc = make(map[string]string)
-				fileKindBucket[e.Name] = nameKindBucketLoc
-			}
 			for _, kind := range kinds {
 				if kind == "" {
 					continue
 				}
-				if existing, ok := nameKindBucketLoc[kind]; ok && existing != e.ID {
-					nameKindBucketLoc[kind] = "" // ambiguous within (file, name, kind)
-				} else {
-					nameKindBucketLoc[kind] = e.ID
-				}
+				nameKindBucketLoc.set(kind, e.ID) // ambiguous within (file, name, kind) => blank
 			}
+			fileKindBucket[e.Name] = nameKindBucketLoc
 
 			// byLocationKindReal — single-pass under the entity's
 			// original kind only. Powers the real-tier preference in
@@ -979,19 +1053,12 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			if e.Kind != "" {
 				realFileBucket := idx.byLocationKindReal[sourceFile]
 				if realFileBucket == nil {
-					realFileBucket = make(map[string]map[string]string)
+					realFileBucket = make(map[string]kindIDs)
 					idx.byLocationKindReal[sourceFile] = realFileBucket
 				}
 				realNameBucket := realFileBucket[e.Name]
-				if realNameBucket == nil {
-					realNameBucket = make(map[string]string)
-					realFileBucket[e.Name] = realNameBucket
-				}
-				if existing, ok := realNameBucket[e.Kind]; ok && existing != e.ID {
-					realNameBucket[e.Kind] = ""
-				} else {
-					realNameBucket[e.Kind] = e.ID
-				}
+				realNameBucket.set(e.Kind, e.ID)
+				realFileBucket[e.Name] = realNameBucket
 			}
 
 			if idx.ambigLocation[sourceFile] == nil || !idx.ambigLocation[sourceFile][e.Name] {
@@ -1636,13 +1703,13 @@ func (idx Index) lookupByKindHint(name, relKind string) (string, bool) {
 	// kind bucket (#525). When a real Component / Class / View / Model
 	// (or Operation / Function / Method) uniquely matches, return it
 	// without consulting the SCOPE.* placeholder tier at all.
-	if realBucket := idx.nameKindsReal[name]; len(realBucket) > 0 {
+	if realBucket := idx.nameKindsReal[name]; realBucket.len() > 0 {
 		if id, ok := uniqueMatchInFamily(realBucket, families, false); ok {
 			return id, true
 		}
 	}
 	bucket := idx.nameKinds[name]
-	if len(bucket) == 0 {
+	if bucket.len() == 0 {
 		return "", false
 	}
 	// Tier 2: full family including SCOPE.* placeholders.
@@ -1654,13 +1721,13 @@ func (idx Index) lookupByKindHint(name, relKind string) (string, bool) {
 // When includePlaceholders is false, kinds prefixed with scopeKindPrefix
 // are skipped — used by the tier-1 pass of lookupByKindHint to prefer
 // real Component over SCOPE.Component (#525).
-func uniqueMatchInFamily(bucket map[string]string, families []string, includePlaceholders bool) (string, bool) {
+func uniqueMatchInFamily(bucket kindIDs, families []string, includePlaceholders bool) (string, bool) {
 	var match string
 	for _, k := range families {
 		if !includePlaceholders && strings.HasPrefix(k, scopeKindPrefix) {
 			continue
 		}
-		id := bucket[k]
+		id, _ := bucket.get(k)
 		if id == "" {
 			continue
 		}
@@ -1715,10 +1782,10 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 				return qid, statusRewritten, true
 			}
 			// Tier 3: unique within the callable (Function/Method) kind family
-			if bucket := idx.nameKinds[qname]; len(bucket) > 0 {
+			if bucket := idx.nameKinds[qname]; bucket.len() > 0 {
 				var hit string
 				for _, knd := range []string{"Function", "Method"} {
-					if id, ok := bucket[knd]; ok && id != "" {
+					if id, ok := bucket.get(knd); ok && id != "" {
 						if hit != "" && hit != id {
 							hit = "" // ambiguous across function/method
 							break
@@ -1831,10 +1898,10 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 				if qid, ok := idx.byName[member]; ok && qid != "" {
 					return qid, statusRewritten, true
 				}
-				if bucket := idx.nameKinds[member]; len(bucket) > 0 {
+				if bucket := idx.nameKinds[member]; bucket.len() > 0 {
 					var hit string
 					for _, knd := range []string{"Function", "Method", "Operation", "SCOPE.Operation"} {
-						if id, ok := bucket[knd]; ok && id != "" {
+						if id, ok := bucket.get(knd); ok && id != "" {
 							if hit != "" && hit != id {
 								hit = ""
 								break
@@ -2109,7 +2176,7 @@ func (idx Index) lookupUniqueRealComponentByName(name string) (string, bool) {
 	if name == "" {
 		return "", false
 	}
-	if realBucket := idx.nameKindsReal[name]; len(realBucket) > 0 {
+	if realBucket := idx.nameKindsReal[name]; realBucket.len() > 0 {
 		if id, ok := uniqueMatchInFamily(realBucket, componentKindFamily, false); ok {
 			return id, true
 		}
@@ -2123,10 +2190,7 @@ func (idx Index) lookupUniqueRealComponentByName(name string) (string, bool) {
 	var match string
 	for _, fileBucket := range idx.byLocationKind {
 		nameBucket := fileBucket[name]
-		if nameBucket == nil {
-			continue
-		}
-		id := nameBucket[scopeKind]
+		id, _ := nameBucket.get(scopeKind)
 		if id == "" {
 			continue
 		}
@@ -2169,7 +2233,7 @@ func (idx Index) lookupUniqueSchemaFieldByName(fieldName string) (string, bool) 
 			}
 			// Must be a Schema-family entity.
 			for _, fam := range schemaKindFamily {
-				id := kindBucket[fam]
+				id, _ := kindBucket.get(fam)
 				if id == "" {
 					continue
 				}
@@ -2223,7 +2287,7 @@ func (idx Index) lookupLocationKind(filePath, name string, families []string) (s
 		return "", false
 	}
 	if realFileBucket := idx.byLocationKindReal[filePath]; realFileBucket != nil {
-		if realNameBucket := realFileBucket[name]; len(realNameBucket) > 0 {
+		if realNameBucket := realFileBucket[name]; realNameBucket.len() > 0 {
 			if id, ok := uniqueMatchInFamily(realNameBucket, families, false); ok {
 				return id, true
 			}
@@ -2234,7 +2298,7 @@ func (idx Index) lookupLocationKind(filePath, name string, families []string) (s
 		return "", false
 	}
 	nameBucket := fileBucket[name]
-	if len(nameBucket) == 0 {
+	if nameBucket.len() == 0 {
 		return "", false
 	}
 	return uniqueMatchInFamily(nameBucket, families, true)
@@ -2735,26 +2799,25 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 		// preference in lookupByKindHint (#525).
 		if len(families) > 0 {
 			if fileBucket := idx.byLocationKindReal[callerFile]; fileBucket != nil {
-				if nameBucket := fileBucket[name]; nameBucket != nil {
-					var match string
-					ambig := false
-					for _, k := range families {
-						if strings.HasPrefix(k, scopeKindPrefix) {
-							continue
-						}
-						id := nameBucket[k]
-						if id == "" {
-							continue
-						}
-						if match != "" && match != id {
-							ambig = true
-							break
-						}
-						match = id
+				nameBucket := fileBucket[name]
+				var match string
+				ambig := false
+				for _, k := range families {
+					if strings.HasPrefix(k, scopeKindPrefix) {
+						continue
 					}
-					if !ambig && match != "" {
-						return match, true
+					id, _ := nameBucket.get(k)
+					if id == "" {
+						continue
 					}
+					if match != "" && match != id {
+						ambig = true
+						break
+					}
+					match = id
+				}
+				if !ambig && match != "" {
+					return match, true
 				}
 			}
 		}
@@ -2809,13 +2872,12 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 	// collisions remain ambig.
 	if callerFile != "" && strings.ToUpper(relKind) == "CALLS" {
 		if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
-			if nameBucket := fileBucket[name]; nameBucket != nil {
-				if id := nameBucket[scopeKindPrefix+"Operation"]; id != "" {
-					return id, true
-				}
-				if id := nameBucket[scopeKindPrefix+"Component"]; id != "" {
-					return id, true
-				}
+			nameBucket := fileBucket[name]
+			if id, _ := nameBucket.get(scopeKindPrefix + "Operation"); id != "" {
+				return id, true
+			}
+			if id, _ := nameBucket.get(scopeKindPrefix + "Component"); id != "" {
+				return id, true
 			}
 		}
 	}
@@ -2836,7 +2898,7 @@ func (idx Index) nameExists(name string) bool {
 	if idx.ambigName[name] {
 		return true
 	}
-	if bucket, ok := idx.nameKinds[name]; ok && len(bucket) > 0 {
+	if bucket, ok := idx.nameKinds[name]; ok && bucket.len() > 0 {
 		return true
 	}
 	return false
@@ -2914,10 +2976,10 @@ func (idx Index) DiagnoseBugResolver(originalStub, relKind string) BugResolverDi
 	diag.StubKind = kind
 
 	if bucket, ok := idx.nameKinds[name]; ok {
-		kinds := make([]string, 0, len(bucket))
-		for k := range bucket {
+		kinds := make([]string, 0, bucket.len())
+		bucket.each(func(k, _ string) {
 			kinds = append(kinds, k)
-		}
+		})
 		sort.Strings(kinds)
 		diag.KindsPresent = kinds
 	}

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -265,8 +265,8 @@ func MergeModuleBatch(si *SymbolIndex, offset, batchSize int) (Index, int) {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string, total),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]map[string]string, total),
-		nameKindsReal:      make(map[string]map[string]string, total),
+		nameKinds:          make(map[string]kindIDs, total),
+		nameKindsReal:      make(map[string]kindIDs, total),
 		byLocation:         make(LocationIndex, total/2+1),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, total/2+1),
@@ -517,8 +517,8 @@ func accumulatorIndex(totalEntities int) Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string, totalEntities),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]map[string]string, totalEntities),
-		nameKindsReal:      make(map[string]map[string]string, totalEntities),
+		nameKinds:          make(map[string]kindIDs, totalEntities),
+		nameKindsReal:      make(map[string]kindIDs, totalEntities),
 		byLocation:         make(LocationIndex, cap2),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, cap2),
@@ -542,8 +542,8 @@ func emptyIndex() Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]map[string]string),
-		nameKindsReal:      make(map[string]map[string]string),
+		nameKinds:          make(map[string]kindIDs),
+		nameKindsReal:      make(map[string]kindIDs),
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
@@ -615,35 +615,23 @@ func insertModuleEntry(
 		bucket[me.name] = me.id
 	}
 
-	// nameKinds (all kinds, including SCOPE.*).
+	// nameKinds (all kinds, including SCOPE.*). Mirror of BuildIndex's
+	// writer using the compact kindIDs bucket (#5954). Stored back by value
+	// since kindIDs lives inline in the map.
 	nameKindBucket := idx.nameKinds[me.name]
-	if nameKindBucket == nil {
-		nameKindBucket = make(map[string]string)
-		idx.nameKinds[me.name] = nameKindBucket
-	}
 	for _, kind := range kinds {
 		if kind == "" {
 			continue
 		}
-		if existing, ok := nameKindBucket[kind]; ok && existing != me.id {
-			nameKindBucket[kind] = ""
-		} else {
-			nameKindBucket[kind] = me.id
-		}
+		nameKindBucket.set(kind, me.id)
 	}
+	idx.nameKinds[me.name] = nameKindBucket
 
 	// nameKindsReal — original kind only.
 	if me.kind != "" {
 		realBucket := idx.nameKindsReal[me.name]
-		if realBucket == nil {
-			realBucket = make(map[string]string)
-			idx.nameKindsReal[me.name] = realBucket
-		}
-		if existing, ok := realBucket[me.kind]; ok && existing != me.id {
-			realBucket[me.kind] = ""
-		} else {
-			realBucket[me.kind] = me.id
-		}
+		realBucket.set(me.kind, me.id)
+		idx.nameKindsReal[me.name] = realBucket
 	}
 
 	// Location indexes.
@@ -652,42 +640,28 @@ func insertModuleEntry(
 		// byLocationKind (both kinds).
 		fileKindBucket := idx.byLocationKind[sf]
 		if fileKindBucket == nil {
-			fileKindBucket = make(map[string]map[string]string)
+			fileKindBucket = make(map[string]kindIDs)
 			idx.byLocationKind[sf] = fileKindBucket
 		}
 		nameKindBucketLoc := fileKindBucket[me.name]
-		if nameKindBucketLoc == nil {
-			nameKindBucketLoc = make(map[string]string)
-			fileKindBucket[me.name] = nameKindBucketLoc
-		}
 		for _, kind := range kinds {
 			if kind == "" {
 				continue
 			}
-			if existing, ok := nameKindBucketLoc[kind]; ok && existing != me.id {
-				nameKindBucketLoc[kind] = ""
-			} else {
-				nameKindBucketLoc[kind] = me.id
-			}
+			nameKindBucketLoc.set(kind, me.id)
 		}
+		fileKindBucket[me.name] = nameKindBucketLoc
 
 		// byLocationKindReal — original kind only.
 		if me.kind != "" {
 			realFileBucket := idx.byLocationKindReal[sf]
 			if realFileBucket == nil {
-				realFileBucket = make(map[string]map[string]string)
+				realFileBucket = make(map[string]kindIDs)
 				idx.byLocationKindReal[sf] = realFileBucket
 			}
 			realNameBucket := realFileBucket[me.name]
-			if realNameBucket == nil {
-				realNameBucket = make(map[string]string)
-				realFileBucket[me.name] = realNameBucket
-			}
-			if existing, ok := realNameBucket[me.kind]; ok && existing != me.id {
-				realNameBucket[me.kind] = ""
-			} else {
-				realNameBucket[me.kind] = me.id
-			}
+			realNameBucket.set(me.kind, me.id)
+			realFileBucket[me.name] = realNameBucket
 		}
 
 		// byLocation (kind-agnostic, unique within file).


### PR DESCRIPTION
## What

Replace the four dominant inner `map[string]string` (kind→id) maps in the resolver `Index` with a compact `kindIDs` value type (`k0,v0` inline + `rest []kindID` spill). These maps — `nameKinds`, `nameKindsReal`, `byLocationKind`, `byLocationKindReal` — hold ~1 entry each at corpus scale but each pay full Go map overhead (~300 B), making `BuildIndex` the #1 peak-heap allocator in the `index-internal` subprocess (measured ~32% of peak, ~0.72 GB). The single-entry common case is now **zero-heap** (inline slot, verified by `AllocsPerRun`).

## Correctness — behaviorally identical to the map

`kindIDs.get/set/put` preserve the exact `map[string]string` semantics the resolver relies on, including the `""` blank-sentinel that encodes an ambiguous name and drives the #525 real-vs-placeholder preference:

- absent → first write stores id; same id → idempotent; **different** id → blanks to `""`; once blanked it **stays blank** on any later write (no resurrection); `get` returns `("",true)` for blanked (ambiguous-present) vs `("",false)` for absent.
- The `k0==""` empty-slot sentinel can never collide with a real kind: every `set` call site guards `kind != ""`, and a blank value is only ever written to an already-present kind.

Both writers converted in parity: `BuildIndex` (`refs.go`) and `insertModuleEntry` (`symbol_index.go`, the `GRAFEL_RESOLVE_MODULE_INDEX` M5 path). No reader depends on entry order. No `graph.fb` format change — in-memory only.

## Tests

- `kindids_test.go`: exhaustive write-sequence fuzz vs a `map` oracle (all sequences ≤3 over 3 kinds × 3 ids — covers the resurrection sequence), explicit blank-stays-blank pin, and the single-entry 0-alloc assertion. RED→GREEN captured.
- `kindids_equiv_test.go`: full-Index `DeepEqual` parity of all four live buckets vs an independent oracle over a multi-language fixture incl. the real+SCOPE collision, plus an entry-point battery asserting every reader binds to the concrete real id (the #525 gate).
- `go build ./... && go vet ./internal/resolve/... && gofmt -l internal` clean; `go test ./internal/resolve/... -race -count=1` green (existing `refs_test.go`, `symbol_index_parity_test.go`, `discriminator_scope_3936_test.go`, `django_fk_test.go` unchanged).

Independently adversarially reviewed (resurrection, empty-kind collision, order-dependence, spill correctness, writer parity — all verified).

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
