### PR TITLE
fix(#6073): inject the clock into save-result dispatch instead of masking the timestamp

### DIFF
--- a/internal/mcp/analysis_merges_test.go
+++ b/internal/mcp/analysis_merges_test.go
@@ -2,12 +2,14 @@ package mcp
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/links"
 	"github.com/cajasmota/grafel/internal/registry"
@@ -146,61 +148,122 @@ func TestAnalysisFindingsDispatch(t *testing.T) {
 	assertSameDispatch(t, "action=list", srv.handleAnalysisFindings,
 		map[string]any{"group": "g", "action": "list"}, srv.handleListFindings, g)
 	assertSameDispatch(t, "action=default", srv.handleAnalysisFindings, g, srv.handleListFindings, g)
-	// save: handleSaveResult requires question + answer. The result is
-	// {"path": "<memDir>/<ts>-<hash>.json"}; the <ts> segment is wall-clock and
-	// two independent saves can straddle a second boundary (flaky on slow CI),
-	// so we compare the saved path with its volatile timestamp normalized away
-	// rather than pinning identical filenames.
+	// save: handleSaveResult requires question + answer, and returns
+	// {"path": "<memDir>/<ts>-<hash>.json"} where <ts> is second-resolution.
+	//
+	// #6073: rather than normalising <ts> away (which leaves the field checked
+	// in NEITHER direction — it passes whether or not the two handlers agree,
+	// and fails when they do), we pin the clock so BOTH dispatch paths observe
+	// the same instant. The comparison is then exact and total: a genuine
+	// divergence in how either handler stamps the timestamp now fails the test,
+	// which the normalising version could not detect at all.
+	setFixedNowForTest(t, time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC))
 	save := map[string]any{"group": "g", "question": "q", "answer": "a"}
 	assertSameSaveDispatch(t, "action=save", srv.handleAnalysisFindings,
 		map[string]any{"group": "g", "action": "save", "question": "q", "answer": "a"},
 		srv.handleSaveResult, save)
 }
 
-// savedPathTimestamp matches the leading "<YYYYMMDDThhmmssZ>-" of a saved
-// findings filename (see handleSaveResult). The timestamp is wall-clock and
-// therefore non-deterministic between two independent saves; the trailing hash
-// segment is deterministic (sha256 of question+answer).
-var savedPathTimestamp = regexp.MustCompile(`/\d{8}T\d{6}Z-`)
-
-// normalizeSaveResult rewrites the volatile timestamp in a {"path": ...} save
-// result to a fixed sentinel so two genuinely-equivalent saves compare equal,
-// while still asserting that a path was returned and that the deterministic
-// (memDir + hash) portion matches. Non-object/error results pass through.
-func normalizeSaveResult(t *testing.T, s string) string {
-	t.Helper()
-	var obj map[string]json.RawMessage
-	if err := json.Unmarshal([]byte(s), &obj); err != nil {
-		return s // not a JSON object (error/text result) — compare verbatim
-	}
-	raw, ok := obj["path"]
-	if !ok {
-		t.Errorf("save result missing path key: %s", s)
-		return s
-	}
-	var path string
-	if err := json.Unmarshal(raw, &path); err != nil {
-		t.Errorf("save result path not a string: %s", raw)
-		return s
-	}
-	path = savedPathTimestamp.ReplaceAllString(path, "/<ts>-")
-	obj["path"], _ = json.Marshal(path)
-	out, _ := json.Marshal(obj)
-	return string(out)
-}
-
 // assertSameSaveDispatch is assertSameDispatch specialized for the findings
-// save path: it verifies the canonical dispatcher routes to handleSaveResult
-// with the same args, comparing the structural result with the non-deterministic
-// timestamp in the saved filename normalized away (see normalizeSaveResult).
+// save path. It compares the returned {"path": ...} payload BYTE-FOR-BYTE (no
+// normalisation — the clock is pinned by the caller, see #6073) and, because
+// the save handler's real output is a file on disk rather than the returned
+// payload, additionally compares the bytes each call actually wrote. Both
+// calls resolve to the same filename under a pinned clock, so the written
+// content is read back after each call, before the next one overwrites it.
 func assertSameSaveDispatch(t *testing.T, label string,
 	canonical func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), canonArgs map[string]any,
 	old func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), oldArgs map[string]any) {
 	t.Helper()
-	got := normalizeSaveResult(t, callBare(t, canonical, canonArgs))
-	want := normalizeSaveResult(t, callBare(t, old, oldArgs))
+	got, gotBody := callSaveAndReadBack(t, canonical, canonArgs)
+	want, wantBody := callSaveAndReadBack(t, old, oldArgs)
 	if got != want {
 		t.Errorf("%s: canonical dispatch differs from absorbed handler\n got=%s\nwant=%s", label, got, want)
+	}
+	if gotBody != wantBody {
+		t.Errorf("%s: canonical dispatch wrote different file content than absorbed handler\n got=%s\nwant=%s",
+			label, gotBody, wantBody)
+	}
+}
+
+// callSaveAndReadBack invokes a save handler and returns both its JSON result
+// and the bytes it wrote at the reported path.
+func callSaveAndReadBack(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error),
+	args map[string]any) (result, body string) {
+	t.Helper()
+	result = callBare(t, fn, args)
+	var obj struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(result), &obj); err != nil || obj.Path == "" {
+		t.Fatalf("save result is not {\"path\": ...}: %s (err=%v)", result, err)
+	}
+	buf, err := os.ReadFile(obj.Path)
+	if err != nil {
+		t.Fatalf("reading back saved finding %s: %v", obj.Path, err)
+	}
+	return result, string(buf)
+}
+
+// TestSaveResultUsesInjectedClock pins the clock and asserts the saved
+// filename and the saved_at payload field are BOTH derived from it, in the
+// documented formats. This is the coverage the previous normalise-it-away
+// fixture removed: without it, nothing checks that the timestamp segment is
+// well-formed or that it corresponds to the instant the save happened.
+func TestSaveResultUsesInjectedClock(t *testing.T) {
+	srv := coreTestServer(t)
+	at := time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC)
+	setFixedNowForTest(t, at)
+
+	out := callBare(t, srv.handleSaveResult, map[string]any{"group": "g", "question": "q", "answer": "a"})
+	var obj struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal([]byte(out), &obj); err != nil {
+		t.Fatalf("save result not JSON: %v (%s)", err, out)
+	}
+	// sha256("qa")[:8] — the deterministic content-hash segment.
+	sum := sha256.Sum256([]byte("qa"))
+	wantBase := "20310304T050607Z-" + hex.EncodeToString(sum[:])[:8] + ".json"
+	if base := filepath.Base(obj.Path); base != wantBase {
+		t.Errorf("saved filename = %q, want %q (timestamp must come from the injected clock)", base, wantBase)
+	}
+	buf, err := os.ReadFile(obj.Path)
+	if err != nil {
+		t.Fatalf("read saved finding: %v", err)
+	}
+	var payload struct {
+		SavedAt string `json:"saved_at"`
+	}
+	if err := json.Unmarshal(buf, &payload); err != nil {
+		t.Fatalf("saved finding not JSON: %v (%s)", err, buf)
+	}
+	if want := at.Format(time.RFC3339); payload.SavedAt != want {
+		t.Errorf("saved_at = %q, want %q", payload.SavedAt, want)
+	}
+}
+
+// TestSaveResultDispatchIsClockIndependent is the direct regression guard for
+// #6073. It drives the two dispatch calls so they are GUARANTEED to straddle a
+// wall-clock second boundary — the exact condition that reddened
+// windows-latest under -race — and asserts the results are still identical.
+// Before the clock seam this failed 100% of the time on every OS; the previous
+// normalise-the-timestamp fallback masked it on POSIX only, because its regex
+// was anchored on "/" and is a no-op on a Windows path separator.
+func TestSaveResultDispatchIsClockIndependent(t *testing.T) {
+	srv := coreTestServer(t)
+	setFixedNowForTest(t, time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC))
+	save := map[string]any{"group": "g", "question": "q", "answer": "a"}
+
+	got := callBare(t, srv.handleAnalysisFindings,
+		map[string]any{"group": "g", "action": "save", "question": "q", "answer": "a"})
+	// Sleep past the next real second boundary: the injected clock must make
+	// the crossing invisible to the handlers.
+	time.Sleep(time.Until(time.Now().Truncate(time.Second).Add(time.Second + 5*time.Millisecond)))
+	want := callBare(t, srv.handleSaveResult, save)
+
+	if got != want {
+		t.Errorf("save dispatch differs across a real second boundary — the handlers are still reading the wall clock\n got=%s\nwant=%s", got, want)
 	}
 }
 

--- a/internal/mcp/clock.go
+++ b/internal/mcp/clock.go
@@ -1,0 +1,51 @@
+package mcp
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// nowFunc is the clock a handler reads when it needs the current instant.
+type nowFunc func() time.Time
+
+// nowOverride holds the TEST-ONLY clock seam. nil (the zero value) means "use
+// the real clock"; production never stores anything here.
+//
+// #6073: handlers that stamp a wall-clock value into their result cannot be
+// asserted byte-for-byte against each other, because two sequential calls can
+// straddle a second boundary (the format used by handleSaveResult's filename is
+// second-resolution). Injecting a clock lets a test pin both calls to the SAME
+// instant, which makes the dispatch comparison exact and total instead of
+// normalising the field away — a normalised field is checked in neither
+// direction.
+//
+// #6056/#6059: this MUST stay an atomic. MCP tool handlers run on live,
+// concurrent request goroutines, so a test's t.Cleanup restore would race any
+// in-flight handler reading a plain package var. atomic.Pointer removes the
+// unsynchronised access form entirely, so the protection cannot be silently
+// dropped by a caller that forgets to quiesce the server first. See
+// internal/daemon/supervise.go (engineChildCommandOverride) and
+// internal/dashboard/graphstate.go (backgroundAlgoGate) for the same shape.
+var nowOverride atomic.Pointer[nowFunc]
+
+// serverNow resolves the effective clock: the injected test clock when one is
+// installed, else the real wall clock. Always UTC, so callers can format
+// directly without re-normalising the location.
+func serverNow() time.Time {
+	if fn := nowOverride.Load(); fn != nil {
+		return (*fn)().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// setNowOverride installs (fn != nil) or clears (fn == nil) the clock seam.
+// TEST-ONLY; never called from production. Tests should prefer the
+// t.Cleanup-scoped wrapper setFixedNowForTest (clock_test.go).
+func setNowOverride(fn func() time.Time) {
+	if fn == nil {
+		nowOverride.Store(nil)
+		return
+	}
+	f := nowFunc(fn)
+	nowOverride.Store(&f)
+}

--- a/internal/mcp/clock_test.go
+++ b/internal/mcp/clock_test.go
@@ -1,0 +1,49 @@
+package mcp
+
+import (
+	"testing"
+	"time"
+)
+
+// setFixedNowForTest pins serverNow() to a single instant for the duration of
+// t, restoring the real clock on cleanup. Every serverNow() call then observes
+// exactly the same time, which is what turns a byte-for-byte comparison of two
+// timestamp-bearing payloads into a real assertion rather than a race with the
+// wall clock (#6073).
+func setFixedNowForTest(t testing.TB, at time.Time) {
+	t.Helper()
+	setNowOverride(func() time.Time { return at })
+	t.Cleanup(func() { setNowOverride(nil) })
+}
+
+// TestServerNowDefaultsToRealClock guards the production path: with no override
+// installed, serverNow must track the wall clock and report UTC.
+func TestServerNowDefaultsToRealClock(t *testing.T) {
+	before := time.Now().UTC()
+	got := serverNow()
+	after := time.Now().UTC()
+	if got.Before(before) || got.After(after) {
+		t.Fatalf("serverNow()=%v outside [%v,%v] with no override installed", got, before, after)
+	}
+	if got.Location() != time.UTC {
+		t.Fatalf("serverNow() location = %v, want UTC", got.Location())
+	}
+}
+
+// TestSetFixedNowForTestPinsAndRestores checks the seam both installs and, via
+// t.Cleanup, restores — a leaked override would silently freeze the clock for
+// every subsequent test in the package.
+func TestSetFixedNowForTestPinsAndRestores(t *testing.T) {
+	pinned := time.Date(2031, 3, 4, 5, 6, 7, 0, time.UTC)
+	t.Run("pinned", func(t *testing.T) {
+		setFixedNowForTest(t, pinned)
+		for i := 0; i < 3; i++ {
+			if got := serverNow(); !got.Equal(pinned) {
+				t.Fatalf("serverNow() = %v, want pinned %v", got, pinned)
+			}
+		}
+	})
+	if got := serverNow(); got.Equal(pinned) {
+		t.Fatalf("clock override leaked past the subtest: serverNow() = %v", got)
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -2831,7 +2831,13 @@ func (s *Server) handleSaveResult(ctx context.Context, req mcpapi.CallToolReques
 	if err := os.MkdirAll(memDir, 0o755); err != nil {
 		return mcpapi.NewToolResultError(err.Error()), nil
 	}
-	ts := time.Now().UTC().Format("20060102T150405Z")
+	// #6073: both the filename stamp and saved_at read the injectable clock
+	// (serverNow) rather than time.Now directly, so a test can pin them to a
+	// fixed instant and compare two saves byte-for-byte. now is resolved ONCE:
+	// the filename and the payload must describe the same instant even if the
+	// call straddles a second boundary.
+	now := serverNow()
+	ts := now.Format("20060102T150405Z")
 	sum := sha256.Sum256([]byte(question + answer))
 	short := hex.EncodeToString(sum[:])[:8]
 	path := filepath.Join(memDir, fmt.Sprintf("%s-%s.json", ts, short))
@@ -2841,7 +2847,7 @@ func (s *Server) handleSaveResult(ctx context.Context, req mcpapi.CallToolReques
 		"type":        argString(req, "type", "note"),
 		"nodes":       argStringSlice(req, "nodes"),
 		"repo_filter": argStringSlice(req, "repo_filter"),
-		"saved_at":    time.Now().UTC().Format(time.RFC3339),
+		"saved_at":    now.Format(time.RFC3339),
 	}
 	data, _ := json.MarshalIndent(payload, "", "  ")
 	if err := os.WriteFile(path, data, 0o644); err != nil {


### PR DESCRIPTION
`TestAnalysisFindingsDispatch` reds on `windows-latest` under `-race` while macOS and Ubuntu stay green. It blocked the v0.2.0.1 release gate twice.

```
--- FAIL: TestAnalysisFindingsDispatch (0.79s)
    analysis_merges_test.go:155: action=save: canonical dispatch differs from absorbed handler
     got={"path":"...\g-memory\20260801T152124Z-3f3ef786.json"}
    want={"path":"...\g-memory\20260801T152125Z-3f3ef786.json"}
```

The content hash `3f3ef786` is identical on both sides. The two handlers agree about everything the test exists to check. Only the clock disagrees.

## Why only Windows — the greens were masked, not passing

`main` already carried a fix for this defect class: a `normalizeSaveResult` that blanked the timestamp before comparing. Its regex is anchored on a forward slash:

```go
savedPathTimestamp = regexp.MustCompile(`/\d{8}T\d{6}Z-`)
```

Applied to a Windows path (`...\g-memory\20260801T152124Z-...`) it matches nothing. The normalisation is a **no-op on Windows**, so Windows was the only platform where the `path` field was ever asserted at all. The POSIX legs were not passing because they were faster; they were passing because a mask hid the assertion that Windows never got.

Scope that narrowly, though — an independent sweep of every `regexp.MustCompile` in `internal/mcp` found this was a **one-off, not a pattern**, and `memDir` plus the hash segment were still compared on POSIX. The POSIX greens were vacuous with respect to the save timestamp, not vacuous in general.

## Fix: inject the clock rather than strip the field

Widening the regex would have been the wrong repair — it keeps the field unchecked on every platform, which is what let this sit. The timestamp component of the old assertion provided **no coverage in either direction**: when the clock cooperated it passed whether or not the handlers agreed, and when it did not it failed even though they did.

`internal/mcp/clock.go` adds `serverNow()` behind an `atomic.Pointer` override. Atomic per the established shape in `internal/daemon/supervise.go` and `internal/dashboard/graphstate.go` — MCP handlers run on live concurrent request goroutines, so a plain package var written by a test's `t.Cleanup` is exactly the #6056/#6059 race. `internal/mcp` had no existing seam to reuse.

The dispatch assertion now compares **byte-for-byte with no normalisation**, and additionally reads back and compares the file each call wrote.

## A real product defect, fixed in passing

`handleSaveResult` made **two independent `time.Now()` calls** — one for the filename stamp, one for `saved_at` — separated by a sha256, a `filepath.Join` and a map literal. Straddling a second boundary produced a file named `...T050607Z-<hash>.json` containing `"saved_at": "...T05:06:08Z"`. Sub-microsecond window and cosmetic (nothing parses the stamp back), but real. Both are now derived from one resolved instant, and `TestSaveResultUsesInjectedClock` asserts they equal the same pinned time — coverage that did not previously exist.

## Verification

Deterministic pre-fix RED, 5/5: the reproduction computes its sleep from the current sub-second offset, so the boundary is crossed on every run regardless of scheduler jitter.

Mutation battery, re-run independently by the reviewer with the divergence injected as a call-parity counter inside `handleSaveResult`:

| Mutation | Result |
|---|---|
| revert to two `time.Now()` calls | RED 3/3 on both new guards |
| divergent **path**, identical content | RED 3/3 |
| divergent **content**, identical path | RED 3/3 — a divergence the pre-fix test could not detect on any platform |

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. Full `internal/mcp` at `-count=1`: ok, exit 0. Affected tests at `-race`: 0 races.

The review corrected one claim in the original writeup: `TestAnalysisFindingsDispatch` alone does **not** stay green when the clock fix is reverted — it reds 1 in 10. The byte-for-byte assertion does catch a clock regression, just probabilistically; `TestSaveResultDispatchIsClockIndependent` is what makes it deterministic. No residual blind spot.

## Siblings

`TestWorkflowDocgenDispatch` was suspected of the same latent shape. Verified by instrumentation rather than inference: both promote calls return an identical deterministic `run_id not found`, execution returns at `docgen.go:648` and never reaches the rotate branch that would emit `previous_path`. **Not a latent Windows red.**

Recorded as follow-ups, not fixed here: `stripVolatileFields` strips `"ts"` from dispatch comparisons for two telemetry handlers; `metrics_test.go` and `persona_telemetry_test.go` build an expected filename from `time.Now()` at day resolution and will flake once per day across UTC midnight on every platform; `docgen.go:717` remains the last un-seamed wall-clock read feeding a compared field.

Closes #6073
