### PR TITLE
perf(#5954): drop the global parse mutex, bound parsing at 25% of cores, split resolving_refs

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 	idiff "github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/ingest"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/memtrace"
@@ -83,6 +84,140 @@ func memtraceLogf(format string, args ...any) {
 	memtraceLogOnce.Do(func() {
 		fmt.Fprintf(os.Stderr, "grafel: "+format+"\n", args...)
 	})
+}
+
+// resolvePassTimer instruments the resolving_refs window (#5954).
+//
+// PROBLEM IT SOLVES. resolving_refs was a single phase label covering ~52% of
+// cold-index wall time across a dozen unrelated passes. Nobody could tell how
+// that time split between per-FILE work (which a content-addressed per-file
+// extraction cache would eliminate) and GLOBAL work (which it would not) — and
+// that split is exactly what decides whether such a cache is worth building.
+//
+// ZERO-RISK CONTRACT. This is observability only; it must not be able to change
+// the graph or the UI.
+//   - enter() calls Tracker.SubPhase, which stamps CurrentPhase WITHOUT
+//     publishing an Event, so the SSE/CLI/wizard streams are unchanged. The
+//     memtrace sampler reads CurrentPhase, so its phase= tag gets the split for
+//     free — no new plumbing, no new file.
+//   - The exact per-pass wall times are only printed when memtrace is already
+//     enabled (GRAFEL_MEMTRACE_DIR set). In a normal run this type does nothing
+//     but a few atomic stores, and stderr is byte-identical to before. The
+//     printed line exists because the sampler polls at 250ms, which is too
+//     coarse to attribute a sub-second pass.
+type resolvePassTimer struct {
+	trk    *progress.Tracker
+	traced bool
+	label  string
+	since  time.Time
+	rows   []string
+}
+
+func newResolvePassTimer(trk *progress.Tracker) *resolvePassTimer {
+	return &resolvePassTimer{
+		trk:    trk,
+		traced: os.Getenv(memtrace.DirEnv) != "",
+	}
+}
+
+// enter closes out the pass that was running (if any) and stamps label as the
+// active sub-phase. Safe on a nil receiver and a nil tracker.
+func (r *resolvePassTimer) enter(label string) {
+	if r == nil {
+		return
+	}
+	r.closeCurrent()
+	r.label = label
+	r.since = time.Now()
+	r.trk.SubPhase(label)
+}
+
+// closeCurrent records the elapsed time of the in-flight pass.
+func (r *resolvePassTimer) closeCurrent() {
+	if r.label == "" {
+		return
+	}
+	if r.traced {
+		r.rows = append(r.rows, fmt.Sprintf("%s=%.3fs", r.label, time.Since(r.since).Seconds()))
+	}
+	r.label = ""
+}
+
+// finish closes the last pass and, under memtrace, emits one machine-greppable
+// stderr line with every pass's wall time. Call it immediately before the next
+// PhaseStart.
+func (r *resolvePassTimer) finish() {
+	if r == nil {
+		return
+	}
+	r.closeCurrent()
+	if r.traced && len(r.rows) > 0 {
+		fmt.Fprintf(os.Stderr, "grafel: resolve-pass-timing %s\n", strings.Join(r.rows, " "))
+	}
+	r.rows = nil
+}
+
+// indexParseCoreBudget returns the number of cores the BACKGROUND indexing
+// path is allowed to spend on tree-sitter parsing: 25% of machine capacity,
+// minimum 1.
+//
+// Dynamic on purpose. The previous policy was a static "never more than 3
+// cores", which protected a laptop but punished a big machine — a 32-core box
+// got the same 3 as a 4-core one. A proportional budget keeps the "grafel must
+// not make the box feel busy" property while letting bigger machines index
+// faster: 4 cores -> 1, 12 -> 3 (identical to the old rule), 32 -> 8.
+//
+// NumCPU, not GOMAXPROCS: this budget governs C parsing, and GOMAXPROCS is
+// neither the machine's capacity nor a bound on cgo. Computed inline pending a
+// canonical shared helper.
+func indexParseCoreBudget() int {
+	return max(1, runtime.NumCPU()/4)
+}
+
+// ensureParseConcurrencyDefault installs the in-process tree-sitter parse
+// concurrency cap for processes that are NOT the daemon. It never lowers or
+// overrides a cap that is already installed.
+//
+// WHY THIS IS REQUIRED (#5954). Removing the global parseMu means N extraction
+// workers can now sit inside ts_parser_parse simultaneously. Two bounds that
+// look like they would contain that do NOT:
+//
+//   - The #5630 parse gate was daemon-only. indexstate.SetParseConcurrency had
+//     exactly one production caller (daemon.go), and parsegate.go treats cap<=0
+//     as UNBOUNDED — so for `grafel index-internal` (the child the scheduler /
+//     rebuild path fork-execs) AcquireParseSlot was a no-op.
+//   - GOMAXPROCS does not bound cgo. A goroutine inside a cgo call parks in
+//     _Gsyscall and the runtime hands its P to another goroutine, so N
+//     concurrent cgo calls occupy N OS threads regardless of GOMAXPROCS. Since
+//     the extract CPU budget is implemented purely as GOMAXPROCS=<n> in the
+//     child's env (sched/subprocess_runner.go, extract/coordinator.go),
+//     GRAFEL_EXTRACT_GOMAXPROCS=2 would have given no protection at all
+//     against 8 concurrent ts_parser_parse (i.workers is 8).
+//
+// The parse gate DOES bound cgo, because it is a counting semaphore acquired on
+// the Go side and held ACROSS the cgo call (AcquireParseSlot in
+// treesitter.parseOfficial, and — since #5954 — around every extractor-level
+// parse that bypasses the factory). At most `cap` goroutines can be inside
+// ts_parser_parse at once, whatever the scheduler does with Ps and threads.
+//
+// INTERACTIVE IS EXEMPT. A foreground rebuild is user-initiated and awaited, so
+// it may use the whole machine; capping it would only make the human wait. The
+// budget applies to the background/CLI-index path, which is the one that runs
+// unasked while the developer is working. This mirrors the same Interactive
+// signal the extract coordinator already uses (CoordinatorConfig.Interactive).
+// Returns the cap now in force (0 = unbounded) and whether THIS call installed
+// it — the caller logs only in the latter case, so a run inside the daemon does
+// not re-announce the daemon's own ceiling as if it were the index budget.
+func ensureParseConcurrencyDefault(interactive bool) (inForce int, installed bool) {
+	if existing := indexstate.ParseConcurrencyCap(); existing > 0 {
+		return existing, false
+	}
+	if interactive {
+		return 0, false
+	}
+	budget := indexParseCoreBudget()
+	indexstate.SetParseConcurrency(budget)
+	return budget, true
 }
 
 // allPassNames is used to validate --skip-pass entries.
@@ -507,6 +642,20 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	}
 	for _, opt := range opts {
 		opt(idx)
+	}
+
+	// #5954 — bound concurrent in-process tree-sitter parses on the non-daemon
+	// path. Placed AFTER the options are applied because the budget depends on
+	// idx.interactive: a foreground, user-awaited rebuild is deliberately
+	// exempt. See ensureParseConcurrencyDefault.
+	//
+	// The one-line log mirrors the daemon's own "cpu-tune: in-process parse
+	// concurrency cap=N" so the ceiling in force is observable in a child's
+	// stderr instead of having to be inferred. Only emitted when this call is
+	// what installed the cap.
+	if cap, installed := ensureParseConcurrencyDefault(idx.interactive); installed {
+		fmt.Fprintf(os.Stderr, "grafel: cpu-tune: in-process parse concurrency cap=%d (25%% of %d cores, #5954)\n",
+			cap, runtime.NumCPU())
 	}
 
 	// #4306: env fallback for the opt-in markdown-ingestion flag, so the
@@ -1062,6 +1211,12 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// fork-execs `grafel extract` per language-bucketed batch and
 	// returns the merged record set (Pass 1 + 2.5 + 3 combined); the
 	// daemon then runs everything from buildDocument onward unchanged.
+
+	// #5954 — per-pass timing inside the composite resolving_refs window. The
+	// timer only stamps sub-phase labels (no published events), so this is
+	// observability with no behavioural surface. See resolvePassTimer.
+	passTimer := newResolvePassTimer(trk)
+
 	trk.PhaseStart(progress.PhaseExtractAST, 0, 0)
 	if subprocExtract() {
 		res, cerr := extract.Coordinate(ctx, absRepo, files, extract.CoordinatorConfig{
@@ -1123,6 +1278,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 
 		// Pass 2.5 — YAML-driven framework rules.
 		trk.PhaseStart(progress.PhaseResolveRefs, len(files), len(pass1Records))
+		passTimer.enter(progress.SubPhasePass25FrameworkRules)
 		pass2Records, pass2Rels, err = i.runPass25FrameworkRules(ctx, absRepo, classified, pass1Records)
 		if err != nil {
 			trk.Fail(err.Error())
@@ -1131,6 +1287,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		i.stats.pass2Rels = len(pass2Rels) + countEmbeddedRels(pass2Records)
 
 		// Pass 3 — cross-language extractors.
+		passTimer.enter(progress.SubPhasePass3CrossLang)
 		pass3Records, err = i.runPass3CrossLang(ctx, absRepo, classified)
 		if err != nil {
 			trk.Fail(err.Error())
@@ -1146,6 +1303,17 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// the classifier would otherwise drop. The pass is idempotent and
 	// always runs against `allFiles` so incremental indexing keeps the
 	// Config entities even when no source file changed.
+	//
+	// NOTE (#5954): passes 3.5 onward run in BOTH the in-process and the
+	// subprocess-extract branch, but only the in-process branch has entered
+	// PhaseResolveRefs. Under GRAFEL_SUBPROC_EXTRACT=1 the active phase is
+	// still extracting_ast, so Tracker.SubPhase DROPS these resolving_refs.*
+	// stamps rather than misattributing samples across phases — the labels'
+	// "<parent>.<pass>" contract is enforced there, not merely documented.
+	// Those passes then read as plain extracting_ast, exactly as before #5954.
+	// The alternative (entering PhaseResolveRefs on the subproc path too) would
+	// change that path's published event stream, which this change must not do.
+	passTimer.enter(progress.SubPhasePass35ConfigDiscovery)
 	configEntities, configRels, configErr := configextract.Discover(ctx, absRepo, allFiles)
 	if configErr != nil {
 		fmt.Fprintf(os.Stderr, "grafel: config-discover warning: %v\n", configErr)
@@ -1162,6 +1330,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// emitting BAZEL_DEPENDS_ON edges between declared Bazel targets.
 	// Runs after config discovery so all graph entities are available for
 	// the resolver overlay.
+	passTimer.enter(progress.SubPhasePass36Bazel)
 	bazelEntities, bazelRels, bazelErr := bazelextract.Discover(ctx, absRepo, allFiles)
 	if bazelErr != nil {
 		fmt.Fprintf(os.Stderr, "grafel: bazel-discover warning: %v\n", bazelErr)
@@ -1177,6 +1346,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Parses mage-tagged magefile.go / magefiles/*.go via go/parser, emitting
 	// one SCOPE.Operation per exported target and MAGE_DEPENDS_ON edges for
 	// mg.Deps / mg.SerialDeps / mg.CtxDeps prerequisites.
+	passTimer.enter(progress.SubPhasePass37Mage)
 	mageEntities, mageRels, mageErr := mageextract.Discover(ctx, absRepo, allFiles)
 	if mageErr != nil {
 		fmt.Fprintf(os.Stderr, "grafel: mage-discover warning: %v\n", mageErr)
@@ -1191,6 +1361,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Pass 3.8 — Task (taskfile.dev) build-graph fusion (#3217).
 	// Parses Taskfile.yml/.yaml, emitting one SCOPE.Operation per task and
 	// TASK_DEPENDS_ON edges for deps: prerequisites and { task: <name> } cmds.
+	passTimer.enter(progress.SubPhasePass38Task)
 	taskEntities, taskRels, taskErr := taskextract.Discover(ctx, absRepo, allFiles)
 	if taskErr != nil {
 		fmt.Fprintf(os.Stderr, "grafel: task-discover warning: %v\n", taskErr)
@@ -1209,6 +1380,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// passes in Pass 2.5 can only see each file in isolation.
 	// Results are appended to pass3Records for buildDocument to merge.
 	if !i.skipPasses[PassFramework] {
+		passTimer.enter(progress.SubPhasePass26DjangoRoutes)
 		nestedEntities := runDjangoNestedURLConf(classified)
 
 		// Pass 2.6b — DRF router.register expansion (#703, #705). Emits
@@ -1284,6 +1456,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// dispatch sites across files (tasks/ ← views/ ← signals/ ← services/)
 		// and emits CALLS edges so find_callees / find_callers on a task and
 		// the flows view show task dispatch. Append-only.
+		passTimer.enter(progress.SubPhasePass26DjangoEdges)
 		celeryDispatchRels := runCeleryDispatchEdges(classified)
 		if len(celeryDispatchRels) > 0 {
 			fmt.Fprintf(os.Stderr, "grafel: celery_dispatch_edges=%d\n", len(celeryDispatchRels))
@@ -1341,6 +1514,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// intervening annotations between @VERB and @Path). Must run before the
 	// classified slice is released below. Refs #682, #683.
 	if !i.skipPasses[PassFramework] {
+		passTimer.enter(progress.SubPhasePass26JavaRoutes)
 		javaEntities := runJavaAnnotationRoutes(classified)
 		pass3Records = append(pass3Records, javaEntities...)
 	}
@@ -1360,6 +1534,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// before buildDocument (where ResolveHTTPEndpointHandlers clears
 	// the source_handler property post-resolution).
 	if !i.skipPasses[PassFramework] && len(classified) > 0 {
+		passTimer.enter(progress.SubPhasePass27ResponseShapes)
 		// Build a file-content lookup from the classified slice.
 		contentByPath := make(map[string][]byte, len(classified))
 		allPaths := make([]string, 0, len(classified))
@@ -1415,6 +1590,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// by following HTTP client call sites through the ROUTES_TO graph.
 	// Must run before releaseClassifiedASTs since we need file content access.
 	if !i.skipPasses[PassFramework] && len(classified) > 0 {
+		passTimer.enter(progress.SubPhasePass28TestsMultiHop)
 		// Gather all paths and build the file-content lookup.
 		var allPaths []string
 		contentByPath := make(map[string][]byte, len(classified))
@@ -1472,9 +1648,11 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// across the entire downstream pipeline (resolver, build-document,
 	// external-synthesis, Pass 4). tree-sitter trees are CGo-allocated so
 	// runtime.GC alone can't reclaim them — Close() is required.
+	passTimer.enter(progress.SubPhaseReleaseASTs)
 	releaseClassifiedASTs(classified)
 	classified = nil
 	runtime.GC()
+	passTimer.finish()
 
 	// Pass 5 — build document (deduped).
 	trk.PhaseStart(progress.PhaseMaterialize, len(files), 0)

--- a/cmd/grafel/parse_concurrency_5954_test.go
+++ b/cmd/grafel/parse_concurrency_5954_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestIndexParseCoreBudget_Is25PercentOfMachine pins the indexing core budget
+// policy: 25% of machine capacity, minimum 1.
+//
+// The rule it replaces was a static "never more than 3 cores", which protected
+// a small laptop but pinned a large machine to the same 3. Proportional keeps
+// the "must not make the box feel busy" property while letting bigger machines
+// index faster; on a 12-core host it evaluates to 3, i.e. the old rule exactly.
+func TestIndexParseCoreBudget_Is25PercentOfMachine(t *testing.T) {
+	got := indexParseCoreBudget()
+	want := runtime.NumCPU() / 4
+	if want < 1 {
+		want = 1
+	}
+	if got != want {
+		t.Errorf("indexParseCoreBudget() = %d, want max(1, NumCPU/4) = %d (NumCPU=%d)",
+			got, want, runtime.NumCPU())
+	}
+	if got < 1 {
+		t.Errorf("budget = %d — must never be < 1, and must never be 0, "+
+			"since parsegate.go treats cap<=0 as UNBOUNDED", got)
+	}
+	if n := runtime.NumCPU(); n >= 4 && got > n/4 {
+		t.Errorf("budget %d exceeds 25%% of %d cores", got, n)
+	}
+}
+
+// TestEnsureParseConcurrencyDefault_InstallsCapOffDaemon pins the #5954
+// blocker fix: the non-daemon background index path must install an in-process
+// parse concurrency cap.
+//
+// Before this, indexstate.SetParseConcurrency had exactly ONE production
+// caller (the daemon), and parsegate treats cap<=0 as unbounded — so
+// `grafel index-internal`, the child the scheduler/rebuild path fork-execs,
+// ran with AcquireParseSlot as a no-op. With parseMu gone that would have
+// allowed i.workers (8) concurrent ts_parser_parse on 8 OS threads, with
+// GRAFEL_EXTRACT_GOMAXPROCS offering no protection because GOMAXPROCS does
+// not bound cgo.
+func TestEnsureParseConcurrencyDefault_InstallsCapOffDaemon(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+
+	indexstate.SetParseConcurrency(0) // the non-daemon starting state
+	if got := indexstate.ParseConcurrencyCap(); got != 0 {
+		t.Fatalf("precondition: cap = %d, want 0 (unbounded)", got)
+	}
+
+	got, installed := ensureParseConcurrencyDefault(false)
+	want := indexParseCoreBudget()
+	if !installed {
+		t.Error("installed = false — the background index path must install a cap when none exists")
+	}
+	if got != want {
+		t.Errorf("returned cap = %d, want the core budget %d", got, want)
+	}
+	if installed := indexstate.ParseConcurrencyCap(); installed != want {
+		t.Errorf("installed cap = %d, want %d — the parse gate is still unbounded, "+
+			"so concurrent ts_parser_parse is uncapped on the non-daemon path", installed, want)
+	}
+	if installed := indexstate.ParseConcurrencyCap(); installed <= 0 {
+		t.Error("cap <= 0 means UNBOUNDED in parsegate.go — the gate must actually bind")
+	}
+}
+
+// TestEnsureParseConcurrencyDefault_InteractiveIsExempt pins the explicit
+// product decision that a foreground, user-awaited rebuild may use the whole
+// machine. Capping it would only make the human wait; the budget exists to
+// protect a developer from work that runs UNASKED.
+func TestEnsureParseConcurrencyDefault_InteractiveIsExempt(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+
+	indexstate.SetParseConcurrency(0)
+	if got, installed := ensureParseConcurrencyDefault(true); got != 0 || installed {
+		t.Errorf("interactive cap = %d installed=%v, want 0/false (uncapped)", got, installed)
+	}
+	if installed := indexstate.ParseConcurrencyCap(); installed != 0 {
+		t.Errorf("interactive run installed cap %d — foreground rebuilds must stay uncapped", installed)
+	}
+}
+
+// TestEnsureParseConcurrencyDefault_NeverOverridesExisting pins the other half:
+// the daemon installs its own cap at startup (and may deliberately tighten it
+// via GRAFEL_DAEMON_GOMAXPROCS). An in-process index inside the daemon must not
+// silently widen that back out — not even an interactive one.
+func TestEnsureParseConcurrencyDefault_NeverOverridesExisting(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+
+	for _, interactive := range []bool{false, true} {
+		indexstate.SetParseConcurrency(2) // pretend the daemon capped us at 2
+		got, installed := ensureParseConcurrencyDefault(interactive)
+		if got != 2 {
+			t.Errorf("interactive=%v: returned cap = %d, want the pre-existing 2", interactive, got)
+		}
+		if installed {
+			t.Errorf("interactive=%v: reported installing a cap when one already existed", interactive)
+		}
+		if installed := indexstate.ParseConcurrencyCap(); installed != 2 {
+			t.Errorf("interactive=%v: cap = %d, want 2 — an existing (daemon) cap must never be changed",
+				interactive, installed)
+		}
+	}
+}

--- a/docs/adrs/0023-migrate-to-official-tree-sitter-binding-per-language-modules.md
+++ b/docs/adrs/0023-migrate-to-official-tree-sitter-binding-per-language-modules.md
@@ -277,8 +277,15 @@ committing the whole codebase to it.)
   (`docs/grammar-canary-baseline.json`) per grammar — catches ABI mismatch (§6)
   that compiles but crashes/garbles at runtime. Refresh the canary baseline after
   each promotion (grammar version changed ⇒ expected node shape may shift).
-- Re-test the **#481 race**: confirm whether the official binding still needs the
-  `parseMu` global serialization (a freebie if it doesn't).
+- ~~Re-test the **#481 race**: confirm whether the official binding still needs the
+  `parseMu` global serialization (a freebie if it doesn't).~~ **DONE (#5954).** It
+  does not. Every parse owns a private `TSParser` (`ts_parser_new` per call), the
+  only shared object is the immutable per-language `TSLanguage` (whose
+  `ts_language_copy` is a no-op for non-wasm grammars), and no bundled external
+  scanner keeps mutable file-scope state. `parseMu` was removed; see
+  `TestParse_ConcurrentMultiLanguage_NoRace` (`-race`) and the `ParserFactory`
+  godoc for the argument. Determinism is anchored by the post-worker-pool sorts
+  in `cmd/grafel/index.go`, not by the mutex.
 
 ### Rollback
 

--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -38,6 +38,7 @@ package cpp
 import (
 	"bytes"
 	"context"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
@@ -97,7 +98,20 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		}
 		defer parser.Close()
 		var err error
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -19,6 +19,7 @@ package dockerfile
 import (
 	"context"
 	"encoding/json"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
@@ -67,7 +68,20 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		}
 		defer parser.Close()
 		var err error
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -31,6 +31,7 @@ package golang
 import (
 	"context"
 	"fmt"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"log"
 	"strconv"
 	"strings"
@@ -87,7 +88,20 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 			return nil, fmt.Errorf("golang extractor: parser init failed: %w", err)
 		}
 		defer parser.Close()
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, fmt.Errorf("golang extractor: parse failed: %w", err)
 		}

--- a/internal/extractors/hcl/extractor.go
+++ b/internal/extractors/hcl/extractor.go
@@ -29,6 +29,7 @@ package hcl
 import (
 	"bytes"
 	"context"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
@@ -87,7 +88,20 @@ func (e *HCLExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 		}
 		defer parser.Close()
 		var err error
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extractors/html/extractor.go
+++ b/internal/extractors/html/extractor.go
@@ -26,6 +26,7 @@ package html
 
 import (
 	"context"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"regexp"
 	"strings"
 
@@ -167,7 +168,20 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		}
 		defer parser.Close()
 		var err error
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extractors/parse_gate_bypass_5954_test.go
+++ b/internal/extractors/parse_gate_bypass_5954_test.go
@@ -1,0 +1,65 @@
+package extractors_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+// TestExtract_InlineParseIsGated proves that the extractor-level parses which
+// BYPASS treesitter.ParserFactory are nonetheless bounded by the #5630 parse
+// gate.
+//
+// WHY THIS MATTERS (#5954). The in-process parse ceiling is only real if every
+// path to ts_parser_parse goes through AcquireParseSlot — GOMAXPROCS cannot
+// bound cgo, so an ungated path is an unbounded path. Two families bypassed the
+// factory (and therefore also bypassed the old parseMu):
+//
+//   - each extractor's `if file.TSTree == nil { NewParser… }` inline parse,
+//     which fires in production whenever the pipeline's own parse failed — i.e.
+//     exactly on the pathological/oversized files that most need capping;
+//   - internal/extractors/yaml/helm.go, which re-parses every Helm template's
+//     stripped content unconditionally.
+//
+// The assertion is blocking, not timing-based: with cap=1 and the only slot
+// held, Extract must not finish; once released, it must.
+func TestExtract_InlineParseIsGated(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+
+	indexstate.SetParseConcurrency(1)
+	indexstate.AcquireParseSlot() // hold the only slot
+
+	// TSTree deliberately nil so the extractor takes its inline-parse path.
+	file := extractor.FileInput{
+		Path:     "svc/models.py",
+		Content:  []byte("class Foo:\n    def bar(self):\n        return 1\n"),
+		Language: "python",
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_, _ = extractors.Extract(context.Background(), file)
+	}()
+
+	select {
+	case <-done:
+		indexstate.ReleaseParseSlot()
+		t.Fatal("extractor inline parse completed while the only parse slot was held — " +
+			"this path bypasses the parse gate, so the in-process parse ceiling is illusory (#5954)")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: blocked in AcquireParseSlot, before the cgo parse.
+	}
+
+	indexstate.ReleaseParseSlot()
+	select {
+	case <-done:
+		// Expected.
+	case <-time.After(20 * time.Second):
+		t.Fatal("extractor did not proceed after the slot was released")
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -25,6 +25,7 @@ package python
 import (
 	"context"
 	"fmt"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -111,7 +112,30 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 			return nil, fmt.Errorf("python extractor: parser init failed: %w", parseErr)
 		}
 		defer parser.Close()
-		tree, parseErr = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo).
+		//
+		// WHY THE DEFER IS SCOPED TO A CLOSURE, not to this function. Both
+		// halves are load-bearing and neither is a style choice:
+		//   - the closure keeps the release BEFORE the node walk. A
+		//     function-scoped defer would hold the slot across the whole
+		//     extractor, which would throttle EXTRACTION instead of parsing —
+		//     a severe regression at a budget of 3.
+		//   - the defer makes the release panic-safe. A bare Acquire/Release
+		//     pair leaks both the slot and the ParseBegin/ParseEnd busy counter
+		//     forever if Parse panics, and daemon.go recovers index panics and
+		//     keeps running — so one panic would permanently cost 33% of a
+		//     cap-3 budget and pin index_status at "parsing" for the life of
+		//     the daemon.
+		// Do not "simplify" either property away.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, parseErr = parser.Parse(file.Content)
+		}()
 		if parseErr != nil {
 			return nil, fmt.Errorf("python extractor: parse failed: %w", parseErr)
 		}

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -50,6 +50,7 @@ package yaml
 import (
 	"bytes"
 	"context"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"log"
 	"strconv"
 	"strings"
@@ -99,7 +100,20 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		}
 		defer parser.Close()
 		var err error
-		tree, err = parser.Parse(file.Content)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. This fallback bypasses the
+		// factory, so before #5954 it bypassed parseMu; it must not now
+		// bypass AcquireParseSlot, or the in-process parse ceiling is
+		// illusory (GOMAXPROCS cannot bound cgo). The defer is scoped to a
+		// closure around the parse alone so the release happens BEFORE the node
+		// walk (holding it across the walk would throttle extraction, not
+		// parsing) and still survives a panic in Parse. See the python
+		// extractor for the full rationale.
+		func() {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			tree, err = parser.Parse(file.Content)
+		}()
 		if err != nil {
 			return nil, err
 		}

--- a/internal/extractors/yaml/helm.go
+++ b/internal/extractors/yaml/helm.go
@@ -41,6 +41,7 @@ package yaml
 
 import (
 	"bytes"
+	"github.com/cajasmota/grafel/internal/indexstate"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -678,7 +679,29 @@ func extractHelmTemplate(file extractor.FileInput) []types.EntityRecord {
 	}
 	if parser, perr := yamlAdapter.NewParser(yamlGrammar()); perr == nil {
 		defer parser.Close()
-		tree, err := parser.Parse(res.stripped)
+		// #5954 — bound this parse by the same daemon-wide gate that
+		// treesitter.ParserFactory.Parse uses. Unlike the per-extractor
+		// `file.TSTree == nil` fallbacks this is an UNCONDITIONAL second parse
+		// of every Helm template (the templating-stripped content), so it is a
+		// hot production path that has always bypassed the factory — and thus
+		// bypassed parseMu, which is the clearest evidence that unserialised
+		// concurrent ts_parser_parse was already shipping. It must not also
+		// bypass AcquireParseSlot, or the in-process parse ceiling is illusory
+		// (GOMAXPROCS cannot bound cgo).
+		//
+		// The slot is taken and released inside a closure around the parse
+		// alone, so it is released BEFORE the node walk below (holding it
+		// across the walk would throttle extraction rather than parsing — a
+		// severe regression at a budget of 3) AND the release survives a panic
+		// in Parse (a leaked slot is permanent: daemon.go recovers index
+		// panics). The closure returns its values rather than assigning to
+		// outer ones so the existing := stays put and nothing is shadowed. See
+		// the python extractor for the full rationale.
+		tree, err := func() (ts.Tree, error) {
+			indexstate.AcquireParseSlot()
+			defer indexstate.ReleaseParseSlot()
+			return parser.Parse(res.stripped)
+		}()
 		if err == nil && tree != nil {
 			root := tree.RootNode()
 			if root != nil {

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -17,6 +17,7 @@
 package progress
 
 import (
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -85,6 +86,67 @@ const (
 	// SSE tick is delivered. See wizard_split_progress.go's
 	// emitStatusPlaneRowEvents (grafel wizard split-mode index).
 	PhaseIndexing = "indexing"
+)
+
+// subPhaseSep separates a sub-phase label's parent phase from its pass name.
+// Filename-safe on purpose: memtrace writes a heap profile named after the
+// active phase on every transition, so a "/" here would break os.Create.
+const subPhaseSep = "."
+
+// Sub-phase labels for the resolving_refs window (#5954).
+//
+// resolving_refs is a COMPOSITE phase: a single label covered ~52% of cold
+// index wall time across a dozen independent passes, so nothing downstream
+// could tell which of them was expensive — and specifically not how much of it
+// is per-FILE work (which a content-addressed per-file extraction cache could
+// eliminate) versus GLOBAL work (which it could not). These labels split that
+// window, one per distinct pass.
+//
+// They are OBSERVABILITY-ONLY. Unlike the phases above they are never
+// published as an Event: Tracker.SubPhase stamps currentPhase without emitting,
+// so the SSE stream, the CLI renderer, and the wizard see exactly the phases
+// they saw before. The only consumer is Tracker.CurrentPhase — i.e. the
+// memtrace sampler's phase= tag (#5956), which is where the timings land.
+//
+// Naming contract, relied on by the analysis scripts: every label is
+// "<parent phase>.<pass>", so grouping memtrace samples on the segment before
+// the first "." reproduces the coarse phase breakdown exactly as before, while
+// grouping on the full string gives the per-pass split. Keep these stable.
+//
+// Tracker.SubPhase enforces the "<parent>.<pass>" contract at stamp time: a
+// label whose parent is not the active phase is dropped rather than recorded.
+const (
+	// Per-file: the YAML rule engine runs over each classified file's content.
+	SubPhasePass25FrameworkRules = PhaseResolveRefs + subPhaseSep + "pass25_framework_rules"
+	// Per-file: cross-language extractors, driven off the classified slice.
+	SubPhasePass3CrossLang = PhaseResolveRefs + subPhaseSep + "pass3_cross_lang"
+	// Per-file: config-entity discovery over the pre-classification file list.
+	SubPhasePass35ConfigDiscovery = PhaseResolveRefs + subPhaseSep + "pass35_config_discovery"
+	// Per-file: BUILD/BUILD.bazel parse (only Bazel files are read).
+	SubPhasePass36Bazel = PhaseResolveRefs + subPhaseSep + "pass36_bazel"
+	// Per-file: magefile parse (only mage-tagged Go files are read).
+	SubPhasePass37Mage = PhaseResolveRefs + subPhaseSep + "pass37_mage"
+	// Per-file: Taskfile.yml parse (only taskfiles are read).
+	SubPhasePass38Task = PhaseResolveRefs + subPhaseSep + "pass38_task"
+	// Per-file scan, global join: Django/DRF route synthesis walks every
+	// classified Python file but composes URLconf chains ACROSS files, so its
+	// output is not a pure function of any single file.
+	SubPhasePass26DjangoRoutes = PhaseResolveRefs + subPhaseSep + "pass26_django_routes"
+	// Per-file scan, global join: Celery dispatch, custom-signal pub/sub,
+	// Serializer/FilterSet Meta.model and @receiver(sender=) edges — all
+	// cross-file resolutions over the same scan.
+	SubPhasePass26DjangoEdges = PhaseResolveRefs + subPhaseSep + "pass26_django_edges"
+	// Per-file: Java JAX-RS / Spring MVC annotation route composition.
+	SubPhasePass26JavaRoutes = PhaseResolveRefs + subPhaseSep + "pass26_java_routes"
+	// Global: response-shape + Sails auth attribution join the whole record
+	// set against the whole file set (handler lives in another module).
+	SubPhasePass27ResponseShapes = PhaseResolveRefs + subPhaseSep + "pass27_response_shapes"
+	// Global: multi-hop TESTS edges follow the corpus-wide ROUTES_TO graph.
+	SubPhasePass28TestsMultiHop = PhaseResolveRefs + subPhaseSep + "pass28_tests_multihop"
+	// Global: release the per-file ASTs/content and force a GC before
+	// buildDocument. Charged separately because runtime.GC() on a multi-GB
+	// heap is not free and would otherwise be misattributed to pass 2.8.
+	SubPhaseReleaseASTs = PhaseResolveRefs + subPhaseSep + "release_asts"
 )
 
 // TickEveryNFiles is the default file-tick interval for the AST extraction
@@ -412,6 +474,57 @@ func (t *Tracker) Phase(phase, passName string, entitiesSoFar int) {
 		PhaseStartedAtMS: t.phaseStartedAtMS,
 		TS:               nowMS(),
 	})
+}
+
+// SubPhase stamps a finer-grained label inside the phase already started by
+// PhaseStart/Phase, WITHOUT publishing an Event (#5954).
+//
+// This is the deliberate difference from PhaseStart and Phase: every consumer
+// of the progress stream — SSE, the CLI renderer, the wizard's fold table —
+// keeps seeing exactly the coarse phases it saw before, byte for byte, while
+// the memtrace sampler (which reads CurrentPhase, not the event stream) starts
+// tagging its samples with the sub-pass that is actually running. It is
+// therefore safe to call from anywhere inside a phase: it can neither change
+// the UI nor perturb the graph.
+//
+// Pass one of the SubPhase* constants; they encode their parent phase as a
+// "<phase>.<pass>" prefix so aggregate-by-phase analysis still works.
+//
+// The prefix contract is ENFORCED, not merely documented: a label whose parent
+// does not match the currently-active phase is IGNORED. Without that guard the
+// contract is violable by the shipped code — the pass-3.5-and-later sites in
+// cmd/grafel/index.go run in both the in-process and the
+// GRAFEL_SUBPROC_EXTRACT branch, and only the former has entered
+// resolving_refs, so under subproc-extract they would stamp "resolving_refs.*"
+// while extracting_ast is active and silently misattribute those samples. A
+// dropped stamp just leaves the coarse phase in place, which is exactly the
+// pre-#5954 behaviour.
+//
+// The stamp is sticky: it stays in effect until the next SubPhase, PhaseStart,
+// or Phase call. There is no "end" call — the following PhaseStart naturally
+// resets it, and a gap between two sub-phases is attributed to the earlier one,
+// which is the right default for a strictly sequential pass list.
+//
+// Concurrency: currentPhase is an atomic.Value, so this is safe to call while
+// the sampler goroutine is polling CurrentPhase (same contract as PhaseStart).
+func (t *Tracker) SubPhase(label string) {
+	if t == nil || label == "" {
+		return
+	}
+	parent, _, ok := strings.Cut(label, subPhaseSep)
+	if !ok || parent == "" {
+		return // not a well-formed sub-phase label
+	}
+	// The active phase is either the parent itself (first sub-phase of the
+	// window) or an earlier sub-phase of the same parent.
+	active := t.CurrentPhase()
+	if activeParent, _, isSub := strings.Cut(active, subPhaseSep); isSub {
+		active = activeParent
+	}
+	if active != parent {
+		return
+	}
+	t.currentPhase.Store(label)
 }
 
 // AlgorithmEvent emits an entry or exit event for a named graph algorithm.

--- a/internal/progress/subphase_5954_test.go
+++ b/internal/progress/subphase_5954_test.go
@@ -1,0 +1,186 @@
+package progress_test
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// TestTracker_SubPhase_StampsWithoutPublishing is the zero-risk gate for the
+// #5954 resolving_refs instrumentation.
+//
+// The whole point of SubPhase is that it splits the memtrace phase= tag
+// WITHOUT touching the event stream: if it published, every consumer of the
+// progress feed (SSE, the CLI renderer, the wizard fold table) would suddenly
+// see a dozen phase labels it has no mapping for. So the test asserts both
+// halves — CurrentPhase moves, the collector stays empty — and that a
+// following PhaseStart resets the stamp cleanly.
+func TestTracker_SubPhase_StampsWithoutPublishing(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+
+	trk.PhaseStart(progress.PhaseResolveRefs, 10, 0)
+	if len(col.Events) != 1 {
+		t.Fatalf("PhaseStart should publish exactly 1 event, got %d", len(col.Events))
+	}
+
+	for _, label := range []string{
+		progress.SubPhasePass25FrameworkRules,
+		progress.SubPhasePass3CrossLang,
+		progress.SubPhasePass27ResponseShapes,
+	} {
+		trk.SubPhase(label)
+		if got := trk.CurrentPhase(); got != label {
+			t.Errorf("CurrentPhase() after SubPhase(%q) = %q", label, got)
+		}
+		if len(col.Events) != 1 {
+			t.Fatalf("SubPhase(%q) published an event — it must not; events=%d",
+				label, len(col.Events))
+		}
+	}
+
+	// An empty label is a no-op, not a phase reset.
+	trk.SubPhase("")
+	if got := trk.CurrentPhase(); got != progress.SubPhasePass27ResponseShapes {
+		t.Errorf("SubPhase(\"\") changed the phase to %q", got)
+	}
+
+	// A malformed (parentless) label is dropped, not stamped.
+	trk.SubPhase("pass99_no_parent")
+	if got := trk.CurrentPhase(); got != progress.SubPhasePass27ResponseShapes {
+		t.Errorf("SubPhase on a parentless label changed the phase to %q", got)
+	}
+
+	// The next real phase boundary takes over, sub-phase stamp and all.
+	trk.PhaseStart(progress.PhaseMaterialize, 10, 5)
+	if got := trk.CurrentPhase(); got != progress.PhaseMaterialize {
+		t.Errorf("CurrentPhase() after PhaseStart(materializing) = %q", got)
+	}
+	if len(col.Events) != 2 {
+		t.Fatalf("expected exactly 2 published events (the two PhaseStarts), got %d", len(col.Events))
+	}
+}
+
+// TestSubPhaseLabels_ParentPrefixContract pins the naming contract the memtrace
+// analysis relies on: every sub-phase label is "<parent>.<pass>", so grouping
+// samples on the segment before the first "." reproduces the coarse phase
+// breakdown exactly as it read before the split.
+func TestSubPhaseLabels_ParentPrefixContract(t *testing.T) {
+	labels := []string{
+		progress.SubPhasePass25FrameworkRules,
+		progress.SubPhasePass3CrossLang,
+		progress.SubPhasePass35ConfigDiscovery,
+		progress.SubPhasePass36Bazel,
+		progress.SubPhasePass37Mage,
+		progress.SubPhasePass38Task,
+		progress.SubPhasePass26DjangoRoutes,
+		progress.SubPhasePass26DjangoEdges,
+		progress.SubPhasePass26JavaRoutes,
+		progress.SubPhasePass27ResponseShapes,
+		progress.SubPhasePass28TestsMultiHop,
+		progress.SubPhaseReleaseASTs,
+	}
+	seen := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		parent, pass, ok := strings.Cut(l, ".")
+		if !ok {
+			t.Errorf("label %q has no \".\" separator", l)
+			continue
+		}
+		if parent != progress.PhaseResolveRefs {
+			t.Errorf("label %q: parent = %q, want %q", l, parent, progress.PhaseResolveRefs)
+		}
+		if pass == "" || strings.Contains(pass, ".") {
+			t.Errorf("label %q: pass segment %q must be non-empty and dot-free", l, pass)
+		}
+		if seen[l] {
+			t.Errorf("duplicate sub-phase label %q", l)
+		}
+		seen[l] = true
+	}
+}
+
+// TestTracker_SubPhase_DroppedWhenParentPhaseInactive pins the enforcement of
+// the "<parent>.<pass>" contract.
+//
+// This is not hypothetical: cmd/grafel/index.go stamps the pass-3.5-and-later
+// labels from code that runs in BOTH the in-process and the
+// GRAFEL_SUBPROC_EXTRACT branch, and only the former enters resolving_refs. If
+// SubPhase stamped unconditionally, a subproc-extract run would tag samples
+// "resolving_refs.pass35_config_discovery" while extracting_ast was the active
+// phase — breaking the prefix contract the memtrace analysis groups on. The
+// stamp must be dropped instead, leaving the coarse phase in place.
+func TestTracker_SubPhase_DroppedWhenParentPhaseInactive(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+
+	// The subproc-extract shape: extracting_ast is active, and the shared
+	// pass-3.5+ code path stamps a resolving_refs.* label.
+	trk.PhaseStart(progress.PhaseExtractAST, 0, 0)
+	for _, label := range []string{
+		progress.SubPhasePass35ConfigDiscovery,
+		progress.SubPhasePass36Bazel,
+		progress.SubPhasePass28TestsMultiHop,
+	} {
+		trk.SubPhase(label)
+		if got := trk.CurrentPhase(); got != progress.PhaseExtractAST {
+			t.Fatalf("SubPhase(%q) under active phase %q stamped %q — cross-phase "+
+				"stamps must be dropped, not recorded",
+				label, progress.PhaseExtractAST, got)
+		}
+	}
+
+	// Same labels, correct parent active: now they stamp.
+	trk.PhaseStart(progress.PhaseResolveRefs, 0, 0)
+	trk.SubPhase(progress.SubPhasePass35ConfigDiscovery)
+	if got := trk.CurrentPhase(); got != progress.SubPhasePass35ConfigDiscovery {
+		t.Fatalf("SubPhase under the matching parent = %q, want %q",
+			got, progress.SubPhasePass35ConfigDiscovery)
+	}
+
+	// Before any phase has started there is no parent, so nothing stamps.
+	fresh := progress.NewTracker(&progress.SliceCollector{}, "g", "r")
+	fresh.SubPhase(progress.SubPhasePass25FrameworkRules)
+	if got := fresh.CurrentPhase(); got != "" {
+		t.Errorf("SubPhase before any PhaseStart = %q, want empty", got)
+	}
+}
+
+// TestTracker_SubPhase_RaceWithCurrentPhase mirrors the real wiring: the
+// indexer goroutine stamps sub-phases while the memtrace sampler goroutine
+// polls CurrentPhase. Run under -race this pins the atomic.Value contract that
+// makes the instrumentation safe to add anywhere inside a phase.
+func TestTracker_SubPhase_RaceWithCurrentPhase(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+	trk.PhaseStart(progress.PhaseResolveRefs, 0, 0)
+
+	labels := []string{
+		progress.SubPhasePass25FrameworkRules,
+		progress.SubPhasePass3CrossLang,
+		progress.SubPhasePass28TestsMultiHop,
+		progress.SubPhaseReleaseASTs,
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { // sampler
+		defer wg.Done()
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = trk.CurrentPhase()
+			}
+		}
+	}()
+	for i := 0; i < 2000; i++ {
+		trk.SubPhase(labels[i%len(labels)])
+	}
+	close(done)
+	wg.Wait()
+}

--- a/internal/treesitter/parse_canary_test.go
+++ b/internal/treesitter/parse_canary_test.go
@@ -28,7 +28,7 @@ package treesitter_test
 //      into the existing ParseErrorCanary. This is a CI-safe proxy for a
 //      daemon-level parse loop: a full daemon is too heavy for CI, but every real
 //      parse funnels through the same in-process chokepoint a runaway daemon
-//      parse would hold (parseMu #481 + the parse slot #5630), so a corpus that
+//      parse would hold (the parse slot #5630), so a corpus that
 //      never settles is the same signal as a daemon that never settles.
 //
 // BOUNDS / MARGIN (deterministic, generous-but-finite)
@@ -59,7 +59,7 @@ const (
 
 	// corpusBound is the wall-clock budget for parsing the entire corpus
 	// sequentially through one factory. ~28 files * (parse + node walk),
-	// serialised on parseMu; 90s is comfortable on the slowest CI runner yet
+	// bounded by the parse-slot gate; 90s is comfortable on the slowest CI runner yet
 	// well under the minutes-long hang a daemon-level loop produces.
 	corpusBound = 90 * time.Second
 
@@ -845,7 +845,7 @@ func TestParseCanary_RealFiles_TimeBounded(t *testing.T) {
 // a single aggregate wall-clock bound, folding every result into the existing
 // ParseErrorCanary. A full daemon is too heavy for CI, but every real parse
 // funnels through the same in-process chokepoint a runaway daemon parse holds
-// (parseMu #481 + the parse slot #5630), so a corpus that never settles is the
+// (the parse slot #5630), so a corpus that never settles is the
 // same signal as a daemon that never settles. It also exercises the aggregate
 // canary path end-to-end (Observe across many files of many languages).
 func TestParseCanary_CorpusSettles_TimeBounded(t *testing.T) {
@@ -899,7 +899,7 @@ func TestParseCanary_CorpusSettles_TimeBounded(t *testing.T) {
 		t.Logf("corpus settled: %d files across %d languages", r.files, len(snap))
 	case <-time.After(corpusBound):
 		t.Fatalf("corpus did NOT settle within %s — daemon-level non-termination suspected "+
-			"(a single looping parse holds parseMu/the parse slot and stalls the whole pipeline, "+
+			"(a single looping parse holds the parse slot and stalls the whole pipeline, "+
 			"the Wave A daemon symptom)", corpusBound)
 	}
 }

--- a/internal/treesitter/parse_concurrency_5954_test.go
+++ b/internal/treesitter/parse_concurrency_5954_test.go
@@ -1,0 +1,292 @@
+package treesitter_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/treesitter"
+)
+
+// repHdr builds a source blob: an optional file header followed by n repeated
+// blocks. Blocks are indexed so every declaration is distinct, which keeps the
+// parse from collapsing onto a trivially-cached shape.
+func repHdr(header string, n int, f func(i int) string) []byte {
+	var b strings.Builder
+	b.WriteString(header)
+	for i := 0; i < n; i++ {
+		b.WriteString(f(i))
+	}
+	return []byte(b.String())
+}
+
+// concurrencyCorpus is the multi-language input set for the #5954 race gate.
+// One entry per grammar family that has an external scanner with per-parser
+// state (bash, python, ruby, css, html, typescript/tsx, rust, scala, php,
+// yaml, toml) plus the scanner-less generated grammars (go, java, csharp, c,
+// cpp, proto, sql, kotlin) — those are the two shapes whose concurrency
+// behaviour differs, so both must be exercised. Sources are deliberately
+// non-trivial (repeated blocks) so a parse is long enough for goroutines to
+// genuinely overlap inside ts_parser_parse rather than finishing serially by
+// luck.
+func concurrencyCorpus() []struct {
+	lang string
+	src  []byte
+} {
+	rep := func(n int, f func(i int) string) []byte { return repHdr("", n, f) }
+	return []struct {
+		lang string
+		src  []byte
+	}{
+		{"go", repHdr("package p\n", 120, func(i int) string {
+			return fmt.Sprintf("func F%d(a int) int { if a > %d { return a }\n\treturn F%d(a + 1) }\n", i, i, i)
+		})},
+		{"python", rep(120, func(i int) string {
+			return fmt.Sprintf("class C%d(Base):\n    def m%d(self, x):\n        return [y for y in range(x) if y %% 2]\n", i, i)
+		})},
+		{"typescript", rep(120, func(i int) string {
+			return fmt.Sprintf("export function f%d<T>(x: T[]): T | undefined { return x[%d]; }\n", i, i)
+		})},
+		{"tsx", rep(120, func(i int) string {
+			return fmt.Sprintf("const C%d = () => <div className=\"c%d\"><span>{%d}</span></div>;\n", i, i, i)
+		})},
+		{"javascript", rep(120, func(i int) string {
+			return fmt.Sprintf("async function g%d() { const r = await fetch('/a/%d'); return r.json(); }\n", i, i)
+		})},
+		{"java", rep(120, func(i int) string {
+			return fmt.Sprintf("class K%d { int m() { return %d; } }\n", i, i)
+		})},
+		{"ruby", rep(120, func(i int) string {
+			return fmt.Sprintf("class R%d\n  def m%d(a)\n    a.map { |x| x + %d }\n  end\nend\n", i, i, i)
+		})},
+		{"bash", rep(120, func(i int) string {
+			return fmt.Sprintf("f%d() {\n  local v=$(echo \"hi %d\")\n  echo \"${v}\"\n}\n", i, i)
+		})},
+		{"rust", rep(120, func(i int) string {
+			return fmt.Sprintf("pub fn f%d(x: i32) -> i32 { let s = r#\"raw %d\"#; s.len() as i32 + x }\n", i, i)
+		})},
+		{"css", rep(120, func(i int) string {
+			return fmt.Sprintf(".c%d { color: #%03d; margin: %dpx; }\n", i, i%1000, i)
+		})},
+		{"html", rep(120, func(i int) string {
+			return fmt.Sprintf("<div id=\"d%d\"><p>row %d</p><script>var x=%d;</script></div>\n", i, i, i)
+		})},
+		{"yaml", rep(120, func(i int) string {
+			return fmt.Sprintf("key%d:\n  nested: value%d\n  list:\n    - a%d\n", i, i, i)
+		})},
+		{"toml", rep(120, func(i int) string {
+			return fmt.Sprintf("[t%d]\nkey = \"value%d\"\nnum = %d\n", i, i, i)
+		})},
+		{"php", rep(120, func(i int) string {
+			return fmt.Sprintf("<?php\nfunction f%d() { $h = <<<EOT\nheredoc %d\nEOT;\n return $h; }\n", i, i)
+		})},
+		{"scala", rep(80, func(i int) string {
+			return fmt.Sprintf("object O%d { def f(x: Int): Int = x + %d }\n", i, i)
+		})},
+		{"csharp", rep(120, func(i int) string {
+			return fmt.Sprintf("class C%d { int M() => %d; }\n", i, i)
+		})},
+		{"c", rep(120, func(i int) string {
+			return fmt.Sprintf("int f%d(int a) { return a + %d; }\n", i, i)
+		})},
+		{"cpp", rep(120, func(i int) string {
+			return fmt.Sprintf("template <typename T> struct S%d { T f() { return T(%d); } };\n", i, i)
+		})},
+		{"proto", repHdr("syntax = \"proto3\";\n", 60, func(i int) string {
+			return fmt.Sprintf("message M%d { int32 id = 1; string name = 2; }\n", i)
+		})},
+		{"sql", rep(120, func(i int) string {
+			return fmt.Sprintf("SELECT a%d, b FROM t%d WHERE id = %d;\n", i, i, i)
+		})},
+		{"kotlin", rep(120, func(i int) string {
+			return fmt.Sprintf("fun f%d(x: Int): Int { return x + %d }\n", i, i)
+		})},
+		{"lua", rep(120, func(i int) string {
+			return fmt.Sprintf("local function f%d(a) return a + %d end\n", i, i)
+		})},
+		{"elixir", rep(80, func(i int) string {
+			return fmt.Sprintf("defmodule M%d do\n  def f(x), do: x + %d\nend\n", i, i)
+		})},
+	}
+}
+
+// parseFingerprint is the observable output of one Parse, reduced to something
+// comparable. The root S-expression is included deliberately: it is the exact
+// artefact issue #481 reported as varying between runs, so comparing it (not
+// merely the node count) is what makes this a real nondeterminism gate.
+type parseFingerprint struct {
+	nodeCount  int
+	errorRatio float64
+	sexp       string
+	errText    string
+}
+
+func fingerprint(t *testing.T, f *treesitter.ParserFactory, src []byte, lang string) parseFingerprint {
+	t.Helper()
+	res, err := f.Parse(context.Background(), src, lang)
+	fp := parseFingerprint{}
+	if err != nil {
+		fp.errText = err.Error()
+	}
+	if res != nil {
+		fp.nodeCount = res.NodeCount
+		fp.errorRatio = res.ErrorRatio
+		if res.TSTree != nil {
+			if root := res.TSTree.RootNode(); root != nil {
+				fp.sexp = root.String()
+			}
+			res.TSTree.Close()
+		}
+	}
+	return fp
+}
+
+// TestParse_ConcurrentMultiLanguage_NoRace is the #5954 safety gate for the
+// removal of the global parseMu.
+//
+// It exercises exactly the path parseMu used to serialise —
+// ParserFactory.Parse -> parseOfficial -> ts.Parser.Parse (ts_parser_parse) —
+// from many goroutines at once, across every grammar shape in the bundle
+// (external-scanner grammars and scanner-less ones), and asserts that each
+// concurrent parse produces a result byte-identical to the serial baseline
+// for the same input.
+//
+// Run under -race this covers the Go side (the factory's abiGuardOnce
+// sync.Map, the indexstate parse gate, the binding's go-pointer payload
+// registry). The C side cannot be instrumented by the Go race detector, so
+// the C-level argument is structural and is documented on the ParserFactory
+// godoc: a private TSParser per call, an immutable shared TSLanguage, and no
+// mutable file-scope state in any bundled external scanner. This test is the
+// empirical half — a shared-grammar race of the #481 kind would surface here
+// as a fingerprint mismatch (garbled tree) or a crash.
+func TestParse_ConcurrentMultiLanguage_NoRace(t *testing.T) {
+	corpus := concurrencyCorpus()
+	f := treesitter.NewParserFactory(nil)
+
+	// Serial baseline first: one parse per language, no concurrency.
+	baseline := make([]parseFingerprint, len(corpus))
+	for i, c := range corpus {
+		baseline[i] = fingerprint(t, f, c.src, c.lang)
+		// Every corpus entry must yield a real, non-trivial tree — otherwise
+		// the concurrent half below would be comparing empty fingerprints and
+		// silently proving nothing.
+		if baseline[i].errText != "" {
+			t.Fatalf("baseline parse of %s failed: %s", c.lang, baseline[i].errText)
+		}
+		if baseline[i].sexp == "" || baseline[i].nodeCount < 500 {
+			t.Fatalf("baseline parse of %s produced a degenerate tree (nodes=%d, sexp_len=%d)",
+				c.lang, baseline[i].nodeCount, len(baseline[i].sexp))
+		}
+	}
+
+	// Then hammer the same inputs concurrently. 8 goroutines × 4 rounds over
+	// 23 languages = 736 concurrent parses; goroutines are released together
+	// so the overlap inside ts_parser_parse is real rather than incidental.
+	const (
+		goroutines = 8
+		rounds     = 4
+	)
+	var (
+		start = make(chan struct{})
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		fails []string
+	)
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			for r := 0; r < rounds; r++ {
+				// Stagger the start index per goroutine so different
+				// languages (hence different grammars) are in flight
+				// simultaneously, not the same one in lockstep.
+				for k := 0; k < len(corpus); k++ {
+					i := (k + g) % len(corpus)
+					got := fingerprint(t, f, corpus[i].src, corpus[i].lang)
+					if got != baseline[i] {
+						mu.Lock()
+						fails = append(fails, fmt.Sprintf(
+							"lang=%s g=%d r=%d: concurrent parse diverged from serial baseline "+
+								"(nodes %d vs %d, ratio %g vs %g, err %q vs %q, sexp_equal=%v)",
+							corpus[i].lang, g, r,
+							got.nodeCount, baseline[i].nodeCount,
+							got.errorRatio, baseline[i].errorRatio,
+							got.errText, baseline[i].errText,
+							got.sexp == baseline[i].sexp))
+						mu.Unlock()
+					}
+				}
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+
+	if len(fails) > 0 {
+		max := len(fails)
+		if max > 10 {
+			max = 10
+		}
+		t.Fatalf("%d concurrent parses diverged from the serial baseline:\n%s",
+			len(fails), strings.Join(fails[:max], "\n"))
+	}
+}
+
+// TestParse_ConcurrentSameLanguage_StableTree narrows the gate to the single
+// riskiest shape: many goroutines parsing DIFFERENT sources through the SAME
+// shared ts.Language handle at the same time. That is precisely the
+// shared-grammar-state configuration ADR-0023:73 blames for #481 under the
+// (now removed) smacker binding, so it gets its own explicit assertion rather
+// than being folded into the round-robin above.
+func TestParse_ConcurrentSameLanguage_StableTree(t *testing.T) {
+	f := treesitter.NewParserFactory(nil)
+
+	const variants = 24
+	srcs := make([][]byte, variants)
+	for i := range srcs {
+		var b strings.Builder
+		b.WriteString("package p\n")
+		for j := 0; j < 40; j++ {
+			fmt.Fprintf(&b, "func F%d_%d(a int) int { m := map[string]int{\"k%d\": %d}; return m[\"k%d\"] + a }\n", i, j, j, j, j)
+		}
+		srcs[i] = []byte(b.String())
+	}
+
+	want := make([]parseFingerprint, variants)
+	for i := range srcs {
+		want[i] = fingerprint(t, f, srcs[i], "go")
+	}
+
+	var (
+		start = make(chan struct{})
+		wg    sync.WaitGroup
+		mu    sync.Mutex
+		bad   int
+	)
+	for g := 0; g < variants; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			<-start
+			for r := 0; r < 6; r++ {
+				i := (g + r) % variants
+				if fingerprint(t, f, srcs[i], "go") != want[i] {
+					mu.Lock()
+					bad++
+					mu.Unlock()
+				}
+			}
+		}(g)
+	}
+	close(start)
+	wg.Wait()
+
+	if bad > 0 {
+		t.Fatalf("%d of %d concurrent same-language parses produced a tree differing from the serial baseline "+
+			"(this is the #481 symptom — do NOT re-land parseMu without recording it against ADR-0023)",
+			bad, variants*6)
+	}
+}

--- a/internal/treesitter/parse_gate_bound_5954_test.go
+++ b/internal/treesitter/parse_gate_bound_5954_test.go
@@ -1,0 +1,94 @@
+package treesitter_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/treesitter"
+)
+
+// TestParse_IsBoundedByParseGate proves that the #5630 parse gate is a real
+// ceiling on ParserFactory.Parse — i.e. that removing parseMu (#5954) did not
+// leave concurrent ts_parser_parse unbounded.
+//
+// WHY A DEDICATED TEST. The gate's own semantics are pinned in
+// internal/indexstate (TestParseGateCap), and TestParse_RegistersBusyCounter
+// pins that Parse touches the accounting. Neither proves the property that
+// actually matters here: that the semaphore is held ACROSS the cgo parse, so a
+// held slot genuinely blocks a parse from starting. That is the whole safety
+// argument for the removal — GOMAXPROCS cannot bound cgo (a goroutine inside a
+// cgo call parks in _Gsyscall and yields its P), so if Parse were not gated,
+// nothing would cap concurrent C parsing on the non-daemon index path.
+//
+// The assertion is a blocking one, not a timing-of-work one, so it is not
+// flaky: with cap=1 and the only slot held by the test, Parse must not
+// complete; once released, it must.
+func TestParse_IsBoundedByParseGate(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+
+	indexstate.SetParseConcurrency(1)
+	if got := indexstate.ParseConcurrencyCap(); got != 1 {
+		t.Fatalf("cap = %d, want 1", got)
+	}
+
+	// Hold the single slot.
+	indexstate.AcquireParseSlot()
+
+	f := treesitter.NewParserFactory(nil)
+	done := make(chan struct{})
+	go func() {
+		res, err := f.Parse(context.Background(), []byte("package p\nfunc F() int { return 1 }\n"), "go")
+		if err == nil && res != nil && res.TSTree != nil {
+			res.TSTree.Close()
+		}
+		close(done)
+	}()
+
+	select {
+	case <-done:
+		indexstate.ReleaseParseSlot()
+		t.Fatal("Parse completed while the only parse slot was held — the gate does " +
+			"NOT bound ts_parser_parse, so concurrent C parsing is uncapped (#5954)")
+	case <-time.After(200 * time.Millisecond):
+		// Expected: blocked in AcquireParseSlot, before the cgo parse.
+	}
+
+	indexstate.ReleaseParseSlot()
+	select {
+	case <-done:
+		// Expected: the freed slot let the parse run.
+	case <-time.After(15 * time.Second):
+		t.Fatal("Parse did not proceed after the slot was released")
+	}
+}
+
+// TestParse_UnboundedGateStillParses guards the other direction: with no cap
+// installed (a bare library caller / most tests) Parse must not block. The gate
+// is a ceiling, never a dependency.
+func TestParse_UnboundedGateStillParses(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetParseConcurrency(0) })
+	indexstate.SetParseConcurrency(0)
+
+	f := treesitter.NewParserFactory(nil)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 8; i++ {
+			res, err := f.Parse(context.Background(), []byte("package p\nfunc F() int { return 1 }\n"), "go")
+			if err != nil {
+				t.Errorf("parse %d failed: %v", i, err)
+				return
+			}
+			if res != nil && res.TSTree != nil {
+				res.TSTree.Close()
+			}
+		}
+	}()
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("parses hung with an unbounded gate")
+	}
+}

--- a/internal/treesitter/parse_watchdog_5473_test.go
+++ b/internal/treesitter/parse_watchdog_5473_test.go
@@ -30,9 +30,12 @@ func bigGoSource(terms int) []byte {
 // TestParse_WatchdogHaltsRunawayAndReleasesLock proves the #5473 safety net:
 //  1. a parse that exceeds the per-parse deadline returns a BOUNDED, sentinel
 //     error (official.ErrParseDeadlineExceeded) instead of hanging, and
-//  2. parseMu is released afterwards — a subsequent normal parse succeeds
-//     (a leaked lock would deadlock here, which the timed wait surfaces as a
-//     clear failure rather than a hang).
+//  2. the daemon-wide parse slot (indexstate) is released afterwards — a
+//     subsequent normal parse succeeds (a leaked slot would deadlock here,
+//     which the timed wait surfaces as a clear failure rather than a hang).
+//
+// The historical global parseMu is gone (#5954); the release invariant this
+// test guards now applies to the parse slot alone.
 func TestParse_WatchdogHaltsRunawayAndReleasesLock(t *testing.T) {
 	// Arm the watchdog tightly. 1ms is comfortably above tree-sitter's deadline
 	// granularity (the binding's own timeout tests use 1000µs) yet far below the
@@ -70,8 +73,8 @@ func TestParse_WatchdogHaltsRunawayAndReleasesLock(t *testing.T) {
 		t.Fatalf("watchdog halt must yield no ParseResult, got: %+v", got.res)
 	}
 
-	// Lock-release invariant: with a normal budget restored, a subsequent parse
-	// must succeed. If parseMu had leaked, this would block forever.
+	// Slot-release invariant: with a normal budget restored, a subsequent parse
+	// must succeed. If the parse slot had leaked, this would block forever.
 	t.Setenv("GRAFEL_PARSE_TIMEOUT", "20s")
 	next := make(chan result, 1)
 	go func() {
@@ -81,7 +84,7 @@ func TestParse_WatchdogHaltsRunawayAndReleasesLock(t *testing.T) {
 	select {
 	case got = <-next:
 	case <-time.After(15 * time.Second):
-		t.Fatal("subsequent parse hung — parseMu was not released after the watchdog halt")
+		t.Fatal("subsequent parse hung — the parse slot was not released after the watchdog halt")
 	}
 	if got.err != nil {
 		t.Fatalf("subsequent normal parse failed: %v", got.err)

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -97,18 +97,50 @@ type ParseResult struct {
 
 // ParserFactory creates tree-sitter parsers for supported languages.
 //
-// Issue #481 — empirically, concurrent Parse() calls produced
-// non-deterministic output. Until that is re-validated against the official
-// binding (ADR 0023 §5) we serialise the parse + node-walk via parseMu;
-// correctness wins over the per-file parallelism we lose, and the impact on
-// real-world repos dominated by I/O+extractor work is marginal.
+// Concurrency. Parse is safe for concurrent use from any number of goroutines
+// (#5954, closing the ADR-0023 §5 open follow-up). The historical global
+// `parseMu` that serialised every process-wide parse is gone; it was a
+// workaround for issue #481, whose root cause ADR-0023:73 identifies as a
+// shared-grammar-state race in the *smacker* binding — a binding that has
+// since been removed entirely (see the package godoc). Under the official
+// binding the safety argument is:
+//
+//   - Every parse builds and owns its OWN *tsofficial.Parser
+//     (parseOfficial -> adapter.NewParser -> ts_parser_new, Close'd on
+//     return). tree-sitter's C contract is "one TSParser per thread", which
+//     this satisfies by construction — no parser instance is ever shared.
+//   - The only object shared across goroutines is the per-language
+//     ts.Language handle in migratedLanguages (adapters.go). A TSLanguage is
+//     an immutable, statically-allocated const struct; ts_parser_set_language
+//     stores it via ts_language_copy, which for a non-wasm language is a
+//     no-op returning the same pointer (upstream src/language.c). Nothing
+//     ever writes through it, and tree-sitter documents TSLanguage as safe to
+//     share read-only across parsers.
+//   - No bundled grammar's external scanner keeps mutable file-scope state;
+//     scanner state is allocated per parser by its create() hook. (The
+//     TSLanguage ref-count path in ts_language_copy is wasm-only and
+//     unreachable: TREE_SITTER_FEATURE_WASM is not in any cgo CFLAGS line.)
+//   - Corroborating evidence that this was always safe: unserialised
+//     concurrent parsing has been shipping regardless. parseMu only ever
+//     covered ParserFactory.Parse, while internal/extractors/yaml/helm.go
+//     (unconditionally, for every Helm template) and every extractor's
+//     `if file.TSTree == nil { NewParser… }` fallback construct their own
+//     parser and call Parse OUTSIDE the mutex, from the same worker pool. The
+//     mutex was cargo, not a constraint.
+//
+// CONCURRENCY IS NOT UNBOUNDED. See parseOfficial: the #5630 parse gate
+// (indexstate.AcquireParseSlot) is the real ceiling on simultaneous
+// ts_parser_parse calls, and it must be, because GOMAXPROCS does not bound cgo.
+//
+// Determinism is NOT provided by serialisation and never was: parseMu wrapped
+// only ts_parser_parse, while the node walk, the extractors, and the
+// append-to-shared-slice all ran outside it. The actual #481 fix is the
+// canonical sort applied to the worker-pool output before anything downstream
+// consumes it (sortClassifiedFiles / sortEntityRecords in
+// cmd/grafel/index.go), which is unaffected by this change.
 type ParserFactory struct {
 	tracer trace.Tracer
 }
-
-// parseMu serialises tree-sitter parse calls across goroutines. See the
-// ParserFactory godoc for the rationale.
-var parseMu sync.Mutex
 
 // NewParserFactory constructs a ParserFactory.
 // If tracer is nil, the global OTel tracer provider is used.
@@ -191,24 +223,52 @@ func (f *ParserFactory) parseOfficial(span trace.Span, source []byte, language s
 
 	// Parser construction/teardown operate on a per-call, independent parser
 	// instance (fresh ts_parser_new + SetLanguage; Close frees only that
-	// parser, and the produced tree outlives it). Issue #481's
-	// non-determinism is specific to the parse itself, so we keep those out of
-	// the critical section and serialise ONLY the parse below.
+	// parser, and the produced tree outlives it). This per-call ownership is
+	// what makes the parse below safe to run concurrently — see the
+	// ParserFactory godoc for the full thread-safety argument (#5954).
 	p, err := adapter.NewParser(lang)
 	if err != nil {
 		return nil, fmt.Errorf("treesitter: parser init failed for language %s: %w", language, err)
 	}
 	defer p.Close()
 
-	// Issue #481 — serialise the parse across goroutines (see ParserFactory
-	// godoc for the rationale). The per-parse watchdog in official.Parse
-	// (GRAFEL_PARSE_TIMEOUT) bounds how long this critical section can be held:
-	// a runaway parse is halted at the deadline and returns an error instead of
-	// hanging, so a single pathological file can no longer pin parseMu — and
-	// thus ALL in-process parsing — indefinitely (was: ~26-min freeze, #5473).
-	parseMu.Lock()
+	// #5954 — parses run concurrently; the process-wide parseMu is gone.
+	//
+	// WHAT BOUNDS THIS. Exactly one thing: the AcquireParseSlot gate above
+	// (#5630). It is a counting semaphore taken on the Go side and held ACROSS
+	// this cgo call, so at most ParseConcurrencyCap() goroutines are inside
+	// ts_parser_parse at any instant.
+	//
+	// GOMAXPROCS DOES NOT BOUND THIS, and it is a mistake to reason as if it
+	// did: a goroutine in a cgo call parks in _Gsyscall and the runtime hands
+	// its P to another goroutine, so N concurrent cgo calls occupy N OS threads
+	// whatever GOMAXPROCS says. grafel's extract CPU budget is implemented
+	// purely as GOMAXPROCS=<n> in a child's env, so it caps Go-side parallelism
+	// and nothing else. The gate is therefore load-bearing, not belt-and-braces
+	// — it is what makes GRAFEL_EXTRACT_GOMAXPROCS mean anything for C parsing.
+	//
+	// The cap is installed by the daemon at startup and, for the non-daemon
+	// index path, by ensureParseConcurrencyDefault in cmd/grafel/index.go,
+	// which sets the background indexing core budget: 25% of machine capacity,
+	// max(1, NumCPU/4). Foreground/interactive rebuilds are deliberately
+	// exempt — they are user-initiated and awaited. When no cap is installed
+	// (a bare library caller, most tests) parsing is unbounded here and the
+	// caller owns the ceiling.
+	//
+	// Coverage: the gate is NOT only this factory. Every extractor-level parse
+	// that constructs its own ts.Parser and so bypasses the factory —
+	// internal/extractors/yaml/helm.go and the seven `file.TSTree == nil`
+	// inline fallbacks — takes the same slot around its Parse call (#5954).
+	// That matters because those paths bypassed parseMu too, which is why they
+	// are also the proof that unserialised concurrent parsing already shipped.
+	// The one remaining ungated parse is abiGuard's per-language probe: it runs
+	// once per language per process, on a few dozen bytes, before this gate is
+	// acquired, so it is bounded by construction.
+	//
+	// The per-parse watchdog in official.Parse (GRAFEL_PARSE_TIMEOUT) still
+	// bounds a runaway parse (#5473) — it now costs one slot instead of
+	// freezing ALL in-process parsing.
 	tree, err := p.Parse(source)
-	parseMu.Unlock()
 	if err != nil {
 		span.RecordError(err)
 		return nil, fmt.Errorf("treesitter: parse failed for language %s: %w", language, err)

--- a/internal/treesitter/ts/official/official.go
+++ b/internal/treesitter/ts/official/official.go
@@ -110,10 +110,12 @@ type Parser struct {
 // pin the daemon indefinitely (#5473).
 //
 // Why this matters. A runtime build was observed sitting ~26 min in one runaway
-// C parse (ts_parser_parse / ts_node_child hot). Because the factory holds a
-// process-wide parse mutex (issue #481) AND a parse slot across this call, that
-// one hung parse froze ALL in-process parsing and the daemon went silent. The
-// bare p.Parse(source, nil) is unbounded.
+// C parse (ts_parser_parse / ts_node_child hot). At the time the factory held a
+// process-wide parse mutex (issue #481) AND a parse slot across this call, so
+// that one hung parse froze ALL in-process parsing and the daemon went silent.
+// The global mutex is gone (#5954) — a runaway parse now only pins its own
+// worker's parse slot — but the bare p.Parse(source, nil) is still unbounded,
+// so the watchdog remains the thing that converts a freeze into an error.
 //
 // Mechanism (v0.24-native). go-tree-sitter v0.24 exposes the C wall-clock
 // deadline ts_parser_set_timeout_micros: tree-sitter checks the elapsed budget
@@ -121,7 +123,7 @@ type Parser struct {
 // returns a nil tree. That is exactly the cancellation path the v0.25 progress
 // callback would provide, without the goroutine/cancellation-flag plumbing. On
 // a halt we return ErrParseDeadlineExceeded so the factory converts the freeze
-// into a bounded, logged per-file failure and releases parseMu + the slot. A
+// into a bounded, logged per-file failure and releases the parse slot. A
 // genuine empty parse (no halt) still maps to (nil, nil). The parser is
 // single-use here (the factory closes it after this call), so no Reset of the
 // halted state is needed.


### PR DESCRIPTION
## What

Three related changes to AST extraction:

1. **Remove `parseMu`**, the global mutex that serialized every tree-sitter parse process-wide, making extraction effectively single-threaded (`extracting_ast` is 34.5% of a 233 s cold index).
2. **Bound parse concurrency at 25% of machine capacity** — `max(1, runtime.NumCPU()/4)` — installed inside `Index()` and interactive-exempt.
3. **Split the `resolving_refs` phase into 12 sub-phase labels**, so the 52% of wall time hidden behind one composite label becomes attributable.

## Why the mutex was safe to remove

`ADR-0023:73` attributed it to a shared-grammar race in the **smacker** binding, which has since been removed entirely; `ADR-0023:280` still listed re-testing without it as an open follow-up. The safety argument, independently replicated in review:

- **Per-call parser.** `parseOfficial` calls `adapter.NewParser(lang)` per invocation (`ts_parser_new()`, with `defer p.Close()`). No parser is ever shared, satisfying tree-sitter's one-`TSParser`-per-thread contract by construction.
- **The shared `TSLanguage` is immutable.** `ts_language_copy` is a no-op returning the same pointer for non-wasm languages, and no wasm path is reachable — `TREE_SITTER_FEATURE_WASM` is absent from every cgo CFLAGS line, so all 31 grammars are statically-linked C.
- **No mutable statics in any scanner.** Audited all 264 `.c/.cc/.h` across every linked grammar module: zero non-`const` file-scope statics outside generated read-only character-set tables.
- **It was already cargo.** `yaml/helm.go` and seven `if file.TSTree == nil` extractor fallbacks parse *outside* `ParserFactory`, so unserialized concurrent `ts_parser_parse` has been shipping all along.
- **Determinism was never the mutex's job.** `parseMu` wrapped only `p.Parse`; `sortClassifiedFiles`/`sortEntityRecords` at the pass-1 fan-in are what order the output, and they are untouched.

## The bound — and why `GOMAXPROCS` isn't it

`GOMAXPROCS` **cannot** bound cgo: a goroutine inside a cgo call parks in `_Gsyscall` and yields its P, so N concurrent parses occupy N OS threads regardless. The `AcquireParseSlot` semaphore is held across the cgo call and is therefore the only real bound.

Previously the gate was installed only by `cmd/grafel/daemon.go`, leaving `grafel index` and the `index-internal` subprocess with `parseGateCap == 0` — unbounded. `ensureParseConcurrencyDefault` now installs the 25% cap in `Index()` (after the option loop, so `interactive` is populated), never overriding an existing cap, and installing nothing when interactive.

**The 8 sites that bypassed `ParserFactory` are now gated too** — `yaml/helm.go` (an unconditional second parse of every Helm template, not a fallback) plus the seven inline fallbacks in python, golang, dockerfile, html, hcl, cpp, yaml. Their comments claimed they were "for direct test callers", which was wrong: `classifyAndReadWithProgress` calls `extractors.Extract` unconditionally even when parsing failed, so they fire in production on exactly the pathological files that most need capping. `abiGuard` is deliberately excluded (once per language, runs before the gate).

Each gated region is a closure scoped to the parse alone:
```go
func() {
    indexstate.AcquireParseSlot()
    defer indexstate.ReleaseParseSlot()
    tree, err = parser.Parse(content)
}()
```
Two load-bearing properties, documented in-code: the release happens **before** the node walk (a function-scoped defer would throttle *extractions* rather than parses — a severe regression at budget 3), and the `defer` makes it panic-safe (a bare acquire/release pair leaks the slot and the busy counter permanently, and `daemon.go:1446` recovers index panics, so that would be a permanent 33% loss at cap 3).

## Instrumentation

`Tracker.SubPhase(label)` stores the phase without publishing an Event, so SSE/CLI/wizard streams stay byte-identical and only memtrace's `phase=` tag gains the split. It **enforces** the parent-phase prefix contract (a label whose parent phase is inactive is dropped, not stamped). Per-pass wall times print to stderr only when `GRAFEL_MEMTRACE_DIR` is set — stdout carries the JSON progress channel and is untouched.

First measurement (this repo, `GOMAXPROCS=3`): `pass25_framework_rules` 27.7 s and `pass3_cross_lang` 19.2 s of a 46.9 s window, with every global pass under 100 ms — i.e. **~99.6% of `resolving_refs` is per-file work**, which is the number needed to size per-file reuse (#5964).

## Verification

Byte-identical output on a 130-file/13-language fixture with `SOURCE_DATE_EPOCH` pinned: **0 bytes differing** in both `graph.fb` and `graph.json`, base vs new, in both background (capped) and interactive (uncapped) modes.

Concurrency tests: 23 languages × 8 goroutines × 4 rounds = 736 concurrent parses compared against serial baselines on node count, error ratio and root S-expression (an S-expr comparison catches a garbled-tree race, which `-race` structurally cannot for cgo). Gate liveness pinned by holding the only slot at cap=1 and asserting non-completion, then completion after release.

`go build ./...`, `go vet`, `gofmt -l internal cmd` clean. `./internal/treesitter/...` 122 pass `-race`; `./internal/extractors/...` 3966 pass `-race`; `./cmd/grafel/...` 293 pass incl. goldens; `./internal/progress/... ./internal/indexstate/...` 57 pass `-race`.

Independently adversarially reviewed twice — the first pass blocked on the concurrency bound being absent off the daemon, the second verified no deadlock (the Helm nested-document case is sequential, not nested), no hold-across-walk, and no double-release.

## Honest note on determinism

A **full-repo** index is not byte-reproducible run-to-run even with `SOURCE_DATE_EPOCH` pinned and the same binary (~8/597,869 relationships). This predates the change — base-vs-base runs diverge by the same magnitude — and the exculpation rests on the structural argument above, not on the sample size (3 base + 2 new runs cannot distinguish "same variance" from "2× variance"). Tracked separately in #5969, along with the finding that 13.8% of relationships carry an `id` that does not match `sha256(from,to,kind)`.

Closes #5960
Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
