### PR TITLE
perf(#5954): barge the foreground rebuild into the stage gate + make gate state observable

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1326,6 +1326,22 @@ func daemonRebuildFuncCore(
 	indexFn func(repoPath, outPath, repoTag string, skipPasses []string, pretty, jsonStats bool, opts ...IndexOption) error,
 	linksFn func(ctx context.Context, group string) error,
 ) ([]string, string, error) {
+	// #5954 FOREGROUND BARGE. This rebuild indexes every repo DIRECTLY (via
+	// indexFn → Index(...)) and then runs its OWN in-process cross-repo link
+	// pass — it never calls scheduler.Enqueue, so s.inflight stays empty and the
+	// heavy write-stage gate would read an IDLE machine for the entire 10–12
+	// minutes. That is exactly what the post-#5993 measurement caught: peak rose
+	// 4258 → 5430 MB with `index child 2979 MB + group-algo 1618 MB` co-resident.
+	//
+	// Registering here holds background link/group-algo passes off for the whole
+	// rebuild — index batch AND link pass — at zero interactive cost: the barge
+	// never waits, whatever the gate's state. It is deliberately the FIRST thing
+	// in the function and released via `defer`, so every exit path (unknown
+	// group, config error, group deleted mid-rebuild, extractor panic) unwinds
+	// it; the closure is idempotent. Inert when no scheduler is running (CLI
+	// one-shots, watcher-less daemons, tests) and when GRAFEL_STAGE_GATE=0.
+	defer sched.BargeForeground("rebuild:" + args.Group)()
+
 	rebuildStart := time.Now()
 	fmt.Fprintf(os.Stderr, "grafel: rebuild start group=%s slug=%q wipe=%v incremental=%v\n",
 		args.Group, args.Slug, args.Wipe, args.Incremental)

--- a/cmd/grafel/daemon_rebuild_barge_5954_test.go
+++ b/cmd/grafel/daemon_rebuild_barge_5954_test.go
@@ -1,0 +1,132 @@
+package main
+
+// daemon_rebuild_barge_5954_test.go — the WIRING half of the #5954 foreground
+// barge.
+//
+// internal/daemon/sched owns the barge mechanism and tests it directly. What
+// those tests cannot pin is the thing that actually went wrong in production:
+// the rebuild path never told the scheduler it existed. `grafel reset` and the
+// rebuild RPC index through makeDaemonRebuildFunc → indexFn → Index(...)
+// DIRECTLY — they never call scheduler.Enqueue, so s.inflight stays empty, the
+// #5993 stage gate reads an idle machine, and a background group-algo pass
+// starts alongside a multi-GB foreground index (measured: peak 4258 → 5430 MB,
+// `index child 2979 MB + group-algo 1618 MB` co-resident at the peak instant).
+//
+// So these tests assert on daemonRebuildFuncCore itself: the barge is HELD
+// while the rebuild runs (covering both the per-repo index batch and the
+// cross-repo link pass), and it is RELEASED on every exit path. Deleting the
+// `defer releaseBarge()` in daemonRebuildFuncCore must fail the release tests;
+// deleting the acquisition must fail the held test.
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+)
+
+// startBargeObserverScheduler starts a minimal real scheduler so the process
+// bridge (sched.BargeForeground) resolves to something observable, and returns
+// a func reporting how many foreground barge holds are live right now.
+func startBargeObserverScheduler(t *testing.T) func() int {
+	t.Helper()
+	s := sched.New(sched.Config{
+		Workers:            1,
+		LinkDebounce:       time.Hour,
+		GroupAlgoDebounce:  time.Hour,
+		StageGateHoldMax:   time.Hour,
+		StageGateBargeMax:  time.Hour,
+		Index:              func(_ context.Context, _ string, _ string) error { return nil },
+		Links:              func(_ context.Context, _ string) error { return nil },
+		GroupAlgo:          func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	t.Cleanup(s.Stop)
+	return func() int { return len(s.Snapshot().Barging) }
+}
+
+// TestRebuild_HoldsForegroundBargeAcrossIndexAndLinks: while daemonRebuildFuncCore
+// is inside the per-repo index batch AND inside the cross-repo link pass, a
+// foreground barge must be registered with the scheduler. Both phases are
+// sampled because both allocate a large slice of the group graph and both run
+// entirely outside the scheduler's view.
+func TestRebuild_HoldsForegroundBargeAcrossIndexAndLinks(t *testing.T) {
+	group := setupTestGroup(t, "barge-group", []string{"first", "second"})
+	barges := startBargeObserverScheduler(t)
+
+	var duringIndex, duringLinks atomic.Int32
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		if n := barges(); int32(n) > duringIndex.Load() {
+			duringIndex.Store(int32(n))
+		}
+		return nil
+	}
+	linksFn := func(_ context.Context, _ string) error {
+		duringLinks.Store(int32(barges()))
+		return nil
+	}
+
+	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, linksFn); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	if duringIndex.Load() < 1 {
+		t.Errorf("no foreground barge registered during the per-repo index batch: " +
+			"a rebuild never populates s.inflight, so without the barge the stage gate sees an idle machine " +
+			"and lets a background group-algo pass go co-resident with a multi-GB index child (#5954)")
+	}
+	if duringLinks.Load() < 1 {
+		t.Errorf("no foreground barge registered during the cross-repo link pass: " +
+			"the rebuild's own link pass runs outside the scheduler and was the SCOPE LIMIT flagged in #5993")
+	}
+	if n := barges(); n != 0 {
+		t.Errorf("barge count = %d after a successful rebuild returned; want 0", n)
+	}
+}
+
+// TestRebuild_ReleasesForegroundBargeOnError: no wedge. A rebuild that fails
+// early (unknown group — returns before any repo is touched) must still leave
+// the ledger clean, or every subsequent background link/group-algo pass defers
+// forever behind a rebuild that is long gone.
+func TestRebuild_ReleasesForegroundBargeOnError(t *testing.T) {
+	_ = setupTestGroup(t, "barge-err-group", []string{"only"})
+	barges := startBargeObserverScheduler(t)
+
+	failIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
+	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "no-such-group"}, failIndexFn, noopLinksFn)
+	if err == nil {
+		t.Fatal("expected an error for an unknown group")
+	}
+	if n := barges(); n != 0 {
+		t.Fatalf("barge count = %d after a FAILED rebuild; want 0 — a leaked barge wedges every background stage", n)
+	}
+}
+
+// TestRebuild_ReleasesForegroundBargeOnGroupCancel: a `grafel delete <group>`
+// mid-rebuild (daemon.CancelGroupRebuild) short-circuits the loop with a
+// cancellation error. That path must release the barge too.
+func TestRebuild_ReleasesForegroundBargeOnGroupCancel(t *testing.T) {
+	group := setupTestGroup(t, "barge-cancel-group", []string{"first", "second"})
+	barges := startBargeObserverScheduler(t)
+
+	var once sync.Once
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		once.Do(func() { daemon.CancelGroupRebuild(group) })
+		return nil
+	}
+	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, noopLinksFn)
+	if err == nil || !strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("expected a 'rebuild cancelled' error, got: %v", err)
+	}
+	if n := barges(); n != 0 {
+		t.Fatalf("barge count = %d after a CANCELLED rebuild; want 0", n)
+	}
+}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -142,6 +143,24 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				len(st.PendingAlgo) > 0 || len(st.PendingLinks) > 0 {
 				fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",
 					st.QueueLen, len(st.IndexInFlight), len(st.PendingAlgo), len(st.PendingLinks))
+			}
+			// #5954 heavy write-stage gate. Printed whenever the gate is doing
+			// ANYTHING (holding, deferring, or being barged) so an operator — or
+			// a peak-RSS measurement run — can confirm from outside the process
+			// that it fired, instead of inferring it from RSS shape. Silent when
+			// the gate is idle, which is the overwhelmingly common case.
+			if st.StageGateHolder != "" || len(st.StageGateDeferred) > 0 || len(st.StageGateBarging) > 0 {
+				fmt.Fprint(w, "  stage_gate:")
+				if len(st.StageGateBarging) > 0 {
+					fmt.Fprintf(w, " barging=%s", strings.Join(st.StageGateBarging, ","))
+				}
+				if st.StageGateHolder != "" {
+					fmt.Fprintf(w, " holder=%s", st.StageGateHolder)
+				}
+				if len(st.StageGateDeferred) > 0 {
+					fmt.Fprintf(w, " deferred=%s", strings.Join(st.StageGateDeferred, ","))
+				}
+				fmt.Fprintln(w)
 			}
 			if st.RSSBudgetMB > 0 {
 				// Two separate lines: daemon idle RSS (informational) vs.

--- a/internal/daemon/engine_liveness_metrics_test.go
+++ b/internal/daemon/engine_liveness_metrics_test.go
@@ -86,7 +86,7 @@ func TestStartEngineLivenessHeartbeat_PopulatesRSS(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	root := t.TempDir()
 
-	stop := startEngineLivenessHeartbeat(root, 0, nil, nil)
+	stop := startEngineLivenessHeartbeat(root, 0, nil, nil, nil)
 	t.Cleanup(stop)
 
 	// The writer's first write happens inside its own goroutine (fired right

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
@@ -81,6 +82,34 @@ func WarmingFromStatusFile() WarmingSnapshot {
 		PendingAlgo:   f.WarmPendingAlgo,
 		PendingLinks:  f.WarmPendingLinks,
 	}
+}
+
+// StageGateFromStatusFile reconstructs the heavy write-stage gate's live state
+// (#5954) from the ambient engine's liveness sidecar, for a reader with no
+// in-process scheduler handle — chiefly a SPLIT-MODE serve process answering
+// Service.Status, where the scheduler is in the engine.
+//
+// It is the exact analogue of WarmingFromStatusFile, and deliberately shares
+// its file and its freshness rule, so monolith and split mode converge on one
+// path. ok=false means "unknown": no engine has ever written the sidecar, or
+// its heartbeat is stale (engine down, starting, or wedged). Callers must leave
+// the gate fields EMPTY in that case rather than reporting a stale holder as
+// live — a phantom "group-algo holds the token" reading would be worse than no
+// reading, given this surface exists to adjudicate exactly that question.
+func StageGateFromStatusFile() (g sched.StageGateState, ok bool) {
+	layout, err := DefaultLayout()
+	if err != nil {
+		return sched.StageGateState{}, false
+	}
+	f, fresh := EngineLivenessStatus(layout.Root)
+	if !fresh || f == nil {
+		return sched.StageGateState{}, false
+	}
+	return sched.StageGateState{
+		Holder:   f.StageGateHolder,
+		Deferred: f.StageGateDeferred,
+		Barging:  f.StageGateBarging,
+	}, true
 }
 
 // FlushRepoStatusFile synchronously recomputes and writes repoPath's per-repo

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -81,7 +81,18 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 			PendingLinks:  len(snap.PendingLinks),
 		}
 	}
-	stopEngineLiveness := startEngineLivenessHeartbeat(cfg.Layout.Root, statusHeartbeatInterval(), warmingFn, logger)
+	// #5954: the heavy write-stage gate's live state, published on the same
+	// heartbeat and off the same schedulerPtr. Degrades to the zero value
+	// (no holder, nothing deferred, nothing barging) before the scheduler is
+	// up or when none is configured — never a crash or a stale read.
+	gateFn := func() sched.StageGateState {
+		sc := schedulerPtr.Load()
+		if sc == nil {
+			return sched.StageGateState{}
+		}
+		return sc.StageGateState()
+	}
+	stopEngineLiveness := startEngineLivenessHeartbeat(cfg.Layout.Root, statusHeartbeatInterval(), warmingFn, gateFn, logger)
 	ep.add(stopEngineLiveness)
 
 	// Phase B — bring up the scheduler + watcher when the caller

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -74,6 +74,25 @@ type StatusReply struct {
 	IndexedRepos   []IndexedRepoState `json:"indexed_repos,omitempty"`
 	RecentLog      []SchedLogEntry    `json:"recent_log,omitempty"`
 
+	// Heavy write-stage gate (#5954) — the daemon-wide token that keeps the
+	// index batch, the cross-repo link pass and the group-algo pass from being
+	// co-resident (two copies of the same group union graph were the measured
+	// cause of a 4.4–5.4GB whole-machine peak).
+	//
+	// StageGateHolder names the EXCLUSIVE stage holding the token
+	// ("links:<group>" / "group-algo:<group>"). StageGateDeferred lists stages
+	// the gate is currently turning away. StageGateBarging lists live FOREGROUND
+	// holds ("rebuild:<group>") — non-empty means a rebuild is registered and
+	// background heavy stages are yielding to it.
+	//
+	// Populated from the in-process scheduler in monolith mode, and from the
+	// engine-liveness status sidecar in SPLIT mode (the default), where the
+	// scheduler lives in the engine and serve answers Status. Both routes agree;
+	// see Service.Status.
+	StageGateHolder   string   `json:"stage_gate_holder,omitempty"`
+	StageGateDeferred []string `json:"stage_gate_deferred,omitempty"`
+	StageGateBarging  []string `json:"stage_gate_barging,omitempty"`
+
 	// Concurrency-cap additions. BudgetMB=0 means admission control is
 	// disabled.
 	//

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -2295,16 +2295,47 @@ func (s *Scheduler) Snapshot() Snapshot {
 	if n := len(s.recentLog); n > 0 {
 		out.RecentLog = append(out.RecentLog, s.recentLog...)
 	}
-	// #5954 gate telemetry. Reported verbatim, WITHOUT reaping expired holders
-	// first: Snapshot is a read-only observation surface and must not have
-	// scheduling side effects. A holder past its bound therefore stays visible
-	// here until a real gate decision reaps it — which is the honest reading,
-	// since it genuinely is still resident.
-	out.StageHolder = s.stageHolder
+	g := s.stageGateStateLocked()
+	out.StageHolder, out.StageDeferred, out.Barging = g.Holder, g.Deferred, g.Barging
+	return out
+}
+
+// StageGateState is the heavy write-stage gate's live state (#5954), sampled
+// cheaply. Snapshot() carries the same three fields, but Snapshot copies the
+// whole RecentLog ring and every RepoSnapshot; the engine-liveness heartbeat
+// samples this on a 5s tick and must not pay for that.
+type StageGateState struct {
+	// Holder names the EXCLUSIVE stage holding the token ("links:<group>" /
+	// "group-algo:<group>"), or "" when none does.
+	Holder string
+	// Deferred lists stages the gate is currently turning away.
+	Deferred []string
+	// Barging lists live FOREGROUND holds ("rebuild:<group>"). Non-empty means
+	// a rebuild is registered and background heavy stages are yielding to it.
+	Barging []string
+}
+
+// StageGateState returns the gate's live state for observability. Safe to call
+// from any goroutine.
+func (s *Scheduler) StageGateState() StageGateState {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.stageGateStateLocked()
+}
+
+// stageGateStateLocked is the shared implementation. MUST be called with s.mu
+// held.
+//
+// Reported VERBATIM, without reaping expired holders first: this is a read-only
+// observation surface and must not have scheduling side effects. A holder past
+// its bound therefore stays visible until a real gate decision reaps it — which
+// is also the honest reading, since it genuinely is still resident.
+func (s *Scheduler) stageGateStateLocked() StageGateState {
+	out := StageGateState{Holder: s.stageHolder}
 	for name := range s.stageDeferSince {
-		out.StageDeferred = append(out.StageDeferred, name)
+		out.Deferred = append(out.Deferred, name)
 	}
-	sort.Strings(out.StageDeferred)
+	sort.Strings(out.Deferred)
 	out.Barging = s.bargeNamesLocked()
 	sort.Strings(out.Barging)
 	return out

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -329,6 +329,17 @@ type Config struct {
 	// while jobs are still executing. <=0 defaults to stageGateDrainMaxDefault
 	// (2m). Env: GRAFEL_STAGE_GATE_DRAIN_MAX.
 	StageGateDrainMax time.Duration
+
+	// StageGateBargeMax bounds a FOREGROUND BARGE hold (see stagegate_barge.go).
+	// Deliberately NOT shared with StageGateHoldMax: a rebuild runs 10–12
+	// minutes, right at that 15m bound, so a barge governed by it would forfeit
+	// itself mid-rebuild on exactly the longest runs and silently reintroduce
+	// the overlap it exists to remove. This is a leak backstop with an
+	// hour-scale default; a `stage_gate_barge_expired` event means a foreground
+	// goroutine never unwound its release — investigate rather than raise it.
+	// <=0 defaults to stageGateBargeMaxDefault (60m).
+	// Env: GRAFEL_STAGE_GATE_BARGE_MAX.
+	StageGateBargeMax time.Duration
 }
 
 // deadManTimeout is how long the scheduler waits with a non-empty pending
@@ -530,6 +541,17 @@ type Scheduler struct {
 	// index dispatch can never be blocked indefinitely.
 	stageDrainFor   string
 	stageDrainUntil time.Time
+	// stageBarge holds the live FOREGROUND registrations (see
+	// stagegate_barge.go), keyed by a monotonic id from stageBargeSeq. A
+	// foreground rebuild indexes OUTSIDE the scheduler — it never populates
+	// s.inflight — so without this the gate reads an idle machine for the whole
+	// 10–12 minutes of a `grafel reset` and lets a background group-algo pass go
+	// co-resident with the largest process on the box. Separate from stageHolder
+	// because a barge must coexist with an already-running background stage
+	// rather than wait for it, and because it carries its own (much longer)
+	// expiry bound. Guarded by mu.
+	stageBarge    map[int64]bargeHold
+	stageBargeSeq int64
 	// stageAdmitBlocked debounces the admit-side "held by a heavy stage" log to
 	// one line per blocked period (admitLoop retries once a second).
 	stageAdmitBlocked bool
@@ -667,6 +689,9 @@ func New(cfg Config) *Scheduler {
 	if cfg.StageGateDrainMax <= 0 {
 		cfg.StageGateDrainMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_DRAIN_MAX", stageGateDrainMaxDefault)
 	}
+	if cfg.StageGateBargeMax <= 0 {
+		cfg.StageGateBargeMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_BARGE_MAX", stageGateBargeMaxDefault)
+	}
 	algoCap := resolveAlgoCap(cfg.AlgoCap)
 	shutdownCtx, shutdownCancel := context.WithCancel(context.Background())
 	return &Scheduler{
@@ -693,6 +718,7 @@ func New(cfg Config) *Scheduler {
 		indexCancel:       map[string]context.CancelFunc{},
 		indexedRepos:      map[string]repoStats{},
 		stageDeferSince:   map[string]time.Time{},
+		stageBarge:        map[int64]bargeHold{},
 		groupAlgoDeferred: map[string]bool{},
 		shutdownCtx:       shutdownCtx,
 		shutdownCancel:    shutdownCancel,
@@ -702,6 +728,14 @@ func New(cfg Config) *Scheduler {
 // Start spins up the dedup goroutine + admission loop + worker pool +
 // dead-man switch. Stop reverses it.
 func (s *Scheduler) Start() {
+	// #5954: publish the foreground-barge bridge. cmd/grafel's rebuild path
+	// runs in the same process but has no scheduler handle (daemon.Config
+	// carries Rebuild INWARD to where the scheduler is built), so it reaches
+	// the gate through the package-level sched.BargeForeground. Registering
+	// here rather than at a call site in the wiring layer means the bridge can
+	// never be silently left unwired — the failure mode this whole change
+	// exists to fix. Withdrawn (identity-checked) in Stop.
+	publishBargeBridge(s)
 	s.wg.Add(1)
 	go s.dedupLoop()
 	s.wg.Add(1)
@@ -731,6 +765,11 @@ func (s *Scheduler) Start() {
 // so a second call returns immediately after the first call's wg.Wait()
 // completes. This is the fix for the double-Stop panic described in issue #2494.
 func (s *Scheduler) Stop() {
+	// #5954: withdraw the foreground-barge bridge before draining, so a rebuild
+	// racing shutdown gets an inert no-op rather than a hold on a scheduler
+	// that is going away. Identity-checked inside, so a newer scheduler that
+	// already published (test suites) is not unpublished by this one.
+	withdrawBargeBridge(s)
 	s.stopOnce.Do(func() {
 		// Cancel the shutdown context first so any in-flight IndexFn /
 		// Incremental / Clone call that spawned a child process via
@@ -761,6 +800,11 @@ func (s *Scheduler) Stop() {
 	s.stageDeferSince = map[string]time.Time{}
 	s.stageDrainFor = ""
 	s.stageDrainUntil = time.Time{}
+	// Live foreground barges are dropped too: their only effect is to make
+	// background stages defer, and there are no background stages left to
+	// defer. A rebuild goroutine that outlives Stop still holds an id-keyed
+	// release closure, but releasing an absent id is a no-op by construction.
+	s.stageBarge = map[int64]bargeHold{}
 }
 
 // Enqueue requests a (debounced+deduped) reindex of repoPath. The current
@@ -2169,6 +2213,21 @@ type Snapshot struct {
 	// when its in-flight run completes — these are the requests that, before
 	// coalescing, would have stacked into concurrent same-repo reindex jobs.
 	CoalescedDirty []string
+
+	// --- heavy write-stage gate (#5954) telemetry. ---
+	// The gate's decisions previously existed only as RecentLog entries, so an
+	// operator (or a peak-RSS measurement run) could not tell from outside
+	// whether the gate had fired at all. These three fields make the CURRENT
+	// state directly observable via `grafel status` / the daemon status RPC.
+	//
+	// StageHolder names the exclusive stage holding the token ("links:<group>" /
+	// "group-algo:<group>"), or "". StageDeferred lists stages currently turned
+	// away by the gate. Barging lists live foreground holds ("rebuild:<group>")
+	// — non-empty means a rebuild is registered and background heavy stages are
+	// yielding to it. All sorted for deterministic output.
+	StageHolder   string   `json:"stage_holder,omitempty"`
+	StageDeferred []string `json:"stage_deferred,omitempty"`
+	Barging       []string `json:"barging,omitempty"`
 }
 
 // InFlightJob is one currently-running index, with its reserved MB.
@@ -2236,6 +2295,18 @@ func (s *Scheduler) Snapshot() Snapshot {
 	if n := len(s.recentLog); n > 0 {
 		out.RecentLog = append(out.RecentLog, s.recentLog...)
 	}
+	// #5954 gate telemetry. Reported verbatim, WITHOUT reaping expired holders
+	// first: Snapshot is a read-only observation surface and must not have
+	// scheduling side effects. A holder past its bound therefore stays visible
+	// here until a real gate decision reaps it — which is the honest reading,
+	// since it genuinely is still resident.
+	out.StageHolder = s.stageHolder
+	for name := range s.stageDeferSince {
+		out.StageDeferred = append(out.StageDeferred, name)
+	}
+	sort.Strings(out.StageDeferred)
+	out.Barging = s.bargeNamesLocked()
+	sort.Strings(out.Barging)
 	return out
 }
 

--- a/internal/daemon/sched/stagegate.go
+++ b/internal/daemon/sched/stagegate.go
@@ -23,12 +23,18 @@ import (
 // co-resident copies of the same graph (engine 1816MB + group-algo 2368MB) even
 // at instants when the index child was at 0MB.
 //
-// The gate is a single daemon-wide token with two classes of holder:
+// The gate is a single daemon-wide token with three classes of holder:
 //
-//   - SHARED  — index jobs. Their occupancy is already tracked exactly by
-//     s.inflight, so the gate reads that rather than duplicating a counter.
+//   - SHARED  — scheduler-dispatched index jobs. Their occupancy is already
+//     tracked exactly by s.inflight, so the gate reads that rather than
+//     duplicating a counter.
 //   - EXCLUSIVE — the link pass and the group-algo pass, one at a time,
 //     and never while any index job is executing.
+//   - BARGE — foreground work that runs OUTSIDE the scheduler entirely (the
+//     rebuild RPC's index batch and its own cross-repo link pass). It
+//     registers unconditionally and never waits; exclusive stages defer to it.
+//     See stagegate_barge.go — including why s.inflight alone left the single
+//     largest process on the machine invisible to this gate.
 //
 // Neither side ever BLOCKS on the other, so the gate cannot deadlock:
 //
@@ -39,6 +45,21 @@ import (
 //
 // Starvation (see noteStageDeferLocked) is bounded by escalating a long-running
 // deferral into a DRAIN BARRIER rather than by letting the stage run anyway.
+//
+// THE INVARIANT, stated truthfully. At most one heavy write-side stage is
+// resident at a time, with exactly two documented exceptions, both of which are
+// single hand-offs rather than steady states:
+//
+//  1. after a FORFEIT — reapStageLocked clears a wedged exclusive holder
+//     without cancelling it (it has no handle that could), so a successor may
+//     become co-resident with it; and
+//  2. the ONE exclusive stage already mid-flight when foreground work BARGES.
+//     The barge neither cancels it (that would discard minutes of unresumable
+//     work) nor waits for it (the foreground path must never pay latency), so
+//     that single pair overlaps. Every exclusive stage that STARTS after the
+//     barge defers until it lifts.
+//
+// Both exceptions are loud: `stage_gate_forfeit` (ERROR) and `stage_gate_barge`.
 
 const (
 	// stageGateRetryDefault is how long a deferred heavy stage waits before
@@ -126,6 +147,10 @@ func (s *Scheduler) stopped() bool {
 // holder's token. Everything else in the gate holds unconditionally; this is the
 // one documented exception, and it is loud (ERROR + stage_gate_forfeit event).
 func (s *Scheduler) reapStageLocked(now time.Time) {
+	// Foreground barges expire on their OWN, much longer bound — never on
+	// StageGateHoldMax. See stageGateBargeMaxDefault for why the two liveness
+	// guarantees differ and why sharing the bound would be actively harmful.
+	s.reapBargeLocked(now)
 	if s.stageHolder != "" && s.cfg.StageGateHoldMax > 0 &&
 		now.Sub(s.stageHeldSince) > s.cfg.StageGateHoldMax {
 		held := now.Sub(s.stageHeldSince).Truncate(time.Second)
@@ -163,14 +188,20 @@ func (s *Scheduler) reapStageLocked(now time.Time) {
 // only caller routed through this gate is Index{Async:true} — background,
 // already-debounced, fire-and-forget reindexing.
 //
-// SCOPE LIMIT — the rebuild link pass is NOT covered. repolock is a per-repo
-// INDEX mutex (internal/repolock: foreground rebuild vs. scheduler reindex of
-// the same repo path); it says nothing about heavy GROUP stages. The rebuild RPC
-// runs its OWN in-process cross-repo link pass (cmd/grafel/daemon.go linksFn →
-// runLinksHookWithCtx) entirely outside the scheduler, so a multi-minute rebuild
-// link pass can still be co-resident with a scheduler group-algo pass. That
-// hazard predates this gate and is user-initiated, so it is not a regression —
-// but do not read this gate as covering it.
+// The foreground rebuild is covered from the OTHER side, by the BARGE (#5954
+// follow-up, stagegate_barge.go): daemonRebuildFuncCore registers a barge for
+// its whole duration — its direct index batch AND its own in-process cross-repo
+// link pass, the SCOPE LIMIT this comment previously flagged as uncovered — so
+// background exclusive stages defer around it. The rebuild still never waits and
+// is still never held by THIS function.
+//
+// SCOPE LIMIT — a barge does not hold index ADMISSION. Scheduler-dispatched
+// index jobs may still be dispatched during a foreground rebuild; they remain
+// bounded by the RSS admission ledger, and same-repo collisions by repolock's
+// foreground claim. Holding admission for the 10–12 minutes of a rebuild would
+// starve the watcher queue for the whole window, which the measurement does not
+// ask for. Also uncovered: the synchronous `grafel index` RPC (daemonIndexFunc),
+// which is single-repo and an order of magnitude smaller than a group rebuild.
 func (s *Scheduler) allowIndexAdmitLocked(now time.Time) bool {
 	if s.cfg.StageGateDisabled {
 		return true
@@ -206,6 +237,12 @@ func (s *Scheduler) tryAcquireStageLocked(name string, now time.Time) bool {
 		return true
 	}
 	s.reapStageLocked(now)
+	// #5954 barge: foreground work (a rebuild's index batch and its own link
+	// pass) runs entirely outside the scheduler, so s.inflight below cannot see
+	// it. A registered barge holds background stages off for its duration.
+	if s.bargeHeldLocked() {
+		return false
+	}
 	if s.stageHolder != "" {
 		return false
 	}
@@ -255,7 +292,17 @@ func (s *Scheduler) noteStageDeferLocked(name string, now time.Time) time.Durati
 		s.logger.Info("sched: deferring heavy write stage to avoid a co-resident graph copy",
 			"stage", name, "reason", s.stageBlockReasonLocked(), "retry_in", s.cfg.StageGateRetry)
 	}
-	if waited := now.Sub(first); waited >= s.cfg.StageGateMaxDefer && s.stageDrainFor == "" {
+	// A deferral caused by a FOREGROUND BARGE must not escalate to a drain
+	// barrier. The barrier's whole mechanism is "stop admitting index jobs so
+	// the in-flight batch drains" — against a barge that is inert, because the
+	// blocker is a rebuild the scheduler does not dispatch and draining
+	// s.inflight cannot end it. Escalating anyway would hold scheduler index
+	// dispatch and emit a starvation WARN every StageGateDrainMax for the whole
+	// 10–12 minutes of a rebuild, buying nothing. The deferral CLOCK keeps
+	// running, so if index churn is what blocks the stage once the barge lifts,
+	// the barrier is raised immediately on the next retry — the starvation
+	// budget is preserved, only the useless escalation is suppressed.
+	if waited := now.Sub(first); waited >= s.cfg.StageGateMaxDefer && s.stageDrainFor == "" && !s.bargeHeldLocked() {
 		s.stageDrainFor = name
 		s.stageDrainUntil = now.Add(s.cfg.StageGateDrainMax)
 		s.logEventLocked("stage_gate_drain", "",
@@ -270,6 +317,8 @@ func (s *Scheduler) noteStageDeferLocked(name string, now time.Time) time.Durati
 // MUST be called with s.mu held.
 func (s *Scheduler) stageBlockReasonLocked() string {
 	switch {
+	case s.bargeHeldLocked():
+		return "foreground " + strings.Join(s.bargeNamesLocked(), ",") + " is barging"
 	case s.stageHolder != "":
 		return "stage " + s.stageHolder + " holds the token"
 	case len(s.inflight) > 0:

--- a/internal/daemon/sched/stagegate.go
+++ b/internal/daemon/sched/stagegate.go
@@ -195,6 +195,15 @@ func (s *Scheduler) reapStageLocked(now time.Time) {
 // background exclusive stages defer around it. The rebuild still never waits and
 // is still never held by THIS function.
 //
+// One bounded interaction, for the reader tracing a stall: if a drain barrier
+// is ALREADY up when a rebuild barges, the starved stage can no longer acquire
+// (tryAcquireStageLocked's barge check precedes the branch that clears the
+// barrier on acquisition), so the barrier cannot be cleared that way. It is
+// still bounded, and NOT by the barge's lifetime: reapStageLocked expires it
+// once now > stageDrainUntil AND the in-flight batch has cleared, so index
+// dispatch is held for at most StageGateDrainMax (2m), not the 10–12 minutes of
+// a rebuild.
+//
 // SCOPE LIMIT — a barge does not hold index ADMISSION. Scheduler-dispatched
 // index jobs may still be dispatched during a foreground rebuild; they remain
 // bounded by the RSS admission ledger, and same-repo collisions by repolock's

--- a/internal/daemon/sched/stagegate_barge.go
+++ b/internal/daemon/sched/stagegate_barge.go
@@ -199,10 +199,22 @@ var (
 	bargeBridge   *Scheduler
 )
 
+// publishBargeBridge installs s as the process's barge target.
+//
+// A silent overwrite of a LIVE predecessor would make that predecessor's barges
+// invisible — the exact shape of the bug this whole slice exists to fix (a
+// guard that is present, looks correct, and does not bind the path that runs).
+// No production path constructs two schedulers, so this cannot bind today; it
+// is loud rather than silent so that if one ever does, it says so instead of
+// quietly degrading to no-barge.
 func publishBargeBridge(s *Scheduler) {
 	bargeBridgeMu.Lock()
+	prev := bargeBridge
 	bargeBridge = s
 	bargeBridgeMu.Unlock()
+	if prev != nil && prev != s {
+		s.logger.Warn("sched: a second scheduler replaced the foreground-barge bridge — the previous scheduler's barges are now invisible to it (#5954)")
+	}
 }
 
 func withdrawBargeBridge(s *Scheduler) {

--- a/internal/daemon/sched/stagegate_barge.go
+++ b/internal/daemon/sched/stagegate_barge.go
@@ -1,0 +1,233 @@
+package sched
+
+import (
+	"sync"
+	"time"
+)
+
+// The FOREGROUND BARGE (#5954 follow-up to the #5993 stage gate).
+//
+// WHY THE GATE ALONE WAS NOT ENOUGH. The gate's SHARED (index) side reads
+// s.inflight, which tracks SCHEDULER-DISPATCHED index jobs only. But the path a
+// user actually takes for a from-scratch index — `grafel reset`, the rebuild
+// RPC — runs through cmd/grafel's makeDaemonRebuildFunc → indexFn → Index(...)
+// DIRECTLY. It never calls scheduler.Enqueue, so throughout a 10–12 minute
+// rebuild len(s.inflight) == 0 and the gate concludes the machine is idle. A
+// background group-algo pass then starts alongside the largest process on the
+// box. Measured after deploying the gate: peak went UP, 4258 → 5430 MB, and the
+// peak instant showed `index child 2979 MB + group-algo 1618 MB` co-resident.
+// The gate was correct for scheduler-driven churn (git hooks, watchers, async
+// enqueue) and simply did not bind the path that runs.
+//
+// THE SHAPE. Foreground work must never WAIT — a user watching a rebuild must
+// not pay latency for a background pass — but it must REGISTER so background
+// stages yield around it. So:
+//
+//   - a foreground rebuild BARGES: bargeForeground records a hold and returns
+//     immediately, unconditionally, whatever else is running;
+//   - background exclusive stages (scheduler link pass, group-algo) see the
+//     hold in tryAcquireStageLocked and DEFER, exactly as they defer for each
+//     other — re-arming their own timer, staying pending, losing no work.
+//
+// THE INVARIANT, stated honestly. At most one heavy write-side stage is
+// resident at a time, EXCEPT:
+//
+//  1. after a forfeit — reapStageLocked clears a wedged exclusive holder
+//     without cancelling it (see its doc), so a successor can overlap it; and
+//  2. the ONE background exclusive stage that was already mid-flight at the
+//     instant a rebuild barged. The barge does not cancel it (the gate has no
+//     handle that could resume the lost work) and does not wait for it. That
+//     one hand-off overlaps; every background stage that STARTS after the barge
+//     defers until the barge lifts.
+//
+// Both exceptions are single-hand-off, not steady-state. Case 2 costs at most
+// one background pass' worth of overlap at the START of a rebuild, versus the
+// pre-barge behaviour of a background pass being free to start at ANY point
+// across the whole rebuild — including its heaviest minutes.
+//
+// SCOPE. The barge holds off EXCLUSIVE stages only; it does not gate index
+// admission. Scheduler-dispatched index jobs remain bounded by the RSS
+// admission ledger, and same-repo collisions by repolock's foreground claim —
+// both unchanged. Blocking admission for the 10–12 minutes of a rebuild would
+// be a much larger behavioural change than the measurement asks for, and it
+// would starve the watcher queue for the whole window.
+
+const (
+	// stageGateBargeMaxDefault is the barge's leak backstop.
+	//
+	// THE HOLD-MAX RESOLUTION. A foreground rebuild takes 10–12 minutes on the
+	// current corpus — right at StageGateHoldMax (15m). A barge subject to that
+	// forfeit would expire itself mid-rebuild on exactly the LONGEST rebuilds,
+	// silently reintroducing the overlap it exists to remove, on the runs with
+	// the largest resident graph. A self-forfeiting barge is worse than no
+	// barge. So the barge is NOT subject to StageGateHoldMax; it carries its own
+	// bound, and that bound is deliberately an order of magnitude looser.
+	//
+	// It can afford to be, because the two holders have different liveness
+	// guarantees. StageGateHoldMax must be tight: an exclusive stage holds the
+	// token ACROSS A SUBPROCESS SPAWN, and a child that is SIGKILLed in a way
+	// the parent never observes wedges INDEX DISPATCH — the daemon's core job.
+	// A barge is held by in-process Go code with `defer release()` at the call
+	// site, so it unwinds on return, error, cancellation and panic alike; and a
+	// leaked barge cannot wedge indexing at all, only delay background link and
+	// group-algo passes. That is a strictly weaker failure mode, so an hour-scale
+	// backstop is the right trade: long enough that no legitimate rebuild can
+	// reach it, short enough that a leak self-heals without a daemon restart.
+	//
+	// This is a BACKSTOP, not a scheduling parameter. A `stage_gate_barge_expired`
+	// event means a rebuild goroutine vanished without unwinding — investigate
+	// it, do not simply raise this. Env: GRAFEL_STAGE_GATE_BARGE_MAX.
+	stageGateBargeMaxDefault = 60 * time.Minute
+)
+
+// bargeHold is one live foreground registration: who, and since when. Holds are
+// keyed by a monotonic id rather than by name so that concurrent rebuilds of
+// different groups each get their own entry, a release cannot drop somebody
+// else's hold, and a double release is a harmless no-op (deleting an absent id).
+type bargeHold struct {
+	name  string
+	since time.Time
+}
+
+// bargeForeground registers a foreground hold on the heavy write-stage gate and
+// returns its release closure. It NEVER blocks and NEVER fails: the returned
+// closure is safe to call more than once and safe to call after the backstop
+// has already reclaimed the hold.
+//
+// Call it with `defer release()` at the top of the foreground unit of work, so
+// the hold spans everything that materialises a big slice of the group graph
+// (for a rebuild: the whole per-repo index batch AND the cross-repo link pass)
+// and unwinds on every exit path.
+//
+// With the gate disabled (GRAFEL_STAGE_GATE=0 / Config.StageGateDisabled) this
+// records nothing and returns an inert closure — the escape hatch must restore
+// the pre-gate baseline exactly, including on this path.
+func (s *Scheduler) bargeForeground(name string) (release func()) {
+	if s.cfg.StageGateDisabled {
+		return func() {}
+	}
+	now := time.Now()
+
+	s.mu.Lock()
+	s.stageBargeSeq++
+	id := s.stageBargeSeq
+	if s.stageBarge == nil {
+		s.stageBarge = map[int64]bargeHold{}
+	}
+	s.stageBarge[id] = bargeHold{name: name, since: now}
+	s.logEventLocked("stage_gate_barge", "",
+		name+": foreground work registered — background heavy stages will defer until it completes (#5954)")
+	s.mu.Unlock()
+
+	s.logger.Info("sched: foreground work barged the heavy write-stage gate",
+		"holder", name, "barge_max", s.cfg.StageGateBargeMax)
+
+	var once sync.Once
+	return func() {
+		once.Do(func() { s.releaseBarge(id) })
+	}
+}
+
+// releaseBarge drops one foreground hold and wakes the gate so a deferred
+// background stage can retry promptly rather than sitting out the rest of its
+// StageGateRetry window.
+func (s *Scheduler) releaseBarge(id int64) {
+	s.mu.Lock()
+	if h, ok := s.stageBarge[id]; ok {
+		held := time.Since(h.since).Truncate(time.Millisecond)
+		delete(s.stageBarge, id)
+		s.logEventLocked("stage_gate_barge_release", "", h.name+" barged for "+held.String())
+	}
+	s.mu.Unlock()
+	// Capacity has freed: let the admission loop and any deferred stage move.
+	s.poke()
+}
+
+// reapBargeLocked expires holds older than StageGateBargeMax. MUST be called
+// with s.mu held. See stageGateBargeMaxDefault for why this bound is an order
+// of magnitude looser than StageGateHoldMax rather than shared with it.
+func (s *Scheduler) reapBargeLocked(now time.Time) {
+	if s.cfg.StageGateBargeMax <= 0 {
+		return
+	}
+	for id, h := range s.stageBarge {
+		if now.Sub(h.since) <= s.cfg.StageGateBargeMax {
+			continue
+		}
+		held := now.Sub(h.since).Truncate(time.Second)
+		delete(s.stageBarge, id)
+		s.logEventLocked("stage_gate_barge_expired", "",
+			h.name+": foreground barge held "+held.String()+" — reclaiming so background stages resume (#5954)")
+		s.logger.Error("sched: foreground barge exceeded its backstop — a foreground unit of work never unwound its release",
+			"holder", h.name, "held_for", held, "barge_max", s.cfg.StageGateBargeMax)
+	}
+}
+
+// bargeHeldLocked reports whether any foreground hold is live. MUST be called
+// with s.mu held, and AFTER reapBargeLocked (reapStageLocked does both).
+func (s *Scheduler) bargeHeldLocked() bool { return len(s.stageBarge) > 0 }
+
+// bargeNamesLocked renders the live holders for Snapshot/observability. MUST be
+// called with s.mu held.
+func (s *Scheduler) bargeNamesLocked() []string {
+	if len(s.stageBarge) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(s.stageBarge))
+	for _, h := range s.stageBarge {
+		out = append(out, h.name)
+	}
+	return out
+}
+
+// --- process bridge ---------------------------------------------------------
+//
+// cmd/grafel's rebuild path has no scheduler handle: daemon.Config carries a
+// Rebuild func INTO internal/daemon, which is where the scheduler is
+// constructed — the dependency runs the wrong way to thread one back out, and
+// restructuring the daemon to fix that is out of proportion to a single
+// advisory hold. So the scheduler publishes its barge here on Start() and
+// withdraws it on Stop(); the rebuild reaches it through the package-level
+// BargeForeground below. Same shape as repolock.DefaultRegistry, which the
+// rebuild already uses for the analogous cross-path claim.
+//
+// Withdrawal is identity-checked so a scheduler stopping after a newer one
+// started (test suites do this) cannot unpublish the live one.
+
+var (
+	bargeBridgeMu sync.Mutex
+	bargeBridge   *Scheduler
+)
+
+func publishBargeBridge(s *Scheduler) {
+	bargeBridgeMu.Lock()
+	bargeBridge = s
+	bargeBridgeMu.Unlock()
+}
+
+func withdrawBargeBridge(s *Scheduler) {
+	bargeBridgeMu.Lock()
+	if bargeBridge == s {
+		bargeBridge = nil
+	}
+	bargeBridgeMu.Unlock()
+}
+
+// BargeForeground registers foreground work with the running daemon's heavy
+// write-stage gate and returns its release closure. Use it with `defer` at the
+// top of any unit of work that materialises a large slice of a group graph
+// OUTSIDE the scheduler — today, the rebuild RPC's index batch and its own
+// cross-repo link pass.
+//
+// It never blocks and never fails. With no scheduler running (CLI one-shots,
+// watcher-less daemons, tests) it is inert and the returned closure is a no-op,
+// so callers need no nil checks and no build-mode branches.
+func BargeForeground(name string) (release func()) {
+	bargeBridgeMu.Lock()
+	s := bargeBridge
+	bargeBridgeMu.Unlock()
+	if s == nil {
+		return func() {}
+	}
+	return s.bargeForeground(name)
+}

--- a/internal/daemon/sched/stagegate_barge_5954_test.go
+++ b/internal/daemon/sched/stagegate_barge_5954_test.go
@@ -295,3 +295,109 @@ func TestStageGateBarge_ProcessBridgeFollowsSchedulerLifetime(t *testing.T) {
 		t.Fatalf("stageBarge = %d after Stop; the bridge must be withdrawn", got)
 	}
 }
+
+// TestStageGateBarge_BridgeWithdrawIsIdentityChecked pins the identity check in
+// withdrawBargeBridge. Stop() withdraws the bridge, but a scheduler must only
+// ever unpublish ITSELF: an older scheduler stopping AFTER a newer one has
+// published must not tear the newer one's bridge down, or every subsequent
+// rebuild silently barges into the void and the gate is back to reading an idle
+// machine — the precise failure this slice exists to fix, reintroduced by a
+// shutdown ordering accident.
+func TestStageGateBarge_BridgeWithdrawIsIdentityChecked(t *testing.T) {
+	var runs1, runs2 atomic.Int32
+	s1 := newBargeTestScheduler(t, &runs1, nil)
+	s2 := newBargeTestScheduler(t, &runs2, nil)
+
+	s1.Start()
+	s2.Start() // s2 is now the published bridge
+	defer s2.Stop()
+
+	// s1 stops LAST. Its withdraw must be a no-op, because it is not the
+	// currently published scheduler.
+	s1.Stop()
+
+	release := BargeForeground("rebuild:acme")
+	defer release()
+	if got := bargeHeld(s2); got != 1 {
+		t.Fatalf("stageBarge on the LIVE scheduler = %d, want 1: an older scheduler's Stop() tore down "+
+			"the newer scheduler's barge bridge — every rebuild after it would register nowhere", got)
+	}
+	if got := bargeHeld(s1); got != 0 {
+		t.Fatalf("stageBarge on the STOPPED scheduler = %d, want 0", got)
+	}
+}
+
+// TestStageGateBarge_DeferralUnderBargeDoesNotRaiseDrainBarrier pins the
+// escalation-suppression half of the change, and the "clock keeps running"
+// claim that makes suppressing it safe.
+//
+// A drain barrier means "stop admitting index jobs so the in-flight batch
+// drains, then the starved stage can acquire". Against a BARGE that mechanism
+// is inert: the blocker is a rebuild the scheduler does not dispatch, so
+// draining s.inflight cannot end it. Raising one anyway would hold scheduler
+// index dispatch and log a starvation WARN every StageGateDrainMax for the
+// entire 10–12 minutes of a rebuild, buying nothing.
+//
+// The deferral CLOCK is deliberately NOT reset, so the starvation budget is
+// preserved rather than forgiven: the moment the barge lifts, an already-starved
+// stage that is still blocked (here, by an index job) raises the barrier on its
+// very next retry. Both halves are asserted.
+func TestStageGateBarge_DeferralUnderBargeDoesNotRaiseDrainBarrier(t *testing.T) {
+	var runs atomic.Int32
+	indexEntered := make(chan struct{}, 1)
+	releaseIndex := make(chan struct{})
+	var once sync.Once
+	letIndexFinish := func() { once.Do(func() { close(releaseIndex) }) }
+
+	s := newBargeTestScheduler(t, &runs, func(c *Config) {
+		// Zero-length starvation budget: EVERY deferral is instantly eligible
+		// to escalate, so a surviving escalation is caught on the first retry
+		// rather than depending on timing.
+		c.StageGateMaxDefer = time.Nanosecond
+		c.StageGateDrainMax = time.Hour
+		c.Index = func(_ context.Context, _ string, _ string) error {
+			select {
+			case indexEntered <- struct{}{}:
+			default:
+			}
+			<-releaseIndex
+			return nil
+		}
+	})
+	s.Start()
+	defer func() { letIndexFinish(); s.Stop() }()
+
+	release := s.bargeForeground("rebuild:acme")
+
+	s.scheduleGroupAlgo("acme")
+	waitFor(t, time.Second, func() bool { return s.stageDeferredFor("group-algo:acme") })
+
+	// Several retry cycles at StageGateRetry=5ms, every one of them past
+	// StageGateMaxDefer. No barrier may be raised while the barge is the blocker.
+	time.Sleep(60 * time.Millisecond)
+	s.mu.Lock()
+	drainFor := s.stageDrainFor
+	_, stillDeferred := s.stageDeferSince["group-algo:acme"]
+	s.mu.Unlock()
+	if drainFor != "" {
+		t.Fatalf("drain barrier raised for %q while a foreground barge was the blocker: "+
+			"draining s.inflight cannot end a rebuild, so the barrier holds index dispatch and warns for "+
+			"the whole rebuild while buying nothing", drainFor)
+	}
+	if !stillDeferred {
+		t.Fatal("group-algo stopped being deferred while the barge was held")
+	}
+
+	// Now start an index job and lift the barge. The stage is still blocked —
+	// this time by index churn, which a barrier CAN resolve — and its deferral
+	// clock was never reset, so the barrier must go up on the next retry.
+	s.Enqueue("/slow-repo")
+	<-indexEntered
+	release()
+
+	waitFor(t, 3*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.stageDrainFor == "group-algo:acme"
+	})
+}

--- a/internal/daemon/sched/stagegate_barge_5954_test.go
+++ b/internal/daemon/sched/stagegate_barge_5954_test.go
@@ -1,0 +1,297 @@
+package sched
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #5954 follow-up — the FOREGROUND BARGE.
+//
+// The #5993 stage gate reads s.inflight for its SHARED (index) side, and
+// s.inflight only tracks SCHEDULER-DISPATCHED index jobs. `grafel reset` and
+// the rebuild RPC index through cmd/grafel's makeDaemonRebuildFunc → Index(...)
+// DIRECTLY, never touching Enqueue, so during a rebuild len(s.inflight)==0 and
+// the gate believed the machine idle: a background group-algo pass started
+// alongside a multi-GB foreground index (measured peak 4258 → 5430 MB, with
+// `index child 2979 MB + group-algo 1618 MB` co-resident at the peak instant).
+//
+// The barge closes that hole WITHOUT adding latency to the user-facing path: a
+// foreground rebuild REGISTERS (never waits), and background exclusive stages
+// see the registration and defer exactly as they defer for each other.
+
+// bargeHeld reports how many foreground barge holds are currently registered.
+// Reads under the scheduler lock so the race detector is satisfied.
+func bargeHeld(s *Scheduler) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.stageBarge)
+}
+
+// stageDeferredFor reports whether `name` is currently recorded as deferred by
+// the gate. Polling this instead of sleeping makes "the pass reached the gate
+// and was turned away" an observed STATE rather than a timing assumption.
+func (s *Scheduler) stageDeferredFor(name string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.stageDeferSince[name]
+	return ok
+}
+
+// newBargeTestScheduler builds a scheduler whose only heavy stage is a
+// group-algo pass we can count. mutate lets a test tweak the config.
+func newBargeTestScheduler(t *testing.T, runs *atomic.Int32, mutate func(*Config)) *Scheduler {
+	t.Helper()
+	cfg := Config{
+		Workers:           2,
+		LinkDebounce:      time.Hour, // never chain; we arm the algo pass by hand
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour, // starvation guard not exercised here
+		StageGateHoldMax:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			runs.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return []string{"acme"} },
+		MemReleaseDisabled: true,
+	}
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	return New(cfg)
+}
+
+// TestStageGateBarge_GroupAlgoDefersWhileRebuildBarges is the core regression:
+// a background group-algo pass whose timer fires while a FOREGROUND rebuild
+// holds the barge must DEFER, and must run once the rebuild releases. This is
+// the exact instant the measurement caught (`index child + group-algo`
+// co-resident) — the scheduler-side gate could not see it because a rebuild
+// never populates s.inflight.
+func TestStageGateBarge_GroupAlgoDefersWhileRebuildBarges(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, nil)
+	s.Start()
+	defer s.Stop()
+
+	release := s.bargeForeground("rebuild:acme")
+	if bargeHeld(s) != 1 {
+		t.Fatalf("bargeForeground did not register a hold: stageBarge=%d", bargeHeld(s))
+	}
+
+	s.scheduleGroupAlgo("acme")
+
+	// Give the 5ms debounce and many 5ms retry cycles a chance to fire.
+	waitFor(t, time.Second, func() bool { return s.stageDeferredFor("group-algo:acme") })
+	time.Sleep(50 * time.Millisecond)
+	if n := runs.Load(); n != 0 {
+		t.Fatalf("group-algo ran %d time(s) while a foreground rebuild held the barge; it must defer", n)
+	}
+
+	release()
+	if bargeHeld(s) != 0 {
+		t.Fatalf("release() left %d barge hold(s) registered", bargeHeld(s))
+	}
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 1 })
+}
+
+// TestStageGateBarge_NeverDefersEvenWhenBackgroundStageHolds pins constraint 1:
+// the foreground path must NEVER wait. Even with an exclusive background stage
+// mid-flight holding the token, bargeForeground returns immediately and the
+// barge coexists with that one holder — the background stage is NOT cancelled
+// (that would throw away minutes of work the gate has no handle to resume).
+func TestStageGateBarge_NeverDefersEvenWhenBackgroundStageHolds(t *testing.T) {
+	var runs atomic.Int32
+	algoEntered := make(chan struct{}, 1)
+	releaseAlgo := make(chan struct{})
+	var once sync.Once
+	letAlgoFinish := func() { once.Do(func() { close(releaseAlgo) }) }
+
+	s := newBargeTestScheduler(t, &runs, func(c *Config) {
+		c.GroupAlgo = func(_ context.Context, _ string) error {
+			runs.Add(1)
+			select {
+			case algoEntered <- struct{}{}:
+			default:
+			}
+			<-releaseAlgo
+			return nil
+		}
+	})
+	s.Start()
+	defer func() { letAlgoFinish(); s.Stop() }()
+
+	s.scheduleGroupAlgo("acme")
+	<-algoEntered
+
+	// The token is definitively held by the background stage right now.
+	s.mu.Lock()
+	holder := s.stageHolder
+	s.mu.Unlock()
+	if holder != "group-algo:acme" {
+		t.Fatalf("stageHolder = %q, want %q — precondition for the barge test", holder, "group-algo:acme")
+	}
+
+	// Barging must return without waiting for that holder.
+	done := make(chan func(), 1)
+	go func() { done <- s.bargeForeground("rebuild:acme") }()
+	var release func()
+	select {
+	case release = <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("bargeForeground BLOCKED while a background stage held the token; the foreground path must never wait")
+	}
+	defer release()
+
+	// The background holder keeps running — the barge does not cancel it.
+	s.mu.Lock()
+	holder = s.stageHolder
+	nBarge := len(s.stageBarge)
+	s.mu.Unlock()
+	if holder != "group-algo:acme" {
+		t.Fatalf("stageHolder = %q after a barge; the barge must NOT evict or cancel the in-flight background stage", holder)
+	}
+	if nBarge != 1 {
+		t.Fatalf("stageBarge = %d, want 1 — the barge must register even when the token is held", nBarge)
+	}
+}
+
+// TestStageGateBarge_ReleasedOnPanicAndIsIdempotent pins the no-wedge
+// constraint at the release-closure level: the closure is installed with
+// `defer` at the rebuild call site, so it fires on normal return, on error, on
+// cancellation and on panic. A double release (panic-recovery defer plus the
+// normal one) must not corrupt the ledger or drop a DIFFERENT rebuild's hold.
+func TestStageGateBarge_ReleasedOnPanicAndIsIdempotent(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, nil)
+	s.Start()
+	defer s.Stop()
+
+	// A second, unrelated barge that must survive the first one's release.
+	other := s.bargeForeground("rebuild:other")
+	defer other()
+
+	func() {
+		defer func() { _ = recover() }()
+		release := s.bargeForeground("rebuild:acme")
+		defer release()
+		defer release() // double release — must be a no-op, not a corruption
+		panic("extractor exploded mid-rebuild")
+	}()
+
+	if got := bargeHeld(s); got != 1 {
+		t.Fatalf("stageBarge = %d after a panicking rebuild released; want 1 (only the unrelated hold)", got)
+	}
+}
+
+// TestStageGateBarge_NotSubjectToStageGateHoldMax is the hold-max resolution.
+// A from-scratch rebuild of the current corpus takes 10–12 minutes, right at
+// StageGateHoldMax (15m). If the barge were subject to that forfeit it would
+// silently expire itself on exactly the LONGEST rebuilds — the ones with the
+// biggest resident graph — and reintroduce the overlap it exists to remove.
+// So the barge carries its own, much longer, independently tunable backstop.
+//
+// StageGateHoldMax is set to 1ms here: an exclusive holder would be forfeited
+// almost instantly. The barge must not be.
+func TestStageGateBarge_NotSubjectToStageGateHoldMax(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, func(c *Config) {
+		c.StageGateHoldMax = time.Millisecond
+		c.StageGateBargeMax = time.Hour
+	})
+	s.Start()
+	defer s.Stop()
+
+	release := s.bargeForeground("rebuild:acme")
+	defer release()
+
+	s.scheduleGroupAlgo("acme")
+	waitFor(t, time.Second, func() bool { return s.stageDeferredFor("group-algo:acme") })
+	time.Sleep(60 * time.Millisecond) // >> StageGateHoldMax
+	if n := runs.Load(); n != 0 {
+		t.Fatalf("group-algo ran %d time(s): the barge was forfeited by StageGateHoldMax (%s). "+
+			"A self-forfeiting barge is worse than no barge — it silently reintroduces overlap on the longest rebuilds",
+			n, time.Millisecond)
+	}
+	if bargeHeld(s) != 1 {
+		t.Fatalf("stageBarge = %d; the barge hold must survive StageGateHoldMax", bargeHeld(s))
+	}
+}
+
+// TestStageGateBarge_ExpiresAfterStageGateBargeMax is the other half of the
+// hold-max resolution: the barge is not immortal. If a rebuild goroutine were
+// ever to vanish without running its deferred release, the backstop reclaims
+// the hold so background stages resume. It is a leak backstop, not a
+// scheduling parameter — hence the hour-scale default.
+func TestStageGateBarge_ExpiresAfterStageGateBargeMax(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, func(c *Config) {
+		c.StageGateBargeMax = 20 * time.Millisecond
+	})
+	s.Start()
+	defer s.Stop()
+
+	release := s.bargeForeground("rebuild:acme")
+	defer release() // late release must be harmless after the reap
+
+	s.scheduleGroupAlgo("acme")
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 1 })
+	if bargeHeld(s) != 0 {
+		t.Fatalf("stageBarge = %d after StageGateBargeMax elapsed; the backstop must reclaim it", bargeHeld(s))
+	}
+}
+
+// TestStageGateBarge_DisabledGateDisablesTheBarge pins constraint 4:
+// GRAFEL_STAGE_GATE=0 (Config.StageGateDisabled) must turn EVERYTHING off,
+// including the barge — otherwise the escape hatch no longer restores the
+// pre-gate baseline the wall-clock cost is measured against.
+func TestStageGateBarge_DisabledGateDisablesTheBarge(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, func(c *Config) { c.StageGateDisabled = true })
+	s.Start()
+	defer s.Stop()
+
+	release := s.bargeForeground("rebuild:acme")
+	defer release()
+	if got := bargeHeld(s); got != 0 {
+		t.Fatalf("stageBarge = %d with StageGateDisabled; the disable switch must cover the barge too", got)
+	}
+
+	s.scheduleGroupAlgo("acme")
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 1 })
+}
+
+// TestStageGateBarge_ProcessBridgeFollowsSchedulerLifetime pins the plumbing
+// cmd/grafel depends on: the rebuild RPC runs in a package with no scheduler
+// handle, so the scheduler publishes its barge through a process-global bridge
+// on Start() and withdraws it on Stop(). Before Start and after Stop the
+// package-level BargeForeground must be an inert no-op — never a nil-deref.
+func TestStageGateBarge_ProcessBridgeFollowsSchedulerLifetime(t *testing.T) {
+	var runs atomic.Int32
+	s := newBargeTestScheduler(t, &runs, nil)
+
+	// Unstarted / no scheduler registered: inert, and safe to call+release.
+	BargeForeground("rebuild:nobody")()
+
+	s.Start()
+	release := BargeForeground("rebuild:acme")
+	if got := bargeHeld(s); got != 1 {
+		t.Fatalf("package-level BargeForeground did not reach the started scheduler: stageBarge=%d", got)
+	}
+	release()
+	if got := bargeHeld(s); got != 0 {
+		t.Fatalf("stageBarge = %d after release via the process bridge", got)
+	}
+
+	s.Stop()
+	// Withdrawn on Stop: still callable, still inert.
+	BargeForeground("rebuild:after-stop")()
+	if got := bargeHeld(s); got != 0 {
+		t.Fatalf("stageBarge = %d after Stop; the bridge must be withdrawn", got)
+	}
+}

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -440,6 +440,27 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 				Msg:  e.Msg,
 			})
 		}
+		// #5954 heavy write-stage gate.
+		reply.StageGateHolder = snap.StageHolder
+		reply.StageGateDeferred = snap.StageDeferred
+		reply.StageGateBarging = snap.Barging
+	} else if g, ok := StageGateFromStatusFile(); ok {
+		// SPLIT MODE (the default): the scheduler lives in the ENGINE process,
+		// so the serve process answering this RPC has s.scheduler == nil and
+		// every field in the block above — including the RecentLog ring that
+		// carries the stage_gate_* events — is simply absent. Without this
+		// fallback the gate is completely unobservable in the default
+		// deployment mode, which is how a measurement run got misread as "the
+		// gate never fired" when it had merely never been reported.
+		//
+		// The engine publishes the same three values onto its liveness sidecar
+		// every heartbeat (startEngineLivenessHeartbeat), so this is the ONE
+		// on-disk source of truth both modes converge on. A missing or stale
+		// sidecar yields ok=false and the fields stay empty — "unknown", never
+		// fabricated.
+		reply.StageGateHolder = g.Holder
+		reply.StageGateDeferred = g.Deferred
+		reply.StageGateBarging = g.Barging
 	}
 	return nil
 }

--- a/internal/daemon/service_stagegate_5954_test.go
+++ b/internal/daemon/service_stagegate_5954_test.go
@@ -1,0 +1,164 @@
+package daemon
+
+// service_stagegate_5954_test.go — the heavy write-stage gate must be
+// OBSERVABLE FROM OUTSIDE THE PROCESS, in both deployment modes.
+//
+// The gate's decisions previously existed only as entries in the scheduler's
+// in-memory RecentLog ring. In SPLIT MODE — the default — the scheduler lives
+// in the engine process and `grafel status` is answered by SERVE, whose
+// s.scheduler is nil: the entire scheduler block of the reply, RecentLog
+// included, was simply absent. So there was no way at all to confirm from
+// outside that the gate had fired, and a measurement run was read as "the gate
+// is dead" when it had merely never been reported.
+//
+// These tests pin BOTH routes to the same three fields: the in-process
+// scheduler (monolith) and the engine-liveness status sidecar (split mode).
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// newStageGateTestService builds a bare Service with no scheduler attached.
+func newStageGateTestService(t *testing.T) *Service {
+	t.Helper()
+	return newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(proto.RebuildArgs) ([]string, string, error) { return []string{}, "", nil },
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+			return proto.QualityAuditReply{}, nil
+		},
+		"/tmp/test-stagegate.sock",
+		make(chan struct{}),
+		nil, // logger
+		2,   // maxConcurrentGroups
+	)
+}
+
+// writeStageGateLivenessFixture stamps the engine-global liveness sidecar with
+// gate state, via the SAME (DefaultLayout + EngineLivenessStatusKey) derivation
+// the production writer and reader use.
+func writeStageGateLivenessFixture(t *testing.T, f *statusfile.File) {
+	t.Helper()
+	layout, err := DefaultLayout()
+	if err != nil {
+		t.Fatalf("DefaultLayout: %v", err)
+	}
+	if err := statusfile.Write(EngineLivenessStatusKey(layout.Root), f); err != nil {
+		t.Fatalf("write engine liveness fixture: %v", err)
+	}
+}
+
+// TestStatus_StageGateFieldsFromInProcessScheduler: with a scheduler attached
+// (monolith mode), a live foreground barge must appear in the RPC reply.
+func TestStatus_StageGateFieldsFromInProcessScheduler(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	svc := newStageGateTestService(t)
+	s := sched.New(sched.Config{Workers: 1, MemReleaseDisabled: true})
+	s.Start()
+	defer s.Stop()
+	svc.scheduler = s
+
+	release := sched.BargeForeground("rebuild:acme")
+	defer release()
+
+	var reply proto.StatusReply
+	if err := svc.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status RPC: %v", err)
+	}
+	if len(reply.StageGateBarging) != 1 || reply.StageGateBarging[0] != "rebuild:acme" {
+		t.Fatalf("StageGateBarging = %v, want [rebuild:acme]: the gate's state must reach the status RPC, "+
+			"not just the in-memory RecentLog ring", reply.StageGateBarging)
+	}
+}
+
+// TestStatus_StageGateFieldsFromEngineLivenessSidecarInSplitMode is the split-
+// mode half, and the one that actually matters: serve has NO scheduler, so the
+// only route is the engine's liveness sidecar. Without the fallback this reply
+// is silently empty in the DEFAULT deployment mode.
+func TestStatus_StageGateFieldsFromEngineLivenessSidecarInSplitMode(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	svc := newStageGateTestService(t)
+	if svc.scheduler != nil {
+		t.Fatal("precondition: this test models a serve process with no scheduler")
+	}
+
+	writeStageGateLivenessFixture(t, &statusfile.File{
+		HeartbeatAt:       time.Now().UTC(),
+		StageGateHolder:   "group-algo:acme",
+		StageGateDeferred: []string{"links:acme"},
+		StageGateBarging:  []string{"rebuild:acme"},
+	})
+
+	var reply proto.StatusReply
+	if err := svc.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status RPC: %v", err)
+	}
+	if reply.StageGateHolder != "group-algo:acme" {
+		t.Errorf("StageGateHolder = %q, want %q", reply.StageGateHolder, "group-algo:acme")
+	}
+	if len(reply.StageGateDeferred) != 1 || reply.StageGateDeferred[0] != "links:acme" {
+		t.Errorf("StageGateDeferred = %v, want [links:acme]", reply.StageGateDeferred)
+	}
+	if len(reply.StageGateBarging) != 1 || reply.StageGateBarging[0] != "rebuild:acme" {
+		t.Errorf("StageGateBarging = %v, want [rebuild:acme]: with no in-process scheduler this is the ONLY "+
+			"route by which gate state reaches an operator, and split mode is the default", reply.StageGateBarging)
+	}
+}
+
+// TestStatus_StageGateFieldsOmittedWhenSidecarStale: a stale heartbeat means
+// the engine is down, starting, or wedged. Reporting its last-known holder as
+// LIVE would be worse than reporting nothing — this surface exists precisely to
+// adjudicate "is a heavy stage running right now", so a phantom holder would
+// mislead exactly the reader it was built for.
+func TestStatus_StageGateFieldsOmittedWhenSidecarStale(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	svc := newStageGateTestService(t)
+
+	writeStageGateLivenessFixture(t, &statusfile.File{
+		HeartbeatAt:      time.Now().UTC().Add(-24 * time.Hour),
+		StageGateHolder:  "group-algo:acme",
+		StageGateBarging: []string{"rebuild:acme"},
+	})
+
+	var reply proto.StatusReply
+	if err := svc.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status RPC: %v", err)
+	}
+	if reply.StageGateHolder != "" || len(reply.StageGateBarging) != 0 {
+		t.Fatalf("stale sidecar reported as live gate state: holder=%q barging=%v; want empty (unknown)",
+			reply.StageGateHolder, reply.StageGateBarging)
+	}
+}
+
+// TestEngineLivenessHeartbeat_PublishesStageGateState pins the WRITE half: the
+// engine's heartbeat must actually stamp gate state onto the sidecar. Without
+// it the reader above has nothing to read and the split-mode path is dead.
+func TestEngineLivenessHeartbeat_PublishesStageGateState(t *testing.T) {
+	root := t.TempDir()
+	gate := sched.StageGateState{
+		Holder:   "group-algo:acme",
+		Deferred: []string{"links:acme"},
+		Barging:  []string{"rebuild:acme"},
+	}
+	stop := startEngineLivenessHeartbeat(root, 0, nil, func() sched.StageGateState { return gate }, nil)
+	stop() // writeOnce has already run synchronously before the ticker loop
+
+	f, err := statusfile.Read(EngineLivenessStatusKey(root))
+	if err != nil {
+		t.Fatalf("read engine liveness sidecar: %v", err)
+	}
+	if f.StageGateHolder != gate.Holder {
+		t.Errorf("StageGateHolder = %q, want %q", f.StageGateHolder, gate.Holder)
+	}
+	if len(f.StageGateDeferred) != 1 || f.StageGateDeferred[0] != "links:acme" {
+		t.Errorf("StageGateDeferred = %v, want [links:acme]", f.StageGateDeferred)
+	}
+	if len(f.StageGateBarging) != 1 || f.StageGateBarging[0] != "rebuild:acme" {
+		t.Errorf("StageGateBarging = %v, want [rebuild:acme]", f.StageGateBarging)
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/indexstate"
@@ -360,7 +361,14 @@ func (s *cpuSampler) sample(pid int, now time.Time) float64 {
 // is wired, e.g. in a test harness with no SchedulerIndex — the corresponding
 // fields are simply omitted). It is invoked on every tick, never cached, so a
 // reader always sees the CURRENT warming state, not a snapshot from startup.
-func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn func() WarmingSnapshot, logger *slog.Logger) (stop func()) {
+//
+// #5954: gateFn is the analogous read-only accessor for the heavy write-stage
+// gate. Same contract (nil ⇒ fields omitted; sampled fresh every tick), and
+// same reason for existing: in split mode the scheduler is in THIS process and
+// serve has none, so without this the gate's state — whether a rebuild is
+// barging, whether a background stage is deferring — is unobservable from
+// outside the engine.
+func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn func() WarmingSnapshot, gateFn func() sched.StageGateState, logger *slog.Logger) (stop func()) {
 	if interval <= 0 {
 		interval = defaultStatusHeartbeatInterval
 	}
@@ -400,6 +408,15 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 			f.WarmIndexInFlight = warm.IndexInFlight
 			f.WarmPendingAlgo = warm.PendingAlgo
 			f.WarmPendingLinks = warm.PendingLinks
+		}
+		// #5954: publish the heavy write-stage gate's live decisions. This is
+		// the ONLY route by which they reach a split-mode serve process, whose
+		// Service.Status has no in-process scheduler to read.
+		if gateFn != nil {
+			g := gateFn()
+			f.StageGateHolder = g.Holder
+			f.StageGateDeferred = g.Deferred
+			f.StageGateBarging = g.Barging
 		}
 		if err := statusfile.Write(key, f); err != nil && logger != nil {
 			logger.Warn("engine liveness: statusfile write failed", "err", err)

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -178,6 +178,25 @@ type File struct {
 	WarmPendingAlgo   int  `json:"warm_pending_algo,omitempty"`
 	WarmPendingLinks  int  `json:"warm_pending_links,omitempty"`
 
+	// StageGate* mirror sched.StageGateState (#5954) — the heavy write-stage
+	// gate's live decisions. They cross the engine→serve boundary for the same
+	// reason the Warm* fields do: in SPLIT MODE (the default) the scheduler
+	// lives in the engine process, so a `grafel status` served by the serve
+	// process has no in-process scheduler to read and would otherwise report
+	// NOTHING about the gate — not even its RecentLog ring. That left no way to
+	// confirm from outside the process that the gate had fired at all, which is
+	// how a measurement run was misread as "the gate is dead" when it was
+	// merely invisible.
+	//
+	// StageGateHolder names the EXCLUSIVE stage holding the token
+	// ("links:<group>" / "group-algo:<group>"); StageGateDeferred lists stages
+	// the gate is turning away; StageGateBarging lists live FOREGROUND holds
+	// ("rebuild:<group>") — non-empty means a rebuild is registered and
+	// background heavy stages are yielding to it.
+	StageGateHolder   string   `json:"stage_gate_holder,omitempty"`
+	StageGateDeferred []string `json:"stage_gate_deferred,omitempty"`
+	StageGateBarging  []string `json:"stage_gate_barging,omitempty"`
+
 	// --- Process metrics (wizard CPU/RAM readout) ---
 	// These are only meaningful on the ENGINE-LIVENESS sidecar (same scope as
 	// the Engine-global fields above): RSS/CPU are per-PROCESS, not per-repo,


### PR DESCRIPTION
## Why — #5993's gate did not bind the path users actually take

The heavy write-stage gate landed in #5993, was deployed, and measured **worse**: whole-machine peak 4258 → 5430 MB, with the peak instant showing `index child 2979 MB + group-algo 1618 MB` co-resident.

Root cause: the gate's SHARED side reads `s.inflight`, which tracks only **scheduler-dispatched** index jobs. `grafel reset` and the rebuild RPC index through `makeDaemonRebuildFunc` → `Index(...)` **directly** (`cmd/grafel/daemon.go:1196-1202`), never touching `scheduler.Enqueue`. During a rebuild `len(s.inflight) == 0`, so the gate believed the machine was idle and let a background group-algo pass start alongside a ~3 GB foreground index.

The gate was correct for scheduler-driven churn (git hooks, watchers). It simply did not cover the path a user takes for a from-scratch index — which is also the path every measurement takes. That is the seventh instance in this epic of *a guard that exists, looks correct, and does not bind the path that runs*.

## The barge

Foreground rebuild work **acquires unconditionally and never waits**; background stages yield around it.

```go
// first statement of daemonRebuildFuncCore
defer sched.BargeForeground("rebuild:" + args.Group)()
```

One hold spans **both** previously-uncovered halves: the direct per-repo index batch and the rebuild's own in-process cross-repo link pass (`linksFn` → `runLinksHookWithCtx`, called synchronously at `daemon.go:1750`).

`daemon.Config` carries `Rebuild` *inward* to where the scheduler is constructed, so a handle cannot be threaded back out to `cmd/grafel`. The scheduler therefore publishes itself to a package-level bridge in `Start()` and withdraws (identity-checked) in `Stop()` — the same shape as `repolock.DefaultRegistry`, which this rebuild path already uses for the analogous cross-path claim. Registration lives **inside `Start()`** rather than at a wiring call site specifically so the bridge cannot be silently left unwired; that is the failure mode this epic keeps hitting.

Holds are keyed by a monotonic `int64` id (never reset by `Stop()`), so a double release, or a release after the backstop reaped it, cannot drop another rebuild's hold. `sync.Once`-wrapped on top.

## Hold-max: a separate bound, because the failure modes differ

The barge is **exempt** from `StageGateHoldMax` (15m) and has its own `StageGateBargeMax` (60m, `GRAFEL_STAGE_GATE_BARGE_MAX`).

- `StageGateHoldMax` must be tight: an exclusive holder holds across a **subprocess spawn**, and a child SIGKILLed in a way the parent never observes wedges **index dispatch** — the daemon's core job.
- A barge is in-process Go code with `defer`, so it unwinds on return, error, cancel and panic alike; and a leaked barge **cannot wedge indexing at all** (verified: `allowIndexAdmitLocked` reads only `stageHolder`/`stageDrainFor`, neither of which a barge sets — an enqueued job dispatches and completes normally under a held barge).

So 60m is a *leak backstop*, ~5× the largest observed rebuild, not a scheduling parameter. A naive shared bound would have been actively harmful: a 10–12 minute rebuild sits right at 15m, so the barge would have **forfeited itself mid-rebuild**, silently reintroducing overlap on exactly the longest rebuilds. `stage_gate_barge_expired` logs at ERROR and means a foreground goroutine vanished without unwinding — investigate it, do not raise the knob.

## The invariant, stated truthfully

> At most one heavy write-side stage is resident at a time, with exactly two exceptions, both **single hand-offs** rather than steady states:
> 1. **after a forfeit** — `reapStageLocked` clears a wedged exclusive holder without cancelling it (it has no handle that could);
> 2. **the ONE exclusive stage already mid-flight when foreground barges** — it is neither cancelled nor waited on, so that single pair overlaps.

Every exclusive stage that *starts* after the barge defers until it lifts (both entry points, `fireLinks` and `fireGroupAlgo`, gate on `tryAcquireStageLocked`). The residual cost of (2) is bounded: at most one background pass overlapping at the *start* of a rebuild, versus the pre-barge behaviour where a background pass could begin at any point across the whole rebuild, including its heaviest minutes.

A barge-caused deferral no longer escalates to the drain barrier — the barrier's mechanism is "stop admitting index jobs so the batch drains", which is inert against a barge since draining `s.inflight` cannot end a rebuild. The deferral **clock keeps running**, so the starvation budget is preserved and the barrier raises immediately on the next retry if index churn is what blocks the stage once the barge lifts.

## Observability — the gate is now visible from outside the process

Gate events previously went only to an in-memory ring buffer, so there was **no way to confirm from outside that the gate had fired**. That gap directly caused a false diagnosis during this epic (grepping `daemon.log` for `stage_gate_*`, finding nothing, and concluding the gate was dead).

State now travels one on-disk path both deployment modes converge on, mirroring the existing `Warm*` fields:

```
sched.StageGateState → statusfile.File.StageGate{Holder,Deferred,Barging}
  (stamped by startEngineLivenessHeartbeat)
  → daemon.StageGateFromStatusFile → Service.Status
  (in-process scheduler when present; sidecar fallback when nil — split mode has no scheduler in serve)
  → proto.StatusReply.StageGate* → `grafel status`
```

`grafel status` renders `stage_gate: barging=… holder=… deferred=…`, printing only when the gate is doing something.

**A stale sidecar reports nothing, not the last-known holder.** A phantom "group-algo holds the token" would be worse than silence on a surface whose entire job is adjudicating whether a heavy stage is running *right now*. Pinned by `TestStatus_StageGateFieldsOmittedWhenSidecarStale`.

## Scope limits, documented in code

- **A barge does not hold index admission.** Scheduler-dispatched index jobs may still dispatch during a rebuild, bounded as before by the RSS ledger and repolock. Holding admission for 10–12 minutes would starve the watcher queue for the whole window.
- A drain barrier already up when a rebuild barges cannot be cleared by acquisition, but `reapStageLocked` still expires it — index dispatch is held at most `StageGateDrainMax` (2m), not the barge's lifetime.
- The synchronous single-repo `grafel index` RPC is not barged (an order of magnitude smaller than a group rebuild).

## Verification

`go build ./...`, `go vet ./internal/daemon/... ./cmd/...`, `gofmt -l internal cmd` clean. 1247 pass across `./internal/daemon/... ./cmd/grafel/...`; 576 pass under `-race -count=4 -p 2`; plus 2814 across `./internal/cli/... ./internal/statusfile/... ./internal/dashboard/... ./internal/mcp/...` since this touches `statusfile.File` and the CLI renderer.

Independently adversarially reviewed. The split-mode placement assumption was **verified rather than assumed**: `Service.Rebuild` short-circuits under `SplitModeEnabled()` and writes a request file; the engine drains it in-process; `sched.New` has exactly one construction site, reachable only from the engine plane. Serve never has a scheduler and never runs a rebuild.

Mutations, no survivors:

| mutation | caught by |
|---|---|
| never release the barge | 3 tests (normal / error / CancelGroup) |
| remove `bargeHeldLocked` check in `tryAcquireStageLocked` | 3 tests |
| remove `reapBargeLocked` | 1 test |
| `withdrawBargeBridge` clears unconditionally | `BridgeWithdrawIsIdentityChecked` |
| drop `&& !bargeHeldLocked()` from drain escalation | `DeferralUnderBargeDoesNotRaiseDrainBarrier` |
| remove the sidecar fallback in `Service.Status` | `FromEngineLivenessSidecarInSplitMode` |
| remove the `gateFn` block in the heartbeat writer | `PublishesStageGateState` |
| drop the in-process `Barging` copy | `FromInProcessScheduler` |
| make `StageGateFromStatusFile` ignore freshness | `OmittedWhenSidecarStale` |

**RSS effect unmeasured** — the overlap is pinned as *state*, not megabytes. The status surface above is what makes the next measurement verifiable rather than inferred.

Refs #5954
