### PR TITLE
fix(#6060): un-pin graph discovery, then pair the description side-table on the discovered dir

### DIFF
--- a/internal/dashboard/enrichment_statedir_6060_test.go
+++ b/internal/dashboard/enrichment_statedir_6060_test.go
@@ -1,0 +1,156 @@
+// enrichment_statedir_6060_test.go — issue #6060, writer half of the
+// description side-table's reader/writer pairing.
+//
+// The reader (mcp.applyDescriptionOverlay via repoStateDir) resolves the sidecar
+// from the directory the graph was DISCOVERED in, which under #3648's AnyRef
+// fallback need not be the current-HEAD per-ref directory. The write-back
+// endpoint must resolve the same way or the write is silently lost: it reports
+// success, the in-memory PropSet makes it visible, and it is gone after the next
+// reload with no error anywhere.
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/descriptions"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// HANDLER-level pin (#6060). The two tests below exercise enrichmentStateDir in
+// isolation; this one drives the actual endpoint, which is where the fix has to
+// take effect. Without it, reverting the single production line that IS the fix
+// — `enrichmentStateDir(found.repoPath)` back to
+// `daemon.StateDirForRepo(found.repoPath)` — leaves the whole package green.
+//
+// Proof the fixture can fail: that revert makes descriptions.json land in the
+// current-HEAD "_unknown" dir and this test reports the sidecar missing from the
+// directory the reader will look in.
+func TestWriteback_PersistsSidecarIntoDiscoveredGraphDir(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	repoDir := t.TempDir() // not a git checkout -> current ref is the _unknown sentinel
+
+	currentHeadDir := daemon.StateDirForRepo(repoDir)
+	indexedDir := daemon.StateDirForRepoRef(repoDir, "main")
+	if currentHeadDir == indexedDir {
+		t.Fatal("fixture degenerate: current-HEAD and indexed ref dirs are identical")
+	}
+
+	// The graph exists ONLY under the indexed ref, so the MCP reader resolves
+	// indexedDir and the write must follow it there.
+	if err := os.MkdirAll(indexedDir, 0o755); err != nil {
+		t.Fatalf("mkdir indexed dir: %v", err)
+	}
+	const entityID = "aabbccddeeff0011"
+	doc := &graph.Document{
+		Version: graph.SchemaVersion,
+		Entities: []graph.Entity{
+			graph.Entity{
+				ID: entityID, Name: "OrderCheckout", Kind: "http_endpoint",
+				Language: "python", SourceFile: "api/views.py",
+			}.WithProperties(map[string]string{}),
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(indexedDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g1"] = &cacheEntry{
+		group: &DashGroup{
+			Name:  "g1",
+			Repos: map[string]*DashRepo{"repo1": {Slug: "repo1", Path: repoDir, Doc: doc}},
+		},
+		loadedAt: time.Now().Add(60 * time.Second),
+	}
+	srv.graphs.mu.Unlock()
+
+	const desc = "Persists the order checkout request and returns a receipt."
+	w := doWritebackRequest(t, srv, entityID, enrichmentWritebackRequest{Description: desc})
+	if w.Code != http.StatusOK {
+		t.Fatalf("write-back failed: %d %s", w.Code, w.Body.String())
+	}
+
+	// The durable assertion: the sidecar is where the reader looks.
+	if sc, ok := descriptions.Read(indexedDir); !ok || sc.Results[entityID] != desc {
+		stray := ""
+		if _, strayOK := descriptions.Read(currentHeadDir); strayOK {
+			stray = "\n  it landed in the current-HEAD dir instead: " + currentHeadDir
+		}
+		t.Errorf("description not persisted where the reader looks (%s)%s\n"+
+			"  the next reload would find nothing and the write would be silently lost",
+			indexedDir, stray)
+	}
+}
+
+// enrichmentStateDir must follow the graph, not HEAD.
+//
+// The fixture builds the AnyRef-fallback population directly: a repo with NO
+// graph under its current-HEAD ref dir (a non-git temp dir resolves to the
+// "_unknown" sentinel) and a real graph.fb under an indexed "main" ref dir.
+// FindGraphFileAnyRef serves the latter, so the sidecar belongs there too.
+//
+// Proof the fixture can fail: restoring the pre-#6060 writer
+// (`daemon.StateDirForRepo(found.repoPath)`) returns the _unknown dir and this
+// test fails naming both directories.
+func TestEnrichmentStateDir_FollowsDiscoveredGraphNotCurrentHead(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	repoDir := t.TempDir() // not a git checkout -> current ref is the _unknown sentinel
+
+	currentHeadDir := daemon.StateDirForRepo(repoDir)
+	indexedDir := daemon.StateDirForRepoRef(repoDir, "main")
+	if currentHeadDir == indexedDir {
+		t.Fatalf("fixture degenerate: current-HEAD and indexed ref dirs are both %s, "+
+			"so it cannot tell the two resolutions apart", indexedDir)
+	}
+
+	// Graph exists ONLY under the indexed ref -> AnyRef fallback territory.
+	if err := os.MkdirAll(indexedDir, 0o755); err != nil {
+		t.Fatalf("mkdir indexed dir: %v", err)
+	}
+	doc := &graph.Document{Entities: []graph.Entity{{ID: "a", Name: "A", Kind: "Function"}}}
+	if err := fbwriter.WriteAtomic(filepath.Join(indexedDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	// Sanity: the loader really does fall back to the indexed dir. Without this
+	// the test could pass for the wrong reason on a layout change.
+	discovered, _ := daemon.FindGraphFileAnyRef(repoDir)
+	if got := filepath.Dir(discovered); got != indexedDir {
+		t.Fatalf("fixture cannot exercise the AnyRef fallback: loader discovered %q, want a graph under %s",
+			discovered, indexedDir)
+	}
+
+	if got := enrichmentStateDir(repoDir); got != indexedDir {
+		t.Errorf("write-back would persist the description where the reader never looks:\n"+
+			"  writer resolved: %s\n  reader reads:    %s\n  (current-HEAD dir was %s)",
+			got, indexedDir, currentHeadDir)
+	}
+}
+
+// With no graph anywhere the writer must still resolve somewhere sane rather
+// than returning "" and writing descriptions.json into the process CWD.
+func TestEnrichmentStateDir_FallsBackWhenNoGraphDiscovered(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	repoDir := t.TempDir()
+
+	got := enrichmentStateDir(repoDir)
+	if got == "" {
+		t.Fatal("enrichmentStateDir returned empty for a repo with no graph")
+	}
+	if want := daemon.StateDirForRepo(repoDir); got != want {
+		t.Errorf("fallback resolved %s, want the current-HEAD state dir %s", got, want)
+	}
+}

--- a/internal/dashboard/handlers_enrichment_writeback.go
+++ b/internal/dashboard/handlers_enrichment_writeback.go
@@ -214,7 +214,7 @@ func (s *Server) handleEnrichmentWriteback(w http.ResponseWriter, r *http.Reques
 	}
 	found.entity.PropSet("description", req.Description)
 
-	stateDir := daemon.StateDirForRepo(found.repoPath)
+	stateDir := enrichmentStateDir(found.repoPath)
 	// graphPath is informational only (echoed in the response); it is NOT written.
 	graphPath := daemon.GraphPathForRepo(found.repoPath)
 
@@ -373,4 +373,47 @@ func yamlScalar(s string) string {
 		return "'" + escaped + "'"
 	}
 	return s
+}
+
+// enrichmentStateDir returns the directory the description side-table must be
+// WRITTEN to for repoPath.
+//
+// This is the writer half of a pair (#6060). The reader is
+// mcp.applyDescriptionOverlay, which resolves the sidecar from
+// filepath.Dir(lr.GraphFile) — the directory the MCP loader DISCOVERED the
+// graph in, via #3648's FindGraphFileAnyRef. The two must agree, so this writer
+// resolves the same way the reader's loader did rather than re-deriving
+// current-HEAD.
+//
+// The failure this prevents is a silently lost durable write:
+//
+//	repo indexed at "main"; HEAD later moves to "feature"; the current-HEAD ref
+//	dir is empty, so FindGraphFileAnyRef serves .../refs/main/graph.fb. A writer
+//	resolving current-HEAD puts descriptions.json in .../refs/feature/, and the
+//	in-memory PropSet in the handler makes the call LOOK successful. The next
+//	reload reads .../refs/main/descriptions.json, finds nothing, and the
+//	description is gone — no error, no log line, nothing to notice.
+//
+// Note this deliberately does NOT use the dashboard's own DashGroup.stateDirs,
+// which is current-HEAD (or an explicitly requested ref) because that is where
+// the dashboard loads its Document from. The sidecar has to follow the MCP
+// reader, not the dashboard's view — and descriptions.Upsert stamps SourceKey
+// from the graph in whichever directory it writes to, so writing to the reader's
+// directory is also what keeps the freshness key checkable by the reader.
+//
+// The flow side-table is NOT on this convention and deliberately stays off it:
+// its writer (internal/cli/links.go, the phantom pass) loads its Document from
+// daemon.StateDirForRepo and writes beside it, so both its halves are
+// current-HEAD and correctly paired as they stand. (links.go's
+// `filepath.Dir(graphPaths[slug])` reads like the discovered dir but graphPaths
+// is daemon.GraphPathForRepo = StateDirForRepo + "graph.json".) Converting flows
+// means moving that pass's LOAD too, which is an indexer-side change.
+//
+// A repo with no discoverable graph falls back to the previous behaviour rather
+// than writing to "".
+func enrichmentStateDir(repoPath string) string {
+	if graphPath, _ := daemon.FindGraphFileAnyRef(repoPath); graphPath != "" {
+		return filepath.Dir(graphPath)
+	}
+	return daemon.StateDirForRepo(repoPath)
 }

--- a/internal/gitmeta/cache.go
+++ b/internal/gitmeta/cache.go
@@ -3,6 +3,7 @@ package gitmeta
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -145,6 +146,29 @@ func CaptureCached(repoPath string) Info {
 	captureCache[repoPath] = captureEntry{info: info, headStat: key}
 	captureMu.Unlock()
 	return info
+}
+
+// HeadToken returns an opaque token identifying the CURRENT state of repoPath's
+// HEAD pointer, and whether one could be determined. The token changes whenever
+// HEAD is rewritten — commit, checkout, branch-switch — and is otherwise stable,
+// which makes it a pure-os.Stat invalidation signal for anything a caller
+// derived from the repo's current ref.
+//
+// It is the same key CaptureCached memoizes on, exported (#6060) so callers that
+// cache a DERIVED value (e.g. the resolved per-ref state directory) can
+// invalidate on the same event without paying a Capture — including for
+// non-git directories, where Capture is a wasted fork that CaptureCached cannot
+// memoize. ok=false means "not a resolvable git checkout"; such a path has no
+// ref to move, so a caller may treat its derived value as permanently valid.
+func HeadToken(repoPath string) (string, bool) {
+	if repoPath == "" {
+		return "", false
+	}
+	key, ok := headPointerKey(repoPath)
+	if !ok {
+		return "", false
+	}
+	return key.path + "\x00" + key.mtime.UTC().Format(time.RFC3339Nano) + "\x00" + strconv.FormatInt(key.size, 10), true
 }
 
 // resetCaptureCacheForTest clears the memo. Test-only.

--- a/internal/mcp/graph_discovery_staleness_6060_test.go
+++ b/internal/mcp/graph_discovery_staleness_6060_test.go
@@ -1,0 +1,168 @@
+// graph_discovery_staleness_6060_test.go — issue #6060.
+//
+// lr.GraphFile is the anchor for everything per-repo: the Document, the
+// embeddings sidecar, and (after this issue) the description side-table. The
+// #2550 short-circuit in reloadAllLocked PINS it — once set, reload stats that
+// exact file and, as long as it still exists, never re-runs discovery. So a repo
+// indexed at "main" whose HEAD then moves to "feature" AND gets reindexed keeps
+// serving refs/main's graph forever, while every other resolver in the process
+// (which re-derives per call) has moved on to refs/feature.
+//
+// That is a staleness bug on its own, and it is also the precondition for the
+// side-table pairing: "the directory the graph was discovered in" is only a
+// correct target if discovery is CURRENT.
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// gitRepoForDiscovery creates a real git repo with one commit on branch "main".
+func gitRepoForDiscovery(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	run("init")
+	run("checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+	return dir
+}
+
+func writeGraphInto(t *testing.T, dir string, doc *graph.Document) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb into %s: %v", dir, err)
+	}
+}
+
+// A reindex under the NEW HEAD ref must be picked up by the next reload.
+//
+// This is the default install shape: watchers ON, so a branch switch is followed
+// by an index of the new ref. Before the fix, lr.GraphFile stayed pinned at
+// refs/main/graph.fb — the file still exists and stats fine, so the #2550
+// short-circuit never falls through to discovery — and the daemon served the old
+// ref's graph indefinitely.
+//
+// Proof the fixture can fail: it does fail with the #2550 short-circuit intact,
+// reporting refs/main where refs/feature is expected.
+func TestReload_RediscoversGraphAfterHeadMovesAndIsReindexed(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+	featureDir := daemon.StateDirForRepoRef(repoDir, "feature")
+	if mainDir == featureDir {
+		t.Fatal("fixture degenerate: both refs resolve to the same state dir")
+	}
+
+	// Indexed at main.
+	writeGraphInto(t, mainDir, lazyTestDoc())
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	lr := st.Group("test").Repos["r"]
+	if lr == nil {
+		t.Fatal("repo not loaded")
+	}
+	if got := filepath.Dir(lr.GraphFile); got != mainDir {
+		t.Fatalf("initial discovery resolved %s, want %s", got, mainDir)
+	}
+
+	// HEAD moves, and the new ref is indexed (watchers ON — the default).
+	cmd := exec.Command("git", "checkout", "-b", "feature")
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout: %v\n%s", err, out)
+	}
+	writeGraphInto(t, featureDir, lazyTestDoc())
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload after head move: %v", err)
+	}
+
+	if got := filepath.Dir(lr.GraphFile); got != featureDir {
+		t.Errorf("reload kept serving a stale ref's graph:\n  lr.GraphFile dir: %s\n  want:             %s\n"+
+			"  (the #2550 short-circuit pinned discovery; every other resolver in the\n"+
+			"   process has already moved to the new ref)", got, featureDir)
+	}
+}
+
+// The reader's anchor and the writer's resolver must name the same directory in
+// the population above. The writer (dashboard enrichment write-back) re-derives
+// through FindGraphFileAnyRef on every call; the reader uses lr.GraphFile. If
+// discovery is pinned they diverge and the description write is silently lost —
+// same signature as the AnyRef case, but in the DEFAULT population.
+//
+// Proof the fixture can fail: with the #2550 short-circuit intact this reports
+// readerDir=refs/main writerDir=refs/feature.
+func TestReload_ReaderAndWriterAgreeAfterHeadMoveAndReindex(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+
+	repoDir := gitRepoForDiscovery(t)
+	writeGraphInto(t, daemon.StateDirForRepoRef(repoDir, "main"), lazyTestDoc())
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	cmd := exec.Command("git", "checkout", "-b", "feature")
+	cmd.Dir = repoDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout: %v\n%s", err, out)
+	}
+	writeGraphInto(t, daemon.StateDirForRepoRef(repoDir, "feature"), lazyTestDoc())
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	lr := st.Group("test").Repos["r"]
+	readerDir := repoStateDir(lr)
+
+	// What the dashboard write-back resolves (enrichmentStateDir's resolution).
+	discovered, _ := daemon.FindGraphFileAnyRef(repoDir)
+	writerDir := filepath.Dir(discovered)
+
+	if readerDir != writerDir {
+		t.Errorf("side-table reader and writer disagree — the description write would be\n"+
+			"silently lost on the next reload:\n  readerDir=%s\n  writerDir=%s", readerDir, writerDir)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/embed"
+	"github.com/cajasmota/grafel/internal/gitmeta"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	fb "github.com/cajasmota/grafel/internal/graph/fbgraph"
@@ -459,6 +460,26 @@ type LoadedRepo struct {
 	descStampedMt time.Time
 	descFileMt    time.Time
 	descApplied   bool
+
+	// curRefDir / curRefHeadTok memoize this repo's CURRENT-HEAD per-ref state
+	// directory (#6060). reloadAllLocked compares it against the directory the
+	// resident graph was discovered in to decide whether discovery has gone stale
+	// — see the #2550/#6060 gate there.
+	//
+	// Resolving it means daemon.StateDirForRepo, and doing that per repo per
+	// reload would undo the very cost this issue removed: gitmeta memoizes the
+	// capture for a git checkout, but for a NON-git directory it cannot (there is
+	// no HEAD to key on) and every call is a wasted fork. So the resolved value is
+	// cached here and invalidated on gitmeta.HeadToken, which is a pure os.Stat of
+	// the HEAD pointer — the same signal CaptureCached uses.
+	//
+	// curRefHeadTok is "" for a non-git directory. Such a path has no ref that can
+	// move (it always resolves to the "_unknown" sentinel), so the cached dir is
+	// permanently valid and is resolved at most once per repo per process.
+	// Mutated only under s.mu, inside reloadAllLocked.
+	curRefDir     string
+	curRefHeadTok string
+	curRefKnown   bool
 
 	// flowOverlay / flowStampedMt / flowFileMt / flowApplied memoize the FLOW
 	// side-table apply (#5904 PR-b), mirroring descApplied for the per-repo
@@ -1334,6 +1355,33 @@ func skeletonizeDocRows(doc *graph.Document) {
 	doc.SurpriseEdges = nil
 }
 
+// currentRefDirLocked returns repoPath's CURRENT-HEAD per-ref state directory,
+// memoized on the repo and invalidated whenever the HEAD pointer is rewritten
+// (#6060). Caller MUST hold s.mu.
+//
+// The steady state is a single os.Stat of <repo>/.git/HEAD via gitmeta.HeadToken
+// — no Capture, no fork — which is what makes it affordable to check on every
+// reload for every repo. A non-git directory has no HEAD to move, so its
+// resolution is cached permanently rather than re-forked per reload; that case
+// is precisely the one gitmeta.CaptureCached cannot memoize.
+// A non-git directory yields tok=="" and is cached under that key, which is why
+// the "resolved yet?" signal is the separate curRefKnown flag rather than a
+// non-empty token.
+//
+// Callers MUST pass lr.Path, not any other spelling of the repo path: the memo
+// has one slot, so two callers feeding it different paths would invalidate each
+// other on every call and reinstate the per-call fork this exists to remove.
+func (lr *LoadedRepo) currentRefDirLocked(repoPath string) string {
+	tok, _ := gitmeta.HeadToken(repoPath)
+	if lr.curRefKnown && tok == lr.curRefHeadTok {
+		return lr.curRefDir
+	}
+	lr.curRefDir = daemon.StateDirForRepo(repoPath)
+	lr.curRefHeadTok = tok
+	lr.curRefKnown = true
+	return lr.curRefDir
+}
+
 // reloadAllLocked is the reload body; the caller MUST already hold s.mu. Split
 // out of reloadLocked (memory epic #5850 PR1) so the eviction revive path can
 // reload from disk while already holding s.mu (Group -> reviveEvictedLocked)
@@ -1375,9 +1423,40 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 			// PATH cache). When lr.GraphFile is already set from a previous reload,
 			// stat the file directly — no git subprocesses needed. Only fall through
 			// to FindGraphFile on first load or when the cached path disappears.
+			//
+			// #6060: that short-circuit also PINNED the ref. lr.GraphFile keeps
+			// pointing at refs/<old>/graph.fb after HEAD moves, because that file
+			// still exists and stats fine, so discovery never re-ran — and the daemon
+			// served the old ref's graph indefinitely even once the new ref had been
+			// indexed (the DEFAULT shape: watchers ON, so a branch switch is followed
+			// by an index of the new ref). It also desynchronised the repo from every
+			// resolver that re-derives per call, which is how a description write-back
+			// could land in one ref's directory while the reader looked in another's
+			// and the write was silently lost.
+			//
+			// The gate below keeps the fast path for the overwhelmingly common case
+			// (pinned file is already in the current-HEAD ref dir → one memoized
+			// capture and a string compare) and re-runs discovery only when the repo
+			// is being served from a NON-current ref, which is exactly the state that
+			// needs re-checking. The git-subprocess cost #2550 was avoiding is gone
+			// regardless: StateDirForRepo memoizes the HEAD capture (see
+			// daemon.StateDirForRepo).
+			//
+			// What this gate fixes is REF staleness, and only that. It does not make
+			// the resident graph current in general: the pinned path can still name a
+			// superseded GENERATION inside the right ref dir, because
+			// graph.GCStaleGens retains gen N-1, so a same-branch reindex leaves the
+			// old generation on disk and this stat keeps succeeding against it with an
+			// unchanged mtime. Pre-existing and tracked separately — do not read the
+			// gate as a freshness guarantee beyond the ref.
 			var graphPath string
 			var modtimeNs int64
-			if ok && lr.GraphFile != "" {
+			// lr.Path, not rEntry.Path: the memo has one slot and applyFlowOverlay
+			// keys it on lr.Path, so feeding two spellings here would make the two
+			// callers invalidate each other every call. They are the same value today
+			// (lr.Path is assigned from rEntry.Path at construction and never
+			// reassigned) — this keeps them the same value by construction.
+			if ok && lr.GraphFile != "" && filepath.Dir(lr.GraphFile) == lr.currentRefDirLocked(lr.Path) {
 				if fi, statErr := os.Stat(lr.GraphFile); statErr == nil {
 					graphPath = lr.GraphFile
 					modtimeNs = fi.ModTime().UnixNano()
@@ -1871,17 +1950,12 @@ var reviveMaterializeHook func(name string)
 //
 // Cost (issue #6060): each of these is memoized to a stat-and-skip in the steady
 // state, which is why the WARM serving path can afford to run them under the
-// State-global lock. The dominant per-call cost is NOT the stat — it is that
-// both side-table overlays resolve their state directory through
-// daemon.StateDirForRepo, whose HEAD capture forks git subprocesses. That
-// resolution is now memoized inside gitmeta (CaptureCached, see
-// daemon.StateDirForRepo), which is what makes the steady state actually cheap
-// rather than merely described as cheap. Sourcing the directory from the repo's
-// already-discovered graph file instead — which would remove the call entirely,
-// and which the reader/writer pairing arguably requires — is deliberately NOT
-// done here: it changes which directory the daemon reads durable side-tables
-// from, so it belongs with the matching writer change, not in a lock-scope
-// commit.
+// State-global lock. The stat is now genuinely all it costs: both side-table
+// overlays source their directory from the repo's already-discovered graph file
+// (repoStateDir) rather than re-resolving current-HEAD through
+// daemon.StateDirForRepo, whose HEAD capture forks git subprocesses. Before that
+// change every routing decision — warm calls included, not just revives — paid
+// two such resolutions per repo.
 func (s *State) touchGroupLocked(grp *LoadedGroup) {
 	// Stamp the LRU/PIN signal on every routing decision (issue #5872 PR2).
 	// This is the per-call choke point, so the group with the newest lastAccess
@@ -2965,7 +3039,14 @@ func applyDescriptionOverlay(grp *LoadedGroup) {
 		if lr == nil || lr.Doc == nil || lr.Path == "" {
 			continue
 		}
-		stateDir := daemon.StateDirForRepo(lr.Path)
+		stateDir := repoStateDir(lr)
+		if stateDir == "" {
+			// No discovered graph → no sidecar directory. Skip rather than fall
+			// through: descriptions.Path("") is "descriptions.json", a CWD-RELATIVE
+			// path that would be stat'd (and on the write side, written) against the
+			// daemon's working directory.
+			continue
+		}
 		var fileMt time.Time
 		if fi, err := os.Stat(descriptions.Path(stateDir)); err == nil {
 			fileMt = fi.ModTime()
@@ -3019,6 +3100,73 @@ func applyDescriptionOverlay(grp *LoadedGroup) {
 	}
 }
 
+// repoStateDir returns the directory holding lr's per-repo durable side-tables
+// (descriptions.json, flows.json). It is the directory the repo's graph file was
+// actually DISCOVERED in — the same value reloadAllLocked computes as
+// filepath.Dir(lr.GraphFile) and hands to readDocumentFromDir and the embeddings
+// sidecar.
+//
+// WHY NOT daemon.StateDirForRepo(lr.Path), which is what this used to be.
+//
+// That call always returns the CURRENT-HEAD per-ref directory. But #3648's
+// FindGraphFileAnyRef deliberately falls back to the newest graph under ANY
+// indexed ref when the current-HEAD ref dir is empty — the common shape for a
+// group registered via `group add --index` (watchers default OFF) whose HEAD has
+// since moved. In that population lr.GraphFile lives under refs/<indexed> while
+// StateDirForRepo returns refs/<current>, so the overlays stamped a Document
+// loaded from one ref with side-tables read from another.
+//
+// The failure that makes this worth fixing is a SILENTLY LOST DURABLE WRITE, not
+// a mismatch: an agent enriches an entity, the write lands in the current-HEAD
+// dir and the in-memory PropSet makes it look applied, and then the next reload
+// reads the indexed-ref dir, finds nothing, and the description is gone with no
+// error anywhere. The reader and the writer must agree on one directory; this
+// function and enrichmentStateDir (dashboard) are the two halves of that
+// agreement.
+//
+// SCOPE OF THAT PRINCIPLE. It is stated generally because it is generally true,
+// but it is NOT uniformly applied in this package. The FLOW side-table is not
+// converted and stays current-HEAD on both halves (see applyFlowOverlay), and
+// roughly ten other per-repo side-tables — repair.json,
+// enrichment-candidates.json, the doc-semantics and docgen artifacts — still
+// resolve through daemon.StateDirForRepo on both sides. Each is presumably
+// self-paired, which is why none of them is a defect today; the point is that
+// "reader and writer agree" was established here for descriptions only, and a
+// future change to any of those must re-establish it for that pair rather than
+// assume it.
+//
+// FRESHNESS, and the limit of it. "The directory the graph was discovered in" is
+// only a correct target if discovery is current. It was not: the #2550
+// short-circuit in reloadAllLocked pinned lr.GraphFile to the ref it was first
+// discovered under, so after a HEAD move plus a reindex this resolved a stale
+// ref's directory while the writer (which re-derives per call) had moved on —
+// the same lost write in the DEFAULT population. That gate is fixed in the same
+// change; this function is only sound because of it.
+//
+// The guarantee that gate delivers is freshness at REF granularity, and no
+// further. Within a ref directory lr.GraphFile can still name a superseded
+// GENERATION: graph.GCStaleGens (internal/graph/genpath.go) deliberately retains
+// gen N-1, so a plain same-branch reindex writes gen N+1 and flips `current`
+// while gen N stays on disk — the gate passes (same directory), the os.Stat
+// succeeds, the mtime is unchanged, and the daemon keeps serving the older
+// generation. That is pre-existing, predates this change, and is tracked
+// separately. It does not affect the pairing argument above: the ref DIRECTORY
+// is right either way, and the directory is all this function resolves.
+//
+// A repo with no discovered graph file returns "". Callers MUST treat that as
+// "no sidecar directory" and skip — it is NOT a harmless miss, because
+// descriptions.Path("") is "descriptions.json", a CWD-relative path that would
+// be resolved against the daemon's working directory. Both callers do skip. The
+// case is also unreachable today (a repo with a parsed Doc always has GraphFile
+// set by reloadAllLocked, and both callers `continue` on lr.Doc == nil), so this
+// is a defensive floor rather than a live path.
+func repoStateDir(lr *LoadedRepo) string {
+	if lr == nil || lr.GraphFile == "" {
+		return ""
+	}
+	return filepath.Dir(lr.GraphFile)
+}
+
 // applyFlowOverlay stamps the per-repo FLOW side-table (#5904 PR-b) onto a
 // loaded group's repos with REPLACE semantics. For each repo it reads
 // <stateDir>/flows.json (absence/corrupt/stale-tolerant) and publishes the
@@ -3041,6 +3189,27 @@ func applyDescriptionOverlay(grp *LoadedGroup) {
 // same lock) + re-arming stepOnce/callsOnce under idxMu (so the adjacencies
 // rebuild against the REPLACE set) mirrors resetIndexes' invalidation. Caller
 // holds s.mu.
+//
+// STATE DIR (#6060). This deliberately stays on daemon.StateDirForRepo while
+// applyDescriptionOverlay moved to repoStateDir, because a side-table's reader
+// must resolve the same directory as its WRITER and the two side-tables have
+// different writers:
+//
+//   - descriptions — written by the dashboard enrichment write-back, which this
+//     issue moved onto the discovered graph dir (enrichmentStateDir). Reader
+//     moved with it.
+//   - flows — written by the phantom-edge pass (internal/cli/links.go). That
+//     pass LOADS its Document from daemon.StateDirForRepo and writes the delta
+//     back beside it: links.go's `filepath.Dir(graphPaths[slug])` looks like the
+//     discovered dir but graphPaths is daemon.GraphPathForRepo, i.e.
+//     StateDirForRepo + "graph.json". It is current-HEAD wearing a filepath.Dir
+//     disguise.
+//
+// So flows is CURRENT-HEAD on both halves and correctly paired as it stands.
+// Moving this reader alone would unpair it — precisely the defect this issue is
+// about. Converting flows means moving the phantom pass's LOAD as well (so its
+// delta and its SourceKey are computed against the graph the reader will serve),
+// which is an indexer-side change and deliberately out of scope here.
 func applyFlowOverlay(grp *LoadedGroup) {
 	if grp == nil {
 		return
@@ -3049,7 +3218,15 @@ func applyFlowOverlay(grp *LoadedGroup) {
 		if lr == nil || lr.Doc == nil || lr.Path == "" {
 			continue
 		}
-		stateDir := daemon.StateDirForRepo(lr.Path)
+		// Current-HEAD, matching this side-table's writer (see the doc comment).
+		// Resolved through the per-repo memo rather than daemon.StateDirForRepo
+		// directly: this runs on EVERY State.Group call, and for a non-git repo
+		// path gitmeta cannot memoize the capture, so a direct call would fork git
+		// per call per repo — the exact cost #6060 removed.
+		stateDir := lr.currentRefDirLocked(lr.Path)
+		if stateDir == "" {
+			continue
+		}
 		var fileMt time.Time
 		if fi, err := os.Stat(flows.Path(stateDir)); err == nil {
 			fileMt = fi.ModTime()

--- a/internal/mcp/state_dir_pairing_6060_test.go
+++ b/internal/mcp/state_dir_pairing_6060_test.go
@@ -1,0 +1,243 @@
+// state_dir_pairing_6060_test.go — issue #6060, reader/writer pairing.
+//
+// The description side-table has two halves that must name the SAME directory:
+// the writer (dashboard enrichment write-back) and the reader
+// (applyDescriptionOverlay). They used to resolve independently — writer via
+// current-HEAD, reader via current-HEAD — which agreed by accident. Moving the
+// reader onto the discovered graph file (#3648 AnyRef) without moving the writer
+// breaks that agreement, and the symptom is the worst kind: a durable write that
+// reports success, shows up in memory, and is gone after the next reload.
+//
+// TestDescriptionSidecar_SurvivesReloadUnderAnyRefFallback is the round-trip
+// that a reader-only change could never pass.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/descriptions"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/graph/flows"
+)
+
+// The pairing round-trip. Builds the exact population the reader change targets
+// — a repo whose graph lives under an INDEXED ref directory while HEAD points
+// somewhere else — writes a description the way the dashboard write-back does,
+// and requires the SERVING path to find it.
+//
+// Scope, stated so this is not mistaken for more than it is: the read here goes
+// through State.Group -> touchGroupLocked -> applyDescriptionOverlay. That is
+// the per-call overlay refresh, NOT a reload — no rediscovery happens, and the
+// group's resident Doc is the one seeded on disk. Coverage of discovery
+// re-resolving after a HEAD move lives in
+// graph_discovery_staleness_6060_test.go.
+//
+// Proof the fixture can exhibit the failure: writing the sidecar into
+// currentHeadDir instead of indexedDir (the pre-#6060 writer) makes the final
+// read return "", which is the silently-lost-write bug.
+func TestDescriptionSidecar_SurvivesReloadUnderAnyRefFallback(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+
+	currentHeadDir := daemon.StateDirForRepo(lr.Path)
+
+	// The AnyRef fallback population: the graph the loader actually serves lives
+	// in a DIFFERENT per-ref directory than the current-HEAD one.
+	indexedDir := t.TempDir()
+	indexedFB := filepath.Join(indexedDir, "graph.fb")
+	if err := fbwriter.WriteAtomic(indexedFB, doc); err != nil {
+		t.Fatalf("write indexed-ref graph: %v", err)
+	}
+	if indexedDir == currentHeadDir {
+		t.Fatal("fixture degenerate: indexed and current-HEAD dirs are the same, " +
+			"so it cannot tell the two resolutions apart")
+	}
+
+	st.mu.Lock()
+	lr.GraphFile = indexedFB // what FindGraphFileAnyRef would have discovered
+	lr.descApplied = false
+	st.mu.Unlock()
+
+	// Write the description through the same call the dashboard write-back makes,
+	// into the directory the WRITER resolves. enrichmentStateDir (dashboard) and
+	// repoStateDir (here) must both land on indexedDir.
+	if err := descriptions.Upsert(indexedDir, "a", "durable description"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// Read it back off the serving path — the durable sidecar, not an in-memory
+	// PropSet left behind by a writer.
+	if grp := st.Group("test"); grp == nil {
+		t.Fatal("Group returned nil")
+	}
+
+	got := ""
+	for i := range lr.Doc.Entities {
+		if lr.Doc.Entities[i].ID == "a" {
+			got = lr.Doc.Entities[i].PropGet("description")
+		}
+	}
+	if got != "durable description" {
+		t.Errorf("description not visible on the serving path: got %q want %q\n"+
+			"  reader resolved a different directory than the writer\n"+
+			"  indexed(graph) dir: %s\n  current-HEAD dir:   %s",
+			got, "durable description", indexedDir, currentHeadDir)
+	}
+}
+
+// The reader must not consult a sidecar sitting in the current-HEAD directory
+// when the graph it loaded came from elsewhere. This is the other direction of
+// the same pairing: reading the wrong ref's descriptions is how a stale or
+// foreign description gets stamped onto entities.
+func TestDescriptionSidecar_IgnoresCurrentHeadDirWhenGraphIsElsewhere(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+
+	currentHeadDir := daemon.StateDirForRepo(lr.Path)
+	indexedDir := t.TempDir()
+	indexedFB := filepath.Join(indexedDir, "graph.fb")
+	if err := fbwriter.WriteAtomic(indexedFB, doc); err != nil {
+		t.Fatalf("write indexed-ref graph: %v", err)
+	}
+
+	// A sidecar belonging to the OTHER ref.
+	if err := descriptions.Upsert(currentHeadDir, "a", "wrong-ref description"); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	st.mu.Lock()
+	lr.GraphFile = indexedFB
+	lr.descApplied = false
+	st.mu.Unlock()
+
+	if grp := st.Group("test"); grp == nil {
+		t.Fatal("Group returned nil")
+	}
+	for i := range lr.Doc.Entities {
+		if lr.Doc.Entities[i].ID == "a" {
+			if d := lr.Doc.Entities[i].PropGet("description"); d == "wrong-ref description" {
+				t.Error("reader stamped a description from the current-HEAD directory " +
+					"onto a graph loaded from a different ref")
+			}
+		}
+	}
+}
+
+// The FLOW side-table is deliberately NOT converted to the discovered-graph dir
+// (its writer, the phantom-edge pass, is current-HEAD on both its load and its
+// write — see applyFlowOverlay). This pins that pairing behaviourally, so the
+// half-conversion this issue is about cannot be reintroduced silently: before
+// this test, reverting applyFlowOverlay's state dir failed nothing in the whole
+// package.
+//
+// Proof the fixture can fail: pointing applyFlowOverlay at repoStateDir(lr)
+// (the description convention) makes it read the discovered dir instead and the
+// overlay comes back nil.
+func TestFlowSidecar_ReadFromCurrentHeadDirMatchingItsWriter(t *testing.T) {
+	doc := lazyTestDoc()
+	st, lr, _ := seedRepoOnDisk(t, doc)
+
+	writerDir := daemon.StateDirForRepo(lr.Path) // what the phantom pass writes to
+
+	// Put the graph somewhere else so the two conventions are distinguishable —
+	// exactly the AnyRef shape the description overlay follows.
+	discoveredDir := t.TempDir()
+	discoveredFB := filepath.Join(discoveredDir, "graph.fb")
+	if err := fbwriter.WriteAtomic(discoveredFB, doc); err != nil {
+		t.Fatalf("write discovered graph: %v", err)
+	}
+	if discoveredDir == writerDir {
+		t.Fatal("fixture degenerate: writer dir and discovered dir are identical")
+	}
+
+	// A flow sidecar written the way the phantom pass writes it.
+	ents := []graph.Entity{{ID: "flow::x", Name: "X", Kind: "process_flow"}}
+	rels := []graph.Relationship{{FromID: "flow::x", ToID: "a", Kind: stepInProcessEdge}}
+	if err := flows.Upsert(writerDir, ents, rels); err != nil {
+		t.Fatalf("flows.Upsert: %v", err)
+	}
+
+	st.mu.Lock()
+	lr.GraphFile = discoveredFB
+	lr.flowApplied = false
+	st.mu.Unlock()
+
+	if grp := st.Group("test"); grp == nil {
+		t.Fatal("Group returned nil")
+	}
+	if fo := lr.flowOverlaySnapshot(); fo == nil {
+		t.Errorf("flow overlay not applied: the reader looked somewhere other than\n"+
+			"its writer's directory (%s), so the phantom pass's flows are invisible", writerDir)
+	}
+}
+
+// The mmap read path. serveFromMMap() defaults ON for this OS, and on that path
+// descriptions are NOT read off lr.Doc.Entities — they come from the
+// entity-INDEX-keyed LabelIndex.descOverlay table that applyDescriptionOverlay
+// builds from the resident Reader. The two tests above use a hand-built Doc with
+// a nil Reader, so they only cover the flag-OFF path. This one drives a REAL
+// reload (Reader opened, index built from the mmap) with the flag forced ON, so
+// production's actual read path is what consumes the resolved sidecar directory.
+func TestDescriptionSidecar_MMapPathReadsDiscoveredDir(t *testing.T) {
+	forceServeFromMMap(t, true)
+
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	repoDir := t.TempDir()
+
+	// AnyRef layout: the graph lives under an indexed ref, not current-HEAD.
+	indexedDir := daemon.StateDirForRepoRef(repoDir, "main")
+	if err := os.MkdirAll(indexedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(indexedDir, "graph.fb"), lazyTestDoc()); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	if daemon.StateDirForRepo(repoDir) == indexedDir {
+		t.Fatal("fixture degenerate: current-HEAD and indexed dirs are identical")
+	}
+
+	const want = "described via the mmap read path"
+	if err := descriptions.Upsert(indexedDir, "a", want); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	grp := st.Group("test")
+	if grp == nil {
+		t.Fatal("Group returned nil")
+	}
+	lr := grp.Repos["r"]
+	if lr == nil || lr.Reader == nil {
+		t.Fatal("fixture cannot exercise the mmap path: no Reader was opened")
+	}
+	if lr.LabelIndex == nil {
+		t.Fatal("no LabelIndex built")
+	}
+
+	lr.rmu().Lock()
+	table := lr.LabelIndex.descOverlay
+	lr.rmu().Unlock()
+
+	found := false
+	for _, d := range table {
+		if d == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("mmap descOverlay table does not carry the sidecar description\n"+
+			"  table size: %d\n  sidecar dir the reader must use: %s", len(table), indexedDir)
+	}
+}


### PR DESCRIPTION
A dashboard-written description could be silently lost. The overlay **reader** and the description **writer** resolved the sidecar directory two different ways, so an enrichment write landed in one directory and was read from another — the in-memory `PropSet` made the call look successful, and it was gone after the next reload.

Fixing that properly turned out to require fixing something upstream first.

## The root cause was stale discovery, not a directory mismatch

`lr.GraphFile` never re-resolved once set (`internal/mcp/state.go`, the #2550 short-circuit): after a HEAD move plus a reindex of the new ref, the daemon kept serving the **old ref's graph** indefinitely, because the old `graph.fb` still existed and stat'd cleanly.

So the sidecar disagreement was a symptom. "The directory the graph was discovered in" is only a correct target **if discovery is current** — and it was not. That also rules out the two obvious repairs:

- **Have the writer ask MCP for `lr.GraphFile`.** This pairs the writer to a *stale* reader — consistently wrong instead of inconsistently wrong, which is worse, because the disagreement is the only thing that surfaces the problem.
- **Re-resolve unconditionally every reload.** `StateDirForRepo` forks git, and on non-git paths `gitmeta.CaptureCached` cannot memoize, so this pays ~5 subprocess forks per repo per reload — exactly the cost #6060 had just removed. Measured: `internal/mcp` goes from 110s to 310s.

The landed shape is a cheap currency check — compare `filepath.Dir(lr.GraphFile)` against the current ref dir, memoized per repo, invalidated on a new `gitmeta.HeadToken` (a plain `os.Stat` of the HEAD pointer, no forks). Re-discover only on a mismatch. Once discovery is current, reader and writer agree **by construction** in all three populations, with no fallback and no precedence rule.

The discovery bug is filed separately as **#6078** so the root cause is not buried in a PR about sidecar directories.

## Flows stays on current-HEAD, deliberately

An earlier revision moved the flows reader too, justified by "the flows writer is already on this convention". **That was false.** `internal/cli/links.go` writes to `filepath.Dir(graphPaths[slug])`, but `graphPaths` is built from `daemon.GraphPathForRepo` → `StateDirForRepo` — current-HEAD wearing a `filepath.Dir` disguise. Moving the reader alone reproduced the very bug this PR fixes, one side-table over.

Flows is correctly self-paired on current-HEAD today, so the reader is reverted to match. Converting it properly means moving the phantom pass's *load* so its delta and `SourceKey` are computed against the graph the reader serves — indexer-side, and out of scope here.

That revert cost real time (`internal/mcp` → 291s) because `applyFlowOverlay` runs on every `State.Group` call and a direct `StateDirForRepo` forks git on non-git paths. Routing it through the same per-repo memo brought it back, with correct pairing intact.

## Freshness, stated exactly

The gate delivers freshness at **ref granularity and no further**. `graph.GCStaleGens` deliberately retains generation N-1, so a same-branch reindex writes N+1, flips `current`, and leaves N on disk — the gate passes (same dir), the stat succeeds, the mtime is unchanged, and the daemon keeps serving the older generation.

That is **pre-existing** (reproduced identically on `main`) and does not affect the pairing argument, since the ref *directory* is right either way and the directory is all `repoStateDir` resolves. Tracked as **#6080**. Both doc comments that previously claimed discovery was simply "current" now name this limit — a comment asserting a guarantee the code does not deliver is worse than no comment.

## Verification

Every new test drives a production path: `graph_discovery_staleness_6060_test.go` does real `git init`/`checkout -b` and a real reload; `TestDescriptionSidecar_MMapPathReadsDiscoveredDir` forces `serveFromMMap` ON (the default) and asserts against `LabelIndex.descOverlay` rather than a hand-built Doc; `TestWriteback_PersistsSidecarIntoDiscoveredGraphDir` drives the real HTTP endpoint.

Mutation battery, re-run independently:

| Mutant | Result |
|---|---|
| restore the discovery pin | killed — both `TestReload_*` |
| description reader → current-HEAD | killed — all three `TestDescriptionSidecar_*` |
| flows reader → discovered dir | killed — `TestFlowSidecar_*` |
| writer → `StateDirForRepo` | killed — the handler test alone (previously the whole package stayed green) |

An independent reviewer wrote its own scenarios rather than reusing the author's, and the gate held in each: HEAD moves but the new ref is **not** indexed (the legitimate AnyRef fallback — over-detecting here would have broken it), HEAD moves and the new ref **is** indexed, HEAD moves back, detached HEAD, non-git path, racing reloads.

An evadable grep-based guard from an earlier revision was **deleted** rather than patched — it passed when the resolver was reintroduced through an import alias, was file-scoped, and false-FAILed on block comments. Behavioural tests are the guard.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `internal/mcp` (119.7s), `internal/dashboard`, `internal/cli`, `internal/gitmeta` green at `-count=1 -p 1`, verified independently rather than taken from the report.

## Perf

`internal/mcp` **429s on `main` → 119.7s here.** Most of the #6060 win lands in this PR rather than in the lock-scope change that preceded it: that one memoized the call, this one removes it from the per-`State.Group` path outright. `TestEvictGroup_ConcurrentReadNoFault_FlagOn` goes 143.6s on `main` → 3.0s.

Known gap, not blocking: defeating the memo triples runtime while failing no test — there is no fork-count instrumentation. Filed as a follow-up; the release gate already gates perf assertions per #6063.

Three independent adversarial review rounds.

Closes #6060
