### PR TITLE
perf(#5954): collapse the post-rebuild analytics batch to one streaming scan per repo

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -47,6 +47,7 @@ import (
 	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/progress"
 	"github.com/cajasmota/grafel/internal/quality"
+	"github.com/cajasmota/grafel/internal/quality/analytics"
 	"github.com/cajasmota/grafel/internal/quality/audit"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/repolock"
@@ -1843,10 +1844,17 @@ func daemonRebuildFuncCore(
 	return rebuilt, warning, nil
 }
 
-// buildAgentsMapStats loads the per-repo graph artefacts produced by the
+// buildAgentsMapStats reads the per-repo graph artefacts produced by the
 // just-completed index and assembles the Stats struct passed to
 // agents.InjectArchitectureMap. It is intentionally best-effort — any read
 // failure yields a zero-valued field rather than an error.
+//
+// #5954: this was the FOURTH full graph.LoadGraphFromDir per repo per rebuild —
+// ~608 MB of materialised heap for a 325 MB graph, to produce six integers. It
+// is now a kind-only streaming tally over the mmap (analytics.TallyRepo), which
+// materialises nothing. The counts and the kind rules are unchanged; see
+// analytics.TallyDocument, the materialised reference the tally is tested
+// against.
 func buildAgentsMapStats(group, repoPath string) agents.Stats {
 	stateDir := daemon.StateDirForRepo(repoPath)
 
@@ -1855,43 +1863,29 @@ func buildAgentsMapStats(group, repoPath string) agents.Stats {
 		DashboardPort: resolveDefaultDashboardPort(),
 	}
 
-	// Read graph.fb for per-kind entity breakdown. Falls back gracefully if the
-	// file is absent or the FB decoder is unavailable.
-	if doc, err := loadGraphFromStateDir(stateDir); err == nil && doc != nil {
-		s.Entities = doc.Stats.Entities
-		s.Relationships = doc.Stats.Relationships
-		for _, e := range doc.Entities {
-			switch e.Kind {
-			// #1217: count all three http endpoint kind strings.
-			case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
-				s.HTTPEndpoints++
-			case "queue":
-				s.Queues++
-			case "topic", "pubsub_topic":
-				s.Topics++
-			}
-			if strings.HasPrefix(e.Kind, "SCOPE.Process") || e.Kind == "process" {
-				s.ProcessFlows++
-			}
-		}
+	if t, err := analytics.TallyRepo(stateDir); err == nil {
+		s.Entities = t.Entities
+		s.Relationships = t.Relationships
+		s.HTTPEndpoints = t.HTTPEndpoints
+		s.Queues = t.Queues
+		s.Topics = t.Topics
+		s.ProcessFlows = t.ProcessFlows
 	}
 
 	return s
 }
 
-// loadGraphFromStateDir is a thin wrapper around graph.LoadGraphFromDir that
-// isolates the graph-loading call used by buildAgentsMapStats. Keeping it
-// separate makes it easy to stub in tests without touching the full graph
-// package.
-func loadGraphFromStateDir(stateDir string) (*graph.Document, error) {
-	return graph.LoadGraphFromDir(stateDir)
-}
-
 // daemonQualityAuditFunc is the QualityAuditFunc handed to daemon.Run.
 // It calls audit.AuditPath (in this process — the daemon process) and
 // serialises the result into the wire reply.
+//
+// #5954: it audits with ONE worker, not audit's CLI default of four. A corpus
+// audit's fan-out is peak heap — each worker holds a full graph.Document — and
+// this runs inside the long-lived daemon, on behalf of an RPC that is not a
+// latency-critical path. The report is byte-identical at any pool size
+// (auditMany writes into a pre-sized slice by index).
 func daemonQualityAuditFunc(args proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
-	rep, err := audit.AuditPath(args.RepoPath, args.Corpus)
+	rep, err := audit.AuditPathWithWorkers(args.RepoPath, args.Corpus, 1)
 	if err != nil {
 		return proto.QualityAuditReply{}, err
 	}

--- a/cmd/grafel/daemon_rebuild_barge_5954_test.go
+++ b/cmd/grafel/daemon_rebuild_barge_5954_test.go
@@ -34,7 +34,19 @@ import (
 // startBargeObserverScheduler starts a minimal real scheduler so the process
 // bridge (sched.BargeForeground) resolves to something observable, and returns
 // a func reporting how many foreground barge holds are live right now.
+//
+// It counts ALL live holds. Use startRebuildBargeObserver in tests whose
+// subject is the rebuild's own hold: the post-rebuild analytics batch takes its
+// own barge from a goroutine that outlives daemonRebuildFuncCore (#5954), so an
+// unscoped count is both wrong and racy for those assertions.
 func startBargeObserverScheduler(t *testing.T) func() int {
+	names := startBargeObserverSchedulerNames(t)
+	return func() int { return len(names()) }
+}
+
+// startBargeObserverSchedulerNames is the same observer, returning the live
+// holder names so a caller can scope its assertion to one of them.
+func startBargeObserverSchedulerNames(t *testing.T) func() []string {
 	t.Helper()
 	s := sched.New(sched.Config{
 		Workers:            1,
@@ -50,7 +62,26 @@ func startBargeObserverScheduler(t *testing.T) func() int {
 	})
 	s.Start()
 	t.Cleanup(s.Stop)
-	return func() int { return len(s.Snapshot().Barging) }
+	return func() []string { return s.Snapshot().Barging }
+}
+
+// startRebuildBargeObserver is startBargeObserverScheduler scoped to the
+// REBUILD's own foreground hold. The three tests below assert that
+// daemonRebuildFuncCore acquires and unwinds its barge; the analytics batch's
+// independent, asynchronous hold is not their subject and must not make them
+// flake. Deleting the rebuild's acquisition still fails them.
+func startRebuildBargeObserver(t *testing.T) func() int {
+	t.Helper()
+	all := startBargeObserverSchedulerNames(t)
+	return func() int {
+		n := 0
+		for _, name := range all() {
+			if strings.HasPrefix(name, "rebuild:") {
+				n++
+			}
+		}
+		return n
+	}
 }
 
 // TestRebuild_HoldsForegroundBargeAcrossIndexAndLinks: while daemonRebuildFuncCore
@@ -60,7 +91,7 @@ func startBargeObserverScheduler(t *testing.T) func() int {
 // entirely outside the scheduler's view.
 func TestRebuild_HoldsForegroundBargeAcrossIndexAndLinks(t *testing.T) {
 	group := setupTestGroup(t, "barge-group", []string{"first", "second"})
-	barges := startBargeObserverScheduler(t)
+	barges := startRebuildBargeObserver(t)
 
 	var duringIndex, duringLinks atomic.Int32
 	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
@@ -98,7 +129,7 @@ func TestRebuild_HoldsForegroundBargeAcrossIndexAndLinks(t *testing.T) {
 // forever behind a rebuild that is long gone.
 func TestRebuild_ReleasesForegroundBargeOnError(t *testing.T) {
 	_ = setupTestGroup(t, "barge-err-group", []string{"only"})
-	barges := startBargeObserverScheduler(t)
+	barges := startRebuildBargeObserver(t)
 
 	failIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
 	_, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: "no-such-group"}, failIndexFn, noopLinksFn)
@@ -115,7 +146,7 @@ func TestRebuild_ReleasesForegroundBargeOnError(t *testing.T) {
 // cancellation error. That path must release the barge too.
 func TestRebuild_ReleasesForegroundBargeOnGroupCancel(t *testing.T) {
 	group := setupTestGroup(t, "barge-cancel-group", []string{"first", "second"})
-	barges := startBargeObserverScheduler(t)
+	barges := startRebuildBargeObserver(t)
 
 	var once sync.Once
 	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {

--- a/cmd/grafel/rebuild_history.go
+++ b/cmd/grafel/rebuild_history.go
@@ -5,6 +5,31 @@ package main
 //
 // All metric collection is best-effort: errors are logged and silently
 // skipped so a failed scan never blocks the rebuild response.
+//
+// #5954 — ONE PASS, AND VISIBLE.
+//
+// This batch used to walk every repo's graph FOUR times, each walk going
+// through graph.LoadGraphFromDir (the full-materialise loader: ~608 MB of heap
+// for a 325 MB graph.fb):
+//
+//	1. audit.AuditPath        — orphan rate + IMPORTS hygiene
+//	2. loadGraphFromStateDir  — coverage + import cycles + endpoint/flow tallies
+//	3. countAuthUncoveredEndpoints — a third load, for one integer
+//	4. buildAgentsMapStats    — a fourth load, in the index loop
+//
+// Every one of those numbers is a counting scan over the same rows. They are
+// now computed by internal/quality/analytics in a SINGLE pass over a single
+// open, mmap-backed view of each repo's graph — no Document is materialised at
+// all. See that package for what survives a scan (id-keyed sets) and what does
+// not (rows).
+//
+// The batch also ran in a bare `go func(){}` that took no stage-gate token and
+// was invisible to the scheduler's busyLocked() accounting, so it could
+// co-reside with the link and group-algo children the epic had just forked out
+// of the engine, and it distorted the debounced FreeOSMemory release. It now
+// registers a foreground hold on the heavy write-stage gate for its whole
+// window — see the comment on the registration below for why a barge rather
+// than the EXCLUSIVE token.
 
 import (
 	"fmt"
@@ -12,12 +37,17 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/quality"
-	"github.com/cajasmota/grafel/internal/quality/audit"
+	"github.com/cajasmota/grafel/internal/quality/analytics"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/secrets"
 )
+
+// scanRepoAnalytics is the single-pass, mmap-backed analytics scan. Indirected
+// so tests can prove the whole batch touches each repo's graph exactly once.
+var scanRepoAnalytics = analytics.ScanRepo
 
 // appendRebuildHistory measures the current graph quality for a group and
 // appends one HealthEntry to the JSONL history file.
@@ -30,29 +60,63 @@ import (
 // The function is designed to run in a goroutine: all errors are surfaced
 // via the returned error rather than panicking.
 func appendRebuildHistory(root, group string, cfg *registry.GroupConfig, rebuiltPaths []string) error {
+	// Register with the heavy write-stage gate for the whole batch (#5954).
+	//
+	// WHY A BARGE, NOT THE EXCLUSIVE TOKEN. The exclusive token is for stages
+	// that must be serialised against each other and that can afford to DEFER
+	// and retry — the link pass and group-algo both re-arm their own timers and
+	// lose no work when they yield. This batch has neither property: it has no
+	// retry timer (it fires exactly once, at the end of a rebuild, and a skipped
+	// run is a permanently missing history point), and taking a token that
+	// background stages block on would make a metrics write able to stall real
+	// write-side work. The barge is the registration built for precisely this
+	// shape — out-of-scheduler work that must never wait but must be SEEN: it
+	// records unconditionally, returns immediately, makes background exclusive
+	// stages defer around the batch instead of co-residing with it, and (with
+	// the busyLocked() clause added alongside this change) stops the debounced
+	// FreeOSMemory from firing underneath a walk of the whole corpus graph.
+	//
+	// `defer release()` so the registration unwinds on every exit path,
+	// including the early error returns below.
+	defer sched.BargeForeground("analytics:" + group)()
+
 	entry := quality.HealthEntry{
 		Timestamp: time.Now().UTC(),
 		Group:     group,
 	}
 
-	// ── Core metrics (orphan + bug rate) ─────────────────────────────────────
-	// Re-use the audit machinery that handleQualityComposite uses.
+	// ── one scan per repo, every metric folded from it ───────────────────────
 	totalEntities := 0
 	totalOrphans := 0
 	totalImports := 0
 	goodImports := 0
+	totalProduction := 0
+	coveredProduction := 0
+	totalCycles := 0
+	totalFlows := 0
+	totalEndpoints := 0
+	authUncovered := 0
+	scanned := false
 
 	for _, repoPath := range rebuiltPaths {
-		rep, err := audit.AuditPath(repoPath, false)
-		if err != nil || len(rep.Repos) == 0 {
+		sc, err := scanRepoAnalytics(stateDirForRepoPath(repoPath))
+		if err != nil {
 			continue
 		}
-		rr := rep.Repos[0]
-		totalEntities += rr.Entities
-		totalOrphans += rr.Orphans
-		totalImports += rr.ImportsTotal
-		goodImports += rr.ImportsToIDFormat[audit.ImportFormatHex] +
-			rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+		scanned = true
+
+		totalEntities += sc.Entities
+		totalOrphans += sc.Orphans
+		totalImports += sc.ImportsTotal
+		goodImports += sc.ImportsResolved
+
+		totalProduction += sc.TotalProduction
+		coveredProduction += sc.CoveredProduction
+		totalCycles += sc.Cycles
+
+		totalEndpoints += sc.Endpoints
+		totalFlows += sc.Flows
+		authUncovered += sc.AuthUncovered
 	}
 
 	entry.TotalEntities = totalEntities
@@ -64,60 +128,16 @@ func appendRebuildHistory(root, group string, cfg *registry.GroupConfig, rebuilt
 	}
 	entry.HealthScore = quality.ComputeHealthScore(entry.OrphanRate, entry.BugRate)
 
-	// ── Coverage + cycles + entity counts ────────────────────────────────────
-	// Walk all repos in the group and aggregate graph-level stats.
-	totalProduction := 0
-	coveredProduction := 0
-	totalCycles := 0
-	totalFlows := 0
-	totalEndpoints := 0
-	hasCoverage := false
-	hasCycles := false
-
-	for _, repoPath := range rebuiltPaths {
-		stateDir := stateDirForRepoPath(repoPath)
-		doc, err := loadGraphFromStateDir(stateDir)
-		if err != nil || doc == nil {
-			continue
-		}
-
-		// Coverage.
-		cov := graph.ComputeCoverage(doc)
-		hasCoverage = true
-		totalProduction += cov.TotalProduction
-		coveredProduction += cov.CoveredProduction
-
-		// Cycles. Pass nil pagerank — uniform weights are fine for counting.
-		cycles := graph.FindImportCycles(doc.Entities, doc.Relationships, nil)
-		hasCycles = true
-		totalCycles += len(cycles)
-
-		// Entity type counts.
-		for _, e := range doc.Entities {
-			switch e.Kind {
-			case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
-				totalEndpoints++
-			}
-			if isProcessFlow(e) {
-				totalFlows++
-			}
-		}
-	}
-
 	entry.TotalFlows = totalFlows
 	entry.TotalEndpoints = totalEndpoints
 
-	if hasCoverage && totalProduction > 0 {
+	if scanned && totalProduction > 0 {
 		covPct := 100.0 * float64(coveredProduction) / float64(totalProduction)
 		entry.CoveragePct = &covPct
 	}
-	if hasCycles {
+	if scanned {
 		entry.Cycles = &totalCycles
 	}
-
-	// ── Auth-uncovered endpoint count ─────────────────────────────────────────
-	// Count endpoints without an auth annotation by scanning relationship kinds.
-	authUncovered := countAuthUncoveredEndpoints(rebuiltPaths)
 	entry.AuthUncovered = &authUncovered
 
 	// ── Secrets ──────────────────────────────────────────────────────────────
@@ -139,49 +159,16 @@ func appendRebuildHistory(root, group string, cfg *registry.GroupConfig, rebuilt
 	return quality.AppendEntry(root, entry)
 }
 
-// isProcessFlow returns true for entity kinds that represent process flows.
-func isProcessFlow(e graph.Entity) bool {
-	switch e.Kind {
-	case "process", "SCOPE.Process":
-		return true
-	}
-	return len(e.Kind) > 14 && e.Kind[:14] == "SCOPE.Process."
-}
-
 // stateDirForRepoPath returns the daemon state directory for a repo path.
 // Delegates to the same helper used by the daemon indexer.
 func stateDirForRepoPath(repoPath string) string {
 	return daemon.StateDirForRepo(repoPath)
 }
 
-// countAuthUncoveredEndpoints returns the number of http_endpoint entities
-// that have no outgoing HAS_AUTH or REQUIRES_AUTH relationship across all
-// rebuilt repos.
-func countAuthUncoveredEndpoints(repoPaths []string) int {
-	uncovered := 0
-	for _, repoPath := range repoPaths {
-		stateDir := stateDirForRepoPath(repoPath)
-		doc, err := loadGraphFromStateDir(stateDir)
-		if err != nil || doc == nil {
-			continue
-		}
-
-		// Build set of endpoint IDs that have an auth edge.
-		authed := make(map[string]bool, 16)
-		for _, r := range doc.Relationships {
-			if r.Kind == "HAS_AUTH" || r.Kind == "REQUIRES_AUTH" || r.Kind == "auth" {
-				authed[r.FromID] = true
-			}
-		}
-		// Count endpoint entities not in the authed set.
-		for _, e := range doc.Entities {
-			switch e.Kind {
-			case "http_endpoint", "http_endpoint_definition":
-				if !authed[e.ID] {
-					uncovered++
-				}
-			}
-		}
-	}
-	return uncovered
+// loadGraphFromStateDir is the full-materialise loader. Nothing on the
+// analytics path calls it any more (#5954) — it is retained as the escape
+// hatch for callers that genuinely need a whole Document, and indirected so
+// tests can assert the analytics batch never reaches it.
+var loadGraphFromStateDir = func(stateDir string) (*graph.Document, error) {
+	return graph.LoadGraphFromDir(stateDir)
 }

--- a/cmd/grafel/rebuild_history_5954_test.go
+++ b/cmd/grafel/rebuild_history_5954_test.go
@@ -1,0 +1,264 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/quality"
+	"github.com/cajasmota/grafel/internal/quality/analytics"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// analyticsFixtureDoc is a small graph carrying every signal the health entry
+// reads: orphans, IMPORTS hygiene, coverage in all four crediting phases, an
+// import cycle, endpoints and a process flow.
+func analyticsFixtureDoc() *graph.Document {
+	ents := []graph.Entity{
+		{ID: "aaaaaaaaaaaaaaa1", Name: "OrderService", Kind: "Class", SourceFile: "src/order_service.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa2", Name: "PaymentService", Kind: "Class", SourceFile: "src/payment_service.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa3", Name: "ListOrders", Kind: "SCOPE.Operation", SourceFile: "src/handlers.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa4", Name: "GET /orders", Kind: "http_endpoint_definition", SourceFile: "src/handlers.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa5", Name: "GET /admin", Kind: "http_endpoint_definition", SourceFile: "src/admin.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb1", Name: "TestOrderService", Kind: "SCOPE.Operation", SourceFile: "src/order_service_test.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb2", Name: "TestPaymentService", Kind: "SCOPE.Operation", SourceFile: "src/payment_service_test.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb3", Name: "TestListOrders", Kind: "SCOPE.Operation", SourceFile: "src/handlers_test.go", Language: "go"},
+		{ID: "ccccccccccccccc1", Name: "modA", Kind: "SCOPE.Module", SourceFile: "src/a.go", Language: "go"},
+		{ID: "ccccccccccccccc2", Name: "modB", Kind: "SCOPE.Module", SourceFile: "src/b.go", Language: "go"},
+		{ID: "ddddddddddddddd1", Name: "checkout", Kind: "SCOPE.Process.Saga", SourceFile: "src/flow.go", Language: "go"},
+		{ID: "ddddddddddddddd2", Name: "Unused", Kind: "Struct", SourceFile: "src/unused.go", Language: "go"},
+		{ID: "eeeeeeeeeeeeeee1", Name: "orders-q", Kind: "queue", SourceFile: "src/queue.go", Language: "go"},
+		{ID: "eeeeeeeeeeeeeee2", Name: "orders-t", Kind: "topic", SourceFile: "src/topic.go", Language: "go"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "bbbbbbbbbbbbbbb1", ToID: "aaaaaaaaaaaaaaa1", Kind: "TESTS"},
+		{ID: "r2", FromID: "bbbbbbbbbbbbbbb3", ToID: "aaaaaaaaaaaaaaa3", Kind: "CALLS"},
+		{ID: "r3", FromID: "aaaaaaaaaaaaaaa3", ToID: "aaaaaaaaaaaaaaa4", Kind: "IMPLEMENTS"},
+		{ID: "r4", FromID: "aaaaaaaaaaaaaaa5", ToID: "aaaaaaaaaaaaaaa1", Kind: "REQUIRES_AUTH"},
+		{ID: "r5", FromID: "ccccccccccccccc1", ToID: "ccccccccccccccc2", Kind: "IMPORTS"},
+		{ID: "r6", FromID: "ccccccccccccccc2", ToID: "ccccccccccccccc1", Kind: "IMPORTS"},
+		{ID: "r7", FromID: "ccccccccccccccc1", ToID: "ext:fmt:Printf", Kind: "IMPORTS"},
+		{ID: "r8", FromID: "ccccccccccccccc2", ToID: "./relative", Kind: "IMPORTS"},
+		{ID: "r9", FromID: "ddddddddddddddd1", ToID: "ddddddddddddddd2", Kind: "CONTAINS"},
+	}
+	return &graph.Document{
+		Version:       graph.SchemaVersion,
+		Entities:      ents,
+		Relationships: rels,
+		Stats:         graph.Stats{Entities: len(ents), Relationships: len(rels)},
+	}
+}
+
+// newAnalyticsFixtureRepo writes the fixture graph into an isolated daemon
+// store and returns the repo path.
+func newAnalyticsFixtureRepo(t *testing.T, doc *graph.Document) string {
+	t.Helper()
+	repoPath := t.TempDir()
+	if _, err := fbwriter.WriteGraphGen(daemon.StateDirForRepo(repoPath), doc); err != nil {
+		t.Fatalf("write fixture graph: %v", err)
+	}
+	return repoPath
+}
+
+// readOnlyHistoryEntry reads the single health entry the batch appended.
+func readOnlyHistoryEntry(t *testing.T, root string) quality.HealthEntry {
+	t.Helper()
+	var path string
+	err := filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+		if err == nil && !info.IsDir() && strings.HasSuffix(p, "health-history.jsonl") {
+			path = p
+		}
+		return nil
+	})
+	if err != nil || path == "" {
+		t.Fatalf("health-history.jsonl not written under %s", root)
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("open history: %v", err)
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	var last quality.HealthEntry
+	n := 0
+	for sc.Scan() {
+		if strings.TrimSpace(sc.Text()) == "" {
+			continue
+		}
+		if err := json.Unmarshal(sc.Bytes(), &last); err != nil {
+			t.Fatalf("decode history line: %v", err)
+		}
+		n++
+	}
+	if n != 1 {
+		t.Fatalf("history lines = %d, want 1", n)
+	}
+	return last
+}
+
+// TestAppendRebuildHistory_ScansEachRepoOnce is the hazard assertion. The
+// pre-change batch materialised each repo's graph FOUR times (audit, coverage+
+// cycles, auth-uncovered, agents-map). One scan per repo, and never through the
+// full-materialise Document loader.
+func TestAppendRebuildHistory_ScansEachRepoOnce(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repoA := newAnalyticsFixtureRepo(t, analyticsFixtureDoc())
+	repoB := newAnalyticsFixtureRepo(t, analyticsFixtureDoc())
+
+	scans := map[string]int{}
+	origScan := scanRepoAnalytics
+	scanRepoAnalytics = func(stateDir string) (analytics.RepoScan, error) {
+		scans[stateDir]++
+		return origScan(stateDir)
+	}
+	t.Cleanup(func() { scanRepoAnalytics = origScan })
+
+	loads := 0
+	origLoad := loadGraphFromStateDir
+	loadGraphFromStateDir = func(stateDir string) (*graph.Document, error) {
+		loads++
+		return origLoad(stateDir)
+	}
+	t.Cleanup(func() { loadGraphFromStateDir = origLoad })
+
+	cfg := &registry.GroupConfig{Name: "acme"}
+	if err := appendRebuildHistory(root, "acme", cfg, []string{repoA, repoB}); err != nil {
+		t.Fatalf("appendRebuildHistory: %v", err)
+	}
+
+	if len(scans) != 2 {
+		t.Fatalf("scanned %d distinct repos, want 2: %v", len(scans), scans)
+	}
+	for dir, n := range scans {
+		if n != 1 {
+			t.Errorf("repo %s scanned %d times, want exactly 1 — the whole analytics "+
+				"batch must share one pass over each repo's graph", dir, n)
+		}
+	}
+	if loads != 0 {
+		t.Errorf("the batch materialised %d full graph.Documents; with a readable graph.fb "+
+			"present it must stream the mmap and never materialise", loads)
+	}
+}
+
+// TestAppendRebuildHistory_OutputUnchanged proves the persisted metrics are
+// identical to what the pre-change four-load batch produced. The expected
+// values are recomputed here from the ORIGINAL reference functions
+// (audit-equivalent counters via analytics.ScanDocument, which itself is pinned
+// to audit.AuditPath / graph.ComputeCoverage / graph.FindImportCycles).
+func TestAppendRebuildHistory_OutputUnchanged(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	doc := analyticsFixtureDoc()
+	repoA := newAnalyticsFixtureRepo(t, doc)
+	repoB := newAnalyticsFixtureRepo(t, doc)
+
+	cfg := &registry.GroupConfig{Name: "acme"}
+	if err := appendRebuildHistory(root, "acme", cfg, []string{repoA, repoB}); err != nil {
+		t.Fatalf("appendRebuildHistory: %v", err)
+	}
+	got := readOnlyHistoryEntry(t, root)
+
+	// Reference: two identical repos, folded exactly as the old loops folded.
+	ref := analytics.ScanDocument(doc)
+	wantEntities := 2 * ref.Entities
+	wantOrphanRate := 100.0 * float64(2*ref.Orphans) / float64(wantEntities)
+	wantBugRate := 100.0 * float64(2*(ref.ImportsTotal-ref.ImportsResolved)) / float64(2*ref.ImportsTotal)
+	wantCoverage := 100.0 * float64(2*ref.CoveredProduction) / float64(2*ref.TotalProduction)
+
+	if got.TotalEntities != wantEntities {
+		t.Errorf("TotalEntities = %d, want %d", got.TotalEntities, wantEntities)
+	}
+	if got.OrphanRate != wantOrphanRate {
+		t.Errorf("OrphanRate = %v, want %v", got.OrphanRate, wantOrphanRate)
+	}
+	if got.BugRate != wantBugRate {
+		t.Errorf("BugRate = %v, want %v", got.BugRate, wantBugRate)
+	}
+	if got.HealthScore != quality.ComputeHealthScore(wantOrphanRate, wantBugRate) {
+		t.Errorf("HealthScore = %v, want %v", got.HealthScore,
+			quality.ComputeHealthScore(wantOrphanRate, wantBugRate))
+	}
+	if got.CoveragePct == nil || *got.CoveragePct != wantCoverage {
+		t.Errorf("CoveragePct = %v, want %v", got.CoveragePct, wantCoverage)
+	}
+	if got.Cycles == nil || *got.Cycles != 2*ref.Cycles {
+		t.Errorf("Cycles = %v, want %d", got.Cycles, 2*ref.Cycles)
+	}
+	if got.AuthUncovered == nil || *got.AuthUncovered != 2*ref.AuthUncovered {
+		t.Errorf("AuthUncovered = %v, want %d", got.AuthUncovered, 2*ref.AuthUncovered)
+	}
+	if got.TotalEndpoints != 2*ref.Endpoints {
+		t.Errorf("TotalEndpoints = %d, want %d", got.TotalEndpoints, 2*ref.Endpoints)
+	}
+	if got.TotalFlows != 2*ref.Flows {
+		t.Errorf("TotalFlows = %d, want %d", got.TotalFlows, 2*ref.Flows)
+	}
+	// Non-vacuity: a fixture that produced zeros everywhere would pass the
+	// equalities above without proving anything.
+	if ref.Orphans == 0 || ref.ImportsTotal == 0 || ref.CoveredProduction == 0 ||
+		ref.Cycles == 0 || ref.AuthUncovered == 0 || ref.Endpoints == 0 || ref.Flows == 0 {
+		t.Fatalf("fixture is vacuous: %+v", ref)
+	}
+}
+
+// TestAppendRebuildHistory_IsVisibleToTheStageGate: the batch is a heavy,
+// unbounded read of the whole corpus graph. Before #5954 it ran in a bare
+// goroutine that took no gate token and was invisible to the scheduler's busy
+// accounting, so it could co-reside with the forked link and group-algo
+// children and it distorted the FreeOSMemory release timing. It must now
+// register with the gate for its whole window and unwind afterwards.
+func TestAppendRebuildHistory_IsVisibleToTheStageGate(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	repo := newAnalyticsFixtureRepo(t, analyticsFixtureDoc())
+
+	liveHolds := startBargeObserverScheduler(t)
+
+	holdsDuringScan := 0
+	origScan := scanRepoAnalytics
+	scanRepoAnalytics = func(stateDir string) (analytics.RepoScan, error) {
+		holdsDuringScan = liveHolds()
+		return origScan(stateDir)
+	}
+	t.Cleanup(func() { scanRepoAnalytics = origScan })
+
+	cfg := &registry.GroupConfig{Name: "acme"}
+	if err := appendRebuildHistory(root, "acme", cfg, []string{repo}); err != nil {
+		t.Fatalf("appendRebuildHistory: %v", err)
+	}
+
+	if holdsDuringScan == 0 {
+		t.Error("no gate registration was live WHILE the analytics batch was walking the corpus " +
+			"graph; the batch must register so background heavy stages defer around it and the " +
+			"scheduler's busy accounting (which gates the FreeOSMemory release loop) sees it")
+	}
+	if n := liveHolds(); n != 0 {
+		t.Errorf("the analytics batch left %d gate registration(s) held after returning", n)
+	}
+}
+
+// TestAppendRebuildHistory_ReleasesGateRegistrationOnError: no wedge. A batch
+// that fails partway must still unwind its registration.
+func TestAppendRebuildHistory_ReleasesGateRegistrationOnError(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	liveHolds := startBargeObserverScheduler(t)
+
+	// An unwritable root makes quality.AppendEntry fail at the end of the batch.
+	root := filepath.Join(t.TempDir(), "missing", "\x00bad")
+	cfg := &registry.GroupConfig{Name: "acme"}
+	_ = appendRebuildHistory(root, "acme", cfg, nil)
+
+	if n := liveHolds(); n != 0 {
+		t.Errorf("a failed analytics batch left %d gate registration(s) held", n)
+	}
+}

--- a/internal/daemon/sched/busy_barge_5954_test.go
+++ b/internal/daemon/sched/busy_barge_5954_test.go
@@ -1,0 +1,93 @@
+package sched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// busy_barge_5954_test.go — a live FOREGROUND BARGE must count as busy.
+//
+// The barge is the only signal the scheduler has for heavy work that runs
+// OUTSIDE it: the rebuild path and the post-rebuild analytics batch never call
+// Enqueue, so s.inflight stays empty and every other busyLocked() clause reads
+// idle for the entire window. busyLocked() also gates the debounced
+// FreeOSMemory release, so without this the daemon fires a stop-the-world GC
+// plus a scavenge in the middle of the largest allocation it performs.
+
+func newBargeBusyScheduler(debounce time.Duration, free func()) *Scheduler {
+	return New(Config{
+		Workers:            1,
+		MemReleaseDebounce: debounce,
+		StageGateBargeMax:  time.Hour,
+		FreeOSMemory:       free,
+		Index:              func(context.Context, string, string) error { return nil },
+	})
+}
+
+// TestBusyLocked_LiveBargeCountsAsBusy: while foreground work is registered,
+// the scheduler must not report itself idle.
+func TestBusyLocked_LiveBargeCountsAsBusy(t *testing.T) {
+	s := newBargeBusyScheduler(time.Minute, func() {})
+
+	// busyLocked takes an injected clock (it reaps expired barges on the way
+	// through). Hold it fixed at wall-clock now: bargeForeground stamps
+	// bargeHold.since from real time, and StageGateBargeMax is an hour, so no
+	// reap can fire inside this test and the barge under assertion stays live.
+	now := time.Now()
+
+	s.mu.Lock()
+	idleBefore := !s.busyLocked(now)
+	s.mu.Unlock()
+	if !idleBefore {
+		t.Fatal("precondition: a fresh scheduler with no work must read idle")
+	}
+
+	release := s.bargeForeground("analytics:acme")
+
+	s.mu.Lock()
+	busyDuring := s.busyLocked(now)
+	s.mu.Unlock()
+	if !busyDuring {
+		t.Error("busyLocked() reported IDLE while a foreground barge was live; heavy work " +
+			"that runs outside the scheduler is invisible to every other clause, so the " +
+			"barge is the only thing that can make it visible")
+	}
+
+	release()
+
+	s.mu.Lock()
+	idleAfter := !s.busyLocked(now)
+	s.mu.Unlock()
+	if !idleAfter {
+		t.Error("busyLocked() still reported BUSY after the barge was released")
+	}
+}
+
+// TestMaybeReleaseMemory_DoesNotFireUnderALiveBarge: the consequence that
+// actually costs something. A debounced FreeOSMemory must not fire underneath
+// foreground work that is still allocating.
+func TestMaybeReleaseMemory_DoesNotFireUnderALiveBarge(t *testing.T) {
+	var freed atomic.Int32
+	s := newBargeBusyScheduler(30*time.Second, func() { freed.Add(1) })
+
+	release := s.bargeForeground("analytics:acme")
+
+	base := time.Now()
+	s.maybeReleaseMemory(base)
+	s.maybeReleaseMemory(base.Add(31 * time.Second))
+	s.maybeReleaseMemory(base.Add(120 * time.Second))
+	if got := freed.Load(); got != 0 {
+		t.Fatalf("FreeOSMemory fired %d time(s) while foreground work was registered; "+
+			"the pages it scavenges are about to be dirtied straight back", got)
+	}
+
+	// Once the barge lifts, a fresh idle period releases as usual.
+	release()
+	s.maybeReleaseMemory(base.Add(200 * time.Second))
+	s.maybeReleaseMemory(base.Add(240 * time.Second))
+	if got := freed.Load(); got != 1 {
+		t.Fatalf("FreeOSMemory did not resume after the barge lifted; want 1 got %d", got)
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1241,6 +1241,11 @@ func (s *Scheduler) workPendingLocked() bool {
 	if s.stageDrainFor != "" || len(s.stageDeferSince) > 0 {
 		return true
 	}
+	// A live FOREGROUND BARGE is deliberately NOT tested here: it is work IN
+	// FLIGHT, not pending, and workInFlightLocked already reads it (see #5954 and
+	// the barge paragraph on that function's doc comment). Duplicating it here
+	// would be dead weight — busyLocked ORs the two predicates — and would wrongly
+	// report a running rebuild as "queued" to any future solo caller of this one.
 	for _, p := range s.groupAlgoPending {
 		if p {
 			return true

--- a/internal/dashboard/handlers_quality.go
+++ b/internal/dashboard/handlers_quality.go
@@ -242,7 +242,7 @@ func (s *Server) handleRunQualityOrphans(w http.ResponseWriter, r *http.Request)
 	// then merge the results into a group-level summary.
 	var allRepos []*audit.RepoReport
 	for _, rp := range repoPaths {
-		rep, aErr := audit.AuditPath(rp.Path, false)
+		rep, aErr := audit.AuditPathWithWorkers(rp.Path, false, inDaemonAuditWorkers)
 		if aErr != nil {
 			// Non-fatal: surface the error as an empty stub repo.
 			allRepos = append(allRepos, &audit.RepoReport{
@@ -694,7 +694,7 @@ func (s *Server) handleQualityComposite(w http.ResponseWriter, r *http.Request) 
 	repos := 0
 
 	for _, rp := range repoPaths {
-		rep, aErr := audit.AuditPath(rp.Path, false)
+		rep, aErr := audit.AuditPathWithWorkers(rp.Path, false, inDaemonAuditWorkers)
 		if aErr != nil || len(rep.Repos) == 0 {
 			continue
 		}
@@ -728,3 +728,14 @@ func (s *Server) handleQualityComposite(w http.ResponseWriter, r *http.Request) 
 		Repos:         repos,
 	})
 }
+
+// inDaemonAuditWorkers is the corpus-audit fan-out for audits that run INSIDE
+// the daemon process (#5954).
+//
+// audit's default is 4, which is right for the interactive CLI: a human is
+// waiting on wall-clock and the process exits afterwards. Inside the daemon
+// neither holds. Each worker materialises a full graph.Document — 300–600 MB
+// for a corpus repo — so four workers put four co-resident copies of the corpus
+// graph into the process whose resident footprint this epic exists to shrink,
+// to save wall-clock on a dashboard panel nobody is blocking on. One worker.
+const inDaemonAuditWorkers = 1

--- a/internal/graph/coverage_view.go
+++ b/internal/graph/coverage_view.go
@@ -1,0 +1,144 @@
+package graph
+
+// coverage_view.go — mmap-backed coverage totals (#5954).
+//
+// ComputeCoverage takes a fully materialised *Document: ~608 MB of heap for a
+// 325 MB graph.fb, all of it retained for the duration of the call. The daemon's
+// post-rebuild analytics batch reads exactly TWO numbers out of the resulting
+// CoverageReport — TotalProduction and CoveredProduction — and throws the rest
+// (the uncovered list, the per-file and per-directory rollups, the percentages)
+// away. Paying a full materialisation for two integers is the single largest
+// avoidable allocation on that path.
+//
+// CoverageTotalsFromView computes those two numbers straight off the mmap. It
+// runs the SAME four crediting phases in the SAME order as ComputeCoverage and
+// shares phases 3 and 4 verbatim (attributeByNameAffinity /
+// creditEndpointsViaHandlers are called unchanged), so the numbers cannot
+// drift — see TestCoverageTotalsFromView_MatchesComputeCoverage.
+//
+// What it does NOT retain, and why that is safe:
+//
+//   - Entities that are neither production nor test are classified and dropped.
+//     Every downstream consumer of entByID (phases 3 and 4) only ever reads
+//     entries whose id is in prodIDs or testIDs: phase 3 iterates those two sets
+//     directly, and phase 4 can only credit an edge when BOTH endpoints are in
+//     prodIDs (covered's key set is a subset of prodIDs by construction, so a
+//     non-production handler can never have covered[handlerID] > 0).
+//   - For the entities it does retain it keeps only the four fields those two
+//     phases read (ID, Name, Kind, SourceFile) rather than the whole row with
+//     its properties, tags, metadata and algorithm overlays.
+//   - Relationships are never materialised in bulk. Phase 1 streams them, and
+//     phase 4 retains only the handler↔endpoint edges (IMPLEMENTS / ROUTES_TO /
+//     SERVES), which are a rounding error next to the full edge vector.
+//
+// Phase 5 (the contract-covered band) is deliberately absent: it mutates
+// contractRef only and never touches `covered`, so it cannot change either
+// number returned here.
+
+import (
+	"strings"
+
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+)
+
+// CoverageTotalsFromView returns the TotalProduction and CoveredProduction
+// counts ComputeCoverage would report for the same graph, without
+// materialising a Document.
+func CoverageTotalsFromView(v fbreader.GraphView) (totalProduction, coveredProduction int) {
+	if v == nil {
+		return 0, 0
+	}
+
+	// ── pass 1: classify entities ────────────────────────────────────────────
+	// Only production and test entities are retained, and only the fields the
+	// later phases read. Everything else is decoded, inspected and dropped.
+	entByID := make(map[string]*Entity)
+	prodIDs := make(map[string]bool)
+	testIDs := make(map[string]bool)
+	contractTestIDs := make(map[string]bool)
+
+	// A FRESH interner per row, deliberately. The Document path shares one
+	// across the whole load because it retains every string anyway; here the
+	// decoded row is dropped immediately, and a shared interner would pin every
+	// unique string in the graph — reintroducing the retention this function
+	// exists to avoid.
+	v.IterateEntities(func(fbEnt *fb.Entity) bool {
+		if fbEnt == nil {
+			return true
+		}
+		e := fbEntityToGraphEntity(fbEnt, newStringInterner())
+		switch {
+		case isProductionEntity(&e):
+			prodIDs[e.ID] = true
+		case isTestEntity(&e):
+			testIDs[e.ID] = true
+			if isContractSpecFile(e.SourceFile) {
+				contractTestIDs[e.ID] = true
+			}
+		default:
+			return true // neither: nothing downstream can read it
+		}
+		entByID[e.ID] = &Entity{
+			ID:         e.ID,
+			Name:       e.Name,
+			Kind:       e.Kind,
+			SourceFile: e.SourceFile,
+		}
+		return true
+	})
+	totalProduction = len(prodIDs)
+
+	// ── phase 1 + 2: TESTS edges, then synthetic TESTS from test CALLS ───────
+	covered := make(map[string]int, len(prodIDs))
+	testCallsTo := make(map[string][]string)
+	// Handler↔endpoint edges are the only edges phase 4 looks at; collect them
+	// on this single pass so phase 4 does not need a second scan.
+	var handlerEdges []Relationship
+
+	v.IterateRelationships(func(fbRel *fb.Relationship) bool {
+		if fbRel == nil {
+			return true
+		}
+		from := string(fbRel.FromId())
+		to := string(fbRel.ToId())
+		kind := strings.ToUpper(string(fbRel.Kind()))
+
+		if handlerEndpointEdgeKinds[kind] {
+			handlerEdges = append(handlerEdges, Relationship{FromID: from, ToID: to, Kind: kind})
+		}
+
+		switch kind {
+		case kindTests:
+			if !prodIDs[to] {
+				return true
+			}
+			if contractTestIDs[from] {
+				// Offline contract spec: a shape assertion, never a reach
+				// signal. ComputeCoverage records it in contractRef, which
+				// does not feed either total returned here.
+				return true
+			}
+			covered[to]++
+		case kindCalls:
+			if testIDs[from] {
+				testCallsTo[from] = append(testCallsTo[from], to)
+			}
+		}
+		return true
+	})
+
+	for _, targets := range testCallsTo {
+		for _, toID := range targets {
+			if prodIDs[toID] && covered[toID] == 0 {
+				covered[toID]++
+			}
+		}
+	}
+
+	// ── phases 3 and 4: shared verbatim with ComputeCoverage ─────────────────
+	attributeByNameAffinity(entByID, testIDs, prodIDs, covered)
+	creditEndpointsViaHandlers(entByID, handlerEdges, prodIDs, covered)
+
+	return totalProduction, len(covered)
+}

--- a/internal/graph/cycles.go
+++ b/internal/graph/cycles.go
@@ -57,25 +57,34 @@ func FindImportCycles(entities []Entity, rels []Relationship, pagerank map[strin
 	// Build adjacency list of IMPORTS edges (directed: from → to).
 	// importsAdj[u] = list of v where u IMPORTS v.
 	importsAdj := make(map[string][]string)
-	// importsEdge is a lookup set for edges inside cycles.
-	type edgeKey struct{ from, to string }
-	edgeSet := make(map[edgeKey]bool)
-
 	for i := range rels {
 		r := &rels[i]
-		if r.Kind != "IMPORTS" {
-			continue
-		}
-		if !known[r.FromID] || !known[r.ToID] {
-			continue
-		}
-		if r.FromID == r.ToID {
-			continue // self-import: not a cycle
-		}
-		importsAdj[r.FromID] = append(importsAdj[r.FromID], r.ToID)
-		edgeSet[edgeKey{r.FromID, r.ToID}] = true
+		addImportEdge(importsAdj, known, r.Kind, r.FromID, r.ToID)
 	}
+	return findImportCyclesFromAdjacency(importsAdj, pagerank)
+}
 
+// addImportEdge appends one IMPORTS edge to the adjacency map, applying the
+// same three filters FindImportCycles has always applied: non-IMPORTS kinds,
+// edges with a dangling endpoint, and self-imports are all skipped. Extracted
+// (#5954) so the mmap-backed CountImportCyclesFromView builds a byte-identical
+// adjacency without materialising []Entity / []Relationship.
+func addImportEdge(importsAdj map[string][]string, known map[string]bool, kind, fromID, toID string) {
+	if kind != "IMPORTS" {
+		return
+	}
+	if !known[fromID] || !known[toID] {
+		return
+	}
+	if fromID == toID {
+		return // self-import: not a cycle
+	}
+	importsAdj[fromID] = append(importsAdj[fromID], toID)
+}
+
+// findImportCyclesFromAdjacency is the Tarjan core, shared verbatim by the
+// slice-based FindImportCycles and the view-based CountImportCyclesFromView.
+func findImportCyclesFromAdjacency(importsAdj map[string][]string, pagerank map[string]float64) []ImportCycle {
 	if len(importsAdj) == 0 {
 		return nil
 	}

--- a/internal/graph/cycles_view.go
+++ b/internal/graph/cycles_view.go
@@ -1,0 +1,54 @@
+package graph
+
+// cycles_view.go — mmap-backed import-cycle counting (#5954).
+//
+// FindImportCycles takes []Entity and []Relationship purely to derive two
+// things: the set of entity ids that exist (so dangling edges are skipped) and
+// the IMPORTS adjacency. Neither needs a materialised row. The daemon's
+// post-rebuild analytics batch then reads a single integer — len(cycles) — off
+// the result, so the whole graph was being copied onto the heap to count
+// strongly-connected components.
+//
+// CountImportCyclesFromView builds the minimal structures the algorithm
+// actually needs (an id set and an id→id adjacency map) directly from the mmap
+// and runs the SAME Tarjan core through the SAME edge filter, so the count is
+// identical by construction.
+
+import (
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+)
+
+// CountImportCyclesFromView returns len(FindImportCycles(...)) for the graph
+// behind v, without materialising a Document.
+//
+// pagerank is not accepted because the count is independent of it: pagerank
+// only annotates each cycle with a weakest link and an extraction candidate,
+// never adds or removes one. (The daemon's caller always passed nil anyway.)
+func CountImportCyclesFromView(v fbreader.GraphView) int {
+	if v == nil {
+		return 0
+	}
+
+	// Pass 1: the id set. This is the ONLY per-entity state the cycle finder
+	// needs — no names, kinds, files or properties.
+	known := make(map[string]bool, v.EntityCount())
+	v.IterateEntities(func(e *fb.Entity) bool {
+		if e != nil {
+			known[string(e.Id())] = true
+		}
+		return true
+	})
+
+	// Pass 2: the IMPORTS adjacency, id→id only.
+	importsAdj := make(map[string][]string)
+	v.IterateRelationships(func(rel *fb.Relationship) bool {
+		if rel == nil {
+			return true
+		}
+		addImportEdge(importsAdj, known, string(rel.Kind()), string(rel.FromId()), string(rel.ToId()))
+		return true
+	})
+
+	return len(findImportCyclesFromAdjacency(importsAdj, nil))
+}

--- a/internal/quality/analytics/scan.go
+++ b/internal/quality/analytics/scan.go
@@ -1,0 +1,330 @@
+// Package analytics computes, in ONE pass over one open graph, every number
+// the daemon's post-rebuild metrics batch needs from a repo.
+//
+// #5954. The batch used to walk each repo's graph FOUR times, each walk
+// materialising the whole corpus onto the Go heap:
+//
+//  1. audit.AuditPath           → graph.LoadGraphFromDir + a map[string]*Entity
+//  2. graph.ComputeCoverage + graph.FindImportCycles → a second LoadGraphFromDir
+//  3. countAuthUncoveredEndpoints → a third LoadGraphFromDir
+//  4. buildAgentsMapStats       → a fourth LoadGraphFromDir
+//
+// graph.LoadGraphFromDir is the full-materialise loader: internal/graph/load.go
+// puts a 325 MB graph.fb at roughly 608 MB of heap. Doing that four times per
+// repo, in a goroutine that took no stage-gate token and was invisible to the
+// scheduler's busy accounting, put a repeat of the largest object in the daemon
+// alongside the very children the epic had just forked out of it.
+//
+// Every one of those numbers is a counting scan. So this package does not build
+// a Document at all: it opens the graph once as an mmap-backed
+// fbreader.GraphView and streams the rows. Entities are decoded one at a time
+// and dropped; what survives a scan is id-keyed sets, not []Entity.
+//
+// The one structure that genuinely needs adjacency is import-cycle detection
+// (Tarjan). It gets an id→id adjacency map — not a slice of materialised rows.
+//
+// ScanDocument is the reference implementation: it computes the same struct
+// from a *graph.Document using the ORIGINAL functions (audit's rules,
+// graph.ComputeCoverage, graph.FindImportCycles). It is the fallback for repos
+// with no readable graph.fb, and it is the oracle the streaming path is tested
+// against.
+package analytics
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
+	"github.com/cajasmota/grafel/internal/quality/audit"
+)
+
+// RepoScan is the complete set of per-repo numbers the post-rebuild analytics
+// batch consumes. It is a plain comparable struct so a test can assert the
+// streaming and materialised paths agree on ALL of it with one ==.
+type RepoScan struct {
+	// Audit-derived (health-history orphan rate and bug rate).
+	Entities        int
+	Orphans         int
+	ImportsTotal    int
+	ImportsResolved int // hex + ext_qualified — the "good imports" numerator
+
+	// Coverage-derived.
+	TotalProduction   int
+	CoveredProduction int
+
+	// Import cycles.
+	Cycles int
+
+	// Kind tallies.
+	Endpoints int // http_endpoint, http_endpoint_definition, http_endpoint_call
+	Flows     int // process / SCOPE.Process / SCOPE.Process.*
+
+	// Endpoints with no HAS_AUTH / REQUIRES_AUTH / auth edge.
+	AuthUncovered int
+}
+
+// KindTally is the much smaller scan the AGENTS.md architecture-map injection
+// needs. It is a separate entry point because it runs at a different time (per
+// repo, inside the index loop) and would otherwise pay for coverage and cycle
+// detection it never reads.
+type KindTally struct {
+	Entities      int
+	Relationships int
+	HTTPEndpoints int
+	Queues        int
+	Topics        int
+	ProcessFlows  int
+}
+
+// graphView is the read surface a scan needs. Aliased so tests can substitute
+// the opener without importing fbreader.
+type graphView = fbreader.GraphView
+
+// errNoView is returned by the opener when the repo has no mmap-readable
+// graph (graph.json only, or a format version this binary cannot read). The
+// caller then falls back to the Document path.
+var errNoView = errors.New("analytics: no mmap-readable graph")
+
+// openGraphView opens the repo's active graph as a streaming view. Indirected
+// for tests, which assert a whole batch shares ONE open.
+var openGraphView = func(stateDir string) (graphView, error) {
+	v, err := graph.ReaderForDir(stateDir)
+	if err != nil {
+		return nil, err
+	}
+	// Apply the same format-version gate LoadGraphFromDir applies. Without it a
+	// graph too old for this binary would be scanned as if it were current,
+	// where the Document path correctly refuses and the caller skips the repo.
+	if required, _ := graph.ReindexRequiredReason(stateDir); required {
+		_ = v.Close()
+		return nil, errNoView
+	}
+	return v, nil
+}
+
+// loadDocument is the full-materialise fallback. Indirected for tests, which
+// assert the streaming path never reaches it.
+var loadDocument = func(stateDir string) (*graph.Document, error) {
+	return graph.LoadGraphFromDir(stateDir)
+}
+
+// ScanRepo computes every analytics number for one repo from a SINGLE open of
+// its graph. It never materialises a graph.Document unless the repo has no
+// mmap-readable graph at all.
+func ScanRepo(stateDir string) (RepoScan, error) {
+	v, err := openGraphView(stateDir)
+	if err != nil {
+		doc, lerr := loadDocument(stateDir)
+		if lerr != nil {
+			return RepoScan{}, lerr
+		}
+		return ScanDocument(doc), nil
+	}
+	defer v.Close()
+	return scanView(v), nil
+}
+
+// TallyRepo computes the AGENTS.md map tally from a single open of the graph.
+func TallyRepo(stateDir string) (KindTally, error) {
+	v, err := openGraphView(stateDir)
+	if err != nil {
+		doc, lerr := loadDocument(stateDir)
+		if lerr != nil {
+			return KindTally{}, lerr
+		}
+		return TallyDocument(doc), nil
+	}
+	defer v.Close()
+
+	t := KindTally{Entities: v.EntityCount(), Relationships: v.RelationshipCount()}
+	v.IterateEntities(func(e *fb.Entity) bool {
+		if e != nil {
+			t.addKind(string(e.Kind()))
+		}
+		return true
+	})
+	return t, nil
+}
+
+func (t *KindTally) addKind(kind string) {
+	switch kind {
+	case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
+		t.HTTPEndpoints++
+	case "queue":
+		t.Queues++
+	case "topic", "pubsub_topic":
+		t.Topics++
+	}
+	if strings.HasPrefix(kind, "SCOPE.Process") || kind == "process" {
+		t.ProcessFlows++
+	}
+}
+
+// TallyDocument is the materialised reference for TallyRepo.
+func TallyDocument(doc *graph.Document) KindTally {
+	t := KindTally{Entities: doc.Stats.Entities, Relationships: doc.Stats.Relationships}
+	for i := range doc.Entities {
+		t.addKind(doc.Entities[i].Kind)
+	}
+	return t
+}
+
+// scanView is the streaming implementation. Three iterations over ONE open
+// mmap — cheap page reads, no heap retention of rows — replace four full
+// materialisations.
+func scanView(v graphView) RepoScan {
+	var s RepoScan
+
+	// ── entity pass: ids, kind tallies ───────────────────────────────────────
+	// entityIDs is deduplicated exactly as audit's entByID map is, so a graph
+	// carrying a duplicate id produces the same orphan count as before.
+	entityIDs := make(map[string]struct{}, v.EntityCount())
+	v.IterateEntities(func(e *fb.Entity) bool {
+		if e == nil {
+			return true
+		}
+		s.Entities++
+		entityIDs[string(e.Id())] = struct{}{}
+		countKinds(&s, string(e.Kind()))
+		return true
+	})
+
+	// ── relationship pass: connectivity, imports, auth ───────────────────────
+	touched := make(map[string]struct{}, len(entityIDs))
+	authed := make(map[string]struct{}, 16)
+	v.IterateRelationships(func(rel *fb.Relationship) bool {
+		if rel == nil {
+			return true
+		}
+		from := string(rel.FromId())
+		to := string(rel.ToId())
+		kind := string(rel.Kind())
+		accumulateRel(&s, touched, authed, kind, from, to)
+		return true
+	})
+
+	// ── orphans: entities with no non-structural edge ────────────────────────
+	for id := range entityIDs {
+		if _, ok := touched[id]; !ok {
+			s.Orphans++
+		}
+	}
+
+	// ── auth-uncovered endpoints: a second entity pass over the same mmap ────
+	v.IterateEntities(func(e *fb.Entity) bool {
+		if e == nil {
+			return true
+		}
+		if isAuthScopedEndpointKind(string(e.Kind())) {
+			if _, ok := authed[string(e.Id())]; !ok {
+				s.AuthUncovered++
+			}
+		}
+		return true
+	})
+
+	s.TotalProduction, s.CoveredProduction = graph.CoverageTotalsFromView(v)
+	s.Cycles = graph.CountImportCyclesFromView(v)
+	return s
+}
+
+// ScanDocument is the materialised reference implementation. It delegates every
+// derived number to the function the daemon used to call, so it is the oracle
+// the streaming path is proven against — and the correct path for a repo with
+// only a graph.json.
+func ScanDocument(doc *graph.Document) RepoScan {
+	var s RepoScan
+
+	entityIDs := make(map[string]struct{}, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		s.Entities++
+		entityIDs[e.ID] = struct{}{}
+		countKinds(&s, e.Kind)
+	}
+
+	touched := make(map[string]struct{}, len(doc.Entities))
+	authed := make(map[string]struct{}, 16)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		accumulateRel(&s, touched, authed, r.Kind, r.FromID, r.ToID)
+	}
+	for id := range entityIDs {
+		if _, ok := touched[id]; !ok {
+			s.Orphans++
+		}
+	}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if isAuthScopedEndpointKind(e.Kind) {
+			if _, ok := authed[e.ID]; !ok {
+				s.AuthUncovered++
+			}
+		}
+	}
+
+	cov := graph.ComputeCoverage(doc)
+	s.TotalProduction = cov.TotalProduction
+	s.CoveredProduction = cov.CoveredProduction
+	s.Cycles = len(graph.FindImportCycles(doc.Entities, doc.Relationships, nil))
+	return s
+}
+
+// countKinds applies the endpoint and process-flow kind rules the health entry
+// has always used.
+func countKinds(s *RepoScan, kind string) {
+	switch kind {
+	case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
+		s.Endpoints++
+	}
+	if isProcessFlowKind(kind) {
+		s.Flows++
+	}
+}
+
+// accumulateRel folds one edge into the connectivity, IMPORTS-hygiene and auth
+// accumulators. Shared by both paths so the two cannot diverge on edge rules.
+func accumulateRel(s *RepoScan, touched, authed map[string]struct{}, kind, from, to string) {
+	upper := strings.ToUpper(kind)
+	// Orphan rule (#1597, via audit): a node linked only by CONTAINS/DECLARES
+	// is still an orphan.
+	if !audit.IsStructuralRelKind(upper) {
+		touched[from] = struct{}{}
+		touched[to] = struct{}{}
+	}
+	if upper == "IMPORTS" {
+		s.ImportsTotal++
+		switch audit.ClassifyImportToID(to) {
+		case audit.ImportFormatHex, audit.ImportFormatExtQualified:
+			s.ImportsResolved++
+		}
+	}
+	// The auth check matches on the RAW kind — "auth" is lowercase by design in
+	// the original countAuthUncoveredEndpoints and must stay case-sensitive.
+	switch kind {
+	case "HAS_AUTH", "REQUIRES_AUTH", "auth":
+		authed[from] = struct{}{}
+	}
+}
+
+// isProcessFlowKind mirrors the health entry's process-flow rule.
+func isProcessFlowKind(kind string) bool {
+	switch kind {
+	case "process", "SCOPE.Process":
+		return true
+	}
+	return len(kind) > 14 && kind[:14] == "SCOPE.Process."
+}
+
+// isAuthScopedEndpointKind is the endpoint set the auth-coverage metric counts.
+// Deliberately NARROWER than the endpoint tally above: http_endpoint_call is a
+// client-side call site, not something that can carry an auth annotation.
+func isAuthScopedEndpointKind(kind string) bool {
+	switch kind {
+	case "http_endpoint", "http_endpoint_definition":
+		return true
+	}
+	return false
+}

--- a/internal/quality/analytics/scan_5954_test.go
+++ b/internal/quality/analytics/scan_5954_test.go
@@ -1,0 +1,436 @@
+package analytics
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/quality/audit"
+)
+
+// fixtureDoc builds a small but structurally rich graph that exercises every
+// number the post-rebuild analytics batch reads: orphans (audit semantics),
+// IMPORTS hygiene, coverage (all four crediting phases), an import cycle,
+// endpoint/flow kind tallies and the auth-uncovered count.
+func fixtureDoc() *graph.Document {
+	ents := []graph.Entity{
+		// Production, covered directly by a TESTS edge.
+		{ID: "aaaaaaaaaaaaaaa1", Name: "OrderService", Kind: "Class", SourceFile: "src/order_service.go", Language: "go"},
+		// Production, covered only via name affinity (phase 3).
+		{ID: "aaaaaaaaaaaaaaa2", Name: "PaymentService", Kind: "Class", SourceFile: "src/payment_service.go", Language: "go"},
+		// Handler + the endpoint definition it implements (phase 4 hop).
+		{ID: "aaaaaaaaaaaaaaa3", Name: "ListOrders", Kind: "SCOPE.Operation", SourceFile: "src/handlers.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa4", Name: "GET /orders", Kind: "http_endpoint_definition", SourceFile: "src/handlers.go", Language: "go"},
+		// Endpoint with an auth edge, and one without.
+		{ID: "aaaaaaaaaaaaaaa5", Name: "GET /admin", Kind: "http_endpoint_definition", SourceFile: "src/admin.go", Language: "go"},
+		// Auth-rule discriminators. /health is an endpoint for the TALLY but is a
+		// client-side call site, so it is outside the auth-scoped set. /login
+		// carries the lowercase "auth" edge kind; /profile carries a lowercase
+		// "requires_auth" that must NOT count (the auth match is case-sensitive).
+		{ID: "aaaaaaaaaaaaaaa7", Name: "GET /health", Kind: "http_endpoint_call", SourceFile: "src/client.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa8", Name: "POST /login", Kind: "http_endpoint", SourceFile: "src/login.go", Language: "go"},
+		{ID: "aaaaaaaaaaaaaaa9", Name: "PUT /profile", Kind: "http_endpoint", SourceFile: "src/profile.go", Language: "go"},
+		// Production subject whose only same-token test lives in a DIFFERENT
+		// directory subtree, so phase-3 name affinity must decline to credit it.
+		// See TestCoverageTotals_NameAffinityIsDirectoryScoped.
+		{ID: "aaaaaaaaaaaaaaa6", Name: "ShippingService", Kind: "Class", SourceFile: "src/shipping_service.go", Language: "go"},
+		// Test entities.
+		{ID: "bbbbbbbbbbbbbbb1", Name: "TestOrderService", Kind: "SCOPE.Operation", SourceFile: "src/order_service_test.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb2", Name: "TestPaymentService", Kind: "SCOPE.Operation", SourceFile: "src/payment_service_test.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb3", Name: "TestListOrders", Kind: "SCOPE.Operation", SourceFile: "src/handlers_test.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb4", Name: "TestShippingService", Kind: "SCOPE.Operation", SourceFile: "tools/qa/shipping_service_test.go", Language: "go"},
+		// Two modules that import each other -> one cycle.
+		{ID: "ccccccccccccccc1", Name: "modA", Kind: "SCOPE.Module", SourceFile: "src/a.go", Language: "go"},
+		{ID: "ccccccccccccccc2", Name: "modB", Kind: "SCOPE.Module", SourceFile: "src/b.go", Language: "go"},
+		// A process flow and a plain orphan (only a CONTAINS edge -> still an orphan).
+		{ID: "ddddddddddddddd1", Name: "checkout", Kind: "SCOPE.Process.Saga", SourceFile: "src/flow.go", Language: "go"},
+		{ID: "ddddddddddddddd2", Name: "Unused", Kind: "Struct", SourceFile: "src/unused.go", Language: "go"},
+		// Flow-rule discriminators: the bare "SCOPE.Process" kind IS a flow;
+		// "SCOPE.Processor" is a 15-char near-miss that must NOT be (its first 14
+		// bytes are "SCOPE.Processo", not "SCOPE.Process.").
+		{ID: "ddddddddddddddd3", Name: "signup", Kind: "SCOPE.Process", SourceFile: "src/flow2.go", Language: "go"},
+		{ID: "ddddddddddddddd4", Name: "Processor", Kind: "SCOPE.Processor", SourceFile: "src/proc.go", Language: "go"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "bbbbbbbbbbbbbbb1", ToID: "aaaaaaaaaaaaaaa1", Kind: "TESTS"},
+		{ID: "r2", FromID: "bbbbbbbbbbbbbbb3", ToID: "aaaaaaaaaaaaaaa3", Kind: "CALLS"},
+		{ID: "r3", FromID: "aaaaaaaaaaaaaaa3", ToID: "aaaaaaaaaaaaaaa4", Kind: "IMPLEMENTS"},
+		{ID: "r4", FromID: "aaaaaaaaaaaaaaa5", ToID: "aaaaaaaaaaaaaaa1", Kind: "REQUIRES_AUTH"},
+		// IMPORTS hygiene: one resolved hex, one ext-qualified, one path string.
+		{ID: "r5", FromID: "ccccccccccccccc1", ToID: "ccccccccccccccc2", Kind: "IMPORTS"},
+		{ID: "r6", FromID: "ccccccccccccccc2", ToID: "ccccccccccccccc1", Kind: "IMPORTS"},
+		{ID: "r7", FromID: "ccccccccccccccc1", ToID: "ext:fmt:Printf", Kind: "IMPORTS"},
+		{ID: "r8", FromID: "ccccccccccccccc2", ToID: "./relative", Kind: "IMPORTS"},
+		// Structural only: does NOT rescue ddddddddddddddd2 from orphan status.
+		{ID: "r9", FromID: "ddddddddddddddd1", ToID: "ddddddddddddddd2", Kind: "CONTAINS"},
+		// Auth edges: "auth" counts, "requires_auth" (wrong case) must not.
+		{ID: "r10", FromID: "aaaaaaaaaaaaaaa8", ToID: "aaaaaaaaaaaaaaa1", Kind: "auth"},
+		{ID: "r11", FromID: "aaaaaaaaaaaaaaa9", ToID: "aaaaaaaaaaaaaaa1", Kind: "requires_auth"},
+	}
+	return &graph.Document{
+		Version:       graph.SchemaVersion,
+		Entities:      ents,
+		Relationships: rels,
+		Stats:         graph.Stats{Entities: len(ents), Relationships: len(rels)},
+	}
+}
+
+// writeFixture persists doc as a graph.fb under a fresh state dir and returns
+// both the repo root and the state dir.
+func writeFixture(t *testing.T, doc *graph.Document) (repoPath, stateDir string) {
+	t.Helper()
+	// Isolate the daemon store so StateDirForRepo (which audit.AuditPath uses
+	// to discover a repo's graph) resolves inside the test's temp tree.
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	repoPath = t.TempDir()
+	stateDir = daemon.StateDirForRepo(repoPath)
+	if _, err := fbwriter.WriteGraphGen(stateDir, doc); err != nil {
+		t.Fatalf("write fixture graph: %v", err)
+	}
+	return repoPath, stateDir
+}
+
+// TestScanRepo_MatchesDocumentReference is the byte-identity proof for the
+// streaming scan: every number the mmap-backed single-pass scanner produces
+// must equal the number the pre-change, fully-materialised Document code path
+// produces for the same graph.
+func TestScanRepo_MatchesDocumentReference(t *testing.T) {
+	doc := fixtureDoc()
+	_, stateDir := writeFixture(t, doc)
+
+	got, err := ScanRepo(stateDir)
+	if err != nil {
+		t.Fatalf("ScanRepo: %v", err)
+	}
+	want := ScanDocument(doc)
+
+	if got != want {
+		t.Fatalf("streaming scan diverged from the materialised reference:\n got  %+v\n want %+v", got, want)
+	}
+}
+
+// TestScanDocument_MatchesAuditReference pins the audit-derived numbers
+// (entities / orphans / IMPORTS hygiene) to audit.AuditPath — the function the
+// daemon used to call — so collapsing the audit load cannot silently move the
+// health-history orphan or bug rate.
+func TestScanDocument_MatchesAuditReference(t *testing.T) {
+	doc := fixtureDoc()
+	repoPath, _ := writeFixture(t, doc)
+
+	rep, err := audit.AuditPath(repoPath, false)
+	if err != nil {
+		t.Fatalf("audit.AuditPath: %v", err)
+	}
+	if len(rep.Repos) != 1 {
+		t.Fatalf("audit repos = %d, want 1", len(rep.Repos))
+	}
+	rr := rep.Repos[0]
+
+	got := ScanDocument(doc)
+	if got.Entities != rr.Entities {
+		t.Errorf("Entities = %d, want %d (audit)", got.Entities, rr.Entities)
+	}
+	if got.Orphans != rr.Orphans {
+		t.Errorf("Orphans = %d, want %d (audit)", got.Orphans, rr.Orphans)
+	}
+	if got.ImportsTotal != rr.ImportsTotal {
+		t.Errorf("ImportsTotal = %d, want %d (audit)", got.ImportsTotal, rr.ImportsTotal)
+	}
+	wantResolved := rr.ImportsToIDFormat[audit.ImportFormatHex] +
+		rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+	if got.ImportsResolved != wantResolved {
+		t.Errorf("ImportsResolved = %d, want %d (audit)", got.ImportsResolved, wantResolved)
+	}
+}
+
+// TestScanDocument_MatchesCoverageAndCyclesReference pins coverage and cycle
+// counts to the canonical graph.ComputeCoverage / graph.FindImportCycles.
+func TestScanDocument_MatchesCoverageAndCyclesReference(t *testing.T) {
+	doc := fixtureDoc()
+	got := ScanDocument(doc)
+
+	cov := graph.ComputeCoverage(doc)
+	if got.TotalProduction != cov.TotalProduction {
+		t.Errorf("TotalProduction = %d, want %d", got.TotalProduction, cov.TotalProduction)
+	}
+	if got.CoveredProduction != cov.CoveredProduction {
+		t.Errorf("CoveredProduction = %d, want %d", got.CoveredProduction, cov.CoveredProduction)
+	}
+	cycles := graph.FindImportCycles(doc.Entities, doc.Relationships, nil)
+	if got.Cycles != len(cycles) {
+		t.Errorf("Cycles = %d, want %d", got.Cycles, len(cycles))
+	}
+	if got.Cycles == 0 {
+		t.Fatal("fixture must contain at least one import cycle or the assertion is vacuous")
+	}
+}
+
+// TestScanRepo_OpensTheGraphExactlyOnce is the hazard assertion: the whole
+// analytics batch for one repo must touch the on-disk graph a single time. The
+// pre-change path opened and fully materialised it four times per repo.
+func TestScanRepo_OpensTheGraphExactlyOnce(t *testing.T) {
+	doc := fixtureDoc()
+	_, stateDir := writeFixture(t, doc)
+
+	opens := 0
+	orig := openGraphView
+	openGraphView = func(dir string) (graphView, error) {
+		opens++
+		return orig(dir)
+	}
+	t.Cleanup(func() { openGraphView = orig })
+
+	if _, err := ScanRepo(stateDir); err != nil {
+		t.Fatalf("ScanRepo: %v", err)
+	}
+	if opens != 1 {
+		t.Fatalf("ScanRepo opened the graph %d times, want exactly 1 — the whole "+
+			"analytics batch must share a single open view", opens)
+	}
+}
+
+// TestScanRepo_NeverMaterialisesADocument is the memory hazard, pinned
+// structurally: the scan must not go through the full-materialise loader.
+func TestScanRepo_NeverMaterialisesADocument(t *testing.T) {
+	doc := fixtureDoc()
+	_, stateDir := writeFixture(t, doc)
+
+	loads := 0
+	orig := loadDocument
+	loadDocument = func(dir string) (*graph.Document, error) {
+		loads++
+		return orig(dir)
+	}
+	t.Cleanup(func() { loadDocument = orig })
+
+	if _, err := ScanRepo(stateDir); err != nil {
+		t.Fatalf("ScanRepo: %v", err)
+	}
+	if loads != 0 {
+		t.Fatalf("ScanRepo materialised a full graph.Document %d times; with a readable "+
+			"graph.fb present it must scan the mmap and never materialise", loads)
+	}
+}
+
+// TestScanRepo_FallsBackToDocumentWhenNoReadableFB keeps the JSON-only /
+// version-incompatible repos working: no mmap view is available there, so the
+// Document loader is the correct (and only) path.
+func TestScanRepo_FallsBackToDocumentWhenNoReadableFB(t *testing.T) {
+	doc := fixtureDoc()
+	_, stateDir := writeFixture(t, doc)
+
+	openGraphViewOrig := openGraphView
+	openGraphView = func(string) (graphView, error) { return nil, errNoView }
+	t.Cleanup(func() { openGraphView = openGraphViewOrig })
+
+	got, err := ScanRepo(stateDir)
+	if err != nil {
+		t.Fatalf("ScanRepo fallback: %v", err)
+	}
+	if want := ScanDocument(doc); got != want {
+		t.Fatalf("fallback scan = %+v, want %+v", got, want)
+	}
+}
+
+// TestCoverageTotals_NameAffinityIsDirectoryScoped pins the SourceFile field to
+// the set graph.CoverageTotalsFromView retains.
+//
+// THE HAZARD IS SILENT INFLATION, not a crash. Phase 3 (attributeByNameAffinity)
+// credits a production subject when a test's normalised name token matches AND
+// the two share a directory subtree. The streaming scan retains only four fields
+// per entity; drop SourceFile from that set and every retained row reports dir
+// "", sharesDirSubtree("", "") is true by its a == b branch, and the subtree gate
+// stops discriminating entirely. On a real corpus that credits every same-token
+// test/subject pair repo-wide and inflates CoveredProduction — a metric that only
+// ever moves up, so nothing downstream would look wrong.
+//
+// A fixture where every entity lives under one directory cannot see this: the
+// gate answers "same subtree" whether or not SourceFile survives. So this fixture
+// is deliberately SPLIT — a same-dir pair that must be credited, and a
+// cross-subtree pair that must not — and asserts the exact count, which is the
+// only form of the assertion that separates the two answers.
+func TestCoverageTotals_NameAffinityIsDirectoryScoped(t *testing.T) {
+	ents := []graph.Entity{
+		// Same directory: affinity SHOULD credit. This is the control — without
+		// it, a scanner that credited nothing at all would also pass.
+		{ID: "aaaaaaaaaaaaaaa1", Name: "AlphaService", Kind: "Class", SourceFile: "src/alpha.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb1", Name: "TestAlphaService", Kind: "SCOPE.Operation", SourceFile: "src/alpha_test.go", Language: "go"},
+		// Disjoint subtrees ("src" vs "tools/qa", neither a prefix of the other):
+		// same token, but affinity MUST decline.
+		{ID: "aaaaaaaaaaaaaaa2", Name: "BetaService", Kind: "Class", SourceFile: "src/beta.go", Language: "go"},
+		{ID: "bbbbbbbbbbbbbbb2", Name: "TestBetaService", Kind: "SCOPE.Operation", SourceFile: "tools/qa/beta_test.go", Language: "go"},
+	}
+	doc := &graph.Document{
+		Version:  graph.SchemaVersion,
+		Entities: ents,
+		Stats:    graph.Stats{Entities: len(ents)},
+	}
+	_, stateDir := writeFixture(t, doc)
+
+	got, err := ScanRepo(stateDir)
+	if err != nil {
+		t.Fatalf("ScanRepo: %v", err)
+	}
+
+	if got.TotalProduction != 2 {
+		t.Fatalf("TotalProduction = %d, want 2 — the fixture no longer holds exactly "+
+			"one same-dir and one cross-subtree subject, so the counts below prove nothing",
+			got.TotalProduction)
+	}
+	if got.CoveredProduction != 1 {
+		t.Errorf("CoveredProduction = %d, want 1: AlphaService is credited by the "+
+			"same-directory test; BetaService must NOT be credited by tools/qa/beta_test.go. "+
+			"Got 2 => phase-3 name affinity is no longer directory-scoped on the streaming "+
+			"path, which means CoverageTotalsFromView stopped retaining SourceFile.",
+			got.CoveredProduction)
+	}
+}
+
+// TestScan_KindRulesMatchTheOriginalInlineRules pins Endpoints, Flows and
+// AuthUncovered to the rules they were extracted FROM.
+//
+// Those three fields are the only ones in RepoScan with no external reference.
+// Every other number is proven against a function that pre-dates the change
+// (audit.AuditPath, graph.ComputeCoverage, graph.FindImportCycles), but these
+// three are computed by countKinds / accumulateRel / isAuthScopedEndpointKind —
+// helpers this change introduced, called by BOTH scanView and ScanDocument. The
+// differential tests therefore compare the new rules against themselves; a
+// mis-transcription would have been invisible, and so would any later drift.
+//
+// The oracle below is transcribed by hand from the pre-change inline code
+// (`git show 388305611:cmd/grafel/rebuild_history.go`) and deliberately calls
+// NONE of the package's helpers — routing it through them would restore exactly
+// the circularity it exists to break.
+func TestScan_KindRulesMatchTheOriginalInlineRules(t *testing.T) {
+	doc := fixtureDoc()
+
+	// ── oracle: the original rules, verbatim ─────────────────────────────────
+	// From the pre-change entity loop in appendRebuildHistory.
+	wantEndpoints, wantFlows := 0, 0
+	for _, e := range doc.Entities {
+		switch e.Kind {
+		case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
+			wantEndpoints++
+		}
+		// isProcessFlow, verbatim — including the len>14 prefix test.
+		isFlow := false
+		switch e.Kind {
+		case "process", "SCOPE.Process":
+			isFlow = true
+		default:
+			isFlow = len(e.Kind) > 14 && e.Kind[:14] == "SCOPE.Process."
+		}
+		if isFlow {
+			wantFlows++
+		}
+	}
+	// From countAuthUncoveredEndpoints, verbatim — case-sensitive on the raw
+	// kind, keyed on FromID, and over a NARROWER endpoint set than the tally.
+	authed := make(map[string]bool, 16)
+	for _, r := range doc.Relationships {
+		if r.Kind == "HAS_AUTH" || r.Kind == "REQUIRES_AUTH" || r.Kind == "auth" {
+			authed[r.FromID] = true
+		}
+	}
+	wantAuthUncovered := 0
+	for _, e := range doc.Entities {
+		switch e.Kind {
+		case "http_endpoint", "http_endpoint_definition":
+			if !authed[e.ID] {
+				wantAuthUncovered++
+			}
+		}
+	}
+
+	// ── the fixture must actually exercise each rule ─────────────────────────
+	// Without these the three comparisons below could all pass on zeroes, and
+	// the equalities would not discriminate between the rules and any weaker
+	// rule that agrees with them on an empty set.
+	if wantEndpoints == 0 || wantFlows == 0 || wantAuthUncovered == 0 {
+		t.Fatalf("vacuous fixture: endpoints=%d flows=%d authUncovered=%d, all must be > 0",
+			wantEndpoints, wantFlows, wantAuthUncovered)
+	}
+	// The endpoint TALLY must be strictly wider than the AUTH-SCOPED set, or the
+	// http_endpoint_call carve-out is untested.
+	if wantEndpoints <= wantAuthUncovered+len(authed) {
+		t.Fatalf("fixture lacks an http_endpoint_call: the endpoint tally (%d) must exceed "+
+			"the auth-scoped set (%d uncovered + %d authed)",
+			wantEndpoints, wantAuthUncovered, len(authed))
+	}
+	// A wrong-case auth kind must be present and must have been REJECTED, or the
+	// case sensitivity of the auth match is untested.
+	sawWrongCase := false
+	for _, r := range doc.Relationships {
+		if strings.EqualFold(r.Kind, "REQUIRES_AUTH") && r.Kind != "REQUIRES_AUTH" {
+			sawWrongCase = true
+			if authed[r.FromID] {
+				t.Fatalf("fixture entity %s is authed by another edge, so the wrong-case "+
+					"edge %q proves nothing about case sensitivity", r.FromID, r.Kind)
+			}
+		}
+	}
+	if !sawWrongCase {
+		t.Fatal("fixture lacks a wrong-case auth edge; the case-sensitive match is untested")
+	}
+	// A "SCOPE.Process"-prefixed near-miss must be present and NOT counted as a
+	// flow, or the len>14 boundary is untested.
+	sawNearMiss := false
+	for _, e := range doc.Entities {
+		if strings.HasPrefix(e.Kind, "SCOPE.Process") && e.Kind != "SCOPE.Process" &&
+			!strings.HasPrefix(e.Kind, "SCOPE.Process.") {
+			sawNearMiss = true
+		}
+	}
+	if !sawNearMiss {
+		t.Fatal("fixture lacks a SCOPE.Process* near-miss kind; the len>14 prefix " +
+			"boundary in isProcessFlowKind is untested")
+	}
+
+	// ── both paths must agree with the oracle ────────────────────────────────
+	_, stateDir := writeFixture(t, doc)
+	streamed, err := ScanRepo(stateDir)
+	if err != nil {
+		t.Fatalf("ScanRepo: %v", err)
+	}
+	for _, tc := range []struct {
+		path string
+		got  RepoScan
+	}{
+		{"ScanDocument", ScanDocument(doc)},
+		{"ScanRepo", streamed},
+	} {
+		if tc.got.Endpoints != wantEndpoints {
+			t.Errorf("%s Endpoints = %d, want %d (original inline rule)",
+				tc.path, tc.got.Endpoints, wantEndpoints)
+		}
+		if tc.got.Flows != wantFlows {
+			t.Errorf("%s Flows = %d, want %d (original isProcessFlow)",
+				tc.path, tc.got.Flows, wantFlows)
+		}
+		if tc.got.AuthUncovered != wantAuthUncovered {
+			t.Errorf("%s AuthUncovered = %d, want %d (original countAuthUncoveredEndpoints)",
+				tc.path, tc.got.AuthUncovered, wantAuthUncovered)
+		}
+	}
+}
+
+// TestTallyRepo_MatchesDocumentReference covers the agents-map stats tally,
+// the fourth full load, which is now a kind-only streaming scan.
+func TestTallyRepo_MatchesDocumentReference(t *testing.T) {
+	doc := fixtureDoc()
+	_, stateDir := writeFixture(t, doc)
+
+	got, err := TallyRepo(stateDir)
+	if err != nil {
+		t.Fatalf("TallyRepo: %v", err)
+	}
+	if want := TallyDocument(doc); got != want {
+		t.Fatalf("TallyRepo = %+v, want %+v", got, want)
+	}
+	if got.Entities != doc.Stats.Entities || got.Relationships != doc.Stats.Relationships {
+		t.Errorf("TallyRepo counts = %d/%d, want %d/%d",
+			got.Entities, got.Relationships, doc.Stats.Entities, doc.Stats.Relationships)
+	}
+}

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -156,6 +156,30 @@ type Recommendation struct {
 // corpus=true forces directory mode regardless of layout, which matches the
 // --corpus flag wired by the CLI.
 func AuditPath(path string, corpus bool) (*Report, error) {
+	return AuditPathWithWorkers(path, corpus, DefaultAuditWorkers)
+}
+
+// DefaultAuditWorkers is the corpus-mode fan-out AuditPath uses. Each worker
+// holds its own fully materialised graph.Document, so the peak heap of a
+// corpus audit is workers × the largest repo's Document.
+const DefaultAuditWorkers = 4
+
+// AuditPathWithWorkers is AuditPath with an explicit corpus-mode fan-out.
+//
+// #5954: four concurrent workers each materialise a 300–600 MB Document. That
+// is the right trade for the interactive CLI (`grafel quality audit-orphans
+// --corpus`), where a human is waiting on wall-clock. It is the wrong trade
+// for anything running INSIDE the daemon — a background metrics write has no
+// latency budget worth four co-resident copies of the corpus graph, and the
+// daemon is exactly the process whose resident footprint this epic is trying to
+// shrink. In-daemon callers pass 1.
+//
+// workers < 1 is clamped to 1. The single-repo (non-corpus) branch is
+// unaffected: it audits one repo inline and never fans out.
+func AuditPathWithWorkers(path string, corpus bool, workers int) (*Report, error) {
+	if workers < 1 {
+		workers = 1
+	}
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve path: %w", err)
@@ -184,7 +208,7 @@ func AuditPath(path string, corpus bool) (*Report, error) {
 		if len(paths) == 0 {
 			return nil, fmt.Errorf("no .grafel/graph.json found under %s", abs)
 		}
-		rep.Repos = auditMany(paths)
+		rep.Repos = auditMany(paths, workers)
 	}
 	rep.Aggregate = aggregate(rep.Repos)
 	rep.Recommendations = recommend(rep.Aggregate)
@@ -243,12 +267,19 @@ func findRepos(root string) ([]string, error) {
 	return out, nil
 }
 
-// auditMany runs auditRepo on each path with a small worker pool (4) so a
+// auditMany runs auditRepo on each path with a small worker pool so a
 // 25-repo corpus completes well under a minute. Each goroutine owns its own
 // json.Decoder; the shared mutex only guards the output slice.
-func auditMany(paths []string) []*RepoReport {
+//
+// The pool size is a parameter (#5954) because each worker holds a full
+// Document: concurrency here IS peak heap, and in-daemon callers must not pay
+// it. Output is written into a pre-sized slice by index, so the report is
+// byte-identical at any pool size.
+func auditMany(paths []string, workers int) []*RepoReport {
 	out := make([]*RepoReport, len(paths))
-	const workers = 4
+	if workers < 1 {
+		workers = 1
+	}
 	var wg sync.WaitGroup
 	jobs := make(chan int)
 	wg.Add(workers)
@@ -460,6 +491,19 @@ func isFunctionLike(e *graph.Entity) bool {
 	}
 	return false
 }
+
+// ClassifyImportToID is the exported form of classifyImportToID (#5954).
+//
+// It exists so the daemon's streaming analytics scan buckets IMPORTS edges with
+// the SAME function the audit report uses, rather than a second copy that could
+// drift and silently move the persisted bug rate.
+func ClassifyImportToID(toID string) ImportFormat { return classifyImportToID(toID) }
+
+// IsStructuralRelKind reports whether an UPPERCASED relationship kind is a
+// containment/declaration edge that does not count toward connectivity — the
+// orphan-detection rule of #1597. Exported for the same single-source-of-truth
+// reason as ClassifyImportToID.
+func IsStructuralRelKind(upperKind string) bool { return structuralRelKinds[upperKind] }
 
 // classifyImportToID buckets an IMPORTS edge's to_id by shape. Anything that
 // doesn't look like an entity id (16 lowercase hex) or an "ext:" placeholder


### PR DESCRIPTION
## What

`appendRebuildHistory` ran in a bare goroutine after every rebuild — outside the stage gate, outside the busy predicate, outside memtrace — and materialised each repo's graph up to four times (audit, coverage + import cycles, auth-uncovered endpoints, agents-map stats).

It now performs **one mmap-backed `fbreader.GraphView` scan per repo**, in a new `internal/quality/analytics` package, and registers itself with the scheduler so it is visible as real work.

## The four loads

| was | now |
|---|---|
| `audit.AuditPath` | streamed id-set + `touched` set |
| `ComputeCoverage` / `FindImportCycles` | `graph.CoverageTotalsFromView` / `graph.CountImportCyclesFromView` |
| `countAuthUncoveredEndpoints` | second iteration over the already-open view |
| `buildAgentsMapStats` | `analytics.TallyRepo` |

No `Document` is constructed on the live path — pinned by `TestScanRepo_NeverMaterialisesADocument` and `TestAppendRebuildHistory_ScansEachRepoOnce`, the latter asserting `loadGraphFromStateDir` is called zero times. `Document` survives only as the graph.json fallback for version-incompatible repos, which doubles as an independent test oracle.

Import cycles genuinely needed adjacency, so that path takes an id set plus an `id -> id` map. A shared `addImportEdge` + `findImportCyclesFromAdjacency` core keeps the slice and view paths running the same code, and the slice path (the pre-existing production path) is unchanged.

## Correction to the original framing

The rebuild caller **never reached `auditMany`** — it calls `AuditPath(repoPath, false)`, which takes the single-repo `auditRepo` branch. The 4-way fan-out was on the CLI/dashboard corpus path. So this change's win on the rebuild path is entirely the removal of four loads per repo, not a pool-size change.

## Scheduler registration

Registers via the **foreground barge**, not the EXCLUSIVE stage token. The batch fires once with no retry timer, so a token it could block on would let a metrics write stall real write-side work; the barge records unconditionally and returns immediately, so it can neither be starved nor starve a stage.

This also closes a pre-existing hole where `FreeOSMemory` could fire mid-rebuild.

## Output identity

The whole point is that a metrics number must not silently change. Three chained differential tests plus a non-vacuity guard prove `health-history.jsonl` is byte-identical.

An independent reviewer verified the load-bearing retention argument from the code rather than accepting it: every writer of `covered` is guarded by `prodIDs`, so `covered` is a subset of `prodIDs` by construction, and phase 4 can never credit an edge whose endpoints were not retained. Phases 3 and 4 are called verbatim, not reimplemented. The reviewer then built an adversarial fixture — neither-entities as handler on both edge directions, a dangling `IMPLEMENTS` endpoint, contract-spec edges — and got identical results from the streaming and materialised paths.

## Test hardening from review

- **`SourceFile` retention was a mutation survivor.** Every fixture entity lived in `src/`, and `sharesDirSubtree("","")` returns true, so phase-3 name affinity credited either way. On a real corpus, dropping `SourceFile` would make every same-token test/subject pair match repo-wide and silently **inflate** `CoveredProduction`. `TestCoverageTotals_NameAffinityIsDirectoryScoped` now uses a split fixture — a same-dir pair that must be credited and a disjoint-subtree pair that must not.
- **`Endpoints` / `Flows` / `AuthUncovered` were self-validated** — both the streaming and document paths routed through the same new helpers, so a mis-transcription would have passed. `TestScan_KindRulesMatchTheOriginalInlineRules` transcribes the pre-change rules by hand and calls none of the new helpers. Fixture gained discriminators: an `http_endpoint_call` (in the tally, outside the auth-scoped set), a lowercase `auth` edge that counts alongside a lowercase `requires_auth` that must not (the match is case-sensitive), and a 15-char near-miss for the `len(kind) > 14` boundary.

## Mutations

All die: orphan count zeroed; test entities not retained in `entByID`; barge registration removed; fixture made genuinely vacuous (guard fires); `SourceFile` dropped; endpoint tally drops `http_endpoint_call`; `isProcessFlowKind` weakened to a plain prefix test; auth match made case-insensitive; auth keyed on `ToID` instead of `FromID`.

## Verification

`go build`, `go vet ./cmd/... ./internal/...`, `gofmt -l internal cmd` clean. 977 passed across the 17 target packages. `./internal/daemon/sched/... -race -count=2` → 344 passed, race-clean.

`TestRunSubprocessLinks_CancelTerminatesChild` is pre-existing flaky and tracked as #5999.

Refs #5954
