### PR TITLE
fix(#6012): scope Step Functions Lambda-ARN scans per state machine; name CFN machines by logical ID

### DIFF
--- a/internal/engine/workflow_edges.go
+++ b/internal/engine/workflow_edges.go
@@ -894,7 +894,11 @@ type aslState struct {
 // sfnLambdaARNRe extracts the function name from a Lambda ARN or
 // `arn:aws:states:::lambda:invoke` resource string.
 // Group 1 = function name (last colon-separated segment, stripping aliases).
-var sfnLambdaARNRe = regexp.MustCompile(`arn:aws(?:-[a-z]+)*:lambda:[^:]+:\d+:function:([^:$/\s]+)`)
+// The capture class excludes quote characters and backslashes so an ARN that
+// appears inside a string literal (`"...:function:charge-card"`) does not carry
+// the closing quote into the function name, which would point the edge at a
+// Lambda entity that does not exist (#6012).
+var sfnLambdaARNRe = regexp.MustCompile(`arn:aws(?:-[a-z]+)*:lambda:[^:]+:\d+:function:([^:$/\s"'` + "`" + `\\,]+)`)
 
 // sfnStatesLambdaRe matches `arn:aws:states:::lambda:invoke` style resources.
 // The actual Lambda ARN is in the Parameters block which we parse separately.
@@ -1352,7 +1356,8 @@ func applyCDKStateMachineJSON(
 	if !strings.Contains(src, "StateMachine") {
 		return entities, relationships
 	}
-	for _, m := range cdkStateMachineRe.FindAllStringSubmatchIndex(src, -1) {
+	matches := cdkStateMachineRe.FindAllStringSubmatchIndex(src, -1)
+	for i, m := range matches {
 		smName := src[m[2]:m[3]]
 		if !looksLikeFunctionName(smName) {
 			continue
@@ -1368,14 +1373,31 @@ func applyCDKStateMachineJSON(
 			EnrichmentStatus:   types.StatusPending,
 			QualityScore:       0.8,
 		})
-		// Scan nearby for Lambda ARNs.
-		for _, lm := range sfnLambdaARNRe.FindAllStringSubmatch(src, -1) {
+		// Scan for Lambda ARNs *inside this construct's own props object only*.
+		// Scanning the whole file here would join every state machine in the
+		// file to every Lambda in the file — a cartesian product of edges that
+		// do not exist (#6012).
+		bound := len(src)
+		if i+1 < len(matches) {
+			bound = matches[i+1][0]
+		}
+		body := cdkConstructPropsBody(src, m[1], bound)
+		if body == "" {
+			continue
+		}
+		seenEdge := map[string]bool{}
+		for _, lm := range sfnLambdaARNRe.FindAllStringSubmatch(body, -1) {
 			fnName := lm[1]
 			if !looksLikeFunctionName(fnName) {
 				continue
 			}
 			lambdaEntityID := lambdaFunctionID(fnName)
 			targetID := fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaEntityID)
+			key := smID + "|" + targetID
+			if seenEdge[key] {
+				continue
+			}
+			seenEdge[key] = true
 			relationships = append(relationships, types.RelationshipRecord{
 				FromID: fmt.Sprintf("%s:%s", stateMachineKind, smID),
 				ToID:   targetID,
@@ -1388,6 +1410,59 @@ func applyCDKStateMachineJSON(
 		}
 	}
 	return entities, relationships
+}
+
+// cdkConstructPropsBody returns the props object belonging to a
+// `new StateMachine(this, "id"` match that ended at `from`.
+//
+// The props object must be this construct's own third argument: the next
+// non-space byte after the construct id must be ',' and the one after that
+// '{'. Anything else — a variable (`new StateMachine(this, "id", props)`), a
+// call, or no third argument at all — means this construct has no inline props
+// object, and "" is returned. Searching forward for the first '{' instead would
+// adopt whatever unrelated construct happens to come next in the file and
+// attribute its Lambda ARNs to this state machine (#6012).
+//
+// `bound` (the start of the next StateMachine construct, or EOF) additionally
+// clamps the body. That matters when a brace inside a string literal
+// desynchronises the counter and the "matching" brace lands past the next
+// construct.
+//
+// "" is likewise returned when no balanced closing brace exists — declining to
+// emit an edge is strictly better than emitting one attributed to the wrong
+// state machine.
+func cdkConstructPropsBody(src string, from, bound int) string {
+	if from < 0 || from >= bound || bound > len(src) {
+		return ""
+	}
+	i := from
+	for i < bound && wfIsSpaceByte(src[i]) {
+		i++
+	}
+	if i >= bound || src[i] != ',' {
+		return ""
+	}
+	i++
+	for i < bound && wfIsSpaceByte(src[i]) {
+		i++
+	}
+	if i >= bound || src[i] != '{' {
+		return ""
+	}
+	open := i
+	closeIdx := findMatchingBraceWF(src, open)
+	if closeIdx < 0 {
+		return ""
+	}
+	if closeIdx > bound {
+		closeIdx = bound
+	}
+	return src[open:closeIdx]
+}
+
+// wfIsSpaceByte reports whether b is ASCII whitespace.
+func wfIsSpaceByte(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/workflow_edges.go
+++ b/internal/engine/workflow_edges.go
@@ -1297,45 +1297,168 @@ func applyCloudFormationSFNEdges(
 		return entities, relationships
 	}
 
-	smName := sfnStateMachineNameFromPath(path)
-	smID := sfnStateMachineID(smName)
+	// One entity per StateMachine *resource*, named after its logical ID.
+	// Naming after the file path collapsed every machine in a template into a
+	// single node holding the union of their targets (#6012).
+	resources := cfnSFNStateMachineResources(src)
+	if len(resources) == 0 {
+		// No logical ID could be identified (fragment, flow-style mapping,
+		// JSON template, ...): keep the previous file-derived behaviour rather
+		// than dropping the machine.
+		resources = []cfnSFNResource{{LogicalID: sfnStateMachineNameFromPath(path), Body: src}}
+	}
 
-	entities = append(entities, types.EntityRecord{
-		Name:               smID,
-		Kind:               stateMachineKind,
-		SourceFile:         path,
-		Language:           "yaml",
-		Properties:         map[string]string{"sm_name": smName, "pattern_type": "workflow_synthesis"},
-		EnrichmentRequired: false,
-		EnrichmentStatus:   types.StatusPending,
-		QualityScore:       0.85,
-	})
+	for _, res := range resources {
+		smName := res.LogicalID
+		smID := sfnStateMachineID(smName)
 
-	seenEdge := map[string]bool{}
-	for _, m := range cfSFNLambdaARNRe.FindAllStringSubmatch(src, -1) {
-		fnName := m[1]
-		if !looksLikeFunctionName(fnName) {
-			continue
+		props := map[string]string{"sm_name": smName, "pattern_type": "workflow_synthesis"}
+		// The deployed name, when the template states it literally. Recorded as
+		// a property, never as identity: StateMachineName is optional and is
+		// frequently an unresolved !Sub/!Ref, which would make node identity
+		// non-deterministic. Cross-source resolution can still match on it.
+		if dn := cfnLiteralStateMachineName(res.Body); dn != "" {
+			props["state_machine_name"] = dn
 		}
-		lambdaEntityID := lambdaFunctionID(fnName)
-		targetID := fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaEntityID)
-		key := smID + "|" + targetID
-		if seenEdge[key] {
-			continue
-		}
-		seenEdge[key] = true
-		relationships = append(relationships, types.RelationshipRecord{
-			FromID: fmt.Sprintf("%s:%s", stateMachineKind, smID),
-			ToID:   targetID,
-			Kind:   stepFunctionStepInvokesEdgeKind,
-			Properties: types.Props{
-				{K: "pattern_type", V: "workflow_synthesis"},
-				{K: "workflow_engine", V: "aws-sfn"},
-			},
+
+		entities = append(entities, types.EntityRecord{
+			Name:               smID,
+			Kind:               stateMachineKind,
+			SourceFile:         path,
+			Language:           "yaml",
+			Properties:         props,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.85,
 		})
+
+		seenEdge := map[string]bool{}
+		for _, m := range cfSFNLambdaARNRe.FindAllStringSubmatch(res.Body, -1) {
+			fnName := m[1]
+			if !looksLikeFunctionName(fnName) {
+				continue
+			}
+			lambdaEntityID := lambdaFunctionID(fnName)
+			targetID := fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaEntityID)
+			key := smID + "|" + targetID
+			if seenEdge[key] {
+				continue
+			}
+			seenEdge[key] = true
+			relationships = append(relationships, types.RelationshipRecord{
+				FromID: fmt.Sprintf("%s:%s", stateMachineKind, smID),
+				ToID:   targetID,
+				Kind:   stepFunctionStepInvokesEdgeKind,
+				Properties: types.Props{
+					{K: "pattern_type", V: "workflow_synthesis"},
+					{K: "workflow_engine", V: "aws-sfn"},
+				},
+			})
+		}
 	}
 
 	return entities, relationships
+}
+
+// cfnSFNResource is one AWS::StepFunctions::StateMachine resource located in a
+// CloudFormation template: its logical ID and its own block body.
+type cfnSFNResource struct {
+	LogicalID string
+	Body      string
+}
+
+// sfnCFNLogicalIDLineRe matches a block-style YAML mapping key with no inline
+// value — the shape of a CloudFormation logical ID under `Resources:`.
+var sfnCFNLogicalIDLineRe = regexp.MustCompile(`^([ ]*)([A-Za-z0-9][A-Za-z0-9_-]*):[ \t]*(#.*)?$`)
+
+// cfnStateMachineNameRe captures a literal `StateMachineName:` value.
+var cfnStateMachineNameRe = regexp.MustCompile(`StateMachineName\s*:\s*["']?([^"'\n\r]+)["']?`)
+
+// cfnLiteralStateMachineName returns the resource's StateMachineName when the
+// template states it literally, and "" when it is absent or an unresolved
+// intrinsic (`!Sub`, `!Ref`, `${...}`).
+func cfnLiteralStateMachineName(body string) string {
+	m := cfnStateMachineNameRe.FindStringSubmatch(body)
+	if len(m) < 2 {
+		return ""
+	}
+	name := strings.TrimSpace(m[1])
+	if name == "" || strings.HasPrefix(name, "!") || strings.Contains(name, "${") {
+		return ""
+	}
+	return name
+}
+
+// cfnSFNStateMachineResources finds every AWS::StepFunctions::StateMachine
+// resource in a block-style YAML template, returning each logical ID with the
+// body of its own block so ARN scans can be scoped to it.
+//
+// A key qualifies when its *immediate* children include the StateMachine Type
+// marker; that indent check is what stops the enclosing `Resources:` key from
+// matching and swallowing every machine in the template.
+//
+// Returns nil when nothing qualifies (fragments, flow-style mappings, JSON
+// templates) so the caller can fall back to the file-derived name.
+func cfnSFNStateMachineResources(src string) []cfnSFNResource {
+	lines := strings.Split(src, "\n")
+	var out []cfnSFNResource
+
+	for i, line := range lines {
+		m := sfnCFNLogicalIDLineRe.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		indent := len(m[1])
+		logicalID := m[2]
+
+		// Collect the block body: following lines that are blank or indented
+		// deeper than the key.
+		end := i + 1
+		childIndent := -1
+		for ; end < len(lines); end++ {
+			l := lines[end]
+			if strings.TrimSpace(l) == "" {
+				continue
+			}
+			li := wfLeadingSpaces(l)
+			if li <= indent {
+				break
+			}
+			if childIndent < 0 || li < childIndent {
+				childIndent = li
+			}
+		}
+		if childIndent < 0 {
+			continue
+		}
+
+		// The Type marker must sit at the immediate-child indent.
+		isStateMachine := false
+		for _, l := range lines[i+1 : end] {
+			if wfLeadingSpaces(l) == childIndent && cfSFNResourceRe.MatchString(l) {
+				isStateMachine = true
+				break
+			}
+		}
+		if !isStateMachine {
+			continue
+		}
+		out = append(out, cfnSFNResource{
+			LogicalID: logicalID,
+			Body:      strings.Join(lines[i+1:end], "\n"),
+		})
+	}
+	return out
+}
+
+// wfLeadingSpaces counts the leading spaces of a line (YAML forbids tabs for
+// indentation, so spaces are the whole story).
+func wfLeadingSpaces(s string) int {
+	n := 0
+	for n < len(s) && s[n] == ' ' {
+		n++
+	}
+	return n
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/engine/workflow_edges_test.go
+++ b/internal/engine/workflow_edges_test.go
@@ -984,3 +984,202 @@ func TestCDKStateMachineBodyClampedToNextConstruct(t *testing.T) {
 		t.Errorf("expected at most 2 STEPFUNCTION_STEP_INVOKES edges, got %d: %v", total, targets)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #6012 — CloudFormation state machines are named per logical ID, not per file
+// ---------------------------------------------------------------------------
+
+// cfnTwoMachineTemplate is a template declaring TWO
+// AWS::StepFunctions::StateMachine resources with TWO distinct Lambda targets.
+// One machine and one Lambda cannot distinguish correct behaviour from a
+// per-file collapse or a cartesian product; two of each can.
+const cfnTwoMachineTemplate = `
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  OrderFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn: arn:aws:iam::111122223333:role/sfn
+      DefinitionString: |
+        {
+          "StartAt": "Validate",
+          "States": {
+            "Validate": {
+              "Type": "Task",
+              "Resource": "arn:aws:lambda:us-east-1:111122223333:function:validate-order",
+              "End": true
+            }
+          }
+        }
+  RefundFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      RoleArn: arn:aws:iam::111122223333:role/sfn
+      DefinitionString: |
+        {
+          "StartAt": "Refund",
+          "States": {
+            "Refund": {
+              "Type": "Task",
+              "Resource": "arn:aws:lambda:us-east-1:111122223333:function:issue-refund",
+              "End": true
+            }
+          }
+        }
+`
+
+func TestCloudFormationStateMachinesNamedByLogicalID(t *testing.T) {
+	ents, rels := runWorkflowEdges(t, "yaml", "infra/template.yaml", cfnTwoMachineTemplate)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("OrderFlow"), "cfn sfn")
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("RefundFlow"), "cfn sfn")
+
+	// The file-derived name must NOT be used when logical IDs are available:
+	// that node conflates the two machines.
+	if workflowEntityByID(ents, stateMachineKind, sfnStateMachineID("template")) != nil {
+		t.Errorf("file-derived state machine %q emitted alongside logical-ID machines",
+			sfnStateMachineID("template"))
+	}
+
+	smCount := 0
+	for _, e := range ents {
+		if e.Kind == stateMachineKind {
+			smCount++
+		}
+	}
+	if smCount != 2 {
+		t.Errorf("expected 2 state machine entities (one per logical ID), got %d", smCount)
+	}
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 2 {
+		t.Errorf("expected exactly 2 STEPFUNCTION_STEP_INVOKES edges, got %d: %v", total, targets)
+	}
+	if got, want := targets[sfnMachineFromID("OrderFlow")], []string{sfnLambdaToID("validate-order")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("OrderFlow targets: got %v, want %v", got, want)
+	}
+	if got, want := targets[sfnMachineFromID("RefundFlow")], []string{sfnLambdaToID("issue-refund")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("RefundFlow targets: got %v, want %v", got, want)
+	}
+}
+
+func TestCloudFormationStateMachineRecordsLiteralStateMachineName(t *testing.T) {
+	// StateMachineName is recorded as a property so cross-source resolution has
+	// something to match on. Node identity must still come from the logical ID:
+	// the field is optional and often an unresolved intrinsic.
+	src := `
+Resources:
+  OrderFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: prod-order-flow
+      DefinitionString: '{"States": {}}'
+  RefundFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      StateMachineName: !Sub '${AWS::StackName}-refund'
+      DefinitionString: '{"States": {}}'
+  AuditFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: '{"States": {}}'
+`
+	ents, _ := runWorkflowEdges(t, "yaml", "infra/template.yaml", src)
+
+	for _, tc := range []struct{ logicalID, wantName string }{
+		{"OrderFlow", "prod-order-flow"},
+		{"RefundFlow", ""}, // unresolved !Sub — not recorded
+		{"AuditFlow", ""},  // absent
+	} {
+		e := workflowEntityByID(ents, stateMachineKind, sfnStateMachineID(tc.logicalID))
+		if e == nil {
+			t.Errorf("%s: entity not found (identity must come from the logical ID)", tc.logicalID)
+			continue
+		}
+		if got := e.Properties["state_machine_name"]; got != tc.wantName {
+			t.Errorf("%s: state_machine_name = %q, want %q", tc.logicalID, got, tc.wantName)
+		}
+		if got := e.Properties["sm_name"]; got != tc.logicalID {
+			t.Errorf("%s: sm_name = %q, want the logical ID", tc.logicalID, got)
+		}
+	}
+}
+
+func TestCloudFormationStateMachineWithoutLambdaEmitsNoInvokeEdges(t *testing.T) {
+	src := `
+Resources:
+  PassOnlyFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: |
+        {"StartAt": "NoOp", "States": {"NoOp": {"Type": "Pass", "End": true}}}
+  OrderFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: |
+        {"StartAt": "Validate", "States": {"Validate": {"Type": "Task",
+         "Resource": "arn:aws:lambda:us-east-1:111122223333:function:validate-order", "End": true}}}
+`
+	ents, rels := runWorkflowEdges(t, "yaml", "infra/template.yaml", src)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("PassOnlyFlow"), "cfn sfn")
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 1 {
+		t.Errorf("expected exactly 1 STEPFUNCTION_STEP_INVOKES edge, got %d: %v", total, targets)
+	}
+	if got := targets[sfnMachineFromID("PassOnlyFlow")]; len(got) != 0 {
+		t.Errorf("PassOnlyFlow must invoke nothing, got %v", got)
+	}
+}
+
+func TestCloudFormationStateMachinesSharingTargetKeepBothEdges(t *testing.T) {
+	src := `
+Resources:
+  OrderFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: |
+        {"States": {"Audit": {"Type": "Task",
+         "Resource": "arn:aws:lambda:us-east-1:111122223333:function:audit-log", "End": true}}}
+  RefundFlow:
+    Type: AWS::StepFunctions::StateMachine
+    Properties:
+      DefinitionString: |
+        {"States": {"Audit": {"Type": "Task",
+         "Resource": "arn:aws:lambda:us-east-1:111122223333:function:audit-log", "End": true}}}
+`
+	_, rels := runWorkflowEdges(t, "yaml", "infra/template.yaml", src)
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 2 {
+		t.Errorf("expected 2 STEPFUNCTION_STEP_INVOKES edges (one per machine), got %d: %v", total, targets)
+	}
+	for _, sm := range []string{"OrderFlow", "RefundFlow"} {
+		if got, want := targets[sfnMachineFromID(sm)], []string{sfnLambdaToID("audit-log")}; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s targets: got %v, want %v", sm, got, want)
+		}
+	}
+}
+
+func TestCloudFormationStateMachineFallsBackToPathNameWithoutLogicalID(t *testing.T) {
+	// A fragment where the resource type marker is present but no enclosing
+	// logical-ID key can be identified: keep the old file-derived name rather
+	// than dropping the machine entirely.
+	src := `
+Type: AWS::StepFunctions::StateMachine
+Properties:
+  DefinitionString: '{"States": {"Validate": {"Type": "Task", "Resource": "arn:aws:lambda:us-east-1:111122223333:function:validate-order", "End": true}}}'
+`
+	ents, rels := runWorkflowEdges(t, "yaml", "infra/order-flow-template.yaml", src)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("order-flow-template"), "cfn sfn fallback")
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 1 {
+		t.Errorf("expected 1 STEPFUNCTION_STEP_INVOKES edge, got %d: %v", total, targets)
+	}
+	if got, want := targets[sfnMachineFromID("order-flow-template")], []string{sfnLambdaToID("validate-order")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("fallback machine targets: got %v, want %v", got, want)
+	}
+}

--- a/internal/engine/workflow_edges_test.go
+++ b/internal/engine/workflow_edges_test.go
@@ -18,6 +18,8 @@
 package engine
 
 import (
+	"reflect"
+	"sort"
 	"strings"
 	"testing"
 
@@ -728,4 +730,257 @@ class ShipmentWorkflow:
 		}
 	}
 	t.Error("ShipmentWorkflow entity not found")
+}
+
+// ---------------------------------------------------------------------------
+// #6012 — CDK StateMachine: no cartesian product of STEPFUNCTION_STEP_INVOKES
+// ---------------------------------------------------------------------------
+
+// sfnInvokeTargets returns, per state-machine FromID, the sorted list of
+// STEPFUNCTION_STEP_INVOKES target IDs, plus the total edge count (so callers
+// can also assert on duplicates, which a per-machine view alone would hide).
+func sfnInvokeTargets(rels []types.RelationshipRecord) (map[string][]string, int) {
+	out := map[string][]string{}
+	total := 0
+	for _, r := range rels {
+		if r.Kind != stepFunctionStepInvokesEdgeKind {
+			continue
+		}
+		total++
+		out[r.FromID] = append(out[r.FromID], r.ToID)
+	}
+	for k := range out {
+		sort.Strings(out[k])
+	}
+	return out, total
+}
+
+func sfnMachineFromID(name string) string {
+	return stateMachineKind + ":" + sfnStateMachineID(name)
+}
+
+func sfnLambdaToID(name string) string {
+	return serverlessFunctionKind + ":" + lambdaFunctionID(name)
+}
+
+func TestSFNLambdaARNNameExcludesSurroundingQuote(t *testing.T) {
+	// An ARN inside a string literal must not carry the closing quote into the
+	// captured function name — that points the edge at a Lambda entity ID that
+	// no serverless-function entity will ever match.
+	src := `
+resource "aws_sfn_state_machine" "order" {
+  name       = "order-flow"
+  definition = <<EOF
+{
+  "StartAt": "Validate",
+  "States": {
+    "Validate": {
+      "Type": "Task",
+      "Resource": "arn:aws:lambda:us-east-1:111122223333:function:validate-order",
+      "End": true
+    }
+  }
+}
+EOF
+}
+`
+	// NOTE: the Terraform path emits this edge twice (once from the block-level
+	// ARN scan, once from the embedded-ASL re-parse, each with its own dedupe
+	// map). That duplication pre-dates #6012 and is deliberately not asserted
+	// on here; this test is about the *target ID*, not the edge count.
+	_, rels := applyTerraformSFNEdges("infra/sfn.tf", []byte(src), nil, nil)
+	targets, total := sfnInvokeTargets(rels)
+	if total == 0 {
+		t.Fatalf("expected a STEPFUNCTION_STEP_INVOKES edge, got none")
+	}
+	for _, got := range targets[sfnMachineFromID("order-flow")] {
+		if got != sfnLambdaToID("validate-order") {
+			t.Errorf("target ID: got %q, want %q", got, sfnLambdaToID("validate-order"))
+		}
+	}
+	if len(targets[sfnMachineFromID("order-flow")]) == 0 {
+		t.Errorf("no edge from order-flow; got %v", targets)
+	}
+}
+
+func TestCDKStateMachineNoCartesianInvokeEdges(t *testing.T) {
+	// Two state machines and two Lambdas in one file, each machine invoking
+	// exactly one of the Lambdas. A whole-file ARN scan run inside the
+	// per-machine loop joins every machine to every Lambda (4 edges).
+	src := `{
+  "source": "
+    const orderFlow = new StateMachine(this, 'OrderFlow', {
+      definition: new LambdaInvoke(this, 'Validate', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      })
+    });
+    const refundFlow = new StateMachine(this, 'RefundFlow', {
+      definition: new LambdaInvoke(this, 'Refund', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:issue-refund'
+      })
+    });
+  "
+}`
+	ents, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("OrderFlow"), "cdk sfn")
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("RefundFlow"), "cdk sfn")
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 2 {
+		t.Errorf("expected exactly 2 STEPFUNCTION_STEP_INVOKES edges (no cartesian product), got %d: %v", total, targets)
+	}
+	if got, want := targets[sfnMachineFromID("OrderFlow")], []string{sfnLambdaToID("validate-order")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("OrderFlow targets: got %v, want %v", got, want)
+	}
+	if got, want := targets[sfnMachineFromID("RefundFlow")], []string{sfnLambdaToID("issue-refund")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("RefundFlow targets: got %v, want %v", got, want)
+	}
+}
+
+func TestCDKStateMachineWithoutLambdaEmitsNoInvokeEdges(t *testing.T) {
+	// A machine that invokes no Lambda must still yield an entity, and must
+	// not inherit its sibling's target.
+	src := `{
+  "source": "
+    new StateMachine(this, 'PassOnlyFlow', {
+      definition: new Pass(this, 'NoOp')
+    });
+    new StateMachine(this, 'OrderFlow', {
+      definition: new LambdaInvoke(this, 'Validate', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      })
+    });
+  "
+}`
+	ents, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("PassOnlyFlow"), "cdk sfn")
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 1 {
+		t.Errorf("expected exactly 1 STEPFUNCTION_STEP_INVOKES edge, got %d: %v", total, targets)
+	}
+	if got := targets[sfnMachineFromID("PassOnlyFlow")]; len(got) != 0 {
+		t.Errorf("PassOnlyFlow must invoke nothing, got %v", got)
+	}
+}
+
+func TestCDKStateMachinesSharingTargetKeepBothEdges(t *testing.T) {
+	// Two machines genuinely invoking the same Lambda must produce one edge
+	// each — dedupe is per-machine, not per-target-across-machines.
+	src := `{
+  "source": "
+    new StateMachine(this, 'OrderFlow', {
+      definition: new LambdaInvoke(this, 'Audit', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:audit-log'
+      })
+    });
+    new StateMachine(this, 'RefundFlow', {
+      definition: new LambdaInvoke(this, 'Audit', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:audit-log'
+      })
+    });
+  "
+}`
+	_, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 2 {
+		t.Errorf("expected 2 STEPFUNCTION_STEP_INVOKES edges (one per machine), got %d: %v", total, targets)
+	}
+	for _, sm := range []string{"OrderFlow", "RefundFlow"} {
+		if got, want := targets[sfnMachineFromID(sm)], []string{sfnLambdaToID("audit-log")}; !reflect.DeepEqual(got, want) {
+			t.Errorf("%s targets: got %v, want %v", sm, got, want)
+		}
+	}
+}
+
+func TestCDKStateMachineDedupesRepeatedARNWithinOneMachine(t *testing.T) {
+	// The same Lambda referenced twice inside one machine's body yields one
+	// edge — matching the CloudFormation sibling's seenEdge behaviour.
+	src := `{
+  "source": "
+    new StateMachine(this, 'OrderFlow', {
+      definition: Chain.start(new LambdaInvoke(this, 'A', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      })).next(new LambdaInvoke(this, 'B', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      }))
+    });
+  "
+}`
+	_, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 1 {
+		t.Errorf("expected 1 deduped STEPFUNCTION_STEP_INVOKES edge, got %d: %v", total, targets)
+	}
+}
+
+func TestCDKStateMachineWithoutInlinePropsAdoptsNothing(t *testing.T) {
+	// A machine whose props come from a variable has no inline props object of
+	// its own. It must adopt neither a *later* construct's braces nor an
+	// unrelated intervening construct's braces — both would attribute an edge
+	// to the wrong machine, which is the whole point of #6012.
+	src := `{
+  "source": "
+    new StateMachine(this, 'FromVariable', props);
+    const fn = new Function(this, 'Worker', {
+      environment: { TARGET_ARN: 'arn:aws:lambda:us-east-1:111122223333:function:gamma-worker' }
+    });
+    new StateMachine(this, 'OrderFlow', {
+      definition: new LambdaInvoke(this, 'Validate', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      })
+    });
+  "
+}`
+	ents, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("FromVariable"), "cdk sfn")
+
+	targets, total := sfnInvokeTargets(rels)
+	if total != 1 {
+		t.Errorf("expected exactly 1 STEPFUNCTION_STEP_INVOKES edge, got %d: %v", total, targets)
+	}
+	if got := targets[sfnMachineFromID("FromVariable")]; len(got) != 0 {
+		t.Errorf("FromVariable has no inline props and must invoke nothing, got %v", got)
+	}
+	if got, want := targets[sfnMachineFromID("OrderFlow")], []string{sfnLambdaToID("validate-order")}; !reflect.DeepEqual(got, want) {
+		t.Errorf("OrderFlow targets: got %v, want %v", got, want)
+	}
+}
+
+func TestCDKStateMachineBodyClampedToNextConstruct(t *testing.T) {
+	// A brace inside a string literal desynchronises the brace counter, so the
+	// "closing" brace found for OrderFlow lies beyond the next construct. The
+	// body must still be clamped to where RefundFlow begins, or OrderFlow
+	// swallows RefundFlow's target.
+	src := `{
+  "source": "
+    new StateMachine(this, 'OrderFlow', {
+      comment: 'this literal opens a brace { and never closes it',
+      definition: new LambdaInvoke(this, 'Validate', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:validate-order'
+      })
+    });
+    new StateMachine(this, 'RefundFlow', {
+      definition: new LambdaInvoke(this, 'Refund', {
+        lambdaFunctionArn: 'arn:aws:lambda:us-east-1:111122223333:function:issue-refund'
+      })
+    });
+    const trailing = 'and this literal closes it }';
+  "
+}`
+	_, rels := runWorkflowEdges(t, "json", "cdk/app-stack.json", src)
+
+	targets, total := sfnInvokeTargets(rels)
+	if got := targets[sfnMachineFromID("OrderFlow")]; len(got) != 0 &&
+		!reflect.DeepEqual(got, []string{sfnLambdaToID("validate-order")}) {
+		t.Errorf("OrderFlow must not reach past RefundFlow's declaration, got %v", got)
+	}
+	if total > 2 {
+		t.Errorf("expected at most 2 STEPFUNCTION_STEP_INVOKES edges, got %d: %v", total, targets)
+	}
 }


### PR DESCRIPTION
Two independent defects that emitted **false** Step Functions orchestration edges — wrong data, not missing data. An agent asking "what does this state machine invoke?" got a confident superset with no signal the answer was untrue.

## 1. Cartesian product of `STEPFUNCTION_STEP_INVOKES` edges

The Lambda-ARN scan ran over the **entire file** from inside the per-state-machine loop, so every machine was joined to every Lambda in the file. It also lacked the `seenEdge` dedupe its sibling had, so duplicates compounded it.

Now scoped to each construct's own props object, with the dedupe added.

## 2. CloudFormation state machines collapsed per file

Machines were named from `sfnStateMachineNameFromPath(path)` — the **file path** — so a template declaring two `AWS::StepFunctions::StateMachine` resources produced a single node named after the file, with both machines' targets merged into it.

Now named from the logical ID. That is not merely the available identifier, it is the correct one: the logical ID is what `!Ref`, `!GetAtt` and `DependsOn` join on within the template, so it is the identity every other edge wants. `StateMachineName` is recorded as a `state_machine_name` **property** instead — literal values only, never unresolved `!Sub`/`!Ref`/`${...}` — so cross-source resolution has something to match on without node identity depending on an optional, frequently-absent, sometimes-unresolvable field.

**Naming alone would have relocated the bug, not fixed it.** The CFN ARN scan had to be scoped per resource too. Proven by mutation: with logical-ID naming in place and the scan left unscoped, the fixtures produce 4 edges where 2 are correct — the cartesian simply migrates onto two correctly-named nodes, which is arguably worse because it now looks authoritative.

## 3. A third defect, found by the new fixtures

`sfnLambdaARNRe`'s capture class `[^:$/\s]+` excluded neither quotes nor backslashes, so an ARN inside a string literal captured its closing delimiter into the function name — `aws-lambda:validate-order'`, `aws-lambda:validate-order\",`. `looksLikeFunctionName` rejects `` \t\n\r/\<>{}`$ `` but not `"`, `'` or `,`, so these passed the filter and produced entity IDs **no serverless function can ever match**. Shipping undetected through the Terraform path.

## Why nothing caught any of this

`applyCDKStateMachineJSON` and `applyCloudFormationSFNEdges` had **zero** test coverage — no caller in any `_test.go` in the repo. Both were shipping entirely unexercised.

The quote leak is the more instructive case. The pre-existing Terraform test *does* assert a target ID via `requireEdge` — it is not count-only. It stayed green because the Terraform path emits the edge twice, and the embedded-ASL re-parse feeds the regex a JSON-decoded string with quotes already stripped. So a **clean** edge satisfied the presence assertion while the dirty one rode along invisibly.

The generalisable lesson, which is why it is recorded here: **presence assertions cannot see extra edges.** Every new fixture asserts on both the per-machine target set and the total.

## Mutation results

Seven defects re-introduced, seven caught:

| Mutation | Result |
|---|---|
| CDK ARN scan back to whole-file | 2 tests fail — 4 edges instead of 2 |
| CDK `seenEdge` dedupe removed | dedupe test fails |
| ARN capture class reverted | quote test + 2 target-ID assertions fail |
| CFN naming back to file path | 3 tests fail — one `…:template` node instead of two |
| CFN scan back to whole-file | 2 tests fail — 4 edges, sibling machine polluted |
| CFN immediate-child indent check dropped | 3 tests fail — spurious `…:Resources` node holding the union |
| CDK next-construct clamp dropped | `TestCDKStateMachineBodyClampedToNextConstruct` fails — 3 edges, wrong attribution |

The indent-check mutation is the one worth noting: without it the enclosing `Resources:` key itself qualifies as a state machine and silently restores a collapsed whole-template node **alongside** the correct ones.

The clamp mutation was found by review — every original fixture gave each machine an inline props object whose brace closed before the next construct, so the clamp never bound in any of them. Independently re-verified: disabling it now fails.

## Scoping guard

Review found `cdkConstructPropsBody` returned the first balanced brace object it found, whether or not it belonged to the construct — so a machine built from a variable adopted an intervening `new Function(...)`'s braces and emitted a false edge. Not a regression (at base that machine received *every* ARN in the file) but the documented intent — decline rather than guess — was not implemented.

Now it is: the props object must be the construct's own third argument. A variable, a call, or a missing third argument yields no edges. This also closes the trailing-machine case, which the clamp alone could never reach.

## Blast radius — stated plainly

Both fixes are correct but narrow, and this should not be read as broad-reach:

- `applyCDKStateMachineJSON` fires **essentially never**. Path-suffix dispatch routes `.asl.*`, `.tf` and `*template.{yaml,json}` away first, and real CDK is TypeScript → `synthesizeNodeWorkflow`, which contains no `StateMachine` handling at all. So CDK TypeScript state machines are not detected by any path.
- The CFN fix benefits **YAML templates only**: `cfSFNResourceRe` requires a literal `Type:` while JSON emits `"Type":`, so JSON CloudFormation templates emit nothing.

Adding JSON `Type` detection and TypeScript CDK support are new capability, not bug fixes, and are deliberately out of scope.

## Also not fixed

Terraform emits each direct-ARN edge twice — once from the block scan, once from the embedded-ASL re-parse, each with its own dedupe map. Pre-existing; documented in a test comment. CFN `!GetAtt`/`!Ref`/`!Sub` Lambda references remain undetected — an unchanged recall gap, since the literal-ARN regex never matched them.

## Verification

`go build ./... && go vet ./... && gofmt -l .` clean. `go test -count=1 ./internal/engine/` green; twelve `#6012` tests pass. Commit 2 reverts independently leaving a green tree (re-checked after the rewrite). All runs via `rtk proxy` on raw exit codes — the wrapper truncates above 10 MiB and prints a green summary over a red run.

Independently adversarially reviewed.

Closes #6012
