### PR TITLE
fix(#6037): compare parity as multisets, not sets

### DIFF
--- a/cmd/grafel/diff_reindex_multiset_test.go
+++ b/cmd/grafel/diff_reindex_multiset_test.go
@@ -1,0 +1,313 @@
+// Package main — diff_reindex_multiset_test.go
+//
+// #6037: the parity comparator compared SETS, not multisets. This file is the
+// demonstration that the multiset conversion is a real instrument and not a
+// notional one: it runs the actual incremental path over a 40-file Go corpus,
+// reads the persisted graph back off disk, and shows that
+//
+//   - the graph the incremental path PERSISTS carries duplicate relationship
+//     rows (#6094), and
+//   - the new multiset comparator reports them, while the pre-#6037 set-based
+//     comparator — reproduced verbatim below — reports parity on the very same
+//     pair of documents.
+//
+// Both directions of that demonstration matter. A new comparator that fires on a
+// fixture where the old one also fired proves nothing.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/parity"
+)
+
+// ───────────────────── the pre-#6037 (set-based) comparator ─────────────────
+//
+// Reproduced from internal/graph/parity/parity.go@65c50e0a9: entities and
+// relationships were keyed into map[string]T, so N rows sharing an identity
+// collapsed into ONE slot and the last writer won. dvLegacySetDiffs is that
+// algorithm, run over the same raw documents the new comparator sees — not a
+// pre-deduplicated stand-in, which would make its verdict tautological.
+
+func dvLegacyEntityKey(e graph.Entity) string {
+	id := e.ID
+	if id == "" {
+		id = graph.EntityID("", e.Kind, e.Name, e.SourceFile)
+	}
+	return fmt.Sprintf("%s|%s|%s|%s|%s", id, e.Kind, e.Name, e.QualifiedName, e.SourceFile)
+}
+
+func dvLegacyRelKey(r graph.Relationship) string {
+	return r.FromID + "→" + r.ToID + ":" + r.Kind
+}
+
+// dvLegacySetDiffs returns the number of divergences the OLD comparator would
+// report: entities/relationships present on exactly one side, plus per-key
+// property drift on the surviving (last-write-wins) representative.
+func dvLegacySetDiffs(a, b *graph.Document) int {
+	entA := map[string]graph.Entity{}
+	for _, e := range a.Entities {
+		entA[dvLegacyEntityKey(e)] = e
+	}
+	entB := map[string]graph.Entity{}
+	for _, e := range b.Entities {
+		entB[dvLegacyEntityKey(e)] = e
+	}
+	relA := map[string]graph.Relationship{}
+	for _, r := range a.Relationships {
+		relA[dvLegacyRelKey(r)] = r
+	}
+	relB := map[string]graph.Relationship{}
+	for _, r := range b.Relationships {
+		relB[dvLegacyRelKey(r)] = r
+	}
+
+	n := 0
+	for k, ea := range entA {
+		eb, ok := entB[k]
+		if !ok {
+			n++
+			continue
+		}
+		if ea.Signature != eb.Signature || ea.StartLine != eb.StartLine || ea.EndLine != eb.EndLine {
+			n++
+		}
+	}
+	for k := range entB {
+		if _, ok := entA[k]; !ok {
+			n++
+		}
+	}
+	for k, ra := range relA {
+		rb, ok := relB[k]
+		if !ok {
+			n++
+			continue
+		}
+		if dvRenderProps(ra.PropsSnapshot()) != dvRenderProps(rb.PropsSnapshot()) {
+			n++
+		}
+	}
+	for k := range relB {
+		if _, ok := relA[k]; !ok {
+			n++
+		}
+	}
+	return n
+}
+
+func dvRenderProps(m map[string]string) string {
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	out := ""
+	for _, k := range ks {
+		out += k + "=" + m[k] + ";"
+	}
+	return out
+}
+
+// ─────────────────────────────── the fixture ────────────────────────────────
+
+// dvMultisetCorpusFile is one file of the 40-file corpus: a struct, an
+// interface, a method, a constructor and two plain functions. The richer shape
+// matters — a corpus of bare functions does not exercise the pass that appends
+// the duplicate rows.
+//
+// Every file gets a UNIQUE basename on purpose: diff.Filter cross-invalidates
+// same-basename files, so a corpus of 40 files all called f.go turns a 1-file
+// delta into a 40-file change and trips the too-many-changed full-reindex
+// fallback, silently making the case vacuous.
+func dvMultisetCorpusFile(i int) string {
+	return fmt.Sprintf(`package svc
+
+type T%d struct{ N int }
+
+type I%d interface{ Do() int }
+
+func (t *T%d) Do() int { return t.N + h%d() }
+
+func h%d() int { return %d }
+
+func New%d() *T%d { return &T%d{N: %d} }
+
+func Use%d(x I%d) int { return x.Do() }
+`, i, i, i, i, i, i, i, i, i, i, i, i)
+}
+
+// dvDuplicateRows returns the number of SURPLUS rows (rows beyond the first for
+// each identity key) in doc, plus a sorted sample of the duplicated keys.
+func dvDuplicateRows(doc *graph.Document) (dupEnts, dupRels int, sample []string) {
+	ce := map[string]int{}
+	for _, e := range doc.Entities {
+		ce[dvLegacyEntityKey(e)]++
+	}
+	for _, n := range ce {
+		if n > 1 {
+			dupEnts += n - 1
+		}
+	}
+	cr := map[string]int{}
+	for _, r := range doc.Relationships {
+		cr[dvLegacyRelKey(r)]++
+	}
+	for k, n := range cr {
+		if n > 1 {
+			dupRels += n - 1
+			sample = append(sample, fmt.Sprintf("%s ×%d", k, n))
+		}
+	}
+	sort.Strings(sample)
+	return dupEnts, dupRels, sample
+}
+
+// dvCollapseToSet returns a copy of doc with duplicate rows collapsed — one row
+// per identity key, keeping the LAST occurrence exactly as the pre-#6037 map
+// build did. This is the reference document: it differs from doc in MULTIPLICITY
+// AND NOTHING ELSE, which is what isolates the dimension under test.
+func dvCollapseToSet(doc *graph.Document) *graph.Document {
+	out := &graph.Document{}
+	entIdx := map[string]int{}
+	for _, e := range doc.Entities {
+		k := dvLegacyEntityKey(e)
+		if i, ok := entIdx[k]; ok {
+			out.Entities[i] = e
+			continue
+		}
+		entIdx[k] = len(out.Entities)
+		out.Entities = append(out.Entities, e)
+	}
+	relIdx := map[string]int{}
+	for _, r := range doc.Relationships {
+		k := dvLegacyRelKey(r)
+		if i, ok := relIdx[k]; ok {
+			out.Relationships[i] = r
+			continue
+		}
+		relIdx[k] = len(out.Relationships)
+		out.Relationships = append(out.Relationships, r)
+	}
+	return out
+}
+
+// ───────────────────────────── the demonstration ────────────────────────────
+
+// TestDiffReindex_MultisetComparatorCatchesDuplicateRows is the #6037 acceptance
+// case, run against the real #6094 defect.
+//
+// It builds a 40-file corpus, full-rebuilds it, then applies three SEQUENTIAL
+// single-file deltas, each followed by a real TryIncremental pass, and reads the
+// persisted graph.fb back with LoadGraphFromDir. The duplicates asserted here
+// are rows ON DISK, not entries in a run log.
+//
+// (Issue #6094 states the duplicates are "silently absorbed by the writer's
+// dedupe" and that the persisted graph is correct. That is not what this fixture
+// observes: fbwriter dedupes shared STRINGS, not rows, and the surplus rows
+// survive into graph.fb — and COMPOUND, one more copy per incremental pass.)
+func TestDiffReindex_MultisetComparatorCatchesDuplicateRows(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	const nFiles = 40
+	for i := 0; i < nFiles; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), dvMultisetCorpusFile(i))
+	}
+
+	dvFullRebuild(t, repo, stateDir)
+
+	// The full rebuild is the control: it must carry NO duplicate rows, so the
+	// duplication below is attributable to the incremental path.
+	base, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if de, dr, sample := dvDuplicateRows(base); de != 0 || dr != 0 {
+		t.Fatalf("control violated: the FULL rebuild already carries duplicate rows (%d entity, %d relationship): %v",
+			de, dr, sample)
+	}
+
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "r07.go", fmt.Sprintf(`package svc
+
+type T7 struct{ N int }
+
+type I7 interface{ Do() int }
+
+func (t *T7) Do() int { return t.N + h7() + %d }
+
+func h7() int { return 7 }
+
+func New7() *T7 { return &T7{N: 7} }
+
+func Use7(x I7) int { return x.Do() }
+`, pass))
+		dvIncremental(t, repo, stateDir)
+	}
+
+	// B is the graph the incremental path PERSISTED — read back off disk.
+	b, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load incremental graph: %v", err)
+	}
+	dupEnts, dupRels, sample := dvDuplicateRows(b)
+	t.Logf("persisted incremental graph: %d entities, %d relationships; surplus rows: %d entity, %d relationship\nduplicated keys: %v",
+		len(b.Entities), len(b.Relationships), dupEnts, dupRels, sample)
+	if dupEnts+dupRels == 0 {
+		t.Fatalf("fixture no longer reproduces #6094: the persisted incremental graph carries no duplicate rows. " +
+			"Either the defect is fixed (delete this fixture and keep the parity unit cases) or the corpus stopped " +
+			"exercising the pass that duplicates — do NOT weaken the comparator to keep this green")
+	}
+
+	// A is B with duplicate rows collapsed. A and B therefore differ in
+	// MULTIPLICITY AND NOTHING ELSE — no entity is added or dropped, no property
+	// drifts, no community is relabelled. Anything a comparator reports here is
+	// the duplication and only the duplication.
+	a := dvCollapseToSet(b)
+
+	// ── Direction 1: the NEW comparator sees it ──────────────────────────────
+	rep := parity.CompareWithOptions(a, b, dvBaselineProfile())
+	if rep.Equivalent {
+		t.Fatalf("the multiset comparator reported parity between a graph with %d surplus rows and the same graph without them:\n%s",
+			dupEnts+dupRels, rep.String())
+	}
+	if len(rep.RelMultiplicityDiffs) == 0 && len(rep.EntityMultiplicityDiffs) == 0 {
+		t.Fatalf("duplication must be reported in the row-count buckets, got:\n%s", rep.String())
+	}
+	// Every reported row-count diff must be a real duplicate key, and every real
+	// duplicate key must be reported — no over- or under-reporting.
+	if got, want := len(rep.RelMultiplicityDiffs), len(sample); got != want {
+		t.Errorf("RelMultiplicityDiffs=%d, want %d (one per duplicated relationship key)\nreport:\n%s",
+			got, want, rep.String())
+	}
+	// Nothing OTHER than multiplicity may be reported — the two documents are
+	// identical in every other dimension by construction, so a diff elsewhere
+	// means the comparator gained a false positive.
+	if len(rep.EntitiesOnlyInA)+len(rep.EntitiesOnlyInB)+len(rep.EntityFieldDiffs)+
+		len(rep.RelsOnlyInA)+len(rep.RelsOnlyInB)+len(rep.RelPropDiffs)+
+		len(rep.CommunityAssignmentDiffs) != 0 {
+		t.Errorf("comparator reported a non-multiplicity divergence between a graph and its own de-duplicated copy:\n%s", rep.String())
+	}
+	t.Logf("NEW multiset comparator correctly reports the duplication:\n%s", rep.String())
+
+	// ── Direction 2: the OLD set comparator is blind to it ───────────────────
+	// Sanity first: the legacy comparator is not blind to EVERYTHING — it does
+	// catch a dropped row, so a verdict of "parity" below is about multiplicity
+	// specifically and not about a broken stand-in.
+	maimed := &graph.Document{
+		Entities:      a.Entities,
+		Relationships: a.Relationships[:len(a.Relationships)-1],
+	}
+	if n := dvLegacySetDiffs(a, maimed); n == 0 {
+		t.Fatal("the legacy set comparator stand-in is inert — it fails to report even a dropped edge")
+	}
+	if n := dvLegacySetDiffs(a, b); n != 0 {
+		t.Fatalf("premise of #6037 does not hold on this fixture: the legacy set comparator reported %d divergence(s) "+
+			"between a graph and its de-duplicated copy; the multiset conversion would not be what caught this", n)
+	}
+	t.Logf("OLD set-based comparator reports PARITY on the same pair (%d surplus rows invisible to it)", dupEnts+dupRels)
+}

--- a/internal/graph/parity/multiset_test.go
+++ b/internal/graph/parity/multiset_test.go
@@ -1,0 +1,168 @@
+package parity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// These cases pin #6037: the comparator must compare MULTISETS, not sets. A set
+// comparison collapses duplicate rows into one map slot and is structurally
+// incapable of seeing a duplication defect (#6094 persists duplicate entity and
+// relationship rows into graph.fb on the incremental path).
+//
+// Every case asserts BOTH directions — a one-directional comparison reports a
+// subset as parity.
+
+func rel(from, to, kind string, props map[string]string) graph.Relationship {
+	r := graph.Relationship{FromID: from, ToID: to, Kind: kind}
+	if props != nil {
+		r = r.WithProperties(props)
+	}
+	return r
+}
+
+// TestCompare_DetectsDuplicateRelationshipRow_Invented is the #6094 shape: the
+// incremental graph carries the SAME edge twice where a full rebuild carries it
+// once.
+func TestCompare_DetectsDuplicateRelationshipRow_Invented(t *testing.T) {
+	a := &graph.Document{Relationships: []graph.Relationship{
+		rel("x", "y", "CALLS", nil),
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		rel("x", "y", "CALLS", nil),
+		rel("x", "y", "CALLS", nil), // duplicate row
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("a duplicated relationship row must NOT be reported as parity")
+	}
+	if len(rep.RelMultiplicityDiffs) != 1 {
+		t.Fatalf("RelMultiplicityDiffs=%+v want 1", rep.RelMultiplicityDiffs)
+	}
+	d := rep.RelMultiplicityDiffs[0]
+	if !strings.Contains(d.Key, "x→y:CALLS") {
+		t.Errorf("diff should name the edge, got %q", d.Key)
+	}
+	if !strings.Contains(d.Detail, "1") || !strings.Contains(d.Detail, "2") {
+		t.Errorf("diff should carry both counts, got %q", d.Detail)
+	}
+	if !strings.Contains(rep.String(), "x→y:CALLS") {
+		t.Errorf("String() must render the multiplicity diff:\n%s", rep.String())
+	}
+}
+
+// TestCompare_DetectsDuplicateRelationshipRow_Lost is the other direction: a
+// LOST duplicate row (the reference has two, the candidate one). A comparator
+// that only checks A→B presence reports this subset as parity.
+func TestCompare_DetectsDuplicateRelationshipRow_Lost(t *testing.T) {
+	a := &graph.Document{Relationships: []graph.Relationship{
+		rel("x", "y", "CALLS", nil),
+		rel("x", "y", "CALLS", nil),
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		rel("x", "y", "CALLS", nil),
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("a LOST duplicate relationship row must NOT be reported as parity")
+	}
+	if len(rep.RelMultiplicityDiffs) != 1 {
+		t.Fatalf("RelMultiplicityDiffs=%+v want 1", rep.RelMultiplicityDiffs)
+	}
+}
+
+// TestCompare_EqualRelationshipMultiplicityIsEquivalent guards the false-positive
+// side the issue calls out: the FULL path legitimately emits distinct
+// relationships sharing a RelationshipID (extractor.go's `?mv` multi-value
+// edges). The correct assertion is "multiplicities are EQUAL", never "every
+// multiplicity is 1".
+func TestCompare_EqualRelationshipMultiplicityIsEquivalent(t *testing.T) {
+	mk := func() []graph.Relationship {
+		return []graph.Relationship{
+			rel("run", "handler", "CALLS", map[string]string{"line": "8"}),
+			rel("run", "handler", "CALLS", map[string]string{"line": "9", "via_value": "true"}),
+		}
+	}
+	a := &graph.Document{Relationships: mk()}
+	// b lists the same two rows in the OPPOSITE order — the comparator must be
+	// order-independent, not last-write-wins.
+	rb := mk()
+	rb[0], rb[1] = rb[1], rb[0]
+	b := &graph.Document{Relationships: rb}
+	if rep := Compare(a, b); !rep.Equivalent {
+		t.Fatalf("equal multiplicities with equal property sets must be equivalent:\n%s", rep.String())
+	}
+}
+
+// TestCompare_DuplicateIDGroupPropertyDriftIsCaught closes the last-write-wins
+// hole: two rows share a key on both sides, but one side's property set differs.
+// The old map-collapsing comparator kept whichever row landed last, so this was
+// detected or missed depending purely on slice order.
+func TestCompare_DuplicateIDGroupPropertyDriftIsCaught(t *testing.T) {
+	a := &graph.Document{Relationships: []graph.Relationship{
+		rel("run", "handler", "CALLS", map[string]string{"line": "8"}),
+		rel("run", "handler", "CALLS", map[string]string{"line": "9"}),
+	}}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		rel("run", "handler", "CALLS", map[string]string{"line": "8"}),
+		rel("run", "handler", "CALLS", map[string]string{"line": "10"}), // drifted
+	}}
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("property drift inside a duplicate-key group must be caught")
+	}
+	if len(rep.RelPropDiffs) != 1 {
+		t.Fatalf("RelPropDiffs=%+v want 1", rep.RelPropDiffs)
+	}
+	// And with the drifted row FIRST — the result must be identical, not order-dependent.
+	b.Relationships[0], b.Relationships[1] = b.Relationships[1], b.Relationships[0]
+	if rep2 := Compare(a, b); rep2.Equivalent || len(rep2.RelPropDiffs) != 1 {
+		t.Fatalf("order-dependent result: equivalent=%v diffs=%+v", rep2.Equivalent, rep2.RelPropDiffs)
+	}
+}
+
+// TestCompare_DetectsDuplicateEntityRow — #6094 persists duplicate ENTITY rows
+// too, and compareEntities collapses them the same way.
+func TestCompare_DetectsDuplicateEntityRow(t *testing.T) {
+	e := ent("SCOPE.Operation", "Alpha", "a.go")
+	a := &graph.Document{Entities: []graph.Entity{e}}
+	b := &graph.Document{Entities: []graph.Entity{e, e}}
+
+	rep := Compare(a, b)
+	if rep.Equivalent {
+		t.Fatal("a duplicated entity row must NOT be reported as parity")
+	}
+	if len(rep.EntityMultiplicityDiffs) != 1 {
+		t.Fatalf("EntityMultiplicityDiffs=%+v want 1", rep.EntityMultiplicityDiffs)
+	}
+	if !strings.Contains(rep.EntityMultiplicityDiffs[0].Key, "Alpha") {
+		t.Errorf("diff should name the entity, got %q", rep.EntityMultiplicityDiffs[0].Key)
+	}
+
+	// Reverse direction.
+	rep = Compare(b, a)
+	if rep.Equivalent || len(rep.EntityMultiplicityDiffs) != 1 {
+		t.Fatalf("LOST duplicate entity row not reported: equivalent=%v diffs=%+v", rep.Equivalent, rep.EntityMultiplicityDiffs)
+	}
+}
+
+// TestCompare_OnlyInListsCarryMultiplicity — when a key is absent from one side
+// entirely, the count on the present side is still load-bearing information
+// (three invented copies is not the same defect as one).
+func TestCompare_OnlyInListsCarryMultiplicity(t *testing.T) {
+	a := &graph.Document{}
+	b := &graph.Document{Relationships: []graph.Relationship{
+		rel("x", "y", "CALLS", nil),
+		rel("x", "y", "CALLS", nil),
+		rel("x", "y", "CALLS", nil),
+	}}
+	rep := Compare(a, b)
+	if len(rep.RelsOnlyInB) != 1 {
+		t.Fatalf("RelsOnlyInB=%v want 1 entry", rep.RelsOnlyInB)
+	}
+	if !strings.Contains(rep.RelsOnlyInB[0], "×3") {
+		t.Errorf("only-in entry should carry the count, got %q", rep.RelsOnlyInB[0])
+	}
+}

--- a/internal/graph/parity/parity.go
+++ b/internal/graph/parity/parity.go
@@ -24,9 +24,17 @@
 //
 // Design
 // ──────
-//   - Order-independent: everything is set/map compared, never slice-index
-//     compared. Two documents that list the same entities in a different order
-//     are equivalent.
+//   - Order-independent: everything is grouped by identity key, never
+//     slice-index compared. Two documents that list the same entities in a
+//     different order are equivalent.
+//   - MULTISET, not set (#6037). Rows are grouped, not overwritten, so a graph
+//     carrying a row N times does NOT compare equal to one carrying it once.
+//     This is the dimension the comparator was blind to while the incremental
+//     path persisted duplicate entity and relationship rows (#6094), and the
+//     dimension a duplicated edge's DEPENDS_ON weight over-count rides on
+//     (#6098). Note the assertion is "multiplicities are EQUAL between A and
+//     B", never "every multiplicity is 1" — the full path legitimately emits
+//     distinct edges sharing a RelationshipID, so the latter would false-alarm.
 //   - Strict on graph STRUCTURE: entity identity + structural fields,
 //     relationship (from, to, kind) + properties, and per-entity community
 //     assignment.
@@ -99,6 +107,12 @@ type Report struct {
 	// structural fields differ, with a per-field description.
 	EntityFieldDiffs []FieldDiff
 
+	// EntityMultiplicityDiffs lists entity identities present in BOTH documents
+	// but a DIFFERENT NUMBER OF TIMES (#6037). A duplicated row is a real
+	// divergence: the incremental path persists it into graph.fb (#6094), and a
+	// set comparison is structurally incapable of seeing it.
+	EntityMultiplicityDiffs []FieldDiff
+
 	// RelsOnlyInA / RelsOnlyInB list relationship identities (from→to:kind)
 	// present in exactly one document.
 	RelsOnlyInA []string
@@ -106,6 +120,11 @@ type Report struct {
 
 	// RelPropDiffs lists relationships present in both whose properties differ.
 	RelPropDiffs []FieldDiff
+
+	// RelMultiplicityDiffs lists relationship identities present in BOTH
+	// documents but a DIFFERENT NUMBER OF TIMES (#6037 / #6094). See
+	// EntityMultiplicityDiffs.
+	RelMultiplicityDiffs []FieldDiff
 
 	// CommunityAssignmentDiffs lists entities whose community_id differs between
 	// the two documents (a community split / merge / relabel that drifted).
@@ -173,9 +192,11 @@ func (r Report) String() string {
 
 	writeList("entities only in A (full rebuild)", r.EntitiesOnlyInA)
 	writeList("entities only in B (incremental)", r.EntitiesOnlyInB)
+	writeFieldDiffs("entity row-count diffs", r.EntityMultiplicityDiffs)
 	writeFieldDiffs("entity field diffs", r.EntityFieldDiffs)
 	writeList("relationships only in A (full rebuild)", r.RelsOnlyInA)
 	writeList("relationships only in B (incremental)", r.RelsOnlyInB)
+	writeFieldDiffs("relationship row-count diffs", r.RelMultiplicityDiffs)
 	writeFieldDiffs("relationship property diffs", r.RelPropDiffs)
 	writeFieldDiffs("community assignment diffs", r.CommunityAssignmentDiffs)
 	writeList("community membership diffs", r.CommunitySetDiff)
@@ -208,9 +229,9 @@ func CompareWithOptions(a, b *graph.Document, opts Options) Report {
 	compareCommunities(a, b, &r)
 
 	if len(r.EntitiesOnlyInA) > 0 || len(r.EntitiesOnlyInB) > 0 ||
-		len(r.EntityFieldDiffs) > 0 ||
+		len(r.EntityFieldDiffs) > 0 || len(r.EntityMultiplicityDiffs) > 0 ||
 		len(r.RelsOnlyInA) > 0 || len(r.RelsOnlyInB) > 0 ||
-		len(r.RelPropDiffs) > 0 ||
+		len(r.RelPropDiffs) > 0 || len(r.RelMultiplicityDiffs) > 0 ||
 		len(r.CommunityAssignmentDiffs) > 0 || len(r.CommunitySetDiff) > 0 {
 		r.Equivalent = false
 	}
@@ -235,35 +256,83 @@ func entityKey(e graph.Entity) string {
 	return fmt.Sprintf("%s|%s|%s|%s|%s", id, e.Kind, e.Name, e.QualifiedName, e.SourceFile)
 }
 
+// compareEntities compares the two entity collections as MULTISETS (#6037).
+//
+// The pre-#6037 implementation keyed a map[string]graph.Entity, so N rows
+// sharing an identity collapsed into one slot: a graph carrying duplicate rows
+// (#6094 persists them into graph.fb on the incremental path) compared equal to
+// one carrying a single row, and the surviving row was whichever landed LAST in
+// slice order. Grouping instead of overwriting fixes both: row COUNT is compared
+// per key, and the field comparison over a duplicate group is order-independent.
 func compareEntities(a, b *graph.Document, r *Report, opts Options) {
-	mapA := make(map[string]graph.Entity, len(a.Entities))
-	for _, e := range a.Entities {
-		mapA[entityKey(e)] = e
-	}
-	mapB := make(map[string]graph.Entity, len(b.Entities))
-	for _, e := range b.Entities {
-		mapB[entityKey(e)] = e
-	}
+	mapA := groupEntities(a.Entities)
+	mapB := groupEntities(b.Entities)
 
-	for k, ea := range mapA {
-		eb, ok := mapB[k]
+	for k, ga := range mapA {
+		gb, ok := mapB[k]
 		if !ok {
-			r.EntitiesOnlyInA = append(r.EntitiesOnlyInA, k)
+			r.EntitiesOnlyInA = append(r.EntitiesOnlyInA, keyWithCount(k, len(ga)))
 			continue
 		}
-		if diff := entityStructuralDiff(ea, eb, opts); diff != "" {
+		if len(ga) != len(gb) {
+			r.EntityMultiplicityDiffs = append(r.EntityMultiplicityDiffs, FieldDiff{
+				Key:    k,
+				Detail: fmt.Sprintf("row count %d in A (full rebuild) ≠ %d in B (incremental)", len(ga), len(gb)),
+			})
+		}
+		if diff := entityGroupDiff(ga, gb, opts); diff != "" {
 			r.EntityFieldDiffs = append(r.EntityFieldDiffs, FieldDiff{Key: k, Detail: diff})
 		}
 	}
-	for k := range mapB {
+	for k, gb := range mapB {
 		if _, ok := mapA[k]; !ok {
-			r.EntitiesOnlyInB = append(r.EntitiesOnlyInB, k)
+			r.EntitiesOnlyInB = append(r.EntitiesOnlyInB, keyWithCount(k, len(gb)))
 		}
 	}
 
 	sort.Strings(r.EntitiesOnlyInA)
 	sort.Strings(r.EntitiesOnlyInB)
 	sortFieldDiffs(r.EntityFieldDiffs)
+	sortFieldDiffs(r.EntityMultiplicityDiffs)
+}
+
+func groupEntities(ents []graph.Entity) map[string][]graph.Entity {
+	m := make(map[string][]graph.Entity, len(ents))
+	for _, e := range ents {
+		k := entityKey(e)
+		m[k] = append(m[k], e)
+	}
+	return m
+}
+
+// entityGroupDiff compares two non-empty groups of entities sharing an identity
+// key. The 1:1 case (overwhelmingly the common one) delegates to
+// entityStructuralDiff so the message stays per-field and legible. For a
+// duplicate group it compares the SORTED structural signatures of each side, so
+// the answer depends on content rather than on which row happened to land last.
+func entityGroupDiff(ga, gb []graph.Entity, opts Options) string {
+	if len(ga) == 1 && len(gb) == 1 {
+		return entityStructuralDiff(ga[0], gb[0], opts)
+	}
+	sa := sortedSignatures(ga, func(e graph.Entity) string { return entitySignature(e, opts) })
+	sb := sortedSignatures(gb, func(e graph.Entity) string { return entitySignature(e, opts) })
+	if strings.Join(sa, " | ") == strings.Join(sb, " | ") {
+		return ""
+	}
+	return fmt.Sprintf("duplicate-key group differs: A=[%s] B=[%s]",
+		strings.Join(sa, " | "), strings.Join(sb, " | "))
+}
+
+// entitySignature renders exactly the fields entityStructuralDiff compares, in a
+// fixed order, so two entities are signature-equal iff that function reports no
+// diff between them.
+func entitySignature(e graph.Entity, opts Options) string {
+	tags := append([]string(nil), e.Tags...)
+	sort.Strings(tags)
+	return fmt.Sprintf("name=%s;qn=%s;kind=%s;subtype=%s;file=%s;lang=%s;sig=%s;lines=%d-%d;tags=%s;props=%s",
+		e.Name, e.QualifiedName, e.Kind, e.Subtype, e.SourceFile, e.Language, e.Signature,
+		e.StartLine, e.EndLine, strings.Join(tags, ","),
+		renderMap(filterMap(e.PropsSnapshot(), opts.IgnoreEntityProps)))
 }
 
 // entityStructuralDiff compares the structural (correctness-bearing) fields of
@@ -319,40 +388,74 @@ func compareRelationships(a, b *graph.Document, r *Report, opts Options) {
 	// gap) folds onto the entity it names. No-op unless NormalizeStubEndpoints.
 	resolver := newEndpointResolver(a, b, opts)
 
-	mapA := make(map[string]graph.Relationship, len(a.Relationships))
-	for _, rel := range a.Relationships {
-		if opts.IgnoreRelKinds[rel.Kind] {
-			continue
-		}
-		mapA[relKey(resolver(rel.FromID), resolver(rel.ToID), rel.Kind)] = rel
-	}
-	mapB := make(map[string]graph.Relationship, len(b.Relationships))
-	for _, rel := range b.Relationships {
-		if opts.IgnoreRelKinds[rel.Kind] {
-			continue
-		}
-		mapB[relKey(resolver(rel.FromID), resolver(rel.ToID), rel.Kind)] = rel
-	}
+	mapA := groupRelationships(a.Relationships, resolver, opts)
+	mapB := groupRelationships(b.Relationships, resolver, opts)
 
-	for k, ra := range mapA {
-		rb, ok := mapB[k]
+	for k, ga := range mapA {
+		gb, ok := mapB[k]
 		if !ok {
-			r.RelsOnlyInA = append(r.RelsOnlyInA, k)
+			r.RelsOnlyInA = append(r.RelsOnlyInA, keyWithCount(k, len(ga)))
 			continue
 		}
-		if d := stringMapDiff("properties", filterMap(ra.PropsSnapshot(), opts.IgnoreRelProps), filterMap(rb.PropsSnapshot(), opts.IgnoreRelProps)); d != "" {
+		if len(ga) != len(gb) {
+			r.RelMultiplicityDiffs = append(r.RelMultiplicityDiffs, FieldDiff{
+				Key:    k,
+				Detail: fmt.Sprintf("row count %d in A (full rebuild) ≠ %d in B (incremental)", len(ga), len(gb)),
+			})
+		}
+		if d := relGroupPropDiff(ga, gb, opts); d != "" {
 			r.RelPropDiffs = append(r.RelPropDiffs, FieldDiff{Key: k, Detail: d})
 		}
 	}
-	for k := range mapB {
+	for k, gb := range mapB {
 		if _, ok := mapA[k]; !ok {
-			r.RelsOnlyInB = append(r.RelsOnlyInB, k)
+			r.RelsOnlyInB = append(r.RelsOnlyInB, keyWithCount(k, len(gb)))
 		}
 	}
 
 	sort.Strings(r.RelsOnlyInA)
 	sort.Strings(r.RelsOnlyInB)
 	sortFieldDiffs(r.RelPropDiffs)
+	sortFieldDiffs(r.RelMultiplicityDiffs)
+}
+
+func groupRelationships(rels []graph.Relationship, resolver func(string) string, opts Options) map[string][]graph.Relationship {
+	m := make(map[string][]graph.Relationship, len(rels))
+	for _, rel := range rels {
+		if opts.IgnoreRelKinds[rel.Kind] {
+			continue
+		}
+		k := relKey(resolver(rel.FromID), resolver(rel.ToID), rel.Kind)
+		m[k] = append(m[k], rel)
+	}
+	return m
+}
+
+// relGroupPropDiff compares the properties of two non-empty groups of
+// relationships sharing a (from, to, kind) key.
+//
+// The duplicate-group case is real, not hypothetical: RelationshipID is
+// sha256(from, 0, to, 0, kind) with properties excluded BY DESIGN, and the Go
+// extractor deliberately emits distinct edges sharing that id (the `?mv`
+// multi-value call sites). The pre-#6037 comparator kept whichever row landed
+// last, making the property diff a function of slice order. Comparing the sorted
+// property signatures of the whole group makes it a function of content.
+func relGroupPropDiff(ga, gb []graph.Relationship, opts Options) string {
+	if len(ga) == 1 && len(gb) == 1 {
+		return stringMapDiff("properties",
+			filterMap(ga[0].PropsSnapshot(), opts.IgnoreRelProps),
+			filterMap(gb[0].PropsSnapshot(), opts.IgnoreRelProps))
+	}
+	sig := func(rel graph.Relationship) string {
+		return renderMap(filterMap(rel.PropsSnapshot(), opts.IgnoreRelProps))
+	}
+	sa := sortedSignatures(ga, sig)
+	sb := sortedSignatures(gb, sig)
+	if strings.Join(sa, " | ") == strings.Join(sb, " | ") {
+		return ""
+	}
+	return fmt.Sprintf("duplicate-key group properties differ: A=[%s] B=[%s]",
+		strings.Join(sa, " | "), strings.Join(sb, " | "))
 }
 
 // ──────────────────────────── communities ───────────────────────────
@@ -444,6 +547,53 @@ func communityLabel(e graph.Entity) string {
 }
 
 // ─────────────────────────── shared helpers ─────────────────────────
+
+// keyWithCount annotates a key present on exactly one side with its row count,
+// so "invented once" and "invented three times" are distinguishable in the
+// report. n==1 renders bare, keeping the common case's output unchanged.
+func keyWithCount(key string, n int) string {
+	if n <= 1 {
+		return key
+	}
+	return fmt.Sprintf("%s ×%d", key, n)
+}
+
+// sortedSignatures renders each element of a group via sig and returns the
+// DISTINCT results, sorted — an order-independent fingerprint of the group's
+// CONTENT. Repetition is deliberately dropped here: row COUNT is reported by its
+// own bucket (Entity/RelMultiplicityDiffs), so folding it in again would report
+// one defect twice.
+func sortedSignatures[T any](group []T, sig func(T) string) []string {
+	seen := make(map[string]struct{}, len(group))
+	out := make([]string, 0, len(group))
+	for _, v := range group {
+		s := sig(v)
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// renderMap renders a string map deterministically (sorted by key).
+func renderMap(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	ks := make([]string, 0, len(m))
+	for k := range m {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	parts := make([]string, 0, len(ks))
+	for _, k := range ks {
+		parts = append(parts, fmt.Sprintf("%s=%q", k, m[k]))
+	}
+	return "{" + strings.Join(parts, ", ") + "}"
+}
 
 func stringSliceDiff(name string, a, b []string) string {
 	sa := append([]string(nil), a...)


### PR DESCRIPTION
`internal/graph/parity` built `map[string]graph.Entity` and `map[string]graph.Relationship` and overwrote on collision. Both comparisons were over sets. A graph carrying a row once and a graph carrying the same row three times compared **Equivalent**, in both directions.

That is why `TestDiffReindex` never caught #6033, and it is why the duplicate rows in #6094 sail through parity as clean.

One correction to the issue: it names only `compareRelationships`. `compareEntities` has the identical defect and is fixed here too.

## The comparator was also order-dependent

Before any fix, `TestCompare_EqualRelationshipMultiplicityIsEquivalent` failed on the unfixed code with a **false positive**: two legitimately distinct edges sharing a `RelationshipID` — the `?mv` case #6037 describes — were reported as a property diff purely because of slice order, last-write-wins.

So the old comparator was blind in one direction and noisy in the other.

## Demonstrated on the real defect, in both directions

`cmd/grafel/diff_reindex_multiset_test.go`: 40-file Go corpus, full rebuild, then three sequential single-file deltas each through a real `TryIncremental`, graph read back via `LoadGraphFromDir`.

The persisted graph carries **9 surplus relationship rows across 3 keys**. The reference is that same graph with duplicate rows collapsed, so the pair differs in **multiplicity and nothing else**:

- **New comparator:** reports all 3 keys in `RelMultiplicityDiffs` with exact counts, and nothing else — asserted, so it cannot pass by reporting noise.
- **Old set comparator:** reports parity. It is reimplemented verbatim in the test over the same *raw* documents rather than a pre-deduplicated stand-in, and is itself checked against a dropped edge so its "parity" verdict is known to be about multiplicity and not an inert helper.

The full rebuild is asserted to carry zero surplus rows as a control.

## Three findings from building it

**1. #6094's stated mechanism is wrong, and the defect is worse than filed.** The issue says the duplicates are "silently absorbed by the writer's dedupe" and the persisted graph is correct. `fbwriter` dedupes shared **strings**, not rows. The surplus rows land in `graph.fb` — and they **compound, one additional copy per incremental pass**: 1 → 5 → 9 over three passes. That is unbounded growth on the default path for a watched repo, not a fixed offset.

**2. The duplication appears entangled with a known separate defect.** Every duplicate reproducible here is a `CONTAINS`/`REFERENCES` edge with an **empty `FromID`** — the import-placeholder-hoist gap already documented in `dvAssertModuleLayerParity`. Plain function corpora produce zero duplicates; structs, interfaces and methods are required. So this may not be an independent defect.

This also forced the fixture design: on a natural incremental-vs-full-rebuild comparison the old comparator *does* fire, on the empty-`FromID` divergence. Demonstrating against that would have proven nothing about multiplicity.

**3. A fixture hazard worth knowing.** `diff.Filter` cross-invalidates files by **basename**. A corpus where many files share a name turns a 1-file delta into an N-file change and trips the `too-many-changed` full-reindex fallback — silently making any such incremental test vacuous. The fixture uses unique basenames and documents why.

## Design note

Row **count** and row **content** are reported in separate buckets: `Entity`/`RelMultiplicityDiffs` for count, while duplicate-key groups compare sorted **distinct** signatures for content.

The first cut compared full multisets of signatures and double-reported every duplication — once as a count diff, and once as a bogus `properties differ: A=[{go}] B=[{go}|{go}|{go}]`. The split reports each defect exactly once.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. At `-count=1 -p 1`, exit codes captured directly:

| package | exit | skips |
|---|---|---|
| `./internal/graph/...` | 0 | **0** |
| `./cmd/grafel/` | 0 | 7 |
| `./internal/extractors/` | 0 | **0** |

454 tests run in `cmd/grafel`, 0 FAIL. All 7 skips are pre-existing env/fixture-gated benchmarks, untouched.

**No existing test went red.** The anticipated case — an existing parity test passing only because it collapsed duplicates — did not materialise; the `dvAssertParity` corpora are small single-package fixtures that produce no duplicates on the incremental path. Nothing was skipped, weakened, or adjusted to keep green.

#6094 and #6098 are deliberately left unfixed. This change builds the detector.

Closes #6037
Refs #6094, #6098, #6033
