### PR TITLE
fix(#6072): read the daemon version from the RPC socket, bounded, instead of the routeless /healthz

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -220,19 +220,87 @@ type DaemonVersionProbeFunc func() (ProbedVersion, error)
 // implausible response is reported as an error ("version unknown") rather
 // than silently treated as a match.
 func defaultDaemonVersionProbe() (ProbedVersion, error) {
-	layout, err := daemon.DefaultLayout()
-	if err != nil {
-		return ProbedVersion{}, fmt.Errorf("resolve daemon layout: %w", err)
+	return boundedDaemonVersionProbe(defaultDaemonProbeTimeout)()
+}
+
+// defaultDaemonProbeTimeout bounds a single Ping round-trip. This is a local
+// Unix socket answering a no-op RPC, so 2s is enormously generous — it matches
+// the dial budget DialPath already applies.
+const defaultDaemonProbeTimeout = 2 * time.Second
+
+// boundedDaemonVersionProbe returns a DaemonVersionProbeFunc that gives up
+// after timeout instead of blocking forever.
+//
+// The timeout is load-bearing, not defensive padding (#6072 review, H-1).
+// dclient.DialPath bounds only the DIAL (2s). Client.Ping sets no deadline,
+// and neither does net/rpc/jsonrpc — there is no SetDeadline anywhere on that
+// path. So a daemon that ACCEPTS the connection and then answers nothing — the
+// wedged state, which is exactly what someone runs `grafel doctor` to diagnose
+// — blocked the caller indefinitely. A daemon that is merely DOWN was never
+// the problem: os.Stat on the missing socket fails instantly.
+// internal/daemon/pidfile.go:51 is this codebase's own precedent for pairing a
+// dial timeout with a conn deadline.
+func boundedDaemonVersionProbe(timeout time.Duration) DaemonVersionProbeFunc {
+	return func() (ProbedVersion, error) {
+		layout, err := daemon.DefaultLayout()
+		if err != nil {
+			return ProbedVersion{}, fmt.Errorf("resolve daemon layout: %w", err)
+		}
+		return probeDaemonVersionWithin(timeout, layout.SocketPath)
 	}
-	c, err := dclient.DialPath(layout.SocketPath)
+}
+
+// probeDaemonVersionWithin dials socketPath and Pings it, giving up after
+// timeout. Split out from boundedDaemonVersionProbe so tests can point it at a
+// stub socket without touching daemon.DefaultLayout / the real environment.
+func probeDaemonVersionWithin(timeout time.Duration, socketPath string) (ProbedVersion, error) {
+	if timeout <= 0 {
+		timeout = defaultDaemonProbeTimeout
+	}
+	c, err := dclient.DialPath(socketPath)
 	if err != nil {
 		return ProbedVersion{}, err
 	}
-	defer func() { _ = c.Close() }()
-	reply, err := c.Ping()
-	if err != nil {
-		return ProbedVersion{}, err
+
+	type pingResult struct {
+		reply proto.PingReply
+		err   error
 	}
+	// Buffered so the goroutine can always deliver and exit, even when this
+	// function has already returned down the timeout branch.
+	done := make(chan pingResult, 1)
+	go func() {
+		reply, perr := c.Ping()
+		done <- pingResult{reply: reply, err: perr}
+	}()
+
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case r := <-done:
+		_ = c.Close()
+		if r.err != nil {
+			return ProbedVersion{}, r.err
+		}
+		return versionFromPingReply(r.reply)
+	case <-timer.C:
+		// Closing the client is what makes this a REAL timeout rather than a
+		// leaked goroutine: with no read deadline available through net/rpc,
+		// tearing down the connection is the only way to abort the in-flight
+		// Ping, and it lets the goroutine above return.
+		_ = c.Close()
+		return ProbedVersion{}, fmt.Errorf(
+			"daemon accepted the connection but did not answer Ping within %s (wedged daemon at %s)",
+			timeout, socketPath)
+	}
+}
+
+// versionFromPingReply validates a Ping reply and reduces it to a
+// ProbedVersion. looksLikeVersion is applied here so an implausible response
+// is reported as an error ("version unknown") rather than silently treated as
+// a match.
+func versionFromPingReply(reply proto.PingReply) (ProbedVersion, error) {
 	display := strings.TrimSpace(reply.Version)
 	if !looksLikeVersion(display) {
 		return ProbedVersion{}, fmt.Errorf("daemon reported an implausible version %q", reply.Version)

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon"
 	dclient "github.com/cajasmota/grafel/internal/daemon/client"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/daemon/service"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/skilllink"

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -108,9 +108,21 @@ type DoctorOptions struct {
 	// the exported options surface and is still the port other tooling reports.
 	DaemonPort int
 
-	// DaemonTimeout is the maximum wait for an HTTP daemon probe.
-	// Defaults to 2 seconds. See DaemonPort re: #6072.
+	// DaemonTimeout bounds the daemon version probe. Defaults to 2 seconds.
 	DaemonTimeout time.Duration
+
+	// ProbeDaemonVersion queries the running daemon's version. Defaults to a
+	// DaemonTimeout-bounded RPC-socket probe.
+	//
+	// Injectable for the same reason install.Options.ProbeDaemonVersion is
+	// (copy.go/update.go): without a seam, every RunDoctor test dials whatever
+	// real socket daemon.DefaultLayout() resolves to on the developer's
+	// machine. On macOS a test's t.Setenv("HOME", tmp) happens to isolate that;
+	// on Linux with XDG_RUNTIME_DIR set (internal/daemon/paths_unix.go) HOME is
+	// not consulted at all, so a developer with a live daemon got a real
+	// version comparison against the test's fake install.json and the daemon
+	// checks failed. CI passed only because CI runs no daemon.
+	ProbeDaemonVersion DaemonVersionProbeFunc
 
 	// SkillsDir is the primary Claude skills directory.
 	// When empty it is derived from ClaudeConfigDirs or auto-detected from HOME.
@@ -139,6 +151,9 @@ func (o *DoctorOptions) applyDefaults() error {
 	}
 	if o.DaemonTimeout == 0 {
 		o.DaemonTimeout = 2 * time.Second
+	}
+	if o.ProbeDaemonVersion == nil {
+		o.ProbeDaemonVersion = boundedDaemonVersionProbe(o.DaemonTimeout)
 	}
 	return nil
 }
@@ -196,7 +211,7 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	report.Checks = append(report.Checks, checkCLI(state))
 
 	// ── Check 2: Daemon version via the RPC socket (#6072) ──────────────────
-	report.Checks = append(report.Checks, checkDaemon(state, defaultDaemonVersionProbe))
+	report.Checks = append(report.Checks, checkDaemon(state, opts.ProbeDaemonVersion))
 
 	// ── Check 2b: Engine liveness + version skew (ADR-0024 PR5/PR6, epic #5729) ──
 	// Monolith-aware: when the escape hatch (GRAFEL_SPLIT_MODE=0) puts the

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -6,7 +6,7 @@
 // against live state across five surfaces:
 //
 //   - CLI binary SHA-256 (Critical)
-//   - Daemon /healthz reachability + version (Critical)
+//   - Daemon RPC-socket reachability + version (Critical)
 //   - Skills per-file SHA manifests (Critical)
 //   - MCP registration in detected .claude.json files (Critical)
 //   - Conventions per-file SHA manifests (Warning)
@@ -20,7 +20,6 @@ package install
 
 import (
 	"bufio"
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -101,12 +100,16 @@ type DoctorOptions struct {
 	// ClaudeConfigDirs overrides .claude.json auto-detection (same flag as install).
 	ClaudeConfigDirs []string
 
-	// DaemonPort is the HTTP port for the daemon's /healthz endpoint.
-	// Defaults to 47274.
+	// DaemonPort is the daemon's dashboard HTTP port. Defaults to 47274.
+	//
+	// #6072: the daemon version check no longer uses it — it reads the RPC
+	// socket, because /healthz is not a registered route and an HTTP probe of
+	// it returns the dashboard SPA's index.html. Retained because it is part of
+	// the exported options surface and is still the port other tooling reports.
 	DaemonPort int
 
-	// DaemonTimeout is the maximum wait for the /healthz call.
-	// Defaults to 2 seconds.
+	// DaemonTimeout is the maximum wait for an HTTP daemon probe.
+	// Defaults to 2 seconds. See DaemonPort re: #6072.
 	DaemonTimeout time.Duration
 
 	// SkillsDir is the primary Claude skills directory.
@@ -192,8 +195,8 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	// ── Check 1: CLI binary SHA ─────────────────────────────────────────────
 	report.Checks = append(report.Checks, checkCLI(state))
 
-	// ── Check 2: Daemon /healthz ────────────────────────────────────────────
-	report.Checks = append(report.Checks, checkDaemon(state, opts.DaemonPort, opts.DaemonTimeout))
+	// ── Check 2: Daemon version via the RPC socket (#6072) ──────────────────
+	report.Checks = append(report.Checks, checkDaemon(state, defaultDaemonVersionProbe))
 
 	// ── Check 2b: Engine liveness + version skew (ADR-0024 PR5/PR6, epic #5729) ──
 	// Monolith-aware: when the escape hatch (GRAFEL_SPLIT_MODE=0) puts the
@@ -340,67 +343,68 @@ func isGitDirAFile(dir string) bool {
 	return !info.IsDir()
 }
 
-// healthzResponse is a minimal struct for parsing the /healthz JSON body.
-type healthzResponse struct {
-	Version string `json:"version"`
-}
-
-// checkDaemon probes /healthz and validates the version against install.json.
-func checkDaemon(state *State, port int, timeout time.Duration) CheckResult {
+// checkDaemon probes the daemon's RPC socket and validates the version it
+// reports against install.json.
+//
+// #6072: this used to GET http://127.0.0.1:<port>/healthz. That route does not
+// exist — the daemon registers no /healthz handler, so the request fell through
+// to the dashboard SPA catch-all and came back HTTP 200 with ~900 bytes of
+// index.html. json.Unmarshal failed on the HTML, the plain-text fallback stuffed
+// the ENTIRE document into the version field, and `grafel doctor` printed the
+// dashboard's HTML as "running=". (Dormant until #6070: before it every install
+// rolled back, so install.json had no DaemonVersion and the `!= ""` guard never
+// let the comparison run.)
+//
+// Hardening the HTML parse was not an option worth taking: there is no /healthz
+// endpoint to harden, so rejecting HTML would leave every healthy daemon
+// reporting "returned no version" forever — a permanent false warning in place
+// of a wrong one. The RPC socket is this package's own designated version
+// authority (defaultDaemonVersionProbe, already used by install step 4), it is
+// not shadowable by the SPA, and since #6071 it carries a STRUCTURED
+// VersionBare. Reusing it therefore also replaces the raw string equality with
+// the normalised probedReleaseIdentity/releaseIdentity comparison #6070
+// established as the correct one — the decorated display string the daemon
+// reports could never equal the bare tag install.json records.
+func checkDaemon(state *State, probe DaemonVersionProbeFunc) CheckResult {
 	cr := CheckResult{Surface: "daemon", OK: true}
 
-	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", port)
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	probed, err := probe()
 	if err != nil {
+		// Socket dial / Ping failed: the daemon is not answering at all. That is
+		// the same class of failure the old "daemon unreachable" branch reported.
 		cr.OK = false
 		cr.Severity = SeverityCritical
-		cr.Drift = []string{fmt.Sprintf("build request: %v", err)}
+		cr.Drift = []string{fmt.Sprintf("daemon unreachable via RPC socket: %v", err)}
 		return cr
 	}
 
-	client := &http.Client{Timeout: timeout}
-	resp, err := client.Do(req)
-	if err != nil {
-		cr.OK = false
-		cr.Severity = SeverityCritical
-		cr.Drift = []string{fmt.Sprintf("daemon unreachable at %s: %v", url, err)}
-		return cr
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		cr.OK = false
-		cr.Severity = SeverityCritical
-		cr.Drift = []string{fmt.Sprintf("daemon /healthz returned HTTP %d", resp.StatusCode)}
-		return cr
-	}
-
-	body, _ := io.ReadAll(resp.Body)
-	// Try to parse JSON version response; also accept plain text version.
-	var hzResp healthzResponse
-	if jerr := json.Unmarshal(body, &hzResp); jerr != nil {
-		// Plain text fallback.
-		hzResp.Version = strings.TrimSpace(string(body))
-	}
-
-	if hzResp.Version == "" {
-		cr.Drift = append(cr.Drift, "daemon /healthz returned no version")
-		// Warning only — daemon is up but didn't report version.
+	// looksLikeVersion is the load-bearing guard of #6072: whatever the version
+	// channel hands back, an HTML document (or any multi-line / bracketed blob)
+	// must never be echoed as the running version.
+	running := strings.TrimSpace(probed.Display)
+	if !looksLikeVersion(running) {
 		cr.OK = false
 		cr.Severity = SeverityWarning
+		cr.Drift = []string{"daemon reported no usable version"}
 		return cr
 	}
 
-	// If install.json recorded a daemon version, compare.
-	if state.DaemonVersion != "" && hzResp.Version != state.DaemonVersion {
-		cr.OK = false
-		cr.Severity = SeverityWarning
-		cr.Drift = []string{fmt.Sprintf("daemon version mismatch: running=%s installed=%s", hzResp.Version, state.DaemonVersion)}
+	if state.DaemonVersion == "" {
+		return cr
 	}
 
+	// Compare RELEASE IDENTITIES, not raw strings (#6070): the daemon reports a
+	// decorated descriptor ("v0.2.1 (commit …, built …)") while install.json
+	// records the bare tag, so raw equality can never succeed.
+	runningID, basis := probedReleaseIdentity(probed)
+	installedID := releaseIdentity(state.DaemonVersion)
+	if runningID != installedID {
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf(
+			"daemon version mismatch: running=%s (release %q, %s) installed=%s (release %q)",
+			running, runningID, basis, state.DaemonVersion, installedID)}
+	}
 	return cr
 }
 
@@ -1009,8 +1013,10 @@ func checkEngineLiveness(state *State, deps engineLivenessDeps) CheckResult {
 		return cr
 	}
 
-	// Version skew: serve's own recorded binary_version (install.json,
-	// refreshed from /healthz on restart — see checkDaemon) vs the engine
+	// Version skew: serve's own recorded binary_version (install.json, written
+	// by install/dev from the daemon-readiness probe — copy.go/dev.go set
+	// state.DaemonVersion; NOT from /healthz, which is not a route at all — see
+	// checkDaemon and #6072) vs the engine
 	// child's self-reported version in the liveness statusfile. Only
 	// meaningful in split mode (we already know engine.pid is present here);
 	// in monolith mode there's a single binary so this branch is unreachable.

--- a/internal/install/doctor_daemon_6072_test.go
+++ b/internal/install/doctor_daemon_6072_test.go
@@ -1,0 +1,143 @@
+package install
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// spaIndexHTML is the dashboard's index.html, which is what an unmatched
+// GET /healthz actually receives: the daemon registers no /healthz route, so
+// the request falls through to the SPA catch-all and comes back HTTP 200 with
+// ~900 bytes of HTML instead of a version.
+const spaIndexHTML = `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>grafel</title>
+    <script type="module" crossorigin src="/assets/index-a1b2c3d4.js"></script>
+    <link rel="stylesheet" href="/assets/index-e5f6a7b8.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>
+`
+
+func stubProbe(p ProbedVersion, err error) DaemonVersionProbeFunc {
+	return func() (ProbedVersion, error) { return p, err }
+}
+
+// Issue #6072: `grafel doctor` printed the dashboard's index.html as the
+// daemon's running version. checkDaemon GET /healthz — a route that does not
+// exist — json.Unmarshal failed on the HTML that came back, the plain-text
+// fallback stuffed the ENTIRE document into the version field, and line 397
+// compared that blob against install.json's DaemonVersion and printed it.
+//
+// checkDaemon now reads the RPC socket instead, but the invariant that actually
+// protects the user is independent of the channel: whatever the version source
+// hands back, an HTML document must never surface as a version.
+//
+// MUTATION ORACLE: delete the looksLikeVersion guard in checkDaemon → this test
+// fails with the HTML document quoted in the drift message.
+func TestCheckDaemon_NeverReportsHTMLAsTheRunningVersion(t *testing.T) {
+	state := &State{DaemonVersion: "v0.2.1"}
+
+	cr := checkDaemon(state, stubProbe(ProbedVersion{Display: spaIndexHTML}, nil))
+
+	if cr.OK {
+		t.Fatal("checkDaemon reported OK for a daemon that returned no usable version")
+	}
+	for _, d := range cr.Drift {
+		if strings.ContainsAny(d, "<>") || strings.Contains(d, "doctype") || strings.Contains(d, "\n") {
+			t.Fatalf("doctor reported HTML as a version string; drift = %q", d)
+		}
+	}
+}
+
+// A healthy daemon whose decorated display version names the SAME release as
+// install.json must pass. This is the case the old raw-string comparison could
+// never satisfy (#6070): the daemon reports "v0.2.1 (commit …, built …)" while
+// install.json records the bare tag "v0.2.1".
+//
+// MUTATION ORACLE: compare `running != state.DaemonVersion` instead of the
+// release identities → this test fails with a spurious version mismatch.
+func TestCheckDaemon_DecoratedDisplayMatchingInstalledReleaseIsOK(t *testing.T) {
+	state := &State{DaemonVersion: "v0.2.1"}
+	probed := ProbedVersion{
+		Display: "v0.2.1 (commit f2fb8c315, built 2026-08-01T11:08:38Z)",
+		Bare:    "v0.2.1",
+	}
+	cr := checkDaemon(state, stubProbe(probed, nil))
+	if !cr.OK {
+		t.Fatalf("healthy matching daemon flagged as drift: %v", cr.Drift)
+	}
+}
+
+// The structured VersionBare is the comparison basis when present, and the
+// display string is the fallback for pre-v0.2.1 daemons that omit it.
+func TestCheckDaemon_ComparisonBasis(t *testing.T) {
+	t.Run("bare field used when present", func(t *testing.T) {
+		state := &State{DaemonVersion: "v0.2.1"}
+		cr := checkDaemon(state, stubProbe(ProbedVersion{
+			Display: "v0.2.1 (commit abc, built 2026-08-01T00:00:00Z)",
+			Bare:    "v0.2.1",
+		}, nil))
+		if !cr.OK {
+			t.Fatalf("want OK, got drift %v", cr.Drift)
+		}
+	})
+	t.Run("display parsed when bare is absent", func(t *testing.T) {
+		state := &State{DaemonVersion: "v0.2.1"}
+		cr := checkDaemon(state, stubProbe(ProbedVersion{
+			Display: "v0.2.1 (commit abc, built 2026-08-01T00:00:00Z)",
+		}, nil))
+		if !cr.OK {
+			t.Fatalf("want OK for a pre-VersionBare daemon on the same release, got drift %v", cr.Drift)
+		}
+	})
+}
+
+// A genuinely stale daemon must still be caught — the fix must not make the
+// check unconditionally green.
+//
+// MUTATION ORACLE: drop the release comparison → this test fails (no drift
+// reported for a daemon two releases behind).
+func TestCheckDaemon_GenuineVersionSkewIsReported(t *testing.T) {
+	state := &State{DaemonVersion: "v0.2.1"}
+	cr := checkDaemon(state, stubProbe(ProbedVersion{
+		Display: "v0.1.9 (commit deadbee, built 2026-07-01T00:00:00Z)",
+		Bare:    "v0.1.9",
+	}, nil))
+	if cr.OK {
+		t.Fatal("a daemon running v0.1.9 against an installed v0.2.1 was reported OK")
+	}
+	if cr.Severity != SeverityWarning {
+		t.Fatalf("severity = %v, want warning", cr.Severity)
+	}
+	joined := strings.Join(cr.Drift, " ")
+	if !strings.Contains(joined, "v0.1.9") || !strings.Contains(joined, "v0.2.1") {
+		t.Fatalf("drift does not name both versions: %q", joined)
+	}
+}
+
+// An unreachable daemon is a critical failure, not a version warning.
+func TestCheckDaemon_UnreachableIsCritical(t *testing.T) {
+	state := &State{DaemonVersion: "v0.2.1"}
+	cr := checkDaemon(state, stubProbe(ProbedVersion{}, errors.New("dial unix: no such file or directory")))
+	if cr.OK {
+		t.Fatal("unreachable daemon reported OK")
+	}
+	if cr.Severity != SeverityCritical {
+		t.Fatalf("severity = %v, want critical", cr.Severity)
+	}
+}
+
+// With no recorded DaemonVersion there is nothing to compare against; a live
+// daemon reporting a plausible version must not be flagged.
+func TestCheckDaemon_NoInstalledVersionSkipsComparison(t *testing.T) {
+	cr := checkDaemon(&State{}, stubProbe(ProbedVersion{Display: "v0.2.1", Bare: "v0.2.1"}, nil))
+	if !cr.OK {
+		t.Fatalf("want OK when install.json records no daemon version, got drift %v", cr.Drift)
+	}
+}

--- a/internal/install/doctor_pingstub_6072_test.go
+++ b/internal/install/doctor_pingstub_6072_test.go
@@ -1,0 +1,81 @@
+package install
+
+import (
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+)
+
+// shortSocketPath returns a bindable Unix-socket path.
+//
+// t.TempDir() is unusable here: on macOS $TMPDIR is
+// /var/folders/<hash>/<hash>/T/ and the test name is appended, which puts the
+// path well past the 104-byte sun_path limit — bind fails with EINVAL. When
+// that failure was a t.Skip, every socket test in this package silently
+// skipped and the package still reported ok.
+func shortSocketPath(t *testing.T, name string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("/tmp", "gf")
+	if err != nil {
+		t.Fatalf("mkdtemp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(dir) })
+	return filepath.Join(dir, name)
+}
+
+// pingStubService answers Daemon.Ping with a canned reply — a real net/rpc
+// service over a real Unix socket, so the probe exercises the same
+// DialPath+Ping path production uses rather than a hand-rolled fake.
+type pingStubService struct{ reply proto.PingReply }
+
+func (s *pingStubService) Ping(_ proto.PingArgs, out *proto.PingReply) error {
+	*out = s.reply
+	return nil
+}
+
+// pingStubSocket serves Daemon.Ping on a temporary Unix socket and returns its
+// path plus the ProbedVersion a correct probe should extract from it.
+func pingStubSocket(t *testing.T, display, bare string) (string, ProbedVersion) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket ping stub; the Windows named-pipe equivalent is not modelled here")
+	}
+	sock := shortSocketPath(t, "p")
+
+	srv := rpc.NewServer()
+	if err := srv.RegisterName(proto.ServiceName, &pingStubService{
+		reply: proto.PingReply{Version: display, VersionBare: bare},
+	}); err != nil {
+		t.Fatalf("register ping stub: %v", err)
+	}
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		// NOT a skip. A skip here is how this whole file silently passed while
+		// testing nothing: t.TempDir() under $TMPDIR blew past the 104-byte
+		// sun_path limit, every bind failed, and the package reported ok.
+		t.Fatalf("bind unix socket %s: %v", sock, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	go func() {
+		for {
+			conn, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			// ServeCodec on OUR server, not jsonrpc.ServeConn (which would use
+			// the process-global default rpc.Server and leak registrations
+			// between tests).
+			go srv.ServeCodec(jsonrpc.NewServerCodec(conn))
+		}
+	}()
+
+	return sock, ProbedVersion{Display: display, Bare: bare}
+}

--- a/internal/install/doctor_probe_timeout_6072_test.go
+++ b/internal/install/doctor_probe_timeout_6072_test.go
@@ -1,0 +1,129 @@
+package install
+
+import (
+	"net"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// wedgedSocket starts a Unix listener that ACCEPTS connections and then never
+// writes a byte — the wedged-daemon state. This is not the same as a daemon
+// that is down: a missing socket fails instantly at os.Stat, and a refused
+// connection fails instantly at dial. A wedged daemon completes the dial and
+// then blocks the caller forever on the read, and it is precisely the state
+// someone runs `grafel doctor` to diagnose.
+func wedgedSocket(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("unix-socket wedged-daemon stub; the Windows named-pipe equivalent is not modelled here")
+	}
+	sock := shortSocketPath(t, "s")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		// Fatal, never Skip — see shortSocketPath.
+		t.Fatalf("bind unix socket %s: %v", sock, err)
+	}
+	t.Cleanup(func() { _ = ln.Close() })
+
+	done := make(chan struct{})
+	t.Cleanup(func() { close(done) })
+	go func() {
+		for {
+			conn, aerr := ln.Accept()
+			if aerr != nil {
+				return
+			}
+			// Hold the connection open and answer nothing.
+			go func(c net.Conn) {
+				<-done
+				_ = c.Close()
+			}(conn)
+		}
+	}()
+	return sock
+}
+
+// H-1 (issue #6072 review): moving the version check from HTTP to the RPC
+// socket dropped the only timeout on it. dclient.DialPath bounds the DIAL at
+// 2s, but Ping() sets no deadline and net/rpc/jsonrpc sets none either — there
+// is no SetDeadline anywhere on that path (internal/daemon/pidfile.go:51 is the
+// codebase's own precedent for adding one). The old HTTP probe was hard-capped
+// by DoctorOptions.DaemonTimeout; the RPC probe was capped by nothing, so
+// `grafel doctor` hung forever against a wedged daemon.
+//
+// MUTATION ORACLE: call the underlying dial+Ping directly instead of routing
+// through probeDaemonVersionWithin → this test fails on its 8s watchdog.
+func TestDaemonVersionProbe_TimesOutAgainstAWedgedDaemon(t *testing.T) {
+	sock := wedgedSocket(t)
+
+	const budget = 300 * time.Millisecond
+	start := time.Now()
+
+	returned := make(chan error, 1)
+	go func() {
+		_, err := probeDaemonVersionWithin(budget, sock)
+		returned <- err
+	}()
+
+	select {
+	case err := <-returned:
+		if err == nil {
+			t.Fatal("probe against a wedged daemon returned success")
+		}
+		if elapsed := time.Since(start); elapsed > 4*time.Second {
+			t.Fatalf("probe took %s to give up on a %s budget", elapsed, budget)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("probe did not return after 8s against a wedged daemon — grafel doctor hangs forever")
+	}
+}
+
+// checkDaemon must surface the wedged daemon as an unreachable-class failure
+// rather than hanging or reporting OK.
+func TestCheckDaemon_WedgedDaemonIsCriticalNotAHang(t *testing.T) {
+	sock := wedgedSocket(t)
+	probe := func() (ProbedVersion, error) { return probeDaemonVersionWithin(300*time.Millisecond, sock) }
+
+	done := make(chan CheckResult, 1)
+	go func() { done <- checkDaemon(&State{DaemonVersion: "v0.2.1"}, probe) }()
+
+	select {
+	case cr := <-done:
+		if cr.OK {
+			t.Fatal("wedged daemon reported OK")
+		}
+		if cr.Severity != SeverityCritical {
+			t.Fatalf("severity = %v, want critical", cr.Severity)
+		}
+	case <-time.After(8 * time.Second):
+		t.Fatal("checkDaemon did not return after 8s against a wedged daemon")
+	}
+}
+
+// The bounded probe must not turn a HEALTHY daemon's normal latency into a
+// spurious timeout, and must still reject an implausible (HTML) version.
+func TestDaemonVersionProbe_BoundedProbeStillReadsAHealthyDaemon(t *testing.T) {
+	sock, want := pingStubSocket(t, "v0.2.1 (commit abc, built 2026-08-01T00:00:00Z)", "v0.2.1")
+
+	got, err := probeDaemonVersionWithin(5*time.Second, sock)
+	if err != nil {
+		t.Fatalf("probe against a healthy daemon: %v", err)
+	}
+	if got.Display != want.Display {
+		t.Fatalf("Display = %q, want %q", got.Display, want.Display)
+	}
+	if got.Bare != want.Bare {
+		t.Fatalf("Bare = %q, want %q", got.Bare, want.Bare)
+	}
+}
+
+// A daemon answering with the SPA's HTML must be rejected by the probe itself,
+// not just by checkDaemon's backstop.
+func TestDaemonVersionProbe_RejectsImplausibleVersion(t *testing.T) {
+	sock, _ := pingStubSocket(t, spaIndexHTML, "")
+
+	if _, err := probeDaemonVersionWithin(5*time.Second, sock); err == nil {
+		t.Fatal("probe accepted an HTML document as a version")
+	}
+}

--- a/internal/install/doctor_test.go
+++ b/internal/install/doctor_test.go
@@ -16,6 +16,7 @@ package install_test
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,14 +142,29 @@ func newDoctorTestEnv(t *testing.T) *doctorTestEnv {
 	}
 }
 
-func runDoctor(t *testing.T, env *doctorTestEnv, port int) *install.DoctorReport {
+// daemonDownProbe stands in for a daemon that is not running — the state every
+// test in this file wants for the daemon check.
+//
+// It replaces the old `runDoctor(t, env, 1)` "port 1 is non-routable" premise,
+// which became vacuous when the daemon check moved off HTTP (#6072): the port
+// argument no longer reached the daemon check at all, so these tests were
+// passing for a reason unrelated to what they claimed. Worse, with no seam they
+// dialled whatever real socket daemon.DefaultLayout() resolved to — isolated on
+// macOS only by t.Setenv("HOME"), and not at all on Linux with XDG_RUNTIME_DIR
+// set, where a developer running a live grafel daemon saw the daemon check come
+// back Warning (version mismatch vs the fake v1.0.0-test) instead of Critical.
+func daemonDownProbe() (install.ProbedVersion, error) {
+	return install.ProbedVersion{}, errors.New("daemon not running: socket missing")
+}
+
+func runDoctor(t *testing.T, env *doctorTestEnv, probe install.DaemonVersionProbeFunc) *install.DoctorReport {
 	t.Helper()
 	opts := install.DoctorOptions{
-		StatePath:        env.statePath,
-		ClaudeConfigDirs: []string{env.claudeJSON},
-		DaemonPort:       port,
-		DaemonTimeout:    200 * time.Millisecond,
-		SkillsDir:        env.skillsDir,
+		StatePath:          env.statePath,
+		ClaudeConfigDirs:   []string{env.claudeJSON},
+		DaemonTimeout:      200 * time.Millisecond,
+		ProbeDaemonVersion: probe,
+		SkillsDir:          env.skillsDir,
 	}
 	report, err := install.RunDoctor(opts)
 	if err != nil {
@@ -170,13 +186,12 @@ func findCheck(report *install.DoctorReport, surface string) *install.CheckResul
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 // TestDoctorHappyPath: clean install state, daemon down, all file checks pass.
-// Daemon will be unreachable (we use port 0 or a closed port) — the daemon
-// check is Critical so OK will be false, but CLI + skills + MCP should pass.
-// We verify those surfaces individually.
+// The injected probe reports the daemon as down, so the daemon check is
+// Critical and report.OK is false — but CLI + skills + MCP + gitignore must all
+// pass. We verify those surfaces individually.
 func TestDoctorHappyPath_NoLiveDaemon(t *testing.T) {
 	env := newDoctorTestEnv(t)
-	// Use port 1 — guaranteed unreachable without root.
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	// CLI check must pass.
 	cli := findCheck(report, "cli")
@@ -232,7 +247,7 @@ func TestDoctorCLITamper(t *testing.T) {
 		t.Fatalf("tamper binary: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	cli := findCheck(report, "cli")
 	if cli == nil {
@@ -269,7 +284,7 @@ func TestDoctorMissingCLIRecordCritical(t *testing.T) {
 		t.Fatalf("write state: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 	cli := findCheck(report, "cli")
 	if cli == nil {
 		t.Fatal("cli check missing")
@@ -292,7 +307,7 @@ func TestDoctorSkillTamper(t *testing.T) {
 		t.Fatalf("tamper SKILL.md: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	skillSurface := "skills/" + env.skillName
 	skill := findCheck(report, skillSurface)
@@ -329,7 +344,7 @@ func TestDoctorSkillMissingFile(t *testing.T) {
 		t.Fatalf("remove SKILL.md: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	skillSurface := "skills/" + env.skillName
 	skill := findCheck(report, skillSurface)
@@ -350,12 +365,18 @@ func TestDoctorSkillMissingFile(t *testing.T) {
 	}
 }
 
-// TestDoctorDaemonOffline: daemon not running → check reports unreachable cleanly (no panic).
+// TestDoctorDaemonOffline: daemon not running → check reports unreachable
+// cleanly (no panic), as Critical rather than a version Warning.
+//
+// The premise is now the injected probe's failure, not a port number. It used
+// to be "port 1 is non-routable without root", which stopped meaning anything
+// once the daemon check moved to the RPC socket (#6072) — RunDoctor never
+// passed the port to it again, so this test was asserting Critical while the
+// real determinant was whatever socket happened to exist on the machine.
 func TestDoctorDaemonOffline(t *testing.T) {
 	env := newDoctorTestEnv(t)
 
-	// Port 1 is non-routable without root — will fail immediately.
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	daemon := findCheck(report, "daemon")
 	if daemon == nil {
@@ -369,6 +390,11 @@ func TestDoctorDaemonOffline(t *testing.T) {
 	}
 	if len(daemon.Drift) == 0 {
 		t.Error("daemon check should report drift message")
+	}
+	// The drift must come from the probe we injected — proof the seam is
+	// actually wired, not that some ambient socket produced a similar verdict.
+	if joined := strings.Join(daemon.Drift, " "); !strings.Contains(joined, "socket missing") {
+		t.Errorf("daemon drift %q does not carry the injected probe error", joined)
 	}
 
 	// report.OK can be false (daemon critical) — that's expected.
@@ -386,7 +412,7 @@ func TestDoctorMCPDrift(t *testing.T) {
 		t.Fatalf("overwrite .claude.json: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	mcp := findCheck(report, "mcp")
 	if mcp == nil {
@@ -406,7 +432,7 @@ func TestDoctorGitignoreMissing(t *testing.T) {
 		t.Fatalf("overwrite .gitignore: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	gitSurface := "gitignore/" + filepath.Base(env.gitRepo)
 	git := findCheck(report, gitSurface)
@@ -436,7 +462,7 @@ func TestDoctorStaleStagingDirs(t *testing.T) {
 		t.Fatalf("chtimes: %v", err)
 	}
 
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	staging := findCheck(report, "staging")
 	if staging == nil {
@@ -482,7 +508,7 @@ func TestDoctorMissingInstallJSON(t *testing.T) {
 // TestDoctorJSONOutput: --json output is valid JSON with schema_version=1.
 func TestDoctorJSONOutput(t *testing.T) {
 	env := newDoctorTestEnv(t)
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	// Marshal to JSON.
 	b, err := json.Marshal(report)
@@ -512,7 +538,7 @@ func TestDoctorJSONOutput(t *testing.T) {
 // TestDoctorJSONSchema: verify required fields are present and stable.
 func TestDoctorJSONSchema(t *testing.T) {
 	env := newDoctorTestEnv(t)
-	report := runDoctor(t, env, 1)
+	report := runDoctor(t, env, daemonDownProbe)
 
 	b, err := json.MarshalIndent(report, "", "  ")
 	if err != nil {


### PR DESCRIPTION
`grafel doctor` reported the dashboard SPA's HTML as the daemon's running version:

```
daemon version mismatch: running=<!doctype html>\n<html lang="en">\n … </html> installed=v0.2.1
```

`checkDaemon` GETs `/healthz`, which **has no route registered anywhere**, so it falls through to the SPA catch-all and returns HTTP 200 with `index.html`. `json.Unmarshal` fails, `hzResp.Version` ends up holding the entire HTML body, and it is compared against `state.DaemonVersion`.

**Newly activated:** before #6070 every install rolled back, so `install.json` carried no `DaemonVersion` and the `!= ""` guard kept this dormant. Installs now succeed, so it fires on real machines.

## Why the version check moved to the RPC socket rather than being hardened

The cheap containment — reject HTML at the parse — is not actually cheap. There is no `/healthz` route to harden, so a parse guard would leave **every healthy daemon** permanently reporting "returned no version" (`OK=false`, warning). That trades a wrong answer for a standing false alarm on every `grafel doctor` run.

Independently verified in review: no `/healthz` handler exists in Go (only test fixtures match the string), `internal/dashboard/server.go` holds the only `Handle("/")` catch-all, and `copy.go:103-110` already documents the SPA rejection from #5596.

The RPC socket is the package's own designated version authority (`defaultDaemonVersionProbe`, already used by install step 4), is not SPA-shadowable, and carries a structured `VersionBare` since #6071. Moving to it also lets the comparison reuse `probedReleaseIdentity`/`releaseIdentity`, removing the raw string equality that #6070 proved can never succeed — decorated display versus bare tag.

## Two defects the review caught in the first version

**`grafel doctor` hung indefinitely against a wedged daemon.** `DialPath` bounds only the *dial* at 2s. `Ping()` sets no deadline, and `internal/daemon/jsonrpc` sets none either — zero `SetDeadline` hits in the package. Demonstrated: against a listener that accepts and never replies, `checkDaemon` did not return after 8 seconds. The old HTTP path was hard-capped by `DaemonTimeout`; the new one had no cap at all. That regression landed precisely on the tool you reach for **when the daemon is misbehaving**.

Fixed by `probeDaemonVersionWithin(timeout, socketPath)`, which runs `Ping()` in a goroutine and selects against a timer. On expiry it **closes the client** — with no read deadline reachable through `net/rpc/jsonrpc`, tearing down the conn is the only way to abort an in-flight `Ping`, and it lets the goroutine return rather than leak. The result channel is buffered so the goroutine always delivers and exits.

`defaultDaemonVersionProbe` now delegates to it at 2s, so **install step 4 gets the same cap** — it had the identical unbounded hang.

**The probe seam was removed from `RunDoctor`,** which hid a real test defect. `checkDaemon` took an injectable probe but `RunDoctor` hardcoded the default, so every `RunDoctor` test dialled whatever real socket `daemon.DefaultLayout()` resolved to. On macOS `t.Setenv("HOME", tmp)` accidentally isolated it; on Linux with `XDG_RUNTIME_DIR` set, `HOME` is irrelevant and a developer with a live daemon would see `TestDoctorDaemonOffline` fail. CI passed only because CI has no daemon.

`DoctorOptions.ProbeDaemonVersion` is now defaulted in `applyDefaults` to a `DaemonTimeout`-bounded probe. The vacuous "port 1 is non-routable" premise was **fixed rather than deleted**: `runDoctor(t, env, port)` → `runDoctor(t, env, probe)` across all 12 call sites, and `TestDoctorDaemonOffline` now asserts the drift carries the injected probe's error, so it fails if the seam is bypassed.

## Verification

The timeout oracle is verified in **both** directions. Mutating the timer to 24h:

```
--- FAIL: TestDaemonVersionProbe_TimesOutAgainstAWedgedDaemon (8.00s)
    probe did not return after 8s against a wedged daemon — grafel doctor hangs forever
--- FAIL: TestCheckDaemon_WedgedDaemonIsCriticalNotAHang (8.00s)
```

With the fix, both return in 0.30s against a 300ms budget. The healthy-daemon and HTML-rejection tests pass under *both* variants — a genuine control proving the timeout is not a false positive.

Other mutants, all killed: `looksLikeVersion` → `running == ""` (HTML document printed in drift); release identities → raw strings (a healthy matching daemon flagged as drift); comparison deleted (genuine v0.1.9-vs-v0.2.1 skew reported OK); `probedReleaseIdentity` → bare-only, dropping the Display fallback; the probe seam reverted to the hardcoded default.

**A harness artifact caught during the work, worth recording:** the first draft of the socket tests used `t.TempDir()`, which on macOS exceeds the 104-byte `sun_path` limit. Every `net.Listen("unix", ...)` failed, every test `t.Skip`'d, and the package reported `ok` **while testing nothing**. Fixed with a short socket path under `/tmp`, and bind failure is now `t.Fatal`, never `t.Skip`. The suite's zero-skip count is the standing check on that.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `./internal/install/...` exit 0, **0 FAIL, 0 SKIP**, verified independently rather than taken from the report.

Independently adversarially reviewed.

## Recorded, not fixed here

`RunQuickDoctor` still GETs `/healthz` and checks only the status code. It never misreports a version, but since no route exists it can only detect a dead HTTP listener — never a wedged daemon. Filed as #6095.

The `doctor.go:1013` comment correction is right in substance: `install.json`'s `binary_version` comes from `copy.go:688`/`dev.go:273`, not from `/healthz`. Strictly, the dev path's value flows through `waitForDaemonReady`, where `copy.go:1022` does consult `/healthz` as an optional enrichment — but `defaultHealthzGet` rejects the HTML content-type, so it never fires in practice.

Closes #6072
