### PR TITLE
fix(#5954): resolve batch-child caps and nice from who asked for the work

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1398,6 +1398,22 @@ func daemonRebuildFuncCore(
 	// one-shots, watcher-less daemons, tests) and when GRAFEL_STAGE_GATE=0.
 	defer sched.BargeForeground("rebuild:" + args.Group)()
 
+	// #5954 WALL TIME. The barge above tells the stage gate "hold background
+	// stages off"; this tells every child spawn helper "a human is waiting on
+	// THIS group, resolve foreground caps". They are separate signals on
+	// purpose — see internal/daemon/sched/foreground.go. The barge lifts when
+	// this function returns, but the stages that dominate the user's wall clock
+	// (the scheduler's cross-repo link pass, and the debounced group-algo pass
+	// that finishes the graph) are spawned minutes AFTER that, so a cap resolved
+	// off the barge would still hand the user's rebuild the 2-core background
+	// cap for its heaviest stage — the 10min → 30min+ regression.
+	//
+	// The mark lingers past this release and is closed by the group-algo pass
+	// completing (sched.ClearGroupForeground in runGroupAlgo), with a time
+	// backstop so a group whose group-algo never runs cannot keep drawing full
+	// machine capacity for background churn.
+	defer sched.MarkGroupForeground(args.Group)()
+
 	rebuildStart := time.Now()
 	fmt.Fprintf(os.Stderr, "grafel: rebuild start group=%s slug=%q wipe=%v incremental=%v\n",
 		args.Group, args.Slug, args.Wipe, args.Incremental)

--- a/cmd/grafel/foreground_wallclock_5954_test.go
+++ b/cmd/grafel/foreground_wallclock_5954_test.go
@@ -1,0 +1,146 @@
+package main
+
+// foreground_wallclock_5954_test.go — the WIRING half of the foreground /
+// background cap split (#5954 wall-time regression).
+//
+// sched owns the policy and tests it directly. What it cannot see is whether
+// the rebuild path — the one place in the product where a human is demonstrably
+// waiting — actually announces itself. Without that announcement every child a
+// `grafel reset` / rebuild RPC ultimately causes (the index child, the
+// scheduler's follow-on link pass, and the debounced group-algo pass that
+// finishes the graph) resolves BACKGROUND caps, and the user waits 30+ minutes
+// for what used to take 10.
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+)
+
+// TestRebuild_MarksTheGroupForeground: while the rebuild runs, and — critically
+// — after it returns, the group must read as foreground so the follow-on
+// stages the user is still waiting on are not spawned at background caps.
+func TestRebuild_MarksTheGroupForeground(t *testing.T) {
+	group := setupTestGroup(t, "fg-caps-group", []string{"first", "second"})
+	t.Cleanup(func() { sched.ClearGroupForeground(group) })
+
+	var duringIndex, duringLinks atomic.Bool
+	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
+		if sched.GroupIsForeground(group) {
+			duringIndex.Store(true)
+		}
+		return nil
+	}
+	linksFn := func(_ context.Context, _ string) error {
+		duringLinks.Store(sched.GroupIsForeground(group))
+		return nil
+	}
+
+	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, mockIndexFn, linksFn); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+
+	if !duringIndex.Load() {
+		t.Error("the group did not read as foreground during the rebuild's index batch — " +
+			"every child spawned for it resolves the 25% background caps (#5954)")
+	}
+	if !duringLinks.Load() {
+		t.Error("the group did not read as foreground during the rebuild's link pass")
+	}
+	if !sched.GroupIsForeground(group) {
+		t.Error("the group stopped reading as foreground the moment the rebuild returned — " +
+			"the debounced group-algo pass (measured 32–53 min at cap=2) fires AFTER this point " +
+			"and is exactly what the user is still waiting for")
+	}
+}
+
+// A rebuild that fails early must still not wedge an unrelated group into
+// foreground caps, and must not leave a permanent hold.
+func TestRebuild_ForegroundMarkDoesNotLeakToOtherGroups(t *testing.T) {
+	group := setupTestGroup(t, "fg-caps-other", []string{"only"})
+	t.Cleanup(func() { sched.ClearGroupForeground(group) })
+
+	idx := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
+	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, idx, noopLinksFn); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if sched.GroupIsForeground("some-other-group") {
+		t.Error("rebuilding one group marked an unrelated group foreground")
+	}
+}
+
+// --- GOGC on the foreground index child --------------------------------------
+
+// GOGC=50 costs ~4.7% wall on the index child and exists to trade GC CPU for
+// RSS on work nobody is waiting on. On the foreground path someone IS waiting,
+// and the standing product rule ("interactive work is never GC-capped", see the
+// allow-list in index_gcpercent.go) already says so — the index child was only
+// capped because the allow-list keys on argv[1], which is `index-internal` for
+// BOTH the background reindex and the user's rebuild.
+func TestIndexGCPercent_ForegroundIndexChildIsNotCapped(t *testing.T) {
+	got, source := indexGCPercentDecision(backgroundIndexCommand, true, "", "")
+	if got != gcPercentUnset {
+		t.Errorf("foreground index child GC percent = %d, want uncapped — "+
+			"a human-awaited rebuild must not pay GC time for RSS it is not short of (source=%s)", got, source)
+	}
+	if !strings.Contains(strings.ToLower(source), "foreground") {
+		t.Errorf("decision source = %q, want it to name the foreground path", source)
+	}
+}
+
+func TestIndexGCPercent_BackgroundIndexChildStillCapped(t *testing.T) {
+	got, source := indexGCPercentDecision(backgroundIndexCommand, false, "", "")
+	if got != indexGCPercentDefault {
+		t.Errorf("background index child GC percent = %d, want %d (source=%s) — "+
+			"the background RSS policy is a standing decision and must not regress",
+			got, indexGCPercentDefault, source)
+	}
+}
+
+// The two batch children keep GOGC=50 even in foreground: their live heap is
+// UNMEASURED, and doubling the GC target on an unmeasured heap on a 16 GB box
+// is the risk this repo has already been burned by.
+func TestIndexGCPercent_BatchChildrenStayCappedEvenForeground(t *testing.T) {
+	for _, cmd := range []string{backgroundGroupAlgoCommand, backgroundLinksCommand} {
+		if got, source := indexGCPercentDecision(cmd, true, "", ""); got != indexGCPercentDefault {
+			t.Errorf("%s foreground GC percent = %d, want %d (source=%s) — "+
+				"this child's live heap is unmeasured; relaxing GC pacing there is unbounded risk",
+				cmd, got, indexGCPercentDefault, source)
+		}
+	}
+}
+
+// The operator escape hatch keeps its precedence on the background path, and
+// still cannot conjure a cap onto the foreground path.
+func TestIndexGCPercent_EnvOverrideUnchanged(t *testing.T) {
+	if got, _ := indexGCPercentDecision(backgroundIndexCommand, false, "35", ""); got != 35 {
+		t.Errorf("GRAFEL_INDEX_GOGC=35 background = %d, want 35", got)
+	}
+	if got, _ := indexGCPercentDecision("rebuild", false, "35", ""); got != gcPercentUnset {
+		t.Errorf("GRAFEL_INDEX_GOGC=35 on a non-allow-listed command = %d, want uncapped", got)
+	}
+}
+
+// The foreground signal for the index child comes off its own argv — the child
+// is already spawned with --interactive (#5135), so no new mechanism is needed.
+func TestIndexChildArgvCarriesTheForegroundSignal(t *testing.T) {
+	if !argvIsInteractive([]string{"--repo=/x", "--interactive"}) {
+		t.Error("--interactive not recognised in the index child argv")
+	}
+	if !argvIsInteractive([]string{"-interactive", "--repo=/x"}) {
+		t.Error("single-dash -interactive not recognised (Go's flag package accepts both)")
+	}
+	if !argvIsInteractive([]string{"--interactive=true"}) {
+		t.Error("--interactive=true not recognised")
+	}
+	if argvIsInteractive([]string{"--interactive=false"}) {
+		t.Error("--interactive=false read as foreground")
+	}
+	if argvIsInteractive([]string{"--repo=/x", "--incremental=/y"}) {
+		t.Error("a background reindex argv read as foreground")
+	}
+}

--- a/cmd/grafel/foreground_wallclock_5954_test.go
+++ b/cmd/grafel/foreground_wallclock_5954_test.go
@@ -26,7 +26,7 @@ import (
 // stages the user is still waiting on are not spawned at background caps.
 func TestRebuild_MarksTheGroupForeground(t *testing.T) {
 	group := setupTestGroup(t, "fg-caps-group", []string{"first", "second"})
-	t.Cleanup(func() { sched.ClearGroupForeground(group) })
+	t.Cleanup(func() { sched.ForgetGroupForeground(group) })
 
 	var duringIndex, duringLinks atomic.Bool
 	mockIndexFn := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error {
@@ -62,7 +62,7 @@ func TestRebuild_MarksTheGroupForeground(t *testing.T) {
 // foreground caps, and must not leave a permanent hold.
 func TestRebuild_ForegroundMarkDoesNotLeakToOtherGroups(t *testing.T) {
 	group := setupTestGroup(t, "fg-caps-other", []string{"only"})
-	t.Cleanup(func() { sched.ClearGroupForeground(group) })
+	t.Cleanup(func() { sched.ForgetGroupForeground(group) })
 
 	idx := func(_, _, _ string, _ []string, _, _ bool, _ ...IndexOption) error { return nil }
 	if _, _, err := daemonRebuildFuncCore(1, proto.RebuildArgs{Group: group}, idx, noopLinksFn); err != nil {

--- a/cmd/grafel/group_algo.go
+++ b/cmd/grafel/group_algo.go
@@ -55,9 +55,14 @@ func runGroupAlgo(args []string) int {
 	// PageRank + betweenness over the whole group union). Lower its OS
 	// scheduling priority so even its capped cores yield to foreground work —
 	// the v0.1.3 CPU regression starved a consumer's test harness. No-op on
-	// Windows. The GOMAXPROCS cap is applied by the parent (env, default 2);
-	// nice is best-effort self-renice so it holds however the child is spawned.
-	sched.NiceSelf()
+	// Windows. The GOMAXPROCS cap is applied by the parent (env); nice is a
+	// best-effort self-renice so it holds however the child is spawned.
+	//
+	// UNLESS the parent told us this pass is user-awaited (#5954). An
+	// unconditional renice here is what put a `grafel reset` the user is
+	// blocking on below their editor: the demotion is right for background
+	// churn and wrong for work someone explicitly asked for and is waiting on.
+	sched.NiceSelfUnlessForeground()
 
 	// #5954 / #5956 memtrace: opt-in phase-tagged memstats sampler + per-phase
 	// heap profiles, gated entirely behind GRAFEL_MEMTRACE_DIR (which this child

--- a/cmd/grafel/group_algo_memory_test.go
+++ b/cmd/grafel/group_algo_memory_test.go
@@ -110,7 +110,7 @@ func TestGroupAlgoGCPercentDecision(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotPercent, gotSource := indexGCPercentDecision(tc.command, tc.rawEnv, tc.rawGOGC)
+			gotPercent, gotSource := indexGCPercentDecision(tc.command, false, tc.rawEnv, tc.rawGOGC)
 			if gotPercent != tc.wantPercent {
 				t.Errorf("indexGCPercentDecision(%q, %q, %q) percent = %d, want %d",
 					tc.command, tc.rawEnv, tc.rawGOGC, gotPercent, tc.wantPercent)
@@ -133,7 +133,7 @@ func TestApplyGroupAlgoGCPercentReachesTheRuntime(t *testing.T) {
 
 	t.Run("group-algo child is capped at the policy value", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent("group-algo", "", "")
+		applyIndexGCPercent("group-algo", false, "", "")
 		if got := debug.SetGCPercent(100); got != indexGCPercentDefault {
 			t.Fatalf("GOGC in force after applyIndexGCPercent(group-algo) = %d, want %d", got, indexGCPercentDefault)
 		}
@@ -141,7 +141,7 @@ func TestApplyGroupAlgoGCPercentReachesTheRuntime(t *testing.T) {
 
 	t.Run("operator override is what actually reaches the runtime", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent("group-algo", "35", "")
+		applyIndexGCPercent("group-algo", false, "35", "")
 		if got := debug.SetGCPercent(100); got != 35 {
 			t.Fatalf("GOGC in force after applyIndexGCPercent(group-algo) = %d, want 35", got)
 		}
@@ -155,7 +155,7 @@ func TestApplyGroupAlgoGCPercentReachesTheRuntime(t *testing.T) {
 	t.Run("interactive commands stay uncapped even with the override set", func(t *testing.T) {
 		for _, cmd := range []string{"index", "rebuild", "daemon", ""} {
 			debug.SetGCPercent(100)
-			applyIndexGCPercent(cmd, "35", "")
+			applyIndexGCPercent(cmd, false, "35", "")
 			if got := debug.SetGCPercent(100); got != 100 {
 				t.Fatalf("applyIndexGCPercent(%q, \"35\", \"\") changed GOGC to %d, want it left at 100", cmd, got)
 			}

--- a/cmd/grafel/index_gcpercent.go
+++ b/cmd/grafel/index_gcpercent.go
@@ -122,23 +122,76 @@ func parseIndexGCPercentEnv(raw string) (percent int, decided bool) {
 	return n, true
 }
 
-// indexGCPercentDecision combines the path guard, the escape hatch and the
-// policy default. The returned source string is operator-facing — it goes
-// straight into the one-shot log line.
+// argvIsInteractive reports whether an `index-internal` argv carries the
+// --interactive flag, i.e. the child was fork-exec'd for a human-awaited
+// rebuild rather than background churn (#5135 sets the flag; see
+// SubprocessIndexOptions.Interactive).
+//
+// Parsed here, from raw argv, rather than read off the flag.FlagSet inside
+// runIndexInternal, because the GC decision has to be made in main() BEFORE the
+// command runs — debug.SetGCPercent wants to be set before the heap grows, not
+// after. Accepts every spelling Go's flag package does: -interactive,
+// --interactive, and =true/=false forms.
+func argvIsInteractive(argv []string) bool {
+	for _, a := range argv {
+		name := strings.TrimPrefix(strings.TrimPrefix(a, "--"), "-")
+		value := ""
+		if i := strings.IndexByte(name, '='); i >= 0 {
+			name, value = name[:i], name[i+1:]
+		}
+		if name != "interactive" {
+			continue
+		}
+		if value == "" {
+			return true
+		}
+		return !(value == "false" || value == "0" || value == "no")
+	}
+	return false
+}
+
+// indexGCPercentDecision combines the path guard, the foreground exemption, the
+// escape hatch and the policy default. The returned source string is
+// operator-facing — it goes straight into the one-shot log line.
 //
 // Precedence, highest first:
 //
 //  1. command is not one of the background batch children -> never capped.
 //     This gate is first on purpose: GRAFEL_INDEX_GOGC tunes the background
 //     cap, it does not create one on the interactive path.
-//  2. GRAFEL_INDEX_GOGC, when well-formed -> the operator's explicit choice.
-//  3. GOGC set explicitly in the environment -> leave the runtime alone. The
+//
+//  2. the child is the INDEX child of a foreground rebuild -> never capped.
+//     Same standing rule as (1) — "a user waiting on a command should not pay
+//     GC time to save memory they are not short of" — reaching a case the
+//     allow-list structurally cannot see, because argv[1] is `index-internal`
+//     for both a background reindex and the rebuild the user just typed. The
+//     cap costs ~4.7% wall on this child (measured, #5954) for RSS that only
+//     matters when the child is competing with the developer's own work; on the
+//     foreground path the stage-gate barge has already held the other heavy
+//     stages off, so it is not competing with anything.
+//
+//     Bounded by evidence, not by preference: this child's heap IS measured —
+//     ~1707MB live peak, and at GOGC=100 it carried a 3679MB heap_sys, which
+//     fits a 16GB box with the barge in force. The two BATCH children
+//     (group-algo, links) get no such exemption even in foreground: their live
+//     heap is unmeasured, and picking a looser GC target for an unmeasured heap
+//     is how this repo landed in the GOMEMLIMIT death spiral it documents in
+//     index_memlimit.go. When they are measured, revisit — not before.
+//
+//  3. GRAFEL_INDEX_GOGC, when well-formed -> the operator's explicit choice.
+//
+//  4. GOGC set explicitly in the environment -> leave the runtime alone. The
 //     runtime has already applied it; overriding would silently discard an
 //     instruction the operator gave in the most standard way there is.
-//  4. otherwise -> indexGCPercentDefault.
-func indexGCPercentDecision(command, rawEnv, rawGOGC string) (percent int, source string) {
+//
+//  5. otherwise -> indexGCPercentDefault.
+func indexGCPercentDecision(command string, foreground bool, rawEnv, rawGOGC string) (percent int, source string) {
 	if !isBackgroundGCPercentCommand(command) {
 		return gcPercentUnset, "interactive/foreground path (" + command + ") — GC pacing is not capped"
+	}
+	if foreground && command == backgroundIndexCommand {
+		return gcPercentUnset, "foreground rebuild index child (" + command +
+			" --interactive) — a human is waiting; GC pacing is not capped (#5954)"
 	}
 	if n, decided := parseIndexGCPercentEnv(rawEnv); decided {
 		return n, indexGCPercentEnv + "=" + strings.TrimSpace(rawEnv) + " (env)"
@@ -176,8 +229,8 @@ func indexGCPercentDecision(command, rawEnv, rawGOGC string) (percent int, sourc
 // on any group. The death spiral is unreachable by construction. That is the
 // whole reason group-algo may be paced now and memory-limited only once it has
 // been measured.
-func applyIndexGCPercent(command, rawEnv, rawGOGC string) {
-	percent, source := indexGCPercentDecision(command, rawEnv, rawGOGC)
+func applyIndexGCPercent(command string, foreground bool, rawEnv, rawGOGC string) {
+	percent, source := indexGCPercentDecision(command, foreground, rawEnv, rawGOGC)
 	tag := command
 	if tag == "" {
 		tag = "grafel"

--- a/cmd/grafel/index_gcpercent_test.go
+++ b/cmd/grafel/index_gcpercent_test.go
@@ -77,7 +77,7 @@ func TestIndexGCPercentDecision(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			gotPercent, gotSource := indexGCPercentDecision(tc.command, tc.rawEnv, tc.rawGOGC)
+			gotPercent, gotSource := indexGCPercentDecision(tc.command, false, tc.rawEnv, tc.rawGOGC)
 			if gotPercent != tc.wantPercent {
 				t.Errorf("indexGCPercentDecision(%q, %q, %q) percent = %d, want %d",
 					tc.command, tc.rawEnv, tc.rawGOGC, gotPercent, tc.wantPercent)
@@ -137,7 +137,7 @@ func TestApplyIndexGCPercentActuallyApplies(t *testing.T) {
 
 	t.Run("background child is capped at the policy value", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent(backgroundIndexCommand, "", "")
+		applyIndexGCPercent(backgroundIndexCommand, false, "", "")
 		if got := debug.SetGCPercent(100); got != indexGCPercentDefault {
 			t.Fatalf("GOGC in force after applyIndexGCPercent = %d, want %d", got, indexGCPercentDefault)
 		}
@@ -145,7 +145,7 @@ func TestApplyIndexGCPercentActuallyApplies(t *testing.T) {
 
 	t.Run("operator override is what actually reaches the runtime", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent(backgroundIndexCommand, "35", "")
+		applyIndexGCPercent(backgroundIndexCommand, false, "35", "")
 		if got := debug.SetGCPercent(100); got != 35 {
 			t.Fatalf("GOGC in force after applyIndexGCPercent = %d, want 35", got)
 		}
@@ -153,7 +153,7 @@ func TestApplyIndexGCPercentActuallyApplies(t *testing.T) {
 
 	t.Run("interactive path is left untouched", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent("index", "", "")
+		applyIndexGCPercent("index", false, "", "")
 		if got := debug.SetGCPercent(100); got != 100 {
 			t.Fatalf("interactive path changed GOGC to %d, want it left at 100", got)
 		}
@@ -161,7 +161,7 @@ func TestApplyIndexGCPercentActuallyApplies(t *testing.T) {
 
 	t.Run("explicit GOGC is left untouched", func(t *testing.T) {
 		debug.SetGCPercent(100)
-		applyIndexGCPercent(backgroundIndexCommand, "", "200")
+		applyIndexGCPercent(backgroundIndexCommand, false, "", "200")
 		if got := debug.SetGCPercent(100); got != 100 {
 			t.Fatalf("explicit GOGC was overridden to %d, want it left at 100", got)
 		}

--- a/cmd/grafel/links_internal.go
+++ b/cmd/grafel/links_internal.go
@@ -47,7 +47,10 @@ func runLinksInternal(args []string) int {
 	// Lower this child's OS scheduling priority so even its capped cores yield
 	// to foreground work. Best-effort self-renice, so it holds however the child
 	// is spawned (the GOMAXPROCS cap itself comes from the parent's env).
-	sched.NiceSelf()
+	//
+	// Skipped when the parent told us this pass is user-awaited (#5954) — see
+	// the same call in group_algo.go.
+	sched.NiceSelfUnlessForeground()
 
 	// #5954 / #5956 memtrace: phase-tagged memstats sampler + per-phase heap
 	// profiles, gated entirely behind GRAFEL_MEMTRACE_DIR (inherited, since the

--- a/cmd/grafel/links_subprocess_5954_test.go
+++ b/cmd/grafel/links_subprocess_5954_test.go
@@ -107,7 +107,7 @@ func TestLinksInternalIsOnTheGCPacingAllowList(t *testing.T) {
 	if !isBackgroundGCPercentCommand(backgroundLinksCommand) {
 		t.Fatalf("%q is not on the background GC-pacing allow-list", backgroundLinksCommand)
 	}
-	pct, source := indexGCPercentDecision(backgroundLinksCommand, "", "")
+	pct, source := indexGCPercentDecision(backgroundLinksCommand, false, "", "")
 	if pct != indexGCPercentDefault {
 		t.Fatalf("GC percent for %q = %d (%s), want the background default %d",
 			backgroundLinksCommand, pct, source, indexGCPercentDefault)

--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -41,7 +41,7 @@ func main() {
 		// death spiral. os.Args[1] is passed explicitly so the "background
 		// only, never interactive" rule is a property of the policy function
 		// and not of this call site. Never fatal.
-		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
+		applyIndexGCPercent(os.Args[1], argvIsInteractive(os.Args[2:]), os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runIndexInternal(os.Args[2:]))
 	}
 	// Hidden group-level algorithm harness (#5349 A1 / epic #5350). Assembles
@@ -62,7 +62,12 @@ func main() {
 		// absolute target below live heap is the documented >4x death spiral
 		// (see index_memlimit.go). GOGC is relative — live * (1+GOGC/100) — and
 		// so cannot enter that regime by construction. Never fatal.
-		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
+		// foreground=false unconditionally: the batch children keep GOGC=50
+		// even when the pass they are running was caused by a foreground
+		// rebuild. Their live heap is UNMEASURED, and a looser GC target on an
+		// unmeasured heap is the death-spiral risk index_memlimit.go documents.
+		// They get the wall-time win from the CPU cap lift, not from GC pacing.
+		applyIndexGCPercent(os.Args[1], false, os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runGroupAlgo(os.Args[2:]))
 	}
 	// Hidden cross-repo link child (#5954). The daemon's scheduler fork-execs
@@ -78,7 +83,12 @@ func main() {
 	// death spiral (index_memlimit.go); GOGC is relative and cannot enter that
 	// regime. Never fatal.
 	if len(os.Args) >= 2 && os.Args[1] == backgroundLinksCommand {
-		applyIndexGCPercent(os.Args[1], os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
+		// foreground=false unconditionally: the batch children keep GOGC=50
+		// even when the pass they are running was caused by a foreground
+		// rebuild. Their live heap is UNMEASURED, and a looser GC target on an
+		// unmeasured heap is the death-spiral risk index_memlimit.go documents.
+		// They get the wall-time win from the CPU cap lift, not from GC pacing.
+		applyIndexGCPercent(os.Args[1], false, os.Getenv(indexGCPercentEnv), os.Getenv("GOGC"))
 		os.Exit(runLinksInternal(os.Args[2:]))
 	}
 	// Release acceptance ladder (#5224). Intercepted before cobra dispatch

--- a/internal/daemon/sched/foreground.go
+++ b/internal/daemon/sched/foreground.go
@@ -85,6 +85,19 @@ var (
 	foregroundHolds = map[string]int{}
 	// foregroundLinger is the expiry of the post-hold window per group.
 	foregroundLinger = map[string]time.Time{}
+	// foregroundEpochs is the identity of the CURRENT mark on each group. Every
+	// MarkGroupForeground call stamps a fresh, process-monotonic epoch.
+	//
+	// It exists so a completion can name the mark it is completing. Without it
+	// a LATE completion silently wipes a FRESHER mark: rebuild #1 marks and
+	// arms a linger; its long group-algo pass starts; rebuild #2 for the same
+	// group runs and re-marks; then #1's pass succeeds and clears — dropping
+	// rebuild #2's mark, so #2's own follow-on link and group-algo children
+	// spawn at background caps with the user still waiting on them.
+	foregroundEpochs = map[string]uint64{}
+	// foregroundEpochSeq is the monotonic source for the above. Never reused, so
+	// two marks on the same group are always distinguishable.
+	foregroundEpochSeq uint64
 	// foregroundNow is the clock, swappable in tests. Read under foregroundMu.
 	foregroundNow = time.Now
 )
@@ -101,6 +114,8 @@ func MarkGroupForeground(group string) (release func()) {
 	}
 	foregroundMu.Lock()
 	foregroundHolds[group]++
+	foregroundEpochSeq++
+	foregroundEpochs[group] = foregroundEpochSeq
 	foregroundMu.Unlock()
 
 	var once sync.Once
@@ -128,39 +143,96 @@ func MarkGroupForeground(group string) (release func()) {
 // GroupIsForeground reports whether work for group should resolve FOREGROUND
 // caps: a hold is live, or the post-hold linger has not expired.
 //
-// Cheap enough to call on every spawn; expired linger entries are reaped here
-// so the maps cannot grow without bound.
+// Cheap enough to call on every spawn.
 func GroupIsForeground(group string) bool {
+	_, fg := GroupForegroundState(group)
+	return fg
+}
+
+// GroupForegroundState reports whether group should resolve FOREGROUND caps,
+// and the epoch of the mark that says so (0 when it should not).
+//
+// Capture the epoch when work is SPAWNED and hand it back to
+// ClearGroupForeground when that work completes, so a slow pass reporting in
+// late cannot clear a mark that a newer rebuild has since installed.
+//
+// Every read sweeps ALL expired linger entries, not just this group's. Per-key
+// reaping would leak any group that is rebuilt once and then deleted or
+// renamed — nothing would ever look it up again to expire it. The map holds one
+// entry per recently-rebuilt group, so a full pass is trivial and this is
+// genuinely bounded rather than bounded-in-the-comment-only.
+func GroupForegroundState(group string) (epoch uint64, foreground bool) {
 	if group == "" {
-		return false
+		return 0, false
 	}
+	foregroundMu.Lock()
+	defer foregroundMu.Unlock()
+	sweepExpiredLingerLocked()
+	if foregroundHolds[group] > 0 {
+		return foregroundEpochs[group], true
+	}
+	if _, ok := foregroundLinger[group]; ok {
+		return foregroundEpochs[group], true
+	}
+	return 0, false
+}
+
+// sweepExpiredLingerLocked drops every linger window that has passed, and the
+// epoch of any group that is left with neither a hold nor a linger. MUST be
+// called with foregroundMu held.
+func sweepExpiredLingerLocked() {
+	now := foregroundNow()
+	for g, exp := range foregroundLinger {
+		if !now.Before(exp) {
+			delete(foregroundLinger, g)
+		}
+	}
+	for g := range foregroundEpochs {
+		if foregroundHolds[g] > 0 {
+			continue
+		}
+		if _, ok := foregroundLinger[g]; ok {
+			continue
+		}
+		delete(foregroundEpochs, g)
+	}
+}
+
+// ClearGroupForeground ends the post-hold linger for group, but ONLY if epoch
+// is still the current mark. Called when the last stage of the user-awaited
+// work — the group-algo pass — completes: the graph the user asked for exists,
+// so anything that runs from here on is background churn again.
+//
+// The epoch check is what makes a late completion safe. A pass spawned under
+// rebuild #1 can finish long after rebuild #2 has re-marked the group; without
+// the check it would clear #2's mark and send #2's own follow-on children to
+// background caps while the user is still waiting on them.
+//
+// It also deliberately does NOT cancel live holds. A hold means a foreground
+// rebuild is running right now; only its own release may end it.
+func ClearGroupForeground(group string, epoch uint64) {
 	foregroundMu.Lock()
 	defer foregroundMu.Unlock()
 	if foregroundHolds[group] > 0 {
-		return true
+		return
 	}
-	exp, ok := foregroundLinger[group]
-	if !ok {
-		return false
-	}
-	if foregroundNow().Before(exp) {
-		return true
+	if foregroundEpochs[group] != epoch {
+		return
 	}
 	delete(foregroundLinger, group)
-	return false
+	delete(foregroundEpochs, group)
 }
 
-// ClearGroupForeground ends the post-hold linger for group. Called when the
-// last stage of the user-awaited work — the group-algo pass — completes: the
-// graph the user asked for exists, so anything that runs from here on is
-// background churn again.
-//
-// It deliberately does NOT cancel live holds. A hold means a foreground rebuild
-// is running right now; only its own release may end it.
-func ClearGroupForeground(group string) {
+// ForgetGroupForeground drops all foreground state for group unconditionally.
+// For teardown — a group delete — where no epoch can still be current because
+// the group itself is gone. Called from Scheduler.CancelGroup, which is the
+// path Service.DeleteGroup invokes.
+func ForgetGroupForeground(group string) {
 	foregroundMu.Lock()
 	defer foregroundMu.Unlock()
+	delete(foregroundHolds, group)
 	delete(foregroundLinger, group)
+	delete(foregroundEpochs, group)
 }
 
 // resetForegroundGroups drops all foreground state. Test-only seam — production
@@ -170,6 +242,7 @@ func resetForegroundGroups() {
 	defer foregroundMu.Unlock()
 	foregroundHolds = map[string]int{}
 	foregroundLinger = map[string]time.Time{}
+	foregroundEpochs = map[string]uint64{}
 }
 
 // setForegroundClockForTest swaps the clock and returns a restore func. Test-only.

--- a/internal/daemon/sched/foreground.go
+++ b/internal/daemon/sched/foreground.go
@@ -1,0 +1,186 @@
+package sched
+
+import (
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// foreground.go — WHO ASKED FOR THIS WORK, per group (#5954 wall-time fix).
+//
+// THE PROBLEM. Every heavy child the daemon spawns resolves its CPU cap inside
+// its own spawn helper, from process-global env + NumCPU. That makes the cap a
+// property of the CHILD, when the user's policy makes it a property of the
+// CALLER:
+//
+//	"Cap it at max of 25% of the machine capacity … Interactive remains uncapped."
+//
+// The 25% half shipped (#5960); the interactive half did not reach the
+// group-algo and links children. So a `grafel reset` — a human sitting there
+// waiting — ran its heaviest stage on 2 cores of a 12-core box, and a full
+// reindex went from ~10 minutes to 30+.
+//
+// WHY NOT THE BARGE. sched.BargeForeground (#5994) already marks "a foreground
+// rebuild is in progress" daemon-wide, and it is the right signal for the stage
+// gate. It is the WRONG signal for cap resolution, because of when it lifts.
+// The rebuild's own index batch and its in-process link pass are inside the
+// barge, but the stages that actually dominate the user's wall clock are NOT:
+// the scheduler's cross-repo link pass and the debounced group-algo pass fire
+// minutes AFTER daemonRebuildFuncCore returned and the barge released. A cap
+// resolved off the barge would give the user full capacity for the two stages
+// that were never the problem, and background caps for the 32–53 minute one
+// that is.
+//
+// WHAT THIS IS INSTEAD. A per-group "the user is waiting on this group's graph"
+// flag with two ways to end:
+//
+//   - a REFCOUNTED hold, taken for the duration of the foreground rebuild, and
+//   - a LINGER after the last hold releases, which covers the follow-on stages
+//     the rebuild causes but does not itself run.
+//
+// The linger is closed explicitly by the group-algo pass completing
+// (ClearGroupForeground in runGroupAlgo) — the last stage of the work the user
+// asked for — and time-bounded by foregroundLingerWindow as a backstop for the
+// cases where that pass never runs (group deleted, GroupAlgo unconfigured,
+// pass failing repeatedly). Without that backstop a single rebuild could leave
+// a group drawing full machine capacity for background churn forever, which is
+// the standing policy this change must not regress.
+//
+// SCOPE. This governs CPU caps only. It does not gate, defer, or reorder any
+// stage; a group being "foreground" changes how much of the machine its child
+// may use, never whether the child runs.
+
+// foregroundLingerDefault is how long a group keeps foreground caps after the
+// last foreground hold on it releases.
+//
+// It has to cover the gap between "the rebuild RPC returned" and "the last
+// stage it caused was SPAWNED" — not how long those stages run, since the flag
+// is read once at spawn. On the user's corpus that gap is the scheduler's link
+// debounce plus the link pass (~9 min) plus the group-algo debounce (180s), so
+// the window is set well clear of it rather than tight against it: the cost of
+// being slightly too generous is that a background pass arriving inside the
+// window runs fast, while the cost of being too tight is the exact 30-minute
+// regression this file exists to fix.
+const foregroundLingerDefault = 30 * time.Minute
+
+// foregroundLingerEnv overrides foregroundLingerDefault with any Go duration
+// ("90s", "10m"). Malformed or negative values are ignored and the default
+// applies; "0" is honoured and means "no linger at all" (holds only).
+const foregroundLingerEnv = "GRAFEL_FOREGROUND_LINGER"
+
+func foregroundLingerWindow() time.Duration {
+	if raw := strings.TrimSpace(os.Getenv(foregroundLingerEnv)); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d >= 0 {
+			return d
+		}
+	}
+	return foregroundLingerDefault
+}
+
+var (
+	foregroundMu sync.Mutex
+	// foregroundHolds counts live foreground holds per group. A count > 0 means
+	// a user-awaited unit of work for that group is running right now.
+	foregroundHolds = map[string]int{}
+	// foregroundLinger is the expiry of the post-hold window per group.
+	foregroundLinger = map[string]time.Time{}
+	// foregroundNow is the clock, swappable in tests. Read under foregroundMu.
+	foregroundNow = time.Now
+)
+
+// MarkGroupForeground records that a user-awaited unit of work for group has
+// started, and returns its release closure. Use it with `defer` at the top of
+// any user-initiated rebuild of a group.
+//
+// Reentrant (refcounted) and idempotent on release. An empty group name is a
+// no-op with a no-op release, so callers need no guards.
+func MarkGroupForeground(group string) (release func()) {
+	if group == "" {
+		return func() {}
+	}
+	foregroundMu.Lock()
+	foregroundHolds[group]++
+	foregroundMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			foregroundMu.Lock()
+			defer foregroundMu.Unlock()
+			if n := foregroundHolds[group]; n > 1 {
+				foregroundHolds[group] = n - 1
+				return
+			}
+			delete(foregroundHolds, group)
+			// Last hold out arms the linger so the stages this rebuild causes
+			// but does not run — the scheduler's link pass and the debounced
+			// group-algo pass — are still spawned at foreground caps.
+			if w := foregroundLingerWindow(); w > 0 {
+				foregroundLinger[group] = foregroundNow().Add(w)
+			} else {
+				delete(foregroundLinger, group)
+			}
+		})
+	}
+}
+
+// GroupIsForeground reports whether work for group should resolve FOREGROUND
+// caps: a hold is live, or the post-hold linger has not expired.
+//
+// Cheap enough to call on every spawn; expired linger entries are reaped here
+// so the maps cannot grow without bound.
+func GroupIsForeground(group string) bool {
+	if group == "" {
+		return false
+	}
+	foregroundMu.Lock()
+	defer foregroundMu.Unlock()
+	if foregroundHolds[group] > 0 {
+		return true
+	}
+	exp, ok := foregroundLinger[group]
+	if !ok {
+		return false
+	}
+	if foregroundNow().Before(exp) {
+		return true
+	}
+	delete(foregroundLinger, group)
+	return false
+}
+
+// ClearGroupForeground ends the post-hold linger for group. Called when the
+// last stage of the user-awaited work — the group-algo pass — completes: the
+// graph the user asked for exists, so anything that runs from here on is
+// background churn again.
+//
+// It deliberately does NOT cancel live holds. A hold means a foreground rebuild
+// is running right now; only its own release may end it.
+func ClearGroupForeground(group string) {
+	foregroundMu.Lock()
+	defer foregroundMu.Unlock()
+	delete(foregroundLinger, group)
+}
+
+// resetForegroundGroups drops all foreground state. Test-only seam — production
+// state is per-group and self-expiring.
+func resetForegroundGroups() {
+	foregroundMu.Lock()
+	defer foregroundMu.Unlock()
+	foregroundHolds = map[string]int{}
+	foregroundLinger = map[string]time.Time{}
+}
+
+// setForegroundClockForTest swaps the clock and returns a restore func. Test-only.
+func setForegroundClockForTest(now func() time.Time) (restore func()) {
+	foregroundMu.Lock()
+	prev := foregroundNow
+	foregroundNow = now
+	foregroundMu.Unlock()
+	return func() {
+		foregroundMu.Lock()
+		foregroundNow = prev
+		foregroundMu.Unlock()
+	}
+}

--- a/internal/daemon/sched/foreground_caps_5954_test.go
+++ b/internal/daemon/sched/foreground_caps_5954_test.go
@@ -214,9 +214,108 @@ func TestForegroundGroupSurvivesTheHoldRelease(t *testing.T) {
 		t.Fatal("group stopped being foreground the instant the rebuild returned — " +
 			"the debounced group-algo pass the user is still waiting for would get background caps (#5954)")
 	}
-	ClearGroupForeground("acme")
+	epoch, _ := GroupForegroundState("acme")
+	ClearGroupForeground("acme", epoch)
 	if GroupIsForeground("acme") {
 		t.Fatal("ClearGroupForeground did not clear the linger")
+	}
+}
+
+// A LATE completion must not wipe a FRESHER mark. The reachable sequence:
+// rebuild #1 marks the group and arms a linger; its (long) group-algo pass
+// starts; rebuild #2 for the same group runs and arms a fresh linger; then the
+// pass from step 2 finally succeeds and clears — silently dropping rebuild #2's
+// mark, so rebuild #2's own follow-on link and group-algo children spawn at
+// background caps while the user waits on them.
+//
+// The completion therefore has to name the mark it is completing.
+func TestClearForegroundIsEpochScoped(t *testing.T) {
+	resetForegroundForTest(t)
+
+	// Rebuild #1 runs and leaves a linger.
+	MarkGroupForeground("acme")()
+	epoch1, fg := GroupForegroundState("acme")
+	if !fg {
+		t.Fatal("group is not foreground after rebuild #1")
+	}
+
+	// Rebuild #2 for the SAME group runs while #1's pass is still going.
+	MarkGroupForeground("acme")()
+	epoch2, fg := GroupForegroundState("acme")
+	if !fg {
+		t.Fatal("group is not foreground after rebuild #2")
+	}
+	if epoch2 == epoch1 {
+		t.Fatal("a second foreground rebuild reused the first one's epoch — " +
+			"a late completion cannot then tell them apart")
+	}
+
+	// #1's pass completes LATE and clears against the epoch it was spawned under.
+	ClearGroupForeground("acme", epoch1)
+	if !GroupIsForeground("acme") {
+		t.Fatal("a stale completion wiped a fresher foreground mark: rebuild #2's " +
+			"follow-on link and group-algo children would spawn at background caps (#5954)")
+	}
+
+	// #2's own completion does clear it.
+	ClearGroupForeground("acme", epoch2)
+	if GroupIsForeground("acme") {
+		t.Fatal("the matching completion did not clear the mark")
+	}
+}
+
+// A completion must never clear a mark that is still HELD — a rebuild running
+// right now outranks any pass reporting in.
+func TestClearForegroundDoesNotCancelALiveHold(t *testing.T) {
+	resetForegroundForTest(t)
+
+	MarkGroupForeground("acme")()
+	epoch, _ := GroupForegroundState("acme")
+	release := MarkGroupForeground("acme") // a new rebuild starts
+	defer release()
+
+	ClearGroupForeground("acme", epoch)
+	if !GroupIsForeground("acme") {
+		t.Fatal("a completion cleared a group with a LIVE foreground hold on it")
+	}
+}
+
+// Group teardown is the one unconditional clear, and it is not epoch-scoped:
+// the group is gone, so no epoch can be current.
+func TestForgetGroupForegroundIsUnconditional(t *testing.T) {
+	resetForegroundForTest(t)
+
+	MarkGroupForeground("acme")()
+	ForgetGroupForeground("acme")
+	if GroupIsForeground("acme") {
+		t.Fatal("ForgetGroupForeground left the group marked")
+	}
+}
+
+// ...and the teardown path must actually CALL it. CancelGroup is what
+// Service.DeleteGroup invokes; without this the mark outlives the group, so a
+// group deleted and recreated inside the linger window gets its first
+// background pass at foreground caps and un-niced.
+func TestCancelGroup_ForgetsTheForegroundMark(t *testing.T) {
+	resetForegroundForTest(t)
+	s := New(Config{Workers: 1})
+	s.Start()
+	defer s.Stop()
+
+	MarkGroupForeground("doomed")()
+	MarkGroupForeground("survivor")()
+	if !GroupIsForeground("doomed") {
+		t.Fatal("precondition: group is not marked foreground")
+	}
+
+	s.CancelGroup("doomed")
+
+	if GroupIsForeground("doomed") {
+		t.Error("CancelGroup left the deleted group marked foreground — recreating it " +
+			"inside the linger window would run its background passes at foreground caps, un-niced")
+	}
+	if !GroupIsForeground("survivor") {
+		t.Error("CancelGroup cleared an unrelated group's foreground mark")
 	}
 }
 
@@ -262,7 +361,7 @@ func TestForegroundGroupRefcounted(t *testing.T) {
 		t.Fatal("the first release dropped a still-held group")
 	}
 	d2()
-	ClearGroupForeground("acme")
+	ForgetGroupForeground("acme")
 	if GroupIsForeground("acme") {
 		t.Fatal("group still foreground after all holds released and cleared")
 	}

--- a/internal/daemon/sched/foreground_caps_5954_test.go
+++ b/internal/daemon/sched/foreground_caps_5954_test.go
@@ -1,0 +1,339 @@
+package sched
+
+// foreground_caps_5954_test.go — the FOREGROUND/BACKGROUND split for the two
+// heavy batch children (group-algo, links).
+//
+// THE HAZARD THESE TESTS ENCODE. Epic #5954 optimised memory and capped every
+// child unconditionally. On a 12-core laptop that means a rebuild the user
+// typed and is sitting in front of runs its heaviest stage — the group-algo
+// pass, measured at 32–53 minutes in the daemon log — on TWO cores, because the
+// cap is resolved inside the spawn helper with no notion of what triggered the
+// work. The user's policy was always two-sided: "cap it at 25% of the machine
+// … interactive remains uncapped". Only the first half shipped.
+//
+// So the assertions below are derived from the hazard, not from whatever the
+// constants happen to be:
+//
+//   - a foreground (user-awaited) pass must get NEAR-FULL machine capacity —
+//     specifically it must never land on the background cap;
+//   - a background pass must stay inside the 25% budget (the standing policy,
+//     which this change must not regress);
+//   - the background default must be PROPORTIONAL to the host — a hardcoded 2
+//     is as wrong on a 64-core server as it is on a 12-core laptop — with a
+//     floor so a small machine still gets a usable pass;
+//   - an explicit operator override wins in BOTH modes and is never clamped.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// nearFullCapacity is the floor a user-awaited pass must clear: three quarters
+// of the machine. Anything at or below the 25% background budget means the
+// human is waiting on a throttled pass, which is the whole regression.
+func nearFullCapacity() int {
+	n := runtime.NumCPU()
+	if n < 1 {
+		n = 1
+	}
+	return (n*3 + 3) / 4
+}
+
+// resetForegroundForTest clears the package foreground registry between tests.
+func resetForegroundForTest(t *testing.T) {
+	t.Helper()
+	resetForegroundGroups()
+	t.Cleanup(resetForegroundGroups)
+}
+
+// --- the two heavy children, foreground -------------------------------------
+
+func TestGroupAlgoGOMAXPROCS_ForegroundRunsNearFullCapacity(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+
+	fg := GroupAlgoGOMAXPROCSFor(true)
+	if want := nearFullCapacity(); fg < want {
+		t.Fatalf("foreground group-algo cap = %d on a %d-core host, want >= %d — "+
+			"a rebuild the user is waiting on must not run at the background budget (#5954 wall-time regression)",
+			fg, runtime.NumCPU(), want)
+	}
+	if bg := GroupAlgoGOMAXPROCSFor(false); runtime.NumCPU() >= 8 && fg <= bg {
+		t.Fatalf("foreground group-algo cap (%d) <= background cap (%d): the split is not wired", fg, bg)
+	}
+}
+
+func TestLinksGOMAXPROCS_ForegroundRunsNearFullCapacity(t *testing.T) {
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+
+	fg := LinksGOMAXPROCSFor(true)
+	if want := nearFullCapacity(); fg < want {
+		t.Fatalf("foreground links cap = %d on a %d-core host, want >= %d", fg, runtime.NumCPU(), want)
+	}
+	if bg := LinksGOMAXPROCSFor(false); runtime.NumCPU() >= 8 && fg <= bg {
+		t.Fatalf("foreground links cap (%d) <= background cap (%d): the split is not wired", fg, bg)
+	}
+}
+
+// GRAFEL_REBUILD_GOMAXPROCS is the EXISTING foreground knob (#5135, already
+// honoured by the extract coordinator and the index child). The two batch
+// children must join it rather than invent a third mechanism.
+func TestForegroundCapsHonourRebuildGOMAXPROCS(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "9")
+
+	if got := GroupAlgoGOMAXPROCSFor(true); got != 9 {
+		t.Errorf("foreground group-algo cap = %d, want 9 (GRAFEL_REBUILD_GOMAXPROCS)", got)
+	}
+	if got := LinksGOMAXPROCSFor(true); got != 9 {
+		t.Errorf("foreground links cap = %d, want 9 (GRAFEL_REBUILD_GOMAXPROCS)", got)
+	}
+	// It must NOT leak into background work — that is the policy this change
+	// must not regress.
+	if got := GroupAlgoGOMAXPROCSFor(false); got == 9 {
+		t.Errorf("background group-algo cap picked up GRAFEL_REBUILD_GOMAXPROCS (= %d); "+
+			"background stays on the 25%%-family budget", got)
+	}
+}
+
+// --- proportional background defaults ---------------------------------------
+
+// The background default must scale with the host and never sink below a usable
+// floor. Asserted as policy invariants across 1/2/4/12/64 cores rather than as
+// a table of magic numbers.
+func TestBackgroundBatchGOMAXPROCS_ProportionalWithFloor(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+
+	cases := []int{1, 2, 4, 12, 64}
+	prev := 0
+	for _, numCPU := range cases {
+		got := backgroundBatchGOMAXPROCSFor(numCPU)
+
+		floor := 2
+		if numCPU < floor {
+			floor = numCPU
+		}
+		if floor < 1 {
+			floor = 1
+		}
+		if got < floor {
+			t.Errorf("background batch cap on %d cores = %d, below the floor %d — "+
+				"a background pass still has to finish", numCPU, got, floor)
+		}
+		// 25% is the standing background policy (process.IndexCoreBudget). The
+		// floor may exceed it on a tiny box; nothing else may.
+		ceiling := numCPU / 4
+		if ceiling < floor {
+			ceiling = floor
+		}
+		if got > ceiling {
+			t.Errorf("background batch cap on %d cores = %d, above the 25%% budget %d — "+
+				"background work must not take the machine away from the human", numCPU, got, ceiling)
+		}
+		if got > numCPU {
+			t.Errorf("background batch cap on %d cores = %d, more cores than the machine has", numCPU, got)
+		}
+		if got < prev {
+			t.Errorf("background batch cap is not monotonic in host size: %d cores -> %d, after a smaller host -> %d",
+				numCPU, got, prev)
+		}
+		prev = got
+	}
+
+	// The proportionality has to BITE, not just be monotonic: a 64-core server
+	// must get materially more than a 12-core laptop.
+	if big, small := backgroundBatchGOMAXPROCSFor(64), backgroundBatchGOMAXPROCSFor(12); big <= small {
+		t.Errorf("64-core background cap (%d) is not better than the 12-core one (%d) — "+
+			"the default is still effectively static", big, small)
+	}
+	// And the 12-core case must not get WORSE than the shipped behaviour (2).
+	if got := backgroundBatchGOMAXPROCSFor(12); got < 2 {
+		t.Errorf("12-core background cap = %d, want >= 2 (no background regression)", got)
+	}
+}
+
+// --- operator overrides win, unclamped, in both modes ------------------------
+
+func TestExplicitOverridesWinInBothModes(t *testing.T) {
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "7")
+	t.Setenv("GRAFEL_LINKS_CPU", "5")
+
+	for _, fg := range []bool{false, true} {
+		if got := GroupAlgoGOMAXPROCSFor(fg); got != 7 {
+			t.Errorf("GroupAlgoGOMAXPROCSFor(foreground=%v) = %d, want 7 — "+
+				"an explicit operator override is an escape hatch and is never clamped", fg, got)
+		}
+		if got := LinksGOMAXPROCSFor(fg); got != 5 {
+			t.Errorf("LinksGOMAXPROCSFor(foreground=%v) = %d, want 5", fg, got)
+		}
+	}
+}
+
+func TestExplicitOverrideOfOneCoreStillHonoured(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "1")
+	t.Setenv("GRAFEL_LINKS_CPU", "1")
+	if got := GroupAlgoGOMAXPROCSFor(true); got != 1 {
+		t.Errorf("GRAFEL_GROUP_ALGO_CPU=1 in foreground = %d, want 1", got)
+	}
+	if got := LinksGOMAXPROCSFor(true); got != 1 {
+		t.Errorf("GRAFEL_LINKS_CPU=1 in foreground = %d, want 1", got)
+	}
+}
+
+// --- the foreground-origin registry ------------------------------------------
+
+// A rebuild's follow-on stages (the scheduler's link pass, then the debounced
+// group-algo pass) fire AFTER daemonRebuildFuncCore has returned — that is
+// precisely why the barge alone is not a sufficient signal. The registry must
+// therefore keep the group hot past the hold's release.
+func TestForegroundGroupSurvivesTheHoldRelease(t *testing.T) {
+	resetForegroundForTest(t)
+
+	if GroupIsForeground("acme") {
+		t.Fatal("group is foreground before anything marked it")
+	}
+	done := MarkGroupForeground("acme")
+	if !GroupIsForeground("acme") {
+		t.Fatal("group is not foreground while a foreground rebuild holds it")
+	}
+	if GroupIsForeground("other") {
+		t.Fatal("marking one group made an unrelated group foreground")
+	}
+	done()
+	if !GroupIsForeground("acme") {
+		t.Fatal("group stopped being foreground the instant the rebuild returned — " +
+			"the debounced group-algo pass the user is still waiting for would get background caps (#5954)")
+	}
+	ClearGroupForeground("acme")
+	if GroupIsForeground("acme") {
+		t.Fatal("ClearGroupForeground did not clear the linger")
+	}
+}
+
+func TestForegroundGroupLingerExpires(t *testing.T) {
+	resetForegroundForTest(t)
+
+	base := time.Now()
+	now := base
+	restore := setForegroundClockForTest(func() time.Time { return now })
+	defer restore()
+
+	MarkGroupForeground("acme")()
+	now = base.Add(foregroundLingerWindow() - time.Second)
+	if !GroupIsForeground("acme") {
+		t.Fatal("linger expired early")
+	}
+	now = base.Add(foregroundLingerWindow() + time.Second)
+	if GroupIsForeground("acme") {
+		t.Fatal("linger never expires — a group that never runs group-algo would stay uncapped forever")
+	}
+}
+
+func TestForegroundLingerWindowIsEnvOverridable(t *testing.T) {
+	t.Setenv("GRAFEL_FOREGROUND_LINGER", "90s")
+	if got := foregroundLingerWindow(); got != 90*time.Second {
+		t.Fatalf("foregroundLingerWindow() = %s, want 90s", got)
+	}
+	t.Setenv("GRAFEL_FOREGROUND_LINGER", "nonsense")
+	if got := foregroundLingerWindow(); got <= 0 {
+		t.Fatalf("a malformed GRAFEL_FOREGROUND_LINGER disabled the linger (%s); want the policy default", got)
+	}
+}
+
+// A concurrent background rebuild of a DIFFERENT group must not be dragged into
+// foreground caps, and nested holds must not release early.
+func TestForegroundGroupRefcounted(t *testing.T) {
+	resetForegroundForTest(t)
+
+	d1 := MarkGroupForeground("acme")
+	d2 := MarkGroupForeground("acme")
+	d1()
+	if !GroupIsForeground("acme") {
+		t.Fatal("the first release dropped a still-held group")
+	}
+	d2()
+	ClearGroupForeground("acme")
+	if GroupIsForeground("acme") {
+		t.Fatal("group still foreground after all holds released and cleared")
+	}
+}
+
+// --- the spawn points actually consult the registry --------------------------
+
+// This is the wiring assertion: the value the group-algo / links children are
+// spawned with must come from the registry, not from a naked call to the
+// background resolver.
+func TestSpawnPointsResolveFromTheForegroundRegistry(t *testing.T) {
+	resetForegroundForTest(t)
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+
+	if got, want := groupAlgoChildGOMAXPROCS("acme"), GroupAlgoGOMAXPROCSFor(false); got != want {
+		t.Errorf("group-algo spawn cap for a background group = %d, want the background cap %d", got, want)
+	}
+	if got, want := linksChildGOMAXPROCS("acme"), LinksGOMAXPROCSFor(false); got != want {
+		t.Errorf("links spawn cap for a background group = %d, want the background cap %d", got, want)
+	}
+
+	defer MarkGroupForeground("acme")()
+	if got, want := groupAlgoChildGOMAXPROCS("acme"), GroupAlgoGOMAXPROCSFor(true); got != want {
+		t.Errorf("group-algo spawn cap during a foreground rebuild = %d, want the foreground cap %d — "+
+			"this is the 32–53 minute pass the user is waiting on", got, want)
+	}
+	if got, want := linksChildGOMAXPROCS("acme"), LinksGOMAXPROCSFor(true); got != want {
+		t.Errorf("links spawn cap during a foreground rebuild = %d, want the foreground cap %d", got, want)
+	}
+	// A DIFFERENT group's background pass must stay capped.
+	if got, want := groupAlgoChildGOMAXPROCS("unrelated"), GroupAlgoGOMAXPROCSFor(false); got != want {
+		t.Errorf("an unrelated group's background group-algo cap = %d, want %d", got, want)
+	}
+}
+
+// End-to-end at the fork: the GOMAXPROCS the links child is ACTUALLY launched
+// with must follow the registry. Asserted through a real fork of a stand-in
+// child (the fakeChildScript harness) so a regression that computes the right
+// number and then forgets to put it in the env still fails.
+func TestRunSubprocessLinks_ForegroundGroupGetsForegroundGOMAXPROCS(t *testing.T) {
+	resetForegroundForTest(t)
+	t.Setenv("GRAFEL_LINKS_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "11")
+
+	out := filepath.Join(t.TempDir(), "gmp.txt")
+	fakeChildScript(t, `printf 'gomaxprocs=%s\n' "$GOMAXPROCS" > `+out)
+
+	defer MarkGroupForeground("hot")()
+	if err := RunSubprocessLinks(context.Background(), "hot", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	b, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read env capture: %v", err)
+	}
+	if got := strings.TrimSpace(string(b)); got != "gomaxprocs=11" {
+		t.Fatalf("links child env %q, want gomaxprocs=11 — the user's rebuild is waiting on this pass", got)
+	}
+
+	// And an unrelated group still forks at the background cap.
+	if err := RunSubprocessLinks(context.Background(), "cold", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	b, err = os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read env capture: %v", err)
+	}
+	want := "gomaxprocs=" + strconv.Itoa(BackgroundBatchGOMAXPROCS())
+	if got := strings.TrimSpace(string(b)); got != want {
+		t.Fatalf("background links child env %q, want %q", got, want)
+	}
+}

--- a/internal/daemon/sched/foreground_nice_5954_test.go
+++ b/internal/daemon/sched/foreground_nice_5954_test.go
@@ -1,0 +1,222 @@
+package sched
+
+// foreground_nice_5954_test.go — OS SCHEDULING PRIORITY is the other half of
+// "interactive remains uncapped".
+//
+// THE HAZARD. Both batch children renice THEMSELVES to +10 at startup
+// (cmd/grafel/group_algo.go, cmd/grafel/links_internal.go → sched.NiceSelf),
+// unconditionally. So a `grafel reset` the user is blocking on runs its
+// group-algo pass below the user's editor, below their browser, and below
+// grafel's own un-niced index children. Lifting the GOMAXPROCS cap does not
+// touch that.
+//
+// HOW MUCH WALL TIME THIS BUYS IS UNMEASURED, and this file does not claim any.
+// nice weighting bites under oversubscription; these passes are single-threaded
+// and the reported box had idle cores, where a single nice+10 thread gets a
+// core on demand. The justification here is policy, not throughput: work a
+// human is blocking on should not be demoted below the machine's other work,
+// and on an idle box the lift costs nothing. If the elapsed time does not move,
+// the answer is upstream of priority — see the note in nice_foreground.go.
+//
+// THE TRAP THIS FILE EXISTS TO CATCH. The renice is issued BY THE CHILD, so a
+// parent-side-only fix does not bind — the recurring bug class of this epic: a
+// guard that exists, looks correct, and does not bind the path that runs.
+// Therefore both halves are pinned:
+//
+//   - the parent must DELIVER the signal (asserted through a real fork), and
+//   - the child must ACT on it (asserted by re-execing this test binary and
+//     reading back its real getpriority(2) value — not by trusting a bool).
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// --- parent side: the signal is delivered ------------------------------------
+
+func TestChildEnvCarriesTheForegroundSignal(t *testing.T) {
+	fgEnv := groupAlgoChildEnv([]string{"PATH=/usr/bin"}, 4, true)
+	if got, _ := lookupEnv(fgEnv, childForegroundEnv); got != "1" {
+		t.Errorf("group-algo foreground child env %s = %q, want \"1\" — "+
+			"without it the child renices itself to +10 and the user's rebuild runs below their editor",
+			childForegroundEnv, got)
+	}
+	bgEnv := groupAlgoChildEnv([]string{"PATH=/usr/bin"}, 2, false)
+	if got, ok := lookupEnv(bgEnv, childForegroundEnv); ok && got == "1" {
+		t.Errorf("background group-algo child env %s = %q, want it absent or 0 — "+
+			"background children keep nice+10 so the machine stays responsive", childForegroundEnv, got)
+	}
+
+	fgEnv = linksChildEnv([]string{"PATH=/usr/bin"}, 4, true)
+	if got, _ := lookupEnv(fgEnv, childForegroundEnv); got != "1" {
+		t.Errorf("links foreground child env %s = %q, want \"1\"", childForegroundEnv, got)
+	}
+	bgEnv = linksChildEnv([]string{"PATH=/usr/bin"}, 2, false)
+	if got, ok := lookupEnv(bgEnv, childForegroundEnv); ok && got == "1" {
+		t.Errorf("background links child env %s = %q, want it absent or 0", childForegroundEnv, got)
+	}
+}
+
+// An operator's pre-existing GRAFEL_CHILD_FOREGROUND in the daemon's own
+// environment must not leak a foreground exemption into every background child.
+func TestChildEnvOverridesAnInheritedForegroundSignal(t *testing.T) {
+	env := groupAlgoChildEnv([]string{childForegroundEnv + "=1"}, 2, false)
+	// lookupEnv returns the LAST occurrence, which is what exec honours.
+	if got, _ := lookupEnv(env, childForegroundEnv); got == "1" {
+		t.Errorf("a background child inherited %s=1 from the daemon env — "+
+			"every background pass would run un-niced", childForegroundEnv)
+	}
+}
+
+// Real fork: the value the links child is ACTUALLY launched with.
+func TestRunSubprocessLinks_ForegroundChildIsToldItIsForeground(t *testing.T) {
+	resetForegroundForTest(t)
+	out := filepath.Join(t.TempDir(), "fg.txt")
+	fakeChildScript(t, `printf 'fg=%s\n' "$`+childForegroundEnv+`" > `+out)
+
+	defer MarkGroupForeground("hot")()
+	if err := RunSubprocessLinks(context.Background(), "hot", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	b, _ := os.ReadFile(out)
+	if got := strings.TrimSpace(string(b)); got != "fg=1" {
+		t.Fatalf("links child env %q, want fg=1 — the parent never told the child it is foreground", got)
+	}
+
+	if err := RunSubprocessLinks(context.Background(), "cold", nil); err != nil {
+		t.Fatalf("RunSubprocessLinks: %v", err)
+	}
+	b, _ = os.ReadFile(out)
+	if got := strings.TrimSpace(string(b)); got == "fg=1" {
+		t.Fatalf("an unrelated background group's links child was told it is foreground (%q)", got)
+	}
+}
+
+// --- child side: the child ACTS on it ----------------------------------------
+
+// niceProbeEnv makes this test binary run the probe below instead of the suite.
+const niceProbeEnv = "GRAFEL_TEST_NICE_PROBE"
+
+// niceAtStartup is this binary's OS priority BEFORE any test ran. Captured at
+// package-var init so the baseline guard below can tell the two causes of a
+// niced parent apart: an already-demoted runner (`nice -n 10 go test ./...`, a
+// CI worker that demotes jobs), which is nobody's bug and should skip, versus a
+// test in this binary renicing the shared process, which disarms the assertion
+// and must fail loudly. Without the split the guard would misdiagnose the
+// former as the latter.
+var niceAtStartup = func() int {
+	n, err := strconv.Atoi(itoaPriority())
+	if err != nil {
+		return 0
+	}
+	return n
+}()
+
+// TestNiceProbeChild is not a test: it is the re-exec entry point. Under the
+// probe env it reports its inherited priority, applies the real nice policy to
+// itself, and reports the result — so the assertions below read the OS's answer
+// rather than the function's return value.
+func TestNiceProbeChild(t *testing.T) {
+	if os.Getenv(niceProbeEnv) == "" {
+		t.Skip("not the re-exec probe")
+	}
+	pre := itoaPriority()
+	applied := NiceSelfUnlessForeground()
+	os.Stdout.WriteString("pre=" + pre + " post=" + itoaPriority() +
+		" applied=" + strconv.FormatBool(applied) + "\n")
+	os.Exit(0)
+}
+
+type niceProbe struct {
+	pre, post int
+	applied   bool
+}
+
+func runNiceProbe(t *testing.T, foreground bool) niceProbe {
+	t.Helper()
+	exe, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	cmd := exec.Command(exe, "-test.run=TestNiceProbeChild")
+	cmd.Env = append(os.Environ(), niceProbeEnv+"=1")
+	if foreground {
+		cmd.Env = append(cmd.Env, childForegroundEnv+"=1")
+	} else {
+		cmd.Env = append(cmd.Env, childForegroundEnv+"=0")
+	}
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("nice probe: %v\n%s", err, out)
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if !strings.HasPrefix(line, "pre=") {
+			continue
+		}
+		var p niceProbe
+		if _, err := fmt.Sscanf(strings.TrimSpace(line), "pre=%d post=%d applied=%t",
+			&p.pre, &p.post, &p.applied); err != nil {
+			t.Fatalf("parse probe line %q: %v", line, err)
+		}
+		return p
+	}
+	t.Fatalf("probe printed no result:\n%s", out)
+	return niceProbe{}
+}
+
+// The load-bearing assertion: a child told it is foreground must NOT end up
+// niced, and a child not told so MUST. Read back from getpriority(2) in a real
+// forked process, because the bug being prevented is precisely a policy that
+// computes the right answer and never reaches the syscall.
+//
+// Everything is expressed relative to the INHERITED priority. A child inherits
+// its parent's nice, and nothing can lower it again without privilege, so any
+// test in this binary that renices the process in-process would otherwise turn
+// this assertion into a tautology (it did — see TestGroupAlgoNiceValue). Rather
+// than skip in that case, the inherited baseline is asserted too, so a future
+// in-process renice fails loudly here instead of silently disarming this test.
+func TestNiceSelfUnlessForeground_RealPriorityInAForkedChild(t *testing.T) {
+	if !niceIsSupported() {
+		t.Skip("no setpriority on this platform")
+	}
+	bg := runNiceProbe(t, false)
+	fg := runNiceProbe(t, true)
+
+	if fg.pre >= groupAlgoNice {
+		if niceAtStartup >= groupAlgoNice {
+			t.Skipf("this test binary was launched already niced (%d >= the demotion %d), so a "+
+				"foreground child and a background child are indistinguishable by priority. "+
+				"Re-run without the external nice to exercise this assertion.",
+				niceAtStartup, groupAlgoNice)
+		}
+		t.Fatalf("the forked child INHERITED nice %d (>= the demotion %d) but this binary started at "+
+			"%d — a test in this package reniced the shared process, which makes the foreground and "+
+			"background cases indistinguishable and disarms this test",
+			fg.pre, groupAlgoNice, niceAtStartup)
+	}
+
+	if bg.post == fg.post {
+		t.Fatalf("forked child nice is %d whether foreground or not — "+
+			"the child self-renices unconditionally, so the foreground signal never binds", bg.post)
+	}
+	if fg.applied {
+		t.Error("foreground child applied the background demotion")
+	}
+	if fg.post != fg.pre {
+		t.Errorf("foreground child nice %d -> %d: a rebuild the user is blocking on "+
+			"must not be demoted below their editor", fg.pre, fg.post)
+	}
+	if !bg.applied {
+		t.Error("background child skipped the demotion")
+	}
+	if bg.post != groupAlgoNice {
+		t.Errorf("background child nice = %d, want %d — background children keep the demotion",
+			bg.post, groupAlgoNice)
+	}
+}

--- a/internal/daemon/sched/groupalgo_cpu_test.go
+++ b/internal/daemon/sched/groupalgo_cpu_test.go
@@ -89,6 +89,13 @@ func TestGroupAlgoNiceValue(t *testing.T) {
 			t.Fatalf("groupAlgoNice on %s = %d, want positive demotion", runtime.GOOS, groupAlgoNice)
 		}
 	}
-	// Best-effort, must not panic regardless of platform/permission.
-	NiceSelf()
+	// NiceSelf is DELIBERATELY not called here. setpriority(2) is a permanent,
+	// one-way demotion of the calling process — nothing can lower it again
+	// without privilege — so calling it in-process renices the whole test binary
+	// to groupAlgoNice for the rest of the run, and every child any later test
+	// forks INHERITS that. That silently destroyed the only assertion that can
+	// catch the #5954 nice bug (a foreground child must come back un-niced):
+	// with the parent already at 10, foreground and background children read
+	// identically. The "must never panic" exercise now happens in a forked
+	// child instead — see TestNiceSelfUnlessForeground_RealPriorityInAForkedChild.
 }

--- a/internal/daemon/sched/nice_foreground.go
+++ b/internal/daemon/sched/nice_foreground.go
@@ -1,0 +1,80 @@
+package sched
+
+import (
+	"os"
+	"strings"
+)
+
+// nice_foreground.go — the OS-PRIORITY half of "interactive remains uncapped"
+// (#5954).
+//
+// THE GAP THIS CLOSES. GOMAXPROCS was not the only thing capping a user-awaited
+// rebuild. Both heavy batch children renice THEMSELVES to +10 at startup, with
+// no notion of what triggered the work, so a `grafel reset` the user is
+// blocking on ran its group-algo pass below the user's editor, below their
+// browser, and below grafel's own un-niced index children.
+//
+// WHAT THIS IS WORTH IS NOT ESTABLISHED — do not cite it as the wall-time fix.
+// nice weighting binds under oversubscription; a single-threaded pass on a box
+// with idle cores gets a core on demand at any nice level, and a process that
+// is blocked, sleeping, or waiting on a debounce is blocked at every nice level
+// too. The case for the change is that it removes a real, provable demotion of
+// work a human is waiting on, and costs nothing when the machine is idle. Where
+// the elapsed time actually goes is a separate question and needs measuring,
+// not patching.
+//
+// WHY AN ENV VAR AND NOT A FLAG. The renice is issued BY THE CHILD (see
+// cmd/grafel/group_algo.go and cmd/grafel/links_internal.go), deliberately, so
+// it holds however the child was spawned. A parent-side-only fix therefore
+// would not bind at all — the recurring failure mode of this epic: a guard that
+// exists, looks correct, and does not bind the path that runs. The signal has
+// to cross the fork, and these children already take their whole configuration
+// (GOMAXPROCS, GODEBUG, state dirs) through the environment.
+//
+// BACKGROUND KEEPS NICE+10. That demotion is the standing policy and the reason
+// a background pass does not make the machine unusable — it is what stopped the
+// v0.1.3 regression from starving a consumer's test harness. It lifts only for
+// work the user explicitly asked for and is blocking on.
+
+// childForegroundEnv tells a spawned batch child that the work it is about to
+// do is user-awaited. Set by the spawn helpers from the per-group foreground
+// registry (foreground.go); read by the child at startup.
+const childForegroundEnv = "GRAFEL_CHILD_FOREGROUND"
+
+// childForegroundEnvEntry renders the env entry for a child spawn.
+//
+// It is always emitted, including as an explicit "=0" for background children,
+// because the child inherits the daemon's whole environment: if the daemon
+// itself was started with GRAFEL_CHILD_FOREGROUND=1 in its environment (an
+// operator export, a stale launchd plist), an omit-when-false scheme would
+// silently un-nice every background pass on the machine. Appended last, so it
+// wins over any inherited value.
+func childForegroundEnvEntry(foreground bool) string {
+	if foreground {
+		return childForegroundEnv + "=1"
+	}
+	return childForegroundEnv + "=0"
+}
+
+// ChildIsForeground reports whether THIS process was spawned as part of
+// user-awaited work.
+func ChildIsForeground() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(childForegroundEnv))) {
+	case "1", "true", "yes":
+		return true
+	}
+	return false
+}
+
+// NiceSelfUnlessForeground applies the background OS-priority demotion to this
+// process unless it was spawned for user-awaited work. Returns whether the
+// demotion was applied.
+//
+// Call this at the top of a batch child instead of NiceSelf.
+func NiceSelfUnlessForeground() bool {
+	if ChildIsForeground() {
+		return false
+	}
+	NiceSelf()
+	return true
+}

--- a/internal/daemon/sched/nice_unix.go
+++ b/internal/daemon/sched/nice_unix.go
@@ -4,6 +4,7 @@ package sched
 
 import (
 	"os/exec"
+	"strconv"
 	"syscall"
 )
 
@@ -29,12 +30,30 @@ func applyGroupAlgoNice(cmd *exec.Cmd) {
 }
 
 // NiceSelf lowers the CURRENT process's OS scheduling priority by
-// groupAlgoNice. Called by the group-algo child at startup so it runs niced
-// regardless of how it was spawned. Best-effort: a failure (e.g. lacking
-// permission to renice) is silently ignored — the cap is the primary control.
+// groupAlgoNice. Best-effort: a failure (e.g. lacking permission to renice) is
+// silently ignored — the cap is the primary control.
+//
+// Prefer NiceSelfUnlessForeground at a child's startup: an unconditional
+// NiceSelf is what put a user-blocking rebuild's group-algo pass below the
+// user's editor.
 func NiceSelf() {
 	// PRIO_PROCESS=0, who=0 → the calling process. A positive value lowers
 	// priority. Errors are ignored: renicing DOWN never requires privilege, but
 	// guard anyway.
 	_ = syscall.Setpriority(syscall.PRIO_PROCESS, 0, groupAlgoNice)
+}
+
+// niceIsSupported reports whether this platform demotes priority at all.
+func niceIsSupported() bool { return true }
+
+// itoaPriority renders the calling process's current nice value, for tests that
+// need the OS's answer rather than a function's return value.
+func itoaPriority() string {
+	n, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+	if err != nil {
+		return "err"
+	}
+	// Darwin/Linux return the raw nice value from Getpriority via the syscall
+	// package (no PZERO bias), so this is directly comparable to groupAlgoNice.
+	return strconv.Itoa(n)
 }

--- a/internal/daemon/sched/nice_windows.go
+++ b/internal/daemon/sched/nice_windows.go
@@ -16,3 +16,9 @@ func applyGroupAlgoNice(cmd *exec.Cmd) {}
 
 // NiceSelf is a no-op on Windows.
 func NiceSelf() {}
+
+// niceIsSupported reports that this platform does not demote priority.
+func niceIsSupported() bool { return false }
+
+// itoaPriority has no meaningful answer on Windows.
+func itoaPriority() string { return "0" }

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -2247,6 +2247,17 @@ func (s *Scheduler) CancelGroup(group string) {
 		}
 	}
 
+	// Drop any foreground mark on the group (#5954). The group is being deleted,
+	// so no epoch can still be current and the epoch-scoped clear does not
+	// apply — this is the one unconditional teardown. Without it a group deleted
+	// and recreated inside the 30m linger window would run its first BACKGROUND
+	// pass at foreground caps and un-niced, which is exactly the policy
+	// inversion this epic is fixing.
+	//
+	// Safe under s.mu: the foreground registry has its own mutex and never
+	// takes s.mu, so there is no lock-order edge to invert.
+	ForgetGroupForeground(group)
+
 	s.logEventLocked("group_cancelled", "", group+": cancelled in-flight enrichment on group delete")
 }
 
@@ -2280,7 +2291,12 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 	// so `cap=` reflects the cores the pass can consume, not the old, misleading
 	// NumCPU/2 concurrency number (the CPU-regression diagnosis confusion).
 	// Log the cap the child will ACTUALLY be spawned with, which since #5954
-	// depends on whether this group is user-awaited (foreground.go).
+	// depends on whether this group is user-awaited (foreground.go). The epoch
+	// is captured HERE, at the start of the pass, so the clear at the end names
+	// the mark this pass was actually spawned under — a rebuild that re-marks
+	// the group while this (long) pass runs must not have its mark wiped by
+	// this pass finishing.
+	fgEpoch, _ := GroupForegroundState(group)
 	capN := groupAlgoChildGOMAXPROCS(group)
 	s.logger.Info("group-algo: starting", "group", group, "cap", capN)
 	select {
@@ -2322,7 +2338,10 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 	// Only on success, and only here: on error or cancellation the awaited
 	// artifact does not exist yet, so the retry stays foreground and the linger
 	// window in foreground.go is what bounds it.
-	ClearGroupForeground(group)
+	//
+	// Epoch-scoped: a pass that started under one rebuild's mark and finished
+	// after a NEWER rebuild re-marked the group clears nothing.
+	ClearGroupForeground(group, fgEpoch)
 }
 
 // Snapshot reports current scheduler state for the Status RPC.

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -2279,7 +2279,9 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 	// core usage of the (subprocess) pass is its GOMAXPROCS. Log that real value
 	// so `cap=` reflects the cores the pass can consume, not the old, misleading
 	// NumCPU/2 concurrency number (the CPU-regression diagnosis confusion).
-	capN := GroupAlgoGOMAXPROCS()
+	// Log the cap the child will ACTUALLY be spawned with, which since #5954
+	// depends on whether this group is user-awaited (foreground.go).
+	capN := groupAlgoChildGOMAXPROCS(group)
 	s.logger.Info("group-algo: starting", "group", group, "cap", capN)
 	select {
 	case s.algoSem <- struct{}{}:
@@ -2312,6 +2314,15 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 		return
 	}
 	s.logEvent("group_algo_ok", "", group+" "+time.Since(t0).Truncate(time.Millisecond).String())
+	// #5954 wall-time: the group-algo pass is the LAST stage of the work a
+	// foreground rebuild sets in motion. Its success means the graph the user
+	// asked for now exists, so the group stops being "user-awaited" and any
+	// later pass is background churn again, on background caps.
+	//
+	// Only on success, and only here: on error or cancellation the awaited
+	// artifact does not exist yet, so the retry stays foreground and the linger
+	// window in foreground.go is what bounds it.
+	ClearGroupForeground(group)
 }
 
 // Snapshot reports current scheduler state for the Status RPC.

--- a/internal/daemon/sched/subprocess_groupalgo_env_test.go
+++ b/internal/daemon/sched/subprocess_groupalgo_env_test.go
@@ -20,7 +20,7 @@ import (
 // TestGroupAlgoChildEnvSetsMadvDontNeed asserts the constructed child env
 // carries the reclaim setting, and still carries the CPU bound.
 func TestGroupAlgoChildEnvSetsMadvDontNeed(t *testing.T) {
-	env := groupAlgoChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2)
+	env := groupAlgoChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2, false)
 
 	godebug, ok := lookupEnv(env, "GODEBUG")
 	if !ok {
@@ -41,13 +41,13 @@ func TestGroupAlgoChildEnvSetsMadvDontNeed(t *testing.T) {
 // GODEBUG settings are merged rather than clobbered, matching withMadvDontNeed's
 // contract, and that an explicit madvdontneed=0 is left alone.
 func TestGroupAlgoChildEnvMergesInheritedGODEBUG(t *testing.T) {
-	env := groupAlgoChildEnv([]string{"GODEBUG=http2debug=1"}, 3)
+	env := groupAlgoChildEnv([]string{"GODEBUG=http2debug=1"}, 3, false)
 	godebug, _ := lookupEnv(env, "GODEBUG")
 	if !strings.Contains(godebug, "http2debug=1") || !strings.Contains(godebug, madvDontNeedSetting) {
 		t.Errorf("GODEBUG = %q, want both the inherited setting and %q", godebug, madvDontNeedSetting)
 	}
 
-	env = groupAlgoChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1)
+	env = groupAlgoChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1, false)
 	godebug, _ = lookupEnv(env, "GODEBUG")
 	if godebug != "madvdontneed=0" {
 		t.Errorf("GODEBUG = %q, want an explicit operator madvdontneed=0 left alone", godebug)

--- a/internal/daemon/sched/subprocess_links_5954_test.go
+++ b/internal/daemon/sched/subprocess_links_5954_test.go
@@ -30,7 +30,7 @@ import (
 // only be delivered through the environment; asserting on the constructed env
 // is the only way to pin it without fork-execing.
 func TestLinksChildEnvSetsMadvDontNeed(t *testing.T) {
-	env := linksChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2)
+	env := linksChildEnv([]string{"PATH=/usr/bin", "HOME=/home/x"}, 2, false)
 
 	godebug, ok := lookupEnv(env, "GODEBUG")
 	if !ok {
@@ -51,13 +51,13 @@ func TestLinksChildEnvSetsMadvDontNeed(t *testing.T) {
 // operator's other GODEBUG settings are merged, not clobbered, and an explicit
 // madvdontneed=0 is left alone.
 func TestLinksChildEnvMergesInheritedGODEBUG(t *testing.T) {
-	env := linksChildEnv([]string{"GODEBUG=http2debug=1"}, 3)
+	env := linksChildEnv([]string{"GODEBUG=http2debug=1"}, 3, false)
 	godebug, _ := lookupEnv(env, "GODEBUG")
 	if !strings.Contains(godebug, "http2debug=1") || !strings.Contains(godebug, madvDontNeedSetting) {
 		t.Errorf("GODEBUG = %q, want both the inherited setting and %q", godebug, madvDontNeedSetting)
 	}
 
-	env = linksChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1)
+	env = linksChildEnv([]string{"GODEBUG=madvdontneed=0"}, 1, false)
 	godebug, _ = lookupEnv(env, "GODEBUG")
 	if godebug != "madvdontneed=0" {
 		t.Errorf("GODEBUG = %q, want an explicit operator madvdontneed=0 left alone", godebug)

--- a/internal/daemon/sched/subprocess_links_5954_test.go
+++ b/internal/daemon/sched/subprocess_links_5954_test.go
@@ -66,8 +66,8 @@ func TestLinksChildEnvMergesInheritedGODEBUG(t *testing.T) {
 
 func TestLinksGOMAXPROCSDefaultAndOverride(t *testing.T) {
 	t.Setenv("GRAFEL_LINKS_CPU", "")
-	if got := LinksGOMAXPROCS(); got != linksGOMAXPROCSDefault {
-		t.Fatalf("default LinksGOMAXPROCS = %d, want %d", got, linksGOMAXPROCSDefault)
+	if got := LinksGOMAXPROCS(); got != BackgroundBatchGOMAXPROCS() {
+		t.Fatalf("default LinksGOMAXPROCS = %d, want %d", got, BackgroundBatchGOMAXPROCS())
 	}
 	for _, c := range []struct {
 		env  string
@@ -75,9 +75,9 @@ func TestLinksGOMAXPROCSDefaultAndOverride(t *testing.T) {
 	}{
 		{"3", 3},
 		{"1", 1},
-		{"0", linksGOMAXPROCSDefault},
-		{"garbage", linksGOMAXPROCSDefault},
-		{"-4", linksGOMAXPROCSDefault},
+		{"0", BackgroundBatchGOMAXPROCS()},
+		{"garbage", BackgroundBatchGOMAXPROCS()},
+		{"-4", BackgroundBatchGOMAXPROCS()},
 	} {
 		t.Setenv("GRAFEL_LINKS_CPU", c.env)
 		if got := LinksGOMAXPROCS(); got != c.want {

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -214,18 +214,36 @@ func resolveChildGOMAXPROCS(interactive bool, foregroundCap int) (n int, reason 
 // WHY /8 AND NOT /4. process.IndexCoreBudget's 25% is the budget for the whole
 // INDEXING fanout, which is many processes sharing it. These are single
 // children, and the divisor was chosen so the value is UNCHANGED at 12 cores —
-// the configuration the current caps were measured on — while still scaling on
-// bigger hosts. It is therefore strictly inside the 25% policy (12.5%) and
-// cannot regress the background behaviour on the machine that reported the
-// problem.
+// the configuration the current caps were measured on — so this cannot regress
+// the background behaviour on the machine that reported the problem.
+//
+// WHAT THIS IS NOT. It is not "the 25% rule". Be precise, because the user's
+// directive was specific and this deviates from it in BOTH directions:
+//
+//   - Above 8 cores it is HALF of what the directive asks. At 32 cores the 25%
+//     rule would give 8; this gives 4. That is a deliberate conservatism for a
+//     single always-on background child, not a fulfilment of the policy, and if
+//     the user wants literal 25% here the divisor is the one thing to change.
+//   - Below 8 cores the FLOOR EXCEEDS 25%. On a 4-core box 2 cores is 50%; on a
+//     2-core box it is 100%. A floor means exactly that — the proportional rule
+//     is overridden at the small end so a background pass can still finish.
+//
+// So: proportional above 8 cores at 12.5%, floored at 2 below that.
 //
 // WHY A FLOOR OF 2. Below 2 the pass loses GC/runtime parallelism entirely and
 // a background pass that never finishes is its own kind of failure. On a
 // 1-core host the floor yields to the machine (clamped to NumCPU).
 //
-// Unlike the index fanout this cap is expressed purely as GOMAXPROCS, which is
-// sound here: neither pass is cgo-bound (no tree-sitter), so GOMAXPROCS really
-// does bound their parallelism.
+// WHAT THIS NUMBER ACTUALLY BUYS TODAY: very little, in either direction. Both
+// passes are SERIAL — internal/links, internal/graph, internal/graph/groupalgo
+// and the gonum packages they call (graph/community, graph/network, graph/path,
+// mat) have no goroutine fan-out, and algorithms.go's network.PageRankSparse
+// never reaches the one parallel path in the dependency (blas dgemm/sgemm). A
+// live group-algo child shows one thread running and the rest asleep. So this
+// value mostly sizes the GC's mark workers, not the pass. It is kept honest and
+// proportional anyway, because it is the number that will bind the moment
+// either pass is parallelised, and because a wrong number here is invisible
+// until it is expensive. Do not cite it as a throughput control.
 const (
 	backgroundBatchCoreDivisor = 8
 	backgroundBatchCoreFloor   = 2
@@ -577,10 +595,15 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 // invisible to the OS until the kernel comes under pressure, which is precisely
 // what whole-machine peak measurement reads (#5954). The index child has had
 // this since RunSubprocessIndex; group-algo was simply never given it.
-func groupAlgoChildEnv(base []string, gomaxprocs int) []string {
-	env := make([]string, 0, len(base)+2)
+//
+// foreground also crosses here (#5954). The child renices ITSELF at startup, so
+// the only way to stop a user-awaited pass running below the user's editor is
+// to tell the child; see nice_foreground.go.
+func groupAlgoChildEnv(base []string, gomaxprocs int, foreground bool) []string {
+	env := make([]string, 0, len(base)+3)
 	env = append(env, base...)
 	env = append(env, "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	env = append(env, childForegroundEnvEntry(foreground))
 	return withMadvDontNeed(env)
 }
 
@@ -598,12 +621,18 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	// host speed, background churn stays on the proportional background cap.
 	// GOMAXPROCS is appended last so it wins over any inherited value.
 	// groupAlgoChildEnv also merges GODEBUG=madvdontneed=1 — see its doc.
-	gomaxprocs := groupAlgoChildGOMAXPROCS(group)
-	cmd.Env = groupAlgoChildEnv(os.Environ(), gomaxprocs)
-	// Lower the child's OS scheduling priority (nice +10) so even its capped
-	// cores yield to foreground work (a consumer's CI / dev harness). No-op /
-	// guarded off on platforms without setpriority (e.g. Windows). See
-	// applyGroupAlgoNice (platform-split files).
+	//
+	// Resolved ONCE here and used for both the cap and the nice signal, so the
+	// two cannot disagree about what kind of work this is.
+	foreground := GroupIsForeground(group)
+	gomaxprocs := GroupAlgoGOMAXPROCSFor(foreground)
+	cmd.Env = groupAlgoChildEnv(os.Environ(), gomaxprocs, foreground)
+	// Put the child in its own process group so it is independently schedulable.
+	// This hook does NOT set priority — despite its name it only sets Setpgid;
+	// the nice increment is applied by the CHILD to itself at startup, and since
+	// #5954 only when it was not told it is foreground
+	// (sched.NiceSelfUnlessForeground, delivered via childForegroundEnv above).
+	// No-op on platforms without process groups (Windows).
 	applyGroupAlgoNice(cmd)
 	// On Windows, prevent a console window from flashing when the daemon
 	// (running as a Task Scheduler task) spawns this subprocess.
@@ -702,10 +731,13 @@ func linksChildGOMAXPROCS(group string) int {
 // under pressure, which is exactly what whole-machine peak measurement reads
 // (#5954). group-algo shipped without it and needed a follow-up; this child has
 // it from its first commit.
-func linksChildEnv(base []string, gomaxprocs int) []string {
-	env := make([]string, 0, len(base)+2)
+//
+// foreground crosses here too — see groupAlgoChildEnv.
+func linksChildEnv(base []string, gomaxprocs int, foreground bool) []string {
+	env := make([]string, 0, len(base)+3)
 	env = append(env, base...)
 	env = append(env, "GOMAXPROCS="+strconv.Itoa(gomaxprocs))
+	env = append(env, childForegroundEnvEntry(foreground))
 	return withMadvDontNeed(env)
 }
 
@@ -771,14 +803,17 @@ func RunSubprocessLinks(ctx context.Context, group string, logger *slog.Logger) 
 	}
 
 	cmd := exec.CommandContext(ctx, binary, "links-internal", group)
-	// Foreground/background split — see groupAlgoChildGOMAXPROCS.
-	gomaxprocs := linksChildGOMAXPROCS(group)
-	cmd.Env = linksChildEnv(os.Environ(), gomaxprocs)
-	// Put the child in its own process group so it is independently
-	// schedulable; the nice increment itself is applied by the child at startup
-	// (sched.NiceSelf). applyGroupAlgoNice is the shared spawn-side hook for
-	// both background batch children — it is named for the first one that
-	// needed it, not scoped to it.
+	// Foreground/background split — see groupAlgoChildGOMAXPROCS. One resolution
+	// feeds both the CPU cap and the OS-priority signal.
+	foreground := GroupIsForeground(group)
+	gomaxprocs := LinksGOMAXPROCSFor(foreground)
+	cmd.Env = linksChildEnv(os.Environ(), gomaxprocs, foreground)
+	// Put the child in its own process group so it is independently schedulable;
+	// the nice increment itself is applied by the child at startup, and only
+	// when it was not told it is foreground (sched.NiceSelfUnlessForeground,
+	// delivered via childForegroundEnv above). applyGroupAlgoNice is the shared
+	// spawn-side hook for both background batch children — it is named for the
+	// first one that needed it, not scoped to it.
 	applyGroupAlgoNice(cmd)
 	// On Windows, prevent a console window from flashing when the daemon
 	// (running as a Task Scheduler task) spawns this subprocess.

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -196,30 +196,106 @@ func resolveChildGOMAXPROCS(interactive bool, foregroundCap int) (n int, reason 
 	return ReindexGraphPhaseGOMAXPROCS(), "daemon-wide reindex CPU ceiling"
 }
 
-// groupAlgoGOMAXPROCSDefault is the per-child CPU cap (Go GOMAXPROCS) for the
-// background group-algorithm subprocess. The pass (Louvain + PageRank +
-// betweenness over the whole group union) is the heaviest analytics job the
-// daemon runs. Without a cap the child inherits the daemon's GOMAXPROCS (= host
-// core count) and the Go runtime spins one worker thread per core — the v0.1.3
-// CPU regression where it pinned a 12-core machine at 500–1000% for hours.
+// backgroundBatchCoreDivisor / backgroundBatchCoreFloor define the BACKGROUND
+// per-child CPU cap shared by the two heavy batch children (group-algo, links):
 //
-// Default 2 follows the extract subprocess's principle — "the less the better"
-// for a background job. (GRAFEL_EXTRACT_GOMAXPROCS itself dropped to 1 in #5960
-// because that fanout is budgeted across many children; the group-algo pass is a
-// single child, so it keeps 2.) The user can set GRAFEL_GROUP_ALGO_CPU=1 to throttle it to a
-// single core.
-const groupAlgoGOMAXPROCSDefault = 2
+//	cap = clamp(NumCPU/8, floor 2, NumCPU)
+//
+//	 1-core → 1     4-core → 2    12-core → 2
+//	 8-core → 2    32-core → 4    64-core → 8
+//
+// WHY PROPORTIONAL. Both children used to be a hardcoded 2. That number is
+// defensible on a 12-core laptop and absurd on a 64-core server, and it
+// contradicts the standing policy, which is explicitly proportional: "cap it at
+// max of 25% of the machine capacity, so it will not be a static number and
+// bigger machines will get better times" (#5960, the same reasoning as
+// process.IndexCoreBudget).
+//
+// WHY /8 AND NOT /4. process.IndexCoreBudget's 25% is the budget for the whole
+// INDEXING fanout, which is many processes sharing it. These are single
+// children, and the divisor was chosen so the value is UNCHANGED at 12 cores —
+// the configuration the current caps were measured on — while still scaling on
+// bigger hosts. It is therefore strictly inside the 25% policy (12.5%) and
+// cannot regress the background behaviour on the machine that reported the
+// problem.
+//
+// WHY A FLOOR OF 2. Below 2 the pass loses GC/runtime parallelism entirely and
+// a background pass that never finishes is its own kind of failure. On a
+// 1-core host the floor yields to the machine (clamped to NumCPU).
+//
+// Unlike the index fanout this cap is expressed purely as GOMAXPROCS, which is
+// sound here: neither pass is cgo-bound (no tree-sitter), so GOMAXPROCS really
+// does bound their parallelism.
+const (
+	backgroundBatchCoreDivisor = 8
+	backgroundBatchCoreFloor   = 2
+)
 
-// GroupAlgoGOMAXPROCS resolves the GOMAXPROCS cap applied to the group-algo
-// subprocess, honouring GRAFEL_GROUP_ALGO_CPU (a strictly-positive integer; 1
-// is valid). Unset, empty, non-numeric, or <= 0 → groupAlgoGOMAXPROCSDefault.
-func GroupAlgoGOMAXPROCS() int {
+// backgroundBatchGOMAXPROCSFor is the pure form of the background batch cap,
+// taking the host core count explicitly so the policy stays unit-testable
+// across core counts. Always >= 1.
+func backgroundBatchGOMAXPROCSFor(numCPU int) int {
+	if numCPU < 1 {
+		numCPU = 1
+	}
+	n := numCPU / backgroundBatchCoreDivisor
+	if n < backgroundBatchCoreFloor {
+		n = backgroundBatchCoreFloor
+	}
+	if n > numCPU {
+		n = numCPU
+	}
+	return n
+}
+
+// BackgroundBatchGOMAXPROCS is backgroundBatchGOMAXPROCSFor for this host.
+func BackgroundBatchGOMAXPROCS() int {
+	return backgroundBatchGOMAXPROCSFor(runtime.NumCPU())
+}
+
+// GroupAlgoGOMAXPROCSFor resolves the GOMAXPROCS cap applied to the group-algo
+// subprocess, dispatching on whether a human is waiting on the result.
+//
+// Precedence, highest first:
+//
+//  1. GRAFEL_GROUP_ALGO_CPU (strictly-positive; 1 is valid) — an explicit
+//     operator override is an escape hatch and is honoured in BOTH modes,
+//     never clamped to either policy.
+//  2. foreground — ForegroundReindexGOMAXPROCS(): GRAFEL_REBUILD_GOMAXPROCS
+//     if set, else the host core count. Deliberately the SAME knob the extract
+//     coordinator and the index child already use for foreground rebuilds
+//     (#5135) rather than a fourth env var, so an operator has one dial for
+//     "how much machine may a rebuild take".
+//  3. background — BackgroundBatchGOMAXPROCS().
+//
+// The pass (Louvain + PageRank + betweenness over the whole group union) is the
+// heaviest analytics job the daemon runs; without any cap the child inherits
+// the daemon's GOMAXPROCS and the Go runtime spins one worker thread per core —
+// the v0.1.3 CPU regression where it pinned a 12-core machine at 500–1000% for
+// hours. That regression was BACKGROUND churn, which is why the cap stays there
+// and lifts only for work the user explicitly asked for and is blocking on.
+func GroupAlgoGOMAXPROCSFor(foreground bool) int {
 	if raw := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_CPU")); raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
 			return n
 		}
 	}
-	return groupAlgoGOMAXPROCSDefault
+	if foreground {
+		return ForegroundReindexGOMAXPROCS()
+	}
+	return BackgroundBatchGOMAXPROCS()
+}
+
+// GroupAlgoGOMAXPROCS is the BACKGROUND resolution. Kept as the no-argument
+// spelling for callers that are unambiguously background work.
+func GroupAlgoGOMAXPROCS() int { return GroupAlgoGOMAXPROCSFor(false) }
+
+// groupAlgoChildGOMAXPROCS is the spawn-site resolution for one group: it reads
+// the foreground registry (see foreground.go) rather than taking a bool, so the
+// signal reaches the fork-exec without threading a parameter through the
+// scheduler's timer/gate machinery — which has no idea who triggered the work.
+func groupAlgoChildGOMAXPROCS(group string) int {
+	return GroupAlgoGOMAXPROCSFor(GroupIsForeground(group))
 }
 
 // SubprocessIndexEnabled reports whether the daemon should run each
@@ -515,13 +591,14 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	}
 
 	cmd := exec.CommandContext(ctx, binary, "group-algo", group, "--write")
-	// Bound the child's Go runtime to GroupAlgoGOMAXPROCS() cores (default 2,
-	// env GRAFEL_GROUP_ALGO_CPU) so the background analytics pass cannot scale
+	// Bound the child's Go runtime so a BACKGROUND analytics pass cannot scale
 	// its worker pool to the full host core count — the v0.1.3 CPU regression.
-	// GOMAXPROCS is appended last so it wins over any inherited value. Mirrors
-	// the extract subprocess (GRAFEL_EXTRACT_GOMAXPROCS). groupAlgoChildEnv also
-	// merges GODEBUG=madvdontneed=1 — see its doc comment.
-	gomaxprocs := GroupAlgoGOMAXPROCS()
+	// groupAlgoChildGOMAXPROCS resolves that from the foreground registry: a
+	// pass the user is waiting on (their rebuild's follow-on group-algo) runs at
+	// host speed, background churn stays on the proportional background cap.
+	// GOMAXPROCS is appended last so it wins over any inherited value.
+	// groupAlgoChildEnv also merges GODEBUG=madvdontneed=1 — see its doc.
+	gomaxprocs := groupAlgoChildGOMAXPROCS(group)
 	cmd.Env = groupAlgoChildEnv(os.Environ(), gomaxprocs)
 	// Lower the child's OS scheduling priority (nice +10) so even its capped
 	// cores yield to foreground work (a consumer's CI / dev harness). No-op /
@@ -580,30 +657,36 @@ func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logg
 	return nil
 }
 
-// linksGOMAXPROCSDefault is the per-child CPU cap for the background cross-repo
-// link child. Same reasoning and same default as the group-algo child: it is a
-// single background batch process nobody is waiting on, so "the less the
-// better", and 2 leaves the host responsive while still letting the per-pass
-// worker pools do useful concurrent work. GRAFEL_LINKS_CPU=1 throttles it
-// further.
+// LinksGOMAXPROCSFor resolves the GOMAXPROCS cap applied to the cross-repo link
+// child. Mirrors GroupAlgoGOMAXPROCSFor exactly — same precedence, same
+// foreground/background split — with GRAFEL_LINKS_CPU as its operator override.
 //
-// Until #5954 this pass ran IN-PROCESS in the engine, i.e. at the engine's
-// GOMAXPROCS (= host core count) with no cap at all — so this constant is not
-// just isolation bookkeeping, it is the first CPU bound the link pass has ever
-// had.
-const linksGOMAXPROCSDefault = 2
-
-// LinksGOMAXPROCS resolves the GOMAXPROCS cap applied to the links child,
-// honouring GRAFEL_LINKS_CPU (a strictly-positive integer; 1 is valid). Unset,
-// empty, non-numeric, or <= 0 → linksGOMAXPROCSDefault. Mirrors
-// GroupAlgoGOMAXPROCS exactly.
-func LinksGOMAXPROCS() int {
+// The background default used to be a hardcoded 2. That value shipped with ZERO
+// measured wall-time delta behind it (it was carried over from the group-algo
+// child by analogy), so it is replaced here by the proportional
+// BackgroundBatchGOMAXPROCS, which is identical at 12 cores and better on
+// larger hosts. Until #5954 this pass ran IN-PROCESS in the engine at the
+// engine's full GOMAXPROCS with no cap at all, so the background cap remains a
+// tightening, not a loosening.
+func LinksGOMAXPROCSFor(foreground bool) int {
 	if raw := strings.TrimSpace(os.Getenv("GRAFEL_LINKS_CPU")); raw != "" {
 		if n, err := strconv.Atoi(raw); err == nil && n > 0 {
 			return n
 		}
 	}
-	return linksGOMAXPROCSDefault
+	if foreground {
+		return ForegroundReindexGOMAXPROCS()
+	}
+	return BackgroundBatchGOMAXPROCS()
+}
+
+// LinksGOMAXPROCS is the BACKGROUND resolution.
+func LinksGOMAXPROCS() int { return LinksGOMAXPROCSFor(false) }
+
+// linksChildGOMAXPROCS is the spawn-site resolution for one group — see
+// groupAlgoChildGOMAXPROCS.
+func linksChildGOMAXPROCS(group string) int {
+	return LinksGOMAXPROCSFor(GroupIsForeground(group))
 }
 
 // linksChildEnv builds the environment for the links child: the GOMAXPROCS
@@ -688,7 +771,8 @@ func RunSubprocessLinks(ctx context.Context, group string, logger *slog.Logger) 
 	}
 
 	cmd := exec.CommandContext(ctx, binary, "links-internal", group)
-	gomaxprocs := LinksGOMAXPROCS()
+	// Foreground/background split — see groupAlgoChildGOMAXPROCS.
+	gomaxprocs := linksChildGOMAXPROCS(group)
 	cmd.Env = linksChildEnv(os.Environ(), gomaxprocs)
 	// Put the child in its own process group so it is independently
 	// schedulable; the nice increment itself is applied by the child at startup


### PR DESCRIPTION
## What

Batch-child resource limits now resolve from **who asked for the work**, not from a single global policy:

- a per-group foreground registry (`internal/daemon/sched/foreground.go`), consulted at fork time by `groupAlgoChildGOMAXPROCS` / `linksChildGOMAXPROCS`
- **`nice+10` is no longer applied to user-awaited children**

Background work is unchanged in the configuration that reported the problem.

## Why

The standing directive had two halves — *background indexing capped at 25% of machine capacity* **and** *interactive/foreground stays uncapped*. Only the first shipped. Caps resolve inside child-spawn helpers that have no notion of foreground versus background, so a user-blocking `grafel reset` inherited background throttling: `GOMAXPROCS=2` on a 12-core box, and `nice+10` while every other process on the machine — including the daemon itself — runs at nice 0.

## ⚠️ What this is NOT

**This is not the wall-time fix, and it should not be cited as one.**

`group-algo` and `links` contain **no parallelism at all** — see #6000. `internal/links`, `internal/graph`, `internal/graph/groupalgo` and the gonum packages they call (`graph/community`, `graph/network`, `graph/path`, `mat`) have zero `go func(` / `WaitGroup` / `errgroup` between them. The only parallel code in the chain is `blas/gonum` dgemm/sgemm, and `algorithms.go:774` uses `network.PageRankSparse`, a sparse mat-vec that never reaches it. Lifting `GOMAXPROCS` for these passes buys additional GC background mark workers on a ~195MB heap and essentially nothing else.

The `nice` half is a real, provable demotion of work a human is blocking on, and removing it is correct policy. But its value is **not established**: nice weighting binds under oversubscription, and a single-threaded pass on a box with idle cores gets a core on demand at any nice level. A live child was measured at ~5% lifetime duty cycle with **92% instantaneous** CPU and 4-5 cores idle — the signature of a process that is blocked, not one losing a CPU race. A blocked process is blocked at every nice level. That mystery is #6002 and is not addressed here.

## The foreground signal

The index child already carries `--interactive` and needed nothing. For `group-algo` and `links`, both spawn points resolve foreground **once** and feed both consumers from that single value, so a cap and an env stamp cannot diverge.

Because the child **self-renices**, a parent-only fix would look correct and do nothing. `GRAFEL_CHILD_FOREGROUND` is stamped by the parent and consumed by `sched.NiceSelfUnlessForeground()`, which replaces the unconditional `NiceSelf()` at both child entrypoints. "Foreground" means *never demote* — nothing attempts to raise priority, which would silently fail for an unprivileged process.

The mark **lingers** past the rebuild, because the stages that dominate a user's wall clock spawn minutes after `daemonRebuildFuncCore` returns — and a foreground rebuild's group-algo is triggered by the stale-overlay sweep or a link-pass completion, both structurally background. It is closed by the group-algo pass succeeding, epoch-scoped so a stale completion cannot wipe a fresher rebuild's mark, time-bounded by `GRAFEL_FOREGROUND_LINGER` (default 30m) checked at read time, and cleared on group teardown via `Scheduler.CancelGroup`.

## Background caps

`clamp(NumCPU/8, floor 2, NumCPU)`. Stated plainly rather than as "the 25% rule", because it is not: `/8` is **12.5%** above 8 cores (at 32 cores the directive wants 8, this gives 4), and the floor of 2 **exceeds** 25% below 8 cores (2 of 4 = 50%). It is unchanged at 12 cores — the configuration every existing measurement was taken on — so the background policy provably cannot regress there.

`GRAFEL_GROUP_ALGO_CPU` / `GRAFEL_LINKS_CPU` keep top precedence in both modes, unclamped.

## A test was disarming another test

The priority test passed at `-count=1` and failed at `-count=2`. `TestGroupAlgoNiceValue` called `NiceSelf()` **in-process** as a panic-safety exercise; `setpriority` is a permanent one-way demotion, so it reniced the whole test binary and every child forked by any later test inherited it — making foreground and background probes read identically and silently turning the only assertion capable of catching the nice bug into a tautology.

The in-process call is gone, the panic exercise moved into the forked probe, and the probe now asserts its **inherited baseline**, so a future in-process renice fails loudly. A binary launched already niced (`nice -n 10 go test ./...`, or a CI runner that demotes workers) skips with a reason rather than failing misleadingly.

## Verification

`go build`, `go vet ./cmd/... ./internal/...`, `gofmt -l internal cmd` clean. `./internal/daemon/... ./internal/process/... ./cmd/grafel/... -count=1 -p 3` → 1309 passed. `./internal/daemon/sched/... -race -count=2` and `-count=3` clean.

All five mutations die: `GroupIsForeground` always-false (9 tests); always-true (9); child renices unconditionally; parent stops stamping the env, so the signal never crosses the fork (3, including a real-fork test); `ClearGroupForeground` ignores the epoch.

The priority test asserts through a **real fork** reading actual OS priority via `syscall.Getpriority` — not a mocked value — and asserts *unchanged*, not merely *below 10*.

`TestRunSubprocessLinks_CancelTerminatesChild` is pre-existing flaky and tracked as #5999.

Refs #5954, #6000, #6002
