### PR TITLE
fix(#6104): merge custom extractor output by identity and enrichment, not name-keyed replacement

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -3430,32 +3430,34 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 				// for why, and why this is NOT the same thing as flipping
 				// GRAFEL_SUBPROC_EXTRACT.
 				//
-				// THE GATE IS NOT PURELY ADDITIVE, AND NOT PYTHON-ONLY (#6104).
-				// MergeWithCustom supersedes by NAME, so a custom entity whose
-				// Name collides with a base entity REPLACES it. Measured effects
-				// per language on the #5989 fixtures:
+				// THE MERGE IS NON-DESTRUCTIVE (#6104, fixed). MergeWithCustom
+				// used to supersede by NAME alone, so a custom entity whose Name
+				// collided with a base entity REPLACED it — 280 entities across 5
+				// kinds and 2 languages on the #5989 fixtures. It is now keyed on
+				// the graph's own identity (SourceFile, Kind, Name) and enforces
+				// two invariants: a merge never loses an entity, and a merge never
+				// narrows a span. Measured effects per language now:
 				//
-				//   python — Celery tasks destroy TWO base entities each
-				//            (Task + SCOPE.Operation), replaced by one
-				//            SCOPE.Service. A different-KIND collision.
-				//   java   — SCOPE.Operation is mutated IN PLACE: subtype
-				//            method->endpoint and EndLine truncated to the start
-				//            line, losing the body extent; the truncation
-				//            propagates into the derived http_endpoint_definition.
-				//            A SAME-KIND collision, so keying supersede on
-				//            (Kind, Name) would NOT fix it.
-				//   js     — route operations are REPLACED by better-positioned
-				//            ones (base emits them at line 0). An improvement,
-				//            but still a substitution, and invisible to any
-				//            count-based comparison.
+				//   python — the Celery task ADDS a SCOPE.Service; the base
+				//            Task and SCOPE.Operation are no longer destroyed by
+				//            the merge. (Task is subsequently folded into
+				//            SCOPE.Service by the #1613 class-shadow fold, which
+				//            repoints its edges — a combine, not a drop.)
+				//   java   — SCOPE.Operation keeps its full span; only the Subtype
+				//            is refined method->endpoint, with the displaced value
+				//            retained under types.EntityBaseSubtypeProperty. The
+				//            derived http_endpoint_definition is no longer
+				//            truncated.
+				//   js     — route operations gain real positions (base emits them
+				//            at line 0). A widening, never a narrowing.
 				//   go, ruby — genuinely inert; identical content tuples.
 				//
-				// The total loss set is 280 entities across 5 kinds and 2
-				// languages. This is the blocker for flipping the gate on by
-				// default; it is pinned by
-				// TestInProcCustomExtractorsSupersedeDestroysBaseEntities and
-				// TestInProcCustomExtractorsJavaEntityMutation. Do not flip the
-				// default until #6104 is closed.
+				// Pinned by TestInProcCustomExtractorsSupersedeIsNonDestructive and
+				// TestInProcCustomExtractorsJavaEnrichment. The gate stays
+				// default-OFF: its wall/alloc cost (+17.5% wall, +18.2%
+				// TotalAlloc) has never been measured at corpus scale, and #6105
+				// (synthetic Class:<Name> endpoints resolving to nothing) is still
+				// open. Flipping the default is a separate decision.
 				//
 				// The `file.TSTree != nil` guard is load-bearing beyond avoiding
 				// a use-after-free: a subset of custom extractors work on file

--- a/cmd/grafel/inproc_custom_extractors_5989_test.go
+++ b/cmd/grafel/inproc_custom_extractors_5989_test.go
@@ -355,98 +355,118 @@ func TestInProcCustomExtractorsJavaScriptIsNotInert(t *testing.T) {
 	t.Logf("javascript destroyed=%v added=%v", destroyed, added)
 }
 
-// TestInProcCustomExtractorsJavaEntityMutation PINS A KNOWN DEFECT (#6104).
+// TestInProcCustomExtractorsJavaEnrichment is the INVERSION of the former
+// TestInProcCustomExtractorsJavaEntityMutation, which pinned #6104's known
+// defect. It is now a correctness test.
 //
-// The Java custom extractors mutate existing entities IN PLACE rather than
-// adding new ones. The collision is SAME KIND, SAME NAME, SAME FILE — only
-// Subtype and EndLine differ:
+// WHAT IT USED TO PIN. The Java custom extractors collide with the base path
+// on SAME KIND, SAME NAME, SAME FILE:
 //
 //	OFF: SCOPE.Operation|OrdersController.list|api.OrdersController.list|method  |...|9|12
 //	ON:  SCOPE.Operation|OrdersController.list|api.OrdersController.list|endpoint|...|9| 9
 //
-// Two things are corrupted: Subtype flips method -> endpoint, and EndLine is
-// TRUNCATED to the start line, losing the body extent. The truncation
-// propagates into the derived http_endpoint_definition entity too.
+// Two things changed, and the old test asserted BOTH as broken behaviour:
+// Subtype flipped method -> endpoint, and EndLine was TRUNCATED to the start
+// line, losing the body extent — a truncation that propagated into the derived
+// http_endpoint_definition.
 //
-// WHY THIS TEST EXISTS SEPARATELY FROM THE CELERY PIN. Because the Java
-// collision is same-(Kind, Name), the obvious remedy for the Celery loss —
-// keying supersede on (Kind, Name) instead of Name alone — does NOT fix Java.
-// Without this test, that fix would turn the Celery pin red, be declared
-// complete, and ship with the Java corruption entirely unpinned.
+// WHAT IT ASSERTS NOW, AND WHY THE TWO ARE TREATED DIFFERENTLY. Those two
+// changes are not the same kind of change:
 //
-// Asserts the BROKEN behaviour deliberately. When #6104 is fixed this test
-// fails and should be inverted, not deleted.
-func TestInProcCustomExtractorsJavaEntityMutation(t *testing.T) {
+//   - The Subtype refinement is INFORMATION. "This method is really an
+//     endpoint" is exactly what the framework extractor exists to know, and
+//     discarding it would discard the point of the gate. It is KEPT, and the
+//     value it displaced is retained under types.EntityBaseSubtypeProperty so
+//     nothing is lost. Still asserted, now as desired behaviour.
+//
+//   - The EndLine truncation is DATA LOSS with no compensating information.
+//     Same kind, same name, same file means these are the same graph node, and
+//     a merge of two observations of one node must never produce a narrower
+//     span than either observation. Now asserted as forbidden.
+//
+// The old test's third assertion — that the truncation propagates to the
+// derived http_endpoint_definition — is kept and inverted with it: the
+// derived entity must not be truncated either.
+func TestInProcCustomExtractorsJavaEnrichment(t *testing.T) {
 	off, on := indexBothArms(t, "java_lang_repo")
-	destroyed, added := tupleDelta(entityTuples(off, "java"), entityTuples(on, "java"))
+	offT, onT := entityTuples(off, "java"), entityTuples(on, "java")
+	destroyed, added := tupleDelta(offT, onT)
 
-	if len(destroyed) == 0 {
-		t.Fatalf("KNOWN DEFECT APPEARS FIXED: the gate no longer destroys Java entities. " +
-			"If #6104 was fixed, invert this test to assert Java is inert.")
-	}
-
-	// 1. Subtype mutation on a same-kind/same-name/same-file entity.
-	var subtypeMutated bool
+	// 1. The Subtype refinement is KEPT — this is the gate's value on Java.
+	var subtypeRefined bool
 	for _, d := range destroyed {
 		if !strings.HasPrefix(d, "SCOPE.Operation|OrdersController.list|") || !strings.Contains(d, "|method|") {
 			continue
 		}
 		for _, a := range added {
 			if strings.HasPrefix(a, "SCOPE.Operation|OrdersController.list|") && strings.Contains(a, "|endpoint|") {
-				subtypeMutated = true
+				subtypeRefined = true
 			}
 		}
 	}
-	if !subtypeMutated {
-		t.Errorf("expected Java SCOPE.Operation subtype mutation method->endpoint; destroyed=%v added=%v",
+	if !subtypeRefined {
+		t.Errorf("expected the Java SCOPE.Operation subtype refinement method->endpoint to survive; destroyed=%v added=%v",
 			destroyed, added)
 	}
 
-	// 2. EndLine truncation — the body extent is lost. Compare the EndLine of
-	// the destroyed vs added tuple for the same Kind|Name|File.
-	endLineOf := func(tuple string) (kindName string, endLine int, ok bool) {
+	// 2. NO SPAN MAY NARROW. Compare the span of every destroyed tuple against
+	// its same Kind|Name|SourceFile successor in `added`. This is the
+	// assertion that used to require a truncation to exist.
+	spanOf := func(tuple string) (kindNameFile string, start, end int, ok bool) {
 		parts := strings.Split(tuple, "|")
 		if len(parts) != 7 {
-			return "", 0, false
+			return "", 0, 0, false
 		}
-		n, err := strconv.Atoi(parts[6])
+		st, err := strconv.Atoi(parts[5])
 		if err != nil {
-			return "", 0, false
+			return "", 0, 0, false
 		}
-		return parts[0] + "|" + parts[1] + "|" + parts[4], n, true
+		en, err := strconv.Atoi(parts[6])
+		if err != nil {
+			return "", 0, 0, false
+		}
+		return parts[0] + "|" + parts[1] + "|" + parts[4], st, en, true
 	}
-	offEnd := map[string]int{}
+	type span struct{ start, end int }
+	offSpan := map[string]span{}
 	for _, d := range destroyed {
-		if k, n, ok := endLineOf(d); ok {
-			offEnd[k] = n
+		if k, st, en, ok := spanOf(d); ok {
+			offSpan[k] = span{st, en}
 		}
 	}
-	var truncated []string
+	var narrowed []string
 	for _, a := range added {
-		k, n, ok := endLineOf(a)
+		k, st, en, ok := spanOf(a)
 		if !ok {
 			continue
 		}
-		if prev, seen := offEnd[k]; seen && n < prev {
-			truncated = append(truncated, fmt.Sprintf("%s EndLine %d->%d", k, prev, n))
+		prev, seen := offSpan[k]
+		if !seen {
+			continue
+		}
+		if en < prev.end {
+			narrowed = append(narrowed, fmt.Sprintf("%s EndLine %d->%d", k, prev.end, en))
+		}
+		// StartLine may only move EARLIER, or fill in from 0 (unknown).
+		if prev.start != 0 && st > prev.start {
+			narrowed = append(narrowed, fmt.Sprintf("%s StartLine %d->%d", k, prev.start, st))
 		}
 	}
-	if len(truncated) == 0 {
-		t.Errorf("expected Java EndLine truncation under the gate; destroyed=%v added=%v",
-			destroyed, added)
+	if len(narrowed) != 0 {
+		t.Errorf("#6104: the merge narrowed %d Java span(s), which is data loss regardless "+
+			"of which side wins: %v", len(narrowed), narrowed)
 	}
-	t.Logf("java truncations: %v", truncated)
 
-	// 3. The truncation must be visible on the derived endpoint entity too,
-	// proving the corruption propagates beyond the entity it originated on.
-	var endpointTruncated bool
-	for _, s := range truncated {
-		if strings.HasPrefix(s, "http_endpoint_definition|") {
-			endpointTruncated = true
+	// 3. And specifically the derived http_endpoint_definition — the entity the
+	// truncation used to propagate into — must be span-identical in both arms.
+	for tuple, n := range offT {
+		if !strings.HasPrefix(tuple, "http_endpoint_definition|") {
+			continue
 		}
-	}
-	if !endpointTruncated {
-		t.Errorf("expected the EndLine truncation to propagate to http_endpoint_definition; got %v", truncated)
+		if onT[tuple] < n {
+			t.Errorf("derived http_endpoint_definition tuple lost or altered under the gate: %q "+
+				"(off=%d on=%d); added=%v", tuple, n, onT[tuple], added)
+		}
 	}
 }
 
@@ -525,72 +545,87 @@ func unresolvedEdgeTargets(doc *graph.Document) map[string]int {
 	return out
 }
 
-// TestInProcCustomExtractorsSupersedeDestroysBaseEntities PINS A KNOWN DEFECT
-// (#6104). It asserts the BROKEN behaviour deliberately so the defect is
-// visible in CI rather than papered over.
+// TestInProcCustomExtractorsSupersedeIsNonDestructive is the INVERSION of the
+// former TestInProcCustomExtractorsSupersedeDestroysBaseEntities, which pinned
+// #6104's known defect deliberately.
 //
-// WHAT BREAKS. MergeWithCustom supersedes by NAME alone. When a custom
-// extractor emits an entity whose Name collides with a base entity, the base
-// node is REPLACED — so the gate is not purely additive, it DESTROYS content
-// the base path produced.
+// WHAT IT USED TO PIN. MergeWithCustom superseded by NAME alone, so a custom
+// entity whose Name collided with a base entity REPLACED it. The gate was not
+// additive, it DESTROYED content the base path produced — 280 entities across
+// 5 kinds and 2 languages on the full fixture, in three shapes: cross-kind
+// (Task vs SCOPE.Operation), same-kind same-name, and same-kind in-place
+// corruption (subtype rewrite + EndLine truncation).
 //
-// THE LOSS SET IS NOT ONE KIND AND NOT ONE LANGUAGE. On the full fixture the
-// loss spans 5 kinds and 2 languages. Two distinct collision shapes exist, and
-// they need DIFFERENT fixes:
+// WHAT IT ASSERTS NOW. The merge policy is keyed on the graph's own identity
+// (SourceFile, Kind, Name) and enforces two invariants — never lose an entity,
+// never narrow a span. Both are asserted here at the WHOLE-GRAPH level, on
+// content tuples compared as MULTISETS and on entity IDs, never on counts.
 //
-//   - DIFFERENT-KIND collision (python/Celery). `@shared_task def
-//     send_receipt` destroys TWO base entities — `Task|send_receipt` AND
-//     `SCOPE.Operation|send_receipt|function` — replaced by a single
-//     `SCOPE.Service|send_receipt|task`. Keying supersede on (Kind, Name)
-//     would fix this shape.
-//
-//   - SAME-KIND collision (java/Spring). `SCOPE.Operation|C.list|method` is
-//     replaced by `SCOPE.Operation|C.list|endpoint` with EndLine truncated.
-//     Kind, Name and SourceFile are all IDENTICAL, so a (Kind, Name) key does
-//     NOT fix this shape.
-//
-// THIS TEST DELIBERATELY COVERS BOTH SHAPES. If it only pinned the Celery
-// loss, the obvious (Kind, Name) remedy would turn it red, be declared
-// complete, and ship with the Java corruption unpinned. The same-kind
-// assertion below is what makes a (Kind, Name)-only fix insufficient to make
-// this test pass — it must still fail until the same-kind shape is fixed too.
-//
-// See also TestInProcCustomExtractorsJavaEntityMutation, which pins the Java
-// field-level corruption in detail.
-func TestInProcCustomExtractorsSupersedeDestroysBaseEntities(t *testing.T) {
+// ON THE ONE ID THAT LEGITIMATELY DISAPPEARS. `Task|send_receipt` still leaves
+// the ON arm — but not at the merge boundary. It is consumed by the #1613
+// class-shadow fold, which enforces a separate, pre-existing "one node per
+// class symbol" invariant: SCOPE.Service outranks Task in
+// frameworkClassKindPriority (100 vs 70), so the pair is folded and the edges
+// are REPOINTED onto the survivor. That is a genuine combine, not a silent
+// drop, and assertion (a) below is written to tell the two apart: a retired ID
+// is only acceptable if a same-(Name, SourceFile) survivor exists AND no edge
+// is left pointing at it.
+func TestInProcCustomExtractorsSupersedeIsNonDestructive(t *testing.T) {
 	off, on := indexBothArms(t, "supersede_repo")
-
-	destroyed, added := tupleDelta(entityTuples(off, ""), entityTuples(on, ""))
-	if len(destroyed) == 0 {
-		t.Fatalf("KNOWN DEFECT APPEARS FIXED: the gate destroys no base entities. " +
-			"If #6104 was fixed, invert this test to assert the gate is purely additive.")
-	}
-	t.Logf("gate destroys %d base entity tuple(s):", len(destroyed))
+	offT, onT := entityTuples(off, ""), entityTuples(on, "")
+	destroyed, added := tupleDelta(offT, onT)
+	t.Logf("gate replaces %d base entity tuple(s) with enriched versions:", len(destroyed))
 	for _, d := range destroyed {
-		t.Logf("    DESTROYED %s", d)
+		t.Logf("    WAS %s", d)
 	}
 
-	// --- Shape 1: DIFFERENT-KIND collision (python / Celery) ---------------
-	// BOTH base entities for the task must be destroyed, not just the Task.
-	// Pinning only `Task` understates the loss by half.
-	wantDestroyed := []string{
-		"Task|send_receipt|",            // the Celery task entity
-		"SCOPE.Operation|send_receipt|", // AND its operation entity
+	// --- (a) INVARIANT 1: a merge never loses an entity -------------------
+	onIDs := make(map[string]bool, len(on.Entities))
+	for i := range on.Entities {
+		onIDs[on.Entities[i].ID] = true
 	}
-	for _, want := range wantDestroyed {
-		found := false
-		for _, d := range destroyed {
-			if strings.HasPrefix(d, want) {
-				found = true
-				break
-			}
+	onNameFile := make(map[string][]string, len(on.Entities))
+	for i := range on.Entities {
+		k := on.Entities[i].Name + "|" + on.Entities[i].SourceFile
+		onNameFile[k] = append(onNameFile[k], on.Entities[i].Kind)
+	}
+	onRefs := make(map[string]int, len(on.Relationships))
+	for i := range on.Relationships {
+		onRefs[on.Relationships[i].FromID]++
+		onRefs[on.Relationships[i].ToID]++
+	}
+	for i := range off.Entities {
+		e := &off.Entities[i]
+		if onIDs[e.ID] {
+			continue
 		}
-		if !found {
-			t.Errorf("expected the gate to destroy an entity matching %q; destroyed=%v",
-				want, destroyed)
+		survivors := onNameFile[e.Name+"|"+e.SourceFile]
+		if len(survivors) == 0 {
+			t.Errorf("#6104: the gate DESTROYED %s|%s (%s) — no entity with the same "+
+				"name survives in that file", e.Kind, e.Name, e.SourceFile)
+			continue
+		}
+		if n := onRefs[e.ID]; n > 0 {
+			t.Errorf("#6104: %s|%s (%s) was retired but %d edge(s) still point at its "+
+				"ID %s — a fold/supersede must re-key every edge, not only the node's own",
+				e.Kind, e.Name, e.SourceFile, n, e.ID)
+		}
+		t.Logf("retired-and-folded (OK, #1613): %s|%s -> %v, 0 dangling edges",
+			e.Kind, e.Name, survivors)
+	}
+
+	// --- (b) Shape 1 + 2: the Celery collisions ---------------------------
+	// `@shared_task def send_receipt` used to destroy BOTH `Task|send_receipt`
+	// (cross-kind) and `SCOPE.Operation|send_receipt` (the second half of the
+	// double-destruction the original report missed). The SCOPE.Operation must
+	// now survive untouched, and the SCOPE.Service must still be ADDED — the
+	// gate's value is that it adds a kind, not that it swaps one for another.
+	for _, d := range destroyed {
+		if strings.HasPrefix(d, "SCOPE.Operation|send_receipt|") {
+			t.Errorf("#6104 shape 1: the gate still destroys the Celery task's operation "+
+				"entity: %q", d)
 		}
 	}
-	// The replacement is a single entity of a DIFFERENT kind.
 	var serviceAdded bool
 	for _, a := range added {
 		if strings.HasPrefix(a, "SCOPE.Service|send_receipt|") {
@@ -598,55 +633,93 @@ func TestInProcCustomExtractorsSupersedeDestroysBaseEntities(t *testing.T) {
 		}
 	}
 	if !serviceAdded {
-		t.Errorf("expected a SCOPE.Service replacement for the superseded task; added=%v", added)
+		t.Errorf("expected the Celery custom extractor to ADD a SCOPE.Service; added=%v", added)
 	}
 
-	// --- Shape 2: SAME-KIND collision (java / Spring) ---------------------
-	// This is the assertion a (Kind, Name)-keyed fix cannot satisfy. Find a
-	// destroyed tuple whose Kind, Name AND SourceFile all reappear in `added`
-	// with different field values — i.e. a substitution that keying on
-	// (Kind, Name) would still permit.
-	keyOf := func(tuple string) (string, bool) {
+	// --- (c) INVARIANT 2: a merge never narrows a span --------------------
+	// Every remaining same-(Kind, Name, SourceFile) substitution must be an
+	// ENRICHMENT: subtype refinement and/or a WIDER span. This is the shape the
+	// old test required to exist; it is now constrained rather than forbidden,
+	// because a same-identity pair IS one graph node and combining them is
+	// correct — silently shrinking them was not.
+	parse := func(tuple string) (key string, start, end int, ok bool) {
 		parts := strings.Split(tuple, "|")
 		if len(parts) != 7 {
-			return "", false
+			return "", 0, 0, false
 		}
-		return parts[0] + "|" + parts[1] + "|" + parts[4], true // Kind|Name|SourceFile
-	}
-	addedKeys := map[string]bool{}
-	for _, a := range added {
-		if k, ok := keyOf(a); ok {
-			addedKeys[k] = true
+		st, err := strconv.Atoi(parts[5])
+		if err != nil {
+			return "", 0, 0, false
 		}
+		en, err := strconv.Atoi(parts[6])
+		if err != nil {
+			return "", 0, 0, false
+		}
+		return parts[0] + "|" + parts[1] + "|" + parts[4], st, en, true
 	}
-	var sameKindSubstitutions []string
+	type span struct{ start, end int }
+	was := map[string]span{}
 	for _, d := range destroyed {
-		if k, ok := keyOf(d); ok && addedKeys[k] {
-			sameKindSubstitutions = append(sameKindSubstitutions, k)
+		if k, st, en, ok := parse(d); ok {
+			was[k] = span{st, en}
 		}
 	}
-	if len(sameKindSubstitutions) == 0 {
-		t.Fatalf("KNOWN DEFECT APPEARS PARTIALLY FIXED: no same-(Kind, Name, SourceFile) "+
-			"substitutions remain. A (Kind, Name)-keyed fix is NOT sufficient — the "+
-			"same-kind shape (java/Spring) must be fixed too before this test may be "+
-			"inverted. destroyed=%v added=%v", destroyed, added)
+	var narrowed, substitutions []string
+	for _, a := range added {
+		k, st, en, ok := parse(a)
+		if !ok {
+			continue
+		}
+		prev, seen := was[k]
+		if !seen {
+			continue
+		}
+		substitutions = append(substitutions, k)
+		if en < prev.end {
+			narrowed = append(narrowed, fmt.Sprintf("%s EndLine %d->%d", k, prev.end, en))
+		}
+		if prev.start != 0 && st > prev.start {
+			narrowed = append(narrowed, fmt.Sprintf("%s StartLine %d->%d", k, prev.start, st))
+		}
 	}
-	t.Logf("same-(Kind,Name,SourceFile) substitutions a (Kind,Name) fix would NOT prevent: %v",
-		sameKindSubstitutions)
+	if len(narrowed) != 0 {
+		t.Errorf("#6104: the merge narrowed %d span(s): %v", len(narrowed), narrowed)
+	}
+	sort.Strings(substitutions)
+	t.Logf("same-(Kind,Name,SourceFile) enrichments (all span-widening or neutral): %v",
+		substitutions)
 
-	// --- Dangling edges left behind by the supersede -----------------------
+	// --- (d) No supersede-induced dangling edges --------------------------
+	// The gate may still introduce dangling endpoints of its own — the
+	// synthetic `Class:<Name>` stubs the framework extractors emit are tracked
+	// separately as #6105 and are explicitly OUT OF SCOPE here. What must NOT
+	// appear is a dangle naming an ID that EXISTED in the gate-off arm: that is
+	// the supersede/re-keying failure this issue is about.
+	offEntityIDs := make(map[string]bool, len(off.Entities))
+	for i := range off.Entities {
+		offEntityIDs[off.Entities[i].ID] = true
+	}
 	uo, un := unresolvedEdgeTargets(off), unresolvedEdgeTargets(on)
-	var introduced []string
+	var introduced, supersedeDangles []string
 	for id := range un {
-		if _, existed := uo[id]; !existed {
-			introduced = append(introduced, id)
+		if _, existed := uo[id]; existed {
+			continue
+		}
+		introduced = append(introduced, id)
+		if offEntityIDs[id] {
+			supersedeDangles = append(supersedeDangles, id)
 		}
 	}
-	if len(introduced) == 0 {
-		t.Errorf("expected the supersede to leave dangling edge endpoints behind")
+	if len(supersedeDangles) != 0 {
+		sort.Strings(supersedeDangles)
+		t.Errorf("#6104: %d edge endpoint(s) now dangle on IDs that were REAL ENTITIES "+
+			"with the gate off — the supersede did not re-key them: %v",
+			len(supersedeDangles), supersedeDangles)
 	}
 	sort.Strings(introduced)
-	t.Logf("gate introduces %d new dangling edge endpoint(s): %v", len(introduced), introduced)
+	t.Logf("gate introduces %d new dangling endpoint(s), none of them retired entity IDs "+
+		"(synthetic Class:<Name> stubs are #6105, out of scope here): %v",
+		len(introduced), introduced)
 }
 
 // TestInProcCustomExtractorsNilTreeGuardIsLoadBearing pins the

--- a/cmd/grafel/inproc_custom_extractors_5989_test.go
+++ b/cmd/grafel/inproc_custom_extractors_5989_test.go
@@ -297,14 +297,38 @@ func tupleDelta(a, b map[string]int) (destroyed, added []string) {
 	return destroyed, added
 }
 
-// indexBothArms runs the fixture with the gate off and on and returns both docs.
+// persistAndReload round-trips a Document through the on-disk graph and reads
+// it back with graph.LoadGraphFromDir.
+//
+// WHY NOT ASSERT ON THE IN-MEMORY DOCUMENT (#6104 review finding M3).
+// runIndexerOn returns the Document straight out of idx.Run(). Anything the
+// persistence layer does — dropping, rewriting or normalising entities and
+// edges on the way to disk — is invisible to assertions made on that value.
+// Entity-loss and dangling-edge claims have to be measured on what actually
+// lands in the graph, so every arm below is compared after a real write/read
+// cycle.
+func persistAndReload(t *testing.T, doc *graph.Document) *graph.Document {
+	t.Helper()
+	dir := t.TempDir()
+	if err := graph.WriteAtomic(filepath.Join(dir, "graph.json"), doc, false); err != nil {
+		t.Fatalf("persist graph: %v", err)
+	}
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	return loaded
+}
+
+// indexBothArms runs the fixture with the gate off and on and returns both
+// docs AS PERSISTED AND RELOADED (see persistAndReload).
 func indexBothArms(t *testing.T, tag string) (off, on *graph.Document) {
 	t.Helper()
 	fixture := writeDjangoFixture(t)
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
-	off = runIndexerOn(t, fixture, tag, nil)
+	off = persistAndReload(t, runIndexerOn(t, fixture, tag, nil))
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
-	on = runIndexerOn(t, fixture, tag, nil)
+	on = persistAndReload(t, runIndexerOn(t, fixture, tag, nil))
 	return off, on
 }
 
@@ -580,38 +604,130 @@ func TestInProcCustomExtractorsSupersedeIsNonDestructive(t *testing.T) {
 	}
 
 	// --- (a) INVARIANT 1: a merge never loses an entity -------------------
-	onIDs := make(map[string]bool, len(on.Entities))
+	//
+	// THIS ASSERTION IS Kind-AWARE ON PURPOSE. An earlier revision excused a
+	// retired entity whenever ANY same-(Name, SourceFile) entity survived,
+	// ignoring Kind — which is precisely the cross-kind supersede shape
+	// (Task|send_receipt -> SCOPE.Service|send_receipt). Had the original
+	// #6104 defect re-keyed its edges, that assertion would have PASSED on the
+	// bug it exists to catch. A retirement is now excused only when either:
+	//
+	//   A. a same-(Kind, Name, SourceFile) successor exists — a Tier A
+	//      combine, which is one graph node either way; or
+	//   B. it is a cross-kind fold that satisfies the #1613 contract IN FULL:
+	//      the survivor's kind strictly OUTRANKS the retired kind in
+	//      frameworkClassKindPriority, AND every edge incident on the retired
+	//      ID in the gate-off arm has a counterpart incident on the survivor
+	//      in the gate-on arm.
+	//
+	// EDGE CONSERVATION, NOT "ZERO DANGLING". Counting dangling references to
+	// the retired ID cannot tell "edges repointed" from "edges deleted" — a
+	// pass that DROPS them scores a perfect zero. Conservation is checked by
+	// content-keyed edge tuples, so a drop fails.
+	//
+	// The non-destruction of the merge itself is separately and directly
+	// pinned at unit level (TestMergeWithCustomCrossKindCollisionKeepsBoth-
+	// Entities); that is the assertion the original defect cannot pass, and
+	// this graph-level test does not try to re-derive it from a delta.
+	offByID := make(map[string]*graph.Entity, len(off.Entities))
+	for i := range off.Entities {
+		offByID[off.Entities[i].ID] = &off.Entities[i]
+	}
+	onByID := make(map[string]*graph.Entity, len(on.Entities))
 	for i := range on.Entities {
-		onIDs[on.Entities[i].ID] = true
+		onByID[on.Entities[i].ID] = &on.Entities[i]
 	}
-	onNameFile := make(map[string][]string, len(on.Entities))
-	for i := range on.Entities {
-		k := on.Entities[i].Name + "|" + on.Entities[i].SourceFile
-		onNameFile[k] = append(onNameFile[k], on.Entities[i].Kind)
+	// Content key for an edge endpoint: the entity's content tuple when the ID
+	// names a real entity, else the raw stub. Mirrors internal/graph/parity's
+	// newEndpointResolver so IDs never leak into the comparison (#6083).
+	contentKey := func(byID map[string]*graph.Entity, id string) string {
+		if e, ok := byID[id]; ok {
+			return fmt.Sprintf("%s|%s|%s", e.Kind, e.Name, e.SourceFile)
+		}
+		return "STUB:" + id
 	}
-	onRefs := make(map[string]int, len(on.Relationships))
-	for i := range on.Relationships {
-		onRefs[on.Relationships[i].FromID]++
-		onRefs[on.Relationships[i].ToID]++
+	// incidentEdges returns content-keyed (direction, kind, otherEndpoint)
+	// tuples for every edge touching id, as a MULTISET.
+	incidentEdges := func(doc *graph.Document, byID map[string]*graph.Entity, id string) map[string]int {
+		out := map[string]int{}
+		for i := range doc.Relationships {
+			r := &doc.Relationships[i]
+			if r.FromID == id {
+				out["out|"+r.Kind+"|"+contentKey(byID, r.ToID)]++
+			}
+			if r.ToID == id {
+				out["in|"+r.Kind+"|"+contentKey(byID, r.FromID)]++
+			}
+		}
+		return out
 	}
+
 	for i := range off.Entities {
 		e := &off.Entities[i]
-		if onIDs[e.ID] {
+		if _, alive := onByID[e.ID]; alive {
 			continue
 		}
-		survivors := onNameFile[e.Name+"|"+e.SourceFile]
-		if len(survivors) == 0 {
-			t.Errorf("#6104: the gate DESTROYED %s|%s (%s) — no entity with the same "+
-				"name survives in that file", e.Kind, e.Name, e.SourceFile)
+		// (A) same-(Kind, Name, SourceFile) successor?
+		var sameKindSuccessor *graph.Entity
+		var crossKindSurvivors []*graph.Entity
+		for j := range on.Entities {
+			s := &on.Entities[j]
+			if s.Name != e.Name || s.SourceFile != e.SourceFile {
+				continue
+			}
+			if s.Kind == e.Kind {
+				sameKindSuccessor = s
+			} else {
+				crossKindSurvivors = append(crossKindSurvivors, s)
+			}
+		}
+		if sameKindSuccessor != nil {
+			continue // Tier A combine
+		}
+		if len(crossKindSurvivors) == 0 {
+			t.Errorf("#6104: the gate DESTROYED %s|%s (%s) — nothing with that name "+
+				"survives in that file", e.Kind, e.Name, e.SourceFile)
 			continue
 		}
-		if n := onRefs[e.ID]; n > 0 {
-			t.Errorf("#6104: %s|%s (%s) was retired but %d edge(s) still point at its "+
-				"ID %s — a fold/supersede must re-key every edge, not only the node's own",
-				e.Kind, e.Name, e.SourceFile, n, e.ID)
+		// (B) cross-kind retirement — must satisfy the #1613 fold contract.
+		var promoted *graph.Entity
+		for _, s := range crossKindSurvivors {
+			if frameworkClassKindPriority[s.Kind] > frameworkClassKindPriority[e.Kind] {
+				promoted = s
+				break
+			}
 		}
-		t.Logf("retired-and-folded (OK, #1613): %s|%s -> %v, 0 dangling edges",
-			e.Kind, e.Name, survivors)
+		if promoted == nil {
+			var kinds []string
+			for _, s := range crossKindSurvivors {
+				kinds = append(kinds, fmt.Sprintf("%s(prio %d)", s.Kind, frameworkClassKindPriority[s.Kind]))
+			}
+			t.Errorf("#6104: %s|%s (%s, prio %d) was retired cross-kind with NO "+
+				"higher-priority survivor — that is a supersede, not a #1613 fold; "+
+				"survivors=%v", e.Kind, e.Name, e.SourceFile,
+				frameworkClassKindPriority[e.Kind], kinds)
+			continue
+		}
+		// EDGE CONSERVATION.
+		wasIncident := incidentEdges(off, offByID, e.ID)
+		nowIncident := incidentEdges(on, onByID, promoted.ID)
+		var lostEdges []string
+		for edge, n := range wasIncident {
+			if nowIncident[edge] < n {
+				lostEdges = append(lostEdges, fmt.Sprintf("%s (x%d, now x%d)", edge, n, nowIncident[edge]))
+			}
+		}
+		if len(lostEdges) > 0 {
+			sort.Strings(lostEdges)
+			t.Errorf("#6104: %s|%s was folded into %s but %d edge class(es) were NOT "+
+				"carried over — a fold must REPOINT edges, not drop them: %v",
+				e.Kind, e.Name, promoted.Kind, len(lostEdges), lostEdges)
+			continue
+		}
+		t.Logf("retired-and-folded (OK, #1613): %s|%s (prio %d) -> %s (prio %d); "+
+			"all %d incident edge class(es) conserved on the survivor",
+			e.Kind, e.Name, frameworkClassKindPriority[e.Kind],
+			promoted.Kind, frameworkClassKindPriority[promoted.Kind], len(wasIncident))
 	}
 
 	// --- (b) Shape 1 + 2: the Celery collisions ---------------------------

--- a/cmd/grafel/inproc_custom_extractors_5989_test.go
+++ b/cmd/grafel/inproc_custom_extractors_5989_test.go
@@ -750,3 +750,172 @@ func TestInProcCustomExtractorsNilTreeGuardIsLoadBearing(t *testing.T) {
 	t.Logf("with a nil parse tree, RunCustomExtractors still emits %d entity(ies) — "+
 		"this is what the `file.TSTree != nil` guard at the seam suppresses", len(ents))
 }
+
+// TestInProcCustomExtractorsThreeCollisionShapesAreClosed is the per-shape
+// evidence for #6104. Each of the three CONFIRMED collision shapes gets its own
+// assertion so a partial fix cannot pass.
+//
+// WHY MULTISETS AND NOT COUNTS. A per-kind count table cannot see
+// destroy-and-re-add: on the full fixture `SCOPE.Operation` showed +120 while
+// 120 of its members were destroyed, and gains masked losses exactly. That is
+// how this defect was originally under-reported by 3.5x. Every assertion below
+// is over entityTuples — a CONTENT multiset (counts per tuple) — or over entity
+// IDs. Same instrument as internal/graph/parity after #6037.
+//
+// WHY THE THREE SHAPES ARE LISTED SEPARATELY. The obvious remedy — keying the
+// supersede on (Kind, Name) instead of Name alone — closes shape 1 ONLY. It was
+// verified by mutation that shapes 2 and 3 survive it intact. Listing them
+// apart keeps that trap visible.
+func TestInProcCustomExtractorsThreeCollisionShapesAreClosed(t *testing.T) {
+	off, on := indexBothArms(t, "shapes_repo")
+	offT, onT := entityTuples(off, ""), entityTuples(on, "")
+	destroyed, added := tupleDelta(offT, onT)
+
+	// Content-tuple multiset survival: a tuple present N times off must be
+	// present at least N times on, OR have a same-(Kind,Name,SourceFile)
+	// successor (a Tier A combine, which is one node either way).
+	key := func(tuple string) string {
+		p := strings.Split(tuple, "|")
+		if len(p) != 7 {
+			return tuple
+		}
+		return p[0] + "|" + p[1] + "|" + p[4]
+	}
+	addedKeys := map[string]bool{}
+	for _, a := range added {
+		addedKeys[key(a)] = true
+	}
+	survived := func(prefix string) (ok bool, why string) {
+		for tuple, n := range offT {
+			if !strings.HasPrefix(tuple, prefix) {
+				continue
+			}
+			if onT[tuple] >= n {
+				return true, "tuple survives verbatim (" + tuple + ")"
+			}
+			if addedKeys[key(tuple)] {
+				return true, "combined into a same-(Kind,Name,File) successor (" + tuple + ")"
+			}
+			return false, "DESTROYED with no successor: " + tuple
+		}
+		return false, "no such tuple in the gate-off arm — fixture drift, assertion is vacuous"
+	}
+
+	// ---- Shape 1: CROSS-KIND collision (python / Celery) -----------------
+	// `@shared_task def send_receipt` used to destroy BOTH the base
+	// `Task|send_receipt` AND `SCOPE.Operation|send_receipt`, collapsing them
+	// into one `SCOPE.Service|send_receipt`. Keying on (Kind, Name) closes
+	// this one. Both base entities must now survive the MERGE.
+	if ok, why := survived("SCOPE.Operation|send_receipt|"); !ok {
+		t.Errorf("shape 1 (cross-kind) NOT closed: %s", why)
+	} else {
+		t.Logf("shape 1 (cross-kind, SCOPE.Operation|send_receipt): CLOSED — %s", why)
+	}
+
+	// ---- Shape 2: SAME-KIND, SAME NAME (python / Celery) -----------------
+	// The custom extractor also emits a `Task`-kind entity of the same name,
+	// so this collision is same-kind and a (Kind, Name) key does NOT close it.
+	// The base Task must not be destroyed AT THE MERGE. It is subsequently
+	// consumed by the #1613 class-shadow fold (SCOPE.Service outranks Task,
+	// 100 vs 70) which REPOINTS its edges — a combine, so we assert on the
+	// fold's contract rather than on tuple identity: a same-(Name, SourceFile)
+	// survivor exists and nothing dangles on the retired ID.
+	onIDs := make(map[string]bool, len(on.Entities))
+	for i := range on.Entities {
+		onIDs[on.Entities[i].ID] = true
+	}
+	onRefs := map[string]int{}
+	for i := range on.Relationships {
+		onRefs[on.Relationships[i].FromID]++
+		onRefs[on.Relationships[i].ToID]++
+	}
+	var checkedShape2 bool
+	for i := range off.Entities {
+		e := &off.Entities[i]
+		if e.Kind != "Task" || !strings.HasPrefix(e.Name, "send_receipt") {
+			continue
+		}
+		checkedShape2 = true
+		if onIDs[e.ID] {
+			t.Logf("shape 2 (same-kind, Task|%s): CLOSED — entity survives verbatim", e.Name)
+			continue
+		}
+		var survivors []string
+		for j := range on.Entities {
+			s := &on.Entities[j]
+			if s.Name == e.Name && s.SourceFile == e.SourceFile {
+				survivors = append(survivors, s.Kind)
+			}
+		}
+		if len(survivors) == 0 {
+			t.Errorf("shape 2 (same-kind) NOT closed: Task|%s destroyed with no survivor "+
+				"in %s", e.Name, e.SourceFile)
+			continue
+		}
+		if n := onRefs[e.ID]; n > 0 {
+			t.Errorf("shape 2: Task|%s was retired but %d edge(s) still point at %s — "+
+				"the retiring pass did not re-key them", e.Name, n, e.ID)
+			continue
+		}
+		t.Logf("shape 2 (same-kind, Task|%s): CLOSED at the merge — folded by #1613 into %v "+
+			"with 0 dangling edges", e.Name, survivors)
+	}
+	if !checkedShape2 {
+		t.Errorf("shape 2 assertion is vacuous: no base Task entity in the gate-off arm")
+	}
+
+	// ---- Shape 3: SAME-KIND IN-PLACE CORRUPTION (java / Spring) ----------
+	// Kind, Name and SourceFile all identical — these ARE one graph node. The
+	// custom extractor rewrote Subtype method->endpoint AND truncated EndLine,
+	// and the truncation propagated into the derived SCOPE.Process and
+	// http_endpoint_definition. A (Kind, Name) key treats this as a legitimate
+	// supersede and lets it through, which is why it needed a POLICY fix.
+	//
+	// Closed means: the node is still ONE node, the subtype refinement is
+	// KEPT, and the span is NOT narrower than the gate-off span.
+	spanOf := func(m map[string]int, prefix string) (tuple string, start, end int, found bool) {
+		for tp := range m {
+			if !strings.HasPrefix(tp, prefix) {
+				continue
+			}
+			p := strings.Split(tp, "|")
+			if len(p) != 7 {
+				continue
+			}
+			st, err1 := strconv.Atoi(p[5])
+			en, err2 := strconv.Atoi(p[6])
+			if err1 != nil || err2 != nil {
+				continue
+			}
+			return tp, st, en, true
+		}
+		return "", 0, 0, false
+	}
+	const javaOp = "SCOPE.Operation|OrdersController.list|"
+	offTuple, offStart, offEnd, okOff := spanOf(offT, javaOp)
+	onTuple, onStart, onEnd, okOn := spanOf(onT, javaOp)
+	switch {
+	case !okOff || !okOn:
+		t.Errorf("shape 3 assertion is vacuous: java operation missing (off=%v on=%v)", okOff, okOn)
+	case onEnd < offEnd:
+		t.Errorf("shape 3 (in-place corruption) NOT closed: EndLine narrowed %d->%d\n  off=%s\n  on =%s",
+			offEnd, onEnd, offTuple, onTuple)
+	case offStart != 0 && onStart > offStart:
+		t.Errorf("shape 3 NOT closed: StartLine clipped %d->%d\n  off=%s\n  on =%s",
+			offStart, onStart, offTuple, onTuple)
+	case !strings.Contains(onTuple, "|endpoint|"):
+		t.Errorf("shape 3: the subtype refinement method->endpoint was lost; on=%s", onTuple)
+	default:
+		t.Logf("shape 3 (in-place corruption): CLOSED — span %d-%d preserved (was truncated to %d), "+
+			"subtype refinement kept\n  off=%s\n  on =%s", onStart, onEnd, offStart, offTuple, onTuple)
+	}
+
+	// And the derived entity the corruption used to propagate into.
+	for tuple, n := range offT {
+		if strings.HasPrefix(tuple, "http_endpoint_definition|") && onT[tuple] < n {
+			t.Errorf("shape 3: corruption still propagates to a derived entity: %q lost "+
+				"(off=%d on=%d)", tuple, n, onT[tuple])
+		}
+	}
+	t.Logf("destroyed=%d added=%d (tuple multiset delta)", len(destroyed), len(added))
+}

--- a/internal/custom/cpp/endpoint_deprecation.go
+++ b/internal/custom/cpp/endpoint_deprecation.go
@@ -51,7 +51,8 @@ package cpp
 // def, a banner comment, a header write) is not on the same line as the route
 // macro, so there is no single composed endpoint op to attach to without
 // fabricating a route binding. The marker carries the full contract as evidence;
-// MergeWithCustom dedups by Name. One marker per deprecation site.
+// MergeWithCustom folds on (SourceFile, Kind, Name) since #6104. One marker
+// per deprecation site.
 //
 // Honest-partial (NEVER fabricated):
 //   - a route handler with NO deprecation marker → no marker emitted;

--- a/internal/custom/elixir/endpoint_deprecation.go
+++ b/internal/custom/elixir/endpoint_deprecation.go
@@ -56,7 +56,8 @@
 // router route lives in a SEPARATE file), and a Sunset header is written in an
 // action body — neither is the composed route op, so attaching the contract to a
 // route would fabricate a binding. The marker carries the full contract as
-// evidence; MergeWithCustom dedups by Name. One marker per deprecation site.
+// evidence; MergeWithCustom folds it onto the base op when (SourceFile, Kind,
+// Name) all match (#6104). One marker per deprecation site.
 //
 // Honest-partial (NEVER fabricated):
 //   - a route/action with NO deprecation marker → no marker emitted;

--- a/internal/custom/elixir/rate_limit.go
+++ b/internal/custom/elixir/rate_limit.go
@@ -48,7 +48,9 @@
 //
 // Like the sibling passes, the Hammer/ExRated surface adds NO new node — it
 // stamps the flat contract on the controller-action op phoenix.go already emits
-// (MergeWithCustom dedups by Name so the custom version wins). The PlugAttack
+// (MergeWithCustom folds it onto the base op when the Kind matches too;
+// since #6104 it keys on (SourceFile, Kind, Name), not Name alone, so a
+// Kind disagreement leaves BOTH nodes standing). The PlugAttack
 // surface adds a marker entity (there is no per-route endpoint to attach to).
 //
 // Honest-partial cases (rate_limited stamped, numeric rate OMITTED):
@@ -205,7 +207,7 @@ func (e *rateLimitExtractor) Extract(ctx context.Context, file extractor.FileInp
 
 // extractCheckRate stamps the flat contract on the controller action enclosing
 // each Hammer/ExRated `check_rate` call. The action op shares the `action:<name>`
-// Name phoenix.go emits, so MergeWithCustom replaces phoenix's bare action op
+// Name phoenix.go emits, so MergeWithCustom folds onto phoenix's bare action op
 // with this rate-limited one (scope=route). When no enclosing `def` precedes the
 // call (a module-level limiter helper), the call is skipped — there is no action
 // to attribute it to and inventing a route would be dishonest.

--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -666,7 +666,7 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		})
 		modelEnt := entity(className, "SCOPE.Schema", "model", file.Path, classLine, props)
 
-		// Issue #4366 — field membership. MergeWithCustom replaces the base
+		// Issue #4366 — field membership. MergeWithCustom used to REPLACE the base
 		// tree-sitter class node (which carried the #526 class→field CONTAINS
 		// edges) with this custom model node, so without re-emitting membership
 		// here every model field is left an orphan. Walk the class body and hang
@@ -679,7 +679,8 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 		seenMember := map[string]bool{}
 		// (a) CONTAINS membership for every class-body attribute (fields,
 		// choices constants, manager attachments) — restores parity with the
-		// base class node that MergeWithCustom replaces.
+		// base class node that MergeWithCustom used to replace (it no longer
+		// does — see #6104; the base node survives and this one is a facet).
 		for _, aIdx := range allMatchesIndex(djangoModelAttrRe, body) {
 			attr := body[aIdx[2]:aIdx[3]]
 			if attr == "" || seenMember[attr] || strings.HasPrefix(attr, "__") {

--- a/internal/custom/python/issue4402_mergeboundary_test.go
+++ b/internal/custom/python/issue4402_mergeboundary_test.go
@@ -71,20 +71,36 @@ func mergeBoundary4402(t *testing.T, path string) []types.EntityRecord {
 	return merged
 }
 
-// findMergedClass returns the single surviving entity named `name`. After the
-// merge there must be exactly ONE node per class Name (custom won the identity).
+// findMergedClass returns the FRAMEWORK-modelled node for `name` — the
+// SCOPE.Schema/model facet the Django custom extractor emitted.
+//
+// UPDATED FOR #6104. This used to assert "exactly ONE node per class Name
+// (custom won the identity)". That assertion WAS the defect: a Kind
+// disagreement means two graph nodes, and #4402 obtained the base node's state
+// by DESTROYING it. Both nodes now survive — the base SCOPE.Component and the
+// custom facet — and the facet still carries the base QualifiedName and the
+// base CONTAINS membership, which is the property these tests exist to prove.
+// The base node must also still be there, so we assert on both.
 func findMergedClass(t *testing.T, ents []types.EntityRecord, name string) types.EntityRecord {
 	t.Helper()
-	var found []types.EntityRecord
+	var facet, base []types.EntityRecord
 	for _, e := range ents {
-		if e.Name == name {
-			found = append(found, e)
+		if e.Name != name {
+			continue
+		}
+		if e.Properties[types.EntityTwinOfProperty] != "" {
+			facet = append(facet, e)
+		} else {
+			base = append(base, e)
 		}
 	}
-	if len(found) != 1 {
-		t.Fatalf("expected exactly 1 merged entity named %q, got %d", name, len(found))
+	if len(base) != 1 {
+		t.Fatalf("expected the base node for %q to survive the merge exactly once, got %d", name, len(base))
 	}
-	return found[0]
+	if len(facet) != 1 {
+		t.Fatalf("expected exactly 1 custom facet for %q, got %d", name, len(facet))
+	}
+	return facet[0]
 }
 
 // TestIssue4402_QualifiedNameSurvivesMerge proves the merged model node keeps
@@ -96,7 +112,7 @@ func TestIssue4402_QualifiedNameSurvivesMerge(t *testing.T) {
 
 	contract := findMergedClass(t, merged, "Contract")
 
-	// Identity is the CUSTOM node's (Django model), proving the custom node won.
+	// The facet keeps the CUSTOM node's identity (Django model).
 	if contract.Subtype != "model" {
 		t.Errorf("merged Contract should keep custom identity subtype=model, got %q", contract.Subtype)
 	}

--- a/internal/custom/python/pytest.go
+++ b/internal/custom/python/pytest.go
@@ -49,7 +49,7 @@ import (
 // relationship kind — no new producer Kind. The single suite entity is named
 // `pytest_suite:<base>` so it never collides by-name with a production
 // function/class node (which would re-orphan it through the resolver's byName
-// index, as in #4343), and so MergeWithCustom's name-keyed replace does not
+// index, as in #4343), and so the MergeWithCustom fold does not
 // clobber the base tree-sitter class/func nodes (lesson from #4366).
 //
 // The cross/testmap Python path (test_coverage entities via direct body-call

--- a/internal/custom/rust/endpoint_deprecation.go
+++ b/internal/custom/rust/endpoint_deprecation.go
@@ -25,7 +25,8 @@
 //	api_version            — "1" | "2" | … numeric version from the route path
 //
 // Three recognised Rust surfaces (Names match the producer extractors so the
-// stamped op merges onto the plain route op by Name via MergeWithCustom):
+// stamped op merges onto the plain route op via MergeWithCustom, which keys on
+// (SourceFile, Kind, Name) since #6104):
 //
 //	axum — `.route("/path", get(handler))`. The route names a handler by symbol;
 //	    the Rust `#[deprecated(since = "2.0", note = "use /api/v2/users")]`

--- a/internal/custom/rust/endpoint_pagination.go
+++ b/internal/custom/rust/endpoint_pagination.go
@@ -12,7 +12,8 @@
 // Kind==http_endpoint_definition — can never reach them. Same gating issue as
 // endpoint_response_codes; the resolution is identical: re-emit the endpoint op
 // carrying the pagination contract from the framework's own idioms, merging onto
-// the producer route op by Name via MergeWithCustom.
+// the producer route op via MergeWithCustom, which keys on (SourceFile, Kind,
+// Name) since #6104.
 //
 // Property contract (mirrors the flagship http_endpoint_pagination.go):
 //

--- a/internal/custom/rust/endpoint_response_codes.go
+++ b/internal/custom/rust/endpoint_response_codes.go
@@ -12,7 +12,8 @@
 // gated on Kind==http_endpoint_definition — can never reach them. This is the
 // SAME situation endpoint_deprecation.go faced; the resolution is identical:
 // re-emit the endpoint op carrying the status-code contract from the framework's
-// own idioms, merging onto the producer route op by Name via MergeWithCustom.
+// own idioms, merging onto the producer route op via MergeWithCustom, which
+// keys on (SourceFile, Kind, Name) since #6104.
 //
 // Property contract (mirrors the flagship http_endpoint_response_codes.go):
 //

--- a/internal/custom/rust/rate_limit.go
+++ b/internal/custom/rust/rate_limit.go
@@ -59,7 +59,8 @@
 // Like the sibling passes these surfaces add NO new node KIND beyond a marker
 // (`SCOPE.Pattern/rate_limit`) — a governor layer guards a whole Router/App and
 // a tower RateLimitLayer wraps a Service rather than a named route. The marker
-// carries the full throttle posture as evidence; MergeWithCustom dedups by Name.
+// carries the full throttle posture as evidence; MergeWithCustom folds it onto
+// the base op when (SourceFile, Kind, Name) all match (#6104).
 //
 // Honest-partial cases (rate_limited stamped, numeric rate OMITTED):
 //   - per_second / burst_size / RateLimitLayer args are non-literal (a config

--- a/internal/custom/scala/endpoint_deprecation.go
+++ b/internal/custom/scala/endpoint_deprecation.go
@@ -53,7 +53,7 @@
 // emitted as un-composed `path(...)`/`route:METHOD` fragments (akka.go), so there
 // is no single composed endpoint op to attach to without fabricating a route
 // binding. The marker carries the full contract as evidence; MergeWithCustom
-// dedups by Name. One marker per deprecation site.
+// folds on (SourceFile, Kind, Name) since #6104. One marker per deprecation site.
 //
 // Honest-partial (NEVER fabricated):
 //   - a route handler with NO deprecation marker → no marker emitted;

--- a/internal/custom/scala/rate_limit.go
+++ b/internal/custom/scala/rate_limit.go
@@ -54,7 +54,8 @@
 // Like the sibling passes these surfaces add NO new node KIND beyond a marker
 // (`SCOPE.Pattern/rate_limit`) — there is no single per-route endpoint to attach
 // an app-wide http4s Throttle to, and the akka throttle binds to a stream rather
-// than a named route. MergeWithCustom dedups by Name; the marker carries the
+// than a named route. MergeWithCustom folds on (SourceFile, Kind, Name) since
+// #6104; the marker carries the
 // full throttle posture as evidence.
 //
 // Honest-partial cases (rate_limited stamped, numeric rate OMITTED):

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -198,7 +198,9 @@ func walk(
 		// Issue #4854 — general field membership: one SCOPE.Schema/field per
 		// property / public field / record positional parameter, plus a
 		// class→field CONTAINS edge so a plain data class has field children
-		// (dedups by Name with the endpoint-bound DTO members in #4715).
+		// (folds with the endpoint-bound DTO members in #4715 when the Kind
+		// matches too — MergeWithCustom keys on (SourceFile, Kind, Name)
+		// since #6104, not on Name alone).
 		fieldEnts, baseNames := emitFieldMembers(node, body, file.Content, rec.Name, file.Path)
 		for _, fe := range fieldEnts {
 			toID := extractor.BuildSchemaFieldStructuralRef("csharp", file.Path, fe.Name)

--- a/internal/extractors/csharp/field_members.go
+++ b/internal/extractors/csharp/field_members.go
@@ -19,7 +19,7 @@ import (
 // gap #4850/#4855 closed for Go and #4845/#4851 for JS/TS.
 //
 // Field Name is "<Owner>.<Property>" (the C# member name, NOT a wire name) so
-// it dedups by Name against the custom DTO field members in MergeWithCustom —
+// it folds against the custom DTO field members in MergeWithCustom —
 // the richer custom entity (validators, library, optionality) wins.
 //
 //	Kind      = "SCOPE.Schema"

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -296,16 +296,34 @@ func RunCustomExtractors(ctx context.Context, file FileInput) (entities []types.
 //
 //	Tier C — no collision. Appended in dispatch order, unchanged.
 //
-// EDGE RE-KEYING. When a Tier A combine retires an ID (the base and custom
-// records carried different pre-stamped IDs), EVERY relationship visible to
-// the merge is re-keyed off the retired ID — not just the survivor's own
-// self-edges, which is all #4402 did, leaving edges emitted by other passes
-// dangling. MergeWithCustomRels additionally accepts and re-keys a standalone
-// relationship set for callers that hold one.
+// EDGE RE-KEYING, AND EXACTLY HOW FAR IT REACHES. When a Tier A combine
+// retires an ID, every relationship VISIBLE TO THE MERGE is re-keyed off it.
+// #4402 re-keyed only the superseded node's OWN self-edges; the sweep now
+// covers the relationships of every entity in the merged set, so an edge
+// emitted by a different pass and hanging off a different entity is corrected
+// too.
 //
-// The survivor prefers the BASE record's ID when it has one: base and custom
-// agree on every identity field in Tier A, and the base ID is the one the rest
-// of the base pass's edges already point at.
+// BE PRECISE ABOUT THE SCOPE. "Visible to the merge" means the relationships
+// carried on the merged EntityRecords. At the only production call site
+// (cmd/grafel/index.go, the #5989 in-process seam) that is ALL of them: pass 1
+// has no standalone relationship slice — classifyAndReadWithProgress returns
+// ([]classifiedFile, []types.EntityRecord) and relationships live exclusively
+// on EntityRecord.Relationships until later passes. So there is currently no
+// production caller of MergeWithCustomRels, and passing it a relationship set
+// is a capability for future callers rather than something exercised today.
+// This does NOT close the #4402 failure mode for edges created after the merge
+// by later passes; those never pass through here at all.
+//
+// ID PREFERENCE IS CONDITIONAL. The survivor prefers the BASE record's ID
+// *when the base has one stamped* — base and custom agree on every identity
+// field in Tier A, and the base ID is the one the rest of the base pass's
+// edges already point at. When the base has NOT been stamped yet, the custom
+// record's ID survives instead. ID stamping is per-extractor (~20 scattered
+// `e.ID = e.ComputeID()` sites), so which side wins depends on which extractor
+// happened to stamp. That is safe but not uniform: the `retired` map re-keys
+// whichever ID lost, so nothing dangles either way. Pinned by
+// TestMergeWithCustomPrefersTheBaseID and
+// TestMergeWithCustomKeepsCustomIDWhenBaseIsUnstamped.
 //
 // Cross-kind dedup is still handled downstream by run-extractor's
 // deduplicateEntities pass, which runs after this merge.
@@ -319,6 +337,10 @@ const BaseSubtypeProperty = types.EntityBaseSubtypeProperty
 // facet of, so the resolver can treat it as an alias rather than as a second
 // competing definition of the same name (#6104).
 const TwinOfProperty = types.EntityTwinOfProperty
+
+// DisjointSpanProperty records a custom-extractor span that was NOT unioned
+// into the survivor because it did not overlap the base span (#6104 / M4).
+const DisjointSpanProperty = "grafel.disjoint_custom_span"
 
 // identityKey is the graph's own entity identity, minus the org/project scope
 // (constant within one merge).
@@ -339,10 +361,13 @@ func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.
 // MergeWithCustomRels merges baseEntities with customEntities and re-keys
 // `rels` against any ID retired by a Tier A combine.
 //
-// The signature exists because the #6104 re-keying requirement cannot be met
-// without the merge seeing the relationship set: #4402 could only re-key the
-// superseded node's own self-edges, so edges produced by other passes were
-// left pointing at an ID that no longer existed.
+// NO PRODUCTION CALLER TODAY. The only production merge site has no standalone
+// relationship slice to hand over (see the policy block above), so every
+// production call goes through MergeWithCustom and `rels` is nil. This entry
+// point exists so that a caller which DOES hold a standalone set can have it
+// re-keyed rather than silently left dangling; it is currently exercised only
+// by tests. Do not describe the #4402 failure mode as closed for standalone
+// relationship streams on the strength of this function alone.
 func MergeWithCustomRels(baseEntities, customEntities []types.EntityRecord, rels []types.RelationshipRecord) ([]types.EntityRecord, []types.RelationshipRecord) {
 	if len(customEntities) == 0 {
 		return baseEntities, rels
@@ -476,9 +501,32 @@ func combineSameIdentity(be, ce types.EntityRecord) types.EntityRecord {
 	// (I2) NEVER NARROW A SPAN. 0 means "position unknown", not "line 0", so
 	// StartLine takes the minimum of the NON-ZERO values while EndLine takes
 	// the plain maximum.
-	survivor.StartLine = minNonZero(be.StartLine, ce.StartLine)
-	if be.EndLine > survivor.EndLine {
+	//
+	// DISJOINT SPANS ARE NOT UNIONED. A blind union of two spans that do not
+	// overlap invents a third span covering code belonging to NEITHER entity
+	// (base 5-8 with custom 40-60 would yield 5-60). That is reachable: Java
+	// method overloads give two declarations the same (Kind, Name, SourceFile)
+	// at different lines, so a custom record can legitimately combine against
+	// the wrong one. When both spans are known AND disjoint we therefore keep
+	// the BASE span — the base AST extractor is the one that actually located
+	// the declaration — and record the discarded custom span as provenance
+	// rather than merging or dropping it silently. The never-narrow invariant
+	// is preserved with respect to the base span, which is the span #6104 was
+	// about (EndLine 12 -> 9 was a base span being truncated).
+	if spansAreDisjoint(be, ce) {
+		if survivor.Properties == nil {
+			survivor.Properties = make(map[string]string, 1)
+		}
+		if _, exists := survivor.Properties[DisjointSpanProperty]; !exists {
+			survivor.Properties[DisjointSpanProperty] = fmt.Sprintf("%d-%d", ce.StartLine, ce.EndLine)
+		}
+		survivor.StartLine = be.StartLine
 		survivor.EndLine = be.EndLine
+	} else {
+		survivor.StartLine = minNonZero(be.StartLine, ce.StartLine)
+		if be.EndLine > survivor.EndLine {
+			survivor.EndLine = be.EndLine
+		}
 	}
 
 	// A displaced base Subtype is retained rather than discarded.
@@ -623,6 +671,23 @@ func enrichFromTwin(ce, be types.EntityRecord) types.EntityRecord {
 		}
 	}
 	return out
+}
+
+// spansAreDisjoint reports whether both records carry a KNOWN span (StartLine
+// > 0) and the two spans do not overlap or touch. A 0 StartLine means "position
+// unknown", which can never be disjoint from anything.
+func spansAreDisjoint(a, b types.EntityRecord) bool {
+	if a.StartLine <= 0 || b.StartLine <= 0 {
+		return false
+	}
+	aEnd, bEnd := a.EndLine, b.EndLine
+	if aEnd < a.StartLine {
+		aEnd = a.StartLine
+	}
+	if bEnd < b.StartLine {
+		bEnd = b.StartLine
+	}
+	return aEnd < b.StartLine || bEnd < a.StartLine
 }
 
 // minNonZero returns the smaller of two line numbers, treating 0 as "unknown"

--- a/internal/extractors/custom_dispatch.go
+++ b/internal/extractors/custom_dispatch.go
@@ -251,76 +251,393 @@ func RunCustomExtractors(ctx context.Context, file FileInput) (entities []types.
 	return entities, errs
 }
 
-// MergeWithCustom merges baseEntities with customEntities applying the
-// dedup rule: when a custom extractor emits an entity with the same
-// Name as a base extractor entity, the custom extractor's version wins.
+// ---------------------------------------------------------------------------
+// MERGE POLICY (issue #6104)
+// ---------------------------------------------------------------------------
 //
-// The merge preserves the original ordering of base entities, replacing any
-// base entity in place when a custom entity with the same Name exists. Custom
-// entities whose Name does not collide with any base entity are appended after
-// the base entities in their dispatch order (already deterministic via
-// CustomExtractorsFor's sort).
+// The old rule was "a custom entity with the same NAME as a base entity
+// replaces it". Name is not an identity. The graph's identity function is
+// EntityRecord.ComputeID = sha256(OrgID+ProjectID+SourceFile+Kind+Name), so
+// keying the merge on Name alone superseded on strictly LESS information than
+// the identity being superseded. On a 361-file fixture that destroyed 280
+// entities across 5 kinds and 2 languages, in three distinct shapes:
 //
-// SUPERSEDE SEMANTICS (issue #4402). A naive "custom wins, base discarded"
-// replacement silently drops two kinds of state the base node carried and the
-// custom node usually does not:
+//   1. cross-kind      Task|send_receipt replaced by SCOPE.Service|send_receipt
+//   2. same-kind       a second Task|send_receipt replacing the first
+//   3. in-place        SCOPE.Operation|C.list|method rewritten to |endpoint
+//                      with EndLine truncated 12 -> 9, propagating into the
+//                      derived SCOPE.Process and http_endpoint_definition
 //
-//   - QualifiedName — the module-qualified name that drives byQualifiedName
-//     resolution and cross-repo joins. Custom/framework extractors typically
-//     emit a bare Name with no QualifiedName; dropping the base one leaves the
-//     surviving entity unresolvable by qualified name (root cause behind the
-//     #4379 settings→middleware late-binding workaround).
-//   - Structural edges — relationships already attached to the base node,
-//     notably the class→field CONTAINS membership emitted by the base
-//     class-body walk (#526). Dropping these orphans every field (root cause
-//     behind the #4366 per-language CONTAINS re-emit workaround).
+// Keying on (Kind, Name) closes only shape 1. The defect is the POLICY, not
+// the key. The policy is now:
 //
-// supersedeBase therefore carries base-only state onto the surviving custom
-// entity: it fills the QualifiedName (and other) gaps the custom node left
-// empty WITHOUT overriding any value the custom node provided, and UNIONS the
-// base node's relationships into the survivor (re-keying base self-edges from
-// the base ID to the survivor ID and deduping). This makes the dropped-state
-// bug impossible at the merge boundary rather than patching it per-language
-// downstream.
+//	Tier A — SAME IDENTITY (SourceFile, Kind, Name).
+//	    These two records ARE the same graph node; the ID-keyed store would
+//	    collapse them anyway. They are COMBINED into one survivor. Custom
+//	    values win where they disagree (the framework extractor is the more
+//	    specific observer), base fills every gap, and:
+//	      * the SPAN IS UNIONED — StartLine takes the minimum of the non-zero
+//	        values, EndLine the maximum. A merge never narrows a span. This is
+//	        what closes shape 3: EndLine 12 survives the "endpoint" rewrite.
+//	      * a displaced non-empty base Subtype is retained under
+//	        BaseSubtypeProperty. "This method is really an endpoint" is real
+//	        information and the custom value wins, but the value it displaced
+//	        is preserved rather than discarded — enrichment, not replacement.
 //
-// This function does NOT perform cross-kind dedup — that is handled downstream
-// by run-extractor's deduplicateEntities pass which runs after this merge.
+//	Tier B — NAME COLLISION, DIFFERENT IDENTITY (different Kind, or different
+//	    SourceFile). These are DIFFERENT graph nodes. BOTH SURVIVE. This is
+//	    what closes shapes 1 and 2. The base node is left untouched; the
+//	    custom node is ENRICHED from its base twin (same file, same name) with
+//	    the base-only state #4402 was created to preserve — QualifiedName
+//	    (#4379), span, descriptive fields, and a re-keyed COPY of the base
+//	    node's structural edges (class->field CONTAINS, #526/#4366). #4402
+//	    obtained that state by destroying the base node; enrichment obtains
+//	    the same state with the base node still standing.
+//
+//	Tier C — no collision. Appended in dispatch order, unchanged.
+//
+// EDGE RE-KEYING. When a Tier A combine retires an ID (the base and custom
+// records carried different pre-stamped IDs), EVERY relationship visible to
+// the merge is re-keyed off the retired ID — not just the survivor's own
+// self-edges, which is all #4402 did, leaving edges emitted by other passes
+// dangling. MergeWithCustomRels additionally accepts and re-keys a standalone
+// relationship set for callers that hold one.
+//
+// The survivor prefers the BASE record's ID when it has one: base and custom
+// agree on every identity field in Tier A, and the base ID is the one the rest
+// of the base pass's edges already point at.
+//
+// Cross-kind dedup is still handled downstream by run-extractor's
+// deduplicateEntities pass, which runs after this merge.
+
+// BaseSubtypeProperty is the Properties key under which a base-path Subtype
+// displaced by a more specific custom-extractor Subtype is retained, so the
+// displaced value is preserved rather than lost (#6104).
+const BaseSubtypeProperty = types.EntityBaseSubtypeProperty
+
+// TwinOfProperty marks a Tier B facet with the ID of the base entity it is a
+// facet of, so the resolver can treat it as an alias rather than as a second
+// competing definition of the same name (#6104).
+const TwinOfProperty = types.EntityTwinOfProperty
+
+// identityKey is the graph's own entity identity, minus the org/project scope
+// (constant within one merge).
+type identityKey struct{ file, kind, name string }
+
+// twinKey identifies "the same source construct, modelled under a different
+// Kind" — used for Tier B enrichment only, never for supersede.
+type twinKey struct{ file, name string }
+
+// MergeWithCustom merges baseEntities with customEntities under the merge
+// policy documented above. It is MergeWithCustomRels with no standalone
+// relationship set.
 func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.EntityRecord {
+	ents, _ := MergeWithCustomRels(baseEntities, customEntities, nil)
+	return ents
+}
+
+// MergeWithCustomRels merges baseEntities with customEntities and re-keys
+// `rels` against any ID retired by a Tier A combine.
+//
+// The signature exists because the #6104 re-keying requirement cannot be met
+// without the merge seeing the relationship set: #4402 could only re-key the
+// superseded node's own self-edges, so edges produced by other passes were
+// left pointing at an ID that no longer existed.
+func MergeWithCustomRels(baseEntities, customEntities []types.EntityRecord, rels []types.RelationshipRecord) ([]types.EntityRecord, []types.RelationshipRecord) {
 	if len(customEntities) == 0 {
-		return baseEntities
+		return baseEntities, rels
 	}
 
-	// Index the first custom entity per Name (dispatch order).
-	customByName := make(map[string]int, len(customEntities))
-	for i, e := range customEntities {
-		if _, seen := customByName[e.Name]; !seen {
-			customByName[e.Name] = i
-		}
+	// Work on a copy: Tier B enriches custom records in place and the caller's
+	// slice must not be mutated.
+	custom := make([]types.EntityRecord, len(customEntities))
+	copy(custom, customEntities)
+
+	byIdentity := make(map[identityKey][]int, len(custom))
+	byTwin := make(map[twinKey][]int, len(custom))
+	for i, ce := range custom {
+		ik := identityKey{ce.SourceFile, ce.Kind, ce.Name}
+		tk := twinKey{ce.SourceFile, ce.Name}
+		byIdentity[ik] = append(byIdentity[ik], i)
+		byTwin[tk] = append(byTwin[tk], i)
 	}
 
-	used := make(map[int]bool, len(customEntities))
-	merged := make([]types.EntityRecord, 0, len(baseEntities)+len(customEntities))
+	combined := make([]bool, len(custom))
+	enriched := make([]bool, len(custom))
+	retired := make(map[string]string) // retired ID -> survivor ID
+	merged := make([]types.EntityRecord, 0, len(baseEntities)+len(custom))
 
-	// Replace base entities in place when a custom entity shares the Name,
-	// carrying base-only state (QualifiedName + structural edges) onto the
-	// surviving custom entity (issue #4402).
 	for _, be := range baseEntities {
-		if idx, ok := customByName[be.Name]; ok && !used[idx] {
-			merged = append(merged, supersedeBase(be, customEntities[idx]))
-			used[idx] = true
+		// --- Tier A: same identity -> combine into one survivor -------------
+		//
+		// A custom record with an empty SourceFile is matched against the base
+		// record's file: dispatch is per-file, so "no file" means "this file".
+		idxs := pickUnused(byIdentity[identityKey{be.SourceFile, be.Kind, be.Name}], combined)
+		if be.SourceFile != "" {
+			idxs = append(idxs, pickUnused(byIdentity[identityKey{"", be.Kind, be.Name}], combined)...)
+		}
+		if len(idxs) > 0 {
+			survivor := be
+			for _, i := range idxs {
+				survivor = combineSameIdentity(survivor, custom[i])
+				combined[i] = true
+			}
+			survivorID := effectiveID(&survivor)
+			if id := effectiveID(&be); id != "" && id != survivorID {
+				retired[id] = survivorID
+			}
+			for _, i := range idxs {
+				if id := effectiveID(&custom[i]); id != "" && id != survivorID {
+					retired[id] = survivorID
+				}
+			}
+			merged = append(merged, survivor)
 			continue
 		}
+
+		// --- Tier B: name twin of a different Kind -> BOTH survive ----------
+		twins := byTwin[twinKey{be.SourceFile, be.Name}]
+		if be.SourceFile != "" {
+			twins = append(twins, byTwin[twinKey{"", be.Name}]...)
+		}
+		for _, i := range twins {
+			if combined[i] || enriched[i] {
+				continue
+			}
+			custom[i] = enrichFromTwin(custom[i], be)
+			enriched[i] = true
+		}
+
 		merged = append(merged, be)
 	}
 
-	// Append remaining custom entities that did not replace a base entity.
-	for i, ce := range customEntities {
-		if used[i] {
+	// --- Tier C: custom entities that collided with nothing ----------------
+	for i := range custom {
+		if combined[i] {
 			continue
 		}
-		merged = append(merged, ce)
+		merged = append(merged, custom[i])
 	}
-	return merged
+
+	if len(retired) > 0 {
+		for i := range merged {
+			rekeyRelationships(merged[i].Relationships, retired)
+		}
+		rekeyRelationships(rels, retired)
+	}
+	return merged, rels
+}
+
+// pickUnused returns the indices in idxs not already consumed by a combine.
+func pickUnused(idxs []int, combined []bool) []int {
+	var out []int
+	for _, i := range idxs {
+		if !combined[i] {
+			out = append(out, i)
+		}
+	}
+	return out
+}
+
+// effectiveID is the entity's stamped ID, or the deterministic computed one
+// when the pipeline has not stamped it yet.
+func effectiveID(e *types.EntityRecord) string {
+	if e.ID != "" {
+		return e.ID
+	}
+	return e.ComputeID()
+}
+
+// rekeyRelationships rewrites every endpoint naming a retired ID, in place.
+func rekeyRelationships(rels []types.RelationshipRecord, retired map[string]string) {
+	for i := range rels {
+		if to, ok := retired[rels[i].FromID]; ok {
+			rels[i].FromID = to
+		}
+		if to, ok := retired[rels[i].ToID]; ok {
+			rels[i].ToID = to
+		}
+	}
+}
+
+// combineSameIdentity returns the single survivor for two records that share
+// the graph's identity (SourceFile, Kind, Name) and are therefore the same
+// node. See the merge policy block above.
+func combineSameIdentity(be, ce types.EntityRecord) types.EntityRecord {
+	survivor := supersedeBase(be, ce)
+
+	// The survivor carries the base ID when the base has one: the identity
+	// fields are equal, and the base ID is what the rest of the base pass's
+	// edges already point at.
+	if be.ID != "" {
+		survivor.ID = be.ID
+	}
+
+	// (I2) NEVER NARROW A SPAN. 0 means "position unknown", not "line 0", so
+	// StartLine takes the minimum of the NON-ZERO values while EndLine takes
+	// the plain maximum.
+	survivor.StartLine = minNonZero(be.StartLine, ce.StartLine)
+	if be.EndLine > survivor.EndLine {
+		survivor.EndLine = be.EndLine
+	}
+
+	// A displaced base Subtype is retained rather than discarded.
+	if be.Subtype != "" && survivor.Subtype != be.Subtype {
+		if survivor.Properties == nil {
+			survivor.Properties = make(map[string]string, 1)
+		}
+		if _, exists := survivor.Properties[BaseSubtypeProperty]; !exists {
+			survivor.Properties[BaseSubtypeProperty] = be.Subtype
+		}
+	}
+
+	// Identity scope: a custom extractor never sees the org/project stamps.
+	if survivor.OrgID == "" {
+		survivor.OrgID = be.OrgID
+	}
+	if survivor.ProjectID == "" {
+		survivor.ProjectID = be.ProjectID
+	}
+	if survivor.ProjectSlug == "" {
+		survivor.ProjectSlug = be.ProjectSlug
+	}
+	if survivor.RepoID == "" {
+		survivor.RepoID = be.RepoID
+	}
+	return survivor
+}
+
+// enrichFromTwin returns the custom entity `ce` enriched from its base twin
+// `be` — a record for the same source construct under a DIFFERENT Kind. The
+// base entity is NOT consumed: the caller keeps it in the merged output.
+//
+// This is the non-destructive replacement for #4402's supersede. It carries
+// the same base-only state onto the custom node (QualifiedName, span,
+// descriptive fields, structural edges) without deleting the node it came
+// from.
+func enrichFromTwin(ce, be types.EntityRecord) types.EntityRecord {
+	out := ce
+
+	// Mark the facet. Both nodes are in the graph, but only the base node is a
+	// competing DEFINITION of this name — the facet is an alias of it, and the
+	// symbol index must not read the pair as an ambiguity.
+	if out.Properties == nil {
+		out.Properties = make(map[string]string, 1)
+	}
+	if _, exists := out.Properties[TwinOfProperty]; !exists {
+		out.Properties[TwinOfProperty] = effectiveID(&be)
+	}
+
+	if out.QualifiedName == "" {
+		out.QualifiedName = be.QualifiedName
+	}
+	if out.Signature == "" {
+		out.Signature = be.Signature
+	}
+	if out.Description == "" {
+		out.Description = be.Description
+	}
+	if out.Domain == "" {
+		out.Domain = be.Domain
+	}
+	if out.Content == "" {
+		out.Content = be.Content
+	}
+	if out.Language == "" {
+		out.Language = be.Language
+	}
+	if out.SourceFile == "" {
+		out.SourceFile = be.SourceFile
+	}
+	if out.OrgID == "" {
+		out.OrgID = be.OrgID
+	}
+	if out.ProjectID == "" {
+		out.ProjectID = be.ProjectID
+	}
+	if out.ProjectSlug == "" {
+		out.ProjectSlug = be.ProjectSlug
+	}
+	if out.RepoID == "" {
+		out.RepoID = be.RepoID
+	}
+	// (I2) the twin describes the same construct, so widen rather than clip.
+	out.StartLine = minNonZero(out.StartLine, be.StartLine)
+	if be.EndLine > out.EndLine {
+		out.EndLine = be.EndLine
+	}
+
+	if len(be.Properties) > 0 {
+		if out.Properties == nil {
+			out.Properties = make(map[string]string, len(be.Properties))
+		}
+		for k, v := range be.Properties {
+			if _, ok := out.Properties[k]; !ok {
+				out.Properties[k] = v
+			}
+		}
+	}
+	if len(be.Metadata) > 0 {
+		if out.Metadata == nil {
+			out.Metadata = make(map[string]interface{}, len(be.Metadata))
+		}
+		for k, v := range be.Metadata {
+			if _, ok := out.Metadata[k]; !ok {
+				out.Metadata[k] = v
+			}
+		}
+	}
+
+	// COPY (never move) the base node's owned structural edges, re-keyed onto
+	// the custom node. An edge whose FromID names some third entity belongs to
+	// that entity and is left alone.
+	if len(be.Relationships) > 0 {
+		baseID := effectiveID(&be)
+		outID := effectiveID(&out)
+		type relKey struct{ from, to, kind string }
+		seen := make(map[relKey]bool, len(out.Relationships)+len(be.Relationships))
+		for _, r := range out.Relationships {
+			seen[relKey{r.FromID, r.ToID, r.Kind}] = true
+		}
+		for _, r := range be.Relationships {
+			if r.FromID != "" && r.FromID != baseID {
+				continue
+			}
+			br := r
+			// An empty FromID means "implicitly owned by whichever node
+			// carries this edge" — that is now the custom node, so leave it
+			// empty rather than materialising an ID that would defeat the
+			// dedup against the custom node's own implicit edges.
+			if br.FromID == baseID {
+				br.FromID = outID
+			}
+			if br.ToID == baseID {
+				br.ToID = outID
+			}
+			k := relKey{br.FromID, br.ToID, br.Kind}
+			if seen[k] {
+				continue
+			}
+			seen[k] = true
+			out.Relationships = append(out.Relationships, br)
+		}
+	}
+	return out
+}
+
+// minNonZero returns the smaller of two line numbers, treating 0 as "unknown"
+// rather than as line zero.
+func minNonZero(a, b int) int {
+	switch {
+	case a == 0:
+		return b
+	case b == 0:
+		return a
+	case a < b:
+		return a
+	default:
+		return b
+	}
 }
 
 // supersedeBase returns the surviving entity for the case where custom node
@@ -339,8 +656,11 @@ func MergeWithCustom(baseEntities, customEntities []types.EntityRecord) []types.
 //     ID so class→field CONTAINS membership is not dropped. Duplicates (same
 //     from/to/kind) are removed.
 //
-// The custom node's ID/Kind/Name are NOT changed — supersede preserves the
-// custom extractor's chosen identity.
+// supersedeBase is the Tier A field-level carry-over, called only by
+// combineSameIdentity — where base and custom already agree on the full
+// identity (SourceFile, Kind, Name), so no node is being displaced. Span and
+// ID handling are finished by combineSameIdentity, which enforces the
+// never-narrow invariant on top of the gap-fills below.
 func supersedeBase(be, ce types.EntityRecord) types.EntityRecord {
 	survivor := ce
 

--- a/internal/extractors/custom_dispatch_6104_test.go
+++ b/internal/extractors/custom_dispatch_6104_test.go
@@ -1,0 +1,335 @@
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6104 — MergeWithCustom destroyed and corrupted base entities.
+//
+// These tests pin the MERGE POLICY that replaces the old "custom wins by Name"
+// rule. The policy has three tiers, keyed on the graph's OWN identity function
+// (EntityRecord.ComputeID == sha256(OrgID+ProjectID+SourceFile+Kind+Name)):
+//
+//	Tier A  same (SourceFile, Kind, Name)      -> ONE node; the two records are
+//	                                              COMBINED, never narrowed.
+//	Tier B  Name collision, different identity -> TWO nodes; BOTH survive, the
+//	                                              custom one ENRICHED from base.
+//	Tier C  no collision                       -> appended unchanged.
+//
+// Two invariants hold across all three:
+//
+//	I1. A merge never loses an entity.
+//	I2. A merge never narrows a span.
+
+// ---- Tier B: cross-kind collision must not destroy the base entity ---------
+
+// The python/Celery shape. `@shared_task def send_receipt` makes the base path
+// emit BOTH `Task|send_receipt` and `SCOPE.Operation|send_receipt`, while the
+// Celery custom extractor emits `SCOPE.Service|send_receipt`. Under Name-only
+// keying the SCOPE.Service replaced one of them outright.
+func TestMergeWithCustomCrossKindCollisionKeepsBothEntities(t *testing.T) {
+	base := []types.EntityRecord{
+		{Name: "send_receipt", Kind: "Task", SourceFile: "app/tasks.py", StartLine: 4, EndLine: 6},
+		{Name: "send_receipt", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: "app/tasks.py", StartLine: 4, EndLine: 6},
+	}
+	custom := []types.EntityRecord{
+		{Name: "send_receipt", Kind: "SCOPE.Service", Subtype: "task", SourceFile: "app/tasks.py", StartLine: 4, EndLine: 4},
+	}
+
+	got := MergeWithCustom(base, custom)
+
+	want := map[string]bool{
+		"Task|send_receipt":            false,
+		"SCOPE.Operation|send_receipt": false,
+		"SCOPE.Service|send_receipt":   false,
+	}
+	for _, e := range got {
+		want[e.Kind+"|"+e.Name] = true
+	}
+	for k, seen := range want {
+		if !seen {
+			t.Errorf("entity %q was lost by the merge; got %v", k, kindNames(got))
+		}
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3 entities (nothing lost, nothing duplicated), got %d: %v", len(got), kindNames(got))
+	}
+}
+
+// A Name collision across DIFFERENT source files is not a collision at all —
+// the two records are different graph nodes and both must survive untouched.
+func TestMergeWithCustomDifferentSourceFileKeepsBoth(t *testing.T) {
+	base := []types.EntityRecord{
+		{Name: "list", Kind: "SCOPE.Operation", SourceFile: "a.java", StartLine: 1, EndLine: 9},
+	}
+	custom := []types.EntityRecord{
+		{Name: "list", Kind: "SCOPE.Operation", SourceFile: "b.java", StartLine: 2, EndLine: 3},
+	}
+	got := MergeWithCustom(base, custom)
+	if len(got) != 2 {
+		t.Fatalf("expected both entities to survive, got %d: %v", len(got), kindNames(got))
+	}
+	for _, e := range got {
+		if e.SourceFile == "a.java" && (e.StartLine != 1 || e.EndLine != 9) {
+			t.Errorf("base entity in a.java was mutated by an unrelated file's custom entity: %d-%d", e.StartLine, e.EndLine)
+		}
+	}
+}
+
+// ---- Tier A: same identity is combined, and the span is never narrowed -----
+
+// The java/Spring shape. Kind, Name and SourceFile are all identical, so these
+// ARE the same graph node — one node out is correct. What was NOT correct was
+// EndLine 12 -> 9: the body extent was silently truncated.
+func TestMergeWithCustomSameIdentityNeverNarrowsSpan(t *testing.T) {
+	base := []types.EntityRecord{{
+		Name: "OrdersController.list", Kind: "SCOPE.Operation", Subtype: "method",
+		QualifiedName: "api.OrdersController.list", SourceFile: "OrdersController.java",
+		StartLine: 9, EndLine: 12,
+	}}
+	custom := []types.EntityRecord{{
+		Name: "OrdersController.list", Kind: "SCOPE.Operation", Subtype: "endpoint",
+		SourceFile: "OrdersController.java",
+		StartLine:  9, EndLine: 9,
+	}}
+
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("same-identity records must collapse to one node, got %d: %v", len(got), kindNames(got))
+	}
+	s := got[0]
+	if s.StartLine != 9 || s.EndLine != 12 {
+		t.Errorf("span narrowed: want 9-12, got %d-%d", s.StartLine, s.EndLine)
+	}
+	if s.QualifiedName != "api.OrdersController.list" {
+		t.Errorf("base QualifiedName lost, got %q", s.QualifiedName)
+	}
+}
+
+// A custom extractor emitting a LATER start line must not clip the start of
+// the span either — StartLine takes the minimum of the non-zero values.
+func TestMergeWithCustomSameIdentityWidensStartLine(t *testing.T) {
+	base := []types.EntityRecord{{Name: "h", Kind: "SCOPE.Operation", SourceFile: "s.go", StartLine: 4, EndLine: 20}}
+	custom := []types.EntityRecord{{Name: "h", Kind: "SCOPE.Operation", SourceFile: "s.go", StartLine: 7, EndLine: 8}}
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(got))
+	}
+	if got[0].StartLine != 4 || got[0].EndLine != 20 {
+		t.Errorf("span narrowed: want 4-20, got %d-%d", got[0].StartLine, got[0].EndLine)
+	}
+}
+
+// A base entity with no position (line 0) must not drag a positioned custom
+// entity back to zero — 0 means "unknown", not "line zero". This is the JS
+// route-operation shape, where the custom extractor is the one with positions.
+func TestMergeWithCustomZeroBaseSpanDoesNotClobberCustomPosition(t *testing.T) {
+	base := []types.EntityRecord{{Name: "GET /api/orders", Kind: "SCOPE.Operation", SourceFile: "server.js"}}
+	custom := []types.EntityRecord{{Name: "GET /api/orders", Kind: "SCOPE.Operation", SourceFile: "server.js", StartLine: 5, EndLine: 5}}
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(got))
+	}
+	if got[0].StartLine != 5 || got[0].EndLine != 5 {
+		t.Errorf("want 5-5, got %d-%d", got[0].StartLine, got[0].EndLine)
+	}
+}
+
+// The custom Subtype is genuinely more specific ("this method is an endpoint")
+// and wins — but the base value it displaced is retained as provenance rather
+// than discarded, so the information is enriched, not replaced.
+func TestMergeWithCustomSameIdentityRetainsDisplacedSubtype(t *testing.T) {
+	base := []types.EntityRecord{{
+		Name: "OrdersController.list", Kind: "SCOPE.Operation", Subtype: "method",
+		SourceFile: "OrdersController.java", StartLine: 9, EndLine: 12,
+	}}
+	custom := []types.EntityRecord{{
+		Name: "OrdersController.list", Kind: "SCOPE.Operation", Subtype: "endpoint",
+		SourceFile: "OrdersController.java", StartLine: 9, EndLine: 9,
+	}}
+	got := MergeWithCustom(base, custom)
+	if got[0].Subtype != "endpoint" {
+		t.Errorf("custom Subtype must win, got %q", got[0].Subtype)
+	}
+	if got[0].Properties[BaseSubtypeProperty] != "method" {
+		t.Errorf("displaced base Subtype must be retained as %q provenance, got %q",
+			BaseSubtypeProperty, got[0].Properties[BaseSubtypeProperty])
+	}
+}
+
+// Two custom entities of the SAME identity must fold into the single node they
+// name, not be appended alongside it as duplicate IDs.
+func TestMergeWithCustomFoldsDuplicateCustomIdentities(t *testing.T) {
+	base := []types.EntityRecord{{Name: "X", Kind: "SCOPE.Operation", SourceFile: "f.py", StartLine: 1, EndLine: 10}}
+	custom := []types.EntityRecord{
+		{Name: "X", Kind: "SCOPE.Operation", SourceFile: "f.py", Subtype: "endpoint", StartLine: 1, EndLine: 2},
+		{Name: "X", Kind: "SCOPE.Operation", SourceFile: "f.py", Domain: "billing", StartLine: 1, EndLine: 3},
+	}
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("expected duplicate identities to fold into 1 node, got %d: %v", len(got), kindNames(got))
+	}
+	if got[0].EndLine != 10 {
+		t.Errorf("span narrowed by fold: want EndLine 10, got %d", got[0].EndLine)
+	}
+	if got[0].Subtype != "endpoint" || got[0].Domain != "billing" {
+		t.Errorf("fold lost custom state: subtype=%q domain=%q", got[0].Subtype, got[0].Domain)
+	}
+}
+
+// ---- Tier B enrichment preserves what #4402 / #4366 / #4379 needed ---------
+
+// #4402 carried the base QualifiedName and structural CONTAINS edges onto the
+// survivor by DESTROYING the base node. Enrichment gets the same state onto
+// the custom node while leaving the base node standing.
+func TestMergeWithCustomCrossKindEnrichesCustomWithoutDestroyingBase(t *testing.T) {
+	baseNode := types.EntityRecord{
+		Name: "Contract", Kind: "SCOPE.Component", QualifiedName: "app.models.Contract",
+		SourceFile: "m.py", StartLine: 3, EndLine: 30,
+	}
+	baseNode.ID = baseNode.ComputeID()
+	baseNode.Relationships = []types.RelationshipRecord{
+		{FromID: baseNode.ID, ToID: "Contract.amount", Kind: "CONTAINS"},
+	}
+	custom := []types.EntityRecord{
+		{Name: "Contract", Kind: "SCOPE.Schema", Subtype: "model", SourceFile: "m.py"},
+	}
+
+	got := MergeWithCustom([]types.EntityRecord{baseNode}, custom)
+	if len(got) != 2 {
+		t.Fatalf("cross-kind collision must keep both nodes, got %d: %v", len(got), kindNames(got))
+	}
+
+	var b, c *types.EntityRecord
+	for i := range got {
+		switch got[i].Kind {
+		case "SCOPE.Component":
+			b = &got[i]
+		case "SCOPE.Schema":
+			c = &got[i]
+		}
+	}
+	if b == nil || c == nil {
+		t.Fatalf("expected both kinds present, got %v", kindNames(got))
+	}
+	// The base node survives INTACT — enrichment is one-directional.
+	if b.QualifiedName != "app.models.Contract" || b.StartLine != 3 || b.EndLine != 30 {
+		t.Errorf("base node was mutated: %+v", *b)
+	}
+	if len(b.Relationships) != 1 {
+		t.Errorf("base node lost its structural edge: %v", b.Relationships)
+	}
+	// The custom node is enriched with base-only state (#4379, #4366).
+	if c.QualifiedName != "app.models.Contract" {
+		t.Errorf("custom node did not inherit base QualifiedName, got %q", c.QualifiedName)
+	}
+	if c.StartLine != 3 || c.EndLine != 30 {
+		t.Errorf("custom node did not inherit the base span, got %d-%d", c.StartLine, c.EndLine)
+	}
+	customID := c.ID
+	if customID == "" {
+		customID = c.ComputeID()
+	}
+	var contains int
+	for _, r := range c.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == "Contract.amount" {
+			contains++
+			if r.FromID != customID {
+				t.Errorf("copied structural edge not re-keyed to the custom node: from=%s want=%s", r.FromID, customID)
+			}
+		}
+	}
+	if contains != 1 {
+		t.Errorf("expected the base CONTAINS edge copied onto the custom node exactly once, got %d", contains)
+	}
+}
+
+// ---- Re-keying edges produced by OTHER passes (#4402 gap) ------------------
+
+// #4402 re-keyed only the superseded node's OWN self-edges. An edge emitted by
+// a different pass, hanging off a different entity, was left pointing at an ID
+// that no longer existed.
+func TestMergeWithCustomRekeysForeignEdgesTargetingTheRetiredID(t *testing.T) {
+	// The base record has not been ID-stamped yet, so its effective ID is the
+	// computed one; the custom record arrives with an ID already stamped. The
+	// survivor can only carry one of the two, so the other must be re-keyed.
+	baseNode := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", StartLine: 1, EndLine: 9}
+	retiredID := baseNode.ComputeID()
+
+	// A third entity, emitted by an unrelated pass, calls the base node.
+	caller := types.EntityRecord{Name: "caller", Kind: "SCOPE.Operation", SourceFile: "C.java"}
+	caller.ID = caller.ComputeID()
+	caller.Relationships = []types.RelationshipRecord{{FromID: caller.ID, ToID: retiredID, Kind: "CALLS"}}
+
+	customNode := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", Subtype: "endpoint", StartLine: 1, EndLine: 1}
+	customNode.ID = "custom-prestamped-id"
+
+	got := MergeWithCustom([]types.EntityRecord{baseNode, caller}, []types.EntityRecord{customNode})
+	baseNode.ID = retiredID // for the assertions below
+
+	var survivorID string
+	for _, e := range got {
+		if e.Name == "list" {
+			survivorID = e.ID
+		}
+	}
+	if survivorID == "" {
+		t.Fatalf("survivor not found: %v", kindNames(got))
+	}
+	for _, e := range got {
+		for _, r := range e.Relationships {
+			if r.ToID == baseNode.ID && baseNode.ID != survivorID {
+				t.Errorf("edge %s->%s (%s) still points at the retired base ID", r.FromID, r.ToID, r.Kind)
+			}
+			if r.Kind == "CALLS" && r.ToID != survivorID {
+				t.Errorf("CALLS edge not re-keyed to survivor: to=%s want=%s", r.ToID, survivorID)
+			}
+		}
+	}
+}
+
+// The merge must be able to see and re-key a STANDALONE relationship set, not
+// only edges embedded on entity records — the signature #6104 asked for.
+func TestMergeWithCustomRelsRekeysStandaloneRelationships(t *testing.T) {
+	baseNode := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", StartLine: 1, EndLine: 9}
+	retiredID := baseNode.ComputeID()
+	customNode := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", Subtype: "endpoint", StartLine: 1, EndLine: 1}
+	customNode.ID = "custom-prestamped-id"
+
+	rels := []types.RelationshipRecord{
+		{FromID: "someOtherPassNode", ToID: retiredID, Kind: "CALLS"},
+		{FromID: retiredID, ToID: "someOtherPassNode", Kind: "USES"},
+		{FromID: "x", ToID: "y", Kind: "IMPORTS"},
+	}
+	baseNode.ID = retiredID // for the assertions below
+
+	ents, gotRels := MergeWithCustomRels([]types.EntityRecord{baseNode}, []types.EntityRecord{customNode}, rels)
+	if len(ents) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(ents))
+	}
+	survivorID := ents[0].ID
+	if len(gotRels) != 3 {
+		t.Fatalf("relationship set must be preserved 1:1, got %d", len(gotRels))
+	}
+	for _, r := range gotRels {
+		if r.FromID == baseNode.ID || r.ToID == baseNode.ID {
+			if baseNode.ID != survivorID {
+				t.Errorf("standalone edge %s->%s (%s) not re-keyed off the retired base ID", r.FromID, r.ToID, r.Kind)
+			}
+		}
+	}
+	if gotRels[2].FromID != "x" || gotRels[2].ToID != "y" {
+		t.Errorf("unrelated edge was rewritten: %+v", gotRels[2])
+	}
+}
+
+// kindNames renders a merged slice compactly for failure messages.
+func kindNames(ents []types.EntityRecord) []string {
+	out := make([]string, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, e.Kind+"|"+e.Name+"|"+e.SourceFile)
+	}
+	return out
+}

--- a/internal/extractors/custom_dispatch_6104_test.go
+++ b/internal/extractors/custom_dispatch_6104_test.go
@@ -333,3 +333,126 @@ func kindNames(ents []types.EntityRecord) []string {
 	}
 	return out
 }
+
+// ---- ID preference (#6104 review finding M1) ------------------------------
+//
+// "The survivor prefers the base ID" is a policy claim, and it was unpinned:
+// deleting the preference killed no test in any package. It is also
+// CONDITIONALLY TRUE, which the pins below make explicit rather than papering
+// over. Either way the `retired` map re-keys the losing ID, so nothing dangles
+// — that is asserted here too, because it is the property that actually
+// matters.
+
+// When the base record HAS a stamped ID, the survivor carries it — that is the
+// ID the rest of the base pass's edges already point at.
+func TestMergeWithCustomPrefersTheBaseID(t *testing.T) {
+	base := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", StartLine: 1, EndLine: 9}
+	base.ID = "base-stamped-id"
+	custom := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", Subtype: "endpoint", StartLine: 1, EndLine: 1}
+	custom.ID = "custom-stamped-id"
+
+	got := MergeWithCustom([]types.EntityRecord{base}, []types.EntityRecord{custom})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(got))
+	}
+	if got[0].ID != "base-stamped-id" {
+		t.Errorf("survivor must carry the BASE id, got %q", got[0].ID)
+	}
+}
+
+// When the base has NOT been stamped, the custom ID survives instead. ID
+// stamping is per-extractor, so which side wins depends on which extractor
+// happened to stamp — documented as conditional, and pinned so it cannot drift
+// silently.
+func TestMergeWithCustomKeepsCustomIDWhenBaseIsUnstamped(t *testing.T) {
+	base := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", StartLine: 1, EndLine: 9}
+	retired := base.ComputeID() // effective ID of the unstamped base
+	custom := types.EntityRecord{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", Subtype: "endpoint", StartLine: 1, EndLine: 1}
+	custom.ID = "custom-stamped-id"
+
+	// A third entity points at the base's effective ID.
+	caller := types.EntityRecord{Name: "caller", Kind: "SCOPE.Operation", SourceFile: "C.java", ID: "caller-id"}
+	caller.Relationships = []types.RelationshipRecord{{FromID: "caller-id", ToID: retired, Kind: "CALLS"}}
+
+	got := MergeWithCustom([]types.EntityRecord{base, caller}, []types.EntityRecord{custom})
+
+	var survivorID string
+	for _, e := range got {
+		if e.Name == "list" {
+			survivorID = e.ID
+		}
+	}
+	if survivorID != "custom-stamped-id" {
+		t.Errorf("with an unstamped base the CUSTOM id survives; got %q", survivorID)
+	}
+	// Whichever side loses, the retired ID must not be left dangling.
+	for _, e := range got {
+		for _, r := range e.Relationships {
+			if r.FromID == retired || r.ToID == retired {
+				t.Errorf("edge %s->%s (%s) still points at the retired base ID %s",
+					r.FromID, r.ToID, r.Kind, retired)
+			}
+		}
+	}
+}
+
+// ---- Disjoint spans (#6104 review finding M4) -----------------------------
+
+// A blind span union invents a span covering code belonging to NEITHER entity.
+// The Java method-overload shape reaches this: two declarations can share
+// (Kind, Name, SourceFile) at different lines, so a custom record may combine
+// against the wrong one. Disjoint spans are therefore NOT unioned.
+func TestMergeWithCustomDoesNotUnionDisjointSpans(t *testing.T) {
+	base := []types.EntityRecord{{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", StartLine: 5, EndLine: 8}}
+	custom := []types.EntityRecord{{Name: "list", Kind: "SCOPE.Operation", SourceFile: "C.java", Subtype: "endpoint", StartLine: 40, EndLine: 60}}
+
+	got := MergeWithCustom(base, custom)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(got))
+	}
+	s := got[0]
+	if s.StartLine == 5 && s.EndLine == 60 {
+		t.Fatalf("disjoint spans were unioned into 5-60, which covers code belonging to neither entity")
+	}
+	if s.StartLine != 5 || s.EndLine != 8 {
+		t.Errorf("expected the BASE span 5-8 to be kept, got %d-%d", s.StartLine, s.EndLine)
+	}
+	if got := s.Properties[DisjointSpanProperty]; got != "40-60" {
+		t.Errorf("the discarded custom span must be recorded as provenance, got %q", got)
+	}
+	// The refinement itself is still kept.
+	if s.Subtype != "endpoint" {
+		t.Errorf("subtype refinement lost, got %q", s.Subtype)
+	}
+}
+
+// Touching and overlapping spans ARE unioned — the guard must not disable the
+// never-narrow invariant for the ordinary case.
+func TestMergeWithCustomUnionsOverlappingAndTouchingSpans(t *testing.T) {
+	for _, tc := range []struct {
+		name                       string
+		bStart, bEnd, cStart, cEnd int
+		wantStart, wantEnd         int
+	}{
+		{"overlapping", 9, 12, 9, 9, 9, 12},
+		{"touching", 5, 8, 8, 20, 5, 20},
+		{"adjacent-contained", 5, 20, 7, 8, 5, 20},
+		{"base position unknown", 0, 0, 5, 5, 5, 5},
+		{"custom position unknown", 4, 20, 0, 0, 4, 20},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base := []types.EntityRecord{{Name: "h", Kind: "SCOPE.Operation", SourceFile: "s.go", StartLine: tc.bStart, EndLine: tc.bEnd}}
+			custom := []types.EntityRecord{{Name: "h", Kind: "SCOPE.Operation", SourceFile: "s.go", StartLine: tc.cStart, EndLine: tc.cEnd}}
+			got := MergeWithCustom(base, custom)
+			if len(got) != 1 {
+				t.Fatalf("expected 1 entity, got %d", len(got))
+			}
+			if got[0].StartLine != tc.wantStart || got[0].EndLine != tc.wantEnd {
+				t.Errorf("want %d-%d, got %d-%d", tc.wantStart, tc.wantEnd, got[0].StartLine, got[0].EndLine)
+			}
+			if _, marked := got[0].Properties[DisjointSpanProperty]; marked {
+				t.Errorf("non-disjoint spans must not be marked disjoint")
+			}
+		})
+	}
+}

--- a/internal/extractors/custom_dispatch_test.go
+++ b/internal/extractors/custom_dispatch_test.go
@@ -316,33 +316,37 @@ func TestMergeWithCustomReturnsBaseWhenCustomEmpty(t *testing.T) {
 	}
 }
 
-func TestMergeWithCustomOverridesBaseEntityByName(t *testing.T) {
+// REWRITTEN FOR #6104. This test used to be
+// TestMergeWithCustomOverridesBaseEntityByName and asserted that a custom
+// SCOPE.View DESTROYS a base SCOPE.Class of the same Name. That is the defect
+// itself: Name is not an identity, and two records that disagree on Kind are
+// two different graph nodes (ComputeID includes Kind). The rewritten
+// assertion is that BOTH survive and the custom one is still distinguishable.
+func TestMergeWithCustomNameCollisionAcrossKindsKeepsBoth(t *testing.T) {
 	base := []types.EntityRecord{
-		{Name: "UserView", Kind: "SCOPE.Class", Signature: "base"},
-		{Name: "Helper", Kind: "SCOPE.Function"},
+		{Name: "UserView", Kind: "SCOPE.Class", SourceFile: "v.py", Signature: "base"},
+		{Name: "Helper", Kind: "SCOPE.Function", SourceFile: "v.py"},
 	}
 	custom := []types.EntityRecord{
-		{Name: "UserView", Kind: "SCOPE.View", Signature: "custom"},
+		{Name: "UserView", Kind: "SCOPE.View", SourceFile: "v.py", Signature: "custom"},
 	}
 	got := MergeWithCustom(base, custom)
 
-	if len(got) != 2 {
-		t.Fatalf("expected 2 merged entities, got %d", len(got))
+	if len(got) != 3 {
+		t.Fatalf("expected 3 merged entities (nothing destroyed), got %d: %v", len(got), kindNames(got))
 	}
-	// UserView must be the custom version; Helper must be the base version.
+	seen := map[string]types.EntityRecord{}
 	for _, e := range got {
-		switch e.Name {
-		case "UserView":
-			if e.Kind != "SCOPE.View" || e.Signature != "custom" {
-				t.Errorf("UserView should be custom, got kind=%s signature=%s", e.Kind, e.Signature)
-			}
-		case "Helper":
-			if e.Kind != "SCOPE.Function" {
-				t.Errorf("Helper should be unchanged, got kind=%s", e.Kind)
-			}
-		default:
-			t.Errorf("unexpected entity %s", e.Name)
-		}
+		seen[e.Kind+"|"+e.Name] = e
+	}
+	if e, ok := seen["SCOPE.Class|UserView"]; !ok || e.Signature != "base" {
+		t.Errorf("base UserView was destroyed or mutated: %+v", e)
+	}
+	if e, ok := seen["SCOPE.View|UserView"]; !ok || e.Signature != "custom" {
+		t.Errorf("custom UserView missing or mutated: %+v", e)
+	}
+	if e, ok := seen["SCOPE.Function|Helper"]; !ok || e.Kind != "SCOPE.Function" {
+		t.Errorf("Helper should be unchanged, got %+v", e)
 	}
 }
 
@@ -368,49 +372,63 @@ func TestMergeWithCustomPreservesBaseOrder(t *testing.T) {
 		{Name: "Third"},
 	}
 	custom := []types.EntityRecord{
-		{Name: "Second", Kind: "SCOPE.View"}, // overrides middle
+		{Name: "Second", Kind: "SCOPE.View"}, // name-twin of the middle entity
 	}
 	got := MergeWithCustom(base, custom)
-	if len(got) != 3 {
-		t.Fatalf("expected 3 entities, got %d", len(got))
+	// #6104: the base entities carry no Kind, so the custom SCOPE.View is a
+	// DIFFERENT graph node and is appended rather than replacing the middle
+	// entity. Base order is still what this test is about.
+	if len(got) != 4 {
+		t.Fatalf("expected 4 entities, got %d: %v", len(got), kindNames(got))
 	}
 	if got[0].Name != "First" || got[1].Name != "Second" || got[2].Name != "Third" {
 		t.Errorf("merge did not preserve base order: %v", extractNames(got))
 	}
-	if got[1].Kind != "SCOPE.View" {
-		t.Errorf("Second was not overridden, got kind=%s", got[1].Kind)
+	if got[1].Kind != "" {
+		t.Errorf("base Second must not be overridden, got kind=%s", got[1].Kind)
+	}
+	if got[3].Kind != "SCOPE.View" || got[3].Name != "Second" {
+		t.Errorf("custom entity must be appended after the base run, got %+v", got[3])
 	}
 }
 
-// TestMergeWithCustomPreservesBaseQualifiedName proves the supersede rule
-// (issue #4402): when a custom node replaces a base node of the same Name but
-// leaves QualifiedName empty, the base node's QualifiedName is carried onto the
-// survivor. A non-empty custom QualifiedName is never overridden.
+// TestMergeWithCustomPreservesBaseQualifiedName proves the #4402 property —
+// a custom node that leaves QualifiedName empty inherits the base node's,
+// which is what makes it resolvable by qualified name (#4379).
+//
+// REWRITTEN FOR #6104. #4402 obtained that state by DESTROYING the base node.
+// It is now obtained by Tier B enrichment, with the base node still standing,
+// so the assertions are per-Kind rather than per-Name and both nodes are
+// checked. The QualifiedName rule itself is unchanged.
 func TestMergeWithCustomPreservesBaseQualifiedName(t *testing.T) {
 	base := []types.EntityRecord{
-		{Name: "Contract", Kind: "SCOPE.Component", QualifiedName: "app.models.Contract"},
-		{Name: "Order", Kind: "SCOPE.Component", QualifiedName: "app.models.Order"},
+		{Name: "Contract", Kind: "SCOPE.Component", SourceFile: "m.py", QualifiedName: "app.models.Contract"},
+		{Name: "Order", Kind: "SCOPE.Component", SourceFile: "m.py", QualifiedName: "app.models.Order"},
 	}
 	custom := []types.EntityRecord{
-		{Name: "Contract", Kind: "SCOPE.Schema", Subtype: "model"},                             // empty QName -> inherit
-		{Name: "Order", Kind: "SCOPE.Schema", Subtype: "model", QualifiedName: "custom.Order"}, // explicit QName -> keep
+		{Name: "Contract", Kind: "SCOPE.Schema", SourceFile: "m.py", Subtype: "model"},                             // empty QName -> inherit
+		{Name: "Order", Kind: "SCOPE.Schema", SourceFile: "m.py", Subtype: "model", QualifiedName: "custom.Order"}, // explicit QName -> keep
 	}
 	got := MergeWithCustom(base, custom)
 
+	if len(got) != 4 {
+		t.Fatalf("expected 4 entities (2 base + 2 custom, nothing destroyed), got %d: %v", len(got), kindNames(got))
+	}
+	byKey := map[string]types.EntityRecord{}
 	for _, e := range got {
-		switch e.Name {
-		case "Contract":
-			if e.Kind != "SCOPE.Schema" {
-				t.Errorf("Contract should keep custom Kind, got %s", e.Kind)
-			}
-			if e.QualifiedName != "app.models.Contract" {
-				t.Errorf("Contract should inherit base QualifiedName, got %q", e.QualifiedName)
-			}
-		case "Order":
-			if e.QualifiedName != "custom.Order" {
-				t.Errorf("Order custom QualifiedName must not be overridden, got %q", e.QualifiedName)
-			}
-		}
+		byKey[e.Kind+"|"+e.Name] = e
+	}
+	if e := byKey["SCOPE.Schema|Contract"]; e.QualifiedName != "app.models.Contract" {
+		t.Errorf("custom Contract should inherit base QualifiedName, got %q", e.QualifiedName)
+	}
+	if e := byKey["SCOPE.Schema|Order"]; e.QualifiedName != "custom.Order" {
+		t.Errorf("custom Order QualifiedName must not be overridden, got %q", e.QualifiedName)
+	}
+	if e := byKey["SCOPE.Component|Contract"]; e.QualifiedName != "app.models.Contract" {
+		t.Errorf("base Contract was destroyed or mutated, got %+v", e)
+	}
+	if e := byKey["SCOPE.Component|Order"]; e.QualifiedName != "app.models.Order" {
+		t.Errorf("base Order was destroyed or mutated, got %+v", e)
 	}
 }
 
@@ -439,14 +457,28 @@ func TestMergeWithCustomUnionsBaseEdges(t *testing.T) {
 	custom := []types.EntityRecord{customNode}
 
 	got := MergeWithCustom(base, custom)
-	if len(got) != 1 {
-		t.Fatalf("expected 1 merged entity, got %d", len(got))
+	// #6104: the base node is NO LONGER DESTROYED — a Kind disagreement means
+	// two graph nodes. The edge-carry property this test exists for now
+	// applies to the enriched custom node, and the base node keeps its own.
+	if len(got) != 2 {
+		t.Fatalf("expected 2 merged entities (base kept), got %d: %v", len(got), kindNames(got))
 	}
-	surv := got[0]
-	if surv.ID == "" {
-		surv.ID = surv.ComputeID()
+	var surv types.EntityRecord
+	for _, e := range got {
+		if e.Kind == "SCOPE.Schema" {
+			surv = e
+		}
+		if e.Kind == "SCOPE.Component" && len(e.Relationships) != 2 {
+			t.Errorf("base node lost its own edges: %v", e.Relationships)
+		}
 	}
-	survID := surv.ComputeID()
+	if surv.Kind == "" {
+		t.Fatalf("custom node missing from merge: %v", kindNames(got))
+	}
+	survID := surv.ID
+	if survID == "" {
+		survID = surv.ComputeID()
+	}
 
 	var status, amount int
 	for _, r := range surv.Relationships {

--- a/internal/extractors/golang/struct_fields.go
+++ b/internal/extractors/golang/struct_fields.go
@@ -110,7 +110,7 @@ func extractStructFieldEntities(
 			}
 			// Wire name: prefer the json tag name (matching the endpoint-bound
 			// DTO field members emitted by internal/custom/golang so the two
-			// passes dedup by Name in MergeWithCustom and the richer custom
+			// passes fold together in MergeWithCustom and the richer custom
 			// entity wins). Only single-name fields carry a meaningful tag.
 			wire := fname
 			if len(names) == 1 {

--- a/internal/extractors/php/field_members.go
+++ b/internal/extractors/php/field_members.go
@@ -21,7 +21,7 @@ import (
 // for JS/TS.
 //
 // Property/param Name is "<Owner>.<prop>" (the PHP member name with the leading
-// `$` stripped) so it dedups by Name in MergeWithCustom against the framework
+// `$` stripped) so it folds in MergeWithCustom against the framework
 // DTO field members.
 //
 //	Kind      = "SCOPE.Schema"

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -100,7 +100,9 @@ func walk(node ts.Node, file extractor.FileInput, out *[]types.EntityRecord, cro
 			// Issue #4854 — general field membership: one SCOPE.Schema/field
 			// per named struct field (serde wire name / skip honoured) + a
 			// struct→field CONTAINS edge, so a plain data struct has field
-			// children (dedups by Name with the serde DTO members in #4635).
+			// children (folds with the serde DTO members in #4635 when the Kind
+			// matches too — MergeWithCustom keys on (SourceFile, Kind, Name)
+			// since #6104, not on Name alone).
 			fieldEnts := emitRustStructFields(node, file, rec.Name)
 			attachRustFieldContains(*out, idx, file.Path, fieldEnts)
 			*out = append(*out, fieldEnts...)

--- a/internal/extractors/rust/struct_fields.go
+++ b/internal/extractors/rust/struct_fields.go
@@ -21,7 +21,7 @@ import (
 // NO EXTENDS pass.
 //
 // Field Name is "<Owner>.<wire>" where <wire> is the serde rename target if
-// present (else the Rust field name) so it dedups by Name in MergeWithCustom
+// present (else the Rust field name) so it folds in MergeWithCustom
 // against the serde DTO field members; `#[serde(skip)]` fields are excluded.
 //
 //	Kind      = "SCOPE.Schema"

--- a/internal/resolve/facet_alias_6104_test.go
+++ b/internal/resolve/facet_alias_6104_test.go
@@ -190,3 +190,130 @@ func TestFacetAliasRuleMatchesOnTheModuleIndexPath(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ORPHANED FACETS (#6104 review finding M2)
+// ---------------------------------------------------------------------------
+//
+// The alias rule is scoped to the facet/ANCHOR PAIR. An earlier revision
+// short-circuited on "is a facet" alone, which excluded facets from ambiguity
+// detection GLOBALLY. That is reachable in production: deduplicateEntities
+// runs AFTER the merge and can remove the anchor, orphaning the facet. With
+// the global short-circuit, an orphaned facet standing next to a genuinely
+// unrelated same-named definition let that unrelated definition SILENTLY own
+// the bare name — trading an honestly-unresolved edge for a possibly-wrong
+// one, deterministically, in both orderings.
+//
+// These pin the pair-scoping in BOTH index builders.
+
+// orphanedFacetEnts builds the ORD-6 shape: a facet whose anchor is ABSENT
+// from the batch, plus an unrelated genuine definition of the same name in a
+// different file.
+func orphanedFacetEnts() (facet, unrelated types.EntityRecord) {
+	missingAnchor := anchorEnt("SCOPE.Component", "Order", "a/m.py", "a.m.Order")
+	facet = facetEnt("SCOPE.Schema", "Order", "a/m.py", "a.m.Order", missingAnchor.ID)
+	unrelated = anchorEnt("SCOPE.Component", "Order", "totally/other.py", "totally.other.Order")
+	return facet, unrelated
+}
+
+func TestOrphanedFacetDoesNotHandTheNameToAnUnrelatedDefinition(t *testing.T) {
+	facet, unrelated := orphanedFacetEnts()
+
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"facet first", []types.EntityRecord{facet, unrelated}},
+		{"unrelated first", []types.EntityRecord{unrelated, facet}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			idx := BuildIndex(tc.ents)
+			if id, ok := idx.Lookup("Order"); ok {
+				var who string
+				switch id {
+				case unrelated.ID:
+					who = "the UNRELATED definition in totally/other.py"
+				case facet.ID:
+					who = "the orphaned facet"
+				default:
+					who = "an unexpected entity"
+				}
+				t.Errorf("an orphaned facet must not suppress a real ambiguity: "+
+					"bare name resolved to %s (%q); it must stay ambiguous", who, id)
+			}
+		})
+	}
+}
+
+// Same shape on the module-index path (#4901), which must not diverge (#5206).
+func TestOrphanedFacetOnTheModuleIndexPath(t *testing.T) {
+	facet, unrelated := orphanedFacetEnts()
+
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"facet first", []types.EntityRecord{facet, unrelated}},
+		{"unrelated first", []types.EntityRecord{unrelated, facet}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flat := BuildIndex(tc.ents)
+			mod := BuildIndexFromModulesOrdered(tc.ents, ModuleKeyByPkgDir)
+
+			flatID, flatOK := flat.Lookup("Order")
+			modID, modOK := mod.Lookup("Order")
+			if modOK != flatOK || modID != flatID {
+				t.Errorf("module index DIVERGES from flat on the orphaned-facet shape: "+
+					"module=(%q,%v) flat=(%q,%v)", modID, modOK, flatID, flatOK)
+			}
+			if modOK {
+				t.Errorf("module index: orphaned facet suppressed a real ambiguity, resolved to %q", modID)
+			}
+		})
+	}
+}
+
+// A facet must not suppress ambiguity against a THIRD entity even when its own
+// anchor IS present — the rule protects the pair, not the name.
+func TestFacetDoesNotSuppressAmbiguityAgainstAThirdDefinition(t *testing.T) {
+	anchor := anchorEnt("SCOPE.Component", "Order", "a/m.py", "a.m.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "a/m.py", "a.m.Order", anchor.ID)
+	third := anchorEnt("SCOPE.Component", "Order", "totally/other.py", "totally.other.Order")
+
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"anchor facet third", []types.EntityRecord{anchor, facet, third}},
+		{"third facet anchor", []types.EntityRecord{third, facet, anchor}},
+		{"facet third anchor", []types.EntityRecord{facet, third, anchor}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if id, ok := BuildIndex(tc.ents).Lookup("Order"); ok {
+				t.Errorf("a third real definition must still make the name ambiguous, got %q", id)
+			}
+		})
+	}
+}
+
+// The QualifiedName tier needs the same pair-scoping: an orphaned facet must
+// not let an unrelated entity own a QualifiedName it shares.
+func TestOrphanedFacetDoesNotHandOverAQualifiedName(t *testing.T) {
+	missingAnchor := anchorEnt("SCOPE.Component", "Order", "a/m.py", "shared.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "a/m.py", "shared.Order", missingAnchor.ID)
+	unrelated := anchorEnt("SCOPE.Operation", "handle", "totally/other.py", "shared.Order")
+
+	for _, tc := range []struct {
+		name string
+		ents []types.EntityRecord
+	}{
+		{"facet first", []types.EntityRecord{facet, unrelated}},
+		{"unrelated first", []types.EntityRecord{unrelated, facet}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if id, ok := BuildIndex(tc.ents).Lookup("shared.Order"); ok {
+				t.Errorf("orphaned facet let %q own a contested QualifiedName", id)
+			}
+		})
+	}
+}

--- a/internal/resolve/facet_alias_6104_test.go
+++ b/internal/resolve/facet_alias_6104_test.go
@@ -1,0 +1,192 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6104 — merge FACETS in the symbol index.
+//
+// The #6104 merge keeps both nodes when a custom/framework extractor models a
+// source construct the base path already emitted under a different Kind (e.g.
+// SCOPE.Schema|Order alongside the base SCOPE.Component|Order). That puts a
+// SECOND node under an existing name. Without special handling the symbol
+// index reads that as a name collision and flips the name to ambiguous, which
+// un-resolves every edge that names it — the #4366 `Class:Order` and #4379
+// dotted-middleware-path failures.
+//
+// The rule: a facet is an ALIAS of its anchor, not a competing definition.
+//
+//	F1. A facet never makes its anchor unresolvable.
+//	F2. A facet never displaces its anchor in a symbol table.
+//	F3. Order-independence: a real entity arriving AFTER a facet still takes
+//	    the entry.
+//	F4. NON-FACETS ARE UNTOUCHED — two genuinely different definitions sharing
+//	    a name are still ambiguous. This is the regression risk: the alias rule
+//	    must not become a general "first writer wins" that silently resolves
+//	    real ambiguity.
+
+func anchorEnt(kind, name, file, qname string) types.EntityRecord {
+	e := types.EntityRecord{Kind: kind, Name: name, SourceFile: file, QualifiedName: qname}
+	e.ID = e.ComputeID()
+	return e
+}
+
+func facetEnt(kind, name, file, qname, anchorID string) types.EntityRecord {
+	e := types.EntityRecord{
+		Kind: kind, Name: name, SourceFile: file, QualifiedName: qname,
+		Properties: map[string]string{types.EntityTwinOfProperty: anchorID},
+	}
+	e.ID = e.ComputeID()
+	return e
+}
+
+// F1 + F2: the anchor stays resolvable by bare name and by QualifiedName, and
+// the ID returned is the ANCHOR's, not the facet's.
+func TestFacetDoesNotMakeAnchorUnresolvable(t *testing.T) {
+	anchor := anchorEnt("SCOPE.Component", "Order", "app/models/orders.py", "app.models.orders.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "app/models/orders.py", "app.models.orders.Order", anchor.ID)
+
+	idx := BuildIndex([]types.EntityRecord{anchor, facet})
+
+	id, ok := idx.Lookup("Order")
+	if !ok {
+		t.Fatalf("bare-name lookup of the anchor failed once a facet was added (the #4366 shape)")
+	}
+	if id != anchor.ID {
+		t.Errorf("bare name resolved to the facet %q, want the anchor %q", id, anchor.ID)
+	}
+
+	// Class:Order — kind "Class" is not a SCOPE.Component alias, so this falls
+	// through to the kind-agnostic path. This is the exact stub #4366 asserts.
+	if id, ok := idx.Lookup("Class:Order"); !ok || id != anchor.ID {
+		t.Errorf("Class:Order did not resolve to the anchor (id=%q ok=%v)", id, ok)
+	}
+
+	// QualifiedName — the facet inherits its anchor's, which must not blank the
+	// entry (the #4379 dotted-middleware-path shape).
+	if id, ok := idx.Lookup("app.models.orders.Order"); !ok || id != anchor.ID {
+		t.Errorf("QualifiedName lookup did not resolve to the anchor (id=%q ok=%v)", id, ok)
+	}
+}
+
+// F3: order-independence. The facet is indexed FIRST here; the anchor arriving
+// afterwards must still take the entry rather than colliding with it.
+func TestFacetDoesNotDisplaceAnchorWhenIndexedFirst(t *testing.T) {
+	anchor := anchorEnt("SCOPE.Component", "Order", "app/models/orders.py", "app.models.orders.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "app/models/orders.py", "app.models.orders.Order", anchor.ID)
+
+	idx := BuildIndex([]types.EntityRecord{facet, anchor}) // facet first
+
+	if id, ok := idx.Lookup("Order"); !ok || id != anchor.ID {
+		t.Errorf("anchor did not take the byName entry from the facet incumbent (id=%q ok=%v)", id, ok)
+	}
+	if id, ok := idx.Lookup("app.models.orders.Order"); !ok || id != anchor.ID {
+		t.Errorf("anchor did not take the byQualifiedName entry from the facet incumbent (id=%q ok=%v)", id, ok)
+	}
+}
+
+// The facet is still addressable under its OWN Kind — keeping both nodes must
+// not make one of them unreachable.
+func TestFacetRemainsAddressableByItsOwnKind(t *testing.T) {
+	anchor := anchorEnt("SCOPE.Component", "Order", "app/models/orders.py", "app.models.orders.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "app/models/orders.py", "app.models.orders.Order", anchor.ID)
+
+	idx := BuildIndex([]types.EntityRecord{anchor, facet})
+
+	if id, ok := idx.Lookup("SCOPE.Schema:Order"); !ok || id != facet.ID {
+		t.Errorf("facet not addressable by its own kind (id=%q ok=%v want %q)", id, ok, facet.ID)
+	}
+	if id, ok := idx.Lookup("SCOPE.Component:Order"); !ok || id != anchor.ID {
+		t.Errorf("anchor not addressable by its own kind (id=%q ok=%v want %q)", id, ok, anchor.ID)
+	}
+}
+
+// F4 — THE REGRESSION GUARD. Two genuinely different definitions sharing a
+// name are still ambiguous. The alias rule keys strictly on
+// EntityTwinOfProperty; it must not leak into ordinary entities.
+func TestNonFacetNameCollisionIsStillAmbiguous(t *testing.T) {
+	a := anchorEnt("SCOPE.Component", "Order", "app/models/orders.py", "app.models.orders.Order")
+	b := anchorEnt("SCOPE.Component", "Order", "billing/models.py", "billing.models.Order")
+
+	idx := BuildIndex([]types.EntityRecord{a, b})
+
+	if id, ok := idx.Lookup("Order"); ok {
+		t.Errorf("two real definitions named Order must stay AMBIGUOUS, resolved to %q", id)
+	}
+	// Same-kind collision must still be ambiguous within the kind too.
+	if id, ok := idx.Lookup("SCOPE.Component:Order"); ok {
+		t.Errorf("same-kind collision between two real definitions must stay ambiguous, got %q", id)
+	}
+	// Distinct QualifiedNames are unaffected either way.
+	if id, ok := idx.Lookup("billing.models.Order"); !ok || id != b.ID {
+		t.Errorf("distinct QualifiedName broke (id=%q ok=%v)", id, ok)
+	}
+}
+
+// A duplicate QualifiedName between two NON-facets must still blank the entry.
+func TestNonFacetQualifiedNameCollisionIsStillBlanked(t *testing.T) {
+	a := anchorEnt("SCOPE.Component", "Order", "a.py", "shared.Order")
+	b := anchorEnt("SCOPE.Operation", "handle", "b.py", "shared.Order")
+
+	idx := BuildIndex([]types.EntityRecord{a, b})
+	if id, ok := idx.Lookup("shared.Order"); ok {
+		t.Errorf("a duplicate QualifiedName between two real entities must stay ambiguous, got %q", id)
+	}
+}
+
+// A self-referential or empty twin marker is NOT a facet — the property must
+// name a DIFFERENT entity for the alias rule to apply, so a stray or corrupted
+// value cannot be used to suppress a real ambiguity.
+func TestSelfReferentialTwinMarkerIsNotAFacet(t *testing.T) {
+	a := anchorEnt("SCOPE.Component", "Order", "a.py", "a.Order")
+	b := anchorEnt("SCOPE.Component", "Order", "b.py", "b.Order")
+	b.Properties = map[string]string{types.EntityTwinOfProperty: b.ID} // points at itself
+
+	if b.IsMergeTwinAlias() {
+		t.Fatalf("an entity naming ITSELF as its twin must not count as a facet")
+	}
+	idx := BuildIndex([]types.EntityRecord{a, b})
+	if id, ok := idx.Lookup("Order"); ok {
+		t.Errorf("self-referential marker suppressed a real ambiguity, resolved to %q", id)
+	}
+}
+
+// The module-index path (GRAFEL_RESOLVE_MODULE_INDEX=1, #4901) must agree with
+// flat BuildIndex on all of the above — a divergence between the two builders
+// is exactly the #5206 class of bug.
+func TestFacetAliasRuleMatchesOnTheModuleIndexPath(t *testing.T) {
+	anchor := anchorEnt("SCOPE.Component", "Order", "app/models/orders.py", "app.models.orders.Order")
+	facet := facetEnt("SCOPE.Schema", "Order", "app/models/orders.py", "app.models.orders.Order", anchor.ID)
+	other := anchorEnt("SCOPE.Component", "Order", "billing/models.py", "billing.models.Order")
+
+	for _, tc := range []struct {
+		name     string
+		ents     []types.EntityRecord
+		stub     string
+		wantID   string
+		wantOK   bool
+		wantWhat string
+	}{
+		{"facet keeps anchor resolvable", []types.EntityRecord{anchor, facet}, "Order", anchor.ID, true, "anchor"},
+		{"facet first", []types.EntityRecord{facet, anchor}, "Order", anchor.ID, true, "anchor"},
+		{"facet keeps qname resolvable", []types.EntityRecord{anchor, facet}, "app.models.orders.Order", anchor.ID, true, "anchor"},
+		{"real collision stays ambiguous", []types.EntityRecord{anchor, other}, "Order", "", false, "ambiguous"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			flat := BuildIndex(tc.ents)
+			gotFlatID, gotFlatOK := flat.Lookup(tc.stub)
+			if gotFlatOK != tc.wantOK || (tc.wantOK && gotFlatID != tc.wantID) {
+				t.Errorf("flat BuildIndex: got (%q,%v) want %s", gotFlatID, gotFlatOK, tc.wantWhat)
+			}
+
+			mod := BuildIndexFromModulesOrdered(tc.ents, ModuleKeyByPkgDir)
+			gotModID, gotModOK := mod.Lookup(tc.stub)
+			if gotModOK != gotFlatOK || gotModID != gotFlatID {
+				t.Errorf("module index DIVERGES from flat: module=(%q,%v) flat=(%q,%v)",
+					gotModID, gotModOK, gotFlatID, gotFlatOK)
+			}
+		})
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -421,19 +421,30 @@ type Index struct {
 	// (file, name, kind) collisions.
 	byLocationKind LocationKindIndex
 
-	// aliasIncumbent[key] = true when the current byName / byQualifiedName
-	// entry for `key` was written by a MERGE FACET rather than by a real
-	// definition (#6104). Keys are prefixed "n:"/"q:" to share one map.
+	// aliasAnchor[key] = the ANCHOR ID of the merge facet that currently owns
+	// the byName / byQualifiedName entry for `key` (#6104). Keys are prefixed
+	// "n:"/"q:" to share one map. Absent = the entry is owned by a real
+	// definition, not a facet.
 	//
 	// A facet (EntityTwinOfProperty) is a second Kind describing the SAME
 	// source construct as a co-located base entity — e.g. SCOPE.Schema|Order
 	// alongside the base SCOPE.Component|Order the ORM extractor recognised as
 	// a model. Both are real graph nodes, but for NAME resolution the facet is
-	// an alias, not a competing definition: it must never flip a name to
-	// ambiguous and never displace its anchor. Tracking incumbency is what
-	// makes the rule order-independent — a real entity arriving after a facet
-	// still takes the entry.
-	aliasIncumbent map[string]bool
+	// an alias of ITS OWN ANCHOR, not a competing definition.
+	//
+	// THE ANCHOR IDENTITY IS LOAD-BEARING, NOT DECORATIVE. The rule is scoped
+	// to the facet/anchor PAIR: a facet suppresses ambiguity only against the
+	// entity it is a facet OF. An earlier revision short-circuited on "is a
+	// facet" alone, which excluded facets from ambiguity detection GLOBALLY —
+	// so an ORPHANED facet (its anchor removed downstream by
+	// deduplicateEntities, which runs after the merge) sitting alongside a
+	// genuinely unrelated same-named definition let that unrelated definition
+	// silently own the bare name. That trades an honestly-unresolved edge for
+	// a possibly-wrong one. Storing the anchor ID rather than a bool is what
+	// makes the check possible in both directions, and keeps the rule
+	// order-independent: the anchor arriving AFTER its facet still takes the
+	// entry, but any OTHER entity arriving after a facet is a real collision.
+	aliasAnchor map[string]string
 
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
@@ -928,27 +939,35 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// produces a non-existent "kind" segment). First writer wins;
 		// collisions blank the entry so the resolver leaves the stub.
 		isFacet := e.IsMergeTwinAlias()
+		facetAnchor := ""
+		if isFacet {
+			facetAnchor = e.Properties[types.EntityTwinOfProperty]
+		}
 		if e.QualifiedName != "" {
+			qk := "q:" + e.QualifiedName
 			if existing, ok := idx.byQualifiedName[e.QualifiedName]; ok && existing != e.ID {
 				// #6104 — a merge facet inherits its anchor's QualifiedName.
 				// That is not a collision between two definitions, so it must
-				// not blank the entry.
+				// not blank the entry — but ONLY against its own anchor.
 				switch {
-				case isFacet:
-					// facet never competes
-				case idx.aliasIncumbent["q:"+e.QualifiedName]:
+				case isFacet && existing == facetAnchor:
+					// facet does not compete with its own anchor
+				case !isFacet && idx.aliasAnchor[qk] == e.ID:
+					// the anchor itself, arriving after its facet: take over
 					idx.byQualifiedName[e.QualifiedName] = e.ID
-					delete(idx.aliasIncumbent, "q:"+e.QualifiedName)
+					delete(idx.aliasAnchor, qk)
 				default:
+					// any other pairing is a real collision
 					idx.byQualifiedName[e.QualifiedName] = ""
+					delete(idx.aliasAnchor, qk)
 				}
 			} else {
 				idx.byQualifiedName[e.QualifiedName] = e.ID
 				if isFacet {
-					if idx.aliasIncumbent == nil {
-						idx.aliasIncumbent = make(map[string]bool)
+					if idx.aliasAnchor == nil {
+						idx.aliasAnchor = make(map[string]string)
 					}
-					idx.aliasIncumbent["q:"+e.QualifiedName] = true
+					idx.aliasAnchor[qk] = facetAnchor
 				}
 			}
 		}
@@ -1418,30 +1437,36 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		if idx.ambigName[e.Name] {
 			continue
 		}
+		nk := "n:" + e.Name
 		if existing, ok := idx.byName[e.Name]; ok && existing != e.ID {
 			// #6104 — a merge facet is an ALIAS of a co-located base entity,
 			// not a second definition. Without this, enabling the custom
 			// extractors would flip every framework-modelled class name
 			// (Order, Contract, …) to ambiguous and silently un-resolve the
-			// edges that name it.
+			// edges that name it. Scoped to the facet/anchor PAIR: an
+			// ORPHANED facet must NOT suppress ambiguity against an unrelated
+			// same-named definition.
 			switch {
-			case isFacet:
-				// facet never competes
-			case idx.aliasIncumbent["n:"+e.Name]:
+			case isFacet && existing == facetAnchor:
+				// facet does not compete with its own anchor
+			case !isFacet && idx.aliasAnchor[nk] == e.ID:
+				// the anchor itself, arriving after its facet: take over
 				idx.byName[e.Name] = e.ID
-				delete(idx.aliasIncumbent, "n:"+e.Name)
+				delete(idx.aliasAnchor, nk)
 			default:
+				// any other pairing is a real collision
 				delete(idx.byName, e.Name)
+				delete(idx.aliasAnchor, nk)
 				idx.ambigName[e.Name] = true
 			}
 			continue
 		}
 		idx.byName[e.Name] = e.ID
 		if isFacet {
-			if idx.aliasIncumbent == nil {
-				idx.aliasIncumbent = make(map[string]bool)
+			if idx.aliasAnchor == nil {
+				idx.aliasAnchor = make(map[string]string)
 			}
-			idx.aliasIncumbent["n:"+e.Name] = true
+			idx.aliasAnchor[nk] = facetAnchor
 		}
 	}
 	return idx

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -421,6 +421,20 @@ type Index struct {
 	// (file, name, kind) collisions.
 	byLocationKind LocationKindIndex
 
+	// aliasIncumbent[key] = true when the current byName / byQualifiedName
+	// entry for `key` was written by a MERGE FACET rather than by a real
+	// definition (#6104). Keys are prefixed "n:"/"q:" to share one map.
+	//
+	// A facet (EntityTwinOfProperty) is a second Kind describing the SAME
+	// source construct as a co-located base entity — e.g. SCOPE.Schema|Order
+	// alongside the base SCOPE.Component|Order the ORM extractor recognised as
+	// a model. Both are real graph nodes, but for NAME resolution the facet is
+	// an alias, not a competing definition: it must never flip a name to
+	// ambiguous and never displace its anchor. Tracking incumbency is what
+	// makes the rule order-independent — a real entity arriving after a facet
+	// still takes the entry.
+	aliasIncumbent map[string]bool
+
 	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
 	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
 	// CONTAINS edges where ToID = "<file>::<heading-slug>"). Issue #100.
@@ -913,11 +927,29 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		// the byKind nor byName paths see it (splitStub on the first ':'
 		// produces a non-existent "kind" segment). First writer wins;
 		// collisions blank the entry so the resolver leaves the stub.
+		isFacet := e.IsMergeTwinAlias()
 		if e.QualifiedName != "" {
 			if existing, ok := idx.byQualifiedName[e.QualifiedName]; ok && existing != e.ID {
-				idx.byQualifiedName[e.QualifiedName] = ""
+				// #6104 — a merge facet inherits its anchor's QualifiedName.
+				// That is not a collision between two definitions, so it must
+				// not blank the entry.
+				switch {
+				case isFacet:
+					// facet never competes
+				case idx.aliasIncumbent["q:"+e.QualifiedName]:
+					idx.byQualifiedName[e.QualifiedName] = e.ID
+					delete(idx.aliasIncumbent, "q:"+e.QualifiedName)
+				default:
+					idx.byQualifiedName[e.QualifiedName] = ""
+				}
 			} else {
 				idx.byQualifiedName[e.QualifiedName] = e.ID
+				if isFacet {
+					if idx.aliasIncumbent == nil {
+						idx.aliasIncumbent = make(map[string]bool)
+					}
+					idx.aliasIncumbent["q:"+e.QualifiedName] = true
+				}
 			}
 		}
 		// Flask-realworld wave — index Properties["ref"] under the same
@@ -1387,11 +1419,30 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			continue
 		}
 		if existing, ok := idx.byName[e.Name]; ok && existing != e.ID {
-			delete(idx.byName, e.Name)
-			idx.ambigName[e.Name] = true
+			// #6104 — a merge facet is an ALIAS of a co-located base entity,
+			// not a second definition. Without this, enabling the custom
+			// extractors would flip every framework-modelled class name
+			// (Order, Contract, …) to ambiguous and silently un-resolve the
+			// edges that name it.
+			switch {
+			case isFacet:
+				// facet never competes
+			case idx.aliasIncumbent["n:"+e.Name]:
+				idx.byName[e.Name] = e.ID
+				delete(idx.aliasIncumbent, "n:"+e.Name)
+			default:
+				delete(idx.byName, e.Name)
+				idx.ambigName[e.Name] = true
+			}
 			continue
 		}
 		idx.byName[e.Name] = e.ID
+		if isFacet {
+			if idx.aliasIncumbent == nil {
+				idx.aliasIncumbent = make(map[string]bool)
+			}
+			idx.aliasIncumbent["n:"+e.Name] = true
+		}
 	}
 	return idx
 }

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -568,25 +568,28 @@ func insertModuleEntry(
 ) {
 	// QualifiedName index.
 	if me.qualifiedName != "" {
+		qk := "q:" + me.qualifiedName
+		anchor, isFacet := me.mergeFacetAnchor()
 		if existing, ok := idx.byQualifiedName[me.qualifiedName]; ok && existing != me.id {
 			// #6104 — mirrors flat BuildIndex: a merge facet never blanks the
-			// entry its anchor owns.
+			// entry ITS OWN ANCHOR owns. An orphaned facet still collides.
 			switch {
-			case me.isMergeFacet():
-				// facet never competes
-			case idx.aliasIncumbent["q:"+me.qualifiedName]:
+			case isFacet && existing == anchor:
+				// facet does not compete with its own anchor
+			case !isFacet && idx.aliasAnchor[qk] == me.id:
 				idx.byQualifiedName[me.qualifiedName] = me.id
-				delete(idx.aliasIncumbent, "q:"+me.qualifiedName)
+				delete(idx.aliasAnchor, qk)
 			default:
 				idx.byQualifiedName[me.qualifiedName] = ""
+				delete(idx.aliasAnchor, qk)
 			}
 		} else {
 			idx.byQualifiedName[me.qualifiedName] = me.id
-			if me.isMergeFacet() {
-				if idx.aliasIncumbent == nil {
-					idx.aliasIncumbent = make(map[string]bool)
+			if isFacet {
+				if idx.aliasAnchor == nil {
+					idx.aliasAnchor = make(map[string]string)
 				}
-				idx.aliasIncumbent["q:"+me.qualifiedName] = true
+				idx.aliasAnchor[qk] = anchor
 			}
 		}
 	}
@@ -885,39 +888,45 @@ func insertModuleEntry(
 	if idx.ambigName[me.name] {
 		return
 	}
+	nk := "n:" + me.name
+	nameAnchor, nameIsFacet := me.mergeFacetAnchor()
 	if existing, ok := idx.byName[me.name]; ok && existing != me.id {
-		// #6104 — mirrors flat BuildIndex: a merge facet is an alias of its
-		// co-located anchor, not a competing definition.
+		// #6104 — mirrors flat BuildIndex: a merge facet is an alias of ITS
+		// OWN ANCHOR, not a competing definition. An orphaned facet (anchor
+		// removed downstream) still collides with an unrelated same-named
+		// definition, rather than silently handing it the name.
 		switch {
-		case me.isMergeFacet():
-			// facet never competes
-		case idx.aliasIncumbent["n:"+me.name]:
+		case nameIsFacet && existing == nameAnchor:
+			// facet does not compete with its own anchor
+		case !nameIsFacet && idx.aliasAnchor[nk] == me.id:
 			idx.byName[me.name] = me.id
-			delete(idx.aliasIncumbent, "n:"+me.name)
+			delete(idx.aliasAnchor, nk)
 		default:
 			delete(idx.byName, me.name)
+			delete(idx.aliasAnchor, nk)
 			idx.ambigName[me.name] = true
 		}
 		return
 	}
 	idx.byName[me.name] = me.id
-	if me.isMergeFacet() {
-		if idx.aliasIncumbent == nil {
-			idx.aliasIncumbent = make(map[string]bool)
+	if nameIsFacet {
+		if idx.aliasAnchor == nil {
+			idx.aliasAnchor = make(map[string]string)
 		}
-		idx.aliasIncumbent["n:"+me.name] = true
+		idx.aliasAnchor[nk] = nameAnchor
 	}
 }
 
-// isMergeFacet reports whether this module entry is a #6104 merge facet — a
-// second Kind describing the same source construct as a co-located base
-// entity. See types.EntityTwinOfProperty.
-func (me *moduleEntry) isMergeFacet() bool {
+// mergeFacetAnchor reports whether this module entry is a #6104 merge facet —
+// a second Kind describing the same source construct as a co-located base
+// entity — and if so the ID of the anchor it is a facet OF. See
+// types.EntityTwinOfProperty.
+func (me *moduleEntry) mergeFacetAnchor() (anchor string, ok bool) {
 	if len(me.properties) == 0 {
-		return false
+		return "", false
 	}
-	anchor := me.properties[types.EntityTwinOfProperty]
-	return anchor != "" && anchor != me.id
+	anchor = me.properties[types.EntityTwinOfProperty]
+	return anchor, anchor != "" && anchor != me.id
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -569,9 +569,25 @@ func insertModuleEntry(
 	// QualifiedName index.
 	if me.qualifiedName != "" {
 		if existing, ok := idx.byQualifiedName[me.qualifiedName]; ok && existing != me.id {
-			idx.byQualifiedName[me.qualifiedName] = ""
+			// #6104 — mirrors flat BuildIndex: a merge facet never blanks the
+			// entry its anchor owns.
+			switch {
+			case me.isMergeFacet():
+				// facet never competes
+			case idx.aliasIncumbent["q:"+me.qualifiedName]:
+				idx.byQualifiedName[me.qualifiedName] = me.id
+				delete(idx.aliasIncumbent, "q:"+me.qualifiedName)
+			default:
+				idx.byQualifiedName[me.qualifiedName] = ""
+			}
 		} else {
 			idx.byQualifiedName[me.qualifiedName] = me.id
+			if me.isMergeFacet() {
+				if idx.aliasIncumbent == nil {
+					idx.aliasIncumbent = make(map[string]bool)
+				}
+				idx.aliasIncumbent["q:"+me.qualifiedName] = true
+			}
 		}
 	}
 	// ref property indexing (endpoint, testcoverage, interface stubs).
@@ -870,11 +886,38 @@ func insertModuleEntry(
 		return
 	}
 	if existing, ok := idx.byName[me.name]; ok && existing != me.id {
-		delete(idx.byName, me.name)
-		idx.ambigName[me.name] = true
+		// #6104 — mirrors flat BuildIndex: a merge facet is an alias of its
+		// co-located anchor, not a competing definition.
+		switch {
+		case me.isMergeFacet():
+			// facet never competes
+		case idx.aliasIncumbent["n:"+me.name]:
+			idx.byName[me.name] = me.id
+			delete(idx.aliasIncumbent, "n:"+me.name)
+		default:
+			delete(idx.byName, me.name)
+			idx.ambigName[me.name] = true
+		}
 		return
 	}
 	idx.byName[me.name] = me.id
+	if me.isMergeFacet() {
+		if idx.aliasIncumbent == nil {
+			idx.aliasIncumbent = make(map[string]bool)
+		}
+		idx.aliasIncumbent["n:"+me.name] = true
+	}
+}
+
+// isMergeFacet reports whether this module entry is a #6104 merge facet — a
+// second Kind describing the same source construct as a co-located base
+// entity. See types.EntityTwinOfProperty.
+func (me *moduleEntry) isMergeFacet() bool {
+	if len(me.properties) == 0 {
+		return false
+	}
+	anchor := me.properties[types.EntityTwinOfProperty]
+	return anchor != "" && anchor != me.id
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/internal/types/entity.go
+++ b/internal/types/entity.go
@@ -80,6 +80,37 @@ func (e *EntityRecord) Validate() error {
 	return nil
 }
 
+// Merge-provenance property keys (issue #6104). The merge boundary between
+// base-path and custom/framework extractor output records what it displaced
+// and what it aliased, so nothing is silently lost.
+const (
+	// EntityBaseSubtypeProperty holds a base-path Subtype that a more
+	// specific custom-extractor Subtype displaced (e.g. "method" displaced by
+	// "endpoint"). The custom value wins because it is more specific; the
+	// displaced value is retained rather than discarded.
+	EntityBaseSubtypeProperty = "grafel.base_subtype"
+
+	// EntityTwinOfProperty holds the entity ID of the co-located base-path
+	// entity this record is a FACET of — same source construct, same file,
+	// same name, DIFFERENT Kind (e.g. SCOPE.Schema|Order alongside the base
+	// SCOPE.Component|Order that the ORM extractor recognised as a model).
+	//
+	// Both nodes exist in the graph, but for name resolution a facet is an
+	// ALIAS, not a competing definition: it must never flip a name to
+	// ambiguous and never displace its anchor in a symbol table.
+	EntityTwinOfProperty = "grafel.twin_of"
+)
+
+// IsMergeTwinAlias reports whether this record is a merge facet of another
+// co-located entity (see EntityTwinOfProperty).
+func (e *EntityRecord) IsMergeTwinAlias() bool {
+	if len(e.Properties) == 0 {
+		return false
+	}
+	anchor := e.Properties[EntityTwinOfProperty]
+	return anchor != "" && anchor != e.ID
+}
+
 // ComputeID generates a deterministic 16-character hex ID from the entity's
 // identity fields. Formula: sha256(OrgID+ProjectID+SourceFile+Kind+Name)[:16].
 func (e *EntityRecord) ComputeID() string {


### PR DESCRIPTION
`MergeWithCustom` superseded base entities keyed on **`Name` alone**. The graph's identity is `ComputeID = sha256(OrgID+ProjectID+SourceFile+Kind+Name)`, so the merge was replacing entities on strictly *less* information than the identity it replaced. On a 361-file fixture that destroyed **280 entities across 5 kinds and 2 languages**.

The key was a symptom. **The policy was the defect.**

## Three collision shapes, and why `(Kind, Name)` was not the fix

| shape | example | closed by `(Kind, Name)`? |
|---|---|---|
| cross-kind | `Task\|send_receipt` replaced by `SCOPE.Service\|send_receipt` | yes |
| same-kind, same name | a second `Task\|send_receipt` replacing the first | **no** |
| same-kind, in-place corruption | `SCOPE.Operation\|C.list\|method` → `\|endpoint`, `EndLine` 12→9 | **no** |

Verified by mutation rather than argument: with a `(Kind, Name)` supersede applied experimentally, the Java pinning test **still passed and still logged the truncation**.

## The policy

- **Tier A** — same `(SourceFile, Kind, Name)`. These *are* one graph node; the ID-keyed store would collapse them regardless, so one survivor is correct. Span is **unioned** — min non-zero `StartLine`, max `EndLine`. The custom `Subtype` wins ("this method is really an endpoint" is the information the gate exists to add) but the displaced value is retained in `grafel.base_subtype`. That closes shape 3: `EndLine` 12 survives the rewrite.
- **Tier B** — name collision, different identity. **Both survive.** The custom node is *enriched* from its co-located twin with exactly the state #4402 wanted — QualifiedName, span, descriptive fields, a re-keyed copy of structural edges. #4402 obtained that state by destroying the base node; enrichment obtains it with the base node standing.
- **Tier C** — no collision, appended unchanged.

Replacement was rejected everywhere it was avoidable. The one place a single node is correct is Tier A, and there it is a combine.

## Tier B forced a resolver change, and that was the risky part

Adding a second node under an existing name flipped it to ambiguous and reded #4366 (`Class:Order`) and #4379 (middleware dotted paths). So a Tier B node is marked `grafel.twin_of` and the symbol index treats a **facet as an alias of its anchor, not a competing definition** — applied identically to flat `BuildIndex` and the module-index path.

**Review found this arm short-circuited on "is a facet" alone**, without checking the incumbent was actually that facet's anchor. Consequence: a facet was excluded from ambiguity detection **globally**. An orphaned facet plus an unrelated genuine definition elsewhere meant the unrelated one **silently owned the bare name**, deterministically, where it was correctly ambiguous before.

Reachable in production, because `deduplicateEntities` runs *after* the merge and can remove the anchor. It traded an honestly-unresolved edge for a possibly-wrong one — the worst failure mode in this codebase.

Fixed by making the relation directional: `aliasIncumbent map[string]bool` → **`aliasAnchor map[string]string`**. A facet now suppresses ambiguity only against the entity it is a facet *of*, and only that anchor may reclaim the entry.

**A second, mirror-image hole was found while fixing it**: the incumbent arm let *any* non-facet displace an alias incumbent. Both directions are now anchor-checked. Pinned in both builders — orphaned facet in both orderings, module-path divergence, a third-definition case, and the QualifiedName tier.

## Independently verified in review

Built with the reviewer's own instruments, not by reading test names:

- **Gate-off inertness holds** — own content-keyed digest (both endpoints resolved to endpoint content, never raw IDs), empty `diff` against `c427f3a59`. Re-confirmed after the resolver rewrite: 99 entities / 212 relationships, identical digest.
- **Span union correct** on 10 constructed degenerate cases — both zero, either zero, disjoint both directions, inverted `StartLine > EndLine`, zero `EndLine`. Never produced an inverted result.
- **The two builders do not diverge** across 10 adversarial orderings. The #5206 class is absent.
- **Non-facets are untouched** — two genuine definitions sharing a name still ambiguous in every ordering, duplicate QualifiedName still blanked, self-referential marker correctly not a facet.
- **#1613 repoints rather than drops** — 0 edges on the retired `Task` ID, 1 on the `SCOPE.Service` ID.
- **Dangle census improves**: 53/236 → 51/243. Fewer dangling edges while adding 7.
- Mutants killed: span union · flat-builder facet check · module-builder facet check · both reclaim branches · re-keying.

## Claims corrected rather than defended

**The re-keying claim overstated what shipped.** `MergeWithCustomRels` has **zero production callers** — the one production site passes `rels = nil`, and the mutant that "proved" re-keying was killed only through a test-only entry point.

Investigated before deciding: `classifyAndReadWithProgress` returns `([]classifiedFile, []types.EntityRecord)`, so **pass 1 holds no standalone relationship slice at the merge point** — relationships live on `EntityRecord.Relationships` until later passes. Wiring the call site would pass `nil` and change nothing. The claim was corrected instead of the code being bent to fit it. Now documented in the code: the real gain is that the sweep covers *all merged entities'* relationships rather than only the survivor's, `MergeWithCustomRels` has no production caller, and this does **not** close #4402 for edges created after the merge by later passes.

**"The survivor prefers the base ID" was unpinned and conditionally false.** Deleting that preference killed no test in any of four packages. When the base record has no stamped ID the **custom** ID survives — and ID stamping is per-extractor across ~20 scattered sites, so which side wins depends on which extractor happened to stamp. Now pinned both ways, documented as conditional, with "the retired ID is re-keyed whichever side loses" asserted.

**The pinning assertion had a hole shaped like the original defect.** It excused a retirement whenever any same-`(Name, SourceFile)` entity survived — **ignoring `Kind`**, which is exactly cross-kind supersede. *Had the original bug re-keyed its edges, that assertion would have passed on it.* And `onRefs == 0` could not distinguish repointed from deleted; a dropping pass scored a perfect zero.

Now Kind-aware: a retirement is excused only by a same-`(Kind, Name, SourceFile)` successor, or by a cross-kind #1613 fold proving the full contract — survivor's kind strictly outranks in `frameworkClassKindPriority` **and** edge conservation holds, measured as content-keyed edge multisets (`direction|kind|otherEndpointContent`) so a dropping pass fails.

## Also changed

- **Disjoint spans are now guarded, not unioned.** Base `5-8` ∪ custom `40-60` → `5-60` covered code belonging to neither entity. Disjoint spans keep the base span; the discarded custom span is recorded under `grafel.disjoint_custom_span`. Overlapping, touching and unknown-position spans still union, so never-narrow holds for the ordinary case.

  **Stated plainly:** keeping the base span is a judgement — the base AST extractor is the one that located the declaration. If a custom extractor is ever the better locator in a disjoint case, that choice is wrong and the recorded property is the only trace. The Java-overload shape that motivates it is reasoned, not observed. This is guarded on argument, not evidence.
- Dangling-edge evidence is now measured **post-persistence** — both arms round-trip through `WriteAtomic` + `LoadGraphFromDir` rather than reading the in-memory Document.
- 18 `internal/custom/**` extractor comments corrected; they documented the obsolete "dedups by Name so the custom version wins" contract, and under Tier B several now produce a second node instead of replacing.

## Test-rewrite audit

All 8 modified pre-existing tests were audited individually in review and judged **stronger, not weakened**. The 4 `MergeWithCustom` unit tests and 2 `#4402` boundary tests moved from per-Name to per-`Kind|Name` keys and now assert on **both** nodes — base survival is newly asserted. `findMergedClass` now fails if either node is missing, where it previously fatal'd on anything but exactly one.

## Coverage, stated honestly

Only go/ruby (inert) and js (not-inert) have language-level pins. Java and Python are covered incidentally by the shape tests. **The other ~20 dispatched languages have none.** Do not read the current coverage as broad.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. At `-count=1 -p 1`:

| suite | exit | pass | skip |
|---|---|---|---|
| `./internal/extractors/...` | 0 | 3825 | 1 |
| `./internal/custom/...` | 0 | 3867 | **0** |
| `./internal/resolve/...` | 0 | 308 | **0** |
| `./cmd/grafel/` | 0 | 313 | 6 |
| `./internal/graph/...` | 0 | 431 | **0** |

0 FAIL throughout. All 7 skips are pre-existing env-gated measurement tests, unchanged from baseline.

`GRAFEL_INPROC_CUSTOM_EXTRACTORS` remains default-off. #6105 untouched.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Closes #6104
Refs #5989, #4402, #4366, #4379, #1613, #6105, #5206
