### PR TITLE
fix(#5941): harden the dashboard disk payload cache (bounded read, byte budget, fan-out cap, wider checksum)

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -238,15 +238,19 @@ group-by). A clean v2 endpoint keeps the two UIs independent. Like v1, it shares
 the server-side payload cache + strong ETag/304 + mux-level gzip (cache keys are
 namespaced with a `v2:` prefix). Pre-serialised payloads are also persisted as
 immutable, checksummed artifacts under
-`~/.grafel/cache/dashboard/v1/<group-hash>/<source-hash>/`. The source hash
+`<grafel-home>/cache/dashboard/v1/<group-hash>/<source-hash>/`, where
+`<grafel-home>` is resolved by `registry.HomeDir()` — `$GRAFEL_HOME` when set,
+otherwise `~/.grafel`. The source hash
 covers the group config, each repo's active graph generation (single-file or
 segment-set), description and flow sidecars, the group algorithm overlay and
 the cross-repo links file. A matching artifact can therefore be served after a
 daemon restart without first materialising the graph; any watched source
 change naturally selects a new source hash. Corrupt or unknown cache files are
 treated as misses and rebuilt asynchronously after the live response is
-generated. Retention is bounded to eight source versions per group and 64
-parameter variants per source version. Entity detail for the inspector still
+generated. Retention is bounded to eight source versions per group, 64
+parameter variants per source version, and a 512 MiB total footprint per group
+(oldest-first eviction) — the byte budget is the bound that holds regardless of
+how many distinct parameter variants a client drives. Entity detail for the inspector still
 uses the v1 `GET /api/graph/{group}/entity/{id}` (unchanged, raw JSON).
 
 ---

--- a/internal/dashboard/payload_disk_cache.go
+++ b/internal/dashboard/payload_disk_cache.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -13,21 +14,57 @@ import (
 )
 
 const (
-	diskPayloadMagic             = "GFPAY01\n"
-	diskPayloadMaxBody           = 1 << 30
-	diskPayloadHeader            = len(diskPayloadMagic) + 4 + 4 + 8 + sha256.Size
+	// diskPayloadMagic also carries the record-format version. Bumping it
+	// retires every record written by an older format: the magic check fails
+	// first, so a stale record is an ordinary miss rather than a record
+	// verified under the wrong rules. 02 widened the checksum from the body
+	// alone to the whole frame.
+	diskPayloadMagic   = "GFPAY02\n"
+	diskPayloadMaxBody = 1 << 30
+	// diskPayloadMaxField caps the key and the etag independently of the body.
+	diskPayloadMaxField = 1 << 20
+	diskPayloadLengths  = 4 + 4 + 8
+	diskPayloadHeader   = len(diskPayloadMagic) + diskPayloadLengths + sha256.Size
+	// diskPayloadMaxRecord is the largest record the framing can legally
+	// describe. Get rejects any file above it on its size alone, before a
+	// single byte is read, so a stray oversized file in the cache directory
+	// cannot be paged into the daemon's heap.
+	diskPayloadMaxRecord         = int64(diskPayloadHeader) + 2*diskPayloadMaxField + diskPayloadMaxBody
 	diskPayloadVersionsPerGroup  = 8
 	diskPayloadVariantsPerSource = 64
+	// diskPayloadAsyncWrites bounds how many persistence goroutines may run at
+	// once across the process. Each one retains an entry whose body can be
+	// large, so the concurrent peak — not the total count — is what matters.
+	diskPayloadAsyncWrites = 4
+	// diskPayloadBytesPerGroup bounds the total on-disk footprint of one group.
+	// The count caps alone cannot: the cache key mixes in client-supplied query
+	// params, and the dashboard is loopback-reachable, so a page in the user's
+	// browser can drive many distinct variants whose reads CORS blocks but
+	// whose writes still land. Bytes, not file counts, are the honest bound on
+	// what ends up on the user's disk.
+	diskPayloadBytesPerGroup = 512 << 20
 )
 
+// diskPayloadWriteSlots bounds the SetAsync goroutine fan-out process-wide. A
+// full semaphore drops the persist instead of waiting: the disk cache is a pure
+// optimisation, a skipped write costs one later rebuild, and the alternative —
+// blocking — would push that wait onto an HTTP handler.
+var diskPayloadWriteSlots = make(chan struct{}, diskPayloadAsyncWrites)
+
 // diskPayloadCache stores immutable pre-serialised HTTP responses. The source
-// version is part of the path and the file header, so memory-pressure eviction
-// never destroys a reusable snapshot and a changed graph can never hit an old
-// response. Corrupt or unknown files are treated as ordinary cache misses.
+// version is part of the path (not of the file itself), so memory-pressure
+// eviction never destroys a reusable snapshot and a changed graph can never hit
+// an old response. Corrupt or unknown files are treated as ordinary cache
+// misses.
 type diskPayloadCache struct {
-	root    string
-	writes  sync.Map // artifact path -> struct{}; coalesces concurrent persistence
-	pruneMu sync.Mutex
+	root string
+	// bytesBudget is the per-group footprint ceiling; tests lower it.
+	bytesBudget int64
+	// asyncHook runs inside a persistence goroutine while it holds a write
+	// slot. Nil outside tests.
+	asyncHook func()
+	writes    sync.Map // artifact path -> struct{}; coalesces concurrent persistence
+	pruneMu   sync.Mutex
 }
 
 func (c *diskPayloadCache) SetAsync(key, sourceVersion string, entry *payloadEntry) {
@@ -38,8 +75,19 @@ func (c *diskPayloadCache) SetAsync(key, sourceVersion string, entry *payloadEnt
 	if _, loaded := c.writes.LoadOrStore(path, struct{}{}); loaded {
 		return
 	}
+	select {
+	case diskPayloadWriteSlots <- struct{}{}:
+	default:
+		// Never block the request path for an optional write.
+		c.writes.Delete(path)
+		return
+	}
 	go func() {
 		defer c.writes.Delete(path)
+		defer func() { <-diskPayloadWriteSlots }()
+		if c.asyncHook != nil {
+			c.asyncHook()
+		}
 		_ = c.Set(key, sourceVersion, entry)
 	}()
 }
@@ -48,7 +96,7 @@ func newDiskPayloadCache(root string) *diskPayloadCache {
 	if root == "" {
 		return nil
 	}
-	return &diskPayloadCache{root: root}
+	return &diskPayloadCache{root: root, bytesBudget: diskPayloadBytesPerGroup}
 }
 
 func (c *diskPayloadCache) Get(key, sourceVersion string) (*payloadEntry, bool) {
@@ -56,46 +104,75 @@ func (c *diskPayloadCache) Get(key, sourceVersion string) (*payloadEntry, bool) 
 	if !ok {
 		return nil, false
 	}
-	data, err := os.ReadFile(path)
-	if err != nil || len(data) < diskPayloadHeader {
+	f, err := os.Open(path)
+	if err != nil {
 		return nil, false
 	}
-	if string(data[:len(diskPayloadMagic)]) != diskPayloadMagic {
+	defer f.Close()
+	// Stat the open handle, not the path: a stat-then-open pair leaves a window
+	// in which the file grows past the ceiling between the two calls.
+	info, err := f.Stat()
+	if err != nil || !info.Mode().IsRegular() {
 		return nil, false
 	}
-	off := len(diskPayloadMagic)
-	keyLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
-	off += 4
-	etagLen := int(binary.LittleEndian.Uint32(data[off : off+4]))
-	off += 4
-	bodyLen := binary.LittleEndian.Uint64(data[off : off+8])
-	off += 8
-	checksum := data[off : off+sha256.Size]
-	off += sha256.Size
-	if keyLen < 1 || keyLen > 1<<20 || etagLen < 1 || etagLen > 1<<20 || bodyLen > diskPayloadMaxBody {
+	size := info.Size()
+	if size < int64(diskPayloadHeader) || size > diskPayloadMaxRecord {
 		return nil, false
 	}
-	wantLen := uint64(off) + uint64(keyLen) + uint64(etagLen) + bodyLen
-	if uint64(len(data)) != wantLen {
+
+	header := make([]byte, diskPayloadHeader)
+	if _, err = io.ReadFull(f, header); err != nil {
 		return nil, false
 	}
-	storedKey := string(data[off : off+keyLen])
-	off += keyLen
-	etag := string(data[off : off+etagLen])
-	off += etagLen
-	body := data[off:]
-	if storedKey != key {
+	if string(header[:len(diskPayloadMagic)]) != diskPayloadMagic {
 		return nil, false
 	}
-	sum := sha256.Sum256(body)
-	if !bytes.Equal(checksum, sum[:]) {
+	lengths := header[len(diskPayloadMagic) : len(diskPayloadMagic)+diskPayloadLengths]
+	checksum := header[len(diskPayloadMagic)+diskPayloadLengths:]
+	keyLen := int(binary.LittleEndian.Uint32(lengths[0:4]))
+	etagLen := int(binary.LittleEndian.Uint32(lengths[4:8]))
+	bodyLen := binary.LittleEndian.Uint64(lengths[8:16])
+	if keyLen < 1 || keyLen > diskPayloadMaxField || etagLen < 1 || etagLen > diskPayloadMaxField || bodyLen > diskPayloadMaxBody {
 		return nil, false
 	}
-	return &payloadEntry{body: body, etag: etag, sourceVersion: sourceVersion}, true
+	// Every declared length is validated, and cross-checked against the file
+	// size, before the record tail is allocated.
+	wantLen := uint64(diskPayloadHeader) + uint64(keyLen) + uint64(etagLen) + bodyLen
+	if uint64(size) != wantLen {
+		return nil, false
+	}
+	tail := make([]byte, keyLen+etagLen+int(bodyLen))
+	if _, err = io.ReadFull(f, tail); err != nil {
+		return nil, false
+	}
+	storedKey := tail[:keyLen]
+	etag := tail[keyLen : keyLen+etagLen]
+	body := tail[keyLen+etagLen:]
+	if string(storedKey) != key {
+		return nil, false
+	}
+	if !bytes.Equal(checksum, diskPayloadChecksum(lengths, storedKey, etag, body)) {
+		return nil, false
+	}
+	return &payloadEntry{body: body, etag: string(etag), sourceVersion: sourceVersion}, true
+}
+
+// diskPayloadChecksum digests the whole frame — magic, declared lengths, key,
+// etag and body — so a bit flip in the metadata is caught too. A body-only
+// digest left the etag unverified, and a wrong ETag is served straight to a
+// browser.
+func diskPayloadChecksum(lengths, key, etag, body []byte) []byte {
+	h := sha256.New()
+	h.Write([]byte(diskPayloadMagic))
+	h.Write(lengths)
+	h.Write(key)
+	h.Write(etag)
+	h.Write(body)
+	return h.Sum(nil)
 }
 
 func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) error {
-	if entry == nil || len(entry.body) > diskPayloadMaxBody || len(key) > 1<<20 || len(entry.etag) > 1<<20 {
+	if entry == nil || len(entry.body) > diskPayloadMaxBody || len(key) > diskPayloadMaxField || len(entry.etag) > diskPayloadMaxField {
 		return nil
 	}
 	path, ok := c.path(key, sourceVersion)
@@ -109,7 +186,12 @@ func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) e
 		return fmt.Errorf("dashboard payload cache mkdir: %w", err)
 	}
 
-	sum := sha256.Sum256(entry.body)
+	lengths := make([]byte, 0, diskPayloadLengths)
+	lengths = binary.LittleEndian.AppendUint32(lengths, uint32(len(key)))
+	lengths = binary.LittleEndian.AppendUint32(lengths, uint32(len(entry.etag)))
+	lengths = binary.LittleEndian.AppendUint64(lengths, uint64(len(entry.body)))
+	sum := diskPayloadChecksum(lengths, []byte(key), []byte(entry.etag), entry.body)
+
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".payload-*.tmp")
 	if err != nil {
 		return fmt.Errorf("dashboard payload cache temp: %w", err)
@@ -118,10 +200,8 @@ func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) e
 	defer os.Remove(tmpPath)
 	header := make([]byte, 0, diskPayloadHeader)
 	header = append(header, diskPayloadMagic...)
-	header = binary.LittleEndian.AppendUint32(header, uint32(len(key)))
-	header = binary.LittleEndian.AppendUint32(header, uint32(len(entry.etag)))
-	header = binary.LittleEndian.AppendUint64(header, uint64(len(entry.body)))
-	header = append(header, sum[:]...)
+	header = append(header, lengths...)
+	header = append(header, sum...)
 	for _, chunk := range [][]byte{header, []byte(key), []byte(entry.etag), entry.body} {
 		if _, err = tmp.Write(chunk); err != nil {
 			_ = tmp.Close()
@@ -153,11 +233,15 @@ func (c *diskPayloadCache) prune(currentPath string) {
 	pruneOldCacheEntries(sourceDir, diskPayloadVariantsPerSource, currentPath, false)
 	groupDir := filepath.Dir(sourceDir)
 	pruneOldCacheEntries(groupDir, diskPayloadVersionsPerGroup, sourceDir, true)
+	// The count caps are the cheap first pass; the byte budget is the bound
+	// that actually holds once variants get large.
+	pruneCacheBytes(groupDir, c.bytesBudget, currentPath)
 }
 
 type cachePathInfo struct {
 	path    string
 	modTime int64
+	size    int64
 }
 
 func pruneOldCacheEntries(dir string, keep int, preserve string, directories bool) {
@@ -188,6 +272,71 @@ func pruneOldCacheEntries(dir string, keep int, preserve string, directories boo
 	sort.Slice(paths, func(i, j int) bool { return paths[i].modTime < paths[j].modTime })
 	for i := 0; i < removeCount && i < len(paths); i++ {
 		_ = os.RemoveAll(paths[i].path)
+	}
+}
+
+// pruneCacheBytes evicts records, oldest mod time first, until the group's
+// total footprint fits budget. It uses the same ordering as
+// pruneOldCacheEntries and honours the same preserve contract: the record the
+// current request just wrote is never a candidate, so a hit is available
+// immediately after a Set even when that one record exceeds the budget alone.
+func pruneCacheBytes(groupDir string, budget int64, preserve string) {
+	if budget <= 0 {
+		return
+	}
+	sourceDirs, err := os.ReadDir(groupDir)
+	if err != nil {
+		return
+	}
+	var total int64
+	candidates := make([]cachePathInfo, 0, len(sourceDirs)*8)
+	for _, dir := range sourceDirs {
+		if !dir.IsDir() {
+			continue
+		}
+		sourceDir := filepath.Join(groupDir, dir.Name())
+		entries, dirErr := os.ReadDir(sourceDir)
+		if dirErr != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				continue
+			}
+			total += info.Size()
+			path := filepath.Join(sourceDir, entry.Name())
+			// A .tmp file belongs to a Set still in flight: it counts towards
+			// the footprint but must never be evicted from under its writer.
+			if path == preserve || !strings.HasSuffix(entry.Name(), ".gpc") {
+				continue
+			}
+			candidates = append(candidates, cachePathInfo{path: path, modTime: info.ModTime().UnixNano(), size: info.Size()})
+		}
+	}
+	if total <= budget {
+		return
+	}
+	sort.Slice(candidates, func(i, j int) bool { return candidates[i].modTime < candidates[j].modTime })
+	for _, candidate := range candidates {
+		if total <= budget {
+			break
+		}
+		if os.Remove(candidate.path) == nil {
+			total -= candidate.size
+		}
+	}
+	// Source-version directories emptied by the eviction would otherwise keep
+	// occupying a slot in the diskPayloadVersionsPerGroup count cap. os.Remove
+	// on a directory fails unless it is already empty, so this cannot discard a
+	// directory another write is populating.
+	for _, dir := range sourceDirs {
+		if dir.IsDir() {
+			_ = os.Remove(filepath.Join(groupDir, dir.Name()))
+		}
 	}
 }
 

--- a/internal/dashboard/payload_disk_cache.go
+++ b/internal/dashboard/payload_disk_cache.go
@@ -26,9 +26,13 @@ const (
 	diskPayloadLengths  = 4 + 4 + 8
 	diskPayloadHeader   = len(diskPayloadMagic) + diskPayloadLengths + sha256.Size
 	// diskPayloadMaxRecord is the largest record the framing can legally
-	// describe. Get rejects any file above it on its size alone, before a
-	// single byte is read, so a stray oversized file in the cache directory
-	// cannot be paged into the daemon's heap.
+	// describe, and Get rejects anything above it on its size alone. It is
+	// belt-and-braces rather than the real bound: because it is defined as
+	// exactly the largest framable record, any file big enough to trip it must
+	// also declare lengths that the per-field caps or the size cross-check
+	// reject, and neither of those allocates either. What actually keeps a
+	// stray oversized file out of the daemon's heap is that the tail is sized
+	// from the *validated* declared lengths, never from the file size.
 	diskPayloadMaxRecord         = int64(diskPayloadHeader) + 2*diskPayloadMaxField + diskPayloadMaxBody
 	diskPayloadVersionsPerGroup  = 8
 	diskPayloadVariantsPerSource = 64
@@ -179,8 +183,17 @@ func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) e
 	if !ok {
 		return nil
 	}
-	if _, err := os.Stat(path); err == nil {
-		return nil // immutable artifact already exists
+	// The immutability shortcut must test "a reader can use what is already
+	// there", not merely "a file exists". The artifact path is a hash of the
+	// key alone, so it does not change when the record format does: a bare
+	// existence check would let a record this build can no longer read — one
+	// written by an older format, or a corrupt one — block its own replacement
+	// forever, and prune only runs after a successful rename, so nothing would
+	// ever reclaim it. Verifying instead makes an unreadable record overwritable
+	// and the cache self-healing. Reaching this at all means the in-memory
+	// lookup missed, so the extra read is off the common path.
+	if _, usable := c.Get(key, sourceVersion); usable {
+		return nil // immutable artifact already exists and is readable
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("dashboard payload cache mkdir: %w", err)
@@ -193,6 +206,19 @@ func (c *diskPayloadCache) Set(key, sourceVersion string, entry *payloadEntry) e
 	sum := diskPayloadChecksum(lengths, []byte(key), []byte(entry.etag), entry.body)
 
 	tmp, err := os.CreateTemp(filepath.Dir(path), ".payload-*.tmp")
+	if err != nil {
+		// MkdirAll above and this CreateTemp are deliberately outside pruneMu,
+		// so a concurrent prune can drop the target directory in between. The
+		// byte-budget sweep no longer removes directories, but the version
+		// count cap still does — pruneOldCacheEntries RemoveAll's whole
+		// source-version directories, which does not even require them to be
+		// empty. Recreate and retry once rather than lose the write; SetAsync
+		// discards the error, so a lost write here would be silent.
+		if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr != nil {
+			return fmt.Errorf("dashboard payload cache mkdir: %w", mkErr)
+		}
+		tmp, err = os.CreateTemp(filepath.Dir(path), ".payload-*.tmp")
+	}
 	if err != nil {
 		return fmt.Errorf("dashboard payload cache temp: %w", err)
 	}
@@ -307,11 +333,20 @@ func pruneCacheBytes(groupDir string, budget int64, preserve string) {
 			if infoErr != nil {
 				continue
 			}
+			// A .tmp file belongs to a Set still in flight. It is deliberately
+			// excluded from the total as well as from the candidates: counting
+			// bytes that cannot be evicted would let a burst of concurrent
+			// writes push the total over budget with nothing attributable to
+			// reclaim, and the loop would then evict every record in the group
+			// and still exit over budget. The overshoot this concedes is
+			// bounded by diskPayloadAsyncWrites in-flight writes and is
+			// reclaimed by the next sweep, once those temps become records.
+			if !strings.HasSuffix(entry.Name(), ".gpc") {
+				continue
+			}
 			total += info.Size()
 			path := filepath.Join(sourceDir, entry.Name())
-			// A .tmp file belongs to a Set still in flight: it counts towards
-			// the footprint but must never be evicted from under its writer.
-			if path == preserve || !strings.HasSuffix(entry.Name(), ".gpc") {
+			if path == preserve {
 				continue
 			}
 			candidates = append(candidates, cachePathInfo{path: path, modTime: info.ModTime().UnixNano(), size: info.Size()})
@@ -329,15 +364,13 @@ func pruneCacheBytes(groupDir string, budget int64, preserve string) {
 			total -= candidate.size
 		}
 	}
-	// Source-version directories emptied by the eviction would otherwise keep
-	// occupying a slot in the diskPayloadVersionsPerGroup count cap. os.Remove
-	// on a directory fails unless it is already empty, so this cannot discard a
-	// directory another write is populating.
-	for _, dir := range sourceDirs {
-		if dir.IsDir() {
-			_ = os.Remove(filepath.Join(groupDir, dir.Name()))
-		}
-	}
+	// Directories this sweep empties are deliberately left in place. Removing
+	// them would race a concurrent Set that has completed its MkdirAll and not
+	// yet created its temp file — os.Remove failing on a non-empty directory is
+	// not the protection it looks like, because in that window the directory
+	// *is* empty. The only thing an empty directory costs is a slot in the
+	// diskPayloadVersionsPerGroup count cap, which already evicts oldest-first
+	// and will reclaim it. An inode is a cheaper price than a lost write.
 }
 
 func (c *diskPayloadCache) path(key, sourceVersion string) (string, bool) {

--- a/internal/dashboard/payload_disk_cache_test.go
+++ b/internal/dashboard/payload_disk_cache_test.go
@@ -3,10 +3,15 @@ package dashboard
 import (
 	"bytes"
 	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -257,5 +262,226 @@ func TestV2GraphRestoresDiskPayloadBeforeLoadingGraph(t *testing.T) {
 	}
 	if len(restarted.entries) != 0 {
 		t.Fatal("graph was materialised even though a valid disk payload existed")
+	}
+}
+
+// --- hardening follow-ups (#5941) --------------------------------------------
+
+// TestDiskPayloadCacheRejectsOversizedRecordWithoutReadingIt covers the read
+// path bound: a file larger than any legal record must be rejected on its size
+// alone, before the body is allocated.
+func TestDiskPayloadCacheRejectsOversizedRecordWithoutReadingIt(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+	)
+	path, ok := cache.path(key, version)
+	if !ok {
+		t.Fatal("expected cache path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.Write([]byte(diskPayloadMagic)); err != nil {
+		t.Fatal(err)
+	}
+	// Sparse: costs no disk, but any implementation that reads before it
+	// validates the length pays for every byte in RAM.
+	if err := f.Truncate(int64(diskPayloadMaxBody) + 4<<20); err != nil {
+		t.Skipf("sparse file unsupported: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	if _, hit := cache.Get(key, version); hit {
+		t.Fatal("oversized cache record must be a miss")
+	}
+	runtime.ReadMemStats(&after)
+	if grew := after.TotalAlloc - before.TotalAlloc; grew > 1<<20 {
+		t.Fatalf("Get allocated %d bytes for an oversized record; it must reject on size before reading the body", grew)
+	}
+}
+
+// TestDiskPayloadCacheEnforcesGroupByteBudget covers the total-footprint bound
+// that the per-directory count caps cannot express.
+func TestDiskPayloadCacheEnforcesGroupByteBudget(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	cache.bytesBudget = 3000
+	const version = "graph-v1"
+	body := bytes.Repeat([]byte("x"), 1000)
+
+	paths := make([]string, 0, 6)
+	for i := 0; i < 6; i++ {
+		key := "assessment::variant-" + string(rune('a'+i))
+		entry := &payloadEntry{body: body, etag: `"etag"`, sourceVersion: version}
+		if err := cache.Set(key, version, entry); err != nil {
+			t.Fatal(err)
+		}
+		path, ok := cache.path(key, version)
+		if !ok {
+			t.Fatal("expected cache path")
+		}
+		// Deterministic oldest-first ordering independent of filesystem
+		// timestamp granularity.
+		stamp := time.Now().Add(time.Duration(i) * time.Minute)
+		if err := os.Chtimes(path, stamp, stamp); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, path)
+	}
+
+	groupDir := filepath.Join(cache.root, shortPayloadHash("assessment"))
+	var total int64
+	survivors := map[string]bool{}
+	sourceDirs, err := os.ReadDir(groupDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, dir := range sourceDirs {
+		entries, dirErr := os.ReadDir(filepath.Join(groupDir, dir.Name()))
+		if dirErr != nil {
+			t.Fatal(dirErr)
+		}
+		for _, entry := range entries {
+			info, infoErr := entry.Info()
+			if infoErr != nil {
+				t.Fatal(infoErr)
+			}
+			total += info.Size()
+			survivors[filepath.Join(groupDir, dir.Name(), entry.Name())] = true
+		}
+	}
+	if total > cache.bytesBudget {
+		t.Fatalf("group footprint = %d bytes, budget %d", total, cache.bytesBudget)
+	}
+	if !survivors[paths[len(paths)-1]] {
+		t.Fatal("the record written by the current request was evicted")
+	}
+	if survivors[paths[0]] {
+		t.Fatal("byte-budget eviction must drop the oldest record first")
+	}
+}
+
+// TestDiskPayloadCacheBoundsAsyncWriteFanOut covers the concurrency bound on
+// SetAsync: bursts must neither exceed the slot count nor block the caller.
+func TestDiskPayloadCacheBoundsAsyncWriteFanOut(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	var inFlight, peak atomic.Int32
+	cache.asyncHook = func() {
+		now := inFlight.Add(1)
+		for {
+			high := peak.Load()
+			if now <= high || peak.CompareAndSwap(high, now) {
+				break
+			}
+		}
+		time.Sleep(2 * time.Millisecond)
+		inFlight.Add(-1)
+	}
+
+	const version = "graph-v1"
+	entry := &payloadEntry{body: []byte(`{"ok":true}`), etag: `"etag"`, sourceVersion: version}
+	start := time.Now()
+	var wg sync.WaitGroup
+	for i := 0; i < 64; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			cache.SetAsync(fmt.Sprintf("assessment::variant-%d", i), version, entry)
+		}(i)
+	}
+	wg.Wait()
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("SetAsync blocked its caller for %v; persistence must never stall a request", elapsed)
+	}
+	waitForDiskPayloadWrites(t, cache)
+	if got := peak.Load(); got > diskPayloadAsyncWrites {
+		t.Fatalf("peak concurrent disk writes = %d, bound %d", got, diskPayloadAsyncWrites)
+	}
+	if peak.Load() == 0 {
+		t.Fatal("no asynchronous write ran")
+	}
+}
+
+// TestDiskPayloadCacheRejectsLegacyRecordFormat covers the record-format bump:
+// the pre-bump framing must read as an ordinary miss, never as a hit and never
+// as a panic.
+func TestDiskPayloadCacheRejectsLegacyRecordFormat(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+		etag    = `"etag-1"`
+	)
+	body := []byte(`{"ok":true}`)
+	path, ok := cache.path(key, version)
+	if !ok {
+		t.Fatal("expected cache path")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Byte-for-byte the record layout shipped in #5941: magic "GFPAY01\n" and
+	// a checksum over the body alone.
+	sum := sha256.Sum256(body)
+	record := make([]byte, 0, 64)
+	record = append(record, "GFPAY01\n"...)
+	record = binary.LittleEndian.AppendUint32(record, uint32(len(key)))
+	record = binary.LittleEndian.AppendUint32(record, uint32(len(etag)))
+	record = binary.LittleEndian.AppendUint64(record, uint64(len(body)))
+	record = append(record, sum[:]...)
+	record = append(record, key...)
+	record = append(record, etag...)
+	record = append(record, body...)
+	if err := os.WriteFile(path, record, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, hit := cache.Get(key, version); hit {
+		t.Fatal("a record in the superseded on-disk format must be a clean miss")
+	}
+}
+
+// TestDiskPayloadCacheDetectsEtagCorruption covers the widened checksum: the
+// body-only digest could not see a flipped etag byte.
+func TestDiskPayloadCacheDetectsEtagCorruption(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+		etag    = `"etag-1"`
+	)
+	entry := &payloadEntry{body: []byte(`{"ok":true}`), etag: etag, sourceVersion: version}
+	if err := cache.Set(key, version, entry); err != nil {
+		t.Fatal(err)
+	}
+	path, ok := cache.path(key, version)
+	if !ok {
+		t.Fatal("expected cache path")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	etagOff := diskPayloadHeader + len(key)
+	if !bytes.Equal(data[etagOff:etagOff+len(etag)], []byte(etag)) {
+		t.Fatalf("etag not at the expected offset: %q", data[etagOff:etagOff+len(etag)])
+	}
+	data[etagOff+2] ^= 0x20
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, hit := cache.Get(key, version); hit {
+		t.Fatalf("a corrupted etag must fail verification, got etag %q", got.etag)
 	}
 }

--- a/internal/dashboard/payload_disk_cache_test.go
+++ b/internal/dashboard/payload_disk_cache_test.go
@@ -267,48 +267,164 @@ func TestV2GraphRestoresDiskPayloadBeforeLoadingGraph(t *testing.T) {
 
 // --- hardening follow-ups (#5941) --------------------------------------------
 
-// TestDiskPayloadCacheRejectsOversizedRecordWithoutReadingIt covers the read
-// path bound: a file larger than any legal record must be rejected on its size
-// alone, before the body is allocated.
-func TestDiskPayloadCacheRejectsOversizedRecordWithoutReadingIt(t *testing.T) {
-	cache := newDiskPayloadCache(t.TempDir())
-	const (
-		key     = "assessment::default"
-		version = "graph-v1"
-	)
-	path, ok := cache.path(key, version)
-	if !ok {
-		t.Fatal("expected cache path")
-	}
+// writeDiskPayloadRecord frames a record exactly as Set does, but with a
+// caller-chosen magic, so tests can build well-formed records that differ from
+// the current format in one specific way.
+func writeDiskPayloadRecord(t *testing.T, path, magic, key, etag string, body []byte, checksum []byte) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	f, err := os.Create(path)
-	if err != nil {
+	record := make([]byte, 0, diskPayloadHeader+len(key)+len(etag)+len(body))
+	record = append(record, magic...)
+	record = binary.LittleEndian.AppendUint32(record, uint32(len(key)))
+	record = binary.LittleEndian.AppendUint32(record, uint32(len(etag)))
+	record = binary.LittleEndian.AppendUint64(record, uint64(len(body)))
+	record = append(record, checksum...)
+	record = append(record, key...)
+	record = append(record, etag...)
+	record = append(record, body...)
+	if err := os.WriteFile(path, record, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := f.Write([]byte(diskPayloadMagic)); err != nil {
-		t.Fatal(err)
-	}
-	// Sparse: costs no disk, but any implementation that reads before it
-	// validates the length pays for every byte in RAM.
-	if err := f.Truncate(int64(diskPayloadMaxBody) + 4<<20); err != nil {
-		t.Skipf("sparse file unsupported: %v", err)
-	}
-	if err := f.Close(); err != nil {
-		t.Fatal(err)
-	}
+}
 
-	var before, after runtime.MemStats
-	runtime.GC()
-	runtime.ReadMemStats(&before)
-	if _, hit := cache.Get(key, version); hit {
-		t.Fatal("oversized cache record must be a miss")
-	}
-	runtime.ReadMemStats(&after)
-	if grew := after.TotalAlloc - before.TotalAlloc; grew > 1<<20 {
-		t.Fatalf("Get allocated %d bytes for an oversized record; it must reject on size before reading the body", grew)
-	}
+// frameChecksum digests a record the way Get will, so a fixture can be made
+// checksum-valid and differ from a real record only in its magic.
+func frameChecksum(key, etag string, body []byte) []byte {
+	lengths := make([]byte, 0, diskPayloadLengths)
+	lengths = binary.LittleEndian.AppendUint32(lengths, uint32(len(key)))
+	lengths = binary.LittleEndian.AppendUint32(lengths, uint32(len(etag)))
+	lengths = binary.LittleEndian.AppendUint64(lengths, uint64(len(body)))
+	return diskPayloadChecksum(lengths, []byte(key), []byte(etag), body)
+}
+
+// TestDiskPayloadCacheRejectsRecordWhoseSizeContradictsItsHeader covers the
+// bound that actually protects the heap: the record tail is sized from the
+// validated declared lengths and cross-checked against the file size, so a file
+// can never be read merely because it is on disk.
+//
+// The diskPayloadMaxRecord ceiling is deliberately NOT what this asserts. That
+// ceiling is defined as the largest framable record, so it is unreachable as a
+// distinct rejection — every file large enough to trip it also declares lengths
+// that the checks below reject, without allocating either.
+func TestDiskPayloadCacheRejectsRecordWhoseSizeContradictsItsHeader(t *testing.T) {
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+		etag    = `"etag-1"`
+	)
+	body := []byte(`{"ok":true}`)
+
+	t.Run("trailing bytes beyond the declared frame", func(t *testing.T) {
+		cache := newDiskPayloadCache(t.TempDir())
+		path, ok := cache.path(key, version)
+		if !ok {
+			t.Fatal("expected cache path")
+		}
+		writeDiskPayloadRecord(t, path, diskPayloadMagic, key, etag, body, frameChecksum(key, etag, body))
+		f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+		if err != nil {
+			t.Fatal(err)
+		}
+		// Every declared length is individually legal and the digest over the
+		// declared frame still verifies; only the file size disagrees.
+		if _, err := f.Write(bytes.Repeat([]byte("\x00"), 4096)); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, hit := cache.Get(key, version); hit {
+			t.Fatal("a record whose file size contradicts its declared lengths must be a miss")
+		}
+	})
+
+	t.Run("declared body length above the cap", func(t *testing.T) {
+		cache := newDiskPayloadCache(t.TempDir())
+		path, ok := cache.path(key, version)
+		if !ok {
+			t.Fatal("expected cache path")
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		bodyLen := uint64(diskPayloadMaxBody) + 1
+		header := make([]byte, 0, diskPayloadHeader)
+		header = append(header, diskPayloadMagic...)
+		header = binary.LittleEndian.AppendUint32(header, uint32(len(key)))
+		header = binary.LittleEndian.AppendUint32(header, uint32(len(etag)))
+		header = binary.LittleEndian.AppendUint64(header, bodyLen)
+		header = append(header, make([]byte, sha256.Size)...)
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write(header); err != nil {
+			t.Fatal(err)
+		}
+		// Sized sparsely so the file size agrees exactly with the declared
+		// lengths, and so it stays under diskPayloadMaxRecord. The per-field
+		// body cap is therefore the only check that can reject this record —
+		// without it, Get would allocate the full declared gigabyte.
+		wantLen := int64(diskPayloadHeader) + int64(len(key)) + int64(len(etag)) + int64(bodyLen)
+		if wantLen > diskPayloadMaxRecord {
+			t.Fatal("fixture must stay under the record ceiling to isolate the body cap")
+		}
+		if err := f.Truncate(wantLen); err != nil {
+			t.Skipf("sparse file unsupported: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		// The miss alone cannot see this guard: without it the record is still
+		// rejected, but only after the declared gigabyte has been allocated and
+		// read. The allocation is the observable property, so assert on it.
+		// TotalAlloc is process-cumulative, so the threshold is deliberately
+		// wide — background goroutines contribute kilobytes here, against a
+		// signal of 1 GiB.
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		if _, hit := cache.Get(key, version); hit {
+			t.Fatal("a declared body length above the cap must be a miss")
+		}
+		runtime.ReadMemStats(&after)
+		if grew := after.TotalAlloc - before.TotalAlloc; grew > 64<<20 {
+			t.Fatalf("Get allocated %d bytes; the tail must be rejected on its declared length, not materialised", grew)
+		}
+	})
+
+	// Documents the diskPayloadMaxRecord early-out. Unlike the subtests above
+	// this one is knowingly not a mutation-killer: deleting the ceiling still
+	// leaves the size-vs-wantLen cross-check to reject the file, and no valid
+	// set of declared lengths can exceed the ceiling in the first place. It is
+	// here to pin the behaviour, not to claim the guard is load-bearing.
+	t.Run("file larger than any framable record", func(t *testing.T) {
+		cache := newDiskPayloadCache(t.TempDir())
+		path, ok := cache.path(key, version)
+		if !ok {
+			t.Fatal("expected cache path")
+		}
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := f.Write([]byte(diskPayloadMagic)); err != nil {
+			t.Fatal(err)
+		}
+		if err := f.Truncate(diskPayloadMaxRecord + 1); err != nil {
+			t.Skipf("sparse file unsupported: %v", err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		if _, hit := cache.Get(key, version); hit {
+			t.Fatal("a file larger than any framable record must be a miss")
+		}
+	})
 }
 
 // TestDiskPayloadCacheEnforcesGroupByteBudget covers the total-footprint bound
@@ -483,5 +599,130 @@ func TestDiskPayloadCacheDetectsEtagCorruption(t *testing.T) {
 
 	if got, hit := cache.Get(key, version); hit {
 		t.Fatalf("a corrupted etag must fail verification, got etag %q", got.etag)
+	}
+}
+
+// TestDiskPayloadCacheReplacesUnreadableRecord covers reclaimability, which is
+// a different property from the clean miss asserted above: the artifact path is
+// a hash of the key alone and does not change with the record format, so a
+// record this build cannot read must not be able to block its own replacement.
+// Without this, every record written before the format bump would wedge its key
+// permanently — Get misses on the magic, Set used to bail on mere existence,
+// and prune only runs after a successful rename.
+func TestDiskPayloadCacheReplacesUnreadableRecord(t *testing.T) {
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+		etag    = `"etag-1"`
+	)
+	body := []byte(`{"ok":true}`)
+
+	cases := map[string]func(t *testing.T, path string){
+		"superseded format": func(t *testing.T, path string) {
+			sum := sha256.Sum256(body) // the body-only digest of GFPAY01
+			writeDiskPayloadRecord(t, path, "GFPAY01\n", key, etag, body, sum[:])
+		},
+		"corrupt checksum": func(t *testing.T, path string) {
+			bad := frameChecksum(key, etag, body)
+			bad[0] ^= 0xff
+			writeDiskPayloadRecord(t, path, diskPayloadMagic, key, etag, body, bad)
+		},
+	}
+	for name, seed := range cases {
+		t.Run(name, func(t *testing.T) {
+			cache := newDiskPayloadCache(t.TempDir())
+			path, ok := cache.path(key, version)
+			if !ok {
+				t.Fatal("expected cache path")
+			}
+			seed(t, path)
+			if _, hit := cache.Get(key, version); hit {
+				t.Fatal("unreadable record must be a miss")
+			}
+
+			fresh := []byte(`{"ok":true,"generation":2}`)
+			if err := cache.Set(key, version, &payloadEntry{body: fresh, etag: `"etag-2"`, sourceVersion: version}); err != nil {
+				t.Fatal(err)
+			}
+			entry, hit := cache.Get(key, version)
+			if !hit {
+				t.Fatal("an unreadable record blocked its own replacement; the key is wedged forever")
+			}
+			if string(entry.body) != string(fresh) || entry.etag != `"etag-2"` {
+				t.Fatalf("stale record survived: body %q etag %q", entry.body, entry.etag)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(data[:len(diskPayloadMagic)]) != diskPayloadMagic {
+				t.Fatalf("on-disk magic = %q, want the current format", data[:len(diskPayloadMagic)])
+			}
+		})
+	}
+}
+
+// TestDiskPayloadCacheRejectsForeignMagic isolates the magic comparison. The
+// fixture is well-formed in every other respect — its digest is the current
+// frame checksum, its lengths and size agree, its key matches — so the magic
+// check is the only thing that can reject it.
+func TestDiskPayloadCacheRejectsForeignMagic(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	const (
+		key     = "assessment::default"
+		version = "graph-v1"
+		etag    = `"etag-1"`
+	)
+	body := []byte(`{"ok":true}`)
+	path, ok := cache.path(key, version)
+	if !ok {
+		t.Fatal("expected cache path")
+	}
+	if len("GFPAY01\n") != len(diskPayloadMagic) {
+		t.Fatal("fixture assumes a fixed-width magic")
+	}
+	writeDiskPayloadRecord(t, path, "GFPAY01\n", key, etag, body, frameChecksum(key, etag, body))
+
+	if _, hit := cache.Get(key, version); hit {
+		t.Fatal("a record carrying a foreign magic must be rejected by the magic check alone")
+	}
+}
+
+// TestDiskPayloadCacheByteSweepLeavesDirectories pins the decision that the
+// byte-budget sweep evicts files but never removes the directories it empties.
+// Removing them would race a concurrent Set sitting between its MkdirAll and
+// its CreateTemp; an empty directory only costs a slot in the version count
+// cap, which reclaims it oldest-first.
+func TestDiskPayloadCacheByteSweepLeavesDirectories(t *testing.T) {
+	cache := newDiskPayloadCache(t.TempDir())
+	cache.bytesBudget = 1
+	body := bytes.Repeat([]byte("x"), 512)
+	for i := 0; i < 3; i++ {
+		version := fmt.Sprintf("graph-v%d", i)
+		key := fmt.Sprintf("assessment::k%d", i)
+		if err := cache.Set(key, version, &payloadEntry{body: body, etag: `"etag"`, sourceVersion: version}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	groupDir := filepath.Join(cache.root, shortPayloadHash("assessment"))
+	dirs, err := os.ReadDir(groupDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(dirs) != 3 {
+		t.Fatalf("source-version directories = %d, want 3 left in place after the sweep", len(dirs))
+	}
+	// The budget still held: only the newest record survives.
+	var files int
+	for _, dir := range dirs {
+		entries, dirErr := os.ReadDir(filepath.Join(groupDir, dir.Name()))
+		if dirErr != nil {
+			t.Fatal(dirErr)
+		}
+		files += len(entries)
+	}
+	if files != 1 {
+		t.Fatalf("records surviving the byte budget = %d, want 1", files)
 	}
 }


### PR DESCRIPTION
## What

Hardening follow-ups on the dashboard disk payload cache contributed in #5941. We committed to doing these ourselves rather than sending another round-trip, so this is our work on top of a contribution that was merged clean.

1. **Bounded read.** `Get` no longer `os.ReadFile`s before any length is known. It opens once, stats the **handle** (not the path — the stat-then-open pair leaves a window in which the file grows past the ceiling), rejects non-regular and short files, `io.ReadFull`s the 56-byte header alone, validates every declared length and cross-checks the declared frame against the file size, and only then allocates the tail. The tail is sized from the *validated declared lengths*, never from the file size.
2. **Per-group byte budget** (`512 MiB`). The existing count caps (64 variants × 8 versions) bound the number of records but not their size; since the cache key includes client-supplied query params on a loopback endpoint, that ceiling can get large on big graphs. Bytes are the actual hazard, so bytes are the bound. Count caps stay as the cheap first pass.
3. **Bounded `SetAsync` fan-out** (4 slots, non-blocking acquire). On a full semaphore the write is **dropped, not queued**: the disk cache is a pure optimisation, a skipped write costs one later rebuild, and blocking would push the wait onto an HTTP handler — the exact thing `SetAsync` exists to avoid.
4. **Widened checksum + format bump.** The digest now covers magic + the 16 length bytes + key + etag + body, not the body alone. Magic bumped `GFPAY01\n` → `GFPAY02\n`.
5. **Docs.** The source version is part of the *path*, not the record; `API_V2.md` now documents the cache location with `<grafel-home>` resolved by `registry.HomeDir()` (`$GRAFEL_HOME`, else `~/.grafel`).

## The bug the review caught, and why it mattered

The format bump alone would have **wedged the cache permanently for existing users**. Old records are a clean miss by design — but the artifact path is `hash(key).gpc`, unchanged by the bump, and `Set` returned early on bare *existence*. So a stale record missed forever *and blocked its own replacement*, while `prune` (only reached after a successful rename) never evicted it. On a repo that isn't changing, with the stable URL set a browser session produces, neither count cap fires either: the cache goes silently dead for exactly the keys it used to serve.

The original test asserted the old format was a clean miss — which was true. "Clean miss" and "reclaimable" are different properties, and only the first was tested.

The fix tests **readability** rather than probing the magic:

```go
if _, usable := c.Get(key, sourceVersion); usable {
    return nil // present *and* readable
}
```

A magic probe would have fixed only the format-bump case and left the identical wedge for a checksum-corrupt record (magic matches, `Get` misses forever, `Set` bails) — the same defect, twice. Unlinking in `Get` was considered and rejected: `Get` takes no lock and `Set`'s rename isn't synchronised against it, so a `Get` that reads stale bytes and then loses the race to a `Set` writing a good record would delete that good record. Reaching this early return implies the disk read already missed, so the full-body read is off the common path — memory-eviction refills promote through `graphPayloadCache.Get`, not through `Set`.

## Verification

Every guard in this change is pinned by a test that demonstrably **fails when the guard is removed** — verified by mutation, independently re-run by the reviewer:

| Mutation | Result |
|---|---|
| `Set` early return → bare `os.Stat` | KILLED |
| magic comparison removed | KILLED |
| `bodyLen` cap removed | KILLED (1073751184 B allocated) |
| `size != wantLen` cross-check removed | KILLED |
| byte-budget sweep removed | KILLED |
| semaphore acquire removed | KILLED |
| frame checksum → body-only | KILLED |
| `preserve` ignored in byte sweep | KILLED |
| directory removal re-added | KILLED |

The single exception is the `diskPayloadMaxRecord` ceiling, which is **structurally unkillable** — it exactly equals the largest framable record, so any file with valid lengths is under it by construction and any file with invalid lengths is rejected earlier without allocating. Both the const comment and the test say so plainly rather than claiming the guard is load-bearing.

Two earlier tests were vacuous and were retargeted: the oversized-read test passed with the ceiling deleted (the fixture's zeroed lengths tripped an earlier guard), and the legacy-format test passed with the magic check deleted (its fixture also carried a stale digest). The replacements isolate the actual property — a fixture with `GFPAY01` magic but a *correct current-format* digest, so only the magic comparison can reject it.

```
go build ./...                          BUILD_OK
go vet ./internal/dashboard/...         VET_OK
gofmt -l internal cmd                   clean
go test ./internal/dashboard/ -count=1  984 passed
go test ./internal/dashboard/ -race     TestHandleGroupStats_NoRef only — pre-existing #5977, confirmed on base
```

Contributor tests: **467 insertions, 0 deletions** against `54ef6abd4` — none weakened or removed.

## Notes

- The empty-directory sweep was **deleted** rather than given a truer comment. Its comment claimed `os.Remove` "cannot discard a directory another write is populating"; that was false (`MkdirAll`/`CreateTemp` run outside `pruneMu`, and a concurrent prune reproducibly deleted an in-flight writer's dir). The `diskPayloadVersionsPerGroup` cap already reclaims empty dirs oldest-first — verified bounded at the cap under a punishing budget — so removing the operation retires the race by construction instead of narrowing it.
- The single `CreateTemp` retry is **not unit-pinned**, deliberately. An adversarial test failed even *with* the fix (EINVAL on APFS, not the modelled ENOENT), so it was deleted rather than kept encoding a false model. The retry is best-effort defence for a rare pre-existing condition whose failure mode is a benign missed cache write.
- A **pre-existing** hazard surfaced while probing this and is filed separately: `pruneOldCacheEntries` `RemoveAll`s whole source-version directories with no emptiness requirement, and `preserve` protects only the current write's dir — nothing protects a concurrent `Set` targeting a different source version. It predates #5941 and is orthogonal to this change.

Closes #5941 follow-ups.
