### PR TITLE
perf(#5954): drop the per-entity centrality pre-seed and the eager names map

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -2924,13 +2924,17 @@ func (i *Indexer) runPass4AlgorithmsWithProgress(doc *graph.Document, trk *progr
 			cidCopy := cid
 			e.CommunityID = &cidCopy
 		}
-		if c, ok := res.Centrality[e.ID]; ok {
-			cCopy := c
-			e.Centrality = &cCopy
-		}
 		if p, ok := res.PageRank[e.ID]; ok {
 			pCopy := p
 			e.PageRank = &pCopy
+			// #5954 — Centrality is keyed off PageRank membership, not off its
+			// own: PageRank covers every entity that took part in the pass,
+			// whereas the betweenness map now holds only non-zero scores. An
+			// entity in the pass with no betweenness entry scores 0, exactly as
+			// the removed zero pre-seed recorded it, so graph.json keeps the
+			// explicit "centrality": 0 it has always carried.
+			cCopy := res.Centrality[e.ID]
+			e.Centrality = &cCopy
 		}
 		if res.GodNodes[e.ID] {
 			e.IsGodNode = true

--- a/cmd/grafel/pass4_centrality_test.go
+++ b/cmd/grafel/pass4_centrality_test.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// zeroBetweennessDoc is a path A→B→C plus an isolated D. Only B sits on a
+// shortest path, so A, C and D all have betweenness 0 — and since #5954 they
+// are ABSENT from AlgorithmResults.Centrality rather than carrying an explicit
+// zero.
+func zeroBetweennessDoc() *graph.Document {
+	return &graph.Document{
+		Repo: "pass4-zero",
+		Entities: []graph.Entity{
+			{ID: "A", Name: "A", Kind: "function"},
+			{ID: "B", Name: "B", Kind: "function"},
+			{ID: "C", Name: "C", Kind: "function"},
+			{ID: "D", Name: "D", Kind: "function"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "A", ToID: "B", Kind: "CALLS"},
+			{FromID: "B", ToID: "C", Kind: "CALLS"},
+		},
+	}
+}
+
+// TestPass4Attachment_ZeroBetweennessKeepsExplicitCentrality pins the
+// serialisation boundary #5954 depends on.
+//
+// Entity.Centrality is *float64 with `json:",omitempty"`: a nil pointer DROPS
+// the key from graph.json, a pointer-to-zero emits `"centrality": 0`. Before
+// #5954 every entity in the pass had an explicit 0 in the result map, so the
+// attachment loop's `if c, ok := res.Centrality[e.ID]; ok` was always true. The
+// map is now sparse, so the loop keys off PageRank membership (still dense over
+// the entity set) and reads centrality with the zero default.
+//
+// Reverting that to a Centrality comma-ok lookup would silently drop
+// `"centrality": 0` for every zero-betweenness entity — ~9% of a real corpus.
+// This test fails if that happens.
+func TestPass4Attachment_ZeroBetweennessKeepsExplicitCentrality(t *testing.T) {
+	doc := zeroBetweennessDoc()
+	(&Indexer{}).runPass4Algorithms(doc)
+
+	byID := map[string]*graph.Entity{}
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+
+	// Sanity: the fixture really does produce a sparse Centrality map, i.e. the
+	// zero-valued entities below are absent from it rather than present-with-0.
+	if b := byID["B"]; b == nil || b.Centrality == nil || *b.Centrality <= 0 {
+		t.Fatalf("B must carry a positive betweenness (it is on the A→C path); got %v", b.Centrality)
+	}
+
+	for _, id := range []string{"A", "C", "D"} {
+		e := byID[id]
+		if e == nil {
+			t.Fatalf("entity %s missing", id)
+		}
+		if e.Centrality == nil {
+			t.Errorf("%s.Centrality is nil — a zero-betweenness entity lost its explicit 0, "+
+				"so graph.json will omit the \"centrality\" key it has always emitted", id)
+			continue
+		}
+		if *e.Centrality != 0 {
+			t.Errorf("%s.Centrality = %v, want 0", id, *e.Centrality)
+		}
+		raw, err := json.Marshal(e)
+		if err != nil {
+			t.Fatalf("marshal %s: %v", id, err)
+		}
+		if !strings.Contains(string(raw), `"centrality":0`) {
+			t.Errorf("%s serialises without \"centrality\":0 — %s", id, raw)
+		}
+	}
+}

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -1228,9 +1228,11 @@ func applyAlgorithmResults(doc *graph.Document, res *graph.AlgorithmResults) {
 		if pr, ok := res.PageRank[e.ID]; ok {
 			prCopy := pr
 			e.PageRank = &prCopy
-		}
-		if bt, ok := res.Centrality[e.ID]; ok {
-			btCopy := bt
+			// #5954 — Centrality follows PageRank membership: PageRank covers
+			// every entity in the pass, while the betweenness map now holds only
+			// non-zero scores, so an absent key means 0 (what the removed zero
+			// pre-seed stored explicitly).
+			btCopy := res.Centrality[e.ID]
 			e.Centrality = &btCopy
 		}
 		if res.GodNodes[e.ID] {

--- a/internal/dashboard/graphstate_pass4_test.go
+++ b/internal/dashboard/graphstate_pass4_test.go
@@ -86,6 +86,42 @@ func TestApplyAlgorithmResults_PersistsCentralityAndArticulation(t *testing.T) {
 	}
 }
 
+// TestApplyAlgorithmResults_ZeroBetweennessKeepsExplicitCentrality pins the
+// serialisation boundary #5954 depends on, on the dashboard's attachment path.
+//
+// Entity.Centrality is *float64 with `json:",omitempty"`: nil DROPS the key,
+// pointer-to-zero emits `"centrality": 0` (and handlers_graph.go only reports
+// `betweenness` when the pointer is non-nil). Before #5954 the result map held
+// an explicit 0 for every entity, so `if bt, ok := res.Centrality[e.ID]; ok`
+// was always true. The map is sparse now, so the loop keys off PageRank
+// membership — dense over the entity set — and reads centrality with the zero
+// default. Reverting that would silently strip the zero from every
+// zero-betweenness entity; this test fails if it does.
+func TestApplyAlgorithmResults_ZeroBetweennessKeepsExplicitCentrality(t *testing.T) {
+	// A→B→C plus an isolated D: only B has non-zero betweenness.
+	doc := pathGraphDoc()
+	doc.Entities = append(doc.Entities, graph.Entity{ID: "D", Name: "D", Kind: "function"})
+	attachAlgorithmResults(doc)
+
+	if b := entByID(doc, "B"); b == nil || b.Centrality == nil || *b.Centrality <= 0 {
+		t.Fatalf("B must carry a positive betweenness (it is on the A→C path)")
+	}
+	for _, id := range []string{"A", "C", "D"} {
+		e := entByID(doc, id)
+		if e == nil {
+			t.Fatalf("entity %s missing", id)
+		}
+		if e.Centrality == nil {
+			t.Errorf("%s.Centrality is nil — a zero-betweenness entity lost its explicit 0, so the "+
+				"serialised graph omits the \"centrality\"/\"betweenness\" key it has always carried", id)
+			continue
+		}
+		if *e.Centrality != 0 {
+			t.Errorf("%s.Centrality = %v, want 0", id, *e.Centrality)
+		}
+	}
+}
+
 // pendingGrp builds a cache + a published group with one repo whose doc needs a
 // background Pass-4 sweep, mirroring the shape loadGroupForRef publishes.
 func pendingGrp(t *testing.T, doc *graph.Document, stateDir string, fbMtime time.Time) (*GraphCache, *DashGroup) {

--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -377,7 +377,7 @@ func atofSafe(s string) float64 {
 // result slice and their members are assigned community_id=-1 ("ungrouped").
 // This prevents singleton/micro-community noise from reaching the MCP surface
 // and the dashboard. Set opts.MinSize=1 to disable denoising.
-func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityNames map[string]string, opts CommunityOptions) ([]CommunityResult, map[string]int, float64, int) {
+func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityNames []string, opts CommunityOptions) ([]CommunityResult, map[string]int, float64, int) {
 	// Project the directed graph onto an undirected graph; community detection
 	// in gonum operates on undirected (or otherwise symmetric) inputs.
 	und := simple.NewWeightedUndirectedGraph(0, 0)
@@ -542,7 +542,7 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 		top := make([]string, 0, topN)
 		for k := 0; k < topN; k++ {
 			eid := idx.fromInt[members[k].id]
-			name := entityNames[eid]
+			name := nameOf(entityNames, members[k].id)
 			if name == "" {
 				name = eid
 			}
@@ -732,16 +732,6 @@ func logBetweennessPath(p betweennessPath, nodes int) {
 }
 
 func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[string]float64, map[string]float64) {
-	betw := make(map[string]float64, idx.next)
-	pr := make(map[string]float64, idx.next)
-	// Pre-seed every entity with a 0 so callers can rely on the keys being
-	// present even when gonum's algorithms only populate the active subset
-	// (e.g. unreachable nodes in PageRank, leaf nodes in Betweenness).
-	for _, id := range idx.toInt {
-		betw[idx.fromInt[id]] = 0
-		pr[idx.fromInt[id]] = 0
-	}
-
 	// Betweenness — choose exact-weighted vs unweighted vs sampled by size.
 	// The selection is factored into chooseBetweennessPath so it is unit-testable
 	// and so operators can force exact computation via GRAFEL_BETWEENNESS_FORCE_EXACT
@@ -771,8 +761,21 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 	if raw == nil {
 		raw = network.Betweenness(g)
 	}
+	// #5954 — betweenness is SPARSE: gonum (and sampledBetweenness) only report
+	// nodes with a non-zero score, so this map is sized to the reported set, not
+	// to the entity count. Callers must read an absent key as 0 (Go's zero value
+	// for a map read), which is what every consumer does — see
+	// identifyGodNodesFrom below, groupalgo.BuildOverlay, and the two
+	// entity-attachment loops (cmd/grafel/index.go, dashboard.applyAlgorithmResults)
+	// that gate on PageRank membership.
+	betw := make(map[string]float64, len(raw))
 	for nid, v := range raw {
-		betw[idx.fromInt[nid]] = roundForDeterminism(sanitizeFloat(v))
+		// Zero scores are dropped, not stored: that makes "absent" the single
+		// representation of a zero betweenness, so a reconstituted result (see
+		// groupalgo.overlayToResults) is comparable to a freshly computed one.
+		if rv := roundForDeterminism(sanitizeFloat(v)); rv != 0 {
+			betw[idx.fromInt[nid]] = rv
+		}
 	}
 
 	// PageRank requires a directed graph — use g directly. damping=0.85,
@@ -786,7 +789,13 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 	// init vector and converge to the same scores; roundForDeterminism()
 	// rounds to 1e-4 (well above the 1e-6 solver tolerance) so the on-disk
 	// bytes stay stable. Always use sparse — code graphs are sparse by nature.
+	//
+	// PageRank is DENSE: PageRankSparse returns a score for every node in g, and
+	// BuildGraph inserts a node per entity, so `pr` still has one entry per
+	// entity. Consumers that need the full entity set (the overlay writer's
+	// fold-in loop, the entity-attachment loops) key off this map.
 	prRaw := network.PageRankSparse(g, 0.85, 1e-6)
+	pr := make(map[string]float64, len(prRaw))
 	for nid, v := range prRaw {
 		pr[idx.fromInt[nid]] = roundForDeterminism(sanitizeFloat(v))
 	}
@@ -966,46 +975,108 @@ func sanitizeFloat(v float64) float64 {
 	return v
 }
 
-// IdentifyGodNodes returns the union of the top-5% nodes by betweenness AND
-// the top-5% nodes by PageRank. Empty maps yield an empty result.
-func IdentifyGodNodes(betw, pr map[string]float64) map[string]bool {
+// identifyGodNodesFrom returns the union of the top-5% entities by betweenness
+// AND the top-5% by PageRank, with the candidate universe taken from the node
+// index (every entity) rather than from each map's key set.
+//
+// It replaces the exported IdentifyGodNodes, deleted in #5954: that function
+// ranked each map over its own keys, which was the entity universe only while
+// both maps were pre-seeded with a zero per entity. The betweenness map is
+// sparse now, so its key set is no longer the right denominator and an exported
+// entry point taking just the two maps cannot compute the cut correctly. It had
+// no callers outside this file.
+//
+// This reproduces the selection made before #5954, when both maps were
+// pre-seeded with a 0 for every entity: the 5% cut is over the entity count,
+// and entities with no score rank last, ordered by id — exactly where an
+// explicit 0 sorted them. TestGodNodesParityWithZeroPreSeed checks it against a
+// verbatim copy of that implementation, including a fixture where the cut is
+// filled entirely from the zero tail.
+func identifyGodNodesFrom(betw, pr map[string]float64, idx *nodeIndex) map[string]bool {
+	universeLen := int(idx.next)
+	universe := func() []string { return mapKeys(idx.toInt) }
 	out := make(map[string]bool)
-	if len(betw) == 0 && len(pr) == 0 {
-		return out
+	for _, id := range pickTopFraction(betw, universeLen, universe) {
+		out[id] = true
 	}
-	pickTop5 := func(m map[string]float64) []string {
-		type pair struct {
-			id string
-			v  float64
-		}
-		ps := make([]pair, 0, len(m))
-		for k, v := range m {
-			ps = append(ps, pair{k, v})
-		}
-		// Issue #481 — ties on score were resolved by map-iteration order,
-		// so the top-5% set flipped between runs. Stable sort with an ID
-		// tiebreaker pins the membership.
-		sort.SliceStable(ps, func(i, j int) bool {
+	for _, id := range pickTopFraction(pr, universeLen, universe) {
+		out[id] = true
+	}
+	return out
+}
+
+// mapKeys collects the keys of m in unspecified order. Callers sort.
+func mapKeys[V any](m map[string]V) []string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}
+
+// pickTopFraction returns the top universeLen/20 (5%, minimum 1) ids ranked by
+// score descending with an id-ascending tiebreak, where every id in the universe
+// that is absent from m scores 0.
+//
+// Issue #481 — ties on score were resolved by map-iteration order, so the top-5%
+// set flipped between runs; the id tiebreaker pins the membership.
+//
+// The universe is passed as a size plus a lazy accessor because on the
+// RunAlgorithms path it is the full entity set (~430k ids): the id slice is only
+// materialised when the positively-scored entries do not already fill the cut,
+// which is the small/sparse-graph case. Scores are non-negative in practice, but
+// the split is written as ">0 first, then the rest ranked the same way" so it
+// stays order-equivalent to ranking one combined slice regardless.
+func pickTopFraction(m map[string]float64, universeLen int, universe func() []string) []string {
+	k := universeLen / 20 // 5%
+	if k == 0 && universeLen > 0 {
+		k = 1
+	}
+	if k == 0 {
+		return nil
+	}
+	type pair struct {
+		id string
+		v  float64
+	}
+	byScore := func(ps []pair) func(i, j int) bool {
+		return func(i, j int) bool {
 			if ps[i].v != ps[j].v {
 				return ps[i].v > ps[j].v
 			}
 			return ps[i].id < ps[j].id
-		})
-		k := len(ps) / 20 // 5%
-		if k == 0 && len(ps) > 0 {
-			k = 1
 		}
-		out := make([]string, 0, k)
-		for i := 0; i < k; i++ {
-			out = append(out, ps[i].id)
+	}
+
+	ps := make([]pair, 0, len(m))
+	for id, v := range m {
+		if v > 0 {
+			ps = append(ps, pair{id, v})
 		}
+	}
+	sort.SliceStable(ps, byScore(ps))
+	if len(ps) > k {
+		ps = ps[:k]
+	}
+	out := make([]string, 0, k)
+	for _, p := range ps {
+		out = append(out, p.id)
+	}
+	if len(out) == k {
 		return out
 	}
-	for _, id := range pickTop5(betw) {
-		out[id] = true
+
+	// The positive scores did not fill the cut — rank the zero/negative tail.
+	ids := universe()
+	tail := make([]pair, 0, len(ids)-len(out))
+	for _, id := range ids {
+		if v := m[id]; v <= 0 {
+			tail = append(tail, pair{id, v})
+		}
 	}
-	for _, id := range pickTop5(pr) {
-		out[id] = true
+	sort.SliceStable(tail, byScore(tail))
+	for i := 0; i < len(tail) && len(out) < k; i++ {
+		out = append(out, tail[i].id)
 	}
 	return out
 }
@@ -1187,6 +1258,31 @@ func IdentifyArticulationPoints(g *simple.WeightedDirectedGraph, idx *nodeIndex)
 	return out
 }
 
+// nodeNames returns entity display names indexed by the gonum node id that
+// BuildGraph assigned to each entity id — the lookup table ComputeCommunities
+// takes. Entities sharing an id collapse onto one slot, last write winning,
+// which is how the map[string]string it replaced resolved them too. An entity
+// absent from the index (BuildGraph indexes every entity it is given, so only a
+// mismatched pair reaches this) is skipped rather than panicking.
+func nodeNames(entities []Entity, idx *nodeIndex) []string {
+	names := make([]string, idx.next)
+	for _, e := range entities {
+		if nid, ok := idx.toInt[e.ID]; ok {
+			names[nid] = e.Name
+		}
+	}
+	return names
+}
+
+// nameOf returns the display name recorded for a gonum node id, or "" when the
+// slice does not cover it.
+func nameOf(names []string, nid int64) string {
+	if nid < 0 || nid >= int64(len(names)) {
+		return ""
+	}
+	return names[nid]
+}
+
 // RunAlgorithms executes the full Pass 4 sweep with default options (community
 // MinSize=5). It is a convenience wrapper over RunAlgorithmsWithOptions.
 func RunAlgorithms(entities []Entity, rels []Relationship) *AlgorithmResults {
@@ -1212,17 +1308,19 @@ func RunAlgorithmsWithOptions(entities []Entity, rels []Relationship, opts Commu
 
 	g, idx := BuildGraph(entities, rels)
 
-	names := make(map[string]string, len(entities))
-	for _, e := range entities {
-		names[e.ID] = e.Name
-	}
+	// Community naming needs at most 5 entity names per community, so #5954
+	// replaced the map[string]string over every entity with a []string indexed
+	// by the gonum node id BuildGraph already assigned: the same lookups off a
+	// flat slice instead of a ~430k-entry string-keyed map (measured 21.5 MB ->
+	// 6.6 MB at 433k entities).
+	names := nodeNames(entities, idx)
 
 	commResults, commOf, overallQ, denoised := ComputeCommunities(g, idx, names, opts)
 	// Layer-1 deterministic naming (TF-IDF over member entity names +
 	// qualified names + source-file basenames). Mutates commResults in place.
 	AssignCommunityNames(commResults, entities, commOf)
 	betw, pr := ComputeCentrality(g, idx)
-	gods := IdentifyGodNodes(betw, pr)
+	gods := identifyGodNodesFrom(betw, pr, idx)
 	arts := IdentifyArticulationPoints(g, idx)
 	surprises := ComputeSurpriseEdges(rels, commOf)
 

--- a/internal/graph/algorithms_preseed_parity_test.go
+++ b/internal/graph/algorithms_preseed_parity_test.go
@@ -1,0 +1,189 @@
+package graph
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+)
+
+// legacyIdentifyGodNodes is the pre-#5954 implementation, verbatim. It is the
+// oracle for the parity tests below: before #5954 ComputeCentrality pre-seeded
+// BOTH result maps with a 0 for every entity, so this ran over dense maps.
+func legacyIdentifyGodNodes(betw, pr map[string]float64) map[string]bool {
+	out := make(map[string]bool)
+	if len(betw) == 0 && len(pr) == 0 {
+		return out
+	}
+	pickTop5 := func(m map[string]float64) []string {
+		type pair struct {
+			id string
+			v  float64
+		}
+		ps := make([]pair, 0, len(m))
+		for k, v := range m {
+			ps = append(ps, pair{k, v})
+		}
+		sort.SliceStable(ps, func(i, j int) bool {
+			if ps[i].v != ps[j].v {
+				return ps[i].v > ps[j].v
+			}
+			return ps[i].id < ps[j].id
+		})
+		k := len(ps) / 20 // 5%
+		if k == 0 && len(ps) > 0 {
+			k = 1
+		}
+		out := make([]string, 0, k)
+		for i := 0; i < k; i++ {
+			out = append(out, ps[i].id)
+		}
+		return out
+	}
+	for _, id := range pickTop5(betw) {
+		out[id] = true
+	}
+	for _, id := range pickTop5(pr) {
+		out[id] = true
+	}
+	return out
+}
+
+// densify reproduces the removed zero pre-seed: every entity id present with a
+// score, defaulting to 0.
+func densify(m map[string]float64, ents []Entity) map[string]float64 {
+	out := make(map[string]float64, len(ents))
+	for _, e := range ents {
+		out[e.ID] = 0
+	}
+	for k, v := range m {
+		out[k] = v
+	}
+	return out
+}
+
+// sparseGraph wires edges among only the first `wired` entities, leaving the
+// rest isolated. With few non-zero betweenness scores and a 5% cut taken over
+// ALL entities, the god-node selection must fall through to the zero tail —
+// the case the removed pre-seed used to cover implicitly.
+func sparseGraph(n, wired int) ([]Entity, []Relationship) {
+	ents := make([]Entity, n)
+	for i := 0; i < n; i++ {
+		ents[i] = Entity{
+			ID:         fmt.Sprintf("s%05d", i),
+			Name:       fmt.Sprintf("S%d", i),
+			Kind:       "function",
+			SourceFile: "pkg/s.go",
+			Language:   "go",
+		}
+	}
+	var rels []Relationship
+	for i := 0; i+1 < wired; i++ {
+		rels = append(rels, Relationship{
+			ID:     RelationshipID(ents[i].ID, ents[i+1].ID, "CALLS"),
+			FromID: ents[i].ID,
+			ToID:   ents[i+1].ID,
+			Kind:   "CALLS",
+		})
+	}
+	return ents, rels
+}
+
+// matchingGraph pairs each of the first n/2 entities with one of the last n/2
+// (a perfect matching). No path has an interior node, so EVERY betweenness score
+// is zero and the 5% cut is filled entirely from the zero tail — ordered by id,
+// which is where the removed pre-seed's explicit zeros sorted. The matched
+// targets carry the higher PageRank, so the PageRank half of the god-node union
+// is disjoint from the betweenness half: dropping the tail is observable.
+func matchingGraph(n int) ([]Entity, []Relationship) {
+	ents, _ := sparseGraph(n, 0)
+	half := n / 2
+	rels := make([]Relationship, 0, half)
+	for i := 0; i < half; i++ {
+		from, to := ents[i].ID, ents[half+i].ID
+		rels = append(rels, Relationship{
+			ID:     RelationshipID(from, to, "CALLS"),
+			FromID: from,
+			ToID:   to,
+			Kind:   "CALLS",
+		})
+	}
+	return ents, rels
+}
+
+// TestGodNodesParityWithZeroPreSeed proves the #5954 removal of the zero
+// pre-seed is output-neutral: ranking the sparse betweenness map over the
+// entity universe selects exactly the god nodes the dense pre-seeded maps did.
+func TestGodNodesParityWithZeroPreSeed(t *testing.T) {
+	cases := []struct {
+		name string
+		ents []Entity
+		rels []Relationship
+	}{
+		{"dense", nil, nil},       // filled below
+		{"sparse-tail", nil, nil}, // filled below
+		{"tiny", nil, nil},
+		{"zero-tail-only", nil, nil},
+	}
+	cases[0].ents, cases[0].rels = buildSyntheticGraph(600, 4, 11)
+	cases[1].ents, cases[1].rels = sparseGraph(400, 12)
+	cases[2].ents, cases[2].rels = sparseGraph(7, 4)
+	cases[3].ents, cases[3].rels = matchingGraph(400)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, idx := BuildGraph(tc.ents, tc.rels)
+			betw, pr := ComputeCentrality(g, idx)
+
+			want := legacyIdentifyGodNodes(densify(betw, tc.ents), densify(pr, tc.ents))
+			got := identifyGodNodesFrom(betw, pr, idx)
+
+			if len(want) != len(got) {
+				t.Fatalf("god-node count: legacy=%d new=%d", len(want), len(got))
+			}
+			for id := range want {
+				if !got[id] {
+					t.Errorf("god node %q selected by the legacy pre-seeded ranking but not by the new one", id)
+				}
+			}
+			for id := range got {
+				if !want[id] {
+					t.Errorf("god node %q selected by the new ranking but not by the legacy pre-seeded one", id)
+				}
+			}
+			t.Logf("%s: entities=%d betw-keys=%d (dense would be %d) gods=%d",
+				tc.name, len(tc.ents), len(betw), len(tc.ents), len(got))
+		})
+	}
+}
+
+// TestEntityCentralityAttachmentParity proves the serialisation boundary is
+// preserved: every entity that took part in the pass still receives an explicit
+// centrality value (0 when it has no betweenness), so graph.json keeps the same
+// key set it had when the pre-seed existed. It mirrors the attachment loops in
+// cmd/grafel/index.go and dashboard.applyAlgorithmResults.
+func TestEntityCentralityAttachmentParity(t *testing.T) {
+	ents, rels := sparseGraph(300, 10)
+	res := RunAlgorithms(ents, rels)
+
+	attached := 0
+	for _, e := range ents {
+		pr, ok := res.PageRank[e.ID]
+		if !ok {
+			t.Fatalf("entity %q missing from PageRank: the attachment loops key centrality off it", e.ID)
+		}
+		_ = pr
+		attached++
+	}
+	if attached != len(ents) {
+		t.Fatalf("attached=%d want=%d", attached, len(ents))
+	}
+	if len(res.Centrality) >= len(ents) {
+		t.Errorf("Centrality map has %d entries for %d entities — it must be sparse", len(res.Centrality), len(ents))
+	}
+	for id, v := range res.Centrality {
+		if v == 0 {
+			t.Errorf("Centrality holds an explicit zero for %q; zeros must be absent", id)
+			break
+		}
+	}
+}

--- a/internal/graph/algorithms_sampled_test.go
+++ b/internal/graph/algorithms_sampled_test.go
@@ -126,8 +126,17 @@ func TestBetweennessSampleThresholdGate(t *testing.T) {
 		t.Fatalf("threshold override not honoured: got %d want 100000", got)
 	}
 	betwExact, _ := ComputeCentrality(g, idx)
-	if len(betwExact) != len(ents) {
-		t.Errorf("exact path: betw map has %d keys, want %d", len(betwExact), len(ents))
+	// The betweenness map is sparse (#5954): it carries non-zero scores only,
+	// never a zero pre-seed, so it must be non-empty but no larger than the
+	// node set.
+	if len(betwExact) == 0 || len(betwExact) > len(ents) {
+		t.Errorf("exact path: betw map has %d keys, want 1..%d", len(betwExact), len(ents))
+	}
+	for id, v := range betwExact {
+		if v == 0 {
+			t.Errorf("exact path: betw map holds an explicit zero for %q; zeros must be absent", id)
+			break
+		}
 	}
 }
 
@@ -203,8 +212,13 @@ func TestBetweennessPerfBudget_28k(t *testing.T) {
 	if elapsed > budget {
 		t.Errorf("centrality pass took %s, over budget %s", elapsed, budget)
 	}
-	if len(betw) != n || len(pr) != n {
-		t.Errorf("expected %d betw/%d pr keys, got %d/%d", n, n, len(betw), len(pr))
+	// PageRank is dense (a score per node); betweenness is sparse since #5954 —
+	// non-zero scores only, no zero pre-seed.
+	if len(pr) != n {
+		t.Errorf("expected %d pr keys, got %d", n, len(pr))
+	}
+	if len(betw) == 0 || len(betw) > n {
+		t.Errorf("expected 1..%d betw keys, got %d", n, len(betw))
 	}
 }
 

--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -317,8 +317,9 @@ func readOverlayUnconditional(path string) *Overlay {
 // applies to entities — are fully reconstructed.
 func overlayToResults(ov *Overlay, entities []graph.Entity) *graph.AlgorithmResults {
 	res := &graph.AlgorithmResults{
-		CommunityID:        make(map[string]int, len(ov.Results)),
-		Centrality:         make(map[string]float64, len(ov.Results)),
+		CommunityID: make(map[string]int, len(ov.Results)),
+		// Sparse: non-zero scores only, matching graph.ComputeCentrality.
+		Centrality:         map[string]float64{},
 		PageRank:           make(map[string]float64, len(ov.Results)),
 		GodNodes:           map[string]bool{},
 		ArticulationPoints: map[string]bool{},
@@ -336,7 +337,13 @@ func overlayToResults(ov *Overlay, entities []graph.Entity) *graph.AlgorithmResu
 		}
 		res.CommunityID[id] = eo.CommunityID
 		res.PageRank[id] = eo.PageRank
-		res.Centrality[id] = eo.Centrality
+		// #5954 — the Centrality map holds non-zero betweenness only (absent
+		// reads as 0), matching what graph.ComputeCentrality now returns, so a
+		// reconstituted result stays equal to a full recompute. The overlay
+		// itself still records an explicit 0 for every entity.
+		if eo.Centrality != 0 {
+			res.Centrality[id] = eo.Centrality
+		}
 		if eo.IsGodNode {
 			res.GodNodes[id] = true
 		}

--- a/internal/membench/algomaps_test.go
+++ b/internal/membench/algomaps_test.go
@@ -1,0 +1,73 @@
+package membench
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// TestAlgoResultMapFootprint measures the allocation cost of the Pass-4
+// algorithm sweep and pins the two structural properties that #5954 slice-2
+// depends on:
+//
+//  1. The betweenness map returned by ComputeCentrality is SPARSE — gonum
+//     reports non-zero scores only, so an entry per entity means storing zeros
+//     nobody wrote. Consumers read an absent key as 0.
+//  2. RunAlgorithms must not build an entity-name map: community naming needs
+//     at most 5 names per community, indexed off the node index.
+//
+// Property 1 is directly assertable (map length) and is the mutation gate: it
+// fails immediately if the zero pre-seed is restored. Property 2 is enforced by
+// ComputeCommunities' signature (a []string indexed by node id, not a
+// map[string]string).
+//
+// SIZE OF THE PRIZE, measured on this fixture at 433,333 entities: the sweep
+// allocates ~40 GB cumulatively and the two maps are worth ~17 MB of it, so the
+// bytes/allocs are LOGGED rather than asserted — a tight bound on a 40 GB total
+// would pin nothing. Note that betweenness turns out to be non-zero for ~91% of
+// nodes on a realistically-connected graph (394,494 of 433,333 here), so the
+// sparse map is only ~9% smaller than the pre-seeded one; the entity-name map
+// (21.5 MB -> 6.6 MB) is where most of the saving is.
+func TestAlgoResultMapFootprint(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping heavy memory bench in -short")
+	}
+	spec := specFromEnv()
+	doc := BuildSyntheticDocument(spec)
+	nEntities := len(doc.Entities)
+
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	res := graph.RunAlgorithms(doc.Entities, doc.Relationships)
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	// Live heap with the result still referenced: what the caller keeps paying.
+	runtime.GC()
+	var live runtime.MemStats
+	runtime.ReadMemStats(&live)
+
+	t.Logf("ALGO-MAPS entities=%d rels=%d", nEntities, len(doc.Relationships))
+	t.Logf("  total-alloc delta = %d MB (%d allocs)",
+		(after.TotalAlloc-before.TotalAlloc)/(1024*1024), after.Mallocs-before.Mallocs)
+	t.Logf("  live heap holding result = %d MB", live.HeapAlloc/(1024*1024))
+	t.Logf("  len(PageRank)=%d len(Centrality)=%d len(CommunityID)=%d",
+		len(res.PageRank), len(res.Centrality), len(res.CommunityID))
+
+	// PageRank is dense by construction (gonum returns a score for every node).
+	if len(res.PageRank) != nEntities {
+		t.Errorf("PageRank map = %d entries, want one per entity (%d)", len(res.PageRank), nEntities)
+	}
+	// Betweenness must NOT be pre-seeded with a zero for every entity.
+	if len(res.Centrality) >= nEntities {
+		t.Errorf("Centrality map = %d entries for %d entities: betweenness map is dense; "+
+			"the zero pre-seed must be gone (absent key == 0)", len(res.Centrality), nEntities)
+	}
+
+	runtime.KeepAlive(doc)
+	runtime.KeepAlive(res)
+}


### PR DESCRIPTION
## What

Removes two allocations from `RunAlgorithmsWithOptions`: a per-entity zero pre-seed of the `betw` and `pr` maps (~433k entries each on the reference corpus), and an eager `names map[string]string` held live for the whole pass.

## Measured — and much smaller than estimated

**~17 MB**, not the ~135 MB this was scoped at. The estimate was wrong for two reasons, both found by measuring rather than reasoning:

- **`pr`'s pre-seed saved zero bytes.** `network.PageRankSparse` returns a score for every node and `BuildGraph` inserts a node per entity, so the map is fully populated one loop later regardless. Removing the pre-seed eliminates ~433k redundant map writes — a CPU win, not a memory one.
- **Betweenness is not "mostly zeros".** On a realistically-connected graph it is non-zero for **91%** of nodes (394,494 / 433,333, independently reproduced at 60k entities → 91.05%). Sparsifying saves ~9% of one map.

The `names` map was the entire prize: 21.5 MB → 6.6 MB via `[]string` indexed by node id.

End-to-end at 433,333 entities / 2.67M rels: live heap holding the result 1004 → 1003 MB, `len(Centrality)` 433,333 → 394,494.

## What the pre-seeded keys were load-bearing for — all three preserved

1. **`IdentifyGodNodes`** took `k = len(m)/20`, and zero-scored entities *filled* the cut in id order when positives ran out. `identifyGodNodesFrom` now takes the universe from the node index: positives ranked first, then the zero tail by id. `k` is computed over the same universe (`int(idx.next)` == distinct entity count), so the cut size is unchanged.
2. **`Entity.Centrality` is `*float64` with `omitempty`** — nil omits the key, pointer-to-zero emits `"centrality":0`. Both attachment loops now gate on **PageRank** membership (still dense, exactly the entities in the pass) and read centrality with the zero default.
3. **`groupalgo.BuildOverlay`** already zero-defaulted and iterates `PageRank`; `EntityOverlay.Centrality` is a non-pointer `float64` with no omitempty. Overlay bytes unchanged, no `OverlayAlgoVersion` bump.

## Verified byte-identical

Differential tests run at `536876b3a` vs this commit, on fixtures built specifically for the removed pre-seed's cases — a 30-node chain (non-zero interiors), a 20-pair perfect matching (all-zero betweenness, connected), and **50 fully isolated entities**:

| surface | base | new | diff |
|---|---|---|---|
| `graph.json` entities | `len(Centrality)=120`, 12 god nodes | `len(Centrality)=28`, 12 god nodes | **byte-identical** |
| group overlay JSON | — | — | **byte-identical** |
| god-node cut filled entirely from the zero tail (400 entities, k=20, 10 positives) | 20 god nodes | 20 god nodes | **byte-identical** |

Every `"centrality":0` survives, including for entities absent from any relationship.

The god-node parity oracle (`legacyIdentifyGodNodes`) is a verbatim copy of the pre-change implementation, diffed line-by-line; it shares no code with the new path.

## Test gap found in review and closed

Reverting **both** attachment sites to `if c, ok := res.Centrality[e.ID]; ok` originally passed the entire suite — precisely the edit that would silently drop `"centrality":0` for ~9% of entities. The parity test *mirrored* the attachment loop rather than invoking it. Two new tests now call the real loops (`runPass4Algorithms`, `attachAlgorithmResults`) on a fixture containing zero-betweenness and isolated entities, and assert the serialised form contains `"centrality":0` — pinning the `omitempty` behaviour, not just the pointer. Mutation confirmed dead at both sites.

## Downgrade note (corrected)

The dashboard's `graph-algo.json` sidecar now serialises a sparse Centrality map. `loadPersistedAlgoResults` keys on the **graph.fb mtime only** — no binary or schema version — so this is **not** version-invalidated. An older binary reading a new sidecar without re-indexing leaves `Centrality` nil for zero-betweenness entities and omits `betweenness` instead of emitting `0`. Cosmetic; pagerank/community/god-node/articulation unaffected; re-indexing rewrites it. The forward direction is exact.

## Also

Exported `IdentifyGodNodes` is deleted. It ranked each map over its own key set, which was the entity universe *only* while the pre-seed existed — post-change an entry point taking just the two maps cannot compute the cut correctly, so leaving it exported would invite a subtly wrong call. Zero callers, zero direct tests.

Independently adversarially reviewed.

Refs #5954
