### PR TITLE
fix(#6070): compare release identities, not decorated strings, in the install version guard

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -343,13 +343,38 @@ jobs:
           set -euo pipefail
           mkdir -p "$HOME/.claude"
           echo '{}' > "$HOME/.claude/.claude.json"
+          LOG="${RUNNER_TEMP:-/tmp}/grafel-install.log"
+          # A non-zero exit here is tolerated ONLY because headless CI has no
+          # service manager to register the daemon with. It is NOT proof that
+          # the failure was benign — the previous version of this step printed
+          # "service step warned … tolerated" unconditionally, which asserted a
+          # diagnosis it had not made. `grafel install` aborted at step 4 on all
+          # three OS legs for five consecutive runs (#6070) and this line
+          # labelled it a service warning every time, so the red was read as
+          # "acceptance is just broken" for two weeks while a shipped install
+          # failure hid behind it. Capture the real exit code and output, and
+          # let the assertions below decide.
+          set +e
           grafel install --copy \
             --skills-source-dir ./skills \
             --claude-config-dirs "$HOME/.claude/.claude.json" \
-            --force || echo "install: service step warned (no service manager in CI) — tolerated"
-          test -f "$HOME/.grafel/install.json" || { echo "FAIL: install.json not written"; exit 1; }
-          test -d "$HOME/.grafel" || { echo "FAIL: ~/.grafel not created"; exit 1; }
-          grep -q grafel "$HOME/.claude/.claude.json" || { echo "FAIL: MCP not registered in .claude.json"; exit 1; }
+            --force 2>&1 | tee "$LOG"
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::warning::grafel install exited $rc — tolerated only if the integrity assertions below pass"
+          fi
+          fail() {
+            echo "FAIL: $1"
+            echo "grafel install exit code: $rc"
+            echo "── grafel install output ──────────────────────────────────"
+            cat "$LOG"
+            echo "───────────────────────────────────────────────────────────"
+            exit 1
+          }
+          test -d "$HOME/.grafel" || fail "~/.grafel not created"
+          test -f "$HOME/.grafel/install.json" || fail "install.json not written"
+          grep -q grafel "$HOME/.claude/.claude.json" || fail "MCP not registered in .claude.json"
           echo "integrity OK: ~/.grafel + install.json + MCP config present"
 
       - name: Integrity — MCP config + install.json (windows)
@@ -367,13 +392,34 @@ jobs:
           New-Item -ItemType Directory -Force -Path $claudeDir | Out-Null
           $claudeCfg = Join-Path $claudeDir '.claude.json'
           '{}' | Set-Content -Path $claudeCfg
+          # See the unix leg for why the tolerated-failure message must not
+          # assert a diagnosis: this printed "service step warned … tolerated"
+          # while `grafel install` was in fact aborting at step 4 (#6070), which
+          # is how a shipped install failure stayed invisible for two weeks.
+          # Keep the output so a failure below is self-diagnosing.
+          $installLog = ''
+          $rc = 0
           try {
-            grafel install --copy --skills-source-dir ./skills --claude-config-dirs $claudeCfg --force
-          } catch { Write-Host "install: service step warned (no service manager in CI) — tolerated" }
+            $installLog = (grafel install --copy --skills-source-dir ./skills --claude-config-dirs $claudeCfg --force 2>&1 | Out-String)
+            $rc = $LASTEXITCODE
+          } catch {
+            $installLog = "$_"
+            $rc = 1
+          }
+          Write-Host $installLog
+          if ($rc -ne 0) { Write-Host "::warning::grafel install exited $rc — tolerated only if the integrity assertions below pass" }
+          $global:LASTEXITCODE = 0
+          function Fail-Integrity($msg) {
+            Write-Host "grafel install exit code: $rc"
+            Write-Host "── grafel install output ──────────────────────────────────"
+            Write-Host $installLog
+            Write-Host "───────────────────────────────────────────────────────────"
+            throw $msg
+          }
           $prefix = Join-Path $GrafelHome '.grafel'
-          if (-not (Test-Path (Join-Path $prefix 'install.json'))) { throw "install.json not written" }
-          if (-not (Test-Path $prefix)) { throw "~/.grafel not created" }
-          if (-not (Select-String -Path $claudeCfg -Pattern 'grafel' -Quiet)) { throw "MCP not registered in .claude.json" }
+          if (-not (Test-Path $prefix)) { Fail-Integrity "~/.grafel not created" }
+          if (-not (Test-Path (Join-Path $prefix 'install.json'))) { Fail-Integrity "install.json not written" }
+          if (-not (Select-String -Path $claudeCfg -Pattern 'grafel' -Quiet)) { Fail-Integrity "MCP not registered in .claude.json" }
           Write-Host "integrity OK: ~/.grafel + install.json + MCP config present"
 
       # ── 4. THE HEART: grafel selftest (functional acceptance ladder) ────────

--- a/internal/daemon/ping_version_6070_test.go
+++ b/internal/daemon/ping_version_6070_test.go
@@ -1,0 +1,57 @@
+package daemon
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/version"
+)
+
+// TestPing_ReportsBareReleaseAlongsideDisplayVersion is the daemon half of
+// #6070.
+//
+// `grafel install` step 4 must decide whether the daemon answering the socket
+// is the release it just installed. It used to derive that by string-matching
+// the daemon's DECORATED version descriptor against a bare tag, which can never
+// match — so the guard fired on the success path and aborted every install on
+// every platform from v0.2.0 onward.
+//
+// The fix gives the installer a structured field to compare instead of a
+// display string to parse. That only helps if the daemon actually POPULATES it,
+// which is what this test pins: declaring the field in proto and forgetting to
+// set it here would leave every daemon reporting an empty VersionBare, silently
+// dropping the installer back onto the parse fallback forever.
+func TestPing_ReportsBareReleaseAlongsideDisplayVersion(t *testing.T) {
+	var reply proto.PingReply
+	if err := (&Service{}).Ping(&proto.PingArgs{}, &reply); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+
+	if reply.VersionBare == "" {
+		t.Fatal("PingReply.VersionBare is empty — the installer's release comparison " +
+			"has nothing structured to compare and falls back to parsing the display string")
+	}
+	if reply.VersionBare != version.Version {
+		t.Errorf("VersionBare = %q, want the bare release identifier version.Version = %q",
+			reply.VersionBare, version.Version)
+	}
+
+	// The display field must keep its decoration — the two fields exist because
+	// they differ. If they ever became identical, the structured field would be
+	// pointless and callers comparing the display string would silently start
+	// "working", re-hiding the defect.
+	if reply.Version != version.String() {
+		t.Errorf("Version = %q, want the decorated descriptor version.String() = %q",
+			reply.Version, version.String())
+	}
+	if reply.Version == reply.VersionBare {
+		t.Errorf("Version and VersionBare are both %q; the display field is supposed to "+
+			"carry commit/build decoration that the bare field does not", reply.Version)
+	}
+	if !strings.HasPrefix(reply.Version, reply.VersionBare) {
+		t.Errorf("Version %q does not start with VersionBare %q — install's parse "+
+			"fallback for pre-v0.2.1 daemons extracts the leading token and would break",
+			reply.Version, reply.VersionBare)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -18,7 +18,23 @@ type PingArgs struct{}
 
 // PingReply carries the daemon's self-reported version.
 type PingReply struct {
+	// Version is the HUMAN-READABLE build descriptor — internal/version.String(),
+	// e.g. "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)". Display only.
 	Version string `json:"version"`
+
+	// VersionBare is the STRUCTURED release identifier — internal/version.Version,
+	// e.g. "v0.2.0" — with no commit or build-date decoration. Added in #6070:
+	// `grafel install` step 4 compares the running daemon's release against the
+	// installed release, and doing that by string-matching the decorated Version
+	// field aborted every install on every platform for two weeks. Consumers
+	// MUST compare on this field, never on Version.
+	//
+	// Per this package's compatibility contract, daemons built before #6070
+	// (v0.2.0 and earlier) simply omit it, so an empty value means "this daemon
+	// predates the field" — NOT "no version". Callers must degrade gracefully;
+	// see install.verifyDaemonVersion, which falls back to parsing the leading
+	// token out of Version.
+	VersionBare string `json:"version_bare,omitempty"`
 }
 
 // StatusArgs requests a snapshot of daemon state.

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -349,6 +349,11 @@ func (s *Service) waitDrain(timeout time.Duration) bool {
 // "daemon not running" from "daemon running but unhealthy".
 func (s *Service) Ping(_ *proto.PingArgs, reply *proto.PingReply) error {
 	reply.Version = version.String()
+	// #6070: also report the BARE release identifier. `grafel install` step 4
+	// needs to know which RELEASE is serving the socket, and deriving that by
+	// string-matching the decorated Version above is what aborted every install
+	// on every platform between v0.2.0 and this fix.
+	reply.VersionBare = version.Version
 	return nil
 }
 

--- a/internal/dashboard/handlers_updates.go
+++ b/internal/dashboard/handlers_updates.go
@@ -16,6 +16,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -114,25 +115,83 @@ func (s *Server) handleUpdatesCheck(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, reply)
 }
 
-// isNewerVersion is a best-effort semver comparison: returns true when
-// latestStr is lexicographically greater than currentStr, ignoring pre-release
-// suffixes. Handles the common case where current="0.0.0-dev".
+// isNewerVersion is a best-effort semver comparison: returns true when latest
+// names a strictly newer release than current, ignoring pre-release suffixes.
+// Handles the common case where current="0.0.0-dev".
+//
+// #6070 (same defect class as the install version guard, one function away):
+// this used to compare the two strings BYTE-WISE, and its callers hand it two
+// differently-shaped strings — handleUpdatesCheck passes a v-STRIPPED GitHub
+// tag ("0.2.1") against a raw, v-PREFIXED version.Version ("v0.2.0"). Because
+// '0' (0x30) sorts before 'v' (0x76), `"0.2.1" > "v0.2.0"` is false, so the
+// dashboard's update banner never appeared on ANY release build — the only
+// builds that can be updated. Byte-wise comparison also got double-digit
+// components backwards ("0.10.0" > "0.9.0" is false). Both are fixed by
+// normalising the 'v' and comparing numerically, component by component.
 func isNewerVersion(latest, current string) bool {
 	if latest == "" || current == "" {
 		return false
 	}
 	// In dev builds the current version is 0.0.0-dev; any real release is newer.
 	if strings.HasSuffix(current, "-dev") {
-		return latest != ""
+		return true
 	}
-	// Strip pre-release suffix for comparison.
-	stripPre := func(v string) string {
-		if idx := strings.IndexByte(v, '-'); idx >= 0 {
-			return v[:idx]
+	return compareReleases(releaseComponents(latest), releaseComponents(current)) > 0
+}
+
+// releaseComponents reduces a version string to its numeric dotted components,
+// tolerating a leading 'v' and discarding any pre-release / build suffix.
+//
+//	"v0.2.1"                → [0 2 1]
+//	"0.10.0"                → [0 10 0]
+//	"v0.1.9-82-gf2fb8c315"  → [0 1 9]
+//
+// Non-numeric components stop the parse: a version we cannot read numerically
+// yields a short (or empty) component list, which compareReleases treats as
+// "not newer" rather than guessing.
+func releaseComponents(v string) []int {
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	v = strings.TrimPrefix(v, "V")
+	// Drop pre-release / build metadata.
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	var out []int
+	for _, part := range strings.Split(v, ".") {
+		n, err := strconv.Atoi(part)
+		if err != nil {
+			break
 		}
-		return v
+		out = append(out, n)
 	}
-	return stripPre(latest) > stripPre(current)
+	return out
+}
+
+// compareReleases returns >0 when a is newer than b, <0 when older, 0 when the
+// two name the same release. Missing trailing components read as zero, so
+// "1.2" and "1.2.0" compare equal.
+func compareReleases(a, b []int) int {
+	n := len(a)
+	if len(b) > n {
+		n = len(b)
+	}
+	for i := 0; i < n; i++ {
+		var av, bv int
+		if i < len(a) {
+			av = a[i]
+		}
+		if i < len(b) {
+			bv = b[i]
+		}
+		if av != bv {
+			if av > bv {
+				return 1
+			}
+			return -1
+		}
+	}
+	return 0
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/dashboard/handlers_updates_version_6070_test.go
+++ b/internal/dashboard/handlers_updates_version_6070_test.go
@@ -1,0 +1,79 @@
+package dashboard
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/version"
+)
+
+// ── #6070, one function away ────────────────────────────────────────────────
+//
+// The install bug was a comparison fed two DIFFERENTLY-SHAPED version strings
+// while its tests only ever fed it matching shapes. handleUpdatesCheck has the
+// same defect:
+//
+//	reply.LatestVersion = strings.TrimPrefix(rel.TagName, "v")   // "0.2.1"
+//	reply.UpdateAvailable = isNewerVersion(reply.LatestVersion, version.Version)
+//	                                                             // "v0.2.0"
+//
+// One side is v-stripped, the other is not. `"0.2.1" > "v0.2.0"` is FALSE in a
+// byte-wise comparison ('0' = 0x30 < 'v' = 0x76), so the dashboard's update
+// banner never appears on any release build — the only builds that can be
+// updated. Every case in TestIsNewerVersion passes bare-vs-bare, which is why
+// it stayed green.
+
+// TestIsNewerVersion_RealCallSiteShapes drives isNewerVersion with exactly what
+// handleUpdatesCheck passes it: a v-STRIPPED GitHub tag against the raw,
+// possibly v-PREFIXED version.Version.
+func TestIsNewerVersion_RealCallSiteShapes(t *testing.T) {
+	// Mirrors handlers_updates.go: TrimPrefix on the tag, version.Version raw.
+	callSite := func(githubTag, currentVersion string) bool {
+		latest := trimV(githubTag)
+		return isNewerVersion(latest, currentVersion)
+	}
+
+	tests := []struct {
+		githubTag, current string
+		want               bool
+		why                string
+	}{
+		{"v0.2.1", "v0.2.0", true, "release build one patch behind must see the update"},
+		{"v0.3.0", "v0.2.0", true, "release build one minor behind must see the update"},
+		{"v1.0.0", "v0.2.0", true, "release build one major behind must see the update"},
+		{"v0.2.0", "v0.2.0", false, "same release must not offer an update"},
+		{"v0.2.0", "v0.2.1", false, "a newer local build must not be told to downgrade"},
+		// The Makefile build: version.Version = `git describe --tags --dirty`.
+		{"v0.2.1", "v0.1.9-82-gf2fb8c315", true, "a make build past v0.1.9 is behind v0.2.1"},
+		// Double-digit minors are coming and byte-wise comparison gets them
+		// backwards: "0.10.0" > "0.9.0" is false lexicographically.
+		{"v0.10.0", "v0.9.0", true, "0.10.0 is newer than 0.9.0 — numeric, not lexicographic"},
+		{"v0.9.0", "v0.10.0", false, "0.9.0 is older than 0.10.0"},
+		{"v1.2.10", "v1.2.9", true, "double-digit patch"},
+	}
+	for _, tc := range tests {
+		if got := callSite(tc.githubTag, tc.current); got != tc.want {
+			t.Errorf("update check (github tag %q, current %q) = %v, want %v — %s",
+				tc.githubTag, tc.current, got, tc.want, tc.why)
+		}
+	}
+}
+
+// TestIsNewerVersion_AgainstLiveVersionPackage uses the real version.Version of
+// this build rather than a literal, so the test cannot drift from whatever
+// shape the build system actually bakes in.
+func TestIsNewerVersion_AgainstLiveVersionPackage(t *testing.T) {
+	// This binary is built without ldflags injection, so version.Version is the
+	// "0.0.0-dev" sentinel and every release counts as newer.
+	if !isNewerVersion("99.0.0", version.Version) {
+		t.Errorf("a far-future release must be newer than this build's version.Version = %q",
+			version.Version)
+	}
+}
+
+// trimV mirrors the v-stripping handleUpdatesCheck applies to the GitHub tag.
+func trimV(tag string) string {
+	if len(tag) > 0 && (tag[0] == 'v' || tag[0] == 'V') {
+		return tag[1:]
+	}
+	return tag
+}

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -113,15 +113,37 @@ func defaultHealthzGet(port int) (string, error) {
 	return string(body), nil
 }
 
+// maxPlausibleVersionLen bounds a plausible daemon version string.
+//
+// #6070 (second half): this was 64, which is SHORTER than the version string a
+// Makefile-built daemon actually reports. `make build` bakes
+// version.Version = `git describe --tags --always --dirty`, so version.String()
+// renders e.g.
+//
+//	"v0.1.9-82-gf2fb8c315 (commit f2fb8c315, built 2026-08-01T11:08:38Z)"  → 67
+//	"v0.1.9-82-gf2fb8c315-dirty (commit f2fb8c315, built …)"               → 73
+//
+// Both were rejected as "implausible", so the version probe errored out BEFORE
+// any comparison happened — meaning fixing versionsEquivalent alone would still
+// have left `grafel install` broken for every developer running a locally-built
+// daemon. Measured against real builds, not estimated.
+//
+// 200 keeps the guard's actual job intact: it exists to stop an HTML document
+// (the /healthz SPA-fallback of #5596) from being printed as a version, and
+// that job is done by the newline / angle-bracket / doctype checks below, which
+// no real HTML page escapes. The length bound is only a coarse backstop.
+const maxPlausibleVersionLen = 200
+
 // looksLikeVersion reports whether s is a plausible daemon version string
-// (short, single-line, not an HTML/JSON document). It is the last line of
+// (single-line, bounded, not an HTML/JSON document). It is the last line of
 // defense against the /healthz SPA-fallback bug: even if a future /healthz
 // response slips past the content-type check, we never let a multi-line HTML
 // blob become the printed "daemon" version. A real version looks like
-// "0.1.5.2", "v0.1.5", "1.2.3-socket", or "dev".
+// "0.1.5.2", "v0.1.5", "1.2.3-socket", "dev", or the full decorated descriptor
+// "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)".
 func looksLikeVersion(s string) bool {
 	s = strings.TrimSpace(s)
-	if s == "" || len(s) > 64 {
+	if s == "" || len(s) > maxPlausibleVersionLen {
 		return false
 	}
 	if strings.ContainsAny(s, "\n\r<>") {
@@ -164,12 +186,31 @@ func defaultDaemonRestart(binPath string, port int, timeout time.Duration) (stri
 // the daemon could not be restarted or did not become healthy in time.
 type DaemonRestartFunc func(binPath string, healthzPort int, timeout time.Duration) (version string, err error)
 
+// ProbedVersion is what the running daemon reported about its own build.
+//
+// The two fields exist because they are NOT interchangeable, and conflating
+// them is what broke `grafel install` on every platform for two weeks (#6070):
+//
+//   - Display is the human-readable descriptor — version.String(), e.g.
+//     "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)". It is what we
+//     record in install.json and print. It is NEVER compared directly.
+//   - Bare is the structured release identifier — version.Version, e.g.
+//     "v0.2.0" — carried in proto.PingReply.VersionBare. It is the comparison
+//     basis. It is EMPTY when the daemon answering the probe predates that
+//     field (any build up to and including v0.2.0), which is precisely the
+//     stale-daemon population this probe exists to detect — so the comparison
+//     must degrade to parsing Display rather than assume Bare is present.
+type ProbedVersion struct {
+	Display string
+	Bare    string
+}
+
 // DaemonVersionProbeFunc queries the CURRENTLY RUNNING daemon's version via a
 // reliable source (the RPC socket, not the HTML-shadowable dashboard route)
 // so step 4 can detect a daemon that stayed bound to the socket through a
 // restart that fast-pathed to a no-op (#5850). Injectable so tests never dial
 // a real socket.
-type DaemonVersionProbeFunc func() (version string, err error)
+type DaemonVersionProbeFunc func() (ProbedVersion, error)
 
 // defaultDaemonVersionProbe is the production version-probe: dial the RPC
 // socket directly (the same liveness/version channel `grafel status` uses,
@@ -178,19 +219,27 @@ type DaemonVersionProbeFunc func() (version string, err error)
 // looksLikeVersion). The result is guarded by looksLikeVersion so an
 // implausible response is reported as an error ("version unknown") rather
 // than silently treated as a match.
-func defaultDaemonVersionProbe() (string, error) {
+func defaultDaemonVersionProbe() (ProbedVersion, error) {
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
-		return "", fmt.Errorf("resolve daemon layout: %w", err)
+		return ProbedVersion{}, fmt.Errorf("resolve daemon layout: %w", err)
 	}
-	v, err := defaultSocketPing(layout.SocketPath)
+	c, err := dclient.DialPath(layout.SocketPath)
 	if err != nil {
-		return "", err
+		return ProbedVersion{}, err
 	}
-	if !looksLikeVersion(v) {
-		return "", fmt.Errorf("daemon reported an implausible version %q", v)
+	defer func() { _ = c.Close() }()
+	reply, err := c.Ping()
+	if err != nil {
+		return ProbedVersion{}, err
 	}
-	return strings.TrimSpace(v), nil
+	display := strings.TrimSpace(reply.Version)
+	if !looksLikeVersion(display) {
+		return ProbedVersion{}, fmt.Errorf("daemon reported an implausible version %q", reply.Version)
+	}
+	// VersionBare is absent on daemons up to v0.2.0; an empty Bare is expected
+	// and handled by the caller, not an error.
+	return ProbedVersion{Display: display, Bare: strings.TrimSpace(reply.VersionBare)}, nil
 }
 
 // defaultDaemonEscalateRestart is the production HARD-restart used when the
@@ -221,7 +270,8 @@ func defaultDaemonEscalateRestart(binPath string, port int, timeout time.Duratio
 // value) on mismatch. An empty installed value skips the comparison (treated
 // as "nothing to verify against").
 func verifyDaemonVersion(installed string, probe DaemonVersionProbeFunc) (string, error) {
-	running, err := probe()
+	probed, err := probe()
+	running := probed.Display
 	if err == nil && !looksLikeVersion(running) {
 		err = fmt.Errorf("implausible version %q", running)
 	}
@@ -229,23 +279,86 @@ func verifyDaemonVersion(installed string, probe DaemonVersionProbeFunc) (string
 		return "", fmt.Errorf("could not verify running daemon version (installed %q): %w", installed, err)
 	}
 	running = strings.TrimSpace(running)
-	// Defensive normalization: compare with any single leading 'v' stripped so
-	// a v-prefixed release tag ("v0.1.9") and a bare version ("0.1.9") — or the
-	// reverse — are treated as the same release. In practice the release build
-	// bakes version.Version = ${GITHUB_REF_NAME} (v-prefixed) and update.go
-	// threads the v-prefixed tag through, so they already match exactly; this
-	// just guards against either side drifting on the 'v'. We still RETURN the
-	// running string verbatim so the recorded/printed version is unmodified.
-	if installed != "" && !versionsEquivalent(running, installed) {
-		return "", fmt.Errorf("daemon is running stale version %q, installed version is %q", running, installed)
+	if installed == "" {
+		return running, nil
 	}
+
+	// #6070: compare RELEASE IDENTITIES, never the raw strings.
+	//
+	// The two sides of this comparison have different shapes and always did:
+	// the daemon reports version.String() — "v0.2.0 (commit f2fb8c3, built
+	// 2026-07-25T…)" — while `installed` is the bare tag "v0.2.0". The previous
+	// implementation compared them for equality after stripping one leading
+	// 'v', which can never succeed, so the guard fired on the SUCCESS path and
+	// rolled back every install on every platform from v0.2.0 onward. The old
+	// comment here asserted the two "already match exactly"; that assumption was
+	// the bug, and it was never checked against a real daemon.
+	runningID, basis := probedReleaseIdentity(probed)
+	installedID := releaseIdentity(installed)
+	if runningID != installedID {
+		// Name the normalised identities and the comparison basis alongside the
+		// raw strings. When this fires in CI the reader must be able to tell at
+		// a glance whether the RELEASES actually differ or the COMPARISON is
+		// wrong again — not being able to tell those apart is why acceptance.yml
+		// sat red for five consecutive runs and was written off as "acceptance
+		// is just broken".
+		return "", fmt.Errorf(
+			"daemon is running stale version %q (release %q, %s), installed version is %q (release %q)",
+			running, runningID, basis, installed, installedID)
+	}
+	// The comparison is normalised; the RECORD is not. Return the running
+	// string verbatim so the printed/persisted version keeps its decoration.
 	return running, nil
 }
 
-// versionsEquivalent reports whether two version strings name the same release,
-// tolerating a single leading 'v' on either side.
+// probedReleaseIdentity reduces a probe result to the token used for the
+// release comparison, and names where that token came from.
+//
+// The daemon's STRUCTURED field is authoritative when present: it is the
+// release identifier verbatim, immune to any future change in how
+// version.String() formats its display output. Re-deriving the release by
+// parsing a display string is precisely the fragility that produced #6070, so
+// it is the fallback, not the mechanism.
+//
+// The fallback is nonetheless mandatory, not defensive padding: proto.PingReply
+// gained VersionBare in this fix, so every daemon up to and including v0.2.0
+// omits it — and a stale pre-v0.2.1 daemon still bound to the socket is exactly
+// the case this guard exists to catch (#5850). Comparing on the structured
+// field alone would leave the guard with nothing to compare in its most
+// important scenario.
+func probedReleaseIdentity(p ProbedVersion) (id, basis string) {
+	if bare := strings.TrimSpace(p.Bare); bare != "" {
+		return releaseIdentity(bare), "from the daemon's structured version field"
+	}
+	return releaseIdentity(p.Display),
+		"parsed from the daemon's display string — it reports no structured version field, so it predates v0.2.1"
+}
+
+// releaseIdentity reduces a version string to the token that names its release.
+//
+// It accepts either shape this codebase produces:
+//
+//	bare       version.Version  →  "v0.2.0"
+//	decorated  version.String() →  "v0.2.0 (commit f2fb8c3, built 2026-07-25T…)"
+//
+// by taking everything up to the first space/tab/paren, then stripping a single
+// leading 'v' so a v-prefixed release tag and a bare version name the same
+// release. It deliberately does NOT understand semver ordering — this is an
+// identity check ("is the daemon serving the release we just installed?"), not
+// a precedence check, and a fuzzy match here would silently admit a stale
+// daemon, which is worse than the bug it replaces.
+func releaseIdentity(s string) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexAny(s, " \t("); i >= 0 {
+		s = s[:i]
+	}
+	return strings.TrimPrefix(strings.TrimSpace(s), "v")
+}
+
+// versionsEquivalent reports whether two version strings name the same release.
+// Either side may be bare or decorated, and either may carry a leading 'v'.
 func versionsEquivalent(a, b string) bool {
-	return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
+	return releaseIdentity(a) == releaseIdentity(b)
 }
 
 // CopyOptions is the input to RunCopy. All fields have sensible defaults;

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -483,8 +483,10 @@ func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 		// Step 4 now re-verifies the running daemon's version against the
 		// installed version (#5850); stub both so this test keeps exercising
 		// only the skills-fallback behavior it was written for.
-		ProbeDaemonVersion: func() (string, error) { return "test-daemon-v0", nil },
-		InstalledVersion:   "test-daemon-v0",
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
+			return install.ProbedVersion{Display: "test-daemon-v0", Bare: "test-daemon-v0"}, nil
+		},
+		InstalledVersion: "test-daemon-v0",
 	}
 
 	result, err := install.RunCopy(opts)
@@ -530,6 +532,17 @@ func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 	}
 }
 
+// decorated renders a bare release tag the way a real daemon reports it over
+// the RPC socket — version.String()'s "<version> (commit <sha>, built <date>)".
+//
+// #6070: every fixture below used to pass the BARE tag on both sides of the
+// step-4 version check, so the whole suite stayed green while `grafel install`
+// aborted on all three platforms for two weeks. The daemon never sends a bare
+// string; it sends this. Keep the format in sync with internal/version.String.
+func decorated(tag string) string {
+	return tag + " (commit f2fb8c3, built 2026-07-25T12:00:00Z)"
+}
+
 // ── step 4: post-restart version verification (#5850) ──────────────────────
 //
 // `grafel install`/`update` previously restarted the daemon and gated success
@@ -556,16 +569,18 @@ func TestRunCopy_DaemonVersionMatch_NoEscalation(t *testing.T) {
 		StatePath:         env.statePath,
 		WorkingDir:        env.gitRepo,
 		SkipDaemonRestart: false,
-		InstalledVersion:  "1.2.3",
+		InstalledVersion:  "v1.2.3",
 		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
-			return "1.2.3", nil
+			return decorated("v1.2.3"), nil
 		},
-		ProbeDaemonVersion: func() (string, error) {
-			return "1.2.3", nil
+		// #6070: a real daemon answers Ping with the DECORATED version.String()
+		// plus the structured bare field — not the bare tag the installer holds.
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
+			return install.ProbedVersion{Display: decorated("v1.2.3"), Bare: "v1.2.3"}, nil
 		},
 		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
 			escalateCalled = true
-			return "1.2.3", nil
+			return decorated("v1.2.3"), nil
 		},
 	}
 
@@ -573,8 +588,9 @@ func TestRunCopy_DaemonVersionMatch_NoEscalation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunCopy: %v", err)
 	}
-	if result.DaemonVersion != "1.2.3" {
-		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "1.2.3")
+	if result.DaemonVersion != decorated("v1.2.3") {
+		t.Errorf("DaemonVersion = %q, want the verbatim display string %q",
+			result.DaemonVersion, decorated("v1.2.3"))
 	}
 	if escalateCalled {
 		t.Error("escalation must NOT run when the post-restart probe already matches the installed version")
@@ -598,23 +614,27 @@ func TestRunCopy_DaemonVersionMismatch_EscalatesThenSucceeds(t *testing.T) {
 		StatePath:         env.statePath,
 		WorkingDir:        env.gitRepo,
 		SkipDaemonRestart: false,
-		InstalledVersion:  "2.0.0",
+		InstalledVersion:  "v2.0.0",
 		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
 			// The (idempotent) restart succeeds but the daemon answering is
 			// still the stale one — RestartDaemon has no way to know that on
 			// its own, which is exactly the #5850 gap.
-			return "0.9.0", nil
+			return decorated("v0.9.0"), nil
 		},
-		ProbeDaemonVersion: func() (string, error) {
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
 			probeCalls++
 			if probeCalls == 1 {
-				return "0.9.0", nil // stale daemon still on the socket
+				// A genuinely stale daemon predates PingReply.VersionBare, so
+				// it reports NO structured field — the comparison must fall
+				// back to parsing the decorated display string and still catch
+				// it (#6070).
+				return install.ProbedVersion{Display: decorated("v0.9.0")}, nil
 			}
-			return "2.0.0", nil // post-escalation: fresh daemon
+			return install.ProbedVersion{Display: decorated("v2.0.0"), Bare: "v2.0.0"}, nil
 		},
 		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
 			escalateCalled = true
-			return "2.0.0", nil
+			return decorated("v2.0.0"), nil
 		},
 	}
 
@@ -628,8 +648,8 @@ func TestRunCopy_DaemonVersionMismatch_EscalatesThenSucceeds(t *testing.T) {
 	if probeCalls < 2 {
 		t.Errorf("expected the probe to be called again after escalation, got %d calls", probeCalls)
 	}
-	if result.DaemonVersion != "2.0.0" {
-		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "2.0.0")
+	if result.DaemonVersion != decorated("v2.0.0") {
+		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, decorated("v2.0.0"))
 	}
 }
 
@@ -648,17 +668,18 @@ func TestRunCopy_DaemonStillStaleAfterEscalation_ReturnsError(t *testing.T) {
 		StatePath:         env.statePath,
 		WorkingDir:        env.gitRepo,
 		SkipDaemonRestart: false,
-		InstalledVersion:  "3.5.0",
+		InstalledVersion:  "v3.5.0",
 		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
-			return "3.4.0", nil
+			return decorated("v3.4.0"), nil
 		},
-		ProbeDaemonVersion: func() (string, error) {
-			// Always reports the stale version, even after escalation.
-			return "3.4.0", nil
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
+			// Always reports the stale version, even after escalation — and it
+			// reports it the way a real daemon does, decorated (#6070).
+			return install.ProbedVersion{Display: decorated("v3.4.0"), Bare: "v3.4.0"}, nil
 		},
 		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
 			escalateCalled = true
-			return "3.4.0", nil
+			return decorated("v3.4.0"), nil
 		},
 	}
 
@@ -710,20 +731,21 @@ func TestRunCopy_DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation(t *t
 		StatePath:         env.statePath,
 		WorkingDir:        env.gitRepo,
 		SkipDaemonRestart: false,
-		InstalledVersion:  "4.1.0",
+		InstalledVersion:  "v4.1.0",
 		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
-			return "4.1.0", nil
+			return decorated("v4.1.0"), nil
 		},
-		ProbeDaemonVersion: func() (string, error) {
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
 			probeCalls++
 			if probeCalls == 1 {
-				return htmlBody, nil // SPA-fallback garbage, must count as "unknown"
+				// SPA-fallback garbage, must count as "unknown".
+				return install.ProbedVersion{Display: htmlBody}, nil
 			}
-			return "4.1.0", nil
+			return install.ProbedVersion{Display: decorated("v4.1.0"), Bare: "v4.1.0"}, nil
 		},
 		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
 			escalateCalled = true
-			return "4.1.0", nil
+			return decorated("v4.1.0"), nil
 		},
 	}
 
@@ -734,8 +756,8 @@ func TestRunCopy_DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation(t *t
 	if !escalateCalled {
 		t.Error("expected an HTML/garbage version probe to be treated as unknown and trigger escalation")
 	}
-	if result.DaemonVersion != "4.1.0" {
-		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, "4.1.0")
+	if result.DaemonVersion != decorated("v4.1.0") {
+		t.Errorf("DaemonVersion = %q, want %q", result.DaemonVersion, decorated("v4.1.0"))
 	}
 }
 

--- a/internal/install/readiness_test.go
+++ b/internal/install/readiness_test.go
@@ -89,10 +89,16 @@ func TestLooksLikeVersion(t *testing.T) {
 		{"", false},
 		{"<!doctype html><html></html>", false},
 		{"<html><body>hi</body></html>", false},
-		{"line1\nline2", false},          // multi-line
-		{strings.Repeat("a", 65), false}, // too long
-		{"{\"version\":\"1.0\"}", true},  // short JSON is tolerated (no angle brackets / newline)
-		{"<svg>", false},                 // angle brackets
+		{"line1\nline2", false}, // multi-line
+		// #6070: the cap was 64, which rejected the 67-char version string a
+		// Makefile-built daemon really reports (`git describe` + commit + date)
+		// — the probe failed as "implausible" before any comparison ran. These
+		// two are measured from real builds, not invented.
+		{"v0.1.9-82-gf2fb8c315 (commit f2fb8c315, built 2026-08-01T11:08:38Z)", true},
+		{"v0.1.9-82-gf2fb8c315-dirty (commit f2fb8c315, built 2026-08-01T11:08:38Z)", true},
+		{strings.Repeat("a", maxPlausibleVersionLen+1), false}, // too long
+		{"{\"version\":\"1.0\"}", true},                        // short JSON is tolerated (no angle brackets / newline)
+		{"<svg>", false},                                       // angle brackets
 		// #5850: exact SPA-fallback body a shadowed version-probe channel could
 		// return; must be rejected so a stale-daemon check never treats this as
 		// a version match.

--- a/internal/install/update_test.go
+++ b/internal/install/update_test.go
@@ -227,8 +227,15 @@ func TestRunUpdate_VerifiesAgainstTargetTag_NotRunningVersion(t *testing.T) {
 		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
 			return tag, nil
 		},
-		ProbeDaemonVersion: func() (string, error) {
-			return tag, nil
+		// A real daemon reports the DECORATED string plus the structured bare
+		// release field (#6070); mirror both here rather than echoing a bare
+		// tag, so this test cannot pass against a comparison that only works
+		// for bare-vs-bare.
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
+			return install.ProbedVersion{
+				Display: tag + " (commit f2fb8c3, built 2026-07-25T12:00:00Z)",
+				Bare:    tag,
+			}, nil
 		},
 		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
 			escalateCalled = true
@@ -248,9 +255,12 @@ func TestRunUpdate_VerifiesAgainstTargetTag_NotRunningVersion(t *testing.T) {
 	if result.InstallResult == nil {
 		t.Fatal("InstallResult is nil after a successful update")
 	}
-	if result.InstallResult.DaemonVersion != tag {
-		t.Errorf("recorded daemon version = %q, want the target tag %q",
-			result.InstallResult.DaemonVersion, tag)
+	// The RECORDED version stays the daemon's verbatim display string — only
+	// the COMPARISON is normalised to a release identity (#6070).
+	const wantRecorded = tag + " (commit f2fb8c3, built 2026-07-25T12:00:00Z)"
+	if result.InstallResult.DaemonVersion != wantRecorded {
+		t.Errorf("recorded daemon version = %q, want the daemon's verbatim display string %q",
+			result.InstallResult.DaemonVersion, wantRecorded)
 	}
 
 	// The binary must be the new one (i.e. no rollback happened).

--- a/internal/install/version_guard_6070_test.go
+++ b/internal/install/version_guard_6070_test.go
@@ -1,0 +1,276 @@
+package install
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/version"
+)
+
+// ── #6070: the step-4 version guard compared a DECORATED string to a BARE tag ─
+//
+// `grafel install` aborted at step 4 on every platform from 2026-07-17 onward
+// (v0.2.0 shipped with it) because verifyDaemonVersion compared:
+//
+//	running   = version.String() = "v0.2.0 (commit f2fb8c3, built 2026-07-25T…)"
+//	installed = version.Version  = "v0.2.0"
+//
+// with an exact equality after stripping a single leading 'v'. Those can never
+// be equal, so the guard fired on the SUCCESS path and rolled the install back
+// — leaving the MCP server unregistered.
+//
+// Every fixture in this file derives its "running" value from the REAL
+// version.String() / version.Version pair (or from the exact shapes the
+// release, acceptance and Makefile builds produce) rather than hand-typed bare
+// versions. A fixture that feeds two bare strings to the comparison passes
+// while the product stays broken — the failure mode this repo has hit
+// repeatedly. See TestReleaseIdentity_RejectsNaiveTrimPrefix for the guard
+// that the fixture itself can actually fail.
+
+// realProbeShapes returns the (display, bare) pairs a real daemon reports,
+// for every build configuration grafel actually ships or builds.
+func realProbeShapes() []struct {
+	name    string
+	display string
+	bare    string
+} {
+	return []struct {
+		name    string
+		display string
+		bare    string
+	}{
+		{
+			// THE fixture: the live version package as compiled into this test
+			// binary. It cannot drift from the product's real format because it
+			// IS the product's format function.
+			name:    "live version package",
+			display: version.String(),
+			bare:    version.Version,
+		},
+		{
+			// release.yml: -X version.Version=${GITHUB_REF_NAME} (v-prefixed
+			// tag) + Commit=${SHORT_SHA} + Date=${BUILD_DATE}. Measured, not
+			// guessed: this is the exact string quoted in issue #6070.
+			name:    "release build (v0.2.0)",
+			display: "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)",
+			bare:    "v0.2.0",
+		},
+		{
+			// acceptance.yml builds with -ldflags "-s -w" only, so no version
+			// is injected and String() falls back to debug.ReadBuildInfo.
+			name:    "acceptance build (no ldflags injection)",
+			display: "0.0.0-dev (commit f2fb8c315403, built 2026-08-01T11:08:38Z)",
+			bare:    "0.0.0-dev",
+		},
+		{
+			// Makefile: version.Version = `git describe --tags --always --dirty`.
+			// 67 characters — longer than the old 64-char looksLikeVersion cap.
+			name:    "make build (git describe)",
+			display: "v0.1.9-82-gf2fb8c315 (commit f2fb8c315, built 2026-08-01T11:08:38Z)",
+			bare:    "v0.1.9-82-gf2fb8c315",
+		},
+		{
+			// A dirty working tree pushes it to 73 characters.
+			name:    "make build (dirty tree)",
+			display: "v0.1.9-82-gf2fb8c315-dirty (commit f2fb8c315, built 2026-08-01T11:08:38Z)",
+			bare:    "v0.1.9-82-gf2fb8c315-dirty",
+		},
+	}
+}
+
+// TestVersionString_IsActuallyDecorated is the premise check. If version.String()
+// ever stopped decorating the bare version, the whole class of tests below would
+// pass vacuously — so assert the premise explicitly.
+func TestVersionString_IsActuallyDecorated(t *testing.T) {
+	display := version.String()
+	bare := version.Version
+	if display == bare {
+		t.Fatalf("premise broken: version.String() == version.Version == %q; "+
+			"the #6070 fixtures below would no longer exercise the decorated shape", display)
+	}
+	if !strings.HasPrefix(display, bare) {
+		t.Fatalf("version.String() = %q does not start with version.Version = %q; "+
+			"releaseIdentity's leading-token parse assumes it does", display, bare)
+	}
+	t.Logf("real shapes in this build: display=%q bare=%q", display, bare)
+}
+
+// TestReleaseIdentity_RejectsNaiveTrimPrefix is the fixture's own proof of
+// failure: it asserts that the PRE-FIX comparison (a bare TrimPrefix equality,
+// reproduced verbatim here) is WRONG for every real shape. If someone reverts
+// releaseIdentity to the old one-line TrimPrefix, this test's premise — that
+// the naive comparison disagrees — still holds, and the tests below go red.
+func TestReleaseIdentity_RejectsNaiveTrimPrefix(t *testing.T) {
+	// The exact pre-fix implementation from copy.go:247.
+	preFix := func(a, b string) bool {
+		return strings.TrimPrefix(a, "v") == strings.TrimPrefix(b, "v")
+	}
+	for _, c := range realProbeShapes() {
+		if preFix(c.display, c.bare) {
+			t.Errorf("%s: the pre-fix comparison unexpectedly matched %q vs %q — "+
+				"this fixture is not exercising the decorated shape and would pass "+
+				"against the broken code", c.name, c.display, c.bare)
+		}
+	}
+}
+
+// TestVersionsEquivalent_DecoratedVsBare is the direct unit repro of #6070.
+func TestVersionsEquivalent_DecoratedVsBare(t *testing.T) {
+	for _, c := range realProbeShapes() {
+		if !versionsEquivalent(c.display, c.bare) {
+			t.Errorf("%s: versionsEquivalent(%q, %q) = false, want true — "+
+				"the decorated daemon string names the same release as the bare tag",
+				c.name, c.display, c.bare)
+		}
+		// Symmetric, and reflexive on the bare form.
+		if !versionsEquivalent(c.bare, c.display) {
+			t.Errorf("%s: versionsEquivalent is not symmetric for %q / %q", c.name, c.bare, c.display)
+		}
+	}
+}
+
+// TestVersionsEquivalent_GenuineMismatchStillDetected is the counterweight: a
+// fix that makes the guard always pass is WORSE than the bug, because it lets a
+// genuinely stale daemon through silently. An actually-different release must
+// still compare unequal, including when the stale daemon reports a decorated
+// string (which is what a real stale daemon does).
+func TestVersionsEquivalent_GenuineMismatchStillDetected(t *testing.T) {
+	cases := []struct{ running, installed, why string }{
+		{"v0.1.9 (commit aaaaaaa, built 2026-07-01T00:00:00Z)", "v0.2.0",
+			"stale daemon one minor behind, decorated"},
+		{"v0.2.0 (commit aaaaaaa, built 2026-07-01T00:00:00Z)", "v0.2.1",
+			"stale daemon one patch behind, decorated"},
+		{"0.0.0-dev (commit aaaaaaa, built 2026-07-01T00:00:00Z)", "v0.2.0",
+			"a dev daemon must NOT be accepted as a release install"},
+		{"v0.1.9-82-gf2fb8c315 (commit f2fb8c315, built 2026-08-01T11:08:38Z)", "v0.1.9",
+			"a make build 82 commits past the tag is not the tag"},
+		{"v0.2.0 (commit aaaaaaa, built 2026-07-01T00:00:00Z)", "v0.20.0",
+			"prefix-only similarity must not match"},
+		{"v0.2.0 (commit aaaaaaa, built 2026-07-01T00:00:00Z)",
+			"v0.2.0-rc1", "a release candidate is a different release"},
+	}
+	for _, c := range cases {
+		if versionsEquivalent(c.running, c.installed) {
+			t.Errorf("versionsEquivalent(%q, %q) = true, want false (%s)", c.running, c.installed, c.why)
+		}
+	}
+}
+
+// TestVerifyDaemonVersion_RealDecoratedString_Succeeds exercises the guard the
+// way step 4 calls it, with the probe reporting exactly what a real daemon
+// reports: the decorated display string plus the structured bare field.
+func TestVerifyDaemonVersion_RealDecoratedString_Succeeds(t *testing.T) {
+	for _, c := range realProbeShapes() {
+		got, err := verifyDaemonVersion(c.bare, func() (ProbedVersion, error) {
+			return ProbedVersion{Display: c.display, Bare: c.bare}, nil
+		})
+		if err != nil {
+			t.Errorf("%s: verifyDaemonVersion(installed=%q) failed against a real daemon "+
+				"reporting %q: %v", c.name, c.bare, c.display, err)
+			continue
+		}
+		// The recorded/printed version must stay the verbatim display string —
+		// the comparison is normalised, the RECORD is not.
+		if got != strings.TrimSpace(c.display) {
+			t.Errorf("%s: verifyDaemonVersion returned %q, want the verbatim display string %q",
+				c.name, got, c.display)
+		}
+	}
+}
+
+// TestVerifyDaemonVersion_NoStructuredField_FallsBackToParse covers the daemon
+// that predates PingReply.VersionBare (anything <= v0.2.0). That is not an edge
+// case: it is EXACTLY the population the guard exists to catch, because a
+// pre-v0.2.1 binary left bound to the socket is the stale daemon of #5850. The
+// structured field cannot be relied on alone, so the parse fallback must work.
+func TestVerifyDaemonVersion_NoStructuredField_FallsBackToParse(t *testing.T) {
+	const display = "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)"
+
+	// Same release, no structured field → must succeed via the parse fallback.
+	if _, err := verifyDaemonVersion("v0.2.0", func() (ProbedVersion, error) {
+		return ProbedVersion{Display: display}, nil
+	}); err != nil {
+		t.Errorf("old daemon (no version_bare) reporting %q vs installed v0.2.0: %v", display, err)
+	}
+
+	// Genuinely stale, no structured field → must still be caught.
+	_, err := verifyDaemonVersion("v0.2.1", func() (ProbedVersion, error) {
+		return ProbedVersion{Display: display}, nil
+	})
+	if err == nil {
+		t.Fatal("a genuinely stale old daemon (no version_bare) must still be detected")
+	}
+	if !strings.Contains(err.Error(), "0.2.0") || !strings.Contains(err.Error(), "0.2.1") {
+		t.Errorf("error must name both releases, got: %v", err)
+	}
+}
+
+// TestVerifyDaemonVersion_StructuredFieldWins asserts the structured field is
+// the PRIMARY comparison basis, not a tiebreaker. If the daemon says its bare
+// release is X, that is authoritative even when the display string is
+// unparseable — parsing a display string is what broke this in the first place.
+func TestVerifyDaemonVersion_StructuredFieldWins(t *testing.T) {
+	// Display deliberately does NOT lead with the release token.
+	const weird = "grafel daemon build v0.2.0 (commit f2fb8c3)"
+
+	if _, err := verifyDaemonVersion("v0.2.0", func() (ProbedVersion, error) {
+		return ProbedVersion{Display: weird, Bare: "v0.2.0"}, nil
+	}); err != nil {
+		t.Errorf("structured bare field should be authoritative over the display string: %v", err)
+	}
+	// And it must be authoritative in the REJECTING direction too — a daemon
+	// whose display string happens to lead with the right token but whose
+	// structured field says otherwise is stale.
+	if _, err := verifyDaemonVersion("v0.2.0", func() (ProbedVersion, error) {
+		return ProbedVersion{Display: "v0.2.0 (commit f2fb8c3)", Bare: "v0.1.9"}, nil
+	}); err == nil {
+		t.Error("structured bare field disagreeing with installed must be reported as stale")
+	}
+}
+
+// TestVerifyDaemonVersion_ErrorNamesBothReleases is the acceptance-legibility
+// requirement. acceptance.yml was red for five consecutive runs across three OS
+// legs and was read as "acceptance is just broken", partly because the error
+//
+//	daemon is running stale version "v0.2.0 (commit …)", installed version is "v0.2.0"
+//
+// looks like a bug in the daemon rather than a bug in the comparison. The
+// message must state the compared RELEASE IDENTITIES and where they came from,
+// so a reader can see at a glance whether the releases actually differ.
+func TestVerifyDaemonVersion_ErrorNamesBothReleases(t *testing.T) {
+	_, err := verifyDaemonVersion("v0.2.1", func() (ProbedVersion, error) {
+		return ProbedVersion{
+			Display: "v0.2.0 (commit f2fb8c3, built 2026-07-25T12:00:00Z)",
+			Bare:    "v0.2.0",
+		}, nil
+	})
+	if err == nil {
+		t.Fatal("expected a stale-version error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"v0.2.0 (commit f2fb8c3", // the verbatim running display string
+		"v0.2.1",                 // the installed version
+		"release",                // labels the normalised identities
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("stale-version error must contain %q for the failure to be legible; got: %s", want, msg)
+		}
+	}
+}
+
+// TestLooksLikeVersion_AcceptsRealDecoratedStrings guards the OTHER half of the
+// defect class. looksLikeVersion capped plausible versions at 64 characters,
+// but a Makefile-built daemon reports 67 (73 on a dirty tree). That build's
+// probe result was rejected as "implausible" BEFORE any comparison happened —
+// so fixing versionsEquivalent alone would leave `grafel install` broken for
+// anyone running a locally-built daemon.
+func TestLooksLikeVersion_AcceptsRealDecoratedStrings(t *testing.T) {
+	for _, c := range realProbeShapes() {
+		if !looksLikeVersion(c.display) {
+			t.Errorf("%s: looksLikeVersion(%q) = false (len %d); a real daemon's version "+
+				"string must never be rejected as implausible",
+				c.name, c.display, len(c.display))
+		}
+	}
+}


### PR DESCRIPTION
`grafel install` has aborted at step 4 on all three platforms since 2026-07-17, and **v0.2.0 shipped with it**. Because the install aborts, the MCP server is never registered in `.claude.json` — so a user who installs grafel gets no working MCP integration, which is the product's primary interface.

```
✗ install (copy mode) failed: step 4 – daemon restart:
  daemon is running stale version "v0.2.0 (commit f2fb8c3, built <timestamp>)",
  installed version is "v0.2.0"
FAIL: MCP not registered in .claude.json
```

## Two independent breaks stacked on the same path

The issue describes one. Measuring found a second.

**1. The comparison.** `copy.go` compared the daemon's **decorated** version string against the **bare** installed tag with `strings.TrimPrefix(a,"v") == strings.TrimPrefix(b,"v")`. They can never be equal, so the guard fired on every *successful* install. The comment asserting they "already match exactly" was the bug.

**2. The plausibility cap.** `looksLikeVersion` capped a plausible version at 64 characters. Measured against every ldflags configuration this repo actually uses:

| build | display string | len |
|---|---|---|
| release.yml | `v0.2.0 (commit f2fb8c3, built …)` | 51 |
| acceptance.yml (`-s -w`, no injection) | `0.0.0-dev (commit …, built …)` | 59 |
| Makefile (`git describe --tags --always --dirty`) | `v0.1.9-82-gf2fb8c315 (commit …)` | **67** |
| Makefile, dirty tree | `…-dirty (commit …)` | **73** |

A Makefile-built daemon's probe was rejected as *implausible before any comparison ran*. Fixing the comparison alone would still have left `grafel install` broken for every developer running a locally-built daemon. Cap raised to 200; the guard's real work is the newline/angle-bracket/doctype checks, and an independent review confirmed the actual SPA HTML fails at every prefix length 1..400.

## Fix shape

`proto.PingReply` gains `VersionBare`; the probe returns `ProbedVersion{Display, Bare}` so the two shapes cannot be conflated again. The parse fallback is **load-bearing, not defensive padding**: every daemon up to v0.2.0 omits the new field, and a stale pre-v0.2.1 daemon bound to the socket is precisely the #5850 case this guard exists to catch. Comparing on the structured field alone would leave the guard with nothing to compare in its most important scenario.

**Kept fatal.** It fires only after a forced unload→load restart has already failed to replace the daemon; at that point the MCP server registered in step 3 points at a binary whose daemon isn't running the installed code. The defect was never that the guard was fatal — it was that it fired on a match. The message now names the normalised identities so a future failure shows at a glance whether the releases actually differ.

## The gate, as an A/B

`acceptance.yml` dispatched on `main` — **red on all three legs**, as it has been for five consecutive runs since 17 July. Dispatched on this branch — **green on all three**. Same workflow, same commit range.

That two-week red is the real lesson here: an unexplained red that nobody triages becomes a red everyone learns to ignore, and it hid a shipped install failure. Commit 3 addresses the mechanism — both legs ran `grafel install … || echo "install: service step warned … tolerated"`, printed unconditionally on *any* non-zero exit. The workflow was asserting a diagnosis it had not made. Non-zero is still tolerated, but the step now captures the real exit code, emits a neutral `::warning::`, and replays the full install output next to whichever integrity assertion fails.

## The same defect class one function away (commit 2)

`internal/dashboard/handlers_updates.go` compared a **v-stripped** GitHub tag against a raw **v-prefixed** `version.Version` byte-wise. `"0.2.1" > "v0.2.0"` is false because `'0'` (0x30) < `'v'` (0x76) — so **the update banner has never appeared on any release build**, the only builds that can be updated. Every existing case in `TestIsNewerVersion` was bare-vs-bare: the identical fixture failure mode.

Kept in this hotfix deliberately. A permanently-dead update banner means users cannot discover v0.2.0.1 in the first place, which halves the value of shipping it. Fixed with a v-normalised numeric component compare, which also fixes `0.10.0` vs `0.9.0` and handles the four-component `0.2.0.1` being tagged here.

## Verification

Fixtures derive from the live `version` package, not hand-typed literals. `TestVersionString_IsActuallyDecorated` pins the premise so the fixture cannot silently stop exercising the bug.

Independent adversarial review reproduced the pre-fix RED itself (**10 tests failing behaviourally, zero build errors**), constructed its own stale-daemon suite rather than reading the author's, and ran an 8×8 false-accept sweep across 112 mismatched version pairs with **zero false accepts** — including a stale daemon with no structured field, `v0.2.0.10` vs `v0.2.0.1` prefix similarity, and a bare field disagreeing with a fresh-looking display.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean; full suites green for `internal/install`, `internal/daemon`, `internal/dashboard`, `internal/version`, `internal/cli`.

Mutation battery re-run independently: 9 of 10 caught. One survivor — the `v`-strip in `releaseIdentity` is unpinned by any test — is defence-in-depth with no production reachability (both sides are v-prefixed in every real path) and is recorded as a follow-up rather than fixed here.

## Follow-ups, filed not fixed

- `internal/install/doctor.go:398` — `checkDaemon` compares `/healthz` output with no content-type or `looksLikeVersion` guard, on a route that has no handler and falls through to the SPA catch-all. **Newly activated by this fix**: rollback previously meant `install.json` had no `DaemonVersion`, so line 397's guard kept it dormant. Once installs succeed, `grafel doctor` will report `daemon version mismatch: running=<!doctype html>…`. Warning severity — degrades output, fails nothing.
- `versionsEquivalent` is now production-dead; either delete it or route the guard through it.

Closes #6070
