### PR TITLE
fix(#6052): treat unstable_cache as a function wrapper, not an un-emitted const

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -2046,7 +2046,14 @@ func (x *extractor) isFunctionWrapperCall(n ts.Node) bool {
 		// also take a function but are imperative side-effects,
 		// not values bound to a name — the `const cleanup =
 		// useEffect(...)` shape is not idiomatic.
-		"useCallback", "useMemo":
+		"useCallback", "useMemo",
+		// Next.js data cache (next/cache): `const getItems =
+		// unstable_cache(async (...) => {...}, [key], {revalidate})`
+		// returns the cached wrapper around its first argument, so the
+		// bound name is a function, the same shape as the hook wrappers
+		// above. Without this the declaration falls through every
+		// branch and no entity is emitted for the name at all.
+		"unstable_cache":
 		return true
 	}
 	// Issue #2859 — generic Higher-Order Component naming convention.

--- a/internal/extractors/javascript/extractor_test.go
+++ b/internal/extractors/javascript/extractor_test.go
@@ -759,6 +759,26 @@ func TestConstExportReactWrappers(t *testing.T) {
 	assertKind(t, entities, "Connected", "SCOPE.Operation")
 }
 
+const constExportNextUnstableCacheSrc = `
+import { unstable_cache } from "next/cache";
+
+export const getItems = unstable_cache(
+  async (ownerId) => fetchItems(ownerId),
+  ["items"],
+  { revalidate: 60 },
+);
+`
+
+// unstable_cache returns the cached wrapper around its first argument, so the
+// bound name is callable. Same shape as useCallback/useMemo.
+func TestConstExportNextUnstableCache(t *testing.T) {
+	src := []byte(constExportNextUnstableCacheSrc)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	assertKind(t, entities, "getItems", "SCOPE.Operation")
+}
+
 const constExportHookAliasSrc = `
 import { useSelector, useDispatch } from "react-redux";
 


### PR DESCRIPTION
`unstable_cache` joins `useCallback` and `useMemo` in the `isFunctionWrapperCall` switch, so `const getItems = unstable_cache(fn, keys, opts)` is emitted as `SCOPE.Operation` instead of falling through every branch un-emitted.

Three shapes change, all of them the wrapper branch (`extractor.go:1896-1930`) taking a declaration that previously reached a later branch or none:

- At module scope with no type annotation, nothing was emitted; now a `SCOPE.Operation` subtype `function` is.
- With a TypeScript type annotation, `const getItems: Loader = unstable_cache(...)` emitted `SCOPE.Component` subtype `const` through the `:1931` branch. The wrapper branch runs first, so it is now `SCOPE.Operation` subtype `function`, which is what `useCallback` already gets.
- Inside a function body, nothing was emitted (the final `else` is gated on `funcDepth == 0`); now the entity is emitted and tagged `local_scope=true` by `:1928-1930`, the same as any other wrapper call in a body. The wrapper branch also runs `extractCallRelationships` at `:1907`, so calls made in the callback are attributed to the const name.

Other notes:

- The switch matches on the callee leaf identifier with no import tracking, so the entry is only as safe as the name. `unstable_cache` is specific enough to `next/cache` for that to hold. I did not add React's `cache()`, which has the same "returns a memoized function" shape, because the bare name `cache` is common enough in ordinary code to misclassify it.
- Declarations inside the callback are unchanged in every case. `walkChildren` at `:1969` recurses into the value regardless of which branch emits.
- Nothing else in the switch moves. The neighbouring `next/cache` names in `internal/external/synth.go:10662-10670` (`revalidatePath`, `revalidateTag`, `unstable_noStore`, `unstable_expireTag`, `unstable_expirePath`, `cacheTag`, `cacheLife`) are called for their effect rather than bound to a name, so they stay out, and `useEffect` stays out for the reason the existing comment gives.
- The extractor instance is registered for both `javascript` and `typescript` (`extractor.go:71-75`), so this applies to TS sources too.

`TestConstExportNextUnstableCache` sits beside `TestConstExportReactWrappers` and follows its shape. Reverting `extractor.go` alone and keeping the test gives `extractor_test.go:779: entity "getItems" not found; got names: [test.go]`.

`go test ./...` green (229 packages, no failures), `go vet ./internal/extractors/javascript/` and `gofmt -l internal/extractors/javascript` clean.

On the coverage matrix: the five `hoc_wrapper_recognition` cells are per-framework (expo, ionic, nativescript, react, react-native) and there is no Next.js one, so I have left `docs/coverage/registry.json` alone rather than invent a slot. The react cell does cite `internal/extractors/javascript/extractor.go` with no name list, so if you would rather this land as a `verified_at` bump and a note there, say so and I will add it. `go run ./tools/coverage validate` exits 0 and `gen` leaves `docs/coverage` byte-identical either way.

Closes #6052
