### PR TITLE
fix(#6057): make Windows work — atomic writes that don't lose data, a reaper that doesn't wipe the registry, and a shutdown that terminates

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -113,6 +113,8 @@ func WriteFile(path string, b []byte, perm os.FileMode) (err error) {
 	if err = os.Chmod(tmp, perm); err != nil {
 		return err
 	}
-	err = os.Rename(tmp, path)
+	// Not os.Rename: on Windows that alone cannot replace a read-only
+	// destination and loses races against other handles. See rename.go.
+	err = renameAtomic(tmp, path)
 	return err
 }

--- a/internal/atomicfile/atomicfile_test.go
+++ b/internal/atomicfile/atomicfile_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 func TestWriteFile_WritesContent(t *testing.T) {
@@ -31,21 +32,23 @@ func TestWriteFile_WritesContent(t *testing.T) {
 // temp file 0600, so WITHOUT an explicit Chmod every destination lands at 0600
 // regardless of the requested perm. Deleting the Chmod from the helper must
 // fail this test — that is the whole point of it (#5978 lost exactly this).
+//
+// The 0444 row is load-bearing on Windows and only there. Windows has no Unix
+// permission bits (see testsupport.AssertPerm), so the 0600/0644/0755 rows all
+// collapse to "the file is writable" and a deleted Chmod would sail past them.
+// 0444 is the one requested mode Windows CAN represent — as
+// FILE_ATTRIBUTE_READONLY — so without the Chmod that row fails there too.
 func TestWriteFile_AppliesPerm(t *testing.T) {
-	for _, perm := range []os.FileMode{0o600, 0o644, 0o755} {
+	for _, perm := range []os.FileMode{0o600, 0o644, 0o755, 0o444} {
 		t.Run(fmt.Sprintf("%04o", perm), func(t *testing.T) {
 			dir := t.TempDir()
 			path := filepath.Join(dir, "out.bin")
 			if err := atomicfile.WriteFile(path, []byte("x"), perm); err != nil {
 				t.Fatalf("WriteFile: %v", err)
 			}
-			fi, err := os.Stat(path)
-			if err != nil {
-				t.Fatalf("Stat: %v", err)
-			}
-			if got := fi.Mode().Perm(); got != perm {
-				t.Fatalf("mode = %04o, want %04o", got, perm)
-			}
+			testsupport.AssertPerm(t, path, perm)
+			// Leave it writable so TempDir cleanup can remove it on Windows.
+			_ = os.Chmod(path, 0o666)
 		})
 	}
 }
@@ -89,10 +92,7 @@ func TestWriteFile_OverwritesExisting(t *testing.T) {
 	if string(got) != "new" {
 		t.Fatalf("content = %q, want %q", got, "new")
 	}
-	fi, _ := os.Stat(path)
-	if fi.Mode().Perm() != 0o644 {
-		t.Fatalf("mode = %04o, want 0644", fi.Mode().Perm())
-	}
+	testsupport.AssertPerm(t, path, 0o644)
 }
 
 // TestWriteFile_NoTempLeftBehind asserts the success path leaves the
@@ -264,13 +264,7 @@ func TestWriteFile_ConcurrentWritersSameDestination(t *testing.T) {
 			t.Fatalf("iteration %d: destination holds a torn write (%d bytes, prefix %q)",
 				it, len(got), truncate(got, 32))
 		}
-		fi, err := os.Stat(path)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if fi.Mode().Perm() != 0o644 {
-			t.Fatalf("iteration %d: mode = %04o, want 0644", it, fi.Mode().Perm())
-		}
+		testsupport.AssertPerm(t, path, 0o644)
 	}
 }
 

--- a/internal/atomicfile/rename.go
+++ b/internal/atomicfile/rename.go
@@ -1,0 +1,118 @@
+package atomicfile
+
+import (
+	"os"
+	"time"
+)
+
+// rename.go — the "replace the destination" half of an atomic write.
+//
+// # Why os.Rename alone is not enough on Windows (#6053)
+//
+// On POSIX, rename(2) replaces the destination unconditionally: the file's own
+// mode is irrelevant (write permission on the DIRECTORY is what governs) and
+// other processes holding the destination open do not block it — they keep
+// reading the old inode. So on unix this file is inert by construction: the
+// platform predicates in rename_other.go are constant false/no-op and
+// renameOver degenerates to exactly one os.Rename.
+//
+// Windows has neither property, and two distinct failures follow. Both were
+// caught by the existing test suite the first time it ran on windows-latest:
+//
+//  1. READ-ONLY DESTINATION — deterministic. Go's os.Rename on Windows already
+//     IS MoveFileEx(from, to, MOVEFILE_REPLACE_EXISTING) (syscall.Rename), so
+//     "call MoveFileEx via golang.org/x/sys/windows instead" buys nothing;
+//     that was the first thing checked. REPLACE_EXISTING refuses to replace a
+//     file carrying FILE_ATTRIBUTE_READONLY and returns ERROR_ACCESS_DENIED,
+//     forever. Retrying cannot fix it. The only remedy is to clear the
+//     attribute, which is what setDestReadOnly does — and, because that
+//     mutates a file we were asked to replace but might still fail to replace,
+//     it is put back on the failure path.
+//
+//  2. SHARING VIOLATION — transient. Replacing a destination needs a handle
+//     with DELETE access, which Windows refuses while anyone holds the file
+//     open without FILE_SHARE_DELETE. Go's own os.OpenFile always passes
+//     FILE_SHARE_DELETE, so grafel is never the offender; the openers we
+//     cannot control are the concurrent replacer's own in-flight MoveFileEx,
+//     Defender's real-time scan of the just-created temp file, and the search
+//     indexer. Nothing in this process can prevent those, and they clear in
+//     milliseconds — a bounded retry is the only remedy available, and it is
+//     the same remedy Git for Windows, Chromium and Rust's std adopted.
+//
+// A retry alone would be wrong: it would spend half a second failing on case 1
+// and then report the same error. Clearing read-only alone would be wrong: it
+// does nothing for case 2. Both are needed, and the order matters — the
+// deterministic case is handled first, without sleeping.
+
+// renameRetries bounds case 2. The backoff doubles from renameRetryBase, so
+// eight retries wait ~510ms in total; a write blocks for at most that before
+// surfacing the error. Long enough for an antivirus scan of a small state
+// file, short enough that a wedged handle is reported rather than hidden.
+const (
+	renameRetries   = 8
+	renameRetryBase = 2 * time.Millisecond
+)
+
+// renameOps is the set of primitives renameOver drives. Splitting them out is
+// what makes the Windows recovery logic testable on a machine that is not
+// Windows: rename_test.go substitutes fakes, and the real implementations in
+// rename_windows.go / rename_other.go stay small enough to review by eye.
+type renameOps struct {
+	rename      func(oldpath, newpath string) error
+	isReadOnly  func(path string) bool
+	setReadOnly func(path string, ro bool) error
+	recoverable func(err error) bool
+	sleep       func(d time.Duration)
+}
+
+var defaultRenameOps = renameOps{
+	rename:      os.Rename,
+	isReadOnly:  destIsReadOnly,
+	setReadOnly: setDestReadOnly,
+	recoverable: renameErrRecoverable,
+	sleep:       time.Sleep,
+}
+
+// renameAtomic renames tmp over path, recovering from the two Windows-only
+// failures described above. On unix it is one os.Rename and nothing else.
+func renameAtomic(tmp, path string) error {
+	return defaultRenameOps.renameOver(tmp, path)
+}
+
+func (o renameOps) renameOver(tmp, path string) (err error) {
+	if err = o.rename(tmp, path); err == nil || !o.recoverable(err) {
+		return err
+	}
+
+	// Case 1: a read-only destination. Deterministic — handled before any
+	// sleep, because no amount of waiting changes a file attribute.
+	if o.isReadOnly(path) && o.setReadOnly(path, false) == nil {
+		// If we end up NOT replacing the destination, put its protection
+		// back: a failed write must not leave the file writable.
+		defer func() {
+			if err != nil {
+				_ = o.setReadOnly(path, true)
+			}
+		}()
+		if err = o.rename(tmp, path); err == nil {
+			return nil
+		}
+		if !o.recoverable(err) {
+			return err
+		}
+	}
+
+	// Case 2: someone else holds a handle without FILE_SHARE_DELETE.
+	delay := renameRetryBase
+	for i := 0; i < renameRetries; i++ {
+		o.sleep(delay)
+		delay *= 2
+		if err = o.rename(tmp, path); err == nil {
+			return nil
+		}
+		if !o.recoverable(err) {
+			return err
+		}
+	}
+	return err
+}

--- a/internal/atomicfile/rename.go
+++ b/internal/atomicfile/rename.go
@@ -1,6 +1,8 @@
 package atomicfile
 
 import (
+	"fmt"
+	"log/slog"
 	"os"
 	"time"
 )
@@ -21,36 +23,74 @@ import (
 //
 //  1. READ-ONLY DESTINATION — deterministic. Go's os.Rename on Windows already
 //     IS MoveFileEx(from, to, MOVEFILE_REPLACE_EXISTING) (syscall.Rename), so
-//     "call MoveFileEx via golang.org/x/sys/windows instead" buys nothing;
+//     "call MoveFileEx by hand via golang.org/x/sys/windows" buys nothing;
 //     that was the first thing checked. REPLACE_EXISTING refuses to replace a
 //     file carrying FILE_ATTRIBUTE_READONLY and returns ERROR_ACCESS_DENIED,
 //     forever. Retrying cannot fix it. The only remedy is to clear the
-//     attribute, which is what setDestReadOnly does — and, because that
-//     mutates a file we were asked to replace but might still fail to replace,
-//     it is put back on the failure path.
+//     attribute — see the warning contract on warnReadOnlyCleared below.
 //
 //  2. SHARING VIOLATION — transient. Replacing a destination needs a handle
 //     with DELETE access, which Windows refuses while anyone holds the file
 //     open without FILE_SHARE_DELETE. Go's own os.OpenFile always passes
 //     FILE_SHARE_DELETE, so grafel is never the offender; the openers we
 //     cannot control are the concurrent replacer's own in-flight MoveFileEx,
-//     Defender's real-time scan of the just-created temp file, and the search
-//     indexer. Nothing in this process can prevent those, and they clear in
-//     milliseconds — a bounded retry is the only remedy available, and it is
-//     the same remedy Git for Windows, Chromium and Rust's std adopted.
+//     a concurrent reader mid-os.ReadFile, Defender's real-time scan of the
+//     just-created temp file, and the search indexer. Nothing in this process
+//     can prevent those and they clear in microseconds, so a bounded retry is
+//     the only remedy available.
 //
-// A retry alone would be wrong: it would spend half a second failing on case 1
-// and then report the same error. Clearing read-only alone would be wrong: it
-// does nothing for case 2. Both are needed, and the order matters — the
-// deterministic case is handled first, without sleeping.
+// A retry alone would be wrong: it would spend the whole budget failing on
+// case 1 and then report the same error. Clearing read-only alone would be
+// wrong: it does nothing for case 2. Both are needed, and the order matters —
+// the deterministic case is handled first, without sleeping.
+//
+// # This is the SIXTH copy of the Windows retry loop in this tree
+//
+// Stated plainly because an earlier draft of this comment claimed it was the
+// second. The existing five are internal/graph/groupalgo,
+// internal/graph/descriptions and internal/graph/flows (three copies of
+// atomicRename), internal/statusfile and internal/install. This one is
+// deliberately aligned with them — same ~40 × 5ms budget, same
+// fs.ErrPermission-first classification, same golang.org/x/sys/windows
+// constants, same vars-not-consts so a test can shrink the delay — rather than
+// inventing a sixth dialect. Consolidating all six behind this package is the
+// right end state and is explicitly NOT done here: this branch is
+// release-blocking and that sweep is not.
+//
+// Two consequences follow from the case-1 analysis above, and are expected
+// rather than surprising:
+//
+//   - graph/{groupalgo,descriptions,flows}.atomicRename are STILL broken for a
+//     read-only destination, and will now burn the full ~200ms per write
+//     retrying something retrying cannot fix.
+//   - ~50 production sites still call bare os.Rename for temp→dest with no
+//     retry at all (graph/manifest.go, graph/graph.go, graph/fbwriter/*,
+//     mcp/repair.go, enrichment/candidates.go, dashboard/*,
+//     daemon/requests/requests.go).
+//
+// If windows-latest goes red again on one of those, that is the next slice of
+// the same defect class, not a regression from this change.
 
-// renameRetries bounds case 2. The backoff doubles from renameRetryBase, so
-// eight retries wait ~510ms in total; a write blocks for at most that before
-// surfacing the error. Long enough for an antivirus scan of a small state
-// file, short enough that a wedged handle is reported rather than hidden.
-const (
-	renameRetries   = 8
-	renameRetryBase = 2 * time.Millisecond
+// renameRetries / renameRetryDelay bound case 2.
+//
+// The budget is sized on ATTEMPT COUNT, not wall-clock. The tests this must
+// fix are 8-way concurrent (links: 8 writers × 20 iterations = 160 writes;
+// atomicfile: 8 × 40) with Defender and the indexer competing on top, so a
+// writer that loses N consecutive races fails — and N, not elapsed time, is
+// what has to exceed the contention. 40 × 5ms ≈ 200ms matches the in-tree
+// precedent (internal/graph/groupalgo/atomicrename_windows.go), whose own
+// comment reasons against a FOUR-reader stress test; 8 concurrent writers is
+// strictly heavier, so anything below that precedent would be a regression in
+// disguise. An earlier draft of this file used 8 attempts with exponential
+// backoff, which optimised the wall-clock number while making the attempt
+// count worse — exactly the wrong axis.
+//
+// Bounded on purpose: if a handle genuinely holds the destination for >200ms,
+// the write surfaces the real error rather than hanging a link pass. Vars, not
+// consts, so a future test can shrink the delay (as all five precedents do).
+var (
+	renameRetries    = 40
+	renameRetryDelay = 5 * time.Millisecond
 )
 
 // renameOps is the set of primitives renameOver drives. Splitting them out is
@@ -63,6 +103,7 @@ type renameOps struct {
 	setReadOnly func(path string, ro bool) error
 	recoverable func(err error) bool
 	sleep       func(d time.Duration)
+	warn        func(path string)
 }
 
 var defaultRenameOps = renameOps{
@@ -71,6 +112,28 @@ var defaultRenameOps = renameOps{
 	setReadOnly: setDestReadOnly,
 	recoverable: renameErrRecoverable,
 	sleep:       time.Sleep,
+	warn:        warnReadOnlyCleared,
+}
+
+// warnReadOnlyCleared reports that a user's read-only protection was removed.
+//
+// On Windows FILE_ATTRIBUTE_READONLY is the user-facing "protect this file"
+// checkbox, and no production call site here ever asks for a read-only mode —
+// every atomicfile.WriteFile in the tree passes 0644 or 0600. So the ONLY way
+// this branch runs in production is that a HUMAN marked the destination
+// read-only, and clearing it is permanent: the replacement file carries the
+// caller's perm, which is writable. Before #6053 grafel reported "Access is
+// denied" and left the file alone; now it wins, silently, unless this says so.
+//
+// The pre-existing contract (TestWriteFile_OverwritesReadOnlyDestination, and
+// the package doc's "a READ-ONLY destination is REPLACED") is deliberate and
+// unix has always behaved this way — but on unix the DIRECTORY's permission
+// still gates it, and on Windows nothing does. Hence a warning rather than an
+// error: the contract stands, the silence does not.
+func warnReadOnlyCleared(path string) {
+	slog.Warn("atomicfile: cleared the read-only attribute on a destination in order to replace it; "+
+		"the file's read-only protection is now gone",
+		"path", path)
 }
 
 // renameAtomic renames tmp over path, recovering from the two Windows-only
@@ -80,6 +143,7 @@ func renameAtomic(tmp, path string) error {
 }
 
 func (o renameOps) renameOver(tmp, path string) (err error) {
+	attempts := 1
 	if err = o.rename(tmp, path); err == nil || !o.recoverable(err) {
 		return err
 	}
@@ -87,6 +151,7 @@ func (o renameOps) renameOver(tmp, path string) (err error) {
 	// Case 1: a read-only destination. Deterministic — handled before any
 	// sleep, because no amount of waiting changes a file attribute.
 	if o.isReadOnly(path) && o.setReadOnly(path, false) == nil {
+		o.warn(path)
 		// If we end up NOT replacing the destination, put its protection
 		// back: a failed write must not leave the file writable.
 		defer func() {
@@ -94,6 +159,7 @@ func (o renameOps) renameOver(tmp, path string) (err error) {
 				_ = o.setReadOnly(path, true)
 			}
 		}()
+		attempts++
 		if err = o.rename(tmp, path); err == nil {
 			return nil
 		}
@@ -103,10 +169,9 @@ func (o renameOps) renameOver(tmp, path string) (err error) {
 	}
 
 	// Case 2: someone else holds a handle without FILE_SHARE_DELETE.
-	delay := renameRetryBase
 	for i := 0; i < renameRetries; i++ {
-		o.sleep(delay)
-		delay *= 2
+		o.sleep(renameRetryDelay)
+		attempts++
 		if err = o.rename(tmp, path); err == nil {
 			return nil
 		}
@@ -114,5 +179,10 @@ func (o renameOps) renameOver(tmp, path string) (err error) {
 			return err
 		}
 	}
-	return err
+	// Wrapped with the attempt count so an exhausted budget is
+	// distinguishable in CI output from no retry having happened at all —
+	// otherwise a badly sized budget and a missing retry loop produce
+	// identical failures.
+	return fmt.Errorf("rename %s -> %s: still failing after %d attempts over %v: %w",
+		tmp, path, attempts, time.Duration(renameRetries)*renameRetryDelay, err)
 }

--- a/internal/atomicfile/rename_other.go
+++ b/internal/atomicfile/rename_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package atomicfile
+
+// The POSIX primitives, all inert. rename(2) replaces the destination whatever
+// the destination's own mode is and whoever else has it open, so there is
+// nothing here to recover from — see rename.go. Keeping them constant (rather
+// than #ifdef-ing the call away) means renameOver is the same code path on
+// every platform and its unit tests are not Windows-only.
+
+func renameErrRecoverable(error) bool { return false }
+
+func destIsReadOnly(string) bool { return false }
+
+func setDestReadOnly(string, bool) error { return nil }

--- a/internal/atomicfile/rename_other_test.go
+++ b/internal/atomicfile/rename_other_test.go
@@ -1,0 +1,45 @@
+//go:build !windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestPlatformPrimitives_UnixAreInert pins the zero-behaviour-change promise on
+// the platforms grafel is developed on. POSIX rename(2) replaces the
+// destination regardless of the destination file's own mode and regardless of
+// other open handles, so none of the recovery in renameOver may ever engage
+// here: WriteFile must remain exactly one os.Rename.
+func TestPlatformPrimitives_UnixAreInert(t *testing.T) {
+	for _, err := range []error{
+		syscall.EACCES, syscall.EPERM, syscall.ENOENT, errors.New("x"), os.ErrPermission,
+	} {
+		if renameErrRecoverable(err) {
+			t.Fatalf("renameErrRecoverable(%v) = true, want false on unix", err)
+		}
+	}
+
+	dir := t.TempDir()
+	ro := filepath.Join(dir, "ro")
+	if err := os.WriteFile(ro, []byte("x"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if destIsReadOnly(ro) {
+		t.Fatal("destIsReadOnly(0444 file) = true, want false on unix (rename does not care)")
+	}
+	if err := setDestReadOnly(ro, false); err != nil {
+		t.Fatalf("setDestReadOnly: %v", err)
+	}
+	fi, err := os.Stat(ro)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fi.Mode().Perm() != 0o444 {
+		t.Fatalf("setDestReadOnly changed the mode to %04o; it must be a no-op on unix", fi.Mode().Perm())
+	}
+}

--- a/internal/atomicfile/rename_test.go
+++ b/internal/atomicfile/rename_test.go
@@ -9,11 +9,19 @@ package atomicfile
 // decision logic lives in rename.go, where these tests drive it directly with
 // fakes. What is NOT covered locally is the errno classification itself and
 // the os.Chmod-clears-FILE_ATTRIBUTE_READONLY mapping; those are asserted only
-// by the end-to-end tests when they run on windows-latest.
+// by rename_windows_test.go when it runs on windows-latest.
+//
+// NO TEST IN THIS PACKAGE MAY CALL t.Parallel. TestWriteFile_RoutesThrough-
+// RenameAtomic swaps the package global defaultRenameOps.rename without
+// synchronisation, and other tests here run 8 concurrent WriteFile goroutines.
+// That is only safe because Go runs a package's tests sequentially unless they
+// opt into parallelism. TestNoParallelTestsInThisPackage enforces it.
 
 import (
 	"errors"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -27,6 +35,7 @@ type fakeRename struct {
 	roSets   []bool // every setReadOnly(_, v) in order
 	roSetErr error
 	probes   int
+	warns    []string
 }
 
 func (f *fakeRename) rename(string, string) error {
@@ -58,6 +67,7 @@ func (f *fakeRename) ops(recoverable func(error) bool) renameOps {
 		setReadOnly: f.setReadOnly,
 		recoverable: recoverable,
 		sleep:       func(d time.Duration) { f.sleeps = append(f.sleeps, d) },
+		warn:        func(p string) { f.warns = append(f.warns, p) },
 	}
 }
 
@@ -65,6 +75,15 @@ var errDenied = errors.New("access is denied")
 
 func allRecoverable(err error) bool { return err != nil }
 func noneRecoverable(error) bool    { return false }
+
+// failN returns a script that fails n times with errDenied then succeeds.
+func failN(n int) []error {
+	out := make([]error, 0, n+1)
+	for i := 0; i < n; i++ {
+		out = append(out, errDenied)
+	}
+	return append(out, nil)
+}
 
 func TestRenameOver_SucceedsFirstTry(t *testing.T) {
 	f := &fakeRename{}
@@ -80,10 +99,13 @@ func TestRenameOver_SucceedsFirstTry(t *testing.T) {
 	if len(f.sleeps) != 0 {
 		t.Fatalf("sleeps = %v, want none", f.sleeps)
 	}
+	if len(f.warns) != 0 {
+		t.Fatalf("warns = %v, want none", f.warns)
+	}
 }
 
 // TestRenameOver_NonRecoverableErrorReturnedImmediately pins that the driver
-// does not turn every rename failure into a half-second retry storm. Only the
+// does not turn every rename failure into a 200ms retry storm. Only the
 // platform-classified sharing/permission errnos are recoverable.
 func TestRenameOver_NonRecoverableErrorReturnedImmediately(t *testing.T) {
 	f := &fakeRename{results: []error{errDenied}}
@@ -124,6 +146,36 @@ func TestRenameOver_ReadOnlyDestinationClearedNotSleptOn(t *testing.T) {
 	}
 }
 
+// TestRenameOver_WarnsWhenItDefeatsReadOnly is the F3 contract. Clearing
+// FILE_ATTRIBUTE_READONLY destroys a protection a HUMAN set — no production
+// call site in this tree ever passes a read-only perm, so a read-only
+// destination in the wild is always user intent. Doing it is the documented
+// behaviour; doing it SILENTLY is not.
+func TestRenameOver_WarnsWhenItDefeatsReadOnly(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied, nil}, readOnly: true}
+	if err := f.ops(allRecoverable).renameOver("tmp", "/some/dst.json"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if len(f.warns) != 1 {
+		t.Fatalf("warns = %v, want exactly one warning naming the destination", f.warns)
+	}
+	if f.warns[0] != "/some/dst.json" {
+		t.Fatalf("warned about %q, want the destination path", f.warns[0])
+	}
+}
+
+// TestRenameOver_DoesNotWarnWhenNoReadOnlyDefeated: the transient path must
+// stay quiet, or the warning becomes noise nobody reads.
+func TestRenameOver_DoesNotWarnWhenNoReadOnlyDefeated(t *testing.T) {
+	f := &fakeRename{results: failN(3)}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if len(f.warns) != 0 {
+		t.Fatalf("warns = %v, want none on the transient path", f.warns)
+	}
+}
+
 // TestRenameOver_ReadOnlyRestoredWhenReplaceStillFails: clearing the attribute
 // is a mutation of a file we do not own. If the replace still fails we must
 // put it back rather than leave a file the user marked read-only writable.
@@ -156,12 +208,12 @@ func TestRenameOver_ReadOnlyNotRestoredAfterSuccess(t *testing.T) {
 }
 
 // TestRenameOver_TransientSharingViolationRetried is the CLASS A concurrency
-// case: another handle (a concurrent replacer, an antivirus scanner, the
-// Windows indexer) holds the destination or the temp open without
-// FILE_SHARE_DELETE. It is genuinely transient, and a bounded retry is the
-// only remedy available to us.
+// case: another handle (a concurrent replacer, a reader mid-ReadFile, an
+// antivirus scanner, the Windows indexer) holds the destination or the temp
+// open without FILE_SHARE_DELETE. It is genuinely transient, and a bounded
+// retry is the only remedy available to us.
 func TestRenameOver_TransientSharingViolationRetried(t *testing.T) {
-	f := &fakeRename{results: []error{errDenied, errDenied, errDenied, nil}}
+	f := &fakeRename{results: failN(3)}
 	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
 		t.Fatalf("renameOver: %v", err)
 	}
@@ -171,10 +223,47 @@ func TestRenameOver_TransientSharingViolationRetried(t *testing.T) {
 	if len(f.sleeps) != 3 {
 		t.Fatalf("sleeps = %v, want 3", f.sleeps)
 	}
-	for i := 1; i < len(f.sleeps); i++ {
-		if f.sleeps[i] <= f.sleeps[i-1] {
-			t.Fatalf("backoff is not increasing: %v", f.sleeps)
+	for i, d := range f.sleeps {
+		if d != renameRetryDelay {
+			t.Fatalf("sleep %d = %v, want the fixed %v delay", i, d, renameRetryDelay)
 		}
+	}
+}
+
+// TestRenameOver_SurvivesLongContentionRun is the F1 regression.
+//
+// The budget is sized on ATTEMPT COUNT, not wall-clock: the tests this fix
+// exists for are 8-way concurrent, so a writer must survive losing many
+// consecutive races. An earlier draft allowed 8 retries with exponential
+// backoff — a bigger wall-clock number and a much worse attempt count. This
+// pins that a writer losing 30 races in a row still lands, which 8 retries
+// cannot do at any delay.
+func TestRenameOver_SurvivesLongContentionRun(t *testing.T) {
+	const losses = 30
+	f := &fakeRename{results: failN(losses)}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver after %d lost races: %v", losses, err)
+	}
+	if f.calls != losses+1 {
+		t.Fatalf("rename calls = %d, want %d", f.calls, losses+1)
+	}
+}
+
+// TestRenameBudget_MatchesInTreePrecedent pins the numbers themselves against
+// internal/graph/groupalgo/atomicrename_windows.go (40 × 5ms ≈ 200ms), whose
+// comment reasons against a FOUR-reader stress test. Eight concurrent writers
+// is strictly heavier load, so dropping below that precedent would be a
+// regression in disguise — and the sizing argument is invisible at the call
+// site, so it is pinned here.
+func TestRenameBudget_MatchesInTreePrecedent(t *testing.T) {
+	if renameRetries < 40 {
+		t.Errorf("renameRetries = %d, want >= 40 (the in-tree precedent, under lighter load)", renameRetries)
+	}
+	if renameRetryDelay > 5*time.Millisecond {
+		t.Errorf("renameRetryDelay = %v, want <= 5ms (the in-tree precedent)", renameRetryDelay)
+	}
+	if total := time.Duration(renameRetries) * renameRetryDelay; total < 200*time.Millisecond || total > time.Second {
+		t.Errorf("total budget = %v, want between 200ms and 1s", total)
 	}
 }
 
@@ -184,7 +273,7 @@ func TestRenameOver_RetryIsBounded(t *testing.T) {
 	f := &fakeRename{results: []error{errDenied}}
 	err := f.ops(allRecoverable).renameOver("tmp", "dst")
 	if !errors.Is(err, errDenied) {
-		t.Fatalf("err = %v, want %v", err, errDenied)
+		t.Fatalf("err = %v, want it to wrap %v", err, errDenied)
 	}
 	if want := renameRetries + 1; f.calls != want {
 		t.Fatalf("rename calls = %d, want %d", f.calls, want)
@@ -192,12 +281,27 @@ func TestRenameOver_RetryIsBounded(t *testing.T) {
 	if len(f.sleeps) != renameRetries {
 		t.Fatalf("sleeps = %d, want %d", len(f.sleeps), renameRetries)
 	}
-	var total time.Duration
-	for _, d := range f.sleeps {
-		total += d
+}
+
+// TestRenameOver_ExhaustionErrorNamesTheAttemptCount is F9. Without it, a
+// budget that is too small and a retry loop that never ran produce byte-
+// identical CI output ("Access is denied"), and the next person debugging
+// windows-latest cannot tell which they are looking at.
+func TestRenameOver_ExhaustionErrorNamesTheAttemptCount(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied}}
+	err := f.ops(allRecoverable).renameOver("tmp", "dst")
+	if err == nil {
+		t.Fatal("want an error")
 	}
-	if total > 2*time.Second {
-		t.Fatalf("total backoff %v exceeds the 2s budget a write may block for", total)
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("err no longer unwraps to the cause: %v", err)
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "attempts") {
+		t.Fatalf("error %q does not report that a retry budget was exhausted", msg)
+	}
+	if !strings.Contains(msg, "41") {
+		t.Fatalf("error %q does not name the attempt count (41)", msg)
 	}
 }
 
@@ -219,7 +323,7 @@ func TestRenameOver_RetryStopsOnNonRecoverableError(t *testing.T) {
 // the attribute (someone else's file, ACL denies us) we must not abandon the
 // write — the failure may still have been the transient kind.
 func TestRenameOver_ReadOnlyClearFailureFallsThroughToRetry(t *testing.T) {
-	f := &fakeRename{results: []error{errDenied, errDenied, nil}, readOnly: true, roSetErr: errors.New("nope")}
+	f := &fakeRename{results: failN(2), readOnly: true, roSetErr: errors.New("nope")}
 	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
 		t.Fatalf("renameOver: %v", err)
 	}
@@ -235,6 +339,9 @@ func TestRenameOver_ReadOnlyClearFailureFallsThroughToRetry(t *testing.T) {
 	if len(f.roSets) != 0 {
 		t.Fatalf("setReadOnly recorded %v despite failing", f.roSets)
 	}
+	if len(f.warns) != 0 {
+		t.Fatalf("warns = %v, want none — nothing was actually cleared", f.warns)
+	}
 }
 
 // TestDefaultRenameOps_Wired guards against the driver being reachable only
@@ -242,7 +349,7 @@ func TestRenameOver_ReadOnlyClearFailureFallsThroughToRetry(t *testing.T) {
 func TestDefaultRenameOps_Wired(t *testing.T) {
 	if defaultRenameOps.rename == nil || defaultRenameOps.isReadOnly == nil ||
 		defaultRenameOps.setReadOnly == nil || defaultRenameOps.recoverable == nil ||
-		defaultRenameOps.sleep == nil {
+		defaultRenameOps.sleep == nil || defaultRenameOps.warn == nil {
 		t.Fatal("defaultRenameOps has a nil primitive")
 	}
 }
@@ -255,6 +362,10 @@ func TestDefaultRenameOps_Wired(t *testing.T) {
 // two apart, and a revert would sail through the whole suite here and only
 // resurface as lost writes on windows-latest. Intercepting the primitive is
 // the only way to bind the wiring on the platform we can actually run.
+//
+// It mutates a package global without synchronisation. See the file header:
+// nothing in this package may call t.Parallel, and
+// TestNoParallelTestsInThisPackage enforces that.
 func TestWriteFile_RoutesThroughRenameAtomic(t *testing.T) {
 	orig := defaultRenameOps.rename
 	t.Cleanup(func() { defaultRenameOps.rename = orig })
@@ -273,5 +384,50 @@ func TestWriteFile_RoutesThroughRenameAtomic(t *testing.T) {
 	if calls != 1 {
 		t.Fatalf("renameAtomic rename calls = %d, want 1 — WriteFile is not going through "+
 			"renameAtomic, so the Windows recovery in rename.go is bypassed", calls)
+	}
+}
+
+// TestNoParallelTestsInThisPackage protects the unsynchronised global swap in
+// TestWriteFile_RoutesThroughRenameAtomic, which is the ONLY test that can
+// catch WriteFile reverting to a bare os.Rename and therefore must not be
+// weakened. Other tests in this package launch 8 concurrent WriteFile
+// goroutines; `go test -race` is green only because Go runs a package's tests
+// sequentially unless they opt in. The first parallel opt-in added here would
+// make that silently untrue, so it is refused rather than merely documented.
+//
+// The needle is assembled at run time so this file — which is itself scanned —
+// contains no literal occurrence of it, and so the guard cannot pass merely by
+// exempting itself.
+func TestNoParallelTestsInThisPackage(t *testing.T) {
+	needle := "t.Paralle" + "l("
+
+	ents, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	scanned, sawSelf := 0, false
+	for _, e := range ents {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(e.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanned++
+		if e.Name() == "rename_test.go" {
+			sawSelf = true
+		}
+		if strings.Contains(string(b), needle) {
+			t.Errorf("%s opts into parallelism: TestWriteFile_RoutesThroughRenameAtomic swaps "+
+				"defaultRenameOps.rename unsynchronised while other tests run concurrent "+
+				"WriteFile goroutines. Guard the global before adding parallelism.", e.Name())
+		}
+	}
+	// A guard that scanned nothing — or that skipped the file holding the
+	// global swap — proves nothing.
+	if scanned == 0 || !sawSelf {
+		t.Fatalf("guard scanned %d test files, saw rename_test.go = %v — wrong working directory?",
+			scanned, sawSelf)
 	}
 }

--- a/internal/atomicfile/rename_test.go
+++ b/internal/atomicfile/rename_test.go
@@ -1,0 +1,247 @@
+package atomicfile
+
+// rename_test.go — the recovery driver around rename, exercised on EVERY
+// platform through injected primitives.
+//
+// The failure this driver exists for only occurs on Windows, and no CI job
+// here can run Windows on demand. So the platform-specific parts are cut down
+// to three tiny predicates (rename_windows.go / rename_other.go) and the whole
+// decision logic lives in rename.go, where these tests drive it directly with
+// fakes. What is NOT covered locally is the errno classification itself and
+// the os.Chmod-clears-FILE_ATTRIBUTE_READONLY mapping; those are asserted only
+// by the end-to-end tests when they run on windows-latest.
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+// fakeRename records calls and replays a scripted sequence of results.
+type fakeRename struct {
+	results  []error // consumed in order; the last one repeats forever
+	calls    int
+	sleeps   []time.Duration
+	readOnly bool
+	roSets   []bool // every setReadOnly(_, v) in order
+	roSetErr error
+	probes   int
+}
+
+func (f *fakeRename) rename(string, string) error {
+	f.calls++
+	if f.calls <= len(f.results) {
+		return f.results[f.calls-1]
+	}
+	if len(f.results) == 0 {
+		return nil
+	}
+	return f.results[len(f.results)-1]
+}
+
+func (f *fakeRename) isReadOnly(string) bool { f.probes++; return f.readOnly }
+
+func (f *fakeRename) setReadOnly(_ string, ro bool) error {
+	if f.roSetErr != nil {
+		return f.roSetErr
+	}
+	f.roSets = append(f.roSets, ro)
+	f.readOnly = ro
+	return nil
+}
+
+func (f *fakeRename) ops(recoverable func(error) bool) renameOps {
+	return renameOps{
+		rename:      f.rename,
+		isReadOnly:  f.isReadOnly,
+		setReadOnly: f.setReadOnly,
+		recoverable: recoverable,
+		sleep:       func(d time.Duration) { f.sleeps = append(f.sleeps, d) },
+	}
+}
+
+var errDenied = errors.New("access is denied")
+
+func allRecoverable(err error) bool { return err != nil }
+func noneRecoverable(error) bool    { return false }
+
+func TestRenameOver_SucceedsFirstTry(t *testing.T) {
+	f := &fakeRename{}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if f.calls != 1 {
+		t.Fatalf("rename calls = %d, want 1", f.calls)
+	}
+	if f.probes != 0 {
+		t.Fatalf("read-only probes = %d, want 0 (the happy path must not stat the destination)", f.probes)
+	}
+	if len(f.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none", f.sleeps)
+	}
+}
+
+// TestRenameOver_NonRecoverableErrorReturnedImmediately pins that the driver
+// does not turn every rename failure into a half-second retry storm. Only the
+// platform-classified sharing/permission errnos are recoverable.
+func TestRenameOver_NonRecoverableErrorReturnedImmediately(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied}}
+	err := f.ops(noneRecoverable).renameOver("tmp", "dst")
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("err = %v, want %v", err, errDenied)
+	}
+	if f.calls != 1 {
+		t.Fatalf("rename calls = %d, want 1", f.calls)
+	}
+	if len(f.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none", f.sleeps)
+	}
+	if len(f.roSets) != 0 {
+		t.Fatalf("setReadOnly calls = %v, want none", f.roSets)
+	}
+}
+
+// TestRenameOver_ReadOnlyDestinationClearedNotSleptOn is the CLASS A read-only
+// case. MoveFileEx(MOVEFILE_REPLACE_EXISTING) — which is exactly what Go's
+// os.Rename is on Windows — fails with ERROR_ACCESS_DENIED forever while the
+// destination carries FILE_ATTRIBUTE_READONLY. Retrying can never fix it, so
+// the driver must clear the attribute and must do so WITHOUT first burning
+// retry budget on sleeps.
+func TestRenameOver_ReadOnlyDestinationClearedNotSleptOn(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied, nil}, readOnly: true}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if f.calls != 2 {
+		t.Fatalf("rename calls = %d, want 2 (fail, clear read-only, succeed)", f.calls)
+	}
+	if len(f.sleeps) != 0 {
+		t.Fatalf("sleeps = %v, want none — a read-only destination is deterministic, not transient", f.sleeps)
+	}
+	if len(f.roSets) != 1 || f.roSets[0] != false {
+		t.Fatalf("setReadOnly calls = %v, want exactly [false]", f.roSets)
+	}
+}
+
+// TestRenameOver_ReadOnlyRestoredWhenReplaceStillFails: clearing the attribute
+// is a mutation of a file we do not own. If the replace still fails we must
+// put it back rather than leave a file the user marked read-only writable.
+func TestRenameOver_ReadOnlyRestoredWhenReplaceStillFails(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied}, readOnly: true}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err == nil {
+		t.Fatal("renameOver: want error, got nil")
+	}
+	if len(f.roSets) != 2 || f.roSets[0] != false || f.roSets[1] != true {
+		t.Fatalf("setReadOnly calls = %v, want [false true] (cleared, then restored)", f.roSets)
+	}
+	if !f.readOnly {
+		t.Fatal("destination left writable after a failed replace")
+	}
+}
+
+// TestRenameOver_ReadOnlyNotRestoredAfterSuccess: the destination is gone —
+// replaced by the temp file — so re-marking it read-only would apply the old
+// flag to the NEW content, which is not what the caller asked for.
+func TestRenameOver_ReadOnlyNotRestoredAfterSuccess(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied, nil}, readOnly: true}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	for i, v := range f.roSets {
+		if v {
+			t.Fatalf("setReadOnly(true) at call %d — must not re-protect a destination we replaced", i)
+		}
+	}
+}
+
+// TestRenameOver_TransientSharingViolationRetried is the CLASS A concurrency
+// case: another handle (a concurrent replacer, an antivirus scanner, the
+// Windows indexer) holds the destination or the temp open without
+// FILE_SHARE_DELETE. It is genuinely transient, and a bounded retry is the
+// only remedy available to us.
+func TestRenameOver_TransientSharingViolationRetried(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied, errDenied, errDenied, nil}}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if f.calls != 4 {
+		t.Fatalf("rename calls = %d, want 4", f.calls)
+	}
+	if len(f.sleeps) != 3 {
+		t.Fatalf("sleeps = %v, want 3", f.sleeps)
+	}
+	for i := 1; i < len(f.sleeps); i++ {
+		if f.sleeps[i] <= f.sleeps[i-1] {
+			t.Fatalf("backoff is not increasing: %v", f.sleeps)
+		}
+	}
+}
+
+// TestRenameOver_RetryIsBounded: the loop must terminate and surface the last
+// error rather than hang a link pass forever.
+func TestRenameOver_RetryIsBounded(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied}}
+	err := f.ops(allRecoverable).renameOver("tmp", "dst")
+	if !errors.Is(err, errDenied) {
+		t.Fatalf("err = %v, want %v", err, errDenied)
+	}
+	if want := renameRetries + 1; f.calls != want {
+		t.Fatalf("rename calls = %d, want %d", f.calls, want)
+	}
+	if len(f.sleeps) != renameRetries {
+		t.Fatalf("sleeps = %d, want %d", len(f.sleeps), renameRetries)
+	}
+	var total time.Duration
+	for _, d := range f.sleeps {
+		total += d
+	}
+	if total > 2*time.Second {
+		t.Fatalf("total backoff %v exceeds the 2s budget a write may block for", total)
+	}
+}
+
+// TestRenameOver_RetryStopsOnNonRecoverableError: once the error class changes
+// (say the directory was removed underneath us) the driver must stop.
+func TestRenameOver_RetryStopsOnNonRecoverableError(t *testing.T) {
+	other := errors.New("no such directory")
+	f := &fakeRename{results: []error{errDenied, errDenied, other}}
+	err := f.ops(func(e error) bool { return errors.Is(e, errDenied) }).renameOver("tmp", "dst")
+	if !errors.Is(err, other) {
+		t.Fatalf("err = %v, want %v", err, other)
+	}
+	if f.calls != 3 {
+		t.Fatalf("rename calls = %d, want 3", f.calls)
+	}
+}
+
+// TestRenameOver_ReadOnlyClearFailureFallsThroughToRetry: if we cannot clear
+// the attribute (someone else's file, ACL denies us) we must not abandon the
+// write — the failure may still have been the transient kind.
+func TestRenameOver_ReadOnlyClearFailureFallsThroughToRetry(t *testing.T) {
+	f := &fakeRename{results: []error{errDenied, errDenied, nil}, readOnly: true, roSetErr: errors.New("nope")}
+	if err := f.ops(allRecoverable).renameOver("tmp", "dst"); err != nil {
+		t.Fatalf("renameOver: %v", err)
+	}
+	if f.calls != 3 {
+		t.Fatalf("rename calls = %d, want 3", f.calls)
+	}
+	// The read-only branch is skipped entirely when the clear fails, so both
+	// remaining attempts come from the retry loop and each is preceded by a
+	// sleep.
+	if len(f.sleeps) != 2 {
+		t.Fatalf("sleeps = %v, want 2", f.sleeps)
+	}
+	if len(f.roSets) != 0 {
+		t.Fatalf("setReadOnly recorded %v despite failing", f.roSets)
+	}
+}
+
+// TestDefaultRenameOps_Wired guards against the driver being reachable only
+// through the fakes: renameAtomic must actually run the real primitives.
+func TestDefaultRenameOps_Wired(t *testing.T) {
+	if defaultRenameOps.rename == nil || defaultRenameOps.isReadOnly == nil ||
+		defaultRenameOps.setReadOnly == nil || defaultRenameOps.recoverable == nil ||
+		defaultRenameOps.sleep == nil {
+		t.Fatal("defaultRenameOps has a nil primitive")
+	}
+}

--- a/internal/atomicfile/rename_test.go
+++ b/internal/atomicfile/rename_test.go
@@ -13,6 +13,7 @@ package atomicfile
 
 import (
 	"errors"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -243,5 +244,34 @@ func TestDefaultRenameOps_Wired(t *testing.T) {
 		defaultRenameOps.setReadOnly == nil || defaultRenameOps.recoverable == nil ||
 		defaultRenameOps.sleep == nil {
 		t.Fatal("defaultRenameOps has a nil primitive")
+	}
+}
+
+// TestWriteFile_RoutesThroughRenameAtomic is the one test that can notice
+// WriteFile going back to a bare os.Rename.
+//
+// On unix renameAtomic IS a single os.Rename — the recovery is compiled to
+// constant-false predicates — so no black-box test off Windows can tell the
+// two apart, and a revert would sail through the whole suite here and only
+// resurface as lost writes on windows-latest. Intercepting the primitive is
+// the only way to bind the wiring on the platform we can actually run.
+func TestWriteFile_RoutesThroughRenameAtomic(t *testing.T) {
+	orig := defaultRenameOps.rename
+	t.Cleanup(func() { defaultRenameOps.rename = orig })
+
+	calls := 0
+	defaultRenameOps.rename = func(oldpath, newpath string) error {
+		calls++
+		return orig(oldpath, newpath)
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "out.json")
+	if err := WriteFile(path, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("renameAtomic rename calls = %d, want 1 — WriteFile is not going through "+
+			"renameAtomic, so the Windows recovery in rename.go is bypassed", calls)
 	}
 }

--- a/internal/atomicfile/rename_windows.go
+++ b/internal/atomicfile/rename_windows.go
@@ -4,36 +4,47 @@ package atomicfile
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
-// The Win32 codes MoveFileEx returns for the two failures in rename.go.
-// Declared here rather than taken from golang.org/x/sys/windows so this
-// package keeps its stdlib-only dependency set (package syscall on Windows
-// does not export the sharing/lock codes).
-const (
-	errorAccessDenied     = syscall.Errno(5)  // ERROR_ACCESS_DENIED
-	errorSharingViolation = syscall.Errno(32) // ERROR_SHARING_VIOLATION
-	errorLockViolation    = syscall.Errno(33) // ERROR_LOCK_VIOLATION
-)
-
-// renameErrRecoverable reports whether err is one of the two failures
-// renameOver knows how to recover from. ERROR_ACCESS_DENIED covers both: it is
-// what REPLACE_EXISTING returns for a read-only destination AND what a
-// no-FILE_SHARE_DELETE opener produces, so the driver tries the deterministic
-// remedy first and falls through to the retry.
+// renameErrRecoverable reports whether err is one of the failures renameOver
+// knows how to recover from.
 //
-// Everything else — ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
-// ERROR_NOT_SAME_DEVICE — is a real error and must surface immediately.
+// Deliberately identical to the five existing copies of this predicate
+// (internal/graph/{groupalgo,descriptions,flows}.isSharingOrAccessError,
+// internal/install.isAccessOrSharingError,
+// internal/statusfile.isRetryableReplaceError) rather than a sixth dialect:
+// same fs.ErrPermission first test, same three golang.org/x/sys/windows
+// constants. An earlier draft hand-declared syscall.Errno(5/32/33) to keep
+// this package stdlib-only — a bad trade, since golang.org/x/sys is already a
+// direct go.mod requirement and internal/process (which this PR's reaper fix
+// now leans on) imports it too.
+//
+// ERROR_ACCESS_DENIED covers both failure modes: it is what REPLACE_EXISTING
+// returns for a read-only destination AND what a no-FILE_SHARE_DELETE opener
+// produces, so renameOver tries the deterministic remedy first and falls
+// through to the retry. Everything else — ERROR_FILE_NOT_FOUND,
+// ERROR_PATH_NOT_FOUND, ERROR_NOT_SAME_DEVICE — is a real error and must
+// surface immediately.
 func renameErrRecoverable(err error) bool {
-	var errno syscall.Errno
-	if !errors.As(err, &errno) {
+	if err == nil {
 		return false
 	}
-	switch errno {
-	case errorAccessDenied, errorSharingViolation, errorLockViolation:
+	if errors.Is(err, fs.ErrPermission) {
 		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case windows.ERROR_ACCESS_DENIED,
+			windows.ERROR_SHARING_VIOLATION,
+			windows.ERROR_LOCK_VIOLATION:
+			return true
+		}
 	}
 	return false
 }
@@ -43,8 +54,9 @@ func renameErrRecoverable(err error) bool {
 // Go's Windows os.Stat reports exactly two permission values — 0444 for a file
 // with the read-only attribute and 0666 for one without — so the owner-write
 // bit is a faithful reading of the attribute. Using os.Stat/os.Chmod rather
-// than GetFileAttributes/SetFileAttributesW keeps this to the stdlib and to
-// the same mapping os.Chmod uses on the way back out.
+// than GetFileAttributes/SetFileAttributesW keeps the read and the write on
+// one mapping: syscall.Chmod toggles FILE_ATTRIBUTE_READONLY off the S_IWRITE
+// bit, which is precisely the bit tested here.
 func destIsReadOnly(path string) bool {
 	fi, err := os.Stat(path)
 	if err != nil {

--- a/internal/atomicfile/rename_windows.go
+++ b/internal/atomicfile/rename_windows.go
@@ -1,0 +1,62 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// The Win32 codes MoveFileEx returns for the two failures in rename.go.
+// Declared here rather than taken from golang.org/x/sys/windows so this
+// package keeps its stdlib-only dependency set (package syscall on Windows
+// does not export the sharing/lock codes).
+const (
+	errorAccessDenied     = syscall.Errno(5)  // ERROR_ACCESS_DENIED
+	errorSharingViolation = syscall.Errno(32) // ERROR_SHARING_VIOLATION
+	errorLockViolation    = syscall.Errno(33) // ERROR_LOCK_VIOLATION
+)
+
+// renameErrRecoverable reports whether err is one of the two failures
+// renameOver knows how to recover from. ERROR_ACCESS_DENIED covers both: it is
+// what REPLACE_EXISTING returns for a read-only destination AND what a
+// no-FILE_SHARE_DELETE opener produces, so the driver tries the deterministic
+// remedy first and falls through to the retry.
+//
+// Everything else — ERROR_FILE_NOT_FOUND, ERROR_PATH_NOT_FOUND,
+// ERROR_NOT_SAME_DEVICE — is a real error and must surface immediately.
+func renameErrRecoverable(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+	switch errno {
+	case errorAccessDenied, errorSharingViolation, errorLockViolation:
+		return true
+	}
+	return false
+}
+
+// destIsReadOnly reports whether path carries FILE_ATTRIBUTE_READONLY.
+//
+// Go's Windows os.Stat reports exactly two permission values — 0444 for a file
+// with the read-only attribute and 0666 for one without — so the owner-write
+// bit is a faithful reading of the attribute. Using os.Stat/os.Chmod rather
+// than GetFileAttributes/SetFileAttributesW keeps this to the stdlib and to
+// the same mapping os.Chmod uses on the way back out.
+func destIsReadOnly(path string) bool {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return false // missing destination: nothing to clear.
+	}
+	return fi.Mode().IsRegular() && fi.Mode().Perm()&0o200 == 0
+}
+
+// setDestReadOnly sets or clears FILE_ATTRIBUTE_READONLY on path.
+func setDestReadOnly(path string, ro bool) error {
+	if ro {
+		return os.Chmod(path, 0o444)
+	}
+	return os.Chmod(path, 0o666)
+}

--- a/internal/atomicfile/rename_windows_test.go
+++ b/internal/atomicfile/rename_windows_test.go
@@ -4,24 +4,38 @@ package atomicfile
 
 import (
 	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
+
+	"golang.org/x/sys/windows"
 )
 
-// TestRenameErrRecoverable_Windows pins the errno classification. Only the
-// three "someone else is holding this / the flag says no" codes are
-// recoverable; everything else must surface immediately.
+// TestRenameErrRecoverable_Windows pins the errno classification: only the
+// three "someone else is holding this / the flag says no" codes, plus the
+// fs.ErrPermission form Go sometimes surfaces instead, are recoverable.
+// Everything else must surface immediately.
 func TestRenameErrRecoverable_Windows(t *testing.T) {
-	for _, e := range []syscall.Errno{errorAccessDenied, errorSharingViolation, errorLockViolation} {
+	for _, e := range []syscall.Errno{
+		windows.ERROR_ACCESS_DENIED,
+		windows.ERROR_SHARING_VIOLATION,
+		windows.ERROR_LOCK_VIOLATION,
+	} {
 		if !renameErrRecoverable(&os.LinkError{Op: "rename", Err: e}) {
 			t.Errorf("renameErrRecoverable(errno %d) = false, want true", uintptr(e))
 		}
 	}
+	if !renameErrRecoverable(&os.LinkError{Op: "rename", Err: fs.ErrPermission}) {
+		t.Error("renameErrRecoverable(fs.ErrPermission) = false, want true")
+	}
+
 	for _, err := range []error{
-		&os.LinkError{Op: "rename", Err: syscall.Errno(2)}, // ERROR_FILE_NOT_FOUND
-		&os.LinkError{Op: "rename", Err: syscall.Errno(3)}, // ERROR_PATH_NOT_FOUND
+		nil,
+		&os.LinkError{Op: "rename", Err: syscall.Errno(2)},  // ERROR_FILE_NOT_FOUND
+		&os.LinkError{Op: "rename", Err: syscall.Errno(3)},  // ERROR_PATH_NOT_FOUND
+		&os.LinkError{Op: "rename", Err: syscall.Errno(17)}, // ERROR_NOT_SAME_DEVICE
 		errors.New("not an errno"),
 	} {
 		if renameErrRecoverable(err) {
@@ -31,8 +45,8 @@ func TestRenameErrRecoverable_Windows(t *testing.T) {
 }
 
 // TestDestReadOnly_WindowsRoundTrip pins the mapping this fix depends on: Go's
-// Windows os.Stat reports 0444 for FILE_ATTRIBUTE_READONLY and 0666 otherwise,
-// and os.Chmod with a write bit clears the attribute.
+// Windows os.Stat reports 0444 for FILE_ATTRIBUTE_READONLY and 0666
+// otherwise, and os.Chmod with a write bit clears the attribute.
 func TestDestReadOnly_WindowsRoundTrip(t *testing.T) {
 	dir := t.TempDir()
 	p := filepath.Join(dir, "ro.json")
@@ -64,5 +78,14 @@ func TestDestReadOnly_WindowsRoundTrip(t *testing.T) {
 func TestDestReadOnly_MissingDestination(t *testing.T) {
 	if destIsReadOnly(filepath.Join(t.TempDir(), "absent")) {
 		t.Fatal("destIsReadOnly(missing) = true, want false")
+	}
+}
+
+// TestDestReadOnly_Directory: renameOver probes the destination path, which
+// may be a directory (WriteFile over a directory is an error path the suite
+// exercises). A directory must never be treated as a read-only file to clear.
+func TestDestReadOnly_Directory(t *testing.T) {
+	if destIsReadOnly(t.TempDir()) {
+		t.Fatal("destIsReadOnly(directory) = true, want false")
 	}
 }

--- a/internal/atomicfile/rename_windows_test.go
+++ b/internal/atomicfile/rename_windows_test.go
@@ -1,0 +1,68 @@
+//go:build windows
+
+package atomicfile
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+)
+
+// TestRenameErrRecoverable_Windows pins the errno classification. Only the
+// three "someone else is holding this / the flag says no" codes are
+// recoverable; everything else must surface immediately.
+func TestRenameErrRecoverable_Windows(t *testing.T) {
+	for _, e := range []syscall.Errno{errorAccessDenied, errorSharingViolation, errorLockViolation} {
+		if !renameErrRecoverable(&os.LinkError{Op: "rename", Err: e}) {
+			t.Errorf("renameErrRecoverable(errno %d) = false, want true", uintptr(e))
+		}
+	}
+	for _, err := range []error{
+		&os.LinkError{Op: "rename", Err: syscall.Errno(2)}, // ERROR_FILE_NOT_FOUND
+		&os.LinkError{Op: "rename", Err: syscall.Errno(3)}, // ERROR_PATH_NOT_FOUND
+		errors.New("not an errno"),
+	} {
+		if renameErrRecoverable(err) {
+			t.Errorf("renameErrRecoverable(%v) = true, want false", err)
+		}
+	}
+}
+
+// TestDestReadOnly_WindowsRoundTrip pins the mapping this fix depends on: Go's
+// Windows os.Stat reports 0444 for FILE_ATTRIBUTE_READONLY and 0666 otherwise,
+// and os.Chmod with a write bit clears the attribute.
+func TestDestReadOnly_WindowsRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "ro.json")
+	if err := os.WriteFile(p, []byte("x"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if !destIsReadOnly(p) {
+		t.Fatal("destIsReadOnly(0444) = false, want true on windows")
+	}
+	if err := setDestReadOnly(p, false); err != nil {
+		t.Fatalf("setDestReadOnly(false): %v", err)
+	}
+	if destIsReadOnly(p) {
+		t.Fatal("read-only attribute survived setDestReadOnly(false)")
+	}
+	if err := setDestReadOnly(p, true); err != nil {
+		t.Fatalf("setDestReadOnly(true): %v", err)
+	}
+	if !destIsReadOnly(p) {
+		t.Fatal("read-only attribute not restored by setDestReadOnly(true)")
+	}
+	// Leave it writable so t.TempDir cleanup can remove it.
+	_ = setDestReadOnly(p, false)
+}
+
+// TestDestReadOnly_MissingDestination: WriteFile's common case is a
+// destination that does not exist yet. The probe must not claim read-only for
+// a file that is not there.
+func TestDestReadOnly_MissingDestination(t *testing.T) {
+	if destIsReadOnly(filepath.Join(t.TempDir(), "absent")) {
+		t.Fatal("destIsReadOnly(missing) = true, want false")
+	}
+}

--- a/internal/daemon/guard_6053_liveness_test.go
+++ b/internal/daemon/guard_6053_liveness_test.go
@@ -1,0 +1,65 @@
+package daemon
+
+// guard_6053_liveness_test.go — no private process-liveness probes in this
+// package's production code.
+//
+// #6053: reaper.go carried its own pidAliveProbe, a signal-0 existence check
+// whose own doc comment said "portable on darwin/linux". On Windows
+// (*os.Process).Signal returns EWINDOWS for anything but Kill, so that probe
+// answered "dead" for EVERY live pid. watchreg.Sweep checks !Alive BEFORE the
+// ownership comparison, so on Windows every registered `grafel watch` entry
+// was classified dead and dropped each sweep — the daemon lost its whole
+// watcher inventory, and the fail-closed orphan contract #5933 established was
+// unreachable dead code there. internal/process.IsAlive has had a correct
+// OpenProcess/GetExitCodeProcess implementation for Windows all along;
+// pidfile.go's pidAlive already used it, the reaper did not.
+//
+// The behavioural difference is invisible on unix — both probes are right
+// there — so no unix test can catch a reintroduction, which is exactly how the
+// second copy survived review. This guard can: it fails the moment a signal-0
+// liveness probe reappears in package daemon. The platform split belongs in
+// internal/process and nowhere else.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestNoPrivateSignalZeroLivenessProbe(t *testing.T) {
+	ents, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scanned := 0
+	sawReaper := false
+	for _, e := range ents {
+		name := e.Name()
+		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		b, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		scanned++
+		if name == "reaper.go" {
+			sawReaper = true
+		}
+		src := string(b)
+		for _, needle := range []string{"syscall.Signal(0)", "syscall.Signal(0x0)"} {
+			if strings.Contains(src, needle) {
+				t.Errorf("%s contains %q — a signal-0 liveness probe always reports DEAD "+
+					"on Windows. Use process.IsAlive (pidAlive); the platform split lives "+
+					"in internal/process (#6053).", name, needle)
+			}
+		}
+	}
+
+	// A guard that scanned nothing proves nothing.
+	if scanned == 0 || !sawReaper {
+		t.Fatalf("guard scanned %d production files and %s reaper.go — wrong working directory?",
+			scanned, map[bool]string{true: "saw", false: "did not see"}[sawReaper])
+	}
+}

--- a/internal/daemon/guard_6053_liveness_test.go
+++ b/internal/daemon/guard_6053_liveness_test.go
@@ -1,7 +1,7 @@
 package daemon
 
-// guard_6053_liveness_test.go — no private process-liveness probes in this
-// package's production code.
+// guard_6053_liveness_test.go — no private process-liveness probes anywhere
+// under internal/.
 //
 // #6053: reaper.go carried its own pidAliveProbe, a signal-0 existence check
 // whose own doc comment said "portable on darwin/linux". On Windows
@@ -11,55 +11,126 @@ package daemon
 // was classified dead and dropped each sweep — the daemon lost its whole
 // watcher inventory, and the fail-closed orphan contract #5933 established was
 // unreachable dead code there. internal/process.IsAlive has had a correct
-// OpenProcess/GetExitCodeProcess implementation for Windows all along;
-// pidfile.go's pidAlive already used it, the reaper did not.
+// OpenProcess/GetExitCodeProcess implementation all along; pidfile.go's
+// pidAlive already used it, the reaper did not.
 //
-// The behavioural difference is invisible on unix — both probes are right
-// there — so no unix test can catch a reintroduction, which is exactly how the
-// second copy survived review. This guard can: it fails the moment a signal-0
-// liveness probe reappears in package daemon. The platform split belongs in
-// internal/process and nowhere else.
+// On unix the two probes differ in exactly one case (EPERM — see
+// reaper_eperm_unix_test.go) and agree on everything a unix test can easily
+// construct, so no behavioural test here catches a reintroduction on the
+// platform CI mostly runs. That is how the second copy survived review. This
+// guard catches it.
+//
+// Scope: the WHOLE of internal/, walked from the module root, not just
+// package daemon's own directory. daemon/{watch,watchreg,sched,service,...}
+// are at least as likely a place for a third copy to appear, and the original
+// bug was one package away from the correct helper already. internal/process
+// is the one exemption: the platform split belongs there and nowhere else.
 
 import (
+	"io/fs"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
 
 func TestNoPrivateSignalZeroLivenessProbe(t *testing.T) {
-	ents, err := os.ReadDir(".")
-	if err != nil {
-		t.Fatal(err)
+	root := moduleRoot(t)
+	internal := filepath.Join(root, "internal")
+
+	// The signal-ZERO idiom in the forms it appears in Go code.
+	//
+	// Scoped to signal 0 on purpose: syscall.Kill with a REAL signal is
+	// legitimate and pre-existing in this tree (sched/nice_unix.go and
+	// supervise_unix.go SIGKILL a process group, on //go:build !windows
+	// files). Only the zero-signal EXISTENCE PROBE is the portability defect,
+	// so a broader "no raw Kill" rule would be three false positives and would
+	// be deleted by the next person rather than obeyed.
+	//
+	// Patterns are compiled from fragments so this file — which lives under
+	// internal/ and is therefore in scope — holds no literal occurrence and
+	// cannot pass merely by exempting itself.
+	sig := `syscall\.Signal\(`
+	pats := []*regexp.Regexp{
+		regexp.MustCompile(sig + `0x?0*\)`), // p.Signal(syscall.Signal(0))
+		regexp.MustCompile(`(?:syscall|unix)\.Kill\([^,]+,\s*` + // syscall.Kill(pid, 0)
+			`(?:0x?0*|` + sig + `0x?0*\))\)`),
 	}
+
+	exempt := filepath.Join(internal, "process")
 
 	scanned := 0
 	sawReaper := false
-	for _, e := range ents {
-		name := e.Name()
-		if e.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
-			continue
-		}
-		b, err := os.ReadFile(name)
+	err := filepath.WalkDir(internal, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			t.Fatal(err)
+			return err
+		}
+		if d.IsDir() {
+			if path == exempt || d.Name() == "testdata" {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+			return nil
+		}
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
 		}
 		scanned++
-		if name == "reaper.go" {
+		rel, _ := filepath.Rel(root, path)
+		if rel == filepath.Join("internal", "daemon", "reaper.go") {
 			sawReaper = true
 		}
-		src := string(b)
-		for _, needle := range []string{"syscall.Signal(0)", "syscall.Signal(0x0)"} {
-			if strings.Contains(src, needle) {
-				t.Errorf("%s contains %q — a signal-0 liveness probe always reports DEAD "+
-					"on Windows. Use process.IsAlive (pidAlive); the platform split lives "+
-					"in internal/process (#6053).", name, needle)
+		for i, line := range strings.Split(string(b), "\n") {
+			// Match code, not prose: pidfile.go's doc comment legitimately
+			// spells out the portable idiom. Cutting at "//" can also clip a
+			// "//" inside a string literal, which would only make the guard
+			// more permissive on that one line — acceptable, since a signal-0
+			// probe hidden in a string is not the reintroduction this guards.
+			if c := strings.Index(line, "//"); c >= 0 {
+				line = line[:c]
+			}
+			for _, re := range pats {
+				if re.MatchString(line) {
+					t.Errorf("%s:%d contains a signal-0 liveness probe (%q) — it always reports "+
+						"DEAD on Windows. Use process.IsAlive; the platform split lives in "+
+						"internal/process (#6053).", rel, i+1, strings.TrimSpace(line))
+				}
 			}
 		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk internal/: %v", err)
 	}
 
-	// A guard that scanned nothing proves nothing.
-	if scanned == 0 || !sawReaper {
-		t.Fatalf("guard scanned %d production files and %s reaper.go — wrong working directory?",
-			scanned, map[bool]string{true: "saw", false: "did not see"}[sawReaper])
+	// A guard that scanned nothing, or that missed the very file the defect
+	// was in, proves nothing.
+	if scanned < 100 || !sawReaper {
+		t.Fatalf("guard scanned %d production files under internal/ and saw reaper.go = %v "+
+			"— the scan is not reaching the tree it claims to cover", scanned, sawReaper)
+	}
+}
+
+// moduleRoot walks up from the test's working directory to the directory
+// holding go.mod.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatal("no go.mod found above the test working directory")
+		}
+		dir = parent
 	}
 }

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -32,7 +32,6 @@ import (
 	"errors"
 	"log/slog"
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
@@ -278,9 +277,16 @@ func (r *Reaper) Sweep() ReapResult {
 // live-but-orphaned watchers (owned by a previous daemon generation). Returns
 // the number of entries reaped. A nil WatchRegistry disables the sweep.
 //
-// Liveness uses the same signal-0 probe as the daemon pidfile; the kill is a
-// SIGTERM (graceful — the watcher's signal handler exits cleanly). Both are
-// injected as functions only in tests; production uses the real syscalls.
+// Liveness uses pidAlive — internal/process.IsAlive — the SAME probe as the
+// daemon pidfile, and the only one that is correct on every platform. It used
+// to be a private signal-0 copy (pidAliveProbe), which on Windows returns
+// EWINDOWS for every pid and therefore reported every live watcher DEAD: the
+// !Alive branch in watchreg.Sweep runs before the ownership check, so the
+// whole of #5933's fail-closed orphan contract was unreachable there and the
+// daemon silently dropped its entire watcher inventory each sweep (#6053).
+// The kill is a SIGTERM (graceful — the watcher's signal handler exits
+// cleanly). Both are injected as functions only in tests; production uses the
+// real syscalls.
 func (r *Reaper) sweepWatchers() int {
 	if r.cfg.WatchRegistry == nil {
 		return 0
@@ -307,7 +313,7 @@ func (r *Reaper) sweepWatchers() int {
 		liveDaemonPID = func() int { return live }
 	}
 	res, err := r.cfg.WatchRegistry.Sweep(watchreg.SweepDeps{
-		Alive:         pidAliveProbe,
+		Alive:         pidAlive,
 		Kill:          sigtermPID,
 		LiveDaemonPID: liveDaemonPID,
 	})
@@ -388,19 +394,6 @@ func (r *Reaper) sweepForeignWatchers() int {
 			"reaped", reaped, "foreign", len(plan.Foreign), "duplicate", len(plan.Duplicate))
 	}
 	return reaped
-}
-
-// pidAliveProbe reports whether pid names a live process (signal-0 existence
-// probe; portable on darwin/linux).
-func pidAliveProbe(pid int) bool {
-	if pid <= 0 {
-		return false
-	}
-	p, err := os.FindProcess(pid)
-	if err != nil {
-		return false
-	}
-	return p.Signal(syscall.Signal(0)) == nil
 }
 
 // sigtermPID sends SIGTERM to pid via the process package's portable Kill.

--- a/internal/daemon/reaper_eperm_unix_test.go
+++ b/internal/daemon/reaper_eperm_unix_test.go
@@ -1,0 +1,89 @@
+//go:build !windows
+
+package daemon
+
+// reaper_eperm_unix_test.go — the ONE unix-visible behaviour change in the
+// #6053 reaper fix, named rather than left as a footnote.
+//
+// The claim "swapping pidAliveProbe for pidAlive is invisible on unix" is
+// false in exactly one case, and the difference is worth stating because it
+// changes what the reaper does to a real class of process:
+//
+//	old pidAliveProbe: return p.Signal(syscall.Signal(0)) == nil  → EPERM means DEAD
+//	new process.IsAlive (isalive_unix.go:31): ... || err == EPERM → EPERM means ALIVE
+//
+// EPERM is returned for a pid that EXISTS but belongs to another uid — the
+// kernel had to look it up in order to deny us. Zombies, pid <= 0 and
+// pid-reuse behave identically under both; only foreign-uid pids differ.
+//
+// Consequence for a foreign-uid `grafel watch` entry on darwin/linux:
+//
+//   - before: classified Dead, dropped from the registry silently.
+//   - after:  classified Alive, so it reaches the ownership check. If its
+//     owner PID does not match the live daemon it is treated as an orphan and
+//     SIGTERMed (which fails with EPERM and is recorded in KillErrors, so the
+//     failure is visible); if the owner does match, it is kept.
+//
+// The new behaviour is the deliberate one: "exists but not ours" is a fact we
+// should surface, not silently forget, and it matches every other IsAlive call
+// site in the tree. Do not "fix" this back.
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// TestPidAlive_ForeignUidPidCountsAsAlive pins the EPERM semantics against a
+// real foreign-uid process. pid 1 (init/launchd) is root-owned and always
+// running, so as a non-root user the signal-0 probe returns EPERM: the exact
+// input on which the old and new probes disagree.
+func TestPidAlive_ForeignUidPidCountsAsAlive(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: signalling pid 1 is permitted, so EPERM cannot be produced")
+	}
+
+	// Establish that this fixture really does exercise EPERM rather than
+	// quietly testing an ordinary live pid — otherwise it proves nothing.
+	p, err := os.FindProcess(1)
+	if err != nil {
+		t.Fatalf("FindProcess(1): %v", err)
+	}
+	if err := p.Signal(syscall.Signal(0)); err != syscall.EPERM {
+		t.Skipf("signal-0 on pid 1 returned %v, not EPERM; no foreign-uid pid available here", err)
+	}
+
+	// The old probe would have said false here. That is the regression.
+	if !pidAlive(1) {
+		t.Fatal("pidAlive(1) = false for a live root-owned process — the reaper is back on the " +
+			"signal-0 probe, and a foreign-uid watcher would be silently dropped from the registry")
+	}
+}
+
+// TestPidAlive_AgreesOnTheUnambiguousCases pins that the swap changed ONLY the
+// EPERM case: a pid that is ours and running is alive, and the invalid pids
+// are dead under both probes.
+func TestPidAlive_AgreesOnTheUnambiguousCases(t *testing.T) {
+	if !pidAlive(os.Getpid()) {
+		t.Error("pidAlive(self) = false, want true")
+	}
+	for _, pid := range []int{0, -1, -12345} {
+		if pidAlive(pid) {
+			t.Errorf("pidAlive(%d) = true, want false", pid)
+		}
+	}
+}
+
+// TestReaperUsesTheSharedProbe binds the reaper's Alive dependency to
+// internal/process rather than to any local copy: same answers on every input
+// the two could disagree about.
+func TestReaperUsesTheSharedProbe(t *testing.T) {
+	for _, pid := range []int{os.Getpid(), 1, 0, -1} {
+		if got, want := pidAlive(pid), process.IsAlive(pid); got != want {
+			t.Errorf("pidAlive(%d) = %v, process.IsAlive(%d) = %v — the daemon has diverged "+
+				"from the shared probe", pid, got, pid, want)
+		}
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -611,7 +611,7 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	_ = os.Remove(cfg.Layout.SocketPath)
 
 	logger.Info("startup: socket-listen begin", "socket", cfg.Layout.SocketPath)
-	listener, err := transport.Listen(cfg.Layout.SocketPath)
+	listener, err := listenFn(cfg.Layout.SocketPath)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", cfg.Layout.SocketPath, err)
 	}
@@ -796,15 +796,31 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	// accepted connection's handler returns, and Rebuild has no shutdown/
 	// ctx.Done case in its own select.
 	//
-	// The close itself is bounded by the transport (see transport.closeBounded):
-	// go-winio's named-pipe listener could otherwise block here forever, which
-	// meant `grafel stop` never completed on Windows — the #6044 symptom. If the
-	// transport could not confirm the close we say so rather than swallow it,
-	// because the alternative is a silent recurrence.
+	// Two separate hazards live in these few lines on Windows, and bounding only
+	// the first would move the hang down one line rather than remove it.
+	//
+	//  1. listener.Close() itself. go-winio's named-pipe listener can block
+	//     indefinitely (see transport.closeBounded), which meant `grafel stop`
+	//     never completed — the #6044 symptom. The transport now bounds it and
+	//     reports a close it could not confirm rather than swallowing it.
+	//
+	//  2. <-acceptDone. This used to be a bare receive. When the close is NOT
+	//     confirmed the listener is by definition still live, so go-winio's
+	//     listenerRoutine can still accept the accept-loop's next handoff and
+	//     park waiting for a client that never arrives; Accept never returns,
+	//     acceptLoop never closes acceptDone, and shutdown wedges here instead.
+	//     The watchdog case is what actually makes this step finite. Falling
+	//     through on watchdogCtx.Done() lands in the select below, which takes
+	//     its already-closed watchdog case and force-exits — the intended
+	//     terminal path.
 	if err := listener.Close(); err != nil {
 		logger.Warn("graceful shutdown: listener close not confirmed", "err", err)
 	}
-	<-acceptDone
+	select {
+	case <-acceptDone:
+	case <-watchdogCtx.Done():
+		logger.Warn("graceful shutdown: accept loop did not stop before the watchdog expired")
+	}
 	connDone := make(chan struct{})
 	go func() {
 		connWG.Wait()
@@ -854,6 +870,27 @@ func SetShutdownExitFuncForTest(f func(int)) (restore func()) {
 	prev := osExit
 	osExit = f
 	return func() { osExit = prev }
+}
+
+// listenFn is the seam through which Run obtains its RPC listener. It exists
+// so a test can inject a listener whose Close does not actually unblock
+// Accept — the "close not confirmed" shape that transport.closeBounded can
+// legitimately return on Windows, and which used to wedge Run at its bare
+// `<-acceptDone` receive. That behaviour is unreachable with a real
+// net.UnixListener, whose Close always unblocks Accept, so on Unix it can only
+// be exercised through a seam.
+var listenFn = transport.Listen
+
+// SetListenFuncForTest overrides the listener constructor for the duration of
+// a test and returns a restore closure. Same rationale and constraints as
+// SetShutdownExitFuncForTest above: tests live in package daemon_test, so an
+// exported hook is the only way in.
+//
+// Production code must never call this.
+func SetListenFuncForTest(f func(string) (net.Listener, error)) (restore func()) {
+	prev := listenFn
+	listenFn = f
+	return func() { listenFn = prev }
 }
 
 // mcpDrainTimeout bounds how long graceful shutdown waits for in-flight MCP

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -795,7 +795,15 @@ func run(ctx context.Context, cfg Config, plane daemonPlaneMode) error {
 	// forever behind a stalled Rebuild RPC: connWG.Wait() blocks until every
 	// accepted connection's handler returns, and Rebuild has no shutdown/
 	// ctx.Done case in its own select.
-	_ = listener.Close()
+	//
+	// The close itself is bounded by the transport (see transport.closeBounded):
+	// go-winio's named-pipe listener could otherwise block here forever, which
+	// meant `grafel stop` never completed on Windows — the #6044 symptom. If the
+	// transport could not confirm the close we say so rather than swallow it,
+	// because the alternative is a silent recurrence.
+	if err := listener.Close(); err != nil {
+		logger.Warn("graceful shutdown: listener close not confirmed", "err", err)
+	}
 	<-acceptDone
 	connDone := make(chan struct{})
 	go func() {

--- a/internal/daemon/shutdown_accept_bound_test.go
+++ b/internal/daemon/shutdown_accept_bound_test.go
@@ -1,0 +1,167 @@
+package daemon_test
+
+// shutdown_accept_bound_test.go pins the SECOND of the two Windows shutdown
+// hazards in Run()'s graceful-shutdown tail.
+//
+// Bounding listener.Close() alone (transport.closeBounded) is not enough. When
+// that close is NOT confirmed the listener is by definition still live, so
+// go-winio's listenerRoutine can still take the accept loop's next handoff and
+// park waiting for a client that never arrives. Accept never returns,
+// acceptLoop never closes acceptDone, and Run's `<-acceptDone` — which used to
+// be a bare channel receive sitting BEFORE the watchdog select — wedges
+// forever. The hang simply moved down one line.
+//
+// A real net.UnixListener cannot exhibit this: its Close always unblocks
+// Accept. So the shape is injected through daemon.SetListenFuncForTest, using
+// a listener that delegates Accept to a real one but whose Close deliberately
+// does not release it — precisely what an unconfirmed close looks like.
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/daemon/transport"
+)
+
+// unconfirmedCloseListener wraps a real listener. Accept and Addr delegate, so
+// the daemon starts and serves normally. Close reports failure WITHOUT closing
+// the underlying listener, leaving Accept blocked exactly as a wedged
+// go-winio listenerRoutine would.
+type unconfirmedCloseListener struct {
+	net.Listener
+	closes atomic.Int32
+	// real is kept separately so the test can genuinely release it at cleanup.
+	real net.Listener
+}
+
+var errCloseNotConfirmedStub = errors.New("listener close not confirmed within budget")
+
+func (l *unconfirmedCloseListener) Close() error {
+	l.closes.Add(1)
+	return errCloseNotConfirmedStub
+}
+
+// TestDaemon_ShutdownBoundedWhenListenerCloseIsNotConfirmed is the RED/GREEN
+// test for hazard 2. With the bare `<-acceptDone` receive, Run never returns
+// and this test fails on its 8s ceiling. With the watchdog case, Run reaches
+// the force-exit path and returns.
+func TestDaemon_ShutdownBoundedWhenListenerCloseIsNotConfirmed(t *testing.T) {
+	isolateDaemonEnv(t)
+
+	const testWatchdog = 300 * time.Millisecond
+	t.Setenv("GRAFEL_SHUTDOWN_WATCHDOG", testWatchdog.String())
+
+	var exitCalled atomic.Bool
+	restoreExit := daemon.SetShutdownExitFuncForTest(func(int) {
+		exitCalled.Store(true)
+	})
+	t.Cleanup(restoreExit)
+
+	var stub *unconfirmedCloseListener
+	restoreListen := daemon.SetListenFuncForTest(func(addr string) (net.Listener, error) {
+		real, err := transport.Listen(addr)
+		if err != nil {
+			return nil, err
+		}
+		stub = &unconfirmedCloseListener{Listener: real, real: real}
+		// The daemon can never release this listener, so the test must.
+		t.Cleanup(func() { _ = real.Close() })
+		return stub, nil
+	})
+	t.Cleanup(restoreListen)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure layout: %v", err)
+	}
+
+	rb := func(proto.RebuildArgs) ([]string, string, error) { return nil, "", nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- daemon.Run(ctx, daemon.Config{Layout: layout, Rebuild: rb})
+	}()
+
+	waitDaemonReady(t, layout.SocketPath, 10*time.Second)
+
+	start := time.Now()
+	cancel()
+
+	select {
+	case <-runDone:
+		elapsed := time.Since(start)
+		t.Logf("Run returned after %s (watchdog=%s), closes=%d", elapsed, testWatchdog, stub.closes.Load())
+		if elapsed > 5*time.Second {
+			t.Fatalf("Run took %s to return; want well under 5s (watchdog=%s)", elapsed, testWatchdog)
+		}
+		if stub.closes.Load() == 0 {
+			t.Fatal("Run never called listener.Close — the fixture never exercised the unconfirmed-close path")
+		}
+		if !exitCalled.Load() {
+			t.Fatal("expected the watchdog force-exit path to fire; Run returned some other way")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Run did not return within 8s: the `<-acceptDone` receive is not bounded by the " +
+			"shutdown watchdog, so an unconfirmed listener close still wedges shutdown forever")
+	}
+}
+
+// TestDaemon_ShutdownStillCleanWhenListenerCloseSucceeds is the fixture-validity
+// anchor: the SAME harness, with a listener whose Close behaves normally, must
+// shut down WITHOUT the force-exit watchdog firing. Without this, the test
+// above could pass on a daemon that force-exits on every shutdown, which would
+// be a regression rather than a fix.
+func TestDaemon_ShutdownStillCleanWhenListenerCloseSucceeds(t *testing.T) {
+	isolateDaemonEnv(t)
+
+	const testWatchdog = 300 * time.Millisecond
+	t.Setenv("GRAFEL_SHUTDOWN_WATCHDOG", testWatchdog.String())
+
+	var exitCalled atomic.Bool
+	restoreExit := daemon.SetShutdownExitFuncForTest(func(int) {
+		exitCalled.Store(true)
+	})
+	t.Cleanup(restoreExit)
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure layout: %v", err)
+	}
+
+	rb := func(proto.RebuildArgs) ([]string, string, error) { return nil, "", nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runDone := make(chan error, 1)
+	go func() {
+		runDone <- daemon.Run(ctx, daemon.Config{Layout: layout, Rebuild: rb})
+	}()
+
+	waitDaemonReady(t, layout.SocketPath, 10*time.Second)
+	cancel()
+
+	select {
+	case runErr := <-runDone:
+		if runErr != nil {
+			t.Fatalf("expected a clean graceful shutdown, got %v", runErr)
+		}
+		if exitCalled.Load() {
+			t.Fatal("the force-exit watchdog fired on a healthy shutdown — the new watchdog " +
+				"case on <-acceptDone must not short-circuit the normal path")
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("Run did not return within 8s on a healthy shutdown")
+	}
+}

--- a/internal/daemon/transport/closebounded.go
+++ b/internal/daemon/transport/closebounded.go
@@ -8,74 +8,121 @@ import (
 // closeBounded exists because closing a Windows named-pipe listener is not
 // guaranteed to terminate.
 //
-// # The defect
+// # The observed wedge
 //
-// github.com/Microsoft/go-winio@v0.6.2 win32PipeListener has three
-// interlocking pieces (pipe.go line numbers):
+// The windows-latest CI job died at a 15-minute test timeout with a goroutine
+// dump showing, on one github.com/Microsoft/go-winio@v0.6.2 listener:
 //
-//   - Close (575) sends one value on the unbuffered closeCh, then waits on
-//     doneCh: `select { case l.closeCh <- 1: <-l.doneCh; case <-l.doneCh: }`.
-//   - listenerRoutine (459) loops until `closed`, closing doneCh on exit. Its
-//     top-of-loop select (462) can receive closeCh directly, which is the
-//     intended shutdown path.
-//   - makeConnectedServerPipe (429), reached while an Accept is outstanding,
-//     ALSO has a `case <-l.closeCh` (447). It aborts the pending connect,
-//     reads the completion at 451, and at 452 maps the result to
-//     ErrPipeListenerClosed — but only when that result is nil or
-//     ErrFileClosed.
+//   - Close parked at pipe.go:578 — `<-l.doneCh`
+//   - that listener's own listenerRoutine parked at pipe.go:462 — the
+//     top-of-loop select — with `closed` still false
 //
-// When a connect is aborted by closing its handle, Windows may complete the
-// pending I/O with ERROR_OPERATION_ABORTED. That value survives 452 unchanged,
-// so listenerRoutine's `closed = err == ErrPipeListenerClosed` at 479 is false
-// and the loop goes back to the top select — having already consumed the one
-// and only value Close sent. doneCh is never closed and Close blocks forever.
+// Those two facts together are diagnostic. Close sends exactly one value on
+// the unbuffered closeCh (pipe.go:577) and then waits on doneCh; only
+// listenerRoutine ever closes doneCh, and only when it leaves its loop. For
+// listenerRoutine to be back at 462 with closed == false, the send must have
+// been consumed somewhere OTHER than the top select — and the only other
+// receiver in the package is makeConnectedServerPipe's abort case at
+// pipe.go:447. Having consumed it, that function returned an error which
+// pipe.go:452 did not map to ErrPipeListenerClosed, so `closed = err ==
+// ErrPipeListenerClosed` at pipe.go:479 was false and the loop went back
+// around — with no value left for it to receive. doneCh is never closed and
+// Close blocks forever.
 //
-// This is not theoretical. It is what killed the windows-latest CI job: the
-// goroutine dump shows Close parked at pipe.go:578 and listenerRoutine parked
-// at pipe.go:462 on the same listener, for the full 15-minute test timeout.
-// The same call shape is on the daemon's own graceful-shutdown path
-// (internal/daemon/server.go), where it means `grafel stop` cannot complete —
-// the exact user-visible symptom of issue #6044.
+// # Which errno escapes pipe.go:452 — read this before bumping go-winio
+//
+// The classification at 452 promotes only nil and ErrFileClosed. It is
+// tempting to conclude the escapee is ERROR_OPERATION_ABORTED, since that is
+// what a cancelled ConnectNamedPipe reports. That is WRONG for v0.6.2 and the
+// mistake is worth recording: file.go:194-197 already remaps
+// ERROR_OPERATION_ABORTED to ErrFileClosed whenever f.closing is set, and
+// closeHandle (file.go:117) sets closing BEFORE cancelIoEx and before
+// f.wg.Wait(). connectPipe holds that waitgroup (pipe.go:541-545), so
+// closeHandle cannot return until asyncIO does, and asyncIO reads closing
+// (file.go:195) after the cancellation it caused. closing is therefore
+// necessarily true and the remap always fires. That path cannot wedge.
+//
+// The reachable variant is a race, not an errno-classification gap:
+// connectNamedPipe can fail IMMEDIATELY with an errno that is neither
+// ERROR_IO_PENDING nor ERROR_PIPE_CONNECTED, in which case asyncIO returns it
+// raw (file.go:175-177) and connectPipe passes it through unmapped
+// (pipe.go:549-551). If Close has sent by then, the select at pipe.go:441 has
+// BOTH cases ready; Go picks uniformly at random, the closeCh branch can win,
+// and `err = <-ch` at 451 picks up that raw errno — which escapes 452 verbatim.
+// The ERROR_NO_DATA retry loop at pipe.go:470-477 is a second way in: it
+// re-enters makeConnectedServerPipe after the single closeCh value is already
+// spent, parking at 441 with nothing left to wake it.
+//
+// This remedy is deliberately errno-agnostic and covers every variant,
+// including ones a future go-winio may introduce. Treat the specific mechanism
+// above as the best-supported reading of the dump — the dump proves SOME error
+// escaped 452, not which one. No Windows machine was available to observe it
+// directly.
+//
+// # Why this is a product bug and not a test artefact
+//
+// internal/daemon/server.go closes this listener on the graceful-shutdown
+// path. A wedge there means the Windows daemon never exits, which is exactly
+// the user-visible symptom of issue #6044.
 //
 // # The remedy
 //
 // The stuck listenerRoutine is not dead; it is parked at 462 with a live
-// `case <-l.closeCh`. One more send is therefore exactly the wakeup it needs:
-// it sets closed = true, exits the loop, closes the real handle and closes
-// doneCh — which releases the original Close call too. So the fix is to issue
-// another Close if the first has not returned, and it produces a genuine,
-// confirmed close rather than an abandoned handle.
+// `case <-l.closeCh`. One more send is therefore precisely the wakeup it
+// needs: it sets closed = true, exits the loop, closes the real handle and
+// closes doneCh — which releases the original Close call too. The result is a
+// genuine, confirmed close, not an abandoned handle.
 //
-// The retry is only ever issued when a close is actually overdue, so the
-// normal path calls Close exactly once.
+// closeCh is unbuffered, which makes the retry safe rather than merely likely
+// to work: a retry issued while listenerRoutine is busy is not lost, it simply
+// blocks as a pending sender until the routine returns to 462 and receives it.
+//
+// Concurrent Close calls are safe on win32PipeListener: Close only sends on
+// closeCh and reads doneCh (pipe.go:575-582), and it is listenerRoutine — not
+// Close — that closes the handle and doneCh, exactly once.
 
 // closeAttemptBudget is how long a single Close is given before another is
 // issued.
 //
 // A healthy Close is a channel rendezvous plus a handle close: microseconds.
-// The slowest legitimate case is the abort branch at pipe.go:451, which waits
-// for a cancelled kernel I/O to complete — sub-millisecond normally, and tens
-// of milliseconds on a loaded CI runner. 250 ms sits two orders of magnitude
-// above that, so a close that is merely slow but still progressing is never
-// interrupted by a spurious retry, while a genuinely wedged one is detected
-// fast enough that shutdown still feels immediate.
+// The slowest legitimate case waits for a cancelled kernel I/O to complete —
+// sub-millisecond normally, tens of milliseconds on a loaded CI runner. 250 ms
+// sits two orders of magnitude above that, so a close that is merely slow but
+// still progressing is never interrupted by a spurious retry, while a
+// genuinely wedged one is detected fast enough that shutdown still feels
+// immediate.
 const closeAttemptBudget = 250 * time.Millisecond
 
 // closeMaxAttempts bounds the total wait at closeAttemptBudget * attempts.
 //
-// Each extra closeCh send can be swallowed by at most one in-flight
-// makeConnectedServerPipe, and the accept loop only ever has one outstanding
-// at a time, so in practice a single retry converges. Four attempts leaves
-// headroom for a listener that is being hammered while it shuts down, and
-// caps the worst case at 1 s — small against any shutdown watchdog or test
-// timeout, and vastly better than blocking forever.
+// Two attempts suffice for the listenerRoutine-parked-at-462 shape: the
+// listener is waiting on closeCh and a single extra send releases it. The
+// headroom is for the ERROR_NO_DATA variant (pipe.go:470-477), where the retry
+// loop can re-enter makeConnectedServerPipe and consume another closeCh value
+// per iteration, so more than one extra send may be needed. Four caps the
+// worst case at 1 s — small against any shutdown watchdog or test timeout, and
+// vastly better than blocking forever.
 const closeMaxAttempts = 4
 
 // errCloseNotConfirmed reports that the listener did not confirm its close
-// within the budget. The caller has stopped waiting; a goroutine and the
-// underlying handle may still be pending. That is deliberately worse-but-
-// finite: the alternative is a process that never exits. Callers should log
-// it rather than discard it, so a recurrence is visible instead of silent.
+// within the budget. The caller has stopped waiting.
+//
+// This is deliberately worse-but-finite. Two costs are accepted, and callers
+// must understand both:
+//
+//   - The underlying handle may still be open, and the listener may still
+//     accept. Callers must NOT treat this call as their bound on shutdown;
+//     internal/daemon/server.go relies on its watchdog for that, precisely
+//     because a listener that did not close can still wedge the accept loop.
+//   - Up to closeMaxAttempts goroutines are leaked, one per attempt, each
+//     blocked inside the wedged Close. They are unrecoverable by construction:
+//     the whole point is that the call they are in does not return. The `done`
+//     channel is buffered to closeMaxAttempts so that if one of them DOES
+//     later return it can send and exit rather than leak again on an unread
+//     channel.
+//
+// It is returned rather than swallowed so a recurrence is visible in logs
+// instead of silent.
 var errCloseNotConfirmed = errors.New("listener close not confirmed within budget")
 
 // closeBounded closes a listener with the retry policy described above.
@@ -83,22 +130,46 @@ func closeBounded(closeFn func() error) error {
 	return closeBoundedFor(closeFn, closeAttemptBudget, closeMaxAttempts)
 }
 
+// closeAttemptResult tags a close result with the attempt that produced it, so
+// a retry's error can never be mistaken for the real close's outcome.
+type closeAttemptResult struct {
+	attempt int
+	err     error
+}
+
 // closeBoundedFor is closeBounded with the budget injected, so tests can pin
 // the mechanism without paying wall-clock for it.
 //
-// Concurrent Close calls are safe on win32PipeListener: Close only sends on
-// closeCh and reads doneCh, and it is listenerRoutine — not Close — that
-// closes the handle and doneCh, exactly once.
+// Attribution matters here. The retries are this function's own doing, so a
+// retry that fails says nothing about whether the listener closed — a wrapped
+// listener whose second Close reports "use of closed network connection" has
+// in fact closed successfully. Returning that would turn a clean shutdown into
+// a spurious warning at the server.go call site. So:
+//
+//   - attempt 0 is authoritative: its result is returned verbatim, error or not
+//   - any attempt returning nil confirms the close
+//   - a LATER attempt's error is discarded and we keep waiting; it carries no
+//     information about attempt 0, which will land promptly if the listener
+//     really did close
 func closeBoundedFor(closeFn func() error, perAttempt time.Duration, maxAttempts int) error {
 	if maxAttempts < 1 {
 		maxAttempts = 1
 	}
 	// Buffered so a late-returning attempt can always send and exit rather
-	// than leaking a goroutine blocked on an unread channel.
-	done := make(chan error, maxAttempts)
+	// than leaking again on an unread channel.
+	done := make(chan closeAttemptResult, maxAttempts)
 
 	timer := time.NewTimer(perAttempt)
 	defer timer.Stop()
+
+	// resolve applies the attribution rules above. ok is false when the result
+	// carries no information and we should keep waiting.
+	resolve := func(r closeAttemptResult) (error, bool) {
+		if r.attempt == 0 || r.err == nil {
+			return r.err, true
+		}
+		return nil, false
+	}
 
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if attempt > 0 {
@@ -106,20 +177,35 @@ func closeBoundedFor(closeFn func() error, perAttempt time.Duration, maxAttempts
 			// which is the only way to reach here, so Reset is safe.
 			timer.Reset(perAttempt)
 		}
-		go func() { done <- closeFn() }()
+		n := attempt
+		go func() { done <- closeAttemptResult{attempt: n, err: closeFn()} }()
 
-		select {
-		case err := <-done:
-			return err
-		case <-timer.C:
+		expired := false
+		for !expired {
+			select {
+			case r := <-done:
+				if err, ok := resolve(r); ok {
+					return err
+				}
+				// A retry failed; it tells us nothing. Keep waiting out this
+				// attempt's budget.
+			case <-timer.C:
+				expired = true
+			}
 		}
 	}
 
 	// A close may have landed in the same instant the last budget expired.
-	select {
-	case err := <-done:
-		return err
-	default:
+	for {
+		select {
+		case r := <-done:
+			if err, ok := resolve(r); ok {
+				return err
+			}
+			continue
+		default:
+		}
+		break
 	}
 	return errCloseNotConfirmed
 }

--- a/internal/daemon/transport/closebounded.go
+++ b/internal/daemon/transport/closebounded.go
@@ -1,0 +1,125 @@
+package transport
+
+import (
+	"errors"
+	"time"
+)
+
+// closeBounded exists because closing a Windows named-pipe listener is not
+// guaranteed to terminate.
+//
+// # The defect
+//
+// github.com/Microsoft/go-winio@v0.6.2 win32PipeListener has three
+// interlocking pieces (pipe.go line numbers):
+//
+//   - Close (575) sends one value on the unbuffered closeCh, then waits on
+//     doneCh: `select { case l.closeCh <- 1: <-l.doneCh; case <-l.doneCh: }`.
+//   - listenerRoutine (459) loops until `closed`, closing doneCh on exit. Its
+//     top-of-loop select (462) can receive closeCh directly, which is the
+//     intended shutdown path.
+//   - makeConnectedServerPipe (429), reached while an Accept is outstanding,
+//     ALSO has a `case <-l.closeCh` (447). It aborts the pending connect,
+//     reads the completion at 451, and at 452 maps the result to
+//     ErrPipeListenerClosed — but only when that result is nil or
+//     ErrFileClosed.
+//
+// When a connect is aborted by closing its handle, Windows may complete the
+// pending I/O with ERROR_OPERATION_ABORTED. That value survives 452 unchanged,
+// so listenerRoutine's `closed = err == ErrPipeListenerClosed` at 479 is false
+// and the loop goes back to the top select — having already consumed the one
+// and only value Close sent. doneCh is never closed and Close blocks forever.
+//
+// This is not theoretical. It is what killed the windows-latest CI job: the
+// goroutine dump shows Close parked at pipe.go:578 and listenerRoutine parked
+// at pipe.go:462 on the same listener, for the full 15-minute test timeout.
+// The same call shape is on the daemon's own graceful-shutdown path
+// (internal/daemon/server.go), where it means `grafel stop` cannot complete —
+// the exact user-visible symptom of issue #6044.
+//
+// # The remedy
+//
+// The stuck listenerRoutine is not dead; it is parked at 462 with a live
+// `case <-l.closeCh`. One more send is therefore exactly the wakeup it needs:
+// it sets closed = true, exits the loop, closes the real handle and closes
+// doneCh — which releases the original Close call too. So the fix is to issue
+// another Close if the first has not returned, and it produces a genuine,
+// confirmed close rather than an abandoned handle.
+//
+// The retry is only ever issued when a close is actually overdue, so the
+// normal path calls Close exactly once.
+
+// closeAttemptBudget is how long a single Close is given before another is
+// issued.
+//
+// A healthy Close is a channel rendezvous plus a handle close: microseconds.
+// The slowest legitimate case is the abort branch at pipe.go:451, which waits
+// for a cancelled kernel I/O to complete — sub-millisecond normally, and tens
+// of milliseconds on a loaded CI runner. 250 ms sits two orders of magnitude
+// above that, so a close that is merely slow but still progressing is never
+// interrupted by a spurious retry, while a genuinely wedged one is detected
+// fast enough that shutdown still feels immediate.
+const closeAttemptBudget = 250 * time.Millisecond
+
+// closeMaxAttempts bounds the total wait at closeAttemptBudget * attempts.
+//
+// Each extra closeCh send can be swallowed by at most one in-flight
+// makeConnectedServerPipe, and the accept loop only ever has one outstanding
+// at a time, so in practice a single retry converges. Four attempts leaves
+// headroom for a listener that is being hammered while it shuts down, and
+// caps the worst case at 1 s — small against any shutdown watchdog or test
+// timeout, and vastly better than blocking forever.
+const closeMaxAttempts = 4
+
+// errCloseNotConfirmed reports that the listener did not confirm its close
+// within the budget. The caller has stopped waiting; a goroutine and the
+// underlying handle may still be pending. That is deliberately worse-but-
+// finite: the alternative is a process that never exits. Callers should log
+// it rather than discard it, so a recurrence is visible instead of silent.
+var errCloseNotConfirmed = errors.New("listener close not confirmed within budget")
+
+// closeBounded closes a listener with the retry policy described above.
+func closeBounded(closeFn func() error) error {
+	return closeBoundedFor(closeFn, closeAttemptBudget, closeMaxAttempts)
+}
+
+// closeBoundedFor is closeBounded with the budget injected, so tests can pin
+// the mechanism without paying wall-clock for it.
+//
+// Concurrent Close calls are safe on win32PipeListener: Close only sends on
+// closeCh and reads doneCh, and it is listenerRoutine — not Close — that
+// closes the handle and doneCh, exactly once.
+func closeBoundedFor(closeFn func() error, perAttempt time.Duration, maxAttempts int) error {
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	// Buffered so a late-returning attempt can always send and exit rather
+	// than leaking a goroutine blocked on an unread channel.
+	done := make(chan error, maxAttempts)
+
+	timer := time.NewTimer(perAttempt)
+	defer timer.Stop()
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if attempt > 0 {
+			// The previous iteration drained timer.C via its <-timer.C case,
+			// which is the only way to reach here, so Reset is safe.
+			timer.Reset(perAttempt)
+		}
+		go func() { done <- closeFn() }()
+
+		select {
+		case err := <-done:
+			return err
+		case <-timer.C:
+		}
+	}
+
+	// A close may have landed in the same instant the last budget expired.
+	select {
+	case err := <-done:
+		return err
+	default:
+	}
+	return errCloseNotConfirmed
+}

--- a/internal/daemon/transport/closebounded_test.go
+++ b/internal/daemon/transport/closebounded_test.go
@@ -16,10 +16,16 @@ package transport
 //
 // The tests below reproduce that state machine faithfully (line references are
 // to github.com/Microsoft/go-winio@v0.6.2/pipe.go) and pin both directions:
-// the model DOES deadlock when the aborted connect is misclassified, and it
-// does NOT when it is classified correctly — so the fixture is not merely
-// always-stuck. closeBounded is then shown to convert the deadlock into a
-// genuine, confirmed close rather than a give-up.
+// the model DOES deadlock when the abort result escapes the classification at
+// pipe.go:452, and it does NOT when that result is classified correctly — so
+// the fixture is not merely always-stuck. closeBounded is then shown to convert
+// the deadlock into a genuine, confirmed close rather than a give-up.
+//
+// SCOPE — what these tests do and do not establish. They prove a conditional:
+// IF an error escapes pipe.go:452, THEN Close deadlocks and a retry resolves
+// it. They do NOT establish which errno escaped in CI, and they deliberately
+// do not name one — see errUnclassifiedModel and closebounded.go for why the
+// obvious candidate is ruled out by the library source.
 //
 // NOTE: this runs on every platform because it models the library rather than
 // calling it. The real Windows behaviour could not be executed here.
@@ -31,17 +37,26 @@ import (
 	"time"
 )
 
-// Sentinels standing in for go-winio's exported errors and for the Windows
-// errno that the library fails to recognise.
+// Sentinels standing in for go-winio's exported errors.
 var (
 	errPipeListenerClosedModel = errors.New("use of closed network connection")
 	errFileClosedModel         = errors.New("file has already been closed")
-	// errOperationAbortedModel stands in for windows.ERROR_OPERATION_ABORTED,
-	// the errno a pending ConnectNamedPipe reports once its handle is closed
-	// out from under it. pipe.go:452 normalises only nil and ErrFileClosed to
-	// ErrPipeListenerClosed, so this value escapes as an ordinary accept
-	// error — which is the whole bug.
-	errOperationAbortedModel = errors.New("the I/O operation has been aborted")
+	// errUnclassifiedModel stands for ANY errno that reaches pipe.go:452
+	// without being nil or ErrFileClosed, and is therefore not promoted to
+	// ErrPipeListenerClosed.
+	//
+	// It is deliberately anonymous. An earlier version of this file named it
+	// ERROR_OPERATION_ABORTED; that was wrong for v0.6.2, where file.go:194-197
+	// always remaps that errno to ErrFileClosed (closeHandle sets f.closing at
+	// file.go:117 before cancelIoEx and before the wg.Wait() that gates
+	// asyncIO's read of it). Naming a specific errno here would re-assert a
+	// claim the library source refutes.
+	//
+	// What these tests establish is the conditional, which is the half that
+	// matters and is errno-independent: IF any error escapes the classification
+	// at 452, THEN Close deadlocks, AND a retry resolves it. Which errno
+	// actually escaped in CI is not established here — see closebounded.go.
+	errUnclassifiedModel = errors.New("an errno pipe.go:452 does not promote")
 )
 
 // winioListenerModel reproduces win32PipeListener's concurrency structure:
@@ -170,11 +185,11 @@ func driveToPendingAccept(t *testing.T, m *winioListenerModel) {
 // --- fixture validity: the model must be able to produce BOTH outcomes ------
 
 // TestWinioModel_MisclassifiedAbortDeadlocksASingleClose is the negative
-// anchor. With ERROR_OPERATION_ABORTED escaping pipe.go:452, one Close hangs
+// anchor. With any unpromoted error escaping pipe.go:452, one Close hangs
 // forever. If this ever starts passing quickly the model has stopped
 // reproducing the bug and every other test in this file is vacuous.
 func TestWinioModel_MisclassifiedAbortDeadlocksASingleClose(t *testing.T) {
-	m := newWinioListenerModel(errOperationAbortedModel)
+	m := newWinioListenerModel(errUnclassifiedModel)
 	driveToPendingAccept(t, m)
 
 	returned := make(chan struct{})
@@ -232,7 +247,7 @@ func TestWinioModel_CorrectlyClassifiedAbortClosesOnFirstTry(t *testing.T) {
 // releasing the original Close as well. The listener is genuinely released,
 // not abandoned.
 func TestCloseBounded_RecoversTheMisclassifiedAbortDeadlock(t *testing.T) {
-	m := newWinioListenerModel(errOperationAbortedModel)
+	m := newWinioListenerModel(errUnclassifiedModel)
 	driveToPendingAccept(t, m)
 
 	start := time.Now()
@@ -301,6 +316,89 @@ func TestCloseBounded_ReturnsWithinBudgetWhenCloseCanNeverSucceed(t *testing.T) 
 	}
 	if elapsed > 5*time.Second {
 		t.Fatalf("took %v; the total budget is not being enforced", elapsed)
+	}
+}
+
+// TestCloseBounded_RetryErrorNeverMasksASuccessfulClose pins attribution.
+//
+// The retries are closeBoundedFor's own doing, so a retry that fails says
+// nothing about whether the listener closed. The realistic shape: the first
+// Close is slow but succeeds, and a retry fired in the meantime reports "use of
+// closed network connection" — which is what a listener that HAS closed says.
+// Returning that would make server.go log a shutdown failure for a shutdown
+// that worked.
+func TestCloseBounded_RetryErrorNeverMasksASuccessfulClose(t *testing.T) {
+	alreadyClosed := errors.New("use of closed network connection")
+
+	var calls atomic.Int32
+	closeFn := func() error {
+		if calls.Add(1) == 1 {
+			// The real close: slow enough that a retry fires first, but it
+			// does succeed.
+			time.Sleep(150 * time.Millisecond)
+			return nil
+		}
+		return alreadyClosed
+	}
+
+	err := closeBoundedFor(closeFn, 40*time.Millisecond, 4)
+	if err != nil {
+		t.Fatalf("a close that succeeded was reported as failed: %v", err)
+	}
+	if calls.Load() < 2 {
+		t.Fatalf("fixture never fired a retry (%d calls), so it cannot exhibit the masking bug", calls.Load())
+	}
+}
+
+// TestCloseBounded_FirstAttemptErrorIsStillReported is the opposite anchor for
+// the rule above: discarding retry errors must not turn into discarding the
+// real one. Attempt 0's error is authoritative and must survive.
+func TestCloseBounded_FirstAttemptErrorIsStillReported(t *testing.T) {
+	realFailure := errors.New("permission denied")
+
+	var calls atomic.Int32
+	closeFn := func() error {
+		if calls.Add(1) == 1 {
+			time.Sleep(150 * time.Millisecond)
+			return realFailure
+		}
+		return errors.New("some later noise")
+	}
+
+	err := closeBoundedFor(closeFn, 40*time.Millisecond, 4)
+	if !errors.Is(err, realFailure) {
+		t.Fatalf("attempt 0's error was lost; got %v", err)
+	}
+	if calls.Load() < 2 {
+		t.Fatalf("fixture never fired a retry (%d calls), so it does not exercise the rule", calls.Load())
+	}
+}
+
+// TestCloseBounded_LeaksAtMostOneGoroutinePerAttempt pins the documented cost
+// of giving up. The leaked goroutines are unrecoverable by construction — they
+// are blocked inside a Close that does not return — so the contract that
+// matters is that the leak is BOUNDED by maxAttempts rather than unbounded.
+//
+// Counting in-flight closeFn invocations is deterministic, unlike
+// runtime.NumGoroutine, which other tests in this package would perturb.
+func TestCloseBounded_LeaksAtMostOneGoroutinePerAttempt(t *testing.T) {
+	const attempts = 4
+
+	var inFlight atomic.Int32
+	release := make(chan struct{})
+	t.Cleanup(func() { close(release) }) // let the leaked goroutines exit with the test
+
+	err := closeBoundedFor(func() error {
+		inFlight.Add(1)
+		<-release
+		return nil
+	}, 30*time.Millisecond, attempts)
+
+	if !errors.Is(err, errCloseNotConfirmed) {
+		t.Fatalf("expected errCloseNotConfirmed, got %v", err)
+	}
+	if got := inFlight.Load(); got != attempts {
+		t.Fatalf("expected exactly %d blocked close goroutines (the documented leak), got %d", attempts, got)
 	}
 }
 

--- a/internal/daemon/transport/closebounded_test.go
+++ b/internal/daemon/transport/closebounded_test.go
@@ -1,0 +1,318 @@
+package transport
+
+// closebounded_test.go pins the mechanism behind the Windows CI hang that
+// blocked the v0.2.0 tag (run 30642094648): the whole windows-latest job died
+// at `-timeout 15m` with
+//
+//	panic: test timed out after 15m0s
+//	  running tests:
+//	    TestRunDaemonStop_RPCPath_ReportsFailureWhenStillRunning (14m10s)
+//
+// and the goroutine dump showed the test goroutine parked forever in
+// t.Cleanup at go-winio pipe.go:578 — `<-l.doneCh` inside win32PipeListener.
+// Close — while the listener's own listenerRoutine sat at pipe.go:462, the
+// top-of-loop select, with closed == false. In that state nothing will ever
+// close doneCh, so Close never returns.
+//
+// The tests below reproduce that state machine faithfully (line references are
+// to github.com/Microsoft/go-winio@v0.6.2/pipe.go) and pin both directions:
+// the model DOES deadlock when the aborted connect is misclassified, and it
+// does NOT when it is classified correctly — so the fixture is not merely
+// always-stuck. closeBounded is then shown to convert the deadlock into a
+// genuine, confirmed close rather than a give-up.
+//
+// NOTE: this runs on every platform because it models the library rather than
+// calling it. The real Windows behaviour could not be executed here.
+
+import (
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Sentinels standing in for go-winio's exported errors and for the Windows
+// errno that the library fails to recognise.
+var (
+	errPipeListenerClosedModel = errors.New("use of closed network connection")
+	errFileClosedModel         = errors.New("file has already been closed")
+	// errOperationAbortedModel stands in for windows.ERROR_OPERATION_ABORTED,
+	// the errno a pending ConnectNamedPipe reports once its handle is closed
+	// out from under it. pipe.go:452 normalises only nil and ErrFileClosed to
+	// ErrPipeListenerClosed, so this value escapes as an ordinary accept
+	// error — which is the whole bug.
+	errOperationAbortedModel = errors.New("the I/O operation has been aborted")
+)
+
+// winioListenerModel reproduces win32PipeListener's concurrency structure:
+// the unbuffered closeCh/acceptCh rendezvous, the doneCh broadcast, the
+// listenerRoutine loop (pipe.go:459-483), makeConnectedServerPipe's abort
+// branch (pipe.go:441-455) and Close (pipe.go:575-582).
+type winioListenerModel struct {
+	closeCh  chan int
+	doneCh   chan int
+	acceptCh chan chan error
+
+	// parked is signalled every time makeConnectedServerPipe enters its
+	// select, i.e. the listener is genuinely waiting for a client. It exists
+	// only so the tests have a deterministic sync point instead of a sleep.
+	parked chan struct{}
+
+	// abortErr is what the aborted async connect reports back at pipe.go:451.
+	abortErr error
+
+	closes atomic.Int32
+}
+
+func newWinioListenerModel(abortErr error) *winioListenerModel {
+	m := &winioListenerModel{
+		closeCh:  make(chan int),
+		doneCh:   make(chan int),
+		acceptCh: make(chan chan error),
+		parked:   make(chan struct{}, 8),
+		abortErr: abortErr,
+	}
+	go m.listenerRoutine()
+	return m
+}
+
+// listenerRoutine mirrors pipe.go:459-483.
+func (m *winioListenerModel) listenerRoutine() {
+	closed := false
+	for !closed {
+		select {
+		case <-m.closeCh:
+			closed = true
+		case respCh := <-m.acceptCh:
+			err := m.makeConnectedServerPipe()
+			respCh <- err
+			// pipe.go:479 — the loop only terminates when the error is
+			// recognised as ErrPipeListenerClosed.
+			closed = errors.Is(err, errPipeListenerClosedModel)
+		}
+	}
+	close(m.doneCh)
+}
+
+// makeConnectedServerPipe mirrors pipe.go:429-457. No client ever arrives in
+// these tests, so the only reachable branch is the closeCh abort.
+func (m *winioListenerModel) makeConnectedServerPipe() error {
+	connectDone := make(chan error, 1) // the real one is fed by connectPipe
+
+	m.parked <- struct{}{}
+
+	select {
+	case err := <-connectDone:
+		return err
+	case <-m.closeCh:
+		// pipe.go:447-454. The handle is closed, the pending connect
+		// completes with abortErr, and ONLY nil / ErrFileClosed are mapped to
+		// ErrPipeListenerClosed.
+		err := m.abortErr
+		if err == nil || errors.Is(err, errFileClosedModel) {
+			err = errPipeListenerClosedModel
+		}
+		return err
+	}
+}
+
+// accept mirrors pipe.go:556-573.
+func (m *winioListenerModel) accept() error {
+	ch := make(chan error)
+	select {
+	case m.acceptCh <- ch:
+		return <-ch
+	case <-m.doneCh:
+		return errPipeListenerClosedModel
+	}
+}
+
+// Close mirrors pipe.go:575-582.
+func (m *winioListenerModel) Close() error {
+	m.closes.Add(1)
+	select {
+	case m.closeCh <- 1:
+		<-m.doneCh
+	case <-m.doneCh:
+	}
+	return nil
+}
+
+func (m *winioListenerModel) isDone() bool {
+	select {
+	case <-m.doneCh:
+		return true
+	default:
+		return false
+	}
+}
+
+// waitParked blocks until the listener is inside makeConnectedServerPipe's
+// select, which is the precondition for the deadlock.
+func (m *winioListenerModel) waitParked(t *testing.T) {
+	t.Helper()
+	select {
+	case <-m.parked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("listener never parked in makeConnectedServerPipe")
+	}
+}
+
+// driveToPendingAccept puts the model in the exact state captured by the CI
+// goroutine dump: an Accept outstanding, the listener parked waiting for a
+// client that will never come.
+func driveToPendingAccept(t *testing.T, m *winioListenerModel) {
+	t.Helper()
+	go func() { _ = m.accept() }()
+	m.waitParked(t)
+}
+
+// --- fixture validity: the model must be able to produce BOTH outcomes ------
+
+// TestWinioModel_MisclassifiedAbortDeadlocksASingleClose is the negative
+// anchor. With ERROR_OPERATION_ABORTED escaping pipe.go:452, one Close hangs
+// forever. If this ever starts passing quickly the model has stopped
+// reproducing the bug and every other test in this file is vacuous.
+func TestWinioModel_MisclassifiedAbortDeadlocksASingleClose(t *testing.T) {
+	m := newWinioListenerModel(errOperationAbortedModel)
+	driveToPendingAccept(t, m)
+
+	returned := make(chan struct{})
+	go func() {
+		_ = m.Close()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+		t.Fatal("Close returned; the model no longer reproduces the go-winio deadlock, " +
+			"so the recovery tests in this file prove nothing")
+	case <-time.After(300 * time.Millisecond):
+		// Still stuck, as observed in CI for 14m10s.
+	}
+	if m.isDone() {
+		t.Fatal("doneCh closed while Close was still blocked — model is inconsistent")
+	}
+}
+
+// TestWinioModel_CorrectlyClassifiedAbortClosesOnFirstTry is the positive
+// anchor for the SAME model: when the abort is reported as nil (the case
+// pipe.go:452 does handle), a single Close converges. This proves the fixture
+// is not simply always-deadlocked, and isolates the misclassification as the
+// sole cause.
+func TestWinioModel_CorrectlyClassifiedAbortClosesOnFirstTry(t *testing.T) {
+	m := newWinioListenerModel(nil)
+	driveToPendingAccept(t, m)
+
+	returned := make(chan struct{})
+	go func() {
+		_ = m.Close()
+		close(returned)
+	}()
+
+	select {
+	case <-returned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Close did not return even though the abort was classified correctly")
+	}
+	if !m.isDone() {
+		t.Fatal("Close returned but doneCh was never closed")
+	}
+	if got := m.closes.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 Close call, got %d", got)
+	}
+}
+
+// --- the fix ---------------------------------------------------------------
+
+// TestCloseBounded_RecoversTheMisclassifiedAbortDeadlock is the core claim:
+// a second Close is not a workaround, it is the precise wakeup the stuck
+// listenerRoutine needs. Parked at pipe.go:462 it still has a live
+// `case <-l.closeCh`, so one more send sets closed = true and closes doneCh —
+// releasing the original Close as well. The listener is genuinely released,
+// not abandoned.
+func TestCloseBounded_RecoversTheMisclassifiedAbortDeadlock(t *testing.T) {
+	m := newWinioListenerModel(errOperationAbortedModel)
+	driveToPendingAccept(t, m)
+
+	start := time.Now()
+	err := closeBoundedFor(m.Close, 50*time.Millisecond, 4)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("closeBounded: %v", err)
+	}
+	if !m.isDone() {
+		t.Fatal("closeBounded returned but the listener was never actually closed — " +
+			"that would be a give-up, not a fix")
+	}
+	if got := m.closes.Load(); got < 2 {
+		t.Fatalf("expected the retry to be the thing that unblocked it (>=2 Close calls), got %d", got)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("recovery took %v, far above the configured budget", elapsed)
+	}
+}
+
+// TestCloseBounded_NoRetryWhenCloseReturnsPromptly pins that the retry is
+// conditional. A listener that closes normally must be closed exactly once —
+// otherwise every shutdown would fire spurious closeCh sends.
+func TestCloseBounded_NoRetryWhenCloseReturnsPromptly(t *testing.T) {
+	var calls atomic.Int32
+	err := closeBoundedFor(func() error {
+		calls.Add(1)
+		return nil
+	}, 50*time.Millisecond, 4)
+	if err != nil {
+		t.Fatalf("closeBounded: %v", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 Close call on the happy path, got %d", got)
+	}
+}
+
+// TestCloseBounded_PropagatesCloseError pins that a real close error is not
+// swallowed by the retry machinery.
+func TestCloseBounded_PropagatesCloseError(t *testing.T) {
+	sentinel := errors.New("boom")
+	err := closeBoundedFor(func() error { return sentinel }, 50*time.Millisecond, 4)
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected the underlying close error, got %v", err)
+	}
+}
+
+// TestCloseBounded_ReturnsWithinBudgetWhenCloseCanNeverSucceed pins the
+// ceiling: against a close that no number of retries can rescue, the helper
+// must still return — reporting honestly that the close was not confirmed —
+// rather than reproducing the 15-minute hang in a slower form.
+func TestCloseBounded_ReturnsWithinBudgetWhenCloseCanNeverSucceed(t *testing.T) {
+	const perAttempt = 40 * time.Millisecond
+	const attempts = 4
+
+	start := time.Now()
+	err := closeBoundedFor(func() error { select {} }, perAttempt, attempts)
+	elapsed := time.Since(start)
+
+	if !errors.Is(err, errCloseNotConfirmed) {
+		t.Fatalf("expected errCloseNotConfirmed, got %v", err)
+	}
+	if elapsed < perAttempt*attempts {
+		t.Fatalf("gave up after %v, before the budget was spent", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Fatalf("took %v; the total budget is not being enforced", elapsed)
+	}
+}
+
+// TestCloseBounded_ProductionConstantsCanRecover guards the two properties the
+// production numbers must have: more than one attempt (a single attempt cannot
+// recover the deadlock at all — see the model above), and a bounded total.
+func TestCloseBounded_ProductionConstantsCanRecover(t *testing.T) {
+	if closeMaxAttempts < 2 {
+		t.Fatalf("closeMaxAttempts=%d: with fewer than 2 attempts the retry can never "+
+			"deliver the second closeCh send that unblocks listenerRoutine", closeMaxAttempts)
+	}
+	if total := closeAttemptBudget * time.Duration(closeMaxAttempts); total > 2*time.Second {
+		t.Fatalf("total close budget %v is too large for a shutdown path", total)
+	}
+}

--- a/internal/daemon/transport/transport_windows.go
+++ b/internal/daemon/transport/transport_windows.go
@@ -124,3 +124,14 @@ func (sl *statsListener) Accept() (net.Conn, error) {
 	}
 	return newStatsConn(c), nil
 }
+
+// Close closes the named-pipe listener under a bounded budget.
+//
+// go-winio's win32PipeListener.Close can block forever when an Accept is
+// outstanding and the aborted connect completes with an errno its
+// classification misses — see closeBounded for the full mechanism and the CI
+// evidence. Unix has no equivalent hazard (net.UnixListener.Close is already
+// bounded), which is why this override lives only on the Windows side.
+func (sl *statsListener) Close() error {
+	return closeBounded(sl.Listener.Close)
+}

--- a/internal/graph/sidecar_bytes_6018_test.go
+++ b/internal/graph/sidecar_bytes_6018_test.go
@@ -14,6 +14,8 @@ import (
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 func sidecarFixture() *GraphStatsSidecar {
@@ -113,11 +115,8 @@ func TestWriteSidecar_Perm(t *testing.T) {
 	if err := WriteSidecar(out, sidecarFixture(), false); err != nil {
 		t.Fatalf("WriteSidecar: %v", err)
 	}
-	fi, err := os.Stat(filepath.Join(dir, "graph-stats.json"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := fi.Mode().Perm(); got != 0o644 {
-		t.Fatalf("mode = %04o, want 0644", got)
-	}
+	// Windows has no Unix permission bits, so AssertPerm degrades this to
+	// "the sidecar is writable" there rather than failing on 0666 != 0644
+	// (#6053). The Unix bits are still asserted exactly on unix.
+	testsupport.AssertPerm(t, filepath.Join(dir, "graph-stats.json"), 0o644)
 }

--- a/internal/links/atomic_write_5978_test.go
+++ b/internal/links/atomic_write_5978_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // TestWriteDocConcurrentPassesLoseNothing models two (here: eight) link passes
@@ -160,18 +162,18 @@ func TestWriteFileAtomicConcurrentWritersLoseNothing(t *testing.T) {
 func TestWriteFileAtomicAppliesRequestedMode(t *testing.T) {
 	dir := t.TempDir()
 
-	for _, perm := range []os.FileMode{0o644, 0o600} {
+	for _, perm := range []os.FileMode{0o644, 0o600, 0o444} {
 		path := filepath.Join(dir, fmt.Sprintf("mode-%o.json", perm))
 		if err := writeFileAtomic(path, []byte("{}"), perm); err != nil {
 			t.Fatalf("writeFileAtomic(%o): %v", perm, err)
 		}
-		fi, err := os.Stat(path)
-		if err != nil {
-			t.Fatalf("stat: %v", err)
-		}
-		if got := fi.Mode().Perm(); got != perm {
-			t.Errorf("mode = %o, want %o — the temp file's 0600 must not survive the rename", got, perm)
-		}
+		// Asserted through testsupport.AssertPerm because Windows cannot
+		// represent Unix permission bits at all (#6053); there the 0644/0600
+		// rows degrade to "the file is writable" and the 0444 row — which
+		// Windows DOES represent, as FILE_ATTRIBUTE_READONLY — is the one that
+		// still catches a lost chmod.
+		testsupport.AssertPerm(t, path, perm)
+		_ = os.Chmod(path, 0o666)
 	}
 
 	// And through the real caller, so writeDoc's own choice of mode is covered.
@@ -179,13 +181,7 @@ func TestWriteFileAtomicAppliesRequestedMode(t *testing.T) {
 	if err := writeDoc(path, &Document{Version: SchemaVersion}); err != nil {
 		t.Fatalf("writeDoc: %v", err)
 	}
-	fi, err := os.Stat(path)
-	if err != nil {
-		t.Fatalf("stat: %v", err)
-	}
-	if got := fi.Mode().Perm(); got != 0o644 {
-		t.Errorf("writeDoc mode = %o, want 644", got)
-	}
+	testsupport.AssertPerm(t, path, 0o644)
 }
 
 func assertNoTempLeftovers(t *testing.T, dir, dest string) {

--- a/internal/links/candidates.go
+++ b/internal/links/candidates.go
@@ -87,8 +87,12 @@ func writeDoc(path string, d *Document) error {
 // os.Rename directly, which on Windows cannot replace a read-only destination
 // and loses races against other open handles — so this package's own
 // concurrency tests failed there while the shared helper's passed (#6053).
-// Keep this a one-line delegation; a fourth private copy is how the bug got
-// back in the first place.
+// Keep this a one-line delegation; a private copy is how the bug got back in
+// the first place. (For the avoidance of a wrong number: the tree still holds
+// five OTHER hand-rolled Windows rename-retry loops — graph/groupalgo,
+// graph/descriptions, graph/flows, statusfile, install — and consolidating
+// them is a separate sweep, deliberately not done on this release-blocking
+// branch. See internal/atomicfile/rename.go.)
 func writeFileAtomic(path string, b []byte, perm os.FileMode) error {
 	return atomicfile.WriteFile(path, b, perm)
 }

--- a/internal/links/candidates.go
+++ b/internal/links/candidates.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // readDoc loads a Document from disk. A missing file returns an empty
@@ -72,37 +74,23 @@ func writeDoc(path string, d *Document) error {
 // filesystem and is therefore atomic; it is removed on every error path.
 //
 // MODE: perm is applied verbatim, NOT masked by the process umask — os.CreateTemp
-// makes the file 0600 and the Chmod below sets exactly what the caller asked
+// makes the file 0600 and an explicit Chmod sets exactly what the caller asked
 // for. os.WriteFile, which this replaced, passes perm through open(2) and so
 // WAS umask-masked. Under a restrictive umask (077) these files therefore widen
 // from 0600 to 0644. That is deliberate: the destinations are per-user state
 // under the grafel home, and a deterministic mode is easier to reason about
 // than one that depends on the umask of whichever process (daemon, CLI, child)
 // happened to run the pass.
-func writeFileAtomic(path string, b []byte, perm os.FileMode) (err error) {
-	f, err := os.CreateTemp(filepath.Dir(path), "."+filepath.Base(path)+".tmp-*")
-	if err != nil {
-		return err
-	}
-	tmp := f.Name()
-	defer func() {
-		if err != nil {
-			_ = os.Remove(tmp)
-		}
-	}()
-	if _, err = f.Write(b); err != nil {
-		_ = f.Close()
-		return err
-	}
-	if err = f.Close(); err != nil {
-		return err
-	}
-	// os.CreateTemp always uses 0600; restore the caller's intended mode.
-	if err = os.Chmod(tmp, perm); err != nil {
-		return err
-	}
-	err = os.Rename(tmp, path)
-	return err
+//
+// The body is now internal/atomicfile.WriteFile (#6018 generalised this exact
+// helper) rather than a second copy of it. That copy was still calling
+// os.Rename directly, which on Windows cannot replace a read-only destination
+// and loses races against other open handles — so this package's own
+// concurrency tests failed there while the shared helper's passed (#6053).
+// Keep this a one-line delegation; a fourth private copy is how the bug got
+// back in the first place.
+func writeFileAtomic(path string, b []byte, perm os.FileMode) error {
+	return atomicfile.WriteFile(path, b, perm)
 }
 
 // loadRejections reads the rejection file and returns a set keyed by

--- a/internal/testsupport/permcheck.go
+++ b/internal/testsupport/permcheck.go
@@ -1,0 +1,72 @@
+package testsupport
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"testing"
+)
+
+// AssertPerm asserts path's permission bits, adapted to what the running
+// platform is capable of representing.
+//
+// # Why this is not just `fi.Mode().Perm() != want`
+//
+// Go's Windows os.Stat does not report Unix permission bits, because NTFS does
+// not have them: it reports 0666 for an ordinary file and 0444 for one
+// carrying FILE_ATTRIBUTE_READONLY, and nothing else. A `want 0644` assertion
+// therefore cannot pass on Windows no matter what the code under test does —
+// it is testing the platform, not the product (#6053).
+//
+// So on Windows this asserts the one thing that IS representable and IS
+// enforced: writability. want with an owner-write bit must produce a writable
+// file; want without one (0444) must produce a read-only file. That is a
+// genuinely weaker assertion than on unix and it is deliberately still an
+// assertion — the alternative, t.Skip, would let a helper that stopped
+// applying perm entirely go unnoticed on Windows.
+//
+// # Is anything security-sensitive weakened by this?
+//
+// No. The narrowest mode any atomicfile call site passes is 0o600, and those
+// destinations are daemon operational state (internal/daemon/mode/mode.go,
+// pins.go, sched/rss.go) — no credential, token or key is written through this
+// path anywhere in the tree. The runtime perm argument is unchanged on every
+// platform; only the test's expectation is adapted. On Windows those files are
+// protected by the ACL on the user profile directory they live in rather than
+// by mode bits, which is the platform's normal mechanism and is not something
+// a chmod could improve.
+func AssertPerm(t *testing.T, path string, want os.FileMode) {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if msg := permMismatch(fi.Mode().Perm(), want, runtime.GOOS == "windows"); msg != "" {
+		t.Fatalf("%s: %s", path, msg)
+	}
+}
+
+// permMismatch returns "" when got satisfies want on the given platform, and
+// the failure message otherwise.
+//
+// The decision is split out of AssertPerm so that BOTH branches are testable
+// from any host. The Windows branch is the one that cannot be exercised by
+// running the assertion off Windows, and a helper that quietly stopped
+// asserting anything there is exactly the failure this change must not
+// introduce — see permcheck_test.go.
+func permMismatch(got, want os.FileMode, windows bool) string {
+	if windows {
+		wantWritable := want&0o200 != 0
+		gotWritable := got&0o200 != 0
+		if wantWritable != gotWritable {
+			return fmt.Sprintf("writable = %v (mode %04o), want writable = %v (requested mode %04o); "+
+				"Windows represents only the read-only attribute",
+				gotWritable, got, wantWritable, want)
+		}
+		return ""
+	}
+	if got != want {
+		return fmt.Sprintf("mode = %04o, want %04o", got, want)
+	}
+	return ""
+}

--- a/internal/testsupport/permcheck_test.go
+++ b/internal/testsupport/permcheck_test.go
@@ -1,0 +1,70 @@
+package testsupport
+
+// permcheck_test.go — both platform branches of the perm expectation, driven
+// from any host.
+//
+// AssertPerm exists because Windows cannot represent Unix permission bits, and
+// the temptation there is to reach for t.Skip. A skip is invisible: a helper
+// that stopped applying perm entirely would keep the Windows job green
+// forever. So the Windows branch still asserts writability, and these cases
+// pin that it can actually FAIL — which is the only thing that distinguishes
+// it from the skip it replaced.
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestPermMismatch(t *testing.T) {
+	cases := []struct {
+		name    string
+		got     os.FileMode
+		want    os.FileMode
+		windows bool
+		fail    bool
+	}{
+		// Unix: exact bits, nothing else.
+		{"unix exact match", 0o644, 0o644, false, false},
+		{"unix wider than wanted", 0o666, 0o644, false, true},
+		{"unix narrower than wanted", 0o600, 0o644, false, true},
+		{"unix read-only match", 0o444, 0o444, false, false},
+
+		// Windows: only the read-only attribute is representable, and
+		// os.Stat there only ever reports 0666 or 0444.
+		{"windows 0666 satisfies 0644", 0o666, 0o644, true, false},
+		{"windows 0666 satisfies 0600", 0o666, 0o600, true, false},
+		{"windows 0666 satisfies 0755", 0o666, 0o755, true, false},
+		// The rows that keep the Windows branch honest: a requested read-only
+		// mode that did not take, and a writable mode that came out read-only.
+		{"windows 0666 does NOT satisfy 0444", 0o666, 0o444, true, true},
+		{"windows 0444 does NOT satisfy 0644", 0o444, 0o644, true, true},
+		{"windows 0444 satisfies 0444", 0o444, 0o444, true, false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			msg := permMismatch(c.got, c.want, c.windows)
+			if c.fail && msg == "" {
+				t.Fatalf("permMismatch(%04o, %04o, windows=%v) = \"\", want a failure message",
+					c.got, c.want, c.windows)
+			}
+			if !c.fail && msg != "" {
+				t.Fatalf("permMismatch(%04o, %04o, windows=%v) = %q, want no failure",
+					c.got, c.want, c.windows, msg)
+			}
+			if c.fail && !strings.Contains(msg, "want") {
+				t.Fatalf("failure message %q does not say what was wanted", msg)
+			}
+		})
+	}
+}
+
+// TestPermMismatch_WindowsIsNotAlwaysPassing is the anti-skip guard, stated as
+// its own assertion rather than left implicit in the table above: if this
+// helper ever degenerates into "return \"\"" on Windows, this fails.
+func TestPermMismatch_WindowsIsNotAlwaysPassing(t *testing.T) {
+	if permMismatch(0o666, 0o444, true) == "" {
+		t.Fatal("the windows branch accepts everything — it has become a silent skip")
+	}
+}


### PR DESCRIPTION
Windows CI on `main` is red, and root-causing it turned up two production defects that had never
been visible. ubuntu-latest and macos-latest are green.

## 1. Atomic writes lose data on Windows

```
FAIL internal/atomicfile  TestWriteFile_OverwritesReadOnlyDestination
  rename ...\.ro.json.tmp-3247049508 ...\ro.json: Access is denied.
FAIL internal/graph       TestWriteDocConcurrentPassesLoseNothing
  18 of 160 concurrent writes failed — a link pass's output was dropped
```

`internal/atomicfile` arrived in #6018 to make writes safe. On Windows it does the opposite:
`os.Rename` fails when the destination is read-only (permanently — `MOVEFILE_REPLACE_EXISTING`
refuses it) or when a sharing violation occurs (transient). Two distinct causes needing two
distinct remedies. #6018 also left a **second private copy** of the helper in `internal/links`
still calling bare `os.Rename` — that copy is where the lost writes came from.

Unix permission-bit assertions (`mode = 0666, want 0600`) also fail there; NTFS represents only the
read-only bit.

## 2. The reaper wipes the watcher registry on Windows every 5 minutes

```
FAIL internal/daemon  TestReaper_sweepWatchers_NilLiveDaemonPIDFailsClosed
  WatchersReaped = 1, want 0 (live watcher must survive when LiveDaemonPID is unset)
```

`reaper.go` carried a private `pidAliveProbe` using signal-0. On Windows `(*os.Process).Signal`
returns `EWINDOWS` for anything but Kill, so it reports **false for every live pid**.
`watchreg.Sweep` checks `!deps.Alive` *before* the ownership comparison and `continue`s, so every
registered watcher is classified Dead and dropped — and #5933's entire fail-closed orphan contract
is unreachable dead code there.

The correct probe already existed: `process.IsAlive` has an `OpenProcess`/`GetExitCodeProcess`
variant and is used at six other sites. The reaper was the outlier.

## 3. The daemon can hang forever on shutdown (found while investigating the above)

A CI run died at `-timeout 15m` with one test hung 14m10s. **There was no slowdown** — real work
was 50.3s versus 53.9s on `main`, every other package uniformly faster. One test deadlocked.

From the goroutine dump, both on listener `0x23a967003900`:

- goroutine 2304, `t.Cleanup` → `go-winio@v0.6.2/pipe.go:578`, `<-l.doneCh` inside `Close`
- goroutine 2305 → `pipe.go:462`, `listenerRoutine`'s top-of-loop select, `closed == false`

`makeConnectedServerPipe` (pipe.go:429) has its own `case <-l.closeCh` at 447, so with an Accept
outstanding it consumes `Close`'s single `closeCh` send. The completion is remapped to
`ErrPipeListenerClosed` only if it is `nil` or `ErrFileClosed` (pipe.go:452); any other errno
escapes verbatim, `closed = err == ErrPipeListenerClosed` (479) stays false, the loop returns to
462 having already eaten the wakeup, `doneCh` never closes, and `Close` blocks forever.

**This is reachable from production.** `internal/daemon/server.go` closes the listener unbounded on
the graceful-shutdown path, so a wedged Windows daemon never exits — the same user-visible symptom
as #6044, arrived at from a different direction.

Which errno escapes is *not* established. The obvious candidate is ruled out:
`ERROR_OPERATION_ABORTED` is always remapped to `ErrFileClosed`, because `closeHandle`
(`file.go:114`) sets `closing` before `cancelIoEx` and `connectPipe` holds the waitgroup, so
`asyncIO` necessarily reads `closing == true` at `file.go:194-197`. The reachable variant is the
two-ready-case select at `pipe.go:441` when `connectPipe` fails with an immediate
non-`ERROR_IO_PENDING` errno — Go picks uniformly at random, and that raw errno escapes 452.

The remedy is errno-agnostic, so it holds regardless of which one it is.

## Scope

Fixed on `fix/windows-ci-atomicfile`: the rename mechanism (read-only clear + bounded retry, aligned
with the three existing in-tree copies), the duplicated helper, the reaper probe, permission
assertions adapted rather than skipped, the unbounded listener close, and the unbounded
`<-acceptDone` receive that followed it.

Deliberately **not** fixed there and left for follow-up: the other five hand-rolled Windows retry
loops (three still broken for read-only destinations), and ~50 sites still calling bare `os.Rename`
for temp→dest with no retry. The next Windows red is expected rather than surprising.
