### PR TITLE
fix(#6059): convert the rebuild* test-knob seams to atomics — the last unreliable red on the race gate

### DIFF
--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -46,29 +46,19 @@ ladder. Run it on real hardware for each release.
       Expect this to take substantially longer than a non-race run — `-race`
       costs roughly 5-10x wall time, and `internal/mcp` alone is ~9-10 min.
 
-      **Triaging a red run — two known failures.** Both are pre-existing and
-      tracked separately. Anything that is not one of these two is real: read
-      the report before deciding. When either is fixed, delete its entry rather
-      than letting it excuse a future failure.
+      **Triaging a red run — one known failure.** It is pre-existing and
+      tracked separately. Anything that is not it is real: read the report
+      before deciding. When it is fixed, delete this paragraph rather than
+      letting it excuse a future failure.
 
-      **(a) `internal/daemon` test-seam data races** — reported at roughly
-      **1 run in 8**, i.e. ~1 dispatch in 3 reds at least one OS leg. The shape
-      is a plain package-var seam written by a test while a live goroutine
-      reads it: `rebuildRPCTimeout` (written by
-      `rebuild_singleflight_test.go`, read from the `net/rpc` serving goroutine
-      in `service.go`, failing `TestRebuild_SingleFlight_NoConcurrentOverlap`),
-      plus the group declared in `internal/daemon/rebuild_wait.go` —
-      `rebuildWaitTimeout`, `rebuildWaitInterval`, `rebuildWaitStartupWindow`,
-      `rebuildWaitStaleAfter`, `rebuildWaitClock` and `rebuildEngineAliveFn`.
+      (There used to be a second entry here, for the `internal/daemon`
+      `rebuild*` test-seam data races. It was deleted when #6059 fixed them:
+      the seven knobs are now atomics behind accessors, pinned by
+      `TestRebuildSeams_ConcurrentOverrideAndRead`. A `WARNING: DATA RACE`
+      naming any `rebuild*` identifier is now a REAL failure — **do not
+      re-dispatch it**.)
 
-      **Match the report against those exact identifiers.** This instruction is
-      scoped by name, which is the only reason it is safe — it cannot launder
-      an unrelated race. A misspelled name in this list breaks that property
-      rather than merely being untidy, so every name here has been grepped
-      against the tree; re-grep before editing it. If a red run's
-      `WARNING: DATA RACE` names one of those vars → **re-dispatch**.
-
-      **(b) `TestV2GraphRestoresDiskPayloadBeforeLoadingGraph`
+      **`TestV2GraphRestoresDiskPayloadBeforeLoadingGraph`
       (`internal/dashboard`)** — assertion-only, **no `DATA RACE` in the
       report**. It fails with `cold disk response = status 200 body
       {...total_node_count:0}`: the disk-payload lookup missed and an empty
@@ -78,11 +68,9 @@ ladder. Run it on real hardware for each release.
       once. If it repeats on the re-dispatch, escalate** — the rate is low
       enough that twice in a row is not the known failure.
 
-      Entry (b) is listed for the same reason (a) is: this checkbox is a
-      REQUIRED gate, and a red gate whose cause is undocumented stalls a
-      release just as effectively as a real defect. Documenting only the race
-      and silently omitting this one would leave the gate untrustworthy in
-      exactly the way #6056 was about.
+      It is listed because this checkbox is a REQUIRED gate, and a red gate
+      whose cause is undocumented stalls a release just as effectively as a
+      real defect — the untrustworthy-signal problem #6056 was about.
 - [ ] `CHANGELOG.md` has a `[X.Y.Z] — YYYY-MM-DD` section; `[Unreleased]` is
       drained.
 - [ ] `go build ./...` and `go vet ./...` are clean locally.

--- a/internal/daemon/rebuild_seam_race_test.go
+++ b/internal/daemon/rebuild_seam_race_test.go
@@ -1,0 +1,299 @@
+package daemon
+
+// rebuild_seam_race_test.go — pins the #6059 fix for the rebuild* test-seam
+// family (rebuildRPCTimeout, rebuildWaitInterval, rebuildWaitStartupWindow,
+// rebuildWaitTimeout, rebuildWaitStaleAfter, rebuildWaitClock,
+// rebuildEngineAliveFn).
+//
+// The hazard is NOT the seams themselves — it is that production resolves every
+// one of them from a goroutine the test does not own. Service.Rebuild runs on a
+// net/rpc serving goroutine and awaitRebuildCompletion polls from it, while a
+// fixture's t.Cleanup writes the knob during teardown. As plain package vars
+// that pairing is an unsynchronised write/read and the detector reported it as
+// `TestRebuild_SingleFlight_NoConcurrentOverlap` on roughly 1 `-race` run in 8.
+//
+// None of the seven is the benign read-once-at-startup shape (contrast
+// listenFn), so all seven were converted.
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// countingWaitClock is a fake clock that records how often it is used, so the
+// clock seam's vacuity can be checked the same way the func seam's is.
+type countingWaitClock struct{ uses *int64 }
+
+func (c countingWaitClock) Now() time.Time {
+	atomic.AddInt64(c.uses, 1)
+	return time.Unix(0, 0)
+}
+func (c countingWaitClock) Sleep(time.Duration) { atomic.AddInt64(c.uses, 1) }
+
+// resolveAllRebuildSeams resolves every member of the family exactly the way
+// production does (Service.Rebuild for the RPC cap; awaitRebuildCompletion for
+// the wait knobs, the clock and the liveness probe). Returns the durations it
+// saw so a caller can assert on them.
+func resolveAllRebuildSeams() (rpc, interval, startup, timeout, stale time.Duration) {
+	rpc = rebuildRPCTimeout()
+	interval = rebuildWaitInterval()
+	startup = rebuildWaitStartupWindow()
+	timeout = rebuildWaitTimeout()
+	stale = rebuildWaitStaleAfter()
+	_ = rebuildWaitClock().Now()
+	_ = rebuildEngineAliveFn()
+	return
+}
+
+// installAllRebuildSeamOverrides installs one override for every member of the
+// family and returns a single LIFO restore closure plus the NUMBER OF SEAM
+// WRITES it performed. The count is returned rather than incremented by the
+// caller so a writer-side vacuity counter cannot survive an edit that removes
+// the writes: there is no way to get a non-zero n without having written.
+func installAllRebuildSeamOverrides(i int, aliveCalls, clockUses *int64) (restore func(), writes int) {
+	rA := setRebuildRPCTimeoutForTest(time.Duration(i%97+1) * time.Millisecond)
+	rB := setRebuildWaitIntervalForTest(time.Duration(i%89+1) * time.Millisecond)
+	rC := setRebuildWaitStartupWindowForTest(time.Duration(i%83+1) * time.Millisecond)
+	rD := setRebuildWaitTimeoutForTest(time.Duration(i%79+1) * time.Millisecond)
+	rE := setRebuildWaitStaleAfterForTest(time.Duration(i%73+1) * time.Millisecond)
+	rF := setRebuildWaitClockForTest(countingWaitClock{uses: clockUses})
+	rG := setRebuildEngineAliveForTest(func() bool {
+		atomic.AddInt64(aliveCalls, 1)
+		return false
+	})
+	return func() {
+		rG()
+		rF()
+		rE()
+		rD()
+		rC()
+		rB()
+		rA()
+	}, 7
+}
+
+// TestRebuildSeams_ConcurrentOverrideAndRead pins #6059. It has three
+// independent failure modes, so it cannot silently stop protecting:
+//
+//   - Phase 1 (no -race needed): each setter must actually take effect and each
+//     override must actually be invoked. This is half the vacuity guard — a
+//     fixture that cannot exhibit the race it claims to guard fails here rather
+//     than passing green. The other half is the writerWrites/readerIters pair at
+//     the end of Phase 2: TSan needs a write and a read that are CONCURRENT, and
+//     Phase 1 runs before the reader exists, so it cannot speak to that.
+//   - Phase 2 (-race): a live reader goroutine resolves all seven seams in a
+//     loop while the test installs and restores overrides. If any seam reverts
+//     to a plain package var, the write/read pair is unsynchronised and the
+//     detector fails this test. This is the shape of the original report.
+//   - Phase 3 (no -race needed): after every restore, every seam must resolve
+//     back to its compiled-in production default. Goes RED if set/restore stops
+//     being LIFO-correct or stops reverting.
+func TestRebuildSeams_ConcurrentOverrideAndRead(t *testing.T) {
+	// ---- Phase 1: wiring + vacuity, fully synchronised. ----------------------
+	var aliveCalls, clockUses int64
+
+	// Every install is registered with t.Cleanup IMMEDIATELY, before anything
+	// that can fail. Each t.Fatal below exits via runtime.Goexit, which runs
+	// registered cleanups but does NOT touch plain locals — so holding these
+	// restores only in locals would leak all seven overrides into every
+	// subsequent test in the binary the moment an assertion fired. That is not a
+	// cosmetic leak: countingWaitClock.Now() is frozen at time.Unix(0, 0), so in
+	// awaitRebuildAck `elapsed` is permanently 0 and the alive override is
+	// permanently true — the wait loop can then never time out, and
+	// TestRebuild_SplitMode_WaitForCompletion_AckTimeout hot-spins on os.ReadFile
+	// until the whole package times out. A one-line regression diagnostic would
+	// become a 10-minute red on all three OS legs, i.e. exactly the
+	// untrustworthy-red failure mode this branch exists to remove. Phase 3 still
+	// calls the restores explicitly and re-asserts; the cleanup re-run is
+	// idempotent because it re-stores the same captured `prev`.
+	restoreRPC := setRebuildRPCTimeoutForTest(11 * time.Millisecond)
+	t.Cleanup(restoreRPC)
+	restoreInterval := setRebuildWaitIntervalForTest(12 * time.Millisecond)
+	t.Cleanup(restoreInterval)
+	restoreStartup := setRebuildWaitStartupWindowForTest(13 * time.Millisecond)
+	t.Cleanup(restoreStartup)
+	restoreTimeout := setRebuildWaitTimeoutForTest(14 * time.Millisecond)
+	t.Cleanup(restoreTimeout)
+	restoreStale := setRebuildWaitStaleAfterForTest(15 * time.Millisecond)
+	t.Cleanup(restoreStale)
+	restoreClock := setRebuildWaitClockForTest(countingWaitClock{uses: &clockUses})
+	t.Cleanup(restoreClock)
+	restoreAlive := setRebuildEngineAliveForTest(func() bool {
+		atomic.AddInt64(&aliveCalls, 1)
+		return true
+	})
+	t.Cleanup(restoreAlive)
+
+	rpc, interval, startup, timeout, stale := resolveAllRebuildSeams()
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"rebuildRPCTimeout", rpc, 11 * time.Millisecond},
+		{"rebuildWaitInterval", interval, 12 * time.Millisecond},
+		{"rebuildWaitStartupWindow", startup, 13 * time.Millisecond},
+		{"rebuildWaitTimeout", timeout, 14 * time.Millisecond},
+		{"rebuildWaitStaleAfter", stale, 15 * time.Millisecond},
+	} {
+		if c.got != c.want {
+			t.Fatalf("%s override did not take effect: got %v, want %v — fixture cannot exhibit the race it claims to guard", c.name, c.got, c.want)
+		}
+	}
+	if atomic.LoadInt64(&aliveCalls) == 0 {
+		t.Fatal("rebuildEngineAliveFn override was never invoked — fixture cannot exhibit the race it claims to guard")
+	}
+	if atomic.LoadInt64(&clockUses) == 0 {
+		t.Fatal("rebuildWaitClock override was never used — fixture cannot exhibit the race it claims to guard")
+	}
+
+	// ---- Phase 2: the race shape. -------------------------------------------
+	//
+	// The liveness override installed above stays in place for the whole phase
+	// so the reader never falls through to defaultRebuildEngineAlive, which
+	// would do real filesystem I/O on every iteration and slow the loop to the
+	// point where it samples almost no interleavings. Inner overrides still
+	// nest under it, which is what the writer loop below exercises.
+	var readerIters int64
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			resolveAllRebuildSeams()
+			atomic.AddInt64(&readerIters, 1)
+		}
+	}()
+
+	// writerWrites counts SEAM WRITES performed while the reader goroutine is
+	// live. It is incremented only from installAllRebuildSeamOverrides' return
+	// value, so it cannot be kept while the writes are removed — see the guard
+	// below for why that matters.
+	var writerWrites int
+	for i := 0; i < 2000; i++ {
+		restore, n := installAllRebuildSeamOverrides(i, &aliveCalls, &clockUses)
+		writerWrites += n
+		// Resolve under the override too, so each seam is exercised in both
+		// directions rather than only written.
+		resolveAllRebuildSeams()
+		restore()
+	}
+
+	close(stop)
+	wg.Wait()
+	if atomic.LoadInt64(&readerIters) == 0 {
+		t.Fatal("reader goroutine never resolved a seam — fixture cannot exhibit the race it claims to guard")
+	}
+	// The writer half of the same guard, and NOT redundant with Phase 1. Phase 1
+	// proves the setters work, but it runs before the reader exists. TSan needs a
+	// WRITE and a READ that are concurrent and unsynchronised: a plausible future
+	// edit — "this test is slow, hoist the setup out of the loop" — leaves the
+	// reader spinning over a set of seams nobody is writing, and the whole race
+	// protection is silently gone while the vacuity messages still read as though
+	// it were guarding. Measured, not assumed: with the plain-var defect present
+	// (DATA RACE otherwise reported 5/5) AND this loop's body reduced to
+	// read-only resolves, the test WITHOUT this guard passed 5/5 green and none
+	// of the other guards fired. With this guard it fails 5/5.
+	if writerWrites == 0 {
+		t.Fatal("no seam override was written while the reader goroutine was live — fixture cannot exhibit the race it claims to guard")
+	}
+
+	// ---- Phase 3: restore semantics. ----------------------------------------
+	restoreAlive()
+	restoreClock()
+	restoreStale()
+	restoreTimeout()
+	restoreStartup()
+	restoreInterval()
+	restoreRPC()
+
+	rpc, interval, startup, timeout, stale = rebuildRPCTimeout(), rebuildWaitInterval(), rebuildWaitStartupWindow(), rebuildWaitTimeout(), rebuildWaitStaleAfter()
+	for _, c := range []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"rebuildRPCTimeout", rpc, defaultRebuildRPCTimeout},
+		{"rebuildWaitInterval", interval, defaultRebuildWaitInterval},
+		{"rebuildWaitStartupWindow", startup, defaultRebuildWaitStartupWindow},
+		{"rebuildWaitTimeout", timeout, defaultRebuildWaitTimeout},
+		{"rebuildWaitStaleAfter", stale, defaultRebuildWaitStaleAfter},
+	} {
+		if c.got != c.want {
+			t.Fatalf("after restore, %s = %v, want the production default %v", c.name, c.got, c.want)
+		}
+	}
+	if _, ok := rebuildWaitClock().(realWaitClock); !ok {
+		t.Fatalf("after restore, rebuildWaitClock = %T, want realWaitClock", rebuildWaitClock())
+	}
+}
+
+// TestRebuildSeamSetters_NilAndZeroClear pins the clear convention (mirroring
+// #6056 F6): passing nil / 0 CLEARS the override rather than installing a nil
+// pointer or a zero bound. Without it, a nil clock or alive func would panic on
+// the next resolve, and a zero duration would turn a 2h cap into an instant
+// timeout — silently, from a live serving goroutine.
+func TestRebuildSeamSetters_NilAndZeroClear(t *testing.T) {
+	// Install real overrides first, so "clear" has something to clear and a
+	// no-op implementation cannot pass by accident.
+	var aliveCalls, clockUses int64
+	defer setRebuildWaitClockForTest(countingWaitClock{uses: &clockUses})()
+	defer setRebuildEngineAliveForTest(func() bool {
+		atomic.AddInt64(&aliveCalls, 1)
+		return true
+	})()
+	defer setRebuildRPCTimeoutForTest(7 * time.Millisecond)()
+
+	if !rebuildEngineAliveFn() || atomic.LoadInt64(&aliveCalls) == 0 {
+		t.Fatal("alive override was not invoked — fixture cannot detect a failed clear")
+	}
+	if _, ok := rebuildWaitClock().(countingWaitClock); !ok {
+		t.Fatal("clock override was not installed — fixture cannot detect a failed clear")
+	}
+	if got := rebuildRPCTimeout(); got != 7*time.Millisecond {
+		t.Fatalf("rpc-timeout override was not installed (got %v) — fixture cannot detect a failed clear", got)
+	}
+
+	// nil / 0 must CLEAR, not install.
+	restoreNilAlive := setRebuildEngineAliveForTest(nil)
+	restoreNilClock := setRebuildWaitClockForTest(nil)
+	restoreZeroRPC := setRebuildRPCTimeoutForTest(0)
+
+	if _, ok := rebuildWaitClock().(realWaitClock); !ok {
+		t.Fatalf("nil did not clear the clock override: got %T", rebuildWaitClock())
+	}
+	if got := rebuildRPCTimeout(); got != defaultRebuildRPCTimeout {
+		t.Fatalf("0 did not clear the rpc-timeout override: got %v, want %v", got, defaultRebuildRPCTimeout)
+	}
+	// The alive seam falls through to defaultRebuildEngineAlive, which reads the
+	// liveness sidecar. Under a temp root there is none, so it must report false
+	// — and must NOT panic, which is what a stored nil func would do.
+	t.Setenv(EnvRoot, t.TempDir())
+	if rebuildEngineAliveFn() {
+		t.Fatal("nil did not clear the alive override: still reporting the override's true")
+	}
+
+	// A clear must nest like any other override: restore() puts the previous one
+	// back.
+	restoreZeroRPC()
+	restoreNilClock()
+	restoreNilAlive()
+	if got := rebuildRPCTimeout(); got != 7*time.Millisecond {
+		t.Fatalf("restore() after a zero clear did not reinstate the previous override: got %v", got)
+	}
+	if _, ok := rebuildWaitClock().(countingWaitClock); !ok {
+		t.Fatalf("restore() after a nil clear did not reinstate the previous clock: got %T", rebuildWaitClock())
+	}
+	before := atomic.LoadInt64(&aliveCalls)
+	if !rebuildEngineAliveFn() || atomic.LoadInt64(&aliveCalls) == before {
+		t.Fatal("restore() after a nil clear did not reinstate the previous alive override")
+	}
+}

--- a/internal/daemon/rebuild_singleflight_test.go
+++ b/internal/daemon/rebuild_singleflight_test.go
@@ -26,9 +26,7 @@ func TestRebuild_SingleFlight_NoConcurrentOverlap(t *testing.T) {
 	// Shrink the RPC timeout so the first rebuild "times out" quickly while its
 	// worker keeps running, and the second rebuild's acquire also times out
 	// quickly. Restored after the test.
-	prev := rebuildRPCTimeout
-	rebuildRPCTimeout = 120 * time.Millisecond
-	t.Cleanup(func() { rebuildRPCTimeout = prev })
+	t.Cleanup(setRebuildRPCTimeoutForTest(120 * time.Millisecond))
 
 	var (
 		concurrent    int32
@@ -120,7 +118,10 @@ func TestRebuild_SingleFlight_NoConcurrentOverlap(t *testing.T) {
 	close(release)
 
 	// Give the orphan a moment to release the guard.
-	rebuildRPCTimeout = 2 * time.Second
+	// Widen the cap for RPC #3. This write is the one the #6059 detector report
+	// named: RPC #1's serving goroutine is still live and still resolving the
+	// seam. Restored LIFO, back to the 120ms installed above.
+	t.Cleanup(setRebuildRPCTimeoutForTest(2 * time.Second))
 	release3 := make(chan struct{})
 	close(release3) // #3 returns immediately
 	// Re-point rebuildFn's release for #3 by using a fresh service-independent

--- a/internal/daemon/rebuild_wait.go
+++ b/internal/daemon/rebuild_wait.go
@@ -38,6 +38,7 @@ package daemon
 
 import (
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/requests"
@@ -56,22 +57,70 @@ type realWaitClock struct{}
 func (realWaitClock) Now() time.Time        { return time.Now() }
 func (realWaitClock) Sleep(d time.Duration) { time.Sleep(d) }
 
-// Wait knobs are vars (not consts), mirroring rebuildRPCTimeout, so tests can
-// shrink them to exercise the completion / timeout / engine-death paths
-// deterministically; production never reassigns them.
-var (
-	// rebuildWaitInterval is the poll cadence between ack checks.
-	rebuildWaitInterval = 500 * time.Millisecond
-	// rebuildWaitStartupWindow fast-fails if the engine is NEVER seen live
-	// within this window after the request was enqueued (S1 in the wizard).
-	rebuildWaitStartupWindow = 30 * time.Second
-	// rebuildWaitTimeout is the last-resort overall bound. Kept equal to the
-	// monolith synchronous cap so both modes bound a blocking Rebuild the same,
-	// and comfortably above a multi-minute large-monorepo rebuild so a healthy
-	// long rebuild never false-times-out.
-	rebuildWaitTimeout = rebuildRPCTimeout
-	// rebuildWaitStaleAfter is how long the engine-liveness heartbeat may go
-	// unrefreshed before the COMPLETION WAIT treats the engine as dead. It is
+// The rebuild* seam family (#6059).
+//
+// These knobs exist ONLY so tests can shrink/fake them and exercise the
+// completion / timeout / engine-death paths deterministically; production never
+// installs an override. They used to be plain package vars, which was a live
+// data race: every one of them is read from a goroutine the test does not own —
+// Service.Rebuild runs on a net/rpc serving goroutine, and awaitRebuildCompletion
+// polls from that same goroutine — while a fixture's t.Cleanup writes them
+// during teardown. The detector caught it as
+// `TestRebuild_SingleFlight_NoConcurrentOverlap`, which is what made the
+// release gate untrustworthy. The organic event is RARE and needs the FULL
+// package: measured on pristine 67f8557c9, 1 failure in 36 full-package
+// `-race` iterations (~3%, vs the ~12% #6056 reported), and 0 in 80 isolated
+// `-run TestRebuild_SingleFlight_NoConcurrentOverlap` iterations — the reader
+// is a net/rpc serving goroutine LEAKED by an earlier test in the same binary,
+// so it only exists once a neighbour has run. That rarity is why the pin below
+// (`TestRebuildSeams_ConcurrentOverrideAndRead`) drives the shape directly
+// instead of relying on the flake: with any seam reverted to a plain var it
+// fails 5/5, and 0/60 with the fix.
+//
+// The fix is the same shape as engineChildCommand (#6056): an atomic behind an
+// accessor. Joining the serving goroutine before restoring would also be
+// correct today, but it silently stops protecting the first time a fixture
+// forgets; an atomic has NO plain-access form, so the protection is structural
+// rather than a convention. That property is why a knob ADDED to this family
+// later inherits the fix instead of inheriting the hazard — declare the
+// override next to its siblings below and go through the accessor.
+//
+// Conventions, uniform across the family:
+//   - the accessor keeps the ORIGINAL identifier (rebuildWaitInterval,
+//     rebuildEngineAliveFn, ...) so the release-runbook triage note and any
+//     `WARNING: DATA RACE` report stay greppable by the same names;
+//   - the zero value of the override means "no override, use the default" —
+//     0 for a duration, nil for a pointer seam. Setting nil/0 CLEARS rather
+//     than installing a nil (#6056 F6: storing a non-nil pointer to a nil func
+//     made the next resolve panic);
+//   - every setter returns a restore closure and they nest LIFO. The STORAGE is
+//     race-free, but set/restore itself is a non-atomic read-modify-write
+//     (Load-then-Store), so the LIFO nesting property holds only for a single
+//     writer. That is sound today because nothing in internal/daemon calls
+//     t.Parallel(); a future parallel fixture that installs an override needs a
+//     compare-and-swap or a mutex here, not just the atomic;
+//   - callers that need a value more than once in one logical operation resolve
+//     it ONCE into a local, so a value and the message explaining it cannot
+//     disagree.
+//
+// None of these seams is the benign read-once-at-startup shape (contrast
+// listenFn): all are resolved from a live RPC-serving goroutine, and
+// rebuildWaitStaleAfter is resolved on every poll iteration of the wait loop.
+const (
+	// defaultRebuildWaitInterval is the poll cadence between ack checks.
+	defaultRebuildWaitInterval = 500 * time.Millisecond
+	// defaultRebuildWaitStartupWindow fast-fails if the engine is NEVER seen
+	// live within this window after the request was enqueued (S1 in the wizard).
+	defaultRebuildWaitStartupWindow = 30 * time.Second
+	// defaultRebuildWaitTimeout is the last-resort overall bound. Kept equal to
+	// the monolith synchronous cap so both modes bound a blocking Rebuild the
+	// same, and comfortably above a multi-minute large-monorepo rebuild so a
+	// healthy long rebuild never false-times-out. NOTE it tracks the DEFAULT
+	// RPC cap, not the effective one: shrinking rebuildRPCTimeout in a test has
+	// never shrunk this, and that stays true.
+	defaultRebuildWaitTimeout = defaultRebuildRPCTimeout
+	// defaultRebuildWaitStaleAfter is how long the engine-liveness heartbeat may
+	// go unrefreshed before the COMPLETION WAIT treats the engine as dead. It is
 	// deliberately far more generous than the shared EngineHeartbeatStaleAfter()
 	// (3×5s=15s) the doctor/warming reads use (#5790 SHOULD-FIX): a memory-heavy
 	// rebuild under GC/swap pressure can starve the engine's 5s heartbeat ticker
@@ -83,14 +132,142 @@ var (
 	// recoverable rebuild. 2 minutes tolerates realistic GC/swap stalls yet still
 	// gives up long before the 2h overall cap on a truly dead engine that is not
 	// coming back.
-	rebuildWaitStaleAfter = 2 * time.Minute
-	// rebuildWaitClock is the injectable production clock.
-	rebuildWaitClock waitClock = realWaitClock{}
-	// rebuildEngineAliveFn reports whether the engine's liveness heartbeat is
-	// fresh (within rebuildWaitStaleAfter). Overridable in tests; production
-	// reads the engine-liveness sidecar.
-	rebuildEngineAliveFn = defaultRebuildEngineAlive
+	defaultRebuildWaitStaleAfter = 2 * time.Minute
 )
+
+// engineAliveFunc reports whether the engine's liveness heartbeat is fresh.
+type engineAliveFunc func() bool
+
+// Test overrides for the family. Zero value == no override; production never
+// stores anything here.
+var (
+	rebuildRPCTimeoutOverride        atomic.Int64 // nanoseconds; 0 == unset
+	rebuildWaitIntervalOverride      atomic.Int64
+	rebuildWaitStartupWindowOverride atomic.Int64
+	rebuildWaitTimeoutOverride       atomic.Int64
+	rebuildWaitStaleAfterOverride    atomic.Int64
+	rebuildWaitClockOverride         atomic.Pointer[waitClock]
+	rebuildEngineAliveOverride       atomic.Pointer[engineAliveFunc]
+)
+
+// loadDurationSeam resolves a duration seam: the override when non-zero, else
+// the compiled-in default.
+func loadDurationSeam(override *atomic.Int64, def time.Duration) time.Duration {
+	if v := override.Load(); v != 0 {
+		return time.Duration(v)
+	}
+	return def
+}
+
+// storeDurationSeam installs a duration override (d == 0 clears it) and returns
+// a restore closure that puts back whatever was there before, so overrides nest
+// LIFO.
+func storeDurationSeam(override *atomic.Int64, d time.Duration) (restore func()) {
+	prev := override.Load()
+	override.Store(int64(d))
+	return func() { override.Store(prev) }
+}
+
+// rebuildWaitInterval resolves the poll cadence between ack checks.
+func rebuildWaitInterval() time.Duration {
+	return loadDurationSeam(&rebuildWaitIntervalOverride, defaultRebuildWaitInterval)
+}
+
+// rebuildWaitStartupWindow resolves the never-became-live fast-fail window.
+func rebuildWaitStartupWindow() time.Duration {
+	return loadDurationSeam(&rebuildWaitStartupWindowOverride, defaultRebuildWaitStartupWindow)
+}
+
+// rebuildWaitTimeout resolves the last-resort overall wait bound.
+func rebuildWaitTimeout() time.Duration {
+	return loadDurationSeam(&rebuildWaitTimeoutOverride, defaultRebuildWaitTimeout)
+}
+
+// rebuildWaitStaleAfter resolves the completion-wait heartbeat staleness bound.
+func rebuildWaitStaleAfter() time.Duration {
+	return loadDurationSeam(&rebuildWaitStaleAfterOverride, defaultRebuildWaitStaleAfter)
+}
+
+// rebuildWaitClock resolves the production clock, or a test's fake.
+func rebuildWaitClock() waitClock {
+	if c := rebuildWaitClockOverride.Load(); c != nil {
+		return *c
+	}
+	return realWaitClock{}
+}
+
+// rebuildEngineAliveFn reports whether the engine's liveness heartbeat is
+// fresh (within rebuildWaitStaleAfter). It has the shape `func() bool` so it
+// can still be passed straight to awaitRebuildAck. Production resolves to
+// defaultRebuildEngineAlive, which reads the engine-liveness sidecar.
+func rebuildEngineAliveFn() bool {
+	if fn := rebuildEngineAliveOverride.Load(); fn != nil {
+		return (*fn)()
+	}
+	return defaultRebuildEngineAlive()
+}
+
+// setRebuildWaitIntervalForTest installs a poll-cadence override (0 clears) and
+// returns a restore closure. Production must never call this — as with every
+// setter below.
+func setRebuildWaitIntervalForTest(d time.Duration) (restore func()) {
+	return storeDurationSeam(&rebuildWaitIntervalOverride, d)
+}
+
+// setRebuildWaitStartupWindowForTest installs a startup-window override (0
+// clears) and returns a restore closure.
+//
+// ASYMMETRY, deliberate (#6059 review F3): awaitRebuildAck still honours
+// startupWindow == 0 as "disable the never-became-live fast-fail", but this
+// setter can no longer produce that, because 0 is the family's clear sentinel
+// and resolves back to defaultRebuildWaitStartupWindow. awaitRebuildAck takes
+// its bounds as parameters and is a pure function, so a direct unit test can
+// still pass 0 — the branch is kept for that caller rather than deleted. What is
+// lost is only the ability to reach it THROUGH the seam, which no test does.
+func setRebuildWaitStartupWindowForTest(d time.Duration) (restore func()) {
+	return storeDurationSeam(&rebuildWaitStartupWindowOverride, d)
+}
+
+// setRebuildWaitTimeoutForTest installs an overall-bound override (0 clears)
+// and returns a restore closure.
+func setRebuildWaitTimeoutForTest(d time.Duration) (restore func()) {
+	return storeDurationSeam(&rebuildWaitTimeoutOverride, d)
+}
+
+// setRebuildWaitStaleAfterForTest installs a staleness-bound override (0
+// clears) and returns a restore closure.
+func setRebuildWaitStaleAfterForTest(d time.Duration) (restore func()) {
+	return storeDurationSeam(&rebuildWaitStaleAfterOverride, d)
+}
+
+// setRebuildWaitClockForTest installs a fake clock and returns a restore
+// closure. c == nil CLEARS the override (the seam falls back to realWaitClock)
+// rather than installing a nil clock whose next method call would panic.
+func setRebuildWaitClockForTest(c waitClock) (restore func()) {
+	prev := rebuildWaitClockOverride.Load()
+	if c == nil {
+		rebuildWaitClockOverride.Store(nil)
+	} else {
+		next := c
+		rebuildWaitClockOverride.Store(&next)
+	}
+	return func() { rebuildWaitClockOverride.Store(prev) }
+}
+
+// setRebuildEngineAliveForTest installs a liveness-probe override and returns a
+// restore closure. fn == nil CLEARS the override (the seam falls back to
+// defaultRebuildEngineAlive); see #6056 F6 for why storing a non-nil pointer to
+// a nil func is the trap this branch avoids.
+func setRebuildEngineAliveForTest(fn func() bool) (restore func()) {
+	prev := rebuildEngineAliveOverride.Load()
+	if fn == nil {
+		rebuildEngineAliveOverride.Store(nil)
+	} else {
+		next := engineAliveFunc(fn)
+		rebuildEngineAliveOverride.Store(&next)
+	}
+	return func() { rebuildEngineAliveOverride.Store(prev) }
+}
 
 // defaultRebuildEngineAlive reads the ambient engine-liveness heartbeat (the
 // same sidecar the wizard/doctor use) and reports whether it is fresh within the
@@ -105,7 +282,7 @@ func defaultRebuildEngineAlive() bool {
 	if err != nil {
 		return false
 	}
-	return time.Since(f.HeartbeatAt) <= rebuildWaitStaleAfter
+	return time.Since(f.HeartbeatAt) <= rebuildWaitStaleAfter()
 }
 
 // awaitRebuildCompletion blocks until the engine writes the terminal ack for the
@@ -119,7 +296,9 @@ func (s *Service) awaitRebuildCompletion(dir, id string) error {
 	// no-op if the wait timed out before any ack was written).
 	defer func() { _ = requests.DeleteAck(dir, id) }()
 	readAck := func() (requests.Ack, bool, error) { return requests.ReadAck(dir, id) }
-	return awaitRebuildAck(readAck, rebuildEngineAliveFn, rebuildWaitClock, rebuildWaitInterval, rebuildWaitStartupWindow, rebuildWaitTimeout)
+	// Each seam is resolved ONCE here, into awaitRebuildAck's parameters, so a
+	// single wait uses one consistent set of bounds (#6059).
+	return awaitRebuildAck(readAck, rebuildEngineAliveFn, rebuildWaitClock(), rebuildWaitInterval(), rebuildWaitStartupWindow(), rebuildWaitTimeout())
 }
 
 // awaitRebuildAck is the pure completion loop (no I/O of its own beyond the
@@ -149,6 +328,9 @@ func awaitRebuildAck(readAck func() (requests.Ack, bool, error), alive func() bo
 			return fmt.Errorf("index engine stopped responding before the group rebuild finished")
 		}
 		elapsed := clk.Now().Sub(start)
+		// startupWindow == 0 disables the fast-fail. Reachable only by a direct
+		// caller of this function: setRebuildWaitStartupWindowForTest treats 0 as
+		// the family's CLEAR sentinel, so it cannot install 0 (#6059 review F3).
 		if !sawAlive && startupWindow > 0 && elapsed >= startupWindow {
 			return fmt.Errorf("index engine never became live within %s; is the daemon/engine running?", startupWindow)
 		}

--- a/internal/daemon/rebuild_wait_test.go
+++ b/internal/daemon/rebuild_wait_test.go
@@ -44,15 +44,9 @@ func withSplitWaitTest(t *testing.T) {
 	t.Setenv(SplitModeEnvVar, "1")
 	t.Setenv(EnvRoot, t.TempDir())
 
-	savInterval, savTimeout, savStartup := rebuildWaitInterval, rebuildWaitTimeout, rebuildWaitStartupWindow
-	savAlive := rebuildEngineAliveFn
-	t.Cleanup(func() {
-		rebuildWaitInterval, rebuildWaitTimeout, rebuildWaitStartupWindow = savInterval, savTimeout, savStartup
-		rebuildEngineAliveFn = savAlive
-	})
-	rebuildWaitInterval = 3 * time.Millisecond
-	rebuildWaitStartupWindow = 50 * time.Millisecond
-	rebuildWaitTimeout = 3 * time.Second
+	t.Cleanup(setRebuildWaitIntervalForTest(3 * time.Millisecond))
+	t.Cleanup(setRebuildWaitStartupWindowForTest(50 * time.Millisecond))
+	t.Cleanup(setRebuildWaitTimeoutForTest(3 * time.Second))
 }
 
 func newWaitService(t *testing.T) *Service {
@@ -68,7 +62,7 @@ func newWaitService(t *testing.T) *Service {
 // engine drains+acks it — exercising the REAL requests ack machinery.
 func TestRebuild_SplitMode_WaitForCompletion_BlocksUntilAck(t *testing.T) {
 	withSplitWaitTest(t)
-	rebuildEngineAliveFn = func() bool { return true }
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return true }))
 	const group = "g"
 	svc := newWaitService(t)
 
@@ -114,7 +108,7 @@ func TestRebuild_SplitMode_WaitForCompletion_BlocksUntilAck(t *testing.T) {
 // `indexed:true` is impossible off a failed rebuild.
 func TestRebuild_SplitMode_WaitForCompletion_FailedRebuildReturnsError(t *testing.T) {
 	withSplitWaitTest(t)
-	rebuildEngineAliveFn = func() bool { return true }
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return true }))
 	const group = "g"
 	svc := newWaitService(t)
 
@@ -150,7 +144,7 @@ func TestRebuild_SplitMode_WaitForCompletion_FailedRebuildReturnsError(t *testin
 // waiter must surface it as an error, not a false success.
 func TestRebuild_SplitMode_WaitForCompletion_DeadLetterReturnsError(t *testing.T) {
 	withSplitWaitTest(t)
-	rebuildEngineAliveFn = func() bool { return true }
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return true }))
 	const group = "g"
 	svc := newWaitService(t)
 
@@ -183,8 +177,8 @@ func TestRebuild_SplitMode_WaitForCompletion_DeadLetterReturnsError(t *testing.T
 // acks — Rebuild must return a clear timeout error, not hang forever.
 func TestRebuild_SplitMode_WaitForCompletion_AckTimeout(t *testing.T) {
 	withSplitWaitTest(t)
-	rebuildEngineAliveFn = func() bool { return true }
-	rebuildWaitTimeout = 80 * time.Millisecond
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return true }))
+	t.Cleanup(setRebuildWaitTimeoutForTest(80 * time.Millisecond))
 	svc := newWaitService(t)
 
 	var reply proto.RebuildReply
@@ -202,8 +196,10 @@ func TestRebuild_SplitMode_WaitForCompletion_AckTimeout(t *testing.T) {
 func TestRebuild_SplitMode_WaitForCompletion_EngineDeath(t *testing.T) {
 	withSplitWaitTest(t)
 	var polls int32
-	rebuildEngineAliveFn = func() bool { return atomic.AddInt32(&polls, 1) <= 1 } // alive once, then dead
-	rebuildWaitTimeout = 3 * time.Second                                          // high, so death (not timeout) is what fires
+	// alive once, then dead
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return atomic.AddInt32(&polls, 1) <= 1 }))
+	// high, so death (not timeout) is what fires
+	t.Cleanup(setRebuildWaitTimeoutForTest(3 * time.Second))
 	svc := newWaitService(t)
 
 	var reply proto.RebuildReply
@@ -221,7 +217,7 @@ func TestRebuild_SplitMode_WaitForCompletion_EngineDeath(t *testing.T) {
 // engine (proved by a dead engine that a wait would have errored on).
 func TestRebuild_SplitMode_FireAndForget_ReturnsImmediately(t *testing.T) {
 	withSplitWaitTest(t)
-	rebuildEngineAliveFn = func() bool { return false }
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return false }))
 	svc := newWaitService(t)
 
 	done := make(chan error, 1)

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -29,16 +29,27 @@ import (
 	"github.com/cajasmota/grafel/internal/version"
 )
 
-// rebuildRPCTimeout is the maximum wall-clock time a single Rebuild RPC is
-// allowed to run. A rebuild that exceeds this limit is treated as a deadlock
+// defaultRebuildRPCTimeout is the maximum wall-clock time a single Rebuild RPC
+// is allowed to run. A rebuild that exceeds this limit is treated as a deadlock
 // and returns an error so the RPC client is unblocked. The underlying index
 // goroutines are abandoned (they will eventually complete or panic-recover and
 // be cleaned up). 2 hours is intentionally conservative — even a full cold
 // re-index of a large group should finish well under 30 minutes in practice.
-//
-// A var (not const) so tests can shrink it to exercise the timeout / single-
-// flight paths deterministically; production never reassigns it.
-var rebuildRPCTimeout = 2 * time.Hour
+const defaultRebuildRPCTimeout = 2 * time.Hour
+
+// rebuildRPCTimeout resolves the effective Rebuild RPC cap: a test override
+// when one is installed, else defaultRebuildRPCTimeout. See the rebuild* seam
+// family note in rebuild_wait.go for WHY this is an accessor over an atomic
+// rather than a plain package var (#6059).
+func rebuildRPCTimeout() time.Duration {
+	return loadDurationSeam(&rebuildRPCTimeoutOverride, defaultRebuildRPCTimeout)
+}
+
+// setRebuildRPCTimeoutForTest installs a test override and returns a restore
+// closure. d == 0 CLEARS the override. Production must never call this.
+func setRebuildRPCTimeoutForTest(d time.Duration) (restore func()) {
+	return storeDurationSeam(&rebuildRPCTimeoutOverride, d)
+}
 
 // defaultStallWarnInterval is how long a Rebuild RPC may run without producing
 // a result before the dead-man detector logs a "possible stall" warning plus a
@@ -732,12 +743,16 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 	// re-triggered rebuilds can never coexist and pile up N multi-GB docs.
 	semVal, _ := s.groupRebuildMu.LoadOrStore(args.Group, make(chan struct{}, 1))
 	groupSem := semVal.(chan struct{})
-	acqTimer := time.NewTimer(rebuildRPCTimeout)
+	// Resolve the seam ONCE into a local: the timer and the message it explains
+	// must describe the same bound even if a test restores the override in
+	// between (the single-Load-into-a-local form, #6059).
+	acqTimeout := rebuildRPCTimeout()
+	acqTimer := time.NewTimer(acqTimeout)
 	select {
 	case groupSem <- struct{}{}:
 		acqTimer.Stop()
 	case <-acqTimer.C:
-		return fmt.Errorf("rebuild group=%s timed out after %s waiting for an in-flight rebuild of the same group to finish", args.Group, rebuildRPCTimeout)
+		return fmt.Errorf("rebuild group=%s timed out after %s waiting for an in-flight rebuild of the same group to finish", args.Group, acqTimeout)
 	}
 	atomic.AddInt64(&s.groupsActiveCount, 1)
 	atomic.AddInt64(&s.rebuildInFlight, 1)
@@ -850,7 +865,9 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 		deadManDone.Wait()
 	}()
 
-	timer := time.NewTimer(rebuildRPCTimeout)
+	// Same single-resolve discipline as the acquire path above (#6059).
+	rpcTimeout := rebuildRPCTimeout()
+	timer := time.NewTimer(rpcTimeout)
 	defer timer.Stop()
 
 	var res rebuildResult
@@ -861,7 +878,7 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 		if s.logger != nil {
 			s.logger.Warn("rebuild: RPC timeout — unblocked; background index may still be running",
 				"group", args.Group,
-				"timeout", rebuildRPCTimeout.String(),
+				"timeout", rpcTimeout.String(),
 			)
 		}
 		if sess != nil {
@@ -876,7 +893,7 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 			}
 			sess.mu.Unlock()
 		}
-		return fmt.Errorf("rebuild group=%s timed out after %s", args.Group, rebuildRPCTimeout)
+		return fmt.Errorf("rebuild group=%s timed out after %s", args.Group, rpcTimeout)
 	}
 
 	if sess != nil {

--- a/internal/daemon/status_rebuild_inflight_6014_test.go
+++ b/internal/daemon/status_rebuild_inflight_6014_test.go
@@ -202,14 +202,8 @@ func TestStatus_InFlightCountsBlockingSplitModeRebuildRPC(t *testing.T) {
 
 	// Keep the completion wait honest but fast: the engine is "alive" and we
 	// poll frequently, so the handler blocks until we write the terminal ack.
-	origAlive := rebuildEngineAliveFn
-	origInterval := rebuildWaitInterval
-	rebuildEngineAliveFn = func() bool { return true }
-	rebuildWaitInterval = time.Millisecond
-	t.Cleanup(func() {
-		rebuildEngineAliveFn = origAlive
-		rebuildWaitInterval = origInterval
-	})
+	t.Cleanup(setRebuildEngineAliveForTest(func() bool { return true }))
+	t.Cleanup(setRebuildWaitIntervalForTest(time.Millisecond))
 
 	svc := newService(nil, func(proto.RebuildArgs) ([]string, string, error) {
 		t.Error("split mode must never call s.rebuild in serve")


### PR DESCRIPTION
`-race` was enabled on the release gate in #6056. This family was the last thing making that gate unreliable: a `WARNING: DATA RACE` in `internal/daemon` on roughly 1 in 8 runs, which works out to about a 1-in-3 chance that at least one of the three OS legs reds per dispatch.

```
WARNING: DATA RACE
Write at 0x...: internal/daemon/rebuild_singleflight_test.go:30
Previous read at 0x...: internal/daemon.(*Service).Rebuild()  service.go:853
  ... net/rpc.(*Server).ServeCodec.gowrap1()
```

Seven plain package vars written by tests and read from live `net/rpc` serving goroutines: `rebuildRPCTimeout`, `rebuildWaitTimeout`, `rebuildWaitInterval`, `rebuildWaitStartupWindow`, `rebuildWaitStaleAfter`, `rebuildWaitClock`, `rebuildEngineAliveFn` — ~21 write-sites across four test files, with `rebuild_wait.go` documenting them as a family so a future knob inherits the hazard.

## Why no one could ever reproduce it

**0 failures in 80 isolated runs** of the failing test, against 1 in 36 full-package iterations. The reader is not the test's own RPC — it is a serving goroutine **leaked by an earlier test in the same binary**. `shutdown_watchdog_test.go:73-94` deliberately abandons a `stall-group` Rebuild blocked on a never-closed channel; that goroutine read the seam twice on its way into the timer select and is still parked there when a later test writes the var. TSan pairs the two across arbitrary wall-time.

So the race needs a *neighbour* to have run first. "Re-run the flake to check" could never have verified anything.

## The fix

All seven converted to `atomic.Int64` (durations) and `atomic.Pointer` (clock, func) behind accessors that keep the **original identifiers**, so the runbook's name-scoped triage and any detector report stay greppable. nil/0 clears, uniformly — #6056 had to fix an asymmetry where one setter stored a non-nil pointer to a nil func and the next resolve panicked; that trap is not reintroduced.

Atomics rather than "join the goroutine before restore": joining is correct today but silently stops protecting the first time a fixture forgets, while an atomic has no plain-access form, so goroutine lifetime stops mattering at all.

None qualified as read-once — `rebuildRPCTimeout` resolves twice per RPC on the serving goroutine, and `rebuildWaitStaleAfter` on every poll iteration of the wait loop. `defaultRebuildWaitTimeout = defaultRebuildRPCTimeout` reproduces the old var-init-order copy exactly: shrinking the RPC cap never shrank the wait cap, and still doesn't.

One behaviour change rides along and is correct: `service.go` previously resolved the acquire timeout twice, so the error message could print `2s` while the timer was actually `120ms`. It now resolves once into a local.

## Evidence

Against a ~3% per-iteration event, 20 clean package runs is ~45% power — a smoke test, not a proof, and it is not what this rests on. The load-bearing evidence is the pin: **0 failures in 60 runs on correct code, 5/5 `WARNING: DATA RACE` on each of the four seam shapes** when reverted to a plain var.

The pin uses a live concurrent reader rather than a leaked one — a structural proxy, and a legitimate one: it exercises the same TSan predicate, and once storage is atomic the hazard is closed for any reader lifetime.

14 mutations, all real test failures. Three came out of review:

**The pin leaked its own overrides.** Seven global installs with no `t.Cleanup`, so any `t.Fatalf` exited via `runtime.Goexit` with no restore — leaking a clock frozen at `time.Unix(0,0)` and a permanently-true `alive()` into every later test in the binary. `awaitRebuildAck`'s exit conditions become *unreachable*, so the next dependent test burns the entire `-timeout` ceiling and Go panics the whole binary, losing everything scheduled after it. On CI that is 40 minutes per leg, three legs, and a one-line diagnostic replaced by a goroutine dump. Isolated by M14 (corrupting an expected constant in the comparison table, so cleanup registration is the only variable): **70s / 0 panics fixed, versus 372s / 1 panic unfixed.**

**The vacuity guard had its own vacuity gap.** It asserted the setters took effect and the reader ran, but never that a write occurred *while the reader was live*. Replacing the override churn with read-only resolves left it green 5/5 with a plain-var defect present. Now `installAllRebuildSeamOverrides` **returns** the write count rather than the caller incrementing it, so a non-zero count cannot exist without a write — and the realistic "hoist the setup out of the loop" refactor deletes the call site, which trips the guard.

## Runbook

`release-signoff.md` §0 entry (a) deleted per its own trigger, replaced by a note that a `rebuild*` DATA RACE is now a **real** failure rather than a re-dispatch. That fails closed: a missed seam would block a release rather than launder a race. The `TestV2GraphRestoresDiskPayloadBeforeLoadingGraph` entry (#6061) is untouched.

## Known and disclosed

- The leaked-goroutine *partner* is inferred from goroutine-creation frames, not from a controlled reproduction — pairing the watchdog test with the singleflight test failed to reproduce in 20 attempts. The fix is structural rather than partner-specific, so this does not gate it.
- `awaitRebuildAck`'s `startupWindow > 0` branch is now unreachable in practice, since the setter clears 0 to the default. Kept deliberately — it is a pure function whose contract a future direct unit test could exercise — with the asymmetry documented at both the setter and the branch.
- Set/restore is a non-atomic read-modify-write, sound only because nothing in `internal/daemon` calls `t.Parallel()`. Noted next to the LIFO claim; a parallel fixture would need a CAS.
- ~3% measured here versus the ~12% in the issue: different quantities, both right. ~12% is per-dispatch across three OS legs; ~3% is per full-package iteration on one box. `1-(1-0.03)^k` reaches 12% at k≈4.
- Only `internal/daemon` was run under `-race` locally.

Independently adversarially reviewed across two rounds.

Closes #6059
