### PR TITLE
perf(resolve): build the Django global-wiring name index lazily instead of over all 427k entities

### DIFF
--- a/internal/resolve/django_global_wiring.go
+++ b/internal/resolve/django_global_wiring.go
@@ -61,7 +61,17 @@ func uniqueID(ids []string) string {
 // It is a method on Index because it reads the symbol table. It mutates the
 // Relationships slice of affected EntityRecords in place.
 func (idx Index) ResolveDjangoGlobalWiringRefs(records []types.EntityRecord) int {
+	rewrites, _ := idx.resolveDjangoGlobalWiringRefs(records)
+	return rewrites
+}
+
+// resolveDjangoGlobalWiringRefs is the implementation. It additionally returns
+// the number of times the lazy whole-corpus bare-Name index was materialised,
+// which the #5986 tests assert on: 0 when no edge reaches Strategy 3, and
+// exactly 1 no matter how many edges do.
+func (idx Index) resolveDjangoGlobalWiringRefs(records []types.EntityRecord) (int, int) {
 	rewrites := 0
+	nameIndexBuilds := 0
 
 	// byNameSrc indexes candidate entities by bare Name → list of (id,
 	// sourceFile). Used by the module-qualified leaf fallback (Strategy 3),
@@ -69,16 +79,35 @@ func (idx Index) ResolveDjangoGlobalWiringRefs(records []types.EntityRecord) int
 	// index (e.g. a MiddlewareMixin subclass re-emitted as both a CBV endpoint
 	// and a SCOPE.Pattern, dropping its QualifiedName) by matching the dotted
 	// path's module against the entity's source-file-derived Python module.
+	//
+	// #5986: this is a whole-corpus map (~42-75 MB live on a 427k-entity
+	// corpus) and it is live concurrently with resolve.BuildIndex, so it adds
+	// to the peak heap. It serves ONLY Strategy 3, which requires a global
+	// USES edge with a dotted_path, an unresolved non-hex ToID, AND both
+	// Strategies 1 and 2 missing — conditions no non-Django repo can meet.
+	// So it is built lazily on first Strategy-3 need rather than behind an
+	// early-return guard: a guard would have to restate those conditions and
+	// could drift out of sync with them, whereas laziness is correct by
+	// construction. nameIndex() memoises, so the build is O(entities) ONCE for
+	// the whole pass — never per-edge, which would be O(edges × entities).
 	type nameCand struct {
 		id, src, kind string
 	}
-	byNameSrc := map[string][]nameCand{}
-	for i := range records {
-		e := &records[i]
-		if e.ID == "" || e.Name == "" || e.SourceFile == "" {
-			continue
+	var byNameSrc map[string][]nameCand
+	nameIndex := func() map[string][]nameCand {
+		if byNameSrc != nil {
+			return byNameSrc
 		}
-		byNameSrc[e.Name] = append(byNameSrc[e.Name], nameCand{e.ID, e.SourceFile, e.Kind})
+		byNameSrc = map[string][]nameCand{}
+		nameIndexBuilds++
+		for i := range records {
+			e := &records[i]
+			if e.ID == "" || e.Name == "" || e.SourceFile == "" {
+				continue
+			}
+			byNameSrc[e.Name] = append(byNameSrc[e.Name], nameCand{e.ID, e.SourceFile, e.Kind})
+		}
+		return byNameSrc
 	}
 
 	for k := range records {
@@ -144,7 +173,7 @@ func (idx Index) ResolveDjangoGlobalWiringRefs(records []types.EntityRecord) int
 					// SCOPE.Pattern), so prefer a definition-bearing node and
 					// resolve only when a single best candidate exists.
 					var defIDs, allIDs []string
-					for _, c := range byNameSrc[leaf] {
+					for _, c := range nameIndex()[leaf] {
 						matched := false
 						for _, mod := range modulesForPythonFile(c.src) {
 							if mod == wantModule {
@@ -176,5 +205,5 @@ func (idx Index) ResolveDjangoGlobalWiringRefs(records []types.EntityRecord) int
 			}
 		}
 	}
-	return rewrites
+	return rewrites, nameIndexBuilds
 }

--- a/internal/resolve/django_global_wiring_test.go
+++ b/internal/resolve/django_global_wiring_test.go
@@ -1,0 +1,319 @@
+// django_global_wiring_test.go — unit tests for the Django global-wiring
+// late-binding resolver pass (ResolveDjangoGlobalWiringRefs, issue #4379) and
+// for the laziness of its whole-corpus bare-Name index (issue #5986).
+//
+// The bare-Name index (byNameSrc) serves ONLY Strategy 3 (module-qualified leaf
+// disambiguation). Building it eagerly cost ~42-75 MB live on a 427k-entity
+// corpus even on repos that contain no Django global wiring at all. These tests
+// pin two things at once:
+//
+//  1. the index is materialised only when Strategy 3 is actually reached, and
+//     at most once across the whole pass (never per-edge);
+//  2. when Strategy 3 IS reached, it still selects exactly the same entity ID
+//     the eager implementation selected — including uniqueID's ambiguity
+//     semantics and the SCOPE.Pattern de-prioritisation.
+package resolve
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// globalWiringUsesEdge builds a USES relationship shaped exactly like the ones
+// the Django settings extractor emits for MIDDLEWARE / AUTHENTICATION_BACKENDS
+// / REST_FRAMEWORK DEFAULT_*_CLASSES entries: ToID is the verbatim dotted path,
+// Properties carry global=true, dotted_path and the leaf class_name.
+func globalWiringUsesEdge(dotted, className string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		ToID: dotted,
+		Kind: string(types.RelationshipKindUses),
+		// types.Props is a binary-searched, key-SORTED slice: entries must be
+		// listed in key order or Get misses.
+		Properties: types.Props{
+			{K: "class_name", V: className},
+			{K: "dotted_path", V: dotted},
+			{K: "global", V: "true"},
+		},
+	}
+}
+
+// djangoSettingsRecord wraps edges in the synthetic django_settings entity.
+func djangoSettingsRecord(edges ...types.RelationshipRecord) types.EntityRecord {
+	return types.EntityRecord{
+		ID:            "django-settings-id",
+		Name:          "django_settings",
+		Kind:          "SCOPE.Configuration",
+		SourceFile:    "config/settings.py",
+		Language:      "python",
+		Relationships: edges,
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_Strategy3ModuleQualified is the important
+// test: it exercises the module-qualified leaf disambiguation for real. Two
+// distinct classes share the leaf name AuthMiddleware in different Django apps,
+// so the bare-Name lookup (Strategy 2) is ambiguous and must miss; neither
+// carries a QualifiedName, so Strategy 1 misses too. Only Strategy 3 — matching
+// the dotted path's module against the source-file-derived Python module — can
+// pick the right one.
+func TestResolveDjangoGlobalWiringRefs_Strategy3ModuleQualified(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "id-app-a", Name: "AuthMiddleware", Kind: "SCOPE.Component",
+			Subtype: "class", SourceFile: "apps/a/middleware.py", Language: "python",
+		},
+		{
+			ID: "id-app-b", Name: "AuthMiddleware", Kind: "SCOPE.Component",
+			Subtype: "class", SourceFile: "apps/b/middleware.py", Language: "python",
+		},
+		djangoSettingsRecord(globalWiringUsesEdge("apps.a.middleware.AuthMiddleware", "AuthMiddleware")),
+	}
+
+	idx := BuildIndex(records)
+
+	// Guard the premise: Strategies 1 and 2 must both miss, otherwise this
+	// test would silently stop covering Strategy 3.
+	if id, ok := idx.Lookup("apps.a.middleware.AuthMiddleware"); ok && id != "" {
+		t.Fatalf("premise broken: Strategy 1 resolved the dotted path to %q", id)
+	}
+	if id, ok := idx.Lookup("AuthMiddleware"); ok && id != "" {
+		t.Fatalf("premise broken: Strategy 2 resolved the ambiguous leaf to %q", id)
+	}
+
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != 1 {
+		t.Errorf("rewrites = %d, want 1", rewrites)
+	}
+	if got := records[2].Relationships[0].ToID; got != "id-app-a" {
+		t.Errorf("ToID = %q, want id-app-a", got)
+	}
+	if builds != 1 {
+		t.Errorf("name-index builds = %d, want 1 (Strategy 3 was reached)", builds)
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_NoGlobalEdges_NeverBuildsNameIndex is the
+// memory regression guard: a corpus with no Django global-wiring edges must
+// never materialise the whole-corpus bare-Name index.
+func TestResolveDjangoGlobalWiringRefs_NoGlobalEdges_NeverBuildsNameIndex(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "id-1", Name: "Handler", Kind: "SCOPE.Component",
+			SourceFile: "svc/handler.go", Language: "go",
+			Relationships: []types.RelationshipRecord{
+				// A plain USES edge with no global marker.
+				{ToID: "id-2", Kind: string(types.RelationshipKindUses)},
+				// A CALLS edge, wrong kind entirely.
+				{ToID: "some.dotted.Path", Kind: string(types.RelationshipKindCalls)},
+			},
+		},
+		{
+			ID: "id-2", Name: "Store", Kind: "SCOPE.Component",
+			SourceFile: "svc/store.go", Language: "go",
+		},
+	}
+
+	idx := BuildIndex(records)
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != 0 {
+		t.Errorf("rewrites = %d, want 0", rewrites)
+	}
+	if builds != 0 {
+		t.Errorf("name-index builds = %d, want 0 (no global wiring edges exist)", builds)
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_EarlyStrategies_NeverBuildNameIndex checks
+// that global-wiring edges resolvable by Strategy 1 (QualifiedName) or
+// Strategy 2 (unique leaf name) short-circuit before the index is needed.
+func TestResolveDjangoGlobalWiringRefs_EarlyStrategies_NeverBuildNameIndex(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "id-qualified", Name: "TraceMiddleware", Kind: "SCOPE.Component",
+			QualifiedName: "apps.obs.middleware.TraceMiddleware",
+			SourceFile:    "apps/obs/middleware.py", Language: "python",
+		},
+		{
+			ID: "id-unique-leaf", Name: "AuditBackend", Kind: "SCOPE.Component",
+			SourceFile: "apps/audit/backends.py", Language: "python",
+		},
+		djangoSettingsRecord(
+			// Strategy 1: resolves via QualifiedName.
+			globalWiringUsesEdge("apps.obs.middleware.TraceMiddleware", "TraceMiddleware"),
+			// Strategy 2: dotted path misses, but the leaf name is globally unique.
+			globalWiringUsesEdge("thirdparty.vendored.AuditBackend", "AuditBackend"),
+			// Skipped before any strategy: no dotted_path property.
+			types.RelationshipRecord{
+				ToID: "nope.Whatever", Kind: string(types.RelationshipKindUses),
+				Properties: types.Props{{K: "global", V: "true"}},
+			},
+		),
+	}
+
+	idx := BuildIndex(records)
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != 2 {
+		t.Errorf("rewrites = %d, want 2", rewrites)
+	}
+	if got := records[2].Relationships[0].ToID; got != "id-qualified" {
+		t.Errorf("edge 0 ToID = %q, want id-qualified", got)
+	}
+	if got := records[2].Relationships[1].ToID; got != "id-unique-leaf" {
+		t.Errorf("edge 1 ToID = %q, want id-unique-leaf", got)
+	}
+	if builds != 0 {
+		t.Errorf("name-index builds = %d, want 0 (Strategy 3 never reached)", builds)
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_NameIndexBuiltAtMostOnce pins the O(entities)
+// bound: a naive lazy build placed inside the edge loop would rebuild the map
+// for every qualifying edge, turning a memory win into an O(edges × entities)
+// time regression. Many Strategy-3 edges, exactly one build.
+func TestResolveDjangoGlobalWiringRefs_NameIndexBuiltAtMostOnce(t *testing.T) {
+	const apps = 12
+
+	var records []types.EntityRecord
+	var edges []types.RelationshipRecord
+	for i := 0; i < apps; i++ {
+		// Every app defines a class with the SAME leaf name, so the bare-name
+		// lookup is ambiguous for all of them and every edge reaches Strategy 3.
+		records = append(records, types.EntityRecord{
+			ID:      fmt.Sprintf("id-app-%d", i),
+			Name:    "SharedMiddleware",
+			Kind:    "SCOPE.Component",
+			Subtype: "class",
+			// Also give each app a second, differently-named ambiguous class so
+			// the corpus is not degenerate.
+			SourceFile: fmt.Sprintf("apps/app%d/middleware.py", i),
+			Language:   "python",
+		})
+		edges = append(edges, globalWiringUsesEdge(
+			fmt.Sprintf("apps.app%d.middleware.SharedMiddleware", i), "SharedMiddleware"))
+	}
+	settingsIdx := len(records)
+	records = append(records, djangoSettingsRecord(edges...))
+
+	idx := BuildIndex(records)
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != apps {
+		t.Errorf("rewrites = %d, want %d", rewrites, apps)
+	}
+	if builds != 1 {
+		t.Errorf("name-index builds = %d, want exactly 1 across %d Strategy-3 edges", builds, apps)
+	}
+	for i := 0; i < apps; i++ {
+		want := fmt.Sprintf("id-app-%d", i)
+		if got := records[settingsIdx].Relationships[i].ToID; got != want {
+			t.Errorf("edge %d ToID = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_Strategy3AmbiguousSameModule pins uniqueID's
+// ambiguity semantics: two DISTINCT entity IDs whose source files derive the
+// same Python module leave the edge unresolved (External synthesis handles it
+// downstream). The index is still built — Strategy 3 was reached — it just
+// declines to pick.
+func TestResolveDjangoGlobalWiringRefs_Strategy3AmbiguousSameModule(t *testing.T) {
+	dotted := "apps.a.middleware.AuthMiddleware"
+	records := []types.EntityRecord{
+		{
+			ID: "id-dup-1", Name: "AuthMiddleware", Kind: "SCOPE.Component",
+			SourceFile: "apps/a/middleware.py", Language: "python",
+		},
+		{
+			ID: "id-dup-2", Name: "AuthMiddleware", Kind: "SCOPE.Operation",
+			SourceFile: "apps/a/middleware.py", Language: "python",
+		},
+		djangoSettingsRecord(globalWiringUsesEdge(dotted, "AuthMiddleware")),
+	}
+
+	idx := BuildIndex(records)
+	if id, ok := idx.Lookup("AuthMiddleware"); ok && id != "" {
+		t.Fatalf("premise broken: Strategy 2 resolved the leaf to %q", id)
+	}
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != 0 {
+		t.Errorf("rewrites = %d, want 0 (two distinct IDs in the same module is ambiguous)", rewrites)
+	}
+	if got := records[2].Relationships[0].ToID; got != dotted {
+		t.Errorf("ToID = %q, want it left as the dotted path %q", got, dotted)
+	}
+	if builds != 1 {
+		t.Errorf("name-index builds = %d, want 1 (Strategy 3 was reached and declined)", builds)
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_Strategy3PrefersDefinitionOverPattern pins
+// the SCOPE.Pattern de-prioritisation: when the same module holds both a
+// synthetic SCOPE.Pattern anchor and a real definition node for the leaf,
+// the definition wins even though allIDs would be ambiguous.
+func TestResolveDjangoGlobalWiringRefs_Strategy3PrefersDefinitionOverPattern(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "id-pattern", Name: "CacheMiddleware", Kind: "SCOPE.Pattern",
+			SourceFile: "apps/a/middleware.py", Language: "python",
+		},
+		{
+			ID: "id-definition", Name: "CacheMiddleware", Kind: "SCOPE.Operation",
+			SourceFile: "apps/a/middleware.py", Language: "python",
+		},
+		// A same-named class in another app keeps the bare-name lookup ambiguous.
+		{
+			ID: "id-other-app", Name: "CacheMiddleware", Kind: "SCOPE.Component",
+			SourceFile: "apps/b/middleware.py", Language: "python",
+		},
+		djangoSettingsRecord(globalWiringUsesEdge("apps.a.middleware.CacheMiddleware", "CacheMiddleware")),
+	}
+
+	idx := BuildIndex(records)
+	rewrites, builds := idx.resolveDjangoGlobalWiringRefs(records)
+	if rewrites != 1 {
+		t.Fatalf("rewrites = %d, want 1", rewrites)
+	}
+	if got := records[3].Relationships[0].ToID; got != "id-definition" {
+		t.Errorf("ToID = %q, want id-definition (SCOPE.Pattern must not win)", got)
+	}
+	if builds != 1 {
+		t.Errorf("name-index builds = %d, want 1", builds)
+	}
+}
+
+// TestResolveDjangoGlobalWiringRefs_ExportedWrapperMatchesInternal guards the
+// exported entry point used by the pipeline (cmd/grafel/index.go) against the
+// internal build-counting variant drifting apart.
+func TestResolveDjangoGlobalWiringRefs_ExportedWrapperMatchesInternal(t *testing.T) {
+	mk := func() []types.EntityRecord {
+		return []types.EntityRecord{
+			{
+				ID: "id-app-a", Name: "AuthMiddleware", Kind: "SCOPE.Component",
+				SourceFile: "apps/a/middleware.py", Language: "python",
+			},
+			{
+				ID: "id-app-b", Name: "AuthMiddleware", Kind: "SCOPE.Component",
+				SourceFile: "apps/b/middleware.py", Language: "python",
+			},
+			djangoSettingsRecord(globalWiringUsesEdge("apps.b.middleware.AuthMiddleware", "AuthMiddleware")),
+		}
+	}
+
+	viaExported := mk()
+	gotExported := BuildIndex(viaExported).ResolveDjangoGlobalWiringRefs(viaExported)
+
+	viaInternal := mk()
+	gotInternal, _ := BuildIndex(viaInternal).resolveDjangoGlobalWiringRefs(viaInternal)
+
+	if gotExported != gotInternal {
+		t.Errorf("exported rewrites = %d, internal = %d", gotExported, gotInternal)
+	}
+	if got := viaExported[2].Relationships[0].ToID; got != "id-app-b" {
+		t.Errorf("exported ToID = %q, want id-app-b", got)
+	}
+	if viaExported[2].Relationships[0].ToID != viaInternal[2].Relationships[0].ToID {
+		t.Errorf("exported ToID = %q, internal ToID = %q",
+			viaExported[2].Relationships[0].ToID, viaInternal[2].Relationships[0].ToID)
+	}
+}


### PR DESCRIPTION
## What

`ResolveDjangoGlobalWiringRefs` built a whole-corpus `byNameSrc` index over **all ~427k entities** at function entry. That map serves **only Strategy 3** (module-qualified leaf disambiguation), which requires a `global="true"` USES edge whose dotted path resolves at neither Strategy 1 nor Strategy 2. It is now built lazily by a memoising closure at the single Strategy-3 use site.

Cost removed on repos that never reach Strategy 3: **41.78–74.76 MB** live at the index peak, concurrent with `resolve.BuildIndex` (allocated at `cmd/grafel/index.go:4869`, immediately after `idx` at `:4851`), so it was genuinely additive to the peak.

Lazy rather than an early-return guard deliberately: a guard has to re-derive the conditions under which Strategy 3 fires and can drift out of sync with them; laziness is correct by construction.

## Behaviour identity

The build loop body is **byte-identical** to the original (verified by diffing the extracted loop against `git show` of the base — differs only by one leading tab per line), so candidate append order into `uniqueID` is unchanged by construction and its tie-breaking cannot shift. `uniqueID` itself is untouched. The Strategy-3 tail differs in exactly two lines: the map read becomes `nameIndex()[leaf]`, and the internal helper returns a build counter for test observability. No skip condition, no reordering, no changed guard.

Verified against a **real Django corpus** (differential, old binary vs new, indexed read-only into a scratch dir):

| | before | after |
|---|---|---|
| `django-global-wiring rewrote=` | 3 | 3 |
| entities / relationships | 15555 / 54320 | 15555 / 54320 |
| global-wiring USES edges | 26 | 26 |
| sha256 over canonical sorted entity set | `0154…` | identical |
| sha256 over canonical sorted relationship set | `3e9e…` | identical |
| per-edge `to_id` mismatches | — | **0** |

Whole-graph sets are hash-identical, not merely count-identical — a wrong-but-plausible ID would pass a count check and fail this one.

## Scope of the win — stated precisely

On that real Django corpus, **24 of 26 edges reach Strategy 3**, so the map is still built there. The saving applies to repos where no global-wiring edge reaches Strategy 3 — i.e. non-Django repos, and Django repos whose wiring resolves at Strategy 1/2. That is the common case, and it is where the profile evidence was taken.

Worth recording because it is counter-intuitive: `rewrites=0` does **not** imply `builds=0`. On the Django corpus, 24 reaches produced 0 rewrites (third-party `django.*` / `rest_framework.*` paths correctly decline to resolve). So a zero-rewrite log line is not evidence the map went unbuilt.

`nameIndexBuilds=1` across those 24 reaches — the at-most-once guarantee holds on real input, not only in a fixture. A naive lazy build inside the edge loop would have been O(edges × entities); that is pinned by a test and by mutation.

## Tests

Seven tests in a new `django_global_wiring_test.go` — there was **no prior direct unit coverage of this pass**. The red step was load-bearing: with the build still eager, every behaviour assertion passed and *only* the two laziness assertions failed, proving the fixtures pin the lazy path rather than merely testing the skip.

Premise guards are `t.Fatalf` (not `Errorf`): the fixture must miss at both `idx.Lookup(dotted)` and `idx.Lookup(leaf)`, so if it ever drifted into being resolvable earlier the test aborts instead of silently ceasing to cover Strategy 3.

Mutation-tested, 4/4 killed: memoisation guard removed (12 builds vs 1); module match forced true; forced false; `SCOPE.Pattern` de-prioritisation removed.

The zero-indexable-entity case (no record has all of ID/Name/SourceFile) memoises correctly — the map is assigned a composite literal before the loop, so it is non-nil even when every record is skipped. Verified empirically, not just reasoned.

## Sibling pass

`ResolveDjangoStringFKRefs` (`internal/resolve/django_fk.go`) does **not** share the flaw — it allocates only an `int` counter and resolves through the already-built `Index`. No change needed.

## Known coverage gap

Strategy 3 resolved **zero** edges on real Django input, so per-ID correctness of the Strategy-3 branch is pinned only by synthetic fixtures. Separately, `internal/custom/python/issue4379_livedrepro_test.go` resolves at Strategy **2**, not 3 — proven by mutation (killing Strategy 3 entirely leaves both `TestIssue4379*` tests green), so it would pass with the lazy map deleted. Filed as a follow-up.

## Verification

`go build ./...`, `go vet ./internal/resolve/...`, `gofmt -l internal cmd` clean. `internal/resolve` 2013 pass, also under `-race`; `internal/custom/python` 398 pass; `cmd/grafel` 367 pass, goldens unchanged.

Closes #5986
Refs #5954
