### PR TITLE
perf(#5954): bound the background-index child's GC pacing with GOGC=50 (-605MB peak RSS)

### DIFF
--- a/cmd/grafel/index_gcpercent.go
+++ b/cmd/grafel/index_gcpercent.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"strconv"
+	"strings"
+)
+
+// indexGCPercentEnv is the operator escape hatch for the GC pacing the
+// `index-internal` child applies to itself. It accepts a positive integer
+// percentage, optionally with a trailing "%" ("50", "35", "60%"). The values
+// "0", "off", "disabled", "none" and "false" mean "apply no cap at all" (leave
+// whatever the Go runtime already has). A malformed value is ignored (logged,
+// never fatal) and the policy default applies instead. Added for #5954,
+// naming and precedence mirror GRAFEL_INDEX_MEMLIMIT.
+const indexGCPercentEnv = "GRAFEL_INDEX_GOGC"
+
+// gcPercentUnset is the sentinel for "do not call debug.SetGCPercent at all".
+// It is distinct from a GOGC of 0 (which the runtime would read as "collect
+// continuously"); we never apply that, and the parser maps "0" to this
+// sentinel precisely so the two cannot be confused.
+const gcPercentUnset = 0
+
+// backgroundIndexCommand is the argv[1] of the hidden subprocess-indexer
+// entrypoint the daemon fork-execs. It is the ONLY command whose GC pacing we
+// cap: background indexing is a batch job nobody is watching, so trading GC
+// CPU for RSS is free there. Interactive/foreground work stays uncapped by
+// standing product decision — a user waiting on a command should not pay GC
+// time to save memory they are not short of.
+const backgroundIndexCommand = "index-internal"
+
+// indexGCPercentDefault is the GC pacing applied to the background index
+// child: next_gc = live * 1.5 instead of the default live * 2.
+//
+// WHY GOGC AND NOT GOMEMLIMIT — this is the crux, and the two are not
+// interchangeable. GOMEMLIMIT is an ABSOLUTE soft target. Set below the
+// workload's live heap it is unsatisfiable, and the runtime answers by running
+// mark cycles back to back forever; this repo measured GOMEMLIMIT=1200MiB
+// against a ~1.7GB live heap running >4x slower and never completing, which is
+// the entire reason indexMemLimitSafeFloorBytes exists. GOGC is a RELATIVE
+// target — next_gc = live * (1 + GOGC/100) — so it is defined in terms of the
+// live heap and therefore CANNOT fall below it, at any value, on any repo.
+// The death-spiral regime is unreachable by construction, not by tuning. That
+// structural difference is why the cap belongs on GOGC.
+//
+// WHY 50 — measured over 6 full corpus runs (.claude/dev/perf/runs, field
+// next_gc in child.ndjson): the live-heap peak is ~1707MB, in `materializing`.
+// Live heap is next_gc/2 at GOGC=100, NOT heap_inuse (3363-3449MB) and not
+// post-GC heap_alloc (up to 2285MB) — both of those include uncollected
+// garbage, and reading a "live heap" off them is the category error that set
+// the old 3GiB safe floor. At GOGC=100 that ~1707MB live heap carried a
+// 3679MB heap_sys; at 50 the steady-state target is ~2560MB. It also matches
+// the value the daemon already runs at (see runDaemonMode), so the two
+// long-lived Go processes in the product are paced the same way.
+const indexGCPercentDefault = 50
+
+// parseIndexGCPercentEnv parses the GRAFEL_INDEX_GOGC escape hatch.
+//
+// decided reports whether the operator expressed a usable intent:
+//   - (n, true)               — apply n percent verbatim
+//   - (gcPercentUnset, true)  — "0"/"off"/"disabled": apply no cap at all
+//   - (0, false)              — unset or malformed: fall through to the policy
+//
+// A negative value is deliberately MALFORMED rather than passed through.
+// debug.SetGCPercent(-1) disables the collector entirely; a knob whose whole
+// purpose is to lower peak RSS must not be a way to switch GC off by typo.
+func parseIndexGCPercentEnv(raw string) (percent int, decided bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return 0, false
+	}
+	switch strings.ToLower(raw) {
+	case "0", "off", "disabled", "false", "none":
+		return gcPercentUnset, true
+	}
+	digits := strings.TrimSpace(strings.TrimSuffix(raw, "%"))
+	n, err := strconv.Atoi(digits)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	if n == 0 {
+		return gcPercentUnset, true
+	}
+	return n, true
+}
+
+// indexGCPercentDecision combines the path guard, the escape hatch and the
+// policy default. The returned source string is operator-facing — it goes
+// straight into the one-shot log line.
+//
+// Precedence, highest first:
+//
+//  1. command is not the background index child -> never capped. This gate is
+//     first on purpose: GRAFEL_INDEX_GOGC tunes the background cap, it does
+//     not create one on the interactive path.
+//  2. GRAFEL_INDEX_GOGC, when well-formed -> the operator's explicit choice.
+//  3. GOGC set explicitly in the environment -> leave the runtime alone. The
+//     runtime has already applied it; overriding would silently discard an
+//     instruction the operator gave in the most standard way there is.
+//  4. otherwise -> indexGCPercentDefault.
+func indexGCPercentDecision(command, rawEnv, rawGOGC string) (percent int, source string) {
+	if command != backgroundIndexCommand {
+		return gcPercentUnset, "interactive/foreground path (" + command + ") — GC pacing is not capped"
+	}
+	if n, decided := parseIndexGCPercentEnv(rawEnv); decided {
+		return n, indexGCPercentEnv + "=" + strings.TrimSpace(rawEnv) + " (env)"
+	}
+	malformed := ""
+	if strings.TrimSpace(rawEnv) != "" {
+		malformed = " (ignored malformed " + indexGCPercentEnv + "=" + strings.TrimSpace(rawEnv) + ")"
+	}
+	if strings.TrimSpace(rawGOGC) != "" {
+		return gcPercentUnset, "GOGC=" + strings.TrimSpace(rawGOGC) + " set by operator, left as-is" + malformed
+	}
+	return indexGCPercentDefault, "policy default" + malformed
+}
+
+// applyIndexGCPercent sets the GC pacing for THIS process before indexing
+// starts, and logs the decision once so a support case can see it immediately
+// (#5954).
+//
+// Scope is the WHOLE child rather than just the memory-heavy phases
+// (materializing / computing_flows). Per-phase scoping would need a
+// set-and-restore pair threaded through Index() for a process-wide runtime
+// side effect, and would buy nothing: the child does one indexing run and then
+// exits, every earlier phase also allocates heavily (extracting_ast peaks at
+// ~1.9GB RSS), and a tighter GOGC in those phases is just as welcome. There is
+// no "after" to restore to, so there is no restore path.
+func applyIndexGCPercent(command, rawEnv, rawGOGC string) {
+	percent, source := indexGCPercentDecision(command, rawEnv, rawGOGC)
+	if percent == gcPercentUnset {
+		fmt.Fprintf(os.Stderr, "index-internal: GC percent not capped (#5954) source=%s\n", source)
+		return
+	}
+	prev := debug.SetGCPercent(percent)
+	fmt.Fprintf(os.Stderr, "index-internal: applied GC percent (#5954) gogc=%d previous=%d source=%s\n",
+		percent, prev, source)
+}

--- a/cmd/grafel/index_gcpercent_test.go
+++ b/cmd/grafel/index_gcpercent_test.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+// The measured corpus figures these tests derive their thresholds from, so
+// that a change to the implementation's own constants cannot silently move the
+// bar (#5954). Source: .claude/dev/perf/runs — 8 full `index-internal` runs
+// (runs/latest/mt-{unlimited,productized}-{1,2,3} plus the earlier
+// runs/mt-unlimited and runs/mt-productized), field `next_gc` in child.ndjson.
+//
+// LIVE HEAP is the number that matters, and it is NOT heap_inuse/heap_alloc —
+// those include uncollected garbage. Go sets next_gc = live * (1 + GOGC/100)
+// at the end of every mark cycle, so with the child running at the GOGC=100
+// default, live = next_gc/2 exactly. Empirically corroborated: across the 881
+// samples of runs/latest/mt-unlimited-1 there is not one sample where
+// heap_alloc < next_gc/2, and over the 109 first-post-GC samples the minimum
+// heap_alloc/(next_gc/2) ratio is 1.003. The harness's orthogonal measure
+// (pprof -inuse_space at `materializing`) reads 1173-1539MB across the six
+// runs/latest runs — same order, and nowhere near 2.7GB.
+//
+// Per-run live peaks, all in the `materializing` phase:
+// 1571 / 1611 / 1674 / 1674 / 1677 / 1682 / 1707 / 1714 MB. We take the worst
+// over ALL runs, 1714MB (runs/mt-unlimited).
+//
+// For contrast, the same runs report heap_inuse up to 3449MB and a post-GC
+// heap_alloc up to 2285MB. Reading a "~2.7GB live heap" off those is a
+// category error; it is what set the memlimit safe floor too high.
+const (
+	// measuredLiveHeapPeakMB is the worst live-heap peak over all 8 runs.
+	measuredLiveHeapPeakMB = int64(1714)
+	// measuredUnlimitedHeapSysMB is the SMALLEST heap_sys peak observed at
+	// GOGC=100 (they range 3679-3783MB). Smallest, deliberately: a bound has
+	// to be below even the most favourable unbounded run to bound anything.
+	measuredUnlimitedHeapSysMB = int64(3679)
+	// measuredThrashLimitMB is the GOMEMLIMIT that made a real run >4x slower
+	// (>16 min vs 235 s) and never complete — 0.70x the live peak.
+	measuredThrashLimitMB = int64(1200)
+)
+
+// TestIndexGCPercentDecision pins the GC-pacing policy (#5954).
+//
+// Precedence, highest first:
+//
+//  1. the command is not the background index child -> NEVER capped
+//  2. GRAFEL_INDEX_GOGC (well-formed)                -> operator wins
+//  3. GOGC set explicitly by the operator            -> leave the runtime alone
+//  4. otherwise                                       -> indexGCPercentDefault
+func TestIndexGCPercentDecision(t *testing.T) {
+	const bg = backgroundIndexCommand
+	cases := []struct {
+		name        string
+		command     string
+		rawEnv      string
+		rawGOGC     string
+		wantPercent int
+		wantSource  string
+	}{
+		{"background child, no env -> policy default", bg, "", "", indexGCPercentDefault, "policy"},
+		{"operator override wins", bg, "35", "", 35, "GRAFEL_INDEX_GOGC"},
+		{"operator override wins over an explicit GOGC", bg, "35", "200", 35, "GRAFEL_INDEX_GOGC"},
+		{"operator override can disable the cap", bg, "off", "", gcPercentUnset, "GRAFEL_INDEX_GOGC"},
+		{"explicit GOGC is respected", bg, "", "200", gcPercentUnset, "GOGC"},
+		{"malformed override falls back to policy", bg, "banana", "", indexGCPercentDefault, "policy"},
+
+		// The standing product decision: background indexing is capped,
+		// interactive/foreground indexing is NOT. The cap must not leak onto any
+		// other command, and not even an explicit GRAFEL_INDEX_GOGC may turn it
+		// on there — the knob tunes the background cap, it does not create one.
+		{"interactive index is not capped", "index", "", "", gcPercentUnset, "interactive"},
+		{"interactive index ignores the override", "index", "35", "", gcPercentUnset, "interactive"},
+		{"daemon is not capped here", "daemon", "", "", gcPercentUnset, "interactive"},
+		{"empty command is not capped", "", "", "", gcPercentUnset, "interactive"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPercent, gotSource := indexGCPercentDecision(tc.command, tc.rawEnv, tc.rawGOGC)
+			if gotPercent != tc.wantPercent {
+				t.Errorf("indexGCPercentDecision(%q, %q, %q) percent = %d, want %d",
+					tc.command, tc.rawEnv, tc.rawGOGC, gotPercent, tc.wantPercent)
+			}
+			if !strings.Contains(gotSource, tc.wantSource) {
+				t.Errorf("indexGCPercentDecision(%q, %q, %q) source = %q, want it to mention %q",
+					tc.command, tc.rawEnv, tc.rawGOGC, gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestParseIndexGCPercentEnv covers the operator escape hatch parser.
+func TestParseIndexGCPercentEnv(t *testing.T) {
+	cases := []struct {
+		name        string
+		raw         string
+		wantPercent int
+		wantDecided bool
+	}{
+		{"empty -> undecided", "", 0, false},
+		{"plain percent", "40", 40, true},
+		{"spaces trimmed", "  75  ", 75, true},
+		{"trailing percent sign", "60%", 60, true},
+		{"off disables the cap", "off", gcPercentUnset, true},
+		{"OFF disables the cap", "OFF", gcPercentUnset, true},
+		{"disabled disables the cap", "disabled", gcPercentUnset, true},
+		{"none disables the cap", "none", gcPercentUnset, true},
+		{"zero disables the cap", "0", gcPercentUnset, true},
+		// Negative would mean "turn GC off entirely" — far outside the intent of
+		// a knob whose job is to LOWER peak RSS. Treat it as malformed so the
+		// policy applies rather than silently shipping a no-GC indexer.
+		{"negative -> malformed", "-1", 0, false},
+		{"garbage -> malformed", "banana", 0, false},
+		{"float -> malformed", "50.5", 0, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPercent, gotDecided := parseIndexGCPercentEnv(tc.raw)
+			if gotPercent != tc.wantPercent || gotDecided != tc.wantDecided {
+				t.Errorf("parseIndexGCPercentEnv(%q) = (%d, %v), want (%d, %v)",
+					tc.raw, gotPercent, gotDecided, tc.wantPercent, tc.wantDecided)
+			}
+		})
+	}
+}
+
+// TestApplyIndexGCPercentActuallyApplies asserts the decision reaches the Go
+// runtime — that the GC percent in force after applyIndexGCPercent equals the
+// policy value, not merely that a pure function returned it.
+//
+// debug.SetGCPercent returns the PREVIOUS value, so a single call both reads
+// the current setting and restores the one we want.
+func TestApplyIndexGCPercentActuallyApplies(t *testing.T) {
+	orig := debug.SetGCPercent(100)
+	t.Cleanup(func() { debug.SetGCPercent(orig) })
+
+	t.Run("background child is capped at the policy value", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent(backgroundIndexCommand, "", "")
+		if got := debug.SetGCPercent(100); got != indexGCPercentDefault {
+			t.Fatalf("GOGC in force after applyIndexGCPercent = %d, want %d", got, indexGCPercentDefault)
+		}
+	})
+
+	t.Run("operator override is what actually reaches the runtime", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent(backgroundIndexCommand, "35", "")
+		if got := debug.SetGCPercent(100); got != 35 {
+			t.Fatalf("GOGC in force after applyIndexGCPercent = %d, want 35", got)
+		}
+	})
+
+	t.Run("interactive path is left untouched", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent("index", "", "")
+		if got := debug.SetGCPercent(100); got != 100 {
+			t.Fatalf("interactive path changed GOGC to %d, want it left at 100", got)
+		}
+	})
+
+	t.Run("explicit GOGC is left untouched", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent(backgroundIndexCommand, "", "200")
+		if got := debug.SetGCPercent(100); got != 100 {
+			t.Fatalf("explicit GOGC was overridden to %d, want it left at 100", got)
+		}
+	})
+}
+
+// TestIndexGCPercentDefaultBoundsTheMeasuredLiveHeap derives the default from
+// the hazard rather than restating the constant.
+//
+// GOGC is a RELATIVE target: next_gc = live * (1 + GOGC/100). Two bounds
+// follow from the measured corpus figures (see measuredLiveHeapPeakMB):
+//
+//   - It must be low enough to actually reduce peak RSS. At GOGC=100 the
+//     measured heap_sys was ~3679MB against a ~1707MB live peak. Anything
+//     that does not bring the steady-state target meaningfully below that is
+//     a no-op change.
+//   - It must be high enough that the collector is not running continuously.
+//     Below ~25% the mark cycle re-runs before the mutator has produced a
+//     working set worth collecting.
+func TestIndexGCPercentDefaultBoundsTheMeasuredLiveHeap(t *testing.T) {
+	targetMB := measuredLiveHeapPeakMB * (100 + indexGCPercentDefault) / 100
+	if targetMB >= measuredUnlimitedHeapSysMB {
+		t.Fatalf("GOGC=%d gives a steady-state target of %dMB against a measured unlimited heap_sys of %dMB — no reduction",
+			indexGCPercentDefault, targetMB, measuredUnlimitedHeapSysMB)
+	}
+	// Require at least a 20% reduction; below that the added GC CPU is not
+	// worth the change.
+	if targetMB > measuredUnlimitedHeapSysMB*80/100 {
+		t.Fatalf("GOGC=%d gives %dMB, less than a 20%% reduction on the measured %dMB",
+			indexGCPercentDefault, targetMB, measuredUnlimitedHeapSysMB)
+	}
+	if indexGCPercentDefault < 25 {
+		t.Fatalf("GOGC=%d is below the continuous-collection floor of 25", indexGCPercentDefault)
+	}
+}

--- a/cmd/grafel/index_memlimit.go
+++ b/cmd/grafel/index_memlimit.go
@@ -212,6 +212,14 @@ const gcThrashCPUThreshold = 0.30
 // When no limit was applied (limit == math.MaxInt64, the runtime default) we
 // stay quiet: high GC CPU then has nothing to do with our tuning and pointing
 // at GRAFEL_INDEX_MEMLIMIT would send a support case down the wrong path.
+//
+// The advice names BOTH knobs, and names the GC-percent one first, because
+// since the GOGC cap landed that is the likelier cause. The soft limit is
+// unreachable on every host that gets one at all (the adaptive policy returns
+// at least 0.75*4GiB = 3GiB, always above the safe floor), whereas the GOGC
+// cap binds on every background index by design and roughly doubles the number
+// of mark cycles. Telling an operator to raise GRAFEL_INDEX_MEMLIMIT when
+// GRAFEL_INDEX_GOGC is what is pacing the collector would waste their time.
 func gcThrashWarning(limit int64, gcFraction float64) string {
 	if limit <= 0 || limit == math.MaxInt64 {
 		return ""
@@ -221,9 +229,11 @@ func gcThrashWarning(limit int64, gcFraction float64) string {
 	}
 	return fmt.Sprintf(
 		"index-internal: WARNING gc_cpu_fraction=%.2f exceeded %.2f with go_soft_memory_limit_mb=%d (#5954). "+
-			"The limit may be below this repo's live heap, which makes the runtime GC continuously. "+
-			"Set GRAFEL_INDEX_MEMLIMIT to a larger value, or to 'off' to disable the limit entirely.",
-		gcFraction, gcThrashCPUThreshold, limit/(1024*1024))
+			"Most likely the GC-percent cap is pacing the collector too aggressively for this repo: "+
+			"raise GRAFEL_INDEX_GOGC (default %d), or set it to 'off'. "+
+			"Less likely, the soft memory limit is below this repo's live heap, which makes the runtime "+
+			"GC continuously: set GRAFEL_INDEX_MEMLIMIT to a larger value, or to 'off' to disable it entirely.",
+		gcFraction, gcThrashCPUThreshold, limit/(1024*1024), indexGCPercentDefault)
 }
 
 // reportGCThrash samples GC CPU once, after indexing has finished, and logs a

--- a/cmd/grafel/index_memlimit_test.go
+++ b/cmd/grafel/index_memlimit_test.go
@@ -25,13 +25,18 @@ func TestResolveIndexMemLimit(t *testing.T) {
 		{"tiny host 1GiB -> unset (do not attempt to bound)", uint64(giB), memLimitUnset},
 		{"small host 3GiB -> unset", uint64(3 * giB), memLimitUnset},
 		{"just under the 4GiB attempt threshold -> unset", uint64(4*giB) - 1, memLimitUnset},
-		{"exactly at the 4GiB threshold -> safe floor 3GiB", uint64(4 * giB), 3 * giB},
-		{"just over the threshold -> safe floor 3GiB", uint64(4*giB) + 1, 3 * giB},
+		// NB: these two are the 0.75*available path, not the floor path. 0.75 of
+		// 4GiB is already 3GiB, so the two coincide here.
+		{"exactly at the 4GiB threshold -> 0.75*available = 3GiB", uint64(4 * giB), 3 * giB},
+		{"just over the threshold -> 0.75*available, still 3GiB", uint64(4*giB) + 1, 3 * giB},
 		// Regression pin for the REQUEST-CHANGES bug: the real value this host
-		// reports. The old max(2GiB, available/2) policy returned 2280MB here,
-		// BELOW the measured ~2.5-2.7GB live heap — i.e. the thrash regime was
-		// the DEFAULT outcome on the measurement machine, not an edge case.
-		{"real host 4560MB -> 3420MB (was 2280MB, below live heap)", uint64(4560 * miB), 3420 * miB},
+		// reports. The old max(2GiB, available/2) policy returned 2280MB here.
+		// That was justified at the time by a "~2.5-2.7GB live heap" reading
+		// which was really heap_inuse/heap_alloc — see measuredLiveHeapPeakMB
+		// for the corrected figure (1714MB), against which 2280MB is 1.33x
+		// live: tight rather than fatal. The 3/4 policy stands regardless; only
+		// the justification for it was wrong.
+		{"real host 4560MB -> 3420MB (was 2280MB, only 1.33x live)", uint64(4560 * miB), 3420 * miB},
 		{"6GiB -> 4.5GiB", uint64(6 * giB), 6 * giB * 3 / 4},
 		{"large host 64GiB -> 48GiB (non-binding, as intended)", uint64(64 * giB), 48 * giB},
 	}
@@ -53,13 +58,18 @@ func TestResolveIndexMemLimit(t *testing.T) {
 // GC CPU. madvdontneed=1 COMPOUNDS it (freed pages go back to the OS and are
 // immediately re-faulted), and the tree-sitter CGo arenas are invisible to
 // GOMEMLIMIT, so the runtime GCs toward a target that non-Go memory
-// guarantees it can never reach. Measured: 1200MiB against a ~2.7GB live heap
-// ran >4x slower (>16 min vs 235 s) and never completed.
+// guarantees it can never reach. Measured: 1200MiB against a 1714MB live heap
+// (0.70x live — see measuredLiveHeapPeakMB) ran >4x slower (>16 min vs 235 s)
+// and never completed.
 //
 // So the trade is asymmetric: a too-low limit costs unbounded, non-terminating
 // time; no limit at all costs a bounded +823MB. The invariant therefore is
-// EITHER unset OR >= 3GiB — never a value in between. The previous
-// ">= 2GiB" form of this test passed on the harmful 2280MB and pinned the bug.
+// EITHER unset OR >= the safe floor — never a value in between.
+//
+// This test restates the implementation constant on purpose: its subject is
+// the "never in between" SHAPE, not the value. The value has to be pinned
+// against the measured hazard instead — an earlier form of this test asserted
+// ">= 2GiB" while the harmful value was 2280MB, so it passed on the bug.
 func TestResolveIndexMemLimitSafeFloorInvariant(t *testing.T) {
 	for avail := uint64(0); avail <= uint64(96*giB); avail += uint64(64 * miB) {
 		got := resolveIndexMemLimit(avail)
@@ -168,8 +178,14 @@ func TestGCThrashWarning(t *testing.T) {
 			if (got != "") != tc.wantWarn {
 				t.Errorf("gcThrashWarning(%d, %v) = %q, wantWarn=%v", tc.limit, tc.fraction, got, tc.wantWarn)
 			}
-			if tc.wantWarn && !strings.Contains(got, "GRAFEL_INDEX_MEMLIMIT") {
-				t.Errorf("warning should name the escape hatch, got %q", got)
+			if tc.wantWarn {
+				// Both knobs, because either can be the cause — and the
+				// GC-percent one is the likelier since the GOGC cap landed.
+				for _, knob := range []string{"GRAFEL_INDEX_GOGC", "GRAFEL_INDEX_MEMLIMIT"} {
+					if !strings.Contains(got, knob) {
+						t.Errorf("warning should name the %s escape hatch, got %q", knob, got)
+					}
+				}
 			}
 		})
 	}

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -34,6 +34,14 @@ func main() {
 		// runIndexInternal is also invoked in-process by the package's tests.
 		// Never fatal.
 		applyIndexMemoryLimit()
+		// Bound GC PACING as well (#5954). The soft memory limit above is an
+		// absolute target and is therefore floored well clear of the live heap;
+		// GOGC is relative (next_gc = live * (1+GOGC/100)) and so does the
+		// actual RSS trimming without any risk of the unsatisfiable-target
+		// death spiral. os.Args[1] is passed explicitly so the "background
+		// only, never interactive" rule is a property of the policy function
+		// and not of this call site. Never fatal.
+		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runIndexInternal(os.Args[2:]))
 	}
 	// Hidden group-level algorithm harness (#5349 A1 / epic #5350). Assembles


### PR DESCRIPTION
## What

Bound the `index-internal` child's GC pacing with **GOGC=50** (`debug.SetGCPercent`), overridable via `GRAFEL_INDEX_GOGC` (accepts `off`/`disabled`/`0` to restore default pacing). Background indexing only — the interactive/foreground path is deliberately left uncapped.

## Why — half the peak was garbage, not data

Peak index RSS was ~3.5 GB, and the epic had been attacking it purely through allocation-site work. The composition turned out to be roughly **half live heap, half GC headroom**:

```
live ≈ 1714 MB   heap_inuse ≈ 3363 MB   heap_sys ≈ 3679 MB   next_gc ≈ 3415 MB
```

The error that hid this was reading `heap_inuse` as live heap. It is not — it is live *plus uncollected garbage in in-use spans*. The exact live figure comes from the Go pacer's own identity: it sets `next_gc = live × (1 + GOGC/100)` at the end of every mark cycle, so at the GOGC=100 default `live = next_gc/2` with no sampling error.

That identity is empirically pinned, not merely cited: across 881 samples of one run, `heap_alloc < next_gc/2` occurs **zero** times, and across the 109 first-post-GC samples the minimum ratio `heap_alloc / (next_gc/2)` is **1.003** — exactly what the identity predicts. An orthogonal measure (`pprof -inuse_space` at `materializing`, 1173–1539 MB across six runs) independently refutes the old "~2.7 GB live heap" reading.

So `RSS ≈ live × 2.06`, and no amount of allocation-site work touches the headroom half.

## Why GOGC and not a lower GOMEMLIMIT

This repo previously measured a **>4× slowdown** from a GOMEMLIMIT of 1200 MiB — an *absolute* soft target set below the live heap is unsatisfiable, so the collector runs continuously without ever reaching its goal. That incident is why the safe floor exists.

GOGC is a *relative* target: `next_gc = live × (1 + GOGC/100)`, which is `> live` for any GOGC ≥ 1. **It cannot enter that regime by construction**, not merely by careful tuning. The failure mode of a too-low GOGC is bounded CPU cost; the failure mode of a too-low GOMEMLIMIT is unbounded. That structural difference is the whole justification, and it is stated in the code.

GOGC=50 also matches what the daemon already runs at (`cmd/grafel/daemon.go:476`), so both long-lived Go processes are now paced identically.

## Measured — 3 reps per config, monorepo corpus, quiet machine

| config | RSS before | RSS after | delta | spread |
|---|---|---|---|---|
| unlimited | 3516 MB | **2911 MB** | **−605 MB (−17%)** | 152 MB |
| productized | 3635 MB | **2925 MB** | **−710 MB (−20%)** | 146 MB |

The delta is ~4× the run spread, so it is resolvable on RSS directly rather than by proxy.

Every falsifier stated up front held:

| check | predicted | measured |
|---|---|---|
| `max(next_gc)` | ~2571 MB | 2424 / 2628 / 2471 MB |
| implied live (`next_gc/1.5`) | 1611–1714 MB | 1616 / 1752 / 1647 MB |
| GC cycles | ~2× | 116 → 249–256 |
| wall time | +2–6% | **+4.7%** (212.8 s → 222.8 s) |

The internal consistency check is the load-bearing one: live heap measured through the *new* pacing (`next_gc/1.5`) lands on the same 1.6–1.75 GB the *old* pacing gave through `next_gc/2`. The lever moved headroom, not data — confirmed independently by `liveheap_mat`, which is flat at 1073 → 1050 MB.

## Cost

+4.7% wall (~+10 s on a ~213 s index) for −605 MB. Accepted deliberately: the driver for this epic is concurrent agent worktrees on a 16 GB laptop shared with the user's real work, where memory is the binding constraint and wall time is not. If a corpus proves worse than +10%, `GRAFEL_INDEX_GOGC=65` is the documented fallback and the test band admits it.

## Verification

`go build ./...`, `go vet ./cmd/...`, `gofmt -l internal cmd` clean; `go test ./cmd/grafel/...` 368 pass, goldens unchanged.

Independently adversarially reviewed: the live-heap identity re-derived from raw NDJSON across all 6 runs, absence of confounding `GOGC`/GOMEMLIMIT clamping verified in the measured runs, and every new test mutation-tested (policy value, command gate, override precedence — each fails when broken). The reviewer confirmed the interactive path cannot be capped even via the operator override, and that the child inherits no `GOGC` that would suppress the cap (`subprocess_runner.go:370` passes `os.Environ()`; the daemon tunes itself via `SetGCPercent`, not an exported `GOGC`).

`gcThrashWarning` now leads with `GRAFEL_INDEX_GOGC` rather than `GRAFEL_INDEX_MEMLIMIT`, since with this cap in force the GC percent is the likelier cause of a high `GCCPUFraction` and raising the memory limit would not help.

Refs #5954
