### PR TITLE
perf(#6060): stop holding the State-global lock across a group revive; memoize the HEAD capture under it

### DIFF
--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -400,11 +400,38 @@ func StateDirForRepoRef(repoPath, ref string) string {
 //
 // The directory is NOT created here; callers that write should
 // os.MkdirAll the returned path.
+//
+// Cost (#6060): the HEAD capture is served through gitmeta.CaptureCached, not
+// the raw gitmeta.Capture. This function is not a cold-start-only helper — it
+// sits under FindGraphFileAnyRef, i.e. under the MCP group revive path, where
+// the ~5 git subprocesses it used to fork per call were measured at ~14 ms and
+// accounted for the whole of a full-reload revive on a THREE-entity graph.
+// CaptureCached is keyed on the repo's HEAD-pointer (path, mtime, size) and the
+// ONLY field consumed here is meta.Ref — which is precisely what a HEAD rewrite
+// changes. Non-git directories are never cached and fall through to a live
+// Capture, preserving prior behaviour exactly.
+//
+// RESIDUAL, stated so the bound is known rather than assumed. The mtime term is
+// what disambiguates two branch switches whose ref names are the SAME LENGTH
+// (the size term does nothing there — see
+// TestCaptureCached_InvalidatesOnEqualLengthHeadSwitch, which exists because
+// dropping mtime from the key passed every other cache test). On a filesystem
+// with coarse mtime granularity — HFS+, FAT/exFAT, some SMB/NFS mounts at 1-2 s
+// — two equal-length branch switches inside a single tick can therefore serve a
+// stale meta.Ref. APFS and ext4 carry ns resolution and are unaffected.
+//
+// This hazard is PRE-EXISTING, not introduced here: CaptureCached already backs
+// routing.go (ResolveCWD) and tools.go (grafel_whoami). Routing this call site
+// through it widens the blast radius rather than creating the hazard, and the
+// consequence here is the mildest of the three: a stale ref makes
+// FindGraphFileAnyRef try the per-ref directories in the wrong ORDER, and its
+// AnyRef fallback still finds the newest indexed graph — "tried the wrong dir
+// first", not "found nothing".
 func StateDirForRepo(repoPath string) string {
 	if repoPath == "" {
 		return ""
 	}
-	meta := gitmeta.Capture(repoPath)
+	meta := gitmeta.CaptureCached(repoPath)
 	return StateDirForRepoRef(repoPath, meta.Ref)
 }
 

--- a/internal/daemon/state_path_6060_test.go
+++ b/internal/daemon/state_path_6060_test.go
@@ -1,0 +1,86 @@
+// state_path_6060_test.go — issue #6060. StateDirForRepo sits under
+// FindGraphFileAnyRef, i.e. under the MCP cold-wake group revive. Its HEAD
+// capture used to fork ~5 git subprocesses on EVERY call (~14 ms measured),
+// which was the entirety of the full-reload revive cost on a 3-entity graph.
+package daemon
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// initGitRepo6060 creates a real git repo with one commit on branch "main".
+func initGitRepo6060(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runIn := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runIn("init")
+	runIn("checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn("add", ".")
+	runIn("commit", "-m", "init")
+	return dir
+}
+
+// A repeat StateDirForRepo on an unchanged HEAD must not shell out to git.
+//
+// Proof the fixture can fail: with the raw gitmeta.Capture restored, the second
+// call re-runs git — which is now absent from PATH — so meta.Ref comes back
+// empty and the resolved directory collapses to the "_unknown" ref sentinel,
+// diverging from the primed value.
+func TestStateDirForRepo_NoGitSubprocessOnRepeatCall(t *testing.T) {
+	dir := initGitRepo6060(t)
+
+	primed := StateDirForRepo(dir)
+	if primed == "" {
+		t.Fatal("priming call returned empty state dir")
+	}
+	wantRef := StateDirForRepoRef(dir, "main")
+	if primed != wantRef {
+		t.Fatalf("priming call resolved an unexpected ref dir:\n got  %s\n want %s", primed, wantRef)
+	}
+
+	// Remove git from PATH: any live capture from here on yields a zero Info,
+	// which would resolve to the "_unknown" ref sentinel instead of "main".
+	t.Setenv("PATH", "")
+	if got := StateDirForRepo(dir); got != primed {
+		t.Errorf("repeat StateDirForRepo re-forked git on an unchanged HEAD:\n got  %s\n want %s", got, primed)
+	}
+}
+
+// The memo must not outlive a HEAD move: a checkout onto a new branch has to be
+// reflected in the resolved per-ref directory.
+func TestStateDirForRepo_FollowsHeadMove(t *testing.T) {
+	dir := initGitRepo6060(t)
+
+	before := StateDirForRepo(dir)
+	if before != StateDirForRepoRef(dir, "main") {
+		t.Fatalf("unexpected pre-checkout dir %s", before)
+	}
+
+	cmd := exec.Command("git", "checkout", "-b", "feature")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout: %v\n%s", err, out)
+	}
+
+	after := StateDirForRepo(dir)
+	if want := StateDirForRepoRef(dir, "feature"); after != want {
+		t.Errorf("state dir did not follow the HEAD move:\n got  %s\n want %s", after, want)
+	}
+}

--- a/internal/gitmeta/cache_test.go
+++ b/internal/gitmeta/cache_test.go
@@ -103,6 +103,66 @@ func TestCaptureCached_InvalidatesOnHeadChange(t *testing.T) {
 	}
 }
 
+// TestCaptureCached_InvalidatesOnEqualLengthHeadSwitch pins the MTIME term of
+// the cache key (#6060).
+//
+// Every other cache test switches between refs of DIFFERENT length
+// ("main" -> "feature/x", "main" -> "other"), which changes HEAD's SIZE — so the
+// size term alone disambiguates them and the whole suite passes even with mtime
+// deleted from headKey. That makes "the cache self-invalidates on any checkout"
+// an unpinned claim, which is exactly the kind of fixture-cannot-fail gap this
+// test closes: "main" -> "mian" is a real branch switch that the size term
+// CANNOT see, so only mtime can catch it.
+//
+// The size assertion below is load-bearing, not decoration: without it a future
+// rename of either branch could silently restore the size term and turn this
+// test back into a duplicate of TestCaptureCached_InvalidatesOnHeadChange.
+//
+// Proof the fixture can fail: deleting the mtime field from headKey (leaving
+// {path, size}) leaves every other test in this package green and fails only
+// this one, with "stale ref served".
+func TestCaptureCached_InvalidatesOnEqualLengthHeadSwitch(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	headPath := filepath.Join(dir, ".git", "HEAD")
+	sizeBefore := statSize(t, headPath)
+
+	first := CaptureCached(dir)
+	if first.Ref != "main" {
+		t.Fatalf("expected ref main, got %q", first.Ref)
+	}
+
+	// "mian" is the same length as "main", so HEAD's size is unchanged and only
+	// its mtime distinguishes the two states.
+	time.Sleep(10 * time.Millisecond) // distinct mtime on coarse-granularity clocks
+	cmd := exec.Command("git", "checkout", "-b", "mian")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout: %v\n%s", err, out)
+	}
+
+	if sizeAfter := statSize(t, headPath); sizeAfter != sizeBefore {
+		t.Fatalf("HEAD size changed %d -> %d: the refs are not equal-length, so this "+
+			"fixture cannot prove the mtime term is load-bearing", sizeBefore, sizeAfter)
+	}
+
+	got := CaptureCached(dir)
+	if got.Ref != "mian" {
+		t.Fatalf("stale ref served after an equal-length branch switch: got %q want mian "+
+			"(the mtime term of headKey is not doing its job)", got.Ref)
+	}
+}
+
+func statSize(t *testing.T, path string) int64 {
+	t.Helper()
+	fi, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	return fi.Size()
+}
+
 // BenchmarkCapture_vs_CaptureCached documents the steady-state speedup: the
 // cached path is a single os.Stat vs ~5 git subprocesses.
 func BenchmarkCaptureUncached(b *testing.B) {

--- a/internal/mcp/group_lock_scope_6060_test.go
+++ b/internal/mcp/group_lock_scope_6060_test.go
@@ -1,0 +1,285 @@
+// group_lock_scope_6060_test.go — issue #6060. State.Group used to hold the
+// State-global s.mu across the whole cold-wake revive, so a revive of group A
+// blocked every call to group B — head-of-line blocking across the fleet, on a
+// server whose consumers are concurrent agents.
+//
+// Three properties are pinned here, and each one is what makes the NEXT one
+// safe to have:
+//
+//   - TestGroup_ColdWakeDoesNotBlockOtherGroups — the revive really is outside
+//     the State-global lock.
+//   - TestGroup_ConcurrentRevivesMaterializeOnce — dropping that lock did not
+//     let two goroutines rebuild the same group (the per-group gate).
+//   - TestGroup_NoCallerObservesHalfRevivedGroup — nor let anyone SEE the group
+//     before it was finished. This is the one that matters most: a half-revived
+//     group is a wrong-results bug, not a crash, so it would not announce
+//     itself.
+//
+// Each test documents the concrete edit that makes it fail; all three were
+// confirmed to fail against that edit rather than assumed to.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+func TestGroup_ColdWakeDoesNotBlockOtherGroups(t *testing.T) {
+	st := seedTwoGroups(t)
+
+	// Both groups warm, then evict A only.
+	if st.Group("a") == nil || st.Group("b") == nil {
+		t.Fatal("warm-up returned nil group")
+	}
+	if !st.EvictGroup("a", true) {
+		t.Fatal("EvictGroup(a) returned false")
+	}
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	reviveMaterializeHook = func(name string) {
+		if name != "a" {
+			return
+		}
+		close(parked)
+		<-release
+	}
+	t.Cleanup(func() { reviveMaterializeHook = nil })
+
+	reviveDone := make(chan struct{})
+	go func() {
+		defer close(reviveDone)
+		if st.Group("a") == nil {
+			t.Error("revive of a returned nil")
+		}
+	}()
+
+	select {
+	case <-parked:
+	case <-time.After(10 * time.Second):
+		close(release)
+		t.Fatal("revive of a never reached the materialization window")
+	}
+
+	// A is parked mid-revive. A call to the untouched, resident group b must not
+	// wait on it.
+	bDone := make(chan struct{})
+	go func() {
+		defer close(bDone)
+		if st.Group("b") == nil {
+			t.Error("Group(b) returned nil")
+		}
+	}()
+
+	select {
+	case <-bDone:
+	case <-time.After(5 * time.Second):
+		close(release)
+		<-reviveDone
+		t.Fatal("call to group b blocked behind group a's revive — State.Group is holding the State-global lock across the revive")
+	}
+
+	close(release)
+	<-reviveDone
+	if !st.groupResident("a") {
+		t.Error("group a not resident after revive")
+	}
+}
+
+// Singleflight pin. Concurrent revives of the SAME group must materialize the
+// dropped heap exactly once and every caller must observe the same, fully
+// materialized group — never a half-revived one. The per-group gate is what
+// replaces "everything under one global lock" here.
+func TestGroup_ConcurrentRevivesMaterializeOnce(t *testing.T) {
+	doc := lazyTestDoc()
+	st, _, _ := seedRepoOnDisk(t, doc)
+	if st.Group("test") == nil {
+		t.Fatal("warm Group returned nil")
+	}
+	if !st.EvictGroup("test", true) {
+		t.Fatal("EvictGroup returned false")
+	}
+
+	var materializations atomic.Int64
+	reviveMaterializeHook = func(string) {
+		materializations.Add(1)
+		// Widen the window so a missing gate is actually observed.
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Cleanup(func() { reviveMaterializeHook = nil })
+
+	const goroutines = 8
+	var wg sync.WaitGroup
+	got := make([]*LoadedGroup, goroutines)
+	start := make(chan struct{})
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			got[i] = st.Group("test")
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	if n := materializations.Load(); n != 1 {
+		t.Errorf("revive materialized %d times under %d concurrent callers; want exactly 1", n, goroutines)
+	}
+	for i, g := range got {
+		if g == nil {
+			t.Fatalf("goroutine %d got a nil group", i)
+		}
+		if g != got[0] {
+			t.Errorf("goroutine %d observed a different group instance — revive was not single-flighted", i)
+		}
+		// Fully materialized, not half: the LabelIndex dropped by the eviction is back.
+		lr := g.Repos["r"]
+		if lr == nil || lr.LabelIndex == nil {
+			t.Fatalf("goroutine %d observed a half-revived group (nil LabelIndex)", i)
+		}
+	}
+}
+
+// Publication-ordering pin (#6060). Dropping s.mu for the materialization window
+// is only safe because the group stays parked in s.evicted — invisible to
+// lookups — until it is FULLY materialized. This test parks a revive at the top
+// of that window and requires that a second caller arriving mid-window never
+// observes the group in s.groups carrying the LabelIndex the eviction dropped.
+//
+// Proof the fixture can fail: publishing `s.groups[name] = cold` BEFORE the
+// rematerializeFromReader loop (instead of after) makes the second caller return
+// immediately with a nil LabelIndex and this test fails with "observed a
+// half-revived group".
+func TestGroup_NoCallerObservesHalfRevivedGroup(t *testing.T) {
+	doc := lazyTestDoc()
+	st, _, _ := seedRepoOnDisk(t, doc)
+	if st.Group("test") == nil {
+		t.Fatal("warm Group returned nil")
+	}
+	if !st.EvictGroup("test", true) {
+		t.Fatal("EvictGroup returned false")
+	}
+	// Sanity: the eviction really did drop the heap the observer checks for, so a
+	// half-revived observation is distinguishable from a complete one.
+	st.mu.Lock()
+	shell := st.evicted["test"]
+	st.mu.Unlock()
+	if shell == nil || shell.Repos["r"] == nil {
+		t.Fatal("no cold shell after keepReader evict")
+	}
+	if shell.Repos["r"].LabelIndex != nil {
+		t.Fatal("cold shell kept its LabelIndex — this fixture cannot detect a half-revive")
+	}
+
+	parked := make(chan struct{})
+	release := make(chan struct{})
+	reviveMaterializeHook = func(string) {
+		close(parked)
+		<-release
+	}
+	t.Cleanup(func() { reviveMaterializeHook = nil })
+
+	reviveDone := make(chan struct{})
+	go func() {
+		defer close(reviveDone)
+		_ = st.Group("test")
+	}()
+	select {
+	case <-parked:
+	case <-time.After(10 * time.Second):
+		close(release)
+		t.Fatal("revive never reached the materialization window")
+	}
+
+	// A second caller arriving mid-window. Either it blocks on the per-group gate
+	// (correct) or it observes whatever is in s.groups (the regression).
+	observed := make(chan bool, 1) // true == LabelIndex present
+	go func() {
+		g := st.Group("test")
+		if g == nil {
+			observed <- false
+			return
+		}
+		lr := g.Repos["r"]
+		lr.rmu().Lock()
+		ok := lr.LabelIndex != nil
+		lr.rmu().Unlock()
+		observed <- ok
+	}()
+
+	select {
+	case complete := <-observed:
+		// Returned while the revive is still parked ⇒ it read s.groups mid-revive.
+		close(release)
+		<-reviveDone
+		if !complete {
+			t.Fatal("second caller observed a half-revived group (nil LabelIndex) published before materialization completed")
+		}
+		t.Fatal("second caller returned while the revive was still parked — the group was published before it was materialized")
+	case <-time.After(500 * time.Millisecond):
+		// Correctly blocked on the per-group gate.
+	}
+
+	close(release)
+	<-reviveDone
+	if complete := <-observed; !complete {
+		t.Error("second caller observed a group with no LabelIndex after the revive completed")
+	}
+}
+
+// seedTwoGroups builds a State with two independent single-repo groups ("a",
+// "b"), each with a real graph.fb on disk, both resident.
+func seedTwoGroups(t *testing.T) *State {
+	t.Helper()
+	reg := &Registry{Groups: map[string]RegistryGroup{}}
+	type seeded struct {
+		lr *LoadedRepo
+	}
+	seeds := map[string]seeded{}
+	for _, name := range []string{"a", "b"} {
+		repoDir := t.TempDir()
+		stateDir := daemon.StateDirForRepo(repoDir)
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state dir: %v", err)
+		}
+		fbPath := filepath.Join(stateDir, "graph.fb")
+		doc := lazyTestDoc()
+		if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+			t.Fatalf("write fb: %v", err)
+		}
+		fi, err := os.Stat(fbPath)
+		if err != nil {
+			t.Fatalf("stat fb: %v", err)
+		}
+		hash, err := hashGraphFile(fbPath)
+		if err != nil {
+			t.Fatalf("hash fb: %v", err)
+		}
+		reg.Groups[name] = RegistryGroup{Repos: map[string]RegistryRepo{"r": {Path: repoDir}}}
+		seeds[name] = seeded{lr: &LoadedRepo{
+			Repo:        "r",
+			Path:        repoDir,
+			GraphFile:   fbPath,
+			Doc:         doc,
+			LabelIndex:  BuildLabelIndex(doc),
+			mtime:       fi.ModTime(),
+			contentHash: hash,
+		}}
+	}
+	st := NewState(reg)
+	st.mu.Lock()
+	for name, s := range seeds {
+		st.groups[name] = &LoadedGroup{Name: name, Repos: map[string]*LoadedRepo{"r": s.lr}}
+	}
+	st.mu.Unlock()
+	t.Cleanup(st.Close)
+	return st
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1118,6 +1118,26 @@ type State struct {
 	// lives here in PR1 — this is the eviction PRIMITIVE's bookkeeping only.
 	evicted map[string]*LoadedGroup
 
+	// reviveGates holds one mutex PER GROUP NAME, single-flighting that group's
+	// cold-wake revive (issue #6060). It is what replaces "the whole revive runs
+	// under one State-global lock":
+	//
+	//   - MUTUAL EXCLUSION per group — at most one goroutine materializes a given
+	//     group's dropped heap; the rest block here and, on entry, re-observe the
+	//     now-resident group under s.mu.
+	//   - ISOLATION between groups — a cold wake of group A takes only A's gate,
+	//     so it can never stall a call to group B (the head-of-line blocking this
+	//     field exists to remove).
+	//
+	// LOCK ORDER: reviveGates[name] is ALWAYS acquired with s.mu NOT held, and
+	// s.mu may be acquired while it is held. The order is gate -> s.mu, never the
+	// reverse, so it cannot invert against any other State critical section.
+	//
+	// The map itself is mutated only under s.mu; the mutexes it hands out are
+	// stable for the life of the State (one per group name ever revived — bounded
+	// by the registry, so no unbounded growth).
+	reviveGates map[string]*sync.Mutex
+
 	// CrossLinkCache is the ref-keyed in-memory cache for cross-repo link
 	// candidates (issue #2224). Keyed by (repoA, refA, repoB, refB); the
 	// secondary index allows O(affected-entries) invalidation on ref-switch.
@@ -1705,40 +1725,182 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 // missing overlay → no re-apply (today's behavior). Runs under s.mu, the same
 // lock applyGroupAlgoOverlay holds during Reload, so the shared apply/memo
 // fields are mutated race-free.
+//
+// Lock scope (issue #6060). This used to hold the State-GLOBAL s.mu across the
+// whole cold-wake revive, so a revive of group A blocked every call to every
+// other group — head-of-line blocking across the fleet, which is exactly the
+// wrong shape for a server whose consumers are concurrent agents. The warm path
+// (the overwhelmingly common one) still runs entirely under s.mu because it is
+// three memoized stats; the COLD path now:
+//
+//  1. observes the miss under s.mu, takes a PER-GROUP revive gate, and releases
+//     s.mu before doing any work;
+//  2. re-checks under s.mu after the gate (another goroutine may have finished
+//     the revive while this one queued);
+//  3. materializes the keepReader heap OUTSIDE s.mu, then publishes it into
+//     s.groups in one map write under s.mu.
+//
+// The invariant that replaces "everything under one global lock" is:
+//
+//   - s.mu still guards EVERY read and write of s.groups / s.evicted, so no
+//     caller can observe a partially populated map;
+//   - a group is published into s.groups only AFTER it is fully materialized, so
+//     no caller can observe a half-revived group — the shell stays parked in
+//     s.evicted (invisible to lookups, still drained by Close) for the whole
+//     materialization window;
+//   - the per-group gate makes the materialization itself single-flighted, so two
+//     concurrent revives of the same group cannot both rebuild the same heap;
+//   - the mmap deref/munmap ordering was never s.mu's job — readerMu is the
+//     strictly-innermost lock that pairs BuildLabelIndexFromReader against
+//     retireHandle/publishHandle, and it is unchanged here.
+//
+// The full-evict (cold == nil) revive still runs under s.mu: it goes through
+// reloadAllLocked, which mutates the registry, the registry signature and every
+// resident group, and is not a per-group operation.
+//
+// KNOWN RESIDUAL — revive racing Close. A Group call that is already past its
+// s.groups miss when Close runs will publish a group into a closed State. This
+// is PRE-EXISTING, not introduced here: before this change a Group() call
+// arriving after Close() resurrected a group identically, because Close does not
+// mark the State closed and reloadAllLocked/reviveEvictedLocked are happy to
+// repopulate s.groups afterwards. What changed is the WIDTH of the window — the
+// materialization now happens with s.mu released, so a Close can land in the
+// middle of it rather than only before or after. The consequence is bounded:
+// Close retires each repo's handle under readerMu, so the revive observes
+// lr.Reader == nil and falls back to BuildLabelIndex(lr.Doc). Under
+// GRAFEL_SERVE_FROM_MMAP (default OFF) the Doc still carries the rows, so the
+// resurrected group is correct; with mmap serving ON the rows were skeletonized
+// away and the group is resident-but-empty. Fixing it properly means a closed
+// flag on State that Group honours, which is a lifecycle change, not a locking
+// one — out of scope here and deliberately left as a comment rather than a
+// silent assumption.
 func (s *State) Group(name string) *LoadedGroup {
 	s.mu.Lock()
-	defer s.mu.Unlock()
-	grp := s.groups[name]
-	if grp == nil {
-		// Cold-gate revive (memory epic #5850, issue #5872 PR1): a group EvictGroup
-		// reclaimed is absent from s.groups and pinned in s.evicted. An explicit
-		// access is exactly the "touch" that ends the eviction — bring it back on
-		// demand (re-materialize from the retained Reader, or reload from disk).
-		if cold, gated := s.evicted[name]; gated {
-			grp = s.reviveEvictedLocked(name, cold)
+	if grp := s.groups[name]; grp != nil {
+		s.touchGroupLocked(grp)
+		s.mu.Unlock()
+		return grp
+	}
+	// Cold-gate revive (memory epic #5850, issue #5872 PR1): a group EvictGroup
+	// reclaimed is absent from s.groups and pinned in s.evicted. An explicit
+	// access is exactly the "touch" that ends the eviction — bring it back on
+	// demand (re-materialize from the retained Reader, or reload from disk).
+	if _, gated := s.evicted[name]; !gated {
+		s.mu.Unlock()
+		return nil
+	}
+	gate := s.reviveGateLocked(name)
+	s.mu.Unlock()
+
+	// gate -> s.mu, never the reverse (see State.reviveGates).
+	gate.Lock()
+	defer gate.Unlock()
+
+	s.mu.Lock()
+	// Re-check: a revive that was already in flight when we queued on the gate
+	// may have published the group by now.
+	if grp := s.groups[name]; grp != nil {
+		s.touchGroupLocked(grp)
+		s.mu.Unlock()
+		return grp
+	}
+	cold, gated := s.evicted[name]
+	if !gated {
+		s.mu.Unlock()
+		return nil
+	}
+	if cold == nil {
+		// Full evict: reload from disk. reloadAllLocked is a whole-State operation
+		// (registry refresh, every resident group, tool-surface signature), so it
+		// stays under s.mu.
+		grp := s.reviveEvictedLocked(name, nil)
+		if grp != nil {
+			s.touchGroupLocked(grp)
+		}
+		s.mu.Unlock()
+		return grp
+	}
+	s.mu.Unlock()
+
+	// keepReader: rebuild each repo's dropped heap from its retained, still-mapped
+	// Reader with s.mu RELEASED. The shell is reachable only through s.evicted,
+	// which no lookup consults for serving and which only a revive (gated above)
+	// mutates, so nobody can observe it mid-materialization.
+	if hook := reviveMaterializeHook; hook != nil {
+		hook(name)
+	}
+	for _, lr := range cold.Repos {
+		if lr != nil {
+			lr.rematerializeFromReader()
 		}
 	}
-	if grp != nil {
-		// Stamp the LRU/PIN signal on every routing decision (issue #5872 PR2).
-		// This is the per-call choke point, so the group with the newest lastAccess
-		// is definitionally the active working set — SweepIdleGroups pins it. It is
-		// also why a group queried within the idle window is never idle-evicted, and
-		// why a revive (below) immediately re-arms the signal for the freshly
-		// re-materialized group.
-		grp.lastAccess = time.Now()
-		s.refreshGroupAlgoOverlayLocked(grp)
-		// Re-check the per-repo description side-table mtimes on the serving path so
-		// a write-back that advanced <stateDir>/descriptions.json mid-session takes
-		// effect without a full Reload (mirrors refreshGroupAlgoOverlayLocked). The
-		// per-repo memo inside applyDescriptionOverlay keeps the steady state a
-		// cheap stat-and-skip.
-		applyDescriptionOverlay(grp)
-		// Re-check the per-repo flow side-table on the serving path so a phantom
-		// write-back that advanced <stateDir>/flows.json mid-session takes effect
-		// (REPLACE) without a full Reload. Per-repo memoized → cheap stat-and-skip.
-		applyFlowOverlay(grp)
+
+	s.mu.Lock()
+	delete(s.evicted, name)
+	s.groups[name] = cold
+	s.touchGroupLocked(cold)
+	s.mu.Unlock()
+	return cold
+}
+
+// reviveGateLocked returns the per-group revive mutex for name, creating it on
+// first use. Caller MUST hold s.mu; the returned mutex MUST be acquired only
+// after s.mu is released (lock order gate -> s.mu, see State.reviveGates).
+func (s *State) reviveGateLocked(name string) *sync.Mutex {
+	if s.reviveGates == nil {
+		s.reviveGates = map[string]*sync.Mutex{}
 	}
-	return grp
+	g, ok := s.reviveGates[name]
+	if !ok {
+		g = &sync.Mutex{}
+		s.reviveGates[name] = g
+	}
+	return g
+}
+
+// reviveMaterializeHook, when non-nil, is invoked with the group name inside the
+// revive's materialization window — the window issue #6060 moved OUT from under
+// the State-global s.mu. TEST-ONLY seam, always nil in production: it exists so a
+// test can park a revive of group A there and prove a call to group B still
+// completes. If the materialization is ever moved back under s.mu that test
+// deadlocks, which is the regression signal.
+var reviveMaterializeHook func(name string)
+
+// touchGroupLocked stamps the LRU/PIN signal and re-checks the three memoized
+// side-table overlays for grp. Caller MUST hold s.mu.
+//
+// Cost (issue #6060): each of these is memoized to a stat-and-skip in the steady
+// state, which is why the WARM serving path can afford to run them under the
+// State-global lock. The dominant per-call cost is NOT the stat — it is that
+// both side-table overlays resolve their state directory through
+// daemon.StateDirForRepo, whose HEAD capture forks git subprocesses. That
+// resolution is now memoized inside gitmeta (CaptureCached, see
+// daemon.StateDirForRepo), which is what makes the steady state actually cheap
+// rather than merely described as cheap. Sourcing the directory from the repo's
+// already-discovered graph file instead — which would remove the call entirely,
+// and which the reader/writer pairing arguably requires — is deliberately NOT
+// done here: it changes which directory the daemon reads durable side-tables
+// from, so it belongs with the matching writer change, not in a lock-scope
+// commit.
+func (s *State) touchGroupLocked(grp *LoadedGroup) {
+	// Stamp the LRU/PIN signal on every routing decision (issue #5872 PR2).
+	// This is the per-call choke point, so the group with the newest lastAccess
+	// is definitionally the active working set — SweepIdleGroups pins it. It is
+	// also why a group queried within the idle window is never idle-evicted, and
+	// why a revive immediately re-arms the signal for the freshly re-materialized
+	// group.
+	grp.lastAccess = time.Now()
+	s.refreshGroupAlgoOverlayLocked(grp)
+	// Re-check the per-repo description side-table mtimes on the serving path so
+	// a write-back that advanced <stateDir>/descriptions.json mid-session takes
+	// effect without a full Reload (mirrors refreshGroupAlgoOverlayLocked). The
+	// per-repo memo inside applyDescriptionOverlay keeps the steady state a
+	// cheap stat-and-skip.
+	applyDescriptionOverlay(grp)
+	// Re-check the per-repo flow side-table on the serving path so a phantom
+	// write-back that advanced <stateDir>/flows.json mid-session takes effect
+	// (REPLACE) without a full Reload. Per-repo memoized → cheap stat-and-skip.
+	applyFlowOverlay(grp)
 }
 
 // EvictGroup reclaims the resident graph of group name — the per-group whole-graph
@@ -1874,7 +2036,7 @@ func (s *State) reviveEvictedLocked(name string, cold *LoadedGroup) *LoadedGroup
 		// still-mapped Reader — no fbreader.Open, no disk re-read — then reinstall.
 		for _, lr := range cold.Repos {
 			if lr != nil {
-				lr.rematerializeFromReaderLocked()
+				lr.rematerializeFromReader()
 			}
 		}
 		s.groups[name] = cold
@@ -1887,15 +2049,25 @@ func (s *State) reviveEvictedLocked(name string, cold *LoadedGroup) *LoadedGroup
 	return s.groups[name]
 }
 
-// rematerializeFromReaderLocked rebuilds the heap indexes dropped by a keepReader
+// rematerializeFromReader rebuilds the heap indexes dropped by a keepReader
 // eviction from this repo's retained mmap Reader, mirroring reloadLocked's
-// LabelIndex wiring. Caller MUST hold s.mu. No fbreader.Open and no disk read: the
-// Reader is the same mapping the eviction kept resident. The lazy derived indexes
+// LabelIndex wiring. No fbreader.Open and no disk read: the Reader is the same
+// mapping the eviction kept resident. The lazy derived indexes
 // (adjacency/BM25/byID/…) are left for their getters to rebuild on first use
 // (resetIndexes re-arms the Once guards). The group-algo overlay side-table is
 // re-applied by the caller's refreshGroupAlgoOverlayLocked (forced via the shell's
 // algoApplied=false).
-func (lr *LoadedRepo) rematerializeFromReaderLocked() {
+//
+// Locking (issue #6060): the caller does NOT need to hold s.mu. It was called
+// under s.mu when it lived inside State.Group's global critical section, but s.mu
+// was never what made it safe — the mmap deref/munmap ordering is carried by
+// readerMu, the strictly-innermost lock this takes around
+// BuildLabelIndexFromReader and that retireHandle/publishHandle take around the
+// munmap. A concurrent Close therefore either retires first (lr.Reader observed
+// nil here → Doc fallback) or waits for this build to finish; it can never unmap
+// underneath the iteration. The caller (State.Group's cold path) additionally
+// holds that group's revive gate, so no second goroutine rebuilds the same repo.
+func (lr *LoadedRepo) rematerializeFromReader() {
 	lr.rmu().Lock()
 	if lr.Reader != nil {
 		li := BuildLabelIndexFromReader(lr.Reader, lr.Doc)


### PR DESCRIPTION
`State.Group()` held the State-**global** `s.mu` across the whole revive, so a cold wake of *one* group blocked calls to *every* group — head-of-line blocking across the entire fleet, not just added latency on the reviving call. For a tool whose primary consumer is concurrent MCP agents, that is the wrong shape.

## Measuring first changed what the fix is

The 31-79 ms revive was assumed to be graph work. It is not. It is `daemon.StateDirForRepo` → `gitmeta.Capture`, which forks ~5 git subprocesses:

| | cost |
|---|---|
| rematerialize | 0.009 ms |
| overlays | ~99% of the revive |

`applyDescriptionOverlay` and `applyFlowOverlay` each re-resolved the repo's state dir that way, per repo, on **every** `State.Group` call — **warm calls included**, not just revives. So the "memoised stat-and-skip" steady state was really two git-fork storms per repo per routing decision.

The issue also *understated* production cost. The 31-79 ms figures came from a non-git temp fixture, where git fails fast. On a real checkout a raw `Capture` measures ~82 ms.

So the lock scope was the secondary problem. The primary one was that the revive was expensive for a reason nobody had looked at.

## What this branch does

1. **`daemon.StateDirForRepo` → `gitmeta.CaptureCached`**, keyed on HEAD-pointer mtime. The only field consumed is `meta.Ref`, which is exactly what a HEAD rewrite changes.
2. **Lock scope.** The warm path stays wholly under `s.mu` (now genuinely three stats). The cold path takes a **per-group revive gate**, releases `s.mu`, materializes outside the global lock, and publishes into `s.groups` in one map write under `s.mu`. The full-evict revive **stays** under `s.mu` — it goes through `reloadAllLocked`, a whole-State operation, not a per-group one.

**The invariant replacing "everything under one global lock":** `s.mu` still guards every read and write of `s.groups`/`s.evicted`; a group is published only *after* full materialization, with the shell parked in `s.evicted` — invisible to lookups, still drained by `Close` — for the whole window; the per-group gate single-flights materialization so a revive is never dropped or duplicated; and mmap deref/munmap ordering was never `s.mu`'s job (`readerMu` remains strictly innermost, pairing `BuildLabelIndexFromReader` against `retireHandle`). Lock order is **gate → s.mu, never the reverse**.

## The failure mode that mattered more than the latency

A locking change that lets a caller observe a half-revived group is a wrong-results bug, not a crash — it surfaces as bad query output, not a stack trace.

**The mutant that publishes into `s.groups` before materializing initially SURVIVED all three concurrency tests.** `TestGroup_NoCallerObservesHalfRevivedGroup` was added for it, and asserts up front that the cold shell genuinely dropped its `LabelIndex`, so the fixture cannot silently stop being able to detect the thing it names.

Independent review enumerated all 22 `s.groups` accesses and every `s.evicted` access, traced both `Close`-racing-revive interleavings (no mmap leak: the handle is in exactly one map at all times; no use-after-munmap: `retireHandle` nils `lr.Reader` under `readerMu` so materialization takes the `BuildLabelIndex(lr.Doc)` branch), and confirmed the gate cannot leak even on panic — `defer gate.Unlock()` covers every return, and a partially materialized shell stays in `s.evicted` for the next revive to redo idempotently.

## Mutation battery

| Mutant | Result |
|---|---|
| materialize back under `s.mu` | killed — "call to group b blocked behind group a's revive" |
| per-group gate defeated | killed — "materialized 8 times under 8 concurrent callers; want exactly 1" |
| post-gate re-check removed | killed |
| publish before materialize | killed — by the test added specifically for it |
| `CaptureCached` → `Capture` | killed — `refs/main` resolves to `refs/_unknown` |
| **mtime dropped from `headKey`** | killed by exactly one test — see below |

The mtime key was initially pinned by nothing: every fixture switched between refs of *different length* (`main`→`feature`), so `HEAD`'s size changed 21→24 bytes and disambiguated on its own. `TestCaptureCached_InvalidatesOnEqualLengthHeadSwitch` (`main`→`mian`) makes the mtime term load-bearing, with a HEAD-size assertion so a future branch rename cannot silently restore the size term.

The coarse-mtime residual is documented at the call site: on a filesystem with 1-2 s mtime resolution, two equal-length ref switches inside one tick can serve a stale `meta.Ref`. Pre-existing — `CaptureCached` already backed several call sites — and bounded by `FindGraphFileAnyRef` falling back across refs, so the consequence is "tried the ref dirs in the wrong order", not "found nothing".

## Perf claims, stated honestly

**This branch's benefit is production-only and unobservable in CI.** `CaptureCached` cannot cache a non-git temp dir (`headPointerKey` returns `ok=false` → live `Capture`), and every `internal/mcp` fixture is a non-git temp dir. Independent measurement: `internal/mcp` takes ~429 s both with and without this change.

What *is* independently reproduced is the mechanism and the call counts — 2 forks per keepReader revive, 4 per full revive, 10 per 5 warm calls before the fix, 0 warm forks after — plus a direct `StateDirForRepo` measurement on a real git repo (~82 ms → ~0.063 ms). `resolveGroupKeepReader()` defaults to **true**, so the optimized path is the production default.

No suite-level A/B was produced; it does not fit the machine's memory budget. All millisecond figures were taken at ~95% swap, so only the ratios and fork counts should be treated as trustworthy.

`TestEvictGroup_ConcurrentReadNoFault_FlagOn` at ~152 s on this branch was checked against `main` at ~143.6 s — pre-existing and within noise for a git-fork-bound test, not a regression here.

## Scope

The `repoStateDir` reader change that originally rode along here has been **split out**. It is a semantic change to which directory the daemon reads durable side-tables from, and landing it reader-only silently lost dashboard-written descriptions. It now lives on its own branch with its writer, and is not part of this PR. Verified by review: this branch leaves both overlays on `daemon.StateDirForRepo`, identical to `main`, so reader and writer remain self-consistent and this branch is independently correct.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `internal/mcp` (428.9 s), `internal/daemon`, `internal/gitmeta`, `internal/graph/descriptions`, `internal/graph/flows` all green at `-count=1 -p 1`, verified independently rather than taken from the report.

Two independent adversarial review rounds.

Refs #6060
