### PR TITLE
perf(#5954): merge byLocationKind + byLocationKindReal into one two-level map (slice 2)

### DIFF
--- a/internal/resolve/kindids_equiv_test.go
+++ b/internal/resolve/kindids_equiv_test.go
@@ -133,14 +133,41 @@ func liveNameKindsReal(m map[string]nameKindEntry) map[string]map[string]string 
 	return out
 }
 
-func liveLocKind(m LocationKindIndex) map[string]map[string]map[string]string {
+// liveLocKindBase materialises the .base field of the merged byLocationKind
+// inner values back into a plain map for comparison.
+func liveLocKindBase(m LocationKindIndex) map[string]map[string]map[string]string {
 	out := map[string]map[string]map[string]string{}
 	for file, fb := range m {
 		of := map[string]map[string]string{}
-		for name, kid := range fb {
+		for name, ent := range fb {
 			b := map[string]string{}
-			kid.each(func(k, id string) { b[k] = id })
+			ent.base.each(func(k, id string) { b[k] = id })
 			of[name] = b
+		}
+		out[file] = of
+	}
+	return out
+}
+
+// liveLocKindReal materialises the .real field of the merged byLocationKind
+// inner values. The oracle only records a (file, name) once an entity with a
+// non-empty Kind carries it, so entries whose .real bucket is empty — and
+// files left with no populated .real at all — are omitted here, matching the
+// pre-merge byLocationKindReal key set exactly at BOTH levels.
+func liveLocKindReal(m LocationKindIndex) map[string]map[string]map[string]string {
+	out := map[string]map[string]map[string]string{}
+	for file, fb := range m {
+		of := map[string]map[string]string{}
+		for name, ent := range fb {
+			if ent.real.len() == 0 {
+				continue
+			}
+			b := map[string]string{}
+			ent.real.each(func(k, id string) { b[k] = id })
+			of[name] = b
+		}
+		if len(of) == 0 {
+			continue
 		}
 		out[file] = of
 	}
@@ -182,11 +209,11 @@ func TestKindIDs_IndexMapParity(t *testing.T) {
 	if got, want := liveNameKindsReal(idx.nameKinds), oracleNameKindsReal(ents); !reflect.DeepEqual(got, want) {
 		t.Fatalf("nameKinds.real diverges from oracle:\n live=%v\noracle=%v", got, want)
 	}
-	if got, want := liveLocKind(idx.byLocationKind), oracleLocKind(ents, false); !reflect.DeepEqual(got, want) {
-		t.Fatalf("byLocationKind diverges from oracle:\n live=%v\noracle=%v", got, want)
+	if got, want := liveLocKindBase(idx.byLocationKind), oracleLocKind(ents, false); !reflect.DeepEqual(got, want) {
+		t.Fatalf("byLocationKind.base diverges from oracle:\n live=%v\noracle=%v", got, want)
 	}
-	if got, want := liveLocKind(idx.byLocationKindReal), oracleLocKind(ents, true); !reflect.DeepEqual(got, want) {
-		t.Fatalf("byLocationKindReal diverges from oracle:\n live=%v\noracle=%v", got, want)
+	if got, want := liveLocKindReal(idx.byLocationKind), oracleLocKind(ents, true); !reflect.DeepEqual(got, want) {
+		t.Fatalf("byLocationKind.real diverges from oracle:\n live=%v\noracle=%v", got, want)
 	}
 }
 

--- a/internal/resolve/lockind_merge_equiv_test.go
+++ b/internal/resolve/lockind_merge_equiv_test.go
@@ -1,0 +1,704 @@
+// Package resolve — behaviour-neutrality battery for the byLocationKind
+// inner-map merge (#5954, BuildIndex outer-map compaction increment 2).
+//
+// The merge folded the two formerly-parallel location-keyed tables
+//
+//	byLocationKind     map[file]map[name]kindIDs   (all kinds, SCOPE.* dual-indexed)
+//	byLocationKindReal map[file]map[name]kindIDs   (original kind only)
+//
+// into ONE map[file]map[name]locKindEntry{base, real}. This file proves the
+// swap is behaviourally invisible by rebuilding the PRE-MERGE tables with an
+// independent replay of the old writers (taken verbatim from refs.go at
+// c90466054, i.e. BEFORE this change) and asserting:
+//
+//  1. storage equivalence — for EVERY probed (file, name) pair, present AND
+//     absent, at BOTH map levels:
+//     idx.byLocationKind[f][n].base ≡ legacy byLocationKind[f][n] and
+//     idx.byLocationKind[f][n].real ≡ legacy byLocationKindReal[f][n],
+//     including the comma-ok presence bits. Since every read site touches the
+//     merged map only through .base / .real, identical values here mean
+//     identical inputs to every consumer by construction.
+//  2. entry-point equivalence — the live resolver entry points are compared
+//     against reference implementations driven by the legacy two-map tables.
+//  3. the #525 independent-blanking invariant — a real Component and a
+//     SCOPE.Component sharing a (file, name) blank .base but leave .real
+//     intact, so the real id stays recoverable. Asserted directly on the
+//     merged value AND end-to-end through lookupLocationKind.
+//
+// THE TWO-LEVEL PRESENCE ARGUMENT (what makes the merge legal here).
+// The pre-merge writer wrote the real tables strictly INSIDE the base write's
+// `sourceFile != ""` block, in the SAME loop iteration, further narrowed only
+// by `e.Kind != ""`. Hence, per index build:
+//
+//	keys(byLocationKindReal)      ⊆ keys(byLocationKind)          (outer, file)
+//	keys(byLocationKindReal[f])   ⊆ keys(byLocationKind[f])       (inner, name)
+//
+// No path anywhere writes the real table for a (file, name) that received no
+// base write. The merged key set is therefore EXACTLY the old byLocationKind
+// key set at both levels, so no comma-ok / nil-bucket read shifts. The
+// assertions below re-establish this mechanically rather than by assumption:
+// assertLocKindMergedMatchesLegacy fails loudly if any legacy real key (at
+// either level) is missing from the legacy base key set.
+//
+// Both index construction paths (flat BuildIndex and the M5
+// BuildIndexFromModulesOrdered mirror) are checked against the same legacy
+// tables.
+package resolve
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ---- legacy (pre-merge) writer replay ---------------------------------------
+
+// legacyLocationKindTables replays the exact pre-merge write rules from
+// BuildIndex (refs.go @ c90466054):
+//
+//	if sourceFile != "" {
+//	    fileKindBucket := idx.byLocationKind[sourceFile]
+//	    if fileKindBucket == nil { ...make... }
+//	    nameKindBucketLoc := fileKindBucket[e.Name]
+//	    for _, kind := range kinds { if kind == "" { continue }; nameKindBucketLoc.set(kind, e.ID) }
+//	    fileKindBucket[e.Name] = nameKindBucketLoc
+//	    if e.Kind != "" {
+//	        realFileBucket := idx.byLocationKindReal[sourceFile]
+//	        if realFileBucket == nil { ...make... }
+//	        realNameBucket := realFileBucket[e.Name]
+//	        realNameBucket.set(e.Kind, e.ID)
+//	        realFileBucket[e.Name] = realNameBucket
+//	    }
+//	}
+//
+// Two separate maps, blanked independently by kindIDs.set. This oracle is
+// derived from the OLD code only — never from the merged implementation.
+func legacyLocationKindTables(ents []types.EntityRecord) (base, real map[string]map[string]kindIDs) {
+	base = map[string]map[string]kindIDs{}
+	real = map[string]map[string]kindIDs{}
+	for _, e := range ents {
+		sourceFile := normalizePath(e.SourceFile)
+		if sourceFile == "" {
+			continue
+		}
+		fileKindBucket := base[sourceFile]
+		if fileKindBucket == nil {
+			fileKindBucket = map[string]kindIDs{}
+			base[sourceFile] = fileKindBucket
+		}
+		nameKindBucketLoc := fileKindBucket[e.Name]
+		for _, kind := range kindsOf(e) {
+			if kind == "" {
+				continue
+			}
+			nameKindBucketLoc.set(kind, e.ID)
+		}
+		fileKindBucket[e.Name] = nameKindBucketLoc
+
+		if e.Kind != "" {
+			realFileBucket := real[sourceFile]
+			if realFileBucket == nil {
+				realFileBucket = map[string]kindIDs{}
+				real[sourceFile] = realFileBucket
+			}
+			realNameBucket := realFileBucket[e.Name]
+			realNameBucket.set(e.Kind, e.ID)
+			realFileBucket[e.Name] = realNameBucket
+		}
+	}
+	return base, real
+}
+
+// ---- reference implementations over the legacy two-map layout ----------------
+
+// refLookupLocationKind is a verbatim copy of the pre-merge lookupLocationKind
+// body driven by the two legacy tables — including the original ordering, where
+// the tier-1 real probe ran BEFORE the base file-bucket nil check.
+func refLookupLocationKind(base, real map[string]map[string]kindIDs, filePath, name string, families []string) (string, bool) {
+	if len(families) == 0 {
+		return "", false
+	}
+	if realFileBucket := real[filePath]; realFileBucket != nil {
+		if realNameBucket := realFileBucket[name]; realNameBucket.len() > 0 {
+			if id, ok := uniqueMatchInFamily(realNameBucket, families, false); ok {
+				return id, true
+			}
+		}
+	}
+	fileBucket := base[filePath]
+	if fileBucket == nil {
+		return "", false
+	}
+	nameBucket := fileBucket[name]
+	if nameBucket.len() == 0 {
+		return "", false
+	}
+	return uniqueMatchInFamily(nameBucket, families, true)
+}
+
+// refRealComponentScopeScan is a verbatim copy of the pre-merge
+// byLocationKind scan inside lookupUniqueRealComponentByName (the part this
+// change touches; the preceding nameKinds tier is untouched by increment 2).
+func refRealComponentScopeScan(base map[string]map[string]kindIDs, name string) (string, bool) {
+	scopeKind := scopeKindPrefix + "Component"
+	var match string
+	for _, fileBucket := range base {
+		nameBucket := fileBucket[name]
+		id, _ := nameBucket.get(scopeKind)
+		if id == "" {
+			continue
+		}
+		if match != "" && match != id {
+			return "", false
+		}
+		match = id
+	}
+	if match != "" {
+		return match, true
+	}
+	return "", false
+}
+
+// refLookupUniqueSchemaFieldByName is a verbatim copy of the pre-merge body.
+func refLookupUniqueSchemaFieldByName(base map[string]map[string]kindIDs, fieldName string) (string, bool) {
+	if fieldName == "" {
+		return "", false
+	}
+	var match string
+	for _, fileBucket := range base {
+		for entityName, kindBucket := range fileBucket {
+			leaf := entityName
+			if dot := strings.LastIndexByte(entityName, '.'); dot >= 0 {
+				leaf = entityName[dot+1:]
+			}
+			if leaf != fieldName {
+				continue
+			}
+			for _, fam := range schemaKindFamily {
+				id, _ := kindBucket.get(fam)
+				if id == "" {
+					continue
+				}
+				if match != "" && match != id {
+					return "", false
+				}
+				match = id
+			}
+		}
+	}
+	if match != "" {
+		return match, true
+	}
+	return "", false
+}
+
+// refBareLocalityRealTier is a verbatim copy of the pre-merge
+// byLocationKindReal tier inside lookupBareWithLocality.
+func refBareLocalityRealTier(real map[string]map[string]kindIDs, callerFile, name string, families []string) (string, bool) {
+	if callerFile == "" || len(families) == 0 {
+		return "", false
+	}
+	if fileBucket := real[callerFile]; fileBucket != nil {
+		nameBucket := fileBucket[name]
+		var match string
+		ambig := false
+		for _, k := range families {
+			if strings.HasPrefix(k, scopeKindPrefix) {
+				continue
+			}
+			id, _ := nameBucket.get(k)
+			if id == "" {
+				continue
+			}
+			if match != "" && match != id {
+				ambig = true
+				break
+			}
+			match = id
+		}
+		if !ambig && match != "" {
+			return match, true
+		}
+	}
+	return "", false
+}
+
+// refBareLocalityScopeTier is a verbatim copy of the pre-merge trailing
+// byLocationKind SCOPE.* CALLS fallback inside lookupBareWithLocality.
+func refBareLocalityScopeTier(base map[string]map[string]kindIDs, callerFile, name string) (string, bool) {
+	if callerFile == "" {
+		return "", false
+	}
+	if fileBucket := base[callerFile]; fileBucket != nil {
+		nameBucket := fileBucket[name]
+		if id, _ := nameBucket.get(scopeKindPrefix + "Operation"); id != "" {
+			return id, true
+		}
+		if id, _ := nameBucket.get(scopeKindPrefix + "Component"); id != "" {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// ---- live-side probes mirroring the reference shapes ------------------------
+
+func liveRealComponentScopeScan(idx Index, name string) (string, bool) {
+	scopeKind := scopeKindPrefix + "Component"
+	var match string
+	for _, fileBucket := range idx.byLocationKind {
+		id, _ := fileBucket[name].base.get(scopeKind)
+		if id == "" {
+			continue
+		}
+		if match != "" && match != id {
+			return "", false
+		}
+		match = id
+	}
+	if match != "" {
+		return match, true
+	}
+	return "", false
+}
+
+func liveBareLocalityRealTier(idx Index, callerFile, name string, families []string) (string, bool) {
+	if callerFile == "" || len(families) == 0 {
+		return "", false
+	}
+	if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
+		nameBucket := fileBucket[name].real
+		var match string
+		ambig := false
+		for _, k := range families {
+			if strings.HasPrefix(k, scopeKindPrefix) {
+				continue
+			}
+			id, _ := nameBucket.get(k)
+			if id == "" {
+				continue
+			}
+			if match != "" && match != id {
+				ambig = true
+				break
+			}
+			match = id
+		}
+		if !ambig && match != "" {
+			return match, true
+		}
+	}
+	return "", false
+}
+
+func liveBareLocalityScopeTier(idx Index, callerFile, name string) (string, bool) {
+	if callerFile == "" {
+		return "", false
+	}
+	if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
+		nameBucket := fileBucket[name].base
+		if id, _ := nameBucket.get(scopeKindPrefix + "Operation"); id != "" {
+			return id, true
+		}
+		if id, _ := nameBucket.get(scopeKindPrefix + "Component"); id != "" {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// ---- fixture ----------------------------------------------------------------
+
+// locMergeFixture = mergeEquivFixture() PLUS shapes that specifically stress
+// the TWO-LEVEL merge: a file whose every entity is kind-less (so the pre-merge
+// byLocationKindReal never created an outer key for it at all), a file mixing
+// kind-less and kinded entities at the same name, a same-(file,name,kind)
+// collision, and a same-file real/SCOPE.Component collision.
+func locMergeFixture() []types.EntityRecord {
+	ents := mergeEquivFixture()
+	ents = append(ents,
+		// Whole file of kind-less entities: legacy byLocationKind has the file
+		// key, legacy byLocationKindReal does NOT. The single strongest test of
+		// the outer presence-bit argument.
+		entAt("0000000000000b01", "", "OnlyKindless", "loc/kindless_only.py"),
+		entAt("0000000000000b02", "", "AlsoKindless", "loc/kindless_only.py"),
+		// Same (file, name) where one entity is kind-less and one is not:
+		// inner base key exists from both, inner real key from one.
+		entAt("0000000000000b03", "", "MixedPresence", "loc/mixed.py"),
+		entAt("0000000000000b04", "Class", "MixedPresence", "loc/mixed.py"),
+		// Same (file, name, kind) twice => blank sentinel in BOTH base and real.
+		entAt("0000000000000b05", "Class", "SameFileDup", "loc/dup.java"),
+		entAt("0000000000000b06", "Class", "SameFileDup", "loc/dup.java"),
+		// #525 shape confined to ONE file: real Component + SCOPE.Component.
+		entAt("0000000000000b07", "Component", "LocWidget", "loc/w.py"),
+		entAt("0000000000000b08", "SCOPE.Component", "LocWidget", "loc/w.py"),
+		// A same-file schema field for lookupUniqueSchemaFieldByName.
+		entAt("0000000000000b09", "SCOPE.Schema", "Holder.locField", "loc/h.java"),
+		// A file with only a SCOPE.Operation, for the CALLS scope fallback.
+		entAt("0000000000000b10", "SCOPE.Operation", "locHandler", "loc/ops.ts"),
+	)
+	return ents
+}
+
+// probeFiles returns every normalized source file in the fixture plus files
+// guaranteed absent, so the outer comma-ok / nil-bucket bit is exercised on
+// both sides.
+func probeFiles(ents []types.EntityRecord) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, e := range ents {
+		sf := normalizePath(e.SourceFile)
+		if sf != "" && !seen[sf] {
+			seen[sf] = true
+			out = append(out, sf)
+		}
+	}
+	return append(out, "", "no/such/file.py", "loc/kindless_only.py.bak")
+}
+
+// ---- 1. storage equivalence -------------------------------------------------
+
+func assertLocKindMergedMatchesLegacy(t *testing.T, label string, idx Index, ents []types.EntityRecord) {
+	t.Helper()
+	base, real := legacyLocationKindTables(ents)
+
+	// Re-establish the TWO-LEVEL presence precondition mechanically: every
+	// legacy real key must exist in legacy base at BOTH levels. If this ever
+	// fails, the merged key set would differ from the old base key set and the
+	// comma-ok / nil-bucket semantics at the read sites would shift.
+	for file, realFileBucket := range real {
+		baseFileBucket, ok := base[file]
+		if !ok {
+			t.Fatalf("%s: legacy real FILE key %q absent from legacy base — merge precondition violated", label, file)
+		}
+		for name := range realFileBucket {
+			if _, ok := baseFileBucket[name]; !ok {
+				t.Fatalf("%s: legacy real NAME key %q in file %q absent from legacy base — merge precondition violated", label, name, file)
+			}
+		}
+	}
+
+	// Outer key set must be exactly the legacy base outer key set.
+	if len(idx.byLocationKind) != len(base) {
+		t.Fatalf("%s: merged byLocationKind has %d file keys, legacy base has %d", label, len(idx.byLocationKind), len(base))
+	}
+
+	names := probeNames(ents)
+	for _, file := range probeFiles(ents) {
+		gotFileBucket, gotFileOK := idx.byLocationKind[file]
+		wantFileBucket, wantFileOK := base[file]
+		if gotFileOK != wantFileOK {
+			t.Fatalf("%s: outer presence bit for %q = %v, legacy byLocationKind = %v", label, file, gotFileOK, wantFileOK)
+		}
+		if len(gotFileBucket) != len(wantFileBucket) {
+			t.Fatalf("%s: file %q inner key count = %d, legacy = %d", label, file, len(gotFileBucket), len(wantFileBucket))
+		}
+		realFileBucket := real[file]
+		for _, name := range names {
+			ent, gotOK := gotFileBucket[name]
+			wantBase, wantOK := wantFileBucket[name]
+			if gotOK != wantOK {
+				t.Fatalf("%s: inner presence bit for (%q,%q) = %v, legacy byLocationKind = %v", label, file, name, gotOK, wantOK)
+			}
+			if !reflect.DeepEqual(ent.base, wantBase) {
+				t.Fatalf("%s: byLocationKind[%q][%q].base = %+v, legacy = %+v", label, file, name, ent.base, wantBase)
+			}
+			// Absent from legacy real (at either level) => zero value, which is
+			// exactly what the old two-step read returned.
+			wantReal := realFileBucket[name]
+			if !reflect.DeepEqual(ent.real, wantReal) {
+				t.Fatalf("%s: byLocationKind[%q][%q].real = %+v, legacy byLocationKindReal = %+v", label, file, name, ent.real, wantReal)
+			}
+		}
+	}
+}
+
+func TestLocKindMerge_StorageEquivalence(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"representative", representativeFixture()},
+		{"equiv", equivFixture()},
+		{"mergeEquiv", mergeEquivFixture()},
+		{"locMerge", locMergeFixture()},
+	} {
+		t.Run(tc.name+"/flat", func(t *testing.T) {
+			assertLocKindMergedMatchesLegacy(t, "BuildIndex", BuildIndex(tc.ents), tc.ents)
+		})
+		t.Run(tc.name+"/modules", func(t *testing.T) {
+			// M5 mirror (insertModuleEntry) must agree with the same legacy
+			// tables, not merely with BuildIndex.
+			idx := BuildIndexFromModulesOrdered(tc.ents, ModuleKeyByPkgDir)
+			assertLocKindMergedMatchesLegacy(t, "BuildIndexFromModulesOrdered", idx, tc.ents)
+		})
+	}
+}
+
+// ---- 2. entry-point equivalence ---------------------------------------------
+
+func TestLocKindMerge_EntryPointEquivalence(t *testing.T) {
+	ents := locMergeFixture()
+	for _, tc := range []struct {
+		label string
+		idx   Index
+	}{
+		{"BuildIndex", BuildIndex(ents)},
+		{"BuildIndexFromModulesOrdered", BuildIndexFromModulesOrdered(ents, ModuleKeyByPkgDir)},
+	} {
+		idx := tc.idx
+		base, real := legacyLocationKindTables(ents)
+		families := [][]string{
+			componentKindFamily, operationKindFamily, schemaKindFamily, nil, {},
+		}
+
+		for _, file := range probeFiles(ents) {
+			for _, name := range probeNames(ents) {
+				for _, fam := range families {
+					gotID, gotOK := idx.lookupLocationKind(file, name, fam)
+					wantID, wantOK := refLookupLocationKind(base, real, file, name, fam)
+					if gotID != wantID || gotOK != wantOK {
+						t.Fatalf("%s: lookupLocationKind(%q,%q,%v) = (%q,%v), legacy = (%q,%v)",
+							tc.label, file, name, fam, gotID, gotOK, wantID, wantOK)
+					}
+				}
+
+				for _, rk := range allHintKinds {
+					fam := hintKinds(rk)
+					gotID, gotOK := liveBareLocalityRealTier(idx, file, name, fam)
+					wantID, wantOK := refBareLocalityRealTier(real, file, name, fam)
+					if gotID != wantID || gotOK != wantOK {
+						t.Fatalf("%s: lookupBareWithLocality real tier(%q,%q,%q) = (%q,%v), legacy = (%q,%v)",
+							tc.label, file, name, rk, gotID, gotOK, wantID, wantOK)
+					}
+				}
+
+				gotID, gotOK := liveBareLocalityScopeTier(idx, file, name)
+				wantID, wantOK := refBareLocalityScopeTier(base, file, name)
+				if gotID != wantID || gotOK != wantOK {
+					t.Fatalf("%s: lookupBareWithLocality SCOPE tier(%q,%q) = (%q,%v), legacy = (%q,%v)",
+						tc.label, file, name, gotID, gotOK, wantID, wantOK)
+				}
+			}
+		}
+
+		for _, name := range probeNames(ents) {
+			gotID, gotOK := liveRealComponentScopeScan(idx, name)
+			wantID, wantOK := refRealComponentScopeScan(base, name)
+			if gotID != wantID || gotOK != wantOK {
+				t.Fatalf("%s: lookupUniqueRealComponentByName scope scan(%q) = (%q,%v), legacy = (%q,%v)",
+					tc.label, name, gotID, gotOK, wantID, wantOK)
+			}
+
+			// Full entry point, including the untouched nameKinds tier.
+			gotID, gotOK = idx.lookupUniqueRealComponentByName(name)
+			wantID, wantOK = func() (string, bool) {
+				if name == "" {
+					return "", false
+				}
+				if realBucket := idx.nameKinds[name].real; realBucket.len() > 0 {
+					if id, ok := uniqueMatchInFamily(realBucket, componentKindFamily, false); ok {
+						return id, true
+					}
+				}
+				return refRealComponentScopeScan(base, name)
+			}()
+			if gotID != wantID || gotOK != wantOK {
+				t.Fatalf("%s: lookupUniqueRealComponentByName(%q) = (%q,%v), legacy = (%q,%v)",
+					tc.label, name, gotID, gotOK, wantID, wantOK)
+			}
+
+			// lookupUniqueSchemaFieldByName probes by LEAF name.
+			leaf := name
+			if d := strings.LastIndexByte(name, '.'); d >= 0 {
+				leaf = name[d+1:]
+			}
+			for _, probe := range []string{name, leaf, "locField", "parentField", "nope"} {
+				gotID, gotOK = idx.lookupUniqueSchemaFieldByName(probe)
+				wantID, wantOK = refLookupUniqueSchemaFieldByName(base, probe)
+				if gotID != wantID || gotOK != wantOK {
+					t.Fatalf("%s: lookupUniqueSchemaFieldByName(%q) = (%q,%v), legacy = (%q,%v)",
+						tc.label, probe, gotID, gotOK, wantID, wantOK)
+				}
+			}
+		}
+	}
+}
+
+// ---- 3. the #525 independent-blanking invariant -----------------------------
+
+// TestLocKindMerge_IndependentBlanking525 proves the load-bearing invariant of
+// the merge: .base and .real inside ONE inner-map value are blanked
+// independently, so a SCOPE.Component placeholder colliding with a real
+// Component at the SAME (file, name) destroys the id in .base but NOT in
+// .real. If the two ever shared state (or .real were derived from .base by
+// filtering SCOPE.*), the real id would be unrecoverable and the location-
+// scoped EXTENDS bind would fall through to the placeholder.
+func TestLocKindMerge_IndependentBlanking525(t *testing.T) {
+	const realID, scopeID = "00000000000005a1", "00000000000005a2"
+	const file = "app/widget.py"
+
+	for label, idx := range map[string]Index{
+		"flat":    BuildIndex(equivFixture()),
+		"modules": BuildIndexFromModulesOrdered(equivFixture(), ModuleKeyByPkgDir),
+	} {
+		ent := idx.byLocationKind[file]["Widget"]
+
+		// .base: "Component" is dual-indexed by BOTH the real Component (5a1)
+		// and the SCOPE.Component's trimmed kind (5a2) => present-but-BLANK.
+		if id, present := ent.base.get("Component"); !present || id != "" {
+			t.Fatalf("%s: base[Component] = (%q,%v), want blank sentinel present — the real id must be UNRECOVERABLE from base", label, id, present)
+		}
+		// The real id is therefore only obtainable from .real.
+		if id, present := ent.real.get("Component"); !present || id != realID {
+			t.Fatalf("%s: real[Component] = (%q,%v), want (%s,true) — independent blanking broken", label, id, present, realID)
+		}
+		// The placeholder keeps its own untrimmed slot in .real; it must not
+		// have blanked the real entity's slot.
+		if id, present := ent.real.get("SCOPE.Component"); !present || id != scopeID {
+			t.Fatalf("%s: real[SCOPE.Component] = (%q,%v), want (%s,true)", label, id, present, scopeID)
+		}
+		// End-to-end: the location-scoped tier-1 real pass must bind to the
+		// real component, never the placeholder.
+		if id, ok := idx.lookupLocationKind(file, "Widget", componentKindFamily); !ok || id != realID {
+			t.Fatalf("%s: lookupLocationKind(%s,Widget,component) = (%q,%v), want (%s,true)", label, file, id, ok, realID)
+		}
+	}
+
+	// Same shape on the increment-2 fixture's own single-file pair.
+	for label, idx := range map[string]Index{
+		"flat":    BuildIndex(locMergeFixture()),
+		"modules": BuildIndexFromModulesOrdered(locMergeFixture(), ModuleKeyByPkgDir),
+	} {
+		ent := idx.byLocationKind["loc/w.py"]["LocWidget"]
+		if id, present := ent.base.get("Component"); !present || id != "" {
+			t.Fatalf("%s: LocWidget base[Component] = (%q,%v), want blank sentinel", label, id, present)
+		}
+		if id, present := ent.real.get("Component"); !present || id != "0000000000000b07" {
+			t.Fatalf("%s: LocWidget real[Component] = (%q,%v), want (b07,true)", label, id, present)
+		}
+		if id, ok := idx.lookupLocationKind("loc/w.py", "LocWidget", componentKindFamily); !ok || id != "0000000000000b07" {
+			t.Fatalf("%s: lookupLocationKind(loc/w.py,LocWidget,component) = (%q,%v), want (b07,true)", label, id, ok)
+		}
+	}
+}
+
+// TestLocKindMerge_CollisionSentinelBothFields asserts present-but-blank
+// ("",true) stays distinguishable from absent ("",false) in BOTH fields of the
+// merged inner value, and that the two-level presence bits behave as argued.
+func TestLocKindMerge_CollisionSentinelBothFields(t *testing.T) {
+	idx := BuildIndex(locMergeFixture())
+
+	ent := idx.byLocationKind["loc/dup.java"]["SameFileDup"]
+	for field, b := range map[string]kindIDs{"base": ent.base, "real": ent.real} {
+		id, present := b.get("Class")
+		if !present {
+			t.Fatalf("%s[Class] absent; want present blank sentinel", field)
+		}
+		if id != "" {
+			t.Fatalf("%s[Class] = %q, want blank sentinel", field, id)
+		}
+		if id, present := b.get("NoSuchKind"); present || id != "" {
+			t.Fatalf("%s[NoSuchKind] = (%q,%v), want (\"\",false)", field, id, present)
+		}
+	}
+
+	// A file of only kind-less entities: the pre-merge byLocationKindReal had
+	// NO outer key for it. After the merge the file key exists (it always did
+	// in byLocationKind) and every .real bucket is empty — the shape every read
+	// site treats identically to the old nil outer bucket.
+	fb, ok := idx.byLocationKind["loc/kindless_only.py"]
+	if !ok {
+		t.Fatalf("kind-less-only file did not create a byLocationKind key")
+	}
+	for name, e := range fb {
+		if e.base.len() != 0 || e.real.len() != 0 {
+			t.Fatalf("loc/kindless_only.py[%q] = %+v, want both buckets empty", name, e)
+		}
+	}
+	if _, ok := idx.lookupLocationKind("loc/kindless_only.py", "OnlyKindless", componentKindFamily); ok {
+		t.Fatalf("lookupLocationKind on an all-empty entry resolved; want miss")
+	}
+
+	// Mixed presence at one (file, name): base carries the Class from the
+	// kinded entity, real carries it too, and neither is blanked by the
+	// kind-less sibling (which contributes no kind at all).
+	mixed := idx.byLocationKind["loc/mixed.py"]["MixedPresence"]
+	if id, present := mixed.base.get("Class"); !present || id != "0000000000000b04" {
+		t.Fatalf("mixed base[Class] = (%q,%v), want (b04,true)", id, present)
+	}
+	if id, present := mixed.real.get("Class"); !present || id != "0000000000000b04" {
+		t.Fatalf("mixed real[Class] = (%q,%v), want (b04,true)", id, present)
+	}
+}
+
+// ---- 4. read-path benchmark -------------------------------------------------
+
+// locBenchFixture builds a corpus-shaped entity set spread over many files so
+// the location-keyed maps reach realistic cardinality.
+func locBenchFixture(n int) []types.EntityRecord {
+	return benchFixture(n)
+}
+
+func locBenchProbes(ents []types.EntityRecord) []struct{ file, name string } {
+	out := make([]struct{ file, name string }, 0, 4096)
+	seen := map[string]bool{}
+	for _, e := range ents {
+		k := e.SourceFile + "\x00" + e.Name
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		out = append(out, struct{ file, name string }{normalizePath(e.SourceFile), e.Name})
+		if len(out) == 4096 {
+			break
+		}
+	}
+	return out
+}
+
+// BenchmarkLookupLocationKind_Merged measures the hot tier-1/tier-2 location
+// read path over the merged inner map (one probe instead of two; map[k]struct
+// copy-on-read is the one cost the merge adds).
+func BenchmarkLookupLocationKind_Merged(b *testing.B) {
+	ents := locBenchFixture(200000)
+	idx := BuildIndex(ents)
+	probes := locBenchProbes(ents)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		p := probes[i%len(probes)]
+		if _, ok := idx.lookupLocationKind(p.file, p.name, componentKindFamily); ok {
+			sink++
+		}
+		if _, ok := idx.lookupLocationKind(p.file, p.name, operationKindFamily); ok {
+			sink++
+		}
+	}
+	_ = sink
+}
+
+// BenchmarkLookupLocationKind_LegacyTwoMap is the SAME read path against the
+// pre-merge two-map layout, so the merge's read cost can be compared directly
+// in one binary.
+func BenchmarkLookupLocationKind_LegacyTwoMap(b *testing.B) {
+	ents := locBenchFixture(200000)
+	base, real := legacyLocationKindTables(ents)
+	probes := locBenchProbes(ents)
+	b.ReportAllocs()
+	b.ResetTimer()
+	var sink int
+	for i := 0; i < b.N; i++ {
+		p := probes[i%len(probes)]
+		if _, ok := refLookupLocationKind(base, real, p.file, p.name, componentKindFamily); ok {
+			sink++
+		}
+		if _, ok := refLookupLocationKind(base, real, p.file, p.name, operationKindFamily); ok {
+			sink++
+		}
+	}
+	_ = sink
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -407,24 +407,19 @@ type Index struct {
 	// ambigLocation[file_path][name] = true when (file, name) collides.
 	ambigLocation map[string]map[string]bool
 
-	// byLocationKind[file_path][name][kind] = entity_id. Kind-aware
-	// (file, name) lookup. PORT-2-FIX-2 emissions can produce two entities
-	// at the same (file, name) with different kinds (e.g. SCOPE.Component
-	// class + SCOPE.Operation method); kind-aware lookup picks the correct
-	// one when the relationship's kind hint maps to a single family.
-	// A blank string sentinel marks (file, name, kind) collisions.
+	// byLocationKind[file_path][name] carries BOTH kind-aware location
+	// buckets in one entry (#5954 outer-map compaction increment 2):
+	// .base is the all-kinds bucket (including SCOPE.* dual-indexing) and
+	// .real is the original-kind-only bucket. See locKindEntry for the
+	// semantics of each field.
+	//
+	// Kind-aware (file, name) lookup exists because PORT-2-FIX-2 emissions
+	// can produce two entities at the same (file, name) with different
+	// kinds (e.g. SCOPE.Component class + SCOPE.Operation method);
+	// kind-aware lookup picks the correct one when the relationship's kind
+	// hint maps to a single family. A blank string sentinel marks
+	// (file, name, kind) collisions.
 	byLocationKind LocationKindIndex
-
-	// byLocationKindReal mirrors byLocationKind but indexes ONLY under
-	// the entity's original kind (no SCOPE.* dual-indexing). Used by
-	// lookupLocationKind's tier-1 pass so structural-ref EXTENDS /
-	// IMPLEMENTS edges that target a same-file collision between a
-	// real Component and a SCOPE.Component placeholder bind to the
-	// real entity (#525). Without this, the dual-indexing in
-	// byLocationKind blanks the "Component" key when a SCOPE.Component
-	// of the same (file, name) is registered, forcing the resolver
-	// into ambig-bare-hint-fail.
-	byLocationKindReal LocationKindIndex
 
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
@@ -528,20 +523,60 @@ type Index struct {
 // that are unique within their file. Returned by BuildLocationIndex.
 type LocationIndex map[string]map[string]string
 
-// LocationKindIndex maps file_path -> name -> kind -> entity_id. Used by the
-// kind-aware structural-ref / location resolver path to disambiguate
-// same-file (file, name) collisions when the relationship supplies a kind
-// hint. A blank string value is the ambiguous-within-kind sentinel.
+// LocationKindIndex maps file_path -> name -> {base, real} kind->entity_id
+// buckets. Used by the kind-aware structural-ref / location resolver path to
+// disambiguate same-file (file, name) collisions when the relationship
+// supplies a kind hint. A blank string value is the ambiguous-within-kind
+// sentinel.
 //
 // The innermost kind->id level is a compact kindIDs rather than a
 // map[string]string: these buckets almost always hold a SINGLE (kind, id)
 // entry, and paying full Go-map overhead (~300B heap) per 1-entry map made
 // the four kind->id inner maps 32% of the index-internal peak heap (#5954).
 // kindIDs stores the first entry inline (zero heap in the common case).
-type LocationKindIndex map[string]map[string]kindIDs
+//
+// The name->… level carries a locKindEntry rather than a bare kindIDs because
+// the base and real tables were formerly two parallel LocationKindIndex maps
+// over the identical (file, name) key set — see locKindEntry (#5954).
+type LocationKindIndex map[string]map[string]locKindEntry
 
 // kindID is one (kind, entity_id) pair inside a kindIDs.
 type kindID struct{ kind, id string }
+
+// locKindEntry merges the two formerly-parallel location-keyed tables
+// (byLocationKind + byLocationKindReal) into a single inner-map value
+// (#5954 outer-map compaction increment 2). Both tables were written over the
+// IDENTICAL (sourceFile, e.Name) key set in the same loop iteration — the real
+// write is nested inside the same `sourceFile != ""` guard as the base write
+// and only narrows it further with `e.Kind != ""` — so storing them as two
+// fields of one value removes ~427k duplicate name-key headers plus one whole
+// inner bucket array per file.
+//
+// The two fields are INDEPENDENT state, never derivable from one another:
+//   - base: indexed under every kind form (original AND SCOPE-trimmed), i.e.
+//     the dual-indexed bucket. A (file, name, kind) collision DESTRUCTIVELY
+//     blanks the entry to the "" sentinel via kindIDs.set, so a real entity's
+//     id can become unrecoverable from base alone.
+//   - real: indexed ONLY under the entity's original kind (no SCOPE.*
+//     dual-indexing), so lookupLocationKind's tier-1 pass can prefer a real
+//     entity over a same-named SCOPE.* placeholder in the same file (#525).
+//     It is NOT a filtered view of base — it survives collisions base has
+//     already blanked.
+//
+// Blanking is therefore applied to each field separately, exactly as the two
+// separate maps did. Deriving real from base (e.g. "store base and filter
+// SCOPE.* at read time") is UNSAFE and would silently corrupt resolution.
+//
+// Presence semantics: because real is written only on a subset of the
+// iterations that write base — at both levels, outer file key and inner name
+// key — the merged key set is exactly the old byLocationKind key set, and no
+// (file, name) that previously existed only in byLocationKindReal exists. A
+// former `byLocationKindReal[file] == nil` outer miss now surfaces as an entry
+// whose .real bucket is empty (len() == 0), which every read site already
+// treats identically to the nil-bucket case.
+type locKindEntry struct {
+	base, real kindIDs
+}
 
 // nameKindEntry merges the two formerly-parallel name-keyed tables
 // (nameKinds + nameKindsReal) into a single map value (#5954). Both tables
@@ -568,7 +603,7 @@ type nameKindEntry struct {
 
 // kindIDs is a heap-frugal replacement for map[string]string (kind -> id) in
 // the resolver Index's four dominant inner buckets (nameKinds .base/.real,
-// byLocationKind, byLocationKindReal). The first entry lives inline (k0/v0);
+// byLocationKind .base/.real). The first entry lives inline (k0/v0);
 // additional kinds spill to rest. Since these buckets carry ~1 entry each, the
 // inline path never touches the heap — that is the entire point of the type.
 //
@@ -836,7 +871,6 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
-		byLocationKindReal: make(LocationKindIndex),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
@@ -1041,36 +1075,31 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			// Kind-aware (file, name, kind) bucket — collision-safe under
 			// PORT-2-FIX-2 emissions. Indexed under both raw and SCOPE-
 			// trimmed kinds to mirror byKind.
-			fileKindBucket := idx.byLocationKind[sourceFile]
-			if fileKindBucket == nil {
-				fileKindBucket = make(map[string]kindIDs)
-				idx.byLocationKind[sourceFile] = fileKindBucket
-			}
-			nameKindBucketLoc := fileKindBucket[e.Name]
-			for _, kind := range kinds {
-				if kind == "" {
-					continue
-				}
-				nameKindBucketLoc.set(kind, e.ID) // ambiguous within (file, name, kind) => blank
-			}
-			fileKindBucket[e.Name] = nameKindBucketLoc
-
-			// byLocationKindReal — single-pass under the entity's
-			// original kind only. Powers the real-tier preference in
+			//
+			// .real is a single pass under the entity's original kind
+			// only. Powers the real-tier preference in
 			// lookupLocationKind so structural-ref EXTENDS targets
 			// like scope:component:class:py:models.py:TimestampedModel
 			// resolve to a real Component even when a SCOPE.Component
 			// placeholder shares the same (file, name) (#525).
-			if e.Kind != "" {
-				realFileBucket := idx.byLocationKindReal[sourceFile]
-				if realFileBucket == nil {
-					realFileBucket = make(map[string]kindIDs)
-					idx.byLocationKindReal[sourceFile] = realFileBucket
-				}
-				realNameBucket := realFileBucket[e.Name]
-				realNameBucket.set(e.Kind, e.ID)
-				realFileBucket[e.Name] = realNameBucket
+			// .base and .real are blanked INDEPENDENTLY — a collision
+			// in one never touches the other (#5954 merge invariant).
+			fileKindBucket := idx.byLocationKind[sourceFile]
+			if fileKindBucket == nil {
+				fileKindBucket = make(map[string]locKindEntry)
+				idx.byLocationKind[sourceFile] = fileKindBucket
 			}
+			locKindEnt := fileKindBucket[e.Name]
+			for _, kind := range kinds {
+				if kind == "" {
+					continue
+				}
+				locKindEnt.base.set(kind, e.ID) // ambiguous within (file, name, kind) => blank
+			}
+			if e.Kind != "" {
+				locKindEnt.real.set(e.Kind, e.ID)
+			}
+			fileKindBucket[e.Name] = locKindEnt
 
 			if idx.ambigLocation[sourceFile] == nil || !idx.ambigLocation[sourceFile][e.Name] {
 				bucket := idx.byLocation[sourceFile]
@@ -2193,7 +2222,7 @@ func (idx Index) lookupUniqueRealComponentByName(name string) (string, bool) {
 			return id, true
 		}
 	}
-	// Python class fallback: scan byLocationKindReal for any file that
+	// Python class fallback: scan byLocationKind .base for any file that
 	// owns a SCOPE.Component entity with this exact name. SCOPE.Component
 	// is the Python extractor's class-entity kind (#525). When exactly
 	// one file owns a SCOPE.Component for this name, bind to it; ambiguous
@@ -2201,7 +2230,7 @@ func (idx Index) lookupUniqueRealComponentByName(name string) (string, bool) {
 	scopeKind := scopeKindPrefix + "Component"
 	var match string
 	for _, fileBucket := range idx.byLocationKind {
-		nameBucket := fileBucket[name]
+		nameBucket := fileBucket[name].base
 		id, _ := nameBucket.get(scopeKind)
 		if id == "" {
 			continue
@@ -2229,12 +2258,13 @@ func (idx Index) lookupUniqueSchemaFieldByName(fieldName string) (string, bool) 
 	if fieldName == "" {
 		return "", false
 	}
-	// Scan byLocationKind for SCOPE.Schema/field entities whose leaf name
-	// matches. The dotted entity name is "ClassName.fieldName"; we compare
-	// the suffix after the last dot.
+	// Scan byLocationKind .base for SCOPE.Schema/field entities whose leaf
+	// name matches. The dotted entity name is "ClassName.fieldName"; we
+	// compare the suffix after the last dot.
 	var match string
 	for _, fileBucket := range idx.byLocationKind {
-		for entityName, kindBucket := range fileBucket {
+		for entityName, locEnt := range fileBucket {
+			kindBucket := locEnt.base
 			// Check if this entity's leaf matches fieldName.
 			leaf := entityName
 			if dot := strings.LastIndexByte(entityName, '.'); dot >= 0 {
@@ -2287,9 +2317,9 @@ func structuralKindFamilies(scopeKind string) []string {
 // supplied kind families. Returns (id, true) only when exactly one family
 // resolves to a non-blank entity ID for this (file, name).
 //
-// Tiered preference (#525): consults byLocationKindReal first, scanning
+// Tiered preference (#525): consults the .real bucket first, scanning
 // only the non-SCOPE.* members of the family. When that yields a unique
-// real entity, return it without consulting the dual-indexed bucket —
+// real entity, return it without consulting the dual-indexed .base bucket —
 // this is what makes `class Article(TimestampedModel):` bind to the
 // imported real Component even when a SCOPE.Component placeholder for
 // the same name lives in the same file. The fallback tier preserves
@@ -2298,18 +2328,24 @@ func (idx Index) lookupLocationKind(filePath, name string, families []string) (s
 	if len(families) == 0 {
 		return "", false
 	}
-	if realFileBucket := idx.byLocationKindReal[filePath]; realFileBucket != nil {
-		if realNameBucket := realFileBucket[name]; realNameBucket.len() > 0 {
-			if id, ok := uniqueMatchInFamily(realNameBucket, families, false); ok {
-				return id, true
-			}
-		}
-	}
 	fileBucket := idx.byLocationKind[filePath]
 	if fileBucket == nil {
 		return "", false
 	}
-	nameBucket := fileBucket[name]
+	// One map probe now serves both tiers. Hoisting the nil check above
+	// tier 1 is safe because keys(real) ⊆ keys(base) at BOTH levels: a
+	// filePath absent from byLocationKind was necessarily absent from the
+	// pre-merge byLocationKindReal too, so the old tier-1 pass could only
+	// have missed. Likewise a (file, name) the pre-merge byLocationKindReal
+	// never recorded yields an entry whose .real bucket is empty, which the
+	// len() == 0 guard treats exactly as the old absent-bucket miss (#5954).
+	locEnt := fileBucket[name]
+	if locEnt.real.len() > 0 {
+		if id, ok := uniqueMatchInFamily(locEnt.real, families, false); ok {
+			return id, true
+		}
+	}
+	nameBucket := locEnt.base
 	if nameBucket.len() == 0 {
 		return "", false
 	}
@@ -2810,8 +2846,8 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 		// ExternalKnown via the python/ts allowlists. Mirrors the tier-1
 		// preference in lookupByKindHint (#525).
 		if len(families) > 0 {
-			if fileBucket := idx.byLocationKindReal[callerFile]; fileBucket != nil {
-				nameBucket := fileBucket[name]
+			if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
+				nameBucket := fileBucket[name].real
 				var match string
 				ambig := false
 				for _, k := range families {
@@ -2884,7 +2920,7 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 	// collisions remain ambig.
 	if callerFile != "" && strings.ToUpper(relKind) == "CALLS" {
 		if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
-			nameBucket := fileBucket[name]
+			nameBucket := fileBucket[name].base
 			if id, _ := nameBucket.get(scopeKindPrefix + "Operation"); id != "" {
 				return id, true
 			}

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -269,7 +269,6 @@ func MergeModuleBatch(si *SymbolIndex, offset, batchSize int) (Index, int) {
 		byLocation:         make(LocationIndex, total/2+1),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, total/2+1),
-		byLocationKindReal: make(LocationKindIndex, total/2+1),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
@@ -520,7 +519,6 @@ func accumulatorIndex(totalEntities int) Index {
 		byLocation:         make(LocationIndex, cap2),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex, cap2),
-		byLocationKindReal: make(LocationKindIndex, cap2),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
@@ -544,7 +542,6 @@ func emptyIndex() Index {
 		byLocation:         make(LocationIndex),
 		ambigLocation:      make(map[string]map[string]bool),
 		byLocationKind:     make(LocationKindIndex),
-		byLocationKindReal: make(LocationKindIndex),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
 		byPackageOperation: make(map[string]map[string]string),
@@ -631,32 +628,27 @@ func insertModuleEntry(
 	// Location indexes.
 	sf := me.sourceFile
 	if sf != "" {
-		// byLocationKind (both kinds).
+		// byLocationKind — .base carries all kinds (including SCOPE.*),
+		// .real only the original kind. Mirror of BuildIndex's merged
+		// writer (#5954). Stored back by value since locKindEntry lives
+		// inline in the inner map. .base and .real are blanked
+		// independently (the #525 invariant).
 		fileKindBucket := idx.byLocationKind[sf]
 		if fileKindBucket == nil {
-			fileKindBucket = make(map[string]kindIDs)
+			fileKindBucket = make(map[string]locKindEntry)
 			idx.byLocationKind[sf] = fileKindBucket
 		}
-		nameKindBucketLoc := fileKindBucket[me.name]
+		locKindEnt := fileKindBucket[me.name]
 		for _, kind := range kinds {
 			if kind == "" {
 				continue
 			}
-			nameKindBucketLoc.set(kind, me.id)
+			locKindEnt.base.set(kind, me.id)
 		}
-		fileKindBucket[me.name] = nameKindBucketLoc
-
-		// byLocationKindReal — original kind only.
 		if me.kind != "" {
-			realFileBucket := idx.byLocationKindReal[sf]
-			if realFileBucket == nil {
-				realFileBucket = make(map[string]kindIDs)
-				idx.byLocationKindReal[sf] = realFileBucket
-			}
-			realNameBucket := realFileBucket[me.name]
-			realNameBucket.set(me.kind, me.id)
-			realFileBucket[me.name] = realNameBucket
+			locKindEnt.real.set(me.kind, me.id)
 		}
+		fileKindBucket[me.name] = locKindEnt
 
 		// byLocation (kind-agnostic, unique within file).
 		if idx.ambigLocation[sf] == nil || !idx.ambigLocation[sf][me.name] {

--- a/internal/resolve/symbol_index_parity_test.go
+++ b/internal/resolve/symbol_index_parity_test.go
@@ -132,7 +132,6 @@ func indexParityDiff(a, b Index) []string {
 	cmp("byLocation", a.byLocation, b.byLocation)
 	cmp("ambigLocation", a.ambigLocation, b.ambigLocation)
 	cmp("byLocationKind", a.byLocationKind, b.byLocationKind)
-	cmp("byLocationKindReal", a.byLocationKindReal, b.byLocationKindReal)
 	cmp("byQualifiedName", a.byQualifiedName, b.byQualifiedName)
 	cmp("byMember", a.byMember, b.byMember)
 	cmp("byPackageMember", a.byPackageMember, b.byPackageMember)


### PR DESCRIPTION
## What

`internal/resolve` kept a second pair of parallel maps — this time **two-level**, over the identical `(file, name)` key set written in the same loop iteration:

```go
byLocationKind     map[string]map[string]kindIDs   // 54.5 MB at the index peak
byLocationKindReal map[string]map[string]kindIDs   // 60.9 MB
```

Every file key, every name key, and every inner map header was stored twice. They are merged into one two-level map with a struct value:

```go
type locKindEntry struct{ base, real kindIDs }
type LocationKindIndex map[string]map[string]locKindEntry
```

so `merged[file][name].base ≡ old byLocationKind[file][name]` and `.real ≡ old byLocationKindReal[file][name]`, consulted independently at every read site. Pure storage-layout change — no semantic change, no format change.

This is increment 2 of 2, following #5979 (`nameKinds`/`nameKindsReal`). It removes one whole outer map, ~N inner map headers (one per source file), and the duplicate name-key set.

## Why

`resolve.BuildIndex` is the **#1 allocator at the measured index peak** — 368 MB of a 1459 MB live heap during `materializing`. Since the peak is now ~100% Go live heap (`heap_inuse` ≈ RSS, non-Go ≈ 0 after the parse-tree fix), map compaction lands directly on peak RSS rather than on headroom. Estimated ~50–55 MB; the corpus measurement is separate.

## The behavioural change worth reviewing carefully

This is not purely mechanical. `lookupLocationKind` previously checked the *real* outer map inside tier 1 and the *base* outer map at tier 2; with one map the outer nil check is **hoisted above tier 1**. That is only equivalent if `keys(real) ⊆ keys(base)` at the outer file level.

It holds by construction, from both pre-merge writers: the real write is textually nested inside the base write's `if sourceFile != ""` block, in the same loop iteration, with no intervening `continue` and no separate loop; its only extra guard (`Kind != ""`) is a strict narrowing. The same nesting holds at the inner name level — the inner store-back executes unconditionally for any name that reaches the real write. A repo-wide grep confirms `BuildIndex` (`refs.go`) and `insertModuleEntry` (`symbol_index.go`) are the only writers.

The tests do not merely assume this: `assertLocKindMergedMatchesLegacy` mechanically fails if any legacy real key at either level is missing from legacy base, across 4 fixtures × 2 construction paths.

## The hard constraint: #525 independent blanking

`real` is **not** a filtered view of `base`. On a name collision `base` destructively blanks the collided kind to `""`, making the real entity's id unrecoverable from it; `real` preserves it. The merge is safe only because both remain separate `kindIDs` fields, blanked independently exactly as before. `TestLocKindMerge_IndependentBlanking525` asserts the strong form directly: `base.get("Component")` is present-**and-blank** while `real.get("Component")` still yields the real id.

## How equivalence is proven

`lockind_merge_equiv_test.go` replays the **actual pre-merge two-map writers** as an oracle — verbatim guards, the same dual-index kind computation, the same first-writer-wins/blank-on-collision ordering, two genuinely separate maps — and asserts per-key equivalence of `.base`, `.real`, and the presence bit on both construction paths across four fixtures. The reader replays preserve the *original* control flow (tier 1 above the base nil check), so they are a real reference rather than the new code re-spelled.

The M5 mirror (`insertModuleEntry`) is converted in parity; the parity test's full-Index `reflect.DeepEqual` now covers `.real` through the merged struct — verified by mutation (breaking the real write two different ways fails 6 tests each).

## Performance

Paired benchmark over a 200k-entity fixture, `-benchtime 300000x -count=5`:

```
Merged        164.1 168.4 162.8 163.1 173.2 ns/op   0 allocs
LegacyTwoMap  234.4 234.4 233.1 231.1 234.8 ns/op   0 allocs
```

≈30% faster — one two-level probe replaces two, and the saved second hash+bucket walk dominates the wider value copy. (Unlike #5979, where the effect was ~2%, the two-level shape saves a full second traversal.)

## Verification

`go build ./...`, `go vet ./internal/resolve/...`, `gofmt -l internal cmd` clean. `./internal/resolve/...` 2006 pass with and without `-race`; `./cmd/grafel/...` 337 pass, goldens unchanged (graph output byte-identical).

Independently adversarially reviewed: the outer nil-check hoist proven behaviour-preserving by path enumeration against both pre-merge writers, the test oracle verified non-circular against `git show`, all 6 read sites checked field-by-field, and every write site mutation-tested.

Two pre-existing, fixture-limited coverage gaps were surfaced by that mutation testing (not introduced here) and are filed as a follow-up.

Refs #5954
