### PR TITLE
perf(#5954): replace gonum community.Modularize with in-repo O(E)-per-sweep Louvain

### DIFF
--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -15,9 +15,17 @@
 //
 // # Community detection algorithm
 //
-// We use Louvain modularity maximisation (gonum's community.Modularize) with a
-// fixed PCG seed (1, 2) and stable node-ordering so results are byte-identical
-// across re-runs of the same graph.
+// We use Louvain modularity maximisation. The implementation is in-repo
+// (louvain.go) rather than gonum's community.Modularize: gonum evaluates a
+// candidate move by iterating every member of the target community, making one
+// local-moving sweep cost Σ_c |c|². On the production corpus that was 3h15m,
+// 99.5% of the whole indexing pipeline. The in-repo version is the SAME
+// algorithm computed the standard way (incremental sigma_tot, neighbour-side
+// k_{i,C}, CSR adjacency) at O(E) per sweep. See louvain.go.
+//
+// It carries no PRNG at all: node ordering, adjacency ordering and move
+// tie-breaks are fixed, so results are byte-identical across re-runs of the
+// same graph by construction.
 //
 // Leiden was evaluated for this release (#1382) and deferred because no
 // production-quality Go Leiden library exists: github.com/vsuryav/leiden-go and
@@ -40,7 +48,6 @@ import (
 	"time"
 
 	gonumgraph "gonum.org/v1/gonum/graph"
-	"gonum.org/v1/gonum/graph/community"
 	"gonum.org/v1/gonum/graph/network"
 	"gonum.org/v1/gonum/graph/path"
 	"gonum.org/v1/gonum/graph/simple"
@@ -206,9 +213,18 @@ func BuildGraph(entities []Entity, rels []Relationship) (*simple.WeightedDirecte
 // transformation BuildGraph applies). The hash is the COMPLETE determinant of
 // the deterministic Pass-4 output (community partition + integer labels +
 // PageRank + betweenness): the gonum node-id assignment is a pure function of
-// entity insertion order, and Modularize is seeded with a fixed PCG source, so
-// two unions with the same CommunityInputHash produce byte-identical
-// AlgorithmResults.
+// entity insertion order, and louvainPartition is a deterministic function of
+// the node/edge set with no PRNG at all, so two unions with the same
+// CommunityInputHash produce byte-identical AlgorithmResults.
+//
+// Scope note: "byte-identical" is a claim about two runs of the SAME grafel
+// build. It is not a claim across builds — a change to the community algorithm
+// itself (as in the #5954 replacement of gonum's community.Modularize with the
+// in-repo Louvain in louvain.go) re-partitions the graph without changing this
+// hash. That is by design: the hash covers the INPUT, not the algorithm
+// version. Any such change therefore requires a full recompute of stored
+// overlays even where the hash matches, and is gated on partition quality
+// (modularity), not on equality with the previously stored partition.
 //
 // This is the gate for incremental community detection (#5309 layer 4): when a
 // reindex leaves this hash unchanged (docs/comment/config edits, or any change
@@ -388,11 +404,12 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 		und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(from), simple.Node(to), e.Weight()))
 	}
 
-	// Deterministic source so the test suite is repeatable.
-	src := rand.NewPCG(1, 2)
-	reduced := community.Modularize(und, 1.0, src)
-
-	groups := reduced.Communities()
+	// In-repo Louvain (louvain.go). No PRNG: node order, adjacency order and
+	// tie-breaks are all fixed, so the partition is deterministic by
+	// construction rather than by seeding. See #5954 / louvain.go for why
+	// gonum's community.Modularize was replaced.
+	const resolution = 1.0
+	groups := louvainPartition(und, resolution)
 
 	// Issue #633 phase-2 — pprof showed `community.Q` accounted for ~90% of
 	// indexing allocations (21.6 GB on client-fixture-b: 9,549 communities ×
@@ -406,9 +423,8 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 	//   3. Per-community contribution: q_c = (2*internal_w - K_C^2/m2) / m2
 	//      (BuildGraph drops self-loops, so the diagonal term collapses to 0
 	//      and gonum's "2*w_uv for u<v" off-diagonal sum becomes 2*internal_w).
-	//   4. Overall Q = Σ q_c — matches gonum's `community.Q(und, groups, 1)`
+	//   4. Overall Q = Σ q_c — matches the textbook modularity of `groups`
 	//      to the rounding tolerance enforced by roundForDeterminism().
-	const resolution = 1.0
 	type nodeStat struct {
 		k      float64
 		cidIdx int // index into groups
@@ -418,8 +434,7 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 	// First, mark community membership so the edge sweep can classify edges
 	// in O(1) without consulting `groups` repeatedly.
 	for cid, gg := range groups {
-		for _, n := range gg {
-			nid := n.ID()
+		for _, nid := range gg {
 			if _, ok := nodeStats[nid]; !ok {
 				nodeStats[nid] = &nodeStat{cidIdx: cid}
 			} else {
@@ -439,9 +454,9 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 		fid, tid := e.From().ID(), e.To().ID()
 		nf, ok := nodeStats[fid]
 		if !ok {
-			// Isolated-from-Modularize node: gonum's Communities() still
-			// covers every node from the original graph, but defensively
-			// guard so the loop is total.
+			// Node absent from the partition: louvainPartition covers every
+			// node of the undirected projection, but defensively guard so the
+			// loop is total.
 			nf = &nodeStat{cidIdx: -1}
 			nodeStats[fid] = nf
 		}
@@ -464,8 +479,8 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 	K := make([]float64, len(groups))
 	for cid, gg := range groups {
 		var k float64
-		for _, n := range gg {
-			if ns, ok := nodeStats[n.ID()]; ok {
+		for _, nid := range gg {
+			if ns, ok := nodeStats[nid]; ok {
 				k += ns.k
 			}
 		}
@@ -486,9 +501,9 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 	overallQ := roundForDeterminism(sanitizeFloat(overallQRaw))
 
 	communityOf := make(map[string]int, idx.next)
-	// Default every node into community -1; Modularize's Communities() lists
-	// only nodes that participate in the reduced graph, but we want a value
-	// for isolated entities too.
+	// Default every node into community -1; the partition lists only nodes
+	// present in the undirected projection, but we want a value for entities
+	// that never made it into the graph too.
 	for sid := range idx.toInt {
 		communityOf[sid] = -1
 	}
@@ -502,8 +517,7 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 			degree int
 		}
 		members := make([]member, 0, len(g))
-		for _, n := range g {
-			nid := n.ID()
+		for _, nid := range g {
 			communityOf[idx.fromInt[nid]] = cid
 			deg := 0
 			if ns, ok := nodeStats[nid]; ok {
@@ -545,7 +559,8 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 		})
 	}
 	// Issue #481 — tiebreak Size-equal communities on the integer community
-	// id assigned by Modularize so result ordering is stable across runs.
+	// id assigned by the partition (ascending lowest-member node index) so
+	// result ordering is stable across runs.
 	sort.SliceStable(results, func(i, j int) bool {
 		if results[i].Size != results[j].Size {
 			return results[i].Size > results[j].Size

--- a/internal/graph/louvain.go
+++ b/internal/graph/louvain.go
@@ -1,0 +1,485 @@
+// Package graph — louvain.go implements Louvain modularity maximisation
+// in-repo, replacing gonum's community.Modularize.
+//
+// # Why
+//
+// gonum v0.17.0's undirectedLocalMover.deltaQ evaluates a candidate move of
+// node i into community C by iterating EVERY MEMBER of C, reading edge weights
+// out of a map[[2]int]float64. One local-moving sweep therefore costs
+// Σ_c |c|² map lookups. On the 25-repo production corpus (427k entities /
+// 1.85M relationships) the partition has a 109k-node community, Σ|c|² = 2.75e10,
+// and community detection took 3h15m — 99.5% of the whole indexing pipeline.
+// Measured scaling was N^1.78–1.88 where an O(E)-per-sweep Louvain is N^1.0.
+//
+// # What this file does differently
+//
+// Same algorithm (multi-level local moving → aggregation → repeat), same
+// resolution parameter, computed the standard way:
+//
+//  1. sigmaTot[c] (Σ of weighted degrees in c) is a running total updated in
+//     O(1) on every move. A community is never rescanned to compute it.
+//  2. k_{i,C} is accumulated by walking node i's NEIGHBOURS (degree ~4-10 on
+//     code graphs) into a scratch array indexed by community id, reset in
+//     O(deg) via a monotone stamp. Community membership is never iterated.
+//  3. Adjacency is flat CSR ([]int32 offsets/targets + []float64 weights)
+//     rather than map[[2]int]float64, which removes the cache-miss constant
+//     on top of the asymptotic win.
+//
+// Per sweep: Σ|c|² → O(E).
+//
+// # Determinism
+//
+// There is no PRNG. Nodes are indexed by ascending gonum node id, each node's
+// adjacency list is sorted by target index, sweeps run in ascending index
+// order, and ties in the move decision are broken toward the lowest community
+// index. Same input ⇒ same output, run to run.
+//
+// # Termination, and why louvainMaxSweeps is a REAL bound
+//
+// The intended argument is that the tie-break "move on equal gain only to a
+// strictly lower community index" guarantees termination: a strict-gain move
+// raises Q, a tie move holds Q and lowers Σ comm-index, so (Q, -Σ idx) is
+// lexicographically monotone. That argument has a hole. The tie branch in
+// localMoving assigns bestGain = gain, so bestGain can ratchet DOWNWARD by up
+// to louvainMinGain per accepted tie; a chain of ties can therefore land a move
+// whose true gain is below staying put by O(deg · 1e-12). Q is consequently not
+// strictly monotone, and the pair is not strictly lexicographically monotone.
+// No cycle has been constructed or observed, so this is theoretical — but it
+// means louvainMaxSweeps is the actual backstop, not a formality.
+//
+// More importantly, the cap BINDS on realistic input. Sweeps-to-convergence at
+// level 0, measured on Barabási-Albert graphs (scale-free, the shape a real
+// code graph has), grows roughly N^0.65:
+//
+//	barabasi-albert n=  8000  117 sweeps
+//	barabasi-albert n= 32000  266 sweeps
+//	barabasi-albert n=128000  387 sweeps
+//	planted-partition n=16000  10 sweeps   <- what the planted fixtures measure
+//
+// Extrapolated to the 427k-entity corpus that is several hundred sweeps, so the
+// original cap of 100 would have truncated level 0 well short of convergence.
+//
+// WHAT THAT TRUNCATION ACTUALLY COSTS, MEASURED — this matters, because the
+// intuitive answer is wrong. Q at cap=100 vs cap=1000 on the BA family:
+//
+//	n=  8000   cap100 Q=0.388869   cap1000 Q=0.388219   (-0.000650)
+//	n= 32000   cap100 Q=0.380061   cap1000 Q=0.378383   (-0.001678)
+//	n=128000   cap100 Q=0.375377   cap1000 Q=0.371322   (-0.004055)
+//
+// Running to convergence scores slightly WORSE here, not better. That is not a
+// paradox: multi-level Louvain's final Q is not monotone in how far level 0 is
+// converged — a truncated level 0 hands a different (here, slightly luckier)
+// starting partition to aggregation. An independent review measured the
+// opposite sign on its own BA fixtures (-0.001223 at n=128000 for cap=100).
+// Both results are inside ±0.005. The honest reading is that the cap's effect
+// on quality is NOISE, not a mechanism.
+//
+// So the cap is 1000 for well-definedness, not for a quality win: "Louvain run
+// to convergence" is a specified algorithm whose output depends only on the
+// graph, whereas "Louvain truncated at 100 sweeps" makes the partition a
+// function of an arbitrary constant, drifting with graph size in a way nothing
+// measures — and it was entirely unmeasured at 427k. Choosing 100 because it
+// scored +0.004 on one synthetic family would be tuning to fixtures. Cost of
+// the headroom: BA-128k goes 944ms -> 3.26s; each corpus sweep is O(E)=1.85e6,
+// so this is seconds against 3h15m saved.
+//
+// louvainMaxLevels is genuinely slack (max observed depth: 6).
+package graph
+
+import (
+	"sort"
+
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+const (
+	// louvainMaxSweeps bounds local-moving iterations within a single level.
+	// This is a TRUNCATION BOUND, not a formality: scale-free graphs need
+	// hundreds of sweeps at level 0 and the count grows ~N^0.65, so a low cap
+	// makes the partition a function of the cap rather than of the graph. Sized
+	// so the 427k-entity corpus converges with headroom. See the "Termination"
+	// section of the package comment for measured sweep counts, and for why the
+	// quality effect of truncation is noise rather than a reason to tune this.
+	louvainMaxSweeps = 1000
+	// louvainMaxLevels bounds the aggregation hierarchy. Each level strictly
+	// reduces the node count; max depth observed across the fixture set is 5,
+	// so unlike louvainMaxSweeps this bound is genuine slack.
+	louvainMaxLevels = 64
+	// louvainMinGain is the epsilon under which two modularity gains are
+	// considered equal (and the lowest-community-index tie-break applies).
+	louvainMinGain = 1e-12
+)
+
+// csrGraph is a weighted undirected graph in compressed sparse row form.
+//
+// Self-loops live in selfw rather than in adj/w: aggregation creates them in
+// bulk (every intra-community edge of one level becomes self-weight at the
+// next) and keeping them out of the adjacency arrays means the local-moving
+// inner loop never has to test for them.
+type csrGraph struct {
+	n     int
+	off   []int32   // len n+1
+	adj   []int32   // len off[n]
+	w     []float64 // len off[n], parallel to adj
+	selfw []float64 // len n, self-loop weight (counted ONCE)
+	k     []float64 // len n, weighted degree: Σ incident w + 2*selfw
+	m2    float64   // Σ k, i.e. 2m. Invariant across aggregation levels.
+}
+
+// buildCSRFromUndirected converts a gonum weighted undirected simple graph
+// into CSR form. Nodes are indexed by ascending node id; ids[i] is the gonum
+// node id of index i. Adjacency lists are sorted by target index so every
+// downstream float summation happens in a fixed order.
+func buildCSRFromUndirected(und *simple.WeightedUndirectedGraph) (*csrGraph, []int64) {
+	var ids []int64
+	nodes := und.Nodes()
+	if nodes != nil {
+		ids = make([]int64, 0, nodes.Len())
+		for nodes.Next() {
+			ids = append(ids, nodes.Node().ID())
+		}
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	n := len(ids)
+	idxOf := make(map[int64]int32, n)
+	for i, id := range ids {
+		idxOf[id] = int32(i)
+	}
+
+	g := &csrGraph{
+		n:     n,
+		off:   make([]int32, n+1),
+		selfw: make([]float64, n),
+		k:     make([]float64, n),
+	}
+	if n == 0 {
+		return g, ids
+	}
+
+	// Pass 1: degree count. gonum's edge iteration order is map-derived and
+	// therefore unstable, so we materialise endpoints and sort later rather
+	// than relying on iteration order for anything.
+	type edge struct {
+		u, v int32
+		w    float64
+	}
+	var edges []edge
+	if it := und.WeightedEdges(); it != nil {
+		edges = make([]edge, 0, it.Len())
+		for it.Next() {
+			e := it.WeightedEdge()
+			u, v := idxOf[e.From().ID()], idxOf[e.To().ID()]
+			if u == v {
+				// simple.WeightedUndirectedGraph rejects self-loops; guard anyway.
+				g.selfw[u] += e.Weight()
+				continue
+			}
+			edges = append(edges, edge{u, v, e.Weight()})
+		}
+	}
+	for i := range edges {
+		g.off[edges[i].u+1]++
+		g.off[edges[i].v+1]++
+	}
+	for i := 0; i < n; i++ {
+		g.off[i+1] += g.off[i]
+	}
+	total := g.off[n]
+	g.adj = make([]int32, total)
+	g.w = make([]float64, total)
+	cursor := make([]int32, n)
+	copy(cursor, g.off[:n])
+	for i := range edges {
+		e := edges[i]
+		g.adj[cursor[e.u]] = e.v
+		g.w[cursor[e.u]] = e.w
+		cursor[e.u]++
+		g.adj[cursor[e.v]] = e.u
+		g.w[cursor[e.v]] = e.w
+		cursor[e.v]++
+	}
+	g.sortAdjacency()
+	g.computeDegrees()
+	return g, ids
+}
+
+// sortAdjacency sorts each node's neighbour slice by target index, carrying the
+// parallel weight slice along. Fixed order ⇒ fixed float summation order.
+func (g *csrGraph) sortAdjacency() {
+	for i := 0; i < g.n; i++ {
+		lo, hi := g.off[i], g.off[i+1]
+		if hi-lo < 2 {
+			continue
+		}
+		sort.Sort(&adjSlice{adj: g.adj[lo:hi], w: g.w[lo:hi]})
+	}
+}
+
+// adjSlice sorts a (targets, weights) pair of parallel slices by target.
+type adjSlice struct {
+	adj []int32
+	w   []float64
+}
+
+func (a *adjSlice) Len() int           { return len(a.adj) }
+func (a *adjSlice) Less(i, j int) bool { return a.adj[i] < a.adj[j] }
+func (a *adjSlice) Swap(i, j int) {
+	a.adj[i], a.adj[j] = a.adj[j], a.adj[i]
+	a.w[i], a.w[j] = a.w[j], a.w[i]
+}
+
+// computeDegrees fills k (weighted degree, self-loops counted twice) and m2.
+func (g *csrGraph) computeDegrees() {
+	g.m2 = 0
+	for i := 0; i < g.n; i++ {
+		var d float64
+		for p := g.off[i]; p < g.off[i+1]; p++ {
+			d += g.w[p]
+		}
+		d += 2 * g.selfw[i]
+		g.k[i] = d
+		g.m2 += d
+	}
+}
+
+// localMoving runs the Louvain local-moving phase: repeatedly sweep every node
+// in ascending index order and move it into the neighbouring community that
+// maximises the modularity gain
+//
+//	ΔQ ∝ k_{i,C} - resolution * k_i * sigmaTot[C] / m2
+//
+// Returns the (compacted) community label per node, the community count,
+// whether any node moved at all, and the number of sweeps consumed. The sweep
+// count is reported so tests can assert louvainMaxSweeps is not binding — see
+// TestLouvainSweepCapIsNotBinding.
+func (g *csrGraph) localMoving(resolution float64) (comm []int32, nComm int, moved bool, sweeps int) {
+	n := g.n
+	comm = make([]int32, n)
+	for i := range comm {
+		comm[i] = int32(i)
+	}
+	if n == 0 || g.m2 <= 0 {
+		return comm, n, false, 0
+	}
+
+	sigmaTot := make([]float64, n)
+	copy(sigmaTot, g.k)
+
+	kIn := make([]float64, n) // scratch: k_{i,C} indexed by community id
+	stamp := make([]int64, n) // scratch: freshness marker for kIn
+	for i := range stamp {
+		stamp[i] = -1
+	}
+	touched := make([]int32, 0, 64)
+	var mark int64
+
+	for sweep := 0; sweep < louvainMaxSweeps; sweep++ {
+		sweeps++
+		moves := 0
+		for i := 0; i < n; i++ {
+			ci := comm[i]
+			ki := g.k[i]
+
+			// Neighbour-side accumulation of k_{i,C}. Cost O(deg(i)); the
+			// scratch reset is implicit via the monotone stamp.
+			mark++
+			touched = touched[:0]
+			stamp[ci] = mark
+			kIn[ci] = 0
+			touched = append(touched, ci)
+			for p := g.off[i]; p < g.off[i+1]; p++ {
+				c := comm[g.adj[p]]
+				if stamp[c] != mark {
+					stamp[c] = mark
+					kIn[c] = 0
+					touched = append(touched, c)
+				}
+				kIn[c] += g.w[p]
+			}
+
+			// Remove i from its own community — O(1), no rescan.
+			sigmaTot[ci] -= ki
+
+			bestC := ci
+			bestGain := kIn[ci] - resolution*ki*sigmaTot[ci]/g.m2
+			for _, c := range touched {
+				if c == ci {
+					continue
+				}
+				gain := kIn[c] - resolution*ki*sigmaTot[c]/g.m2
+				switch {
+				case gain > bestGain+louvainMinGain:
+					bestGain, bestC = gain, c
+				case gain > bestGain-louvainMinGain && c < bestC:
+					// Equal gain: prefer the lowest community index. This is
+					// both the determinism rule and the termination argument
+					// (see the package comment).
+					bestGain, bestC = gain, c
+				}
+			}
+
+			sigmaTot[bestC] += ki
+			if bestC != ci {
+				comm[i] = bestC
+				moves++
+				moved = true
+			}
+		}
+		if moves == 0 {
+			break
+		}
+	}
+
+	nComm = compactLabels(comm)
+	return comm, nComm, moved, sweeps
+}
+
+// compactLabels renumbers labels to 0..k-1 in order of first appearance
+// scanning ascending node index. Returns the number of distinct labels.
+func compactLabels(comm []int32) int {
+	remap := make(map[int32]int32, len(comm))
+	next := int32(0)
+	for i, c := range comm {
+		nc, ok := remap[c]
+		if !ok {
+			nc = next
+			remap[c] = nc
+			next++
+		}
+		comm[i] = nc
+	}
+	return int(next)
+}
+
+// aggregate collapses each community into a single node, producing the graph
+// for the next Louvain level. Intra-community edge weight becomes the new
+// node's self-loop; inter-community weight becomes the new edges.
+func (g *csrGraph) aggregate(comm []int32, nc int) *csrGraph {
+	// Bucket members by community (counting sort, O(n)).
+	counts := make([]int32, nc+1)
+	for _, c := range comm {
+		counts[c+1]++
+	}
+	for i := 0; i < nc; i++ {
+		counts[i+1] += counts[i]
+	}
+	members := make([]int32, g.n)
+	cursor := make([]int32, nc)
+	copy(cursor, counts[:nc])
+	for i, c := range comm {
+		members[cursor[c]] = int32(i)
+		cursor[c]++
+	}
+
+	out := &csrGraph{
+		n:     nc,
+		off:   make([]int32, nc+1),
+		selfw: make([]float64, nc),
+		k:     make([]float64, nc),
+		m2:    g.m2, // total weight is invariant under aggregation
+	}
+	out.adj = make([]int32, 0, len(g.adj))
+	out.w = make([]float64, 0, len(g.w))
+
+	acc := make([]float64, nc)
+	stamp := make([]int64, nc)
+	for i := range stamp {
+		stamp[i] = -1
+	}
+	touched := make([]int32, 0, 64)
+
+	for c := 0; c < nc; c++ {
+		mark := int64(c)
+		touched = touched[:0]
+		var selfSum, internal float64
+		for mi := counts[c]; mi < counts[c+1]; mi++ {
+			u := members[mi]
+			selfSum += g.selfw[u]
+			out.k[c] += g.k[u]
+			for p := g.off[u]; p < g.off[u+1]; p++ {
+				d := comm[g.adj[p]]
+				if d == int32(c) {
+					internal += g.w[p]
+					continue
+				}
+				if stamp[d] != mark {
+					stamp[d] = mark
+					acc[d] = 0
+					touched = append(touched, d)
+				}
+				acc[d] += g.w[p]
+			}
+		}
+		// Every intra-community edge was seen from both endpoints.
+		out.selfw[c] = selfSum + internal/2
+		sort.Slice(touched, func(i, j int) bool { return touched[i] < touched[j] })
+		for _, d := range touched {
+			out.adj = append(out.adj, d)
+			out.w = append(out.w, acc[d])
+		}
+		out.off[c+1] = int32(len(out.adj))
+	}
+	return out
+}
+
+// louvainPartition runs multi-level Louvain over the undirected projection and
+// returns the communities as slices of gonum node ids.
+//
+// Community ordering is deterministic: communities are numbered by the
+// ascending node index of their lowest-indexed member, and members within a
+// community are listed in ascending node-id order.
+func louvainPartition(und *simple.WeightedUndirectedGraph, resolution float64) [][]int64 {
+	groups, _ := louvainPartitionWithSweeps(und, resolution)
+	return groups
+}
+
+// louvainPartitionWithSweeps is louvainPartition plus the per-level
+// sweeps-to-convergence counts. Exposed (unexported, test-facing) because
+// louvainMaxSweeps is a real truncation bound and silent truncation is the one
+// way this implementation can degrade partition quality at scale — so it has to
+// be observable, not inferred.
+func louvainPartitionWithSweeps(und *simple.WeightedUndirectedGraph, resolution float64) ([][]int64, []int) {
+	base, ids := buildCSRFromUndirected(und)
+	n := base.n
+	if n == 0 {
+		return nil, nil
+	}
+	var sweepsPerLevel []int
+
+	global := make([]int32, n)
+	for i := range global {
+		global[i] = int32(i)
+	}
+
+	cur := base
+	for level := 0; level < louvainMaxLevels; level++ {
+		comm, nc, moved, sweeps := cur.localMoving(resolution)
+		sweepsPerLevel = append(sweepsPerLevel, sweeps)
+		if !moved {
+			break
+		}
+		for i := range global {
+			global[i] = comm[global[i]]
+		}
+		if nc >= cur.n || nc <= 1 {
+			break
+		}
+		cur = cur.aggregate(comm, nc)
+	}
+
+	// Renumber final labels by ascending lowest member index, then emit.
+	nGroups := compactLabels(global)
+	sizes := make([]int, nGroups)
+	for _, c := range global {
+		sizes[c]++
+	}
+	groups := make([][]int64, nGroups)
+	for c := range groups {
+		groups[c] = make([]int64, 0, sizes[c])
+	}
+	for i, c := range global {
+		groups[c] = append(groups[c], ids[i])
+	}
+	return groups, sweepsPerLevel
+}

--- a/internal/graph/louvain_test.go
+++ b/internal/graph/louvain_test.go
@@ -1,0 +1,716 @@
+package graph
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"sort"
+	"testing"
+	"time"
+
+	"gonum.org/v1/gonum/graph/community"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// plantedSpec describes a planted-partition graph: a set of communities with
+// dense intra-community wiring and sparse inter-community wiring.
+type plantedSpec struct {
+	// Sizes are the community sizes. Sum(Sizes) is the node count.
+	Sizes []int
+	// IntraDeg is the average intra-community degree per node.
+	IntraDeg int
+	// InterEdges is the number of random cross-community edges.
+	InterEdges int
+	Seed       uint64
+}
+
+// plantedSizes returns community sizes for a graph of n nodes shaped like the
+// real 25-repo corpus partition: one community holding ~25% of the nodes,
+// a second holding ~22%, and the remainder spread over many smaller ones.
+// This is the pathological case for gonum's Σ|c|² local mover.
+func plantedSizes(n int) []int {
+	sizes := []int{n * 25 / 100, n * 22 / 100}
+	rest := n - sizes[0] - sizes[1]
+	// 20 mid-size communities absorbing the remainder.
+	const k = 20
+	for i := 0; i < k; i++ {
+		s := rest / k
+		if i == k-1 {
+			s = rest - (rest/k)*(k-1)
+		}
+		if s > 0 {
+			sizes = append(sizes, s)
+		}
+	}
+	return sizes
+}
+
+// buildPlantedGraph materialises a plantedSpec as a weighted undirected gonum
+// graph. Deterministic for a given seed.
+func buildPlantedGraph(spec plantedSpec) *simple.WeightedUndirectedGraph {
+	rng := rand.New(rand.NewPCG(spec.Seed, spec.Seed^0x9e3779b9))
+	und := simple.NewWeightedUndirectedGraph(0, 0)
+
+	// Assign node ids per community.
+	var n int
+	for _, s := range spec.Sizes {
+		n += s
+	}
+	for i := 0; i < n; i++ {
+		und.AddNode(simple.Node(int64(i)))
+	}
+	starts := make([]int, len(spec.Sizes))
+	acc := 0
+	for i, s := range spec.Sizes {
+		starts[i] = acc
+		acc += s
+	}
+
+	addEdge := func(u, v int, w float64) {
+		if u == v {
+			return
+		}
+		if e := und.WeightedEdge(int64(u), int64(v)); e != nil {
+			nw := e.Weight() + w
+			und.RemoveEdge(int64(u), int64(v))
+			und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(int64(u)), simple.Node(int64(v)), nw))
+			return
+		}
+		und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(int64(u)), simple.Node(int64(v)), w))
+	}
+
+	for ci, size := range spec.Sizes {
+		if size < 2 {
+			continue
+		}
+		start := starts[ci]
+		// Ring backbone guarantees connectivity within the community.
+		for i := 0; i < size; i++ {
+			addEdge(start+i, start+(i+1)%size, 1.0)
+		}
+		extra := size * spec.IntraDeg / 2
+		for e := 0; e < extra; e++ {
+			u := start + int(rng.Uint64N(uint64(size)))
+			v := start + int(rng.Uint64N(uint64(size)))
+			addEdge(u, v, 1.0+float64(rng.Uint64N(3)))
+		}
+	}
+	for e := 0; e < spec.InterEdges; e++ {
+		u := int(rng.Uint64N(uint64(n)))
+		v := int(rng.Uint64N(uint64(n)))
+		addEdge(u, v, 1.0)
+	}
+	return und
+}
+
+// defaultPlanted returns the standard test fixture at size n.
+//
+// NOTE its limits: IntraDeg=6 with only n/4 inter-community edges converges in
+// 8-10 local-moving sweeps at ANY size, so this family cannot exercise the
+// louvainMaxSweeps truncation bound. plantedSizes reproduces the corpus's
+// community-size skew but not its degree heavy tail. Use buildBarabasiAlbert
+// for anything that depends on convergence behaviour.
+func defaultPlanted(n int, seed uint64) *simple.WeightedUndirectedGraph {
+	return buildPlantedGraph(plantedSpec{
+		Sizes:      plantedSizes(n),
+		IntraDeg:   6,
+		InterEdges: n / 4,
+		Seed:       seed,
+	})
+}
+
+// buildBarabasiAlbert generates a scale-free graph by preferential attachment:
+// each new node attaches m edges to existing nodes chosen with probability
+// proportional to degree. Deterministic for a given seed.
+//
+// This is the shape a real code graph has — a power-law degree tail with a few
+// very-high-degree hubs — and unlike the planted fixtures it needs HUNDREDS of
+// local-moving sweeps to converge. It has no planted community structure at
+// all, so it is also the honest test of whether the implementation finds
+// structure comparable to gonum's where none was designed in.
+func buildBarabasiAlbert(n, m int, seed uint64) *simple.WeightedUndirectedGraph {
+	rng := rand.New(rand.NewPCG(seed, seed^0xdeadbeef))
+	und := simple.NewWeightedUndirectedGraph(0, 0)
+	for i := 0; i < n; i++ {
+		und.AddNode(simple.Node(int64(i)))
+	}
+	if m < 1 {
+		m = 1
+	}
+	// targets is the degree-weighted urn: each node appears once per incident
+	// edge endpoint, so a uniform draw is a preferential-attachment draw.
+	targets := make([]int, 0, 2*n*m)
+	// Seed core: a small clique so the urn is non-empty.
+	for i := 0; i <= m; i++ {
+		for j := i + 1; j <= m && j < n; j++ {
+			und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(int64(i)), simple.Node(int64(j)), 1))
+			targets = append(targets, i, j)
+		}
+	}
+	for v := m + 1; v < n; v++ {
+		chosen := make(map[int]bool, m)
+		for len(chosen) < m && len(targets) > 0 {
+			u := targets[rng.Uint64N(uint64(len(targets)))]
+			if u == v {
+				continue
+			}
+			chosen[u] = true
+		}
+		picks := make([]int, 0, len(chosen))
+		for u := range chosen {
+			picks = append(picks, u)
+		}
+		sort.Ints(picks) // determinism: map iteration order is not stable
+		for _, u := range picks {
+			und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(int64(u)), simple.Node(int64(v)), 1))
+			targets = append(targets, u, v)
+		}
+	}
+	return und
+}
+
+// ---------------------------------------------------------------------------
+// Modularity helper (independent of the implementation under test)
+// ---------------------------------------------------------------------------
+
+// modularityOfGroups computes Q for a partition given as node-id groups,
+// straight from the definition:
+//
+//	Q = Σ_c [ in_c/(2m) - γ (tot_c/(2m))² ]
+//
+// where in_c counts intra-community edge weight twice.
+func modularityOfGroups(und *simple.WeightedUndirectedGraph, groups [][]int64, resolution float64) float64 {
+	commOf := make(map[int64]int, 1024)
+	for c, g := range groups {
+		for _, id := range g {
+			commOf[id] = c
+		}
+	}
+	deg := make(map[int64]float64, len(commOf))
+	in := make([]float64, len(groups))
+	var m2 float64
+	it := und.WeightedEdges()
+	if it != nil {
+		for it.Next() {
+			e := it.WeightedEdge()
+			u, v, w := e.From().ID(), e.To().ID(), e.Weight()
+			deg[u] += w
+			deg[v] += w
+			m2 += 2 * w
+			if cu, ok := commOf[u]; ok {
+				if cv, ok2 := commOf[v]; ok2 && cu == cv {
+					in[cu] += 2 * w
+				}
+			}
+		}
+	}
+	if m2 == 0 {
+		return 0
+	}
+	tot := make([]float64, len(groups))
+	for c, g := range groups {
+		for _, id := range g {
+			tot[c] += deg[id]
+		}
+	}
+	var q float64
+	for c := range groups {
+		q += in[c]/m2 - resolution*(tot[c]/m2)*(tot[c]/m2)
+	}
+	return q
+}
+
+func gonumGroups(und *simple.WeightedUndirectedGraph, resolution float64) [][]int64 {
+	src := rand.NewPCG(1, 2)
+	reduced := community.Modularize(und, resolution, src)
+	var out [][]int64
+	for _, g := range reduced.Communities() {
+		ids := make([]int64, 0, len(g))
+		for _, n := range g {
+			ids = append(ids, n.ID())
+		}
+		sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+		out = append(out, ids)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Correctness
+// ---------------------------------------------------------------------------
+
+// TestLouvainPartitionIsAPartition — every node appears in exactly one group.
+func TestLouvainPartitionIsAPartition(t *testing.T) {
+	t.Parallel()
+	und := defaultPlanted(2000, 7)
+	groups := louvainPartition(und, 1.0)
+
+	seen := make(map[int64]int)
+	for _, g := range groups {
+		for _, id := range g {
+			seen[id]++
+		}
+	}
+	nodes := und.Nodes()
+	count := 0
+	for nodes.Next() {
+		count++
+		id := nodes.Node().ID()
+		if seen[id] != 1 {
+			t.Fatalf("node %d appears %d times in the partition, want 1", id, seen[id])
+		}
+	}
+	if len(seen) != count {
+		t.Fatalf("partition covers %d nodes, graph has %d", len(seen), count)
+	}
+}
+
+// TestLouvainRecoversPlantedCommunities — on a graph with obvious block
+// structure the partition must recover it: two nodes planted together should
+// (overwhelmingly) land together.
+func TestLouvainRecoversPlantedCommunities(t *testing.T) {
+	t.Parallel()
+	sizes := []int{100, 100, 100, 100}
+	und := buildPlantedGraph(plantedSpec{Sizes: sizes, IntraDeg: 8, InterEdges: 20, Seed: 3})
+	groups := louvainPartition(und, 1.0)
+
+	commOf := map[int64]int{}
+	for c, g := range groups {
+		for _, id := range g {
+			commOf[id] = c
+		}
+	}
+	// Each planted block should be dominated by a single detected community.
+	start := 0
+	for bi, s := range sizes {
+		counts := map[int]int{}
+		for i := start; i < start+s; i++ {
+			counts[commOf[int64(i)]]++
+		}
+		best := 0
+		for _, v := range counts {
+			if v > best {
+				best = v
+			}
+		}
+		if float64(best)/float64(s) < 0.9 {
+			t.Errorf("planted block %d: dominant community holds only %d/%d nodes", bi, best, s)
+		}
+		start += s
+	}
+}
+
+// TestLouvainTinyGraphs — degenerate inputs must not panic and must produce
+// sane partitions.
+func TestLouvainTinyGraphs(t *testing.T) {
+	t.Parallel()
+	t.Run("empty", func(t *testing.T) {
+		und := simple.NewWeightedUndirectedGraph(0, 0)
+		if g := louvainPartition(und, 1.0); len(g) != 0 {
+			t.Fatalf("empty graph produced %d groups", len(g))
+		}
+	})
+	t.Run("isolated nodes only", func(t *testing.T) {
+		und := simple.NewWeightedUndirectedGraph(0, 0)
+		for i := 0; i < 5; i++ {
+			und.AddNode(simple.Node(int64(i)))
+		}
+		g := louvainPartition(und, 1.0)
+		if len(g) != 5 {
+			t.Fatalf("5 isolated nodes -> %d groups, want 5 singletons", len(g))
+		}
+	})
+	t.Run("single edge", func(t *testing.T) {
+		und := simple.NewWeightedUndirectedGraph(0, 0)
+		und.SetWeightedEdge(und.NewWeightedEdge(simple.Node(0), simple.Node(1), 1))
+		g := louvainPartition(und, 1.0)
+		if len(g) != 1 || len(g[0]) != 2 {
+			t.Fatalf("single edge -> %v, want one group of 2", g)
+		}
+	})
+}
+
+// TestLouvainDeterminism — same input, same output, run to run. Run with
+// -race -count=2 in CI.
+func TestLouvainDeterminism(t *testing.T) {
+	t.Parallel()
+	und := defaultPlanted(3000, 11)
+	want := louvainPartition(und, 1.0)
+	for run := 0; run < 3; run++ {
+		got := louvainPartition(und, 1.0)
+		if len(got) != len(want) {
+			t.Fatalf("run %d: %d groups, want %d", run, len(got), len(want))
+		}
+		for c := range want {
+			if len(got[c]) != len(want[c]) {
+				t.Fatalf("run %d: group %d size %d, want %d", run, c, len(got[c]), len(want[c]))
+			}
+			for i := range want[c] {
+				if got[c][i] != want[c][i] {
+					t.Fatalf("run %d: group %d member %d = %d, want %d", run, c, i, got[c][i], want[c][i])
+				}
+			}
+		}
+	}
+}
+
+// TestLouvainMemberOrderIsSorted — members are emitted in ascending node-id
+// order, and groups in ascending lowest-member order. Downstream code sorts
+// again, but the contract is asserted here.
+func TestLouvainMemberOrderIsSorted(t *testing.T) {
+	t.Parallel()
+	groups := louvainPartition(defaultPlanted(1000, 5), 1.0)
+	prevMin := int64(-1)
+	for c, g := range groups {
+		if !sort.SliceIsSorted(g, func(i, j int) bool { return g[i] < g[j] }) {
+			t.Fatalf("group %d members not sorted: %v", c, g)
+		}
+		if g[0] <= prevMin {
+			t.Fatalf("group %d lowest member %d <= previous group's %d", c, g[0], prevMin)
+		}
+		prevMin = g[0]
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Modularity parity with gonum — THE quality gate
+// ---------------------------------------------------------------------------
+
+// modularityParityEpsilon is the tolerance on Q_new >= Q_gonum - eps. Louvain
+// is a heuristic; float summation order and tie-breaks differ, so exact
+// equality is not the contract. Partition QUALITY is.
+const modularityParityEpsilon = 0.01
+
+func TestLouvainModularityParityWithGonum(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		und  *simple.WeightedUndirectedGraph
+	}{
+		{"planted-1k-corpus-shape", defaultPlanted(1000, 1)},
+		{"planted-4k-corpus-shape", defaultPlanted(4000, 2)},
+		{"planted-uniform-blocks", buildPlantedGraph(plantedSpec{
+			Sizes: []int{250, 250, 250, 250, 250, 250, 250, 250}, IntraDeg: 6, InterEdges: 400, Seed: 4,
+		})},
+		{"planted-one-giant-community", buildPlantedGraph(plantedSpec{
+			Sizes: []int{1500, 100, 100, 100, 100, 50, 50}, IntraDeg: 6, InterEdges: 300, Seed: 5,
+		})},
+		{"sparse-weak-structure", buildPlantedGraph(plantedSpec{
+			Sizes: []int{300, 300, 300}, IntraDeg: 2, InterEdges: 900, Seed: 6,
+		})},
+		// Scale-free, no planted structure, hard-convergence regime (hundreds
+		// of sweeps). The planted fixtures above all converge in <10 sweeps and
+		// so cannot detect louvainMaxSweeps truncation; these can.
+		{"barabasi-albert-2k", buildBarabasiAlbert(2000, 3, 41)},
+		{"barabasi-albert-8k", buildBarabasiAlbert(8000, 3, 42)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			qNew := modularityOfGroups(tc.und, louvainPartition(tc.und, 1.0), 1.0)
+			qOld := modularityOfGroups(tc.und, gonumGroups(tc.und, 1.0), 1.0)
+			t.Logf("Q_new=%.6f Q_gonum=%.6f delta=%+.6f", qNew, qOld, qNew-qOld)
+			if qNew < qOld-modularityParityEpsilon {
+				t.Errorf("modularity regression: Q_new=%.6f < Q_gonum=%.6f - %g", qNew, qOld, modularityParityEpsilon)
+			}
+		})
+	}
+}
+
+// TestLouvainResolutionParameterHasEffect — a higher resolution must not
+// produce fewer communities than a lower one (standard Louvain behaviour); the
+// parameter is genuinely threaded through.
+func TestLouvainResolutionParameterHasEffect(t *testing.T) {
+	t.Parallel()
+	und := defaultPlanted(2000, 9)
+	lo := len(louvainPartition(und, 0.5))
+	hi := len(louvainPartition(und, 4.0))
+	if hi <= lo {
+		t.Errorf("resolution 4.0 gave %d communities, resolution 0.5 gave %d — resolution has no effect", hi, lo)
+	}
+}
+
+// TestLouvainSweepCapIsNotBinding — louvainMaxSweeps is a TRUNCATION bound, not
+// a formality: on scale-free graphs level 0 needs hundreds of sweeps and the
+// count grows ~N^0.65. If the cap binds, the partition is silently cut off
+// mid-convergence and quality degrades by an amount that grows with n. That is
+// the one way this implementation can quietly cost MCP quality, so it is
+// asserted directly rather than inferred from modularity.
+func TestLouvainSweepCapIsNotBinding(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		und  *simple.WeightedUndirectedGraph
+	}{
+		{"barabasi-albert-2k", buildBarabasiAlbert(2000, 3, 41)},
+		{"barabasi-albert-8k", buildBarabasiAlbert(8000, 3, 42)},
+		{"barabasi-albert-16k", buildBarabasiAlbert(16000, 3, 43)},
+		{"planted-16k", defaultPlanted(16000, 44)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, sweeps := louvainPartitionWithSweeps(tc.und, 1.0)
+			t.Logf("sweeps per level: %v (cap %d)", sweeps, louvainMaxSweeps)
+			for lvl, s := range sweeps {
+				if s >= louvainMaxSweeps {
+					t.Errorf("level %d consumed %d sweeps and hit the cap (%d): the partition was "+
+						"TRUNCATED mid-convergence, not converged", lvl, s, louvainMaxSweeps)
+				}
+			}
+		})
+	}
+}
+
+// TestLouvainAggregationPreservesModularity — aggregating a level must not
+// change Q: collapsing each community into one node with the intra-community
+// weight as its self-loop is supposed to be exactly Q-preserving.
+//
+// This test exists specifically because selfw is otherwise WRITE-ONLY in the
+// production path: localMoving never reads it and computeDegrees is never
+// called on an aggregated graph, so dropping the 2*selfw term from
+// computeDegrees, or the internal/2 term from aggregate, leaves every other
+// assertion in this file bit-identical. An incorrect selfw would be silently
+// untestable — a trap for anyone later adding Leiden refinement or reading
+// selfw in the ΔQ expression.
+func TestLouvainAggregationPreservesModularity(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		und  *simple.WeightedUndirectedGraph
+	}{
+		{"planted-1k", defaultPlanted(1000, 61)},
+		{"planted-uniform", buildPlantedGraph(plantedSpec{
+			Sizes: []int{200, 200, 200, 200}, IntraDeg: 6, InterEdges: 300, Seed: 62,
+		})},
+		{"barabasi-albert-2k", buildBarabasiAlbert(2000, 3, 63)},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			g, _ := buildCSRFromUndirected(tc.und)
+			comm, nc, moved, _ := g.localMoving(1.0)
+			if !moved {
+				t.Skip("no moves at level 0; nothing to aggregate")
+			}
+			qBefore := csrModularity(g, comm, nc, 1.0)
+
+			agg := g.aggregate(comm, nc)
+
+			// Identity partition on the aggregated graph.
+			identity := make([]int32, agg.n)
+			for i := range identity {
+				identity[i] = int32(i)
+			}
+			qAfter := csrModularity(agg, identity, agg.n, 1.0)
+
+			if math.Abs(qBefore-qAfter) > 1e-9 {
+				t.Errorf("aggregation changed Q: before=%.12f after=%.12f delta=%.3e",
+					qBefore, qAfter, qAfter-qBefore)
+			}
+
+			// The degree invariant k[c] == Σ incident w + 2*selfw[c] is what
+			// makes selfw load-bearing; assert it on the aggregated graph,
+			// which is the only place self-loops are ever non-zero.
+			var anySelf bool
+			for c := 0; c < agg.n; c++ {
+				var inc float64
+				for p := agg.off[c]; p < agg.off[c+1]; p++ {
+					inc += agg.w[p]
+				}
+				if agg.selfw[c] != 0 {
+					anySelf = true
+				}
+				if got, want := agg.k[c], inc+2*agg.selfw[c]; math.Abs(got-want) > 1e-9 {
+					t.Fatalf("aggregated node %d: k=%.12f but Σw+2*selfw=%.12f", c, got, want)
+				}
+			}
+			if !anySelf {
+				t.Error("aggregated graph has no self-loops at all — the fixture is not exercising selfw")
+			}
+			if math.Abs(agg.m2-g.m2) > 1e-9 {
+				t.Errorf("aggregation changed total weight: m2 %.12f -> %.12f", g.m2, agg.m2)
+			}
+		})
+	}
+}
+
+// TestCSRComputeDegreesCountsSelfLoopsTwice — computeDegrees is only ever
+// called on the level-0 graph, where simple.WeightedUndirectedGraph guarantees
+// selfw is all-zero, so its `2*selfw` term is unreachable in production and
+// deleting it changes nothing observable. That makes it a live trap: the term
+// is REQUIRED the moment anyone calls computeDegrees on an aggregated graph
+// (e.g. adding Leiden refinement). Pin the contract on a hand-built CSR graph
+// with non-zero self-loops.
+func TestCSRComputeDegreesCountsSelfLoopsTwice(t *testing.T) {
+	t.Parallel()
+	// Two nodes, one edge of weight 3 between them; self-loops 5 and 7.
+	g := &csrGraph{
+		n:     2,
+		off:   []int32{0, 1, 2},
+		adj:   []int32{1, 0},
+		w:     []float64{3, 3},
+		selfw: []float64{5, 7},
+		k:     make([]float64, 2),
+	}
+	g.computeDegrees()
+
+	// A self-loop contributes both of its endpoints to the node's degree.
+	if want := 3 + 2*5.0; g.k[0] != want {
+		t.Errorf("k[0] = %v, want %v (edge 3 + twice the self-loop 5)", g.k[0], want)
+	}
+	if want := 3 + 2*7.0; g.k[1] != want {
+		t.Errorf("k[1] = %v, want %v (edge 3 + twice the self-loop 7)", g.k[1], want)
+	}
+	if want := (3 + 10.0) + (3 + 14.0); g.m2 != want {
+		t.Errorf("m2 = %v, want %v", g.m2, want)
+	}
+}
+
+// csrModularity computes Q directly from a CSR graph and a labelling, honouring
+// self-loops. Independent of louvainPartition's own bookkeeping.
+func csrModularity(g *csrGraph, comm []int32, nc int, resolution float64) float64 {
+	if g.m2 <= 0 {
+		return 0
+	}
+	in := make([]float64, nc)  // intra-community weight, counted twice
+	tot := make([]float64, nc) // Σ k over members
+	for u := 0; u < g.n; u++ {
+		c := comm[u]
+		tot[c] += g.k[u]
+		in[c] += 2 * g.selfw[u] // a self-loop is entirely internal
+		for p := g.off[u]; p < g.off[u+1]; p++ {
+			if comm[g.adj[p]] == c {
+				in[c] += g.w[p] // each intra edge is seen from both endpoints
+			}
+		}
+	}
+	var q float64
+	for c := 0; c < nc; c++ {
+		q += in[c]/g.m2 - resolution*(tot[c]/g.m2)*(tot[c]/g.m2)
+	}
+	return q
+}
+
+// ---------------------------------------------------------------------------
+// Scaling
+// ---------------------------------------------------------------------------
+
+// TestLouvainScalingExponent — the whole point of this change. gonum's local
+// mover scales ~N^1.8 because a sweep costs Σ|c|²; the neighbour-side
+// formulation costs O(E) per sweep, i.e. ~N^1.0-1.2 on a fixed-degree family.
+//
+// Pinning the EXPONENT rather than a wall-clock threshold is deliberate: a
+// fixed threshold passes on a fast machine even after an asymptotic
+// regression, an exponent does not.
+func TestLouvainScalingExponent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("scaling fit is slow; skipped under -short")
+	}
+	sizes := []int{8000, 16000, 32000, 64000}
+	var logN, logT []float64
+	for _, n := range sizes {
+		und := defaultPlanted(n, 21)
+		// Warm up allocator/page cache, then take the best of 3 to damp noise.
+		best := time.Duration(math.MaxInt64)
+		for r := 0; r < 3; r++ {
+			start := time.Now()
+			louvainPartition(und, 1.0)
+			if d := time.Since(start); d < best {
+				best = d
+			}
+		}
+		t.Logf("n=%-6d louvain=%v", n, best)
+		logN = append(logN, math.Log(float64(n)))
+		logT = append(logT, math.Log(float64(best.Nanoseconds())))
+	}
+	exp := leastSquaresSlope(logN, logT)
+	t.Logf("fitted scaling exponent: N^%.2f", exp)
+	if exp > 1.45 {
+		t.Errorf("scaling exponent N^%.2f exceeds 1.45 — the O(E)-per-sweep property has regressed", exp)
+	}
+}
+
+// leastSquaresSlope fits y = a + b*x and returns b.
+func leastSquaresSlope(x, y []float64) float64 {
+	n := float64(len(x))
+	var sx, sy, sxy, sxx float64
+	for i := range x {
+		sx += x[i]
+		sy += y[i]
+		sxy += x[i] * y[i]
+		sxx += x[i] * x[i]
+	}
+	den := n*sxx - sx*sx
+	if den == 0 {
+		return 0
+	}
+	return (n*sxy - sx*sy) / den
+}
+
+// ---------------------------------------------------------------------------
+// Benchmarks
+// ---------------------------------------------------------------------------
+
+func benchLouvainSizes() []int { return []int{2000, 8000, 32000} }
+
+// BenchmarkLouvainNew measures the in-repo implementation on corpus-shaped
+// planted partitions (one community holding ~25% of the nodes).
+func BenchmarkLouvainNew(b *testing.B) {
+	for _, n := range benchLouvainSizes() {
+		und := defaultPlanted(n, 31)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				louvainPartition(und, 1.0)
+			}
+		})
+	}
+}
+
+// BenchmarkLouvainGonum is the baseline: gonum's community.Modularize on the
+// exact same graphs. Kept so the comparison can be re-run at any time.
+func BenchmarkLouvainGonum(b *testing.B) {
+	for _, n := range benchLouvainSizes() {
+		und := defaultPlanted(n, 31)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				gonumGroups(und, 1.0)
+			}
+		})
+	}
+}
+
+// BenchmarkLouvainNewScaleFree / BenchmarkLouvainGonumScaleFree measure the
+// hard-convergence regime the planted fixtures never reach: scale-free graphs
+// need hundreds of local-moving sweeps, so these are where louvainMaxSweeps
+// headroom actually costs time. Reported separately from the planted numbers so
+// the speedup claim is not quoted from the easy family alone.
+func BenchmarkLouvainNewScaleFree(b *testing.B) {
+	for _, n := range benchLouvainSizes() {
+		und := buildBarabasiAlbert(n, 3, 37)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				louvainPartition(und, 1.0)
+			}
+		})
+	}
+}
+
+func BenchmarkLouvainGonumScaleFree(b *testing.B) {
+	for _, n := range benchLouvainSizes() {
+		und := buildBarabasiAlbert(n, 3, 37)
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				gonumGroups(und, 1.0)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Replaces gonum's `community.Modularize` with an in-repo Louvain using the standard formulation. Same algorithm, same multi-level structure, same resolution parameter — computed the way the literature specifies rather than the way gonum chose.

## Why

Community detection was **3h15m** on a 427k-entity / 1.85M-relationship corpus — 99.5% of the entire indexing pipeline. Betweenness, long assumed to be the cost centre, is **8 seconds**.

The cost is in gonum's `deltaQ` (`graph/community/louvain_undirected.go:530-585`). To evaluate moving node *i* into community *C* it **iterates every member of C**:

```go
for _, u := range c {                    // every member
    k_aC       += l.weight(id, uid)      // map[[2]int]float64, 1.85M entries (~100MB) => L3 miss
    sigma_totC += l.edgeWeightOf[uid]
}
```

So one sweep costs `Σ_c |c|²`, with no sweep or level cap. gonum's own comment at `:578-583` acknowledges the O(1) alternative and declines it as "not compelling" — at this scale it is very compelling.

The measured partition explains why: 68 communities, largest **109,091 nodes** (25% of the graph), `Σ|c|² = 2.749e10`. That one community is ~43% of the total cost.

## The three mechanisms

1. **Incremental `sigmaTot[c]`** — a running per-community total updated in O(1) on every move. Never rescan a community.
2. **Neighbour-side `k_{i,C}`** — computed by iterating node *i*'s neighbours (degree ~4-10) into a scratch array indexed by community, with an O(deg) monotone-stamp reset. Never iterate membership.
3. **Flat CSR** — `[]int32` offsets/targets + `[]float64` weights, self-loops held separately, replacing the 100MB map.

Per sweep: `Σ|c|²` (2.75e10) → `O(E)` (1.85e6), and each operation ~14× cheaper.

## Benchmarks

Scale-free (Barabási-Albert) graphs are the shape a real code graph has — import/call fan-in produces heavy-tailed degree — and that is where the win lands:

| n | gonum planted | new planted | gonum BA | new BA |
|---|---|---|---|---|
| 2000 | 33.8ms | 3.6ms (9.5×) | 187.8ms | 4.7ms (**39.7×**) |
| 8000 | 251.6ms | 15.8ms (15.9×) | 2436.5ms | 37.9ms (**64.2×**) |
| 32000 | 2523.6ms | 65.8ms (38.4×) | 18741.7ms | 426.4ms (**44.0×**) |

Fitted exponent **N^1.61 → N^1.13**. Allocations at BA-32k: 1340MB / 9.25M → 24MB / 43k.

The scaling exponent is asserted by a test, not a wall-clock threshold, so a future regression that changes the complexity class fails even on faster hardware.

## Quality is preserved — this is the part that matters

Gate: `Q_new >= Q_gonum - 0.01`. Across 11 fixtures including power-law community sizes, power-law degrees, explicit bridging hubs, skewed weights, and pure Barabási-Albert with no planted structure at all:

- worst case **−0.0048**, half the gate
- the new implementation **wins on 4 of 9** of the reviewer's hard fixtures, including both unstructured scale-free graphs

ΔQ verified against brute force (400 random node/community pairs, full Q recomputation before and after each move) to <1e-9, including a hand-built CSR graph with non-zero self-loops. Aggregation verified to preserve Q exactly. CSR symmetry, sorting, and degree invariants asserted directly.

The modularity oracle is independent of the implementation, and the reviewer wrote a *second* structurally-different oracle to rule out circularity — all 18 pairs agreed to <1e-9.

**Determinism is preserved and is now structural rather than seeded** — the `rand` source is gone. Ascending node-id indexing, adjacency sorted by target, ascending sweep order, ties to the lowest community index. A full-assignment diff of two in-process runs on a 20k fixture is byte-identical.

## What legitimately changes

Community **membership** shifts, even where quality is equal — near-equal Q does not mean a near-equal partition. On one fixture the largest community went 547 → 1178 nodes at a Q delta of −0.0012. This is inherent to swapping Louvain implementations. Expect `grafel_clusters` output to look different.

`find` / `expand` / `traces` / `find_callers` are unaffected — those files contain zero references to `CommunityID`.

**No goldens needed re-baselining.** This was checked rather than assumed: no assertion in the repo pins detector-produced output. `pr_impact_test.go`, `orientation_test.go` and `community_names_test.go` all feed hand-authored `CommunityID` values and never invoke the detector. The suite does constrain quality from both sides — `algorithms_test.go:68` requires a split, `groupalgo_test.go:134-166` requires a community to span both repos — and both still pass.

`CommunityInputHash`'s contract text is corrected: "same hash ⇒ byte-identical output" holds across two runs of the *same build*, not across builds. Cross-build invalidation is handled by `OverlayAlgoVersion` (#6007).

## `louvainMaxSweeps`

Raised 100 → 1000. Review found the old cap **binding on realistic input**: scale-free graphs need 117 sweeps at n=8k, 266 at 32k, 387 at 128k (~N^0.65), while clean planted fixtures converge in ~10 at any size — which is why the original fixtures never caught it.

Deliberately **not** justified as a quality win. Measured Q at cap=100 vs cap=1000 came out with *opposite signs* on different fixture families (−0.004 one way, −0.001 the other), both inside ±0.005: the cap's quality effect is noise, not a mechanism. The real justification is well-definedness — "Louvain run to convergence" depends only on the graph, whereas "Louvain truncated at 100" makes the partition a function of an arbitrary constant that drifts with corpus size. Cost of the change: BA-128k 944ms → 3.26s.

The termination argument is stated honestly rather than overclaimed: the tie branch assigns `bestGain = gain`, so `bestGain` can ratchet down by up to `louvainMinGain` per tie; Q is therefore not strictly monotone and the caps are the real backstop. No cycle was constructible or observed.

## Known coverage note

`selfw` is write-only in the production path (level 0 has no self-loops; `aggregate` sets `k` directly), so an incorrect `selfw` was undetectable. Two tests now close that: an aggregation-invariant test and a direct `computeDegrees` unit test on a hand-built CSR graph with self-loops.

## Not in scope

Betweenness / PageRank / articulation points (8s total) untouched, including the 512-pivot sampling gate. No hub-node pruning — that changes which entities receive a community and is a separate product decision. Non-local-optimality of the final partition is symmetric with gonum (+0.03 refinement gain on both) — the known Louvain deficiency Leiden addresses.

Independently adversarially reviewed.

Refs #5954
