### PR TITLE
feat(#5964): seed a worktree's graph from its parent instead of indexing the corpus again

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -829,38 +829,7 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 		// Issue #2406: capture extractorCfg at construction time so the closure
 		// owns an immutable pointer — no package-level singleton needed.
 		SchedulerIncremental: func(ctx context.Context, repoPath string, ref string) sched.IncrementalResult {
-			// Issue #5719: ref can be "" (unknown at enqueue time). Resolve it
-			// to HEAD via ResolveIncrementalStateDir instead of encoding the
-			// empty ref as the "refs/_unknown/" sentinel — otherwise the
-			// incremental pass can never find the real graph and falls back
-			// forever.
-			stateDir := daemon.ResolveIncrementalStateDir(repoPath, ref)
-			// #5964: a worktree state dir may have been SEEDED from its
-			// parent ref's graph. Before that seed is consumed, prove it is
-			// still the generation it claims to be — a seed whose graph and
-			// diff manifest straddle two parent generations makes files that
-			// really differ read as unchanged, so their stale entities survive
-			// into the child's graph. That is worse than slow: it is
-			// invisible. On any failed check the seed is discarded (leaving
-			// nothing resolvable, so a full index runs) and the reason is
-			// reported, never swallowed.
-			if reason, ok := verifyOrDiscardSeed(stateDir); !ok {
-				return sched.IncrementalResult{Done: false, FallbackReason: "seed_" + reason}
-			}
-			// Use the caller-supplied ctx (the scheduler's shutdownCtx) so that
-			// daemon SIGTERM cancels any in-flight incremental subprocess —
-			// matching the fix applied to runIndex in issue #2176/#2491.
-			// Fixes issue #2495.
-			res := extractors.TryIncremental(ctx, repoPath, stateDir, nil, &extractorCfg)
-			if res.Done {
-				invalidateAfterIndex(repoPath)
-				tierAfterIndex(repoPath, ref)
-			}
-			return sched.IncrementalResult{
-				Done:           res.Done,
-				FallbackReason: res.FallbackReason,
-				ChangedFiles:   res.ChangedFiles,
-			}
+			return daemonSchedulerIncremental(ctx, repoPath, ref, &extractorCfg)
 		},
 		// #5710 follow-up: cheap entity count for the "indexer: completed" log so
 		// a silent 0-entity completion (empty-graph store recreation) is visible.
@@ -1246,6 +1215,42 @@ func daemonWorktreeParents() []worktree.ParentRepo {
 // reindex workloads AND the per-child GOMAXPROCS cap (default 2) bounds CPU.
 // The in-process path is the OPT-OUT (GRAFEL_SUBPROCESS_INDEXER=0); see
 // sched.SubprocessIndexEnabled for the env gate.
+// daemonSchedulerIncremental is the scheduler's S3 incremental-reindex
+// callback, lifted out of the config literal so it can be driven directly by a
+// test. Keeping it inline made the #5964 seed-verification guard below
+// unreachable from any test: deleting the guard left every suite green.
+func daemonSchedulerIncremental(ctx context.Context, repoPath string, ref string, extractorCfg *extractor.ExtractorConfig) sched.IncrementalResult {
+	// Issue #5719: ref can be "" (unknown at enqueue time). Resolve it to
+	// HEAD via ResolveIncrementalStateDir instead of encoding the empty ref
+	// as the "refs/_unknown/" sentinel — otherwise the incremental pass can
+	// never find the real graph and falls back forever.
+	stateDir := daemon.ResolveIncrementalStateDir(repoPath, ref)
+	// #5964: a worktree state dir may have been SEEDED from its parent ref's
+	// graph. Before that seed is consumed, prove it is still the generation it
+	// claims to be — a seed whose graph and diff manifest straddle two parent
+	// generations makes files that really differ read as unchanged, so their
+	// stale entities survive into the child's graph. That is worse than slow:
+	// it is invisible. On any failed check the seed is discarded (leaving
+	// nothing resolvable, so a full index runs) and the reason is reported,
+	// never swallowed.
+	if reason, ok := verifyOrDiscardSeed(stateDir); !ok {
+		return sched.IncrementalResult{Done: false, FallbackReason: "seed_" + reason}
+	}
+	// Use the caller-supplied ctx (the scheduler's shutdownCtx) so that daemon
+	// SIGTERM cancels any in-flight incremental subprocess — matching the fix
+	// applied to runIndex in issue #2176/#2491. Fixes issue #2495.
+	res := extractors.TryIncremental(ctx, repoPath, stateDir, nil, extractorCfg)
+	if res.Done {
+		invalidateAfterIndex(repoPath)
+		tierAfterIndex(repoPath, ref)
+	}
+	return sched.IncrementalResult{
+		Done:           res.Done,
+		FallbackReason: res.FallbackReason,
+		ChangedFiles:   res.ChangedFiles,
+	}
+}
+
 // verifyOrDiscardSeed re-checks any #5964 worktree seed sitting in stateDir
 // before a pass consumes it. It returns (reason, false) when the seed could
 // not be trusted — the caller must then run a FULL index and surface the
@@ -1257,11 +1262,12 @@ func daemonWorktreeParents() []worktree.ParentRepo {
 // make the NEXT verification report generation_moved against the child's own
 // legitimate graph.
 func verifyOrDiscardSeed(stateDir string) (string, bool) {
-	stamp, reason, err := daemon.VerifySeededGraph(stateDir)
-	if err != nil {
-		reason = daemon.SeedFallbackStampMismatch
-	}
-	if reason != "" {
+	stamp, reason, _ := daemon.VerifySeededGraph(stateDir)
+	// Branch on the VERDICT, not on `reason != ""`. A superseded stamp — the
+	// dir's pointer already names a generation newer than the seed, i.e. the
+	// child built its own graph over it — is benign and must not be discarded,
+	// or a full corpus reindex the child paid for is thrown away.
+	if !daemon.SeedVerdictIsBenign(reason) {
 		if derr := daemon.DiscardSeed(stateDir); derr != nil {
 			slog.Default().Warn("worktree: failed to discard an untrusted seed",
 				"state_dir", stateDir, "reason", string(reason), "err", derr)
@@ -1270,8 +1276,7 @@ func verifyOrDiscardSeed(stateDir string) (string, bool) {
 			"state_dir", stateDir,
 			"reason", string(reason),
 			"parent_ref", seedStampParentRef(stamp),
-			"parent_generation", seedStampParentGen(stamp),
-			"err", err)
+			"parent_generation", seedStampParentGen(stamp))
 		return string(reason), false
 	}
 	if stamp != nil {
@@ -1279,11 +1284,18 @@ func verifyOrDiscardSeed(stateDir string) (string, bool) {
 			slog.Default().Warn("worktree: failed to consume seed stamp",
 				"state_dir", stateDir, "err", cerr)
 		}
-		slog.Default().Info("worktree: seeded graph verified — indexing the delta only",
-			"state_dir", stateDir,
-			"parent_ref", stamp.ParentRef,
-			"parent_generation", stamp.ParentPointer,
-			"repo_tag", stamp.RepoTag)
+		if reason == daemon.SeedFallbackSuperseded {
+			slog.Default().Info("worktree: stale seed stamp cleared — the child's own graph is newer",
+				"state_dir", stateDir,
+				"parent_ref", stamp.ParentRef,
+				"seed_generation", stamp.ParentPointer)
+		} else {
+			slog.Default().Info("worktree: seeded graph verified — indexing the delta only",
+				"state_dir", stateDir,
+				"parent_ref", stamp.ParentRef,
+				"parent_generation", stamp.ParentPointer,
+				"repo_tag", stamp.RepoTag)
+		}
 	}
 	return "", true
 }
@@ -1302,16 +1314,38 @@ func seedStampParentGen(s *daemon.SeedStamp) string {
 	return s.ParentPointer
 }
 
+// resolveIndexRepoTag returns the repo tag an index of stateDir's repo must be
+// pinned to, or "" to keep Index()'s default (filepath.Base(repoPath)).
+//
+// #5964: graph.EntityID hashes the repo tag FIRST, and for a worktree the
+// default is the WORKTREE directory's own name, which disagrees with the
+// parent's slug. A full index of a worktree must use the same tag a seeded
+// index would, or the two graphs have different entity ids: parity between
+// them becomes untestable and a later seed can never be correct. Empty for
+// every non-worktree repo, preserving today's default exactly.
+//
+// A separate named seam so a test can pin the forwarding without indexing.
+func resolveIndexRepoTag(stateDir string) string {
+	return daemon.ReadRepoTagPin(stateDir)
+}
+
 func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) error {
 	var err error
-	// #5964: honour the repo-tag pin a worktree activation wrote. graph.EntityID
-	// hashes the repo tag FIRST and Index() defaults it to filepath.Base(repoPath)
-	// — for a worktree, the worktree directory's own name, which disagrees with
-	// the parent's slug. A full index of a worktree must use the SAME tag a
-	// seeded index would, or the two graphs have different entity ids: parity
-	// between them becomes untestable and a later seed can never be correct.
-	// Empty for every non-worktree repo, preserving today's default exactly.
-	repoTag := daemon.ReadRepoTagPin(daemon.ResolveIncrementalStateDir(repoPath, ref))
+	stateDir := daemon.ResolveIncrementalStateDir(repoPath, ref)
+	repoTag := resolveIndexRepoTag(stateDir)
+	// #5964: a FULL index also consumes a seeded state dir — it merges nothing,
+	// it simply overwrites — and it is the ONLY path taken when incremental
+	// reindexing is disabled (GRAFEL_INCREMENTAL_REINDEX=0), where the
+	// scheduler never calls the incremental callback that would otherwise
+	// consume the stamp. Left behind, that stamp goes stale the moment this
+	// index writes its own generation. Consuming it here closes the second of
+	// the two paths that can reach a seeded dir.
+	defer func() {
+		if cerr := daemon.ConsumeSeedStamp(stateDir); cerr != nil {
+			slog.Default().Warn("worktree: failed to consume seed stamp after a full index",
+				"state_dir", stateDir, "err", cerr)
+		}
+	}()
 	if sched.SubprocessIndexEnabled() {
 		// S5 path: fork-exec `grafel index-internal` for memory isolation.
 		var opts *sched.SubprocessIndexOptions

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -835,6 +835,18 @@ func runDaemonMode(argv []string, runMode daemonRunMode) error {
 			// incremental pass can never find the real graph and falls back
 			// forever.
 			stateDir := daemon.ResolveIncrementalStateDir(repoPath, ref)
+			// #5964: a worktree state dir may have been SEEDED from its
+			// parent ref's graph. Before that seed is consumed, prove it is
+			// still the generation it claims to be — a seed whose graph and
+			// diff manifest straddle two parent generations makes files that
+			// really differ read as unchanged, so their stale entities survive
+			// into the child's graph. That is worse than slow: it is
+			// invisible. On any failed check the seed is discarded (leaving
+			// nothing resolvable, so a full index runs) and the reason is
+			// reported, never swallowed.
+			if reason, ok := verifyOrDiscardSeed(stateDir); !ok {
+				return sched.IncrementalResult{Done: false, FallbackReason: "seed_" + reason}
+			}
 			// Use the caller-supplied ctx (the scheduler's shutdownCtx) so that
 			// daemon SIGTERM cancels any in-flight incremental subprocess —
 			// matching the fix applied to runIndex in issue #2176/#2491.
@@ -1234,18 +1246,88 @@ func daemonWorktreeParents() []worktree.ParentRepo {
 // reindex workloads AND the per-child GOMAXPROCS cap (default 2) bounds CPU.
 // The in-process path is the OPT-OUT (GRAFEL_SUBPROCESS_INDEXER=0); see
 // sched.SubprocessIndexEnabled for the env gate.
+// verifyOrDiscardSeed re-checks any #5964 worktree seed sitting in stateDir
+// before a pass consumes it. It returns (reason, false) when the seed could
+// not be trusted — the caller must then run a FULL index and surface the
+// reason — and ("", true) otherwise, which includes the overwhelming common
+// case of a state dir that was never seeded at all.
+//
+// On success the stamp is consumed immediately: from here the pass owns the
+// dir and will write a new generation into it, so a stamp left behind would
+// make the NEXT verification report generation_moved against the child's own
+// legitimate graph.
+func verifyOrDiscardSeed(stateDir string) (string, bool) {
+	stamp, reason, err := daemon.VerifySeededGraph(stateDir)
+	if err != nil {
+		reason = daemon.SeedFallbackStampMismatch
+	}
+	if reason != "" {
+		if derr := daemon.DiscardSeed(stateDir); derr != nil {
+			slog.Default().Warn("worktree: failed to discard an untrusted seed",
+				"state_dir", stateDir, "reason", string(reason), "err", derr)
+		}
+		slog.Default().Warn("worktree: seeded graph rejected — running a full index",
+			"state_dir", stateDir,
+			"reason", string(reason),
+			"parent_ref", seedStampParentRef(stamp),
+			"parent_generation", seedStampParentGen(stamp),
+			"err", err)
+		return string(reason), false
+	}
+	if stamp != nil {
+		if cerr := daemon.ConsumeSeedStamp(stateDir); cerr != nil {
+			slog.Default().Warn("worktree: failed to consume seed stamp",
+				"state_dir", stateDir, "err", cerr)
+		}
+		slog.Default().Info("worktree: seeded graph verified — indexing the delta only",
+			"state_dir", stateDir,
+			"parent_ref", stamp.ParentRef,
+			"parent_generation", stamp.ParentPointer,
+			"repo_tag", stamp.RepoTag)
+	}
+	return "", true
+}
+
+func seedStampParentRef(s *daemon.SeedStamp) string {
+	if s == nil {
+		return ""
+	}
+	return s.ParentRef
+}
+
+func seedStampParentGen(s *daemon.SeedStamp) string {
+	if s == nil {
+		return ""
+	}
+	return s.ParentPointer
+}
+
 func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) error {
 	var err error
+	// #5964: honour the repo-tag pin a worktree activation wrote. graph.EntityID
+	// hashes the repo tag FIRST and Index() defaults it to filepath.Base(repoPath)
+	// — for a worktree, the worktree directory's own name, which disagrees with
+	// the parent's slug. A full index of a worktree must use the SAME tag a
+	// seeded index would, or the two graphs have different entity ids: parity
+	// between them becomes untestable and a later seed can never be correct.
+	// Empty for every non-worktree repo, preserving today's default exactly.
+	repoTag := daemon.ReadRepoTagPin(daemon.ResolveIncrementalStateDir(repoPath, ref))
 	if sched.SubprocessIndexEnabled() {
 		// S5 path: fork-exec `grafel index-internal` for memory isolation.
-		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, nil, slog.Default())
+		var opts *sched.SubprocessIndexOptions
+		if repoTag != "" {
+			// RepoSlug is forwarded to the child as --repo-tag. No publisher is
+			// set, so no other subprocess flag changes.
+			opts = &sched.SubprocessIndexOptions{RepoSlug: repoTag}
+		}
+		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, opts, slog.Default())
 	} else {
 		// In-process path (opt-out via GRAFEL_SUBPROCESS_INDEXER=0).
 		// ADR-0016 flip-day (#808): graph.fb is always written by default now.
 		// ref is stored via StateDirForRepo → StateDirForRepoRef at write time;
 		// the indexer itself resolves the correct path via gitmeta at index time.
 		_ = ref
-		err = Index(repoPath, "", "", []string{"graph-algo"}, false, false)
+		err = Index(repoPath, "", repoTag, []string{"graph-algo"}, false, false)
 	}
 	// Drop the cached mmap so the next MCP query reopens against the
 	// freshly written graph.fb. Done on both success and failure paths

--- a/cmd/grafel/worktree_seed_heap_test.go
+++ b/cmd/grafel/worktree_seed_heap_test.go
@@ -16,22 +16,30 @@ package main
 //   vm_stat ; sysctl vm.swapusage
 //
 // MEASURED FINDING, recorded here so it is not re-inferred the other way.
-// Seeding is O(delta) in WORK and WALL CLOCK, not in peak memory:
+// Seeding is O(delta) in WORK, and its wall-clock win is SCALE-DEPENDENT. It is
+// never a memory win. 16 GB macOS laptop, 3 changed files, swap steady across
+// every run:
 //
-//   2500-file fixture, 3 changed files, 16 GB macOS laptop (swap 1877 MB used,
-//   unchanged across the run):
-//     A  full index of the worktree : peak live heap 105.3 MB, wall 7.252 s
-//     B  seed + incremental delta   : peak live heap 138.8 MB, wall 1.245 s
-//     ratio B/A                     : heap 1.32x, wall 0.17x
-//   800-file fixture: heap 1.15x, wall 0.83x.
+//   files   full index          seeded + delta      heap    wall
+//     400   60.7 MB / 515 ms    62.3 MB / 533 ms    1.03x   1.03x   (no win)
+//    1200   75.8 MB / 997 ms    91.3 MB / 668 ms    1.20x   0.67x
+//    2500  105.3 MB / 7.252 s  138.8 MB / 1.245 s   1.32x   0.17x
 //
-// The seeded pass re-extracts 3 of 2503 files, but it must MATERIALISE THE
+// The wall-clock crossover is between 400 and 1200 files: below it, seeding is
+// break-even or marginally worse. The heap ratio degrades monotonically with
+// graph size.
+//
+// Why: the seeded pass re-extracts 3 of N files, but it must MATERIALISE THE
 // WHOLE PARENT GRAPH to merge the unchanged-file portion forward
-// (graph.LoadGraphFromDir + mergeIncrementalPrevDoc + the carry-forward entity
-// slice), and holds it alongside the document being built. So peak heap tracks
-// GRAPH SIZE, not delta size, and comes out slightly ABOVE a full index rather
-// than below it. Anyone sizing concurrent per-worktree indexing off this should
-// budget for the graph, not for the delta.
+// (internal/extractors/incremental.go calls graph.LoadGraphFromDir; the
+// Index() path does the same via mergeIncrementalPrevDoc plus the carry-forward
+// entity slice) and holds it alongside the document being built. Peak heap
+// therefore tracks GRAPH SIZE, not delta size, and lands ABOVE a full index
+// rather than below it. This is structural, not a fixture artifact.
+//
+// Consequence for epic #5954: seeding does NOT reduce the per-process memory
+// budget for concurrent per-worktree indexing. Anyone sizing that must budget
+// for the graph, not for the delta.
 
 import (
 	"fmt"

--- a/cmd/grafel/worktree_seed_heap_test.go
+++ b/cmd/grafel/worktree_seed_heap_test.go
@@ -1,0 +1,231 @@
+package main
+
+// Peak live-heap measurement for #5964 worktree graph seeding.
+//
+// Opt-in only: set GRAFEL_SEED_HEAP_MEASURE=1. It builds a several-hundred-file
+// fixture and indexes it three times, which is far too expensive for the
+// ordinary suite. It exists so the O(delta) claim is reproducible rather than
+// asserted from memory.
+//
+// The metric is LIVE HEAP — next_gc / (1 + GOGC/100) — sampled on a ticker and
+// reduced to its peak. It is NOT RSS: on macOS, RSS counts MADV_FREE pages the
+// allocator has already returned logically but the kernel has not reclaimed, so
+// RSS is an upper bound on footprint, not a measurement of it (a grafel engine
+// measured at 2396 MB RSS fell to 1282 MB under memory pressure without doing
+// any work). Report machine state alongside any number from this test:
+//   vm_stat ; sysctl vm.swapusage
+//
+// MEASURED FINDING, recorded here so it is not re-inferred the other way.
+// Seeding is O(delta) in WORK and WALL CLOCK, not in peak memory:
+//
+//   2500-file fixture, 3 changed files, 16 GB macOS laptop (swap 1877 MB used,
+//   unchanged across the run):
+//     A  full index of the worktree : peak live heap 105.3 MB, wall 7.252 s
+//     B  seed + incremental delta   : peak live heap 138.8 MB, wall 1.245 s
+//     ratio B/A                     : heap 1.32x, wall 0.17x
+//   800-file fixture: heap 1.15x, wall 0.83x.
+//
+// The seeded pass re-extracts 3 of 2503 files, but it must MATERIALISE THE
+// WHOLE PARENT GRAPH to merge the unchanged-file portion forward
+// (graph.LoadGraphFromDir + mergeIncrementalPrevDoc + the carry-forward entity
+// slice), and holds it alongside the document being built. So peak heap tracks
+// GRAPH SIZE, not delta size, and comes out slightly ABOVE a full index rather
+// than below it. Anyone sizing concurrent per-worktree indexing off this should
+// budget for the graph, not for the delta.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// heapSampler tracks the peak live heap across a window.
+type heapSampler struct {
+	peak  atomic.Uint64
+	stop  chan struct{}
+	done  chan struct{}
+	gogc  float64
+	every time.Duration
+}
+
+func startHeapSampler() *heapSampler {
+	gogc := 100.0
+	if v := os.Getenv("GOGC"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			gogc = f
+		}
+	}
+	h := &heapSampler{
+		stop:  make(chan struct{}),
+		done:  make(chan struct{}),
+		gogc:  gogc,
+		every: 20 * time.Millisecond,
+	}
+	go func() {
+		defer close(h.done)
+		t := time.NewTicker(h.every)
+		defer t.Stop()
+		var ms runtime.MemStats
+		for {
+			select {
+			case <-h.stop:
+				return
+			case <-t.C:
+				runtime.ReadMemStats(&ms)
+				// Live heap implied by the GC's next-collection target.
+				live := uint64(float64(ms.NextGC) / (1.0 + h.gogc/100.0))
+				for {
+					cur := h.peak.Load()
+					if live <= cur || h.peak.CompareAndSwap(cur, live) {
+						break
+					}
+				}
+			}
+		}
+	}()
+	return h
+}
+
+func (h *heapSampler) peakMB() float64 {
+	close(h.stop)
+	<-h.done
+	return float64(h.peak.Load()) / (1 << 20)
+}
+
+func writeBigFixture(t *testing.T, dir, branch string, n int) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module bigfixture\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < n; i++ {
+		src := fmt.Sprintf(`package svc
+
+type Svc%[1]d struct{ Name string }
+
+func (s *Svc%[1]d) Handle%[1]d(in string) string { return s.help%[1]d(in) }
+func (s *Svc%[1]d) help%[1]d(in string) string   { return in + s.Name }
+
+func Dispatch%[1]d(in string) string {
+	p := &Svc%[2]d{Name: "p"}
+	return p.Handle%[2]d(in)
+}
+
+func Fan%[1]dA(in string) string { return Dispatch%[1]d(in) }
+func Fan%[1]dB(in string) string { return Fan%[1]dA(in) }
+`, i, (i+n-1)%n)
+		if err := os.WriteFile(filepath.Join(dir, "svc", fmt.Sprintf("s%04d.go", i)), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedGitRun(t, dir, "init", "-q", "-b", branch)
+	seedGitRun(t, dir, "add", "-A")
+	seedGitRun(t, dir, "commit", "-q", "-m", "big fixture")
+}
+
+func TestWorktreeSeedPeakHeapAndWallClock(t *testing.T) {
+	if os.Getenv("GRAFEL_SEED_HEAP_MEASURE") != "1" {
+		t.Skip("set GRAFEL_SEED_HEAP_MEASURE=1 to run the peak live-heap measurement")
+	}
+	n := 800
+	if v := os.Getenv("GRAFEL_SEED_HEAP_FILES"); v != "" {
+		if k, err := strconv.Atoi(v); err == nil && k > 0 {
+			n = k
+		}
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	parentPath := filepath.Join(root, "parent")
+	const parentRef = "release/2026-07"
+	writeBigFixture(t, parentPath, parentRef, n)
+	parentSD := daemon.StateDirForRepo(parentPath)
+	if err := Index(parentPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(parentSD)); err != nil {
+		t.Fatalf("index parent: %v", err)
+	}
+
+	childPath := filepath.Join(root, "wt-measure")
+	const childRef = "feat/measure"
+	addFixtureWorktree(t, parentPath, childPath, childRef)
+	applyBigDelta(t, childPath)
+	childSD := daemon.StateDirForRepo(childPath)
+
+	// --- A: full index of the worktree, no seed ---
+	runtime.GC()
+	sA := startHeapSampler()
+	tA := time.Now()
+	if err := Index(childPath, "", parityRepoTag, []string{"graph-algo"}, false, false); err != nil {
+		t.Fatalf("full index: %v", err)
+	}
+	durA := time.Since(tA)
+	peakA := sA.peakMB()
+
+	// --- B: seed + incremental over the delta ---
+	if err := os.RemoveAll(childSD); err != nil {
+		t.Fatal(err)
+	}
+	out := daemon.SeedWorktreeGraph(daemon.SeedRequest{
+		ParentPath: parentPath, ParentRef: parentRef,
+		ChildPath: childPath, ChildRef: childRef, RepoTag: parityRepoTag,
+	})
+	if !out.Seeded {
+		t.Fatalf("seed failed: %s — %s", out.Reason, out.Detail)
+	}
+	if _, reason, err := daemon.VerifySeededGraph(childSD); err != nil || reason != "" {
+		t.Fatalf("verify: %q %v", reason, err)
+	}
+	runtime.GC()
+	sB := startHeapSampler()
+	tB := time.Now()
+	if err := Index(childPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(childSD)); err != nil {
+		t.Fatalf("seeded incremental index: %v", err)
+	}
+	durB := time.Since(tB)
+	peakB := sB.peakMB()
+
+	t.Logf("fixture files=%d  seed_bytes_copied=%d", n, out.BytesCopied)
+	t.Logf("A full index      : peak_live_heap=%.1f MB  wall=%s", peakA, durA.Round(time.Millisecond))
+	t.Logf("B seeded+delta    : peak_live_heap=%.1f MB  wall=%s", peakB, durB.Round(time.Millisecond))
+	t.Logf("ratio B/A         : heap=%.2f  wall=%.2f", peakB/peakA, float64(durB)/float64(durA))
+	t.Log("live heap = next_gc / (1 + GOGC/100); NOT RSS (macOS RSS counts MADV_FREE pages)")
+}
+
+// applyBigDelta changes exactly three files: one committed, one uncommitted,
+// one untracked — the same three shapes the parity test uses.
+func applyBigDelta(t *testing.T, dir string) {
+	t.Helper()
+	p0 := filepath.Join(dir, "svc", "s0000.go")
+	b, err := os.ReadFile(p0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p0, append(b, []byte("\nfunc CommittedOnChild(in string) string { return in }\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedGitRun(t, dir, "add", "-A")
+	seedGitRun(t, dir, "commit", "-q", "-m", "delta")
+
+	p1 := filepath.Join(dir, "svc", "s0001.go")
+	b1, err := os.ReadFile(p1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p1, append(b1, []byte("\nfunc UncommittedOnChild(in string) string { return in }\n")...), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "svc", "untracked.go"),
+		[]byte("package svc\n\nfunc UntrackedHelper(in string) string { return in }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/grafel/worktree_seed_parity_test.go
+++ b/cmd/grafel/worktree_seed_parity_test.go
@@ -373,6 +373,89 @@ func TestWorktreeSeedConsumedByTheDaemonPath(t *testing.T) {
 	}
 }
 
+// TestWorktreeSeedParity_PathAOnASeededBaseMatchesPathAOnASelfBuiltBase is the
+// parity gate for the path users actually take.
+//
+// A naive "Path A seeded vs full scratch index" compare would be noisy: Path A
+// is an in-place patch that re-runs a reduced pass set, so its output is not
+// expected to equal a full pipeline run. That noise is cancelled by running
+// Path A on BOTH sides and varying only the thing under test — where the base
+// graph came from:
+//
+//	X: worktree indexed from scratch at parent content, then the delta applied,
+//	   then Path A  -> base graph built by this worktree itself
+//	Y: worktree SEEDED from the parent, same delta, then Path A
+//	   -> base graph byte-copied from the parent
+//
+// Both worktrees hold identical content and are pinned to the same repo tag, so
+// their entity ids coincide. Any difference in the resulting sets is
+// attributable to seeding — including a merge that drops carry-forward edges,
+// which is what the entity-only assertions elsewhere cannot see.
+func TestWorktreeSeedParity_PathAOnASeededBaseMatchesPathAOnASelfBuiltBase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("indexes fixture repos; skipped under -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	parentPath := filepath.Join(root, "parent")
+	const parentRef = "release/2026-07"
+	writeSeedFixtureRepo(t, parentPath, parentRef)
+	parentSD := daemon.StateDirForRepo(parentPath)
+	if err := Index(parentPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(parentSD)); err != nil {
+		t.Fatalf("index parent: %v", err)
+	}
+
+	// --- X: self-built base ---
+	xPath := filepath.Join(root, "wt-selfbuilt")
+	addFixtureWorktree(t, parentPath, xPath, "feat/selfbuilt")
+	xSD := daemon.StateDirForRepo(xPath)
+	if err := Index(xPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(xSD)); err != nil {
+		t.Fatalf("index worktree X at parent content: %v", err)
+	}
+	applyChildDelta(t, xPath)
+	resX := extractors.TryIncremental(context.Background(), xPath, xSD, nil, nil)
+	if !resX.Done {
+		t.Fatalf("Path A fell back on the self-built base (%q) — the control arm did not run", resX.FallbackReason)
+	}
+	digX := digestOf(t, xSD)
+
+	// --- Y: seeded base ---
+	yPath := filepath.Join(root, "wt-seeded")
+	addFixtureWorktree(t, parentPath, yPath, "feat/seeded")
+	applyChildDelta(t, yPath)
+	ySD := daemon.StateDirForRepo(yPath)
+	out := daemon.SeedWorktreeGraph(daemon.SeedRequest{
+		ParentPath: parentPath, ParentRef: parentRef,
+		ChildPath: yPath, ChildRef: "feat/seeded", RepoTag: parityRepoTag,
+	})
+	if !out.Seeded {
+		t.Fatalf("seed failed: %s — %s", out.Reason, out.Detail)
+	}
+	if _, reason, err := daemon.VerifySeededGraph(ySD); err != nil || reason != "" {
+		t.Fatalf("verify: reason=%q err=%v", reason, err)
+	}
+	resY := extractors.TryIncremental(context.Background(), yPath, ySD, nil, nil)
+	if !resY.Done {
+		t.Fatalf("Path A fell back on the seeded base (%q)", resY.FallbackReason)
+	}
+	digY := digestOf(t, ySD)
+
+	if len(digX.entities) == 0 || len(digX.rels) == 0 {
+		t.Fatal("control arm produced an empty graph — the fixture proves nothing")
+	}
+	t.Logf("Path A control: %d entities / %d rels (changed=%d); seeded: %d entities / %d rels (changed=%d)",
+		len(digX.entities), len(digX.rels), resX.ChangedFiles,
+		len(digY.entities), len(digY.rels), resY.ChangedFiles)
+
+	assertParity(t, digX, digY, "pathA-seeded-vs-pathA-selfbuilt")
+}
+
 func digestHasName(d semanticDigest, name string) bool {
 	for k := range d.entities {
 		parts := strings.Split(k, "|")

--- a/cmd/grafel/worktree_seed_parity_test.go
+++ b/cmd/grafel/worktree_seed_parity_test.go
@@ -1,0 +1,384 @@
+package main
+
+// Parity gate for #5964 worktree graph seeding.
+//
+// Seeding is only worth having if the graph it produces is the graph a full
+// index would have produced. Counts alone cannot show that — a bug that loses
+// N edges and invents N others passes any count assertion, and #6085 was
+// itself a count bug. So this compares SEMANTIC DIGESTS: the full sets of
+// entity and relationship identities, diffed both ways.
+//
+// It also cannot compare bytes. Per #6083 a whole-file cmp on graph.fb is
+// invalid: one length change cascades through every FlatBuffers offset, so two
+// runs of the same binary can differ by tens of megabytes while being
+// semantically identical.
+//
+// The fixture is deliberately tiny (a couple of dozen small Go files) and runs
+// in-process. Repeatedly indexing a large corpus to test this is what killed
+// two earlier attempts on #6085.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+const parityRepoTag = "fixture-svc"
+
+// fixtureFileCount is small on purpose — big enough that the delta is a small
+// fraction of the graph, small enough that a run costs a second or two.
+const fixtureFileCount = 24
+
+func seedGitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
+	}
+}
+
+// writeSeedFixtureRepo lays down a small multi-file Go service and commits it on
+// the given branch.
+func writeSeedFixtureRepo(t *testing.T, dir, branch string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fixture\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < fixtureFileCount; i++ {
+		src := fmt.Sprintf(`package svc
+
+// Service%[1]d is a fixture type.
+type Service%[1]d struct {
+	Name string
+}
+
+// Handle%[1]d does the work for service %[1]d.
+func (s *Service%[1]d) Handle%[1]d(in string) string {
+	return s.helper%[1]d(in)
+}
+
+func (s *Service%[1]d) helper%[1]d(in string) string {
+	return in + s.Name
+}
+
+// Dispatch%[1]d calls into the previous service, giving the graph cross-file
+// CALLS edges so the parity check exercises edge carry-forward, not just
+// entity carry-forward.
+func Dispatch%[1]d(in string) string {
+	prev := &Service%[2]d{Name: "p"}
+	return prev.Handle%[2]d(in)
+}
+`, i, (i+fixtureFileCount-1)%fixtureFileCount)
+		if err := os.WriteFile(filepath.Join(dir, "svc", fmt.Sprintf("svc%02d.go", i)), []byte(src), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedGitRun(t, dir, "init", "-q", "-b", branch)
+	seedGitRun(t, dir, "add", "-A")
+	seedGitRun(t, dir, "commit", "-q", "-m", "fixture")
+}
+
+// addFixtureWorktree creates a REAL linked git worktree of parentPath on a new
+// branch. Using two independent `git init` repos instead would be a fixture
+// that cannot fail the way production does: the parent's indexed commit would
+// be unreachable from the child, so the incremental pass's commit-range diff
+// reports "head-advance-unconfirmed" and falls back before the seed is ever
+// exercised. A worktree shares the parent's object store, which is the whole
+// premise of #5954.
+func addFixtureWorktree(t *testing.T, parentPath, childPath, branch string) {
+	t.Helper()
+	seedGitRun(t, parentPath, "worktree", "add", "-q", "-b", branch, childPath)
+}
+
+// applyChildDelta makes the child tree differ from the parent in the three
+// ways an agent's worktree actually differs: a committed change, an
+// uncommitted working-tree edit, and an untracked new file. The last two are
+// exactly what a `git diff <parentRef>..<childRef>` would MISS, and they are
+// the most common thing an agent asks about — its own in-progress work.
+func applyChildDelta(t *testing.T, dir string) {
+	t.Helper()
+	// (a) committed change
+	committed := filepath.Join(dir, "svc", "svc00.go")
+	body, err := os.ReadFile(committed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body = append(body, []byte("\n// CommittedOnChild is new on the child branch.\nfunc CommittedOnChild(in string) string { return in }\n")...)
+	if err := os.WriteFile(committed, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedGitRun(t, dir, "add", "-A")
+	seedGitRun(t, dir, "commit", "-q", "-m", "child commit")
+
+	// (b) uncommitted working-tree edit
+	dirty := filepath.Join(dir, "svc", "svc01.go")
+	dbody, err := os.ReadFile(dirty)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbody = append(dbody, []byte("\n// UncommittedOnChild is an in-progress edit.\nfunc UncommittedOnChild(in string) string { return in }\n")...)
+	if err := os.WriteFile(dirty, dbody, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// (c) untracked new file
+	untracked := `package svc
+
+// UntrackedHelper lives in a file git has never seen.
+func UntrackedHelper(in string) string { return in + "!" }
+`
+	if err := os.WriteFile(filepath.Join(dir, "svc", "untracked.go"), []byte(untracked), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// semanticDigest reduces a graph to the two identity sets that matter. Entity
+// rows carry id AND (kind, name, source_file) so a bug that keeps the id but
+// moves the entity, or keeps the shape but changes the id, both show up.
+type semanticDigest struct {
+	entities map[string]bool
+	rels     map[string]bool
+}
+
+func digestOf(t *testing.T, stateDir string) semanticDigest {
+	t.Helper()
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil || doc == nil {
+		t.Fatalf("load graph from %s: %v", stateDir, err)
+	}
+	d := semanticDigest{
+		entities: make(map[string]bool, len(doc.Entities)),
+		rels:     make(map[string]bool, len(doc.Relationships)),
+	}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		d.entities[strings.Join([]string{e.ID, e.Kind, e.Name, filepath.ToSlash(e.SourceFile)}, "|")] = true
+	}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		d.rels[strings.Join([]string{r.FromID, r.ToID, r.Kind}, "|")] = true
+	}
+	return d
+}
+
+// seedDiffSets returns up to `limit` members of a\b and b\a, sorted, plus the full
+// counts — so a failure names WHICH rows were lost or invented rather than
+// only how many.
+func seedDiffSets(a, b map[string]bool, limit int) (onlyA, onlyB []string, nA, nB int) {
+	for k := range a {
+		if !b[k] {
+			nA++
+			if len(onlyA) < limit {
+				onlyA = append(onlyA, k)
+			}
+		}
+	}
+	for k := range b {
+		if !a[k] {
+			nB++
+			if len(onlyB) < limit {
+				onlyB = append(onlyB, k)
+			}
+		}
+	}
+	sort.Strings(onlyA)
+	sort.Strings(onlyB)
+	return
+}
+
+func assertParity(t *testing.T, want, got semanticDigest, label string) {
+	t.Helper()
+	lost, invented, nLost, nInv := seedDiffSets(want.entities, got.entities, 8)
+	if nLost != 0 || nInv != 0 {
+		t.Errorf("%s: entity parity broken — %d lost, %d invented\n  lost: %v\n  invented: %v",
+			label, nLost, nInv, lost, invented)
+	}
+	lost, invented, nLost, nInv = seedDiffSets(want.rels, got.rels, 8)
+	if nLost != 0 || nInv != 0 {
+		t.Errorf("%s: relationship parity broken — %d lost, %d invented\n  lost: %v\n  invented: %v",
+			label, nLost, nInv, lost, invented)
+	}
+}
+
+// TestWorktreeSeedParity_SeededGraphMatchesAFullIndex is the correctness gate.
+// It indexes the SAME child tree twice — once from scratch, once seeded from
+// the parent ref's graph plus an incremental pass over the delta — and asserts
+// the two graphs are semantically identical.
+func TestWorktreeSeedParity_SeededGraphMatchesAFullIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("indexes a fixture repo twice; skipped under -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	// --- parent, on a ref that is deliberately NOT "main" ---
+	parentPath := filepath.Join(root, "parent")
+	const parentRef = "release/2026-07"
+	writeSeedFixtureRepo(t, parentPath, parentRef)
+	parentSD := daemon.StateDirForRepo(parentPath)
+	if err := Index(parentPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(parentSD)); err != nil {
+		t.Fatalf("index parent: %v", err)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(parentSD); desc.Kind == graph.GraphAbsent {
+		t.Fatalf("parent state dir %s has no graph after indexing", parentSD)
+	}
+
+	// --- child worktree: same tree, plus a committed / uncommitted /
+	//     untracked delta ---
+	childPath := filepath.Join(root, "wt-agent-a")
+	const childRef = "feat/agent-a"
+	addFixtureWorktree(t, parentPath, childPath, childRef)
+	applyChildDelta(t, childPath)
+	childSD := daemon.StateDirForRepo(childPath)
+
+	// --- PASS 1: from scratch, no seed. Pinned to the parent's tag, exactly
+	//     as daemonSchedulerIndex does via the repo-tag pin. ---
+	if err := Index(childPath, "", parityRepoTag, []string{"graph-algo"}, false, false); err != nil {
+		t.Fatalf("scratch index child: %v", err)
+	}
+	scratch := digestOf(t, childSD)
+	if len(scratch.entities) == 0 {
+		t.Fatal("scratch index produced no entities — the fixture is inert")
+	}
+
+	// --- PASS 2: wipe, seed from the parent ref, index the delta only. ---
+	if err := os.RemoveAll(childSD); err != nil {
+		t.Fatal(err)
+	}
+	out := daemon.SeedWorktreeGraph(daemon.SeedRequest{
+		ParentPath: parentPath,
+		ParentRef:  parentRef,
+		ChildPath:  childPath,
+		ChildRef:   childRef,
+		RepoTag:    parityRepoTag,
+	})
+	if !out.Seeded {
+		t.Fatalf("seed failed: %s — %s", out.Reason, out.Detail)
+	}
+	stamp, reason, err := daemon.VerifySeededGraph(childSD)
+	if err != nil || reason != "" {
+		t.Fatalf("seed verification: reason=%q err=%v", reason, err)
+	}
+	if stamp.RepoTag != parityRepoTag {
+		t.Fatalf("stamp RepoTag=%q want %q", stamp.RepoTag, parityRepoTag)
+	}
+	if err := Index(childPath, "", stamp.RepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(childSD)); err != nil {
+		t.Fatalf("seeded incremental index child: %v", err)
+	}
+	seeded := digestOf(t, childSD)
+
+	assertParity(t, scratch, seeded, "seeded-vs-scratch")
+
+	// The delta must actually be in the graph: if the seeded pass silently
+	// skipped the child's own work, parity against a broken scratch index
+	// could still pass. Assert the three delta shapes by name.
+	for _, name := range []string{"CommittedOnChild", "UncommittedOnChild", "UntrackedHelper"} {
+		if !digestHasName(seeded, name) {
+			t.Errorf("seeded graph is missing %q — an agent would be served stale results for its own work", name)
+		}
+		if !digestHasName(scratch, name) {
+			t.Errorf("scratch graph is missing %q — the fixture never exercised this delta shape", name)
+		}
+	}
+}
+
+// TestWorktreeSeedConsumedByTheDaemonPath covers the path the daemon actually
+// takes for a seeded worktree: the scheduler calls extractors.TryIncremental
+// before it ever calls Index. The parity gate above exercises
+// Index()+WithIncremental (Path B); this asserts the SHIPPING path (Path A)
+// consumes the same seed, indexes only the delta, and carries the child's own
+// work into the graph.
+//
+// It deliberately does NOT assert full parity against a scratch index: Path A
+// is an in-place patch that re-runs a reduced pass set, so it is not expected
+// to be byte- or set-identical to a full pipeline run. What it must prove is
+// that the seed is consumable and that the delta is not lost.
+func TestWorktreeSeedConsumedByTheDaemonPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("indexes a fixture repo; skipped under -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	parentPath := filepath.Join(root, "parent")
+	const parentRef = "release/2026-07"
+	writeSeedFixtureRepo(t, parentPath, parentRef)
+	parentSD := daemon.StateDirForRepo(parentPath)
+	if err := Index(parentPath, "", parityRepoTag, []string{"graph-algo"}, false, false,
+		WithIncremental(parentSD)); err != nil {
+		t.Fatalf("index parent: %v", err)
+	}
+
+	childPath := filepath.Join(root, "wt-agent-b")
+	const childRef = "feat/agent-b"
+	addFixtureWorktree(t, parentPath, childPath, childRef)
+	applyChildDelta(t, childPath)
+	childSD := daemon.StateDirForRepo(childPath)
+
+	out := daemon.SeedWorktreeGraph(daemon.SeedRequest{
+		ParentPath: parentPath,
+		ParentRef:  parentRef,
+		ChildPath:  childPath,
+		ChildRef:   childRef,
+		RepoTag:    parityRepoTag,
+	})
+	if !out.Seeded {
+		t.Fatalf("seed failed: %s — %s", out.Reason, out.Detail)
+	}
+	if _, reason, err := daemon.VerifySeededGraph(childSD); err != nil || reason != "" {
+		t.Fatalf("verification: reason=%q err=%v", reason, err)
+	}
+
+	res := extractors.TryIncremental(context.Background(), childPath, childSD, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental fell back (%q) on a freshly seeded state dir — the seed is not consumable by the shipping path", res.FallbackReason)
+	}
+	// O(delta), not O(corpus): only the child's own changed files were
+	// re-extracted, out of a fixture of fixtureFileCount+1 source files.
+	if res.ChangedFiles == 0 || res.ChangedFiles > 6 {
+		t.Errorf("ChangedFiles=%d — expected the small delta, not the whole corpus of %d files", res.ChangedFiles, fixtureFileCount+1)
+	}
+	t.Logf("seeded daemon-path pass re-extracted %d of %d source files", res.ChangedFiles, fixtureFileCount+1)
+	got := digestOf(t, childSD)
+	for _, name := range []string{"CommittedOnChild", "UncommittedOnChild", "UntrackedHelper"} {
+		if !digestHasName(got, name) {
+			t.Errorf("graph is missing %q after the seeded daemon-path pass", name)
+		}
+	}
+}
+
+func digestHasName(d semanticDigest, name string) bool {
+	for k := range d.entities {
+		parts := strings.Split(k, "|")
+		if len(parts) >= 3 && parts[2] == name {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/grafel/worktree_seed_wiring_test.go
+++ b/cmd/grafel/worktree_seed_wiring_test.go
@@ -1,0 +1,267 @@
+package main
+
+// Wiring guards for #5964 on the cmd/grafel side.
+//
+// The seeding primitives in internal/daemon are well covered on their own, but
+// coverage of a helper proves nothing about whether it is CALLED. Two mutants
+// removed the consumption side entirely and left every suite green:
+//
+//   - deleting the verifyOrDiscardSeed guard from the incremental callback, so
+//     seeds were consumed with no provenance verification at all;
+//   - forcing repoTag to "" in daemonSchedulerIndex, so the repo-tag pin was
+//     ignored on the full-index path and a worktree's entity ids silently
+//     diverged from its parent's.
+//
+// Both are now driven behaviourally. None of these tests inspects source text.
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// seedFakeStateDir writes a state dir that LOOKS seeded: a generation file, a
+// `current` pointer, a diff manifest, and a valid provenance stamp. No indexing
+// involved, so these run in microseconds.
+func seedFakeStateDir(t *testing.T, parentSD, childSD, repoTag string) {
+	t.Helper()
+	if err := os.MkdirAll(parentSD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := graph.GenFileName(1)
+	if err := os.WriteFile(filepath.Join(parentSD, name), []byte("PARENT-GRAPH-BYTES"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(parentSD, name); err != nil {
+		t.Fatal(err)
+	}
+	m := diff.LoadManifest(parentSD)
+	m.Files["a.go"] = diff.FileEntry{SHA256: "aa", Size: 1}
+	if err := diff.SaveManifest(parentSD, "/x", m); err != nil {
+		t.Fatal(err)
+	}
+	out := daemon.SeedWorktreeGraph(daemon.SeedRequest{
+		ParentPath:     filepath.Join(t.TempDir(), "p"),
+		ParentRef:      "release/x",
+		ParentStateDir: parentSD,
+		ChildPath:      filepath.Join(t.TempDir(), "c"),
+		ChildRef:       "feat/x",
+		ChildStateDir:  childSD,
+		RepoTag:        repoTag,
+	})
+	if !out.Seeded {
+		t.Fatalf("fixture seed failed: %s — %s", out.Reason, out.Detail)
+	}
+}
+
+func TestVerifyOrDiscardSeed_RejectsAndDiscardsATamperedSeed(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	seedFakeStateDir(t, parentSD, childSD, "svc")
+
+	// Tamper: the graph on disk is no longer the graph the stamp covers.
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(1)), []byte("TAMPERED-CONTENT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reason, ok := verifyOrDiscardSeed(childSD)
+	if ok {
+		t.Fatal("verifyOrDiscardSeed accepted a seed whose content does not match its stamp")
+	}
+	if reason != string(daemon.SeedFallbackStampMismatch) {
+		t.Errorf("reason=%q want %q", reason, daemon.SeedFallbackStampMismatch)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Error("the untrusted seed is still resolvable — a full index would merge into it")
+	}
+}
+
+func TestVerifyOrDiscardSeed_AcceptsAnIntactSeedAndConsumesTheStamp(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	seedFakeStateDir(t, parentSD, childSD, "svc")
+
+	reason, ok := verifyOrDiscardSeed(childSD)
+	if !ok || reason != "" {
+		t.Fatalf("intact seed rejected: reason=%q ok=%v", reason, ok)
+	}
+	if _, err := daemon.ReadSeedStamp(childSD); err == nil {
+		t.Error("stamp not consumed — the next pass would verify it against this pass's own newer generation")
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind == graph.GraphAbsent {
+		t.Error("the verified seed was removed")
+	}
+}
+
+func TestVerifyOrDiscardSeed_KeepsTheChildsOwnGraphWhenTheStampIsMerelyStale(t *testing.T) {
+	// The GRAFEL_INCREMENTAL_REINDEX=0 sequence: a full index ran over the
+	// seeded dir and wrote a newer generation. The stale stamp must not cause
+	// that graph to be discarded.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	seedFakeStateDir(t, parentSD, childSD, "svc")
+
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(2)), []byte("CHILD-OWN-GRAPH"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(2)); err != nil {
+		t.Fatal(err)
+	}
+
+	reason, ok := verifyOrDiscardSeed(childSD)
+	if !ok {
+		t.Fatalf("a stale stamp over the child's own newer graph was treated as untrusted: reason=%q", reason)
+	}
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	if desc.Kind == graph.GraphAbsent {
+		t.Fatal("DATA LOSS: the child's own graph was made unresolvable by a stale stamp")
+	}
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "CHILD-OWN-GRAPH" {
+		t.Errorf("resolved body=%q want CHILD-OWN-GRAPH", body)
+	}
+	if _, err := daemon.ReadSeedStamp(childSD); err == nil {
+		t.Error("the stale stamp was not cleared — it would re-trigger on every subsequent pass")
+	}
+}
+
+// Drives the scheduler's incremental callback itself, so deleting the
+// verification guard from it fails here rather than silently.
+func TestDaemonSchedulerIncremental_RefusesToConsumeATamperedSeed(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "a.go"), []byte("package p\nfunc A() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	stateDir := daemon.ResolveIncrementalStateDir(repo, "")
+	seedFakeStateDir(t, filepath.Join(root, "parent-state"), stateDir, "svc")
+	// The seeded graph bytes are not a real graph, but that is irrelevant: the
+	// verification guard must reject this before anything tries to load it.
+	if err := os.WriteFile(filepath.Join(stateDir, graph.GenFileName(1)), []byte("TAMPERED-CONTENT"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res := daemonSchedulerIncremental(context.Background(), repo, "", nil)
+
+	if res.Done {
+		t.Fatal("the incremental callback consumed a seed that failed provenance verification")
+	}
+	if !strings.HasPrefix(res.FallbackReason, "seed_") {
+		t.Fatalf("FallbackReason=%q want a seed_* reason naming which check failed", res.FallbackReason)
+	}
+	if !strings.Contains(res.FallbackReason, string(daemon.SeedFallbackStampMismatch)) {
+		t.Errorf("FallbackReason=%q does not name the failing check", res.FallbackReason)
+	}
+}
+
+// resolveIndexRepoTag is the seam daemonSchedulerIndex reads. Forcing it to ""
+// is the mutant that silently un-pins a worktree's entity ids.
+func TestResolveIndexRepoTag_ReturnsThePinAndNothingWhenUnpinned(t *testing.T) {
+	dir := t.TempDir()
+	if got := resolveIndexRepoTag(dir); got != "" {
+		t.Errorf("unpinned state dir returned %q — every ordinary repo would be re-tagged", got)
+	}
+	if err := daemon.WriteRepoTagPin(dir, "myservice"); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveIndexRepoTag(dir); got != "myservice" {
+		t.Fatalf("resolveIndexRepoTag=%q want myservice", got)
+	}
+}
+
+// End-to-end on the FULL-index path: a pinned worktree state dir must produce
+// entity ids computed from the PIN, not from the worktree directory's name.
+// This runs a real (small) in-process index, because that is the only way to
+// prove the tag reached graph.EntityID.
+func TestDaemonSchedulerIndex_FullIndexHonoursTheRepoTagPin(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+	// Force the in-process index path so this stays one fast process. The
+	// toggle is an atomic, not an env read at call time.
+	prev := sched.SetSubprocessIndexEnabled(false)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prev) })
+
+	repo := filepath.Join(root, "wt-agent-pinned")
+	if err := os.MkdirAll(filepath.Join(repo, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(repo, "go.mod"), []byte("module pinned\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	src := "package svc\n\ntype Widget struct{ Name string }\n\nfunc (w *Widget) Render() string { return w.Name }\n"
+	if err := os.WriteFile(filepath.Join(repo, "svc", "widget.go"), []byte(src), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	seedGitRun(t, repo, "init", "-q", "-b", "feat/pinned")
+	seedGitRun(t, repo, "add", "-A")
+	seedGitRun(t, repo, "commit", "-q", "-m", "fixture")
+
+	const pinnedTag = "parent-slug-not-the-dir-name"
+	stateDir := daemon.ResolveIncrementalStateDir(repo, "")
+	if err := daemon.WriteRepoTagPin(stateDir, pinnedTag); err != nil {
+		t.Fatal(err)
+	}
+	defaultTag := filepath.Base(repo)
+	if defaultTag == pinnedTag {
+		t.Fatal("fixture is inert: the pin must differ from the directory basename")
+	}
+
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil || doc == nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	// Assert over EVERY source-bearing entity rather than one hand-picked
+	// name, so the test cannot rot on a naming change in the extractor.
+	checked := 0
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.SourceFile == "" || e.ID == "" {
+			continue // synthetic (ext:*) entities have no repo-tagged id
+		}
+		wantPinned := graph.EntityID(pinnedTag, e.Kind, e.Name, e.SourceFile)
+		gotDefault := graph.EntityID(defaultTag, e.Kind, e.Name, e.SourceFile)
+		if wantPinned == gotDefault {
+			t.Fatalf("fixture is inert: pinned and default ids collide for %q", e.Name)
+		}
+		if e.ID == gotDefault {
+			t.Fatalf("entity %q (%s) id=%s was computed from the DIRECTORY BASENAME %q — the repo-tag pin was ignored on the full-index path (want %s from pin %q)",
+				e.Name, e.Kind, e.ID, defaultTag, wantPinned, pinnedTag)
+		}
+		if e.ID == wantPinned {
+			checked++
+		}
+	}
+	if checked == 0 {
+		t.Fatalf("no source-bearing entity carried a pin-derived id (graph had %d entities) — the fixture proves nothing", len(doc.Entities))
+	}
+	t.Logf("%d source-bearing entities carry ids derived from the pinned tag %q", checked, pinnedTag)
+}

--- a/docs/adrs/0020-multi-branch-worktree.md
+++ b/docs/adrs/0020-multi-branch-worktree.md
@@ -172,7 +172,17 @@ tier system and Pass-4 semantics are unchanged - this is index-side only.
 4. **Verify before use.** The consuming pass re-hashes every stamped artifact
    and re-reads the pointer (`VerifySeededGraph`) before the seed is used. The
    stamp is consumed at the moment verification succeeds, since the pass then
-   writes its own generation into the same dir.
+   writes its own generation into the same dir. Both paths that can reach a
+   seeded dir consume it - the incremental callback and `daemonSchedulerIndex` -
+   because the scheduler skips the incremental callback entirely when
+   `GRAFEL_INCREMENTAL_REINDEX=0`, a documented and supported setting.
+   Belt and braces, a pointer naming a generation *newer* than the stamp is
+   classified `seed_superseded_by_child_graph` (benign: the child built its own
+   graph, so the stamp is merely stale), and `DiscardSeed` **refuses** to touch
+   such a dir. Without both, a stale stamp would make `DiscardSeed` remove the
+   `current` pointer and render a full corpus reindex the child legitimately
+   paid for unresolvable - throwing away exactly the cost this work exists to
+   eliminate.
 5. **Index the delta.** The existing content-hash + git machinery
    (`diff.FilterWithGit`) recomputes the changed set from the child's working
    tree. Because the baseline is content hashes rather than a commit range,
@@ -207,23 +217,43 @@ every FlatBuffers offset), and counts alone are insufficient - a bug that loses
 N rows and invents N others passes a count assertion, and #6085 was itself a
 count bug.
 
-**Measured, not inferred.** On a 2500-file fixture with a 3-file delta
-(16 GB macOS laptop; `TestWorktreeSeedPeakHeapAndWallClock`, opt-in via
-`GRAFEL_SEED_HEAP_MEASURE=1`):
+**Measured, not inferred. Read this before quoting a benefit.** Seeding is
+O(delta) in work; its wall-clock win is **scale-dependent**, and it is **never a
+memory win**. 16 GB macOS laptop, 3 changed files, swap steady across every run
+(`TestWorktreeSeedPeakHeapAndWallClock`, opt-in via `GRAFEL_SEED_HEAP_MEASURE=1`;
+peak is live heap `next_gc / (1 + GOGC/100)`, not RSS - macOS RSS counts
+`MADV_FREE` pages and is an upper bound, not a footprint):
 
-| | full index of the worktree | seed + incremental delta |
-|---|---|---|
-| peak live heap | 105.3 MB | 138.8 MB (1.32x) |
-| wall clock | 7.252 s | 1.245 s (0.17x) |
+| files | full index | seed + delta | heap | wall |
+|---|---|---|---|---|
+| 400 | 60.7 MB / 515 ms | 62.3 MB / 533 ms | 1.03x | **1.03x - no win** |
+| 1200 | 75.8 MB / 997 ms | 91.3 MB / 668 ms | 1.20x | 0.67x |
+| 2500 | 105.3 MB / 7.252 s | 138.8 MB / 1.245 s | 1.32x | 0.17x |
 
-Seeding is O(delta) in work and wall clock, **not** in peak memory. The seeded
-pass re-extracts 3 of 2503 files, but it materialises the whole parent graph to
-merge the unchanged-file portion forward, and holds it alongside the document
-being built - so peak heap tracks graph size and lands slightly *above* a full
-index. Peak is reported as live heap (`next_gc / (1 + GOGC/100)`), not RSS:
-macOS RSS counts `MADV_FREE` pages and is an upper bound, not a footprint.
-Sizing concurrent per-worktree indexing off this must budget for the graph, not
-for the delta.
+The wall-clock crossover sits between 400 and 1200 files; below it seeding is
+break-even or marginally worse. The heap ratio degrades monotonically with graph
+size.
+
+This is **structural, not a fixture artifact**. The seeded pass re-extracts 3 of
+N files, but it must materialise the *whole parent graph* to merge the
+unchanged-file portion forward (`internal/extractors/incremental.go` calls
+`graph.LoadGraphFromDir`; the `Index()` path does the same via
+`mergeIncrementalPrevDoc` plus the carry-forward entity slice) and holds it
+alongside the document being built. Peak heap therefore tracks **graph size**,
+not delta size, and lands *above* a full index.
+
+**So: "seed instead of full index" is a latency optimisation, not a memory one.
+It does NOT reduce the per-process memory budget that epic #5954 exists to
+reduce** - the ~1.0-1.1 GB per concurrent indexing process is untouched by this
+change, and anyone sizing concurrent per-worktree indexing must budget for the
+graph, not for the delta. Reducing that peak is separate work.
+
+**One-time entity-id change for already-indexed worktrees.** The repo-tag pin is
+written on activation, so a worktree that was already indexed under the default
+tag (its own directory basename) has every entity id re-minted from the parent's
+slug on its next full index. No hybrid graph arises - the whole graph is
+rewritten in one pass - but ids that external state may have cached do change
+once. Repos that are not worktrees never get a pin and are entirely unaffected.
 
 **Not covered.** Seeding is wired to worktree activation only. An in-place
 branch switch on a single checkout (the `.git/HEAD` watch path above) is not

--- a/docs/adrs/0020-multi-branch-worktree.md
+++ b/docs/adrs/0020-multi-branch-worktree.md
@@ -107,8 +107,9 @@ extended to watch `.git/HEAD` in addition to source files. A HEAD change event:
 1. Reads the new ref name via `gitmeta.Capture`.
 2. Marks the old slot as WARM (triggers the idle timer immediately).
 3. Triggers an incremental reindex for the new ref's slot. If the new ref has
-   never been indexed, the clone-from-parent optimisation is tried first (see
-   below). If clone fails or is not applicable, a full index runs (#2129).
+   never been indexed, a full index runs (#2129). Graph seeding (see "Worktree
+   graph seeding" below) is wired to worktree ACTIVATION, not to this
+   HEAD-switch path.
 
 Git hooks (`post-checkout`, `post-merge`, `post-rewrite`) installed by
 `grafel install-hooks` send an explicit signal to the daemon via the
@@ -126,23 +127,129 @@ Worktree slots receive `SlotKindWorktree` in the tier manager, applying the
 aggressive eviction policy. Worktrees that are removed between two discovery
 cycles have their slots transitioned to COLD (#2138, watcher pause/resume #2139).
 
-### Clone-from-parent optimisation
+### Worktree graph seeding
 
-When a new ref has never been indexed (no `graph.fb` present), the daemon
-checks whether a close ancestor ref's graph can be seeded. If the diff between
-the ancestor and the new ref touches ≤ `GRAFEL_CLONE_MAX_FILES` files
-(default 20, hard cap 100), the optimisation:
+> **Status correction (#5964).** This section previously described a
+> *"clone-from-parent optimisation"* in the present indicative, as though it
+> shipped. It did not. That attempt (#3652) was written, found broken, and
+> deleted in `65427c5a8`; `GRAFEL_CLONE_MAX_FILES` has never existed in the
+> code, and the "~5 s -> ~180 ms" figure was never measured against a shipped
+> implementation. The original text is preserved, collapsed, at the end of this
+> section rather than deleted: an ADR asserting a guarantee the code does not
+> deliver is a defect class this repo has paid for repeatedly, and removing the
+> claim silently would hide that it was ever made.
 
-1. Copies the parent's `graph.fb` and side-cars to the new ref's store dir.
-2. Patches the metadata header (`indexed_ref`, `indexed_sha`, `computed_at`)
-   via a streaming read-modify-write (no in-place FlatBuffers mutation).
-3. Re-extracts only the changed files: removes stale entities/relationships,
-   runs the language extractor callback, merges new results.
-4. Persists the updated `graph.fb` atomically.
+When a linked worktree is activated (`worktree.Watcher.OnActivate`), the daemon
+seeds the worktree's `(path, ref)` slot from its parent's graph before the
+initial reindex is enqueued, so that reindex becomes an incremental pass over
+the delta instead of a full index of the corpus. Implemented in
+`internal/daemon/worktree_seed.go`. The read path, storage format, cache keys,
+tier system and Pass-4 semantics are unchanged - this is index-side only.
 
-Typical speedup on a 6 k-entity repo with 5 changed files: ~5 s → ~180 ms.
-If any precondition fails, the partially-built graph is removed and a full
-reindex runs (#2146).
+1. **Resolve the parent.** `WorktreeChild.ParentPath` (recorded at discovery),
+   falling back to `gitmeta.ResolveCommonDir` matched against the watcher's own
+   parents provider. The parent's **actual** current ref is then read via
+   `gitmeta.CaptureCached` - never a hardcoded `"main"`. Resolving a hardcoded
+   ref against the *worktree's* own path was the bug that killed #3652: wrong
+   store root and wrong ref name, so it always read an empty directory.
+2. **Pin the repo tag.** `graph.EntityID` hashes the repo tag first, and
+   `Index()` defaults it to `filepath.Base(repoPath)` - for a worktree, the
+   worktree directory's own name, which disagrees with the parent's slug.
+   Without a pin a seeded graph would mix two id spaces, leaving every
+   cross-file edge between them dangling. The pin (`repo-tag`, in the state
+   dir) is written whether or not seeding succeeds, because a *full* index of
+   the worktree must use the same tag for the two graphs to be comparable at
+   all.
+3. **Copy and stamp.** The parent's active graph generation (single-file or
+   segment-set) **and its `file-index.json` diff manifest** are copied into
+   `StateDirForRepoRef(child.Path, child.Branch)`. The manifest is not
+   optional: it is the baseline the child's changed-file set is computed
+   against, and a graph seeded without it is silently wrong. The copy is
+   bracketed by a generation-stability check and recorded in
+   `seed-provenance.json` with a SHA-256 of every artifact copied. The
+   `current` pointer is published **last**, so a torn copy leaves inert bytes
+   rather than a resolvable, wrong graph.
+4. **Verify before use.** The consuming pass re-hashes every stamped artifact
+   and re-reads the pointer (`VerifySeededGraph`) before the seed is used. The
+   stamp is consumed at the moment verification succeeds, since the pass then
+   writes its own generation into the same dir.
+5. **Index the delta.** The existing content-hash + git machinery
+   (`diff.FilterWithGit`) recomputes the changed set from the child's working
+   tree. Because the baseline is content hashes rather than a commit range,
+   committed changes, uncommitted working-tree edits and untracked files are
+   all covered by one mechanism - a `git diff <parentRef>..<childRef>` alone
+   would miss the last two, which are exactly an agent's in-progress work.
+
+`diff.FilterWithGit` was extended as part of this work. It previously trusted
+`git diff --name-only HEAD` and never hashed a file git did not report, which
+is sound only while the manifest was written at the commit the repo is on now.
+A seeded state dir violates that by construction (the manifest is the
+parent's), so `FilterWithGit` now unions in the `manifest.GitCommit..HEAD`
+range diff, and falls back to a full hash comparison when that range cannot be
+resolved (unreachable commit after a gc, shallow clone, or history rewrite).
+The parity test below found this: without the union, a file changed by a
+*commit* on the child branch was never re-extracted and its stale entities
+survived. The same hole affected any `Index()`+`WithIncremental` run after a
+HEAD advance; `internal/extractors.TryIncremental` had its own equivalent
+(#5710).
+
+**Fallback policy.** Every failed precondition - parent not indexed, parent
+without a diff manifest, generation moved mid-copy, copy error, child already
+indexed, no repo tag to pin, stamp mismatch - falls back to a full index **and
+logs a named reason**. A silent fallback is explicitly rejected: a seed that
+systematically never fired would be invisible.
+
+**Correctness gate.** `TestWorktreeSeedParity_SeededGraphMatchesAFullIndex`
+(`cmd/grafel/`) indexes the same worktree twice - seeded, and from scratch -
+and diffs the full entity and relationship identity sets both ways. Byte
+comparison of `graph.fb` is invalid (#6083: one length change cascades through
+every FlatBuffers offset), and counts alone are insufficient - a bug that loses
+N rows and invents N others passes a count assertion, and #6085 was itself a
+count bug.
+
+**Measured, not inferred.** On a 2500-file fixture with a 3-file delta
+(16 GB macOS laptop; `TestWorktreeSeedPeakHeapAndWallClock`, opt-in via
+`GRAFEL_SEED_HEAP_MEASURE=1`):
+
+| | full index of the worktree | seed + incremental delta |
+|---|---|---|
+| peak live heap | 105.3 MB | 138.8 MB (1.32x) |
+| wall clock | 7.252 s | 1.245 s (0.17x) |
+
+Seeding is O(delta) in work and wall clock, **not** in peak memory. The seeded
+pass re-extracts 3 of 2503 files, but it materialises the whole parent graph to
+merge the unchanged-file portion forward, and holds it alongside the document
+being built - so peak heap tracks graph size and lands slightly *above* a full
+index. Peak is reported as live heap (`next_gc / (1 + GOGC/100)`), not RSS:
+macOS RSS counts `MADV_FREE` pages and is an upper bound, not a footprint.
+Sizing concurrent per-worktree indexing off this must budget for the graph, not
+for the delta.
+
+**Not covered.** Seeding is wired to worktree activation only. An in-place
+branch switch on a single checkout (the `.git/HEAD` watch path above) is not
+seeded from the previous ref.
+
+<details>
+<summary>Superseded: the #3652 "clone-from-parent optimisation" as this ADR
+previously described it. NEVER SHIPPED.</summary>
+
+> When a new ref has never been indexed (no `graph.fb` present), the daemon
+> checks whether a close ancestor ref's graph can be seeded. If the diff between
+> the ancestor and the new ref touches ≤ `GRAFEL_CLONE_MAX_FILES` files
+> (default 20, hard cap 100), the optimisation:
+>
+> 1. Copies the parent's `graph.fb` and side-cars to the new ref's store dir.
+> 2. Patches the metadata header (`indexed_ref`, `indexed_sha`, `computed_at`)
+>    via a streaming read-modify-write (no in-place FlatBuffers mutation).
+> 3. Re-extracts only the changed files: removes stale entities/relationships,
+>    runs the language extractor callback, merges new results.
+> 4. Persists the updated `graph.fb` atomically.
+>
+> Typical speedup on a 6 k-entity repo with 5 changed files: ~5 s → ~180 ms.
+> If any precondition fails, the partially-built graph is removed and a full
+> reindex runs (#2146).
+
+</details>
 
 ### CLI `--ref` flag
 

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -307,29 +307,16 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				// scheduler.Enqueue captures the worktree's checked-out ref via
 				// RefCapture(worktreePath), so the graph lands in the correct
 				// per-ref dir keyed by the worktree path (multi-ref model).
-				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
-					// #5964: seed this worktree's graph from its parent ref's
-					// graph before the reindex below is enqueued, so that
-					// reindex becomes an incremental pass over the delta
-					// instead of a full index of the whole corpus. What gets
-					// enqueued is UNCHANGED; only the state dir it finds
-					// differs. Every outcome — seeded or not — is logged with a
-					// named reason. OnActivate fires once per activation
-					// transition (new discovery or re-activation after expiry,
-					// see worktree.Watcher.poll), so this runs once per
-					// worktree activation, not per poll tick.
-					seedWorktreeOnActivate(logger, child, cfg.WorktreeParents)
-
-					activateSem <- struct{}{}
-					_, aerr := watcher.AddRepo(child.Path)
-					<-activateSem
-					if aerr != nil {
-						logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
-					}
-					scheduler.Enqueue(child.Path)
-					logger.Info("worktree: watching working tree + enqueued initial reindex",
-						"path", child.Path, "branch", child.Branch, "group", child.GroupName, "slug", child.ParentSlug, "locked", child.Locked)
-				}
+				wtWatcher.OnActivate = newWorktreeActivateHandler(worktreeActivateDeps{
+					Logger:  logger,
+					Parents: cfg.WorktreeParents,
+					AddRepo: func(path string) error {
+						_, err := watcher.AddRepo(path)
+						return err
+					},
+					Enqueue:     scheduler.Enqueue,
+					ActivateSem: activateSem,
+				})
 				// On expiry, unsubscribe the working tree from the watcher.
 				wtWatcher.OnExpire = func(child *worktree.WorktreeChild) {
 					watcher.RemoveRepo(child.Path)
@@ -458,6 +445,64 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 	logger.Info("startup: docgen-sweeper done")
 
 	return ep
+}
+
+// worktreeActivateDeps is what the worktree activation handler needs from the
+// engine plane, narrowed to function values so a test can drive the real
+// handler without an fsnotify watcher or a scheduler.
+type worktreeActivateDeps struct {
+	Logger  *slog.Logger
+	Parents func() []worktree.ParentRepo
+	// AddRepo subscribes a worktree's working tree to the file watcher.
+	AddRepo func(path string) error
+	// Enqueue schedules the worktree's initial reindex.
+	Enqueue func(path string)
+	// ActivateSem bounds concurrent watcher subscriptions (#5675). May be nil
+	// in tests.
+	ActivateSem chan struct{}
+}
+
+// newWorktreeActivateHandler builds the worktree.Watcher.OnActivate callback.
+//
+// This is a named factory rather than an inline closure specifically so the
+// #5964 seeding call below is reachable from a test. Inline, the entire
+// feature could be deleted from the activation path — `_ = child` — and every
+// suite stayed green: the unit tests for seedWorktreeOnActivate all still
+// passed, because nothing asserted it was ever CALLED. A source-scanning guard
+// would not have helped either (an import alias or a call moved behind a
+// comment defeats it); the test drives this handler and asserts a seed landed
+// on disk.
+func newWorktreeActivateHandler(deps worktreeActivateDeps) func(*worktree.WorktreeChild) {
+	return func(child *worktree.WorktreeChild) {
+		// #5964: seed this worktree's graph from its parent ref's graph before
+		// the reindex below is enqueued, so that reindex becomes an incremental
+		// pass over the delta instead of a full index of the whole corpus. What
+		// gets enqueued is UNCHANGED; only the state dir it finds differs.
+		// Every outcome — seeded or not — is logged with a named reason.
+		// OnActivate fires once per activation transition (new discovery or
+		// re-activation after expiry, see worktree.Watcher.poll), so this runs
+		// once per worktree activation, not per poll tick.
+		seedWorktreeOnActivate(deps.Logger, child, deps.Parents)
+
+		if deps.ActivateSem != nil {
+			deps.ActivateSem <- struct{}{}
+		}
+		var aerr error
+		if deps.AddRepo != nil {
+			aerr = deps.AddRepo(child.Path)
+		}
+		if deps.ActivateSem != nil {
+			<-deps.ActivateSem
+		}
+		if aerr != nil {
+			deps.Logger.Warn("worktree: failed to watch working tree", "path", child.Path, "err", aerr)
+		}
+		if deps.Enqueue != nil {
+			deps.Enqueue(child.Path)
+		}
+		deps.Logger.Info("worktree: watching working tree + enqueued initial reindex",
+			"path", child.Path, "branch", child.Branch, "group", child.GroupName, "slug", child.ParentSlug, "locked", child.Locked)
+	}
 }
 
 // seedWorktreeOnActivate seeds a newly-activated worktree's graph from its

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
 	"github.com/cajasmota/grafel/internal/daemon/worktree"
 	"github.com/cajasmota/grafel/internal/gitmeta"
-	"github.com/cajasmota/grafel/internal/graph"
 )
 
 // enginePlane holds the engine-plane background runtime (scheduler, watcher,
@@ -309,15 +308,17 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				// RefCapture(worktreePath), so the graph lands in the correct
 				// per-ref dir keyed by the worktree path (multi-ref model).
 				wtWatcher.OnActivate = func(child *worktree.WorktreeChild) {
-					// #5964 increment 1: probe-only diagnostic. This resolves
-					// and logs the worktree→parent state-dir mapping but does
-					// NOT copy/seed anything and does NOT alter what gets
-					// enqueued below — zero behaviour change. OnActivate fires
-					// once per activation transition (new discovery or
-					// re-activation after expiry, see worktree.Watcher.poll),
-					// so this logs once per worktree activation, not per poll
-					// tick.
-					logWorktreeParentSeedProbe(logger, child, cfg.WorktreeParents)
+					// #5964: seed this worktree's graph from its parent ref's
+					// graph before the reindex below is enqueued, so that
+					// reindex becomes an incremental pass over the delta
+					// instead of a full index of the whole corpus. What gets
+					// enqueued is UNCHANGED; only the state dir it finds
+					// differs. Every outcome — seeded or not — is logged with a
+					// named reason. OnActivate fires once per activation
+					// transition (new discovery or re-activation after expiry,
+					// see worktree.Watcher.poll), so this runs once per
+					// worktree activation, not per poll tick.
+					seedWorktreeOnActivate(logger, child, cfg.WorktreeParents)
 
 					activateSem <- struct{}{}
 					_, aerr := watcher.AddRepo(child.Path)
@@ -459,81 +460,122 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 	return ep
 }
 
-// logWorktreeParentSeedProbe resolves and logs the worktree→parent state-dir
-// mapping for a newly-activated worktree (#5964 increment 1). It is a
-// diagnostic PROBE ONLY: it never copies, seeds, or otherwise changes what
-// gets indexed — it exists solely to confirm or kill, on real data, the
-// finding that killed the first clone-from-parent attempt (#3652): that
-// attempt resolved the parent via StateDirForRepoRef(worktreePath, "main"),
-// which is keyed by the WORKTREE's own path (wrong root) and a hardcoded ref
-// (wrong ref for any parent not on "main"), so it always resolved to an
-// empty directory.
+// seedWorktreeOnActivate seeds a newly-activated worktree's graph from its
+// parent ref's graph (#5964, epic #5954), replacing the increment-1 probe that
+// only logged the resolution.
 //
-// Resolution order:
-//  1. child.ParentPath, populated at discovery (worktree.Watcher.poll).
-//  2. Fallback via gitmeta.ResolveCommonDir when ParentPath is empty (a
-//     store entry persisted before this field existed) — matched against
-//     the same parents provider the watcher itself uses, rather than the
-//     O(registered repos) registry scan in internal/mcp/routing.go.
+// What it does, in order:
+//  1. Resolve the parent repo path — child.ParentPath, recorded at discovery
+//     (worktree.Watcher.poll); otherwise derived via gitmeta.ResolveCommonDir
+//     against the same parents provider the watcher uses, for a store entry
+//     persisted before that field existed.
+//  2. Resolve the parent's ACTUAL current ref via gitmeta.CaptureCached. Never
+//     a hardcoded "main" — that is the bug that killed the first
+//     clone-from-parent attempt (#3652), which resolved
+//     StateDirForRepoRef(worktreePath, "main"): wrong root AND wrong ref, so it
+//     always read an empty directory.
+//  3. Pin the repo tag to the parent's slug. graph.EntityID hashes the repo tag
+//     first and cmd/grafel.Index defaults it to the repo dir's basename — the
+//     WORKTREE dir's name — so without this pin a seeded graph mixes two id
+//     spaces. The pin is written even when seeding does not happen, because a
+//     FULL index of the worktree must use the same tag for the two graphs to
+//     be comparable at all.
+//  4. Copy + stamp via SeedWorktreeGraph.
 //
-// dst is the worktree's own state dir (StateDirForRepoRef(child.Path,
-// child.Branch), unchanged from today's Enqueue target). src is the
-// parent's CURRENT state dir — StateDirForRepo(parentPath), which resolves
-// the parent's actual HEAD ref via gitmeta.Capture, not a hardcoded ref name
-// (the same bug class as #3652). Whether src actually holds a usable graph
-// is reported via graph.CurrentGraphDescriptor, which is segment-set aware
-// (a graph.<gen>/ dir with a `current` pointer is not necessarily a flat
-// graph.fb).
-func logWorktreeParentSeedProbe(logger *slog.Logger, child *worktree.WorktreeChild, parentsProvider func() []worktree.ParentRepo) {
+// Every outcome is logged. On success the log names the source generation; on
+// any fallback it names WHICH check failed — a silent fallback is the rejected
+// design, because a seed that systematically never fires would be invisible.
+//
+// Seeding never blocks or changes what is enqueued: the caller enqueues the
+// same reindex it always did. A seeded state dir simply turns that reindex
+// into an incremental pass over the delta (the existing content-hash + git
+// machinery recomputes the changed set from the child's working tree, so
+// uncommitted and untracked edits are covered), while an unseeded one runs the
+// full index exactly as before.
+func seedWorktreeOnActivate(logger *slog.Logger, child *worktree.WorktreeChild, parentsProvider func() []worktree.ParentRepo) SeedOutcome {
 	parentPath := child.ParentPath
-	fallbackUsed := false
+	parentPathSource := "recorded"
 	if parentPath == "" {
 		parentPath = resolveWorktreeParentPathFallback(child.Path, parentsProvider)
-		fallbackUsed = true
+		parentPathSource = "fallback_commondir"
 	}
 
-	// current_repo_tag: what Index() would default repoTag to for this
-	// worktree TODAY (filepath.Base(absRepo), cmd/grafel/index.go:~462 —
-	// the daemon always passes repoTag=""), vs the parent's slug it would
-	// need to be pinned to for entity IDs to agree with a full index of the
-	// parent (graph.EntityID hashes repoTag as its first component). This
-	// increment only REPORTS the mismatch; pinning repoTag is a separate,
-	// follow-up increment.
-	currentRepoTag := filepath.Base(filepath.Clean(child.Path))
+	childStateDir := StateDirForRepoRef(child.Path, child.Branch)
+
+	// defaultRepoTag is what Index() would use for this worktree with no pin:
+	// filepath.Base(absRepo). Logged so the mismatch the pin corrects stays
+	// visible in the field.
+	defaultRepoTag := filepath.Base(filepath.Clean(child.Path))
+
+	// The pin is written FIRST and unconditionally (when a slug is known), so
+	// the full-index fallback path uses the parent's tag too.
+	if child.ParentSlug != "" && childStateDir != "" {
+		if err := WriteRepoTagPin(childStateDir, child.ParentSlug); err != nil {
+			logger.Warn("worktree: failed to pin repo tag; a later seed cannot match a graph indexed without it",
+				"path", child.Path, "branch", child.Branch, "repo_tag", child.ParentSlug, "err", err)
+		}
+	}
 
 	if parentPath == "" {
-		logger.Info("worktree: parent-seed probe — no parent path (neither recorded nor derivable)",
-			"path", child.Path, "branch", child.Branch, "parent_slug", child.ParentSlug,
-			"current_repo_tag", currentRepoTag, "fallback_attempted", fallbackUsed)
-		return
+		out := SeedOutcome{
+			Reason:        SeedFallbackParentPathUnresolved,
+			Detail:        "no parent path recorded and none derivable from the git common-dir",
+			ChildStateDir: childStateDir,
+		}
+		logSeedFallback(logger, child, parentPath, parentPathSource, defaultRepoTag, "", out)
+		return out
 	}
 
-	dst := StateDirForRepoRef(child.Path, child.Branch)
-	src := StateDirForRepo(parentPath)
+	// The parent's ACTUAL ref — the #3652 guard.
+	parentRef := gitmeta.CaptureCached(parentPath).Ref
 
-	desc, descErr := graph.CurrentGraphDescriptor(src)
-	hasGraph := descErr == nil && desc.Kind != graph.GraphAbsent
-	kind := "absent"
-	switch desc.Kind {
-	case graph.GraphSingleFile:
-		kind = "single_file"
-	case graph.GraphSegmentSet:
-		kind = "segment_set"
+	out := SeedWorktreeGraph(SeedRequest{
+		ParentPath:    parentPath,
+		ParentRef:     parentRef,
+		ChildPath:     child.Path,
+		ChildRef:      child.Branch,
+		ChildStateDir: childStateDir,
+		RepoTag:       child.ParentSlug,
+	})
+	if !out.Seeded {
+		logSeedFallback(logger, child, parentPath, parentPathSource, defaultRepoTag, parentRef, out)
+		return out
 	}
 
-	logger.Info("worktree: parent-seed probe",
+	logger.Info("worktree: seeded graph from parent ref",
 		"path", child.Path,
 		"branch", child.Branch,
 		"parent_path", parentPath,
+		"parent_ref", parentRef,
+		"parent_path_source", parentPathSource,
+		"repo_tag", child.ParentSlug,
+		"default_repo_tag", defaultRepoTag,
+		"repo_tag_pinned", child.ParentSlug != defaultRepoTag,
+		"src_state_dir", out.ParentStateDir,
+		"dst_state_dir", out.ChildStateDir,
+		"parent_generation", out.Stamp.ParentPointer,
+		"artifacts", len(out.Stamp.Artifacts),
+		"bytes_copied", out.BytesCopied,
+	)
+	return out
+}
+
+// logSeedFallback emits the single, always-present line that names which check
+// refused the seed. Kept separate so every fallback path is guaranteed to log
+// the same fields — the reason must never be swallowed.
+func logSeedFallback(logger *slog.Logger, child *worktree.WorktreeChild, parentPath, parentPathSource, defaultRepoTag, parentRef string, out SeedOutcome) {
+	logger.Info("worktree: graph seeding skipped — running a full index",
+		"path", child.Path,
+		"branch", child.Branch,
+		"parent_path", parentPath,
+		"parent_ref", parentRef,
+		"parent_path_source", parentPathSource,
 		"parent_slug", child.ParentSlug,
-		"current_repo_tag", currentRepoTag,
-		"repo_tag_mismatch", currentRepoTag != child.ParentSlug,
-		"parent_path_source", map[bool]string{true: "fallback_commondir", false: "recorded"}[fallbackUsed],
-		"src_state_dir", src,
-		"dst_state_dir", dst,
-		"src_has_graph", hasGraph,
-		"src_graph_kind", kind,
-		"src_descriptor_err", errString(descErr),
+		"default_repo_tag", defaultRepoTag,
+		"src_state_dir", out.ParentStateDir,
+		"dst_state_dir", out.ChildStateDir,
+		"reason", string(out.Reason),
+		"detail", out.Detail,
 	)
 }
 
@@ -559,12 +601,4 @@ func resolveWorktreeParentPathFallback(worktreePath string, parentsProvider func
 		}
 	}
 	return ""
-}
-
-// errString renders err for structured logging, "" for nil.
-func errString(err error) string {
-	if err == nil {
-		return ""
-	}
-	return err.Error()
 }

--- a/internal/daemon/worktree_seed.go
+++ b/internal/daemon/worktree_seed.go
@@ -1,0 +1,660 @@
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// Worktree graph seeding (#5964, epic #5954).
+//
+// grafel stores one complete graph per (repo, ref) pair. Creating a worktree
+// or a branch and indexing it therefore costs a FULL index of the whole
+// corpus even when a single file differs from the parent — the dominant cost
+// for the epic's driver, concurrent AI agents each working in their own
+// worktree.
+//
+// Seeding copies the parent ref's graph generation AND its incremental diff
+// manifest into the child's state dir, so the child's first pass is an
+// ordinary incremental one: the existing content-hash + git machinery
+// (internal/indexer/diff.FilterWithGit, plus the #5710 HEAD-advance range
+// diff in internal/extractors.TryIncremental) recomputes the changed-file set
+// from the child's WORKING TREE against the parent's baseline. That covers
+// committed history, uncommitted edits and untracked files in one mechanism,
+// because the baseline is content hashes rather than a commit range — an
+// agent's in-progress edits, which are exactly what is not committed, are
+// picked up without a special case.
+//
+// TWO THINGS MAKE THIS SAFE, and both are enforced here rather than assumed.
+//
+// 1. IDENTITY. graph.EntityID hashes the repo tag FIRST, and cmd/grafel.Index
+//    defaults that tag to filepath.Base(repoPath) — the WORKTREE directory's
+//    basename, which differs from the parent's. A seeded graph would otherwise
+//    be a hybrid of two id spaces: parent-tagged carried-forward entities and
+//    child-tagged freshly-extracted ones, with every cross-file edge between
+//    them dangling. SeedWorktreeGraph therefore refuses to seed without an
+//    explicit tag and records it as a PIN (WriteRepoTagPin) that the indexer
+//    must honour on BOTH the seeded and the from-scratch path — otherwise the
+//    two are not even comparable.
+//
+//    (The premise that entity ids are already stable across worktrees comes
+//    from types.EntityRecord.ComputeID, which hashes OrgID+ProjectID+… and has
+//    no repo tag. That is NOT the id function the graph is built with: every
+//    producer calls graph.EntityID(i.repoTag, …). Traced, not assumed.)
+//
+// 2. PROVENANCE. The graph and the diff manifest MUST come from the same
+//    parent generation. If they do not — a torn copy, or the parent finishing
+//    a reindex mid-copy — a file that really differs can read as unchanged and
+//    its stale entities survive into the child's graph: code that is not in
+//    the child's tree, invisibly. So the copy is bracketed by a
+//    generation-stability check, the result is stamped with a content digest
+//    of every artifact copied, and the stamp is re-verified before the seed is
+//    consumed (VerifySeededGraph). Anything that fails falls back to a full
+//    index with a NAMED reason — never silently, because a seed that
+//    systematically never fired would be invisible.
+//
+// The read path, storage format, cache keys, tier system and Pass-4 semantics
+// are untouched: this is index-side only.
+
+// SeedStampFileName is the basename of the provenance stamp written into a
+// seeded child's state dir.
+const SeedStampFileName = "seed-provenance.json"
+
+// RepoTagPinFileName is the basename of the repo-tag pin. It is written for a
+// worktree whether or not seeding succeeds, because a full index of the
+// worktree must use the same tag a seeded index would — otherwise the two
+// graphs have different entity ids and neither parity nor a later seed is
+// possible.
+const RepoTagPinFileName = "repo-tag"
+
+// seedStampVersion is bumped when the stamp's JSON shape changes
+// incompatibly. A stamp with an unknown version is treated as unverifiable
+// (SeedFallbackStampMismatch), never as absent.
+const seedStampVersion = 1
+
+// SeedFallbackReason names WHY a seed did not happen, or why a seed already on
+// disk must not be trusted. It is always logged. Fallback policy: on any
+// non-empty reason the caller runs a full index and reports the reason —
+// correctness first, and loudly, so a seed that never fires cannot hide.
+type SeedFallbackReason string
+
+const (
+	// SeedFallbackParentPathUnresolved — no parent repo path could be
+	// resolved for the worktree (neither recorded nor derivable).
+	SeedFallbackParentPathUnresolved SeedFallbackReason = "parent_path_unresolved"
+	// SeedFallbackRepoTagUnresolved — no repo tag to pin. Seeding without one
+	// would mint a hybrid id space (see note 1 above).
+	SeedFallbackRepoTagUnresolved SeedFallbackReason = "repo_tag_unresolved"
+	// SeedFallbackParentNotIndexed — the parent ref's state dir holds no
+	// graph. Nothing to seed from.
+	SeedFallbackParentNotIndexed SeedFallbackReason = "parent_not_indexed"
+	// SeedFallbackParentManifestAbsent — the parent has a graph but no diff
+	// manifest, so there is no baseline for the child's incremental pass.
+	// Seeding the graph alone would make every file read as changed: a full
+	// reindex with extra copying.
+	SeedFallbackParentManifestAbsent SeedFallbackReason = "parent_diff_manifest_absent"
+	// SeedFallbackGenerationMoved — the parent's active generation changed
+	// across the copy, or a verified seed's `current` pointer no longer names
+	// the stamped generation. The copied artifacts may straddle two
+	// generations.
+	SeedFallbackGenerationMoved SeedFallbackReason = "parent_generation_moved"
+	// SeedFallbackCopyFailed — an I/O error while copying.
+	SeedFallbackCopyFailed SeedFallbackReason = "copy_failed"
+	// SeedFallbackChildAlreadyIndexed — the child already has its own graph.
+	// Seeding over it would discard newer work.
+	SeedFallbackChildAlreadyIndexed SeedFallbackReason = "child_already_indexed"
+	// SeedFallbackStampMismatch — a stamp is present but the artifacts on disk
+	// do not hash to what it recorded. The seed is not provably tied to the
+	// generation it claims.
+	SeedFallbackStampMismatch SeedFallbackReason = "stamp_mismatch"
+)
+
+// SeedStamp is the provenance record written next to a seeded graph. It is
+// what makes the seed provably tied to the parent generation it came from:
+// Artifacts maps each copied file (relative to the state dir, forward-slash)
+// to its SHA-256 at copy time, so VerifySeededGraph can prove the bytes on
+// disk are the bytes that were copied, from the generation named by
+// ParentPointer.
+type SeedStamp struct {
+	Version int `json:"version"`
+	// ParentPath / ParentRef / ParentStateDir identify the source. ParentRef
+	// is the parent's ACTUAL ref, never a hardcoded default — the bug that
+	// killed the first clone-from-parent attempt (#3652).
+	ParentPath     string `json:"parent_path"`
+	ParentRef      string `json:"parent_ref"`
+	ParentStateDir string `json:"parent_state_dir"`
+	// ParentPointer is the parent's `current` pointer value at copy time (a
+	// graph.<gen>.fb name, a graph.<gen> dir name, or the legacy flat
+	// "graph.fb"). This is the generation the child's graph descends from.
+	ParentPointer string `json:"parent_pointer"`
+	// RepoTag is the tag the child's index MUST be pinned to.
+	RepoTag string `json:"repo_tag"`
+	// ChildPath / ChildRef identify the destination slot.
+	ChildPath string `json:"child_path"`
+	ChildRef  string `json:"child_ref"`
+	// Artifacts maps state-dir-relative path → SHA-256 hex of the bytes
+	// copied. Every entry is re-hashed by VerifySeededGraph.
+	Artifacts   map[string]string `json:"artifacts"`
+	BytesCopied int64             `json:"bytes_copied"`
+	SeededAt    time.Time         `json:"seeded_at"`
+}
+
+// SeedRequest describes one seeding attempt.
+type SeedRequest struct {
+	// ParentPath is the parent repo's main checkout.
+	ParentPath string
+	// ParentRef is the parent's ACTUAL current ref. When empty the parent's
+	// state dir is resolved via StateDirForRepo (which captures HEAD) — still
+	// never a hardcoded "main".
+	ParentRef string
+	// ParentStateDir overrides the resolved parent state dir (tests).
+	ParentStateDir string
+	// ChildPath / ChildRef identify the worktree slot to seed.
+	ChildPath string
+	ChildRef  string
+	// ChildStateDir overrides the resolved child state dir (tests).
+	ChildStateDir string
+	// RepoTag is the tag to pin the child's index to — the parent's slug.
+	// Required.
+	RepoTag string
+
+	// afterCopyHook runs between the artifact copy and the
+	// generation-stability re-check. Test-only seam for exercising "the
+	// parent reindexed while the copy was in flight", which is otherwise a
+	// genuine race and cannot be provoked deterministically.
+	afterCopyHook func()
+}
+
+// SeedOutcome is the result of a seeding attempt. Seeded==false is a normal,
+// expected outcome; Reason is then always non-empty and Detail always says
+// what was actually observed.
+type SeedOutcome struct {
+	Seeded      bool
+	Reason      SeedFallbackReason
+	Detail      string
+	BytesCopied int64
+	Stamp       *SeedStamp
+	// ParentStateDir / ChildStateDir are reported even on the fallback paths
+	// so the log line can name the dirs that were checked.
+	ParentStateDir string
+	ChildStateDir  string
+}
+
+// SeedWorktreeGraph copies a parent ref's graph generation and diff manifest
+// into a worktree's state dir, stamping the result with the parent generation
+// it came from. See the package-level note above for why both halves matter.
+//
+// It never returns an error: every failure is a named SeedFallbackReason, so
+// the caller's only decision is "seeded, or full index with this reason".
+func SeedWorktreeGraph(req SeedRequest) SeedOutcome {
+	out := SeedOutcome{}
+
+	parentSD := req.ParentStateDir
+	if parentSD == "" {
+		if req.ParentPath == "" {
+			out.Reason = SeedFallbackParentPathUnresolved
+			out.Detail = "no parent repo path and no explicit parent state dir"
+			return out
+		}
+		if req.ParentRef != "" {
+			parentSD = StateDirForRepoRef(req.ParentPath, req.ParentRef)
+		} else {
+			// Resolves the parent's ACTUAL HEAD ref via gitmeta — #3652's bug
+			// was resolving a hardcoded "main" here.
+			parentSD = StateDirForRepo(req.ParentPath)
+		}
+	}
+	if parentSD == "" {
+		out.Reason = SeedFallbackParentPathUnresolved
+		out.Detail = fmt.Sprintf("parent state dir unresolvable for %q ref %q", req.ParentPath, req.ParentRef)
+		return out
+	}
+	out.ParentStateDir = parentSD
+
+	childSD := req.ChildStateDir
+	if childSD == "" {
+		childSD = StateDirForRepoRef(req.ChildPath, req.ChildRef)
+	}
+	if childSD == "" {
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = "child state dir unresolvable"
+		return out
+	}
+	out.ChildStateDir = childSD
+
+	if req.RepoTag == "" {
+		out.Reason = SeedFallbackRepoTagUnresolved
+		out.Detail = fmt.Sprintf("no repo tag to pin for worktree %q; seeding would mint entity ids that disagree with the parent's", req.ChildPath)
+		return out
+	}
+
+	// The child must not already own a graph — seeding over it would discard
+	// newer work.
+	if desc, err := graph.CurrentGraphDescriptor(childSD); err == nil && desc.Kind != graph.GraphAbsent {
+		out.Reason = SeedFallbackChildAlreadyIndexed
+		out.Detail = fmt.Sprintf("child state dir %s already holds a graph", childSD)
+		return out
+	}
+
+	// Resolve the parent's active generation, twice: once now, once after the
+	// copy. Both must agree.
+	ptrBefore, desc, err := parentGeneration(parentSD)
+	if err != nil {
+		out.Reason = SeedFallbackParentNotIndexed
+		out.Detail = fmt.Sprintf("parent state dir %s: %v", parentSD, err)
+		return out
+	}
+	if desc.Kind == graph.GraphAbsent {
+		out.Reason = SeedFallbackParentNotIndexed
+		out.Detail = fmt.Sprintf("parent state dir %s holds no graph", parentSD)
+		return out
+	}
+	manifestSrc := filepath.Join(parentSD, diff.ManifestFileName)
+	if _, statErr := os.Stat(manifestSrc); statErr != nil {
+		out.Reason = SeedFallbackParentManifestAbsent
+		out.Detail = fmt.Sprintf("parent state dir %s has a graph but no %s: %v", parentSD, diff.ManifestFileName, statErr)
+		return out
+	}
+
+	if err := os.MkdirAll(childSD, 0o755); err != nil {
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = fmt.Sprintf("mkdir child state dir %s: %v", childSD, err)
+		return out
+	}
+
+	// Collect the artifacts to copy, relative to the state dir.
+	rels, err := seedArtifactRels(parentSD, desc)
+	if err != nil {
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = fmt.Sprintf("enumerate parent artifacts in %s: %v", parentSD, err)
+		return out
+	}
+	rels = append(rels, diff.ManifestFileName)
+
+	stamp := &SeedStamp{
+		Version:        seedStampVersion,
+		ParentPath:     req.ParentPath,
+		ParentRef:      req.ParentRef,
+		ParentStateDir: parentSD,
+		ParentPointer:  ptrBefore,
+		RepoTag:        req.RepoTag,
+		ChildPath:      req.ChildPath,
+		ChildRef:       req.ChildRef,
+		Artifacts:      make(map[string]string, len(rels)),
+		SeededAt:       time.Now().UTC(),
+	}
+
+	// Copy. The `current` pointer is deliberately NOT copied yet: until it
+	// lands the child's dir does not resolve to a graph, so a crash or a
+	// torn copy leaves inert bytes rather than a silently-wrong graph.
+	for _, rel := range rels {
+		sum, n, cerr := copyArtifact(filepath.Join(parentSD, rel), filepath.Join(childSD, rel))
+		if cerr != nil {
+			cleanupSeedArtifacts(childSD, stamp.Artifacts, rels)
+			out.Reason = SeedFallbackCopyFailed
+			out.Detail = fmt.Sprintf("copy %s: %v", rel, cerr)
+			return out
+		}
+		stamp.Artifacts[filepath.ToSlash(rel)] = sum
+		stamp.BytesCopied += n
+	}
+
+	if req.afterCopyHook != nil {
+		req.afterCopyHook()
+	}
+
+	// Generation-stability re-check. If the parent reindexed while we copied,
+	// the graph and the manifest may be from different generations — the
+	// silently-wrong case.
+	ptrAfter, _, aerr := parentGeneration(parentSD)
+	if aerr != nil || ptrAfter != ptrBefore {
+		cleanupSeedArtifacts(childSD, stamp.Artifacts, rels)
+		out.Reason = SeedFallbackGenerationMoved
+		out.Detail = fmt.Sprintf("parent %s generation moved during copy: %q → %q (err=%v)", parentSD, ptrBefore, ptrAfter, aerr)
+		return out
+	}
+
+	// Stamp BEFORE the pointer: a reader that finds a resolvable graph in a
+	// seeded dir always finds a stamp to verify it against.
+	if err := writeSeedStamp(childSD, stamp); err != nil {
+		cleanupSeedArtifacts(childSD, stamp.Artifacts, rels)
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = fmt.Sprintf("write seed stamp: %v", err)
+		return out
+	}
+	if err := WriteRepoTagPin(childSD, req.RepoTag); err != nil {
+		cleanupSeedArtifacts(childSD, stamp.Artifacts, rels)
+		_ = os.Remove(filepath.Join(childSD, SeedStampFileName))
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = fmt.Sprintf("write repo-tag pin: %v", err)
+		return out
+	}
+	// Finally publish the pointer, making the seeded graph resolvable.
+	if err := writePointerRaw(childSD, ptrBefore); err != nil {
+		cleanupSeedArtifacts(childSD, stamp.Artifacts, rels)
+		_ = os.Remove(filepath.Join(childSD, SeedStampFileName))
+		out.Reason = SeedFallbackCopyFailed
+		out.Detail = fmt.Sprintf("publish current pointer %q: %v", ptrBefore, err)
+		return out
+	}
+
+	out.Seeded = true
+	out.Stamp = stamp
+	out.BytesCopied = stamp.BytesCopied
+	return out
+}
+
+// VerifySeededGraph re-checks a seed already on disk before it is consumed.
+//
+// Returns (nil, "", nil) for a state dir that was never seeded — that is the
+// overwhelming common case (every non-worktree repo) and must not be treated
+// as a failure. For a seeded dir it re-hashes every stamped artifact and
+// re-reads the `current` pointer; any disagreement yields a named reason and
+// the caller must fall back to a full index.
+func VerifySeededGraph(stateDir string) (*SeedStamp, SeedFallbackReason, error) {
+	if stateDir == "" {
+		return nil, "", nil
+	}
+	stamp, err := ReadSeedStamp(stateDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, "", nil
+		}
+		// A stamp that exists but cannot be parsed is unverifiable, not
+		// absent: refuse to trust the graph next to it.
+		return nil, SeedFallbackStampMismatch, nil
+	}
+	if stamp.Version != seedStampVersion {
+		return stamp, SeedFallbackStampMismatch, nil
+	}
+	// The pointer must still name the stamped generation.
+	ptr, _, perr := parentGeneration(stateDir)
+	if perr != nil || ptr != stamp.ParentPointer {
+		return stamp, SeedFallbackGenerationMoved, nil
+	}
+	// Every stamped artifact must hash to what was recorded. This is the
+	// check a mutation that "trusts the stamp" would delete.
+	for rel, want := range stamp.Artifacts {
+		got, herr := hashFile(filepath.Join(stateDir, filepath.FromSlash(rel)))
+		if herr != nil || got != want {
+			return stamp, SeedFallbackStampMismatch, nil
+		}
+	}
+	return stamp, "", nil
+}
+
+// DiscardSeed removes every artifact a seed placed in stateDir, plus the
+// pointer that made them resolvable, so the next pass runs a clean full index.
+// The repo-tag pin deliberately SURVIVES: a full index of the worktree must
+// still use the parent's tag.
+//
+// It is a no-op on a dir that was never seeded — it never deletes a graph it
+// did not put there.
+func DiscardSeed(stateDir string) error {
+	stamp, err := ReadSeedStamp(stateDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		// Unparseable stamp: we cannot know which artifacts were seeded, but
+		// we DO know this dir's graph is untrusted. Drop the pointer (making
+		// it un-resolvable, so a full index runs) and the stamp.
+		_ = os.Remove(filepath.Join(stateDir, graph.CurrentPointerName))
+		return os.Remove(filepath.Join(stateDir, SeedStampFileName))
+	}
+	// Remove the pointer FIRST so the dir stops resolving to the seeded graph
+	// even if a later removal fails.
+	if err := os.Remove(filepath.Join(stateDir, graph.CurrentPointerName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	for rel := range stamp.Artifacts {
+		p := filepath.Join(stateDir, filepath.FromSlash(rel))
+		if err := os.RemoveAll(p); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+	if err := os.Remove(filepath.Join(stateDir, SeedStampFileName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ConsumeSeedStamp removes the provenance stamp while leaving the seeded
+// graph and manifest in place.
+//
+// It is called by the pass that has just VERIFIED the seed, at the moment the
+// verification succeeds — not after the pass finishes. From that instant the
+// pass owns the state dir and will write a new generation into it, at which
+// point the stamp's recorded pointer no longer describes what is on disk. A
+// stamp left behind would make the NEXT verification report
+// generation_moved and DiscardSeed would then delete a graph the child
+// legitimately built.
+//
+// Consuming early is also the safe choice under a crash: the seeded graph is a
+// complete copy of the parent's, so an un-stamped state dir is just an
+// ordinary already-indexed one and the next pass runs an ordinary incremental
+// against it.
+func ConsumeSeedStamp(stateDir string) error {
+	if stateDir == "" {
+		return nil
+	}
+	if err := os.Remove(filepath.Join(stateDir, SeedStampFileName)); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// ReadSeedStamp reads the provenance stamp from stateDir. The returned error
+// wraps os.ErrNotExist when there is no stamp (i.e. the dir was never seeded).
+func ReadSeedStamp(stateDir string) (*SeedStamp, error) {
+	if stateDir == "" {
+		return nil, fmt.Errorf("seed stamp: empty state dir: %w", os.ErrNotExist)
+	}
+	data, err := os.ReadFile(filepath.Join(stateDir, SeedStampFileName))
+	if err != nil {
+		return nil, err
+	}
+	var st SeedStamp
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("seed stamp: parse: %w", err)
+	}
+	return &st, nil
+}
+
+func writeSeedStamp(stateDir string, st *SeedStamp) error {
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfile.WriteFile(filepath.Join(stateDir, SeedStampFileName), append(data, '\n'), 0o644)
+}
+
+// WriteRepoTagPin records the repo tag an index of stateDir's repo must use.
+//
+// It exists because cmd/grafel.Index defaults the tag to the repo directory's
+// basename, which for a worktree is the worktree dir name, not the parent's
+// slug — and graph.EntityID hashes that tag first. Both the seeded and the
+// from-scratch index of a worktree must read this pin, or their graphs are not
+// comparable and a seed can never be correct.
+func WriteRepoTagPin(stateDir, tag string) error {
+	if stateDir == "" || tag == "" {
+		return fmt.Errorf("repo-tag pin: empty state dir or tag")
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		return err
+	}
+	return atomicfile.WriteFile(filepath.Join(stateDir, RepoTagPinFileName), []byte(tag+"\n"), 0o644)
+}
+
+// ReadRepoTagPin returns the pinned repo tag for stateDir, or "" when there is
+// none (every non-worktree repo — the caller then keeps today's default).
+func ReadRepoTagPin(stateDir string) string {
+	if stateDir == "" {
+		return ""
+	}
+	data, err := os.ReadFile(filepath.Join(stateDir, RepoTagPinFileName))
+	if err != nil {
+		return ""
+	}
+	tag := strings.TrimSpace(string(data))
+	// A pin is a bare tag, never a path: reject anything that could escape.
+	if tag == "" || strings.ContainsAny(tag, "/\\") || strings.Contains(tag, "..") {
+		return ""
+	}
+	return tag
+}
+
+// ---------------------------------------------------------------------------
+// internals
+// ---------------------------------------------------------------------------
+
+// parentGeneration returns the raw `current` pointer value for stateDir plus
+// the resolved descriptor. For a legacy flat graph.fb (no pointer) the
+// sentinel "graph.fb" is returned, so the stamp always names something.
+func parentGeneration(stateDir string) (string, graph.GraphDescriptor, error) {
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		return "", desc, err
+	}
+	raw, rerr := os.ReadFile(filepath.Join(stateDir, graph.CurrentPointerName))
+	if rerr == nil {
+		if v := strings.TrimSpace(string(raw)); v != "" {
+			return v, desc, nil
+		}
+	}
+	if desc.Kind == graph.GraphSingleFile {
+		return filepath.Base(desc.Path), desc, nil
+	}
+	return "", desc, nil
+}
+
+// seedArtifactRels lists the graph artifacts to copy, relative to stateDir:
+// the single generation file, or every file inside the generation directory
+// for a segment set.
+func seedArtifactRels(stateDir string, desc graph.GraphDescriptor) ([]string, error) {
+	switch desc.Kind {
+	case graph.GraphSingleFile:
+		rel, err := filepath.Rel(stateDir, desc.Path)
+		if err != nil {
+			return nil, err
+		}
+		return []string{rel}, nil
+	case graph.GraphSegmentSet:
+		var rels []string
+		genRel, err := filepath.Rel(stateDir, desc.GenDir)
+		if err != nil {
+			return nil, err
+		}
+		ents, err := os.ReadDir(desc.GenDir)
+		if err != nil {
+			return nil, err
+		}
+		for _, e := range ents {
+			if e.IsDir() {
+				continue
+			}
+			rels = append(rels, filepath.Join(genRel, e.Name()))
+		}
+		if len(rels) == 0 {
+			return nil, fmt.Errorf("segment-set dir %s is empty", desc.GenDir)
+		}
+		return rels, nil
+	default:
+		return nil, fmt.Errorf("no graph to seed from")
+	}
+}
+
+// copyArtifact copies src→dst, returning the SHA-256 of the bytes written and
+// the byte count. The digest is computed from the same stream that is written,
+// so it describes exactly what landed on disk.
+func copyArtifact(src, dst string) (string, int64, error) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return "", 0, err
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return "", 0, err
+	}
+	defer in.Close()
+
+	tmp := dst + ".seedtmp"
+	outF, err := os.OpenFile(tmp, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o644)
+	if err != nil {
+		return "", 0, err
+	}
+	h := sha256.New()
+	n, cerr := io.Copy(io.MultiWriter(outF, h), in)
+	if cerr != nil {
+		outF.Close()
+		_ = os.Remove(tmp)
+		return "", 0, cerr
+	}
+	if serr := outF.Sync(); serr != nil {
+		outF.Close()
+		_ = os.Remove(tmp)
+		return "", 0, serr
+	}
+	if cerr := outF.Close(); cerr != nil {
+		_ = os.Remove(tmp)
+		return "", 0, cerr
+	}
+	if rerr := os.Rename(tmp, dst); rerr != nil {
+		_ = os.Remove(tmp)
+		return "", 0, rerr
+	}
+	return hex.EncodeToString(h.Sum(nil)), n, nil
+}
+
+func hashFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// cleanupSeedArtifacts removes whatever a failed seed managed to write. It
+// never touches the `current` pointer because a failed seed never publishes
+// one.
+func cleanupSeedArtifacts(stateDir string, done map[string]string, rels []string) {
+	for rel := range done {
+		_ = os.RemoveAll(filepath.Join(stateDir, filepath.FromSlash(rel)))
+	}
+	for _, rel := range rels {
+		_ = os.Remove(filepath.Join(stateDir, rel+".seedtmp"))
+	}
+}
+
+// writePointerRaw publishes a `current` pointer value verbatim. It exists
+// because graph.WriteCurrentPointer only accepts the graph.<gen>.fb shape,
+// while a seed must be able to republish a segment-set pointer (graph.<gen> or
+// graph.<gen>/manifest.json) or a legacy flat sentinel unchanged. The value is
+// never caller-supplied: it is the parent's own pointer, already validated by
+// graph.CurrentGraphDescriptor having resolved it.
+func writePointerRaw(stateDir, value string) error {
+	if value == "" {
+		return fmt.Errorf("empty pointer value")
+	}
+	if value == "graph.fb" {
+		// Legacy flat layout: the copied graph.fb IS the resolution. Writing a
+		// pointer naming it would not parse as a gen name.
+		return nil
+	}
+	return atomicfile.WriteFile(filepath.Join(stateDir, graph.CurrentPointerName), []byte(value), 0o644)
+}

--- a/internal/daemon/worktree_seed.go
+++ b/internal/daemon/worktree_seed.go
@@ -9,6 +9,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -118,7 +120,32 @@ const (
 	// do not hash to what it recorded. The seed is not provably tied to the
 	// generation it claims.
 	SeedFallbackStampMismatch SeedFallbackReason = "stamp_mismatch"
+	// SeedFallbackSuperseded — BENIGN. The state dir's `current` pointer names
+	// a generation STRICTLY NEWER than the one the stamp recorded: the child
+	// has already built its own graph over the seed and the stamp is simply
+	// stale. The caller must consume the stamp and carry on — it must NOT
+	// discard, because the graph being pointed at is the child's own.
+	//
+	// This verdict exists because ConsumeSeedStamp is only reachable from the
+	// paths that go looking for a stamp, and the scheduler skips the
+	// incremental callback entirely when incremental reindexing is disabled
+	// (GRAFEL_INCREMENTAL_REINDEX=0 — documented and supported). A full index
+	// can therefore run over a seeded dir and leave the stamp behind. Reading
+	// that stale stamp as "generation moved" and discarding would throw away a
+	// full corpus reindex the child legitimately paid for: the exact cost this
+	// feature exists to eliminate.
+	SeedFallbackSuperseded SeedFallbackReason = "seed_superseded_by_child_graph"
 )
+
+// SeedVerdictIsBenign reports whether a reason returned by VerifySeededGraph
+// describes a state dir that is FINE to keep using — as opposed to one whose
+// graph cannot be trusted and must be discarded in favour of a full index.
+//
+// Callers must branch on this rather than on `reason != ""`, or a superseded
+// (stale-stamp) dir will be treated as corrupt and its graph thrown away.
+func SeedVerdictIsBenign(reason SeedFallbackReason) bool {
+	return reason == "" || reason == SeedFallbackSuperseded
+}
 
 // SeedStamp is the provenance record written next to a seeded graph. It is
 // what makes the seed provably tied to the parent generation it came from:
@@ -298,6 +325,15 @@ func SeedWorktreeGraph(req SeedRequest) SeedOutcome {
 	// Copy. The `current` pointer is deliberately NOT copied yet: until it
 	// lands the child's dir does not resolve to a graph, so a crash or a
 	// torn copy leaves inert bytes rather than a silently-wrong graph.
+	//
+	// KNOWN, ACCEPTED: a process crash between here and the stamp write
+	// orphans a full graph generation on disk with neither a stamp nor a
+	// pointer, so cleanupSeedArtifacts never runs and nothing later collects
+	// it. Correctness is unaffected — an unpointed, unstamped file is inert
+	// and the next pass runs a clean full index — but it is a disk leak
+	// proportional to one graph. Reclaiming it belongs with the existing
+	// generation GC (graph.IsGraphFileName already recognises these files),
+	// not here.
 	for _, rel := range rels {
 		sum, n, cerr := copyArtifact(filepath.Join(parentSD, rel), filepath.Join(childSD, rel))
 		if cerr != nil {
@@ -378,9 +414,19 @@ func VerifySeededGraph(stateDir string) (*SeedStamp, SeedFallbackReason, error) 
 	if stamp.Version != seedStampVersion {
 		return stamp, SeedFallbackStampMismatch, nil
 	}
-	// The pointer must still name the stamped generation.
+	// The pointer must still name the stamped generation — UNLESS it names a
+	// strictly newer one, which means the child has already built its own
+	// graph over the seed and the stamp is merely stale. Generation numbers
+	// within one state dir are minted monotonically by the writer, so "newer
+	// gen in this dir" is the child's own work, never the parent's.
 	ptr, _, perr := parentGeneration(stateDir)
-	if perr != nil || ptr != stamp.ParentPointer {
+	if perr != nil {
+		return stamp, SeedFallbackGenerationMoved, nil
+	}
+	if ptr != stamp.ParentPointer {
+		if movedForward(stamp.ParentPointer, ptr) {
+			return stamp, SeedFallbackSuperseded, nil
+		}
 		return stamp, SeedFallbackGenerationMoved, nil
 	}
 	// Every stamped artifact must hash to what was recorded. This is the
@@ -412,6 +458,19 @@ func DiscardSeed(stateDir string) error {
 		// it un-resolvable, so a full index runs) and the stamp.
 		_ = os.Remove(filepath.Join(stateDir, graph.CurrentPointerName))
 		return os.Remove(filepath.Join(stateDir, SeedStampFileName))
+	}
+	// REFUSAL. If the dir's active generation is strictly NEWER than the one
+	// the stamp recorded, the graph being pointed at is the child's own — the
+	// stamp is merely stale (see SeedFallbackSuperseded). Removing the pointer
+	// here would make a full corpus reindex the child paid for unresolvable.
+	// Drop only the stale stamp. This is deliberately enforced in DiscardSeed
+	// itself rather than only at the call sites, so the data loss is
+	// structurally impossible rather than merely unreached by today's callers.
+	if ptr, _, perr := parentGeneration(stateDir); perr == nil && movedForward(stamp.ParentPointer, ptr) {
+		if rerr := os.Remove(filepath.Join(stateDir, SeedStampFileName)); rerr != nil && !os.IsNotExist(rerr) {
+			return rerr
+		}
+		return nil
 	}
 	// Remove the pointer FIRST so the dir stops resolving to the seeded graph
 	// even if a later removal fails.
@@ -539,6 +598,39 @@ func parentGeneration(stateDir string) (string, graph.GraphDescriptor, error) {
 	return "", desc, nil
 }
 
+// seedGenRe extracts the generation number from any shape a `current` pointer
+// can take: graph.<gen>.fb, graph.<gen>, or graph.<gen>/manifest.json.
+var seedGenRe = regexp.MustCompile(`^graph\.(\d+)(?:\.fb|/manifest\.json)?$`)
+
+// pointerGen parses a pointer value's generation number. The legacy flat
+// "graph.fb" sentinel has no generation and reports ok=false.
+func pointerGen(ptr string) (uint64, bool) {
+	m := seedGenRe.FindStringSubmatch(strings.TrimSpace(ptr))
+	if m == nil {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(m[1], 10, 64)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// movedForward reports whether `now` names a strictly newer generation than
+// `stamped`, in the same state dir. Generation numbers are minted
+// monotonically per dir by the writer, so this is the signal that the child
+// built its own graph over the seed.
+//
+// Fails CLOSED: if either pointer has no parseable generation (the legacy flat
+// layout, or a hostile value), this returns false and the caller treats the
+// mismatch as untrusted rather than benign. Being wrong in that direction
+// costs a full reindex; being wrong the other way loses a graph.
+func movedForward(stamped, now string) bool {
+	sg, sok := pointerGen(stamped)
+	ng, nok := pointerGen(now)
+	return sok && nok && ng > sg
+}
+
 // seedArtifactRels lists the graph artifacts to copy, relative to stateDir:
 // the single generation file, or every file inside the generation directory
 // for a segment set.
@@ -562,7 +654,13 @@ func seedArtifactRels(stateDir string, desc graph.GraphDescriptor) ([]string, er
 		}
 		for _, e := range ents {
 			if e.IsDir() {
-				continue
+				// Fail LOUD rather than skipping. Gen dirs are flat today, so
+				// this is unreachable — but if the layout ever nests, silently
+				// skipping a subdirectory would copy a PARTIAL graph, stamp
+				// only what was copied, pass verification, and leave the child
+				// resolving an incomplete graph. Silently wrong is the failure
+				// class this whole design is built against.
+				return nil, fmt.Errorf("segment-set dir %s contains a subdirectory %q; seeding cannot prove it copied the whole graph", desc.GenDir, e.Name())
 			}
 			rels = append(rels, filepath.Join(genRel, e.Name()))
 		}

--- a/internal/daemon/worktree_seed_activate_test.go
+++ b/internal/daemon/worktree_seed_activate_test.go
@@ -65,6 +65,99 @@ func seedableParent(t *testing.T, stateDir string, gen uint64, body string) {
 	}
 }
 
+// WIRING GUARD. Everything below this comment tests seedWorktreeOnActivate
+// directly. This one drives the handler the engine plane actually installs as
+// worktree.Watcher.OnActivate, so that deleting the seeding call from the
+// activation path — the mutant that removes the entire feature and leaves
+// every suite green — fails here.
+//
+// It asserts observable behaviour only: a seeded graph on disk, and that the
+// activation's pre-existing duties (watch + enqueue) still happen. No source
+// scanning: an import alias or a call moved behind a comment would defeat that,
+// and two such guards were written this week and both fell to trivial mutants.
+func TestNewWorktreeActivateHandler_SeedsTheWorktreeAndStillWatchesAndEnqueues(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	parentPath := filepath.Join(root, "parent-repo")
+	childPath := filepath.Join(root, "wt", "agent-wired")
+	for _, d := range []string{parentPath, childPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedableParent(t, StateDirForRepo(parentPath), 4, "PARENT-GRAPH-VIA-HANDLER")
+
+	var watched, enqueued []string
+	logger, buf := captureLogger()
+	handler := newWorktreeActivateHandler(worktreeActivateDeps{
+		Logger:      logger,
+		Parents:     nil,
+		AddRepo:     func(p string) error { watched = append(watched, p); return nil },
+		Enqueue:     func(p string) { enqueued = append(enqueued, p) },
+		ActivateSem: make(chan struct{}, 1),
+	})
+
+	handler(&worktree.WorktreeChild{
+		ParentSlug: "myservice",
+		ParentPath: parentPath,
+		Path:       childPath,
+		Branch:     "feat/wired",
+	})
+
+	childSD := StateDirForRepoRef(childPath, "feat/wired")
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	if desc.Kind == graph.GraphAbsent {
+		t.Fatalf("activation did not seed the worktree — the graph-seeding payload is not wired into OnActivate.\nlog:\n%s", buf.String())
+	}
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "PARENT-GRAPH-VIA-HANDLER" {
+		t.Errorf("seeded body=%q want PARENT-GRAPH-VIA-HANDLER", body)
+	}
+	if got := ReadRepoTagPin(childSD); got != "myservice" {
+		t.Errorf("repo-tag pin=%q want myservice", got)
+	}
+	// The activation's original duties must survive the refactor.
+	if len(watched) != 1 || watched[0] != childPath {
+		t.Errorf("AddRepo calls=%v want exactly [%s]", watched, childPath)
+	}
+	if len(enqueued) != 1 || enqueued[0] != childPath {
+		t.Errorf("Enqueue calls=%v want exactly [%s]", enqueued, childPath)
+	}
+}
+
+// The handler must still watch + enqueue when seeding cannot happen: a
+// worktree whose parent is unindexed must not be left unwatched.
+func TestNewWorktreeActivateHandler_WatchesAndEnqueuesEvenWhenSeedingIsSkipped(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	parentPath := filepath.Join(root, "parent-repo") // never indexed
+	childPath := filepath.Join(root, "wt", "agent-noseed")
+	for _, d := range []string{parentPath, childPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var watched, enqueued []string
+	logger, buf := captureLogger()
+	handler := newWorktreeActivateHandler(worktreeActivateDeps{
+		Logger:  logger,
+		AddRepo: func(p string) error { watched = append(watched, p); return nil },
+		Enqueue: func(p string) { enqueued = append(enqueued, p) },
+	})
+	handler(&worktree.WorktreeChild{
+		ParentSlug: "myservice", ParentPath: parentPath,
+		Path: childPath, Branch: "feat/noseed",
+	})
+
+	if len(watched) != 1 || len(enqueued) != 1 {
+		t.Errorf("watched=%v enqueued=%v — activation duties were skipped on the no-seed path", watched, enqueued)
+	}
+	if !logHas(t, buf, "reason", string(SeedFallbackParentNotIndexed)) {
+		t.Errorf("fallback reason not logged; got:\n%s", buf.String())
+	}
+}
+
 func TestSeedWorktreeOnActivate_SeedsFromTheParentsActualRef(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv(EnvRoot, root)

--- a/internal/daemon/worktree_seed_activate_test.go
+++ b/internal/daemon/worktree_seed_activate_test.go
@@ -1,0 +1,217 @@
+package daemon
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/worktree"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// These tests drive seedWorktreeOnActivate — the function the daemon's
+// worktree OnActivate hook calls — and assert on its OBSERVABLE output: what
+// lands on disk and what it logs. They do not inspect source text, so a
+// mutation that deletes the call, renames an import, or swallows the fallback
+// reason is caught by the on-disk / log assertions rather than by a grep.
+
+func captureLogger() (*slog.Logger, *bytes.Buffer) {
+	var buf bytes.Buffer
+	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), &buf
+}
+
+// logHas reports whether any logged record carries key=want.
+func logHas(t *testing.T, buf *bytes.Buffer, key, want string) bool {
+	t.Helper()
+	for _, line := range strings.Split(strings.TrimSpace(buf.String()), "\n") {
+		if line == "" {
+			continue
+		}
+		var rec map[string]any
+		if err := json.Unmarshal([]byte(line), &rec); err != nil {
+			continue
+		}
+		if v, ok := rec[key]; ok {
+			if s, ok := v.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func seedableParent(t *testing.T, stateDir string, gen uint64, body string) {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	name := graph.GenFileName(gen)
+	if err := os.WriteFile(filepath.Join(stateDir, name), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(stateDir, name); err != nil {
+		t.Fatal(err)
+	}
+	m := diff.LoadManifest(stateDir)
+	m.Files["a.go"] = diff.FileEntry{SHA256: "aa", Size: 1}
+	if err := diff.SaveManifest(stateDir, "/x", m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSeedWorktreeOnActivate_SeedsFromTheParentsActualRef(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	parentPath := filepath.Join(root, "parent-repo")
+	childPath := filepath.Join(root, "wt", "agent-a")
+	if err := os.MkdirAll(parentPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(childPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The parent's ACTUAL ref, as StateDirForRepo resolves it for a
+	// non-git dir, is the "_unknown" sentinel — deliberately NOT "main". A
+	// hardcoded-"main" implementation (the #3652 bug) reads an empty dir here
+	// and cannot seed.
+	parentSD := StateDirForRepo(parentPath)
+	if parentSD == StateDirForRepoRef(parentPath, "main") {
+		t.Fatal("fixture is inert: the parent's actual ref dir must differ from the 'main' dir")
+	}
+	seedableParent(t, parentSD, 5, "PARENT-GRAPH")
+	// Populate the "main" dir with DIFFERENT content, so an implementation
+	// that reads "main" would succeed but with the wrong bytes — the failure
+	// this asserts against is wrong content, not merely absence.
+	seedableParent(t, StateDirForRepoRef(parentPath, "main"), 5, "WRONG-MAIN-GRAPH")
+
+	child := &worktree.WorktreeChild{
+		ParentSlug: "myservice",
+		ParentPath: parentPath,
+		Path:       childPath,
+		Branch:     "feat/x",
+	}
+	logger, buf := captureLogger()
+
+	out := seedWorktreeOnActivate(logger, child, nil)
+
+	if !out.Seeded {
+		t.Fatalf("Seeded=false reason=%q detail=%q", out.Reason, out.Detail)
+	}
+	childSD := StateDirForRepoRef(childPath, "feat/x")
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "PARENT-GRAPH" {
+		t.Errorf("seeded body=%q want PARENT-GRAPH (got the 'main' dir's content → #3652 regression)", body)
+	}
+	if got := ReadRepoTagPin(childSD); got != "myservice" {
+		t.Errorf("repo-tag pin=%q want myservice", got)
+	}
+	if !logHas(t, buf, "msg", "worktree: seeded graph from parent ref") {
+		t.Errorf("no success log line; got:\n%s", buf.String())
+	}
+}
+
+func TestSeedWorktreeOnActivate_LogsANamedReasonWhenItCannotSeed(t *testing.T) {
+	// A silent fallback is the rejected design: a seed that systematically
+	// never fires must be visible in the log.
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+
+	parentPath := filepath.Join(root, "parent-repo")
+	childPath := filepath.Join(root, "wt", "agent-b")
+	for _, d := range []string{parentPath, childPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Parent never indexed.
+	child := &worktree.WorktreeChild{
+		ParentSlug: "myservice",
+		ParentPath: parentPath,
+		Path:       childPath,
+		Branch:     "feat/y",
+	}
+	logger, buf := captureLogger()
+
+	out := seedWorktreeOnActivate(logger, child, nil)
+
+	if out.Seeded {
+		t.Fatal("Seeded=true with an unindexed parent")
+	}
+	if out.Reason != SeedFallbackParentNotIndexed {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackParentNotIndexed)
+	}
+	if !logHas(t, buf, "reason", string(SeedFallbackParentNotIndexed)) {
+		t.Errorf("fallback reason not logged; got:\n%s", buf.String())
+	}
+	// The repo-tag pin must still be written: a FULL index of this worktree
+	// must use the parent's tag too, or a later seed can never match it.
+	if got := ReadRepoTagPin(StateDirForRepoRef(childPath, "feat/y")); got != "myservice" {
+		t.Errorf("repo-tag pin=%q want myservice even on the fallback path", got)
+	}
+}
+
+func TestSeedWorktreeOnActivate_LogsAReasonWhenNoParentSlugIsKnown(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	parentPath := filepath.Join(root, "parent-repo")
+	childPath := filepath.Join(root, "wt", "agent-c")
+	for _, d := range []string{parentPath, childPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	seedableParent(t, StateDirForRepo(parentPath), 1, "G")
+
+	child := &worktree.WorktreeChild{
+		ParentPath: parentPath, // ParentSlug deliberately empty
+		Path:       childPath,
+		Branch:     "feat/z",
+	}
+	logger, buf := captureLogger()
+
+	out := seedWorktreeOnActivate(logger, child, nil)
+	if out.Seeded {
+		t.Fatal("Seeded=true with no parent slug to pin the repo tag to")
+	}
+	if out.Reason != SeedFallbackRepoTagUnresolved {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackRepoTagUnresolved)
+	}
+	if !logHas(t, buf, "reason", string(SeedFallbackRepoTagUnresolved)) {
+		t.Errorf("reason not logged; got:\n%s", buf.String())
+	}
+}
+
+func TestSeedWorktreeOnActivate_ReportsUnresolvableParent(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	childPath := filepath.Join(root, "wt", "orphan")
+	if err := os.MkdirAll(childPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	child := &worktree.WorktreeChild{
+		ParentSlug: "myservice",
+		Path:       childPath,
+		Branch:     "feat/q",
+	} // no ParentPath, no parents provider → nothing to derive from
+	logger, buf := captureLogger()
+
+	out := seedWorktreeOnActivate(logger, child, nil)
+	if out.Seeded {
+		t.Fatal("Seeded=true with no resolvable parent")
+	}
+	if out.Reason != SeedFallbackParentPathUnresolved {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackParentPathUnresolved)
+	}
+	if !logHas(t, buf, "reason", string(SeedFallbackParentPathUnresolved)) {
+		t.Errorf("reason not logged; got:\n%s", buf.String())
+	}
+}

--- a/internal/daemon/worktree_seed_test.go
+++ b/internal/daemon/worktree_seed_test.go
@@ -1,0 +1,590 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture helpers — a state dir is just a directory holding graph.<gen>.fb, a
+// `current` pointer naming it, and the incremental diff manifest. None of the
+// seeding machinery decodes the graph, so opaque bytes are a faithful stand-in
+// and every test in this file runs in microseconds (no index, no git).
+// ---------------------------------------------------------------------------
+
+func writeParentStateDir(t *testing.T, dir string, gen uint64, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir parent state dir: %v", err)
+	}
+	name := graph.GenFileName(gen)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+		t.Fatalf("write gen file: %v", err)
+	}
+	if err := graph.WriteCurrentPointer(dir, name); err != nil {
+		t.Fatalf("write current pointer: %v", err)
+	}
+	m := diff.LoadManifest(dir) // empty manifest, correct Version
+	m.Files["a.go"] = diff.FileEntry{SHA256: "deadbeef", Size: 3}
+	if err := diff.SaveManifest(dir, "/does/not/matter", m); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+	return name
+}
+
+func seedReq(t *testing.T, parentStateDir, childStateDir string) SeedRequest {
+	t.Helper()
+	return SeedRequest{
+		ParentPath:     filepath.Join(t.TempDir(), "parent-repo"),
+		ParentRef:      "release/v9",
+		ParentStateDir: parentStateDir,
+		ChildPath:      filepath.Join(t.TempDir(), "child-wt"),
+		ChildRef:       "feat/x",
+		ChildStateDir:  childStateDir,
+		RepoTag:        "myservice",
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Happy path
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_CopiesGenGraphManifestAndStamp(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	genName := writeParentStateDir(t, parentSD, 7, "GRAPH-BYTES-7")
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if !out.Seeded {
+		t.Fatalf("Seeded=false reason=%q detail=%q", out.Reason, out.Detail)
+	}
+	if out.Reason != "" {
+		t.Errorf("Reason=%q want empty on a successful seed", out.Reason)
+	}
+
+	// Graph generation file copied byte-for-byte.
+	got, err := os.ReadFile(filepath.Join(childSD, genName))
+	if err != nil {
+		t.Fatalf("read seeded gen file: %v", err)
+	}
+	if string(got) != "GRAPH-BYTES-7" {
+		t.Errorf("seeded gen body=%q want GRAPH-BYTES-7", got)
+	}
+	// The `current` pointer resolves the seeded graph.
+	desc, err := graph.CurrentGraphDescriptor(childSD)
+	if err != nil {
+		t.Fatalf("descriptor: %v", err)
+	}
+	if desc.Kind != graph.GraphSingleFile || filepath.Base(desc.Path) != genName {
+		t.Errorf("child descriptor kind=%v path=%q want single-file %s", desc.Kind, desc.Path, genName)
+	}
+	// The diff manifest came across — without it the incremental pass has no
+	// baseline and every file reads as changed.
+	if _, err := os.Stat(filepath.Join(childSD, diff.ManifestFileName)); err != nil {
+		t.Errorf("diff manifest not seeded: %v", err)
+	}
+	// Provenance stamp is on disk and names the parent generation.
+	st, err := ReadSeedStamp(childSD)
+	if err != nil {
+		t.Fatalf("ReadSeedStamp: %v", err)
+	}
+	if st.ParentPointer != genName {
+		t.Errorf("stamp ParentPointer=%q want %q", st.ParentPointer, genName)
+	}
+	if st.ParentRef != "release/v9" {
+		t.Errorf("stamp ParentRef=%q want release/v9", st.ParentRef)
+	}
+	if st.RepoTag != "myservice" {
+		t.Errorf("stamp RepoTag=%q want myservice", st.RepoTag)
+	}
+	if len(st.Artifacts) < 2 {
+		t.Errorf("stamp Artifacts=%v want at least the gen file + manifest", st.Artifacts)
+	}
+}
+
+func TestSeedWorktreeGraph_PinsRepoTagSoEntityIDsAgreeWithTheParent(t *testing.T) {
+	// graph.EntityID hashes the repo tag FIRST. A worktree indexed with the
+	// default tag (its own directory basename) mints entity IDs that disagree
+	// with the parent's for byte-identical files, which would make a seeded
+	// graph a hybrid of two ID spaces. The seed therefore records the tag the
+	// index MUST be pinned to.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 1, "G")
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if !out.Seeded {
+		t.Fatalf("seed failed: %s %s", out.Reason, out.Detail)
+	}
+	if got := ReadRepoTagPin(childSD); got != "myservice" {
+		t.Errorf("ReadRepoTagPin=%q want myservice", got)
+	}
+	parentID := graph.EntityID("myservice", "SCOPE.Operation", "Handle", "svc/a.go")
+	pinnedID := graph.EntityID(ReadRepoTagPin(childSD), "SCOPE.Operation", "Handle", "svc/a.go")
+	if parentID != pinnedID {
+		t.Errorf("pinned tag yields %s, parent yields %s — seeded graph would be a hybrid", pinnedID, parentID)
+	}
+	unpinnedID := graph.EntityID("child-wt", "SCOPE.Operation", "Handle", "svc/a.go")
+	if unpinnedID == parentID {
+		t.Fatal("fixture is inert: the unpinned tag must produce a DIFFERENT id, else this test proves nothing")
+	}
+}
+
+func TestWriteRepoTagPin_RoundTripsAndIsIndependentOfTheSeed(t *testing.T) {
+	dir := t.TempDir()
+	if got := ReadRepoTagPin(dir); got != "" {
+		t.Errorf("unpinned dir returned %q want empty", got)
+	}
+	if err := WriteRepoTagPin(dir, "svc-a"); err != nil {
+		t.Fatalf("WriteRepoTagPin: %v", err)
+	}
+	if got := ReadRepoTagPin(dir); got != "svc-a" {
+		t.Errorf("ReadRepoTagPin=%q want svc-a", got)
+	}
+	// A full (unseeded) index of the same worktree must use the SAME tag, or
+	// the seeded and from-scratch graphs would not be comparable at all.
+	if err := DiscardSeed(dir); err != nil {
+		t.Fatalf("DiscardSeed: %v", err)
+	}
+	if got := ReadRepoTagPin(dir); got != "svc-a" {
+		t.Errorf("after DiscardSeed ReadRepoTagPin=%q want svc-a (the pin outlives the seed)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback path 1 — parent never indexed
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_FallsBackWhenParentNotIndexed(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state") // empty: never indexed
+	childSD := filepath.Join(root, "child-state")
+	if err := os.MkdirAll(parentSD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if out.Seeded {
+		t.Fatal("Seeded=true for an unindexed parent")
+	}
+	if out.Reason != SeedFallbackParentNotIndexed {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackParentNotIndexed)
+	}
+	// A silent fallback is the failure mode this feature is designed against.
+	if out.Detail == "" {
+		t.Error("Detail is empty — the fallback must name what it found")
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Error("child state dir must be left with no graph so a full index runs")
+	}
+}
+
+func TestSeedWorktreeGraph_FallsBackWhenParentHasNoDiffManifest(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 3, "G")
+	if err := os.Remove(filepath.Join(parentSD, diff.ManifestFileName)); err != nil {
+		t.Fatal(err)
+	}
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if out.Seeded {
+		t.Fatal("Seeded=true with no parent diff manifest")
+	}
+	if out.Reason != SeedFallbackParentManifestAbsent {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackParentManifestAbsent)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Error("no graph must be left behind")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback path 2 — the parent generation moved under the copy
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_FallsBackWhenParentGenerationMovesMidCopy(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 4, "GEN-4")
+
+	req := seedReq(t, parentSD, childSD)
+	// Simulate the parent finishing a reindex while the copy is in flight:
+	// a new generation lands and `current` flips.
+	req.afterCopyHook = func() {
+		if err := os.WriteFile(filepath.Join(parentSD, graph.GenFileName(5)), []byte("GEN-5"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if err := graph.WriteCurrentPointer(parentSD, graph.GenFileName(5)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out := SeedWorktreeGraph(req)
+	if out.Seeded {
+		t.Fatal("Seeded=true although the parent generation moved mid-copy — the graph and the diff manifest could be from different generations")
+	}
+	if out.Reason != SeedFallbackGenerationMoved {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackGenerationMoved)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Error("a torn seed must not be left resolvable — it would be silently wrong")
+	}
+	if _, err := ReadSeedStamp(childSD); err == nil {
+		t.Error("a stamp must not be written for a torn seed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback path 3 — copy failure
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_FallsBackWhenCopyFails(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	writeParentStateDir(t, parentSD, 2, "G")
+	// Make the child state dir un-creatable: its parent path is a FILE.
+	blocker := filepath.Join(root, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	childSD := filepath.Join(blocker, "child-state")
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if out.Seeded {
+		t.Fatal("Seeded=true despite an unwritable destination")
+	}
+	if out.Reason != SeedFallbackCopyFailed {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackCopyFailed)
+	}
+	if out.Detail == "" {
+		t.Error("copy failure must carry the underlying error in Detail")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Fallback path 4 — the child already has a graph
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_DoesNotClobberAnAlreadyIndexedChild(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 9, "PARENT")
+	writeParentStateDir(t, childSD, 1, "CHILD-OWN-GRAPH")
+
+	out := SeedWorktreeGraph(seedReq(t, parentSD, childSD))
+	if out.Seeded {
+		t.Fatal("Seeded=true over an already-indexed child — that would discard the child's own newer graph")
+	}
+	if out.Reason != SeedFallbackChildAlreadyIndexed {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackChildAlreadyIndexed)
+	}
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "CHILD-OWN-GRAPH" {
+		t.Errorf("child graph body=%q — the child's own graph was clobbered", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Stamp verification + the mutation that must fail
+// ---------------------------------------------------------------------------
+
+func TestVerifySeededGraph_AcceptsAnIntactSeed(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 11, "G")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+
+	st, reason, err := VerifySeededGraph(childSD)
+	if err != nil {
+		t.Fatalf("VerifySeededGraph: %v", err)
+	}
+	if reason != "" {
+		t.Fatalf("reason=%q want empty for an intact seed", reason)
+	}
+	if st == nil || st.ParentPointer != graph.GenFileName(11) {
+		t.Fatalf("stamp=%+v want ParentPointer=%s", st, graph.GenFileName(11))
+	}
+}
+
+// MUTATION GUARD: a seed whose recorded generation does not match what is on
+// disk must be REJECTED. If VerifySeededGraph is weakened to trust the stamp
+// without recomputing the digest, this test fails.
+func TestVerifySeededGraph_RejectsAStampWhoseGraphContentChanged(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 11, "TRUSTED")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	// Swap the seeded graph body for content the stamp never covered — the
+	// exact shape of "the child's graph contains entities from code not in
+	// the child's tree".
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(11)), []byte("TAMPERED-LONGER"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, reason, err := VerifySeededGraph(childSD)
+	if err != nil {
+		t.Fatalf("VerifySeededGraph returned err: %v", err)
+	}
+	if reason != SeedFallbackStampMismatch {
+		t.Fatalf("reason=%q want %q — a seed whose content does not match its stamp was ACCEPTED", reason, SeedFallbackStampMismatch)
+	}
+}
+
+func TestVerifySeededGraph_RejectsWhenTheDiffManifestWasSwappedIndependently(t *testing.T) {
+	// The graph and the diff manifest must come from the SAME parent
+	// generation. If the manifest is newer than the graph, files that really
+	// differ read as unchanged and their stale entities survive — silently.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 6, "G")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	m := diff.LoadManifest(childSD)
+	m.Files["b.go"] = diff.FileEntry{SHA256: "cafebabe", Size: 9}
+	if err := diff.SaveManifest(childSD, "/x", m); err != nil {
+		t.Fatal(err)
+	}
+
+	_, reason, _ := VerifySeededGraph(childSD)
+	if reason != SeedFallbackStampMismatch {
+		t.Fatalf("reason=%q want %q", reason, SeedFallbackStampMismatch)
+	}
+}
+
+func TestVerifySeededGraph_RejectsWhenTheCurrentPointerNoLongerNamesTheSeed(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 6, "G")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(99)), []byte("OTHER"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(99)); err != nil {
+		t.Fatal(err)
+	}
+
+	_, reason, _ := VerifySeededGraph(childSD)
+	if reason != SeedFallbackGenerationMoved {
+		t.Fatalf("reason=%q want %q", reason, SeedFallbackGenerationMoved)
+	}
+}
+
+func TestVerifySeededGraph_NoStampIsNotAFailure(t *testing.T) {
+	// An ordinary, never-seeded state dir must verify clean — otherwise every
+	// non-worktree repo would be forced down the fallback path forever.
+	dir := t.TempDir()
+	writeParentStateDir(t, dir, 1, "G")
+	st, reason, err := VerifySeededGraph(dir)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if st != nil || reason != "" {
+		t.Fatalf("st=%+v reason=%q want nil/empty for an unseeded dir", st, reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DiscardSeed
+// ---------------------------------------------------------------------------
+
+func TestDiscardSeed_RemovesEverySeededArtifactAndThePointer(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 8, "G")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+
+	if err := DiscardSeed(childSD); err != nil {
+		t.Fatalf("DiscardSeed: %v", err)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Error("graph still resolvable after DiscardSeed → a full index would merge into an untrusted seed")
+	}
+	if _, err := os.Stat(filepath.Join(childSD, diff.ManifestFileName)); !os.IsNotExist(err) {
+		t.Error("diff manifest survived DiscardSeed → the next pass would use an untrusted baseline")
+	}
+	if _, err := ReadSeedStamp(childSD); err == nil {
+		t.Error("stamp survived DiscardSeed")
+	}
+}
+
+func TestConsumeSeedStamp_LeavesTheGraphAndStopsLaterVerificationFromWipingIt(t *testing.T) {
+	// After the consuming pass writes its own generation, an un-consumed
+	// stamp would make the next VerifySeededGraph report generation_moved and
+	// DiscardSeed would delete a graph the child legitimately built.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 4, "G")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+
+	if err := ConsumeSeedStamp(childSD); err != nil {
+		t.Fatalf("ConsumeSeedStamp: %v", err)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind == graph.GraphAbsent {
+		t.Fatal("ConsumeSeedStamp removed the graph")
+	}
+	if _, err := os.Stat(filepath.Join(childSD, diff.ManifestFileName)); err != nil {
+		t.Fatalf("ConsumeSeedStamp removed the diff manifest: %v", err)
+	}
+
+	// The child now writes its own generation, as a real pass would.
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(12)), []byte("CHILD-OWN"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(12)); err != nil {
+		t.Fatal(err)
+	}
+	st, reason, err := VerifySeededGraph(childSD)
+	if err != nil || st != nil || reason != "" {
+		t.Fatalf("VerifySeededGraph after consume = (%+v, %q, %v) want (nil, \"\", nil)", st, reason, err)
+	}
+	if err := DiscardSeed(childSD); err != nil {
+		t.Fatal(err)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind == graph.GraphAbsent {
+		t.Fatal("DiscardSeed deleted the child's OWN graph after the stamp was consumed")
+	}
+}
+
+func TestConsumeSeedStamp_IsANoOpWithoutAStamp(t *testing.T) {
+	if err := ConsumeSeedStamp(t.TempDir()); err != nil {
+		t.Fatalf("ConsumeSeedStamp: %v", err)
+	}
+}
+
+func TestDiscardSeed_IsANoOpOnADirItNeverSeeded(t *testing.T) {
+	dir := t.TempDir()
+	writeParentStateDir(t, dir, 1, "REAL-GRAPH")
+	if err := DiscardSeed(dir); err != nil {
+		t.Fatalf("DiscardSeed: %v", err)
+	}
+	desc, _ := graph.CurrentGraphDescriptor(dir)
+	if desc.Kind == graph.GraphAbsent {
+		t.Fatal("DiscardSeed deleted a real, unseeded graph")
+	}
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "REAL-GRAPH" {
+		t.Errorf("body=%q want REAL-GRAPH", body)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Input validation
+// ---------------------------------------------------------------------------
+
+func TestSeedWorktreeGraph_RefusesWithoutAPinnedRepoTag(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 1, "G")
+	req := seedReq(t, parentSD, childSD)
+	req.RepoTag = ""
+
+	out := SeedWorktreeGraph(req)
+	if out.Seeded {
+		t.Fatal("Seeded=true with no repo tag — entity IDs would not agree with the parent's")
+	}
+	if out.Reason != SeedFallbackRepoTagUnresolved {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackRepoTagUnresolved)
+	}
+}
+
+func TestSeedWorktreeGraph_RefusesWithoutAParentPath(t *testing.T) {
+	root := t.TempDir()
+	childSD := filepath.Join(root, "child-state")
+	req := seedReq(t, "", childSD)
+	req.ParentPath = ""
+	req.ParentStateDir = ""
+
+	out := SeedWorktreeGraph(req)
+	if out.Seeded {
+		t.Fatal("Seeded=true with no parent path")
+	}
+	if out.Reason != SeedFallbackParentPathUnresolved {
+		t.Errorf("Reason=%q want %q", out.Reason, SeedFallbackParentPathUnresolved)
+	}
+}
+
+// #3652 REGRESSION GUARD. The first clone-from-parent attempt resolved the
+// parent's graph with a HARDCODED "main" ref, so it always read an empty dir
+// for any parent not on main. SeedWorktreeGraph must resolve the parent's
+// state dir from the parent's ACTUAL ref.
+func TestSeedWorktreeGraph_UsesTheParentsActualRefNotMain(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+	parentRepo := filepath.Join(root, "parent-repo")
+	childRepo := filepath.Join(root, "child-wt")
+	for _, d := range []string{parentRepo, childRepo} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	const actualParentRef = "release/2026-07"
+	realSD := StateDirForRepoRef(parentRepo, actualParentRef)
+	mainSD := StateDirForRepoRef(parentRepo, "main")
+	if realSD == mainSD {
+		t.Fatal("fixture is inert: the two ref dirs must differ")
+	}
+	// Only the parent's ACTUAL ref has a graph. "main" is deliberately empty —
+	// the #3652 bug, reproduced.
+	writeParentStateDir(t, realSD, 3, "PARENT-ON-RELEASE-BRANCH")
+	if err := os.MkdirAll(mainSD, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	childSD := StateDirForRepoRef(childRepo, "feat/x")
+	out := SeedWorktreeGraph(SeedRequest{
+		ParentPath: parentRepo,
+		ParentRef:  actualParentRef,
+		ChildPath:  childRepo,
+		ChildRef:   "feat/x",
+		RepoTag:    "myservice",
+	})
+	if !out.Seeded {
+		t.Fatalf("Seeded=false (%s: %s) — the parent's actual ref was not used; this is the #3652 regression", out.Reason, out.Detail)
+	}
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "PARENT-ON-RELEASE-BRANCH" {
+		t.Errorf("seeded body=%q want the release-branch graph", body)
+	}
+	st, err := ReadSeedStamp(childSD)
+	if err != nil {
+		t.Fatalf("ReadSeedStamp: %v", err)
+	}
+	if st.ParentRef != actualParentRef {
+		t.Errorf("stamp ParentRef=%q want %q — a hardcoded ref would be recorded here", st.ParentRef, actualParentRef)
+	}
+	if strings.Contains(st.ParentStateDir, string(filepath.Separator)+"main"+string(filepath.Separator)) {
+		t.Errorf("stamp ParentStateDir=%q resolved through a 'main' segment", st.ParentStateDir)
+	}
+}

--- a/internal/daemon/worktree_seed_test.go
+++ b/internal/daemon/worktree_seed_test.go
@@ -371,7 +371,10 @@ func TestVerifySeededGraph_RejectsWhenTheDiffManifestWasSwappedIndependently(t *
 	}
 }
 
-func TestVerifySeededGraph_RejectsWhenTheCurrentPointerNoLongerNamesTheSeed(t *testing.T) {
+func TestVerifySeededGraph_RejectsWhenTheCurrentPointerMovedToAnUnrelatedGeneration(t *testing.T) {
+	// A pointer that moved BACKWARD (or sideways) is not the child having
+	// built its own graph — generations are minted monotonically per state
+	// dir — so it cannot be classified as superseded and must be rejected.
 	root := t.TempDir()
 	parentSD := filepath.Join(root, "parent-state")
 	childSD := filepath.Join(root, "child-state")
@@ -379,16 +382,19 @@ func TestVerifySeededGraph_RejectsWhenTheCurrentPointerNoLongerNamesTheSeed(t *t
 	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
 		t.Fatalf("seed failed: %s", out.Reason)
 	}
-	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(99)), []byte("OTHER"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(2)), []byte("OTHER"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(99)); err != nil {
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(2)); err != nil {
 		t.Fatal(err)
 	}
 
 	_, reason, _ := VerifySeededGraph(childSD)
 	if reason != SeedFallbackGenerationMoved {
 		t.Fatalf("reason=%q want %q", reason, SeedFallbackGenerationMoved)
+	}
+	if SeedVerdictIsBenign(reason) {
+		t.Error("a backward pointer move must not be treated as benign")
 	}
 }
 
@@ -430,6 +436,113 @@ func TestDiscardSeed_RemovesEverySeededArtifactAndThePointer(t *testing.T) {
 	}
 	if _, err := ReadSeedStamp(childSD); err == nil {
 		t.Error("stamp survived DiscardSeed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// A stale stamp must never destroy the child's own graph.
+//
+// ConsumeSeedStamp is only reachable on the paths that go looking for a stamp.
+// The scheduler skips cfg.Incremental entirely when incremental reindexing is
+// disabled (GRAFEL_INCREMENTAL_REINDEX=0, a documented, supported setting), so
+// a full index can run over a seeded dir and leave the stamp behind. If the
+// next verification then read that stale stamp as "generation moved" and
+// DiscardSeed removed the pointer, a full corpus reindex the child legitimately
+// paid for would be thrown away — the exact cost this feature exists to
+// eliminate.
+// ---------------------------------------------------------------------------
+
+func TestVerifySeededGraph_TreatsAPointerMovedFORWARDAsASupersededSeed(t *testing.T) {
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 1, "PARENT")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	// The child runs a FULL index over the seeded dir (the path that never
+	// consumes the stamp) and writes its own, newer generation.
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(2)), []byte("CHILD-OWN-GRAPH"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(2)); err != nil {
+		t.Fatal(err)
+	}
+
+	stamp, reason, err := VerifySeededGraph(childSD)
+	if err != nil {
+		t.Fatalf("err=%v", err)
+	}
+	if reason != SeedFallbackSuperseded {
+		t.Fatalf("reason=%q want %q — a stale stamp over the child's OWN newer graph was reported as an untrusted seed", reason, SeedFallbackSuperseded)
+	}
+	if stamp == nil {
+		t.Fatal("stamp must still be returned so the caller can consume it")
+	}
+	if !SeedVerdictIsBenign(reason) {
+		t.Error("a superseded seed must be classified benign — the caller consumes the stamp, it does not fall back")
+	}
+	if SeedVerdictIsBenign(SeedFallbackGenerationMoved) || SeedVerdictIsBenign(SeedFallbackStampMismatch) {
+		t.Error("genuinely untrusted verdicts must NOT be classified benign")
+	}
+}
+
+func TestDiscardSeed_RefusesToRemoveAGraphNEWERThanTheStamp(t *testing.T) {
+	// Belt and braces: even if a caller ignores the superseded verdict and
+	// calls DiscardSeed anyway, the child's own graph must survive. This is
+	// the mechanism that makes the data loss structurally impossible rather
+	// than merely unreached.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 1, "PARENT")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(2)), []byte("CHILD-OWN-GRAPH"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := graph.WriteCurrentPointer(childSD, graph.GenFileName(2)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DiscardSeed(childSD); err != nil {
+		t.Fatalf("DiscardSeed: %v", err)
+	}
+
+	desc, _ := graph.CurrentGraphDescriptor(childSD)
+	if desc.Kind == graph.GraphAbsent {
+		t.Fatal("DATA LOSS: DiscardSeed made the child's own legitimately built graph unresolvable")
+	}
+	body, _ := os.ReadFile(desc.Path)
+	if string(body) != "CHILD-OWN-GRAPH" {
+		t.Errorf("resolved body=%q want CHILD-OWN-GRAPH", body)
+	}
+	// The stale stamp itself must be gone, so the dir stops re-triggering this.
+	if _, err := ReadSeedStamp(childSD); err == nil {
+		t.Error("the stale stamp survived DiscardSeed")
+	}
+}
+
+func TestDiscardSeed_StillRemovesAGraphThatIsNOTNewerThanTheStamp(t *testing.T) {
+	// The refusal above must not become a blanket refusal: a seed that is
+	// genuinely untrusted (same generation, tampered content) must still be
+	// made unresolvable so a full index runs.
+	root := t.TempDir()
+	parentSD := filepath.Join(root, "parent-state")
+	childSD := filepath.Join(root, "child-state")
+	writeParentStateDir(t, parentSD, 3, "PARENT")
+	if out := SeedWorktreeGraph(seedReq(t, parentSD, childSD)); !out.Seeded {
+		t.Fatalf("seed failed: %s", out.Reason)
+	}
+	if err := os.WriteFile(filepath.Join(childSD, graph.GenFileName(3)), []byte("TAMPERED"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := DiscardSeed(childSD); err != nil {
+		t.Fatalf("DiscardSeed: %v", err)
+	}
+	if desc, _ := graph.CurrentGraphDescriptor(childSD); desc.Kind != graph.GraphAbsent {
+		t.Fatal("an untrusted, non-superseded seed stayed resolvable")
 	}
 }
 

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -61,6 +61,16 @@ const Version = 1
 // manifestFile is the name of the per-repo manifest inside the state directory.
 const manifestFile = "file-index.json"
 
+// ManifestFileName is the exported basename of the per-repo diff manifest.
+// Callers outside this package that must COPY or REMOVE the manifest as an
+// artifact — rather than read it through LoadManifest — need the basename:
+// #5964's worktree graph seeding copies the parent ref's manifest alongside
+// its graph so the child's first incremental pass has the parent's baseline.
+// Seeding a graph without its manifest is silently wrong, so the coupling is
+// named here rather than re-spelled as a literal at each call site (it was
+// already re-spelled once, in internal/daemon/state_migrate.go).
+const ManifestFileName = manifestFile
+
 // FileEntry holds the hash + metadata for one indexed source file.
 type FileEntry struct {
 	SHA256 string `json:"sha256"`
@@ -335,6 +345,38 @@ func FilterWithGit(absRepo string, relPaths []string, manifest *Manifest) (chang
 	if err != nil || gitChanged == nil {
 		// git unavailable or repo is not a git repo — fall back to hash comparison.
 		return Filter(absRepo, relPaths, manifest)
+	}
+
+	// HEAD-ADVANCE UNION (#5964).
+	//
+	// GitChangedFiles only ever answers "working tree vs the CURRENT HEAD".
+	// Trusting it alone is sound only while the manifest was written at the
+	// commit the repo is on NOW. Whenever HEAD has moved since — a
+	// fetch+reset / checkout / pull, or a worktree state dir SEEDED with its
+	// parent ref's manifest (#5964) — every file that differs by a commit
+	// looks clean to that diff and is never hashed, so its stale entities
+	// survive into the graph silently.
+	//
+	// So union in the commit-RANGE diff manifest.GitCommit..HEAD. One extra
+	// bounded `git diff`, and only when HEAD actually moved. When the range
+	// cannot be computed at all — manifest.GitCommit unreachable after a gc,
+	// shallow clone or history rewrite — we must NOT read that as "nothing
+	// changed": fall back to the full hash comparison, which is slower but
+	// cannot be silently stale.
+	//
+	// internal/extractors.TryIncremental performs the same union for its own
+	// path (#5710). Doing it here covers Index()+WithIncremental too, which
+	// had no HEAD-advance handling at all.
+	if manifest != nil && manifest.GitCommit != "" {
+		if head := headCommit(absRepo); head != "" && head != manifest.GitCommit {
+			since, serr := GitChangedFilesSince(absRepo, manifest.GitCommit)
+			if serr != nil {
+				return Filter(absRepo, relPaths, manifest)
+			}
+			for rel := range since {
+				gitChanged[rel] = true
+			}
+		}
 	}
 
 	// git-aware path: files reported by git go through hash-based check;

--- a/internal/indexer/diff/head_advance_test.go
+++ b/internal/indexer/diff/head_advance_test.go
@@ -1,0 +1,191 @@
+package diff
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// FilterWithGit trusts `git diff --name-only HEAD` — working tree vs the
+// CURRENT HEAD — and never hashes a file git did not report. That is only
+// sound while the manifest was written at the SAME commit the repo is on now.
+//
+// #5964 (worktree graph seeding) breaks that premise on purpose: a worktree's
+// state dir is seeded with its PARENT ref's manifest, so the manifest's commit
+// is the parent's while the child's HEAD has already advanced. Every file that
+// differs by a COMMIT then looks clean to `git diff HEAD` and is never hashed
+// — its stale entities survive into the child's graph, invisibly.
+//
+// The same hole exists for any HEAD advance (fetch+reset / checkout / pull)
+// that leaves a clean working tree; internal/extractors.TryIncremental papers
+// over it with its own range diff (#5710), but Index()+WithIncremental does
+// not. These tests pin the fix at the source.
+
+func gitT(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+func TestFilterWithGit_CatchesAFileChangedByACommitSinceTheManifest(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	repo := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.go", "package p\nfunc A() {}\n")
+	write("b.go", "package p\nfunc B() {}\n")
+	gitT(t, repo, "init", "-q", "-b", "trunk")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "one")
+
+	// Manifest pinned at commit one, describing both files exactly.
+	m := newManifest()
+	files := []string{"a.go", "b.go"}
+	UpdateManifest(repo, files, m)
+	m.GitCommit = HeadCommit(repo)
+	if m.GitCommit == "" {
+		t.Fatal("no HEAD commit recorded")
+	}
+
+	// a.go changes and is COMMITTED. The working tree is now clean against
+	// the new HEAD, so `git diff --name-only HEAD` reports nothing.
+	write("a.go", "package p\nfunc A() {}\nfunc ANew() {}\n")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "two")
+	if wt, err := GitChangedFiles(repo); err != nil || len(wt) != 0 {
+		t.Fatalf("fixture is inert: working-tree diff must be empty, got %v (err %v)", wt, err)
+	}
+
+	changed, unchanged := FilterWithGit(repo, files, m)
+
+	if !contains(changed, "a.go") {
+		t.Errorf("changed=%v — a.go changed by a commit since the manifest and was NOT re-extracted; its stale entities would survive", changed)
+	}
+	if !contains(unchanged, "b.go") {
+		t.Errorf("unchanged=%v — b.go did not change and must stay cached", unchanged)
+	}
+}
+
+func TestFilterWithGit_KeepsEverythingCachedWhenHeadHasNotMoved(t *testing.T) {
+	// The common case must not regress into a full hash sweep.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	repo := t.TempDir()
+	for _, n := range []string{"a.go", "b.go"} {
+		if err := os.WriteFile(filepath.Join(repo, n), []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	gitT(t, repo, "init", "-q", "-b", "trunk")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "one")
+
+	files := []string{"a.go", "b.go"}
+	m := newManifest()
+	UpdateManifest(repo, files, m)
+	m.GitCommit = HeadCommit(repo)
+
+	changed, unchanged := FilterWithGit(repo, files, m)
+	if len(changed) != 0 {
+		t.Errorf("changed=%v want none", changed)
+	}
+	if len(unchanged) != 2 {
+		t.Errorf("unchanged=%v want both files", unchanged)
+	}
+}
+
+func TestFilterWithGit_StillSeesUncommittedAndUntrackedWork(t *testing.T) {
+	// The union must not lose what the working-tree diff already caught —
+	// an agent's in-progress edits are the most common thing it asks about.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	repo := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.go", "package p\nfunc A() {}\n")
+	write("b.go", "package p\nfunc B() {}\n")
+	gitT(t, repo, "init", "-q", "-b", "trunk")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "one")
+
+	m := newManifest()
+	UpdateManifest(repo, []string{"a.go", "b.go"}, m)
+	m.GitCommit = HeadCommit(repo)
+
+	// Committed change to a.go …
+	write("a.go", "package p\nfunc A() {}\nfunc ACommitted() {}\n")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "two")
+	// … uncommitted change to b.go …
+	write("b.go", "package p\nfunc B() {}\nfunc BDirty() {}\n")
+	// … and an untracked file.
+	write("c.go", "package p\nfunc C() {}\n")
+
+	files := []string{"a.go", "b.go", "c.go"}
+	changed, _ := FilterWithGit(repo, files, m)
+	for _, want := range files {
+		if !contains(changed, want) {
+			t.Errorf("changed=%v is missing %s", changed, want)
+		}
+	}
+}
+
+func TestFilterWithGit_FallsBackToHashesWhenTheManifestCommitIsUnreachable(t *testing.T) {
+	// A manifest commit that git can no longer resolve (gc, shallow clone,
+	// history rewrite) must NOT be read as "nothing changed since then".
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	repo := t.TempDir()
+	write := func(name, body string) {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write("a.go", "package p\nfunc A() {}\n")
+	gitT(t, repo, "init", "-q", "-b", "trunk")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "one")
+
+	m := newManifest()
+	UpdateManifest(repo, []string{"a.go"}, m)
+	m.GitCommit = "0123456789abcdef0123456789abcdef01234567" // unreachable
+
+	// a.go really did change, but only in a way a commit would have carried.
+	write("a.go", "package p\nfunc A() {}\nfunc ANew() {}\n")
+	gitT(t, repo, "add", "-A")
+	gitT(t, repo, "commit", "-q", "-m", "two")
+
+	changed, _ := FilterWithGit(repo, []string{"a.go"}, m)
+	if !contains(changed, "a.go") {
+		t.Errorf("changed=%v — an unresolvable manifest commit was treated as 'nothing changed'", changed)
+	}
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Creating a branch or worktree costs a **full index of the entire corpus** today, even when one file differs from its parent. `docs/user-guide/multi-branch.md` states it plainly: *"Each `(repo, ref)` slot stores one `graph.fb` file."*

This seeds the child's state dir from the parent's graph and incrementally indexes only the delta.

## Read this before the rest: it is a latency optimisation, not a memory one

Measured, live-heap metric (`next_gc / (1 + GOGC/100)`), swap steady across all runs:

| files | full index | seed + delta | heap | wall |
|---|---|---|---|---|
| 400 | 60.7 MB / 515 ms | 62.3 MB / 533 ms | 1.03× | **1.03× — no win** |
| 1200 | 75.8 MB / 997 ms | 91.3 MB / 668 ms | 1.20× | 0.67× |
| 2500 | 105.3 MB / 7.252 s | 138.8 MB / 1.245 s | **1.32×** | **0.17×** |

The crossover is between 400 and 1200 files, and the heap ratio degrades monotonically. The seeded pass re-extracts only the delta but still materialises the *whole parent graph* to merge the unchanged portion forward (`internal/extractors/incremental.go:393`, `LoadGraphFromDir`), so peak tracks **graph size**, not delta size.

**This does not reduce the ~1.0–1.1 GB per-process budget that epic #5954 exists to reduce.** Task #16 is what would. Stated in the ADR too, because "seed instead of full index" reads as a memory win to every future reader and is not one.

## Two premises of the original design were wrong

**1. Entity IDs are *not* stable across worktrees.** The design cited `types.EntityRecord.ComputeID`, which has no repo tag. That is not the function the graph is built with: every producer calls `graph.EntityID(repoTag, kind, name, sourceFile)` (`internal/graph/graph.go:259`), which hashes `repoTag` **first**, and `Index()` defaults it to `filepath.Base(absRepo)` (`cmd/grafel/index.go:603`) — the worktree directory's own name. Without pinning, a seeded graph is a hybrid of two ID spaces with every cross-file edge dangling.

The #5964 probe had already recorded this as `repo_tag_mismatch` and deferred it.

So seeding **refuses** without a resolved tag, and a `repo-tag` pin is written into the state dir and honoured on the **full** index path as well — otherwise seeded and from-scratch graphs are not comparable and the parity gate asserts nothing. Non-worktree repos never get a pin and their IDs are provably unchanged, including after a directory rename.

**2. The changed-set already covers committed + uncommitted + untracked** — it is content-hash based (`diff.FilterWithGit`), not a commit range. But building the parity gate exposed a **real pre-existing bug**: `FilterWithGit` trusted `git diff --name-only HEAD` and never hashed a file git did not report — sound only while the manifest matches the current commit, which a seeded dir violates by construction. A file changed by a *commit* on the child branch was never re-extracted.

Fixed at source by unioning in the `manifest.GitCommit..HEAD` range diff with a full-hash-sweep fallback. This affected **any** `Index()+WithIncremental` run after a HEAD advance, not just seeding — `internal/extractors.TryIncremental` had its own #5710 union; `Index()` had none.

## Flow

Resolve parent path → resolve the parent's **actual** ref via `gitmeta.CaptureCached` (never assume `main` — that is what killed #3652) → write the repo-tag pin → copy the graph generation + `file-index.json` → generation-stability re-check → write the stamp → **publish `current` last**, so a torn copy leaves inert bytes rather than a resolvable wrong graph.

`seed-provenance.json` records parent path/ref/state-dir, the `current` pointer, the repo tag, and a SHA-256 per copied artifact. `VerifySeededGraph` re-reads the pointer and re-hashes every artifact.

Eight fallback paths, each with a test and a named log reason: `parent_path_unresolved`, `repo_tag_unresolved`, `parent_not_indexed`, `parent_diff_manifest_absent`, `parent_generation_moved`, `copy_failed`, `child_already_indexed`, `stamp_mismatch`. A silent fallback was rejected — a seed that systematically never fires would be invisible.

## Two blockers found in review, both fixed

**The entire feature could be silently disabled with the suite green.** Replacing the `seedWorktreeOnActivate` call with `_ = child` left both suites at exit 0, as did deleting the verification guard and ignoring the repo-tag pin. The unit tests were good; nothing asserted the functions were *called*.

Fixed by extracting three seams — `newWorktreeActivateHandler`, `daemonSchedulerIncremental`, `resolveIndexRepoTag` — so the real code is reachable without a live daemon. All three mutants now fail, with no source scanning. The repo-tag test runs a real in-process index and asserts over **every** source-bearing entity rather than one hand-picked name.

**A stale stamp destroyed the child's legitimately built graph.** `ConsumeSeedStamp` ran only on the incremental path, but the scheduler skips it entirely under `GRAFEL_INCREMENTAL_REINDEX=0` (documented and supported). A full index then ran over the seeded dir, the stamp was never consumed, and the next incremental pass verified the stale stamp against the child's own graph → `DiscardSeed` removed `current` → a full corpus reindex thrown away. Reproduced.

Fixed three ways rather than one, because a single mechanism at a single call site is how the bug existed:
1. `VerifySeededGraph` returns `SeedFallbackSuperseded` when `current` names a generation **strictly newer** than the stamp. Callers branch on `SeedVerdictIsBenign(reason)` rather than `reason != ""` — that framing is what made the bug possible.
2. `DiscardSeed` **refuses** a dir whose pointer moved forward, dropping only the stale stamp. The loss is now structurally impossible, not merely unreached.
3. `daemonSchedulerIndex` consumes the stamp too, deferred so it runs on the error path.

`movedForward` **fails closed**: an unparseable pointer is untrusted. Being wrong that way costs a reindex; being wrong the other way loses a graph.

## Parity

**Path B**: a real linked git worktree (`git worktree add`, not two `git init` repos — that made an earlier fixture inert, because the parent's commit was unreachable so it fell back before the seed was exercised). Indexes the same tree seeded and from scratch and diffs full entity and relationship identity sets **both ways**. Independently extended to 400 files in review: 3407 entities / 8809 relationships, exact set parity.

**Path A** — the shipping path — parity was initially missing and is now built: run Path A on *both* arms, varying only whether the base graph was seeded or built from scratch. Identical content and pinned tag, so IDs coincide and the reduced-pass-set noise cancels exactly. Exact set equality, 173 entities / 500 relationships. Any divergence would be attributable to seeding alone.

Comparison is on semantic digests, never bytes — per #6083, whole-file `cmp` on `graph.fb` is invalid.

## ADR-0020 corrected

`docs/adrs/0020-multi-branch-worktree.md` described "Clone-from-parent optimisation" in the present indicative as though it shipped. It never did: #3652 was deleted in `65427c5a8`, `GRAFEL_CLONE_MAX_FILES` never existed in code, and its "~5 s → ~180 ms" was never measured against a shipped implementation.

Replaced with what exists, plus the measured table and the memory caveat. The superseded text is preserved collapsed rather than deleted — hiding that the claim was made would repeat the defect.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `./cmd/grafel/`, `./internal/daemon/...`, `./internal/graph/...`, `./internal/indexer/...`, `./internal/extractors/...` — **107 packages, exit 0, zero FAIL lines**, verified independently rather than taken from the report.

Mutants: digest re-hash deleted → 2 fail · #3652's hardcoded `"main"` restored → named regression test fails · head-advance union reverted → 3 fail · plus the three wiring mutants above.

Two independent adversarial review rounds.

Closes #5964
Refs #5954, #16
