### PR TITLE
perf(#5954): instrument group-algo with memtrace, then pace it with GOGC=50 + madvdontneed

### DIFF
--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/memtrace"
 )
 
 func runGroupAlgo(args []string) int {
@@ -57,6 +58,22 @@ func runGroupAlgo(args []string) int {
 	// Windows. The GOMAXPROCS cap is applied by the parent (env, default 2);
 	// nice is best-effort self-renice so it holds however the child is spawned.
 	sched.NiceSelf()
+
+	// #5954 / #5956 memtrace: opt-in phase-tagged memstats sampler + per-phase
+	// heap profiles, gated entirely behind GRAFEL_MEMTRACE_DIR (which this child
+	// inherits, since its env derives from the daemon's os.Environ()). Start
+	// returns nil — no goroutine, no file — when the var is unset, so this is
+	// zero overhead by default.
+	//
+	// WHY THIS EXISTS. Whole-machine measurement put the memory peak entirely
+	// POST-index: at the peak instant the index child is at 0MB while this
+	// process is one of the two largest on the box, and it reported NOTHING.
+	// The phase comes from groupalgo.CurrentPhase, stamped by the pass itself,
+	// mirroring how the index child feeds memtrace from progress.Tracker's
+	// CurrentPhase — one source of phase state, so the trace cannot drift.
+	// Best-effort: no memtrace failure can affect the result or the exit code.
+	memSampler := memtrace.Start("group-algo", groupalgo.CurrentPhase, memtraceLogf)
+	defer memSampler.Stop()
 
 	// --diff (#5349 A4): run the differential validator (per-repo-old vs
 	// group-new) and emit a machine-readable JSON report on stdout. It writes
@@ -113,6 +130,7 @@ func runGroupAlgo(args []string) int {
 	}
 
 	if write {
+		groupalgo.SetPhase(groupalgo.PhaseWritingOverlay)
 		if werr := groupalgo.WriteOverlayFromResult(res); werr != nil {
 			fmt.Fprintf(os.Stderr, "grafel group-algo: write overlay: %v\n", werr)
 			return 1

--- a/cmd/grafel/group_algo_memory_test.go
+++ b/cmd/grafel/group_algo_memory_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"runtime/debug"
+	"strings"
+	"testing"
+)
+
+// The GC-pacing cap was originally scoped to the `index-internal` child alone
+// (#5954). Whole-machine measurement then showed the peak instant has moved
+// entirely POST-index: the index child is at 0MB while `group-algo` is one of
+// the two largest processes on the box. group-algo is the second background,
+// nobody-is-watching batch child in the product, so the same standing trade —
+// spend GC CPU where no human is waiting, to buy RSS — applies verbatim.
+//
+// These tests are written against the HAZARD (an uncapped background child /
+// a cap leaking onto an interactive command), not against the implementation's
+// constants.
+
+// TestBackgroundGCPercentCommandsCoverBothChildren asserts the gate is a SET
+// covering every background child the daemon fork-execs, and that it does not
+// admit anything else.
+func TestBackgroundGCPercentCommandsCoverBothChildren(t *testing.T) {
+	background := []string{"index-internal", "group-algo"}
+	for _, cmd := range background {
+		if !isBackgroundGCPercentCommand(cmd) {
+			t.Errorf("isBackgroundGCPercentCommand(%q) = false, want true — it is a background batch child and must be capped", cmd)
+		}
+	}
+	// Everything a human can be waiting on must stay out of the set. These are
+	// the real argv[1] values on the interactive/foreground paths.
+	interactive := []string{"", "index", "rebuild", "daemon", "serve", "engine", "mcp", "doctor", "selftest", "group-algorithm", "group"}
+	for _, cmd := range interactive {
+		if isBackgroundGCPercentCommand(cmd) {
+			t.Errorf("isBackgroundGCPercentCommand(%q) = true, want false — interactive/foreground work is never capped", cmd)
+		}
+	}
+}
+
+// TestGroupAlgoGCPercentDecision pins the policy for the group-algo child. It
+// is the same precedence ladder the index child already has; the point of the
+// test is that group-algo actually rides it.
+func TestGroupAlgoGCPercentDecision(t *testing.T) {
+	const ga = "group-algo"
+	cases := []struct {
+		name        string
+		command     string
+		rawEnv      string
+		rawGOGC     string
+		wantPercent int
+		wantSource  string
+	}{
+		{"group-algo child, no env -> policy default", ga, "", "", indexGCPercentDefault, "policy"},
+		{"operator override wins", ga, "35", "", 35, "GRAFEL_INDEX_GOGC"},
+		{"operator override wins over an explicit GOGC", ga, "35", "200", 35, "GRAFEL_INDEX_GOGC"},
+		{"operator override can disable the cap", ga, "off", "", gcPercentUnset, "GRAFEL_INDEX_GOGC"},
+		{"explicit GOGC is respected", ga, "", "200", gcPercentUnset, "GOGC"},
+		{"malformed override falls back to policy", ga, "banana", "", indexGCPercentDefault, "policy"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotPercent, gotSource := indexGCPercentDecision(tc.command, tc.rawEnv, tc.rawGOGC)
+			if gotPercent != tc.wantPercent {
+				t.Errorf("indexGCPercentDecision(%q, %q, %q) percent = %d, want %d",
+					tc.command, tc.rawEnv, tc.rawGOGC, gotPercent, tc.wantPercent)
+			}
+			if !strings.Contains(gotSource, tc.wantSource) {
+				t.Errorf("indexGCPercentDecision(%q, %q, %q) source = %q, want it to mention %q",
+					tc.command, tc.rawEnv, tc.rawGOGC, gotSource, tc.wantSource)
+			}
+		})
+	}
+}
+
+// TestApplyGroupAlgoGCPercentReachesTheRuntime asserts the decision actually
+// lands in the Go runtime for a group-algo invocation, not merely that a pure
+// function returned it. debug.SetGCPercent returns the PREVIOUS value, so one
+// call both reads the setting and restores the one we want.
+func TestApplyGroupAlgoGCPercentReachesTheRuntime(t *testing.T) {
+	orig := debug.SetGCPercent(100)
+	t.Cleanup(func() { debug.SetGCPercent(orig) })
+
+	t.Run("group-algo child is capped at the policy value", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent("group-algo", "", "")
+		if got := debug.SetGCPercent(100); got != indexGCPercentDefault {
+			t.Fatalf("GOGC in force after applyIndexGCPercent(group-algo) = %d, want %d", got, indexGCPercentDefault)
+		}
+	})
+
+	t.Run("operator override is what actually reaches the runtime", func(t *testing.T) {
+		debug.SetGCPercent(100)
+		applyIndexGCPercent("group-algo", "35", "")
+		if got := debug.SetGCPercent(100); got != 35 {
+			t.Fatalf("GOGC in force after applyIndexGCPercent(group-algo) = %d, want 35", got)
+		}
+	})
+
+	// The standing product rule, restated where it is easiest to break: adding
+	// a second command to the gate must not turn the gate into a pass-through.
+	// Not even an explicit GRAFEL_INDEX_GOGC may create a cap on a command a
+	// human is waiting on. Break the gate (e.g. `return true` from
+	// isBackgroundGCPercentCommand) and this subtest fails.
+	t.Run("interactive commands stay uncapped even with the override set", func(t *testing.T) {
+		for _, cmd := range []string{"index", "rebuild", "daemon", ""} {
+			debug.SetGCPercent(100)
+			applyIndexGCPercent(cmd, "35", "")
+			if got := debug.SetGCPercent(100); got != 100 {
+				t.Fatalf("applyIndexGCPercent(%q, \"35\", \"\") changed GOGC to %d, want it left at 100", cmd, got)
+			}
+		}
+	})
+}

--- a/cmd/grafel/group_algo_memory_test.go
+++ b/cmd/grafel/group_algo_memory_test.go
@@ -1,10 +1,61 @@
 package main
 
 import (
+	"path/filepath"
 	"runtime/debug"
+	"slices"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
+
+// TestWriteOverlayPhaseIsStamped asserts the FOURTH phase label — the one
+// stamped here in cmd/grafel rather than inside the pass — actually lands on
+// the daemon's real `--write` path.
+//
+// It matters more than its size suggests. writing_overlay got ZERO memtrace
+// samples on the first real corpus run (the phase is far shorter than the
+// 250ms default sampling interval), so the NDJSON alone can never confirm the
+// stamp exists; without this test, deleting it would be invisible in both the
+// test suite and the trace.
+func TestWriteOverlayPhaseIsStamped(t *testing.T) {
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	// A registered group whose single repo was never indexed: assembly yields an
+	// empty union, so the whole pass runs end-to-end with no graph.fb fixture.
+	const group = "overlay-phase"
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{
+		Name:  group,
+		Repos: []registry.Repo{{Slug: "ghost", Path: filepath.Join(root, "ghost")}},
+	}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	groupalgo.ResetPhaseHistory()
+	t.Cleanup(groupalgo.ResetPhaseHistory)
+	if code := runGroupAlgo([]string{group, "--write"}); code != 0 {
+		t.Fatalf("runGroupAlgo --write exit code = %d, want 0", code)
+	}
+
+	want := []string{"assembling", "hashing", "running_algorithms", "writing_overlay"}
+	if got := groupalgo.PhaseHistory(); !slices.Equal(got, want) {
+		t.Fatalf("phases stamped by a --write run = %v, want %v", got, want)
+	}
+}
 
 // The GC-pacing cap was originally scoped to the `index-internal` child alone
 // (#5954). Whole-machine measurement then showed the peak instant has moved

--- a/cmd/grafel/index_gcpercent.go
+++ b/cmd/grafel/index_gcpercent.go
@@ -9,7 +9,12 @@ import (
 )
 
 // indexGCPercentEnv is the operator escape hatch for the GC pacing the
-// `index-internal` child applies to itself. It accepts a positive integer
+// BACKGROUND children apply to themselves — both of them: `index-internal` and
+// `group-algo` (see backgroundGCPercentCommands). Deliberately ONE knob and not
+// one per child: the policy is a single product decision ("nobody is waiting on
+// a background batch child, so trade GC CPU for RSS there"), the default is the
+// same value for both, and a second env var would only create a way for the two
+// to drift apart in a support case. It accepts a positive integer
 // percentage, optionally with a trailing "%" ("50", "35", "60%"). The values
 // "0", "off", "disabled", "none" and "false" mean "apply no cap at all" (leave
 // whatever the Go runtime already has). A malformed value is ignored (logged,
@@ -24,12 +29,36 @@ const indexGCPercentEnv = "GRAFEL_INDEX_GOGC"
 const gcPercentUnset = 0
 
 // backgroundIndexCommand is the argv[1] of the hidden subprocess-indexer
-// entrypoint the daemon fork-execs. It is the ONLY command whose GC pacing we
-// cap: background indexing is a batch job nobody is watching, so trading GC
-// CPU for RSS is free there. Interactive/foreground work stays uncapped by
-// standing product decision — a user waiting on a command should not pay GC
-// time to save memory they are not short of.
+// entrypoint the daemon fork-execs.
 const backgroundIndexCommand = "index-internal"
+
+// backgroundGroupAlgoCommand is the argv[1] of the hidden group-scope analytics
+// entrypoint the daemon's scheduler fork-execs (RunSubprocessGroupAlgo).
+const backgroundGroupAlgoCommand = "group-algo"
+
+// backgroundGCPercentCommands is the ALLOW-LIST of commands whose GC pacing we
+// cap. Both members are batch children the daemon fork-execs with no human
+// waiting on them, so trading GC CPU for RSS is free there.
+//
+// It became a set rather than a single constant when whole-machine measurement
+// showed the peak instant had moved entirely post-index (#5954): at that
+// instant the index child is at 0MB and `group-algo` is one of the two largest
+// processes on the box, at GOGC=100 and completely untuned.
+//
+// An ALLOW-LIST, not a deny-list, is the load-bearing choice. Interactive /
+// foreground work stays uncapped by standing product decision — a user waiting
+// on a command should not pay GC time to save memory they are not short of —
+// and a deny-list would silently cap every future command by default.
+var backgroundGCPercentCommands = map[string]bool{
+	backgroundIndexCommand:     true,
+	backgroundGroupAlgoCommand: true,
+}
+
+// isBackgroundGCPercentCommand reports whether argv[1] names a background batch
+// child. Everything else — including the empty command — is interactive.
+func isBackgroundGCPercentCommand(command string) bool {
+	return backgroundGCPercentCommands[command]
+}
 
 // indexGCPercentDefault is the GC pacing applied to the background index
 // child: next_gc = live * 1.5 instead of the default live * 2.
@@ -92,16 +121,16 @@ func parseIndexGCPercentEnv(raw string) (percent int, decided bool) {
 //
 // Precedence, highest first:
 //
-//  1. command is not the background index child -> never capped. This gate is
-//     first on purpose: GRAFEL_INDEX_GOGC tunes the background cap, it does
-//     not create one on the interactive path.
+//  1. command is not one of the background batch children -> never capped.
+//     This gate is first on purpose: GRAFEL_INDEX_GOGC tunes the background
+//     cap, it does not create one on the interactive path.
 //  2. GRAFEL_INDEX_GOGC, when well-formed -> the operator's explicit choice.
 //  3. GOGC set explicitly in the environment -> leave the runtime alone. The
 //     runtime has already applied it; overriding would silently discard an
 //     instruction the operator gave in the most standard way there is.
 //  4. otherwise -> indexGCPercentDefault.
 func indexGCPercentDecision(command, rawEnv, rawGOGC string) (percent int, source string) {
-	if command != backgroundIndexCommand {
+	if !isBackgroundGCPercentCommand(command) {
 		return gcPercentUnset, "interactive/foreground path (" + command + ") — GC pacing is not capped"
 	}
 	if n, decided := parseIndexGCPercentEnv(rawEnv); decided {
@@ -128,13 +157,29 @@ func indexGCPercentDecision(command, rawEnv, rawGOGC string) (percent int, sourc
 // exits, every earlier phase also allocates heavily (extracting_ast peaks at
 // ~1.9GB RSS), and a tighter GOGC in those phases is just as welcome. There is
 // no "after" to restore to, so there is no restore path.
+// GROUP-ALGO GETS GOGC AND DELIBERATELY NOT GOMEMLIMIT. The group-algo child's
+// live heap is, as of this change, UNMEASURED (that is what the memtrace
+// instrumentation added alongside this is for). GOMEMLIMIT is an ABSOLUTE soft
+// target: set below a workload's live heap it is unsatisfiable and the runtime
+// answers with back-to-back mark cycles forever — the >4x death spiral this
+// repo measured and documented in index_memlimit.go. Picking an absolute target
+// for a heap nobody has measured is exactly how you land in that regime. GOGC
+// is RELATIVE — next_gc = live * (1 + GOGC/100) — so it is defined in terms of
+// whatever the live heap turns out to be and cannot fall below it at any value,
+// on any group. The death spiral is unreachable by construction. That is the
+// whole reason group-algo may be paced now and memory-limited only once it has
+// been measured.
 func applyIndexGCPercent(command, rawEnv, rawGOGC string) {
 	percent, source := indexGCPercentDecision(command, rawEnv, rawGOGC)
+	tag := command
+	if tag == "" {
+		tag = "grafel"
+	}
 	if percent == gcPercentUnset {
-		fmt.Fprintf(os.Stderr, "index-internal: GC percent not capped (#5954) source=%s\n", source)
+		fmt.Fprintf(os.Stderr, "%s: GC percent not capped (#5954) source=%s\n", tag, source)
 		return
 	}
 	prev := debug.SetGCPercent(percent)
-	fmt.Fprintf(os.Stderr, "index-internal: applied GC percent (#5954) gogc=%d previous=%d source=%s\n",
-		percent, prev, source)
+	fmt.Fprintf(os.Stderr, "%s: applied GC percent (#5954) gogc=%d previous=%d source=%s\n",
+		tag, percent, prev, source)
 }

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -49,6 +49,20 @@ func main() {
 	// at group scope, printing stats. --dry-run writes no files. Not part of the
 	// public command surface; intercepted before cobra dispatch.
 	if len(os.Args) >= 2 && os.Args[1] == "group-algo" {
+		// Bound GC PACING for this child too (#5954). Whole-machine measurement
+		// after the index child was optimised showed the peak instant had moved
+		// entirely post-index: the index child is at 0MB there while this
+		// process is one of the two largest on the machine, running at the
+		// GOGC=100 default and otherwise untuned. os.Args[1] is passed
+		// explicitly so the "background only, never interactive" rule stays a
+		// property of the policy function rather than of this call site.
+		//
+		// Deliberately NO applyIndexMemoryLimit here. GOMEMLIMIT is an absolute
+		// soft target and this child's live heap is not yet measured; an
+		// absolute target below live heap is the documented >4x death spiral
+		// (see index_memlimit.go). GOGC is relative — live * (1+GOGC/100) — and
+		// so cannot enter that regime by construction. Never fatal.
+		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runGroupAlgo(os.Args[2:]))
 	}
 	// Release acceptance ladder (#5224). Intercepted before cobra dispatch

--- a/internal/daemon/sched/subprocess_groupalgo_env_test.go
+++ b/internal/daemon/sched/subprocess_groupalgo_env_test.go
@@ -1,0 +1,67 @@
+package sched
+
+import (
+	"strings"
+	"testing"
+)
+
+// The group-algo child is the second background batch process the daemon
+// fork-execs, and until #5954's follow-up it was built with a plain
+// `append(os.Environ(), "GOMAXPROCS=...")` — no GODEBUG merge, unlike the
+// index child. That left it returning freed pages with MADV_FREE, so any RSS
+// it gave back stayed invisible to the OS (and to whole-machine measurement)
+// until the kernel came under pressure.
+//
+// GODEBUG is read once at process start, so — unlike GOGC, which the child
+// sets on itself — madvdontneed can ONLY be delivered through the child's env.
+// That is why this is asserted on the constructed env rather than on runtime
+// state.
+
+// TestGroupAlgoChildEnvSetsMadvDontNeed asserts the constructed child env
+// carries the reclaim setting, and still carries the CPU bound.
+func TestGroupAlgoChildEnvSetsMadvDontNeed(t *testing.T) {
+	env := groupAlgoChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2)
+
+	godebug, ok := lookupEnv(env, "GODEBUG")
+	if !ok {
+		t.Fatalf("group-algo child env has no GODEBUG entry: %v", env)
+	}
+	if !strings.Contains(godebug, madvDontNeedSetting) {
+		t.Errorf("GODEBUG = %q, want it to carry %q", godebug, madvDontNeedSetting)
+	}
+	if got, ok := lookupEnv(env, "GOMAXPROCS"); !ok || got != "2" {
+		t.Errorf("GOMAXPROCS = %q (present=%v), want \"2\" — the CPU bound must survive the GODEBUG merge", got, ok)
+	}
+	if got, ok := lookupEnv(env, "PATH"); !ok || got != "/usr/bin" {
+		t.Errorf("PATH = %q (present=%v), want the inherited value preserved", got, ok)
+	}
+}
+
+// TestGroupAlgoChildEnvMergesInheritedGODEBUG asserts an operator's other
+// GODEBUG settings are merged rather than clobbered, matching withMadvDontNeed's
+// contract, and that an explicit madvdontneed=0 is left alone.
+func TestGroupAlgoChildEnvMergesInheritedGODEBUG(t *testing.T) {
+	env := groupAlgoChildEnv([]string{"GODEBUG=http2debug=1"}, 3)
+	godebug, _ := lookupEnv(env, "GODEBUG")
+	if !strings.Contains(godebug, "http2debug=1") || !strings.Contains(godebug, madvDontNeedSetting) {
+		t.Errorf("GODEBUG = %q, want both the inherited setting and %q", godebug, madvDontNeedSetting)
+	}
+
+	env = groupAlgoChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1)
+	godebug, _ = lookupEnv(env, "GODEBUG")
+	if godebug != "madvdontneed=0" {
+		t.Errorf("GODEBUG = %q, want an explicit operator madvdontneed=0 left alone", godebug)
+	}
+}
+
+// lookupEnv returns the LAST value for key, mirroring os/exec's dedupEnv
+// ("preserve the last occurrence of each key") — i.e. what the child sees.
+func lookupEnv(env []string, key string) (string, bool) {
+	val, found := "", false
+	for _, kv := range env {
+		if v, ok := strings.CutPrefix(kv, key+"="); ok {
+			val, found = v, true
+		}
+	}
+	return val, found
+}

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -484,6 +484,25 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 // The child inherits the daemon's full environment (GRAFEL_HOME /
 // GRAFEL_DAEMON_ROOT) so it resolves the same group config + state dirs and
 // writes the overlay into the same ~/.grafel/groups directory.
+// groupAlgoChildEnv builds the environment for the group-algo child: the
+// GOMAXPROCS bound plus the madvdontneed reclaim setting, merged into any
+// inherited GODEBUG. Extracted as a pure function so the constructed env is
+// assertable without fork-execing anything.
+//
+// The GODEBUG entry is why this exists. GODEBUG is read ONCE at process start,
+// so — unlike GOGC, which the child sets on itself in main() — madvdontneed can
+// only be delivered through the child's environment. Without it the runtime
+// returns freed pages with MADV_FREE and any RSS group-algo gives back stays
+// invisible to the OS until the kernel comes under pressure, which is precisely
+// what whole-machine peak measurement reads (#5954). The index child has had
+// this since RunSubprocessIndex; group-algo was simply never given it.
+func groupAlgoChildEnv(base []string, gomaxprocs int) []string {
+	env := make([]string, 0, len(base)+2)
+	env = append(env, base...)
+	env = append(env, "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	return withMadvDontNeed(env)
+}
+
 func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logger) error {
 	binary, err := os.Executable()
 	if err != nil {
@@ -495,9 +514,10 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	// env GRAFEL_GROUP_ALGO_CPU) so the background analytics pass cannot scale
 	// its worker pool to the full host core count — the v0.1.3 CPU regression.
 	// GOMAXPROCS is appended last so it wins over any inherited value. Mirrors
-	// the extract subprocess (GRAFEL_EXTRACT_GOMAXPROCS).
+	// the extract subprocess (GRAFEL_EXTRACT_GOMAXPROCS). groupAlgoChildEnv also
+	// merges GODEBUG=madvdontneed=1 — see its doc comment.
 	gomaxprocs := GroupAlgoGOMAXPROCS()
-	cmd.Env = append(os.Environ(), "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	cmd.Env = groupAlgoChildEnv(os.Environ(), gomaxprocs)
 	// Lower the child's OS scheduling priority (nice +10) so even its capped
 	// cores yield to foreground work (a consumer's CI / dev harness). No-op /
 	// guarded off on platforms without setpriority (e.g. Windows). See

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -225,6 +225,7 @@ func AssembleGroupGraph(group string) (entities []graph.Entity, rels []graph.Rel
 // Results is an empty AlgorithmResults (graph.RunAlgorithms guards len==0), so
 // callers get a safe no-op rather than a panic.
 func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
+	SetPhase(PhaseAssembling)
 	entities, rels, entityRepo, srcMtimes, err := AssembleGroupGraph(group)
 	if err != nil {
 		return nil, err
@@ -236,7 +237,11 @@ func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
 		numRepos = len(cfg.Repos)
 	}
 
+	SetPhase(PhaseRunningAlgorithms)
 	res := graph.RunAlgorithms(entities, rels)
+
+	SetPhase(PhaseHashing)
+	inputHash := graph.CommunityInputHash(entities, rels)
 
 	return &GroupAlgoResult{
 		Group:        group,
@@ -246,7 +251,7 @@ func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
 		NumEntities:  len(entities),
 		NumRels:      len(rels),
 		NumRepos:     numRepos,
-		InputHash:    graph.CommunityInputHash(entities, rels),
+		InputHash:    inputHash,
 	}, nil
 }
 
@@ -277,6 +282,11 @@ func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
 // the whole union and a partial pass could not reproduce the exact same labels
 // a full pass assigns — that would break strict parity.)
 func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
+	// Phase stamps (#5954). The group-algo child is one of the two largest
+	// processes on the machine at the whole-machine memory peak and had zero
+	// instrumentation; memtrace polls CurrentPhase on a ticker so each memstats
+	// sample and each per-phase heap profile is attributable to a stage.
+	SetPhase(PhaseAssembling)
 	entities, rels, entityRepo, srcMtimes, err := AssembleGroupGraph(group)
 	if err != nil {
 		return nil, err
@@ -288,6 +298,7 @@ func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
 		numRepos = len(cfg.Repos)
 	}
 
+	SetPhase(PhaseHashing)
 	inputHash := graph.CommunityInputHash(entities, rels)
 
 	// Skip-when-unaffected: a prior overlay whose recorded input hash matches the
@@ -335,6 +346,7 @@ func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
 	}
 
 	// Full deterministic recompute (input changed, or no usable prior overlay).
+	SetPhase(PhaseRunningAlgorithms)
 	res := graph.RunAlgorithms(entities, rels)
 	// Record BEFORE returning (and thus before the caller's overlay write), so a
 	// persist failure cannot cause a re-run for this same version.

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -237,11 +237,17 @@ func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
 		numRepos = len(cfg.Repos)
 	}
 
-	SetPhase(PhaseRunningAlgorithms)
-	res := graph.RunAlgorithms(entities, rels)
-
+	// Hash BEFORE running the algorithms, matching RunGroupAlgorithmsIncremental.
+	// inputHash is a pure function of (entities, rels) and has no dependency on
+	// res, so the order is free — and one true phase order across both
+	// entrypoints is worth more than a comment explaining two. The phase labels
+	// are the operator-facing contract for reading a memtrace, in a workstream
+	// whose premise is that a misread memory metric already cost a day.
 	SetPhase(PhaseHashing)
 	inputHash := graph.CommunityInputHash(entities, rels)
+
+	SetPhase(PhaseRunningAlgorithms)
+	res := graph.RunAlgorithms(entities, rels)
 
 	return &GroupAlgoResult{
 		Group:        group,

--- a/internal/graph/groupalgo/phase.go
+++ b/internal/graph/groupalgo/phase.go
@@ -1,0 +1,79 @@
+package groupalgo
+
+// phase.go — the phase state the group-algo child's memory trace is tagged
+// with (#5954).
+//
+// WHY THIS EXISTS. Epic #5954 cut the `index-internal` child from 4247MB to
+// 2975MB, and whole-machine measurement then showed the peak instant had moved
+// entirely POST-index: at that instant the index child is at 0MB while
+// `group-algo` is frequently the single largest process on the machine — and it
+// reported nothing at all. No memstats, no heap profiles, no phases. This epic
+// has already lost a day to tuning allocation sites off a misread heap_inuse;
+// a 2.4GB process that emits no numbers must not be tuned before it emits some.
+//
+// SHAPE. The index child feeds memtrace's phaseFn from progress.Tracker's
+// CurrentPhase — the same state the UI reports — so the trace can never drift
+// from what the process is actually doing. group-algo has no Tracker (it is a
+// short batch child with no progress plane), so this file is the minimal
+// equivalent: one process-wide holder, stamped by the pass at each stage and
+// polled by the memtrace sampler goroutine on its ticker. Still ONE source of
+// phase state, which is the property that matters.
+//
+// A process-wide holder is correct here because the child runs exactly one
+// group-algo pass and exits; there is no second concurrent pass to interleave
+// with. It is a package-level var rather than a field on a result struct
+// precisely so the stamps can live at the call sites inside the pass without
+// threading a parameter through every entrypoint.
+
+import "sync/atomic"
+
+// The phase labels the pass stamps, in the order a full (non-skipped) run
+// stamps them. They are the operator-facing contract with the measurement
+// harness — they appear verbatim in the memtrace NDJSON `phase` field and in
+// the per-phase heap-profile filenames — so they are stable identifiers, not
+// display strings to be reworded.
+//
+//   - assembling         — AssembleGroupGraph: reads every repo's graph.fb and
+//     concatenates the union. Expected to be allocation-heavy: this is where
+//     the whole group's entities + relationships become live at once.
+//   - hashing            — CommunityInputHash over that union.
+//   - running_algorithms — graph.RunAlgorithms: Louvain + PageRank +
+//     betweenness. The CPU peak; whether it is also the memory peak is exactly
+//     what this instrumentation exists to answer.
+//   - writing_overlay    — serialising and atomically swapping in the
+//     <group>-algo.json overlay.
+//
+// The incremental entrypoint may stamp only the first two before taking the
+// skip path — an unchanged input hash reconstitutes the prior overlay and never
+// reaches running_algorithms. A trace that stops at `hashing` is therefore a
+// successful skip, not a truncated run.
+const (
+	PhaseAssembling        = "assembling"
+	PhaseHashing           = "hashing"
+	PhaseRunningAlgorithms = "running_algorithms"
+	PhaseWritingOverlay    = "writing_overlay"
+)
+
+// phaseHolder is a race-free string cell. The pass goroutine stores; the
+// memtrace sampler goroutine loads on every tick. atomic.Value (rather than a
+// mutex) keeps the read side — the hot one, polled on a ticker for the life of
+// the process — free of any contention with the writer.
+type phaseHolder struct{ v atomic.Value }
+
+func (h *phaseHolder) set(p string) { h.v.Store(p) }
+
+// get returns "" before the first store: atomic.Value's zero Load yields a nil
+// any, and the failed type assertion leaves the zero string. memtrace may well
+// poll before the pass has stamped anything, and an empty phase is exactly the
+// right answer there.
+func (h *phaseHolder) get() string { s, _ := h.v.Load().(string); return s }
+
+var currentPhase phaseHolder
+
+// SetPhase records the stage the group-algo pass has entered. Called from the
+// pass itself; safe to call from any goroutine.
+func SetPhase(p string) { currentPhase.set(p) }
+
+// CurrentPhase reports the stage last stamped, or "" if none has been. Pass it
+// to memtrace.Start as the phaseFn — it is polled once per sampling tick.
+func CurrentPhase() string { return currentPhase.get() }

--- a/internal/graph/groupalgo/phase.go
+++ b/internal/graph/groupalgo/phase.go
@@ -25,28 +25,60 @@ package groupalgo
 // precisely so the stamps can live at the call sites inside the pass without
 // threading a parameter through every entrypoint.
 
-import "sync/atomic"
+import (
+	"sync"
+	"sync/atomic"
+)
 
-// The phase labels the pass stamps, in the order a full (non-skipped) run
-// stamps them. They are the operator-facing contract with the measurement
-// harness — they appear verbatim in the memtrace NDJSON `phase` field and in
-// the per-phase heap-profile filenames — so they are stable identifiers, not
-// display strings to be reworded.
+// The phase labels the pass stamps, in the order the pass stamps them. They are
+// the operator-facing contract with the measurement harness — they appear
+// verbatim in the memtrace NDJSON `phase` field and in the per-phase
+// heap-profile filenames — so they are stable identifiers, not display strings
+// to be reworded.
 //
 //   - assembling         — AssembleGroupGraph: reads every repo's graph.fb and
-//     concatenates the union. Expected to be allocation-heavy: this is where
-//     the whole group's entities + relationships become live at once.
-//   - hashing            — CommunityInputHash over that union.
+//     concatenates the union. First measurement on the real corpus: 303MB live
+//     over 148,455 entities / 700,321 rels.
+//   - hashing            — CommunityInputHash over that union. 457MB live, from
+//     only 2 samples out of 775 — see the sampling caveat below.
 //   - running_algorithms — graph.RunAlgorithms: Louvain + PageRank +
-//     betweenness. The CPU peak; whether it is also the memory peak is exactly
-//     what this instrumentation exists to answer.
+//     betweenness. The measured MEMORY peak as well as the CPU peak: 623MB
+//     live, more than double assembly. Any future presizing work belongs here,
+//     not in assembly.
 //   - writing_overlay    — serialising and atomically swapping in the
 //     <group>-algo.json overlay.
 //
-// The incremental entrypoint may stamp only the first two before taking the
-// skip path — an unchanged input hash reconstitutes the prior overlay and never
-// reaches running_algorithms. A trace that stops at `hashing` is therefore a
-// successful skip, not a truncated run.
+// BOTH entrypoints stamp this same order. RunGroupAlgorithms hashes before
+// running the algorithms purely so that it does — inputHash does not depend on
+// the algorithm result, so the ordering is free, and a single true order beats
+// a comment explaining two.
+//
+// WHERE A TRACE CAN END. On the incremental entrypoint a skip (unchanged input
+// hash) never reaches running_algorithms, so the LIBRARY stops after hashing.
+// The daemon's real `--write` invocation nonetheless still stamps
+// writing_overlay afterwards, skip or not, because cmd/grafel/group_algo.go
+// stamps it unconditionally on that path. A `--dry-run` ends at
+// running_algorithms. So the last label is not by itself evidence of a
+// truncated run, nor of a skip.
+//
+// READING A GROUP-ALGO TRACE — three inherited memtrace properties that will
+// otherwise mislead you:
+//
+//   - Samples are written ONLY on ticker ticks, and Stop writes no final
+//     sample. A run shorter than one tick therefore produces a 0-byte NDJSON
+//     and zero heap profiles — indistinguishable from "instrumentation is
+//     broken". A 1.7s empty-group probe hit exactly this.
+//   - At the 250ms default interval fast phases are near-invisible. On the
+//     first real run `hashing` got 2 samples of 775 and `writing_overlay` got
+//     ZERO. Treat writing_overlay as UNMEASURED unless GRAFEL_MEMTRACE_INTERVAL
+//     is lowered for the run.
+//   - `group-algo` is on the GC-pacing allow-list unconditionally
+//     (cmd/grafel/index_gcpercent.go), so a human running `grafel group-algo
+//     <g> --dry-run` by hand gets GOGC=50 too. That is a deliberate choice, not
+//     an oversight — it is a hidden diagnostic command, and pacing the manual
+//     invocation exactly as the daemon's is paced is what makes a hand-run
+//     trace representative of the real child. It does mean this one foreground
+//     invocation is capped, contrary to the general rule.
 const (
 	PhaseAssembling        = "assembling"
 	PhaseHashing           = "hashing"
@@ -54,19 +86,53 @@ const (
 	PhaseWritingOverlay    = "writing_overlay"
 )
 
-// phaseHolder is a race-free string cell. The pass goroutine stores; the
-// memtrace sampler goroutine loads on every tick. atomic.Value (rather than a
-// mutex) keeps the read side — the hot one, polled on a ticker for the life of
-// the process — free of any contention with the writer.
-type phaseHolder struct{ v atomic.Value }
+// phaseHolder is a race-free string cell plus the transition log. The pass
+// goroutine stores; the memtrace sampler goroutine loads on every tick.
+//
+// The current value is an atomic.Value rather than a mutex-guarded field
+// because the READ side is the hot one — polled on a ticker for the life of the
+// process — and must not contend with the writer. The transition log takes a
+// mutex, which costs nothing: it is only touched on a genuine phase CHANGE, of
+// which a whole pass has four.
+type phaseHolder struct {
+	v atomic.Value
 
-func (h *phaseHolder) set(p string) { h.v.Store(p) }
+	mu      sync.Mutex
+	history []string
+}
+
+// set records a stamp, appending to the transition log only when the phase
+// actually changes. Re-stamping the same phase is a no-op for the log, so the
+// log is a true transition sequence rather than a call counter.
+func (h *phaseHolder) set(p string) {
+	h.v.Store(p)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if n := len(h.history); n == 0 || h.history[n-1] != p {
+		h.history = append(h.history, p)
+	}
+}
 
 // get returns "" before the first store: atomic.Value's zero Load yields a nil
 // any, and the failed type assertion leaves the zero string. memtrace may well
 // poll before the pass has stamped anything, and an empty phase is exactly the
 // right answer there.
 func (h *phaseHolder) get() string { s, _ := h.v.Load().(string); return s }
+
+func (h *phaseHolder) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.history...)
+}
+
+// reset stores the empty phase rather than re-zeroing the atomic.Value, so it
+// stays safe against a concurrent sampler poll (and copies no sync type).
+func (h *phaseHolder) reset() {
+	h.v.Store("")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.history = nil
+}
 
 var currentPhase phaseHolder
 
@@ -77,3 +143,20 @@ func SetPhase(p string) { currentPhase.set(p) }
 // CurrentPhase reports the stage last stamped, or "" if none has been. Pass it
 // to memtrace.Start as the phaseFn — it is polled once per sampling tick.
 func CurrentPhase() string { return currentPhase.get() }
+
+// PhaseHistory returns the sequence of distinct phases stamped so far.
+//
+// It exists because CurrentPhase alone cannot answer the question that actually
+// matters when reading a trace: which stages ran, in what order. The memtrace
+// NDJSON only tells you which phases were SAMPLED, and a phase shorter than the
+// sampling interval leaves no sample at all (writing_overlay got zero on the
+// first real run). The history is the ground truth a sampled record is read
+// against — and it is what lets a test observe the stamps the pass really
+// makes, rather than round-tripping the constants through the holder.
+func PhaseHistory() []string { return currentPhase.snapshot() }
+
+// ResetPhaseHistory clears both the current phase and the transition log,
+// returning the package to its pre-pass state. The child runs one pass and then
+// exits, so production never needs this; it exists so a test can observe one
+// pass's stamps in isolation from another's.
+func ResetPhaseHistory() { currentPhase.reset() }

--- a/internal/graph/groupalgo/phase_test.go
+++ b/internal/graph/groupalgo/phase_test.go
@@ -1,8 +1,13 @@
 package groupalgo
 
 import (
+	"path/filepath"
+	"slices"
 	"sync"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // The group-algo child had ZERO memory instrumentation while being one of the
@@ -11,30 +16,71 @@ import (
 // phaseFn; this package owns that phase state so the four stages of the pass
 // are distinguishable in the NDJSON and in the per-phase heap profiles.
 //
-// Without a phase label the trace is one flat curve and the same misreading
-// that cost this epic a day — attributing heap_inuse to the wrong stage — is
-// exactly as available as before.
+// These tests must OBSERVE THE PASS. An earlier version of TestPhaseOrder
+// compared the four constants to four string literals and round-tripped them
+// through the holder — a tautology: every stamp except `assembling` could be
+// deleted from the production code with the whole package still green. The
+// labels are only worth anything if the pass actually stamps them, in order.
 
-// TestPhaseOrder asserts the labels a full group-algo pass stamps, in the
-// order the pass stamps them. The labels are the operator-facing contract with
-// the measurement harness, so they are spelled out here rather than derived
-// from the constants.
+// TestPhaseOrder runs a real RunGroupAlgorithms and asserts the sequence of
+// phases the pass stamped. Deleting any single SetPhase call in
+// RunGroupAlgorithms fails this test.
+//
+// An empty (registered but never-indexed) group is deliberate: assembly,
+// hashing and the algorithm pass all still run — graph.RunAlgorithms guards
+// len==0 — so all three stamps are exercised with no graph.fb fixture, and the
+// test stays fast enough to leave the ordering the only thing under assertion.
 func TestPhaseOrder(t *testing.T) {
 	restorePhase(t)
+	registerEmptyGroup(t, "phase-order")
+	ResetPhaseHistory()
 
-	want := []string{"assembling", "hashing", "running_algorithms", "writing_overlay"}
-	got := []string{PhaseAssembling, PhaseHashing, PhaseRunningAlgorithms, PhaseWritingOverlay}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Errorf("phase %d = %q, want %q", i, got[i], want[i])
-		}
+	if _, err := RunGroupAlgorithms("phase-order"); err != nil {
+		t.Fatalf("RunGroupAlgorithms: %v", err)
 	}
 
-	// The holder must report whatever the pass last stamped, in sequence.
-	for _, p := range want {
-		SetPhase(p)
-		if CurrentPhase() != p {
-			t.Fatalf("after SetPhase(%q), CurrentPhase() = %q", p, CurrentPhase())
+	// Spelled out rather than derived from the constants: these strings are the
+	// operator-facing contract — they appear verbatim in the memtrace NDJSON
+	// `phase` field and in the heap-profile filenames — so a rename must break
+	// a test rather than silently re-key every trace the harness has collected.
+	want := []string{"assembling", "hashing", "running_algorithms"}
+	if got := PhaseHistory(); !slices.Equal(got, want) {
+		t.Fatalf("phases stamped by RunGroupAlgorithms = %v, want %v", got, want)
+	}
+}
+
+// TestPhaseOrderIncremental asserts the incremental entrypoint — the one the
+// daemon's --write child actually calls — stamps the SAME order. The two
+// entrypoints agreeing is the property that lets the phase doc state one order
+// instead of two.
+func TestPhaseOrderIncremental(t *testing.T) {
+	restorePhase(t)
+	registerEmptyGroup(t, "phase-order-inc")
+	ResetPhaseHistory()
+
+	if _, err := RunGroupAlgorithmsIncremental("phase-order-inc"); err != nil {
+		t.Fatalf("RunGroupAlgorithmsIncremental: %v", err)
+	}
+
+	want := []string{"assembling", "hashing", "running_algorithms"}
+	if got := PhaseHistory(); !slices.Equal(got, want) {
+		t.Fatalf("phases stamped by RunGroupAlgorithmsIncremental = %v, want %v", got, want)
+	}
+}
+
+// TestPhaseConstantsMatchTheContract pins the label spellings themselves. The
+// order tests above compare against literals, so this is the one place a
+// constant rename is reported as a rename rather than as a mystery sequence
+// mismatch.
+func TestPhaseConstantsMatchTheContract(t *testing.T) {
+	for _, tc := range []struct{ got, want string }{
+		{PhaseAssembling, "assembling"},
+		{PhaseHashing, "hashing"},
+		{PhaseRunningAlgorithms, "running_algorithms"},
+		{PhaseWritingOverlay, "writing_overlay"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("phase constant = %q, want %q", tc.got, tc.want)
 		}
 	}
 }
@@ -44,9 +90,30 @@ func TestPhaseOrder(t *testing.T) {
 // goroutine and may well poll before the pass has stamped anything.
 func TestCurrentPhaseBeforeAnyStamp(t *testing.T) {
 	restorePhase(t)
-	currentPhase = phaseHolder{}
+	ResetPhaseHistory()
 	if got := CurrentPhase(); got != "" {
 		t.Fatalf("CurrentPhase() before any stamp = %q, want \"\"", got)
+	}
+	if got := PhaseHistory(); len(got) != 0 {
+		t.Fatalf("PhaseHistory() before any stamp = %v, want empty", got)
+	}
+}
+
+// TestPhaseHistoryRecordsTransitionsNotCalls asserts a re-stamp of the same
+// phase does not grow the log. The log is read as a transition sequence, and a
+// stamp inside a loop must not turn it into a call counter.
+func TestPhaseHistoryRecordsTransitionsNotCalls(t *testing.T) {
+	restorePhase(t)
+	ResetPhaseHistory()
+
+	SetPhase(PhaseAssembling)
+	SetPhase(PhaseAssembling)
+	SetPhase(PhaseHashing)
+	SetPhase(PhaseAssembling)
+
+	want := []string{"assembling", "hashing", "assembling"}
+	if got := PhaseHistory(); !slices.Equal(got, want) {
+		t.Fatalf("PhaseHistory() = %v, want %v", got, want)
 	}
 }
 
@@ -58,7 +125,7 @@ func TestPhaseHolderIsRaceFree(t *testing.T) {
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
-	wg.Add(1)
+	wg.Add(2)
 	go func() {
 		defer wg.Done()
 		for {
@@ -70,6 +137,17 @@ func TestPhaseHolderIsRaceFree(t *testing.T) {
 			}
 		}
 	}()
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = PhaseHistory()
+			}
+		}
+	}()
 	for i := 0; i < 1000; i++ {
 		SetPhase(PhaseRunningAlgorithms)
 		SetPhase(PhaseHashing)
@@ -78,26 +156,58 @@ func TestPhaseHolderIsRaceFree(t *testing.T) {
 	wg.Wait()
 }
 
-// TestAssemblingIsStampedByTheEntrypoint asserts the FIRST stamp is real —
-// that the phase is set by the pass itself and not only by the tests. A group
-// that does not resolve fails inside assembly, which is precisely when the
-// phase must already read "assembling".
-func TestAssemblingIsStampedByTheEntrypoint(t *testing.T) {
+// TestAssemblingIsStampedOnTheFailurePath asserts the first stamp lands before
+// assembly can fail — the phase must already read "assembling" when a group
+// that does not resolve blows up inside it, or a trace of a failed run is
+// unattributable.
+func TestAssemblingIsStampedOnTheFailurePath(t *testing.T) {
 	restorePhase(t)
-	currentPhase = phaseHolder{}
+	ResetPhaseHistory()
 
 	if _, err := RunGroupAlgorithms("grafel-no-such-group-5954"); err == nil {
 		t.Skip("unexpected: a bogus group resolved; cannot exercise the assembly failure path")
 	}
 	if got := CurrentPhase(); got != PhaseAssembling {
-		t.Fatalf("CurrentPhase() after a failed assembly = %q, want %q — the entrypoint does not stamp the phase",
-			got, PhaseAssembling)
+		t.Fatalf("CurrentPhase() after a failed assembly = %q, want %q", got, PhaseAssembling)
+	}
+}
+
+// registerEmptyGroup registers a group whose single repo was never indexed (no
+// graph.fb), so assembly yields an empty union without needing a fixture.
+func registerEmptyGroup(t *testing.T, name string) {
+	t.Helper()
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	cfgPath, err := registry.ConfigPathFor(name)
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{
+		Name:  name,
+		Repos: []registry.Repo{{Slug: "ghost", Path: filepath.Join(root, "ghost")}},
+	}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup(name, cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
 	}
 }
 
 // restorePhase makes the process-wide holder test-local.
 func restorePhase(t *testing.T) {
 	t.Helper()
-	prev := CurrentPhase()
-	t.Cleanup(func() { SetPhase(prev) })
+	prevPhase, prevHistory := CurrentPhase(), PhaseHistory()
+	t.Cleanup(func() {
+		ResetPhaseHistory()
+		for _, p := range prevHistory {
+			SetPhase(p)
+		}
+		if prevPhase != "" {
+			SetPhase(prevPhase)
+		}
+	})
 }

--- a/internal/graph/groupalgo/phase_test.go
+++ b/internal/graph/groupalgo/phase_test.go
@@ -1,0 +1,103 @@
+package groupalgo
+
+import (
+	"sync"
+	"testing"
+)
+
+// The group-algo child had ZERO memory instrumentation while being one of the
+// two largest processes on the machine at the whole-machine peak (#5954). The
+// memtrace sampler tags every sample with a phase read from a caller-supplied
+// phaseFn; this package owns that phase state so the four stages of the pass
+// are distinguishable in the NDJSON and in the per-phase heap profiles.
+//
+// Without a phase label the trace is one flat curve and the same misreading
+// that cost this epic a day — attributing heap_inuse to the wrong stage — is
+// exactly as available as before.
+
+// TestPhaseOrder asserts the labels a full group-algo pass stamps, in the
+// order the pass stamps them. The labels are the operator-facing contract with
+// the measurement harness, so they are spelled out here rather than derived
+// from the constants.
+func TestPhaseOrder(t *testing.T) {
+	restorePhase(t)
+
+	want := []string{"assembling", "hashing", "running_algorithms", "writing_overlay"}
+	got := []string{PhaseAssembling, PhaseHashing, PhaseRunningAlgorithms, PhaseWritingOverlay}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("phase %d = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	// The holder must report whatever the pass last stamped, in sequence.
+	for _, p := range want {
+		SetPhase(p)
+		if CurrentPhase() != p {
+			t.Fatalf("after SetPhase(%q), CurrentPhase() = %q", p, CurrentPhase())
+		}
+	}
+}
+
+// TestCurrentPhaseBeforeAnyStamp asserts the zero value is a safe empty
+// string, not a panic. memtrace polls phaseFn on a ticker from its own
+// goroutine and may well poll before the pass has stamped anything.
+func TestCurrentPhaseBeforeAnyStamp(t *testing.T) {
+	restorePhase(t)
+	currentPhase = phaseHolder{}
+	if got := CurrentPhase(); got != "" {
+		t.Fatalf("CurrentPhase() before any stamp = %q, want \"\"", got)
+	}
+}
+
+// TestPhaseHolderIsRaceFree exercises the real access pattern: the pass
+// goroutine stamps while the memtrace sampler goroutine polls. Run under -race
+// this fails outright on an unsynchronised holder.
+func TestPhaseHolderIsRaceFree(t *testing.T) {
+	restorePhase(t)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				_ = CurrentPhase()
+			}
+		}
+	}()
+	for i := 0; i < 1000; i++ {
+		SetPhase(PhaseRunningAlgorithms)
+		SetPhase(PhaseHashing)
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// TestAssemblingIsStampedByTheEntrypoint asserts the FIRST stamp is real —
+// that the phase is set by the pass itself and not only by the tests. A group
+// that does not resolve fails inside assembly, which is precisely when the
+// phase must already read "assembling".
+func TestAssemblingIsStampedByTheEntrypoint(t *testing.T) {
+	restorePhase(t)
+	currentPhase = phaseHolder{}
+
+	if _, err := RunGroupAlgorithms("grafel-no-such-group-5954"); err == nil {
+		t.Skip("unexpected: a bogus group resolved; cannot exercise the assembly failure path")
+	}
+	if got := CurrentPhase(); got != PhaseAssembling {
+		t.Fatalf("CurrentPhase() after a failed assembly = %q, want %q — the entrypoint does not stamp the phase",
+			got, PhaseAssembling)
+	}
+}
+
+// restorePhase makes the process-wide holder test-local.
+func restorePhase(t *testing.T) {
+	t.Helper()
+	prev := CurrentPhase()
+	t.Cleanup(func() { SetPhase(prev) })
+}


### PR DESCRIPTION
## Why

Whole-machine measurement of a from-scratch group reindex shows the peak is **no longer the index child**. At the peak instant the child is frequently at **0 MB**, and the machine holds:

```
engine 1816 MB  +  group-algo 2368 MB  =  4406 MB   (child 0 MB)
```

`group-algo` is often the single largest process on the machine — and it was completely untuned. `applyIndexGCPercent` / `applyIndexMemoryLimit` were called only in the `index-internal` branch of `main()`, and `RunSubprocessGroupAlgo` built its child env without `withMadvDontNeed` (unlike `RunSubprocessIndex`). So it ran at **GOGC=100, no memory limit, MADV_FREE**, with **zero memory instrumentation** — `memtrace.Start` had only two call sites repo-wide, neither of them this process.

## Instrumentation first, deliberately

The largest process at the machine peak reported nothing at all. This epic already lost a day to optimising against a misread metric (`heap_inuse` is live *plus uncollected garbage*, not live heap), so tuning a 2.4 GB process with no memstats was not going to happen twice.

`group-algo` now emits the same phase-tagged NDJSON + per-phase heap profiles as the index child, picked up by the perf harness for free. Phases: `assembling` → `hashing` → `running_algorithms` → `writing_overlay`.

**It immediately paid for itself.** Measured end-to-end against a scratch `GRAFEL_HOME` (read-only symlinks to already-indexed state dirs, dry-run, registered groups untouched), on a 148,455-entity / 700,321-relationship union:

| phase | live heap (`next_gc/1.5`) | samples |
|---|---|---|
| assembling | 303 MB | 6 |
| hashing | 457 MB | 2 |
| **running_algorithms** | **623 MB** | 767 |

**The peak is `running_algorithms`, not `assembling`.** Loading the entire group union costs 303 MB live; the Louvain/PageRank/betweenness pass more than doubles it. That redirects the next slice — presizing the assembly slices would have targeted the smaller half. This is recorded per-label in the phase doc where the next contributor will read it.

## Pacing

GOGC=50 and `madvdontneed` now apply to the `group-algo` child, matching the index child. The command gate became an **allow-list** (`index-internal`, `group-algo`) so a future command is not capped by default, and the standing rule is preserved: **interactive/foreground is never capped** — verified at the runtime level in a real process, and by mutation (forcing the gate true fails 10 subtests, including `interactive path is left untouched`).

**No GOMEMLIMIT on group-algo, deliberately.** An absolute soft target below an unmeasured live heap is the documented >4× death spiral (GOMEMLIMIT=1200 MiB against a 1714 MB live heap, never completed). GOGC is *relative* — `live × (1+GOGC/100)` — so it is ≥ live at any positive value and cannot enter that regime by construction. The distinction is stated in the code so a future contributor does not "tighten" it into a spiral.

## Phase order: a reorder, and it is hash-neutral

`RunGroupAlgorithms` previously stamped `assembling → running_algorithms → hashing`, disagreeing with the incremental entrypoint. Rather than document two orders, the hash now runs first so both entrypoints share one — pinned by a behavioural test rather than a comment.

That moved production code, so the risk was that `CommunityInputHash` had been seeing *post*-algorithm state: a changed hash would silently invalidate every stored memo or produce a false cache hit. Verified empirically on a real 148k-entity union:

```
hash before RunAlgorithms = 883cdf81469af11b8a210753eaec2ebeb3a80ba37e58c863641dc5ec86b935c8
hash after  RunAlgorithms = 883cdf81469af11b8a210753eaec2ebeb3a80ba37e58c863641dc5ec86b935c8
```

Byte-identical. Backed statically: `CommunityInputHash` is a pure function of the two slices and never sees `res`; the entire `RunAlgorithms` call tree reads `entities`/`rels` through value-copy range loops with **no indexed write anywhere** (`entities[` → 0 matches). The skip decision lives only in `RunGroupAlgorithmsIncremental`, which already hashed first and is unchanged here.

## Phase history, not just a sampled trace

`writing_overlay` drew **0 samples out of 775** — at the 250 ms default the sampled NDJSON structurally cannot tell an operator which stages ran. `PhaseHistory()` records the transition sequence as the ground truth a sampled trace is read against. Reads of the current phase stay lock-free on the `atomic.Value` (the ticker-polled hot path); the log takes a mutex only on a genuine change — four times per pass — and records transitions, not calls, so a stamp in a loop cannot inflate it.

## Verification

`go build ./...`, `go vet ./cmd/... ./internal/daemon/... ./internal/graph/...`, `gofmt -l internal cmd` clean. 27 packages ok across `./cmd/grafel/... ./internal/graph/... ./internal/daemon/...`; `groupalgo` green under `-race` with concurrent readers against 2,000 stamps. Goldens unchanged.

Independently adversarially reviewed across two rounds. Mutation-tested, no survivors:

| mutation | caught by |
|---|---|
| force the command gate true | 10 subtests, incl. interactive-uncapped |
| `withMadvDontNeed` → passthrough | `internal/daemon/sched` |
| drop `hashing` stamp in **one** entrypoint only | `TestPhaseOrder` (single-site divergence) |
| drop all `running_algorithms` / all `hashing` stamps | both order tests + write-overlay test |
| drop `writing_overlay` stamp | `TestWriteOverlayPhaseIsStamped` (its sole guard) |
| revert the reorder | `TestPhaseOrder` |

Also verified: child env construction is non-aliasing (tested with the `make([]string, 2, 8)` spare-capacity trap), and the instrumentation is inert when `GRAFEL_MEMTRACE_DIR` is unset.

## Known limits of the trace, documented at the source

- `memtrace` writes only on ticker ticks and `Stop` flushes nothing, so a run shorter than one tick produces a **0-byte NDJSON and zero profiles** — indistinguishable from broken instrumentation.
- `writing_overlay` should be treated as **unmeasured** unless the sample interval is lowered.
- `group-algo` is allow-listed unconditionally, so a hand-run `grafel group-algo --dry-run` is also capped at GOGC=50 — deliberate, so a manual trace is representative of the daemon's child, but it is one foreground invocation running capped.

**The MB win is unmeasured.** GOGC=50 was worth −605 MB on the index child, but nothing here has been measured on the corpus; that is the coordinator's next step.

Refs #5954
