### PR TITLE
fix(#5978,#5999): unique temp names for link-pass atomic writes; cancel heavy batch children by process group

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1202,8 +1202,8 @@ var subprocessLinksRunner = sched.RunSubprocessLinks
 // CANCELLATION. ctx is the scheduler's per-group cancel context (derived from
 // shutdownCtx), so daemon shutdown or a CancelGroup on a group delete still
 // stops the pass; across the fork the in-process ctx checks become a SIGKILL of
-// the child (exec.CommandContext's default Cancel is cmd.Process.Kill — not a
-// SIGTERM). More prompt than the boundary checks it replaces, at the cost of
+// the child's whole process group (#5999 — not a SIGTERM, and not the
+// single-pid kill os/exec would do by default). More prompt than the boundary checks it replaces, at the cost of
 // leaking the pass's staging temp dir, which stageGraphsDir sweeps.
 func daemonSchedulerLinks(ctx context.Context, group string) error {
 	if sched.SubprocessIndexEnabled() {

--- a/cmd/grafel/links_internal.go
+++ b/cmd/grafel/links_internal.go
@@ -62,8 +62,8 @@ func runLinksInternal(args []string) int {
 	defer memSampler.Stop()
 
 	// context.Background(), deliberately: cancellation of this child is a
-	// SIGKILL from the parent (exec.CommandContext's default Cancel is
-	// cmd.Process.Kill), not an in-process ctx. A signal handler is therefore
+	// SIGKILL from the parent, delivered to this process's whole process group
+	// (#5999), not an in-process ctx. A signal handler is therefore
 	// not an option — SIGKILL cannot be caught — and none is wanted: the kill
 	// is more prompt than the ctx checks it replaces, which only took effect at
 	// a pass boundary. The pass's writes are temp+rename so a kill cannot tear

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -329,7 +329,7 @@ const stagingDirMaxAge = 24 * time.Hour
 // sweepStaleStagingDirs removes abandoned staging dirs from previous passes.
 //
 // #5954: the scheduler-driven pass now runs in a child that the daemon cancels
-// with SIGKILL (exec.CommandContext's default Cancel is cmd.Process.Kill), so
+// with a SIGKILL of the child's whole process group (#5999), so
 // the `defer cleanup()` below cannot run on cancellation. That is a genuine
 // regression against the in-process path, where a CancelGroup unwound the pass
 // cooperatively and the cleanup ran; a group deleted or a daemon stopped

--- a/internal/daemon/sched/cancel_processgroup_5999_test.go
+++ b/internal/daemon/sched/cancel_processgroup_5999_test.go
@@ -1,0 +1,139 @@
+//go:build !windows
+
+package sched
+
+// cancel_processgroup_5999_test.go — cancellation must kill the child's whole
+// process GROUP, not just its pid (#5999).
+//
+// The heavy batch children are spawned with Setpgid (applyGroupAlgoNice), so a
+// process group already exists around each of them. exec.CommandContext's
+// DEFAULT Cancel is cmd.Process.Kill() — a single-pid SIGKILL — which leaves
+// any grandchild the child forked alive. That is not a test artifact: the index
+// child fans out `grafel extract` subprocesses and the link child shells out
+// too, so a cancelled pass could leave live grandchildren behind holding the
+// inherited stdout/stderr pipes. The runner drains those pipes to EOF before
+// cmd.Wait(), so a surviving grandchild also wedges the runner itself: the call
+// never returns, and the stage token it is holding is never released.
+//
+// The stand-in child below makes that deterministic rather than flaky: it forks
+// a long `sleep` that inherits the pipes and records its pid, then blocks.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// fakeGroupAlgoBinary points the group-algo runner at a shell-script stand-in,
+// the group-algo analogue of fakeChildScript.
+func fakeGroupAlgoBinary(t *testing.T, body string) {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-group-algo-child.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake group-algo child: %v", err)
+	}
+	prev := groupAlgoChildBinary
+	groupAlgoChildBinary = func() (string, error) { return path, nil }
+	t.Cleanup(func() { groupAlgoChildBinary = prev })
+}
+
+// pidIsAlive reports whether pid still exists (signal 0 probe).
+func pidIsAlive(pid int) bool {
+	return syscall.Kill(pid, 0) == nil
+}
+
+func waitPidGone(pid int, d time.Duration) bool {
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if !pidIsAlive(pid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	return !pidIsAlive(pid)
+}
+
+// readPidFile waits for the stand-in child's grandchild to record its pid, and
+// registers a cleanup that kills it. The cleanup matters on the FAILURE path:
+// when the group kill does not bind, every failing run would otherwise leave a
+// live `sleep` behind, and a mutation sweep leaves a pile of them on the box.
+func readPidFile(t *testing.T, path string) int {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if b, err := os.ReadFile(path); err == nil {
+			if pid, err := strconv.Atoi(strings.TrimSpace(string(b))); err == nil && pid > 0 {
+				t.Cleanup(func() { _ = syscall.Kill(pid, syscall.SIGKILL) })
+				return pid
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("grandchild never recorded its pid in %s", path)
+	return 0
+}
+
+// TestRunSubprocessLinks_CancelKillsGrandchildren is the deterministic form of
+// the flaky #5999 failure: with a single-pid kill the backgrounded `sleep`
+// survives, keeps the inherited stdout pipe open, and the runner blocks in its
+// drain loop past the assertion window.
+func TestRunSubprocessLinks_CancelKillsGrandchildren(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	fakeChildScript(t, "sleep 60 &\necho $! > "+pidFile+"\nsleep 60")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunSubprocessLinks(ctx, "g", nil) }()
+
+	pid := readPidFile(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled run returned nil error, want a cancellation error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("runner still blocked 5s after cancel — grandchild pid %d alive=%v holding the inherited pipes",
+			pid, pidIsAlive(pid))
+	}
+
+	if !waitPidGone(pid, 2*time.Second) {
+		t.Fatalf("grandchild pid %d survived cancellation — the kill did not reach the process group", pid)
+	}
+}
+
+// TestRunSubprocessGroupAlgo_CancelKillsGrandchildren pins the same contract on
+// the other Setpgid child. group-algo does not fan out today, but it is spawned
+// through the same hook, and a supervisor whose cancellation reaches only the
+// direct child is the defect — not the particular argv it happens to run.
+func TestRunSubprocessGroupAlgo_CancelKillsGrandchildren(t *testing.T) {
+	pidFile := filepath.Join(t.TempDir(), "grandchild.pid")
+	fakeGroupAlgoBinary(t, "sleep 60 &\necho $! > "+pidFile+"\nsleep 60")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- RunSubprocessGroupAlgo(ctx, "g", nil) }()
+
+	pid := readPidFile(t, pidFile)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("cancelled group-algo returned nil error, want a cancellation error")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("group-algo runner still blocked 5s after cancel — grandchild pid %d alive=%v",
+			pid, pidIsAlive(pid))
+	}
+
+	if !waitPidGone(pid, 2*time.Second) {
+		t.Fatalf("group-algo grandchild pid %d survived cancellation — the kill did not reach the process group", pid)
+	}
+}

--- a/internal/daemon/sched/nice_unix.go
+++ b/internal/daemon/sched/nice_unix.go
@@ -3,6 +3,7 @@
 package sched
 
 import (
+	"os"
 	"os/exec"
 	"strconv"
 	"syscall"
@@ -22,11 +23,56 @@ const groupAlgoNice = 10
 // startup (see niceSelf), because Go's exec package does not expose a portable
 // "spawn at nice N" knob; here we only ensure the child is independently
 // schedulable. Kept as a hook so the spawn site stays platform-agnostic.
+//
+// It also wires cmd.Cancel so cancellation reaches that whole process group —
+// see applyProcessGroupCancel. The two belong together: the moment a child gets
+// its own group, the default single-pid kill stops covering everything the
+// child spawned, so no caller of this hook can opt into one without the other.
 func applyGroupAlgoNice(cmd *exec.Cmd) {
 	if cmd.SysProcAttr == nil {
 		cmd.SysProcAttr = &syscall.SysProcAttr{}
 	}
 	cmd.SysProcAttr.Setpgid = true
+	applyProcessGroupCancel(cmd)
+}
+
+// applyProcessGroupCancel makes ctx cancellation SIGKILL the child's entire
+// process GROUP instead of its pid alone (#5999).
+//
+// exec.CommandContext's default Cancel is cmd.Process.Kill(): one pid, one
+// SIGKILL. Because Setpgid above already gave the child its own group (pgid ==
+// the child's pid), every process the child forks lands in that same group, and
+// the default kill leaves all of them running. Two consequences, both real:
+// the index child fans out `grafel extract` subprocesses, so a cancelled pass
+// leaked live grandchildren; and those grandchildren inherit the child's
+// stdout/stderr pipes, so the runner's drain-to-EOF loop never finishes and the
+// supervising call never returns — with the daemon's exclusive heavy-stage
+// token still held.
+//
+// Must be called only on a cmd that carries Setpgid. kill(-pid) addresses the
+// group whose PGID equals that pid — NOT the caller's own group — so without
+// Setpgid the child leads no group, the kill returns ESRCH, and the fallback
+// below quietly papers over it: the group kill would never actually bind. (The
+// residual hazard is narrower but real: after pid reuse, that pid could have
+// become the leader of an unrelated group, and the signal would land there.)
+// That is why the only caller is applyGroupAlgoNice, which sets Setpgid on the
+// same cmd — the pairing must not be split.
+//
+// Setting Cancel on a cmd built without a context is harmless: os/exec only
+// consults it when a context is present.
+func applyProcessGroupCancel(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		if cmd.Process == nil {
+			return os.ErrProcessDone
+		}
+		// Negative pid == "the process group led by that pid".
+		if err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL); err != nil {
+			// The group may already be gone, or Setpgid may not have taken;
+			// fall back to the single-pid kill we are replacing.
+			return cmd.Process.Kill()
+		}
+		return nil
+	}
 }
 
 // NiceSelf lowers the CURRENT process's OS scheduling priority by

--- a/internal/daemon/sched/nice_windows.go
+++ b/internal/daemon/sched/nice_windows.go
@@ -12,6 +12,13 @@ import "os/exec"
 const groupAlgoNice = 0
 
 // applyGroupAlgoNice is a no-op on Windows.
+//
+// It is also where the #5999 process-group kill lives on Unix. Windows has no
+// setpgid and no signals, so there is nothing equivalent to wire here: cmd.Cancel
+// is left at the os/exec default (cmd.Process.Kill(), which terminates the child
+// alone). Killing a whole tree on Windows needs a Job object around the spawn,
+// which this hook deliberately does not attempt — so on Windows a cancelled
+// child's grandchildren still outlive it.
 func applyGroupAlgoNice(cmd *exec.Cmd) {}
 
 // NiceSelf is a no-op on Windows.

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -403,9 +403,11 @@ type ipcEvent struct {
 // repo basename) so the daemon log file includes child extractor output
 // without growing the daemon's own heap.
 //
-// Cancellation: ctx.Done() sends SIGTERM to the child. The child is
-// expected to exit on SIGTERM; if it does not, the parent waits and the
-// context timeout (if any) will eventually unblock the caller.
+// Cancellation: ctx.Done() SIGKILLs the child's whole process group — the
+// child plus every `grafel extract` subprocess its coordinator forked (#5999).
+// It is NOT a SIGTERM: an earlier version of this comment said so and was
+// simply wrong, and nothing on this path may depend on the child getting a
+// chance to run deferred cleanup.
 func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, opts *SubprocessIndexOptions, logger *slog.Logger) error {
 	binary, err := os.Executable()
 	if err != nil {
@@ -487,6 +489,15 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	if logger != nil {
 		logger.Info("subprocess-indexer: "+reason, "gomaxprocs", gmp, "repo", repoPath)
 	}
+	// Own process group + group-wide kill on cancellation (#5999). This child is
+	// the one that actually fans out: the extract coordinator forks a `grafel
+	// extract` subprocess per batch. Under the os/exec default Cancel — a
+	// single-pid SIGKILL — every one of those extract processes survived the
+	// cancellation, kept the inherited stderr pipe open, and so also kept this
+	// runner blocked in its drain loop. Both call sites are inside the daemon
+	// (no controlling terminal), so moving the child out of the daemon's process
+	// group costs no signal delivery that anything relies on.
+	applyGroupAlgoNice(cmd)
 	// On Windows, prevent a console window from flashing when the daemon
 	// (running as a Task Scheduler task) spawns this subprocess.
 	executil.NoWindow(cmd)
@@ -573,9 +584,9 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 // MCP apply path picks up the fresh overlay by mtime on the next group load.
 //
 // Cancellation: ctx.Done() (daemon shutdown, or a newer link pass superseding
-// this one) SIGKILLs the child. exec.CommandContext's default Cancel is
-// cmd.Process.Kill(), not a SIGTERM — an earlier version of this comment said
-// SIGTERM and was simply wrong. The child gets no chance to run deferred
+// this one) SIGKILLs the child's process group — see applyProcessGroupCancel,
+// wired by applyGroupAlgoNice below. It is not a SIGTERM: an earlier version of
+// this comment said SIGTERM and was simply wrong. The child gets no chance to run deferred
 // cleanup, so nothing on the group-algo path may depend on a graceful shutdown;
 // the overlay write is a temp+rename swap, so a kill mid-write leaves an orphan
 // temp file and never a torn overlay.
@@ -607,8 +618,14 @@ func groupAlgoChildEnv(base []string, gomaxprocs int, foreground bool) []string 
 	return withMadvDontNeed(env)
 }
 
+// groupAlgoChildBinary resolves the executable to fork for the group-algo
+// child. A var for the same reason as linksChildBinary: a test can substitute a
+// stand-in and exercise the fork / cancel contract without running the real
+// pass.
+var groupAlgoChildBinary = os.Executable
+
 func RunSubprocessGroupAlgo(ctx context.Context, group string, logger *slog.Logger) error {
-	binary, err := os.Executable()
+	binary, err := groupAlgoChildBinary()
 	if err != nil {
 		return fmt.Errorf("subprocess-group-algo: resolve binary: %w", err)
 	}
@@ -771,16 +788,19 @@ var linksChildBinary = os.Executable
 // SetRepoSourcePaths is written before use on every entry, so the child's fresh
 // globals are not a hazard — they are one less thing to invalidate.
 //
-// CONCURRENCY around the known #5978 hazard (candidates.go / string_pass.go
-// build temp files as path+".tmp", deterministic per destination, so two
-// concurrent writers collide): this change does NOT make it worse. The pass is
+// CONCURRENCY: the pass's temp files are now uniquely named per writer
+// (#5978 — links.writeFileAtomic), so two concurrent writers to one
+// destination no longer collide. Independently of that, the pass is
 // serialised by the daemon's EXCLUSIVE heavy-stage token, which is held across
 // this call for the child's whole lifetime, so at most one background link pass
 // exists at a time — the same guarantee the in-process path had.
 //
 // CANCELLATION IS SIGKILL, NOT SIGTERM. ctx.Done() (daemon shutdown, or
-// CancelGroup on a group delete) makes exec.CommandContext run its default
-// Cancel, which is cmd.Process.Kill() — see os/exec. That is more prompt than
+// CancelGroup on a group delete) SIGKILLs the child's whole process GROUP:
+// applyGroupAlgoNice below sets Setpgid and overrides cmd.Cancel accordingly
+// (#5999), replacing os/exec's default single-pid cmd.Process.Kill() — which
+// left anything the child forked alive, holding this runner's pipes open past
+// the child's own death. That is more prompt than
 // the in-process ctx checks it replaces (those only took effect at a pass
 // boundary, which on this pass can be minutes away), and it is why the child
 // installs no signal handler: under SIGKILL no handler could run.

--- a/internal/links/atomic_write_5978_test.go
+++ b/internal/links/atomic_write_5978_test.go
@@ -1,0 +1,203 @@
+package links
+
+// atomic_write_5978_test.go — concurrent writers to one destination (#5978).
+//
+// Both link-output sinks in this package write temp-then-rename. When the temp
+// name is derived from the destination by string concatenation (path+".tmp"),
+// every writer aiming at the same destination shares ONE temp file: the first
+// rename moves it away and the second fails with ENOENT, so that writer's
+// payload never lands. On the writeDoc path that surfaces as an error the pass
+// reports; on the scan-cache path the rename error is discarded, so a whole
+// pass's work is dropped silently. These tests drive concurrent writers at one
+// destination and assert every writer succeeds and the file that survives is
+// one COMPLETE payload — never a torn or partial one.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestWriteDocConcurrentPassesLoseNothing models two (here: eight) link passes
+// over the same group writing the same candidates file at once. Every write
+// must either land whole or report an error — a rename that silently loses a
+// pass's links is the bug.
+func TestWriteDocConcurrentPassesLoseNothing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "candidates.json")
+
+	const writers = 8
+	const iterations = 20
+	// Each writer owns a distinct link count, so the surviving file identifies
+	// exactly which writer won — and any partial write is detectable.
+	docFor := func(w int) *Document {
+		d := &Document{Version: SchemaVersion}
+		for i := 0; i <= w*40; i++ {
+			d.Links = append(d.Links, Link{
+				ID:     fmt.Sprintf("w%d-l%d", w, i),
+				Source: fmt.Sprintf("svc-%d/handler-%d", w, i),
+				Target: fmt.Sprintf("svc-%d/endpoint-%d", w, i),
+				Method: "GET",
+			})
+		}
+		return d
+	}
+
+	var mu sync.Mutex
+	var errs []error
+
+	for it := 0; it < iterations; it++ {
+		var wg sync.WaitGroup
+		for w := 0; w < writers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				if err := writeDoc(path, docFor(w)); err != nil {
+					mu.Lock()
+					errs = append(errs, err)
+					mu.Unlock()
+				}
+			}(w)
+		}
+		wg.Wait()
+
+		// Whatever survived must be a complete document from ONE writer.
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("iteration %d: read destination: %v", it, err)
+		}
+		var got Document
+		if err := json.Unmarshal(b, &got); err != nil {
+			t.Fatalf("iteration %d: destination is not valid JSON (torn write): %v", it, err)
+		}
+		ok := false
+		for w := 0; w < writers; w++ {
+			if len(got.Links) == len(docFor(w).Links) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Fatalf("iteration %d: destination has %d links, which matches no writer's complete output",
+				it, len(got.Links))
+		}
+	}
+
+	if len(errs) > 0 {
+		t.Fatalf("%d of %d concurrent writes failed — a link pass's output was dropped; first: %v",
+			len(errs), writers*iterations, errs[0])
+	}
+
+	// No temp files may be left behind on the success path.
+	assertNoTempLeftovers(t, dir, "candidates.json")
+}
+
+// TestWriteFileAtomicConcurrentWritersLoseNothing pins the shared helper both
+// sinks use (the scan cache in string_pass.go writes through it too, and it
+// discards its rename error — so a collision there is invisible at runtime and
+// can only be caught here).
+func TestWriteFileAtomicConcurrentWritersLoseNothing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "abcdef0123456789.json")
+
+	const writers = 8
+	const iterations = 20
+	payload := func(w int) []byte {
+		return []byte(strings.Repeat(fmt.Sprintf("%d", w), 4096*(w+1)))
+	}
+
+	var mu sync.Mutex
+	var errs []error
+
+	for it := 0; it < iterations; it++ {
+		var wg sync.WaitGroup
+		for w := 0; w < writers; w++ {
+			wg.Add(1)
+			go func(w int) {
+				defer wg.Done()
+				if err := writeFileAtomic(path, payload(w), 0o644); err != nil {
+					mu.Lock()
+					errs = append(errs, err)
+					mu.Unlock()
+				}
+			}(w)
+		}
+		wg.Wait()
+
+		b, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("iteration %d: read destination: %v", it, err)
+		}
+		ok := false
+		for w := 0; w < writers; w++ {
+			if string(b) == string(payload(w)) {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			t.Fatalf("iteration %d: destination holds %d bytes matching no writer's complete payload (torn write)",
+				it, len(b))
+		}
+	}
+
+	if len(errs) > 0 {
+		t.Fatalf("%d of %d concurrent writes failed — a writer's payload was dropped; first: %v",
+			len(errs), writers*iterations, errs[0])
+	}
+	assertNoTempLeftovers(t, dir, filepath.Base(path))
+}
+
+// TestWriteFileAtomicAppliesRequestedMode pins the destination's permission
+// bits. os.CreateTemp makes its file 0600, so without an explicit chmod the
+// switch away from os.WriteFile would silently narrow every file this helper
+// writes — a mode regression no other test in this package would notice.
+// The mode is asserted verbatim (not umask-masked): see writeFileAtomic's doc.
+func TestWriteFileAtomicAppliesRequestedMode(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, perm := range []os.FileMode{0o644, 0o600} {
+		path := filepath.Join(dir, fmt.Sprintf("mode-%o.json", perm))
+		if err := writeFileAtomic(path, []byte("{}"), perm); err != nil {
+			t.Fatalf("writeFileAtomic(%o): %v", perm, err)
+		}
+		fi, err := os.Stat(path)
+		if err != nil {
+			t.Fatalf("stat: %v", err)
+		}
+		if got := fi.Mode().Perm(); got != perm {
+			t.Errorf("mode = %o, want %o — the temp file's 0600 must not survive the rename", got, perm)
+		}
+	}
+
+	// And through the real caller, so writeDoc's own choice of mode is covered.
+	path := filepath.Join(dir, "candidates.json")
+	if err := writeDoc(path, &Document{Version: SchemaVersion}); err != nil {
+		t.Fatalf("writeDoc: %v", err)
+	}
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if got := fi.Mode().Perm(); got != 0o644 {
+		t.Errorf("writeDoc mode = %o, want 644", got)
+	}
+}
+
+func assertNoTempLeftovers(t *testing.T, dir, dest string) {
+	t.Helper()
+	ents, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	for _, e := range ents {
+		if e.Name() == dest {
+			continue
+		}
+		t.Errorf("temp file %q left behind after successful writes", e.Name())
+	}
+}

--- a/internal/links/candidates.go
+++ b/internal/links/candidates.go
@@ -53,11 +53,56 @@ func writeDoc(path string, d *Document) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	return writeFileAtomic(path, b, 0o644)
+}
+
+// writeFileAtomic writes b to path via a UNIQUE temp file in path's own
+// directory, then renames it over path.
+//
+// The temp name comes from os.CreateTemp and NOT from path+".tmp" (#5978). A
+// temp name derived from the destination is shared by every writer aiming at
+// that destination, so two concurrent link passes over one group interleave
+// inside one temp file: they overwrite each other's bytes (the destination can
+// end up holding a torn mix), and the writer that renames second fails with
+// ENOENT because the first already moved the file away. On the scan-cache sink
+// in string_pass.go that rename error is discarded, so the collision there is
+// invisible at runtime.
+//
+// The temp file is created in path's directory so the rename stays within one
+// filesystem and is therefore atomic; it is removed on every error path.
+//
+// MODE: perm is applied verbatim, NOT masked by the process umask — os.CreateTemp
+// makes the file 0600 and the Chmod below sets exactly what the caller asked
+// for. os.WriteFile, which this replaced, passes perm through open(2) and so
+// WAS umask-masked. Under a restrictive umask (077) these files therefore widen
+// from 0600 to 0644. That is deliberate: the destinations are per-user state
+// under the grafel home, and a deterministic mode is easier to reason about
+// than one that depends on the umask of whichever process (daemon, CLI, child)
+// happened to run the pass.
+func writeFileAtomic(path string, b []byte, perm os.FileMode) (err error) {
+	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmp := f.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err = f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	// os.CreateTemp always uses 0600; restore the caller's intended mode.
+	if err = os.Chmod(tmp, perm); err != nil {
+		return err
+	}
+	err = os.Rename(tmp, path)
+	return err
 }
 
 // loadRejections reads the rejection file and returns a set keyed by

--- a/internal/links/string_pass.go
+++ b/internal/links/string_pass.go
@@ -321,10 +321,11 @@ func scanFile(absPath, relPath, cacheDir string) ([]Extraction, error) {
 		_ = os.MkdirAll(filepath.Dir(cacheFile), 0o755)
 		entry := scanCacheEntry{File: absPath, Mtime: fi.ModTime().UnixNano(), Size: fi.Size(), Values: out}
 		if b, err := json.Marshal(entry); err == nil {
-			tmp := cacheFile + ".tmp"
-			if err := os.WriteFile(tmp, b, 0o644); err == nil {
-				_ = os.Rename(tmp, cacheFile)
-			}
+			// Unique temp name per writer (#5978): two passes scanning the
+			// same file at once would otherwise share cacheFile+".tmp" and
+			// leave a torn cache entry behind — and the rename error that
+			// follows is discarded right here, so nothing would report it.
+			_ = writeFileAtomic(cacheFile, b, 0o644)
 		}
 	}
 	return out, nil


### PR DESCRIPTION
Two independent fixes to the daemon's heavy-batch path, both found to be worse than originally filed.

## #5978 — the link pass's atomic writes collide

`internal/links/candidates.go` and `string_pass.go` built temp files as `path + ".tmp"`: deterministic per destination. Two concurrent writers therefore `O_TRUNC` and interleave into the **same tmp inode**, then each renames a torn file into place. The failure is not a lost write — it is a *garbled* one that a later pass reads back as truth.

Fixed with `writeFileAtomic` (`os.CreateTemp` in the destination directory → write → chmod → rename, remove-on-error).

**Behaviour change, stated deliberately:** `os.WriteFile(tmp, b, 0o644)` was umask-masked by open(2); `os.CreateTemp` + `os.Chmod` is not. Under `umask 077` these files widen from 0600 to 0644. Restoring masking would mean reading `syscall.Umask`, which is process-global and racy; a mode that does not depend on whether the daemon, the CLI, or a child ran the pass is the better property for per-user state under the grafel home. Documented on the helper and here rather than left to be discovered.

Note on the sinks, since an earlier draft of this message got it wrong: `writeDoc` — the actual cross-repo links output — always returned its error, so a *dropped* write there was already reported. `string_pass.go`'s scan cache still discards its error deliberately (best-effort, keyed on mtime+size; a miss costs a rescan). What neither could tolerate was the torn entry.

## #5999 — the heavy batch children were cancelled by pid, not by process group

`exec.CommandContext`'s default `Cancel` is `Process.Kill()` — a single-pid kill. The child's own children survived. `applyGroupAlgoNice` now sets `Setpgid: true` and wires `cmd.Cancel` to `syscall.Kill(-pid, SIGKILL)`.

The two halves are **load-bearing together**, and the doc comment explaining why previously stated the wrong mechanism. Corrected: `kill(-pid)` addresses the group whose PGID equals that pid — not the caller's group. Without `Setpgid` that group normally does not exist, so the kill returns ESRCH and the fallback quietly papers over it, meaning the group kill never binds at all. The real residual hazard is pid reuse aliasing onto an unrelated group's PGID.

## Verification

Both fixes were confirmed to **bind**, by mutation rather than inspection:

| mutation | result |
|---|---|
| restore deterministic `path + ".tmp"` | both tests fail on iteration 1, torn destinations |
| drop `applyProcessGroupCancel` | 10/10 deterministic failures |
| drop only `Setpgid` (keep the group kill) | fails 3/3 — ESRCH, falls through safely |
| delete `os.Chmod(tmp, perm)` | **passed clean until this PR added a mode assertion** |

That last row is the interesting one. The mode was unbound, so a future edit could have silently dropped these files to 0600 with the suite green. `TestWriteFileAtomicAppliesRequestedMode` now asserts `os.Stat().Mode().Perm()` for 0644 and 0600 through the helper and 0644 through the real `writeDoc` caller; the mutation is dead.

`RunSubprocessIndex` was checked on three axes before extending the group cancel to it: SIGTERM/SIGINT still reach the child, the `grafel extract` children write nothing to disk (they stream on stdout), and both callers are daemon-side.

Local gate: `go build ./...`, `go vet`, `gofmt -l` clean; `GOOS=windows` build/vet of `internal/daemon/sched` clean; 1686 tests across 22 packages; `internal/links -race -count=2` (724) and `CancelTerminatesChild -race -count=10` (10/10) green.

## Not done here

The codebase-wide sweep. This is the **third** independent occurrence of the `.tmp` class — `internal/statusfile/statusfile.go:434-441` (citing review #5734) and `internal/daemon/watchreg/watchreg.go:255-261` each diagnosed and fixed it separately, and `internal/daemon/sched/subprocess_runner.go:775` already names it a known hazard and argues its own path is safe via a scheduler invariant. 48 deterministic `.tmp` sites remain across 40 files. Tracked as #6018, deliberately out of scope here.

One unrelated flake observed and not touched: `TestIndexErrorRecorded` (`internal/daemon/sched/scheduler_test.go:282`) failed once under `-race -count=4`. It asserts after a fixed `time.Sleep(150ms)` and injects an in-process `Index` func, so it never reaches the subprocess path; it passed 20/20 in isolation and passed the identical run before these edits.

Independently adversarially reviewed.

Closes #5978
Closes #5999
