### PR TITLE
fix(#5954): re-derive the index memlimit safe floor from the true live heap

### DIFF
--- a/cmd/grafel/index_memlimit.go
+++ b/cmd/grafel/index_memlimit.go
@@ -23,9 +23,50 @@ const indexMemLimitEnv = "GRAFEL_INDEX_MEMLIMIT"
 // memLimitUnset is the sentinel for "do not call debug.SetMemoryLimit at all".
 const memLimitUnset int64 = 0
 
-// indexMemLimitSafeFloorBytes is the smallest soft limit we will ever apply.
-// It is ~1.15x the measured ~2.7GB live-heap ceiling of a full corpus index,
-// so the runtime always has room to actually REACH the target.
+// indexMemLimitSafeFloorLiveHeapPeakBytes is the measured LIVE-heap peak of a
+// full corpus index, and the input the safe floor is derived from.
+//
+// WHICH METRIC, AND WHY THE NAME IS EXPLICIT — this used to be an inline
+// "~2.7GB live-heap ceiling" in the comment below. That 2.7GB was a
+// heap_inuse/heap_alloc reading: live PLUS uncollected garbage, not live. Live
+// heap is next_gc/2 while the child runs at the GOGC=100 default, because Go
+// sets next_gc = live * (1 + GOGC/100) at the end of every mark cycle. Across
+// 8 full corpus runs (.claude/dev/perf/runs, child.ndjson) the live-heap peak
+// is 1571-1714MB, always in `materializing`, against a heap_inuse of up to
+// 3449MB and a post-GC heap_alloc of up to 2285MB. We take the worst, 1714MB.
+// An independent pprof -inuse_space sample at the same phase reads
+// 1173-1539MB, confirming the order of magnitude.
+//
+// It is a named constant rather than a number inside the floor so that the
+// unit test can assert the floor is derived from a LIVE-heap figure that
+// matches the harness data — the category error above cannot recur silently.
+const indexMemLimitSafeFloorLiveHeapPeakBytes int64 = 1714 << 20
+
+// indexMemLimitSafeFloorMarginPct is how far above the live heap the smallest
+// soft limit we will ever apply must sit, in percent.
+//
+// 150% is bounded on both sides by the hazard, not by any tuning knob:
+//   - below ~140% the limit approaches the unsatisfiable regime (the measured
+//     death-spiral value, 1200MiB, was 70% of live);
+//   - at 200% it coincides with the heap goal the Go runtime picks unaided at
+//     its GOGC=100 default, so it could never bind on any host.
+//
+// The old 3GiB constant is 179% of the corrected live peak — inside that band,
+// so it was not unsafe, but it was not derivable from its own stated 1.15x
+// rule either. 150% restates the intent against the corrected input.
+const indexMemLimitSafeFloorMarginPct = 150
+
+// indexMemLimitSafeFloorBytes is the smallest soft limit we will ever apply:
+// 1.5x the measured live-heap peak, so the runtime always has room to actually
+// REACH the target.
+//
+// Note this floor does not currently bind for ANY input: the adaptive policy
+// declines to set a limit at all below 4GiB available, and 3/4 of 4GiB is
+// already above it. It stays as an explicit invariant guard so that a future
+// change to the 3/4 multiplier or to indexMemLimitMinAvailableBytes cannot
+// silently start returning a thrashing limit. Since the GOGC cap landed
+// (indexGCPercentDefault) that cap, not this limit, is what actually trims
+// peak RSS.
 //
 // This floor is the anti-thrash guarantee. GOMEMLIMIT is SOFT: set BELOW the
 // live heap, the runtime cannot honor it and instead runs repeated full-heap
@@ -42,37 +83,43 @@ const memLimitUnset int64 = 0
 //     keeps GC'ing toward a target that non-Go memory guarantees it can
 //     never reach.
 //
-// Measured on the real corpus (#5954): GOMEMLIMIT=1200MiB against a ~2.7GB
-// live heap made `index-internal` >4x slower (>16 min vs 235 s) and never
-// completed. So the trade is ASYMMETRIC — a too-low limit costs unbounded,
-// non-terminating time; no limit at all costs a bounded +823MB. Never take
-// the former to avoid the latter.
-const indexMemLimitSafeFloorBytes int64 = 3 << 30 // 3 GiB
+// Measured on the real corpus (#5954): GOMEMLIMIT=1200MiB against a 1714MB
+// live heap (70% of live) made `index-internal` >4x slower (>16 min vs 235 s)
+// and never completed. So the trade is ASYMMETRIC — a too-low limit costs
+// unbounded, non-terminating time; no limit at all costs a bounded +823MB.
+// Never take the former to avoid the latter.
+const indexMemLimitSafeFloorBytes int64 = indexMemLimitSafeFloorLiveHeapPeakBytes * indexMemLimitSafeFloorMarginPct / 100 // 2571MB
 
 // indexMemLimitMinAvailableBytes is the amount of available RAM below which we
-// do not attempt to bound the indexer AT ALL. Under 4GiB available there is no
-// limit that is simultaneously above the safe floor and actually useful, so the
-// honest answer is "unset": degrade to today's unbounded behavior rather than
-// strangle the process. This is the small-host escape valve that the previous
+// do not attempt to bound the indexer AT ALL. Under 4GiB available, 3/4 of
+// available is under 3GiB and closing on the 1714MB live heap, so the honest
+// answer is "unset": degrade to today's unbounded behavior rather than strangle
+// the process. Note this gate is also why the safe floor never binds — it
+// already excludes every input for which 3/4 of available would fall below it. This is the small-host escape valve that the previous
 // max(2GiB, available/2) policy got wrong — it kept returning a limit no matter
 // how little RAM there was.
 const indexMemLimitMinAvailableBytes uint64 = 4 << 30 // 4 GiB
 
 // resolveIndexMemLimit implements the adaptive policy (#5954):
 //
-//	unset                            if available == 0 or available < 4GiB
-//	max(3GiB, availableRAM * 3/4)    otherwise
+//	unset                                if available == 0 or available < 4GiB
+//	max(safeFloor, availableRAM * 3/4)   otherwise
 //
 // availableBytes == 0 means "available RAM could not be determined"; we return
 // memLimitUnset rather than guessing, leaving the Go runtime default in place.
 //
 // Why 3/4 rather than 1/2: on the measurement host (4560MB available) 3/4
-// yields 3420MB — safely ABOVE the ~2.7GB live heap while still ~600MB below
-// the 4026MB unlimited baseline, so it trims the reclaimable arena without
-// entering the thrash regime. 1/2 yielded 2280MB there, i.e. BELOW the live
-// heap: the harmful case was the DEFAULT outcome on that machine, not an edge
-// case. On a 4GB-available host the policy degrades to today's behavior; on a
-// 32GB host it is non-binding, which is correct — the limit exists to trim the
+// yields 3420MB — 2.0x the 1714MB live heap while still ~600MB below the
+// 4026MB unlimited baseline, so it trims the reclaimable arena without
+// entering the thrash regime. 1/2 yields 2280MB there, only 1.33x live, which
+// is inside the band this floor exists to keep us out of.
+//
+// (The original justification for 3/4 said 2280MB was BELOW the live heap.
+// That rested on the same mis-read of heap_inuse as the old safe floor; the
+// conclusion survives the correction, the reasoning did not.)
+//
+// On a 4GB-available host the policy degrades to today's behavior; on a 32GB
+// host it is non-binding, which is correct — the limit exists to trim the
 // reclaimable arena, not to act as a quota.
 //
 // Integer math throughout: a float multiply here would be a needless source of
@@ -167,7 +214,7 @@ func indexMemLimitDecision(rawEnv string, availableBytes uint64) (limit int64, s
 		return resolveIndexMemLimit(availableBytes),
 			"adaptive (ignored malformed " + indexMemLimitEnv + "=" + strings.TrimSpace(rawEnv) + ")"
 	}
-	return resolveIndexMemLimit(availableBytes), "adaptive (max(3GiB, 0.75*available); unset under 4GiB available)"
+	return resolveIndexMemLimit(availableBytes), "adaptive (max(safe floor, 0.75*available); unset under 4GiB available)"
 }
 
 // applyIndexMemoryLimit sets the Go soft memory limit for THIS process (the

--- a/cmd/grafel/index_memlimit_test.go
+++ b/cmd/grafel/index_memlimit_test.go
@@ -190,3 +190,63 @@ func TestGCThrashWarning(t *testing.T) {
 		})
 	}
 }
+
+// TestIndexMemLimitSafeFloorIsDerivedFromMeasuredLiveHeap pins the safe floor
+// against the measured hazard rather than restating the constant.
+//
+// The defect this corrects: the floor was documented as "~1.15x the measured
+// ~2.7GB live-heap ceiling", but 2.7GB was a heap_inuse/heap_alloc reading —
+// live PLUS uncollected garbage. The true live peak is measuredLiveHeapPeakMB.
+// Two consequences: the stated rule no longer produced the stated constant
+// (3072MB is 1.79x live, a margin nobody chose), and the mis-named input
+// invited the same mistake again. The implementation now DERIVES the floor
+// from a named live-heap input times a named margin, so this test can check
+// the derivation instead of the answer.
+//
+// Note what is deliberately NOT asserted here: any bound involving
+// indexGCPercentDefault. A thrash floor is a safety property and must be
+// driven by distance from the hazard alone; making it a dependent of the
+// pacing knob would mean that tuning GOGC down later silently drags the safety
+// floor toward the cliff. The bounds below reference only measured values and
+// the Go runtime's own default pacing.
+func TestIndexMemLimitSafeFloorIsDerivedFromMeasuredLiveHeap(t *testing.T) {
+	if measuredThrashLimitMB >= measuredLiveHeapPeakMB {
+		t.Fatalf("test premise broken: the measured thrash limit %dMB is not below the live peak %dMB",
+			measuredThrashLimitMB, measuredLiveHeapPeakMB)
+	}
+
+	// The input must be the LIVE heap, and it must be the measured one. This is
+	// the assertion that makes the original category error impossible to repeat
+	// silently: swap in a heap_inuse figure and this goes red.
+	if got := indexMemLimitSafeFloorLiveHeapPeakBytes / miB; got != measuredLiveHeapPeakMB {
+		t.Errorf("safe floor is derived from a %dMB live-heap input, but the measured live-heap peak is %dMB",
+			got, measuredLiveHeapPeakMB)
+	}
+
+	// LOWER BOUND — distance from the observed cliff. The measured death-spiral
+	// value was 1200MiB against a 1714MB live peak, i.e. 0.70x live. 1.4x is
+	// double that distance on the safe side.
+	if indexMemLimitSafeFloorMarginPct < 140 {
+		t.Errorf("safe-floor margin %d%% of live is too close to the measured cliff (%dMB = %d%% of live); want >= 140%%",
+			indexMemLimitSafeFloorMarginPct, measuredThrashLimitMB,
+			measuredThrashLimitMB*100/measuredLiveHeapPeakMB)
+	}
+
+	// UPPER BOUND — at 200% the soft limit sits exactly at the heap goal the Go
+	// runtime picks unaided at its GOGC=100 default, so it could never bind on
+	// any host, even with GRAFEL_INDEX_GOGC=off. A floor above that is not a
+	// bound, it is a number. 100 is the runtime's default, not our policy
+	// value, so this bound does not move when the policy is tuned.
+	const goRuntimeDefaultGCPercent = 100
+	if indexMemLimitSafeFloorMarginPct > 100+goRuntimeDefaultGCPercent {
+		t.Errorf("safe-floor margin %d%% of live is at or above the runtime's own unaided heap goal (%d%%) — it could never bind",
+			indexMemLimitSafeFloorMarginPct, 100+goRuntimeDefaultGCPercent)
+	}
+
+	// And the resulting absolute value must be below the most favourable
+	// unbounded run, or it cannot trim the arena on any measured run.
+	if floorMB := indexMemLimitSafeFloorBytes / miB; floorMB >= measuredUnlimitedHeapSysMB {
+		t.Errorf("safe floor %dMB is at or above the smallest measured unbounded heap_sys (%dMB)",
+			floorMB, measuredUnlimitedHeapSysMB)
+	}
+}


### PR DESCRIPTION
## What

Re-derive the GOMEMLIMIT safe floor in `cmd/grafel/index_memlimit.go` from the **true** live-heap peak, and make the derivation explicit in code instead of asserting a hand-picked number.

Split out of #5984 deliberately: that PR's GOGC change is behaviourally load-bearing and measurable; this one is **behaviourally inert** and is a correctness-of-reasoning fix. Keeping them apart let #5984 be measured in isolation.

## Why

The old floor was `3 GiB`, justified by a comment citing a *"measured ~2.7 GB live-heap ceiling"*. That figure was a `heap_inuse` / `heap_alloc` reading, **not live heap** — `heap_inuse` is live *plus uncollected garbage in in-use spans*.

The true live-heap peak, taken from the Go pacer's own identity (`next_gc = live × (1 + GOGC/100)`, so `live = next_gc/2` at the GOGC=100 default), is **1714 MB** — the worst of 8 measured runs (1571 / 1611 / 1674 / 1674 / 1677 / 1682 / 1707 / 1714). An orthogonal measure agrees: `pprof -inuse_space` at `materializing` reads 1173–1539 MB across those runs. The identity is empirically pinned, not merely cited — across 881 samples of one run, `heap_alloc < next_gc/2` occurs **zero** times, and the minimum `heap_alloc / (next_gc/2)` ratio across first-post-GC samples is **1.003**.

So the floor's stated basis was wrong by ~1 GB. This replaces the number with a computation:

```go
const indexMemLimitSafeFloorLiveHeapPeakBytes int64 = 1714 << 20
const indexMemLimitSafeFloorMarginPct         = 150
const indexMemLimitSafeFloorBytes             = ...LiveHeapPeakBytes * ...MarginPct / 100  // 2571MB
```

## Honest framing: this is not a safety win

No hazard bound distinguishes the new 2571 MB from the old 3072 MB — 3072 MB is 1.79× live, comfortably inside the safe band. **The old value was not unsafe; it was underivable from its own stated rule.** That is what this fixes.

It is also **behaviourally inert**: the floor is the returned value for *zero* inputs, at either value. `indexMemLimitMinAvailableBytes = 4 GiB` already excludes everything below `0.75 × 4 GiB = 3072 MiB`, verified by sweeping `resolveIndexMemLimit` over 0–256 GiB on a 1 MiB grid. That note now sits on `indexMemLimitMinAvailableBytes`, since the gate is the actual cause. The floor is an invariant guard against a future change to the multiplier or the min-available gate, not a live bound.

## The test asserts the derivation, not the constant

`TestIndexMemLimitSafeFloorIsDerivedFromMeasuredLiveHeap` bounds the margin from both sides, using **hazard-derived** criteria only:

- **lower**: `margin >= 140%` — twice the distance from the measured death-spiral cliff. The >4× slowdown incident was a 1200 MiB limit against 1714 MB live, i.e. **0.70× live**. A premise assertion pins that the thrash value really is below live, so the test breaks if that relationship is ever edited away.
- **upper**: `margin <= 100 + goRuntimeDefaultGCPercent`, where that constant is literally `100` — the Go runtime's own unaided heap goal. Above 200% the limit could never bind on any host, *including* with `GRAFEL_INDEX_GOGC=off`.
- the absolute value must stay below `measuredUnlimitedHeapSysMB`.

An earlier revision of this change asserted `floor <= live × (1 + indexGCPercentDefault/100)`, which coupled the **safety floor to the pacing knob** — lowering GOGC to 40 in a future tune would have *forced* the safety floor down toward the cliff. That is the wrong direction of dependency and it is gone; `indexGCPercentDefault` is not referenced anywhere in this test, with a comment saying why. 150% now sits mid-band [140, 200] with headroom on both sides.

Mutation-verified all three bounds bite: margin 130 → red on the lower bound, 210 → red on the upper, live input reverted to 2700 → red on both the input assertion and the absolute bound.

## Also corrected

Three comments that carried the same category error, including one in `resolveIndexMemLimit`'s own doc comment still reading *"BELOW the measured ~2.5-2.7GB live heap"*. It now states that 2280 MB is **1.33× live** — tight rather than fatal — and that the `3/4` policy survives but its original reasoning did not. Two test case names claiming to cover the *"safe floor 3GiB"* were renamed to `0.75*available = 3GiB`, since they assert the adaptive result and the floor path is unreachable.

## Verification

`go build ./...`, `go vet ./cmd/...`, `gofmt -l cmd internal` clean; `go test ./cmd/grafel/...` pass, goldens unchanged.

Independently adversarially reviewed as part of #5984, where the reviewer recommended precisely this split and flagged the knob-coupling.

Refs #5954
