### PR TITLE
perf(#5954): stop re-inflating compacted entity properties into a map in the link pass

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -12,6 +12,8 @@ import (
 	"path/filepath"
 	"sort"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // SchemaVersion is the integer version of the on-disk graph.json schema.
@@ -416,6 +418,23 @@ func (e Entity) PropLen() int {
 // internal storage.
 func (e Entity) PropsSnapshot() map[string]string {
 	return propsToMap(e.properties)
+}
+
+// PropsClone returns an independent copy of the properties as a types.Props,
+// or nil if there are none. It is the map-free counterpart of PropsSnapshot:
+// both graph's internal propKV and types.PropKV are the same sorted key/value
+// pair shape, so this is one exact-sized slice allocation with no hmap header
+// or bucket. Callers that only need keyed reads should prefer this over
+// PropsSnapshot — at group-union scale the map header dominates (#5954).
+func (e Entity) PropsClone() types.Props {
+	if len(e.properties) == 0 {
+		return nil
+	}
+	out := make(types.Props, len(e.properties))
+	for i, kv := range e.properties {
+		out[i] = types.PropKV{K: kv.K, V: kv.V}
+	}
+	return out
 }
 
 // WithProperties returns a copy of e with its properties replaced by props,

--- a/internal/links/complexity_pass.go
+++ b/internal/links/complexity_pass.go
@@ -29,6 +29,8 @@ import (
 	"sort"
 
 	"github.com/cajasmota/grafel/internal/substrate"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodComplexity identifies this pass in telemetry.
@@ -89,12 +91,12 @@ func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 			}
 			res.Candidates++
 			if e.Properties == nil {
-				e.Properties = map[string]string{}
+				e.Properties = types.Props{}
 			}
 			// Idempotent: if a prior path (e.g. the data-flow pass for a bound
 			// handler) already stamped complexity, leave it — both paths call the
 			// same ComputeFunctionComplexity, so the value is identical anyway.
-			if _, ok := e.Properties[ComplexityPropertyKeyCyclomatic]; ok {
+			if _, ok := e.Properties.Lookup(ComplexityPropertyKeyCyclomatic); ok {
 				continue
 			}
 			content := readFile(e.SourceFile)
@@ -106,8 +108,8 @@ func runComplexityPass(graphs []repoGraph, _ Paths) (PassResult, error) {
 				continue
 			}
 			cx := substrate.ComputeFunctionComplexity(win)
-			e.Properties[ComplexityPropertyKeyCyclomatic] = fmt.Sprintf("%d", cx.Cyclomatic)
-			e.Properties[ComplexityPropertyKeyBranchCount] = fmt.Sprintf("%d", cx.BranchCount)
+			e.Properties.Set(ComplexityPropertyKeyCyclomatic, fmt.Sprintf("%d", cx.Cyclomatic))
+			e.Properties.Set(ComplexityPropertyKeyBranchCount, fmt.Sprintf("%d", cx.BranchCount))
 			stamped++
 		}
 	}

--- a/internal/links/complexity_pass_test.go
+++ b/internal/links/complexity_pass_test.go
@@ -2,6 +2,8 @@ package links
 
 import (
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // runComplexityForTest runs the universal complexity pass over a single in-memory
@@ -50,10 +52,10 @@ func computeScore(a, b int) int { // line 3
 	}})
 
 	e := g.Entities[0]
-	if got := e.Properties[ComplexityPropertyKeyCyclomatic]; got != "4" {
+	if got := e.Properties.Get(ComplexityPropertyKeyCyclomatic); got != "4" {
 		t.Fatalf("cyclomatic_complexity = %q, want 4", got)
 	}
-	if got := e.Properties[ComplexityPropertyKeyBranchCount]; got != "3" {
+	if got := e.Properties.Get(ComplexityPropertyKeyBranchCount); got != "3" {
 		t.Fatalf("branch_count = %q, want 3", got)
 	}
 }
@@ -63,10 +65,10 @@ func computeScore(a, b int) int { // line 3
 // truth and preventing double-counting.
 func TestComplexityPass_Idempotent(t *testing.T) {
 	src := "func f() { if x { return } }\n"
-	pre := map[string]string{
+	pre := types.PropsFromMap(map[string]string{
 		ComplexityPropertyKeyCyclomatic:  "99",
 		ComplexityPropertyKeyBranchCount: "98",
-	}
+	})
 	g := runComplexityForTest(t, "f.go", src, []entityNode{{
 		ID:         "fn:f",
 		Name:       "f",
@@ -76,7 +78,7 @@ func TestComplexityPass_Idempotent(t *testing.T) {
 		EndLine:    1,
 		Properties: pre,
 	}})
-	if got := g.Entities[0].Properties[ComplexityPropertyKeyCyclomatic]; got != "99" {
+	if got := g.Entities[0].Properties.Get(ComplexityPropertyKeyCyclomatic); got != "99" {
 		t.Fatalf("idempotency broken: cyclomatic_complexity = %q, want preserved 99", got)
 	}
 }
@@ -92,7 +94,7 @@ func TestComplexityPass_NoSourceLineInfoSkipped(t *testing.T) {
 		SourceFile: "f.go",
 		StartLine:  0, // unknown
 	}})
-	if _, ok := g.Entities[0].Properties[ComplexityPropertyKeyCyclomatic]; ok {
+	if _, ok := g.Entities[0].Properties.Lookup(ComplexityPropertyKeyCyclomatic); ok {
 		t.Fatal("expected no complexity property when StartLine is unknown")
 	}
 }
@@ -108,7 +110,7 @@ func TestComplexityPass_NonFunctionKindSkipped(t *testing.T) {
 		StartLine:  1,
 		EndLine:    1,
 	}})
-	if _, ok := g.Entities[0].Properties[ComplexityPropertyKeyCyclomatic]; ok {
+	if _, ok := g.Entities[0].Properties.Lookup(ComplexityPropertyKeyCyclomatic); ok {
 		t.Fatal("expected no complexity property on a non-function entity")
 	}
 }

--- a/internal/links/constant_propagation.go
+++ b/internal/links/constant_propagation.go
@@ -462,14 +462,14 @@ func applyResolverToConsumerHTTP(graphs []repoGraph, resolver *Resolver) int {
 			if e.Properties == nil {
 				continue
 			}
-			if e.Properties["url_kind"] != "dynamic_baseurl" {
+			if e.Properties.Get("url_kind") != "dynamic_baseurl" {
 				continue
 			}
-			callerFile := e.Properties["caller_file"]
+			callerFile := e.Properties.Get("caller_file")
 			if callerFile == "" {
 				callerFile = e.SourceFile
 			}
-			path := e.Properties["path"]
+			path := e.Properties.Get("path")
 			if path == "" {
 				continue
 			}
@@ -487,11 +487,11 @@ func applyResolverToConsumerHTTP(graphs []repoGraph, resolver *Resolver) int {
 			if replaced == "" || replaced[0] != '/' {
 				replaced = "/" + replaced
 			}
-			e.Properties["path"] = replaced
-			e.Properties["url_kind"] = "literal"
-			e.Properties["substrate_resolved_value"] = rr.Value
-			e.Properties["substrate_resolved_via"] = joinSteps(rr.Steps)
-			e.Properties["substrate_confidence"] = fmt.Sprintf("%.2f", rr.Confidence)
+			e.Properties.Set("path", replaced)
+			e.Properties.Set("url_kind", "literal")
+			e.Properties.Set("substrate_resolved_value", rr.Value)
+			e.Properties.Set("substrate_resolved_via", joinSteps(rr.Steps))
+			e.Properties.Set("substrate_confidence", fmt.Sprintf("%.2f", rr.Confidence))
 			mutated++
 		}
 	}

--- a/internal/links/constant_propagation_test.go
+++ b/internal/links/constant_propagation_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 func writeFile(t *testing.T, dir, rel, content string) {
@@ -93,12 +95,12 @@ fetch(`+"`"+`${apiUrl}/things`+"`"+`);
 				Name:       "GET /{apiUrl}/things",
 				Kind:       "http_endpoint_call",
 				SourceFile: "src/app.ts",
-				Properties: map[string]string{
+				Properties: types.PropsFromMap(map[string]string{
 					"verb":        "GET",
 					"path":        "/{apiUrl}/things",
 					"url_kind":    "dynamic_baseurl",
 					"caller_file": "src/app.ts",
-				},
+				}),
 			},
 		},
 	}}
@@ -111,13 +113,13 @@ fetch(`+"`"+`${apiUrl}/things`+"`"+`);
 		t.Fatalf("mutated = %d, want 1", mutated)
 	}
 	e := graphs[0].Entities[0]
-	if e.Properties["path"] != "/things" {
-		t.Errorf("rewritten path = %q, want /things", e.Properties["path"])
+	if e.Properties.Get("path") != "/things" {
+		t.Errorf("rewritten path = %q, want /things", e.Properties.Get("path"))
 	}
-	if e.Properties["url_kind"] != "literal" {
-		t.Errorf("url_kind = %q, want literal", e.Properties["url_kind"])
+	if e.Properties.Get("url_kind") != "literal" {
+		t.Errorf("url_kind = %q, want literal", e.Properties.Get("url_kind"))
 	}
-	if e.Properties["substrate_resolved_value"] != "https://api.example.com" {
+	if e.Properties.Get("substrate_resolved_value") != "https://api.example.com" {
 		t.Errorf("substrate_resolved_value missing or wrong: %+v", e.Properties)
 	}
 }

--- a/internal/links/dataflow_pass.go
+++ b/internal/links/dataflow_pass.go
@@ -536,21 +536,21 @@ func stampDataFlowSummary(g *repoGraph, entityID string, flows []substrate.DataF
 		}
 		e := &g.Entities[ei]
 		if e.Properties == nil {
-			e.Properties = map[string]string{}
+			e.Properties = types.Props{}
 		}
-		e.Properties[DataFlowPropertyKeyFlows] = formatDataFlowSummary(flows, maxDataFlowSummary)
-		e.Properties[DataFlowPropertyKeyCount] = fmt.Sprintf("%d", len(flows))
+		e.Properties.Set(DataFlowPropertyKeyFlows, formatDataFlowSummary(flows, maxDataFlowSummary))
+		e.Properties.Set(DataFlowPropertyKeyCount, fmt.Sprintf("%d", len(flows)))
 		// #4831: the universal complexity pass (runComplexityPass) is the single
 		// source of truth for cyclomatic_complexity / branch_count and runs BEFORE
 		// this pass, so the value is already stamped here. Defer to it idempotently
 		// — only fall back to stamping when it is somehow absent (e.g. an isolated
 		// test harness that invokes the data-flow pass alone). Both paths call the
 		// same ComputeFunctionComplexity, so the numbers can never diverge.
-		if _, ok := e.Properties[ComplexityPropertyKeyCyclomatic]; !ok {
+		if _, ok := e.Properties.Lookup(ComplexityPropertyKeyCyclomatic); !ok {
 			if win := functionSourceWindow(fileContent, e.StartLine, e.EndLine); win != "" {
 				cx := substrate.ComputeFunctionComplexity(win)
-				e.Properties[ComplexityPropertyKeyCyclomatic] = fmt.Sprintf("%d", cx.Cyclomatic)
-				e.Properties[ComplexityPropertyKeyBranchCount] = fmt.Sprintf("%d", cx.BranchCount)
+				e.Properties.Set(ComplexityPropertyKeyCyclomatic, fmt.Sprintf("%d", cx.Cyclomatic))
+				e.Properties.Set(ComplexityPropertyKeyBranchCount, fmt.Sprintf("%d", cx.BranchCount))
 			}
 		}
 		return

--- a/internal/links/def_use_pass.go
+++ b/internal/links/def_use_pass.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/substrate"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodDefUse identifies sidecar artefacts from this pass.
@@ -170,11 +172,11 @@ func runDefUsePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 					}
 					e := &g.Entities[ei]
 					if e.Properties == nil {
-						e.Properties = map[string]string{}
+						e.Properties = types.Props{}
 					}
 					summary := formatDefUseSummary(chains, maxPropertyChains)
-					e.Properties[DefUsePropertyKeyChains] = summary
-					e.Properties[DefUsePropertyKeyCount] = fmt.Sprintf("%d", len(chains))
+					e.Properties.Set(DefUsePropertyKeyChains, summary)
+					e.Properties.Set(DefUsePropertyKeyCount, fmt.Sprintf("%d", len(chains)))
 					allEntries = append(allEntries, defUseEntry{
 						Repo:       g.Repo,
 						EntityID:   eid,

--- a/internal/links/effect_propagation.go
+++ b/internal/links/effect_propagation.go
@@ -45,6 +45,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/substrate"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodEffectPropagation identifies sidecar artefacts produced by the
@@ -248,9 +250,9 @@ func runEffectPropagationPass(graphs []repoGraph, paths Paths, _ map[string]bool
 				continue
 			}
 			if e.Properties == nil {
-				e.Properties = map[string]string{}
+				e.Properties = types.Props{}
 			}
-			stampEffectProperties(e.Properties, *set, directByEntity[fullID] != nil, endpointDerived[fullID])
+			stampEffectProperties(&e.Properties, *set, directByEntity[fullID] != nil, endpointDerived[fullID])
 			stamped++
 		}
 	}
@@ -384,7 +386,7 @@ func propagateScheduledJobEffects(graphs []repoGraph, effects map[string]*substr
 			if !isScheduledJobKind(e.Kind) {
 				continue
 			}
-			handler := e.Properties["handler"]
+			handler := e.Properties.Get("handler")
 			if handler == "" {
 				continue
 			}
@@ -423,7 +425,7 @@ func propagateScheduledJobEffects(graphs []repoGraph, effects map[string]*substr
 // effect_source key, with endpoint taking precedence so an http_endpoint
 // reads as source="endpoint" rather than the underlying direct/transitive
 // shape of its handler.
-func stampEffectProperties(props map[string]string, set substrate.EffectSet, direct, endpoint bool) {
+func stampEffectProperties(props *types.Props, set substrate.EffectSet, direct, endpoint bool) {
 	effs := set.AsList()
 	if len(effs) == 0 {
 		return
@@ -438,18 +440,18 @@ func stampEffectProperties(props map[string]string, set substrate.EffectSet, dir
 			sinks = append(sinks, string(e)+":"+s)
 		}
 	}
-	props[EffectPropertyKeyList] = strings.Join(names, ",")
-	props[EffectPropertyKeyConfidence] = strings.Join(confs, ",")
+	props.Set(EffectPropertyKeyList, strings.Join(names, ","))
+	props.Set(EffectPropertyKeyConfidence, strings.Join(confs, ","))
 	if len(sinks) > 0 {
-		props[EffectPropertyKeySinks] = strings.Join(sinks, ",")
+		props.Set(EffectPropertyKeySinks, strings.Join(sinks, ","))
 	}
 	switch {
 	case endpoint:
-		props[EffectPropertyKeySource] = "endpoint"
+		props.Set(EffectPropertyKeySource, "endpoint")
 	case direct:
-		props[EffectPropertyKeySource] = "direct"
+		props.Set(EffectPropertyKeySource, "direct")
 	default:
-		props[EffectPropertyKeySource] = "transitive"
+		props.Set(EffectPropertyKeySource, "transitive")
 	}
 }
 
@@ -518,7 +520,7 @@ func newEffectBinder(graphs []repoGraph) *effectBinder {
 			// task-body def with that name exists in the file, the sniffer
 			// produces no match and nothing is fabricated.
 			if isScheduledJobKind(e.Kind) {
-				if h := e.Properties["handler"]; h != "" && h != e.Name {
+				if h := e.Properties.Get("handler"); h != "" && h != e.Name {
 					fileIdx[h] = append(fileIdx[h], e.ID)
 				}
 			}

--- a/internal/links/effect_propagation_test.go
+++ b/internal/links/effect_propagation_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // TestEffectPropagation_HandlerServiceRepoChain exercises the canonical
@@ -53,16 +55,16 @@ def handle(req):
 	}
 	// Look up the handler — should carry db_write transitively.
 	h := graphs[0].Entities[0]
-	effs := h.Properties[EffectPropertyKeyList]
+	effs := h.Properties.Get(EffectPropertyKeyList)
 	if !strings.Contains(effs, "db_write") {
 		t.Fatalf("handler effects=%q; want db_write", effs)
 	}
-	if got := h.Properties[EffectPropertyKeySource]; got != "transitive" {
+	if got := h.Properties.Get(EffectPropertyKeySource); got != "transitive" {
 		t.Errorf("handler effect_source=%q; want transitive", got)
 	}
 	// Repo should be the direct owner.
 	r := graphs[0].Entities[2]
-	if got := r.Properties[EffectPropertyKeySource]; got != "direct" {
+	if got := r.Properties.Get(EffectPropertyKeySource); got != "direct" {
 		t.Errorf("repo effect_source=%q; want direct", got)
 	}
 	// Sidecar written.
@@ -118,14 +120,14 @@ class ContractViewSet:
 		t.Fatal(err)
 	}
 	// Repo owns the direct db_read.
-	if got := graphs[0].Entities[2].Properties[EffectPropertyKeySource]; got != "direct" {
+	if got := graphs[0].Entities[2].Properties.Get(EffectPropertyKeySource); got != "direct" {
 		t.Errorf("repo effect_source=%q; want direct", got)
 	}
-	if effs := graphs[0].Entities[2].Properties[EffectPropertyKeyList]; !strings.Contains(effs, "db_read") {
+	if effs := graphs[0].Entities[2].Properties.Get(EffectPropertyKeyList); !strings.Contains(effs, "db_read") {
 		t.Fatalf("repo effects=%q; want db_read (the read sniffer must match self.queryset.filter)", effs)
 	}
 	// Controller inherits db_read transitively — the #4668 reach.
-	cEffs := graphs[0].Entities[0].Properties[EffectPropertyKeyList]
+	cEffs := graphs[0].Entities[0].Properties.Get(EffectPropertyKeyList)
 	if !strings.Contains(cEffs, "db_read") {
 		t.Fatalf("controller effects=%q; want db_read to reach the GET/list handler transitively", cEffs)
 	}
@@ -151,7 +153,7 @@ def add(a, b):
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v, ok := graphs[0].Entities[0].Properties[EffectPropertyKeyList]; ok {
+	if v, ok := graphs[0].Entities[0].Properties.Lookup(EffectPropertyKeyList); ok {
 		t.Errorf("pure function carries effects=%q; want unstamped", v)
 	}
 }
@@ -248,7 +250,7 @@ def persist_to_db(row):
 	if job == nil {
 		t.Fatal("process_job not stamped — qualified-name binding regression (#2804)")
 	}
-	effs := job[EffectPropertyKeyList]
+	effs := job.Get(EffectPropertyKeyList)
 	// Direct sinks on the task body.
 	for _, want := range []string{"http_out", "env_read"} {
 		if !strings.Contains(effs, want) {
@@ -262,7 +264,7 @@ def persist_to_db(row):
 		}
 	}
 	// Helper is the direct DB owner.
-	if got := graphs[0].Entities[1].Properties[EffectPropertyKeySource]; got != "direct" {
+	if got := graphs[0].Entities[1].Properties.Get(EffectPropertyKeySource); got != "direct" {
 		t.Errorf("persist_to_db effect_source=%q; want direct", got)
 	}
 }
@@ -299,7 +301,7 @@ def process_job(self, payload):
 		t.Fatal(err)
 	}
 	for _, ent := range graphs[0].Entities {
-		effs := ent.Properties[EffectPropertyKeyList]
+		effs := ent.Properties.Get(EffectPropertyKeyList)
 		if effs == "" {
 			t.Fatalf("%s node (%s) left unstamped — decorator-wrapper binding regression (#2804)", ent.Kind, ent.ID)
 		}
@@ -308,7 +310,7 @@ def process_job(self, payload):
 				t.Errorf("%s node effects=%q; want %q", ent.Kind, effs, want)
 			}
 		}
-		if got := ent.Properties[EffectPropertyKeySource]; got != "direct" {
+		if got := ent.Properties.Get(EffectPropertyKeySource); got != "direct" {
 			t.Errorf("%s node effect_source=%q; want direct", ent.Kind, got)
 		}
 	}
@@ -332,7 +334,7 @@ class BuildingViewSet:
 		Entities: []entityNode{
 			{ID: "h1", Name: "create", Kind: "SCOPE.Function", SourceFile: "views.py"},
 			{ID: "ep1", Name: "http:POST:/buildings", Kind: "http_endpoint", SourceFile: "views.py",
-				Properties: map[string]string{"verb": "POST", "path": "/buildings", "pattern_type": "http_endpoint_synthesis"}},
+				Properties: types.PropsFromMap(map[string]string{"verb": "POST", "path": "/buildings", "pattern_type": "http_endpoint_synthesis"})},
 		},
 		Edges: []edgeRef{
 			// handler → endpoint (producer-side IMPLEMENTS).
@@ -344,11 +346,11 @@ class BuildingViewSet:
 		t.Fatal(err)
 	}
 	ep := graphs[0].Entities[1]
-	effs := ep.Properties[EffectPropertyKeyList]
+	effs := ep.Properties.Get(EffectPropertyKeyList)
 	if !strings.Contains(effs, "db_write") {
 		t.Fatalf("endpoint effects=%q; want db_write inherited from handler", effs)
 	}
-	if got := ep.Properties[EffectPropertyKeySource]; got != "endpoint" {
+	if got := ep.Properties.Get(EffectPropertyKeySource); got != "endpoint" {
 		t.Errorf("endpoint effect_source=%q; want endpoint", got)
 	}
 	// Sidecar entry for the endpoint should also carry source=endpoint.
@@ -379,7 +381,7 @@ class HealthView:
 		Entities: []entityNode{
 			{ID: "h1", Name: "get", Kind: "SCOPE.Function", SourceFile: "ping.py"},
 			{ID: "ep1", Name: "http:GET:/health", Kind: "http_endpoint", SourceFile: "ping.py",
-				Properties: map[string]string{"verb": "GET", "path": "/health"}},
+				Properties: types.PropsFromMap(map[string]string{"verb": "GET", "path": "/health"})},
 		},
 		Edges: []edgeRef{
 			{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"},
@@ -388,7 +390,7 @@ class HealthView:
 	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
 		t.Fatal(err)
 	}
-	if v, ok := graphs[0].Entities[1].Properties[EffectPropertyKeyList]; ok {
+	if v, ok := graphs[0].Entities[1].Properties.Lookup(EffectPropertyKeyList); ok {
 		t.Errorf("endpoint with pure handler carries effects=%q; want unstamped", v)
 	}
 }
@@ -418,10 +420,10 @@ def send_me_notifications():
 			// The synthetic ScheduledJob node, as scheduled_jobs_edges.go emits
 			// it: Name is the celery job ID, the bare task name is in `handler`.
 			{ID: "job", Name: "celery:tasks.py:send_me_notifications", Kind: "SCOPE.ScheduledJob",
-				SourceFile: "tasks.py", Properties: map[string]string{
+				SourceFile: "tasks.py", Properties: types.PropsFromMap(map[string]string{
 					"handler":   "send_me_notifications",
 					"framework": "celery",
-				}},
+				})},
 		},
 	}}
 	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
@@ -440,7 +442,7 @@ def send_me_notifications():
 	if job.Properties == nil {
 		t.Fatal("ScheduledJob node left unstamped — #3869 binding regression")
 	}
-	effs := job.Properties[EffectPropertyKeyList]
+	effs := job.Properties.Get(EffectPropertyKeyList)
 	if !strings.Contains(effs, "db_write") {
 		t.Fatalf("ScheduledJob (celery:...:send_me_notifications) effects=%q; "+
 			"want db_write inherited from the task body (#3869)", effs)
@@ -465,10 +467,10 @@ def add_numbers():
 		Entities: []entityNode{
 			{ID: "op", Name: "add_numbers", Kind: "SCOPE.Operation", SourceFile: "tasks.py"},
 			{ID: "job", Name: "celery:tasks.py:add_numbers", Kind: "SCOPE.ScheduledJob",
-				SourceFile: "tasks.py", Properties: map[string]string{
+				SourceFile: "tasks.py", Properties: types.PropsFromMap(map[string]string{
 					"handler":   "add_numbers",
 					"framework": "celery",
-				}},
+				})},
 		},
 	}}
 	if _, err := runEffectPropagationPass(graphs, Paths{}, nil); err != nil {
@@ -483,7 +485,7 @@ def add_numbers():
 	if job == nil {
 		t.Fatal("ScheduledJob entity missing from graph")
 	}
-	if v, ok := job.Properties[EffectPropertyKeyList]; ok {
+	if v, ok := job.Properties.Lookup(EffectPropertyKeyList); ok {
 		t.Errorf("pure-bodied ScheduledJob carries fabricated effects=%q; want unstamped", v)
 	}
 }
@@ -519,10 +521,10 @@ def _do_clear():
 			// The synthetic ScheduledJob wrapper: name is the celery job ID, bare
 			// task name is in `handler`. It has NO outgoing CALLS of its own.
 			{ID: "job", Name: "celery:tasks.py:clear_inspections_task", Kind: "SCOPE.ScheduledJob",
-				SourceFile: "tasks.py", Properties: map[string]string{
+				SourceFile: "tasks.py", Properties: types.PropsFromMap(map[string]string{
 					"handler":   "clear_inspections_task",
 					"framework": "celery",
-				}},
+				})},
 		},
 		Edges: []edgeRef{
 			// CALLS lives on the BODY function, not the wrapper.
@@ -544,7 +546,7 @@ def _do_clear():
 	if job.Properties == nil {
 		t.Fatal("ScheduledJob node left unstamped — #3934 transitive-via-helper gap")
 	}
-	effs := job.Properties[EffectPropertyKeyList]
+	effs := job.Properties.Get(EffectPropertyKeyList)
 	// The .delete() ORM sink classifies as db_write (and may add db_delete);
 	// the wrapper must carry the helper's transitive effect, not be pure.
 	if !strings.Contains(effs, "db_write") && !strings.Contains(effs, "db_delete") {
@@ -553,14 +555,14 @@ def _do_clear():
 	}
 	// Effects arrived through a helper the body CALLS, not a direct sink on the
 	// wrapper itself → source must be transitive.
-	if got := job.Properties[EffectPropertyKeySource]; got != "transitive" {
+	if got := job.Properties.Get(EffectPropertyKeySource); got != "transitive" {
 		t.Errorf("ScheduledJob effect_source=%q; want transitive (inherited via helper)", got)
 	}
 	// The body itself must also carry the transitive effect (sanity on the join).
-	if !strings.Contains(graphs[0].Entities[0].Properties[EffectPropertyKeyList], "db_write") &&
-		!strings.Contains(graphs[0].Entities[0].Properties[EffectPropertyKeyList], "db_delete") {
+	if !strings.Contains(graphs[0].Entities[0].Properties.Get(EffectPropertyKeyList), "db_write") &&
+		!strings.Contains(graphs[0].Entities[0].Properties.Get(EffectPropertyKeyList), "db_delete") {
 		t.Errorf("task body effects=%q; want transitive db_write/db_delete",
-			graphs[0].Entities[0].Properties[EffectPropertyKeyList])
+			graphs[0].Entities[0].Properties.Get(EffectPropertyKeyList))
 	}
 }
 
@@ -588,10 +590,10 @@ def _pure_add():
 			{ID: "op", Name: "compute_task", Kind: "SCOPE.Operation", SourceFile: "tasks.py"},
 			{ID: "helper", Name: "_pure_add", Kind: "SCOPE.Operation", SourceFile: "helpers.py"},
 			{ID: "job", Name: "celery:tasks.py:compute_task", Kind: "SCOPE.ScheduledJob",
-				SourceFile: "tasks.py", Properties: map[string]string{
+				SourceFile: "tasks.py", Properties: types.PropsFromMap(map[string]string{
 					"handler":   "compute_task",
 					"framework": "celery",
-				}},
+				})},
 		},
 		Edges: []edgeRef{
 			{FromID: "op", ToID: "helper", Kind: "CALLS"},
@@ -609,16 +611,16 @@ def _pure_add():
 	if job == nil {
 		t.Fatal("ScheduledJob entity missing from graph")
 	}
-	if v, ok := job.Properties[EffectPropertyKeyList]; ok {
+	if v, ok := job.Properties.Lookup(EffectPropertyKeyList); ok {
 		t.Errorf("pure-chain ScheduledJob carries fabricated effects=%q; want unstamped", v)
 	}
 }
 
-func confFromProps(props map[string]string, effect string) float64 {
+func confFromProps(props types.Props, effect string) float64 {
 	if props == nil {
 		return 0
 	}
-	raw := props[EffectPropertyKeyConfidence]
+	raw := props.Get(EffectPropertyKeyConfidence)
 	for _, part := range strings.Split(raw, ",") {
 		if !strings.HasPrefix(part, effect+"=") {
 			continue

--- a/internal/links/entity_props_alloc_5954_test.go
+++ b/internal/links/entity_props_alloc_5954_test.go
@@ -1,0 +1,353 @@
+package links
+
+// entity_props_alloc_5954_test.go — pins the heap cost of projecting a
+// graph.Entity into the link pass's entityNode (#5954, slice 2).
+//
+// Background: #5976 compacted the extraction records' properties from
+// map[string]string to the sorted-slice types.Props. loadAllGraphs then
+// RE-INFLATED every entity's property set back into a map[string]string via
+// PropsSnapshot, one map per entity, ~427k entities on the reference corpus.
+//
+// What these tests measure, precisely: BYTES ALLOCATED per projection, via
+// runtime.MemStats.TotalAlloc. That is NOT resident heap. Allocation volume
+// and steady-state RSS differ — a transient map is allocated and collected,
+// and a property set that later passes stamp four more keys onto grows past
+// its loaded size. No test in this package pins resident heap; treat any
+// RSS figure quoted elsewhere as a separate, hand-run measurement.
+//
+// The measurement is deliberately BYTES, not testing.AllocsPerRun's
+// allocation COUNT. Count alone is a weak pin here: a map with a small hint
+// and a slice are both "a couple of allocations", so a count assertion would
+// still pass if someone reintroduced the map.
+
+import (
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// allocBytesPerOp returns the number of bytes f allocates per call, averaged
+// over n calls and MINIMISED over allocTrials repetitions. Callers must
+// pre-size any destination slice so only the work under test is billed.
+//
+// runtime.MemStats.TotalAlloc is PROCESS-wide, so anything else allocating
+// concurrently is billed to f. In practice this measurement is stable — it
+// reports exactly 64.0 B/entity both in isolation and with the whole links
+// suite running before it — so the min-over-trials is insurance rather than a
+// fix for an observed flake. It is sound insurance because outside traffic can
+// only ADD to the delta, never subtract: the minimum across trials can be
+// dragged down towards f's true cost but never below it, and a genuine
+// regression raises every trial including the minimum.
+func allocBytesPerOp(n int, f func(i int)) float64 {
+	const allocTrials = 7
+
+	// Warm up so lazily-initialised globals inside f are not billed.
+	f(0)
+
+	best := math.Inf(1)
+	for trial := 0; trial < allocTrials; trial++ {
+		runtime.GC()
+		var before, after runtime.MemStats
+		runtime.ReadMemStats(&before)
+		for i := 0; i < n; i++ {
+			f(i)
+		}
+		runtime.ReadMemStats(&after)
+		got := float64(after.TotalAlloc-before.TotalAlloc) / float64(n)
+		if got < best {
+			best = got
+		}
+	}
+	return best
+}
+
+// syntheticEntities builds n graph.Entity values with a UNIFORM 2-property
+// set. This is the regression-detector fixture, not the headline-number
+// fixture: 2 entries is close to the map's worst case (a full 48 B header plus
+// a whole 272 B bucket for two pairs) and the slice's best case (exactly 64 B,
+// no slack), which maximises the signal a ceiling assertion can see. It
+// deliberately OVERSTATES the corpus-wide saving — see realisticEntities.
+func syntheticEntities(n int) []graph.Entity {
+	out := make([]graph.Entity, n)
+	for i := range out {
+		out[i] = graph.Entity{
+			ID:         fmt.Sprintf("e%06d", i),
+			Name:       fmt.Sprintf("Handler%06d", i),
+			Kind:       "function",
+			Subtype:    "function",
+			SourceFile: fmt.Sprintf("src/pkg%03d/mod%05d.go", i%512, i%4096),
+			StartLine:  i%900 + 1,
+			EndLine:    i%900 + 12,
+		}.WithProperties(map[string]string{
+			"language": "go",
+			"line":     fmt.Sprintf("%d", i%900+1),
+		})
+	}
+	return out
+}
+
+// realisticEntities builds n graph.Entity values with a MIXED property-count
+// distribution approximating what the extractors actually emit across a corpus:
+//
+//	25% with 0 properties   (plain functions/classes carrying no annotations)
+//	50% with 2 properties   (the language/line pair)
+//	15% with 5 properties   (HTTP endpoint entities: verb/path/framework/…)
+//	10% with 12 properties  (richly annotated endpoints, long keys and values)
+//
+// This is the fixture the headline saving should be quoted from. The two
+// representations converge as the property count rises — one map header
+// amortises over more pairs while the slice grows linearly — so the uniform
+// 2-property fixture flatters the change by roughly a third.
+func realisticEntities(n int) []graph.Entity {
+	out := make([]graph.Entity, n)
+	for i := range out {
+		var props map[string]string
+		switch bucket := i % 20; {
+		case bucket < 5: // 25%: none
+			props = nil
+		case bucket < 15: // 50%: two
+			props = map[string]string{
+				"language": "go",
+				"line":     fmt.Sprintf("%d", i%900+1),
+			}
+		case bucket < 18: // 15%: five
+			props = map[string]string{
+				"verb": "GET", "path": fmt.Sprintf("/api/v1/orders/%d", i%97),
+				"framework": "django", "pattern_type": "http_endpoint_synthesis",
+				"language": "python",
+			}
+		default: // 10%: twelve, with long keys and values
+			props = map[string]string{
+				"verb": "POST", "path": fmt.Sprintf("/api/v1/organisations/{org_id}/orders/%d/reconcile", i%97),
+				"framework": "django-rest-framework", "pattern_type": "http_endpoint_synthesis",
+				"language": "python", "lookup_url_kwarg": "organisation_identifier",
+				"source_caller": "Class:OrderReconciliationViewSet", "url_prefix": "/api/v1",
+				"substrate_resolved_via":   "settings.BASE_URL>env(SERVICE_ROOT)>literal",
+				"substrate_resolved_value": "https://orders.internal.example.com/api/v1",
+				"substrate_confidence":     "0.85", "effects": "db_read,db_write,http_out,env_read",
+			}
+		}
+		out[i] = graph.Entity{
+			ID:         fmt.Sprintf("e%06d", i),
+			Name:       fmt.Sprintf("Handler%06d", i),
+			Kind:       "function",
+			Subtype:    "function",
+			SourceFile: fmt.Sprintf("src/pkg%03d/mod%05d.go", i%512, i%4096),
+			StartLine:  i%900 + 1,
+			EndLine:    i%900 + 12,
+		}.WithProperties(props)
+	}
+	return out
+}
+
+// maxEntityNodeProjectionBytes is the per-entity allocation ceiling for
+// newEntityNode on the uniform 2-property fixture. A 2-entry types.Props is
+// 64 B. The ceiling must sit below the CHEAPEST re-inflation shape, not merely
+// below a bare map — TestEntityNodeProjection_MapReintroductionWouldFail
+// asserts exactly that, so raising this constant past the cheapest bounce
+// fails there rather than silently defanging the gate.
+const maxEntityNodeProjectionBytes = 150
+
+// TestEntityNodeProjection_DoesNotAllocateAMapPerEntity is the primary gate:
+// projecting one entity must cost roughly one small slice, not a map.
+func TestEntityNodeProjection_DoesNotAllocateAMapPerEntity(t *testing.T) {
+	const n = 50_000
+	src := syntheticEntities(n)
+	dst := make([]entityNode, n)
+
+	got := allocBytesPerOp(n, func(i int) {
+		dst[i] = newEntityNode(src[i])
+	})
+
+	// Keep dst alive past the measurement so the projected property storage
+	// is genuinely resident, exactly as it is for the whole link pass.
+	if dst[n-1].ID == "" {
+		t.Fatal("projection produced an empty entity — measurement is not exercising the path")
+	}
+
+	t.Logf("newEntityNode: %.1f bytes/entity over %d entities", got, n)
+	if got > maxEntityNodeProjectionBytes {
+		t.Fatalf("newEntityNode allocates %.1f bytes/entity, want <= %d — "+
+			"a map[string]string property set has been (re)introduced on the load path",
+			got, maxEntityNodeProjectionBytes)
+	}
+}
+
+// TestEntityNodeProjection_MapReintroductionWouldFail is the anti-vacuity
+// check on maxEntityNodeProjectionBytes.
+//
+// It bounds the ceiling against the CHEAPEST re-inflation shape, not against a
+// bare map. That distinction is the whole point. A bare PropsSnapshot costs
+// ~336 B/entity, but the realistic regression — someone writing
+// `types.PropsFromMap(e.PropsSnapshot())` — is far cheaper, because the map
+// never escapes and much of it is billed away by inlining. Measured, that
+// bounce is ~168 B/entity. A ceiling asserted only against 336 would happily
+// admit a 200-byte limit that lets the 168-byte bounce through; asserting
+// against the bounce itself closes that hole.
+func TestEntityNodeProjection_MapReintroductionWouldFail(t *testing.T) {
+	const n = 50_000
+	src := syntheticEntities(n)
+
+	bare := make([]map[string]string, n)
+	bareBytes := allocBytesPerOp(n, func(i int) {
+		bare[i] = src[i].PropsSnapshot()
+	})
+
+	// The shape a regression would actually take: inflate to a map, then
+	// convert straight back to the field's Props type.
+	bounced := make([]types.Props, n)
+	bounceBytes := allocBytesPerOp(n, func(i int) {
+		bounced[i] = types.PropsFromMap(src[i].PropsSnapshot())
+	})
+
+	t.Logf("bare map projection: %.1f bytes/entity; cheapest map bounce: %.1f bytes/entity (over %d entities)",
+		bareBytes, bounceBytes, n)
+
+	if bounceBytes <= maxEntityNodeProjectionBytes {
+		t.Fatalf("the cheapest map re-inflation costs %.1f bytes/entity, which is UNDER the "+
+			"%d-byte ceiling — the ceiling no longer excludes a map bounce and the primary "+
+			"assertion is vacuous. Lower maxEntityNodeProjectionBytes.",
+			bounceBytes, maxEntityNodeProjectionBytes)
+	}
+	if bareBytes <= bounceBytes {
+		t.Errorf("bare map (%.1f B) is not more expensive than the bounce (%.1f B) — "+
+			"the cost model this test reasons about no longer holds", bareBytes, bounceBytes)
+	}
+}
+
+// TestEntityNodeProjection_RealisticDistributionSaving is the fixture the
+// headline corpus number should be quoted from. It asserts only the DIRECTION
+// (Props strictly cheaper) and logs the magnitude, because the magnitude
+// depends on the property-count distribution, which is a property of the
+// corpus and not of this code. Pinning it to a constant would be pinning an
+// assumption about someone else's repositories.
+func TestEntityNodeProjection_RealisticDistributionSaving(t *testing.T) {
+	const n = 50_000
+	src := realisticEntities(n)
+
+	nodes := make([]entityNode, n)
+	propsBytes := allocBytesPerOp(n, func(i int) {
+		nodes[i] = newEntityNode(src[i])
+	})
+
+	maps := make([]map[string]string, n)
+	mapBytes := allocBytesPerOp(n, func(i int) {
+		maps[i] = src[i].PropsSnapshot()
+	})
+
+	saving := mapBytes - propsBytes
+	t.Logf("realistic distribution (25%%×0 / 50%%×2 / 15%%×5 / 10%%×12 props): "+
+		"Props %.1f B/entity vs map %.1f B/entity — saving %.1f B/entity "+
+		"(~%.0f MB at the 427k-entity reference corpus)",
+		propsBytes, mapBytes, saving, saving*427_000/1e6)
+
+	if saving <= 0 {
+		t.Fatalf("Props (%.1f B/entity) is not cheaper than the map (%.1f B/entity) on a "+
+			"realistic property distribution — the premise of this slice does not hold",
+			propsBytes, mapBytes)
+	}
+	runtime.KeepAlive(nodes)
+	runtime.KeepAlive(maps)
+}
+
+// TestEntityNodeProjection_PropertiesReadBackIdentically guards the obvious
+// way to pass the allocation gate for the wrong reason: dropping the
+// properties entirely. Every key/value on the source entity must still be
+// readable off the projected node.
+func TestEntityNodeProjection_PropertiesReadBackIdentically(t *testing.T) {
+	want := map[string]string{
+		"language":     "python",
+		"path":         "/api/users/{id}",
+		"verb":         "GET",
+		"pattern_type": "http_endpoint_synthesis",
+	}
+	e := graph.Entity{ID: "x1", Name: "getUser", Kind: "function"}.WithProperties(want)
+	n := newEntityNode(e)
+
+	if got := n.Properties.Len(); got != len(want) {
+		t.Fatalf("projected property count = %d, want %d", got, len(want))
+	}
+	for k, v := range want {
+		if got := n.Properties.Get(k); got != v {
+			t.Errorf("Properties[%q] = %q, want %q", k, got, v)
+		}
+	}
+	if got, ok := n.Properties.Lookup("absent"); ok || got != "" {
+		t.Errorf("Lookup(absent) = (%q, %v), want (\"\", false)", got, ok)
+	}
+}
+
+// TestLinkPass_NoPropertyMapBounceInProductionCode is LOAD-BEARING, not
+// belt-and-braces, for two independent reasons:
+//
+//  1. The allocation tests pin only the LOAD path (newEntityNode). They say
+//     nothing about the 14 passes that read entityNode.Properties afterwards.
+//     A single `e.Properties.Snapshot()` inside one of those passes would
+//     rebuild the per-entity map this slice removed, spread across the pass
+//     pipeline where no bytes/entity assertion is watching, and every
+//     functional test would still pass.
+//  2. It is the only test that kills the combined mutation "loosen the ceiling
+//     AND reintroduce the map". Adjusting maxEntityNodeProjectionBytes upward
+//     is caught by MapReintroductionWouldFail, but a re-inflation added
+//     somewhere other than newEntityNode is caught ONLY here.
+//
+// Scope of the guarantee, stated narrowly: this is a TEXTUAL check for
+// `.Snapshot()` / `.PropsSnapshot()` calls in non-test files of this package.
+// It does NOT detect every possible re-inflation. Building a shadow
+// `map[string]string` by hand via `Properties.Range` would slip past it, as
+// would any conversion in another package (notably cmd/, which is out of this
+// glob entirely). It catches the idiomatic mistake, which is the one that
+// actually happens; it is not a proof of absence.
+//
+// PropsFromMap is allowed — it converts INTO the compact form, which is the
+// direction this slice wants. Snapshot/PropsSnapshot are the ones that inflate.
+func TestLinkPass_NoPropertyMapBounceInProductionCode(t *testing.T) {
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	checked := 0
+	for _, f := range files {
+		if strings.HasSuffix(f, "_test.go") {
+			continue
+		}
+		checked++
+		b, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, line := range strings.Split(string(b), "\n") {
+			code := line
+			if j := strings.Index(code, "//"); j >= 0 {
+				code = code[:j] // prose about Snapshot is fine; calls are not
+			}
+			if strings.Contains(code, ".Snapshot()") || strings.Contains(code, ".PropsSnapshot()") {
+				t.Errorf("%s:%d re-inflates a property set into a map:\n\t%s\n"+
+					"use the types.Props accessors (Get/Lookup/Range/Set) instead", f, i+1, strings.TrimSpace(line))
+			}
+		}
+	}
+	if checked < 20 {
+		t.Fatalf("only scanned %d non-test files in this package — the glob is not finding the sources", checked)
+	}
+}
+
+// BenchmarkEntityNodeProjection reports the same figure as
+// TestEntityNodeProjection_DoesNotAllocateAMapPerEntity through the standard
+// -benchmem surface, for before/after comparison across commits.
+func BenchmarkEntityNodeProjection(b *testing.B) {
+	src := syntheticEntities(4096)
+	dst := make([]entityNode, len(src))
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		dst[i%len(src)] = newEntityNode(src[i%len(src)])
+	}
+}

--- a/internal/links/entity_props_diff_5954_test.go
+++ b/internal/links/entity_props_diff_5954_test.go
@@ -1,0 +1,368 @@
+package links
+
+// entity_props_diff_5954_test.go — the byte-identical-output gate for #5954
+// slice 2 (entityNode.Properties: map[string]string -> types.Props).
+//
+// "The existing tests pass" is not evidence here. The existing tests assert
+// individual facts about individual links; none of them assert that the FULL
+// set of bytes the link pass writes is unchanged. The property representation
+// swap touches ~14 passes, several of which stamp properties that end up
+// serialised into the group link document and the per-pass sidecars, so the
+// failure mode to guard is a subtle reordering or a dropped/duplicated key in
+// one sidecar that no per-fact test happens to look at.
+//
+// The gate: run RunAllPasses over the fixture below, then compare EVERY byte
+// of EVERY file the run writes under groups/ against goldens captured from the
+// PRE-change (map-backed) implementation. Regenerate with:
+//
+//	GRAFEL_UPDATE_LINKOUT_GOLDEN=1 go test ./internal/links/ -run TestLinkPassOutput_ByteIdentical
+//
+// Regenerating is only legitimate when the output is INTENDED to change.
+// Doing it to make this slice pass would defeat the entire point.
+//
+// HOW MUCH THIS GATE ACTUALLY COVERS — read before trusting it.
+//
+// It does NOT exercise every property-reading pass. Read the committed
+// testdata/linkout_5954/g5954-link-pass-stats.json: of the 19 passes that run,
+// only import (4 links), http (3 links), reachability (7 links / 8 candidates),
+// label (4 candidates) and module_cycles (4 candidates) produce anything.
+// constant_propagation, effect_propagation, taint_flow, openapi-spec, same_as,
+// payload_drift, pure_functions, def_use, complexity and data_flow all report
+// links_added=0, candidates=0 — they run and emit nothing, so their converted
+// property sites contribute no bytes to compare.
+//
+// Concretely: this gate covers roughly 3 of the 14 passes whose property
+// access was converted in #5954 slice 2. The remaining passes need real source
+// files under FileRoot (the substrate passes read function bodies off disk) or
+// richer entity graphs than a synthetic fixture supplies.
+//
+// Six converted Set calls, at four locations, are covered by NO test in this
+// package — before or after this change:
+//
+//	def_use_pass.go:178-179        (chains / count stamp)
+//	module_cycle_pass.go:145       (cycle tag stamp)
+//	pure_function_pass.go:91       (the pure="false" branch)
+//	dataflow_pass.go:552-553       (complexity-fallback branch)
+//
+// All are straight `m[k] = v` -> `p.Set(k, v)` rewrites with no branching
+// introduced, and all were equally untested before the change. This note is
+// disclosure of a pre-existing gap, not a claim that the gap is harmless.
+//
+// A demonstrated limit of this gate. Mutating types.Props.Set to insert a
+// DUPLICATE at the correct sorted position instead of overwriting in place —
+// i.e. breaking last-write-wins while keeping key order intact — was not caught
+// by either golden test, nor by anything else in internal/links: the whole
+// package stayed green. The only test that failed was TestPropsMatchesMapOracle
+// in internal/types.
+//
+// The cruder shape of the same mutation (append at the end, breaking sort
+// order as well) IS caught here, loudly, by ~11 tests including
+// TestApplyResolverDynamicBaseURL and the effect-propagation suite. So the
+// package's sensitivity to property-semantics bugs comes almost entirely from
+// key ORDER being observable in output, not from key SEMANTICS being asserted.
+// Byte-identity over a thin fixture is a weaker instrument than it looks, and
+// internal/types' oracle test is doing more of the load-bearing work here than
+// anything in this file.
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"testing"
+)
+
+const linkoutGoldenDir = "testdata/linkout_5954"
+
+// rfc3339Stamp matches the "2026-07-27T21:14:55.855987Z" wall-clock values the
+// pass writes into discovered_at / written_at.
+var rfc3339Stamp = regexp.MustCompile(`\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})`)
+
+// propsDiffFixture writes a three-repo group carrying the property shapes the
+// converted passes key off. Which of them actually FIRE is a separate question
+// from which are represented here — see the coverage note at the top of this
+// file, and check g5954-link-pass-stats.json rather than this list.
+//
+// Properties present in the fixture, and the observed outcome:
+//
+//   - http_pass:             pattern_type / verb / path / framework /
+//     url_prefix / lookup_url_kwarg / source_caller, plus a URL mount point.
+//     FIRES — 3 links.
+//   - import/label/reachability/module_cycles: cross-repo import edges.
+//     FIRE — 4 / 4 / 7 / 4 links or candidates.
+//   - openapi_pass:          method+path (spec side), verb+path (code side).
+//     Present but emits nothing — the pass needs a real spec artefact.
+//   - constant_propagation:  url_kind=dynamic_baseurl + caller_file + path.
+//     Present but emits nothing — no resolvable substrate binding on disk.
+//   - effect_propagation:    handler. Emits nothing — needs source bodies.
+//   - sameas_pass:           fields. Emits nothing — needs matching model
+//     shapes the heuristic will accept.
+//
+// The four "present but silent" entries are kept deliberately: they cost
+// nothing, and they are the fixture rows to extend first if someone widens
+// this gate later.
+func propsDiffFixture(t *testing.T, root string) {
+	t.Helper()
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "acme-core",
+		Entities: []map[string]any{
+			{"id": "view1", "name": "OrderViewSet", "kind": "Controller",
+				"source_file": "core/views/orders.py",
+				"properties":  map[string]any{"handler": "OrderViewSet", "framework": "django"}},
+			{"id": "ep-prod-1", "name": "http:GET:/api/v1/orders", "kind": "http_endpoint",
+				"source_file": "core/views/orders.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/orders", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				}},
+			{"id": "ep-prod-2", "name": "http:POST:/api/v1/orders/{id}", "kind": "http_endpoint",
+				"source_file": "core/views/orders.py",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/api/v1/orders/{id}", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis", "lookup_url_kwarg": "order_id",
+				}},
+			{"id": "mount1", "name": "urls", "kind": "http_endpoint",
+				"source_file": "core/urls.py",
+				"properties": map[string]any{
+					"pattern_type": patternTypeURLMountPoint, "url_prefix": "/api/v1",
+					"path": "/api/v1",
+				}},
+			{"id": "model1", "name": "Order", "kind": "Model",
+				"source_file": "core/models.py",
+				"properties":  map[string]any{"fields": "id,total,status,created_at"}},
+			{"id": "spec1", "name": "openapi:GET:/api/v1/orders", "kind": "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties":  map[string]any{"method": "get", "path": "/api/v1/orders"}},
+		},
+		Edges: []map[string]string{
+			{"from_id": "view1", "to_id": "ep-prod-1", "kind": "IMPLEMENTS"},
+			{"from_id": "view1", "to_id": "ep-prod-2", "kind": "IMPLEMENTS"},
+			{"from_id": "view1", "to_id": "model1", "kind": "CALLS"},
+		},
+	})
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "acme-web",
+		Entities: []map[string]any{
+			{"id": "svc1", "name": "OrderService", "kind": "Class",
+				"source_file": "src/api/orders.ts",
+				"properties":  map[string]any{"language": "typescript"}},
+			{"id": "ep-cons-1", "name": "http:GET:/api/v1/orders", "kind": "http_endpoint",
+				"source_file": "src/api/orders.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/orders", "framework": "axios",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Class:OrderService", "url_kind": "literal",
+				}},
+			{"id": "ep-cons-2", "name": "http:POST:/orders/{orderId}", "kind": "http_endpoint",
+				"source_file": "src/api/orders.ts",
+				"properties": map[string]any{
+					"verb": "POST", "path": "/orders/{orderId}", "framework": "axios",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Class:OrderService",
+				}},
+			{"id": "ep-cons-3", "name": "http:GET:/api/v1/orders", "kind": "http_endpoint",
+				"source_file": "src/api/dyn.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "${BASE}/api/v1/orders", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis",
+					"url_kind":     "dynamic_baseurl", "caller_file": "src/api/dyn.ts",
+				}},
+			{"id": "model2", "name": "Order", "kind": "Interface",
+				"source_file": "src/models/order.ts",
+				"properties":  map[string]any{"fields": "id,total,status,created_at"}},
+			{"id": "spec2", "name": "openapi:POST:/api/v1/orders/{id}", "kind": "openapi_operation",
+				"source_file": "spec/openapi.yaml",
+				"properties":  map[string]any{"method": "post", "path": "/api/v1/orders/{id}"}},
+		},
+		Edges: []map[string]string{
+			{"from_id": "svc1", "to_id": "ep-cons-1", "kind": "CALLS"},
+			{"from_id": "svc1", "to_id": "ep-cons-2", "kind": "CALLS"},
+			{"from_id": "svc1", "to_id": "acme-core::model1", "kind": "IMPORTS"},
+		},
+	})
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "acme-worker",
+		Entities: []map[string]any{
+			{"id": "job1", "name": "OrderReconcileJob", "kind": "Function",
+				"source_file": "worker/jobs/reconcile.go",
+				"properties":  map[string]any{"language": "go", "line": "42"}},
+			{"id": "ep-cons-4", "name": "http:GET:/api/v1/orders", "kind": "http_endpoint",
+				"source_file": "worker/jobs/reconcile.go",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/api/v1/orders", "framework": "nethttp",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:OrderReconcileJob",
+				}},
+			{"id": "pkg1", "name": "OrderBook", "kind": "class",
+				"source_file": "worker/pkg/book.go",
+				"properties":  map[string]any{"language": "go"}},
+		},
+		Edges: []map[string]string{
+			{"from_id": "job1", "to_id": "ep-cons-4", "kind": "CALLS"},
+			{"from_id": "job1", "to_id": "model1", "kind": "imports"},
+		},
+	})
+}
+
+// collectLinkOutputs runs the fixture and returns filename -> file bytes for
+// every file the pass wrote under <home>/groups, with the (per-run, temporary)
+// root and home paths scrubbed so the bytes are comparable across machines.
+func collectLinkOutputs(t *testing.T) map[string]string {
+	t.Helper()
+
+	root := t.TempDir()
+	home := t.TempDir()
+	propsDiffFixture(t, root)
+
+	if _, err := RunAllPasses("g5954", root, home); err != nil {
+		t.Fatalf("RunAllPasses: %v", err)
+	}
+
+	groups := filepath.Join(home, "groups")
+	ents, err := os.ReadDir(groups)
+	if err != nil {
+		t.Fatalf("read groups dir: %v", err)
+	}
+	// Resolve symlinks too: on macOS t.TempDir() lives under /var, which is a
+	// symlink to /private/var, and the pass records the resolved form.
+	scrub := []string{root, home}
+	for _, p := range []string{root, home} {
+		if rp, err := filepath.EvalSymlinks(p); err == nil && rp != p {
+			scrub = append(scrub, rp)
+		}
+	}
+
+	out := map[string]string{}
+	for _, de := range ents {
+		if de.IsDir() {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(groups, de.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", de.Name(), err)
+		}
+		s := string(b)
+		for _, p := range scrub {
+			s = strings.ReplaceAll(s, p, "<TMP>")
+		}
+		// discovered_at / written_at are wall-clock stamps; they vary between
+		// two runs of the SAME implementation and so carry no information
+		// about the property representation. Everything else is compared byte
+		// for byte. TestLinkPassOutput_GoldenIsDeterministic proves this is
+		// the ONLY varying field — if a second source of nondeterminism ever
+		// appears it fails there rather than being silently absorbed here.
+		s = rfc3339Stamp.ReplaceAllString(s, "<TS>")
+		out[de.Name()] = s
+	}
+	if len(out) == 0 {
+		t.Fatal("the fixture produced no output files — the gate would assert nothing")
+	}
+	return out
+}
+
+// TestLinkPassOutput_ByteIdenticalToPreCompactionGolden is the gate described
+// at the top of this file.
+func TestLinkPassOutput_ByteIdenticalToPreCompactionGolden(t *testing.T) {
+	got := collectLinkOutputs(t)
+
+	if os.Getenv("GRAFEL_UPDATE_LINKOUT_GOLDEN") == "1" {
+		if err := os.RemoveAll(linkoutGoldenDir); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(linkoutGoldenDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		for name, body := range got {
+			if err := os.WriteFile(filepath.Join(linkoutGoldenDir, name), []byte(body), 0o644); err != nil {
+				t.Fatal(err)
+			}
+		}
+		t.Fatalf("regenerated %d goldens in %s — rerun without GRAFEL_UPDATE_LINKOUT_GOLDEN to verify",
+			len(got), linkoutGoldenDir)
+	}
+
+	goldenEntries, err := os.ReadDir(linkoutGoldenDir)
+	if err != nil {
+		t.Fatalf("read goldens (regenerate with GRAFEL_UPDATE_LINKOUT_GOLDEN=1): %v", err)
+	}
+	want := map[string]string{}
+	for _, de := range goldenEntries {
+		b, err := os.ReadFile(filepath.Join(linkoutGoldenDir, de.Name()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		want[de.Name()] = string(b)
+	}
+
+	names := map[string]bool{}
+	for n := range want {
+		names[n] = true
+	}
+	for n := range got {
+		names[n] = true
+	}
+	sorted := make([]string, 0, len(names))
+	for n := range names {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	for _, n := range sorted {
+		w, okW := want[n]
+		g, okG := got[n]
+		switch {
+		case !okW:
+			t.Errorf("%s: the run emitted a file the pre-change implementation did not", n)
+		case !okG:
+			t.Errorf("%s: the pre-change implementation emitted this file and the run did not", n)
+		case w != g:
+			t.Errorf("%s: output differs from the pre-change implementation\n--- want (%d bytes)\n%s\n--- got (%d bytes)\n%s",
+				n, len(w), firstDiffContext(w, g), len(g), firstDiffContext(g, w))
+		}
+	}
+}
+
+// TestLinkPassOutput_GoldenIsDeterministic guards the gate itself: if the pass
+// output varied run to run (map iteration order leaking into a sidecar, a
+// timestamp), the byte-comparison above would flake rather than catch anything,
+// and someone would "fix" it by loosening the comparison.
+func TestLinkPassOutput_GoldenIsDeterministic(t *testing.T) {
+	a := collectLinkOutputs(t)
+	b := collectLinkOutputs(t)
+	if len(a) != len(b) {
+		t.Fatalf("run emitted %d files then %d — output file set is not deterministic", len(a), len(b))
+	}
+	for n, av := range a {
+		bv, ok := b[n]
+		if !ok {
+			t.Errorf("%s present in the first run only", n)
+			continue
+		}
+		if av != bv {
+			t.Errorf("%s differs between two identical runs — the pass output is not deterministic\n%s",
+				n, firstDiffContext(av, bv))
+		}
+	}
+}
+
+// firstDiffContext returns a short window of a around the first byte at which
+// it diverges from b, so a failure message is readable for multi-KB JSON.
+func firstDiffContext(a, b string) string {
+	i := 0
+	for i < len(a) && i < len(b) && a[i] == b[i] {
+		i++
+	}
+	lo := i - 120
+	if lo < 0 {
+		lo = 0
+	}
+	hi := i + 120
+	if hi > len(a) {
+		hi = len(a)
+	}
+	return "…" + a[lo:hi] + "…"
+}

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -1044,13 +1044,13 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 			// slash by the emitter) and the canonical join in `path`. Both
 			// are recorded under a normalised "/<segments>/" shape so the
 			// retry sweep can prepend them verbatim.
-			if e.Properties != nil && e.Properties["pattern_type"] == patternTypeURLMountPoint {
-				raw := e.Properties["url_prefix"]
+			if e.Properties != nil && e.Properties.Get("pattern_type") == patternTypeURLMountPoint {
+				raw := e.Properties.Get("url_prefix")
 				if raw == "" {
-					raw = e.Properties["route"]
+					raw = e.Properties.Get("route")
 				}
 				if raw == "" {
-					raw = e.Properties["path"]
+					raw = e.Properties.Get("path")
 				}
 				if pfx := normalizeMountPrefix(raw); pfx != "" {
 					if mountPrefixesByRepo[g.Repo] == nil {
@@ -1072,20 +1072,20 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				sourceFile: e.SourceFile,
 			}
 			if e.Properties != nil {
-				hit.verb = e.Properties["verb"]
-				hit.canonicalPath = e.Properties["path"]
-				hit.framework = e.Properties["framework"]
-				hit.urlPrefix = e.Properties["url_prefix"]
+				hit.verb = e.Properties.Get("verb")
+				hit.canonicalPath = e.Properties.Get("path")
+				hit.framework = e.Properties.Get("framework")
+				hit.urlPrefix = e.Properties.Get("url_prefix")
 				// #2808 — capture the producer's overridden detail-route param
 				// name. lookup_url_kwarg takes precedence over lookup_field (DRF
 				// uses lookup_url_kwarg for the URL placeholder, falling back to
 				// lookup_field). Empty ⇒ the DRF default `pk`.
-				if lk := e.Properties["lookup_url_kwarg"]; lk != "" {
+				if lk := e.Properties.Get("lookup_url_kwarg"); lk != "" {
 					hit.lookupKwarg = lk
-				} else if lf := e.Properties["lookup_field"]; lf != "" {
+				} else if lf := e.Properties.Get("lookup_field"); lf != "" {
 					hit.lookupKwarg = lf
 				}
-				switch e.Properties["pattern_type"] {
+				switch e.Properties.Get("pattern_type") {
 				case patternTypeProducer:
 					hit.side = sideProducer
 				case patternTypeConsumer:
@@ -1094,7 +1094,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				// Resolve source_caller (consumer side) to a stamped
 				// entity ID in the same file. Falls through silently
 				// when missing or unresolvable.
-				if ref := e.Properties["source_caller"]; ref != "" {
+				if ref := e.Properties.Get("source_caller"); ref != "" {
 					if kind, name, ok := splitKindNameRef(ref); ok {
 						if id := entIDByKey[entKey{kind, name, e.SourceFile}]; id != "" {
 							hit.callerID = id

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // SchemaVersion is the integer version of the links file shape.
@@ -661,16 +662,39 @@ type entityNode struct {
 	Subtype string // package/function/...; required to discriminate
 	// real external packages (subtype=package) from bare-name built-in
 	// placeholders (subtype=function). See issue #566 / import_pass.go.
-	SourceFile string            // relative path
-	StartLine  int               // 1-indexed body start (0 when unknown)
-	EndLine    int               // 1-indexed body end (0 when unknown)
-	Properties map[string]string // optional
+	SourceFile string // relative path
+	StartLine  int    // 1-indexed body start (0 when unknown)
+	EndLine    int    // 1-indexed body end (0 when unknown)
+	// Properties is the compact sorted key/value slice, NOT a map: at
+	// ~427k entities in the group union a per-entity map[string]string
+	// header+bucket costs ~336 B against ~64 B for the equivalent Props
+	// (#5954). Reads go through Get/Lookup, writes through Set/SetDefault
+	// on a *entityNode. Do not add a .Snapshot() at a read site — that
+	// re-creates exactly the map this field exists to avoid.
+	Properties types.Props // optional
 }
 
 type edgeRef struct {
 	FromID string
 	ToID   string
 	Kind   string // imports, calls, ...
+}
+
+// newEntityNode projects one graph.Entity into the link pass's entityNode.
+// Called once per entity in the group union (~427k on the reference corpus),
+// so its per-call allocation is a first-order term in the link pass's peak
+// RSS (#5954).
+func newEntityNode(e graph.Entity) entityNode {
+	return entityNode{
+		ID:         e.ID,
+		Name:       e.Name,
+		Kind:       e.Kind,
+		Subtype:    e.Subtype,
+		SourceFile: e.SourceFile,
+		StartLine:  e.StartLine,
+		EndLine:    e.EndLine,
+		Properties: e.PropsClone(),
+	}
 }
 
 // loadAllGraphs walks graphsDir and returns one repoGraph per slug directory
@@ -805,17 +829,9 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 			Path:     filepath.Join(dir, "graph.json"), // keep for logging/compat
 			FileRoot: filepath.Dir(realDir),
 		}
+		rg.Entities = make([]entityNode, 0, len(doc.Entities))
 		for _, e := range doc.Entities {
-			rg.Entities = append(rg.Entities, entityNode{
-				ID:         e.ID,
-				Name:       e.Name,
-				Kind:       e.Kind,
-				Subtype:    e.Subtype,
-				SourceFile: e.SourceFile,
-				StartLine:  e.StartLine,
-				EndLine:    e.EndLine,
-				Properties: e.PropsSnapshot(),
-			})
+			rg.Entities = append(rg.Entities, newEntityNode(e))
 		}
 		for _, r := range doc.Relationships {
 			rg.Edges = append(rg.Edges, edgeRef{FromID: r.FromID, ToID: r.ToID, Kind: r.Kind})

--- a/internal/links/module_cycle_pass.go
+++ b/internal/links/module_cycle_pass.go
@@ -20,6 +20,8 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodModuleCycles identifies sidecar artefacts from this pass.
@@ -138,9 +140,9 @@ func runModuleCyclePass(graphs []repoGraph, paths Paths) (PassResult, error) {
 					continue
 				}
 				if e.Properties == nil {
-					e.Properties = map[string]string{}
+					e.Properties = types.Props{}
 				}
-				e.Properties[ModuleCyclePropertyKey] = tag
+				e.Properties.Set(ModuleCyclePropertyKey, tag)
 				mem = append(mem, moduleCycleMember{
 					Repo:       g.Repo,
 					EntityID:   id,

--- a/internal/links/openapi_pass.go
+++ b/internal/links/openapi_pass.go
@@ -102,8 +102,8 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 			if e.Properties == nil {
 				continue
 			}
-			verb := strings.ToUpper(e.Properties["method"])
-			path := e.Properties["path"]
+			verb := strings.ToUpper(e.Properties.Get("method"))
+			path := e.Properties.Get("path")
 			if verb == "" || path == "" {
 				continue
 			}
@@ -193,8 +193,8 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 			if e.Name == "" || e.Properties == nil {
 				continue
 			}
-			verb := strings.ToUpper(e.Properties["verb"])
-			path := e.Properties["path"]
+			verb := strings.ToUpper(e.Properties.Get("verb"))
+			path := e.Properties.Get("path")
 			if verb == "" && path == "" {
 				// Fall back to parsing from canonical name.
 				if v, p, ok := parseHTTPName(e.Name); ok {
@@ -214,11 +214,11 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 				verb:          verb,
 				canonicalPath: path,
 				sourceFile:    e.SourceFile,
-				framework:     e.Properties["framework"],
+				framework:     e.Properties.Get("framework"),
 			}
 
 			// Determine side from pattern_type property.
-			switch e.Properties["pattern_type"] {
+			switch e.Properties.Get("pattern_type") {
 			case patternTypeProducer:
 				hit.side = sideProducer
 			case patternTypeConsumer:
@@ -226,7 +226,7 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 			}
 
 			// Resolve source_caller (consumer side).
-			if ref := e.Properties["source_caller"]; ref != "" {
+			if ref := e.Properties.Get("source_caller"); ref != "" {
 				if kind, name, ok := splitKindNameRef(ref); ok {
 					if id := entIDByKey[entKey{kind, name, e.SourceFile}]; id != "" {
 						hit.callerID = id

--- a/internal/links/payload_drift_test.go
+++ b/internal/links/payload_drift_test.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // TestPayloadDrift_MissingFieldsOnBothSides exercises the canonical
@@ -44,7 +46,7 @@ function submit() {
 			Entities: []entityNode{
 				{ID: "h1", Name: "create_user", Kind: "SCOPE.Function", SourceFile: "server/handler.py"},
 				{ID: "ep1", Name: "http:POST:/api/users", Kind: "synthetic.http_endpoint",
-					Properties: map[string]string{"pattern_type": "http_endpoint_synthesis", "verb": "POST", "path": "/api/users"}},
+					Properties: types.PropsFromMap(map[string]string{"pattern_type": "http_endpoint_synthesis", "verb": "POST", "path": "/api/users"})},
 			},
 			Edges: []edgeRef{
 				{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"},
@@ -56,7 +58,7 @@ function submit() {
 			Entities: []entityNode{
 				{ID: "c1", Name: "submit", Kind: "SCOPE.Function", SourceFile: "client/submit.ts"},
 				{ID: "ep2", Name: "http:POST:/api/users", Kind: "synthetic.http_endpoint_call",
-					Properties: map[string]string{"pattern_type": "http_endpoint_client_synthesis", "verb": "POST", "path": "/api/users"}},
+					Properties: types.PropsFromMap(map[string]string{"pattern_type": "http_endpoint_client_synthesis", "verb": "POST", "path": "/api/users"})},
 			},
 			Edges: []edgeRef{
 				{FromID: "c1", ToID: "ep2", Kind: "CALLS"},
@@ -123,7 +125,7 @@ function submit() {
 			Entities: []entityNode{
 				{ID: "h1", Name: "create_user", Kind: "SCOPE.Function", SourceFile: "server/handler.py"},
 				{ID: "ep1", Name: "http:POST:/api/users", Kind: "synthetic.http_endpoint",
-					Properties: map[string]string{"pattern_type": "http_endpoint_synthesis", "verb": "POST", "path": "/api/users"}},
+					Properties: types.PropsFromMap(map[string]string{"pattern_type": "http_endpoint_synthesis", "verb": "POST", "path": "/api/users"})},
 			},
 			Edges: []edgeRef{{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"}},
 		},
@@ -132,7 +134,7 @@ function submit() {
 			Entities: []entityNode{
 				{ID: "c1", Name: "submit", Kind: "SCOPE.Function", SourceFile: "client/submit.ts"},
 				{ID: "ep2", Name: "http:POST:/api/users", Kind: "synthetic.http_endpoint_call",
-					Properties: map[string]string{"pattern_type": "http_endpoint_client_synthesis"}},
+					Properties: types.PropsFromMap(map[string]string{"pattern_type": "http_endpoint_client_synthesis"})},
 			},
 			Edges: []edgeRef{{FromID: "c1", ToID: "ep2", Kind: "CALLS"}},
 		},
@@ -187,7 +189,7 @@ function submit() {
 			Entities: []entityNode{
 				{ID: "h1", Name: "create_user", Kind: "SCOPE.Function", SourceFile: "server/handler.py"},
 				{ID: "ep1", Name: "http:POST:/api/users", Kind: "synthetic.http_endpoint",
-					Properties: map[string]string{"pattern_type": "http_endpoint_synthesis"}},
+					Properties: types.PropsFromMap(map[string]string{"pattern_type": "http_endpoint_synthesis"})},
 			},
 			Edges: []edgeRef{{FromID: "h1", ToID: "ep1", Kind: "IMPLEMENTS"}},
 		},

--- a/internal/links/pure_function_pass.go
+++ b/internal/links/pure_function_pass.go
@@ -27,6 +27,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodPureFunctions identifies sidecar artefacts produced by this pass.
@@ -82,15 +84,15 @@ func runPureFunctionPass(graphs []repoGraph, paths Paths) (PassResult, error) {
 				continue
 			}
 			if e.Properties == nil {
-				e.Properties = map[string]string{}
+				e.Properties = types.Props{}
 			}
 			// If Phase 1A stamped effects, this entity is not pure.
-			if eff := e.Properties[EffectPropertyKeyList]; eff != "" {
-				e.Properties[PurePropertyKeyPure] = "false"
+			if eff := e.Properties.Get(EffectPropertyKeyList); eff != "" {
+				e.Properties.Set(PurePropertyKeyPure, "false")
 				continue
 			}
-			e.Properties[PurePropertyKeyPure] = "true"
-			e.Properties[PurePropertyKeyConfidence] = fmt.Sprintf("%.2f", purityConfidence)
+			e.Properties.Set(PurePropertyKeyPure, "true")
+			e.Properties.Set(PurePropertyKeyConfidence, fmt.Sprintf("%.2f", purityConfidence))
 			totalPure++
 			entries = append(entries, pureEntry{
 				Repo:       g.Repo,

--- a/internal/links/reachability.go
+++ b/internal/links/reachability.go
@@ -40,6 +40,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/substrate"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodReachability identifies entries produced by the Phase 1B
@@ -309,19 +311,19 @@ func runReachabilityPass(group string, graphs []repoGraph, paths Paths) (PassRes
 			e := &g.Entities[ei]
 			isReach := reachable[e.ID] != nil
 			if e.Properties == nil {
-				e.Properties = map[string]string{}
+				e.Properties = types.Props{}
 			}
 			if isReach {
-				e.Properties["reachable"] = "true"
+				e.Properties.Set("reachable", "true")
 				vias := keysOf(reachable[e.ID])
 				sort.Strings(vias)
 				if len(vias) > 8 {
 					vias = vias[:8]
 				}
-				e.Properties["reachable_via"] = strings.Join(vias, ",")
+				e.Properties.Set("reachable_via", strings.Join(vias, ","))
 				repoReachable++
 			} else {
-				e.Properties["reachable"] = "false"
+				e.Properties.Set("reachable", "false")
 			}
 			// Only emit entries for code-bearing entities — keeps the
 			// sidecar focused. Skip Module/File/Document/External

--- a/internal/links/reachability_test.go
+++ b/internal/links/reachability_test.go
@@ -57,7 +57,7 @@ func orphan() {}
 	// orphanFn must be flagged unreachable.
 	got := map[string]string{}
 	for _, e := range graphs[0].Entities {
-		got[e.ID] = e.Properties["reachable"]
+		got[e.ID] = e.Properties.Get("reachable")
 	}
 	if got["orphanFn"] != "false" {
 		t.Errorf("orphanFn should be reachable=false, got %q", got["orphanFn"])

--- a/internal/links/sameas_pass.go
+++ b/internal/links/sameas_pass.go
@@ -198,7 +198,7 @@ func fieldsForModel(g repoGraph, model entityNode, childrenByParent map[string][
 
 	// Representation 1: comma-separated `fields` property.
 	if model.Properties != nil {
-		if raw, ok := model.Properties["fields"]; ok && raw != "" {
+		if raw, ok := model.Properties.Lookup("fields"); ok && raw != "" {
 			for _, f := range strings.Split(raw, ",") {
 				if n := normalizeFieldName(f); n != "" {
 					out[n] = true

--- a/internal/links/taint_flow.go
+++ b/internal/links/taint_flow.go
@@ -50,6 +50,8 @@ import (
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/substrate"
+
+	"github.com/cajasmota/grafel/internal/types"
 )
 
 // MethodTaintFlow identifies sidecar artefacts produced by the Phase
@@ -437,7 +439,7 @@ func stampTaintRoles(graphs []repoGraph, byEntity map[string][]substrate.TaintMa
 				continue
 			}
 			if e.Properties == nil {
-				e.Properties = map[string]string{}
+				e.Properties = types.Props{}
 			}
 			// Canonical order: source, sink, sanitizer.
 			parts := make([]string, 0, 3)
@@ -446,9 +448,9 @@ func stampTaintRoles(graphs []repoGraph, byEntity map[string][]substrate.TaintMa
 					parts = append(parts, string(k))
 				}
 			}
-			e.Properties[TaintRolePropertyKey] = strings.Join(parts, ",")
+			e.Properties.Set(TaintRolePropertyKey, strings.Join(parts, ","))
 			if c := findingCount[full]; c > 0 {
-				e.Properties[TaintFindingCountPropertyKey] = fmt.Sprintf("%d", c)
+				e.Properties.Set(TaintFindingCountPropertyKey, fmt.Sprintf("%d", c))
 			}
 			stamped++
 		}

--- a/internal/links/taint_flow_test.go
+++ b/internal/links/taint_flow_test.go
@@ -37,7 +37,7 @@ def search(cursor):
 	if res.LinksAdded == 0 {
 		t.Fatal("expected at least one entity stamped with taint_role")
 	}
-	role := graphs[0].Entities[0].Properties[TaintRolePropertyKey]
+	role := graphs[0].Entities[0].Properties.Get(TaintRolePropertyKey)
 	if !strings.Contains(role, "source") || !strings.Contains(role, "sink") {
 		t.Errorf("entity taint_role=%q; want source+sink", role)
 	}

--- a/internal/links/testdata/linkout_5954/g5954-link-candidates.json
+++ b/internal/links/testdata/linkout_5954/g5954-link-candidates.json
@@ -1,0 +1,65 @@
+{
+  "version": 1,
+  "links": [
+    {
+      "id": "7c7e3f1c",
+      "source": "acme-core::ep-prod-1",
+      "target": "acme-web::ep-cons-1",
+      "relation": "shared_label",
+      "method": "label_match",
+      "confidence": 0.6548794940695398,
+      "channel": null,
+      "identifier": "http:get:/api/v1/orders",
+      "discovered_at": "<TS>",
+      "reason": "label_match below threshold",
+      "properties": {
+        "confidence": "heuristic"
+      }
+    },
+    {
+      "id": "1ee28d97",
+      "source": "acme-core::ep-prod-1",
+      "target": "acme-worker::ep-cons-4",
+      "relation": "shared_label",
+      "method": "label_match",
+      "confidence": 0.6548794940695398,
+      "channel": null,
+      "identifier": "http:get:/api/v1/orders",
+      "discovered_at": "<TS>",
+      "reason": "label_match below threshold",
+      "properties": {
+        "confidence": "heuristic"
+      }
+    },
+    {
+      "id": "0c1a1697",
+      "source": "acme-core::view1",
+      "target": "acme-web::svc1",
+      "relation": "shared_label",
+      "method": "label_match",
+      "confidence": 0.6024397470347699,
+      "channel": null,
+      "identifier": "order",
+      "discovered_at": "<TS>",
+      "reason": "label_match below threshold",
+      "properties": {
+        "confidence": "heuristic"
+      }
+    },
+    {
+      "id": "1c1207af",
+      "source": "acme-web::ep-cons-1",
+      "target": "acme-worker::ep-cons-4",
+      "relation": "shared_label",
+      "method": "label_match",
+      "confidence": 0.6548794940695398,
+      "channel": null,
+      "identifier": "http:get:/api/v1/orders",
+      "discovered_at": "<TS>",
+      "reason": "label_match below threshold",
+      "properties": {
+        "confidence": "heuristic"
+      }
+    }
+  ]
+}

--- a/internal/links/testdata/linkout_5954/g5954-link-pass-stats.json
+++ b/internal/links/testdata/linkout_5954/g5954-link-pass-stats.json
@@ -1,0 +1,128 @@
+{
+  "version": 1,
+  "group": "g5954",
+  "written_at": "<TS>",
+  "passes": [
+    {
+      "pass": "import",
+      "links_added": 4,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "constant_propagation",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "effect_propagation",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "taint_flow",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "label",
+      "links_added": 0,
+      "candidates": 4,
+      "skipped": 0
+    },
+    {
+      "pass": "string",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "http",
+      "links_added": 3,
+      "candidates": 0,
+      "skipped": 0,
+      "cross_repo_resolved": 4
+    },
+    {
+      "pass": "openapi-spec",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "grpc",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "topic",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "same_as",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "reachability",
+      "links_added": 7,
+      "candidates": 8,
+      "skipped": 7
+    },
+    {
+      "pass": "payload_drift",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "pure_functions",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "module_cycles",
+      "links_added": 0,
+      "candidates": 4,
+      "skipped": 2
+    },
+    {
+      "pass": "def_use",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "template_patterns",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "complexity",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    },
+    {
+      "pass": "data_flow",
+      "links_added": 0,
+      "candidates": 0,
+      "skipped": 0
+    }
+  ],
+  "http_resolve": {
+    "cross_repo_resolve_attempts": 4,
+    "cross_repo_resolve_hits_by_strategy": {
+      "exact": 3
+    }
+  }
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-data-flow.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-data-flow.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "method": "data_flow",
+  "total_flows": 0,
+  "links": null
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-def-use.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-def-use.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "method": "def_use",
+  "total_chains": 0,
+  "entries": null
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-module-cycles.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-module-cycles.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "method": "module_cycles",
+  "total_nodes": 4,
+  "total_edges": 2,
+  "cycles": null
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-pure-functions.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-pure-functions.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "method": "pure_functions",
+  "total": 0,
+  "entries": null
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-reachability.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-reachability.json
@@ -1,0 +1,159 @@
+{
+  "version": 1,
+  "group": "g5954",
+  "written_at": "<TS>",
+  "total_entities": 15,
+  "reachable": 7,
+  "unreachable": 8,
+  "entry_points": 7,
+  "entries": [
+    {
+      "repo": "acme-core",
+      "entity_id": "ep-prod-1",
+      "name": "http:GET:/api/v1/orders",
+      "kind": "http_endpoint",
+      "source_file": "core/views/orders.py",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-core",
+      "entity_id": "ep-prod-2",
+      "name": "http:POST:/api/v1/orders/{id}",
+      "kind": "http_endpoint",
+      "source_file": "core/views/orders.py",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-core",
+      "entity_id": "model1",
+      "name": "Order",
+      "kind": "Model",
+      "source_file": "core/models.py",
+      "reachable": false
+    },
+    {
+      "repo": "acme-core",
+      "entity_id": "mount1",
+      "name": "urls",
+      "kind": "http_endpoint",
+      "source_file": "core/urls.py",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-core",
+      "entity_id": "spec1",
+      "name": "openapi:GET:/api/v1/orders",
+      "kind": "openapi_operation",
+      "source_file": "openapi.yaml",
+      "reachable": false
+    },
+    {
+      "repo": "acme-core",
+      "entity_id": "view1",
+      "name": "OrderViewSet",
+      "kind": "Controller",
+      "source_file": "core/views/orders.py",
+      "reachable": false
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "ep-cons-1",
+      "name": "http:GET:/api/v1/orders",
+      "kind": "http_endpoint",
+      "source_file": "src/api/orders.ts",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "ep-cons-2",
+      "name": "http:POST:/orders/{orderId}",
+      "kind": "http_endpoint",
+      "source_file": "src/api/orders.ts",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "ep-cons-3",
+      "name": "http:GET:/api/v1/orders",
+      "kind": "http_endpoint",
+      "source_file": "src/api/dyn.ts",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "model2",
+      "name": "Order",
+      "kind": "Interface",
+      "source_file": "src/models/order.ts",
+      "reachable": false
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "spec2",
+      "name": "openapi:POST:/api/v1/orders/{id}",
+      "kind": "openapi_operation",
+      "source_file": "spec/openapi.yaml",
+      "reachable": false
+    },
+    {
+      "repo": "acme-web",
+      "entity_id": "svc1",
+      "name": "OrderService",
+      "kind": "Class",
+      "source_file": "src/api/orders.ts",
+      "reachable": false
+    },
+    {
+      "repo": "acme-worker",
+      "entity_id": "ep-cons-4",
+      "name": "http:GET:/api/v1/orders",
+      "kind": "http_endpoint",
+      "source_file": "worker/jobs/reconcile.go",
+      "reachable": true,
+      "reachable_via": [
+        "graph:http_endpoint"
+      ],
+      "entry_source": "graph:http_endpoint"
+    },
+    {
+      "repo": "acme-worker",
+      "entity_id": "job1",
+      "name": "OrderReconcileJob",
+      "kind": "Function",
+      "source_file": "worker/jobs/reconcile.go",
+      "reachable": false
+    },
+    {
+      "repo": "acme-worker",
+      "entity_id": "pkg1",
+      "name": "OrderBook",
+      "kind": "class",
+      "source_file": "worker/pkg/book.go",
+      "reachable": false
+    }
+  ]
+}

--- a/internal/links/testdata/linkout_5954/g5954-links-template-patterns.json
+++ b/internal/links/testdata/linkout_5954/g5954-links-template-patterns.json
@@ -1,0 +1,7 @@
+{
+  "version": 1,
+  "method": "template_patterns",
+  "total": 0,
+  "by_kind": {},
+  "entries": null
+}

--- a/internal/links/testdata/linkout_5954/g5954-links.json
+++ b/internal/links/testdata/linkout_5954/g5954-links.json
@@ -1,0 +1,118 @@
+{
+  "version": 1,
+  "links": [
+    {
+      "id": "03878b59",
+      "source": "acme-core::ep-prod-1",
+      "target": "acme-web::ep-cons-1",
+      "relation": "imports",
+      "method": "import",
+      "confidence": 1,
+      "channel": null,
+      "identifier": null,
+      "discovered_at": "<TS>"
+    },
+    {
+      "id": "23b930e3",
+      "source": "acme-core::ep-prod-1",
+      "target": "acme-worker::ep-cons-4",
+      "relation": "imports",
+      "method": "import",
+      "confidence": 1,
+      "channel": null,
+      "identifier": null,
+      "discovered_at": "<TS>"
+    },
+    {
+      "id": "5deaa6d1",
+      "source": "acme-web::ep-cons-1",
+      "target": "acme-worker::ep-cons-4",
+      "relation": "imports",
+      "method": "import",
+      "confidence": 1,
+      "channel": null,
+      "identifier": null,
+      "discovered_at": "<TS>"
+    },
+    {
+      "id": "2c38d270",
+      "source": "acme-web::ep-cons-3",
+      "target": "acme-core::view1",
+      "relation": "calls",
+      "method": "http",
+      "confidence": 1,
+      "channel": "http",
+      "identifier": "http:GET:${BASE}/api/v1/orders",
+      "discovered_at": "<TS>",
+      "source_locations": [
+        [
+          "src/api/dyn.ts"
+        ],
+        [
+          "core/views/orders.py"
+        ]
+      ],
+      "match_quality": "exact_verb",
+      "properties": {
+        "confidence": "resolved"
+      }
+    },
+    {
+      "id": "84230933",
+      "source": "acme-web::svc1",
+      "target": "acme-core::view1",
+      "relation": "calls",
+      "method": "http",
+      "confidence": 1,
+      "channel": "http",
+      "identifier": "http:GET:/api/v1/orders",
+      "discovered_at": "<TS>",
+      "source_locations": [
+        [
+          "src/api/orders.ts"
+        ],
+        [
+          "core/views/orders.py"
+        ]
+      ],
+      "match_quality": "exact_verb",
+      "properties": {
+        "confidence": "resolved"
+      }
+    },
+    {
+      "id": "84ce2fae",
+      "source": "acme-worker::job1",
+      "target": "acme-core::model1",
+      "relation": "imports",
+      "method": "import",
+      "confidence": 1,
+      "channel": null,
+      "identifier": null,
+      "discovered_at": "<TS>"
+    },
+    {
+      "id": "b38c3320",
+      "source": "acme-worker::job1",
+      "target": "acme-core::view1",
+      "relation": "calls",
+      "method": "http",
+      "confidence": 1,
+      "channel": "http",
+      "identifier": "http:GET:/api/v1/orders",
+      "discovered_at": "<TS>",
+      "source_locations": [
+        [
+          "worker/jobs/reconcile.go"
+        ],
+        [
+          "core/views/orders.py"
+        ]
+      ],
+      "match_quality": "exact_verb",
+      "properties": {
+        "confidence": "resolved"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## What

`entityNode.Properties` in the link pass carried `map[string]string`, rebuilt from the already-compacted `types.Props`. It now carries `types.Props` directly.

## Why

#5976 compacted `RelationshipRecord.Properties` from a map to a `[]propKV`-backed `types.Props`, banking ~436 MB. The link pass then **re-inflated it** on load: one map header plus buckets per entity, across ~427k entities. This is self-inflicted waste rather than new engineering — it gives back part of a win we had already paid for.

## Measured, not estimated

| fixture | Props | map | saving |
|---|---|---|---|
| realistic distribution (25%×0, 50%×2, 15%×5, 10%×12 props, long keys) | 94.4 B/entity | 284.8 B/entity | **~81 MB @ 427k** |
| post-stamp steady state (4 extra `Set`s) | 297.6 B/entity | 475.6 B/entity | ~76 MB @ 427k |

`BenchmarkEntityNodeProjection`: **336 B/op, 2 allocs → 64 B/op, 1 alloc.**

An earlier revision of this PR claimed ~119 MB. That came from a fixture with a uniform 2 properties per entity — near the map's worst case and the slice's best — and overstated the win by about a third. The uniform fixture is retained, but as the *regression detector* (a tight ceiling is exactly what you want there), not as the corpus estimate.

The committed tests measure **allocation** via `TotalAlloc`, not RSS. No committed test pins resident heap.

## Translation

`entityNode.Properties` is populated by a new `graph.Entity.PropsClone()` — one exact-sized slice copy, no map. All read sites use `Get`/`Lookup`; all write sites use `Set`. **Zero** `.Snapshot()`/`PropsFromMap` bounces were added in non-test code.

Converted: `openapi_pass`, `http_pass`, `constant_propagation`, `effect_propagation` (signature changed `map[string]string` → `*types.Props`), `sameas_pass`, `complexity_pass`, `dataflow_pass`, `def_use_pass`, `pure_function_pass`, `reachability`, `taint_flow`, `module_cycle_pass`.

`Link.Properties` deliberately stays a map: it is built fresh by the matchers, never re-inflated from a compacted form, and there are thousands of links rather than hundreds of thousands of entities.

## Semantic equivalence

Independently verified by review, since map and slice diverge in four ways that matter:

- **nil vs empty** — `types.Props{}` is non-nil, and `PropsClone`/`PropsSnapshot` both return nil for an empty set, so every `== nil` guard translates exactly.
- **duplicate keys** — impossible: `Set` binary-searches, then overwrites in place or inserts at the sorted position.
- **iteration order** — no exposure; nothing ranges over `Properties`, every read is keyed.
- **aliasing** — all 30 `range …Entities` sites that mutate use `&g.Entities[ei]`. Inserting through a value copy would be visible with a map and lost with a slice; no such site exists.

One dependency this change **newly extends** to the link pass: `Props.Get` binary-searches, so an unsorted backing slice silently returns `""`. Verified the invariant holds at both producers — `fbwriter/writer.go:284-288` sorts before emission, `load.go:541-556` relies on exactly that, and the JSON path sorts via `propsFromMap`. `Entity.Prop()` already binary-searched, so the invariant was load-bearing before; the blast radius is wider now.

## Byte-identical output

9 golden files in `testdata/linkout_5954/`, generated from the pre-change map-backed implementation. The reviewer did not take that on trust: they built a detached worktree at the base commit, copied in only the diff test, regenerated, and `diff -r`'d against the committed goldens — identical. That also proves pre-change output was already deterministic, so there was no map-iteration-order leak for this change to alter.

**Coverage is narrower than "9 goldens" suggests, and this is recorded rather than implied:** only import, http, reachability, label and module_cycles emit anything; ten passes report `links_added=0`. The gate covers ~3 of the 14 converted passes. Six `Set` calls at four locations (`def_use_pass.go:178-179`, `module_cycle_pass.go:145`, `pure_function_pass.go:91`, `dataflow_pass.go:552-553`) are untested by anything in the package — all straight `m[k]=v` → `p.Set(k,v)` with no branching, and equally untested before.

## Gate strength

`TestEntityNodeProjection_MapReintroductionWouldFail` bounds the ceiling against the **cheapest re-inflation shape** (`PropsFromMap(PropsSnapshot())`, 168 B/entity), not a bare map (336). Review found that a ceiling asserted only against 336 would admit a 200-byte limit that lets the 168-byte bounce through; that hole is now closed.

`TestLinkPass_NoPropertyMapBounceInProductionCode` is documented as **load-bearing** — it is the only test catching a re-inflation added anywhere other than `newEntityNode` — with its limits stated: a textual match on `.Snapshot()`/`.PropsSnapshot()` in non-test files *of this package*. A shadow map built via `Range`, or anything under `cmd/`, slips past.

## Mutation results

Killed: map bounce in `newEntityNode` (both the byte gate and the static guard); ceiling loosened to 400; `.Snapshot()` added inside `reachability.go`; duplicate-key `Set`.

Recorded honestly: the duplicate-key kill is **shape-dependent**. Appending at the end breaks sort order and fails ~11 tests here. Inserting a duplicate at the correct sorted position is caught by **nothing** in `internal/links` — both golden tests pass — and only `internal/types.TestPropsMatchesMapOracle` fails. So this package's sensitivity comes from key *order* being observable in serialised output, not from key *semantics* being asserted anywhere.

## Follow-up found by review

`types.EntityRecord.Properties` is still `map[string]string`, so `cmd/grafel/index.go:1197` does `Properties: pe.PropsSnapshot()` on a per-entity loop — the same re-inflation, on the write path, outside this package's static guard. That is the next propKV slice, tracked separately.

Independently adversarially reviewed.

Refs #5954
