### PR TITLE
perf(#5954): reuse betweenness scratch across pivots — -675MB peak on the reference corpus

### DIFF
--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -44,6 +44,7 @@ import (
 	"math"
 	"math/rand/v2"
 	"os"
+	"slices"
 	"sort"
 	"time"
 
@@ -845,53 +846,14 @@ func sampledBetweenness(g *simple.WeightedDirectedGraph, k int, seed uint64) map
 	}
 	pivots := perm[:k]
 
-	// Pre-extract successor adjacency once (avoids repeated gonum map lookups).
-	succ := make(map[int64][]int64, v)
-	for _, id := range ids {
-		var out []int64
-		it := g.From(id)
-		for it.Next() {
-			out = append(out, it.Node().ID())
-		}
-		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] }) // determinism
-		succ[id] = out
-	}
+	// Dense successor adjacency, built once. Node i is the i-th entry of the
+	// ascending-id `ids` slice, so adjacency sorted by dense index is the same
+	// order as the previous sort-by-node-id — every float summation below
+	// therefore happens in exactly the order the map-based version used.
+	sc := newBCScratch(g, ids)
 
 	for _, s := range pivots {
-		// Single-source Brandes (unweighted BFS).
-		stack := make([]int64, 0, v)
-		pred := make(map[int64][]int64, v)
-		sigma := make(map[int64]float64, v)
-		dist := make(map[int64]int, v)
-		sigma[s] = 1
-		dist[s] = 0
-		queue := []int64{s}
-		for len(queue) > 0 {
-			cur := queue[0]
-			queue = queue[1:]
-			stack = append(stack, cur)
-			for _, w := range succ[cur] {
-				if _, seen := dist[w]; !seen {
-					dist[w] = dist[cur] + 1
-					queue = append(queue, w)
-				}
-				if dist[w] == dist[cur]+1 {
-					sigma[w] += sigma[cur]
-					pred[w] = append(pred[w], cur)
-				}
-			}
-		}
-		// Back-accumulation.
-		delta := make(map[int64]float64, len(stack))
-		for i := len(stack) - 1; i >= 0; i-- {
-			w := stack[i]
-			for _, p := range pred[w] {
-				delta[p] += (sigma[p] / sigma[w]) * (1 + delta[w])
-			}
-			if w != s {
-				cb[w] += delta[w]
-			}
-		}
+		sc.accumulatePivot(sc.dense.of(s), cb, ids)
 	}
 
 	// Rescale so sampled magnitudes match full Brandes (V/K estimator scale).
@@ -900,6 +862,247 @@ func sampledBetweenness(g *simple.WeightedDirectedGraph, k int, seed uint64) map
 		cb[id] *= scale
 	}
 	return cb
+}
+
+// denseIDMap maps a gonum node id to its index in an ascending-sorted id slice.
+//
+// BuildGraph hands out node ids sequentially from 0, so in production ids[i]==i
+// and the lookup is a subtraction. The map fallback covers any caller that
+// supplies a sparse id space (e.g. a graph built by hand in a test).
+type denseIDMap struct {
+	contiguous bool
+	base       int64
+	byID       map[int64]int32
+}
+
+func newDenseIDMap(ids []int64) *denseIDMap {
+	d := &denseIDMap{contiguous: true}
+	if len(ids) == 0 {
+		return d
+	}
+	d.base = ids[0]
+	for i, id := range ids {
+		if id != d.base+int64(i) {
+			d.contiguous = false
+			break
+		}
+	}
+	if !d.contiguous {
+		d.byID = make(map[int64]int32, len(ids))
+		for i, id := range ids {
+			d.byID[id] = int32(i)
+		}
+	}
+	return d
+}
+
+func (d *denseIDMap) of(id int64) int32 {
+	if d.contiguous {
+		return int32(id - d.base)
+	}
+	return d.byID[id]
+}
+
+// bcScratch is the reusable working set for sampled Brandes. Every field is
+// allocated ONCE for the whole K-pivot run; a pivot mutates it and then restores
+// only the entries it touched. This is the #5954 fix: the previous version
+// allocated four V-hinted maps plus a V-capacity stack PER PIVOT, which on the
+// reference corpus (V=427k, K=512) churned ~25 GB to produce a 9 MB result.
+//
+// Representation choices, all of which preserve the exact arithmetic order of
+// the map-based original:
+//
+//   - dist is generation-stamped (`gen`/`curGen`) so it is never cleared: a
+//     dist entry is meaningful only when gen[i] == curGen, which makes "has this
+//     pivot's BFS seen node i?" an O(1) test with no per-pivot O(V) reset.
+//   - sigma/delta are flat float64 slices indexed by dense node index instead of
+//     map[int64]float64.
+//   - predecessors are a linked list over the CSR edge slots (predHead/predNext/
+//     predNode) instead of a map of append-grown slices.
+//   - the BFS queue and the Brandes stack are the same sequence (dequeue order
+//     == the order nodes are pushed), so one slice with a read cursor serves as
+//     both.
+//
+// The two EXACT betweenness paths (betweennessPathExactWeighted and
+// betweennessPathExactBrandes) are gonum's own implementations and deliberately
+// do NOT share this scratch: they run only below betweennessSampleThreshold
+// (8000 nodes) where the per-source allocation is not the bottleneck, and
+// rewriting them would put their output — which this change keeps byte-identical
+// — at risk for no memory benefit.
+type bcScratch struct {
+	n   int
+	off []int32 // len n+1, CSR row offsets into adj
+	adj []int32 // len off[n], successor dense indices, ascending within a row
+
+	dist   []int32  // valid only where gen[i] == curGen
+	gen    []uint32 // generation stamp per node
+	curGen uint32
+
+	sigma []float64 // path counts; reset to 0 for touched nodes after each pivot
+	delta []float64 // dependencies; reset to 0 for touched nodes after each pivot
+
+	stack []int32 // BFS visit order; doubles as the back-accumulation stack
+
+	predHead []int32 // len n, -1 == empty; head slot of the predecessor list
+	predNext []int32 // len off[n], next slot in the predecessor list, -1 == end
+	predNode []int32 // len off[n], the predecessor's dense index
+	predCnt  int32   // slots used by the current pivot
+
+	// dense maps gonum node ids to dense indices; retained so callers can
+	// translate a pivot id without rebuilding the mapping.
+	dense *denseIDMap
+}
+
+// newBCScratch builds the dense successor CSR and allocates all per-run scratch.
+// ids must be ascending; dense index i corresponds to gonum node ids[i].
+func newBCScratch(g *simple.WeightedDirectedGraph, ids []int64) *bcScratch {
+	n := len(ids)
+	sc := &bcScratch{
+		n:        n,
+		dense:    newDenseIDMap(ids),
+		off:      make([]int32, n+1),
+		dist:     make([]int32, n),
+		gen:      make([]uint32, n),
+		sigma:    make([]float64, n),
+		delta:    make([]float64, n),
+		stack:    make([]int32, 0, n),
+		predHead: make([]int32, n),
+	}
+	if n == 0 {
+		return sc
+	}
+
+	// Materialise the edge list ONCE via a single global iterator. Calling
+	// g.From(id) per node instead would allocate one gonum iterator per node
+	// per pass — 2V allocations and hundreds of MB of churn at corpus scale.
+	dense := sc.dense
+	type edge struct{ u, v int32 }
+	var edges []edge
+	if it := g.Edges(); it != nil {
+		edges = make([]edge, 0, it.Len())
+		for it.Next() {
+			e := it.Edge()
+			edges = append(edges, edge{dense.of(e.From().ID()), dense.of(e.To().ID())})
+		}
+	}
+
+	for i := range edges {
+		sc.off[edges[i].u+1]++
+	}
+	for i := 0; i < n; i++ {
+		sc.off[i+1] += sc.off[i]
+	}
+	total := sc.off[n]
+	sc.adj = make([]int32, total)
+	sc.predNext = make([]int32, total)
+	sc.predNode = make([]int32, total)
+
+	cursor := make([]int32, n)
+	copy(cursor, sc.off[:n])
+	for i := range edges {
+		e := edges[i]
+		sc.adj[cursor[e.u]] = e.v
+		cursor[e.u]++
+	}
+	// gonum's edge iteration order is map-derived and unstable, so each row is
+	// sorted by dense index (== ascending node id). slices.Sort, not sort.Slice:
+	// the latter allocates a closure and a reflect-based swapper per row, which
+	// at corpus scale is V extra allocations.
+	for i := 0; i < n; i++ {
+		slices.Sort(sc.adj[sc.off[i]:sc.off[i+1]])
+	}
+
+	for i := range sc.predHead {
+		sc.predHead[i] = -1
+	}
+	return sc
+}
+
+// accumulatePivot runs one single-source Brandes pass from pivot s (a dense
+// index), adding its dependency contributions into cb (keyed by gonum node id),
+// then restores the scratch so the next pivot starts from a clean state.
+//
+// The float arithmetic is identical to the map-based original:
+//   - sigma[w] accumulates over predecessors in BFS-discovery order, which is
+//     fixed by (queue order, ascending-successor order) — unchanged here.
+//   - in the back-accumulation, a given w contributes to delta[p] for each of
+//     its predecessors p; the graph is simple, so p appears at most ONCE in
+//     pred[w] and each delta[p] receives exactly one += per w. Predecessor
+//     iteration order therefore cannot change any sum, only which distinct
+//     accumulator is touched. The order of w itself (reverse stack) is
+//     unchanged, so delta[p] sees its addends in the same sequence as before.
+func (sc *bcScratch) accumulatePivot(s int32, cb map[int64]float64, ids []int64) {
+	if sc.n == 0 || int(s) >= sc.n {
+		return
+	}
+	sc.curGen++
+	if sc.curGen == 0 {
+		// Generation counter wrapped: clear the stamps so no stale entry can
+		// alias generation 0. Happens at most once per 4 billion pivots.
+		for i := range sc.gen {
+			sc.gen[i] = 0
+		}
+		sc.curGen = 1
+	}
+	gen := sc.curGen
+	sc.predCnt = 0
+	sc.stack = sc.stack[:0]
+
+	sc.dist[s] = 0
+	sc.gen[s] = gen
+	sc.sigma[s] = 1
+	sc.stack = append(sc.stack, s)
+
+	// BFS. `head` is the queue read cursor into stack; stack grows as nodes are
+	// enqueued, so stack[head:] is exactly the pending queue.
+	for head := 0; head < len(sc.stack); head++ {
+		cur := sc.stack[head]
+		dcur := sc.dist[cur]
+		scur := sc.sigma[cur]
+		for p := sc.off[cur]; p < sc.off[cur+1]; p++ {
+			w := sc.adj[p]
+			if sc.gen[w] != gen {
+				sc.gen[w] = gen
+				sc.dist[w] = dcur + 1
+				sc.stack = append(sc.stack, w)
+			}
+			if sc.dist[w] == dcur+1 {
+				sc.sigma[w] += scur
+				// Prepend cur onto w's predecessor list. Order within the list
+				// is irrelevant to the sums (see the doc comment above).
+				slot := sc.predCnt
+				sc.predCnt++
+				sc.predNode[slot] = cur
+				sc.predNext[slot] = sc.predHead[w]
+				sc.predHead[w] = slot
+			}
+		}
+	}
+
+	// Back-accumulation, then per-node cleanup in the same sweep.
+	for i := len(sc.stack) - 1; i >= 0; i-- {
+		w := sc.stack[i]
+		sw := sc.sigma[w]
+		// Kept in the ORIGINAL (sigma[p]/sigma[w]) * (1+delta[w]) form. Hoisting
+		// the division out as (1+delta[w])/sigma[w] would be algebraically equal
+		// but NOT bit-identical, and this feeds a persisted ranking.
+		// delta[w] cannot change inside this loop: every p has dist[p] < dist[w],
+		// so p != w.
+		factor := 1 + sc.delta[w]
+		for slot := sc.predHead[w]; slot >= 0; slot = sc.predNext[slot] {
+			p := sc.predNode[slot]
+			sc.delta[p] += (sc.sigma[p] / sw) * factor
+		}
+		if w != s {
+			cb[ids[w]] += sc.delta[w]
+		}
+	}
+	// Reset only what this pivot touched. dist/gen need no reset (stamped).
+	for _, w := range sc.stack {
+		sc.sigma[w] = 0
+		sc.delta[w] = 0
+		sc.predHead[w] = -1
+	}
 }
 
 // runtimeMSFor returns wall-clock milliseconds elapsed since start, or 0

--- a/internal/graph/algorithms_betweenness_mem_test.go
+++ b/internal/graph/algorithms_betweenness_mem_test.go
@@ -1,0 +1,450 @@
+package graph
+
+import (
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"runtime"
+	"sort"
+	"testing"
+	"time"
+
+	gonumgraph "gonum.org/v1/gonum/graph"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// sampledBetweennessLegacy is a verbatim copy of the pre-#5954-slice-3
+// implementation of sampledBetweenness: four per-pivot maps hinted at V
+// entries (pred/sigma/dist/delta) plus a per-pivot stack, for every pivot.
+//
+// It is retained ONLY as the byte-identity oracle for the scratch-reusing
+// production implementation. Do not call it outside tests.
+func sampledBetweennessLegacy(g *simple.WeightedDirectedGraph, k int, seed uint64) map[int64]float64 {
+	nodes := gonumgraph.NodesOf(g.Nodes())
+	v := len(nodes)
+	cb := make(map[int64]float64, v)
+	if v == 0 {
+		return cb
+	}
+	ids := make([]int64, v)
+	for i, n := range nodes {
+		ids[i] = n.ID()
+	}
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+
+	if k > v {
+		k = v
+	}
+	rng := rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15)) //nolint:gosec // reproducibility, not security
+	perm := make([]int64, v)
+	copy(perm, ids)
+	for i := 0; i < k; i++ {
+		j := i + int(rng.Uint64N(uint64(v-i)))
+		perm[i], perm[j] = perm[j], perm[i]
+	}
+	pivots := perm[:k]
+
+	succ := make(map[int64][]int64, v)
+	for _, id := range ids {
+		var out []int64
+		it := g.From(id)
+		for it.Next() {
+			out = append(out, it.Node().ID())
+		}
+		sort.Slice(out, func(i, j int) bool { return out[i] < out[j] })
+		succ[id] = out
+	}
+
+	for _, s := range pivots {
+		stack := make([]int64, 0, v)
+		pred := make(map[int64][]int64, v)
+		sigma := make(map[int64]float64, v)
+		dist := make(map[int64]int, v)
+		sigma[s] = 1
+		dist[s] = 0
+		queue := []int64{s}
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			stack = append(stack, cur)
+			for _, w := range succ[cur] {
+				if _, seen := dist[w]; !seen {
+					dist[w] = dist[cur] + 1
+					queue = append(queue, w)
+				}
+				if dist[w] == dist[cur]+1 {
+					sigma[w] += sigma[cur]
+					pred[w] = append(pred[w], cur)
+				}
+			}
+		}
+		delta := make(map[int64]float64, len(stack))
+		for i := len(stack) - 1; i >= 0; i-- {
+			w := stack[i]
+			for _, p := range pred[w] {
+				delta[p] += (sigma[p] / sigma[w]) * (1 + delta[w])
+			}
+			if w != s {
+				cb[w] += delta[w]
+			}
+		}
+	}
+
+	scale := float64(v) / float64(k)
+	for id := range cb {
+		cb[id] *= scale
+	}
+	return cb
+}
+
+// buildHeavyTailedGraph builds a deterministic directed graph whose in-degree
+// distribution is heavy-tailed (preferential attachment), and whose nodes are
+// clustered so one cluster holds a disproportionate share of the entities.
+// This matches the reference corpus shape (hub nodes, one community holding
+// ~26% of entities) far better than a uniform-random synthetic graph, so
+// memory numbers measured on it are not misleading.
+func buildHeavyTailedGraph(n, edgesPerNode int, seed uint64) ([]Entity, []Relationship) {
+	rng := rand.New(rand.NewPCG(seed, seed^0x9e3779b97f4a7c15))
+	ents := make([]Entity, n)
+	for i := 0; i < n; i++ {
+		// Cluster 0 holds ~26% of entities; the remainder spread over 40 more.
+		cluster := 0
+		if i%100 >= 26 {
+			cluster = 1 + (i % 40)
+		}
+		ents[i] = Entity{
+			ID:         fmt.Sprintf("e%07d", i),
+			Name:       fmt.Sprintf("E%d", i),
+			Kind:       "function",
+			SourceFile: fmt.Sprintf("pkg%02d/file%d.go", cluster, i/64),
+			Language:   "go",
+		}
+	}
+
+	// Preferential attachment: repeat[] holds each node once per inbound edge
+	// already received, so drawing uniformly from it draws proportional to
+	// current in-degree — the standard Barabasi-Albert generator.
+	repeat := make([]int32, 0, n*edgesPerNode*2)
+	for i := 0; i < n && i < 32; i++ {
+		repeat = append(repeat, int32(i))
+	}
+
+	rels := make([]Relationship, 0, n*edgesPerNode)
+	seen := make(map[uint64]struct{}, n*edgesPerNode)
+	for i := 32; i < n; i++ {
+		for d := 0; d < edgesPerNode; d++ {
+			to := int(repeat[rng.Uint64N(uint64(len(repeat)))])
+			if to == i {
+				continue
+			}
+			key := uint64(i)<<32 | uint64(uint32(to))
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			rels = append(rels, Relationship{
+				ID:     fmt.Sprintf("e%07d->e%07d-%d", i, to, d),
+				FromID: ents[i].ID,
+				ToID:   ents[to].ID,
+				Kind:   "CALLS",
+			})
+			repeat = append(repeat, int32(to))
+		}
+		repeat = append(repeat, int32(i))
+	}
+	return ents, rels
+}
+
+// assertSameBetweenness fails unless two raw betweenness maps are identical
+// key-set and BIT-identical value-for-value (not merely close).
+func assertSameBetweenness(t *testing.T, want, got map[int64]float64) {
+	t.Helper()
+	if len(want) != len(got) {
+		t.Fatalf("key count differs: legacy=%d new=%d", len(want), len(got))
+	}
+	var maxRelErr float64
+	mismatch := 0
+	for id, wv := range want {
+		gv, ok := got[id]
+		if !ok {
+			t.Fatalf("node %d present in legacy output but missing from new output", id)
+		}
+		if math.Float64bits(wv) != math.Float64bits(gv) {
+			mismatch++
+			if wv != 0 {
+				if e := math.Abs(gv-wv) / math.Abs(wv); e > maxRelErr {
+					maxRelErr = e
+				}
+			}
+			if mismatch <= 5 {
+				t.Errorf("node %d: legacy=%v new=%v (bits %x vs %x)", id, wv, gv,
+					math.Float64bits(wv), math.Float64bits(gv))
+			}
+		}
+	}
+	if mismatch > 0 {
+		t.Fatalf("%d/%d values are not bit-identical (max rel err %g)", mismatch, len(want), maxRelErr)
+	}
+}
+
+// TestSampledBetweenness_BitIdenticalToLegacy is the correctness contract: the
+// scratch-reusing implementation must reproduce the legacy per-pivot-allocating
+// implementation BIT for BIT, on a heavy-tailed graph with hubs, multiple
+// shortest paths and unreachable nodes.
+func TestSampledBetweenness_BitIdenticalToLegacy(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		n    int
+		deg  int
+		k    int
+		seed uint64
+	}{
+		{"small", 300, 3, 64, 1},
+		{"mid", 3000, 4, 128, 7},
+		{"k-exceeds-v", 40, 3, 512, 11},
+		{"dense", 800, 8, 256, 13},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ents, rels := buildHeavyTailedGraph(tc.n, tc.deg, tc.seed)
+			g, _ := BuildGraph(ents, rels)
+			want := sampledBetweennessLegacy(g, tc.k, betweennessSampleSeed)
+			got := sampledBetweenness(g, tc.k, betweennessSampleSeed)
+			assertSameBetweenness(t, want, got)
+			nonzero := 0
+			for _, v := range got {
+				if v != 0 {
+					nonzero++
+				}
+			}
+			t.Logf("%s: V=%d entries=%d nonzero=%d", tc.name, tc.n, len(got), nonzero)
+		})
+	}
+}
+
+// TestSampledBetweenness_EmptyAndIsolated covers the degenerate shapes: an
+// empty graph, and a graph with no edges at all (every BFS visits one node).
+func TestSampledBetweenness_EmptyAndIsolated(t *testing.T) {
+	empty := simple.NewWeightedDirectedGraph(0, 0)
+	if got := sampledBetweenness(empty, 8, betweennessSampleSeed); len(got) != 0 {
+		t.Fatalf("empty graph: want 0 entries, got %d", len(got))
+	}
+
+	ents := make([]Entity, 50)
+	for i := range ents {
+		ents[i] = Entity{ID: fmt.Sprintf("e%d", i), Name: fmt.Sprintf("E%d", i), Kind: "function"}
+	}
+	g, _ := BuildGraph(ents, nil)
+	want := sampledBetweennessLegacy(g, 8, betweennessSampleSeed)
+	got := sampledBetweenness(g, 8, betweennessSampleSeed)
+	assertSameBetweenness(t, want, got)
+}
+
+// TestComputeCentrality_ByteIdenticalOnSampledPath asserts the rounded,
+// string-keyed Centrality map that actually reaches disk is unchanged.
+func TestComputeCentrality_ByteIdenticalOnSampledPath(t *testing.T) {
+	t.Setenv("GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD", "10")
+	ents, rels := buildHeavyTailedGraph(4000, 4, 3)
+	g, idx := BuildGraph(ents, rels)
+
+	legacyRaw := sampledBetweennessLegacy(g, betweennessSampleSize, betweennessSampleSeed)
+	want := make(map[string]float64, len(ents))
+	for _, id := range idx.toInt {
+		want[idx.fromInt[id]] = 0
+	}
+	for nid, v := range legacyRaw {
+		want[idx.fromInt[nid]] = roundForDeterminism(sanitizeFloat(v))
+	}
+
+	got, _ := ComputeCentrality(g, idx)
+	if len(want) != len(got) {
+		t.Fatalf("centrality key count: legacy=%d new=%d", len(want), len(got))
+	}
+	nonzero, mismatch := 0, 0
+	for id, wv := range want {
+		gv := got[id]
+		if math.Float64bits(wv) != math.Float64bits(gv) {
+			mismatch++
+			if mismatch <= 5 {
+				t.Errorf("centrality[%s]: legacy=%v new=%v", id, wv, gv)
+			}
+		}
+		if gv != 0 {
+			nonzero++
+		}
+	}
+	if mismatch > 0 {
+		t.Fatalf("%d centrality values differ after rounding", mismatch)
+	}
+	t.Logf("centrality: %d keys, %d nonzero, 0 mismatches after roundForDeterminism", len(got), nonzero)
+}
+
+// TestSampledBetweenness_Deterministic re-runs the same input and requires a
+// bit-identical result, including across an interleaved unrelated run (which
+// would expose scratch left dirty between calls).
+func TestSampledBetweenness_Deterministic(t *testing.T) {
+	ents, rels := buildHeavyTailedGraph(2000, 4, 21)
+	g, _ := BuildGraph(ents, rels)
+	a := sampledBetweenness(g, 128, betweennessSampleSeed)
+	other, orels := buildHeavyTailedGraph(500, 3, 22)
+	og, _ := BuildGraph(other, orels)
+	_ = sampledBetweenness(og, 64, betweennessSampleSeed)
+	b := sampledBetweenness(g, 128, betweennessSampleSeed)
+	assertSameBetweenness(t, a, b)
+}
+
+// betweennessMemProbe runs fn while sampling runtime HeapInuse, and returns the
+// peak HeapInuse observed above the pre-call baseline plus the total bytes
+// allocated (churn) during the call.
+//
+// Peak HeapInuse — not TotalAlloc — is the number that decides whether the
+// indexer swaps, so it is what this asserts. TotalAlloc is reported alongside
+// because it is deterministic and pins down per-pivot allocation directly.
+func betweennessMemProbe(fn func()) (peakHeapInuse, totalAlloc uint64) {
+	runtime.GC()
+	var base runtime.MemStats
+	runtime.ReadMemStats(&base)
+
+	done := make(chan struct{})
+	peakCh := make(chan uint64, 1)
+	go func() {
+		var peak uint64
+		var ms runtime.MemStats
+		for {
+			select {
+			case <-done:
+				peakCh <- peak
+				return
+			default:
+			}
+			runtime.ReadMemStats(&ms)
+			if ms.HeapInuse > peak {
+				peak = ms.HeapInuse
+			}
+			time.Sleep(200 * time.Microsecond)
+		}
+	}()
+
+	fn()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+	close(done)
+	peak := <-peakCh
+	if after.HeapInuse > peak {
+		peak = after.HeapInuse
+	}
+	if peak > base.HeapInuse {
+		peakHeapInuse = peak - base.HeapInuse
+	}
+	return peakHeapInuse, after.TotalAlloc - base.TotalAlloc
+}
+
+// TestSampledBetweenness_ScratchIsReusedAcrossPivots is the anti-regression
+// guard for the whole point of this change: scratch must be allocated ONCE,
+// not per pivot.
+//
+// The assertion is on the MARGINAL cost of a pivot: the same graph is run at
+// two pivot counts and the churn difference is divided by the pivot-count
+// difference. Every one-time cost (CSR build, scratch allocation, result map)
+// cancels, so the number left is exactly "bytes allocated per additional
+// pivot". Legacy allocates four V-hinted maps + a V-capacity stack per pivot,
+// which at V=60k is several MB; the scratch-reusing version must be ~0.
+func TestSampledBetweenness_ScratchIsReusedAcrossPivots(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping memory-budget test in -short mode")
+	}
+	const n = 60_000
+	ents, rels := buildHeavyTailedGraph(n, 5, 0x5954)
+	g, _ := BuildGraph(ents, rels)
+
+	const kLo, kHi = 64, 512
+	var out map[int64]float64
+	_, churnLo := betweennessMemProbe(func() {
+		out = sampledBetweenness(g, kLo, betweennessSampleSeed)
+	})
+	runtime.KeepAlive(out)
+	peakHeap, churnHi := betweennessMemProbe(func() {
+		out = sampledBetweenness(g, kHi, betweennessSampleSeed)
+	})
+	runtime.KeepAlive(out)
+	runtime.KeepAlive(g)
+
+	var marginal float64
+	if churnHi > churnLo {
+		marginal = float64(churnHi-churnLo) / float64(kHi-kLo)
+	}
+	t.Logf("V=%d E=%d: churn K=%d -> %.1f MB, K=%d -> %.1f MB; marginal = %.1f KB/pivot; peak HeapInuse over baseline (K=%d) = %.1f MB; result entries = %d",
+		n, len(rels),
+		kLo, float64(churnLo)/(1<<20), kHi, float64(churnHi)/(1<<20),
+		marginal/(1<<10), kHi, float64(peakHeap)/(1<<20), len(out))
+
+	// At V=60k the legacy per-pivot scratch is >1 MB. 32 KB/pivot leaves ample
+	// room for the result map filling in as more pivots run, while being ~30x
+	// below anything that allocates per-node state per pivot.
+	if marginal > 32*1024 {
+		t.Errorf("marginal allocation %.1f KB per additional pivot exceeds 32 KB — scratch is not being reused across pivots",
+			marginal/(1<<10))
+	}
+
+	// Peak HeapInuse: scratch is O(V+E) ints/floats. At V=60k / E~300k that is
+	// well under the budget even with the result map and GC slack. Legacy peaked
+	// at ~161 MB over baseline on this exact shape.
+	const peakBudget = 64 << 20
+	if peakHeap > peakBudget {
+		t.Errorf("peak HeapInuse over baseline %.1f MB exceeds budget %.1f MB",
+			float64(peakHeap)/(1<<20), float64(peakBudget)/(1<<20))
+	}
+}
+
+// BenchmarkSampledBetweenness_HeavyTailed measures the production pivot count
+// on a heavy-tailed graph and reports peak HeapInuse over baseline as a custom
+// metric, alongside the standard -benchmem churn numbers.
+func BenchmarkSampledBetweenness_HeavyTailed(b *testing.B) {
+	const n = 60_000
+	ents, rels := buildHeavyTailedGraph(n, 5, 0x5954)
+	g, _ := BuildGraph(ents, rels)
+
+	var peakSum, iters uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out map[int64]float64
+		p, _ := betweennessMemProbe(func() {
+			out = sampledBetweenness(g, betweennessSampleSize, betweennessSampleSeed)
+		})
+		runtime.KeepAlive(out)
+		peakSum += p
+		iters++
+	}
+	b.StopTimer()
+	if iters > 0 {
+		b.ReportMetric(float64(peakSum/iters)/(1<<20), "peakHeapInuseMB")
+	}
+	runtime.KeepAlive(g)
+}
+
+// BenchmarkSampledBetweennessLegacy_HeavyTailed is the before-picture for the
+// same shape, so the peak-HeapInuse delta is reproducible on demand.
+func BenchmarkSampledBetweennessLegacy_HeavyTailed(b *testing.B) {
+	const n = 60_000
+	ents, rels := buildHeavyTailedGraph(n, 5, 0x5954)
+	g, _ := BuildGraph(ents, rels)
+
+	var peakSum, iters uint64
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var out map[int64]float64
+		p, _ := betweennessMemProbe(func() {
+			out = sampledBetweennessLegacy(g, betweennessSampleSize, betweennessSampleSeed)
+		})
+		runtime.KeepAlive(out)
+		peakSum += p
+		iters++
+	}
+	b.StopTimer()
+	if iters > 0 {
+		b.ReportMetric(float64(peakSum/iters)/(1<<20), "peakHeapInuseMB")
+	}
+	runtime.KeepAlive(g)
+}


### PR DESCRIPTION
## What

Rewrites `sampledBetweenness` to reuse scratch across pivots instead of allocating per pivot: generation-stamped `dist`, flat `sigma`/`delta` slices indexed by dense node id, linked-list predecessors, one reusable stack, and a minimal directed unweighted CSR built once.

## Why — measured on the real corpus

`sampledBetweenness` allocated **four maps hinted at 427k entries** (`pred`, `sigma`, `dist`, `delta`) **plus a 427k stack, per pivot, across 512 pivots** — roughly **21 GB of allocation to produce 9 MB of result**. A heap profile mid-phase showed 1,842 MB HeapInuse against only 922 MB live; the rest was uncollected garbage.

It was the single largest memory consumer in the indexing pipeline, and it had been walked past repeatedly because it costs only **8 seconds** of wall time. Time and memory are independent axes here.

## Measured

Reference corpus (`427,301` entities / `1,852,625` relationships → V=427,301, E=1,334,444 after `BuildGraph` collapses parallel edges), K=512, measured with the whole graph resident so GC pacing matches production:

| | peak over baseline | churn |
|---|---|---|
| before | 844.2 MB | 21,297.8 MB |
| after | **169.0 MB** | **169.0 MB** |

**−675 MB peak, 126× less churn.** Synthetic benchmark at V=60k: 165.3 → 39.2 MB peak, 1,073,887 → 321 allocs/op, 3.69s → 0.32s.

## Output is bit-identical, not "close"

Compared against a **verbatim copy** of the pre-change implementation (mechanically diffed against `87787cf0e` — zero code differences) using `math.Float64bits`:

- **Real corpus: 26,249 output entries, every one bit-identical.**
- Synthetic: 4 shapes in-commit, plus review coverage of out/in/bidirectional stars (hub degree 9998), fully disconnected graphs, 25-component mixed graphs, complete digraphs, a 30×30 lattice, a 1000-node chain, non-contiguous/stride/random/**negative** node ids, `k>V`, `k=1`, `k=V`, and generation-counter wraparound at 12 offsets. Zero mismatches.

### The numerical argument, verified rather than assumed

BFS order is unchanged: the old code pushed to the stack at dequeue, the new at enqueue — identical for a FIFO queue. Adjacency rows are sorted ascending by dense index, which maps monotonically to node id, so successor order matches the old `sort.Slice`.

In back-accumulation, each `p` receives exactly one `+=` per `w`, so predecessor order selects *which* accumulator but never reorders a sum. That relies on the graph being simple — **verified from the code and empirically**: `algorithms.go:195-197` drops self-loops and `:200-203` collapses parallel edges into one weighted edge; feeding 300 self-loops and 4×-duplicated relationships through `BuildGraph` produces zero of either.

One gotcha found and reverted during implementation: hoisting the division to `(1+delta[w])/sigma[w]` is algebraically equal but **not** bit-identical. The original `(sigma[p]/sigma[w]) * (1+delta[w])` grouping is required, and a mutation restoring the hoist is caught.

## Scratch-reuse correctness

Every `bcScratch` field was traced for per-pivot lifetime: `dist` is generation-stamped with every read guaranteed preceded by a same-gen write; `sigma`/`delta`/`predHead` are written only for stack members and reset over the stack; `predNext`/`predNode` are write-before-read within `[0, predCnt)`. Predecessor slot overflow is impossible — `predCnt` is bounded by `Σ outdeg = off[n] = len(predNext)`, an exact fit.

Mutations killed: removing the generation bump (hangs — stale `predHead` forms a cycle), truncating the predecessor list, restoring per-pivot allocation, reassociating the division, dropping the `sigma`/`delta` reset, reversing adjacency order, dropping the `predHead` reset.

The memory test asserts **marginal** cost — churn difference between K=64 and K=512 over the pivot difference — so one-time build cost cancels and a per-pivot regression cannot hide in it. A separate peak-HeapInuse budget covers one-time blowups; legacy exceeds it 2.6×.

## Scope

The **exact**-Brandes path deliberately does not share the new scratch: it is gonum's own output and only runs below the 8000-node threshold where per-source allocation isn't the bottleneck. The sampling gate is untouched — `betweennessSampleSize=512`, `betweennessSampleThreshold=8000`, `GRAFEL_BETWEENNESS_FORCE_EXACT`, `GRAFEL_BETWEENNESS_SAMPLE_THRESHOLD` all unchanged and still tested.

Adjacency construction moved from per-node `g.From()` to a single `g.Edges()` pass (854k iterator allocations → 1). Verified safe: gonum's `Edges()` returns either `graph.Empty` or an exact-length ordered iterator, never -1 or nil.

## Next, identified by measurement

Of the remaining 169 MB, **105.1 MB (62%) is `g.Edges()` materialising 1.33M boxed `graph.Edge` interfaces** during the one-time CSR build. The natural fix is to build the directed CSR once inside `BuildGraph` and share it with both betweenness and Louvain, which also removes a duplicated builder skeleton. Tracked separately.

Note `RunAlgorithms` runs in-process in **both** the indexer (`cmd/grafel/index.go:2915`) and the daemon (`internal/dashboard/graphstate.go:1120,1207`), so this spike landed in two processes.

Independently adversarially reviewed, including a real-corpus differential.

Refs #5954, #5996
