### PR TITLE
fix(#6044): make `grafel stop` actually stop grafel — service-aware, persistent, honestly confirmed

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,13 +221,33 @@ restart_daemon() {
       uid=$(id -u)
       target="gui/${uid}/com.grafel.daemon"
       plist="$HOME/Library/LaunchAgents/com.grafel.daemon.plist"
-      # Detect a registered launchd agent (print, falling back to list).
-      if ! launchctl print "$target" >/dev/null 2>&1 &&
-         ! launchctl list 2>/dev/null | grep -q "com.grafel.daemon"; then
-        return 1
-      fi
-      if ! launchctl kickstart -k "$target" >/dev/null 2>&1; then
-        info "warning: failed to restart the grafel daemon; $hint" >&2
+      # Detect a registered (currently LOADED) launchd agent (print, falling
+      # back to list).
+      if launchctl print "$target" >/dev/null 2>&1 ||
+         launchctl list 2>/dev/null | grep -q "com.grafel.daemon"; then
+        if ! launchctl kickstart -k "$target" >/dev/null 2>&1; then
+          info "warning: failed to restart the grafel daemon; $hint" >&2
+          return 1
+        fi
+      elif [ -f "$plist" ]; then
+        # Not currently loaded, but a plist IS registered on disk — the
+        # #6044 shape: `grafel stop` pairs `launchctl bootout` with a
+        # persistent `launchctl disable` (so the stop survives reboot/
+        # logout, matching what Unload() does in
+        # internal/daemon/service/launchd_darwin.go), which is exactly why
+        # the print/list check above finds nothing. The OLD code treated
+        # that identically to "nothing registered at all" and gave up with
+        # only the generic post-install message — silently undoing nothing,
+        # but also silently NOT restarting a daemon the user has every
+        # reason to expect gets updated. Clear the disable (mirrors Load()
+        # in the Go service package) and bootstrap it back.
+        launchctl enable "$target" >/dev/null 2>&1 || true
+        if ! launchctl bootstrap "gui/${uid}" "$plist" >/dev/null 2>&1; then
+          info "warning: failed to restart the grafel daemon; $hint" >&2
+          return 1
+        fi
+      else
+        # No plist at all — nothing registered to restart.
         return 1
       fi
       ;;

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -515,7 +515,11 @@ func defaultServiceStopForThisRoot(out io.Writer) error {
 		SocketPath: layout.SocketPath,
 		LogDir:     layout.LogDir,
 	}); err != nil {
-		return fmt.Errorf("service stop: %w", err)
+		// #6044 review item 7: the RPC path's failure names a log to check
+		// (layout.LogPath); give the service path the same next step instead
+		// of leaving the user with only "service stop: <err>" and no idea
+		// what to do about it.
+		return fmt.Errorf("service stop: %w (check %s, or run 'grafel status')", err, layout.LogPath)
 	}
 	fmt.Fprintln(out, "daemon stopped (will not restart automatically — even across reboot — until 'grafel start')")
 	return nil

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -61,6 +61,19 @@ Stopping the daemon also stops all services it manages:
   - Indexer + file-watcher
   - Dashboard HTTP server
 
+When the daemon is registered as an OS service (launchd on macOS, systemd on
+Linux, Task Scheduler on Windows — i.e. it was set up via 'grafel install'),
+stop goes through that service manager instead of only asking the daemon to
+exit over RPC: an RPC-only stop is undone almost immediately by the service
+manager's own keep-alive/restart behavior. Going through the service manager
+also makes stop PERSISTENT — it disables auto-start, so the daemon stays down
+across logout/reboot too, not just for the current session. 'grafel start'
+re-enables it.
+
+For a manually-started foreground daemon (no OS service installed), stop
+sends the shutdown RPC directly and waits to confirm the daemon actually
+exited before reporting success.
+
 Use 'grafel start' to bring everything back up.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDaemonStop(cmd.OutOrStdout())
@@ -120,7 +133,9 @@ func runDaemonRestart(out io.Writer) error {
 	// exact process exits (rather than racing a freshly-spawned one).
 	oldPID := daemon.ReadPIDFile(layout.PIDPath)
 
-	if err := runDaemonStop(out); err != nil && !errors.Is(err, client.ErrDaemonNotRunning) {
+	if err := runDaemonStop(out); err != nil &&
+		!errors.Is(err, client.ErrDaemonNotRunning) &&
+		!errors.Is(err, errStopNotConfirmed) {
 		return err
 	}
 
@@ -483,7 +498,44 @@ func pidStillAlive(pid int) bool {
 	return process.IsAlive(pid)
 }
 
+// serviceStopForThisRoot performs the OS-service-aware stop (launchctl
+// bootout+disable / systemctl disable --now / schtasks /delete) via
+// service.Stop, instead of only sending the daemon a Stop RPC and trusting
+// the result. Overridable for tests; production default is
+// defaultServiceStopForThisRoot.
+var serviceStopForThisRoot = defaultServiceStopForThisRoot
+
+func defaultServiceStopForThisRoot(out io.Writer) error {
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out, "OS service detected for this daemon; stopping via the OS service manager")
+	if _, err := service.Stop(service.Options{
+		SocketPath: layout.SocketPath,
+		LogDir:     layout.LogDir,
+	}); err != nil {
+		return fmt.Errorf("service stop: %w", err)
+	}
+	fmt.Fprintln(out, "daemon stopped (will not restart automatically — even across reboot — until 'grafel start')")
+	return nil
+}
+
 func runDaemonStop(out io.Writer) error {
+	// #6044: `start` is service-aware (it routes through the OS service
+	// manager when one is installed for this root, via
+	// serviceRestartForThisRoot); `stop` was not — it only asked the daemon
+	// to exit over RPC, and launchd's unconditional KeepAlive (or the
+	// systemd/schtasks equivalent) immediately respawned it, so the command
+	// reported "stop requested" and exit 0 over a daemon that came right
+	// back. Route through the same service manager start/restart use
+	// whenever one is installed for this root; only fall back to the
+	// RPC-only path for a manually-started foreground daemon (no OS service
+	// registered here).
+	if serviceInstalledForThisRoot() {
+		return serviceStopForThisRoot(out)
+	}
+
 	c, err := client.Dial()
 	if err != nil {
 		if errors.Is(err, client.ErrDaemonNotRunning) {
@@ -496,8 +548,63 @@ func runDaemonStop(out io.Writer) error {
 	if err := c.Stop(); err != nil {
 		return err
 	}
-	fmt.Fprintln(out, "stop requested")
+
+	// #6044 (same defect class as #5991's `grafel reset`): confirm the
+	// daemon actually exited instead of unconditionally reporting success. A
+	// manually-started foreground daemon has no service manager to respawn
+	// it, but a stuck shutdown or a slow drain should still be reported
+	// honestly rather than as "stop requested" over a daemon that, in fact,
+	// is still up.
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return err
+	}
+	if !waitForSocketGone(layout.SocketPath, stopConfirmTimeout) {
+		return fmt.Errorf("%w: stop requested but the daemon is still running after %s (check %s)",
+			errStopNotConfirmed, stopConfirmTimeout, layout.LogPath)
+	}
+	fmt.Fprintln(out, "daemon stopped")
 	return nil
+}
+
+// errStopNotConfirmed marks a stop RPC that was accepted but whose
+// completion runDaemonStop could not confirm within stopConfirmTimeout.
+// runDaemonRestart tolerates this specific error (like ErrDaemonNotRunning)
+// because it performs its own, more thorough pid-based wait + SIGKILL
+// escalation immediately afterward — this sentinel exists so `grafel stop`
+// itself can still report the honest failure (#6044) without that stricter
+// confirmation breaking restart's own slower-but-more-patient sequence.
+var errStopNotConfirmed = errors.New("stop not confirmed")
+
+// stopConfirmTimeout bounds how long the RPC-only stop path waits to confirm
+// the daemon's socket has actually gone away before reporting a failure. A
+// var (not a const) so tests can shrink it instead of waiting out the real
+// production budget; see stopConfirmTimeoutForTest in the test file.
+var stopConfirmTimeout = 5 * time.Second
+
+// waitForSocketGone polls until the daemon socket at socketPath is no longer
+// connectable (client.ErrDaemonNotRunning) or timeout elapses. Returns true
+// once confirmed gone.
+func waitForSocketGone(socketPath string, timeout time.Duration) bool {
+	gone := func() bool {
+		c, err := client.DialPath(socketPath)
+		if err != nil {
+			return errors.Is(err, client.ErrDaemonNotRunning)
+		}
+		_ = c.Close()
+		return false
+	}
+	if gone() {
+		return true
+	}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		time.Sleep(100 * time.Millisecond)
+		if gone() {
+			return true
+		}
+	}
+	return false
 }
 
 func runDaemonLogs(out io.Writer, follow bool, tail int) error {

--- a/internal/cli/watcher_ctl_service_test.go
+++ b/internal/cli/watcher_ctl_service_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -115,6 +116,78 @@ func TestRunDaemonRestart_RoutesToServiceRestart_WhenInstalled_NoManualForkOrPid
 	}
 	if _, statErr := os.Stat(layout.PIDPath); statErr == nil {
 		t.Fatalf("pidfile should not exist — the service-restart path must not touch it")
+	}
+}
+
+// --- stop routing (issue #6044) ---------------------------------------------
+
+// stubStopSeam overrides serviceInstalledForThisRoot / serviceStopForThisRoot
+// for the duration of the test and restores them on cleanup. Mirrors
+// stubServiceSeams but for the stop path.
+func stubStopSeam(t *testing.T, installed bool) (stopCalls *int) {
+	t.Helper()
+	stopCalls = new(int)
+
+	origInstalled := serviceInstalledForThisRoot
+	origStop := serviceStopForThisRoot
+	t.Cleanup(func() {
+		serviceInstalledForThisRoot = origInstalled
+		serviceStopForThisRoot = origStop
+	})
+
+	serviceInstalledForThisRoot = func() bool { return installed }
+	serviceStopForThisRoot = func(_ io.Writer) error {
+		*stopCalls++
+		return nil
+	}
+	return stopCalls
+}
+
+// TestRunDaemonStop_RoutesToServiceStop_WhenInstalled pins the #6044 fix: when
+// an OS service is installed for this root, `grafel stop` must route through
+// the service manager (serviceStopForThisRoot) — exactly symmetric with how
+// `grafel start`/`restart` already route to serviceRestartForThisRoot —
+// instead of only sending an RPC that launchd's KeepAlive can undo before the
+// caller observes anything.
+func TestRunDaemonStop_RoutesToServiceStop_WhenInstalled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, dir)
+
+	stopCalls := stubStopSeam(t, true)
+
+	var out bytes.Buffer
+	if err := runDaemonStop(&out); err != nil {
+		t.Fatalf("runDaemonStop: %v", err)
+	}
+	if *stopCalls != 1 {
+		t.Fatalf("expected serviceStopForThisRoot to be called once, got %d", *stopCalls)
+	}
+}
+
+// TestRunDaemonStop_FallsBackToRPC_WhenNotInstalled is the OTHER direction of
+// the same fixture: prove the gate can and does take the RPC-only path when
+// no OS service is registered (a manually-started foreground daemon) — the
+// service seam must NOT fire in that case.
+func TestRunDaemonStop_FallsBackToRPC_WhenNotInstalled(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, dir)
+
+	stopCalls := stubStopSeam(t, false)
+
+	var out bytes.Buffer
+	// No daemon is running in this sandboxed root, so the RPC dial itself
+	// fails with ErrDaemonNotRunning — that is fine, it proves the code took
+	// the RPC branch (and not the service branch) rather than exercising a
+	// live daemon.
+	err := runDaemonStop(&out)
+	if err != nil {
+		t.Fatalf("runDaemonStop (no daemon running): %v", err)
+	}
+	if !strings.Contains(out.String(), "daemon not running") {
+		t.Fatalf("expected the RPC-path 'daemon not running' message, got %q", out.String())
+	}
+	if *stopCalls != 0 {
+		t.Fatalf("expected serviceStopForThisRoot NOT to be called, got %d calls", *stopCalls)
 	}
 }
 

--- a/internal/cli/watcher_ctl_stop_rpc_test.go
+++ b/internal/cli/watcher_ctl_stop_rpc_test.go
@@ -1,0 +1,145 @@
+package cli
+
+// watcher_ctl_stop_rpc_test.go pins requirement 3 of issue #6044: the
+// RPC-only stop path (no OS service installed — a manually-started
+// foreground daemon) must confirm the daemon actually exited instead of
+// unconditionally printing "stop requested" and returning 0, the same
+// defect class as #5991's `grafel reset`.
+//
+// Both directions of the fixture are pinned: a daemon that honors the Stop
+// RPC and tears down its socket promptly (success), and one that accepts the
+// RPC but keeps the socket alive (the exact #6044 shape — a service manager,
+// or here a stand-in "stubborn" daemon, that does not actually go away) must
+// be reported as a genuine failure.
+
+import (
+	"bytes"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
+)
+
+// stopStub implements just the Stop RPC method the daemon service exposes.
+// closeAfter, when >= 0, closes the listener (simulating the socket going
+// away as the daemon fully exits) that many milliseconds after Stop is
+// called. A negative value means "never close" — the stubborn-daemon case.
+type stopStub struct {
+	calls      int32
+	closeAfter time.Duration
+	ln         net.Listener
+}
+
+func (s *stopStub) Stop(_ proto.StopArgs, _ *proto.StopReply) error {
+	atomic.AddInt32(&s.calls, 1)
+	if s.closeAfter >= 0 {
+		go func() {
+			time.Sleep(s.closeAfter)
+			_ = s.ln.Close()
+		}()
+	}
+	return nil
+}
+
+// serveStopStub starts a fake daemon on a sandboxed GRAFEL_DAEMON_ROOT
+// exposing only Stop, and returns the stub for assertions.
+func serveStopStub(t *testing.T, closeAfter time.Duration) *stopStub {
+	t.Helper()
+	root, err := os.MkdirTemp("", "ag-stop-")
+	if err != nil {
+		t.Fatalf("mkdirtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(root) })
+	t.Setenv(daemon.EnvRoot, root)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if layout.SocketDir != "" {
+		if err := os.MkdirAll(layout.SocketDir, 0o755); err != nil {
+			t.Fatalf("mkdir socket dir: %v", err)
+		}
+	}
+	ln, err := transport.Listen(layout.SocketPath)
+	if err != nil {
+		t.Fatalf("listen %s: %v", layout.SocketPath, err)
+	}
+	stub := &stopStub{closeAfter: closeAfter, ln: ln}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(proto.ServiceName, stub); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	go func() {
+		for {
+			conn, acceptErr := ln.Accept()
+			if acceptErr != nil {
+				return
+			}
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+	return stub
+}
+
+// stopConfirmTimeoutForTest overrides the package-level stopConfirmTimeout
+// for the duration of a test and returns a restore closure, so tests don't
+// have to wait out the real 5s production budget.
+func stopConfirmTimeoutForTest(d time.Duration) (restore func()) {
+	prev := stopConfirmTimeout
+	stopConfirmTimeout = d
+	return func() { stopConfirmTimeout = prev }
+}
+
+// TestRunDaemonStop_RPCPath_ConfirmsRealExit is the fixture-validity anchor:
+// a daemon that honors Stop and promptly tears down its socket must be
+// reported as a genuine, confirmed success.
+func TestRunDaemonStop_RPCPath_ConfirmsRealExit(t *testing.T) {
+	stubStopSeam(t, false) // force the RPC path, not the service path
+	serveStopStub(t, 50*time.Millisecond)
+
+	var out bytes.Buffer
+	if err := runDaemonStop(&out); err != nil {
+		t.Fatalf("runDaemonStop: %v", err)
+	}
+	if !strings.Contains(out.String(), "daemon stopped") {
+		t.Fatalf("expected a confirmed 'daemon stopped' message, got %q", out.String())
+	}
+}
+
+// TestRunDaemonStop_RPCPath_ReportsFailureWhenStillRunning is the OTHER
+// direction of the same fixture — and the actual #6044 pin: a daemon that
+// accepts the Stop RPC but does NOT actually go away (its socket stays live)
+// must make `grafel stop` fail loudly, not print "stop requested" and exit 0.
+func TestRunDaemonStop_RPCPath_ReportsFailureWhenStillRunning(t *testing.T) {
+	stubStopSeam(t, false) // force the RPC path, not the service path
+	stub := serveStopStub(t, -1*time.Second)
+
+	orig := stopConfirmTimeoutForTest(300 * time.Millisecond)
+	defer orig()
+
+	var out bytes.Buffer
+	err := runDaemonStop(&out)
+	if err == nil {
+		t.Fatalf("expected runDaemonStop to fail when the daemon is still running after Stop, got success (output: %q)", out.String())
+	}
+	if !strings.Contains(err.Error(), "still running") {
+		t.Fatalf("expected the error to say the daemon is still running, got %q", err.Error())
+	}
+	if atomic.LoadInt32(&stub.calls) != 1 {
+		t.Fatalf("expected exactly one Stop RPC call, got %d", stub.calls)
+	}
+	if strings.Contains(out.String(), "daemon stopped") {
+		t.Fatalf("must not print the success message when the daemon did not actually stop, got %q", out.String())
+	}
+}

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -117,6 +117,16 @@ type launchdManager struct {
 	opts      Options
 	plistPath string
 	uid       string
+
+	// lastDisableErr records the outcome of the most recent launchctlDisable
+	// call made by Unload (issue #6044 review item 3). stopConverge's
+	// ServiceManager interface has no room for a second, persistence-specific
+	// error channel, so stopService (which holds the concrete *launchdManager,
+	// not just the interface) reads this directly after a successful
+	// stopConverge to decide whether it can honestly claim the stop survives
+	// reboot/login, instead of asserting that unconditionally over a
+	// discarded error.
+	lastDisableErr error
 }
 
 func newServiceManager(opts Options) (ServiceManager, error) {
@@ -148,6 +158,33 @@ func (m *launchdManager) WriteUnit() error {
 	return nil
 }
 
+// launchctlBootout / launchctlBootstrap / launchctlDisable / launchctlEnable
+// are package vars (not direct inline exec.Command calls) so Unload/Load's
+// full behavior — including the #6044 persistent-stop pairing (review item
+// 2) — is unit-testable without ever invoking a real `launchctl bootout` /
+// `bootstrap` against gui/$UID/com.grafel.daemon, which on a dev machine is
+// the user's actual, live daemon (see launchd_darwin_stop_test.go: it
+// overrides all four and calls the REAL Unload()/Load() methods, so the full
+// call graph — not just an isolated helper — is under test). Before this,
+// disable/enable were bare, result-discarding exec.Command(...).Run() calls
+// with no seam to observe them at all, so deleting either line outright left
+// the whole suite green.
+var launchctlBootout = func(uid string) error {
+	return exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchLabel).Run()
+}
+
+var launchctlBootstrap = func(uid, plistPath string) ([]byte, error) {
+	return exec.Command("launchctl", "bootstrap", "gui/"+uid, plistPath).CombinedOutput()
+}
+
+var launchctlDisable = func(uid string) error {
+	return exec.Command("launchctl", "disable", "gui/"+uid+"/"+launchLabel).Run()
+}
+
+var launchctlEnable = func(uid string) error {
+	return exec.Command("launchctl", "enable", "gui/"+uid+"/"+launchLabel).Run()
+}
+
 func (m *launchdManager) IsLoaded() (bool, error) {
 	// `launchctl list <label>` exits non-zero (113) when the service is not
 	// loaded; that is a clean "false", not an error.
@@ -168,7 +205,7 @@ func (m *launchdManager) Unload() error {
 	// non-fatal here: the subsequent Load + readiness poll is the real success
 	// signal. So we ignore the result entirely rather than branching on the
 	// localized error text, which would break on non-English macOS.
-	_ = exec.Command("launchctl", "bootout", "gui/"+m.uid+"/"+launchLabel).Run()
+	_ = launchctlBootout(m.uid)
 
 	// #6044: bootout alone only clears the CURRENT session's loaded job — the
 	// plist on disk is untouched, and RunAtLoad fires again at the next
@@ -181,7 +218,14 @@ func (m *launchdManager) Unload() error {
 	// before bootstrap, so this has no effect on the ordinary
 	// install/start/restart Unload;Load cycle — it only matters for a caller
 	// (`grafel stop`) that stops WITHOUT a following Load.
-	_ = exec.Command("launchctl", "disable", "gui/"+m.uid+"/"+launchLabel).Run()
+	//
+	// The outcome is recorded (not discarded) on lastDisableErr: Unload's own
+	// contract stays best-effort (a disable hiccup must not fail
+	// ensureLoaded's restart/install path, which re-enables via Load()
+	// immediately afterward regardless), but stopService reads this field to
+	// decide whether it can honestly report the stop as persistent (#6044
+	// review item 3) instead of asserting that unconditionally.
+	m.lastDisableErr = launchctlDisable(m.uid)
 	return nil
 }
 
@@ -189,9 +233,11 @@ func (m *launchdManager) Load() error {
 	// Clear any persisted disable — from a prior `grafel stop`, or a stale
 	// state — before bootstrap. Without this, RunAtLoad silently does
 	// nothing on a disabled service and WaitReady times out with no
-	// explanation. See the disable call in Unload for the pairing.
-	_ = exec.Command("launchctl", "enable", "gui/"+m.uid+"/"+launchLabel).Run()
-	out, err := exec.Command("launchctl", "bootstrap", "gui/"+m.uid, m.plistPath).CombinedOutput()
+	// explanation. See the disable call in Unload for the pairing. Best
+	// effort like Unload's own disable: bootstrap immediately below is the
+	// real convergence signal, and a failed enable here does not block it.
+	_ = launchctlEnable(m.uid)
+	out, err := launchctlBootstrap(m.uid, m.plistPath)
 	if err != nil {
 		// bootstrap exits non-zero (err 5 / "already bootstrapped") when a
 		// previous bootout did not fully clear the service. The goal is "loaded";
@@ -251,13 +297,29 @@ func restartService(opts Options) (StatusInfo, error) {
 }
 
 // stopService is the macOS implementation of Stop: bootout + persistent
-// disable, then confirm the service is actually down (issue #6044).
+// disable, then confirm — by polling the daemon socket, not launchd-domain
+// membership — that the daemon is actually down (issue #6044 item 1).
+//
+// If the daemon is confirmed down but the disable call itself failed
+// (m.lastDisableErr), stop does NOT report the persistent-stop success —
+// it returns that failure instead (#6044 review item 3): the caller asked
+// for a stop that survives reboot/login, so failing to make it persistent is
+// a genuine failure of the requested operation, not a detail to gloss over
+// in the success message.
 func stopService(opts Options) (StatusInfo, error) {
 	sm, err := newServiceManager(opts)
 	if err != nil {
 		return StatusInfo{}, err
 	}
-	return stopConverge(sm)
+	st, err := stopConverge(context.Background(), sm, defaultReadiness, nil)
+	if err != nil {
+		return st, err
+	}
+	if lm, ok := sm.(*launchdManager); ok && lm.lastDisableErr != nil {
+		return st, fmt.Errorf("daemon stopped, but could not persist the stop across reboot/login "+
+			"(launchctl disable failed): %w", lm.lastDisableErr)
+	}
+	return st, nil
 }
 
 // uninstall is the macOS implementation of Uninstall: idempotent teardown.
@@ -266,7 +328,21 @@ func uninstall(opts Options) error {
 	if err != nil {
 		return err
 	}
-	return teardown(sm)
+	if err := teardown(sm); err != nil {
+		return err
+	}
+	// #6044 follow-up (review item 6): teardown's Unload() persists a
+	// `launchctl disable` override (see Unload's doc comment) so a bare
+	// `grafel stop` survives reboot. A full uninstall removes the plist
+	// entirely, so nothing on disk explains that override afterward — clear
+	// it so the label carries no residue past uninstall. Best-effort: this is
+	// cleanup, not the operation's success signal (RemoveArtifacts already
+	// succeeded by this point), and a fresh `grafel install` would write a
+	// new plist and re-enable via Load() regardless.
+	if lm, ok := sm.(*launchdManager); ok {
+		_ = launchctlEnable(lm.uid)
+	}
+	return nil
 }
 
 // registeredRoot is the macOS implementation: it reads the installed

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -169,10 +169,28 @@ func (m *launchdManager) Unload() error {
 	// signal. So we ignore the result entirely rather than branching on the
 	// localized error text, which would break on non-English macOS.
 	_ = exec.Command("launchctl", "bootout", "gui/"+m.uid+"/"+launchLabel).Run()
+
+	// #6044: bootout alone only clears the CURRENT session's loaded job — the
+	// plist on disk is untouched, and RunAtLoad fires again at the next
+	// login, so a bare bootout is a "stop until next login", not a real stop.
+	// `launchctl disable` writes a persistent override that suppresses that
+	// automatic relaunch (survives login/reboot), which is what puts macOS on
+	// equal footing with systemd's `disable --now` (systemd_linux.go Unload)
+	// and schtasks's task deletion (schtasks_windows.go Unload) — both of
+	// which already persist past a reboot. Load() below always re-enables
+	// before bootstrap, so this has no effect on the ordinary
+	// install/start/restart Unload;Load cycle — it only matters for a caller
+	// (`grafel stop`) that stops WITHOUT a following Load.
+	_ = exec.Command("launchctl", "disable", "gui/"+m.uid+"/"+launchLabel).Run()
 	return nil
 }
 
 func (m *launchdManager) Load() error {
+	// Clear any persisted disable — from a prior `grafel stop`, or a stale
+	// state — before bootstrap. Without this, RunAtLoad silently does
+	// nothing on a disabled service and WaitReady times out with no
+	// explanation. See the disable call in Unload for the pairing.
+	_ = exec.Command("launchctl", "enable", "gui/"+m.uid+"/"+launchLabel).Run()
 	out, err := exec.Command("launchctl", "bootstrap", "gui/"+m.uid, m.plistPath).CombinedOutput()
 	if err != nil {
 		// bootstrap exits non-zero (err 5 / "already bootstrapped") when a
@@ -230,6 +248,16 @@ func restartService(opts Options) (StatusInfo, error) {
 		return StatusInfo{}, err
 	}
 	return restart(context.Background(), sm, defaultReadiness, nil)
+}
+
+// stopService is the macOS implementation of Stop: bootout + persistent
+// disable, then confirm the service is actually down (issue #6044).
+func stopService(opts Options) (StatusInfo, error) {
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		return StatusInfo{}, err
+	}
+	return stopConverge(sm)
 }
 
 // uninstall is the macOS implementation of Uninstall: idempotent teardown.

--- a/internal/daemon/service/launchd_stop_persistence_darwin_test.go
+++ b/internal/daemon/service/launchd_stop_persistence_darwin_test.go
@@ -1,0 +1,265 @@
+//go:build darwin
+
+package service
+
+// launchd_stop_persistence_darwin_test.go pins the #6044 review findings:
+//
+//   - item 2: the persistent-stop decision (launchctl disable paired with
+//     Unload, launchctl enable paired with Load) had zero coverage — both
+//     were bare, result-discarding exec.Command(...).Run() calls, so
+//     deleting either line outright left the whole suite green.
+//   - item 3: the CLI's "will not restart... even across reboot" claim was
+//     unconditional even though the only thing making it true (disable) had
+//     its result thrown away.
+//
+// These tests call the REAL launchdManager.Unload()/Load() and the REAL
+// darwin stopService()/uninstall() functions — not a hand-rolled helper —
+// with launchctlBootout/launchctlBootstrap/launchctlDisable/launchctlEnable
+// all stubbed. That is what makes it safe to run on a dev machine where
+// gui/$UID/com.grafel.daemon may be the user's actual live daemon: nothing
+// here ever execs a real launchctl bootout/bootstrap/disable/enable.
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+)
+
+// launchctlSpy records every call made through the four seams, in order,
+// with the uid (and plistPath, for bootstrap) each was called with.
+type launchctlSpy struct {
+	order []string
+
+	bootoutCalls, bootstrapCalls, disableCalls, enableCalls int
+	lastDisableUID, lastEnableUID, lastBootoutUID           string
+	lastBootstrapUID, lastBootstrapPlistPath                string
+
+	bootoutErr   error
+	bootstrapErr error
+	bootstrapOut []byte
+	disableErr   error
+	enableErr    error
+}
+
+// stubLaunchctl overrides all four launchctl seams for the duration of a
+// test and restores them on cleanup.
+func stubLaunchctl(t *testing.T) *launchctlSpy {
+	t.Helper()
+	spy := &launchctlSpy{}
+
+	origBootout, origBootstrap := launchctlBootout, launchctlBootstrap
+	origDisable, origEnable := launchctlDisable, launchctlEnable
+	t.Cleanup(func() {
+		launchctlBootout, launchctlBootstrap = origBootout, origBootstrap
+		launchctlDisable, launchctlEnable = origDisable, origEnable
+	})
+
+	launchctlBootout = func(uid string) error {
+		spy.order = append(spy.order, "bootout")
+		spy.bootoutCalls++
+		spy.lastBootoutUID = uid
+		return spy.bootoutErr
+	}
+	launchctlBootstrap = func(uid, plistPath string) ([]byte, error) {
+		spy.order = append(spy.order, "bootstrap")
+		spy.bootstrapCalls++
+		spy.lastBootstrapUID = uid
+		spy.lastBootstrapPlistPath = plistPath
+		return spy.bootstrapOut, spy.bootstrapErr
+	}
+	launchctlDisable = func(uid string) error {
+		spy.order = append(spy.order, "disable")
+		spy.disableCalls++
+		spy.lastDisableUID = uid
+		return spy.disableErr
+	}
+	launchctlEnable = func(uid string) error {
+		spy.order = append(spy.order, "enable")
+		spy.enableCalls++
+		spy.lastEnableUID = uid
+		return spy.enableErr
+	}
+	return spy
+}
+
+// darwinTestOpts builds Options against a sandboxed HOME (so plistPath()
+// never touches the real ~/Library/LaunchAgents/com.grafel.daemon.plist) and
+// an unreachable socket path (so Probe() deterministically reports "down"
+// without any real daemon involved).
+func darwinTestOpts(t *testing.T) Options {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return Options{
+		BinPath:    filepath.Join(home, "bin", "grafel"),
+		SocketPath: filepath.Join(home, "sockets", "daemon.sock"), // never listened on
+		LogDir:     filepath.Join(home, "logs"),
+	}
+}
+
+func indexOfStr(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}
+
+// --- Unload: bootout + disable pairing (item 2) ----------------------------
+
+func TestUnload_CallsBootoutThenDisable_WithMatchingUID(t *testing.T) {
+	spy := stubLaunchctl(t)
+	opts := darwinTestOpts(t)
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+	lm := sm.(*launchdManager)
+
+	if err := lm.Unload(); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	if spy.bootoutCalls != 1 {
+		t.Fatalf("expected exactly one bootout call, got %d", spy.bootoutCalls)
+	}
+	if spy.disableCalls != 1 {
+		t.Fatalf("expected exactly one disable call (the #6044 persistence pairing) — "+
+			"deleting this call previously left the whole suite green, got %d", spy.disableCalls)
+	}
+	bi, di := indexOfStr(spy.order, "bootout"), indexOfStr(spy.order, "disable")
+	if bi < 0 || di < 0 || bi > di {
+		t.Fatalf("expected bootout before disable, got order %v", spy.order)
+	}
+	wantUID := strconv.Itoa(os.Getuid())
+	if spy.lastBootoutUID != wantUID {
+		t.Errorf("bootout uid = %q, want %q", spy.lastBootoutUID, wantUID)
+	}
+	if spy.lastDisableUID != wantUID {
+		t.Errorf("disable uid = %q, want %q", spy.lastDisableUID, wantUID)
+	}
+}
+
+// TestUnload_RecordsDisableError pins that a genuine disable failure is
+// preserved (not discarded) on lastDisableErr for stopService to inspect,
+// while Unload's own return contract stays best-effort (nil) — a disable
+// hiccup must not fail ensureLoaded's restart/install path.
+func TestUnload_RecordsDisableError(t *testing.T) {
+	spy := stubLaunchctl(t)
+	spy.disableErr = os.ErrPermission
+	opts := darwinTestOpts(t)
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+	lm := sm.(*launchdManager)
+
+	if err := lm.Unload(); err != nil {
+		t.Fatalf("Unload must stay best-effort even when disable fails, got: %v", err)
+	}
+	if lm.lastDisableErr == nil {
+		t.Fatal("expected lastDisableErr to record the disable failure, got nil")
+	}
+}
+
+// --- Load: enable + bootstrap pairing (item 2) ------------------------------
+
+func TestLoad_CallsEnableBeforeBootstrap_WithMatchingArgs(t *testing.T) {
+	spy := stubLaunchctl(t)
+	opts := darwinTestOpts(t)
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+	lm := sm.(*launchdManager)
+	if err := lm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit: %v", err)
+	}
+
+	if err := lm.Load(); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if spy.enableCalls != 1 {
+		t.Fatalf("expected exactly one enable call (the #6044 persistence pairing) — "+
+			"deleting this call previously left the whole suite green, got %d", spy.enableCalls)
+	}
+	if spy.bootstrapCalls != 1 {
+		t.Fatalf("expected exactly one bootstrap call, got %d", spy.bootstrapCalls)
+	}
+	ei, bi := indexOfStr(spy.order, "enable"), indexOfStr(spy.order, "bootstrap")
+	if ei < 0 || bi < 0 || ei > bi {
+		t.Fatalf("expected enable before bootstrap (otherwise RunAtLoad silently no-ops on a disabled "+
+			"service and WaitReady times out with no explanation), got order %v", spy.order)
+	}
+	wantUID := strconv.Itoa(os.Getuid())
+	if spy.lastEnableUID != wantUID {
+		t.Errorf("enable uid = %q, want %q", spy.lastEnableUID, wantUID)
+	}
+	if spy.lastBootstrapUID != wantUID {
+		t.Errorf("bootstrap uid = %q, want %q", spy.lastBootstrapUID, wantUID)
+	}
+	if spy.lastBootstrapPlistPath != lm.plistPath {
+		t.Errorf("bootstrap plist path = %q, want %q", spy.lastBootstrapPlistPath, lm.plistPath)
+	}
+}
+
+// --- stopService: honesty about persistence (item 3) ------------------------
+
+// TestStopService_Success_WhenDisableSucceeds is the fixture-validity anchor:
+// a well-behaved disable must let stopService report success.
+func TestStopService_Success_WhenDisableSucceeds(t *testing.T) {
+	stubLaunchctl(t) // all seams succeed (zero-value errors)
+	opts := darwinTestOpts(t)
+
+	if _, err := stopService(opts); err != nil {
+		t.Fatalf("stopService: %v", err)
+	}
+}
+
+// TestStopService_ReportsFailure_WhenDisableFails is the #6044 review item-3
+// pin: stopService must NOT claim the persistent-stop guarantee when the
+// launchctl disable call that is the only thing making it true actually
+// failed. Before this fix the CLI printed "will not restart... even across
+// reboot" unconditionally over a discarded error.
+func TestStopService_ReportsFailure_WhenDisableFails(t *testing.T) {
+	spy := stubLaunchctl(t)
+	spy.disableErr = os.ErrPermission
+	opts := darwinTestOpts(t)
+
+	_, err := stopService(opts)
+	if err == nil {
+		t.Fatal("expected stopService to fail when the persistence-critical disable call failed, " +
+			"got success (which is what let the CLI assert a guarantee it never verified)")
+	}
+}
+
+// --- uninstall: no disabled residue after a full teardown (item 6) ---------
+
+// TestUninstall_ReEnablesAfterTeardown pins review item 6: a full uninstall
+// removes the plist entirely, so a `launchctl disable` override left behind
+// by a prior `grafel stop` (or by teardown's own Unload call) would have
+// nothing on disk to explain it. uninstall must clear that override.
+func TestUninstall_ReEnablesAfterTeardown(t *testing.T) {
+	spy := stubLaunchctl(t)
+	opts := darwinTestOpts(t)
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		t.Fatalf("newServiceManager: %v", err)
+	}
+	if err := sm.WriteUnit(); err != nil {
+		t.Fatalf("WriteUnit: %v", err)
+	}
+
+	if err := uninstall(opts); err != nil {
+		t.Fatalf("uninstall: %v", err)
+	}
+	if spy.enableCalls < 1 {
+		t.Fatalf("expected uninstall to call enable at least once to clear the disable override "+
+			"left by teardown's Unload, got %d calls (order: %v)", spy.enableCalls, spy.order)
+	}
+	// The plist must still be gone — re-enabling must not resurrect it.
+	if _, statErr := os.Stat(sm.(*launchdManager).plistPath); !os.IsNotExist(statErr) {
+		t.Fatalf("expected the plist to remain removed after uninstall, stat err = %v", statErr)
+	}
+}

--- a/internal/daemon/service/manager.go
+++ b/internal/daemon/service/manager.go
@@ -131,6 +131,60 @@ func waitReady(ctx context.Context, probe func() bool, cfg readinessConfig, onPr
 	}
 }
 
+// errStillResponding is returned by waitStopped when the daemon endpoint is
+// still connectable after the full budget has elapsed.
+var errStillResponding = errors.New("daemon endpoint is still responding after stop")
+
+// waitStopped is the mirror image of waitReady: it polls probe until it
+// returns FALSE (endpoint no longer connectable) or the budget is exhausted.
+//
+// This exists because Status() alone is the WRONG axis to confirm a stop on
+// (issue #6044 review, item 1). On darwin, status() derives Running purely
+// from `launchctl list <label>`'s exit code — i.e. "is the job loaded in the
+// launchd domain", not "is the serve process still alive". Immediately after
+// Unload (bootout) the job is, by definition, no longer in the domain, so
+// Running=false there is very nearly a tautology: it would say "stopped" even
+// for a daemon that was started manually (never loaded in the domain to
+// begin with) and is still very much running. Probe() dials the actual
+// daemon socket — the same signal Install/Restart already trust for the
+// opposite question ("did it come up?") — so it is the axis that actually
+// answers "is the daemon still there".
+func waitStopped(ctx context.Context, probe func() bool, cfg readinessConfig, onProgress progressFn) error {
+	if cfg.budget <= 0 {
+		cfg.budget = defaultReadiness.budget
+	}
+	if cfg.interval <= 0 {
+		cfg.interval = defaultReadiness.interval
+	}
+
+	if !probe() {
+		return nil
+	}
+
+	deadline := time.Now().Add(cfg.budget)
+	ticker := time.NewTicker(cfg.interval)
+	defer ticker.Stop()
+
+	lastProgress := time.Now()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("waiting for daemon endpoint to stop responding: %w", ctx.Err())
+		case <-ticker.C:
+			if !probe() {
+				return nil
+			}
+			if now := time.Now(); now.After(deadline) {
+				return fmt.Errorf("%w (%s)", errStillResponding, cfg.budget)
+			} else if now.Sub(lastProgress) >= 5*time.Second {
+				remaining := time.Until(deadline).Round(time.Second)
+				onProgress.emit("  waiting for the daemon socket to close… (%s remaining)", remaining)
+				lastProgress = now
+			}
+		}
+	}
+}
+
 // ensureLoaded converges the OS service to the loaded+ready state in an
 // idempotent, race-free way (issue #4458):
 //
@@ -181,13 +235,15 @@ func restart(ctx context.Context, sm ServiceManager, cfg readinessConfig, onProg
 }
 
 // stopConverge takes an installed service down NOW — Unload only, no Load —
-// and then CONFIRMS convergence via Status() before returning success
-// (issue #6044). This is the entry point `grafel stop` routes through when an
-// OS service is installed for this root, instead of only sending the daemon
-// an RPC and trusting it: launchd/systemd/schtasks KeepAlive-equivalent
-// respawn logic means an RPC-only stop can be undone before the caller even
-// sees the result, and the old `grafel stop` reported success (exit 0)
-// regardless (the same defect class as #5991's `grafel reset`).
+// and then CONFIRMS convergence by polling Probe() (the daemon's actual
+// socket, NOT Status()/launchd-domain membership — see waitStopped) before
+// returning success (issue #6044). This is the entry point `grafel stop`
+// routes through when an OS service is installed for this root, instead of
+// only sending the daemon an RPC and trusting it: launchd/systemd/schtasks
+// KeepAlive-equivalent respawn logic means an RPC-only stop can be undone
+// before the caller even sees the result, and the old `grafel stop` reported
+// success (exit 0) regardless (the same defect class as #5991's
+// `grafel reset`).
 //
 // Semantics: this is a PERSISTENT stop, not merely "kill the current
 // instance" — Unload on every platform backend already reaches for that
@@ -201,16 +257,17 @@ func restart(ctx context.Context, sm ServiceManager, cfg readinessConfig, onProg
 // stopConverge does NOT call RemoveArtifacts — the unit/plist/task file is
 // left on disk so `grafel start` can re-register from it without needing
 // `grafel install` again. That is what distinguishes stop from uninstall.
-func stopConverge(sm ServiceManager) (StatusInfo, error) {
+func stopConverge(ctx context.Context, sm ServiceManager, cfg readinessConfig, onProgress progressFn) (StatusInfo, error) {
 	if err := sm.Unload(); err != nil {
 		return StatusInfo{}, fmt.Errorf("unload service: %w", err)
+	}
+	if err := waitStopped(ctx, sm.Probe, cfg, onProgress); err != nil {
+		st, _ := sm.Status()
+		return st, fmt.Errorf("service manager unloaded the job, but the daemon is still reachable: %w", err)
 	}
 	st, err := sm.Status()
 	if err != nil {
 		return StatusInfo{}, fmt.Errorf("confirm service stopped: %w", err)
-	}
-	if st.Running {
-		return st, fmt.Errorf("service manager still reports the daemon running (pid %d) after stop", st.PID)
 	}
 	return st, nil
 }

--- a/internal/daemon/service/manager.go
+++ b/internal/daemon/service/manager.go
@@ -180,6 +180,41 @@ func restart(ctx context.Context, sm ServiceManager, cfg readinessConfig, onProg
 	return ensureLoaded(ctx, sm, cfg, onProgress)
 }
 
+// stopConverge takes an installed service down NOW — Unload only, no Load —
+// and then CONFIRMS convergence via Status() before returning success
+// (issue #6044). This is the entry point `grafel stop` routes through when an
+// OS service is installed for this root, instead of only sending the daemon
+// an RPC and trusting it: launchd/systemd/schtasks KeepAlive-equivalent
+// respawn logic means an RPC-only stop can be undone before the caller even
+// sees the result, and the old `grafel stop` reported success (exit 0)
+// regardless (the same defect class as #5991's `grafel reset`).
+//
+// Semantics: this is a PERSISTENT stop, not merely "kill the current
+// instance" — Unload on every platform backend already reaches for that
+// (launchd: bootout + disable so RunAtLoad does not fire at the next login;
+// systemd: `disable --now`; schtasks: task deletion), and the matching Load
+// unconditionally re-enables/recreates before starting, so a normal
+// install/start/restart cycle (Unload;Load) is unaffected — only a caller
+// that stops WITHOUT a following Load (this one) observes the persisted-down
+// state. `grafel start` is the explicit, symmetric way back.
+//
+// stopConverge does NOT call RemoveArtifacts — the unit/plist/task file is
+// left on disk so `grafel start` can re-register from it without needing
+// `grafel install` again. That is what distinguishes stop from uninstall.
+func stopConverge(sm ServiceManager) (StatusInfo, error) {
+	if err := sm.Unload(); err != nil {
+		return StatusInfo{}, fmt.Errorf("unload service: %w", err)
+	}
+	st, err := sm.Status()
+	if err != nil {
+		return StatusInfo{}, fmt.Errorf("confirm service stopped: %w", err)
+	}
+	if st.Running {
+		return st, fmt.Errorf("service manager still reports the daemon running (pid %d) after stop", st.PID)
+	}
+	return st, nil
+}
+
 // teardown idempotently removes the service: Unload (treating not-loaded as
 // success) then RemoveArtifacts (treating missing files as success). It never
 // fails because the service is already gone — the desired post-state is

--- a/internal/daemon/service/manager_test.go
+++ b/internal/daemon/service/manager_test.go
@@ -39,6 +39,17 @@ type fakeManager struct {
 	// race against a bare RPC stop).
 	stubbornRunning bool
 	statusErr       error
+
+	// probeAlwaysUp forces Probe() to always report the daemon reachable,
+	// independent of loaded/probeReadyAfter/probeCalls — models the daemon's
+	// actual socket still answering regardless of what the service manager's
+	// domain membership says. This is the axis review item 1 (#6044) insists
+	// stopConverge trust: Status()/loaded reflects "is the job registered
+	// with the service manager", which can say "not running" for a daemon
+	// that isn't in that domain at all (started manually) yet is still very
+	// much alive. Checked before neverReady/probeReadyAfter so it composes
+	// cleanly with a fakeManager that also has loaded=false.
+	probeAlwaysUp bool
 }
 
 func (f *fakeManager) record(name string) {
@@ -84,7 +95,11 @@ func (f *fakeManager) Probe() bool {
 	f.mu.Lock()
 	f.probeCalls++
 	n := f.probeCalls
+	up := f.probeAlwaysUp
 	f.mu.Unlock()
+	if up {
+		return true
+	}
 	if f.neverReady {
 		return false
 	}
@@ -318,13 +333,16 @@ func TestTeardown_NotLoadedIsIdempotent(t *testing.T) {
 // --- stop (issue #6044) -----------------------------------------------------
 
 // TestStopConverge_UnloadsAndConfirmsDown is the fixture-validity anchor:
-// a well-behaved Unload actually clears f.loaded, so stopConverge must
-// observe Running=false and return success. Also confirms stopConverge never
-// touches RemoveArtifacts — stop must not delete the unit file (that is what
-// distinguishes it from uninstall/teardown).
+// a well-behaved stop actually makes the daemon socket stop responding
+// (Probe() goes false), so stopConverge must observe that and return
+// success. Also confirms stopConverge never touches RemoveArtifacts — stop
+// must not delete the unit file (that is what distinguishes it from
+// uninstall/teardown).
 func TestStopConverge_UnloadsAndConfirmsDown(t *testing.T) {
-	f := &fakeManager{loaded: true}
-	st, err := stopConverge(f)
+	// neverReady here means "Probe always reports false" — i.e. the daemon
+	// socket is confirmed gone, which is exactly the success condition.
+	f := &fakeManager{loaded: true, neverReady: true}
+	st, err := stopConverge(context.Background(), f, fastReadiness, nil)
 	if err != nil {
 		t.Fatalf("stopConverge: %v", err)
 	}
@@ -340,26 +358,45 @@ func TestStopConverge_UnloadsAndConfirmsDown(t *testing.T) {
 }
 
 // TestStopConverge_StubbornServiceReportsError is the OTHER direction of the
-// same fixture: prove stopConverge can and does fail when the service manager
-// still reports the daemon running after Unload — the exact #6044 shape
-// (KeepAlive/Restart respawning it faster than the caller can observe). This
-// pins requirement 3: stop must stop lying about its outcome.
+// same fixture: prove stopConverge can and does fail when the daemon socket
+// is STILL reachable after Unload — the exact #6044 shape (KeepAlive/Restart
+// respawning it faster than the caller can observe). This pins requirement
+// 3: stop must stop lying about its outcome.
 func TestStopConverge_StubbornServiceReportsError(t *testing.T) {
-	f := &fakeManager{loaded: true, stubbornRunning: true}
-	st, err := stopConverge(f)
+	f := &fakeManager{loaded: true, stubbornRunning: true, probeAlwaysUp: true}
+	st, err := stopConverge(context.Background(), f, fastReadiness, nil)
 	if err == nil {
-		t.Fatalf("expected stopConverge to report an error when the service manager still shows it running, got success %+v", st)
+		t.Fatalf("expected stopConverge to report an error when the daemon socket is still reachable, got success %+v", st)
 	}
 	if !st.Running {
 		t.Errorf("expected the returned status to still show Running=true (the honest observation), got %+v", st)
 	}
 }
 
+// TestStopConverge_TrustsProbeNotStatus is the #6044 review item-1 pin: a
+// service manager can report the job "not loaded"/"not running"
+// (Status().Running=false) while the daemon itself is still reachable — the
+// concrete failure was a daemon started manually, outside the service
+// manager's domain entirely, for which bootout is a silent, correct no-op
+// and Status() derived from domain membership is very nearly a tautological
+// "not running". stopConverge must trust Probe() (the real socket), not
+// Status(), and fail here even though Status alone would have said success.
+func TestStopConverge_TrustsProbeNotStatus(t *testing.T) {
+	f := &fakeManager{loaded: false, probeAlwaysUp: true} // Status: not running. Probe: still there.
+	if st, err := f.Status(); err != nil || st.Running {
+		t.Fatalf("fixture invalid: expected Status().Running=false pre-check, got %+v err=%v", st, err)
+	}
+	_, err := stopConverge(context.Background(), f, fastReadiness, nil)
+	if err == nil {
+		t.Fatal("expected stopConverge to fail: Probe (the real socket) still responds even though Status reports not-running")
+	}
+}
+
 // TestStopConverge_NotLoadedIsIdempotent: stopping an already-stopped service
 // succeeds (Unload treats not-loaded as success by contract).
 func TestStopConverge_NotLoadedIsIdempotent(t *testing.T) {
-	f := &fakeManager{loaded: false}
-	if _, err := stopConverge(f); err != nil {
+	f := &fakeManager{loaded: false, neverReady: true}
+	if _, err := stopConverge(context.Background(), f, fastReadiness, nil); err != nil {
 		t.Fatalf("stopConverge of an already-stopped service should succeed: %v", err)
 	}
 }
@@ -368,8 +405,24 @@ func TestStopConverge_NotLoadedIsIdempotent(t *testing.T) {
 // "already not loaded") must abort and be reported, not swallowed.
 func TestStopConverge_UnloadErrorPropagates(t *testing.T) {
 	f := &fakeManager{loaded: true, unloadErr: errors.New("launchctl bootout: permission denied")}
-	if _, err := stopConverge(f); err == nil {
+	if _, err := stopConverge(context.Background(), f, fastReadiness, nil); err == nil {
 		t.Fatal("expected Unload error to propagate")
+	}
+}
+
+// TestStopConverge_NeverStopsRespondingFailsAfterBudget: the daemon socket
+// never goes away — the timeout/budget path of waitStopped must still be
+// reached and reported (not hang forever, not silently succeed).
+func TestStopConverge_NeverStopsRespondingFailsAfterBudget(t *testing.T) {
+	f := &fakeManager{loaded: true, probeAlwaysUp: true}
+	cfg := readinessConfig{budget: 100 * time.Millisecond, interval: 10 * time.Millisecond}
+	start := time.Now()
+	_, err := stopConverge(context.Background(), f, cfg, nil)
+	if err == nil {
+		t.Fatal("expected stopConverge to fail when the daemon never stops responding")
+	}
+	if elapsed := time.Since(start); elapsed < cfg.budget {
+		t.Errorf("stopConverge gave up before the full budget elapsed (%s < %s)", elapsed, cfg.budget)
 	}
 }
 
@@ -377,8 +430,8 @@ func TestStopConverge_UnloadErrorPropagates(t *testing.T) {
 // query itself fails, stop must report that failure rather than silently
 // claiming success.
 func TestStopConverge_StatusErrorPropagates(t *testing.T) {
-	f := &fakeManager{loaded: true, statusErr: errors.New("launchctl list: boom")}
-	if _, err := stopConverge(f); err == nil {
+	f := &fakeManager{loaded: true, neverReady: true, statusErr: errors.New("launchctl list: boom")}
+	if _, err := stopConverge(context.Background(), f, fastReadiness, nil); err == nil {
 		t.Fatal("expected Status error to propagate")
 	}
 }

--- a/internal/daemon/service/manager_test.go
+++ b/internal/daemon/service/manager_test.go
@@ -31,6 +31,14 @@ type fakeManager struct {
 
 	// neverReady forces Probe to always return false (budget-exhaustion case).
 	neverReady bool
+
+	// stubbornRunning makes Status() report Running=true even after Unload
+	// has been called — simulating a service manager whose KeepAlive/Restart
+	// equivalent respawned the daemon before stop could confirm it was down
+	// (the exact #6044 defect: launchd's unconditional KeepAlive winning the
+	// race against a bare RPC stop).
+	stubbornRunning bool
+	statusErr       error
 }
 
 func (f *fakeManager) record(name string) {
@@ -86,7 +94,15 @@ func (f *fakeManager) Probe() bool {
 func (f *fakeManager) Status() (StatusInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	return StatusInfo{Installed: true, Running: f.loaded}, nil
+	if f.statusErr != nil {
+		return StatusInfo{}, f.statusErr
+	}
+	running := f.loaded || f.stubbornRunning
+	pid := 0
+	if running {
+		pid = 12345
+	}
+	return StatusInfo{Installed: true, Running: running, PID: pid}, nil
 }
 
 func (f *fakeManager) callOrder() []string {
@@ -296,6 +312,74 @@ func TestTeardown_NotLoadedIsIdempotent(t *testing.T) {
 	// Second teardown is still a no-op success.
 	if err := teardown(f); err != nil {
 		t.Fatalf("repeated teardown should be idempotent: %v", err)
+	}
+}
+
+// --- stop (issue #6044) -----------------------------------------------------
+
+// TestStopConverge_UnloadsAndConfirmsDown is the fixture-validity anchor:
+// a well-behaved Unload actually clears f.loaded, so stopConverge must
+// observe Running=false and return success. Also confirms stopConverge never
+// touches RemoveArtifacts — stop must not delete the unit file (that is what
+// distinguishes it from uninstall/teardown).
+func TestStopConverge_UnloadsAndConfirmsDown(t *testing.T) {
+	f := &fakeManager{loaded: true}
+	st, err := stopConverge(f)
+	if err != nil {
+		t.Fatalf("stopConverge: %v", err)
+	}
+	if st.Running {
+		t.Errorf("expected Running=false after stopConverge, got %+v", st)
+	}
+	if indexOf(f.callOrder(), "Unload") < 0 {
+		t.Errorf("expected Unload to be called, got %v", f.callOrder())
+	}
+	if indexOf(f.callOrder(), "RemoveArtifacts") >= 0 {
+		t.Errorf("stopConverge must not remove artifacts (that is uninstall's job), got %v", f.callOrder())
+	}
+}
+
+// TestStopConverge_StubbornServiceReportsError is the OTHER direction of the
+// same fixture: prove stopConverge can and does fail when the service manager
+// still reports the daemon running after Unload — the exact #6044 shape
+// (KeepAlive/Restart respawning it faster than the caller can observe). This
+// pins requirement 3: stop must stop lying about its outcome.
+func TestStopConverge_StubbornServiceReportsError(t *testing.T) {
+	f := &fakeManager{loaded: true, stubbornRunning: true}
+	st, err := stopConverge(f)
+	if err == nil {
+		t.Fatalf("expected stopConverge to report an error when the service manager still shows it running, got success %+v", st)
+	}
+	if !st.Running {
+		t.Errorf("expected the returned status to still show Running=true (the honest observation), got %+v", st)
+	}
+}
+
+// TestStopConverge_NotLoadedIsIdempotent: stopping an already-stopped service
+// succeeds (Unload treats not-loaded as success by contract).
+func TestStopConverge_NotLoadedIsIdempotent(t *testing.T) {
+	f := &fakeManager{loaded: false}
+	if _, err := stopConverge(f); err != nil {
+		t.Fatalf("stopConverge of an already-stopped service should succeed: %v", err)
+	}
+}
+
+// TestStopConverge_UnloadErrorPropagates: a genuine Unload failure (not just
+// "already not loaded") must abort and be reported, not swallowed.
+func TestStopConverge_UnloadErrorPropagates(t *testing.T) {
+	f := &fakeManager{loaded: true, unloadErr: errors.New("launchctl bootout: permission denied")}
+	if _, err := stopConverge(f); err == nil {
+		t.Fatal("expected Unload error to propagate")
+	}
+}
+
+// TestStopConverge_StatusErrorPropagates: if the post-Unload confirmation
+// query itself fails, stop must report that failure rather than silently
+// claiming success.
+func TestStopConverge_StatusErrorPropagates(t *testing.T) {
+	f := &fakeManager{loaded: true, statusErr: errors.New("launchctl list: boom")}
+	if _, err := stopConverge(f); err == nil {
+		t.Fatal("expected Status error to propagate")
 	}
 }
 

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -271,6 +271,17 @@ func restartService(opts Options) (StatusInfo, error) {
 	return restart(context.Background(), sm, defaultReadiness, nil)
 }
 
+// stopService is the Windows implementation of Stop: schtasks task deletion
+// (already persistent — the task will not fire at next logon) via Unload,
+// then confirm the daemon is actually down (issue #6044).
+func stopService(opts Options) (StatusInfo, error) {
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		return StatusInfo{}, err
+	}
+	return stopConverge(sm)
+}
+
 // uninstall is the Windows implementation of Uninstall.
 func uninstall(opts Options) error {
 	sm, err := newServiceManager(opts)

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -273,13 +273,14 @@ func restartService(opts Options) (StatusInfo, error) {
 
 // stopService is the Windows implementation of Stop: schtasks task deletion
 // (already persistent — the task will not fire at next logon) via Unload,
-// then confirm the daemon is actually down (issue #6044).
+// then confirm — by polling the daemon socket — that the daemon is actually
+// down (issue #6044).
 func stopService(opts Options) (StatusInfo, error) {
 	sm, err := newServiceManager(opts)
 	if err != nil {
 		return StatusInfo{}, err
 	}
-	return stopConverge(sm)
+	return stopConverge(context.Background(), sm, defaultReadiness, nil)
 }
 
 // uninstall is the Windows implementation of Uninstall.

--- a/internal/daemon/service/service.go
+++ b/internal/daemon/service/service.go
@@ -190,6 +190,25 @@ func Restart(opts Options) (StatusInfo, error) {
 	return restartService(opts)
 }
 
+// Stop takes an already-installed OS service down now and confirms it is
+// actually down before returning (issue #6044). Unlike Restart/Install, it
+// does NOT re-Load: the desired end-state is "stopped", not "stopped then
+// immediately restarted". See stopConverge in manager.go for the exact
+// semantics (persistent — survives the next login/reboot — and why that does
+// not disturb the ordinary install/start/restart Unload;Load cycle).
+//
+// This is the entry point `grafel stop` routes through when it detects an OS
+// service registered for this root, instead of only sending the daemon a
+// Stop RPC and trusting the result: a bare RPC stop races the service
+// manager's own KeepAlive/Restart-equivalent respawn, which can undo it
+// before the caller observes anything.
+func Stop(opts Options) (StatusInfo, error) {
+	if err := resolveOptions(&opts); err != nil {
+		return StatusInfo{}, fmt.Errorf("resolve options: %w", err)
+	}
+	return stopService(opts)
+}
+
 // RegisteredRoot returns the daemon root directory recorded in the currently
 // installed OS service unit (the HOME baked into the launchd plist / systemd
 // unit at install time, or the root derived from the installed task's socket on

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -194,14 +194,14 @@ func restartService(opts Options) (StatusInfo, error) {
 }
 
 // stopService is the Linux implementation of Stop: `systemctl disable --now`
-// (already persistent — survives the next boot) via Unload, then confirm the
-// service is actually down (issue #6044).
+// (already persistent — survives the next boot) via Unload, then confirm —
+// by polling the daemon socket — that the daemon is actually down (#6044).
 func stopService(opts Options) (StatusInfo, error) {
 	sm, err := newServiceManager(opts)
 	if err != nil {
 		return StatusInfo{}, err
 	}
-	return stopConverge(sm)
+	return stopConverge(context.Background(), sm, defaultReadiness, nil)
 }
 
 // uninstall is the Linux implementation of Uninstall.

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -193,6 +193,17 @@ func restartService(opts Options) (StatusInfo, error) {
 	return restart(context.Background(), sm, defaultReadiness, nil)
 }
 
+// stopService is the Linux implementation of Stop: `systemctl disable --now`
+// (already persistent — survives the next boot) via Unload, then confirm the
+// service is actually down (issue #6044).
+func stopService(opts Options) (StatusInfo, error) {
+	sm, err := newServiceManager(opts)
+	if err != nil {
+		return StatusInfo{}, err
+	}
+	return stopConverge(sm)
+}
+
 // uninstall is the Linux implementation of Uninstall.
 func uninstall(opts Options) error {
 	sm, err := newServiceManager(opts)

--- a/internal/daemon/service/unsupported.go
+++ b/internal/daemon/service/unsupported.go
@@ -10,6 +10,7 @@ func install(_ Options) (StatusInfo, error)        { return StatusInfo{}, errUns
 func uninstall(_ Options) error                    { return errUnsupported }
 func status(_ Options) (StatusInfo, error)         { return StatusInfo{}, errUnsupported }
 func restartService(_ Options) (StatusInfo, error) { return StatusInfo{}, errUnsupported }
+func stopService(_ Options) (StatusInfo, error)    { return StatusInfo{}, errUnsupported }
 
 // registeredRoot has no service to read on unsupported platforms.
 func registeredRoot() (string, bool, error) { return "", false, errUnsupported }

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -431,7 +431,7 @@ func (s *engineSupervisor) terminateChild(cmd *exec.Cmd, waitCh chan error) {
 	case <-timer.C:
 		s.logger.Warn("engine supervisor: engine child did not exit within drain window — SIGKILL",
 			"pid", pid, "timeout", s.drainTimeout)
-		_ = cmd.Process.Kill()
+		_ = signalKill(cmd.Process)
 		<-waitCh // reap
 	}
 	s.setChildPID(0)

--- a/internal/daemon/supervise_groupkill_test.go
+++ b/internal/daemon/supervise_groupkill_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strconv"
 	"strings"
 	"syscall"
@@ -108,6 +109,116 @@ func TestEngineSupervisor_DrainKillsGrandchild(t *testing.T) {
 	}
 }
 
+// TestEngineChildIgnoresSIGTERMGroupHelper is the subprocess entrypoint for
+// TestEngineSupervisor_SIGKILLEscalationKillsGrandchild. Unlike
+// TestEngineChildGroupHelper (which dies on SIGTERM's default disposition and
+// so only ever exercises terminateChild's FIRST signal), this helper installs
+// a SIGTERM handler that swallows the signal and does nothing, so it can only
+// be brought down by SIGKILL — forcing the supervisor's drain to actually
+// reach the escalation branch (supervise.go's signalKill call). This is the
+// issue's stated worst case: "an engine that cannot exit promptly — mid-index,
+// mid-link-pass, or blocked on a long group-algo run".
+func TestEngineChildIgnoresSIGTERMGroupHelper(t *testing.T) {
+	if os.Getenv("GRAFEL_ENGINE_IGNORE_SIGTERM_HELPER") != "1" {
+		return
+	}
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGTERM)
+
+	// The grandchild must ALSO ignore SIGTERM (`trap '' TERM`), not just this
+	// process. Otherwise the FIRST drain signal — terminateChild's SIGTERM,
+	// which is (correctly, and independently of this test) group-directed —
+	// already kills a plain `sleep` grandchild outright, and the test would
+	// never actually reach the SIGKILL escalation it exists to exercise: it
+	// would pass even with signalKill mutated back to a single-pid p.Kill().
+	gc := exec.Command("sh", "-c", "trap '' TERM; exec sleep 300")
+	if err := gc.Start(); err != nil {
+		t.Fatalf("start grandchild: %v", err)
+	}
+	if pidFile := os.Getenv("GRAFEL_GRANDCHILD_PIDFILE"); pidFile != "" {
+		_ = os.WriteFile(pidFile, []byte(strconv.Itoa(gc.Process.Pid)), 0o600)
+	}
+	// Swallow SIGTERM indefinitely; only SIGKILL (uncatchable) ends this.
+	for range sigs {
+	}
+}
+
+// helperIgnoreSIGTERMGroupEngineCommand spawns
+// TestEngineChildIgnoresSIGTERMGroupHelper in its own process group.
+func helperIgnoreSIGTERMGroupEngineCommand(grandchildPIDFile string) func(selfExe, root string) *exec.Cmd {
+	return func(selfExe, root string) *exec.Cmd {
+		cmd := exec.Command(selfExe, "-test.run=TestEngineChildIgnoresSIGTERMGroupHelper", "-test.timeout=60s")
+		cmd.Env = append(os.Environ(),
+			"GRAFEL_ENGINE_IGNORE_SIGTERM_HELPER=1",
+			"GRAFEL_GRANDCHILD_PIDFILE="+grandchildPIDFile,
+			EnvRoot+"="+root,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.SysProcAttr = engineChildSysProcAttr()
+		return cmd
+	}
+}
+
+// TestEngineSupervisor_SIGKILLEscalationKillsGrandchild is the #6044 review
+// item-4 pin: mutating ONLY signalKill back to a plain p.Kill() (leaving
+// signalTerminate group-directed) kept TestEngineSupervisor_DrainKillsGrandchild
+// green, because that test's helper dies on the FIRST signal (SIGTERM) and
+// never exercises the escalation branch. This test uses a child that ignores
+// SIGTERM, forcing terminateChild's drainTimeout to expire and signalKill to
+// actually fire — the branch the issue's stated worst case depends on.
+func TestEngineSupervisor_SIGKILLEscalationKillsGrandchild(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	pidFile := root + "/grandchild.pid"
+	defer SetEngineChildCommandForTest(helperIgnoreSIGTERMGroupEngineCommand(pidFile))()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newTestSupervisor(t, root)
+	// Short drain timeout: the child ignores SIGTERM, so this must expire and
+	// force the SIGKILL escalation within the test's patience.
+	sup.drainTimeout = 500 * time.Millisecond
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+
+	if !waitFor(t, 10*time.Second, func() bool {
+		_, err := os.Stat(pidFile)
+		return err == nil
+	}) {
+		t.Fatal("grandchild pidfile never appeared — helper did not start")
+	}
+	gcPID := readIntFile(t, pidFile)
+	if gcPID <= 0 {
+		t.Fatalf("invalid grandchild pid read from %s: %d", pidFile, gcPID)
+	}
+	if !pidAliveUnix(gcPID) {
+		t.Fatalf("grandchild pid %d not alive right after spawn", gcPID)
+	}
+	childPID := sup.getChildPID()
+	if childPID == 0 {
+		t.Fatal("supervisor reports no engine child pid")
+	}
+
+	start := time.Now()
+	sup.stop()
+	elapsed := time.Since(start)
+	if elapsed < sup.drainTimeout {
+		t.Fatalf("drain returned before drainTimeout (%s) elapsed (%s) — "+
+			"the child must have died on SIGTERM, which would mean this test isn't "+
+			"actually exercising the SIGKILL escalation branch", sup.drainTimeout, elapsed)
+	}
+
+	if !waitFor(t, 6*time.Second, func() bool { return !pidAliveUnix(childPID) }) {
+		t.Fatalf("engine child %d still alive after SIGKILL escalation", childPID)
+	}
+	if !waitFor(t, 6*time.Second, func() bool { return !pidAliveUnix(gcPID) }) {
+		t.Fatalf("grandchild %d survived the SIGKILL escalation — orphaned. This is exactly "+
+			"the #6044 review item-4 gap: signalKill must be group-directed, not just "+
+			"signalTerminate", gcPID)
+	}
+}
+
 func readIntFile(t *testing.T, path string) int {
 	t.Helper()
 	b, err := os.ReadFile(path)
@@ -154,6 +265,44 @@ func TestSignalTerminate_IsGroupDirected(t *testing.T) {
 	if !waitFor(t, 3*time.Second, func() bool { return !pidAliveUnix(gcPID) }) {
 		_ = syscall.Kill(-parent.Process.Pid, syscall.SIGKILL)
 		t.Fatalf("grandchild %d survived signalTerminate — not group-directed", gcPID)
+	}
+	_ = parent.Wait()
+}
+
+// TestSignalKill_IsGroupDirected mirrors TestSignalTerminate_IsGroupDirected
+// but for the SIGKILL escalation path specifically (#6044 review item 4: this
+// is the branch that actually matters for the issue's stated worst case — an
+// engine that cannot exit promptly on SIGTERM at all).
+func TestSignalKill_IsGroupDirected(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not on PATH")
+	}
+	parent := exec.Command("sh", "-c", "sleep 300 & echo $! ; wait")
+	parent.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := parent.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := parent.Start(); err != nil {
+		t.Fatalf("start parent shell: %v", err)
+	}
+	buf := make([]byte, 32)
+	n, _ := stdout.Read(buf)
+	gcPID, convErr := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if convErr != nil || gcPID <= 0 {
+		_ = parent.Process.Kill()
+		t.Fatalf("could not parse grandchild pid from shell output %q: %v", string(buf[:n]), convErr)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return pidAliveUnix(gcPID) }) {
+		t.Fatalf("grandchild %d never came up", gcPID)
+	}
+
+	if err := signalKill(parent.Process); err != nil {
+		t.Fatalf("signalKill: %v", err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool { return !pidAliveUnix(gcPID) }) {
+		t.Fatalf("grandchild %d survived signalKill — not group-directed", gcPID)
 	}
 	_ = parent.Wait()
 }

--- a/internal/daemon/supervise_groupkill_test.go
+++ b/internal/daemon/supervise_groupkill_test.go
@@ -1,0 +1,159 @@
+//go:build darwin || linux
+
+package daemon
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestEngineChildGroupHelper is the subprocess entrypoint for
+// TestEngineSupervisor_DrainKillsGrandchild: it forks a "grandchild" (a plain
+// `sleep`) that inherits the helper's process group (no Setpgid of its own),
+// writes the grandchild's pid to GRAFEL_GRANDCHILD_PIDFILE, and then blocks.
+// It does not forward any signal to the grandchild itself — the grandchild's
+// survival past drain depends ENTIRELY on whether the supervisor's
+// SIGTERM/SIGKILL was delivered to the engine child's process group or just
+// to the child's own pid. This is the #6044 item-4 regression shape: a
+// serve-supervised child that fans out its own subprocesses (mirrors the
+// `grafel extract` fanout #5999 fixed for the batch scheduler).
+func TestEngineChildGroupHelper(t *testing.T) {
+	if os.Getenv("GRAFEL_ENGINE_GROUP_HELPER") != "1" {
+		return
+	}
+	gc := exec.Command("sleep", "300")
+	if err := gc.Start(); err != nil {
+		t.Fatalf("start grandchild: %v", err)
+	}
+	if pidFile := os.Getenv("GRAFEL_GRANDCHILD_PIDFILE"); pidFile != "" {
+		_ = os.WriteFile(pidFile, []byte(strconv.Itoa(gc.Process.Pid)), 0o600)
+	}
+	// Block until this process itself is signalled (default disposition
+	// terminates on SIGTERM/SIGKILL — no handler needed). Long enough to
+	// outlast the test's drain timeout if left running.
+	time.Sleep(300 * time.Second)
+}
+
+// helperGroupEngineCommand spawns TestEngineChildGroupHelper in its own
+// process group (mirroring production engineChildSysProcAttr) and arranges
+// for the grandchild pid to land in a file the test can read.
+func helperGroupEngineCommand(grandchildPIDFile string) func(selfExe, root string) *exec.Cmd {
+	return func(selfExe, root string) *exec.Cmd {
+		cmd := exec.Command(selfExe, "-test.run=TestEngineChildGroupHelper", "-test.timeout=60s")
+		cmd.Env = append(os.Environ(),
+			"GRAFEL_ENGINE_GROUP_HELPER=1",
+			"GRAFEL_GRANDCHILD_PIDFILE="+grandchildPIDFile,
+			EnvRoot+"="+root,
+		)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.SysProcAttr = engineChildSysProcAttr()
+		return cmd
+	}
+}
+
+// TestEngineSupervisor_DrainKillsGrandchild is the pin for #6044 item 4: a
+// graceful drain (sup.stop()) must take down not just the supervised engine
+// child but everything in its process group, including grandchildren it
+// forked itself. Before the group-directed signalTerminate/signalKill fix,
+// terminateChild signalled only the child's own pid (p.Signal /
+// cmd.Process.Kill single-target), so the grandchild — reparented but never
+// signalled — survived the drain as an orphan.
+func TestEngineSupervisor_DrainKillsGrandchild(t *testing.T) {
+	root := isolateSupervisorEnv(t)
+	pidFile := root + "/grandchild.pid"
+	defer SetEngineChildCommandForTest(helperGroupEngineCommand(pidFile))()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sup := newTestSupervisor(t, root)
+	sup.drainTimeout = 3 * time.Second
+	if err := sup.start(ctx); err != nil {
+		t.Fatalf("start supervisor: %v", err)
+	}
+
+	// Wait for the grandchild pidfile to appear (helper has forked `sleep`).
+	if !waitFor(t, 10*time.Second, func() bool {
+		_, err := os.Stat(pidFile)
+		return err == nil
+	}) {
+		t.Fatal("grandchild pidfile never appeared — helper did not start")
+	}
+	gcPID := readIntFile(t, pidFile)
+	if gcPID <= 0 {
+		t.Fatalf("invalid grandchild pid read from %s: %d", pidFile, gcPID)
+	}
+	if !pidAliveUnix(gcPID) {
+		t.Fatalf("grandchild pid %d not alive right after spawn", gcPID)
+	}
+	childPID := sup.getChildPID()
+	if childPID == 0 {
+		t.Fatal("supervisor reports no engine child pid")
+	}
+
+	sup.stop()
+
+	if !waitFor(t, 6*time.Second, func() bool { return !pidAliveUnix(childPID) }) {
+		t.Fatalf("engine child %d still alive after drain", childPID)
+	}
+	if !waitFor(t, 6*time.Second, func() bool { return !pidAliveUnix(gcPID) }) {
+		t.Fatalf("grandchild %d (forked by the engine child) survived the drain — orphaned, "+
+			"which is the exact #6044 item-4 defect: the drain signal was not group-directed", gcPID)
+	}
+}
+
+func readIntFile(t *testing.T, path string) int {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	n, _ := strconv.Atoi(strings.TrimSpace(string(b)))
+	return n
+}
+
+// TestSignalTerminate_IsGroupDirected is a narrower unit-level pin: it spawns
+// a child in its own process group with a grandchild inside that same group,
+// and asserts signalTerminate alone (not the full supervisor drain path)
+// reaches the grandchild too.
+func TestSignalTerminate_IsGroupDirected(t *testing.T) {
+	if _, err := exec.LookPath("sleep"); err != nil {
+		t.Skip("sleep not on PATH")
+	}
+	// Parent shell forks the grandchild `sleep` inside its own new group.
+	parent := exec.Command("sh", "-c", "sleep 300 & echo $! ; wait")
+	parent.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stdout, err := parent.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := parent.Start(); err != nil {
+		t.Fatalf("start parent shell: %v", err)
+	}
+	buf := make([]byte, 32)
+	n, _ := stdout.Read(buf)
+	gcPID, convErr := strconv.Atoi(strings.TrimSpace(string(buf[:n])))
+	if convErr != nil || gcPID <= 0 {
+		_ = parent.Process.Kill()
+		t.Fatalf("could not parse grandchild pid from shell output %q: %v", string(buf[:n]), convErr)
+	}
+	if !waitFor(t, 3*time.Second, func() bool { return pidAliveUnix(gcPID) }) {
+		t.Fatalf("grandchild %d never came up", gcPID)
+	}
+
+	if err := signalTerminate(parent.Process); err != nil {
+		t.Fatalf("signalTerminate: %v", err)
+	}
+
+	if !waitFor(t, 3*time.Second, func() bool { return !pidAliveUnix(gcPID) }) {
+		_ = syscall.Kill(-parent.Process.Pid, syscall.SIGKILL)
+		t.Fatalf("grandchild %d survived signalTerminate — not group-directed", gcPID)
+	}
+	_ = parent.Wait()
+}

--- a/internal/daemon/supervise_unix.go
+++ b/internal/daemon/supervise_unix.go
@@ -26,23 +26,52 @@ func engineChildSysProcAttr() *syscall.SysProcAttr {
 // A single-pid signal — the trap exec.CommandContext's default Cancel falls
 // into — only reaches the child itself, not any grandchildren it forks (its
 // own subprocess fanout), leaving them running as orphans once the child
-// exits. Negative pid addresses the whole group the child leads. Fall back
-// to the single-pid signal if the group kill fails (group already gone, or
-// Setpgid didn't take for some reason) rather than silently doing nothing.
+// exits. See groupOrSingleSignal for the pid-reuse guard this needs that the
+// #5999 precedent did not (different call shape — see its doc comment).
 func signalTerminate(p *os.Process) error {
-	if err := syscall.Kill(-p.Pid, syscall.SIGTERM); err != nil {
-		return p.Signal(syscall.SIGTERM)
-	}
-	return nil
+	return groupOrSingleSignal(p, syscall.SIGTERM)
 }
 
 // signalKill is the SIGKILL escalation used when the child does not exit
 // within the drain window. Group-directed for the same reason as
 // signalTerminate: a lone SIGKILL to the child pid can leave grandchildren
-// alive.
+// alive. This is the branch where the pid-reuse race in groupOrSingleSignal
+// actually matters in production — see its doc comment.
 func signalKill(p *os.Process) error {
-	if err := syscall.Kill(-p.Pid, syscall.SIGKILL); err != nil {
-		return p.Kill()
+	return groupOrSingleSignal(p, syscall.SIGKILL)
+}
+
+// groupOrSingleSignal delivers sig to the process group p leads (kill(-pid)),
+// but only after confirming p.Pid is STILL that group's leader (Getpgid(pid)
+// == pid) at the moment of signalling. If it is not — or the check itself
+// fails (ESRCH: the pid is already gone) — it falls back to a plain
+// single-pid signal instead of attempting the group kill at all.
+//
+// Why the check matters (issue #6044 review item 5): terminateChild's SIGKILL
+// escalation (supervise.go) races cmd.Wait() — a separate supervisor-owned
+// goroutine reaps the child concurrently with the drain timer, and `select`
+// picks whichever case is ready with no ordering guarantee between them. If
+// Wait wins that race, the child's pid is freed back to the OS *before* this
+// signal fires; on a busy system pids recycle within milliseconds. A blind
+// kill(-pid) at that point would signal the process group led by whatever
+// unrelated process the OS handed that pid to next — a BIGGER blast radius
+// than the single-pid kill it replaces, not a smaller one.
+//
+// This is precisely the caveat that is present, but only implicit, in the
+// #5999 precedent this follows (internal/daemon/sched/nice_unix.go
+// applyProcessGroupCancel — its own doc comment names the pid-reuse hazard
+// explicitly). That call site is safe from reuse ONLY because os/exec's
+// Cancel hook runs on the watchdog goroutine strictly BEFORE Wait returns and
+// frees the pid — an ordering guarantee this supervisor's separate-goroutine
+// drain race does not have. Getpgid closes that gap: it fails once the pid is
+// freed, and even in the freed-then-reused window, a stale pid coincidentally
+// being reported as its own group's leader is a materially narrower hazard
+// than signalling an arbitrary recycled pid outright.
+func groupOrSingleSignal(p *os.Process, sig syscall.Signal) error {
+	if pgid, err := syscall.Getpgid(p.Pid); err == nil && pgid == p.Pid {
+		if err := syscall.Kill(-p.Pid, sig); err == nil {
+			return nil
+		}
 	}
-	return nil
+	return p.Signal(sig)
 }

--- a/internal/daemon/supervise_unix.go
+++ b/internal/daemon/supervise_unix.go
@@ -19,6 +19,30 @@ func engineChildSysProcAttr() *syscall.SysProcAttr {
 
 // signalTerminate asks the engine child to shut down gracefully (SIGTERM). Its
 // RunEngine signal handler catches this and unwinds the scheduler/watcher.
+//
+// Group-directed (issue #6044, following the #5999 precedent in
+// internal/daemon/sched/nice_unix.go applyProcessGroupCancel): the engine
+// child owns its own process group (Setpgid, engineChildSysProcAttr above).
+// A single-pid signal — the trap exec.CommandContext's default Cancel falls
+// into — only reaches the child itself, not any grandchildren it forks (its
+// own subprocess fanout), leaving them running as orphans once the child
+// exits. Negative pid addresses the whole group the child leads. Fall back
+// to the single-pid signal if the group kill fails (group already gone, or
+// Setpgid didn't take for some reason) rather than silently doing nothing.
 func signalTerminate(p *os.Process) error {
-	return p.Signal(syscall.SIGTERM)
+	if err := syscall.Kill(-p.Pid, syscall.SIGTERM); err != nil {
+		return p.Signal(syscall.SIGTERM)
+	}
+	return nil
+}
+
+// signalKill is the SIGKILL escalation used when the child does not exit
+// within the drain window. Group-directed for the same reason as
+// signalTerminate: a lone SIGKILL to the child pid can leave grandchildren
+// alive.
+func signalKill(p *os.Process) error {
+	if err := syscall.Kill(-p.Pid, syscall.SIGKILL); err != nil {
+		return p.Kill()
+	}
+	return nil
 }

--- a/internal/daemon/supervise_windows.go
+++ b/internal/daemon/supervise_windows.go
@@ -22,3 +22,9 @@ func engineChildSysProcAttr() *syscall.SysProcAttr {
 func signalTerminate(p *os.Process) error {
 	return p.Kill()
 }
+
+// signalKill mirrors signalTerminate on Windows: there is no POSIX group-kill
+// primitive here, so both escalation levels collapse to the same p.Kill().
+func signalKill(p *os.Process) error {
+	return p.Kill()
+}

--- a/internal/install/installsh_restart_stopped_test.go
+++ b/internal/install/installsh_restart_stopped_test.go
@@ -1,0 +1,201 @@
+// installsh_restart_stopped_test.go pins issue #6044 review item 6's second
+// sub-finding: after `grafel stop` on macOS (which pairs `launchctl bootout`
+// with a persistent `launchctl disable` — see
+// internal/daemon/service/launchd_darwin.go Unload), install.sh's
+// restart_daemon must still be able to bring the daemon back during an
+// upgrade. Before this fix, restart_daemon's "is a launchd agent
+// registered?" guard (`launchctl print` / `launchctl list`) only detects a
+// currently-LOADED job — which a disabled, bootout'd job is not, by
+// definition — so it fell straight through to the generic "nothing
+// registered" case and gave up silently, with only a generic post-install
+// message and no attempt to restart anything.
+//
+// Unlike installsh_restart_verify_test.go's structural (string-contains)
+// checks, this test actually SOURCES install.sh as a library and calls the
+// real restart_daemon function with a fake `launchctl` on PATH — so it
+// verifies the runtime branching, not just that certain substrings appear
+// somewhere in the function body.
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeLaunchctlScript is a bash stand-in for launchctl. It logs every
+// invocation (one line per call, space-joined args) to $LAUNCHCTL_LOG, and
+// answers deterministically:
+//   - print / list: simulate "not currently loaded" (the state after
+//     `grafel stop`'s bootout) — print exits 1, list prints nothing that
+//     matches "com.grafel.daemon".
+//   - enable / bootstrap / bootout / kickstart: succeed (exit 0).
+const fakeLaunchctlScript = `#!/usr/bin/env bash
+echo "$@" >> "$LAUNCHCTL_LOG"
+case "$1" in
+  print) exit 1 ;;
+  list) exit 0 ;;
+  *) exit 0 ;;
+esac
+`
+
+// fakeGrafelStatusScript is a bash stand-in for the just-installed grafel
+// binary. It answers `grafel status` with a v-prefixed line reporting
+// $WANT_VERSION so wait_for_daemon_version's very first poll matches
+// immediately (no need to wait out its ~10s budget).
+const fakeGrafelStatusScript = `#!/usr/bin/env bash
+if [ "$1" = "status" ]; then
+  echo "Daemon: running  pid=1  uptime=1s"
+  echo "  version: v${WANT_VERSION}"
+  exit 0
+fi
+exit 0
+`
+
+// writeExecutable writes an executable script at dir/name.
+func writeExecutable(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestInstallSh_RestartDaemon_MacOS_RecoversFromPriorStop is the runtime pin:
+// with a plist on disk but the launchd job reported as not-loaded (exactly
+// what `grafel stop` leaves behind — see the package doc comment above), the
+// real restart_daemon must call `launchctl enable` before `launchctl
+// bootstrap`, and must ultimately report "restarted" — not silently give up
+// with the generic post-install message.
+func TestInstallSh_RestartDaemon_MacOS_RecoversFromPriorStop(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; skipping install.sh runtime test")
+	}
+
+	fakeHome := t.TempDir()
+	launchAgents := filepath.Join(fakeHome, "Library", "LaunchAgents")
+	if err := os.MkdirAll(launchAgents, 0o755); err != nil {
+		t.Fatalf("mkdir LaunchAgents: %v", err)
+	}
+	plistPath := filepath.Join(launchAgents, "com.grafel.daemon.plist")
+	if err := os.WriteFile(plistPath, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatalf("write fake plist: %v", err)
+	}
+
+	// install.sh unconditionally sets PREFIX="${GRAFEL_PREFIX:-$HOME/.grafel}"
+	// and BIN_DIR="$PREFIX/bin" at sourcing time — overriding a bare BIN_DIR
+	// env var — so redirect it via GRAFEL_PREFIX instead.
+	fakePrefix := t.TempDir()
+	fakeBinDir := filepath.Join(fakePrefix, "bin")
+	if err := os.MkdirAll(fakeBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bin dir: %v", err)
+	}
+	wantVersion := "9.9.9"
+	writeExecutable(t, fakeBinDir, "grafel", fakeGrafelStatusScript)
+
+	fakePathDir := t.TempDir()
+	launchctlPath := writeExecutable(t, fakePathDir, "launchctl", fakeLaunchctlScript)
+	logPath := filepath.Join(t.TempDir(), "launchctl.log")
+
+	script := `set -eu; GRAFEL_INSTALL_SH_LIB=1 . "$1"; restart_daemon macos "$2"`
+	cmd := exec.Command(bash, "-c", script, "bash", installShPath(t), wantVersion)
+	cmd.Env = append(os.Environ(),
+		"HOME="+fakeHome,
+		"GRAFEL_PREFIX="+fakePrefix,
+		"WANT_VERSION="+wantVersion,
+		"LAUNCHCTL_LOG="+logPath,
+		"PATH="+fakePathDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, runErr := cmd.CombinedOutput()
+	if runErr != nil {
+		t.Fatalf("restart_daemon macos: %v\noutput:\n%s", runErr, out)
+	}
+	stdout := strings.TrimSpace(string(out))
+	if stdout != "restarted" {
+		t.Fatalf(`restart_daemon must recover from a prior "grafel stop" and echo "restarted", got %q`, stdout)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read launchctl log (path=%s, launchctl=%s): %v", logPath, launchctlPath, err)
+	}
+	log := string(logBytes)
+	enableIdx := strings.Index(log, "enable ")
+	bootstrapIdx := strings.Index(log, "bootstrap ")
+	if enableIdx < 0 {
+		t.Errorf("expected restart_daemon to call `launchctl enable` to clear the persistent disable "+
+			"a prior `grafel stop` left behind, got launchctl log:\n%s", log)
+	}
+	if bootstrapIdx < 0 {
+		t.Errorf("expected restart_daemon to call `launchctl bootstrap` to reload the daemon, got launchctl log:\n%s", log)
+	}
+	if enableIdx >= 0 && bootstrapIdx >= 0 && enableIdx > bootstrapIdx {
+		t.Errorf("expected `launchctl enable` before `launchctl bootstrap` (otherwise bootstrap loads a still-disabled "+
+			"job and RunAtLoad silently no-ops), got launchctl log:\n%s", log)
+	}
+	if strings.Contains(log, "kickstart") {
+		t.Errorf("did not expect a `launchctl kickstart` call on this path (the job was not loaded — "+
+			"kickstart operates on an already-bootstrapped job), got launchctl log:\n%s", log)
+	}
+}
+
+// TestInstallSh_RestartDaemon_MacOS_NothingRegisteredStillNoOps is the OTHER
+// direction of the same fixture: when there is truly nothing registered (no
+// plist on disk at all — a fresh machine, never `grafel install`ed), restart_daemon
+// must still return non-zero and print nothing on stdout, exactly as before
+// this fix. This proves the new elif branch is scoped to "plist present but
+// not loaded" and does not fire for "nothing registered at all".
+func TestInstallSh_RestartDaemon_MacOS_NothingRegisteredStillNoOps(t *testing.T) {
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash not available; skipping install.sh runtime test")
+	}
+
+	fakeHome := t.TempDir() // no Library/LaunchAgents/com.grafel.daemon.plist at all
+	fakePrefix := t.TempDir()
+	fakeBinDir := filepath.Join(fakePrefix, "bin")
+	if err := os.MkdirAll(fakeBinDir, 0o755); err != nil {
+		t.Fatalf("mkdir fake bin dir: %v", err)
+	}
+	wantVersion := "9.9.9"
+	writeExecutable(t, fakeBinDir, "grafel", fakeGrafelStatusScript)
+
+	fakePathDir := t.TempDir()
+	writeExecutable(t, fakePathDir, "launchctl", fakeLaunchctlScript)
+	logPath := filepath.Join(t.TempDir(), "launchctl.log")
+
+	script := `set -eu; GRAFEL_INSTALL_SH_LIB=1 . "$1"; restart_daemon macos "$2"`
+	cmd := exec.Command(bash, "-c", script, "bash", installShPath(t), wantVersion)
+	cmd.Env = append(os.Environ(),
+		"HOME="+fakeHome,
+		"GRAFEL_PREFIX="+fakePrefix,
+		"WANT_VERSION="+wantVersion,
+		"LAUNCHCTL_LOG="+logPath,
+		"PATH="+fakePathDir+string(os.PathListSeparator)+os.Getenv("PATH"),
+	)
+	out, runErr := cmd.CombinedOutput()
+	stdout := strings.TrimSpace(string(out))
+	if runErr == nil {
+		t.Fatalf("restart_daemon must return non-zero when nothing is registered at all, got success with output %q", stdout)
+	}
+	if stdout != "" {
+		t.Fatalf("restart_daemon must print nothing on stdout when nothing is registered, got %q", stdout)
+	}
+	// print/list ARE expected (that's how the "nothing loaded" state is
+	// detected in the first place) — what must NOT happen is any attempt to
+	// actually load/start anything, since there is nothing (no plist) to load.
+	logBytes, rerr := os.ReadFile(logPath)
+	if rerr != nil {
+		t.Fatalf("read launchctl log: %v", rerr)
+	}
+	log := string(logBytes)
+	for _, forbidden := range []string{"enable", "bootstrap", "kickstart", "bootout"} {
+		if strings.Contains(log, forbidden) {
+			t.Errorf("expected no %q call when nothing is registered at all, got launchctl log:\n%s", forbidden, log)
+		}
+	}
+}


### PR DESCRIPTION
`grafel stop` did not stop grafel. It sent the Stop RPC, the daemon obeyed, and launchd immediately respawned it — the LaunchAgent declares an unconditional `KeepAlive`. The command printed `stop requested` and returned 0 either way, so the user saw the service still running and reasonably concluded the command was broken.

Reported by a user, reproduced four times on macOS. The asymmetry is the root cause: `grafel start` **is** service-aware (`OS service detected for this daemon; restarting via the OS service manager`); `stop` was not. `start` went through launchd, `stop` went around it.

```
03:30:11  serve=72746 (up since 03:05:47)
03:30:20  $ grafel stop  →  "stop requested"  (rc=0)
03:30:21  serve=82993   ← respawned ~1s later
```

Three `stop` calls inside the same second returned `stop requested` / `daemon not running` / `stop requested` — launchd resurrecting the daemon between consecutive calls. That flapping is what a user experiences as "sometimes it stops it, and it never stays down".

## `stop` is now persistent, and that decision is deliberate

The issue asked for this to be chosen rather than defaulted into. `bootout` stops the job now but the plist still loads at login, so macOS pairs it with `launchctl disable`; `Load()` unconditionally `enable`s before `bootstrap` so the ordinary install/start/restart cycle is unaffected. systemd's `Unload()` was already `disable --now` and schtasks's already deletes the registration, so all three platforms now agree: **stop means stay down; `grafel start` is the way back.** `grafel stop --help` says so explicitly.

## Confirmation is on the socket, not the job registry

The first implementation confirmed via `Status()`, which on darwin derives `Running` purely from `launchctl list <label>`'s exit code — *is the job loaded in the domain*, not *is the process alive*. After `bootout` the job is gone by definition, making the check very nearly a tautology, and blind to a manually-started daemon outside the domain entirely.

Concretely: a plist on disk plus a hand-started daemon routes to the service path (`serviceInstalledForThisRoot` only stats the plist). `Unload()` gives up after 3s with errors ignored, `bootout` no-ops on an unloaded job with its exit status discarded, and `stop` printed **"daemon stopped"** over a live daemon.

`stopConverge` now polls `Probe()` — the real socket — via `waitStopped`, mirroring the existing `waitReady`. Pinned by `TestStopConverge_TrustsProbeNotStatus`, whose fixture composes `probeAlwaysUp` with `loaded:false` so it genuinely models "Status says down, socket says up", and which asserts its own fixture precondition before the real assertion.

## The persistence decision is now falsifiable

`launchctlBootout/Bootstrap/Disable/Enable` are package vars. Before that seam existed, deleting **both** the `disable` and `enable` calls outright left the entire suite green — the diff's most consequential decision was unpinned. `Unload` records the outcome on `lastDisableErr` and `stopService` reads it, so the CLI no longer prints "even across reboot" over a `disable` whose error it discarded.

Two callers of the new persistence that the first pass missed: `uninstall` now re-enables the label after teardown rather than leaving a launchd override with no plist to explain it, and `install.sh`'s `restart_daemon` detects "plist present but not loaded" and calls `enable` before `bootstrap` instead of silently giving up on any machine where `stop` had been used.

## The orphaned-engine window

A hard exit of `serve` orphaned its `engine` child — `ppid` flips to 1 — while launchd spawned a replacement alongside it: two process trees against one state directory, the shape that produces torn writes and doubled memory. Drain signals are now group-directed.

`groupOrSingleSignal` checks `Getpgid(pid) == pid` before negating. The #5999 precedent (`sched/nice_unix.go`) was verified rather than cited: it is safe there because `Cancel` runs strictly before `Wait` frees the pid. This supervisor's drain races a separate reaping goroutine and has no such ordering, so without the leadership check a lost race would signal whatever group inherited the reused pid. A microsecond TOCTOU window remains and is documented as such — a reuse race is not constructible in a test, and the comment says so rather than implying coverage.

`defaultEngineChildCommand`'s `cmd.Env = os.Environ()` and its load-bearing comment are byte-identical; `git diff -- internal/daemon/supervise.go` is empty.

## Verification

`go build ./... && go vet ./... && gofmt -l .` clean. 30 packages green at raw exit 0 across `internal/cli`, `internal/daemon`, `cmd/grafel`, `internal/install`. `-race` clean on the service and supervisor packages.

Mutation battery rebuilt against the final tree; every behavioural change dies individually. **Two mutations that survived the first round now die**, each naming its hole: reverting `stopConverge` to `Status()`-only, and deleting the `disable`/`enable` calls.

**A false-pass fixture was found, disclosed by the author, and independently reproduced.** The original SIGKILL test used a plain `sleep` grandchild, which died to the group SIGTERM before the drain timeout ever elapsed — so it passed regardless of whether `signalKill` was group-directed. The grandchild now does `trap '' TERM; exec sleep 300` (`SIG_IGN` survives `exec`), and the escalation branch is genuinely reached: 0.59s blind versus 6.63s biting. Reverting the trap alone, with `signalKill` still broken, restores the false pass — which is how the fixture's load-bearing element was confirmed rather than assumed. `signalTerminate` and `signalKill` now have independent pins; mutating either fails only its own tests.

## Known and disclosed

- **`Probe()` proves socket-death, not process-death.** `listener.Close()` precedes the remaining graceful tail, so `waitStopped` can return before the process is gone — the issue's own worst case, a stalled RPC mid-index. Bounded by `defaultShutdownWatchdog = 5s`, which force-exits the whole tail, so the window is ≤~5s. The definitive axis (`ReadPIDFile` + `pidStillAlive`, already used by `runDaemonRestart`) is in-tree and unused here. Follow-up, not a blocker.
- **The Linux half of the installer asymmetry is unaddressed.** A disabled systemd unit still appears in `list-unit-files` and still `restart`s, so an upgrade brings the daemon back running-but-still-disabled-at-boot, while macOS now fully reverts the stop. Neither tells the user their deliberate stop was undone. Follow-up.
- **`waitStopped`'s budget is 60s against the RPC path's 5s.** Success is fast (the first probe short-circuits); a stubborn daemon now blocks for a minute before reporting. Correct-over-fast, but the asymmetry is unexplained.
- The watchdog force-exit can still orphan the engine — the pre-existing hard-exit case the issue itself calls out, orthogonal to the group-signal fix, which only applies when the drain actually runs.

Independently adversarially reviewed across two rounds; five of six findings verified closed by execution.

Closes #6044
