### PR TITLE
perf(#5954): filter http-endpoint drops in place (kill 183 MB whole-set copy)

### DIFF
--- a/internal/engine/http_endpoint_anon_inline_4324_test.go
+++ b/internal/engine/http_endpoint_anon_inline_4324_test.go
@@ -83,7 +83,12 @@ func assertInlineEndpointBridged(t *testing.T, ents []types.EntityRecord, rels [
 
 	// Mirror buildDocument: resolve the http-endpoint pass, stamp IDs, then run
 	// the CENTRAL resolver over the synthesis relationships.
-	merged, _ := ResolveHTTPEndpointHandlers(ents)
+	//
+	// cloneEnts: the resolve pass CONSUMES its input (it edits records in
+	// place and compacts drops over the same backing array, #5954). Callers
+	// invoke this helper repeatedly against the SAME fixture set, so each run
+	// needs its own copy.
+	merged, _ := ResolveHTTPEndpointHandlers(cloneEnts(ents))
 	for i := range merged {
 		merged[i].ID = merged[i].ComputeID()
 	}

--- a/internal/engine/http_endpoint_py_programmatic_4383_test.go
+++ b/internal/engine/http_endpoint_py_programmatic_4383_test.go
@@ -74,7 +74,10 @@ func assertNamedEndpointBridged(t *testing.T, ents []types.EntityRecord, rels []
 		t.Errorf("[%s] named handler %s %s wrongly synthesized an inline stand-in", framework, verb, path)
 	}
 
-	merged, _ := ResolveHTTPEndpointHandlers(ents)
+	// cloneEnts: the resolve pass CONSUMES its input (in-place edits +
+	// in-place drop compaction, #5954) and this helper is called repeatedly
+	// against the SAME fixture set.
+	merged, _ := ResolveHTTPEndpointHandlers(cloneEnts(ents))
 	for i := range merged {
 		merged[i].ID = merged[i].ComputeID()
 	}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -43,9 +43,11 @@
 //     are valuable cross-repo bridges regardless of caller resolution)
 //     but no FETCHES edge is emitted.
 //
-// Returning a NEW slice of EntityRecords (with unresolved producer
-// synthetics dropped) keeps the data flow obvious and avoids in-place
-// slice shuffling at the call site.
+// Returning a slice of EntityRecords (with unresolved producer
+// synthetics dropped) keeps the data flow obvious at the call site. The
+// pass CONSUMES the input slice: it edits records in place and compacts
+// the drops over the same backing array (#5954), so callers must use the
+// returned slice and never the pre-call view.
 //
 // Refs #534 Phase 2, #754.
 package engine
@@ -117,7 +119,10 @@ type ResolveHTTPEndpointStats struct {
 //
 // `merged` MUST already be sorted in canonical order (entity-id
 // disambiguation depends on first-writer-wins). The slice may be
-// returned as-is if no synthetics were dropped.
+// returned as-is if no synthetics were dropped; otherwise the survivors
+// are compacted into `merged`'s own backing array and the tail is
+// zeroed. Either way the pass takes ownership of `merged` — read the
+// returned slice, not the one you passed in.
 // httpResolveKey is the (kind, name, sourceFile) index key used by the
 // resolver to look up entities by their stable in-file identity.
 type httpResolveKey struct{ kind, name, sourceFile string }
@@ -741,12 +746,31 @@ func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag st
 	if len(drop) == 0 {
 		return merged, stats
 	}
-	out := make([]types.EntityRecord, 0, len(merged)-len(drop))
+	// #5954 — compact IN PLACE over `merged`'s existing backing array.
+	// Allocating a second full []types.EntityRecord here just to skip a
+	// handful of dropped synthetics was the single largest line-level
+	// allocation at the corpus index peak (183 MB live, both copies
+	// simultaneously reachable). EntityRecord is a fat struct, so the
+	// per-element value copy is what costs — and it is the SAME copy we
+	// already have to do to close the gaps.
+	//
+	// Safe because `merged` is consumed by this call: the only production
+	// caller (buildDocument in cmd/grafel/index.go) builds `merged` fresh,
+	// passes it here and assigns the result straight back over the same
+	// variable, keeping no pre-filter view. The order-preserving forward
+	// walk keeps output byte-identical to the copy-based version (#481 —
+	// merged order drives first-writer-wins downstream).
+	out := merged[:0]
 	for i := range merged {
 		if drop[i] {
 			continue
 		}
 		out = append(out, merged[i])
+	}
+	// Release the tail so the dropped records — and the Properties maps /
+	// Relationships slices they carry — are not retained by the backing array.
+	for i := len(out); i < len(merged); i++ {
+		merged[i] = types.EntityRecord{}
 	}
 	return out, stats
 }

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -45,9 +45,8 @@
 //
 // Returning a slice of EntityRecords (with unresolved producer
 // synthetics dropped) keeps the data flow obvious at the call site. The
-// pass CONSUMES the input slice: it edits records in place and compacts
-// the drops over the same backing array (#5954), so callers must use the
-// returned slice and never the pre-call view.
+// pass CONSUMES the input slice — see the ownership contract on
+// ResolveHTTPEndpointHandlersWithRepo.
 //
 // Refs #534 Phase 2, #754.
 package engine
@@ -119,10 +118,7 @@ type ResolveHTTPEndpointStats struct {
 //
 // `merged` MUST already be sorted in canonical order (entity-id
 // disambiguation depends on first-writer-wins). The slice may be
-// returned as-is if no synthetics were dropped; otherwise the survivors
-// are compacted into `merged`'s own backing array and the tail is
-// zeroed. Either way the pass takes ownership of `merged` — read the
-// returned slice, not the one you passed in.
+// returned as-is if no synthetics were dropped.
 // httpResolveKey is the (kind, name, sourceFile) index key used by the
 // resolver to look up entities by their stable in-file identity.
 type httpResolveKey struct{ kind, name, sourceFile string }
@@ -139,6 +135,10 @@ type httpResolveNameKey struct{ kind, name string }
 // ResolveHTTPEndpointHandlersWithRepo from the production pipeline so the e2e
 // pass can mint each endpoint's unique entity ID directly and resolve
 // same-Name endpoint collisions (#4651).
+//
+// OWNERSHIP: this pass CONSUMES `merged` — see
+// ResolveHTTPEndpointHandlersWithRepo for the full contract. Use the returned
+// slice; never read the one you passed in.
 func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	return ResolveHTTPEndpointHandlersWithRepo(merged, "")
 }
@@ -151,6 +151,27 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 // route whose synthesized endpoint Name collides across modules (acme-v3 has
 // many same-named handlers/routes, e.g. `getCounts`) still credits the correct,
 // per-file endpoint as covered rather than dangling on an ambiguous name.
+//
+// `merged` MUST already be sorted in canonical order (entity-id
+// disambiguation depends on first-writer-wins downstream, #481). The returned
+// slice preserves that order exactly, minus the dropped synthetics.
+//
+// OWNERSHIP: this pass CONSUMES `merged`. Pass it a slice you solely own, and
+// read ONLY the returned slice afterwards — never the one you passed in.
+// Specifically the pass:
+//
+//   - edits records in place (rewrites Kind for the #1217 http_endpoint split,
+//     appends to embedded Relationships, clears resolved source_handler /
+//     source_caller properties, retargets edge IDs);
+//   - compacts dropped synthetics over `merged`'s OWN backing array (#5954 —
+//     copying the whole record set just to skip a few entries was the single
+//     largest allocation at the corpus index peak), so element POSITIONS and
+//     the effective length change and any index into the pre-call slice is
+//     invalidated.
+//
+// Aliasing therefore matters: if two slices share this backing array, or a
+// caller retains the pre-call view, the compaction will be visible to them as
+// scrambled contents. If you need the input intact, hand over a copy.
 func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag string) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	var stats ResolveHTTPEndpointStats
 
@@ -767,8 +788,14 @@ func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag st
 		}
 		out = append(out, merged[i])
 	}
-	// Release the tail so the dropped records — and the Properties maps /
-	// Relationships slices they carry — are not retained by the backing array.
+	// Zero the tail so `out` itself holds no reference to the dropped records
+	// past its length. This is hygiene, not a production memory win: in the
+	// real pipeline the pass1/pass2/pass3 slices that fed `merged` stay live
+	// in cmd/grafel/index.go well after buildDocument returns, so the dropped
+	// records' Properties maps and Relationships slices remain reachable
+	// through those regardless. What it does guarantee is that re-slicing or
+	// re-growing `out` can never resurrect a dropped record, and that callers
+	// with no other reference (the test entry point) do drop them.
 	for i := len(out); i < len(merged); i++ {
 		merged[i] = types.EntityRecord{}
 	}

--- a/internal/engine/http_endpoint_resolve_filter_5954_test.go
+++ b/internal/engine/http_endpoint_resolve_filter_5954_test.go
@@ -1,0 +1,149 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Parity harness for the final drop-compaction step of
+// ResolveHTTPEndpointHandlersWithRepo (#5954).
+//
+// The pass ends by removing every synthetic whose `source_handler` never
+// resolved. That compaction used to allocate a SECOND full copy of the
+// whole []types.EntityRecord set (183 MB at the corpus index peak — the
+// #1 line-level allocation site) purely to skip a handful of entries.
+// It now filters in place over the caller-owned backing array.
+//
+// These tests pin the OBSERVABLE contract of that step so the in-place
+// rewrite cannot change it: the surviving records must be exactly the
+// non-dropped ones, in exactly the original relative ORDER (issue #481 —
+// merged order drives first-writer-wins disambiguation downstream, so any
+// reordering silently changes the graph).
+
+// keeper5954 builds a record the resolver never touches or drops.
+func keeper5954(name string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       name,
+		SourceFile: "keep/" + name + ".py",
+		Language:   "python",
+	}
+}
+
+// dropper5954 builds an http_endpoint synthetic whose source_handler
+// points at a handler that exists nowhere in the set, so the resolver
+// drops it.
+func dropper5954(name string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       "http_endpoint",
+		Name:       "http:GET:/" + name,
+		SourceFile: "routes/" + name + ".py",
+		Language:   "python",
+		Properties: map[string]string{
+			"source_handler": "Controller:absent_" + name,
+		},
+	}
+}
+
+// TestResolveHTTPEndpointHandlers_DropCompactionOrderParity drives the real
+// pass over hand-built record sets with a known drop mask and asserts the
+// exact surviving names, in the exact original order.
+func TestResolveHTTPEndpointHandlers_DropCompactionOrderParity(t *testing.T) {
+	cases := []struct {
+		name string
+		// mask[i] == true  → element i is a dropper (must NOT survive)
+		// mask[i] == false → element i is a keeper (must survive, in order)
+		mask []bool
+	}{
+		{"empty", nil},
+		{"drop_none", []bool{false, false, false, false}},
+		{"drop_all", []bool{true, true, true}},
+		{"drop_first", []bool{true, false, false, false}},
+		{"drop_last", []bool{false, false, false, true}},
+		{"drop_alternating", []bool{true, false, true, false, true, false}},
+		{"drop_interior_run", []bool{false, true, true, true, false}},
+		{"single_keeper", []bool{false}},
+		{"single_dropper", []bool{true}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			in := make([]types.EntityRecord, 0, len(tc.mask))
+			var wantNames []string
+			for i, dropped := range tc.mask {
+				n := itoaSmall(i)
+				if dropped {
+					in = append(in, dropper5954(n))
+					continue
+				}
+				in = append(in, keeper5954("keep_"+n))
+				wantNames = append(wantNames, "keep_"+n)
+			}
+
+			out, stats := ResolveHTTPEndpointHandlers(in)
+
+			if len(out) != len(wantNames) {
+				t.Fatalf("len(out)=%d want %d (out=%s)", len(out), len(wantNames), namesOf5954(out))
+			}
+			for i := range wantNames {
+				if out[i].Name != wantNames[i] {
+					t.Fatalf("order/membership mismatch at %d: got %q want %q (out=%s want=%v)",
+						i, out[i].Name, wantNames[i], namesOf5954(out), wantNames)
+				}
+			}
+
+			// stats must be unaffected by the compaction strategy.
+			wantDropped := 0
+			for _, d := range tc.mask {
+				if d {
+					wantDropped++
+				}
+			}
+			if stats.HandlerDropped != wantDropped {
+				t.Errorf("stats.HandlerDropped=%d want %d (%+v)", stats.HandlerDropped, wantDropped, stats)
+			}
+			if stats.Synthetics != wantDropped {
+				t.Errorf("stats.Synthetics=%d want %d (%+v)", stats.Synthetics, wantDropped, stats)
+			}
+		})
+	}
+}
+
+// TestResolveHTTPEndpointHandlers_DropCompactionZeroesTail asserts the
+// in-place compaction releases the tail of the backing array, so dropped
+// records (and the Properties / Relationships maps + slices they carry)
+// are not retained by the surviving slice.
+func TestResolveHTTPEndpointHandlers_DropCompactionZeroesTail(t *testing.T) {
+	in := []types.EntityRecord{
+		keeper5954("keep_a"),
+		dropper5954("d1"),
+		keeper5954("keep_b"),
+		dropper5954("d2"),
+	}
+	n := len(in)
+
+	out, _ := ResolveHTTPEndpointHandlers(in)
+	if len(out) != 2 {
+		t.Fatalf("len(out)=%d want 2", len(out))
+	}
+
+	// The compaction reuses `in`'s backing array; everything past len(out)
+	// must be the zero record so the dropped payloads are collectable.
+	tail := in[:n]
+	for i := len(out); i < n; i++ {
+		r := tail[i]
+		if r.Kind != "" || r.Name != "" || r.SourceFile != "" ||
+			r.Properties != nil || r.Relationships != nil {
+			t.Errorf("tail slot %d not released: %+v", i, r)
+		}
+	}
+}
+
+func namesOf5954(rs []types.EntityRecord) []string {
+	out := make([]string, 0, len(rs))
+	for i := range rs {
+		out = append(out, rs[i].Name)
+	}
+	return out
+}

--- a/internal/engine/http_endpoint_resolve_filter_5954_test.go
+++ b/internal/engine/http_endpoint_resolve_filter_5954_test.go
@@ -111,9 +111,9 @@ func TestResolveHTTPEndpointHandlers_DropCompactionOrderParity(t *testing.T) {
 }
 
 // TestResolveHTTPEndpointHandlers_DropCompactionZeroesTail asserts the
-// in-place compaction releases the tail of the backing array, so dropped
-// records (and the Properties / Relationships maps + slices they carry)
-// are not retained by the surviving slice.
+// in-place compaction zeroes the tail of the backing array, so no dropped
+// record survives past len(out) where re-slicing or re-growing the result
+// could resurrect it.
 func TestResolveHTTPEndpointHandlers_DropCompactionZeroesTail(t *testing.T) {
 	in := []types.EntityRecord{
 		keeper5954("keep_a"),
@@ -129,7 +129,7 @@ func TestResolveHTTPEndpointHandlers_DropCompactionZeroesTail(t *testing.T) {
 	}
 
 	// The compaction reuses `in`'s backing array; everything past len(out)
-	// must be the zero record so the dropped payloads are collectable.
+	// must be the zero record.
 	tail := in[:n]
 	for i := len(out); i < n; i++ {
 		r := tail[i]


### PR DESCRIPTION
## What

`ResolveHTTPEndpointHandlersWithRepo` allocated a **second full `[]types.EntityRecord`** purely to filter out a handful of dropped entries:

```go
out := make([]types.EntityRecord, 0, len(merged)-len(drop))
```

At the index peak this was the **#1 line-level allocation site — 183.26 MB** (`internal/engine/http_endpoint_resolve.go:744`), with both slices live simultaneously. It now compacts in place (`out := merged[:0]`, forward walk, write index always `<= i`), then zeroes the tail slots.

## Safety — the pass takes ownership of `merged`

In-place compaction destroys the caller's slice contents, so this is only sound if the pass exclusively owns the slice. Verified:

- **One production caller** — `cmd/grafel/index.go:4487`, which assigns the result straight back over the same variable. (`ResolveHTTPEndpointHandlers` is a second exported entry point but has zero non-test callers.)
- **Fresh backing array** — `merged` is built 18 lines earlier at `index.go:4469` via `make` + three `append`s, so it shares no array with pass1/2/3.
- **No retained positional indices** — every index table over `merged` (`idx`, `globalIdx`, `sameFileBareIdx`, `sameFileLineIdx`, `globalMulti`, `definitionByPath`, `defIndices`, `drop`) is function-local, `int`-valued, and last read before the compaction. `ResolveHTTPEndpointStats` is all-`int`, so nothing escapes in the return value. No goroutine, defer, or package-level cache retains the slice.
- **Precedent** — `index.go:4439` already does the identical `out := merged[:0]` compaction for the folded-class drop pass.

The pass **already** mutated its input (the #1217 `Kind` rewrite, `Relationships` appends, the #1615 edge-ID retargets), so this widens the contract only to *position/length* destruction. That contract is now documented on the exported functions themselves — the previous ownership note was orphaned onto `type httpResolveKey` and invisible to `go doc`.

Two test helpers that re-ran the pass against the same fixture slice were fixed to use the package's pre-existing `cloneEnts` helper, which exists for exactly this reason.

## Tests

`http_endpoint_resolve_filter_5954_test.go` drives the **real** pass over 9 drop masks (empty, none, all, first, last, alternating, interior run, single keeper, single dropper), asserting exact surviving membership **and order** plus `stats`. It was pinned GREEN against the old copy-based implementation first, then RED was demonstrated by reversing the compaction loop (4 subcases failed with order diagnostics). A second test asserts the tail slots are zeroed.

`go build ./...`, `go vet ./internal/engine/...`, `gofmt -l internal cmd` clean. `./internal/engine/...` 2706 pass; `./cmd/grafel/...` 329 pass (goldens unchanged); `-race` green. Test runs capped at `-p 3` per the core-budget rule.

Independently adversarially reviewed.

## Note on the tail zeroing

It is hygiene, not a production memory win: `pass1Records`/`pass2Records`/`pass3Records` stay live in `cmd/grafel/index.go` until after `buildDocument` returns, so the dropped records' `Properties` maps remain reachable through them regardless. What it does guarantee is that no dropped record survives past `len(out)` where re-slicing could resurrect it. The comment says so rather than overclaiming.

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
