### PR TITLE
fix(#6068,#6069): snapshot cancel generations at every deferred arm; measure the poll rate in observed ticks

### DIFF
--- a/internal/daemon/sched/cancelgroup_indexrearm_6068_test.go
+++ b/internal/daemon/sched/cancelgroup_indexrearm_6068_test.go
@@ -192,17 +192,94 @@ func TestRunIndex_ChainedLinksCancelInGap_DoesNotArm(t *testing.T) {
 	}
 }
 
-// TestRunIndex_GroupJoiningDuringIndexStillArms is the third over-suppression
-// guard, and the one a plausible wrong implementation trips: a group that was
-// NOT a member when the index started has no captured generation, so the arm
-// must treat it as a fresh trigger. Defaulting the missing entry to 0 instead
-// (the zero value) looks harmless and is not — for any group name that had ever
-// been cancelled, groupCancelSeq is non-zero, 0 never matches, and the first
-// link pass of that newly-added repo/group pair is dropped silently and forever.
+// TestRunIndex_GroupJoiningThenCancelledDuringIndex_DoesNotArm closes the
+// absent-group branch, which is the same #6068 hazard reached through the
+// permissive default rather than through a captured generation.
+//
+// A snapshot keyed on the groups the repo belonged to at the authorising hold
+// has nothing to say about a group that joined AFTERWARDS — and "nothing to
+// say" was being read as "arm unconditionally":
+//
+//  1. Repo R is in gA only. runIndex(R) dequeues; the pre-hold membership read
+//     returns ["gA"], so only gA's generation is captured.
+//  2. R is added to gB — live, never cancelled.
+//  3. gB is deleted. CancelGroup bumps its generation 0→1. Registry teardown
+//     starts but has not finished.
+//  4. The index completes and the terminal membership read returns
+//     ["gA","gB"] — the very window DeleteGroup's cancel-before-teardown
+//     ordering opens, and the same reachability argument that motivates the
+//     guard in the first place.
+//  5. gB is absent from the capture, so a permissive default arms a LIVE link
+//     timer for it, and the whole chain runs for a deleted group.
+//
+// The fix is to snapshot the GENERATIONS (all of groupCancelSeq) rather than
+// the MEMBERSHIP: an absent name then means "generation 0 as of the hold", a
+// real claim that a later CancelGroup contradicts, instead of an exemption.
+func TestRunIndex_GroupJoiningThenCancelledDuringIndex_DoesNotArm(t *testing.T) {
+	var s *Scheduler
+	joined := &atomic.Bool{}
+	deleted := &atomic.Bool{}
+	s, _, algoRan := indexRearmScheduler(nil, nil)
+	s.cfg.GroupsForRepo = func(_ string) []string {
+		if joined.Load() {
+			return []string{"gA", "gB"}
+		}
+		return []string{"gA"}
+	}
+	s.cfg.Index = func(_ context.Context, _ string, _ string) error {
+		// gB joins AFTER the pre-hold membership read, so it is absent from the
+		// capture...
+		joined.Store(true)
+		// ...and is then deleted, still during the index.
+		s.CancelGroup("gB")
+		deleted.Store(true)
+		return nil
+	}
+	s.Start()
+	defer s.Stop()
+
+	s.runIndex(jobToken{repoPath: "/repo-a", ref: "main", commit: "c0"})
+
+	if !joined.Load() || !deleted.Load() {
+		t.Fatalf("the index body did not complete the join-then-delete sequence (joined=%v deleted=%v) — the fixture never opened the window and every assertion below is vacuous", joined.Load(), deleted.Load())
+	}
+	// The terminal membership read must actually still name gB, or the test is
+	// passing for the wrong reason (nothing to arm rather than an arm refused).
+	if got := s.cfg.GroupsForRepo("/repo-a"); len(got) != 2 {
+		t.Fatalf("the terminal membership read returned %v — the fixture must still name the deleted group, which is the whole cancel-before-teardown window", got)
+	}
+
+	if timer, arm, pending := linkArmed(s, "gB"); timer || arm || pending {
+		t.Fatalf("a group that joined AFTER the capture and was then deleted still armed a live link timer (timer=%v arm=%v pending=%v) — absent from the capture must mean 'generation 0 as of the hold', not 'exempt from the guard'", timer, arm, pending)
+	}
+	// Over-suppression guard: gA was captured, never cancelled, same loop.
+	if timer, arm, pending := linkArmed(s, "gA"); !timer || !arm || !pending {
+		t.Fatalf("the live captured group gA was suppressed (timer=%v arm=%v pending=%v)", timer, arm, pending)
+	}
+	if n := algoRan.Load(); n != 0 {
+		t.Fatalf("no group-algo pass should have run, ran %d", n)
+	}
+}
+
+// TestRunIndex_GroupJoiningDuringIndexStillArms is the over-suppression
+// counterweight to the test above, and the reason the snapshot must cover
+// groupCancelSeq WHOLESALE rather than just this repo's current membership.
+//
+// A group re-registered under a previously-cancelled name joins mid-index. Its
+// generation is non-zero (an earlier delete moved it), and it is not in the
+// repo's membership at the authorising hold — so a snapshot keyed on membership
+// alone would have no entry, resolve it to 0, find 0 != 1 and suppress. That
+// silently drops the first link pass, and the group-algo pass behind it, for
+// every newly-added repo/group pair whose name had ever been deleted.
+//
+// The wholesale copy carries that name's real generation forward, so the arm
+// matches and proceeds. The two tests are a matched pair: the same mutation —
+// narrowing the snapshot to membership — makes this one fail by suppressing a
+// live group and the one above fail by arming a dead one.
 func TestRunIndex_GroupJoiningDuringIndexStillArms(t *testing.T) {
 	// gJoin is deleted up front, so its generation is 1, not the zero value.
-	// Membership then changes mid-index: gJoin is absent at the authorising hold
-	// and present at the chained arm.
+	// Membership then changes mid-index: gJoin is absent from the repo's groups
+	// at the authorising hold and present at the chained arm.
 	var s *Scheduler
 	joined := &atomic.Bool{}
 	s, _, _ = indexRearmScheduler(nil, nil)
@@ -227,7 +304,7 @@ func TestRunIndex_GroupJoiningDuringIndexStillArms(t *testing.T) {
 		t.Fatal("the index body never ran — membership never changed, so the fixture is not exercising the join-during-index path")
 	}
 	if timer, arm, pending := linkArmed(s, "gJoin"); !timer || !arm || !pending {
-		t.Fatalf("a group that JOINED during the index was suppressed (timer=%v arm=%v pending=%v) — it has no captured generation because it is not a continuation of anything, and gating it drops the first link pass of every newly-added repo/group pair, invisibly", timer, arm, pending)
+		t.Fatalf("a group that JOINED during the index was suppressed (timer=%v arm=%v pending=%v) — its generation never moved during this index, so the snapshot must carry it forward; suppressing here drops the first link pass of every newly-added repo/group pair whose name had ever been deleted, invisibly", timer, arm, pending)
 	}
 }
 

--- a/internal/daemon/sched/cancelgroup_indexrearm_6068_test.go
+++ b/internal/daemon/sched/cancelgroup_indexrearm_6068_test.go
@@ -1,0 +1,255 @@
+package sched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The #6068 hazard one hop UPSTREAM of the two sites pinned in
+// cancelgroup_rearmgap_6068_test.go.
+//
+// runIndex's success path chains scheduleLinks for every group the repo belongs
+// to. That call happens after a multi-MINUTE index, outside every lock, and —
+// before this file — with no generation to re-present. So:
+//
+//  1. repo R is indexing for group gB (minutes).
+//  2. DeleteGroup(gB) → cancelGroupWork → CancelGroup("gB"). Generation 0→1,
+//     link timers dropped, group-algo torn down.
+//  3. runIndex completes successfully and chains scheduleLinks("gB") — a LIVE
+//     link timer for a group that no longer exists.
+//  4. That timer fires; fireLinks captures gen = groupGenLocked("gB") = 1, the
+//     CURRENT value, so the #6068 guard on the chained group-algo arm sees
+//     1 == 1 and arms.
+//  5. ~180s later Louvain + PageRank + betweenness run for a deleted group,
+//     under a ctx rooted only at shutdownCtx, with nothing left to cancel it.
+//
+// The guard added for runLinks cannot see this: by the time fireLinks runs, the
+// delete is in the PAST and the generation it reads is already the post-delete
+// one. The generation has to be captured at the hold that dequeued the index —
+// the hold that AUTHORISED this whole chain — and threaded through.
+//
+// Reachable, not theoretical, for two reasons:
+//   - CancelGroup deliberately leaves running any reindex whose repo is still
+//     referenced by a surviving group (repoBelongsOnlyToLocked). That reindex
+//     completes normally and chains scheduleLinks for every group
+//     GroupsForRepo returns.
+//   - service.go's DeleteGroup calls cancelGroupWork BEFORE registry teardown,
+//     so there is a real window in which GroupsForRepo(repoPath) still returns
+//     the deleted group.
+//
+// OVER-SUPPRESSION is the dangerous failure mode for the fix, not the bug: a
+// guard that silently drops link (and therefore group-algo) passes for LIVE
+// groups means missing analysis, which is worse than the leak because it is
+// invisible. Every test below pairs its negative with a live sibling group that
+// must still arm — in the SAME GroupsForRepo loop, on the SAME index — plus a
+// fresh-trigger control.
+
+// indexRearmScheduler builds a scheduler whose repo belongs to groups and whose
+// Index body runs onIndex (the seam that places a delete DURING the index).
+// Debounces are an hour out so nothing fires on its own: the assertions read
+// whether a timer was ARMED, never whether it ran.
+func indexRearmScheduler(groups []string, onIndex func()) (*Scheduler, *atomic.Int32, *atomic.Int32) {
+	var linksRan atomic.Int32
+	var algoRan atomic.Int32
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		Index: func(_ context.Context, _ string, _ string) error {
+			if onIndex != nil {
+				onIndex()
+			}
+			return nil
+		},
+		Links: func(_ context.Context, _ string) error {
+			linksRan.Add(1)
+			return nil
+		},
+		GroupAlgo: func(_ context.Context, _ string) error {
+			algoRan.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return groups },
+		MemReleaseDisabled: true,
+	})
+	return s, &linksRan, &algoRan
+}
+
+// linkArmed reports whether group currently holds link-timer state of any kind.
+// All three are checked because the pre-fix defect resurrects all three, and a
+// fix that dropped only the timer while leaving linkPending set would still
+// re-arm on the next retry.
+func linkArmed(s *Scheduler, group string) (timer, arm, pending bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, timer = s.linkTimers[group]
+	_, arm = s.linkArm[group]
+	pending = s.linkPending[group]
+	return
+}
+
+// TestRunIndex_ChainedLinksAcrossCancelGroup_DoesNotArm is the primary
+// interleaving: the delete lands WHILE the index is running, i.e. after the
+// hold that dequeued the job and long before scheduleLinks is chained.
+//
+// runIndex is invoked directly from the test goroutine — the #6067 convention.
+// It is the worker-loop body (`s.runIndex(tok)`), so calling it is exactly the
+// work a dequeued job performs, with the scheduling non-determinism removed.
+func TestRunIndex_ChainedLinksAcrossCancelGroup_DoesNotArm(t *testing.T) {
+	var s *Scheduler
+	// deleted fires the delete from INSIDE the index body. That is the window:
+	// the authorising hold has been released, the index is in flight, and the
+	// GroupsForRepo loop has not run yet.
+	deleted := &atomic.Bool{}
+	s, linksRan, algoRan := indexRearmScheduler([]string{"gA", "gB"}, func() {
+		if deleted.Swap(true) {
+			return // only the first index deletes; the control below must not
+		}
+		s.CancelGroup("gB")
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.runIndex(jobToken{repoPath: "/repo-a", ref: "main", commit: "c0"})
+
+	if !deleted.Load() {
+		t.Fatal("the index body never ran — the fixture never opened the window it claims to guard, and every assertion below is vacuous")
+	}
+
+	timer, arm, pending := linkArmed(s, "gB")
+	if timer || arm || pending {
+		t.Fatalf("a reindex that completed AFTER its group was deleted armed a live link timer for it (timer=%v arm=%v pending=%v) — that timer fires, fireLinks reads the post-delete generation, and the chained group-algo pass runs for a group that is gone", timer, arm, pending)
+	}
+
+	// OVER-SUPPRESSION GUARD. gA was never deleted and is in the SAME
+	// GroupsForRepo loop, on the SAME index, one iteration away from gB. If the
+	// fix suppresses this too, the negative above still holds and the bug is
+	// traded for a silent, invisible loss of every downstream link + group-algo
+	// pass for live groups.
+	if ctlTimer, ctlArm, ctlPending := linkArmed(s, "gA"); !ctlTimer || !ctlArm || !ctlPending {
+		t.Fatalf("the LIVE sibling group gA was suppressed by a delete of gB (timer=%v arm=%v pending=%v) — over-suppression drops analysis for groups that still exist and does so silently", ctlTimer, ctlArm, ctlPending)
+	}
+
+	// Nothing downstream may have run: the debounces are an hour out, so a
+	// non-zero count here means an arm fired immediately, not that it was armed.
+	if n := linksRan.Load(); n != 0 {
+		t.Fatalf("no link pass should have RUN yet (debounce is an hour), ran %d", n)
+	}
+	if n := algoRan.Load(); n != 0 {
+		t.Fatalf("no group-algo pass should have RUN yet, ran %d", n)
+	}
+
+	// CONTROL: a second index of the same repo, with no delete in flight, must
+	// arm gB again. The cancel generation gates CONTINUATIONS of work the delete
+	// already cancelled — it must never gate the group name forever.
+	s.mu.Lock()
+	prevArm := s.linkArm["gA"]
+	s.mu.Unlock()
+
+	s.runIndex(jobToken{repoPath: "/repo-a", ref: "main", commit: "c1"})
+
+	if timer, arm, pending = linkArmed(s, "gB"); !timer || !arm || !pending {
+		t.Fatalf("control: a fresh index after the delete must arm gB's link timer (timer=%v arm=%v pending=%v) — without this the test passes even when the guard has disabled the group name permanently", timer, arm, pending)
+	}
+	s.mu.Lock()
+	newArm := s.linkArm["gA"]
+	s.mu.Unlock()
+	if newArm == prevArm {
+		t.Fatal("control: gA's link timer was not re-armed by the second index — the fixture cannot distinguish a fresh arm from the stale one left by the first")
+	}
+}
+
+// TestRunIndex_ChainedLinksCancelInGap_DoesNotArm pins the NARROWEST form of the
+// same window: the index body has already returned, and the delete lands in the
+// handful of instructions between the success log and the scheduleLinks call.
+// Driven through rearmGapHook rather than raced for, so the delete is placed
+// exactly there.
+func TestRunIndex_ChainedLinksCancelInGap_DoesNotArm(t *testing.T) {
+	s, _, algoRan := indexRearmScheduler([]string{"gA", "gB"}, nil)
+	s.Start()
+	defer s.Stop()
+
+	entered := installRearmGapCancel(s, "index-done", "gB")
+
+	s.runIndex(jobToken{repoPath: "/repo-a", ref: "main", commit: "c0"})
+
+	if !entered.Load() {
+		t.Fatal("runIndex never entered the pre-scheduleLinks gap — the fixture cannot exhibit the window it claims to guard")
+	}
+
+	if timer, arm, pending := linkArmed(s, "gB"); timer || arm || pending {
+		t.Fatalf("a delete landing in the gap between a completed index and its chained scheduleLinks still armed a live link timer (timer=%v arm=%v pending=%v)", timer, arm, pending)
+	}
+	// Over-suppression guard again: gA is armed by the SAME loop.
+	if timer, arm, pending := linkArmed(s, "gA"); !timer || !arm || !pending {
+		t.Fatalf("the live sibling gA was suppressed (timer=%v arm=%v pending=%v)", timer, arm, pending)
+	}
+	if n := algoRan.Load(); n != 0 {
+		t.Fatalf("no group-algo pass should have run, ran %d", n)
+	}
+}
+
+// TestRunIndex_GroupJoiningDuringIndexStillArms is the third over-suppression
+// guard, and the one a plausible wrong implementation trips: a group that was
+// NOT a member when the index started has no captured generation, so the arm
+// must treat it as a fresh trigger. Defaulting the missing entry to 0 instead
+// (the zero value) looks harmless and is not — for any group name that had ever
+// been cancelled, groupCancelSeq is non-zero, 0 never matches, and the first
+// link pass of that newly-added repo/group pair is dropped silently and forever.
+func TestRunIndex_GroupJoiningDuringIndexStillArms(t *testing.T) {
+	// gJoin is deleted up front, so its generation is 1, not the zero value.
+	// Membership then changes mid-index: gJoin is absent at the authorising hold
+	// and present at the chained arm.
+	var s *Scheduler
+	joined := &atomic.Bool{}
+	s, _, _ = indexRearmScheduler(nil, nil)
+	s.cfg.GroupsForRepo = func(_ string) []string {
+		if joined.Load() {
+			return []string{"gJoin"}
+		}
+		return nil
+	}
+	s.cfg.Index = func(_ context.Context, _ string, _ string) error {
+		joined.Store(true) // gJoin joins WHILE the index runs
+		return nil
+	}
+	s.Start()
+	defer s.Stop()
+
+	s.CancelGroup("gJoin") // some earlier delete moved gJoin's generation off 0
+
+	s.runIndex(jobToken{repoPath: "/repo-a", ref: "main", commit: "c0"})
+
+	if !joined.Load() {
+		t.Fatal("the index body never ran — membership never changed, so the fixture is not exercising the join-during-index path")
+	}
+	if timer, arm, pending := linkArmed(s, "gJoin"); !timer || !arm || !pending {
+		t.Fatalf("a group that JOINED during the index was suppressed (timer=%v arm=%v pending=%v) — it has no captured generation because it is not a continuation of anything, and gating it drops the first link pass of every newly-added repo/group pair, invisibly", timer, arm, pending)
+	}
+}
+
+// TestScheduleLinks_FreshRequestAfterDeleteStillArms is the standalone
+// counterweight for the link timer, mirroring the group-algo one. A group that
+// is deleted and then re-registered — or any fresh trigger arriving afterwards —
+// must schedule normally. Without this, a guard that gated on the group name
+// rather than on the generation captured by a continuation would pass every
+// other test in this file.
+func TestScheduleLinks_FreshRequestAfterDeleteStillArms(t *testing.T) {
+	s, _, _ := indexRearmScheduler([]string{"gB"}, nil)
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleLinks("gB")
+	s.CancelGroup("gB")
+	if timer, arm, pending := linkArmed(s, "gB"); timer || arm || pending {
+		t.Fatalf("CancelGroup left link state behind (timer=%v arm=%v pending=%v) — fixture cannot tell a suppressed arm from a surviving one", timer, arm, pending)
+	}
+
+	s.scheduleLinks("gB")
+	if timer, arm, pending := linkArmed(s, "gB"); !timer || !arm || !pending {
+		t.Fatalf("a FRESH scheduleLinks after a delete must arm (timer=%v arm=%v pending=%v) — the cancel generation must gate continuations only, not the group name forever", timer, arm, pending)
+	}
+}

--- a/internal/daemon/sched/cancelgroup_rearmgap_6068_test.go
+++ b/internal/daemon/sched/cancelgroup_rearmgap_6068_test.go
@@ -1,0 +1,234 @@
+package sched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// #6067 made the arm id order a group delete against a timer that had ALREADY
+// FIRED. It structurally cannot order a delete against a re-arm taken later:
+// both fireGroupAlgo's rerun completion and runLinks' chained arm decide to
+// re-arm while holding s.mu (or while holding the pass), then release and call
+// scheduleGroupAlgo. A CancelGroup landing in that gap has already run — it
+// dropped the arm id and cancelled what existed — so the arm that follows
+// allocates a FRESH, legitimately-live id for a group that is gone. ~180s later
+// runGroupAlgo (Louvain + PageRank + betweenness over the group union, in a
+// subprocess, under a ctx rooted only at shutdownCtx) runs for a deleted group,
+// with nothing left that can cancel it.
+//
+// The gap is microseconds wide, so these tests do not race for it: they install
+// rearmGapHook, the test-only seam invoked inside the gap, and cancel from
+// there. That places the delete exactly where the hazard lives. Both bodies are
+// invoked directly from the test goroutine (the #6067 convention — the body is
+// the residual work the timer leaves behind), so when the call returns the
+// re-arm decision has already been taken and the state can be read without a
+// single sleep.
+
+// installRearmGapCancel makes the FIRST entry into the re-arm gap at `site`
+// delete `group`, and reports whether the gap was ever entered. A test whose
+// entered flag stays false never reached the window and is asserting nothing.
+func installRearmGapCancel(s *Scheduler, site, group string) (entered *atomic.Bool) {
+	entered = &atomic.Bool{}
+	var fn func(string, string)
+	fn = func(gotSite, gotGroup string) {
+		if gotSite != site || gotGroup != group {
+			return
+		}
+		if entered.Swap(true) {
+			return // only the first pass through the gap gets deleted
+		}
+		s.CancelGroup(group)
+	}
+	s.rearmGapHook.Store(&fn)
+	return entered
+}
+
+// TestFireGroupAlgo_RerunRearmAcrossCancelGroup_DoesNotArm drives the rerun
+// completion path: a pass finishes, a recompute was requested while it ran, and
+// the group is deleted in the gap between releasing s.mu and re-arming.
+func TestFireGroupAlgo_RerunRearmAcrossCancelGroup_DoesNotArm(t *testing.T) {
+	var ran atomic.Int32
+	var s *Scheduler
+	// requestRerun makes the RUNNING pass ask for a follow-up, which is the only
+	// way to set groupAlgoRerun — this is what a link completion landing
+	// mid-pass does. Guarded so only the first pass requests one, or the control
+	// phase would chain forever.
+	var requested atomic.Bool
+	s = New(Config{
+		Workers: 1,
+		// An hour out: no timer fires on its own. The bodies below ARE the
+		// timer bodies, invoked directly.
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(_ context.Context, group string) error {
+			ran.Add(1)
+			if !requested.Swap(true) {
+				s.scheduleGroupAlgo(group) // recompute requested mid-pass
+			}
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	entered := installRearmGapCancel(s, "group-algo-rerun", "gB")
+
+	s.fireGroupAlgo("gB", armedGroupAlgo(t, s, "gB"))
+
+	if !entered.Load() {
+		t.Fatal("the completion path never entered the re-arm gap — the fixture cannot exhibit the window it claims to guard")
+	}
+	if n := ran.Load(); n != 1 {
+		t.Fatalf("the first (pre-delete) pass must run exactly once, ran %d time(s) — fixture is not driving the rerun path", n)
+	}
+
+	s.mu.Lock()
+	_, reArmed := s.groupAlgoTimers["gB"]
+	_, reArmID := s.groupAlgoArm["gB"]
+	pending := s.groupAlgoPending["gB"]
+	s.mu.Unlock()
+	if reArmed || reArmID || pending {
+		t.Fatalf("the rerun re-armed a group deleted in the gap (timer=%v arm=%v pending=%v) — the pass will run for a group that is gone, and nothing can cancel it", reArmed, reArmID, pending)
+	}
+
+	// CONTROL. Every assertion above is a negative, and all of them would also
+	// hold if the rerun path were simply unreachable in this fixture — a
+	// dropped rerun flag, a nil GroupAlgo, a stopped scheduler. Run the SAME
+	// path with no delete in the gap: it must re-arm.
+	var fn func(string, string)
+	fn = func(_, _ string) {}
+	s.rearmGapHook.Store(&fn)
+	requested.Store(false)
+
+	s.fireGroupAlgo("gB", armedGroupAlgo(t, s, "gB"))
+	if n := ran.Load(); n != 2 {
+		t.Fatalf("control: the second pass must run, ran total %d time(s)", n)
+	}
+	s.mu.Lock()
+	_, ctlArmed := s.groupAlgoTimers["gB"]
+	s.mu.Unlock()
+	if !ctlArmed {
+		t.Fatal("control: an UNcancelled rerun must re-arm the group-algo timer — without this the test passes even when the rerun path is dead")
+	}
+}
+
+// TestRunLinks_ChainedGroupAlgoAcrossCancelGroup_DoesNotArm drives the second
+// call site. Here the gap is not microseconds: cfg.Links runs for minutes
+// between the hold that authorised the pass and the chained arm, so a delete
+// anywhere in that span must suppress it.
+func TestRunLinks_ChainedGroupAlgoAcrossCancelGroup_DoesNotArm(t *testing.T) {
+	var algoRan atomic.Int32
+	var linksRan atomic.Int32
+	s := New(Config{
+		Workers:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		Links: func(_ context.Context, _ string) error {
+			linksRan.Add(1)
+			return nil
+		},
+		GroupAlgo: func(_ context.Context, _ string) error {
+			algoRan.Add(1)
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	entered := installRearmGapCancel(s, "links-done", "gB")
+
+	s.scheduleLinks("gB")
+	s.mu.Lock()
+	arm, armed := s.linkArm["gB"]
+	s.mu.Unlock()
+	if !armed {
+		t.Fatal("scheduleLinks recorded no arm id — fixture cannot stand in for a fired timer body")
+	}
+	s.fireLinks("gB", arm)
+
+	if !entered.Load() {
+		t.Fatal("the link pass never reached the chained group-algo arm — the fixture cannot exhibit the window it claims to guard")
+	}
+	if n := linksRan.Load(); n != 1 {
+		t.Fatalf("the link pass must have run exactly once, ran %d time(s)", n)
+	}
+
+	s.mu.Lock()
+	_, reArmed := s.groupAlgoTimers["gB"]
+	_, reArmID := s.groupAlgoArm["gB"]
+	pending := s.groupAlgoPending["gB"]
+	s.mu.Unlock()
+	if reArmed || reArmID || pending {
+		t.Fatalf("a link pass whose group was deleted mid-pass still armed the group-algo pass (timer=%v arm=%v pending=%v)", reArmed, reArmID, pending)
+	}
+	if n := algoRan.Load(); n != 0 {
+		t.Fatalf("a group-algo pass ran %d time(s) for a deleted group", n)
+	}
+
+	// CONTROL: the same path with no delete in the gap must arm.
+	var fn func(string, string)
+	fn = func(_, _ string) {}
+	s.rearmGapHook.Store(&fn)
+
+	s.scheduleLinks("gB")
+	s.mu.Lock()
+	arm2 := s.linkArm["gB"]
+	s.mu.Unlock()
+	if arm2 == arm {
+		t.Fatal("re-arm reused the cancelled arm id — the control cannot distinguish cancelled from live")
+	}
+	s.fireLinks("gB", arm2)
+	s.mu.Lock()
+	_, ctlArmed := s.groupAlgoTimers["gB"]
+	s.mu.Unlock()
+	if !ctlArmed {
+		t.Fatal("control: a successful link pass must chain the group-algo arm — without this the test passes even when Links never reaches the chain")
+	}
+}
+
+// TestScheduleGroupAlgo_FreshRequestAfterDeleteStillArms is the counterweight.
+// The generation check must reject only CONTINUATIONS of work authorised before
+// the delete; a group that is deleted and then re-registered (or any fresh
+// trigger arriving afterwards) must still schedule normally. Without this, a
+// too-eager guard would silently disable the group-algo pass for every group
+// name that had ever been deleted, and every other test here would still pass.
+func TestScheduleGroupAlgo_FreshRequestAfterDeleteStillArms(t *testing.T) {
+	s := New(Config{
+		Workers:            1,
+		LinkDebounce:       time.Hour,
+		GroupAlgoDebounce:  time.Hour,
+		GroupAlgoMaxWait:   time.Hour,
+		Links:              func(_ context.Context, _ string) error { return nil },
+		GroupAlgo:          func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.scheduleGroupAlgo("gB")
+	s.CancelGroup("gB")
+	s.mu.Lock()
+	_, armedAfterCancel := s.groupAlgoTimers["gB"]
+	s.mu.Unlock()
+	if armedAfterCancel {
+		t.Fatal("CancelGroup left a group-algo timer armed — fixture cannot tell a suppressed arm from a surviving one")
+	}
+
+	s.scheduleGroupAlgo("gB")
+	s.mu.Lock()
+	_, rearmed := s.groupAlgoTimers["gB"]
+	s.mu.Unlock()
+	if !rearmed {
+		t.Fatal("a FRESH scheduleGroupAlgo after a delete must arm — the cancel generation must gate continuations only, not the group name forever")
+	}
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1593,20 +1593,41 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	// tears the registry down, so GroupsForRepo can still name the deleted group
 	// when this returns.
 	//
-	// So capture the membership BEFORE the authorising hold (cfg.GroupsForRepo
-	// is an external callback and must not run under s.mu — #6060) and the
-	// generations inside it, then re-present them at the arm.
+	// So snapshot the cancel GENERATIONS under the hold that dequeues this job —
+	// the hold that AUTHORISES the whole downstream chain — and re-present them
+	// at the arm.
+	//
+	// The snapshot is of groupCancelSeq WHOLESALE, not of this repo's group
+	// membership, and that distinction is the whole correctness argument. A
+	// membership-keyed capture has nothing to say about a group that joins after
+	// it is taken, and "nothing to say" can only be resolved as an exemption —
+	// which reopens the hazard through exactly the window described above: repo
+	// joins gB after the capture, gB is deleted, the terminal membership read
+	// still names gB because teardown has not finished, and an exempt arm goes
+	// live for a deleted group. Snapshotting generations instead turns an absent
+	// name into the positive claim "generation 0 as of the hold", which a later
+	// CancelGroup contradicts and the guard below then catches.
+	//
+	// Absent-means-0 costs nothing in over-suppression, because 0 is also the
+	// current generation of every group that has never been cancelled: a
+	// brand-new group arms (0 == 0), and a group re-registered under a
+	// previously-cancelled name arms too (the snapshot carries that name's real
+	// generation, so it matches). Only a cancel landing INSIDE this index's
+	// window can produce a mismatch.
+	//
+	// Membership is read before the hold because cfg.GroupsForRepo is an
+	// external callback and must not run under s.mu (#6060); it is only needed
+	// to keep the snapshot covering names the map has not seen yet.
 	var startGroups []string
 	if s.cfg.GroupsForRepo != nil {
 		startGroups = s.cfg.GroupsForRepo(repoPath)
 	}
 
 	s.mu.Lock()
-	// Cancel generation per group as of the hold that dequeues this job — the
-	// hold that AUTHORISES the whole downstream chain. A group absent from this
-	// map when the success path runs joined during the index; that is genuinely
-	// new membership, not a continuation of cancelled work, so it arms freely.
-	linkGen := make(map[string]uint64, len(startGroups))
+	linkGen := make(map[string]uint64, len(s.groupCancelSeq)+len(startGroups))
+	for g, v := range s.groupCancelSeq {
+		linkGen[g] = v
+	}
 	for _, g := range startGroups {
 		linkGen[g] = s.groupGenLocked(g)
 	}
@@ -1937,17 +1958,14 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	// one-repo union, computed by the group pass.
 	if s.cfg.GroupsForRepo != nil {
 		for _, g := range s.cfg.GroupsForRepo(repoPath) {
-			// #6068: re-present the generation captured at the authorising hold.
-			// A group that was NOT a member when this index started (linkGen has
-			// no entry) is fresh membership, not a continuation, and is never
-			// gated — gating it would silently drop the first link pass of every
-			// newly-added repo/group pair.
-			gen, known := linkGen[g]
-			if !known {
-				gen = groupGenFresh
-			}
+			// #6068: re-present the generation snapshotted at the authorising
+			// hold. A name absent from the snapshot had generation 0 then — the
+			// zero value IS the claim, not a missing one — so it arms unless a
+			// CancelGroup has moved it since. No exemption branch: an exemption
+			// here is precisely the hole that lets a group which joined after
+			// the snapshot and was then deleted arm a live timer.
 			s.fireRearmGapHook("index-done", g)
-			s.scheduleLinksFor(g, gen)
+			s.scheduleLinksFor(g, linkGen[g])
 		}
 	}
 }
@@ -1961,18 +1979,32 @@ func (s *Scheduler) scheduleLinks(group string) {
 
 // scheduleLinksFor is scheduleLinks with the #6068 continuation guard, the same
 // shape as scheduleGroupAlgoFor. gen is the cancel generation the caller
-// captured under the hold that AUTHORISED this arm; if a CancelGroup has landed
-// since, the generation has moved and the arm is refused, because the link pass
-// it would arm chains the group-algo pass in turn. Callers with nothing to
-// re-present pass groupGenFresh.
+// snapshotted under the hold that AUTHORISED this arm; if a CancelGroup has
+// landed since, the generation has moved and the arm is refused — the link pass
+// it would arm chains the group-algo pass in turn, so letting it through leaks
+// the heaviest pass in the daemon to a deleted group.
+//
+// 0 is a MEANINGFUL gen, not a "don't know": it is the generation of every group
+// that has never been cancelled, so a caller whose snapshot lacks a name still
+// makes a real, falsifiable claim by passing 0. Only callers with genuinely
+// nothing to re-present — a fresh trigger that is not a continuation of anything
+// — pass groupGenFresh, which bypasses the check outright.
 //
 // The guard is deliberately narrow. CancelGroup has exactly two production
 // callers (Service.cancelGroupWork and the engine's KindCancelGroup drain), both
-// of which mean "this group was deleted" — so a moved generation is never a
+// of which mean "this group was deleted", so a moved generation is never a
 // transient condition a live group can be in. Over-suppression would be the
-// worse defect (a silently dropped link + group-algo pass for a group that still
-// exists is invisible), which is why only continuations are gated and every
-// fresh trigger passes straight through.
+// worse defect — a silently dropped link + group-algo pass for a group that
+// still exists is invisible — and the snapshot form costs none of it: a
+// never-cancelled group matches at 0, and a group re-registered under a
+// previously-cancelled name matches at that name's real snapshotted generation.
+// Only a cancel landing inside the authorised window can refuse an arm.
+//
+// The single residual: a group deleted and RE-created inside one index's window
+// is live at the arm and still refused. That is self-healing rather than a
+// silent loss — re-registering a group enqueues its repos, and those indexes
+// chain their own arms under a fresh snapshot — and it is the same exposure the
+// other two call sites already carry, not something this one introduces.
 func (s *Scheduler) scheduleLinksFor(group string, gen uint64) {
 	if s.cfg.Links == nil {
 		return

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -530,9 +530,16 @@ type Scheduler struct {
 	// GroupsForRepo, keyed by repo) and CancelGroup IS the delete signal it
 	// would be asking about.
 	//
-	// Entries are never deleted: the whole point is that the generation outlives
-	// the group's other state. Bounded by the number of distinct group names
-	// ever cancelled in a daemon lifetime. Guarded by mu.
+	// Entries are never deleted, and that is CORRECT BY DESIGN rather than an
+	// oversight — do not "tidy" it into a leak fix. Deleting group's entry
+	// resets its generation to 0, which is precisely the value a continuation
+	// authorised before the very first CancelGroup is still holding; that
+	// continuation would then match and re-arm, reopening the window this field
+	// exists to close. The generation MUST outlive every other piece of the
+	// group's state, including the group itself. The cost is bounded by the
+	// number of distinct group names ever cancelled in one daemon lifetime (a
+	// uint64 per name, and a group delete is a human-initiated operation), which
+	// is not a growth curve worth trading correctness for. Guarded by mu.
 	groupCancelSeq map[string]uint64
 	// rearmGapHook is a test-only seam; see fireRearmGapHook. Nil in production.
 	rearmGapHook atomic.Pointer[func(site, group string)]
@@ -1574,7 +1581,35 @@ func (s *Scheduler) workerLoop() {
 func (s *Scheduler) runIndex(tok jobToken) {
 	repoPath := tok.repoPath
 
+	// #6068 (one hop upstream of runLinks): the success path below chains
+	// scheduleLinks for every group this repo belongs to, after an index that
+	// runs for MINUTES and outside every lock. A CancelGroup landing in that
+	// span is invisible to everything downstream — by the time the chained link
+	// timer fires, fireLinks reads the POST-delete generation and matches it, so
+	// the group-algo guard passes and the heaviest pass in the daemon runs for a
+	// group that is gone. This is reachable rather than theoretical: CancelGroup
+	// deliberately leaves running any reindex whose repo a surviving group still
+	// references (repoBelongsOnlyToLocked), and DeleteGroup cancels BEFORE it
+	// tears the registry down, so GroupsForRepo can still name the deleted group
+	// when this returns.
+	//
+	// So capture the membership BEFORE the authorising hold (cfg.GroupsForRepo
+	// is an external callback and must not run under s.mu — #6060) and the
+	// generations inside it, then re-present them at the arm.
+	var startGroups []string
+	if s.cfg.GroupsForRepo != nil {
+		startGroups = s.cfg.GroupsForRepo(repoPath)
+	}
+
 	s.mu.Lock()
+	// Cancel generation per group as of the hold that dequeues this job — the
+	// hold that AUTHORISES the whole downstream chain. A group absent from this
+	// map when the success path runs joined during the index; that is genuinely
+	// new membership, not a continuation of cancelled work, so it arms freely.
+	linkGen := make(map[string]uint64, len(startGroups))
+	for _, g := range startGroups {
+		linkGen[g] = s.groupGenLocked(g)
+	}
 	s.pendingIndex[repoPath] = false
 	s.queueLen--
 	// #5138 no-lost-update: clear the dirty marker BEFORE the index runs so
@@ -1902,7 +1937,17 @@ func (s *Scheduler) runIndex(tok jobToken) {
 	// one-repo union, computed by the group pass.
 	if s.cfg.GroupsForRepo != nil {
 		for _, g := range s.cfg.GroupsForRepo(repoPath) {
-			s.scheduleLinks(g)
+			// #6068: re-present the generation captured at the authorising hold.
+			// A group that was NOT a member when this index started (linkGen has
+			// no entry) is fresh membership, not a continuation, and is never
+			// gated — gating it would silently drop the first link pass of every
+			// newly-added repo/group pair.
+			gen, known := linkGen[g]
+			if !known {
+				gen = groupGenFresh
+			}
+			s.fireRearmGapHook("index-done", g)
+			s.scheduleLinksFor(g, gen)
 		}
 	}
 }
@@ -1911,16 +1956,39 @@ func (s *Scheduler) runIndex(tok jobToken) {
 // window is meant to coalesce bursts where multiple repos in a group
 // re-index back-to-back.
 func (s *Scheduler) scheduleLinks(group string) {
+	s.scheduleLinksFor(group, groupGenFresh)
+}
+
+// scheduleLinksFor is scheduleLinks with the #6068 continuation guard, the same
+// shape as scheduleGroupAlgoFor. gen is the cancel generation the caller
+// captured under the hold that AUTHORISED this arm; if a CancelGroup has landed
+// since, the generation has moved and the arm is refused, because the link pass
+// it would arm chains the group-algo pass in turn. Callers with nothing to
+// re-present pass groupGenFresh.
+//
+// The guard is deliberately narrow. CancelGroup has exactly two production
+// callers (Service.cancelGroupWork and the engine's KindCancelGroup drain), both
+// of which mean "this group was deleted" — so a moved generation is never a
+// transient condition a live group can be in. Over-suppression would be the
+// worse defect (a silently dropped link + group-algo pass for a group that still
+// exists is invisible), which is why only continuations are gated and every
+// fresh trigger passes straight through.
+func (s *Scheduler) scheduleLinksFor(group string, gen uint64) {
 	if s.cfg.Links == nil {
 		return
 	}
 	s.mu.Lock()
+	defer s.mu.Unlock()
+	if gen != groupGenFresh && s.groupCancelSeq[group] != gen {
+		s.logEventLocked("link_arm_dropped", "",
+			group+": group cancelled while the index that would arm its link pass was in flight — not arming")
+		return
+	}
 	if t, ok := s.linkTimers[group]; ok {
 		t.Stop()
 	}
 	s.linkPending[group] = true
 	s.armLinkTimerLocked(group, s.cfg.LinkDebounce)
-	s.mu.Unlock()
 }
 
 // armLinkTimerLocked arms (or re-arms) group's link timer under a FRESH arm id
@@ -2385,12 +2453,19 @@ func (s *Scheduler) fireGroupAlgo(group string, arm uint64) {
 	}
 }
 
-// rearmGapHook is a TEST-ONLY seam, nil in production, invoked on the two paths
-// that release s.mu and then re-arm the group-algo pass (#6068): fireGroupAlgo's
-// rerun completion and runLinks' chained arm. It exists because that gap is
-// microseconds wide and cannot otherwise be driven deterministically — a test
-// installs a hook that calls CancelGroup, which places the delete EXACTLY in the
-// gap instead of racing for it. site is "group-algo-rerun" or "links-done".
+// rearmGapHook is a TEST-ONLY seam, nil in production, invoked on the three
+// paths that release s.mu and then re-arm downstream work (#6068):
+// fireGroupAlgo's rerun completion ("group-algo-rerun"), runLinks' chained
+// group-algo arm ("links-done"), and runIndex's chained link arm
+// ("index-done"). It exists because those gaps cannot otherwise be driven
+// deterministically — a test installs a hook that calls CancelGroup, which
+// places the delete EXACTLY in the gap instead of racing for it.
+//
+// PRECONDITION, for any call site added later: this MUST NOT be called with
+// s.mu held. The hook a test installs calls s.CancelGroup, which takes s.mu, so
+// a call site under the lock self-deadlocks the moment a test installs a hook.
+// All three current sites are lock-free, and that is load-bearing, not
+// incidental.
 //
 // An atomic pointer, not a plain field: the hook is read from the timer/link
 // goroutine while the test goroutine may still be storing it (#6056/#6059).

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -48,6 +48,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/extractor"
@@ -505,6 +506,36 @@ type Scheduler struct {
 	// grafel_stats reporting a pass in flight forever.
 	groupAlgoArm map[string]uint64
 	armSeq       uint64
+	// groupCancelSeq is the per-group CANCEL GENERATION: CancelGroup bumps it,
+	// and nothing else touches it. It closes the one window the arm ids
+	// structurally cannot (#6068).
+	//
+	// The arm id orders a delete against a timer that has already FIRED. It
+	// cannot order a delete against a re-arm that happens LATER, on a path that
+	// decided to re-arm while it still held s.mu but calls scheduleGroupAlgo
+	// after releasing it: fireGroupAlgo's rerun path, and runLinks' chained
+	// group-algo arm. A CancelGroup landing in that gap has already run — it
+	// dropped the arm id and cancelled what existed — so the re-arm that follows
+	// allocates a FRESH, legitimately-live arm id for a group that is gone, and
+	// ~180s later the heaviest pass in the daemon runs for it under a ctx rooted
+	// only at shutdownCtx.
+	//
+	// A continuation therefore captures the generation under the SAME hold that
+	// authorised it and re-presents it to scheduleGroupAlgoFor, which refuses to
+	// arm if the generation has moved. Chosen over widening the lock hold
+	// because runLinks' call site cannot be brought under s.mu at all (cfg.Links
+	// runs for minutes between the authorising hold and the arm), so the lock
+	// change would fix one site and leave the other — and over a group-existence
+	// re-check because the scheduler has no group oracle (Config exposes only
+	// GroupsForRepo, keyed by repo) and CancelGroup IS the delete signal it
+	// would be asking about.
+	//
+	// Entries are never deleted: the whole point is that the generation outlives
+	// the group's other state. Bounded by the number of distinct group names
+	// ever cancelled in a daemon lifetime. Guarded by mu.
+	groupCancelSeq map[string]uint64
+	// rearmGapHook is a test-only seam; see fireRearmGapHook. Nil in production.
+	rearmGapHook atomic.Pointer[func(site, group string)]
 	// Per-GROUP algorithm pass (#5349 A3). Mirrors the link timer machinery:
 	// debounce timer + pending flag + in-flight cancel func, all keyed by group.
 	// Replaces the old per-repo algo timers — algorithms now run once over the
@@ -793,6 +824,7 @@ func New(cfg Config) *Scheduler {
 		linkPending:       map[string]bool{},
 		linkArm:           map[string]uint64{},
 		groupAlgoArm:      map[string]uint64{},
+		groupCancelSeq:    map[string]uint64{},
 		groupAlgoTimers:   map[string]*time.Timer{},
 		groupAlgoPending:  map[string]bool{},
 		groupAlgoCancel:   map[string]*groupAlgoPassCancel{},
@@ -1948,6 +1980,11 @@ func (s *Scheduler) fireLinks(group string, arm uint64) {
 	s.linkPending[group] = false
 	delete(s.linkTimers, group)
 	delete(s.linkArm, group)
+	// Cancel generation as of the hold that authorises THIS pass (#6068). The
+	// chained group-algo arm at the end of runLinks happens minutes later and
+	// outside s.mu; re-presenting this generation there is what stops a group
+	// deleted in the meantime from getting a fresh, live arm.
+	gen := s.groupGenLocked(group)
 	// Derive a PER-GROUP cancel context from shutdownCtx (not shutdownCtx
 	// directly) so that a group delete can interrupt THIS group's in-flight
 	// link pass via CancelGroup without waiting for daemon Stop(). Still
@@ -1978,7 +2015,7 @@ func (s *Scheduler) fireLinks(group string, arm uint64) {
 	// forfeit-grace expiry cannot free its successor's token here.
 	defer s.releaseStage(name, stageEpoch)
 
-	s.runLinks(ctx, group)
+	s.runLinks(ctx, group, gen)
 
 	s.mu.Lock()
 	// Only clear the entry if it is still OUR token. An overlapping second
@@ -1992,7 +2029,9 @@ func (s *Scheduler) fireLinks(group string, arm uint64) {
 	cancel()
 }
 
-func (s *Scheduler) runLinks(ctx context.Context, group string) {
+// gen is the cancel generation captured by fireLinks when it authorised this
+// pass; it gates the chained group-algo arm below (#6068).
+func (s *Scheduler) runLinks(ctx context.Context, group string, gen uint64) {
 	s.logEvent("links_start", "", group)
 	t0 := time.Now()
 	err := s.cfg.Links(ctx, group)
@@ -2008,7 +2047,12 @@ func (s *Scheduler) runLinks(ctx context.Context, group string) {
 	// scheduleLinks already coalesced a burst of repo reindexes into this one
 	// link pass, chaining the algo pass here means N file saves → 1 link pass →
 	// 1 group-algo pass. Re-arm (cancel previous) on every link completion.
-	s.scheduleGroupAlgo(group)
+	//
+	// The #6068 gap, in its widest form: cfg.Links above can run for minutes,
+	// and this arm is not under s.mu (nor can it be). A CancelGroup at any point
+	// since fireLinks authorised this pass must suppress the chained arm.
+	s.fireRearmGapHook("links-done", group)
+	s.scheduleGroupAlgoFor(group, gen)
 }
 
 // groupAlgoDebounceDefault is the settling window between a successful link
@@ -2124,11 +2168,43 @@ func overlaySweepIntervalFromEnv() time.Duration {
 // that pass returns. Staleness is bounded by the follow-up pass; unavailability
 // under the old behaviour was not bounded at all.
 func (s *Scheduler) scheduleGroupAlgo(group string) {
+	s.scheduleGroupAlgoFor(group, groupGenFresh)
+}
+
+// groupGenFresh marks a scheduleGroupAlgoFor call that is a FRESH trigger, not
+// a continuation of work authorised earlier, and therefore has no generation to
+// re-present. uint64 max is unreachable as a real generation (it counts
+// CancelGroup calls for one group).
+const groupGenFresh = ^uint64(0)
+
+// groupGenLocked returns group's current cancel generation, to be re-presented
+// to scheduleGroupAlgoFor by a continuation that will arm after releasing s.mu.
+// MUST be called with s.mu held.
+func (s *Scheduler) groupGenLocked(group string) uint64 {
+	return s.groupCancelSeq[group]
+}
+
+// scheduleGroupAlgoFor is scheduleGroupAlgo with the #6068 continuation guard.
+// gen is the cancel generation the caller captured under the hold that
+// AUTHORISED this arm; if a CancelGroup has landed since, the generation has
+// moved and the arm is refused. Callers with nothing to re-present pass
+// groupGenFresh — a delete must not gate a genuinely new request, only a
+// continuation of work the delete already cancelled.
+func (s *Scheduler) scheduleGroupAlgoFor(group string, gen uint64) {
 	if s.cfg.GroupAlgo == nil {
 		return
 	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if gen != groupGenFresh && s.groupCancelSeq[group] != gen {
+		// The group was deleted between the authorising hold and this arm. The
+		// arm ids cannot see this: CancelGroup dropped an id we are about to
+		// replace, so a fresh one here would be legitimately live for a group
+		// that is gone.
+		s.logEventLocked("group_algo_arm_dropped", "",
+			group+": group cancelled while the pass that would re-arm it was in flight — not re-arming")
+		return
+	}
 	// A pass is RUNNING right now. Record the request and leave it alone; the
 	// completion path in fireGroupAlgo consumes the flag and re-arms.
 	if _, running := s.groupAlgoCancel[group]; running {
@@ -2285,6 +2361,11 @@ func (s *Scheduler) fireGroupAlgo(group string, arm uint64) {
 	// silently dropping the request.
 	rerun := s.groupAlgoRerun[group]
 	delete(s.groupAlgoRerun, group)
+	// Capture the cancel generation under the SAME hold that decides to re-arm
+	// (#6068). A CancelGroup that lands BEFORE this hold has already cleared
+	// groupAlgoRerun, so rerun is false and there is nothing to suppress; one
+	// that lands AFTER it moves the generation, and the re-arm below is refused.
+	gen := s.groupGenLocked(group)
 	// Drop the deferred marker only now: runGroupAlgo holds its own
 	// GroupAlgoBegin for the RUNNING window, so clearing here keeps the
 	// deferred→running indexstate coverage continuous (count 1 → 2 → 1 → 0)
@@ -2292,10 +2373,30 @@ func (s *Scheduler) fireGroupAlgo(group string, arm uint64) {
 	s.markGroupAlgoDeferredLocked(group, false)
 	s.mu.Unlock()
 	cancel()
+	// The #6068 gap: s.mu is released, the decision to re-arm has been taken,
+	// and the arm has not happened yet. A CancelGroup landing HERE is invisible
+	// to the arm id (it drops an id we are about to replace) — only the cancel
+	// generation captured above can see it.
+	s.fireRearmGapHook("group-algo-rerun", group)
 
 	if rerun && !s.stopped() {
 		s.logEvent("group_algo_rearm", "", group+": servicing the recompute requested during the previous pass")
-		s.scheduleGroupAlgo(group)
+		s.scheduleGroupAlgoFor(group, gen)
+	}
+}
+
+// rearmGapHook is a TEST-ONLY seam, nil in production, invoked on the two paths
+// that release s.mu and then re-arm the group-algo pass (#6068): fireGroupAlgo's
+// rerun completion and runLinks' chained arm. It exists because that gap is
+// microseconds wide and cannot otherwise be driven deterministically — a test
+// installs a hook that calls CancelGroup, which places the delete EXACTLY in the
+// gap instead of racing for it. site is "group-algo-rerun" or "links-done".
+//
+// An atomic pointer, not a plain field: the hook is read from the timer/link
+// goroutine while the test goroutine may still be storing it (#6056/#6059).
+func (s *Scheduler) fireRearmGapHook(site, group string) {
+	if h := s.rearmGapHook.Load(); h != nil {
+		(*h)(site, group)
 	}
 }
 
@@ -2393,6 +2494,14 @@ type linkPassCancel struct {
 func (s *Scheduler) CancelGroup(group string) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+
+	// Bump the cancel generation FIRST (#6068). Everything below cancels state
+	// that exists NOW; the generation is what reaches the arms that do not exist
+	// yet — a completion path that has already decided to re-arm, released s.mu,
+	// and not yet called scheduleGroupAlgo. Bumping before the teardown means
+	// there is no sub-window in which a continuation could observe the old
+	// generation and still find its state cancelled.
+	s.groupCancelSeq[group]++
 
 	// Group-algo pass (pending timer + in-flight run) — already per-group.
 	s.cancelGroupAlgoLocked(group)

--- a/internal/daemon/watch/githead_poller.go
+++ b/internal/daemon/watch/githead_poller.go
@@ -145,6 +145,14 @@ type GitHeadPoller struct {
 	repoToGroup map[string]string          // key: abs repo path → common-dir
 
 	statCalls uint64 // atomic — total os.Stat calls on HEAD/ref files (for measurement)
+	// pollCycles counts COMPLETED poll cycles (atomic). It is the honest
+	// denominator for the stat-rate measurement: asserting stats against a
+	// wall-clock sleep measures how many ticks the runner granted, which a
+	// loaded CI host can drive arbitrarily low, whereas stats-per-cycle is a
+	// property of the poller alone (#6069). Incremented at the END of poll() so
+	// the counter never runs ahead of the stats its cycles issued; a reader that
+	// also joins the loop goroutine (Stop) sees the two exactly in step.
+	pollCycles uint64
 
 	stopOnce sync.Once
 	stopCh   chan struct{}
@@ -193,6 +201,13 @@ func (p *GitHeadPoller) Stop() {
 // measurement of the M1 dedup.
 func (p *GitHeadPoller) StatCalls() uint64 {
 	return atomic.LoadUint64(&p.statCalls)
+}
+
+// PollCycles returns the number of poll cycles COMPLETED since the poller was
+// created. Paired with StatCalls it expresses the dedup measurement as a rate
+// per cycle rather than per wall-clock second (#6069).
+func (p *GitHeadPoller) PollCycles() uint64 {
+	return atomic.LoadUint64(&p.pollCycles)
 }
 
 // GroupCount returns the number of distinct common-dir groups currently
@@ -414,6 +429,10 @@ func (p *GitHeadPoller) statModTime(path string) int64 {
 // classification is per-repo (correct: the working tree differs per repo path
 // even when HEAD is shared).
 func (p *GitHeadPoller) poll() {
+	// Counted LAST so PollCycles never runs ahead of the stats that cycle
+	// issued (#6069).
+	defer atomic.AddUint64(&p.pollCycles, 1)
+
 	// Snapshot group metadata under the lock, then do all I/O outside it.
 	p.mu.Lock()
 	type groupSnap struct {

--- a/internal/daemon/watch/githead_poller_test.go
+++ b/internal/daemon/watch/githead_poller_test.go
@@ -495,61 +495,76 @@ func TestCommonDirDedup_FanOut_AllWorktreesReceiveEvent(t *testing.T) {
 	}
 }
 
-// TestCommonDirDedup_StatCountMeasurement is an instrumented measurement test
-// that prints before/after stat rates for the PR description.
+// TestCommonDirDedup_StatCountMeasurement is the instrumented side-by-side
+// measurement: the same repo count, deduped vs not, in one test.
 //
-// Before M1: N repos → N stats/cycle.
-// After M1:  N repos sharing 1 common-dir → 1 stat/cycle.
+// Before M1: N repos → 2N stats/cycle.
+// After M1:  N repos sharing 1 common-dir → 2 stats/cycle.
+//
+// Converted off the wall clock for the same reason as the two tests above
+// (#6069). It used to sleep for a fixed measureWindow and then assert against
+// `cycles := measureWindow / pollInterval` — a count ASSUMED rather than
+// OBSERVED, which silently presumes the runner grants every tick. Injecting
+// 150ms of per-cycle latency drove indepStats to 44 against a `>= 55` bound: a
+// red that says nothing about the poller. Both pollers now run through
+// runPollCycles, so each is measured over the cycles it actually completed, and
+// both bounds are exact equalities on that basis.
 func TestCommonDirDedup_StatCountMeasurement(t *testing.T) {
 	const (
-		numSubRepos   = 10
-		pollInterval  = 20 * time.Millisecond
-		measureWindow = 200 * time.Millisecond // ~10 cycles
+		numSubRepos  = 10
+		pollInterval = 20 * time.Millisecond
 	)
 
-	// Shared common-dir scenario.
+	// Shared common-dir scenario: numSubRepos+1 repos, exactly 1 group.
 	base, worktrees := makeSharedCommonDirRepos(t, numSubRepos)
 	pShared := NewGitHeadPoller(pollInterval, func(_ BranchSwitchEvent) {}, nil)
 	pShared.AddRepo(base)
 	for _, wt := range worktrees {
 		pShared.AddRepo(wt)
 	}
-	pShared.Start()
-	time.Sleep(measureWindow)
-	pShared.Stop()
-	sharedStats := pShared.StatCalls()
+	if gc := pShared.GroupCount(); gc != 1 {
+		t.Fatalf("shared: GroupCount want 1 (all repos share a common-dir), got %d — the two arms would not be comparable", gc)
+	}
+	sharedStats, sharedCycles := runPollCycles(t, pShared)
 
-	// Independent repos scenario.
+	// Independent repos scenario: the same repo count, numSubRepos+1 groups.
 	pIndep := NewGitHeadPoller(pollInterval, func(_ BranchSwitchEvent) {}, nil)
 	for i := 0; i <= numSubRepos; i++ {
 		pIndep.AddRepo(initGitRepo(t))
 	}
-	pIndep.Start()
-	time.Sleep(measureWindow)
-	pIndep.Stop()
-	indepStats := pIndep.StatCalls()
+	if gc := pIndep.GroupCount(); gc != numSubRepos+1 {
+		t.Fatalf("independent: GroupCount want %d (one per repo), got %d", numSubRepos+1, gc)
+	}
+	indepStats, indepCycles := runPollCycles(t, pIndep)
 
-	cycles := int(measureWindow / pollInterval)
-	t.Logf("M1 measurement (%d sub-repos, %s window, ~%d cycles):", numSubRepos, measureWindow, cycles)
-	t.Logf("  Shared common-dir: %d stat calls (want ~%d = 1×cycles)", sharedStats, cycles)
-	t.Logf("  Independent repos: %d stat calls (want ~%d = %d×cycles)", indepStats, cycles*(numSubRepos+1), numSubRepos+1)
+	t.Logf("M1 measurement (%d repos each arm, %s interval):", numSubRepos+1, pollInterval)
+	t.Logf("  Shared common-dir: %d stats over %d cycles = %.2f/cycle", sharedStats, sharedCycles, float64(sharedStats)/float64(sharedCycles))
+	t.Logf("  Independent repos: %d stats over %d cycles = %.2f/cycle", indepStats, indepCycles, float64(indepStats)/float64(indepCycles))
 
-	// Shared: 2 stats per cycle (HEAD + ref file), 1 group.
-	// Allow up to 4× cycles for timing jitter.
-	if sharedStats > uint64(cycles*4) {
-		t.Errorf("shared: too many stat calls — want ≤%d (2/cycle×%d cycles), got %d",
-			cycles*4, cycles, sharedStats)
+	// Shared: 2 stats per GROUP per cycle (HEAD + ref) × 1 group. Exact, not a
+	// 4× ceiling: the old `sharedStats > cycles*4` was a 4× upper bound on a 2×
+	// expectation, so it survived a mutant issuing 50% extra stats and asserted
+	// close to nothing.
+	if want := 2 * sharedCycles; sharedStats != want {
+		t.Errorf("shared: %d stats over %d cycles = %.2f/cycle, want exactly %d (2/cycle: HEAD + ref for the one shared common-dir)",
+			sharedStats, sharedCycles, float64(sharedStats)/float64(sharedCycles), want)
 	}
 
-	// Independent: 2 stats per repo per cycle × (N+1) repos.
-	expectedIndep := uint64(cycles * (numSubRepos + 1))
-	if indepStats < expectedIndep/2 {
-		t.Errorf("independent: too few stat calls — want ≥%d, got %d", expectedIndep/2, indepStats)
+	// Independent: 2 stats per repo per cycle × (N+1) repos — the un-deduped
+	// baseline the shared arm is measured against.
+	if want := 2 * uint64(numSubRepos+1) * indepCycles; indepStats != want {
+		t.Errorf("independent: %d stats over %d cycles = %.2f/cycle, want exactly %d (%d repos × 2 files per cycle)",
+			indepStats, indepCycles, float64(indepStats)/float64(indepCycles), want, numSubRepos+1)
 	}
 
-	// Key ratio: shared (1 group) must be ≥3× cheaper than independent (11 groups).
-	if indepStats > 0 && sharedStats*3 > indepStats {
-		t.Errorf("dedup ratio insufficient: shared=%d indep=%d (need shared ≤ indep/3)",
-			sharedStats, indepStats)
+	// The headline claim, stated as a RATE ratio so the two arms need not have
+	// been granted the same number of ticks. Implied by the two equalities above
+	// when both hold, but it is the number the M1 work exists to move, so it is
+	// asserted directly rather than left to be inferred from a red elsewhere.
+	sharedRate := float64(sharedStats) / float64(sharedCycles)
+	indepRate := float64(indepStats) / float64(indepCycles)
+	if sharedRate*3 > indepRate {
+		t.Errorf("dedup ratio insufficient: shared=%.2f/cycle indep=%.2f/cycle (need shared ≤ indep/3)",
+			sharedRate, indepRate)
 	}
 }

--- a/internal/daemon/watch/githead_poller_test.go
+++ b/internal/daemon/watch/githead_poller_test.go
@@ -293,9 +293,47 @@ func makeSharedCommonDirRepos(t *testing.T, n int) (base string, worktrees []str
 	return base, worktrees
 }
 
+// statsPerCycleFloor is how many poll cycles the two dedup measurements below
+// wait for before they assert. It is a FLOOR ON EVIDENCE, not a rate: the
+// assertion is stats-per-cycle, which is independent of how fast the runner
+// ticks, but a single observed cycle would let a rounding accident pass, so the
+// tests insist on several before believing the ratio.
+const statsPerCycleFloor = 5
+
+// runPollCycles starts p, waits until it has COMPLETED at least
+// statsPerCycleFloor poll cycles, stops it, and returns the stats and cycles
+// observed. Stop() joins the loop goroutine, so no poll can be half-done when
+// the counters are read: every stat those cycles issued is already counted.
+//
+// The wait is a hang guard (eventHangGuard), not a budget — it bounds "the
+// poller ticks at all", and a runner too starved to manage five 50ms ticks in
+// 30s fails loudly here instead of quietly asserting on a sample of one. This
+// is what replaces the old fixed time.Sleep + wall-clock-derived call-count
+// bounds, which a tick-starved Windows runner could only push BELOW their lower
+// bound (#6069).
+func runPollCycles(t *testing.T, p *GitHeadPoller) (stats, cycles uint64) {
+	t.Helper()
+	p.Start()
+	deadline := time.Now().Add(eventHangGuard)
+	for p.PollCycles() < statsPerCycleFloor && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	p.Stop()
+	stats, cycles = p.StatCalls(), p.PollCycles()
+	if cycles < statsPerCycleFloor {
+		t.Fatalf("poller completed only %d cycle(s) in %s (want >= %d) — the runner never granted enough ticks to measure anything",
+			cycles, eventHangGuard, statsPerCycleFloor)
+	}
+	return stats, cycles
+}
+
 // TestCommonDirDedup_SharedRepos_OneStatPerCycle is the primary M1 measurement
 // test. 11 repos (base + 10 linked worktrees) sharing one common-dir must
 // produce 2 stat calls per poll cycle (HEAD + ref), not 22.
+//
+// The measurement is expressed per CYCLE, not per wall-clock interval: how many
+// ticks the machine grants is the runner's business, how many stats the poller
+// issues per tick is the poller's (#6069).
 func TestCommonDirDedup_SharedRepos_OneStatPerCycle(t *testing.T) {
 	const numWorktrees = 10
 	base, worktrees := makeSharedCommonDirRepos(t, numWorktrees)
@@ -311,16 +349,13 @@ func TestCommonDirDedup_SharedRepos_OneStatPerCycle(t *testing.T) {
 		t.Fatalf("GroupCount: want 1 (all repos share common-dir), got %d", gc)
 	}
 
-	p.Start()
-	// Let ~5 poll cycles run (50ms * 5 = 250ms, +slack).
-	time.Sleep(300 * time.Millisecond)
-	p.Stop()
+	stats, cycles := runPollCycles(t, p)
 
-	got := p.StatCalls()
-	// Expect ~10 stat calls (2 per cycle × 5 cycles). Allow [8,18] for jitter.
-	// Without M1 dedup: 11 repos × 2 files × 5 cycles = 110 calls.
-	if got < 8 || got > 18 {
-		t.Errorf("StatCalls: want 8-18 (2/cycle × ~5 cycles), got %d (dedup broken? without dedup: ~110)", got)
+	// 2 stats per GROUP per cycle (HEAD + ref), and dedup collapses all 11 repos
+	// into 1 group. Without M1 dedup this is 22 per cycle.
+	if want := 2 * cycles; stats != want {
+		t.Errorf("StatCalls: %d stats over %d cycles = %.2f/cycle, want exactly %d (2/cycle: HEAD + ref for the single shared common-dir; without dedup it is 22/cycle)",
+			stats, cycles, float64(stats)/float64(cycles), want)
 	}
 }
 
@@ -339,14 +374,16 @@ func TestCommonDirDedup_IndependentRepos_OneStatEachPerCycle(t *testing.T) {
 		t.Fatalf("GroupCount: want %d (one per repo), got %d", numRepos, gc)
 	}
 
-	p.Start()
-	time.Sleep(300 * time.Millisecond)
-	p.Stop()
+	stats, cycles := runPollCycles(t, p)
 
-	got := p.StatCalls()
-	// Expect ~100 stat calls (10 repos × 2 files × 5 cycles). Allow [60,140].
-	if got < 60 || got > 140 {
-		t.Errorf("StatCalls: want 60-140 (10 repos × 2 files × ~5 cycles), got %d", got)
+	// The counterweight to the dedup test: 10 independent repos are 10 groups,
+	// so the poller MUST issue 2 stats each per cycle. An over-eager dedup that
+	// collapsed unrelated repos would show up here as a rate below 20/cycle,
+	// where the old wall-clock bound [60,140] could not tell that apart from a
+	// slow runner.
+	if want := 2 * uint64(numRepos) * cycles; stats != want {
+		t.Errorf("StatCalls: %d stats over %d cycles = %.2f/cycle, want exactly %d (%d repos × 2 files per cycle)",
+			stats, cycles, float64(stats)/float64(cycles), want, numRepos)
 	}
 }
 


### PR DESCRIPTION
Two issues, both in the deferred-arm family that #6067 opened.

## #6068 — a cancel landing mid-flight could still arm work for a deleted group

Both fixes proposed in the issue were rejected, with reasons:

- **"Re-arm under the same hold"** closes `fireGroupAlgo` but *cannot* close `runLinks`. `cfg.Links` is the cross-repo link pass and runs for minutes between the authorising hold and the chained arm; bringing that arm under `s.mu` would serialise every other group in the daemon for the duration. One site fixed, one left open.
- **"Re-check group existence in `scheduleGroupAlgo`"** has no implementation. `Config` exposes only `GroupsForRepo` (keyed by repo, not group), so the scheduler owns no group oracle — and it would be asking the store a question that `CancelGroup` *is* the answer to.

Instead: a **per-group cancel generation** (`groupCancelSeq`). One map read under an already-held lock, no lock-scope change. The guard sits as the first statement after `s.mu.Lock()` in `scheduleGroupAlgoFor`, ahead of the running/rerun branch, so a stale continuation cannot even set `groupAlgoRerun` and resurrect the pass one hop later.

This is **wider than the issue described**: a `CancelGroup` landing anywhere during a link pass now also suppresses the chained group-algo arm, which was previously unguarded.

### The hazard was one hop further upstream than the issue said

Review found `runIndex`'s success path chains `scheduleLinks` after a multi-minute index, outside any lock and with no generation to re-present. Reachable, not theoretical, for two reasons: `CancelGroup` **deliberately leaves running** any reindex whose repo is still referenced by a surviving group, and `cancelGroupWork` runs *before* registry teardown, so there is a real window where `GroupsForRepo` still returns the deleted group. The consequence was Louvain + PageRank + betweenness running ~180s later for a group that no longer exists, under a ctx rooted only at `shutdownCtx` with nothing left to cancel it.

`runIndex` now captures generations in its authorising hold and re-presents them through `scheduleLinksFor`.

### And the first version of that fix had the same shape of hole

The capture was keyed on `startGroups`, so a group *absent* at the hold fell to a permissive `groupGenFresh` default and armed unconditionally — re-opening the hazard through the absent-group branch for a group that joined the repo after the capture and was cancelled before the terminal read.

The fix is to **snapshot the generations, not the membership**: copy `groupCancelSeq` wholesale under the hold and default absent to `0`. The reframe that settles it — **`0` is a meaningful generation, not a "don't know"**. It is the live generation of every group never cancelled, so an absent name makes a real falsifiable claim instead of no claim at all. All three cases then fall out without an exemption: a rejoining previously-cancelled name carries its true generation and arms; a brand-new name gets 0, matches 0, and arms; the hazard case has a stale 0 against a current 1 and gates.

**Over-suppression was the dangerous direction** — a dropped link pass is missing analysis, which is invisible, unlike a crash. Suppression requires a `CancelGroup` inside the index window, and its only two production callers both mean "group deleted". The sole residual is delete-and-recreate inside one index window, which is self-healing (re-registering enqueues the repos) and is the identical exposure the other two call sites already carry. Recorded on `scheduleLinksFor` rather than left for the next reader.

## #6069 — poll-rate assertions measured the runner, not the code

`cycles` was computed from the interval rather than observed, so the tests assumed the runner granted every tick. Replaced with a `pollCycles` atomic and **exact equality** on observed cycles — strictly stronger than the `[8,18]` and `[60,140]` ranges it replaces, and than the `sharedStats > cycles*4` ceiling (a 4x bound on a 2x expectation, which asserted nearly nothing).

Verified with injected latency: at 150ms/cycle the old form fails (`indepStats=44, want ≥55`) while the converted form passes — and notably the two arms were granted *different* tick counts, 7 vs 6, which the per-cycle rate framing absorbs exactly. A 50%-extra-stat mutant now dies on both arms (`3.00/cycle want 2`, `33.00/cycle want 22`) where the old ranges survived it.

The exact equalities are structural, not lucky: `captureInitialSnap` uses bare `os.Stat` rather than `statModTime`, so registration contributes no counted stats and sets `CurrentRef` so cycle 1 issues 2 stats like every other.

## Verification

Every guard is mutation-verified, and the two that matter form a matched pair: **narrowing the snapshot fails by suppressing a live group; widening the exemption fails by arming a dead one.** No remaining form passes both.

| Mutant | Result |
|---|---|
| neuter the gen check | 3 FAIL |
| always-suppress | 5 FAIL, incl. both over-suppression counterweights |
| membership-only snapshot | join-still-arms FAIL |
| restore the `groupGenFresh` exemption | joined-then-cancelled FAIL |
| per-site guards removed individually | one test each — neither guard is load-bearing for the other's |

Fixtures fail loudly rather than vacuously: `deleted`/`entered`/`joined` atomic-bool gates that `t.Fatal` if the window was never reached, plus explicit CONTROL phases asserting a live group still arms, and an `arm2 != arm` check so a cancelled arm id cannot masquerade as a live one.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `internal/daemon/sched` and `internal/daemon/watch` green at `-count=1` and `-race`, verified independently rather than taken from the report.

Two independent adversarial review rounds; the second was scoped to the new surface only.

Closes #6068
Closes #6069
