### PR TITLE
fix(#6080,#6079): re-resolve the active generation on the fast path; freshen the SHA cache key

### DIFF
--- a/internal/daemon/find_graph_in_dir_bench_test.go
+++ b/internal/daemon/find_graph_in_dir_bench_test.go
@@ -1,0 +1,61 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6080 asked for the freshness gate's cost to be MEASURED rather than assumed,
+// because #6060 exists to keep the serving reload path free of git subprocesses.
+// These two benchmarks are the before/after of the gate's per-repo-per-reload
+// work: BenchmarkGate_StatPinnedFile is what it used to do (one os.Stat of the
+// pinned path, which is why it could not see a generation flip);
+// BenchmarkGate_FindGraphFileInDir is what it does now.
+//
+// Both are pure filesystem calls on a tiny directory. Neither forks.
+func benchStateDir(b *testing.B) (dir, genPath string) {
+	b.Helper()
+	dir = b.TempDir()
+	p, err := graph.WriteGenGraph(dir, []byte("not-a-real-graph-but-a-real-file"))
+	if err != nil {
+		b.Fatalf("WriteGenGraph: %v", err)
+	}
+	return dir, p
+}
+
+func BenchmarkGate_StatPinnedFile(b *testing.B) {
+	_, genPath := benchStateDir(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := os.Stat(genPath); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkGate_FindGraphFileInDir(b *testing.B) {
+	dir, genPath := benchStateDir(b)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if p, _ := FindGraphFileInDir(dir); p != genPath {
+			b.Fatalf("resolved %s, want %s", p, genPath)
+		}
+	}
+}
+
+// BenchmarkGate_StateDirForRepo is the cost the gate must NOT pay per reload —
+// the git-capture path #2550/#6060 removed. Present for scale: the two
+// benchmarks above must stay orders of magnitude below it.
+func BenchmarkGate_StateDirForRepo(b *testing.B) {
+	dir := b.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		b.Fatal(err)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = StateDirForRepo(dir)
+	}
+}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -506,6 +506,21 @@ func GraphFBExistsForRepo(repoPath string) bool {
 	return err == nil && desc.Kind != graph.GraphAbsent
 }
 
+// FindGraphFileInDir resolves the ACTIVE graph artifact inside an
+// already-known per-ref state directory: it reads the `current` generation
+// pointer (falling back to the legacy flat graph.fb) and returns that path plus
+// its freshness mtime. Returns ("", 0) when the directory holds no graph.
+//
+// It is the directory-level half of FindGraphFile / FindGraphFileAnyRef, split
+// out (#6080) so a caller that already knows the repo's current-ref directory
+// can re-resolve the active GENERATION without paying StateDirForRepo's git
+// capture. Cost is a `current` pointer read plus two or three os.Stat calls —
+// no subprocesses — which is what makes it affordable on the serving reload
+// path that #6060 exists to keep fork-free.
+func FindGraphFileInDir(dir string) (path string, modtime int64) {
+	return findGraphFileInDir(dir)
+}
+
 // findGraphFileInDir checks dir for graph.fb / graph.json and returns the
 // path + modtime of the newest one. Returns ("", 0) if neither exists.
 func findGraphFileInDir(dir string) (path string, modtime int64) {
@@ -523,24 +538,49 @@ func findGraphFileInDir(dir string) (path string, modtime int64) {
 	// mtime advances on each rebuild). Downstream readers route on this via the
 	// descriptor; the mmap zero-copy cutover correctly declines a dir (see
 	// internal/mcp/state.go's .fb-ext guard) and serves the segment-set Document.
-	if desc, dErr := graph.CurrentGraphDescriptor(dir); dErr == nil && desc.Kind == graph.GraphSegmentSet {
+	// #6080: resolve the `current` pointer ONCE. This used to call
+	// CurrentGraphDescriptor and then CurrentGraphPath, each of which opens and
+	// reads <dir>/current — and that read, not the stats, is the dominant cost
+	// (~22us vs ~1.6us for an os.Stat on an M2 Pro under load). Halving it
+	// matters now that the MCP reload gate calls this per repo per reload to
+	// detect a generation flip; CurrentGraphDescriptor already resolves every
+	// layout CurrentGraphPath does, so the second read was pure duplication.
+	var fbPath string
+	var fbMtime int64
+	desc, dErr := graph.CurrentGraphDescriptor(dir)
+	switch {
+	case dErr != nil:
+		// Only a resolvable gen dir with a CORRUPT manifest errors. Preserve the
+		// pre-#6080 behaviour of falling back to the flat path in that case.
+		fbPath = graph.CurrentGraphPath(dir)
+	case desc.Kind == graph.GraphSegmentSet:
+		fbPath = desc.GenDir
+		// The gen dir is not itself a freshness signal; manifest.json is (a real
+		// file whose mtime advances at the atomic commit point of a rebuild).
 		if fi, err := os.Stat(filepath.Join(desc.GenDir, graph.ManifestFileName)); err == nil {
-			segMtime := fi.ModTime().UnixNano()
-			jsonPath := filepath.Join(dir, "graph.json")
-			if jInfo, jErr := os.Stat(jsonPath); jErr == nil && jInfo.ModTime().UnixNano() > segMtime {
-				return jsonPath, jInfo.ModTime().UnixNano()
-			}
-			return desc.GenDir, segMtime
+			fbMtime = fi.ModTime().UnixNano()
+		} else {
+			// Torn segment-set: fall back to the flat path exactly as before.
+			fbPath = graph.CurrentGraphPath(dir)
+		}
+	default:
+		// GraphSingleFile (gen file or legacy flat) and GraphAbsent both carry
+		// the path to stat in desc.Path — for GraphAbsent that is the flat
+		// graph.fb, which is expected not to exist.
+		fbPath = desc.Path
+	}
+
+	jsonPath := filepath.Join(dir, "graph.json")
+	if fbMtime == 0 && fbPath != "" {
+		if fi, err := os.Stat(fbPath); err == nil {
+			fbMtime = fi.ModTime().UnixNano()
+		} else {
+			fbPath = ""
 		}
 	}
-	fbPath := graph.CurrentGraphPath(dir)
-	jsonPath := filepath.Join(dir, "graph.json")
-
-	fbInfo, fbErr := os.Stat(fbPath)
 	jsonInfo, jsonErr := os.Stat(jsonPath)
 
-	if fbErr == nil {
-		fbMtime := fbInfo.ModTime().UnixNano()
+	if fbPath != "" {
 		if jsonErr == nil {
 			jsonMtime := jsonInfo.ModTime().UnixNano()
 			if fbMtime >= jsonMtime {

--- a/internal/gitmeta/cache.go
+++ b/internal/gitmeta/cache.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -19,21 +20,51 @@ import (
 // before this cache every whoami call shelled out to git 5–10× (~0.5–2s under
 // indexer contention); after it the steady-state call is a single os.Stat.
 //
-// Correctness: the only inputs that change Capture's output are the HEAD ref,
-// the commit it points at, and the gitdir/commondir relationship. A commit or
-// checkout always updates <gitdir>/HEAD (its mtime advances); a branch-switch
-// likewise. Reindex is irrelevant — git metadata is independent of the graph —
-// so this cache does not need wiring to the index-completion signal. When HEAD
+// WHAT THE HEAD-POINTER KEY ACTUALLY PROTECTS (#6079). This comment previously
+// claimed "a commit ... always updates <gitdir>/HEAD". That is false, and the
+// correction matters per-field:
+//
+//   - `git commit` ON THE BRANCH YOU ARE ALREADY ON does NOT touch <gitdir>/HEAD.
+//     It writes refs/heads/<branch> and appends to logs/HEAD. HEAD is a symbolic
+//     ref ("ref: refs/heads/main") and is rewritten only when the BRANCH changes
+//     — checkout, switch, detach.
+//   - Ref / IsWorktree / TopLevel / GitDir are therefore CORRECTLY protected:
+//     each changes exactly when the symbolic ref or the gitdir layout changes,
+//     which is exactly when this key changes.
+//   - SHA is NOT protected: it advances on every commit, so it can be stale for
+//     the whole lifetime of the key.
+//
+// Callers that need a per-commit-fresh SHA MUST use CaptureCachedFresh, which
+// keys on the branch tip as well. The split is deliberate rather than widening
+// this key for everyone: daemon.StateDirForRepo consumes only .Ref and is on the
+// serving hot path — #6060 exists precisely because it used to fork git per
+// request — so making its key commit-sensitive would re-fork Capture after every
+// commit to fix a different caller's problem.
+//
+// Reindex is irrelevant to both keys — git metadata is independent of the graph
+// — so neither cache needs wiring to the index-completion signal. When HEAD
 // cannot be located (non-git dir) we fall through to a live Capture and do not
 // cache, preserving exact prior behaviour for those paths.
 var (
-	captureMu    sync.Mutex
+	captureMu sync.Mutex
+	// captureCache is keyed on the HEAD pointer alone: Ref-correct, SHA-stale.
 	captureCache = map[string]captureEntry{}
+	// captureFreshCache is keyed on the HEAD pointer AND the commit token, so
+	// every field including SHA is fresh. Kept in a SEPARATE map so a hit stored
+	// by the cheap variant can never be served to a caller that asked for the
+	// strict one.
+	captureFreshCache = map[string]captureFreshEntry{}
 )
 
 type captureEntry struct {
 	info     Info
 	headStat headKey
+}
+
+type captureFreshEntry struct {
+	info        Info
+	headStat    headKey
+	commitToken string
 }
 
 // headKey identifies the state of a repo's HEAD pointer. A zero value means
@@ -81,6 +112,163 @@ func headPointerKey(repoPath string) (headKey, bool) {
 	return headKey{path: dotGit, mtime: fi.ModTime(), size: fi.Size()}, true
 }
 
+// resolveGitDirs returns repoPath's own git directory and the COMMON git
+// directory that holds its refs, without invoking git. For a normal checkout
+// both are "<repo>/.git". For a linked worktree, "<repo>/.git" is a gitdir file
+// naming the worktree's private dir, and that dir's "commondir" file names the
+// shared one (relative paths are resolved against the private dir). ok is false
+// when repoPath is not a resolvable checkout.
+func resolveGitDirs(repoPath string) (gitDir, commonDir string, ok bool) {
+	dotGit := filepath.Join(repoPath, ".git")
+	fi, err := os.Stat(dotGit)
+	if err != nil {
+		return "", "", false
+	}
+	if fi.IsDir() {
+		return dotGit, dotGit, true
+	}
+	gitDir = readGitdirFile(dotGit)
+	if gitDir == "" {
+		return "", "", false
+	}
+	commonDir = gitDir
+	if data, err := os.ReadFile(filepath.Join(gitDir, "commondir")); err == nil {
+		if cd := strings.TrimSpace(string(data)); cd != "" {
+			if filepath.IsAbs(cd) {
+				commonDir = filepath.Clean(cd)
+			} else {
+				commonDir = filepath.Clean(filepath.Join(gitDir, cd))
+			}
+		}
+	}
+	return gitDir, commonDir, true
+}
+
+// statToken renders a path's existence + mtime + size as a comparable token.
+// A missing file yields a distinct "absent" token rather than an error, because
+// absence is itself a meaningful, changeable state (packed-refs appears when
+// refs are packed).
+//
+// Use contentToken instead for anything whose SIZE is constant, where mtime is
+// the only discriminating component and two writes within one filesystem
+// timestamp tick would collide.
+func statToken(path string) string {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return "-"
+	}
+	return fi.ModTime().UTC().Format(time.RFC3339Nano) + ":" + strconv.FormatInt(fi.Size(), 10)
+}
+
+// contentToken renders a small file's exact CONTENT as a comparable token, with
+// the same "-" sentinel for absence. Used for the loose branch tip, which is a
+// fixed-width 41-byte file ("<40-hex sha>\n"): its size never changes, so a
+// stat-based token would discriminate on mtime alone and two commits landing in
+// one filesystem timestamp tick would share a token and serve a stale SHA. The
+// tip's bytes ARE the commit id, so comparing them is exact — and at 41 bytes it
+// costs the same open/read/close the HEAD pointer already pays.
+func contentToken(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "-"
+	}
+	return strings.TrimSpace(string(data))
+}
+
+// commitToken identifies the state of the COMMIT repoPath's HEAD resolves to,
+// without invoking git. It changes on every commit, and is the missing half of
+// the HEAD-pointer key (#6079).
+//
+// Components, all cheap file operations:
+//
+//   - HEAD's raw bytes. Covers a branch switch and a detach; for a DETACHED
+//     HEAD these bytes ARE the commit id, so nothing further is needed.
+//   - the loose branch-tip file <commonDir>/refs/heads/<branch>, by CONTENT.
+//     Its bytes are the commit id, so this component is exact. It is read rather
+//     than stat'd deliberately: a loose ref is a fixed-width 41-byte file, so its
+//     size never varies and a stat token would rest on mtime alone — two commits
+//     inside one filesystem timestamp tick would then share a token and serve a
+//     stale SHA. Absence is part of the token too (a packed ref that a commit
+//     un-packs flips this component).
+//   - <commonDir>/packed-refs, by stat: the branch tip may live there instead.
+//     Stat is adequate here because that file's size does vary with its
+//     contents, and it is rewritten whenever refs are packed or a packed ref
+//     moves.
+//
+// ok is false only when the repo's git dirs or HEAD cannot be read at all, in
+// which case CaptureCachedFresh declines to cache and runs a live Capture —
+// failing toward freshness rather than serving an unverifiable memo.
+func commitToken(repoPath string) (string, bool) {
+	gitDir, commonDir, ok := resolveGitDirs(repoPath)
+	if !ok {
+		return "", false
+	}
+	headBytes, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", false
+	}
+	head := strings.TrimSpace(string(headBytes))
+
+	var b strings.Builder
+	b.WriteString(head)
+	b.WriteByte(0)
+	if rest, isSym := strings.CutPrefix(head, "ref:"); isSym {
+		ref := strings.TrimSpace(rest)
+		// Reject anything that could escape commonDir. A hostile/corrupt HEAD is
+		// not a reason to build a path out of it; treat it as unresolvable and
+		// let the caller run uncached.
+		if ref == "" || strings.Contains(ref, "..") || filepath.IsAbs(ref) {
+			return "", false
+		}
+		b.WriteString(contentToken(filepath.Join(commonDir, filepath.FromSlash(ref))))
+		b.WriteByte(0)
+	}
+	b.WriteString(statToken(filepath.Join(commonDir, "packed-refs")))
+	return b.String(), true
+}
+
+// CaptureCachedFresh returns the same value as Capture, memoized on a key that
+// covers BOTH the HEAD pointer and the commit it resolves to. Unlike
+// CaptureCached it is correct for Info.SHA across a same-branch commit (#6079),
+// at the cost of one extra small file read and two os.Stat calls per call — no
+// git subprocess on the steady-state path.
+//
+// Use this wherever a per-commit-accurate SHA is observable (ResolveCWD,
+// grafel_whoami's indexed_sha). Use CaptureCached when only .Ref / .IsWorktree /
+// .TopLevel matter and the call is hot (daemon.StateDirForRepo).
+//
+// When the repo's git state cannot be read (non-git directory, unreadable HEAD)
+// it runs a live Capture and does not cache — identical observable behaviour to
+// Capture for those inputs.
+func CaptureCachedFresh(repoPath string) Info {
+	if repoPath == "" {
+		return Capture(repoPath)
+	}
+	key, ok := headPointerKey(repoPath)
+	if !ok {
+		return Capture(repoPath)
+	}
+	tok, ok := commitToken(repoPath)
+	if !ok {
+		// Cannot verify commit freshness — never serve a possibly-stale memo.
+		return Capture(repoPath)
+	}
+
+	captureMu.Lock()
+	if ent, hit := captureFreshCache[repoPath]; hit && ent.headStat == key && ent.commitToken == tok {
+		captureMu.Unlock()
+		return ent.info
+	}
+	captureMu.Unlock()
+
+	info := Capture(repoPath)
+
+	captureMu.Lock()
+	captureFreshCache[repoPath] = captureFreshEntry{info: info, headStat: key, commitToken: tok}
+	captureMu.Unlock()
+	return info
+}
+
 // readGitdirFile parses a worktree ".git" gitdir-file ("gitdir: <path>\n") and
 // returns the referenced directory, or "" on any error.
 func readGitdirFile(path string) string {
@@ -116,10 +304,21 @@ func indexOf(s, sub string) int {
 	return -1
 }
 
-// CaptureCached returns the same value as Capture but memoizes the result
-// keyed on the repo's HEAD-pointer mtime, eliminating the per-call git
-// subprocess cost on the hot whoami / ResolveCWD path. The cache self-
-// invalidates whenever HEAD is rewritten (commit / checkout / branch-switch).
+// CaptureCached returns Capture's value memoized on the repo's HEAD-pointer
+// mtime+size, eliminating the per-call git subprocess cost on the hot
+// StateDirForRepo path. The cache self-invalidates whenever HEAD is REWRITTEN —
+// checkout, branch-switch, detach.
+//
+// FRESHNESS CONTRACT (#6079), read this before adding a caller:
+//
+//	Ref, IsWorktree, TopLevel, GitDir — fresh. They change exactly when the
+//	symbolic ref or the gitdir layout changes, which is exactly when the key
+//	changes.
+//	SHA — MAY BE STALE. A same-branch commit does not rewrite HEAD, so the key
+//	is unchanged and the previous commit's SHA keeps being served.
+//
+// If you need SHA, call CaptureCachedFresh. Do not "fix" a stale SHA by
+// widening this key: the hot caller here reads only .Ref.
 //
 // When HEAD cannot be located (non-git directory) it runs a live Capture and
 // does not cache — identical observable behaviour to Capture for those inputs.
@@ -175,5 +374,6 @@ func HeadToken(repoPath string) (string, bool) {
 func resetCaptureCacheForTest() {
 	captureMu.Lock()
 	captureCache = map[string]captureEntry{}
+	captureFreshCache = map[string]captureFreshEntry{}
 	captureMu.Unlock()
 }

--- a/internal/gitmeta/cache_sha_6079_test.go
+++ b/internal/gitmeta/cache_sha_6079_test.go
@@ -1,0 +1,278 @@
+// cache_sha_6079_test.go — issue #6079.
+//
+// captureCache is keyed on the <gitdir>/HEAD pointer's mtime+size. The doc
+// comment claimed "a commit ... always updates <gitdir>/HEAD", and that is not
+// true: `git commit` on the branch you are already on writes
+// refs/heads/<branch> and appends to logs/HEAD; HEAD itself is a symbolic ref
+// and is only rewritten when the BRANCH changes (checkout / switch / detach).
+//
+// meta.Ref is therefore correctly protected — it changes exactly when the
+// symbolic ref changes, which is exactly when the key changes — but Info.SHA
+// changes on every commit and goes stale for the lifetime of the key. Its
+// consumers (ResolveCWD, grafel_whoami's indexed_sha) then report the previous
+// commit with a success response, which is the silent-wrong-answer shape.
+package gitmeta
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// commitOnSameBranch adds a commit to dir's current branch and returns the new
+// abbreviated SHA.
+func commitOnSameBranch(t *testing.T, dir, content string) string {
+	t.Helper()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", content)
+	return Capture(dir).SHA
+}
+
+// TestCaptureCached_HeadPointerIsUnmovedBySameBranchCommit pins the mechanism
+// the issue rests on, by execution rather than by assertion in prose: a
+// same-branch commit leaves <gitdir>/HEAD byte- and mtime-identical, so the
+// HEAD-pointer cache key cannot possibly observe it, while the branch tip does
+// move.
+func TestCaptureCached_HeadPointerIsUnmovedBySameBranchCommit(t *testing.T) {
+	dir := initGitRepo(t)
+
+	before, ok := headPointerKey(dir)
+	if !ok {
+		t.Fatal("headPointerKey failed on a real checkout")
+	}
+	tipPath := filepath.Join(dir, ".git", "refs", "heads", "main")
+	tipBefore, err := os.ReadFile(tipPath)
+	if err != nil {
+		t.Fatalf("read branch tip: %v", err)
+	}
+
+	commitOnSameBranch(t, dir, "second")
+
+	after, ok := headPointerKey(dir)
+	if !ok {
+		t.Fatal("headPointerKey failed after commit")
+	}
+	if after != before {
+		t.Fatalf("fixture invalid: the HEAD pointer DID move on a same-branch commit\n before=%+v\n after =%+v", before, after)
+	}
+	tipAfter, err := os.ReadFile(tipPath)
+	if err != nil {
+		t.Fatalf("read branch tip after commit: %v", err)
+	}
+	if string(tipAfter) == string(tipBefore) {
+		t.Fatal("fixture invalid: the branch tip did not move — no commit happened")
+	}
+}
+
+// TestCaptureCachedFresh_InvalidatesOnSameBranchCommit is the #6079 regression:
+// the SHA-fresh variant must report the NEW commit after a same-branch commit.
+func TestCaptureCachedFresh_InvalidatesOnSameBranchCommit(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	first := CaptureCachedFresh(dir)
+	if first.SHA == "" {
+		t.Fatal("fixture degenerate: no SHA captured for the initial commit")
+	}
+	if first.Ref != "main" {
+		t.Fatalf("fixture degenerate: Ref=%q, want main", first.Ref)
+	}
+
+	wantSHA := commitOnSameBranch(t, dir, "second")
+	if wantSHA == "" || wantSHA == first.SHA {
+		t.Fatalf("fixture degenerate: SHA did not advance (%q -> %q)", first.SHA, wantSHA)
+	}
+
+	got := CaptureCachedFresh(dir)
+	if got.SHA != wantSHA {
+		t.Errorf("stale SHA served after a same-branch commit:\n got  %q\n want %q\n"+
+			"(the cache key identifies the ref, not the state of the ref)", got.SHA, wantSHA)
+	}
+	// The branch did not change, so Ref must be untouched — this is the guard
+	// against "fixed" by accidentally moving off main.
+	if got.Ref != "main" {
+		t.Errorf("vacuous: Ref changed to %q — the HEAD-pointer key would have caught that already", got.Ref)
+	}
+}
+
+// TestCaptureCachedFresh_TipTokenIsContentNotMtime: the branch-tip component of
+// the commit token must discriminate on the tip's CONTENT, not on its mtime.
+//
+// A loose ref is a fixed-width 41-byte file, so a stat-based token varies only
+// in mtime — and two commits landing inside one filesystem timestamp tick would
+// then produce the same token and serve the earlier commit's SHA. That is
+// unreachable on APFS but not a property to leave resting on the filesystem.
+// The fixture forces the collision by stamping the post-commit tip with the
+// pre-commit mtime, which is exactly what a coarse-granularity filesystem does
+// on its own.
+func TestCaptureCachedFresh_TipTokenIsContentNotMtime(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+	tipPath := filepath.Join(dir, ".git", "refs", "heads", "main")
+
+	first := CaptureCachedFresh(dir)
+	fiBefore, err := os.Stat(tipPath)
+	if err != nil {
+		t.Fatalf("stat tip: %v", err)
+	}
+
+	wantSHA := commitOnSameBranch(t, dir, "second")
+	if wantSHA == first.SHA {
+		t.Fatalf("fixture degenerate: SHA did not advance (%q)", first.SHA)
+	}
+	// Collapse the mtime difference the token must NOT depend on.
+	if err := os.Chtimes(tipPath, fiBefore.ModTime(), fiBefore.ModTime()); err != nil {
+		t.Fatalf("chtimes tip: %v", err)
+	}
+	fiAfter, err := os.Stat(tipPath)
+	if err != nil {
+		t.Fatalf("stat tip after: %v", err)
+	}
+	if !fiAfter.ModTime().Equal(fiBefore.ModTime()) {
+		t.Fatalf("fixture degenerate: mtimes still differ (%v vs %v)", fiBefore.ModTime(), fiAfter.ModTime())
+	}
+	// Non-vacuity: this only proves something if size is genuinely constant, so
+	// a stat token really would have collided.
+	if fiAfter.Size() != fiBefore.Size() {
+		t.Fatalf("vacuous: tip size changed (%d -> %d), so a stat token would have caught this anyway",
+			fiBefore.Size(), fiAfter.Size())
+	}
+
+	if got := CaptureCachedFresh(dir); got.SHA != wantSHA {
+		t.Errorf("commit token collided across a same-tick commit:\n got  %q\n want %q\n"+
+			"(the branch-tip component is resting on mtime, not on the tip's bytes)", got.SHA, wantSHA)
+	}
+}
+
+// TestCaptureCachedFresh_MatchesCapture: the fresh variant must be observably
+// identical to the uncached Capture, including on a cache hit.
+func TestCaptureCachedFresh_MatchesCapture(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	want := Capture(dir)
+	if got := CaptureCachedFresh(dir); got != want {
+		t.Fatalf("CaptureCachedFresh != Capture\n got  %+v\n want %+v", got, want)
+	}
+	if got := CaptureCachedFresh(dir); got != want {
+		t.Fatalf("cached second call diverged: %+v", got)
+	}
+}
+
+// TestCaptureCachedFresh_HitsCacheNoSubprocess: the fix must not degenerate into
+// "no caching". Prime the cache, then remove `git` from PATH — a subprocess
+// Capture would then return a zero Info, so a non-zero result proves the second
+// call was served from the memo.
+func TestCaptureCachedFresh_HitsCacheNoSubprocess(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	primed := CaptureCachedFresh(dir)
+	if primed.SHA == "" {
+		t.Fatal("fixture degenerate: nothing primed")
+	}
+
+	t.Setenv("PATH", t.TempDir()) // no git on PATH
+	if live := Capture(dir); live.SHA != "" {
+		t.Skip("git still reachable without PATH; cannot prove the no-subprocess property here")
+	}
+	if got := CaptureCachedFresh(dir); got != primed {
+		t.Errorf("cache miss on an unchanged repo — the fresh variant is re-forking git every call:\n got  %+v\n want %+v", got, primed)
+	}
+}
+
+// TestCaptureCachedFresh_InvalidatesOnBranchSwitch: the fresh key must still
+// cover everything the HEAD-pointer key covered.
+func TestCaptureCachedFresh_InvalidatesOnBranchSwitch(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	if got := CaptureCachedFresh(dir); got.Ref != "main" {
+		t.Fatalf("initial Ref=%q, want main", got.Ref)
+	}
+	cmd := exec.Command("git", "checkout", "-b", "feature")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout: %v\n%s", err, out)
+	}
+	if got := CaptureCachedFresh(dir); got.Ref != "feature" {
+		t.Errorf("stale Ref after a branch switch: %q, want feature", got.Ref)
+	}
+}
+
+// TestCaptureCachedFresh_DetachedHead: with a detached HEAD the commit id lives
+// in HEAD's own bytes, so the key must still track it.
+func TestCaptureCachedFresh_DetachedHead(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+	first := CaptureCachedFresh(dir)
+
+	wantSHA := commitOnSameBranch(t, dir, "second")
+	if wantSHA == first.SHA {
+		t.Fatal("fixture degenerate: SHA did not advance")
+	}
+	// Detach onto the first commit.
+	cmd := exec.Command("git", "checkout", "--detach", "HEAD~1")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git checkout --detach: %v\n%s", err, out)
+	}
+	got := CaptureCachedFresh(dir)
+	if got.SHA != first.SHA {
+		t.Errorf("detached HEAD reported SHA %q, want %q", got.SHA, first.SHA)
+	}
+}
+
+// TestCaptureCachedFresh_NonGitDir: a non-git directory must behave exactly like
+// Capture (no panic, no cache).
+func TestCaptureCachedFresh_NonGitDir(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := t.TempDir()
+	if got, want := CaptureCachedFresh(dir), Capture(dir); got != want {
+		t.Fatalf("non-git dir: got %+v want %+v", got, want)
+	}
+	if got := CaptureCachedFresh(""); got != Capture("") {
+		t.Fatal("empty path diverged from Capture")
+	}
+}
+
+// TestCaptureCached_RefStillCachedCheaply: the ref-only key must NOT be widened.
+// #6060 removed a per-request git fork from StateDirForRepo by memoizing on the
+// HEAD pointer; making that key commit-sensitive would re-fork Capture after
+// every commit for a caller that only ever reads meta.Ref. This pins the split.
+func TestCaptureCached_RefStillCachedCheaply(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	primed := CaptureCached(dir)
+	if primed.Ref != "main" {
+		t.Fatalf("primed Ref=%q, want main", primed.Ref)
+	}
+	commitOnSameBranch(t, dir, "second")
+
+	t.Setenv("PATH", t.TempDir()) // no git on PATH
+	if live := Capture(dir); live.Ref != "" {
+		t.Skip("git still reachable without PATH; cannot prove the no-subprocess property here")
+	}
+	if got := CaptureCached(dir); got.Ref != "main" {
+		t.Errorf("CaptureCached re-forked after a same-branch commit — the cheap ref-only key regressed (got %+v)", got)
+	}
+}

--- a/internal/mcp/graph_generation_staleness_6080_test.go
+++ b/internal/mcp/graph_generation_staleness_6080_test.go
@@ -1,0 +1,501 @@
+// graph_generation_staleness_6080_test.go — issue #6080.
+//
+// #6060 made the reload gate re-run discovery when the repo was being served
+// from a NON-current REF. That is correct at ref granularity and blind one level
+// down: a plain same-branch reindex publishes graph.<gen+1>.fb, flips the
+// `current` pointer, and — by design (graph.GCStaleGens keeps the current gen
+// AND the one before it) — LEAVES graph.<gen>.fb on disk. The pinned lr.GraphFile
+// still stats fine with an unchanged mtime, so the fast path is taken and the
+// daemon keeps answering from generation N-1 with a success response.
+//
+// This is the ordinary edit-and-reindex event, and there is no git activity at
+// all between the two reloads below: HEAD, refs/heads/main and the ref state
+// directory are byte-for-byte identical. No gitmeta-keyed gate of ANY
+// granularity could observe this — which is also the evidence that #6080 and
+// #6079 are independent defects rather than one root cause.
+package mcp
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// genDocWithMarker returns a document whose only entity carries the given id, so
+// "which generation is being served" is answerable from the resident read path
+// rather than from a path string.
+func genDocWithMarker(marker string) *graph.Document {
+	pr := 0.5
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: marker, Name: marker, Kind: "Function", SourceFile: marker + ".go", StartLine: 1, PageRank: &pr},
+		},
+	}
+}
+
+// headStateFingerprint captures everything a git-derived cache key could
+// possibly observe about the repo's HEAD: the HEAD pointer's bytes, the branch
+// tip's bytes, and the resolved per-ref state directory. Used to PROVE the
+// reproduction below involves no git movement whatsoever.
+func headStateFingerprint(t *testing.T, repoDir string) string {
+	t.Helper()
+	head, err := os.ReadFile(filepath.Join(repoDir, ".git", "HEAD"))
+	if err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	tip, err := os.ReadFile(filepath.Join(repoDir, ".git", "refs", "heads", "main"))
+	if err != nil {
+		t.Fatalf("read refs/heads/main: %v", err)
+	}
+	return string(head) + "\x00" + string(tip) + "\x00" + daemon.StateDirForRepo(repoDir)
+}
+
+// TestReload_PicksUpNewGenerationOnSameBranchReindex is the #6080 regression.
+//
+// It drives a REAL same-branch reindex (fbwriter.WriteGraphGen — the production
+// publish path: write graph.<gen>.fb, flip `current`, GC older gens) through the
+// REAL reload gate, and asserts the served graph is the new generation.
+//
+// Non-vacuity is asserted explicitly, because the two ways this test could
+// silently prove nothing are (a) the generation never actually advancing and
+// (b) the ref moving, which the #6060 gate would already have caught:
+//   - the generation genuinely advanced (`current` names a different file);
+//   - generation N-1 is genuinely still on disk (otherwise the old fast-path
+//     stat would have failed and masked the defect);
+//   - the ref directory genuinely did NOT change;
+//   - HEAD and refs/heads/main are byte-identical across the reindex.
+func TestReload_PicksUpNewGenerationOnSameBranchReindex(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	// #6101: never let this test read the developer's real state directory.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+	if got := daemon.StateDirForRepo(repoDir); got != mainDir {
+		t.Fatalf("fixture degenerate: HEAD ref dir %s != refs/main dir %s", got, mainDir)
+	}
+	fpBefore := headStateFingerprint(t, repoDir)
+
+	// Generation 1 — the repo as first indexed.
+	gen1Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen1only"))
+	if err != nil {
+		t.Fatalf("publish gen 1: %v", err)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	lr := st.Group("test").Repos["r"]
+	if lr == nil {
+		t.Fatal("repo not loaded")
+	}
+	if lr.GraphFile != gen1Path {
+		t.Fatalf("initial discovery resolved %s, want %s", lr.GraphFile, gen1Path)
+	}
+	if _, ok := lr.getByIDOne("gen1only"); !ok {
+		t.Fatal("fixture degenerate: generation 1's entity is not served after the initial reload")
+	}
+
+	// ---- A plain same-branch reindex. No git activity of any kind. ----
+	gen2Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen2only"))
+	if err != nil {
+		t.Fatalf("publish gen 2: %v", err)
+	}
+
+	// Non-vacuity guard 1: the generation genuinely advanced.
+	if gen2Path == gen1Path {
+		t.Fatalf("vacuous: reindex reused the same generation file %s", gen1Path)
+	}
+	if got := graph.CurrentGraphPath(mainDir); got != gen2Path {
+		t.Fatalf("vacuous: `current` resolves to %s, want the new generation %s", got, gen2Path)
+	}
+	// Non-vacuity guard 2: generation N-1 is RETAINED (graph.GCStaleGens keeps
+	// current and current-1). If it had been GC'd, the old fast path's os.Stat
+	// would fail and fall through to discovery on its own — the defect would be
+	// invisible and this test would pass for the wrong reason.
+	if _, err := os.Stat(gen1Path); err != nil {
+		t.Fatalf("vacuous: generation N-1 (%s) was GC'd, so the stale stat could not have succeeded: %v", gen1Path, err)
+	}
+	// Non-vacuity guard 3: the REF did not move. This is what makes the defect
+	// distinct from #6060/#6078 rather than a re-run of them.
+	if got := daemon.StateDirForRepo(repoDir); got != mainDir {
+		t.Fatalf("vacuous: ref dir moved to %s — the #6060 gate would catch that already", got)
+	}
+	if fpAfter := headStateFingerprint(t, repoDir); fpAfter != fpBefore {
+		t.Fatalf("vacuous: git HEAD state changed across the reindex:\n before=%q\n after =%q", fpBefore, fpAfter)
+	}
+
+	// ---- The reload the daemon performs on its next poll. ----
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload after same-branch reindex: %v", err)
+	}
+
+	if lr.GraphFile != gen2Path {
+		t.Errorf("reload kept the superseded generation pinned:\n  lr.GraphFile: %s\n  want:         %s",
+			lr.GraphFile, gen2Path)
+	}
+	if _, ok := lr.getByIDOne("gen2only"); !ok {
+		t.Errorf("daemon is serving generation N-1: the new generation's entity %q is not visible\n"+
+			"after a same-branch reindex — a query for it returns 'not found' with a success response", "gen2only")
+	}
+	if _, ok := lr.getByIDOne("gen1only"); ok {
+		t.Errorf("daemon is serving generation N-1: the superseded generation's entity %q is still visible", "gen1only")
+	}
+}
+
+// TestReload_SameBranchReindexIsInvisibleToGitState is the independence
+// evidence for the "#6080 and #6079 are one defect" hypothesis, stated as an
+// executable assertion rather than an argument: across a full publish of a new
+// generation, EVERY git-observable input to gitmeta's cache key is unchanged.
+//
+// gitmeta.CaptureCached (#6079) keys on the HEAD pointer; a hypothetical
+// per-commit-correct key would additionally observe refs/heads/<branch>. Neither
+// moves here. Widening the gitmeta key — the #6079 fix — therefore cannot
+// detect a generation flip, and the two issues are independent.
+func TestReload_SameBranchReindexIsInvisibleToGitState(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+
+	stat := func(rel string) (int64, int64) {
+		t.Helper()
+		fi, err := os.Stat(filepath.Join(repoDir, ".git", rel))
+		if err != nil {
+			t.Fatalf("stat .git/%s: %v", rel, err)
+		}
+		return fi.ModTime().UnixNano(), fi.Size()
+	}
+
+	gen1Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("g1"))
+	if err != nil {
+		t.Fatalf("publish gen 1: %v", err)
+	}
+	headMt, headSz := stat("HEAD")
+	tipMt, tipSz := stat(filepath.Join("refs", "heads", "main"))
+
+	gen2Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("g2"))
+	if err != nil {
+		t.Fatalf("publish gen 2: %v", err)
+	}
+	// This test CARRIES the independence argument, so it must not lean on a
+	// sibling test to establish that a publish actually happened. If the second
+	// WriteGraphGen were a no-op, "git state did not change" would be trivially
+	// true and would prove nothing.
+	if gen2Path == gen1Path {
+		t.Fatalf("vacuous: no new generation was published (both %s)", gen1Path)
+	}
+	if got := graph.CurrentGraphPath(mainDir); got != gen2Path {
+		t.Fatalf("vacuous: `current` resolves to %s, want the new generation %s", got, gen2Path)
+	}
+
+	if mt, sz := stat("HEAD"); mt != headMt || sz != headSz {
+		t.Errorf("HEAD pointer moved across a reindex (%d/%d -> %d/%d)", headMt, headSz, mt, sz)
+	}
+	if mt, sz := stat(filepath.Join("refs", "heads", "main")); mt != tipMt || sz != tipSz {
+		t.Errorf("branch tip moved across a reindex (%d/%d -> %d/%d)", tipMt, tipSz, mt, sz)
+	}
+}
+
+// A same-branch reindex must not be masked by the mtime memo either: when the
+// resolved graph path CHANGES, lr.mtime describes a DIFFERENT file and is not a
+// valid freshness signal for the new one. Coarse filesystem timestamps can make
+// two generations written milliseconds apart compare equal, in which case the
+// `fileMtime.Equal(lr.mtime)` skip would decline to reparse and the daemon would
+// serve generation N-1 even with discovery corrected.
+//
+// The fixture forces the collision by stamping both generations with an
+// identical mtime, which is exactly the state a coarse-granularity filesystem
+// produces on its own.
+func TestReload_NewGenerationWithIdenticalMtimeStillReparses(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+
+	gen1Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen1only"))
+	if err != nil {
+		t.Fatalf("publish gen 1: %v", err)
+	}
+	fi1, err := os.Stat(gen1Path)
+	if err != nil {
+		t.Fatalf("stat gen 1: %v", err)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	lr := st.Group("test").Repos["r"]
+	if lr == nil {
+		t.Fatal("repo not loaded")
+	}
+
+	gen2Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen2only"))
+	if err != nil {
+		t.Fatalf("publish gen 2: %v", err)
+	}
+	// Simulate a coarse-granularity filesystem: both generations share an mtime.
+	if err := os.Chtimes(gen2Path, fi1.ModTime(), fi1.ModTime()); err != nil {
+		t.Fatalf("chtimes gen 2: %v", err)
+	}
+	fi2, err := os.Stat(gen2Path)
+	if err != nil {
+		t.Fatalf("stat gen 2: %v", err)
+	}
+	if !fi2.ModTime().Equal(fi1.ModTime()) {
+		t.Fatalf("fixture degenerate: mtimes differ (%v vs %v)", fi1.ModTime(), fi2.ModTime())
+	}
+	if gen2Path == gen1Path {
+		t.Fatal("vacuous: reindex reused the same generation file")
+	}
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if _, ok := lr.getByIDOne("gen2only"); !ok {
+		t.Errorf("mtime memo suppressed the reparse of a NEW generation file: %q not served", "gen2only")
+	}
+}
+
+// TestReload_PicksUpNewSegmentSetGenerationOnSameBranchReindex is the headline
+// #6080 scenario on the MULTI-SEGMENT layout, where a generation is a
+// graph.<gen>/ DIRECTORY rather than a graph.<gen>.fb file.
+//
+// This shape exercises two paths the single-file tests never reach:
+// findGraphFileInDir's segment-set branch (which resolves the gen dir and takes
+// its freshness from manifest.json), and hashGraphFile applied to a directory on
+// the pathChanged reparse. Cheap to cover because the flush threshold is
+// env-tunable, so a tiny document still produces a real segment set.
+func TestReload_PicksUpNewSegmentSetGenerationOnSameBranchReindex(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_STREAM_SEGMENTS", "1")
+	t.Setenv("GRAFEL_SEGMENT_BYTES", "1") // force segmentation of even a tiny doc
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+
+	gen1Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen1only"))
+	if err != nil {
+		t.Fatalf("publish gen 1: %v", err)
+	}
+	// Non-vacuity: this test only means something if the layout really is a
+	// segment set. If the writer took its single-file fast path, the single-file
+	// tests already cover what remains.
+	desc, dErr := graph.CurrentGraphDescriptor(mainDir)
+	if dErr != nil {
+		t.Fatalf("descriptor: %v", dErr)
+	}
+	if desc.Kind != graph.GraphSegmentSet {
+		t.Skipf("writer produced %v, not a segment set — cannot exercise the segment path here", desc.Kind)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	lr := st.Group("test").Repos["r"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatalf("segment-set graph not loaded (loadErr=%q)", func() string {
+			if lr == nil {
+				return "<no repo>"
+			}
+			return lr.loadErr
+		}())
+	}
+	if _, ok := lr.getByIDOne("gen1only"); !ok {
+		t.Fatal("fixture degenerate: generation 1's entity is not served after the initial reload")
+	}
+
+	// Same-branch reindex, still segmented.
+	gen2Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen2only"))
+	if err != nil {
+		t.Fatalf("publish gen 2: %v", err)
+	}
+	if gen2Path == gen1Path {
+		t.Fatal("vacuous: no new generation was published")
+	}
+	if _, err := os.Stat(gen1Path); err != nil {
+		t.Fatalf("vacuous: gen N-1 was GC'd, so the stale stat could not have succeeded: %v", err)
+	}
+	if got := daemon.StateDirForRepo(repoDir); got != mainDir {
+		t.Fatalf("vacuous: ref dir moved to %s", got)
+	}
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload after same-branch reindex: %v", err)
+	}
+	if lr.GraphFile != gen2Path {
+		t.Errorf("reload kept the superseded segment-set generation pinned:\n  lr.GraphFile: %s\n  want:         %s",
+			lr.GraphFile, gen2Path)
+	}
+	if _, ok := lr.getByIDOne("gen2only"); !ok {
+		t.Error("daemon is serving generation N-1 on the segment-set layout: \"gen2only\" is not visible")
+	}
+	if _, ok := lr.getByIDOne("gen1only"); ok {
+		t.Error("daemon is serving generation N-1 on the segment-set layout: \"gen1only\" is still visible")
+	}
+}
+
+// TestReload_UnreadablePointerFallsThroughAndFlagsTheRepo pins the LIMIT of the
+// #6080 gate, so the contract in state.go is pinned by execution rather than by
+// prose. Read this before strengthening that comment again.
+//
+// When the `current` pointer cannot be read, the gate declines the fast path and
+// falls through to full discovery — that much is real, and this test kills the
+// mutant that serves the pinned generation instead. But the DESTINATION is not
+// safe: when full discovery also comes up empty, reloadAllLocked sets
+// lr.loadErr and `continue`s WITHOUT clearing lr.Doc, so the previously-resident
+// generation keeps being served and the newer one on disk stays invisible.
+//
+// That is NOT a regression — the pre-#6080 gate stat'd the pinned file and
+// served exactly the same stale graph on the same trigger — and it is NOT fixed
+// here. Clearing lr.Doc is the correct destination (tools.go's `unavailable`
+// list keys on Doc==nil plus loadErr, which is precisely the "report
+// unavailable" shape this wants) but there is no `lr.Doc = nil` anywhere in this
+// package today, and introducing one is unsafe while State.Group() hands out the
+// group and drops s.mu: readers nil-check r.Doc and dereference it later, so a
+// concurrent nil would convert a stale answer into a nil-deref panic across the
+// whole read surface. The locking hole has to close first.
+func TestReload_UnreadablePointerFallsThroughAndFlagsTheRepo(t *testing.T) {
+	if os.Geteuid() == 0 {
+		t.Skip("running as root: chmod 000 does not prevent reads")
+	}
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+
+	gen1Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen1only"))
+	if err != nil {
+		t.Fatalf("publish gen 1: %v", err)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	lr := st.Group("test").Repos["r"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatal("fixture degenerate: repo not loaded")
+	}
+	if lr.loadErr != "" {
+		t.Fatalf("fixture degenerate: repo already flagged before the fault (%q)", lr.loadErr)
+	}
+
+	// A newer generation is published, then the pointer becomes unreadable.
+	gen2Path, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen2only"))
+	if err != nil {
+		t.Fatalf("publish gen 2: %v", err)
+	}
+	if gen2Path == gen1Path {
+		t.Fatal("vacuous: no new generation was published")
+	}
+	// Non-vacuity: the pinned generation must still exist, or the old gate's
+	// os.Stat would fail on its own and the mutant would be unkillable.
+	if _, err := os.Stat(gen1Path); err != nil {
+		t.Fatalf("vacuous: gen N-1 is gone, so the pinned-stat mutant cannot be distinguished: %v", err)
+	}
+	pointer := filepath.Join(mainDir, "current")
+	if err := os.Chmod(pointer, 0o000); err != nil {
+		t.Fatalf("chmod current: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(pointer, 0o644) })
+	if _, err := os.ReadFile(pointer); err == nil {
+		t.Skip("current is still readable after chmod 000; cannot stage the fault here")
+	}
+
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("reload with unreadable pointer: %v", err)
+	}
+
+	// THE ASSERTION THAT MATTERS: the gate did NOT take the fast path on an
+	// unverifiable pointer. A mutant that serves the pinned generation leaves
+	// loadErr empty and this fails.
+	if lr.loadErr == "" {
+		t.Error("gate served the pinned generation on an unverifiable `current` pointer: " +
+			"the repo was not flagged, so nothing anywhere records that freshness is unknown")
+	}
+
+	// CHARACTERIZATION of the known gap, asserted so it cannot change silently.
+	// If a later change clears lr.Doc / marks the repo unservable, this block is
+	// the one to delete — and the comment in state.go must be strengthened with it.
+	if lr.Doc == nil {
+		t.Error("lr.Doc was cleared — the known gap this test documents has been closed; " +
+			"update the #6080 contract comment in state.go and delete this block")
+	} else if _, ok := lr.getByIDOne("gen1only"); !ok {
+		t.Error("expected the superseded generation to still be resident (documented gap)")
+	}
+}
+
+// The freshness gate must not regress the #6060 ref-staleness fix, and must not
+// break the legacy flat graph.fb layout (no `current` pointer at all).
+func TestReload_FlatLegacyGraphStillServed(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+	writeGraphInto(t, mainDir, genDocWithMarker("flat"))
+	if _, err := os.Stat(filepath.Join(mainDir, graph.CurrentPointerName)); err == nil {
+		t.Fatal("fixture degenerate: legacy flat layout must have no `current` pointer")
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	lr := st.Group("test").Repos["r"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatalf("legacy flat graph.fb not loaded (loadErr=%q)", func() string {
+			if lr == nil {
+				return "<no repo>"
+			}
+			return lr.loadErr
+		}())
+	}
+	// A second reload must keep serving it (the gate must not evict a layout it
+	// cannot find a generation pointer for).
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("second reload: %v", err)
+	}
+	if _, ok := lr.getByIDOne("flat"); !ok {
+		t.Error("legacy flat graph.fb stopped being served after a second reload")
+	}
+}

--- a/internal/mcp/resolvecwd_sha_6079_test.go
+++ b/internal/mcp/resolvecwd_sha_6079_test.go
@@ -1,0 +1,61 @@
+// resolvecwd_sha_6079_test.go — issue #6079, at the consumer the issue names.
+//
+// The gitmeta-level regression lives in internal/gitmeta/cache_sha_6079_test.go.
+// This one drives the actual serving surface: ResolveCWD is what grafel_whoami
+// reports indexed_sha from, so a stale gitmeta memo becomes a confidently wrong
+// commit id in an MCP response.
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// TestResolveCWD_SHAIsFreshAfterSameBranchCommit: commit on the branch you are
+// already on, then ask again. The reported SHA must be the new commit.
+func TestResolveCWD_SHAIsFreshAfterSameBranchCommit(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	// #6101: never read the developer's real state directory.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+
+	first := ResolveCWD(st, repoDir)
+	if first.SHA == "" {
+		t.Fatalf("fixture degenerate: no SHA resolved (source=%q group=%q)", first.Source, first.Group)
+	}
+	if first.Ref != "main" {
+		t.Fatalf("fixture degenerate: Ref=%q, want main", first.Ref)
+	}
+
+	// A plain same-branch commit: refs/heads/main moves, HEAD does not.
+	//
+	// The non-vacuity guard MUST straddle the commit. An earlier version of this
+	// test read the HEAD bytes AFTER committing and compared them to a re-read
+	// after ResolveCWD, which only proved HEAD stayed put across the lookup —
+	// inert, since nothing in that window could have moved it. What has to be
+	// asserted is that the COMMIT left the HEAD pointer untouched, because that is
+	// the whole premise of #6079.
+	checkHead := assertHeadPointerUnmoved(t, repoDir)
+	wantSHA := commitOnBranch(t, repoDir, "second")
+	checkHead()
+
+	if wantSHA == "" || wantSHA == first.SHA {
+		t.Fatalf("fixture degenerate: SHA did not advance (%q -> %q)", first.SHA, wantSHA)
+	}
+
+	got := ResolveCWD(st, repoDir)
+	if got.Ref != "main" {
+		t.Fatalf("vacuous: Ref moved to %q — the pre-existing key would have caught that", got.Ref)
+	}
+	if got.SHA != wantSHA {
+		t.Errorf("grafel_whoami would report a stale commit after a same-branch commit:\n got  %q\n want %q",
+			got.SHA, wantSHA)
+	}
+}

--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -433,7 +433,7 @@ func ResolveCWD(s *State, cwd string) CWDResolution {
 	s.mu.Unlock()
 	if wl != nil {
 		// Walk up to the git toplevel for this cwd, then look up that path.
-		wtMeta := gitmeta.CaptureCached(abs)
+		wtMeta := gitmeta.CaptureCachedFresh(abs)
 		if wtMeta.IsWorktree && wtMeta.TopLevel != "" {
 			wtTop := filepath.Clean(wtMeta.TopLevel)
 			if gname, slug, branch := wl.LookupPath(wtTop); gname != "" {
@@ -454,7 +454,7 @@ func ResolveCWD(s *State, cwd string) CWDResolution {
 	if group != "" {
 		// Determine which repo slug contains cwd (longest-prefix match).
 		slug, repoPath := repoSlugForCWD(s, group, abs)
-		meta := gitmeta.CaptureCached(repoPath)
+		meta := gitmeta.CaptureCachedFresh(repoPath)
 		// M3 (#2180): if the matched repo has declared modules, determine which
 		// module sub-path cwd is inside.
 		modSlug := moduleSlugForCWD(s, group, slug, repoPath, abs)
@@ -477,7 +477,7 @@ func ResolveCWD(s *State, cwd string) CWDResolution {
 		return CWDResolution{Source: "none"}
 	}
 	// Ask git for the toplevel of whatever repo cwd is inside.
-	meta := gitmeta.CaptureCached(abs)
+	meta := gitmeta.CaptureCachedFresh(abs)
 	if meta.TopLevel == "" || !meta.IsWorktree {
 		// Not inside a git repo at all, or not a linked worktree.
 		return CWDResolution{Source: "none"}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1475,13 +1475,58 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 			// regardless: StateDirForRepo memoizes the HEAD capture (see
 			// daemon.StateDirForRepo).
 			//
-			// What this gate fixes is REF staleness, and only that. It does not make
-			// the resident graph current in general: the pinned path can still name a
-			// superseded GENERATION inside the right ref dir, because
-			// graph.GCStaleGens retains gen N-1, so a same-branch reindex leaves the
-			// old generation on disk and this stat keeps succeeding against it with an
-			// unchanged mtime. Pre-existing and tracked separately — do not read the
-			// gate as a freshness guarantee beyond the ref.
+			// #6080: the ref gate above was correct at REF granularity and blind one
+			// level down. Stat'ing the pinned lr.GraphFile is not a freshness check,
+			// because a same-branch reindex publishes graph.<gen+1>.fb, flips the
+			// `current` pointer, and DELIBERATELY retains gen N-1 (graph.GCStaleGens
+			// keeps the current generation and the one before it, so an in-flight mmap
+			// is never unlinked underneath a reader). The old generation therefore
+			// keeps stat'ing successfully with an unchanged mtime, the fast path is
+			// taken, and the daemon answers every query from the superseded graph —
+			// with a success response — until the NEXT reindex finally GCs it.
+			//
+			// The fix keeps the shape of the #6060 gate (resolve the current-ref dir
+			// via the memoized HeadToken — no git subprocess) and then re-resolves the
+			// ACTIVE ARTIFACT inside that dir with the very resolver full discovery
+			// uses, daemon.FindGraphFileInDir. That reads the `current` pointer and
+			// stats the resolved generation: a couple of syscalls on a tiny file, no
+			// fork. The expensive part of discovery — StateDirForRepo's git capture,
+			// which is what #2550 and #6060 exist to avoid — is still skipped.
+			//
+			// #6080 asked for this to be measured rather than assumed. On an M2 Pro
+			// under load (internal/daemon's BenchmarkGate_*): the old pinned os.Stat
+			// ~1.6us, this ~25us, and the memoized StateDirForRepo this same loop
+			// already calls per repo ~5.6us — so the gate is a few tens of
+			// microseconds per repo per reload, against the ~50-200ms git fork the
+			// #2550 short-circuit exists to eliminate. Reading <dir>/current is the
+			// dominant term, which is why findGraphFileInDir was changed to read it
+			// ONCE (it used to read it twice, and cost ~45us).
+			//
+			// WHAT THIS DOES AND DOES NOT GUARANTEE — do not restate it more
+			// strongly than this. If the pointer is missing, unreadable, or names a
+			// generation that is not on disk, the resolver returns "" (or the legacy
+			// flat path) and the fast path is DECLINED: we fall through to full
+			// discovery rather than serving the pinned file on trust. That part is
+			// real, and TestReload_UnreadablePointerFallsThroughAndFlagsTheRepo pins
+			// it.
+			//
+			// But the fall-through DESTINATION is not itself safe. If full discovery
+			// also finds nothing, the graphPath=="" branch below sets lr.loadErr and
+			// `continue`s WITHOUT clearing lr.Doc — so the previously-resident
+			// generation keeps being served and a newer one on disk stays invisible.
+			// This gate is therefore "re-resolves the active generation", NOT "never
+			// serves a stale graph".
+			//
+			// That gap is pre-existing (the old gate stat'd the pinned file and
+			// served the same stale graph on the same trigger) and is deliberately
+			// NOT closed here. The correct destination already exists — tools.go's
+			// `unavailable` list keys on Doc==nil plus loadErr, which is exactly the
+			// "report unavailable" shape — but reaching it needs `lr.Doc = nil`,
+			// which appears nowhere in this package and is unsafe while State.Group()
+			// returns the group and drops s.mu: readers nil-check r.Doc and
+			// dereference it later (see tools.go's repo-stats loop), so a concurrent
+			// nil turns a stale answer into a nil-deref panic across the whole read
+			// surface. Close that locking hole first, then clear the Doc.
 			var graphPath string
 			var modtimeNs int64
 			// lr.Path, not rEntry.Path: the memo has one slot and applyFlowOverlay
@@ -1489,12 +1534,12 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 			// callers invalidate each other every call. They are the same value today
 			// (lr.Path is assigned from rEntry.Path at construction and never
 			// reassigned) — this keeps them the same value by construction.
-			if ok && lr.GraphFile != "" && filepath.Dir(lr.GraphFile) == lr.currentRefDirLocked(lr.Path) {
-				if fi, statErr := os.Stat(lr.GraphFile); statErr == nil {
-					graphPath = lr.GraphFile
-					modtimeNs = fi.ModTime().UnixNano()
+			if ok && lr.GraphFile != "" {
+				if refDir := lr.currentRefDirLocked(lr.Path); filepath.Dir(lr.GraphFile) == refDir {
+					graphPath, modtimeNs = daemon.FindGraphFileInDir(refDir)
 				}
-				// If stat failed (file removed) fall through to full discovery below.
+				// A miss (wrong ref dir, or no resolvable graph in it) falls through
+				// to full discovery below.
 			}
 			if graphPath == "" {
 				// Use FindGraphFileAnyRef to discover graph.fb (preferred) or
@@ -1527,6 +1572,15 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 				lr = &LoadedRepo{Repo: rName, Path: rEntry.Path, GraphFile: graphPath}
 				grp.Repos[rName] = lr
 			}
+			// #6080: whether discovery resolved a DIFFERENT artifact than the one
+			// currently resident. lr.mtime describes the file lr.GraphFile named, so
+			// once the path moves (a new generation, or a new ref dir) that memo is
+			// about a different file and is not a valid freshness signal for this
+			// one. Two generations published within one filesystem timestamp tick
+			// compare equal, which would otherwise let the mtime skip below decline
+			// the reparse and keep serving the superseded graph even with discovery
+			// corrected. Computed BEFORE the assignment below.
+			pathChanged := lr.GraphFile != graphPath
 			// Update GraphFile in case .fb appeared after initial load.
 			lr.GraphFile = graphPath
 			fileMtime := time.Unix(0, modtimeNs)
@@ -1537,7 +1591,7 @@ func (s *State) reloadAllLocked() (int, bool, error) {
 			// below must all read from the SAME dir as the parsed Document, or a
 			// fallback-discovered graph would be paired with a stale/empty sidecar.
 			stateDir := filepath.Dir(lr.GraphFile)
-			if !(fileMtime.Equal(lr.mtime) && lr.Doc != nil) {
+			if pathChanged || !(fileMtime.Equal(lr.mtime) && lr.Doc != nil) {
 				// #3377 content-hash skip: the live indexer rewrites graph.fb on
 				// every reindex, bumping mtime even when the bytes are identical
 				// (no-op reindex / touch / unchanged re-emit). Hash the file
@@ -3192,15 +3246,18 @@ func applyDescriptionOverlay(grp *LoadedGroup) {
 // the same lost write in the DEFAULT population. That gate is fixed in the same
 // change; this function is only sound because of it.
 //
-// The guarantee that gate delivers is freshness at REF granularity, and no
-// further. Within a ref directory lr.GraphFile can still name a superseded
-// GENERATION: graph.GCStaleGens (internal/graph/genpath.go) deliberately retains
-// gen N-1, so a plain same-branch reindex writes gen N+1 and flips `current`
-// while gen N stays on disk — the gate passes (same directory), the os.Stat
-// succeeds, the mtime is unchanged, and the daemon keeps serving the older
-// generation. That is pre-existing, predates this change, and is tracked
-// separately. It does not affect the pairing argument above: the ref DIRECTORY
-// is right either way, and the directory is all this function resolves.
+// That gate originally delivered freshness at REF granularity and no further:
+// within a ref directory lr.GraphFile could still name a superseded GENERATION,
+// because graph.GCStaleGens (internal/graph/genpath.go) deliberately retains gen
+// N-1, so a plain same-branch reindex wrote gen N+1 and flipped `current` while
+// gen N stayed on disk — same directory, successful os.Stat, unchanged mtime,
+// and the daemon kept serving the older generation. That was #6080, and it is
+// now fixed in the same gate: the fast path re-resolves the active artifact
+// inside the (cheaply known) ref dir via daemon.FindGraphFileInDir, so
+// lr.GraphFile tracks the `current` pointer as well as the ref.
+//
+// It never affected the pairing argument above either way: the ref DIRECTORY is
+// right in both generations, and the directory is all this function resolves.
 //
 // A repo with no discovered graph file returns "". Callers MUST treat that as
 // "no sidecar directory" and skip — it is NOT a harmless miss, because

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -467,7 +467,7 @@ func groupIndexedRefSHA(s *State, groupName string) (ref, sha string) {
 			}
 			// Graph predates the IndexedSHA field — fall through to gitmeta.
 			if lr.Path != "" {
-				meta := gitmeta.CaptureCached(lr.Path)
+				meta := gitmeta.CaptureCachedFresh(lr.Path)
 				return meta.Ref, meta.SHA
 			}
 		}
@@ -490,7 +490,7 @@ func groupIndexedRefSHA(s *State, groupName string) (ref, sha string) {
 		if repo.Path == "" {
 			continue
 		}
-		meta := gitmeta.CaptureCached(repo.Path)
+		meta := gitmeta.CaptureCachedFresh(repo.Path)
 		return meta.Ref, meta.SHA
 	}
 	return "", ""

--- a/internal/mcp/whoami_sha_6079_test.go
+++ b/internal/mcp/whoami_sha_6079_test.go
@@ -1,0 +1,187 @@
+// whoami_sha_6079_test.go — issue #6079 at its HEADLINE symptom.
+//
+// groupIndexedRefSHA is what grafel_whoami reports as `indexed_sha` when the
+// caller passes an explicit group=. It is the field a user actually looks at to
+// answer "which commit is the graph I am querying built from", so a stale SHA
+// here is the observable form of this defect — and it was the one surface with
+// no test: reverting either of its two gitmeta call sites to the
+// HEAD-pointer-keyed CaptureCached left the whole internal/mcp suite green.
+//
+// Both call sites are covered below, because they are reached under different
+// preconditions and a fix to one does not exercise the other.
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// commitOnBranch adds a commit to repoDir's CURRENT branch (no checkout, no
+// branch creation) and returns the resulting abbreviated SHA. This is the event
+// the HEAD-pointer cache key cannot see.
+func commitOnBranch(t *testing.T, repoDir, content string) string {
+	t.Helper()
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repoDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "f.txt"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", content)
+	return gitmeta.Capture(repoDir).SHA
+}
+
+// assertHeadPointerUnmoved is the non-vacuity guard shared by both cases: it
+// captures the HEAD pointer's exact bytes BEFORE the commit and returns a
+// checker to run after, so "the commit did not rewrite HEAD" is asserted about
+// the commit itself rather than about some later interval. Without this the test
+// could pass for the wrong reason — a branch change would invalidate the old key
+// on its own and prove nothing about #6079.
+func assertHeadPointerUnmoved(t *testing.T, repoDir string) func() {
+	t.Helper()
+	headPath := filepath.Join(repoDir, ".git", "HEAD")
+	before, err := os.ReadFile(headPath)
+	if err != nil {
+		t.Fatalf("read HEAD: %v", err)
+	}
+	fiBefore, err := os.Stat(headPath)
+	if err != nil {
+		t.Fatalf("stat HEAD: %v", err)
+	}
+	return func() {
+		t.Helper()
+		after, err := os.ReadFile(headPath)
+		if err != nil {
+			t.Fatalf("read HEAD after: %v", err)
+		}
+		fiAfter, err := os.Stat(headPath)
+		if err != nil {
+			t.Fatalf("stat HEAD after: %v", err)
+		}
+		if string(after) != string(before) {
+			t.Fatalf("vacuous: the commit rewrote HEAD (%q -> %q) — the pre-existing key would have caught that", before, after)
+		}
+		if !fiAfter.ModTime().Equal(fiBefore.ModTime()) || fiAfter.Size() != fiBefore.Size() {
+			t.Fatalf("vacuous: the commit moved the HEAD pointer's mtime/size (%v/%d -> %v/%d)",
+				fiBefore.ModTime(), fiBefore.Size(), fiAfter.ModTime(), fiAfter.Size())
+		}
+	}
+}
+
+// TestWhoamiIndexedSHA_FreshAfterSameBranchCommit_LoadedRepo covers
+// tools.go's RESIDENT-GRAPH path: a repo whose graph predates the IndexedSHA
+// field (Doc.IndexedSHA == "") falls through to gitmeta, which is where the
+// stale key bit.
+func TestWhoamiIndexedSHA_FreshAfterSameBranchCommit_LoadedRepo(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	// #6101: never read the developer's real state directory.
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	// genDocWithMarker leaves IndexedRef/IndexedSHA empty, which is exactly the
+	// pre-#2088 graph shape that routes groupIndexedRefSHA to gitmeta.
+	if _, err := fbwriter.WriteGraphGen(daemon.StateDirForRepoRef(repoDir, "main"), genDocWithMarker("e")); err != nil {
+		t.Fatalf("publish graph: %v", err)
+	}
+
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	lr := st.Group("test").Repos["r"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatal("fixture degenerate: repo not loaded")
+	}
+	if lr.Doc.IndexedSHA != "" {
+		t.Fatalf("fixture degenerate: Doc.IndexedSHA=%q, so the gitmeta path is never reached", lr.Doc.IndexedSHA)
+	}
+
+	_, firstSHA := groupIndexedRefSHA(st, "test")
+	if firstSHA == "" {
+		t.Fatal("fixture degenerate: no SHA reported before the commit")
+	}
+
+	checkHead := assertHeadPointerUnmoved(t, repoDir)
+	wantSHA := commitOnBranch(t, repoDir, "second")
+	checkHead()
+	if wantSHA == "" || wantSHA == firstSHA {
+		t.Fatalf("fixture degenerate: SHA did not advance (%q -> %q)", firstSHA, wantSHA)
+	}
+
+	gotRef, gotSHA := groupIndexedRefSHA(st, "test")
+	if gotRef != "main" {
+		t.Fatalf("vacuous: ref moved to %q — the branch was supposed to stay put", gotRef)
+	}
+	if gotSHA != wantSHA {
+		t.Errorf("grafel_whoami would report a stale indexed_sha after a same-branch commit:\n got  %q\n want %q",
+			gotSHA, wantSHA)
+	}
+}
+
+// TestWhoamiIndexedSHA_FreshAfterSameBranchCommit_RegistryFallback covers
+// tools.go's REGISTRY-FALLBACK path, taken when the group has no repo with a
+// resident Doc (e.g. the first whoami before any graph is read into memory).
+// It is a separate gitmeta call site and was equally unpinned.
+func TestWhoamiIndexedSHA_FreshAfterSameBranchCommit_RegistryFallback(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	// Deliberately NO graph on disk: every repo stays Doc==nil, so
+	// groupIndexedRefSHA falls past the resident-graph loop to the registry.
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+
+	if lg := st.Group("test"); lg != nil {
+		for slug, lr := range lg.Repos {
+			if lr != nil && lr.Doc != nil {
+				t.Fatalf("fixture degenerate: repo %q has a resident Doc, so the registry fallback is not reached", slug)
+			}
+		}
+	}
+
+	_, firstSHA := groupIndexedRefSHA(st, "test")
+	if firstSHA == "" {
+		t.Fatal("fixture degenerate: no SHA reported before the commit")
+	}
+
+	checkHead := assertHeadPointerUnmoved(t, repoDir)
+	wantSHA := commitOnBranch(t, repoDir, "second")
+	checkHead()
+	if wantSHA == firstSHA {
+		t.Fatalf("fixture degenerate: SHA did not advance (%q)", firstSHA)
+	}
+
+	gotRef, gotSHA := groupIndexedRefSHA(st, "test")
+	if gotRef != "main" {
+		t.Fatalf("vacuous: ref moved to %q", gotRef)
+	}
+	if gotSHA != wantSHA {
+		t.Errorf("grafel_whoami registry fallback would report a stale indexed_sha:\n got  %q\n want %q",
+			gotSHA, wantSHA)
+	}
+}


### PR DESCRIPTION
After a reindex on the same branch, the daemon kept serving **generation N-1** — no error, no indication. MCP callers got confidently stale answers.

## Root cause

The fast-path freshness gate (`internal/mcp/state.go:1492`) was:

```go
if ok && lr.GraphFile != "" && filepath.Dir(lr.GraphFile) == lr.currentRefDirLocked(lr.Path)
```

followed by a bare `os.Stat(lr.GraphFile)`. **The key is the ref directory path.** It captures nothing about which generation is active inside that directory, so a generation flip within one ref is invisible to it.

The correct oracle already existed — `daemon.findGraphFileInDir` reads the `current` pointer via `CurrentGraphDescriptor` — but the fast path short-circuited before reaching it.

The code's own comment conceded this before the fix ("the pinned path can still name a superseded GENERATION… do not read the gate as a freshness guarantee beyond the ref"). That is agreement, not evidence, so it was reproduced by execution: `TestReload_PicksUpNewGenerationOnSameBranchReindex` failed with `lr.GraphFile` still on `graph.1.fb` while `current` named `graph.2.fb`, and a gen-2-only entity returning not-found.

Non-vacuity guards all asserted: the generation advanced, gen N-1 was still on disk, the ref dir was unchanged, and HEAD plus tip were byte-identical.

## A second, independent defect found while fixing it

`lr.mtime` is a memo describing the file `lr.GraphFile` **named when it was recorded**. Once the path moves, it describes a different file — so two generations sharing one filesystem timestamp tick would let the mtime skip decline the reparse even with discovery corrected.

Correcting the gate alone was therefore **not sufficient**. A `pathChanged` force-reparse closes it, and the guard is independently load-bearing: reverting only `pathChanged` reds the mtime test on its own.

This hazard also affects the #6078/#6060 ref fix — a ref change resolves a new path whose mtime may coincidentally match. That was never filed; it is now **#6111**.

## #6079 is a separate defect — the shared-root-cause hypothesis was refuted by measurement

Both issues share a *shape* — a key that identifies ref **identity** rather than ref **state** — and nothing else.

`TestReload_SameBranchReindexIsInvisibleToGitState` asserts that across a full generation publish, `HEAD` **and** `refs/heads/main` are unchanged in both mtime and size. So **no gitmeta-keyed gate at any granularity** — including a hypothetical per-commit-perfect one — could detect a generation flip. Fixing #6079 could never have fixed #6080.

The converse holds too: #6080's oracle is grafel's own `current` pointer, which says nothing about commits. Different packages, different oracles, disjoint fixes.

#6079's key is `headKey{path, mtime, size}` of `<gitdir>/HEAD` (`internal/gitmeta/cache.go:42-46`). Verified empirically on a scratch repo: across a same-branch commit, `HEAD` stayed `1785770463/21` while `refs/heads/main` moved `…463 → …465`.

Fixed by splitting rather than widening: `CaptureCached` keeps the cheap HEAD key for `StateDirForRepo`/engineplane (`.Ref`-only, hot path), and a new `CaptureCachedFresh` adds a commit token — HEAD bytes plus loose-tip stat plus packed-refs stat — backing the five SHA consumers in `internal/mcp`. It still memoizes, pinned by a no-git-on-PATH test. The misleading comment is replaced with a per-field freshness contract.

## Fall-through behaviour — stated precisely

A missing, unreadable, or dangling `current` pointer yields **no fast-path answer** and falls through to full discovery.

That is weaker than "fails toward freshness", and the distinction matters — see the review findings below. When full discovery *also* comes up empty, the resident generation continues to be served. This change re-resolves the active generation; it does not guarantee a stale graph is never served.

`StateDirForRepo`'s git capture is still skipped on this path, so #2550 and #6060 are not regressed.

## Cost — measured, not assumed

`internal/daemon/BenchmarkGate_*` on an M2 Pro under load:

| | |
|---|---|
| old pinned `os.Stat` | 1.6 µs |
| **new gate** | **24.6 µs** |
| memoized `StateDirForRepo`, already called per repo in the same loop | 5.6 µs |
| the git fork the short-circuit exists to avoid | ~50–200 ms |

The first measurement was 45 µs. Profiling showed the `<dir>/current` read (22 µs) dominates and that `findGraphFileInDir` was reading it **twice** — `CurrentGraphDescriptor` then `CurrentGraphPath`. It now reads once, which also makes the slow discovery path roughly 2× cheaper.

## Red-then-green

Every fix confirmed red under a targeted revert:

- revert the gate → generation test and mtime test both fail
- keep the gate, drop only `pathChanged` → mtime test fails alone
- revert `routing.go` to `CaptureCached` → `TestResolveCWD_SHAIsFresh` fails with the previous commit's SHA
- stub `CaptureCachedFresh` to delegate → exactly one failure, the SHA test

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. At `-count=1 -p 1`, sequentially:

| package | exit | skips |
|---|---|---|
| `./internal/gitmeta/` | 0 | **0** |
| `./internal/daemon/...` (14 pkgs) | 0 | 10 |
| `./internal/mcp/` | 0 | 8 |
| `./cmd/grafel/` + `./internal/graph/...` | 0 | **0** |

`cmd/grafel` and `internal/graph/...` were run beyond the stated floor because `findGraphFileInDir` is shared and was refactored.

## Review findings addressed

**The `grafel_whoami` `indexed_sha` field — the one place a user actually observes #6079 — had no test.** Reverting `groupIndexedRefSHA` to the stale-prone call left the entire `internal/mcp` suite green. Now covered at both call sites separately, because they sit behind different preconditions: the resident-graph path is reached only when `lr.Doc.IndexedSHA == ""` (pre-#2088 graph shape), the registry-fallback path only when no repo has a resident `Doc`. Both are asserted in their fixtures so neither can silently stop being reached. Mutation kills are disjoint.

**The freshness contract was stated more strongly than the code delivers, and the comment is corrected rather than the behaviour.** The fall-through to full discovery happens, but when discovery also comes up empty the loop sets `loadErr` and does **not** clear `lr.Doc` — so the resident generation keeps being served. Reproduced two ways, including an unreadable `current` while a newer generation sits on disk.

Clearing `lr.Doc` was considered and **rejected on evidence**: there is no `lr.Doc = nil` anywhere in `internal/mcp`, and `tools.go`'s repo-stats loop is `if r.Doc == nil { continue }` followed by `r.Doc.Communities` — the exact check-then-deref pattern that would panic under the unlocked-reader hazard below. Converting a stale answer into a nil-deref panic across the whole read surface is the worse trade, and it is not safe to make until `State.Group()` stops dropping `s.mu`.

This is **not a regression** — the old gate stat'd the pinned file and served the same stale graph. The comment now says what happens ("re-resolves the active generation", not "never serves a stale graph"), with the blocked follow-up and its ordering — close the locking hole, then clear the Doc — recorded in the code.

`TestReload_UnreadablePointerFallsThroughAndFlagsTheRepo` pins both halves and kills the surviving mutation (reimplementing the pinned-file fallback reds it on `loadErr == ""`). It characterizes the retained-`Doc` gap with a self-destructing assertion: if someone later clears `lr.Doc`, the test fails and tells them to strengthen the comment and delete the block.

**`commitToken` now compares the loose tip by content, not by stat.** The comment claimed "its mtime/size advance on every commit" — size does not, a loose ref is always 41 bytes, so that component discriminated on mtime alone and two commits in one filesystem tick shared a token. `TestCaptureCachedFresh_TipTokenIsContentNotMtime` forces the collision via `Chtimes` and reds against the stat-based variant, with a guard asserting size really is constant so it cannot pass for the wrong reason. `packed-refs` stays stat-keyed, where size does vary.

**Two test guards that were inert are now real.** The refutation test captures both `WriteGraphGen` paths and asserts `gen2Path != gen1Path` and that `current` flipped — it carries a public argument, so it establishes its own non-vacuity. And `resolvecwd_sha_6079_test.go` read `headBefore` *after* the commit, proving only that HEAD did not move across `ResolveCWD`; replaced with a shared helper that straddles the commit and checks bytes, mtime and size.

## Segment-set coverage

All the original tests exercised single-file generations. `GRAFEL_SEGMENT_BYTES` makes the threshold tunable, so a tiny fixture yields a real segment set: `TestReload_PicksUpNewSegmentSetGenerationOnSameBranchReindex` runs the headline scenario on the `graph.<gen>/` directory layout, exercising `findGraphFileInDir`'s segment branch and `hashGraphFile` against a gen *directory* on the `pathChanged` path. It kills the old-gate mutant, and skips loudly rather than passing vacuously if the writer ever takes its single-file fast path.

## Recorded, not fixed

`State.Group()` returns the `*LoadedGroup` and drops `s.mu`, so readers dereference `lr.Doc` unlocked while `reloadAllLocked` swaps it. Pre-existing — but this change **increases exposure**, because a same-branch reindex now swaps `Doc` where it previously did not. It is also the blocking dependency for the unavailability fix above, so it has a concrete consumer waiting on it. Filed separately.

Independently adversarially reviewed (APPROVE), with the findings above addressed on top.

Closes #6080
Closes #6079
Refs #6111, #6078, #6060, #2550
