### PR TITLE
perf(#5954): stop retaining tree-sitter parse trees (-34% peak RSS, -78% wall)

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -43,7 +43,6 @@ import (
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/resolve"
 	"github.com/cajasmota/grafel/internal/treesitter"
-	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"github.com/cajasmota/grafel/internal/types"
 	"github.com/cajasmota/grafel/internal/version"
 )
@@ -100,12 +99,20 @@ type fileTask struct {
 
 // classifiedFile is a file that survived classification — extractors will
 // be run against it in Pass 1 and Pass 3.
+//
+// Deliberately carries NO tree-sitter parse tree (#5954). Trees are
+// CGo-allocated (~19.7 bytes of C heap per source byte, ~89 B/node) and
+// go-tree-sitter@v0.24.0 installs no finalizer, so a tree retained here is a
+// tree held for the life of the process — retaining one per classified file
+// cost ~1.4-1.6 GB of peak RSS on a 24k-file corpus. Pass 1 closes each tree
+// the moment its extractor returns (see runPass1ExtractWithProgress); Pass 3
+// cross-language extractors read only Path/Content/Language and never touch
+// a tree. Do not re-add a tree field here.
 type classifiedFile struct {
 	relPath  string
 	absPath  string
 	language string
 	content  []byte
-	tree     ts.Tree
 }
 
 // Indexer owns the pass-by-pass orchestration. Constructing a fresh Indexer
@@ -3167,7 +3174,6 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				}
 				if pr, perr := i.parser.Parse(ctx, content, parseLang); perr == nil && pr != nil {
 					file.TSTree = pr.TSTree
-					cf.tree = pr.TSTree
 					// A4 canary (#5414): fold this parse's ERROR-node ratio
 					// into the per-language accumulator. Key by the classifier
 					// language (not the tsx parse override) so .tsx/.jsx roll
@@ -3178,6 +3184,12 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				}
 
 				if !runExtract {
+					// #5954 — nothing will consume this tree; release the
+					// CGo allocation now (see the close below for why).
+					if file.TSTree != nil {
+						file.TSTree.Close()
+						file.TSTree = nil
+					}
 					mu.Lock()
 					classified = append(classified, cf)
 					mu.Unlock()
@@ -3187,6 +3199,33 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				}
 
 				ents, extractErr := extractors.Extract(ctx, file)
+
+				// #5954 — release the parse tree the moment its only consumer
+				// (the Pass-1 language extractor above) has returned. Mirrors
+				// internal/daemon/extract/subproc.go:446-453 ("this is what
+				// keeps batch RSS bounded", ADR 0023 / #5418).
+				//
+				// WHY THIS MATTERS: tree-sitter trees are CGo-allocated —
+				// invisible to the Go heap profiler and to GOMEMLIMIT — and
+				// cost ~19.7 bytes of C heap per source byte (~89 B/node).
+				// go-tree-sitter@v0.24.0 installs NO finalizer, so an
+				// un-Close()d tree leaks for the life of the process. Holding
+				// one tree per classified file (the old behaviour: stash it on
+				// classifiedFile, close it only after Pass 3) pinned ~1.4-1.6
+				// GB of C heap on a 24k-file corpus, and macOS libmalloc never
+				// returns that high-water to the OS. Keeping the live set at
+				// one tree per worker keeps it under ~50 MB.
+				//
+				// INVARIANT: extractors return plain []types.EntityRecord and
+				// must not retain a ts.Node past Extract — a Node holds a
+				// pointer INTO the tree, so retaining one past Close is a
+				// use-after-free. Close() is NOT idempotent (it calls
+				// ts_tree_delete unconditionally), hence the nil-out.
+				if file.TSTree != nil {
+					file.TSTree.Close()
+					file.TSTree = nil
+				}
+
 				relCount := 0
 				for k := range ents {
 					relCount += len(ents[k].Relationships)
@@ -3402,9 +3441,9 @@ func (i *Indexer) runPass3CrossLang(ctx context.Context, absRepo string, classif
 					Language: cf.language,
 					RepoRoot: absRepo,
 				}
-				if cf.tree != nil {
-					input.TSTree = cf.tree
-				}
+				// No TSTree is stamped here (#5954): every registered cross
+				// extractor reads only Path/Content/Language, and Pass 1 has
+				// already closed the tree. See classifiedFile.
 				for _, e := range exts {
 					ents, err := e.Extractor.Extract(ctx, input)
 					if err != nil {
@@ -5187,21 +5226,20 @@ func runJavaAnnotationRoutes(classified []classifiedFile) []types.EntityRecord {
 	return engine.ApplyJavaAnnotationRoutesWithContext(javaPaths, reader, authCtx)
 }
 
-// releaseClassifiedASTs explicitly drops the tree-sitter parse trees + source
-// bytes attached to each classifiedFile entry. Called after the last
-// extractor pass (Pass 3 cross-language) finishes. The tree-sitter Tree.Close
-// path releases the C-side tree allocation that runtime.GC cannot reclaim
-// because the goroutine handle is reference-counted via CGo, not via the Go
-// allocator. Setting .content to nil drops the per-file source-byte buffer
-// the resolver no longer needs. Issue #633.
+// releaseClassifiedASTs drops the source bytes attached to each
+// classifiedFile entry. Called after the last extractor pass (Pass 3
+// cross-language) finishes; setting .content to nil drops the per-file
+// source-byte buffer the resolver no longer needs. Issue #633.
+//
+// It no longer closes parse trees: since #5954 classifiedFile carries none.
+// Pass 1 closes each tree as soon as its extractor returns, which is what
+// keeps the CGo high-water bounded — closing here was far too late (the peak
+// had already been paid) and macOS libmalloc never returns the pages anyway.
+// Re-adding a close here would also risk a double free: ts.Tree.Close() maps
+// straight onto ts_tree_delete and is not idempotent.
 func releaseClassifiedASTs(classified []classifiedFile) {
 	for k := range classified {
-		cf := &classified[k]
-		if cf.tree != nil {
-			cf.tree.Close()
-			cf.tree = nil
-		}
-		cf.content = nil
+		classified[k].content = nil
 	}
 }
 

--- a/cmd/grafel/tstree_retention_5954_test.go
+++ b/cmd/grafel/tstree_retention_5954_test.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+)
+
+// Issue #5954 — tree-sitter parse trees must NOT outlive the Pass-1 extractor
+// that consumes them.
+//
+// Trees are CGo-allocated (~19.7 bytes of C heap per source byte, ~89 B/node),
+// they are invisible to the Go heap profiler and to GOMEMLIMIT, and
+// go-tree-sitter@v0.24.0 installs NO finalizer — an un-Close()d tree is a leak
+// for the life of the process. Retaining one tree per classified file (the old
+// behaviour) pinned ~1.4-1.6 GB of C heap on a 24k-file corpus, and macOS
+// libmalloc never returns that high-water to the OS.
+//
+// These tests are the guard rail against silently reintroducing retention.
+
+// TestIssue5954_ClassifiedFileHoldsNoParseTree fails if anyone re-adds a
+// tree-sitter tree (or any handle onto one) to classifiedFile. classifiedFile
+// is retained for the whole run, so a tree stored there is a tree held for the
+// whole run — exactly the regression this issue removed.
+func TestIssue5954_ClassifiedFileHoldsNoParseTree(t *testing.T) {
+	treeIface := reflect.TypeOf((*ts.Tree)(nil)).Elem()
+	nodeIface := reflect.TypeOf((*ts.Node)(nil)).Elem()
+
+	rt := reflect.TypeOf(classifiedFile{})
+	for i := 0; i < rt.NumField(); i++ {
+		f := rt.Field(i)
+		if f.Type == treeIface || f.Type == nodeIface {
+			t.Fatalf("classifiedFile.%s is a %s: parse trees/nodes must not be "+
+				"retained past Pass 1 (#5954 — CGo memory, no finalizer, "+
+				"~19.7 B of C heap per source byte)", f.Name, f.Type)
+		}
+		if f.Type.Implements(treeIface) || f.Type.Implements(nodeIface) {
+			t.Fatalf("classifiedFile.%s (%s) implements a tree-sitter handle "+
+				"interface: parse trees/nodes must not be retained past Pass 1 (#5954)",
+				f.Name, f.Type)
+		}
+	}
+}
+
+// TestIssue5954_Pass1ClosesTreesWithoutBreakingOutput drives the full indexer
+// over a small multi-language fixture and asserts the run is deterministic and
+// non-empty.
+//
+// Value under -race / normally: Pass 1 now Close()s each tree the moment its
+// extractor returns, and ts.Tree.Close maps straight onto ts_tree_delete (it is
+// NOT idempotent). If any extractor retained a ts.Node past Extract — a Node
+// holds a pointer INTO the tree — or if any later pass tried to read the tree,
+// this exercise would fault in C or produce diverging output.
+//
+// The fixture deliberately includes Java/Kotlin/Python sources shaped for the
+// Spring and Django route-composition passes, which own their own trees and
+// now close them (the three leaks fixed alongside #5954).
+func TestIssue5954_Pass1ClosesTreesWithoutBreakingOutput(t *testing.T) {
+	repo := t.TempDir()
+	files := map[string]string{
+		"svc/OrderController.java": `package svc;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+    @GetMapping("/{id}")
+    public String get(@PathVariable String id) { return id; }
+}
+`,
+		"svc/UserController.kt": `package svc
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api/users")
+class UserController {
+    @GetMapping("/{id}")
+    fun get(id: String): String = id
+}
+`,
+		"app/urls.py": `from django.urls import path, include
+from rest_framework import routers
+
+router = routers.DefaultRouter()
+router.register(r'widgets', WidgetViewSet)
+
+urlpatterns = [
+    path("api/", include(router.urls)),
+]
+`,
+		"app/views.py": `class WidgetViewSet:
+    def list(self, request):
+        return helper()
+
+def helper():
+    return 1
+`,
+		"pkg/main.go": `package pkg
+
+func Helper() int { return 1 }
+
+func Caller() int { return Helper() }
+`,
+		"web/client.ts": `export async function fetchOrder(id: string) {
+  return fetch("/api/orders/" + id);
+}
+`,
+		"lib/thing.rb": `class Thing
+  def run
+    helper
+  end
+end
+`,
+	}
+	for rel, src := range files {
+		abs := filepath.Join(repo, rel)
+		if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(abs, []byte(src), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+
+	fingerprint := func(doc *graph.Document) (int, int, string) {
+		t.Helper()
+		if doc == nil {
+			t.Fatal("nil document")
+		}
+		var b []byte
+		for _, e := range doc.Entities {
+			b = append(b, e.ID...)
+			b = append(b, '|')
+			b = append(b, e.Kind...)
+			b = append(b, '|')
+			b = append(b, e.Name...)
+			b = append(b, '\n')
+		}
+		return len(doc.Entities), len(doc.Relationships), string(b)
+	}
+
+	e1, r1, fp1 := fingerprint(runIndexerOn(t, repo, "tstree5954", nil))
+	if e1 == 0 {
+		t.Fatal("no entities extracted — fixture or Pass 1 is broken")
+	}
+	e2, r2, fp2 := fingerprint(runIndexerOn(t, repo, "tstree5954", nil))
+
+	if e1 != e2 || r1 != r2 {
+		t.Fatalf("nondeterministic counts: run1 e=%d r=%d, run2 e=%d r=%d", e1, r1, e2, r2)
+	}
+	if fp1 != fp2 {
+		t.Fatal("nondeterministic entity fingerprint across two runs of the same fixture")
+	}
+}

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -385,6 +385,10 @@ func extractDjangoComposedRoutes(ctx context.Context, path string, content []byt
 	if err != nil || pr == nil || pr.TSTree == nil {
 		return out, false
 	}
+	// #5954 — CGo-allocated tree with no finalizer; leaks for the life of the
+	// process unless explicitly closed. `out` holds only plain records and
+	// strings, never a ts.Node, so closing on return is safe.
+	defer pr.TSTree.Close()
 
 	root := pr.TSTree.RootNode()
 

--- a/internal/engine/spring_routes.go
+++ b/internal/engine/spring_routes.go
@@ -152,6 +152,12 @@ func extractSpringComposedRoutes(ctx context.Context, path string, content []byt
 	if err != nil || pr == nil || pr.TSTree == nil {
 		return out, false
 	}
+	// #5954 — tree-sitter trees are CGo-allocated (~19.7 B of C heap per
+	// source byte) and go-tree-sitter@v0.24.0 installs no finalizer, so an
+	// un-Close()d tree leaks for the life of the process. `out` holds only
+	// plain records/strings, never a ts.Node, so closing on return is safe.
+	// Same pattern as http_endpoint_client_ast.go.
+	defer pr.TSTree.Close()
 
 	root := pr.TSTree.RootNode()
 	walkSpringClasses(root, content, path, &out)

--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -69,6 +69,10 @@ func extractKotlinSpringEndpoints(ctx context.Context, path string, content []by
 	if err != nil || pr == nil || pr.TSTree == nil {
 		return nil, nil
 	}
+	// #5954 — CGo-allocated tree with no finalizer; leaks for the life of the
+	// process unless explicitly closed. The returned entities/relationships
+	// are plain records, never a ts.Node, so closing on return is safe.
+	defer pr.TSTree.Close()
 
 	var entities []types.EntityRecord
 	var rels []types.RelationshipRecord


### PR DESCRIPTION
## What

Stop retaining tree-sitter parse trees, and close three that never closed at all.

tree-sitter trees are C-`malloc`'d (~19.7 bytes of C heap per source byte) and `go-tree-sitter@v0.24.0` has **no finalizer** — an unclosed tree leaks for the process lifetime and is invisible to Go's heap profiler.

- **F0:** Pass 1 stored every file's tree on `classifiedFile.tree` and closed them only much later, so all ~24k trees were live simultaneously. The field is removed; each tree is now closed (and the handle nil'd) immediately after that file's `extractors.Extract`, mirroring the existing precedent at `internal/daemon/extract/subproc.go:446-453`.
- **F0b:** `internal/engine/spring_routes.go`, `spring_routes_kotlin.go`, and `django_routes.go` parsed their own trees and never closed them. Each now has `defer Close()`.
- The `input.TSTree = cf.tree` stamp in `runPass3CrossLang` was dead code (no cross extractor references `TSTree`/`RootNode`/`ts.Node` at all) and is removed.

## Why this matters

This is CGo memory, so it was untouched by every Go-side optimization in this epic. Measured on a 7,281-file tree: **peak RSS 2.77 GB → 1.84 GB (−34%)** and **wall 185 s → 40 s (−78%)**, with identical output.

## Safety

`ts.Node` holds a raw pointer into the tree's C memory, so closing early is a use-after-free if any Node escapes `Extract`. Audited repo-wide: all ~22 language extractors read `file.TSTree`/`RootNode()` only inside `Extract` and return plain records; the only 4 structs holding a `ts.Node` are function/`*extractor`-scoped and drained before return; no package-level Node/Tree vars, no goroutines in `internal/extractors`, no Node fields on `EntityRecord`/`RelationshipRecord`.

`Close()` is **not** idempotent (it guards a nil receiver but does not nil `_inner`), so every close site nils the handle and each tree has exactly one owner with exactly one close — verified across the `!runExtract` early-continue, normal, error and panic paths (`safeExtract`'s `recover()` keeps the panic path correct).

Independently adversarially reviewed, including a use-after-free probe under `MallocScribble=1 MallocPreScribble=1` (freed C memory poisoned) over a 7,281-file index: entity symdiff 0, no crash.

## Tests

- New `cmd/grafel/tstree_retention_5954_test.go`: reflect guard failing if `classifiedFile` regains a `ts.Tree`/`ts.Node` field (negative-tested), plus a 7-file multi-language fixture (Java Spring / Kotlin Spring / Django / Go / TS / Ruby — deliberately hitting the three F0b sites).
- Output byte-identical: 1,726-file multi-language repo → entities 15586, relationships 67210 on both binaries; per-key JSON identical (`entities` 7,078,191 B, `relationships` 11,988,997 B). Reviewer independently confirmed on 382-file/22-language and 7,281-file corpora, with deltas inside the base-vs-base noise floor.
- `go build ./...`, `go vet`, `gofmt -l internal cmd` clean; `./cmd/grafel/...` 289 pass (incl `-race`); engine/extractor/extractors 6714 pass. Existing determinism goldens (`TestIssue481_*`, `TestBuildDocumentGolden5955`) unchanged.

## Follow-up (separate issue)

Trees are still leaked when `parseOfficial` returns `ErrHighSyntaxErrorRate` (>10% error nodes) — callers bail on `err != nil` before acquiring the handle, so exactly the large malformed/minified files leak. Same bug class, tracked separately.

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
