### PR TITLE
perf(#5954): gate the write-side heavy stages so index/link/group-algo never overlap

### DIFF
--- a/internal/daemon/sched/cancelgroup_test.go
+++ b/internal/daemon/sched/cancelgroup_test.go
@@ -2,6 +2,7 @@ package sched
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -74,6 +75,15 @@ func TestCancelGroup_SupersededLinkPassCancelledThenNoneSurvives(t *testing.T) {
 	s := New(Config{
 		Workers:      1,
 		LinkDebounce: time.Millisecond,
+		// #5954: this test asserts the cancel-token IDENTITY machinery, whose
+		// whole premise is two link passes for one group running CONCURRENTLY.
+		// The heavy write-stage gate now makes that impossible in production
+		// (a second pass defers until the first releases the token), so the
+		// gate is switched off here to keep exercising the identity logic —
+		// which must remain correct as the defense-in-depth layer. The gated
+		// behaviour (a DEFERRED link pass is still reachable by CancelGroup) is
+		// covered by TestCancelGroup_DeferredLinkPassNeverRuns below.
+		StageGateDisabled: true,
 		Links: func(ctx context.Context, _ string) error {
 			n := int(atomic.AddInt32(&callN, 1) - 1)
 			if n > 1 {
@@ -113,6 +123,69 @@ func TestCancelGroup_SupersededLinkPassCancelledThenNoneSurvives(t *testing.T) {
 	}
 }
 
+// TestCancelGroup_DeferredLinkPassNeverRuns is the gate-ON counterpart of the
+// supersede test (#5954). With the heavy write-stage gate active, a second
+// group's link pass does not run concurrently — it DEFERS, staying armed under
+// linkTimers[group]. CancelGroup must still reach it, so a deleted group's
+// deferred pass never runs after the delete.
+func TestCancelGroup_DeferredLinkPassNeverRuns(t *testing.T) {
+	startedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	var ranB atomic.Int32
+
+	s := New(Config{
+		Workers:        1,
+		LinkDebounce:   time.Millisecond,
+		StageGateRetry: 5 * time.Millisecond,
+		Links: func(_ context.Context, group string) error {
+			if group == "gB" {
+				ranB.Add(1)
+				return nil
+			}
+			close(startedA)
+			<-releaseA
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	var releaseOnce sync.Once
+	releaseAFn := func() { releaseOnce.Do(func() { close(releaseA) }) }
+	s.Start()
+	defer func() { releaseAFn(); s.Stop() }()
+
+	s.scheduleLinks("gA")
+	<-startedA
+
+	// gB's pass fires while gA holds the token → it must defer, not run.
+	s.scheduleLinks("gB")
+	waitFor(t, 2*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, deferred := s.stageDeferSince["links:gB"]
+		return deferred
+	})
+	if n := ranB.Load(); n != 0 {
+		t.Fatalf("gB's link pass ran %d time(s) while gA held the stage token", n)
+	}
+
+	// Deleting gB must drop the deferred pass entirely.
+	s.CancelGroup("gB")
+
+	s.mu.Lock()
+	_, stillArmed := s.linkTimers["gB"]
+	_, stillDeferred := s.stageDeferSince["links:gB"]
+	s.mu.Unlock()
+	if stillArmed || stillDeferred {
+		t.Fatalf("CancelGroup must drop a DEFERRED link pass (armed=%v deferred=%v)", stillArmed, stillDeferred)
+	}
+
+	releaseAFn()
+	time.Sleep(50 * time.Millisecond)
+	if n := ranB.Load(); n != 0 {
+		t.Fatalf("a cancelled, deferred link pass ran %d time(s) after the group was deleted", n)
+	}
+}
+
 // TestCancelGroup_ScopedToGroup verifies cancellation is scoped: cancelling
 // group g1 does NOT cancel a different group g2's in-flight link pass.
 func TestCancelGroup_ScopedToGroup(t *testing.T) {
@@ -128,6 +201,11 @@ func TestCancelGroup_ScopedToGroup(t *testing.T) {
 	s := New(Config{
 		Workers:      1,
 		LinkDebounce: time.Millisecond,
+		// #5954: cancellation SCOPING is asserted by having two groups' link
+		// passes in flight simultaneously — which the heavy write-stage gate now
+		// serialises. Disable the gate so the scoping assertion (cancelling g1
+		// must not touch g2) keeps testing what it was written to test.
+		StageGateDisabled: true,
 		Links: func(ctx context.Context, group string) error {
 			close(started[group])
 			select {

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -285,6 +285,50 @@ type Config struct {
 	// heap to the OS. nil defaults to runtime/debug.FreeOSMemory. Overridable
 	// so tests can assert the trigger fires without paying for a real STW GC.
 	FreeOSMemory func()
+
+	// StageGateDisabled turns off the daemon-wide heavy write-stage gate
+	// (#5954), restoring the legacy behaviour where the index batch, the
+	// cross-repo link pass and the group-algo pass may run CONCURRENTLY. The
+	// gate is on by default: two co-resident copies of the same group union
+	// graph were the measured cause of the 4.4–5.3GB whole-machine peak. Kept
+	// as an escape hatch so the wall-clock cost of serialising is measurable
+	// against the pre-gate baseline. Env: GRAFEL_STAGE_GATE=0.
+	StageGateDisabled bool
+
+	// StageGateRetry is how long a DEFERRED heavy stage waits before re-testing
+	// the gate. <=0 defaults to stageGateRetryDefault (15s). Env:
+	// GRAFEL_STAGE_GATE_RETRY.
+	StageGateRetry time.Duration
+
+	// StageGateMaxDefer bounds how long an exclusive stage may be deferred by
+	// index activity before the gate raises a DRAIN BARRIER (stops admitting new
+	// index jobs so the in-flight batch clears and the starved stage can acquire
+	// without overlapping). This is the gate's own starvation guard — it
+	// replaces, rather than shares, GroupAlgoMaxWait, because gate deferral
+	// deliberately takes precedence over that max-wait. <=0 defaults to
+	// stageGateMaxDeferDefault (300s). Env: GRAFEL_STAGE_GATE_MAX_DEFER.
+	StageGateMaxDefer time.Duration
+
+	// StageGateHoldMax is the longest an exclusive stage may hold the token
+	// before the gate forfeits it and resumes index dispatch. The token is held
+	// across a subprocess spawn, so a crashed/wedged child must not wedge the
+	// daemon.
+	//
+	// This is the SCALE-SENSITIVE knob. It must exceed the duration of a
+	// LEGITIMATE group-algo pass on the deployment's largest group, or every
+	// pass is forfeited mid-flight and the gate silently degrades to no-gate on
+	// exactly the corpora it was built for. Watch for `stage_gate_forfeit` events
+	// and raise it if they appear. <=0 defaults to stageGateHoldMaxDefault (15m).
+	// Env: GRAFEL_STAGE_GATE_HOLD_MAX.
+	StageGateHoldMax time.Duration
+
+	// StageGateDrainMax bounds the drain barrier: how long index dispatch may be
+	// held while waiting for the in-flight batch to clear for a starved stage.
+	// The barrier only lapses once the batch has actually drained (see
+	// reapStageLocked), so this is the floor on that wait, not a hard cutoff
+	// while jobs are still executing. <=0 defaults to stageGateDrainMaxDefault
+	// (2m). Env: GRAFEL_STAGE_GATE_DRAIN_MAX.
+	StageGateDrainMax time.Duration
 }
 
 // deadManTimeout is how long the scheduler waits with a non-empty pending
@@ -468,6 +512,33 @@ type Scheduler struct {
 	// CURRENT idle period, so we release at most once until activity resumes
 	// (which resets it). Guarded by mu.
 	memReleased bool
+
+	// --- heavy write-stage gate (#5954). See stagegate.go. ---
+	// stageHolder names the exclusive stage currently holding the daemon-wide
+	// heavy write-stage token ("links:<group>" / "group-algo:<group>"), or "".
+	// The SHARED (index) side of the gate is not counted here: s.inflight
+	// already tracks it exactly.
+	stageHolder string
+	// stageHeldSince is when stageHolder acquired; drives StageGateHoldMax.
+	stageHeldSince time.Time
+	// stageDeferSince records, per stage name, when its CURRENT continuous
+	// deferral began. Cleared on acquire. Drives both the "deferred for N"
+	// observability and the StageGateMaxDefer starvation guard.
+	stageDeferSince map[string]time.Time
+	// stageDrainFor / stageDrainUntil are the DRAIN BARRIER: the starved stage
+	// that raised it, and the bounded deadline after which the barrier lapses so
+	// index dispatch can never be blocked indefinitely.
+	stageDrainFor   string
+	stageDrainUntil time.Time
+	// stageAdmitBlocked debounces the admit-side "held by a heavy stage" log to
+	// one line per blocked period (admitLoop retries once a second).
+	stageAdmitBlocked bool
+	// groupAlgoDeferred marks groups whose group-algo pass is currently DEFERRED
+	// by the gate. While set, the scheduler holds an indexstate.GroupAlgoBegin
+	// on the group's behalf so grafel_stats does NOT report an idle daemon
+	// across a deferral (an MCP consumer would otherwise read a stale overlay
+	// believing the work had settled). Guarded by mu.
+	groupAlgoDeferred map[string]bool
 }
 
 // jobToken couples a repo path with the predicted MB that admission
@@ -579,33 +650,52 @@ func New(cfg Config) *Scheduler {
 	if cfg.FreeOSMemory == nil {
 		cfg.FreeOSMemory = debug.FreeOSMemory
 	}
+	// Heavy write-stage gate (#5954). On by default; GRAFEL_STAGE_GATE=0 opts
+	// out. An explicit StageGateDisabled=true always wins.
+	if !cfg.StageGateDisabled && stageGateDisabledFromEnv() {
+		cfg.StageGateDisabled = true
+	}
+	if cfg.StageGateRetry <= 0 {
+		cfg.StageGateRetry = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_RETRY", stageGateRetryDefault)
+	}
+	if cfg.StageGateMaxDefer <= 0 {
+		cfg.StageGateMaxDefer = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_MAX_DEFER", stageGateMaxDeferDefault)
+	}
+	if cfg.StageGateHoldMax <= 0 {
+		cfg.StageGateHoldMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_HOLD_MAX", stageGateHoldMaxDefault)
+	}
+	if cfg.StageGateDrainMax <= 0 {
+		cfg.StageGateDrainMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_DRAIN_MAX", stageGateDrainMaxDefault)
+	}
 	algoCap := resolveAlgoCap(cfg.AlgoCap)
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	return &Scheduler{
-		cfg:              cfg,
-		logger:           cfg.Logger,
-		enq:              make(chan enqueueRequest, 64),
-		jobs:             make(chan jobToken, cfg.Workers),
-		wake:             make(chan struct{}, 1),
-		stop:             make(chan struct{}),
-		algoSem:          make(chan struct{}, algoCap),
-		inflight:         map[string]int64{},
-		pendingIndex:     map[string]bool{},
-		dirty:            map[string]bool{},
-		pendingRefs:      map[string]string{},
-		pendingCommits:   map[string]string{},
-		linkTimers:       map[string]*time.Timer{},
-		linkPending:      map[string]bool{},
-		groupAlgoTimers:  map[string]*time.Timer{},
-		groupAlgoPending: map[string]bool{},
-		groupAlgoCancel:  map[string]context.CancelFunc{},
-		groupAlgoArmedAt: map[string]time.Time{},
-		groupAlgoFireAt:  map[string]time.Time{},
-		linkCancel:       map[string]*linkPassCancel{},
-		indexCancel:      map[string]context.CancelFunc{},
-		indexedRepos:     map[string]repoStats{},
-		shutdownCtx:      shutdownCtx,
-		shutdownCancel:   shutdownCancel,
+		cfg:               cfg,
+		logger:            cfg.Logger,
+		enq:               make(chan enqueueRequest, 64),
+		jobs:              make(chan jobToken, cfg.Workers),
+		wake:              make(chan struct{}, 1),
+		stop:              make(chan struct{}),
+		algoSem:           make(chan struct{}, algoCap),
+		inflight:          map[string]int64{},
+		pendingIndex:      map[string]bool{},
+		dirty:             map[string]bool{},
+		pendingRefs:       map[string]string{},
+		pendingCommits:    map[string]string{},
+		linkTimers:        map[string]*time.Timer{},
+		linkPending:       map[string]bool{},
+		groupAlgoTimers:   map[string]*time.Timer{},
+		groupAlgoPending:  map[string]bool{},
+		groupAlgoCancel:   map[string]context.CancelFunc{},
+		groupAlgoArmedAt:  map[string]time.Time{},
+		groupAlgoFireAt:   map[string]time.Time{},
+		linkCancel:        map[string]*linkPassCancel{},
+		indexCancel:       map[string]context.CancelFunc{},
+		indexedRepos:      map[string]repoStats{},
+		stageDeferSince:   map[string]time.Time{},
+		groupAlgoDeferred: map[string]bool{},
+		shutdownCtx:       shutdownCtx,
+		shutdownCancel:    shutdownCancel,
 	}
 }
 
@@ -662,6 +752,15 @@ func (s *Scheduler) Stop() {
 	for _, c := range s.groupAlgoCancel {
 		c()
 	}
+	// #5954: drop every deferred-by-the-gate marker so the process-global
+	// indexstate counters return to zero on shutdown (they are balanced
+	// Begin/End pairs held on the scheduler's behalf, not per-goroutine defers).
+	for g := range s.groupAlgoDeferred {
+		s.markGroupAlgoDeferredLocked(g, false)
+	}
+	s.stageDeferSince = map[string]time.Time{}
+	s.stageDrainFor = ""
+	s.stageDrainUntil = time.Time{}
 }
 
 // Enqueue requests a (debounced+deduped) reindex of repoPath. The current
@@ -827,13 +926,19 @@ func (s *Scheduler) checkDeadMan() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if len(s.pendingQ) == 0 || len(s.inflight) > 0 {
+	now := time.Now()
+	// #5954: a held stage token (or a drain barrier) means heavy write-side work
+	// IS in progress — just not index work. The dead-man exists to detect
+	// "queue non-empty and nothing is happening"; force-admitting here would
+	// re-create the exact co-residency the gate removes. Both gate states are
+	// independently time-bounded (StageGateHoldMax / stageGateDrainMax), so the
+	// dead-man's own liveness guarantee survives the suppression.
+	if len(s.pendingQ) == 0 || len(s.inflight) > 0 || s.stageBusyLocked(now) {
 		// Queue is clear OR jobs are running — reset the clock.
 		s.deadManAt = time.Time{}
 		return
 	}
 
-	now := time.Now()
 	if s.deadManAt.IsZero() {
 		// Start the clock: queue has jobs but nothing is running.
 		s.deadManAt = now
@@ -991,6 +1096,12 @@ func (s *Scheduler) busyLocked() bool {
 	if len(s.inflight) > 0 || s.queueLen > 0 || len(s.pendingQ) > 0 {
 		return true
 	}
+	// #5954: an exclusive heavy stage holding the gate, or a stage deferred by
+	// it, is write-side work in flight — releasing the heap underneath it would
+	// be paid straight back.
+	if s.stageHolder != "" || s.stageDrainFor != "" || len(s.stageDeferSince) > 0 {
+		return true
+	}
 	for _, p := range s.groupAlgoPending {
 		if p {
 			return true
@@ -1126,6 +1237,23 @@ func (s *Scheduler) groupAlgoBusyLocked(group string) bool {
 func (s *Scheduler) tryAdmit() {
 	s.mu.Lock()
 	for len(s.pendingQ) > 0 {
+		// #5954: hold index dispatch while an exclusive heavy stage (link pass /
+		// group-algo) owns the daemon-wide stage token, or while a starved stage
+		// has raised the drain barrier. The queue is untouched — every release
+		// pokes the admission loop, and the 1s safety tick is a second path back
+		// here, so nothing is lost.
+		if !s.allowIndexAdmitLocked(time.Now()) {
+			if !s.stageAdmitBlocked {
+				s.stageAdmitBlocked = true
+				s.logEventLocked("admit_stage_defer", s.pendingQ[0],
+					"holding index dispatch — "+s.stageBlockReasonLocked()+" (#5954)")
+				s.logger.Info("sched: holding index dispatch behind a heavy write stage",
+					"reason", s.stageBlockReasonLocked(), "queued", len(s.pendingQ))
+			}
+			s.mu.Unlock()
+			return
+		}
+		s.stageAdmitBlocked = false
 		repo := s.pendingQ[0]
 		ref := s.pendingRefs[repo]
 		commit := s.pendingCommits[repo]
@@ -1557,49 +1685,73 @@ func (s *Scheduler) scheduleLinks(group string) {
 		t.Stop()
 	}
 	s.linkPending[group] = true
-	s.linkTimers[group] = time.AfterFunc(s.cfg.LinkDebounce, func() {
-		s.mu.Lock()
-		s.linkPending[group] = false
-		delete(s.linkTimers, group)
-		// Derive a PER-GROUP cancel context from shutdownCtx (not shutdownCtx
-		// directly) so that a group delete can interrupt THIS group's in-flight
-		// link pass via CancelGroup without waiting for daemon Stop(). Still
-		// rooted at shutdownCtx so daemon shutdown also cancels it. Stored so
-		// CancelGroup can reach it; cleared once runLinks returns.
-		ctx, cancel := context.WithCancel(s.shutdownCtx)
-		tok := &linkPassCancel{cancel: cancel}
-		// Supersede any still-registered predecessor by CANCELLING it before
-		// overwriting the entry — do NOT just drop it. runLinks executes on this
-		// timer AfterFunc goroutine (not the worker pool), so when a link pass
-		// outlasts LinkDebounce and a repo reindex re-arms scheduleLinks, pass-1
-		// and pass-2 run CONCURRENTLY. Without this cancel, only pass-2's token is
-		// in the map, so a later CancelGroup reaches only pass-2 and pass-1 (the
-		// long betweenness/phantom pass) runs to completion for a deleted group.
-		// Cancelling the predecessor makes link passes single-flight for
-		// cancellation: at any moment only the newest pass is live, so CancelGroup
-		// always reaches it and NO pass survives a delete. The superseded pass
-		// aborts at its next ctx checkpoint (RunLinksForGroupCtx); its output is
-		// harmless — the newer pass rewrites everything from the latest graphs.
-		if prev, ok := s.linkCancel[group]; ok {
-			prev.cancel()
-		}
-		s.linkCancel[group] = tok
-		s.mu.Unlock()
-
-		s.runLinks(ctx, group)
-
-		s.mu.Lock()
-		// Only clear the entry if it is still OUR token. An overlapping second
-		// link pass (this group's timer re-armed while we ran) or a CancelGroup
-		// may have already replaced/removed it; blind-deleting here would drop
-		// the newer pass's live cancel and re-open the leak.
-		if s.linkCancel[group] == tok {
-			delete(s.linkCancel, group)
-		}
-		s.mu.Unlock()
-		cancel()
-	})
+	s.linkTimers[group] = time.AfterFunc(s.cfg.LinkDebounce, func() { s.fireLinks(group) })
 	s.mu.Unlock()
+}
+
+// fireLinks is the link-debounce timer body, split out of scheduleLinks so a
+// firing timer that finds the machine BUSY can re-arm itself instead of running
+// (#5954). It acquires the daemon-wide heavy write-stage token first; on failure
+// the pass stays PENDING (linkPending is never cleared) and a fresh retry timer
+// is armed under the same linkTimers[group] key — so CancelGroup still reaches
+// it and no work is lost.
+func (s *Scheduler) fireLinks(group string) {
+	if s.stopped() {
+		return // shutting down — do not re-arm a retry timer that outlives Stop
+	}
+	name := "links:" + group
+	now := time.Now()
+
+	s.mu.Lock()
+	if !s.tryAcquireStageLocked(name, now) {
+		delay := s.noteStageDeferLocked(name, now)
+		s.linkPending[group] = true
+		if t, ok := s.linkTimers[group]; ok {
+			t.Stop()
+		}
+		s.linkTimers[group] = time.AfterFunc(delay, func() { s.fireLinks(group) })
+		s.mu.Unlock()
+		return
+	}
+	s.linkPending[group] = false
+	delete(s.linkTimers, group)
+	// Derive a PER-GROUP cancel context from shutdownCtx (not shutdownCtx
+	// directly) so that a group delete can interrupt THIS group's in-flight
+	// link pass via CancelGroup without waiting for daemon Stop(). Still
+	// rooted at shutdownCtx so daemon shutdown also cancels it. Stored so
+	// CancelGroup can reach it; cleared once runLinks returns.
+	ctx, cancel := context.WithCancel(s.shutdownCtx)
+	tok := &linkPassCancel{cancel: cancel}
+	// Supersede any still-registered predecessor by CANCELLING it before
+	// overwriting the entry — do NOT just drop it. runLinks executes on this
+	// timer AfterFunc goroutine (not the worker pool), so when a link pass
+	// outlasts LinkDebounce and a repo reindex re-arms scheduleLinks, pass-1
+	// and pass-2 could run CONCURRENTLY. (The stage token now also serialises
+	// them, but the identity check remains the cancellation-correctness
+	// guarantee.) Without this cancel, only pass-2's token is in the map, so a
+	// later CancelGroup reaches only pass-2 and pass-1 (the long
+	// betweenness/phantom pass) runs to completion for a deleted group.
+	if prev, ok := s.linkCancel[group]; ok {
+		prev.cancel()
+	}
+	s.linkCancel[group] = tok
+	s.mu.Unlock()
+
+	// Release on EVERY exit path — normal return, error, cancellation, panic.
+	defer s.releaseStage(name)
+
+	s.runLinks(ctx, group)
+
+	s.mu.Lock()
+	// Only clear the entry if it is still OUR token. An overlapping second
+	// link pass (this group's timer re-armed while we ran) or a CancelGroup
+	// may have already replaced/removed it; blind-deleting here would drop
+	// the newer pass's live cancel and re-open the leak.
+	if s.linkCancel[group] == tok {
+		delete(s.linkCancel, group)
+	}
+	s.mu.Unlock()
+	cancel()
 }
 
 func (s *Scheduler) runLinks(ctx context.Context, group string) {
@@ -1758,26 +1910,84 @@ func (s *Scheduler) scheduleGroupAlgo(group string) {
 	s.groupAlgoArmedAt[group] = armedAt
 	s.groupAlgoFireAt[group] = fireAt
 	s.groupAlgoPending[group] = true
-	s.groupAlgoTimers[group] = time.AfterFunc(delay, func() {
-		s.mu.Lock()
-		s.groupAlgoPending[group] = false
-		delete(s.groupAlgoTimers, group)
-		delete(s.groupAlgoArmedAt, group) // window closed — next arm starts fresh
-		delete(s.groupAlgoFireAt, group)
-		// Derive the per-run cancel context from shutdownCtx (not
-		// context.Background()) so that on Stop() the in-flight group-algo pass
-		// — which may fork a subprocess — receives cancellation. Mirrors runIndex
-		// and runLinks. Fixes the leak class of issue #2493.
-		ctx, cancel := context.WithCancel(s.shutdownCtx)
-		s.groupAlgoCancel[group] = cancel
-		s.mu.Unlock()
+	s.groupAlgoTimers[group] = time.AfterFunc(delay, func() { s.fireGroupAlgo(group) })
+}
 
-		s.runGroupAlgo(ctx, group)
+// fireGroupAlgo is the group-algo debounce timer body, split out of
+// scheduleGroupAlgo so a firing timer that finds the machine BUSY can re-arm
+// itself instead of running (#5954).
+//
+// This is where the #5450 max-wait and the stage gate meet. The max-wait forces
+// the timer to FIRE promptly under sustained churn; the gate can still refuse to
+// let it RUN. Deferral wins — a max-wait firing that runs anyway would make the
+// gate decorative under exactly the sustained-churn conditions that produce the
+// worst peaks. The gate's own bounded starvation guard (the drain barrier, see
+// noteStageDeferLocked) is what keeps the pass from being starved forever.
+func (s *Scheduler) fireGroupAlgo(group string) {
+	if s.stopped() {
+		return // shutting down — do not re-arm a retry timer that outlives Stop
+	}
+	name := "group-algo:" + group
+	now := time.Now()
 
-		s.mu.Lock()
-		delete(s.groupAlgoCancel, group)
+	s.mu.Lock()
+	if !s.tryAcquireStageLocked(name, now) {
+		delay := s.noteStageDeferLocked(name, now)
+		// A DEFERRED pass must stay visible to grafel_stats exactly like a
+		// RUNNING one, or an MCP consumer polling across the deferral sees an
+		// idle daemon and trusts a stale overlay.
+		s.markGroupAlgoDeferredLocked(group, true)
+		s.groupAlgoPending[group] = true
+		if t, ok := s.groupAlgoTimers[group]; ok {
+			t.Stop()
+		}
+		s.groupAlgoFireAt[group] = now.Add(delay)
+		s.groupAlgoTimers[group] = time.AfterFunc(delay, func() { s.fireGroupAlgo(group) })
 		s.mu.Unlock()
-	})
+		return
+	}
+	s.groupAlgoPending[group] = false
+	delete(s.groupAlgoTimers, group)
+	delete(s.groupAlgoArmedAt, group) // window closed — next arm starts fresh
+	delete(s.groupAlgoFireAt, group)
+	// Derive the per-run cancel context from shutdownCtx (not
+	// context.Background()) so that on Stop() the in-flight group-algo pass
+	// — which may fork a subprocess — receives cancellation. Mirrors runIndex
+	// and runLinks. Fixes the leak class of issue #2493.
+	ctx, cancel := context.WithCancel(s.shutdownCtx)
+	s.groupAlgoCancel[group] = cancel
+	s.mu.Unlock()
+
+	// Release on EVERY exit path — normal return, error, cancellation, panic.
+	defer s.releaseStage(name)
+
+	s.runGroupAlgo(ctx, group)
+
+	s.mu.Lock()
+	delete(s.groupAlgoCancel, group)
+	// Drop the deferred marker only now: runGroupAlgo holds its own
+	// GroupAlgoBegin for the RUNNING window, so clearing here keeps the
+	// deferred→running indexstate coverage continuous (count 1 → 2 → 1 → 0)
+	// rather than dipping to zero between the two.
+	s.markGroupAlgoDeferredLocked(group, false)
+	s.mu.Unlock()
+	cancel()
+}
+
+// markGroupAlgoDeferredLocked toggles a group's "deferred by the stage gate"
+// marker, holding exactly one balanced indexstate.GroupAlgoBegin/End pair for
+// the duration. Idempotent. MUST be called with s.mu held.
+func (s *Scheduler) markGroupAlgoDeferredLocked(group string, deferred bool) {
+	if s.groupAlgoDeferred[group] == deferred {
+		return
+	}
+	if deferred {
+		s.groupAlgoDeferred[group] = true
+		indexstate.GroupAlgoBegin()
+		return
+	}
+	delete(s.groupAlgoDeferred, group)
+	indexstate.GroupAlgoEnd()
 }
 
 // cancelGroupAlgoLocked stops any pending timer or cancels an in-flight
@@ -1797,6 +2007,23 @@ func (s *Scheduler) cancelGroupAlgoLocked(group string) {
 	// superseding pass) ends the window so the next arm starts a fresh budget.
 	delete(s.groupAlgoArmedAt, group)
 	delete(s.groupAlgoFireAt, group)
+	// #5954: the pass is no longer deferred-by-the-gate — drop the marker (and
+	// its balanced indexstate hold) plus any deferral bookkeeping, so a cancelled
+	// pass cannot leave the daemon looking permanently busy.
+	s.markGroupAlgoDeferredLocked(group, false)
+	s.clearStageDeferralLocked("group-algo:" + group)
+}
+
+// clearStageDeferralLocked drops a stage's deferral bookkeeping (and the drain
+// barrier if that stage owns it), so a cancelled or superseded stage does not
+// keep index dispatch held or the scheduler reported busy. MUST be called with
+// s.mu held.
+func (s *Scheduler) clearStageDeferralLocked(name string) {
+	delete(s.stageDeferSince, name)
+	if s.stageDrainFor == name {
+		s.stageDrainFor = ""
+		s.stageDrainUntil = time.Time{}
+	}
 }
 
 // linkPassCancel is a per-in-flight-link-pass identity token wrapping its cancel
@@ -1840,6 +2067,7 @@ func (s *Scheduler) CancelGroup(group string) {
 		tok.cancel()
 		delete(s.linkCancel, group)
 	}
+	s.clearStageDeferralLocked("links:" + group)
 
 	// In-flight per-repo reindexes whose repo belongs ONLY to this group (or to
 	// this group among others that are also being torn down). A repo still

--- a/internal/daemon/sched/stagegate.go
+++ b/internal/daemon/sched/stagegate.go
@@ -1,0 +1,298 @@
+package sched
+
+import (
+	"os"
+	"strings"
+	"time"
+)
+
+// The heavy write-stage gate (#5954).
+//
+// The daemon runs three heavy write-side stages, each of which materialises a
+// large slice of a group's union graph:
+//
+//  1. the per-repo index batch (subprocess `grafel index-internal`),
+//  2. the cross-repo link pass (IN-PROCESS in the engine),
+//  3. the group-algorithm pass (subprocess `grafel group-algo --write`).
+//
+// Nothing used to make them mutually exclusive. algoSem bounds group-algo passes
+// against EACH OTHER; the RSS admission ledger (tryAdmit) ledgers INDEX jobs
+// only and has no knowledge that the other two exist. With a 180s group-algo
+// debounce against per-repo indexes that take tens of seconds, overlap was the
+// normal case — and the measured whole-machine peak was the SUM of two
+// co-resident copies of the same graph (engine 1816MB + group-algo 2368MB) even
+// at instants when the index child was at 0MB.
+//
+// The gate is a single daemon-wide token with two classes of holder:
+//
+//   - SHARED  — index jobs. Their occupancy is already tracked exactly by
+//     s.inflight, so the gate reads that rather than duplicating a counter.
+//   - EXCLUSIVE — the link pass and the group-algo pass, one at a time,
+//     and never while any index job is executing.
+//
+// Neither side ever BLOCKS on the other, so the gate cannot deadlock:
+//
+//   - an exclusive stage whose timer fires while the machine is busy DEFERS:
+//     it re-arms its own timer (stays pending, never dropped) and retries;
+//   - index dispatch is held in tryAdmit while an exclusive stage holds the
+//     token, and is released by the poke() that every stage release performs.
+//
+// Starvation (see noteStageDeferLocked) is bounded by escalating a long-running
+// deferral into a DRAIN BARRIER rather than by letting the stage run anyway.
+
+const (
+	// stageGateRetryDefault is how long a deferred heavy stage waits before
+	// re-testing the gate. Short enough to seize a natural gap between index
+	// batches (a per-repo index takes tens of seconds), long enough that a
+	// deferral loop costs nothing measurable.
+	stageGateRetryDefault = 15 * time.Second
+
+	// stageGateMaxDeferDefault bounds how long an exclusive stage may be held
+	// off by index activity before the gate escalates to a drain barrier. It
+	// deliberately mirrors groupAlgoMaxWaitDefault (300s): the gate takes
+	// PRECEDENCE over that max-wait (otherwise the gate would be decorative
+	// under exactly the sustained-churn conditions that produce the worst RSS
+	// peaks), so it must carry an equivalent starvation budget of its own.
+	stageGateMaxDeferDefault = 300 * time.Second
+
+	// stageGateHoldMaxDefault is the longest an exclusive stage may hold the
+	// token before the gate FORFEITS it and resumes index dispatch. The token
+	// is held across a subprocess spawn (group-algo), so a child that wedges or
+	// is SIGKILLed in a way that never returns must not wedge the daemon
+	// forever. This is a safety valve, not a scheduling parameter — but it is
+	// SCALE-SENSITIVE and must be tunable in the field (GRAFEL_STAGE_GATE_HOLD_
+	// MAX / Config.StageGateHoldMax). A group-algo pass measures ~4 min on the
+	// current corpus, so 15m is ~3.75x headroom; on a corpus ~4x larger a
+	// LEGITIMATE pass would exceed it, be forfeited on every run, and silently
+	// degrade the gate to no-gate precisely on the largest corpora it exists
+	// for. A burst of `stage_gate_forfeit` events is that signal — raise this.
+	stageGateHoldMaxDefault = 15 * time.Minute
+
+	// stageGateDrainMaxDefault bounds the DRAIN BARRIER (the starvation guard).
+	// While the barrier is up no NEW index job is dispatched, so the in-flight
+	// batch drains and the starved stage can acquire the token without ever
+	// overlapping. The barrier is bounded so that a stage which somehow never
+	// acquires cannot block index dispatch indefinitely; it is comfortably
+	// longer than a single per-repo index. Tunable via Config.StageGateDrainMax.
+	stageGateDrainMaxDefault = 2 * time.Minute
+)
+
+// stageGateDisabledFromEnv reports whether GRAFEL_STAGE_GATE explicitly turns
+// the gate off ("0"/"false"/"off"). Any other value (including unset) leaves it
+// enabled — the gate is the default because peak RSS on a 16GB laptop is the
+// binding constraint, not reindex wall-clock.
+func stageGateDisabledFromEnv() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("GRAFEL_STAGE_GATE"))) {
+	case "0", "false", "off", "no":
+		return true
+	}
+	return false
+}
+
+// stageGateDurationFromEnv resolves a Go duration from env, falling back to def.
+func stageGateDurationFromEnv(key string, def time.Duration) time.Duration {
+	if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return def
+}
+
+// stopped reports whether Stop() has been signalled. A deferred stage re-arms a
+// retry timer, so every fire path checks this first: without it a timer firing
+// during shutdown could arm a successor that outlives the scheduler.
+func (s *Scheduler) stopped() bool {
+	select {
+	case <-s.stop:
+		return true
+	default:
+		return false
+	}
+}
+
+// reapStageLocked expires a wedged token holder and a stale drain barrier. MUST
+// be called with s.mu held. It is the "no lost work, no wedge" half of the gate:
+// every blocking-ish piece of state has a bounded lifetime.
+//
+// THE NO-OVERLAP INVARIANT IS CONDITIONAL ON THIS FUNCTION NOT FIRING. The
+// forfeit below clears stageHolder WITHOUT cancelling the wedged stage — the
+// gate has no cancel handle for it, and even if it did, a stage that has stopped
+// responding for StageGateHoldMax is unlikely to honour one. So after a forfeit a
+// second exclusive stage CAN become co-resident with the first. That is the
+// deliberate trade: a transient overlap is strictly better than a permanently
+// wedged daemon that never indexes again. The identity check in releaseStage is
+// the other half — a late-returning forfeited stage must not clear the NEW
+// holder's token. Everything else in the gate holds unconditionally; this is the
+// one documented exception, and it is loud (ERROR + stage_gate_forfeit event).
+func (s *Scheduler) reapStageLocked(now time.Time) {
+	if s.stageHolder != "" && s.cfg.StageGateHoldMax > 0 &&
+		now.Sub(s.stageHeldSince) > s.cfg.StageGateHoldMax {
+		held := now.Sub(s.stageHeldSince).Truncate(time.Second)
+		s.logEventLocked("stage_gate_forfeit", "",
+			s.stageHolder+": held the heavy-stage token for "+held.String()+" — forfeiting so index dispatch resumes (#5954)")
+		s.logger.Error("sched: heavy write-stage token forfeited after hold-max — a stage or its subprocess never returned",
+			"stage", s.stageHolder, "held_for", held, "hold_max", s.cfg.StageGateHoldMax)
+		s.stageHolder = ""
+		s.stageHeldSince = time.Time{}
+	}
+	// Expire a stale drain barrier — but ONLY once the batch it was raised to
+	// drain has actually cleared. Expiring while index jobs are still executing
+	// would re-open dispatch in the one state the barrier exists to prevent, and
+	// the starved stage would immediately re-raise it on its next retry anyway
+	// (measured: latency-to-first-run is unchanged either way, because the
+	// re-raise wins the race). Gating on an empty inflight map turns that race
+	// into a guarantee. The barrier is still bounded: with dispatch held, the
+	// in-flight batch drains within one index duration.
+	if s.stageDrainFor != "" && now.After(s.stageDrainUntil) && len(s.inflight) == 0 {
+		s.logEventLocked("stage_gate_drain_expired", "",
+			s.stageDrainFor+": drain barrier expired without acquiring — resuming index dispatch (#5954)")
+		s.stageDrainFor = ""
+		s.stageDrainUntil = time.Time{}
+	}
+}
+
+// allowIndexAdmitLocked reports whether a NEW index job may be dispatched to a
+// worker. It is false while an exclusive heavy stage holds the token, and while
+// a starved stage has raised the drain barrier. MUST be called with s.mu held.
+//
+// Interactive/user-initiated work is NOT held by this gate. The synchronous
+// Index RPC (Service.Index without Async) calls s.index directly and never
+// touches the scheduler queue; the foreground group-rebuild
+// (daemonRebuildFuncCore) calls the extractor directly for the same reason. The
+// only caller routed through this gate is Index{Async:true} — background,
+// already-debounced, fire-and-forget reindexing.
+//
+// SCOPE LIMIT — the rebuild link pass is NOT covered. repolock is a per-repo
+// INDEX mutex (internal/repolock: foreground rebuild vs. scheduler reindex of
+// the same repo path); it says nothing about heavy GROUP stages. The rebuild RPC
+// runs its OWN in-process cross-repo link pass (cmd/grafel/daemon.go linksFn →
+// runLinksHookWithCtx) entirely outside the scheduler, so a multi-minute rebuild
+// link pass can still be co-resident with a scheduler group-algo pass. That
+// hazard predates this gate and is user-initiated, so it is not a regression —
+// but do not read this gate as covering it.
+func (s *Scheduler) allowIndexAdmitLocked(now time.Time) bool {
+	if s.cfg.StageGateDisabled {
+		return true
+	}
+	s.reapStageLocked(now)
+	return s.stageHolder == "" && s.stageDrainFor == ""
+}
+
+// stageBusyLocked reports whether the gate itself represents work in progress
+// (an exclusive stage running, or a drain barrier waiting for the index batch to
+// clear). The dead-man switch consults this: its job is to detect "queue
+// non-empty and NOTHING is happening", and under the gate something IS happening
+// — force-admitting an index there would re-create the exact overlap the gate
+// exists to remove. Both states are individually time-bounded (StageGateHoldMax,
+// StageGateDrainMax), so the dead-man's own guarantee survives.
+// MUST be called with s.mu held.
+func (s *Scheduler) stageBusyLocked(now time.Time) bool {
+	if s.cfg.StageGateDisabled {
+		return false
+	}
+	s.reapStageLocked(now)
+	return s.stageHolder != "" || s.stageDrainFor != ""
+}
+
+// tryAcquireStageLocked attempts to take the EXCLUSIVE heavy-stage token for
+// `name`. It never blocks. It succeeds only when no other exclusive stage holds
+// the token AND no index job is executing. MUST be called with s.mu held.
+//
+// A drain barrier raised by a DIFFERENT stage also blocks acquisition, so the
+// starved stage that paid for the barrier is the one that gets through it.
+func (s *Scheduler) tryAcquireStageLocked(name string, now time.Time) bool {
+	if s.cfg.StageGateDisabled {
+		return true
+	}
+	s.reapStageLocked(now)
+	if s.stageHolder != "" {
+		return false
+	}
+	if len(s.inflight) > 0 {
+		return false
+	}
+	if s.stageDrainFor != "" && s.stageDrainFor != name {
+		return false
+	}
+	if since, ok := s.stageDeferSince[name]; ok {
+		waited := now.Sub(since).Truncate(time.Millisecond)
+		s.logEventLocked("stage_gate_admit", "",
+			name+": acquired the heavy-stage token after deferring for "+waited.String()+" (#5954)")
+		s.logger.Info("sched: heavy write-stage resumed after deferral",
+			"stage", name, "deferred_for", waited)
+		delete(s.stageDeferSince, name)
+	}
+	if s.stageDrainFor == name {
+		s.stageDrainFor = ""
+		s.stageDrainUntil = time.Time{}
+	}
+	s.stageHolder = name
+	s.stageHeldSince = now
+	return true
+}
+
+// noteStageDeferLocked records that `name` could not acquire the token, and
+// returns how long to wait before re-testing. MUST be called with s.mu held.
+//
+// Starvation resolution (the max-wait tension). scheduleGroupAlgo's #5450
+// max-wait bounds DEBOUNCE starvation by firing the timer promptly under
+// churn; the gate then refuses to let that firing RUN while an index batch is
+// executing. Deferral deliberately takes precedence over the max-wait —
+// otherwise the gate would be bypassed exactly when it matters. The replacement
+// bound is not "eventually run anyway" (that would reintroduce the overlap);
+// it is a DRAIN BARRIER: after StageGateMaxDefer of continuous deferral the
+// gate stops admitting NEW index jobs, so the in-flight batch drains within one
+// index duration and the starved stage then acquires cleanly. Progress is
+// therefore guaranteed, and the no-overlap invariant is never traded away.
+func (s *Scheduler) noteStageDeferLocked(name string, now time.Time) time.Duration {
+	first, ok := s.stageDeferSince[name]
+	if !ok {
+		first = now
+		s.stageDeferSince[name] = now
+		s.logEventLocked("stage_gate_defer", "",
+			name+": deferring — "+s.stageBlockReasonLocked()+" (#5954)")
+		s.logger.Info("sched: deferring heavy write stage to avoid a co-resident graph copy",
+			"stage", name, "reason", s.stageBlockReasonLocked(), "retry_in", s.cfg.StageGateRetry)
+	}
+	if waited := now.Sub(first); waited >= s.cfg.StageGateMaxDefer && s.stageDrainFor == "" {
+		s.stageDrainFor = name
+		s.stageDrainUntil = now.Add(s.cfg.StageGateDrainMax)
+		s.logEventLocked("stage_gate_drain", "",
+			name+": deferred "+waited.Truncate(time.Second).String()+" — holding index dispatch so the batch drains (#5954)")
+		s.logger.Warn("sched: heavy write stage starved by index churn — raising drain barrier",
+			"stage", name, "deferred_for", waited.Truncate(time.Second), "max_defer", s.cfg.StageGateMaxDefer)
+	}
+	return s.cfg.StageGateRetry
+}
+
+// stageBlockReasonLocked renders why the token is currently unavailable.
+// MUST be called with s.mu held.
+func (s *Scheduler) stageBlockReasonLocked() string {
+	switch {
+	case s.stageHolder != "":
+		return "stage " + s.stageHolder + " holds the token"
+	case len(s.inflight) > 0:
+		return itoa(int64(len(s.inflight))) + " index job(s) in flight"
+	case s.stageDrainFor != "":
+		return "stage " + s.stageDrainFor + " owns the drain barrier"
+	default:
+		return "unknown"
+	}
+}
+
+// releaseStage hands the exclusive token back and wakes admission. Always
+// invoked via `defer` at the acquisition site, so it also runs when the stage
+// returns an error, is cancelled, or panics.
+func (s *Scheduler) releaseStage(name string) {
+	s.mu.Lock()
+	if s.stageHolder == name {
+		held := time.Since(s.stageHeldSince).Truncate(time.Millisecond)
+		s.stageHolder = ""
+		s.stageHeldSince = time.Time{}
+		s.logEventLocked("stage_gate_release", "", name+" held "+held.String())
+	}
+	s.mu.Unlock()
+	// Capacity has freed: let the admission loop dispatch queued index jobs.
+	s.poke()
+}

--- a/internal/daemon/sched/stagegate_5954_test.go
+++ b/internal/daemon/sched/stagegate_5954_test.go
@@ -1,0 +1,635 @@
+package sched
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+)
+
+var errStageTest = errors.New("stage failed (test)")
+
+// #5954 heavy write-stage gate.
+//
+// The daemon has three heavy write stages — the per-repo index batch, the
+// cross-repo link pass, and the group-algorithm pass. Each materialises a large
+// slice of the group graph. Historically nothing prevented them from running
+// CONCURRENTLY (the 180s group-algo debounce is shorter than a full reindex, so
+// overlap was the normal case), and the whole-machine RSS peak was the SUM of
+// two co-resident copies. These tests pin the invariant: at most ONE heavy
+// stage executes at a time, deferral is always eventually resolved, and the
+// gate is released on every exit path.
+
+// stageProbe records, for every heavy-stage callback, whether a stage of the
+// OTHER class was executing at the same moment. Index jobs may run concurrently
+// with each other (worker pool + RSS admission bound that); what must never
+// happen is an index job overlapping an exclusive stage, or two exclusive
+// stages overlapping.
+type stageProbe struct {
+	indexActive     atomic.Int32
+	exclusiveActive atomic.Int32
+	violations      atomic.Int32
+
+	mu    sync.Mutex
+	order []string
+}
+
+func (p *stageProbe) record(ev string) {
+	p.mu.Lock()
+	p.order = append(p.order, ev)
+	p.mu.Unlock()
+}
+
+func (p *stageProbe) events() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	out := make([]string, len(p.order))
+	copy(out, p.order)
+	return out
+}
+
+// enterIndex/leaveIndex bracket an index callback.
+func (p *stageProbe) enterIndex(name string) {
+	if p.exclusiveActive.Load() > 0 {
+		p.violations.Add(1)
+	}
+	p.indexActive.Add(1)
+	p.record("index_start:" + name)
+}
+
+func (p *stageProbe) leaveIndex(name string) {
+	p.indexActive.Add(-1)
+	p.record("index_done:" + name)
+}
+
+// enterExclusive/leaveExclusive bracket a link or group-algo callback.
+func (p *stageProbe) enterExclusive(name string) {
+	if p.indexActive.Load() > 0 || p.exclusiveActive.Load() > 0 {
+		p.violations.Add(1)
+	}
+	p.exclusiveActive.Add(1)
+	p.record("exclusive_start:" + name)
+}
+
+func (p *stageProbe) leaveExclusive(name string) {
+	p.exclusiveActive.Add(-1)
+	p.record("exclusive_done:" + name)
+}
+
+func (p *stageProbe) assertNoOverlap(t *testing.T) {
+	t.Helper()
+	if v := p.violations.Load(); v != 0 {
+		t.Fatalf("heavy write stages overlapped %d time(s); event order: %v", v, p.events())
+	}
+}
+
+// TestStageGate_GroupAlgoDefersWhileIndexRunning: an armed group-algo pass whose
+// timer fires while a per-repo index is in flight must DEFER — it must not start
+// until the index batch has drained.
+func TestStageGate_GroupAlgoDefersWhileIndexRunning(t *testing.T) {
+	var probe stageProbe
+	release := make(chan struct{})
+	indexEntered := make(chan struct{}, 1)
+	var algoRuns atomic.Int32
+
+	s := New(Config{
+		Workers:           2,
+		LinkDebounce:      time.Hour, // never chain; we arm the algo pass by hand
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour, // starvation guard NOT exercised here
+		Index: func(_ context.Context, repo string, _ string) error {
+			probe.enterIndex(repo)
+			defer probe.leaveIndex(repo)
+			select {
+			case indexEntered <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			probe.enterExclusive("algo:" + g)
+			defer probe.leaveExclusive("algo:" + g)
+			algoRuns.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return []string{"acme"} },
+		MemReleaseDisabled: true,
+	})
+	var releaseOnce sync.Once
+	releaseIndex := func() { releaseOnce.Do(func() { close(release) }) }
+	s.Start()
+	defer func() { releaseIndex(); s.Stop() }()
+
+	s.Enqueue("/slow-repo")
+	<-indexEntered
+
+	// Arm the group-algo pass while the index is still executing.
+	s.scheduleGroupAlgo("acme")
+
+	// Give the (5ms) debounce and several retry cycles a chance to fire.
+	time.Sleep(80 * time.Millisecond)
+	if n := algoRuns.Load(); n != 0 {
+		t.Fatalf("group-algo ran %d time(s) while an index was in flight; it must defer", n)
+	}
+
+	// Release the index; the deferred pass must now run.
+	releaseIndex()
+	waitFor(t, 3*time.Second, func() bool { return algoRuns.Load() >= 1 })
+	probe.assertNoOverlap(t)
+}
+
+// TestStageGate_IndexDefersWhileGroupAlgoRunning: the reciprocal direction. A
+// newly enqueued repo must NOT be dispatched to a worker while an exclusive
+// stage (group-algo) is executing.
+func TestStageGate_IndexDefersWhileGroupAlgoRunning(t *testing.T) {
+	var probe stageProbe
+	algoEntered := make(chan struct{}, 1)
+	releaseAlgo := make(chan struct{})
+	var indexRuns atomic.Int32
+
+	s := New(Config{
+		Workers:           2,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		StageGateHoldMax:  time.Hour,
+		Index: func(_ context.Context, repo string, _ string) error {
+			probe.enterIndex(repo)
+			defer probe.leaveIndex(repo)
+			indexRuns.Add(1)
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			probe.enterExclusive("algo:" + g)
+			defer probe.leaveExclusive("algo:" + g)
+			select {
+			case algoEntered <- struct{}{}:
+			default:
+			}
+			<-releaseAlgo
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return []string{"acme"} },
+		MemReleaseDisabled: true,
+	})
+	var releaseOnce sync.Once
+	releaseAlgoFn := func() { releaseOnce.Do(func() { close(releaseAlgo) }) }
+	s.Start()
+	defer func() { releaseAlgoFn(); s.Stop() }()
+
+	s.scheduleGroupAlgo("acme")
+	<-algoEntered
+
+	s.Enqueue("/repo-a")
+	time.Sleep(80 * time.Millisecond)
+	if n := indexRuns.Load(); n != 0 {
+		t.Fatalf("index ran %d time(s) while a group-algo pass was in flight; it must defer", n)
+	}
+
+	releaseAlgoFn()
+	waitFor(t, 3*time.Second, func() bool { return indexRuns.Load() >= 1 })
+	probe.assertNoOverlap(t)
+}
+
+// TestStageGate_TwoLinkPassesDoNotOverlap: two distinct groups whose link
+// debounce timers fire together must serialise — one runs, the other defers.
+func TestStageGate_TwoLinkPassesDoNotOverlap(t *testing.T) {
+	var probe stageProbe
+	var linkRuns atomic.Int32
+	gate := make(chan struct{})
+	var once sync.Once
+
+	s := New(Config{
+		Workers:           2,
+		LinkDebounce:      5 * time.Millisecond,
+		GroupAlgoDebounce: time.Hour, // don't chain an algo pass into this test
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		StageGateHoldMax:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links: func(_ context.Context, g string) error {
+			probe.enterExclusive("links:" + g)
+			defer probe.leaveExclusive("links:" + g)
+			linkRuns.Add(1)
+			// The FIRST pass holds the gate long enough that the second group's
+			// timer definitely fires underneath it.
+			once.Do(func() { <-gate })
+			return nil
+		},
+		GroupAlgo:          func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer func() { s.Stop() }()
+
+	s.scheduleLinks("groupA")
+	s.scheduleLinks("groupB")
+
+	waitFor(t, 2*time.Second, func() bool { return probe.exclusiveActive.Load() == 1 })
+	time.Sleep(60 * time.Millisecond)
+	if n := probe.exclusiveActive.Load(); n != 1 {
+		t.Fatalf("expected exactly 1 in-flight link pass while the gate is held, got %d", n)
+	}
+	close(gate)
+	waitFor(t, 3*time.Second, func() bool { return linkRuns.Load() >= 2 })
+	probe.assertNoOverlap(t)
+}
+
+// TestStageGate_DeferredStageRunsUnderSustainedChurn is the constraint-1 test:
+// the gate takes precedence over the group-algo max-wait, so a busy daemon could
+// defer the pass forever. The gate therefore carries its OWN bounded starvation
+// guard: after StageGateMaxDefer of continuous deferral it stops admitting NEW
+// index jobs, lets the in-flight batch drain, and then runs — WITHOUT ever
+// overlapping. This test drives sustained index churn (there is never a natural
+// idle gap) and asserts the pass still runs, with zero overlap.
+func TestStageGate_DeferredStageRunsUnderSustainedChurn(t *testing.T) {
+	var probe stageProbe
+	var algoRuns atomic.Int32
+	inflightAtAlgoEntry := make(chan int, 4)
+
+	var s *Scheduler
+	s = New(Config{
+		Workers:           2,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: 120 * time.Millisecond,
+		StageGateHoldMax:  time.Hour,
+		Index: func(_ context.Context, repo string, _ string) error {
+			probe.enterIndex(repo)
+			defer probe.leaveIndex(repo)
+			time.Sleep(10 * time.Millisecond)
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, g string) error {
+			probe.enterExclusive("algo:" + g)
+			defer probe.leaveExclusive("algo:" + g)
+			s.mu.Lock()
+			n := len(s.inflight)
+			s.mu.Unlock()
+			select {
+			case inflightAtAlgoEntry <- n:
+			default:
+			}
+			algoRuns.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+
+	// Sustained churn: keep re-enqueuing so the index batch is (almost) never
+	// empty. This is the condition under which the pre-gate max-wait would fire
+	// ANYWAY and the gate would be decorative.
+	stopChurn := make(chan struct{})
+	churnDone := make(chan struct{})
+	go func() {
+		defer close(churnDone)
+		i := 0
+		for {
+			select {
+			case <-stopChurn:
+				return
+			default:
+			}
+			s.Enqueue("/churn-" + itoa(int64(i%6)))
+			i++
+			time.Sleep(2 * time.Millisecond)
+		}
+	}()
+
+	s.scheduleGroupAlgo("acme")
+
+	waitFor(t, 5*time.Second, func() bool { return algoRuns.Load() >= 1 })
+	close(stopChurn)
+	<-churnDone
+	s.Stop()
+
+	if n := <-inflightAtAlgoEntry; n != 0 {
+		t.Fatalf("group-algo started with %d index job(s) still in flight — the starvation guard must DRAIN, not overlap", n)
+	}
+	probe.assertNoOverlap(t)
+}
+
+// TestStageGate_ReleasedOnStageError: a stage whose callback returns an error
+// must release the token, or every later heavy stage defers forever. Asserted
+// via a SECOND exclusive stage acquiring afterwards — with StageGateHoldMax set
+// to an hour, a leaked token would never be reaped inside the test window.
+func TestStageGate_ReleasedOnStageError(t *testing.T) {
+	algoEntered := make(chan struct{}, 1)
+	var linkRuns atomic.Int32
+
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      5 * time.Millisecond,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		StageGateHoldMax:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links: func(_ context.Context, _ string) error {
+			linkRuns.Add(1)
+			return nil
+		},
+		GroupAlgo: func(_ context.Context, _ string) error {
+			select {
+			case algoEntered <- struct{}{}:
+			default:
+			}
+			return errStageTest
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-algoEntered
+
+	s.scheduleLinks("acme")
+	waitFor(t, 3*time.Second, func() bool { return linkRuns.Load() >= 1 })
+}
+
+// TestStageGate_ReleasedOnCancel: a cancelled stage (group delete / shutdown)
+// must release the gate too.
+func TestStageGate_ReleasedOnCancel(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		StageGateHoldMax:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered
+	s.CancelGroup("acme")
+
+	waitFor(t, 3*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.stageHolder == ""
+	})
+}
+
+// TestStageGate_ReleasedOnPanic drives the REAL production path: a GroupAlgo
+// callback that panics unwinds through fireGroupAlgo, whose `defer
+// s.releaseStage(name)` must still hand the token back. Asserted on
+// fireGroupAlgo's own goroutine (the timer path would take the panic to the
+// whole process, which is pre-existing behaviour and not what this pins).
+//
+// Mutation guard: removing the `defer s.releaseStage(name)` from fireGroupAlgo
+// fails this test.
+func TestStageGate_ReleasedOnPanic(t *testing.T) {
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateHoldMax:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			panic("group-algo exploded")
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+
+	panicked := make(chan any, 1)
+	go func() {
+		defer func() { panicked <- recover() }()
+		s.fireGroupAlgo("acme")
+	}()
+
+	select {
+	case r := <-panicked:
+		if r == nil {
+			t.Fatal("expected the GroupAlgo panic to propagate out of fireGroupAlgo")
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("fireGroupAlgo never returned")
+	}
+
+	s.mu.Lock()
+	holder := s.stageHolder
+	s.mu.Unlock()
+	if holder != "" {
+		t.Fatalf("stage token still held by %q after a panicking group-algo pass", holder)
+	}
+}
+
+// TestStageGate_HoldMaxForfeitsAndLateReturnerCannotStealToken pins the one
+// branch where the no-overlap invariant is deliberately given up. A stage that
+// holds the token past StageGateHoldMax is FORFEITED — index dispatch must
+// resume (a permanently wedged daemon is worse than a transient overlap) — and
+// when the wedged stage eventually returns, its releaseStage must NOT clear the
+// token of whoever holds it by then.
+func TestStageGate_HoldMaxForfeitsAndLateReturnerCannotStealToken(t *testing.T) {
+	var indexRuns atomic.Int32
+	releaseAlgo := make(chan struct{})
+	algoEntered := make(chan struct{}, 1)
+
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		StageGateHoldMax:  20 * time.Millisecond, // wedge threshold, for the test
+		Index: func(_ context.Context, _ string, _ string) error {
+			indexRuns.Add(1)
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			select {
+			case algoEntered <- struct{}{}:
+			default:
+			}
+			<-releaseAlgo // wedged: holds the token past StageGateHoldMax
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	var releaseOnce sync.Once
+	releaseAlgoFn := func() { releaseOnce.Do(func() { close(releaseAlgo) }) }
+	s.Start()
+	defer func() { releaseAlgoFn(); s.Stop() }()
+
+	s.scheduleGroupAlgo("acme")
+	<-algoEntered
+
+	// (a) Index dispatch must resume once the hold-max forfeits the token,
+	// even though the wedged pass is still running.
+	s.Enqueue("/repo-a")
+	waitFor(t, 3*time.Second, func() bool { return indexRuns.Load() >= 1 })
+
+	// (b) A NEW exclusive stage takes the token after the forfeit...
+	waitFor(t, 3*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return len(s.inflight) == 0
+	})
+	s.mu.Lock()
+	if !s.tryAcquireStageLocked("links:acme", time.Now()) {
+		s.mu.Unlock()
+		t.Fatal("a forfeited token must be re-acquirable by a new stage")
+	}
+	s.mu.Unlock()
+
+	// ...and the wedged pass returning LATE must not steal it back.
+	releaseAlgoFn()
+	time.Sleep(100 * time.Millisecond)
+
+	s.mu.Lock()
+	holder := s.stageHolder
+	s.mu.Unlock()
+	if holder != "links:acme" {
+		t.Fatalf("a late-returning forfeited stage cleared the new holder's token (holder=%q, want %q)",
+			holder, "links:acme")
+	}
+	s.releaseStage("links:acme")
+}
+
+// TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState: constraint 3. An MCP
+// consumer polling grafel_stats must not see the daemon go quiet while a heavy
+// stage is merely DEFERRED — it would read a stale overlay believing the daemon
+// is idle. The deferred case gets the same indexstate treatment as the running
+// case.
+func TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState(t *testing.T) {
+	s := New(Config{
+		Workers:            1,
+		LinkDebounce:       time.Hour,
+		GroupAlgoDebounce:  time.Hour,
+		GroupAlgoMaxWait:   time.Hour,
+		StageGateRetry:     time.Hour, // no retry inside the test window
+		StageGateMaxDefer:  time.Hour,
+		StageGateHoldMax:   time.Hour,
+		Index:              func(_ context.Context, _ string, _ string) error { return nil },
+		Links:              func(_ context.Context, _ string) error { return nil },
+		GroupAlgo:          func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+
+	before := indexstate.Get().GroupAlgoInFlight
+
+	// indexstate is PROCESS-GLOBAL: a t.Fatal below would otherwise leak this
+	// test's GroupAlgoBegin into every later test in the binary.
+	t.Cleanup(func() {
+		s.mu.Lock()
+		delete(s.inflight, "/busy")
+		s.markGroupAlgoDeferredLocked("acme", false)
+		s.mu.Unlock()
+	})
+
+	// Simulate an index batch in flight so the fire attempt must defer.
+	s.mu.Lock()
+	s.inflight["/busy"] = 1
+	s.mu.Unlock()
+
+	s.fireGroupAlgo("acme")
+
+	snap := indexstate.Get()
+	if snap.GroupAlgoInFlight <= before {
+		t.Fatalf("a DEFERRED group-algo pass must stay visible in indexstate (got %d, was %d)",
+			snap.GroupAlgoInFlight, before)
+	}
+	if !snap.Busy {
+		t.Fatal("indexstate must report Busy while a heavy stage is deferred")
+	}
+
+	s.mu.Lock()
+	pending := s.groupAlgoPending["acme"]
+	s.mu.Unlock()
+	if !pending {
+		t.Fatal("a deferred group-algo pass must remain PENDING (re-armed), not dropped")
+	}
+
+	// Clean up: cancelling the group must also drop the deferred-state marker so
+	// indexstate does not leak a permanently-busy daemon.
+	s.mu.Lock()
+	delete(s.inflight, "/busy")
+	s.mu.Unlock()
+	s.CancelGroup("acme")
+
+	waitFor(t, 2*time.Second, func() bool { return indexstate.Get().GroupAlgoInFlight <= before })
+}
+
+// TestStageGate_DisabledRestoresLegacyOverlap: the gate must be switchable off
+// so the wall-clock cost can be measured against the pre-gate behaviour.
+func TestStageGate_DisabledRestoresLegacyOverlap(t *testing.T) {
+	algoEntered := make(chan struct{}, 1)
+	releaseAlgo := make(chan struct{})
+	var indexRuns atomic.Int32
+
+	s := New(Config{
+		Workers:           2,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateDisabled: true,
+		Index: func(_ context.Context, _ string, _ string) error {
+			indexRuns.Add(1)
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			select {
+			case algoEntered <- struct{}{}:
+			default:
+			}
+			<-releaseAlgo
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer func() { close(releaseAlgo); s.Stop() }()
+
+	s.scheduleGroupAlgo("acme")
+	<-algoEntered
+	s.Enqueue("/repo-a")
+	// With the gate disabled the index must NOT be held back by the in-flight
+	// group-algo pass (legacy, overlapping behaviour).
+	waitFor(t, 3*time.Second, func() bool { return indexRuns.Load() >= 1 })
+}


### PR DESCRIPTION
## Why

Whole-machine RSS during a from-scratch group reindex peaks at 4.3–5.3 GB, and at the peak instant the index child is frequently at **0 MB**. The peak is `engine` (running the link pass in-process) plus `group-algo`, co-resident — each materialising a full copy of the same group union graph in a separate address space.

Nothing gated them. `tryAdmit` ledgers **index jobs only**; `algoSem` bounds group-algo passes against *each other*. With a 180 s debounce against per-repo indexes taking tens of seconds, **overlap was the normal case, not the exception**.

Making the index child smaller actually made this worse: a faster child finishes its heavy phase sooner and lands on top of the next stage. The child fell 4247 → 2975 MB (−30%) while the machine peak rose 4853 → 5274 MB.

## The gate

One daemon-wide heavy-stage token — effectively a writer-preferring RW lock:

- **SHARED** = index jobs. No new reader counter: `s.inflight` already tracks executing index jobs exactly, so the gate reads it. Index jobs stay concurrent among themselves (the worker pool and RSS ledger already bound them); the batch is one stage.
- **EXCLUSIVE** = link pass and group-algo — one at a time, never alongside an executing index job.

**Neither side ever blocks on the other**, which is what makes deadlock structurally impossible. An exclusive stage that cannot acquire **defers**: it re-arms its own retry timer under the same `linkTimers[group]` / `groupAlgoTimers[group]` key *while still holding `s.mu`*, so deferral is polling rather than signalling and there is no wakeup to lose. Index dispatch is gated inside `tryAdmit` and woken by the `poke()` that every `releaseStage` performs, with the existing 1 s admit tick as a second path back.

## The hard part: max-wait must not defeat the gate

A pre-existing 300 s max-wait forces the group-algo timer to **fire** promptly under churn. The gate can still refuse to let it **run** — and "run anyway after N deferrals" would make the gate decorative under exactly the sustained-churn conditions that produce the worst peaks.

Instead, deferral wins, and starvation is bounded by a **drain barrier**: after `StageGateMaxDefer` of continuous deferral the starved stage stops admission of **new** index jobs, the in-flight batch drains, and the stage then acquires cleanly. Progress is guaranteed *without ever trading away the no-overlap invariant*. The barrier is owned by a single stage so it cannot be jumped, expires only when `len(inflight) == 0`, and lapses after `StageGateDrainMax` so it cannot wedge dispatch.

Second-order effect handled: the dead-man switch would otherwise have force-admitted an index straight back into overlap after 2 minutes of a held token. `checkDeadMan` now treats a held token or raised barrier as work-in-progress; both states are independently time-bounded, so its liveness guarantee survives.

## The invariant is conditional — stated, not implied

`reapStageLocked` forfeits a token held longer than `StageGateHoldMax` (the crashed/wedged-subprocess case) **without cancelling** the wedged stage, so a second exclusive stage may then run alongside it. A permanent wedge is worse than a transient overlap, so this is deliberate — and `releaseStage`'s identity check stops the late returner from stealing the new holder's token. The correct statement is **"no overlap except after a forfeit"**, and that is now what both the code and this description say.

All three thresholds are env-tunable (`GRAFEL_STAGE_GATE_RETRY`, `_MAX_DEFER`, `_HOLD_MAX`, `_DRAIN_MAX`). That matters: at ~4 min per pass today the 15 min hold-max is ~3.75× headroom, but on a corpus ~4× larger a *legitimate* pass would exceed it, be forfeited every time, and **the gate would silently degrade to no-gate precisely on the largest corpora it exists for**. `stage_gate_forfeit` is the operator signal.

## Observability

`IsIndexing` is extraction-only; a running group-algo surfaces via `GroupAlgoBegin`. A **deferred** group-algo now holds a balanced `GroupAlgoBegin` for the deferral window, so coverage goes 1→2→1→0 with no dip to zero at the deferred→running handoff. Without it this change would have opened a new gap: the index batch finishes, `IsIndexing` goes false while the pass is merely deferred, and an MCP consumer reads a stale overlay believing the daemon settled.

Logged: `stage_gate_defer` (with reason), `_drain`, `_admit` (with `deferred_for` — **sum this for wall-time attribution**), `_release` (held duration), `_forfeit`, `_drain_expired`, and `admit_stage_defer` on the index side.

`GRAFEL_STAGE_GATE=0` restores legacy overlap for an A/B baseline, verified to leave **no residual gating**.

## Interactive paths are not blocked

Verified independently: the synchronous `Service.Index` RPC calls `s.index(...)` directly and never touches the scheduler queue; foreground group-rebuild calls the extractor directly; the `group-algo` CLI is its own process. Only `Index{Async:true}` (git hooks) is gated, and it already ACKs immediately and is debounced.

**Scope limit, documented in the code**: the foreground rebuild RPC runs its own in-process link pass (`cmd/grafel/daemon.go` `linksFn` → `runLinksHookWithCtx`) entirely outside the scheduler, so it can still be co-resident with a scheduler group-algo pass. This is pre-existing and user-initiated. The follow-up shape — let the rebuild pass **barge** (take the token unconditionally, never defer) so background stages yield around it at zero interactive cost — is deliberately left to its own slice, since it needs a scheduler handle `cmd/grafel` does not currently take and its own hold-max reasoning.

## Behaviour change worth calling out

`TestCancelGroup_SupersededLinkPassCancelledThenNoneSurvives` and `TestCancelGroup_ScopedToGroup` have **concurrent link passes as their premise** — precisely what this removes. They now run with `StageGateDisabled: true`, assertions verbatim, because they test cancel-token identity which must stay correct as defence-in-depth whenever the gate is off.

That was verified to be premise-obsolescence rather than a gate deadlock, by evidence: re-enabling the gate and dumping goroutines shows every scheduler loop (`dedupLoop`, `admitLoop`, `deadManLoop`, `memReleaseLoop`, `workerLoop`) parked in its normal select — the scheduler is live. The hang is a circular wait *inside the test*: pass-0's body blocks on `<-ctx.Done()`, which only pass-1 superseding it can deliver, but pass-1 cannot start until pass-0 releases. The guarded property still holds under the gate by a different mechanism (`CancelGroup` stops the deferred retry timer *and* cancels the running pass), pinned by the new `TestCancelGroup_DeferredLinkPassNeverRuns`.

## Verification

`go build ./...`, `go vet ./internal/daemon/...`, `gofmt -l internal cmd` clean. `./internal/daemon/... ./cmd/grafel/...` pass; `./internal/daemon/sched/...` green under `-race -count=4 -p 2` and `-race -count=2 -cpu=1,2,8`.

Independently adversarially reviewed. Mutations, no survivors:

| mutation | caught by |
|---|---|
| barrier raise disabled | `DeferredStageRunsUnderSustainedChurn` |
| `defer releaseStage` removed (`fireGroupAlgo`) | 3 tests |
| `defer releaseStage` removed (`fireLinks`) | 8 tests |
| deferred `GroupAlgoBegin` removed | `DeferredGroupAlgoStaysVisibleToIndexState` |
| its clear removed from `cancelGroupAlgoLocked` | same |
| forfeit condition disabled | `HoldMaxForfeitsAndLateReturnerCannotStealToken` |
| `releaseStage` identity check → `if true` | same |

Negative assertions ("did not start yet") fail only in the safe direction — a flake there is a real gate violation.

**RSS effect unmeasured.** The expectation is that the peak approaches the max of the individual stages rather than their sum; wall time should rise ~1–3 min on a full group reindex and ~0 under incremental churn. Both are for the coordinator's `GRAFEL_STAGE_GATE=0` control run to confirm or falsify.

Refs #5954
