### PR TITLE
feat(#5989): wire the 340 dead custom extractors into the in-process path, behind a default-off gate

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -3412,6 +3412,74 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 
 				ents, extractErr := extractors.Extract(ctx, file)
 
+				// #5989 — dispatch the custom/framework extractors registered
+				// under internal/custom/** (Django/DRF/Celery/Flask/FastAPI/
+				// SQLAlchemy + 20 other languages). They register under
+				// PREFIXED registry keys ("python_django"), which the exact-key
+				// Get(file.Language) lookup inside extractors.Extract above can
+				// never match — RunCustomExtractors is the only dispatcher that
+				// selects them.
+				//
+				// SEAM PLACEMENT IS LOAD-BEARING: this must sit AFTER
+				// extractors.Extract (so base entities exist to merge into) and
+				// BEFORE the TSTree.Close() below, because custom extractors
+				// walk the same parse tree. Moving it after the Close is a
+				// use-after-free, not merely a no-op.
+				//
+				// Default-OFF: see inProcCustomExtractors (cmd/grafel/inproc_custom.go)
+				// for why, and why this is NOT the same thing as flipping
+				// GRAFEL_SUBPROC_EXTRACT.
+				//
+				// THE GATE IS NOT PURELY ADDITIVE, AND NOT PYTHON-ONLY (#6104).
+				// MergeWithCustom supersedes by NAME, so a custom entity whose
+				// Name collides with a base entity REPLACES it. Measured effects
+				// per language on the #5989 fixtures:
+				//
+				//   python — Celery tasks destroy TWO base entities each
+				//            (Task + SCOPE.Operation), replaced by one
+				//            SCOPE.Service. A different-KIND collision.
+				//   java   — SCOPE.Operation is mutated IN PLACE: subtype
+				//            method->endpoint and EndLine truncated to the start
+				//            line, losing the body extent; the truncation
+				//            propagates into the derived http_endpoint_definition.
+				//            A SAME-KIND collision, so keying supersede on
+				//            (Kind, Name) would NOT fix it.
+				//   js     — route operations are REPLACED by better-positioned
+				//            ones (base emits them at line 0). An improvement,
+				//            but still a substitution, and invisible to any
+				//            count-based comparison.
+				//   go, ruby — genuinely inert; identical content tuples.
+				//
+				// The total loss set is 280 entities across 5 kinds and 2
+				// languages. This is the blocker for flipping the gate on by
+				// default; it is pinned by
+				// TestInProcCustomExtractorsSupersedeDestroysBaseEntities and
+				// TestInProcCustomExtractorsJavaEntityMutation. Do not flip the
+				// default until #6104 is closed.
+				//
+				// The `file.TSTree != nil` guard is load-bearing beyond avoiding
+				// a use-after-free: a subset of custom extractors work on file
+				// CONTENT and emit entities even with no parse tree, so without
+				// the guard a file that FAILED to parse would still produce
+				// custom entities. See
+				// TestInProcCustomExtractorsNilTreeGuardIsLoadBearing.
+				if inProcCustomExtractors() && file.TSTree != nil {
+					customEnts, customErrs := extractors.RunCustomExtractors(ctx, file)
+					if len(customErrs) > 0 && verbose() {
+						for _, ce := range customErrs {
+							fmt.Fprintf(os.Stderr, "custom extractor: %v\n", ce)
+						}
+					}
+					if len(customEnts) > 0 {
+						// MergeWithCustom applies the #4402 supersede
+						// semantics (carry base QualifiedName + structural
+						// edges onto the surviving custom entity) rather than
+						// a naive append; cross-kind dedup still happens
+						// downstream in deduplicateEntities.
+						ents = extractors.MergeWithCustom(ents, customEnts)
+					}
+				}
+
 				// #5954 — release the parse tree the moment its only consumer
 				// (the Pass-1 language extractor above) has returned. Mirrors
 				// internal/daemon/extract/subproc.go:446-453 ("this is what
@@ -3445,6 +3513,21 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				mu.Lock()
 				i.stats.processed++
 				if extractErr != nil {
+					// #5989 CAVEAT: `ents` is DISCARDED entirely on this branch —
+					// allRecords is only appended in the else below. When the
+					// custom-extractor gate is on, that means any file whose base
+					// extractor returned an error (notably
+					// ErrNoExtractorForLanguage) has already run ~340 custom
+					// extractors, allocated their output and merged it, only for
+					// all of it to be thrown away here.
+					//
+					// Two consequences: (a) wasted work proportional to the number
+					// of such files, and (b) a trap for anyone who later expects a
+					// language to be covered by custom extractors ALONE — that can
+					// never work while base failure discards the merged result.
+					// Deliberately left as-is: changing it would alter default-path
+					// behaviour for base-extractor failures, which is out of scope
+					// for a default-off gate.
 					if errors.Is(extractErr, extractors.ErrNoExtractorForLanguage) {
 						i.stats.skipped++
 					} else {

--- a/cmd/grafel/inproc_custom.go
+++ b/cmd/grafel/inproc_custom.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+// inProcCustomExtractors reports whether the DEFAULT in-process indexing path
+// should additionally dispatch the custom/framework extractors registered
+// under internal/custom/** (issue #5989).
+//
+// WHY THIS GATE EXISTS. ~340 framework extractors (Django/DRF/Celery/Flask/
+// FastAPI/SQLAlchemy plus 20 other languages, ~141k lines) register in the
+// shared extractor registry under PREFIXED keys — "python_django",
+// "custom_js_grafeo", … — while ordinary dispatch does an exact-key
+// Get(file.Language) lookup on "python". That lookup can never match a
+// prefixed key, so none of these extractors has ever run on the default path.
+// extractors.RunCustomExtractors is the only dispatcher that selects them, and
+// before this change its sole non-test caller sat behind GRAFEL_SUBPROC_EXTRACT
+// — an env var with zero writers anywhere in the tree. This was never
+// connected; it is not a regression.
+//
+// WHY IT IS DEFAULT-OFF. Epic #5954 exists to REDUCE indexing peak heap and
+// wall time; running 340 additional extractors per file moves both the wrong
+// way. The gate keeps default behaviour byte-for-byte unchanged so the cost
+// can be measured before anyone decides to flip it.
+//
+// NOT A FIX FOR GRAFEL_SUBPROC_EXTRACT. The two branches are disjoint, not
+// superset/subset: the subprocess branch leaves `classified` nil, which
+// silently disables ~12 framework post-passes, and on a Django fixture it is a
+// NET LOSS (entities 201→186, http_endpoint_definition 18→4). That hole is
+// tracked separately as #6102 and is out of scope here.
+func inProcCustomExtractors() bool {
+	v := strings.TrimSpace(os.Getenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS"))
+	return v == "1" || strings.EqualFold(v, "true") || strings.EqualFold(v, "yes")
+}

--- a/cmd/grafel/inproc_custom_extractors_5989_test.go
+++ b/cmd/grafel/inproc_custom_extractors_5989_test.go
@@ -1,0 +1,679 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Issue #5989 — the ~340 framework/custom extractors under internal/custom/**
+// register under prefixed registry keys (e.g. "python_django") and are only
+// selectable via extractors.RunCustomExtractors. Ordinary dispatch does an
+// exact-key Get(file.Language) on "python", which never matches, so none of
+// them have ever run on the DEFAULT in-process indexing path.
+//
+// These tests pin (a) the new opt-in gate's parsing and default-off contract
+// and (b) the behavioural difference at the seam: with the gate on, a Django
+// fixture must produce framework entities that the gate-off run does not.
+
+func TestInProcCustomExtractorsDefaultOff(t *testing.T) {
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	if inProcCustomExtractors() {
+		t.Fatalf("gate must be OFF when GRAFEL_INPROC_CUSTOM_EXTRACTORS is unset")
+	}
+}
+
+func TestInProcCustomExtractorsGateParsing(t *testing.T) {
+	cases := []struct {
+		val  string
+		want bool
+	}{
+		{"", false},
+		{"0", false},
+		{"no", false},
+		{"false", false},
+		{"garbage", false},
+		{"1", true},
+		{" 1 ", true},
+		{"true", true},
+		{"TRUE", true},
+		{"yes", true},
+		{"Yes", true},
+	}
+	for _, tc := range cases {
+		t.Run("val="+tc.val, func(t *testing.T) {
+			t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", tc.val)
+			if got := inProcCustomExtractors(); got != tc.want {
+				t.Fatalf("inProcCustomExtractors(%q) = %v, want %v", tc.val, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeDjangoFixture lays down a minimal but realistic Django/DRF project —
+// enough surface for the python_django / python_drf custom extractors to fire.
+func writeDjangoFixture(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"myproj/settings.py": `
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "rest_framework",
+    "myapp",
+]
+ROOT_URLCONF = "myproj.urls"
+DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "app"}}
+`,
+		"myproj/urls.py": `
+from django.urls import path, include
+from myapp import views
+
+urlpatterns = [
+    path("orders/", views.OrderList.as_view(), name="order-list"),
+    path("orders/<int:pk>/", views.OrderDetail.as_view(), name="order-detail"),
+    path("health/", views.health, name="health"),
+]
+`,
+		"myapp/models.py": `
+from django.db import models
+
+
+class Order(models.Model):
+    reference = models.CharField(max_length=64)
+    total = models.DecimalField(max_digits=10, decimal_places=2)
+    customer = models.ForeignKey("Customer", on_delete=models.CASCADE)
+
+
+class Customer(models.Model):
+    email = models.EmailField(unique=True)
+`,
+		"myapp/serializers.py": `
+from rest_framework import serializers
+from myapp.models import Order
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = ["id", "reference", "total"]
+`,
+		"myapp/views.py": `
+from rest_framework import generics
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from myapp.models import Order
+from myapp.serializers import OrderSerializer
+
+
+class OrderList(generics.ListCreateAPIView):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+
+class OrderDetail(generics.RetrieveUpdateDestroyAPIView):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+
+@api_view(["GET"])
+def health(request):
+    return Response({"ok": True})
+`,
+		"myapp/tasks.py": `
+from celery import shared_task
+
+
+@shared_task
+def send_receipt(order_id):
+    return order_id
+`,
+		// Non-Python surface — #5989 requires checking that languages other
+		// than Python survive the custom-extractor dispatch cleanly.
+		"web/server.js": `
+const express = require("express");
+const app = express();
+
+app.get("/api/orders", (req, res) => res.json([]));
+app.post("/api/orders", (req, res) => res.status(201).json({}));
+
+module.exports = app;
+`,
+		"svc/handler.go": `
+package svc
+
+import "net/http"
+
+// Handler serves the orders API.
+type Handler struct{}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+`,
+		"api/OrdersController.java": `
+package api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrdersController {
+    @GetMapping("/orders")
+    public String list() {
+        return "[]";
+    }
+}
+`,
+		"rb/orders_controller.rb": `
+class OrdersController < ApplicationController
+  def index
+    render json: []
+  end
+end
+`,
+	}
+	for rel, body := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+func kindCounts(doc *graph.Document) map[string]int {
+	out := map[string]int{}
+	for i := range doc.Entities {
+		out[doc.Entities[i].Kind]++
+	}
+	return out
+}
+
+// TestInProcCustomExtractorsProduceFrameworkEntities is the core behavioural
+// test for #5989: flipping the gate on must route the Django fixture through
+// the custom/framework extractors and yield entity kinds the base python
+// extractor alone never emits.
+func TestInProcCustomExtractorsProduceFrameworkEntities(t *testing.T) {
+	fixture := writeDjangoFixture(t)
+
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	off := runIndexerOn(t, fixture, "fx_off", nil)
+	offKinds := kindCounts(off)
+
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	on := runIndexerOn(t, fixture, "fx_on", nil)
+	onKinds := kindCounts(on)
+
+	if len(on.Entities) <= len(off.Entities) {
+		t.Fatalf("gate ON must add entities: off=%d on=%d\noff kinds=%v\non kinds=%v",
+			len(off.Entities), len(on.Entities), offKinds, onKinds)
+	}
+	if len(on.Relationships) <= len(off.Relationships) {
+		t.Fatalf("gate ON must add relationships: off=%d on=%d",
+			len(off.Relationships), len(on.Relationships))
+	}
+
+	// NOTE ON http_endpoint_definition: it does NOT grow here, and that is
+	// correct. The Django URLconf → endpoint mapping is already performed on
+	// the base path by the in-index django_cbv_routes post-pass (it reports
+	// "django_cbv_routes=8 entities" in BOTH arms). The custom extractors are
+	// additive to a surface the post-passes already cover, which is precisely
+	// why the entity gain from this gate is modest. Asserting endpoint growth
+	// here would encode a false expectation.
+	if onKinds["http_endpoint_definition"] == 0 {
+		t.Fatalf("expected the base path to already emit http_endpoint_definition; on kinds=%v", onKinds)
+	}
+
+	// What the Python framework extractors genuinely add on this fixture:
+	// richer SCOPE.* modelling of the DRF serializers / Celery task / settings.
+	for _, k := range []string{"SCOPE.Schema", "SCOPE.Operation"} {
+		if onKinds[k] <= offKinds[k] {
+			t.Errorf("kind %s did not grow with the gate on: off=%d on=%d",
+				k, offKinds[k], onKinds[k])
+		}
+	}
+	// Kinds only the custom extractors produce at all.
+	for _, k := range []string{"SCOPE.Pattern", "SCOPE.Service"} {
+		if offKinds[k] != 0 {
+			t.Errorf("kind %s unexpectedly present with the gate OFF: %d", k, offKinds[k])
+		}
+		if onKinds[k] == 0 {
+			t.Errorf("kind %s absent with the gate ON", k)
+		}
+	}
+}
+
+// entityTuples returns a CONTENT multiset of the entities for one language
+// (or all languages when lang is ""), keyed by every field a substitution
+// could change.
+//
+// COUNTS ARE NOT ENOUGH. An earlier version of the multi-language check
+// compared per-language entity COUNTS and was therefore vacuous: on the big
+// fixture Java's count is identical in both arms (320 -> 320) while 120
+// entities are destroyed and 120 mutated replacements appear. A set-or-count
+// comparison is structurally blind to substitution — the same defect class as
+// #6037. Compare tuples, and compare them as a MULTISET (counts per tuple),
+// so a duplicate appearing or disappearing is also visible.
+func entityTuples(doc *graph.Document, lang string) map[string]int {
+	out := map[string]int{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if lang != "" && e.Language != lang {
+			continue
+		}
+		out[fmt.Sprintf("%s|%s|%s|%s|%s|%d|%d",
+			e.Kind, e.Name, e.QualifiedName, e.Subtype, e.SourceFile, e.StartLine, e.EndLine)]++
+	}
+	return out
+}
+
+// tupleDelta returns the tuples destroyed by (present in a, missing/reduced in
+// b) and added by (present in b, missing/reduced in a) the gate.
+func tupleDelta(a, b map[string]int) (destroyed, added []string) {
+	for k, n := range a {
+		if b[k] < n {
+			destroyed = append(destroyed, k)
+		}
+	}
+	for k, n := range b {
+		if a[k] < n {
+			added = append(added, k)
+		}
+	}
+	sort.Strings(destroyed)
+	sort.Strings(added)
+	return destroyed, added
+}
+
+// indexBothArms runs the fixture with the gate off and on and returns both docs.
+func indexBothArms(t *testing.T, tag string) (off, on *graph.Document) {
+	t.Helper()
+	fixture := writeDjangoFixture(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	off = runIndexerOn(t, fixture, tag, nil)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	on = runIndexerOn(t, fixture, tag, nil)
+	return off, on
+}
+
+// TestInProcCustomExtractorsGoAndRubyAreInert pins the two languages that are
+// GENUINELY unaffected by the gate. Go (40 dispatched custom extractors) and
+// Ruby (21) produce byte-identical content tuples in both arms.
+//
+// This is a strict content-level assertion, not a count: if a future extractor
+// starts mutating Go or Ruby entities in place, this fails.
+func TestInProcCustomExtractorsGoAndRubyAreInert(t *testing.T) {
+	off, on := indexBothArms(t, "inert_lang_repo")
+	for _, lang := range []string{"go", "ruby"} {
+		destroyed, added := tupleDelta(entityTuples(off, lang), entityTuples(on, lang))
+		if len(destroyed) != 0 || len(added) != 0 {
+			t.Errorf("%s is no longer inert under the gate: destroyed=%v added=%v",
+				lang, destroyed, added)
+		}
+	}
+}
+
+// TestInProcCustomExtractorsJavaScriptIsNotInert pins that JavaScript IS
+// affected by the gate — correcting an earlier false claim that every
+// non-Python language contributed nothing.
+//
+// On this fixture the JS custom extractors REPLACE the two express route
+// operations with better-positioned versions: the base path emits them at
+// line 0 (no position), the custom path emits them at their real lines. That
+// is an improvement, but it is still a SUBSTITUTION, and a count-based test
+// cannot see it (2 -> 2).
+func TestInProcCustomExtractorsJavaScriptIsNotInert(t *testing.T) {
+	off, on := indexBothArms(t, "js_lang_repo")
+	destroyed, added := tupleDelta(entityTuples(off, "javascript"), entityTuples(on, "javascript"))
+	if len(destroyed) == 0 && len(added) == 0 {
+		t.Fatalf("expected the gate to change JavaScript entities; it changed nothing. " +
+			"If the JS custom extractors genuinely became inert, move javascript " +
+			"into TestInProcCustomExtractorsGoAndRubyAreInert.")
+	}
+	// The specific substitution: line-0 route operations replaced by located ones.
+	var zeroLineDestroyed int
+	for _, d := range destroyed {
+		if strings.Contains(d, "SCOPE.Operation|") && strings.HasSuffix(d, "|0|0") {
+			zeroLineDestroyed++
+		}
+	}
+	if zeroLineDestroyed == 0 {
+		t.Errorf("expected the gate to replace line-0 JS route operations; destroyed=%v", destroyed)
+	}
+	t.Logf("javascript destroyed=%v added=%v", destroyed, added)
+}
+
+// TestInProcCustomExtractorsJavaEntityMutation PINS A KNOWN DEFECT (#6104).
+//
+// The Java custom extractors mutate existing entities IN PLACE rather than
+// adding new ones. The collision is SAME KIND, SAME NAME, SAME FILE — only
+// Subtype and EndLine differ:
+//
+//	OFF: SCOPE.Operation|OrdersController.list|api.OrdersController.list|method  |...|9|12
+//	ON:  SCOPE.Operation|OrdersController.list|api.OrdersController.list|endpoint|...|9| 9
+//
+// Two things are corrupted: Subtype flips method -> endpoint, and EndLine is
+// TRUNCATED to the start line, losing the body extent. The truncation
+// propagates into the derived http_endpoint_definition entity too.
+//
+// WHY THIS TEST EXISTS SEPARATELY FROM THE CELERY PIN. Because the Java
+// collision is same-(Kind, Name), the obvious remedy for the Celery loss —
+// keying supersede on (Kind, Name) instead of Name alone — does NOT fix Java.
+// Without this test, that fix would turn the Celery pin red, be declared
+// complete, and ship with the Java corruption entirely unpinned.
+//
+// Asserts the BROKEN behaviour deliberately. When #6104 is fixed this test
+// fails and should be inverted, not deleted.
+func TestInProcCustomExtractorsJavaEntityMutation(t *testing.T) {
+	off, on := indexBothArms(t, "java_lang_repo")
+	destroyed, added := tupleDelta(entityTuples(off, "java"), entityTuples(on, "java"))
+
+	if len(destroyed) == 0 {
+		t.Fatalf("KNOWN DEFECT APPEARS FIXED: the gate no longer destroys Java entities. " +
+			"If #6104 was fixed, invert this test to assert Java is inert.")
+	}
+
+	// 1. Subtype mutation on a same-kind/same-name/same-file entity.
+	var subtypeMutated bool
+	for _, d := range destroyed {
+		if !strings.HasPrefix(d, "SCOPE.Operation|OrdersController.list|") || !strings.Contains(d, "|method|") {
+			continue
+		}
+		for _, a := range added {
+			if strings.HasPrefix(a, "SCOPE.Operation|OrdersController.list|") && strings.Contains(a, "|endpoint|") {
+				subtypeMutated = true
+			}
+		}
+	}
+	if !subtypeMutated {
+		t.Errorf("expected Java SCOPE.Operation subtype mutation method->endpoint; destroyed=%v added=%v",
+			destroyed, added)
+	}
+
+	// 2. EndLine truncation — the body extent is lost. Compare the EndLine of
+	// the destroyed vs added tuple for the same Kind|Name|File.
+	endLineOf := func(tuple string) (kindName string, endLine int, ok bool) {
+		parts := strings.Split(tuple, "|")
+		if len(parts) != 7 {
+			return "", 0, false
+		}
+		n, err := strconv.Atoi(parts[6])
+		if err != nil {
+			return "", 0, false
+		}
+		return parts[0] + "|" + parts[1] + "|" + parts[4], n, true
+	}
+	offEnd := map[string]int{}
+	for _, d := range destroyed {
+		if k, n, ok := endLineOf(d); ok {
+			offEnd[k] = n
+		}
+	}
+	var truncated []string
+	for _, a := range added {
+		k, n, ok := endLineOf(a)
+		if !ok {
+			continue
+		}
+		if prev, seen := offEnd[k]; seen && n < prev {
+			truncated = append(truncated, fmt.Sprintf("%s EndLine %d->%d", k, prev, n))
+		}
+	}
+	if len(truncated) == 0 {
+		t.Errorf("expected Java EndLine truncation under the gate; destroyed=%v added=%v",
+			destroyed, added)
+	}
+	t.Logf("java truncations: %v", truncated)
+
+	// 3. The truncation must be visible on the derived endpoint entity too,
+	// proving the corruption propagates beyond the entity it originated on.
+	var endpointTruncated bool
+	for _, s := range truncated {
+		if strings.HasPrefix(s, "http_endpoint_definition|") {
+			endpointTruncated = true
+		}
+	}
+	if !endpointTruncated {
+		t.Errorf("expected the EndLine truncation to propagate to http_endpoint_definition; got %v", truncated)
+	}
+}
+
+// TestInProcCustomExtractorsGateOffIsInert asserts the gate genuinely gates:
+// with it off, the produced graph must be semantically identical to a second
+// gate-off run (i.e. the new code path contributes nothing at all).
+func TestInProcCustomExtractorsGateOffIsInert(t *testing.T) {
+	fixture := writeDjangoFixture(t)
+
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	a := runIndexerOn(t, fixture, "inert_repo", nil)
+	b := runIndexerOn(t, fixture, "inert_repo", nil)
+
+	if len(a.Entities) != len(b.Entities) {
+		t.Fatalf("gate-off entity count unstable: %d vs %d", len(a.Entities), len(b.Entities))
+	}
+	ka, kb := kindCounts(a), kindCounts(b)
+	for k, v := range ka {
+		if kb[k] != v {
+			t.Fatalf("gate-off kind %q unstable: %d vs %d", k, v, kb[k])
+		}
+	}
+}
+
+// TestInProcCustomExtractorsGraphHygiene checks the correctness risk called
+// out in #5989: these extractors have not run against the current graph in
+// ~3 months. Assert no duplicate entity IDs, no empty names, and that every
+// relationship endpoint resolves to a real entity.
+func TestInProcCustomExtractorsGraphHygiene(t *testing.T) {
+	fixture := writeDjangoFixture(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	doc := runIndexerOn(t, fixture, "hygiene_repo", nil)
+
+	ids := map[string]int{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		ids[e.ID]++
+		if e.Name == "" {
+			t.Errorf("entity %s (kind=%s, file=%s) has empty Name", e.ID, e.Kind, e.SourceFile)
+		}
+		// Line-0 entities are the classic signature of an extractor that
+		// synthesised a node without a real tree-sitter position.
+		if e.StartLine < 0 {
+			t.Errorf("entity %s (kind=%s) has negative StartLine %d", e.ID, e.Kind, e.StartLine)
+		}
+	}
+	for id, n := range ids {
+		if n > 1 {
+			t.Errorf("duplicate entity ID %q appears %d times", id, n)
+		}
+	}
+}
+
+// unresolvedEdgeTargets returns every relationship endpoint ID that does not
+// name a real entity in the document, with its occurrence count.
+//
+// NOTE: a non-empty result is NORMAL on the base path — grafel deliberately
+// keeps placeholder endpoints ("ext:django:models", "scope:operation:…") for
+// unresolved externals. Absolute assertions on this set are therefore
+// meaningless; only the DELTA introduced by the gate is informative.
+func unresolvedEdgeTargets(doc *graph.Document) map[string]int {
+	ids := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		ids[doc.Entities[i].ID] = true
+	}
+	out := map[string]int{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if !ids[r.FromID] {
+			out[r.FromID]++
+		}
+		if !ids[r.ToID] {
+			out[r.ToID]++
+		}
+	}
+	return out
+}
+
+// TestInProcCustomExtractorsSupersedeDestroysBaseEntities PINS A KNOWN DEFECT
+// (#6104). It asserts the BROKEN behaviour deliberately so the defect is
+// visible in CI rather than papered over.
+//
+// WHAT BREAKS. MergeWithCustom supersedes by NAME alone. When a custom
+// extractor emits an entity whose Name collides with a base entity, the base
+// node is REPLACED — so the gate is not purely additive, it DESTROYS content
+// the base path produced.
+//
+// THE LOSS SET IS NOT ONE KIND AND NOT ONE LANGUAGE. On the full fixture the
+// loss spans 5 kinds and 2 languages. Two distinct collision shapes exist, and
+// they need DIFFERENT fixes:
+//
+//   - DIFFERENT-KIND collision (python/Celery). `@shared_task def
+//     send_receipt` destroys TWO base entities — `Task|send_receipt` AND
+//     `SCOPE.Operation|send_receipt|function` — replaced by a single
+//     `SCOPE.Service|send_receipt|task`. Keying supersede on (Kind, Name)
+//     would fix this shape.
+//
+//   - SAME-KIND collision (java/Spring). `SCOPE.Operation|C.list|method` is
+//     replaced by `SCOPE.Operation|C.list|endpoint` with EndLine truncated.
+//     Kind, Name and SourceFile are all IDENTICAL, so a (Kind, Name) key does
+//     NOT fix this shape.
+//
+// THIS TEST DELIBERATELY COVERS BOTH SHAPES. If it only pinned the Celery
+// loss, the obvious (Kind, Name) remedy would turn it red, be declared
+// complete, and ship with the Java corruption unpinned. The same-kind
+// assertion below is what makes a (Kind, Name)-only fix insufficient to make
+// this test pass — it must still fail until the same-kind shape is fixed too.
+//
+// See also TestInProcCustomExtractorsJavaEntityMutation, which pins the Java
+// field-level corruption in detail.
+func TestInProcCustomExtractorsSupersedeDestroysBaseEntities(t *testing.T) {
+	off, on := indexBothArms(t, "supersede_repo")
+
+	destroyed, added := tupleDelta(entityTuples(off, ""), entityTuples(on, ""))
+	if len(destroyed) == 0 {
+		t.Fatalf("KNOWN DEFECT APPEARS FIXED: the gate destroys no base entities. " +
+			"If #6104 was fixed, invert this test to assert the gate is purely additive.")
+	}
+	t.Logf("gate destroys %d base entity tuple(s):", len(destroyed))
+	for _, d := range destroyed {
+		t.Logf("    DESTROYED %s", d)
+	}
+
+	// --- Shape 1: DIFFERENT-KIND collision (python / Celery) ---------------
+	// BOTH base entities for the task must be destroyed, not just the Task.
+	// Pinning only `Task` understates the loss by half.
+	wantDestroyed := []string{
+		"Task|send_receipt|",            // the Celery task entity
+		"SCOPE.Operation|send_receipt|", // AND its operation entity
+	}
+	for _, want := range wantDestroyed {
+		found := false
+		for _, d := range destroyed {
+			if strings.HasPrefix(d, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected the gate to destroy an entity matching %q; destroyed=%v",
+				want, destroyed)
+		}
+	}
+	// The replacement is a single entity of a DIFFERENT kind.
+	var serviceAdded bool
+	for _, a := range added {
+		if strings.HasPrefix(a, "SCOPE.Service|send_receipt|") {
+			serviceAdded = true
+		}
+	}
+	if !serviceAdded {
+		t.Errorf("expected a SCOPE.Service replacement for the superseded task; added=%v", added)
+	}
+
+	// --- Shape 2: SAME-KIND collision (java / Spring) ---------------------
+	// This is the assertion a (Kind, Name)-keyed fix cannot satisfy. Find a
+	// destroyed tuple whose Kind, Name AND SourceFile all reappear in `added`
+	// with different field values — i.e. a substitution that keying on
+	// (Kind, Name) would still permit.
+	keyOf := func(tuple string) (string, bool) {
+		parts := strings.Split(tuple, "|")
+		if len(parts) != 7 {
+			return "", false
+		}
+		return parts[0] + "|" + parts[1] + "|" + parts[4], true // Kind|Name|SourceFile
+	}
+	addedKeys := map[string]bool{}
+	for _, a := range added {
+		if k, ok := keyOf(a); ok {
+			addedKeys[k] = true
+		}
+	}
+	var sameKindSubstitutions []string
+	for _, d := range destroyed {
+		if k, ok := keyOf(d); ok && addedKeys[k] {
+			sameKindSubstitutions = append(sameKindSubstitutions, k)
+		}
+	}
+	if len(sameKindSubstitutions) == 0 {
+		t.Fatalf("KNOWN DEFECT APPEARS PARTIALLY FIXED: no same-(Kind, Name, SourceFile) "+
+			"substitutions remain. A (Kind, Name)-keyed fix is NOT sufficient — the "+
+			"same-kind shape (java/Spring) must be fixed too before this test may be "+
+			"inverted. destroyed=%v added=%v", destroyed, added)
+	}
+	t.Logf("same-(Kind,Name,SourceFile) substitutions a (Kind,Name) fix would NOT prevent: %v",
+		sameKindSubstitutions)
+
+	// --- Dangling edges left behind by the supersede -----------------------
+	uo, un := unresolvedEdgeTargets(off), unresolvedEdgeTargets(on)
+	var introduced []string
+	for id := range un {
+		if _, existed := uo[id]; !existed {
+			introduced = append(introduced, id)
+		}
+	}
+	if len(introduced) == 0 {
+		t.Errorf("expected the supersede to leave dangling edge endpoints behind")
+	}
+	sort.Strings(introduced)
+	t.Logf("gate introduces %d new dangling edge endpoint(s): %v", len(introduced), introduced)
+}
+
+// TestInProcCustomExtractorsNilTreeGuardIsLoadBearing pins the
+// `file.TSTree != nil` guard at the seam (mutant M3).
+//
+// The guard is not decorative. RunCustomExtractors does NOT require a parse
+// tree to produce output — a subset of the custom extractors work directly on
+// file CONTENT — so with a nil tree it still returns entities rather than
+// erroring out. Dropping the guard would therefore admit content-only
+// extractor output for files that FAILED TO PARSE, silently producing entities
+// on exactly the inputs the indexer decided it could not understand.
+//
+// This asserts the underlying behaviour that makes the guard necessary; the
+// guard itself is a one-line condition at the seam in classifyAndReadWithProgress.
+func TestInProcCustomExtractorsNilTreeGuardIsLoadBearing(t *testing.T) {
+	fi := extractors.FileInput{
+		Path:     "myapp/models.py",
+		Language: "python",
+		Content: []byte("from django.db import models\n\n\n" +
+			"class Widget(models.Model):\n    name = models.CharField(max_length=10)\n"),
+		// TSTree deliberately nil — simulating a file that failed to parse.
+	}
+	ents, _ := extractors.RunCustomExtractors(context.Background(), fi)
+	if len(ents) == 0 {
+		t.Skip("custom extractors no longer emit content-only entities without a " +
+			"parse tree; the nil-tree guard may now be redundant")
+	}
+	t.Logf("with a nil parse tree, RunCustomExtractors still emits %d entity(ies) — "+
+		"this is what the `file.TSTree != nil` guard at the seam suppresses", len(ents))
+}

--- a/cmd/grafel/inproc_custom_measure_5989_test.go
+++ b/cmd/grafel/inproc_custom_measure_5989_test.go
@@ -1,0 +1,163 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// dualHeapSampler records BOTH heap metrics for the #5989 cost measurement.
+//
+// WHY TWO. next_gc/(1+GOGC/100) is the conventional live-heap estimate, but it
+// is a LAGGING, GC-QUANTIZED proxy: it only updates when the GC sets a new
+// target, so over a sub-second run with ~20 collections it cannot observe a
+// peak that occurs BETWEEN marks. Peak HeapAlloc is sampled directly and has
+// no such blind spot (though it includes not-yet-collected garbage). Recording
+// both means the conclusion does not rest on the proxy alone — if they
+// disagree, the proxy is the one to distrust.
+//
+// TotalAlloc is captured separately by the caller. It is cumulative
+// allocation, i.e. the transient per-file garbage that dies before the next
+// mark. That garbage is INVISIBLE in peak live heap at small scale but is real
+// GC pressure at corpus scale, so it is the metric that actually tracks the
+// cost of running ~340 extra extractors per file.
+type dualHeapSampler struct {
+	stop, done   chan struct{}
+	gogc         float64
+	peakNextGC   atomic.Uint64
+	peakHeapUsed atomic.Uint64
+}
+
+func startDualHeapSampler() *dualHeapSampler {
+	gogc := 100.0
+	if v := os.Getenv("GOGC"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			gogc = f
+		}
+	}
+	h := &dualHeapSampler{stop: make(chan struct{}), done: make(chan struct{}), gogc: gogc}
+	go func() {
+		defer close(h.done)
+		tk := time.NewTicker(5 * time.Millisecond)
+		defer tk.Stop()
+		var ms runtime.MemStats
+		bump := func(a *atomic.Uint64, v uint64) {
+			for {
+				cur := a.Load()
+				if v <= cur || a.CompareAndSwap(cur, v) {
+					return
+				}
+			}
+		}
+		for {
+			select {
+			case <-h.stop:
+				return
+			case <-tk.C:
+				runtime.ReadMemStats(&ms)
+				bump(&h.peakNextGC, uint64(float64(ms.NextGC)/(1.0+h.gogc/100.0)))
+				bump(&h.peakHeapUsed, ms.HeapAlloc)
+			}
+		}
+	}()
+	return h
+}
+
+func (h *dualHeapSampler) finish() (liveMB, heapAllocMB float64) {
+	close(h.stop)
+	<-h.done
+	return float64(h.peakNextGC.Load()) / (1 << 20), float64(h.peakHeapUsed.Load()) / (1 << 20)
+}
+
+// TestInProcCustomExtractorsCost measures the cost of the #5989 gate for
+// EXACTLY ONE ARM, selected by GRAFEL_CUSTOM_MEASURE_ARM=off|on.
+//
+// ONE ARM PER PROCESS IS THE POINT. An earlier version of this harness ran
+// both arms inside a single test binary. That was wrong: the second arm always
+// inherited a warmed heap and a grown GC target from the first, and reversing
+// the within-rep order swung the reported heap delta from -6.6% to -1.3% — an
+// order bias of the SAME MAGNITUDE as the effect being measured. A harness
+// whose bias is as large as its signal cannot support a signed claim. Each arm
+// now gets a pristine process; alternate arms by alternating invocations:
+//
+//	for i in 1 2 3; do
+//	  for arm in off on; do
+//	    GRAFEL_CUSTOM_MEASURE=1 GRAFEL_CUSTOM_MEASURE_ARM=$arm \
+//	    GRAFEL_CUSTOM_MEASURE_REPO=/path/to/fixture \
+//	      go test ./cmd/grafel/ -run TestInProcCustomExtractorsCost -count=1 -v
+//	  done
+//	done
+//
+// SCALE CAVEAT. Both fixtures used for #5989 peak under ~120 MB of live heap.
+// Epic #5954 targets the GB-scale regime (24k-file corpora). Nothing here
+// measures that regime, so a flat peak-heap result at this scale must NOT be
+// read as "free at corpus scale" — see the TotalAlloc figure, which is where
+// the per-file cost actually shows up.
+func TestInProcCustomExtractorsCost(t *testing.T) {
+	if os.Getenv("GRAFEL_CUSTOM_MEASURE") != "1" {
+		t.Skip("set GRAFEL_CUSTOM_MEASURE=1 to run the #5989 cost measurement")
+	}
+	repo := os.Getenv("GRAFEL_CUSTOM_MEASURE_REPO")
+	if repo == "" {
+		t.Fatal("set GRAFEL_CUSTOM_MEASURE_REPO to the fixture repo path")
+	}
+	arm := os.Getenv("GRAFEL_CUSTOM_MEASURE_ARM")
+	switch arm {
+	case "off":
+		t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	case "on":
+		t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	default:
+		t.Fatal("set GRAFEL_CUSTOM_MEASURE_ARM to exactly one of: off, on")
+	}
+
+	state := t.TempDir()
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+
+	s := startDualHeapSampler()
+	start := time.Now()
+	err := Index(repo, filepath.Join(state, "graph.json"), "measure_repo", nil, false, false)
+	wall := time.Since(start)
+	liveMB, heapAllocMB := s.finish()
+	runtime.ReadMemStats(&after)
+	if err != nil {
+		t.Fatalf("Index(arm=%s): %v", arm, err)
+	}
+
+	doc, err := graph.LoadGraphFromDir(state)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir(arm=%s): %v", arm, err)
+	}
+	kinds := map[string]int{}
+	for i := range doc.Entities {
+		kinds[doc.Entities[i].Kind]++
+	}
+	var ks []string
+	for k := range kinds {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+
+	totalAllocMB := float64(after.TotalAlloc-before.TotalAlloc) / (1 << 20)
+
+	// Single machine-readable line so an external driver can aggregate across
+	// process invocations without parsing prose.
+	fmt.Printf("MEASURE arm=%s wall_s=%.3f peak_live_mb=%.1f peak_heapalloc_mb=%.1f total_alloc_mb=%.1f num_gc=%d entities=%d rels=%d\n",
+		arm, wall.Seconds(), liveMB, heapAllocMB, totalAllocMB,
+		after.NumGC-before.NumGC, len(doc.Entities), len(doc.Relationships))
+	for _, k := range ks {
+		fmt.Printf("KIND arm=%s %s=%d\n", arm, k, kinds[k])
+	}
+}


### PR DESCRIPTION
`internal/custom/**` is **21 packages, ~141k lines of non-test Go, ~340 registered extractors** — all of Django/DRF/Celery/Flask/FastAPI/SQLAlchemy plus 20 other languages. **None of it has ever run on the default indexing path.**

This adds the wiring, behind a new default-off flag, and measures what turning it on would cost. **It does not turn it on**: review found that enabling it currently destroys graph content, and the blockers are filed separately.

## Why it was dead

`RunCustomExtractors` (`internal/extractors/custom_dispatch.go:208`) is the only dispatcher that can select these extractors — they register under prefixed keys (`python_django`), while ordinary dispatch does an exact-key `Get(file.Language)` on `"python"`, which never matches. Its only non-test caller sits behind `GRAFEL_SUBPROC_EXTRACT`, a flag with **zero writers anywhere in the tree**.

`git log -S` returns **zero commits** where `cmd/` referenced `RunCustomExtractors` or `CustomExtractorsFor`. This was never connected; it is not a regression. The flag comment says "during the rollout" — a rollout that never started.

The failure mode worth naming: every later "wire the dead X extractors into live dispatch" commit wired into `RunCustomExtractors` and verified with unit tests that genuinely pass. The extractor really is reachable *from the test*. Nothing on the default path changed.

## Why not just enable `GRAFEL_SUBPROC_EXTRACT`

Because the two branches are **disjoint, not superset/subset**. That branch leaves `classified` nil (`cmd/grafel/index.go:1206-1210`, filled only at `:1294`), so ~12 framework post-passes silently stop and the result is a **net loss** — entities 201→186, `http_endpoint_definition` 18→4, `STEP_IN_PROCESS` 31→4. Filed as #6102.

## The seam

Inside `classifyAndReadWithProgress`, immediately after `extractors.Extract(ctx, file)` and before `file.TSTree.Close()`, merging via `MergeWithCustom`. Gated on `GRAFEL_INPROC_CUSTOM_EXTRACTORS`.

Verified in review rather than assumed: the tree is live at the seam on every reaching path (the only early-close path `continue`s before it), only one of the two callers reaches it so there is no double-run, and `classified` continues to be appended unconditionally afterwards.

**Gate-off inertness is the property that makes this safe to merge, and it was reproduced independently** — different fixture, different digest implementation, plus a base re-run to establish the digest is deterministic rather than accidentally matching:

```
BASE   c7852db92   ents=3058 rels=7420  ent_sha=ec3ed681… rel_sha=31e6c6ce… kind_sha=51f89ed8…
BASE   re-run      ents=3058 rels=7420  ent_sha=ec3ed681… rel_sha=31e6c6ce… kind_sha=51f89ed8…
FEAT   gate off    ents=3058 rels=7420  ent_sha=ec3ed681… rel_sha=31e6c6ce… kind_sha=51f89ed8…
```

Digests are over content tuples with endpoints keyed by entity content, never by ID — byte comparison of `graph.fb` is invalid (#6083). It also holds by construction: every added line is inside the gate, and the diff adds no imports and no package-level state.

## What it costs — measured twice, and the first answer was wrong

The first harness ran both arms in one process and reported peak live heap **flat (−1.3%)**. Review rejected that: reversing the arm order swung the result −6.6% → −1.3%, an order bias **the same magnitude as the effect**. That harness cannot resolve this measurement.

Rebuilt to **one arm per process**, alternated externally, 10 reps each, both heap metrics recorded:

| metric | OFF | ON | delta |
|---|---|---|---|
| peak live heap (`next_gc` proxy) | 96.1 MB | 110.5 MB | +15.0% |
| **peak `HeapAlloc` (sampled direct)** | 162.3 MB | 169.7 MB | **+4.6%** |
| **`TotalAlloc`** | 805.5 MB | 952.3 MB | **+18.2%** |
| wall | 1.82 s | 2.14 s | +17.5% |
| entities / relationships | 15360 / 42055 | 18583 / 49714 | +21.0% / +18.2% |

So the honest result is **peak heap increases modestly** — not "flat", and not the "−1.3% improvement" first reported. 9 of 10 ON values exceed all 10 OFF values.

The two heap metrics disagree in magnitude (+15% proxy vs +4.6% direct), which is the lagging-proxy artefact: `next_gc/(1+GOGC/100)` is GC-quantized and cannot see a between-mark peak. **+4.6% is the figure to stand behind**; recording both is what made the discrepancy visible, and both are now recorded.

**Scale caveat, stated in the code as well as here:** every fixture involved peaks under ~170 MB. Nothing here touches the GB-scale regime #5954 targets, and `TotalAlloc` +18.2% is transient churn that dies before the next mark — invisible in peak heap at this size, real GC pressure at 24k files. This must not be read as cheap at corpus scale.

## Why the flag stays off: enabling it destroys entities

**280 entities destroyed** across 5 kinds and 2 languages. `MergeWithCustom` supersedes on `Name` alone, ignoring `Kind`, so a base entity is replaced whenever a custom entity shares its name.

The per-kind count table cannot see this — `SCOPE.Operation` showed **+120 while 120 of its members were destroyed**. Gains masked losses exactly. That is the same blindness fixed in #6037 for the parity comparator, and it is why the first pass of this work reported the non-Python languages as clean.

Three distinct failure modes, of which the obvious `(Kind, Name)` fix addresses only one:

| collision | example | fixed by `(Kind, Name)`? |
|---|---|---|
| cross-kind | `Task` vs `SCOPE.Operation` (python) | yes |
| same-kind, same name | `Task\|send_receipt` (python) | **no** |
| same-kind, in-place corruption | `SCOPE.Operation\|C0.list0` (java) | **no** |

The Java case is entity corruption, not deletion — subtype `method`→`endpoint` and **`EndLine` truncated 12→9**, propagating into derived `SCOPE.Process` and `http_endpoint_definition`.

Filed as #6104 (rescoped) and #6105 (~240 synthetic `Class:<Name>` endpoints resolving to entities that never existed in either arm).

## Tests: three were weaker than their names

- `...NonPythonLanguagesAreClean` asserted a per-language **count**. Java is 320 in both arms while 120 entities are swapped — it could not detect the corruption it was named for. Replaced with content-tuple multiset comparison. Vacuity proved directly on the data: `java: COUNT 7→7 (count-test blind) | TUPLES destroyed=2 added=2 (tuple-test detects)`.
- The claim "non-Python extractors contribute nothing" was **committed in a code comment and is false for 2 of 4 languages**. JavaScript adds +120 entities; Java mutates 120 in place. Only go and ruby are genuinely inert, and that is now pinned by strict content equality.
- The Celery pinning test pinned strictly less than exists. Widened to the full destroyed set including **both** entities each task destroys, and **verified resistant by mutation**: with a `(Kind, Name)` supersede applied, `...JavaEntityMutation` still passes and still logs `EndLine 12→9`, so the corruption cannot be declared fixed by that change. Mutation reverted; `custom_dispatch.go` is unchanged.

The nil-tree guard mutant survived the original suite and is now killed — and the mechanism was not what was assumed. With a nil tree `RunCustomExtractors` returns **1 entity, 0 errors**, not ~340 recovered errors: content-only extractors fire without a tree, so dropping the guard would emit entities for files that **failed to parse**.

Recorded, not fixed: on `extractErr != nil` the merged result is discarded entirely, so custom-only language coverage can never work while base extraction fails. Changing that would alter default-path behaviour, out of scope for a default-off gate.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. At `-count=1 -p 1`:

| package | exit | run | skip |
|---|---|---|---|
| `./cmd/grafel/` | 0 | 476 | 8 |
| `./internal/extractors/...` | 0 | 3997 | 1 |
| `./internal/custom/...` | 0 | 3952 | **0** |
| `./internal/graph/...` | 0 | 492 | **0** |

0 FAIL throughout. Skips are 7 pre-existing env-gated harnesses plus the new env-gated cost harness.

Gate mutants both killed — silently-always-on and silently-always-off, the pair that bit #5964 and task #16.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Refs #5989, #6102, #6104, #6105, #5954
