### PR TITLE
fix(#6010): carry the load-failure record through evict/revive

### DIFF
--- a/internal/mcp/evict_loaderr_6010_test.go
+++ b/internal/mcp/evict_loaderr_6010_test.go
@@ -1,0 +1,115 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// Issue #6010 follow-up: coldShellRepo drops loadErr (and the sibling
+// reindexRequired/reindexReason). A repo whose graph failed to load is reported
+// as unavailable WITH its reason before an eviction; after a keepReader
+// evict -> revive cycle the LoadedRepo is rebuilt from the cold shell, which
+// never carried loadErr, so both real consumers degrade:
+//
+//   - handleGraphStats (tools.go) renders totals.unavailable entries as
+//     name + ": " + r.loadErr -> "broken: " with nothing after the colon.
+//   - handleDiagnostics (dashboard_tools.go) sets LoadError: lr.loadErr, which
+//     is `json:"load_error,omitempty"` -> the field vanishes from the payload.
+//
+// This is a BEHAVIOURAL test: it drives the real revive path
+// (State.Group -> reviveEvictedLocked -> rematerializeFromReader) and asserts
+// on what the two user-facing tool handlers actually emit.
+//
+// MUTATION ORACLE: delete the `loadErr: lr.loadErr` line from coldShellRepo and
+// both assertions below red again.
+func TestEvictRevive_PreservesLoadErrorForConsumers_6010(t *testing.T) {
+	const wantErr = "read graph.fb: unexpected EOF"
+
+	// Isolate the status-plane scan handleGraphStats performs: without this it
+	// walks the developer's real $GRAFEL_HOME (seconds of I/O, and results that
+	// vary per machine). Nothing this test asserts on comes from there.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"broken": {Path: t.TempDir()}}},
+	}}
+	st := NewState(reg)
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{Name: "test", Repos: map[string]*LoadedRepo{
+		// Exactly the shape reloadLocked leaves behind when readDocumentFromDir
+		// fails: no Doc, no Reader, a recorded load error (+ the version-skew
+		// observability pair, which travels with the same failed reload).
+		"broken": {
+			Repo:            "broken",
+			loadErr:         wantErr,
+			reindexRequired: true,
+			reindexReason:   "graph.fb format v3 < required v5",
+		},
+	}}
+	st.mu.Unlock()
+	srv := &Server{State: st, Tel: NewTelemetry(0)}
+
+	// Baseline: before any eviction both consumers surface the reason.
+	assertLoadErrSurfaced(t, srv, "pre-evict", wantErr)
+
+	if !st.EvictGroup("test", true) {
+		t.Fatal("EvictGroup(keepReader) returned false")
+	}
+	// Revive on demand: State.Group -> reviveEvictedLocked -> rematerializeFromReader.
+	if lg := st.Group("test"); lg == nil {
+		t.Fatal("revive returned a nil group")
+	}
+
+	// The regression: the same two consumers must still surface the SAME reason.
+	assertLoadErrSurfaced(t, srv, "post-revive", wantErr)
+
+	// The sibling version-skew observability must survive the cycle too.
+	st.mu.Lock()
+	rr := st.groups["test"].Repos["broken"]
+	st.mu.Unlock()
+	if !rr.reindexRequired || rr.reindexReason == "" {
+		t.Errorf("post-revive: reindexRequired=%v reindexReason=%q, want true + non-empty",
+			rr.reindexRequired, rr.reindexReason)
+	}
+}
+
+// assertLoadErrSurfaced drives both real consumers and checks each reports the
+// broken repo's load error verbatim.
+func assertLoadErrSurfaced(t *testing.T, srv *Server, phase, wantErr string) {
+	t.Helper()
+
+	// Consumer 1: grafel_diagnostics -> repos[].load_error.
+	diag := callDashboardTool(t, srv.handleDiagnostics, map[string]any{"group": "test"})
+	repos, _ := diag["repos"].([]any)
+	if len(repos) != 1 {
+		t.Fatalf("%s: diagnostics returned %d repos, want 1", phase, len(repos))
+	}
+	r0, _ := repos[0].(map[string]any)
+	if got, _ := r0["load_error"].(string); got != wantErr {
+		t.Errorf("%s: diagnostics load_error = %q, want %q", phase, got, wantErr)
+	}
+
+	// Consumer 2: grafel_stats -> totals.unavailable[] ("<repo>: <reason>").
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test"}
+	res, err := srv.handleGraphStats(context.Background(), req)
+	if err != nil {
+		t.Fatalf("%s: handleGraphStats: %v", phase, err)
+	}
+	// handleGraphStats returns the totals map itself as the JSON body.
+	totals := extractResultJSON(t, res)
+	unavail, _ := totals["unavailable"].([]any)
+	if len(unavail) != 1 {
+		t.Fatalf("%s: stats unavailable = %v, want 1 entry", phase, totals["unavailable"])
+	}
+	entry, _ := unavail[0].(string)
+	if want := "broken: " + wantErr; entry != want {
+		t.Errorf("%s: stats unavailable[0] = %q, want %q", phase, entry, want)
+	}
+	if strings.HasSuffix(entry, ": ") {
+		t.Errorf("%s: stats unavailable[0] = %q — reason lost, colon with nothing after it", phase, entry)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -2130,6 +2130,22 @@ func coldShellRepo(lr *LoadedRepo) *LoadedRepo {
 		// (rebuilding the LabelIndex side-table dropped with the heap) is the shell
 		// group's algoApplied=false, set in EvictGroup — not a spurious stale mtime.
 		algoStampedMt: lr.algoStampedMt,
+		// #6010 follow-up: the LAST-reload failure record must survive the cycle.
+		// A keepReader eviction does NOT re-read graph.fb — the shell inherits the
+		// exact same (possibly stale, possibly absent) Doc/Reader — so the reason
+		// the load failed is still the current truth about this repo. Dropping it
+		// silently degrades both consumers: handleGraphStats renders
+		// totals.unavailable as "<repo>: "+loadErr → a bare "repo: ", and
+		// handleDiagnostics's `load_error,omitempty` field disappears entirely.
+		// reindexRequired/reindexReason are the version-skew half of that same
+		// failure record and travel with it for the same reason.
+		//
+		// Contrast with descApplied/flowApplied/curRef* (deliberately NOT copied):
+		// those are memo caches whose absence merely forces a correct re-apply /
+		// re-resolve on revive, exactly like the forced algoApplied=false.
+		loadErr:         lr.loadErr,
+		reindexRequired: lr.reindexRequired,
+		reindexReason:   lr.reindexReason,
 	}
 }
 


### PR DESCRIPTION
Recorded as a follow-up when #6010 merged, fixed here.

`coldShellRepo` (`internal/mcp/state.go`) builds the shell kept when a repo is evicted with `keepReader`. It dropped `loadErr`, so after an evict→revive cycle a repo whose graph failed to load was still correctly listed as unavailable but **with no reason**: `handleGraphStats` rendered `"<repo>: "` — a colon with nothing after it — and `handleDiagnostics`'s `load_error` field vanished entirely under `omitempty`.

Message degradation rather than silence, which is why it did not block #6010.

## Why these three fields and not the others

The field set was enumerated against the `LoadedRepo` struct rather than eyeballed. Three categories:

- **Deliberately dropped — the point of the cold shell:** `LabelIndex`, `BM25`, `hotIdx`, and every lazy derived index with its `sync.Once` (`adjacency`, `callsAdj`, `byID`, `suffixIndex`, `mroInbound`, …). Mutexes are zero-value-usable and correctly not copied.
- **Deliberately dropped — memo caches:** `descApplied`/`descStampedMt`, `flowApplied`/`flowOverlay`, `curRefDir`/`curRefKnown`. Their absence forces a correct re-apply on revive, mirroring the intentional `algoApplied=false` in `EvictGroup`. Left alone.
- **Wrongly dropped — the last-reload failure record:** `loadErr`, `reindexRequired`, `reindexReason`.

The third group is the fix. A `keepReader` eviction does **not** re-read `graph.fb` — the shell inherits the same `Doc`/`Reader` — so the recorded reason the load failed is still current truth about that repo, not a stale cache. `rematerializeFromReader` only rebuilds `LabelIndex` and resets the derived indexes; it never touches `loadErr`, so whatever the shell carries is what survives.

The reasoning is recorded in a comment at the copy site, including the contrast with the memo caches, because "which dropped field is a bug and which is the design" is exactly what made this defect survive the original fix.

**Stated plainly:** `reindexRequired`/`reindexReason` currently have **zero readers** in the tree — unexported, written only in `reloadLocked`, and the struct comment says "detection + observability only". They are not user-visible today. They are copied because they are the version-skew half of the same failure record, and having half of it survive a revive is a latent trap for whichever reader lands next.

## Revive path

`State.Group` → miss in `s.groups`, hit in `s.evicted` → `reviveGateLocked` → `reviveEvictedLocked` → per-repo `rematerializeFromReader`.

Worth noting because #6010's own triage listed the wrong call sites; this one was traced rather than assumed.

## Verification

Behavioural, through both real consumers — not a source scan. Three source-scanning guards written in this repo recently all fell to trivial mutants.

The test builds a `Server`, asserts both consumers **pre-evict** so the baseline is known to pass, then drives `EvictGroup("test", true)` → `State.Group("test")` and re-asserts. Red on unfixed `main`, with the pre-evict assertions silent and every failure post-revive:

```
post-revive: diagnostics load_error = "", want "read graph.fb: unexpected EOF"
post-revive: stats unavailable[0] = "broken: ", want "broken: read graph.fb: unexpected EOF"
post-revive: stats unavailable[0] = "broken: " — reason lost, colon with nothing after it
post-revive: reindexRequired=false reindexReason="", want true + non-empty
```

Mutants: removing the `loadErr` copy returns 3 failures across both consumers; additionally removing the reindex pair returns the 4th.

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. `go test -count=1 -p 1 ./internal/mcp/...` exit 0 — **1343 PASS, 0 FAIL, 8 SKIP**, counted from `-v` output rather than a summary. All 8 skips are pre-existing and env/fixture-gated.

## Found while doing this, filed separately

`handleGraphStats` walks the real `$GRAFEL_HOME` via `statusfile.ReadAll` / `daemon.EngineLivenessStatus`. Unisolated, this test took **35.5s**; with `t.Setenv("GRAFEL_HOME", t.TempDir())` it is 0.00s. Other tests exercising that handler do not isolate it either — both a chunk of the package's 103s wall time and a machine-dependent-results risk.

Refs #6010
