### PR TITLE
fix(#6085): stop the incremental merge deleting a third of the graph; persist relationship identity

### DIFF
--- a/cmd/grafel/incremental_merge_test.go
+++ b/cmd/grafel/incremental_merge_test.go
@@ -214,8 +214,198 @@ func TestMergeIncrementalPrevDoc_ThreeFileScenario(t *testing.T) {
 			t.Errorf("merged doc missing entities from %s; #2719 regression", f)
 		}
 	}
-	// Both prev edges still point at live endpoints → both carried forward.
+	// Edge carry-forward, per the #6085 invariant:
+	//   ab (a.go → b.go) is anchored in the UNCHANGED a.go: this run never
+	//     re-emitted it, so it must survive. B kept its ID, so it is not a
+	//     dangling pointer either.
+	//   bc (b.go → c.go) is anchored in the RE-EXTRACTED b.go. The fresh pass
+	//     emitted no outgoing edge for B, which means the call is gone from
+	//     the source — the prev copy is superseded and must be dropped.
+	// (Before #6085 this asserted 2: bc was retained purely because both of
+	// its endpoint rows happened to still exist, so a deleted call lived on
+	// in the graph indefinitely.)
+	if len(doc.Relationships) != 1 {
+		t.Errorf("relationships=%d want 1 (ab carried forward, bc superseded)", len(doc.Relationships))
+	}
+	for _, r := range doc.Relationships {
+		if r.FromID == "ID_b" && r.ToID == "ID_c" {
+			t.Error("edge out of the re-extracted b.go survived; the fresh pass did not re-emit it")
+		}
+	}
+	if len(doc.Relationships) == 1 && doc.Relationships[0].FromID != "ID_a" {
+		t.Errorf("surviving edge = %s→%s, want ID_a→ID_b",
+			doc.Relationships[0].FromID, doc.Relationships[0].ToID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6085 — the incremental merge dropped ~35% of the graph on every run.
+//
+// The invariant these tests pin, in both directions:
+//
+//	a prev relationship is dropped IFF it is genuinely superseded by this
+//	run's re-extraction — i.e. its FromID is an entity anchored in a file we
+//	just re-extracted (that file re-emitted its outgoing edges), or its ToID
+//	is an entity anchored in a re-extracted file that no longer exists.
+//
+// The pre-#6085 predicate was "both endpoints resolve to a live entity row",
+// which is wrong in BOTH directions:
+//
+//   - too aggressive: it deleted every edge whose endpoint is not an entity
+//     row — ext:* synthetics and unresolved bare-name targets — even though a
+//     full reindex keeps them. On archigraph that was 347,946 edges after a
+//     ONE-file change.
+//   - too conservative: it KEPT an edge out of a changed file whenever the
+//     re-extraction happened to mint the same entity ID, so a call deleted
+//     from the source survived in the graph forever.
+// ---------------------------------------------------------------------------
+
+// TestMergeIncrementalPrevDoc_KeepsEdgesIntoNonEntityEndpoints pins the
+// "too aggressive" direction: edges into synthetic ext:* nodes and into
+// unresolved bare-name targets are NOT stale and must be carried forward.
+// Fails on e43dbeab9 (both edges dropped, ext node lost).
+func TestMergeIncrementalPrevDoc_KeepsEdgesIntoNonEntityEndpoints(t *testing.T) {
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "A", Name: "AlphaFn", Kind: "SCOPE.Operation", SourceFile: "a.go"},
+			// Synthetic external: no source file. external.Synthesize minted
+			// it on a previous run and persisted it into the graph.
+			{ID: "ext:fmt", Name: "fmt", Kind: "SCOPE.External", SourceFile: ""},
+			// A synthetic nothing points at: must NOT be resurrected.
+			{ID: "ext:orphan", Name: "orphan", Kind: "SCOPE.External", SourceFile: ""},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "A", ToID: "ext:fmt", Kind: "IMPORTS"},
+			// Unresolved bare-name target: never an entity row, in the full
+			// reindex either. Still a real edge the graph ships.
+			{ID: "r2", FromID: "A", ToID: "Join", Kind: "CALLS"},
+		},
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+	}
+
+	stats := mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	if stats.relsDropped != 0 {
+		t.Errorf("relsDropped=%d want 0: neither edge is superseded by re-extracting b.go", stats.relsDropped)
+	}
+	if stats.relsAdded != 2 {
+		t.Errorf("relsAdded=%d want 2 (IMPORTS→ext:fmt, CALLS→bare name)", stats.relsAdded)
+	}
+	got := map[string]bool{}
+	for _, r := range doc.Relationships {
+		got[r.FromID+"->"+r.ToID] = true
+	}
+	for _, want := range []string{"A->ext:fmt", "A->Join"} {
+		if !got[want] {
+			t.Errorf("edge %s lost by the incremental merge (#6085)", want)
+		}
+	}
+	// The ext node a surviving edge points at must come back so the carried
+	// edge does not dangle; the unreferenced one must not.
+	ents := map[string]bool{}
+	for _, e := range doc.Entities {
+		ents[e.ID] = true
+	}
+	if !ents["ext:fmt"] {
+		t.Error("ext:fmt is referenced by a carried edge but was not carried forward — dangling edge")
+	}
+	if ents["ext:orphan"] {
+		t.Error("unreferenced synthetic ext:orphan must not be carried forward")
+	}
+}
+
+// TestMergeIncrementalPrevDoc_DropsSupersededEdgeOutOfChangedFile pins the
+// "too conservative" direction: when a changed file's entity keeps its ID but
+// the source no longer contains the call, the prev edge MUST go. A fix that
+// simply drops fewer edges fails this test.
+func TestMergeIncrementalPrevDoc_DropsSupersededEdgeOutOfChangedFile(t *testing.T) {
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "A", Name: "AlphaFn", Kind: "SCOPE.Operation", SourceFile: "a.go"},
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+		Relationships: []graph.Relationship{
+			// b.go used to call a.go. The edit under test deleted that call.
+			{ID: "rBA", FromID: "B", ToID: "A", Kind: "CALLS"},
+			// a.go calls b.go — anchored in an UNCHANGED file, so this run
+			// never re-emitted it and it must be preserved.
+			{ID: "rAB", FromID: "A", ToID: "B", Kind: "CALLS"},
+		},
+	}
+	// Fresh extraction of b.go: same deterministic ID for B, no outgoing call.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+	}
+
+	stats := mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	for _, r := range doc.Relationships {
+		if r.FromID == "B" && r.ToID == "A" {
+			t.Error("edge out of the re-extracted file survived the merge — the deleted call is still in the graph")
+		}
+	}
+	if stats.relsDropped != 1 {
+		t.Errorf("relsDropped=%d want 1 (only B→A is superseded)", stats.relsDropped)
+	}
+	found := false
+	for _, r := range doc.Relationships {
+		if r.FromID == "A" && r.ToID == "B" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("edge from the UNCHANGED file into the changed file was dropped — it was never re-emitted, so it is lost")
+	}
+}
+
+// TestMergeIncrementalPrevDoc_RestoresRelationshipIDAndDedupes pins the
+// duplicate-accumulation half of #6085. graph.fb does not persist
+// Relationship.ID, so prev edges arrive with an empty one; keying the dedupe
+// on that empty ID meant every incremental run re-appended edges the fresh
+// pass had already emitted, and the graph grew without bound.
+func TestMergeIncrementalPrevDoc_RestoresRelationshipIDAndDedupes(t *testing.T) {
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "A", Name: "AlphaFn", Kind: "SCOPE.Operation", SourceFile: "a.go"},
+			{ID: "C", Name: "GammaFn", Kind: "SCOPE.Operation", SourceFile: "c.go"},
+		},
+		Relationships: []graph.Relationship{
+			// Both arrive ID-less, exactly as LoadGraphFromDir returned them
+			// before the fbRelToGraphRel fix.
+			{FromID: "A", ToID: "C", Kind: "CALLS"},
+			{FromID: "C", ToID: "A", Kind: "CALLS"},
+		},
+	}
+	// The fresh run already emitted A→C (with a proper ID).
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: graph.RelationshipID("A", "C", "CALLS"), FromID: "A", ToID: "C", Kind: "CALLS"},
+		},
+	}
+
+	stats := mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	if stats.relsAdded != 1 {
+		t.Errorf("relsAdded=%d want 1 (A→C already present, only C→A is new)", stats.relsAdded)
+	}
 	if len(doc.Relationships) != 2 {
-		t.Errorf("relationships=%d want 2 (ab,bc carried forward)", len(doc.Relationships))
+		t.Fatalf("relationships=%d want 2 — the merge duplicated an edge the fresh pass had emitted", len(doc.Relationships))
+	}
+	for _, r := range doc.Relationships {
+		if r.ID == "" {
+			t.Errorf("carried edge %s→%s has no ID; consumers key on it", r.FromID, r.ToID)
+		}
+		if want := graph.RelationshipID(r.FromID, r.ToID, r.Kind); r.ID != want {
+			t.Errorf("edge %s→%s ID=%q want %q", r.FromID, r.ToID, r.ID, want)
+		}
 	}
 }

--- a/cmd/grafel/incremental_merge_test.go
+++ b/cmd/grafel/incremental_merge_test.go
@@ -397,15 +397,262 @@ func TestMergeIncrementalPrevDoc_RestoresRelationshipIDAndDedupes(t *testing.T) 
 	if stats.relsAdded != 1 {
 		t.Errorf("relsAdded=%d want 1 (A→C already present, only C→A is new)", stats.relsAdded)
 	}
-	if len(doc.Relationships) != 2 {
-		t.Fatalf("relationships=%d want 2 — the merge duplicated an edge the fresh pass had emitted", len(doc.Relationships))
+	// Assert the resulting edge SET with multiplicities, not just the count.
+	// Counting alone passes on a result that duplicated one edge AND destroyed
+	// another, which is exactly what a dedupe keyed on the (empty) prev ID
+	// produces: [A→C, A→C] with C→A gone.
+	got := map[string]int{}
+	for _, r := range doc.Relationships {
+		got[r.FromID+"->"+r.ToID+":"+r.Kind]++
+	}
+	want := map[string]int{"A->C:CALLS": 1, "C->A:CALLS": 1}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("edge %s appears %d time(s), want %d — merged set is %v", k, got[k], n, got)
+		}
+	}
+	for k, n := range got {
+		if want[k] == 0 {
+			t.Errorf("unexpected edge %s (x%d) in merged graph", k, n)
+		}
 	}
 	for _, r := range doc.Relationships {
 		if r.ID == "" {
 			t.Errorf("carried edge %s→%s has no ID; consumers key on it", r.FromID, r.ToID)
 		}
-		if want := graph.RelationshipID(r.FromID, r.ToID, r.Kind); r.ID != want {
-			t.Errorf("edge %s→%s ID=%q want %q", r.FromID, r.ToID, r.ID, want)
+	}
+}
+
+// TestMergeIncrementalPrevDoc_KeepsDistinctEdgesSharingATriple pins the other
+// half of edge identity: (FromID, ToID, Kind) is NOT a unique key. Several
+// producers deliberately mint distinct salted IDs for edges that share one
+// triple — here, the three schema ops a single Django migration performs on
+// the same table, which converge on one table node yet must remain three
+// edges (internal/engine/migration_schema_ops.go). A merge that dedupes on
+// the triple alone carries one of the three and silently deletes the rest,
+// permanently diverging from a full reindex on an UNCHANGED file.
+func TestMergeIncrementalPrevDoc_KeepsDistinctEdgesSharingATriple(t *testing.T) {
+	const from, to, kind = "mig:0003", "ext:db.users", "MODIFIES"
+	salted := func(op string) graph.Relationship {
+		return graph.Relationship{
+			ID:     graph.RelationshipID(from, to, kind+"\x00"+op),
+			FromID: from, ToID: to, Kind: kind,
+		}.WithProperties(map[string]string{"op": op})
+	}
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: from, Name: "0003_add_email", Kind: "SCOPE.Operation", SourceFile: "m.py"},
+			{ID: to, Name: "db.users", Kind: "SCOPE.Datastore", SourceFile: ""},
+		},
+		Relationships: []graph.Relationship{
+			salted("create_table"), salted("add_column"), salted("drop_column"),
+		},
+	}
+	// An unrelated file was edited; m.py was not re-extracted.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+	}
+
+	stats := mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	if stats.relsAdded != 3 {
+		t.Errorf("relsAdded=%d want 3", stats.relsAdded)
+	}
+	ids := map[string]bool{}
+	n := 0
+	for _, r := range doc.Relationships {
+		if r.FromID == from && r.ToID == to && r.Kind == kind {
+			n++
+			ids[r.ID] = true
 		}
+	}
+	if n != 3 {
+		t.Errorf("carried %d of 3 semantically-distinct %s edges — the dedupe collapsed them", n, kind)
+	}
+	if len(ids) != 3 {
+		t.Errorf("carried edges have %d distinct IDs, want 3: %v", len(ids), ids)
+	}
+}
+
+// TestMergeIncrementalPrevDoc_DedupeIsPerIdentityNotPerTriple is the
+// discriminating case for the dedupe key. It only bites when the fresh pass
+// re-emits ONE of several edges that share a triple — which the corpus-wide
+// synthesisers do (they run over the whole file set, not just changed files),
+// so `doc` can hold a same-triple edge whose prev siblings must still come
+// across.
+//
+// prev order deliberately does not match doc: a triple-keyed dedupe consumes
+// the doc slot against the WRONG sibling, so it carries a duplicate of the one
+// the fresh pass already emitted and silently drops a different one. Counting
+// edges cannot see this — the total is right either way — so the assertion is
+// on the identity set.
+func TestMergeIncrementalPrevDoc_DedupeIsPerIdentityNotPerTriple(t *testing.T) {
+	const from, to, kind = "flow:checkout", "svc:payments", "STEP_IN_PROCESS"
+	salted := func(step string) graph.Relationship {
+		return graph.Relationship{
+			ID:     graph.RelationshipID(from, to, kind+":"+step),
+			FromID: from, ToID: to, Kind: kind,
+		}.WithProperties(map[string]string{"step_index": step})
+	}
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: from, Name: "checkout", Kind: "SCOPE.Process", SourceFile: "flow.go"},
+			{ID: to, Name: "payments", Kind: "SCOPE.Component", SourceFile: "svc.go"},
+		},
+		// Note the order: step 1 first, not the one doc re-emitted.
+		Relationships: []graph.Relationship{salted("1"), salted("0"), salted("2")},
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+		Relationships: []graph.Relationship{salted("0")},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	got := map[string]int{}
+	for _, r := range doc.Relationships {
+		got[r.ID]++
+	}
+	for _, step := range []string{"0", "1", "2"} {
+		id := salted(step).ID
+		if got[id] != 1 {
+			t.Errorf("step %s edge (id %s) appears %d time(s), want exactly 1 — merged identities: %v",
+				step, id, got[id], got)
+		}
+	}
+	if len(doc.Relationships) != 3 {
+		t.Errorf("relationships=%d want 3", len(doc.Relationships))
+	}
+}
+
+// TestMergeIncrementalPrevDoc_CarriesSyntheticReferencedOnlyByADedupedEdge
+// pins the ordering inside the relationship loop: an edge suppressed as a
+// duplicate still REFERENCES its endpoints. If the synthetic is only reachable
+// through such an edge and we mark references after the dedupe, the synthetic
+// is not carried and the fresh copy of that same edge dangles.
+func TestMergeIncrementalPrevDoc_CarriesSyntheticReferencedOnlyByADedupedEdge(t *testing.T) {
+	edge := graph.Relationship{
+		ID:     graph.RelationshipID("A", "ext:redis", "DEPENDS_ON"),
+		FromID: "A", ToID: "ext:redis", Kind: "DEPENDS_ON",
+	}
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "A", Name: "AlphaFn", Kind: "SCOPE.Operation", SourceFile: "a.go"},
+			{ID: "ext:redis", Name: "redis", Kind: "SCOPE.External", SourceFile: ""},
+		},
+		Relationships: []graph.Relationship{edge},
+	}
+	// A corpus-wide pass in this run re-emitted the very same edge, so the
+	// merge dedupes it — but the ext node it points at lives only in prev.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+		Relationships: []graph.Relationship{edge},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	found := false
+	for _, e := range doc.Entities {
+		if e.ID == "ext:redis" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("ext:redis is the target of a surviving edge but was not carried forward — that edge now dangles")
+	}
+	if len(doc.Relationships) != 1 {
+		t.Errorf("relationships=%d want 1 (the edge was already emitted by this run)", len(doc.Relationships))
+	}
+}
+
+// TestMergeIncrementalPrevDoc_LegacyGraphKeepsCollidingRows pins the upgrade
+// path. A graph.fb written BEFORE #6085 persisted no relationship identity at
+// all, so the salted producers' edges all load with the same derived ID and
+// collide on the dedupe key — the on-disk information is genuinely gone and no
+// key can separate them. Counting multiplicity still preserves every row, so
+// the first incremental after an upgrade does not delete two thirds of them;
+// one rewrite then restores real identity.
+func TestMergeIncrementalPrevDoc_LegacyGraphKeepsCollidingRows(t *testing.T) {
+	const from, to, kind = "mig:0003", "ext:db.users", "MODIFIES"
+	// As a pre-#6085 graph.fb loads them: no ID, one indistinguishable triple.
+	legacy := func(op string) graph.Relationship {
+		return graph.Relationship{FromID: from, ToID: to, Kind: kind}.
+			WithProperties(map[string]string{"op": op})
+	}
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: from, Name: "0003_add_email", Kind: "SCOPE.Operation", SourceFile: "m.py"},
+			{ID: to, Name: "db.users", Kind: "SCOPE.Datastore", SourceFile: ""},
+		},
+		Relationships: []graph.Relationship{
+			legacy("create_table"), legacy("add_column"), legacy("drop_column"),
+		},
+	}
+	// This run's corpus-wide pass re-emitted one of them.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+		Relationships: []graph.Relationship{
+			graph.Relationship{ID: graph.RelationshipID(from, to, kind), FromID: from, ToID: to, Kind: kind}.
+				WithProperties(map[string]string{"op": "create_table"}),
+		},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	n := 0
+	for _, r := range doc.Relationships {
+		if r.FromID == from && r.ToID == to && r.Kind == kind {
+			n++
+		}
+	}
+	if n != 3 {
+		t.Errorf("kept %d of the 3 rows a legacy graph holds for this triple — presence-based dedupe deletes the indistinguishable siblings", n)
+	}
+}
+
+// TestMergeIncrementalPrevDoc_IdentityAloneSeparatesEdges states the contract
+// the dedupe key rests on: Relationship.ID IS the identity of an edge. Two
+// edges that agree on endpoints, kind and payload but carry different IDs are
+// two edges, and the merge must keep both.
+//
+// Every salted producer today also mirrors its salt into a property (op,
+// step_index, method, derived-helper), so a key built from triple+payload
+// alone would pass on the current corpus — and silently start collapsing
+// edges the day a producer salts on something it does not also publish. The
+// ID is in the key so that never becomes a data-loss bug.
+func TestMergeIncrementalPrevDoc_IdentityAloneSeparatesEdges(t *testing.T) {
+	twin := func(id string) graph.Relationship {
+		return graph.Relationship{ID: id, FromID: "A", ToID: "ext:queue", Kind: "PUBLISHES_TO"}.
+			WithProperties(map[string]string{"topic": "orders"})
+	}
+	prev := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "A", Name: "AlphaFn", Kind: "SCOPE.Operation", SourceFile: "a.go"},
+			{ID: "ext:queue", Name: "queue", Kind: "SCOPE.External", SourceFile: ""},
+		},
+		Relationships: []graph.Relationship{twin("1111111111111111"), twin("2222222222222222")},
+	}
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "B", Name: "BetaFn", Kind: "SCOPE.Operation", SourceFile: "b.go"},
+		},
+	}
+
+	mergeIncrementalPrevDoc(doc, prev, map[string]bool{"b.go": true})
+
+	ids := map[string]bool{}
+	for _, r := range doc.Relationships {
+		ids[r.ID] = true
+	}
+	if len(ids) != 2 {
+		t.Errorf("kept %d of 2 distinct edge identities: %v — identity is the key, not the payload", len(ids), ids)
 	}
 }

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -5336,14 +5336,32 @@ type incrementalMergeStats struct {
 //   - Adds every prev entity whose SourceFile is NOT in changedFiles, unless
 //     an entity with the same ID is already present in doc (which would
 //     indicate a re-extraction collision from a freshly-extracted file).
-//   - Adds every prev relationship whose endpoints are both alive — meaning
-//     both endpoints are either already in doc or are being carried forward
-//     in this same merge. Edges with an endpoint sourced from a changed file
-//     are dropped: the per-file extraction pass already re-emitted the
-//     authoritative version of those edges against the fresh entity IDs.
-//   - Pure-string-keyed relationships pointing at synthetic / external nodes
-//     (kind="ext:*", or any entity ID present in doc.Entities) are carried
-//     forward normally — the surviving-endpoint check covers them.
+//   - Carries a prev relationship forward UNLESS it is genuinely superseded by
+//     this run's re-extraction. #6085: the staleness test is "was this edge
+//     re-produced by the files we just re-extracted?", NOT "do both endpoints
+//     resolve to a live entity row". An edge is dropped iff:
+//     (a) its FromID is a prev entity anchored in a CHANGED file — that file's
+//     re-extraction re-emitted its outgoing edges, so the prev copy is
+//     superseded; or
+//     (b) its ToID is a prev entity anchored in a CHANGED file that no longer
+//     exists after re-extraction (renamed/deleted) — the edge now points at
+//     a destroyed node.
+//     Every other prev edge is preserved verbatim, including edges whose
+//     endpoint is a synthetic ext:* node or an unresolved bare name. Those
+//     endpoints are not entity rows, so the old endpoint-liveness test dropped
+//     them wholesale even though a full reindex keeps them (#6085: ~35% of the
+//     graph on archigraph — every IMPORTS/CALLS edge into an external package
+//     plus every unresolved-target edge).
+//   - Carries forward the source-less prev entities (ext:* / _external
+//     synthetics) that are still referenced by a surviving edge, so those
+//     carried edges do not dangle. external.Synthesize runs after this merge
+//     and is idempotent against entity IDs already present, so re-adding them
+//     here does not double-emit.
+//   - Restores the deterministic relationship ID on carried edges. graph.fb
+//     does not persist Relationship.ID (see fbRelToGraphRel), so prev edges
+//     arrive with an empty ID; leaving it empty defeated the dedupe below and
+//     made every incremental run append duplicates of edges the fresh pass had
+//     already emitted (#6085: the run-to-run count drift).
 //
 // The function is intentionally separate from internal/extractors.TryIncremental:
 // TryIncremental owns the daemon's fast in-place reindex (Path A), while this
@@ -5365,49 +5383,82 @@ func mergeIncrementalPrevDoc(doc *graph.Document, prev *graph.Document, changedF
 		docEntityIDs[e.ID] = true
 	}
 
-	// First pass: copy across entities sourced from UNCHANGED files. Track
-	// every entity ID that will survive the merge so we can filter
-	// relationships in the second pass.
-	survivingIDs := make(map[string]bool, len(docEntityIDs)+len(prev.Entities))
-	for id := range docEntityIDs {
-		survivingIDs[id] = true
-	}
+	// First pass: copy across entities sourced from UNCHANGED files, and
+	// record the IDs of prev entities anchored in a CHANGED file — those are
+	// the only ones whose incident edges this run could have superseded.
+	changedEntityIDs := make(map[string]bool)
+	// Source-less prev entities (ext:* / _external synthetics) are held back
+	// until the relationship pass has told us which of them a surviving edge
+	// still references (#6085).
+	var syntheticPrev []graph.Entity
 	for _, e := range prev.Entities {
-		// Entities without a source file (e.g. ext:* synthetics) are
-		// regenerated downstream by external.Synthesize against the merged
-		// graph; skip them here so we do not double-emit.
 		if e.SourceFile == "" {
+			if !docEntityIDs[e.ID] {
+				syntheticPrev = append(syntheticPrev, e)
+			}
 			continue
 		}
 		if changedFiles[filepath.ToSlash(e.SourceFile)] {
+			changedEntityIDs[e.ID] = true
 			continue
 		}
 		if docEntityIDs[e.ID] {
 			continue
 		}
 		doc.Entities = append(doc.Entities, e)
-		survivingIDs[e.ID] = true
+		docEntityIDs[e.ID] = true
 		stats.entitiesAdded++
 	}
 
-	// Second pass: copy across relationships whose endpoints are both alive
-	// in the merged graph. Edges incident to a changed-file entity are
-	// dropped — the fresh extraction has already emitted the canonical
-	// replacements against the new entity IDs in this run.
-	docRelIDs := make(map[string]bool, len(doc.Relationships))
-	for _, r := range doc.Relationships {
-		docRelIDs[r.ID] = true
+	// Second pass: copy across every prev relationship that this run did not
+	// supersede. See the doc comment for the exact drop predicate (#6085).
+	// Dedupe is keyed on the deterministic (from, to, kind) triple rather than
+	// on Relationship.ID: graph.fb does not persist the ID, so prev edges
+	// arrive with an empty one.
+	relKey := func(r *graph.Relationship) string {
+		return r.FromID + "\x00" + r.ToID + "\x00" + r.Kind
 	}
+	docRelKeys := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		docRelKeys[relKey(&doc.Relationships[k])] = true
+	}
+	referenced := make(map[string]bool)
 	for _, r := range prev.Relationships {
-		if !survivingIDs[r.FromID] || !survivingIDs[r.ToID] {
+		// (a) the edge's owning file was re-extracted this run.
+		if changedEntityIDs[r.FromID] {
 			stats.relsDropped++
 			continue
 		}
-		if docRelIDs[r.ID] {
+		// (b) the edge's target was destroyed by this run's re-extraction.
+		if changedEntityIDs[r.ToID] && !docEntityIDs[r.ToID] {
+			stats.relsDropped++
 			continue
+		}
+		key := relKey(&r)
+		if docRelKeys[key] {
+			continue
+		}
+		docRelKeys[key] = true
+		if r.ID == "" {
+			r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
 		}
 		doc.Relationships = append(doc.Relationships, r)
 		stats.relsAdded++
+		referenced[r.FromID] = true
+		referenced[r.ToID] = true
+	}
+
+	// Third pass: re-attach the source-less synthetic endpoints that surviving
+	// edges still point at, so no carried edge dangles. Synthetics nothing
+	// references are left out — external.Synthesize regenerates whatever the
+	// current graph actually needs.
+	for _, e := range syntheticPrev {
+		if !referenced[e.ID] || docEntityIDs[e.ID] {
+			continue
+		}
+		doc.Entities = append(doc.Entities, e)
+		docEntityIDs[e.ID] = true
+		stats.entitiesAdded++
 	}
 
 	doc.Stats.Entities = len(doc.Entities)

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -5357,11 +5357,13 @@ type incrementalMergeStats struct {
 //     carried edges do not dangle. external.Synthesize runs after this merge
 //     and is idempotent against entity IDs already present, so re-adding them
 //     here does not double-emit.
-//   - Restores the deterministic relationship ID on carried edges. graph.fb
-//     does not persist Relationship.ID (see fbRelToGraphRel), so prev edges
-//     arrive with an empty ID; leaving it empty defeated the dedupe below and
-//     made every incremental run append duplicates of edges the fresh pass had
-//     already emitted (#6085: the run-to-run count drift).
+//   - Dedupes carried edges against the fresh ones by (from, to, kind, ID)
+//     multiplicity. Before #6085 graph.fb persisted no relationship ID at all,
+//     so every prev edge arrived with an empty one, the dedupe never matched,
+//     and each incremental run appended duplicates of edges the fresh pass had
+//     already emitted (the run-to-run count drift). fbwriter now persists the
+//     ID; the key includes it because (from, to, kind) is NOT unique — see
+//     graph.RelationshipIDProperty for the producers that rely on that.
 //
 // The function is intentionally separate from internal/extractors.TryIncremental:
 // TryIncremental owns the daemon's fast in-place reindex (Path A), while this
@@ -5412,11 +5414,59 @@ func mergeIncrementalPrevDoc(doc *graph.Document, prev *graph.Document, changedF
 
 	// Second pass: copy across every prev relationship that this run did not
 	// supersede. See the doc comment for the exact drop predicate (#6085).
-	// Dedupe is keyed on the deterministic (from, to, kind) triple rather than
-	// on Relationship.ID: graph.fb does not persist the ID, so prev edges
-	// arrive with an empty one.
+	//
+	// Dedupe key is (from, to, kind, ID, properties).
+	//
+	// The ID is load-bearing, NOT redundant: several producers deliberately
+	// mint distinct IDs for edges that share one triple (migration ops salted
+	// per operation, phantom CALLS salted per HTTP method, process/event steps
+	// salted per step index — see graph.RelationshipIDProperty), so a
+	// triple-keyed dedupe silently collapses semantically distinct edges.
+	//
+	// The properties are load-bearing too, for the upgrade path: a graph.fb
+	// written before #6085 persisted no identity at all, so those salted
+	// siblings all load with the SAME derived ID and are separable only by
+	// their payload. Keying on the payload keeps all of them.
+	//
+	// Anything left over — same endpoints, same kind, same identity, same
+	// payload — is the same edge twice, never two edges. Collapsing it is what
+	// stops the graph growing: passes that run AFTER this merge append edges
+	// that are already in the carried-forward set, and without this the
+	// duplicates compound on every incremental run (measured: +380 rows/run,
+	// unbounded).
+	//
+	// An absent ID is normalized to the derived one — exactly what
+	// LoadGraphFromDir does — so a prev Document assembled by hand keys the
+	// same way as one read off disk, and an ID-less prev edge cannot slip past
+	// the dedupe and duplicate an edge the fresh pass already emitted.
 	relKey := func(r *graph.Relationship) string {
-		return r.FromID + "\x00" + r.ToID + "\x00" + r.Kind
+		id := r.ID
+		if id == "" {
+			id = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+		}
+		var b strings.Builder
+		b.WriteString(r.FromID)
+		b.WriteByte(0)
+		b.WriteString(r.ToID)
+		b.WriteByte(0)
+		b.WriteString(r.Kind)
+		b.WriteByte(0)
+		b.WriteString(id)
+		props := r.PropsSnapshot()
+		if len(props) > 0 {
+			keys := make([]string, 0, len(props))
+			for k := range props {
+				keys = append(keys, k)
+			}
+			sort.Strings(keys)
+			for _, k := range keys {
+				b.WriteByte(0)
+				b.WriteString(k)
+				b.WriteByte(1)
+				b.WriteString(props[k])
+			}
+		}
+		return b.String()
 	}
 	docRelKeys := make(map[string]bool, len(doc.Relationships))
 	for k := range doc.Relationships {
@@ -5434,8 +5484,15 @@ func mergeIncrementalPrevDoc(doc *graph.Document, prev *graph.Document, changedF
 			stats.relsDropped++
 			continue
 		}
+		// Mark the endpoints BEFORE the dedupe below: an edge the fresh pass
+		// already emitted still references its endpoints, and the synthetic
+		// node it points at must be carried forward for THAT edge's sake.
+		referenced[r.FromID] = true
+		referenced[r.ToID] = true
 		key := relKey(&r)
 		if docRelKeys[key] {
+			// Already in the merged graph — either emitted by this run's
+			// extraction, or an exact duplicate row earlier in prev.
 			continue
 		}
 		docRelKeys[key] = true
@@ -5444,8 +5501,6 @@ func mergeIncrementalPrevDoc(doc *graph.Document, prev *graph.Document, changedF
 		}
 		doc.Relationships = append(doc.Relationships, r)
 		stats.relsAdded++
-		referenced[r.FromID] = true
-		referenced[r.ToID] = true
 	}
 
 	// Third pass: re-attach the source-less synthetic endpoints that surviving

--- a/internal/graph/fbwriter/writer.go
+++ b/internal/graph/fbwriter/writer.go
@@ -239,7 +239,28 @@ func buildRelationship(b *flatbuffers.Builder, r *graph.Relationship) flatbuffer
 	fromOff := b.CreateSharedString(r.FromID)
 	toOff := b.CreateSharedString(r.ToID)
 	kindOff := b.CreateSharedString(r.Kind)
-	propsVec := buildPropertyVector(b, r.PropsSnapshot())
+	props := r.PropsSnapshot()
+	// #6085 — persist relationship identity. graph.fb has no id field, so a
+	// round-trip used to return every edge with an EMPTY ID, and (from,to,kind)
+	// is NOT a key: several producers deliberately mint distinct IDs for edges
+	// that share a triple (migration ops salted per operation, phantom CALLS
+	// salted per HTTP method, process/event steps salted per step index). Those
+	// edges are semantically distinct and must stay distinct across a reload.
+	//
+	// The ID is stored as a reserved "id" property (no schema change, no format
+	// bump — the loader strips it back out, so a round-tripped Relationship has
+	// exactly the properties it was written with). It is written ONLY when the
+	// ID is not derivable from (from, to, kind), so the common unsalted edge
+	// costs nothing on disk and the loader recomputes it instead.
+	if r.ID != "" && r.ID != graph.RelationshipID(r.FromID, r.ToID, r.Kind) {
+		withID := make(map[string]string, len(props)+1)
+		for k, v := range props {
+			withID[k] = v
+		}
+		withID[graph.RelationshipIDProperty] = r.ID
+		props = withID
+	}
+	propsVec := buildPropertyVector(b, props)
 	fb.RelationshipStart(b)
 	fb.RelationshipAddFromId(b, fromOff)
 	fb.RelationshipAddToId(b, toOff)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -276,11 +276,19 @@ func EntityID(repo, kind, name, sourceFile string) string {
 // method (internal/links/phantom_edges.go), process/event steps salted per
 // step index — so identity cannot be recovered from the endpoints alone.
 //
-// The key is reserved: no producer emits a relationship property called "id",
-// fbwriter writes it only when the ID is not derivable from the triple, and
+// The leading NUL makes the key unreachable by construction rather than by
+// convention: no producer can collide with it, so identity can never be
+// hijacked by a payload key and a payload key can never be swallowed as
+// identity. A plain "id" WOULD collide — relationships carrying a producer-set
+// "id" property already exist in tree (internal/mcp/mmapview_test.go:70) — and
+// the failure would be silent in both directions: the loader would lift the
+// producer's value into Relationship.ID and delete the property, and the writer
+// would overwrite the producer's value on any salted edge.
+//
+// fbwriter writes the key only when the ID is not derivable from the triple;
 // the loader strips it back out of Properties after restoring the ID. It must
 // never be read or written as an ordinary property.
-const RelationshipIDProperty = "id"
+const RelationshipIDProperty = "\x00id"
 
 // RelationshipID computes a stable 16-char hex id for an edge. It is the
 // DEFAULT identity scheme, not the only one — see RelationshipIDProperty.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -268,7 +268,22 @@ func EntityID(repo, kind, name, sourceFile string) string {
 	return hex.EncodeToString(h.Sum(nil))[:16]
 }
 
-// RelationshipID computes a stable 16-char hex id for an edge.
+// RelationshipIDProperty is the reserved property key under which graph.fb
+// persists Relationship.ID (#6085). graph.fb has no id field, and (from, to,
+// kind) is NOT a unique key for an edge: producers deliberately mint distinct
+// IDs for edges that share a triple — migration ops salted per operation
+// (internal/engine/migration_schema_ops.go), phantom CALLS salted per HTTP
+// method (internal/links/phantom_edges.go), process/event steps salted per
+// step index — so identity cannot be recovered from the endpoints alone.
+//
+// The key is reserved: no producer emits a relationship property called "id",
+// fbwriter writes it only when the ID is not derivable from the triple, and
+// the loader strips it back out of Properties after restoring the ID. It must
+// never be read or written as an ordinary property.
+const RelationshipIDProperty = "id"
+
+// RelationshipID computes a stable 16-char hex id for an edge. It is the
+// DEFAULT identity scheme, not the only one — see RelationshipIDProperty.
 func RelationshipID(fromID, toID, kind string) string {
 	h := sha256.New()
 	h.Write([]byte(fromID))

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -672,6 +672,16 @@ func fbRelToGraphRel(r *fb.Relationship, si *stringInterner) Relationship {
 	if id, ok := rel.PropLookup("id"); ok {
 		rel.ID = id
 	}
+	// #6085 — graph.fb has no id field and fbwriter.buildRelationship stores
+	// no "id" property, so every relationship used to come back from disk with
+	// an EMPTY ID. RelationshipID is a pure function of (from, to, kind) — the
+	// exact expression buildDocument used when it minted the ID — so recompute
+	// it here rather than persisting a redundant 16-byte string per edge. Edge
+	// identity is what the incremental merge dedupes on; without it each
+	// incremental run re-appended edges the fresh pass had already emitted.
+	if rel.ID == "" {
+		rel.ID = RelationshipID(rel.FromID, rel.ToID, rel.Kind)
+	}
 	return rel
 }
 

--- a/internal/graph/load.go
+++ b/internal/graph/load.go
@@ -653,32 +653,42 @@ func fbRelToGraphRel(r *fb.Relationship, si *stringInterner) Relationship {
 	// fbEntityToGraphEntity above — the FB vector is already key-sorted.
 	n := r.PropertiesLength()
 	var props []propKV
+	// #6085 — the reserved RelationshipIDProperty slot carries the edge's ID
+	// when it is not derivable from (from, to, kind). It is identity, not a
+	// property: lift it out here so a round-tripped Relationship carries
+	// exactly the properties fbwriter was handed.
+	storedID := ""
 	if n > 0 {
 		props = make([]propKV, 0, n)
 		var pe fb.PropertyEntry
 		for i := 0; i < n; i++ {
-			if r.Properties(&pe, i) {
-				props = append(props, propKV{K: si.intern(pe.Key()), V: string(pe.Value())})
+			if !r.Properties(&pe, i) {
+				continue
 			}
+			k := si.intern(pe.Key())
+			if k == RelationshipIDProperty {
+				storedID = string(pe.Value())
+				continue
+			}
+			props = append(props, propKV{K: k, V: string(pe.Value())})
 		}
 	}
 	rel := Relationship{
+		ID:     storedID,
 		FromID: si.intern(r.FromId()),
 		ToID:   si.intern(r.ToId()),
 		Kind:   si.intern(r.Kind()),
 	}
 	rel.properties = props
-	// Restore the ID from Properties if the writer stored it.
-	if id, ok := rel.PropLookup("id"); ok {
-		rel.ID = id
-	}
-	// #6085 — graph.fb has no id field and fbwriter.buildRelationship stores
-	// no "id" property, so every relationship used to come back from disk with
-	// an EMPTY ID. RelationshipID is a pure function of (from, to, kind) — the
-	// exact expression buildDocument used when it minted the ID — so recompute
-	// it here rather than persisting a redundant 16-byte string per edge. Edge
-	// identity is what the incremental merge dedupes on; without it each
-	// incremental run re-appended edges the fresh pass had already emitted.
+	// No stored ID means one of two things, and both recompute correctly:
+	// the writer omitted it because ID == RelationshipID(from, to, kind), or
+	// the file predates #6085 (graph.fb persisted no identity at all, so every
+	// edge loaded with an EMPTY ID — a broken key for every consumer, and the
+	// reason each incremental run re-appended edges the fresh pass had already
+	// emitted). On a pre-#6085 file the salted producers' edges are genuinely
+	// unrecoverable and collapse onto one derived ID; the incremental merge
+	// therefore dedupes on MULTIPLICITY, not on key presence, so colliding rows
+	// still survive. One rewrite restores real identity.
 	if rel.ID == "" {
 		rel.ID = RelationshipID(rel.FromID, rel.ToID, rel.Kind)
 	}

--- a/internal/graph/load_test.go
+++ b/internal/graph/load_test.go
@@ -225,3 +225,37 @@ func TestLoadGraphFromDir_EmbeddingRefRoundTrip(t *testing.T) {
 			handlerEnt.EmbeddingRef, "sha256:embedding-round-trip-hash")
 	}
 }
+
+// TestLoadGraphFromDir_RelationshipIDSurvivesFBRoundTrip pins #6085: graph.fb
+// has no relationship id field and fbwriter stores no "id" property, so every
+// relationship used to come back from disk with an EMPTY ID. The incremental
+// merge keys its dedupe on edge identity, so ID-less prev edges made each
+// incremental run re-append edges the fresh pass had already emitted.
+//
+// RelationshipID is a pure function of (from, to, kind) — the same expression
+// buildDocument uses to mint the ID — so the loader recomputes it. IDs minted
+// any other way are NOT recoverable from graph.fb; every producer in the
+// pipeline uses graph.RelationshipID.
+func TestLoadGraphFromDir_RelationshipIDSurvivesFBRoundTrip(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	doc := makeTestDoc()
+	doc.Relationships[0].ID = graph.RelationshipID(
+		doc.Relationships[0].FromID, doc.Relationships[0].ToID, doc.Relationships[0].Kind)
+	want := doc.Relationships[0].ID
+
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(got.Relationships) != 1 {
+		t.Fatalf("relationships: got %d want 1", len(got.Relationships))
+	}
+	if got.Relationships[0].ID != want {
+		t.Errorf("relationship ID after FB round-trip = %q, want %q (#6085)",
+			got.Relationships[0].ID, want)
+	}
+}

--- a/internal/graph/load_test.go
+++ b/internal/graph/load_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/graph/fbwriter"
 )
 
@@ -311,5 +312,108 @@ func TestLoadGraphFromDir_RelationshipIdentitySurvivesFBRoundTrip(t *testing.T) 
 				t.Errorf("edge %s lost its op property (got %q, ok=%v)", r.ID, op, ok)
 			}
 		}
+	}
+}
+
+// TestFBWriter_ReservedIDSlotOnlyForNonDerivableIDs guards the write predicate
+// itself (#6085). fbwriter persists the reserved identity slot ONLY when the ID
+// cannot be recomputed from (from, to, kind); an unsalted edge must cost zero
+// extra bytes on disk and be reconstructed by the loader instead.
+//
+// Without this, "always persist the ID" is an unguarded claim: it round-trips
+// identically, so every behavioural test still passes while the graph pays ~16
+// bytes plus a property entry on every edge in the corpus. The assertion is on
+// the RAW property-vector length, which is the only place the difference shows.
+func TestFBWriter_ReservedIDSlotOnlyForNonDerivableIDs(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const from, to = "aabbccdd00000001", "aabbccdd00000002"
+	doc := makeTestDoc()
+	doc.Relationships = []graph.Relationship{
+		// Derivable ID: the slot must NOT be written — 1 property on disk.
+		graph.Relationship{
+			ID: graph.RelationshipID(from, to, "CALLS"), FromID: from, ToID: to, Kind: "CALLS",
+		}.WithProperties(map[string]string{"line": "12"}),
+		// Salted ID: the slot IS written — 2 properties on disk.
+		graph.Relationship{
+			ID: graph.RelationshipID(from, to, "MODIFIES\x00add_column"), FromID: from, ToID: to, Kind: "MODIFIES",
+		}.WithProperties(map[string]string{"line": "12"}),
+	}
+
+	path := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(path, doc); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	r, err := fbreader.Open(path)
+	if err != nil {
+		t.Fatalf("fbreader.Open: %v", err)
+	}
+	defer r.Close()
+
+	if got := r.RelationshipCount(); got != 2 {
+		t.Fatalf("relationship count on disk = %d, want 2", got)
+	}
+	wantRaw := []int{1, 2} // derivable → no slot; salted → slot present
+	for i, want := range wantRaw {
+		if got := r.RelationshipAt(i).PropertiesLength(); got != want {
+			t.Errorf("rel[%d] on-disk property count = %d, want %d — the write predicate changed",
+				i, got, want)
+		}
+	}
+
+	// And the heap view of both is identical: one property, right ID.
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	for i, rel := range loaded.Relationships {
+		if rel.PropLen() != 1 {
+			t.Errorf("rel[%d] loaded PropLen=%d want 1 (reserved slot must not surface)", i, rel.PropLen())
+		}
+		if rel.ID != doc.Relationships[i].ID {
+			t.Errorf("rel[%d] ID=%q want %q", i, rel.ID, doc.Relationships[i].ID)
+		}
+	}
+}
+
+// TestFBWriter_ProducerSuppliedIDPropertyIsNotIdentity pins the other half of
+// the reserved-key choice (#6085): a relationship property literally called
+// "id" is an ORDINARY property. It must round-trip as one, and it must not be
+// mistaken for identity in either direction — neither swallowed into
+// Relationship.ID and deleted from the payload, nor overwritten by the writer.
+// Such relationships exist in tree (internal/mcp/mmapview_test.go:70), which is
+// why RelationshipIDProperty carries a NUL that no producer can emit.
+func TestFBWriter_ProducerSuppliedIDPropertyIsNotIdentity(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	const from, to = "aabbccdd00000001", "aabbccdd00000002"
+	saltedID := graph.RelationshipID(from, to, "MODIFIES\x00add_column")
+	doc := makeTestDoc()
+	doc.Relationships = []graph.Relationship{
+		graph.Relationship{ID: saltedID, FromID: from, ToID: to, Kind: "MODIFIES"}.
+			WithProperties(map[string]string{"id": "edge-0001", "line": "12"}),
+	}
+
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+	got, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(got.Relationships) != 1 {
+		t.Fatalf("relationships: got %d want 1", len(got.Relationships))
+	}
+	rel := got.Relationships[0]
+	if rel.ID != saltedID {
+		t.Errorf("ID=%q want %q — a producer's \"id\" property must not become identity", rel.ID, saltedID)
+	}
+	if v, ok := rel.PropLookup("id"); !ok || v != "edge-0001" {
+		t.Errorf(`PropLookup("id") = (%q,%v), want ("edge-0001",true) — the producer's property was swallowed`, v, ok)
+	}
+	if rel.PropLen() != 2 {
+		t.Errorf("PropLen=%d want 2 (id, line)", rel.PropLen())
 	}
 }

--- a/internal/graph/load_test.go
+++ b/internal/graph/load_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -226,23 +227,51 @@ func TestLoadGraphFromDir_EmbeddingRefRoundTrip(t *testing.T) {
 	}
 }
 
-// TestLoadGraphFromDir_RelationshipIDSurvivesFBRoundTrip pins #6085: graph.fb
-// has no relationship id field and fbwriter stores no "id" property, so every
-// relationship used to come back from disk with an EMPTY ID. The incremental
-// merge keys its dedupe on edge identity, so ID-less prev edges made each
-// incremental run re-append edges the fresh pass had already emitted.
+// TestLoadGraphFromDir_RelationshipIdentitySurvivesFBRoundTrip pins #6085:
+// graph.fb must preserve Relationship.ID for edges whose ID is NOT derivable
+// from (from, to, kind).
 //
-// RelationshipID is a pure function of (from, to, kind) — the same expression
-// buildDocument uses to mint the ID — so the loader recomputes it. IDs minted
-// any other way are NOT recoverable from graph.fb; every producer in the
-// pipeline uses graph.RelationshipID.
-func TestLoadGraphFromDir_RelationshipIDSurvivesFBRoundTrip(t *testing.T) {
+// The IDs below are not invented for the test — they are built with the exact
+// salting scheme of real producers, which is the contract that matters:
+//
+//	internal/engine/migration_schema_ops.go:134  RelationshipID(f,t,kind+"\x00"+op)
+//	internal/links/phantom_edges.go:149          RelationshipID(f,t,"CALLS:phantom:"+method)
+//	internal/engine/process_flow.go:475          RelationshipID(f,t,kind+":"+stepIndex)
+//	internal/graph/tests_walkup.go:161           domain-prefixed 4-tuple
+//	internal/daemon/mcp/handlers.go:177          residual edge id
+//
+// All of them store a PLAIN Kind, so all of them collide under
+// RelationshipID(from, to, kind). Asserting only that the loader reproduces
+// graph.RelationshipID would pin the loader against itself and pass while
+// three distinct edges collapse onto one identity. The assertions here are on
+// the ORIGINAL IDs the producer minted.
+func TestLoadGraphFromDir_RelationshipIdentitySurvivesFBRoundTrip(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
+
+	const from, to = "aabbccdd00000001", "aabbccdd00000002"
 	doc := makeTestDoc()
-	doc.Relationships[0].ID = graph.RelationshipID(
-		doc.Relationships[0].FromID, doc.Relationships[0].ToID, doc.Relationships[0].Kind)
-	want := doc.Relationships[0].ID
+	// One ordinary edge (ID derivable from the triple) …
+	plain := graph.Relationship{
+		ID: graph.RelationshipID(from, to, "CALLS"), FromID: from, ToID: to, Kind: "CALLS",
+	}
+	// … and three salted edges that share a single (from, to, kind) triple.
+	salted := func(op string) graph.Relationship {
+		return graph.Relationship{
+			ID:     graph.RelationshipID(from, to, "MODIFIES\x00"+op),
+			FromID: from, ToID: to, Kind: "MODIFIES",
+		}.WithProperties(map[string]string{"op": op})
+	}
+	ops := []string{"create_table", "add_column", "drop_column"}
+	doc.Relationships = []graph.Relationship{plain, salted(ops[0]), salted(ops[1]), salted(ops[2])}
+
+	wantIDs := map[string]bool{}
+	for _, r := range doc.Relationships {
+		wantIDs[r.ID] = true
+	}
+	if len(wantIDs) != 4 {
+		t.Fatalf("fixture is wrong: %d distinct IDs, want 4", len(wantIDs))
+	}
 
 	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
 		t.Fatalf("WriteAtomic: %v", err)
@@ -251,11 +280,36 @@ func TestLoadGraphFromDir_RelationshipIDSurvivesFBRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadGraphFromDir: %v", err)
 	}
-	if len(got.Relationships) != 1 {
-		t.Fatalf("relationships: got %d want 1", len(got.Relationships))
+	if len(got.Relationships) != 4 {
+		t.Fatalf("relationships after round-trip: got %d want 4", len(got.Relationships))
 	}
-	if got.Relationships[0].ID != want {
-		t.Errorf("relationship ID after FB round-trip = %q, want %q (#6085)",
-			got.Relationships[0].ID, want)
+	gotIDs := map[string]bool{}
+	for _, r := range got.Relationships {
+		if r.ID == "" {
+			t.Errorf("edge %s→%s (%s) lost its ID in the FB round-trip", r.FromID, r.ToID, r.Kind)
+		}
+		gotIDs[r.ID] = true
+	}
+	if len(gotIDs) != 4 {
+		t.Errorf("round-trip collapsed 4 distinct edge identities onto %d (#6085): %v", len(gotIDs), gotIDs)
+	}
+	for id := range wantIDs {
+		if !gotIDs[id] {
+			t.Errorf("producer-minted ID %q did not survive the FB round-trip", id)
+		}
+	}
+
+	// The reserved id slot is identity, not a property: a round-tripped edge
+	// must carry exactly the properties it was written with.
+	for _, r := range got.Relationships {
+		if _, leaked := r.PropLookup(graph.RelationshipIDProperty); leaked {
+			t.Errorf("edge %s leaked the reserved %q key into Properties",
+				r.ID, graph.RelationshipIDProperty)
+		}
+		if r.Kind == "MODIFIES" {
+			if op, ok := r.PropLookup("op"); !ok || !slices.Contains(ops, op) {
+				t.Errorf("edge %s lost its op property (got %q, ok=%v)", r.ID, op, ok)
+			}
+		}
 	}
 }

--- a/internal/mcp/mmapview.go
+++ b/internal/mcp/mmapview.go
@@ -190,14 +190,25 @@ func (v mmapRelationshipView) FromID() string { return zeroCopyString(v.r.FromId
 func (v mmapRelationshipView) ToID() string   { return zeroCopyString(v.r.ToId()) }
 func (v mmapRelationshipView) Kind() string   { return zeroCopyString(v.r.Kind()) }
 
-// ID mirrors fbRelToGraphRel: the relationship id is tunneled through the "id"
-// property (the writer stores it there), restored to rel.ID on load. "" when
-// absent.
+// ID mirrors graph.fbRelToGraphRel (#6085): identity is tunneled through the
+// reserved graph.RelationshipIDProperty slot, which the writer populates ONLY
+// when the ID is not derivable from (from, to, kind). When the slot is absent —
+// the majority of edges, plus every edge in a pre-#6085 graph.fb — the ID is
+// the derived one. Returning "" here instead would diverge from the heap view
+// for almost every relationship.
 func (v mmapRelationshipView) ID() string {
-	if id, ok := v.PropLookup("id"); ok {
+	if id, ok := v.reservedID(); ok {
 		return id
 	}
-	return ""
+	return graph.RelationshipID(v.FromID(), v.ToID(), v.Kind())
+}
+
+// reservedID reads the reserved identity slot straight off the property vector,
+// bypassing the accessors below (which hide it).
+func (v mmapRelationshipView) reservedID() (string, bool) {
+	return lookupPropertyEntry(graph.RelationshipIDProperty, v.r.PropertiesLength(), func(pe *fb.PropertyEntry, i int) bool {
+		return v.r.Properties(pe, i)
+	})
 }
 
 // PropGet returns the value for key, or "" if absent — zero-copy. Mirrors
@@ -209,15 +220,28 @@ func (v mmapRelationshipView) PropGet(key string) string {
 
 // PropLookup returns the value for key and whether present, zero-copy — a straight
 // property-vector lookup, matching Relationship.PropLookup.
+//
+// The reserved identity slot is NOT a property: graph.fbRelToGraphRel lifts it
+// out of the set on load, so every accessor here hides it too or the two views
+// disagree on PropLen/PropsSnapshot/PropRange for every salted edge (#6085).
 func (v mmapRelationshipView) PropLookup(key string) (string, bool) {
+	if key == graph.RelationshipIDProperty {
+		return "", false
+	}
 	return lookupPropertyEntry(key, v.r.PropertiesLength(), func(pe *fb.PropertyEntry, i int) bool {
 		return v.r.Properties(pe, i)
 	})
 }
 
-// PropLen returns the number of properties (incl. the tunneled "id"), matching
-// heap Relationship.PropLen (fbRelToGraphRel leaves "id" in the property set).
-func (v mmapRelationshipView) PropLen() int { return v.r.PropertiesLength() }
+// PropLen returns the number of properties, EXCLUDING the reserved identity
+// slot, matching heap Relationship.PropLen.
+func (v mmapRelationshipView) PropLen() int {
+	n := v.r.PropertiesLength()
+	if _, ok := v.reservedID(); ok {
+		n--
+	}
+	return n
+}
 
 // PropRange calls f for every key/value pair in key-sorted order, zero-copy,
 // stopping early if f returns false. Same lifetime contract as the entity view's.
@@ -226,7 +250,11 @@ func (v mmapRelationshipView) PropRange(f func(k, v string) bool) {
 	var pe fb.PropertyEntry
 	for i := 0; i < n; i++ {
 		if v.r.Properties(&pe, i) {
-			if !f(zeroCopyString(pe.Key()), zeroCopyString(pe.Value())) {
+			k := zeroCopyString(pe.Key())
+			if k == graph.RelationshipIDProperty {
+				continue
+			}
+			if !f(k, zeroCopyString(pe.Value())) {
 				return
 			}
 		}
@@ -245,8 +273,14 @@ func (v mmapRelationshipView) PropsSnapshot() map[string]string {
 	var pe fb.PropertyEntry
 	for i := 0; i < n; i++ {
 		if v.r.Properties(&pe, i) {
+			if zeroCopyString(pe.Key()) == graph.RelationshipIDProperty {
+				continue
+			}
 			out[string(pe.Key())] = string(pe.Value())
 		}
+	}
+	if len(out) == 0 {
+		return nil
 	}
 	return out
 }

--- a/internal/mcp/mmapview_test.go
+++ b/internal/mcp/mmapview_test.go
@@ -38,8 +38,8 @@ func TestZeroCopyStringEmptyByteVector(t *testing.T) {
 
 // parityDoc builds a Document exercising every field the views expose plus the
 // empty-ByteVector cases that WILL hit real data: an entity with empty
-// Signature and empty Subtype, an entity with no module, a relationship with
-// and without the tunneled "id" property, and multi/zero property sets.
+// Signature and empty Subtype, an entity with no module, relationships with and
+// without the reserved identity slot (#6085), and multi/zero property sets.
 func parityDoc() *graph.Document {
 	e0 := graph.Entity{
 		ID: "r::pkg.Foo", Name: "Foo", QualifiedName: "pkg.Foo", Kind: "type",
@@ -66,15 +66,30 @@ func parityDoc() *graph.Document {
 		SourceFile: "pkg/baz.go", Language: "go",
 	}
 
+	// A producer-supplied "id" PROPERTY. Since #6085 that is an ordinary
+	// property with no bearing on identity — the reserved slot carries a NUL
+	// no producer can emit — so both views must surface it as a property and
+	// neither may treat it as the edge's ID.
 	r0 := graph.Relationship{FromID: "r::pkg.Foo", ToID: "r::pkg.bar", Kind: "calls"}
 	r0.PropsReplace(map[string]string{"id": "edge-0001", "line": "12"})
 
-	// Relationship without an id property → ID() must be "" on both sides.
+	// No reserved slot on disk (its ID is derivable), so BOTH views must
+	// reconstruct ID() as graph.RelationshipID(from, to, kind).
 	r1 := graph.Relationship{FromID: "r::pkg.bar", ToID: "r::pkg.Baz", Kind: "references"}
+	r1.ID = graph.RelationshipID(r1.FromID, r1.ToID, r1.Kind)
+
+	// A SALTED id — not derivable from the triple — so fbwriter writes the
+	// reserved slot. Both views must report that ID and both must hide the
+	// slot from the property surface (PropLen 1, not 2). Without a salted edge
+	// in this fixture the slot is never present on disk and the mmap view's
+	// hiding of it is untested.
+	r2 := graph.Relationship{FromID: "r::pkg.Foo", ToID: "r::pkg.Baz", Kind: "modifies"}
+	r2.ID = graph.RelationshipID(r2.FromID, r2.ToID, r2.Kind+"\x00add_column")
+	r2.PropsReplace(map[string]string{"op": "add_column"})
 
 	return &graph.Document{
 		Entities:      []graph.Entity{e0, e1, e2},
-		Relationships: []graph.Relationship{r0, r1},
+		Relationships: []graph.Relationship{r0, r1, r2},
 	}
 }
 
@@ -273,9 +288,11 @@ func assertRelViewEqual(t *testing.T, i int, want, got graph.RelationshipView) {
 	if want.Kind() != got.Kind() {
 		t.Errorf("rel[%d] Kind: heap %q mmap %q", i, want.Kind(), got.Kind())
 	}
-	// W2: full read-only property surface parity, incl. the id-tunneled "id"
-	// property (which also backs ID()).
-	assertPropReadParity(t, "rel["+strconv.Itoa(i)+"]", want, got, []string{"id", "line", "__absent__"})
+	// W2: full read-only property surface parity. The probe list includes the
+	// producer-supplied "id" property (an ordinary property since #6085) and
+	// the reserved identity slot, which BOTH views must hide.
+	assertPropReadParity(t, "rel["+strconv.Itoa(i)+"]", want, got,
+		[]string{"id", "op", "line", graph.RelationshipIDProperty, "__absent__"})
 }
 
 func idsOfViews(vs []graph.EntityView) []string {


### PR DESCRIPTION
An incremental index emitted **~30% fewer relationships** than a full reindex of identical source, and the count moved between successive runs:

| run | relationships |
|---|---|
| full reindex | 620,811 |
| incremental #1 (1 file of 6318 touched) | 430,710 — `dropped 347946 stale edges` |
| incremental #2 | 467,991 |

Incremental is the **default** path for a watched repo. A third of the graph silently missing means MCP callers get confident wrong answers — "nothing calls this", "no path exists" — with no error and a success report.

## Two defects

**1. The staleness predicate was wrong in both directions.** `mergeIncrementalPrevDoc` asked *"do both endpoints resolve to a live entity row?"*

- **Too aggressive:** `survivingIDs` is built only from source-bearing entities, so every edge touching an `ext:*` synthetic or an unresolved bare name (`Join`, `ReadFile`) was dropped. **100% of the missing edges had exactly that shape** — zero had two ordinary endpoints. The code assumed `external.Synthesize` would regenerate them, but Synthesize rebuilds ext *nodes* from unresolved edges **in the current doc** — the edges this loop had just deleted.
- **Too conservative:** an edge out of a changed file whose entity ID was unchanged survived the liveness check and was retained even though the fresh pass is authoritative. A call deleted from source stayed in the graph indefinitely. The pre-existing `ThreeFileScenario` test **asserted that wrong behaviour**; it is corrected here, not weakened.

The predicate is now: drop a prev edge **iff** its `FromID` is a prev entity anchored in a changed file, or its `ToID` is a prev entity anchored in a changed file that no longer exists after re-extraction. Everything else is preserved verbatim. All seven cases verified by execution — ext endpoints, bare names, deleted call, deleted file, all-IDs-change, both-endpoints-changed, added file.

**2. Relationship identity was never persisted.** `graph.fb` had no relationship id field, so every prior edge loaded with `ID == ""`, the merge deduped on that empty ID, never matched, and re-appended edges the fresh pass had already emitted — 8,097 of 12,549 rows on the fixture. The graph grew run over run.

## The trap: `(from, to, kind)` is not a key

The obvious fix — dedupe on the triple — **collapses edges the codebase deliberately keeps distinct**, and the producers say so:

- `migration_schema_ops.go:130` — "several distinct ops (create_table + add_column + drop_column) a single Django migration performs on the SAME table converge on one table node yet **must remain distinct edges**"
- `phantom_edges.go:149` — two HTTP methods between one entity pair, one triple
- `process_flow.go:475`, `event_flow.go:350` — step edges salted by index

Caught in review with a reproduction: three salted `MODIFIES` edges on an **unchanged** file, an unrelated file edited, and the merge carried 1 and dropped 2.

So the root fix is to **persist `Relationship.ID`**, not to work around its absence. It goes in a reserved property slot — **no schema change, no format bump** — written only when the ID is not derivable from the triple, so ordinary edges cost nothing on disk.

The reserved key is `"\x00id"`, unreachable from any producer **by construction** rather than by convention. `"id"` was tried first and rejected: a relationship carrying a producer-set `id` property already exists in-tree (`internal/mcp/mmapview_test.go:70`), so the collision was real, and the failure would have been silent in both directions — a producer's `id` hijacking edge identity, or the writer overwriting the producer's value.

Deliberate cost: an older binary can no longer recover the ID through its `PropLookup("id")` hook. Those binaries had no relationship IDs at all before this change, so this withdraws a bonus rather than causing a regression — and it is the price of making hijack structurally impossible.

## The defect found while fixing it

Keying on identity alone made the graph grow **without bound** — passes running after the merge re-append edges already in the carried set. Same identity *and* same payload is one edge, never two:

```
triple key      19042 18767 18928 19024 19041 19042 19042   converged
identity only   19042 19621 20162 20638 21035 21416 21796…  +380/run, unbounded
final           19042 19621 19782 19878 19895 19896 19896   converged
```

The final key is `(FromID, ToID, Kind, ID, properties)`.

Note the first sequence **dips to 18767 before recovering**: the lower fixed point was reached by *deleting* salted siblings. It converged on data loss.

Converged incremental vs a full reindex of the same tree: **0 missing relationships, 0 missing entities, 0 extra entities.** The 474 extra edges are all `source=tests-walkup` — a converging transitive closure tracked as #6089.

## Verification

Reproduced deterministically on a **126-file fixture** in ~1.5s per run, not by repeatedly indexing a large corpus. Two earlier attempts at this issue died doing the latter.

11 mutants, all killed: writer always persists the ID · reserved key reverts to `"id"` · mmap `ID()` returns `""` · each of the four mmap accessors stops hiding the slot · never drop edges out of a changed file · endpoint-liveness predicate restored · `referenced` marked after the dedupe · synthetics skipped · dedupe drops the payload · dedupe drops the ID · triple-only key.

Two fixture defects were caught and fixed rather than shipped:
- the dedupe test asserted counts, and passed on a result that both duplicated one edge **and destroyed another**; it now asserts the edge set with multiplicities
- the parity fixture had no salted relationship, so the reserved slot was never on disk and three mutants against the new mmap code initially **survived**; a salted edge was added and two now-false fixture comments corrected

The round-trip test was rebuilt around the real producers' salting schemes; its previous form pinned the loader against itself and carried a false comment claiming every producer uses `graph.RelationshipID`.

Cost, stated: `buildRelationship` runs SHA-256 per relationship per write to decide derivability — ~139.6 ns/op, 160 B/op, 3 allocs/op, so ≈49 ms and ~56 MB transient at 350k edges. Short-lived garbage, not RSS.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `./internal/graph/...`, `./internal/mcp/...` (105.7s), `./cmd/grafel/` (61.2s) green at `-count=1 -p 1`, verified independently rather than taken from the report.

Three independent adversarial review rounds.

Closes #6085
Refs #5969, #6089, #6090
