### PR TITLE
perf(#5954): phase-instrument the engine link pass, then move it into a paced subprocess

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	"github.com/cajasmota/grafel/internal/indexstate"
 	"github.com/cajasmota/grafel/internal/jobs"
+	"github.com/cajasmota/grafel/internal/links"
 	"github.com/cajasmota/grafel/internal/mcp"
 	"github.com/cajasmota/grafel/internal/memtrace"
 	"github.com/cajasmota/grafel/internal/process"
@@ -671,8 +672,18 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 	// (inherited automatically — RunSubprocessIndex builds the child's env
 	// from os.Environ(), so setting this var before starting the daemon is
 	// enough for both the engine/serve process AND every child it forks to
-	// trace). No phase concept applies to the long-running engine/serve
-	// plane, so phaseFn is nil (every sample's phase is ""). Inert by
+	// trace).
+	//
+	// #5954: phaseFn is links.CurrentPhase, NOT nil. It used to be nil on the
+	// reasoning that "no phase concept applies to a long-running process", and
+	// the cost of that was a whole unprofiled plane: the engine peaks AFTER the
+	// index child exits and holds ~1.9GB for minutes with every sample tagged
+	// "", leaving heap-peak.pprof as the only usable artifact. The engine DOES
+	// have one heavy staged workload — the cross-repo link pass, which
+	// materialises the group union twice — and that is what this reports.
+	// Outside a link pass the phase reads "" (none run yet) or "idle" (one has
+	// finished), and an idle-tagged sample is itself the finding: it is
+	// plateau — memory held but not being worked on. Inert by
 	// default: Start returns nil (no goroutine, no file) when
 	// GRAFEL_MEMTRACE_DIR is unset. Runs for the lifetime of the process —
 	// no Stop() call needed, matching other fire-and-forget daemon-startup
@@ -681,7 +692,7 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 	if runMode == daemonRunModeEngine {
 		memtraceRole = "engine"
 	}
-	memtrace.Start(memtraceRole, nil, func(format string, args ...any) {
+	memtrace.Start(memtraceRole, links.CurrentPhase, func(format string, args ...any) {
 		logger.Warn(fmt.Sprintf("memtrace: "+format, args...))
 	})
 
@@ -1096,12 +1107,56 @@ func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) erro
 	return err
 }
 
+// subprocessLinksRunner is the fork-exec used by daemonSchedulerLinks. A var
+// solely so a test can observe that the scheduler path forks (and that the
+// foreground path does not) without spawning a real multi-minute child.
+var subprocessLinksRunner = sched.RunSubprocessLinks
+
 // daemonSchedulerLinks re-runs the cross-repo link passes for a group.
-// Delegates to the context-aware version of the links hook so the scheduler's
-// shutdownCtx is threaded through for clean cancellation on daemon shutdown.
-// Behaviour is identical to a force rebuild's link step, except context is
-// propagated.
+//
+// By default the pass runs in a short-lived child process
+// (`grafel links-internal <group>`) so its heap is isolated from the engine and
+// reclaimed by the OS on exit (#5954; mirrors group-algo and the subprocess
+// indexer). Until this change it was the last heavy stage still running inside
+// the long-lived engine, and it showed: per-phase measurement put the pass
+// window at ~830MB LIVE heap / ~1.2GB heap_inuse — a plateau the engine then
+// held for the rest of its life, on top of everything else it is resident for.
+// The child also inherits GOGC=50, GODEBUG=madvdontneed=1 and a GOMAXPROCS cap,
+// none of which the in-process pass ever had.
+// GRAFEL_SUBPROCESS_INDEXER=0 opts back into the in-process path.
+//
+// THE STAGE TOKEN SPANS THE FORK. The scheduler calls this while holding the
+// daemon-wide EXCLUSIVE heavy-stage token (fireLinks → tryAcquireStageLocked,
+// released by a defer around the call), so this function must not return until
+// the child has exited — otherwise the token would be released with the heavy
+// work still running and the gate would stop serialising the very stage it
+// exists for. RunSubprocessLinks waits on the child, so the token covers the
+// child's whole lifetime exactly as it does for group-algo.
+//
+// CANCELLATION. ctx is the scheduler's per-group cancel context (derived from
+// shutdownCtx), so daemon shutdown or a CancelGroup on a group delete still
+// stops the pass; across the fork the in-process ctx checks become a SIGKILL of
+// the child (exec.CommandContext's default Cancel is cmd.Process.Kill — not a
+// SIGTERM). More prompt than the boundary checks it replaces, at the cost of
+// leaking the pass's staging temp dir, which stageGraphsDir sweeps.
 func daemonSchedulerLinks(ctx context.Context, group string) error {
+	if sched.SubprocessIndexEnabled() {
+		return subprocessLinksRunner(ctx, group, slog.Default())
+	}
+	// In-process fallback (opt-out via GRAFEL_SUBPROCESS_INDEXER=0).
+	return runLinksHookWithCtx(ctx, group)
+}
+
+// daemonForegroundLinks is the link step of a user-initiated rebuild, run
+// synchronously inside daemonRebuildFuncCore.
+//
+// It deliberately does NOT fork (#5954). The rebuild is foreground work with a
+// human waiting on it — the wizard's "Detecting cross-repo links…" phase — and
+// it is already covered by the stage gate's barge, so the memory argument that
+// justifies the child on the scheduler path does not apply here while the
+// latency and progress-plumbing costs of a fork would. Kept as a named function
+// rather than an inline closure so that this distinction is testable.
+func daemonForegroundLinks(ctx context.Context, group string) error {
 	return runLinksHookWithCtx(ctx, group)
 }
 
@@ -1201,12 +1256,12 @@ func makeDaemonRebuildFunc(concurrency int) daemon.RebuildFunc {
 		opts = append([]IndexOption{WithInteractive(true)}, opts...)
 		return Index(repoPath, outPath, repoTag, skipPasses, pretty, jsonStats, opts...)
 	}
-	linksFn := func(ctx context.Context, group string) error {
-		// Context-aware so a group delete mid-rebuild cancels the (multi-minute)
-		// cross-repo link/phantom pass instead of running it to completion for a
-		// group that no longer exists (v0.1.8 leak fix).
-		return runLinksHookWithCtx(ctx, group)
-	}
+	// Context-aware so a group delete mid-rebuild cancels the (multi-minute)
+	// cross-repo link/phantom pass instead of running it to completion for a
+	// group that no longer exists (v0.1.8 leak fix). Runs IN-PROCESS — see
+	// daemonForegroundLinks for why the #5954 fork is scoped to the
+	// scheduler-driven pass only.
+	linksFn := daemonForegroundLinks
 	return func(args proto.RebuildArgs) ([]string, string, error) {
 		return daemonRebuildFuncCore(concurrency, args, indexFn, linksFn)
 	}

--- a/cmd/grafel/index_gcpercent.go
+++ b/cmd/grafel/index_gcpercent.go
@@ -36,9 +36,15 @@ const backgroundIndexCommand = "index-internal"
 // entrypoint the daemon's scheduler fork-execs (RunSubprocessGroupAlgo).
 const backgroundGroupAlgoCommand = "group-algo"
 
+// backgroundLinksCommand is the argv[1] of the hidden cross-repo link
+// entrypoint the daemon's scheduler fork-execs (RunSubprocessLinks). Note it is
+// NOT "links" — that name belongs to the public cobra command, which is
+// interactive and must stay uncapped.
+const backgroundLinksCommand = "links-internal"
+
 // backgroundGCPercentCommands is the ALLOW-LIST of commands whose GC pacing we
-// cap. Both members are batch children the daemon fork-execs with no human
-// waiting on them, so trading GC CPU for RSS is free there.
+// cap. Every member is a batch child the daemon fork-execs with no human
+// waiting on it, so trading GC CPU for RSS is free there.
 //
 // It became a set rather than a single constant when whole-machine measurement
 // showed the peak instant had moved entirely post-index (#5954): at that
@@ -52,6 +58,7 @@ const backgroundGroupAlgoCommand = "group-algo"
 var backgroundGCPercentCommands = map[string]bool{
 	backgroundIndexCommand:     true,
 	backgroundGroupAlgoCommand: true,
+	backgroundLinksCommand:     true,
 }
 
 // isBackgroundGCPercentCommand reports whether argv[1] names a background batch

--- a/cmd/grafel/links_internal.go
+++ b/cmd/grafel/links_internal.go
@@ -1,0 +1,75 @@
+package main
+
+// links_internal.go — hidden `grafel links-internal <group>` subcommand
+// (#5954).
+//
+// One cross-repo link pass for one group, in a short-lived child process. The
+// daemon's scheduler fork-execs this instead of running the pass inside the
+// long-lived engine (see sched.RunSubprocessLinks); it is the third and last
+// heavy stage to be moved out, after the index child and group-algo.
+//
+// WHY. The pass materialises the whole group union TWICE in sequence — every
+// repo's Document held live across ~19 passes in links.RunAllPasses, then
+// reloaded into the phantom-edge pass's docs map — and the engine kept that
+// arena for the rest of its life. Per-phase measurement on the real corpus put
+// the pass window at ~830MB LIVE heap (~1.2GB heap_inuse; the gap is exactly
+// why live heap must be read off next_gc/(1+GOGC/100) and not off heap_inuse),
+// peaking in link_pass_load → link_pass_import → link_pass_constant_propagation
+// — i.e. the union load and the passes that immediately follow it, not the
+// phantom reload. In a child the OS takes all of it back on exit.
+//
+// Not part of the public command surface; intercepted before cobra dispatch in
+// main.go, exactly like index-internal and group-algo. The user-facing
+// `grafel links pass <group>` (internal/cli) is unchanged and still runs in
+// whatever process invoked it.
+//
+//	grafel links-internal <group>
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/cli"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/links"
+	"github.com/cajasmota/grafel/internal/memtrace"
+)
+
+func runLinksInternal(args []string) int {
+	if len(args) != 1 || args[0] == "" {
+		fmt.Fprintln(os.Stderr, "usage: grafel links-internal <group>")
+		return 2
+	}
+	group := args[0]
+
+	// Lower this child's OS scheduling priority so even its capped cores yield
+	// to foreground work. Best-effort self-renice, so it holds however the child
+	// is spawned (the GOMAXPROCS cap itself comes from the parent's env).
+	sched.NiceSelf()
+
+	// #5954 / #5956 memtrace: phase-tagged memstats sampler + per-phase heap
+	// profiles, gated entirely behind GRAFEL_MEMTRACE_DIR (inherited, since the
+	// child's env derives from the daemon's os.Environ()). Start returns nil —
+	// no goroutine, no file — when the var is unset, so this is zero overhead by
+	// default. The phase comes from links.CurrentPhase, stamped by the pass
+	// itself, so the trace cannot drift from what the process is doing.
+	memSampler := memtrace.Start("links", links.CurrentPhase, memtraceLogf)
+	defer memSampler.Stop()
+
+	// context.Background(), deliberately: cancellation of this child is a
+	// SIGKILL from the parent (exec.CommandContext's default Cancel is
+	// cmd.Process.Kill), not an in-process ctx. A signal handler is therefore
+	// not an option — SIGKILL cannot be caught — and none is wanted: the kill
+	// is more prompt than the ctx checks it replaces, which only took effect at
+	// a pass boundary. The pass's writes are temp+rename so a kill cannot tear
+	// them; it does leak the staging temp dir. See RunSubprocessLinks's doc.
+	t0 := time.Now()
+	if err := cli.RunLinksForGroupCtx(context.Background(), group); err != nil {
+		fmt.Fprintf(os.Stderr, "grafel links-internal: %v\n", err)
+		return 1
+	}
+	fmt.Printf("links-internal: group=%s elapsed=%s\n", group, time.Since(t0).Truncate(time.Millisecond))
+	return 0
+}

--- a/cmd/grafel/links_subprocess_5954_test.go
+++ b/cmd/grafel/links_subprocess_5954_test.go
@@ -1,0 +1,115 @@
+package main
+
+// links_subprocess_5954_test.go — the scheduler-driven link pass runs in a
+// child process (#5954).
+//
+// SCOPE. This is the BACKGROUND, scheduler-driven pass only. The foreground
+// rebuild's link step (daemonForegroundLinks, called synchronously inside
+// daemonRebuildFuncCore) is user-initiated and latency-sensitive and stays
+// in-process; the second test here is the guard that keeps it that way.
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+func TestDaemonSchedulerLinks_ForksTheChild(t *testing.T) {
+	var gotGroup string
+	var gotCtx context.Context
+	release := make(chan struct{})
+	entered := make(chan struct{})
+
+	prev := subprocessLinksRunner
+	subprocessLinksRunner = func(ctx context.Context, group string, _ *slog.Logger) error {
+		gotCtx, gotGroup = ctx, group
+		close(entered)
+		<-release
+		return nil
+	}
+	t.Cleanup(func() { subprocessLinksRunner = prev })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- daemonSchedulerLinks(ctx, "acme") }()
+
+	select {
+	case <-entered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("daemonSchedulerLinks never reached the subprocess runner")
+	}
+
+	// The scheduler holds the EXCLUSIVE heavy-stage token across this callback
+	// (fireLinks acquires it, a defer releases it), so the callback must not
+	// return while the child is still running — otherwise the gate stops
+	// binding for exactly the stage it was built to serialise.
+	select {
+	case <-done:
+		t.Fatal("daemonSchedulerLinks returned while the child was still running — the stage token would be released early")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("daemonSchedulerLinks: %v", err)
+	}
+	if gotGroup != "acme" {
+		t.Errorf("group forwarded to the child = %q, want %q", gotGroup, "acme")
+	}
+	if gotCtx == nil {
+		t.Fatal("no context forwarded to the child runner")
+	}
+	// Cancellation must survive the fork: the scheduler's per-group cancel ctx
+	// is what CancelGroup trips mid-pass, and the runner turns it into SIGTERM.
+	if gotCtx.Err() != nil {
+		t.Fatalf("forwarded ctx already cancelled: %v", gotCtx.Err())
+	}
+	cancel()
+	if !errors.Is(gotCtx.Err(), context.Canceled) {
+		t.Errorf("cancelling the scheduler ctx did not reach the child runner's ctx (err=%v)", gotCtx.Err())
+	}
+}
+
+// TestDaemonForegroundLinks_DoesNotFork keeps the foreground rebuild's link
+// step in-process. It is user-initiated, latency-sensitive, and already covered
+// by the stage gate's barge; routing it through a fork would add process
+// startup to a path a human is waiting on.
+func TestDaemonForegroundLinks_DoesNotFork(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+
+	forked := false
+	prev := subprocessLinksRunner
+	subprocessLinksRunner = func(context.Context, string, *slog.Logger) error {
+		forked = true
+		return nil
+	}
+	t.Cleanup(func() { subprocessLinksRunner = prev })
+
+	// The group does not exist, so the in-process pass errors out early. The
+	// error is irrelevant — what matters is which path it took.
+	_ = daemonForegroundLinks(context.Background(), "no-such-group-5954")
+	if forked {
+		t.Fatal("the foreground rebuild's link step forked a child — it must stay in-process")
+	}
+}
+
+// TestLinksInternalIsOnTheGCPacingAllowList — the child is a background batch
+// process with nobody waiting on it, so it gets the same GOGC=50 pacing the
+// other two children have. group-algo needed a follow-up PR for its half of
+// this; the link child gets it in the same commit that creates it.
+func TestLinksInternalIsOnTheGCPacingAllowList(t *testing.T) {
+	if !isBackgroundGCPercentCommand(backgroundLinksCommand) {
+		t.Fatalf("%q is not on the background GC-pacing allow-list", backgroundLinksCommand)
+	}
+	pct, source := indexGCPercentDecision(backgroundLinksCommand, "", "")
+	if pct != indexGCPercentDefault {
+		t.Fatalf("GC percent for %q = %d (%s), want the background default %d",
+			backgroundLinksCommand, pct, source, indexGCPercentDefault)
+	}
+}

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -65,6 +65,22 @@ func main() {
 		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runGroupAlgo(os.Args[2:]))
 	}
+	// Hidden cross-repo link child (#5954). The daemon's scheduler fork-execs
+	// this instead of running the multi-minute link pass inside the long-lived
+	// engine, where its ~830MB live / ~1.2GB heap_inuse arena became a plateau
+	// the engine held for the rest of its life. Intercepted before cobra
+	// dispatch; the public `grafel links pass <group>` is unaffected.
+	//
+	// Same GC pacing as the other two background children, and for the same
+	// reason: nobody is waiting on it, so trading GC CPU for RSS is free.
+	// Deliberately NO applyIndexMemoryLimit — GOMEMLIMIT is an absolute soft
+	// target and an absolute target below the live heap is the documented >4x
+	// death spiral (index_memlimit.go); GOGC is relative and cannot enter that
+	// regime. Never fatal.
+	if len(os.Args) >= 2 && os.Args[1] == backgroundLinksCommand {
+		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
+		os.Exit(runLinksInternal(os.Args[2:]))
+	}
 	// Release acceptance ladder (#5224). Intercepted before cobra dispatch
 	// because it owns its own argv, lifecycle, and exit code (it boots an
 	// isolated in-process daemon and asserts each layer). Lives in cmd/grafel

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -57,6 +57,16 @@ func RunLinksForGroup(group string) error {
 // the partial work already written to disk is harmless (the group is being torn
 // down anyway).
 func RunLinksForGroupCtx(ctx context.Context, group string) error {
+	// #5954 — phase stamps for the memory trace. The link pass is the widest
+	// live-heap window in whichever process runs it (it materialises the group
+	// union twice, sequentially), and until these stamps existed every sample
+	// the ENGINE emitted was tagged "" so no stage could be blamed. The `idle`
+	// stamp on the way out is load-bearing for reading an engine trace: samples
+	// tagged idle are the post-pass PLATEAU — memory the process is still
+	// holding but no longer working on — which is the whole reason the
+	// scheduler-driven pass now runs in a child. See internal/links/phase.go.
+	links.SetPhase(links.PhaseStage)
+	defer links.SetPhase(links.PhaseIdle)
 	if err := ctx.Err(); err != nil {
 		return err
 	}
@@ -111,6 +121,7 @@ func RunLinksForGroupCtx(ctx context.Context, group string) error {
 		// Best-effort: log but don't fail the link pass.
 		fmt.Fprintf(os.Stderr, "grafel: phantom-edge pass warning: %v\n", perr)
 	}
+	links.SetPhase(links.PhaseLinkStats)
 	// #5692: record link_ms into each group repo's dedicated link-stats.json.
 	// The link pass is the SOLE writer of that file, so this never races the
 	// reindex worker's graph-stats.json write. Best-effort — a write failure
@@ -233,7 +244,8 @@ func runLinksForGroup(cmd *cobra.Command, group string) error {
 //   - GraphAbsent: nothing to stage for the fb side (graph.json, if any, is
 //     still staged below).
 func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
-	tmp, err := os.MkdirTemp("", "grafel-links-")
+	sweepStaleStagingDirs()
+	tmp, err := os.MkdirTemp("", stagingDirPrefix)
 	if err != nil {
 		return "", func() {}, err
 	}
@@ -300,6 +312,49 @@ func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
 		}
 	}
 	return tmp, cleanup, nil
+}
+
+// stagingDirPrefix names the pass's scratch dir. Shared by the creator and the
+// sweeper so the two cannot drift.
+const stagingDirPrefix = "grafel-links-"
+
+// stagingDirMaxAge is how long a staging dir must have gone untouched before
+// the sweeper will remove it. It only has to exceed the longest plausible link
+// pass — the real corpus runs ~9 minutes — with enough margin that a slow or
+// deferred pass is never swept out from under itself. A leaked dir surviving an
+// extra day costs nothing; deleting a LIVE pass's staged graphs would fail the
+// pass outright, so the guard is deliberately lopsided.
+const stagingDirMaxAge = 24 * time.Hour
+
+// sweepStaleStagingDirs removes abandoned staging dirs from previous passes.
+//
+// #5954: the scheduler-driven pass now runs in a child that the daemon cancels
+// with SIGKILL (exec.CommandContext's default Cancel is cmd.Process.Kill), so
+// the `defer cleanup()` below cannot run on cancellation. That is a genuine
+// regression against the in-process path, where a CancelGroup unwound the pass
+// cooperatively and the cleanup ran; a group deleted or a daemon stopped
+// mid-pass now leaves a symlink farm under $TMPDIR every time. This bounds the
+// accumulation without pretending the leak is not there.
+//
+// Best-effort by construction: every error is ignored. This is a housekeeping
+// courtesy on the way into a multi-minute pass, and no staging failure of any
+// kind may be allowed to fail the pass itself.
+func sweepStaleStagingDirs() {
+	entries, err := os.ReadDir(os.TempDir())
+	if err != nil {
+		return
+	}
+	cutoff := time.Now().Add(-stagingDirMaxAge)
+	for _, e := range entries {
+		if !e.IsDir() || !strings.HasPrefix(e.Name(), stagingDirPrefix) {
+			continue
+		}
+		info, ierr := e.Info()
+		if ierr != nil || info.ModTime().After(cutoff) {
+			continue
+		}
+		_ = os.RemoveAll(filepath.Join(os.TempDir(), e.Name()))
+	}
 }
 
 // linkOrCopyFile stages src at dst by symlink, falling back to a byte copy when
@@ -370,6 +425,12 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 
 	// Load each repo's graph.Document. Prefer graph.fb when available
 	// (ADR-0016 flip-day #808); fall back to graph.json via LoadGraphFromDir.
+	//
+	// #5954: this is the SECOND full materialisation of the group union in this
+	// process (RunAllPasses already loaded and released one), so it gets its own
+	// phase — the two windows want different fixes and an untagged trace cannot
+	// tell them apart.
+	links.SetPhase(links.PhasePhantomLoad)
 	docs := make(map[string]*graph.Document, len(cfg.Repos))
 	graphPaths := make(map[string]string, len(cfg.Repos)) // slug → graph.json path for WriteAtomic
 	for _, r := range cfg.Repos {
@@ -414,12 +475,23 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 	}
 
 	// Promote phantom edges.
+	links.SetPhase(links.PhasePhantomPromote)
 	added, err := links.PromoteToPhantomEdges(allLinks, docs, group)
 	if err != nil {
 		return added, fmt.Errorf("phantom-edge pass: promote: %w", err)
 	}
 
 	// Re-run RunProcessFlow on each affected doc + write back to disk.
+	//
+	// #5954: stamped unconditionally, before the loop, so the phase reflects the
+	// stage the pass ENTERED rather than whether it found work — an empty
+	// affectedRepos set is a legitimate outcome (all cross-repo links removed)
+	// and must still be distinguishable from the load stage in a trace. The
+	// side-table writes are folded into this phase deliberately: stamping them
+	// separately inside the loop would produce an alternating flow/write history
+	// that says nothing a per-repo log line does not already say, and the writes
+	// are trivial next to the companion-set recompute they interleave with.
+	links.SetPhase(links.PhasePhantomFlow)
 	slugs := sortedStringKeys(affectedRepos)
 	for _, slug := range slugs {
 		doc, ok := docs[slug]
@@ -499,6 +571,7 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 	// read overlay would resurrect old cross-repo flows for a repo whose links
 	// were removed (without a reindex to invalidate the source_key). The phantom
 	// pass is the sole writer of the flow side-table, so it owns this cleanup.
+	links.SetPhase(links.PhasePhantomCleanup)
 	for slug := range docs {
 		if affectedRepos[slug] {
 			continue

--- a/internal/cli/links_phase_5954_test.go
+++ b/internal/cli/links_phase_5954_test.go
@@ -1,0 +1,140 @@
+// links_phase_5954_test.go — the phantom-edge pass's phase stamps (#5954).
+//
+// runPhantomEdgePass is the SECOND full materialisation of the group union in
+// the same process: it reloads every repo's graph.Document into `docs`,
+// promotes phantom edges, and then re-runs process flow with every other
+// repo's Document held live as a companion. Whether the engine's plateau is
+// owned by that reload or by the eight-pass window upstream is exactly the
+// question the trace has to answer, so the phantom pass gets its own stamps
+// rather than inheriting the link pass's last one.
+//
+// Observed from a real pass, not asserted against literals.
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/links"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+func TestPhantomEdgePass_StampsPhasesInOrder(t *testing.T) {
+	links.ResetPhaseHistory()
+	t.Cleanup(links.ResetPhaseHistory)
+
+	daemonRoot := t.TempDir()
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	fePath := filepath.Join(t.TempDir(), "fe")
+	bePath := filepath.Join(t.TempDir(), "be")
+	for _, p := range []string{fePath, bePath} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir repo %s: %v", p, err)
+		}
+	}
+
+	fe := &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+			{ID: "fe_loadData", Name: "fetchSummary", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_r1", FromID: "fe_entry", ToID: "fe_loadData", Kind: "CALLS"},
+		},
+	}
+	be := &graph.Document{
+		Repo: "be",
+		Entities: []graph.Entity{
+			{ID: "be_handler", Name: "OrdersController.getSummary", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrdersController.java"},
+		},
+	}
+	writeFixtureFB(t, fePath, fe)
+	writeFixtureFB(t, bePath, be)
+
+	cfg := &registry.GroupConfig{
+		Name: "fixtgrp",
+		Repos: []registry.Repo{
+			{Slug: "fe", Path: fePath},
+			{Slug: "be", Path: bePath},
+		},
+	}
+	linksDoc := links.Document{
+		Version: 1,
+		Links: []links.Link{{
+			ID:       "lnk1",
+			Source:   "fe::fe_loadData",
+			Target:   "be::be_handler",
+			Relation: links.RelationCalls,
+			Method:   links.MethodHTTP,
+		}},
+	}
+	b, err := json.Marshal(linksDoc)
+	if err != nil {
+		t.Fatalf("marshal links: %v", err)
+	}
+	linksPath := filepath.Join(t.TempDir(), "fixtgrp-links.json")
+	if err := os.WriteFile(linksPath, b, 0o644); err != nil {
+		t.Fatalf("write links file: %v", err)
+	}
+
+	if _, err := runPhantomEdgePass("fixtgrp", cfg, linksPath); err != nil {
+		t.Fatalf("runPhantomEdgePass: %v", err)
+	}
+
+	want := []string{
+		links.PhasePhantomLoad,
+		links.PhasePhantomPromote,
+		links.PhasePhantomFlow,
+		links.PhasePhantomCleanup,
+	}
+	got := links.PhaseHistory()
+	if len(got) != len(want) {
+		t.Fatalf("phase history = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("phase history[%d] = %q, want %q (full: %v)", i, got[i], want[i], got)
+		}
+	}
+}
+
+// TestPhantomEdgePass_LoadPhaseCoversTheReload pins the attribution that
+// matters: the docs-map reload happens under phantom_load, so the second
+// materialisation of the union is billed to its own phase and not to whatever
+// the link pass left stamped. If the stamp moved below the loop, the reload's
+// heap would be attributed to the last link pass instead.
+func TestPhantomEdgePass_LoadPhaseCoversTheReload(t *testing.T) {
+	links.ResetPhaseHistory()
+	t.Cleanup(links.ResetPhaseHistory)
+	links.SetPhase("sentinel_from_a_previous_stage")
+
+	daemonRoot := t.TempDir()
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+	repo := filepath.Join(t.TempDir(), "solo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFB(t, repo, &graph.Document{
+		Repo:     "solo",
+		Entities: []graph.Entity{{ID: "s1", Name: "f", Kind: "SCOPE.Function", Language: "go", SourceFile: "a.go"}},
+	})
+	cfg := &registry.GroupConfig{Name: "g", Repos: []registry.Repo{{Slug: "solo", Path: repo}}}
+
+	linksPath := filepath.Join(t.TempDir(), "g-links.json")
+	if err := os.WriteFile(linksPath, []byte(`{"version":1,"links":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runPhantomEdgePass("g", cfg, linksPath); err != nil {
+		t.Fatalf("runPhantomEdgePass: %v", err)
+	}
+	got := links.PhaseHistory()
+	if len(got) < 2 || got[1] != links.PhasePhantomLoad {
+		t.Fatalf("phase history = %v, want %q immediately after the sentinel", got, links.PhasePhantomLoad)
+	}
+}

--- a/internal/cli/links_stage_test.go
+++ b/internal/cli/links_stage_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
@@ -262,5 +263,54 @@ func TestRunPhantomEdgePass_SegmentSetNotSkipped(t *testing.T) {
 	}
 	if added != 1 {
 		t.Fatalf("phantom edges added = %d, want 1 (segment-set source repo must not be skipped)", added)
+	}
+}
+
+// #5954 — the scheduler-driven pass runs in a child the daemon cancels with
+// SIGKILL, so stageGraphsDir's `defer cleanup()` cannot run on cancellation and
+// every cancelled pass leaks its staging dir. sweepStaleStagingDirs bounds that.
+// The two guards that matter are asymmetric on purpose: sweeping a stale dir is
+// housekeeping, but sweeping a LIVE pass's dir would fail that pass outright, so
+// the age cutoff and the prefix match are both tested from the entry point that
+// production actually calls (stageGraphsDir), not from the sweeper directly.
+func TestStageGraphsDir_SweepsOnlyStaleStagingDirs(t *testing.T) {
+	tmpRoot := t.TempDir()
+	t.Setenv("TMPDIR", tmpRoot)
+	if os.TempDir() != tmpRoot {
+		t.Skipf("os.TempDir() = %s, not honouring TMPDIR on this platform", os.TempDir())
+	}
+
+	mkdir := func(name string, age time.Duration) string {
+		p := filepath.Join(tmpRoot, name)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		when := time.Now().Add(-age)
+		if err := os.Chtimes(p, when, when); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	stale := mkdir(stagingDirPrefix+"abandoned", stagingDirMaxAge+time.Hour)
+	live := mkdir(stagingDirPrefix+"inflight", time.Minute)
+	unrelated := mkdir("some-other-tool-cache", stagingDirMaxAge+time.Hour)
+
+	staged, cleanup, err := stageGraphsDir(&registry.GroupConfig{Name: "g"})
+	if err != nil {
+		t.Fatalf("stageGraphsDir: %v", err)
+	}
+	defer cleanup()
+	if _, err := os.Stat(staged); err != nil {
+		t.Fatalf("staging dir not created: %v", err)
+	}
+
+	if _, err := os.Stat(stale); !os.IsNotExist(err) {
+		t.Errorf("stale staging dir survived the sweep (err=%v)", err)
+	}
+	if _, err := os.Stat(live); err != nil {
+		t.Errorf("a recent staging dir was swept — that would pull the graphs out from under a running pass: %v", err)
+	}
+	if _, err := os.Stat(unrelated); err != nil {
+		t.Errorf("the sweep removed a non-grafel temp dir: %v", err)
 	}
 }

--- a/internal/daemon/sched/subprocess_links_5954_test.go
+++ b/internal/daemon/sched/subprocess_links_5954_test.go
@@ -1,0 +1,194 @@
+package sched
+
+// subprocess_links_5954_test.go — the cross-repo link child's contract (#5954).
+//
+// The link pass is the third heavy batch stage the daemon runs and the last one
+// that still ran IN-PROCESS, inside the long-lived engine. It materialises the
+// whole group union twice (loadAllGraphs for the pass window, then the
+// phantom-edge reload) and the engine holds the resulting arena for the rest of
+// its life. Forking it gives the OS the pages back on child exit and — the part
+// this file pins — finally puts it under the same pacing the other two children
+// already have.
+//
+// group-algo shipped WITHOUT the GODEBUG merge and needed a follow-up to add
+// it, which is precisely why the env is asserted here from day one rather than
+// left to a measurement to notice.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestLinksChildEnvSetsMadvDontNeed asserts the constructed child env carries
+// the reclaim setting AND the CPU bound. GODEBUG is read once at process start,
+// so — unlike GOGC, which the child sets on itself in main() — madvdontneed can
+// only be delivered through the environment; asserting on the constructed env
+// is the only way to pin it without fork-execing.
+func TestLinksChildEnvSetsMadvDontNeed(t *testing.T) {
+	env := linksChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2)
+
+	godebug, ok := lookupEnv(env, "GODEBUG")
+	if !ok {
+		t.Fatalf("links child env has no GODEBUG entry: %v", env)
+	}
+	if !strings.Contains(godebug, madvDontNeedSetting) {
+		t.Errorf("GODEBUG = %q, want it to carry %q", godebug, madvDontNeedSetting)
+	}
+	if got, ok := lookupEnv(env, "GOMAXPROCS"); !ok || got != "2" {
+		t.Errorf("GOMAXPROCS = %q (present=%v), want \"2\" — the CPU bound must survive the GODEBUG merge", got, ok)
+	}
+	if got, ok := lookupEnv(env, "PATH"); !ok || got != "/usr/bin" {
+		t.Errorf("PATH = %q (present=%v), want the inherited value preserved", got, ok)
+	}
+}
+
+// TestLinksChildEnvMergesInheritedGODEBUG mirrors the group-algo contract: an
+// operator's other GODEBUG settings are merged, not clobbered, and an explicit
+// madvdontneed=0 is left alone.
+func TestLinksChildEnvMergesInheritedGODEBUG(t *testing.T) {
+	env := linksChildEnv([]string{"GODEBUG=http2debug=1"}, 3)
+	godebug, _ := lookupEnv(env, "GODEBUG")
+	if !strings.Contains(godebug, "http2debug=1") || !strings.Contains(godebug, madvDontNeedSetting) {
+		t.Errorf("GODEBUG = %q, want both the inherited setting and %q", godebug, madvDontNeedSetting)
+	}
+
+	env = linksChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1)
+	godebug, _ = lookupEnv(env, "GODEBUG")
+	if godebug != "madvdontneed=0" {
+		t.Errorf("GODEBUG = %q, want an explicit operator madvdontneed=0 left alone", godebug)
+	}
+}
+
+func TestLinksGOMAXPROCSDefaultAndOverride(t *testing.T) {
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+	if got := LinksGOMAXPROCS(); got != linksGOMAXPROCSDefault {
+		t.Fatalf("default LinksGOMAXPROCS = %d, want %d", got, linksGOMAXPROCSDefault)
+	}
+	for _, c := range []struct {
+		env  string
+		want int
+	}{
+		{"3", 3},
+		{"1", 1},
+		{"0", linksGOMAXPROCSDefault},
+		{"garbage", linksGOMAXPROCSDefault},
+		{"-4", linksGOMAXPROCSDefault},
+	} {
+		t.Setenv("GRAFEL_LINKS_CPU", c.env)
+		if got := LinksGOMAXPROCS(); got != c.want {
+			t.Errorf("LinksGOMAXPROCS(%q) = %d, want %d", c.env, got, c.want)
+		}
+	}
+}
+
+// fakeChildScript writes an executable shell script and points the links runner
+// at it, so the fork/cancel/argv contract can be exercised without running the
+// real (multi-minute) pass or the test binary's own main.
+func fakeChildScript(t *testing.T, body string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script child stand-in is POSIX-only")
+	}
+	path := filepath.Join(t.TempDir(), "fake-links-child.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake child: %v", err)
+	}
+	prev := linksChildBinary
+	linksChildBinary = func() (string, error) { return path, nil }
+	t.Cleanup(func() { linksChildBinary = prev })
+}
+
+// TestRunSubprocessLinks_PassesGroupToChild pins the argv the child is forked
+// with. The group name is the ONLY state handed over — everything else the pass
+// needs (the group config, each repo's path for links.SetRepoSourcePaths, the
+// state dirs it writes into) is re-derived in the child from the registry via
+// the inherited GRAFEL_HOME / GRAFEL_DAEMON_ROOT, which is why the inherited
+// environment is asserted alongside the arguments.
+func TestRunSubprocessLinks_PassesGroupToChild(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "argv.txt")
+	fakeChildScript(t, `printf '%s\n' "$@" > `+out+`
+printf 'root=%s\n' "$GRAFEL_DAEMON_ROOT" >> `+out)
+	t.Setenv("GRAFEL_DAEMON_ROOT", "/tmp/some-daemon-root")
+
+	if err := RunSubprocessLinks(context.Background(), "mygroup", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read argv capture: %v", err)
+	}
+	got := string(b)
+	if !strings.Contains(got, "links-internal") {
+		t.Errorf("child argv = %q, want the hidden links-internal subcommand", got)
+	}
+	if !strings.Contains(got, "mygroup") {
+		t.Errorf("child argv = %q, want the group name", got)
+	}
+	if !strings.Contains(got, "root=/tmp/some-daemon-root") {
+		t.Errorf("child env = %q, want the daemon root inherited so the child resolves the same registry", got)
+	}
+}
+
+// TestRunSubprocessLinks_BlocksUntilChildExits is the stage-gate constraint in
+// test form. daemonSchedulerLinks runs while the scheduler holds the EXCLUSIVE
+// heavy-stage token, released by a defer around the callback — so if the runner
+// returned before the child finished, the token would be released with the
+// heavy work still running and the gate would stop binding.
+func TestRunSubprocessLinks_BlocksUntilChildExits(t *testing.T) {
+	fakeChildScript(t, "sleep 1")
+	start := time.Now()
+	if err := RunSubprocessLinks(context.Background(), "g", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	if el := time.Since(start); el < 900*time.Millisecond {
+		t.Fatalf("returned after %v — must not return before the child exits", el)
+	}
+}
+
+// TestRunSubprocessLinks_CancelTerminatesChild is the cancellation contract.
+// In-process the pass honoured ctx at each heavy boundary; across a fork the
+// same cancellation must kill the child — exec.CommandContext's default Cancel
+// is cmd.Process.Kill(), i.e. SIGKILL, which is why the stand-in below is a
+// bare `sleep` with no trap: nothing in this path may depend on the child
+// getting a chance to clean up. The call must return the context error so the
+// scheduler can tell cancellation from failure.
+func TestRunSubprocessLinks_CancelTerminatesChild(t *testing.T) {
+	fakeChildScript(t, "sleep 60")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunSubprocessLinks(ctx, "g", nil) }()
+
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled run returned nil error, want a cancellation error")
+		}
+		if !strings.Contains(err.Error(), "cancel") && !strings.Contains(err.Error(), context.Canceled.Error()) {
+			t.Fatalf("err = %v, want it to report cancellation", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("child was not terminated by context cancellation")
+	}
+}
+
+// TestRunSubprocessLinks_ChildFailureIsReported keeps a real failure
+// distinguishable from a cancellation — the scheduler logs links_err off this.
+func TestRunSubprocessLinks_ChildFailureIsReported(t *testing.T) {
+	fakeChildScript(t, "exit 3")
+	err := RunSubprocessLinks(context.Background(), "g", nil)
+	if err == nil {
+		t.Fatal("child exit 3 reported success")
+	}
+	if strings.Contains(err.Error(), "cancelled") {
+		t.Fatalf("err = %v, want a child-exit error, not a cancellation", err)
+	}
+}

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -479,7 +479,12 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 // MCP apply path picks up the fresh overlay by mtime on the next group load.
 //
 // Cancellation: ctx.Done() (daemon shutdown, or a newer link pass superseding
-// this one) sends SIGTERM to the child via exec.CommandContext.
+// this one) SIGKILLs the child. exec.CommandContext's default Cancel is
+// cmd.Process.Kill(), not a SIGTERM — an earlier version of this comment said
+// SIGTERM and was simply wrong. The child gets no chance to run deferred
+// cleanup, so nothing on the group-algo path may depend on a graceful shutdown;
+// the overlay write is a temp+rename swap, so a kill mid-write leaves an orphan
+// temp file and never a torn overlay.
 //
 // The child inherits the daemon's full environment (GRAFEL_HOME /
 // GRAFEL_DAEMON_ROOT) so it resolves the same group config + state dirs and
@@ -571,6 +576,173 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	}
 	if logger != nil {
 		logger.Info("subprocess-group-algo: completed", "pid", pid, "group", group)
+	}
+	return nil
+}
+
+// linksGOMAXPROCSDefault is the per-child CPU cap for the background cross-repo
+// link child. Same reasoning and same default as the group-algo child: it is a
+// single background batch process nobody is waiting on, so "the less the
+// better", and 2 leaves the host responsive while still letting the per-pass
+// worker pools do useful concurrent work. GRAFEL_LINKS_CPU=1 throttles it
+// further.
+//
+// Until #5954 this pass ran IN-PROCESS in the engine, i.e. at the engine's
+// GOMAXPROCS (= host core count) with no cap at all — so this constant is not
+// just isolation bookkeeping, it is the first CPU bound the link pass has ever
+// had.
+const linksGOMAXPROCSDefault = 2
+
+// LinksGOMAXPROCS resolves the GOMAXPROCS cap applied to the links child,
+// honouring GRAFEL_LINKS_CPU (a strictly-positive integer; 1 is valid). Unset,
+// empty, non-numeric, or <= 0 → linksGOMAXPROCSDefault. Mirrors
+// GroupAlgoGOMAXPROCS exactly.
+func LinksGOMAXPROCS() int {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_LINKS_CPU")); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
+			return n
+		}
+	}
+	return linksGOMAXPROCSDefault
+}
+
+// linksChildEnv builds the environment for the links child: the GOMAXPROCS
+// bound plus the madvdontneed reclaim setting, merged into any inherited
+// GODEBUG. Extracted as a pure function so the constructed env is assertable
+// without fork-execing anything.
+//
+// The GODEBUG entry is the reason this is a function and not an inline append.
+// GODEBUG is read ONCE at process start, so — unlike GOGC, which the child sets
+// on itself in main() — madvdontneed can only be delivered through the child's
+// environment. Without it the runtime hands freed pages back with MADV_FREE and
+// the RSS the child gives up stays invisible to the OS until the kernel comes
+// under pressure, which is exactly what whole-machine peak measurement reads
+// (#5954). group-algo shipped without it and needed a follow-up; this child has
+// it from its first commit.
+func linksChildEnv(base []string, gomaxprocs int) []string {
+	env := make([]string, 0, len(base)+2)
+	env = append(env, base...)
+	env = append(env, "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	return withMadvDontNeed(env)
+}
+
+// linksChildBinary resolves the executable to fork for the links child. It is a
+// var solely so a test can substitute a stand-in and exercise the fork /
+// cancel / argv contract without running the real multi-minute pass.
+var linksChildBinary = os.Executable
+
+// RunSubprocessLinks forks `grafel links-internal <group>` for one cross-repo
+// link pass and waits for it to exit (#5954). It is the exact analogue of
+// RunSubprocessGroupAlgo, for the same reason: the pass materialises the whole
+// group union TWICE in sequence — once in links.RunAllPasses (every repo's
+// Document, held live across ~19 passes) and again in the phantom-edge pass's
+// docs map — and while it ran in-process the engine kept that arena for the
+// rest of its life. Measured on the real corpus the pass window alone peaks at
+// ~830MB LIVE heap (~1.2GB heap_inuse), and the engine held ~1.9GB for minutes
+// after the index child had already exited. In a child the OS takes it all back
+// on exit.
+//
+// SCOPE: the SCHEDULER-DRIVEN background pass only. The foreground rebuild's
+// link step stays in-process — it is user-initiated and latency-sensitive, and
+// is already covered by the stage gate's barge.
+//
+// STATE HANDED OVER: the group name, and nothing else. Everything the pass
+// needs is re-derived in the child from the registry — the group config, each
+// repo's on-disk path (which is what links.SetRepoSourcePaths is populated
+// from, inside RunLinksForGroupCtx, at the start of every pass), and each
+// repo's state dir. That works because the child inherits the daemon's full
+// environment (GRAFEL_HOME / GRAFEL_DAEMON_ROOT) and therefore resolves the
+// same registry and the same state dirs. The pass's process-global
+// SetRepoSourcePaths is written before use on every entry, so the child's fresh
+// globals are not a hazard — they are one less thing to invalidate.
+//
+// CONCURRENCY around the known #5978 hazard (candidates.go / string_pass.go
+// build temp files as path+".tmp", deterministic per destination, so two
+// concurrent writers collide): this change does NOT make it worse. The pass is
+// serialised by the daemon's EXCLUSIVE heavy-stage token, which is held across
+// this call for the child's whole lifetime, so at most one background link pass
+// exists at a time — the same guarantee the in-process path had.
+//
+// CANCELLATION IS SIGKILL, NOT SIGTERM. ctx.Done() (daemon shutdown, or
+// CancelGroup on a group delete) makes exec.CommandContext run its default
+// Cancel, which is cmd.Process.Kill() — see os/exec. That is more prompt than
+// the in-process ctx checks it replaces (those only took effect at a pass
+// boundary, which on this pass can be minutes away), and it is why the child
+// installs no signal handler: under SIGKILL no handler could run.
+//
+// What that costs, precisely: the child cannot run deferred cleanup, so the
+// pass's staging dir (os.MkdirTemp "grafel-links-*", a symlink/hardlink farm)
+// is LEAKED on every cancellation. This is a real regression against the
+// in-process path, where cancellation was cooperative and the deferred cleanup
+// ran; it is not merely the pre-existing daemon-kill case. stageGraphsDir
+// sweeps old strays at pass start to bound the accumulation.
+//
+// What it does NOT cost: output integrity. Every sink the pass writes —
+// flows.WriteTo and graph.WriteLinkStats (writeJSONAtomic) — is
+// write-temp-then-rename, and the flows temp name is pid-suffixed, so a killed
+// child leaves at most an orphan .tmp and never a truncated or torn side-table.
+func RunSubprocessLinks(ctx context.Context, group string, logger *slog.Logger) error {
+	binary, err := linksChildBinary()
+	if err != nil {
+		return fmt.Errorf("subprocess-links: resolve binary: %w", err)
+	}
+
+	cmd := exec.CommandContext(ctx, binary, "links-internal", group)
+	gomaxprocs := LinksGOMAXPROCS()
+	cmd.Env = linksChildEnv(os.Environ(), gomaxprocs)
+	// Put the child in its own process group so it is independently
+	// schedulable; the nice increment itself is applied by the child at startup
+	// (sched.NiceSelf). applyGroupAlgoNice is the shared spawn-side hook for
+	// both background batch children — it is named for the first one that
+	// needed it, not scoped to it.
+	applyGroupAlgoNice(cmd)
+	// On Windows, prevent a console window from flashing when the daemon
+	// (running as a Task Scheduler task) spawns this subprocess.
+	executil.NoWindow(cmd)
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("subprocess-links: stderr pipe: %w", err)
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("subprocess-links: stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("subprocess-links: start: %w", err)
+	}
+	pid := cmd.Process.Pid
+	if logger != nil {
+		logger.Info("subprocess-links: started", "pid", pid, "group", group, "gomaxprocs", gomaxprocs)
+	}
+
+	drain := func(r interface{ Read([]byte) (int, error) }, tag string, done chan struct{}) {
+		defer close(done)
+		sc := bufio.NewScanner(r)
+		for sc.Scan() {
+			if logger != nil {
+				logger.Info(tag, "pid", pid, "line", sc.Text())
+			}
+		}
+	}
+	stdoutDone := make(chan struct{})
+	stderrDone := make(chan struct{})
+	go drain(stdoutPipe, "[links]", stdoutDone)
+	go drain(stderrPipe, "[links]", stderrDone)
+
+	<-stdoutDone
+	<-stderrDone
+	waitErr := cmd.Wait()
+
+	if waitErr != nil {
+		if ctx.Err() != nil {
+			return fmt.Errorf("subprocess-links: cancelled: %w", ctx.Err())
+		}
+		return fmt.Errorf("subprocess-links: child exit: %w", waitErr)
+	}
+	if logger != nil {
+		logger.Info("subprocess-links: completed", "pid", pid, "group", group)
 	}
 	return nil
 }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -288,6 +288,10 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Stamp BEFORE the load: loadAllGraphs is the first full materialisation
+	// of the group union and must be billed to its own phase, not to the
+	// pass that happens to run first (#5954).
+	SetPhase(PhaseLoad)
 	graphs, err := loadAllGraphs(graphsDir)
 	if err != nil {
 		return nil, err
@@ -305,6 +309,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 		OutReject: paths.Rejections,
 	}
 
+	SetPhase(PhaseForPass("import"))
 	p1, err := runImportPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("import pass: %w", err)
@@ -317,6 +322,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// canonicalise consumer-side dynamic_baseurl HTTP endpoint paths
 	// before the HTTP pass below sees them, lifting those orphans into
 	// the resolvable bucket.
+	SetPhase(PhaseForPass("constant_propagation"))
 	pCP, resolver, err := runConstantPropagationPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("constant propagation pass: %w", err)
@@ -339,6 +345,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// reading entity.Properties see the effect annotation. Mutates
 	// entity.Properties in-memory; emits a <group>-links-effects.json
 	// sidecar for the MCP grafel_effects tool.
+	SetPhase(PhaseForPass("effect_propagation"))
 	pEP, err := runEffectPropagationPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("effect propagation pass: %w", err)
@@ -352,18 +359,21 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// annotation. Mutates entity.Properties in-memory and emits the
 	// <group>-links-taint.json sidecar consumed by the MCP
 	// grafel_security_findings tool.
+	SetPhase(PhaseForPass("taint_flow"))
 	pTF, err := runTaintFlowPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("taint flow pass: %w", err)
 	}
 	res.Results = append(res.Results, pTF)
 
+	SetPhase(PhaseForPass("label"))
 	p2, err := runLabelPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("label pass: %w", err)
 	}
 	res.Results = append(res.Results, p2)
 
+	SetPhase(PhaseForPass("string"))
 	p3, err := runStringPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("string pass: %w", err)
@@ -374,6 +384,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// after the structural / label / string passes so that its
 	// method-segregated entries are rewritten cleanly without
 	// disturbing earlier output.
+	SetPhase(PhaseForPass("http"))
 	p4, err := runHTTPPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("http pass: %w", err)
@@ -383,6 +394,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// P5 — OpenAPI spec → HTTP route cross-linker. Uses openapi_operation
 	// entities emitted by the patterns extractor as the pivot to create
 	// consumer-caller → producer-handler links with method=openapi-spec.
+	SetPhase(PhaseForPass("openapi-spec"))
 	p5, err := runOpenAPISpecPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("openapi-spec pass: %w", err)
@@ -392,6 +404,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// P6 — cross-repo gRPC client-stub → server-impl linker. Uses
 	// SCOPE.GrpcMethod entities with canonical name grpc:Service/Method
 	// emitted by the gRPC engine pass (#725) as the join key.
+	SetPhase(PhaseForPass("grpc"))
 	p6, err := runGRPCPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("grpc pass: %w", err)
@@ -401,6 +414,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// P7 — cross-repo message-topic publisher↔subscriber linker. Uses
 	// SCOPE.MessageTopic entities emitted by the Kafka/SNS/SQS/EventBridge
 	// passes as the join key, matched by canonical topic Name.
+	SetPhase(PhaseForPass("topic"))
 	p7, err := runTopicPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("topic pass: %w", err)
@@ -412,6 +426,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// kinds) that live in shared-lib repos and share enough field names to
 	// be the same concept across languages (e.g. py-shared Order ↔
 	// js-shared Order). See sameas_pass.go.
+	SetPhase(PhaseForPass("same_as"))
 	p8, err := runSameAsPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("same-as pass: %w", err)
@@ -422,6 +437,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// last so it observes the in-memory entity/edge state after every
 	// upstream pass has had a chance to mutate it (e.g. the constant
 	// propagation pass rewriting consumer-side HTTP endpoint paths).
+	SetPhase(PhaseForPass("reachability"))
 	pReach, err := runReachabilityPass(group, graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("reachability pass: %w", err)
@@ -434,6 +450,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// payload-shape facts emitted by the substrate sniffers. Findings
 	// land in a sidecar JSON document read by the
 	// grafel_payload_drift MCP tool.
+	SetPhase(PhaseForPass("payload_drift"))
 	pDrift, err := runPayloadDriftPass(group, graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("payload drift pass: %w", err)
@@ -445,6 +462,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// marked pure=true with a low confidence floor. Runs after the
 	// effect propagation pass so it observes the in-memory effect
 	// annotations stamped on entity Properties.
+	SetPhase(PhaseForPass("pure_functions"))
 	pPure, err := runPureFunctionPass(graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("pure-function pass: %w", err)
@@ -455,6 +473,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// over IMPORTS edges. Language-agnostic; stamps `module_cycle_id`
 	// on every cycle participant and emits a sidecar with full SCC
 	// membership for the grafel_import_cycles MCP tool.
+	SetPhase(PhaseForPass("module_cycles"))
 	pCycle, err := runModuleCyclePass(graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("module-cycle pass: %w", err)
@@ -466,6 +485,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// definitions (last-write-wins), stamps a compact summary on the
 	// owning function entity, and persists the full chain set in a
 	// sidecar for the grafel_def_use MCP tool.
+	SetPhase(PhaseForPass("def_use"))
 	pDU, err := runDefUsePass(graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("def-use pass: %w", err)
@@ -476,6 +496,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// format / SQL templates). Per-language sniffer lifts every recog-
 	// nised template literal; the pass persists them in a sidecar for
 	// the grafel_template_patterns MCP tool.
+	SetPhase(PhaseForPass("template_patterns"))
 	pTP, err := runTemplatePatternPass(graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("template-pattern pass: %w", err)
@@ -490,6 +511,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// idempotent and finds the value already present (both call the same
 	// ComputeFunctionComplexity, so they can never diverge). Generalises part
 	// (a) (#4821), which only stamped data-flow-bound handlers.
+	SetPhase(PhaseForPass(MethodComplexity))
 	pCx, err := runComplexityPass(graphs, paths)
 	if err != nil {
 		return nil, fmt.Errorf("complexity pass: %w", err)
@@ -500,6 +522,7 @@ func RunAllPasses(group, graphsDir, grafelHome string) (*RunResult, error) {
 	// DATA_FLOWS_TO links (intra-function + one local-call hop) from the
 	// per-language substrate dataflow sniffers. Honest-partial: see
 	// internal/links/dataflow_pass.go.
+	SetPhase(PhaseForPass("data_flow"))
 	pDF, err := runDataFlowPass(graphs, paths, rejects)
 	if err != nil {
 		return nil, fmt.Errorf("data-flow pass: %w", err)

--- a/internal/links/phase.go
+++ b/internal/links/phase.go
@@ -1,0 +1,173 @@
+package links
+
+// phase.go — the stage state the cross-repo link pass's memory trace is tagged
+// with (#5954).
+//
+// WHY THIS EXISTS. After the index child was cut to ~2984MB and group-algo was
+// paced and instrumented (#5992), the remaining unprofiled plane was the
+// ENGINE: memtrace.Start is called for it with a nil phaseFn, so every sample
+// it writes is tagged "" and heap-peak.pprof is the only usable artifact. The
+// engine peaks AFTER the index child exits and holds ~1.9GB for minutes,
+// because the cross-repo link pass runs in-process there and materialises the
+// group union TWICE, sequentially:
+//
+//   - RunAllPasses → loadAllGraphs: every repo's full Document, held live
+//     across all ~19 passes, several of which mutate entity Properties in
+//     place;
+//   - then the phantom-edge pass (internal/cli/links.go) reloads every repo's
+//     Document again and re-runs process flow with every OTHER repo's Document
+//     held live as a companion.
+//
+// Those two windows want completely different fixes, and an untagged trace
+// cannot tell them apart. This epic has twice picked the wrong target by
+// reasoning from allocation-site size instead of measured live heap, so the
+// stamps land BEFORE any refactor.
+//
+// SHAPE. Mirrors internal/graph/groupalgo/phase.go deliberately: one
+// process-wide holder, stamped by the pass at each stage boundary and polled by
+// the memtrace sampler goroutine on its ticker — ONE source of phase state, so
+// the trace cannot drift from what the process is actually doing.
+//
+// The holder is process-wide (not per-run) because the link pass is serialised
+// by the daemon's heavy-stage gate: fireLinks acquires an EXCLUSIVE token for
+// "links:<group>" before calling the pass, so two passes never run
+// concurrently in one process. In the child added alongside this
+// (`grafel links-internal <group>`) there is exactly one pass and then exit.
+// The ONE caller that can interleave is a test running passes back-to-back,
+// which is what ResetPhaseHistory is for.
+//
+// READING A LINK TRACE — three memtrace properties inherited from the sampler
+// that will otherwise mislead you:
+//
+//   - Samples are written only on ticker ticks and Stop writes no final
+//     sample, so a phase shorter than one tick leaves NO sample. Absence of a
+//     phase in the NDJSON is not evidence it did not run — PhaseHistory is.
+//   - `heap_inuse` is live heap PLUS uncollected garbage. Live heap is
+//     next_gc / (1 + GOGC/100). Read the per-phase live heap off next_gc, not
+//     off heap_inuse; the latter is how this epic mis-targeted twice already.
+//   - The pass stamps `idle` when it finishes, so a long tail of `idle`
+//     samples in an ENGINE trace is the post-pass plateau — memory the process
+//     is holding but no longer working on. That plateau is the whole reason
+//     the background pass was moved into a child.
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// The stage labels, in the order a full pass stamps them. They are the
+// operator-facing contract with the measurement harness — they appear verbatim
+// in the memtrace NDJSON `phase` field and in per-phase heap-profile filenames
+// — so they are stable identifiers, not display strings to be reworded.
+//
+//	link_stage        — staging the graphs dir (symlink farm; near-zero heap).
+//	link_pass_load    — loadAllGraphs: the FIRST materialisation of the union.
+//	link_pass_<name>  — one per pass, labelled with the pass's own name as it
+//	                    appears in PassResult.Pass (import, http, string, …).
+//	phantom_load      — the SECOND materialisation: the docs-map reload.
+//	phantom_promote   — phantom CALLS edge promotion over that map.
+//	phantom_flow      — per-repo process/event-flow recompute with every other
+//	                    repo's Document held live as a companion, plus the flow
+//	                    side-table writes. The widest live set in the pass.
+//	phantom_cleanup   — removing stale flow side-tables for unaffected repos.
+//	link_stats        — the per-repo link-stats.json sidecar writes.
+//	idle              — the pass has finished; anything still resident here is
+//	                    plateau, not working set.
+const (
+	PhaseStage          = "link_stage"
+	PhaseLoad           = "link_pass_load"
+	PhasePhantomLoad    = "phantom_load"
+	PhasePhantomPromote = "phantom_promote"
+	PhasePhantomFlow    = "phantom_flow"
+	PhasePhantomCleanup = "phantom_cleanup"
+	PhaseLinkStats      = "link_stats"
+	PhaseIdle           = "idle"
+)
+
+// passPhasePrefix namespaces the per-pass labels so a trace can be filtered to
+// "the eight-pass window" with a single prefix match, and so a pass name can
+// never collide with a stage label.
+const passPhasePrefix = "link_pass_"
+
+// PhaseForPass returns the phase label for a link pass. The argument is the
+// pass's OWN name — the same string it puts in PassResult.Pass — so the label
+// and the reported pass cannot drift apart, and a new pass added without a
+// stamp is visible as a missing entry in the history rather than as a
+// mislabelled sample.
+func PhaseForPass(name string) string { return passPhasePrefix + name }
+
+// phaseHolder is a race-free string cell plus the transition log. The pass
+// goroutine stores; the memtrace sampler goroutine loads on every tick.
+//
+// The current value is an atomic.Value rather than a mutex-guarded field
+// because the READ side is the hot one — polled on a ticker for the life of the
+// process — and must not contend with the writer. The transition log takes a
+// mutex, which costs nothing: it is only touched on a genuine phase CHANGE, of
+// which a whole pass has a couple of dozen.
+type phaseHolder struct {
+	v atomic.Value
+
+	mu      sync.Mutex
+	history []string
+}
+
+// set records a stamp, appending to the transition log only when the phase
+// actually changes, so the log is a true transition sequence rather than a call
+// counter.
+func (h *phaseHolder) set(p string) {
+	h.v.Store(p)
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if n := len(h.history); n == 0 || h.history[n-1] != p {
+		h.history = append(h.history, p)
+	}
+}
+
+// get returns "" before the first store: atomic.Value's zero Load yields a nil
+// any, and the failed type assertion leaves the zero string. memtrace may well
+// poll before the pass has stamped anything, and an empty phase is exactly the
+// right answer there.
+func (h *phaseHolder) get() string { s, _ := h.v.Load().(string); return s }
+
+func (h *phaseHolder) snapshot() []string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return append([]string(nil), h.history...)
+}
+
+// reset stores the empty phase rather than re-zeroing the atomic.Value, so it
+// stays safe against a concurrent sampler poll (and copies no sync type).
+func (h *phaseHolder) reset() {
+	h.v.Store("")
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.history = nil
+}
+
+var currentPhase phaseHolder
+
+// SetPhase records the stage the link pass has entered. Called from the pass
+// itself (and from the phantom-edge pass in internal/cli, which is the same
+// logical pass split across a package boundary to keep the dependency arrow
+// pointing inward); safe to call from any goroutine.
+func SetPhase(p string) { currentPhase.set(p) }
+
+// CurrentPhase reports the stage last stamped, or "" if none has been. Pass it
+// to memtrace.Start as the phaseFn — it is polled once per sampling tick.
+func CurrentPhase() string { return currentPhase.get() }
+
+// PhaseHistory returns the sequence of distinct phases stamped so far.
+//
+// It exists because CurrentPhase alone cannot answer the question that actually
+// matters when reading a trace: which stages ran, in what order. The memtrace
+// NDJSON only tells you which phases were SAMPLED, and a phase shorter than the
+// sampling interval leaves no sample at all. The history is the ground truth a
+// sampled record is read against — and it is what lets a test observe the
+// stamps the pass really makes, rather than round-tripping constants through
+// the holder.
+func PhaseHistory() []string { return currentPhase.snapshot() }
+
+// ResetPhaseHistory clears both the current phase and the transition log. The
+// child runs one pass and exits, so production never needs it; it exists so a
+// test can observe one pass's stamps in isolation from another's.
+func ResetPhaseHistory() { currentPhase.reset() }

--- a/internal/links/phase_5954_test.go
+++ b/internal/links/phase_5954_test.go
@@ -1,0 +1,104 @@
+package links
+
+// phase_5954_test.go — the cross-repo link pass's phase stamps (#5954).
+//
+// The engine process was the last unprofiled memory plane in the epic: it
+// calls memtrace.Start with a nil phaseFn, so every sample it emits is tagged
+// "" and the only usable artifact is heap-peak.pprof. That is enough to know
+// the engine is big and not enough to know WHICH stage is big — and the two
+// candidate stages (the multi-pass window over the whole group union, versus
+// the phantom-edge reload of the same union) call for completely different
+// fixes.
+//
+// This test observes a REAL RunAllPasses run rather than asserting the
+// constants against literals. An earlier test in this epic did the latter and
+// three of four stamps turned out to be unprotected: round-tripping a constant
+// through the holder proves the holder works, not that the pass stamps. The
+// assertion here is derived from res.Results — the pass's own report of which
+// passes it ran, in the order it ran them — so a new pass added without a
+// stamp, or a stamp that drifts from the pass it labels, fails.
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestRunAllPasses_StampsOnePhasePerPassInOrder(t *testing.T) {
+	ResetPhaseHistory()
+	t.Cleanup(ResetPhaseHistory)
+
+	root := fixtureRoot(t)
+	twoRepoGraphs(t, root)
+
+	res, err := RunAllPasses("g1", root, filepath.Join(root, "ag-home"))
+	if err != nil {
+		t.Fatalf("RunAllPasses: %v", err)
+	}
+	if len(res.Results) < 10 {
+		t.Fatalf("fixture ran only %d passes — too few for this contract to mean anything", len(res.Results))
+	}
+
+	// The expected history is derived from the run itself: the load stage,
+	// then one phase per pass, labelled with the pass's own name.
+	want := make([]string, 0, len(res.Results)+1)
+	want = append(want, PhaseLoad)
+	for _, r := range res.Results {
+		want = append(want, PhaseForPass(r.Pass))
+	}
+
+	got := PhaseHistory()
+	if len(got) != len(want) {
+		t.Fatalf("phase history has %d entries, want %d\n got: %v\nwant: %v",
+			len(got), len(want), got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("phase history[%d] = %q, want %q\n got: %v\nwant: %v",
+				i, got[i], want[i], got, want)
+		}
+	}
+
+	if cur := CurrentPhase(); cur != want[len(want)-1] {
+		t.Errorf("CurrentPhase() = %q after the run, want the last stamped phase %q", cur, want[len(want)-1])
+	}
+}
+
+// TestPhaseLoadIsStampedBeforeTheGraphsAreRead pins the ordering property the
+// measurement actually depends on: loadAllGraphs — which materialises every
+// repo's Document and holds them for the whole pass — is attributed to
+// link_pass_load and not to whichever pass happens to run first. A stamp placed
+// after the load would silently bill the union's peak to the import pass.
+func TestPhaseLoadIsStampedBeforeTheGraphsAreRead(t *testing.T) {
+	ResetPhaseHistory()
+	t.Cleanup(ResetPhaseHistory)
+
+	root := fixtureRoot(t)
+	twoRepoGraphs(t, root)
+	if _, err := RunAllPasses("g1", root, filepath.Join(root, "ag-home")); err != nil {
+		t.Fatalf("RunAllPasses: %v", err)
+	}
+	hist := PhaseHistory()
+	if len(hist) == 0 || hist[0] != PhaseLoad {
+		t.Fatalf("first stamped phase = %v, want %q first", hist, PhaseLoad)
+	}
+}
+
+// TestPhaseHistoryIsResettable keeps ResetPhaseHistory honest: a second run in
+// the same process must not inherit the first run's transitions, or a hand-run
+// diagnostic reading PhaseHistory would report a concatenation of two passes.
+func TestPhaseHistoryIsResettable(t *testing.T) {
+	ResetPhaseHistory()
+	t.Cleanup(ResetPhaseHistory)
+
+	SetPhase(PhaseLoad)
+	if len(PhaseHistory()) != 1 {
+		t.Fatalf("history = %v, want one entry", PhaseHistory())
+	}
+	ResetPhaseHistory()
+	if h := PhaseHistory(); len(h) != 0 {
+		t.Fatalf("history after reset = %v, want empty", h)
+	}
+	if c := CurrentPhase(); c != "" {
+		t.Fatalf("CurrentPhase after reset = %q, want empty", c)
+	}
+}


### PR DESCRIPTION
## Why

The whole-machine peak during a reindex is now **post-index**: the index child has exited and `engine` holds ~1.9 GB while the cross-repo link pass runs **in-process**.

The engine was the last unprofiled plane. `memtrace.Start` was already called for it, but with `phaseFn = nil`, so every sample was tagged `""` and only `heap-peak.pprof` was usable — you could see the peak but not which pass owned it.

## Instrumented first, then refactored

Measured on the live corpus group, isolated harness, GOGC=50, live = `next_gc / 1.5`:

| phase | live MB | heap_inuse MB |
|---|---|---|
| link_stage | 33 | 44 |
| **link_pass_load** | **747** | 1134 |
| **link_pass_import** | **827** | 1154 |
| **link_pass_constant_propagation** | **827** | 1190 |
| link_pass_effect_propagation | 500 | 739 |
| link_pass_def_use | 624 | 861 |
| link_pass_complexity | 542 | 931 |
| phantom_load | 609 | 927 |

**The peak is the eight-pass window's head** — `loadAllGraphs` landing the union, plus the two passes immediately after — **not** the phantom reload, which was the other plausible candidate and would have called for a different fix.

Note the 44% gap between live (827) and `heap_inuse` (1190) at the peak. Reading the larger number as live heap is the misread that hid half of this epic's problem for a day; it is called out at the source.

**Caveat, stated rather than buried:** `phantom_load` is *understated* on this group — a single repo means no cross-repo links, no companion Documents, and `phantom_flow` does no work. On a genuinely multi-repo group that phase is the one that grows. The stamps are now in place to see it. These numbers must **not** be used to size a future in-process optimisation of `phantom_flow`; re-run against a multi-repo group first. The conclusion here survives the caveat either way, because the peak phases all live in `RunAllPasses`, which loads the union regardless of cross-repo-ness — and a multi-repo corpus can only make the child *more* worthwhile.

## The subprocess

`grafel links-internal <group>`, mirroring the `group-algo` precedent, with **GOGC=50, `withMadvDontNeed`, and a GOMAXPROCS cap from the first commit** — group-algo shipped without `madvdontneed` and needed a follow-up.

The engine's ~830 MB live / ~1.2 GB `heap_inuse` transient becomes a child process reclaimed on exit rather than a multi-minute plateau, and the pass finally gets pacing. Worth noting it previously ran at the engine's **full GOMAXPROCS with no cap at all** — unlike group-algo, which at least had `algoSem`.

Scope is the **scheduler-driven background pass only**. The foreground rebuild's link pass (`daemonForegroundLinks`) is untouched: it is user-initiated, latency-sensitive, and already covered by the barge in #5994.

**The gate token spans the child.** `fireLinks` acquires the EXCLUSIVE token and releases it by `defer`; the runner blocks on `<-stdoutDone; <-stderrDone; cmd.Wait()`, and every return after `Start` sits below that `Wait`. Had it returned early, the work would run outside the token and #5993 would silently stop binding for link passes — the same failure that made the gate decorative for rebuilds. Mutation-tested: making the runner not wait is caught by four tests, one of which observes it returning in **979 µs**.

`links-internal`, not `links` — the public interactive command stays uncapped, and the allow-list is an exact map lookup.

## Cancellation is SIGKILL, and the code now says so

`exec.CommandContext`'s default cancel is `cmd.Process.Kill()`. An earlier revision of this change asserted SIGTERM in five places and built a rationale on it ("the child installs no signal handler, because a handler would delay death to the next pass boundary") — an argument about a signal that is never sent. Corrected at all five sites, including the pre-existing `RunSubprocessGroupAlgo` comment that had the same error, with the wording stating plainly that the earlier claim was wrong so it is not re-derived.

The behaviour was always right: SIGKILL is *more* prompt than the boundary checks it replaces, and on a pass whose next checkpoint can be minutes away that matters.

**SIGKILL cannot corrupt output**, and the runner doc now records why, because it is the first question a reader will have: `flows.WriteTo` and `graph.WriteLinkStats` → `writeJSONAtomic` are both temp-then-rename, and the flows temp name is pid-suffixed. A killed child leaves at most an orphan `.tmp.<pid>`, never a torn side-table.

**One genuine regression, fixed rather than excused.** `stageGraphsDir` cleaned itself via `defer` when the pass ran in-process, so a cooperative `CancelGroup` removed it. Under SIGKILL that defer cannot run, so the leak is now on *every* cancellation — newly worsened, not pre-existing as first claimed. `sweepStaleStagingDirs()` at pass start removes `grafel-links-*` dirs older than 24h. The cutoff is deliberately lopsided: a leaked dir surviving an extra day costs nothing, while deleting a live pass's staged graphs would fail that pass outright, and the real pass runs ~9 minutes.

## Child self-sufficiency

Only the group name is passed; everything else is inherited env. Verified rather than assumed: `repoSourcePathOverrides` is the **only** mutable package global in `internal/links` (everything else is a compiled regexp, const table, or `nowFn`), and it is rewritten from `registry.LoadGroupConfig(...).Repos` on every entry to `RunLinksForGroupCtx` — not seeded at daemon start. The child does no less work.

Also confirmed: `internal/cli/links.go` no longer rewrites `graph.fb`/`graph.json` (repointed at `flows.Upsert` by #5904), so there is no concurrent-graph-writer hazard. #5978's deterministic `path+".tmp"` collision is untouched and not worsened — the pass is still serialised by the exclusive stage token.

## Unquantified trade, stated so it is on record

`GRAFEL_LINKS_CPU` defaults to 2, taking the pass from 12 → 2 usable procs on a 12-core host, with **zero measured wall-time delta**. Defensible on the "nobody waits on a background pass" rule that governs this epic, but it is a guess. Measure it before anyone lowers it further.

## Verification

`go build ./...`, `go vet ./cmd/... ./internal/...`, `gofmt -l internal cmd` clean. `./cmd/grafel/... ./internal/daemon/... ./internal/links/... ./internal/cli/...` **2133 pass**, goldens unmoved; `./internal/daemon/sched/...` green under `-race -count=2`.

Independently adversarially reviewed. Mutations, no survivors:

| mutation | caught by |
|---|---|
| runner does not wait for the child | 4 tests (one observed a 979 µs return) |
| `withMadvDontNeed` → passthrough | 2 env tests |
| remove `links-internal` from the allow-list | `IsOnTheGCPacingAllowList` |
| `daemonForegroundLinks` forks | `DoesNotFork` |
| delete the stale-staging sweep | `stale staging dir survived the sweep` |

Phase labels are pinned by deriving the expected history from `res.Results[i].Pass`, so label↔pass drift is caught rather than round-tripped through a constant.

**Known gaps, disclosed:** `GRAFEL_SUBPROCESS_INDEXER=0` keeping links in-process is untested (as with group-algo); `link_stage` / `link_stats` / `idle` are the only unpinned stamps, needing a registered group; `RunSubprocessIndex` has the same SIGTERM comment error, left alone to keep this diff from sprawling into the index child.

**RSS effect unmeasured** — the coordinator measures.

Refs #5954
