### PR TITLE
fix(#5954): stage-gate hold-max from the measured pass; forfeit no longer releases; holder identity is an epoch

### DIFF
--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -149,7 +149,8 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 			// a peak-RSS measurement run — can confirm from outside the process
 			// that it fired, instead of inferring it from RSS shape. Silent when
 			// the gate is idle, which is the overwhelmingly common case.
-			if st.StageGateHolder != "" || len(st.StageGateDeferred) > 0 || len(st.StageGateBarging) > 0 {
+			if st.StageGateHolder != "" || len(st.StageGateDeferred) > 0 || len(st.StageGateBarging) > 0 ||
+				st.StageGateForfeits > 0 {
 				fmt.Fprint(w, "  stage_gate:")
 				if len(st.StageGateBarging) > 0 {
 					fmt.Fprintf(w, " barging=%s", strings.Join(st.StageGateBarging, ","))
@@ -159,6 +160,11 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				}
 				if len(st.StageGateDeferred) > 0 {
 					fmt.Fprintf(w, " deferred=%s", strings.Join(st.StageGateDeferred, ","))
+				}
+				// Sticky: a forfeit is a failure, so it stays on the line for
+				// the life of the daemon rather than vanishing with the holder.
+				if st.StageGateForfeits > 0 {
+					fmt.Fprintf(w, " FORFEITS=%d", st.StageGateForfeits)
 				}
 				fmt.Fprintln(w)
 			}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -157,6 +157,13 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				}
 				if st.StageGateHolder != "" {
 					fmt.Fprintf(w, " holder=%s", st.StageGateHolder)
+					// LIVE, unlike FORFEITS below: this holder blew the 4h
+					// hold-max and the gate is inside its forfeit grace right
+					// now. It is the state an operator staring at a stalled
+					// daemon is trying to identify, so it rides on the holder.
+					if st.StageGateForfeitedHolder {
+						fmt.Fprint(w, "(FORFEITED,awaiting-cancel)")
+					}
 				}
 				if len(st.StageGateDeferred) > 0 {
 					fmt.Fprintf(w, " deferred=%s", strings.Join(st.StageGateDeferred, ","))

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -109,6 +109,7 @@ func StageGateFromStatusFile() (g sched.StageGateState, ok bool) {
 		Holder:   f.StageGateHolder,
 		Deferred: f.StageGateDeferred,
 		Barging:  f.StageGateBarging,
+		Forfeits: f.StageGateForfeits,
 	}, true
 }
 

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -106,10 +106,11 @@ func StageGateFromStatusFile() (g sched.StageGateState, ok bool) {
 		return sched.StageGateState{}, false
 	}
 	return sched.StageGateState{
-		Holder:   f.StageGateHolder,
-		Deferred: f.StageGateDeferred,
-		Barging:  f.StageGateBarging,
-		Forfeits: f.StageGateForfeits,
+		Holder:          f.StageGateHolder,
+		Deferred:        f.StageGateDeferred,
+		Barging:         f.StageGateBarging,
+		Forfeits:        f.StageGateForfeits,
+		ForfeitedHolder: f.StageGateForfeitedHolder,
 	}, true
 }
 

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -92,6 +92,10 @@ type StatusReply struct {
 	StageGateHolder   string   `json:"stage_gate_holder,omitempty"`
 	StageGateDeferred []string `json:"stage_gate_deferred,omitempty"`
 	StageGateBarging  []string `json:"stage_gate_barging,omitempty"`
+	// StageGateForfeits counts stages that blew StageGateHoldMax (4h) since
+	// daemon start. It is a FAILURE counter: any non-zero value means the gate
+	// caught a wedged heavy stage, and a measurement run should assert it is 0.
+	StageGateForfeits int64 `json:"stage_gate_forfeits,omitempty"`
 
 	// Concurrency-cap additions. BudgetMB=0 means admission control is
 	// disabled.

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -96,6 +96,14 @@ type StatusReply struct {
 	// daemon start. It is a FAILURE counter: any non-zero value means the gate
 	// caught a wedged heavy stage, and a measurement run should assert it is 0.
 	StageGateForfeits int64 `json:"stage_gate_forfeits,omitempty"`
+	// StageGateForfeitedHolder reports that StageGateHolder is INSIDE A FORFEIT
+	// GRACE right now: it blew the 4h hold-max, the gate is deliberately keeping
+	// it resident rather than releasing it (which would admit a successor beside
+	// a live stage), and it will be cancelled when the grace expires. The
+	// counter above is sticky for the life of the daemon and cannot answer
+	// "is this happening now"; this can, which is what an operator looking at a
+	// stalled daemon needs.
+	StageGateForfeitedHolder bool `json:"stage_gate_forfeited_holder,omitempty"`
 
 	// Concurrency-cap additions. BudgetMB=0 means admission control is
 	// disabled.

--- a/internal/daemon/sched/memrelease_test.go
+++ b/internal/daemon/sched/memrelease_test.go
@@ -94,10 +94,21 @@ func TestMaybeReleaseMemory_BusyResetsAndDebounces(t *testing.T) {
 	}
 }
 
-// TestMaybeReleaseMemory_PendingAlgoCountsAsBusy asserts a pending downstream
+// TestMaybeReleaseMemory_PendingAlgoDoesNotBlockRelease pins the corrected
+// rule. This test previously asserted the OPPOSITE — that a pending downstream
 // algo pass keeps the scheduler "busy" so we don't FreeOSMemory in the gap
-// between an index completing and its algo/link passes running.
-func TestMaybeReleaseMemory_PendingAlgoCountsAsBusy(t *testing.T) {
+// between an index completing and its passes running.
+//
+// That rule was wrong in both directions. It never protected in-flight work (a
+// PENDING pass is by definition not executing), and it made the release
+// starvable: a stage the gate defers keeps groupAlgoPending set for as long as
+// it is blocked, so one wedged gate meant 8+ hours without a single heap
+// release. It also held the arena through the 180s group-algo debounce — a
+// two-and-a-half-minute idle window, against a 30s release debounce — which is
+// the best moment to scavenge, not the worst.
+//
+// Release is now gated on workInFlightLocked only. See workPendingLocked.
+func TestMaybeReleaseMemory_PendingAlgoDoesNotBlockRelease(t *testing.T) {
 	var freed atomic.Int32
 	s := newMemTestScheduler(10*time.Second, func() { freed.Add(1) })
 
@@ -107,19 +118,21 @@ func TestMaybeReleaseMemory_PendingAlgoCountsAsBusy(t *testing.T) {
 
 	base := time.Now()
 	s.maybeReleaseMemory(base)
-	s.maybeReleaseMemory(base.Add(20 * time.Second))
-	if got := freed.Load(); got != 0 {
-		t.Fatalf("released while an algo pass was pending; want 0 got %d", got)
+	s.maybeReleaseMemory(base.Add(11 * time.Second))
+	if got := freed.Load(); got != 1 {
+		t.Fatalf("a merely-pending algo pass blocked the heap release; want 1 got %d", got)
 	}
 
-	// Algo pass clears → now genuinely idle.
+	// ...but once it is actually RUNNING (it holds the stage gate), the release
+	// must stop: that is the case the old rule was reaching for.
 	s.mu.Lock()
 	s.groupAlgoPending["shared"] = false
+	s.stageHolder = "group-algo:shared"
 	s.mu.Unlock()
-	s.maybeReleaseMemory(base.Add(30 * time.Second)) // arms fresh clock
-	s.maybeReleaseMemory(base.Add(41 * time.Second)) // fires
+	s.maybeReleaseMemory(base.Add(20 * time.Second))
+	s.maybeReleaseMemory(base.Add(40 * time.Second))
 	if got := freed.Load(); got != 1 {
-		t.Fatalf("did not release once truly idle; want 1 got %d", got)
+		t.Fatalf("released the heap under a RUNNING algo pass; want 1 got %d", got)
 	}
 }
 

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -542,6 +542,17 @@ type Scheduler struct {
 	// The SHARED (index) side of the gate is not counted here: s.inflight
 	// already tracks it exactly.
 	stageHolder string
+	// stageEpoch is the IDENTITY of the current holder, bumped on every
+	// acquisition and never reset. stageHolder alone cannot serve as an
+	// identity: the two exclusive stages are named "links:<group>" and
+	// "group-algo:<group>", so the pass that follows an ABANDONED
+	// "group-algo:acme" is very often a fresh "group-algo:acme" — the SAME
+	// STRING. Without the epoch, the abandoned pass returning late would find
+	// its own name in stageHolder and clear its SUCCESSOR'S token, admitting a
+	// third stage beside two live ones (strictly worse than the degrade the
+	// abandonment already advertises). releaseStage and setStageCancelLocked
+	// therefore match on (name, epoch), not on name.
+	stageEpoch int64
 	// stageHeldSince is when stageHolder acquired; drives StageGateHoldMax.
 	stageHeldSince time.Time
 	// stageForfeitedAt is when stageHolder was declared FORFEITED (it blew
@@ -1183,7 +1194,26 @@ func (s *Scheduler) publishRepoStatesLocked() {
 // here. Barge holds are id-keyed (not name-keyed), so independent registrations
 // never collide, never overwrite one another, and each release drops only its
 // own id — two subsystems can register concurrently without coordinating.
-func (s *Scheduler) workInFlightLocked() bool {
+//
+// It REAPS the barge first, per bargeHeldLocked's contract. That is not
+// bookkeeping hygiene here, it is the liveness bound: this predicate gates
+// FreeOSMemory, and a leaked barge (a foreground goroutine that vanished without
+// unwinding its release) would otherwise read as in-flight work forever and
+// starve the heap release on an idle daemon — with nothing else to reap it,
+// since every other reap site is a GATE decision and an idle daemon makes none.
+// Reaping stops that at StageGateBargeMax. The stage holder needs no equivalent
+// reap: this predicate must report a forfeited-but-resident holder as in-flight
+// (it IS running), and its own bound is enforced by the gate paths.
+//
+// `now` is threaded from the caller rather than read as time.Now() here, because
+// the caller (maybeReleaseMemory) already takes an injected clock so tests can
+// drive the idle/debounce logic synthetically. Reading the wall clock instead
+// would work today only because the existing tests seed bargeHold.since from
+// real time; a test that advanced a synthetic `now` past StageGateBargeMax would
+// silently fail to reap, and the bound this reap exists to enforce would go
+// untested exactly where it was being asserted.
+func (s *Scheduler) workInFlightLocked(now time.Time) bool {
+	s.reapBargeLocked(now)
 	return len(s.inflight) > 0 || s.stageHolder != "" || s.bargeHeldLocked()
 }
 
@@ -1227,8 +1257,8 @@ func (s *Scheduler) workPendingLocked() bool {
 // busyLocked reports whether any indexing-related work is in flight OR pending.
 // Must be called with s.mu held. Callers that specifically mean "is anything
 // executing" want workInFlightLocked instead.
-func (s *Scheduler) busyLocked() bool {
-	return s.workInFlightLocked() || s.workPendingLocked()
+func (s *Scheduler) busyLocked(now time.Time) bool {
+	return s.workInFlightLocked(now) || s.workPendingLocked()
 }
 
 // maybeReleaseMemory is the testable core of the idle-release trigger. It
@@ -1241,7 +1271,7 @@ func (s *Scheduler) maybeReleaseMemory(now time.Time) {
 	s.mu.Lock()
 	// Gated on IN-FLIGHT work only, never on pending work — see
 	// workPendingLocked for the wedge that conflating them caused.
-	if s.workInFlightLocked() {
+	if s.workInFlightLocked(now) {
 		// Activity resumed (or never settled): reset the idle clock so the
 		// next idle period must serve out a fresh debounce, and re-arm the
 		// one-shot release.
@@ -1821,7 +1851,8 @@ func (s *Scheduler) fireLinks(group string) {
 	now := time.Now()
 
 	s.mu.Lock()
-	if !s.tryAcquireStageLocked(name, now) {
+	stageEpoch, acquired := s.tryAcquireStageLocked(name, now)
+	if !acquired {
 		delay := s.noteStageDeferLocked(name, now)
 		s.linkPending[group] = true
 		if t, ok := s.linkTimers[group]; ok {
@@ -1855,11 +1886,13 @@ func (s *Scheduler) fireLinks(group string) {
 	s.linkCancel[group] = tok
 	// Give the gate a handle on this pass, so a forfeit that outlives its grace
 	// has something to cancel instead of reclaiming the token beside a live one.
-	s.setStageCancelLocked(name, cancel)
+	s.setStageCancelLocked(name, stageEpoch, cancel)
 	s.mu.Unlock()
 
 	// Release on EVERY exit path — normal return, error, cancellation, panic.
-	defer s.releaseStage(name)
+	// Carries the epoch so that a pass whose token was already abandoned by the
+	// forfeit-grace expiry cannot free its successor's token here.
+	defer s.releaseStage(name, stageEpoch)
 
 	s.runLinks(ctx, group)
 
@@ -2052,7 +2085,8 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	now := time.Now()
 
 	s.mu.Lock()
-	if !s.tryAcquireStageLocked(name, now) {
+	stageEpoch, acquired := s.tryAcquireStageLocked(name, now)
+	if !acquired {
 		delay := s.noteStageDeferLocked(name, now)
 		// A DEFERRED pass must stay visible to grafel_stats exactly like a
 		// RUNNING one, or an MCP consumer polling across the deferral sees an
@@ -2080,11 +2114,13 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	// Give the gate a handle on this pass — cancelling it SIGKILLs the
 	// group-algo child (subprocess_runner.go). Only the forfeit-grace expiry
 	// uses it; a plain forfeit deliberately does not.
-	s.setStageCancelLocked(name, cancel)
+	s.setStageCancelLocked(name, stageEpoch, cancel)
 	s.mu.Unlock()
 
 	// Release on EVERY exit path — normal return, error, cancellation, panic.
-	defer s.releaseStage(name)
+	// Carries the epoch so that a pass whose token was already abandoned by the
+	// forfeit-grace expiry cannot free its successor's token here.
+	defer s.releaseStage(name, stageEpoch)
 
 	s.runGroupAlgo(ctx, group)
 
@@ -2311,10 +2347,17 @@ type Snapshot struct {
 	// It is a FAILURE counter, not a warning: any non-zero value means a heavy
 	// stage held the gate past a 4h bound. A measurement run should assert it
 	// stays 0.
-	StageHolder   string   `json:"stage_holder,omitempty"`
-	StageDeferred []string `json:"stage_deferred,omitempty"`
-	Barging       []string `json:"barging,omitempty"`
-	StageForfeits int64    `json:"stage_forfeits,omitempty"`
+	//
+	// StageForfeitedHolder is the LIVE counterpart of that sticky counter:
+	// StageHolder is past its hold-max RIGHT NOW and the gate is deliberately
+	// keeping it resident rather than releasing it. The counter alone cannot
+	// answer "is the gate in a forfeit grace at this instant", which is the
+	// question an operator staring at a stalled daemon actually has.
+	StageHolder          string   `json:"stage_holder,omitempty"`
+	StageDeferred        []string `json:"stage_deferred,omitempty"`
+	Barging              []string `json:"barging,omitempty"`
+	StageForfeits        int64    `json:"stage_forfeits,omitempty"`
+	StageForfeitedHolder bool     `json:"stage_forfeited_holder,omitempty"`
 }
 
 // InFlightJob is one currently-running index, with its reserved MB.
@@ -2384,7 +2427,7 @@ func (s *Scheduler) Snapshot() Snapshot {
 	}
 	g := s.stageGateStateLocked()
 	out.StageHolder, out.StageDeferred, out.Barging = g.Holder, g.Deferred, g.Barging
-	out.StageForfeits = g.Forfeits
+	out.StageForfeits, out.StageForfeitedHolder = g.Forfeits, g.ForfeitedHolder
 	return out
 }
 
@@ -2405,7 +2448,11 @@ type StageGateState struct {
 	// Non-zero is a FAILURE signal, not a warning — see Snapshot.StageForfeits.
 	Forfeits int64
 	// ForfeitedHolder is true when Holder has been forfeited and is being kept
-	// resident by the gate rather than released (see reapStageLocked).
+	// resident by the gate rather than released (see reapStageLocked). Unlike
+	// Forfeits, which is sticky for the life of the daemon, this is the LIVE
+	// signal: the gate is inside a forfeit grace at this instant, and Holder
+	// will be cancelled when it expires. Reaches `grafel status` in both
+	// monolith and split mode alongside Forfeits.
 	ForfeitedHolder bool
 }
 

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -309,18 +309,30 @@ type Config struct {
 	// stageGateMaxDeferDefault (300s). Env: GRAFEL_STAGE_GATE_MAX_DEFER.
 	StageGateMaxDefer time.Duration
 
-	// StageGateHoldMax is the longest an exclusive stage may hold the token
-	// before the gate forfeits it and resumes index dispatch. The token is held
-	// across a subprocess spawn, so a crashed/wedged child must not wedge the
-	// daemon.
+	// StageGateHoldMax is how long an exclusive stage may hold the token before
+	// the gate declares it FORFEITED. The token is held across a subprocess
+	// spawn, so a crashed/wedged child must not wedge the daemon.
 	//
-	// This is the SCALE-SENSITIVE knob. It must exceed the duration of a
-	// LEGITIMATE group-algo pass on the deployment's largest group, or every
-	// pass is forfeited mid-flight and the gate silently degrades to no-gate on
-	// exactly the corpora it was built for. Watch for `stage_gate_forfeit` events
-	// and raise it if they appear. <=0 defaults to stageGateHoldMaxDefault (15m).
+	// This is the SCALE-SENSITIVE knob, and it shipped mis-sized: 15m against a
+	// pass that measures 32–53 minutes on the real corpus, so every run was
+	// forfeited. It must exceed a LEGITIMATE group-algo pass on the deployment's
+	// largest group with room for that group to grow. <=0 defaults to
+	// stageGateHoldMaxDefault (4h = 4x the measured worst pass), sized in
+	// stagegate.go against stageGateMeasuredPassWorst.
+	//
+	// A `stage_gate_forfeit` event now means a holder blew a bound no legitimate
+	// pass can reach — investigate it, do not reflexively raise this.
 	// Env: GRAFEL_STAGE_GATE_HOLD_MAX.
 	StageGateHoldMax time.Duration
+
+	// StageGateForfeitGrace is how long a FORFEITED stage keeps the gate closed
+	// before it is cancelled and its token reclaimed. The forfeit itself neither
+	// cancels nor releases (see reapStageLocked: releasing re-ran the very pass
+	// it forfeited, and cancelling discarded up to 53 minutes of work); this is
+	// the terminal remedy that bounds the resulting wedge. <=0 defaults to
+	// stageGateForfeitGraceDefault (30m), i.e. 4h30m of total patience.
+	// Env: GRAFEL_STAGE_GATE_FORFEIT_GRACE.
+	StageGateForfeitGrace time.Duration
 
 	// StageGateDrainMax bounds the drain barrier: how long index dispatch may be
 	// held while waiting for the in-flight batch to clear for a starved stage.
@@ -532,6 +544,21 @@ type Scheduler struct {
 	stageHolder string
 	// stageHeldSince is when stageHolder acquired; drives StageGateHoldMax.
 	stageHeldSince time.Time
+	// stageForfeitedAt is when stageHolder was declared FORFEITED (it blew
+	// StageGateHoldMax), or zero. A forfeited holder still HOLDS the gate — the
+	// forfeit is a diagnostic, not a release (see reapStageLocked) — so this is
+	// what distinguishes "wedged but still doing real work" from "healthy", and
+	// it starts the StageGateForfeitGrace clock after which the stage is
+	// cancelled and its token reclaimed.
+	stageForfeitedAt time.Time
+	// stageForfeits counts forfeits since daemon start. Surfaced in Snapshot /
+	// StageGateState so a measurement run can assert the gate never fired on
+	// legitimate work; any non-zero value means a stage blew a 4h bound.
+	stageForfeits int64
+	// stageCancel cancels the work of stageHolder (SIGKILLing a group-algo
+	// child). Registered by the holder once its context exists; the ONLY caller
+	// is the forfeit-grace expiry. nil when the holder registered none.
+	stageCancel func()
 	// stageDeferSince records, per stage name, when its CURRENT continuous
 	// deferral began. Cleared on acquire. Drives both the "deferred for N"
 	// observability and the StageGateMaxDefer starvation guard.
@@ -685,6 +712,9 @@ func New(cfg Config) *Scheduler {
 	}
 	if cfg.StageGateHoldMax <= 0 {
 		cfg.StageGateHoldMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_HOLD_MAX", stageGateHoldMaxDefault)
+	}
+	if cfg.StageGateForfeitGrace <= 0 {
+		cfg.StageGateForfeitGrace = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_FORFEIT_GRACE", stageGateForfeitGraceDefault)
 	}
 	if cfg.StageGateDrainMax <= 0 {
 		cfg.StageGateDrainMax = stageGateDurationFromEnv("GRAFEL_STAGE_GATE_DRAIN_MAX", stageGateDrainMaxDefault)
@@ -1132,18 +1162,53 @@ func (s *Scheduler) publishRepoStatesLocked() {
 	indexstate.SetRepoStates(out)
 }
 
-// busyLocked reports whether any indexing-related work is in flight or
-// pending. Must be called with s.mu held. Algo/link debounce timers count
-// as "busy" so we don't FreeOSMemory in the gap between an index completing
-// and its downstream passes firing.
-func (s *Scheduler) busyLocked() bool {
-	if len(s.inflight) > 0 || s.queueLen > 0 || len(s.pendingQ) > 0 {
+// workInFlightLocked reports whether heavy work is ACTUALLY EXECUTING right
+// now: an index job on a worker, an exclusive stage holding the gate, or
+// foreground work holding a barge. Must be called with s.mu held.
+//
+// This is the predicate FreeOSMemory is gated on, and only this one. Returning
+// the heap arena to the OS under genuinely in-flight work is paid straight back
+// (and costs a stop-the-world scavenge to do it), which is what busyLocked was
+// protecting against and what must not regress.
+//
+// A BARGE counts, and did not before: a foreground rebuild is the single
+// largest process on the machine and is invisible to s.inflight (it never
+// enqueues), so the pre-split predicate would happily scavenge mid-rebuild.
+//
+// THE BARGE IS ALSO THE EXTENSION POINT for heavy work that lives outside the
+// scheduler entirely. The post-rebuild analytics path (appendRebuildHistory) is
+// a bare goroutine that materialises the corpus and is invisible to both
+// s.inflight and this predicate; registering it via bargeForeground is all that
+// is needed to make it both gate-visible and release-visible, with no change
+// here. Barge holds are id-keyed (not name-keyed), so independent registrations
+// never collide, never overwrite one another, and each release drops only its
+// own id — two subsystems can register concurrently without coordinating.
+func (s *Scheduler) workInFlightLocked() bool {
+	return len(s.inflight) > 0 || s.stageHolder != "" || s.bargeHeldLocked()
+}
+
+// workPendingLocked reports whether heavy work is QUEUED OR WAITING but not
+// executing: queued index jobs, an armed link/group-algo debounce, a stage the
+// gate is deferring, or a drain barrier. Must be called with s.mu held.
+//
+// Split out of busyLocked because conflating the two starved the heap release.
+// busyLocked treated "a stage is deferred" as work in flight, and a deferred
+// stage that cannot acquire stays in stageDeferSince (and keeps
+// groupAlgoPending set) for as long as it is blocked — so a single wedged gate
+// meant the engine went 8+ hours without ONE FreeOSMemory, and its 1290–2112 MB
+// "idle floor" was largely an un-returned watermark rather than live data.
+//
+// A stage that is merely waiting is not doing work, and the debounce gap is the
+// BEST moment to scavenge, not the worst: the group-algo debounce is 180s
+// against a 30s MemReleaseDebounce, so the pre-split rule was holding the arena
+// through a two-and-a-half-minute idle window on purpose. The cost of releasing
+// there is one extra tens-of-ms scavenge per cascade; the cost of not releasing
+// was unbounded retention.
+func (s *Scheduler) workPendingLocked() bool {
+	if s.queueLen > 0 || len(s.pendingQ) > 0 {
 		return true
 	}
-	// #5954: an exclusive heavy stage holding the gate, or a stage deferred by
-	// it, is write-side work in flight — releasing the heap underneath it would
-	// be paid straight back.
-	if s.stageHolder != "" || s.stageDrainFor != "" || len(s.stageDeferSince) > 0 {
+	if s.stageDrainFor != "" || len(s.stageDeferSince) > 0 {
 		return true
 	}
 	for _, p := range s.groupAlgoPending {
@@ -1159,6 +1224,13 @@ func (s *Scheduler) busyLocked() bool {
 	return false
 }
 
+// busyLocked reports whether any indexing-related work is in flight OR pending.
+// Must be called with s.mu held. Callers that specifically mean "is anything
+// executing" want workInFlightLocked instead.
+func (s *Scheduler) busyLocked() bool {
+	return s.workInFlightLocked() || s.workPendingLocked()
+}
+
 // maybeReleaseMemory is the testable core of the idle-release trigger. It
 // tracks when the scheduler became idle and, once idle for the debounce
 // window, invokes FreeOSMemory exactly once (until the next busy→idle
@@ -1167,7 +1239,9 @@ func (s *Scheduler) busyLocked() bool {
 // repeatedly; only the first post-debounce call in an idle period releases.
 func (s *Scheduler) maybeReleaseMemory(now time.Time) {
 	s.mu.Lock()
-	if s.busyLocked() {
+	// Gated on IN-FLIGHT work only, never on pending work — see
+	// workPendingLocked for the wedge that conflating them caused.
+	if s.workInFlightLocked() {
 		// Activity resumed (or never settled): reset the idle clock so the
 		// next idle period must serve out a fresh debounce, and re-arm the
 		// one-shot release.
@@ -1779,6 +1853,9 @@ func (s *Scheduler) fireLinks(group string) {
 		prev.cancel()
 	}
 	s.linkCancel[group] = tok
+	// Give the gate a handle on this pass, so a forfeit that outlives its grace
+	// has something to cancel instead of reclaiming the token beside a live one.
+	s.setStageCancelLocked(name, cancel)
 	s.mu.Unlock()
 
 	// Release on EVERY exit path — normal return, error, cancellation, panic.
@@ -2000,6 +2077,10 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	// and runLinks. Fixes the leak class of issue #2493.
 	ctx, cancel := context.WithCancel(s.shutdownCtx)
 	s.groupAlgoCancel[group] = cancel
+	// Give the gate a handle on this pass — cancelling it SIGKILLs the
+	// group-algo child (subprocess_runner.go). Only the forfeit-grace expiry
+	// uses it; a plain forfeit deliberately does not.
+	s.setStageCancelLocked(name, cancel)
 	s.mu.Unlock()
 
 	// Release on EVERY exit path — normal return, error, cancellation, panic.
@@ -2225,9 +2306,15 @@ type Snapshot struct {
 	// away by the gate. Barging lists live foreground holds ("rebuild:<group>")
 	// — non-empty means a rebuild is registered and background heavy stages are
 	// yielding to it. All sorted for deterministic output.
+	//
+	// StageForfeits counts stages that blew StageGateHoldMax since daemon start.
+	// It is a FAILURE counter, not a warning: any non-zero value means a heavy
+	// stage held the gate past a 4h bound. A measurement run should assert it
+	// stays 0.
 	StageHolder   string   `json:"stage_holder,omitempty"`
 	StageDeferred []string `json:"stage_deferred,omitempty"`
 	Barging       []string `json:"barging,omitempty"`
+	StageForfeits int64    `json:"stage_forfeits,omitempty"`
 }
 
 // InFlightJob is one currently-running index, with its reserved MB.
@@ -2297,6 +2384,7 @@ func (s *Scheduler) Snapshot() Snapshot {
 	}
 	g := s.stageGateStateLocked()
 	out.StageHolder, out.StageDeferred, out.Barging = g.Holder, g.Deferred, g.Barging
+	out.StageForfeits = g.Forfeits
 	return out
 }
 
@@ -2313,6 +2401,12 @@ type StageGateState struct {
 	// Barging lists live FOREGROUND holds ("rebuild:<group>"). Non-empty means
 	// a rebuild is registered and background heavy stages are yielding to it.
 	Barging []string
+	// Forfeits counts stages that blew StageGateHoldMax since daemon start.
+	// Non-zero is a FAILURE signal, not a warning — see Snapshot.StageForfeits.
+	Forfeits int64
+	// ForfeitedHolder is true when Holder has been forfeited and is being kept
+	// resident by the gate rather than released (see reapStageLocked).
+	ForfeitedHolder bool
 }
 
 // StageGateState returns the gate's live state for observability. Safe to call
@@ -2331,7 +2425,11 @@ func (s *Scheduler) StageGateState() StageGateState {
 // its bound therefore stays visible until a real gate decision reaps it — which
 // is also the honest reading, since it genuinely is still resident.
 func (s *Scheduler) stageGateStateLocked() StageGateState {
-	out := StageGateState{Holder: s.stageHolder}
+	out := StageGateState{
+		Holder:          s.stageHolder,
+		Forfeits:        s.stageForfeits,
+		ForfeitedHolder: s.stageHolder != "" && !s.stageForfeitedAt.IsZero(),
+	}
 	for name := range s.stageDeferSince {
 		out.Deferred = append(out.Deferred, name)
 	}

--- a/internal/daemon/sched/stagegate.go
+++ b/internal/daemon/sched/stagegate.go
@@ -212,8 +212,12 @@ func (s *Scheduler) stopped() bool {
 // a holder to blow StageGateHoldMax (4h) AND survive cancellation for
 // StageGateForfeitGrace (30m) — a child stuck in uninterruptible I/O, not a slow
 // pass. It is loud and separately named: `stage_gate_forfeit_abandoned`.
-// The identity check in releaseStage is the other half — a late-returning
-// abandoned stage must not clear the NEW holder's token.
+// The epoch check in releaseStage is the other half — a late-returning
+// abandoned stage must not clear the NEW holder's token. It has to be an EPOCH
+// and not a name: the successor to an abandoned "group-algo:acme" is usually
+// another "group-algo:acme", so a name comparison would let the late returner
+// free its successor's token and admit a third stage beside two live ones.
+// See Scheduler.stageEpoch.
 func (s *Scheduler) reapStageLocked(now time.Time) {
 	// Foreground barges expire on their OWN, much longer bound — never on
 	// StageGateHoldMax. See stageGateBargeMaxDefault for why the two liveness
@@ -300,11 +304,21 @@ func (s *Scheduler) clearStageHolderLocked() {
 
 // setStageCancelLocked registers the cancel handle for the current exclusive
 // holder, so a forfeit that outlives its grace has something to cancel. It is a
-// no-op unless `name` is still the holder — a stage whose token was already
-// abandoned must not attach its cancel to its successor. MUST be called with
+// no-op unless (name, epoch) still identifies the holder. MUST be called with
 // s.mu held.
-func (s *Scheduler) setStageCancelLocked(name string, cancel func()) {
-	if s.stageHolder == name {
+//
+// The guard is BELT-AND-BRACES, not a live hazard, and the distinction is worth
+// stating so nobody later "hardens" it on a misreading. Both call sites
+// (fireLinks, fireGroupAlgo) acquire the token and register the handle inside
+// ONE unbroken s.mu critical section, and nothing in between reaps, so the
+// holder provably still is us — mutating this back to a name-only comparison
+// leaves the whole suite green, correctly. It takes the epoch because the
+// authorising identity of a holder IS the epoch (see Scheduler.stageEpoch) and
+// having one identity check in the package rather than two spellings is what
+// keeps a future caller that registers outside the acquiring critical section
+// from being silently wrong.
+func (s *Scheduler) setStageCancelLocked(name string, epoch int64, cancel func()) {
+	if s.stageHolder == name && s.stageEpoch == epoch {
 		s.stageCancel = cancel
 	}
 }
@@ -371,27 +385,36 @@ func (s *Scheduler) stageBusyLocked(now time.Time) bool {
 // `name`. It never blocks. It succeeds only when no other exclusive stage holds
 // the token AND no index job is executing. MUST be called with s.mu held.
 //
+// On success it returns the holder's EPOCH, which the caller must carry to
+// releaseStage and setStageCancelLocked. The epoch is the holder's identity;
+// `name` is not, because a successor commonly shares it (see Scheduler.
+// stageEpoch). It is returned rather than re-read from s.stageEpoch so that a
+// caller cannot silently acquire without capturing one.
+//
 // A drain barrier raised by a DIFFERENT stage also blocks acquisition, so the
 // starved stage that paid for the barrier is the one that gets through it.
-func (s *Scheduler) tryAcquireStageLocked(name string, now time.Time) bool {
+func (s *Scheduler) tryAcquireStageLocked(name string, now time.Time) (epoch int64, ok bool) {
 	if s.cfg.StageGateDisabled {
-		return true
+		// The escape hatch runs ungated, so there is no holder and no identity.
+		// Epoch 0 never matches a real acquisition (stageEpoch is pre-incremented
+		// from 0), and every guard it feeds is a no-op with no holder set.
+		return 0, true
 	}
 	s.reapStageLocked(now)
 	// #5954 barge: foreground work (a rebuild's index batch and its own link
 	// pass) runs entirely outside the scheduler, so s.inflight below cannot see
 	// it. A registered barge holds background stages off for its duration.
 	if s.bargeHeldLocked() {
-		return false
+		return 0, false
 	}
 	if s.stageHolder != "" {
-		return false
+		return 0, false
 	}
 	if len(s.inflight) > 0 {
-		return false
+		return 0, false
 	}
 	if s.stageDrainFor != "" && s.stageDrainFor != name {
-		return false
+		return 0, false
 	}
 	if since, ok := s.stageDeferSince[name]; ok {
 		waited := now.Sub(since).Truncate(time.Millisecond)
@@ -405,9 +428,10 @@ func (s *Scheduler) tryAcquireStageLocked(name string, now time.Time) bool {
 		s.stageDrainFor = ""
 		s.stageDrainUntil = time.Time{}
 	}
+	s.stageEpoch++
 	s.stageHolder = name
 	s.stageHeldSince = now
-	return true
+	return s.stageEpoch, true
 }
 
 // noteStageDeferLocked records that `name` could not acquire the token, and
@@ -474,9 +498,21 @@ func (s *Scheduler) stageBlockReasonLocked() string {
 // releaseStage hands the exclusive token back and wakes admission. Always
 // invoked via `defer` at the acquisition site, so it also runs when the stage
 // returns an error, is cancelled, or panics.
-func (s *Scheduler) releaseStage(name string) {
+//
+// `epoch` is the value tryAcquireStageLocked returned, and it — not `name` — is
+// what authorises the release. A stage whose token was ABANDONED by the
+// forfeit-grace expiry (reapForfeitedStageLocked) is still running and will
+// still reach this defer, potentially long after a SUCCESSOR acquired. Matching
+// on name alone would let it free the successor's token, because the successor
+// is usually the same name (a fresh group-algo after an abandoned group-algo);
+// the gate would then admit a third stage beside two live ones. Matching on the
+// epoch makes the late return a no-op, which is the whole of the guarantee the
+// abandonment path advertises: the gate is non-binding against the ONE
+// abandoned stage, and no further.
+func (s *Scheduler) releaseStage(name string, epoch int64) {
 	s.mu.Lock()
-	if s.stageHolder == name {
+	switch {
+	case s.stageHolder == name && s.stageEpoch == epoch:
 		held := time.Since(s.stageHeldSince).Truncate(time.Millisecond)
 		forfeited := !s.stageForfeitedAt.IsZero()
 		s.clearStageHolderLocked()
@@ -488,6 +524,27 @@ func (s *Scheduler) releaseStage(name string) {
 			msg += " (was forfeited — returned before the grace expired; no work lost)"
 		}
 		s.logEventLocked("stage_gate_release", "", msg)
+	default:
+		// Not the authorised holder, so this is an ABANDONED stage finally
+		// exiting. Worth saying: it closes out the `stage_gate_forfeit_abandoned`
+		// ERROR that opened the non-binding window, which otherwise has no end —
+		// an operator reading it needs to see when the invariant was restored.
+		//
+		// The condition is DEFAULT rather than something narrower like
+		// `epoch < s.stageEpoch` ("a successor has already acquired"). That test
+		// would miss the PRIMARY case: the grace expiry cancels the stage, so it
+		// usually exits within moments and long before anything else acquires —
+		// and clearStageHolderLocked does not bump the epoch, so with no
+		// successor the epoch is unchanged and the branch would never be taken,
+		// precisely in the window the operator is watching. The only other way to
+		// land here is epoch 0, i.e. the gate-disabled escape hatch, which never
+		// held anything; a set holder always carries the current epoch.
+		if epoch != 0 {
+			s.logEventLocked("stage_gate_abandoned_returned", "",
+				name+" (epoch "+itoa(epoch)+"): abandoned stage finally returned — its token was reclaimed by the "+
+					"forfeit grace, so this release is a no-op and any current holder keeps it. "+
+					"The no-co-residency invariant is guaranteed again (#5954)")
+		}
 	}
 	s.mu.Unlock()
 	// Capacity has freed: let the admission loop dispatch queued index jobs.

--- a/internal/daemon/sched/stagegate.go
+++ b/internal/daemon/sched/stagegate.go
@@ -50,16 +50,20 @@ import (
 // resident at a time, with exactly two documented exceptions, both of which are
 // single hand-offs rather than steady states:
 //
-//  1. after a FORFEIT — reapStageLocked clears a wedged exclusive holder
-//     without cancelling it (it has no handle that could), so a successor may
-//     become co-resident with it; and
+//  1. after a forfeit is ABANDONED — a stage that blew StageGateHoldMax (4h)
+//     and then survived cancellation for StageGateForfeitGrace (30m) has its
+//     token reclaimed while it may still be alive, so a successor may become
+//     co-resident with it. (A plain FORFEIT is no longer an exception: it keeps
+//     the gate closed. See reapStageLocked for why that changed.) And
 //  2. the ONE exclusive stage already mid-flight when foreground work BARGES.
 //     The barge neither cancels it (that would discard minutes of unresumable
 //     work) nor waits for it (the foreground path must never pay latency), so
 //     that single pair overlaps. Every exclusive stage that STARTS after the
 //     barge defers until it lifts.
 //
-// Both exceptions are loud: `stage_gate_forfeit` (ERROR) and `stage_gate_barge`.
+// Both exceptions are loud: `stage_gate_forfeit_abandoned` (ERROR) and
+// `stage_gate_barge`. A `stage_gate_forfeit` (ERROR) means the gate DETECTED a
+// wedge and is holding the line, not that it gave up.
 
 const (
 	// stageGateRetryDefault is how long a deferred heavy stage waits before
@@ -76,18 +80,55 @@ const (
 	// peaks), so it must carry an equivalent starvation budget of its own.
 	stageGateMaxDeferDefault = 300 * time.Second
 
+	// stageGateMeasuredPassWorst is THE MEASUREMENT the hold-max is sized
+	// against, kept as its own named constant so the next person sizing this
+	// knob has the number rather than a round figure to argue with.
+	//
+	// Observed in the live daemon's own logs (2026-07, the grafel corpus):
+	//
+	//   ERROR "heavy write-stage token forfeited after hold-max" stage=group-algo
+	//         held_for=53m27s hold_max=15m0s
+	//
+	// That 53m27s was a LEGITIMATE group-algo pass, not a wedge. Rounded up.
+	stageGateMeasuredPassWorst = 54 * time.Minute
+
+	// stageGateHoldMaxGrowthFactor is the corpus growth the default must absorb
+	// without ever firing on legitimate work. A group-algo pass is dominated by
+	// whole-graph analytics (Louvain + PageRank + betweenness) whose cost grows
+	// FASTER than node count, so the headroom has to be multiplicative, not a
+	// fixed "+30 min" that a slightly bigger group eats immediately.
+	stageGateHoldMaxGrowthFactor = 4
+
 	// stageGateHoldMaxDefault is the longest an exclusive stage may hold the
-	// token before the gate FORFEITS it and resumes index dispatch. The token
-	// is held across a subprocess spawn (group-algo), so a child that wedges or
-	// is SIGKILLed in a way that never returns must not wedge the daemon
-	// forever. This is a safety valve, not a scheduling parameter — but it is
-	// SCALE-SENSITIVE and must be tunable in the field (GRAFEL_STAGE_GATE_HOLD_
-	// MAX / Config.StageGateHoldMax). A group-algo pass measures ~4 min on the
-	// current corpus, so 15m is ~3.75x headroom; on a corpus ~4x larger a
-	// LEGITIMATE pass would exceed it, be forfeited on every run, and silently
-	// degrade the gate to no-gate precisely on the largest corpora it exists
-	// for. A burst of `stage_gate_forfeit` events is that signal — raise this.
-	stageGateHoldMaxDefault = 15 * time.Minute
+	// token before the gate declares it FORFEITED. The token is held across a
+	// subprocess spawn (group-algo), so a child that wedges or is SIGKILLed in a
+	// way that never returns must not wedge the daemon forever.
+	//
+	// THIS IS A WEDGE DETECTOR, NOT A SCHEDULING PARAMETER, and it shipped
+	// mis-sized. The original 15m was derived from a ~4 min pass on a small
+	// corpus; the real corpus measured 32–53 minutes, so the gate forfeited its
+	// own token on EVERY run, deterministically, and degraded to no-gate on
+	// exactly the corpora it exists for. The env override nobody sets was not a
+	// mitigation. The default has to be right.
+	//
+	// 4h is stageGateHoldMaxGrowthFactor x stageGateMeasuredPassWorst rounded up
+	// (4 x 54m = 3h36m): a corpus four times this one cannot reach it. A holder
+	// past FOUR HOURS is not slow, it is broken — which is what lets the forfeit
+	// path below be as conservative as it is. Still tunable in the field via
+	// GRAFEL_STAGE_GATE_HOLD_MAX / Config.StageGateHoldMax.
+	stageGateHoldMaxDefault = 4 * time.Hour
+
+	// stageGateForfeitGraceDefault is how long a FORFEITED stage keeps the gate
+	// closed before the gate gives up on it, cancels it, and reclaims the token.
+	//
+	// See reapStageLocked for why the forfeit itself neither cancels nor
+	// releases. This grace is the terminal remedy behind that decision: it
+	// bounds the wedge the forfeit-without-release reintroduces. It is measured
+	// from the forfeit, i.e. from StageGateHoldMax, so the total patience before
+	// anything is killed is 4h30m — an order of magnitude past any legitimate
+	// pass, so no real work is ever destroyed by it.
+	// Env: GRAFEL_STAGE_GATE_FORFEIT_GRACE.
+	stageGateForfeitGraceDefault = 30 * time.Minute
 
 	// stageGateDrainMaxDefault bounds the DRAIN BARRIER (the starvation guard).
 	// While the barrier is up no NEW index job is dispatched, so the in-flight
@@ -136,31 +177,49 @@ func (s *Scheduler) stopped() bool {
 // be called with s.mu held. It is the "no lost work, no wedge" half of the gate:
 // every blocking-ish piece of state has a bounded lifetime.
 //
-// THE NO-OVERLAP INVARIANT IS CONDITIONAL ON THIS FUNCTION NOT FIRING. The
-// forfeit below clears stageHolder WITHOUT cancelling the wedged stage — the
-// gate has no cancel handle for it, and even if it did, a stage that has stopped
-// responding for StageGateHoldMax is unlikely to honour one. So after a forfeit a
-// second exclusive stage CAN become co-resident with the first. That is the
-// deliberate trade: a transient overlap is strictly better than a permanently
-// wedged daemon that never indexes again. The identity check in releaseStage is
-// the other half — a late-returning forfeited stage must not clear the NEW
-// holder's token. Everything else in the gate holds unconditionally; this is the
-// one documented exception, and it is loud (ERROR + stage_gate_forfeit event).
+// THE FORFEIT, AND WHY IT NO LONGER RELEASES THE TOKEN.
+//
+// The original forfeit cleared stageHolder without cancelling the stage and
+// resumed admitting — knowingly trading the no-overlap invariant for liveness.
+// On the real corpus that trade was not transient, it was the steady state, and
+// it was strictly negative on BOTH axes it was supposed to balance:
+//
+//   - MEMORY. hold-max was 15m against a group-algo pass that measures 32–53
+//     minutes, so the forfeit fired on every run and admitted a link pass
+//     alongside a still-live group-algo child — precisely the co-residency the
+//     gate exists to prevent, on every single run.
+//   - WALL TIME. Worse than the memory cost. releaseStage → links acquires →
+//     runLinks' SUCCESS path calls scheduleGroupAlgo (scheduler.go), which arms
+//     a FRESH group-algo pass. So a forfeit does not merely permit overlap, it
+//     RE-RUNS the very pass it forfeited: observed 11:51:51 forfeit → 12:00:51
+//     links resumed → 12:10:43 a second "group-algo: starting". A 32–53 minute
+//     pass paid twice, both copies co-resident, on a machine a user was waiting
+//     on. Cancelling the child on forfeit is no better: it discards up to 53
+//     minutes of completed work AND the re-arm still recomputes it from scratch.
+//
+// So the forfeit is now a DIAGNOSTIC, not a release. The gate stays closed, the
+// stage keeps running, it finishes, and normal ordering resumes — no work
+// discarded, no pass recomputed, invariant intact. The forfeit's job is to say
+// loudly that a holder has blown a bound that no legitimate pass can reach.
+//
+// The wedge risk that release existed to bound is instead bounded by
+// StageGateForfeitGrace: once a stage has been forfeited for that long, the gate
+// CANCELS it (SIGKILLing its subprocess — see subprocess_runner.go) and only
+// then reclaims the token. Killing before releasing is what keeps the invariant:
+// a successor is never admitted next to a child we have not first told to die.
+//
+// This leaves exactly ONE reachable path to a no-gate state, and it now requires
+// a holder to blow StageGateHoldMax (4h) AND survive cancellation for
+// StageGateForfeitGrace (30m) — a child stuck in uninterruptible I/O, not a slow
+// pass. It is loud and separately named: `stage_gate_forfeit_abandoned`.
+// The identity check in releaseStage is the other half — a late-returning
+// abandoned stage must not clear the NEW holder's token.
 func (s *Scheduler) reapStageLocked(now time.Time) {
 	// Foreground barges expire on their OWN, much longer bound — never on
 	// StageGateHoldMax. See stageGateBargeMaxDefault for why the two liveness
 	// guarantees differ and why sharing the bound would be actively harmful.
 	s.reapBargeLocked(now)
-	if s.stageHolder != "" && s.cfg.StageGateHoldMax > 0 &&
-		now.Sub(s.stageHeldSince) > s.cfg.StageGateHoldMax {
-		held := now.Sub(s.stageHeldSince).Truncate(time.Second)
-		s.logEventLocked("stage_gate_forfeit", "",
-			s.stageHolder+": held the heavy-stage token for "+held.String()+" — forfeiting so index dispatch resumes (#5954)")
-		s.logger.Error("sched: heavy write-stage token forfeited after hold-max — a stage or its subprocess never returned",
-			"stage", s.stageHolder, "held_for", held, "hold_max", s.cfg.StageGateHoldMax)
-		s.stageHolder = ""
-		s.stageHeldSince = time.Time{}
-	}
+	s.reapForfeitedStageLocked(now)
 	// Expire a stale drain barrier — but ONLY once the batch it was raised to
 	// drain has actually cleared. Expiring while index jobs are still executing
 	// would re-open dispatch in the one state the barrier exists to prevent, and
@@ -174,6 +233,79 @@ func (s *Scheduler) reapStageLocked(now time.Time) {
 			s.stageDrainFor+": drain barrier expired without acquiring — resuming index dispatch (#5954)")
 		s.stageDrainFor = ""
 		s.stageDrainUntil = time.Time{}
+	}
+}
+
+// reapForfeitedStageLocked implements the two-tier forfeit described above:
+// tier 1 (hold-max) marks and shouts but changes nothing; tier 2 (forfeit
+// grace) cancels the stage, then reclaims the token. MUST be called with s.mu
+// held.
+func (s *Scheduler) reapForfeitedStageLocked(now time.Time) {
+	if s.stageHolder == "" || s.cfg.StageGateHoldMax <= 0 {
+		return
+	}
+	// Tier 1 — declare the forfeit. No cancel, no release: the gate stays
+	// closed so the holder cannot become co-resident with a successor, and its
+	// in-flight work is neither discarded nor scheduled for recomputation.
+	if s.stageForfeitedAt.IsZero() {
+		if now.Sub(s.stageHeldSince) <= s.cfg.StageGateHoldMax {
+			return
+		}
+		held := now.Sub(s.stageHeldSince).Truncate(time.Second)
+		s.stageForfeitedAt = now
+		s.stageForfeits++
+		s.logEventLocked("stage_gate_forfeit", "",
+			s.stageHolder+": held the heavy-stage token for "+held.String()+" (hold-max "+
+				s.cfg.StageGateHoldMax.String()+") — FORFEITED; the gate stays CLOSED and the stage is NOT "+
+				"cancelled, so no work is discarded or recomputed. It will be cancelled in "+
+				s.cfg.StageGateForfeitGrace.String()+" if it has not returned (#5954)")
+		s.logger.Error("sched: heavy write-stage FORFEITED — a holder blew a bound no legitimate pass can reach",
+			"stage", s.stageHolder, "held_for", held, "hold_max", s.cfg.StageGateHoldMax,
+			"action", "gate stays closed; stage will be cancelled after the forfeit grace",
+			"cancel_in", s.cfg.StageGateForfeitGrace, "forfeits", s.stageForfeits)
+		return
+	}
+	// Tier 2 — the terminal remedy. Cancel FIRST (SIGKILLs a group-algo child),
+	// then reclaim, so a successor is never admitted beside a child that has not
+	// been told to die. This is the only path that can leave the gate
+	// non-binding, and only against a process that survived cancellation.
+	if s.cfg.StageGateForfeitGrace <= 0 || now.Sub(s.stageForfeitedAt) <= s.cfg.StageGateForfeitGrace {
+		return
+	}
+	held := now.Sub(s.stageHeldSince).Truncate(time.Second)
+	name := s.stageHolder
+	cancel := s.stageCancel
+	s.logEventLocked("stage_gate_forfeit_abandoned", "",
+		name+": still resident "+held.String()+" after forfeit — cancelling it and reclaiming the token. "+
+			"THE GATE IS NON-BINDING until it exits (#5954)")
+	s.logger.Error("sched: forfeited write-stage abandoned after the grace window — cancelling and reclaiming; "+
+		"the no-co-residency invariant is NOT guaranteed until this stage exits",
+		"stage", name, "held_for", held, "forfeit_grace", s.cfg.StageGateForfeitGrace)
+	s.clearStageHolderLocked()
+	// Safe under s.mu: a context.CancelFunc never re-enters the scheduler
+	// synchronously (fireLinks does the same at its supersede site).
+	if cancel != nil {
+		cancel()
+	}
+}
+
+// clearStageHolderLocked drops every field describing the current exclusive
+// holder. MUST be called with s.mu held.
+func (s *Scheduler) clearStageHolderLocked() {
+	s.stageHolder = ""
+	s.stageHeldSince = time.Time{}
+	s.stageForfeitedAt = time.Time{}
+	s.stageCancel = nil
+}
+
+// setStageCancelLocked registers the cancel handle for the current exclusive
+// holder, so a forfeit that outlives its grace has something to cancel. It is a
+// no-op unless `name` is still the holder — a stage whose token was already
+// abandoned must not attach its cancel to its successor. MUST be called with
+// s.mu held.
+func (s *Scheduler) setStageCancelLocked(name string, cancel func()) {
+	if s.stageHolder == name {
+		s.stageCancel = cancel
 	}
 }
 
@@ -346,9 +478,16 @@ func (s *Scheduler) releaseStage(name string) {
 	s.mu.Lock()
 	if s.stageHolder == name {
 		held := time.Since(s.stageHeldSince).Truncate(time.Millisecond)
-		s.stageHolder = ""
-		s.stageHeldSince = time.Time{}
-		s.logEventLocked("stage_gate_release", "", name+" held "+held.String())
+		forfeited := !s.stageForfeitedAt.IsZero()
+		s.clearStageHolderLocked()
+		msg := name + " held " + held.String()
+		if forfeited {
+			// A forfeited stage that returns of its own accord is the GOOD
+			// outcome of the two-tier forfeit: the gate never opened, the work
+			// was never discarded, and it is now complete.
+			msg += " (was forfeited — returned before the grace expired; no work lost)"
+		}
+		s.logEventLocked("stage_gate_release", "", msg)
 	}
 	s.mu.Unlock()
 	// Capacity has freed: let the admission loop dispatch queued index jobs.

--- a/internal/daemon/sched/stagegate_5954_test.go
+++ b/internal/daemon/sched/stagegate_5954_test.go
@@ -454,80 +454,12 @@ func TestStageGate_ReleasedOnPanic(t *testing.T) {
 	}
 }
 
-// TestStageGate_HoldMaxForfeitsAndLateReturnerCannotStealToken pins the one
-// branch where the no-overlap invariant is deliberately given up. A stage that
-// holds the token past StageGateHoldMax is FORFEITED — index dispatch must
-// resume (a permanently wedged daemon is worse than a transient overlap) — and
-// when the wedged stage eventually returns, its releaseStage must NOT clear the
-// token of whoever holds it by then.
-func TestStageGate_HoldMaxForfeitsAndLateReturnerCannotStealToken(t *testing.T) {
-	var indexRuns atomic.Int32
-	releaseAlgo := make(chan struct{})
-	algoEntered := make(chan struct{}, 1)
-
-	s := New(Config{
-		Workers:           1,
-		LinkDebounce:      time.Hour,
-		GroupAlgoDebounce: 5 * time.Millisecond,
-		GroupAlgoMaxWait:  time.Hour,
-		StageGateRetry:    5 * time.Millisecond,
-		StageGateMaxDefer: time.Hour,
-		StageGateHoldMax:  20 * time.Millisecond, // wedge threshold, for the test
-		Index: func(_ context.Context, _ string, _ string) error {
-			indexRuns.Add(1)
-			return nil
-		},
-		Links: func(_ context.Context, _ string) error { return nil },
-		GroupAlgo: func(_ context.Context, _ string) error {
-			select {
-			case algoEntered <- struct{}{}:
-			default:
-			}
-			<-releaseAlgo // wedged: holds the token past StageGateHoldMax
-			return nil
-		},
-		GroupsForRepo:      func(_ string) []string { return nil },
-		MemReleaseDisabled: true,
-	})
-	var releaseOnce sync.Once
-	releaseAlgoFn := func() { releaseOnce.Do(func() { close(releaseAlgo) }) }
-	s.Start()
-	defer func() { releaseAlgoFn(); s.Stop() }()
-
-	s.scheduleGroupAlgo("acme")
-	<-algoEntered
-
-	// (a) Index dispatch must resume once the hold-max forfeits the token,
-	// even though the wedged pass is still running.
-	s.Enqueue("/repo-a")
-	waitFor(t, 3*time.Second, func() bool { return indexRuns.Load() >= 1 })
-
-	// (b) A NEW exclusive stage takes the token after the forfeit...
-	waitFor(t, 3*time.Second, func() bool {
-		s.mu.Lock()
-		defer s.mu.Unlock()
-		return len(s.inflight) == 0
-	})
-	s.mu.Lock()
-	if !s.tryAcquireStageLocked("links:acme", time.Now()) {
-		s.mu.Unlock()
-		t.Fatal("a forfeited token must be re-acquirable by a new stage")
-	}
-	s.mu.Unlock()
-
-	// ...and the wedged pass returning LATE must not steal it back.
-	releaseAlgoFn()
-	time.Sleep(100 * time.Millisecond)
-
-	s.mu.Lock()
-	holder := s.stageHolder
-	s.mu.Unlock()
-	if holder != "links:acme" {
-		t.Fatalf("a late-returning forfeited stage cleared the new holder's token (holder=%q, want %q)",
-			holder, "links:acme")
-	}
-	s.releaseStage("links:acme")
-}
+// The hold-max forfeit used to be pinned here, asserting that a stage past
+// StageGateHoldMax has its token cleared and index dispatch resumed while it
+// runs on. That behaviour was the bug, not the contract: on the real corpus it
+// fired every run and made the gate non-binding. The forfeit now keeps the gate
+// closed; see stagegate_forfeit_5954_test.go, which covers the forfeit, the
+// bounded grace, and the late-returner identity check that lived here.
 
 // TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState: constraint 3. An MCP
 // consumer polling grafel_stats must not see the daemon go quiet while a heavy

--- a/internal/daemon/sched/stagegate_barge.go
+++ b/internal/daemon/sched/stagegate_barge.go
@@ -29,16 +29,25 @@ import (
 //     hold in tryAcquireStageLocked and DEFER, exactly as they defer for each
 //     other — re-arming their own timer, staying pending, losing no work.
 //
-// THE INVARIANT, stated honestly. At most one heavy write-side stage is
-// resident at a time, EXCEPT:
+// THE INVARIANT, stated honestly. This is the SAME invariant stated at the head
+// of stagegate.go — read that for the authoritative version; the exceptions are
+// restated here only because case 2 is this file's doing. At most one heavy
+// write-side stage is resident at a time, EXCEPT:
 //
-//  1. after a forfeit — reapStageLocked clears a wedged exclusive holder
-//     without cancelling it (see its doc), so a successor can overlap it; and
+//  1. after a forfeit is ABANDONED. A plain forfeit is NOT an exception: it
+//     changes nothing, keeps the gate closed, and leaves the stage running (see
+//     reapStageLocked). Only a holder that blows StageGateHoldMax (4h) AND then
+//     survives cancellation for StageGateForfeitGrace (30m) has its token
+//     reclaimed while it may still be alive, so a successor may overlap it. The
+//     gate DOES hold a cancel handle (stageCancel) and uses it at that expiry —
+//     it cancels first and reclaims second — so this exception is a process
+//     ignoring SIGKILL, not a policy choice; and
 //  2. the ONE background exclusive stage that was already mid-flight at the
-//     instant a rebuild barged. The barge does not cancel it (the gate has no
-//     handle that could resume the lost work) and does not wait for it. That
-//     one hand-off overlaps; every background stage that STARTS after the barge
-//     defers until the barge lifts.
+//     instant a rebuild barged. Here the gate declines to use that handle: the
+//     work is minutes of unresumable analytics and cancelling it would discard
+//     it outright, so the barge neither cancels the stage nor waits for it.
+//     That one hand-off overlaps; every background stage that STARTS after the
+//     barge defers until the barge lifts.
 //
 // Both exceptions are single-hand-off, not steady-state. Case 2 costs at most
 // one background pass' worth of overlap at the START of a rebuild, versus the

--- a/internal/daemon/sched/stagegate_forfeit_5954_test.go
+++ b/internal/daemon/sched/stagegate_forfeit_5954_test.go
@@ -1,0 +1,393 @@
+package sched
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #5954 follow-up — the forfeit path.
+//
+// The gate shipped with a 15m hold-max against a group-algo pass that MEASURES
+// 32–53 minutes on the real corpus, so the forfeit fired on every single run and
+// the gate degraded to no-gate on exactly the corpora it exists for. Worse, the
+// forfeit released the token WITHOUT stopping the forfeited stage, so the
+// successor became co-resident with a still-live child — the precise condition
+// the gate prevents.
+//
+// These tests pin both halves: the default cannot fire on legitimate work, and a
+// forfeit never re-opens the gate while the forfeited stage is still resident.
+
+// TestStageGateHoldMaxDefault_ExceedsMeasuredPassWithGrowthHeadroom asserts the
+// default against the MEASUREMENT, not against the implementation's own value.
+//
+// Asserting `stageGateHoldMaxDefault > someRoundNumber` is how the 15m default
+// survived review in the first place. The measurement is the independent
+// authority here: stageGateMeasuredPassWorst carries the observed worst-case
+// legitimate pass, and the default must clear it by the corpus-growth factor the
+// gate is expected to absorb.
+func TestStageGateHoldMaxDefault_ExceedsMeasuredPassWithGrowthHeadroom(t *testing.T) {
+	// The measurement itself, from the live daemon's own logs (2026-07):
+	//   held_for=53m27s  — a LEGITIMATE group-algo pass, forfeited at hold_max=15m.
+	const observedWorstPass = 53*time.Minute + 27*time.Second
+
+	if stageGateMeasuredPassWorst < observedWorstPass {
+		t.Fatalf("stageGateMeasuredPassWorst (%v) is below the observed worst legitimate pass (%v) — "+
+			"the constant must carry the measurement, not a smaller convenient number",
+			stageGateMeasuredPassWorst, observedWorstPass)
+	}
+	want := time.Duration(stageGateHoldMaxGrowthFactor) * stageGateMeasuredPassWorst
+	if stageGateHoldMaxDefault < want {
+		t.Fatalf("stageGateHoldMaxDefault=%v cannot absorb a %dx corpus: a legitimate pass measured %v, "+
+			"so the default must be >= %v or the gate forfeits every run and degrades to no-gate",
+			stageGateHoldMaxDefault, stageGateHoldMaxGrowthFactor, stageGateMeasuredPassWorst, want)
+	}
+	// And New() must actually install it.
+	s := New(Config{Workers: 1, Index: func(context.Context, string, string) error { return nil }})
+	if s.cfg.StageGateHoldMax != stageGateHoldMaxDefault {
+		t.Fatalf("New did not install the hold-max default: want %v got %v",
+			stageGateHoldMaxDefault, s.cfg.StageGateHoldMax)
+	}
+	if s.cfg.StageGateForfeitGrace != stageGateForfeitGraceDefault {
+		t.Fatalf("New did not install the forfeit-grace default: want %v got %v",
+			stageGateForfeitGraceDefault, s.cfg.StageGateForfeitGrace)
+	}
+}
+
+// forfeitTestScheduler builds a started scheduler whose group-algo pass wedges
+// until either its context is cancelled (respectCtx) or the returned unwedge
+// func is called.
+type forfeitHarness struct {
+	s         *Scheduler
+	indexRuns atomic.Int32
+	entered   chan struct{}
+	unwedge   func()
+	cancelled atomic.Bool
+}
+
+func newForfeitHarness(t *testing.T, holdMax, grace time.Duration, respectCtx bool) *forfeitHarness {
+	t.Helper()
+	h := &forfeitHarness{entered: make(chan struct{}, 1)}
+	release := make(chan struct{})
+	var once sync.Once
+	h.unwedge = func() { once.Do(func() { close(release) }) }
+
+	h.s = New(Config{
+		Workers:               1,
+		LinkDebounce:          time.Hour,
+		GroupAlgoDebounce:     5 * time.Millisecond,
+		GroupAlgoMaxWait:      time.Hour,
+		StageGateRetry:        5 * time.Millisecond,
+		StageGateMaxDefer:     time.Hour,
+		StageGateHoldMax:      holdMax,
+		StageGateForfeitGrace: grace,
+		Index: func(_ context.Context, _ string, _ string) error {
+			h.indexRuns.Add(1)
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			select {
+			case h.entered <- struct{}{}:
+			default:
+			}
+			if respectCtx {
+				select {
+				case <-ctx.Done():
+					h.cancelled.Store(true)
+				case <-release:
+				}
+				return ctx.Err()
+			}
+			<-release // wedged: ignores cancellation entirely
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	h.s.Start()
+	t.Cleanup(func() { h.unwedge(); h.s.Stop() })
+	return h
+}
+
+func (h *forfeitHarness) reap(now time.Time) {
+	h.s.mu.Lock()
+	h.s.reapStageLocked(now)
+	h.s.mu.Unlock()
+}
+
+func (h *forfeitHarness) holder() string {
+	h.s.mu.Lock()
+	defer h.s.mu.Unlock()
+	return h.s.stageHolder
+}
+
+func hasEvent(s *Scheduler, kind string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.recentLog {
+		if e.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// TestStageGate_ForfeitDoesNotAdmitWhileForfeitedStageIsAlive is the core
+// regression. The pre-fix forfeit cleared stageHolder and resumed admitting
+// while the forfeited child was still resident, so links and a still-live
+// group-algo became co-resident — the exact failure the gate exists to prevent,
+// observed on the real corpus at held_for=53m27s.
+func TestStageGate_ForfeitDoesNotAdmitWhileForfeitedStageIsAlive(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, time.Hour, false /* ignores ctx */)
+
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+
+	// Drive the hold-max past its bound and reap.
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now())
+
+	if !hasEvent(h.s, "stage_gate_forfeit") {
+		t.Fatal("no stage_gate_forfeit event — the forfeit must stay loud")
+	}
+	if got := h.s.StageGateState().Forfeits; got != 1 {
+		t.Fatalf("forfeit counter must be observable in the gate snapshot: want 1 got %d", got)
+	}
+	if got := h.s.Snapshot().StageForfeits; got != 1 {
+		t.Fatalf("forfeit counter must be observable in Snapshot: want 1 got %d", got)
+	}
+
+	// (a) The gate stays CLOSED to a second exclusive stage while the forfeited
+	// one is still alive.
+	h.s.mu.Lock()
+	acquired := h.s.tryAcquireStageLocked("links:acme", time.Now())
+	holder := h.s.stageHolder
+	h.s.mu.Unlock()
+	if acquired {
+		t.Fatal("a second exclusive stage acquired the token while the forfeited stage was still resident — " +
+			"this is the co-residency the gate exists to prevent")
+	}
+	if holder != "group-algo:acme" {
+		t.Fatalf("forfeited-but-alive holder must remain visible; got %q", holder)
+	}
+
+	// (b) Index dispatch is likewise still held.
+	h.s.Enqueue("/repo-a")
+	time.Sleep(200 * time.Millisecond)
+	if n := h.indexRuns.Load(); n != 0 {
+		t.Fatalf("index dispatch resumed while the forfeited stage was still resident (%d run(s))", n)
+	}
+}
+
+// TestStageGate_ForfeitDoesNotCancelTheStageOrRecomputeIt: the forfeit must not
+// destroy work. Releasing the token re-ran the forfeited pass (releaseStage →
+// links acquires → runLinks' success path calls scheduleGroupAlgo → a FRESH
+// group-algo), and cancelling it discards up to 53 minutes outright. Either way
+// a 32–53 minute pass is paid twice. So a forfeited stage is left alone to
+// finish, and the gate reopens on its own release.
+func TestStageGate_ForfeitDoesNotCancelTheStageOrRecomputeIt(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, time.Hour, true /* respects ctx */)
+
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now())
+
+	// The stage must NOT have been cancelled: it is still running, still
+	// holding, and its work is intact.
+	time.Sleep(150 * time.Millisecond)
+	if got := h.holder(); got != "group-algo:acme" {
+		t.Fatalf("a forfeited stage was cancelled or released; holder=%q, want it left alone to finish", got)
+	}
+	if h.cancelled.Load() {
+		t.Fatal("the forfeit cancelled the stage — up to 53 minutes of completed work discarded, " +
+			"and the pass then re-armed and recomputed from scratch")
+	}
+
+	// It finishes on its own; the gate reopens then, and only then.
+	h.unwedge()
+	waitFor(t, 3*time.Second, func() bool { return h.holder() == "" })
+	h.s.Enqueue("/repo-a")
+	waitFor(t, 3*time.Second, func() bool { return h.indexRuns.Load() >= 1 })
+}
+
+// TestStageGate_ForfeitGraceIsBoundedAndLateReturnerCannotStealToken: the
+// escape hatch. A stage that survives cancellation (an uninterruptible child)
+// must not wedge the daemon forever — after StageGateForfeitGrace the token is
+// abandoned, loudly, and index dispatch resumes. This is the ONE reachable
+// condition under which the gate degrades to no-gate, so it gets its own
+// event kind rather than sharing stage_gate_forfeit.
+func TestStageGate_ForfeitGraceIsBoundedAndLateReturnerCannotStealToken(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, 30*time.Millisecond, false /* ignores ctx */)
+
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+
+	// Past hold-max: forfeited, cancelled, still held.
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now())
+	if h.holder() == "" {
+		t.Fatal("token released before the forfeit grace elapsed")
+	}
+	// Past hold-max + grace: abandoned.
+	time.Sleep(60 * time.Millisecond)
+	h.reap(time.Now())
+
+	if h.holder() != "" {
+		t.Fatalf("forfeit grace did not bound the wedge — holder still %q", h.holder())
+	}
+	if !hasEvent(h.s, "stage_gate_forfeit_abandoned") {
+		t.Fatal("abandoning a forfeited stage must emit its own loud event")
+	}
+
+	// Index dispatch resumes.
+	h.s.Enqueue("/repo-a")
+	waitFor(t, 3*time.Second, func() bool { return h.indexRuns.Load() >= 1 })
+
+	// A successor takes the token...
+	waitFor(t, 3*time.Second, func() bool {
+		h.s.mu.Lock()
+		defer h.s.mu.Unlock()
+		return len(h.s.inflight) == 0
+	})
+	h.s.mu.Lock()
+	ok := h.s.tryAcquireStageLocked("links:acme", time.Now())
+	h.s.mu.Unlock()
+	if !ok {
+		t.Fatal("an abandoned token must be re-acquirable by a new stage")
+	}
+	// ...and the abandoned pass returning LATE must not steal it back.
+	h.unwedge()
+	time.Sleep(100 * time.Millisecond)
+	if got := h.holder(); got != "links:acme" {
+		t.Fatalf("a late-returning abandoned stage cleared the new holder's token (holder=%q)", got)
+	}
+	h.s.releaseStage("links:acme")
+}
+
+// TestStageGate_ForfeitGraceCancelsTheStage: reclaiming the token beside a
+// child nobody told to die is the co-residency the gate exists to prevent, so
+// the grace expiry must CANCEL first (SIGKILLing a group-algo subprocess) and
+// only then release. Without this the grace would be the old broken forfeit
+// with a longer fuse.
+func TestStageGate_ForfeitGraceCancelsTheStage(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, 30*time.Millisecond, true /* respects ctx */)
+
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now()) // tier 1: forfeit, no cancel
+	if h.cancelled.Load() {
+		t.Fatal("the forfeit itself cancelled the stage; only the grace expiry may")
+	}
+	time.Sleep(60 * time.Millisecond)
+	h.reap(time.Now()) // tier 2: cancel, then reclaim
+
+	waitFor(t, 3*time.Second, func() bool { return h.cancelled.Load() })
+	if got := h.holder(); got != "" {
+		t.Fatalf("token not reclaimed after the grace; holder=%q", got)
+	}
+}
+
+// TestStageGate_ForfeitLogMessageSaysWhatItDid: a forfeit means the epic's
+// central mechanism just intervened. The message must name the remedy, not read
+// as a shrug.
+func TestStageGate_ForfeitLogMessageSaysWhatItDid(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, time.Hour, false)
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now())
+
+	h.s.mu.Lock()
+	var msg string
+	for _, e := range h.s.recentLog {
+		if e.Kind == "stage_gate_forfeit" {
+			msg = e.Msg
+		}
+	}
+	h.s.mu.Unlock()
+	if msg == "" {
+		t.Fatal("no stage_gate_forfeit event recorded")
+	}
+	// The message must say what the gate DID (held the line), not read as a
+	// shrug that leaves the reader guessing whether the gate is still binding.
+	for _, want := range []string{"FORFEITED", "CLOSED", "not"} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("forfeit message must be unambiguous about the gate's state (missing %q): %q", want, msg)
+		}
+	}
+}
+
+// TestMemRelease_PendingStageDoesNotBlockRelease: busyLocked conflated "a stage
+// is WAITING" with "heavy work is in flight", so a permanently-deferred stage
+// starved FreeOSMemory — measured: 8+ hours without a single heap release, and
+// an idle floor that was mostly an un-returned watermark. A stage that is merely
+// pending is not doing work.
+func TestMemRelease_PendingStageDoesNotBlockRelease(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(s *Scheduler)
+	}{
+		{"deferred stage", func(s *Scheduler) { s.stageDeferSince["group-algo:acme"] = time.Now() }},
+		{"drain barrier", func(s *Scheduler) { s.stageDrainFor = "group-algo:acme" }},
+		{"pending group-algo", func(s *Scheduler) { s.groupAlgoPending["acme"] = true }},
+		{"pending links", func(s *Scheduler) { s.linkPending["acme"] = true }},
+		{"queued job", func(s *Scheduler) { s.pendingQ = append(s.pendingQ, "/repo-a") }},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var freed atomic.Int32
+			s := newMemTestScheduler(10*time.Second, func() { freed.Add(1) })
+			s.mu.Lock()
+			tc.setup(s)
+			s.mu.Unlock()
+
+			base := time.Now()
+			s.maybeReleaseMemory(base)
+			s.maybeReleaseMemory(base.Add(11 * time.Second))
+			if got := freed.Load(); got != 1 {
+				t.Fatalf("a merely-pending stage blocked the heap release; want 1 got %d", got)
+			}
+		})
+	}
+}
+
+// TestMemRelease_InFlightWorkStillBlocksRelease is the other half: releasing the
+// heap underneath genuinely in-flight work is what busyLocked was protecting
+// against, and splitting it must not regress that.
+func TestMemRelease_InFlightWorkStillBlocksRelease(t *testing.T) {
+	cases := []struct {
+		name  string
+		setup func(s *Scheduler)
+	}{
+		{"index in flight", func(s *Scheduler) { s.inflight["/repo"] = 1 }},
+		{"exclusive stage holding", func(s *Scheduler) { s.stageHolder = "group-algo:acme" }},
+		{"foreground barge", func(s *Scheduler) {
+			s.stageBarge = map[int64]bargeHold{1: {name: "rebuild:acme", since: time.Now()}}
+		}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var freed atomic.Int32
+			s := newMemTestScheduler(10*time.Second, func() { freed.Add(1) })
+			s.mu.Lock()
+			tc.setup(s)
+			s.mu.Unlock()
+
+			base := time.Now()
+			s.maybeReleaseMemory(base)
+			s.maybeReleaseMemory(base.Add(11 * time.Second))
+			s.maybeReleaseMemory(base.Add(60 * time.Second))
+			if got := freed.Load(); got != 0 {
+				t.Fatalf("released the heap under in-flight work; want 0 got %d", got)
+			}
+		})
+	}
+}

--- a/internal/daemon/sched/stagegate_forfeit_5954_test.go
+++ b/internal/daemon/sched/stagegate_forfeit_5954_test.go
@@ -160,11 +160,21 @@ func TestStageGate_ForfeitDoesNotAdmitWhileForfeitedStageIsAlive(t *testing.T) {
 	if got := h.s.Snapshot().StageForfeits; got != 1 {
 		t.Fatalf("forfeit counter must be observable in Snapshot: want 1 got %d", got)
 	}
+	// The counter is STICKY for the life of the daemon; it cannot answer "is a
+	// forfeit grace running right now", which is the state an operator looking
+	// at a stalled daemon is actually trying to identify. That live signal must
+	// be observable too, on both surfaces that reach `grafel status`.
+	if !h.s.StageGateState().ForfeitedHolder {
+		t.Fatal("StageGateState must report a LIVE forfeit grace, not only the sticky counter")
+	}
+	if !h.s.Snapshot().StageForfeitedHolder {
+		t.Fatal("Snapshot must report a LIVE forfeit grace, not only the sticky counter")
+	}
 
 	// (a) The gate stays CLOSED to a second exclusive stage while the forfeited
 	// one is still alive.
 	h.s.mu.Lock()
-	acquired := h.s.tryAcquireStageLocked("links:acme", time.Now())
+	_, acquired := h.s.tryAcquireStageLocked("links:acme", time.Now())
 	holder := h.s.stageHolder
 	h.s.mu.Unlock()
 	if acquired {
@@ -216,58 +226,122 @@ func TestStageGate_ForfeitDoesNotCancelTheStageOrRecomputeIt(t *testing.T) {
 	waitFor(t, 3*time.Second, func() bool { return h.indexRuns.Load() >= 1 })
 }
 
+// TestStageGate_AbandonedStageReturningWithNoSuccessorIsStillAnnounced pins the
+// PRIMARY timing of the abandoned-return event, which is the one with NO
+// successor.
+//
+// stage_gate_forfeit_abandoned is an open-ended ERROR: it says the gate is
+// non-binding and does not say when that stopped. stage_gate_abandoned_returned
+// is what closes it out. But the grace expiry has just cancelled the stage
+// (SIGKILLing its child), so the likeliest sequence by far is that it exits
+// within moments — BEFORE anything else acquires. Announcing the recovery only
+// once a successor happens to acquire would miss exactly the window an operator
+// is staring at the ERROR in, and would leave a quiet daemon looking permanently
+// degraded when it had recovered seconds later.
+//
+// Guarding the branch on `epoch < s.stageEpoch` (i.e. "a successor has already
+// acquired") gets this backwards, because clearStageHolderLocked does not bump
+// the epoch: with no successor the epoch is unchanged and the release falls
+// through in silence. The authorising release and the stale release are the only
+// two possibilities, so the stale one is the DEFAULT, not a narrower case.
+func TestStageGate_AbandonedStageReturningWithNoSuccessorIsStillAnnounced(t *testing.T) {
+	h := newForfeitHarness(t, 20*time.Millisecond, 30*time.Millisecond, false /* ignores ctx */)
+
+	h.s.scheduleGroupAlgo("acme")
+	<-h.entered
+
+	time.Sleep(40 * time.Millisecond)
+	h.reap(time.Now()) // tier 1: forfeit
+	time.Sleep(60 * time.Millisecond)
+	h.reap(time.Now()) // tier 2: cancel + abandon
+
+	if !hasEvent(h.s, "stage_gate_forfeit_abandoned") {
+		t.Fatal("precondition: the stage must have been abandoned")
+	}
+	// The abandoned pass now returns with NOTHING having acquired in between —
+	// the whole point of this case.
+	h.unwedge()
+	waitFor(t, 3*time.Second, func() bool { return hasEvent(h.s, "stage_gate_abandoned_returned") })
+
+	h.s.mu.Lock()
+	holder, epoch := h.s.stageHolder, h.s.stageEpoch
+	h.s.mu.Unlock()
+	if holder != "" || epoch != 1 {
+		t.Fatalf("precondition drifted: this test must exercise the NO-successor path "+
+			"(holder=%q epoch=%d, want \"\" and 1)", holder, epoch)
+	}
+}
+
 // TestStageGate_ForfeitGraceIsBoundedAndLateReturnerCannotStealToken: the
 // escape hatch. A stage that survives cancellation (an uninterruptible child)
 // must not wedge the daemon forever — after StageGateForfeitGrace the token is
 // abandoned, loudly, and index dispatch resumes. This is the ONE reachable
 // condition under which the gate degrades to no-gate, so it gets its own
 // event kind rather than sharing stage_gate_forfeit.
+//
+// It is parametrised over the SUCCESSOR'S NAME, and the same-name case is the
+// one that matters. The abandoned stage is `group-algo:acme`; the pass that
+// naturally follows an abandonment is a fresh `group-algo:acme` — the SAME
+// NAME. A release guarded only by `s.stageHolder == name` cannot tell the two
+// apart, so the late returner would clear its successor's token and admit a
+// THIRD stage beside two live ones: strictly worse than the state the
+// abandonment already advertises. Only a monotonic epoch captured at acquire
+// distinguishes them. The differently-named case is kept as the weaker control:
+// it passes under a name-only check, which is precisely why it could not catch
+// this.
 func TestStageGate_ForfeitGraceIsBoundedAndLateReturnerCannotStealToken(t *testing.T) {
-	h := newForfeitHarness(t, 20*time.Millisecond, 30*time.Millisecond, false /* ignores ctx */)
+	for _, successor := range []string{"links:acme", "group-algo:acme"} {
+		t.Run(successor, func(t *testing.T) {
+			h := newForfeitHarness(t, 20*time.Millisecond, 30*time.Millisecond, false /* ignores ctx */)
 
-	h.s.scheduleGroupAlgo("acme")
-	<-h.entered
+			h.s.scheduleGroupAlgo("acme")
+			<-h.entered
 
-	// Past hold-max: forfeited, cancelled, still held.
-	time.Sleep(40 * time.Millisecond)
-	h.reap(time.Now())
-	if h.holder() == "" {
-		t.Fatal("token released before the forfeit grace elapsed")
-	}
-	// Past hold-max + grace: abandoned.
-	time.Sleep(60 * time.Millisecond)
-	h.reap(time.Now())
+			// Past hold-max: forfeited, cancelled, still held.
+			time.Sleep(40 * time.Millisecond)
+			h.reap(time.Now())
+			if h.holder() == "" {
+				t.Fatal("token released before the forfeit grace elapsed")
+			}
+			// Past hold-max + grace: abandoned.
+			time.Sleep(60 * time.Millisecond)
+			h.reap(time.Now())
 
-	if h.holder() != "" {
-		t.Fatalf("forfeit grace did not bound the wedge — holder still %q", h.holder())
-	}
-	if !hasEvent(h.s, "stage_gate_forfeit_abandoned") {
-		t.Fatal("abandoning a forfeited stage must emit its own loud event")
-	}
+			if h.holder() != "" {
+				t.Fatalf("forfeit grace did not bound the wedge — holder still %q", h.holder())
+			}
+			if !hasEvent(h.s, "stage_gate_forfeit_abandoned") {
+				t.Fatal("abandoning a forfeited stage must emit its own loud event")
+			}
 
-	// Index dispatch resumes.
-	h.s.Enqueue("/repo-a")
-	waitFor(t, 3*time.Second, func() bool { return h.indexRuns.Load() >= 1 })
+			// Index dispatch resumes.
+			h.s.Enqueue("/repo-a")
+			waitFor(t, 3*time.Second, func() bool { return h.indexRuns.Load() >= 1 })
 
-	// A successor takes the token...
-	waitFor(t, 3*time.Second, func() bool {
-		h.s.mu.Lock()
-		defer h.s.mu.Unlock()
-		return len(h.s.inflight) == 0
-	})
-	h.s.mu.Lock()
-	ok := h.s.tryAcquireStageLocked("links:acme", time.Now())
-	h.s.mu.Unlock()
-	if !ok {
-		t.Fatal("an abandoned token must be re-acquirable by a new stage")
+			// A successor takes the token...
+			waitFor(t, 3*time.Second, func() bool {
+				h.s.mu.Lock()
+				defer h.s.mu.Unlock()
+				return len(h.s.inflight) == 0
+			})
+			h.s.mu.Lock()
+			_, ok := h.s.tryAcquireStageLocked(successor, time.Now())
+			h.s.mu.Unlock()
+			if !ok {
+				t.Fatal("an abandoned token must be re-acquirable by a new stage")
+			}
+			// ...and the abandoned pass returning LATE must not steal it back,
+			// even when it shares the successor's name.
+			h.unwedge()
+			time.Sleep(100 * time.Millisecond)
+			if got := h.holder(); got != successor {
+				t.Fatalf("a late-returning abandoned stage cleared the new holder's token (holder=%q, want %q)", got, successor)
+			}
+			h.s.mu.Lock()
+			h.s.clearStageHolderLocked()
+			h.s.mu.Unlock()
+		})
 	}
-	// ...and the abandoned pass returning LATE must not steal it back.
-	h.unwedge()
-	time.Sleep(100 * time.Millisecond)
-	if got := h.holder(); got != "links:acme" {
-		t.Fatalf("a late-returning abandoned stage cleared the new holder's token (holder=%q)", got)
-	}
-	h.s.releaseStage("links:acme")
 }
 
 // TestStageGate_ForfeitGraceCancelsTheStage: reclaiming the token beside a
@@ -389,5 +463,63 @@ func TestMemRelease_InFlightWorkStillBlocksRelease(t *testing.T) {
 				t.Fatalf("released the heap under in-flight work; want 0 got %d", got)
 			}
 		})
+	}
+}
+
+// TestMemRelease_LeakedBargeIsReapedAndStopsBlockingRelease: making the barge
+// gate FreeOSMemory (the test above) created a net-new way to wedge the heap
+// release, because workInFlightLocked read bargeHeldLocked WITHOUT reaping
+// first — in violation of that function's stated contract. Every other reap
+// site is a gate DECISION (acquire/admit/defer), and an idle daemon makes none,
+// so on the one machine state where FreeOSMemory matters most there was nothing
+// left to expire a leaked hold: a foreground goroutine that vanished without
+// unwinding its release would have blocked the heap release forever. Pre-commit
+// the barge did not gate the release at all, so this exposure is entirely the
+// gate's own to bound.
+//
+// Driven on a fully SYNTHETIC clock, which is also the point of threading `now`
+// into workInFlightLocked rather than letting it read time.Now(): with a wall
+// clock inside, advancing `now` past StageGateBargeMax here would not reap, and
+// this assertion would pass or fail on real elapsed time instead of on the bound
+// it claims to test.
+func TestMemRelease_LeakedBargeIsReapedAndStopsBlockingRelease(t *testing.T) {
+	const (
+		debounce = 10 * time.Second
+		bargeMax = 30 * time.Minute
+	)
+	var freed atomic.Int32
+	s := newMemTestScheduler(debounce, func() { freed.Add(1) })
+	s.cfg.StageGateBargeMax = bargeMax
+
+	base := time.Now()
+	// A hold whose release closure was never called — the leak the backstop
+	// exists for.
+	s.mu.Lock()
+	s.stageBarge = map[int64]bargeHold{1: {name: "rebuild:acme", since: base}}
+	s.mu.Unlock()
+
+	// Well past the debounce but inside the backstop: the barge is still a live
+	// foreground hold and must keep blocking.
+	s.maybeReleaseMemory(base)
+	s.maybeReleaseMemory(base.Add(debounce + time.Second))
+	if got := freed.Load(); got != 0 {
+		t.Fatalf("a live barge must still block the heap release; want 0 got %d", got)
+	}
+
+	// Past StageGateBargeMax the hold is reclaimed BY THIS PATH — there is no
+	// gate decision anywhere in this test to reap it, which is the whole point:
+	// an idle daemon makes none.
+	after := base.Add(bargeMax + time.Second)
+	s.maybeReleaseMemory(after)
+	s.mu.Lock()
+	n := len(s.stageBarge)
+	s.mu.Unlock()
+	if n != 0 {
+		t.Fatalf("the leaked barge was never reaped by the heap-release path; %d hold(s) remain", n)
+	}
+	// ...and the release then serves out a fresh debounce and fires.
+	s.maybeReleaseMemory(after.Add(debounce + time.Second))
+	if got := freed.Load(); got != 1 {
+		t.Fatalf("heap release still starved after the leaked barge expired; want 1 got %d", got)
 	}
 }

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -445,6 +445,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateDeferred = snap.StageDeferred
 		reply.StageGateBarging = snap.Barging
 		reply.StageGateForfeits = snap.StageForfeits
+		reply.StageGateForfeitedHolder = snap.StageForfeitedHolder
 	} else if g, ok := StageGateFromStatusFile(); ok {
 		// SPLIT MODE (the default): the scheduler lives in the ENGINE process,
 		// so the serve process answering this RPC has s.scheduler == nil and
@@ -463,6 +464,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateDeferred = g.Deferred
 		reply.StageGateBarging = g.Barging
 		reply.StageGateForfeits = g.Forfeits
+		reply.StageGateForfeitedHolder = g.ForfeitedHolder
 	}
 	return nil
 }

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -444,6 +444,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateHolder = snap.StageHolder
 		reply.StageGateDeferred = snap.StageDeferred
 		reply.StageGateBarging = snap.Barging
+		reply.StageGateForfeits = snap.StageForfeits
 	} else if g, ok := StageGateFromStatusFile(); ok {
 		// SPLIT MODE (the default): the scheduler lives in the ENGINE process,
 		// so the serve process answering this RPC has s.scheduler == nil and
@@ -461,6 +462,7 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateHolder = g.Holder
 		reply.StageGateDeferred = g.Deferred
 		reply.StageGateBarging = g.Barging
+		reply.StageGateForfeits = g.Forfeits
 	}
 	return nil
 }

--- a/internal/daemon/service_stagegate_5954_test.go
+++ b/internal/daemon/service_stagegate_5954_test.go
@@ -15,6 +15,7 @@ package daemon
 // scheduler (monolith) and the engine-liveness status sidecar (split mode).
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -76,6 +77,90 @@ func TestStatus_StageGateFieldsFromInProcessScheduler(t *testing.T) {
 	}
 }
 
+// TestStatus_ForfeitedHolderFromInProcessScheduler pins the MONOLITH half of
+// the live forfeit signal, driving a real forfeit through a real scheduler
+// rather than asserting on a hand-built snapshot.
+//
+// The split-mode test below covers the sidecar route, but monolith mode reads a
+// different line in Service.Status (snap.StageForfeitedHolder, not
+// g.ForfeitedHolder). Deleting that line left the whole daemon suite green until
+// this test existed — the two branches have to be pinned separately or one of
+// them silently reports nothing.
+func TestStatus_ForfeitedHolderFromInProcessScheduler(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	svc := newStageGateTestService(t)
+
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	s := sched.New(sched.Config{
+		Workers: 1,
+		// An index chains to the LINK pass, and group-algo is chained off the
+		// link pass's success path (#5349 A3) — so links must be allowed to run
+		// or the group-algo pass this test needs is never scheduled at all.
+		LinkDebounce:      time.Millisecond,
+		GroupAlgoDebounce: time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    5 * time.Millisecond,
+		StageGateMaxDefer: time.Hour,
+		// Forfeit almost immediately, but never reach the grace: this test is
+		// about the FORFEITED-AND-STILL-HELD state, which is the whole point of
+		// a live signal the sticky counter cannot express.
+		StageGateHoldMax:      10 * time.Millisecond,
+		StageGateForfeitGrace: time.Hour,
+		Index:                 func(context.Context, string, string) error { return nil },
+		Links:                 func(context.Context, string) error { return nil },
+		GroupAlgo: func(context.Context, string) error {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release // wedged past hold-max
+			return nil
+		},
+		GroupsForRepo:      func(string) []string { return []string{"acme"} },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer func() { close(release); s.Stop() }()
+	svc.scheduler = s
+
+	// An index job schedules the group-algo pass, which takes the token and wedges.
+	s.Enqueue("/repo-a")
+	select {
+	case <-entered:
+	case <-time.After(10 * time.Second):
+		t.Fatal("group-algo never started; cannot exercise the forfeit path")
+	}
+
+	// The forfeit is declared by the next gate DECISION, not by a timer, so poke
+	// the admit loop into making one.
+	deadline := time.Now().Add(10 * time.Second)
+	var reply proto.StatusReply
+	for {
+		s.Enqueue("/repo-b")
+		reply = proto.StatusReply{}
+		if err := svc.Status(&proto.StatusArgs{}, &reply); err != nil {
+			t.Fatalf("Status RPC: %v", err)
+		}
+		// Require the WEDGED holder specifically. The instantaneous link pass
+		// shares this gate and could in principle be the one caught by a reap,
+		// which would satisfy a bare ForfeitedHolder check without exercising
+		// what this test is about.
+		if reply.StageGateForfeitedHolder && reply.StageGateHolder == "group-algo:acme" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("StageGateForfeitedHolder never became true for the wedged group-algo in monolith mode "+
+				"(holder=%q forfeited=%v forfeits=%d): the live forfeit-grace signal does not reach the status RPC",
+				reply.StageGateHolder, reply.StageGateForfeitedHolder, reply.StageGateForfeits)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if reply.StageGateForfeits < 1 {
+		t.Errorf("StageGateForfeits = %d, want >= 1 alongside the live signal", reply.StageGateForfeits)
+	}
+}
+
 // TestStatus_StageGateFieldsFromEngineLivenessSidecarInSplitMode is the split-
 // mode half, and the one that actually matters: serve has NO scheduler, so the
 // only route is the engine's liveness sidecar. Without the fallback this reply
@@ -88,10 +173,12 @@ func TestStatus_StageGateFieldsFromEngineLivenessSidecarInSplitMode(t *testing.T
 	}
 
 	writeStageGateLivenessFixture(t, &statusfile.File{
-		HeartbeatAt:       time.Now().UTC(),
-		StageGateHolder:   "group-algo:acme",
-		StageGateDeferred: []string{"links:acme"},
-		StageGateBarging:  []string{"rebuild:acme"},
+		HeartbeatAt:              time.Now().UTC(),
+		StageGateHolder:          "group-algo:acme",
+		StageGateDeferred:        []string{"links:acme"},
+		StageGateBarging:         []string{"rebuild:acme"},
+		StageGateForfeits:        2,
+		StageGateForfeitedHolder: true,
 	})
 
 	var reply proto.StatusReply
@@ -100,6 +187,18 @@ func TestStatus_StageGateFieldsFromEngineLivenessSidecarInSplitMode(t *testing.T
 	}
 	if reply.StageGateHolder != "group-algo:acme" {
 		t.Errorf("StageGateHolder = %q, want %q", reply.StageGateHolder, "group-algo:acme")
+	}
+	if reply.StageGateForfeits != 2 {
+		t.Errorf("StageGateForfeits = %d, want 2", reply.StageGateForfeits)
+	}
+	// The LIVE forfeit signal, which is the one an operator looking at a stalled
+	// daemon actually needs: FORFEITS=n is sticky for the life of the daemon and
+	// cannot answer "is a forfeit grace running right now". It crosses the
+	// engine→serve boundary by exactly the same route as the rest, and in split
+	// mode — the default — that route is the ONLY one.
+	if !reply.StageGateForfeitedHolder {
+		t.Errorf("StageGateForfeitedHolder = false, want true: the live 'inside a forfeit grace' signal " +
+			"must survive the sidecar round trip, or it is invisible in the default deployment mode")
 	}
 	if len(reply.StageGateDeferred) != 1 || reply.StageGateDeferred[0] != "links:acme" {
 		t.Errorf("StageGateDeferred = %v, want [links:acme]", reply.StageGateDeferred)
@@ -141,9 +240,11 @@ func TestStatus_StageGateFieldsOmittedWhenSidecarStale(t *testing.T) {
 func TestEngineLivenessHeartbeat_PublishesStageGateState(t *testing.T) {
 	root := t.TempDir()
 	gate := sched.StageGateState{
-		Holder:   "group-algo:acme",
-		Deferred: []string{"links:acme"},
-		Barging:  []string{"rebuild:acme"},
+		Holder:          "group-algo:acme",
+		Deferred:        []string{"links:acme"},
+		Barging:         []string{"rebuild:acme"},
+		Forfeits:        2,
+		ForfeitedHolder: true,
 	}
 	stop := startEngineLivenessHeartbeat(root, 0, nil, func() sched.StageGateState { return gate }, nil)
 	stop() // writeOnce has already run synchronously before the ticker loop
@@ -160,5 +261,15 @@ func TestEngineLivenessHeartbeat_PublishesStageGateState(t *testing.T) {
 	}
 	if len(f.StageGateBarging) != 1 || f.StageGateBarging[0] != "rebuild:acme" {
 		t.Errorf("StageGateBarging = %v, want [rebuild:acme]", f.StageGateBarging)
+	}
+	if f.StageGateForfeits != 2 {
+		t.Errorf("StageGateForfeits = %d, want 2", f.StageGateForfeits)
+	}
+	// The heartbeat is the ONLY writer of the split-mode route, so a field the
+	// reader handles but the writer never stamps is dead in the default
+	// deployment mode while looking wired end to end.
+	if !f.StageGateForfeitedHolder {
+		t.Errorf("StageGateForfeitedHolder = false, want true: the heartbeat must publish the live " +
+			"forfeit-grace signal, not only the sticky counter")
 	}
 }

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -418,6 +418,7 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 			f.StageGateDeferred = g.Deferred
 			f.StageGateBarging = g.Barging
 			f.StageGateForfeits = g.Forfeits
+			f.StageGateForfeitedHolder = g.ForfeitedHolder
 		}
 		if err := statusfile.Write(key, f); err != nil && logger != nil {
 			logger.Warn("engine liveness: statusfile write failed", "err", err)

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -417,6 +417,7 @@ func startEngineLivenessHeartbeat(root string, interval time.Duration, warmingFn
 			f.StageGateHolder = g.Holder
 			f.StageGateDeferred = g.Deferred
 			f.StageGateBarging = g.Barging
+			f.StageGateForfeits = g.Forfeits
 		}
 		if err := statusfile.Write(key, f); err != nil && logger != nil {
 			logger.Warn("engine liveness: statusfile write failed", "err", err)

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -196,6 +196,9 @@ type File struct {
 	StageGateHolder   string   `json:"stage_gate_holder,omitempty"`
 	StageGateDeferred []string `json:"stage_gate_deferred,omitempty"`
 	StageGateBarging  []string `json:"stage_gate_barging,omitempty"`
+	// StageGateForfeits counts stages that blew StageGateHoldMax since daemon
+	// start — a FAILURE counter, see proto.StatusReply.
+	StageGateForfeits int64 `json:"stage_gate_forfeits,omitempty"`
 
 	// --- Process metrics (wizard CPU/RAM readout) ---
 	// These are only meaningful on the ENGINE-LIVENESS sidecar (same scope as

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -199,6 +199,10 @@ type File struct {
 	// StageGateForfeits counts stages that blew StageGateHoldMax since daemon
 	// start — a FAILURE counter, see proto.StatusReply.
 	StageGateForfeits int64 `json:"stage_gate_forfeits,omitempty"`
+	// StageGateForfeitedHolder is the LIVE half of that counter: the holder
+	// named above is past its hold-max right now and the gate is inside a
+	// forfeit grace. See proto.StatusReply.
+	StageGateForfeitedHolder bool `json:"stage_gate_forfeited_holder,omitempty"`
 
 	// --- Process metrics (wizard CPU/RAM readout) ---
 	// These are only meaningful on the ENGINE-LIVENESS sidecar (same scope as


### PR DESCRIPTION
## What

Two changes to the heavy write-stage gate:

1. **Size `hold_max` from the measured worst pass.** It was 15 minutes. A legitimate `group-algo` pass on the corpus group was observed holding for **53m27s**. `stageGateHoldMaxDefault` is now derived as `4 x stageGateMeasuredPassWorst (54m)` = 4h, with the derivation in code rather than a hand-picked constant.

2. **A forfeit no longer releases the token**, and the holder's identity is an **epoch**, not a name.

## Why this matters more than it looks

The 15-minute `hold_max` was not merely impatient — it triggered a full recompute:

```
11:51:51 ERROR  heavy write-stage token forfeited after hold-max —
                a stage or its subprocess never returned
                stage=group-algo:monorepo-corpus held_for=53m27s hold_max=15m0s
12:10:43 INFO   group-algo: starting  group=monorepo-corpus cap=2
```

Forfeiting released the token, which admitted a parked links pass. `runLinks` succeeding calls `scheduleGroupAlgo`, which calls `cancelGroupAlgoLocked`, which cancels the in-flight pass via `exec.CommandContext` — i.e. **SIGKILL of the live group-algo child** — and re-arms it from zero. So a healthy 32-53 minute pass was killed and restarted every cycle.

Verified by an independent reviewer tracing every `scheduleGroupAlgo` caller. With the forfeit no longer releasing, links cannot acquire, so that path is unreachable while a group-algo holds.

## The epoch

`releaseStage` matched the holder by **name**, a plain string compare, while a comment claimed an identity check existed. The case the gate cares most about is `group-algo:acme` abandoned then a fresh `group-algo:acme` acquiring — **the same name**. A probe confirmed a late-returning abandoned stage could clear the *successor's* token, admitting a third stage alongside two live ones.

`Scheduler.stageEpoch` is now bumped on every acquire and returned from `tryAcquireStageLocked`, so a caller cannot acquire without capturing one. `releaseStage` and `setStageCancelLocked` match on the `(name, epoch)` pair.

`setStageCancelLocked` takes the epoch as belt-and-braces only: both call sites hold `s.mu` unbroken from acquire to set, so a name-only check is provably still correct there. It takes the epoch so the package has one spelling of the identity check.

## Degradation is bounded and announced

A forfeited holder enters a 30m grace, after which the gate cancels the stage (it does hold a `stageCancel` handle) and only then reclaims the token. If the stage survives SIGKILL for the full grace, the gate declares itself non-binding for that stage and says so, rather than quietly overlapping. A late return now emits `stage_gate_abandoned_returned`, closing out the otherwise open-ended ERROR.

`ForfeitedHolder` is plumbed to `grafel status`, so "we are inside a forfeit grace right now" is visible live rather than only as a sticky counter.

## `busyLocked` split

`busyLocked` is split into `workInFlightLocked` / `workPendingLocked`. Heap release now gates on in-flight work only. Previously a deferred stage re-set its pending flag on every retry, so `FreeOSMemory` was starvable without bound — 8 hours was observed. The original rule (#3648) was a thrash-cost argument written before the stage gate existed; a *running* pass sets `stageHolder` and still blocks release, so the correctness intent is preserved.

`workInFlightLocked` also counts a held foreground barge, closing a pre-existing hole where a scavenge could fire mid-rebuild.

## Verification

Independently adversarially reviewed twice. All mutations die:

| Mutation | Result |
|---|---|
| `hold_max` back to 15m | dies |
| shrink the measured constant so the ratio still holds | dies (cannot pin the bug) |
| forfeit releases the token | dies |
| forfeit cancels immediately | dies |
| grace never expires | dies |
| `stageCancel` never registered | dies |
| heap release re-gated on `busyLocked` | dies |
| `releaseStage` matches on name only | dies |
| epoch never bumped | dies |
| each of the 6 `ForfeitedHolder` hops | dies |

`go build`, `go vet`, `gofmt -l` clean. `./internal/daemon/... ./cmd/grafel/... -count=1 -p 3` → 1279 passed. `./internal/daemon/sched/... -race -count=4 -p 2` → 680 passed.

`TestRunSubprocessLinks_CancelTerminatesChild` is pre-existing flaky on the base commit and is tracked separately as #5999.

## Not fixed here

`fireGroupAlgo` blind-deletes its group cancel handle, so a late return can drop a live successor's handle. Pre-existing, same reachability window, filed as #6001 to keep this commit reviewable.

Refs #5954
