### PR TITLE
fix(#6094): stop the incremental path persisting duplicate rows that compound every pass

### DIFF
--- a/cmd/grafel/diff_reindex_multiset_test.go
+++ b/cmd/grafel/diff_reindex_multiset_test.go
@@ -299,7 +299,7 @@ func Use7(x I7) int { return x.Do() }
 	// rows, and it no longer gets one for free. It now INJECTS the duplication
 	// into the persisted graph — re-appending rows that are already present,
 	// with the exact multiplicities the pre-fix defect produced on this very
-	// fixture (CONTAINS ×3, REFERENCES ×6, CONTAINS ×3). The comparator input is
+	// fixture (CONTAINS ×3, REFERENCES ×6). The comparator input is
 	// therefore the same shape it always was; only its provenance changed, from
 	// "a live defect" to "a defect replayed on purpose".
 	if de, dr, sample := dvDuplicateRows(b); de != 0 || dr != 0 {

--- a/cmd/grafel/diff_reindex_multiset_test.go
+++ b/cmd/grafel/diff_reindex_multiset_test.go
@@ -195,6 +195,40 @@ func dvCollapseToSet(doc *graph.Document) *graph.Document {
 	return out
 }
 
+// dvInjectDuplicateRows returns a copy of doc in which ONE relationship of each
+// requested kind has been replicated to the requested multiplicity, replaying
+// the shape #6094 used to produce here before it was fixed. The chosen row is
+// the first of its kind in canonical order, so the injection is deterministic.
+//
+// Injecting rather than mutating in place keeps the caller's document intact,
+// and injecting only EXACT copies is what makes dvCollapseToSet's output differ
+// from the result in multiplicity and in nothing else — the property the
+// comparator assertions below depend on.
+func dvInjectDuplicateRows(t *testing.T, doc *graph.Document, kindMultiplicity map[string]int) *graph.Document {
+	t.Helper()
+	out := &graph.Document{
+		Entities:      append([]graph.Entity(nil), doc.Entities...),
+		Relationships: append([]graph.Relationship(nil), doc.Relationships...),
+	}
+	for kind, mult := range kindMultiplicity {
+		var seed *graph.Relationship
+		for i := range doc.Relationships {
+			if doc.Relationships[i].Kind == kind {
+				seed = &doc.Relationships[i]
+				break
+			}
+		}
+		if seed == nil {
+			t.Fatalf("cannot inject %s duplicates: the persisted graph carries no %s edge at all — "+
+				"the corpus stopped exercising the shape this case is about", kind, kind)
+		}
+		for i := 1; i < mult; i++ {
+			out.Relationships = append(out.Relationships, *seed)
+		}
+	}
+	return out
+}
+
 // ───────────────────────────── the demonstration ────────────────────────────
 
 // TestDiffReindex_MultisetComparatorCatchesDuplicateRows is the #6037 acceptance
@@ -254,13 +288,34 @@ func Use7(x I7) int { return x.Do() }
 	if err != nil {
 		t.Fatalf("load incremental graph: %v", err)
 	}
+	// #6094 IS FIXED, so this graph no longer duplicates rows on its own — the
+	// incremental path now substitutes the owning record's ID for an empty
+	// record-embedded FromID and dedupes the re-extraction batch, exactly as the
+	// full-index assembly loop does. The regression gate for that lives in
+	// TestIncremental_NoDuplicateRowsAcrossPasses_6094.
+	//
+	// What THIS case exists for is #6037: proving the multiset comparator is a
+	// real instrument. That demonstration needs a document carrying duplicate
+	// rows, and it no longer gets one for free. It now INJECTS the duplication
+	// into the persisted graph — re-appending rows that are already present,
+	// with the exact multiplicities the pre-fix defect produced on this very
+	// fixture (CONTAINS ×3, REFERENCES ×6, CONTAINS ×3). The comparator input is
+	// therefore the same shape it always was; only its provenance changed, from
+	// "a live defect" to "a defect replayed on purpose".
+	if de, dr, sample := dvDuplicateRows(b); de != 0 || dr != 0 {
+		t.Fatalf("#6094 has REGRESSED: the persisted incremental graph carries duplicate rows again "+
+			"(%d entity, %d relationship): %v", de, dr, sample)
+	}
+	b = dvInjectDuplicateRows(t, b, map[string]int{
+		"CONTAINS":   3,
+		"REFERENCES": 6,
+	})
+
 	dupEnts, dupRels, sample := dvDuplicateRows(b)
-	t.Logf("persisted incremental graph: %d entities, %d relationships; surplus rows: %d entity, %d relationship\nduplicated keys: %v",
+	t.Logf("injected duplication: %d entities, %d relationships; surplus rows: %d entity, %d relationship\nduplicated keys: %v",
 		len(b.Entities), len(b.Relationships), dupEnts, dupRels, sample)
 	if dupEnts+dupRels == 0 {
-		t.Fatalf("fixture no longer reproduces #6094: the persisted incremental graph carries no duplicate rows. " +
-			"Either the defect is fixed (delete this fixture and keep the parity unit cases) or the corpus stopped " +
-			"exercising the pass that duplicates — do NOT weaken the comparator to keep this green")
+		t.Fatal("fixture is inert: the injection produced no duplicate rows, so neither comparator is under test")
 	}
 
 	// A is B with duplicate rows collapsed. A and B therefore differ in

--- a/cmd/grafel/incremental_dup_rows_6094_test.go
+++ b/cmd/grafel/incremental_dup_rows_6094_test.go
@@ -1,0 +1,322 @@
+// Package main — incremental_dup_rows_6094_test.go
+//
+// #6094 — the incremental path persists DUPLICATE relationship rows into
+// graph.fb, and they COMPOUND: one additional copy of the affected rows per
+// incremental pass. Incremental is the default path for a watched repo, so a
+// long-lived watched graph accumulates duplicates without bound.
+//
+// ROOT CAUSE OF #6094.
+// ────────────────────
+// The full-index assembly loop (cmd/grafel/index.go, buildDocument) converts a
+// record-embedded types.RelationshipRecord into a graph.Relationship with two
+// steps the incremental re-extraction loop omitted:
+//
+//  1. `if fromID == "" { fromID = id }` — a record-embedded edge with no
+//     explicit FromID is owned by the entity record carrying it, so the
+//     owner's ID is substituted.
+//  2. a `seenRel` guard keyed on (FromID, ToID, Kind) — an extractor may emit
+//     the same owned edge twice within one file.
+//
+// extractors.relRecordToGraphRel did neither, so the incremental path emitted
+// those edges with an EMPTY FromID — and the stale-edge eviction in
+// TryIncremental drops an old edge only when removedEntityIDs[r.FromID]. An
+// empty FromID matches no removed entity, so each pass's copies SURVIVE while
+// re-extraction appends fresh ones. That is the compounding: +1 copy per pass,
+// unbounded. The fix restores both steps; there is no downstream row dedupe,
+// which would have hidden the malformed edges instead of removing them.
+//
+// #6098 IS A DIFFERENT DEFECT and is NOT fixed here. The fix above moves its
+// numbers by exactly zero — see TestIncremental_DependsOnWeightParity_6098
+// below for the measurement and the actual chain.
+//
+// This file is the regression gate. It asserts on the graph READ BACK OFF DISK
+// (never the run log, which over-reports — that over-reporting is #6094), over
+// THREE sequential incremental passes, so a fix that merely removes the first
+// pass's surplus without stopping the accumulation still fails here.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// dupRowKey is the identity of a relationship ROW for duplicate detection.
+//
+// (FromID, ToID, Kind) alone is NOT a unique relationship key: several
+// producers deliberately salt the relationship ID so that edges sharing a
+// triple stay distinct (internal/engine/migration_schema_ops.go,
+// phantom_edges.go, process_flow.go, event_flow.go, tests_walkup.go). Keying a
+// duplicate check on the bare triple would report those legitimate edges as
+// duplicates — and any dedupe built on it would destroy them. The key here is
+// (FromID, ToID, Kind, ID, properties): two rows collide only when they are
+// indistinguishable in every persisted dimension, which is the only case where
+// a second copy carries no information.
+func dupRowKey(r graph.Relationship) string {
+	props := r.PropsSnapshot()
+	ks := make([]string, 0, len(props))
+	for k := range props {
+		ks = append(ks, k)
+	}
+	sort.Strings(ks)
+	var b strings.Builder
+	b.WriteString(r.FromID)
+	b.WriteString("\x00")
+	b.WriteString(r.ToID)
+	b.WriteString("\x00")
+	b.WriteString(r.Kind)
+	b.WriteString("\x00")
+	b.WriteString(r.ID)
+	for _, k := range ks {
+		b.WriteString("\x00")
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(props[k])
+	}
+	return b.String()
+}
+
+// dupSurplusRows counts rows beyond the first for each dupRowKey, and returns a
+// sorted sample of the offending keys.
+func dupSurplusRows(doc *graph.Document) (surplus int, sample []string) {
+	c := map[string]int{}
+	for _, r := range doc.Relationships {
+		c[dupRowKey(r)]++
+	}
+	for k, n := range c {
+		if n > 1 {
+			surplus += n - 1
+			sample = append(sample, fmt.Sprintf("%s ×%d", strings.ReplaceAll(k, "\x00", "|"), n))
+		}
+	}
+	sort.Strings(sample)
+	return surplus, sample
+}
+
+// dupEmptyFrom counts relationships with an empty FromID and samples them.
+func dupEmptyFrom(doc *graph.Document) (n int, sample []string) {
+	seen := map[string]bool{}
+	for _, r := range doc.Relationships {
+		if r.FromID != "" {
+			continue
+		}
+		n++
+		k := fmt.Sprintf("(empty)→%s:%s", r.ToID, r.Kind)
+		if !seen[k] {
+			seen[k] = true
+			sample = append(sample, k)
+		}
+	}
+	sort.Strings(sample)
+	return n, sample
+}
+
+// TestIncremental_NoDuplicateRowsAcrossPasses_6094 is the compounding gate.
+//
+// A 40-file Go corpus (structs + interfaces + methods — a corpus of plain
+// functions does NOT reproduce this; the owned CONTAINS/REFERENCES edges the
+// defect rides on only exist for type members) is full-rebuilt, then three
+// SEQUENTIAL single-file deltas are applied, each through a real
+// TryIncremental. After EVERY pass the persisted graph.fb is read back and
+// asserted to carry zero surplus rows and zero empty-FromID edges.
+//
+// Asserting after every pass — not only at the end — is what makes this a
+// compounding gate: the pre-fix numbers were 1 → 5 → 9 surplus rows, so a
+// per-pass trace also documents the accumulation rate if it ever returns.
+//
+// Every corpus file gets a UNIQUE basename on purpose: diff.Filter
+// cross-invalidates same-basename files, so a corpus of 40 files all named f.go
+// turns a 1-file delta into a 40-file change and trips the too-many-changed
+// full-reindex fallback — silently making the case vacuous. dvIncremental
+// additionally fails the test if TryIncremental falls back.
+func TestIncremental_NoDuplicateRowsAcrossPasses_6094(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	const nFiles = 40
+	for i := 0; i < nFiles; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), dvMultisetCorpusFile(i))
+	}
+
+	dvFullRebuild(t, repo, stateDir)
+
+	// Control: the full rebuild must be clean on both dimensions, so anything
+	// observed after an incremental pass is attributable to the incremental path.
+	base, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	if n, sample := dupSurplusRows(base); n != 0 {
+		t.Fatalf("control violated: the FULL rebuild already carries %d surplus relationship row(s): %v", n, sample)
+	}
+	if n, sample := dupEmptyFrom(base); n != 0 {
+		t.Fatalf("control violated: the FULL rebuild already carries %d empty-FromID edge(s): %v", n, sample)
+	}
+	// Pass-over-pass stability, not equality with the full rebuild. The
+	// incremental graph is legitimately a few rows SHORT of a full rebuild on
+	// this corpus for an unrelated, still-open reason (#6098: the scoped
+	// resolver has no receiver-type / package-member tier, so an intra-file
+	// method CALLS stays a bare-name stub and the process-flow pass never builds
+	// the SCOPE.Process it would have anchored — see the comment on
+	// TestIncremental_DependsOnWeightParity_6098). Asserting equality here would
+	// couple this gate to that defect. What #6094 is about is GROWTH: the row
+	// count must reach a fixed point after the first pass and stay there.
+	var prevRels int
+
+	var trace []string
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "r07.go", fmt.Sprintf(`package svc
+
+type T7 struct{ N int }
+
+type I7 interface{ Do() int }
+
+func (t *T7) Do() int { return t.N + h7() + %d }
+
+func h7() int { return 7 }
+
+func New7() *T7 { return &T7{N: 7} }
+
+func Use7(x I7) int { return x.Do() }
+`, pass))
+		dvIncremental(t, repo, stateDir)
+
+		// Read the PERSISTED graph — never the run log, which over-reports.
+		b, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			t.Fatalf("pass %d: load persisted graph: %v", pass, err)
+		}
+		surplus, dupSample := dupSurplusRows(b)
+		empty, emptySample := dupEmptyFrom(b)
+		trace = append(trace, fmt.Sprintf("pass %d: rels=%d surplus=%d empty-from=%d", pass, len(b.Relationships), surplus, empty))
+
+		if empty != 0 {
+			t.Errorf("pass %d: persisted graph carries %d relationship(s) with an EMPTY FromID (full rebuild: 0): %v\n"+
+				"the incremental re-extraction must substitute the owning entity record's ID for an empty "+
+				"record-embedded FromID, exactly as the full-index assembly loop does", pass, empty, emptySample)
+		}
+		if surplus != 0 {
+			t.Errorf("pass %d: persisted graph carries %d SURPLUS relationship row(s) keyed on "+
+				"(FromID, ToID, Kind, ID, properties): %v", pass, surplus, dupSample)
+		}
+		// The corpus end-state is the same shape on every pass (only a literal
+		// inside one method body changes), so the total row count must be a fixed
+		// point from pass 2 onwards. This catches accumulation even in a form the
+		// surplus key above would miss — e.g. rows that differ in a property and
+		// so are not byte-identical duplicates, but still pile up.
+		if pass > 1 && len(b.Relationships) != prevRels {
+			t.Errorf("pass %d: persisted relationship count %d ≠ previous pass's %d — the incremental path "+
+				"is not at a fixed point; it is accumulating (or shedding) rows across passes",
+				pass, len(b.Relationships), prevRels)
+		}
+		prevRels = len(b.Relationships)
+	}
+	t.Logf("per-pass trace:\n  %s", strings.Join(trace, "\n  "))
+}
+
+// TestIncremental_DependsOnWeightParity_6098 is a live, self-contained
+// reproduction of #6098 — SKIPPED, because #6098 is a DIFFERENT defect from
+// #6094 and its fix does not belong in this change. Un-skip it when the
+// resolver work below is picked up; it is already red for the right reason.
+//
+// #6098 IS NOT THE SAME ROOT CAUSE AS #6094. Evidence.
+// ─────────────────────────────────────────────────────
+// The empty-FromID fix in extractors.relRecordToGraphRel removes 100% of the
+// #6094 surplus (1→5→9 becomes 0→0→0) and moves the #6098 weights by exactly
+// ZERO: [39, 117] incremental vs [40, 120] full, both before and after. An
+// initial hypothesis that module aggregation was losing the empty-FromID edges
+// through idMod[r.FromID] is therefore refuted by measurement.
+//
+// The actual chain, from a full row-level diff of the two persisted graphs:
+//
+//  1. The scoped resolver (internal/extractors/sresolver) resolves a stub
+//     endpoint through two tiers only: whole-string name/qualified-name, and
+//     Format A (file, tail). It has NO receiver-type tier. So the Go
+//     extractor's `Use7 -CALLS-> "Do"` and `T7.Do -CALLS-> "N"` — bare-name
+//     stubs carrying Properties["receiver_type"]={I7,T7} — stay unresolved,
+//     where the full resolver binds them via its package-scoped member index
+//     (internal/resolve/refs.go:5588, issues #148/#364) to T7.Do and T7.N.
+//  2. With those CALLS dangling, the process-flow pass cannot chain
+//     Use7 → T7.Do → T7.N, so the SCOPE.Process entity `Use7 → T7.N` is never
+//     built on the incremental path (it IS built by the full rebuild).
+//  3. That missing process costs 5 relationship rows: 3 STEP_IN_PROCESS, 1
+//     ENTRY_POINT_OF, 1 CONTAINS — which is exactly the 882 vs 877 row gap.
+//  4. Module aggregation weighs cross-module edges. The 3 STEP_IN_PROCESS run
+//     _external→test-repo (120−117=3) and the ENTRY_POINT_OF runs
+//     test-repo→_external (40−39=1). The weight shortfall is fully accounted
+//     for by the missing rows, with no residual.
+//
+// So #6098 is a RESOLUTION-PARITY gap in sresolver, surfacing as a weight
+// discrepancy three passes downstream. Closing it means porting the full
+// resolver's receiver-type / package-member tier — which is built on a
+// package-scoped member index over the entire entity set — onto the scoped
+// path. That is a separate change against a separate component, and shipping a
+// partial version of it here would be worse than leaving the defect visible.
+func TestIncremental_DependsOnWeightParity_6098(t *testing.T) {
+	t.Skip("#6098 is open and is NOT the #6094 root cause — see the comment above for the " +
+		"measured evidence and the exact chain; un-skip when sresolver gains a receiver-type tier")
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	const nFiles = 20
+	for i := 0; i < nFiles; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("a/r%02d.go", i), dvMultisetCorpusFile(i))
+	}
+	for i := nFiles; i < 2*nFiles; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("b/r%02d.go", i), dvMultisetCorpusFile(i))
+	}
+
+	dvFullRebuild(t, repo, stateDir)
+
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "a/r07.go", fmt.Sprintf(`package svc
+
+type T7 struct{ N int }
+
+type I7 interface{ Do() int }
+
+func (t *T7) Do() int { return t.N + h7() + %d }
+
+func h7() int { return 7 }
+
+func New7() *T7 { return &T7{N: 7} }
+
+func Use7(x I7) int { return x.Do() }
+`, pass))
+		dvIncremental(t, repo, stateDir)
+	}
+
+	b, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load incremental graph: %v", err)
+	}
+	// Full-rebuild the SAME end-state into a fresh state dir — the reference.
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	got := dvModuleLayer(b)
+	want := dvModuleLayer(c)
+	if len(want) == 0 {
+		t.Fatal("fixture is vacuous: the full rebuild produced no Module→Module DEPENDS_ON edge to compare weights on")
+	}
+	for k, wv := range want {
+		gv, ok := got[k]
+		if !ok {
+			t.Errorf("module edge %s missing from the incremental graph (full rebuild weight=%s)", k, wv)
+			continue
+		}
+		if gv != wv {
+			t.Errorf("module edge %s: incremental weight=%s, full-rebuild weight=%s (#6098)", k, gv, wv)
+		}
+	}
+	for k, gv := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("module edge %s present ONLY in the incremental graph (weight=%s)", k, gv)
+		}
+	}
+	t.Logf("incremental module layer: %v\nfull rebuild:            %v", got, want)
+}

--- a/cmd/grafel/incremental_dup_rows_6094_test.go
+++ b/cmd/grafel/incremental_dup_rows_6094_test.go
@@ -25,6 +25,15 @@
 // unbounded. The fix restores both steps; there is no downstream row dedupe,
 // which would have hidden the malformed edges instead of removing them.
 //
+// BLAST RADIUS — corrected. An earlier reading of #6094, including the version
+// first published on the issue, held that type members were REQUIRED and that
+// plain-function corpora were immune. That is false. The defect rides on ANY
+// omitted-FromID record-embedded edge; a plain-function corpus carrying a single
+// import accumulates too (measured pre-fix: surplus 0/1/2, empty-FromID 1/2/3).
+// Only plain functions with ZERO imports are clean. Type members simply produce
+// more owned edges per file, so they accumulate faster. Both shapes are in the
+// table below for that reason.
+//
 // #6098 IS A DIFFERENT DEFECT and is NOT fixed here. The fix above moves its
 // numbers by exactly zero — see TestIncremental_DependsOnWeightParity_6098
 // below for the measurement and the actual chain.
@@ -114,18 +123,62 @@ func dupEmptyFrom(doc *graph.Document) (n int, sample []string) {
 	return n, sample
 }
 
+// dupImportCorpusFile is the second corpus shape: PLAIN FUNCTIONS ONLY, no
+// types at all, but carrying imports — including the same package imported
+// twice under different aliases.
+//
+// Two things ride on this shape.
+//
+// FIRST, it corrects the blast radius. An earlier reading of #6094 held that
+// type members were REQUIRED to trigger the defect and that plain-function
+// corpora were clean. That is false, and the false version was published: a
+// plain-function corpus with a single import accumulates too (measured on the
+// pre-fix tree: surplus 0/1/2, empty-FromID 1/2/3, growing per pass). Only
+// plain functions with ZERO imports are clean. The defect rides on ANY omitted-
+// FromID record-embedded edge — here the function→import REFERENCES edge.
+// Type members merely produce more of them per file.
+//
+// SECOND, the duplicate-alias import is the only shape in this suite that fires
+// the seenRel dedupe guard through the real pipeline. Go emits one
+// SCOPE.Component record PER import statement, so `strings` + `s2 "strings"`
+// yields two records that both emit `<file> -IMPORTS-> ext:strings`. Without the
+// guard the incremental graph carries that row twice where a full rebuild
+// carries it once. Before this corpus existed the guard never fired once across
+// either suite, and reverting it left every test green.
+func dupImportCorpusFile(i int) string {
+	return fmt.Sprintf(`package svc
+
+import (
+	"strings"
+	s2 "strings"
+	"strconv"
+)
+
+func Up%d(x string) string { return strings.ToUpper(x) }
+
+func Down%d(x string) string { return s2.ToLower(x) }
+
+func Num%d(x int) string { return strconv.Itoa(x + %d) }
+`, i, i, i, i)
+}
+
 // TestIncremental_NoDuplicateRowsAcrossPasses_6094 is the compounding gate.
 //
-// A 40-file Go corpus (structs + interfaces + methods — a corpus of plain
-// functions does NOT reproduce this; the owned CONTAINS/REFERENCES edges the
-// defect rides on only exist for type members) is full-rebuilt, then three
-// SEQUENTIAL single-file deltas are applied, each through a real
-// TryIncremental. After EVERY pass the persisted graph.fb is read back and
-// asserted to carry zero surplus rows and zero empty-FromID edges.
+// A 40-file Go corpus is full-rebuilt, then three SEQUENTIAL single-file deltas
+// are applied, each through a real TryIncremental. After EVERY pass the
+// persisted graph.fb is read back and asserted to carry zero surplus rows and
+// zero empty-FromID edges.
 //
 // Asserting after every pass — not only at the end — is what makes this a
-// compounding gate: the pre-fix numbers were 1 → 5 → 9 surplus rows, so a
-// per-pass trace also documents the accumulation rate if it ever returns.
+// compounding gate: the pre-fix numbers were 1 → 5 → 9 surplus rows on the
+// type-member corpus, so a per-pass trace also documents the accumulation rate
+// if it ever returns.
+//
+// TWO corpus shapes, because they exercise different halves of the fix:
+// "type-members" carries owned CONTAINS/REFERENCES edges from structs,
+// interfaces and methods; "plain-functions-with-imports" has no types at all and
+// pins both the corrected blast radius and the dedupe guard (see
+// dupImportCorpusFile).
 //
 // Every corpus file gets a UNIQUE basename on purpose: diff.Filter
 // cross-invalidates same-basename files, so a corpus of 40 files all named f.go
@@ -133,42 +186,17 @@ func dupEmptyFrom(doc *graph.Document) (n int, sample []string) {
 // full-reindex fallback — silently making the case vacuous. dvIncremental
 // additionally fails the test if TryIncremental falls back.
 func TestIncremental_NoDuplicateRowsAcrossPasses_6094(t *testing.T) {
-	repo := t.TempDir()
-	stateDir := t.TempDir()
-	const nFiles = 40
-	for i := 0; i < nFiles; i++ {
-		dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), dvMultisetCorpusFile(i))
-	}
-
-	dvFullRebuild(t, repo, stateDir)
-
-	// Control: the full rebuild must be clean on both dimensions, so anything
-	// observed after an incremental pass is attributable to the incremental path.
-	base, err := graph.LoadGraphFromDir(stateDir)
-	if err != nil {
-		t.Fatalf("load baseline: %v", err)
-	}
-	if n, sample := dupSurplusRows(base); n != 0 {
-		t.Fatalf("control violated: the FULL rebuild already carries %d surplus relationship row(s): %v", n, sample)
-	}
-	if n, sample := dupEmptyFrom(base); n != 0 {
-		t.Fatalf("control violated: the FULL rebuild already carries %d empty-FromID edge(s): %v", n, sample)
-	}
-	// Pass-over-pass stability, not equality with the full rebuild. The
-	// incremental graph is legitimately a few rows SHORT of a full rebuild on
-	// this corpus for an unrelated, still-open reason (#6098: the scoped
-	// resolver has no receiver-type / package-member tier, so an intra-file
-	// method CALLS stays a bare-name stub and the process-flow pass never builds
-	// the SCOPE.Process it would have anchored — see the comment on
-	// TestIncremental_DependsOnWeightParity_6098). Asserting equality here would
-	// couple this gate to that defect. What #6094 is about is GROWTH: the row
-	// count must reach a fixed point after the first pass and stay there.
-	var prevRels int
-
-	var trace []string
-	for pass := 1; pass <= 3; pass++ {
-		dvSeedManifest(t, repo, stateDir)
-		dvWriteFile(t, repo, "r07.go", fmt.Sprintf(`package svc
+	cases := []struct {
+		name string
+		file func(int) string
+		// delta returns the pass-N content of the file that is edited.
+		delta func(pass int) string
+	}{
+		{
+			name: "type-members",
+			file: dvMultisetCorpusFile,
+			delta: func(pass int) string {
+				return fmt.Sprintf(`package svc
 
 type T7 struct{ N int }
 
@@ -181,40 +209,193 @@ func h7() int { return 7 }
 func New7() *T7 { return &T7{N: 7} }
 
 func Use7(x I7) int { return x.Do() }
+`, pass)
+			},
+		},
+		{
+			name: "plain-functions-with-imports",
+			file: dupImportCorpusFile,
+			delta: func(pass int) string {
+				return fmt.Sprintf(`package svc
+
+import (
+	"strings"
+	s2 "strings"
+	"strconv"
+)
+
+func Up7(x string) string { return strings.ToUpper(x) + "%d" }
+
+func Down7(x string) string { return s2.ToLower(x) }
+
+func Num7(x int) string { return strconv.Itoa(x + 7) }
+`, pass)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			stateDir := t.TempDir()
+			const nFiles = 40
+			for i := 0; i < nFiles; i++ {
+				dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), tc.file(i))
+			}
+
+			dvFullRebuild(t, repo, stateDir)
+
+			// Control: the full rebuild must be clean on both dimensions, so
+			// anything observed after an incremental pass is attributable to the
+			// incremental path.
+			base, err := graph.LoadGraphFromDir(stateDir)
+			if err != nil {
+				t.Fatalf("load baseline: %v", err)
+			}
+			if n, sample := dupSurplusRows(base); n != 0 {
+				t.Fatalf("control violated: the FULL rebuild already carries %d surplus relationship row(s): %v", n, sample)
+			}
+			if n, sample := dupEmptyFrom(base); n != 0 {
+				t.Fatalf("control violated: the FULL rebuild already carries %d empty-FromID edge(s): %v", n, sample)
+			}
+			fullRels := len(base.Relationships)
+
+			// Pass-over-pass stability, NOT equality with the full rebuild.
+			//
+			// Read this before interpreting the row counts in the trace: the
+			// incremental graph settles on a fixed point that is a few rows SHORT
+			// of a full rebuild (877 vs 882 on the type-member corpus). That
+			// residual gap is #6098 — still open, tracked, and verified to be
+			// entirely attributable to it, not to the #6094 fix. A stable count is
+			// therefore NOT parity with a full rebuild, and nothing here should be
+			// read as claiming it is. #6094 is about GROWTH: the count must reach a
+			// fixed point after the first pass and stay there.
+			var prevRels int
+
+			var trace []string
+			for pass := 1; pass <= 3; pass++ {
+				dvSeedManifest(t, repo, stateDir)
+				dvWriteFile(t, repo, "r07.go", tc.delta(pass))
+				dvIncremental(t, repo, stateDir)
+
+				// Read the PERSISTED graph — never the run log, which over-reports.
+				b, err := graph.LoadGraphFromDir(stateDir)
+				if err != nil {
+					t.Fatalf("pass %d: load persisted graph: %v", pass, err)
+				}
+				surplus, dupSample := dupSurplusRows(b)
+				empty, emptySample := dupEmptyFrom(b)
+				trace = append(trace, fmt.Sprintf("pass %d: rels=%d surplus=%d empty-from=%d", pass, len(b.Relationships), surplus, empty))
+
+				if empty != 0 {
+					t.Errorf("pass %d: persisted graph carries %d relationship(s) with an EMPTY FromID (full rebuild: 0): %v\n"+
+						"the incremental re-extraction must substitute the owning entity record's ID for an empty "+
+						"record-embedded FromID, exactly as the full-index assembly loop does", pass, empty, emptySample)
+				}
+				if surplus != 0 {
+					t.Errorf("pass %d: persisted graph carries %d SURPLUS relationship row(s) keyed on "+
+						"(FromID, ToID, Kind, ID, properties): %v", pass, surplus, dupSample)
+				}
+				// The corpus end-state is the same shape on every pass (only a
+				// literal inside one body changes), so the total row count must be a
+				// fixed point from pass 2 onwards. This catches accumulation even in
+				// a form the surplus key above would miss — e.g. rows that differ in
+				// a property and so are not byte-identical duplicates, but still
+				// pile up.
+				if pass > 1 && len(b.Relationships) != prevRels {
+					t.Errorf("pass %d: persisted relationship count %d ≠ previous pass's %d — the incremental path "+
+						"is not at a fixed point; it is accumulating (or shedding) rows across passes",
+						pass, len(b.Relationships), prevRels)
+				}
+				prevRels = len(b.Relationships)
+			}
+			t.Logf("full rebuild: %d rels (residual gap to the incremental fixed point is #6098, still open)\nper-pass trace:\n  %s",
+				fullRels, strings.Join(trace, "\n  "))
+		})
+	}
+}
+
+// TestIncremental_GuardSuppressesDuplicateImportRow_6094 pins, through the REAL
+// pipeline, that the dedupe guard both FIRES and lands on the full rebuild's
+// row count for a duplicated-alias import.
+//
+// The gate above asserts "no surplus rows", which a guard-less tree can satisfy
+// by accident if the duplicated row is evicted before the next pass. This
+// asserts the positive form directly: the incremental graph must carry the
+// `<file> -IMPORTS-> strings` row EXACTLY as many times as a full rebuild of the
+// identical source does. Reverting the guard makes the incremental count exceed
+// the full-rebuild count, which no other assertion in the suite observes.
+func TestIncremental_GuardSuppressesDuplicateImportRow_6094(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	const nFiles = 12
+	for i := 0; i < nFiles; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), dupImportCorpusFile(i))
+	}
+	dvFullRebuild(t, repo, stateDir)
+
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "r07.go", fmt.Sprintf(`package svc
+
+import (
+	"strings"
+	s2 "strings"
+	"strconv"
+)
+
+func Up7(x string) string { return strings.ToUpper(x) + "%d" }
+
+func Down7(x string) string { return s2.ToLower(x) }
+
+func Num7(x int) string { return strconv.Itoa(x + 7) }
 `, pass))
 		dvIncremental(t, repo, stateDir)
-
-		// Read the PERSISTED graph — never the run log, which over-reports.
-		b, err := graph.LoadGraphFromDir(stateDir)
-		if err != nil {
-			t.Fatalf("pass %d: load persisted graph: %v", pass, err)
-		}
-		surplus, dupSample := dupSurplusRows(b)
-		empty, emptySample := dupEmptyFrom(b)
-		trace = append(trace, fmt.Sprintf("pass %d: rels=%d surplus=%d empty-from=%d", pass, len(b.Relationships), surplus, empty))
-
-		if empty != 0 {
-			t.Errorf("pass %d: persisted graph carries %d relationship(s) with an EMPTY FromID (full rebuild: 0): %v\n"+
-				"the incremental re-extraction must substitute the owning entity record's ID for an empty "+
-				"record-embedded FromID, exactly as the full-index assembly loop does", pass, empty, emptySample)
-		}
-		if surplus != 0 {
-			t.Errorf("pass %d: persisted graph carries %d SURPLUS relationship row(s) keyed on "+
-				"(FromID, ToID, Kind, ID, properties): %v", pass, surplus, dupSample)
-		}
-		// The corpus end-state is the same shape on every pass (only a literal
-		// inside one method body changes), so the total row count must be a fixed
-		// point from pass 2 onwards. This catches accumulation even in a form the
-		// surplus key above would miss — e.g. rows that differ in a property and
-		// so are not byte-identical duplicates, but still pile up.
-		if pass > 1 && len(b.Relationships) != prevRels {
-			t.Errorf("pass %d: persisted relationship count %d ≠ previous pass's %d — the incremental path "+
-				"is not at a fixed point; it is accumulating (or shedding) rows across passes",
-				pass, len(b.Relationships), prevRels)
-		}
-		prevRels = len(b.Relationships)
 	}
-	t.Logf("per-pass trace:\n  %s", strings.Join(trace, "\n  "))
+
+	b, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load incremental graph: %v", err)
+	}
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	// Count IMPORTS rows sourced from the edited file, on both sides. The
+	// import-placeholder-prune hoists these edges onto the file's SCOPE.Component
+	// and re-keys FromID to its hex ID, so the edited file has to be identified
+	// by resolving FromID back to an entity and reading its SourceFile — matching
+	// on the raw FromID string finds nothing.
+	count := func(doc *graph.Document) map[string]int {
+		src := make(map[string]string, len(doc.Entities))
+		for i := range doc.Entities {
+			src[doc.Entities[i].ID] = doc.Entities[i].SourceFile
+		}
+		out := map[string]int{}
+		for _, r := range doc.Relationships {
+			if r.Kind != "IMPORTS" || src[r.FromID] != "r07.go" {
+				continue
+			}
+			out[src[r.FromID]+"→"+r.ToID]++
+		}
+		return out
+	}
+	got, want := count(b), count(c)
+	if len(want) == 0 {
+		t.Fatal("fixture is vacuous: the full rebuild carries no IMPORTS edge out of r07.go, so the guard " +
+			"cannot be under test here — the extractor's import shape must have changed")
+	}
+	for k, wv := range want {
+		if gv := got[k]; gv != wv {
+			t.Errorf("IMPORTS row %s appears %d× in the incremental graph, %d× in a full rebuild of identical "+
+				"source — the re-extraction dedupe guard is not matching the full path", k, gv, wv)
+		}
+	}
+	for k, gv := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("IMPORTS row %s (×%d) exists ONLY in the incremental graph", k, gv)
+		}
+	}
+	t.Logf("IMPORTS rows out of r07.go — incremental: %v ; full rebuild: %v", got, want)
 }
 
 // TestIncremental_DependsOnWeightParity_6098 is a live, self-contained
@@ -242,12 +423,23 @@ func Use7(x I7) int { return x.Do() }
 //  2. With those CALLS dangling, the process-flow pass cannot chain
 //     Use7 → T7.Do → T7.N, so the SCOPE.Process entity `Use7 → T7.N` is never
 //     built on the incremental path (it IS built by the full rebuild).
-//  3. That missing process costs 5 relationship rows: 3 STEP_IN_PROCESS, 1
-//     ENTRY_POINT_OF, 1 CONTAINS — which is exactly the 882 vs 877 row gap.
+//  3. The 882 vs 877 row gap is a NET, not a loss set. A bidirectional multiset
+//     diff on this fixture reports 7 rows LOST and 2 INVENTED (7−2=5). The 2
+//     invented are the same two CALLS in mis-bound stub form — `Use7→"Do"` and
+//     `T7.Do→"N"` — against the resolved `→T7.Do` / `→T7.N` a full rebuild
+//     produces. The net 5 is the missing process: 3 STEP_IN_PROCESS, 1
+//     ENTRY_POINT_OF, 1 CONTAINS. Both absolute counts are corpus-dependent: on
+//     a richer corpus (embedded structs, generics, value + pointer receivers)
+//     they become 14 LOST / 9 INVENTED, net still 5. Read the NET as the
+//     invariant — "net 5; N lost / N−5 invented, N growing with corpus
+//     richness" — and the absolutes as fixture-specific.
 //  4. Module aggregation weighs cross-module edges. The 3 STEP_IN_PROCESS run
 //     _external→test-repo (120−117=3) and the ENTRY_POINT_OF runs
-//     test-repo→_external (40−39=1). The weight shortfall is fully accounted
-//     for by the missing rows, with no residual.
+//     test-repo→_external (40−39=1). The 2 invented stub CALLS contribute 0 in
+//     both directions — intra-module once resolved, and unresolvable while they
+//     remain stubs — so the weight shortfall is fully accounted for, with no
+//     residual. parity.CompareWithOptions reports exactly 2 RelPropDiffs here,
+//     which is that pair and nothing else.
 //
 // So #6098 is a RESOLUTION-PARITY gap in sresolver, surfacing as a weight
 // discrepancy three passes downstream. Closing it means porting the full

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -459,6 +459,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	var newEntities []graph.Entity
 	var newRels []graph.Relationship
+	// #6094 — mirrors buildDocument's `seenRel`: one identity per
+	// (FromID, ToID, Kind) across this whole re-extraction batch.
+	seenNewRel := make(map[string]bool)
 
 	for _, rel := range reallyChanged {
 		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
@@ -499,7 +502,29 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			e := entityRecordToGraphEntity(rec, doc.Repo)
 			newEntities = append(newEntities, e)
 			for _, relRec := range rec.Relationships {
-				newRels = append(newRels, relRecordToGraphRel(relRec))
+				// #6094: a record-embedded edge with no explicit FromID is OWNED
+				// by the record carrying it — the full-index assembly loop
+				// (cmd/grafel/index.go, buildDocument) substitutes the owning
+				// entity's ID, and so must this path. Leaving it empty makes the
+				// edge invisible to every FromID-keyed consumer: the stale-edge
+				// eviction above never drops it (so each pass appends another
+				// copy — the unbounded accumulation in #6094) and module
+				// aggregation cannot attribute it to a module (so it never
+				// contributes to the DEPENDS_ON weight — #6098).
+				r := relRecordToGraphRel(relRec, e.ID)
+				// #6094: the full path also guards with `seenRel` keyed on
+				// (FromID, ToID, Kind), because an extractor may emit the same
+				// owned edge twice within one file. types.RelationshipRecord has
+				// no ID field, so record-embedded edges can never carry the
+				// salted IDs some engine passes use to keep distinct edges that
+				// share a triple — the triple is a safe identity HERE and only
+				// here. seenNewRel is scoped to this re-extraction batch, exactly
+				// as buildDocument's is scoped to its own assembly.
+				if seenNewRel[r.ID] {
+					continue
+				}
+				seenNewRel[r.ID] = true
+				newRels = append(newRels, r)
 			}
 		}
 	}
@@ -971,12 +996,23 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 }
 
 // relRecordToGraphRel converts an embedded types.RelationshipRecord to a
-// graph.Relationship.
-func relRecordToGraphRel(r types.RelationshipRecord) graph.Relationship {
-	id := graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+// graph.Relationship, mirroring the full-index assembly loop in
+// cmd/grafel/index.go (buildDocument).
+//
+// ownerID is the ID of the entity record that carried r. A record-embedded edge
+// may legitimately omit FromID to mean "from my owner"; the full path
+// substitutes the owner's ID in that case and this path must agree, or the edge
+// lands with an empty FromID and becomes invisible to every FromID-keyed
+// consumer downstream (#6094 duplicate accumulation, #6098 weight shortfall).
+func relRecordToGraphRel(r types.RelationshipRecord, ownerID string) graph.Relationship {
+	fromID := r.FromID
+	if fromID == "" {
+		fromID = ownerID
+	}
+	id := graph.RelationshipID(fromID, r.ToID, r.Kind)
 	return graph.Relationship{
 		ID:     id,
-		FromID: r.FromID,
+		FromID: fromID,
 		ToID:   r.ToID,
 		Kind:   r.Kind,
 

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -459,8 +459,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	var newEntities []graph.Entity
 	var newRels []graph.Relationship
-	// #6094 — mirrors buildDocument's `seenRel`: one identity per
-	// (FromID, ToID, Kind) across this whole re-extraction batch.
+	// #6094 — one identity per (FromID, ToID, Kind), shared across every file in
+	// this re-extraction batch. See convertExtractedRecords for why the triple is
+	// a safe identity here and how this scope differs from buildDocument's.
 	seenNewRel := make(map[string]bool)
 
 	for _, rel := range reallyChanged {
@@ -498,35 +499,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		}
 
 		// Convert types.EntityRecord → graph.Entity (same logic as buildDocument).
-		for _, rec := range records {
-			e := entityRecordToGraphEntity(rec, doc.Repo)
-			newEntities = append(newEntities, e)
-			for _, relRec := range rec.Relationships {
-				// #6094: a record-embedded edge with no explicit FromID is OWNED
-				// by the record carrying it — the full-index assembly loop
-				// (cmd/grafel/index.go, buildDocument) substitutes the owning
-				// entity's ID, and so must this path. Leaving it empty makes the
-				// edge invisible to every FromID-keyed consumer: the stale-edge
-				// eviction above never drops it (so each pass appends another
-				// copy — the unbounded accumulation in #6094) and module
-				// aggregation cannot attribute it to a module (so it never
-				// contributes to the DEPENDS_ON weight — #6098).
-				r := relRecordToGraphRel(relRec, e.ID)
-				// #6094: the full path also guards with `seenRel` keyed on
-				// (FromID, ToID, Kind), because an extractor may emit the same
-				// owned edge twice within one file. types.RelationshipRecord has
-				// no ID field, so record-embedded edges can never carry the
-				// salted IDs some engine passes use to keep distinct edges that
-				// share a triple — the triple is a safe identity HERE and only
-				// here. seenNewRel is scoped to this re-extraction batch, exactly
-				// as buildDocument's is scoped to its own assembly.
-				if seenNewRel[r.ID] {
-					continue
-				}
-				seenNewRel[r.ID] = true
-				newRels = append(newRels, r)
-			}
-		}
+		ents, rels := convertExtractedRecords(records, doc.Repo, seenNewRel)
+		newEntities = append(newEntities, ents...)
+		newRels = append(newRels, rels...)
 	}
 
 	// --- Step 6a: inbound-dangling prune (#2719) ---
@@ -993,6 +968,68 @@ func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entit
 
 		Confidence: r.Confidence, // Phase 1C (#2769) — propagates extractor stamp.
 	}.WithProperties(r.Properties)
+}
+
+// convertExtractedRecords converts one file's extractor output into graph
+// entities and relationships, mirroring the assembly loop in cmd/grafel/index.go
+// (buildDocument). seenRel carries the (FromID, ToID, Kind) identities already
+// emitted and is MUTATED — callers share one map across the whole re-extraction
+// batch.
+//
+// Two behaviours here are the #6094 fix, and both must be preserved:
+//
+// OWNER-ID SUBSTITUTION. A record-embedded edge with no explicit FromID is
+// OWNED by the record carrying it, so the owning entity's ID is substituted (see
+// relRecordToGraphRel). Leaving FromID empty makes the edge invisible to every
+// FromID-keyed consumer: the stale-edge eviction in TryIncremental drops an old
+// edge only when removedEntityIDs[r.FromID], so an empty FromID matched nothing
+// and each pass appended another copy — the unbounded accumulation in #6094.
+//
+// THE seenRel GUARD. An extractor may emit the same owned edge more than once
+// for one file — e.g. Go's `import "strings"` plus `import s2 "strings"` yields
+// two SCOPE.Component records that both emit `<file> -IMPORTS-> ext:strings`.
+// The full path suppresses the repeat and this path must agree, or the
+// incremental graph carries a row the full rebuild does not.
+//
+// WHY (FromID, ToID, Kind) IS A SAFE IDENTITY HERE, AND ONLY HERE.
+// (from, to, kind) is NOT a unique relationship key in general: several engine
+// passes deliberately salt the relationship ID so edges sharing a triple stay
+// distinct (internal/engine/migration_schema_ops.go, phantom_edges.go,
+// process_flow.go, event_flow.go, internal/links, internal/graph). Collapsing on
+// the triple would destroy those. It is safe in THIS function because
+// types.RelationshipRecord has no ID field at all (internal/types/relationship.go)
+// — a record-embedded edge cannot carry a salted ID — and because those salted
+// producers are engine passes that never reach this loop, which only consumes
+// `ext.Extract` output. Kind is therefore load-bearing in the key: two edges
+// between the same pair of endpoints under different kinds are distinct edges and
+// both must survive.
+//
+// SCOPE DIFFERENCE FROM buildDocument. buildDocument's seenRel spans the whole
+// corpus; this one spans only the re-extracted batch, and is NOT seeded from the
+// surviving doc.Relationships. The asymmetry is harmless because the two maps
+// guard disjoint row sets: every entity sourced from a changed file — and, via
+// owner-ID substitution, every edge owned by one — is evicted from
+// doc.Relationships before this runs, so a surviving row and a freshly emitted
+// row cannot share a (FromID, ToID, Kind) identity unless the survivor is
+// inbound from an UNCHANGED file, and inbound rows are not re-emitted here at
+// all. Seeding from the survivors would additionally risk suppressing a
+// legitimately re-emitted edge, so it is deliberately not done.
+func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenRel map[string]bool) ([]graph.Entity, []graph.Relationship) {
+	ents := make([]graph.Entity, 0, len(records))
+	var rels []graph.Relationship
+	for _, rec := range records {
+		e := entityRecordToGraphEntity(rec, repoTag)
+		ents = append(ents, e)
+		for _, relRec := range rec.Relationships {
+			r := relRecordToGraphRel(relRec, e.ID)
+			if seenRel[r.ID] {
+				continue
+			}
+			seenRel[r.ID] = true
+			rels = append(rels, r)
+		}
+	}
+	return ents, rels
 }
 
 // relRecordToGraphRel converts an embedded types.RelationshipRecord to a

--- a/internal/extractors/incremental_convert_records_6094_test.go
+++ b/internal/extractors/incremental_convert_records_6094_test.go
@@ -1,0 +1,200 @@
+// Package extractors — incremental_convert_records_6094_test.go
+//
+// #6094 unit gates for convertExtractedRecords: the record→graph seam on the
+// incremental path. Two behaviours live there and each has a destructive
+// failure mode, so each is pinned independently:
+//
+//	OWNER-ID SUBSTITUTION — an omitted FromID means "from my owner". Dropping
+//	  it strands the edge with an empty FromID, invisible to the stale-edge
+//	  eviction, which is the unbounded accumulation in #6094.
+//	THE seenRel GUARD — the same owned edge emitted twice for one file must be
+//	  emitted once, as the full path does.
+//
+// The guard's KEY is the dangerous part. (from, to, kind) is not a unique
+// relationship key in general — engine passes salt IDs precisely because edges
+// share a triple, and #6085 converged on data loss by collapsing on it. It is
+// safe HERE only because types.RelationshipRecord has no ID field and the
+// salted producers never reach this loop. TestConvertExtractedRecords_GuardKey
+// pins every component of that key, so widening OR narrowing it fails loudly.
+package extractors
+
+import (
+	"fmt"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// ceRec builds an EntityRecord with a deterministic identity and the given
+// embedded relationships.
+func ceRec(kind, name, file string, rels ...types.RelationshipRecord) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:          kind,
+		Name:          name,
+		QualifiedName: name,
+		SourceFile:    file,
+		Language:      "go",
+		Relationships: rels,
+	}
+}
+
+// ceRel builds a RelationshipRecord. An empty from means "owned by my record".
+func ceRel(from, to, kind string, props map[string]string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID:     from,
+		ToID:       to,
+		Kind:       kind,
+		Properties: types.PropsFromMap(props),
+	}
+}
+
+// ceTriples renders the produced edges as sorted "from|to|kind" strings.
+func ceTriples(rels []graph.Relationship) []string {
+	out := make([]string, 0, len(rels))
+	for _, r := range rels {
+		out = append(out, fmt.Sprintf("%s|%s|%s", r.FromID, r.ToID, r.Kind))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestConvertExtractedRecords_GuardKey pins the identity the dedupe guard uses.
+//
+// Each sub-case is a mutant detector. The (from,to) case is the one that
+// matters most: dropping Kind from the key is the exact shape of the #6085 data
+// loss, and it is invisible to any test that only counts rows per file.
+func TestConvertExtractedRecords_GuardKey(t *testing.T) {
+	const repo = "r"
+
+	t.Run("identical owned edges collapse to one", func(t *testing.T) {
+		// Two SCOPE.Component records for the same import, each emitting the
+		// same file→package IMPORTS edge — the real shape produced by Go's
+		// `import "strings"` + `import s2 "strings"`.
+		recs := []types.EntityRecord{
+			ceRec("SCOPE.Component", "strings", "a.go", ceRel("a.go", "ext:strings", "IMPORTS", map[string]string{"language": "go"})),
+			ceRec("SCOPE.Component", "strings", "a.go", ceRel("a.go", "ext:strings", "IMPORTS", map[string]string{"language": "go"})),
+		}
+		_, rels := convertExtractedRecords(recs, repo, map[string]bool{})
+		if got := ceTriples(rels); len(got) != 1 {
+			t.Fatalf("the guard must suppress the byte-identical repeat: got %d edge(s) %v, want 1", len(got), got)
+		}
+	})
+
+	t.Run("same endpoints, DIFFERENT kinds both survive", func(t *testing.T) {
+		// THE KEY ASSERTION. These two edges share (from, to) and differ only in
+		// Kind. They are distinct edges and both must reach the graph. A guard
+		// keyed on (from, to) silently destroys one of them — that is the #6085
+		// data-loss shape, and this is the only thing in the tree that sees it.
+		recs := []types.EntityRecord{
+			ceRec("SCOPE.Component", "a.go", "a.go",
+				ceRel("a.go", "ext:strings", "IMPORTS", map[string]string{"language": "go"}),
+				ceRel("a.go", "ext:strings", "REFERENCES", map[string]string{"language": "go"}),
+			),
+		}
+		_, rels := convertExtractedRecords(recs, repo, map[string]bool{})
+		got := ceTriples(rels)
+		want := []string{"a.go|ext:strings|IMPORTS", "a.go|ext:strings|REFERENCES"}
+		if len(got) != 2 || got[0] != want[0] || got[1] != want[1] {
+			t.Fatalf("edges sharing (from,to) but differing in Kind must BOTH survive — Kind is "+
+				"load-bearing in the dedupe key.\ngot:  %v\nwant: %v", got, want)
+		}
+	})
+
+	t.Run("same kind, DIFFERENT endpoints both survive", func(t *testing.T) {
+		// Pins the from- and to- components of the key the same way, so a guard
+		// narrowed to (to, kind) or (from, kind) also fails.
+		recs := []types.EntityRecord{
+			ceRec("SCOPE.Component", "a.go", "a.go",
+				ceRel("a.go", "ext:strings", "IMPORTS", nil),
+				ceRel("a.go", "ext:bytes", "IMPORTS", nil),
+				ceRel("b.go", "ext:strings", "IMPORTS", nil),
+			),
+		}
+		_, rels := convertExtractedRecords(recs, repo, map[string]bool{})
+		if got := ceTriples(rels); len(got) != 3 {
+			t.Fatalf("three edges differing in an endpoint must all survive: got %d %v", len(got), got)
+		}
+	})
+
+	t.Run("owned edges from DIFFERENT owners both survive", func(t *testing.T) {
+		// Two distinct records emit an omitted-FromID edge to the same target —
+		// the shape Go produces when two functions in one file both reference the
+		// same import. After owner substitution these are different edges. If
+		// owner substitution were dropped, BOTH would key on ("", to, kind) and
+		// the guard would collapse them to one — so this case also fails if the
+		// substitution regresses, in a way distinct from the empty-FromID check.
+		recs := []types.EntityRecord{
+			ceRec("SCOPE.Operation", "A", "a.go", ceRel("", "scope:component:ref:go:a.go:strings", "REFERENCES", nil)),
+			ceRec("SCOPE.Operation", "B", "a.go", ceRel("", "scope:component:ref:go:a.go:strings", "REFERENCES", nil)),
+		}
+		ents, rels := convertExtractedRecords(recs, repo, map[string]bool{})
+		if len(rels) != 2 {
+			t.Fatalf("two owners emitting the same owned edge produce two distinct edges: got %d %v",
+				len(rels), ceTriples(rels))
+		}
+		if rels[0].FromID != ents[0].ID || rels[1].FromID != ents[1].ID {
+			t.Fatalf("each owned edge must be attributed to ITS OWN owner: got from=[%s %s], want [%s %s]",
+				rels[0].FromID, rels[1].FromID, ents[0].ID, ents[1].ID)
+		}
+	})
+
+	t.Run("guard is shared across files in one batch", func(t *testing.T) {
+		// seenRel is threaded through the whole re-extraction batch, so the same
+		// edge emitted from two different files is still emitted once — matching
+		// buildDocument, whose seenRel is corpus-wide.
+		seen := map[string]bool{}
+		_, r1 := convertExtractedRecords([]types.EntityRecord{
+			ceRec("SCOPE.Component", "strings", "a.go", ceRel("shared", "ext:strings", "IMPORTS", nil)),
+		}, repo, seen)
+		_, r2 := convertExtractedRecords([]types.EntityRecord{
+			ceRec("SCOPE.Component", "strings", "b.go", ceRel("shared", "ext:strings", "IMPORTS", nil)),
+		}, repo, seen)
+		if len(r1) != 1 || len(r2) != 0 {
+			t.Fatalf("the batch-wide guard must suppress the cross-file repeat: got %d then %d, want 1 then 0",
+				len(r1), len(r2))
+		}
+	})
+}
+
+// TestConvertExtractedRecords_OwnerIDSubstitution pins the other half of the
+// #6094 fix: no edge may leave this seam with an empty FromID.
+func TestConvertExtractedRecords_OwnerIDSubstitution(t *testing.T) {
+	recs := []types.EntityRecord{
+		ceRec("SCOPE.Class", "T", "a.go",
+			ceRel("", "field:T.N", "CONTAINS", map[string]string{"language": "go"}),
+			ceRel("", "method:T.Do", "CONTAINS", map[string]string{"language": "go"}),
+			// An edge that DOES carry an explicit FromID must be left alone.
+			ceRel("explicit", "ext:strings", "IMPORTS", nil),
+		),
+	}
+	ents, rels := convertExtractedRecords(recs, "r", map[string]bool{})
+	if len(ents) != 1 {
+		t.Fatalf("want 1 entity, got %d", len(ents))
+	}
+	owner := ents[0].ID
+	if owner == "" {
+		t.Fatal("owner entity ID is empty — the fixture cannot pin substitution")
+	}
+	for _, r := range rels {
+		if r.FromID == "" {
+			t.Errorf("edge →%s:%s left the record→graph seam with an EMPTY FromID; the owning "+
+				"record's ID (%s) must be substituted, exactly as buildDocument does", r.ToID, r.Kind, owner)
+		}
+		// The ID must be derived from the SUBSTITUTED FromID, not the empty one,
+		// or downstream re-keying disagrees with the full path.
+		if want := graph.RelationshipID(r.FromID, r.ToID, r.Kind); r.ID != want {
+			t.Errorf("edge %s→%s:%s has ID %q, want %q (derived from the substituted FromID)",
+				r.FromID, r.ToID, r.Kind, r.ID, want)
+		}
+	}
+	for _, r := range rels {
+		if r.Kind == "CONTAINS" && r.FromID != owner {
+			t.Errorf("owned CONTAINS edge →%s attributed to %q, want the owning record %q", r.ToID, r.FromID, owner)
+		}
+		if r.Kind == "IMPORTS" && r.FromID != "explicit" {
+			t.Errorf("edge with an EXPLICIT FromID was overwritten: got %q, want %q", r.FromID, "explicit")
+		}
+	}
+}


### PR DESCRIPTION
An incremental index persisted **duplicate relationship rows into `graph.fb`, compounding one additional copy per pass** — 1 → 5 → 9 across three sequential single-file deltas. Incremental is the default path for a watched repo, so a long-lived graph accumulated duplicates without bound.

## Root cause

The full-index assembly loop (`cmd/grafel/index.go:5310-5330`) converted a record-embedded `types.RelationshipRecord` while omitting two steps that `extractors.relRecordToGraphRel` performs: owner-ID substitution (`if fromID == "" { fromID = id }`) and a `seenRel` guard.

Without the first, edges reached disk with an **empty `FromID`**. The stale-edge eviction (`internal/extractors/incremental.go:446`) drops a prior edge only when `removedEntityIDs[r.FromID]` — an empty string matches no removed entity. So every prior pass's copies survived while re-extraction appended fresh ones.

The omitted steps are restored. **Deliberately not a downstream dedupe**: a row dedupe would have made the malformed edges invisible while leaving them in the graph.

| | pre-fix | post-fix |
|---|---|---|
| pass 1 | surplus 1, empty-from 4 | 0, 0 |
| pass 2 | surplus 5, empty-from 8 | 0, 0 |
| pass 3 | surplus 9, empty-from 12 | 0, 0 |

## The blast radius is wider than originally filed

The issue and my first analysis both said this requires structs, interfaces and methods, and that plain-function corpora are clean. **That is false.** A plain-function corpus containing a single `import "strings"` accumulates identically — surplus 0/1/2, growing per pass. Only plain functions with **zero imports** are clean.

The defect rides on **any** record-embedded edge with an omitted `FromID`. Type members merely produce more of them. In practice this affected essentially every repository, not a subset. The regression gate is now a table over both corpus shapes.

## The guard is the dangerous part, and it is now pinned

`(from, to, kind)` is **not** a unique relationship key in this codebase — producers deliberately salt IDs for edges sharing a triple (`migration_schema_ops.go:130`, `phantom_edges.go:149`, `process_flow.go:475`, `event_flow.go:350`, `tests_walkup.go:161`). #6085 converged on **data loss** deduping that way, reaching a lower fixed point by destroying legitimately distinct edges.

Review found the new guard **completely untested — it never fired once across either full suite** — and three mutants surviving. It was untestable in place, so the per-file conversion was extracted into `convertExtractedRecords` (behaviour unchanged) and pinned directly.

| mutant | at review | now |
|---|---|---|
| revert owner-ID substitution | KILLED | KILLED (6 assertions) |
| revert the `seenRel` guard | **SURVIVED** | **KILLED** (unit + both e2e gates) |
| key on `(from,to)`, drop `kind` | **SURVIVED** | **KILLED** |

The `(from,to)` mutant now fails with exactly the #6085 shape — `got: [a.go\|ext:strings\|IMPORTS]` against `want: [… IMPORTS … REFERENCES]`, one edge silently destroyed. The e2e gate reds with `IMPORTS row r07.go→ext:strings appears 2× in the incremental graph, 1× in a full rebuild`.

Triggering it required two imports of one package under different aliases (`import "strings"` + `import s2 "strings"`), since Go emits one `SCOPE.Component` record per import statement.

**Why the guard is safe here specifically:** `types.RelationshipRecord` has no `ID` field (`internal/types/relationship.go:10`), and all five salted-edge producers live in `internal/engine`, `internal/links` and `internal/graph` — engine passes. This loop only reaches `ext.Extract` via `Get(cr.Language)`, so none of them can arrive. Verified independently in review, which also forced the guard to fire and confirmed the suppressed row byte-identical in properties *and* confidence each time.

A fourth mutant — making the eviction also match empty `FromID` — is **unobservable by construction, not by omission**: with owner-ID substitution in place no edge reaches eviction with an empty `FromID`, so that branch is dead. Reported as such rather than as a kill that wasn't obtained; `TestConvertExtractedRecords_OwnerIDSubstitution` guarantees the precondition and fails if it stops holding.

## #6098 is a separate defect — the shared-root-cause hypothesis was refuted by measurement

Fixing this removes **100%** of the surplus rows and moves the `DEPENDS_ON` weights by **exactly zero**. #6098 instead traces to `sresolver` lacking a receiver-type tier, so bare-name stubs carrying `receiver_type` stay unresolved, the process-flow pass never builds `SCOPE.Process`, and its absence costs the observed rows.

Two corrections to what was published on that issue:

- **The gap is a net, not a loss set.** Bidirectional multiset diff gives **7 LOST / 2 INVENTED**, not 5 lost — the 2 are the same `CALLS` in mis-bound stub form. The weight conclusion survives with no residual (`RelPropDiffs` is exactly 2), but the framing was wrong: a pure shortfall and "also emitting rows the full rebuild doesn't" are different defects.
- **The number is corpus-specific.** A richer corpus gives 14 LOST / 9 INVENTED, net still 5. Restated in the test as *"net 5; N lost / N−5 invented, N growing with corpus richness."*

Both errors came from comparing in **one direction only**, which is structurally blind to what was added — the same blindness #6037 fixed in the parity comparator.

`TestIncremental_DependsOnWeightParity_6098` lands as a live, already-red reproduction, `t.Skip`ped, with the chain documented. Verified in review by un-skipping: it reds for exactly the documented reason and is non-vacuous.

## Also corrected

- **877 is a stable fixed point, not parity** — a full rebuild is 882. The gate now says so outright, and states the residual is #6098. Review verified the entire gap is attributable to #6098 and none of it to this change.
- The comment claiming `seenNewRel` is scoped "exactly as `buildDocument`'s" was false — this one is batch-scoped, `buildDocument`'s is corpus-wide. Replaced with why the asymmetry is harmless (the two maps guard disjoint row sets; every edge owned by a changed file is evicted before this runs, and inbound survivors are never re-emitted here) plus why seeding from survivors is deliberately avoided — it would risk suppressing a legitimate re-emission.

## Fixture integrity

`dvIncremental` hard-fails if the run falls back to a full reindex. Unique basenames throughout, because **`diff.Filter` cross-invalidates by basename** — a corpus with repeated filenames turns a 1-file delta into an N-file change and trips the `too-many-changed` fallback, silently making the test vacuous. The injection test `t.Fatal`s if the target kind is absent or inert.

`TestDiffReindex_MultisetComparatorCatchesDuplicateRows` previously consumed this defect as its live source of duplicates; it now injects the same shape deliberately, so it still proves both directions of the #6037 claim without depending on a bug existing.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. At `-count=1 -p 1`:

| package | exit | pass | skip |
|---|---|---|---|
| `./cmd/grafel/` | 0 | 472 | 9 |
| `./internal/graph/...` | 0 | 492 | **0** |
| `./internal/extractors/...` | 0 | 4003 | 1 |

0 FAIL throughout. Skips unchanged from before this work — 9 pre-existing benchmark/environment gates plus the intentional #6098 repro. No new skips; every added test runs.

Independently adversarially reviewed, returned REQUEST-CHANGES for the untested guard, re-verified.

Closes #6094
Refs #6098, #6037, #6085, #6083
