### PR TITLE
perf(index): release the per-pass entity backing arrays as buildDocument consumes them

### DIFF
--- a/cmd/grafel/builddocument_golden_5955_test.go
+++ b/cmd/grafel/builddocument_golden_5955_test.go
@@ -119,7 +119,7 @@ func canonicalDocHash(t *testing.T, doc *graph.Document) string {
 func TestBuildDocumentGolden5955(t *testing.T) {
 	pass1, pass2Rels := buildDocumentGoldenFixture()
 	idx := &Indexer{repoTag: "test_repo"}
-	doc := idx.buildDocument(pass1, nil, pass2Rels, nil)
+	doc := idx.buildDocument(&pass1, nil, pass2Rels, nil)
 
 	// Sanity: the fixture must have exercised the Bazel overlay (a
 	// BAZEL_DEP_STATUS edge must be present), otherwise target-1 is not

--- a/cmd/grafel/builddocument_pass_release_5985_test.go
+++ b/cmd/grafel/builddocument_pass_release_5985_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #5985 — buildDocument used to hold the three per-pass entity backing
+// arrays alive for its whole duration, alongside the merged copy built from
+// them. Both were live at the index peak (~165 MB of pass-slice spine +
+// ~183 MB of `merged` on a large corpus).
+//
+// The hazard is a LIFETIME one, not a size one: the pass slices must stop being
+// reachable from buildDocument's frame the moment their records have been
+// appended into `merged`. These tests assert exactly that release, plus the
+// invariant that releasing early changes nothing about what buildDocument
+// computes.
+
+// recordsFixture returns three distinguishable per-pass slices.
+func passReleaseFixture() (p1, p2, p3 []types.EntityRecord) {
+	p1 = []types.EntityRecord{
+		{Kind: "Function", Name: "p1a", SourceFile: "a.go"},
+		{Kind: "Function", Name: "p1b", SourceFile: "a.go"},
+	}
+	p2 = []types.EntityRecord{
+		{Kind: "Class", Name: "p2a", SourceFile: "b.go"},
+	}
+	p3 = []types.EntityRecord{
+		{Kind: "Class", Name: "p3a", SourceFile: "c.go"},
+		{Kind: "Class", Name: "p3b", SourceFile: "c.go"},
+		{Kind: "Class", Name: "p3c", SourceFile: "c.go"},
+	}
+	return p1, p2, p3
+}
+
+// TestMergePassRecordsReleasesEachSlice is the direct hazard assertion: the
+// merge helper must nil out each caller-owned slice header as it consumes it,
+// so the per-pass backing array becomes unreachable while `merged` is live.
+// Asserted on the release itself (the slice headers), not on a memory proxy.
+func TestMergePassRecordsReleasesEachSlice(t *testing.T) {
+	p1, p2, p3 := passReleaseFixture()
+	wantNames := []string{"p1a", "p1b", "p2a", "p3a", "p3b", "p3c"}
+
+	merged := mergePassRecords(&p1, &p2, &p3)
+
+	if p1 != nil {
+		t.Errorf("pass1 slice not released: len=%d cap=%d (backing array still reachable from buildDocument's frame)", len(p1), cap(p1))
+	}
+	if p2 != nil {
+		t.Errorf("pass2 slice not released: len=%d cap=%d", len(p2), cap(p2))
+	}
+	if p3 != nil {
+		t.Errorf("pass3 slice not released: len=%d cap=%d", len(p3), cap(p3))
+	}
+
+	if len(merged) != len(wantNames) {
+		t.Fatalf("merged len = %d, want %d", len(merged), len(wantNames))
+	}
+	for i, want := range wantNames {
+		if merged[i].Name != want {
+			t.Fatalf("merged[%d].Name = %q, want %q (append order regression: pass1, then pass2, then pass3)", i, merged[i].Name, want)
+		}
+	}
+}
+
+// TestMergePassRecordsIdenticalToPlainAppend guards against any content or
+// ordering divergence from the pre-change `append(pass1...); append(pass2...);
+// append(pass3...)` behaviour, including the no-dedup property (the helper must
+// NOT drop anything — dedup happens later, keyed on stamped IDs).
+func TestMergePassRecordsIdenticalToPlainAppend(t *testing.T) {
+	p1, p2, p3 := passReleaseFixture()
+	// Add an exact duplicate across passes: the merge step must keep both.
+	p2 = append(p2, p1[0])
+
+	want := make([]types.EntityRecord, 0, len(p1)+len(p2)+len(p3))
+	want = append(want, p1...)
+	want = append(want, p2...)
+	want = append(want, p3...)
+
+	got := mergePassRecords(&p1, &p2, &p3)
+
+	if len(got) != len(want) {
+		t.Fatalf("merged len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].Kind != want[i].Kind || got[i].Name != want[i].Name || got[i].SourceFile != want[i].SourceFile {
+			t.Fatalf("merged[%d] = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}
+
+// TestMergePassRecordsNilPointers — the caller may legitimately pass an absent
+// pass (the unit tests and the daemon single-stream path both do).
+func TestMergePassRecordsNilPointers(t *testing.T) {
+	p1, _, _ := passReleaseFixture()
+	got := mergePassRecords(&p1, nil, nil)
+	if len(got) != 2 {
+		t.Fatalf("merged len = %d, want 2", len(got))
+	}
+	if p1 != nil {
+		t.Errorf("pass1 slice not released with nil siblings")
+	}
+	if got := mergePassRecords(nil, nil, nil); len(got) != 0 {
+		t.Fatalf("all-nil merge returned %d records, want 0", len(got))
+	}
+}
+
+// TestBuildDocumentReleasesPassSlices drives the real buildDocument (the golden
+// #5955 fixture, so the produced Document is hash-checked by
+// TestBuildDocumentGolden5955) and asserts the caller's slice variable is nil
+// once buildDocument returns — i.e. the release happens inside buildDocument
+// rather than at cmd/grafel/index.go:1754.
+func TestBuildDocumentReleasesPassSlices(t *testing.T) {
+	pass1, pass2Rels := buildDocumentGoldenFixture()
+	pass2 := []types.EntityRecord{{Kind: "Function", Name: "fromPass2", SourceFile: "p2.go"}}
+	pass3 := []types.EntityRecord{{Kind: "Function", Name: "fromPass3", SourceFile: "p3.go"}}
+
+	idx := &Indexer{repoTag: "test_repo"}
+	doc := idx.buildDocument(&pass1, &pass2, pass2Rels, &pass3)
+
+	if pass1 != nil {
+		t.Errorf("pass1 still held after buildDocument returned (len=%d)", len(pass1))
+	}
+	if pass2 != nil {
+		t.Errorf("pass2 still held after buildDocument returned (len=%d)", len(pass2))
+	}
+	if pass3 != nil {
+		t.Errorf("pass3 still held after buildDocument returned (len=%d)", len(pass3))
+	}
+
+	// The pass2/pass3 records must still be in the output — releasing the
+	// spine must not drop payload.
+	var sawP2, sawP3 bool
+	for k := range doc.Entities {
+		switch doc.Entities[k].Name {
+		case "fromPass2":
+			sawP2 = true
+		case "fromPass3":
+			sawP3 = true
+		}
+	}
+	if !sawP2 || !sawP3 {
+		t.Fatalf("pass2/pass3 entities missing from Document: sawP2=%v sawP3=%v", sawP2, sawP3)
+	}
+}
+
+// TestBuildDocumentIncrementalCarryForwardUnaffected — the incremental path
+// makes a SECOND full copy of `merged` (index.go:4826) to seed the resolver
+// index with carried-forward unchanged-file entities. Releasing the pass slices
+// must not change that behaviour: the carry-forward entities are index-only
+// (never appended to the Document) and the Document must be identical to the
+// non-incremental run over the same passes.
+func TestBuildDocumentIncrementalCarryForwardUnaffected(t *testing.T) {
+	carry := []types.EntityRecord{{
+		ID:         graph.EntityID("test_repo", "Class", "CarriedService", "unchanged/svc.ts"),
+		Kind:       "Class",
+		Name:       "CarriedService",
+		SourceFile: "unchanged/svc.ts",
+	}}
+
+	// Baseline: no carry-forward.
+	p1, r1 := buildDocumentGoldenFixture()
+	base := (&Indexer{repoTag: "test_repo"}).buildDocument(&p1, nil, r1, nil)
+	baseHash := canonicalDocHash(t, base)
+
+	// Same passes, with carry-forward entities seeded.
+	p2, r2 := buildDocumentGoldenFixture()
+	inc := &Indexer{repoTag: "test_repo", incrementalCarryForwardEntities: carry}
+	incDoc := inc.buildDocument(&p2, nil, r2, nil)
+
+	if p2 != nil {
+		t.Errorf("pass1 not released on the incremental path (len=%d)", len(p2))
+	}
+	for k := range incDoc.Entities {
+		if incDoc.Entities[k].Name == "CarriedService" {
+			t.Fatalf("carry-forward entity leaked into the Document — it is resolver-index-only (mergeIncrementalPrevDoc re-adds it, so emitting here double-emits)")
+		}
+	}
+	if got := canonicalDocHash(t, incDoc); got != baseHash {
+		t.Fatalf("carry-forward run diverged from baseline: %s != %s", got, baseHash)
+	}
+	// The carry-forward slice itself must survive — it is read again by the
+	// resolver-index construction and is owned by the Indexer, not by the pass.
+	if len(inc.incrementalCarryForwardEntities) != 1 {
+		t.Fatalf("incrementalCarryForwardEntities clobbered: len=%d, want 1", len(inc.incrementalCarryForwardEntities))
+	}
+}

--- a/cmd/grafel/dedup_qname_edges_4406_test.go
+++ b/cmd/grafel/dedup_qname_edges_4406_test.go
@@ -96,10 +96,8 @@ func TestDedup4406_QNameAndEdgesSurviveDedup(t *testing.T) {
 	caller := types.EntityRecord{Kind: "Function", Name: "save_contract", SourceFile: "core/services.py", StartLine: 3}
 
 	idx := dedup4406Indexer()
-	doc := idx.buildDocument(
-		[]types.EntityRecord{survivor, duplicate, field, caller},
-		nil, nil, nil,
-	)
+	pass1 := []types.EntityRecord{survivor, duplicate, field, caller}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
 
 	got := findEntity(t, doc.Entities, id)
 
@@ -175,7 +173,8 @@ func TestDedup4406_SurvivorQNameNotOverridden(t *testing.T) {
 	}
 
 	idx := dedup4406Indexer()
-	doc := idx.buildDocument([]types.EntityRecord{survivor, duplicate}, nil, nil, nil)
+	pass1 := []types.EntityRecord{survivor, duplicate}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
 	got := findEntity(t, doc.Entities, id)
 	if got.QualifiedName != "app.User" {
 		t.Fatalf("survivor QualifiedName = %q; want survivor's own app.User preserved (not overridden by duplicate)", got.QualifiedName)
@@ -200,7 +199,8 @@ func TestDedup4406_NonDuplicateUnchanged(t *testing.T) {
 	other := types.EntityRecord{Kind: "Class", Name: "Line", SourceFile: srcFile, StartLine: 20}
 
 	idx := dedup4406Indexer()
-	doc := idx.buildDocument([]types.EntityRecord{ent, other}, nil, nil, nil)
+	pass1 := []types.EntityRecord{ent, other}
+	doc := idx.buildDocument(&pass1, nil, nil, nil)
 
 	got := findEntity(t, doc.Entities, id)
 	if got.QualifiedName != "Lib::Order" {

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -1662,7 +1662,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 
 	// Pass 5 — build document (deduped).
 	trk.PhaseStart(progress.PhaseMaterialize, len(files), 0)
-	doc := i.buildDocument(pass1Records, pass2Records, pass2Rels, pass3Records)
+	doc := i.buildDocument(&pass1Records, &pass2Records, pass2Rels, &pass3Records)
 
 	// #2719 — incremental merge: when this run processed only the changed
 	// subset of files, splice the unchanged-file portion of the previous
@@ -1751,6 +1751,14 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Metadata maps and embedded Relationship slices; releasing them
 	// before the resolver-classification + Pass 4 algorithms cuts the
 	// peak by roughly the merged-set size on entity-dense repos.
+	//
+	// #5985 — pass1Records / pass2Records / pass3Records are ALREADY nil here:
+	// buildDocument takes them by pointer and releases each one the instant it
+	// has copied it into `merged` (mergePassRecords), so the duplicate spine is
+	// collectable during buildDocument instead of only after it returns. The
+	// assignments below are kept for pass2Rels (still passed by value) and as a
+	// belt-and-braces statement of the "dead after buildDocument" contract —
+	// nothing between the buildDocument call above and this point may read them.
 	pass1Records = nil
 	pass2Records = nil
 	pass2Rels = nil
@@ -4646,14 +4654,52 @@ func useModuleResolveIndex() bool {
 	}
 }
 
+// mergePassRecords concatenates the per-pass entity records into one slice, in
+// canonical pass order (pass1, pass2, pass3), and RELEASES each caller-owned
+// slice header as soon as its records have been copied.
+//
+// #5985 — the copy into the merged slice is SHALLOW: every record's Properties
+// / Metadata / Tags / embedded Relationships live on unchanged in the merged
+// copy. Dropping the caller's header therefore frees only the duplicate spine
+// (the per-pass backing arrays — ~165 MB on a large corpus, where `merged`
+// itself is ~183 MB), never any entity payload. Before this, both spines stayed
+// live for the whole of buildDocument because the caller did not release the
+// pass slices until well after buildDocument returned.
+//
+// A nil pointer means "this pass produced nothing" (unit tests and the daemon's
+// single-stream path both rely on that).
+func mergePassRecords(pass1, pass2, pass3 *[]types.EntityRecord) []types.EntityRecord {
+	n := lenRecords(pass1) + lenRecords(pass2) + lenRecords(pass3)
+	merged := make([]types.EntityRecord, 0, n)
+	merged = appendAndRelease(merged, pass1)
+	merged = appendAndRelease(merged, pass2)
+	merged = appendAndRelease(merged, pass3)
+	return merged
+}
+
+func lenRecords(p *[]types.EntityRecord) int {
+	if p == nil {
+		return 0
+	}
+	return len(*p)
+}
+
+// appendAndRelease appends *src to dst and then drops the caller's reference to
+// src's backing array. See mergePassRecords for why this is safe.
+func appendAndRelease(dst []types.EntityRecord, src *[]types.EntityRecord) []types.EntityRecord {
+	if src == nil {
+		return dst
+	}
+	dst = append(dst, *src...)
+	*src = nil
+	return dst
+}
+
 // buildDocument merges entity records from every pass, dedupes by stable
 // graph-entity ID, resolves cross-file CALLS edges, then assembles the
 // final on-disk document.
-func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []types.RelationshipRecord, pass3 []types.EntityRecord) *graph.Document {
-	merged := make([]types.EntityRecord, 0, len(pass1)+len(pass2)+len(pass3))
-	merged = append(merged, pass1...)
-	merged = append(merged, pass2...)
-	merged = append(merged, pass3...)
+func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []types.RelationshipRecord, pass3 *[]types.EntityRecord) *graph.Document {
+	merged := mergePassRecords(pass1, pass2, pass3)
 
 	// Issue #481 — the merged slice drives BuildIndex's first-writer-wins
 	// disambiguation. Sort by canonical fields so identically-named entities


### PR DESCRIPTION
## What

`buildDocument` held the per-pass entity backing arrays alive alongside the merged copy built from them — both live at the index peak:

- `cmd/grafel/index.go:3427` — `allRecords = append(allRecords, ents...)`, **165.11 MB** flat, still live in the `materializing` profile across all 3 measured reps.
- `cmd/grafel/index.go:4653` — `merged := make([]types.EntityRecord, 0, len(pass1)+len(pass2)+len(pass3))`, **183.27 MB**, byte-identical across reps (533.7k records × 360 B — `EntityRecord` size probed directly at 360 B).

They overlapped because the caller did not drop `pass1Records`/`pass2Records`/`pass3Records` until `index.go:1754-1757`, long after `buildDocument` returned at `:1665`.

The pass slices are now passed by pointer and released as they are consumed, via `mergePassRecords` + `appendAndRelease`.

The copy into `merged` is **shallow**, so this reclaims the duplicate *spine* only — no entity payload is freed. That is exactly the ~165 MB, and it is why the change cannot lose data.

## Why a helper rather than three inline `= nil` statements

`appendAndRelease` makes the release the *same expression* as the consumption — you cannot append without releasing — and it is unit-testable without driving the whole 500-line `buildDocument`. A `nil` pointer means "this pass produced nothing", which keeps existing call sites (`buildDocument(&pass1, nil, rels, nil)`) working unchanged; `lenRecords` returns 0 and `appendAndRelease` returns `dst` untouched, exactly equivalent to appending a nil slice.

## The load-bearing question: is the memory actually unreachable?

Nil-ing one variable frees nothing if another reference survives, so every candidate retainer was traced:

| holder | verdict |
|---|---|
| `runPass1ExtractWithProgress` → `allRecords` | frame-local; declared `:3241`, returned `:3478`, no other use |
| `engine.BuildCrossFileFieldLookup(pass1Records)` | **no retention** — the returned closure captures a fresh `map[string][]EntityRecord` of value copies (`internal/engine/field_index.go:110-132`), not the slice |
| `Indexer` fields | none — the only `[]EntityRecord` field is `incrementalCarryForwardEntities`, built from `prev.Entities` copies |
| `pass1ByFile` / `FileInput.Pass1Entities` | new arrays of value copies |
| `concatRecords(...)` (4 sites) | **no aliasing** — always `make`s a new array (`index.go:5486-5499`) |

No sub-slice escapes into anything longer-lived; no goroutine, cache, or global holds one. The `:1665`–`:1754` span was read in full: it operates on `doc` (incremental prev-doc merge, migration prune, opt-in `--ingest-docs`), never on the pass slices.

## TDD

Red for the right reason: with the pointer signature in place but `*src = nil` omitted — `pass1 slice not released: len=2 cap=2`, `pass1 still held after buildDocument returned (len=7)`, `pass1 not released on the incremental path (len=7)`.

Assertions are on the release itself (nil slice header) and on the full concatenation in pass order, including a deliberate cross-pass duplicate to catch an accidental dedup at merge time. No size thresholds and no implementation constants — a prior test in this epic asserted `>= 2GiB` while the harmful value was 2280MB, pinning the bug instead of catching it.

## Verification

`go build ./...`, `go vet ./cmd/...`, `gofmt -l internal cmd` clean. `cmd/grafel` **372 pass**, `internal/...` **9208 pass** across 59 packages.

**Goldens unchanged, and the golden was not adjusted to fit**: the entire diff to `builddocument_golden_5955_test.go` is one insertion and one deletion — the call site gaining `&` — with `const want = "b6aa628c…c9c55"` byte-identical to base.

Independently adversarially reviewed. Mutation-tested with no survivors: removing `*src = nil` fails 4 tests; reordering the appends fails 2; appending carry-forward into `merged` is caught; disabling the carry-forward augmentation is caught by the pre-existing `TestNestJSControllerDIPipeline_Incremental`.

## Expected effect, stated honestly

~165 MB live ≈ ~250 MB RSS at the GOGC=50 pacing landed in #5984. The tests prove the reference is dropped at consumption time; they cannot prove the collector reclaims it before the peak. There is a forced `runtime.GC()` at `index.go:1661` *before* `buildDocument`, so the heap goal is set with the pass arrays still live and the release then happens inside a ~0.5×live allocation budget. Post-release allocation before the `BuildIndex` peak is substantial (three-plus maps sized to `len(merged)` in HTTP endpoint resolution, `stampEntityIDs` over 533k IDs, `BuildImportTable`, `ResolveImports`, `BuildIndex`), so a cycle should fire — but this is pacing-dependent, so expect *most* of the 165 MB rather than a guarantee. The measurement will settle it, and a second forced `runtime.GC()` after the merge is the deterministic fallback if it comes in short.

`pass2Rels` is deliberately left by value: it is read, appended to, and mutated in place until `index.go:5247`, so releasing it early would free nothing — and at 80 B/record it is ~1/7 the size of the entity spine, consistent with its absence from the profile.

Closes #5985
Refs #5954
