### PR TITLE
fix(#6002): take group-algo off the critical path and make background mean it finishes

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1033,16 +1033,27 @@ func groupAlgoSweepWants(group string, needsRecompute, hasOverlay, hasIndexedMem
 	return hasIndexedMember(group)
 }
 
-// groupHasOverlay reports whether a group has an overlay file on disk at all.
-// An unresolvable path reports true — "unknown" must not force-fire a heavy
-// pass.
+// groupHasOverlay reports whether a group has a USABLE overlay on disk.
+//
+// Usable, not merely present: a CORRUPT overlay (truncated write from a killed
+// process, a hand-edited file) is the last state that could still leave a group
+// with no communities forever. OverlayNeedsRecompute returns false on an
+// unmarshal failure — deliberately, so the sweep does not thrash on garbage —
+// and a bare os.Stat would report the file as present, so both gates would say
+// "nothing to do" and the backstop would never fire. OverlayAlgoVersionOnDisk
+// reports ok=false for absent AND unparseable, which routes corruption into the
+// first-compute path that overwrites it. Still bounded: one pass, after which a
+// valid overlay exists.
+//
+// An unresolvable overlay path reports true — "unknown" must not force-fire a
+// heavy pass.
 func groupHasOverlay(group string) bool {
 	path, err := groupalgo.OverlayPath(group)
 	if err != nil || path == "" {
 		return true
 	}
-	_, statErr := os.Stat(path)
-	return statErr == nil
+	_, ok := groupalgo.OverlayAlgoVersionOnDisk(group)
+	return ok
 }
 
 // groupHasIndexedMember reports whether at least one of a group's repos has a

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -983,11 +983,28 @@ func daemonGroupsForRepo(repoPath string) []string {
 // push, or an idle re-stat) settles the overlay in place and is NOT returned
 // here, so the sweep no longer fires a ~½-core Louvain burst on an idle daemon.
 //
-// Groups with NO overlay yet are deliberately excluded (OverlayNeedsRecompute
-// returns false for an absent overlay): those take the normal first-compute
-// link-pass chain after their first reindex, and the sweep must not force-fire
-// them. Best-effort: any registry error yields an empty list (sweep skips this
-// tick) rather than wedging.
+// FIRST COMPUTE (#6002). It ALSO returns a group that has member graphs on disk
+// but NO overlay at all. That case used to be deliberately excluded, on the
+// reasoning that "those take the normal first-compute link-pass chain after
+// their first reindex" — but that chain does not cover the path a user actually
+// takes. `grafel rebuild` / `grafel reset` runs its own IN-PROCESS link pass
+// (daemonRebuildFuncCore → daemonForegroundLinks); it never goes through the
+// scheduler, so runLinks — the only caller of scheduleGroupAlgo — never runs and
+// no pass is ever armed. With the sweep also excluding the group (no overlay
+// file), a freshly reset group could sit indefinitely with a complete, queryable
+// graph and no communities at all, until some unrelated watcher-driven reindex
+// happened to fire the chain. That is exactly the "silently dropped" failure the
+// background overlay must not have: taking the pass off the rebuild's critical
+// path is only acceptable if something reliably picks it up afterwards.
+//
+// The extra work is bounded: the sweep skips groups with a pending/in-flight
+// pass, and a successful pass writes an overlay, so this fires once per group
+// and then falls back to the (content-gated) staleness predicate. A group with
+// no indexed member yet is excluded — assembling an empty union would be pure
+// waste, and it will be picked up on the sweep after its first index.
+//
+// Best-effort throughout: any registry error yields an empty list (sweep skips
+// this tick) rather than wedging.
 func daemonSchedulerStaleGroups() []string {
 	groups, err := registry.Groups()
 	if err != nil {
@@ -995,11 +1012,48 @@ func daemonSchedulerStaleGroups() []string {
 	}
 	var out []string
 	for _, g := range groups {
-		if groupalgo.OverlayNeedsRecompute(g.Name) {
+		if groupAlgoSweepWants(g.Name, groupalgo.OverlayNeedsRecompute, groupHasOverlay, groupHasIndexedMember) {
 			out = append(out, g.Name)
 		}
 	}
 	return out
+}
+
+// groupAlgoSweepWants is the testable core of the sweep predicate: recompute a
+// stale-and-changed overlay, or compute a missing one for a group that has at
+// least one indexed member. The three probes are injected so the decision can be
+// tested without a registry, a $GRAFEL_HOME, or real graph files.
+func groupAlgoSweepWants(group string, needsRecompute, hasOverlay, hasIndexedMember func(string) bool) bool {
+	if needsRecompute(group) {
+		return true
+	}
+	if hasOverlay(group) {
+		return false // present and not stale-with-changed-content → nothing to do.
+	}
+	return hasIndexedMember(group)
+}
+
+// groupHasOverlay reports whether a group has an overlay file on disk at all.
+// An unresolvable path reports true — "unknown" must not force-fire a heavy
+// pass.
+func groupHasOverlay(group string) bool {
+	path, err := groupalgo.OverlayPath(group)
+	if err != nil || path == "" {
+		return true
+	}
+	_, statErr := os.Stat(path)
+	return statErr == nil
+}
+
+// groupHasIndexedMember reports whether at least one of a group's repos has a
+// materialized graph. CurrentSourceMtimes omits repos with no graph yet, so a
+// non-empty map is exactly "something to assemble".
+func groupHasIndexedMember(group string) bool {
+	mt, err := groupalgo.CurrentSourceMtimes(group)
+	if err != nil {
+		return false
+	}
+	return len(mt) > 0
 }
 
 // daemonWorktreeParents returns the registered repos whose group opts into

--- a/cmd/grafel/groupalgo_firstcompute_6002_test.go
+++ b/cmd/grafel/groupalgo_firstcompute_6002_test.go
@@ -1,0 +1,56 @@
+package main
+
+import "testing"
+
+// #6002: taking the group-algo annotation pass off the critical path of a
+// user-awaited rebuild is only acceptable if something reliably produces the
+// overlay AFTERWARDS. The overlay sweep is that backstop — but it used to skip
+// any group with no overlay file, on the assumption that "the first-compute
+// link-pass chain" would cover them.
+//
+// It does not. `grafel rebuild` / `grafel reset` runs its own in-process link
+// pass and never touches the scheduler, so runLinks — the only caller of
+// scheduleGroupAlgo — never fires. A freshly reset group therefore had a
+// complete, queryable graph and NO path that would ever compute its
+// communities.
+func TestGroupAlgoSweepWants_FirstComputeForIndexedGroupWithNoOverlay(t *testing.T) {
+	no := func(string) bool { return false }
+	yes := func(string) bool { return true }
+
+	if !groupAlgoSweepWants("acme", no /*needsRecompute*/, no /*hasOverlay*/, yes /*hasIndexedMember*/) {
+		t.Fatal("a group with indexed members and no overlay must be swept for a first compute — otherwise `grafel reset` leaves it permanently without communities")
+	}
+}
+
+// A group that has never been indexed has nothing to assemble; sweeping it
+// would be pure waste. It gets picked up after its first index.
+func TestGroupAlgoSweepWants_SkipsNeverIndexedGroup(t *testing.T) {
+	no := func(string) bool { return false }
+
+	if groupAlgoSweepWants("acme", no, no /*hasOverlay*/, no /*hasIndexedMember*/) {
+		t.Fatal("a group with no indexed member must not be swept — assembling an empty union is wasted work")
+	}
+}
+
+// The pre-existing contract is preserved: a present overlay that the
+// content-gated predicate says is fine must NOT be re-armed. This is the
+// property that keeps an idle daemon from firing Louvain every sweep interval.
+func TestGroupAlgoSweepWants_PresentFreshOverlayIsLeftAlone(t *testing.T) {
+	no := func(string) bool { return false }
+	yes := func(string) bool { return true }
+
+	if groupAlgoSweepWants("acme", no /*needsRecompute*/, yes /*hasOverlay*/, yes) {
+		t.Fatal("a present, fresh overlay must not be re-armed by the sweep")
+	}
+}
+
+// And a stale-with-changed-content overlay still wins regardless of the rest —
+// including the algorithm-version invalidation, which reports through the same
+// needsRecompute probe.
+func TestGroupAlgoSweepWants_NeedsRecomputeAlwaysWins(t *testing.T) {
+	yes := func(string) bool { return true }
+
+	if !groupAlgoSweepWants("acme", yes /*needsRecompute*/, yes /*hasOverlay*/, yes) {
+		t.Fatal("needsRecompute (stale content, or a changed algorithm version) must always arm a pass")
+	}
+}

--- a/cmd/grafel/groupalgo_firstcompute_6002_test.go
+++ b/cmd/grafel/groupalgo_firstcompute_6002_test.go
@@ -1,6 +1,12 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+)
 
 // #6002: taking the group-algo annotation pass off the critical path of a
 // user-awaited rebuild is only acceptable if something reliably produces the
@@ -52,5 +58,41 @@ func TestGroupAlgoSweepWants_NeedsRecomputeAlwaysWins(t *testing.T) {
 
 	if !groupAlgoSweepWants("acme", yes /*needsRecompute*/, yes /*hasOverlay*/, yes) {
 		t.Fatal("needsRecompute (stale content, or a changed algorithm version) must always arm a pass")
+	}
+}
+
+// A CORRUPT overlay is the last state that could leave a group with no
+// communities forever: OverlayNeedsRecompute returns false on an unmarshal
+// failure (deliberately — do not thrash on garbage) and a bare os.Stat would
+// see the file and report it present, so both gates say "nothing to do".
+// groupHasOverlay must treat unparseable as absent so the first-compute path
+// overwrites it.
+func TestGroupHasOverlay_CorruptFileCountsAsAbsent(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	path, err := groupalgo.OverlayPath("acme")
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	if groupHasOverlay("acme") {
+		t.Fatal("no overlay file at all must report absent")
+	}
+
+	if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write corrupt overlay: %v", err)
+	}
+	if groupHasOverlay("acme") {
+		t.Fatal("a corrupt overlay must count as ABSENT so the sweep re-computes it — otherwise the group has no communities forever")
+	}
+
+	if err := os.WriteFile(path, []byte(`{"group":"acme","algo_version":1,"results":{}}`), 0o644); err != nil {
+		t.Fatalf("write valid overlay: %v", err)
+	}
+	if !groupHasOverlay("acme") {
+		t.Fatal("a well-formed overlay must count as present")
 	}
 }

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -144,6 +144,7 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 				fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",
 					st.QueueLen, len(st.IndexInFlight), len(st.PendingAlgo), len(st.PendingLinks))
 			}
+			printAnnotationStatus(w, st)
 			// #5954 heavy write-stage gate. Printed whenever the gate is doing
 			// ANYTHING (holding, deferring, or being barged) so an operator — or
 			// a peak-RSS measurement run — can confirm from outside the process

--- a/internal/cli/status_annotation.go
+++ b/internal/cli/status_annotation.go
@@ -1,0 +1,48 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// printAnnotationStatus renders the ANNOTATION (group-algo) line of
+// `grafel status`.
+//
+// A rebuild reports completion once extraction + the cross-repo link pass have
+// written graph.fb — the graph is queryable at that point and every structural
+// MCP tool (find/expand/find_callers/traces/cross_links/get_source) works. The
+// community / pagerank / centrality OVERLAY is produced afterwards, in the
+// background, by the group-algo pass. On a large corpus that pass takes far
+// longer than the rebuild it follows.
+//
+// That is the right trade — but it makes a specific user complaint possible:
+// "the rebuild said it was done, so why does grafel_clusters return nothing?"
+// Absent overlay is a silent state everywhere it is consumed (nil community
+// pointers, empty cluster lists), so without this line the honest answer
+// ("it has not been computed yet") is indistinguishable from a real fault.
+// The line is silent when nothing is running or pending — the common case.
+func printAnnotationStatus(w io.Writer, st proto.StatusReply) {
+	running := st.GroupAlgoInFlight
+	if running == 0 {
+		running = len(st.GroupAlgoRunning)
+	}
+	if running == 0 && len(st.PendingAlgo) == 0 {
+		return
+	}
+	fmt.Fprint(w, "  annotation:")
+	switch {
+	case len(st.GroupAlgoRunning) > 0:
+		// Monolith mode knows WHICH groups.
+		fmt.Fprintf(w, " running=%s", strings.Join(st.GroupAlgoRunning, ","))
+	case running > 0:
+		// Split mode publishes only the count.
+		fmt.Fprintf(w, " running=%d", running)
+	}
+	if len(st.PendingAlgo) > 0 {
+		fmt.Fprintf(w, " pending=%s", strings.Join(st.PendingAlgo, ","))
+	}
+	fmt.Fprint(w, "  (communities/pagerank/centrality overlay not yet current; the graph itself is queryable)\n")
+}

--- a/internal/cli/status_annotation_test.go
+++ b/internal/cli/status_annotation_test.go
@@ -1,0 +1,55 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// "My communities are missing" must be diagnosable from `grafel status` while
+// the background annotation pass is still running — otherwise an absent overlay
+// is indistinguishable from a fault.
+func TestPrintAnnotationStatus_RunningPassIsVisible(t *testing.T) {
+	var buf bytes.Buffer
+	printAnnotationStatus(&buf, proto.StatusReply{
+		GroupAlgoRunning:  []string{"acme"},
+		GroupAlgoInFlight: 1,
+	})
+	out := buf.String()
+	if !strings.Contains(out, "annotation:") || !strings.Contains(out, "running=acme") {
+		t.Fatalf("a running annotation pass must be visible in `grafel status`, got %q", out)
+	}
+	if !strings.Contains(out, "queryable") {
+		t.Fatalf("the line must say the graph itself is still queryable, got %q", out)
+	}
+}
+
+// Split mode (the default) has no scheduler in the serve process, so only the
+// COUNT is available. It must still be reported.
+func TestPrintAnnotationStatus_SplitModeCountOnly(t *testing.T) {
+	var buf bytes.Buffer
+	printAnnotationStatus(&buf, proto.StatusReply{GroupAlgoInFlight: 1})
+	if out := buf.String(); !strings.Contains(out, "running=1") {
+		t.Fatalf("split mode must report the in-flight count, got %q", out)
+	}
+}
+
+// A recompute armed (or queued behind a running pass) is pending, not missing.
+func TestPrintAnnotationStatus_PendingIsVisible(t *testing.T) {
+	var buf bytes.Buffer
+	printAnnotationStatus(&buf, proto.StatusReply{PendingAlgo: []string{"acme"}})
+	if out := buf.String(); !strings.Contains(out, "pending=acme") {
+		t.Fatalf("a pending annotation pass must be visible, got %q", out)
+	}
+}
+
+// Silent when there is nothing to say — the overwhelmingly common case.
+func TestPrintAnnotationStatus_SilentWhenIdle(t *testing.T) {
+	var buf bytes.Buffer
+	printAnnotationStatus(&buf, proto.StatusReply{})
+	if out := buf.String(); out != "" {
+		t.Fatalf("idle daemon must print no annotation line, got %q", out)
+	}
+}

--- a/internal/daemon/engine_status.go
+++ b/internal/daemon/engine_status.go
@@ -114,6 +114,27 @@ func StageGateFromStatusFile() (g sched.StageGateState, ok bool) {
 	}, true
 }
 
+// GroupAlgoInFlightFromStatusFile reports how many group-algo ANNOTATION passes
+// the ambient engine has in flight, read from its liveness sidecar for a reader
+// with no in-process scheduler handle (split-mode serve answering
+// Service.Status). 0 when the sidecar is missing or stale — "unknown" reported
+// as "none pending", the same conservative default the rest of this file uses.
+//
+// The pass writes the community/pagerank/centrality overlay AFTER the rebuild
+// has already reported completion, so without this the only observable symptom
+// of "the overlay is still being computed" is that clusters come back empty.
+func GroupAlgoInFlightFromStatusFile() int {
+	layout, err := DefaultLayout()
+	if err != nil {
+		return 0
+	}
+	f, fresh := EngineLivenessStatus(layout.Root)
+	if !fresh || f == nil {
+		return 0
+	}
+	return f.EngineGroupAlgoInFlight
+}
+
 // FlushRepoStatusFile synchronously recomputes and writes repoPath's per-repo
 // status-plane sidecar from the CURRENT indexstate + the on-disk graph.fb, right
 // now — the same work the async statusWriter goroutine would do on its next

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -74,6 +74,20 @@ type StatusReply struct {
 	IndexedRepos   []IndexedRepoState `json:"indexed_repos,omitempty"`
 	RecentLog      []SchedLogEntry    `json:"recent_log,omitempty"`
 
+	// GroupAlgoRunning names the groups whose ANNOTATION (group-algo) pass is
+	// executing right now, and GroupAlgoInFlight counts them. The pass produces
+	// the community/pagerank/centrality overlay, which is written separately
+	// from graph.fb and does not exist until the pass completes — so "my
+	// communities are missing" is only diagnosable if the pending/running state
+	// is visible. PendingAlgo above covers the ARMED-but-not-yet-running case
+	// (including a recompute queued behind a running pass).
+	//
+	// Monolith mode fills the names from the scheduler snapshot; SPLIT mode (the
+	// default, where serve has no scheduler) fills only the count, from the
+	// engine-liveness sidecar. Both routes agree on "is an overlay pending".
+	GroupAlgoRunning  []string `json:"group_algo_running,omitempty"`
+	GroupAlgoInFlight int      `json:"group_algo_in_flight,omitempty"`
+
 	// Heavy write-stage gate (#5954) — the daemon-wide token that keeps the
 	// index batch, the cross-repo link pass and the group-algo pass from being
 	// co-resident (two copies of the same group union graph were the measured

--- a/internal/daemon/sched/groupalgo_letfinish_6002_test.go
+++ b/internal/daemon/sched/groupalgo_letfinish_6002_test.go
@@ -1,0 +1,238 @@
+package sched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The group-algo (overlay annotation) pass is a PURE ANNOTATION over an
+// already-written graph.fb: it loads finished per-repo graphs, computes
+// communities/centrality over the union, and writes a separate <group>-algo.json
+// overlay. Nothing the MCP structural tools answer depends on it, so it must
+// never sit on the critical path of a user-awaited rebuild — and, crucially, it
+// must actually COMPLETE once it starts.
+//
+// Historical failure mode (91 `group-algo: starting` events, 2 completions on
+// the reference corpus): every link completion called scheduleGroupAlgo, which
+// called cancelGroupAlgoLocked, which SIGKILLed the in-flight pass and restarted
+// it from zero. On a corpus where the pass takes longer than the inter-trigger
+// interval that is an infinite churn loop that never produces an overlay while
+// keeping the daemon permanently "busy".
+//
+// These tests pin the two halves of the contract:
+//  1. a re-arm arriving while a pass is IN FLIGHT must let that pass finish;
+//  2. the re-arm must not be dropped — a follow-up pass must still run.
+
+// TestScheduleGroupAlgo_InFlightPassIsNotCancelledByRearm: the core anti-churn
+// guarantee. A pass that is already running must observe no cancellation when a
+// fresh trigger (link completion, overlay sweep, reindex) arrives, and must run
+// to completion.
+func TestScheduleGroupAlgo_InFlightPassIsNotCancelledByRearm(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var cancelled atomic.Bool
+	var completed atomic.Int32
+
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				cancelled.Store(true)
+				return ctx.Err()
+			}
+			completed.Add(1)
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered // pass 1 is in flight and blocked
+
+	// A burst of fresh triggers arrives mid-pass — exactly what a busy daemon
+	// does on every link completion.
+	for i := 0; i < 5; i++ {
+		s.scheduleGroupAlgo("acme")
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	if cancelled.Load() {
+		t.Fatal("re-arm cancelled the in-flight group-algo pass — this is the churn loop that never produces an overlay (91 starts / 2 completions)")
+	}
+
+	close(release)
+	waitFor(t, 2*time.Second, func() bool { return completed.Load() >= 1 })
+	if cancelled.Load() {
+		t.Fatal("in-flight group-algo pass was cancelled instead of being allowed to finish")
+	}
+}
+
+// TestScheduleGroupAlgo_RearmDuringPassStillProducesFollowUp: letting the
+// in-flight pass finish must NOT silently drop the newer request. The overlay
+// the running pass writes reflects the graph snapshot it loaded; a trigger that
+// arrived after that snapshot means the overlay will be stale on completion, so
+// a follow-up pass has to be armed once the current one returns.
+func TestScheduleGroupAlgo_RearmDuringPassStillProducesFollowUp(t *testing.T) {
+	entered := make(chan struct{}, 8)
+	release := make(chan struct{})
+	var runs atomic.Int32
+
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			n := runs.Add(1)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			if n == 1 {
+				<-release // hold pass 1 open so the re-arm lands mid-pass
+			}
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered // pass 1 in flight
+
+	s.scheduleGroupAlgo("acme") // newer content arrived mid-pass
+	close(release)
+
+	waitFor(t, 3*time.Second, func() bool { return runs.Load() >= 2 })
+}
+
+// TestGroupAlgoRerunPending_VisibleAsPending: a request deferred behind an
+// in-flight pass must be OBSERVABLE. "My communities are missing" has to be
+// diagnosable from `grafel status` / the Status RPC, so the group shows up in
+// PendingAlgo for the whole time it is waiting on the running pass.
+func TestGroupAlgoRerunPending_VisibleAsPending(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered
+
+	snap := s.Snapshot()
+	if len(snap.GroupAlgoRunning) != 1 || snap.GroupAlgoRunning[0] != "acme" {
+		t.Fatalf("an in-flight annotation pass must be visible in Snapshot.GroupAlgoRunning, got %v", snap.GroupAlgoRunning)
+	}
+
+	s.scheduleGroupAlgo("acme") // queued behind the running pass
+	snap = s.Snapshot()
+	found := false
+	for _, g := range snap.PendingAlgo {
+		if g == "acme" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("a group-algo request queued behind a running pass must stay visible in PendingAlgo, got %v", snap.PendingAlgo)
+	}
+
+	close(release)
+}
+
+// TestFireGroupAlgo_LateReturnKeepsSuccessorCancel (#6001): fireGroupAlgo used
+// to blind-delete s.groupAlgoCancel[group] on return, so a pass that returns
+// late — after a CancelGroup cleared the map and a successor registered its own
+// handle — dropped the LIVE successor's cancel func. A subsequent CancelGroup /
+// Stop then had nothing to cancel and the successor ran to completion for a
+// deleted group. fireLinks already guards this with a token identity check.
+func TestFireGroupAlgo_LateReturnKeepsSuccessorCancel(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var passCtx atomic.Value // context.Context of pass 1
+
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			passCtx.Store(ctx)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			<-release
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered // pass 1 is in flight and has registered its handle
+
+	// A CancelGroup drains the registry, then a SUCCESSOR pass registers its own
+	// live handle — the window in which the old blind delete destroyed it.
+	var successorCancelled atomic.Bool
+	successor := &groupAlgoPassCancel{cancel: func() { successorCancelled.Store(true) }}
+	s.mu.Lock()
+	delete(s.groupAlgoCancel, "acme")
+	s.groupAlgoCancel["acme"] = successor
+	s.mu.Unlock()
+
+	// Pass 1 now returns LATE. fireGroupAlgo cancels its own ctx as the last
+	// thing it does, strictly after the registry cleanup — so observing the ctx
+	// die means the cleanup has already happened.
+	close(release)
+	waitFor(t, 2*time.Second, func() bool {
+		ctx, _ := passCtx.Load().(context.Context)
+		return ctx != nil && ctx.Err() != nil
+	})
+
+	s.mu.Lock()
+	live := s.groupAlgoCancel["acme"]
+	s.mu.Unlock()
+	if live != successor {
+		t.Fatalf("#6001: a late-returning group-algo pass dropped the live successor's cancel handle (registry now %v)", live)
+	}
+
+	s.CancelGroup("acme")
+	if !successorCancelled.Load() {
+		t.Fatal("#6001: CancelGroup could not reach the successor pass")
+	}
+}

--- a/internal/daemon/sched/groupalgo_letfinish_6002_test.go
+++ b/internal/daemon/sched/groupalgo_letfinish_6002_test.go
@@ -172,6 +172,80 @@ func TestGroupAlgoRerunPending_VisibleAsPending(t *testing.T) {
 	close(release)
 }
 
+// TestCancelGroupAlgo_DropsQueuedRerun: the other side of the let-it-finish
+// contract. A re-arm that lands mid-pass is DEFERRED rather than serviced, so
+// it lives as a flag until the running pass returns. An EXPLICIT cancel —
+// daemon shutdown, or a group delete — must drop that flag with everything
+// else: the group is going away, so servicing a queued recompute afterwards
+// would run a heavy pass for a group nobody asked about, exactly the leak
+// CancelGroup exists to close.
+//
+// Note this path is unreachable from scheduleGroupAlgo, which never cancels a
+// running pass any more; only Stop and CancelGroup get here.
+func TestCancelGroupAlgo_DropsQueuedRerun(t *testing.T) {
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var runs atomic.Int32
+
+	s := New(Config{
+		Workers:           1,
+		GroupAlgoDebounce: 5 * time.Millisecond,
+		GroupAlgoMaxWait:  time.Hour,
+		Index:             func(_ context.Context, _ string, _ string) error { return nil },
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			runs.Add(1)
+			select {
+			case entered <- struct{}{}:
+			default:
+			}
+			select {
+			case <-release:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("acme")
+	<-entered
+
+	s.scheduleGroupAlgo("acme") // queued behind the running pass
+	s.mu.Lock()
+	queued := s.groupAlgoRerun["acme"]
+	s.mu.Unlock()
+	if !queued {
+		t.Fatal("setup: the mid-pass re-arm should have queued a re-run")
+	}
+
+	s.CancelGroup("acme") // group deleted — cancels the pass AND drops the queue
+	close(release)
+
+	waitFor(t, 2*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, running := s.groupAlgoCancel["acme"]
+		return !running
+	})
+
+	s.mu.Lock()
+	stillQueued := s.groupAlgoRerun["acme"]
+	s.mu.Unlock()
+	if stillQueued {
+		t.Fatal("an explicit cancel must drop a queued group-algo re-run — a deleted group must not get a follow-up pass")
+	}
+
+	// And no follow-up pass may actually run for the cancelled group.
+	time.Sleep(80 * time.Millisecond) // well past the 5ms debounce
+	if n := runs.Load(); n != 1 {
+		t.Fatalf("cancelled group ran %d group-algo passes, want exactly the one that was already in flight", n)
+	}
+}
+
 // TestFireGroupAlgo_LateReturnKeepsSuccessorCancel (#6001): fireGroupAlgo used
 // to blind-delete s.groupAlgoCancel[group] on return, so a pass that returns
 // late — after a CancelGroup cleared the map and a successor registered its own

--- a/internal/daemon/sched/overlay_sweep_5403_test.go
+++ b/internal/daemon/sched/overlay_sweep_5403_test.go
@@ -121,7 +121,7 @@ func TestOverlaySweep_DoesNotReArmInFlightPass(t *testing.T) {
 	// Simulate an in-flight pass: a cancel func registered, no pending timer.
 	_, cancel := context.WithCancel(context.Background())
 	s.mu.Lock()
-	s.groupAlgoCancel["acme"] = cancel
+	s.groupAlgoCancel["acme"] = &groupAlgoPassCancel{cancel: cancel}
 	s.mu.Unlock()
 
 	s.sweepStaleOverlays()

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -483,7 +483,20 @@ type Scheduler struct {
 	// assembled group union, chained off link completion.
 	groupAlgoTimers  map[string]*time.Timer
 	groupAlgoPending map[string]bool
-	groupAlgoCancel  map[string]context.CancelFunc
+	// groupAlgoCancel holds a per-in-flight-pass identity TOKEN (not a bare
+	// cancel func) so a pass that returns LATE can distinguish its own registry
+	// entry from a successor's — the same shape linkCancel uses. Blind-deleting
+	// here let a late returner drop a live successor's handle, so a subsequent
+	// CancelGroup/Stop had nothing to cancel and the successor ran on for a
+	// deleted group (#6001).
+	groupAlgoCancel map[string]*groupAlgoPassCancel
+	// groupAlgoRerun marks a group whose overlay recompute was REQUESTED while a
+	// pass was already in flight. The request is deliberately NOT serviced by
+	// cancelling the running pass (see scheduleGroupAlgo); instead the flag is
+	// consumed when that pass returns, which re-arms the debounce. It is the
+	// "the newer request is not silently dropped" half of the let-it-finish
+	// contract. Guarded by mu.
+	groupAlgoRerun map[string]bool
 	// groupAlgoArmedAt records when a group's debounce window FIRST started (and
 	// is NOT reset on subsequent re-arms while still pending). It bounds debounce
 	// starvation: once the window has been continuously armed for
@@ -752,7 +765,8 @@ func New(cfg Config) *Scheduler {
 		linkPending:       map[string]bool{},
 		groupAlgoTimers:   map[string]*time.Timer{},
 		groupAlgoPending:  map[string]bool{},
-		groupAlgoCancel:   map[string]context.CancelFunc{},
+		groupAlgoCancel:   map[string]*groupAlgoPassCancel{},
+		groupAlgoRerun:    map[string]bool{},
 		groupAlgoArmedAt:  map[string]time.Time{},
 		groupAlgoFireAt:   map[string]time.Time{},
 		linkCancel:        map[string]*linkPassCancel{},
@@ -829,8 +843,8 @@ func (s *Scheduler) Stop() {
 	for _, t := range s.groupAlgoTimers {
 		t.Stop()
 	}
-	for _, c := range s.groupAlgoCancel {
-		c()
+	for _, tok := range s.groupAlgoCancel {
+		tok.cancel()
 	}
 	// #5954: drop every deferred-by-the-gate marker so the process-global
 	// indexstate counters return to zero on shutdown (they are balanced
@@ -2024,12 +2038,42 @@ func overlaySweepIntervalFromEnv() time.Duration {
 // since the armedAt+maxWait deadline does not move across re-arms, continuous
 // churn can push the fire out no later than that deadline. Still one pass per
 // window (coalesced) and still on the CPU-capped path — no unbounded recompute.
+//
+// LET AN IN-FLIGHT PASS FINISH. A re-arm that arrives while a pass is RUNNING
+// does NOT cancel it. It used to: scheduleGroupAlgo called cancelGroupAlgoLocked
+// unconditionally, which SIGKILLed the group-algo child and restarted it from
+// zero. On the reference 25-repo corpus, where the pass outlives the interval
+// between triggers, that is an infinite churn loop — the daemon's own logs show
+// 91 `group-algo: starting` events against 2 completions, i.e. the overlay was
+// effectively never produced while the daemon looked permanently busy.
+//
+// Letting it finish is correct, not merely cheaper. The pass is a PURE
+// ANNOTATION over an already-written graph.fb: it loads a SNAPSHOT of the
+// per-repo graphs, computes over the union, and writes a separate overlay file.
+// Its result is therefore always internally consistent — it is at worst stale
+// relative to content that landed after the snapshot, never wrong. Cancelling
+// trades a slightly-stale-but-real overlay for NO overlay plus a full recompute,
+// and under sustained churn that trade never converges. So: the running pass
+// keeps its input snapshot and runs to completion, and the newer request is
+// recorded (groupAlgoRerun) and serviced by re-arming the debounce the moment
+// that pass returns. Staleness is bounded by the follow-up pass; unavailability
+// under the old behaviour was not bounded at all.
 func (s *Scheduler) scheduleGroupAlgo(group string) {
 	if s.cfg.GroupAlgo == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	// A pass is RUNNING right now. Record the request and leave it alone; the
+	// completion path in fireGroupAlgo consumes the flag and re-arms.
+	if _, running := s.groupAlgoCancel[group]; running {
+		if !s.groupAlgoRerun[group] {
+			s.groupAlgoRerun[group] = true
+			s.logEventLocked("group_algo_requeued", "",
+				group+": recompute requested while a pass is in flight — letting it finish, re-arming on completion")
+		}
+		return
+	}
 	// Preserve the window-start timestamp across re-arms.
 	armedAt, hadWindow := s.groupAlgoArmedAt[group]
 	now := time.Now()
@@ -2115,7 +2159,8 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	// — which may fork a subprocess — receives cancellation. Mirrors runIndex
 	// and runLinks. Fixes the leak class of issue #2493.
 	ctx, cancel := context.WithCancel(s.shutdownCtx)
-	s.groupAlgoCancel[group] = cancel
+	tok := &groupAlgoPassCancel{cancel: cancel}
+	s.groupAlgoCancel[group] = tok
 	// Give the gate a handle on this pass — cancelling it SIGKILLs the
 	// group-algo child (subprocess_runner.go). Only the forfeit-grace expiry
 	// uses it; a plain forfeit deliberately does not.
@@ -2130,7 +2175,20 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	s.runGroupAlgo(ctx, group)
 
 	s.mu.Lock()
-	delete(s.groupAlgoCancel, group)
+	// #6001: only clear the entry if it is still OUR token. A CancelGroup may
+	// have drained the map and a successor pass registered its own handle while
+	// this (long) pass was returning; blind-deleting would drop the LIVE
+	// successor's cancel func, leaving a later CancelGroup/Stop with nothing to
+	// cancel. fireLinks has guarded the same shape since the v0.1.8 leak fix.
+	if s.groupAlgoCancel[group] == tok {
+		delete(s.groupAlgoCancel, group)
+	}
+	// A recompute requested WHILE this pass ran was deliberately not serviced by
+	// cancelling us (see scheduleGroupAlgo). Consume the marker now so the newer
+	// content gets its own pass — this is what keeps "let it finish" from
+	// silently dropping the request.
+	rerun := s.groupAlgoRerun[group]
+	delete(s.groupAlgoRerun, group)
 	// Drop the deferred marker only now: runGroupAlgo holds its own
 	// GroupAlgoBegin for the RUNNING window, so clearing here keeps the
 	// deferred→running indexstate coverage continuous (count 1 → 2 → 1 → 0)
@@ -2138,6 +2196,18 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	s.markGroupAlgoDeferredLocked(group, false)
 	s.mu.Unlock()
 	cancel()
+
+	if rerun && !s.stopped() {
+		s.logEvent("group_algo_rearm", "", group+": servicing the recompute requested during the previous pass")
+		s.scheduleGroupAlgo(group)
+	}
+}
+
+// groupAlgoPassCancel is a per-in-flight-group-algo-pass identity token wrapping
+// its cancel func, so a completing pass can distinguish ITS OWN registry entry
+// from a successor's (#6001). Mirrors linkPassCancel.
+type groupAlgoPassCancel struct {
+	cancel context.CancelFunc
 }
 
 // markGroupAlgoDeferredLocked toggles a group's "deferred by the stage gate"
@@ -2164,10 +2234,14 @@ func (s *Scheduler) cancelGroupAlgoLocked(group string) {
 		delete(s.groupAlgoTimers, group)
 		s.groupAlgoPending[group] = false
 	}
-	if c, ok := s.groupAlgoCancel[group]; ok {
-		c()
+	if tok, ok := s.groupAlgoCancel[group]; ok {
+		tok.cancel()
 		delete(s.groupAlgoCancel, group)
 	}
+	// An explicit cancel (shutdown, group delete) drops a queued re-run too:
+	// there is nothing left to annotate. Note scheduleGroupAlgo never reaches
+	// here for a running pass — only Stop and CancelGroup do.
+	delete(s.groupAlgoRerun, group)
 	// Clear the max-wait window (#5450). scheduleGroupAlgo snapshots and restores
 	// this for a re-arm of a still-open window; an explicit cancel (shutdown, or a
 	// superseding pass) ends the window so the next arm starts a fresh budget.
@@ -2349,11 +2423,19 @@ type Snapshot struct {
 	QueueLen int
 	InFlight []InFlightJob
 	// PendingAlgo lists groups with a debounced GROUP-algo pass armed (#5349
-	// A3). The per-repo algo pass was removed; this is now group-keyed.
-	PendingAlgo  []string
-	PendingLinks []string
-	IndexedRepos []RepoSnapshot
-	RecentLog    []LogEntry
+	// A3). The per-repo algo pass was removed; this is now group-keyed. It also
+	// covers a recompute QUEUED behind an in-flight pass (groupAlgoRerun), so a
+	// deferred request is never invisible.
+	PendingAlgo []string
+	// GroupAlgoRunning lists groups whose annotation (group-algo) pass is
+	// executing RIGHT NOW. The overlay it produces — communities, pagerank,
+	// centrality — does not exist until it completes, so "my communities are
+	// missing" needs this to be diagnosable from `grafel status` rather than
+	// inferred from the RSS shape or the log ring.
+	GroupAlgoRunning []string
+	PendingLinks     []string
+	IndexedRepos     []RepoSnapshot
+	RecentLog        []LogEntry
 
 	// Budget telemetry (added with admission control).
 	BudgetMB    int64
@@ -2436,7 +2518,18 @@ func (s *Scheduler) Snapshot() Snapshot {
 			out.PendingAlgo = append(out.PendingAlgo, g)
 		}
 	}
+	// A recompute queued behind an in-flight pass is pending too — it just has
+	// no timer yet, because the completion of the running pass is what arms it.
+	for g := range s.groupAlgoRerun {
+		if s.groupAlgoRerun[g] && !s.groupAlgoPending[g] {
+			out.PendingAlgo = append(out.PendingAlgo, g)
+		}
+	}
 	sort.Strings(out.PendingAlgo)
+	for g := range s.groupAlgoCancel {
+		out.GroupAlgoRunning = append(out.GroupAlgoRunning, g)
+	}
+	sort.Strings(out.GroupAlgoRunning)
 	for g := range s.linkPending {
 		if s.linkPending[g] {
 			out.PendingLinks = append(out.PendingLinks, g)

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -446,6 +446,11 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateBarging = snap.Barging
 		reply.StageGateForfeits = snap.StageForfeits
 		reply.StageGateForfeitedHolder = snap.StageForfeitedHolder
+		// Overlay annotation pass (#6002): the group-algo pass runs AFTER the
+		// rebuild has already reported completion, so its state is invisible
+		// unless reported here.
+		reply.GroupAlgoRunning = snap.GroupAlgoRunning
+		reply.GroupAlgoInFlight = len(snap.GroupAlgoRunning)
 	} else if g, ok := StageGateFromStatusFile(); ok {
 		// SPLIT MODE (the default): the scheduler lives in the ENGINE process,
 		// so the serve process answering this RPC has s.scheduler == nil and
@@ -465,6 +470,11 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.StageGateBarging = g.Barging
 		reply.StageGateForfeits = g.Forfeits
 		reply.StageGateForfeitedHolder = g.ForfeitedHolder
+		// #6002: the sidecar carries the COUNT but not the group names (the
+		// scheduler that knows them lives in the engine process). A count is
+		// enough to answer "is an overlay recompute in flight" — which is the
+		// question behind "why are my communities missing".
+		reply.GroupAlgoInFlight = GroupAlgoInFlightFromStatusFile()
 	}
 	return nil
 }

--- a/internal/dashboard/graphstate_group_overlay_test.go
+++ b/internal/dashboard/graphstate_group_overlay_test.go
@@ -19,6 +19,7 @@ func TestApplyGroupAlgorithmOverlay(t *testing.T) {
 		}}},
 	}}
 	ov := &groupalgo.Overlay{
+		AlgoVersion: groupalgo.OverlayAlgoVersion,
 		Results: map[string]groupalgo.EntityOverlay{
 			"api:a": {CommunityID: 7, PageRank: 0.8, Centrality: 0.4, IsGodNode: true},
 			"api:b": {CommunityID: 7, PageRank: 0.2},
@@ -52,6 +53,7 @@ func TestApplyGroupAlgorithmOverlay(t *testing.T) {
 func TestRestorePersistedGroupAlgorithmOverlay(t *testing.T) {
 	mtimes := map[string]int64{"repo": 42}
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "cold-overlay",
 		SourceMtimes: mtimes,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -403,7 +403,13 @@ func runGroupAlgorithmsIncremental(group string, memoize bool) (*GroupAlgoResult
 	// freshly assembled union is, by determinism, exactly what a full recompute
 	// would produce. Reconstitute it instead of re-running Louvain+PageRank.
 	if path, perr := OverlayPath(group); perr == nil && path != "" {
-		if prior := readOverlayUnconditional(path); prior != nil && prior.InputHash != "" && prior.InputHash == inputHash {
+		// OverlayAlgoVersionCurrent is part of the skip condition, not just the
+		// hash: the hash covers the INPUT, the version covers the FUNCTION
+		// applied to it. Without it, an upgrade that changes the partitioning
+		// hits this memo on an unchanged union and reconstitutes the OLD
+		// implementation's overlay indefinitely. See OverlayAlgoVersion.
+		if prior := readOverlayUnconditional(path); prior != nil && OverlayAlgoVersionCurrent(prior) &&
+			prior.InputHash != "" && prior.InputHash == inputHash {
 			res := overlayToResults(prior, entities)
 			return &GroupAlgoResult{
 				Group:        group,

--- a/internal/graph/groupalgo/groupalgo.go
+++ b/internal/graph/groupalgo/groupalgo.go
@@ -435,6 +435,15 @@ func runGroupAlgorithmsIncremental(group string, memoize bool) (*GroupAlgoResult
 	// the heavy pass run at most once per group-version in a process regardless of
 	// whether the overlay reached disk; a real re-index bumps the input hash and
 	// falls through to exactly one recompute (correctness preserved).
+	//
+	// VERSION SAFETY. This memo is keyed on (group, inputHash) with NO
+	// OverlayAlgoVersion component, unlike the disk skip above. That is safe for
+	// exactly one reason: OverlayAlgoVersion is a compile-time constant and the
+	// memo is process-local, so every entry was necessarily produced by the
+	// running binary — a hit can never be another version's result. If this memo
+	// is ever persisted across restarts, or shared between processes, that
+	// argument evaporates and the key MUST gain the version, or an upgraded
+	// daemon will serve the previous implementation's partition from cache.
 	if res, ok := loadMemoizedGroupResult(group, inputHash); ok {
 		return &GroupAlgoResult{
 			Group:        group,

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -48,8 +48,48 @@ type EntityOverlay struct {
 	IsArticulationPoint bool    `json:"is_articulation_point,omitempty"`
 }
 
+// OverlayAlgoVersion identifies the ALGORITHM CONTRACT a stored overlay was
+// produced under: the community-detection / centrality / ranking implementation
+// whose output the overlay's numbers are.
+//
+// WHY THIS EXISTS. Every skip in this package is justified by determinism —
+// "the same input hash means a recompute would reproduce this overlay
+// byte-for-byte" (see Overlay.InputHash, OverlayNeedsRecompute, and the
+// disk-overlay skip in runGroupAlgorithmsIncremental). That premise is
+// conditional on the algorithm being fixed. Swap the community detector for one
+// that produces a different — even equally good — partition and the premise
+// silently fails: the union is unchanged, so the hash matches, so every gate
+// skips, and the daemon keeps serving the PREVIOUS implementation's partition
+// indefinitely. A user who upgrades gets none of the new behaviour and a stored
+// overlay that disagrees with what the running binary would compute.
+//
+// So the version is part of every skip/apply decision, not just the input hash.
+// A mismatch in EITHER direction invalidates:
+//
+//   - OLDER stored version (upgrade, incl. 0 = written before this field):
+//     recompute. That is the case this constant exists for.
+//   - NEWER stored version (a downgrade, or a shared $GRAFEL_HOME between two
+//     binaries): also recompute. An old binary must not apply an overlay it did
+//     not produce and cannot reproduce — skipping and recomputing is correct,
+//     mixing two implementations' partitions is not. The recompute simply
+//     rewrites the file at THIS binary's version.
+//
+// BUMPING IT. Any change to the partitioning or ranking a pass produces must
+// bump this in the same commit — including replacing the Louvain
+// implementation, changing its resolution/seed/tie-breaks, or changing PageRank
+// or betweenness in a way that moves the stored numbers. Do NOT bump it for
+// changes that cannot move the output (refactors, performance work with
+// identical results): every bump invalidates every overlay on every machine and
+// costs one full recompute per group. TestOverlayAlgoVersion_MustBeBumpedDeliberately
+// pins the value so the decision has to be made explicitly.
+const OverlayAlgoVersion = 1
+
 // Overlay is the on-disk <group>-algo.json document.
 type Overlay struct {
+	// AlgoVersion is the OverlayAlgoVersion of the build that computed this
+	// overlay. Absent/0 on overlays written before the field existed, which are
+	// therefore always invalidated. See OverlayAlgoVersion.
+	AlgoVersion int `json:"algo_version,omitempty"`
 	// Group is the group name (informational; the filename is authoritative).
 	Group string `json:"group"`
 	// ComputedAt is when the group-algo pass that produced this overlay ran.
@@ -94,6 +134,7 @@ func BuildOverlay(res *GroupAlgoResult) *Overlay {
 	r := res.Results
 	ov := &Overlay{
 		Group:        res.Group,
+		AlgoVersion:  OverlayAlgoVersion,
 		ComputedAt:   time.Now().UTC(),
 		SourceMtimes: map[string]int64{},
 		InputHash:    res.InputHash,
@@ -206,10 +247,41 @@ func ReadOverlay(path string, currentMtimes map[string]int64) (*Overlay, bool) {
 	if err := json.Unmarshal(data, &ov); err != nil {
 		return nil, false // corrupt (e.g. a partial write that — impossibly — leaked)
 	}
+	if !OverlayAlgoVersionCurrent(&ov) {
+		// Produced by a different algorithm implementation — do not apply it.
+		// Absent-tolerance is already the contract for every consumer of this
+		// function, so a version mismatch degrades to exactly the same "no
+		// overlay yet" state rather than mixing two partitions.
+		return nil, false
+	}
 	if IsOverlayStale(&ov, currentMtimes) {
 		return nil, false
 	}
 	return &ov, true
+}
+
+// OverlayAlgoVersionCurrent reports whether an overlay was produced by THIS
+// build's algorithm contract. Exported so status/observability surfaces can
+// distinguish "no overlay yet" from "an overlay exists but this binary will not
+// use it" — an upgraded daemon recomputing every group is expected behaviour
+// that has to be explainable, not a mystery reindex.
+func OverlayAlgoVersionCurrent(ov *Overlay) bool {
+	return ov != nil && ov.AlgoVersion == OverlayAlgoVersion
+}
+
+// OverlayAlgoVersionOnDisk returns the algorithm version stamped on a group's
+// stored overlay, and whether an overlay could be read at all. A present
+// overlay written before the field existed reports (0, true).
+func OverlayAlgoVersionOnDisk(group string) (int, bool) {
+	path, err := OverlayPath(group)
+	if err != nil || path == "" {
+		return 0, false
+	}
+	ov := readOverlayUnconditional(path)
+	if ov == nil {
+		return 0, false
+	}
+	return ov.AlgoVersion, true
 }
 
 // readOverlayUnconditional loads and unmarshals the overlay at path WITHOUT the
@@ -363,6 +435,17 @@ func OverlayNeedsRecompute(group string) bool {
 	var ov Overlay
 	if err := json.Unmarshal(data, &ov); err != nil {
 		return false // corrupt — a fresh pass will overwrite it; don't thrash.
+	}
+	// ALGORITHM VERSION comes BEFORE the mtime gate, deliberately. An upgrade
+	// that changes the partitioning moves nothing on disk: the graphs, their
+	// mtimes and the community input hash are all unchanged, so both gates below
+	// would report "fresh" and the daemon would serve the previous
+	// implementation's partition forever. This is the one condition that must
+	// force a recompute with the graph completely idle.
+	if !OverlayAlgoVersionCurrent(&ov) {
+		slog.Default().Info("group-algo: overlay algorithm version changed — forcing recompute",
+			"group", group, "stored_version", ov.AlgoVersion, "current_version", OverlayAlgoVersion)
+		return true
 	}
 	cur, err := CurrentSourceMtimes(group)
 	if err != nil {

--- a/internal/graph/groupalgo/overlay_algo_version_test.go
+++ b/internal/graph/groupalgo/overlay_algo_version_test.go
@@ -1,0 +1,156 @@
+package groupalgo
+
+import (
+	"testing"
+)
+
+// ALGORITHM-VERSION INVALIDATION.
+//
+// Every skip decision in this package is justified by DETERMINISM: "the same
+// input hash implies a recompute would reproduce this overlay byte-for-byte."
+// That premise holds only while the algorithm is fixed. Replacing the community
+// detector — a different but equally good partition — silently breaks it: the
+// union is unchanged, so the input hash matches, so the memo hits, so grafel
+// keeps serving the OLD partition forever. The user upgrades and gets none of
+// the benefit, and the stored overlay disagrees with what the running code
+// would produce.
+//
+// So the skip/apply decision is gated on an explicit OverlayAlgoVersion in
+// addition to the input hash. These tests pin all three decision points.
+
+// The version must be stamped on every overlay this build writes, or the gates
+// below would immediately invalidate everything they read.
+func TestBuildOverlay_StampsAlgoVersion(t *testing.T) {
+	ov := BuildOverlay(sampleResult())
+	if ov == nil {
+		t.Fatal("BuildOverlay returned nil for a non-nil result")
+	}
+	if ov.AlgoVersion != OverlayAlgoVersion {
+		t.Fatalf("AlgoVersion = %d, want %d (every overlay this build writes must carry the current version)", ov.AlgoVersion, OverlayAlgoVersion)
+	}
+}
+
+// A legacy overlay (written before the field existed, so version 0) must not be
+// APPLIED — applying it would mix a stale partition into a build that would
+// compute a different one.
+func TestReadOverlay_RejectsForeignAlgoVersion(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+	writeFreshOverlay(t, group)
+	path, err := OverlayPath(group)
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+	cur, err := CurrentSourceMtimes(group)
+	if err != nil {
+		t.Fatalf("CurrentSourceMtimes: %v", err)
+	}
+	if _, ok := ReadOverlay(path, cur); !ok {
+		t.Fatal("setup: a freshly written overlay must be readable")
+	}
+
+	for _, stored := range []int{0, OverlayAlgoVersion - 1, OverlayAlgoVersion + 1} {
+		ov := readOverlayUnconditional(path)
+		if ov == nil {
+			t.Fatal("readOverlayUnconditional returned nil for a present overlay")
+		}
+		ov.AlgoVersion = stored
+		if err := WriteOverlayTo(path, ov); err != nil {
+			t.Fatalf("WriteOverlayTo: %v", err)
+		}
+		if _, ok := ReadOverlay(path, cur); ok {
+			t.Fatalf("an overlay stamped algo_version=%d must NOT be applied by a build at version %d (downgrade must skip and recompute, never mix partitions)", stored, OverlayAlgoVersion)
+		}
+	}
+}
+
+// The sweep predicate must force a recompute after a version change even when
+// the mtimes and the input hash are both perfectly current — that is exactly
+// the upgrade case, where nothing about the graph moved.
+func TestOverlayNeedsRecompute_ForcedByAlgoVersionChange(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+	writeFreshOverlay(t, group)
+	path, err := OverlayPath(group)
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+
+	if OverlayNeedsRecompute(group) {
+		t.Fatal("setup: a freshly computed overlay must not need recompute")
+	}
+
+	ov := readOverlayUnconditional(path)
+	ov.AlgoVersion = OverlayAlgoVersion - 1
+	if err := WriteOverlayTo(path, ov); err != nil {
+		t.Fatalf("WriteOverlayTo: %v", err)
+	}
+	if !OverlayNeedsRecompute(group) {
+		t.Fatal("an overlay from a different algorithm version must force a recompute even with matching mtimes and input hash — otherwise an upgrade silently keeps serving the old partition forever")
+	}
+}
+
+// The incremental entrypoint's disk-overlay skip is the memo the coordinator
+// flagged: same union, same hash, different algorithm. It must NOT skip.
+func TestRunGroupAlgorithmsIncremental_DoesNotSkipAcrossAlgoVersions(t *testing.T) {
+	group, _, _, _ := setupIncrGroup(t)
+	writeFreshOverlay(t, group)
+	path, err := OverlayPath(group)
+	if err != nil {
+		t.Fatalf("OverlayPath: %v", err)
+	}
+
+	// Same-version overlay: the skip is expected (this is the property the
+	// version gate must not break).
+	resetGroupAlgoMemo()
+	same, err := RunGroupAlgorithmsIncrementalOneShot(group)
+	if err != nil {
+		t.Fatalf("RunGroupAlgorithmsIncrementalOneShot: %v", err)
+	}
+	if !same.Skipped {
+		t.Fatal("an unchanged union with a current-version overlay must still take the cheap skip path")
+	}
+
+	// Foreign-version overlay: the skip must NOT fire.
+	ov := readOverlayUnconditional(path)
+	ov.AlgoVersion = OverlayAlgoVersion - 1
+	if err := WriteOverlayTo(path, ov); err != nil {
+		t.Fatalf("WriteOverlayTo: %v", err)
+	}
+	resetGroupAlgoMemo()
+	changed, err := RunGroupAlgorithmsIncrementalOneShot(group)
+	if err != nil {
+		t.Fatalf("RunGroupAlgorithmsIncrementalOneShot: %v", err)
+	}
+	if changed.Skipped {
+		t.Fatal("the input-hash memo must not hit across an algorithm-version change — that is how an upgrade ends up serving the old gonum partition indefinitely")
+	}
+	// And the recompute must re-stamp the CURRENT version, so the next run can
+	// legitimately skip again.
+	if err := WriteOverlayFromResult(changed); err != nil {
+		t.Fatalf("WriteOverlayFromResult: %v", err)
+	}
+	if got := readOverlayUnconditional(path).AlgoVersion; got != OverlayAlgoVersion {
+		t.Fatalf("recomputed overlay stamped algo_version=%d, want %d", got, OverlayAlgoVersion)
+	}
+}
+
+// Drift guard. OverlayAlgoVersion is the ONLY thing standing between an
+// algorithm change and an indefinitely stale partition, and it is invisible at
+// the call site that would need to bump it (internal/graph's Louvain/PageRank
+// implementation). This test exists to fail loudly on the value, so that
+// changing the partitioning without bumping the version cannot pass review
+// silently: whoever changes the algorithm has to come here, read why, and
+// update both numbers together.
+func TestOverlayAlgoVersion_MustBeBumpedDeliberately(t *testing.T) {
+	// EXPECTED VALUE — bump this IN THE SAME COMMIT as OverlayAlgoVersion, and
+	// only when the change alters the partition/ranking a pass produces.
+	const expected = 1
+	if OverlayAlgoVersion != expected {
+		t.Fatalf("OverlayAlgoVersion = %d but this test expects %d.\n"+
+			"If you changed the community/centrality algorithm, bump BOTH — every stored overlay is then invalidated and recomputed.\n"+
+			"If you did not, revert the constant: lowering or reusing a version makes upgraded daemons keep serving a partition the current code would not produce.",
+			OverlayAlgoVersion, expected)
+	}
+	if OverlayAlgoVersion <= 0 {
+		t.Fatal("OverlayAlgoVersion must be >= 1: 0 is reserved for pre-versioning overlays, which are always invalidated")
+	}
+}

--- a/internal/graph/groupalgo/overlay_needs_recompute_5403_test.go
+++ b/internal/graph/groupalgo/overlay_needs_recompute_5403_test.go
@@ -21,7 +21,11 @@ import (
 func setupGroupWithOverlay(t *testing.T, name string, seedMtimes map[string]int64) {
 	t.Helper()
 	ov := &Overlay{
-		Group:        name,
+		Group: name,
+		// Stamped like a real compute: these fixtures stand in for "an overlay
+		// this build just wrote", so they must carry the current algorithm
+		// version or the version gate (correctly) invalidates them.
+		AlgoVersion:  OverlayAlgoVersion,
 		ComputedAt:   time.Now().UTC(),
 		SourceMtimes: seedMtimes,
 		Results:      map[string]EntityOverlay{},

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -634,6 +634,33 @@ both mean "every loaded repo".
 `grafel_index_status`) when the daemon has per-repo state. For a cheap freshness
 poll that does NOT assemble the group graph, prefer `grafel_index_status`.
 
+**Busy signals — `is_indexing` vs `is_enhancing`.** Two different stages can
+make the daemon busy, and they mean opposite things for whether you should wait:
+
+| Field | Stage | What it means for you |
+|-------|-------|-----------------------|
+| `is_indexing` | EXTRACTION + the cross-repo link pass, which write `graph.fb` | The graph is incomplete. Wait. (Prefer `grafel_index_status` — see below — so you gate on **your** repo, not any repo.) |
+| `is_enhancing` | The group-algo ANNOTATION pass, which writes a separate overlay | The graph is **fully queryable**. Every structural tool (`grafel_find`, `grafel_expand`, `grafel_find_callers`, `grafel_traces`, `grafel_cross_links`, `grafel_get_source`) works right now. Only cluster/ranking data is not ready. |
+
+Both are always present. `group_algo_in_flight` carries the annotation-pass
+count when `is_enhancing` is true. Do **not** treat `is_enhancing` as "not
+ready" — on a large corpus the annotation pass runs far longer than the index
+it follows, and waiting on it is waiting for nothing.
+
+**`communities_overlay`** — the state of the community / pagerank / centrality
+overlay for this group. It exists so an empty `communities` count is never
+ambiguous:
+
+| Value | Meaning | What to do |
+|-------|---------|------------|
+| `current` | An overlay is applied. `community_id` / pagerank / centrality are real values. A group can legitimately be `current` with **zero** communities. | Use them. |
+| `computing` | No overlay yet, and the annotation pass is running now. | Retry later if you need clusters; everything else works. |
+| `pending` | No overlay, and no pass running — never computed, or the last one failed. The daemon's overlay sweep re-arms one, so this is "not yet", not permanent. | Do not spin. Proceed without cluster data; `grafel status` shows the annotation state. |
+
+When `communities_overlay` is not `current`, `grafel_clusters` returns an empty
+list and entity `community_id` fields are absent — that is "not computed", not
+"no structure found".
+
 ---
 
 ### `grafel_index_status`

--- a/internal/mcp/busy_totals.go
+++ b/internal/mcp/busy_totals.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// applyBusyTotals fills the grafel_stats `totals` block with the daemon's live
+// busy signal. Extracted from handleStats so the EXTRACTION vs ENRICHMENT
+// distinction — the thing every agent polls to decide whether the index is
+// usable yet — is unit-testable without standing up a whole *Server.
+//
+// THE DISTINCTION, AND WHY IT IS NOT COSMETIC.
+//
+// Two different stages can make the daemon busy:
+//
+//   - INDEXING (extraction + the cross-repo link pass) writes graph.fb. Until it
+//     finishes, the graph a consumer would read is incomplete. "Wait."
+//   - ENHANCING (the group-algo annotation pass) writes a SEPARATE overlay file
+//     holding communities/pagerank/centrality. It never touches graph.fb, and
+//     none of the structural tools — find, expand, find_callers, traces,
+//     cross_links, get_source — read it. The graph is fully queryable the whole
+//     time it runs. "Go ahead; clusters/ranking may be missing for now."
+//
+// The engine-liveness branch used to report `is_indexing: true` for BOTH, and
+// omitted is_enhancing entirely. On the reference corpus the annotation pass is
+// hours long, so an agent (or the dashboard) polling grafel_stats saw
+// "still indexing" for hours after the graph had been ready for ten minutes —
+// i.e. the user-awaited rebuild never reported completion on the surface people
+// actually watch. That is the bug this function fixes: the two branches now
+// answer identically, and `is_indexing` means extraction only.
+//
+// engineFile/engineFresh come from daemon.EngineLivenessStatus. When the sidecar
+// is missing or stale (no engine plane has run, or it is down/starting) the
+// function falls back to the process-global indexstate record, preserving the
+// pre-#5729-PR3 behavior for an in-process scheduler.
+// Overlay states published in grafel_stats' `communities_overlay` field.
+const (
+	// overlayStateCurrent — an overlay is loaded; community_id / pagerank /
+	// centrality are real values.
+	overlayStateCurrent = "current"
+	// overlayStateComputing — no overlay is loaded and the annotation pass is
+	// running RIGHT NOW. Clusters/ranking will appear when it finishes; the
+	// graph itself is already queryable.
+	overlayStateComputing = "computing"
+	// overlayStatePending — no overlay is loaded and no pass is running. Either
+	// one has never been computed for this group, or the last one was
+	// cancelled/failed. The scheduler's overlay sweep re-arms a pass for stale
+	// groups, so this is a "not yet", not a permanent verdict — but it is the
+	// state to report when someone asks why grafel_clusters is empty.
+	overlayStatePending = "pending"
+)
+
+// overlayStateFor maps (overlay loaded?, annotation pass running?) onto the
+// published state string. Split out so the mapping is testable and so the two
+// "absent" cases stay distinguishable — an agent that sees `computing` should
+// retry, one that sees `pending` should not spin.
+func overlayStateFor(loaded, enhancing bool) string {
+	switch {
+	case loaded:
+		return overlayStateCurrent
+	case enhancing:
+		return overlayStateComputing
+	default:
+		return overlayStatePending
+	}
+}
+
+func applyBusyTotals(totals map[string]any, engineFile *statusfile.File, engineFresh bool) {
+	if engineFresh && engineFile != nil {
+		isIndexing := engineFile.EngineInFlight > 0
+		isEnhancing := engineFile.EngineGroupAlgoInFlight > 0
+		totals["is_indexing"] = isIndexing
+		totals["is_enhancing"] = isEnhancing
+		if isIndexing {
+			totals["indexing_in_flight"] = engineFile.EngineInFlight
+		}
+		// #5349 A3: surface an in-flight group-scope algorithm pass so a
+		// coordinator can tell the daemon is busy recomputing communities /
+		// centrality over the union, not just reindexing a repo.
+		if isEnhancing {
+			totals["group_algo_in_flight"] = engineFile.EngineGroupAlgoInFlight
+		}
+		if (isIndexing || isEnhancing) && !engineFile.EngineBusyStartedAt.IsZero() {
+			totals["indexing_started_at"] = engineFile.EngineBusyStartedAt.UTC().Format(time.RFC3339)
+		}
+		return
+	}
+	// No fresh engine-liveness sidecar exists yet — either no engine plane has
+	// ever run against this daemon root (e.g. this *mcp.Server was constructed
+	// directly in a test harness with no daemon/heartbeat goroutine), or the
+	// engine is down/starting/degraded. Fall back to the process-global
+	// indexstate record so an in-process scheduler (true legacy monolith, or a
+	// test that drives indexstate directly) is still reflected immediately
+	// rather than waiting on the periodic heartbeat.
+	ix := indexstate.Get()
+	totals["is_indexing"] = ix.IsIndexing
+	totals["is_enhancing"] = ix.IsEnhancing
+	if ix.IsIndexing {
+		totals["indexing_in_flight"] = ix.InFlight
+	}
+	if ix.IsEnhancing {
+		totals["group_algo_in_flight"] = ix.GroupAlgoInFlight
+	}
+	if (ix.IsIndexing || ix.IsEnhancing) && !ix.StartedAt.IsZero() {
+		totals["indexing_started_at"] = ix.StartedAt.UTC().Format(time.RFC3339)
+	}
+}

--- a/internal/mcp/busy_totals.go
+++ b/internal/mcp/busy_totals.go
@@ -53,6 +53,32 @@ const (
 	overlayStatePending = "pending"
 )
 
+// publishOverlayState writes grafel_stats' `communities_overlay` field.
+//
+// The community/pagerank/centrality overlay is produced by the group-algo
+// annotation pass AFTER a rebuild reports completion, so an empty `communities`
+// count is ambiguous on its own — it means either "this group genuinely has no
+// communities" or "the pass has not run yet". Every consumer degrades SILENTLY
+// when the overlay is absent (nil community pointers, empty cluster lists), so
+// the state is published explicitly rather than left for callers to infer.
+//
+// PRESENCE, NOT CONTENT. The signal is grp.algoApplied — "a present,
+// non-stale, current-algorithm-version overlay was applied" — and deliberately
+// NOT len(grp.Communities). A group whose overlay legitimately contains zero
+// communities (tiny group, everything ungrouped) is fully computed; reporting
+// it as `pending` would reintroduce, for exactly that group, the ambiguity this
+// field exists to remove, and would tell an agent to keep retrying something
+// that is already finished.
+//
+// The `is_enhancing` source is load-bearing: it must be the ENRICHMENT signal,
+// not `is_indexing`. An absent overlay while extraction happens to be running
+// is still `pending` — a running index does not mean the annotation pass is on
+// its way. Only a running group-algo pass justifies telling a caller to retry.
+func publishOverlayState(totals map[string]any, grp *LoadedGroup) {
+	loaded := grp != nil && grp.algoApplied
+	totals["communities_overlay"] = overlayStateFor(loaded, totals["is_enhancing"] == true)
+}
+
 // overlayStateFor maps (overlay loaded?, annotation pass running?) onto the
 // published state string. Split out so the mapping is testable and so the two
 // "absent" cases stay distinguishable — an agent that sees `computing` should

--- a/internal/mcp/busy_totals_test.go
+++ b/internal/mcp/busy_totals_test.go
@@ -94,3 +94,50 @@ func TestOverlayStateFor(t *testing.T) {
 		t.Fatal("computing (retry) and pending (do not spin) must be distinguishable states")
 	}
 }
+
+// WIRING of communities_overlay. overlayStateFor is well covered above, but the
+// call site is where the two inputs are chosen — and both choices are easy to
+// get wrong in a way no other test notices.
+//
+// (a) presence, not content: a group whose overlay genuinely holds zero
+// communities is COMPUTED. Deriving the state from len(Communities) would
+// report it `pending` forever, reintroducing the exact ambiguity this field
+// removes.
+func TestPublishOverlayState_EmptyButAppliedOverlayIsCurrent(t *testing.T) {
+	totals := map[string]any{"is_enhancing": false}
+	publishOverlayState(totals, &LoadedGroup{algoApplied: true, Communities: nil})
+
+	if got := totals["communities_overlay"]; got != overlayStateCurrent {
+		t.Fatalf("an applied overlay with zero communities is COMPUTED, not pending: communities_overlay = %v, want %q", got, overlayStateCurrent)
+	}
+}
+
+func TestPublishOverlayState_NoOverlayIsPending(t *testing.T) {
+	totals := map[string]any{"is_enhancing": false}
+	publishOverlayState(totals, &LoadedGroup{algoApplied: false})
+
+	if got := totals["communities_overlay"]; got != overlayStatePending {
+		t.Fatalf("communities_overlay = %v, want %q", got, overlayStatePending)
+	}
+}
+
+// (b) the retry signal must come from is_ENHANCING. Wiring it to is_indexing
+// would tell an agent to retry whenever any extraction is running, and would
+// stay `pending` through the annotation pass that is actually about to produce
+// the overlay.
+func TestPublishOverlayState_RetrySignalComesFromEnhancingNotIndexing(t *testing.T) {
+	// Annotation pass running, no extraction → the caller SHOULD retry.
+	enhancing := map[string]any{"is_enhancing": true, "is_indexing": false}
+	publishOverlayState(enhancing, &LoadedGroup{algoApplied: false})
+	if got := enhancing["communities_overlay"]; got != overlayStateComputing {
+		t.Fatalf("a running annotation pass must report %q, got %v", overlayStateComputing, got)
+	}
+
+	// Extraction running, no annotation pass → nothing is producing an overlay,
+	// so the caller must NOT be told to spin.
+	indexing := map[string]any{"is_enhancing": false, "is_indexing": true}
+	publishOverlayState(indexing, &LoadedGroup{algoApplied: false})
+	if got := indexing["communities_overlay"]; got != overlayStatePending {
+		t.Fatalf("a running INDEX is not a running annotation pass: communities_overlay = %v, want %q (wiring must read is_enhancing, not is_indexing)", got, overlayStatePending)
+	}
+}

--- a/internal/mcp/busy_totals_test.go
+++ b/internal/mcp/busy_totals_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// A user-awaited rebuild is DONE once extraction + links have written graph.fb.
+// The group-algo annotation pass that follows writes a separate overlay and
+// never touches graph.fb, so it must not keep grafel_stats reporting
+// "is_indexing" — that is the flag agents and the dashboard poll to decide
+// whether the graph is usable, and on the reference corpus the annotation pass
+// runs for hours.
+func TestApplyBusyTotals_EngineSidecar_GroupAlgoIsEnhancingNotIndexing(t *testing.T) {
+	started := time.Now().Add(-3 * time.Hour).UTC().Truncate(time.Second)
+	totals := map[string]any{}
+	applyBusyTotals(totals, &statusfile.File{
+		EngineInFlight:          0, // extraction finished
+		EngineGroupAlgoInFlight: 1, // annotation pass still running
+		EngineBusyStartedAt:     started,
+	}, true)
+
+	if got := totals["is_indexing"]; got != false {
+		t.Fatalf("a running group-algo pass must NOT report is_indexing (the rebuild is complete and the graph is queryable), got %v", got)
+	}
+	if got := totals["is_enhancing"]; got != true {
+		t.Fatalf("a running group-algo pass must report is_enhancing so the pending overlay is diagnosable, got %v", got)
+	}
+	if got := totals["group_algo_in_flight"]; got != 1 {
+		t.Fatalf("group_algo_in_flight = %v, want 1", got)
+	}
+	if _, ok := totals["indexing_in_flight"]; ok {
+		t.Fatalf("indexing_in_flight must be absent when nothing is extracting: %v", totals["indexing_in_flight"])
+	}
+	if got := totals["indexing_started_at"]; got != started.Format(time.RFC3339) {
+		t.Fatalf("indexing_started_at = %v, want %v", got, started.Format(time.RFC3339))
+	}
+}
+
+// Real extraction still reports is_indexing.
+func TestApplyBusyTotals_EngineSidecar_ExtractionIsIndexing(t *testing.T) {
+	totals := map[string]any{}
+	applyBusyTotals(totals, &statusfile.File{EngineInFlight: 2}, true)
+
+	if got := totals["is_indexing"]; got != true {
+		t.Fatalf("is_indexing = %v, want true", got)
+	}
+	if got := totals["is_enhancing"]; got != false {
+		t.Fatalf("is_enhancing = %v, want false", got)
+	}
+	if got := totals["indexing_in_flight"]; got != 2 {
+		t.Fatalf("indexing_in_flight = %v, want 2", got)
+	}
+}
+
+// An idle daemon reports both flags false — is_enhancing must be PRESENT and
+// false, not omitted, so "not yet computed" is a defined state a consumer can
+// read rather than an absent key it has to guess about.
+func TestApplyBusyTotals_EngineSidecar_IdleReportsBothFlags(t *testing.T) {
+	totals := map[string]any{}
+	applyBusyTotals(totals, &statusfile.File{}, true)
+
+	if got, ok := totals["is_indexing"]; !ok || got != false {
+		t.Fatalf("is_indexing = %v (present=%v), want false", got, ok)
+	}
+	if got, ok := totals["is_enhancing"]; !ok || got != false {
+		t.Fatalf("is_enhancing = %v (present=%v), want false", got, ok)
+	}
+}
+
+// "Not yet computed" must be a DEFINED, distinguishable state. Every overlay
+// consumer degrades silently when the overlay is absent (nil community
+// pointers, empty cluster lists), so an empty communities count on its own
+// cannot tell a caller whether to retry.
+func TestOverlayStateFor(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		loaded    bool
+		enhancing bool
+		want      string
+	}{
+		{"loaded overlay is current", true, false, overlayStateCurrent},
+		{"loaded overlay wins over a running pass", true, true, overlayStateCurrent},
+		{"absent overlay with a running pass is computing", false, true, overlayStateComputing},
+		{"absent overlay with no pass is pending", false, false, overlayStatePending},
+	} {
+		if got := overlayStateFor(tc.loaded, tc.enhancing); got != tc.want {
+			t.Errorf("%s: overlayStateFor(%v,%v) = %q, want %q", tc.name, tc.loaded, tc.enhancing, got, tc.want)
+		}
+	}
+	if overlayStateComputing == overlayStatePending {
+		t.Fatal("computing (retry) and pending (do not spin) must be distinguishable states")
+	}
+}

--- a/internal/mcp/evict_group_5872_test.go
+++ b/internal/mcp/evict_group_5872_test.go
@@ -445,6 +445,7 @@ func TestEvictGroup_ReviveKeepsOverlay(t *testing.T) {
 	st, overlayPath, cur, serviceID, _ := setupApplyGroup(t)
 
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/group_algo_overlay_apply_5354_test.go
+++ b/internal/mcp/group_algo_overlay_apply_5354_test.go
@@ -136,6 +136,7 @@ func TestApplyOverlay_GroupValuesAppliedAtLoad(t *testing.T) {
 	st, overlayPath, cur, serviceID, leafID := setupApplyGroup(t)
 
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -229,6 +230,7 @@ func TestApplyOverlay_StaleNotApplied(t *testing.T) {
 		stale[slug] = mt + 1 // off by one nano → mismatch
 	}
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: stale,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -264,6 +266,7 @@ func TestApplyOverlay_MidSessionSwap(t *testing.T) {
 
 	write := func(pr float64) {
 		ov := &groupalgo.Overlay{
+			AlgoVersion:  groupalgo.OverlayAlgoVersion,
 			Group:        "acme",
 			SourceMtimes: cur,
 			Results:      map[string]groupalgo.EntityOverlay{serviceID: {CommunityID: 1, PageRank: pr}},

--- a/internal/mcp/group_algo_overlay_readpath_5729_test.go
+++ b/internal/mcp/group_algo_overlay_readpath_5729_test.go
@@ -34,6 +34,7 @@ import (
 // test: backend/frontend/mobile each get a distinct cross-repo community.
 func buildOverlayFor5729(cur map[string]int64, beID, feID, mobID string) *groupalgo.Overlay {
 	return &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/group_algo_overlay_reapply_5403_test.go
+++ b/internal/mcp/group_algo_overlay_reapply_5403_test.go
@@ -36,6 +36,7 @@ func TestGroupReapplyOverlayOnMtimeAdvance(t *testing.T) {
 
 	// --- v1 overlay: mobile → community 80.
 	ovV1 := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -80,6 +81,7 @@ func TestGroupReapplyOverlayOnMtimeAdvance(t *testing.T) {
 	// settled-daemon case (#5403): the scheduler/CLI rewrote the overlay on disk
 	// but never poked the cached group.
 	ovV2 := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/group_algo_overlay_restamp_5400_test.go
+++ b/internal/mcp/group_algo_overlay_restamp_5400_test.go
@@ -135,6 +135,7 @@ func TestApplyOverlay_ReStampsReparsedMobileRepo(t *testing.T) {
 	// the backend god-node to 39, the frontend to 203 — mirroring the live acme
 	// overlay shape from the validation report.
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -164,6 +164,7 @@ func TestOverlaySideTable_ReaderMaterializeByteEqualsOverlaidDoc(t *testing.T) {
 
 	alpha, bravo := ids[0], ids[1] // charlie (ids[2]) deliberately un-overlaid
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -271,6 +272,7 @@ func TestOverlaySideTable_BuiltFromReaderNotDoc(t *testing.T) {
 
 	alpha, bravo := ids[0], ids[1] // charlie (ids[2]) deliberately un-overlaid
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -345,6 +347,7 @@ func TestOverlaySideTable_FlagOffBuildsNoSideTableAndReadsDoc(t *testing.T) {
 
 	alpha := ids[0]
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/segment_serve_5912h_test.go
+++ b/internal/mcp/segment_serve_5912h_test.go
@@ -426,7 +426,7 @@ func TestSegmentSet_OverlayMergeOverMultiReader_5912h(t *testing.T) {
 		t.Fatalf("cross-segment pair not contiguous: %d,%d", fromIdx, toIdx)
 	}
 
-	ov := &groupalgo.Overlay{Results: map[string]groupalgo.EntityOverlay{
+	ov := &groupalgo.Overlay{AlgoVersion: groupalgo.OverlayAlgoVersion, Results: map[string]groupalgo.EntityOverlay{
 		fromID: {CommunityID: 111, Centrality: 0.5, IsGodNode: true},
 		toID:   {CommunityID: 222},
 	}}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3401,46 +3401,14 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 	if layout, lerr := daemon.DefaultLayout(); lerr == nil {
 		engineFile, engineFresh = daemon.EngineLivenessStatus(layout.Root)
 	}
-	if engineFresh && engineFile != nil {
-		isIndexing := engineFile.EngineInFlight > 0 || engineFile.EngineGroupAlgoInFlight > 0
-		totals["is_indexing"] = isIndexing
-		if isIndexing {
-			totals["indexing_in_flight"] = engineFile.EngineInFlight
-			// #5349 A3: surface an in-flight group-scope algorithm pass so a
-			// coordinator can tell the daemon is busy recomputing communities /
-			// centrality over the union, not just reindexing a repo.
-			if engineFile.EngineGroupAlgoInFlight > 0 {
-				totals["group_algo_in_flight"] = engineFile.EngineGroupAlgoInFlight
-			}
-			if !engineFile.EngineBusyStartedAt.IsZero() {
-				totals["indexing_started_at"] = engineFile.EngineBusyStartedAt.UTC().Format(time.RFC3339)
-			}
-		}
-	} else {
-		// No fresh engine-liveness sidecar exists yet — either no engine plane
-		// has ever run against this daemon root (e.g. this *mcp.Server was
-		// constructed directly in a test harness with no daemon/heartbeat
-		// goroutine), or the engine is down/starting/degraded. Fall back to the
-		// process-global indexstate record so an in-process scheduler (true
-		// legacy monolith, or a test that drives indexstate directly) is still
-		// reflected immediately rather than waiting on the periodic heartbeat —
-		// this is the exact pre-#5729-PR3 behavior, preserved for equivalence.
-		ix := indexstate.Get()
-		totals["is_indexing"] = ix.IsIndexing
-		// is_enhancing surfaces the post-extraction ENRICHMENT tail (group-algo
-		// passes) distinctly from extraction, so a consumer never mistakes the
-		// enrichment tail for "still indexing".
-		totals["is_enhancing"] = ix.IsEnhancing
-		if ix.IsIndexing {
-			totals["indexing_in_flight"] = ix.InFlight
-		}
-		if ix.IsEnhancing {
-			totals["group_algo_in_flight"] = ix.GroupAlgoInFlight
-		}
-		if (ix.IsIndexing || ix.IsEnhancing) && !ix.StartedAt.IsZero() {
-			totals["indexing_started_at"] = ix.StartedAt.UTC().Format(time.RFC3339)
-		}
-	}
+	applyBusyTotals(totals, engineFile, engineFresh)
+	// #6002: the community/pagerank/centrality overlay is produced by the
+	// group-algo annotation pass AFTER a rebuild reports completion, so an empty
+	// `communities` count is ambiguous — it means either "this group genuinely
+	// has no communities" or "the pass has not run yet". Every consumer degrades
+	// SILENTLY when the overlay is absent (nil community pointers, empty cluster
+	// lists), so publish the state explicitly instead of making callers infer it.
+	totals["communities_overlay"] = overlayStateFor(len(lg.Communities) > 0, totals["is_enhancing"] == true)
 
 	// #5433/#5729 PR3: surface per-repo index freshness from the status-plane
 	// sidecars (a disk scan, not process memory) so this works identically in

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -3402,13 +3402,7 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 		engineFile, engineFresh = daemon.EngineLivenessStatus(layout.Root)
 	}
 	applyBusyTotals(totals, engineFile, engineFresh)
-	// #6002: the community/pagerank/centrality overlay is produced by the
-	// group-algo annotation pass AFTER a rebuild reports completion, so an empty
-	// `communities` count is ambiguous — it means either "this group genuinely
-	// has no communities" or "the pass has not run yet". Every consumer degrades
-	// SILENTLY when the overlay is absent (nil community pointers, empty cluster
-	// lists), so publish the state explicitly instead of making callers infer it.
-	totals["communities_overlay"] = overlayStateFor(len(lg.Communities) > 0, totals["is_enhancing"] == true)
+	publishOverlayState(totals, lg)
 
 	// #5433/#5729 PR3: surface per-repo index freshness from the status-plane
 	// sidecars (a disk scan, not process memory) so this works identically in

--- a/internal/mcp/topk_pagerank_overlay_test.go
+++ b/internal/mcp/topk_pagerank_overlay_test.go
@@ -220,6 +220,7 @@ func TestGetTopKPageRank_FlagOnOffParity_SideTableNotSentinel(t *testing.T) {
 		// Assign PageRank so the ranked order (Charlie > Alpha > Bravo) is the
 		// REVERSE-ish of vector order, so a sentinel-collapse is detectable.
 		ov := &groupalgo.Overlay{
+			AlgoVersion:  groupalgo.OverlayAlgoVersion,
 			Group:        "acme",
 			SourceMtimes: cur,
 			Results: map[string]groupalgo.EntityOverlay{

--- a/internal/mcp/view_iter_test.go
+++ b/internal/mcp/view_iter_test.go
@@ -81,6 +81,7 @@ func TestForEachEntity_FlagOnParityWithOverlay(t *testing.T) {
 
 	alpha, bravo := ids[0], ids[1] // charlie deliberately un-overlaid
 	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
 		SourceMtimes: cur,
 		Results: map[string]groupalgo.EntityOverlay{
@@ -403,6 +404,7 @@ func TestForEachEntity_RealReloadOverlayRestampRace(t *testing.T) {
 
 	writeOverlay := func(mtimes map[string]int64, seed int) {
 		ov := &groupalgo.Overlay{
+			AlgoVersion:  groupalgo.OverlayAlgoVersion,
 			Group:        "acme",
 			SourceMtimes: mtimes,
 			Results: map[string]groupalgo.EntityOverlay{


### PR DESCRIPTION
## What

Takes `group-algo` (community detection + centrality) off the critical path of a user-awaited rebuild, and makes "runs in the background" mean **it actually finishes**.

## Why — the measurement

A from-scratch reindex of a 25-repo corpus takes 3h30m, of which **3h15m is `group-algo`**. But the historical record shows something worse than slowness:

```
group-algo: starting  events for this corpus ....... 91
completions .................................... 2
```

For most of the corpus's life the pass was started, ran 5-10 minutes, and was cancelled by the next trigger — `scheduleGroupAlgo` -> `cancelGroupAlgoLocked` -> SIGKILL — then restarted from zero. It essentially never produced an overlay. A reindex *appeared* to finish in ~12 minutes because index + links completed and the annotation churned invisibly forever.

`group-algo` is a pure annotation pass over an already-written `graph.fb`. `AssembleGroupGraph` loads finished per-repo graphs; `RunAlgorithmsWithOptions` takes `(entities, rels)` and returns a separate result. It never mutates the graph, and `find` / `expand` / `traces` / `find_callers` / `cross_links` do not read community at all. There is no reason for it to block a rebuild.

## The changes

**1. Let an in-flight pass finish.** `scheduleGroupAlgo` no longer cancels a *running* pass; it records `groupAlgoRerun[group]` and returns. `fireGroupAlgo` consumes the flag on completion and re-arms the debounce. Explicit cancels (`Stop`, `CancelGroup`) still cancel.

The reasoning: the pass reads an input **snapshot** and writes a separate file, so its output is always internally consistent — at worst stale with respect to content that landed mid-pass, never wrong. Cancelling trades a slightly-stale-but-real overlay for *no* overlay plus a full recompute, and under sustained churn that never converges.

This also turns out to be what makes the system **terminate**: `runGroupAlgorithmsIncremental` content-gates on `CommunityInputHash` and skips the expensive work when the union is unchanged — but that gate can only engage if a previous pass actually *wrote* the overlay. Under cancel-always it never could.

Staleness is self-reporting: `AssembleGroupGraph` stats source mtimes *before* loading each repo and `BuildOverlay` copies them verbatim, so a repo reindexed mid-pass yields an overlay stamped with the pre-reindex mtime, which trips the staleness gate and re-arms. The TOCTOU fails safe.

**2. First-compute backstop.** A real hole: `grafel rebuild` / `reset` runs its link pass **in-process** (`daemonRebuildFuncCore` -> `daemonForegroundLinks`), never through the scheduler — so `runLinks`, the only caller of `scheduleGroupAlgo`, never fires. Combined with `sweepStaleOverlays` returning false for an absent overlay, **a freshly reset group would never get communities at all.** The sweep now also arms a first compute for groups with indexed members and no usable overlay.

**3. Algorithm-version invalidation.** `OverlayAlgoVersion` gates all three skip points — `ReadOverlay`, `OverlayNeedsRecompute`, and the incremental disk-overlay skip — checked *before* the mtime gate, since on upgrade nothing on disk moves. Mismatch in either direction invalidates, so a downgrade recomputes rather than mixing partitions. Without this, changing the partitioning algorithm would leave every unchanged group serving the old partition indefinitely.

**4. Status honesty.** The engine-sidecar branch reported `is_indexing: true` for the entire annotation stage and omitted `is_enhancing`, so an agent polling `grafel_stats` saw "still indexing" for **hours** after the graph was ready and answering queries. Both branches now answer identically. Adds `communities_overlay: current|computing|pending`, `GroupAlgoRunning` / `GroupAlgoInFlight`, and a `grafel status` `annotation:` line.

**5. #6001 fixed.** `fireGroupAlgo` registers a per-pass cancel token and only deletes its own entry, mirroring `fireLinks` — so a late return can no longer drop a live successor's handle.

## Verification

Independently adversarially reviewed → APPROVE, with four follow-ups since closed.

The reviewer traced every remaining path that can kill an in-flight pass, confirmed there is no lost-update race on `groupAlgoRerun` (setter and consumer share the same `s.mu` section as the token delete), and confirmed the re-arm loop converges. It enumerated **all 18** `Overlay{}` literals in the tree to check whether stamping `AlgoVersion` into fixtures had masked a stale-overlay test case — none had; the two that looked like traps *require* stamping to avoid passing vacuously through the wrong gate.

Mutations killed: cancel-on-re-arm; drop the rerun consumption; each of the three version gates; backstop never/always fires; status conflation; the #6001 blind delete; snapshot pending visibility; `overlayStateFor` wiring; `cancelGroupAlgoLocked`'s rerun drop.

`go build`, `go vet`, `gofmt -l` clean. 4183 tests across 27 packages green. `./internal/daemon/sched/... -race -count=2` clean.

## Accepted limits (stated rather than hidden)

- Let-finish protects a *running* pass, not a stage-gate-**deferred** one — no token is registered while deferred, so triggers still reset its retry timer. It cannot churn work, but it can be postponed; bounded by the drain barrier.
- The forfeit-grace path still SIGKILLs after `StageGateHoldMax` (4h) + 30m grace. At the measured 3h15m that leaves ~1h15m of headroom, so a ~40% larger corpus would reintroduce churn in slow motion. Loud when it happens (`stage_gate_forfeit_abandoned`, ERROR).
- On repeated failure the first-compute backstop retries at the 10-minute sweep cadence with no backoff — the same shape the stale-overlay path already had.

## Not in scope

No algorithm work; nothing touched in `internal/graph/algorithms.go`. The version gate is implementation-agnostic. `pr_impact` is left alone and filed separately as #6006.

Closes #6002. Refs #5954, #6001.
