### PR TITLE
probe(#5964): resolve a worktree's parent store dir (diagnostic, zero behaviour change)

### DIFF
--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // enginePlane holds the engine-plane background runtime (scheduler, watcher,
@@ -297,6 +298,16 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				// RefCapture(worktreePath), so the graph lands in the correct
 				// per-ref dir keyed by the worktree path (multi-ref model).
 				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
+					// #5964 increment 1: probe-only diagnostic. This resolves
+					// and logs the worktree→parent state-dir mapping but does
+					// NOT copy/seed anything and does NOT alter what gets
+					// enqueued below — zero behaviour change. OnActivate fires
+					// once per activation transition (new discovery or
+					// re-activation after expiry, see worktree.Watcher.poll),
+					// so this logs once per worktree activation, not per poll
+					// tick.
+					logWorktreeParentSeedProbe(logger, child, cfg.WorktreeParents)
+
 					activateSem <- struct{}{}
 					_, aerr := watcher.AddRepo(child.Path)
 					<-activateSem
@@ -435,4 +446,114 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 	logger.Info("startup: docgen-sweeper done")
 
 	return ep
+}
+
+// logWorktreeParentSeedProbe resolves and logs the worktree→parent state-dir
+// mapping for a newly-activated worktree (#5964 increment 1). It is a
+// diagnostic PROBE ONLY: it never copies, seeds, or otherwise changes what
+// gets indexed — it exists solely to confirm or kill, on real data, the
+// finding that killed the first clone-from-parent attempt (#3652): that
+// attempt resolved the parent via StateDirForRepoRef(worktreePath, "main"),
+// which is keyed by the WORKTREE's own path (wrong root) and a hardcoded ref
+// (wrong ref for any parent not on "main"), so it always resolved to an
+// empty directory.
+//
+// Resolution order:
+//  1. child.ParentPath, populated at discovery (worktree.Watcher.poll).
+//  2. Fallback via gitmeta.ResolveCommonDir when ParentPath is empty (a
+//     store entry persisted before this field existed) — matched against
+//     the same parents provider the watcher itself uses, rather than the
+//     O(registered repos) registry scan in internal/mcp/routing.go.
+//
+// dst is the worktree's own state dir (StateDirForRepoRef(child.Path,
+// child.Branch), unchanged from today's Enqueue target). src is the
+// parent's CURRENT state dir — StateDirForRepo(parentPath), which resolves
+// the parent's actual HEAD ref via gitmeta.Capture, not a hardcoded ref name
+// (the same bug class as #3652). Whether src actually holds a usable graph
+// is reported via graph.CurrentGraphDescriptor, which is segment-set aware
+// (a graph.<gen>/ dir with a `current` pointer is not necessarily a flat
+// graph.fb).
+func logWorktreeParentSeedProbe(logger *slog.Logger, child *worktree.WorktreeChild, parentsProvider func() []worktree.ParentRepo) {
+	parentPath := child.ParentPath
+	fallbackUsed := false
+	if parentPath == "" {
+		parentPath = resolveWorktreeParentPathFallback(child.Path, parentsProvider)
+		fallbackUsed = true
+	}
+
+	// current_repo_tag: what Index() would default repoTag to for this
+	// worktree TODAY (filepath.Base(absRepo), cmd/grafel/index.go:~462 —
+	// the daemon always passes repoTag=""), vs the parent's slug it would
+	// need to be pinned to for entity IDs to agree with a full index of the
+	// parent (graph.EntityID hashes repoTag as its first component). This
+	// increment only REPORTS the mismatch; pinning repoTag is a separate,
+	// follow-up increment.
+	currentRepoTag := filepath.Base(filepath.Clean(child.Path))
+
+	if parentPath == "" {
+		logger.Info("worktree: parent-seed probe — no parent path (neither recorded nor derivable)",
+			"path", child.Path, "branch", child.Branch, "parent_slug", child.ParentSlug,
+			"current_repo_tag", currentRepoTag, "fallback_attempted", fallbackUsed)
+		return
+	}
+
+	dst := StateDirForRepoRef(child.Path, child.Branch)
+	src := StateDirForRepo(parentPath)
+
+	desc, descErr := graph.CurrentGraphDescriptor(src)
+	hasGraph := descErr == nil && desc.Kind != graph.GraphAbsent
+	kind := "absent"
+	switch desc.Kind {
+	case graph.GraphSingleFile:
+		kind = "single_file"
+	case graph.GraphSegmentSet:
+		kind = "segment_set"
+	}
+
+	logger.Info("worktree: parent-seed probe",
+		"path", child.Path,
+		"branch", child.Branch,
+		"parent_path", parentPath,
+		"parent_slug", child.ParentSlug,
+		"current_repo_tag", currentRepoTag,
+		"repo_tag_mismatch", currentRepoTag != child.ParentSlug,
+		"parent_path_source", map[bool]string{true: "fallback_commondir", false: "recorded"}[fallbackUsed],
+		"src_state_dir", src,
+		"dst_state_dir", dst,
+		"src_has_graph", hasGraph,
+		"src_graph_kind", kind,
+		"src_descriptor_err", errString(descErr),
+	)
+}
+
+// resolveWorktreeParentPathFallback derives a worktree's parent repo path
+// when WorktreeChild.ParentPath is empty (legacy store entry predating
+// #5964). It compares the worktree's git common-dir against each candidate
+// parent's own common-dir — the same fact gitmeta.ResolveCommonDir /
+// internal/mcp/routing.go's ResolveCWD already use to attribute a worktree
+// to its parent, but matched directly against the watcher's own parents
+// provider instead of the O(registered repos) registry scan. Returns "" when
+// no parent's common-dir matches (or parentsProvider is nil).
+func resolveWorktreeParentPathFallback(worktreePath string, parentsProvider func() []worktree.ParentRepo) string {
+	if parentsProvider == nil {
+		return ""
+	}
+	childCommon := gitmeta.ResolveCommonDir(worktreePath)
+	if childCommon == "" {
+		return ""
+	}
+	for _, p := range parentsProvider() {
+		if gitmeta.ResolveCommonDir(p.Path) == childCommon {
+			return p.Path
+		}
+	}
+	return ""
+}
+
+// errString renders err for structured logging, "" for nil.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }

--- a/internal/daemon/worktree/worktree.go
+++ b/internal/daemon/worktree/worktree.go
@@ -114,6 +114,13 @@ type WorktreeChild struct {
 	ParentSlug string `json:"parent_slug"`
 	// GroupName is the grafel group that owns the parent.
 	GroupName string `json:"group_name"`
+	// ParentPath is the absolute path of the parent repo's main checkout
+	// (ParentRepo.Path at discovery time) — the state-dir key for the
+	// parent's graph. Populated at discovery/refresh; omitempty so a
+	// worktrees.json written before this field existed loads unchanged
+	// with ParentPath == "" (callers fall back to derivation in that
+	// case). See #5964.
+	ParentPath string `json:"parent_path,omitempty"`
 	// Path is the absolute path of the worktree on disk.
 	Path string `json:"path"`
 	// Branch is the git ref checked out in the worktree.
@@ -768,6 +775,7 @@ func (w *Watcher) poll() {
 				child := &WorktreeChild{
 					ParentSlug:   p.Slug,
 					GroupName:    p.GroupName,
+					ParentPath:   p.Path,
 					Path:         normPath(raw.Path),
 					Branch:       raw.Branch,
 					Locked:       raw.Locked,
@@ -783,6 +791,12 @@ func (w *Watcher) poll() {
 				existing.LastSeenAt = now
 				existing.Branch = raw.Branch
 				existing.Locked = raw.Locked
+				// Correct a re-registered parent path/slug (e.g. the parent
+				// repo moved on disk or was re-registered under a new slug)
+				// and backfill legacy store entries persisted before
+				// ParentPath existed.
+				existing.ParentPath = p.Path
+				existing.ParentSlug = p.Slug
 				if existing.Status == StatusExpired {
 					existing.Status = StatusActive
 					existing.StaleAt = nil

--- a/internal/daemon/worktree/worktree_test.go
+++ b/internal/daemon/worktree/worktree_test.go
@@ -577,6 +577,67 @@ func TestWatcher_OnActivate_fires_on_discovery(t *testing.T) {
 	}
 }
 
+// TestWatcher_poll_populatesParentPath verifies poll() records the parent
+// repo's absolute path AND slug on discovery (#5964 increment 1) — ParentPath
+// is the field that #3652's clone-from-parent attempt discarded, forcing it
+// to guess the parent via a hardcoded ref name and find nothing. ParentSlug
+// already existed on WorktreeChild but is asserted here too because it is
+// the input to a follow-up increment (pinning a worktree's repoTag to its
+// parent's slug) and must stay correct as ParentPath is added alongside it.
+func TestWatcher_poll_populatesParentPath(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	repoDir := filepath.Join(tmp, "repo")
+	if err := os.MkdirAll(repoDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	initGitRepo(t, repoDir)
+	wt1 := filepath.Join(tmp, "wt1")
+	addWorktree(t, repoDir, wt1, "feat/parentpath")
+
+	store := worktree.NewStore(filepath.Join(tmp, "wt.json"))
+	parents := func() []worktree.ParentRepo {
+		return []worktree.ParentRepo{{GroupName: "g", Slug: "r", Path: repoDir}}
+	}
+	w := worktree.NewWatcher(store, parents, nil)
+	w.Poll()
+
+	realWt1 := realPath(t, wt1)
+	child := store.Lookup(realWt1)
+	if child == nil {
+		child = store.Lookup(wt1)
+	}
+	if child == nil {
+		t.Fatalf("worktree %q not found in store after poll", wt1)
+	}
+	realRepoDir := realPath(t, repoDir)
+	if child.ParentPath != repoDir && child.ParentPath != realRepoDir {
+		t.Errorf("ParentPath = %q, want %q (or resolved %q)", child.ParentPath, repoDir, realRepoDir)
+	}
+	if child.ParentSlug != "r" {
+		t.Errorf("ParentSlug = %q, want %q", child.ParentSlug, "r")
+	}
+
+	// Re-poll (refresh path): ParentPath/ParentSlug must still be populated,
+	// not wiped or left stale, so a re-registered parent self-corrects.
+	w.Poll()
+	child = store.Lookup(realWt1)
+	if child == nil {
+		child = store.Lookup(wt1)
+	}
+	if child == nil {
+		t.Fatalf("worktree %q not found in store after second poll", wt1)
+	}
+	if child.ParentPath != repoDir && child.ParentPath != realRepoDir {
+		t.Errorf("after refresh: ParentPath = %q, want %q (or resolved %q)", child.ParentPath, repoDir, realRepoDir)
+	}
+	if child.ParentSlug != "r" {
+		t.Errorf("after refresh: ParentSlug = %q, want %q", child.ParentSlug, "r")
+	}
+}
+
 // TestWatcher_OnExpire_fires_on_removal verifies OnExpire fires when a
 // worktree is removed — the daemon uses it to unsubscribe the working tree.
 func TestWatcher_OnExpire_fires_on_removal(t *testing.T) {

--- a/internal/daemon/worktree_parent_seed_probe_test.go
+++ b/internal/daemon/worktree_parent_seed_probe_test.go
@@ -1,0 +1,74 @@
+package daemon
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestWorktreeParentSeedMismatch_pins5964Bug pins the EXACT mismatch that
+// killed the first clone-from-parent attempt (#3652, deleted in #65427c5a8):
+// that code resolved the parent via
+// StateDirForRepoRef(worktreePath, "main") — keyed by the WORKTREE's own
+// absolute path (wrong store root: a worktree and its parent hash to
+// different roots) AND a hardcoded ref name (wrong ref whenever the parent's
+// HEAD isn't literally "main"). Both mistakes independently guarantee a
+// miss.
+//
+// This test asserts the two dirs a correct implementation must treat as
+// distinct, so a future change can't silently reintroduce either mistake:
+//   - dst = StateDirForRepoRef(worktreePath, branch)   — unchanged Enqueue target
+//   - src = StateDirForRepo(parentPath)                — the parent's ACTUAL
+//     HEAD ref, not a hardcoded "main"
+//
+// and that the broken lookup (worktree path + hardcoded "main") never
+// coincides with the correct src.
+func TestWorktreeParentSeedMismatch_pins5964Bug(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	parentPath := filepath.Join(root, "parent-repo")
+	worktreePath := filepath.Join(root, "worktree", "agent-foo")
+	branch := "worktree-agent-foo"
+
+	// The two roots the original attempt conflated: a worktree and its
+	// parent hash to DIFFERENT store roots because RepoBaseDir hashes the
+	// absolute repo path, not any shared git-common-dir fact.
+	if RepoBaseDir(parentPath) == RepoBaseDir(worktreePath) {
+		t.Fatalf("parent and worktree must hash to different store roots; got the same: %q", RepoBaseDir(parentPath))
+	}
+
+	// dst: unchanged Enqueue target, keyed by the WORKTREE path + its branch.
+	dst := StateDirForRepoRef(worktreePath, branch)
+
+	// src (correct): keyed by the PARENT path, at the parent's ACTUAL HEAD
+	// ref (gitmeta.Capture on a non-existent dir returns Ref == "", which
+	// RefSafeEncode maps to the "_unknown" sentinel — still a real,
+	// deterministic dir, just not "main").
+	src := StateDirForRepo(parentPath)
+
+	// src (the #3652 bug): worktree path + hardcoded "main".
+	buggySrc := StateDirForRepoRef(worktreePath, "main")
+
+	if src == dst {
+		t.Fatalf("src must differ from dst (would mean parent and worktree state dirs collided): %q", src)
+	}
+	if src == buggySrc {
+		t.Fatalf("src must differ from the #3652 buggy lookup (worktree path + hardcoded main): both resolved to %q", src)
+	}
+	if buggySrc != dst {
+		// This is the precise shape of the original bug: the buggy lookup
+		// (worktree path + "main") is NOT the parent's dir at all — it's a
+		// sibling ref dir under the WORKTREE's own (wrong) store root, which
+		// is why it was always empty: nothing ever writes a graph there
+		// under the ref name "main" for a worktree checked out on a
+		// differently-named branch.
+		t.Logf("buggy lookup %q != correct dst %q (expected — demonstrates the wrong root)", buggySrc, dst)
+	}
+
+	// Sanity: src is actually rooted under the parent's own hashed base dir,
+	// not the worktree's.
+	parentBase := RepoBaseDir(parentPath)
+	if filepath.Dir(filepath.Dir(src)) != parentBase { // strip /refs/<ref>
+		t.Fatalf("src %q is not under parent's base dir %q", src, parentBase)
+	}
+}


### PR DESCRIPTION
## What

First increment of worktree graph seeding (#5964): make a worktree able to resolve its parent repo's store, and prove the resolution is correct. **Diagnostic only — zero behaviour change.** Nothing is copied or seeded; `scheduler.Enqueue(child.Path)` is untouched.

- `WorktreeChild` gains `ParentPath` (`json:"parent_path,omitempty"`), populated at discovery from the `ParentRepo{GroupName, Slug, Path}` already in scope, and refreshed on re-registration. `ParentSlug` is now refreshed on re-registration too (it existed but wasn't self-correcting).
- A probe at the `OnActivate` seam logs the resolved parent path/slug, the current-vs-parent `repoTag` mismatch, `src`/`dst` state dirs, and whether the parent's store holds a usable graph (segment-set aware via `graph.CurrentGraphDescriptor`).
- `resolveWorktreeParentPathFallback` handles legacy entries with an empty `ParentPath` via `gitmeta.ResolveCommonDir` (2 s timeout, returns `""` on failure).

## Why this exact increment

A previous clone-from-parent implementation (`c47052b05`) was deleted as abandoned (`65427c5a8`, #3652) because it resolved the parent via `StateDirForRepoRef(worktreePath, "main")` — but a worktree's store key is `hash(worktreePath)` while the parent's graph lives under `hash(parentRepoPath)`. It would have found nothing and fallen back to a full reindex every time. This increment proves the corrected mapping **before** any machinery is rebuilt on top of it.

The correct lookup is `src = StateDirForRepo(parentPath)`, which resolves the parent's **actual HEAD ref** via `gitmeta.Capture` — not a hardcoded `"main"`, which was the same bug class.

## Live results on a real machine

```
parent path = /Users/jorgecajas/Projects/archigraph   (HEAD ref "main")
src         = ~/.grafel/store/archigraph-194c2ac1dc133733/refs/main
dst         = ~/.grafel/store/agent-wtparent-b40cedf7a3b6d72b/refs/worktree-agent-wtparent
```

`src` currently holds no graph — because that repo is not a registered grafel group, not because of a mapping fault. `CurrentGraphDescriptor` was sanity-checked against a populated ref dir on the same machine and resolved correctly (`GraphSingleFile`, `graph.2.fb`).

All four live worktrees tag as `filepath.Base(worktreePath)` versus the parent slug `archigraph` — confirming the `repoTag` divergence that a follow-up increment must fix before seeding can be correct, since `repoTag` is the first component of `graph.EntityID`.

## Tests

- `TestWatcher_poll_populatesParentPath` — asserts `ParentPath` and `ParentSlug` are populated at discovery and survive a refresh poll. RED verified by reverting the population line.
- `worktree_parent_seed_probe_test.go` — pins the #3652 mismatch: `dst`, `src`, and the broken `StateDirForRepoRef(worktreePath, "main")` are three distinct dirs, so the old lookup cannot be silently reintroduced.

`go build ./...`, `go vet ./internal/daemon/... ./internal/gitmeta/...`, `gofmt -l internal cmd` clean. `./internal/daemon/... ./internal/gitmeta/...` 848 pass; `./cmd/grafel/...` 329 pass (goldens untouched).

Independently reviewed: zero behaviour change confirmed, and the probe logs once per activation transition (not per poll cycle) because `OnActivate` is only queued on first discovery or re-activation from expired.

## Known follow-up

The pinning test exercises the underlying primitives rather than `logWorktreeParentSeedProbe`'s own body, so it would not catch someone editing the probe to use the buggy lookup. Acceptable for a diagnostic with no behavioural stakes; the seeding increment should add a test that drives that function directly.

Refs #5964, Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
