### PR TITLE
fix(#5963): close tree-sitter tree before returning ErrHighSyntaxErrorRate

### DIFF
--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -79,8 +79,12 @@ func SupportedLanguages() []string {
 
 // ParseResult holds the output of a single Parse call.
 type ParseResult struct {
-	// TSTree is the binding-agnostic parse tree, always populated. Extractors
-	// consume it via the ts façade (ADR 0023, #5418).
+	// TSTree is the binding-agnostic parse tree. Extractors consume it via the
+	// ts façade (ADR 0023, #5418). It is populated on success, but is nil
+	// when Parse returns ErrHighSyntaxErrorRate (#5963) — the tree is closed
+	// internally before the error is returned, since no caller uses it on
+	// that path and leaving it live with no owner leaked C heap for the life
+	// of the process.
 	TSTree ts.Tree
 	// Language is the normalised language name used for the parse.
 	Language string
@@ -120,6 +124,8 @@ func NewParserFactory(tracer trace.Tracer) *ParserFactory {
 // Behaviour:
 //   - Returns ErrUnsupportedLanguage if language is not in the registry.
 //   - Returns ErrHighSyntaxErrorRate if error_ratio > 10% (file too malformed).
+//     The returned ParseResult still carries Language/ErrorRatio/NodeCount,
+//     but TSTree is nil — the tree is closed before returning (#5963).
 //   - An empty source slice returns a zero-node result with no error.
 //   - The OTel span "treesitter.parse" is always emitted with attributes:
 //     language, file_size_bytes, error_ratio, node_count.
@@ -215,16 +221,34 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 	errorRatio := ratio(total, errNodes)
 	setParseSpan(span, language, len(source), errorRatio, total)
 
-	result := &ParseResult{
+	if errorRatio > maxErrorRatio {
+		// #5963 — same leak class as #5954/#5962: every caller bails on
+		// err != nil without ever taking ownership of (or closing) the tree,
+		// so a tree returned alongside ErrHighSyntaxErrorRate would leak for
+		// the life of the process (no finalizer on go-tree-sitter@v0.24.0,
+		// ~19.7 bytes of C heap per source byte). Files that trip this ratio
+		// skew toward the largest minified/generated/malformed inputs, so the
+		// leak was biased toward the biggest trees. Close it here — the
+		// single chokepoint every real parse funnels through — instead of
+		// patching every call site: no caller inspects the tree on this
+		// error path (verified by audit), so there is nothing to preserve.
+		// TSTree is left nil (not just closed) so a caller that forgets to
+		// check the error still gets a nil-deref instead of a use-after-free
+		// on a dangling Close()'d handle.
+		tree.Close()
+		return &ParseResult{
+			Language:   language,
+			ErrorRatio: errorRatio,
+			NodeCount:  total,
+		}, fmt.Errorf("%w: language=%s error_ratio=%.4f", ErrHighSyntaxErrorRate, language, errorRatio)
+	}
+
+	return &ParseResult{
 		TSTree:     tree,
 		Language:   language,
 		ErrorRatio: errorRatio,
 		NodeCount:  total,
-	}
-	if errorRatio > maxErrorRatio {
-		return result, fmt.Errorf("%w: language=%s error_ratio=%.4f", ErrHighSyntaxErrorRate, language, errorRatio)
-	}
-	return result, nil
+	}, nil
 }
 
 func ratio(total, errNodes int) float64 {

--- a/internal/treesitter/parser_test.go
+++ b/internal/treesitter/parser_test.go
@@ -94,12 +94,22 @@ func )()()(  }{}{}{} :::
 	if !errors.Is(err, treesitter.ErrHighSyntaxErrorRate) {
 		t.Errorf("expected ErrHighSyntaxErrorRate, got: %v", err)
 	}
-	// Result is returned alongside the error so callers can inspect the tree.
+	// Result is returned alongside the error so callers can inspect the
+	// metadata (Language/ErrorRatio/NodeCount), but NOT the tree itself: no
+	// caller uses the tree on this path, and an un-Close()d tree leaks C heap
+	// for the life of the process (#5963, same class as #5962). The tree is
+	// closed internally before the error is returned, so TSTree must be nil
+	// here — that is the directly-testable contract; asserting the C memory
+	// was actually freed isn't possible from Go without cgo instrumentation.
 	if res == nil {
-		t.Error("expected non-nil ParseResult even on ErrHighSyntaxErrorRate")
+		t.Fatal("expected non-nil ParseResult even on ErrHighSyntaxErrorRate")
 	}
-	if res != nil && res.ErrorRatio <= 0.10 {
+	if res.ErrorRatio <= 0.10 {
 		t.Errorf("expected error_ratio > 0.10, got %.4f", res.ErrorRatio)
+	}
+	if res.TSTree != nil {
+		t.Error("expected TSTree to be nil on ErrHighSyntaxErrorRate — the tree must be closed internally " +
+			"before returning since no caller takes ownership on this path (#5963)")
 	}
 }
 


### PR DESCRIPTION
## What

`parseOfficial` returned a **live** `ParseResult.TSTree` alongside a non-nil `ErrHighSyntaxErrorRate` (error-node ratio > 10%). Every caller bails on `err != nil` *before* taking ownership of the handle, so the tree was never closed — and because tree-sitter trees are C-`malloc`'d and `go-tree-sitter@v0.24.0` has **no finalizer**, each one stayed resident for the process lifetime, invisible to Go heap profiling.

Files that trip a >10% error-node ratio are disproportionately the large minified/generated/malformed ones, so the leak was biased toward the biggest trees.

## The fix — central, not per-caller

`parseOfficial` now closes the tree itself on the high-error-ratio branch and returns `TSTree == nil` (still populating `Language`/`ErrorRatio`/`NodeCount` for the canary path).

This was chosen over patching the six call sites because an audit showed **no caller consumes the tree when `err != nil`**, so fixing it once at the source removes the entire footgun class and prevents a seventh caller from reintroducing it.

## Safety

- **No error-ignoring callers.** Every `ParserFactory.Parse` call site either gates the tree assignment on `perr == nil && pr != nil` (`cmd/grafel/index.go:3175`, `internal/daemon/extract/subproc.go:317`) or double-guards with `err != nil || pr == nil || pr.TSTree == nil` (the four `internal/engine` sites and `internal/custom/kotlin/ktor_routes.go`). None destructures the error with `_` or checks `pr.TSTree != nil` in place of `err`. The per-language extractor adapters bypass `ParserFactory` entirely and are unaffected.
- **No intentional partial-parse consumer.** History and `docs/grammar-freshness-audit.md` describe `maxErrorRatio` purely as a rejection gate plus OTel signal, never as best-effort extraction.
- **Double-close impossible.** The error branch returns a nil `TSTree` interface value, so no caller can obtain a handle to the freed tree. (`Close()` is non-idempotent — it guards a nil receiver but does not nil `_inner` — which is why returning nil rather than the closed handle matters.)
- **Node lifetime.** `countNodesTS(tree.RootNode())` fully returns before `tree.Close()`, so no `ts.Node` outlives the close.

## Tests

`TestParse_MalformedFile_TriggerHighSyntaxErrorRate` extended to assert `TSTree == nil` on the error path. Verified RED against the pre-fix `parser.go` and GREEN after — independently reproduced by the reviewer by reverting only `parser.go`.

`go build ./...`, `go vet`, `gofmt -l internal cmd` clean. `./internal/treesitter/...` 118 pass; `./internal/engine/... ./internal/extractors/...` 6660 pass; `./cmd/grafel/...` 289 pass including goldens (output byte-identical), also green under `-race`.

Independently adversarially reviewed.

Closes #5963
Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
