### PR TITLE
docs: contributors avatar grid in the README acknowledgments

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,11 +250,13 @@ For code contributions, see [CONTRIBUTING.md](CONTRIBUTING.md). If you're an AI 
 
 ## Acknowledgments
 
-Thanks to grafel's contributors:
+grafel is built by the people below — every extractor fix, quality report and review is in here somewhere. Thank you.
 
-- [@marcus555](https://github.com/marcus555)
-- [@auxmedrano](https://github.com/auxmedrano)
-- [@walter-ajanel](https://github.com/walter-ajanel)
+<a href="https://github.com/cajasmota/grafel/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=cajasmota/grafel" alt="grafel contributors" />
+</a>
+
+Also a separate thank-you to [@auxmedrano](https://github.com/auxmedrano) and [@walter-ajanel](https://github.com/walter-ajanel), whose quality reports and issue triage shaped the extractors without ever landing as a commit.
 
 ---
 


### PR DESCRIPTION
Replaces the hand-maintained bullet list in Acknowledgments with the [contrib.rocks](https://contrib.rocks) grid generated from the repo's contributor graph, so a new contributor shows up without anyone remembering to edit the README.

The grid only covers people with **commits**. `@auxmedrano` and `@walter-ajanel` contributed quality reports and issue triage rather than code, so switching to the automated grid alone would have silently dropped them. They keep an explicit named thank-you underneath — automation should add people, not quietly remove them.

Verified the image renders for this repo: `https://contrib.rocks/image?repo=cajasmota/grafel` returns `200 image/svg+xml`.

Note it is a third-party image fetched at README render time, in exchange for not maintaining the list by hand.