### PR TITLE
fix(#6090): replay prior corpus-wide bindings for edges single-file extraction cannot resolve

### DIFF
--- a/cmd/grafel/incremental_prior_resolution_6090_test.go
+++ b/cmd/grafel/incremental_prior_resolution_6090_test.go
@@ -1,0 +1,462 @@
+// Package main — incremental_prior_resolution_6090_test.go
+//
+// #6090 — incremental drops correct edges out of a changed file when the
+// single-file re-extraction cannot re-resolve them.
+//
+// Mechanism, grounded at 2f0175dfc:
+//
+//   - internal/extractors/incremental.go:446 prunes every prior edge whose
+//     FromID is an entity sourced from a changed file, on the principle that the
+//     re-extraction is authoritative for that file's outgoing edges.
+//   - The re-extraction is a SINGLE-FILE extraction followed by
+//     sresolver.ResolveScoped, whose binding ladder is strictly weaker than the
+//     corpus-wide resolver's (internal/extractors/sresolver/scoped.go:247 —
+//     whole-string name/qualified-name, then the Format A (file, tail) tiers).
+//     A Go method entity is named "T11.Do11" while the call site emits the bare
+//     stub "Do11"; the full resolver binds it via its member-suffix tier, the
+//     scoped one cannot.
+//   - Net effect: the resolved CALLS edge the full graph held is pruned, and the
+//     fresh pass re-emits the same call with an UNRESOLVED bare-name ToID.
+//
+// This is measurable and monotone: editing three DIFFERENT files in sequence
+// loses 3 → 6 → 9 CALLS edges against a full rebuild of the same end-state, and
+// nothing restores them until a full reindex.
+//
+// Scope, established by measurement rather than taken from the issue: the loss
+// reproduced here is on the DAEMON path (internal/extractors.TryIncremental),
+// not on the CLI full-pipeline incremental (cmd/grafel/index.go). The CLI path
+// seeds the corpus-wide resolver with the prev graph's unchanged-file entities
+// (i.incrementalCarryForwardEntities, index.go:1243), whose member tier keys on
+// Name + SourceFile — both carried — so THIS stub shape resolves there and the
+// CLI path measures zero loss on this fixture across all three passes.
+//
+// That is a statement about this stub shape, not a clean bill of health: the
+// carried record (index.go:1250-1256) copies six fields and omits
+// QualifiedName, which the symbol index also keys on, so stubs that resolve
+// only via the QualifiedName tier against an unchanged-file entity are lost on
+// the CLI path too. Same defect shape, narrower blast radius, pre-existing and
+// tracked separately.
+//
+// The daemon path is the default for a watched repo, which is what makes this
+// degrade a long-lived graph.
+//
+// The fix replays the previous graph's resolution decision: for a fresh edge the
+// isolated pass left unresolved, if the prior graph held an edge with the same
+// FromID and Kind bound to a live entity whose name matches the unresolved stub,
+// the fresh edge is bound to that entity. It is a REPLAY, not a retention — the
+// prior edge is only consulted to bind an edge the fresh extraction actually
+// re-emitted, so a call genuinely deleted from source has nothing to bind and
+// stays dropped (asserted by the companion test below).
+package main
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/parity"
+)
+
+// pr6090File is one corpus file. Every basename is UNIQUE on purpose:
+// diff.Filter cross-invalidates same-basename files, which would turn a
+// one-file delta into an N-file change and trip the too-many-changed
+// full-reindex fallback, making the case vacuous.
+func pr6090File(i int) string {
+	return fmt.Sprintf(`package svc
+
+type T%02d struct{ N int }
+
+func (t *T%02d) Do%02d(x int) int { return x + t.N + %d }
+
+func Helper%02d(x int) int { return x + %d }
+
+func Local%02d(x int) int { return Helper%02d(x) }
+`, i, i, i, i, i, i, i, i)
+}
+
+// pr6090Edited is the content of the edited file at pass N — pass 0 being the
+// BASELINE that the first full rebuild resolves with corpus-wide context. Its
+// Local07 calls two methods defined in OTHER files, the shape the scoped
+// resolver cannot bind in isolation (entity name "T11.Do11" vs call-site stub
+// "Do11"). Successive passes change only a literal inside the body, so the two
+// cross-file calls are unchanged in source at every pass and a full rebuild
+// binds them every time.
+//
+// The baseline must already contain the calls: an edge the edit ITSELF
+// introduces has no prior binding to replay, and closing that (a call the scoped
+// resolver cannot bind on first sight) is a separate gap in sresolver's ladder,
+// not the #6090 loss class.
+func pr6090Edited(pass int) string {
+	return fmt.Sprintf(`package svc
+
+type T07 struct{ N int }
+
+func (t *T07) Do07(x int) int { return x + t.N + 7 }
+
+func Helper07(x int) int { return x + 7 }
+
+func Local07(x int) int {
+	a := &T11{N: 1}
+	b := &T23{N: 2}
+	return Helper07(x) + a.Do11(x) + b.Do23(x) + %d
+}
+`, pass)
+}
+
+// pr6090CorpusSize is small enough to run in ~1.5s and large enough that the
+// scoped resolver has a real corpus to fail to bind against.
+const pr6090CorpusSize = 40
+
+func pr6090WriteCorpus(t *testing.T, repo string) {
+	t.Helper()
+	for i := 0; i < pr6090CorpusSize; i++ {
+		dvWriteFile(t, repo, fmt.Sprintf("r%02d.go", i), pr6090File(i))
+	}
+	// r07.go carries the cross-file calls from the very first build.
+	dvWriteFile(t, repo, "r07.go", pr6090Edited(0))
+}
+
+// pr6090IsCallsKey reports whether a parity report key names a CALLS group.
+//
+// The key is NOT always "<from>→<to>:CALLS": parity.keyWithCount (parity.go:554)
+// renders a group of n>1 identical rows as "<from>→<to>:CALLS ×3". A plain
+// HasSuffix(":CALLS") check therefore skips exactly the duplicated groups —
+// so a lost or invented CALLS multiplicity, the #6094 failure shape, would be
+// invisible to every assertion built on it.
+func pr6090IsCallsKey(k string) bool {
+	if i := strings.LastIndex(k, " ×"); i > 0 {
+		k = k[:i]
+	}
+	return strings.HasSuffix(k, ":CALLS")
+}
+
+// pr6090CallsDiff returns the CALLS groups a full rebuild of the SAME end-state
+// has that the incremental graph does not (lost), and those the incremental
+// graph has that the full rebuild does not (invented). Both directions matter:
+// asserting only on `lost` would accept a graph that replaced a correct edge
+// with a wrong one. Read off the PERSISTED graphs (never the run log — #6094)
+// and compared as multisets in both directions (#6037).
+func pr6090CallsDiff(t *testing.T, incremental, full *graph.Document) (lost, invented []string) {
+	t.Helper()
+	rep := parity.CompareWithOptions(full, incremental, parity.Options{})
+	for _, k := range rep.RelsOnlyInA {
+		if pr6090IsCallsKey(k) {
+			lost = append(lost, k)
+		}
+	}
+	for _, k := range rep.RelsOnlyInB {
+		if pr6090IsCallsKey(k) {
+			invented = append(invented, k)
+		}
+	}
+	// A group present on BOTH sides at different multiplicities is neither
+	// "only in A" nor "only in B" — it lands here, and is a divergence too.
+	for _, d := range rep.RelMultiplicityDiffs {
+		if pr6090IsCallsKey(d.Key) {
+			lost = append(lost, d.Key+" ("+d.Detail+")")
+		}
+	}
+	return lost, invented
+}
+
+// pr6090AssertCallsParity fails when the incremental graph diverges from the
+// full rebuild on CALLS edges in either direction.
+func pr6090AssertCallsParity(t *testing.T, label string, incremental, full *graph.Document) {
+	t.Helper()
+	lost, invented := pr6090CallsDiff(t, incremental, full)
+	if len(lost) != 0 {
+		t.Errorf("%s: incremental graph is MISSING %d CALLS group(s) a full rebuild of the "+
+			"identical end-state holds — the single-file re-extraction could not re-resolve them "+
+			"and the prior resolved copy was pruned (#6090):\n  %s",
+			label, len(lost), strings.Join(lost, "\n  "))
+	}
+	if len(invented) != 0 {
+		t.Errorf("%s: incremental graph holds %d CALLS group(s) a full rebuild does NOT:\n  %s",
+			label, len(invented), strings.Join(invented, "\n  "))
+	}
+}
+
+// pr6090CountResolvedCrossFileCalls counts the CALLS edges that run from an
+// entity of `file` to a live entity in a DIFFERENT file. This is the population
+// #6090 destroys — the outgoing, corpus-resolved edges of a re-extracted file —
+// so it is the positive form of the assertion: not "nothing is missing" (true of
+// an empty graph) but "these specific edges are present and resolved".
+func pr6090CountResolvedCrossFileCalls(doc *graph.Document, file string) int {
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	n := 0
+	for _, r := range doc.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		from, ok := byID[r.FromID]
+		if !ok || from.SourceFile != file {
+			continue
+		}
+		to, ok := byID[r.ToID] // unresolved stubs are not entity ids → excluded
+		if !ok || to.SourceFile == file || to.SourceFile == "" {
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// TestIncremental_PriorResolutionSurvivesRepeatedEdits_6090 is the regression
+// gate. The defect is monotone, so a single-edit assertion could pass while the
+// loss continues — the edge must survive THREE successive edits to the same
+// file, each checked against a full rebuild of that pass's end-state.
+func TestIncremental_PriorResolutionSurvivesRepeatedEdits_6090(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	pr6090WriteCorpus(t, repo)
+	dvFullRebuild(t, repo, stateDir)
+
+	// Reference corpus, rebuilt from scratch at every pass's end-state.
+	fullRepo := t.TempDir()
+	pr6090WriteCorpus(t, fullRepo)
+
+	// Positive baseline — without it every assertion below is satisfied by a
+	// graph with no CALLS edges at all, and the case rots into vacuity the day
+	// the fixture stops producing them. The two cross-file method calls must be
+	// present AND resolved in the very first full rebuild.
+	base, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	const wantCrossFile = 2
+	if n := pr6090CountResolvedCrossFileCalls(base, "r07.go"); n != wantCrossFile {
+		t.Fatalf("fixture is inert: the baseline full rebuild holds %d resolved cross-file CALLS edge(s) "+
+			"out of r07.go, want %d — the fixture no longer exercises #6090", n, wantCrossFile)
+	}
+
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "r07.go", pr6090Edited(pass))
+		// dvIncremental fails the test if TryIncremental falls back, so a
+		// silent full-reindex cannot make this vacuous.
+		dvIncremental(t, repo, stateDir)
+		b, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			t.Fatalf("pass %d: load persisted incremental graph: %v", pass, err)
+		}
+
+		dvWriteFile(t, fullRepo, "r07.go", pr6090Edited(pass))
+		c := dvFullRebuild(t, fullRepo, t.TempDir())
+
+		pr6090AssertCallsParity(t, fmt.Sprintf("pass %d", pass), b, c)
+
+		// Positive form: the edges are still THERE and still resolved, not
+		// merely "not reported missing".
+		if n := pr6090CountResolvedCrossFileCalls(b, "r07.go"); n != wantCrossFile {
+			t.Errorf("pass %d: incremental graph holds %d resolved cross-file CALLS edge(s) out of "+
+				"r07.go, want %d", pass, n, wantCrossFile)
+		}
+	}
+}
+
+// pr6090EditedN is the pass-N content of file r<i>.go, whose Local<i> calls a
+// method on two OTHER files' types. Same shape as pr6090Edited, parameterised
+// over which file is edited.
+func pr6090EditedN(i, a, b, pass int) string {
+	return fmt.Sprintf(`package svc
+
+type T%02d struct{ N int }
+
+func (t *T%02d) Do%02d(x int) int { return x + t.N + %d }
+
+func Helper%02d(x int) int { return x + %d }
+
+func Local%02d(x int) int {
+	p := &T%02d{N: 1}
+	q := &T%02d{N: 2}
+	return Helper%02d(x) + p.Do%02d(x) + q.Do%02d(x) + %d
+}
+`, i, i, i, i, i, i, i, a, b, i, a, b, pass)
+}
+
+// TestIncremental_PriorResolutionAcrossDifferentFiles_6090 pins the property that makes
+// #6090 severe: the deficit is MONOTONE across edits to DIFFERENT files. Each
+// edited file permanently contributes its own unresolvable outgoing edges, so a
+// long-lived watched repo degrades continuously and nothing restores the edges
+// before a full reindex.
+//
+// Measured at 2f0175dfc on this fixture: 3 → 6 → 9 CALLS edges missing versus a
+// full rebuild of the same end-state, growing by one file's worth per edit. The gate
+// asserts the fixed point the fix lands on instead: ZERO, at every step.
+//
+// The accumulation is asserted directly rather than described: the count of
+// resolved cross-file CALLS edges out of the files edited SO FAR must grow
+// 2 → 4 → 6 and never shed. That number is precisely the population the defect
+// destroys, so on an unfixed tree it stays flat at 0 while the fixture keeps
+// adding to it — and a test that only asked "is anything missing?" would be
+// satisfied by a graph that had never held the edges at all.
+//
+// The same-file three-edit gate above cannot see this — re-editing one file
+// re-loses the SAME edges, so its deficit is constant, not growing.
+func TestIncremental_PriorResolutionAcrossDifferentFiles_6090(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	edits := []int{7, 11, 23}
+
+	// Baseline: every edited file already carries its cross-file calls, so the
+	// first full rebuild resolves them with corpus-wide context.
+	seed := func(dst string) {
+		for i := 0; i < pr6090CorpusSize; i++ {
+			dvWriteFile(t, dst, fmt.Sprintf("r%02d.go", i), pr6090File(i))
+		}
+		for _, idx := range edits {
+			dvWriteFile(t, dst, fmt.Sprintf("r%02d.go", idx),
+				pr6090EditedN(idx, (idx+3)%pr6090CorpusSize, (idx+5)%pr6090CorpusSize, 0))
+		}
+	}
+	seed(repo)
+	dvFullRebuild(t, repo, stateDir)
+
+	fullRepo := t.TempDir()
+	seed(fullRepo)
+
+	// Positive baseline: each of the three files really does hold 2 resolved
+	// cross-file CALLS edges before anything is edited.
+	base, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	for _, idx := range edits {
+		name := fmt.Sprintf("r%02d.go", idx)
+		if n := pr6090CountResolvedCrossFileCalls(base, name); n != 2 {
+			t.Fatalf("fixture is inert: baseline full rebuild holds %d resolved cross-file CALLS "+
+				"edge(s) out of %s, want 2", n, name)
+		}
+	}
+
+	var trace []string
+	prevAtRisk := -1
+	for pass, idx := range edits {
+		content := pr6090EditedN(idx, (idx+3)%pr6090CorpusSize, (idx+5)%pr6090CorpusSize, pass+1)
+		name := fmt.Sprintf("r%02d.go", idx)
+
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, name, content)
+		dvIncremental(t, repo, stateDir)
+		b, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			t.Fatalf("pass %d: load persisted incremental graph: %v", pass+1, err)
+		}
+
+		dvWriteFile(t, fullRepo, name, content)
+		c := dvFullRebuild(t, fullRepo, t.TempDir())
+
+		lost, invented := pr6090CallsDiff(t, b, c)
+		pr6090AssertCallsParity(t, fmt.Sprintf("pass %d (edited %s)", pass+1, name), b, c)
+
+		// The accumulating population: every file edited SO FAR must still hold
+		// its resolved cross-file calls. This is the monotone axis — it grows by
+		// 2 per pass here and is flat at 0 on an unfixed tree.
+		atRisk := 0
+		for _, done := range edits[:pass+1] {
+			atRisk += pr6090CountResolvedCrossFileCalls(b, fmt.Sprintf("r%02d.go", done))
+		}
+		want := 2 * (pass + 1)
+		trace = append(trace, fmt.Sprintf("pass %d (edited %s): lost=%d invented=%d resolved-cross-file-calls-out-of-edited-files=%d",
+			pass+1, name, len(lost), len(invented), atRisk))
+		if atRisk != want {
+			t.Errorf("pass %d (edited %s): %d resolved cross-file CALLS edge(s) survive out of the "+
+				"%d file(s) edited so far, want %d — the deficit accumulates per edited file (#6090)",
+				pass+1, name, atRisk, pass+1, want)
+		}
+		if atRisk < prevAtRisk {
+			t.Errorf("pass %d: the surviving population SHRANK %d → %d — successive edits are still "+
+				"shedding edges", pass+1, prevAtRisk, atRisk)
+		}
+		prevAtRisk = atRisk
+	}
+	t.Logf("per-pass trace:\n  %s", strings.Join(trace, "\n  "))
+}
+
+// TestIncremental_DeletedCallIsStillDropped_6090 is the counter-test: the fix
+// must not degrade into "retain everything". A call REMOVED from source must
+// disappear from the incremental graph exactly as it does from a full rebuild.
+//
+// Without it, a fix that carried the prior edge forward whenever the fresh pass
+// could not re-emit it would keep a call that no longer exists in source,
+// invisibly and forever.
+func TestIncremental_DeletedCallIsStillDropped_6090(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	pr6090WriteCorpus(t, repo)
+	dvFullRebuild(t, repo, stateDir)
+
+	// Pass 1: introduce the two cross-file method calls and let the fix bind
+	// them from the prior graph's resolution.
+	dvSeedManifest(t, repo, stateDir)
+	dvWriteFile(t, repo, "r07.go", pr6090Edited(1))
+	dvIncremental(t, repo, stateDir)
+
+	// Pass 2: delete BOTH cross-file calls from source.
+	const deleted = `package svc
+
+type T07 struct{ N int }
+
+func (t *T07) Do07(x int) int { return x + t.N + 7 }
+
+func Helper07(x int) int { return x + 7 }
+
+func Local07(x int) int { return Helper07(x) }
+`
+	dvSeedManifest(t, repo, stateDir)
+	dvWriteFile(t, repo, "r07.go", deleted)
+	dvIncremental(t, repo, stateDir)
+
+	b, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load persisted incremental graph: %v", err)
+	}
+
+	// Reference: a full rebuild of the deleted end-state.
+	fullRepo := t.TempDir()
+	pr6090WriteCorpus(t, fullRepo)
+	dvWriteFile(t, fullRepo, "r07.go", deleted)
+	c := dvFullRebuild(t, fullRepo, t.TempDir())
+
+	// Control: the reference must genuinely not hold the deleted calls, or the
+	// assertion below is vacuous.
+	if pr6090HasCallTo(c, "Do11") || pr6090HasCallTo(c, "Do23") {
+		t.Fatal("premise violated: the full rebuild of the deleted end-state still holds the removed calls")
+	}
+	if pr6090HasCallTo(b, "Do11") || pr6090HasCallTo(b, "Do23") {
+		t.Error("incremental graph retained a CALLS edge to a method whose call site was DELETED from source — " +
+			"the #6090 fix must replay the prior resolution for edges the fresh pass re-emitted, " +
+			"never retain edges the fresh pass did not emit at all")
+	}
+
+	// And the deleted end-state must be at strict CALLS parity with the full
+	// rebuild in BOTH directions — nothing lost, nothing invented.
+	pr6090AssertCallsParity(t, "after the deletion", b, c)
+}
+
+// pr6090HasCallTo reports whether doc holds a CALLS edge whose target is the
+// entity named `<type>.<name>` (resolved form) or the bare stub `name`
+// (unresolved form). Both forms count: the point of the assertion is that the
+// deleted call is gone in EITHER shape.
+func pr6090HasCallTo(doc *graph.Document, name string) bool {
+	byID := make(map[string]string, len(doc.Entities))
+	for _, e := range doc.Entities {
+		byID[e.ID] = e.Name
+	}
+	for _, r := range doc.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if r.ToID == name {
+			return true
+		}
+		if n, ok := byID[r.ToID]; ok && (n == name || strings.HasSuffix(n, "."+name)) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -451,6 +451,18 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 	doc.Relationships = filteredRels
 
+	// #6090 — snapshot the OUTBOUND prior edges just pruned, before the
+	// inbound-dangling pass below starts appending to removedRels. These are the
+	// edges the previous (corpus-wide) resolver had already bound; Step 7a
+	// replays those bindings onto the fresh edges the isolated re-extraction
+	// could not resolve.
+	//
+	// The three-index form is load-bearing: Step 6a appends the dangling INBOUND
+	// edges to removedRels, and a two-index sub-slice would let those appends
+	// write into the shared backing array within this snapshot's capacity. Capping
+	// cap==len forces the append to copy, so the snapshot stays outbound-only.
+	priorOutboundRels := removedRels[:len(removedRels):len(removedRels)]
+
 	// --- Step 6: re-extract each changed file ---
 	cls, clsErr := classifier.New("", nil)
 	if clsErr != nil {
@@ -575,6 +587,25 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// flow / affected-module passes below.
 	doc.Relationships = scopedResult.UpdatedExistingRelationships
 	newRels = scopedResult.ResolvedNewRelationships
+
+	// --- Step 7a: prior-resolution replay (#6090) ---
+	// The scoped resolver's binding ladder does not cover what the corpus-wide
+	// one does (it has no member-suffix tier, so entity "T11.Do11" is unreachable
+	// from the call-site stub "Do11"), so an outgoing edge of the changed file
+	// can come back from this isolated pass with an unresolved bare-name ToID
+	// even though a full rebuild binds it. Not a strict subset in the other
+	// direction either: the scoped ladder's whole-string tier is last-writer-wins
+	// with no ambiguity sentinel, so it can bind where the full resolver
+	// deliberately refuses. Step 5 already pruned the prior, RESOLVED copy of
+	// that same edge (it was outbound from a re-extracted entity), so the edge
+	// is lost until the next full reindex — and the loss is monotone across
+	// edits to different files.
+	//
+	// Replay the previous graph's binding onto the fresh edge. See
+	// replayPriorResolution for why this cannot resurrect a deleted call.
+	if healed := replayPriorResolution(newRels, priorOutboundRels, doc.Entities, newEntities); healed > 0 {
+		logger.Printf("incremental: prior-resolution replay bound %d unresolved edge endpoint(s) (#6090)", healed)
+	}
 
 	// --- Step 7a: stamp Properties["module"] on new entities (#5309 layer 2) ---
 	// The full-rebuild path stamps every sourced entity with a deterministic

--- a/internal/extractors/incremental_prior_resolution.go
+++ b/internal/extractors/incremental_prior_resolution.go
@@ -1,0 +1,330 @@
+package extractors
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// prior-resolution replay (#6090)
+//
+// # The problem
+//
+// TryIncremental re-extracts a changed file ALONE and then binds its edges with
+// sresolver.ResolveScoped, whose ladder (whole-string name / qualified-name,
+// then the Format A (file, tail) tiers) is strictly weaker than the corpus-wide
+// resolver's. A Go method entity is named "T11.Do11" while the call site emits
+// the bare stub "Do11": the full resolver binds it through its member-suffix
+// tier, the scoped one leaves it verbatim.
+//
+// Step 5 of TryIncremental has meanwhile pruned every prior edge whose FromID is
+// an entity of the changed file — correct in principle (the re-extraction is
+// authoritative for that file's outgoing edges), fatal in this case: the
+// resolved edge is gone and its replacement is an unresolved stub. Nothing
+// restores it before a full reindex, and because each edited file contributes
+// its own losses permanently, the deficit is monotone (measured on a 40-file
+// fixture, editing three different files: 10 → 18 → 21 edges missing versus a
+// full rebuild of the same end-state).
+//
+// # Why this is a replay and not a retention
+//
+// Three cases look alike from inside a single-file extraction, and only the
+// middle one may be repaired:
+//
+//	the fresh pass re-emitted the edge differently  → the fresh version wins
+//	the fresh pass could not RESOLVE the target     → replay the prior binding
+//	the edge no longer exists in source             → drop it
+//
+// The separating signal is the fresh pass's own output. This function never
+// looks at a prior edge on its own: it starts from an edge the CURRENT
+// extraction re-emitted, observes that its ToID is an unresolved bare name, and
+// consults the prior graph only to ask "what did the corpus-wide resolver bind
+// THIS name to, from THIS source, under THIS kind?".
+//
+//   - A call deleted from source produces no fresh edge, so there is nothing to
+//     bind and the prior edge stays dropped. Retention is structurally
+//     impossible — the function only ever mutates the ToID of an edge the fresh
+//     pass emitted; it never appends a row.
+//   - A call retargeted in source produces a fresh edge naming the NEW target,
+//     which does not match the prior binding's name, so nothing is replayed and
+//     the stale edge stays dropped.
+//   - A call the scoped resolver DID bind arrives with a hex ToID and is skipped
+//     outright, so the fresh resolution always wins over the prior one.
+//
+// The binding replayed is the one a corpus-wide resolver computed over the same
+// source — on the first incremental pass that is literally a full rebuild's
+// output, and each subsequent pass replays the binding the previous pass
+// preserved. It is not an inference about what the target "probably" is.
+//
+// # Ambiguity
+//
+// A name is replayed only when the prior graph bound it from this source, under
+// this kind, to exactly ONE still-live entity. Two distinct prior targets for
+// one name is precisely the case the full resolver itself calls ambiguous and
+// leaves unresolved, so the stub is left verbatim — the same thing a full
+// rebuild does. When both the prior and the fresh edge carry a `receiver_type`
+// property, they must agree; a method call moved to a different receiver type is
+// therefore not replayed onto the old receiver's method.
+//
+// # Known limits — recorded, not fixed
+//
+// Neither limit below can point an edge at an entity that does not exist, and
+// neither can retain a deleted call, so both are precision losses rather than
+// soundness holes. They are written down so the next reader does not take the
+// guards for stronger than they are.
+//
+//  1. Dead candidates never enter the index (they have no name keys), which
+//     means they are filtered BEFORE ambiguity is counted. A name the prior
+//     graph bound to two targets, one of which this run destroyed, therefore
+//     looks unambiguous and binds to the survivor. That target is a real, live
+//     entity the prior corpus-wide resolver did associate with this name from
+//     this source — so the edge is plausible rather than fabricated — but it is
+//     a confident answer to a question the full resolver would have declined.
+//
+//  2. The receiver_type veto is stamp-dependent, and the stamp is emitted by the
+//     Go extractor only — and dropped even there when the extractor cannot
+//     determine the receiver. The veto is therefore inactive for every non-Go
+//     language, and for exactly the Go call sites the extractor was unsure
+//     about. The ambiguity guard, which needs no stamp, is the load-bearing one;
+//     the veto is a refinement on top of it.
+//
+// Every guard named above is pinned by a mutation-gate test in
+// incremental_prior_resolution_test.go: delete one and exactly one test fails.
+
+// replayPriorResolutionReceiverProp is the extractor-supplied property that
+// records the receiver type of a method call ("receiver_type:T11"). It is the
+// one call-site discriminator that survives into the edge, and it is used as a
+// veto — never as a binder — so extractors that do not emit it are unaffected.
+const replayPriorResolutionReceiverProp = "receiver_type"
+
+// replayPriorResolution binds unresolved ToIDs on freshly extracted edges from
+// the previous graph's resolution of the same (FromID, Kind, name) triple.
+//
+// newRels is mutated in place; the return value is the number of endpoints
+// bound. priorOutbound is the set of prior edges pruned because their FromID was
+// a changed-file entity. survivors and fresh supply the entity rows the prior
+// targets are named by — fresh is required as well as survivors because a prior
+// target inside the changed file itself was removed from survivors and comes
+// back only via re-extraction (entity IDs are deterministic over
+// kind/name/source_file, so it returns under the same ID).
+func replayPriorResolution(newRels []graph.Relationship, priorOutbound []graph.Relationship, survivors, fresh []graph.Entity) int {
+	if len(newRels) == 0 || len(priorOutbound) == 0 {
+		return 0
+	}
+
+	// Only edges with an unresolved endpoint are candidates. Bail out before
+	// touching the entity vectors when there are none — the common case on a
+	// corpus whose edges all bind, and survivors can be very large.
+	anyUnresolved := false
+	for i := range newRels {
+		if !replayIsHexID(newRels[i].ToID) {
+			anyUnresolved = true
+			break
+		}
+	}
+	if !anyUnresolved {
+		return 0
+	}
+
+	// The prior targets we need entity names for: hex ToIDs of pruned outbound
+	// edges. Typically a handful, so this bounds the entity scan's output.
+	wanted := make(map[string]bool, len(priorOutbound))
+	for i := range priorOutbound {
+		if replayIsHexID(priorOutbound[i].ToID) {
+			wanted[priorOutbound[i].ToID] = true
+		}
+	}
+	if len(wanted) == 0 {
+		return 0
+	}
+
+	// live[id] holds the name keys of a still-present prior target. An id absent
+	// here either never existed or was destroyed by this run's re-extraction —
+	// either way its prior binding must not be replayed onto a live edge.
+	live := make(map[string][]string, len(wanted))
+	collect := func(ents []graph.Entity) {
+		for i := range ents {
+			if !wanted[ents[i].ID] {
+				continue
+			}
+			if _, seen := live[ents[i].ID]; seen {
+				continue
+			}
+			live[ents[i].ID] = replayNameKeys(&ents[i])
+		}
+	}
+	collect(survivors)
+	collect(fresh)
+	if len(live) == 0 {
+		return 0
+	}
+
+	// Index: (FromID, Kind, name key) → the prior edges that bound that name.
+	index := make(map[string][]int, len(priorOutbound))
+	for i := range priorOutbound {
+		keys, ok := live[priorOutbound[i].ToID]
+		if !ok {
+			continue
+		}
+		for _, nk := range keys {
+			k := replayKey(priorOutbound[i].FromID, priorOutbound[i].Kind, nk)
+			index[k] = append(index[k], i)
+		}
+	}
+	if len(index) == 0 {
+		return 0
+	}
+
+	bound := 0
+	for i := range newRels {
+		r := &newRels[i]
+		if replayIsHexID(r.ToID) {
+			continue
+		}
+		target, ok := replayLookup(index, priorOutbound, r)
+		if !ok {
+			continue
+		}
+		r.ToID = target
+		// Recomputing the ID from the triple is safe ONLY because newRels is
+		// structurally salt-free: it is built by convertExtractedRecords from
+		// types.RelationshipRecord, which has no ID field, so every row here
+		// already carries the derived RelationshipID and nothing distinguishes
+		// two rows sharing a triple. That is NOT true of the graph at large —
+		// several producers deliberately mint salted IDs for edges sharing one
+		// triple (see graph.RelationshipIDProperty), and #6085 converged on data
+		// loss by assuming the triple was a key. If a salted producer ever feeds
+		// this path, this line silently collapses those siblings: carry the
+		// prior row's ID forward instead of deriving one.
+		r.ID = graph.RelationshipID(r.FromID, r.ToID, r.Kind)
+		bound++
+	}
+	return bound
+}
+
+// replayLookup resolves one unresolved edge against the prior-binding index,
+// returning the single live target the previous graph bound this name to from
+// this source under this kind. ok is false when the name was never bound, or
+// when the prior graph bound it to more than one target (the ambiguous case a
+// full rebuild also leaves unresolved).
+func replayLookup(index map[string][]int, priorOutbound []graph.Relationship, r *graph.Relationship) (string, bool) {
+	freshRecv := r.PropGet(replayPriorResolutionReceiverProp)
+	for _, name := range replayStubNames(r.ToID) {
+		idxs, ok := index[replayKey(r.FromID, r.Kind, name)]
+		if !ok {
+			continue
+		}
+		target := ""
+		for _, pi := range idxs {
+			p := &priorOutbound[pi]
+			// receiver_type veto: when both sides record one they must agree,
+			// so a call moved to a different receiver is not replayed onto the
+			// old receiver's method.
+			if freshRecv != "" {
+				if pr := p.PropGet(replayPriorResolutionReceiverProp); pr != "" && pr != freshRecv {
+					continue
+				}
+			}
+			if target == "" {
+				target = p.ToID
+				continue
+			}
+			if target != p.ToID {
+				return "", false // ambiguous — leave the stub verbatim
+			}
+		}
+		if target != "" {
+			return target, true
+		}
+	}
+	return "", false
+}
+
+// replayKey builds the index key. The separator is NUL so a name containing the
+// delimiter cannot collide with a different (from, kind) pair.
+func replayKey(fromID, kind, name string) string {
+	var b strings.Builder
+	b.Grow(len(fromID) + len(kind) + len(name) + 2)
+	b.WriteString(fromID)
+	b.WriteByte(0)
+	b.WriteString(kind)
+	b.WriteByte(0)
+	b.WriteString(name)
+	return b.String()
+}
+
+// replayNameKeys returns every name an unresolved stub could plausibly spell for
+// this entity: its Name and QualifiedName, plus the trailing segment of each
+// (the bare-member form a call site emits — entity "T11.Do11", stub "Do11").
+func replayNameKeys(e *graph.Entity) []string {
+	keys := make([]string, 0, 4)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		for _, k := range keys {
+			if k == s {
+				return
+			}
+		}
+		keys = append(keys, s)
+	}
+	add(e.Name)
+	add(replayTail(e.Name))
+	add(e.QualifiedName)
+	add(replayTail(e.QualifiedName))
+	return keys
+}
+
+// replayStubNames returns the names an unresolved endpoint may be spelling: the
+// stub verbatim, its trailing segment, and — for a Format A structural ref
+// (`scope:<kind>:<subtype>:<lang>:<file>:<name>`) — the ref's tail. Ordered most
+// specific first so a whole-string match wins over a suffix match.
+func replayStubNames(stub string) []string {
+	names := make([]string, 0, 3)
+	add := func(s string) {
+		if s == "" {
+			return
+		}
+		for _, n := range names {
+			if n == s {
+				return
+			}
+		}
+		names = append(names, s)
+	}
+	add(stub)
+	if strings.HasPrefix(stub, "scope:") {
+		if parts := strings.SplitN(stub, ":", 6); len(parts) == 6 {
+			add(parts[5])
+			add(replayTail(parts[5]))
+		}
+	}
+	add(replayTail(stub))
+	return names
+}
+
+// replayTail returns the segment after the last member/path separator, or "" if
+// there is none (so a bare name does not index itself twice).
+func replayTail(s string) string {
+	if i := strings.LastIndexAny(s, ".#/"); i >= 0 && i+1 < len(s) {
+		return s[i+1:]
+	}
+	return ""
+}
+
+// replayIsHexID reports whether s is a resolved entity id — the 16-char
+// lowercase hex form graph.EntityID produces. Anything else is an unresolved
+// stub. Mirrors sresolver.isHexID, which is unexported there.
+func replayIsHexID(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/extractors/incremental_prior_resolution_test.go
+++ b/internal/extractors/incremental_prior_resolution_test.go
@@ -1,0 +1,363 @@
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Guard-level tests for the #6090 prior-resolution replay.
+//
+// The end-to-end gates in cmd/grafel pin the HAPPY PATH: a resolved edge out of
+// a changed file survives repeated edits, and a deleted call still disappears.
+// They do not pin the mechanisms that keep the replay from becoming the #6085
+// failure mode (retaining edges that no longer reflect source) — every one of
+// those guards could be deleted with the behavioural suite still green, because
+// the fixtures never reach them.
+//
+// These tests reach them directly. Each one is a mutation gate: deleting the
+// single guard it names makes exactly this test fail.
+//
+// The subject is a pure function over slices, so the cases are exact — no
+// extraction, no resolver, no corpus.
+
+const (
+	prCaller = "aaaaaaaaaaaaaaa1" // 16 hex — a resolved entity id
+	prAlpha  = "bbbbbbbbbbbbbbb2"
+	prBeta   = "ccccccccccccccc3"
+	prDead   = "ddddddddddddddd4"
+	prDead2  = "eeeeeeeeeeeeeee5"
+)
+
+// prRel builds a relationship, optionally with properties.
+func prRel(from, to, kind string, props map[string]string) graph.Relationship {
+	r := graph.Relationship{ID: graph.RelationshipID(from, to, kind), FromID: from, ToID: to, Kind: kind}
+	if len(props) > 0 {
+		r = r.WithProperties(props)
+	}
+	return r
+}
+
+func prEnt(id, name, file string) graph.Entity {
+	return graph.Entity{ID: id, Name: name, Kind: "SCOPE.Operation", SourceFile: file}
+}
+
+// ── the baseline: the replay fires at all ────────────────────────────────────
+
+// TestReplayPriorResolution_BindsUnresolvedStubFromPriorBinding is the control.
+// Without it a test that asserts "nothing was bound" could pass on a function
+// that never binds anything.
+func TestReplayPriorResolution_BindsUnresolvedStubFromPriorBinding(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Do11", "CALLS", nil)}
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", nil)}
+	survivors := []graph.Entity{prEnt(prAlpha, "T11.Do11", "r11.go")}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 1 {
+		t.Fatalf("bound %d endpoint(s), want 1", n)
+	}
+	if fresh[0].ToID != prAlpha {
+		t.Errorf("ToID = %q, want the prior binding %q", fresh[0].ToID, prAlpha)
+	}
+	if want := graph.RelationshipID(prCaller, prAlpha, "CALLS"); fresh[0].ID != want {
+		t.Errorf("ID = %q, want it recomputed to %q after the rebind", fresh[0].ID, want)
+	}
+}
+
+// TestReplayPriorResolution_NeverAppendsRows pins the structural property the
+// whole safety argument rests on: the replay only ever mutates the ToID of an
+// edge the fresh extraction emitted. It cannot resurrect a prior edge, so a call
+// deleted from source has nothing to bind.
+func TestReplayPriorResolution_NeverAppendsRows(t *testing.T) {
+	// The fresh pass emitted NOTHING for the prior edge's name — the call was
+	// deleted from source. The prior binding must not come back in any form.
+	fresh := []graph.Relationship{prRel(prCaller, "Unrelated", "CALLS", nil)}
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", nil)}
+	survivors := []graph.Entity{prEnt(prAlpha, "T11.Do11", "r11.go")}
+
+	before := len(fresh)
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 0 {
+		t.Errorf("bound %d endpoint(s) for a name the fresh pass never emitted, want 0", n)
+	}
+	if len(fresh) != before {
+		t.Fatalf("the replay changed the row count %d → %d — it must never append", before, len(fresh))
+	}
+	if fresh[0].ToID != "Unrelated" {
+		t.Errorf("ToID = %q, want the unresolved stub left verbatim", fresh[0].ToID)
+	}
+}
+
+// ── guard 1: liveness ────────────────────────────────────────────────────────
+
+// TestReplayPriorResolution_RefusesDeadPriorTarget is the mutation gate for the
+// `live` filter in replayPriorResolution.
+//
+// The prior graph bound "Do11" to an entity this run's re-extraction destroyed
+// (the method was deleted, or moved to another file — entity IDs are
+// deterministic over kind/name/source_file, so a move re-keys it). Replaying
+// that binding would point a live edge at an id no entity carries: a dangling
+// endpoint a full rebuild never produces. Without the filter this test binds.
+func TestReplayPriorResolution_RefusesDeadPriorTarget(t *testing.T) {
+	fresh := []graph.Relationship{
+		prRel(prCaller, "Do11", "CALLS", nil),  // prior target destroyed
+		prRel(prCaller, "Other", "CALLS", nil), // prior target still live
+	}
+	prior := []graph.Relationship{
+		prRel(prCaller, prDead, "CALLS", nil),
+		prRel(prCaller, prAlpha, "CALLS", nil),
+	}
+	// prDead is in NEITHER the survivors nor the freshly extracted entities.
+	// The live sibling is deliberately present so the case does not pass merely
+	// via the "no live prior targets at all" early exit.
+	survivors := []graph.Entity{prEnt(prAlpha, "T99.Other", "r99.go")}
+
+	n := replayPriorResolution(fresh, prior, survivors, nil)
+	if fresh[0].ToID != "Do11" {
+		t.Errorf("ToID = %q, want the stub left verbatim rather than bound to the dead id %q",
+			fresh[0].ToID, prDead)
+	}
+	if n != 1 || fresh[1].ToID != prAlpha {
+		t.Errorf("bound n=%d, fresh[1].ToID=%q; want n=1 with only the LIVE prior target bound",
+			n, fresh[1].ToID)
+	}
+}
+
+// TestReplayPriorResolution_AcceptsTargetReEmittedByThisRun is the other half of
+// the liveness rule: a prior target INSIDE the changed file was removed from the
+// survivor set and comes back only via re-extraction, under the same id. It is
+// live, and refusing it would re-open the #6090 loss for intra-file edges.
+func TestReplayPriorResolution_AcceptsTargetReEmittedByThisRun(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "N", "CALLS", nil)}
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", nil)}
+	reEmitted := []graph.Entity{prEnt(prAlpha, "T07.N", "r07.go")}
+
+	if n := replayPriorResolution(fresh, prior, nil, reEmitted); n != 1 {
+		t.Fatalf("bound %d endpoint(s) for a target re-emitted by this run, want 1", n)
+	}
+	if fresh[0].ToID != prAlpha {
+		t.Errorf("ToID = %q, want %q", fresh[0].ToID, prAlpha)
+	}
+}
+
+// ── guard 2: ambiguity ───────────────────────────────────────────────────────
+
+// TestReplayPriorResolution_RefusesAmbiguousPriorBinding is the mutation gate
+// for the "two distinct targets → give up" branch in replayLookup.
+//
+// The prior graph bound the same bare name, from the same source under the same
+// kind, to two different live entities ("A30.Same" and "B31.Same" both spell the
+// member name "Same"). That is exactly the case the corpus-wide resolver itself
+// calls ambiguous and leaves unresolved, so the replay must leave the stub
+// verbatim too. Without the guard it binds to whichever prior row is visited
+// first — a coin flip persisted into the graph.
+func TestReplayPriorResolution_RefusesAmbiguousPriorBinding(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Same", "CALLS", nil)}
+	prior := []graph.Relationship{
+		prRel(prCaller, prAlpha, "CALLS", nil),
+		prRel(prCaller, prBeta, "CALLS", nil),
+	}
+	survivors := []graph.Entity{
+		prEnt(prAlpha, "A30.Same", "r30.go"),
+		prEnt(prBeta, "B31.Same", "r31.go"),
+	}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 0 {
+		t.Errorf("bound %d endpoint(s) for a name the prior graph bound to TWO live targets, want 0", n)
+	}
+	if fresh[0].ToID != "Same" {
+		t.Errorf("ToID = %q, want the ambiguous stub left verbatim", fresh[0].ToID)
+	}
+}
+
+// TestReplayPriorResolution_AmbiguityIsPerNameKeyNotPerTarget guards the
+// converse: two prior rows that agree on the target are not ambiguous (the same
+// call appearing twice in a body, or the same edge reached through both the Name
+// and the tail key), and must still bind.
+func TestReplayPriorResolution_AmbiguityIsPerNameKeyNotPerTarget(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Do11", "CALLS", nil)}
+	prior := []graph.Relationship{
+		prRel(prCaller, prAlpha, "CALLS", nil),
+		prRel(prCaller, prAlpha, "CALLS", nil),
+	}
+	survivors := []graph.Entity{prEnt(prAlpha, "T11.Do11", "r11.go")}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 1 {
+		t.Errorf("bound %d endpoint(s) for two prior rows agreeing on one target, want 1", n)
+	}
+}
+
+// TestReplayPriorResolution_AmbiguityIsScopedToSourceAndKind pins that the index
+// key is the full (FromID, Kind, name) triple: the same member name bound from a
+// DIFFERENT caller, or under a different edge kind, is not a competing candidate.
+func TestReplayPriorResolution_AmbiguityIsScopedToSourceAndKind(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Same", "CALLS", nil)}
+	prior := []graph.Relationship{
+		prRel(prCaller, prAlpha, "CALLS", nil),
+		prRel("aaaaaaaaaaaaaaa9", prBeta, "CALLS", nil), // other caller
+		prRel(prCaller, prBeta, "REFERENCES", nil),      // other kind
+	}
+	survivors := []graph.Entity{
+		prEnt(prAlpha, "A30.Same", "r30.go"),
+		prEnt(prBeta, "B31.Same", "r31.go"),
+	}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 1 {
+		t.Fatalf("bound %d endpoint(s), want 1 — only the same (source, kind) is a candidate", n)
+	}
+	if fresh[0].ToID != prAlpha {
+		t.Errorf("ToID = %q, want %q", fresh[0].ToID, prAlpha)
+	}
+}
+
+// ── guard 3: the receiver_type veto ──────────────────────────────────────────
+
+// TestReplayPriorResolution_ReceiverTypeVetoBlocksRetarget is the mutation gate
+// for the receiver_type comparison in replayLookup.
+//
+// The call site moved from `a.Same(x)` (receiver A30) to `b.Same(x)` (receiver
+// B07) in the same edit. The stub is "Same" either way, so without the veto the
+// prior binding to A30.Same is replayed onto a call that now targets a different
+// type — a wrong edge, persisted, where today there would merely be an
+// unresolved stub.
+func TestReplayPriorResolution_ReceiverTypeVetoBlocksRetarget(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Same", "CALLS", map[string]string{"receiver_type": "B07"})}
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", map[string]string{"receiver_type": "A30"})}
+	survivors := []graph.Entity{prEnt(prAlpha, "A30.Same", "r30.go")}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 0 {
+		t.Errorf("bound %d endpoint(s) across a changed receiver_type, want 0", n)
+	}
+	if fresh[0].ToID != "Same" {
+		t.Errorf("ToID = %q, want the stub left verbatim", fresh[0].ToID)
+	}
+}
+
+// TestReplayPriorResolution_ReceiverTypeVetoDisambiguates pins the veto's second
+// role: when the prior graph bound one member name to two live targets, matching
+// receivers pick the right one instead of giving up.
+func TestReplayPriorResolution_ReceiverTypeVetoDisambiguates(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Same", "CALLS", map[string]string{"receiver_type": "B31"})}
+	prior := []graph.Relationship{
+		prRel(prCaller, prAlpha, "CALLS", map[string]string{"receiver_type": "A30"}),
+		prRel(prCaller, prBeta, "CALLS", map[string]string{"receiver_type": "B31"}),
+	}
+	survivors := []graph.Entity{
+		prEnt(prAlpha, "A30.Same", "r30.go"),
+		prEnt(prBeta, "B31.Same", "r31.go"),
+	}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 1 {
+		t.Fatalf("bound %d endpoint(s), want 1", n)
+	}
+	if fresh[0].ToID != prBeta {
+		t.Errorf("ToID = %q, want the receiver-matched target %q", fresh[0].ToID, prBeta)
+	}
+}
+
+// TestReplayPriorResolution_ReceiverTypeVetoIsOffWhenUnstamped documents the
+// veto's known limit rather than pretending it is universal: the property is
+// stamped by the Go extractor only, and even there it is dropped when the
+// extractor is unsure of the receiver. When either side lacks it the veto cannot
+// fire, and the binding rests on the ambiguity guard alone — which is why that
+// guard, not this one, is the load-bearing one.
+func TestReplayPriorResolution_ReceiverTypeVetoIsOffWhenUnstamped(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Same", "CALLS", nil)} // no receiver_type
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", map[string]string{"receiver_type": "A30"})}
+	survivors := []graph.Entity{prEnt(prAlpha, "A30.Same", "r30.go")}
+
+	if n := replayPriorResolution(fresh, prior, survivors, nil); n != 1 {
+		t.Errorf("bound %d endpoint(s), want 1 — an unstamped fresh edge is not vetoed", n)
+	}
+}
+
+// ── guard 4: the fresh resolution always wins ────────────────────────────────
+
+// TestReplayPriorResolution_LeavesResolvedEdgesAlone is the mutation gate for
+// the `if replayIsHexID(r.ToID) { continue }` skip.
+//
+// The skip is a real contract — the fresh pass's own resolution is authoritative
+// and must never be overwritten by a stale one — even though the index cannot
+// reach a hex endpoint in practice (its keys are entity names). Pinning it here
+// means a future change that starts indexing ids, or an entity whose Name is
+// 16 hex characters, is caught rather than silently retargeting live edges.
+func TestReplayPriorResolution_LeavesResolvedEdgesAlone(t *testing.T) {
+	fresh := []graph.Relationship{
+		// The edge under test: already resolved by the fresh pass.
+		prRel(prCaller, prBeta, "CALLS", nil),
+		// A second, genuinely unresolved edge. Without it the function's
+		// "nothing to do" pre-scan would return before reaching the per-edge
+		// skip, and this case would pass on a tree with the skip deleted.
+		prRel(prCaller, "Do11", "CALLS", nil),
+	}
+	prior := []graph.Relationship{
+		prRel(prCaller, prAlpha, "CALLS", nil),
+		prRel(prCaller, prDead2, "CALLS", nil),
+	}
+	// The first prior target is NAMED with the fresh edge's resolved ToID, so
+	// an index keyed on names reaches it the moment the hex skip is removed.
+	survivors := []graph.Entity{
+		prEnt(prAlpha, prBeta, "r30.go"),
+		prEnt(prBeta, "T23.Do23", "r23.go"),
+		prEnt(prDead2, "T11.Do11", "r11.go"),
+	}
+
+	n := replayPriorResolution(fresh, prior, survivors, nil)
+	if fresh[0].ToID != prBeta {
+		t.Errorf("ToID = %q, want the fresh resolution %q preserved — an ALREADY-RESOLVED "+
+			"endpoint must never be overwritten by a prior binding", fresh[0].ToID, prBeta)
+	}
+	// The unresolved sibling is expected to bind; only the resolved one is off limits.
+	if n != 1 || fresh[1].ToID != prDead2 {
+		t.Errorf("bound n=%d, fresh[1].ToID=%q; want n=1 with the UNRESOLVED sibling bound to %q",
+			n, fresh[1].ToID, prDead2)
+	}
+}
+
+// ── name-key shapes ──────────────────────────────────────────────────────────
+
+// TestReplayPriorResolution_NameKeyShapes pins which spellings of a stub reach a
+// prior binding. The member-tail form is the whole point of the fix (entity
+// "T11.Do11" vs call-site stub "Do11"); the Format A structural ref is the other
+// shape the extractors emit.
+func TestReplayPriorResolution_NameKeyShapes(t *testing.T) {
+	cases := []struct {
+		name     string
+		stub     string
+		priorEnt graph.Entity
+		wantBind bool
+	}{
+		{"bare member tail", "Do11", prEnt(prAlpha, "T11.Do11", "r11.go"), true},
+		{"whole name", "T11.Do11", prEnt(prAlpha, "T11.Do11", "r11.go"), true},
+		{"format A ref", "scope:operation:method:go:r11.go:Do11", prEnt(prAlpha, "T11.Do11", "r11.go"), true},
+		{"qualified name", "svc.T11.Do11", graph.Entity{
+			ID: prAlpha, Name: "T11.Do11", QualifiedName: "svc.T11.Do11", SourceFile: "r11.go",
+		}, true},
+		{"unrelated name", "Nope", prEnt(prAlpha, "T11.Do11", "r11.go"), false},
+		// A stub that shares only a PREFIX must not bind — suffix matching is
+		// deliberate, prefix matching would be a fabrication.
+		{"prefix only", "T11", prEnt(prAlpha, "T11.Do11", "r11.go"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fresh := []graph.Relationship{prRel(prCaller, tc.stub, "CALLS", nil)}
+			prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", nil)}
+			n := replayPriorResolution(fresh, prior, []graph.Entity{tc.priorEnt}, nil)
+			if got := n == 1; got != tc.wantBind {
+				t.Errorf("bound=%v (n=%d), want bound=%v", got, n, tc.wantBind)
+			}
+		})
+	}
+}
+
+// TestReplayPriorResolution_NoPriorOutboundIsANoOp pins the cheap exits: a run
+// with nothing pruned, or nothing unresolved, must not touch the fresh edges.
+func TestReplayPriorResolution_NoPriorOutboundIsANoOp(t *testing.T) {
+	fresh := []graph.Relationship{prRel(prCaller, "Do11", "CALLS", nil)}
+	if n := replayPriorResolution(fresh, nil, []graph.Entity{prEnt(prAlpha, "T11.Do11", "r11.go")}, nil); n != 0 {
+		t.Errorf("bound %d with no prior outbound edges, want 0", n)
+	}
+	resolved := []graph.Relationship{prRel(prCaller, prBeta, "CALLS", nil)}
+	prior := []graph.Relationship{prRel(prCaller, prAlpha, "CALLS", nil)}
+	if n := replayPriorResolution(resolved, prior, []graph.Entity{prEnt(prAlpha, "T11.Do11", "r11.go")}, nil); n != 0 {
+		t.Errorf("bound %d with no unresolved endpoints, want 0", n)
+	}
+}


### PR DESCRIPTION
Incremental indexing dropped correct edges out of a changed file when single-file re-extraction could not re-resolve them. Incremental is the **default** path for a watched repo, so a long-lived graph degraded continuously.

## The issue pointed at the wrong path

#6090 locates this in `cmd/grafel/index.go`. Measured on the same fixture, **that path loses nothing for this stub shape**: Path B seeds `resolve.BuildIndex` with the prior graph's unchanged-file entities (`incrementalCarryForwardEntities`, `index.go:1243`), and the `byMember` tier keys on `Name` + `SourceFile` — both carried. The "sketch of a real fix" in the issue describes a mechanism Path B already has.

The defect is in **Path A, the daemon merge** (`internal/extractors/incremental.go:446`). Its only rebinding is `sresolver.ResolveScoped`, whose ladder (`sresolver/scoped.go:247`) lacks the member-suffix tier — and its whole-string tier is last-writer-wins with no ambiguity sentinel, so it is *unsound* where the full resolver is not, rather than a strict subset.

Concretely: a Go method entity is named `T11.Do11`, the call site emits the bare stub `Do11`, the full resolver's member-suffix tier binds it, the scoped one cannot.

Path A is the default for a watched repo, so the severity stands — it is just in `internal/extractors/`.

**Not claimed:** that Path B is clean in general. Its carry-forward record omits `QualifiedName` (`index.go:1250-1256`), which `symbol_index.go:186,573` indexes, so `byQualifiedName` receives no entries from unchanged files. Same defect shape, narrower blast radius, pre-existing — tracked as #6119.

## Monotonicity is per-file, not per-edit

- Editing three **different** files: **3 → 6 → 9** CALLS lost. Each edited file permanently contributes its own unresolvable outgoing edges.
- Editing the **same** file three times: a constant 3, re-lost each pass rather than accumulating.

That distinction matters for anyone testing here: a three-edits-to-one-file test shows a flat count and looks like the defect is bounded.

The loss is also **invisible one-directionally** — each lost edge is paired with an *invented* one carrying an unresolved ToID (`…→Do11:CALLS` where a full rebuild has `…→4d59f7188927591f:CALLS`). A one-way comparison reports "nothing missing"; the edge is present, pointing at a name instead of an entity. Only the bidirectional multiset comparison from #6037 surfaces it.

## The mechanism, and why a deleted edge cannot survive

The fix uses **the fresh pass's own output as the trigger**, with the prior graph only as a resolution oracle:

- fresh edge has a hex ToID → skip; the fresh pass wins
- fresh edge has a bare-name ToID → ask the prior graph what the corpus-wide resolver bound *that name*, from *that FromID*, under *that Kind*, and rebind
- no fresh edge → nothing to bind; the prior edge stays dropped

The safety property is **structural, not probabilistic**: the pass only mutates the `ToID` of an edge the fresh extraction emitted, and **never appends a row**. Retaining a deleted edge is therefore impossible by construction. A retargeted call emits a fresh edge naming the *new* target, which does not match, so the stale edge stays dropped.

Review verified this rather than accepting it — `replayPriorResolution` returns an `int`, never a slice; the only appends are to local buffers; the sole write to caller state is `r.ToID = target`. `newRels` at Step 7a is literally the fresh per-file output, and `sresolver`'s `ResolvedNewRelationships` is that same set without survivors folded in.

Adversarial cases, all run against persisted graphs read back via `LoadGraphFromDir`:

| case | result |
|---|---|
| call deleted outright | no retention |
| target method deleted in the same edit | matched full rebuild **exactly**; liveness check works |
| target moved to a different file | **a loss, not a fabrication** — liveness refused the stale ID |
| retarget to a different receiver, same method name | `receiver_type` veto fired |
| same, in Python (no `receiver_type` stamp) | scoped resolver bound it, so replay was skipped |
| file deleted entirely | no fresh edge, nothing to bind |

**No adversarial case produced a stale resolved edge.** Staleness also cannot compound: entity IDs are deterministic over `kind/name/source_file`, so a binding surviving the liveness filter genuinely denotes the same entity.

Ambiguity guard: replay only when the prior graph bound the name to exactly one still-live entity — two targets is what the full resolver calls ambiguous and leaves unresolved. Plus a `receiver_type` veto when both edges carry one.

## The mutation work, and two false negatives worth recording

Review found **4 of 5 safety mechanisms unkilled** by the original suite — only the happy path was pinned, in the file where #6085 deleted a third of the graph. Now all four are killed by 13 guard-level tests:

| mutation | before | now |
|---|---|---|
| disable replay entirely | KILLED | KILLED |
| remove the ambiguity guard | **SURVIVED** | **KILLED** |
| disable the `receiver_type` veto | **SURVIVED** | **KILLED** |
| remove the liveness filter | **SURVIVED** | **KILLED** |
| replay onto already-resolved edges | **SURVIVED** | **KILLED** |

Two of those needed the *mutation* corrected, not just a test added, and that partly explains the original survivals:

- **Liveness is not freely separable.** Name keys are obtainable only from a live entity row, so deleting the `if !ok { continue }` check alone is a **no-op** — there is no name for a dead id to index under. The honest mutation is a stale-name oracle independent of existence; under that, the test fails.
- **The hex skip was unreachable** in the original fixture: the function's "nothing unresolved" pre-scan returned before reaching it, so the case passed with the skip deleted. Fixed by adding an unresolved sibling edge so the skip is actually exercised, with the prior target deliberately *named* with the fresh edge's resolved id so a name-keyed index reaches it the moment the skip goes.

A surviving mutant can be a false negative when the mutation is itself a no-op. The guards are now documented in the package doc as mutation-gated, so deleting one has a named consequence.

## A real bug in the test's own filter

`strings.HasSuffix(k, ":CALLS")` missed multiplicity keys — `parity.keyWithCount` renders `n>1` as `"…:CALLS ×3"` — so **lost or invented duplicate CALLS groups were invisible** to two of the three tests. Fixed by stripping a trailing ` ×N` before the suffix check, and `RelMultiplicityDiffs` is now folded in as well: a group present on both sides at *different* multiplicities is neither "only in A" nor "only in B" and was slipping through both filters.

## Tests

All three behavioural tests verified RED before the fix for the stated reason, GREEN after.

- Three successive edits to the same file — RED with "missing 3 CALLS edge(s)" at each pass.
- Three edits to different files — RED at 3 → 6 → 9.
- **Monotonicity is now asserted, not commented**: resolved cross-file CALLS out of the files edited so far must equal `2×pass` and never shrink. Green trace `2 → 4 → 6`; on the disabled-fix tree it is flat at `0 / 0 / 0` while lost/invented climb 3/6/9.
- Deleted-call counter-test: the deleted calls are absent in both resolved and stub form, with strict CALLS parity in both directions (0 lost, 0 invented), and the replay bound only the one unrelated intra-file edge.
- Positive baselines added — every test fails fast with "fixture is inert" if the baseline full rebuild does not hold the expected resolved calls. Previously all three passed on a CALLS-free graph.

## Residual — this reduces the symptom, it does not eliminate it

A call the edit **itself introduces** has no prior binding to replay, so `sresolver`'s weaker ladder still leaves it unresolved on first sight: measured `[Helper07, STUB:Do11, STUB:Do23]` incrementally versus `[Helper07, T11.Do11, T23.Do23]` on full rebuild.

That is a not-yet-gain rather than a loss of a correct edge — but **the same monotone accumulation applies to newly-written edges**, so #6090's headline symptom is reduced, not closed. It is an `sresolver` ladder-parity gap (#5309 layer 1 residual).

## Two weaknesses documented rather than chased

Neither could be turned into a wrong persisted edge:

- Dead candidates are filtered *before* ambiguity is counted, so an ambiguous prior name where one candidate died becomes a confident bind.
- The `receiver_type` veto is stamp-dependent, and per `internal/resolve/refs.go:1206` that stamp is **Go-only** — and within Go, `extractor.go:509` drops it when the extractor is unsure. The veto is therefore off in exactly the uncertain cases, and for every non-Go language.

Also recorded: `incremental_prior_resolution.go:164` recomputes `r.ID` unguarded. Safe **only** because `newRels` comes from `types.RelationshipRecord`, which has no ID field, so the path is structurally salt-free. The constraint is now written at the site with a pointer to the #6085 precedent and instructions to carry the prior row's ID forward if a salted producer ever feeds this path.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`:

| package | exit | skips |
|---|---|---|
| `./internal/extractors/...` | 0 | 1 |
| `./cmd/grafel/` | 0 | 7 |
| `./internal/graph/...` | 0 | **0** |

Independently adversarially reviewed, returned REQUEST-CHANGES on coverage, re-verified.

Closes #6090
Refs #6085, #6119, #6037, #5309
