### PR TITLE
fix(#6108): bound Pass-4 CPU at both in-process sites — the 571% was the GC, not the algorithm

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1425,6 +1425,13 @@ func daemonForegroundLinks(ctx context.Context, group string) error {
 	return runLinksHookWithCtx(ctx, group)
 }
 
+// groupAlgoCapApply applies the resolved CPU bound around the in-process
+// group-algo pass (#6108). It is process.WithGOMAXPROCSCap; a var only so a
+// test can observe the cap the fallback ACTUALLY asks for and the GOMAXPROCS
+// actually in force when the pass body runs — the assertion #6091 taught us to
+// make behaviourally rather than by reading the source.
+var groupAlgoCapApply = process.WithGOMAXPROCSCap
+
 // daemonSchedulerGroupAlgo runs the group-scope algorithm pass ONCE over the
 // assembled union of a group's per-repo graphs and writes the <group>-algo.json
 // overlay (#5349 A3, epic #5350). It replaces the old per-repo daemonSchedulerAlgo:
@@ -1442,23 +1449,138 @@ func daemonSchedulerGroupAlgo(ctx context.Context, group string) error {
 		// Preferred path: fork-exec for heap isolation under the per-child CPU
 		// cap. The child writes the overlay; the MCP apply path picks it up by
 		// mtime on the next group load (no daemon-side cache to poke).
+		//
+		// The heartbeat covers this branch too: the child's own per-phase
+		// memtrace is off unless GRAFEL_MEMTRACE is set, so without this the
+		// daemon log goes silent between "starting" and the child's exit — which
+		// on the real corpus is tens of minutes, and on a loaded host was
+		// measured at ~4 hours (#6108).
+		defer startGroupAlgoProgress(ctx, group, "child")()
 		return sched.RunSubprocessGroupAlgo(ctx, group, slog.Default())
 	}
 	// In-process fallback (opt-out via GRAFEL_SUBPROCESS_INDEXER=0). Runs under
 	// the scheduler's algoSem cap. The union heap is freed when the result goes
 	// out of scope; no per-repo graph.fb is rewritten.
 	//
-	// #5309 layer 4 — incremental community detection: when the assembled union's
-	// community-input hash matches the prior overlay's, the heavy Louvain +
-	// PageRank + betweenness recompute is skipped and the prior overlay is
-	// reconstituted verbatim (strict parity by determinism); otherwise a full
-	// deterministic recompute runs (CPU-bounded by #5602). Either way the overlay
-	// is re-written so its source_mtimes settle the staleness gate.
-	res, err := groupalgo.RunGroupAlgorithmsIncremental(group)
-	if err != nil {
-		return err
+	// #6108 — CPU BOUND. There is no child here to hand a GOMAXPROCS to, so the
+	// pass used to run at the daemon's own GOMAXPROCS (= every core on the box)
+	// while the scheduler logged the CHILD's cap. Resolve the SAME cap the child
+	// would have been spawned with and apply it to this process for the duration.
+	// Foreground groups resolve to the host core count, and WithGOMAXPROCSCap
+	// never raises, so user-awaited work is left uncapped exactly as #5954
+	// intends. See internal/process/gomaxprocs.go for why GOMAXPROCS is the
+	// right lever for a pass with no goroutine fan-out of its own (it is the
+	// GC's parallelism, not the algorithm's, that produced 571.9%).
+	capN := sched.GroupAlgoGOMAXPROCSFor(sched.GroupIsForeground(group))
+	defer startGroupAlgoProgress(ctx, group, "in-process")()
+	return groupAlgoCapApply(capN, func() error {
+		// #5309 layer 4 — incremental community detection: when the assembled
+		// union's community-input hash matches the prior overlay's, the heavy
+		// Louvain + PageRank + betweenness recompute is skipped and the prior
+		// overlay is reconstituted verbatim (strict parity by determinism);
+		// otherwise a full deterministic recompute runs (CPU-bounded by #5602).
+		// Either way the overlay is re-written so its source_mtimes settle the
+		// staleness gate.
+		res, err := groupalgo.RunGroupAlgorithmsIncremental(group)
+		if err != nil {
+			return err
+		}
+		return groupalgo.WriteOverlayFromResult(res)
+	})
+}
+
+// groupAlgoProgressInterval is how often a running group-algo pass reports
+// progress. GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL overrides it; "0" disables the
+// heartbeat entirely.
+//
+// 60s is chosen against the failure it exists for: a pass with a ~40 minute
+// expectation that ran for ~4 hours and emitted NOTHING after "starting", so an
+// operator staring at a daemon holding six cores could not tell slow progress
+// from a wedge. At 60s a healthy pass adds a handful of lines and a pathological
+// one leaves a per-phase timeline. Anything much finer would spam the ring
+// buffer that holds the daemon's recent log.
+const groupAlgoProgressInterval = time.Minute
+
+func groupAlgoProgressEvery() time.Duration {
+	if raw := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL")); raw != "" {
+		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
+			return d
+		}
+		if raw == "0" {
+			return 0
+		}
 	}
-	return groupalgo.WriteOverlayFromResult(res)
+	return groupAlgoProgressInterval
+}
+
+// startGroupAlgoProgress emits a periodic progress line for an in-flight
+// group-algo pass and returns a stop function (call it, or defer it, exactly
+// once).
+//
+// WHAT IT REPORTS AND WHY EACH FIELD IS THERE:
+//
+//   - phase — groupalgo.CurrentPhase(), the same stamp the memtrace sampler
+//     reads, so the two can never disagree. Only meaningful on the in-process
+//     branch; the child stamps its own copy in its own address space, so the
+//     child branch reports the mode instead of a phase it cannot see. A phase
+//     that has not advanced in twenty lines is what "wedged" looks like.
+//   - elapsed — wall time since the pass started.
+//   - cpu — percent of one core, averaged over the interval, derived from the
+//     process's cumulative CPU seconds. This is the field that would have made
+//     #6108 self-evident from the log alone: `cap=2` beside `cpu=571%` is the
+//     whole bug in one line. On the child branch it is the DAEMON's own draw,
+//     which is the number that matters for "is the daemon eating my machine".
+//
+// It never takes a lock the pass can block on and never fails the pass: a CPU
+// read error simply drops the cpu field for that tick.
+func startGroupAlgoProgress(ctx context.Context, group, mode string) func() {
+	every := groupAlgoProgressEvery()
+	if every <= 0 {
+		return func() {}
+	}
+	logger := slog.Default()
+	pid := os.Getpid()
+	start := time.Now()
+	lastWall := start
+	lastCPU, cpuOK := 0.0, false
+	if s, err := process.CPUTimeSeconds(pid); err == nil {
+		lastCPU, cpuOK = s, true
+	}
+
+	done := make(chan struct{})
+	var once sync.Once
+	go func() {
+		t := time.NewTicker(every)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case <-ctx.Done():
+				return
+			case now := <-t.C:
+				attrs := []any{
+					"group", group,
+					"mode", mode,
+					"elapsed", time.Since(start).Truncate(time.Second).String(),
+				}
+				if phase := groupalgo.CurrentPhase(); phase != "" && mode != "child" {
+					attrs = append(attrs, "phase", phase)
+				}
+				if s, err := process.CPUTimeSeconds(pid); err == nil {
+					if wall := now.Sub(lastWall).Seconds(); cpuOK && wall > 0 {
+						if pct := 100 * (s - lastCPU) / wall; pct >= 0 {
+							attrs = append(attrs, "cpu_pct", int(pct))
+						}
+					}
+					lastCPU, cpuOK = s, true
+				}
+				lastWall = now
+				logger.Info("group-algo: progress", attrs...)
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(done) }) }
 }
 
 // daemonIndexFunc is the IndexFunc handed to daemon.Run. It bridges the

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -368,12 +368,16 @@ func applyDaemonGOMAXPROCSFromCaps(store *caps.Store, hostCPU int) (int, int, bo
 	if target < 1 {
 		target = 1
 	}
-	cur := runtime.GOMAXPROCS(0) // query without changing
-	if cur == target {
-		return target, cur, false
-	}
-	prev := runtime.GOMAXPROCS(target)
-	return target, prev, true
+	// #6108 — MUST go through process.ApplyGOMAXPROCS, not runtime directly.
+	// The daemon now opens capped GOMAXPROCS regions around its in-process
+	// analytics passes, and a handler that read/wrote the runtime value itself
+	// lost this reload whenever one was open: a target equal to the region's
+	// clamp read back as "unchanged" and no-oped, and the region's restore then
+	// wrote back the pre-region host value — leaving the daemon PERMANENTLY
+	// ABOVE the operator's configured cap. Routing through the package makes the
+	// operator's value the baseline a live region restores to.
+	prev, changed := process.ApplyGOMAXPROCS(target)
+	return target, prev, changed
 }
 
 // installCapReloadHandler registers a SIGHUP handler that re-reads cpu.json and
@@ -1490,8 +1494,8 @@ func daemonSchedulerGroupAlgo(ctx context.Context, group string) error {
 }
 
 // groupAlgoProgressInterval is how often a running group-algo pass reports
-// progress. GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL overrides it; "0" disables the
-// heartbeat entirely.
+// progress. GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL overrides it; any non-positive
+// duration ("0", "0s", "-1s") disables the heartbeat entirely.
 //
 // 60s is chosen against the failure it exists for: a pass with a ~40 minute
 // expectation that ran for ~4 hours and emitted NOTHING after "starting", so an
@@ -1499,18 +1503,38 @@ func daemonSchedulerGroupAlgo(ctx context.Context, group string) error {
 // from a wedge. At 60s a healthy pass adds a handful of lines and a pathological
 // one leaves a per-phase timeline. Anything much finer would spam the ring
 // buffer that holds the daemon's recent log.
-const groupAlgoProgressInterval = time.Minute
+//
+// groupAlgoProgressMin is a hard floor on the override. Without it
+// GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL=1ns is accepted and the heartbeat spins a
+// core logging — a diagnostic knob that becomes its own CPU incident. 10ms is
+// low enough for a test to drive and high enough to cost nothing.
+const (
+	groupAlgoProgressInterval = time.Minute
+	groupAlgoProgressMin      = 10 * time.Millisecond
+)
 
 func groupAlgoProgressEvery() time.Duration {
-	if raw := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL")); raw != "" {
-		if d, err := time.ParseDuration(raw); err == nil && d > 0 {
-			return d
-		}
+	raw := strings.TrimSpace(os.Getenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL"))
+	if raw == "" {
+		return groupAlgoProgressInterval
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		// A bare "0" is not a valid Go duration but is the conventional and
+		// documented way to disable a knob, so honour it rather than silently
+		// falling back to the default the operator was trying to turn off.
 		if raw == "0" {
 			return 0
 		}
+		return groupAlgoProgressInterval
 	}
-	return groupAlgoProgressInterval
+	if d <= 0 {
+		return 0
+	}
+	if d < groupAlgoProgressMin {
+		return groupAlgoProgressMin
+	}
+	return d
 }
 
 // startGroupAlgoProgress emits a periodic progress line for an in-flight

--- a/cmd/grafel/group_algo_cpu_budget_6108_test.go
+++ b/cmd/grafel/group_algo_cpu_budget_6108_test.go
@@ -1,0 +1,218 @@
+package main
+
+// group_algo_cpu_budget_6108_test.go — the in-process group-algo fallback must
+// run under a real, in-force CPU bound (#6108).
+//
+// WHAT WENT WRONG. `runGroupAlgo` logs `cap=<n>` where n is
+// groupAlgoChildGOMAXPROCS — the GOMAXPROCS the group-algo CHILD would be
+// spawned with. When the pass runs IN-PROCESS instead (the
+// GRAFEL_SUBPROCESS_INDEXER=0 fallback) there is no child, nothing consumes
+// that number, and the pass runs at the daemon's own GOMAXPROCS = every core on
+// the box. Measured live: `cap=2` logged, 571.9% CPU sustained for hours inside
+// the daemon serving MCP.
+//
+// WHY THESE ARE BEHAVIOURAL AND NOT SOURCE SCANS. Three source-scanning guards
+// in this repo have already fallen to trivial mutants, and #6091 exists
+// precisely because the subprocess budget had no test that observed it. These
+// tests drive the REAL daemonSchedulerGroupAlgo and observe the effective
+// runtime.GOMAXPROCS in force at the moment the pass body runs. Deleting the
+// cap, resolving it from the foreground branch for background work, or applying
+// it around nothing all fail here.
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// observeInProcessGroupAlgoCap runs the real daemonSchedulerGroupAlgo on the
+// in-process branch and reports (the cap it asked for, the GOMAXPROCS actually
+// in force inside the capped region). A zero observed cap means the fallback
+// applied no bound at all.
+//
+// The group does not exist, so the pass body errors out promptly — that error
+// is expected and ignored. What is asserted is the runtime state the body would
+// have run under, which is established before the body is entered.
+func observeInProcessGroupAlgoCap(t *testing.T, group string) (askedFor, inForce int) {
+	t.Helper()
+	// Isolate all grafel state: the pass resolves the group from the registry.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	// No operator override — assert the POLICY default.
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+
+	// Force the in-process fallback: this is the path under test.
+	prevSub := sched.SetSubprocessIndexEnabled(false)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prevSub) })
+
+	prevApply := groupAlgoCapApply
+	t.Cleanup(func() { groupAlgoCapApply = prevApply })
+	groupAlgoCapApply = func(n int, fn func() error) error {
+		askedFor = n
+		// Apply the cap for real, then observe what the pass body sees.
+		return process.WithGOMAXPROCSCap(n, func() error {
+			inForce = runtime.GOMAXPROCS(0)
+			return fn()
+		})
+	}
+
+	_ = daemonSchedulerGroupAlgo(context.Background(), group)
+	return askedFor, inForce
+}
+
+// TestInProcessGroupAlgo_BackgroundRunsUnderTheBackgroundCPUCap is the direct
+// regression for the observed defect.
+func TestInProcessGroupAlgo_BackgroundRunsUnderTheBackgroundCPUCap(t *testing.T) {
+	want := sched.GroupAlgoGOMAXPROCS() // BACKGROUND resolution
+	askedFor, inForce := observeInProcessGroupAlgoCap(t, "no-such-group-6108")
+
+	if askedFor == 0 {
+		t.Fatalf("the in-process group-algo fallback applied NO CPU cap — the scheduler logs cap=%d and then runs the pass at the daemon's full GOMAXPROCS=%d (#6108)",
+			want, runtime.GOMAXPROCS(0))
+	}
+	if askedFor != want {
+		t.Errorf("in-process group-algo cap = %d, want the background cap %d — the number the scheduler logs and the number it enforces must be the same number (#6108)", askedFor, want)
+	}
+	if runtime.NumCPU() <= want {
+		t.Skipf("host NumCPU=%d is at or below the background cap %d — there is no clamp to observe on this machine", runtime.NumCPU(), want)
+	}
+	if inForce != want {
+		t.Errorf("GOMAXPROCS in force during the in-process group-algo pass = %d, want %d — a serial pass on %d Ps lets the GC fill every idle P with mark workers, which is where the measured 571.9%% came from (#6108)",
+			inForce, want, inForce)
+	}
+}
+
+// TestInProcessGroupAlgo_ForegroundIsNotThrottled pins the other half of the
+// policy: work a human is waiting on is deliberately UNCAPPED. A fix that
+// clamps every pass to the background budget would break the foreground
+// rebuild's follow-on pass, which #5954 explicitly runs at host speed.
+func TestInProcessGroupAlgo_ForegroundIsNotThrottled(t *testing.T) {
+	const group = "fg-group-6108"
+	release := sched.MarkGroupForeground(group)
+	t.Cleanup(release)
+
+	hostProcs := runtime.GOMAXPROCS(0)
+	askedFor, inForce := observeInProcessGroupAlgoCap(t, group)
+
+	if want := sched.ForegroundReindexGOMAXPROCS(); askedFor != want {
+		t.Errorf("foreground in-process group-algo cap = %d, want %d (the foreground resolution)", askedFor, want)
+	}
+	if inForce != hostProcs {
+		t.Errorf("GOMAXPROCS during a FOREGROUND in-process group-algo pass = %d, want the unchanged %d — user-awaited work must not be throttled to the background budget (#5954)", inForce, hostProcs)
+	}
+}
+
+// TestGroupAlgoProgress_EmitsPhaseAndCPU: the pass must report progress while
+// it runs. ~4 hours of total silence after "starting" is what made #6108
+// undiagnosable from outside — there was no way to distinguish slow progress
+// from a wedge, and no CPU number next to the cap the line claimed.
+func TestGroupAlgoProgress_EmitsPhaseAndCPU(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "20ms")
+
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&syncWriter{mu: &mu, w: buf}, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	groupalgo.ResetPhaseHistory()
+	groupalgo.SetPhase(groupalgo.PhaseRunningAlgorithms)
+	t.Cleanup(groupalgo.ResetPhaseHistory)
+
+	stop := startGroupAlgoProgress(context.Background(), "gProg", "in-process")
+	deadline := time.Now().Add(5 * time.Second)
+	var out string
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		out = buf.String()
+		mu.Unlock()
+		if strings.Contains(out, "group-algo: progress") {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	stop()
+
+	if !strings.Contains(out, "group-algo: progress") {
+		t.Fatalf("a running group-algo pass emitted no progress line — slow and wedged remain indistinguishable (#6108):\n%s", out)
+	}
+	for _, field := range []string{"group=gProg", "mode=in-process", "elapsed=", "phase=" + groupalgo.PhaseRunningAlgorithms} {
+		if !strings.Contains(out, field) {
+			t.Errorf("progress line is missing %q:\n%s", field, out)
+		}
+	}
+	if !strings.Contains(out, "cpu_pct=") {
+		t.Errorf("progress line carries no cpu_pct — `cap=2` beside the real draw is the single field that would have made #6108 self-evident:\n%s", out)
+	}
+}
+
+// TestGroupAlgoProgress_StopsWithThePass: the heartbeat must not outlive the
+// pass, or a daemon accumulates one ticker goroutine per group-algo run.
+func TestGroupAlgoProgress_StopsWithThePass(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "10ms")
+
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&syncWriter{mu: &mu, w: buf}, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	stop := startGroupAlgoProgress(context.Background(), "gStop", "child")
+	time.Sleep(60 * time.Millisecond)
+	stop()
+	time.Sleep(30 * time.Millisecond)
+	mu.Lock()
+	settled := strings.Count(buf.String(), "group-algo: progress")
+	mu.Unlock()
+	time.Sleep(80 * time.Millisecond)
+	mu.Lock()
+	after := strings.Count(buf.String(), "group-algo: progress")
+	mu.Unlock()
+	if after != settled {
+		t.Errorf("progress heartbeat kept ticking after the pass ended (%d -> %d lines) — one leaked goroutine per pass", settled, after)
+	}
+	// Calling stop twice must not panic on a double close.
+	stop()
+}
+
+// TestGroupAlgoProgress_Disabled: "0" turns the heartbeat off entirely.
+func TestGroupAlgoProgress_Disabled(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "0")
+
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	prev := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&syncWriter{mu: &mu, w: buf}, nil)))
+	t.Cleanup(func() { slog.SetDefault(prev) })
+
+	stop := startGroupAlgoProgress(context.Background(), "gOff", "in-process")
+	time.Sleep(50 * time.Millisecond)
+	stop()
+	mu.Lock()
+	defer mu.Unlock()
+	if strings.Contains(buf.String(), "group-algo: progress") {
+		t.Errorf("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL=0 must disable the heartbeat:\n%s", buf.String())
+	}
+}
+
+type syncWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (s *syncWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.w.Write(p)
+}

--- a/cmd/grafel/group_algo_cpu_budget_6108_test.go
+++ b/cmd/grafel/group_algo_cpu_budget_6108_test.go
@@ -23,6 +23,7 @@ import (
 	"bytes"
 	"context"
 	"log/slog"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
@@ -43,14 +44,23 @@ import (
 // The group does not exist, so the pass body errors out promptly — that error
 // is expected and ignored. What is asserted is the runtime state the body would
 // have run under, which is established before the body is entered.
-func observeInProcessGroupAlgoCap(t *testing.T, group string) (askedFor, inForce int) {
+func observeInProcessGroupAlgoCap(t *testing.T, group string, baseline int) (askedFor, inForce int) {
 	t.Helper()
+	// PIN the baseline. GOMAXPROCS is settable independent of the host, so the
+	// clamp is observable on a 1-core CI runner exactly as on a 12-core laptop.
+	// The first draft skipped the clamp assertion when NumCPU <= cap, which
+	// silently disarmed it on precisely the machines most likely to run CI.
+	prevProcs := runtime.GOMAXPROCS(baseline)
+	t.Cleanup(func() { runtime.GOMAXPROCS(prevProcs) })
+
 	// Isolate all grafel state: the pass resolves the group from the registry.
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	t.Setenv("HOME", t.TempDir())
 	// No operator override — assert the POLICY default.
 	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
 	t.Setenv("GRAFEL_REBUILD_GOMAXPROCS", "")
+	// The heartbeat is not under test here; keep it off so it cannot interleave.
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "0")
 
 	// Force the in-process fallback: this is the path under test.
 	prevSub := sched.SetSubprocessIndexEnabled(false)
@@ -71,21 +81,32 @@ func observeInProcessGroupAlgoCap(t *testing.T, group string) (askedFor, inForce
 	return askedFor, inForce
 }
 
+// TestGroupAlgoCapSeam_DefaultsToTheRealCap is the M7 guard.
+//
+// The cap is reached through a package var so a test can observe it. That seam
+// is also the obvious way to make the whole fix vacuous: replace the default
+// with a passthrough and every assertion below still passes while production
+// applies no cap at all. #6091 is exactly that failure, one layer down. So pin
+// the DEFAULT — the wiring is the thing #6108 is about.
+func TestGroupAlgoCapSeam_DefaultsToTheRealCap(t *testing.T) {
+	got := reflect.ValueOf(groupAlgoCapApply).Pointer()
+	want := reflect.ValueOf(process.WithGOMAXPROCSCap).Pointer()
+	if got != want {
+		t.Fatalf("groupAlgoCapApply does not default to process.WithGOMAXPROCSCap — production applies no CPU bound and every seam-based test still passes (#6108 / the #6091 shape)")
+	}
+}
+
 // TestInProcessGroupAlgo_BackgroundRunsUnderTheBackgroundCPUCap is the direct
 // regression for the observed defect.
 func TestInProcessGroupAlgo_BackgroundRunsUnderTheBackgroundCPUCap(t *testing.T) {
 	want := sched.GroupAlgoGOMAXPROCS() // BACKGROUND resolution
-	askedFor, inForce := observeInProcessGroupAlgoCap(t, "no-such-group-6108")
+	askedFor, inForce := observeInProcessGroupAlgoCap(t, "no-such-group-6108", want+4)
 
 	if askedFor == 0 {
-		t.Fatalf("the in-process group-algo fallback applied NO CPU cap — the scheduler logs cap=%d and then runs the pass at the daemon's full GOMAXPROCS=%d (#6108)",
-			want, runtime.GOMAXPROCS(0))
+		t.Fatalf("the in-process group-algo fallback applied NO CPU cap — the scheduler logs cap=%d and then runs the pass at the daemon's full GOMAXPROCS (#6108)", want)
 	}
 	if askedFor != want {
 		t.Errorf("in-process group-algo cap = %d, want the background cap %d — the number the scheduler logs and the number it enforces must be the same number (#6108)", askedFor, want)
-	}
-	if runtime.NumCPU() <= want {
-		t.Skipf("host NumCPU=%d is at or below the background cap %d — there is no clamp to observe on this machine", runtime.NumCPU(), want)
 	}
 	if inForce != want {
 		t.Errorf("GOMAXPROCS in force during the in-process group-algo pass = %d, want %d — a serial pass on %d Ps lets the GC fill every idle P with mark workers, which is where the measured 571.9%% came from (#6108)",
@@ -94,22 +115,68 @@ func TestInProcessGroupAlgo_BackgroundRunsUnderTheBackgroundCPUCap(t *testing.T)
 }
 
 // TestInProcessGroupAlgo_ForegroundIsNotThrottled pins the other half of the
-// policy: work a human is waiting on is deliberately UNCAPPED. A fix that
-// clamps every pass to the background budget would break the foreground
-// rebuild's follow-on pass, which #5954 explicitly runs at host speed.
+// policy: work a human is waiting on is deliberately UNCAPPED.
+//
+// GIVING THIS TEETH. The foreground resolution is the host core count, which
+// equals the ambient GOMAXPROCS, so "inForce == baseline" would hold whether or
+// not the never-raise rule worked. So the baseline is pinned BELOW the
+// foreground cap: a clamp would show as a drop, and a naive max() that took the
+// resolved cap literally would show as a RISE. Only leaving the runtime alone
+// passes.
 func TestInProcessGroupAlgo_ForegroundIsNotThrottled(t *testing.T) {
 	const group = "fg-group-6108"
 	release := sched.MarkGroupForeground(group)
 	t.Cleanup(release)
 
-	hostProcs := runtime.GOMAXPROCS(0)
-	askedFor, inForce := observeInProcessGroupAlgoCap(t, group)
+	const baseline = 2
+	askedFor, inForce := observeInProcessGroupAlgoCap(t, group, baseline)
 
 	if want := sched.ForegroundReindexGOMAXPROCS(); askedFor != want {
 		t.Errorf("foreground in-process group-algo cap = %d, want %d (the foreground resolution)", askedFor, want)
 	}
-	if inForce != hostProcs {
-		t.Errorf("GOMAXPROCS during a FOREGROUND in-process group-algo pass = %d, want the unchanged %d — user-awaited work must not be throttled to the background budget (#5954)", inForce, hostProcs)
+	if inForce != baseline {
+		t.Errorf("GOMAXPROCS during a FOREGROUND in-process group-algo pass = %d, want the untouched %d — user-awaited work must be left exactly as it was, neither throttled to the background budget nor widened to the resolved cap (#5954)", inForce, baseline)
+	}
+}
+
+// TestInProcessGroupAlgo_ForegroundDoesNotQueueBehindABackgroundRegion is the
+// H1 regression at the call site.
+//
+// A foreground pass resolves a cap that lowers nothing, so it must not merely
+// leave the VALUE alone — it must not WAIT. With the cap primitive serialising
+// every region, a user-awaited rebuild's follow-on pass would block for the
+// whole lifetime of an in-flight background sweep: minutes to hours,
+// uncancellable, and invisible to any assertion about the cap integer.
+func TestInProcessGroupAlgo_ForegroundDoesNotQueueBehindABackgroundRegion(t *testing.T) {
+	const group = "fg-nonblocking-6108"
+	release := sched.MarkGroupForeground(group)
+	t.Cleanup(release)
+
+	prevProcs := runtime.GOMAXPROCS(8)
+	t.Cleanup(func() { runtime.GOMAXPROCS(prevProcs) })
+
+	// A background region, held open for the duration.
+	entered, hold, bgDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(bgDone)
+		_ = process.WithGOMAXPROCSCap(1, func() error { close(entered); <-hold; return nil })
+	}()
+	<-entered
+	defer func() { close(hold); <-bgDone }()
+
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRAFEL_GROUP_ALGO_CPU", "")
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "0")
+	prevSub := sched.SetSubprocessIndexEnabled(false)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prevSub) })
+
+	done := make(chan struct{})
+	go func() { defer close(done); _ = daemonSchedulerGroupAlgo(context.Background(), group) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("a FOREGROUND in-process group-algo pass blocked behind a live background capped region — the user's rebuild serialises behind background churn (#6108 H1)")
 	}
 }
 
@@ -215,4 +282,31 @@ func (s *syncWriter) Write(p []byte) (int, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.w.Write(p)
+}
+
+// TestGroupAlgoProgressEvery_OverrideParsing covers the two knob defects review
+// caught: "0s" (a valid zero duration) silently fell back to the 60s default
+// while bare "0" disabled, and "1ns" was accepted and spun a core logging.
+func TestGroupAlgoProgressEvery_OverrideParsing(t *testing.T) {
+	for _, tc := range []struct {
+		raw  string
+		want time.Duration
+	}{
+		{"", groupAlgoProgressInterval},
+		{"0", 0},
+		{"0s", 0},
+		{"0ms", 0},
+		{"-5s", 0},
+		{"1ns", groupAlgoProgressMin},
+		{"1ms", groupAlgoProgressMin},
+		{"30s", 30 * time.Second},
+		{"not-a-duration", groupAlgoProgressInterval},
+	} {
+		t.Run(tc.raw, func(t *testing.T) {
+			t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", tc.raw)
+			if got := groupAlgoProgressEvery(); got != tc.want {
+				t.Errorf("groupAlgoProgressEvery(%q) = %v, want %v", tc.raw, got, tc.want)
+			}
+		})
+	}
 }

--- a/internal/daemon/sched/group_algo_log_honesty_6108_test.go
+++ b/internal/daemon/sched/group_algo_log_honesty_6108_test.go
@@ -1,0 +1,147 @@
+package sched
+
+// group_algo_log_honesty_6108_test.go — the group-algo scheduler log must not
+// assert a bound it cannot account for, and must not go silent (#6108).
+//
+// Observed: `group-algo: starting group=… cap=2` followed by ~4 hours of
+// nothing, while the process sustained 571.9% CPU. Two separate log defects:
+// the line named a cap whose enforcement depended on a branch the line did not
+// mention, and there was no way to tell a queued pass from a running one from a
+// wedged one.
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func captureLogger() (*slog.Logger, func() string) {
+	var mu sync.Mutex
+	buf := &bytes.Buffer{}
+	h := slog.NewTextHandler(&lockedWriter{mu: &mu, w: buf}, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return slog.New(h), func() string {
+		mu.Lock()
+		defer mu.Unlock()
+		return buf.String()
+	}
+}
+
+type lockedWriter struct {
+	mu *sync.Mutex
+	w  *bytes.Buffer
+}
+
+func (l *lockedWriter) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.w.Write(p)
+}
+
+// TestGroupAlgoStartLog_NamesTheEnforcementMode: `cap=` is only meaningful
+// alongside WHICH path is enforcing it. Before #6108 the in-process path
+// enforced nothing at all, and the line was indistinguishable from the child's.
+func TestGroupAlgoStartLog_NamesTheEnforcementMode(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		subprocess bool
+		wantMode   string
+	}{
+		{"child", true, "mode=child"},
+		{"in-process", false, "mode=in-process"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prev := SetSubprocessIndexEnabled(tc.subprocess)
+			t.Cleanup(func() { SetSubprocessIndexEnabled(prev) })
+
+			logger, dump := captureLogger()
+			s := New(Config{
+				Workers:            1,
+				LinkDebounce:       time.Hour,
+				GroupAlgoDebounce:  time.Hour,
+				GroupAlgoMaxWait:   time.Hour,
+				Logger:             logger,
+				Links:              func(_ context.Context, _ string) error { return nil },
+				GroupAlgo:          func(_ context.Context, _ string) error { return nil },
+				GroupsForRepo:      func(_ string) []string { return nil },
+				MemReleaseDisabled: true,
+			})
+			s.Start()
+			defer s.Stop()
+
+			s.runGroupAlgo(context.Background(), "gLog")
+
+			out := dump()
+			if !strings.Contains(out, "group-algo: starting") {
+				t.Fatalf("no start line emitted at all:\n%s", out)
+			}
+			if !strings.Contains(out, tc.wantMode) {
+				t.Errorf("start line does not carry %q — `cap=` names a bound whose enforcement depends on this branch, so the branch must be on the line (#6108):\n%s", tc.wantMode, out)
+			}
+			if !strings.Contains(out, "cap=") {
+				t.Errorf("start line lost its cap= field:\n%s", out)
+			}
+		})
+	}
+}
+
+// TestGroupAlgoQueuedPass_SaysItIsQueued: a pass that cannot get an algo slot
+// must say so. Otherwise "starting" + silence covers both "running slowly" and
+// "not running at all", which is exactly the ambiguity #6108 was diagnosed
+// through.
+func TestGroupAlgoQueuedPass_SaysItIsQueued(t *testing.T) {
+	logger, dump := captureLogger()
+	release := make(chan struct{})
+	started := make(chan struct{}, 2)
+	s := New(Config{
+		Workers:           1,
+		AlgoCap:           1,
+		LinkDebounce:      time.Hour,
+		GroupAlgoDebounce: time.Hour,
+		GroupAlgoMaxWait:  time.Hour,
+		Logger:            logger,
+		Links:             func(_ context.Context, _ string) error { return nil },
+		GroupAlgo: func(ctx context.Context, _ string) error {
+			started <- struct{}{}
+			select {
+			case <-release:
+			case <-ctx.Done():
+			}
+			return nil
+		},
+		GroupsForRepo:      func(_ string) []string { return nil },
+		MemReleaseDisabled: true,
+	})
+	s.Start()
+	defer s.Stop()
+
+	go s.runGroupAlgo(context.Background(), "gHold")
+	select {
+	case <-started:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first pass never entered GroupAlgo")
+	}
+
+	done := make(chan struct{})
+	go func() { defer close(done); s.runGroupAlgo(context.Background(), "gQueued") }()
+
+	deadline := time.After(5 * time.Second)
+	for {
+		if strings.Contains(dump(), "group-algo: waiting for an algo slot") {
+			break
+		}
+		select {
+		case <-deadline:
+			close(release)
+			<-done
+			t.Fatalf("a group-algo pass blocked on the algo semaphore logged nothing — an operator cannot tell it apart from a pass that is running (#6108):\n%s", dump())
+		default:
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	close(release)
+	<-done
+}

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -2690,17 +2690,40 @@ func (s *Scheduler) runGroupAlgo(ctx context.Context, group string) {
 	// the mark this pass was actually spawned under — a rebuild that re-marks
 	// the group while this (long) pass runs must not have its mark wiped by
 	// this pass finishing.
+	//
+	// #6108 — `cap` MUST NAME SOMETHING THAT IS ACTUALLY ENFORCED. This value is
+	// the pass's GOMAXPROCS, and until #6108 it was enforced only when the pass
+	// ran as a CHILD: the in-process fallback had nothing to hand it to and ran
+	// at the daemon's own GOMAXPROCS, which is how `cap=2` was logged beside a
+	// sustained 571.9%. Both paths now apply it (the in-process one via
+	// process.WithGOMAXPROCSCap in daemonSchedulerGroupAlgo), and `mode` says
+	// which enforcement is in play so the line can be read without guessing.
 	fgEpoch, _ := GroupForegroundState(group)
 	capN := groupAlgoChildGOMAXPROCS(group)
-	s.logger.Info("group-algo: starting", "group", group, "cap", capN)
+	mode := "in-process"
+	if SubprocessIndexEnabled() {
+		mode = "child"
+	}
+	s.logger.Info("group-algo: starting", "group", group, "cap", capN, "mode", mode)
+	// Try the semaphore without blocking first, purely so a pass that is QUEUED
+	// rather than running says so. "starting" followed by hours of silence has
+	// two very different causes — waiting for a slot, and running slowly — and
+	// the log could not distinguish them (#6108).
 	select {
 	case s.algoSem <- struct{}{}:
-		// acquired
-	case <-ctx.Done():
-		s.logEvent("group_algo_cancelled", "", group+": waiting for algo-sem slot")
-		return
-	case <-s.stop:
-		return
+		// acquired immediately
+	default:
+		s.logger.Info("group-algo: waiting for an algo slot", "group", group, "slots", cap(s.algoSem))
+		s.logEvent("group_algo_queued", "", group)
+		select {
+		case s.algoSem <- struct{}{}:
+			// acquired
+		case <-ctx.Done():
+			s.logEvent("group_algo_cancelled", "", group+": waiting for algo-sem slot")
+			return
+		case <-s.stop:
+			return
+		}
 	}
 	defer func() { <-s.algoSem }()
 

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -234,16 +234,37 @@ func resolveChildGOMAXPROCS(interactive bool, foregroundCap int) (n int, reason 
 // a background pass that never finishes is its own kind of failure. On a
 // 1-core host the floor yields to the machine (clamped to NumCPU).
 //
-// WHAT THIS NUMBER ACTUALLY BUYS TODAY: very little, in either direction. Both
-// passes are SERIAL — internal/links, internal/graph, internal/graph/groupalgo
-// and the gonum packages they call (graph/community, graph/network, graph/path,
-// mat) have no goroutine fan-out, and algorithms.go's network.PageRankSparse
-// never reaches the one parallel path in the dependency (blas dgemm/sgemm). A
-// live group-algo child shows one thread running and the rest asleep. So this
-// value mostly sizes the GC's mark workers, not the pass. It is kept honest and
-// proportional anyway, because it is the number that will bind the moment
-// either pass is parallelised, and because a wrong number here is invisible
-// until it is expensive. Do not cite it as a throughput control.
+// WHAT THIS NUMBER ACTUALLY BUYS — CORRECTED (#6108). Both passes really are
+// SERIAL: internal/links, internal/graph (including louvain.go),
+// internal/graph/groupalgo and every gonum package in the dependency closure
+// have no goroutine fan-out, and gonum's network.Betweenness even carries a
+// literal "TODO: Consider using the parallel algorithm when GOMAXPROCS != 1". A
+// live group-algo child shows one thread running and the rest asleep.
+//
+// This comment used to draw the inference that the cap therefore "buys very
+// little" and should not be cited as a throughput control. THAT INFERENCE IS
+// WRONG, and it is what let an unbounded in-process pass sustain 571.9% CPU
+// inside the daemon while the scheduler logged cap=2 (#6108).
+//
+// "This value mostly sizes the GC's mark workers, not the pass" is the true
+// half — and on this workload the GC's mark workers ARE the CPU. GC mark
+// parallelism is sized by GOMAXPROCS, and idle mark workers are scheduled on
+// every otherwise-idle P, so a single-threaded mutator on a 12-P runtime hands
+// the collector 11 Ps to fill. Measured on a serial mutator over a
+// pointer-dense retained heap (getrusage, total CPU seconds):
+//
+//	GOMAXPROCS=12   cpu=0.55s   311.1%
+//	GOMAXPROCS= 3   cpu=0.38s   188.0%
+//	GOMAXPROCS= 1   cpu=0.38s    99.2%
+//
+// The CPU SECONDS fall — the excess is idle-mark-worker overhead the cap
+// deletes, not work redistributed. Serial does not imply cheap when the live
+// set is a dense pointer graph, which is exactly what these passes retain.
+//
+// So this number binds TODAY, on real machines, and is load-bearing for the
+// in-process caps in internal/process/gomaxprocs.go as well as for the children.
+// It is a CPU control, not a throughput control: raising it does not make a
+// serial pass faster, but lowering it genuinely reduces what the host gives up.
 const (
 	backgroundBatchCoreDivisor = 8
 	backgroundBatchCoreFloor   = 2

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 	"github.com/cajasmota/grafel/internal/graph/flows"
 	"github.com/cajasmota/grafel/internal/graph/groupalgo"
+	"github.com/cajasmota/grafel/internal/process"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/types"
 )
@@ -1054,6 +1055,12 @@ type (
 	algoDoneFunc func(cacheKey string)
 )
 
+// backgroundAlgoCapApply applies the background CPU bound around the deferred
+// Pass-4 sweep (#6108). It is process.WithGOMAXPROCSCap; a var only so a test
+// can observe the cap the sweep asks for and the GOMAXPROCS actually in force
+// when RunAlgorithms runs, rather than asserting the fix by reading the source.
+var backgroundAlgoCapApply = process.WithGOMAXPROCSCap
+
 // backgroundAlgoGate, when set, blocks a scheduled background Pass-4
 // computation until it receives — so a test can deterministically assert the
 // load returned WITHOUT the full sweep having run.
@@ -1150,18 +1157,39 @@ func (c *GraphCache) schedulePendingAlgo(cacheKey string, grp *DashGroup) {
 		if gate := backgroundAlgoGate.Load(); gate != nil {
 			<-(chan struct{})(*gate)
 		}
-		for _, p := range pending {
-			// READ-ONLY over p.doc.Entities/Relationships (RunAlgorithms mutates
-			// neither, and touches only heap slices — not the mmap reader). Safe
-			// to run concurrently with handlers reading the same doc, and safe if
-			// the group was already evicted under us (concern #2).
-			res := graph.RunAlgorithms(p.doc.Entities, p.doc.Relationships)
-			persistAlgoResults(p.stateDir, p.fbMtime, res)
-			// Record that this graph.fb version has been computed BEFORE the evict
-			// below, so a reload triggered by the eviction filters this repo out
-			// (termination) even if the persist above failed.
-			c.markAlgoComputed(p.stateDir, p.fbMtime)
-		}
+		// #6108 — CPU BOUND. This is the daemon's OTHER in-process Pass-4 site,
+		// and it had no bound at all: no child process to give a GOMAXPROCS to,
+		// nothing to inherit the extract fanout's budget, running at whatever
+		// GOMAXPROCS `serve` itself has. The sweep is unambiguously BACKGROUND —
+		// the request that triggered it was already answered with the degree
+		// fallback (attachDegreeFallback) and nobody is waiting on this — so it
+		// takes the canonical background budget, process.IndexCoreBudget().
+		//
+		// GOMAXPROCS is the right lever even though the sweep is serial: it is
+		// the GC, sized by GOMAXPROCS and free to fill every idle P with mark
+		// workers, that turns a single-threaded Brandes over a large union into
+		// the multi-hundred-percent draw #6108 measured. See
+		// internal/process/gomaxprocs.go.
+		//
+		// COST: WithGOMAXPROCSCap serialises capped regions process-wide, so two
+		// groups warming at once now sweep one after the other instead of
+		// together. That is the intended trade — concurrent unbounded sweeps are
+		// how the daemon came to be the top process on the user's machine.
+		_ = backgroundAlgoCapApply(process.IndexCoreBudget(), func() error {
+			for _, p := range pending {
+				// READ-ONLY over p.doc.Entities/Relationships (RunAlgorithms mutates
+				// neither, and touches only heap slices — not the mmap reader). Safe
+				// to run concurrently with handlers reading the same doc, and safe if
+				// the group was already evicted under us (concern #2).
+				res := graph.RunAlgorithms(p.doc.Entities, p.doc.Relationships)
+				persistAlgoResults(p.stateDir, p.fbMtime, res)
+				// Record that this graph.fb version has been computed BEFORE the evict
+				// below, so a reload triggered by the eviction filters this repo out
+				// (termination) even if the persist above failed.
+				c.markAlgoComputed(p.stateDir, p.fbMtime)
+			}
+			return nil
+		})
 		// Evict THIS entry (only if it is still the group we computed for) so the
 		// next request reloads with the persisted Pass-4 applied synchronously.
 		c.mu.Lock()

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/graph"
 	"github.com/cajasmota/grafel/internal/graph/descriptions"
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
@@ -1171,11 +1172,24 @@ func (c *GraphCache) schedulePendingAlgo(cacheKey string, grp *DashGroup) {
 		// the multi-hundred-percent draw #6108 measured. See
 		// internal/process/gomaxprocs.go.
 		//
-		// COST: WithGOMAXPROCSCap serialises capped regions process-wide, so two
-		// groups warming at once now sweep one after the other instead of
-		// together. That is the intended trade — concurrent unbounded sweeps are
-		// how the daemon came to be the top process on the user's machine.
-		_ = backgroundAlgoCapApply(process.IndexCoreBudget(), func() error {
+		// WHICH NUMBER, AND WHY NOT IndexCoreBudget DIRECTLY. This uses the same
+		// sched.BackgroundBatchGOMAXPROCS the group-algo child is spawned with,
+		// so the daemon has ONE background-analytics core policy rather than two
+		// that disagree. IndexCoreBudget (NumCPU/4) floors at 1, and a floor of 1
+		// is wrong for this specific workload for reasons this repo already wrote
+		// down: below 2 the pass loses GC/runtime parallelism entirely, and
+		// measurement puts GOMAXPROCS=1 at ~2.2x the wall time of 12 for the same
+		// total CPU — so it would hold a single-P MCP daemon for twice as long to
+		// no benefit. IndexCoreBudget's own doc also says GOMAXPROCS is not a
+		// valid way to enforce THAT budget on its own (it is about cgo parse
+		// slots and child counts); this is a different mechanism for a different
+		// bottleneck. BackgroundBatchGOMAXPROCS floors at 2 and is the policy
+		// written for exactly this pass.
+		//
+		// Regions do not serialise (see internal/process/gomaxprocs.go): two
+		// groups warming at once both run, and the effective GOMAXPROCS is the
+		// minimum of their caps, which bounds the process as a whole.
+		_ = backgroundAlgoCapApply(sched.BackgroundBatchGOMAXPROCS(), func() error {
 			for _, p := range pending {
 				// READ-ONLY over p.doc.Entities/Relationships (RunAlgorithms mutates
 				// neither, and touches only heap slices — not the mmap reader). Safe

--- a/internal/dashboard/graphstate_algo_cpu_budget_6108_test.go
+++ b/internal/dashboard/graphstate_algo_cpu_budget_6108_test.go
@@ -1,7 +1,8 @@
 package dashboard
 
 // graphstate_algo_cpu_budget_6108_test.go — the dashboard's BACKGROUND Pass-4
-// sweep must run under the canonical background core budget (#6108).
+// sweep must run under the same background core policy as the group-algo child
+// (#6108).
 //
 // WHY THIS FILE EXISTS ALONGSIDE THE group-algo FIX. #6108 was reported against
 // the group-algo pass, but graph.RunAlgorithms has a SECOND in-daemon caller
@@ -11,31 +12,61 @@ package dashboard
 // bounding it. Symptomatically it is indistinguishable from the reported defect
 // — same function, same process, no child to find in `ps` — so fixing only the
 // scheduler path could have left the user's actual symptom in place.
-//
-// Behavioural, not a source scan: the assertion is the effective
-// runtime.GOMAXPROCS at the moment the sweep body runs.
 
 import (
+	"reflect"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/daemon/sched"
 	"github.com/cajasmota/grafel/internal/process"
 )
 
-func TestBackgroundPass4_RunsUnderTheIndexCoreBudget(t *testing.T) {
+// TestBackgroundPass4CapSeam_DefaultsToTheRealCap is the M7 guard.
+//
+// The cap is reached through a package var so a test can observe it. That seam
+// is also the obvious way to make the whole fix vacuous: replace the default
+// with a passthrough and every assertion below still passes while production
+// applies no cap at all. #6091 is exactly that failure, one layer down. So pin
+// the DEFAULT — the wiring is the thing #6108 is about.
+func TestBackgroundPass4CapSeam_DefaultsToTheRealCap(t *testing.T) {
+	got := reflect.ValueOf(backgroundAlgoCapApply).Pointer()
+	want := reflect.ValueOf(process.WithGOMAXPROCSCap).Pointer()
+	if got != want {
+		t.Fatalf("backgroundAlgoCapApply does not default to process.WithGOMAXPROCSCap — production applies no CPU bound and every seam-based test still passes (#6108 / the #6091 shape)")
+	}
+}
+
+// TestBackgroundPass4_RunsUnderTheBackgroundBatchCap observes the effective
+// runtime.GOMAXPROCS at the moment the sweep body runs.
+//
+// The baseline is raised above the cap through a MANAGED outer region rather
+// than a raw runtime.GOMAXPROCS write, so the clamp is observable on any host
+// without this test mutating process-global scheduling state that outlives it.
+// (The first draft skipped the assertion when NumCPU <= cap, which silently
+// disarmed it on small CI runners; the draft after that wrote the global
+// directly, and a full-suite run then perturbed an unrelated async test.)
+func TestBackgroundPass4_RunsUnderTheBackgroundBatchCap(t *testing.T) {
+	want := sched.BackgroundBatchGOMAXPROCS()
+
 	done := make(chan string, 1)
 	setBackgroundAlgoDoneForTest(func(k string) { done <- k })
 	t.Cleanup(func() { setBackgroundAlgoDoneForTest(nil) })
 
-	var askedFor, inForce int
+	var askedFor, baselineSeen, inForce int
 	prev := backgroundAlgoCapApply
 	t.Cleanup(func() { backgroundAlgoCapApply = prev })
 	backgroundAlgoCapApply = func(n int, fn func() error) error {
 		askedFor = n
-		return process.WithGOMAXPROCSCap(n, func() error {
-			inForce = runtime.GOMAXPROCS(0)
-			return fn()
+		// Outer region lifts the baseline above n where the host allows it, so
+		// the inner clamp is a real transition and not a coincidence.
+		return process.WithGOMAXPROCSCap(n+4, func() error {
+			baselineSeen = runtime.GOMAXPROCS(0)
+			return process.WithGOMAXPROCSCap(n, func() error {
+				inForce = runtime.GOMAXPROCS(0)
+				return fn()
+			})
 		})
 	}
 
@@ -48,17 +79,34 @@ func TestBackgroundPass4_RunsUnderTheIndexCoreBudget(t *testing.T) {
 		t.Fatal("background Pass-4 sweep never completed")
 	}
 
-	want := process.IndexCoreBudget()
 	if askedFor == 0 {
-		t.Fatalf("the dashboard's background Pass-4 sweep applied NO CPU cap — it runs graph.RunAlgorithms inside the daemon at the daemon's full GOMAXPROCS=%d, with no child process to find and no budget to inherit (#6108)", runtime.GOMAXPROCS(0))
+		t.Fatalf("the dashboard's background Pass-4 sweep applied NO CPU cap — it runs graph.RunAlgorithms inside the daemon at the daemon's full GOMAXPROCS, with no child process to find and no budget to inherit (#6108)")
 	}
 	if askedFor != want {
-		t.Errorf("background Pass-4 cap = %d, want the canonical process.IndexCoreBudget() = %d (#6108/#5960)", askedFor, want)
+		t.Errorf("background Pass-4 cap = %d, want sched.BackgroundBatchGOMAXPROCS() = %d — the daemon must have ONE background-analytics core policy, not two (#6108 H3)", askedFor, want)
 	}
-	if runtime.NumCPU() <= want {
-		t.Skipf("host NumCPU=%d is at or below the budget %d — no clamp to observe here", runtime.NumCPU(), want)
+	wantInForce := want
+	if baselineSeen < wantInForce {
+		wantInForce = baselineSeen // a host smaller than the cap; never raise
 	}
-	if inForce != want {
-		t.Errorf("GOMAXPROCS in force during the background Pass-4 sweep = %d, want %d", inForce, want)
+	if inForce != wantInForce {
+		t.Errorf("GOMAXPROCS in force during the background Pass-4 sweep = %d, want %d (baseline %d)", inForce, wantInForce, baselineSeen)
+	}
+	if baselineSeen <= want {
+		t.Logf("note: host baseline %d <= cap %d, so the clamp was a no-op here; askedFor still pins the policy", baselineSeen, want)
+	}
+}
+
+// TestBackgroundPass4Cap_NeverFloorsAtOne pins the H3 reconciliation itself.
+//
+// IndexCoreBudget is NumCPU/4 floored at 1, which on a 4-core host clamps the
+// whole MCP-serving daemon to a single P for the length of the sweep. This
+// repo's own subprocess_runner.go says why that is wrong ("below 2 the pass
+// loses GC/runtime parallelism entirely"), and GOMAXPROCS=1 measures ~2.2x the
+// wall time of 12 for identical total CPU — twice as long holding a single-P
+// daemon, for nothing.
+func TestBackgroundPass4Cap_NeverFloorsAtOne(t *testing.T) {
+	if got := sched.BackgroundBatchGOMAXPROCS(); got < 2 && runtime.NumCPU() >= 2 {
+		t.Errorf("the background analytics cap resolved to %d on a %d-core host — a background sweep must not pin the MCP daemon to a single P (#6108 H3)", got, runtime.NumCPU())
 	}
 }

--- a/internal/dashboard/graphstate_algo_cpu_budget_6108_test.go
+++ b/internal/dashboard/graphstate_algo_cpu_budget_6108_test.go
@@ -1,0 +1,64 @@
+package dashboard
+
+// graphstate_algo_cpu_budget_6108_test.go — the dashboard's BACKGROUND Pass-4
+// sweep must run under the canonical background core budget (#6108).
+//
+// WHY THIS FILE EXISTS ALONGSIDE THE group-algo FIX. #6108 was reported against
+// the group-algo pass, but graph.RunAlgorithms has a SECOND in-daemon caller
+// with exactly the same shape and exactly the same defect: schedulePendingAlgo
+// runs the full O(V·E) Louvain + PageRank + betweenness sweep on a goroutine
+// inside `serve`, with no child process, no GOMAXPROCS of its own, and nothing
+// bounding it. Symptomatically it is indistinguishable from the reported defect
+// — same function, same process, no child to find in `ps` — so fixing only the
+// scheduler path could have left the user's actual symptom in place.
+//
+// Behavioural, not a source scan: the assertion is the effective
+// runtime.GOMAXPROCS at the moment the sweep body runs.
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+func TestBackgroundPass4_RunsUnderTheIndexCoreBudget(t *testing.T) {
+	done := make(chan string, 1)
+	setBackgroundAlgoDoneForTest(func(k string) { done <- k })
+	t.Cleanup(func() { setBackgroundAlgoDoneForTest(nil) })
+
+	var askedFor, inForce int
+	prev := backgroundAlgoCapApply
+	t.Cleanup(func() { backgroundAlgoCapApply = prev })
+	backgroundAlgoCapApply = func(n int, fn func() error) error {
+		askedFor = n
+		return process.WithGOMAXPROCSCap(n, func() error {
+			inForce = runtime.GOMAXPROCS(0)
+			return fn()
+		})
+	}
+
+	c, grp := pendingGrp(t, pathGraphDoc(), t.TempDir(), time.Now())
+	c.schedulePendingAlgo("g", grp)
+
+	select {
+	case <-done:
+	case <-time.After(30 * time.Second):
+		t.Fatal("background Pass-4 sweep never completed")
+	}
+
+	want := process.IndexCoreBudget()
+	if askedFor == 0 {
+		t.Fatalf("the dashboard's background Pass-4 sweep applied NO CPU cap — it runs graph.RunAlgorithms inside the daemon at the daemon's full GOMAXPROCS=%d, with no child process to find and no budget to inherit (#6108)", runtime.GOMAXPROCS(0))
+	}
+	if askedFor != want {
+		t.Errorf("background Pass-4 cap = %d, want the canonical process.IndexCoreBudget() = %d (#6108/#5960)", askedFor, want)
+	}
+	if runtime.NumCPU() <= want {
+		t.Skipf("host NumCPU=%d is at or below the budget %d — no clamp to observe here", runtime.NumCPU(), want)
+	}
+	if inForce != want {
+		t.Errorf("GOMAXPROCS in force during the background Pass-4 sweep = %d, want %d", inForce, want)
+	}
+}

--- a/internal/process/gomaxprocs.go
+++ b/internal/process/gomaxprocs.go
@@ -10,21 +10,36 @@ import (
 //
 // WHY THIS EXISTS AT ALL, GIVEN THE PASS IS SERIAL. The heavy background
 // analytics passes (group-algo's Louvain + PageRank + Brandes betweenness, and
-// the cross-repo link pass) contain no goroutine fan-out, and neither do the
-// gonum packages they call — gonum's network.Betweenness carries a literal
-// "TODO: Consider using the parallel algorithm when GOMAXPROCS != 1". One
-// mutator thread does the work. That fact was used to argue the cap was
-// decorative. It is not, and the argument had the mechanism backwards:
+// the cross-repo link pass) contain no goroutine fan-out, and neither does any
+// package they reach: internal/graph (including the in-repo louvain.go),
+// internal/graph/groupalgo, internal/links, and every gonum package in the
+// dependency closure were audited for it. gonum's network.Betweenness even
+// carries a literal "TODO: Consider using the parallel algorithm when
+// GOMAXPROCS != 1". One mutator thread does the work. That fact was used to
+// argue the cap was decorative. It is not, and the argument had the mechanism
+// backwards:
 //
 // The CPU those passes draw is overwhelmingly the GARBAGE COLLECTOR, and the
 // GC's parallelism is sized by GOMAXPROCS, not by the application's. A cycle
 // runs 25% of GOMAXPROCS as dedicated mark workers, and — decisively for a
 // single-threaded mutator — schedules IDLE mark workers on every otherwise-idle
 // P. A serial pass on a 12-P runtime leaves 11 idle Ps, all of which the GC is
-// free to fill. Brandes allocates per-source maps over a multi-hundred-thousand
-// node union, so cycles are near-continuous. That is how a "fully serial" pass
-// was measured sustaining 571.9% CPU inside the daemon (#6108) while the
-// scheduler logged cap=2.
+// free to fill.
+//
+// MEASURED, on a serial single-goroutine mutator over a pointer-dense retained
+// heap (getrusage, so this is total CPU time, not a sampled percentage):
+//
+//	GOMAXPROCS=12   cpu=0.55s   311.1%
+//	GOMAXPROCS= 3   cpu=0.38s   188.0%
+//	GOMAXPROCS= 1   cpu=0.38s    99.2%
+//
+// Note the CPU SECONDS fall 0.55 -> 0.38: the excess is not the same work spread
+// wider, it is pure idle-mark-worker overhead that the cap deletes outright. The
+// effect depends on mark work over a dense live pointer set — a sparse heap only
+// reached 119% — which is exactly what an assembled graph union is. Brandes
+// allocates per-source maps over a multi-hundred-thousand node union, so cycles
+// are near-continuous. That is how a "fully serial" pass was measured sustaining
+// 571.9% CPU inside the daemon (#6108) while the scheduler logged cap=2.
 //
 // So GOMAXPROCS IS the enforcement lever on this path — it is the only knob the
 // Go runtime offers that bounds total process CPU — and it is precisely the one
@@ -32,56 +47,170 @@ import (
 // pass has no environment of its own, which is why it needs this.
 //
 // THE COST, STATED PLAINLY. runtime.GOMAXPROCS is process-global. For the
-// duration of the region every OTHER goroutine in the process — MCP request
+// duration of a region every OTHER goroutine in the process — MCP request
 // serving included — runs on the same reduced set of Ps. That is a deliberate
 // trade and it is the right way round: a daemon serving MCP from 2 Ps is
 // responsive; a daemon whose host is at load 76 because the daemon itself took
 // six cores is not. It is also strictly bounded in time by the pass, and it
-// applies only to BACKGROUND work — foreground callers resolve a cap at or
-// above the host core count, and WithGOMAXPROCSCap never raises, so they are
-// left exactly as they were.
+// applies only to BACKGROUND work — foreground callers resolve a cap at or above
+// the host core count and take the unsynchronised fast path below, so they are
+// left exactly as they were and never wait on anything.
 //
 // This is a mitigation for the in-process path, not an endorsement of it. A
 // subprocess would get the same bound with no global side effect at all and
 // would return its heap to the OS on exit.
 
-// gomaxprocsCapMu serialises capped regions. Overlapping regions would
-// otherwise have the inner region's restore write back the OUTER region's
-// clamped value as if it were the baseline, leaving the process throttled after
-// both had returned. Serialising costs nothing in production: the daemon's
-// exclusive heavy-stage token already admits at most one background heavy pass
-// at a time.
-var gomaxprocsCapMu sync.Mutex
+// The cap state. capMu guards all of it and is held only for the O(len(active))
+// bookkeeping — NEVER across a caller's fn. Regions therefore run concurrently
+// and are not serialised; the effective GOMAXPROCS is simply the minimum of the
+// baseline and every active cap, which bounds the process as a whole regardless
+// of how many regions are in flight.
+//
+// WHY NOT A MUTEX HELD FOR THE WHOLE REGION (the shape this took first): it made
+// every caller queue behind every other, so a user-awaited foreground pass —
+// which needs no clamp at all — would block for the minutes-to-hours lifetime of
+// a background sweep, uncancellably. It also deadlocked on nesting. Neither is
+// visible in an assertion about the cap VALUE, which is how both survived the
+// first round of tests.
+var (
+	capMu sync.Mutex
+	// capBaseline is the GOMAXPROCS to return to when the last region exits. It
+	// is NOT captured once and frozen: ApplyGOMAXPROCS rewrites it so an
+	// operator's live cap change (SIGHUP / cpu.json, #5137) is what a region
+	// restores to, rather than the value that happened to be in force when the
+	// region started.
+	capBaseline int
+	// capCurrent is the value this package last installed, so recompute can tell
+	// a real transition from a no-op.
+	capCurrent int
+	// activeCaps is the multiset of caps held by in-flight regions. A slice, not
+	// a counter: overlapping regions may exit in any order, and restoring to
+	// "whatever was in force when I started" would raise the runtime back above
+	// a sibling region's still-live cap.
+	activeCaps []int
+)
+
+// recomputeCapLocked installs min(capBaseline, activeCaps...) if it differs from
+// what is currently installed.
+func recomputeCapLocked() {
+	eff := capBaseline
+	for _, c := range activeCaps {
+		if c < eff {
+			eff = c
+		}
+	}
+	if eff < 1 {
+		eff = 1
+	}
+	if eff != capCurrent {
+		runtime.GOMAXPROCS(eff)
+		capCurrent = eff
+	}
+}
 
 // WithGOMAXPROCSCap runs fn with the process-wide runtime.GOMAXPROCS clamped to
 // at most n, restoring the previous value before it returns — including when fn
 // returns an error or panics.
 //
-// It NEVER RAISES. n at or above the current value (and any n <= 0, which is
-// what a bogus core count looks like) runs fn with the runtime untouched. That
+// It NEVER RAISES, and a call that would not lower anything takes no lock and
+// blocks on nothing. n at or above the current value, and any n <= 0 (which is
+// what a bogus core count looks like), run fn with the runtime untouched. That
 // asymmetry is the property foreground work depends on: a foreground cap
-// resolves to the host core count, so passing it through here is a no-op rather
-// than a widening.
+// resolves to the host core count, so passing it through here must be a no-op in
+// SCHEDULING as well as in value.
 //
-// Callers must not hold a lock that fn's work can block on: this takes a
-// package mutex for the whole region.
+// Nesting and overlap are safe: the effective limit is the minimum of all live
+// caps, and exiting any region restores only what that region contributed.
 func WithGOMAXPROCSCap(n int, fn func() error) error {
 	if fn == nil {
 		return nil
 	}
-	if n <= 0 {
+	// Unsynchronised fast path. GOMAXPROCS(0) queries without setting. A racing
+	// region may move the value under us, but either answer is correct: if n
+	// does not lower what is installed, this call has nothing to install.
+	if n <= 0 || n >= runtime.GOMAXPROCS(0) {
 		return fn()
 	}
-
-	gomaxprocsCapMu.Lock()
-	defer gomaxprocsCapMu.Unlock()
-
-	// GOMAXPROCS(0) reads without setting; only lower.
-	prev := runtime.GOMAXPROCS(0)
-	if n >= prev {
-		return fn()
-	}
-	runtime.GOMAXPROCS(n)
-	defer runtime.GOMAXPROCS(prev)
+	defer enterGOMAXPROCSCap(n)()
 	return fn()
+}
+
+// enterGOMAXPROCSCap registers a cap and returns its release. Split out from
+// WithGOMAXPROCSCap so the release is a plain defer and therefore runs on panic.
+func enterGOMAXPROCSCap(n int) func() {
+	capMu.Lock()
+	if len(activeCaps) == 0 {
+		// First region: adopt whatever is installed as the baseline to return to.
+		capBaseline = runtime.GOMAXPROCS(0)
+		capCurrent = capBaseline
+	}
+	activeCaps = append(activeCaps, n)
+	recomputeCapLocked()
+	capMu.Unlock()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			capMu.Lock()
+			defer capMu.Unlock()
+			for i, c := range activeCaps {
+				if c == n {
+					activeCaps = append(activeCaps[:i], activeCaps[i+1:]...)
+					break
+				}
+			}
+			recomputeCapLocked()
+		})
+	}
+}
+
+// ApplyGOMAXPROCS sets the process's baseline GOMAXPROCS to target and reports
+// the previous baseline and whether it changed. It is the ONLY correct way for
+// the daemon to apply an operator's cap (cpu.json / SIGHUP, #5137) while this
+// package may hold a region open.
+//
+// WHAT GOES WRONG WITHOUT IT — two interleavings, both real:
+//
+//   - A SIGHUP asking for 3 lands while a region has clamped to 3. A handler
+//     reading runtime.GOMAXPROCS directly sees cur == target, reports "unchanged"
+//     and no-ops. The region's restore then writes back the pre-region 12, and the
+//     daemon ends PERMANENTLY ABOVE the operator's configured cap.
+//   - A SIGHUP applies 6 mid-region. The region's restore writes back 12. Same
+//     outcome.
+//
+// Routing through here makes the operator's value the baseline the region will
+// restore TO, and lowers immediately if it is tighter than what is installed. A
+// cap change is therefore never lost and never inverted.
+func ApplyGOMAXPROCS(target int) (previous int, changed bool) {
+	if target < 1 {
+		target = 1
+	}
+	capMu.Lock()
+	defer capMu.Unlock()
+
+	if len(activeCaps) == 0 {
+		cur := runtime.GOMAXPROCS(0)
+		capBaseline, capCurrent = target, target
+		if cur == target {
+			return cur, false
+		}
+		return runtime.GOMAXPROCS(target), true
+	}
+
+	prev := capBaseline
+	capBaseline = target
+	recomputeCapLocked()
+	return prev, prev != target
+}
+
+// GOMAXPROCSBaseline reports the value an in-flight capped region will restore
+// to, or the installed GOMAXPROCS when no region is active. Exported for tests
+// and diagnostics; production code reads runtime.GOMAXPROCS.
+func GOMAXPROCSBaseline() int {
+	capMu.Lock()
+	defer capMu.Unlock()
+	if len(activeCaps) == 0 {
+		return runtime.GOMAXPROCS(0)
+	}
+	return capBaseline
 }

--- a/internal/process/gomaxprocs.go
+++ b/internal/process/gomaxprocs.go
@@ -1,0 +1,87 @@
+package process
+
+import (
+	"runtime"
+	"sync"
+)
+
+// gomaxprocs.go — the in-process counterpart of the per-child GOMAXPROCS bound
+// (#6108).
+//
+// WHY THIS EXISTS AT ALL, GIVEN THE PASS IS SERIAL. The heavy background
+// analytics passes (group-algo's Louvain + PageRank + Brandes betweenness, and
+// the cross-repo link pass) contain no goroutine fan-out, and neither do the
+// gonum packages they call — gonum's network.Betweenness carries a literal
+// "TODO: Consider using the parallel algorithm when GOMAXPROCS != 1". One
+// mutator thread does the work. That fact was used to argue the cap was
+// decorative. It is not, and the argument had the mechanism backwards:
+//
+// The CPU those passes draw is overwhelmingly the GARBAGE COLLECTOR, and the
+// GC's parallelism is sized by GOMAXPROCS, not by the application's. A cycle
+// runs 25% of GOMAXPROCS as dedicated mark workers, and — decisively for a
+// single-threaded mutator — schedules IDLE mark workers on every otherwise-idle
+// P. A serial pass on a 12-P runtime leaves 11 idle Ps, all of which the GC is
+// free to fill. Brandes allocates per-source maps over a multi-hundred-thousand
+// node union, so cycles are near-continuous. That is how a "fully serial" pass
+// was measured sustaining 571.9% CPU inside the daemon (#6108) while the
+// scheduler logged cap=2.
+//
+// So GOMAXPROCS IS the enforcement lever on this path — it is the only knob the
+// Go runtime offers that bounds total process CPU — and it is precisely the one
+// the subprocess children get for free from their environment. An in-process
+// pass has no environment of its own, which is why it needs this.
+//
+// THE COST, STATED PLAINLY. runtime.GOMAXPROCS is process-global. For the
+// duration of the region every OTHER goroutine in the process — MCP request
+// serving included — runs on the same reduced set of Ps. That is a deliberate
+// trade and it is the right way round: a daemon serving MCP from 2 Ps is
+// responsive; a daemon whose host is at load 76 because the daemon itself took
+// six cores is not. It is also strictly bounded in time by the pass, and it
+// applies only to BACKGROUND work — foreground callers resolve a cap at or
+// above the host core count, and WithGOMAXPROCSCap never raises, so they are
+// left exactly as they were.
+//
+// This is a mitigation for the in-process path, not an endorsement of it. A
+// subprocess would get the same bound with no global side effect at all and
+// would return its heap to the OS on exit.
+
+// gomaxprocsCapMu serialises capped regions. Overlapping regions would
+// otherwise have the inner region's restore write back the OUTER region's
+// clamped value as if it were the baseline, leaving the process throttled after
+// both had returned. Serialising costs nothing in production: the daemon's
+// exclusive heavy-stage token already admits at most one background heavy pass
+// at a time.
+var gomaxprocsCapMu sync.Mutex
+
+// WithGOMAXPROCSCap runs fn with the process-wide runtime.GOMAXPROCS clamped to
+// at most n, restoring the previous value before it returns — including when fn
+// returns an error or panics.
+//
+// It NEVER RAISES. n at or above the current value (and any n <= 0, which is
+// what a bogus core count looks like) runs fn with the runtime untouched. That
+// asymmetry is the property foreground work depends on: a foreground cap
+// resolves to the host core count, so passing it through here is a no-op rather
+// than a widening.
+//
+// Callers must not hold a lock that fn's work can block on: this takes a
+// package mutex for the whole region.
+func WithGOMAXPROCSCap(n int, fn func() error) error {
+	if fn == nil {
+		return nil
+	}
+	if n <= 0 {
+		return fn()
+	}
+
+	gomaxprocsCapMu.Lock()
+	defer gomaxprocsCapMu.Unlock()
+
+	// GOMAXPROCS(0) reads without setting; only lower.
+	prev := runtime.GOMAXPROCS(0)
+	if n >= prev {
+		return fn()
+	}
+	runtime.GOMAXPROCS(n)
+	defer runtime.GOMAXPROCS(prev)
+	return fn()
+}

--- a/internal/process/gomaxprocs_test.go
+++ b/internal/process/gomaxprocs_test.go
@@ -5,83 +5,94 @@ import (
 	"runtime"
 	"sync"
 	"testing"
+	"time"
 )
 
-// gomaxprocs_test.go — behavioural coverage for WithGOMAXPROCSCap (#6108).
+// gomaxprocs_test.go — behavioural coverage for WithGOMAXPROCSCap and
+// ApplyGOMAXPROCS (#6108).
 //
 // These assert the EFFECTIVE runtime.GOMAXPROCS observed from inside the
-// callback, not the presence of any particular source construct. Deleting the
-// clamp, inverting the min, or forgetting the restore each fails one of them.
+// callback, and the SCHEDULING behaviour around it — not the presence of any
+// particular source construct.
+//
+// EVERY TEST PINS ITS OWN BASELINE. GOMAXPROCS is settable to any value
+// independent of the host, so nothing here is conditioned on runtime.NumCPU()
+// and nothing skips: a 1-core CI runner exercises exactly the same clamps as a
+// 12-core laptop. The first draft skipped on small hosts, which meant the
+// central clamp assertion silently vanished on precisely the machines most
+// likely to be running CI. It also inherited whatever GOMAXPROCS a previous test
+// had leaked — a mutant run demonstrated that by turning a FAIL into a SKIP.
+
+// pinGOMAXPROCS installs a deterministic baseline for one test and restores both
+// the runtime value and this package's cap bookkeeping afterwards.
+func pinGOMAXPROCS(t *testing.T, n int) {
+	t.Helper()
+	prev := runtime.GOMAXPROCS(n)
+	t.Cleanup(func() {
+		capMu.Lock()
+		activeCaps = nil
+		capBaseline, capCurrent = prev, prev
+		capMu.Unlock()
+		runtime.GOMAXPROCS(prev)
+	})
+}
 
 func TestWithGOMAXPROCSCap_ClampsInsideCallback(t *testing.T) {
-	before := runtime.GOMAXPROCS(0)
-	if before < 2 {
-		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
-	}
-	want := before - 1
+	pinGOMAXPROCS(t, 8)
 
 	var inside int
-	err := WithGOMAXPROCSCap(want, func() error {
-		inside = runtime.GOMAXPROCS(0)
-		return nil
-	})
-	if err != nil {
+	if err := WithGOMAXPROCSCap(3, func() error { inside = runtime.GOMAXPROCS(0); return nil }); err != nil {
 		t.Fatalf("WithGOMAXPROCSCap: %v", err)
 	}
-	if inside != want {
-		t.Errorf("GOMAXPROCS inside the capped region = %d, want %d — the cap is not in force on the work it is supposed to bound (#6108)", inside, want)
+	if inside != 3 {
+		t.Errorf("GOMAXPROCS inside the capped region = %d, want 3 — the cap is not in force on the work it is supposed to bound (#6108)", inside)
 	}
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after the capped region = %d, want the prior %d — the cap leaked past the pass and throttles the whole daemon", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 8 {
+		t.Errorf("GOMAXPROCS after the capped region = %d, want the prior 8 — the cap leaked past the pass and throttles the whole daemon", after)
 	}
 }
 
 func TestWithGOMAXPROCSCap_NeverRaises(t *testing.T) {
-	before := runtime.GOMAXPROCS(0)
+	pinGOMAXPROCS(t, 4)
+
 	var inside int
-	err := WithGOMAXPROCSCap(before+8, func() error {
-		inside = runtime.GOMAXPROCS(0)
-		return nil
-	})
-	if err != nil {
+	if err := WithGOMAXPROCSCap(16, func() error { inside = runtime.GOMAXPROCS(0); return nil }); err != nil {
 		t.Fatalf("WithGOMAXPROCSCap: %v", err)
 	}
-	if inside != before {
-		t.Errorf("GOMAXPROCS inside = %d, want the unchanged %d — a cap ABOVE the host value must never widen the runtime (foreground work is uncapped, not over-capped)", inside, before)
+	if inside != 4 {
+		t.Errorf("GOMAXPROCS inside = %d, want the unchanged 4 — a cap ABOVE the current value must never widen the runtime (foreground work is uncapped, not over-capped)", inside)
 	}
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after = %d, want %d", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 4 {
+		t.Errorf("GOMAXPROCS after = %d, want 4", after)
 	}
 }
 
 func TestWithGOMAXPROCSCap_NonPositiveIsNoOp(t *testing.T) {
-	before := runtime.GOMAXPROCS(0)
+	pinGOMAXPROCS(t, 4)
+
 	for _, n := range []int{0, -1} {
 		var inside int
 		if err := WithGOMAXPROCSCap(n, func() error { inside = runtime.GOMAXPROCS(0); return nil }); err != nil {
 			t.Fatalf("WithGOMAXPROCSCap(%d): %v", n, err)
 		}
-		if inside != before {
-			t.Errorf("WithGOMAXPROCSCap(%d): GOMAXPROCS inside = %d, want %d — a bogus core count must not pin the process to 1", n, inside, before)
+		if inside != 4 {
+			t.Errorf("WithGOMAXPROCSCap(%d): GOMAXPROCS inside = %d, want 4 — a bogus core count must not pin the process to 1", n, inside)
 		}
 	}
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after = %d, want %d", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 4 {
+		t.Errorf("GOMAXPROCS after = %d, want 4", after)
 	}
 }
 
 func TestWithGOMAXPROCSCap_RestoresOnErrorAndPanic(t *testing.T) {
-	before := runtime.GOMAXPROCS(0)
-	if before < 2 {
-		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
-	}
+	pinGOMAXPROCS(t, 8)
 
 	sentinel := errors.New("boom")
 	if err := WithGOMAXPROCSCap(1, func() error { return sentinel }); !errors.Is(err, sentinel) {
 		t.Errorf("error not propagated: got %v, want %v", err, sentinel)
 	}
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after an erroring pass = %d, want %d", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 8 {
+		t.Errorf("GOMAXPROCS after an erroring pass = %d, want 8", after)
 	}
 
 	func() {
@@ -92,20 +103,14 @@ func TestWithGOMAXPROCSCap_RestoresOnErrorAndPanic(t *testing.T) {
 		}()
 		_ = WithGOMAXPROCSCap(1, func() error { panic("wedged") })
 	}()
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after a panicking pass = %d, want %d — the daemon is left throttled for the rest of its life", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 8 {
+		t.Errorf("GOMAXPROCS after a panicking pass = %d, want 8 — the daemon is left throttled for the rest of its life", after)
 	}
 }
 
-// TestWithGOMAXPROCSCap_SerialisesConcurrentCallers: two overlapping capped
-// regions must not have the inner one's restore clobber the outer's baseline.
-// Serialising is the simplest correct answer (background heavy passes are
-// already mutually exclusive under the daemon's stage gate).
-func TestWithGOMAXPROCSCap_SerialisesConcurrentCallers(t *testing.T) {
-	before := runtime.GOMAXPROCS(0)
-	if before < 2 {
-		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
-	}
+func TestWithGOMAXPROCSCap_ConcurrentRegionsAreAllClamped(t *testing.T) {
+	pinGOMAXPROCS(t, 8)
+
 	var wg sync.WaitGroup
 	for i := 0; i < 8; i++ {
 		wg.Add(1)
@@ -120,7 +125,187 @@ func TestWithGOMAXPROCSCap_SerialisesConcurrentCallers(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	if after := runtime.GOMAXPROCS(0); after != before {
-		t.Errorf("GOMAXPROCS after concurrent capped regions = %d, want %d — a restore raced and the baseline was lost", after, before)
+	if after := runtime.GOMAXPROCS(0); after != 8 {
+		t.Errorf("GOMAXPROCS after concurrent capped regions = %d, want 8 — a restore raced and the baseline was lost", after)
+	}
+}
+
+// TestWithGOMAXPROCSCap_NoOpCapDoesNotBlockBehindALiveRegion is the H1
+// regression.
+//
+// The first draft took a package mutex BEFORE deciding whether it had anything
+// to clamp, so a call that needed no clamp at all still queued behind every live
+// region. In the daemon that means a user-awaited foreground pass — whose cap
+// resolves to the host core count and therefore lowers nothing — waits out a
+// background sweep that can run for minutes or hours, uncancellably. An
+// assertion about the cap VALUE cannot see this: the integer was always right;
+// the SCHEDULING was not.
+func TestWithGOMAXPROCSCap_NoOpCapDoesNotBlockBehindALiveRegion(t *testing.T) {
+	pinGOMAXPROCS(t, 8)
+
+	entered, holdUntil, bgDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(bgDone)
+		_ = WithGOMAXPROCSCap(1, func() error { close(entered); <-holdUntil; return nil })
+	}()
+	<-entered
+	defer func() { close(holdUntil); <-bgDone }()
+
+	// A cap at or above the baseline must complete immediately, NOT wait for the
+	// background region above to release.
+	ran := make(chan struct{})
+	go func() {
+		_ = WithGOMAXPROCSCap(8, func() error { close(ran); return nil })
+	}()
+	select {
+	case <-ran:
+	case <-time.After(2 * time.Second):
+		t.Fatal("a no-op (non-lowering) cap blocked behind a live background region — a foreground pass would serialise behind a multi-hour background sweep (#6108 H1)")
+	}
+}
+
+// TestWithGOMAXPROCSCap_NestingDoesNotDeadlock: a region opened inside another
+// must complete. A plain non-reentrant mutex taken unconditionally wedges the
+// daemon permanently here.
+func TestWithGOMAXPROCSCap_NestingDoesNotDeadlock(t *testing.T) {
+	pinGOMAXPROCS(t, 8)
+
+	done := make(chan int, 1)
+	go func() {
+		var inner int
+		_ = WithGOMAXPROCSCap(2, func() error {
+			return WithGOMAXPROCSCap(1, func() error { inner = runtime.GOMAXPROCS(0); return nil })
+		})
+		done <- inner
+	}()
+	select {
+	case inner := <-done:
+		if inner != 1 {
+			t.Errorf("nested cap: GOMAXPROCS inside = %d, want the tighter 1", inner)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("nested WithGOMAXPROCSCap deadlocked — a permanent daemon wedge (#6108 H1)")
+	}
+	if after := runtime.GOMAXPROCS(0); after != 8 {
+		t.Errorf("GOMAXPROCS after nested regions = %d, want 8", after)
+	}
+}
+
+// TestWithGOMAXPROCSCap_OverlappingExitDoesNotRaiseAboveALiveSibling: two
+// independent regions, the looser exiting first. Its exit must not restore the
+// runtime above the tighter one's still-live cap.
+func TestWithGOMAXPROCSCap_OverlappingExitDoesNotRaiseAboveALiveSibling(t *testing.T) {
+	pinGOMAXPROCS(t, 8)
+
+	aIn, aRelease, aDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	bIn, bRelease, bDone := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(aDone)
+		_ = WithGOMAXPROCSCap(4, func() error { close(aIn); <-aRelease; return nil })
+	}()
+	<-aIn
+	go func() {
+		defer close(bDone)
+		_ = WithGOMAXPROCSCap(1, func() error { close(bIn); <-bRelease; return nil })
+	}()
+	<-bIn
+
+	close(aRelease)
+	<-aDone
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("after the looser region exited, GOMAXPROCS = %d, want 1 — the exit raised the runtime above a sibling region's live cap", got)
+	}
+	close(bRelease)
+	<-bDone
+	if got := runtime.GOMAXPROCS(0); got != 8 {
+		t.Errorf("after all regions exited, GOMAXPROCS = %d, want the baseline 8", got)
+	}
+}
+
+// TestApplyGOMAXPROCS_OperatorCapSurvivesAnActiveRegion is the H2 regression.
+//
+// #5137 lets an operator retune the daemon's GOMAXPROCS live via cpu.json +
+// SIGHUP. A handler that reads and writes runtime.GOMAXPROCS directly loses that
+// change whenever a capped region is open — and it loses it in the dangerous
+// direction: the region's restore writes back the pre-region value, leaving the
+// daemon permanently ABOVE the operator's configured cap.
+func TestApplyGOMAXPROCS_OperatorCapSurvivesAnActiveRegion(t *testing.T) {
+	pinGOMAXPROCS(t, 12)
+
+	// Case 1: the operator's target EQUALS the value the region has installed.
+	// A direct-read handler sees cur == target and no-ops.
+	entered, release, done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = WithGOMAXPROCSCap(2, func() error { close(entered); <-release; return nil })
+	}()
+	<-entered
+	if _, changed := ApplyGOMAXPROCS(2); !changed {
+		t.Errorf("ApplyGOMAXPROCS(2) during a region already clamped to 2 reported unchanged — the operator's new BASELINE was dropped, so the region's restore will undo it (#6108 H2 / #5137)")
+	}
+	close(release)
+	<-done
+	if got := runtime.GOMAXPROCS(0); got != 2 {
+		t.Fatalf("after the region exited, GOMAXPROCS = %d, want the operator's 2 — the daemon is running permanently ABOVE its configured cap (#6108 H2 / #5137)", got)
+	}
+
+	// Case 2: the operator RAISES mid-region. The region keeps its clamp while
+	// live; the raise takes effect on release.
+	entered2, release2, done2 := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(done2)
+		_ = WithGOMAXPROCSCap(1, func() error { close(entered2); <-release2; return nil })
+	}()
+	<-entered2
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Fatalf("region did not clamp: GOMAXPROCS = %d, want 1", got)
+	}
+	ApplyGOMAXPROCS(3)
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("an operator RAISE mid-region lifted the region's clamp to %d — a live background pass must stay bounded", got)
+	}
+	close(release2)
+	<-done2
+	if got := runtime.GOMAXPROCS(0); got != 3 {
+		t.Errorf("after the region exited, GOMAXPROCS = %d, want the operator's 3 — the restore wrote back a stale baseline (#6108 H2)", got)
+	}
+}
+
+// TestApplyGOMAXPROCS_TightensImmediatelyMidRegion: an operator LOWERING below a
+// live region's cap must take effect at once, not at the end of the pass.
+func TestApplyGOMAXPROCS_TightensImmediatelyMidRegion(t *testing.T) {
+	pinGOMAXPROCS(t, 12)
+
+	entered, release, done := make(chan struct{}), make(chan struct{}), make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = WithGOMAXPROCSCap(3, func() error { close(entered); <-release; return nil })
+	}()
+	<-entered
+	ApplyGOMAXPROCS(1)
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("an operator cap tighter than a live region's did not apply: GOMAXPROCS = %d, want 1", got)
+	}
+	close(release)
+	<-done
+	if got := runtime.GOMAXPROCS(0); got != 1 {
+		t.Errorf("after the region exited, GOMAXPROCS = %d, want the operator's 1", got)
+	}
+}
+
+// TestApplyGOMAXPROCS_NoActiveRegion keeps the plain path honest: with nothing
+// in flight it behaves exactly like the direct runtime call it replaces.
+func TestApplyGOMAXPROCS_NoActiveRegion(t *testing.T) {
+	pinGOMAXPROCS(t, 8)
+
+	prev, changed := ApplyGOMAXPROCS(3)
+	if prev != 8 || !changed {
+		t.Errorf("ApplyGOMAXPROCS(3) from 8 = (%d, %v), want (8, true)", prev, changed)
+	}
+	if got := runtime.GOMAXPROCS(0); got != 3 {
+		t.Errorf("GOMAXPROCS = %d, want 3", got)
+	}
+	if prev, changed := ApplyGOMAXPROCS(3); prev != 3 || changed {
+		t.Errorf("re-applying the same target = (%d, %v), want (3, false)", prev, changed)
 	}
 }

--- a/internal/process/gomaxprocs_test.go
+++ b/internal/process/gomaxprocs_test.go
@@ -1,0 +1,126 @@
+package process
+
+import (
+	"errors"
+	"runtime"
+	"sync"
+	"testing"
+)
+
+// gomaxprocs_test.go — behavioural coverage for WithGOMAXPROCSCap (#6108).
+//
+// These assert the EFFECTIVE runtime.GOMAXPROCS observed from inside the
+// callback, not the presence of any particular source construct. Deleting the
+// clamp, inverting the min, or forgetting the restore each fails one of them.
+
+func TestWithGOMAXPROCSCap_ClampsInsideCallback(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	if before < 2 {
+		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
+	}
+	want := before - 1
+
+	var inside int
+	err := WithGOMAXPROCSCap(want, func() error {
+		inside = runtime.GOMAXPROCS(0)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithGOMAXPROCSCap: %v", err)
+	}
+	if inside != want {
+		t.Errorf("GOMAXPROCS inside the capped region = %d, want %d — the cap is not in force on the work it is supposed to bound (#6108)", inside, want)
+	}
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after the capped region = %d, want the prior %d — the cap leaked past the pass and throttles the whole daemon", after, before)
+	}
+}
+
+func TestWithGOMAXPROCSCap_NeverRaises(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	var inside int
+	err := WithGOMAXPROCSCap(before+8, func() error {
+		inside = runtime.GOMAXPROCS(0)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("WithGOMAXPROCSCap: %v", err)
+	}
+	if inside != before {
+		t.Errorf("GOMAXPROCS inside = %d, want the unchanged %d — a cap ABOVE the host value must never widen the runtime (foreground work is uncapped, not over-capped)", inside, before)
+	}
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after = %d, want %d", after, before)
+	}
+}
+
+func TestWithGOMAXPROCSCap_NonPositiveIsNoOp(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	for _, n := range []int{0, -1} {
+		var inside int
+		if err := WithGOMAXPROCSCap(n, func() error { inside = runtime.GOMAXPROCS(0); return nil }); err != nil {
+			t.Fatalf("WithGOMAXPROCSCap(%d): %v", n, err)
+		}
+		if inside != before {
+			t.Errorf("WithGOMAXPROCSCap(%d): GOMAXPROCS inside = %d, want %d — a bogus core count must not pin the process to 1", n, inside, before)
+		}
+	}
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after = %d, want %d", after, before)
+	}
+}
+
+func TestWithGOMAXPROCSCap_RestoresOnErrorAndPanic(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	if before < 2 {
+		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
+	}
+
+	sentinel := errors.New("boom")
+	if err := WithGOMAXPROCSCap(1, func() error { return sentinel }); !errors.Is(err, sentinel) {
+		t.Errorf("error not propagated: got %v, want %v", err, sentinel)
+	}
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after an erroring pass = %d, want %d", after, before)
+	}
+
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Errorf("panic was swallowed — a wedged pass must still crash loudly")
+			}
+		}()
+		_ = WithGOMAXPROCSCap(1, func() error { panic("wedged") })
+	}()
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after a panicking pass = %d, want %d — the daemon is left throttled for the rest of its life", after, before)
+	}
+}
+
+// TestWithGOMAXPROCSCap_SerialisesConcurrentCallers: two overlapping capped
+// regions must not have the inner one's restore clobber the outer's baseline.
+// Serialising is the simplest correct answer (background heavy passes are
+// already mutually exclusive under the daemon's stage gate).
+func TestWithGOMAXPROCSCap_SerialisesConcurrentCallers(t *testing.T) {
+	before := runtime.GOMAXPROCS(0)
+	if before < 2 {
+		t.Skipf("host GOMAXPROCS=%d — nothing to clamp below", before)
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = WithGOMAXPROCSCap(1, func() error {
+				if got := runtime.GOMAXPROCS(0); got != 1 {
+					t.Errorf("GOMAXPROCS inside a concurrent capped region = %d, want 1", got)
+				}
+				return nil
+			})
+		}()
+	}
+	wg.Wait()
+	if after := runtime.GOMAXPROCS(0); after != before {
+		t.Errorf("GOMAXPROCS after concurrent capped regions = %d, want %d — a restore raced and the baseline was lost", after, before)
+	}
+}


### PR DESCRIPTION
`grafel serve` was observed at **4.97 GB RSS and 571.9% CPU sustained for ~4 hours** on a group-algo pass, on a 12-core laptop shared with the user's work, with `cap=2` in the log and **no child process in `ps`**. The machine had ~62 MB free and a load average of 76.

## The contradiction, and the answer

Pass-4 is genuinely serial. Verified across the whole compute path — `internal/graph/*.go` including the in-repo `louvain.go`, `groupalgo/`, `internal/links/`, and every gonum package in `go list -deps` (`graph/network`, `graph/path`, `graph/spectral`, `graph/traverse`, `mat`, `lapack/gonum`, `internal/asm/f64`). **Zero** `go func`, `WaitGroup` or `NumCPU` in any of them. gonum's Brandes carries a literal `// TODO(kortschak): Consider using the parallel algorithm when GOMAXPROCS != 1`, and `graph/community` is not even a dependency.

**So the CPU is the garbage collector.** GC mark parallelism is sized by `GOMAXPROCS`, not by the application's own parallelism: 25% dedicated mark workers plus idle mark workers on every otherwise-idle P. A serial mutator on a 12-P runtime leaves 11 Ps for the collector, and Brandes allocates per-source maps across a 427k-node union, so cycles are near-continuous.

Reproduced rather than argued — serial single-goroutine mutator, pointer-dense retained heap, `getrusage`:

| GOMAXPROCS | wall | cpu | % |
|---|---|---|---|
| 12 | 0.18s | **0.55s** | 311.1% |
| 6 | 0.17s | 0.40s | 236.1% |
| 3 | 0.20s | 0.38s | 188.0% |
| 2 | 0.24s | 0.38s | 154.5% |
| 1 | 0.39s | 0.38s | 99.2% |

The load-bearing number is **CPU seconds, not percent**: 0.55 → 0.38. The excess at 12 is overhead the cap *deletes*, not work redistributed. A pointer-**sparse** heap reaches only 119%, so the effect depends on mark work over a dense live set — which is exactly what a graph union is.

571% at a ~100× larger live set is a plausible extrapolation from the 311% point, not a measurement. Stated as such.

## `cap=2` was real, correct, and applied to a process that did not exist

`groupAlgoChildGOMAXPROCS` → `BackgroundBatchGOMAXPROCS()` = `max(2, NumCPU/8)`. It is logged in `runGroupAlgo` (`scheduler.go:2695`) **before** the branch on subprocess-vs-in-process, and the in-process branch never consumed it.

## A second uncapped site, not in the original report

`internal/dashboard/graphstate.go schedulePendingAlgo` ran the same `graph.RunAlgorithms` **on a bare goroutine inside `serve`** — no child, no budget. Symptomatically identical to the report (no child in `ps`) and arguably the likelier source of the observed sample. Both sites are now capped, so the diagnosis does not have to be settled first; a new `mode=child|in-process` log field will settle it on recurrence.

## What review found in the first version — three defects the suite could not see

**The cap blocked foreground behind background.** The mutex was taken *before* the `n >= prev` early-out, so a non-lowering call still queued. The value was untouched; the scheduling was not. A user-awaited `grafel rebuild` would serialise behind an in-flight dashboard sweep — minutes to hours — and the wait honoured neither `ctx.Done()` nor daemon shutdown. Nested regions **deadlocked** on a non-reentrant mutex; under test the old primitive did not merely fail, it **hung the binary to the 120s timeout**.

Rewritten around a short-held lock over a **multiset of live caps**: effective `GOMAXPROCS` is `min(baseline, active…)`, non-lowering calls take no lock at all, regions run concurrently, and each exit restores only its own contribution.

That last property fixed a defect neither the review nor the brief named, found by the new tests: with a depth counter, a **looser sibling exiting first restores the runtime above a tighter live sibling's cap**. Pinned by `TestWithGOMAXPROCSCap_OverlappingExitDoesNotRaiseAboveALiveSibling`.

**It clobbered the SIGHUP cap-reload (#5137).** `applyDaemonGOMAXPROCSFromCaps` writes `runtime.GOMAXPROCS` from a signal goroutine, entirely outside the new mutex. Two losing interleavings left the daemon **permanently above the operator's configured cap**. Now routed through `process.ApplyGOMAXPROCS`, which rewrites the baseline a live region will restore to and lowers immediately if tighter. Mutant output:

```
ApplyGOMAXPROCS(2) during a region already clamped to 2 reported unchanged — the operator's new BASELINE was dropped
after the region exited, GOMAXPROCS = 12, want the operator's 2 — the daemon is running permanently ABOVE its configured cap
```

**The dashboard site could clamp the whole MCP daemon to `GOMAXPROCS=1`.** It used `IndexCoreBudget()` = `NumCPU/4` floored at 1; on a 4-core host that is 1. It now uses `sched.BackgroundBatchGOMAXPROCS()` — the same function the child is spawned with, floored at 2. One policy. Verified no import cycle. `IndexCoreBudget`'s own doc disclaims `GOMAXPROCS` as its enforcement mechanism; it governs cgo parse slots and child counts, a different bottleneck. Recorded at the call site.

## The seam was silently bypassable — the #6091 shape again

Replacing **both** seam defaults with a no-op passthrough left `./cmd/grafel/`, `./internal/dashboard/`, `./internal/process/` and `./internal/daemon/sched/` **all green, exit 0**. Both tests overwrote the seam and called the real function themselves, so the production wiring — the entire point of this change — was never asserted.

Fixed with `reflect`-pointer identity guards in both packages. Running the same mutant now:

```
--- FAIL: TestGroupAlgoCapSeam_DefaultsToTheRealCap
--- FAIL: TestBackgroundPass4CapSeam_DefaultsToTheRealCap
--- PASS: (everything else)
```

Only the two new guards catch it, which is the point.

## Vacuity removed

Both tests previously carried `if runtime.NumCPU() <= want { t.Skipf(...) }` **before** the assertion — on a 1–2 core CI runner the clamp check silently vanished and the suite reported green. And `ForegroundIsNotThrottled` was near-vacuous: the foreground cap resolves to `NumCPU`, equal to ambient `GOMAXPROCS`, so its assertion held whether clamping worked or not.

`internal/process` tests now pin their own baseline independent of the host: **11 tests, 0 skips, no `NumCPU` read**. `ForegroundIsNotThrottled` pins baseline **2, below** the resolved foreground cap, so it fails on a clamp *and* on a naive `max()` that applies the resolved cap literally.

The mutation run showed why this mattered in a way the first version missed: leaked ambient `GOMAXPROCS` turned a would-be FAIL into a SKIP mid-suite.

## Observability

- `group-algo: starting` now carries `mode=child|in-process`.
- A pass blocked on the algo semaphore logs `group-algo: waiting for an algo slot` instead of being indistinguishable from a running one.
- A 60s heartbeat emitting `group`, `mode`, `elapsed`, `phase` and `cpu_pct`, on **both** branches. #6002's per-phase instrumentation never reached these logs because the child's memtrace is off unless `GRAFEL_MEMTRACE` is set. `cap=2` beside `cpu_pct=571` on one line is the entire defect.
- Interval parsing floors at 10ms and treats any non-positive duration as disabled — `"0s"`, `"0ms"`, `"-5s"` now behave like `"0"`, where previously they silently fell back to 60s and `1ns` was accepted and spun.

## The comment that let this ship

`subprocess_runner.go:237-246` asserted the background cap "buys very little" and "do not cite it as a throughput control" — sitting in the definition of the constant this change depends on. Rewritten: the serial-code premise is kept and stated *more* strongly using the broader audit above, the inference is retracted, and the `getrusage` table is inline including the CPU-seconds drop. Closing line: **"a CPU control, not a throughput control."**

## Recommended, deliberately not done here

Move the dashboard Pass-4 sweep to a subprocess. It already does `persistAlgoResults` → `markAlgoComputed` → evict-and-reload, so the parent re-reads from disk on the next request regardless — a child costs one `graph.fb` re-read per repo that is already being paid, and its multi-hundred-MB arena would return to the OS on exit instead of staying resident in the MCP-serving daemon. It also removes all three defects above at once, since there would be no process-global `GOMAXPROCS` mutation and no cross-pass mutex.

Also open: two divergent background-core policies now coexist (`NumCPU/8` floor 2 and `NumCPU/4`), worth reconciling separately.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. Sequential, at `-count=1 -p 1`:

| package | exit | skips |
|---|---|---|
| `internal/process` | 0 | **0** |
| `internal/dashboard` | 0 | **0** |
| `internal/daemon/...` (incl. `sched`) | 0 | 10 |
| `cmd/grafel` | 0 | 9 |

0 FAIL throughout.

One transient noted rather than dismissed: a single full-suite `internal/dashboard` run failed `TestV2GraphRestoresDiskPayloadBeforeLoadingGraph` (#6061, a known ~10% flake). At the time a new test in that package was writing process-global `runtime.GOMAXPROCS` directly, which perturbs scheduling binary-wide. That write is gone — the baseline is now raised through a managed region — and three clean full-suite runs followed. Causation is unproven in either direction; recorded on #6061 as a **confounded** sighting so it is not later cited as a reproduction.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Closes #6108
Refs #5954, #5996, #6002, #5872, #6091, #5137, #6061
