### PR TITLE
perf(#5954): stop testmap records pinning the test bodies they were sliced out of (-197MB live heap)

### DIFF
--- a/internal/extractors/cross/testmap/body_retention_5954_test.go
+++ b/internal/extractors/cross/testmap/body_retention_5954_test.go
@@ -1,0 +1,217 @@
+package testmap
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"strings"
+	"testing"
+	"unsafe"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #5954 — testmap string-retention.
+//
+// Every identifier the resolver lifts out of a test function comes from
+// regexp's *String* API, which slices the input rather than copying it
+// (`s[a:b]`). The sliced-out identifier therefore keeps the WHOLE backing
+// array — the entire captured test-function body — alive for as long as the
+// identifier is reachable. The identifiers land in EntityRecord properties and
+// relationship properties, which live from pass 3 until the document is
+// written, so each emitted test_coverage record pins its own multi-KB test
+// body across the peak-heap phase.
+//
+// On a heap profile taken at the child's peak (`heap-peak.pprof`,
+// materializing) this showed up as 223 MB under
+// strings.Join <- extractIndentedBody <- detectPytest, i.e. bodies that are
+// semantically dead but structurally reachable.
+//
+// Both tests below fail on the unfixed extractor:
+//   - the pointer test fails deterministically (identifier addresses land
+//     inside the body buffer),
+//   - the retention test fails by ~16 MB of retained heap.
+
+// pointsInto reports whether s's backing array starts inside buf's backing
+// array. A true result means s is a substring view of buf and keeps all of buf
+// alive.
+func pointsInto(s, buf string) bool {
+	if len(s) == 0 || len(buf) == 0 {
+		return false
+	}
+	base := uintptr(unsafe.Pointer(unsafe.StringData(buf)))
+	p := uintptr(unsafe.Pointer(unsafe.StringData(s)))
+	return p >= base && p < base+uintptr(len(buf))
+}
+
+// TestPointsIntoDetectsSubstringViews proves the detector itself works — a
+// substring view is reported, an independent copy is not. Without this the
+// retention assertions below could pass vacuously.
+func TestPointsIntoDetectsSubstringViews(t *testing.T) {
+	buf := strings.Repeat("x", 4096) + "MARKER" + strings.Repeat("y", 4096)
+	view := buf[4096 : 4096+len("MARKER")]
+	if !pointsInto(view, buf) {
+		t.Fatal("pointsInto() = false for a substring view of buf; the detector cannot observe retention")
+	}
+	if pointsInto(strings.Clone(view), buf) {
+		t.Fatal("pointsInto() = true for an independent copy; the detector reports false positives")
+	}
+}
+
+// TestBuildCollapsedEntity_DoesNotRetainBodyBuffer is the deterministic
+// assertion: no string reachable from the emitted EntityRecord may be a view
+// into the test-body buffer the identifiers were sliced out of.
+func TestBuildCollapsedEntity_DoesNotRetainBodyBuffer(t *testing.T) {
+	// A realistic shape: one large body buffer, identifiers sliced out of it.
+	body := strings.Repeat("    filler_line_that_is_not_a_call\n", 4096) +
+		"    result = CreateOrder(payload)\n" +
+		"    other = ChargeCard(payload)\n"
+	testName := "test_create_order_charges_card"
+	holder := testName + "\x00" + body // one buffer holding both, as a real source would
+
+	tf := testFunction{
+		qname: holder[:len(testName)],
+		body:  holder[len(testName)+1:],
+	}
+	calls := resolveCalls(tf, "orders.py", "CreateOrder", nil)
+	if len(calls) == 0 {
+		t.Fatal("resolveCalls() returned no calls; the fixture cannot exhibit retention")
+	}
+	// The fixture must actually be in the retaining state before the record is
+	// built, otherwise the assertion below is vacuous.
+	retaining := false
+	for _, c := range calls {
+		if pointsInto(c.qname, holder) {
+			retaining = true
+		}
+	}
+	if !retaining {
+		t.Fatal("no resolved call qname is a view into the source buffer; the fixture cannot exhibit the bug")
+	}
+
+	rec := buildCollapsedEntity("orders_test.py", "python", "pytest", "unit", tf.qname, calls)
+
+	// A clone that changes the VALUE would satisfy every pointer assertion
+	// below while corrupting the graph — the dangerous failure mode for a
+	// lifetime change is wrong data, not a crash. Pin the values too, so this
+	// file backs its own claim instead of leaning on the rest of the package
+	// suite. (Mutation: `strings.Clone(testQName) + "_CORRUPT"` passes every
+	// pointer check and fails here.)
+	if got, want := rec.Properties["test_function"], testName; got != want {
+		t.Errorf("Properties[\"test_function\"] = %q, want %q — the clone changed the value", got, want)
+	}
+	if got, want := rec.Properties["tested_function"], calls[0].qname; got != want {
+		t.Errorf("Properties[\"tested_function\"] = %q, want %q — the clone changed the value", got, want)
+	}
+	if got, want := rec.Name, testName+" -> "+calls[0].qname; got != want {
+		t.Errorf("EntityRecord.Name = %q, want %q — the clone changed the value", got, want)
+	}
+
+	for k, v := range rec.Properties {
+		if pointsInto(v, holder) {
+			t.Errorf("EntityRecord.Properties[%q] = %q is a view into the %d-byte source buffer; it pins the whole test body across the peak-heap phase", k, v, len(holder))
+		}
+	}
+	if pointsInto(rec.Name, holder) {
+		t.Errorf("EntityRecord.Name = %q is a view into the source buffer", rec.Name)
+	}
+	for _, rel := range rec.Relationships {
+		for _, kv := range rel.Properties {
+			if pointsInto(kv.V, holder) {
+				t.Errorf("RelationshipRecord.Properties[%q] = %q is a view into the %d-byte source buffer", kv.K, kv.V, len(holder))
+			}
+		}
+		if pointsInto(rel.FromID, holder) || pointsInto(rel.ToID, holder) {
+			t.Errorf("RelationshipRecord endpoint is a view into the source buffer (from=%q to=%q)", rel.FromID, rel.ToID)
+		}
+	}
+}
+
+// TestExtract_DoesNotRetainTestBodies is the end-to-end retention check: after
+// extracting N large pytest files and keeping ONLY the returned records, the
+// retained heap must be a small fraction of the source that produced them.
+func TestExtract_DoesNotRetainTestBodies(t *testing.T) {
+	const (
+		files    = 8
+		bodyKB   = 2048 // 2 MB of body per file => 16 MB of bodies total
+		budgetMB = 6    // unfixed retains ~16 MB; fixed retains well under 1 MB
+	)
+
+	// The `before` snapshot MUST be taken while the fixture does not yet exist.
+	// Taking it with `sources` already live silently subtracts the fixture size
+	// from the measurement: the sources are released before `after`, so ~17 MB
+	// of legitimate shrinkage cancels ~16 MB of illegitimate retention and the
+	// test reads ≈0. That confounding is what let the call-qname retention path
+	// slip past this guard in the first place.
+	runtime.GC()
+	runtime.GC()
+	var before runtime.MemStats
+	runtime.ReadMemStats(&before)
+
+	sources := make([]string, files)
+	totalBytes := 0
+	for i := range sources {
+		var sb strings.Builder
+		sb.WriteString("import pytest\n\n")
+		for f := 0; f < 4; f++ {
+			fmt.Fprintf(&sb, "def test_case_%d_%d():\n", i, f)
+			// Padding lines are indented so they are part of the function body.
+			sb.WriteString(strings.Repeat("    x = 1  # padding padding padding padding padding\n", bodyKB*1024/(4*50)))
+			fmt.Fprintf(&sb, "    result = CreateOrder_%d_%d(payload)\n", i, f)
+		}
+		sources[i] = sb.String()
+		totalBytes += len(sources[i])
+	}
+
+	// The budget assertion below can only observe the bug if the bodies the
+	// records would pin are substantially larger than the budget. Without this
+	// gate, shrinking the fixture silently turns the test into a tautology —
+	// the exact failure mode that has bitten this repo repeatedly. Verified by
+	// mutation: dropping bodyKB to 8 fails HERE rather than passing green.
+	totalMB := float64(totalBytes) / (1 << 20)
+	if totalMB < 2*budgetMB {
+		t.Fatalf("fixture generates only %.1f MB of test bodies against a %d MB budget; it cannot exhibit retention and the assertion below would pass vacuously", totalMB, budgetMB)
+	}
+
+	e := &Extractor{}
+	var kept [][]types.EntityRecord
+
+	for i, src := range sources {
+		recs, err := e.Extract(context.Background(), extractor.FileInput{
+			Path:     fmt.Sprintf("tests/test_orders_%d.py", i),
+			Language: "python",
+			Content:  []byte(src),
+		})
+		if err != nil {
+			t.Fatalf("Extract() error = %v", err)
+		}
+		if len(recs) == 0 {
+			t.Fatalf("Extract() returned no records for file %d; the fixture cannot exhibit retention", i)
+		}
+		kept = append(kept, recs)
+	}
+	// Drop every reference to the inputs; only `kept` may hold memory now.
+	for i := range sources {
+		sources[i] = ""
+	}
+
+	runtime.GC()
+	runtime.GC()
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	retained := int64(after.HeapAlloc) - int64(before.HeapAlloc)
+	retainedMB := float64(retained) / (1 << 20)
+	nrec := 0
+	for _, r := range kept {
+		nrec += len(r)
+	}
+	t.Logf("retained heap after extracting %.1f MB of test source across %d files: %.1f MB (%d records)",
+		totalMB, files, retainedMB, nrec)
+
+	if retainedMB > budgetMB {
+		t.Errorf("Extract() retained %.1f MB, want <= %d MB — the emitted records are pinning the test-function bodies they were sliced out of", retainedMB, budgetMB)
+	}
+	runtime.KeepAlive(kept)
+}

--- a/internal/extractors/cross/testmap/extractor.go
+++ b/internal/extractors/cross/testmap/extractor.go
@@ -394,6 +394,31 @@ func buildCollapsedEntity(
 	testQName string,
 	calls []testedCall,
 ) types.EntityRecord {
+	// #5954 — cut the body/source backing arrays loose before anything is
+	// retained.
+	//
+	// testQName and every testedCall.qname reach this function as SUBSTRING
+	// VIEWS: regexp's String API returns `input[a:b]`, so a 10-byte identifier
+	// keeps the entire captured test-function body (and, for the test name,
+	// the whole file source) alive for as long as it is reachable. These
+	// records live from pass 3 all the way to the document write, so without
+	// the clone every emitted test_coverage entity pins its own multi-KB body
+	// across the peak-heap phase — 223 MB of otherwise-dead bodies on the
+	// child's peak profile.
+	//
+	// Cloning here (the single chokepoint through which testmap emits records)
+	// copies a handful of short identifiers per test function and lets the
+	// bodies die with the extraction of their file. The cloned strings compare
+	// equal to the originals, so entity IDs, relationship IDs, ordering and
+	// every serialized byte are unchanged.
+	testQName = strings.Clone(testQName)
+	if len(calls) > 0 {
+		calls = append([]testedCall(nil), calls...)
+		for i := range calls {
+			calls[i].qname = strings.Clone(calls[i].qname)
+		}
+	}
+
 	// Primary call: highest-confidence entry (calls is already sorted high→low).
 	var primary testedCall
 	if len(calls) > 0 {
@@ -469,75 +494,14 @@ func buildCollapsedEntity(
 	return rec
 }
 
-// buildEntity assembles a SCOPE.Pattern EntityRecord (subtype "test_coverage")
-// plus its TESTS edge from the test function to the production function.
-//
-// Deprecated: prefer buildCollapsedEntity which emits one entity per test
-// function with all TESTS edges collapsed in, avoiding degree-0 orphans.
-// Retained for any callers that need the original one-entity-per-call form.
-func buildEntity(
-	filePath string,
-	language string,
-	framework string,
-	testType string,
-	testQName string,
-	tc testedCall,
-) types.EntityRecord {
-	entityID := testCoverageEntityID(filePath, testQName, tc.qname)
-	props := map[string]string{
-		"test_framework":  framework,
-		"test_type":       testType,
-		"tested_function": tc.qname,
-		"confidence":      tc.confidence,
-		"test_function":   testQName,
-		"ref":             entityID,
-		"provenance":      confidenceProvenance(tc.confidence),
-		// pattern_kind preserves the original semantic ("test_coverage")
-		// after we collapsed the entity Kind into the SCOPE.Pattern bucket so the graph
-		// allowlist validation passes.
-		"pattern_kind": "test_coverage",
-	}
-	// tested_file is only stamped for the low-confidence naming-convention
-	// fallback (issue #2060) — for high/medium calls prodFile is now also
-	// populated as a resolver hint, but the file is a convention guess and
-	// not a verified location, so we keep the property meaning ("the
-	// best-guess tested file when no direct call/mock was found").
-	if tc.prodFile != "" && tc.confidence == "low" {
-		props["tested_file"] = tc.prodFile
-	}
-
-	rec := types.EntityRecord{
-		Name: testQName + " -> " + tc.qname,
-		// SCOPE.TestCoverage is not in the 14-type allowlist.
-		// Coverage records map to SCOPE.Pattern (canonical bucket for inferred
-		// structural patterns); the framework-specific test type is preserved on
-		// Subtype, and the originating test framework remains on Properties.
-		Kind:         "SCOPE.Pattern",
-		SourceFile:   filePath,
-		Language:     language,
-		Subtype:      testType,
-		Properties:   props,
-		QualityScore: confidenceScore(tc.confidence),
-	}
-
-	fromID := testFunctionRef(filePath, testQName)
-	toID := productionFunctionRef(tc.prodFile, tc.qname)
-	if toID != "" {
-		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
-			FromID: fromID,
-			ToID:   toID,
-			Kind:   "TESTS",
-			Properties: types.Props{
-				{K: "confidence", V: tc.confidence},
-				{K: "test_framework", V: framework},
-				{K: "test_function", V: testQName},
-				{K: "tested", V: tc.qname},
-			},
-		})
-	}
-
-	return rec
-}
+// #5954 — the deprecated one-entity-per-call buildEntity was deleted here.
+// It had zero callers (buildCollapsedEntity superseded it in #2080) but built
+// records the same way WITHOUT cloning the resolver's substring views, so a
+// future caller reviving it would have silently reintroduced the test-body
+// retention this package's guards are written against — and no guard would
+// have caught it, because they exercise the emit path that actually runs.
+// Recover it from git history if the one-entity-per-call form is ever needed;
+// it must clone testQName and tc.qname the way buildCollapsedEntity does.
 
 func confidenceProvenance(c string) string {
 	switch c {


### PR DESCRIPTION
**−197 MB live heap (−24%) on the `index-internal` child, from 25 lines in one function.**

## Both targets named in the epic were wrong

Profiling `heap-peak.pprof` before changing anything:

- **`BuildImportTable` is not on the peak at all.** It does not appear in the materializing profile. (Roadmap observation from profiling, not a correctness claim for this PR.)
- **`buildDocument`'s per-pass copy is already fixed** — `mergePassRecords`/`appendAndRelease` landed in #5985 (`dba250584`, PR #5990), confirmed an ancestor of this branch.

The actual #1, traced rather than assumed:

```
188.4 MB  internal/bytealg.MakeNoZero          29.0% of the materializing profile
  <- strings.(*Builder).grow
  185.4 MB of it <- strings.Join <- testmap.extractIndentedBody <- testmap.detectPytest
```

Captured **test-function bodies**, semantically dead after pass 3, still reachable at the document write. The whole `testmap` subtree was 379 MB / 30% of a 1255 MB peak profile.

## Mechanism

`regexp`'s `String` API returns `input[a:b]` — a substring **view**, not a copy. Every identifier the test-map resolver lifts out of a body is a view pinning that body's entire backing array. Those identifiers go into `EntityRecord`/`RelationshipRecord` properties, which live from pass 3 to the write. So each `test_coverage` record pinned its own multi-KB body, and the test name pinned the whole file source.

**Brace languages are worse than Python.** `extractIndentedBody` returns a `strings.Join` allocation (a per-function copy), but `extractBraceBody` returns `source[start:i+1]` — a view into the **entire file**. Independently measured with a jest/TypeScript fixture: **16.7 MB retained unfixed → 0.1 MB fixed.**

## Fix

`strings.Clone` on `testQName` and each `testedCall.qname` in `buildCollapsedEntity`, the single chokepoint through which testmap emits records.

Independently verified as genuinely single: `Extract` is the only public entry with one emission call; an exhaustive package grep found exactly two record producers, and the other (`buildEntity`) was dead with zero callers repo-wide — **now deleted**, since it carried the same retention with no clone under a "retained for any callers that need the original form" comment, which is an invitation. Every string reaching a record was traced to its provenance, including `prodFile` back to `productionFileFromTestPath`'s `path.Join` allocations.

**Invariant:** `strings.Clone` returns a string equal to its input in everything the program can observe; only the backing array's identity changes. Confirmed nothing depends on that: `EntityID`/`RelationshipID` are sha256 content hashes, both interning mechanisms are content-keyed (`flatbuffers.CreateSharedString` maps by value; `internal/mcp/id_interning.go` runs post-load), there is no `unsafe.StringData` in non-test `internal/`, and nothing sorts or compares by address.

## Numbers — live heap, not RSS

django corpus, `GOMAXPROCS=3`, interleaved base/fix/base/fix, `swap_delta=0`, no paging:

| metric | base | fix | delta |
|---|---|---|---|
| live heap peak (`next_gc`/1.5, GOGC=50) | 806 / 804 MB | 597 / 619 MB | **−197 MB (−24%)** |
| pprof `inuse_space` @ materializing | 678.8 / 648.9 MB | 414.1 / 407.3 MB | **−253 MB (−38%)** |

`MakeNoZero` disappears entirely from the fixed profile. Wall time did not regress. Within-config spread was 2 MB / 22 MB, so the delta is ~9x the worst spread.

RSS is deliberately not headlined: macOS RSS counts `MADV_FREE` pages and is an upper bound, not a footprint. `next_gc/(1+GOGC/100)` is the correct inversion of Go's pacer target and a genuine live-heap proxy (`heap_inuse` is not).

## Correctness

**`requests`: `graph.fb` byte-identical apart from the timestamp digits.**

**django: whole-file `cmp` is not a valid instrument** — the same binary run twice differs in ~86.6 MB. Compared semantically instead: entity digest identical across all four runs; base-vs-fix differs in **8 of 791,025** relationships against **16** for a base-vs-base control. The load-bearing fact is not `8 < 16` — it is that **every diverging edge in both sets is a django-ORM `setUpTestData` `filter_keys` edge, and no testmap edge appears in either**. Map iteration order is seeded per-process and independent of addresses, so a `strings.Clone` cannot systematically perturb it.

That nondeterminism is pre-existing and filed as **#6083**. Its cause was initially misdiagnosed twice — first as a variable-length `indexed_at` field (there is no such field; `computed_at` is fixed-width 20 bytes and cannot shift an offset), then as evidence of nondeterminism larger than the 16 relationships. Neither held. The diverging `filter_keys` values differ in **length** (`age,name`(8) vs `alias,name`(10)), netting 4 bytes, and one length change shifts every subsequent flatbuffer offset — sufficient to produce 86.6 MB on its own. Corroborated: file sizes differ by 12 bytes, the first differing bytes at offsets 152–155 are digits changing **in place**, and the first non-digit divergence is at offset 169. Both corrections are recorded on #6083.

## Guards

The e2e retention guard was **wrong when first written** — it snapshotted the heap while the 17 MB fixture was still live, so legitimate shrinkage cancelled illegitimate retention and it read ≈0, letting a mutation survive. The snapshot now precedes the fixture, and a fixture-size gate coupled to the budget (`totalMB < 2*budgetMB` → `Fatal`) means inflating the budget trips the gate rather than silently widening it.

Mutation battery, 9/9 caught, all real test failures: revert whole fix · drop call-qname clone · drop testQName clone · discard clone result · blind the pointer detector · strip calls from the unit fixture · shrink e2e bodies · inflate e2e budget · **clone then corrupt the value**. The last one initially passed the new guards (caught only by the wider package suite); three value assertions were added so the file is now self-contained.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `./internal/extractors/...`, `./internal/graph/...`, `./internal/daemon/extract/...`, `./internal/resolve/...`, `./cmd/grafel/` green at `-count=1 -p 1`, verified independently rather than taken from the report.

Two independent adversarial review rounds.

Refs #5954
