### PR TITLE
fix(#5974): incremental reindex must emit id-sorted entities (LookupEntityByID was missing present entities)

### DIFF
--- a/cmd/grafel/determinism.go
+++ b/cmd/grafel/determinism.go
@@ -73,57 +73,12 @@ func sortRelationshipRecords(rs []types.RelationshipRecord) {
 }
 
 // sortDocumentForEmission is the final, post-everything sort applied
-// immediately before graph.WriteAtomic. Even with every fan-in already
-// sorted, intermediate passes that mutate slices in place (external
-// synthesis appends, Pass 4 reads via maps) deserve a defensive belt-and-
-// braces sort. Sorting on the canonical graph IDs keeps diffs minimal.
+// immediately before graph.WriteAtomic. The implementation lives in
+// internal/graph (#5974) so the incremental-reindex producer in
+// internal/extractors shares one canonical order with the full-index
+// producer here instead of carrying a copy that can drift.
 func sortDocumentForEmission(doc *graph.Document) {
-	sort.SliceStable(doc.Entities, func(i, j int) bool {
-		return doc.Entities[i].ID < doc.Entities[j].ID
-	})
-	sort.SliceStable(doc.Relationships, func(i, j int) bool {
-		a, b := &doc.Relationships[i], &doc.Relationships[j]
-		if a.FromID != b.FromID {
-			return a.FromID < b.FromID
-		}
-		if a.ToID != b.ToID {
-			return a.ToID < b.ToID
-		}
-		if a.Kind != b.Kind {
-			return a.Kind < b.Kind
-		}
-		return a.ID < b.ID
-	})
-	// Pass 4 outputs — order by community ID (already deterministic from the
-	// algorithms layer) then size as a tiebreaker, then top-entity name to
-	// stabilise ties across re-runs.
-	sort.SliceStable(doc.Communities, func(i, j int) bool {
-		a, b := &doc.Communities[i], &doc.Communities[j]
-		if a.Size != b.Size {
-			return a.Size > b.Size
-		}
-		if a.ID != b.ID {
-			return a.ID < b.ID
-		}
-		ai, bi := "", ""
-		if len(a.TopEntities) > 0 {
-			ai = a.TopEntities[0]
-		}
-		if len(b.TopEntities) > 0 {
-			bi = b.TopEntities[0]
-		}
-		return ai < bi
-	})
-	sort.SliceStable(doc.SurpriseEdges, func(i, j int) bool {
-		a, b := &doc.SurpriseEdges[i], &doc.SurpriseEdges[j]
-		if a.Score != b.Score {
-			return a.Score > b.Score
-		}
-		if a.FromID != b.FromID {
-			return a.FromID < b.FromID
-		}
-		return a.ToID < b.ToID
-	})
+	graph.SortDocumentForEmission(doc)
 }
 
 // deterministicGeneratedAt returns the timestamp to stamp into Document.

--- a/internal/extractors/emission_order_test.go
+++ b/internal/extractors/emission_order_test.go
@@ -1,0 +1,149 @@
+// Package extractors — emission_order_test.go
+//
+// Regression tests for issue #5974: the incremental reindex path emitted
+// entities in a non-ID order, while fbreader.Reader.LookupEntityByID is a bare
+// FlatBuffers `(key)` binary search with no linear fallback. Any graph written
+// by the incremental producer therefore lost lookups for entities that were
+// demonstrably present in the vector.
+//
+// These live in-package (not extractors_test) so they can drive the producer's
+// own sortGraphDocumentForEmission directly.
+package extractors
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// emissionFixture builds a document whose natural (SourceFile, Kind, Name)
+// order is the exact reverse of its ID order. Under the pre-#5974 comparator
+// the emitted entity vector came out ID-descending, which is precisely what
+// EntitiesByKey's binary search cannot cope with.
+func emissionFixture(n int) *graph.Document {
+	doc := &graph.Document{Repo: "fixture"}
+	for i := 0; i < n; i++ {
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:            fmt.Sprintf("ent-%03d", i),
+			Name:          fmt.Sprintf("Sym%03d", i),
+			QualifiedName: fmt.Sprintf("pkg.Sym%03d", i),
+			Kind:          "function",
+			SourceFile:    fmt.Sprintf("src/f%03d.go", n-i),
+			StartLine:     n - i,
+		})
+	}
+	for i := 0; i+1 < n; i++ {
+		from, to := doc.Entities[i].ID, doc.Entities[i+1].ID
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(from, to, "CALLS"),
+			FromID: from,
+			ToID:   to,
+			Kind:   "CALLS",
+		})
+	}
+	return doc
+}
+
+// writeFlatAndOpen runs the incremental producer's emission sort, writes the
+// document through the flat gen writer (the flag-OFF default path) and opens
+// the result with the real reader.
+func writeFlatAndOpen(t *testing.T, doc *graph.Document) *fbreader.Reader {
+	t.Helper()
+	sortGraphDocumentForEmission(doc)
+	stateDir := t.TempDir()
+	genPath, err := fbwriter.WriteGraphGen(stateDir, doc)
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	if fi, err := os.Stat(genPath); err != nil || fi.IsDir() {
+		t.Fatalf("expected a flat gen file at %s (err=%v)", genPath, err)
+	}
+	r, err := fbreader.Open(genPath)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	t.Cleanup(func() { _ = r.Close() })
+	return r
+}
+
+// TestIncrementalEmission_EveryEntityIsLookupable is the test that would have
+// caught #5974: every entity reachable via IterateEntities must also be
+// reachable via LookupEntityByID.
+func TestIncrementalEmission_EveryEntityIsLookupable(t *testing.T) {
+	doc := emissionFixture(64)
+	want := len(doc.Entities)
+	r := writeFlatAndOpen(t, doc)
+
+	var seen int
+	var missing []string
+	r.IterateEntities(func(e *fb.Entity) bool {
+		seen++
+		id := string(e.Id())
+		if r.LookupEntityByID(id) == nil {
+			missing = append(missing, id)
+		}
+		return true
+	})
+	if seen != want {
+		t.Fatalf("IterateEntities visited %d entities, want %d", seen, want)
+	}
+	if len(missing) > 0 {
+		t.Fatalf("LookupEntityByID missed %d/%d entities present in the vector (first few: %v)",
+			len(missing), seen, missing[:min(5, len(missing))])
+	}
+}
+
+// TestIncrementalEmission_EntityVectorIsIDSorted asserts the on-disk invariant
+// the binary search depends on, directly.
+func TestIncrementalEmission_EntityVectorIsIDSorted(t *testing.T) {
+	doc := emissionFixture(64)
+	r := writeFlatAndOpen(t, doc)
+
+	prev := ""
+	first := true
+	r.IterateEntities(func(e *fb.Entity) bool {
+		id := string(e.Id())
+		if !first && id < prev {
+			t.Errorf("entity vector not ID-sorted: %q follows %q", id, prev)
+		}
+		prev, first = id, false
+		return true
+	})
+}
+
+// TestIncrementalEmission_ComparatorSortsEntitiesByID pins the comparator
+// itself, independent of the writer. The gen writers also canonicalise
+// defensively, so without this assertion a regression in the producer's own
+// sort would be masked at the reader level.
+func TestIncrementalEmission_ComparatorSortsEntitiesByID(t *testing.T) {
+	doc := emissionFixture(64)
+	sortGraphDocumentForEmission(doc)
+	for i := 1; i < len(doc.Entities); i++ {
+		if doc.Entities[i-1].ID > doc.Entities[i].ID {
+			t.Fatalf("entities not ID-sorted at %d: %q then %q",
+				i, doc.Entities[i-1].ID, doc.Entities[i].ID)
+		}
+	}
+}
+
+// TestIncrementalEmission_RelationshipsCanonicallyOrdered pins the
+// relationship order to (FromID, ToID, Kind, ID) — the same tuple the
+// full-index path uses.
+func TestIncrementalEmission_RelationshipsCanonicallyOrdered(t *testing.T) {
+	doc := emissionFixture(32)
+	sortGraphDocumentForEmission(doc)
+	for i := 1; i < len(doc.Relationships); i++ {
+		a, b := doc.Relationships[i-1], doc.Relationships[i]
+		if a.FromID > b.FromID ||
+			(a.FromID == b.FromID && a.ToID > b.ToID) ||
+			(a.FromID == b.FromID && a.ToID == b.ToID && a.Kind > b.Kind) ||
+			(a.FromID == b.FromID && a.ToID == b.ToID && a.Kind == b.Kind && a.ID > b.ID) {
+			t.Fatalf("relationships out of canonical order at %d: %+v then %+v", i, a, b)
+		}
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -949,39 +949,16 @@ func relRecordToGraphRel(r types.RelationshipRecord) graph.Relationship {
 	}.WithProperties(r.Properties)
 }
 
-// sortGraphDocumentForEmission sorts entities and relationships in the same
-// canonical order used by cmd/grafel/index.go (sortDocumentForEmission).
-// Kept here to avoid a cmd → internal import cycle.
+// sortGraphDocumentForEmission sorts entities and relationships into the
+// canonical emission order. #5974: this used to be a local copy that ordered
+// entities by (SourceFile, Kind, QualifiedName, Name, StartLine, ID) — NOT the
+// ID order the full-index path uses and the FlatBuffers `(key)` binary search
+// in fbreader requires, so LookupEntityByID silently missed entities in every
+// incrementally written graph. It now delegates to the one shared
+// implementation in internal/graph; there is no cmd → internal cycle because
+// both producers depend on internal/graph already.
 func sortGraphDocumentForEmission(doc *graph.Document) {
-	sort.SliceStable(doc.Entities, func(a, b int) bool {
-		ra, rb := &doc.Entities[a], &doc.Entities[b]
-		if ra.SourceFile != rb.SourceFile {
-			return ra.SourceFile < rb.SourceFile
-		}
-		if ra.Kind != rb.Kind {
-			return ra.Kind < rb.Kind
-		}
-		if ra.QualifiedName != rb.QualifiedName {
-			return ra.QualifiedName < rb.QualifiedName
-		}
-		if ra.Name != rb.Name {
-			return ra.Name < rb.Name
-		}
-		if ra.StartLine != rb.StartLine {
-			return ra.StartLine < rb.StartLine
-		}
-		return ra.ID < rb.ID
-	})
-	sort.SliceStable(doc.Relationships, func(a, b int) bool {
-		ra, rb := &doc.Relationships[a], &doc.Relationships[b]
-		if ra.FromID != rb.FromID {
-			return ra.FromID < rb.FromID
-		}
-		if ra.ToID != rb.ToID {
-			return ra.ToID < rb.ToID
-		}
-		return ra.Kind < rb.Kind
-	})
+	graph.SortDocumentForEmission(doc)
 }
 
 // entityPropKey returns a stable string key for an entity used in the

--- a/internal/graph/emission_order.go
+++ b/internal/graph/emission_order.go
@@ -1,0 +1,79 @@
+package graph
+
+import "sort"
+
+// Issue #5974 — canonical emission order, shared by every producer.
+//
+// The full-index path (cmd/grafel) and the incremental-reindex path
+// (internal/extractors) each used to carry their own copy of this sort. They
+// drifted: the incremental copy ordered entities by
+// (SourceFile, Kind, QualifiedName, Name, StartLine, ID) instead of by ID.
+// That matters because the emitted FlatBuffers entity vector is searched with
+// the generated `(key)` binary search (fbreader.Reader.LookupEntityByID), which
+// has no linear fallback — a vector that is not sorted by ID makes lookups
+// silently miss entities that are demonstrably present. One implementation,
+// here, so the two paths cannot drift again.
+
+// SortDocumentForEmission sorts doc in place into the canonical order every
+// on-disk graph must be written in: entities by byte-wise ID (the FlatBuffers
+// `(key)` order the reader binary-searches), relationships by
+// (FromID, ToID, Kind, ID), and the Pass-4 outputs by their own stable keys.
+//
+// It is the final, post-everything sort applied immediately before the graph
+// is serialized. Even with every fan-in already sorted, intermediate passes
+// that mutate slices in place (external synthesis appends, Pass 4 reads via
+// maps) deserve a defensive belt-and-braces sort. Sorting on the canonical
+// graph IDs keeps diffs minimal and is idempotent, so callers may run it more
+// than once.
+func SortDocumentForEmission(doc *Document) {
+	if doc == nil {
+		return
+	}
+	// Entity IDs are unique, so ID alone is a total order — no secondary keys.
+	sort.SliceStable(doc.Entities, func(i, j int) bool {
+		return doc.Entities[i].ID < doc.Entities[j].ID
+	})
+	sort.SliceStable(doc.Relationships, func(i, j int) bool {
+		a, b := &doc.Relationships[i], &doc.Relationships[j]
+		if a.FromID != b.FromID {
+			return a.FromID < b.FromID
+		}
+		if a.ToID != b.ToID {
+			return a.ToID < b.ToID
+		}
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		return a.ID < b.ID
+	})
+	// Pass 4 outputs — order by community ID (already deterministic from the
+	// algorithms layer) then size as a tiebreaker, then top-entity name to
+	// stabilise ties across re-runs.
+	sort.SliceStable(doc.Communities, func(i, j int) bool {
+		a, b := &doc.Communities[i], &doc.Communities[j]
+		if a.Size != b.Size {
+			return a.Size > b.Size
+		}
+		if a.ID != b.ID {
+			return a.ID < b.ID
+		}
+		ai, bi := "", ""
+		if len(a.TopEntities) > 0 {
+			ai = a.TopEntities[0]
+		}
+		if len(b.TopEntities) > 0 {
+			bi = b.TopEntities[0]
+		}
+		return ai < bi
+	})
+	sort.SliceStable(doc.SurpriseEdges, func(i, j int) bool {
+		a, b := &doc.SurpriseEdges[i], &doc.SurpriseEdges[j]
+		if a.Score != b.Score {
+			return a.Score > b.Score
+		}
+		if a.FromID != b.FromID {
+			return a.FromID < b.FromID
+		}
+		return a.ToID < b.ToID
+	})
+}

--- a/internal/graph/fbwriter/emission_parity_test.go
+++ b/internal/graph/fbwriter/emission_parity_test.go
@@ -1,0 +1,86 @@
+package fbwriter
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// parityDoc returns a document deliberately NOT in canonical emission order:
+// entities are ID-descending. Before #5974 the segmented writer re-sorted and
+// the flat writer did not, so the two producers emitted different bytes for
+// the same input — and the flat file's entity vector violated the
+// sorted-by-key invariant EntitiesByKey binary-searches on.
+func parityDoc(n int) *graph.Document {
+	// A fixed GeneratedAt is required for a byte-wise comparison: a zero
+	// timestamp makes the writer stamp time.Now(), which differs between the
+	// two writes whenever they straddle a second boundary.
+	doc := &graph.Document{
+		Repo:        "parity",
+		GeneratedAt: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	for i := n - 1; i >= 0; i-- {
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         fmt.Sprintf("ent-%03d", i),
+			Name:       fmt.Sprintf("Sym%03d", i),
+			Kind:       "function",
+			SourceFile: fmt.Sprintf("src/f%03d.go", i),
+		})
+	}
+	for i := 0; i+1 < n; i++ {
+		from := fmt.Sprintf("ent-%03d", i+1)
+		to := fmt.Sprintf("ent-%03d", i)
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(from, to, "CALLS"),
+			FromID: from,
+			ToID:   to,
+			Kind:   "CALLS",
+		})
+	}
+	return doc
+}
+
+// TestFlatAndSegmentedWritersAgree asserts the flat gen writer and the
+// segmented writer's single-file fast path emit byte-identical output for the
+// same (unsorted) document (#5974).
+func TestFlatAndSegmentedWritersAgree(t *testing.T) {
+	flatPath, err := WriteGraphGen(t.TempDir(), parityDoc(48))
+	if err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	segPath, err := WriteGraphGenSegmented(t.TempDir(), parityDoc(48))
+	if err != nil {
+		t.Fatalf("WriteGraphGenSegmented: %v", err)
+	}
+	flatBytes, err := os.ReadFile(flatPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	segBytes, err := os.ReadFile(segPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(flatBytes, segBytes) {
+		t.Fatalf("flat and segmented writers disagree: %d vs %d bytes", len(flatBytes), len(segBytes))
+	}
+}
+
+// TestWriteGraphGenCanonicalisesEntityOrder asserts the flat producer leaves
+// the document in the ID order the reader's binary search requires, even when
+// the caller hands it an unsorted slice.
+func TestWriteGraphGenCanonicalisesEntityOrder(t *testing.T) {
+	doc := parityDoc(48)
+	if _, err := WriteGraphGen(t.TempDir(), doc); err != nil {
+		t.Fatalf("WriteGraphGen: %v", err)
+	}
+	for i := 1; i < len(doc.Entities); i++ {
+		if doc.Entities[i-1].ID > doc.Entities[i].ID {
+			t.Fatalf("entities not ID-sorted at %d: %q then %q",
+				i, doc.Entities[i-1].ID, doc.Entities[i].ID)
+		}
+	}
+}

--- a/internal/graph/fbwriter/segmented.go
+++ b/internal/graph/fbwriter/segmented.go
@@ -59,7 +59,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strconv"
 
 	flatbuffers "github.com/google/flatbuffers/go"
@@ -144,19 +143,7 @@ func WriteGraphGenSegmented(stateDir string, doc *graph.Document) (string, error
 // this is idempotent; it is repeated here to make the per-segment key-bounds
 // invariant hold regardless of the caller.
 func sortDocForSegments(doc *graph.Document) {
-	sort.SliceStable(doc.Entities, func(i, j int) bool {
-		return doc.Entities[i].ID < doc.Entities[j].ID
-	})
-	sort.SliceStable(doc.Relationships, func(i, j int) bool {
-		a, b := &doc.Relationships[i], &doc.Relationships[j]
-		if a.FromID != b.FromID {
-			return a.FromID < b.FromID
-		}
-		if a.ToID != b.ToID {
-			return a.ToID < b.ToID
-		}
-		return a.Kind < b.Kind
-	})
+	graph.SortDocumentForEmission(doc)
 }
 
 // graphFitsSingleBuilder reports whether the entire graph serializes to fewer

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -89,7 +89,12 @@ func WriteGraphGen(stateDir string, doc *graph.Document) (genPath string, err er
 // doc into one buffer (fail-softing an oversized-graph panic into an error) and
 // write it as a new graph.<gen>.fb generation. It is the flag-OFF path and the
 // SegmentedWriter's single-file fast path, so both share byte-identical output.
+//
+// #5974 — the canonical sort runs here as well as in WriteGraphGenSegmented so
+// the two writers cannot emit different orders for the same document. It is
+// idempotent: producers already sort before calling.
 func writeGraphGenFlat(stateDir string, doc *graph.Document) (genPath string, err error) {
+	graph.SortDocumentForEmission(doc)
 	buf, err := Marshal(doc)
 	if err != nil {
 		return "", fmt.Errorf("fbwriter: marshal: %w", err)


### PR DESCRIPTION
## What

The incremental reindex path emitted entities in a **different order** than the full index path, while the reader looks entities up with a **binary search that assumes ID order and has no fallback**. After an incremental reindex, `LookupEntityByID` could silently fail to find entities that are present in the graph.

- full index (`sortDocumentForEmission`) sorted entities by **`ID`**
- incremental (`sortGraphDocumentForEmission`) sorted by `(SourceFile, Kind, QualifiedName, Name, StartLine, ID)`

`Reader.LookupEntityByID` is a bare FlatBuffers `EntitiesByKey` binary search — no linear fallback — and `StreamingWriter.finalize` preserves caller order rather than re-sorting. Incremental is **on by default**, so this was the common case after any file edit, not an edge case. A doc comment claimed the two sorts matched; they didn't.

## Empirical proof

64 entities with IDs ascending and `SourceFile` descending, written through the real flat producer and opened with the real reader: **63 of 64** were returned by `IterateEntities` but `nil` from `LookupEntityByID`; the emitted vector was ID-descending. Post-fix: every entity is lookupable and the on-disk vector is genuinely ID-sorted.

## The fix

- One shared `graph.SortDocumentForEmission` (`internal/graph/emission_order.go`); `cmd/grafel/determinism.go` and `internal/extractors/incremental.go` both delegate. Entity secondary keys deleted (IDs are unique → unreachable). The cited "cmd → internal import cycle" never existed — the duplicate was already in `internal`.
- Relationship comparators unified to `(FromID, ToID, Kind, ID)` (the full path already had the `ID` tiebreaker; incremental did not).
- `writeGraphGenFlat` now sorts its input itself, so the flat and segmented writers cannot diverge regardless of caller. Verified there are only two live `WriteGraphGen` callers and both already sorted immediately before writing, so this is idempotent for every real caller — full-path goldens are byte-identical.

## Safety / performance

- **Writer-side sort is safe for all callers**: the two live callers already sorted; no caller hands the writer a deliberately-different order. ~35 ms on a 115k-entity/600k-rel already-sorted document, against a write phase that is ~11.8% of index wall time — negligible.
- **The `ID` tiebreaker is safe** even given #5969 (13.8% of relationships have `id != sha256(from,to,kind)`): it simply matches the canonical full-path order, which has always used it. Relationships are never binary-searched by triple, so this is purely an ordering-consistency change.
- **Locality**: ID order scatters a file's entities, but the full-index path has *always* emitted ID order, so first-index and full rebuilds already do this — the change only aligns incremental to existing behaviour, which correctness requires.

## Tests

`internal/extractors/emission_order_test.go` — every-entity lookup after incremental (drives the real path, not a reimplementation); id-sortedness of the emitted vector; comparator-level order. `internal/graph/fbwriter/emission_parity_test.go` — flat vs segmented byte-identical output for an ID-descending document. All confirmed to fail against the pre-fix comparator. Existing `incremental_test.go` semantic comparison left untouched.

`go build ./...`, `go vet`, `gofmt -l internal cmd` clean. `./internal/graph/...` 341 pass, `./internal/extractors/...` 3970 pass, `./cmd/grafel/...` 337 pass (goldens unchanged). Parity test `-count=20` no flake.

Independently adversarially reviewed (RED reproduced at 63/64, writer-caller safety and the #5969 interaction both independently verified).

## Follow-up (not in this PR)

A third copy of this ordering exists at `internal/cli/export.go:127` (`sortDocumentForExport`) — it feeds byte-stable HTML/SVG/JSON export, not the reader's binary search, so it's correctness-safe to leave, but it still carries the old relationship comparator without the `ID` tiebreaker and is now the one remaining copy that can drift.

Closes #5974
Refs #5954, #5969

🤖 Generated with [Claude Code](https://claude.com/claude-code)
