### PR TITLE
fix(#6056): make the race detector actually run — and fix the two races that were stopping it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,18 @@ name: test
 # Milestone gate: full 3-platform matrix runs on version tags (push: tags 'v*') + manual workflow_dispatch.
 #   → batch the platform checks before shipping a milestone.
 # Opt-in: add label `ci:full` to force full 3-platform testing on a specific PR.
+# Race detector: ON for tag pushes and (by default) workflow_dispatch — see the
+# "Race detector policy" comment on the Test step for exactly what each trigger
+# delivers. There is deliberately NO push-to-main trigger; the comment used to
+# claim post-merge race sanity on main that the triggers never provided (#6056).
 
 on:
   workflow_dispatch:
+    inputs:
+      race:
+        description: 'Run the suite under the Go race detector (-race). ON by default so a pre-release dispatch matches the tag gate exactly; turn it off for a quick platform-only check.'
+        type: boolean
+        default: true
 
   push:
     tags: ['v*']
@@ -21,8 +30,9 @@ permissions:
 jobs:
   test:
     # Gate: run when —
-    #   (a) workflow_dispatch / push to main, OR
-    #   (b) pull_request_target with the `ci:full` label.
+    #   (a) workflow_dispatch, OR
+    #   (b) a `v*` tag push (the only `push` this workflow subscribes to), OR
+    #   (c) pull_request_target with the `ci:full` label.
     if: |
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
@@ -40,7 +50,7 @@ jobs:
       # We explicitly ref the PR HEAD here. This is safe because the workflow is
       # gated by the `ci:full` label (line 28 above), which only collaborators with
       # write access can apply — making this functionally equivalent to pull_request.
-      # The `|| github.sha` fallback handles workflow_dispatch and push-to-main.
+      # The `|| github.sha` fallback handles workflow_dispatch and tag pushes.
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -154,25 +164,55 @@ jobs:
             exit 1
           fi
 
-      # Race detector policy (#2406):
-      #   - push to main → always race (post-merge sanity)
-      #   - release event → always race
-      #   - PR with ci:full label → race (platform-sensitive opt-in)
-      #   - all other CI runs (standard PRs) → no race; saves ~4 min per run
+      # Race detector policy (#2406, rewired in #6056).
       #
-      # -timeout 15m: the suite with -race on a loaded CI runner can take
-      # 8-10 min end-to-end. Without -race, 3-4 min is the observed ceiling.
-      # 15m gives headroom for both modes while catching real deadlocks well
-      # before GitHub's 6-hour job limit (refs #1797 / #937 / #2196).
+      # Every condition below is reachable from this workflow's `on:` block —
+      # that is the point of #6056. The previous version documented three
+      # guarantees, two of which the triggers could never deliver: it gated on
+      # `push && ref == refs/heads/main` (this workflow has no
+      # `push: branches: [main]`, so a push to main never starts it) and on
+      # `event_name == 'release'` (there is no `release:` trigger). A `v*` tag
+      # push arrives as refs/tags/v*, so the release path ran WITHOUT -race and
+      # only a `ci:full`-labelled PR ever turned the detector on. Do not add a
+      # condition here without adding the matching trigger above.
+      #
+      # What the triggers actually deliver now:
+      #   - push of a `v*` tag  → race. This is the release gate: no tag ships
+      #     without a clean detector run on all three platforms.
+      #   - workflow_dispatch   → race when the `race` input is true (default).
+      #     Lets an operator get the exact release gate before tagging.
+      #   - PR with `ci:full`   → race (platform-sensitive opt-in).
+      #   - anything else       → no race (there is nothing else today; the
+      #     branch exists so adding a cheap trigger later stays cheap).
+      #
+      # -timeout 15m is UNCHANGED and is a KNOWN RISK on the -race path. It is
+      # per test binary, not per job. Measured on an M-series laptop:
+      # `go test -race ./internal/mcp/` alone is 525s (610s in a second,
+      # independent measurement) — 58-68% of the 900s ceiling before any
+      # parallel-package contention and before the slower CI CPUs (contention
+      # elsewhere in this repo has inflated timings 4.3x). Two tests in
+      # internal/mcp/evict_group_5872_test.go are ~76% of that package and are
+      # being throttled on chore/ci-test-gating-audit; until that lands, a tag
+      # push may hit `panic: test timed out` in internal/mcp, which fails the
+      # binary with no useful signal.
+      # Deliberately NOT raised here: the timeout value is the release owner's
+      # call (see #6056 report). If it is raised, 30m is the smallest value that
+      # keeps a 4.3x-contended internal/mcp inside the ceiling post-throttle.
+      # Next-slowest packages measured under -race on the same laptop (-p 2):
+      # internal/engine 349s, cmd/grafel 134s, internal/graph 119s,
+      # internal/membench 108s, internal/cli 44s, internal/daemon 34s;
+      # everything else < 30s. internal/engine is the second long pole and is
+      # already ~39% of the ceiling before contention or the slower CI CPUs.
+      # (refs #1797 / #937 / #2196)
       - name: Test
         shell: bash
         run: |
-          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]] || \
-             [[ "${{ github.event_name }}" == "release" ]] || \
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == refs/tags/v* ]] || \
+             [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.race }}" == "true" ]] || \
              [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}" == "true" ]]; then
-            echo "Running with -race (main / release / ci:full label)"
+            echo "Running with -race (tag push / dispatch with race=true / ci:full label)"
             go test -race -count=1 -timeout 15m ./...
           else
-            echo "Running without -race (PR fast path)"
+            echo "Running without -race"
             go test -count=1 -timeout 15m ./...
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,14 +1,21 @@
 name: test
 
-# Free-tier minute budget: macOS bills 10x, Windows 2x — one full 3-OS run ~195 billed min.
+# Free-tier minute budget: macOS bills 10x, Windows 2x. The "~195 billed min"
+# figure this comment used to quote was measured WITHOUT -race and no longer
+# describes the tag/dispatch path: -race costs roughly 5-10x wall time, and it
+# is now on by default for both (see the Race detector policy step below).
+# Locally the -race suite is ~30 min of package wall time vs ~5 min without, so
+# treat a tag run as multiples of 195 billed min, not 195. NOT re-measured on
+# GitHub runners — do that before relying on any number here (#6056).
 # Default: NO auto-CI on routine pushes/PRs. Local `go test -race` is the routine backstop.
 # Milestone gate: full 3-platform matrix runs on version tags (push: tags 'v*') + manual workflow_dispatch.
 #   → batch the platform checks before shipping a milestone.
 # Opt-in: add label `ci:full` to force full 3-platform testing on a specific PR.
 # Race detector: ON for tag pushes and (by default) workflow_dispatch — see the
 # "Race detector policy" comment on the Test step for exactly what each trigger
-# delivers. There is deliberately NO push-to-main trigger; the comment used to
-# claim post-merge race sanity on main that the triggers never provided (#6056).
+# delivers, and for why a tag push is NOT a release gate. There is deliberately
+# NO push-to-main trigger; the comment used to claim post-merge race sanity on
+# main that the triggers never provided (#6056).
 
 on:
   workflow_dispatch:
@@ -37,6 +44,15 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'push' ||
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'ci:full'))
+
+    # Bound the whole matrix leg. GitHub's default is 6 HOURS, billed at 10x on
+    # macOS — so a genuine deadlock, which is exactly what -race exists to
+    # surface, used to be the most expensive possible outcome. 90m is well above
+    # the observed -race wall time (see the Test step's timing notes) and well
+    # below the default. Distinct from `go test -timeout`, which is per test
+    # binary and only fires if a binary hangs; this one also catches a hang in
+    # any other step (module download, MSYS2 setup, the build).
+    timeout-minutes: 90
 
     strategy:
       fail-fast: false
@@ -177,32 +193,52 @@ jobs:
       # condition here without adding the matching trigger above.
       #
       # What the triggers actually deliver now:
-      #   - push of a `v*` tag  → race. This is the release gate: no tag ships
-      #     without a clean detector run on all three platforms.
+      #   - push of a `v*` tag  → race, on all three platforms.
       #   - workflow_dispatch   → race when the `race` input is true (default).
-      #     Lets an operator get the exact release gate before tagging.
       #   - PR with `ci:full`   → race (platform-sensitive opt-in).
       #   - anything else       → no race (there is nothing else today; the
       #     branch exists so adding a cheap trigger later stays cheap).
       #
-      # -timeout 15m is UNCHANGED and is a KNOWN RISK on the -race path. It is
-      # per test binary, not per job. Measured on an M-series laptop:
-      # `go test -race ./internal/mcp/` alone is 525s (610s in a second,
-      # independent measurement) — 58-68% of the 900s ceiling before any
-      # parallel-package contention and before the slower CI CPUs (contention
-      # elsewhere in this repo has inflated timings 4.3x). Two tests in
-      # internal/mcp/evict_group_5872_test.go are ~76% of that package and are
-      # being throttled on chore/ci-test-gating-audit; until that lands, a tag
-      # push may hit `panic: test timed out` in internal/mcp, which fails the
-      # binary with no useful signal.
-      # Deliberately NOT raised here: the timeout value is the release owner's
-      # call (see #6056 report). If it is raised, 30m is the smallest value that
-      # keeps a 4.3x-contended internal/mcp inside the ceiling post-throttle.
-      # Next-slowest packages measured under -race on the same laptop (-p 2):
-      # internal/engine 349s, cmd/grafel 134s, internal/graph 119s,
-      # internal/membench 108s, internal/cli 44s, internal/daemon 34s;
-      # everything else < 30s. internal/engine is the second long pole and is
-      # already ~39% of the ceiling before contention or the slower CI CPUs.
+      # A TAG PUSH IS NOT A RELEASE GATE. Say what the trigger delivers and no
+      # more — claiming otherwise is the #6056 defect all over again.
+      # release.yml is `on: push: tags: ['v*']`, the SAME trigger, and its job
+      # graph (dashboard → build → release) has no `needs:` on this workflow, no
+      # `workflow_run`, and no environment approval. The two workflows start
+      # concurrently and neither can fail the other: release.yml can publish the
+      # Release at ~14 min while this workflow is still running, and a race
+      # tripped by the windows leg at ~22 min lands on an already-shipped tag.
+      # On the tag path -race is a POST-MORTEM.
+      # The only mechanism by which -race actually blocks a release today is the
+      # manual `workflow_dispatch` on the release commit BEFORE tagging — which
+      # is why the `race` input exists and why it defaults to true, and it is a
+      # required §0 checkbox in docs/runbooks/release-signoff.md.
+      # Recommended follow-up (NOT done here — it changes how releases work and
+      # is the user's call): make release.yml's first job `needs:` a green test
+      # run, or gate the publish step on a `workflow_run` of this workflow.
+      #
+      # -timeout is PER TEST BINARY, and the two branches need different values.
+      #
+      # -race branch → 40m. Measured on an M-series laptop at -p 2:
+      # internal/mcp 525s (610s in a second, independent measurement) and
+      # internal/engine 349s. Against the old 15m/900s ceiling that is 58-68%
+      # and 39% respectively — consumed BEFORE the two effects that only apply
+      # on CI: default -p equals runner cores (4 on ubuntu/windows, i.e. MORE
+      # concurrent packages than measured here), and the runners' CPUs are
+      # slower than this laptop. This file's own history cites 4.3x contention
+      # inflation. 15m would therefore have produced `panic: test timed out` in
+      # internal/mcp on the very tag run this change enables — red, with no race
+      # signal, indistinguishable from a real failure and strictly worse than no
+      # signal at all. 40m (not 30m) so the value does not depend on any other
+      # branch landing an internal/mcp speedup first.
+      # Next-slowest under -race: cmd/grafel 134s, internal/graph 119s,
+      # internal/membench 108s, internal/cli 44s, internal/daemon 34s; the
+      # remaining ~230 packages < 30s.
+      #
+      # no-race branch → 15m, unchanged; nothing about the non-race path moved.
+      #
+      # Job-level timeout-minutes: 90 (above) bounds the whole matrix leg. A
+      # genuine deadlock — precisely what -race exists to surface — otherwise
+      # runs to GitHub's 6-hour default on a 10x-billed macOS runner.
       # (refs #1797 / #937 / #2196)
       - name: Test
         shell: bash
@@ -211,7 +247,7 @@ jobs:
              [[ "${{ github.event_name }}" == "workflow_dispatch" && "${{ inputs.race }}" == "true" ]] || \
              [[ "${{ contains(github.event.pull_request.labels.*.name, 'ci:full') }}" == "true" ]]; then
             echo "Running with -race (tag push / dispatch with race=true / ci:full label)"
-            go test -race -count=1 -timeout 15m ./...
+            go test -race -count=1 -timeout 40m ./...
           else
             echo "Running without -race"
             go test -count=1 -timeout 15m ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ on:
   workflow_dispatch:
     inputs:
       race:
-        description: 'Run the suite under the Go race detector (-race). ON by default so a pre-release dispatch matches the tag gate exactly; turn it off for a quick platform-only check.'
+        description: 'Run the suite under the Go race detector (-race). ON by default so a pre-release dispatch matches the tag run exactly; turn it off for a quick platform-only check.'
         type: boolean
         default: true
 

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -49,17 +49,25 @@ ladder. Run it on real hardware for each release.
       **Triaging a red run — known flake.** `internal/daemon` has a
       *pre-existing* family of test-seam data races that `-race` reports at
       roughly **1 run in 8**, i.e. ~1 dispatch in 3 reds at least one OS leg.
-      The shape is a plain package-var timeout seam written by a test while a
-      live goroutine reads it: `rebuildRPCTimeout` (written by
+      The shape is a plain package-var seam written by a test while a live
+      goroutine reads it: `rebuildRPCTimeout` (written by
       `rebuild_singleflight_test.go`, read from the `net/rpc` serving goroutine
       in `service.go`, failing `TestRebuild_SingleFlight_NoConcurrentOverlap`),
-      and the `rebuildWaitTimeout` / `rebuildWaitInterval` /
-      `rebuildStartupWindow` / `rebuildStaleAfter` group documented at
-      `internal/daemon/rebuild_wait.go`. If a red run's `WARNING: DATA RACE`
-      names one of those vars, it is the known flake — **re-dispatch**, and do
-      not treat it as a release blocker. Anything else is real: read the report
-      before deciding. Tracked separately; when that family is fixed, delete
-      this paragraph rather than letting it excuse a future failure.
+      plus the group declared in `internal/daemon/rebuild_wait.go` —
+      `rebuildWaitTimeout`, `rebuildWaitInterval`, `rebuildWaitStartupWindow`,
+      `rebuildWaitStaleAfter`, `rebuildWaitClock` and `rebuildEngineAliveFn`.
+
+      **Match the report against those exact identifiers.** The instruction
+      below is scoped by name, which is the only reason it is safe — it cannot
+      launder an unrelated race. A misspelled name in this list breaks that
+      property rather than merely being untidy, so every name here has been
+      grepped against the tree; re-grep before editing it.
+
+      If a red run's `WARNING: DATA RACE` names one of those vars, it is the
+      known flake — **re-dispatch**, and do not treat it as a release blocker.
+      Anything else is real: read the report before deciding. Tracked
+      separately; when that family is fixed, delete this paragraph rather than
+      letting it excuse a future failure.
 - [ ] `CHANGELOG.md` has a `[X.Y.Z] — YYYY-MM-DD` section; `[Unreleased]` is
       drained.
 - [ ] `go build ./...` and `go vet ./...` are clean locally.

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -46,28 +46,43 @@ ladder. Run it on real hardware for each release.
       Expect this to take substantially longer than a non-race run — `-race`
       costs roughly 5-10x wall time, and `internal/mcp` alone is ~9-10 min.
 
-      **Triaging a red run — known flake.** `internal/daemon` has a
-      *pre-existing* family of test-seam data races that `-race` reports at
-      roughly **1 run in 8**, i.e. ~1 dispatch in 3 reds at least one OS leg.
-      The shape is a plain package-var seam written by a test while a live
-      goroutine reads it: `rebuildRPCTimeout` (written by
+      **Triaging a red run — two known failures.** Both are pre-existing and
+      tracked separately. Anything that is not one of these two is real: read
+      the report before deciding. When either is fixed, delete its entry rather
+      than letting it excuse a future failure.
+
+      **(a) `internal/daemon` test-seam data races** — reported at roughly
+      **1 run in 8**, i.e. ~1 dispatch in 3 reds at least one OS leg. The shape
+      is a plain package-var seam written by a test while a live goroutine
+      reads it: `rebuildRPCTimeout` (written by
       `rebuild_singleflight_test.go`, read from the `net/rpc` serving goroutine
       in `service.go`, failing `TestRebuild_SingleFlight_NoConcurrentOverlap`),
       plus the group declared in `internal/daemon/rebuild_wait.go` —
       `rebuildWaitTimeout`, `rebuildWaitInterval`, `rebuildWaitStartupWindow`,
       `rebuildWaitStaleAfter`, `rebuildWaitClock` and `rebuildEngineAliveFn`.
 
-      **Match the report against those exact identifiers.** The instruction
-      below is scoped by name, which is the only reason it is safe — it cannot
-      launder an unrelated race. A misspelled name in this list breaks that
-      property rather than merely being untidy, so every name here has been
-      grepped against the tree; re-grep before editing it.
+      **Match the report against those exact identifiers.** This instruction is
+      scoped by name, which is the only reason it is safe — it cannot launder
+      an unrelated race. A misspelled name in this list breaks that property
+      rather than merely being untidy, so every name here has been grepped
+      against the tree; re-grep before editing it. If a red run's
+      `WARNING: DATA RACE` names one of those vars → **re-dispatch**.
 
-      If a red run's `WARNING: DATA RACE` names one of those vars, it is the
-      known flake — **re-dispatch**, and do not treat it as a release blocker.
-      Anything else is real: read the report before deciding. Tracked
-      separately; when that family is fixed, delete this paragraph rather than
-      letting it excuse a future failure.
+      **(b) `TestV2GraphRestoresDiskPayloadBeforeLoadingGraph`
+      (`internal/dashboard`)** — assertion-only, **no `DATA RACE` in the
+      report**. It fails with `cold disk response = status 200 body
+      {...total_node_count:0}`: the disk-payload lookup missed and an empty
+      graph was served. Seen at roughly **2 runs in 21**, only in FULL-package
+      runs — it has never reproduced in isolation (20/20 clean with `-run`), so
+      do not try to confirm it by re-running the single test. → **Re-dispatch
+      once. If it repeats on the re-dispatch, escalate** — the rate is low
+      enough that twice in a row is not the known failure.
+
+      Entry (b) is listed for the same reason (a) is: this checkbox is a
+      REQUIRED gate, and a red gate whose cause is undocumented stalls a
+      release just as effectively as a real defect. Documenting only the race
+      and silently omitting this one would leave the gate untrustworthy in
+      exactly the way #6056 was about.
 - [ ] `CHANGELOG.md` has a `[X.Y.Z] — YYYY-MM-DD` section; `[Unreleased]` is
       drained.
 - [ ] `go build ./...` and `go vet ./...` are clean locally.

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -45,6 +45,21 @@ ladder. Run it on real hardware for each release.
 
       Expect this to take substantially longer than a non-race run — `-race`
       costs roughly 5-10x wall time, and `internal/mcp` alone is ~9-10 min.
+
+      **Triaging a red run — known flake.** `internal/daemon` has a
+      *pre-existing* family of test-seam data races that `-race` reports at
+      roughly **1 run in 8**, i.e. ~1 dispatch in 3 reds at least one OS leg.
+      The shape is a plain package-var timeout seam written by a test while a
+      live goroutine reads it: `rebuildRPCTimeout` (written by
+      `rebuild_singleflight_test.go`, read from the `net/rpc` serving goroutine
+      in `service.go`, failing `TestRebuild_SingleFlight_NoConcurrentOverlap`),
+      and the `rebuildWaitTimeout` / `rebuildWaitInterval` /
+      `rebuildStartupWindow` / `rebuildStaleAfter` group documented at
+      `internal/daemon/rebuild_wait.go`. If a red run's `WARNING: DATA RACE`
+      names one of those vars, it is the known flake — **re-dispatch**, and do
+      not treat it as a release blocker. Anything else is real: read the report
+      before deciding. Tracked separately; when that family is fixed, delete
+      this paragraph rather than letting it excuse a future failure.
 - [ ] `CHANGELOG.md` has a `[X.Y.Z] — YYYY-MM-DD` section; `[Unreleased]` is
       drained.
 - [ ] `go build ./...` and `go vet ./...` are clean locally.

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -31,6 +31,20 @@ ladder. Run it on real hardware for each release.
 - [ ] `acceptance.yml` has a **green** `workflow_dispatch` run on the release
       commit across **all three** OSes (ubuntu-latest, windows-latest,
       macos-14). Re-dispatch if the last run predates the commit.
+- [ ] `test.yml` has a **green** `workflow_dispatch` run **with the `race`
+      input left ON (the default)** on the release commit, across all three
+      OSes. Re-dispatch if the last run predates the commit.
+
+      **This is the only thing that makes the race detector a release gate.**
+      `test.yml` does run with `-race` on a `v*` tag push, but `release.yml`
+      fires on that *same* tag and does not depend on it: the two start
+      concurrently, and `release.yml` typically publishes the Release before
+      the slowest `test.yml` leg finishes. A race caught by the tag run lands
+      on a tag that has already shipped. Dispatching **before** tagging is what
+      converts `-race` from a post-mortem into a gate (#6056).
+
+      Expect this to take substantially longer than a non-race run — `-race`
+      costs roughly 5-10x wall time, and `internal/mcp` alone is ~9-10 min.
 - [ ] `CHANGELOG.md` has a `[X.Y.Z] — YYYY-MM-DD` section; `[Unreleased]` is
       drained.
 - [ ] `go build ./...` and `go vet ./...` are clean locally.

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/process"
@@ -44,11 +45,32 @@ const (
 	engineHealthStaleMultiplier = 3
 )
 
-// engineChildCommand builds the exec.Cmd that launches the engine child. It is
-// a package var so tests can substitute a helper-process command (the standard
-// os/exec subprocess-testing pattern) instead of spawning a real grafel binary.
-// Production uses defaultEngineChildCommand.
-var engineChildCommand = defaultEngineChildCommand
+// engineChildCommandFunc builds the exec.Cmd that launches the engine child.
+type engineChildCommandFunc func(selfExe, root string) *exec.Cmd
+
+// engineChildCommandOverride holds the test seam that substitutes a
+// helper-process command (the standard os/exec subprocess-testing pattern) for
+// a real grafel binary. nil (the zero value) means "use production's
+// defaultEngineChildCommand"; production never stores anything here.
+//
+// #6056: this MUST stay an atomic. engineSupervisor.run resolves the seam
+// repeatedly from a live goroutine, so a test's deferred restore() writing it
+// during cleanup races that loop. Making it an atomic.Pointer removes the
+// plain-access form entirely: there is no way to read or write it
+// unsynchronised, so the protection cannot be silently dropped by a caller
+// that forgets to join the supervisor first. (Contrast listenFn, read exactly
+// once at startup — repeated reads from a live goroutine are the hazard, not
+// the seam pattern.)
+var engineChildCommandOverride atomic.Pointer[engineChildCommandFunc]
+
+// engineChildCommand resolves the effective child-spawn constructor: the test
+// override when one is installed, else the production default.
+func engineChildCommand(selfExe, root string) *exec.Cmd {
+	if fn := engineChildCommandOverride.Load(); fn != nil {
+		return (*fn)(selfExe, root)
+	}
+	return defaultEngineChildCommand(selfExe, root)
+}
 
 // defaultEngineChildCommand launches `grafel engine --foreground` from the
 // current executable, in its own process group, with stdio inherited so its
@@ -92,10 +114,13 @@ func defaultEngineChildCommand(selfExe, root string) *exec.Cmd {
 // child for the duration of a test and returns a restore closure. Tests use it
 // to spawn a helper subprocess (re-invoking the test binary) rather than a real
 // grafel binary. Production code must never call this.
+// Overrides nest LIFO: restore() puts back whatever was installed before, so
+// an inner Set/restore pair inside an outer one behaves correctly.
 func SetEngineChildCommandForTest(fn func(selfExe, root string) *exec.Cmd) (restore func()) {
-	prev := engineChildCommand
-	engineChildCommand = fn
-	return func() { engineChildCommand = prev }
+	prev := engineChildCommandOverride.Load()
+	next := engineChildCommandFunc(fn)
+	engineChildCommandOverride.Store(&next)
+	return func() { engineChildCommandOverride.Store(prev) }
 }
 
 // engineSupervisor spawns and supervises the split-mode engine child process.

--- a/internal/daemon/supervise.go
+++ b/internal/daemon/supervise.go
@@ -116,8 +116,19 @@ func defaultEngineChildCommand(selfExe, root string) *exec.Cmd {
 // grafel binary. Production code must never call this.
 // Overrides nest LIFO: restore() puts back whatever was installed before, so
 // an inner Set/restore pair inside an outer one behaves correctly.
+//
+// fn == nil CLEARS the override (the seam falls back to
+// defaultEngineChildCommand), matching setBackgroundAlgoGateForTest /
+// setBackgroundAlgoDoneForTest in internal/dashboard. Without this branch a nil
+// fn would store a non-nil pointer to a nil func and the next resolve would
+// panic on the call — a latent trap for the first caller that clears by passing
+// nil rather than by calling restore().
 func SetEngineChildCommandForTest(fn func(selfExe, root string) *exec.Cmd) (restore func()) {
 	prev := engineChildCommandOverride.Load()
+	if fn == nil {
+		engineChildCommandOverride.Store(nil)
+		return func() { engineChildCommandOverride.Store(prev) }
+	}
 	next := engineChildCommandFunc(fn)
 	engineChildCommandOverride.Store(&next)
 	return func() { engineChildCommandOverride.Store(prev) }

--- a/internal/daemon/supervise_seam_race_test.go
+++ b/internal/daemon/supervise_seam_race_test.go
@@ -94,3 +94,45 @@ func TestEngineChildCommandSeam_ConcurrentOverrideAndRead(t *testing.T) {
 		t.Fatal("seam override was never invoked — fixture cannot exhibit the race it claims to guard")
 	}
 }
+
+// TestSetEngineChildCommandForTest_NilClears pins the nil convention (#6056
+// review F6): passing nil CLEARS the override rather than installing a nil
+// func, matching setBackgroundAlgoGateForTest / setBackgroundAlgoDoneForTest in
+// internal/dashboard. Without the nil branch this test panics with
+// "invalid memory address or nil pointer dereference" on the resolve below,
+// which is exactly the trap the convention exists to remove.
+func TestSetEngineChildCommandForTest_NilClears(t *testing.T) {
+	root := t.TempDir()
+
+	// Install a real override first, so "clear" has something to clear and a
+	// no-op implementation cannot pass by accident.
+	installed := false
+	restoreOuter := SetEngineChildCommandForTest(func(selfExe, r string) *exec.Cmd {
+		installed = true
+		return exec.Command("true")
+	})
+	defer restoreOuter()
+	if cmd := engineChildCommand("/nonexistent/selfexe", root); cmd == nil {
+		t.Fatal("resolve returned nil under the installed override")
+	}
+	if !installed {
+		t.Fatal("override was not invoked — fixture cannot detect a failed clear")
+	}
+
+	restoreNil := SetEngineChildCommandForTest(nil)
+	cmd := engineChildCommand("/nonexistent/selfexe", root)
+	if len(cmd.Args) < 3 || cmd.Args[1] != "engine" || cmd.Args[2] != "--foreground" {
+		t.Fatalf("nil did not clear the override: args=%v", cmd.Args)
+	}
+
+	// restore() after a nil clear must put the previous override back, so a
+	// nil clear nests like any other.
+	restoreNil()
+	installed = false
+	if cmd := engineChildCommand("/nonexistent/selfexe", root); cmd == nil {
+		t.Fatal("resolve returned nil after restoring the outer override")
+	}
+	if !installed {
+		t.Fatal("restore() after a nil clear did not reinstate the previous override")
+	}
+}

--- a/internal/daemon/supervise_seam_race_test.go
+++ b/internal/daemon/supervise_seam_race_test.go
@@ -1,0 +1,96 @@
+package daemon
+
+import (
+	"os/exec"
+	"sync"
+	"testing"
+)
+
+// TestEngineChildCommandSeam_ConcurrentOverrideAndRead pins the fix for #6056.
+//
+// The hazard is NOT the test seam itself — it is that the supervisor's respawn
+// loop (engineSupervisor.run) reads the seam REPEATEDLY from a live goroutine,
+// while a test's deferred restore() writes it during cleanup. Contrast
+// listenFn, which is read exactly once at startup and is therefore clean.
+//
+// This test reproduces that exact shape without a real supervisor: a live
+// reader goroutine resolves the seam in a loop while the test installs and
+// restores overrides. It has two independent failure modes, so it cannot
+// silently stop protecting:
+//
+//   - Under -race (the CI tag / workflow_dispatch path, and the local
+//     backstop): if the seam ever goes back to a plain package var, the
+//     write/read pair is unsynchronised and the detector fails this test.
+//   - Without -race: the restore-semantics assertions below still go RED if
+//     Set/restore stops being LIFO-correct or stops reverting to the
+//     production default.
+func TestEngineChildCommandSeam_ConcurrentOverrideAndRead(t *testing.T) {
+	// Resolve the temp root once, up front: calling t.TempDir() inside the
+	// loops would take testing's own mutex on every iteration, creating
+	// happens-before edges that hide the very race this test exists to catch.
+	root := t.TempDir()
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Resolve the seam the way engineSupervisor.run does. We only
+			// resolve it; we never Start() the returned command.
+			if cmd := engineChildCommand("/nonexistent/selfexe", root); cmd == nil {
+				panic("engine child command resolved to nil")
+			}
+		}
+	}()
+
+	var mu sync.Mutex
+	invoked := 0
+	mkA := func(selfExe, r string) *exec.Cmd {
+		mu.Lock()
+		invoked++
+		mu.Unlock()
+		return exec.Command("true")
+	}
+	mkB := func(selfExe, r string) *exec.Cmd {
+		mu.Lock()
+		invoked++
+		mu.Unlock()
+		return exec.Command("true")
+	}
+
+	for i := 0; i < 2000; i++ {
+		restoreA := SetEngineChildCommandForTest(mkA)
+		restoreB := SetEngineChildCommandForTest(mkB)
+		// Resolve under the override too, so the seam is exercised in both
+		// directions rather than only written.
+		_ = engineChildCommand("/nonexistent/selfexe", root)
+		restoreB()
+		restoreA()
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Restore semantics (these fail without -race too): after every override
+	// has been restored, the seam must resolve back to the production default,
+	// i.e. `<selfExe> engine --foreground`.
+	cmd := engineChildCommand("/nonexistent/selfexe", root)
+	if len(cmd.Args) < 3 || cmd.Args[1] != "engine" || cmd.Args[2] != "--foreground" {
+		t.Fatalf("after restore, seam did not resolve to defaultEngineChildCommand: args=%v", cmd.Args)
+	}
+
+	// Guard against a vacuous fixture: if no override was ever actually
+	// invoked, this test would be exercising nothing.
+	mu.Lock()
+	n := invoked
+	mu.Unlock()
+	if n == 0 {
+		t.Fatal("seam override was never invoked — fixture cannot exhibit the race it claims to guard")
+	}
+}

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -1037,16 +1038,53 @@ type persistedAlgo struct {
 	Results         *graph.AlgorithmResults `json:"results"`
 }
 
-// backgroundAlgoGate, when non-nil, blocks a scheduled background Pass-4
-// computation until it receives — a TEST-ONLY seam so a test can deterministically
-// assert the load returned WITHOUT the full sweep having run. Never set in prod.
-var backgroundAlgoGate chan struct{}
+// backgroundAlgoGate / backgroundAlgoDone are TEST-ONLY seams, never set in
+// prod, both read from the background Pass-4 goroutine started by
+// schedulePendingAlgo.
+//
+// #6056: both MUST stay atomics. The reader is a LIVE goroutine that outlives
+// the request that started it, while the writer is a test's t.Cleanup —
+// exactly the shape that raced in internal/daemon's engineChildCommand. Storing
+// them in an atomic.Pointer removes the plain-access form entirely, so the
+// protection cannot be silently dropped by a fixture that forgets to join the
+// sweep before restoring. (A seam read exactly once at startup would be fine;
+// repeated reads from a live goroutine are the hazard.)
+type (
+	algoGateChan chan struct{}
+	algoDoneFunc func(cacheKey string)
+)
 
-// backgroundAlgoDone, when non-nil, is invoked with the cache key after a
-// background Pass-4 computation has been persisted AND its cache entry evicted.
-// Test-only seam so a test can wait for the async work without polling. Never
-// set in prod.
-var backgroundAlgoDone func(cacheKey string)
+// backgroundAlgoGate, when set, blocks a scheduled background Pass-4
+// computation until it receives — so a test can deterministically assert the
+// load returned WITHOUT the full sweep having run.
+var backgroundAlgoGate atomic.Pointer[algoGateChan]
+
+// backgroundAlgoDone, when set, is invoked with the cache key after a
+// background Pass-4 computation has been persisted AND its cache entry evicted,
+// so a test can wait for the async work without polling.
+var backgroundAlgoDone atomic.Pointer[algoDoneFunc]
+
+// setBackgroundAlgoGateForTest installs (ch != nil) or clears (ch == nil) the
+// gate seam. Test-only.
+func setBackgroundAlgoGateForTest(ch chan struct{}) {
+	if ch == nil {
+		backgroundAlgoGate.Store(nil)
+		return
+	}
+	g := algoGateChan(ch)
+	backgroundAlgoGate.Store(&g)
+}
+
+// setBackgroundAlgoDoneForTest installs (fn != nil) or clears (fn == nil) the
+// completion seam. Test-only.
+func setBackgroundAlgoDoneForTest(fn func(cacheKey string)) {
+	if fn == nil {
+		backgroundAlgoDone.Store(nil)
+		return
+	}
+	d := algoDoneFunc(fn)
+	backgroundAlgoDone.Store(&d)
+}
 
 // pendingAlgoRepo names a repo whose served graph.fb omitted Pass-4 and whose
 // sidecar was absent/stale, so the full sweep must be computed off the request
@@ -1109,8 +1147,8 @@ func (c *GraphCache) schedulePendingAlgo(cacheKey string, grp *DashGroup) {
 		return
 	}
 	go func() {
-		if backgroundAlgoGate != nil {
-			<-backgroundAlgoGate
+		if gate := backgroundAlgoGate.Load(); gate != nil {
+			<-(chan struct{})(*gate)
 		}
 		for _, p := range pending {
 			// READ-ONLY over p.doc.Entities/Relationships (RunAlgorithms mutates
@@ -1132,8 +1170,8 @@ func (c *GraphCache) schedulePendingAlgo(cacheKey string, grp *DashGroup) {
 			delete(c.entries, cacheKey)
 		}
 		c.mu.Unlock()
-		if backgroundAlgoDone != nil {
-			backgroundAlgoDone(cacheKey)
+		if done := backgroundAlgoDone.Load(); done != nil {
+			(*done)(cacheKey)
 		}
 	}()
 }

--- a/internal/dashboard/graphstate_pass4_test.go
+++ b/internal/dashboard/graphstate_pass4_test.go
@@ -176,6 +176,16 @@ func TestApplyAlgorithmsOnLoad_NonBlockingThenPersistsAndEvicts(t *testing.T) {
 	c.schedulePendingAlgo("g", grp)
 
 	// Still gated: entry present, live doc untouched.
+	//
+	// CAVEAT (#6056 review F7, filed separately): this block does NOT actually
+	// prove the gate held. Mutating setBackgroundAlgoGateForTest so the gate is
+	// never installed leaves this test passing 5/5 — the background goroutine
+	// simply has not been scheduled yet by the time we look. The assertion is
+	// timing luck, not gate coverage. Real coverage of the seam's install/clear
+	// behaviour lives in TestBackgroundAlgoSeams_ConcurrentSetAndRead
+	// (graphstate_seam_race_test.go), which does go RED under that mutation.
+	// Making THIS test honest needs a deterministic "sweep has reached the
+	// gate" signal, not a stronger assertion here.
 	c.mu.Lock()
 	_, present := c.entries["g"]
 	c.mu.Unlock()

--- a/internal/dashboard/graphstate_pass4_test.go
+++ b/internal/dashboard/graphstate_pass4_test.go
@@ -152,9 +152,9 @@ func TestApplyAlgorithmsOnLoad_NonBlockingThenPersistsAndEvicts(t *testing.T) {
 	// returned BEFORE the full sweep ran.
 	gate := make(chan struct{})
 	done := make(chan string, 1)
-	backgroundAlgoGate = gate
-	backgroundAlgoDone = func(k string) { done <- k }
-	t.Cleanup(func() { backgroundAlgoGate = nil; backgroundAlgoDone = nil })
+	setBackgroundAlgoGateForTest(gate)
+	setBackgroundAlgoDoneForTest(func(k string) { done <- k })
+	t.Cleanup(func() { setBackgroundAlgoGateForTest(nil); setBackgroundAlgoDoneForTest(nil) })
 
 	stateDir := t.TempDir()
 	doc := pathGraphDoc()
@@ -213,10 +213,10 @@ func TestApplyAlgorithmsOnLoad_NonBlockingThenPersistsAndEvicts(t *testing.T) {
 // Communities/PageRank/Centrality WHILE the background sweep runs. Because the
 // sweep is read-only over the published doc, `go test -race` must be clean.
 func TestSchedulePendingAlgo_NoDataRaceWithConcurrentReaders(t *testing.T) {
-	backgroundAlgoGate = nil // run immediately, maximise overlap with readers
+	setBackgroundAlgoGateForTest(nil) // run immediately, maximise overlap with readers
 	done := make(chan string, 1)
-	backgroundAlgoDone = func(k string) { done <- k }
-	t.Cleanup(func() { backgroundAlgoDone = nil })
+	setBackgroundAlgoDoneForTest(func(k string) { done <- k })
+	t.Cleanup(func() { setBackgroundAlgoDoneForTest(nil) })
 
 	stateDir := t.TempDir()
 	doc := pathGraphDocN(60)
@@ -285,11 +285,11 @@ func TestSchedulePendingAlgo_PersistFailureDoesNotRecomputeForever(t *testing.T)
 		// POSIX dir-write-permission semantics are a real requirement here.
 		t.Skip("POSIX dir-write-permission semantics required")
 	}
-	backgroundAlgoGate = nil // run immediately
+	setBackgroundAlgoGateForTest(nil) // run immediately
 	var computes int32
 	done := make(chan string, 4)
-	backgroundAlgoDone = func(k string) { atomic.AddInt32(&computes, 1); done <- k }
-	t.Cleanup(func() { backgroundAlgoDone = nil })
+	setBackgroundAlgoDoneForTest(func(k string) { atomic.AddInt32(&computes, 1); done <- k })
+	t.Cleanup(func() { setBackgroundAlgoDoneForTest(nil) })
 
 	stateDir := t.TempDir()
 	// Force persistAlgoResults to fail: a read-only state dir makes its

--- a/internal/dashboard/graphstate_seam_race_test.go
+++ b/internal/dashboard/graphstate_seam_race_test.go
@@ -1,0 +1,91 @@
+package dashboard
+
+import (
+	"sync"
+	"testing"
+)
+
+// TestBackgroundAlgoSeams_ConcurrentSetAndRead pins the second fix for #6056.
+//
+// schedulePendingAlgo starts a LIVE background goroutine that reads
+// backgroundAlgoGate (and later backgroundAlgoDone) after the request that
+// started it has returned. Fixtures set those seams and clear them from
+// t.Cleanup, which is precisely the write-during-live-read shape that made
+// TestHandleGroupStats_NoRef fail under -race.
+//
+// Two independent failure modes, so this cannot silently stop protecting:
+//
+//   - Under -race: if either seam goes back to a plain package var, the
+//     set/clear here races the reader loop and the detector fails this test.
+//   - Without -race: the install/clear assertions below go RED if
+//     setBackgroundAlgoGateForTest / setBackgroundAlgoDoneForTest stop
+//     actually installing or actually clearing the seam.
+func TestBackgroundAlgoSeams_ConcurrentSetAndRead(t *testing.T) {
+	// Save and restore whatever the package-level state was, so this test does
+	// not leak a seam into any other test in this package.
+	prevGate := backgroundAlgoGate.Load()
+	prevDone := backgroundAlgoDone.Load()
+	t.Cleanup(func() {
+		backgroundAlgoGate.Store(prevGate)
+		backgroundAlgoDone.Store(prevDone)
+	})
+
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			// Read both seams the way the background sweep does. We never
+			// receive on the gate (that would park us) and never invoke done.
+			_ = backgroundAlgoGate.Load()
+			_ = backgroundAlgoDone.Load()
+		}
+	}()
+
+	ch := make(chan struct{})
+	for i := 0; i < 2000; i++ {
+		setBackgroundAlgoGateForTest(ch)
+		setBackgroundAlgoDoneForTest(func(string) {})
+		setBackgroundAlgoGateForTest(nil)
+		setBackgroundAlgoDoneForTest(nil)
+	}
+
+	close(stop)
+	wg.Wait()
+
+	// Install must actually install (fails without -race).
+	setBackgroundAlgoGateForTest(ch)
+	got := backgroundAlgoGate.Load()
+	if got == nil {
+		t.Fatal("setBackgroundAlgoGateForTest(ch) did not install the gate")
+	}
+	if (chan struct{})(*got) != ch {
+		t.Fatal("setBackgroundAlgoGateForTest installed a different channel")
+	}
+	var called bool
+	setBackgroundAlgoDoneForTest(func(string) { called = true })
+	d := backgroundAlgoDone.Load()
+	if d == nil {
+		t.Fatal("setBackgroundAlgoDoneForTest(fn) did not install the callback")
+	}
+	(*d)("k")
+	if !called {
+		t.Fatal("installed done callback was not the one provided")
+	}
+
+	// Clear must actually clear (fails without -race).
+	setBackgroundAlgoGateForTest(nil)
+	if backgroundAlgoGate.Load() != nil {
+		t.Fatal("setBackgroundAlgoGateForTest(nil) did not clear the gate")
+	}
+	setBackgroundAlgoDoneForTest(nil)
+	if backgroundAlgoDone.Load() != nil {
+		t.Fatal("setBackgroundAlgoDoneForTest(nil) did not clear the callback")
+	}
+}

--- a/internal/dashboard/graphstate_seam_race_test.go
+++ b/internal/dashboard/graphstate_seam_race_test.go
@@ -254,7 +254,16 @@ func TestBackgroundAlgoGate_ClearedBetweenCheckAndUse(t *testing.T) {
 		case <-swept:
 			sweeps++
 		case <-time.After(10 * time.Second):
-			t.Fatal("background sweep never reported completion — seam wiring broken")
+			// 10s is now the tighter of this test's two bounds (maxWall is
+			// 180s), so word this for both causes rather than only the likely
+			// one. A sweep here is an empty doc plus an os.CreateTemp that
+			// fails immediately against a read-only dir — microseconds of work,
+			// so 10s is ~10^6x headroom and "broken wiring" is the overwhelming
+			// favourite. It is not the only possibility.
+			t.Fatal("background sweep never reported completion within 10s — " +
+				"either the seam wiring is broken (backgroundAlgoDone no longer " +
+				"fires, or schedulePendingAlgo stopped spawning) or the machine " +
+				"is pathologically slow, in which case raise this bound")
 		}
 	}
 

--- a/internal/dashboard/graphstate_seam_race_test.go
+++ b/internal/dashboard/graphstate_seam_race_test.go
@@ -111,27 +111,29 @@ func TestBackgroundAlgoSeams_ConcurrentSetAndRead(t *testing.T) {
 // worth recording, because "the fix made the latent bug catchable" is the only
 // reason this test can exist at all.
 //
-// Two ingredients make the window reachable, and both are load-bearing:
+// THREE ingredients make the window reachable. Each has been verified
+// load-bearing by mutating it away:
 //
 //  1. A CLOSED channel as the installed gate. Every other fixture installs
 //     either an open channel (the sweep parks on load #2 and never returns) or
 //     nil (load #1 is false, so load #2 never executes). Neither traverses the
 //     window more than once. A closed channel makes the receive non-blocking,
 //     so the reader streams through the window as fast as it can be scheduled.
+//     Mutate the close() away and this test fails with "background sweep never
+//     reported completion" instead of exercising anything.
 //  2. BOUNDED in-flight sweeps, via the backgroundAlgoDone seam: wait for each
 //     sweep to finish before scheduling the next. Unbounded, the harness dies
 //     of "pthread_create failed: Resource temporarily unavailable" on CORRECT
 //     code — a false positive that reds both arms and proves nothing.
+//  3. An EMPTY doc and a READ-ONLY state dir, so a sweep costs almost nothing
+//     but the window itself. With a real doc and a writable dir the sweep rate
+//     drops ~50x and the mutated arm survives.
 //
-// Third ingredient: an EMPTY doc and a READ-ONLY state dir, so a sweep costs
-// almost nothing but the window itself. With a real doc and a writable dir the
-// sweep rate drops ~50x and the mutated arm survives.
-//
-// Verified to separate, on the final fixture (M-series laptop):
+// Verified to separate, on the final fixture (M-series laptop, 16 runs):
 //
 //	              correct code            double-read mutation
-//	-race         8/8 PASS  1.5-4.0s      5/5 FAIL  panic in 1.2-1.5s
-//	no -race      8/8 PASS  0.76-0.92s    3/3 FAIL  panic in 0.8-1.5s
+//	-race         5/5 PASS  2.5-4.5s      5/5 FAIL  panic in 1.1-1.7s
+//	no -race      3/3 PASS  1.0-1.3s      3/3 FAIL  panic in 0.8-1.4s
 //
 // Note the panic is a plain TOCTOU, not a data race: the detector is NOT what
 // catches it, which is why the no-race arm has to work too and why it needs its
@@ -203,28 +205,41 @@ func TestBackgroundAlgoGate_ClearedBetweenCheckAndUse(t *testing.T) {
 	// power is a function of how many times the reader crosses the window, and
 	// the rate varies ~30x between modes (measured on an M-series laptop:
 	// ~5000 traversals/s without -race, ~150/s with it) and again with machine
-	// speed. A fixed time budget would therefore hand a slow CI runner far less
-	// sampling than the machine it was tuned on — and this test now sits behind
-	// a REQUIRED release checkbox, so a fixture that reds on slowness would be
-	// worse than no fixture. Targeting a count makes the sampling identical
-	// everywhere; the wall cap only bounds a pathological machine.
-	// The two modes need DIFFERENT targets, and both were measured against the
-	// mutated arm rather than guessed:
-	//   -race    → 400 traversals. -race widens the window, so the double-read
-	//              mutation panics within a few hundred; 400 costs ~3s.
-	//   no -race → 5000 traversals. The window is a couple of instructions
-	//              wide, so detection needs volume; at 400 the mutated arm
-	//              survived 3/3 runs, at 5000 it fails. Costs ~1s.
-	// Using the -race number in both modes would leave the no-race arm unable
-	// to exhibit the bug — the failure mode this repo hits most often.
+	// speed. A fixed time budget would hand a slow CI runner far less sampling
+	// than the machine it was tuned on; targeting a count makes the sampling
+	// identical everywhere.
+	//
+	// The two modes need DIFFERENT targets, both measured against the mutated
+	// arm rather than guessed. Detection vs traversal count without -race,
+	// 5 runs per level:
+	//
+	//	  100 → 0/5 detected      2000 → 3/5
+	//	  400 → 1/5               3000 → 5/5   ← knee
+	//	 1000 → 1/5               5000 → 4/4
+	//
+	// Hence 5000 without -race (1.67x above the knee). Under -race the window
+	// is far wider, 400 detects 4/4, and 5000 would cost ~33s for nothing.
+	//
+	// FALLING SHORT OF THE TARGET IS A FAILURE, not a warning. An earlier
+	// version logged "reduced sampling" and PASSED above a floor of 100 — but
+	// the table above shows detection at 100 is exactly ZERO, and most of the
+	// 100..2500 band is non-detecting. A hatch like that does not trade full
+	// coverage for reduced coverage; across most of its range it trades
+	// coverage for none while still reporting PASS. That is the precise defect
+	// class #6056 exists to close, so it is gone. Wiring failures are caught by
+	// the 10s no-completion Fatal below and by the zero-mtime re-entry guard
+	// above, both of which are wiring checks rather than coverage floors.
+	//
+	// maxWall is 180s so that failure can never be a speed red: it is ~34x the
+	// -race arm's cost on a loaded machine (400 traversals in ~5.3s) and ~138x
+	// the no-race arm's (5000 in ~1.3s). It is 0.75% of the 40m per-binary CI
+	// budget on a test that runs once. The point is to stop NEEDING a hatch,
+	// not to make the hatch quiet.
 	targetSweeps := 5000
 	if raceEnabled {
 		targetSweeps = 400
 	}
-	const (
-		minSweeps = 100 // below this the fixture is not driving the reader
-		maxWall   = 45 * time.Second
-	)
+	const maxWall = 180 * time.Second
 
 	hardDeadline := time.Now().Add(maxWall)
 	sweeps := 0
@@ -243,21 +258,16 @@ func TestBackgroundAlgoGate_ClearedBetweenCheckAndUse(t *testing.T) {
 		}
 	}
 
-	// Vacuity guard. The strong signal is the 10s no-completion Fatal above;
-	// this catches the subtler case where sweeps DO complete but the fixture
-	// has stopped re-entering schedulePendingAlgo (e.g. a filterAlreadyComputed
-	// change that makes the zero-mtime re-entry a no-op), leaving a handful of
-	// traversals that could never sample the window.
-	if sweeps < minSweeps {
-		t.Fatalf("only %d sweeps completed in %s — the fixture is not driving "+
-			"the reader through the check-then-use window; it cannot exhibit "+
-			"the bug it guards", sweeps, maxWall)
-	}
+	// Short of target = FAIL. Below the target this fixture cannot reliably
+	// exhibit the bug it guards, so passing would be a false green — see the
+	// detection table above. If this ever fires on a machine that is merely
+	// slow, raise maxWall; do not lower the target and do not restore a
+	// warn-and-pass band.
 	if sweeps < targetSweeps {
-		// Reached the wall cap on a slow machine. Still meaningful sampling, so
-		// do not red the run — but say so rather than implying full coverage.
-		t.Logf("WARNING: reduced sampling — %d/%d traversals before the %s cap",
-			sweeps, targetSweeps, maxWall)
+		t.Fatalf("only %d/%d traversals of the check-then-use window within %s — "+
+			"below target this fixture cannot detect the double-read regression "+
+			"it exists to catch (measured: 0/5 at 100 traversals, 5/5 at 3000), "+
+			"so a PASS here would be a false green", sweeps, targetSweeps, maxWall)
 	}
 	t.Logf("drove %d bounded sweeps through the gate window", sweeps)
 }

--- a/internal/dashboard/graphstate_seam_race_test.go
+++ b/internal/dashboard/graphstate_seam_race_test.go
@@ -1,8 +1,12 @@
 package dashboard
 
 import (
+	"os"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // TestBackgroundAlgoSeams_ConcurrentSetAndRead pins the second fix for #6056.
@@ -88,4 +92,172 @@ func TestBackgroundAlgoSeams_ConcurrentSetAndRead(t *testing.T) {
 	if backgroundAlgoDone.Load() != nil {
 		t.Fatal("setBackgroundAlgoDoneForTest(nil) did not clear the callback")
 	}
+}
+
+// TestBackgroundAlgoGate_ClearedBetweenCheckAndUse pins the OTHER half of the
+// #6056 seam fix: the production reader must load the gate EXACTLY ONCE.
+//
+// The pre-fix shape was a double read:
+//
+//	if backgroundAlgoGate != nil {  // load #1
+//	    <-backgroundAlgoGate       // load #2
+//	}
+//
+// A clear that lands between the two loads is a TOCTOU. With the original plain
+// `chan struct{}` var it wedged the sweep goroutine forever on a receive from a
+// nil channel — silent, and effectively unobservable from a test. Converting the
+// seam to atomic.Pointer changed the failure mode: load #2 now returns a nil
+// *algoGateChan and the dereference panics. Louder, and therefore pinnable —
+// worth recording, because "the fix made the latent bug catchable" is the only
+// reason this test can exist at all.
+//
+// Two ingredients make the window reachable, and both are load-bearing:
+//
+//  1. A CLOSED channel as the installed gate. Every other fixture installs
+//     either an open channel (the sweep parks on load #2 and never returns) or
+//     nil (load #1 is false, so load #2 never executes). Neither traverses the
+//     window more than once. A closed channel makes the receive non-blocking,
+//     so the reader streams through the window as fast as it can be scheduled.
+//  2. BOUNDED in-flight sweeps, via the backgroundAlgoDone seam: wait for each
+//     sweep to finish before scheduling the next. Unbounded, the harness dies
+//     of "pthread_create failed: Resource temporarily unavailable" on CORRECT
+//     code — a false positive that reds both arms and proves nothing.
+//
+// Third ingredient: an EMPTY doc and a READ-ONLY state dir, so a sweep costs
+// almost nothing but the window itself. With a real doc and a writable dir the
+// sweep rate drops ~50x and the mutated arm survives.
+//
+// Verified to separate, on the final fixture (M-series laptop):
+//
+//	              correct code            double-read mutation
+//	-race         8/8 PASS  1.5-4.0s      5/5 FAIL  panic in 1.2-1.5s
+//	no -race      8/8 PASS  0.76-0.92s    3/3 FAIL  panic in 0.8-1.5s
+//
+// Note the panic is a plain TOCTOU, not a data race: the detector is NOT what
+// catches it, which is why the no-race arm has to work too and why it needs its
+// own traversal target (see below).
+func TestBackgroundAlgoGate_ClearedBetweenCheckAndUse(t *testing.T) {
+	prevGate := backgroundAlgoGate.Load()
+	prevDone := backgroundAlgoDone.Load()
+	t.Cleanup(func() {
+		backgroundAlgoGate.Store(prevGate)
+		backgroundAlgoDone.Store(prevDone)
+	})
+
+	// Closed: receiving from it never blocks, so the sweep goroutine runs
+	// straight through the check-then-use window instead of parking in it.
+	closed := make(chan struct{})
+	close(closed)
+
+	swept := make(chan string, 1)
+	setBackgroundAlgoDoneForTest(func(k string) {
+		select {
+		case swept <- k:
+		default:
+		}
+	})
+	setBackgroundAlgoGateForTest(closed)
+
+	// Writers: several goroutines hammering install/clear, so a clear can land
+	// inside the window on whichever core the sweep goroutine is running on.
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				setBackgroundAlgoGateForTest(closed)
+				setBackgroundAlgoGateForTest(nil)
+			}
+		}()
+	}
+	t.Cleanup(func() { close(stop); wg.Wait() })
+
+	// An EMPTY doc plus a read-only state dir strips ~all per-sweep cost:
+	// RunAlgorithms over zero entities is trivial, and persistAlgoResults'
+	// os.CreateTemp fails immediately (its error is swallowed by design). What
+	// remains per sweep is essentially the gate window itself, which is the only
+	// part this test samples. With a real doc and a writable dir the sweep rate
+	// drops ~50x and the mutated arm survives the time budget.
+	stateDir := t.TempDir()
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+	doc := &graph.Document{Repo: "gate-window-test"}
+
+	// fbMtime is deliberately the ZERO time: filterAlreadyComputed only skips
+	// repos with a non-zero mtime it has already computed, so a zero mtime lets
+	// us re-enter schedulePendingAlgo unboundedly. With a real mtime the second
+	// iteration would be filtered out and the loop below would drive the reader
+	// exactly once — a fixture that cannot exhibit what it claims to check.
+	var zeroMtime time.Time
+
+	// Drive to a TARGET TRAVERSAL COUNT, not a wall-clock budget. Detection
+	// power is a function of how many times the reader crosses the window, and
+	// the rate varies ~30x between modes (measured on an M-series laptop:
+	// ~5000 traversals/s without -race, ~150/s with it) and again with machine
+	// speed. A fixed time budget would therefore hand a slow CI runner far less
+	// sampling than the machine it was tuned on — and this test now sits behind
+	// a REQUIRED release checkbox, so a fixture that reds on slowness would be
+	// worse than no fixture. Targeting a count makes the sampling identical
+	// everywhere; the wall cap only bounds a pathological machine.
+	// The two modes need DIFFERENT targets, and both were measured against the
+	// mutated arm rather than guessed:
+	//   -race    → 400 traversals. -race widens the window, so the double-read
+	//              mutation panics within a few hundred; 400 costs ~3s.
+	//   no -race → 5000 traversals. The window is a couple of instructions
+	//              wide, so detection needs volume; at 400 the mutated arm
+	//              survived 3/3 runs, at 5000 it fails. Costs ~1s.
+	// Using the -race number in both modes would leave the no-race arm unable
+	// to exhibit the bug — the failure mode this repo hits most often.
+	targetSweeps := 5000
+	if raceEnabled {
+		targetSweeps = 400
+	}
+	const (
+		minSweeps = 100 // below this the fixture is not driving the reader
+		maxWall   = 45 * time.Second
+	)
+
+	hardDeadline := time.Now().Add(maxWall)
+	sweeps := 0
+	for sweeps < targetSweeps && time.Now().Before(hardDeadline) {
+		c, grp := pendingGrp(t, doc, stateDir, zeroMtime)
+		c.schedulePendingAlgo("g", grp)
+		// Bound in-flight sweeps to one: without this the loop spawns
+		// goroutines far faster than they retire and the process dies of
+		// "pthread_create failed: Resource temporarily unavailable" on CORRECT
+		// code — a false positive that reds both arms and proves nothing.
+		select {
+		case <-swept:
+			sweeps++
+		case <-time.After(10 * time.Second):
+			t.Fatal("background sweep never reported completion — seam wiring broken")
+		}
+	}
+
+	// Vacuity guard. The strong signal is the 10s no-completion Fatal above;
+	// this catches the subtler case where sweeps DO complete but the fixture
+	// has stopped re-entering schedulePendingAlgo (e.g. a filterAlreadyComputed
+	// change that makes the zero-mtime re-entry a no-op), leaving a handful of
+	// traversals that could never sample the window.
+	if sweeps < minSweeps {
+		t.Fatalf("only %d sweeps completed in %s — the fixture is not driving "+
+			"the reader through the check-then-use window; it cannot exhibit "+
+			"the bug it guards", sweeps, maxWall)
+	}
+	if sweeps < targetSweeps {
+		// Reached the wall cap on a slow machine. Still meaningful sampling, so
+		// do not red the run — but say so rather than implying full coverage.
+		t.Logf("WARNING: reduced sampling — %d/%d traversals before the %s cap",
+			sweeps, targetSweeps, maxWall)
+	}
+	t.Logf("drove %d bounded sweeps through the gate window", sweeps)
 }

--- a/internal/dashboard/raceflag_norace_test.go
+++ b/internal/dashboard/raceflag_norace_test.go
@@ -1,0 +1,7 @@
+//go:build !race
+
+package dashboard
+
+// raceEnabled reports whether this test binary was built with -race.
+// See raceflag_race_test.go for why the distinction is needed.
+const raceEnabled = false

--- a/internal/dashboard/raceflag_race_test.go
+++ b/internal/dashboard/raceflag_race_test.go
@@ -1,0 +1,16 @@
+//go:build race
+
+package dashboard
+
+// raceEnabled reports whether this test binary was built with -race.
+//
+// TestBackgroundAlgoGate_ClearedBetweenCheckAndUse needs it because the two
+// modes sample the check-then-use window at ~30x different rates AND with
+// different per-traversal hit probabilities: -race widens the window (so it
+// needs far fewer traversals) while also making each traversal ~30x slower.
+// A single traversal target therefore cannot serve both — too low and the
+// no-race arm stops detecting, too high and the -race arm takes 30+ seconds.
+//
+// This is a test-only build flag. It does not weaken, skip, or suppress
+// anything: both modes still run the same assertions to the same conclusion.
+const raceEnabled = true

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -64,8 +64,21 @@ func quiesceGraphCache(t *testing.T, srv *Server) {
 	prev := backgroundAlgoGate.Load()
 	setBackgroundAlgoGateForTest(make(chan struct{})) // never closed → sweeps park pre-write
 	t.Cleanup(func() {
-		// Restoring via the atomic is what makes this cleanup safe: the parked
-		// sweep goroutine is still live and still reading the seam (#6056).
+		// Going through the atomic makes this restore free of a DATA RACE: the
+		// parked sweep goroutine is still live and still loading the seam
+		// (#6056). It does NOT make the restore logically safe, and this
+		// cleanup does not claim to.
+		//
+		// KNOWN GAP (#6056 review F5, filed separately): we neither close the
+		// gate nor join the sweep. A schedulePendingAlgo goroutine that has not
+		// yet reached its gate load can observe the RESTORED value (usually
+		// nil = "run immediately"), skip parking, and go on to write
+		// graph-algo.json into the t.TempDir that RemoveAll is tearing down —
+		// the precise Windows failure this helper exists to prevent. -race
+		// slows scheduling 5-20x and therefore WIDENS that window rather than
+		// narrowing it. Closing this properly needs the sweep to be joinable
+		// (a WaitGroup or a done channel the fixture can wait on), which is a
+		// production-side change, not a comment.
 		backgroundAlgoGate.Store(prev)
 		if srv != nil && srv.graphs != nil {
 			srv.graphs.InvalidateAll()

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -61,10 +61,12 @@ func TestMain(m *testing.M) {
 // load (i.e. before the fixture hands the caller a live URL).
 func quiesceGraphCache(t *testing.T, srv *Server) {
 	t.Helper()
-	prev := backgroundAlgoGate
-	backgroundAlgoGate = make(chan struct{}) // never closed → sweeps park pre-write
+	prev := backgroundAlgoGate.Load()
+	setBackgroundAlgoGateForTest(make(chan struct{})) // never closed → sweeps park pre-write
 	t.Cleanup(func() {
-		backgroundAlgoGate = prev
+		// Restoring via the atomic is what makes this cleanup safe: the parked
+		// sweep goroutine is still live and still reading the seam (#6056).
+		backgroundAlgoGate.Store(prev)
 		if srv != nil && srv.graphs != nil {
 			srv.graphs.InvalidateAll()
 		}


### PR DESCRIPTION
Go's race detector has essentially never run in this repo's CI, and the policy comment says otherwise.

`.github/workflows/test.yml` documented three enabling paths — push to main, release event, `ci:full` label — gated on `github.event_name == "push" && github.ref == "refs/heads/main"`, `event_name == "release"`, or the label. But the workflow's `on:` block only accepts `workflow_dispatch`, `push` on **tags**, and labeled `pull_request_target`. There is no `push: branches: [main]` and no `release:` trigger, and a tag push arrives as `refs/tags/v*`. **Two of the three guarantees describe events the workflow cannot receive.** Only a `ci:full`-labelled PR has ever enabled `-race`.

That is the direct explanation for everything below.

## What the first sweep found

**`internal/daemon`** — `supervise.go:98` (`SetEngineChildCommandForTest`'s deferred restore) racing `:329`, `engineSupervisor.run` reading `engineChildCommand` in its live respawn loop.

**`internal/dashboard`** — `server_test.go:67` racing `graphstate.go:1112`, a live background Pass-4 goroutine. Plus `backgroundAlgoDone`, same shape, latent.

Both are test-hygiene rather than product races: exhaustive grep confirms the only writers of all three seams are the test-only setters, and production reads only. Both converted to `atomic.Pointer` behind accessors rather than "join before restore" — joining is correct today but silently stops protecting the first time a fixture forgets, while an atomic has no plain-access form.

The distinguishing hazard, recorded in both files: **repeated reads from a live goroutine**, not the seam pattern itself. `listenFn`, read exactly once at startup, is fine either way.

## The dashboard race was not a flake

An A/B against pristine `main` was unusable as a control. Full-package `go test -race -count=3 -shuffle=on ./internal/dashboard/` on `9fae0967b` fails **9 runs out of 9**, one race each, two `backgroundAlgoGate` frames each — with a different reporting test every time. Six distinct reporters observed: `TestHandleGroupStats_{AtAll,NamedRef,NoRef}`, `TestHandleRepoRelationships_NoRef`, `TestHandleRepoCrossRepoEdges_AtAll`, `TestHandleV2RepoDiff_CacheHit`.

So it is **deterministic in occurrence and nondeterministic only in which test reports it** — which is exactly why every per-test reproduction understated it, including the two done during review.

The consequence reframes this PR: **the two fixes are what make enabling `-race` possible at all.** `main` is green on three platforms only because the old gate could never fire; the first `-race` run this change enables would otherwise have been a guaranteed red.

## A latent production crash, now pinned

The old seams were **double reads** — `if backgroundAlgoGate != nil { <-backgroundAlgoGate }` and `if backgroundAlgoDone != nil { backgroundAlgoDone(k) }`. Cleared between check and use, the first parks a goroutine forever on a nil channel and the second panics the process. The single-`Load`-into-a-local form eliminates both.

This was initially reported as unpinnable without a production hook. That was wrong, and the pin took three ingredients, each verified by mutating it away:

1. **A closed channel as the gate.** Every existing fixture installs an open channel (parks the sweep) or `nil` (skips the branch), so the window is traversed at most once. Closed makes the receive non-blocking.
2. **Bounded in-flight sweeps** via the `backgroundAlgoDone` seam. Unbounded, the harness dies of `pthread_create failed` on *correct* code — a false positive on both arms.
3. **Empty doc plus a read-only state dir**, stripping `RunAlgorithms` and the sidecar write out of each sweep and raising the traversal rate ~50x. Without it the mutated arm survives at ~5.5k traversals.

Note the atomic conversion is what made this catchable: with a plain `chan` var a clear between the reads blocks forever on a nil channel; with `atomic.Pointer` the second `Load` returns nil and the dereference panics. The panic is a plain TOCTOU, **not** a data race — the detector is not what catches it, which is why the no-race arm must work and needs its own sampling target.

Separation, 16 runs: `-race` 5/5 PASS vs 5/5 FAIL (panic, 1.1-1.7s); no-race 3/3 vs 3/3.

## Shortfall is fatal, not a warning

The fixture drives to a traversal target (400 under `-race`, 5000 without) rather than a wall-clock budget, so sampling is identical on any machine. An earlier revision logged `WARNING: reduced sampling` and passed when a slow runner fell short. Detection was then measured against traversal count:

| traversals | mutation detected |
|---|---|
| 100 | **0/5** |
| 2000 | 3/5 |
| 3000 | 5/5 |
| 5000 (target) | 4/4 |

**At the proposed floor, detection is exactly zero.** The band did not trade full coverage for reduced coverage — across most of its range it traded coverage for none while printing PASS. Shortfall is now `t.Fatalf`, `maxWall` is 180s (~34x headroom on the tight `-race` arm, 0.75% of the per-binary budget), and the Fatal message carries the measurements plus the remedy: raise `maxWall`, do not lower the target, do not restore a warn band.

## What the workflow now delivers, stated exactly

`-race` fires on a `v*` tag push, on `workflow_dispatch` with the new `race` boolean (default true), and on a `ci:full`-labelled PR. `push: branches: [main]` was deliberately **not** added — this repo runs no automatic per-PR CI by design, so the post-merge-sanity claim was deleted rather than bought.

**A tag push is not a release gate, and the comment now says so.** `release.yml` is `on: push: tags: ['v*']` — the same trigger — with no `needs:`, no `workflow_run`, no environment approval. Both start concurrently; neither can fail the other. A Release can publish at ~14 minutes while the windows leg trips a race at ~22. On the tag path `-race` is a post-mortem.

The gate that does exist is `docs/runbooks/release-signoff.md` §0: a required green `test.yml` dispatch with `race` ON, on the release commit, all three OSes — placed under the `acceptance.yml` checkbox it mirrors, with the reasoning inline so it cannot be dropped as redundant. Making it structural needs a `needs:`/`workflow_run` restructure of `release.yml`; recorded as a follow-up, deliberately not taken here.

`-timeout 40m` on the `-race` branch (15m unchanged otherwise) — `internal/mcp` is 525-610s on a fast laptop at `-p 2`, and CI runs at default `-p` on slower cores. Plus `timeout-minutes: 90` at job level, which did not exist: a genuine deadlock, the thing `-race` exists to catch, would otherwise burn up to GitHub's 6h limit on a 10x-billed runner.

## Two known failures documented for triage

§0 names both, each with its own deletion trigger, because a red REQUIRED gate whose cause is undocumented stalls a release as effectively as a real defect:

- `internal/daemon` `rebuild*` seam races (#6059) — ~1 in 8, matched by exact identifier → re-dispatch. Scoped by identifier rather than file, and every name grepped against the tree, because name-scoping *is* the safety property: an un-greppable name does not make the hatch untidy, it makes it non-functional.
- `TestV2GraphRestoresDiskPayloadBeforeLoadingGraph` (#6061) — assertion-only with **no** `DATA RACE`, full-package runs only, ~2 in 21 → re-dispatch once, escalate if it repeats.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. Full packages at `-race -count=3 -shuffle=on -p 1`: `internal/daemon` 97.6s ok, `internal/dashboard` 106.0s ok, exit 0. Without `-race`: 19.2s / 30.0s, exit 0.

Sweep coverage: 235 packages under `-race`, zero races, zero failures, plus the two fixed packages at `-count=3 -shuffle=on`. **This is not a claim the suite is race-free** — the detector only sees interleavings that executed, five expensive packages got a single `-count=1` pass, and `-shuffle` ran on two.

Mutation battery, rebuilt against the final tree: the double-read restored (RED 8/8, both modes); each of the three fixture ingredients removed individually; both seam setters made no-ops; the daemon nil-clear branch deleted. `SetEngineChildCommandForTest(nil)` now clears rather than storing a non-nil pointer to a nil func, matching both dashboard setters, pinned by a test that installs a real override first so a no-op implementation cannot pass.

Four review rounds, independently adversarially reviewed.

Closes #6056
