### PR TITLE
perf(#5954): adaptive Go soft memory limit for index-internal (safe-floor policy)

### DIFF
--- a/cmd/grafel/index_internal.go
+++ b/cmd/grafel/index_internal.go
@@ -26,12 +26,11 @@ import (
 //   - stdout  = JSON progress lines (one per pipeline phase)
 //   - SIGTERM = clean cancellation; exit non-zero
 func runIndexInternal(argv []string) int {
-	// Bound this process's peak footprint before any indexing work starts
-	// (#5954). Measured on the real corpus: 4026MB -> 3203MB peak RSS for
-	// +1.7% wall time. Applied here rather than via a GOMEMLIMIT env var so it
-	// holds no matter how the child was launched. Never fatal.
-	applyIndexMemoryLimit()
-
+	// NOTE: the Go soft memory limit for this process is applied by the
+	// `index-internal` intercept in main.go, NOT here (#5954).
+	// debug.SetMemoryLimit is a PROCESS-WIDE side effect, and this function is
+	// also called in-process by cmd/grafel's own tests — setting it here would
+	// silently pin a soft limit for the remainder of the package's test binary.
 	fs := flag.NewFlagSet("index-internal", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 
@@ -113,6 +112,11 @@ func runIndexInternal(argv []string) int {
 
 	outPath := *out
 	err := Index(*repo, outPath, *repoTag, skipList, false, false, opts...)
+	// #5954: one post-run GC CPU sample. Diagnosis only — it never re-tunes the
+	// limit. Silent unless a soft limit was actually applied AND the run spent
+	// an implausible share of CPU in GC. Runs on the failure path too: a run
+	// that fought the limit may well have failed because of it.
+	reportGCThrash()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "index-internal: %v\n", err)
 		fmt.Printf("{\"event\":\"index_error\",\"repo\":%q,\"error\":%q}\n", *repo, err.Error())

--- a/cmd/grafel/index_internal.go
+++ b/cmd/grafel/index_internal.go
@@ -26,6 +26,12 @@ import (
 //   - stdout  = JSON progress lines (one per pipeline phase)
 //   - SIGTERM = clean cancellation; exit non-zero
 func runIndexInternal(argv []string) int {
+	// Bound this process's peak footprint before any indexing work starts
+	// (#5954). Measured on the real corpus: 4026MB -> 3203MB peak RSS for
+	// +1.7% wall time. Applied here rather than via a GOMEMLIMIT env var so it
+	// holds no matter how the child was launched. Never fatal.
+	applyIndexMemoryLimit()
+
 	fs := flag.NewFlagSet("index-internal", flag.ContinueOnError)
 	fs.SetOutput(os.Stderr)
 

--- a/cmd/grafel/index_memlimit.go
+++ b/cmd/grafel/index_memlimit.go
@@ -1,0 +1,158 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// indexMemLimitEnv is the operator escape hatch for the Go soft memory limit
+// the `index-internal` child applies to itself. It accepts a byte size, either
+// plain bytes ("2621440000") or a MiB/GiB suffix ("2500MiB", "3GiB"). The
+// values "0", "off" and "disabled" mean "apply no limit at all" (leave the Go
+// runtime default). A malformed value is ignored (logged, never fatal) and the
+// adaptive policy applies instead. Added for #5954.
+const indexMemLimitEnv = "GRAFEL_INDEX_MEMLIMIT"
+
+// memLimitUnset is the sentinel for "do not call debug.SetMemoryLimit at all".
+const memLimitUnset int64 = 0
+
+// indexMemLimitFloorBytes is the smallest soft limit the ADAPTIVE policy will
+// ever return. This floor is the anti-thrash guarantee and it is not
+// negotiable on small-RAM hosts.
+//
+// GOMEMLIMIT is a SOFT limit: when it sits BELOW the workload's live heap the
+// runtime cannot honor it and instead GCs continuously — a death spiral.
+// Measured on the real corpus (#5954): GOMEMLIMIT=1200MiB against a ~2.7GB
+// live heap made `index-internal` >4x slower (>16 min vs 235 s, never
+// completed). By contrast 2500MiB cut peak RSS 4026MB -> 3203MB for +2 s
+// (+1.7%). So a low-RAM machine must degrade to "generous limit" rather than
+// to "strangled process": we never hand the indexer a limit under 2GiB.
+const indexMemLimitFloorBytes int64 = 2 << 30 // 2 GiB
+
+// indexMemLimitFraction is the share of AVAILABLE (not total) host RAM used as
+// the soft limit when no override is set. On the measurement machine (~6GB
+// available) 0.5 resolves to 3GiB — just above the measured 2500MiB sweet spot
+// and comfortably above the ~2.7GB live heap, so the runtime trims the
+// reclaimable arena without ever GC-thrashing.
+const indexMemLimitFraction = 2 // divisor, i.e. 1/2 — integer math avoids float overflow on huge hosts
+
+// resolveIndexMemLimit implements the adaptive policy:
+//
+//	max(2GiB, 0.5 * availableRAM)
+//
+// availableBytes == 0 means "available RAM could not be determined"; we return
+// memLimitUnset rather than guessing, leaving the Go runtime default in place.
+func resolveIndexMemLimit(availableBytes uint64) int64 {
+	if availableBytes == 0 {
+		return memLimitUnset
+	}
+	half := availableBytes / indexMemLimitFraction
+	if half > uint64(math.MaxInt64) {
+		return math.MaxInt64
+	}
+	if limit := int64(half); limit > indexMemLimitFloorBytes {
+		return limit
+	}
+	return indexMemLimitFloorBytes
+}
+
+// parseIndexMemLimitEnv parses the GRAFEL_INDEX_MEMLIMIT escape hatch.
+//
+// decided reports whether the operator expressed a usable intent:
+//   - (n, true)              — apply n bytes verbatim (operator's explicit choice)
+//   - (memLimitUnset, true)  — "0"/"off"/"disabled": apply no limit at all
+//   - (0, false)             — unset or malformed: fall through to the adaptive policy
+func parseIndexMemLimitEnv(raw string) (limit int64, decided bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	switch strings.ToLower(raw) {
+	case "0", "off", "disabled", "false", "none":
+		return memLimitUnset, true
+	}
+
+	mult := int64(1)
+	digits := raw
+	switch {
+	case hasSuffixFold(raw, "gib"), hasSuffixFold(raw, "gb"):
+		mult = 1 << 30
+		digits = raw[:len(raw)-suffixLen(raw, "gib", "gb")]
+	case hasSuffixFold(raw, "mib"), hasSuffixFold(raw, "mb"):
+		mult = 1 << 20
+		digits = raw[:len(raw)-suffixLen(raw, "mib", "mb")]
+	case hasSuffixFold(raw, "b"):
+		digits = raw[:len(raw)-1]
+	}
+	digits = strings.TrimSpace(digits)
+	n, err := strconv.ParseInt(digits, 10, 64)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	if n == 0 {
+		return memLimitUnset, true
+	}
+	if n > math.MaxInt64/mult {
+		return 0, false
+	}
+	return n * mult, true
+}
+
+func hasSuffixFold(s, suffix string) bool {
+	return len(s) >= len(suffix) && strings.EqualFold(s[len(s)-len(suffix):], suffix)
+}
+
+// suffixLen returns the length of whichever candidate suffix s actually ends
+// with (longest first), so "4GiB" strips 3 chars and "4GB" strips 2.
+func suffixLen(s string, candidates ...string) int {
+	for _, c := range candidates {
+		if hasSuffixFold(s, c) {
+			return len(c)
+		}
+	}
+	return 0
+}
+
+// indexMemLimitDecision combines the escape hatch and the adaptive policy.
+// The env override always wins when it is well-formed; a malformed value falls
+// back to the adaptive policy (and never panics). The returned source string is
+// operator-facing — it goes straight into the one-shot log line.
+func indexMemLimitDecision(rawEnv string, availableBytes uint64) (limit int64, source string) {
+	if n, decided := parseIndexMemLimitEnv(rawEnv); decided {
+		return n, indexMemLimitEnv + "=" + strings.TrimSpace(rawEnv) + " (env)"
+	}
+	if strings.TrimSpace(rawEnv) != "" {
+		return resolveIndexMemLimit(availableBytes),
+			"adaptive (ignored malformed " + indexMemLimitEnv + "=" + strings.TrimSpace(rawEnv) + ")"
+	}
+	return resolveIndexMemLimit(availableBytes), "adaptive (max(2GiB, 0.5*available))"
+}
+
+// applyIndexMemoryLimit sets the Go soft memory limit for THIS process (the
+// `index-internal` child) before indexing starts, and logs the decision once so
+// a support case can see it immediately (#5954).
+//
+// Measured on the real corpus: 4026MB -> 3203MB peak RSS for +2 s (+1.7%).
+// See indexMemLimitFloorBytes for why the adaptive policy never goes low.
+func applyIndexMemoryLimit() {
+	availMB := process.AvailableMemoryMB()
+	var availBytes uint64
+	if availMB > 0 {
+		availBytes = uint64(availMB) * 1024 * 1024
+	}
+	limit, source := indexMemLimitDecision(os.Getenv(indexMemLimitEnv), availBytes)
+	if limit <= memLimitUnset {
+		fmt.Fprintf(os.Stderr, "index-internal: Go soft memory limit not applied (#5954) source=%s available_mb=%d\n",
+			source, availMB)
+		return
+	}
+	debug.SetMemoryLimit(limit)
+	fmt.Fprintf(os.Stderr, "index-internal: applied Go soft memory limit (#5954) limit_mb=%d available_mb=%d source=%s\n",
+		limit/(1024*1024), availMB, source)
+}

--- a/cmd/grafel/index_memlimit.go
+++ b/cmd/grafel/index_memlimit.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -22,44 +23,79 @@ const indexMemLimitEnv = "GRAFEL_INDEX_MEMLIMIT"
 // memLimitUnset is the sentinel for "do not call debug.SetMemoryLimit at all".
 const memLimitUnset int64 = 0
 
-// indexMemLimitFloorBytes is the smallest soft limit the ADAPTIVE policy will
-// ever return. This floor is the anti-thrash guarantee and it is not
-// negotiable on small-RAM hosts.
+// indexMemLimitSafeFloorBytes is the smallest soft limit we will ever apply.
+// It is ~1.15x the measured ~2.7GB live-heap ceiling of a full corpus index,
+// so the runtime always has room to actually REACH the target.
 //
-// GOMEMLIMIT is a SOFT limit: when it sits BELOW the workload's live heap the
-// runtime cannot honor it and instead GCs continuously — a death spiral.
+// This floor is the anti-thrash guarantee. GOMEMLIMIT is SOFT: set BELOW the
+// live heap, the runtime cannot honor it and instead runs repeated full-heap
+// mark cycles. Three things make that regime unbounded rather than merely
+// slow, and none of them are obvious:
+//
+//  1. Go's 50% GC CPU limiter does NOT bound the damage. It throttles
+//     mutator ASSISTS, but the mark cycles themselves are cache/TLB/
+//     page-fault bound and are not accounted to GC CPU.
+//  2. madvdontneed=1 (which we set on this child, see withMadvDontNeed)
+//     COMPOUNDS it: freed pages are returned to the OS and then immediately
+//     re-faulted on the next cycle.
+//  3. The tree-sitter CGo arenas are invisible to GOMEMLIMIT, so the runtime
+//     keeps GC'ing toward a target that non-Go memory guarantees it can
+//     never reach.
+//
 // Measured on the real corpus (#5954): GOMEMLIMIT=1200MiB against a ~2.7GB
-// live heap made `index-internal` >4x slower (>16 min vs 235 s, never
-// completed). By contrast 2500MiB cut peak RSS 4026MB -> 3203MB for +2 s
-// (+1.7%). So a low-RAM machine must degrade to "generous limit" rather than
-// to "strangled process": we never hand the indexer a limit under 2GiB.
-const indexMemLimitFloorBytes int64 = 2 << 30 // 2 GiB
+// live heap made `index-internal` >4x slower (>16 min vs 235 s) and never
+// completed. So the trade is ASYMMETRIC — a too-low limit costs unbounded,
+// non-terminating time; no limit at all costs a bounded +823MB. Never take
+// the former to avoid the latter.
+const indexMemLimitSafeFloorBytes int64 = 3 << 30 // 3 GiB
 
-// indexMemLimitFraction is the share of AVAILABLE (not total) host RAM used as
-// the soft limit when no override is set. On the measurement machine (~6GB
-// available) 0.5 resolves to 3GiB — just above the measured 2500MiB sweet spot
-// and comfortably above the ~2.7GB live heap, so the runtime trims the
-// reclaimable arena without ever GC-thrashing.
-const indexMemLimitFraction = 2 // divisor, i.e. 1/2 — integer math avoids float overflow on huge hosts
+// indexMemLimitMinAvailableBytes is the amount of available RAM below which we
+// do not attempt to bound the indexer AT ALL. Under 4GiB available there is no
+// limit that is simultaneously above the safe floor and actually useful, so the
+// honest answer is "unset": degrade to today's unbounded behavior rather than
+// strangle the process. This is the small-host escape valve that the previous
+// max(2GiB, available/2) policy got wrong — it kept returning a limit no matter
+// how little RAM there was.
+const indexMemLimitMinAvailableBytes uint64 = 4 << 30 // 4 GiB
 
-// resolveIndexMemLimit implements the adaptive policy:
+// resolveIndexMemLimit implements the adaptive policy (#5954):
 //
-//	max(2GiB, 0.5 * availableRAM)
+//	unset                            if available == 0 or available < 4GiB
+//	max(3GiB, availableRAM * 3/4)    otherwise
 //
 // availableBytes == 0 means "available RAM could not be determined"; we return
 // memLimitUnset rather than guessing, leaving the Go runtime default in place.
+//
+// Why 3/4 rather than 1/2: on the measurement host (4560MB available) 3/4
+// yields 3420MB — safely ABOVE the ~2.7GB live heap while still ~600MB below
+// the 4026MB unlimited baseline, so it trims the reclaimable arena without
+// entering the thrash regime. 1/2 yielded 2280MB there, i.e. BELOW the live
+// heap: the harmful case was the DEFAULT outcome on that machine, not an edge
+// case. On a 4GB-available host the policy degrades to today's behavior; on a
+// 32GB host it is non-binding, which is correct — the limit exists to trim the
+// reclaimable arena, not to act as a quota.
+//
+// Integer math throughout: a float multiply here would be a needless source of
+// rounding surprise in a value that gates a thrash cliff.
 func resolveIndexMemLimit(availableBytes uint64) int64 {
-	if availableBytes == 0 {
+	if availableBytes == 0 || availableBytes < indexMemLimitMinAvailableBytes {
 		return memLimitUnset
 	}
-	half := availableBytes / indexMemLimitFraction
-	if half > uint64(math.MaxInt64) {
+	// Overflow care: prefer the exact form, fall back to divide-first on
+	// absurdly large inputs so the multiply cannot wrap.
+	var target uint64
+	if availableBytes <= math.MaxUint64/3 {
+		target = availableBytes * 3 / 4
+	} else {
+		target = availableBytes / 4 * 3
+	}
+	if target > uint64(math.MaxInt64) {
 		return math.MaxInt64
 	}
-	if limit := int64(half); limit > indexMemLimitFloorBytes {
+	if limit := int64(target); limit > indexMemLimitSafeFloorBytes {
 		return limit
 	}
-	return indexMemLimitFloorBytes
+	return indexMemLimitSafeFloorBytes
 }
 
 // parseIndexMemLimitEnv parses the GRAFEL_INDEX_MEMLIMIT escape hatch.
@@ -131,7 +167,7 @@ func indexMemLimitDecision(rawEnv string, availableBytes uint64) (limit int64, s
 		return resolveIndexMemLimit(availableBytes),
 			"adaptive (ignored malformed " + indexMemLimitEnv + "=" + strings.TrimSpace(rawEnv) + ")"
 	}
-	return resolveIndexMemLimit(availableBytes), "adaptive (max(2GiB, 0.5*available))"
+	return resolveIndexMemLimit(availableBytes), "adaptive (max(3GiB, 0.75*available); unset under 4GiB available)"
 }
 
 // applyIndexMemoryLimit sets the Go soft memory limit for THIS process (the
@@ -139,7 +175,8 @@ func indexMemLimitDecision(rawEnv string, availableBytes uint64) (limit int64, s
 // a support case can see it immediately (#5954).
 //
 // Measured on the real corpus: 4026MB -> 3203MB peak RSS for +2 s (+1.7%).
-// See indexMemLimitFloorBytes for why the adaptive policy never goes low.
+// See indexMemLimitSafeFloorBytes for why the adaptive policy would rather
+// apply NO limit than apply a low one.
 func applyIndexMemoryLimit() {
 	availMB := process.AvailableMemoryMB()
 	var availBytes uint64
@@ -155,4 +192,48 @@ func applyIndexMemoryLimit() {
 	debug.SetMemoryLimit(limit)
 	fmt.Fprintf(os.Stderr, "index-internal: applied Go soft memory limit (#5954) limit_mb=%d available_mb=%d source=%s\n",
 		limit/(1024*1024), availMB, source)
+}
+
+// gcThrashCPUThreshold is the cumulative GC CPU fraction above which a run is
+// reported as suspicious. A healthy corpus index sits in the low single digits.
+const gcThrashCPUThreshold = 0.30
+
+// gcThrashWarning returns an operator-facing warning when a run finished with
+// an implausible share of CPU spent in GC while a soft memory limit was in
+// force — the fingerprint of the thrash regime described on
+// indexMemLimitSafeFloorBytes. It returns "" when there is nothing to say.
+//
+// This is DIAGNOSIS ONLY and deliberately so: there is no runtime valve that
+// re-tunes the limit mid-run. With the corrected policy (never a limit below
+// the safe floor, and no limit at all under 4GiB available) there is nothing
+// for a valve to rescue, and one would add a goroutine, thresholds, hysteresis
+// and nondeterminism to the hot path for no measured benefit.
+//
+// When no limit was applied (limit == math.MaxInt64, the runtime default) we
+// stay quiet: high GC CPU then has nothing to do with our tuning and pointing
+// at GRAFEL_INDEX_MEMLIMIT would send a support case down the wrong path.
+func gcThrashWarning(limit int64, gcFraction float64) string {
+	if limit <= 0 || limit == math.MaxInt64 {
+		return ""
+	}
+	if gcFraction < gcThrashCPUThreshold {
+		return ""
+	}
+	return fmt.Sprintf(
+		"index-internal: WARNING gc_cpu_fraction=%.2f exceeded %.2f with go_soft_memory_limit_mb=%d (#5954). "+
+			"The limit may be below this repo's live heap, which makes the runtime GC continuously. "+
+			"Set GRAFEL_INDEX_MEMLIMIT to a larger value, or to 'off' to disable the limit entirely.",
+		gcFraction, gcThrashCPUThreshold, limit/(1024*1024))
+}
+
+// reportGCThrash samples GC CPU once, after indexing has finished, and logs a
+// warning if the run looks like it fought the soft memory limit. One
+// ReadMemStats at process end is cheap (a single stop-the-world on a process
+// that is about to exit) and adds no goroutine.
+func reportGCThrash() {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	if w := gcThrashWarning(debug.SetMemoryLimit(-1), ms.GCCPUFraction); w != "" {
+		fmt.Fprintln(os.Stderr, w)
+	}
 }

--- a/cmd/grafel/index_memlimit_test.go
+++ b/cmd/grafel/index_memlimit_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+const (
+	giB = int64(1) << 30
+	miB = int64(1) << 20
+)
+
+// TestResolveIndexMemLimit pins the adaptive policy: max(2GiB, 0.5*available),
+// and "unset" when available RAM cannot be determined (#5954).
+func TestResolveIndexMemLimit(t *testing.T) {
+	cases := []struct {
+		name      string
+		available uint64
+		want      int64
+	}{
+		{"unknown ram -> unset", 0, memLimitUnset},
+		{"tiny host 1GiB -> floor", uint64(giB), 2 * giB},
+		{"small host 3GiB -> floor (half is 1.5GiB)", uint64(3 * giB), 2 * giB},
+		{"exactly at floor boundary 4GiB -> 2GiB", uint64(4 * giB), 2 * giB},
+		{"dev machine ~6GiB -> 3GiB", uint64(6 * giB), 3 * giB},
+		{"large host 64GiB -> 32GiB", uint64(64 * giB), 32 * giB},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveIndexMemLimit(tc.available); got != tc.want {
+				t.Errorf("resolveIndexMemLimit(%d) = %d, want %d", tc.available, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResolveIndexMemLimitFloorInvariant is the anti-thrash guarantee: a
+// GOMEMLIMIT BELOW the live heap sends the runtime into a GC death spiral
+// (measured: 1200MiB against a ~2.7GB live heap ran >4x slower and never
+// finished). So whenever the policy returns a limit at all, it is >= 2GiB.
+func TestResolveIndexMemLimitFloorInvariant(t *testing.T) {
+	for avail := uint64(0); avail <= uint64(96*giB); avail += uint64(64 * miB) {
+		got := resolveIndexMemLimit(avail)
+		if got == memLimitUnset {
+			continue
+		}
+		if got < 2*giB {
+			t.Fatalf("resolveIndexMemLimit(%d) = %d, below the 2GiB anti-thrash floor", avail, got)
+		}
+	}
+}
+
+// TestParseIndexMemLimitEnv covers the operator escape hatch.
+func TestParseIndexMemLimitEnv(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		wantLimit   int64
+		wantDecided bool
+	}{
+		{"empty -> undecided", "", 0, false},
+		{"plain bytes", "3221225472", 3 * giB, true},
+		{"MiB suffix", "2500MiB", 2500 * miB, true},
+		{"GiB suffix", "4GiB", 4 * giB, true},
+		{"lowercase gib", "4gib", 4 * giB, true},
+		{"spaces trimmed", "  2GiB  ", 2 * giB, true},
+		{"zero disables", "0", memLimitUnset, true},
+		{"off disables", "off", memLimitUnset, true},
+		{"OFF disables", "OFF", memLimitUnset, true},
+		{"disabled disables", "disabled", memLimitUnset, true},
+		{"negative -> malformed", "-5", 0, false},
+		{"garbage -> malformed", "banana", 0, false},
+		{"bad suffix -> malformed", "12PiB", 0, false},
+		{"empty number -> malformed", "GiB", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLimit, gotDecided := parseIndexMemLimitEnv(tc.raw)
+			if gotLimit != tc.wantLimit || gotDecided != tc.wantDecided {
+				t.Errorf("parseIndexMemLimitEnv(%q) = (%d, %v), want (%d, %v)",
+					tc.raw, gotLimit, gotDecided, tc.wantLimit, tc.wantDecided)
+			}
+		})
+	}
+}
+
+// TestIndexMemLimitDecision asserts precedence: a well-formed env override
+// always wins; a malformed one falls back to the adaptive policy (and never
+// panics).
+func TestIndexMemLimitDecision(t *testing.T) {
+	cases := []struct {
+		name       string
+		raw        string
+		available  uint64
+		wantLimit  int64
+		wantSource string
+	}{
+		{"no env -> adaptive", "", uint64(6 * giB), 3 * giB, "adaptive"},
+		{"env wins over adaptive", "2500MiB", uint64(64 * giB), 2500 * miB, "env"},
+		{"env disables even with ram known", "off", uint64(64 * giB), memLimitUnset, "env"},
+		{"malformed env -> adaptive", "banana", uint64(6 * giB), 3 * giB, "adaptive"},
+		{"malformed env, unknown ram -> unset", "banana", 0, memLimitUnset, "adaptive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLimit, gotSource := indexMemLimitDecision(tc.raw, tc.available)
+			if gotLimit != tc.wantLimit {
+				t.Errorf("indexMemLimitDecision(%q, %d) limit = %d, want %d",
+					tc.raw, tc.available, gotLimit, tc.wantLimit)
+			}
+			if !strings.Contains(gotSource, tc.wantSource) {
+				t.Errorf("indexMemLimitDecision(%q, %d) source = %q, want it to mention %q",
+					tc.raw, tc.available, gotSource, tc.wantSource)
+			}
+		})
+	}
+}

--- a/cmd/grafel/index_memlimit_test.go
+++ b/cmd/grafel/index_memlimit_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"math"
 	"strings"
 	"testing"
 )
@@ -10,8 +11,10 @@ const (
 	miB = int64(1) << 20
 )
 
-// TestResolveIndexMemLimit pins the adaptive policy: max(2GiB, 0.5*available),
-// and "unset" when available RAM cannot be determined (#5954).
+// TestResolveIndexMemLimit pins the adaptive policy (#5954):
+//
+//	unset                          if available == 0 or available < 4GiB
+//	max(3GiB, available*3/4)       otherwise
 func TestResolveIndexMemLimit(t *testing.T) {
 	cases := []struct {
 		name      string
@@ -19,11 +22,18 @@ func TestResolveIndexMemLimit(t *testing.T) {
 		want      int64
 	}{
 		{"unknown ram -> unset", 0, memLimitUnset},
-		{"tiny host 1GiB -> floor", uint64(giB), 2 * giB},
-		{"small host 3GiB -> floor (half is 1.5GiB)", uint64(3 * giB), 2 * giB},
-		{"exactly at floor boundary 4GiB -> 2GiB", uint64(4 * giB), 2 * giB},
-		{"dev machine ~6GiB -> 3GiB", uint64(6 * giB), 3 * giB},
-		{"large host 64GiB -> 32GiB", uint64(64 * giB), 32 * giB},
+		{"tiny host 1GiB -> unset (do not attempt to bound)", uint64(giB), memLimitUnset},
+		{"small host 3GiB -> unset", uint64(3 * giB), memLimitUnset},
+		{"just under the 4GiB attempt threshold -> unset", uint64(4*giB) - 1, memLimitUnset},
+		{"exactly at the 4GiB threshold -> safe floor 3GiB", uint64(4 * giB), 3 * giB},
+		{"just over the threshold -> safe floor 3GiB", uint64(4*giB) + 1, 3 * giB},
+		// Regression pin for the REQUEST-CHANGES bug: the real value this host
+		// reports. The old max(2GiB, available/2) policy returned 2280MB here,
+		// BELOW the measured ~2.5-2.7GB live heap — i.e. the thrash regime was
+		// the DEFAULT outcome on the measurement machine, not an edge case.
+		{"real host 4560MB -> 3420MB (was 2280MB, below live heap)", uint64(4560 * miB), 3420 * miB},
+		{"6GiB -> 4.5GiB", uint64(6 * giB), 6 * giB * 3 / 4},
+		{"large host 64GiB -> 48GiB (non-binding, as intended)", uint64(64 * giB), 48 * giB},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -34,18 +44,31 @@ func TestResolveIndexMemLimit(t *testing.T) {
 	}
 }
 
-// TestResolveIndexMemLimitFloorInvariant is the anti-thrash guarantee: a
-// GOMEMLIMIT BELOW the live heap sends the runtime into a GC death spiral
-// (measured: 1200MiB against a ~2.7GB live heap ran >4x slower and never
-// finished). So whenever the policy returns a limit at all, it is >= 2GiB.
-func TestResolveIndexMemLimitFloorInvariant(t *testing.T) {
+// TestResolveIndexMemLimitSafeFloorInvariant is the anti-thrash guarantee.
+//
+// GOMEMLIMIT is SOFT: set BELOW the workload's live heap the runtime cannot
+// honor it and instead runs repeated full-heap mark cycles. Go's 50% GC CPU
+// limiter does NOT bound that damage — it throttles assists, but the mark
+// cycles themselves are cache/TLB/page-fault bound and are not accounted to
+// GC CPU. madvdontneed=1 COMPOUNDS it (freed pages go back to the OS and are
+// immediately re-faulted), and the tree-sitter CGo arenas are invisible to
+// GOMEMLIMIT, so the runtime GCs toward a target that non-Go memory
+// guarantees it can never reach. Measured: 1200MiB against a ~2.7GB live heap
+// ran >4x slower (>16 min vs 235 s) and never completed.
+//
+// So the trade is asymmetric: a too-low limit costs unbounded, non-terminating
+// time; no limit at all costs a bounded +823MB. The invariant therefore is
+// EITHER unset OR >= 3GiB — never a value in between. The previous
+// ">= 2GiB" form of this test passed on the harmful 2280MB and pinned the bug.
+func TestResolveIndexMemLimitSafeFloorInvariant(t *testing.T) {
 	for avail := uint64(0); avail <= uint64(96*giB); avail += uint64(64 * miB) {
 		got := resolveIndexMemLimit(avail)
 		if got == memLimitUnset {
 			continue
 		}
-		if got < 2*giB {
-			t.Fatalf("resolveIndexMemLimit(%d) = %d, below the 2GiB anti-thrash floor", avail, got)
+		if got < indexMemLimitSafeFloorBytes {
+			t.Fatalf("resolveIndexMemLimit(%d) = %d — a limit was returned below the %d-byte safe floor (thrash regime)",
+				avail, got, indexMemLimitSafeFloorBytes)
 		}
 	}
 }
@@ -95,11 +118,12 @@ func TestIndexMemLimitDecision(t *testing.T) {
 		wantLimit  int64
 		wantSource string
 	}{
-		{"no env -> adaptive", "", uint64(6 * giB), 3 * giB, "adaptive"},
+		{"no env -> adaptive", "", uint64(8 * giB), 6 * giB, "adaptive"},
 		{"env wins over adaptive", "2500MiB", uint64(64 * giB), 2500 * miB, "env"},
 		{"env disables even with ram known", "off", uint64(64 * giB), memLimitUnset, "env"},
-		{"malformed env -> adaptive", "banana", uint64(6 * giB), 3 * giB, "adaptive"},
+		{"malformed env -> adaptive", "banana", uint64(8 * giB), 6 * giB, "adaptive"},
 		{"malformed env, unknown ram -> unset", "banana", 0, memLimitUnset, "adaptive"},
+		{"no env, low ram -> unset", "", uint64(2 * giB), memLimitUnset, "adaptive"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -111,6 +135,41 @@ func TestIndexMemLimitDecision(t *testing.T) {
 			if !strings.Contains(gotSource, tc.wantSource) {
 				t.Errorf("indexMemLimitDecision(%q, %d) source = %q, want it to mention %q",
 					tc.raw, tc.available, gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestGCThrashWarning covers the post-index diagnostic (#5954). It is
+// DIAGNOSIS ONLY — it never adjusts the limit. A sustained GC CPU fraction
+// above the threshold alongside an applied soft limit is the fingerprint of
+// the thrash regime the safe floor exists to prevent, so it must be visible in
+// a support bundle without a profiler.
+func TestGCThrashWarning(t *testing.T) {
+	const noLimit = int64(math.MaxInt64)
+	cases := []struct {
+		name     string
+		limit    int64
+		fraction float64
+		wantWarn bool
+	}{
+		{"healthy run under a limit", 3 * giB, 0.04, false},
+		{"just under threshold", 3 * giB, 0.29, false},
+		{"over threshold with a limit -> warn", 3 * giB, 0.55, true},
+		{"way over threshold -> warn", 3 * giB, 0.92, true},
+		// No limit applied: high GC CPU is not attributable to our tuning, so
+		// we stay quiet rather than emit a misleading warning.
+		{"no limit applied, high gc -> quiet", noLimit, 0.92, false},
+		{"no limit applied, low gc -> quiet", noLimit, 0.01, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gcThrashWarning(tc.limit, tc.fraction)
+			if (got != "") != tc.wantWarn {
+				t.Errorf("gcThrashWarning(%d, %v) = %q, wantWarn=%v", tc.limit, tc.fraction, got, tc.wantWarn)
+			}
+			if tc.wantWarn && !strings.Contains(got, "GRAFEL_INDEX_MEMLIMIT") {
+				t.Errorf("warning should name the escape hatch, got %q", got)
 			}
 		})
 	}

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -25,6 +25,15 @@ func main() {
 	// fork-exec'd by the daemon's subprocess runner; not part of the public
 	// command surface and intentionally not registered with cobra.
 	if len(os.Args) >= 2 && os.Args[1] == "index-internal" {
+		// Bound this process's peak footprint before any indexing work starts
+		// (#5954). Measured on the real corpus: 4026MB -> 3203MB peak RSS for
+		// +1.7% wall time. Applied from inside the process rather than via a
+		// GOMEMLIMIT env var so it holds no matter how the child was launched,
+		// and applied HERE rather than inside runIndexInternal because
+		// debug.SetMemoryLimit is a process-wide side effect and
+		// runIndexInternal is also invoked in-process by the package's tests.
+		// Never fatal.
+		applyIndexMemoryLimit()
 		os.Exit(runIndexInternal(os.Args[2:]))
 	}
 	// Hidden group-level algorithm harness (#5349 A1 / epic #5350). Assembles

--- a/internal/daemon/sched/subprocess_godebug.go
+++ b/internal/daemon/sched/subprocess_godebug.go
@@ -9,9 +9,18 @@ const madvDontNeedSetting = "madvdontneed=1"
 
 // withMadvDontNeed returns env with GODEBUG carrying madvdontneed=1, preserving
 // any inherited GODEBUG settings (they are merged, never clobbered) and leaving
-// an explicit operator madvdontneed choice alone. Exactly one GODEBUG entry is
-// present in the result: the Go runtime reads the FIRST matching env entry, so
-// appending a duplicate key would be a silent no-op (#5954).
+// an explicit operator madvdontneed=0 choice alone.
+//
+// The MERGE is the whole point of this function. Note it is NOT needed to
+// defeat a duplicate key: os/exec runs dedupEnv over cmd.Env before exec and
+// "preserve[s] the last occurrence of each key", so a plain append would in
+// fact reach the child with the appended value winning. (That is also why the
+// neighbouring GOMAXPROCS append in subprocess_runner.go is safe — dedupEnv
+// keeps the appended value. Worth stating explicitly, because runtime.gogetenv
+// returns the FIRST match, which invites the opposite conclusion; the child
+// simply never sees two entries.) What a plain append WOULD lose is any other
+// inherited GODEBUG setting, since the appended entry replaces the inherited
+// one wholesale. Hence: strip, merge, re-append exactly one entry (#5954).
 func withMadvDontNeed(env []string) []string {
 	out := make([]string, 0, len(env)+1)
 	inherited := ""

--- a/internal/daemon/sched/subprocess_godebug.go
+++ b/internal/daemon/sched/subprocess_godebug.go
@@ -1,0 +1,42 @@
+package sched
+
+import "strings"
+
+// madvDontNeedSetting is the GODEBUG knob that makes the Go runtime release
+// freed heap pages with MADV_DONTNEED instead of MADV_FREE, so the reclaim
+// shows up as an immediate RSS drop rather than a lazy one under pressure.
+const madvDontNeedSetting = "madvdontneed=1"
+
+// withMadvDontNeed returns env with GODEBUG carrying madvdontneed=1, preserving
+// any inherited GODEBUG settings (they are merged, never clobbered) and leaving
+// an explicit operator madvdontneed choice alone. Exactly one GODEBUG entry is
+// present in the result: the Go runtime reads the FIRST matching env entry, so
+// appending a duplicate key would be a silent no-op (#5954).
+func withMadvDontNeed(env []string) []string {
+	out := make([]string, 0, len(env)+1)
+	inherited := ""
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, "GODEBUG="); ok {
+			inherited = v
+			continue
+		}
+		out = append(out, kv)
+	}
+
+	merged := madvDontNeedSetting
+	if inherited != "" {
+		already := false
+		for _, s := range strings.Split(inherited, ",") {
+			if strings.HasPrefix(strings.TrimSpace(s), "madvdontneed=") {
+				already = true
+				break
+			}
+		}
+		if already {
+			merged = inherited
+		} else {
+			merged = inherited + "," + madvDontNeedSetting
+		}
+	}
+	return append(out, "GODEBUG="+merged)
+}

--- a/internal/daemon/sched/subprocess_godebug_test.go
+++ b/internal/daemon/sched/subprocess_godebug_test.go
@@ -1,0 +1,52 @@
+package sched
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestWithMadvDontNeed pins the child-env GODEBUG merge (#5954): madvdontneed=1
+// is appended to any inherited GODEBUG rather than clobbering it, and exactly
+// one GODEBUG entry survives (the Go runtime reads the FIRST match, so a
+// duplicate key would be a silent no-op).
+func TestWithMadvDontNeed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "no inherited GODEBUG",
+			in:   []string{"PATH=/bin", "GOMAXPROCS=3"},
+			want: []string{"PATH=/bin", "GOMAXPROCS=3", "GODEBUG=madvdontneed=1"},
+		},
+		{
+			name: "inherited GODEBUG is preserved and extended",
+			in:   []string{"GODEBUG=http2debug=1", "PATH=/bin"},
+			want: []string{"PATH=/bin", "GODEBUG=http2debug=1,madvdontneed=1"},
+		},
+		{
+			name: "already set is not duplicated",
+			in:   []string{"GODEBUG=madvdontneed=1", "PATH=/bin"},
+			want: []string{"PATH=/bin", "GODEBUG=madvdontneed=1"},
+		},
+		{
+			name: "operator opt-out is respected",
+			in:   []string{"GODEBUG=madvdontneed=0", "PATH=/bin"},
+			want: []string{"PATH=/bin", "GODEBUG=madvdontneed=0"},
+		},
+		{
+			name: "empty inherited GODEBUG",
+			in:   []string{"GODEBUG=", "PATH=/bin"},
+			want: []string{"PATH=/bin", "GODEBUG=madvdontneed=1"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := withMadvDontNeed(tc.in)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("withMadvDontNeed(%v) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/daemon/sched/subprocess_godebug_test.go
+++ b/internal/daemon/sched/subprocess_godebug_test.go
@@ -7,8 +7,9 @@ import (
 
 // TestWithMadvDontNeed pins the child-env GODEBUG merge (#5954): madvdontneed=1
 // is appended to any inherited GODEBUG rather than clobbering it, and exactly
-// one GODEBUG entry survives (the Go runtime reads the FIRST match, so a
-// duplicate key would be a silent no-op).
+// one GODEBUG entry survives. See withMadvDontNeed for why the single-entry
+// property is a tidiness invariant rather than a correctness one (os/exec
+// dedupEnv already keeps the last occurrence).
 func TestWithMadvDontNeed(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -372,6 +372,12 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	}
 	gmp, reason := resolveChildGOMAXPROCS(interactive, foregroundCap)
 	cmd.Env = append(cmd.Env, "GOMAXPROCS="+strconv.Itoa(gmp))
+	// #5954: GODEBUG is read once at process start, so the child cannot set
+	// madvdontneed for itself the way it sets its own GOMEMLIMIT
+	// (applyIndexMemoryLimit). Returning freed pages with MADV_DONTNEED rather
+	// than MADV_FREE makes the RSS drop from that soft limit visible to the OS
+	// (and to the operator) immediately instead of lazily under pressure.
+	cmd.Env = withMadvDontNeed(cmd.Env)
 	if logger != nil {
 		logger.Info("subprocess-indexer: "+reason, "gomaxprocs", gmp, "repo", repoPath)
 	}

--- a/internal/process/sysinfo_darwin.go
+++ b/internal/process/sysinfo_darwin.go
@@ -24,10 +24,13 @@ func TotalMemoryMB() int64 {
 
 // AvailableMemoryMB returns the memory available for a new allocation without
 // paging, in megabytes. macOS exposes no single MemAvailable counter, so we sum
-// the page classes the kernel can hand out immediately — free, inactive,
-// speculative and purgeable — from vm_stat, mirroring what Activity Monitor
-// treats as reclaimable. Returns 0 when it cannot be determined; callers must
-// treat 0 as "unknown" and fall back rather than guessing (#5954).
+// the page classes the kernel can hand out immediately — free, inactive and
+// speculative — from vm_stat.
+//
+// "Pages purgeable" is deliberately NOT summed: in vm_stat it is a SUBSET of
+// the active/inactive counts, not a disjoint class, so adding it double-counts
+// (~56MB on the reference host). Returns 0 when it cannot be determined;
+// callers must treat 0 as "unknown" and fall back rather than guessing (#5954).
 func AvailableMemoryMB() int64 {
 	out, err := exec.Command("vm_stat").Output()
 	if err != nil {
@@ -53,7 +56,7 @@ func AvailableMemoryMB() int64 {
 			continue
 		}
 		switch strings.TrimSpace(key) {
-		case "Pages free", "Pages inactive", "Pages speculative", "Pages purgeable":
+		case "Pages free", "Pages inactive", "Pages speculative":
 		default:
 			continue
 		}

--- a/internal/process/sysinfo_darwin.go
+++ b/internal/process/sysinfo_darwin.go
@@ -21,3 +21,51 @@ func TotalMemoryMB() int64 {
 	}
 	return bytes / (1024 * 1024)
 }
+
+// AvailableMemoryMB returns the memory available for a new allocation without
+// paging, in megabytes. macOS exposes no single MemAvailable counter, so we sum
+// the page classes the kernel can hand out immediately — free, inactive,
+// speculative and purgeable — from vm_stat, mirroring what Activity Monitor
+// treats as reclaimable. Returns 0 when it cannot be determined; callers must
+// treat 0 as "unknown" and fall back rather than guessing (#5954).
+func AvailableMemoryMB() int64 {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return 0
+	}
+	pageSize := int64(4096)
+	var pages int64
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "Mach Virtual Memory Statistics:") {
+			// "... (page size of 16384 bytes)"
+			if i := strings.Index(line, "page size of "); i >= 0 {
+				f := strings.Fields(line[i+len("page size of "):])
+				if len(f) > 0 {
+					if n, err := strconv.ParseInt(f[0], 10, 64); err == nil && n > 0 {
+						pageSize = n
+					}
+				}
+			}
+			continue
+		}
+		key, val, ok := strings.Cut(line, ":")
+		if !ok {
+			continue
+		}
+		switch strings.TrimSpace(key) {
+		case "Pages free", "Pages inactive", "Pages speculative", "Pages purgeable":
+		default:
+			continue
+		}
+		val = strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(val), "."))
+		n, err := strconv.ParseInt(val, 10, 64)
+		if err != nil || n < 0 {
+			continue
+		}
+		pages += n
+	}
+	if pages <= 0 {
+		return 0
+	}
+	return pages * pageSize / (1024 * 1024)
+}

--- a/internal/process/sysinfo_linux.go
+++ b/internal/process/sysinfo_linux.go
@@ -32,3 +32,31 @@ func TotalMemoryMB() int64 {
 	}
 	return 0
 }
+
+// AvailableMemoryMB returns the memory available for a new allocation without
+// swapping, in megabytes. On Linux it reads MemAvailable from /proc/meminfo
+// (the kernel's own estimate, which already accounts for reclaimable page
+// cache). Returns 0 when it cannot be determined; callers must treat 0 as
+// "unknown" and fall back rather than guessing (#5954).
+func AvailableMemoryMB() int64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if !strings.HasPrefix(line, "MemAvailable:") {
+			continue
+		}
+		// Format: "MemAvailable:   8123456 kB"
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			break
+		}
+		kb, err := strconv.ParseInt(fields[1], 10, 64)
+		if err != nil || kb <= 0 {
+			break
+		}
+		return kb / 1024
+	}
+	return 0
+}

--- a/internal/process/sysinfo_other.go
+++ b/internal/process/sysinfo_other.go
@@ -8,3 +8,9 @@ package process
 func TotalMemoryMB() int64 {
 	return 0
 }
+
+// AvailableMemoryMB returns 0 on unsupported platforms — "unknown", not zero
+// available memory. Callers must fall back to a safe default (#5954).
+func AvailableMemoryMB() int64 {
+	return 0
+}


### PR DESCRIPTION
## What

Apply an adaptive Go soft memory limit to the `index-internal` subprocess, plus `GODEBUG=madvdontneed=1` on the spawned child.

```
unset                        if available == 0 || available < 4GiB
max(3GiB, available * 3/4)   otherwise
```

On a host reporting 4235 MB available this yields a 3176 MB limit, versus a 4026 MB unbounded peak.

## Why these constants

Measured: `GOMEMLIMIT=2500MiB` cut peak RSS by 823 MB for +2 s. But a limit set **below** the workload's live heap is catastrophic rather than merely suboptimal — `GOMEMLIMIT=1200MiB` against a ~2.7 GB live heap ran **>4× slower and never completed**.

The Go GC CPU limiter does not bound that damage: it throttles assists but not repeated full-heap mark cycles (cache/TLB/page-fault bound, not accounted to GC CPU), `madvdontneed=1` compounds it via immediate re-faulting of returned pages, and the tree-sitter CGo arenas are invisible to `GOMEMLIMIT` so the runtime GCs toward a target it can never reach.

The failure modes are asymmetric and one-directional — **no limit costs a bounded ~800 MB; a too-low limit costs unbounded, non-terminating time on a background daemon task**. Hence the `3GiB` safe floor (~1.15× the measured live-heap ceiling) and the refusal to bound at all below `4GiB` available.

## Escape hatch

`GRAFEL_INDEX_MEMLIMIT` accepts bytes / `MiB` / `GiB`; `0`/`off`/`disabled` applies no limit; malformed input is logged and ignored (never fatal). An explicit override is honored verbatim and deliberately not floor-clamped — an escape hatch that silently overrides the operator is not an escape hatch.

The decision is logged once to **stderr** (`limit_mb`, `available_mb`, `source`) so a support case — or a benchmark run — can see which branch was taken. stdout is left untouched because it carries the JSON progress channel the parent parses.

## Also

- New `process.AvailableMemoryMB()`: linux `MemAvailable`, darwin `vm_stat` (free+inactive+speculative, page size parsed from the header), other ⇒ 0 ⇒ unset. `Pages purgeable` is deliberately excluded — it is a subset of active/inactive and was double-counting ~296 MB.
- `withMadvDontNeed` merges into any inherited `GODEBUG` rather than appending, preserving other keys and honoring an explicit `madvdontneed=0`.
- `applyIndexMemoryLimit()` is hooked at the `index-internal` intercept in `main.go` — a process-wide setting belongs at the process entrypoint, and this keeps it out of in-process tests that call `runIndexInternal` directly.
- `reportGCThrash()` takes one `ReadMemStats` sample after indexing and warns on stderr if GC CPU exceeded 30%, but only when a limit was actually applied. Diagnosis only — no runtime valve, no goroutine.

## Tests

Policy table tests incl. both sides of the 4 GiB threshold and a regression pin at the real-world 4560 MB ⇒ 3420 MB (verified to fail under the previous `max(2GiB, available/2)` policy, which returned a thrash-inducing 2280 MB there). The safe-floor invariant asserts **unset or ≥ 3GiB**, swept 0→96 GiB.

`go build ./...`, `go vet`, `gofmt -l internal cmd` clean. `./cmd/grafel/...` 329 pass (goldens unchanged — `SetMemoryLimit` cannot alter results). `./internal/daemon/... ./internal/process/...` 842 pass. New tests green under `-race`.

Independently adversarially reviewed twice: the first policy was rejected for producing a below-live-heap limit by default on a 16 GB host, and for an invariant test that pinned the bug rather than the guarantee.

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
