### PR TITLE
fix(sched): CancelGroup could not cancel an already-fired link or group-algo pass — plus two Windows fixtures

### DIFF
--- a/internal/daemon/rebuild_seam_race_test.go
+++ b/internal/daemon/rebuild_seam_race_test.go
@@ -158,10 +158,15 @@ func TestRebuildSeams_ConcurrentOverrideAndRead(t *testing.T) {
 	// nest under it, which is what the writer loop below exercises.
 	var readerIters int64
 	stop := make(chan struct{})
+	readerLive := make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+		// Announce BEFORE the loop, not after an iteration: every counted
+		// iteration must be concurrent with the writer, so the barrier must not
+		// itself contribute one.
+		close(readerLive)
 		for {
 			select {
 			case <-stop:
@@ -172,13 +177,32 @@ func TestRebuildSeams_ConcurrentOverrideAndRead(t *testing.T) {
 			atomic.AddInt64(&readerIters, 1)
 		}
 	}()
+	// The writer must not start until the reader goroutine is provably running.
+	// Without this the whole 2000-iteration writer loop can complete and close
+	// `stop` before the reader is ever scheduled — the fixture then reports
+	// itself vacuous, which is exactly what windows-latest did on the v0.2.0
+	// gate (macos/ubuntu green). Go gives no scheduling guarantee to a freshly
+	// created goroutine on any OS; Windows just loses the coin flip more often
+	// under -race with several test binaries sharing the runner's cores.
+	<-readerLive
 
 	// writerWrites counts SEAM WRITES performed while the reader goroutine is
 	// live. It is incremented only from installAllRebuildSeamOverrides' return
 	// value, so it cannot be kept while the writes are removed — see the guard
 	// below for why that matters.
 	var writerWrites int
-	for i := 0; i < 2000; i++ {
+
+	// The loop runs 2000 iterations, and KEEPS GOING past 2000 until the reader
+	// has resolved at least once. That extension is a hang guard, not a latency
+	// budget: it does not decide whether the assertion holds, it only refuses to
+	// stop writing while the reader still has nothing to be concurrent WITH. On
+	// a host that hands the reader a core promptly it never runs a single extra
+	// iteration; on a starved one it keeps the write side live instead of
+	// declaring the fixture vacuous. Bounded by wall clock so a reader that
+	// genuinely cannot run still reaches the guard below and fails the test
+	// rather than hanging the package.
+	writerDeadline := time.Now().Add(30 * time.Second)
+	for i := 0; i < 2000 || (atomic.LoadInt64(&readerIters) == 0 && time.Now().Before(writerDeadline)); i++ {
 		restore, n := installAllRebuildSeamOverrides(i, &aliveCalls, &clockUses)
 		writerWrites += n
 		// Resolve under the override too, so each seam is exercised in both
@@ -186,10 +210,15 @@ func TestRebuildSeams_ConcurrentOverrideAndRead(t *testing.T) {
 		resolveAllRebuildSeams()
 		restore()
 	}
+	// Sampled BEFORE close(stop) so it counts only resolves that happened while
+	// the writer was still writing. Reading it after wg.Wait() would also count
+	// the iterations the reader gets in during the shutdown handshake, which are
+	// concurrent with nothing and would let the guard pass vacuously.
+	concurrentIters := atomic.LoadInt64(&readerIters)
 
 	close(stop)
 	wg.Wait()
-	if atomic.LoadInt64(&readerIters) == 0 {
+	if concurrentIters == 0 {
 		t.Fatal("reader goroutine never resolved a seam — fixture cannot exhibit the race it claims to guard")
 	}
 	// The writer half of the same guard, and NOT redundant with Phase 1. Phase 1

--- a/internal/daemon/sched/cancelgroup_armcancel_test.go
+++ b/internal/daemon/sched/cancelgroup_armcancel_test.go
@@ -6,6 +6,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
 // The windows-latest leg of the v0.2.0 release gate reported
@@ -25,7 +27,61 @@ import (
 // Calling s.fireLinks(group, arm) directly IS that in-flight body: the timer is
 // armed as time.AfterFunc(d, func() { s.fireLinks(group, arm) }), so this is
 // the residual work a failed Stop() leaves behind, with the scheduling
-// non-determinism removed.
+// non-determinism removed. The group-algo family carries the identical hazard
+// and is pinned the same way at the bottom of this file.
+
+// armCancelHangGuard bounds the waits in this file. Every one of them is a hang
+// guard on a state transition that must happen, never a latency budget: the
+// assertions are all "this did / did not run", none of them "within X". Sized
+// generously because a loaded windows-latest runner has to schedule a goroutine,
+// fire a 1ms timer, acquire the stage token and enter a callback — a 2s wait for
+// that chain is a Windows red waiting to happen, which is the whole reason this
+// branch exists.
+const armCancelHangGuard = 30 * time.Second
+
+// waitForState polls cond until it holds, and fails with what the caller was
+// waiting FOR when it does not. (The package's shared waitFor reports only
+// "condition not met", which on a starved runner is indistinguishable from a
+// dozen other things.)
+func waitForState(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(armCancelHangGuard)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("timed out after %s waiting for: %s", armCancelHangGuard, what)
+}
+
+// waitForChan waits for ch to close, failing with what the caller expected
+// rather than hanging until the package timeout dumps every goroutine.
+func waitForChan(t *testing.T, what string, ch <-chan struct{}) {
+	t.Helper()
+	select {
+	case <-ch:
+	case <-time.After(armCancelHangGuard):
+		t.Fatalf("timed out after %s waiting for: %s", armCancelHangGuard, what)
+	}
+}
+
+// armedGroupAlgo arms group's group-algo timer through the production path and
+// returns the id of the timer it armed — the id that timer's AfterFunc body
+// carries. A test that invokes fireGroupAlgo directly is STANDING IN for that
+// body, so it must use this: calling with an id no timer ever held is not a
+// faithful stand-in, and the arm check would (correctly) decline to run it.
+func armedGroupAlgo(t *testing.T, s *Scheduler, group string) uint64 {
+	t.Helper()
+	s.scheduleGroupAlgo(group)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	arm, ok := s.groupAlgoArm[group]
+	if !ok {
+		t.Fatalf("scheduleGroupAlgo(%q) armed no timer — the fixture cannot stand in for a fired timer body", group)
+	}
+	return arm
+}
 
 // TestFireLinks_AfterCancelGroup_DoesNotRun covers the plain (non-deferred)
 // arm: a debounce timer that fired just before the group was deleted.
@@ -131,11 +187,11 @@ func TestFireLinks_AfterCancelGroup_DeferredArmDoesNotRun(t *testing.T) {
 	defer func() { releaseAFn(); s.Stop() }()
 
 	s.scheduleLinks("gA")
-	<-startedA
+	waitForChan(t, "gA's link pass to start and take the heavy write-stage token", startedA)
 
 	// gB fires while gA holds the token → it defers and re-arms a retry timer.
 	s.scheduleLinks("gB")
-	waitFor(t, 2*time.Second, func() bool {
+	waitForState(t, "gB's link pass to be DEFERRED by the stage gate", func() bool {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		_, deferred := s.stageDeferSince["links:gB"]
@@ -166,12 +222,180 @@ func TestFireLinks_AfterCancelGroup_DeferredArmDoesNotRun(t *testing.T) {
 
 	// Free the token: nothing must be waiting on it for gB.
 	releaseAFn()
-	waitFor(t, 2*time.Second, func() bool {
+	waitForState(t, "gA to release the heavy write-stage token", func() bool {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 		return s.stageHolder == ""
 	})
 	if n := ranB.Load(); n != 0 {
 		t.Fatalf("a cancelled, deferred link pass ran %d time(s) after the group was deleted", n)
+	}
+
+	// CONTROL. Everything above is a negative assertion, and with the retry armed
+	// an hour out and then cancelled, ranB == 0 would also hold if gB's pass were
+	// unreachable for some reason that has nothing to do with the cancel — a
+	// mis-wired Links callback, a permanently held token, a stopped scheduler.
+	// Re-arming gB now, with the token free, must produce exactly the run the
+	// cancel suppressed.
+	s.scheduleLinks("gB")
+	waitForState(t, "a freshly armed gB link pass to run (control for the cancelled one)", func() bool {
+		return ranB.Load() == 1
+	})
+}
+
+// TestFireGroupAlgo_AfterCancelGroup_DoesNotRun is the group-algo twin of
+// TestFireLinks_AfterCancelGroup_DoesNotRun, and the stakes are higher.
+// runGroupAlgo is the heaviest job the daemon runs — Louvain + PageRank +
+// betweenness over the group union, in a subprocess — and its ctx is rooted only
+// at shutdownCtx, so a pass that escapes its group's delete has nothing left to
+// cancel it: it pins cores to completion for a group that no longer exists,
+// which is the exact leak CancelGroup was written to prevent.
+func TestFireGroupAlgo_AfterCancelGroup_DoesNotRun(t *testing.T) {
+	var ran atomic.Int32
+	s := New(Config{
+		Workers: 1,
+		// Both an hour out, so no timer fires on its own: this test invokes the
+		// body, exactly as an already-fired timer would.
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			ran.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	arm := armedGroupAlgo(t, s, "gB")
+	s.CancelGroup("gB")
+
+	// The already-fired timer body runs AFTER the delete.
+	s.fireGroupAlgo("gB", arm)
+	if n := ran.Load(); n != 0 {
+		t.Fatalf("a group-algo pass whose group was deleted ran %d time(s) — nothing can cancel it once it starts", n)
+	}
+	s.mu.Lock()
+	_, reArmed := s.groupAlgoTimers["gB"]
+	_, reInflight := s.groupAlgoCancel["gB"]
+	s.mu.Unlock()
+	if reArmed || reInflight {
+		t.Fatalf("a cancelled fire re-registered the deleted group (armed=%v inflight=%v)", reArmed, reInflight)
+	}
+
+	// CONTROL — without it this passes for any reason fireGroupAlgo might
+	// decline to run, and would not be testing the cancel at all.
+	arm2 := armedGroupAlgo(t, s, "gB")
+	if arm2 == arm {
+		t.Fatal("re-arm reused the cancelled arm id — the control cannot distinguish cancelled from live")
+	}
+	s.fireGroupAlgo("gB", arm2)
+	if n := ran.Load(); n != 1 {
+		t.Fatalf("control: an UNcancelled fired timer must run the pass exactly once, ran %d time(s)", n)
+	}
+
+	// groupAlgoArm must track groupAlgoTimers exactly. This is a consistency
+	// assertion, not a behavioural pin: groupAlgoArm has one reader and ids never
+	// repeat, so a stale entry has no observable effect beyond the disagreement
+	// itself.
+	s.mu.Lock()
+	_, stillTimed := s.groupAlgoTimers["gB"]
+	_, stillArm := s.groupAlgoArm["gB"]
+	s.mu.Unlock()
+	if stillTimed != stillArm {
+		t.Fatalf("groupAlgoArm/groupAlgoTimers disagree after the pass ran (timer=%v arm=%v)", stillTimed, stillArm)
+	}
+}
+
+// TestFireGroupAlgo_AfterCancelGroup_DeferredArmBalancesIndexstate covers the
+// gate-deferred arm, where the escape did more than waste CPU. The deferred
+// branch of fireGroupAlgo takes an indexstate.GroupAlgoBegin (so a DEFERRED pass
+// stays visible to grafel_stats). cancelGroupAlgoLocked releases that pair on
+// delete — and then the already-fired body took a FRESH one that nothing would
+// ever release: the process-global counter sits at +1 forever and every
+// grafel_stats consumer sees a group-algo pass permanently in flight.
+func TestFireGroupAlgo_AfterCancelGroup_DeferredArmBalancesIndexstate(t *testing.T) {
+	var ran atomic.Int32
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		StageGateRetry:    time.Hour,
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, _ string) error {
+			ran.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	// indexstate is PROCESS-GLOBAL: a t.Fatal mid-test would otherwise leak this
+	// test's hold into every later test in the binary.
+	t.Cleanup(func() {
+		s.mu.Lock()
+		delete(s.inflight, "/busy")
+		s.markGroupAlgoDeferredLocked("gB", false)
+		s.mu.Unlock()
+	})
+	before := indexstate.Get().GroupAlgoInFlight
+
+	// An index batch in flight makes the gate refuse, so the fire DEFERS.
+	s.mu.Lock()
+	s.inflight["/busy"] = 1
+	s.mu.Unlock()
+
+	s.fireGroupAlgo("gB", armedGroupAlgo(t, s, "gB"))
+	if got := indexstate.Get().GroupAlgoInFlight; got != before+1 {
+		t.Fatalf("a DEFERRED pass must hold exactly one indexstate count (got %d, was %d) — fixture cannot detect an unbalanced re-take", got, before)
+	}
+	s.mu.Lock()
+	deferredArm, armed := s.groupAlgoArm["gB"]
+	s.mu.Unlock()
+	if !armed {
+		t.Fatal("a deferred pass recorded no retry arm id — fixture cannot exhibit the race it claims to guard")
+	}
+
+	// The delete releases the deferred hold.
+	s.CancelGroup("gB")
+	if got := indexstate.Get().GroupAlgoInFlight; got != before {
+		t.Fatalf("CancelGroup must release the deferred pass's indexstate hold (got %d, want %d)", got, before)
+	}
+
+	// The retry timer had already fired when the delete landed.
+	s.fireGroupAlgo("gB", deferredArm)
+
+	if got := indexstate.Get().GroupAlgoInFlight; got != before {
+		t.Fatalf("a cancelled deferred fire re-took an indexstate hold nobody will release (got %d, want %d) — grafel_stats reports a group-algo pass in flight forever", got, before)
+	}
+	s.mu.Lock()
+	_, reArmed := s.groupAlgoTimers["gB"]
+	_, reDeferred := s.stageDeferSince["group-algo:gB"]
+	stillMarked := s.groupAlgoDeferred["gB"]
+	s.mu.Unlock()
+	if reArmed || reDeferred || stillMarked {
+		t.Fatalf("a cancelled deferred fire re-registered the deleted group (armed=%v deferred=%v marked=%v)", reArmed, reDeferred, stillMarked)
+	}
+	if n := ran.Load(); n != 0 {
+		t.Fatalf("a cancelled, deferred group-algo pass ran %d time(s) after the group was deleted", n)
+	}
+
+	// CONTROL: with the gate free again, a freshly armed pass must run — so the
+	// zeroes above are the cancel's doing, not an unreachable callback.
+	s.mu.Lock()
+	delete(s.inflight, "/busy")
+	s.mu.Unlock()
+	s.fireGroupAlgo("gB", armedGroupAlgo(t, s, "gB"))
+	if n := ran.Load(); n != 1 {
+		t.Fatalf("control: an UNcancelled fired timer must run the pass exactly once, ran %d time(s)", n)
+	}
+	if got := indexstate.Get().GroupAlgoInFlight; got != before {
+		t.Fatalf("indexstate did not return to its baseline after the control pass (got %d, want %d)", got, before)
 	}
 }

--- a/internal/daemon/sched/cancelgroup_armcancel_test.go
+++ b/internal/daemon/sched/cancelgroup_armcancel_test.go
@@ -1,0 +1,177 @@
+package sched
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The windows-latest leg of the v0.2.0 release gate reported
+// `TestCancelGroup_DeferredLinkPassNeverRuns: a cancelled, deferred link pass
+// ran 1 time(s) after the group was deleted`. That test drives the window
+// through real timers, so it only reports the defect on a host slow enough to
+// open it. The two tests here drive the SAME window deterministically.
+//
+// The window: CancelGroup stops the group's debounce/retry timer with
+// Timer.Stop(), which reports false once the timer has ALREADY fired — the
+// AfterFunc body (fireLinks) is then in flight on the timer goroutine and is
+// not reachable by anything CancelGroup does. Pre-fix that body went on to
+// acquire the heavy write-stage token and run the deleted group's link pass;
+// on the deferred path it re-armed a fresh retry timer and re-registered the
+// stage deferral, resurrecting both map entries CancelGroup had just dropped.
+//
+// Calling s.fireLinks(group, arm) directly IS that in-flight body: the timer is
+// armed as time.AfterFunc(d, func() { s.fireLinks(group, arm) }), so this is
+// the residual work a failed Stop() leaves behind, with the scheduling
+// non-determinism removed.
+
+// TestFireLinks_AfterCancelGroup_DoesNotRun covers the plain (non-deferred)
+// arm: a debounce timer that fired just before the group was deleted.
+func TestFireLinks_AfterCancelGroup_DoesNotRun(t *testing.T) {
+	var ran atomic.Int32
+	s := New(Config{
+		Workers: 1,
+		// Long enough that the timer never fires on its own — this test fires
+		// the body itself, exactly as the already-fired timer would.
+		LinkDebounce: time.Hour,
+		Links: func(_ context.Context, _ string) error {
+			ran.Add(1)
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleLinks("gB")
+	s.mu.Lock()
+	arm, armed := s.linkArm["gB"]
+	s.mu.Unlock()
+	if !armed {
+		t.Fatal("scheduleLinks recorded no arm id — fixture cannot exhibit the cancel/fire race it claims to guard")
+	}
+
+	s.CancelGroup("gB")
+
+	// The already-fired timer body runs AFTER the delete.
+	s.fireLinks("gB", arm)
+	if n := ran.Load(); n != 0 {
+		t.Fatalf("a link pass whose group was deleted ran %d time(s) — CancelGroup's Timer.Stop() lost the race with the firing timer", n)
+	}
+	// It must also not resurrect the group's scheduling state.
+	s.mu.Lock()
+	_, reArmed := s.linkTimers["gB"]
+	_, reDeferred := s.stageDeferSince["links:gB"]
+	s.mu.Unlock()
+	if reArmed || reDeferred {
+		t.Fatalf("a cancelled fire re-registered the deleted group (armed=%v deferred=%v)", reArmed, reDeferred)
+	}
+
+	// CONTROL — without this the test passes for any reason fireLinks might
+	// decline to run (nil Links, stopped scheduler, a permanently blocked
+	// stage gate), i.e. it would not be checking the cancel at all.
+	s.scheduleLinks("gB")
+	s.mu.Lock()
+	arm2 := s.linkArm["gB"]
+	s.mu.Unlock()
+	if arm2 == arm {
+		t.Fatal("re-arm reused the cancelled arm id — the control cannot distinguish cancelled from live")
+	}
+	s.fireLinks("gB", arm2)
+	if n := ran.Load(); n != 1 {
+		t.Fatalf("control: an UNcancelled fired timer must run the pass exactly once, ran %d time(s)", n)
+	}
+
+	// linkArm must track linkTimers exactly: an id outliving the timer it names
+	// is an entry that grows per group and can never be matched again, and it
+	// makes "is this group armed?" answerable two ways that disagree.
+	s.mu.Lock()
+	_, stillTimed := s.linkTimers["gB"]
+	_, stillArm := s.linkArm["gB"]
+	s.mu.Unlock()
+	if stillTimed != stillArm {
+		t.Fatalf("linkArm/linkTimers disagree after the pass ran (timer=%v arm=%v) — the arm id must be dropped with the timer", stillTimed, stillArm)
+	}
+}
+
+// TestFireLinks_AfterCancelGroup_DeferredArmDoesNotRun covers the arm the CI
+// failure actually hit: the retry timer of a pass DEFERRED by the heavy
+// write-stage gate. gA holds the token, so an unguarded fire would not run the
+// pass immediately — it would re-arm a retry timer and re-register the stage
+// deferral for the deleted group, and run it as soon as gA released.
+func TestFireLinks_AfterCancelGroup_DeferredArmDoesNotRun(t *testing.T) {
+	startedA := make(chan struct{})
+	releaseA := make(chan struct{})
+	var ranB atomic.Int32
+
+	s := New(Config{
+		Workers: 1,
+		// The debounce is short so gB's first fire really goes through the timer
+		// and really defers on the gate. The RETRY it then arms is an hour out,
+		// so the only thing that fires it is this test — the fired-timer body is
+		// invoked deterministically below rather than raced for.
+		LinkDebounce:   time.Millisecond,
+		StageGateRetry: time.Hour,
+		Links: func(_ context.Context, group string) error {
+			if group == "gB" {
+				ranB.Add(1)
+				return nil
+			}
+			close(startedA)
+			<-releaseA
+			return nil
+		},
+		MemReleaseDisabled: true,
+	})
+	var releaseOnce sync.Once
+	releaseAFn := func() { releaseOnce.Do(func() { close(releaseA) }) }
+	s.Start()
+	defer func() { releaseAFn(); s.Stop() }()
+
+	s.scheduleLinks("gA")
+	<-startedA
+
+	// gB fires while gA holds the token → it defers and re-arms a retry timer.
+	s.scheduleLinks("gB")
+	waitFor(t, 2*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		_, deferred := s.stageDeferSince["links:gB"]
+		return deferred
+	})
+	s.mu.Lock()
+	retryArm, armed := s.linkArm["gB"]
+	s.mu.Unlock()
+	if !armed {
+		t.Fatal("a deferred pass recorded no retry arm id — fixture cannot exhibit the race it claims to guard")
+	}
+	if n := ranB.Load(); n != 0 {
+		t.Fatalf("gB's link pass ran %d time(s) while gA held the stage token", n)
+	}
+
+	s.CancelGroup("gB")
+
+	// The retry timer had already fired when the delete landed.
+	s.fireLinks("gB", retryArm)
+
+	s.mu.Lock()
+	_, reArmed := s.linkTimers["gB"]
+	_, reDeferred := s.stageDeferSince["links:gB"]
+	s.mu.Unlock()
+	if reArmed || reDeferred {
+		t.Fatalf("a cancelled deferred fire re-registered the deleted group (armed=%v deferred=%v) — it will run as soon as the token frees", reArmed, reDeferred)
+	}
+
+	// Free the token: nothing must be waiting on it for gB.
+	releaseAFn()
+	waitFor(t, 2*time.Second, func() bool {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		return s.stageHolder == ""
+	})
+	if n := ranB.Load(); n != 0 {
+		t.Fatalf("a cancelled, deferred link pass ran %d time(s) after the group was deleted", n)
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -477,6 +477,21 @@ type Scheduler struct {
 	usedMB         int64             // sum of inflight MB
 	linkTimers     map[string]*time.Timer
 	linkPending    map[string]bool
+	// linkArm is the identity of the CURRENTLY ARMED link timer for a group,
+	// and linkArmSeq the monotonic source of those ids. Every arm site
+	// (scheduleLinks and fireLinks' defer-retry) goes through
+	// armLinkTimerLocked, which allocates a new id.
+	//
+	// Timer.Stop() cannot stop a timer that has already fired, so CancelGroup
+	// alone could not reach the in-flight AfterFunc body of a link pass whose
+	// timer fired just before the group was deleted: the body went on to run
+	// the deleted group's pass (or, on the gate-deferred path, to re-arm a
+	// retry timer and re-register the stage deferral for the deleted group).
+	// fireLinks therefore re-checks its own arm id against this map under the
+	// same lock hold that acquires the stage token, and CancelGroup deletes the
+	// entry — so the delete strictly orders against the fire. Guarded by mu.
+	linkArm    map[string]uint64
+	linkArmSeq uint64
 	// Per-GROUP algorithm pass (#5349 A3). Mirrors the link timer machinery:
 	// debounce timer + pending flag + in-flight cancel func, all keyed by group.
 	// Replaces the old per-repo algo timers — algorithms now run once over the
@@ -763,6 +778,7 @@ func New(cfg Config) *Scheduler {
 		pendingCommits:    map[string]string{},
 		linkTimers:        map[string]*time.Timer{},
 		linkPending:       map[string]bool{},
+		linkArm:           map[string]uint64{},
 		groupAlgoTimers:   map[string]*time.Timer{},
 		groupAlgoPending:  map[string]bool{},
 		groupAlgoCancel:   map[string]*groupAlgoPassCancel{},
@@ -840,6 +856,10 @@ func (s *Scheduler) Stop() {
 	for _, t := range s.linkTimers {
 		t.Stop()
 	}
+	// Same reason as CancelGroup: a link timer that already fired is only
+	// reachable through its arm id. fireLinks also checks stopped(), so this is
+	// belt-and-braces for a body that passed that check before Stop began.
+	s.linkArm = map[string]uint64{}
 	for _, t := range s.groupAlgoTimers {
 		t.Stop()
 	}
@@ -1852,8 +1872,22 @@ func (s *Scheduler) scheduleLinks(group string) {
 		t.Stop()
 	}
 	s.linkPending[group] = true
-	s.linkTimers[group] = time.AfterFunc(s.cfg.LinkDebounce, func() { s.fireLinks(group) })
+	s.armLinkTimerLocked(group, s.cfg.LinkDebounce)
 	s.mu.Unlock()
+}
+
+// armLinkTimerLocked arms (or re-arms) group's link timer under a FRESH arm id
+// and records that id in linkArm. fireLinks refuses to run for any other id, so
+// the id is what makes a delete stick: CancelGroup drops linkArm[group], and a
+// timer that had already fired when the delete landed — Timer.Stop() reports
+// false for it and nothing else can reach its in-flight AfterFunc body — finds
+// its id gone and returns without running or re-arming.
+// MUST be called with s.mu held.
+func (s *Scheduler) armLinkTimerLocked(group string, delay time.Duration) {
+	s.linkArmSeq++
+	arm := s.linkArmSeq
+	s.linkArm[group] = arm
+	s.linkTimers[group] = time.AfterFunc(delay, func() { s.fireLinks(group, arm) })
 }
 
 // fireLinks is the link-debounce timer body, split out of scheduleLinks so a
@@ -1862,7 +1896,14 @@ func (s *Scheduler) scheduleLinks(group string) {
 // the pass stays PENDING (linkPending is never cleared) and a fresh retry timer
 // is armed under the same linkTimers[group] key — so CancelGroup still reaches
 // it and no work is lost.
-func (s *Scheduler) fireLinks(group string) {
+//
+// arm is the identity of the timer whose body this is. The "is this arm still
+// live" test and the stage acquisition happen under ONE hold of s.mu, so
+// CancelGroup is strictly ordered against it: either the delete lands first and
+// this returns having done nothing, or the pass has already acquired the token
+// and registered its linkCancel token, which the delete then cancels. There is
+// no third outcome in which a deleted group's pass runs.
+func (s *Scheduler) fireLinks(group string, arm uint64) {
 	if s.stopped() {
 		return // shutting down — do not re-arm a retry timer that outlives Stop
 	}
@@ -1870,6 +1911,14 @@ func (s *Scheduler) fireLinks(group string) {
 	now := time.Now()
 
 	s.mu.Lock()
+	if live, ok := s.linkArm[group]; !ok || live != arm {
+		// Cancelled (group deleted) or superseded by a newer arm while this
+		// timer body was in flight. Running now would run a deleted group's
+		// link pass; re-arming now would resurrect the very timer and stage
+		// deferral CancelGroup just dropped.
+		s.mu.Unlock()
+		return
+	}
 	stageEpoch, acquired := s.tryAcquireStageLocked(name, now)
 	if !acquired {
 		delay := s.noteStageDeferLocked(name, now)
@@ -1877,12 +1926,13 @@ func (s *Scheduler) fireLinks(group string) {
 		if t, ok := s.linkTimers[group]; ok {
 			t.Stop()
 		}
-		s.linkTimers[group] = time.AfterFunc(delay, func() { s.fireLinks(group) })
+		s.armLinkTimerLocked(group, delay)
 		s.mu.Unlock()
 		return
 	}
 	s.linkPending[group] = false
 	delete(s.linkTimers, group)
+	delete(s.linkArm, group)
 	// Derive a PER-GROUP cancel context from shutdownCtx (not shutdownCtx
 	// directly) so that a group delete can interrupt THIS group's in-flight
 	// link pass via CancelGroup without waiting for daemon Stop(). Still
@@ -2303,6 +2353,10 @@ func (s *Scheduler) CancelGroup(group string) {
 		delete(s.linkTimers, group)
 		s.linkPending[group] = false
 	}
+	// Stop() above is a no-op for a timer that has ALREADY fired: its fireLinks
+	// body is in flight on the timer goroutine and holds only its arm id.
+	// Dropping the id is what stops that body — see linkArm.
+	delete(s.linkArm, group)
 	if tok, ok := s.linkCancel[group]; ok {
 		tok.cancel()
 		delete(s.linkCancel, group)

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -478,8 +478,9 @@ type Scheduler struct {
 	linkTimers     map[string]*time.Timer
 	linkPending    map[string]bool
 	// linkArm is the identity of the CURRENTLY ARMED link timer for a group,
-	// and linkArmSeq the monotonic source of those ids. Every arm site
-	// (scheduleLinks and fireLinks' defer-retry) goes through
+	// and armSeq the monotonic source of those ids (shared with groupAlgoArm;
+	// the two keyspaces are independent but the counter need not be). Every arm
+	// site (scheduleLinks and fireLinks' defer-retry) goes through
 	// armLinkTimerLocked, which allocates a new id.
 	//
 	// Timer.Stop() cannot stop a timer that has already fired, so CancelGroup
@@ -490,8 +491,20 @@ type Scheduler struct {
 	// fireLinks therefore re-checks its own arm id against this map under the
 	// same lock hold that acquires the stage token, and CancelGroup deletes the
 	// entry — so the delete strictly orders against the fire. Guarded by mu.
-	linkArm    map[string]uint64
-	linkArmSeq uint64
+	linkArm map[string]uint64
+	// groupAlgoArm is the same mechanism for the group-algo family, and it
+	// matters MORE there. A link pass that escapes its delete at least runs
+	// under a ctx CancelGroup can still cancel; runGroupAlgo's ctx is rooted
+	// only at shutdownCtx, so an escaped group-algo pass — Louvain + PageRank +
+	// betweenness over the group union, in a subprocess, the heaviest job the
+	// daemon runs — has nothing left to cancel it and burns cores to completion
+	// for a group that no longer exists. On the gate-deferred path the escape
+	// was worse than wasted work: the body called markGroupAlgoDeferredLocked
+	// (indexstate.GroupAlgoBegin) after cancelGroupAlgoLocked had already
+	// released the pair, leaving the process-global counter permanently +1 and
+	// grafel_stats reporting a pass in flight forever.
+	groupAlgoArm map[string]uint64
+	armSeq       uint64
 	// Per-GROUP algorithm pass (#5349 A3). Mirrors the link timer machinery:
 	// debounce timer + pending flag + in-flight cancel func, all keyed by group.
 	// Replaces the old per-repo algo timers — algorithms now run once over the
@@ -779,6 +792,7 @@ func New(cfg Config) *Scheduler {
 		linkTimers:        map[string]*time.Timer{},
 		linkPending:       map[string]bool{},
 		linkArm:           map[string]uint64{},
+		groupAlgoArm:      map[string]uint64{},
 		groupAlgoTimers:   map[string]*time.Timer{},
 		groupAlgoPending:  map[string]bool{},
 		groupAlgoCancel:   map[string]*groupAlgoPassCancel{},
@@ -863,6 +877,7 @@ func (s *Scheduler) Stop() {
 	for _, t := range s.groupAlgoTimers {
 		t.Stop()
 	}
+	s.groupAlgoArm = map[string]uint64{}
 	for _, tok := range s.groupAlgoCancel {
 		tok.cancel()
 	}
@@ -1884,8 +1899,8 @@ func (s *Scheduler) scheduleLinks(group string) {
 // its id gone and returns without running or re-arming.
 // MUST be called with s.mu held.
 func (s *Scheduler) armLinkTimerLocked(group string, delay time.Duration) {
-	s.linkArmSeq++
-	arm := s.linkArmSeq
+	s.armSeq++
+	arm := s.armSeq
 	s.linkArm[group] = arm
 	s.linkTimers[group] = time.AfterFunc(delay, func() { s.fireLinks(group, arm) })
 }
@@ -2163,7 +2178,20 @@ func (s *Scheduler) scheduleGroupAlgo(group string) {
 	s.groupAlgoArmedAt[group] = armedAt
 	s.groupAlgoFireAt[group] = fireAt
 	s.groupAlgoPending[group] = true
-	s.groupAlgoTimers[group] = time.AfterFunc(delay, func() { s.fireGroupAlgo(group) })
+	s.armGroupAlgoTimerLocked(group, delay)
+}
+
+// armGroupAlgoTimerLocked arms (or re-arms) group's group-algo timer under a
+// FRESH arm id, recorded in groupAlgoArm. It is the group-algo twin of
+// armLinkTimerLocked and exists for the same reason: Timer.Stop() cannot stop a
+// timer that has already fired, so the id — which cancelGroupAlgoLocked deletes
+// — is the only thing that can reach that in-flight body.
+// MUST be called with s.mu held.
+func (s *Scheduler) armGroupAlgoTimerLocked(group string, delay time.Duration) {
+	s.armSeq++
+	arm := s.armSeq
+	s.groupAlgoArm[group] = arm
+	s.groupAlgoTimers[group] = time.AfterFunc(delay, func() { s.fireGroupAlgo(group, arm) })
 }
 
 // fireGroupAlgo is the group-algo debounce timer body, split out of
@@ -2176,7 +2204,14 @@ func (s *Scheduler) scheduleGroupAlgo(group string) {
 // gate decorative under exactly the sustained-churn conditions that produce the
 // worst peaks. The gate's own bounded starvation guard (the drain barrier, see
 // noteStageDeferLocked) is what keeps the pass from being starved forever.
-func (s *Scheduler) fireGroupAlgo(group string) {
+// arm is the identity of the timer whose body this is; see groupAlgoArm. The
+// check and the stage acquisition share ONE hold of s.mu, so a group delete is
+// strictly ordered against a fire: either the delete lands first and this
+// returns having touched nothing — in particular NOT having taken a fresh
+// indexstate.GroupAlgoBegin the delete can no longer balance — or the pass
+// already holds the token and has registered its groupAlgoCancel token, which
+// the delete then cancels.
+func (s *Scheduler) fireGroupAlgo(group string, arm uint64) {
 	if s.stopped() {
 		return // shutting down — do not re-arm a retry timer that outlives Stop
 	}
@@ -2184,6 +2219,14 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	now := time.Now()
 
 	s.mu.Lock()
+	if live, ok := s.groupAlgoArm[group]; !ok || live != arm {
+		// Cancelled (group deleted) or superseded while this timer body was in
+		// flight. Returning here is what keeps the heaviest pass in the daemon
+		// from running for a group that is gone, and what keeps the deferred
+		// branch below from re-taking an indexstate hold nobody will release.
+		s.mu.Unlock()
+		return
+	}
 	stageEpoch, acquired := s.tryAcquireStageLocked(name, now)
 	if !acquired {
 		delay := s.noteStageDeferLocked(name, now)
@@ -2196,12 +2239,13 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 			t.Stop()
 		}
 		s.groupAlgoFireAt[group] = now.Add(delay)
-		s.groupAlgoTimers[group] = time.AfterFunc(delay, func() { s.fireGroupAlgo(group) })
+		s.armGroupAlgoTimerLocked(group, delay)
 		s.mu.Unlock()
 		return
 	}
 	s.groupAlgoPending[group] = false
 	delete(s.groupAlgoTimers, group)
+	delete(s.groupAlgoArm, group)
 	delete(s.groupAlgoArmedAt, group) // window closed — next arm starts fresh
 	delete(s.groupAlgoFireAt, group)
 	// Derive the per-run cancel context from shutdownCtx (not
@@ -2229,7 +2273,9 @@ func (s *Scheduler) fireGroupAlgo(group string) {
 	// have drained the map and a successor pass registered its own handle while
 	// this (long) pass was returning; blind-deleting would drop the LIVE
 	// successor's cancel func, leaving a later CancelGroup/Stop with nothing to
-	// cancel. fireLinks has guarded the same shape since the v0.1.8 leak fix.
+	// cancel. fireLinks guards the identical shape at its own completion site —
+	// and both now also guard the ARM, one hazard earlier: a timer that fires
+	// just before the delete lands (see groupAlgoArm / linkArm).
 	if s.groupAlgoCancel[group] == tok {
 		delete(s.groupAlgoCancel, group)
 	}
@@ -2284,6 +2330,10 @@ func (s *Scheduler) cancelGroupAlgoLocked(group string) {
 		delete(s.groupAlgoTimers, group)
 		s.groupAlgoPending[group] = false
 	}
+	// Stop() above is a no-op for a timer that ALREADY fired: its fireGroupAlgo
+	// body is in flight and holds only its arm id, so dropping the id is what
+	// stops it — see groupAlgoArm.
+	delete(s.groupAlgoArm, group)
 	if tok, ok := s.groupAlgoCancel[group]; ok {
 		tok.cancel()
 		delete(s.groupAlgoCancel, group)

--- a/internal/daemon/sched/stagegate_5954_test.go
+++ b/internal/daemon/sched/stagegate_5954_test.go
@@ -499,7 +499,18 @@ func TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState(t *testing.T) {
 	s.inflight["/busy"] = 1
 	s.mu.Unlock()
 
-	s.fireGroupAlgo("acme", armedGroupAlgo(t, s, "acme"))
+	arm := armedGroupAlgo(t, s, "acme")
+	// armedGroupAlgo goes through scheduleGroupAlgo, which sets groupAlgoPending
+	// itself. Leaving that in place would PRE-SATISFY the "still pending" check
+	// below, so it would no longer bind on anything fireGroupAlgo does: deleting
+	// the deferred branch's own `groupAlgoPending[group] = true` leaves this test
+	// green. Clear it, so re-setting it is the deferred branch's job alone —
+	// which is what the assertion claims to be checking.
+	s.mu.Lock()
+	delete(s.groupAlgoPending, "acme")
+	s.mu.Unlock()
+
+	s.fireGroupAlgo("acme", arm)
 
 	snap := indexstate.Get()
 	if snap.GroupAlgoInFlight <= before {

--- a/internal/daemon/sched/stagegate_5954_test.go
+++ b/internal/daemon/sched/stagegate_5954_test.go
@@ -431,10 +431,11 @@ func TestStageGate_ReleasedOnPanic(t *testing.T) {
 		MemReleaseDisabled: true,
 	})
 
+	arm := armedGroupAlgo(t, s, "acme")
 	panicked := make(chan any, 1)
 	go func() {
 		defer func() { panicked <- recover() }()
-		s.fireGroupAlgo("acme")
+		s.fireGroupAlgo("acme", arm)
 	}()
 
 	select {
@@ -498,7 +499,7 @@ func TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState(t *testing.T) {
 	s.inflight["/busy"] = 1
 	s.mu.Unlock()
 
-	s.fireGroupAlgo("acme")
+	s.fireGroupAlgo("acme", armedGroupAlgo(t, s, "acme"))
 
 	snap := indexstate.Get()
 	if snap.GroupAlgoInFlight <= before {

--- a/internal/daemon/watch/githead_poller_test.go
+++ b/internal/daemon/watch/githead_poller_test.go
@@ -65,6 +65,39 @@ func commitFile(t *testing.T, dir, name string) {
 	run("commit", "-m", "add "+name)
 }
 
+// eventHangGuard bounds how long a test waits for an event the poller MUST
+// emit. It is deliberately far larger than any plausible detection latency
+// because it is a hang guard, not a latency budget: the assertion under test is
+// "the event is emitted", never "the event is emitted within X".
+//
+// Sizing it as a budget is what made TestGitHeadPoller_SHAChange the only red
+// on the windows-latest leg of the v0.2.0 gate (macos/ubuntu green, same
+// commit). Detecting a new commit costs one poll tick plus SIX git subprocess
+// spawns on the critical path — five in gitmeta.Capture (rev-parse
+// --show-toplevel, rev-parse --short=12, symbolic-ref, rev-parse --git-dir,
+// rev-parse --git-common-dir) and one more for classifyRefChange's git diff.
+// That is ~100ms on an idle macOS box and comfortably over a second on a loaded
+// Windows runner, where process creation is an order of magnitude dearer. Note
+// which sibling survived: TestGitHeadPoller_BranchSwitch had the same 1s wait
+// but short-circuits the git diff (oldSHA == newSHA), i.e. it was one spawn
+// away from the same red.
+const eventHangGuard = 30 * time.Second
+
+// waitForEvent polls have() until it reports true or the hang guard expires,
+// then returns either way. It deliberately does not assert: the caller's own
+// check is the one that names the missing event, so a timeout still fails the
+// test — with the message that describes the defect rather than "timed out".
+func waitForEvent(t *testing.T, have func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(eventHangGuard)
+	for time.Now().Before(deadline) {
+		if have() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 // TestGitHeadPoller_BranchSwitch verifies that switching branches emits
 // exactly one BranchSwitchEvent with the correct old/new ref.
 func TestGitHeadPoller_BranchSwitch(t *testing.T) {
@@ -88,17 +121,11 @@ func TestGitHeadPoller_BranchSwitch(t *testing.T) {
 	// Switch to a new branch.
 	switchBranch(t, repoDir, "feat/test-branch")
 
-	// Wait up to 1 second for the event to arrive.
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
+	waitForEvent(t, func() bool {
 		mu.Lock()
-		n := len(events)
-		mu.Unlock()
-		if n >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		defer mu.Unlock()
+		return len(events) >= 1
+	})
 
 	mu.Lock()
 	got := make([]BranchSwitchEvent, len(events))
@@ -165,16 +192,11 @@ func TestGitHeadPoller_SHAChange(t *testing.T) {
 	// Make a new commit on main (SHA advances, ref stays "main").
 	commitFile(t, repoDir, "new-file.txt")
 
-	deadline := time.Now().Add(time.Second)
-	for time.Now().Before(deadline) {
+	waitForEvent(t, func() bool {
 		mu.Lock()
-		n := len(events)
-		mu.Unlock()
-		if n >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		defer mu.Unlock()
+		return len(events) >= 1
+	})
 
 	mu.Lock()
 	got := make([]BranchSwitchEvent, len(events))
@@ -359,16 +381,11 @@ func TestCommonDirDedup_FanOut_BaseRepoReceivesEvent(t *testing.T) {
 	// Switch branch in the base repo (advances HEAD on the shared common-dir).
 	switchBranch(t, base, "feat/fanout-test")
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	waitForEvent(t, func() bool {
 		mu.Lock()
-		n := received[base]
-		mu.Unlock()
-		if n >= 1 {
-			break
-		}
-		time.Sleep(10 * time.Millisecond)
-	}
+		defer mu.Unlock()
+		return received[base] >= 1
+	})
 
 	mu.Lock()
 	baseEvents := received[base]
@@ -423,16 +440,11 @@ func TestCommonDirDedup_FanOut_AllWorktreesReceiveEvent(t *testing.T) {
 	// that worktree, triggering an event for worktrees[0] at minimum.
 	commitFile(t, worktrees[0], "from-wt0.go")
 
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
+	waitForEvent(t, func() bool {
 		mu.Lock()
-		n := received[worktrees[0]]
-		mu.Unlock()
-		if len(n) >= 1 {
-			break
-		}
-		time.Sleep(15 * time.Millisecond)
-	}
+		defer mu.Unlock()
+		return len(received[worktrees[0]]) >= 1
+	})
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
Windows went red on the release gate (run 30678618594) with three failures, while macOS and ubuntu were green and the immediately preceding run on `main` was green on all three. Two of the three turned out to be fixtures. **One was a genuine scheduler defect, and chasing it found a second one nobody was looking for.**

## `CancelGroup` could not cancel a link pass whose timer had already fired

`CancelGroup` cancels a pending link pass with `Timer.Stop()` — a no-op once the timer has fired. The `fireLinks` body is then in flight on the timer goroutine, holding nothing `CancelGroup` can reach. It went on to run the deleted group's link pass, or on the stage-gate-deferred path to re-arm a retry and re-register the stage deferral `CancelGroup` had just dropped, so the pass ran the moment the other group released the token.

The reproduction is exact: `cancelgroup_test.go:139` sets `StageGateRetry: 5ms`, and between the `waitFor` that observes the deferral and the `CancelGroup` call, that retry timer can fire. The window exists on every platform; Windows scheduling opens it often enough to be observed. Same class as #6001/#5954's token identity checks, one layer earlier — at the *arm*, not the run.

Every link timer is now armed through `armLinkTimerLocked` under a fresh monotonic id in `linkArm`. `fireLinks(group, arm)` re-checks its id and acquires the stage token under **one** unbroken hold of `s.mu`, so a delete is strictly ordered against a fire: either the delete lands first and the body does nothing, or the pass already holds the token and registered its `linkCancel` token, which the delete cancels. Review tried to construct a third outcome six ways — split-lock between acquire and cancel-token registration, the `stopped()`-check-then-`Stop` race, two concurrent bodies for one group, delete-then-recreate inside the window, a stage-token leak on the early-return path, `armSeq` overflow — and found none.

No work is dropped: both arm sites set `linkPending = true` before arming, so a live timer always exists when a body declines. A superseded-but-already-fired timer now stops running a duplicate pass.

## The same defect was still open on `fireGroupAlgo`, and worse there

Found in review, confirmed by an independent probe:

```
PROBE CONFIRMS DEFECT: group-algo pass ran 1 time(s) for a DELETED group
```

`cancelGroupAlgoLocked` used the same no-op `Stop()`, and `fireGroupAlgo` had no arm-id equivalent. Two consequences, both worse than the link case:

- **The work is uncancellable.** `runGroupAlgo` is the heaviest job the daemon runs — Louvain, PageRank and betweenness over the group union, in a subprocess — and its ctx is rooted only at `shutdownCtx`. An escaped pass runs to completion for a group that no longer exists. Precisely the leak `CancelGroup` exists to prevent.
- **A permanent process-global counter leak.** On the deferred branch, `cancelGroupAlgoLocked` releases the `indexstate` pair via `markGroupAlgoDeferredLocked(false)`; the already-fired body then took a fresh `GroupAlgoBegin()` that nothing balances. `grafel_stats` would report a group-algo pass in flight for the life of the daemon.

Fixed with the same mechanism. `markGroupAlgoDeferredLocked(group, true)` sits **inside** the hold and **after** the arm check, so a delete that lands first prevents the `GroupAlgoBegin` from ever being taken rather than taking it and hoping something balances it. Verified by a probe measuring the process-global counter across `defer → cancel → late-fire`, firing the stale retry arm, the original arm, and a never-allocated id (`^uint64(0)`): returns to baseline.

`linkArmSeq` became a shared `armSeq` — one monotonic source, two independent keyspaces. The comment claiming "fireLinks already guards this with a token identity check" was a false parallel the moment the link half landed; it now states what is true of both families.

## The two fixtures

**`TestRebuildSeams_ConcurrentOverrideAndRead`** failed with `reader goroutine never resolved a seam — fixture cannot exhibit the race it claims to guard`. That is #6059's own vacuity guard doing its job: the writer's 2000 iterations finished and closed `stop` before the new reader goroutine was ever scheduled. Go gives a new goroutine no scheduling guarantee on any OS; a windows-latest runner under `-race` with several binaries sharing cores loses that race far more often.

The reader now closes a `readerLive` barrier before entering its loop and the writer blocks on it, so the reader is provably running before the first write. The writer continues past 2000 while `readerIters == 0`, bounded by a 30s **hang guard** — it never decides whether the assertion holds, only whether to keep writing. The guard's sample moved to *before* `close(stop)`, so iterations the reader sneaks in during the shutdown handshake — concurrent with nothing — can no longer satisfy it. Strictly stricter than before.

**`TestGitHeadPoller_SHAChange`** was a latency budget. Detecting a new commit costs a poll tick plus **six git subprocess spawns**: five in `gitmeta.Capture` (`rev-parse --show-toplevel`, `rev-parse --short=12`, `symbolic-ref`, `rev-parse --git-dir`, `rev-parse --git-common-dir`) and one in `classifyRefChange`'s `git diff`. Measured at 91-110ms on an idle macOS box; on a runner where process creation is an order of magnitude dearer, it exceeds the fixture's 1s deadline. `TestGitHeadPoller_BranchSwitch` had the identical wait and survived only because it short-circuits the `git diff` — one spawn from the same red. No event is ever lost; it arrives late.

All four positive-event waits now use a shared `waitForEvent` with a 30s hang guard. Every assertion is byte-for-byte unchanged, and the helper deliberately never asserts, so a timeout still fails with the caller's own message rather than a generic one.

## Two regressions caught in review, both in the tests

**The new deferred test reintroduced the anti-pattern this branch removes** — a 2s `waitFor` reporting only "condition not met", plus an unbounded channel receive that yields a 10-minute package-timeout dump on a starved runner. Both replaced with 30s guards naming what they waited for.

**Modifying two pre-existing tests to fit the new signature disarmed an assertion.** `armedGroupAlgo` → `scheduleGroupAlgo` sets `groupAlgoPending[group] = true` before `fireGroupAlgo` runs, so `TestStageGate_DeferredGroupAlgoStaysVisibleToIndexState`'s check that a deferred pass "must remain PENDING (re-armed), not dropped" was pre-satisfied by the fixture. Caught by differential mutation — deleting `groupAlgoPending[group] = true` from the deferred branch failed pre-delta, **survived the whole package** mid-delta, and fails again now. Routing through the production arm path is right in general and necessary for the panic test; it just happened to pre-set the exact state this assertion checked. Fixed by clearing the key after arming, with a comment so it is not tidied away.

One more control was missing: the deferred link test's final `ranB == 0` was trivially satisfied (the retry was armed an hour out, then cancelled), so it would have passed even if `fireLinks` declined for unrelated reasons. It now re-arms with the token free and requires the run the cancel suppressed — verified discriminating.

## Verification

`go build ./... && go vet ./... && gofmt -l .` clean. `go test -race -count=5 -shuffle=on -p 2 ./internal/daemon/...` exit 0 across all 19 packages, no `DATA RACE`.

**`test.yml` with `-race` green on all three OSes, windows-latest included** — both at `480a46765` (the three original fixes) and at `dcc58ef20` (with the group-algo fix).

Mutation battery rebuilt against the final tree: arm checks disabled on both families, cancel keeping the id on both, stale arm ids, the gB-unreachable control, a seam reverted to a plain package var (`DATA RACE`), a reader that never resolves a seam (vacuity guard), and a poller blind to the ref-file mtime (`SHAChange` red, `BranchSwitch` correctly green).

## Known and disclosed

- **`fireGroupAlgo`'s completion path calls `scheduleGroupAlgo` outside `s.mu`**, after reading `rerun` under the lock. A `CancelGroup` landing in that window arms a fresh timer for a deleted group under a *live* arm id, so this mechanism structurally cannot catch it. Same shape in `runLinks`. Pre-existing, microsecond window, reachable only from a user-initiated `DeleteGroup` — the "no third outcome" claim is scoped to the fired-timer hazard. Filed separately.
- **`githead_poller_test.go:322` and `:348`** assert `StatCalls()` in `[8,18]` and `[60,140]` after fixed sleeps on a 50ms ticker. A tick-starved runner can only push these below the lower bound — predicted Windows reds, left because rewriting a rate measurement into a non-timing assertion is a design question, not a mechanical fix. Filed separately.
- **The link path has no `GroupAlgoMaxWait` analogue.** `fireGroupAlgo` has a #5450 debounce-starvation ceiling; `scheduleLinks` has none. Removing the accidental escape valve (a superseded-but-fired body running immediately) slightly widens that gap.
- The `linkArm`/`groupAlgoArm` map-invariant assertions are consistency assertions, not behavioural pins — no behavioural consequence of a stale entry could be constructed.

Independently adversarially reviewed across three rounds.
