### PR TITLE
fix(#5991,#6013): reset reports an unconfirmed rebuild as a failure; status reports a corrupt graph as failed

### DIFF
--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -64,7 +64,9 @@ Flags:
 			}
 			// --full overrides --incremental.
 			inc := incremental && !full
-			return runRebuildClient(cmd, args, false, quiet, jsonProgress, plain, resolvedRef, inc, timeoutFlag)
+			// `rebuild` does not request a completion guarantee, so it has no
+			// wait to bound (#5991 is scoped to `reset`).
+			return runRebuildClient(cmd, args, false, quiet, jsonProgress, plain, resolvedRef, inc, timeoutFlag, 0)
 		},
 	}
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output; print only the final summary")
@@ -84,16 +86,36 @@ func newResetCmd() *cobra.Command {
 	var plain bool
 	var refFlag string
 	var timeoutFlag string
+	var waitTimeoutFlag string
 
 	cmd := &cobra.Command{
 		Use:   "reset [group] [slug]",
 		Short: "Wipe .grafel/ and rebuild via the daemon",
+		Long: `Reset wipes each repo's .grafel/ and rebuilds the group from scratch.
+
+Unlike ` + "`grafel rebuild`" + `, reset BLOCKS until the daemon confirms the wipe and
+rebuild actually completed, and exits non-zero if it cannot confirm them
+(#5991) — a reset that reports success must mean the graph was really rebuilt.
+A large group therefore holds the command for the whole rebuild; the daemon's
+own bound is 2h. Use --wait-timeout to bound the wait on scripted paths.
+
+Flags:
+  --quiet           suppress progress output; print only the final summary
+  --plain           no ANSI color or carriage-return overwriting (CI-safe)
+  --json-progress   NDJSON output: one broker event per line (for scripting)
+  --ref <ref>       operate on a specific git ref; @all is refused (destructive)
+  --timeout <dur>   per-repo rebuild watchdog (daemon-side; see below)
+  --wait-timeout    how long THIS command waits for the daemon to confirm`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resolvedRef, _, err := resolveRef(refFlag, false /* @all NOT ok — destructive */)
 			if err != nil {
 				return err
 			}
-			return runRebuildClient(cmd, args, true, quiet, jsonProgress, plain, resolvedRef, false, timeoutFlag)
+			waitTimeout, err := parseWaitTimeout(waitTimeoutFlag)
+			if err != nil {
+				return err
+			}
+			return runRebuildClient(cmd, args, true, quiet, jsonProgress, plain, resolvedRef, false, timeoutFlag, waitTimeout)
 		},
 	}
 	cmd.Flags().BoolVar(&quiet, "quiet", false, "suppress progress output; print only the final summary")
@@ -102,7 +124,59 @@ func newResetCmd() *cobra.Command {
 	cmd.Flags().StringVar(&refFlag, "ref", "", refFlagUsage)
 	cmd.Flags().StringVar(&timeoutFlag, "timeout", "",
 		`override the per-repo rebuild watchdog for this invocation (Go duration, e.g. "45m"; "0" disables it; default: GRAFEL_REBUILD_REPO_TIMEOUT or 30m)`)
+	cmd.Flags().StringVar(&waitTimeoutFlag, "wait-timeout", "",
+		`bound how long THIS command waits for the daemon to confirm the wipe+rebuild (Go duration, e.g. "30m"; default/"0" = unbounded, i.e. until the daemon's own 2h bound). On expiry reset exits non-zero with an UNCONFIRMED outcome — the rebuild may still be running. Distinct from --timeout, which is the daemon-side per-repo watchdog.`)
 	return cmd
+}
+
+// parseWaitTimeout parses the --wait-timeout flag. "" and "0" mean unbounded.
+// A malformed value is REJECTED rather than ignored: silently falling back to
+// unbounded would leave the caller believing they were bounded.
+func parseWaitTimeout(raw string) (time.Duration, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil {
+		return 0, fmt.Errorf("--wait-timeout %q is not a valid Go duration (e.g. \"30m\", \"90s\"; \"0\" or unset = unbounded): %w", raw, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("--wait-timeout %q must not be negative", raw)
+	}
+	return d, nil
+}
+
+// errRebuildUnconfirmed marks the CLI's OWN give-up: the --wait-timeout bound
+// expired before the daemon answered. It is deliberately distinct from a
+// daemon-reported failure — we stopped waiting, we did not learn the outcome,
+// so the wipe+rebuild may or may not have completed.
+var errRebuildUnconfirmed = errors.New("the daemon did not answer in time")
+
+// boundOutcome bounds a rebuild-outcome wait at timeout, yielding an
+// errRebuildUnconfirmed outcome if the daemon has not answered by then. A
+// non-positive timeout means unbounded and returns src unchanged, so the common
+// path adds no goroutine at all.
+//
+// On expiry the source goroutine is left blocked on the RPC — net/rpc offers no
+// cancellation and the process is on its way out; the bound exists so a scripted
+// caller regains control, not to tear the call down.
+func boundOutcome(src <-chan rebuildOutcome, timeout time.Duration) <-chan rebuildOutcome {
+	if timeout <= 0 {
+		return src
+	}
+	out := make(chan rebuildOutcome, 1)
+	go func() {
+		t := time.NewTimer(timeout)
+		defer t.Stop()
+		select {
+		case o := <-src:
+			out <- o
+		case <-t.C:
+			out <- rebuildOutcome{err: fmt.Errorf("no completion confirmed within %s: %w", timeout, errRebuildUnconfirmed)}
+		}
+	}()
+	return out
 }
 
 // progressToken generates a short unique token for a rebuild session.
@@ -163,12 +237,41 @@ func fmtDuration(d time.Duration) string {
 // operate on that specific ref). @all is pre-rejected by the caller since
 // rebuild/reset are destructive. Wiring ref into the daemon RPC is tracked
 // separately (#2220); for now it is validated and stored but not forwarded.
-func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, jsonProgress bool, plain bool, ref string, incremental bool, repoTimeout string) error {
+//
+// waitTimeout bounds how long THIS command waits for the daemon's answer
+// (`reset --wait-timeout`); 0 means unbounded. See boundOutcome.
+func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, jsonProgress bool, plain bool, ref string, incremental bool, repoTimeout string, waitTimeout time.Duration) error {
 	if len(args) == 0 {
 		return errors.New("supply [group] (and optional [slug])")
 	}
 
 	inc := incremental
+
+	// #5991 — `reset` must never report success for work that did not happen.
+	//
+	// Split mode is the DEFAULT (daemon.SplitModeEnabled is true unless
+	// GRAFEL_SPLIT_MODE is explicitly falsy). There, Service.Rebuild is
+	// fire-and-forget: it writes a KindRebuild request file for the group and
+	// returns nil immediately, with the ZERO RebuildReply. The engine drains
+	// that file on its own schedule — and if it never does (engine down,
+	// crash-resume backoff, dead-letter), nothing ever wipes `.grafel/` or
+	// rebuilds, because BOTH the wipe and the rebuild live inside the
+	// engine-side RebuildFunc. The CLI saw err==nil + an empty reply and
+	// printed nothing after "Rebuilding group '<g>'...", so `reset` exited 0
+	// having done precisely nothing.
+	//
+	// `reset` is the destructive escape hatch users reach for when they
+	// suspect the index is bad, so a silent no-op there is the worst possible
+	// outcome. Opt INTO the #5790 completion contract (the same one
+	// `group add --index` uses): WaitForCompletion makes the daemon block on
+	// the engine's terminal ack and return nil ONLY on a real StatusOK
+	// completion, and a clear error on failure / dead-letter / engine-death /
+	// timeout. In monolith mode the flag is inert (that path is already
+	// synchronous), so this is a no-op there.
+	//
+	// Deliberately scoped to wipe (i.e. `reset`) — plain `rebuild` keeps its
+	// existing fire-and-forget semantics; see #5991 for that discussion.
+	waitForCompletion := wipe
 
 	c, err := client.Dial()
 	if err != nil {
@@ -192,19 +295,27 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 		fmt.Fprintf(w, "Note: --ref %q recorded; daemon-side ref routing is tracked in #2220.\n", ref)
 	}
 
-	// --quiet: skip progress, run synchronously with no token.
+	// --quiet: skip progress, no token. The RPC still runs on a goroutine so
+	// --wait-timeout can bound it — with WaitForCompletion this call blocks for
+	// the whole rebuild, and --quiet prints nothing while it does, so an
+	// unbounded wait here is a silent multi-hour hang on scripted paths.
 	if quiet {
-		// #5328: an explicit `grafel rebuild`/repair is human-awaited → foreground.
-		reply, err := c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug, Wipe: wipe, Incremental: inc, Interactive: true, RepoTimeout: repoTimeout})
-		if err != nil {
-			return err
+		quietCh := make(chan rebuildOutcome, 1)
+		go func() {
+			// #5328: an explicit `grafel rebuild`/repair is human-awaited → foreground.
+			reply, rpcErr := c.Rebuild(proto.RebuildArgs{Group: group, Slug: slug, Wipe: wipe, Incremental: inc, Interactive: true, RepoTimeout: repoTimeout, WaitForCompletion: waitForCompletion})
+			quietCh <- rebuildOutcome{repos: reply.Repos, warning: reply.Warning, err: rpcErr}
+		}()
+		outcome := <-boundOutcome(quietCh, waitTimeout)
+		if outcome.err != nil {
+			return wrapResetFailure(wipe, group, outcome.err)
 		}
-		for _, r := range reply.Repos {
-			// reply.Repos contains absolute paths since #1076 fix; show basename.
+		for _, r := range outcome.repos {
+			// repos contains absolute paths since #1076 fix; show basename.
 			fmt.Fprintf(w, "rebuilt %s\n", filepath.Base(r))
 		}
-		if reply.Warning != "" {
-			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", reply.Warning)
+		if outcome.warning != "" {
+			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", outcome.warning)
 		}
 		return nil
 	}
@@ -216,7 +327,8 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 	}
 
 	// Kick off the async rebuild RPC on the primary connection.
-	outcomeCh := make(chan rebuildOutcome, 1)
+	rpcCh := make(chan rebuildOutcome, 1)
+	var outcomeCh <-chan rebuildOutcome
 	token := progressToken()
 	go func() {
 		reply, rpcErr := c.Rebuild(proto.RebuildArgs{
@@ -228,8 +340,10 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 			// #5328: explicit user-triggered repair → foreground (priority + cap).
 			Interactive: true,
 			RepoTimeout: repoTimeout,
+			// #5991: reset blocks for a real completion ack; see above.
+			WaitForCompletion: waitForCompletion,
 		})
-		outcomeCh <- rebuildOutcome{
+		rpcCh <- rebuildOutcome{
 			repos:    reply.Repos,
 			warning:  reply.Warning,
 			elapsed:  reply.ElapsedSec,
@@ -238,6 +352,11 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 			err:      rpcErr,
 		}
 	}()
+
+	// Apply the --wait-timeout bound ONCE, on the channel every progress path
+	// below consumes, so the bound cannot be reachable on one renderer and not
+	// the other. No-op (same channel) when unbounded.
+	outcomeCh = boundOutcome(rpcCh, waitTimeout)
 
 	if !jsonProgress {
 		fmt.Fprintf(w, "Rebuilding group '%s'...\n", group)
@@ -250,10 +369,10 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 
 		sseCh, sseErr := subscribeSSE(ctx, dashPort, group, token)
 		if sseErr == nil {
-			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, plain, jsonProgress)
+			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, plain, jsonProgress, waitForCompletion)
 			cancel()
 			if outcome.err != nil {
-				return outcome.err
+				return wrapResetFailure(wipe, group, outcome.err)
 			}
 			return finishRebuild(cmd, w, group, token, outcome.repos, outcome.warning,
 				outcome.elapsed, outcome.entities, outcome.rels, jsonProgress)
@@ -272,7 +391,10 @@ func runPollProgress(
 	w io.Writer,
 	group, _ string,
 	token string,
-	_ bool,
+	// wipe identifies a `reset` (as opposed to a plain `rebuild`) so a
+	// non-completing run is reported as "not wiped or rebuilt" (#5991). This
+	// parameter was previously accepted and ignored (`_ bool`).
+	wipe bool,
 	resultCh <-chan rebuildOutcome,
 	jsonProgress bool,
 	c *client.Client,
@@ -283,7 +405,7 @@ func runPollProgress(
 		// Polling unavailable — wait for RPC result silently.
 		outcome := <-resultCh
 		if outcome.err != nil {
-			return outcome.err
+			return wrapResetFailure(wipe, group, outcome.err)
 		}
 		for _, r := range outcome.repos {
 			fmt.Fprintf(w, "rebuilt %s\n", filepath.Base(r))
@@ -357,11 +479,34 @@ func runPollProgress(
 	}
 
 	if finalOutcome.err != nil {
-		return finalOutcome.err
+		return wrapResetFailure(wipe, group, finalOutcome.err)
 	}
 
 	return finishRebuild(cmd, w, group, token, finalOutcome.repos, finalOutcome.warning,
 		finalOutcome.elapsed, finalOutcome.entities, finalOutcome.rels, jsonProgress)
+}
+
+// wrapResetFailure names what did NOT happen when a `reset` fails to complete
+// (#5991). `reset`'s whole contract is "wipe `.grafel/`, then rebuild", and
+// both halves run engine-side inside RebuildFunc — so an unconfirmed rebuild
+// means neither happened, and the previous (possibly corrupt) graph is still
+// on disk. The raw daemon error alone ("timed out after 2h0m0s") does not say
+// that; this prefix does, and names the group.
+//
+// Plain `rebuild` (wipe=false) is returned unwrapped so its message is
+// unchanged.
+func wrapResetFailure(wipe bool, group string, err error) error {
+	if err == nil || !wipe {
+		return err
+	}
+	// The CLI's own --wait-timeout give-up is NOT a confirmed failure: we
+	// stopped waiting, we did not learn the outcome. Saying "was NOT wiped or
+	// rebuilt" there would be exactly the kind of confident-but-wrong report
+	// this issue is about, pointed the other way.
+	if errors.Is(err, errRebuildUnconfirmed) {
+		return fmt.Errorf("reset: group %q — %w; the rebuild may or may not have completed (check `grafel status`), and --wait-timeout only bounds this command, it does not cancel the daemon", group, err)
+	}
+	return fmt.Errorf("reset: group %q was NOT wiped or rebuilt (the previous graph is still on disk): %w", group, err)
 }
 
 // finishRebuild renders the final summary after a rebuild completes.
@@ -487,7 +632,9 @@ func indexGroupWithProgress(w, errW io.Writer, group string) error {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if sseCh, sseErr := subscribeSSE(ctx, dashPort, group, token); sseErr == nil {
-			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, false, false)
+			// indexGroupWithProgress does not request WaitForCompletion, so it
+			// keeps the historical 5s post-SSE-close give-up (#5991).
+			outcome := runBrokerProgress(ctx, w, group, sseCh, outcomeCh, false, false, false)
 			cancel()
 			if outcome.err != nil {
 				return outcome.err

--- a/internal/cli/repair_broker.go
+++ b/internal/cli/repair_broker.go
@@ -136,8 +136,12 @@ func readSSEEvents(ctx context.Context, r io.Reader, ch chan<- sseEvent) {
 //
 // Flags:
 //
-//	plain      — no ANSI escapes, one line per event
-//	jsonEvents — NDJSON one line per broker event
+//	plain             — no ANSI escapes, one line per event
+//	jsonEvents        — NDJSON one line per broker event
+//	waitForCompletion — the caller asked the daemon for a real completion
+//	                    guarantee (proto.RebuildArgs.WaitForCompletion), so the
+//	                    RPC outcome is the ONLY authority on whether the work
+//	                    happened. See the `!ok` arm below.
 func runBrokerProgress(
 	ctx context.Context,
 	w io.Writer,
@@ -146,6 +150,7 @@ func runBrokerProgress(
 	resultCh <-chan rebuildOutcome,
 	plain bool,
 	jsonEvents bool,
+	waitForCompletion bool,
 ) rebuildOutcome {
 	tty := isTTY(w) && !plain
 
@@ -166,8 +171,12 @@ func runBrokerProgress(
 			if ok {
 				outcome = o
 				rpcDone = true
-				// Drain one last batch from SSE before returning.
-				drainSSE(ctx, w, group, sseCh, lastLineLen, tty, plain, jsonEvents, 300*time.Millisecond)
+				// Drain one last batch from SSE before returning. Skipped when
+				// the stream already closed (sseCh nil'd above) — there is
+				// nothing left to drain and the wait would be dead time.
+				if sseCh != nil {
+					drainSSE(ctx, w, group, sseCh, lastLineLen, tty, plain, jsonEvents, 300*time.Millisecond)
+				}
 				return outcome
 			}
 
@@ -176,6 +185,27 @@ func runBrokerProgress(
 				// SSE stream closed (daemon shutdown or group done).
 				if rpcDone {
 					return outcome
+				}
+				// #5991: an SSE close is NOT evidence the rebuild finished.
+				// The dashboard's progress handler
+				// (internal/dashboard/handlers_progress.go) matches only on
+				// RunToken and has no repo scoping, so it closes the WHOLE
+				// group stream on the FIRST per-repo terminal event — long
+				// before a multi-repo group is done. Giving up here and
+				// returning the zero `outcome` hands the caller err == nil
+				// with no repos, which `reset` then reported as success for a
+				// rebuild that may never have run.
+				//
+				// When the caller asked the daemon for a real completion
+				// guarantee, the RPC result is the ONLY authority: stop
+				// selecting on the dead SSE channel (nil blocks forever) and
+				// keep looping so resultCh — and the 10s heartbeat that keeps
+				// the user informed — stay live for as long as the rebuild
+				// takes. Callers that did NOT ask for a guarantee keep the
+				// historical 5-second give-up.
+				if waitForCompletion {
+					sseCh = nil
+					continue
 				}
 				// Wait up to 5 seconds for the RPC to land.
 				select {

--- a/internal/cli/reset_completion_test.go
+++ b/internal/cli/reset_completion_test.go
@@ -1,0 +1,210 @@
+package cli
+
+// reset_completion_test.go — `grafel reset` completion honesty (#5991).
+//
+// The bug: split mode is the DEFAULT (daemon.SplitModeEnabled returns true
+// unless GRAFEL_SPLIT_MODE is explicitly falsy), and in split mode
+// Service.Rebuild returns nil the instant the KindRebuild request file is
+// written to disk — fire-and-forget. The reply is the zero RebuildReply, so
+// `reset` printed "Rebuilding group 'X'..." and exited 0 whether or not the
+// engine ever drained that request; the `.grafel/` wipe (which happens inside
+// RebuildFunc, i.e. engine-side) never happened either. The exit code carried
+// no information at all.
+//
+// The fix makes `reset` request WaitForCompletion (the same #5790 contract
+// `group add --index` uses), so err==nil means the engine really wiped and
+// rebuilt, and any non-completion (timeout / engine-death / failed rebuild)
+// becomes a NON-ZERO exit naming what did not happen.
+
+import (
+	"bytes"
+	"fmt"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
+)
+
+// stubDefaultLocationDaemon points GRAFEL_DAEMON_ROOT at a private temp root
+// and serves svc on the socket `client.Dial()` resolves from it. This drives
+// the REAL command path (cobra RunE → runRebuildClient → client.Dial), with no
+// production-side injection seam.
+func stubDefaultLocationDaemon(t *testing.T, svc *mockRebuildService) {
+	t.Helper()
+	// os.MkdirTemp (not t.TempDir) keeps the UDS path short enough for the
+	// 104-byte sun_path limit on macOS.
+	root, err := os.MkdirTemp("", "ag-reset-")
+	if err != nil {
+		t.Fatalf("mkdirtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	t.Setenv(daemon.EnvRoot, root)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if layout.SocketDir != "" {
+		if err := os.MkdirAll(layout.SocketDir, 0o755); err != nil {
+			t.Fatalf("mkdir socket dir: %v", err)
+		}
+	}
+	ln, err := transport.Listen(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", layout.SocketPath, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(proto.ServiceName, svc); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+}
+
+// runResetCmd executes the real `reset` cobra command against the stub daemon.
+func runResetCmd(t *testing.T, buf *bytes.Buffer, args ...string) error {
+	t.Helper()
+	cmd := newResetCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// TestReset_ForwardsWaitForCompletion: `reset` must ask the daemon to block for
+// real completion. Without it the split-mode daemon fire-and-forgets and the
+// exit code says nothing about whether the wipe+rebuild happened (#5991).
+func TestReset_ForwardsWaitForCompletion(t *testing.T) {
+	withSandboxHome(t)
+	svc := &mockRebuildService{}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	if err := runResetCmd(t, &buf, "mygroup", "--plain"); err != nil {
+		t.Fatalf("reset: %v\n%s", err, buf.String())
+	}
+	if !svc.gotArgs.Wipe {
+		t.Fatal("reset must request Wipe=true")
+	}
+	if !svc.gotArgs.WaitForCompletion {
+		t.Fatal("reset must set WaitForCompletion=true so err==nil means the wipe+rebuild really ran (#5991)")
+	}
+}
+
+// TestReset_QuietForwardsWaitForCompletion: the --quiet path is a separate
+// c.Rebuild call site and must carry the same contract.
+func TestReset_QuietForwardsWaitForCompletion(t *testing.T) {
+	withSandboxHome(t)
+	svc := &mockRebuildService{}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	if err := runResetCmd(t, &buf, "mygroup", "--quiet"); err != nil {
+		t.Fatalf("reset --quiet: %v\n%s", err, buf.String())
+	}
+	if !svc.gotArgs.WaitForCompletion {
+		t.Fatal("reset --quiet must also set WaitForCompletion=true (#5991)")
+	}
+}
+
+// TestReset_NonCompletionExitsNonZero: when the daemon cannot confirm the
+// rebuild ran (engine never became live / timed out), `reset` must FAIL with a
+// message naming what did not happen — never print "Rebuilding..." and exit 0.
+func TestReset_NonCompletionExitsNonZero(t *testing.T) {
+	withSandboxHome(t)
+	svc := &mockRebuildService{
+		rErr: fmt.Errorf("index engine never became live within 30s; is the daemon/engine running?"),
+	}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runResetCmd(t, &buf, "mygroup", "--plain")
+	if err == nil {
+		t.Fatalf("reset must exit non-zero when the daemon did not confirm the rebuild (#5991)\noutput:\n%s", buf.String())
+	}
+	msg := err.Error()
+	for _, want := range []string{"mygroup", "not wiped or rebuilt", "never became live"} {
+		if !strings.Contains(strings.ToLower(msg), strings.ToLower(want)) {
+			t.Fatalf("reset error %q must name what did not happen and why; missing %q", msg, want)
+		}
+	}
+}
+
+// TestReset_QuietNonCompletionExitsNonZero: same honesty on the --quiet path.
+func TestReset_QuietNonCompletionExitsNonZero(t *testing.T) {
+	withSandboxHome(t)
+	svc := &mockRebuildService{rErr: fmt.Errorf("group rebuild failed: boom")}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runResetCmd(t, &buf, "mygroup", "--quiet")
+	if err == nil {
+		t.Fatalf("reset --quiet must exit non-zero on an unconfirmed rebuild (#5991)\noutput:\n%s", buf.String())
+	}
+	if !strings.Contains(strings.ToLower(err.Error()), "not wiped or rebuilt") {
+		t.Fatalf("reset --quiet error %q must name what did not happen", err.Error())
+	}
+}
+
+// runRebuildCmd executes the real `rebuild` cobra command against the stub.
+func runRebuildCmd(t *testing.T, buf *bytes.Buffer, args ...string) error {
+	t.Helper()
+	cmd := newRebuildCmd()
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	return cmd.Execute()
+}
+
+// TestRebuild_ScopePin pins the OTHER side of the #5991 guard: the fix is
+// deliberately scoped to `reset` (the destructive escape hatch), so plain
+// `rebuild` keeps its fire-and-forget RPC and its unwrapped error message. A
+// guard that fired for every rebuild would pass the reset tests above while
+// silently changing `rebuild`; this test makes that mutation visible.
+func TestRebuild_ScopePin(t *testing.T) {
+	withSandboxHome(t)
+	svc := &mockRebuildService{rErr: fmt.Errorf("boom-from-daemon")}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runRebuildCmd(t, &buf, "mygroup", "--plain")
+	if svc.gotArgs.Wipe {
+		t.Fatal("rebuild must not request a wipe")
+	}
+	if svc.gotArgs.WaitForCompletion {
+		t.Fatal("the #5991 completion contract is scoped to reset; rebuild must be unchanged")
+	}
+	if err == nil || err.Error() != "boom-from-daemon" {
+		t.Fatalf("rebuild error must pass through unwrapped, got %v", err)
+	}
+}
+
+// TestReset_SuccessStillExitsZero: the honesty fix must NOT turn every reset
+// into a failure — a daemon that confirms completion still exits 0.
+func TestReset_SuccessStillExitsZero(t *testing.T) {
+	withSandboxHome(t)
+	repo := filepath.Join(t.TempDir(), "alpha")
+	makeRepo(t, repo)
+	svc := &mockRebuildService{reply: proto.RebuildReply{Repos: []string{repo}, ElapsedSec: 1.5}}
+	stubDefaultLocationDaemon(t, svc)
+
+	var buf bytes.Buffer
+	if err := runResetCmd(t, &buf, "mygroup", "--plain"); err != nil {
+		t.Fatalf("a confirmed reset must exit 0, got %v\n%s", err, buf.String())
+	}
+}

--- a/internal/cli/reset_sse_completion_test.go
+++ b/internal/cli/reset_sse_completion_test.go
@@ -1,0 +1,267 @@
+package cli
+
+// reset_sse_completion_test.go — the SSE branch of `grafel reset` (#5991).
+//
+// The first cut of the #5991 fix (WaitForCompletion + wrapResetFailure) did NOT
+// reach the path users are actually on. The daemon's embedded dashboard is
+// started by default, so `c.Status()` reports a DashboardPort > 0 and
+// runRebuildClient takes the BROKER (SSE) branch — the poll fallback only runs
+// when the dashboard is down.
+//
+// On that branch, runBrokerProgress's `case ev, ok := <-sseCh:` `!ok` arm gave
+// up 5 seconds after the SSE stream closed and returned the ZERO rebuildOutcome
+// with err == nil. The real dashboard handler closes the WHOLE group stream on
+// the first per-repo terminal event (handlers_progress.go checks only RunToken,
+// never repo scope), so for any group that keeps working past its first repo
+// finishing, the stream closes long before the rebuild is done. wrapResetFailure
+// then saw a nil error and was a no-op, finishRebuild took its len(repos)==0
+// branch and printed nothing, and reset exited 0 — #5991 verbatim.
+//
+// Worse, asking for WaitForCompletion made this the NORMAL interleaving rather
+// than a rarity: the RPC now deliberately blocks for the whole rebuild instead
+// of returning in milliseconds, so SSE-close-beats-RPC is expected.
+//
+// These tests drive the REAL cobra `reset` command against a stub daemon that
+// reports a dashboard port and a stub SSE endpoint that closes the stream early,
+// so the SSE branch is bound by execution rather than by argument.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/progress"
+)
+
+// rebuildRelease is the outcome a blocked Rebuild handler returns once the test
+// releases it — standing in for the real WaitForCompletion behaviour, where the
+// RPC blocks until the engine writes its terminal ack.
+type rebuildRelease struct {
+	reply proto.RebuildReply
+	err   error
+}
+
+// blockingRebuildService is a stub daemon that (a) advertises a dashboard port
+// so the CLI takes the SSE branch, and (b) blocks its Rebuild RPC until the
+// test releases it.
+type blockingRebuildService struct {
+	dashPort int
+	release  chan rebuildRelease
+
+	mu      sync.Mutex
+	gotArgs proto.RebuildArgs
+}
+
+func (s *blockingRebuildService) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
+	reply.DashboardPort = s.dashPort
+	return nil
+}
+
+func (s *blockingRebuildService) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) error {
+	s.mu.Lock()
+	s.gotArgs = *args
+	s.mu.Unlock()
+	r := <-s.release
+	*reply = r.reply
+	return r.err
+}
+
+func (s *blockingRebuildService) args() proto.RebuildArgs {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.gotArgs
+}
+
+// startEarlyCloseSSE serves /api/index-progress/{group}: it emits ONE per-repo
+// terminal progress event and then returns, closing the stream — exactly what
+// the real handler does when it sees the first terminal event for the run token.
+func startEarlyCloseSSE(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/index-progress/", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		ev := progress.Event{GroupSlug: "mygroup", RepoSlug: "repo-a", Phase: progress.PhaseDone, EntitiesSoFar: 7}
+		body, _ := json.Marshal(ev)
+		fmt.Fprintf(w, "event: progress\ndata: %s\n\n", body)
+		if flusher != nil {
+			flusher.Flush()
+		}
+		// Return → stream closes while the rebuild is still running.
+	})
+	srv := &http.Server{Handler: mux}
+	go func() { _ = srv.Serve(ln) }()
+	t.Cleanup(func() { _ = srv.Close() })
+
+	return ln.Addr().(*net.TCPAddr).Port
+}
+
+// stubBlockingDaemon wires blockingRebuildService onto the socket client.Dial()
+// resolves from GRAFEL_DAEMON_ROOT.
+func stubBlockingDaemon(t *testing.T, svc *blockingRebuildService) {
+	t.Helper()
+	root, err := os.MkdirTemp("", "ag-sse-")
+	if err != nil {
+		t.Fatalf("mkdirtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	t.Setenv(daemon.EnvRoot, root)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if layout.SocketDir != "" {
+		if mkErr := os.MkdirAll(layout.SocketDir, 0o755); mkErr != nil {
+			t.Fatalf("mkdir socket dir: %v", mkErr)
+		}
+	}
+	ln, err := transport.Listen(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", layout.SocketPath, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := rpc.NewServer()
+	if regErr := srv.RegisterName(proto.ServiceName, svc); regErr != nil {
+		t.Fatalf("register: %v", regErr)
+	}
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+}
+
+// sseGiveUpWindow is runBrokerProgress's post-SSE-close give-up window. The
+// tests below must outlive it to prove the CLI no longer returns on it.
+const sseGiveUpWindow = 5 * time.Second
+
+// TestReset_SSEStreamClosesEarly_DoesNotFalselySucceed is the #5991 regression
+// on the path users are actually on: the SSE stream closes while the rebuild is
+// still running, and the CLI must NOT return a nil error at the 5s give-up.
+func TestReset_SSEStreamClosesEarly_DoesNotFalselySucceed(t *testing.T) {
+	withSandboxHome(t)
+	port := startEarlyCloseSSE(t)
+	svc := &blockingRebuildService{dashPort: port, release: make(chan rebuildRelease, 1)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- runResetCmd(t, &buf, "mygroup", "--plain") }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("reset returned (err=%v) before the daemon confirmed anything — the SSE give-up path reports success for an unconfirmed rebuild (#5991)\noutput:\n%s", err, buf.String())
+	case <-time.After(sseGiveUpWindow + 2*time.Second):
+		// Still waiting on the RPC — correct.
+	}
+
+	svc.release <- rebuildRelease{err: fmt.Errorf("group rebuild failed: engine died mid-rebuild")}
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatalf("reset must surface the daemon's failure\noutput:\n%s", buf.String())
+		}
+		msg := strings.ToLower(err.Error())
+		if !strings.Contains(msg, "not wiped or rebuilt") || !strings.Contains(msg, "engine died") {
+			t.Fatalf("reset error %q must name what did not happen and why", err.Error())
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("reset never returned after the daemon answered")
+	}
+}
+
+// TestRebuild_SSEGiveUpUnchanged pins the OTHER side of the SSE guard. Plain
+// `rebuild` does NOT request a completion guarantee, so it keeps the historical
+// 5-second give-up after the stream closes. A change that made runBrokerProgress
+// wait unconditionally would pass every reset test above while silently turning
+// `rebuild` (and the wizard's indexGroupWithProgress, which also passes false)
+// into a command that blocks for the whole rebuild.
+func TestRebuild_SSEGiveUpUnchanged(t *testing.T) {
+	withSandboxHome(t)
+	port := startEarlyCloseSSE(t)
+	svc := &blockingRebuildService{dashPort: port, release: make(chan rebuildRelease, 1)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- runRebuildCmd(t, &buf, "mygroup", "--plain") }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("rebuild's give-up path must stay a nil-error return, got %v", err)
+		}
+	case <-time.After(sseGiveUpWindow + 5*time.Second):
+		t.Fatal("rebuild no longer gives up after the SSE stream closes; the #5991 wait is scoped to reset")
+	}
+	if svc.args().WaitForCompletion {
+		t.Fatal("rebuild must not request WaitForCompletion")
+	}
+}
+
+// TestReset_SSEStreamClosesEarly_SuccessIsStillReported: the same interleaving
+// with a SUCCESSFUL daemon outcome must exit 0 AND report the real repos from
+// the RPC reply. The old give-up path returned the ZERO outcome, so it exited 0
+// with an EMPTY summary — indistinguishable from the failure above.
+func TestReset_SSEStreamClosesEarly_SuccessIsStillReported(t *testing.T) {
+	withSandboxHome(t)
+	port := startEarlyCloseSSE(t)
+	svc := &blockingRebuildService{dashPort: port, release: make(chan rebuildRelease, 1)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- runResetCmd(t, &buf, "mygroup", "--json-progress") }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("reset returned early (err=%v); the RPC had not answered yet\noutput:\n%s", err, buf.String())
+	case <-time.After(sseGiveUpWindow + 2*time.Second):
+	}
+
+	svc.release <- rebuildRelease{reply: proto.RebuildReply{
+		Repos: []string{"/tmp/repo-a"}, ElapsedSec: 12, TotalEntities: 99, TotalRels: 42,
+	}}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("a confirmed reset must exit 0, got %v\noutput:\n%s", err, buf.String())
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("reset never returned after the daemon answered")
+	}
+
+	if !strings.Contains(buf.String(), `"repo-a"`) {
+		t.Fatalf("the final summary must carry the RPC's real repos, not the zero outcome, got:\n%s", buf.String())
+	}
+	if !svc.args().WaitForCompletion {
+		t.Fatal("reset must still request WaitForCompletion on the SSE path")
+	}
+}

--- a/internal/cli/reset_waittimeout_test.go
+++ b/internal/cli/reset_waittimeout_test.go
@@ -1,0 +1,131 @@
+package cli
+
+// reset_waittimeout_test.go — the CLI-side bound on `reset`'s completion wait.
+//
+// Making `reset` request WaitForCompletion (#5991) turned an RPC that returned
+// in milliseconds into one that blocks for the whole rebuild. The daemon's own
+// bounds are generous — rebuildWaitTimeout == rebuildRPCTimeout == 2h, with
+// faster exits only for a never-live engine (30s) or a live-then-stale one
+// (2m) — and net/rpc over the UDS sets no client deadline. So a wedged but
+// still-heartbeating engine could hold a `reset --quiet` for two hours in total
+// silence, where it used to return instantly. The instant return WAS the bug,
+// but the new blocking behaviour needs an escape hatch on scripted paths.
+//
+// `--wait-timeout` is that hatch. It bounds the CLI's wait only; it defaults to
+// unbounded (0) so a legitimately long monorepo reset is never false-failed,
+// and its error is deliberately weaker than the confirmed-failure message: the
+// CLI gave up waiting, so it does NOT know whether the wipe+rebuild happened.
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+// runResetBounded runs the reset command on a goroutine and fails the test if
+// it has not returned within limit. Without this an UNBOUNDED mutant would hang
+// the whole package until the go-test deadline instead of producing a clean,
+// attributable failure — a mutation that only manifests as a hang is not a
+// mutation the suite really catches.
+func runResetBounded(t *testing.T, buf *bytes.Buffer, limit time.Duration, args ...string) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() { done <- runResetCmd(t, buf, args...) }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(limit):
+		t.Fatalf("reset did not return within %s — the wait was not bounded\noutput:\n%s", limit, buf.String())
+		return nil
+	}
+}
+
+// TestReset_WaitTimeout_QuietPath: --quiet is the silent path the bound exists
+// for. It must fail with an "unconfirmed", not a "did not happen", message.
+func TestReset_WaitTimeout_QuietPath(t *testing.T) {
+	withSandboxHome(t)
+	// release is never fed → the Rebuild RPC blocks forever.
+	svc := &blockingRebuildService{release: make(chan rebuildRelease)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runResetBounded(t, &buf, 10*time.Second, "mygroup", "--quiet", "--wait-timeout", "400ms")
+	if err == nil {
+		t.Fatalf("reset --quiet must fail when the bound expires, got nil\noutput:\n%s", buf.String())
+	}
+	msg := err.Error()
+	for _, want := range []string{"mygroup", "no completion confirmed within", "may or may not"} {
+		if !strings.Contains(strings.ToLower(msg), strings.ToLower(want)) {
+			t.Fatalf("error %q must report an UNCONFIRMED outcome; missing %q", msg, want)
+		}
+	}
+	// It must NOT claim the wipe definitely did not happen — the CLI stopped
+	// waiting, it did not learn the outcome.
+	if strings.Contains(msg, "was NOT wiped or rebuilt") {
+		t.Fatalf("a give-up is not a confirmed failure; error overstates: %q", msg)
+	}
+}
+
+// TestReset_WaitTimeout_ProgressPath: the bound is applied to the shared
+// outcome channel, so it binds the progress paths too — not just --quiet.
+func TestReset_WaitTimeout_ProgressPath(t *testing.T) {
+	withSandboxHome(t)
+	svc := &blockingRebuildService{release: make(chan rebuildRelease)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runResetBounded(t, &buf, 10*time.Second, "mygroup", "--plain", "--wait-timeout", "400ms")
+	if err == nil {
+		t.Fatalf("reset must fail when the bound expires, got nil\noutput:\n%s", buf.String())
+	}
+	if !strings.Contains(err.Error(), "no completion confirmed within") {
+		t.Fatalf("error %q must report an unconfirmed outcome", err.Error())
+	}
+}
+
+// TestReset_WaitTimeout_DefaultIsUnbounded: without the flag the CLI must keep
+// waiting for the daemon — a default cap would false-fail a legitimately long
+// monorepo reset. Proven by outliving the largest internal give-up window.
+func TestReset_WaitTimeout_DefaultIsUnbounded(t *testing.T) {
+	withSandboxHome(t)
+	svc := &blockingRebuildService{release: make(chan rebuildRelease, 1)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	done := make(chan error, 1)
+	go func() { done <- runResetCmd(t, &buf, "mygroup", "--plain") }()
+
+	select {
+	case err := <-done:
+		t.Fatalf("reset gave up on its own with no --wait-timeout (err=%v)\noutput:\n%s", err, buf.String())
+	case <-time.After(sseGiveUpWindow + 2*time.Second):
+	}
+	svc.release <- rebuildRelease{}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("want exit 0 once the daemon confirms, got %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("reset never returned after the daemon answered")
+	}
+}
+
+// TestReset_WaitTimeout_Invalid: a malformed duration is rejected up front
+// rather than silently ignored (which would leave the user unbounded while
+// believing they were bounded).
+func TestReset_WaitTimeout_Invalid(t *testing.T) {
+	withSandboxHome(t)
+	svc := &blockingRebuildService{release: make(chan rebuildRelease)}
+	stubBlockingDaemon(t, svc)
+
+	var buf bytes.Buffer
+	err := runResetBounded(t, &buf, 10*time.Second, "mygroup", "--quiet", "--wait-timeout", "banana")
+	if err == nil {
+		t.Fatal("a malformed --wait-timeout must be rejected, not ignored")
+	}
+	if !strings.Contains(err.Error(), "wait-timeout") {
+		t.Fatalf("error %q must name the offending flag", err.Error())
+	}
+}

--- a/internal/cli/status_graphload_test.go
+++ b/internal/cli/status_graphload_test.go
@@ -1,0 +1,315 @@
+package cli
+
+// status_graphload_test.go — `grafel status` must not report a corrupt graph as
+// healthy (#6013).
+//
+// The bug: ComputeStatusSummary wrapped its LoadGraphFromDir call in an
+// anonymous func with `defer func(){ if r := recover(); r != nil {} }()` and an
+// empty body ("Silently ignore panics during graph loading"), and additionally
+// dropped the returned error on the floor (`if err == nil && doc != nil`). A
+// truncated/garbage graph.fb therefore produced a plausible, SMALLER-than-
+// reality repo line — Files/IndexedRef/IndexedSHA blank, endpoint/flow counts
+// missing — with no warning at all, indistinguishable from a healthy repo.
+//
+// The fix records the failure on RepoStatus.GraphLoadError (the same
+// string-valued "load failed" representation internal/mcp uses for
+// LoadedRepo.loadErr / the dashboard's LoadError, see #6010) and renders it.
+// A repo that simply has NO graph yet is NOT a failure — that stays the
+// existing "0 entities … indexed (never)" shape.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// statusFixtureRepo registers a repo path under the sandbox home and returns
+// both the registry entry and its resolved state dir.
+func statusFixtureRepo(t *testing.T, home, slug string) (registry.Repo, string) {
+	t.Helper()
+	path := filepath.Join(home, "repos", slug)
+	makeRepo(t, path)
+	stateDir := daemon.StateDirForRepo(path)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	return registry.Repo{Slug: slug, Path: path}, stateDir
+}
+
+// writeHealthyGraph writes a real, readable graph.fb into stateDir.
+func writeHealthyGraph(t *testing.T, stateDir string) {
+	t.Helper()
+	doc := &graph.Document{Repo: "ok", Entities: []graph.Entity{
+		{ID: "a1", QualifiedName: "p.A", Kind: "function", Name: "A"},
+		{ID: "a2", QualifiedName: "p.B", Kind: "http_endpoint_definition", Name: "B"},
+	}}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// writeTruncatedGraph writes a REAL graph.fb and then chops it in half. The
+// flatbuffers accessors PANIC on this input ("slice bounds out of range"),
+// which is exactly the swallowed-panic path #6013 is about.
+func writeTruncatedGraph(t *testing.T, stateDir string) {
+	t.Helper()
+	writeHealthyGraph(t, stateDir)
+	p := filepath.Join(stateDir, "graph.fb")
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read graph.fb: %v", err)
+	}
+	if err := os.WriteFile(p, b[:len(b)/2], 0o644); err != nil {
+		t.Fatalf("truncate graph.fb: %v", err)
+	}
+}
+
+// writeUnreadableGraph writes a graph.fb that fails to load via a returned
+// ERROR rather than a panic (all-zero bytes read as format version 2, below
+// the required version). This is the second half of the swallowed-failure
+// path: the old code's `if err == nil && doc != nil` dropped it just as
+// silently as the recover() dropped the panic.
+func writeUnreadableGraph(t *testing.T, stateDir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.fb"), make([]byte, 512), 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+}
+
+// TestStatus_TruncatedGraphReportedAsFailed: a graph.fb whose reader PANICS
+// must be reported as a load failure, never as a healthy (smaller) repo.
+func TestStatus_TruncatedGraphReportedAsFailed(t *testing.T) {
+	home := withSandboxHome(t)
+	repo, stateDir := statusFixtureRepo(t, home, "broken")
+	writeTruncatedGraph(t, stateDir)
+
+	s := ComputeStatusSummary("g", []registry.Repo{repo})
+	rs := s.RepoStats["broken"]
+	if rs == nil {
+		t.Fatal("repo missing from summary")
+	}
+	if rs.GraphLoadError == "" {
+		t.Fatal("a graph.fb that panics the reader must set GraphLoadError (#6013)")
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+	if !strings.Contains(out, "graph FAILED to load") {
+		t.Fatalf("status output must mark the repo as failed, got:\n%s", out)
+	}
+	if !strings.Contains(out, "broken") {
+		t.Fatalf("status output must name the repo, got:\n%s", out)
+	}
+}
+
+// TestStatus_UnreadableGraphReportedAsFailed: the returned-error half of the
+// same defect.
+func TestStatus_UnreadableGraphReportedAsFailed(t *testing.T) {
+	home := withSandboxHome(t)
+	repo, stateDir := statusFixtureRepo(t, home, "unreadable")
+	writeUnreadableGraph(t, stateDir)
+
+	s := ComputeStatusSummary("g", []registry.Repo{repo})
+	rs := s.RepoStats["unreadable"]
+	if rs == nil {
+		t.Fatal("repo missing from summary")
+	}
+	if rs.GraphLoadError == "" {
+		t.Fatal("a graph.fb that fails to load with an error must set GraphLoadError (#6013)")
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	if !strings.Contains(buf.String(), "graph FAILED to load") {
+		t.Fatalf("status output must mark the repo as failed, got:\n%s", buf.String())
+	}
+}
+
+// TestStatus_NoGraphYetIsNotAFailure: a never-indexed repo is a DISTINCT state
+// from a failed load. It must keep the plain "indexed (never)" shape and must
+// NOT be flagged as failed.
+func TestStatus_NoGraphYetIsNotAFailure(t *testing.T) {
+	home := withSandboxHome(t)
+	repo, _ := statusFixtureRepo(t, home, "fresh")
+
+	s := ComputeStatusSummary("g", []registry.Repo{repo})
+	rs := s.RepoStats["fresh"]
+	if rs == nil {
+		t.Fatal("repo missing from summary")
+	}
+	if rs.GraphLoadError != "" {
+		t.Fatalf("a never-indexed repo is not a load failure, got GraphLoadError=%q", rs.GraphLoadError)
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+	if strings.Contains(out, "FAILED to load") {
+		t.Fatalf("a never-indexed repo must not be marked failed, got:\n%s", out)
+	}
+	if !strings.Contains(out, "indexed (never)") {
+		t.Fatalf("a never-indexed repo keeps its existing shape, got:\n%s", out)
+	}
+}
+
+// TestStatus_HealthyGraphIsNotAFailure: the guard must not fire on a good
+// graph — the third state.
+func TestStatus_HealthyGraphIsNotAFailure(t *testing.T) {
+	home := withSandboxHome(t)
+	repo, stateDir := statusFixtureRepo(t, home, "healthy")
+	writeHealthyGraph(t, stateDir)
+
+	s := ComputeStatusSummary("g", []registry.Repo{repo})
+	rs := s.RepoStats["healthy"]
+	if rs == nil {
+		t.Fatal("repo missing from summary")
+	}
+	if rs.GraphLoadError != "" {
+		t.Fatalf("healthy graph must not be flagged, got GraphLoadError=%q", rs.GraphLoadError)
+	}
+	if s.HTTPEndpoints != 1 {
+		t.Fatalf("healthy graph must still be fully counted, HTTPEndpoints=%d", s.HTTPEndpoints)
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	if strings.Contains(buf.String(), "FAILED to load") {
+		t.Fatalf("healthy repo must not be marked failed, got:\n%s", buf.String())
+	}
+}
+
+// writeCorruptSegmentSet points `current` at a segment-set gen dir whose
+// manifest.json is garbage. CurrentGraphDescriptor surfaces that as
+// "graph: resolve segment-set <ABSOLUTE PATH>: …" — the failure mode that
+// carries a filesystem path into the error string.
+func writeCorruptSegmentSet(t *testing.T, stateDir string) {
+	t.Helper()
+	genDir := filepath.Join(stateDir, graph.GenDirName(3))
+	if err := os.MkdirAll(genDir, 0o755); err != nil {
+		t.Fatalf("mkdir gen dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(genDir, "manifest.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(3)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}
+
+// TestStatus_GraphLoadErrorCarriesNoFilesystemPaths: GraphLoadError is printed
+// to the terminal and may be pasted into an issue. Repository layouts are
+// sensitive here, so a load error must be reduced to basenames rather than
+// relying on which underlying error happens to fire.
+func TestStatus_GraphLoadErrorCarriesNoFilesystemPaths(t *testing.T) {
+	home := withSandboxHome(t)
+	repo, stateDir := statusFixtureRepo(t, home, "segbroken")
+	writeCorruptSegmentSet(t, stateDir)
+
+	s := ComputeStatusSummary("g", []registry.Repo{repo})
+	rs := s.RepoStats["segbroken"]
+	if rs == nil || rs.GraphLoadError == "" {
+		t.Fatalf("a corrupt segment-set manifest must be reported, got %+v", rs)
+	}
+	if strings.Contains(rs.GraphLoadError, string(os.PathSeparator)) {
+		t.Fatalf("GraphLoadError must not carry filesystem paths, got %q", rs.GraphLoadError)
+	}
+	if strings.Contains(rs.GraphLoadError, home) {
+		t.Fatalf("GraphLoadError leaked the repo location: %q", rs.GraphLoadError)
+	}
+	// The diagnosis must survive the scrub: what failed, and on which
+	// generation — just not where the repo lives.
+	for _, want := range []string{"manifest", "graph.3", "invalid character"} {
+		if !strings.Contains(rs.GraphLoadError, want) {
+			t.Fatalf("scrubbing must keep the diagnosis (missing %q), got %q", want, rs.GraphLoadError)
+		}
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	if strings.Contains(buf.String(), home) {
+		t.Fatalf("rendered status leaked the repo location:\n%s", buf.String())
+	}
+}
+
+// TestStatus_TotalLineMarkedIncompleteOnLoadFailure: the aggregated TOTAL line
+// under-reports whenever any repo's graph failed to load. Marking only the
+// per-repo line leaves the headline number silently wrong.
+func TestStatus_TotalLineMarkedIncompleteOnLoadFailure(t *testing.T) {
+	home := withSandboxHome(t)
+	bad, badDir := statusFixtureRepo(t, home, "broken")
+	good, goodDir := statusFixtureRepo(t, home, "fine")
+	writeTruncatedGraph(t, badDir)
+	writeHealthyGraph(t, goodDir)
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, ComputeStatusSummary("g", []registry.Repo{bad, good}))
+	out := buf.String()
+
+	totalLine := ""
+	for _, l := range strings.Split(out, "\n") {
+		if strings.Contains(l, "TOTAL:") {
+			totalLine = l
+		}
+	}
+	if totalLine == "" {
+		t.Fatalf("no TOTAL line in:\n%s", out)
+	}
+	if !strings.Contains(totalLine, "INCOMPLETE") {
+		t.Fatalf("the TOTAL line must be marked incomplete when a repo's graph failed to load, got %q", totalLine)
+	}
+	if !strings.Contains(totalLine, "1 repo") {
+		t.Fatalf("the TOTAL marker must say how many repos are missing, got %q", totalLine)
+	}
+}
+
+// TestStatus_TotalLineCleanWhenAllGraphsLoad: the marker must not fire when
+// every graph is readable.
+func TestStatus_TotalLineCleanWhenAllGraphsLoad(t *testing.T) {
+	home := withSandboxHome(t)
+	good, goodDir := statusFixtureRepo(t, home, "fine")
+	writeHealthyGraph(t, goodDir)
+	fresh, _ := statusFixtureRepo(t, home, "never")
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, ComputeStatusSummary("g", []registry.Repo{good, fresh}))
+	if strings.Contains(buf.String(), "INCOMPLETE") {
+		t.Fatalf("no repo failed to load; TOTAL must not be marked:\n%s", buf.String())
+	}
+}
+
+// TestStatus_OneBadGraphDoesNotHideTheOthers: status stays NON-FATAL. A repo
+// with a corrupt graph must not stop the healthy repos in the same group from
+// being loaded and counted.
+func TestStatus_OneBadGraphDoesNotHideTheOthers(t *testing.T) {
+	home := withSandboxHome(t)
+	bad, badDir := statusFixtureRepo(t, home, "aaa-broken")
+	good, goodDir := statusFixtureRepo(t, home, "zzz-healthy")
+	writeTruncatedGraph(t, badDir)
+	writeHealthyGraph(t, goodDir)
+
+	s := ComputeStatusSummary("g", []registry.Repo{bad, good})
+	if s.RepoStats["aaa-broken"].GraphLoadError == "" {
+		t.Fatal("corrupt repo must be flagged")
+	}
+	if got := s.RepoStats["zzz-healthy"]; got == nil || got.GraphLoadError != "" {
+		t.Fatalf("healthy repo must survive a sibling's corrupt graph, got %+v", got)
+	}
+	if s.HTTPEndpoints != 1 {
+		t.Fatalf("healthy repo's derived counts must still be computed, HTTPEndpoints=%d", s.HTTPEndpoints)
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+	if !strings.Contains(out, "aaa-broken") || !strings.Contains(out, "zzz-healthy") {
+		t.Fatalf("both repos must appear in the output, got:\n%s", out)
+	}
+}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -65,6 +66,29 @@ type RepoStatus struct {
 	// run, and this marker sits alongside it as an additional warning. Cleared
 	// (nil again) once a subsequent rebuild of this repo succeeds.
 	RebuildFailure *statusfile.RebuildFailure
+
+	// GraphLoadError is non-empty when this repo HAS a graph artefact on disk
+	// but it could not be read: a truncated/garbage graph.fb (the flatbuffers
+	// accessors PANIC on those), an unreadable segment-set manifest, an
+	// incompatible format version, or a nil Document from a load that reported
+	// no error. It is the third state, distinct from BOTH:
+	//
+	//   - healthy      → GraphLoadError == "" and the counts below are real;
+	//   - no graph yet → GraphLoadError == "" with LastIndexedAge "(never)".
+	//
+	// The string-valued "the last load failed, here is why" shape mirrors the
+	// representation the rest of the codebase already uses for exactly this
+	// condition: internal/mcp's LoadedRepo.loadErr (state.go), surfaced as the
+	// dashboard's LoadError and as tools.go's "unavailable" list. See #6013
+	// (this defect), #6010 (a nil Doc from the same failed-load state reaching
+	// BuildLabelIndex) and #5969 (the malformed-graph class).
+	//
+	// When set, the Files / IndexedRef / IndexedSHA / IsWorktree fields and the
+	// group's HTTPEndpoints / ProcessFlows / orphan-rate contributions from
+	// this repo are MISSING, not zero — which is precisely why reporting the
+	// failure matters: silently under-reported numbers read as a healthy,
+	// smaller repo.
+	GraphLoadError string
 }
 
 // ComputeStatusSummary loads the per-repo graph-stats.json files and enrichment
@@ -142,19 +166,47 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			}
 		}
 
-		// Load full graph document to extract entities with incoming rels + kind-based counts.
-		// Errors are silently skipped — graph may not exist yet or may be invalid.
-		// This is only for computing derived counts like HTTPEndpoints and ProcessFlows;
-		// the main entity/relationship counts come from graph-stats.json.
+		// Load full graph document to extract entities with incoming rels +
+		// kind-based counts. This is only for computing derived counts like
+		// HTTPEndpoints and ProcessFlows; the main entity/relationship counts
+		// come from graph-stats.json.
+		//
+		// #6013: this used to swallow BOTH failure modes — a `recover()` with
+		// an empty body ("Silently ignore panics during graph loading"), and
+		// an `if err == nil && doc != nil` that dropped the returned error on
+		// the floor. A corrupt/truncated graph.fb (the flatbuffers accessors
+		// panic with "slice bounds out of range") therefore produced a
+		// plausible, SMALLER-than-reality repo line with no warning at all,
+		// indistinguishable from a healthy repo.
+		//
+		// The recover STAYS — `status` must remain non-fatal and keep
+		// reporting every other repo and group — but the failure is now
+		// RECORDED on rs.GraphLoadError and rendered by PrintStatusSummary.
+		// A repo that simply has no graph yet is NOT a failure: that keeps the
+		// existing "0 entities … indexed (never)" shape, so the three states
+		// (healthy / not indexed yet / failed) stay distinguishable.
 		func() {
 			defer func() {
-				// Catch panics from malformed graph files (e.g., in tests).
-				if r := recover(); r != nil {
-					// Silently ignore panics during graph loading.
+				// Catch panics from malformed graph files.
+				if rec := recover(); rec != nil {
+					rs.GraphLoadError = scrubPaths(fmt.Sprintf("panic while reading the graph: %v", rec))
 				}
 			}()
 			doc, err := graph.LoadGraphFromDir(stateDir)
-			if err == nil && doc != nil {
+			switch {
+			case err != nil:
+				// Only a graph that EXISTS and cannot be read is a failure.
+				// "neither graph.fb nor graph.json found" is the never-indexed
+				// state and stays silent.
+				if graphArtifactPresent(stateDir) {
+					rs.GraphLoadError = scrubPaths(err.Error())
+				}
+			case doc == nil:
+				// A nil Document with a nil error is the same failed-load state
+				// that reaches BuildLabelIndex in #6010 — report it, never treat
+				// it as an empty-but-healthy repo.
+				rs.GraphLoadError = "graph loaded as a nil document"
+			default:
 				rs.Files = doc.Stats.Files
 				// Phase 0 git metadata (#2088).
 				rs.IndexedRef = doc.IndexedRef
@@ -220,6 +272,61 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 	s.CrossRepoEdges = loadCrossRepoEdgeCount(group)
 
 	return s
+}
+
+// fsPathRe matches an absolute (or otherwise multi-segment) filesystem path,
+// Unix or Windows. It requires at least one INTERIOR separator so ordinary
+// prose like "and/or" is never mistaken for a path.
+var fsPathRe = regexp.MustCompile(`(?:[A-Za-z]:)?[/\\](?:[^\s:/\\]+[/\\])+[^\s:/\\]*`)
+
+// scrubPaths reduces every filesystem path in a message to its last segment.
+//
+// GraphLoadError is printed to the terminal and is exactly the kind of string a
+// user pastes into a bug report, and graph-load errors readily embed absolute
+// paths — a corrupt segment-set manifest surfaces as
+// "graph: resolve segment-set <abs>: graph: parse manifest in <abs>: …",
+// which discloses the repository layout. Scrubbing here rather than relying on
+// which underlying error happens to fire keeps that true for load failures we
+// have not seen yet. The basename is kept so the diagnosis (which generation,
+// which file, what went wrong) survives.
+func scrubPaths(msg string) string {
+	return fsPathRe.ReplaceAllStringFunc(msg, func(p string) string {
+		trimmed := strings.TrimRight(p, `/\`)
+		if i := strings.LastIndexAny(trimmed, `/\`); i >= 0 {
+			trimmed = trimmed[i+1:]
+		}
+		if trimmed == "" {
+			return "<path>"
+		}
+		return trimmed
+	})
+}
+
+// graphArtifactPresent reports whether stateDir contains something that is
+// MEANT to be a graph. It is what separates the two error outcomes of
+// graph.LoadGraphFromDir (#6013):
+//
+//   - present + load error  → a real failure, surfaced as GraphLoadError;
+//   - absent                → the never-indexed state ("neither graph.fb nor
+//     graph.json found in …"), which is normal and must stay silent.
+//
+// A CurrentGraphDescriptor that itself errors counts as PRESENT: the only way
+// it errors is a segment-set pointer whose manifest is corrupt, which is a
+// broken artefact, not a missing one.
+func graphArtifactPresent(stateDir string) bool {
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		return true
+	}
+	if desc.Kind != graph.GraphAbsent {
+		return true
+	}
+	// GraphAbsent only speaks for the .fb layouts; graph.json is the other
+	// artefact LoadGraphFromDir accepts.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "graph.json")); statErr == nil {
+		return true
+	}
+	return false
 }
 
 // formatTimeSince returns a human-readable duration like "5m ago" relative to now.
@@ -352,15 +459,43 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 			fmt.Fprintf(w, "  %-*s  ⚠ last rebuild FAILED: %s%s — see daemon.err; raise GRAFEL_REBUILD_REPO_TIMEOUT (or `grafel rebuild --timeout <dur>`) or rebuild again\n",
 				maxSlugLen, "", rf.Reason, formatRebuildFailureRef(rf))
 		}
+		// #6013: a graph that exists but cannot be READ used to be swallowed
+		// entirely, so the line above read as a healthy — merely smaller —
+		// repo. Say so explicitly, and say which numbers on that line are
+		// therefore missing rather than genuinely zero.
+		if rs.GraphLoadError != "" {
+			fmt.Fprintf(w, "  %-*s  ⚠ graph FAILED to load: %s — file/endpoint/flow counts above are INCOMPLETE; run `grafel reset %s` to rebuild from scratch\n",
+				maxSlugLen, "", rs.GraphLoadError, s.GroupName)
+		}
 	}
 
 	// Print aggregated totals.
-	fmt.Fprintf(w, "\n  TOTAL: %s entities · %s relationships · %s cross-repo edges · %s flows · %s endpoints\n",
+	//
+	// #6013: every repo whose graph failed to load contributed NOTHING to the
+	// flow/endpoint/orphan aggregates, so this headline under-reports. Marking
+	// only the per-repo lines would leave the number most people actually read
+	// silently wrong.
+	incomplete := 0
+	for _, rs := range s.RepoStats {
+		if rs.GraphLoadError != "" {
+			incomplete++
+		}
+	}
+	totalSuffix := ""
+	if incomplete > 0 {
+		noun := "repos"
+		if incomplete == 1 {
+			noun = "repo"
+		}
+		totalSuffix = fmt.Sprintf("  ⚠ INCOMPLETE — %d %s could not be read (see above)", incomplete, noun)
+	}
+	fmt.Fprintf(w, "\n  TOTAL: %s entities · %s relationships · %s cross-repo edges · %s flows · %s endpoints%s\n",
 		fmtInt(s.TotalEntities),
 		fmtInt(s.TotalRelationships),
 		fmtInt(s.CrossRepoEdges),
 		fmtInt(s.ProcessFlows),
-		fmtInt(s.HTTPEndpoints))
+		fmtInt(s.HTTPEndpoints),
+		totalSuffix)
 
 	// Print available optional candidates.
 	//


### PR DESCRIPTION
Two release blockers in one class: **the tool reported success or health when it wasn't true.** grafel is consumed by AI agents that treat its output as ground truth, so a silently-wrong success is worse than a loud failure.

## #5991 — `grafel reset` exited 0 on a rebuild that never ran

The reported mechanism was a rebuild cooldown. It was not. Split mode is the **default** (`daemon.SplitModeEnabled()`, `internal/daemon/server.go:298` — true unless explicitly falsy). In split mode `Service.Rebuild` (`service.go:657-683`) writes a `KindRebuild` request file and returns `nil` with the **zero** `RebuildReply` unless `WaitForCompletion` is set, which `reset` did not set. The CLI printed `Rebuilding group 'X'...`, received `{repos: nil, elapsed: 0, entities: 0, err: nil}` instantly, took `finishRebuild`'s `len(repos)==0` branch, built an empty `summaryParts`, and printed **nothing**.

Both the `.grafel/` wipe and the rebuild live engine-side in `RebuildFunc`, so when the engine never drains that request — engine down, crash-resume backoff, dead-lettered after `maxRebuildAttempts` — nothing happens at all. The CLI was **structurally incapable** of distinguishing that from success: byte-identical output, and the exit code carried no information in either case.

Fixed by opting `reset` into the existing #5790 `WaitForCompletion` contract on both call sites, so the daemon blocks on the engine's terminal ack and returns `nil` only on a real `StatusOK`. Failures are wrapped: `reset: group "X" was NOT wiped or rebuilt (the previous graph is still on disk): <reason>`.

### The first fix did not reach the path users are on

Review reproduced #5991 **on the fixed branch**, which is the most useful thing in this PR.

The dashboard's progress handler (`internal/dashboard/handlers_progress.go:246-262`) matches only on `RunToken` and has no repo scoping, so it closes the **whole group stream on the first per-repo terminal event**. The CLI then fell into its `!ok` arm, waited 5 s, and returned the zero outcome with `err == nil` — so `wrapResetFailure(wipe, group, nil)` was a no-op and the fix never executed:

```
--- FAIL: TestReset_SSEStreamClosesEarly_DoesNotFalselySucceed (5.03s)
    reset returned (err=<nil>) before the daemon confirmed anything
    Rebuilding group 'mygroup'...
    repo-a: done  (7 entities)
```

And the first fix **made that ordering normal**: previously the RPC returned in milliseconds so `resultCh` was always ready first; `WaitForCompletion` deliberately blocks it for the whole rebuild, so for any group taking >5 s past its first repo, SSE-close-beats-RPC is the expected interleaving. The dashboard is embedded and started by default, so `dashPort > 0` and the SSE branch **is** production — the poll path, which the original tests exercised, runs only when the dashboard is down.

`runBrokerProgress` now takes `waitForCompletion`. When a completion guarantee was requested the RPC is the only authority: `sseCh = nil` and `continue`, so the loop keeps selecting on `resultCh` and the 10 s heartbeat for as long as the rebuild takes. Callers that did not ask for one (`rebuild`, the wizard's `indexGroupWithProgress`) keep the historical 5 s give-up, pinned by `TestRebuild_SSEGiveUpUnchanged` so the guard binds in both directions.

### `--wait-timeout` (BEHAVIOUR CHANGE)

Blocking on an engine ack means `reset --quiet` could otherwise hang for the daemon's full 2 h (`rebuildWaitTimeout`, and `net/rpc` over the UDS sets no client deadline). A CI invocation that used to return instantly could hang.

A flag rather than a default cap: a default cap would false-fail a legitimately long monorepo reset — the same confident-but-wrong report this issue is about, pointed the other way. Default stays unbounded; `--wait-timeout 30m` bounds the CLI's wait only. Applied via `boundOutcome` at the **single** channel every renderer consumes, so it cannot be live on one path and dead on another, and `--quiet` runs its RPC on a goroutine so the bound reaches it too. A malformed value is rejected, not ignored.

The give-up message is deliberately weaker than a confirmed failure, because the CLI stopped waiting rather than learning the outcome:

```
reset: group "X" — no completion confirmed within 30m: the daemon did not answer
in time; the rebuild may or may not have completed (check `grafel status`), and
--wait-timeout only bounds this command, it does not cancel the daemon
```

## #6013 — `grafel status` reported a corrupt graph as healthy

Two swallows on the same call, not the one reported: an empty `recover()` at `status_stats.go:149-155`, **and** `if err == nil && doc != nil { … }` dropping the returned error with no else branch. Both verified reachable with real fixtures — a truncated `graph.fb` panics the flatbuffers accessors, an all-zero one returns a format-version error.

`RepoStatus.GraphLoadError` deliberately reuses the string representation `internal/mcp` already uses (`LoadedRepo.loadErr`) rather than inventing a type. Rendered as `⚠ graph FAILED to load: … — counts above are INCOMPLETE`, with `graphArtifactPresent` keeping "no graph yet" distinct from "failed". The `recover` stays, so `status` remains non-fatal and still reports the other repos. The group `TOTAL:` line is now marked `⚠ INCOMPLETE — N repos could not be read`.

Error text is scrubbed to basenames — a corrupt segment-set manifest leaked an absolute path twice in one message. Diagnosis survives: `graph: resolve segment-set graph.3: graph: parse manifest in graph.3: invalid character 'n' …`.

## Verification

21 mutations across both rounds, all caught. Independently re-verified: restoring the 5 s SSE give-up fails both `TestReset_SSEStreamClosesEarly_*` at 5.01 s.

One test-quality problem found and fixed mid-review: a mutant originally **hung** the package rather than failing, because the wait-timeout tests called `runResetCmd` synchronously. A mutation that manifests only as a hang is not one the suite catches. `runResetBounded` (goroutine + bounded select) makes those fail in 10 s with an attributable message.

`go build ./... && go vet ./... && gofmt -l .` clean; `internal/cli` — the only package touched — passes `-count=1` and `-race`, raw exit codes via `rtk proxy`. Revertability checked by execution: commit 1 alone builds and passes, and reverting commit 1 leaves commit 2 building and passing.

## Known and disclosed

- **`grafel rebuild` retains the same class of bug** — fire-and-forget, empty reply, 5 s give-up, exit 0. Deliberately out of scope and pinned by two scope tests so it is an explicit decision, not an accident. Tracked as #6032.
- `finishRebuild` prints nothing on a *successful* split-mode reset (empty `summaryParts`), so success still reads as silence. Untouched.
- `indexGroupWithProgress` (wizard / `group add`) keeps the 5 s give-up; `group add --index` gets its honesty from `indexGroup`'s own `WaitForCompletion` path (#5790), not this one.
- The `DialProgress`-failure branch in `runPollProgress` has a `wrapResetFailure` call no test binds — it needs `DialProgress` to fail against a live socket. Genuinely rare, unlike the SSE branch.
- `boundOutcome` leaks the RPC goroutine on expiry; `net/rpc` offers no cancellation. Documented in code, reachable only when `--wait-timeout` is set and expires.
- `case doc == nil` in status is defensive and untested — not constructible through `LoadGraphFromDir` today.

Independently adversarially reviewed.

Closes #5991
Closes #6013
