### PR TITLE
perf(#5954): merge nameKinds + nameKindsReal into one map[string]nameKindEntry

### DIFF
--- a/internal/resolve/django_fk.go
+++ b/internal/resolve/django_fk.go
@@ -57,11 +57,11 @@ func (idx Index) lookupUniqueModelByName(name string) (string, bool) {
 	if name == "" {
 		return "", false
 	}
-	realBucket := idx.nameKindsReal[name]
+	realBucket := idx.nameKinds[name].real
 	if realBucket.len() == 0 {
 		return "", false
 	}
-	// nameKindsReal[name][kind] = "" sentinel means ambiguous (>=2
+	// nameKinds[name].real[kind] = "" sentinel means ambiguous (>=2
 	// entities share that name+kind pair); a non-empty value is the
 	// unique entity ID for that pair.
 	id, ok := realBucket.get(string(types.EntityKindModel))

--- a/internal/resolve/kindids_equiv_test.go
+++ b/internal/resolve/kindids_equiv_test.go
@@ -104,12 +104,30 @@ func oracleLocKind(ents []types.EntityRecord, realOnly bool) map[string]map[stri
 	return m
 }
 
-// liveNameKinds materialises a kindIDs map back into a plain map for comparison.
-func liveNameKinds(m map[string]kindIDs) map[string]map[string]string {
+// liveNameKindsBase materialises the .base field of the merged nameKinds map
+// back into a plain map for comparison.
+func liveNameKindsBase(m map[string]nameKindEntry) map[string]map[string]string {
 	out := map[string]map[string]string{}
-	for name, kid := range m {
+	for name, ent := range m {
 		b := map[string]string{}
-		kid.each(func(k, id string) { b[k] = id })
+		ent.base.each(func(k, id string) { b[k] = id })
+		out[name] = b
+	}
+	return out
+}
+
+// liveNameKindsReal materialises the .real field of the merged nameKinds map.
+// The oracle only records a name once an entity with a non-empty Kind carries
+// it, so names whose .real bucket is empty are omitted here — matching the
+// pre-merge nameKindsReal key set exactly.
+func liveNameKindsReal(m map[string]nameKindEntry) map[string]map[string]string {
+	out := map[string]map[string]string{}
+	for name, ent := range m {
+		if ent.real.len() == 0 {
+			continue
+		}
+		b := map[string]string{}
+		ent.real.each(func(k, id string) { b[k] = id })
 		out[name] = b
 	}
 	return out
@@ -158,11 +176,11 @@ func TestKindIDs_IndexMapParity(t *testing.T) {
 	ents := equivFixture()
 	idx := BuildIndex(ents)
 
-	if got, want := liveNameKinds(idx.nameKinds), oracleNameKinds(ents); !reflect.DeepEqual(got, want) {
-		t.Fatalf("nameKinds diverges from oracle:\n live=%v\noracle=%v", got, want)
+	if got, want := liveNameKindsBase(idx.nameKinds), oracleNameKinds(ents); !reflect.DeepEqual(got, want) {
+		t.Fatalf("nameKinds.base diverges from oracle:\n live=%v\noracle=%v", got, want)
 	}
-	if got, want := liveNameKinds(idx.nameKindsReal), oracleNameKindsReal(ents); !reflect.DeepEqual(got, want) {
-		t.Fatalf("nameKindsReal diverges from oracle:\n live=%v\noracle=%v", got, want)
+	if got, want := liveNameKindsReal(idx.nameKinds), oracleNameKindsReal(ents); !reflect.DeepEqual(got, want) {
+		t.Fatalf("nameKinds.real diverges from oracle:\n live=%v\noracle=%v", got, want)
 	}
 	if got, want := liveLocKind(idx.byLocationKind), oracleLocKind(ents, false); !reflect.DeepEqual(got, want) {
 		t.Fatalf("byLocationKind diverges from oracle:\n live=%v\noracle=%v", got, want)
@@ -245,8 +263,8 @@ func TestKindIDs_CollisionSentinelPreserved(t *testing.T) {
 		ent("bbbbbbbbbbbbbbbb", "Function", "Dup"),
 	}
 	idx := BuildIndex(ents)
-	// nameKinds[Dup][Function] must be present-but-blank.
-	id, present := idx.nameKinds["Dup"].get("Function")
+	// nameKinds[Dup].base[Function] must be present-but-blank.
+	id, present := idx.nameKinds["Dup"].base.get("Function")
 	if !present {
 		t.Fatalf("collision entry absent; want present blank sentinel")
 	}

--- a/internal/resolve/namekinds_merge_equiv_test.go
+++ b/internal/resolve/namekinds_merge_equiv_test.go
@@ -1,0 +1,461 @@
+// Package resolve — behaviour-neutrality battery for the nameKinds outer-map
+// merge (#5954, BuildIndex outer-map compaction increment 1).
+//
+// The merge folded the two formerly-parallel name-keyed tables
+//
+//	nameKinds     map[string]kindIDs   (all kinds, SCOPE.* dual-indexed)
+//	nameKindsReal map[string]kindIDs   (original kind only)
+//
+// into ONE map[string]nameKindEntry{base, real}. This file proves the swap is
+// behaviourally invisible by rebuilding the PRE-MERGE tables with an
+// independent replay of the old writers and asserting:
+//
+//  1. storage equivalence — for EVERY probed name (present or absent),
+//     idx.nameKinds[name].base ≡ legacy nameKinds[name] and
+//     idx.nameKinds[name].real ≡ legacy nameKindsReal[name], including the
+//     comma-ok presence bit. Since every read site touches the merged map only
+//     through .base / .real, identical values here mean identical inputs to
+//     every consumer by construction.
+//  2. entry-point equivalence — the live resolver entry points are compared
+//     against reference implementations driven by the legacy two-map tables.
+//  3. the #525 independent-blanking invariant — a real Component and a
+//     SCOPE.Component sharing a name blank .base but leave .real intact, so the
+//     real id stays recoverable. Asserted directly on the merged value.
+//
+// Both index construction paths (flat BuildIndex and the M5
+// BuildIndexFromModulesOrdered mirror) are checked against the same legacy
+// tables.
+package resolve
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---- legacy (pre-merge) writer replay ---------------------------------------
+
+// legacyNameKindTables replays the exact pre-merge write rules from BuildIndex:
+// nameKinds is written unconditionally under every (original + SCOPE-trimmed)
+// kind; nameKindsReal is written only when e.Kind != "" and only under the
+// original kind. Two separate maps, blanked independently by kindIDs.set.
+func legacyNameKindTables(ents []types.EntityRecord) (base, real map[string]kindIDs) {
+	base = map[string]kindIDs{}
+	real = map[string]kindIDs{}
+	for _, e := range ents {
+		b := base[e.Name]
+		for _, k := range kindsOf(e) {
+			if k == "" {
+				continue
+			}
+			b.set(k, e.ID)
+		}
+		base[e.Name] = b
+
+		if e.Kind != "" {
+			r := real[e.Name]
+			r.set(e.Kind, e.ID)
+			real[e.Name] = r
+		}
+	}
+	return base, real
+}
+
+// ---- reference implementations over the legacy two-map layout ----------------
+
+// refLookupByKindHint is a verbatim copy of the pre-merge lookupByKindHint body
+// driven by the two legacy tables.
+func refLookupByKindHint(base, real map[string]kindIDs, name, relKind string) (string, bool) {
+	families := hintKinds(relKind)
+	if len(families) == 0 {
+		return "", false
+	}
+	if realBucket := real[name]; realBucket.len() > 0 {
+		if id, ok := uniqueMatchInFamily(realBucket, families, false); ok {
+			return id, true
+		}
+	}
+	bucket := base[name]
+	if bucket.len() == 0 {
+		return "", false
+	}
+	return uniqueMatchInFamily(bucket, families, true)
+}
+
+// refLookupUniqueModelByName mirrors the pre-merge django_fk.go probe.
+func refLookupUniqueModelByName(real map[string]kindIDs, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	realBucket := real[name]
+	if realBucket.len() == 0 {
+		return "", false
+	}
+	id, ok := realBucket.get(string(types.EntityKindModel))
+	if !ok || id == "" {
+		return "", false
+	}
+	return id, true
+}
+
+// refRealComponentTier1 mirrors the pre-merge tier-1 of
+// lookupUniqueRealComponentByName (the only part that reads nameKindsReal).
+func refRealComponentTier1(real map[string]kindIDs, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	if realBucket := real[name]; realBucket.len() > 0 {
+		return uniqueMatchInFamily(realBucket, componentKindFamily, false)
+	}
+	return "", false
+}
+
+// liveRealComponentTier1 is the same tier-1 read against the merged value.
+func liveRealComponentTier1(idx Index, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	if realBucket := idx.nameKinds[name].real; realBucket.len() > 0 {
+		return uniqueMatchInFamily(realBucket, componentKindFamily, false)
+	}
+	return "", false
+}
+
+// ---- fixture ----------------------------------------------------------------
+
+// mergeEquivFixture = equivFixture() (multi-language representative set + the
+// #525 Widget collision) PLUS adversarial shapes that stress the merge:
+// kind-less entities (base key written, real key NOT), pure SCOPE.* entities,
+// same-name/different-kind, same-(name,kind) collisions in both tiers, and a
+// name whose base bucket is blanked while real survives.
+func mergeEquivFixture() []types.EntityRecord {
+	ents := equivFixture()
+	ents = append(ents,
+		// Kind-less entity: writes the base key only, never the real key.
+		entAt("0000000000000a01", "", "KindlessThing", "app/kindless.py"),
+		// Pure SCOPE.* placeholder with no real twin: base gets both
+		// "SCOPE.Operation" and "Operation"; real gets "SCOPE.Operation".
+		entAt("0000000000000a02", "SCOPE.Operation", "OnlyPlaceholder", "app/p.py"),
+		// #525 shape again for an Operation family: real Function + a
+		// SCOPE.Operation sharing the name. base["Operation"] stays clean but
+		// the pair exercises the cross-tier preference.
+		entAt("0000000000000a03", "Function", "HandlerX", "app/h.py"),
+		entAt("0000000000000a04", "SCOPE.Operation", "HandlerX", "app/h2.py"),
+		// Same (name, kind) twice => blank sentinel in BOTH base and real.
+		entAt("0000000000000a05", "Class", "DoubleBooked", "a/one.java"),
+		entAt("0000000000000a06", "Class", "DoubleBooked", "a/two.java"),
+		// Same name under two different real kinds => no blanking in either.
+		entAt("0000000000000a07", "Model", "Mixed", "a/m.py"),
+		entAt("0000000000000a08", "View", "Mixed", "a/v.py"),
+		// SCOPE.Component whose TRIMMED kind collides with a real Component
+		// under a THIRD name — base["Component"] blanks, real keeps both.
+		entAt("0000000000000a09", "Component", "Trimmed", "a/c1.ts"),
+		entAt("0000000000000a10", "SCOPE.Component", "Trimmed", "a/c2.ts"),
+	)
+	return ents
+}
+
+// probeNames returns every name in the fixture plus names guaranteed absent, so
+// the comma-ok presence bit is exercised on both sides.
+func probeNames(ents []types.EntityRecord) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range ents {
+		if !seen[e.Name] {
+			seen[e.Name] = true
+			out = append(out, e.Name)
+		}
+	}
+	return append(out, "", "AbsentName", "Widget.NotAKey", "SCOPE.Component")
+}
+
+// allHintKinds covers every relKind branch of hintKinds plus an unhinted one.
+var allHintKinds = []string{
+	"EXTENDS", "IMPLEMENTS", "CALLS", "PUBLISHES_TO",
+	"INJECTED_INTO", "BINDS", "GRAPH_RELATES", "REGISTERS",
+	"HANDLES_SIGNAL", "FEDERATES", "DEPENDS_ON_SERVICE", "TRIGGERS",
+	"ENQUEUES", "HANDLES_COMMAND", "GATED_BY", "DATA_FLOWS_TO", "THROWS",
+	"CATCHES", "INSTRUMENTS", "CACHES", "INVALIDATES", "JOINS_CHANNEL",
+	"BROADCASTS_TO", "RESOLVED_BY", "VALIDATES", "FETCHES",
+	"GRPC_IMPLEMENTS", "GRPC_HANDLES", "HANDLES", "DISCRIMINATES_ON",
+	"BRANCHES_ON", "RENDERS", "USES_TRANSLATION", "REFERENCES", "",
+}
+
+// ---- 1. storage equivalence -------------------------------------------------
+
+func assertMergedMatchesLegacy(t *testing.T, label string, idx Index, ents []types.EntityRecord) {
+	t.Helper()
+	base, real := legacyNameKindTables(ents)
+
+	// Key set: the merged map must carry exactly the legacy base key set
+	// (legacy real keys are a strict subset — real is only written on
+	// iterations that also write base).
+	if len(idx.nameKinds) != len(base) {
+		t.Fatalf("%s: merged nameKinds has %d keys, legacy base has %d", label, len(idx.nameKinds), len(base))
+	}
+	for name := range real {
+		if _, ok := base[name]; !ok {
+			t.Fatalf("%s: legacy real key %q absent from legacy base — merge precondition violated", label, name)
+		}
+	}
+
+	for _, name := range probeNames(ents) {
+		ent, gotOK := idx.nameKinds[name]
+		wantBase, wantOK := base[name]
+		if gotOK != wantOK {
+			t.Fatalf("%s: presence bit for %q = %v, legacy nameKinds = %v", label, name, gotOK, wantOK)
+		}
+		if !reflect.DeepEqual(ent.base, wantBase) {
+			t.Fatalf("%s: nameKinds[%q].base = %+v, legacy = %+v", label, name, ent.base, wantBase)
+		}
+		// Absent from legacy real => zero value, which is exactly what the
+		// old `idx.nameKindsReal[name]` read returned.
+		wantReal := real[name]
+		if !reflect.DeepEqual(ent.real, wantReal) {
+			t.Fatalf("%s: nameKinds[%q].real = %+v, legacy = %+v", label, name, ent.real, wantReal)
+		}
+	}
+}
+
+func TestNameKindsMerge_StorageEquivalence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"representative", representativeFixture()},
+		{"equiv", equivFixture()},
+		{"mergeEquiv", mergeEquivFixture()},
+	} {
+		t.Run(tc.name+"/flat", func(t *testing.T) {
+			assertMergedMatchesLegacy(t, "BuildIndex", BuildIndex(tc.ents), tc.ents)
+		})
+		t.Run(tc.name+"/modules", func(t *testing.T) {
+			// M5 mirror (insertModuleEntry) must agree with the same legacy
+			// tables, not merely with BuildIndex.
+			idx := BuildIndexFromModulesOrdered(tc.ents, ModuleKeyByPkgDir)
+			assertMergedMatchesLegacy(t, "BuildIndexFromModulesOrdered", idx, tc.ents)
+		})
+	}
+}
+
+// ---- 2. entry-point equivalence ---------------------------------------------
+
+func TestNameKindsMerge_EntryPointEquivalence(t *testing.T) {
+	ents := mergeEquivFixture()
+	idx := BuildIndex(ents)
+	base, real := legacyNameKindTables(ents)
+
+	for _, name := range probeNames(ents) {
+		for _, rk := range allHintKinds {
+			gotID, gotOK := idx.lookupByKindHint(name, rk)
+			wantID, wantOK := refLookupByKindHint(base, real, name, rk)
+			if gotID != wantID || gotOK != wantOK {
+				t.Fatalf("lookupByKindHint(%q,%q) = (%q,%v), legacy = (%q,%v)",
+					name, rk, gotID, gotOK, wantID, wantOK)
+			}
+		}
+
+		gotID, gotOK := idx.lookupUniqueModelByName(name)
+		wantID, wantOK := refLookupUniqueModelByName(real, name)
+		if gotID != wantID || gotOK != wantOK {
+			t.Fatalf("lookupUniqueModelByName(%q) = (%q,%v), legacy = (%q,%v)",
+				name, gotID, gotOK, wantID, wantOK)
+		}
+
+		gotID, gotOK = liveRealComponentTier1(idx, name)
+		wantID, wantOK = refRealComponentTier1(real, name)
+		if gotID != wantID || gotOK != wantOK {
+			t.Fatalf("lookupUniqueRealComponentByName tier-1(%q) = (%q,%v), legacy = (%q,%v)",
+				name, gotID, gotOK, wantID, wantOK)
+		}
+
+		// nameExists reads the merged presence bit + .base length; the other
+		// two tiers (byName / ambigName) are untouched by this change.
+		wantExists := false
+		if _, ok := idx.byName[name]; ok {
+			wantExists = true
+		} else if idx.ambigName[name] {
+			wantExists = true
+		} else if b, ok := base[name]; ok && b.len() > 0 {
+			wantExists = true
+		}
+		if got := idx.nameExists(name); got != wantExists {
+			t.Fatalf("nameExists(%q) = %v, legacy = %v", name, got, wantExists)
+		}
+
+		// DiagnoseBugResolver's KindsPresent is drawn from the base bucket.
+		diag := idx.DiagnoseBugResolver(name+":"+name, "EXTENDS")
+		wantKinds := map[string]bool{}
+		if b, ok := base[name]; ok {
+			b.each(func(k, _ string) { wantKinds[k] = true })
+		}
+		gotKinds := map[string]bool{}
+		for _, k := range diag.KindsPresent {
+			gotKinds[k] = true
+		}
+		if len(wantKinds) > 0 && !reflect.DeepEqual(gotKinds, wantKinds) {
+			t.Fatalf("DiagnoseBugResolver(%q).KindsPresent = %v, legacy = %v", name, gotKinds, wantKinds)
+		}
+	}
+}
+
+// ---- 3. the #525 independent-blanking invariant -----------------------------
+
+// TestNameKindsMerge_IndependentBlanking525 proves the load-bearing invariant of
+// the merge: .base and .real inside ONE map value are blanked independently, so
+// a SCOPE.* placeholder colliding with a real entity destroys the id in .base
+// but NOT in .real. If the two ever shared state (or .real were derived from
+// .base by filtering SCOPE.*), the real id would be unrecoverable and the
+// EXTENDS bind would fall through to the placeholder.
+func TestNameKindsMerge_IndependentBlanking525(t *testing.T) {
+	const realID, scopeID = "00000000000005a1", "00000000000005a2"
+	idx := BuildIndex(equivFixture())
+	ent := idx.nameKinds["Widget"]
+
+	// .base: "Component" is dual-indexed by BOTH the real Component (5a1) and
+	// the SCOPE.Component's trimmed kind (5a2) => present-but-BLANK.
+	if id, present := ent.base.get("Component"); !present || id != "" {
+		t.Fatalf("base[Component] = (%q,%v), want blank sentinel present — the real id must be UNRECOVERABLE from base", id, present)
+	}
+	// The real id is therefore only obtainable from .real.
+	if id, present := ent.real.get("Component"); !present || id != realID {
+		t.Fatalf("real[Component] = (%q,%v), want (%s,true) — independent blanking broken", id, present, realID)
+	}
+	// The placeholder keeps its own untrimmed slot in .real; it must not have
+	// blanked the real entity's slot.
+	if id, present := ent.real.get("SCOPE.Component"); !present || id != scopeID {
+		t.Fatalf("real[SCOPE.Component] = (%q,%v), want (%s,true)", id, present, scopeID)
+	}
+	// End-to-end: the tier-1 real pass must bind to the real component.
+	if id, ok := idx.lookupByKindHint("Widget", "EXTENDS"); !ok || id != realID {
+		t.Fatalf("lookupByKindHint(Widget,EXTENDS) = (%q,%v), want (%s,true)", id, ok, realID)
+	}
+
+	// Mirror check on the merged Trimmed pair from mergeEquivFixture: same
+	// shape, different names, and the M5 path must agree.
+	for label, built := range map[string]Index{
+		"flat":    BuildIndex(mergeEquivFixture()),
+		"modules": BuildIndexFromModulesOrdered(mergeEquivFixture(), ModuleKeyByPkgDir),
+	} {
+		e := built.nameKinds["Trimmed"]
+		if id, present := e.base.get("Component"); !present || id != "" {
+			t.Fatalf("%s: Trimmed base[Component] = (%q,%v), want blank sentinel", label, id, present)
+		}
+		if id, present := e.real.get("Component"); !present || id != "0000000000000a09" {
+			t.Fatalf("%s: Trimmed real[Component] = (%q,%v), want (a09,true)", label, id, present)
+		}
+		if id, ok := built.lookupByKindHint("Trimmed", "EXTENDS"); !ok || id != "0000000000000a09" {
+			t.Fatalf("%s: lookupByKindHint(Trimmed,EXTENDS) = (%q,%v), want (a09,true)", label, id, ok)
+		}
+	}
+}
+
+// TestNameKindsMerge_CollisionSentinelBothFields asserts present-but-blank
+// ("",true) stays distinguishable from absent ("",false) in BOTH fields of the
+// merged value — the sentinel semantics every consumer depends on.
+func TestNameKindsMerge_CollisionSentinelBothFields(t *testing.T) {
+	idx := BuildIndex(mergeEquivFixture())
+	ent := idx.nameKinds["DoubleBooked"]
+
+	for field, b := range map[string]kindIDs{"base": ent.base, "real": ent.real} {
+		id, present := b.get("Class")
+		if !present {
+			t.Fatalf("%s[Class] absent; want present blank sentinel", field)
+		}
+		if id != "" {
+			t.Fatalf("%s[Class] = %q, want blank sentinel", field, id)
+		}
+		if id, present := b.get("NoSuchKind"); present || id != "" {
+			t.Fatalf("%s[NoSuchKind] = (%q,%v), want (\"\",false)", field, id, present)
+		}
+	}
+
+	// A kind-less entity writes the base key but leaves .real empty — the
+	// exact shape that made keys(real) a strict subset of keys(base).
+	kl, ok := idx.nameKinds["KindlessThing"]
+	if !ok {
+		t.Fatalf("kind-less entity did not create a nameKinds key")
+	}
+	if kl.base.len() != 0 || kl.real.len() != 0 {
+		t.Fatalf("KindlessThing entry = %+v, want both buckets empty", kl)
+	}
+}
+
+// ---- 4. read-path benchmark -------------------------------------------------
+
+// benchFixture builds a corpus-shaped entity set: n distinct names, a mix of
+// real and SCOPE.* kinds, plus collisions, so the benchmark exercises a map of
+// realistic cardinality rather than the tiny correctness fixture.
+func benchFixture(n int) []types.EntityRecord {
+	kinds := []string{"Component", "Class", "Function", "Method", "Model",
+		"View", "Operation", "SCOPE.Component", "SCOPE.Operation"}
+	ents := make([]types.EntityRecord, 0, n)
+	for i := 0; i < n; i++ {
+		name := "Sym" + strconv.Itoa(i%(n*3/4+1))
+		id := fmt.Sprintf("%016x", i+1)
+		ents = append(ents, entAt(id, kinds[i%len(kinds)], name,
+			"pkg"+strconv.Itoa(i%512)+"/f"+strconv.Itoa(i%64)+".go"))
+	}
+	return ents
+}
+
+func benchNames(ents []types.EntityRecord) []string {
+	out := make([]string, 0, 4096)
+	seen := map[string]bool{}
+	for _, e := range ents {
+		if !seen[e.Name] {
+			seen[e.Name] = true
+			out = append(out, e.Name)
+		}
+		if len(out) == 4096 {
+			break
+		}
+	}
+	return out
+}
+
+// BenchmarkLookupByKindHint_Merged measures the hot tier-1/tier-2 read path over
+// the merged map (map[k]struct copy-on-read is the one cost the merge adds).
+func BenchmarkLookupByKindHint_Merged(b *testing.B) {
+	ents := benchFixture(200000)
+	idx := BuildIndex(ents)
+	names := benchNames(ents)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		n := names[i%len(names)]
+		if _, ok := idx.lookupByKindHint(n, "EXTENDS"); ok {
+			sink++
+		}
+		if _, ok := idx.lookupByKindHint(n, "CALLS"); ok {
+			sink++
+		}
+	}
+	_ = sink
+}
+
+// BenchmarkLookupByKindHint_LegacyTwoMap is the SAME read path against the
+// pre-merge two-map layout, so the merge's read cost can be compared directly
+// in one binary.
+func BenchmarkLookupByKindHint_LegacyTwoMap(b *testing.B) {
+	ents := benchFixture(200000)
+	base, real := legacyNameKindTables(ents)
+	names := benchNames(ents)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		n := names[i%len(names)]
+		if _, ok := refLookupByKindHint(base, real, n, "EXTENDS"); ok {
+			sink++
+		}
+		if _, ok := refLookupByKindHint(base, real, n, "CALLS"); ok {
+			sink++
+		}
+	}
+	_ = sink
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -395,21 +395,11 @@ type Index struct {
 	// ambigName[name] = true when a name appears in two or more entities.
 	ambigName map[string]bool
 
-	// nameKinds[name][kind] = entity_id for every entity sharing this
-	// name. A blank string sentinel means two entities share that
-	// (name, kind) tuple — i.e. the kind itself is ambiguous for this
-	// name and the kind hint cannot disambiguate via this family.
-	nameKinds map[string]kindIDs
-
-	// nameKindsReal[name][kind] = entity_id, indexed under the entity's
-	// ORIGINAL kind only (no SCOPE.* dual-indexing). Used by
-	// lookupByKindHint's tier-1 pass to prefer real entities over
-	// SCOPE.* placeholders when EXTENDS / IMPLEMENTS / CALLS edges
-	// resolve a bare name that lives under both tiers (#525). Blank
-	// string sentinel marks (name, kind) collisions; identical
-	// semantics to nameKinds but without the cross-tier ambiguity that
-	// dual-indexing introduces.
-	nameKindsReal map[string]kindIDs
+	// nameKinds[name] carries BOTH name-keyed kind buckets in one entry
+	// (#5954 outer-map compaction): .base is the all-kinds bucket
+	// (including SCOPE.* dual-indexing) and .real is the original-kind-only
+	// bucket. See nameKindEntry for the semantics of each field.
+	nameKinds map[string]nameKindEntry
 
 	// byLocation[file_path][name] = entity_id, retained only when unique
 	// within the file. Used by structural-ref Format A resolution.
@@ -553,8 +543,31 @@ type LocationKindIndex map[string]map[string]kindIDs
 // kindID is one (kind, entity_id) pair inside a kindIDs.
 type kindID struct{ kind, id string }
 
+// nameKindEntry merges the two formerly-parallel name-keyed tables
+// (nameKinds + nameKindsReal) into a single map value (#5954). Both tables
+// were written over the IDENTICAL e.Name key set in the same loop iteration,
+// so storing them as two fields of one value removes ~427k duplicate name-key
+// headers plus one whole map's bucket array.
+//
+// The two fields are INDEPENDENT state, never derivable from one another:
+//   - base: indexed under every kind form (original AND SCOPE-trimmed), i.e.
+//     the dual-indexed bucket. A (name, kind) collision DESTRUCTIVELY blanks
+//     the entry to the "" sentinel via kindIDs.set, so a real entity's id can
+//     become unrecoverable from base alone.
+//   - real: indexed ONLY under the entity's original kind (no SCOPE.*
+//     dual-indexing), so lookupByKindHint's tier-1 pass can prefer a real
+//     entity over a same-named SCOPE.* placeholder (#525). It is NOT a
+//     filtered view of base — it survives collisions base has already blanked.
+//
+// Blanking is therefore applied to each field separately, exactly as the two
+// separate maps did. Deriving real from base (e.g. "store base and filter
+// SCOPE.* at read time") is UNSAFE and would silently corrupt resolution.
+type nameKindEntry struct {
+	base, real kindIDs
+}
+
 // kindIDs is a heap-frugal replacement for map[string]string (kind -> id) in
-// the resolver Index's four dominant inner buckets (nameKinds, nameKindsReal,
+// the resolver Index's four dominant inner buckets (nameKinds .base/.real,
 // byLocationKind, byLocationKindReal). The first entry lives inline (k0/v0);
 // additional kinds spill to rest. Since these buckets carry ~1 entry each, the
 // inline path never touches the heap — that is the entire point of the type.
@@ -819,8 +832,7 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]kindIDs),
-		nameKindsReal:      make(map[string]kindIDs),
+		nameKinds:          make(map[string]nameKindEntry),
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
@@ -1002,26 +1014,25 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// blanking the entry so the hint falls through. kindIDs.set
 		// encapsulates that rule; the value is stored back since kindIDs
 		// lives inline in the map (no per-entry heap in the 1-kind case).
-		nameKindBucket := idx.nameKinds[e.Name]
+		//
+		// .real is a single pass under the entity's ORIGINAL kind only.
+		// Used by lookupByKindHint's tier-1 real-entity pass (#525) so
+		// that SCOPE.Component dual-indexing under "Component" doesn't
+		// poison the hint when a same-named real Component coexists.
+		// Blank sentinel marks collisions within the same original kind.
+		// .base and .real are blanked INDEPENDENTLY — a collision in one
+		// never touches the other (#5954 merge invariant).
+		nameKindEnt := idx.nameKinds[e.Name]
 		for _, kind := range kinds {
 			if kind == "" {
 				continue
 			}
-			nameKindBucket.set(kind, e.ID)
+			nameKindEnt.base.set(kind, e.ID)
 		}
-		idx.nameKinds[e.Name] = nameKindBucket
-
-		// nameKindsReal — single-pass under the entity's original kind
-		// only. Used by lookupByKindHint's tier-1 real-entity pass
-		// (#525) so that SCOPE.Component dual-indexing under
-		// "Component" doesn't poison the hint when a same-named real
-		// Component coexists. Blank sentinel marks collisions within
-		// the same original kind.
 		if e.Kind != "" {
-			realBucket := idx.nameKindsReal[e.Name]
-			realBucket.set(e.Kind, e.ID)
-			idx.nameKindsReal[e.Name] = realBucket
+			nameKindEnt.real.set(e.Kind, e.ID)
 		}
+		idx.nameKinds[e.Name] = nameKindEnt
 
 		// Location index — (file_path, name) -> entity_id. Same logic as
 		// byKind: ambiguous (file, name) tuples are tracked separately so
@@ -1698,17 +1709,18 @@ func (idx Index) lookupByKindHint(name, relKind string) (string, bool) {
 	if len(families) == 0 {
 		return "", false
 	}
-	// Tier 1: real entity kinds only, consulted via nameKindsReal so
-	// SCOPE.* dual-indexing in nameKinds doesn't blank a real entity's
+	// Tier 1: real entity kinds only, consulted via nameKinds[name].real so
+	// SCOPE.* dual-indexing in .base doesn't blank a real entity's
 	// kind bucket (#525). When a real Component / Class / View / Model
 	// (or Operation / Function / Method) uniquely matches, return it
 	// without consulting the SCOPE.* placeholder tier at all.
-	if realBucket := idx.nameKindsReal[name]; realBucket.len() > 0 {
-		if id, ok := uniqueMatchInFamily(realBucket, families, false); ok {
+	entry := idx.nameKinds[name]
+	if entry.real.len() > 0 {
+		if id, ok := uniqueMatchInFamily(entry.real, families, false); ok {
 			return id, true
 		}
 	}
-	bucket := idx.nameKinds[name]
+	bucket := entry.base
 	if bucket.len() == 0 {
 		return "", false
 	}
@@ -1782,7 +1794,7 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 				return qid, statusRewritten, true
 			}
 			// Tier 3: unique within the callable (Function/Method) kind family
-			if bucket := idx.nameKinds[qname]; bucket.len() > 0 {
+			if bucket := idx.nameKinds[qname].base; bucket.len() > 0 {
 				var hit string
 				for _, knd := range []string{"Function", "Method"} {
 					if id, ok := bucket.get(knd); ok && id != "" {
@@ -1898,7 +1910,7 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 				if qid, ok := idx.byName[member]; ok && qid != "" {
 					return qid, statusRewritten, true
 				}
-				if bucket := idx.nameKinds[member]; bucket.len() > 0 {
+				if bucket := idx.nameKinds[member].base; bucket.len() > 0 {
 					var hit string
 					for _, knd := range []string{"Function", "Method", "Operation", "SCOPE.Operation"} {
 						if id, ok := bucket.get(knd); ok && id != "" {
@@ -2176,7 +2188,7 @@ func (idx Index) lookupUniqueRealComponentByName(name string) (string, bool) {
 	if name == "" {
 		return "", false
 	}
-	if realBucket := idx.nameKindsReal[name]; realBucket.len() > 0 {
+	if realBucket := idx.nameKinds[name].real; realBucket.len() > 0 {
 		if id, ok := uniqueMatchInFamily(realBucket, componentKindFamily, false); ok {
 			return id, true
 		}
@@ -2898,7 +2910,10 @@ func (idx Index) nameExists(name string) bool {
 	if idx.ambigName[name] {
 		return true
 	}
-	if bucket, ok := idx.nameKinds[name]; ok && bucket.len() > 0 {
+	// The merged nameKinds key set is exactly the old base-table key set:
+	// .base is written on every entity iteration, .real only on a subset of
+	// those same iterations, so presence semantics are unchanged (#5954).
+	if entry, ok := idx.nameKinds[name]; ok && entry.base.len() > 0 {
 		return true
 	}
 	return false
@@ -2975,7 +2990,8 @@ func (idx Index) DiagnoseBugResolver(originalStub, relKind string) BugResolverDi
 	diag.Name = name
 	diag.StubKind = kind
 
-	if bucket, ok := idx.nameKinds[name]; ok {
+	if entry, ok := idx.nameKinds[name]; ok {
+		bucket := entry.base
 		kinds := make([]string, 0, bucket.len())
 		bucket.each(func(k, _ string) {
 			kinds = append(kinds, k)

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -265,8 +265,7 @@ func MergeModuleBatch(si *SymbolIndex, offset, batchSize int) (Index, int) {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string, total),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]kindIDs, total),
-		nameKindsReal:      make(map[string]kindIDs, total),
+		nameKinds:          make(map[string]nameKindEntry, total),
 		byLocation:         make(LocationIndex, total/2+1),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, total/2+1),
@@ -517,8 +516,7 @@ func accumulatorIndex(totalEntities int) Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string, totalEntities),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]kindIDs, totalEntities),
-		nameKindsReal:      make(map[string]kindIDs, totalEntities),
+		nameKinds:          make(map[string]nameKindEntry, totalEntities),
 		byLocation:         make(LocationIndex, cap2),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, cap2),
@@ -542,8 +540,7 @@ func emptyIndex() Index {
 		ambigKind:          make(map[string]map[string]bool),
 		byName:             make(map[string]string),
 		ambigName:          make(map[string]bool),
-		nameKinds:          make(map[string]kindIDs),
-		nameKindsReal:      make(map[string]kindIDs),
+		nameKinds:          make(map[string]nameKindEntry),
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
@@ -615,24 +612,21 @@ func insertModuleEntry(
 		bucket[me.name] = me.id
 	}
 
-	// nameKinds (all kinds, including SCOPE.*). Mirror of BuildIndex's
-	// writer using the compact kindIDs bucket (#5954). Stored back by value
-	// since kindIDs lives inline in the map.
-	nameKindBucket := idx.nameKinds[me.name]
+	// nameKinds — .base carries all kinds (including SCOPE.*), .real only the
+	// original kind. Mirror of BuildIndex's merged writer (#5954). Stored
+	// back by value since nameKindEntry lives inline in the map. .base and
+	// .real are blanked independently (the #525 invariant).
+	nameKindEnt := idx.nameKinds[me.name]
 	for _, kind := range kinds {
 		if kind == "" {
 			continue
 		}
-		nameKindBucket.set(kind, me.id)
+		nameKindEnt.base.set(kind, me.id)
 	}
-	idx.nameKinds[me.name] = nameKindBucket
-
-	// nameKindsReal — original kind only.
 	if me.kind != "" {
-		realBucket := idx.nameKindsReal[me.name]
-		realBucket.set(me.kind, me.id)
-		idx.nameKindsReal[me.name] = realBucket
+		nameKindEnt.real.set(me.kind, me.id)
 	}
+	idx.nameKinds[me.name] = nameKindEnt
 
 	// Location indexes.
 	sf := me.sourceFile

--- a/internal/resolve/symbol_index_parity_test.go
+++ b/internal/resolve/symbol_index_parity_test.go
@@ -129,7 +129,6 @@ func indexParityDiff(a, b Index) []string {
 	cmp("byName", a.byName, b.byName)
 	cmp("ambigName", a.ambigName, b.ambigName)
 	cmp("nameKinds", a.nameKinds, b.nameKinds)
-	cmp("nameKindsReal", a.nameKindsReal, b.nameKindsReal)
 	cmp("byLocation", a.byLocation, b.byLocation)
 	cmp("ambigLocation", a.ambigLocation, b.ambigLocation)
 	cmp("byLocationKind", a.byLocationKind, b.byLocationKind)


### PR DESCRIPTION
## What

`internal/resolve` kept two parallel maps written over the **identical name-key set in the same loop iteration**:

```go
nameKinds     map[string]kindIDs   // 45.9 MB at the index peak
nameKindsReal map[string]kindIDs   // 41.6 MB
```

Each stored the same ~427k name keys and their bucket headers twice. They are merged into one map with a struct value:

```go
type nameKindEntry struct{ base, real kindIDs }
nameKinds map[string]nameKindEntry
```

so `merged[name].base ≡ old nameKinds[name]` and `merged[name].real ≡ old nameKindsReal[name]`, consulted independently at every read site. Pure storage-layout change — no semantic change.

## Why

`resolve.BuildIndex` is the **#1 allocator at the measured index peak** — 368 MB of a 1459 MB live heap, during `materializing`, so it contributes directly to peak RSS. This removes one whole map header + bucket array and ~427k duplicate string-key headers. Estimated ~35–40 MB; the corpus measurement is separate.

This is increment 1 of 2 — `byLocationKind`/`byLocationKindReal` (the larger pair) is deliberately untouched and follows next.

## The hard constraint: #525 independent blanking

`real` is **not** a filtered view of `base`. On a name collision `base` destructively blanks the collided kind to `""`, making the real entity's id unrecoverable from it; `real` preserves it. The merge is safe only because both remain separate `kindIDs` fields, each blanked independently exactly as before. Deriving one from the other would silently corrupt resolution — the type carries a doc comment saying so.

## How equivalence is proven

`namekinds_merge_equiv_test.go` replays the **actual pre-merge two-map writers** as an oracle and asserts, for every probed name (present *and* absent) on **both** construction paths (`BuildIndex` and `BuildIndexFromModulesOrdered`) across three fixtures:

- `merged[name].base` ≡ legacy `nameKinds[name]`
- `merged[name].real` ≡ legacy `nameKindsReal[name]` (zero value when absent — exactly what the old missing-key read returned)
- the presence bit matches

plus an entry-point sweep (`lookupByKindHint` over all 35 hint-kind branches, `lookupUniqueModelByName`, the real-component tier-1, `nameExists`, `DiagnoseBugResolver`) against verbatim legacy-backed reference implementations.

`TestNameKindsMerge_IndependentBlanking525` asserts the strong form directly: `base.get("Component")` is present-but-**blank** while `real.get("Component")` still yields the real id, and `lookupByKindHint("Widget","EXTENDS")` still binds to the real component rather than the `SCOPE.` placeholder.

**Key-set safety**: both writers write `.base` unconditionally per entity iteration and `.real` only inside `if Kind != ""` in the *same* iteration, so `keys(real) ⊆ keys(base)` structurally — the merged key set equals the old `nameKinds` key set, leaving `nameExists`/`DiagnoseBugResolver` comma-ok semantics unchanged.

The M5 mirror (`insertModuleEntry`, `symbol_index.go`) is converted in parity; `symbol_index_parity_test.go`'s full-Index `reflect.DeepEqual` now covers `.real` through the merged struct (verified by mutation — breaking either write fails the parity tests).

## Performance

Paired benchmark over a 200k-entity fixture, `-benchtime 3s -count=3`:

```
Merged        142.6 / 143.8 / 142.0 ns/op   0 allocs
LegacyTwoMap  148.2 / 144.3 / 144.8 ns/op   0 allocs
```

≈2% faster — the saved second map probe offsets the wider `map[k]struct` copy-on-read. The load-bearing result is that the merged layout is **not slower**, so no pointer-return workaround is needed. (An earlier single-run measurement suggested ~15%; that was noise and is corrected here.)

## Verification

`go build ./...`, `go vet ./internal/resolve/...`, `gofmt -l internal cmd` clean. `./internal/resolve/...` 1994 pass with and without `-race`; `./cmd/grafel/...` 337 pass, goldens unchanged (graph output byte-identical). No format change, no new goroutines.

Independently adversarially reviewed, including verifying the test oracle is non-circular against `git show main:` and mutation-testing every read/write site.

Refs #5954

🤖 Generated with [Claude Code](https://claude.com/claude-code)
