### PR TITLE
fix(#6087): bound rename detection by Levenshtein work, not pair count — 3.4h worst case to ~9s

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -723,6 +723,17 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 					"rename-detect: %d rename(s) detected (moves=%d splits=%d)\n",
 					renameStats.Renames, renameStats.Moves, renameStats.Splits)
 			}
+			// #6087 — the pass is pair-budgeted. When the budget ran out the
+			// result is a PARTIAL rename scan, so say so explicitly: without
+			// this line a truncated run is indistinguishable from "no renames
+			// existed", which is the confident-wrong-answer failure mode.
+			if renameStats.Truncated {
+				fmt.Fprintf(os.Stderr,
+					"rename-detect: TRUNCATED — pair budget %d exhausted after %d pair(s); %d added entities not examined, %d candidate pair(s) skipped. "+
+						"Rename detection is INCOMPLETE for this run: the prior graph is largely dissimilar to the new one (#6087)\n",
+					renameStats.PairBudget, renameStats.PairsExamined,
+					renameStats.AddedSkipped, renameStats.PairsSkipped)
+			}
 		}
 		// If no previous graph exists (first run) or it cannot be loaded,
 		// we simply skip rename detection — this is not an error.

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -446,6 +447,31 @@ func WithIngestDocs(enabled bool) IndexOption {
 
 // ingestDocsEnvEnabled reports whether GRAFEL_INGEST_DOCS requests doc
 // ingestion (accepts "1", "true", "yes", "on"; case-insensitive).
+// renameWorkBudget returns the Phase-2 work budget for the rename-detection
+// pass (#6087), in Levenshtein DP cells.
+//
+// GRAFEL_RENAME_WORK_BUDGET overrides algorithms.DefaultRenameWorkBudget. It
+// exists for two reasons: an operator who hits truncation on a genuinely huge
+// but legitimate delta can raise the ceiling without a rebuild, and tests can
+// drive the truncation path in milliseconds instead of needing a fixture large
+// enough to burn four billion work units. Unparseable or non-positive values
+// fall back to the default rather than disabling the bound — there is no
+// unbounded mode.
+func renameWorkBudget() int64 {
+	raw := strings.TrimSpace(os.Getenv("GRAFEL_RENAME_WORK_BUDGET"))
+	if raw == "" {
+		return algorithms.DefaultRenameWorkBudget
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 {
+		fmt.Fprintf(os.Stderr,
+			"grafel: ignoring invalid GRAFEL_RENAME_WORK_BUDGET=%q; using default %d\n",
+			raw, algorithms.DefaultRenameWorkBudget)
+		return algorithms.DefaultRenameWorkBudget
+	}
+	return v
+}
+
 func ingestDocsEnvEnabled() bool {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv("GRAFEL_INGEST_DOCS"))) {
 	case "1", "true", "yes", "on":
@@ -709,6 +735,11 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		}
 	}
 
+	// #6087 — captured here so the truncation flag can be persisted into the
+	// graph-stats.json sidecar further down. Zero value (Truncated=false) is
+	// the correct default when the pass is skipped or no prior graph exists.
+	var renameStats algorithms.RenameStats
+
 	// Pass 5.5 — rename detection (#1344). Load the previous graph from disk
 	// and compare it with the freshly-built doc to detect entity renames,
 	// moves, and splits. Runs BEFORE the final sort and disk write so the
@@ -717,21 +748,24 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	if !skipSet[PassRenameDetect] {
 		stateDir := filepath.Dir(outPath)
 		if prevDoc, err := graph.LoadGraphFromDir(stateDir); err == nil {
-			renameStats := algorithms.DetectRenames(prevDoc, doc)
+			renameStats = algorithms.DetectRenamesBounded(prevDoc, doc, renameWorkBudget())
 			if renameStats.Renames > 0 {
 				fmt.Fprintf(os.Stderr,
 					"rename-detect: %d rename(s) detected (moves=%d splits=%d)\n",
 					renameStats.Renames, renameStats.Moves, renameStats.Splits)
 			}
-			// #6087 — the pass is pair-budgeted. When the budget ran out the
+			// #6087 — the pass is work-budgeted. When the budget ran out the
 			// result is a PARTIAL rename scan, so say so explicitly: without
 			// this line a truncated run is indistinguishable from "no renames
 			// existed", which is the confident-wrong-answer failure mode.
+			// The same fact is persisted machine-readably into
+			// graph-stats.json below, for consumers that are not a human
+			// tailing stderr.
 			if renameStats.Truncated {
 				fmt.Fprintf(os.Stderr,
-					"rename-detect: TRUNCATED — pair budget %d exhausted after %d pair(s); %d added entities not examined, %d candidate pair(s) skipped. "+
+					"rename-detect: TRUNCATED — work budget %d exhausted after %d unit(s) over %d pair(s); %d added entities not examined, %d candidate pair(s) skipped. "+
 						"Rename detection is INCOMPLETE for this run: the prior graph is largely dissimilar to the new one (#6087)\n",
-					renameStats.PairBudget, renameStats.PairsExamined,
+					renameStats.WorkBudget, renameStats.WorkUsed, renameStats.PairsExamined,
 					renameStats.AddedSkipped, renameStats.PairsSkipped)
 			}
 		}
@@ -874,7 +908,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		// never zero out real algorithm data that a previous full build
 		// computed.
 		prior, _ := graph.LoadSidecar(filepath.Dir(outPath))
-		side := buildStatsSidecar(doc, extractMS, canaryRaw, canarySpiked, prior, deterministicGeneratedAt())
+		side := buildStatsSidecar(doc, extractMS, canaryRaw, canarySpiked, prior, deterministicGeneratedAt(), renameStats)
 		if err := graph.WriteSidecar(outPath, side, pretty); err != nil {
 			fmt.Fprintf(os.Stderr, "grafel: sidecar write failed: %v\n", err)
 		}

--- a/cmd/grafel/rename_truncation_report_6087_test.go
+++ b/cmd/grafel/rename_truncation_report_6087_test.go
@@ -1,0 +1,182 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ─── #6087 — a truncated rename scan must be REPORTED, not silently dropped ──
+//
+// The bound itself is guarded in internal/algorithms. What is guarded here is
+// the half nobody can see from inside that package: that a truncated pass is
+// actually surfaced to the two audiences that consume an index —
+//
+//   - a human watching the indexer, via the stderr warning, and
+//   - every programmatic consumer (MCP, the dashboard, `grafel doctor`), via
+//     the graph-stats.json sidecar, which is the only machine-readable
+//     artefact they read. Without the sidecar flag, truncation is non-silent
+//     to a human tailing a terminal and completely silent to everything else.
+//
+// Deleting either report leaves the package building and every other test
+// green, which is exactly why these exist.
+
+// writeRenameFixtureRepo writes a tiny Go repo whose function names are all
+// derived from nameFn, so two successive indexes with different nameFns
+// produce a large added/deleted entity delta.
+func writeRenameFixtureRepo(t *testing.T, dir string, n int, nameFn func(i int) string) {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString("package fixture\n\n")
+	for i := 0; i < n; i++ {
+		fmt.Fprintf(&b, "func %s() int { return %d }\n\n", nameFn(i), i)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "fixture.go"), []byte(b.String()), 0o644); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module fixture\n\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+}
+
+// indexCapturingStderr runs Index and returns everything it wrote to stderr.
+//
+// NOTE: this mutates the process-global os.Stderr handle, matching the
+// existing convention in index_test.go. Do not run it in parallel.
+func indexCapturingStderr(t *testing.T, repo, out string) string {
+	t.Helper()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stderr
+	os.Stderr = w
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	idxErr := Index(repo, out, "rename-fixture", nil, false, false)
+
+	os.Stderr = orig
+	_ = w.Close()
+	captured := <-done
+	_ = r.Close()
+
+	if idxErr != nil {
+		t.Fatalf("index: %v", idxErr)
+	}
+	return captured
+}
+
+// TestRenameDetect_TruncationIsReported drives a real two-pass index through
+// the shipped CLI entry point with a work budget small enough to guarantee
+// truncation, and asserts BOTH reports fire.
+func TestRenameDetect_TruncationIsReported(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	// A budget of 1 unit cannot admit any candidate bucket, so any non-empty
+	// delta truncates. The env override exists precisely so this path is
+	// reachable in milliseconds instead of needing a four-billion-unit fixture.
+	t.Setenv("GRAFEL_RENAME_WORK_BUDGET", "1")
+
+	repo := t.TempDir()
+	state := t.TempDir()
+	out := filepath.Join(state, "graph.json")
+
+	const n = 40
+	// Pass 1 — establishes the prior graph.
+	writeRenameFixtureRepo(t, repo, n, func(i int) string { return fmt.Sprintf("AlphaHandler%03d", i) })
+	if err := Index(repo, out, "rename-fixture", nil, false, false); err != nil {
+		t.Fatalf("first index: %v", err)
+	}
+
+	// Pass 2 — every function renamed, so every entity is both a deletion and
+	// an addition: a delta the (tiny) budget cannot possibly cover.
+	writeRenameFixtureRepo(t, repo, n, func(i int) string { return fmt.Sprintf("AlphaHandlers%03d", i) })
+	stderr := indexCapturingStderr(t, repo, out)
+
+	if !strings.Contains(stderr, "rename-detect: TRUNCATED") {
+		t.Errorf("no truncation warning on stderr; a partial rename scan was reported as a complete one.\nstderr:\n%s", stderr)
+	}
+	if !strings.Contains(stderr, "INCOMPLETE") {
+		t.Errorf("truncation warning does not say the result is incomplete.\nstderr:\n%s", stderr)
+	}
+
+	// The machine-readable half: every non-human consumer reads this file.
+	var side graph.GraphStatsSidecar
+	sideBytes, err := os.ReadFile(filepath.Join(state, "graph-stats.json"))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if err := json.Unmarshal(sideBytes, &side); err != nil {
+		t.Fatalf("parse sidecar: %v", err)
+	}
+	if !side.RenameDetectTruncated {
+		t.Errorf("sidecar rename_detect_truncated=false after a truncated pass — "+
+			"MCP/dashboard/doctor cannot tell the rename data is partial.\nsidecar: %s", sideBytes)
+	}
+	if side.RenameDetectAddedSkipped <= 0 {
+		t.Errorf("sidecar rename_detect_added_skipped=%d, want >0", side.RenameDetectAddedSkipped)
+	}
+}
+
+// TestRenameDetect_CompleteRunReportsNoTruncation is the other half: an
+// ordinary index under the real default budget must not raise the alarm, or
+// the flag means nothing.
+func TestRenameDetect_CompleteRunReportsNoTruncation(t *testing.T) {
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+
+	repo := t.TempDir()
+	state := t.TempDir()
+	out := filepath.Join(state, "graph.json")
+
+	const n = 40
+	writeRenameFixtureRepo(t, repo, n, func(i int) string { return fmt.Sprintf("AlphaHandler%03d", i) })
+	if err := Index(repo, out, "rename-fixture", nil, false, false); err != nil {
+		t.Fatalf("first index: %v", err)
+	}
+	writeRenameFixtureRepo(t, repo, n, func(i int) string { return fmt.Sprintf("AlphaHandlers%03d", i) })
+	stderr := indexCapturingStderr(t, repo, out)
+
+	if strings.Contains(stderr, "TRUNCATED") {
+		t.Errorf("ordinary index reported truncation under the default budget.\nstderr:\n%s", stderr)
+	}
+
+	var side graph.GraphStatsSidecar
+	sideBytes, err := os.ReadFile(filepath.Join(state, "graph-stats.json"))
+	if err != nil {
+		t.Fatalf("read sidecar: %v", err)
+	}
+	if err := json.Unmarshal(sideBytes, &side); err != nil {
+		t.Fatalf("parse sidecar: %v", err)
+	}
+	if side.RenameDetectTruncated {
+		t.Errorf("sidecar reports truncation on a complete run: %s", sideBytes)
+	}
+
+	// And the renames themselves must actually be in the graph — a run that
+	// reports "not truncated" while detecting nothing is the same wrong answer
+	// wearing a different hat.
+	doc, err := graph.LoadGraphFromDir(state)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	renames := 0
+	for _, r := range doc.Relationships {
+		if r.Kind == "RENAMED_FROM" {
+			renames++
+		}
+	}
+	if renames == 0 {
+		t.Errorf("no RENAMED_FROM edges after renaming %d functions in place", n)
+	}
+}

--- a/cmd/grafel/sidecar_build.go
+++ b/cmd/grafel/sidecar_build.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/algorithms"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -32,6 +33,7 @@ func buildStatsSidecar(
 	canarySpiked bool,
 	prior *graph.GraphStatsSidecar,
 	computedAt time.Time,
+	renameStats algorithms.RenameStats,
 ) *graph.GraphStatsSidecar {
 	side := &graph.GraphStatsSidecar{
 		Version:            1,
@@ -42,6 +44,15 @@ func buildStatsSidecar(
 		ExtractMS:          extractMS,
 		ParseErrorCanary:   canaryRaw,
 		ParseErrorSpike:    canarySpiked,
+
+		// #6087 — rename-detection completeness, always taken from THIS run
+		// and never carried forward from prior: it describes the pass that
+		// produced the graph now being written, so a stale true would be as
+		// wrong as a stale false. A run that skipped the pass or had no prior
+		// graph writes false, which is correct — nothing was dropped.
+		RenameDetectTruncated:    renameStats.Truncated,
+		RenameDetectAddedSkipped: renameStats.AddedSkipped,
+		RenameDetectPairsSkipped: renameStats.PairsSkipped,
 	}
 
 	if doc.AlgorithmStats != nil {

--- a/cmd/grafel/sidecar_build_test.go
+++ b/cmd/grafel/sidecar_build_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cajasmota/grafel/internal/algorithms"
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
@@ -19,7 +20,7 @@ func TestBuildStatsSidecar_AlgoNil_CountsAlwaysWritten(t *testing.T) {
 	doc := &graph.Document{
 		Stats: graph.Stats{Files: 10, Entities: 200, Relationships: 66000},
 	}
-	side := buildStatsSidecar(doc, 1500, nil, false, nil, time.Unix(1000, 0).UTC())
+	side := buildStatsSidecar(doc, 1500, nil, false, nil, time.Unix(1000, 0).UTC(), algorithms.RenameStats{})
 
 	if side == nil {
 		t.Fatalf("buildStatsSidecar returned nil; sidecar must always be built so it can be written")
@@ -55,7 +56,7 @@ func TestBuildStatsSidecar_AlgoNil_PreservesPriorAlgoFields(t *testing.T) {
 		RuntimeMS:          8800,
 	}
 
-	side := buildStatsSidecar(doc, 2000, nil, false, prior, time.Unix(2000, 0).UTC())
+	side := buildStatsSidecar(doc, 2000, nil, false, prior, time.Unix(2000, 0).UTC(), algorithms.RenameStats{})
 
 	if side.TotalEntities != 300 || side.TotalRelationships != 500 || side.TotalFiles != 12 {
 		t.Errorf("counts must be refreshed from fresh doc.Stats, not carried from prior: %+v", side)
@@ -73,7 +74,7 @@ func TestBuildStatsSidecar_AlgoNil_NoPriorSidecar(t *testing.T) {
 	doc := &graph.Document{
 		Stats: graph.Stats{Files: 1, Entities: 5, Relationships: 4},
 	}
-	side := buildStatsSidecar(doc, 10, nil, false, nil, time.Unix(3000, 0).UTC())
+	side := buildStatsSidecar(doc, 10, nil, false, nil, time.Unix(3000, 0).UTC(), algorithms.RenameStats{})
 
 	if side.TotalEntities != 5 || side.TotalRelationships != 4 {
 		t.Errorf("counts: %+v", side)
@@ -109,7 +110,7 @@ func TestBuildStatsSidecar_AlgoPresent_AllFieldsFromFreshBuild(t *testing.T) {
 	}
 	canary := json.RawMessage(`{"spiked":false}`)
 
-	side := buildStatsSidecar(doc, 777, canary, true, prior, time.Unix(4000, 0).UTC())
+	side := buildStatsSidecar(doc, 777, canary, true, prior, time.Unix(4000, 0).UTC(), algorithms.RenameStats{})
 
 	if side.TotalFiles != 20 || side.TotalEntities != 400 || side.TotalRelationships != 900 {
 		t.Errorf("counts: %+v", side)

--- a/internal/algorithms/rename_detection.go
+++ b/internal/algorithms/rename_detection.go
@@ -38,15 +38,46 @@
 // The pass is append-only: it never removes or modifies existing entities or
 // edges.  It is safe to skip (--skip-pass=rename-detect) without affecting any
 // other pass.
+//
+// # Bounding (#6087)
+//
+// Phase 2 is pairwise: |deleted| × |added|.  With a largely dissimilar prior
+// graph over a large repo (~119k entities observed) that is ~1.4e10 pairs at
+// ~0.9 µs each — hours of pinned CPU on an index that otherwise takes 49
+// seconds.  Three ceilings now apply, cheapest first:
+//
+//  1. Kind bucketing — an added entity only ever visits deleted entities of
+//     the same Kind (the old code scanned every deleted entity and rejected on
+//     Kind inside the loop).
+//  2. Name-length banding — nameSimilarity >= 0.65 requires the edit distance
+//     to be <= 35 % of the longer name, and edit distance is at least the
+//     length difference.  Pairs outside that band are rejected without ever
+//     calling levenshtein.
+//  3. A hard pair budget (DefaultRenamePairBudget).  Added entities are
+//     visited cheapest-candidate-set-first, then by entity ID, so the cap
+//     falls in the same place on every run.  When the budget runs out the pass
+//     stops and reports RenameStats.Truncated together with how much work was
+//     dropped — it never silently claims "no renames found".
 package algorithms
 
 import (
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/grafel/internal/graph"
 )
+
+// DefaultRenamePairBudget caps the number of (deleted, added) candidate pairs
+// Phase 2 may visit in a single DetectRenames call.
+//
+// Sizing: a visited pair costs at most one levenshtein over two entity names,
+// measured at ~0.9 µs for ~18-character names, so 2e6 pairs bounds the pass at
+// roughly two seconds of CPU.  That is a rounding error against a 49-second
+// index and still enough headroom to fully examine any realistic delta — a
+// 1400-deleted × 1400-added change of a single kind fits inside it.
+const DefaultRenamePairBudget = 2_000_000
 
 // RelKindRenamedFrom is the edge kind emitted by the rename-detection pass.
 // The edge runs from the NEW entity (the post-rename entity) → the OLD entity
@@ -64,6 +95,25 @@ type RenameStats struct {
 	Moves int
 	// Splits is the number of split events (one old entity → two+ new ones).
 	Splits int
+
+	// PairBudget is the pair ceiling this run was given (#6087).
+	PairBudget int
+	// PairsExamined is the number of (deleted, added) candidate pairs Phase 2
+	// actually visited.  Always <= PairBudget.
+	PairsExamined int
+	// PairsPrefiltered is the subset of PairsExamined rejected by the cheap
+	// name-length band without running levenshtein.
+	PairsPrefiltered int
+	// Truncated reports that the pair budget ran out before every added entity
+	// had been examined.  Renames may exist that this run did not look for —
+	// callers must not read "0 renames" as "no renames exist".
+	Truncated bool
+	// AddedSkipped is the number of added entities never examined because the
+	// budget ran out.  Zero unless Truncated.
+	AddedSkipped int
+	// PairsSkipped is the number of candidate pairs those skipped entities
+	// would have contributed.  Zero unless Truncated.
+	PairsSkipped int
 }
 
 // DetectRenames compares prevDoc (the last persisted graph) and newDoc (the
@@ -75,6 +125,20 @@ type RenameStats struct {
 // same set of edges (because both docs are immutable from the caller's
 // perspective; only newDoc.Relationships grows).
 func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
+	return DetectRenamesBounded(prevDoc, newDoc, DefaultRenamePairBudget)
+}
+
+// DetectRenamesBounded is DetectRenames with an explicit Phase-2 pair budget
+// (#6087).  A budget <= 0 is treated as DefaultRenamePairBudget; there is no
+// unbounded mode, because an unbounded quadratic on the index path is the bug.
+//
+// Phase 1 (exact kind+name move detection) is a map probe and is never subject
+// to the budget: pure moves and pure renames-in-place are always detected in
+// full, however large the delta.
+func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) RenameStats {
+	if pairBudget <= 0 {
+		pairBudget = DefaultRenamePairBudget
+	}
 	if prevDoc == nil || newDoc == nil {
 		return RenameStats{}
 	}
@@ -136,6 +200,7 @@ func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
 
 	var stats RenameStats
 	stats.Candidates = len(deleted) * len(added)
+	stats.PairBudget = pairBudget
 
 	// Phase 1 — exact name+kind, file changed (move detection).
 	// Build lookup: (kind, name) → deleted entity for O(1) move probe.
@@ -176,21 +241,78 @@ func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
 	}
 
 	// Phase 2 — fuzzy rename matching for remaining added entities.
+	//
+	// Bounded (#6087). Candidates are bucketed by Kind so an added entity never
+	// scans deleted entities it could not possibly match, each bucket is sorted
+	// by ID, and added entities are visited smallest-bucket-first (then by ID).
+	// That ordering is deterministic AND cap-friendly: the cheap, high-yield
+	// candidates are examined before the budget can be burned by one enormous
+	// same-kind bucket.
+	byKind := make(map[string][]candidate, 8)
+	for _, d := range deleted {
+		byKind[d.Kind] = append(byKind[d.Kind], candidate{ent: d, lowLen: len(strings.ToLower(d.Name))})
+	}
+	for kind := range byKind {
+		bucket := byKind[kind]
+		sort.Slice(bucket, func(i, j int) bool { return bucket[i].ent.ID < bucket[j].ent.ID })
+	}
+
+	probes := make([]addedProbe, 0, len(remainingAdded))
 	for _, a := range remainingAdded {
+		probes = append(probes, addedProbe{
+			ent:     a,
+			lowLen:  len(strings.ToLower(a.Name)),
+			bucketN: len(byKind[a.Kind]),
+		})
+	}
+	sort.Slice(probes, func(i, j int) bool {
+		if probes[i].bucketN != probes[j].bucketN {
+			return probes[i].bucketN < probes[j].bucketN
+		}
+		return probes[i].ent.ID < probes[j].ent.ID
+	})
+
+	budgetLeft := pairBudget
+	for pi, p := range probes {
+		bucket := byKind[p.ent.Kind]
+		if len(bucket) > budgetLeft {
+			// Not enough budget left to examine this entity's candidates in
+			// full. Stop here rather than half-examining it: a partial scan
+			// would pick a "best match" from an arbitrary prefix of the
+			// bucket. Everything from here on is reported as dropped.
+			stats.Truncated = true
+			for _, rest := range probes[pi:] {
+				stats.AddedSkipped++
+				stats.PairsSkipped += len(byKind[rest.ent.Kind])
+			}
+			break
+		}
+
+		a := p.ent
 		bestEdge := renameEdge{}
 		bestScore := -1.0
 
-		for _, d := range deleted {
-			if d.Kind != a.Kind {
+		for _, c := range bucket {
+			d := c.ent
+			budgetLeft--
+			stats.PairsExamined++
+
+			// Cheap prefilter: nameSimilarity >= 0.65 requires an edit distance
+			// <= 35 % of the longer name, and edit distance is never smaller
+			// than the length difference. Pairs outside the band cannot pass,
+			// so skip the O(mn) levenshtein entirely.
+			if !lengthBandOK(p.lowLen, c.lowLen) {
+				stats.PairsPrefiltered++
 				continue
 			}
+
 			// Signal 1: name similarity.
 			// Threshold: reject pairs where more than 35 % of the longer name
 			// needs to change (sim < 0.65). This accepts common rename patterns
 			// like getUserByID→getUserByName (sim≈0.69) while rejecting
 			// completely unrelated names like foo→bar (sim=0.0).
 			nameSim := nameSimilarity(d.Name, a.Name)
-			if nameSim < 0.65 {
+			if nameSim < nameSimilarityFloor {
 				continue
 			}
 
@@ -239,8 +361,16 @@ func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
 	}
 
 	// Phase 3 — emit edges. Tag splits where one deleted entity maps to 2+
-	// new ones.
-	for deletedID, edges := range matchesByDeleted {
+	// new ones. Keys are sorted so the emitted edge order (and therefore the
+	// on-disk bytes before the final sort) does not depend on map iteration.
+	deletedIDs := make([]string, 0, len(matchesByDeleted))
+	for id := range matchesByDeleted {
+		deletedIDs = append(deletedIDs, id)
+	}
+	sort.Strings(deletedIDs)
+
+	for _, deletedID := range deletedIDs {
+		edges := matchesByDeleted[deletedID]
 		isSplit := len(edges) > 1
 		if isSplit {
 			stats.Splits++
@@ -277,6 +407,49 @@ func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
 }
 
 // ─── helpers ────────────────────────────────────────────────────────────────
+
+// candidate is a deleted entity plus its lowercased-name length, precomputed
+// once so the Phase-2 inner loop never re-lowercases (#6087).
+type candidate struct {
+	ent    graph.Entity
+	lowLen int
+}
+
+// addedProbe is an added entity plus the size of the candidate bucket it will
+// scan, used to order Phase 2 cheapest-first under the pair budget (#6087).
+type addedProbe struct {
+	ent     graph.Entity
+	lowLen  int
+	bucketN int
+}
+
+// nameSimilarityFloor is the minimum normalised-Levenshtein score Phase 2
+// accepts. It is duplicated as a named constant so lengthBandOK and the inner
+// loop cannot drift apart.
+const nameSimilarityFloor = 0.65
+
+// lengthBandOK reports whether two lowercased names are close enough in length
+// that nameSimilarity COULD reach nameSimilarityFloor.
+//
+// sim = 1 - dist/maxLen and dist >= |lenA-lenB|, so
+// sim <= 1 - |lenA-lenB|/maxLen. If that upper bound is already below the
+// floor, the pair is unmatchable and levenshtein can be skipped. The predicate
+// is a strict superset of the accepted set — it never rejects a pair the full
+// comparison would have accepted.
+func lengthBandOK(lenA, lenB int) bool {
+	maxLen := lenA
+	if lenB > maxLen {
+		maxLen = lenB
+	}
+	if maxLen == 0 {
+		return true
+	}
+	diff := lenA - lenB
+	if diff < 0 {
+		diff = -diff
+	}
+	return 1.0-float64(diff)/float64(maxLen) >= nameSimilarityFloor
+}
 
 // neighborIndex maps an entity ID to the set of IDs it is connected to (both
 // callers and callees across all edge kinds).

--- a/internal/algorithms/rename_detection.go
+++ b/internal/algorithms/rename_detection.go
@@ -53,11 +53,27 @@
 //     to be <= 35 % of the longer name, and edit distance is at least the
 //     length difference.  Pairs outside that band are rejected without ever
 //     calling levenshtein.
-//  3. A hard pair budget (DefaultRenamePairBudget).  Added entities are
-//     visited cheapest-candidate-set-first, then by entity ID, so the cap
-//     falls in the same place on every run.  When the budget runs out the pass
-//     stops and reports RenameStats.Truncated together with how much work was
-//     dropped — it never silently claims "no renames found".
+//  3. A hard WORK budget (DefaultRenameWorkBudget), denominated in
+//     Levenshtein DP cells rather than in pairs.  A pair budget would be the
+//     wrong unit: levenshtein is O(mn) in the name lengths, and grafel entity
+//     names are not uniformly short — http_endpoint entities are named
+//     "http:DELETE:/invoices/{id}" and a real nested route runs to 60+
+//     characters, so 2e6 pairs costs 1 s at 13-char names and 30 s at 90-char
+//     names.  Charging actual work keeps the ceiling in wall-clock terms
+//     whatever the names look like.  Added entities are visited
+//     cheapest-candidate-set-first, then by entity ID, so the cap falls in the
+//     same place on every run.  When the budget runs out the pass stops and
+//     reports RenameStats.Truncated together with how much work was dropped —
+//     it never silently claims "no renames found".
+//
+// Ordering caveat: cheapest-first maximises the NUMBER of added entities
+// examined and guarantees a rare kind is never starved by one enormous
+// Function/Method bucket — but it means that when truncation does bite, the
+// largest kind is the one sacrificed, and that is where renames are most
+// likely to live.  The budget is sized so that truncation only occurs well
+// outside the range of a realistic refactor (see DefaultRenameWorkBudget);
+// inside that range every kind is examined in full and the ordering has no
+// effect on the result.
 package algorithms
 
 import (
@@ -69,15 +85,35 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
-// DefaultRenamePairBudget caps the number of (deleted, added) candidate pairs
-// Phase 2 may visit in a single DetectRenames call.
+// DefaultRenameWorkBudget caps the work Phase 2 may perform in a single
+// DetectRenames call, denominated in Levenshtein DP cells.
 //
-// Sizing: a visited pair costs at most one levenshtein over two entity names,
-// measured at ~0.9 µs for ~18-character names, so 2e6 pairs bounds the pass at
-// roughly two seconds of CPU.  That is a rounding error against a 49-second
-// index and still enough headroom to fully examine any realistic delta — a
-// 1400-deleted × 1400-added change of a single kind fits inside it.
-const DefaultRenamePairBudget = 2_000_000
+// Accounting: visiting a candidate pair costs 1 unit (the length-band check is
+// a pair of integer compares); a pair that survives the band and actually runs
+// levenshtein costs an additional len(a)*len(b) units.  Band rejections are
+// therefore ~170x cheaper than comparisons at typical name lengths, instead of
+// costing the same as they would under a pair budget.
+//
+// Sizing: measured at 1.9–2.9 ns per DP cell, and the ceiling holds whatever
+// the names look like — a 20000x20000 dissimilar delta (4e8 pairs) exhausts
+// the budget in 9.1 s, and so does a 1200x1200 delta of 90-char names (7.0 s).
+// Against the 3.4-hour worst case this fixes, on an index that already takes
+// 49 s, that is the right trade.
+//
+// Coverage is what drove the number up from an earlier 2e6-PAIR cap: that cap
+// returned only 666 of 3000 renames on a 3000-entity same-kind refactor that
+// the old unbounded code got fully right in ~6 s — trading a hang for silent
+// incompleteness, which is the worse bug.  Measured at 4e9 units: a
+// 1500-entity same-kind refactor scores 1500/1500 and a 3000-entity one scores
+// 3000/3000, neither truncating; the same-kind ceiling is ~4000 entities at
+// typical (13-char) names, below which no realistic refactor truncates.  Above
+// it recall degrades (8000 scores 2074/8000) but the run is reported truncated
+// on stderr AND in graph-stats.json, so incompleteness is never silent.
+const DefaultRenameWorkBudget int64 = 4_000_000_000
+
+// pairVisitCost is what visiting a candidate pair costs before any comparison
+// runs — the length-band check. One DP-cell equivalent.
+const pairVisitCost = 1
 
 // RelKindRenamedFrom is the edge kind emitted by the rename-detection pass.
 // The edge runs from the NEW entity (the post-rename entity) → the OLD entity
@@ -96,15 +132,22 @@ type RenameStats struct {
 	// Splits is the number of split events (one old entity → two+ new ones).
 	Splits int
 
-	// PairBudget is the pair ceiling this run was given (#6087).
-	PairBudget int
+	// WorkBudget is the Phase-2 work ceiling this run was given, in
+	// Levenshtein DP cells (#6087).
+	WorkBudget int64
+	// WorkUsed is the work Phase 2 actually performed, in the same units.
+	// Always <= WorkBudget.
+	WorkUsed int64
 	// PairsExamined is the number of (deleted, added) candidate pairs Phase 2
-	// actually visited.  Always <= PairBudget.
+	// visited.
 	PairsExamined int
 	// PairsPrefiltered is the subset of PairsExamined rejected by the cheap
 	// name-length band without running levenshtein.
 	PairsPrefiltered int
-	// Truncated reports that the pair budget ran out before every added entity
+	// Comparisons is the number of pairs that survived the band and ran a full
+	// name comparison. PairsExamined = PairsPrefiltered + Comparisons.
+	Comparisons int
+	// Truncated reports that the work budget ran out before every added entity
 	// had been examined.  Renames may exist that this run did not look for —
 	// callers must not read "0 renames" as "no renames exist".
 	Truncated bool
@@ -125,19 +168,27 @@ type RenameStats struct {
 // same set of edges (because both docs are immutable from the caller's
 // perspective; only newDoc.Relationships grows).
 func DetectRenames(prevDoc, newDoc *graph.Document) RenameStats {
-	return DetectRenamesBounded(prevDoc, newDoc, DefaultRenamePairBudget)
+	return DetectRenamesBounded(prevDoc, newDoc, DefaultRenameWorkBudget)
 }
 
-// DetectRenamesBounded is DetectRenames with an explicit Phase-2 pair budget
-// (#6087).  A budget <= 0 is treated as DefaultRenamePairBudget; there is no
-// unbounded mode, because an unbounded quadratic on the index path is the bug.
+// DetectRenamesBounded is DetectRenames with an explicit Phase-2 work budget in
+// Levenshtein DP cells (#6087).  A budget <= 0 is treated as
+// DefaultRenameWorkBudget; there is no unbounded mode, because an unbounded
+// quadratic on the index path is the bug.
 //
-// Phase 1 (exact kind+name move detection) is a map probe and is never subject
-// to the budget: pure moves and pure renames-in-place are always detected in
-// full, however large the delta.
-func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) RenameStats {
-	if pairBudget <= 0 {
-		pairBudget = DefaultRenamePairBudget
+// What is and is not budgeted:
+//
+//   - Phase 1 is a (Kind, Name) map probe and is never budgeted, so a pure MOVE
+//     — same kind, same name, different file — is always detected in full,
+//     however large the delta.
+//   - A rename-in-place is NOT a Phase-1 match (the name changed, so the map
+//     probe misses) and falls through to budgeted Phase 2.  Renames are
+//     therefore subject to truncation; the budget is sized so this only bites
+//     outside the range of a realistic refactor, but it is not a guarantee.
+//     Check RenameStats.Truncated before reading a rename count as complete.
+func DetectRenamesBounded(prevDoc, newDoc *graph.Document, workBudget int64) RenameStats {
+	if workBudget <= 0 {
+		workBudget = DefaultRenameWorkBudget
 	}
 	if prevDoc == nil || newDoc == nil {
 		return RenameStats{}
@@ -200,7 +251,7 @@ func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) Renam
 
 	var stats RenameStats
 	stats.Candidates = len(deleted) * len(added)
-	stats.PairBudget = pairBudget
+	stats.WorkBudget = workBudget
 
 	// Phase 1 — exact name+kind, file changed (move detection).
 	// Build lookup: (kind, name) → deleted entity for O(1) move probe.
@@ -249,8 +300,11 @@ func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) Renam
 	// candidates are examined before the budget can be burned by one enormous
 	// same-kind bucket.
 	byKind := make(map[string][]candidate, 8)
+	sumLowLen := make(map[string]int64, 8)
 	for _, d := range deleted {
-		byKind[d.Kind] = append(byKind[d.Kind], candidate{ent: d, lowLen: len(strings.ToLower(d.Name))})
+		l := len(strings.ToLower(d.Name))
+		byKind[d.Kind] = append(byKind[d.Kind], candidate{ent: d, lowLen: l})
+		sumLowLen[d.Kind] += int64(l)
 	}
 	for kind := range byKind {
 		bucket := byKind[kind]
@@ -259,27 +313,38 @@ func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) Renam
 
 	probes := make([]addedProbe, 0, len(remainingAdded))
 	for _, a := range remainingAdded {
+		lowLen := len(strings.ToLower(a.Name))
 		probes = append(probes, addedProbe{
 			ent:     a,
-			lowLen:  len(strings.ToLower(a.Name)),
+			lowLen:  lowLen,
 			bucketN: len(byKind[a.Kind]),
+			// Worst-case cost of scanning this entity's whole bucket: one
+			// visit per candidate, plus a full levenshtein against every one
+			// of them. Computed in O(1) from the per-kind length sum.
+			maxCost: int64(len(byKind[a.Kind]))*pairVisitCost + int64(lowLen)*sumLowLen[a.Kind],
 		})
 	}
 	sort.Slice(probes, func(i, j int) bool {
-		if probes[i].bucketN != probes[j].bucketN {
-			return probes[i].bucketN < probes[j].bucketN
+		if probes[i].maxCost != probes[j].maxCost {
+			return probes[i].maxCost < probes[j].maxCost
 		}
 		return probes[i].ent.ID < probes[j].ent.ID
 	})
 
-	budgetLeft := pairBudget
+	budgetLeft := workBudget
 	for pi, p := range probes {
 		bucket := byKind[p.ent.Kind]
-		if len(bucket) > budgetLeft {
+		if p.maxCost > budgetLeft {
 			// Not enough budget left to examine this entity's candidates in
 			// full. Stop here rather than half-examining it: a partial scan
 			// would pick a "best match" from an arbitrary prefix of the
 			// bucket. Everything from here on is reported as dropped.
+			//
+			// The admission test is deliberately conservative — it uses the
+			// worst case (every candidate survives the band) rather than the
+			// actual cost, which is not knowable without doing the scan. A
+			// bucket that would in fact have been cheap can therefore be
+			// dropped; the alternative is a partial scan, which is worse.
 			stats.Truncated = true
 			for _, rest := range probes[pi:] {
 				stats.AddedSkipped++
@@ -294,17 +359,24 @@ func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) Renam
 
 		for _, c := range bucket {
 			d := c.ent
-			budgetLeft--
+			budgetLeft -= pairVisitCost
+			stats.WorkUsed += pairVisitCost
 			stats.PairsExamined++
 
 			// Cheap prefilter: nameSimilarity >= 0.65 requires an edit distance
 			// <= 35 % of the longer name, and edit distance is never smaller
 			// than the length difference. Pairs outside the band cannot pass,
-			// so skip the O(mn) levenshtein entirely.
+			// so skip the O(mn) levenshtein entirely — and, crucially, charge
+			// nothing for it beyond the visit: a band rejection is two integer
+			// compares, not a comparison's worth of work.
 			if !lengthBandOK(p.lowLen, c.lowLen) {
 				stats.PairsPrefiltered++
 				continue
 			}
+			cost := int64(p.lowLen) * int64(c.lowLen)
+			budgetLeft -= cost
+			stats.WorkUsed += cost
+			stats.Comparisons++
 
 			// Signal 1: name similarity.
 			// Threshold: reject pairs where more than 35 % of the longer name
@@ -337,6 +409,15 @@ func DetectRenamesBounded(prevDoc, newDoc *graph.Document, pairBudget int) Renam
 			// Weights: name=0.5, neighborhood=0.35, file=0.15.
 			confidence := nameSim*0.50 + nbSim*0.35 + sameFile*0.15
 
+			// Ties keep the FIRST candidate encountered (the comparison is
+			// strict). Before #6087 the scan ran over `deleted` in
+			// prevDoc.Entities order; it now runs over the kind bucket sorted
+			// by entity ID. Both are deterministic, but they are not the same
+			// order — on equal confidence a DIFFERENT deleted entity can win,
+			// so this changes which edges are emitted, not merely the order
+			// they are emitted in. Sorting by ID is the deliberate choice: it
+			// does not depend on how the previous graph happened to be laid
+			// out on disk.
 			if confidence > bestScore {
 				method := buildMethodTag(nameSim, nbSim, sameFile > 0)
 				bestScore = confidence
@@ -421,6 +502,9 @@ type addedProbe struct {
 	ent     graph.Entity
 	lowLen  int
 	bucketN int
+	// maxCost is the worst-case Phase-2 work of scanning this entity's whole
+	// candidate bucket, in the same DP-cell units as the work budget.
+	maxCost int64
 }
 
 // nameSimilarityFloor is the minimum normalised-Levenshtein score Phase 2

--- a/internal/algorithms/rename_detection_bound_6087_test.go
+++ b/internal/algorithms/rename_detection_bound_6087_test.go
@@ -1,0 +1,213 @@
+package algorithms_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/algorithms"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ─── #6087 — the rename-detection pass must be bounded ───────────────────────
+//
+// DetectRenames ran an unbounded pairwise comparison over (deleted × added)
+// entities. With a largely dissimilar prior graph over ~119k entities that is
+// ~1.4e10 pairs at ~0.9 µs/pair — hours of pinned CPU on a 49-second index.
+//
+// The guards below are behavioural: they assert on the work actually performed
+// and on the edges actually emitted, not on the source text.
+
+// noisePair builds `n` deleted and `n` added entities of kind `kind` whose
+// names are the same length but share no useful structure, so nothing matches
+// and every pair survives every cheap prefilter.
+func noiseDocs(n int, kind string) (prev, next []graph.Entity) {
+	for i := 0; i < n; i++ {
+		on := fmt.Sprintf("alphaOld%05d", i)
+		nn := fmt.Sprintf("betaNew__%04d", i)
+		of := fmt.Sprintf("old/p%03d.go", i%64)
+		nf := fmt.Sprintf("new/p%03d.go", i%64)
+		prev = append(prev, graph.Entity{ID: entityID(kind, on, of), Name: on, Kind: kind, SourceFile: of})
+		next = append(next, graph.Entity{ID: entityID(kind, nn, nf), Name: nn, Kind: kind, SourceFile: nf})
+	}
+	return prev, next
+}
+
+// TestDetectRenames_PairBudgetBounded pins the ceiling: with an explicit budget
+// far below the full pair count, the pass must stop early and must SAY that it
+// stopped early. Removing the bound makes PairsExamined blow past the budget
+// and Truncated go false — this test fails either way.
+func TestDetectRenames_PairBudgetBounded(t *testing.T) {
+	t.Parallel()
+
+	const n = 400 // 160_000 pairs
+	prev, next := noiseDocs(n, "Function")
+	prevDoc := makeDoc(prev, nil)
+	newDoc := makeDoc(next, nil)
+
+	const budget = 1000
+	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, budget)
+
+	if !stats.Truncated {
+		t.Errorf("expected Truncated=true with budget=%d over %d pairs, got false", budget, n*n)
+	}
+	if stats.PairsExamined > budget {
+		t.Errorf("pair budget not enforced: examined=%d budget=%d", stats.PairsExamined, budget)
+	}
+	if stats.AddedSkipped <= 0 {
+		t.Errorf("expected some added entities to be reported as skipped, got %d", stats.AddedSkipped)
+	}
+	if stats.PairsSkipped <= 0 {
+		t.Errorf("expected the dropped pair count to be reported, got %d", stats.PairsSkipped)
+	}
+	if stats.PairBudget != budget {
+		t.Errorf("PairBudget = %d, want %d", stats.PairBudget, budget)
+	}
+}
+
+// TestDetectRenames_DefaultBudgetBounded pins that the DEFAULT entry point —
+// the one cmd/grafel actually calls — is bounded too. A fix that only bounds
+// the explicit-budget variant leaves the shipped path quadratic.
+func TestDetectRenames_DefaultBudgetBounded(t *testing.T) {
+	t.Parallel()
+
+	if algorithms.DefaultRenamePairBudget <= 0 {
+		t.Fatalf("DefaultRenamePairBudget must be positive, got %d", algorithms.DefaultRenamePairBudget)
+	}
+
+	// Enough entities that the full pair set exceeds the default budget.
+	n := 1
+	for n*n <= algorithms.DefaultRenamePairBudget {
+		n *= 2
+	}
+	prev, next := noiseDocs(n, "Function")
+	prevDoc := makeDoc(prev, nil)
+	newDoc := makeDoc(next, nil)
+
+	stats := algorithms.DetectRenames(prevDoc, newDoc)
+
+	if !stats.Truncated {
+		t.Errorf("default path not bounded: %d pairs, budget %d, Truncated=false",
+			n*n, algorithms.DefaultRenamePairBudget)
+	}
+	if stats.PairsExamined > algorithms.DefaultRenamePairBudget {
+		t.Errorf("default budget not enforced: examined=%d budget=%d",
+			stats.PairsExamined, algorithms.DefaultRenamePairBudget)
+	}
+}
+
+// TestDetectRenames_TruncationKeepsCheapCandidates asserts detection quality
+// survives the cap: a genuine rename whose candidate set is tiny must still be
+// found even when a huge same-kind noise set exhausts the budget. Asserted on
+// edge CONTENT (which old entity, under which name), so a pass that emits the
+// right number of edges pointing at the wrong entities still fails.
+func TestDetectRenames_TruncationKeepsCheapCandidates(t *testing.T) {
+	t.Parallel()
+
+	const n = 400
+	prev, next := noiseDocs(n, "Function")
+
+	// A genuine rename in a kind of its own, so its candidate bucket is tiny.
+	const file = "pkg/repo.go"
+	oldName, newName := "loadUserRecord", "loadUserRecords"
+	oldID := entityID("Method", oldName, file)
+	newID := entityID("Method", newName, file)
+	prev = append(prev, graph.Entity{ID: oldID, Name: oldName, Kind: "Method", SourceFile: file})
+	next = append(next, graph.Entity{ID: newID, Name: newName, Kind: "Method", SourceFile: file})
+
+	prevDoc := makeDoc(prev, nil)
+	newDoc := makeDoc(next, nil)
+
+	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, 1000)
+	if !stats.Truncated {
+		t.Fatalf("fixture did not truncate; the guard would be vacuous")
+	}
+
+	rel := findRenamedFrom(newDoc, newID)
+	if rel == nil {
+		t.Fatalf("genuine rename %s -> %s lost under truncation", oldName, newName)
+	}
+	if rel.ToID != oldID {
+		t.Errorf("RENAMED_FROM points at %q, want %q", rel.ToID, oldID)
+	}
+	if got := rel.PropGet("old_name"); got != oldName {
+		t.Errorf("old_name = %q, want %q", got, oldName)
+	}
+}
+
+// TestDetectRenames_BoundedIsDeterministic pins that the cap falls in the same
+// place on every run: same edges, same targets, same stats. A map-iteration
+// dependent cap would produce a different surviving edge set across runs.
+func TestDetectRenames_BoundedIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	const n = 200
+	build := func() (*graph.Document, *graph.Document) {
+		prev, next := noiseDocs(n, "Function")
+		// Sprinkle in real renames so there is content to compare.
+		for i := 0; i < 8; i++ {
+			f := fmt.Sprintf("pkg/svc%02d.go", i)
+			on := fmt.Sprintf("handleOrder%02d", i)
+			nn := fmt.Sprintf("handleOrders%02d", i)
+			prev = append(prev, graph.Entity{ID: entityID("Method", on, f), Name: on, Kind: "Method", SourceFile: f})
+			next = append(next, graph.Entity{ID: entityID("Method", nn, f), Name: nn, Kind: "Method", SourceFile: f})
+		}
+		return makeDoc(prev, nil), makeDoc(next, nil)
+	}
+
+	fingerprint := func(doc *graph.Document) []string {
+		var out []string
+		for _, r := range doc.Relationships {
+			if r.Kind == algorithms.RelKindRenamedFrom {
+				out = append(out, r.FromID+"->"+r.ToID+"|"+r.PropGet("method")+"|"+r.PropGet("old_name")+"|"+r.PropGet("confidence"))
+			}
+		}
+		return out
+	}
+
+	p1, n1 := build()
+	s1 := algorithms.DetectRenamesBounded(p1, n1, 900)
+	p2, n2 := build()
+	s2 := algorithms.DetectRenamesBounded(p2, n2, 900)
+
+	f1, f2 := fingerprint(n1), fingerprint(n2)
+	if len(f1) == 0 {
+		t.Fatalf("fixture produced no rename edges; guard would be vacuous")
+	}
+	if len(f1) != len(f2) {
+		t.Fatalf("non-deterministic edge count: %d vs %d", len(f1), len(f2))
+	}
+	for i := range f1 {
+		if f1[i] != f2[i] {
+			t.Errorf("edge %d differs across runs:\n  %s\n  %s", i, f1[i], f2[i])
+		}
+	}
+	if s1.PairsExamined != s2.PairsExamined || s1.Truncated != s2.Truncated || s1.AddedSkipped != s2.AddedSkipped {
+		t.Errorf("non-deterministic stats: %+v vs %+v", s1, s2)
+	}
+}
+
+// TestDetectRenames_UntruncatedRunsReportNoTruncation guards the other failure
+// mode: an ordinary small delta must NOT be reported as truncated, or the
+// signal is worthless.
+func TestDetectRenames_UntruncatedRunsReportNoTruncation(t *testing.T) {
+	t.Parallel()
+
+	const file = "pkg/service.go"
+	oldName, newName := "getUserByID", "getUserByName"
+	oldID := entityID("Function", oldName, file)
+	newID := entityID("Function", newName, file)
+
+	prevDoc := makeDoc([]graph.Entity{{ID: oldID, Name: oldName, Kind: "Function", SourceFile: file}}, nil)
+	newDoc := makeDoc([]graph.Entity{{ID: newID, Name: newName, Kind: "Function", SourceFile: file}}, nil)
+
+	stats := algorithms.DetectRenames(prevDoc, newDoc)
+	if stats.Truncated {
+		t.Errorf("small delta wrongly reported as truncated: %+v", stats)
+	}
+	if stats.AddedSkipped != 0 || stats.PairsSkipped != 0 {
+		t.Errorf("small delta reported dropped work: %+v", stats)
+	}
+	if findRenamedFrom(newDoc, newID) == nil {
+		t.Errorf("ordinary rename not detected")
+	}
+}

--- a/internal/algorithms/rename_detection_bound_6087_test.go
+++ b/internal/algorithms/rename_detection_bound_6087_test.go
@@ -2,6 +2,7 @@ package algorithms_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/algorithms"
@@ -17,7 +18,7 @@ import (
 // The guards below are behavioural: they assert on the work actually performed
 // and on the edges actually emitted, not on the source text.
 
-// noisePair builds `n` deleted and `n` added entities of kind `kind` whose
+// noiseDocs builds `n` deleted and `n` added entities of kind `kind` whose
 // names are the same length but share no useful structure, so nothing matches
 // and every pair survives every cheap prefilter.
 func noiseDocs(n int, kind string) (prev, next []graph.Entity) {
@@ -32,26 +33,59 @@ func noiseDocs(n int, kind string) (prev, next []graph.Entity) {
 	return prev, next
 }
 
-// TestDetectRenames_PairBudgetBounded pins the ceiling: with an explicit budget
-// far below the full pair count, the pass must stop early and must SAY that it
-// stopped early. Removing the bound makes PairsExamined blow past the budget
-// and Truncated go false — this test fails either way.
-func TestDetectRenames_PairBudgetBounded(t *testing.T) {
+// renameDocs builds `n` genuine same-file, same-kind renames: name N -> name
+// N+"s", which is a high-similarity in-place rename of exactly the shape a
+// refactor produces. Returns the prev/new entity slices and the new→old ID map
+// the caller uses to assert recall by CONTENT.
+func renameDocs(n int, kind string) (prev, next []graph.Entity, wantEdge map[string]string) {
+	wantEdge = make(map[string]string, n)
+	for i := 0; i < n; i++ {
+		f := fmt.Sprintf("pkg/svc%04d.go", i)
+		on := fmt.Sprintf("handleOrder%04d", i)
+		nn := fmt.Sprintf("handleOrders%04d", i)
+		oid := entityID(kind, on, f)
+		nid := entityID(kind, nn, f)
+		prev = append(prev, graph.Entity{ID: oid, Name: on, Kind: kind, SourceFile: f})
+		next = append(next, graph.Entity{ID: nid, Name: nn, Kind: kind, SourceFile: f})
+		wantEdge[nid] = oid
+	}
+	return prev, next, wantEdge
+}
+
+// recall counts how many of the wanted new→old RENAMED_FROM edges are present
+// AND point at the right old entity. Content, not counts: an implementation
+// that emits the right number of edges pointing at the wrong entities scores 0.
+func recall(doc *graph.Document, wantEdge map[string]string) int {
+	got := 0
+	for newID, oldID := range wantEdge {
+		rel := findRenamedFrom(doc, newID)
+		if rel != nil && rel.ToID == oldID {
+			got++
+		}
+	}
+	return got
+}
+
+// TestDetectRenames_WorkBudgetBounded pins the ceiling: with an explicit budget
+// far below the full cost, the pass must stop early and must SAY that it
+// stopped early. Removing the bound makes WorkUsed blow past the budget and
+// Truncated go false — this test fails either way.
+func TestDetectRenames_WorkBudgetBounded(t *testing.T) {
 	t.Parallel()
 
-	const n = 400 // 160_000 pairs
+	const n = 400 // 160_000 pairs, ~170 work units each
 	prev, next := noiseDocs(n, "Function")
 	prevDoc := makeDoc(prev, nil)
 	newDoc := makeDoc(next, nil)
 
-	const budget = 1000
+	const budget = 10_000
 	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, budget)
 
 	if !stats.Truncated {
 		t.Errorf("expected Truncated=true with budget=%d over %d pairs, got false", budget, n*n)
 	}
-	if stats.PairsExamined > budget {
-		t.Errorf("pair budget not enforced: examined=%d budget=%d", stats.PairsExamined, budget)
+	if stats.WorkUsed > budget {
+		t.Errorf("work budget not enforced: used=%d budget=%d", stats.WorkUsed, budget)
 	}
 	if stats.AddedSkipped <= 0 {
 		t.Errorf("expected some added entities to be reported as skipped, got %d", stats.AddedSkipped)
@@ -59,39 +93,149 @@ func TestDetectRenames_PairBudgetBounded(t *testing.T) {
 	if stats.PairsSkipped <= 0 {
 		t.Errorf("expected the dropped pair count to be reported, got %d", stats.PairsSkipped)
 	}
-	if stats.PairBudget != budget {
-		t.Errorf("PairBudget = %d, want %d", stats.PairBudget, budget)
+	if stats.WorkBudget != budget {
+		t.Errorf("WorkBudget = %d, want %d", stats.WorkBudget, budget)
+	}
+	if stats.PairsExamined != stats.PairsPrefiltered+stats.Comparisons {
+		t.Errorf("accounting inconsistent: examined=%d prefiltered=%d comparisons=%d",
+			stats.PairsExamined, stats.PairsPrefiltered, stats.Comparisons)
 	}
 }
 
-// TestDetectRenames_DefaultBudgetBounded pins that the DEFAULT entry point —
-// the one cmd/grafel actually calls — is bounded too. A fix that only bounds
-// the explicit-budget variant leaves the shipped path quadratic.
-func TestDetectRenames_DefaultBudgetBounded(t *testing.T) {
+// TestDetectRenames_BandRejectionsAreCheap pins the accounting fix: a pair
+// rejected by the length band is two integer compares, and must not consume a
+// full comparison's worth of budget. Under a pair-denominated budget a band
+// rejection cost exactly as much as a Levenshtein, so a delta full of
+// length-mismatched names burned the ceiling doing nothing.
+//
+// Both fixtures have the same pair count. The band-rejecting one must cost
+// dramatically less work.
+func TestDetectRenames_BandRejectionsAreCheap(t *testing.T) {
 	t.Parallel()
 
-	if algorithms.DefaultRenamePairBudget <= 0 {
-		t.Fatalf("DefaultRenamePairBudget must be positive, got %d", algorithms.DefaultRenamePairBudget)
+	const n = 120
+	const kind = "Function"
+
+	buildPrev := func() *graph.Document {
+		var prev []graph.Entity
+		for i := 0; i < n; i++ {
+			on := fmt.Sprintf("alphaHandler%04d", i) // 16 chars
+			of := fmt.Sprintf("old/p%03d.go", i)
+			prev = append(prev, graph.Entity{ID: entityID(kind, on, of), Name: on, Kind: kind, SourceFile: of})
+		}
+		return makeDoc(prev, nil)
+	}
+	buildNext := func(newName func(i int) string) *graph.Document {
+		var next []graph.Entity
+		for i := 0; i < n; i++ {
+			nn := newName(i)
+			nf := fmt.Sprintf("new/p%03d.go", i)
+			next = append(next, graph.Entity{ID: entityID(kind, nn, nf), Name: nn, Kind: kind, SourceFile: nf})
+		}
+		return makeDoc(next, nil)
 	}
 
-	// Enough entities that the full pair set exceeds the default budget.
-	n := 1
-	for n*n <= algorithms.DefaultRenamePairBudget {
-		n *= 2
-	}
-	prev, next := noiseDocs(n, "Function")
-	prevDoc := makeDoc(prev, nil)
-	newDoc := makeDoc(next, nil)
+	const hugeBudget = int64(1) << 40
+	// Same length as the deleted names → in band → full comparisons.
+	sameLen := algorithms.DetectRenamesBounded(buildPrev(),
+		buildNext(func(i int) string { return fmt.Sprintf("betaProcess_%04d", i) }), hugeBudget)
+	// Wildly different length → out of band → visit only.
+	outOfBand := algorithms.DetectRenamesBounded(buildPrev(),
+		buildNext(func(i int) string { return fmt.Sprintf("b%04d", i) }), hugeBudget)
 
-	stats := algorithms.DetectRenames(prevDoc, newDoc)
+	if sameLen.PairsExamined != outOfBand.PairsExamined {
+		t.Fatalf("fixtures must examine the same pair count: %d vs %d",
+			sameLen.PairsExamined, outOfBand.PairsExamined)
+	}
+	if outOfBand.Comparisons != 0 {
+		t.Errorf("out-of-band fixture ran %d comparisons, want 0", outOfBand.Comparisons)
+	}
+	if sameLen.Comparisons == 0 {
+		t.Fatalf("in-band fixture ran no comparisons; guard would be vacuous")
+	}
+	// The in-band fixture must cost at least an order of magnitude more work
+	// for the identical number of pairs.
+	if sameLen.WorkUsed < 10*outOfBand.WorkUsed {
+		t.Errorf("band rejections are not being charged less: in-band work=%d out-of-band work=%d",
+			sameLen.WorkUsed, outOfBand.WorkUsed)
+	}
+}
+
+// TestDetectRenames_DefaultBudgetIsFiniteAndEnforced pins that the DEFAULT
+// entry point — the one cmd/grafel actually calls — is bounded too. A fix that
+// only bounds the explicit-budget variant leaves the shipped path quadratic.
+//
+// The fixture is deliberately cheap to build and cheap to reject: one added
+// entity against a bucket whose worst-case cost exceeds the default budget, so
+// the admission test fires immediately and no work is done.
+func TestDetectRenames_DefaultBudgetIsFiniteAndEnforced(t *testing.T) {
+	t.Parallel()
+
+	if algorithms.DefaultRenameWorkBudget <= 0 {
+		t.Fatalf("DefaultRenameWorkBudget must be positive, got %d", algorithms.DefaultRenameWorkBudget)
+	}
+
+	const nameLen = 1000
+	// The worst-case cost of the single added entity's bucket is
+	// len(bucket) + nameLen*sum(nameLen), i.e. ~bucket*nameLen^2. Size the
+	// bucket so that comfortably exceeds the default budget — the admission
+	// test must then reject it without doing any work at all.
+	bucket := int(algorithms.DefaultRenameWorkBudget/int64(nameLen*nameLen)) + 256
+	long := strings.Repeat("a", nameLen-8)
+
+	prev := make([]graph.Entity, 0, bucket)
+	for i := 0; i < bucket; i++ {
+		on := fmt.Sprintf("%s%06d", long, i)
+		f := fmt.Sprintf("old/p%05d.go", i)
+		prev = append(prev, graph.Entity{ID: entityID("Function", on, f), Name: on, Kind: "Function", SourceFile: f})
+	}
+	nn := fmt.Sprintf("%s%06d", strings.Repeat("b", nameLen-8), 0)
+	next := []graph.Entity{{ID: entityID("Function", nn, "new/p.go"), Name: nn, Kind: "Function", SourceFile: "new/p.go"}}
+
+	stats := algorithms.DetectRenames(makeDoc(prev, nil), makeDoc(next, nil))
 
 	if !stats.Truncated {
-		t.Errorf("default path not bounded: %d pairs, budget %d, Truncated=false",
-			n*n, algorithms.DefaultRenamePairBudget)
+		t.Errorf("default path not bounded: worst-case cost ~%d, budget %d, Truncated=false",
+			int64(bucket)*int64(1+nameLen*nameLen), algorithms.DefaultRenameWorkBudget)
 	}
-	if stats.PairsExamined > algorithms.DefaultRenamePairBudget {
-		t.Errorf("default budget not enforced: examined=%d budget=%d",
-			stats.PairsExamined, algorithms.DefaultRenamePairBudget)
+	if stats.WorkUsed > algorithms.DefaultRenameWorkBudget {
+		t.Errorf("default budget not enforced: used=%d budget=%d",
+			stats.WorkUsed, algorithms.DefaultRenameWorkBudget)
+	}
+	if stats.AddedSkipped != 1 {
+		t.Errorf("AddedSkipped = %d, want 1", stats.AddedSkipped)
+	}
+	// Admission rejected the bucket up front, so nothing was scanned.
+	if stats.WorkUsed != 0 || stats.PairsExamined != 0 {
+		t.Errorf("over-budget bucket was partially scanned: work=%d pairs=%d",
+			stats.WorkUsed, stats.PairsExamined)
+	}
+}
+
+// TestDetectRenames_DefaultBudgetCoversARealisticRefactor is the guard a
+// too-small budget fails. It is the direct regression test for the first
+// version of this fix, whose 2e6-PAIR budget returned 666 of 3000 renames on
+// exactly this shape — trading a hang for silent incompleteness, the worse bug.
+//
+// 3000 same-kind renames-in-place is a large but entirely ordinary refactor
+// (a package-wide method rename). It must be detected in FULL, with no
+// truncation, under the shipped default.
+func TestDetectRenames_DefaultBudgetCoversARealisticRefactor(t *testing.T) {
+	t.Parallel()
+
+	const n = 3000
+	prev, next, wantEdge := renameDocs(n, "Method")
+	newDoc := makeDoc(next, nil)
+
+	stats := algorithms.DetectRenames(makeDoc(prev, nil), newDoc)
+
+	if stats.Truncated {
+		t.Errorf("a %d-entity same-kind refactor was truncated under the default budget "+
+			"(used=%d budget=%d, %d added entities dropped) — the budget is too small",
+			n, stats.WorkUsed, stats.WorkBudget, stats.AddedSkipped)
+	}
+	if got := recall(newDoc, wantEdge); got != n {
+		t.Errorf("recall %d/%d renames under the default budget", got, n)
 	}
 }
 
@@ -117,7 +261,7 @@ func TestDetectRenames_TruncationKeepsCheapCandidates(t *testing.T) {
 	prevDoc := makeDoc(prev, nil)
 	newDoc := makeDoc(next, nil)
 
-	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, 1000)
+	stats := algorithms.DetectRenamesBounded(prevDoc, newDoc, 10_000)
 	if !stats.Truncated {
 		t.Fatalf("fixture did not truncate; the guard would be vacuous")
 	}
@@ -165,9 +309,16 @@ func TestDetectRenames_BoundedIsDeterministic(t *testing.T) {
 	}
 
 	p1, n1 := build()
-	s1 := algorithms.DetectRenamesBounded(p1, n1, 900)
+	s1 := algorithms.DetectRenamesBounded(p1, n1, 60_000)
 	p2, n2 := build()
-	s2 := algorithms.DetectRenamesBounded(p2, n2, 900)
+	s2 := algorithms.DetectRenamesBounded(p2, n2, 60_000)
+
+	// The determinism being pinned is specifically determinism UNDER
+	// truncation; without this assertion the fixture could drift into fitting
+	// the budget and the guard would silently stop testing anything.
+	if !s1.Truncated {
+		t.Fatalf("fixture no longer truncates; the determinism guard would be vacuous")
+	}
 
 	f1, f2 := fingerprint(n1), fingerprint(n2)
 	if len(f1) == 0 {
@@ -181,33 +332,75 @@ func TestDetectRenames_BoundedIsDeterministic(t *testing.T) {
 			t.Errorf("edge %d differs across runs:\n  %s\n  %s", i, f1[i], f2[i])
 		}
 	}
-	if s1.PairsExamined != s2.PairsExamined || s1.Truncated != s2.Truncated || s1.AddedSkipped != s2.AddedSkipped {
+	if s1.WorkUsed != s2.WorkUsed || s1.Truncated != s2.Truncated || s1.AddedSkipped != s2.AddedSkipped {
 		t.Errorf("non-deterministic stats: %+v vs %+v", s1, s2)
 	}
 }
 
-// TestDetectRenames_UntruncatedRunsReportNoTruncation guards the other failure
-// mode: an ordinary small delta must NOT be reported as truncated, or the
-// signal is worthless.
-func TestDetectRenames_UntruncatedRunsReportNoTruncation(t *testing.T) {
+// TestDetectRenames_FittingDeltaReportsNoTruncation guards the other failure
+// mode: a delta that fits must NOT be reported as truncated, or the signal is
+// worthless. Uses a 1000×1000 delta — large enough that a budget
+// implementation which truncates on any sizeable input fails here, unlike a
+// 1×1 delta which almost anything passes.
+func TestDetectRenames_FittingDeltaReportsNoTruncation(t *testing.T) {
 	t.Parallel()
 
-	const file = "pkg/service.go"
-	oldName, newName := "getUserByID", "getUserByName"
+	const n = 1000
+	prev, next, wantEdge := renameDocs(n, "Function")
+	newDoc := makeDoc(next, nil)
+
+	stats := algorithms.DetectRenamesBounded(makeDoc(prev, nil), newDoc, algorithms.DefaultRenameWorkBudget)
+
+	if stats.Truncated {
+		t.Errorf("fitting %dx%d delta wrongly reported as truncated: %+v", n, n, stats)
+	}
+	if stats.AddedSkipped != 0 || stats.PairsSkipped != 0 {
+		t.Errorf("fitting delta reported dropped work: added=%d pairs=%d",
+			stats.AddedSkipped, stats.PairsSkipped)
+	}
+	if got := recall(newDoc, wantEdge); got != n {
+		t.Errorf("recall %d/%d on a fitting delta", got, n)
+	}
+}
+
+// TestDetectRenames_BandBoundaryIsInclusive pins the exact off-by-one the
+// losslessness argument depends on.
+//
+// lengthBandOK admits a pair when 1 - diff/maxLen >= 0.65. At maxLen=20,
+// diff=7 that expression is 0.65000000000000002 — accepted by the band AND by
+// the inner-loop similarity floor, because they are the same float
+// computation. Tightening the band to a strict `>` silently drops this pair,
+// and every other pair on the boundary, losing real renames. That mutation
+// survives every other test in this package.
+func TestDetectRenames_BandBoundaryIsInclusive(t *testing.T) {
+	t.Parallel()
+
+	const file = "pkg/handlers.go"
+	// 20 chars -> 13 chars by deleting a 7-char suffix: distance exactly 7,
+	// similarity exactly 1 - 7/20 = 0.65, the inclusive boundary.
+	oldName := "handleUserRequest123"
+	newName := "handleUserReq"
+	if len(oldName) != 20 || len(newName) != 13 {
+		t.Fatalf("fixture drift: len(old)=%d len(new)=%d, want 20 and 13", len(oldName), len(newName))
+	}
+
 	oldID := entityID("Function", oldName, file)
 	newID := entityID("Function", newName, file)
-
 	prevDoc := makeDoc([]graph.Entity{{ID: oldID, Name: oldName, Kind: "Function", SourceFile: file}}, nil)
 	newDoc := makeDoc([]graph.Entity{{ID: newID, Name: newName, Kind: "Function", SourceFile: file}}, nil)
 
 	stats := algorithms.DetectRenames(prevDoc, newDoc)
-	if stats.Truncated {
-		t.Errorf("small delta wrongly reported as truncated: %+v", stats)
+
+	if stats.Comparisons != 1 {
+		t.Fatalf("boundary pair was rejected by the length band: comparisons=%d prefiltered=%d "+
+			"(the band must admit sim == 0.65 exactly, or real renames are lost)",
+			stats.Comparisons, stats.PairsPrefiltered)
 	}
-	if stats.AddedSkipped != 0 || stats.PairsSkipped != 0 {
-		t.Errorf("small delta reported dropped work: %+v", stats)
+	rel := findRenamedFrom(newDoc, newID)
+	if rel == nil {
+		t.Fatalf("boundary rename %s -> %s not detected", oldName, newName)
 	}
-	if findRenamedFrom(newDoc, newID) == nil {
-		t.Errorf("ordinary rename not detected")
+	if rel.ToID != oldID {
+		t.Errorf("RENAMED_FROM points at %q, want %q", rel.ToID, oldID)
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -586,6 +586,26 @@ type GraphStatsSidecar struct {
 	// ParseErrorSpike mirrors ParseErrorCanary.spiked at the top level so
 	// dashboards / crons can read the alarm without decoding the full report.
 	ParseErrorSpike bool `json:"parse_error_spike,omitempty"`
+
+	// RenameDetectTruncated reports that the rename-detection pass (#6087) hit
+	// its work budget and did NOT examine every candidate entity, so the
+	// RENAMED_FROM edges in the accompanying graph are a PARTIAL result.
+	//
+	// This exists because the stderr warning is invisible to every
+	// programmatic consumer: MCP, the dashboard and `grafel doctor` read the
+	// graph, not the indexer's log. A consumer that reports "no renames" off a
+	// truncated index is stating a confident wrong answer; this flag is how it
+	// can tell the difference. Absent/false means the pass ran to completion
+	// (or was skipped, or there was no prior graph to compare against — in all
+	// of which cases no rename data was dropped).
+	RenameDetectTruncated bool `json:"rename_detect_truncated,omitempty"`
+	// RenameDetectAddedSkipped is how many added entities the truncated pass
+	// never examined. Only meaningful when RenameDetectTruncated is true.
+	RenameDetectAddedSkipped int `json:"rename_detect_added_skipped,omitempty"`
+	// RenameDetectPairsSkipped is how many candidate pairs those skipped
+	// entities would have contributed. Only meaningful when
+	// RenameDetectTruncated is true.
+	RenameDetectPairsSkipped int `json:"rename_detect_pairs_skipped,omitempty"`
 }
 
 // WriteSidecar emits the graph-stats.json sidecar next to the main document.


### PR DESCRIPTION
`DetectRenames` ran unbounded pairwise Levenshtein over deleted × added **entities**. Clean N² at ~0.88 µs/pair — at the reported ~119k entities that is ~1.4e10 pairs ≈ **3.4 hours**, consistent with the issue's "49-second index still running after 13 minutes."

Single call site, `cmd/grafel/index.go:720` (Pass 5.5), on **both** the full and incremental paths — `Index` is the shared entry point.

## Two corrections to the issue's framing

The Levenshtein is over entity **names**, not paths or file contents — so per-pair cost is small and the pair *count* dominates entirely. And content-hash matching does not apply here, since this compares graph entities rather than files; the equivalent exact-match short-circuit (a `Kind+Name` map probe) already existed as Phase 1.

## Three ceilings, cheapest first

1. **Kind bucketing** — an added entity only ever visits same-`Kind` deleted entities. Provably lossless: the old code did `if d.Kind != a.Kind { continue }` inside the loop, exactly equivalent.
2. **Name-length banding** — `sim >= 0.65` requires edit distance ≤ 35% of the longer name, and edit distance ≥ the length difference, so out-of-band pairs can never have been accepted.
3. **A work budget**, described below.

**The band's losslessness was verified, not asserted.** Review derived it independently from `nameSimilarity` and then attacked it empirically: 2,000,000 random pairs across five alphabets including length-changing Unicode, exhaustive over all strings ≤6 chars on a binary alphabet, and every pure-insertion pair for base lengths 1–60. **Zero** cases where `!lengthBandOK` but `sim >= 0.65`. It also confirmed `lowLen` uses the same byte length `nameSimilarity` does, so `İ`-class case folding stays consistent, and that in the tight case the two are the *same float computation*, so there is no boundary drift.

## The budget is denominated in work, not pairs — and the first version was wrong

The first attempt used a 2,000,000-**pair** budget. Review showed that trades a hang for silent incompleteness, which is the worse bug:

| scenario | 2e6 pairs | unbounded |
|---|---|---|
| 3000 same-kind renames | 666/3000, 1.39 s | 3000/3000, 6.15 s |
| 8000 same-kind renames | 250/8000, 1.48 s | 8000/8000, 44.4 s |

For a routine 3000-entity refactor the old code returned a **fully correct** answer in ~6 s, on an index that already takes 49 s. That saved 4.8 s and dropped 78% of the renames.

Two causes, both fixed:

- **Band rejections were charged full price.** `budgetLeft--` fired before the band check, so an integer compare consumed the same budget as a full Levenshtein.
- **A pair count cannot bound work.** Levenshtein is O(mn), so 2e6 pairs is 0.97 s at 13-char names, 6.78 s at 40, and **30.5 s at 90**.

The budget is now **Levenshtein DP cells, default 4e9**. Visiting a pair costs 1 unit; a pair that survives the band and actually runs the comparison costs `len(a)*len(b)`. Band rejections are ~170× cheaper than comparisons instead of equal. Admission remains O(1) per added entity — worst-case cost is computed from a per-kind length sum — so the no-partial-scan invariant is preserved.

| scenario | 2e6 pairs | 4e9 units | unbounded |
|---|---|---|---|
| 1500 same-kind renames | 1333/1500 | **1500/1500**, 1.18 s | 1500/1500, 1.19 s |
| 3000 same-kind renames | 666/3000 | **3000/3000**, 4.64 s | 3000/3000, 4.65 s |
| 8000 same-kind renames | 250/8000 | 2074/8000, 8.4 s, truncated | 8000/8000, 32.4 s |
| 20000 × 20000 dissimilar | — | **9.1 s**, truncated | ~350 s |
| 1200 × 1200, 90-char names | — | **7.0 s**, truncated | ~30 s+ |

The last row is the point of the unit change: the ceiling holds at ~9–10 s regardless of name length.

**Long names are real, established from the corpus rather than assumed.** Across `internal/quality/golden/*/expected.json`: mean 12.3, p50 11, p95 26, max 42. `http_endpoint_definition` entities are named like `http:DELETE:/invoices/{id}` — 26 chars in a *mini* fixture; a real nested route runs past 60. So the 30-second worst case was reachable, not theoretical.

Full recall now holds to ~4000 same-kind entities at typical name lengths. Beyond that recall degrades and the run says so in both channels.

**Ordering:** probes are visited smallest-candidate-bucket-first, then by entity ID — deterministic rather than map-iteration-dependent. Review objected that this sacrifices the largest bucket, normally `Function`/`Method`, where renames actually happen. The objection is correct in isolation but largest-first is worse overall: one 100k-entity `Function` bucket would consume the whole budget in a few hundred probes and starve every rare kind, detecting fewer renames in total. With the budget sized so truncation only bites outside a realistic refactor, ordering has no effect inside that range. The trade is documented in the package doc rather than left implicit.

## Determinism

Verified more strongly than in-process testing can: review ran a truncating 4-kind fixture in **five separate OS processes** — Go randomizes map iteration per process — and got byte-identical edge fingerprints, stats and edge counts every time.

No edge can come from a partial scan: the `len(bucket) > budgetLeft` guard is evaluated *before* entering the bucket loop, `bestScore` resets per probe, and the inner loop has no budget break. If a bucket does not fit the remaining budget the pass stops rather than picking a best match from an arbitrary prefix.

## Truncation is reported in both channels

Human: `index.go` logs `rename-detect: TRUNCATED — pair budget N exhausted … INCOMPLETE for this run`.

Machine: persisted to `graph-stats.json` — the artefact MCP, the dashboard and `grafel doctor` actually read — as `rename_detect_truncated`, `rename_detect_added_skipped`, `rename_detect_pairs_skipped`. Always taken from the current run, **never carried forward from the prior sidecar**, since a stale `true` would be as wrong as a stale `false`.

Before review, `Truncated` existed only in `RenameStats`, which nothing but `index.go` consumed — so a truncated index was non-silent to a human tailing stderr and **fully silent to every downstream consumer**.

## Phase 1 is unbudgeted, and the comment saying more than that is gone

Pure moves (exact `Kind+Name`) are a map probe and are never budgeted — verified with `pairBudget=1` against 400 noise entities, the move is still detected.

The doc comment additionally claimed pure **renames-in-place** are always detected. That is false: Phase 1 keys on `Kind+Name`, so a rename-in-place never matches it and falls to budgeted Phase 2. Measured, a 1500-entity same-file rename refactor lost 167 under the old budget. The comment now states only what holds, and tells the reader to check `Truncated` before treating a rename count as complete.

## Also fixed

- **Phase 3 emitted in map order** — a pre-existing nondeterminism hit while making the cap deterministic. Now sorted. Verified order-only: `matchesByDeleted` is fully populated beforehand, Phase 3 makes no dedup decision, and `isSplit` depends solely on `len(edges)`.
- **Phase 2's tie-break winner changed** and was initially undocumented. Scan order moved from `prevDoc.Entities` order to bucket-sorted-by-ID; selection is `confidence > bestScore` (strict), so ties keep the first encountered and **a different deleted entity can now win on equal confidence** — a change in which edges are emitted, not merely their order. ID order is deliberate: it does not depend on the previous graph's on-disk layout. Now documented at the site.

## Tests

Behavioural, asserting on edge content (`ToID`, `old_name`) rather than counts — a count assertion cannot see detect-and-lose.

The band boundary is now pinned by `TestDetectRenames_BandBoundaryIsInclusive`: `handleUserRequest123` (20) → `handleUserReq` (13), distance exactly 7, similarity exactly 0.65. It asserts the band admitted the pair *and* that the edge points at the right old entity. This closes a **live rename-losing mutation** review found — changing `>=` to `>` previously survived the whole suite, and real pairs exist at `sim=0.65000000000000002`.

Two guards strengthened: the no-false-truncation case was a 1×1 delta that many broken implementations would pass, now a 1000×1000 fitting delta asserting full recall by content; and the determinism guard now asserts `Truncated` so it cannot silently stop exercising truncation.

**Five mutants verified failing**: bound removed · band tightened to `>` · band rejections charged full price · stderr warning deleted · sidecar flag hardcoded false.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`:

| package | exit | pass | skip |
|---|---|---|---|
| `./internal/algorithms/...` | 0 | 17 | **0** |
| `./internal/graph/...` | 0 | 431 | **0** |
| `./cmd/grafel/` | 0 | 325 | 7 |

0 FAIL throughout. The 7 skips are pre-existing env-gated gates.

Independently adversarially reviewed, returned REQUEST-CHANGES on the budget sizing, re-verified.

Closes #6087
