### PR TITLE
perf(#5995): stream grafel status instead of materialising every graph — TotalAlloc 192MB to 3MB

### DIFF
--- a/internal/cli/status_heap_5995_test.go
+++ b/internal/cli/status_heap_5995_test.go
@@ -1,0 +1,285 @@
+package cli
+
+// Memory characterisation + regression guard for `grafel status` (#5995,
+// epic #5954).
+//
+// ComputeStatusSummary used to call graph.LoadGraphFromDir per repo, which
+// materialises EVERY entity and EVERY relationship of the repo's graph onto
+// the Go heap. It used four header fields (ref/sha/worktree/files) plus two
+// entity-kind tallies, and walked the relationship vector to fill a
+// `hasIncoming` map that nothing ever read. On a corpus-sized graph that is
+// hundreds of megabytes materialised to print two counts.
+//
+// Metric discipline: RSS is NOT used here. macOS RSS counts MADV_FREE pages
+// and is an upper bound, not a footprint (see cmd/grafel/worktree_seed_heap_test.go).
+// The guard below asserts on TotalAlloc — cumulative bytes allocated, which is
+// deterministic and immune to GC timing — and the opt-in characterisation test
+// additionally reports peak LIVE heap (next_gc / (1 + GOGC/100)) and peak
+// HeapAlloc.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// buildStatusHeapFixture writes a repo state dir containing a flat graph.fb
+// with nEnt entities and nRel relationships, plus the graph-stats.json sidecar
+// the status path reads first. Returns the repo path.
+func buildStatusHeapFixture(t *testing.T, root string, slug string, nEnt, nRel int) string {
+	t.Helper()
+
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+
+	doc := &graph.Document{
+		Repo:       slug,
+		IndexedRef: "main",
+		IndexedSHA: "abcdef123456",
+		IsWorktree: false,
+		Entities:   make([]graph.Entity, 0, nEnt),
+	}
+	for i := 0; i < nEnt; i++ {
+		kind := "function"
+		switch i % 10 {
+		case 0:
+			kind = "http_endpoint_definition"
+		case 1:
+			kind = "process"
+		}
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:            fmt.Sprintf("ent-%08d", i),
+			Name:          fmt.Sprintf("Symbol%08d", i),
+			QualifiedName: fmt.Sprintf("pkg/mod/sub.Symbol%08d", i),
+			Kind:          kind,
+			SourceFile:    fmt.Sprintf("src/pkg%03d/file%05d.go", i%200, i%5000),
+			Language:      "go",
+			Signature:     fmt.Sprintf("func Symbol%08d(ctx context.Context, in *Request) (*Response, error)", i),
+			StartLine:     i % 900,
+			EndLine:       i%900 + 12,
+		})
+	}
+	doc.Relationships = make([]graph.Relationship, 0, nRel)
+	for i := 0; i < nRel; i++ {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     fmt.Sprintf("rel-%08d", i),
+			FromID: fmt.Sprintf("ent-%08d", i%nEnt),
+			ToID:   fmt.Sprintf("ent-%08d", (i*7+3)%nEnt),
+			Kind:   "calls",
+		})
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	// Free the fixture document before any measurement starts.
+	doc = nil
+	_ = doc
+	runtime.GC()
+
+	side := graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         time.Now().Add(-3 * time.Minute),
+		TotalFiles:         5000,
+		TotalEntities:      nEnt,
+		TotalRelationships: nRel,
+	}
+	sideData, _ := json.Marshal(side)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), sideData, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+	return repoPath
+}
+
+// TestStatusSummaryDoesNotMaterialiseGraph is the behavioural regression guard
+// for #5995. It measures the cumulative bytes ComputeStatusSummary allocates
+// over a graph with a large relationship vector and fails if that figure is
+// consistent with materialising the graph.
+//
+// Why TotalAlloc and not peak heap: TotalAlloc is deterministic (no GC-timing
+// dependence), and it is the metric a reintroduced LoadGraphFromDir cannot
+// hide from — materialising N relationships must allocate them, whether or not
+// the GC has reclaimed them by the time the call returns.
+//
+// The ceiling has to kill BOTH regressions, which is why it is not merely
+// "under what materialising the relationships would cost":
+//
+//   - full re-materialisation (LoadGraphFromDir again): 62.9 MB on this
+//     fixture. A relationship-derived ceiling catches this easily — 300k
+//     relationships are >30 MB of Relationship structs alone.
+//   - the PARTIAL regression: swapping EachEntityKind for a full EachEntity
+//     walk, i.e. reinstating the entity decode but not the relationship one.
+//     That is 6.6 MB — a 9.4x rise that a relationship-scaled ceiling sails
+//     straight past, because 20k entities are only ~34x smaller than the
+//     bound that catches 300k relationships.
+//
+// So the bound is set from the measured floor instead: 0.7 MB with the kind-
+// only walk, ceiling 4 MB. That kills the partial mutant with room to spare
+// and still leaves ~5x headroom for interner/GC noise and fixture drift. It
+// remains hazard-consistent — 4 MB is nowhere near "on the order of the
+// graph" for any corpus-sized repo.
+func TestStatusSummaryDoesNotMaterialiseGraph(t *testing.T) {
+	if testing.Short() {
+		t.Skip("allocation measurement; skipped under -short")
+	}
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	const nEnt = 20000
+	const nRel = 300000
+	repoPath := buildStatusHeapFixture(t, tmpDir, "heapfix", nEnt, nRel)
+	repos := []registry.Repo{{Slug: "heapfix", Path: repoPath}}
+
+	// Warm any lazily-initialised package state so it is not attributed to
+	// the measured call.
+	_ = ComputeStatusSummary("grp", repos)
+	runtime.GC()
+
+	var before, after runtime.MemStats
+	runtime.ReadMemStats(&before)
+	summary := ComputeStatusSummary("grp", repos)
+	runtime.ReadMemStats(&after)
+	runtime.KeepAlive(summary)
+
+	allocated := after.TotalAlloc - before.TotalAlloc
+	const ceiling = 4 << 20 // 4 MB — see the ceiling rationale above
+
+	t.Logf("ComputeStatusSummary allocated %.1f MB over a %d-entity / %d-relationship graph",
+		float64(allocated)/(1<<20), nEnt, nRel)
+
+	if allocated > ceiling {
+		t.Fatalf("ComputeStatusSummary allocated %.1f MB (ceiling %.1f MB): the graph is being "+
+			"materialised to answer a status poll (#5995)",
+			float64(allocated)/(1<<20), float64(ceiling)/(1<<20))
+	}
+
+	// The cheap path must still report the real numbers.
+	rs := summary.RepoStats["heapfix"]
+	if rs == nil {
+		t.Fatal("heapfix missing from RepoStats")
+	}
+	if rs.Entities != nEnt || rs.Relationships != nRel {
+		t.Fatalf("counts = %d/%d, want %d/%d", rs.Entities, rs.Relationships, nEnt, nRel)
+	}
+	if rs.IndexedRef != "main" || rs.IndexedSHA != "abcdef123456" {
+		t.Fatalf("git metadata = %q/%q, want main/abcdef123456", rs.IndexedRef, rs.IndexedSHA)
+	}
+	if summary.HTTPEndpoints != nEnt/10 {
+		t.Fatalf("HTTPEndpoints = %d, want %d", summary.HTTPEndpoints, nEnt/10)
+	}
+	if summary.ProcessFlows != nEnt/10 {
+		t.Fatalf("ProcessFlows = %d, want %d", summary.ProcessFlows, nEnt/10)
+	}
+	if rs.GraphLoadError != "" {
+		t.Fatalf("GraphLoadError = %q, want empty", rs.GraphLoadError)
+	}
+}
+
+// statusHeapSampler samples the live heap (next_gc / (1 + GOGC/100)) and
+// HeapAlloc, tracking the peak of each.
+type statusHeapSampler struct {
+	peakLive  atomic.Uint64
+	peakAlloc atomic.Uint64
+	stop      chan struct{}
+	done      chan struct{}
+	gogc      float64
+}
+
+func startStatusHeapSampler() *statusHeapSampler {
+	gogc := 100.0
+	if v := os.Getenv("GOGC"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil && f > 0 {
+			gogc = f
+		}
+	}
+	h := &statusHeapSampler{stop: make(chan struct{}), done: make(chan struct{}), gogc: gogc}
+	go func() {
+		defer close(h.done)
+		t := time.NewTicker(5 * time.Millisecond)
+		defer t.Stop()
+		var ms runtime.MemStats
+		for {
+			select {
+			case <-h.stop:
+				return
+			case <-t.C:
+				runtime.ReadMemStats(&ms)
+				live := uint64(float64(ms.NextGC) / (1.0 + h.gogc/100.0))
+				if live > h.peakLive.Load() {
+					h.peakLive.Store(live)
+				}
+				if ms.HeapAlloc > h.peakAlloc.Load() {
+					h.peakAlloc.Store(ms.HeapAlloc)
+				}
+			}
+		}
+	}()
+	return h
+}
+
+func (h *statusHeapSampler) stopAndReport() (liveMB, allocMB float64) {
+	close(h.stop)
+	<-h.done
+	return float64(h.peakLive.Load()) / (1 << 20), float64(h.peakAlloc.Load()) / (1 << 20)
+}
+
+// TestStatusSummaryPeakHeapMeasure is the opt-in characterisation run behind
+// GRAFEL_STATUS_HEAP_MEASURE=1. It reports peak live heap AND peak HeapAlloc
+// for ComputeStatusSummary over a fixture whose size is controlled by
+// GRAFEL_STATUS_HEAP_ENTS (default 100000; relationships = 8x entities, the
+// corpus mean degree). It asserts nothing — it exists so the before/after
+// figures quoted on #5995 are reproducible from this tree.
+func TestStatusSummaryPeakHeapMeasure(t *testing.T) {
+	if os.Getenv("GRAFEL_STATUS_HEAP_MEASURE") != "1" {
+		t.Skip("set GRAFEL_STATUS_HEAP_MEASURE=1 to run the status peak-heap measurement")
+	}
+	nEnt := 100000
+	if v := os.Getenv("GRAFEL_STATUS_HEAP_ENTS"); v != "" {
+		if k, err := strconv.Atoi(v); err == nil && k > 0 {
+			nEnt = k
+		}
+	}
+	nRel := nEnt * 8
+
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+	repoPath := buildStatusHeapFixture(t, tmpDir, "measure", nEnt, nRel)
+	repos := []registry.Repo{{Slug: "measure", Path: repoPath}}
+
+	runtime.GC()
+	var base runtime.MemStats
+	runtime.ReadMemStats(&base)
+	baseLive := float64(base.NextGC) / 2.0 / (1 << 20)
+
+	s := startStatusHeapSampler()
+	summary := ComputeStatusSummary("grp", repos)
+	runtime.KeepAlive(summary)
+	liveMB, allocMB := s.stopAndReport()
+
+	var after runtime.MemStats
+	runtime.ReadMemStats(&after)
+
+	t.Logf("#5995 status heap: entities=%d relationships=%d", nEnt, nRel)
+	t.Logf("  baseline live heap : %.1f MB", baseLive)
+	t.Logf("  PEAK live heap     : %.1f MB", liveMB)
+	t.Logf("  PEAK HeapAlloc     : %.1f MB", allocMB)
+	t.Logf("  TotalAlloc delta   : %.1f MB", float64(after.TotalAlloc-base.TotalAlloc)/(1<<20))
+	t.Logf("  reported: %d entities, %d rels, %d endpoints, %d flows",
+		summary.TotalEntities, summary.TotalRelationships, summary.HTTPEndpoints, summary.ProcessFlows)
+}

--- a/internal/cli/status_output_parity_5995_test.go
+++ b/internal/cli/status_output_parity_5995_test.go
@@ -1,0 +1,259 @@
+package cli
+
+// Output-parity guard for `grafel status` (#5995).
+//
+// #5995 makes ComputeStatusSummary stop materialising each repo's graph. The
+// hazard of that change is silent drift: a status command that quietly reports
+// a different number than before is worse than a slow one. This test renders
+// PrintStatusSummary over a fixture covering every graph state the status path
+// distinguishes and compares it byte-for-byte with a golden file captured from
+// the pre-change implementation.
+//
+// Regenerate deliberately (and only when a reported value is MEANT to change):
+//
+//	GRAFEL_UPDATE_GOLDEN=1 go test ./internal/cli/ -run StatusOutputParity
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// parityIndexedAge is how far in the past every fixture graph claims to have
+// been indexed.
+//
+// Fixtures WITHOUT a graph-stats.json sidecar take their age from the graph.fb
+// header's ComputedAt, or from the file mtime when that is unreadable — i.e.
+// from wall-clock now. Leaving those at "now" pinned `indexed 0s ago` into the
+// golden, and any run that crossed the one-second boundary between writing the
+// fixture and rendering the summary produced `1s ago` and failed the byte-diff.
+// That made this test flaky (measured ~25% at load ~4) AND made the golden a
+// timing artefact of whichever implementation happened to be fast enough to
+// stay under a second, which is the opposite of an implementation-independent
+// parity guard.
+//
+// 90 minutes renders as the stable string "1h30m ago" — formatTimeSince
+// truncates to whole minutes there, so the whole 90m00s–90m59s window (about
+// 59 s of slack, versus the 1 s the old fixture had) maps to one output.
+const parityIndexedAge = 90 * time.Minute
+
+func parityDoc(repo string, ref, sha string, worktree bool) *graph.Document {
+	return &graph.Document{
+		Repo:        repo,
+		GeneratedAt: time.Now().Add(-parityIndexedAge),
+		IndexedRef:  ref,
+		IndexedSHA:  sha,
+		IsWorktree:  worktree,
+		Stats:       graph.Stats{Files: 7},
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "e2", Name: "B", Kind: "http_endpoint_definition", SourceFile: "b.go", Language: "go"},
+			{ID: "e3", Name: "C", Kind: "http_endpoint_call", SourceFile: "b.go", Language: "go"},
+			{ID: "e4", Name: "D", Kind: "http_endpoint", SourceFile: "c.go", Language: "go"},
+			{ID: "e5", Name: "E", Kind: "process", SourceFile: "c.go", Language: "go"},
+			{ID: "e6", Name: "F", Kind: "SCOPE.ProcessFlow", SourceFile: "d.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "e1", ToID: "e2", Kind: "calls"},
+			{ID: "r2", FromID: "e2", ToID: "e3", Kind: "calls"},
+		},
+	}
+}
+
+// backdateGraphArtefacts pins the mtime of every graph artefact under root to
+// parityIndexedAge ago.
+//
+// The header ComputedAt covers fixtures whose header is READABLE. It does not
+// cover the rest: a graph.fb that fails to open has no header to read, so
+// ComputeStatusSummary falls back to daemon.FindGraphFile's mtime — wall-clock
+// now — and pinned `indexed 0s ago` into the golden with a one-second flake
+// window. Backdating closes that second path to the clock.
+func backdateGraphArtefacts(t *testing.T, root string) {
+	t.Helper()
+	when := time.Now().Add(-parityIndexedAge)
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		switch filepath.Ext(path) {
+		case ".fb", ".json":
+			return os.Chtimes(path, when, when)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("backdate artefacts: %v", err)
+	}
+}
+
+// parityRepo creates a repo dir under root and returns its path + state dir.
+func parityRepo(t *testing.T, root, slug string) (string, string) {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", slug, err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state %s: %v", slug, err)
+	}
+	return repoPath, stateDir
+}
+
+func writeParitySidecar(t *testing.T, stateDir string, ents, rels, files int, age time.Duration) {
+	t.Helper()
+	side := graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         time.Now().Add(-age),
+		TotalFiles:         files,
+		TotalEntities:      ents,
+		TotalRelationships: rels,
+	}
+	data, _ := json.Marshal(side)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), data, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
+// writeParitySegmentSet writes a 1-segment gen dir and points `current` at it.
+func writeParitySegmentSet(t *testing.T, stateDir string, doc *graph.Document, gen uint64) {
+	t.Helper()
+	genDir := filepath.Join(stateDir, graph.GenDirName(gen))
+	name := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, name), doc); err != nil {
+		t.Fatalf("write segment: %v", err)
+	}
+	ids := make([]string, 0, len(doc.Entities))
+	for _, e := range doc.Entities {
+		ids = append(ids, e.ID)
+	}
+	sort.Strings(ids)
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: name, Kind: graph.SegmentEntities, EntityCount: len(doc.Entities),
+		MinKey: ids[0], MaxKey: ids[len(ids)-1],
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(gen)); err != nil {
+		t.Fatalf("write current: %v", err)
+	}
+}
+
+// TestStatusOutputParity renders every graph state the status path
+// distinguishes and compares against testdata/status_parity_5995.golden.
+func TestStatusOutputParity(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	var repos []registry.Repo
+	add := func(slug, path string) { repos = append(repos, registry.Repo{Slug: slug, Path: path}) }
+
+	// 1. Healthy flat graph.fb WITH the graph-stats.json sidecar.
+	p, sd := parityRepo(t, tmpDir, "healthy")
+	if err := fbwriter.WriteAtomic(filepath.Join(sd, "graph.fb"), parityDoc("healthy", "main", "abc123def456", false)); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	writeParitySidecar(t, sd, 6, 2, 7, 3*time.Minute)
+	add("healthy", p)
+
+	// 2. Flat graph.fb, NO sidecar (the PersistedStats header path, #5442).
+	p, sd = parityRepo(t, tmpDir, "nosidecar")
+	if err := fbwriter.WriteAtomic(filepath.Join(sd, "graph.fb"), parityDoc("nosidecar", "feat/x", "0badc0ffee11", true)); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	add("nosidecar", p)
+
+	// 3. Never indexed: state dir exists, no graph artefact at all.
+	p, _ = parityRepo(t, tmpDir, "neverindexed")
+	add("neverindexed", p)
+
+	// 4. Truncated graph.fb — the reader PANICS (#6013).
+	p, sd = parityRepo(t, tmpDir, "truncated")
+	fbPath := filepath.Join(sd, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, parityDoc("truncated", "main", "aaaaaaaaaaaa", false)); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	raw, err := os.ReadFile(fbPath)
+	if err != nil {
+		t.Fatalf("read graph.fb: %v", err)
+	}
+	if err := os.WriteFile(fbPath, raw[:len(raw)/2], 0o644); err != nil {
+		t.Fatalf("truncate graph.fb: %v", err)
+	}
+	add("truncated", p)
+
+	// 5. graph.fb that fails to OPEN with a returned error (#6013).
+	p, sd = parityRepo(t, tmpDir, "unreadable")
+	if err := os.WriteFile(filepath.Join(sd, "graph.fb"), make([]byte, 512), 0o644); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	add("unreadable", p)
+
+	// 6. Segment-set layout (graph.<gen>/ + manifest.json, no flat .fb).
+	p, sd = parityRepo(t, tmpDir, "segmentset")
+	writeParitySegmentSet(t, sd, parityDoc("segmentset", "main", "5e65e75e7000", false), 4)
+	writeParitySidecar(t, sd, 6, 2, 7, 10*time.Minute)
+	add("segmentset", p)
+
+	// 7. graph.json only (the non-mmap fallback).
+	p, sd = parityRepo(t, tmpDir, "jsononly")
+	jdoc := parityDoc("jsononly", "main", "111122223333", false)
+	jraw, _ := json.Marshal(jdoc)
+	if err := os.WriteFile(filepath.Join(sd, "graph.json"), jraw, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	writeParitySidecar(t, sd, 6, 2, 7, time.Hour)
+	add("jsononly", p)
+
+	// 8. Healthy graph with a COLD ref slot alongside the hot one.
+	p, sd = parityRepo(t, tmpDir, "coldrefs")
+	if err := fbwriter.WriteAtomic(filepath.Join(sd, "graph.fb"), parityDoc("coldrefs", "main", "c01dc01dc01d", false)); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	writeParitySidecar(t, sd, 6, 2, 7, 25*time.Hour)
+	coldDir := filepath.Join(filepath.Dir(sd), "develop")
+	if err := os.MkdirAll(coldDir, 0o755); err != nil {
+		t.Fatalf("mkdir cold: %v", err)
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(coldDir, "graph.fb"), parityDoc("coldrefs", "develop", "dddddddddddd", false)); err != nil {
+		t.Fatalf("write cold graph.fb: %v", err)
+	}
+	add("coldrefs", p)
+
+	// Every reported age must now come from a fixed offset, never from "now".
+	backdateGraphArtefacts(t, tmpDir)
+
+	summary := ComputeStatusSummary("parity", repos)
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, summary)
+	got := buf.String()
+
+	goldenPath := filepath.Join("testdata", "status_parity_5995.golden")
+	if os.Getenv("GRAFEL_UPDATE_GOLDEN") == "1" {
+		if err := os.MkdirAll("testdata", 0o755); err != nil {
+			t.Fatalf("mkdir testdata: %v", err)
+		}
+		if err := os.WriteFile(goldenPath, []byte(got), 0o644); err != nil {
+			t.Fatalf("write golden: %v", err)
+		}
+		t.Logf("golden updated:\n%s", got)
+		return
+	}
+	want, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatalf("read golden (regenerate with GRAFEL_UPDATE_GOLDEN=1): %v", err)
+	}
+	if got != string(want) {
+		t.Fatalf("status output changed (#5995 must not alter reported values)\n--- want ---\n%s\n--- got ---\n%s", want, got)
+	}
+}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -101,9 +101,6 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 		RepoStats: make(map[string]*RepoStatus),
 	}
 
-	// Track entities with incoming relationships to compute orphan rate later.
-	hasIncoming := make(map[string]bool)
-
 	for _, r := range repos {
 		rs := &RepoStatus{
 			Slug:           r.Slug,
@@ -166,10 +163,28 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			}
 		}
 
-		// Load full graph document to extract entities with incoming rels +
-		// kind-based counts. This is only for computing derived counts like
-		// HTTPEndpoints and ProcessFlows; the main entity/relationship counts
-		// come from graph-stats.json.
+		// Read the graph's header + entity KINDS to fill in the derived counts
+		// (HTTPEndpoints, ProcessFlows) and the git metadata; the main
+		// entity/relationship counts come from graph-stats.json above.
+		//
+		// #5995: this used to call graph.LoadGraphFromDir, which materialises
+		// EVERY entity and EVERY relationship of the repo's graph onto the Go
+		// heap — hundreds of megabytes on a corpus-sized repo — to read four
+		// header fields and tally two entity kinds. `status` is the CLI's
+		// most-polled command (shell prompts, statusline, editor integrations,
+		// watch scripts), so that cost recurs on a timer on a memory-
+		// constrained machine (epic #5954).
+		//
+		// It now streams: graph.OpenGraphStream holds the mmap open and hands
+		// rows over one at a time without retaining them, Header() reads the
+		// Graph root table directly, and EachEntityKind decodes ONLY the kind
+		// string per row. Nothing here holds a row past the visit call.
+		//
+		// The relationship walk is GONE, not streamed. It populated a
+		// `hasIncoming` map ("to compute orphan rate later") that no code ever
+		// read — the orphan rate is computed in doctor_summary.go from its own
+		// load. Relationships outnumber entities ~8:1 on the real corpus, so
+		// that dead walk was the single largest item here.
 		//
 		// #6013: this used to swallow BOTH failure modes — a `recover()` with
 		// an empty body ("Silently ignore panics during graph loading"), and
@@ -192,42 +207,67 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 					rs.GraphLoadError = scrubPaths(fmt.Sprintf("panic while reading the graph: %v", rec))
 				}
 			}()
-			doc, err := graph.LoadGraphFromDir(stateDir)
+			stream, err := graph.OpenGraphStream(stateDir)
 			switch {
 			case err != nil:
 				// Only a graph that EXISTS and cannot be read is a failure.
 				// "neither graph.fb nor graph.json found" is the never-indexed
 				// state and stays silent.
 				if graphArtifactPresent(stateDir) {
-					rs.GraphLoadError = scrubPaths(err.Error())
+					rs.GraphLoadError = scrubPaths(loadErrorText(stateDir, err))
 				}
-			case doc == nil:
-				// A nil Document with a nil error is the same failed-load state
-				// that reaches BuildLabelIndex in #6010 — report it, never treat
-				// it as an empty-but-healthy repo.
+			case stream == nil:
+				// A nil stream with a nil error is the analogue of the nil
+				// Document that reaches BuildLabelIndex in #6010 — report it,
+				// never treat it as an empty-but-healthy repo.
 				rs.GraphLoadError = "graph loaded as a nil document"
 			default:
-				rs.Files = doc.Stats.Files
-				// Phase 0 git metadata (#2088).
-				rs.IndexedRef = doc.IndexedRef
-				rs.IndexedSHA = doc.IndexedSHA
-				rs.IsWorktree = doc.IsWorktree
-				for _, e := range doc.Entities {
+				defer stream.Close()
+				// Staged in locals and committed only once the walk has
+				// completed. LoadGraphFromDir decoded every row BEFORE its
+				// caller saw a single field, so a graph that PANICKED part-way
+				// through contributed nothing at all: no git metadata, no
+				// partial kind tallies. A streamed read reaches the panic AFTER
+				// publishing whatever it has already seen. Without this
+				// staging, a truncated graph.fb starts reporting a ref/sha next
+				// to its "FAILED to load" warning and folds a partial endpoint
+				// count into the group TOTAL — a reported-value change, which
+				// #5995 must not make.
+				//
+				// The invariant this buys is exactly "a PANIC publishes
+				// nothing", and no more. A walk that completes but silently
+				// visits fewer rows than the graph holds — EachEntityKind skips
+				// a nil vector slot with `continue`, and has no way to report
+				// that it did — still commits its undercount. That is not a
+				// regression: materializeGraphView skips nil slots the same way
+				// and the old code committed the same undercount. It is a
+				// pre-existing gap in both, noted so this staging is not read
+				// as protecting against more than it does.
+				//
+				// Stats.Files is zero for every .fb-backed graph (the format
+				// encodes no file count) and real only for the graph.json
+				// fallback — see GraphStream.DocStats. Preserved verbatim.
+				files := stream.DocStats().Files
+				// Phase 0 git metadata (#2088), straight off the header.
+				meta := stream.Header()
+				endpoints, flows := 0, 0
+				stream.EachEntityKind(func(kind string) bool {
 					// #1217: count all three http endpoint kind strings.
-					if e.Kind == "http_endpoint" || e.Kind == "http_endpoint_definition" || e.Kind == "http_endpoint_call" {
-						s.HTTPEndpoints++
+					if kind == "http_endpoint" || kind == "http_endpoint_definition" || kind == "http_endpoint_call" {
+						endpoints++
 					}
 					// Check for process flows: SCOPE.Process or process kind.
-					if e.Kind == "process" || strings.HasPrefix(e.Kind, "SCOPE.Process") {
-						s.ProcessFlows++
+					if kind == "process" || strings.HasPrefix(kind, "SCOPE.Process") {
+						flows++
 					}
-				}
-				// Track which entities have incoming relationships.
-				for _, rel := range doc.Relationships {
-					if rel.ToID != "" {
-						hasIncoming[rel.ToID] = true
-					}
-				}
+					return true
+				})
+				rs.Files = files
+				rs.IndexedRef = meta.IndexedRef
+				rs.IndexedSHA = meta.IndexedSHA
+				rs.IsWorktree = meta.IsWorktree
+				s.HTTPEndpoints += endpoints
+				s.ProcessFlows += flows
 			}
 		}()
 
@@ -272,6 +312,38 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 	s.CrossRepoEdges = loadCrossRepoEdgeCount(group)
 
 	return s
+}
+
+// loadErrorText returns the message to report for a graph that exists but
+// could not be opened.
+//
+// #5995 replaced graph.LoadGraphFromDir with graph.OpenGraphStream here. The
+// two resolve a dir identically but WORD their failures differently (e.g.
+// "graph.loadFBDocument: …" vs "graph.OpenGraphStream: open …"), and this text
+// is printed to the terminal — changing it would change what `status` reports.
+// So when the stream fails to open, ask the loader for its wording.
+//
+// It asks the HEADER-ONLY loader, deliberately. LoadGraphFromDir gives the same
+// wording — loadFBDocument and loadFBDocumentHeaderOnly are one function
+// (loadFBDoc) and share both the open error and materializeGraphView's
+// format-version error, and the segment-set path is literally the same
+// loadSegmentSetDocument call — but it is UNBOUNDED on the one input this
+// reasoning does not cover: a load that SUCCEEDS where the stream failed.
+// `status` is polled constantly, so a generation flip landing between the
+// stream's descriptor resolve and its open is the plausible way to get there,
+// and the full loader would then materialise the entire graph inside the
+// command whose whole purpose is not to. LoadGraphHeaderOnlyFromDir cannot:
+// it skips both materialize loops. Its only delegation to the full loader is
+// the no-.fb case (graph.json or absent), where OpenGraphStream materialises
+// the JSON document too — so that branch costs exactly what it did before.
+//
+// If the loader somehow does NOT fail, the stream's own error stands rather
+// than inventing a success.
+func loadErrorText(stateDir string, streamErr error) string {
+	if _, lerr := graph.LoadGraphHeaderOnlyFromDir(stateDir); lerr != nil {
+		return lerr.Error()
+	}
+	return streamErr.Error()
 }
 
 // fsPathRe matches an absolute (or otherwise multi-segment) filesystem path,

--- a/internal/cli/testdata/status_parity_5995.golden
+++ b/internal/cli/testdata/status_parity_5995.golden
@@ -1,0 +1,14 @@
+
+Group: parity
+  coldrefs          0 files       6 entities       2 rels  indexed 1d ago @ main (c01dc01dc01d) [+ develop cold]
+  healthy           0 files       6 entities       2 rels  indexed 3m ago @ main (abc123def456)
+  jsononly          7 files       6 entities       2 rels  indexed 1h ago @ main (111122223333)
+  neverindexed      0 files       0 entities       0 rels  indexed (never)
+  nosidecar         0 files       6 entities       2 rels  indexed 1h30m ago @ feat/x (0badc0ffee11) [worktree]
+  segmentset        0 files       6 entities       2 rels  indexed 10m ago @ main (5e65e75e7000)
+  truncated         0 files       6 entities       2 rels  indexed 1h30m ago
+                ⚠ graph FAILED to load: panic while reading the graph: runtime error: slice bounds out of range [888:500] — file/endpoint/flow counts above are INCOMPLETE; run `grafel reset parity` to rebuild from scratch
+  unreadable        0 files       0 entities       0 rels  indexed 1h30m ago
+                ⚠ graph FAILED to load: graph.loadFBDocument: graph.fb format version 2 is older than required version 5 — please reindex (run: grafel index <repo>) — file/endpoint/flow counts above are INCOMPLETE; run `grafel reset parity` to rebuild from scratch
+
+  TOTAL: 36 entities · 12 relationships · 0 cross-repo edges · 10 flows · 15 endpoints  ⚠ INCOMPLETE — 2 repos could not be read (see above)

--- a/internal/graph/stream.go
+++ b/internal/graph/stream.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/graph/fbreader"
 )
@@ -156,6 +157,95 @@ func (s *GraphStream) RelationshipCount() int {
 		return 0
 	}
 	return s.view.RelationshipCount()
+}
+
+// Header returns the graph's header fields without decoding a single row.
+//
+// It is the streaming equivalent of reading Document.IndexedRef / IndexedSHA /
+// IsWorktree / Repo / CoverageStatus off a LoadGraphFromDir result: the same
+// values from the same place (the Graph root table), for callers that want the
+// header and NOT the hundreds of megabytes of rows behind it (#5995).
+//
+// On the graph.json fallback the fields are reconstituted from the already-
+// materialised Document so both paths answer identically.
+func (s *GraphStream) Header() fbreader.GraphMeta {
+	if s == nil {
+		return fbreader.GraphMeta{}
+	}
+	if s.doc != nil {
+		m := fbreader.GraphMeta{
+			Version:        s.doc.Version,
+			RepoTag:        s.doc.Repo,
+			IndexedRef:     s.doc.IndexedRef,
+			IndexedSHA:     s.doc.IndexedSHA,
+			IsWorktree:     s.doc.IsWorktree,
+			CoverageStatus: s.doc.CoverageStatus,
+		}
+		if !s.doc.GeneratedAt.IsZero() {
+			m.ComputedAt = s.doc.GeneratedAt.Format(time.RFC3339)
+		}
+		return m
+	}
+	if s.view == nil {
+		return fbreader.GraphMeta{}
+	}
+	return s.view.LoadGraphMeta()
+}
+
+// DocStats returns the Stats block LoadGraphFromDir would have put on the
+// Document, without materialising it.
+//
+// Read the Files field carefully: the .fb formats do NOT encode a file count,
+// so materializeGraphView leaves Stats.Files zero for every .fb-backed graph
+// and only the graph.json fallback carries a real value. This method reproduces
+// that exactly rather than papering over it — a caller that wants the true
+// indexed-file count should read graph-stats.json's TotalFiles instead.
+func (s *GraphStream) DocStats() Stats {
+	if s == nil {
+		return Stats{}
+	}
+	if s.doc != nil {
+		return s.doc.Stats
+	}
+	return Stats{Entities: s.EntityCount(), Relationships: s.RelationshipCount()}
+}
+
+// EachEntityKind visits the Kind field of every entity row, decoding NOTHING
+// else. Return false from visit to stop early.
+//
+// This exists for the kind-tally callers (`grafel status` counts http endpoints
+// and process flows, #5995): EachEntity converts a whole row — name, qualified
+// name, signature, source file, properties — of which a tally reads one string.
+// The kind strings are interned by the same interner the full walk uses, so a
+// tally over a corpus-sized graph allocates a bounded handful of strings rather
+// than one object graph per row.
+func (s *GraphStream) EachEntityKind(visit func(kind string) bool) {
+	if s == nil || visit == nil {
+		return
+	}
+	if s.doc != nil {
+		for i := range s.doc.Entities {
+			if !visit(s.doc.Entities[i].Kind) {
+				return
+			}
+		}
+		return
+	}
+	if s.view == nil {
+		return
+	}
+	n := s.view.EntityCount()
+	for i := 0; i < n; i++ {
+		fbEnt := s.view.EntityAt(i)
+		if fbEnt == nil {
+			// Match EachEntity/materializeGraphView: skip nil vector slots
+			// rather than reporting an empty kind.
+			continue
+		}
+		if !visit(s.si.intern(fbEnt.Kind())) {
+			return
+		}
+	}
 }
 
 // EachEntity decodes and visits every entity row in file order. Return false

--- a/internal/graph/stream_header_5995_test.go
+++ b/internal/graph/stream_header_5995_test.go
@@ -1,0 +1,335 @@
+package graph_test
+
+// Parity tests for the header/kind accessors GraphStream grew for #5995
+// (`grafel status` reads a graph's header and entity kinds without
+// materialising it).
+//
+// The contract is the same one the rest of stream_test.go locks down: what the
+// stream reports must equal what LoadGraphFromDir would have put on the
+// Document. A status command that streams a DIFFERENT ref, sha or kind tally
+// than the loader reported is worse than a slow one.
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// writeSegmentedHeaderFixture lays headerFixtureDoc down as an nSeg-segment
+// generation, stamping the header metadata onto EVERY segment (the MultiReader
+// sources the header from segment 0; stamping all of them means the test
+// cannot pass by accident of which segment is read).
+//
+// Segment-set coverage matters specifically for EachEntityKind: it indexes
+// s.view.EntityAt(i) by GLOBAL index across a key-routed multi-segment view,
+// which is the #6080 / task-16 failure class — an accessor that reads only
+// segment 0, or mis-routes the index, silently undercounts and `grafel status`
+// would report a smaller endpoint/flow tally with no error anywhere.
+func writeSegmentedHeaderFixture(t *testing.T, nSeg int) (dir string, doc *graph.Document) {
+	t.Helper()
+	dir = t.TempDir()
+	doc = headerFixtureDoc()
+
+	segs := splitDocIntoSegments(doc, nSeg)
+	populated := 0
+	for _, s := range segs {
+		if len(s.Entities) > 0 {
+			populated++
+		}
+		s.GeneratedAt = doc.GeneratedAt
+		s.IndexedRef = doc.IndexedRef
+		s.IndexedSHA = doc.IndexedSHA
+		s.IsWorktree = doc.IsWorktree
+		s.CoverageStatus = doc.CoverageStatus
+	}
+	if populated < 2 {
+		t.Fatalf("fixture is vacuous: only %d/%d segments carry entities", populated, nSeg)
+	}
+	writeSegmentSet(t, dir, 7, segs)
+
+	desc, err := graph.CurrentGraphDescriptor(dir)
+	if err != nil {
+		t.Fatalf("CurrentGraphDescriptor: %v", err)
+	}
+	if desc.Kind != graph.GraphSegmentSet {
+		t.Fatalf("descriptor Kind = %v, want GraphSegmentSet — the test would exercise the single-file branch", desc.Kind)
+	}
+	return dir, doc
+}
+
+// TestGraphStream_SegmentSetHeaderAndKinds is the segment-set gate on the
+// accessors #5995 added. Both must agree with LoadGraphFromDir over the SAME
+// multi-segment dir: an accessor that reads one segment shows up here as a
+// short kind tally, and one that misses the header shows up as empty metadata.
+func TestGraphStream_SegmentSetHeaderAndKinds(t *testing.T) {
+	t.Parallel()
+	dir, _ := writeSegmentedHeaderFixture(t, 3)
+
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	want := map[string]int{}
+	for _, e := range loaded.Entities {
+		want[e.Kind]++
+	}
+
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	defer s.Close()
+
+	h := s.Header()
+	if h.IndexedRef != loaded.IndexedRef || h.IndexedSHA != loaded.IndexedSHA ||
+		h.IsWorktree != loaded.IsWorktree || h.RepoTag != loaded.Repo ||
+		h.CoverageStatus != loaded.CoverageStatus {
+		t.Fatalf("segment-set header = %+v, loader ref=%q sha=%q worktree=%v repo=%q coverage=%q",
+			h, loaded.IndexedRef, loaded.IndexedSHA, loaded.IsWorktree, loaded.Repo, loaded.CoverageStatus)
+	}
+
+	got := map[string]int{}
+	s.EachEntityKind(func(k string) bool { got[k]++; return true })
+	if len(got) != len(want) {
+		t.Fatalf("segment-set kind sets differ: stream %v, loader %v", got, want)
+	}
+	total := 0
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("segment-set kind %q: stream %d, loader %d", k, got[k], n)
+		}
+		total += n
+	}
+	if total != len(loaded.Entities) || total == 0 {
+		t.Fatalf("loader tally %d does not cover its %d entities", total, len(loaded.Entities))
+	}
+
+	// DocStats must sum across every segment, not report segment 0's counts.
+	if st := s.DocStats(); st.Entities != loaded.Stats.Entities {
+		t.Errorf("segment-set DocStats.Entities = %d, loader Stats.Entities = %d", st.Entities, loaded.Stats.Entities)
+	}
+}
+
+// TestGraphStream_TwoSegmentKindTallyIsNotSegmentZero is the explicit
+// non-vacuity gate: with two segments, the tally must exceed what segment 0
+// alone holds, so an accessor that stopped at the first segment cannot pass.
+func TestGraphStream_TwoSegmentKindTallyIsNotSegmentZero(t *testing.T) {
+	t.Parallel()
+	dir, doc := writeSegmentedHeaderFixture(t, 2)
+
+	segs := splitDocIntoSegments(doc, 2)
+	seg0 := len(segs[0].Entities)
+	if seg0 == 0 || seg0 == len(doc.Entities) {
+		t.Fatalf("split is vacuous: segment 0 holds %d of %d entities", seg0, len(doc.Entities))
+	}
+
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	defer s.Close()
+
+	n := 0
+	s.EachEntityKind(func(string) bool { n++; return true })
+	if n != len(doc.Entities) {
+		t.Fatalf("EachEntityKind visited %d kinds, want %d (segment 0 alone holds %d)", n, len(doc.Entities), seg0)
+	}
+}
+
+// headerFixtureDoc is streamFixtureDoc plus populated header metadata and a
+// kind mix (the loader's fixture is single-kind, which cannot distinguish a
+// correct tally from a constant).
+func headerFixtureDoc() *graph.Document {
+	doc := streamFixtureDoc()
+	doc.Repo = "acme/widgets"
+	doc.IndexedRef = "feature/streaming"
+	doc.IndexedSHA = "0123456789ab"
+	doc.IsWorktree = true
+	doc.CoverageStatus = "partial"
+	doc.Entities = append(doc.Entities,
+		graph.Entity{ID: "h1", Name: "GetUser", Kind: "http_endpoint_definition", SourceFile: "h.go"},
+		graph.Entity{ID: "h2", Name: "CallUser", Kind: "http_endpoint_call", SourceFile: "h.go"},
+		graph.Entity{ID: "h3", Name: "Legacy", Kind: "http_endpoint", SourceFile: "h.go"},
+		graph.Entity{ID: "p1", Name: "Ingest", Kind: "process", SourceFile: "p.go"},
+		graph.Entity{ID: "p2", Name: "Batch", Kind: "SCOPE.ProcessFlow", SourceFile: "p.go"},
+	)
+	return doc
+}
+
+func writeHeaderFixture(t *testing.T) (dir string, doc *graph.Document) {
+	t.Helper()
+	dir = t.TempDir()
+	doc = headerFixtureDoc()
+	if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	return dir, doc
+}
+
+// TestGraphStream_HeaderMatchesLoadedDocument: Header() must report exactly the
+// git/repo metadata LoadGraphFromDir puts on the Document.
+func TestGraphStream_HeaderMatchesLoadedDocument(t *testing.T) {
+	t.Parallel()
+	dir, _ := writeHeaderFixture(t)
+
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	defer s.Close()
+	h := s.Header()
+
+	if h.IndexedRef != loaded.IndexedRef {
+		t.Errorf("IndexedRef = %q, loader = %q", h.IndexedRef, loaded.IndexedRef)
+	}
+	if h.IndexedSHA != loaded.IndexedSHA {
+		t.Errorf("IndexedSHA = %q, loader = %q", h.IndexedSHA, loaded.IndexedSHA)
+	}
+	if h.IsWorktree != loaded.IsWorktree {
+		t.Errorf("IsWorktree = %v, loader = %v", h.IsWorktree, loaded.IsWorktree)
+	}
+	if h.RepoTag != loaded.Repo {
+		t.Errorf("RepoTag = %q, loader Repo = %q", h.RepoTag, loaded.Repo)
+	}
+	if h.CoverageStatus != loaded.CoverageStatus {
+		t.Errorf("CoverageStatus = %q, loader = %q", h.CoverageStatus, loaded.CoverageStatus)
+	}
+	// The fixture sets every field non-zero, so an accessor that returned a
+	// zero GraphMeta would be caught above only if the loader also zeroed it.
+	if h.IndexedRef == "" || h.IndexedSHA == "" {
+		t.Fatalf("header came back empty: %+v", h)
+	}
+}
+
+// TestGraphStream_HeaderJSONFallback: the graph.json path has no mmap header,
+// so Header() reconstitutes from the materialised Document. It must agree with
+// the .fb path on the same content.
+func TestGraphStream_HeaderJSONFallback(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	doc := headerFixtureDoc()
+	if err := writeJSONGraphForTest(t, filepath.Join(dir, "graph.json"), doc); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream (json): %v", err)
+	}
+	defer s.Close()
+	h := s.Header()
+	if h.IndexedRef != doc.IndexedRef || h.IndexedSHA != doc.IndexedSHA ||
+		h.IsWorktree != doc.IsWorktree || h.RepoTag != doc.Repo ||
+		h.CoverageStatus != doc.CoverageStatus {
+		t.Fatalf("json fallback header = %+v, want ref=%q sha=%q worktree=%v repo=%q coverage=%q",
+			h, doc.IndexedRef, doc.IndexedSHA, doc.IsWorktree, doc.Repo, doc.CoverageStatus)
+	}
+}
+
+// TestGraphStream_EachEntityKindMatchesFullWalk: the kind-only walk must visit
+// the same kinds, in the same multiplicity, as the full entity walk — and
+// therefore as the loaded Document.
+func TestGraphStream_EachEntityKindMatchesFullWalk(t *testing.T) {
+	t.Parallel()
+	dir, _ := writeHeaderFixture(t)
+
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	want := map[string]int{}
+	for _, e := range loaded.Entities {
+		want[e.Kind]++
+	}
+
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	defer s.Close()
+
+	got := map[string]int{}
+	s.EachEntityKind(func(k string) bool { got[k]++; return true })
+
+	if len(got) != len(want) {
+		t.Fatalf("kind sets differ: stream %v, loader %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("kind %q: stream %d, loader %d", k, got[k], n)
+		}
+	}
+	// Guard against a walk that visits nothing (which would satisfy a
+	// one-sided comparison against an empty map).
+	if got["http_endpoint_definition"] != 1 || got["SCOPE.ProcessFlow"] != 1 {
+		t.Fatalf("expected the seeded status kinds to be visited, got %v", got)
+	}
+}
+
+// TestGraphStream_EachEntityKindEarlyReturn: returning false stops the walk.
+func TestGraphStream_EachEntityKindEarlyReturn(t *testing.T) {
+	t.Parallel()
+	dir, _ := writeHeaderFixture(t)
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	defer s.Close()
+	n := 0
+	s.EachEntityKind(func(string) bool { n++; return n < 3 })
+	if n != 3 {
+		t.Fatalf("early return visited %d kinds, want 3", n)
+	}
+	if s.EntityCount() <= 3 {
+		t.Fatalf("fixture too small (%d entities) to prove early return", s.EntityCount())
+	}
+}
+
+// TestGraphStream_DocStatsMatchesLoadedDocument: DocStats must reproduce the
+// loader's Stats block, INCLUDING the fact that the .fb formats carry no file
+// count (Stats.Files is zero there) while graph.json does.
+func TestGraphStream_DocStatsMatchesLoadedDocument(t *testing.T) {
+	t.Parallel()
+
+	// .fb path.
+	dir, _ := writeHeaderFixture(t)
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	s, err := graph.OpenGraphStream(dir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream: %v", err)
+	}
+	st := s.DocStats()
+	s.Close()
+	if st.Files != loaded.Stats.Files {
+		t.Errorf("fb Stats.Files = %d, loader = %d", st.Files, loaded.Stats.Files)
+	}
+	if st.Entities != loaded.Stats.Entities || st.Relationships != loaded.Stats.Relationships {
+		t.Errorf("fb Stats counts = %d/%d, loader = %d/%d",
+			st.Entities, st.Relationships, loaded.Stats.Entities, loaded.Stats.Relationships)
+	}
+
+	// graph.json path: a persisted file count must survive.
+	jdir := t.TempDir()
+	jdoc := headerFixtureDoc()
+	jdoc.Stats = graph.Stats{Files: 41, Entities: len(jdoc.Entities), Relationships: len(jdoc.Relationships)}
+	if err := writeJSONGraphForTest(t, filepath.Join(jdir, "graph.json"), jdoc); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	js, err := graph.OpenGraphStream(jdir)
+	if err != nil {
+		t.Fatalf("OpenGraphStream (json): %v", err)
+	}
+	defer js.Close()
+	if got := js.DocStats().Files; got != 41 {
+		t.Fatalf("json Stats.Files = %d, want 41", got)
+	}
+}


### PR DESCRIPTION
`grafel status` is the most-frequently-polled command in the tool, and it materialised **every entity and every relationship** of every repo in every group to print a summary. Measured peak live heap on a 100k-entity / 800k-relationship fixture: **147.8 MB**, with 192.3 MB of total allocation.

On the 16 GB laptop epic #5954 exists to protect, that is a large spike that recurs on every poll.

## The expensive part was dead code

`ComputeStatusSummary` → `internal/cli/status_stats.go:195` called `graph.LoadGraphFromDir`. From that, it used four header fields (`Stats.Files`, `IndexedRef`, `IndexedSHA`, `IsWorktree`) and a tally of entity kinds.

The relationship walk at `:226-230` filled a `hasIncoming` map, commented "to compute orphan rate later". **`hasIncoming` is written and never read** — verified by `git grep` at `120db38be` (one declaration, one write, no reader; no closure capture, no embedding) and by `git log -S` across all branches showing only the four commits that introduced and removed it. The orphan rate is computed independently in `doctor_summary.go:259` and `rebuild_summary.go:138`, each building its own local.

Relationships outnumber entities roughly 8:1, so **the single largest cost in the command produced a result that was discarded.**

Two other hypotheses on the issue turned out to be wrong and are recorded here so they are not re-investigated: the sidecar path is **not** bypassed (`:128` reads `graph-stats.json` first, and it is what supplies the entity and relationship counts), and the registry walk does **not** materialise other groups.

## The fix

`graph.GraphStream` — the existing non-materialising mmap reader added for the incremental path — gains three accessors in `internal/graph/stream.go`: `Header()`, `DocStats()`, and `EachEntityKind()`, the last decoding only the `Kind` string per row.

Status now opens one stream per repo, reads the header, tallies kinds, and never touches relationships. Both layouts are covered: `OpenGraphStream` resolves segment-set, single-file and `graph.json` exactly as the loader does.

| metric | before | after |
|---|---|---|
| peak live heap | 147.8 MB | 31.3 MB |
| peak `HeapAlloc` | 215.3 MB | 33.0 MB |
| `TotalAlloc` delta | 192.3 MB | **3.1 MB** |

Reproduced independently in review to the decimal, on a calm machine (load 3–6, swap flat).

**The 31.3 MB is the harness's own pre-call baseline, identical to the peak** — status now contributes no measurable live heap at all. So `147.8 → 31.3` is a floor, not residual cost, and understates the win. `TotalAlloc` 192.3 MB → 3.1 MB is the honest measure.

## Output parity — and a correction to how it was established

The command is user-facing, so a silently different number would be worse than a slow one. `TestStatusOutputParity` renders `PrintStatusSummary` over eight graph states and diffs byte-for-byte against a golden.

It caught two real drifts that would otherwise have shipped:

1. **A partial commit on a failed walk.** A stream hitting a mid-walk panic *after* publishing rows caused a truncated `graph.fb` to print `@ main (aaaaaaaaaaaa)` next to its "FAILED to load" warning **and fold a partial endpoint count into the group TOTAL**. Results are now staged in locals and committed only on a completed walk, matching the loader's all-or-nothing semantics.
2. **Different open-failure wording.** `OpenGraphStream` and `LoadGraphFromDir` word failures differently, and that text is printed.

**The original golden was not what it claimed to be.** It was described as captured from the pre-change implementation, and review disproved that: reverting `status_stats.go` to `120db38be` made the test fail, with the only diff being two age fields (`0s ago` → `1s ago`). Three fixtures — `nosidecar`, `truncated`, and `unreadable`, which takes its age from a different clock path — had no `graph-stats.json`, so their age came from wall-clock now. The golden had recorded a timing artefact of the *fast* path, and the test was **25% flaky** (5/20 failures at load ~4).

Every other byte — counts, error strings, the TOTAL line — was identical, so the parity claim itself was sound. But the test could not demonstrate it.

Fixed on both clock paths, since backdating one leaves the other live: `parityDoc` sets `GeneratedAt = now - 90m` (passed through to the header `ComputedAt`), and `backdateGraphArtefacts` `os.Chtimes`-es every `.fb`/`.json` under the fixture root for the fixtures whose header is unreadable. At 90 minutes `formatTimeSince` truncates to whole minutes, so the stable window is ~59 s rather than 1 s.

Golden regenerated against the **pre-change** implementation and verified both directions at `-count=20`:

| | exit | runs |
|---|---|---|
| golden vs pre-change `status_stats.go` | 0 | 20/20 |
| golden vs post-change `status_stats.go` | 0 | 20/20 |

It is now an implementation-independent contract.

Review additionally rendered old versus new across **nine states the eight cases miss** — empty graph, single entity, dangling `current` pointer, segment set with a missing later segment, corrupt `graph.json`, `.fb` and `.json` present with divergent contents, zero-byte `.fb`, `.fb` deleted under a live sidecar, and a two-segment set. **Byte-identical in every case.**

## The memory guard had a blind spot

`TestStatusSummaryDoesNotMaterialiseGraph` asserts `TotalAlloc` over a 20k/300k fixture. Its ceiling was derived from the **relationship** hazard only, leaving ~34× headroom on the entity side — so reintroducing just the entity walk (`EachEntity`), the exact partial regression, took allocation from 0.7 MB to **6.6 MB (9.4×)** and was caught by nothing.

Ceiling tightened 24 MB → **4 MB**, with the rationale rewritten to name both regressions. The mutant now fails at `allocated 6.6 MB (ceiling 4.0 MB)`, reproducing review's figure to the decimal, with ~5× slack still above the 0.7 MB floor.

## `loadErrorText` no longer materialises on the error path

It called `LoadGraphFromDir` — a full materialisation inside the command whose purpose is avoiding one. The argument that the loader errors out before decoding held for the exercised cases, but was unbounded: if `LoadGraphFromDir` **succeeded** where `OpenGraphStream` failed — most plausibly a generation flip landing between descriptor resolve and open, which `status` polls into constantly — it would materialise the whole graph *and* still report "FAILED to load" with the stale stream error.

Now `graph.LoadGraphHeaderOnlyFromDir`. Wording is identical **by construction rather than by luck**: `loadFBDocument` and `loadFBDocumentHeaderOnly` are both `loadFBDoc`, sharing the open error and `materializeGraphView`'s format-version error, and the segment-set branch is the same `loadSegmentSetDocument` call. Its only delegation to the full loader is the no-`.fb` case, where `OpenGraphStream` materialises the JSON document anyway.

## Segment-set coverage

That branch has been an untested gap twice in this codebase, and `EachEntityKind` indexes `s.view.EntityAt(i)` by **global** index across a routed multi-segment view — the same failure class. Two tests added:

- `TestGraphStream_SegmentSetHeaderAndKinds` — 3-segment set, `Header()` and the `EachEntityKind()` multiset both compared against `LoadGraphFromDir` over the same directory, with `DocStats().Entities` summed across segments. Header metadata is stamped on **every** segment so it cannot pass by accident of which one is read.
- `TestGraphStream_TwoSegmentKindTallyIsNotSegmentZero` — explicit non-vacuity: asserts segment 0 holds strictly fewer than all entities, then that the tally equals the full count.

No bug found; the gap was in coverage, not behaviour.

## Preserved, not fixed

`files` prints **0 for every `.fb`-backed repo** — `Stats.Files` is never populated by `materializeGraphView` and overwrites the sidecar's real count. Reproduced verbatim rather than corrected, because silently changing a printed value inside a memory change would have defeated the parity guard. Filed as **#6115**, which notes the golden pins the current output and will need updating as part of that fix.

## One comment corrected

`EachEntityKind` skips nil vector slots with `continue` and cannot signal a partial walk, so a completed walk that skipped a slot still commits its undercount. The staging protects against **panics** only. This matches `materializeGraphView` exactly and is not a regression, but the comment claimed a stronger invariant than the code provides and now says what actually holds.

## Verification

`go build ./...`, `go vet ./...`, `gofmt -l .` clean. Sequential, `-count=1 -p 1`:

| package | exit | pass | skip |
|---|---|---|---|
| `./internal/cli/` | 0 | 440 | 1 |
| `./internal/graph/...` | 0 | 438 | **0** |
| `./cmd/grafel/` | 0 | 323 | 7 |

0 FAIL throughout. The single `internal/cli` skip is the opt-in heap measurement; the 7 in `cmd/grafel` are pre-existing opt-in gates.

Mutants killed: reintroduce `LoadGraphFromDir` · remove the staging so failures publish · `EachEntityKind` skips the last row · break `Header()` · break `DocStats()` · swallow a mid-walk panic · reintroduce the entity walk.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Closes #5995
Refs #5954, #6115
