### PR TITLE
fix(#6118): Python EndLine omission + C# file components starved by the class shadow-fold

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -1,0 +1,563 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Issue #6118 — span completeness of the entities the in-process custom
+// extractor gate (GRAFEL_INPROC_CUSTOM_EXTRACTORS) adds, and the C# file-level
+// component start-line regression the same gate causes.
+//
+// WHY THIS IS BEHAVIOURAL AND NOT A SOURCE SCAN. Three source-scanning guards
+// written in this area recently all fell to trivial mutants: a scan that
+// asserts "every EntityRecord literal in internal/custom mentions EndLine" is
+// satisfied by `EndLine: 0`. These tests index a real multi-language fixture
+// with the gate off and on, persist and reload both graphs through
+// graph.LoadGraphFromDir, and assert on the CONTENT of what lands on disk.
+
+// writeSpanFixture6118 lays down a fixture covering the languages that
+// actually contribute added entities under the gate. C# and Java dominate the
+// corpus gain (84% between them), so both are represented in depth; the C#
+// files are deliberately named after the class they declare, because that is
+// the precondition for the file-component fold whose regression this pins.
+func writeSpanFixture6118(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"cs/OrdersController.cs": `using Microsoft.AspNetCore.Mvc;
+
+namespace Shop.Api
+{
+    [ApiController]
+    [Route("api/orders")]
+    public class OrdersController : ControllerBase
+    {
+        private readonly IOrderService _svc;
+
+        public OrdersController(IOrderService svc) { _svc = svc; }
+
+        [HttpGet]
+        [Authorize(Roles = "admin")]
+        public IActionResult List()
+        {
+            return Ok(_svc.All());
+        }
+
+        [HttpPost("{id}")]
+        public IActionResult Create(int id)
+        {
+            return Ok();
+        }
+    }
+}
+`,
+		// A DbContext, a MassTransit consumer, a MediatR handler, a
+		// FluentValidation validator and a Quartz job: each is a class the C#
+		// custom extractors re-emit under a framework-typed kind, which is what
+		// turns the base AST SCOPE.Component into a shadow fold SOURCE.
+		"cs/ShopContext.cs": `using Microsoft.EntityFrameworkCore;
+
+namespace Shop.Api
+{
+    public class ShopContext : DbContext
+    {
+        public DbSet<Order> Orders { get; set; }
+    }
+}
+`,
+		"cs/OrderCreatedConsumer.cs": `using MassTransit;
+
+namespace Shop.Api
+{
+    public class OrderCreatedConsumer : IConsumer<OrderCreated>
+    {
+        public async Task Consume(ConsumeContext<OrderCreated> context)
+        {
+        }
+    }
+}
+`,
+		"cs/CreateOrderHandler.cs": `using MediatR;
+
+namespace Shop.Api
+{
+    public class CreateOrderHandler : IRequestHandler<CreateOrder, int>
+    {
+        public Task<int> Handle(CreateOrder request, CancellationToken ct)
+        {
+            return Task.FromResult(1);
+        }
+    }
+}
+`,
+		"cs/OrderValidator.cs": `using FluentValidation;
+
+namespace Shop.Api
+{
+    public class OrderValidator : AbstractValidator<Order>
+    {
+        public OrderValidator()
+        {
+            RuleFor(x => x.Total).NotEmpty();
+        }
+    }
+}
+`,
+		"cs/CleanupJob.cs": `using Quartz;
+
+namespace Shop.Api
+{
+    public class CleanupJob : IJob
+    {
+        public Task Execute(IJobExecutionContext context)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}
+`,
+		"cs/Startup.cs": `using Microsoft.Extensions.DependencyInjection;
+
+namespace Shop.Api
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddScoped<IOrderService, OrderService>();
+            services.AddSingleton<ICache, MemCache>();
+            services.AddDbContext<ShopContext>();
+        }
+    }
+}
+`,
+		"java/OrdersController.java": `package api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrdersController {
+    @GetMapping("/orders")
+    public String list() {
+        return "[]";
+    }
+
+    @PostMapping("/orders")
+    public String create() {
+        return "{}";
+    }
+}
+`,
+		"ts/routes.ts": `import express from "express";
+
+const app = express();
+
+app.get("/api/items", (req, res) => res.json([]));
+app.post("/api/items", (req, res) => res.status(201).json({}));
+
+export default app;
+`,
+		"web/server.js": `const express = require("express");
+const app = express();
+
+app.get("/api/orders", (req, res) => res.json([]));
+
+module.exports = app;
+`,
+		// Python: settings + URLconf + DRF serializer + Celery task. This is
+		// the language whose custom-extractor helper never populated EndLine.
+		"myproj/settings.py": `
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "rest_framework",
+    "myapp",
+]
+ROOT_URLCONF = "myproj.urls"
+DATABASES = {"default": {"ENGINE": "django.db.backends.postgresql", "NAME": "app"}}
+`,
+		"myproj/urls.py": `
+from django.urls import path
+from myapp import views
+
+urlpatterns = [
+    path("orders/", views.OrderList.as_view(), name="order-list"),
+    path("health/", views.health, name="health"),
+]
+`,
+		"myapp/models.py": `
+from django.db import models
+
+
+class Order(models.Model):
+    reference = models.CharField(max_length=64)
+`,
+		"myapp/serializers.py": `
+from rest_framework import serializers
+from myapp.models import Order
+
+
+class OrderSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Order
+        fields = ["id", "reference"]
+`,
+		"myapp/views.py": `
+from rest_framework import generics
+from rest_framework.decorators import api_view
+from rest_framework.response import Response
+from myapp.models import Order
+from myapp.serializers import OrderSerializer
+
+
+class OrderList(generics.ListCreateAPIView):
+    queryset = Order.objects.all()
+    serializer_class = OrderSerializer
+
+
+@api_view(["GET"])
+def health(request):
+    return Response({"ok": True})
+`,
+		"myapp/tasks.py": `
+from celery import shared_task
+
+
+@shared_task
+def send_receipt(order_id):
+    return order_id
+`,
+		"svc/handler.go": `package svc
+
+import "net/http"
+
+// Handler serves the orders API.
+type Handler struct{}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}
+`,
+		"rs/routes.rs": `use axum::{routing::get, Router};
+
+pub fn app() -> Router {
+    Router::new().route("/items", get(list_items))
+}
+
+async fn list_items() -> &'static str {
+    "[]"
+}
+`,
+	}
+	for rel, body := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// indexSpanFixtureBothArms indexes the #6118 fixture with the gate off and on,
+// round-tripping each arm through the on-disk graph (see persistAndReload —
+// asserting on the in-memory Document would be blind to anything persistence
+// rewrites).
+func indexSpanFixtureBothArms(t *testing.T) (off, on *graph.Document) {
+	t.Helper()
+	fixture := writeSpanFixture6118(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	off = persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	on = persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
+	return off, on
+}
+
+// TestCustomExtractorAddedEntitiesCarryACompleteSpan is the #6118 headline
+// gate: every entity the custom-extractor gate ADDS must be locatable in its
+// own source file — StartLine > 0 and EndLine >= StartLine.
+//
+// "Added" is computed as a CONTENT-tuple delta (entityTuples/tupleDelta), not
+// a count: an entity mutated in place shows up as one destroyed tuple plus one
+// added tuple, and the added half is held to the same standard.
+func TestCustomExtractorAddedEntitiesCarryACompleteSpan(t *testing.T) {
+	off, on := indexSpanFixtureBothArms(t)
+
+	// Index the ON graph by content tuple so an added tuple can be resolved
+	// back to the entity that carries it.
+	byTuple := map[string]*graph.Entity{}
+	for i := range on.Entities {
+		e := &on.Entities[i]
+		byTuple[entityTupleKey(e)] = e
+	}
+
+	_, added := tupleDelta(entityTuples(off, ""), entityTuples(on, ""))
+	if len(added) == 0 {
+		t.Fatalf("fixture produced no added entities — the gate is not firing, so this test is vacuous")
+	}
+
+	var bad []string
+	for _, tup := range added {
+		e, ok := byTuple[tup]
+		if !ok {
+			t.Fatalf("added tuple %q not found in the ON graph", tup)
+		}
+		if e.StartLine <= 0 || e.EndLine < e.StartLine {
+			bad = append(bad, fmt.Sprintf("%s|%s|%s start=%d end=%d",
+				e.Kind, e.Name, e.SourceFile, e.StartLine, e.EndLine))
+		}
+	}
+	sort.Strings(bad)
+	if len(bad) > 0 {
+		t.Errorf("%d of %d entities added by the custom-extractor gate lack a complete span "+
+			"(want StartLine > 0 and EndLine >= StartLine):\n  %s",
+			len(bad), len(added), strings.Join(bad, "\n  "))
+	}
+}
+
+// TestCustomExtractorGateDoesNotRegressFileComponentStartLines pins the second
+// #6118 defect: a SCOPE.Component(subtype="file") entity that carries a real
+// start line with the gate OFF must not lose it when the gate is ON.
+//
+// MECHANISM. foldFileComponentDuplicates promotes a class-like
+// SCOPE.Component's span onto its co-located file entity. It runs AFTER
+// foldClassHierarchyShadows. With the gate on, the C# custom extractors emit a
+// framework-typed node for the same symbol (DbContext, MassTransit consumer,
+// MediatR handler, Quartz job, …), which turns the base AST class component
+// into a shadow fold SOURCE — it is dropped before the file fold ever sees it,
+// so the file entity is left at line 0. An entity that had a correct position
+// loses it.
+func TestCustomExtractorGateDoesNotRegressFileComponentStartLines(t *testing.T) {
+	off, on := indexSpanFixtureBothArms(t)
+
+	spans := func(doc *graph.Document) map[string][2]int {
+		out := map[string][2]int{}
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+				out[e.SourceFile] = [2]int{e.StartLine, e.EndLine}
+			}
+		}
+		return out
+	}
+	offSpans, onSpans := spans(off), spans(on)
+
+	var regressed []string
+	for file, o := range offSpans {
+		n, ok := onSpans[file]
+		if !ok {
+			t.Errorf("file component for %s disappeared with the gate on", file)
+			continue
+		}
+		if o[0] > 0 && n[0] <= 0 {
+			regressed = append(regressed, fmt.Sprintf("%s: start %d -> %d", file, o[0], n[0]))
+		}
+		if o[1] > 0 && n[1] <= 0 {
+			regressed = append(regressed, fmt.Sprintf("%s: end %d -> %d", file, o[1], n[1]))
+		}
+	}
+	sort.Strings(regressed)
+	if len(regressed) > 0 {
+		t.Errorf("%d file-level components lost a real position under the gate:\n  %s",
+			len(regressed), strings.Join(regressed, "\n  "))
+	}
+
+	// Guard against the test being satisfied by the fixture producing no
+	// positioned C# file components at all.
+	positioned := 0
+	for file, s := range offSpans {
+		if strings.HasPrefix(file, "cs/") && s[0] > 0 {
+			positioned++
+		}
+	}
+	if positioned < 4 {
+		t.Fatalf("fixture no longer exercises the regression: only %d C# file components "+
+			"carry a start line with the gate OFF", positioned)
+	}
+}
+
+// entityTupleKey is the same content tuple entityTuples aggregates on, for a
+// single entity.
+func entityTupleKey(e *graph.Entity) string {
+	return fmt.Sprintf("%s|%s|%s|%s|%s|%d|%d",
+		e.Kind, e.Name, e.QualifiedName, e.Subtype, e.SourceFile, e.StartLine, e.EndLine)
+}
+
+// semanticDigest6118 is a stable content digest of a graph: entities as
+// content tuples, relationships keyed by the CONTENT of their endpoints rather
+// than by entity ID.
+//
+// WHY ENDPOINTS ARE KEYED BY CONTENT. Entity IDs embed the repo tag and are
+// re-stamped by the merge, so an ID-keyed digest reports churn that is not a
+// content change (#6083 — raw graph.fb bytes are meaningless for the same
+// reason). Keying an edge by its endpoints' content tuples makes the digest
+// sensitive to a real rewiring and blind to a re-keying.
+func semanticDigest6118(doc *graph.Document) string {
+	byID := map[string]string{}
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = entityTupleKey(&doc.Entities[i])
+	}
+	lines := make([]string, 0, len(doc.Entities)+len(doc.Relationships))
+	for i := range doc.Entities {
+		lines = append(lines, "E "+entityTupleKey(&doc.Entities[i]))
+	}
+	resolve := func(id string) string {
+		if t, ok := byID[id]; ok {
+			return t
+		}
+		return "?" + id
+	}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		lines = append(lines, fmt.Sprintf("R %s -[%s]-> %s", resolve(r.FromID), r.Kind, resolve(r.ToID)))
+	}
+	sort.Strings(lines)
+	h := sha256.New()
+	for _, l := range lines {
+		h.Write([]byte(l))
+		h.Write([]byte{'\n'})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// gateOffDigest6118Base is the semantic digest of the #6118 fixture indexed
+// with GRAFEL_INPROC_CUSTOM_EXTRACTORS unset, captured at 2f0175dfc — the
+// commit this work branched from. gateOffDigest6118 is the digest after the
+// span-donation fix.
+//
+// THIS PIN IS DELIBERATELY A PAIR, AND THE PAIR IS THE POINT. Everything in
+// #5989/#6118 is reachable only with the gate ON, so the working assumption
+// going in was that the fix would leave the default graph byte-identical in
+// content. IT DOES NOT, and pretending otherwise by quietly re-baselining a
+// single constant would hide the most important thing this change found:
+//
+// the C# start-line regression is NOT caused by the gate. The gate only makes
+// it fire more often. foldFileComponentDuplicates is the only pass that ever
+// positions a SCOPE.Component(subtype="file"), and it is starved whenever
+// foldClassHierarchyShadows has already consumed the class component that
+// would have donated the span. That happens on the DEFAULT path too, wherever
+// a framework-typed node already exists for the symbol — an ASP.NET
+// controller, a Spring @Service, a Django CBV.
+//
+// On this fixture the default-path change is exactly one entity, and it is a
+// pure gain of information with nothing destroyed:
+//
+//	cs/OrdersController.cs  SCOPE.Component(subtype="file")  start 0 -> 5
+//
+// Entity and relationship counts are unchanged (141 / 284), no entity loses a
+// position, and no edge is rewired. TestCustomExtractorGateOffDeltaIsExactly-
+// TheDocumentedSpanGain below asserts that shape directly, so the deviation is
+// pinned behaviourally and not merely absorbed into a hash.
+//
+// If gateOffDigest6118 fails again, the change is no longer gate-scoped in the
+// way described here: characterise the new delta and say so, rather than
+// re-baselining a second time.
+const (
+	gateOffDigest6118Base = "a0a6ede910d8d0465d901153f483b27b8a57a565bdd79dd0104bef53786d9ca1"
+	gateOffDigest6118     = "387a9c36cb585b4d73828afc997744dbe02e6df347e0860054adf69431996d46"
+)
+
+func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
+	fixture := writeSpanFixture6118(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
+	got := semanticDigest6118(off)
+	if got == gateOffDigest6118 {
+		return
+	}
+	if got == gateOffDigest6118Base {
+		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
+			"span donation is no longer reaching the default path")
+	}
+	t.Fatalf("gate-OFF graph changed against BOTH pinned digests\n got  %s\n post-fix %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6118, gateOffDigest6118Base,
+		len(off.Entities), len(off.Relationships))
+}
+
+// TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain pins the shape
+// of the default-path change described above, in content terms rather than as
+// a hash: the gate-OFF graph must keep its 2f0175dfc entity and relationship
+// counts, every file component that had a position must still have it, and the
+// one entity that was positionless and is now positioned must be the documented
+// one.
+func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T) {
+	fixture := writeSpanFixture6118(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
+
+	const (
+		wantEntities = 141
+		wantRels     = 284
+	)
+	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
+		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+
+			"the span donation must add and destroy nothing",
+			len(off.Entities), wantEntities, len(off.Relationships), wantRels)
+	}
+
+	// Every file component in the fixture that a positioned declaration can
+	// donate to must now be positioned, including the one that regressed at
+	// 2f0175dfc because its class component had already been shadow-folded.
+	want := map[string]int{
+		"cs/OrdersController.cs":     5,
+		"cs/ShopContext.cs":          5,
+		"cs/OrderCreatedConsumer.cs": 5,
+		"cs/CreateOrderHandler.cs":   5,
+		"cs/CleanupJob.cs":           5,
+		"cs/OrderValidator.cs":       5,
+		"cs/Startup.cs":              5,
+	}
+	got := map[string]int{}
+	for i := range off.Entities {
+		e := &off.Entities[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+			got[e.SourceFile] = e.StartLine
+		}
+	}
+	for file, wantLine := range want {
+		if got[file] != wantLine {
+			t.Errorf("gate-OFF file component %s: start=%d, want %d", file, got[file], wantLine)
+		}
+	}
+}
+
+// TestFileComponentSpanDonationIsDeterministic guards the donor tie-break: two
+// runs over the same fixture must position every file component identically.
+// The donor scan walks `merged` in slice order, so a non-deterministic choice
+// would show up as a flapping start line rather than as a crash.
+func TestFileComponentSpanDonationIsDeterministic(t *testing.T) {
+	fixture := writeSpanFixture6118(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	spans := func() map[string][2]int {
+		doc := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
+		out := map[string][2]int{}
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+				out[e.SourceFile] = [2]int{e.StartLine, e.EndLine}
+			}
+		}
+		return out
+	}
+	a, b := spans(), spans()
+	if len(a) != len(b) {
+		t.Fatalf("file component count is not stable across runs: %d vs %d", len(a), len(b))
+	}
+	for f, sa := range a {
+		if sb := b[f]; sa != sb {
+			t.Errorf("%s span is not stable across runs: %v vs %v", f, sa, sb)
+		}
+	}
+}

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -4605,6 +4605,11 @@ type foldFileComponentStats struct {
 	// EdgesRepointed is the number of edge endpoints rewritten from a folded
 	// class-like component ID to its file-entity survivor ID.
 	EdgesRepointed int
+	// SpansDonated is the number of positionless file entities that took their
+	// span from a surviving stem-named declaration in the same file, because
+	// the class-like component that would normally have donated it was already
+	// consumed by foldClassHierarchyShadows (#6118).
+	SpansDonated int
 }
 
 // filePathStem returns the base filename without extension, lower-cased.
@@ -4738,6 +4743,107 @@ func (i *Indexer) foldFileComponentDuplicates(
 			sv.Relationships = append(sv.Relationships, rel)
 		}
 		r.Relationships = nil
+	}
+
+	// --- Span donation from a surviving stem-named declaration (#6118) ------
+	//
+	// THE DEFECT THIS CLOSES. The loop above is the ONLY thing that ever gives
+	// a SCOPE.Component(subtype="file") entity a position: FileEntity() emits
+	// it with no span, and the span is promoted from the class-like
+	// SCOPE.Component that shares its file and matches its stem. But this pass
+	// runs AFTER foldClassHierarchyShadows, which drops that very class
+	// component whenever a framework-typed node exists for the same symbol.
+	// When it does, the file entity is left at line 0 — an entity that had a
+	// correct position in one configuration loses it in another.
+	//
+	// That is exactly the shape #6118 measured on the corpus: 187 C# file-level
+	// components regressing from a real start line to 0 with
+	// GRAFEL_INPROC_CUSTOM_EXTRACTORS on. The gate does not create the defect,
+	// it only makes it fire more often — turning on the C# custom extractors
+	// emits framework-typed nodes for DbContexts, MassTransit consumers, MediatR
+	// handlers, Quartz jobs and so on, so more class components become shadow
+	// fold sources and disappear before this pass can read them. The same loss
+	// is reachable on the default path wherever a framework-typed node already
+	// exists (an ASP.NET controller, a Spring @Service, a Django CBV).
+	//
+	// The fix is to stop depending on WHICH node survived. A file entity with
+	// no position takes its span from any SURVIVING entity in the same file
+	// whose name matches the file stem — the class-like component when it is
+	// still there, the framework-typed survivor when it is not. This donates a
+	// span only; it folds nothing, drops nothing and re-keys nothing, so it
+	// cannot interact with the remap/drop bookkeeping below and deliberately
+	// sits ahead of the `len(remap) == 0` early return.
+	//
+	// THE DONOR SET IS DELIBERATELY NARROW. It is exactly "a class-like
+	// declaration": a framework-typed class kind (frameworkClassKindPriority —
+	// the survivor set foldClassHierarchyShadows folds INTO) or a class-like
+	// SCOPE.Component (the fold-source set it folds AWAY). Anything looser is
+	// wrong, not merely over-eager: a Go file caller2.go declaring
+	// `func Caller2()` has a SCOPE.Operation whose name matches the stem, and
+	// letting a function donate its line to the file entity says "this file
+	// starts where that function starts", which is false. It also breaks
+	// incremental/full-rebuild equivalence, because the incremental path does
+	// not run this fold at all — caught by TestDiffReindex_NewCrossFileCall and
+	// its four siblings.
+	isClassLikeDonor := func(r *types.EntityRecord) bool {
+		if _, ok := frameworkClassKindPriority[r.Kind]; ok {
+			return true
+		}
+		return r.Kind == "SCOPE.Component" && r.Subtype != "file" &&
+			(classLikeComponentSubtypes[r.Subtype] || r.Properties["role"] == "class")
+	}
+
+	// Deterministic donor choice: smallest real start line, then largest end
+	// line, then smallest ID.
+	for _, fe := range fileBySourceFile {
+		sv := &merged[fe.idx]
+		if sv.StartLine > 0 || drop[fe.idx] {
+			continue
+		}
+		donor := -1
+		for k := range merged {
+			if k == fe.idx || drop[k] {
+				continue
+			}
+			r := &merged[k]
+			if r.StartLine <= 0 || r.SourceFile != sv.SourceFile {
+				continue
+			}
+			if r.Name == "" || strings.ToLower(r.Name) != fe.stem {
+				continue
+			}
+			if !isClassLikeDonor(r) {
+				continue
+			}
+			if donor < 0 {
+				donor = k
+				continue
+			}
+			d := &merged[donor]
+			switch {
+			case r.StartLine != d.StartLine:
+				if r.StartLine < d.StartLine {
+					donor = k
+				}
+			case r.EndLine != d.EndLine:
+				if r.EndLine > d.EndLine {
+					donor = k
+				}
+			default:
+				if r.ID < d.ID {
+					donor = k
+				}
+			}
+		}
+		if donor < 0 {
+			continue
+		}
+		d := &merged[donor]
+		sv.StartLine = d.StartLine
+		if sv.EndLine == 0 && d.EndLine > 0 {
+			sv.EndLine = d.EndLine
+		}
+		stats.SpansDonated++
 	}
 
 	if len(remap) == 0 {
@@ -5204,8 +5310,8 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 		var fileStats foldFileComponentStats
 		merged, pass2Rels, fileStats = i.foldFileComponentDuplicates(merged, pass2Rels)
 		fmt.Fprintf(os.Stderr,
-			"foldFileComponentDuplicates: observed=%d folded=%d (edges_repointed=%d)\n",
-			fileStats.Observed, fileStats.Folded, fileStats.EdgesRepointed)
+			"foldFileComponentDuplicates: observed=%d folded=%d (edges_repointed=%d spans_donated=%d)\n",
+			fileStats.Observed, fileStats.Folded, fileStats.EdgesRepointed, fileStats.SpansDonated)
 	}
 
 	// Pass 3.7 — Bazel resolver overlay (#2183 / M6).

--- a/internal/custom/python/helpers.go
+++ b/internal/custom/python/helpers.go
@@ -20,6 +20,20 @@ func lineOf(source string, offset int) int {
 }
 
 // entity builds an EntityRecord with the common fields pre-filled.
+//
+// ENDLINE IS ANCHORED TO STARTLINE, NOT LEFT AT ZERO (#6118). This was the one
+// EntityRecord construction site in the whole of internal/custom/** that
+// populated StartLine and left EndLine at its zero value — every other
+// language's helper (csharp, java, javascript, golang, ruby, rust, php, kotlin,
+// scala, swift, dart, lua, cpp, elixir, fsharp, crystal, groovy, nim, …) emits
+// EndLine == lineNum. A zero EndLine is not "line zero", it is "extent
+// unknown": any consumer that slices source by extent (grafel_get_source,
+// docgen, the dashboard code panels, entity-size metrics) gets an unanchored
+// region rather than a one-line one.
+//
+// These extractors are regex-based and match a single declaration line, so the
+// honest extent IS one line. If a caller knows a wider extent it should widen
+// EndLine after calling; MergeWithCustom's span union never narrows it.
 func entity(name, kind, subtype, sourceFile string, startLine int, props map[string]string) types.EntityRecord {
 	return types.EntityRecord{
 		Name:               name,
@@ -27,6 +41,7 @@ func entity(name, kind, subtype, sourceFile string, startLine int, props map[str
 		Subtype:            subtype,
 		SourceFile:         sourceFile,
 		StartLine:          startLine,
+		EndLine:            startLine,
 		Language:           "python",
 		Properties:         props,
 		EnrichmentRequired: true,


### PR DESCRIPTION
Two contained defects that leave custom-extractor entities without a usable source span.

## First: retracting the issue's own headline

#6118 was filed claiming **"0 of 61,131 added entities carry a complete span"**, from a corpus measurement. That is a measurement artifact.

The two hygiene buckets partition the entity set exactly:

```
87,532 + 339,753 = 427,285  = total entities, flag OFF
87,745 + 398,595 = 486,340  = total entities, flag ON
```

So `213 + 58,842 = 59,055` is `total_on − total_off` — an arithmetic identity that holds for any two-way partition. It was presented as the damning detail ("exactly the net entity delta") and carries no information about spans. The bucket labelled `EndLine == 0 && StartLine > 0` was behaving as plain `StartLine > 0`.

The corollary is independently false: it would mean 100% of the base graph's 427k entities also lack a complete span, and they do not.

**Ground truth on a 7-language fixture: 38 of 47 added entities already carried a complete span.** The nine that did not are 5 Python + 4 C# — two distinct, small defects.

Recorded here rather than quietly dropped, because the retraction is the more useful artifact: *a hygiene bucket whose counts sum exactly to the population is not measuring the condition in its label.*

## Defect 1 — Python omits `EndLine`

Every `types.EntityRecord{...}` composite literal in `internal/custom/**` was scanned — **82 literals, balanced-brace parse, not a grep**. Exactly **one** sets `StartLine` and omits `EndLine`: `internal/custom/python/helpers.go:24`.

Every other language's helper emits `EndLine: lineNum` — csharp, java, javascript, golang, ruby, rust, php, kotlin, scala, swift, dart, lua, cpp, elixir, fsharp, crystal, groovy, nim.

The other two hypotheses in the issue are cleared: the record→entity conversion does carry `EndLine` through (`cmd/grafel/index.go:5278`), and `MergeWithCustom` only ever widens a span (`custom_dispatch.go:526-529`, `enrichFromTwin` 608-612).

Fixed by anchoring `EndLine` to `StartLine`, matching the other 20 languages.

## Defect 2 — C# file components are never positioned: a starved fold, not an overwrite

The issue predicted "a path that overwrites an already-populated `StartLine` with zero." **No such path exists.**

`foldFileComponentDuplicates` (`cmd/grafel/index.go:4641`) is the only pass that ever positions a `SCOPE.Component(subtype="file")` — it promotes the span from the co-located class-like component. It runs **after** `foldClassHierarchyShadows`, which *drops* that class component whenever a framework-typed node exists for the same symbol. The file entity is then never positioned at all.

The gate does not create this — it makes it fire more often, because C# custom extractors emit framework-typed nodes for DbContexts, consumers, handlers and jobs, so more class components become shadow-fold sources. Visible in the run logs: `class-shadow-fold: folded=3 → 10`, `foldFileComponentDuplicates: observed=8 → 4`.

Fixed by donating the span from any **surviving** class-like declaration matching the file stem, so the outcome no longer depends on which node happened to survive the shadow fold.

| | before | after |
|---|---|---|
| added entities lacking a complete span | 9 / 47 | **0 / 47** |
| C# file components regressing to line 0 | 4 (`5→0`, start and end, all four files) | **0** |

## Gate-off is NOT inert, and both digests are pinned

Because the C# defect lives on the **default** path, fixing it changes the gate-off graph. On the fixture that is exactly **one entity** — a C# controller file component, `start 0 → 5`. Entity and relationship counts unchanged (141 / 284), nothing destroyed, nothing rewired.

Rather than silently re-baselining, **both** digests are pinned — `gateOffDigest6118Base` (`a0a6ede9…`, at `2f0175dfc`) and `gateOffDigest6118` (`387a9c36…`, after) — plus a behavioural test asserting the delta's exact shape. If strict inertness is required instead, the C# half must be dropped; the Python half is gate-scoped by construction.

## A trap found while building it

The first cut allowed any stem-named donor, which let `func Caller2()` donate its line to `caller2.go` and broke **five** `TestDiffReindex_*` tests. Caught by the existing suite; fixed by restricting donors to class-like declarations.

Worth recording: **`foldFileComponentDuplicates` output is load-bearing for incremental/full-rebuild parity, and the incremental path does not run this fold.** Anything that changes what that fold emits can break equivalence in a way unrelated to the change's intent.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`:

| package | exit | skips |
|---|---|---|
| `./internal/custom/...` | 0 | **0** |
| `./internal/extractors/...` | 0 | **0** |
| `./internal/graph/...` | 0 | **0** |
| `./cmd/grafel/` | 0 | 9 (497 pass) |

The 9 skips are pre-existing environment gates. Machine clean throughout: load 1.1–4.7, zero swap.

Mutants killed: reverting the Python `EndLine` fails the span test (5/43 incomplete); disabling the span donation fails the regression test (8 positions lost).

Closes #6118
Refs #5989, #6104
