### PR TITLE
fix(#6006): pr_impact stops reporting zero merge conflicts when communities were never computed

### DIFF
--- a/internal/graph/groupalgo/overlay.go
+++ b/internal/graph/groupalgo/overlay.go
@@ -260,6 +260,38 @@ func ReadOverlay(path string, currentMtimes map[string]int64) (*Overlay, bool) {
 	return &ov, true
 }
 
+// ReadOverlayAnyAge is ReadOverlay without the mtime-staleness gate: it returns
+// the stored overlay even when a source graph.fb has moved on, leaving the
+// caller to decide what a stale partition is worth. Absent, corrupt and
+// version-mismatched still collapse to (nil, false) — those are overlays that
+// cannot be applied at all, as opposed to ones that are merely older than the
+// graphs.
+//
+// It exists for consumers whose question is COMMUNITY-LEVEL rather than
+// entity-exact (issue #6006: grafel_pr_impact merge risk). The staleness key is
+// the currently-checked-out ref's graph.fb, so a `git checkout` of the very
+// branch the user is asking about flips a fresh overlay to stale, and after any
+// reindex of any repo in the group the overlay is stale for ~50 minutes until
+// the group-algo pass catches up. For a verdict like "do these two refs touch
+// the same community?" a partition that is 50 minutes old is overwhelmingly the
+// same partition, so refusing to answer buys almost no correctness and costs the
+// tool its entire workflow. Consumers that need entity-exact values
+// (PageRank/centrality shown as numbers) must keep using ReadOverlay.
+//
+// Callers MUST surface the staleness they were handed — use IsOverlayStale with
+// CurrentSourceMtimes — rather than silently presenting a stale partition as
+// current.
+func ReadOverlayAnyAge(path string) (*Overlay, bool) {
+	ov := readOverlayUnconditional(path)
+	if ov == nil {
+		return nil, false // absent, unreadable, or corrupt
+	}
+	if !OverlayAlgoVersionCurrent(ov) {
+		return nil, false // a different algorithm's partition — never applicable
+	}
+	return ov, true
+}
+
 // OverlayAlgoVersionCurrent reports whether an overlay was produced by THIS
 // build's algorithm contract. Exported so status/observability surfaces can
 // distinguish "no overlay yet" from "an overlay exists but this binary will not

--- a/internal/graph/groupalgo/overlay_anyage_6006_test.go
+++ b/internal/graph/groupalgo/overlay_anyage_6006_test.go
@@ -1,0 +1,91 @@
+// overlay_anyage_6006_test.go — ReadOverlayAnyAge (#6006 D2): staleness is
+// tolerated, but the two conditions that make an overlay INAPPLICABLE rather
+// than merely old are not.
+package groupalgo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func anyAgeOverlay(version int) *Overlay {
+	return &Overlay{
+		AlgoVersion:  version,
+		Group:        "acme",
+		SourceMtimes: map[string]int64{"svc": 12345},
+		Results:      map[string]EntityOverlay{"svc:A": {CommunityID: 7}},
+		Communities:  []graph.CommunityResult{{ID: 7, Size: 1}},
+	}
+}
+
+// The whole point: an overlay whose recorded source mtimes match nothing is
+// returned anyway, so a caller can apply a slightly-old partition rather than
+// refuse to answer. ReadOverlay, by contrast, rejects it.
+func TestReadOverlayAnyAge_StaleIsReturned(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acme-algo.json")
+	if err := WriteOverlayTo(path, anyAgeOverlay(OverlayAlgoVersion)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	current := map[string]int64{"svc": 99999} // nothing matches
+
+	if _, ok := ReadOverlay(path, current); ok {
+		t.Fatal("precondition failed: ReadOverlay accepted a stale overlay, so this " +
+			"test cannot distinguish the two readers")
+	}
+	ov, ok := ReadOverlayAnyAge(path)
+	if !ok || ov == nil {
+		t.Fatal("ReadOverlayAnyAge must return a stale overlay — refusing it is the #6006 D2 regression")
+	}
+	if !IsOverlayStale(ov, current) {
+		t.Error("the returned overlay should still REPORT as stale so callers can flag it")
+	}
+	if ov.Results["svc:A"].CommunityID != 7 {
+		t.Errorf("stale overlay content mangled: %+v", ov.Results)
+	}
+}
+
+// Version mismatch is NOT staleness: an overlay produced by a different
+// algorithm implementation is a different partition, and applying it would mix
+// two numbering schemes. Both directions must be refused.
+func TestReadOverlayAnyAge_VersionMismatchIsRefused(t *testing.T) {
+	for _, v := range []int{0, OverlayAlgoVersion - 1, OverlayAlgoVersion + 1} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "acme-algo.json")
+		if err := WriteOverlayTo(path, anyAgeOverlay(v)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if ov, ok := ReadOverlayAnyAge(path); ok {
+			t.Errorf("algo_version=%d is not this build's contract (%d) and must be refused, got %+v",
+				v, OverlayAlgoVersion, ov)
+		}
+	}
+	// Control: the current version IS accepted, so the loop above is not passing
+	// simply because ReadOverlayAnyAge refuses everything.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "acme-algo.json")
+	if err := WriteOverlayTo(path, anyAgeOverlay(OverlayAlgoVersion)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := ReadOverlayAnyAge(path); !ok {
+		t.Fatal("control: the current algo version must be accepted")
+	}
+}
+
+// Absent and corrupt collapse to a miss, matching ReadOverlay's contract.
+func TestReadOverlayAnyAge_AbsentAndCorrupt(t *testing.T) {
+	dir := t.TempDir()
+	if _, ok := ReadOverlayAnyAge(filepath.Join(dir, "nope.json")); ok {
+		t.Error("absent overlay must be a miss")
+	}
+	bad := filepath.Join(dir, "corrupt.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if _, ok := ReadOverlayAnyAge(bad); ok {
+		t.Error("corrupt overlay must be a miss")
+	}
+}

--- a/internal/graph/pr_impact.go
+++ b/internal/graph/pr_impact.go
@@ -74,11 +74,10 @@ type PRImpactResult struct {
 	BlastRadiusCount int  `json:"blast_radius_count"`
 	Truncated        bool `json:"truncated,omitempty"`
 
-	// CommunityDataAvailable reports whether the analysed graph carried ANY real
-	// community assignment (issue #6006). It is NOT a quality metric — it is the
-	// validity flag for every community-derived field in this struct
-	// (ImpactedCommunities, CommunityCount, ImpactedCommunityIDs, and therefore
-	// the whole merge-risk analysis built on top of them).
+	// CommunityDataAvailable is the validity flag for every community-derived
+	// field in this struct (ImpactedCommunities, CommunityCount,
+	// ImpactedCommunityIDs, and therefore the whole merge-risk analysis built on
+	// top of them). Issue #6006.
 	//
 	// It exists because the per-repo Pass-4 algorithm pass was removed when the
 	// group-scope algo pass replaced it: entities loaded straight out of graph.fb
@@ -86,7 +85,27 @@ type PRImpactResult struct {
 	// empty. Without this flag "no impacted communities" is indistinguishable
 	// from "communities were never computed" — and on a merge-risk question that
 	// reads as "safe to merge", which is the worst direction to be wrong in.
+	//
+	// MEASURED OVER THE CHANGED SET, NOT THE ENTITY SET. The first cut of this
+	// flag asked "does any entity anywhere in the graph carry a community?", and
+	// that is the wrong question: the group-algo overlay is computed from the
+	// INDEXED GROUP UNION, so entities that exist only on a feature ref — every
+	// entity a PR ADDS — are absent from it by construction. A pure add-only PR
+	// therefore has a fully-covered repo and a completely uncovered change set,
+	// and the graph-wide flag reported `community_data_available: true` next to
+	// `risky_pair_count: 0` — an affirmative all-clear on a change nothing was
+	// known about. Coverage of the entities we are actually reasoning about is
+	// the only coverage that makes the answer valid.
+	//
+	// An EMPTY change set is vacuously available: nothing changed, so nothing can
+	// conflict, and that is a real answer rather than a missing one. (This is the
+	// live default-base case — conflicts mode diffs refs[0] against itself.)
 	CommunityDataAvailable bool `json:"community_data_available"`
+	// ChangedWithoutCommunity counts changed entities carrying no community, i.e.
+	// the entities this analysis could not place. Non-zero with
+	// CommunityDataAvailable=true is PARTIAL coverage: the verdict stands on the
+	// entities that were placed, but this many were invisible to it.
+	ChangedWithoutCommunity int `json:"changed_entities_without_community"`
 }
 
 // PRImpactOptions bounds the analysis.
@@ -158,16 +177,8 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 	opts = opts.normalized()
 
 	byID := make(map[string]Entity, len(entities))
-	communityDataAvailable := false
 	for i := range entities {
 		byID[entities[i].ID] = entities[i]
-		// #6006: "did community detection actually run on this graph?" — answered
-		// over the WHOLE entity set, not just the changed slice, so a change that
-		// happens to touch only ungrouped entities is reported as a real (empty)
-		// answer rather than as missing data.
-		if entities[i].CommunityID != nil && *entities[i].CommunityID >= 0 {
-			communityDataAvailable = true
-		}
 	}
 
 	// Inbound adjacency: in[X] = entities that depend on X (callers). Restricted
@@ -204,6 +215,10 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 	changed := make([]ChangedEntity, 0, len(changedIDs))
 	// communityChanged[community] = #changed entities in it.
 	communityChanged := map[int]int{}
+	// #6006: how many changed entities we could NOT place in a community. This,
+	// not the graph-wide entity set, decides whether the community-derived output
+	// below means anything — see PRImpactResult.CommunityDataAvailable.
+	changedWithoutCommunity := 0
 	seedSet := make(map[string]struct{}, len(changedIDs))
 	for _, id := range changedIDs {
 		seedSet[id] = struct{}{}
@@ -231,7 +246,13 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 			CommunityID: comm,
 		})
 		communityChanged[comm]++
+		if comm < 0 {
+			changedWithoutCommunity++
+		}
 	}
+	// Vacuously available when nothing changed; otherwise at least one changed
+	// entity must have been placed for the community verdict to mean anything.
+	communityDataAvailable := len(changedIDs) == 0 || changedWithoutCommunity < len(changedIDs)
 
 	// ── Part 2: downstream blast radius (inbound BFS from all seeds) ──────────
 	// Multi-source BFS: distance is hops from the nearest changed seed.
@@ -343,7 +364,8 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 		BlastRadiusCount:    blastTotal,
 		Truncated:           truncated,
 
-		CommunityDataAvailable: communityDataAvailable,
+		CommunityDataAvailable:  communityDataAvailable,
+		ChangedWithoutCommunity: changedWithoutCommunity,
 	}
 }
 

--- a/internal/graph/pr_impact.go
+++ b/internal/graph/pr_impact.go
@@ -73,6 +73,20 @@ type PRImpactResult struct {
 	CommunityCount   int  `json:"impacted_community_count"`
 	BlastRadiusCount int  `json:"blast_radius_count"`
 	Truncated        bool `json:"truncated,omitempty"`
+
+	// CommunityDataAvailable reports whether the analysed graph carried ANY real
+	// community assignment (issue #6006). It is NOT a quality metric — it is the
+	// validity flag for every community-derived field in this struct
+	// (ImpactedCommunities, CommunityCount, ImpactedCommunityIDs, and therefore
+	// the whole merge-risk analysis built on top of them).
+	//
+	// It exists because the per-repo Pass-4 algorithm pass was removed when the
+	// group-scope algo pass replaced it: entities loaded straight out of graph.fb
+	// carry the -2/nil sentinel, so every community-derived output collapses to
+	// empty. Without this flag "no impacted communities" is indistinguishable
+	// from "communities were never computed" — and on a merge-risk question that
+	// reads as "safe to merge", which is the worst direction to be wrong in.
+	CommunityDataAvailable bool `json:"community_data_available"`
 }
 
 // PRImpactOptions bounds the analysis.
@@ -144,8 +158,16 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 	opts = opts.normalized()
 
 	byID := make(map[string]Entity, len(entities))
+	communityDataAvailable := false
 	for i := range entities {
 		byID[entities[i].ID] = entities[i]
+		// #6006: "did community detection actually run on this graph?" — answered
+		// over the WHOLE entity set, not just the changed slice, so a change that
+		// happens to touch only ungrouped entities is reported as a real (empty)
+		// answer rather than as missing data.
+		if entities[i].CommunityID != nil && *entities[i].CommunityID >= 0 {
+			communityDataAvailable = true
+		}
 	}
 
 	// Inbound adjacency: in[X] = entities that depend on X (callers). Restricted
@@ -286,6 +308,16 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 	}
 	impacted := make([]ImpactedCommunity, 0, len(commIDs))
 	for c := range commIDs {
+		// #6006: align this filter with ImpactedCommunityIDs and AnalyzeMergeRisk,
+		// both of which already drop c < 0. Without it the payload reported
+		// impacted_community_count: 1 with a single community_id: -1 — the
+		// "ungrouped" bucket dressed up as a real community, which reads as a
+		// genuine (and singular) impact signal. Entities with no community are
+		// still fully reported in changed_entities / blast_radius, each carrying
+		// community_id: -1; they just do not manufacture a community here.
+		if c < 0 {
+			continue
+		}
 		impacted = append(impacted, ImpactedCommunity{
 			CommunityID:    c,
 			ChangedCount:   communityChanged[c],
@@ -310,6 +342,8 @@ func AnalyzePRImpact(entities []Entity, rels []Relationship, change ChangeSet, o
 		CommunityCount:      len(impacted),
 		BlastRadiusCount:    blastTotal,
 		Truncated:           truncated,
+
+		CommunityDataAvailable: communityDataAvailable,
 	}
 }
 
@@ -339,6 +373,13 @@ func (r PRImpactResult) ImpactedCommunityIDs() []int {
 type ChangeImpact struct {
 	Ref         string // ref / branch / PR label
 	Communities []int  // impacted community ids (grouped only)
+
+	// CommunityDataAvailable carries PRImpactResult.CommunityDataAvailable for
+	// this ref (#6006). An empty Communities slice means "this change touched no
+	// community" only when this is true; when it is false the slice is empty
+	// because nothing was computed, and no conclusion about merge safety can be
+	// drawn from this ref at all.
+	CommunityDataAvailable bool
 }
 
 // MergeRiskPair is two refs whose impacted-community sets overlap.
@@ -354,6 +395,17 @@ type MergeRiskResult struct {
 	Pairs      []MergeRiskPair `json:"risk_pairs"`
 	RefCount   int             `json:"ref_count"`
 	RiskyPairs int             `json:"risky_pair_count"`
+
+	// CommunityDataAvailable is false when ANY input ref lacked community data
+	// (#6006). A zero risky_pair_count is only a "these refs do not conflict"
+	// answer when this is true; when it is false the analysis did not run and the
+	// empty pair list carries no safety information whatsoever.
+	//
+	// Deliberately conservative: one uncovered ref taints the whole result,
+	// because merge risk is a property of the pair set, not of a single ref.
+	CommunityDataAvailable bool `json:"community_data_available"`
+	// RefsWithoutCommunityData names the refs that had no community data, sorted.
+	RefsWithoutCommunityData []string `json:"refs_without_community_data,omitempty"`
 }
 
 // AnalyzeMergeRisk intersects every change's impacted-community set pairwise and
@@ -368,6 +420,12 @@ func AnalyzeMergeRisk(impacts []ChangeImpact) MergeRiskResult {
 	norm := make([]ChangeImpact, len(impacts))
 	copy(norm, impacts)
 	sort.SliceStable(norm, func(i, j int) bool { return norm[i].Ref < norm[j].Ref })
+	var missing []string
+	for _, ci := range norm {
+		if !ci.CommunityDataAvailable {
+			missing = append(missing, ci.Ref)
+		}
+	}
 	sets := make([]map[int]struct{}, len(norm))
 	for i, ci := range norm {
 		s := make(map[int]struct{}, len(ci.Communities))
@@ -409,6 +467,9 @@ func AnalyzeMergeRisk(impacts []ChangeImpact) MergeRiskResult {
 		Pairs:      pairs,
 		RefCount:   len(norm),
 		RiskyPairs: len(pairs),
+
+		CommunityDataAvailable:   len(missing) == 0,
+		RefsWithoutCommunityData: missing,
 	}
 }
 

--- a/internal/graph/pr_impact_6006_test.go
+++ b/internal/graph/pr_impact_6006_test.go
@@ -48,6 +48,94 @@ func TestAnalyzePRImpact_CommunityDataAvailability(t *testing.T) {
 	}
 }
 
+// D1 — the production shape. The GRAPH is fully covered by communities but the
+// CHANGED entity is not, which is exactly what an add-only PR looks like: the
+// group-algo overlay is computed from the indexed group union, so an entity that
+// exists only on a feature ref cannot be in it.
+//
+// The first cut of CommunityDataAvailable measured the whole entity set and
+// reported `true` here — an affirmative all-clear on a change nothing was known
+// about. Availability must follow the changed set.
+func TestAnalyzePRImpact_AvailabilityFollowsChangedSetNotEntitySet(t *testing.T) {
+	ents, rels := prImpactFixture() // a,b,c,d,e — ALL in communities
+	// The added entity is the only uncovered one, and it is the only thing that
+	// changed. It depends on c, so it is a well-formed member of the graph.
+	ents = append(ents, Entity{ID: "new", Name: "New", Kind: "function", SourceFile: "api/new.go"})
+	rels = append(rels, Relationship{FromID: "new", ToID: "c", Kind: "CALLS"})
+
+	res := AnalyzePRImpact(ents, rels, ChangeSet{
+		Added: []DiffEntityEntry{{ID: "new", Name: "New", Kind: "function"}},
+	}, DefaultPRImpactOptions())
+
+	if res.ChangedCount != 1 {
+		t.Fatalf("fixture must change exactly the uncovered entity, got %+v", res.ChangedEntities)
+	}
+	if res.CommunityDataAvailable {
+		t.Errorf("no CHANGED entity carries a community, yet CommunityDataAvailable = true — " +
+			"this is the #6006 false negative wearing an availability stamp")
+	}
+	if res.ChangedWithoutCommunity != 1 {
+		t.Errorf("ChangedWithoutCommunity = %d, want 1", res.ChangedWithoutCommunity)
+	}
+	if len(res.ImpactedCommunityIDs()) != 0 {
+		t.Errorf("an uncovered added entity has no downstream in HEAD, so no communities; got %v",
+			res.ImpactedCommunityIDs())
+	}
+}
+
+// Partial coverage is NOT unavailability: one covered changed entity is enough
+// for the verdict to stand, but the uncovered count must be reported so the
+// caller knows the verdict is incomplete.
+func TestAnalyzePRImpact_PartialCoverageIsAvailableButCounted(t *testing.T) {
+	ents, rels := prImpactFixture()
+	ents = append(ents, Entity{ID: "new", Name: "New", Kind: "function"})
+
+	res := AnalyzePRImpact(ents, rels, ChangeSet{
+		Modified: []DiffEntityEntry{{ID: "c"}},              // covered (community 0)
+		Added:    []DiffEntityEntry{{ID: "new", Name: "N"}}, // uncovered
+	}, DefaultPRImpactOptions())
+
+	if !res.CommunityDataAvailable {
+		t.Errorf("one covered changed entity is enough to make the verdict valid")
+	}
+	if res.ChangedWithoutCommunity != 1 {
+		t.Errorf("ChangedWithoutCommunity = %d, want 1 (the added entity)", res.ChangedWithoutCommunity)
+	}
+}
+
+// An EMPTY change set is vacuously available — nothing changed, so nothing can
+// conflict. This is the live default-base path (conflicts mode diffs refs[0]
+// against itself), so getting it wrong would hard-error every default call.
+func TestAnalyzePRImpact_EmptyChangeSetIsAvailable(t *testing.T) {
+	ents, rels := prImpactFixture()
+	res := AnalyzePRImpact(stripCommunities(ents), rels, ChangeSet{}, DefaultPRImpactOptions())
+	if !res.CommunityDataAvailable {
+		t.Errorf("an empty change set is a real answer (nothing changed), not missing data")
+	}
+}
+
+// D3 — a NON-NIL pointer to a negative community id. Reachable in production:
+// stamp() copies EntityOverlay.CommunityID verbatim, and the overlay uses -2 for
+// "not assigned a community"; legacy graph.json can carry -1 directly. If such a
+// value counted as coverage, CommunityDataAvailable would be true while all
+// three `c >= 0` filters dropped everything — #6006 again, stamped available.
+func TestAnalyzePRImpact_NegativeCommunityIDIsNotCoverage(t *testing.T) {
+	for _, cid := range []int{-1, -2} {
+		ents := []Entity{{ID: "a", Name: "A", Kind: "function", CommunityID: ci(cid)}}
+		res := AnalyzePRImpact(ents, nil, ChangeSet{
+			Modified: []DiffEntityEntry{{ID: "a"}},
+		}, DefaultPRImpactOptions())
+		if res.CommunityDataAvailable {
+			t.Errorf("community_id=%d is the ungrouped sentinel, not a community; "+
+				"CommunityDataAvailable must be false", cid)
+		}
+		if res.ChangedWithoutCommunity != 1 {
+			t.Errorf("community_id=%d: ChangedWithoutCommunity = %d, want 1",
+				cid, res.ChangedWithoutCommunity)
+		}
+	}
+}
+
 // The ungrouped bucket must not be presented as a real community. The fixture
 // mixes a grouped changed entity with an ungrouped one so the filter has
 // something to remove AND something to keep — a fixture with only ungrouped

--- a/internal/graph/pr_impact_6006_test.go
+++ b/internal/graph/pr_impact_6006_test.go
@@ -1,0 +1,128 @@
+// pr_impact_6006_test.go — issue #6006: merge-risk must not answer "no
+// conflicts" when the community data the answer depends on was never computed.
+//
+// The dangerous shape is a FALSE NEGATIVE on a safety question. These tests pin
+// the discrimination directly: two refs with NO community data and two refs with
+// REAL, DISJOINT community data both produce zero risky pairs — the result must
+// still tell them apart.
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+// stripCommunities returns a copy of ents with every CommunityID cleared, which
+// is exactly what a graph.fb loaded from disk looks like today (the per-repo
+// Pass-4 algo pass was removed; the fb scalars are permanent sentinels).
+func stripCommunities(ents []Entity) []Entity {
+	out := make([]Entity, len(ents))
+	copy(out, ents)
+	for i := range out {
+		out[i].CommunityID = nil
+	}
+	return out
+}
+
+// A graph that DOES carry communities reports community data as available; the
+// same graph with the ids stripped reports it as unavailable. The two fixtures
+// differ only in the community stamps, so this cannot pass by accident.
+func TestAnalyzePRImpact_CommunityDataAvailability(t *testing.T) {
+	ents, rels := prImpactFixture()
+	change := ChangeSet{Modified: []DiffEntityEntry{{ID: "c"}}}
+
+	withComm := AnalyzePRImpact(ents, rels, change, DefaultPRImpactOptions())
+	if !withComm.CommunityDataAvailable {
+		t.Errorf("graph carries community ids; CommunityDataAvailable = false, want true")
+	}
+
+	without := AnalyzePRImpact(stripCommunities(ents), rels, change, DefaultPRImpactOptions())
+	if without.CommunityDataAvailable {
+		t.Errorf("graph carries NO community ids; CommunityDataAvailable = true, want false")
+	}
+	// And the community-derived output really is empty in that case — which is
+	// precisely why the flag has to exist.
+	if len(without.ImpactedCommunityIDs()) != 0 {
+		t.Errorf("expected no impacted community ids without community data, got %v",
+			without.ImpactedCommunityIDs())
+	}
+}
+
+// The ungrouped bucket must not be presented as a real community. The fixture
+// mixes a grouped changed entity with an ungrouped one so the filter has
+// something to remove AND something to keep — a fixture with only ungrouped
+// entities could not tell "filtered" from "empty".
+func TestAnalyzePRImpact_UngroupedBucketNotReportedAsCommunity(t *testing.T) {
+	ents := []Entity{
+		{ID: "a", Name: "A", Kind: "function", CommunityID: ci(0)},
+		{ID: "u", Name: "U", Kind: "function"}, // no community
+	}
+	change := ChangeSet{Modified: []DiffEntityEntry{{ID: "a"}, {ID: "u"}}}
+	res := AnalyzePRImpact(ents, nil, change, DefaultPRImpactOptions())
+
+	for _, c := range res.ImpactedCommunities {
+		if c.CommunityID < 0 {
+			t.Errorf("impacted_communities surfaced the ungrouped bucket: %+v (all: %+v)",
+				c, res.ImpactedCommunities)
+		}
+	}
+	if res.CommunityCount != 1 {
+		t.Errorf("impacted_community_count = %d, want 1 (community 0 only); got %+v",
+			res.CommunityCount, res.ImpactedCommunities)
+	}
+	// The grouped community is still fully reported.
+	if len(res.ImpactedCommunities) != 1 || res.ImpactedCommunities[0].CommunityID != 0 ||
+		res.ImpactedCommunities[0].ChangedCount != 1 {
+		t.Errorf("community 0 rollup lost: %+v", res.ImpactedCommunities)
+	}
+}
+
+// THE critical test. Both scenarios yield zero risky pairs; the result must make
+// them distinguishable.
+func TestAnalyzeMergeRisk_UnavailableIsDistinguishableFromNoConflicts(t *testing.T) {
+	// Genuine "no conflicts": community data present, sets disjoint.
+	genuine := AnalyzeMergeRisk([]ChangeImpact{
+		{Ref: "pr-a", Communities: []int{1}, CommunityDataAvailable: true},
+		{Ref: "pr-b", Communities: []int{2}, CommunityDataAvailable: true},
+	})
+	if genuine.RiskyPairs != 0 {
+		t.Fatalf("disjoint communities should be 0 risky pairs, got %+v", genuine.Pairs)
+	}
+	if !genuine.CommunityDataAvailable {
+		t.Errorf("genuine no-conflict result reported community data unavailable")
+	}
+	if len(genuine.RefsWithoutCommunityData) != 0 {
+		t.Errorf("genuine no-conflict result listed refs without community data: %v",
+			genuine.RefsWithoutCommunityData)
+	}
+
+	// "Not computed": no community data at all.
+	unknown := AnalyzeMergeRisk([]ChangeImpact{
+		{Ref: "pr-a", CommunityDataAvailable: false},
+		{Ref: "pr-b", CommunityDataAvailable: false},
+	})
+	if unknown.RiskyPairs != 0 {
+		t.Fatalf("no community data cannot produce risky pairs, got %+v", unknown.Pairs)
+	}
+	if unknown.CommunityDataAvailable {
+		t.Errorf("uncomputed result claimed community data was available — this is the #6006 false negative")
+	}
+	if !reflect.DeepEqual(unknown.RefsWithoutCommunityData, []string{"pr-a", "pr-b"}) {
+		t.Errorf("RefsWithoutCommunityData = %v, want [pr-a pr-b]", unknown.RefsWithoutCommunityData)
+	}
+}
+
+// A partial outage — one ref has community data, one does not — is still not a
+// trustworthy "no conflicts", and the specific ref must be named.
+func TestAnalyzeMergeRisk_PartialUnavailabilityIsReported(t *testing.T) {
+	res := AnalyzeMergeRisk([]ChangeImpact{
+		{Ref: "pr-a", Communities: []int{1}, CommunityDataAvailable: true},
+		{Ref: "pr-b", CommunityDataAvailable: false},
+	})
+	if res.CommunityDataAvailable {
+		t.Errorf("one ref without community data must make the whole result untrusted")
+	}
+	if !reflect.DeepEqual(res.RefsWithoutCommunityData, []string{"pr-b"}) {
+		t.Errorf("RefsWithoutCommunityData = %v, want [pr-b]", res.RefsWithoutCommunityData)
+	}
+}

--- a/internal/mcp/pr_impact_6006_test.go
+++ b/internal/mcp/pr_impact_6006_test.go
@@ -1,0 +1,257 @@
+// pr_impact_6006_test.go — issue #6006: grafel_pr_impact must never answer a
+// merge-risk question with a silent "no conflicts" when the community data the
+// answer depends on was never computed.
+//
+// The fixtures below are deliberately IDENTICAL except for the presence of the
+// group-algo overlay: same repo, same refs, same diff. With the overlay the tool
+// finds a real conflict; without it the tool must say so explicitly rather than
+// returning an empty risky-pair list.
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// prImpact6006Env is the on-disk world a grafel_pr_impact call needs: a
+// registered group, a repo with per-ref graph.fb files, and a resolved overlay
+// path the test can populate or leave empty.
+type prImpact6006Env struct {
+	srv         *Server
+	overlayPath string
+	curMtimes   map[string]int64
+}
+
+func prImpact6006Ent(id string) graph.Entity {
+	return graph.Entity{ID: id, Name: id, Kind: "function", SourceFile: id + ".go", Language: "go"}
+}
+
+// setupPRImpact6006 writes three ref graphs for one repo:
+//
+//	main     : A, B
+//	featureA : A, B, NewA   (NewA CALLS A)
+//	featureB : A, B, NewB   (NewB CALLS A)
+//
+// NONE of the entities carry a CommunityID — that is exactly what graph.fb looks
+// like today, since the per-repo Pass-4 algo pass was removed in favour of the
+// group-scope pass that writes <group>-algo.json.
+func setupPRImpact6006(t *testing.T) prImpact6006Env {
+	t.Helper()
+	testsupport.IsolateHome(t)
+	root := t.TempDir()
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemon"))
+
+	repoPath := filepath.Join(root, "svc")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	base := []graph.Entity{prImpact6006Ent("svc:A"), prImpact6006Ent("svc:B")}
+	mk := func(extra string) *graph.Document {
+		d := &graph.Document{Version: 1, Repo: "svc"}
+		d.Entities = append(d.Entities, base...)
+		if extra != "" {
+			d.Entities = append(d.Entities, prImpact6006Ent(extra))
+			d.Relationships = []graph.Relationship{{FromID: extra, ToID: "svc:A", Kind: "CALLS"}}
+		}
+		return d
+	}
+	refs := map[string]*graph.Document{
+		"main":     mk(""),
+		"featureA": mk("svc:NewA"),
+		"featureB": mk("svc:NewB"),
+	}
+	for ref, doc := range refs {
+		dir := daemon.StateDirForRepoRef(repoPath, ref)
+		if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+			t.Fatalf("write graph.fb for %s: %v", ref, err)
+		}
+	}
+	// The HEAD-ref graph.fb the overlay's staleness check keys off.
+	if err := fbwriter.WriteAtomic(
+		filepath.Join(daemon.StateDirForRepo(repoPath), "graph.fb"), mk("")); err != nil {
+		t.Fatalf("write HEAD graph.fb: %v", err)
+	}
+
+	cfgPath, err := registry.ConfigPathFor("acme")
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	cfg := &registry.GroupConfig{Name: "acme", Repos: []registry.Repo{{Slug: "svc", Path: repoPath}}}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	if err := registry.AddGroup("acme", cfgPath); err != nil {
+		t.Fatalf("add group: %v", err)
+	}
+
+	overlayPath, err := groupalgo.OverlayPath("acme")
+	if err != nil {
+		t.Fatalf("overlay path: %v", err)
+	}
+	cur, err := groupalgo.CurrentSourceMtimes("acme")
+	if err != nil {
+		t.Fatalf("current mtimes: %v", err)
+	}
+	return prImpact6006Env{
+		srv:         newTestServer(t, &graph.Document{Repo: "svc"}),
+		overlayPath: overlayPath,
+		curMtimes:   cur,
+	}
+}
+
+// writeOverlay6006 stamps every fixture entity into ONE community (7), so the
+// two feature refs genuinely conflict.
+func (e prImpact6006Env) writeOverlay(t *testing.T) {
+	t.Helper()
+	res := map[string]groupalgo.EntityOverlay{}
+	for _, id := range []string{"svc:A", "svc:B", "svc:NewA", "svc:NewB"} {
+		res[id] = groupalgo.EntityOverlay{CommunityID: 7, PageRank: 0.1}
+	}
+	ov := &groupalgo.Overlay{
+		AlgoVersion:  groupalgo.OverlayAlgoVersion,
+		Group:        "acme",
+		SourceMtimes: e.curMtimes,
+		Results:      res,
+		Communities:  []graph.CommunityResult{{ID: 7, Size: 4, AutoName: "core"}},
+	}
+	if err := groupalgo.WriteOverlayTo(e.overlayPath, ov); err != nil {
+		t.Fatalf("write overlay: %v", err)
+	}
+}
+
+func conflictsArgs() map[string]any {
+	return map[string]any{
+		"group": "acme", "repo": "svc",
+		"base": "main",
+		"refs": []any{"featureA", "featureB"},
+	}
+}
+
+// Control arm: with the group overlay present, the two refs DO conflict. This is
+// what proves the fixture can exhibit a conflict at all — without it, the
+// unavailable arm below would be indistinguishable from a fixture that simply
+// has nothing to find.
+func TestPRImpact6006_ConflictsDetectedWithOverlay(t *testing.T) {
+	env := setupPRImpact6006(t)
+	env.writeOverlay(t)
+
+	res := callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
+	if res == nil || res.IsError {
+		t.Fatalf("expected a successful result, got: %v / %s", res, resultText(res))
+	}
+	var payload struct {
+		RiskyPairCount         int  `json:"risky_pair_count"`
+		CommunityDataAvailable bool `json:"community_data_available"`
+		RiskPairs              []struct {
+			SharedCommunities []int `json:"shared_communities"`
+		} `json:"risk_pairs"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, resultText(res))
+	}
+	if !payload.CommunityDataAvailable {
+		t.Errorf("overlay is present and fresh; community_data_available = false")
+	}
+	if payload.RiskyPairCount != 1 {
+		t.Fatalf("expected 1 risky pair from the shared community, got %d: %s",
+			payload.RiskyPairCount, resultText(res))
+	}
+	if len(payload.RiskPairs) != 1 || len(payload.RiskPairs[0].SharedCommunities) != 1 ||
+		payload.RiskPairs[0].SharedCommunities[0] != 7 {
+		t.Errorf("expected shared community [7], got %+v", payload.RiskPairs)
+	}
+}
+
+// THE #6006 test. Identical call, overlay removed. The tool must NOT hand back a
+// payload whose risky_pair_count is 0 — that reads as "safe to merge".
+func TestPRImpact6006_NoOverlayIsNotReportedAsNoConflicts(t *testing.T) {
+	env := setupPRImpact6006(t)
+	_ = os.Remove(env.overlayPath)
+
+	res := callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	text := resultText(res)
+	if !res.IsError {
+		t.Fatalf("merge risk with no community data must be an explicit error, not a result; got: %s", text)
+	}
+	low := strings.ToLower(text)
+	for _, want := range []string{"community", "not", "conflict"} {
+		if !strings.Contains(low, want) {
+			t.Errorf("error message should explain the unavailability and that it is NOT a no-conflicts answer; missing %q in: %s", want, text)
+		}
+	}
+	// Belt and braces: whatever shape the message takes, it must not be a JSON
+	// payload that an agent could parse as a clean zero-risk answer.
+	var payload map[string]any
+	if json.Unmarshal([]byte(text), &payload) == nil {
+		if v, ok := payload["risky_pair_count"]; ok {
+			t.Errorf("unavailable merge risk still emitted risky_pair_count=%v", v)
+		}
+	}
+}
+
+// A STALE overlay is treated exactly like an absent one — it must not silently
+// supply a partition that no longer matches the graphs being compared.
+func TestPRImpact6006_StaleOverlayIsNotReportedAsNoConflicts(t *testing.T) {
+	env := setupPRImpact6006(t)
+	// Record mtimes that do not match anything on disk → IsOverlayStale.
+	env.curMtimes = map[string]int64{"svc": 1}
+	env.writeOverlay(t)
+
+	res := callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
+	if res == nil || !res.IsError {
+		t.Fatalf("stale overlay must be reported, not silently treated as no-conflicts; got: %s", resultText(res))
+	}
+}
+
+// Single mode keeps returning its payload (the blast radius does not depend on
+// communities) but must label the community data so an empty
+// impacted_communities is explicable.
+func TestPRImpact6006_SingleModeLabelsCommunityData(t *testing.T) {
+	env := setupPRImpact6006(t)
+	args := map[string]any{"group": "acme", "repo": "svc", "base": "main", "head": "featureA"}
+
+	parse := func(t *testing.T) (bool, int) {
+		t.Helper()
+		res := callHandlerResult(t, env.srv.handlePRImpact, args)
+		if res == nil || res.IsError {
+			t.Fatalf("single mode should succeed, got: %s", resultText(res))
+		}
+		var p struct {
+			CommunityDataAvailable bool `json:"community_data_available"`
+			CommunityCount         int  `json:"impacted_community_count"`
+			ChangedCount           int  `json:"changed_count"`
+		}
+		if err := json.Unmarshal([]byte(resultText(res)), &p); err != nil {
+			t.Fatalf("unmarshal: %v\n%s", err, resultText(res))
+		}
+		if p.ChangedCount == 0 {
+			t.Fatalf("fixture produced no changed entities — it cannot test anything: %s", resultText(res))
+		}
+		return p.CommunityDataAvailable, p.CommunityCount
+	}
+
+	_ = os.Remove(env.overlayPath)
+	if avail, count := parse(t); avail || count != 0 {
+		t.Errorf("no overlay: want community_data_available=false and 0 communities, got %v/%d", avail, count)
+	}
+
+	env.writeOverlay(t)
+	if avail, count := parse(t); !avail || count != 1 {
+		t.Errorf("with overlay: want community_data_available=true and 1 community, got %v/%d", avail, count)
+	}
+}

--- a/internal/mcp/pr_impact_6006_test.go
+++ b/internal/mcp/pr_impact_6006_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
@@ -21,6 +22,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/testsupport"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
 // prImpact6006Env is the on-disk world a grafel_pr_impact call needs: a
@@ -57,20 +59,32 @@ func setupPRImpact6006(t *testing.T) prImpact6006Env {
 		t.Fatalf("mkdir repo: %v", err)
 	}
 
-	base := []graph.Entity{prImpact6006Ent("svc:A"), prImpact6006Ent("svc:B")}
-	mk := func(extra string) *graph.Document {
-		d := &graph.Document{Version: 1, Repo: "svc"}
-		d.Entities = append(d.Entities, base...)
-		if extra != "" {
-			d.Entities = append(d.Entities, prImpact6006Ent(extra))
-			d.Relationships = []graph.Relationship{{FromID: extra, ToID: "svc:A", Kind: "CALLS"}}
+	// mk builds a ref graph. sigA perturbs svc:A's signature, which feeds
+	// graph.DiffDocs' sourceWindowHash and so classifies it as MODIFIED (and
+	// which load.go explicitly round-trips through graph.fb); added names an
+	// entity that exists only on this ref.
+	mk := func(sigA string, added string) *graph.Document {
+		a := prImpact6006Ent("svc:A")
+		a.Signature = sigA
+		d := &graph.Document{Version: 1, Repo: "svc",
+			Entities: []graph.Entity{a, prImpact6006Ent("svc:B")}}
+		if added != "" {
+			d.Entities = append(d.Entities, prImpact6006Ent(added))
+			d.Relationships = []graph.Relationship{{FromID: added, ToID: "svc:A", Kind: "CALLS"}}
 		}
 		return d
 	}
 	refs := map[string]*graph.Document{
-		"main":     mk(""),
-		"featureA": mk("svc:NewA"),
-		"featureB": mk("svc:NewB"),
+		"main": mk("func A()", ""),
+		// Two refs that MODIFY a pre-existing, overlay-covered entity.
+		"modA":  mk("func A(x int)", ""),
+		"modA2": mk("func A(y string)", ""),
+		// Two refs that only ADD entities. These are the #6006 D1 shape: the
+		// overlay is computed from the indexed group union, so svc:NewA / svc:NewB
+		// CANNOT be in it. A fixture that stamps them into the overlay is testing a
+		// state production cannot produce.
+		"addOnly1": mk("func A()", "svc:NewA"),
+		"addOnly2": mk("func A()", "svc:NewB"),
 	}
 	for ref, doc := range refs {
 		dir := daemon.StateDirForRepoRef(repoPath, ref)
@@ -80,7 +94,7 @@ func setupPRImpact6006(t *testing.T) prImpact6006Env {
 	}
 	// The HEAD-ref graph.fb the overlay's staleness check keys off.
 	if err := fbwriter.WriteAtomic(
-		filepath.Join(daemon.StateDirForRepo(repoPath), "graph.fb"), mk("")); err != nil {
+		filepath.Join(daemon.StateDirForRepo(repoPath), "graph.fb"), mk("func A()", "")); err != nil {
 		t.Fatalf("write HEAD graph.fb: %v", err)
 	}
 
@@ -111,32 +125,74 @@ func setupPRImpact6006(t *testing.T) prImpact6006Env {
 	}
 }
 
-// writeOverlay6006 stamps every fixture entity into ONE community (7), so the
-// two feature refs genuinely conflict.
+// writeOverlay writes the overlay in the PRODUCTION shape: it covers exactly the
+// entities that exist in the indexed group union (svc:A, svc:B) and nothing
+// else. Entities that live only on a feature ref are deliberately absent —
+// stamping them in would fabricate a state the group-algo pass cannot produce
+// and would make the add-only test below vacuously pass.
 func (e prImpact6006Env) writeOverlay(t *testing.T) {
 	t.Helper()
 	res := map[string]groupalgo.EntityOverlay{}
-	for _, id := range []string{"svc:A", "svc:B", "svc:NewA", "svc:NewB"} {
+	for _, id := range []string{"svc:A", "svc:B"} {
 		res[id] = groupalgo.EntityOverlay{CommunityID: 7, PageRank: 0.1}
 	}
 	ov := &groupalgo.Overlay{
 		AlgoVersion:  groupalgo.OverlayAlgoVersion,
 		Group:        "acme",
+		ComputedAt:   time.Now().UTC().Add(-time.Hour),
 		SourceMtimes: e.curMtimes,
 		Results:      res,
-		Communities:  []graph.CommunityResult{{ID: 7, Size: 4, AutoName: "core"}},
+		Communities:  []graph.CommunityResult{{ID: 7, Size: 2, AutoName: "core"}},
 	}
 	if err := groupalgo.WriteOverlayTo(e.overlayPath, ov); err != nil {
 		t.Fatalf("write overlay: %v", err)
 	}
 }
 
+// conflictsArgs asks the merge-risk question about two refs that MODIFY a
+// pre-existing, overlay-covered entity.
 func conflictsArgs() map[string]any {
 	return map[string]any{
 		"group": "acme", "repo": "svc",
 		"base": "main",
-		"refs": []any{"featureA", "featureB"},
+		"refs": []any{"modA", "modA2"},
 	}
+}
+
+// addOnlyConflictsArgs asks it about two refs that only ADD entities — the shape
+// the overlay cannot cover.
+func addOnlyConflictsArgs() map[string]any {
+	return map[string]any{
+		"group": "acme", "repo": "svc",
+		"base": "main",
+		"refs": []any{"addOnly1", "addOnly2"},
+	}
+}
+
+// prImpact6006Payload is the union of the fields these tests assert on.
+type prImpact6006Payload struct {
+	RiskyPairCount         int    `json:"risky_pair_count"`
+	CommunityDataAvailable bool   `json:"community_data_available"`
+	CommunityDataStale     bool   `json:"community_data_stale"`
+	OverlayComputedAt      string `json:"overlay_computed_at"`
+	CommunityCount         int    `json:"impacted_community_count"`
+	ChangedCount           int    `json:"changed_count"`
+	ChangedUncovered       int    `json:"changed_entities_without_community"`
+	RiskPairs              []struct {
+		SharedCommunities []int `json:"shared_communities"`
+	} `json:"risk_pairs"`
+}
+
+func mustPayload(t *testing.T, res *mcpapi.CallToolResult) prImpact6006Payload {
+	t.Helper()
+	if res == nil || res.IsError {
+		t.Fatalf("expected a successful result, got: %s", resultText(res))
+	}
+	var p prImpact6006Payload
+	if err := json.Unmarshal([]byte(resultText(res)), &p); err != nil {
+		t.Fatalf("unmarshal payload: %v\n%s", err, resultText(res))
+	}
+	return p
 }
 
 // Control arm: with the group overlay present, the two refs DO conflict. This is
@@ -147,30 +203,53 @@ func TestPRImpact6006_ConflictsDetectedWithOverlay(t *testing.T) {
 	env := setupPRImpact6006(t)
 	env.writeOverlay(t)
 
-	res := callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
-	if res == nil || res.IsError {
-		t.Fatalf("expected a successful result, got: %v / %s", res, resultText(res))
+	p := mustPayload(t, callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs()))
+	if !p.CommunityDataAvailable {
+		t.Errorf("overlay covers the changed entity; community_data_available = false")
 	}
-	var payload struct {
-		RiskyPairCount         int  `json:"risky_pair_count"`
-		CommunityDataAvailable bool `json:"community_data_available"`
-		RiskPairs              []struct {
-			SharedCommunities []int `json:"shared_communities"`
-		} `json:"risk_pairs"`
+	if p.CommunityDataStale {
+		t.Errorf("overlay records the current graph.fb mtimes; community_data_stale = true")
 	}
-	if err := json.Unmarshal([]byte(resultText(res)), &payload); err != nil {
-		t.Fatalf("unmarshal payload: %v\n%s", err, resultText(res))
+	if p.OverlayComputedAt == "" {
+		t.Errorf("overlay_computed_at missing — callers cannot judge the partition's age")
 	}
-	if !payload.CommunityDataAvailable {
-		t.Errorf("overlay is present and fresh; community_data_available = false")
+	if p.RiskyPairCount != 1 {
+		t.Fatalf("expected 1 risky pair from the shared community, got %d", p.RiskyPairCount)
 	}
-	if payload.RiskyPairCount != 1 {
-		t.Fatalf("expected 1 risky pair from the shared community, got %d: %s",
-			payload.RiskyPairCount, resultText(res))
+	if len(p.RiskPairs) != 1 || len(p.RiskPairs[0].SharedCommunities) != 1 ||
+		p.RiskPairs[0].SharedCommunities[0] != 7 {
+		t.Errorf("expected shared community [7], got %+v", p.RiskPairs)
 	}
-	if len(payload.RiskPairs) != 1 || len(payload.RiskPairs[0].SharedCommunities) != 1 ||
-		payload.RiskPairs[0].SharedCommunities[0] != 7 {
-		t.Errorf("expected shared community [7], got %+v", payload.RiskPairs)
+}
+
+// D1 — the regression the first fix missed. The overlay is present, fresh, and
+// covers the repo; the two refs only ADD entities, so nothing they changed is in
+// it. Before this fix the tool returned risky_pair_count:0 alongside
+// community_data_available:true — an affirmative all-clear on a change nothing
+// was known about, which is worse than the original bug.
+func TestPRImpact6006_AddOnlyRefsAreNotReportedAsNoConflicts(t *testing.T) {
+	env := setupPRImpact6006(t)
+	env.writeOverlay(t)
+
+	res := callHandlerResult(t, env.srv.handlePRImpact, addOnlyConflictsArgs())
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	text := resultText(res)
+	if !res.IsError {
+		t.Fatalf("no changed entity is covered by the overlay, so merge risk was not computed; "+
+			"must not return a payload: %s", text)
+	}
+	// The remedy differs from the absent-overlay case: telling a user to run a
+	// group index when the overlay exists and is fresh is actively misleading.
+	if !strings.Contains(text, "does not cover the changed entities") {
+		t.Errorf("error must name the real cause (overlay does not cover the changed entities), got: %s", text)
+	}
+	var payload map[string]any
+	if json.Unmarshal([]byte(text), &payload) == nil {
+		if v, ok := payload["risky_pair_count"]; ok {
+			t.Errorf("uncomputed merge risk still emitted risky_pair_count=%v", v)
+		}
 	}
 }
 
@@ -194,6 +273,10 @@ func TestPRImpact6006_NoOverlayIsNotReportedAsNoConflicts(t *testing.T) {
 			t.Errorf("error message should explain the unavailability and that it is NOT a no-conflicts answer; missing %q in: %s", want, text)
 		}
 	}
+	// The absent case must NOT be described as staleness — the remedy differs.
+	if !strings.Contains(text, "absent, corrupt") {
+		t.Errorf("error should name the absent/corrupt overlay specifically, got: %s", text)
+	}
 	// Belt and braces: whatever shape the message takes, it must not be a JSON
 	// payload that an agent could parse as a clean zero-risk answer.
 	var payload map[string]any
@@ -204,17 +287,70 @@ func TestPRImpact6006_NoOverlayIsNotReportedAsNoConflicts(t *testing.T) {
 	}
 }
 
-// A STALE overlay is treated exactly like an absent one — it must not silently
-// supply a partition that no longer matches the graphs being compared.
-func TestPRImpact6006_StaleOverlayIsNotReportedAsNoConflicts(t *testing.T) {
+// D2 — a STALE overlay must still ANSWER, flagged. The staleness key is the
+// currently-checked-out ref's graph.fb, so refusing on stale turned "I am
+// standing on a feature branch" — the only posture from which anyone asks this
+// question — into a hard error, and made the tool unusable for ~50 minutes after
+// any reindex. A community-level verdict from a slightly older partition is
+// worth far more than a refusal.
+func TestPRImpact6006_StaleOverlayStillAnswersButIsFlagged(t *testing.T) {
 	env := setupPRImpact6006(t)
-	// Record mtimes that do not match anything on disk → IsOverlayStale.
+	// Record mtimes that match nothing on disk → IsOverlayStale.
 	env.curMtimes = map[string]int64{"svc": 1}
 	env.writeOverlay(t)
 
-	res := callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
-	if res == nil || !res.IsError {
-		t.Fatalf("stale overlay must be reported, not silently treated as no-conflicts; got: %s", resultText(res))
+	p := mustPayload(t, callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs()))
+	if p.RiskyPairCount != 1 {
+		t.Fatalf("a stale partition still places these refs in community 7; "+
+			"expected the conflict to be reported, got %d", p.RiskyPairCount)
+	}
+	if !p.CommunityDataStale {
+		t.Errorf("overlay IS stale but community_data_stale = false — the caller cannot tell")
+	}
+	if !p.CommunityDataAvailable {
+		t.Errorf("stale is not unavailable: community_data_available should be true")
+	}
+	if p.OverlayComputedAt == "" {
+		t.Errorf("overlay_computed_at missing — the only way to judge how stale")
+	}
+}
+
+// D4 — the overlay is parsed once per (path, mtime), not once per call. On the
+// live corpus the file is 31.9 MB: ~326 ms and ~76 MB of transient heap per
+// read, and concurrent MCP agents are exactly the workload that cannot afford it.
+func TestPRImpact6006_OverlayReadIsMemoized(t *testing.T) {
+	env := setupPRImpact6006(t)
+	env.writeOverlay(t)
+
+	// Prime the cache, then measure hits across two further calls.
+	_ = callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs())
+	overlayCacheMu.Lock()
+	before := overlayCacheHits
+	overlayCacheMu.Unlock()
+
+	for i := 0; i < 2; i++ {
+		_ = mustPayload(t, callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs()))
+	}
+
+	overlayCacheMu.Lock()
+	got := overlayCacheHits - before
+	overlayCacheMu.Unlock()
+	if got != 2 {
+		t.Errorf("expected 2 cache hits across 2 repeat calls, got %d (overlay re-parsed per call)", got)
+	}
+
+	// A rewritten overlay must invalidate: same path, new content.
+	time.Sleep(10 * time.Millisecond) // ensure a distinct mtime
+	env.writeOverlay(t)
+	overlayCacheMu.Lock()
+	before = overlayCacheHits
+	overlayCacheMu.Unlock()
+	_ = mustPayload(t, callHandlerResult(t, env.srv.handlePRImpact, conflictsArgs()))
+	overlayCacheMu.Lock()
+	got = overlayCacheHits - before
+	overlayCacheMu.Unlock()
+	if got != 0 {
+		t.Errorf("a rewritten overlay must invalidate the cache, got %d hits", got)
 	}
 }
 
@@ -223,35 +359,42 @@ func TestPRImpact6006_StaleOverlayIsNotReportedAsNoConflicts(t *testing.T) {
 // impacted_communities is explicable.
 func TestPRImpact6006_SingleModeLabelsCommunityData(t *testing.T) {
 	env := setupPRImpact6006(t)
-	args := map[string]any{"group": "acme", "repo": "svc", "base": "main", "head": "featureA"}
-
-	parse := func(t *testing.T) (bool, int) {
+	parse := func(t *testing.T, head string) prImpact6006Payload {
 		t.Helper()
-		res := callHandlerResult(t, env.srv.handlePRImpact, args)
-		if res == nil || res.IsError {
-			t.Fatalf("single mode should succeed, got: %s", resultText(res))
-		}
-		var p struct {
-			CommunityDataAvailable bool `json:"community_data_available"`
-			CommunityCount         int  `json:"impacted_community_count"`
-			ChangedCount           int  `json:"changed_count"`
-		}
-		if err := json.Unmarshal([]byte(resultText(res)), &p); err != nil {
-			t.Fatalf("unmarshal: %v\n%s", err, resultText(res))
-		}
+		p := mustPayload(t, callHandlerResult(t, env.srv.handlePRImpact,
+			map[string]any{"group": "acme", "repo": "svc", "base": "main", "head": head}))
 		if p.ChangedCount == 0 {
-			t.Fatalf("fixture produced no changed entities — it cannot test anything: %s", resultText(res))
+			t.Fatalf("fixture produced no changed entities for head=%s — it cannot test anything", head)
 		}
-		return p.CommunityDataAvailable, p.CommunityCount
+		return p
 	}
 
+	// No overlay at all.
 	_ = os.Remove(env.overlayPath)
-	if avail, count := parse(t); avail || count != 0 {
-		t.Errorf("no overlay: want community_data_available=false and 0 communities, got %v/%d", avail, count)
+	if p := parse(t, "modA"); p.CommunityDataAvailable || p.CommunityCount != 0 {
+		t.Errorf("no overlay: want available=false / 0 communities, got %v/%d",
+			p.CommunityDataAvailable, p.CommunityCount)
 	}
 
+	// Overlay present, change touches a covered entity.
 	env.writeOverlay(t)
-	if avail, count := parse(t); !avail || count != 1 {
-		t.Errorf("with overlay: want community_data_available=true and 1 community, got %v/%d", avail, count)
+	p := parse(t, "modA")
+	if !p.CommunityDataAvailable || p.CommunityCount != 1 {
+		t.Errorf("with overlay: want available=true / 1 community, got %v/%d",
+			p.CommunityDataAvailable, p.CommunityCount)
+	}
+	if p.ChangedUncovered != 0 {
+		t.Errorf("the modified entity IS covered; changed_entities_without_community = %d", p.ChangedUncovered)
+	}
+
+	// D1 in single mode: same fresh overlay, add-only change. Single mode still
+	// returns its payload (the blast radius is valid) but must NOT claim the
+	// community data covered this change.
+	add := parse(t, "addOnly1")
+	if add.CommunityDataAvailable {
+		t.Errorf("add-only change is uncovered by the overlay; community_data_available must be false")
+	}
+	if add.ChangedUncovered != 1 {
+		t.Errorf("changed_entities_without_community = %d, want 1", add.ChangedUncovered)
 	}
 }

--- a/internal/mcp/pr_impact_tools.go
+++ b/internal/mcp/pr_impact_tools.go
@@ -19,17 +19,15 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"os"
+	"sync"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
-
-// noCommunityDataHint is appended to every "community data unavailable" message
-// so the answer is actionable rather than merely negative.
-const noCommunityDataHint = "the group-algo overlay (<group>-algo.json) is missing or stale — " +
-	"run/await a group index so community detection produces it, then retry"
 
 // handlePRImpact implements grafel_pr_impact.
 //
@@ -109,12 +107,24 @@ func (s *Server) handlePRImpact(_ context.Context, req mcpapi.CallToolRequest) (
 		// #6006: the blast radius is valid regardless, but impacted_communities
 		// is only meaningful when this is true. Without the flag an empty
 		// impacted_communities is indistinguishable from "nothing was computed".
-		"community_data_available": res.CommunityDataAvailable,
+		"community_data_available":           res.CommunityDataAvailable,
+		"changed_entities_without_community": res.ChangedWithoutCommunity,
 	}
+	stamper.describeInto(out)
 	if !res.CommunityDataAvailable {
-		out["community_data_unavailable_reason"] = noCommunityDataHint
+		out["community_data_unavailable_reason"] = stamper.unavailableCause(groupName)
 	}
 	return jsonResult(out), nil
+}
+
+// describeInto adds the overlay-provenance fields every pr_impact payload
+// carries, so a caller can tell a current partition from a 50-minute-old one
+// without the tool having to refuse the older one.
+func (s groupCommunityStamper) describeInto(out map[string]any) {
+	out["community_data_stale"] = s.ov != nil && s.stale
+	if s.ov != nil && !s.ov.ComputedAt.IsZero() {
+		out["overlay_computed_at"] = s.ov.ComputedAt.UTC().Format(time.RFC3339)
+	}
 }
 
 // groupCommunityStamper supplies the community assignments grafel_pr_impact
@@ -130,12 +140,22 @@ func (s *Server) handlePRImpact(_ context.Context, req mcpapi.CallToolRequest) (
 // reports — two disagreeing community numberings, and merge risk computed
 // against the wrong one.
 //
-// Absence-tolerance mirrors applyGroupAlgoOverlay: an absent, corrupt, stale or
-// version-mismatched overlay yields the zero stamper, which stamps nothing. The
-// difference is what the CALLER then does — here that state is reported, not
-// silently rendered as "no conflicts".
+// An absent, corrupt or version-mismatched overlay yields the zero stamper,
+// which stamps nothing — and the CALLER reports that state instead of silently
+// rendering it as "no conflicts".
+//
+// STALENESS IS TOLERATED, NOT REFUSED (see groupalgo.ReadOverlayAnyAge). The
+// staleness key is the graph.fb of whichever ref is currently CHECKED OUT, so
+// refusing on stale meant that standing on a feature branch — the only posture
+// from which anyone asks a merge-risk question — turned conflicts mode into a
+// hard error, as did any reindex of any repo in the group for the ~50 minutes
+// until group-algo caught up. Merge risk is a community-level verdict; a
+// 50-minute-old partition is overwhelmingly the same partition. So a stale
+// overlay is applied and the staleness is REPORTED (community_data_stale +
+// overlay_computed_at) rather than withheld.
 type groupCommunityStamper struct {
-	ov *groupalgo.Overlay // nil ⇒ no community data available
+	ov    *groupalgo.Overlay // nil ⇒ no community data at all
+	stale bool               // overlay applied, but older than the current graphs
 }
 
 func newGroupCommunityStamper(group string) groupCommunityStamper {
@@ -143,15 +163,78 @@ func newGroupCommunityStamper(group string) groupCommunityStamper {
 	if err != nil || path == "" {
 		return groupCommunityStamper{}
 	}
-	cur, err := groupalgo.CurrentSourceMtimes(group)
-	if err != nil {
-		return groupCommunityStamper{}
-	}
-	ov, ok := groupalgo.ReadOverlay(path, cur)
+	ov, ok := cachedOverlayAnyAge(path)
 	if !ok {
 		return groupCommunityStamper{}
 	}
-	return groupCommunityStamper{ov: ov}
+	// Staleness is computed per call (cheap: a registry read + one stat per repo)
+	// and deliberately NOT part of the cache key — the parsed overlay is the
+	// expensive part and does not change when a graph.fb mtime moves.
+	stale := true
+	if cur, mtErr := groupalgo.CurrentSourceMtimes(group); mtErr == nil {
+		stale = groupalgo.IsOverlayStale(ov, cur)
+	}
+	return groupCommunityStamper{ov: ov, stale: stale}
+}
+
+// unavailableCause explains WHY no community data reached the changed entities.
+// The two causes need different remedies, and telling a user to "run a group
+// index" when they have just done so is worse than saying nothing.
+func (s groupCommunityStamper) unavailableCause(group string) string {
+	if s.ov == nil {
+		return fmt.Sprintf("no usable group-algo overlay exists for group %q "+
+			"(%s-algo.json is absent, corrupt, or was produced by a different algorithm "+
+			"version) — run or await a group index so community detection produces it", group, group)
+	}
+	return "the group-algo overlay exists but does not cover the changed entities. " +
+		"The overlay is computed from the INDEXED group union, so entities that exist only " +
+		"on a feature ref are absent from it by construction — this is the expected shape for " +
+		"a change that only ADDS entities. Reindex the group with those refs' code present, " +
+		"or fall back to single mode and triage by blast radius"
+}
+
+// ── overlay read cache (one entry) ───────────────────────────────────────────
+//
+// The overlay is read and unmarshalled on every grafel_pr_impact call, in both
+// modes. On the live corpus that is a 31.9 MB JSON file: ~326 ms and ~76 MB of
+// transient heap PER CALL. The latency is acceptable (RSS over latency is the
+// standing trade for MCP agents) but the transient heap is not — concurrent MCP
+// agents on a 16 GB box are precisely the workload this costs the most.
+//
+// One entry is the right size: a session works one group at a time, and
+// concurrent agents share it. Keyed on path + mtime + size so an atomic overlay
+// swap (os.Rename, see overlay.go) invalidates it. The cached *Overlay is
+// treated as IMMUTABLE — stamp() only reads it and writes to the caller's
+// Document — so sharing it across concurrent calls needs no copy.
+var (
+	overlayCacheMu   sync.Mutex
+	overlayCacheKey  string
+	overlayCacheVal  *groupalgo.Overlay
+	overlayCacheHits int // test-visible; not reported anywhere
+)
+
+func cachedOverlayAnyAge(path string) (*groupalgo.Overlay, bool) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return nil, false
+	}
+	key := fmt.Sprintf("%s\x00%d\x00%d", path, fi.ModTime().UnixNano(), fi.Size())
+
+	overlayCacheMu.Lock()
+	defer overlayCacheMu.Unlock()
+	if overlayCacheKey == key && overlayCacheVal != nil {
+		overlayCacheHits++
+		return overlayCacheVal, true
+	}
+	ov, ok := groupalgo.ReadOverlayAnyAge(path)
+	if !ok {
+		// Do not cache misses: an absent/corrupt overlay is usually transient
+		// (mid-write, or not computed yet) and re-reading it is cheap.
+		overlayCacheKey, overlayCacheVal = "", nil
+		return nil, false
+	}
+	overlayCacheKey, overlayCacheVal = key, ov
+	return ov, true
 }
 
 // stamp copies the overlay's CommunityID onto doc's entities in place, by id.
@@ -221,6 +304,10 @@ func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, r
 			"changed_count":        res.ChangedCount,
 			"impacted_communities": comms,
 			"blast_radius_count":   res.BlastRadiusCount,
+			// #6006 D1: partial coverage is visible per ref, so a caller can see
+			// that (say) 3 of 4 changed entities were placed even when the overall
+			// verdict stands.
+			"changed_entities_without_community": res.ChangedWithoutCommunity,
 		})
 	}
 
@@ -233,12 +320,12 @@ func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, r
 	// client cannot mistake for an answer.
 	if !risk.CommunityDataAvailable {
 		return mcpapi.NewToolResultError(fmt.Sprintf(
-			"merge-risk analysis did NOT run: no community assignments are available for ref(s) %v, "+
-				"so grafel cannot tell whether these refs conflict. This is NOT a \"no conflicts\" result. "+
-				"Cause: %s.",
-			risk.RefsWithoutCommunityData, noCommunityDataHint)), nil
+			"merge-risk analysis did NOT run: none of the changed entities on ref(s) %v could be "+
+				"placed in a community, so grafel cannot tell whether these refs conflict. "+
+				"This is NOT a \"no conflicts\" result. Cause: %s.",
+			risk.RefsWithoutCommunityData, stamper.unavailableCause(groupName))), nil
 	}
-	return jsonResult(map[string]any{
+	out := map[string]any{
 		"mode":                     "conflicts",
 		"group":                    groupName,
 		"repo":                     repoSlug,
@@ -248,7 +335,9 @@ func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, r
 		"ref_count":                risk.RefCount,
 		"risky_pair_count":         risk.RiskyPairs,
 		"community_data_available": risk.CommunityDataAvailable,
-	}), nil
+	}
+	stamper.describeInto(out)
+	return jsonResult(out), nil
 }
 
 // loadRefGraph loads an indexed graph for a single ref from disk, using the same

--- a/internal/mcp/pr_impact_tools.go
+++ b/internal/mcp/pr_impact_tools.go
@@ -22,8 +22,14 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
+
+// noCommunityDataHint is appended to every "community data unavailable" message
+// so the answer is actionable rather than merely negative.
+const noCommunityDataHint = "the group-algo overlay (<group>-algo.json) is missing or stale — " +
+	"run/await a group index so community detection produces it, then retry"
 
 // handlePRImpact implements grafel_pr_impact.
 //
@@ -73,17 +79,21 @@ func (s *Server) handlePRImpact(_ context.Context, req mcpapi.CallToolRequest) (
 		return mcpapi.NewToolResultError(fmt.Sprintf("repo lookup failed: %v", err)), nil
 	}
 
+	// Community data is NOT in graph.fb (see newGroupCommunityStamper): resolve
+	// the group overlay once and stamp it onto each ref graph we analyse.
+	stamper := newGroupCommunityStamper(groupName)
+
 	// ── Conflicts mode: refs supplied ────────────────────────────────────────
 	if conflictsMode {
-		return s.prImpactConflicts(groupName, repoSlug, repoPath, base, refs, opts)
+		return s.prImpactConflicts(groupName, repoSlug, repoPath, base, refs, opts, stamper)
 	}
 
 	// ── Single mode: base/head ───────────────────────────────────────────────
-	res, errRes := s.prImpactSingle(repoPath, base, head, opts)
+	res, errRes := s.prImpactSingle(repoPath, base, head, opts, stamper)
 	if errRes != nil {
 		return errRes, nil
 	}
-	return jsonResult(map[string]any{
+	out := map[string]any{
 		"mode":                     "single",
 		"group":                    groupName,
 		"repo":                     repoSlug,
@@ -96,16 +106,79 @@ func (s *Server) handlePRImpact(_ context.Context, req mcpapi.CallToolRequest) (
 		"impacted_community_count": res.CommunityCount,
 		"blast_radius_count":       res.BlastRadiusCount,
 		"truncated":                res.Truncated,
-	}), nil
+		// #6006: the blast radius is valid regardless, but impacted_communities
+		// is only meaningful when this is true. Without the flag an empty
+		// impacted_communities is indistinguishable from "nothing was computed".
+		"community_data_available": res.CommunityDataAvailable,
+	}
+	if !res.CommunityDataAvailable {
+		out["community_data_unavailable_reason"] = noCommunityDataHint
+	}
+	return jsonResult(out), nil
+}
+
+// groupCommunityStamper supplies the community assignments grafel_pr_impact
+// needs, from the ONE place they actually live (#6006).
+//
+// Why the overlay and not graph.fb: the per-repo Pass-4 algorithm pass was
+// removed when the group-scope pass replaced it (cmd/grafel/index.go — the
+// graph.fb per-entity algo fields are retained but "left at their schema
+// sentinels (-2 / 0 / false) rather than recomputed per-repo"). A graph loaded
+// straight off disk therefore carries NO community ids at all, permanently, on
+// every invocation. Restamping graph.fb instead would mean reviving a per-repo
+// Louvain whose partition is not the group partition every other grafel surface
+// reports — two disagreeing community numberings, and merge risk computed
+// against the wrong one.
+//
+// Absence-tolerance mirrors applyGroupAlgoOverlay: an absent, corrupt, stale or
+// version-mismatched overlay yields the zero stamper, which stamps nothing. The
+// difference is what the CALLER then does — here that state is reported, not
+// silently rendered as "no conflicts".
+type groupCommunityStamper struct {
+	ov *groupalgo.Overlay // nil ⇒ no community data available
+}
+
+func newGroupCommunityStamper(group string) groupCommunityStamper {
+	path, err := groupalgo.OverlayPath(group)
+	if err != nil || path == "" {
+		return groupCommunityStamper{}
+	}
+	cur, err := groupalgo.CurrentSourceMtimes(group)
+	if err != nil {
+		return groupCommunityStamper{}
+	}
+	ov, ok := groupalgo.ReadOverlay(path, cur)
+	if !ok {
+		return groupCommunityStamper{}
+	}
+	return groupCommunityStamper{ov: ov}
+}
+
+// stamp copies the overlay's CommunityID onto doc's entities in place, by id.
+// Entities absent from the overlay (e.g. an entity that exists only on a feature
+// ref and so was never part of the indexed group union) are left ungrouped.
+func (s groupCommunityStamper) stamp(doc *graph.Document) {
+	if s.ov == nil || doc == nil {
+		return
+	}
+	for i := range doc.Entities {
+		eo, ok := s.ov.Results[doc.Entities[i].ID]
+		if !ok {
+			continue
+		}
+		cid := eo.CommunityID
+		doc.Entities[i].CommunityID = &cid
+	}
 }
 
 // prImpactSingle loads base+head graphs, diffs them (reusing graph.DiffDocs),
 // and runs the impact analysis on the head graph.
-func (s *Server) prImpactSingle(repoPath, base, head string, opts graph.PRImpactOptions) (graph.PRImpactResult, *mcpapi.CallToolResult) {
+func (s *Server) prImpactSingle(repoPath, base, head string, opts graph.PRImpactOptions, stamper groupCommunityStamper) (graph.PRImpactResult, *mcpapi.CallToolResult) {
 	headDoc, err := loadRefGraph(repoPath, head)
 	if err != nil {
 		return graph.PRImpactResult{}, mcpapi.NewToolResultError(err.Error())
 	}
+	stamper.stamp(headDoc)
 	change, errRes := diffChangeSet(repoPath, base, head)
 	if errRes != nil {
 		return graph.PRImpactResult{}, errRes
@@ -116,7 +189,7 @@ func (s *Server) prImpactSingle(repoPath, base, head string, opts graph.PRImpact
 // prImpactConflicts diffs each ref against the base (defaulting to the first
 // ref) to derive its change set, runs impact analysis to get its impacted
 // communities, then triages pairwise overlaps via graph.AnalyzeMergeRisk.
-func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, refs []string, opts graph.PRImpactOptions) (*mcpapi.CallToolResult, error) {
+func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, refs []string, opts graph.PRImpactOptions, stamper groupCommunityStamper) (*mcpapi.CallToolResult, error) {
 	if len(refs) < 2 {
 		return mcpapi.NewToolResultError("conflicts mode requires at least 2 refs"), nil
 	}
@@ -131,13 +204,18 @@ func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, r
 		if err != nil {
 			return mcpapi.NewToolResultError(err.Error()), nil
 		}
+		stamper.stamp(headDoc)
 		change, errRes := diffChangeSet(repoPath, base, ref)
 		if errRes != nil {
 			return errRes, nil
 		}
 		res := graph.AnalyzePRImpact(headDoc.Entities, headDoc.Relationships, change, opts)
 		comms := res.ImpactedCommunityIDs()
-		impacts = append(impacts, graph.ChangeImpact{Ref: ref, Communities: comms})
+		impacts = append(impacts, graph.ChangeImpact{
+			Ref:                    ref,
+			Communities:            comms,
+			CommunityDataAvailable: res.CommunityDataAvailable,
+		})
 		perRef = append(perRef, map[string]any{
 			"ref":                  ref,
 			"changed_count":        res.ChangedCount,
@@ -147,15 +225,29 @@ func (s *Server) prImpactConflicts(groupName, repoSlug, repoPath, base string, r
 	}
 
 	risk := graph.AnalyzeMergeRisk(impacts)
+	// #6006 — merge risk is a SAFETY question, and an empty risky-pair list is
+	// read as "safe to merge". When the community data the intersection is
+	// computed from is missing, there is no analysis to report: returning the
+	// zero-risk payload would be a false negative in the one direction that
+	// causes harm. Fail loudly instead — an error result is the only shape an MCP
+	// client cannot mistake for an answer.
+	if !risk.CommunityDataAvailable {
+		return mcpapi.NewToolResultError(fmt.Sprintf(
+			"merge-risk analysis did NOT run: no community assignments are available for ref(s) %v, "+
+				"so grafel cannot tell whether these refs conflict. This is NOT a \"no conflicts\" result. "+
+				"Cause: %s.",
+			risk.RefsWithoutCommunityData, noCommunityDataHint)), nil
+	}
 	return jsonResult(map[string]any{
-		"mode":             "conflicts",
-		"group":            groupName,
-		"repo":             repoSlug,
-		"base":             base,
-		"per_ref":          perRef,
-		"risk_pairs":       risk.Pairs,
-		"ref_count":        risk.RefCount,
-		"risky_pair_count": risk.RiskyPairs,
+		"mode":                     "conflicts",
+		"group":                    groupName,
+		"repo":                     repoSlug,
+		"base":                     base,
+		"per_ref":                  perRef,
+		"risk_pairs":               risk.Pairs,
+		"ref_count":                risk.RefCount,
+		"risky_pair_count":         risk.RiskyPairs,
+		"community_data_available": risk.CommunityDataAvailable,
 	}), nil
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -1802,7 +1802,10 @@ func (s *Server) registerTools() {
 	// ranked merge-order/conflict triage. Core logic is pure (graph.AnalyzePRImpact
 	// / AnalyzeMergeRisk); refs are taken explicitly (offline, deterministic).
 	s.addTool(mcpapi.NewTool("grafel_pr_impact",
-		mcpapi.WithDescription("PR impact + merge-risk: changes->communities->blast radius."),
+		// #6006: the 80-char budget (budget_test.go) leaves room for exactly one
+		// safety fact, and this is it — an agent must not read a missing answer as
+		// a zero-risk one. The full explanation is in the error result itself.
+		mcpapi.WithDescription("PR impact + merge-risk. Conflicts mode errors (not 0 pairs) when uncomputed."),
 		mcpapi.WithString("repo", mcpapi.Required()),
 		mcpapi.WithString("base"),
 		mcpapi.WithString("head"),


### PR DESCRIPTION
`grafel_pr_impact` answered "do these branches conflict?" with **"no", always** — a false negative on a safety question, which is the worst direction to be wrong in. An agent reads absence of data as absence of risk.

## Mechanism

Merge risk intersects the community sets each ref touches. Both producer (`pr_impact.go:375`) and consumer (`:323`) filter the ungrouped sentinel `c < 0`. With no community overlay every entity carries `CommunityID = -1`, so both filters dropped everything, the intersection was empty, and `AnalyzeMergeRisk` returned an empty risky-pair list — indistinguishable from a genuine no-conflict result.

**And this was the permanent state, not an edge case.** Verified two ways: `cmd/grafel/index.go:1975-1991` states the per-repo Pass-4 pass no longer runs and algo fields stay at schema sentinels; `runPass4Algorithms` is retained but has **no callers**; `carryForwardAlgoAttrs` only copies from a prior doc that also has none. Empirically, no entity in any readable `graph.fb` carries a `CommunityID`. Reproduced through MCP before fixing: two refs with a genuine shared community returned `"risky_pair_count":0`.

Note the issue was already one correction deep — the original report claimed the *opposite* behaviour ("reports every ref pair as conflicting"), disproved by reading the filters.

## Data source: the group overlay

`groupCommunityStamper` reads `<group>-algo.json` and stamps `CommunityID` onto each ref graph before analysis, mirroring `applyGroupAlgoOverlay` exactly so the two surfaces can never disagree on availability.

Restamping `graph.fb` was rejected deliberately: it would revive a per-repo Louvain whose partition is **not** the group partition every other grafel surface reports, so merge risk would be computed against a second, disagreeing community numbering.

Review confirmed no shared-state hazard — `loadRefGraph` materialises a fresh `*Document` per call, so in-place stamping cannot leak into other readers.

## Availability is measured over the changed set, not the entity set

The first version of this fix **reintroduced the bug in a worse costume**, and review caught it.

`CommunityDataAvailable` was computed over the whole entity set, so any covered entity anywhere in the repo flipped it true — including when **zero changed entities** were covered. The test fixture concealed this: it stamped `svc:NewA`/`svc:NewB` into the overlay, entities that exist only on the feature refs and that the group-algo pass, computed from the indexed group union, **cannot produce**. Swapping in a production-shaped overlay and changing nothing else gave:

```
risky_pair_count=0   community_data_available=true
```

The exact scenario the control arm existed to detect returned a confident all-clear — #6006 again, now wearing an availability stamp that made it look *more* trustworthy than before the fix.

Now: availability follows the changed set, and `changed_entities_without_community` is reported at result, per-ref and single-mode level so partial coverage is legible rather than silent. An empty change set stays vacuously available — that is the live default-base path (conflicts mode diffs `refs[0]` against itself) and hard-erroring it would break every default call. Fixture rewritten to production shape: the overlay covers only pre-existing entities, conflict refs *modify* a covered entity, and separate add-only refs exercise the failing shape.

One fixture detail worth recording: perturbing `EndLine` to trigger modified-classification yielded `changed_count: 0`, because `EndLine` does not round-trip through `graph.fb`. `Signature` does (`load.go:601`).

## Stale overlays are answered, not refused

The first version used `ReadOverlay`, which rejects stale overlays. Review demonstrated with a real git repo that this made a **`git checkout` alone** turn conflicts mode into a hard error: the staleness key is the graph.fb of whichever ref is currently checked out, so standing on a feature branch — the only posture from which anyone asks about conflicts — refused to answer, with the overlay fully covering both refs and the conflict entirely computable.

The window is not marginal. Measured constants: link debounce 10 s, link pass ~9 min, group-algo debounce 180 s, sweep 10 m. After any reindex of **any repo in the group**, conflicts mode would have errored for roughly **50 minutes**.

A partition 50 minutes old is overwhelmingly the same partition. `ReadOverlayAnyAge` now applies a stale overlay and reports it (`community_data_stale`, `overlay_computed_at`); absent, corrupt and version-mismatched remain hard misses. Error causes are split — the previous message said "missing or stale" for both, so a user hitting the staleness path was told to "run/await a group index" when they had just done exactly that.

## Also

- Third filter aligned: `impacted_communities` now drops `c < 0`, so the ungrouped bucket is no longer surfaced as `community_id: -1`.
- A **non-nil pointer to a negative** community id no longer counts as coverage. This was a ninth mutation review found surviving: no fixture produced that value (`stripCommunities` sets `nil`, and `load.go:609` maps the fb `-2` sentinel to `nil`), but it is reachable — `stamp()` writes the overlay value verbatim, and any legacy `graph.json` carries it. It would have set `CommunityDataAvailable: true` while all three filters dropped everything.
- Overlay read memoized on `(path, mtime, size)`, parsed overlay treated as immutable so concurrent agents share it; staleness deliberately outside the key and recomputed per call; misses not cached. Previously re-read and unmarshalled per call — measured at **326 ms / 76 MB** on the 31.9 MB corpus overlay, which matters on a 16 GB box running concurrent MCP agents.

## Verification

16 mutations across both rounds, all killed. Independently re-verified: weakening availability back to always-true fails three tests including `TestAnalyzePRImpact_AvailabilityFollowsChangedSetNotEntitySet`.

`go build ./... && go vet ./... && gofmt -l .` clean. `internal/graph/...` (all 8 sub-packages) and `internal/mcp` green with raw exit codes via `rtk proxy`.

Review confirmed `grafel_impact_radius scope=changeset` — the canonical advertised name, with `grafel_pr_impact` a hidden alias — routes to the same handler, so this covers the surface agents actually use.

## Known and disclosed

- **Add-only PRs now hard-error in conflicts mode.** Intended: their entities were never in the indexed group union, so we genuinely cannot place them. It is a common PR shape and the error will be seen; the message routes to single mode and blast radius. Flagged as a product call rather than settled.
- **Partial coverage still under-reports.** A PR modifying one covered entity and adding three uncovered ones reports `available: true` with `changed_entities_without_community: 3`. The verdict stands on what was placed; the count makes the gap legible. No weighting or threshold attempted.
- The tool-description budget (`budget_test.go`) caps descriptions at 80 chars, leaving room for exactly one fact. It was spent on the safety point: `"PR impact + merge-risk. Conflicts mode errors (not 0 pairs) when uncomputed."`

Independently adversarially reviewed.

Closes #6006
