### PR TITLE
fix(#6010,#5932): nil-Document guard on revive; discriminate registry formats on JSON shape

### DIFF
--- a/internal/mcp/evict_nil_doc_6010_test.go
+++ b/internal/mcp/evict_nil_doc_6010_test.go
@@ -1,0 +1,61 @@
+package mcp
+
+import "testing"
+
+// Issue #6010: a repo whose graph failed to load carries Doc == nil and
+// Reader == nil (reloadLocked records loadErr and `continue`s before either is
+// set). A keepReader evict copies that repo into a cold shell verbatim, and the
+// revive calls rematerializeFromReader on it. With Reader nil the else branch
+// runs BuildLabelIndex(nil), which dereferences doc.Entities and panics — taking
+// down `serve` on a routine evict/revive cycle.
+//
+// MUTATION ORACLE: drop the `doc == nil` guard from BuildLabelIndex (or the
+// nil-Doc branch in rematerializeFromReader) → this test panics with
+// "invalid memory address or nil pointer dereference" instead of failing cleanly.
+func TestEvictRevive_RepoWithFailedGraphLoadDoesNotPanic(t *testing.T) {
+	s := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{"broken": {}}},
+	}})
+	// Exactly the shape reloadLocked leaves behind when readDocumentFromDir
+	// fails: no Doc, no Reader, a recorded load error.
+	lr := &LoadedRepo{Repo: "broken", loadErr: "read graph.fb: unexpected EOF"}
+	s.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"broken": lr}}
+
+	if !s.EvictGroup("g", true) {
+		t.Fatal("EvictGroup(keepReader) returned false")
+	}
+
+	// The revive path; on d2a7f28ae this panics inside BuildLabelIndex(nil).
+	got := s.Group("g")
+	if got == nil {
+		t.Fatal("revive returned a nil group")
+	}
+	rr := got.Repos["broken"]
+	if rr == nil {
+		t.Fatal("revive dropped the broken repo from the group")
+	}
+	// The repo must come back usable-but-empty rather than half-built: a nil
+	// LabelIndex would move the same panic to the first lookup.
+	if rr.LabelIndex == nil {
+		t.Fatal("revive left LabelIndex nil for a repo with no Doc")
+	}
+	// And an actual lookup against it must be a clean miss, not a crash.
+	if e := rr.LabelIndex.ByID("anything"); e != nil {
+		t.Fatalf("empty LabelIndex reported a hit for an unknown id: %v", e)
+	}
+}
+
+// BuildLabelIndex(nil) is reachable from any caller that has not yet parsed a
+// graph; it must yield a usable empty index rather than panicking.
+func TestBuildLabelIndex_NilDocument(t *testing.T) {
+	idx := BuildLabelIndex(nil)
+	if idx == nil {
+		t.Fatal("BuildLabelIndex(nil) returned nil")
+	}
+	if e := idx.ByID("x"); e != nil {
+		t.Fatalf("nil-doc index reported a hit: %v", e)
+	}
+	if got := idx.LookupAll("x"); len(got) != 0 {
+		t.Fatalf("nil-doc index LookupAll returned %d entries, want 0", len(got))
+	}
+}

--- a/internal/mcp/index.go
+++ b/internal/mcp/index.go
@@ -214,7 +214,17 @@ func (l *LabelIndex) add(ki *keyInterner, i int32, id, name, qname, kind string)
 // materialize a heap copy out of doc.Entities. This is the nil-Reader fallback
 // (JSON-only load / no graph.fb) and the parity baseline for the Reader-sourced
 // build.
+//
+// A nil doc yields a usable EMPTY index rather than panicking (issue #6010): a
+// repo whose graph failed to parse carries Doc == nil and Reader == nil, and a
+// keepReader evict/revive routes it straight through rematerializeFromReader's
+// nil-Reader fallback into here. Every lookup on the result is a clean miss,
+// which is the correct answer for a repo with no graph.
 func BuildLabelIndex(doc *graph.Document) *LabelIndex {
+	if doc == nil {
+		idx, _ := newLabelIndex(0)
+		return idx
+	}
 	idx, ki := newLabelIndex(len(doc.Entities))
 	idx.doc = doc
 	for i := range doc.Entities {

--- a/internal/mcp/registry_empty_groups_5932_test.go
+++ b/internal/mcp/registry_empty_groups_5932_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Issue #5932: Registry.UnmarshalJSON discriminated CLI-array format from legacy
+// map format on `len(raw.Groups) > 0` rather than on the JSON shape. A CLI-format
+// registry with zero groups — {"version":1,"groups":[]}, exactly what a fresh
+// install or a `grafel remove` of the last group writes — therefore fell through
+// to the legacy branch, where unmarshalling a JSON array into
+// map[string]RegistryGroup fails. LoadRegistry returned an error, NewServer
+// aborted, and the MCP session degraded to a single sentinel tool for the rest of
+// its life (a client reconnect does not recover it).
+//
+// MUTATION ORACLE: restore the `len(raw.Groups) > 0` condition → every subtest
+// here fails with "invalid format (neither CLI array nor legacy map)".
+func TestRegistryUnmarshal_EmptyCLIGroupsIsNotAnError(t *testing.T) {
+	cases := []struct {
+		name string
+		data string
+	}{
+		{"cli empty array with version", `{"version":1,"groups":[]}`},
+		{"cli empty array no version", `{"groups":[]}`},
+		{"cli empty array whitespace", `{"version":1,"groups": [ ]}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var r Registry
+			if err := json.Unmarshal([]byte(tc.data), &r); err != nil {
+				t.Fatalf("unmarshal %s: %v", tc.data, err)
+			}
+			if r.Groups == nil {
+				t.Fatal("Groups is nil; callers range over it and expect a usable empty map")
+			}
+			if len(r.Groups) != 0 {
+				t.Fatalf("Groups has %d entries, want 0", len(r.Groups))
+			}
+		})
+	}
+}
+
+// The populated CLI-array and legacy-map formats must keep working unchanged —
+// the shape discriminator must not have traded one format for another.
+func TestRegistryUnmarshal_FormatsStillDiscriminated(t *testing.T) {
+	t.Run("cli array populated", func(t *testing.T) {
+		var r Registry
+		if err := json.Unmarshal([]byte(`{"version":1,"groups":[{"name":"acme","config_path":""}]}`), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		g, ok := r.Groups["acme"]
+		if !ok {
+			t.Fatalf("group 'acme' missing; got %v", r.Groups)
+		}
+		if g.Repos == nil {
+			t.Fatal("CLI-format group has nil Repos map")
+		}
+	})
+	t.Run("legacy map populated", func(t *testing.T) {
+		var r Registry
+		data := `{"groups":{"acme":{"repos":{"api":{"path":"/tmp/api"}}}}}`
+		if err := json.Unmarshal([]byte(data), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if got := r.Groups["acme"].Repos["api"].Path; got != "/tmp/api" {
+			t.Fatalf("legacy repo path = %q, want /tmp/api", got)
+		}
+	})
+	t.Run("legacy empty map", func(t *testing.T) {
+		var r Registry
+		if err := json.Unmarshal([]byte(`{"groups":{}}`), &r); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		if r.Groups == nil || len(r.Groups) != 0 {
+			t.Fatalf("Groups = %v, want empty non-nil map", r.Groups)
+		}
+	})
+	t.Run("genuinely malformed still errors", func(t *testing.T) {
+		var r Registry
+		if err := json.Unmarshal([]byte(`{"groups":"nope"}`), &r); err == nil {
+			t.Fatal("a string 'groups' unmarshalled without error; the format guard is gone")
+		}
+	})
+}
+
+// End-to-end on the path that actually bricked the session: LoadRegistry over a
+// real on-disk empty CLI registry must succeed, so NewServer does not abort and
+// the full toolset gets registered.
+func TestLoadRegistry_EmptyCLIRegistryFileLoads(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "registry.json")
+	if err := os.WriteFile(path, []byte(`{"version":1,"groups":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	reg, err := LoadRegistry(path)
+	if err != nil {
+		t.Fatalf("LoadRegistry on an empty CLI registry: %v", err)
+	}
+	if reg.Groups == nil {
+		t.Fatal("LoadRegistry returned a nil Groups map")
+	}
+	if len(reg.Groups) != 0 {
+		t.Fatalf("LoadRegistry returned %d groups, want 0", len(reg.Groups))
+	}
+	if reg.Path != path {
+		t.Fatalf("Path = %q, want %q", reg.Path, path)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -76,6 +76,30 @@ type RegistryRepo struct {
 	GraphFile string `json:"graph_file,omitempty"`
 }
 
+// groupsIsJSONArray reports whether the top-level "groups" member of data is a
+// JSON array — the CLI registry format — as opposed to an object (legacy MCP
+// format), some other type, or absent. Decoding "groups" into a json.RawMessage
+// keeps the check on the value's SHAPE and independent of how many elements it
+// holds, which is the whole point of issue #5932: an empty CLI registry is still
+// a CLI registry.
+func groupsIsJSONArray(data []byte) bool {
+	var probe struct {
+		Groups json.RawMessage `json:"groups"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return false
+	}
+	for _, b := range probe.Groups {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			return b == '['
+		}
+	}
+	return false
+}
+
 // UnmarshalJSON implements custom unmarshaling to accept both array format
 // (written by CLI registry) and map format (legacy MCP format).
 // CLI format: {"version":1,"groups":[{"name":"...","config_path":"..."}]}
@@ -90,8 +114,17 @@ func (r *Registry) UnmarshalJSON(data []byte) error {
 		Version int      `json:"version"`
 		Groups  []rawRef `json:"groups"`
 	}
+	// Issue #5932: discriminate on the JSON SHAPE of "groups", not on how many
+	// elements it has. Keying off len(raw.Groups) > 0 conflated "not CLI format"
+	// with "CLI format, zero groups", so a legitimate {"version":1,"groups":[]}
+	// — what a fresh install or removal of the last group writes — fell through
+	// to the legacy branch, failed to unmarshal an array into a map, and bricked
+	// the whole MCP session down to a single sentinel tool for its lifetime.
 	var raw rawReg
-	if err := json.Unmarshal(data, &raw); err == nil && len(raw.Groups) > 0 {
+	if groupsIsJSONArray(data) {
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return fmt.Errorf("unmarshal registry: CLI format: %w", err)
+		}
 		// CLI format: groups is an array of refs with names and config paths
 		r.Groups = make(map[string]RegistryGroup, len(raw.Groups))
 		for _, ref := range raw.Groups {


### PR DESCRIPTION
Two independent, independently-revertable fixes from a triaged backlog pass. Both reproduced before being fixed.

## #6010 — `serve` crashes on evict/revive of a repo whose graph failed to load

A repo whose graph fails to parse keeps **both** `Doc == nil` and `Reader == nil` — `reloadLocked` records `loadErr` and `continue`s at both failure points (no-graph-file and parse-failure) before either is assigned. So the `keepReader` cold shell carries two nils, the revive takes the nil-Reader fallback, and `BuildLabelIndex(nil)` dereferences.

Reproduced as a real SIGSEGV, not inferred:

```
panic: runtime error: invalid memory address or nil pointer dereference
mcp.BuildLabelIndex(0x0)                    internal/mcp/index.go
mcp.(*LoadedRepo).rematerializeFromReader   internal/mcp/state.go
mcp.(*State).Group                          internal/mcp/state.go
```

The triage's call-site list was wrong; the real path is `State.Group` → `reviveEvictedLocked` → `rematerializeFromReader` → `BuildLabelIndex`. Verified independently in review, which also confirmed there is **no** path where `Doc == nil` but `Reader != nil` — `Reader` is only ever assigned in `publishHandle` and nilled in `retireHandle`, and nothing assigns `Doc = nil` post-construction.

`BuildLabelIndex(nil)` now returns an empty, usable index.

**This does not make a load failure silent.** The failure is surfaced on a channel independent of `LabelIndex` and untouched here: `tools.go` (`handleGraphStats`) keys off `r.Doc == nil` and lists the repo as `unavailable`; `dashboard_tools.go` sets `Loaded: lr.Doc != nil` and `LoadError: lr.loadErr`. A broken repo is reported broken, not as "no results" — which matters, because the confident-wrong-answer failure mode is exactly what this codebase has been bitten by three times this cycle.

Also unblocks #5872 (per-group LRU eviction) from shipping its default.

## #5932 — an empty registry bricks MCP to a 1-tool sentinel

`{"version":1,"groups":[]}` failed with:

```
invalid format (neither CLI array nor legacy map): json: cannot unmarshal array
into Go struct field legacyReg.groups of type map[string]mcp.RegistryGroup
```

which propagates through `LoadRegistry` → `NewServer` and degrades the session to a single sentinel tool. That state is **unrecoverable in-session** — a client reconnect does not clear it; the session can only be abandoned.

The cause was `len(raw.Groups) > 0`, which conflates "not CLI format" with "CLI format, zero groups". Now discriminated on JSON shape: `groups` is decoded into a `json.RawMessage` and branched on its first non-space byte.

Review ran a shape table well beyond the four tested — absent `groups` key, `null`, leading whitespace, `\r\n`, BOM, `"nope"`, `3`, `true`, populated array, populated legacy map, empty legacy map, malformed documents. All correct. The two edge shapes specifically checked, empty `RawMessage` and `null`, both fall to the legacy branch and yield a usable empty map.

## Verification

Both mutants killed: deleting the `doc == nil` guard panics; restoring `len(raw.Groups) > 0` reds five tests.

Tests are behavioural — an evict→revive cycle on a load-failed repo, and an on-disk `LoadRegistry` round-trip — not source scans. Three source-scanning guards written elsewhere this week all fell to trivial mutants, so none were used here.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `./internal/mcp/...` (106.1s) and `./internal/install/...` green at `-count=1 -p 1`.

Independently adversarially reviewed, per commit.

## Recorded, not fixed here

`coldShellRepo` copies `Doc`, `Reader`, `handle`, `mtime` and friends but **not** `loadErr`, so after an evict→revive cycle a broken repo is still correctly listed as unavailable but with an empty reason, and the dashboard's `load_error` field disappears. Message degradation rather than silence, hence non-blocking — filed as a follow-up.

The third commit from this batch (#6072, daemon version via the RPC socket) is **held back**: review found it removes the `DaemonTimeout` cap, so `grafel doctor` hangs indefinitely against a socket-bound but unresponsive daemon — the exact situation doctor exists for. It returns separately once bounded.

Closes #6010
Closes #5932
