### PR TITLE
fix(#6098): port the receiver-type and leaf-name tiers to the scoped resolver, delta-indexed

### DIFF
--- a/cmd/grafel/incremental_dup_rows_6094_test.go
+++ b/cmd/grafel/incremental_dup_rows_6094_test.go
@@ -399,9 +399,28 @@ func Num7(x int) string { return strconv.Itoa(x + 7) }
 }
 
 // TestIncremental_DependsOnWeightParity_6098 is a live, self-contained
-// reproduction of #6098 — SKIPPED, because #6098 is a DIFFERENT defect from
-// #6094 and its fix does not belong in this change. Un-skip it when the
-// resolver work below is picked up; it is already red for the right reason.
+// reproduction of #6098. It was landed SKIPPED and is now un-skipped.
+//
+// IT NO LONGER FAILS FOR THE REASON DOCUMENTED BELOW — recorded because the
+// distinction matters to anyone reading this as the #6098 acceptance gate.
+// Measured on this fixture: with prior-resolution replay (#6121) disabled the
+// test is RED at exactly the documented signature, 39/117 against 40/120;
+// with it enabled it is GREEN, and the replay log reports it binding the two
+// endpoints per pass. So #6121 — which landed for #6090 — already closed THIS
+// fixture, because the two CALLS edges exist in the baseline graph and
+// therefore have a prior binding to replay.
+//
+// Verifying that took a corrected mutation: multiplying the replay's return
+// value by zero leaves the test GREEN, because replayPriorResolution mutates
+// its argument in place and only the log line is suppressed. The honest
+// mutation is to not call it at all.
+//
+// What the fixture can no longer see is the residual: a call the edit ITSELF
+// introduces has no prior binding, so replay cannot help and only a resolver
+// tier can bind it. That case is
+// TestIncremental_NewlyIntroducedCrossFileCall_6098, and it was RED here until
+// internal/extractors/sresolver/pkgmember.go landed. This test is kept
+// un-skipped as a weight-parity regression gate.
 //
 // #6098 IS NOT THE SAME ROOT CAUSE AS #6094. Evidence.
 // ─────────────────────────────────────────────────────
@@ -448,9 +467,6 @@ func Num7(x int) string { return strconv.Itoa(x + 7) }
 // path. That is a separate change against a separate component, and shipping a
 // partial version of it here would be worse than leaving the defect visible.
 func TestIncremental_DependsOnWeightParity_6098(t *testing.T) {
-	t.Skip("#6098 is open and is NOT the #6094 root cause — see the comment above for the " +
-		"measured evidence and the exact chain; un-skip when sresolver gains a receiver-type tier")
-
 	repo := t.TempDir()
 	stateDir := t.TempDir()
 	const nFiles = 20

--- a/cmd/grafel/incremental_member_tier_6098_test.go
+++ b/cmd/grafel/incremental_member_tier_6098_test.go
@@ -1,0 +1,133 @@
+// Package main — incremental_member_tier_6098_test.go
+//
+// #6098 / #6090-residual — the scoped resolver's receiver-type tier, measured
+// end-to-end on a persisted graph.
+//
+// #6121 closed the #6090 loss class by REPLAYING the prior graph's binding for
+// an edge the single-file re-extraction could not re-bind. That mechanism is
+// structurally unable to help a call the edit ITSELF introduces: there is no
+// prior edge to consult, so the stub is permanent until a full reindex.
+// Measured in that PR as `[Helper07, STUB:Do11, STUB:Do23]` incrementally
+// versus `[Helper07, T11.Do11, T23.Do23]` on a full rebuild.
+//
+// Only a resolver TIER can bind it, which is what
+// internal/extractors/sresolver/pkgmember.go adds: the corpus-wide resolver's
+// package-scoped member index (internal/resolve/refs.go:5684, refs #148/#364),
+// restricted on the scoped path to the package directories actually probed.
+//
+// The fixture below is the exact complement of
+// incremental_prior_resolution_6090_test.go: there the cross-file calls exist
+// in the BASELINE (so replay can bind them), here they do NOT (so replay
+// cannot).
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// mt6098Baseline is the pass-0 content of the file that will be edited. It has
+// NO cross-file calls — that is the whole point. Compare pr6090Edited(0),
+// which deliberately does.
+func mt6098Baseline() string {
+	return `package svc
+
+type T07 struct{ N int }
+
+func (t *T07) Do07(x int) int { return x + t.N + 7 }
+
+func Helper07(x int) int { return x + 7 }
+
+func Local07(x int) int { return Helper07(x) }
+`
+}
+
+// mt6098Introduces adds two cross-file method calls that did not exist in any
+// prior graph. `a.Do11` / `b.Do23` are bare-name stubs at the call site while
+// the callee entities are named `T11.Do11` / `T23.Do23` in sibling files of
+// the same package directory — the shape only the receiver-type tier binds.
+func mt6098Introduces(pass int) string {
+	return fmt.Sprintf(`package svc
+
+type T07 struct{ N int }
+
+func (t *T07) Do07(x int) int { return x + t.N + 7 }
+
+func Helper07(x int) int { return x + 7 }
+
+func Local07(x int) int {
+	a := &T11{N: 1}
+	b := &T23{N: 2}
+	return Helper07(x) + a.Do11(x) + b.Do23(x) + %d
+}
+`, pass)
+}
+
+// TestIncremental_NewlyIntroducedCrossFileCall_6098 is the #6090 residual gate.
+//
+// Every basename in the corpus is unique: diff.Filter cross-invalidates
+// same-basename files, which would turn the one-file delta into an N-file
+// change and trip the too-many-changed full-reindex fallback, making the case
+// vacuous. dvIncremental fails the test if TryIncremental falls back, so a
+// silent full reindex cannot fake a pass either.
+func TestIncremental_NewlyIntroducedCrossFileCall_6098(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	pr6090WriteCorpus(t, repo)
+	// Overwrite r07.go with the call-free baseline, replacing the variant
+	// pr6090WriteCorpus installs. Replay must have NOTHING to replay.
+	dvWriteFile(t, repo, "r07.go", mt6098Baseline())
+	dvFullRebuild(t, repo, stateDir)
+
+	base, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load baseline: %v", err)
+	}
+	// Precondition, not a result: if the baseline already held these edges the
+	// test would be measuring #6121's replay, not the tier.
+	if n := pr6090CountResolvedCrossFileCalls(base, "r07.go"); n != 0 {
+		t.Fatalf("fixture is not testing the residual: the baseline already holds %d resolved "+
+			"cross-file CALLS edge(s) out of r07.go, so prior-resolution replay could bind them "+
+			"and the receiver-type tier is not what is under test", n)
+	}
+
+	fullRepo := t.TempDir()
+	pr6090WriteCorpus(t, fullRepo)
+	dvWriteFile(t, fullRepo, "r07.go", mt6098Baseline())
+
+	const wantCrossFile = 2
+	for pass := 1; pass <= 3; pass++ {
+		dvSeedManifest(t, repo, stateDir)
+		dvWriteFile(t, repo, "r07.go", mt6098Introduces(pass))
+		dvIncremental(t, repo, stateDir)
+
+		b, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			t.Fatalf("pass %d: load persisted incremental graph: %v", pass, err)
+		}
+
+		dvWriteFile(t, fullRepo, "r07.go", mt6098Introduces(pass))
+		c := dvFullRebuild(t, fullRepo, t.TempDir())
+
+		// Positive baseline — without this the assertions below are satisfied
+		// by a graph that never held the edges at all.
+		if n := pr6090CountResolvedCrossFileCalls(c, "r07.go"); n != wantCrossFile {
+			t.Fatalf("pass %d: fixture is inert — the full rebuild holds %d resolved cross-file "+
+				"CALLS edge(s) out of r07.go, want %d", pass, n, wantCrossFile)
+		}
+		if n := pr6090CountResolvedCrossFileCalls(b, "r07.go"); n != wantCrossFile {
+			t.Errorf("pass %d: the incremental graph holds %d resolved cross-file CALLS edge(s) out "+
+				"of r07.go, want %d — a call the edit ITSELF introduced has no prior binding to "+
+				"replay, so it stays a bare-name stub unless the scoped resolver's receiver-type "+
+				"tier binds it (#6098 / #6090 residual)", pass, n, wantCrossFile)
+		}
+
+		// Bidirectional multiset parity (#6037): asserting only on `lost`
+		// accepts a graph that replaced a correct edge with a wrong one, and
+		// each stub here is paired with an INVENTED `…→Do11:CALLS` row, so a
+		// one-way comparison reports nothing missing.
+		pr6090AssertCallsParity(t, fmt.Sprintf("pass %d", pass), b, c)
+	}
+}

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -1,0 +1,320 @@
+package sresolver
+
+import (
+	"strings"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// receiverTypeProp is the extractor-supplied property that names the receiver
+// a method-dispatch CALLS edge was invoked on. Stamped by the Go extractor
+// only (internal/resolve/refs.go:1206), and dropped by
+// golang/extractor.go:509 when the extractor is unsure — so an absent stamp
+// means "no receiver information", never "no receiver".
+const receiverTypeProp = "receiver_type"
+
+// pkgDirOf returns the directory portion of a slash-normalised source file
+// path, used as the package key for the member tiers. Mirrors
+// internal/resolve/refs.go:126 exactly, including its edge cases: a path with
+// no separator (file in repo root) returns "." so a caller in the root
+// package still hits a non-empty bucket, a leading-slash path returns "/",
+// and an empty input returns "".
+//
+// It is duplicated rather than imported because internal/resolve is a heavy
+// package whose test suite imports internal/extractors; this package is
+// deliberately kept light (see the package doc).
+func pkgDirOf(p string) string {
+	if p == "" {
+		return ""
+	}
+	if i := strings.LastIndexByte(p, '/'); i >= 0 {
+		if i == 0 {
+			return "/"
+		}
+		return p[:i]
+	}
+	return "."
+}
+
+// normalizeSlashes puts a source path into the slash form pkgDirOf expects.
+func normalizeSlashes(p string) string {
+	if strings.IndexByte(p, '\\') >= 0 {
+		p = strings.ReplaceAll(p, "\\", "/")
+	}
+	return strings.TrimPrefix(p, "./")
+}
+
+// ambiguous is the blank-string sentinel stored in every index below when two
+// DISTINCT entities claim one key. The corpus-wide resolver leaves such a stub
+// verbatim rather than picking a candidate, and so do we — see
+// memberIndexes.lookupReceiver for why collapsing that into a plain miss would be
+// actively harmful here.
+const ambiguous = ""
+
+// memberIndexes is the scoped path's port of the member tiers the corpus-wide
+// resolver reaches for a bare-name CALLS/dispatch stub that its global
+// name index cannot bind.
+//
+// # The three ported tiers, with their upstream sites
+//
+//  1. byPackageMember[pkgDir][receiverType][member] — issue #148 / #364,
+//     internal/resolve/refs.go:5684. Fires when the edge carries
+//     Properties["receiver_type"]. The most PRECISE tier: the receiver stamp
+//     names the scope, so no cross-scope guessing is involved.
+//
+//  2. leafByFile[file][member] — issue #778,
+//     internal/resolve/refs.go:lookupMemberByLeafName (probed from
+//     rewriteOneWithCaller at refs.go:2963). A bare CALLS stub binds to a
+//     member of ANY scope declared in the caller's own file, provided exactly
+//     one scope declares it.
+//
+//  3. leafByPkg[pkgDir][member] — issue #778,
+//     internal/resolve/refs.go:lookupPackageMemberByLeafName (refs.go:2969).
+//     Same, widened to the caller's package directory. This is the tier that
+//     actually binds the #6090-residual shape: `a.Do11(x)` inside a free
+//     function, where the callee entity is `T11.Do11` in a SIBLING file.
+//
+// The scoped ladder previously had none of them. Its nameToID tier is keyed on
+// the WHOLE entity name (`T11.Do11`, never `Do11`) and its byLocation tier on
+// the EXACT source file, so a same-package/different-file member was
+// unreachable — which is #6098's root cause and #6090's residual.
+//
+// # Memory — why this is not the corpus-sized index the scoped path avoids
+//
+// The corpus-wide resolver indexes every dotted-name entity in the corpus.
+// Doing that here would reintroduce exactly the peak the scoped path exists to
+// avoid (epic #5954). Instead the index is built ONLY over the package
+// directories of the freshly extracted files — the changed-file delta. Every
+// other entity is scanned (one pointer-walk, no allocation) and discarded.
+//
+// So the retained size is O(entities in the changed files' packages), which is
+// a property of the edit, not of the repository. On a one-file edit to a
+// 20-file package that is a few hundred map entries; the pre-existing nameToID
+// and byLocation maps in ResolveScoped, which ARE built over every surviving
+// entity, dominate it by orders of magnitude. Measured in
+// pkgmember_memory_test.go.
+//
+// A caller outside those directories simply does not get the tiers, which is
+// the status quo for it — a surviving edge left unresolved by the previous
+// build was already unresolvable by the corpus-wide resolver that produced it.
+type memberIndexes struct {
+	byPackageMember map[string]map[string]map[string]string // [dir][scope][member]
+	leafByFile      map[string]map[string]string            // [file][member]
+	leafByPkg       map[string]map[string]string            // [dir][member]
+
+	// callerLoc maps an entity ID to its location. It is probed with the
+	// edge's RESOLVED FromID, which is why ResolveScoped must rewrite the
+	// from-side of an edge before the to-side: the Go extractor emits the
+	// from-side as a Format A structural stub
+	// (`scope:operation:method:go:r07.go:Local07`), not as an entity ID, so
+	// keying this on the raw FromID finds nothing and every tier silently
+	// misses. That was a real defect during development — the tiers were
+	// correct and never fired.
+	callerLoc map[string]callerLocation
+}
+
+type callerLocation struct {
+	file string
+	dir  string
+}
+
+// relWantsMemberTier reports whether r is a candidate for any ported tier: an
+// unresolved (non-hex) ToID that is either receiver-stamped or CALLS-shaped.
+// Format A structural stubs are excluded — they carry colons and are the
+// existing ladder's business.
+func relWantsMemberTier(r *graph.Relationship) bool {
+	if r.ToID == "" || isHexID(r.ToID) || strings.IndexByte(r.ToID, ':') >= 0 {
+		return false
+	}
+	return strings.EqualFold(r.Kind, "CALLS") || r.PropGet(receiverTypeProp) != ""
+}
+
+// buildMemberIndexes constructs the tiers over newEntities ∪ existingEntities,
+// restricted to the package directories of newEntities (the changed files).
+// Returns nil — retaining nothing — when the delta has no package directory.
+func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberIndexes {
+	// The probe set: the packages the changed files live in. This is the
+	// memory bound, and it is deliberately derived from the DELTA.
+	probeDirs := map[string]bool{}
+	for i := range newEntities {
+		if dir := pkgDirOf(normalizeSlashes(newEntities[i].SourceFile)); dir != "" {
+			probeDirs[dir] = true
+		}
+	}
+	if len(probeDirs) == 0 {
+		return nil
+	}
+
+	idx := &memberIndexes{
+		byPackageMember: map[string]map[string]map[string]string{},
+		leafByFile:      map[string]map[string]string{},
+		leafByPkg:       map[string]map[string]string{},
+		callerLoc:       map[string]callerLocation{},
+	}
+
+	put := func(bucket map[string]string, key, id string) {
+		if existing, ok := bucket[key]; ok && existing != id {
+			bucket[key] = ambiguous
+			return
+		}
+		bucket[key] = id
+	}
+
+	scan := func(ents []graph.Entity) {
+		for i := range ents {
+			e := &ents[i]
+			file := normalizeSlashes(e.SourceFile)
+			dir := pkgDirOf(file)
+			// Everything retained is gated on the probe set, which is what
+			// keeps this index delta-sized rather than corpus-sized.
+			if dir == "" || !probeDirs[dir] {
+				continue
+			}
+			idx.callerLoc[e.ID] = callerLocation{file: file, dir: dir}
+
+			dot := strings.LastIndexByte(e.Name, '.')
+			if dot <= 0 || dot >= len(e.Name)-1 {
+				continue
+			}
+			scope, member := e.Name[:dot], e.Name[dot+1:]
+
+			pkgBucket := idx.byPackageMember[dir]
+			if pkgBucket == nil {
+				pkgBucket = map[string]map[string]string{}
+				idx.byPackageMember[dir] = pkgBucket
+			}
+			scopeBucket := pkgBucket[scope]
+			if scopeBucket == nil {
+				scopeBucket = map[string]string{}
+				pkgBucket[scope] = scopeBucket
+			}
+			put(scopeBucket, member, e.ID)
+
+			fileBucket := idx.leafByFile[file]
+			if fileBucket == nil {
+				fileBucket = map[string]string{}
+				idx.leafByFile[file] = fileBucket
+			}
+			put(fileBucket, member, e.ID)
+
+			pkgLeaf := idx.leafByPkg[dir]
+			if pkgLeaf == nil {
+				pkgLeaf = map[string]string{}
+				idx.leafByPkg[dir] = pkgLeaf
+			}
+			put(pkgLeaf, member, e.ID)
+		}
+	}
+	scan(existingEntities)
+	scan(newEntities)
+	return idx
+}
+
+// lookup probes the ported tiers for one edge. callerEndpoint is the edge's
+// RAW (pre-resolution) FromID.
+//
+// The return contract has THREE outcomes, mirroring
+// internal/resolve/refs.go:lookupPackageMember:
+//
+//	(id, true)  — unambiguous hit; bind.
+//	("", true)  — AMBIGUOUS. Handled, but not bound. The caller must leave the
+//	              stub verbatim and must NOT continue down the ladder.
+//	("", false) — no entry; the caller falls through to the next tier.
+//
+// The ("", true) case is the soundness guard and it is not cosmetic. The
+// scoped ladder's whole-string tier is LAST-WRITER-WINS with no ambiguity
+// sentinel of its own, so collapsing ambiguity into ("", false) would turn a
+// correctly-unresolved stub into a CONFIDENT WRONG binding the moment some
+// unrelated entity happens to be named after the member. A wrong edge is worse
+// than the stub it replaces — that is the whole reason #6098 was left open
+// rather than half-fixed.
+// It is split into two entry points because the two halves sit on OPPOSITE
+// sides of the scoped ladder's whole-string tier, mirroring where the
+// corpus-wide resolver probes each:
+//
+//	lookupReceiver — BEFORE (refs.go:5684 runs ahead of rewriteOneWithCaller)
+//	lookupLeaf     — AFTER  (refs.go:2963/2969 are fallbacks inside it)
+//
+// Getting that order wrong in either direction changes which binding wins for
+// a name that several tiers can see, so it is pinned by tests rather than
+// left to the reader.
+func (idx *memberIndexes) lookupReceiver(r *graph.Relationship, callerEndpoint string) (string, bool) {
+	if idx == nil || callerEndpoint == "" || !relWantsMemberTier(r) {
+		return "", false
+	}
+	loc := idx.callerLoc[callerEndpoint]
+	if loc.dir == "" {
+		return "", false
+	}
+	member := r.ToID
+
+	// Tier 1 — receiver-stamped dispatch (#148 / #364). Most precise, so
+	// first, exactly as internal/resolve/refs.go orders it.
+	if recv := r.PropGet(receiverTypeProp); recv != "" {
+		if pkgBucket := idx.byPackageMember[loc.dir]; pkgBucket != nil {
+			// #148 baseline: the stamped type as-is. #364 follow-up: when the
+			// stamp is package-qualified (`chi.Mux`), strip the package
+			// segment and retry, because entities are emitted under their
+			// bare receiver name. As-is FIRST so a type whose name genuinely
+			// contains a dot still wins.
+			tryTypes := [2]string{recv, ""}
+			n := 1
+			if dot := strings.LastIndexByte(recv, '.'); dot >= 0 && dot < len(recv)-1 {
+				tryTypes[1] = recv[dot+1:]
+				n = 2
+			}
+			for i := 0; i < n; i++ {
+				scopeBucket := pkgBucket[tryTypes[i]]
+				if scopeBucket == nil {
+					continue
+				}
+				id, ok := scopeBucket[member]
+				if !ok {
+					continue
+				}
+				if id == ambiguous {
+					// Do NOT retry the stripped form, do NOT fall through.
+					return "", true
+				}
+				return id, true
+			}
+		}
+	}
+
+	return "", false
+}
+
+// lookupLeaf probes tiers 2 and 3. Same three-outcome contract as
+// lookupReceiver.
+func (idx *memberIndexes) lookupLeaf(r *graph.Relationship, callerEndpoint string) (string, bool) {
+	if idx == nil || callerEndpoint == "" || !relWantsMemberTier(r) {
+		return "", false
+	}
+	loc := idx.callerLoc[callerEndpoint]
+	if loc.dir == "" {
+		return "", false
+	}
+	member := r.ToID
+
+	// Tiers 2 and 3 are CALLS-only (#778): a bare call name binding to a
+	// member of some scope is only the natural shape for a call edge. The
+	// same gate is what stops a DEPENDS_ON from catching a same-named method.
+	if !strings.EqualFold(r.Kind, "CALLS") {
+		return "", false
+	}
+	// Tier 2 — same file, any scope.
+	if id, ok := idx.leafByFile[loc.file][member]; ok {
+		if id == ambiguous {
+			return "", true
+		}
+		return id, true
+	}
+	// Tier 3 — same package directory, any scope. The #6090-residual tier.
+	if id, ok := idx.leafByPkg[loc.dir][member]; ok {
+		if id == ambiguous {
+			return "", true
+		}
+		return id, true
+	}
+	return "", false
+}

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -70,14 +70,37 @@ const ambiguous = ""
 //
 //  3. leafByPkg[pkgDir][member] — issue #778,
 //     internal/resolve/refs.go:lookupPackageMemberByLeafName (refs.go:2969).
-//     Same, widened to the caller's package directory. This is the tier that
-//     actually binds the #6090-residual shape: `a.Do11(x)` inside a free
-//     function, where the callee entity is `T11.Do11` in a SIBLING file.
+//     Same, widened to the caller's package directory.
 //
 // The scoped ladder previously had none of them. Its nameToID tier is keyed on
 // the WHOLE entity name (`T11.Do11`, never `Do11`) and its byLocation tier on
 // the EXACT source file, so a same-package/different-file member was
 // unreachable — which is #6098's root cause and #6090's residual.
+//
+// # Tier 1 and tiers 2-3 are REDUNDANT on the integration fixture
+//
+// Stated because an earlier version of this comment claimed the opposite.
+// Ablated tier-by-tier against
+// cmd/grafel:TestIncremental_NewlyIntroducedCrossFileCall_6098:
+//
+//	leaf tiers removed, receiver tier only  → PASSES
+//	receiver tier removed, leaf tiers only  → PASSES
+//	both removed                            → FAILS 3/3 (0 resolved, want 2)
+//
+// The Go extractor DOES stamp receiver_type for `a := &T11{...}; a.Do11(x)`,
+// so tier 1 alone binds that fixture — #6098's stated root cause was
+// sufficient for it. Tiers 2-3 are carried for LADDER PARITY with refs.go, not
+// because this fixture needs them; they are exercised by the unit tests in
+// scoped_member_6098_test.go only.
+//
+// A shape that separates them was looked for and not found within the time
+// box. The nearest candidate — a chained call `New23().Do23(x)`, which the
+// extractor emits as an unstamped Format A stub — is not one: the corpus-wide
+// resolver leaves it unresolved too, so there is nothing to reach parity with.
+//
+// The general lesson, recorded because it cost a wrong published claim:
+// "measured end-to-end" must mean tier-by-tier ablation, not "the whole change
+// makes the test pass".
 //
 // # Memory — why this is not the corpus-sized index the scoped path avoids
 //
@@ -87,12 +110,19 @@ const ambiguous = ""
 // directories of the freshly extracted files — the changed-file delta. Every
 // other entity is scanned (one pointer-walk, no allocation) and discarded.
 //
-// So the retained size is O(entities in the changed files' packages), which is
-// a property of the edit, not of the repository. On a one-file edit to a
-// 20-file package that is a few hundred map entries; the pre-existing nameToID
-// and byLocation maps in ResolveScoped, which ARE built over every surviving
-// entity, dominate it by orders of magnitude. Measured in
+// So the retained size is O(entities in the PACKAGES THE EDIT TOUCHES) — not
+// of the repository, but not of the edit alone either: probeDirs is keyed on
+// directories, so a delta spanning K packages costs K packages' worth of
+// entities regardless of how few files changed in each. On a one-file edit to
+// a 20-file package that is a few hundred map entries; the pre-existing
+// nameToID and byLocation maps in ResolveScoped, which ARE built over every
+// surviving entity, dominate it by orders of magnitude. Measured in
 // pkgmember_memory_test.go.
+//
+// Precision note for future work here: what ResolveScoped already holds is ONE
+// REPOSITORY's entity set. Epic #5954's peak concerns the multi-repo GROUP
+// corpus, which this path genuinely never materialises. "The scoped path
+// already holds the corpus" is true only at repo granularity.
 //
 // A caller outside those directories simply does not get the tiers, which is
 // the status quo for it — a surviving edge left unresolved by the previous
@@ -122,6 +152,16 @@ type callerLocation struct {
 // unresolved (non-hex) ToID that is either receiver-stamped or CALLS-shaped.
 // Format A structural stubs are excluded — they carry colons and are the
 // existing ladder's business.
+//
+// Divergence, verified inert today: refs.go:2875 gates the equivalent bare
+// lookup on !strings.ContainsAny(ref, ":.#"), i.e. it also rejects a DOT and
+// the Format B member delimiter. We reject only ':'. That is currently
+// harmless because every index key here is built from the segment AFTER the
+// last dot, so a dotted stub cannot spuriously match a member key. It goes
+// live the moment key construction changes — e.g. if a scope were ever
+// indexed under its dotted form. Left divergent rather than aligned so the
+// gate keeps stating the condition this code actually depends on, but the
+// coupling is written down here.
 func relWantsMemberTier(r *graph.Relationship) bool {
 	if r.ToID == "" || isHexID(r.ToID) || strings.IndexByte(r.ToID, ':') >= 0 {
 		return false
@@ -213,8 +253,9 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 // lookup probes the ported tiers for one edge. callerEndpoint is the edge's
 // RAW (pre-resolution) FromID.
 //
-// The return contract has THREE outcomes, mirroring
-// internal/resolve/refs.go:lookupPackageMember:
+// The return contract has THREE outcomes. The SIGNATURE mirrors
+// internal/resolve/refs.go:lookupPackageMember; the LADDER BEHAVIOUR
+// deliberately does not — see the asymmetry note below.
 //
 //	(id, true)  — unambiguous hit; bind.
 //	("", true)  — AMBIGUOUS. Handled, but not bound. The caller must leave the
@@ -228,6 +269,28 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 // unrelated entity happens to be named after the member. A wrong edge is worse
 // than the stub it replaces — that is the whole reason #6098 was left open
 // rather than half-fixed.
+//
+// # Deliberate asymmetry with refs.go on ambiguity — NOT parity
+//
+// The corpus-wide resolver does the OPPOSITE. At refs.go:5681-5697 an
+// ambiguous (pkg, recv, member) `break`s with resolved=false, so control
+// falls into the Go component tier and then rewriteOneWithCaller → the global
+// name index, WHICH CAN AND DOES BIND. The inline comment there ("fall through
+// to record as unmatched (preserve the stub)") is wrong about its own code —
+// the same misconception this port had to fix on the scoped side.
+//
+// Concretely: for an ambiguous (svc, T11, Do11) plus a single global entity
+// named `Do11` elsewhere, a FULL REBUILD binds the edge and this resolver
+// leaves a stub. That is a divergence in the #6090 loss direction, and
+// TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough asserts our
+// behaviour, not refs.go's.
+//
+// We keep our behaviour because refs.go's is unsound HERE: its global tier
+// carries an ambiguity sentinel, ours does not, so falling through would bind
+// arbitrarily rather than bind-or-refuse. Closing the divergence properly
+// means fixing the refs.go side, which is filed separately. Until then this is
+// a known, deliberate asymmetry — do not "restore parity" by deleting the
+// guard.
 // It is split into two entry points because the two halves sit on OPPOSITE
 // sides of the scoped ladder's whole-string tier, mirroring where the
 // corpus-wide resolver probes each:
@@ -286,6 +349,37 @@ func (idx *memberIndexes) lookupReceiver(r *graph.Relationship, callerEndpoint s
 
 // lookupLeaf probes tiers 2 and 3. Same three-outcome contract as
 // lookupReceiver.
+//
+// # What was NOT ported, and the gap it leaves
+//
+// These two are the tail of refs.go:lookupBareWithLocality (refs.go:2909),
+// which is a four-step ladder: byLocationKind[callerFile] →
+// byPackageOperation[callerPkgDir] → the two leaf lookups. Only the leaf
+// lookups are ported here, and only on an outright MISS — refs.go enters
+// lookupBareWithLocality on statusAmbiguous as well as statusUnmatched.
+//
+// The live gap: when a bare name is GLOBALLY AMBIGUOUS, refs.go rescues it
+// locally via byPackageOperation, whereas the scoped ladder's nameToID is
+// last-writer-wins and binds arbitrarily — possibly cross-package — so
+// control never reaches here at all. That is pre-existing scoped-path
+// unsoundness, not something this change introduced, but it now sits directly
+// beneath tiers that claim refs.go parity, so it is named rather than left
+// implicit. Closing it requires giving nameToID an ambiguity sentinel first;
+// doing that here would change the binding of every existing bare stub and is
+// out of scope for #6098.
+//
+// # The ("", true) refusals below are INERT TODAY
+//
+// Reverting either leaf tier's ambiguity to ("", false) does not change any
+// observable behaviour: lookupLeaf is the LAST rung of resolveToID, so a
+// refusal and a miss are indistinguishable to the caller, and tier-2
+// ambiguity implies tier-3 ambiguity. No guard is missing and no test is
+// absent — the mutants are genuine no-ops.
+//
+// They become load-bearing AND unpinned the instant a tier is appended after
+// lookupLeaf in resolveToID. If you add one, add the counter-test too; the
+// receiver tier's TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough
+// is the shape to copy.
 func (idx *memberIndexes) lookupLeaf(r *graph.Relationship, callerEndpoint string) (string, bool) {
 	if idx == nil || callerEndpoint == "" || !relWantsMemberTier(r) {
 		return "", false

--- a/internal/extractors/sresolver/pkgmember_memory_test.go
+++ b/internal/extractors/sresolver/pkgmember_memory_test.go
@@ -1,0 +1,210 @@
+package sresolver
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Memory characterisation of the member tiers.
+//
+// The reason #6098 was left open rather than half-fixed is that the
+// corpus-wide resolver's member tier is built over the ENTIRE entity set, and
+// the whole point of the scoped path is that it does not hold a corpus-sized
+// index (epic #5954; a corpus A/B measured peak HeapAlloc at ~3.0 GB).
+//
+// This file pins the property that makes the port safe: the index is built
+// over the package directories of the CHANGED files only, so its retained size
+// is a function of the edit, not of the repository. The structural assertion
+// below is deterministic; the reported byte figures come from
+// TestMemberIndexes_HeapCost, which is a measurement, not a threshold gate.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// memFixture builds a synthetic corpus: dirs packages of filesPerDir files,
+// each declaring one type with methodsPerType methods. Entity names are
+// dotted (`T<d>_<f>.M<m>`) so every one of them is a member-tier candidate —
+// the worst case for index size.
+func memFixture(dirs, filesPerDir, methodsPerType int) []graph.Entity {
+	ents := make([]graph.Entity, 0, dirs*filesPerDir*(methodsPerType+1))
+	for d := 0; d < dirs; d++ {
+		for f := 0; f < filesPerDir; f++ {
+			file := fmt.Sprintf("pkg%04d/f%03d.go", d, f)
+			typ := fmt.Sprintf("T%04d_%03d", d, f)
+			ents = append(ents, graph.Entity{
+				ID: fmt.Sprintf("%016x", len(ents)), Name: typ,
+				Kind: "SCOPE.Component", SourceFile: file, Language: "go",
+			})
+			for m := 0; m < methodsPerType; m++ {
+				ents = append(ents, graph.Entity{
+					ID: fmt.Sprintf("%016x", len(ents)), Name: fmt.Sprintf("%s.M%02d", typ, m),
+					Kind: "SCOPE.Operation", SourceFile: file, Language: "go",
+				})
+			}
+		}
+	}
+	return ents
+}
+
+// countEntries returns the number of leaf map entries the index retains.
+func (idx *memberIndexes) countEntries() int {
+	if idx == nil {
+		return 0
+	}
+	n := len(idx.callerLoc)
+	for _, pkg := range idx.byPackageMember {
+		for _, scope := range pkg {
+			n += len(scope)
+		}
+	}
+	for _, b := range idx.leafByFile {
+		n += len(b)
+	}
+	for _, b := range idx.leafByPkg {
+		n += len(b)
+	}
+	return n
+}
+
+// TestMemberIndexes_RetainedSizeIsDeltaBounded is the guard that keeps the
+// corpus-sized index out. A one-package edit against a 200-package corpus must
+// retain entries for that ONE package, and the count must not grow when the
+// corpus around it grows.
+//
+// This is asserted structurally rather than in bytes so it cannot go flaky:
+// deleting the probeDirs gate makes the retained count scale with the corpus
+// and both assertions below fail immediately.
+func TestMemberIndexes_RetainedSizeIsDeltaBounded(t *testing.T) {
+	const filesPerDir, methods = 20, 5
+	// The delta: one file's worth of freshly extracted entities, in pkg0000.
+	fresh := memFixture(1, 1, methods)
+
+	small := buildMemberIndexes(fresh, memFixture(50, filesPerDir, methods))
+	large := buildMemberIndexes(fresh, memFixture(200, filesPerDir, methods))
+	if small == nil || large == nil {
+		t.Fatal("index was not built")
+	}
+
+	nSmall, nLarge := small.countEntries(), large.countEntries()
+	if nSmall != nLarge {
+		t.Errorf("retained entry count moved with corpus size (%d entries against 50 packages, "+
+			"%d against 200) — the index is corpus-scoped, which is exactly the peak the scoped "+
+			"path exists to avoid (#5954)", nSmall, nLarge)
+	}
+	if got, want := len(large.byPackageMember), 1; got != want {
+		t.Errorf("byPackageMember spans %d package directories, want %d (only the changed file's)",
+			got, want)
+	}
+
+	// Positive form: the index is not merely small, it is POPULATED — a
+	// trivially empty index would satisfy the equality above. The one probed
+	// package declares filesPerDir types × methods members, all of which must
+	// be reachable by (scope, member).
+	got := 0
+	for _, scope := range large.byPackageMember["pkg0000"] {
+		got += len(scope)
+	}
+	if want := filesPerDir * methods; got != want {
+		t.Fatalf("index is inert: byPackageMember[pkg0000] holds %d (scope, member) entries, want %d",
+			got, want)
+	}
+}
+
+// TestMemberIndexes_HeapCost reports the heap the index actually retains, on
+// both metrics that matter here. Peak live heap (next_gc/(1+GOGC/100)) and
+// HeapAlloc have disagreed by ~2x on this codebase, so both are reported and
+// neither is inferred from RSS. This is a MEASUREMENT — it fails only on an
+// order-of-magnitude regression, because a tight byte threshold here would be
+// a flaky gate, not a guard.
+func TestMemberIndexes_HeapCost(t *testing.T) {
+	const dirs, filesPerDir, methods = 200, 20, 5
+	corpus := memFixture(dirs, filesPerDir, methods)
+	fresh := memFixture(1, 1, methods)
+
+	// Two GC cycles: one pass can leave the previous round's garbage unswept,
+	// which shows up as a NEGATIVE delta and makes the measurement
+	// meaningless. Read GOGC ONCE, outside the measurement: debug.SetGCPercent itself runs
+	// a collection, so calling it between ReadMemStats calls perturbs exactly
+	// the number being measured.
+	gogc := debug.SetGCPercent(-1)
+	debug.SetGCPercent(gogc)
+	if gogc <= 0 {
+		gogc = 100
+	}
+	read := func() (heapAlloc, liveHeap uint64) {
+		var ms runtime.MemStats
+		runtime.GC()
+		runtime.GC()
+		runtime.ReadMemStats(&ms)
+		return ms.HeapAlloc, ms.NextGC / uint64(1+gogc/100)
+	}
+
+	t.Logf("corpus=%d entities across %d packages (%d files/pkg, %d methods/type)",
+		len(corpus), dirs, filesPerDir, methods)
+
+	// A/B: the shipped delta-scoped build versus what the corpus-wide
+	// resolver's tier costs — obtained by handing the WHOLE corpus in as the
+	// delta, which makes probeDirs span every package.
+	//
+	// Both indexes are built and held ALIVE across all three reads and are
+	// only released after the last one. Measuring them one at a time makes
+	// the second reading include the first index becoming garbage, which is
+	// how this first produced a nonsensical NEGATIVE cost for the larger
+	// index.
+	baseAlloc, baseLive := read()
+	deltaIdx := buildMemberIndexes(fresh, corpus)
+	midAlloc, midLive := read()
+	corpusIdx := buildMemberIndexes(corpus, corpus)
+	endAlloc, endLive := read()
+	// KeepAlive(corpus) is LOAD-BEARING, not defensive. `corpus` has no
+	// syntactic use after the call above, so the compiler lets the GC reclaim
+	// its 24000 Entity structs during the final read — the index retains only
+	// the STRINGS, not the structs. Without this the measurement reported the
+	// larger index as costing -1.17 MB: a fixture-shaped artifact, not a
+	// result. Recorded because it is the same class of mistake as a mutation
+	// that turns out to be a no-op.
+	runtime.KeepAlive(corpus)
+	runtime.KeepAlive(fresh)
+
+	deltaEntries, corpusEntries := deltaIdx.countEntries(), corpusIdx.countEntries()
+	deltaAlloc := int64(midAlloc) - int64(baseAlloc)
+	deltaLive := int64(midLive) - int64(baseLive)
+	corpusAlloc := int64(endAlloc) - int64(midAlloc)
+	corpusLive := int64(endLive) - int64(midLive)
+	runtime.KeepAlive(deltaIdx)
+	runtime.KeepAlive(corpusIdx)
+
+	t.Logf("%-14s entries=%-7d HeapAlloc=%10d B   live-heap (next_gc/(1+GOGC/100))=%10d B",
+		"delta-scoped", deltaEntries, deltaAlloc, deltaLive)
+	t.Logf("%-14s entries=%-7d HeapAlloc=%10d B   live-heap (next_gc/(1+GOGC/100))=%10d B",
+		"corpus-scoped", corpusEntries, corpusAlloc, corpusLive)
+
+	if corpusEntries <= deltaEntries*10 {
+		t.Fatalf("measurement is inert: the corpus-scoped variant retains %d entries and the "+
+			"delta-scoped one %d — the A/B is not exercising the probeDirs gate",
+			corpusEntries, deltaEntries)
+	}
+	t.Logf("ratio: corpus-scoped retains %.0fx the entries and %.0fx the HeapAlloc",
+		float64(corpusEntries)/float64(deltaEntries),
+		float64(corpusAlloc)/float64(max64(deltaAlloc, 1)))
+
+	// Order-of-magnitude guard only — a tight byte threshold here would be a
+	// flaky gate, not a guard.
+	if deltaEntries > 4000 {
+		t.Errorf("index retains %d entries for a one-file delta — corpus-scoped behaviour",
+			deltaEntries)
+	}
+	if deltaAlloc > 4<<20 {
+		t.Errorf("index cost %d B of HeapAlloc for a one-file delta, want < 4 MiB", deltaAlloc)
+	}
+}
+
+func max64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/extractors/sresolver/scoped.go
+++ b/internal/extractors/sresolver/scoped.go
@@ -46,6 +46,14 @@
 // falling through hands the stub to the unsound tier. That is enforced by
 // TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough, which a
 // mutation-test showed the obvious ("", false) contract does not satisfy.
+//
+// That guard is a DELIBERATE ASYMMETRY with refs.go, not parity with it: on
+// ambiguity refs.go falls through and its global name index binds. Rationale
+// and the residual divergence are documented on lookupReceiver. Two further
+// gaps are named there and on lookupLeaf rather than closed: the
+// byPackageOperation rung of lookupBareWithLocality is not ported, and refs.go
+// enters that ladder on statusAmbiguous as well as on an outright miss —
+// unreachable from here while nameToID binds ambiguous names arbitrarily.
 package sresolver
 
 import (

--- a/internal/extractors/sresolver/scoped.go
+++ b/internal/extractors/sresolver/scoped.go
@@ -29,6 +29,23 @@
 // (toID → []Relationship) over the existing relationships and re-resolves
 // inbound CALLS/REFERENCES edges for those IDs in the scoped pass, avoiding
 // the safety-net full-reindex fallback for pure signature changes.
+//
+// # Ladder parity with the corpus-wide resolver (#6098)
+//
+// This resolver's binding ladder must not be weaker than
+// internal/resolve/refs.go's, or the incremental graph diverges from a full
+// rebuild — and because the incremental path is the DEFAULT for a watched
+// repo, the divergence accumulates. See pkgmember.go for the member tiers
+// ported to close that gap, the memory bound that makes the port viable on
+// this path, and the ambiguity contract that keeps it sound.
+//
+// The scoped ladder is NOT a strict subset of the corpus-wide one: its
+// whole-string tier is last-writer-wins with no ambiguity sentinel, so it is
+// unsound where the full resolver is not. Any tier added here must therefore
+// carry its own ambiguity guard AND terminate the ladder when it fires —
+// falling through hands the stub to the unsound tier. That is enforced by
+// TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough, which a
+// mutation-test showed the obvious ("", false) contract does not satisfy.
 package sresolver
 
 import (
@@ -238,12 +255,24 @@ func ResolveScoped(
 		addLocation(e)
 	}
 
+	// Receiver-type / package-member tier (#6098). Built only over the package
+	// directories this pass will actually probe — see packageMemberIndex for
+	// the memory rationale. nil when no edge carries a receiver_type stamp on
+	// an unresolved ToID, which is the common case.
+	memberIdx := buildMemberIndexes(newEntities, existingEntities)
+
 	// resolveStub maps a non-hex relationship endpoint to a canonical entity ID,
 	// returning ok=false when it cannot be bound (the stub is then left verbatim,
 	// exactly as the full resolver leaves an unresolved structural ref). The ladder
 	// mirrors internal/resolve/refs.go:lookupStructural for Format A stubs:
 	//   1. whole-string name / qualified-name match (handles bare-name stubs);
 	//   2. Format A (file, tail): same-file byLocation, then unique bare-name.
+	//
+	// The receiver-type tier is NOT part of this ladder — it is probed by
+	// resolveToID BEFORE this function, mirroring internal/resolve/refs.go
+	// where the package-scoped member index is consulted first so a bare-name
+	// target binds locally instead of colliding with a same-named symbol
+	// elsewhere.
 	resolveStub := func(stub string) (string, bool) {
 		if id, ok := nameToID[stub]; ok && id != "" {
 			return id, true
@@ -262,6 +291,38 @@ func ResolveScoped(
 		}
 		if id, ok := nameToID[tail]; ok && id != "" {
 			return id, true
+		}
+		return "", false
+	}
+
+	// resolveToID is the ToID-side ladder. It probes the receiver-type /
+	// package-member tier first (#6098, porting internal/resolve/refs.go:5684,
+	// refs #148/#364) and then falls back to the shared resolveStub ladder.
+	//
+	// callerEndpoint MUST be the edge's RAW, pre-resolution FromID: that is the
+	// key buildPackageMemberIndex indexed the caller's package directory under.
+	// The tier order below mirrors internal/resolve/refs.go, which is the
+	// point of the whole change: a stub the corpus-wide resolver binds, the
+	// scoped resolver must bind, to the SAME entity.
+	//
+	//	1. receiver-stamped package member   (refs.go:5684, #148/#364)
+	//	2. the pre-existing scoped ladder    (≈ refs.go rewriteOneWithCaller's
+	//	   whole-string / Format A tiers        global name index)
+	//	3. same-file then same-package leaf  (refs.go:2963/2969, #778)
+	//
+	// `handled` with an empty id is the AMBIGUITY verdict: the tier owns this
+	// stub and refuses to guess. It must NOT fall through — the next tier down
+	// is last-writer-wins and would bind whatever entity happened to be named
+	// after the member.
+	resolveToID := func(r *graph.Relationship, callerEndpoint string) (string, bool) {
+		if id, handled := memberIdx.lookupReceiver(r, callerEndpoint); handled {
+			return id, id != ""
+		}
+		if id, ok := resolveStub(r.ToID); ok {
+			return id, true
+		}
+		if id, handled := memberIdx.lookupLeaf(r, callerEndpoint); handled {
+			return id, id != ""
 		}
 		return "", false
 	}
@@ -293,6 +354,11 @@ func ResolveScoped(
 	resolvedNewRels := make([]graph.Relationship, 0, len(newRels))
 	for _, r := range newRels {
 		changed := false
+		// The from-side MUST be rewritten before the to-side: the member
+		// tiers key the caller's location on an entity ID, and the Go
+		// extractor emits the from-side as a Format A structural stub
+		// (`scope:operation:method:go:r07.go:Local07`). Probing with the raw
+		// FromID finds no caller and every tier silently misses.
 		if !isHexID(r.FromID) {
 			if resolved, ok := resolveStub(r.FromID); ok {
 				r.FromID = resolved
@@ -300,7 +366,7 @@ func ResolveScoped(
 			}
 		}
 		if !isHexID(r.ToID) {
-			if resolved, ok := resolveStub(r.ToID); ok {
+			if resolved, ok := resolveToID(&r, r.FromID); ok {
 				r.ToID = resolved
 				changed = true
 			}
@@ -322,7 +388,7 @@ func ResolveScoped(
 	var mutatedExistingRels []graph.Relationship
 	for _, r := range existingRels {
 		if !isHexID(r.ToID) {
-			if resolved, ok := resolveStub(r.ToID); ok {
+			if resolved, ok := resolveToID(&r, r.FromID); ok {
 				// Bind the inbound stub to the (possibly re-keyed) entity ID via
 				// the same Format A ladder the full resolver uses, so a cross-file
 				// edge from a surviving file is never left in stub form when a

--- a/internal/extractors/sresolver/scoped_member_6098_test.go
+++ b/internal/extractors/sresolver/scoped_member_6098_test.go
@@ -1,0 +1,383 @@
+package sresolver_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/sresolver"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Receiver-type / package-member tier (#6098, #6090 residual)
+//
+// The scoped resolver's ladder used to stop at whole-string name /
+// qualified-name plus the Format A (file, tail) tiers. The corpus-wide
+// resolver has one more: when a CALLS edge carries
+// Properties["receiver_type"], it probes a PACKAGE-scoped member index —
+// byPackageMember[pkgDirOf(callerFile)][receiverType][member] — so a bare
+// stub `Do11` out of svc/a.go binds to the entity `T11.Do11` declared in the
+// SIBLING file svc/b.go (internal/resolve/refs.go:5684, refs #148/#364).
+//
+// byLocation cannot do this: it is keyed on the exact source file, so a
+// same-package/different-file member is invisible to it, and the bare name
+// `Do11` is not a key in nameToID (the entity is named `T11.Do11`).
+//
+// These are unit tests on ResolveScoped's observable output — no source
+// scanning.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const (
+	mtCaller = "1111111111111111" // svc/a.go — the calling method
+	mtDoB    = "2222222222222222" // svc/b.go — T11.Do11
+	mtDoC    = "3333333333333333" // svc/c.go — a second T11.Do11 (ambiguity)
+	mtDoOth  = "4444444444444444" // other/b.go — T11.Do11 in a DIFFERENT package
+)
+
+func mtEnt(id, name, sourceFile string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		SourceFile: sourceFile,
+		Language:   "go",
+	}
+}
+
+// mtCallRel builds a CALLS edge with a bare-name stub ToID, optionally
+// stamped with a receiver_type property (empty string = unstamped).
+func mtCallRel(fromID, stub, recvType string) graph.Relationship {
+	r := graph.Relationship{
+		ID:     graph.RelationshipID(fromID, stub, "CALLS"),
+		FromID: fromID,
+		ToID:   stub,
+		Kind:   "CALLS",
+	}
+	if recvType != "" {
+		r = r.WithProperties(map[string]string{"receiver_type": recvType})
+	}
+	return r
+}
+
+// mtOnlyCall returns the single CALLS edge out of fromID in rels.
+func mtOnlyCall(t *testing.T, rels []graph.Relationship, fromID string) graph.Relationship {
+	t.Helper()
+	var hits []graph.Relationship
+	for _, r := range rels {
+		if r.Kind == "CALLS" && r.FromID == fromID {
+			hits = append(hits, r)
+		}
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected exactly 1 CALLS edge from %s, got %d: %+v", fromID, len(hits), hits)
+	}
+	return hits[0]
+}
+
+// TestResolveScoped_ReceiverTypeTier_SamePackageSiblingFile is the core
+// #6090-residual case: a call the edit ITSELF introduces, so there is no
+// prior binding for replayPriorResolution to replay. Only a resolver tier can
+// bind it.
+func TestResolveScoped_ReceiverTypeTier_SamePackageSiblingFile(t *testing.T) {
+	// Sibling file in the same package, present in the SURVIVING set.
+	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	// The caller is freshly extracted out of the edited file.
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	if res.FallbackRequired {
+		t.Fatalf("unexpected fallback: %s", res.UnresolvedTarget)
+	}
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != mtDoB {
+		t.Errorf("bare stub %q with receiver_type=T11 from svc/a.go should bind to T11.Do11 in the "+
+			"sibling file svc/b.go (%s); got ToID=%q (#6098 / #6090 residual)", "Do11", mtDoB, got.ToID)
+	}
+	if got.ID != graph.RelationshipID(got.FromID, got.ToID, got.Kind) {
+		t.Errorf("rebound edge did not have its RelationshipID recomputed: ID=%q", got.ID)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_QualifiedStampStripped covers the #364
+// follow-up: the extractor may stamp a package-qualified receiver
+// (`chi.Mux`), while entities are emitted under the bare receiver name.
+func TestResolveScoped_ReceiverTypeTier_QualifiedStampStripped(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "pkg.T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != mtDoB {
+		t.Errorf("package-qualified receiver stamp %q should be retried bare (#364); got ToID=%q",
+			"pkg.T11", got.ToID)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_AmbiguousStaysUnresolved is the
+// SOUNDNESS guard. Two entities named T11.Do11 live in the same package
+// directory (different files). The corpus-wide resolver calls this ambiguous
+// and leaves the stub verbatim; the scoped resolver must do the same rather
+// than silently picking one.
+//
+// Deleting the blank-sentinel ambiguity guard makes this test bind to
+// whichever candidate was indexed last — a confident WRONG edge, which is
+// strictly worse than the unresolved stub it replaces.
+func TestResolveScoped_ReceiverTypeTier_AmbiguousStaysUnresolved(t *testing.T) {
+	existing := []graph.Entity{
+		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
+		mtEnt(mtDoC, "T11.Do11", "svc/c.go"),
+	}
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != "Do11" {
+		t.Errorf("two candidates for (svc, T11, Do11) must leave the stub UNRESOLVED, matching the "+
+			"corpus-wide resolver; got a confident binding ToID=%q (candidates were %s and %s)",
+			got.ToID, mtDoB, mtDoC)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough is the
+// SECOND half of the soundness guard, and the one the previous test cannot
+// see. Returning false on ambiguity and *continuing down the ladder* is
+// observationally identical to refusing, UNLESS a later tier can bind the
+// name — and the very next tier is the last-writer-wins whole-string tier,
+// which has no ambiguity sentinel at all.
+//
+// So: (svc, T11, Do11) is ambiguous AND a foreign-package free function is
+// literally named `Do11`. Falling through converts a correctly-ambiguous stub
+// into a confident cross-package edge. That mutation survives the previous
+// test and is killed only by this one.
+func TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough(t *testing.T) {
+	existing := []graph.Entity{
+		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
+		mtEnt(mtDoC, "T11.Do11", "svc/c.go"),
+		mtEnt(mtDoOth, "Do11", "other/free.go"), // whole-string tier WOULD hit this
+	}
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID == mtDoOth {
+		t.Errorf("ambiguity fell through to the unsound whole-string tier and bound the "+
+			"foreign-package %q; ambiguity must terminate the ToID ladder", mtDoOth)
+	}
+	if got.ToID != "Do11" {
+		t.Errorf("ambiguous (svc, T11, Do11) must stay unresolved; got ToID=%q", got.ToID)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_DoesNotCrossPackages guards the other
+// direction: the tier is package-SCOPED. A same-named member in a different
+// directory must not be bound, or the scoped path would invent cross-package
+// edges the full rebuild does not have.
+func TestResolveScoped_ReceiverTypeTier_DoesNotCrossPackages(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoOth, "T11.Do11", "other/b.go")}
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != "Do11" {
+		t.Errorf("T11.Do11 in package %q must not bind a caller in package %q; got ToID=%q",
+			"other", "svc", got.ToID)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Leaf-name tiers (#778) — the ones that bind REAL Go source
+//
+// The receiver-stamped tier above is the precise one, but it only fires when
+// the callee is invoked on the enclosing method's OWN receiver. The
+// #6090-residual shape is `a.Do11(x)` on a local variable inside a free
+// function, which carries no stamp. The corpus-wide resolver binds that with
+// lookupMemberByLeafName / lookupPackageMemberByLeafName
+// (internal/resolve/refs.go:2963 and :2969, probed from
+// rewriteOneWithCaller): a bare CALLS name matching exactly ONE member across
+// the caller's file, then across the caller's package.
+//
+// Grounding note recorded because it contradicts #6098's own write-up: that
+// issue attributes the gap to the receiver-type tier alone. Measured
+// end-to-end, the tier that binds `a.Do11(x)` is the #778 leaf tier. Porting
+// only the receiver tier leaves the residual open.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestResolveScoped_LeafTier_SamePackageUnstamped is the #6090-residual shape.
+func TestResolveScoped_LeafTier_SamePackageUnstamped(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != mtDoB {
+		t.Errorf("unstamped bare CALLS %q should bind to the unique same-package member T11.Do11 "+
+			"(%s) via the #778 leaf tier; got ToID=%q", "Do11", mtDoB, got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_AmbiguousStaysUnresolved is the leaf tier's own
+// soundness guard. Note this is a DIFFERENT ambiguity from the receiver
+// tier's: there the scope is pinned and the collision is inside it; here two
+// distinct scopes each declare a member by that name and there is no type
+// information to choose between them.
+func TestResolveScoped_LeafTier_AmbiguousStaysUnresolved(t *testing.T) {
+	existing := []graph.Entity{
+		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
+		mtEnt(mtDoC, "T23.Do11", "svc/c.go"), // different scope, same member
+	}
+	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != "Do11" {
+		t.Errorf("two scopes in package svc declare member Do11 — the stub must stay unresolved; "+
+			"got a confident binding ToID=%q", got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_IsCallsOnly: the leaf tiers key on a bare member
+// name with NO scope information, so they are gated to CALLS, matching
+// refs.go's `case "CALLS":`. A DEPENDS_ON naming a type must not catch a
+// same-named method.
+func TestResolveScoped_LeafTier_IsCallsOnly(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+	dep := graph.Relationship{
+		ID:     graph.RelationshipID(mtCaller, "Do11", "DEPENDS_ON"),
+		FromID: mtCaller,
+		ToID:   "Do11",
+		Kind:   "DEPENDS_ON",
+	}
+
+	res := sresolver.ResolveScoped(fresh, existing, []graph.Relationship{dep}, nil, nil)
+	if len(res.ResolvedNewRelationships) != 1 {
+		t.Fatalf("expected 1 rel, got %d", len(res.ResolvedNewRelationships))
+	}
+	if got := res.ResolvedNewRelationships[0]; got.ToID != "Do11" {
+		t.Errorf("the leaf tier is CALLS-only; a DEPENDS_ON must not bind to the method T11.Do11; "+
+			"got ToID=%q", got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_FollowsWholeStringTier pins the OTHER half of the
+// ordering. Unlike the receiver tier, the leaf tiers are FALLBACKS inside
+// rewriteOneWithCaller — they run only after the global name index misses. So
+// an entity literally NAMED `Do11` must win over a leaf match on `T11.Do11`.
+//
+// Together with TestResolveScoped_ReceiverTypeTier_PrecedesWholeStringTier
+// this brackets the whole-string tier from both sides; reversing either
+// direction changes which entity a real call binds to.
+func TestResolveScoped_LeafTier_FollowsWholeStringTier(t *testing.T) {
+	const exactName = "5555555555555555"
+	existing := []graph.Entity{
+		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
+		mtEnt(exactName, "Do11", "svc/free.go"), // exact-name free function
+	}
+	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != exactName {
+		t.Errorf("an entity literally named %q must win over the #778 leaf tier's member match; "+
+			"got ToID=%q (want %s)", "Do11", got.ToID, exactName)
+	}
+}
+
+// TestResolveScoped_LeafTier_SameFileBeatsSamePackage pins tier 2 ahead of
+// tier 3 (refs.go probes lookupMemberByLeafName before
+// lookupPackageMemberByLeafName). Two scopes declare `Do11`, one of them in
+// the caller's own file — which makes the package-wide view ambiguous and the
+// same-file view decisive.
+func TestResolveScoped_LeafTier_SameFileBeatsSamePackage(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	fresh := []graph.Entity{
+		mtEnt(mtCaller, "Local07", "svc/a.go"),
+		mtEnt(mtDoC, "T23.Do11", "svc/a.go"), // same file as the caller
+	}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != mtDoC {
+		t.Errorf("the same-file member T23.Do11 (%s) must win over the same-package T11.Do11 (%s); "+
+			"got ToID=%q", mtDoC, mtDoB, got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_DoesNotCrossPackages: the leaf tier is
+// package-scoped, and a same-named member in another directory must not be
+// bound.
+func TestResolveScoped_LeafTier_DoesNotCrossPackages(t *testing.T) {
+	existing := []graph.Entity{mtEnt(mtDoOth, "T11.Do11", "other/b.go")}
+	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID != "Do11" {
+		t.Errorf("T11.Do11 in package %q must not bind a caller in package %q; got ToID=%q",
+			"other", "svc", got.ToID)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_AppliesToSurvivingInboundEdges: the
+// corpus-wide resolver applies this tier to EVERY edge it walks, not only to
+// the ones out of changed files. A surviving edge left in stub form by an
+// earlier build must be bindable too, or the incremental graph keeps a stub
+// the full rebuild resolves.
+func TestResolveScoped_ReceiverTypeTier_AppliesToSurvivingInboundEdges(t *testing.T) {
+	// The caller survives; the callee is what was just re-extracted.
+	existing := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	fresh := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+	existingRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, nil, existingRels, nil)
+	if res.FallbackRequired {
+		t.Fatalf("unexpected fallback: %s", res.UnresolvedTarget)
+	}
+	got := mtOnlyCall(t, res.UpdatedExistingRelationships, mtCaller)
+	if got.ToID != mtDoB {
+		t.Errorf("surviving stub edge with receiver_type=T11 should bind to the re-extracted "+
+			"T11.Do11 (%s); got ToID=%q", mtDoB, got.ToID)
+	}
+	if res.InboundFixed != 1 {
+		t.Errorf("expected InboundFixed=1, got %d", res.InboundFixed)
+	}
+}
+
+// TestResolveScoped_ReceiverTypeTier_PrecedesWholeStringTier pins the tier
+// ORDER. The scoped ladder's whole-string tier is last-writer-wins with no
+// ambiguity sentinel, so it is unsound where the corpus-wide resolver is not.
+// The receiver tier must be probed FIRST, exactly as
+// internal/resolve/refs.go does ("probe the package-scoped member index FIRST
+// so a bare-name target like `handle` binds to the local `<pkg>/Mux.handle`
+// rather than colliding with same-named methods elsewhere").
+//
+// Here a FOREIGN-package entity is literally NAMED `Do11`, so nameToID["Do11"]
+// hits. If the whole-string tier ran first the edge would bind cross-package;
+// with the receiver tier first it binds to the local T11.Do11.
+func TestResolveScoped_ReceiverTypeTier_PrecedesWholeStringTier(t *testing.T) {
+	existing := []graph.Entity{
+		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
+		mtEnt(mtDoOth, "Do11", "other/free.go"), // free function, foreign package
+	}
+	fresh := []graph.Entity{mtEnt(mtCaller, "T11.Use", "svc/a.go")}
+	newRels := []graph.Relationship{mtCallRel(mtCaller, "Do11", "T11")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, mtCaller)
+	if got.ToID == mtDoOth {
+		t.Errorf("receiver tier must precede the whole-string tier: bound to the foreign-package "+
+			"free function %q instead of the same-package T11.Do11", mtDoOth)
+	}
+	if got.ToID != mtDoB {
+		t.Errorf("expected ToID=%s (svc/b.go T11.Do11), got %q", mtDoB, got.ToID)
+	}
+}

--- a/internal/extractors/sresolver/scoped_member_6098_test.go
+++ b/internal/extractors/sresolver/scoped_member_6098_test.go
@@ -151,6 +151,20 @@ func TestResolveScoped_ReceiverTypeTier_AmbiguousStaysUnresolved(t *testing.T) {
 // literally named `Do11`. Falling through converts a correctly-ambiguous stub
 // into a confident cross-package edge. That mutation survives the previous
 // test and is killed only by this one.
+//
+// THIS ASSERTS A DELIBERATE ASYMMETRY WITH refs.go, NOT PARITY WITH IT.
+// On exactly this shape the corpus-wide resolver BINDS the edge: refs.go:5697
+// `break`s with resolved=false on ambiguity and control reaches
+// rewriteOneWithCaller's global name index, despite an inline comment there
+// claiming it "preserves the stub". So a full rebuild resolves this and the
+// scoped path leaves a stub — a divergence in the #6090 loss direction, which
+// will become a live failure if a fixture ever reaches this shape.
+//
+// We keep the refusal anyway, because refs.go's fall-through is safe only for
+// refs.go: its global tier carries an ambiguity sentinel and the scoped
+// ladder's nameToID does not, so falling through here binds arbitrarily
+// rather than bind-or-refuse. Closing the divergence means fixing the refs.go
+// side; that is filed separately. Do not "restore parity" by deleting this.
 func TestResolveScoped_ReceiverTypeTier_AmbiguityDoesNotFallThrough(t *testing.T) {
 	existing := []graph.Entity{
 		mtEnt(mtDoB, "T11.Do11", "svc/b.go"),
@@ -245,23 +259,47 @@ func TestResolveScoped_LeafTier_AmbiguousStaysUnresolved(t *testing.T) {
 // name with NO scope information, so they are gated to CALLS, matching
 // refs.go's `case "CALLS":`. A DEPENDS_ON naming a type must not catch a
 // same-named method.
+//
+// The stamped sub-case is the one that actually exercises lookupLeaf's inner
+// CALLS gate. Without it the gate is DEAD CODE for testing purposes:
+// relWantsMemberTier already rejects an unstamped non-CALLS edge, so deleting
+// the inner gate leaves the unstamped case passing. The stamp gets the edge
+// past relWantsMemberTier, and a receiver type with no matching scope gets it
+// past tier 1, so the inner gate is the only thing standing between a
+// DEPENDS_ON and a method binding.
 func TestResolveScoped_LeafTier_IsCallsOnly(t *testing.T) {
-	existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
-	fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
-	dep := graph.Relationship{
-		ID:     graph.RelationshipID(mtCaller, "Do11", "DEPENDS_ON"),
-		FromID: mtCaller,
-		ToID:   "Do11",
-		Kind:   "DEPENDS_ON",
-	}
+	for _, tc := range []struct {
+		name     string
+		recvType string
+	}{
+		// Rejected early, by relWantsMemberTier.
+		{"unstamped", ""},
+		// Reaches lookupLeaf and is stopped only by its inner CALLS gate. The
+		// receiver type names no scope in the package, so tier 1 misses.
+		{"stamped_with_unknown_receiver", "Tzz"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			existing := []graph.Entity{mtEnt(mtDoB, "T11.Do11", "svc/b.go")}
+			fresh := []graph.Entity{mtEnt(mtCaller, "Local07", "svc/a.go")}
+			dep := graph.Relationship{
+				ID:     graph.RelationshipID(mtCaller, "Do11", "DEPENDS_ON"),
+				FromID: mtCaller,
+				ToID:   "Do11",
+				Kind:   "DEPENDS_ON",
+			}
+			if tc.recvType != "" {
+				dep = dep.WithProperties(map[string]string{"receiver_type": tc.recvType})
+			}
 
-	res := sresolver.ResolveScoped(fresh, existing, []graph.Relationship{dep}, nil, nil)
-	if len(res.ResolvedNewRelationships) != 1 {
-		t.Fatalf("expected 1 rel, got %d", len(res.ResolvedNewRelationships))
-	}
-	if got := res.ResolvedNewRelationships[0]; got.ToID != "Do11" {
-		t.Errorf("the leaf tier is CALLS-only; a DEPENDS_ON must not bind to the method T11.Do11; "+
-			"got ToID=%q", got.ToID)
+			res := sresolver.ResolveScoped(fresh, existing, []graph.Relationship{dep}, nil, nil)
+			if len(res.ResolvedNewRelationships) != 1 {
+				t.Fatalf("expected 1 rel, got %d", len(res.ResolvedNewRelationships))
+			}
+			if got := res.ResolvedNewRelationships[0]; got.ToID != "Do11" {
+				t.Errorf("the leaf tier is CALLS-only; a DEPENDS_ON must not bind to the method "+
+					"T11.Do11 (%s); got ToID=%q", mtDoB, got.ToID)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
The incremental/daemon path resolves symbol references with `sresolver.ResolveScoped`, whose ladder lacked tiers the corpus-wide resolver has. Three separately-filed issues converged on that one gap: #6098 (unresolved `receiver_type` stubs → no `SCOPE.Process` → under-counted `DEPENDS_ON` weight), the #6090 residual (a call the edit *itself* introduces stays a permanent stub), and #6119.

This ports the **receiver-type** tier (#148/#364) and the two **#778 leaf-name** tiers, with a delta-scoped index.

## The soundness bug found by writing the counter-test

The brief required an ambiguity counter-test. It **failed on unmutated code**.

Returning `("", false)` on ambiguity is observationally identical to "not handled", so the ladder fell through to the next tier — the whole-string tier, which is **last-writer-wins with no ambiguity sentinel**. With a foreign-package entity named `Do11` present, an ambiguous case became a **confident cross-package bind**.

Fixed with a three-outcome contract: `("", true)` means handled-but-refused and terminates the ladder. Tier order is pinned from both sides — receiver tier before the whole-string tier, leaf tiers after it.

## This is a deliberate asymmetry with `refs.go`, not parity — and `refs.go` has the same bug

`refs.go:5681-5697` does the same thing on ambiguity:

```go
// Ambiguous within (pkg, recv, member) — fall through
// to record as unmatched (preserve the stub).
break
```

`resolved` stays `false`, so control reaches the Go component tier and then `rewriteOneWithCaller` → the global name index, **which binds**. The inline comment is wrong about its own code — the identical misconception fixed here on the scoped side.

So on ambiguous `(svc, T11, Do11)` plus a single global `Do11` elsewhere, a **full rebuild binds and this resolver leaves a stub** — the #6090 loss direction.

The scoped behaviour is the safer one and is kept, but it is now **labelled an asymmetry in three places** (the `lookupReceiver` doc, the counter-test, the package doc), each stating the residual and warning against "restoring parity" by deleting the guard. The rationale: `refs.go`'s fall-through is safe only for `refs.go`, whose global tier *has* an ambiguity sentinel. Scoped `nameToID` does not, so falling through binds **arbitrarily** rather than bind-or-refuse.

The `refs.go` side is filed as **#6125**.

## A claim in this PR was wrong, and the correction is recorded

An earlier revision reported that #6098's stated root cause (the receiver tier) was insufficient, and that the #778 leaf tier is what binds `a.Do11(x)`. Tier-by-tier ablation refutes that:

| ablation | result |
|---|---|
| leaf tiers removed, receiver tier only | **passes** |
| receiver tier removed, leaf tiers only | **passes** |
| both removed | **fails 3/3**, 0 resolved cross-file CALLS, want 2 |

The Go extractor does stamp `receiver_type` for `a := &T11{...}; a.Do11(x)`, so tier 1 binds the fixture alone. **#6098's stated root cause was sufficient.** The two tiers are fully redundant end-to-end.

A time-boxed search for a separating shape found a candidate — a chained call `New23().Do23(x)` emits an *unstamped* Format A stub that `relWantsMemberTier` rejects on the `:` — but it is not one: the full rebuild also resolves 0 for that shape, so there is nothing to reach parity with.

Tiers 2–3 are therefore documented as **carried for ladder parity with `refs.go`, not because this fixture needs them**, exercised by unit tests only.

The method note is in the source: *"measured end-to-end" must mean tier-by-tier ablation, not "the whole change makes the test pass."*

## Memory

The full resolver's tier is built over the entire entity set. This one indexes only the package directories of `newEntities` — the changed files.

| variant | entries | `HeapAlloc` | live heap |
|---|---|---|---|
| delta-scoped (shipped) | 325 | 29,944 B | 29,960 B |
| corpus-scoped (A/B) | 65,000 | 5,036,040 B | 5,036,248 B |

**200× entries, 168× bytes.** Re-measured independently; growth is strictly linear in entities-within-probe-dirs, no fan-out multiplier. The two metrics agree to <0.1% here, unlike the 1.96× disagreement recorded elsewhere. No RSS used.

Bound stated precisely: **O(entities in the packages the edit touches)** — `probeDirs` is directory-keyed, so a K-package delta costs K packages regardless of files per package.

**A measurement trap worth recording:** the first two harness attempts produced a deterministic **−1.17 MB for the larger index**. `corpus` had no syntactic use after its last call, so the compiler let the GC reclaim 24,000 `Entity` structs mid-measurement — the index retains only strings. `runtime.KeepAlive` is load-bearing.

## Correcting a premise this work was briefed on

"The scoped path does not hold the corpus" is **false**. `ResolveScoped` already receives `doc.Entities` — every surviving entity of the repo — and builds `nameToID` and `byLocation` over all of it. The real constraint was index *shape*, not the entity set, which is why delta-scoping is viable.

Precisely: that is **one repository's** entity set. #5954's peak concerns the multi-repo **group** corpus, which this path never materialises.

## Tests

- **`TestIncremental_DependsOnWeightParity_6098` un-skipped** — but it now **passes without any resolver change**. #6121 (merged for #6090) already closed its fixture, because its two CALLS exist in the baseline and therefore have a prior binding to replay. Kept as a weight-parity gate; verified by ablation that it no longer touches this ladder.
- **`TestIncremental_NewlyIntroducedCrossFileCall_6098`** is the real gate — baseline has *no* cross-file calls, so replay has nothing to replay. Its own precondition asserts 0 baseline cross-file edges. RED at all three passes before the change (0/2 resolved, with paired invented `→Do11:CALLS` rows), green after.
- **Two ambiguity counter-tests**, one per tier family.

Nine of eleven mutants killed, including `callerLoc` keyed on Name rather than ID (7 failures) and to-side-resolved-before-from-side (killed end-to-end only: 2 LOST + 2 INVENTED per pass; the unit suite stays green).

Two survivors, both **verified genuine no-ops** rather than missing guards: the leaf-tier `("", true)` refusals are unreachable as the last rung (tier-2 ambiguity implies tier-3), and are documented as inert-but-load-bearing-if-a-tier-is-appended. The inner CALLS gate was near-dead — so the case was **constructed rather than the claim dropped**: `..._LeafTier_IsCallsOnly` is now table-driven with a `DEPENDS_ON` carrying `receiver_type="Tzz"`, which reaches the gate; deleting it now fails.

## Also found

`callerLoc` was keyed on entity ID but probed with the **resolved** `FromID`, while the Go extractor emits the from-side as a Format A stub — so every tier silently missed *while looking correct*. Fixed during development; the from-before-to ordering is now pinned end-to-end.

Dead candidates cannot enter the index at all: `incremental.go` step 5 strips changed-file entities from `doc.Entities` before `ResolveScoped`, which is strictly better than `replayPriorResolution`'s documented limitation.

## Not closed, documented

`lookupBareWithLocality` (`refs.go:2909`) has four rungs and is entered on `statusAmbiguous` as well as `statusUnmatched`; only the two leaf rungs are ported, only on outright miss. A globally ambiguous bare name is rescued upstream by `byPackageOperation` in `refs.go`, while scoped `nameToID` binds arbitrarily and never reaches here. Closing it requires an ambiguity sentinel on `nameToID` first, which would change the binding of every existing bare stub.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`:

| package | exit | skips |
|---|---|---|
| `./internal/extractors/...` | 0 | 1 |
| `./internal/resolve/...` | 0 | 6 |
| `./cmd/grafel/` | 0 | 8 |
| `./internal/graph/...` | 0 | **0** |

All skips pre-existing. Note an earlier revision reported `internal/resolve` as 0 skips — that used an anchored `^--- SKIP` which misses subtests; the true count is 6, all `TestElixirDynamic_NotFiredForOtherLanguages/*`.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Closes #6098
Refs #6090, #6119, #6125, #148, #364, #778, #5954
