### PR TITLE
perf(#5909): presize the group union + skip the memo in the one-shot group-algo child

### DIFF
--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -120,7 +120,14 @@ func runGroupAlgo(args []string) int {
 	var res *groupalgo.GroupAlgoResult
 	var err error
 	if write {
-		res, err = groupalgo.RunGroupAlgorithmsIncremental(group)
+		// ONE-SHOT variant (#5909): this process computes once and exits, so the
+		// process-local memo can never be read again — populating it would only
+		// pin a SECOND full *AlgorithmResults (PageRank + community + centrality
+		// maps over the whole union) live across the overlay write, at the exact
+		// point this child is already at its heap peak. The daemon's in-process
+		// fallback (daemon.go daemonSchedulerGroupAlgo) still uses the memoizing
+		// entrypoint, where the guard is load-bearing.
+		res, err = groupalgo.RunGroupAlgorithmsIncrementalOneShot(group)
 	} else {
 		res, err = groupalgo.RunGroupAlgorithms(group)
 	}

--- a/cmd/grafel/group_algo_wiring_5909_test.go
+++ b/cmd/grafel/group_algo_wiring_5909_test.go
@@ -1,0 +1,106 @@
+package main
+
+// group_algo_wiring_5909_test.go — pins WHICH group-algo entrypoint each caller
+// uses (#5909, refs #5954).
+//
+// groupalgo has two incremental entrypoints that differ only in retention:
+//
+//   - RunGroupAlgorithmsIncremental       — memoizes. The long-lived daemon's
+//     in-process fallback needs this: the process-local guard is what bounds the
+//     O(V*E) betweenness recompute to once per group-version when the overlay
+//     cannot be persisted (#5309 / the group-scope CPU spin).
+//   - RunGroupAlgorithmsIncrementalOneShot — does NOT memoize. The forked
+//     `group-algo --write` child computes once and exits, so the memo can never
+//     be read again; storing it only pins a SECOND full *AlgorithmResults
+//     (PageRank + community + centrality maps over the whole union) live across
+//     the entire WriteOverlayFromResult window, at the child's heap peak.
+//
+// Each entrypoint is well covered by the groupalgo package tests. The CHOICE
+// between them at the call site is not: swapping the two calls compiles, and
+// every behavioural test in both packages still passes, because each function
+// remains individually correct. A silent swap is a DOUBLE regression that CI
+// cannot see — the daemon loses the compute-once guard AND the child re-acquires
+// the retention this change removed.
+//
+// So this test asserts the wiring structurally, from source. It parses the two
+// call sites and matches the selector identifier EXACTLY (never by substring:
+// "RunGroupAlgorithmsIncremental" is a prefix of the one-shot name).
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+const (
+	memoizingEntrypoint = "RunGroupAlgorithmsIncremental"
+	oneShotEntrypoint   = "RunGroupAlgorithmsIncrementalOneShot"
+)
+
+// groupalgoCallsIn returns the set of groupalgo.<Name> functions called within
+// the named top-level func in file. Exact identifier match on both the package
+// qualifier and the selector.
+func groupalgoCallsIn(t *testing.T, file, funcName string) map[string]bool {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, file, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", file, err)
+	}
+	var target *ast.FuncDecl
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == funcName && fd.Recv == nil {
+			target = fd
+			break
+		}
+	}
+	if target == nil {
+		t.Fatalf("func %s not found in %s — this test's anchor moved; re-point it, do not delete it", funcName, file)
+	}
+	got := map[string]bool{}
+	ast.Inspect(target, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "groupalgo" {
+			return true
+		}
+		got[sel.Sel.Name] = true
+		return true
+	})
+	return got
+}
+
+// TestWiring_OneShotChildUsesOneShotEntrypoint: the `group-algo --write` child
+// must call the NON-memoizing entrypoint.
+func TestWiring_OneShotChildUsesOneShotEntrypoint(t *testing.T) {
+	calls := groupalgoCallsIn(t, "group_algo.go", "runGroupAlgo")
+
+	if !calls[oneShotEntrypoint] {
+		t.Errorf("the `group-algo --write` child does not call groupalgo.%s — the short-lived child would retain a second full *AlgorithmResults across the overlay write (#5909)", oneShotEntrypoint)
+	}
+	if calls[memoizingEntrypoint] {
+		t.Errorf("the `group-algo --write` child calls the MEMOIZING groupalgo.%s — that is the daemon's entrypoint; in a process that exits immediately the memo is pure retention", memoizingEntrypoint)
+	}
+}
+
+// TestWiring_DaemonInProcessUsesMemoizingEntrypoint: the daemon's in-process
+// group-algo fallback must call the MEMOIZING entrypoint — the compute-once
+// guard (#5309) only exists in that one.
+func TestWiring_DaemonInProcessUsesMemoizingEntrypoint(t *testing.T) {
+	calls := groupalgoCallsIn(t, "daemon.go", "daemonSchedulerGroupAlgo")
+
+	if !calls[memoizingEntrypoint] {
+		t.Errorf("the daemon in-process group-algo fallback does not call groupalgo.%s — it loses the compute-once-per-version guard, reopening the unbounded O(V*E) betweenness re-spin when the overlay cannot be persisted (#5309)", memoizingEntrypoint)
+	}
+	if calls[oneShotEntrypoint] {
+		t.Errorf("the daemon in-process group-algo fallback calls the one-shot groupalgo.%s — the daemon is long-lived and MUST memoize", oneShotEntrypoint)
+	}
+}

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -148,6 +148,51 @@ func resolveGroup(group string) (*registry.GroupConfig, error) {
 	return cfg, nil
 }
 
+// unionCapacityHint pre-computes the exact size of the union about to be
+// assembled, from each repo's PERSISTED header counts (#5909, refs #5954).
+//
+// Why: the assembly below appends entities one at a time and relationships
+// repo-by-repo. An unpresized append grows by doubling, so at the copy instant
+// the process transiently holds BOTH the old backing array and a new one up to
+// ~2x its size — for the real corpus (427k entities) that copy is the single
+// largest allocation in the group-algo child. Presizing removes every growth
+// copy: one allocation of the final size, no transient double.
+//
+// graph.PersistedStatsFromDir is a header read (fbreader/MultiReader entity +
+// relationship counts) — no entity materialization — the same cheap pre-pass
+// cmd/grafel/daemon.go:767 uses for SchedulerEntityCount.
+//
+// MISSING/ZERO STATS ARE CONTRIBUTED AS ZERO, deliberately. A repo that has no
+// readable graph descriptor (never indexed, or graph.json-only — the JSON
+// fallback carries no header counts) is simply not counted, so the hint is an
+// UNDER-estimate and the remaining share is filled by ordinary append growth
+// from a truthful base. That direction is the safe one: a hint that
+// OVER-estimates would allocate a union larger than the union, which is exactly
+// the hazard this change exists to remove. For the same reason nothing is ever
+// guessed, rounded up, or extrapolated from a sibling repo.
+//
+// The hint can still under-count by a small delta if a repo is re-indexed
+// between this header pre-pass and its LoadGraphFromDir below; that is a
+// bounded under-estimate, handled by the same append growth.
+func unionCapacityHint(cfg *registry.GroupConfig) (entCap, relCap int) {
+	if cfg == nil {
+		return 0, 0
+	}
+	for _, r := range cfg.Repos {
+		ps, ok := graph.PersistedStatsFromDir(daemon.StateDirForRepo(r.Path))
+		if !ok {
+			continue
+		}
+		if ps.Entities > 0 {
+			entCap += ps.Entities
+		}
+		if ps.Relationships > 0 {
+			relCap += ps.Relationships
+		}
+	}
+	return entCap, relCap
+}
+
 // AssembleGroupGraph loads every repo's graph.fb and concatenates entities +
 // relationships into a single in-memory group graph. The cross-repo phantom
 // CALLS edges are already present in each repo's graph.fb (post-P5), so the
@@ -169,9 +214,14 @@ func AssembleGroupGraph(group string) (entities []graph.Entity, rels []graph.Rel
 		return nil, nil, nil, nil, err
 	}
 
-	entities = []graph.Entity{}
-	rels = []graph.Relationship{}
-	entityRepo = map[string]string{}
+	// Presize from the persisted per-repo header counts (#5909). Under-estimates
+	// are safe (append growth covers the rest); over-estimates are the hazard, so
+	// unionCapacityHint never guesses for a repo it cannot read. cap==0 degrades
+	// to exactly the previous behaviour.
+	entCap, relCap := unionCapacityHint(cfg)
+	entities = make([]graph.Entity, 0, entCap)
+	rels = make([]graph.Relationship, 0, relCap)
+	entityRepo = make(map[string]string, entCap)
 	srcMtimes = map[string]int64{}
 
 	for _, r := range cfg.Repos {
@@ -288,6 +338,42 @@ func RunGroupAlgorithms(group string) (*GroupAlgoResult, error) {
 // the whole union and a partial pass could not reproduce the exact same labels
 // a full pass assigns — that would break strict parity.)
 func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
+	return runGroupAlgorithmsIncremental(group, true)
+}
+
+// RunGroupAlgorithmsIncrementalOneShot is RunGroupAlgorithmsIncremental for a
+// process that computes ONCE and then exits — the `grafel group-algo --write`
+// child the daemon's scheduler forks (#5909, refs #5954).
+//
+// It is identical in every observable way (same union, same input_hash, same
+// deterministic results, same overlay) except that it does NOT populate the
+// process-local memo. The memo exists so a LONG-LIVED daemon does not re-run
+// Louvain + PageRank + O(V*E) betweenness for a group-version it already
+// computed, and so a failed overlay persist cannot reopen the
+// recompute->persist-fail->recompute spin. Neither property can ever be
+// exercised by a process that is about to exit: for the one-shot child the memo
+// is pure retention — a SECOND live reference to the PageRank / community /
+// centrality maps over the whole union, pinned across the entire
+// WriteOverlayFromResult window, which is precisely when the child is already
+// at its heap peak (running_algorithms measured at 1433 MB live / 1983 MB RSS
+// on the 427k-entity corpus, #5992).
+//
+// NOTE ON #5909's FRAMING: the issue says the retention is "on the in-process
+// path (GRAFEL_SUBPROCESS_INDEXER=0)". That is inverted. storeMemoizedGroupResult
+// was called UNCONDITIONALLY from the single incremental entrypoint, so the
+// subprocess child paid the retention too — and the child is the process where
+// it can never pay for itself. The in-process/daemon path keeps the memo
+// unchanged; it is the one caller for which the memo is the point.
+func RunGroupAlgorithmsIncrementalOneShot(group string) (*GroupAlgoResult, error) {
+	return runGroupAlgorithmsIncremental(group, false)
+}
+
+// runGroupAlgorithmsIncremental is the shared body. memoize selects whether a
+// full recompute is recorded in the process-local guard: true for the
+// long-lived daemon (see RunGroupAlgorithmsIncremental), false for the one-shot
+// child (see RunGroupAlgorithmsIncrementalOneShot). It affects RETENTION only —
+// never the union, the hash, the results, or the overlay.
+func runGroupAlgorithmsIncremental(group string, memoize bool) (*GroupAlgoResult, error) {
 	// Phase stamps (#5954). The group-algo child is one of the two largest
 	// processes on the machine at the whole-machine memory peak and had zero
 	// instrumentation; memtrace polls CurrentPhase on a ticker so each memstats
@@ -355,8 +441,12 @@ func RunGroupAlgorithmsIncremental(group string) (*GroupAlgoResult, error) {
 	SetPhase(PhaseRunningAlgorithms)
 	res := graph.RunAlgorithms(entities, rels)
 	// Record BEFORE returning (and thus before the caller's overlay write), so a
-	// persist failure cannot cause a re-run for this same version.
-	storeMemoizedGroupResult(group, inputHash, res)
+	// persist failure cannot cause a re-run for this same version. Skipped for
+	// the one-shot child, which exits before any second run could read it — see
+	// RunGroupAlgorithmsIncrementalOneShot.
+	if memoize {
+		storeMemoizedGroupResult(group, inputHash, res)
+	}
 	return &GroupAlgoResult{
 		Group:        group,
 		Results:      res,

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -164,16 +164,22 @@ func resolveGroup(group string) (*registry.GroupConfig, error) {
 //
 // MISSING/ZERO STATS ARE CONTRIBUTED AS ZERO, deliberately. A repo that has no
 // readable graph descriptor (never indexed, or graph.json-only — the JSON
-// fallback carries no header counts) is simply not counted, so the hint is an
-// UNDER-estimate and the remaining share is filled by ordinary append growth
-// from a truthful base. That direction is the safe one: a hint that
-// OVER-estimates would allocate a union larger than the union, which is exactly
-// the hazard this change exists to remove. For the same reason nothing is ever
-// guessed, rounded up, or extrapolated from a sibling repo.
+// fallback carries no header counts) is simply not counted, so it makes the hint
+// an UNDER-estimate and the remaining share is filled by ordinary append growth
+// from a truthful base. That is the safe direction: a hint that OVER-estimates
+// would allocate a union larger than the union, which is exactly the hazard this
+// change exists to remove. For the same reason nothing is ever guessed, rounded
+// up, or extrapolated from a sibling repo.
 //
-// The hint can still under-count by a small delta if a repo is re-indexed
-// between this header pre-pass and its LoadGraphFromDir below; that is a
-// bounded under-estimate, handled by the same append growth.
+// The one way the hint can go WRONG IN EITHER DIRECTION is the TOCTOU window
+// between this header pre-pass and each repo's LoadGraphFromDir below: a repo
+// re-indexed LARGER in that window under-counts, and one re-indexed SMALLER
+// over-counts. Both are bounded by that single repo's own delta, both are
+// transient, and neither has any correctness effect — an under-count is
+// absorbed by append growth, an over-count leaves the union slice with spare
+// capacity for its (short) lifetime. Nothing is re-read or reconciled to close
+// the window: a second header pass would only move it, and the group union is
+// discarded at the end of the pass either way.
 func unionCapacityHint(cfg *registry.GroupConfig) (entCap, relCap int) {
 	if cfg == nil {
 		return 0, 0

--- a/internal/graph/groupalgo/union_presize_5909_test.go
+++ b/internal/graph/groupalgo/union_presize_5909_test.go
@@ -1,0 +1,336 @@
+package groupalgo
+
+// union_presize_5909_test.go — #5909 (Refs #5954): the group union assembly
+// must be PRESIZED, and the one-shot `group-algo --write` child must not retain
+// a second full *AlgorithmResults in the process-local memo.
+//
+// Hazard 1 (assembly). AssembleGroupGraph appended entities one at a time and
+// relationships repo-by-repo into UNPRESIZED slices. append() grows by
+// doubling, so at the copy instant the process transiently holds both the old
+// backing array and a new one ~2x its size — for a 427k-entity union that is
+// the single largest allocation in the process. Presizing from the persisted
+// per-repo header counts removes the growth copies entirely.
+//
+// Hazard 2 (memo). storeMemoizedGroupResult was called UNCONDITIONALLY. The
+// memo exists so the long-lived daemon does not re-run Louvain + PageRank +
+// betweenness for a group-version it already computed. The one-shot
+// `group-algo --write` child computes exactly once and then exits — for it the
+// memo is pure retention: a second reference to the PageRank / community /
+// centrality maps over the whole union, held live across the entire
+// WriteOverlayFromResult window (the phase where the child is already at its
+// heap peak).
+//
+// Both changes must be strictly behaviour-preserving: same union ORDER (the
+// order feeds graph.CommunityInputHash, and a changed hash silently invalidates
+// every persisted overlay), same input_hash, same overlay.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestAssembleGroupGraph_PresizesUnionSlices is the core RED assertion for
+// hazard 1: with every repo reporting persisted header stats, the union slices
+// must be allocated at exactly the union size — no growth doubling, and no
+// over-allocation either (over-allocating the union is the very thing we are
+// trying to avoid). cap is asserted, not timing.
+func TestAssembleGroupGraph_PresizesUnionSlices(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+
+	ents, rels, _, _, err := AssembleGroupGraph(group)
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	if len(ents) == 0 || len(rels) == 0 {
+		t.Fatalf("fixture degenerate: %d entities, %d rels", len(ents), len(rels))
+	}
+	if cap(ents) != len(ents) {
+		t.Errorf("entities cap=%d len=%d — union slice is not presized from the persisted per-repo stats (append doubling transiently allocates ~1.5-2x the union)", cap(ents), len(ents))
+	}
+	if cap(rels) != len(rels) {
+		t.Errorf("relationships cap=%d len=%d — union slice is not presized", cap(rels), len(rels))
+	}
+}
+
+// writeFixtureRepoJSON writes a repo whose ONLY graph artifact is graph.json —
+// no graph.fb — so graph.PersistedStatsFromDir reports ok=false for it while
+// graph.LoadGraphFromDir still materializes it. This is the "stats unavailable"
+// case the presize must handle explicitly.
+func writeFixtureRepoJSON(t *testing.T, slug, repoPath string, doc *graph.Document) registry.Repo {
+	t.Helper()
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir for %s: %v", slug, err)
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal fixture doc for %s: %v", slug, err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), b, 0o644); err != nil {
+		t.Fatalf("write fixture graph.json for %s: %v", slug, err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}
+
+// setupMixedStatsGroup registers a 2-repo group where repo "svc" has a real
+// graph.fb (stats available) and repo "web" has graph.json only (stats
+// UNAVAILABLE). Returns the group name and the two source documents in
+// registry order.
+func setupMixedStatsGroup(t *testing.T) (group string, docs []*graph.Document) {
+	t.Helper()
+	resetGroupAlgoMemo()
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoA, repoB, _ := fixtureGraphs()
+	rA := writeFixtureRepo(t, "svc", filepath.Join(root, "repoA"), repoA)
+	rB := writeFixtureRepoJSON(t, "web", filepath.Join(root, "repoB"), repoB)
+
+	cfgPath, err := registry.ConfigPathFor("mixed")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	if err := registry.SaveGroupConfig(cfgPath, &registry.GroupConfig{Name: "mixed", Repos: []registry.Repo{rA, rB}}); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("mixed", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+	return "mixed", []*graph.Document{repoA, repoB}
+}
+
+// TestAssembleGroupGraph_MissingStats_NoWrongCapacity: a repo whose persisted
+// stats are unavailable (graph.json only) must contribute NOTHING to the
+// presize — never a guessed capacity — and must not panic or lose content. The
+// resulting capacity must never EXCEED the union size: an over-sized union
+// allocation is worse than no presize at all.
+func TestAssembleGroupGraph_MissingStats_NoWrongCapacity(t *testing.T) {
+	group, docs := setupMixedStatsGroup(t)
+
+	ents, rels, entityRepo, _, err := AssembleGroupGraph(group)
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	wantEnts := len(docs[0].Entities) + len(docs[1].Entities)
+	wantRels := len(docs[0].Relationships) + len(docs[1].Relationships)
+	if len(ents) != wantEnts {
+		t.Fatalf("union entities=%d want=%d — a repo with unavailable stats was dropped", len(ents), wantEnts)
+	}
+	if len(rels) != wantRels {
+		t.Fatalf("union rels=%d want=%d", len(rels), wantRels)
+	}
+	// An unavailable-stats repo must not fabricate capacity. The union may still
+	// grow by ordinary append doubling for that repo's share (that is correct and
+	// unavoidable), but capacity must never run away beyond that bound.
+	if cap(ents) > 2*len(ents) {
+		t.Errorf("entities cap=%d len=%d — an unavailable-stats repo produced a fabricated/over-sized union allocation", cap(ents), len(ents))
+	}
+	if cap(rels) > 2*len(rels) {
+		t.Errorf("rels cap=%d len=%d — over-sized union allocation", cap(rels), len(rels))
+	}
+	if entityRepo["web:b1"] != "web" {
+		t.Errorf("web:b1 attributed to %q want web", entityRepo["web:b1"])
+	}
+}
+
+// TestUnionCapacityHint_MissingStatsContributesZero pins the presize hint
+// itself: a repo whose persisted header stats are unavailable contributes
+// EXACTLY ZERO to the hint — never a guess, never another repo's count. A wrong
+// capacity is worse than no capacity, because over-allocating the union is the
+// hazard being fixed.
+func TestUnionCapacityHint_MissingStatsContributesZero(t *testing.T) {
+	// All-stats-available group: the hint is exactly the union size.
+	full, _, _, _ := setupIncrGroup(t)
+	cfgFull, err := resolveGroup(full)
+	if err != nil {
+		t.Fatalf("resolve group: %v", err)
+	}
+	ents, rels, _, _, err := AssembleGroupGraph(full)
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	gotE, gotR := unionCapacityHint(cfgFull)
+	if gotE != len(ents) || gotR != len(rels) {
+		t.Errorf("hint for a fully-indexed group = (%d,%d), want the exact union size (%d,%d)", gotE, gotR, len(ents), len(rels))
+	}
+
+	// Mixed group: only the graph.fb repo contributes.
+	mixed, docs := setupMixedStatsGroup(t)
+	cfgMixed, err := resolveGroup(mixed)
+	if err != nil {
+		t.Fatalf("resolve mixed group: %v", err)
+	}
+	gotE, gotR = unionCapacityHint(cfgMixed)
+	if gotE != len(docs[0].Entities) || gotR != len(docs[0].Relationships) {
+		t.Errorf("hint for a mixed group = (%d,%d), want only the stats-bearing repo's counts (%d,%d) — the graph.json-only repo must contribute zero",
+			gotE, gotR, len(docs[0].Entities), len(docs[0].Relationships))
+	}
+}
+
+// TestAssembleGroupGraph_UnionMatchesPlainConcatenation is the behaviour lock:
+// the presized assembly must produce the union in EXACTLY the same order as the
+// plain per-element/per-repo appends it replaces, element for element, and
+// therefore the same graph.CommunityInputHash. The expected value is computed
+// here from the source documents by the very appends the implementation no
+// longer performs, so this is a direct pre-change vs post-change comparison
+// (the method #5992 used to prove its reorder hash-neutral).
+func TestAssembleGroupGraph_UnionMatchesPlainConcatenation(t *testing.T) {
+	group, pathA, pathB, _ := setupIncrGroup(t)
+
+	// Pre-change assembly, verbatim, over the SAME loaded documents the
+	// implementation reads: per-element entity append, whole-slice rel append,
+	// in registry repo order (svc then web), into unpresized slices.
+	var wantEnts []graph.Entity
+	var wantRels []graph.Relationship
+	wantRepo := map[string]string{}
+	for _, rd := range []struct {
+		slug string
+		path string
+	}{{"svc", pathA}, {"web", pathB}} {
+		doc, err := graph.LoadGraphFromDir(daemon.StateDirForRepo(rd.path))
+		if err != nil {
+			t.Fatalf("load %s: %v", rd.slug, err)
+		}
+		for i := range doc.Entities {
+			wantEnts = append(wantEnts, doc.Entities[i])
+			wantRepo[doc.Entities[i].ID] = rd.slug
+		}
+		wantRels = append(wantRels, doc.Relationships...)
+	}
+
+	gotEnts, gotRels, gotRepo, _, err := AssembleGroupGraph(group)
+	if err != nil {
+		t.Fatalf("AssembleGroupGraph: %v", err)
+	}
+	if len(gotEnts) != len(wantEnts) {
+		t.Fatalf("entity count %d want %d", len(gotEnts), len(wantEnts))
+	}
+	for i := range wantEnts {
+		if gotEnts[i].ID != wantEnts[i].ID {
+			t.Fatalf("union entity order changed at %d: got %q want %q — the union order feeds CommunityInputHash", i, gotEnts[i].ID, wantEnts[i].ID)
+		}
+	}
+	if len(gotRels) != len(wantRels) {
+		t.Fatalf("rel count %d want %d", len(gotRels), len(wantRels))
+	}
+	for i := range wantRels {
+		if gotRels[i].ID != wantRels[i].ID || gotRels[i].FromID != wantRels[i].FromID || gotRels[i].ToID != wantRels[i].ToID {
+			t.Fatalf("union rel order changed at %d: got %+v want %+v", i, gotRels[i], wantRels[i])
+		}
+	}
+	if !reflect.DeepEqual(gotRepo, wantRepo) {
+		t.Error("entityRepo attribution changed")
+	}
+	if got, want := graph.CommunityInputHash(gotEnts, gotRels), graph.CommunityInputHash(wantEnts, wantRels); got != want {
+		t.Fatalf("CommunityInputHash changed: got %s want %s — every persisted overlay memo would be silently invalidated", got, want)
+	}
+}
+
+// TestIncremental_OneShot_DoesNotMemoize is the RED assertion for hazard 2: the
+// one-shot entrypoint must NOT leave a second full *AlgorithmResults in the
+// process-local memo, because the process is about to exit and the memo can
+// never be read again — it is pure retention across the overlay write.
+func TestIncremental_OneShot_DoesNotMemoize(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+
+	res, err := RunGroupAlgorithmsIncrementalOneShot(group)
+	if err != nil {
+		t.Fatalf("one-shot incremental run: %v", err)
+	}
+	if res.Skipped {
+		t.Fatal("first run must NOT skip (nothing computed yet)")
+	}
+	if _, ok := loadMemoizedGroupResult(group, res.InputHash); ok {
+		t.Fatal("one-shot group-algo stored the full AlgorithmResults in the process-local memo — the short-lived --write child retains a second copy of the PageRank/community/centrality maps for the whole overlay-write window")
+	}
+}
+
+// TestIncremental_Daemon_StillMemoizes is the other half of the mutation pair:
+// the in-process/daemon entrypoint MUST still memoize — that memo is the guard
+// that bounds the O(V*E) betweenness recompute to once per group-version when
+// the overlay cannot be persisted (#5309 / the group-scope CPU spin). Inverting
+// the condition must fail exactly one of these two tests.
+func TestIncremental_Daemon_StillMemoizes(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+
+	res, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("daemon incremental run: %v", err)
+	}
+	if _, ok := loadMemoizedGroupResult(group, res.InputHash); !ok {
+		t.Fatal("daemon-path group-algo did NOT memoize — the compute-once-per-version guard is gone")
+	}
+}
+
+// TestOneShot_ResultAndOverlayIdenticalToDaemonPath proves the memo skip is
+// behaviour-neutral end to end: the one-shot path must produce the same
+// input_hash, the same algorithm results, and the same on-disk overlay bytes as
+// the memoizing daemon path (modulo the two intentionally non-deterministic
+// fields: the wall-clock computed_at and stats.runtime_ms).
+func TestOneShot_ResultAndOverlayIdenticalToDaemonPath(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+	path, perr := OverlayPath(group)
+	if perr != nil {
+		t.Fatalf("overlay path: %v", perr)
+	}
+
+	writeAndRead := func(res *GroupAlgoResult) []byte {
+		t.Helper()
+		if err := WriteOverlayFromResult(res); err != nil {
+			t.Fatalf("write overlay: %v", err)
+		}
+		var ov Overlay
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read overlay: %v", err)
+		}
+		if err := json.Unmarshal(b, &ov); err != nil {
+			t.Fatalf("decode overlay: %v", err)
+		}
+		ov.ComputedAt = time.Time{}
+		ov.Stats.RuntimeMS = 0
+		norm, err := json.Marshal(&ov)
+		if err != nil {
+			t.Fatalf("re-encode overlay: %v", err)
+		}
+		return norm
+	}
+
+	oneShot, err := RunGroupAlgorithmsIncrementalOneShot(group)
+	if err != nil {
+		t.Fatalf("one-shot run: %v", err)
+	}
+	oneShotBytes := writeAndRead(oneShot)
+
+	// Fresh process-equivalent state: clear the memo AND the overlay so the
+	// daemon path takes the same full-compute branch.
+	resetGroupAlgoMemo()
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove overlay: %v", err)
+	}
+
+	daemonRes, err := RunGroupAlgorithmsIncremental(group)
+	if err != nil {
+		t.Fatalf("daemon run: %v", err)
+	}
+	daemonBytes := writeAndRead(daemonRes)
+
+	if oneShot.InputHash != daemonRes.InputHash {
+		t.Fatalf("input_hash differs between one-shot and daemon path: %s != %s", oneShot.InputHash, daemonRes.InputHash)
+	}
+	resultsEqual(t, daemonRes.Results, oneShot.Results)
+	if string(oneShotBytes) != string(daemonBytes) {
+		t.Fatal("overlay bytes differ between the one-shot and daemon paths")
+	}
+}


### PR DESCRIPTION
## What

Two mechanical reductions in the `group-algo` pass, plus the wiring assertion that keeps them from silently reverting.

**A. Presize the union assembly.** `AssembleGroupGraph` appended into unpresized slices, so the largest allocation in the process transiently grew by doubling. `unionCapacityHint` now does a header-only pre-pass via `graph.PersistedStatsFromDir` (the same cheap call already used at `cmd/grafel/daemon.go:767`) and sizes `entities`, `rels` and `entityRepo` up front.

**B. Skip the result memo in the one-shot child.** `storeMemoizedGroupResult` retained a second `*AlgorithmResults` — PageRank, community and centrality maps over 427k entities — for the whole `WriteOverlayFromResult` window, in a process that is about to exit.

### Scope correction to #5909

That issue states the problem is "on the in-process path (`GRAFEL_SUBPROCESS_INDEXER=0`)". That is **inverted**: the call was unconditional on the single incremental entrypoint, so the `group-algo --write` subprocess paid it too — and the subprocess is the one that gains nothing, since it exits immediately after. The daemon path, which the issue blames, is the one where the memo is actually the point (#5309's compute-once guard against an unbounded O(V·E) betweenness re-spin).

## Why these are the smaller half — stated up front

`group-algo` is now instrumented (#5992), so this is measured rather than assumed. Real corpus, 427k entities, live = `next_gc / 1.5`:

| phase | live heap | RSS |
|---|---|---|
| assembling | 605 MB | 1069 MB |
| hashing | 842 MB | 1228 MB |
| **running_algorithms** | **1433 MB** | **1983 MB** |

**The peak is `running_algorithms`, not `assembling`.** These two changes remove a transient growth-copy spike and one retained result; they do not touch the +830 MB step inside `RunAlgorithms`, which is filed as **#5996** (the union stays live across the whole call while `BuildGraph` materialises a second complete graph representation, plus an eager 427k `map[string]string` and four string-keyed output maps). That is the top remaining write-side lever, and it was found by this instrumentation rather than by inspection.

## The hash must not move

`CommunityInputHash` is computed over the assembled union and feeds the incremental **skip decision** — a changed hash silently invalidates every stored memo, or produces a false cache hit.

The entire delta inside `AssembleGroupGraph` is three `make(...)` calls. The `for _, r := range cfg.Repos` loop, the per-element entity appends and the per-repo `rels` append are byte-identical to base. Capacity is not observable to `append` semantics — it can only affect whether a growth copy occurs, never contents, length or order.

`TestAssembleGroupGraph_UnionMatchesPlainConcatenation` proves it rather than arguing it: it hardcodes registry order, loads the documents directly, re-runs the **pre-change** appends into an unpresized slice, and asserts element-wise order equality plus `CommunityInputHash` equality. Verified non-circular in review — it never calls `AssembleGroupGraph`, `unionCapacityHint` or `resolveGroup`, and hardcoding the order makes it strictly stronger than the implementation.

## The capacity hint cannot over-allocate the union

Over-estimating would allocate a union larger than the union — the exact hazard this change exists to remove — so a repo with unreadable or absent stats contributes **zero** rather than a guess. `PersistedStatsFromDir` returns `ok=false` whenever `ReaderForDir` fails, which covers never-indexed and `graph.json`-only repos (the JSON fallback carries no header counts). `cap == 0` degrades to exactly the old behaviour.

Review independently ruled out every over-count path: segment sets sum each segment's own header count (`m.ranges` is lookup-routing only, never a subset of the counts), superseded generations cannot leak because the hint and the load both resolve through `CurrentGraphDescriptor`, and no repo can fund the hint yet be skipped by the assembly (`graphSourceMtime` cannot fail while `ReaderForDir` succeeds).

The one residual window — a repo re-indexed between the header pre-pass and its `LoadGraphFromDir` — is documented in **both** directions: re-indexed larger under-counts, re-indexed smaller over-counts, each bounded by that single repo's own delta, neither with a correctness effect.

## The wiring is now pinned

The two entrypoints are `RunGroupAlgorithmsIncrementalOneShot` (memo skipped) and `RunGroupAlgorithmsIncremental` (memo kept), delegating to a shared body. Each is individually well-tested — but **which caller uses which** was not, and review demonstrated that swapping them at the call sites passes **389/389** tests.

That silent swap is a double regression: the daemon loses #5309's compute-once guard, and the child re-acquires exactly the retention this commit removes. Both invisible to CI.

`group_algo_wiring_5909_test.go` closes it with an AST assertion over the two anchor functions. Matching is on the **exact selector identifier**, deliberately: `RunGroupAlgorithmsIncremental` is a proper prefix of `RunGroupAlgorithmsIncrementalOneShot`, so a `strings.Contains` implementation would see the memoizing name inside the one-shot name and report both call sites as correct *in either configuration* — silently passing the very swap it exists to catch. If an anchor function is renamed the helper fails loudly rather than vacuously passing on a function it could not find.

Mutation-verified: swapping the call sites fails both tests, 4 assertions, one per direction.

## Design note

The one-shot signal is an explicit entrypoint rather than process sniffing (`os.Args`, an env var). The caller statically knows its own lifetime, so daemon and child differ by *which function they call* — something a refactor or test harness cannot silently flip. The memo **load** is deliberately unchanged on both paths: it is a guaranteed miss in a fresh process, and keeping it shared preserves exact structural parity.

## Verification

`go build ./...`, `go vet ./internal/graph/... ./cmd/...`, `gofmt -l internal cmd` clean. `./internal/graph/... ./cmd/grafel/...` **746 pass**, no goldens moved; `./internal/graph/groupalgo/...` green under `-race`.

Independently adversarially reviewed. Mutations, no survivors:

| mutation | caught by |
|---|---|
| revert the presize | `PresizesUnionSlices` (`cap=18 len=13` — observes the doubling directly) |
| over-estimate the hint (`× 2`) | `PresizesUnionSlices` + `MissingStatsContributesZero` |
| invert `if memoize` | 5 tests, incl. all three pre-existing `MemoGuard_*` |
| swap the two call sites | both wiring tests, 4 assertions |

The hint is **exact** on a fully-indexed fixture (`hint == (len(ents), len(rels))`, and `cap == len` after assembly), so on the real corpus the doubling is eliminated rather than merely reduced.

**MB win unmeasured** — the coordinator measures. These are the smaller half by construction; see #5996 for where the 1433 MB actually lives.

Closes #5909
Refs #5954
