### PR TITLE
fix(#6105): emit the missing language slot in java structural refs — no ref this package minted could ever bind

### DIFF
--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -1,0 +1,676 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Issue #6105 (refs #5989) — relationship endpoints emitted by the in-process
+// custom extractors (GRAFEL_INPROC_CUSTOM_EXTRACTORS) that resolve to no
+// entity.
+//
+// WHAT THE CORPUS MEASURED. Six edge kinds were 100% dangling under the gate:
+// RETURNS (1,072), OWNS (466), ACCEPTS_INPUT (85), CACHES (18), INVALIDATES (4),
+// DEPENDS_ON_SERVICE (4). Grounded here, they are THREE different defects, not
+// one:
+//
+//  1. RETURNS / ACCEPTS_INPUT / OWNS — the target entity EXISTS and the ref is
+//     malformed. Every structural ref minted in internal/custom/java has the
+//     shape `scope:<kind>:<subtype>:<file>:<name>` (five segments; see
+//     synthesizeCarrier's doc comment, which documents that shape as the
+//     package's convention). The resolver's Format A is
+//     `scope:<kind>:<subtype>:<lang>:<file>:<name>` — SIX segments, split with
+//     stubScopeSegments = 6 at internal/resolve/refs.go:69 and rejected
+//     outright when len(parts) != 6 at refs.go:2037-2039. The language slot was
+//     never emitted. Refs whose NAME contains no colon were rejected on the
+//     count; refs whose name DOES contain colons yielded six parts and did
+//     parse, but with every field shifted one place left (file read as the
+//     language), so they could only miss. Either way nothing bound. That is the
+//     fix in this change; it is applied once, centrally, in
+//     patternResultToRecords.
+//
+//     MEASURED SCOPE OF THE REPAIR ON THIS FIXTURE (fix neutered vs. applied):
+//     13 distinct unresolved `scope:` endpoints before, 4 after. Recovered:
+//     RETURNS (2), ACCEPTS_INPUT (1), OWNS via an `operation` scope-kind (1),
+//     and the six #4367 `bean_validation_field` CONTAINS endpoints — which
+//     #6105 never named and which were also 100% dangling.
+//
+//  2. CACHES / INVALIDATES — the target entity also EXISTS, but the ref is a
+//     colon-bearing NAME (`cache:spring:orders`, `cache:django:orders`,
+//     `Datastore:redis:orders`) and no index reaches it. LookupStatusHint
+//     (refs.go:1629-1646) runs splitStub, which splits on the FIRST colon and
+//     then probes byName with the REMAINDER — `django:orders`, never
+//     `cache:django:orders`. Any convention where an entity Name contains a
+//     colon and an edge addresses it by that Name is structurally unresolvable.
+//     NOT fixed here: see TestCustomExtractorColonNameRefsRemainUnresolved6105.
+//
+//  3. DEPENDS_ON_SERVICE — failure mode 1, and the only one of the three where
+//     the target does not exist. internal/custom/csharp/test_doubles.go:244
+//     points the edge at `service:<Name>` and no pass anywhere creates a
+//     `service:` entity; the only node it emits is `container:<Name>`. Also not
+//     fixed here — inventing the missing node is exactly the placeholder
+//     fabrication this work is not allowed to do.
+//
+// WHY BEHAVIOURAL. A source scan ("every ref literal contains a language
+// segment") is satisfied by any string that happens to contain one, and three
+// source-scanning guards written in this area recently fell to trivial mutants.
+// These tests index a real fixture with the gate off and on, round-trip both
+// arms through graph.LoadGraphFromDir, and assert on the endpoints that land on
+// disk.
+//
+// WHY THE DELTA AND NOT THE ABSOLUTE. grafel deliberately retains `ext:` and
+// `scope:` placeholder endpoints on the base path, so an absolute dangling
+// count is meaningless. Every dangling assertion below is scoped to endpoints
+// the GATE introduces.
+
+// writeDanglingFixture6105 lays down the smallest fixture that exercises each
+// edge kind the corpus measurement reported as 100% dangling under the gate:
+//
+//	RETURNS / ACCEPTS_INPUT — Spring @RestController request/response DTOs
+//	                          (internal/custom/java/spring_request_response.go)
+//	OWNS                    — Spring AOP aspect owning its pointcut and advice
+//	                          (internal/custom/java/spring_aop.go)
+//	CACHES / INVALIDATES    — Spring @Cacheable/@CacheEvict cache regions
+//	                          (internal/custom/java/caching.go) and the Django
+//	                          low-level cache API (internal/custom/python/caching.go)
+//	DEPENDS_ON_SERVICE      — Testcontainers container topology
+//	                          (internal/custom/csharp/test_doubles.go)
+func writeDanglingFixture6105(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"java/OrdersController.java": `package api;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class OrdersController {
+    @GetMapping("/orders")
+    public OrderResponse list() {
+        return null;
+    }
+
+    @PostMapping("/orders")
+    public OrderResponse create(@RequestBody OrderRequest body) {
+        return null;
+    }
+}
+`,
+		"java/AuditAspect.java": `package api;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class AuditAspect {
+    @Pointcut("execution(* api..*(..))")
+    public void anyApiCall() {}
+
+    @Before("anyApiCall()")
+    public void auditBefore() {}
+}
+`,
+		"java/Order.java": `package api;
+
+import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
+
+@Entity
+@NamedQuery(name = "findAllOrders", query = "select o from Order o")
+public class Order {
+    private Long id;
+}
+`,
+		"java/OrderCache.java": `package api;
+
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
+public class OrderCache {
+    @Cacheable("orders")
+    public String load(String id) {
+        return id;
+    }
+
+    @CacheEvict("orders")
+    public void drop(String id) {
+    }
+}
+`,
+		// Three DTOs in ONE package directory, deliberately sharing the field
+		// leaf names `id` and `reference`. This is the collision
+		// lookupPackageMemberByLeafName would exploit if a
+		// `scope:schema:bean_validation_field:` ref ever missed byLocation — see
+		// TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105.
+		"dto/OrderRequest.java": `package dto;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class OrderRequest {
+    @NotNull
+    private String id;
+
+    @Size(max = 64)
+    private String reference;
+
+    @Valid
+    private Address address;
+}
+`,
+		"dto/Customer.java": `package dto;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class Customer {
+    @NotNull
+    private String id;
+
+    @Size(max = 32)
+    private String reference;
+}
+`,
+		"dto/Address.java": `package dto;
+
+import javax.validation.constraints.NotNull;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+public class Address {
+    @NotNull
+    private String id;
+}
+`,
+		"cs/OrderTests.cs": `using Testcontainers.PostgreSql;
+
+namespace Shop.Tests
+{
+    public class OrderTests
+    {
+        public void Setup()
+        {
+            var db = new PostgreSqlContainer();
+        }
+    }
+}
+`,
+		"myapp/cacheviews.py": `
+from django.core.cache import cache
+
+
+def read_order(order_id):
+    return cache.get("orders")
+
+
+def drop_order(order_id):
+    cache.delete("orders")
+`,
+	}
+	for rel, body := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// danglingEndpoint6105 is one unresolved relationship endpoint: the edge kind,
+// which side dangles, and the raw endpoint string left on the edge.
+type danglingEndpoint6105 struct {
+	kind string
+	side string
+	id   string
+}
+
+func (d danglingEndpoint6105) String() string {
+	return fmt.Sprintf("%s %s %s", d.kind, d.side, d.id)
+}
+
+// danglingEndpoints6105 returns every relationship endpoint in doc that names no
+// entity in doc, as a multiset keyed by (kind, side, endpoint).
+//
+// BIDIRECTIONAL BY CONSTRUCTION (#6037): both FromID and ToID are checked, so an
+// edge that is present but points at a name rather than an ID is visible
+// whichever side it is on.
+func danglingEndpoints6105(doc *graph.Document) map[danglingEndpoint6105]int {
+	ids := make(map[string]struct{}, len(doc.Entities))
+	for i := range doc.Entities {
+		ids[doc.Entities[i].ID] = struct{}{}
+	}
+	out := map[danglingEndpoint6105]int{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if _, ok := ids[r.FromID]; !ok {
+			out[danglingEndpoint6105{r.Kind, "FROM", r.FromID}]++
+		}
+		if _, ok := ids[r.ToID]; !ok {
+			out[danglingEndpoint6105{r.Kind, "TO", r.ToID}]++
+		}
+	}
+	return out
+}
+
+// gateArms6105 indexes the fixture with the gate off and on and returns the
+// dangling endpoints the gate ADDS (present, or more frequent, with the gate on)
+// alongside the gate-on graph.
+func gateArms6105(t *testing.T) (added map[danglingEndpoint6105]int, on *graph.Document) {
+	t.Helper()
+	fixture := writeDanglingFixture6105(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
+	offDoc := persistAndReload(t, runIndexerOn(t, fixture, "dangling6105", nil))
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	on = persistAndReload(t, runIndexerOn(t, fixture, "dangling6105", nil))
+
+	off := danglingEndpoints6105(offDoc)
+	all := danglingEndpoints6105(on)
+	added = map[danglingEndpoint6105]int{}
+	for k, n := range all {
+		if d := n - off[k]; d > 0 {
+			added[k] = d
+		}
+	}
+	return added, on
+}
+
+// edgeSet6105 renders every relationship of the given kinds as
+// "KIND: <fromKind>:<fromName> -> <toKind>:<toName>", with an unresolvable
+// endpoint rendered as "DANGLING(<raw endpoint>)".
+//
+// CONTENT, NOT COUNTS. The assertions below name the exact entities each edge
+// must join, so an edge that resolves to the WRONG node fails just as loudly as
+// one that resolves to nothing — the failure mode a count-based or
+// "dangling == 0" check is blind to.
+func edgeSet6105(doc *graph.Document, kinds ...string) map[string]int {
+	want := map[string]bool{}
+	for _, k := range kinds {
+		want[k] = true
+	}
+	byID := make(map[string]string, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		byID[e.ID] = e.Kind + ":" + e.Name
+	}
+	show := func(id string) string {
+		if s, ok := byID[id]; ok {
+			return s
+		}
+		return "DANGLING(" + id + ")"
+	}
+	out := map[string]int{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if !want[r.Kind] {
+			continue
+		}
+		out[fmt.Sprintf("%s: %s -> %s", r.Kind, show(r.FromID), show(r.ToID))]++
+	}
+	return out
+}
+
+// TestCustomExtractorJavaStructuralRefEdgesBindToRealEntities6105 is the
+// headline gate for defect (1). Each Java custom-extractor edge whose kind the
+// corpus reported as 100% dangling must join the two entities it names.
+//
+// The DTO / pointcut / advice targets are all emitted by the same extractor run
+// that emits the edge, in the same file — so this is purely a question of
+// whether the ref the edge carries is addressable, and nothing here depends on
+// another pass materialising a node.
+func TestCustomExtractorJavaStructuralRefEdgesBindToRealEntities6105(t *testing.T) {
+	_, on := gateArms6105(t)
+	got := edgeSet6105(on, "RETURNS", "ACCEPTS_INPUT", "OWNS", "CONTAINS")
+
+	want := []string{
+		// Spring request/response DTOs (spring_request_response.go:130,150).
+		"ACCEPTS_INPUT: SCOPE.Operation:OrdersController.create -> SCOPE.Schema:OrderRequest",
+		"RETURNS: SCOPE.Operation:OrdersController.create -> SCOPE.Schema:OrderResponse",
+		"RETURNS: SCOPE.Operation:OrdersController.list -> SCOPE.Schema:OrderResponse",
+		// JPA entity owning its named query (hibernate.go:242). This is the
+		// majority OWNS shape: an `operation` scope-kind, which
+		// structuralKindFamilies maps onto the Operation family, so it resolves
+		// even though the base extractor indexes the same file.
+		"OWNS: SCOPE.Schema:Order -> SCOPE.Operation:Order.findAllOrders",
+		// #4367 DTO field membership (bean_validation.go:316,338). Not one of the
+		// six kinds #6105 named, but measured as 100% dangling on this fixture
+		// before the fix (six `CONTAINS TO
+		// scope:schema:bean_validation_field:…` endpoints) and resolving after
+		// it — the largest single group the repair recovers here.
+		//
+		// Asserted per-field, and per-OWNER, because `id` and `reference`
+		// deliberately exist in three classes in one package directory: a field
+		// bound to the wrong class fails here rather than passing a count.
+		//
+		// The class-owner form appears only for OrderRequest: the #4367 edge's
+		// FromID is `Class:<Owner>` and only OrderRequest has a SCOPE.Class node
+		// (synthesised as the nested-@Valid carrier, bean_validation.go:356).
+		// Customer and Address have no class node, so their membership lands on
+		// the file component. Both forms are the same repair — the ToID
+		// resolving — so both are pinned.
+		"CONTAINS: SCOPE.Class:OrderRequest -> SCOPE.Schema:OrderRequest.id",
+		"CONTAINS: SCOPE.Class:OrderRequest -> SCOPE.Schema:OrderRequest.reference",
+		"CONTAINS: SCOPE.Class:OrderRequest -> SCOPE.Schema:OrderRequest.address",
+		"CONTAINS: SCOPE.Component:dto/Customer.java -> SCOPE.Schema:Customer.id",
+		"CONTAINS: SCOPE.Component:dto/Customer.java -> SCOPE.Schema:Customer.reference",
+		"CONTAINS: SCOPE.Component:dto/Address.java -> SCOPE.Schema:Address.id",
+	}
+	var missing []string
+	for _, w := range want {
+		if got[w] == 0 {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) > 0 {
+		have := make([]string, 0, len(got))
+		for e, n := range got {
+			have = append(have, fmt.Sprintf("%dx %s", n, e))
+		}
+		sort.Strings(have)
+		t.Errorf("%d of %d Java custom-extractor edges do not join the entities they name:\nmissing:\n  %s\nactual:\n  %s",
+			len(missing), len(want), strings.Join(missing, "\n  "), strings.Join(have, "\n  "))
+	}
+}
+
+// TestCustomExtractorGateStructuralRefResidueIsRecorded6105 is the general form
+// of the same defect, and the ratchet that stops the fix being special-cased to
+// the edges named above: EVERY unresolved `scope:` endpoint the gate introduces
+// must be recorded here by its exact ref, with a reason. A new five-segment ref
+// escaping canonicalStructuralRef shows up as an unrecorded entry.
+//
+// WHY `scope:pattern:` SURVIVES THE FIX — AND WHY IT IS NOT FIXED HERE. With the
+// segment count repaired, lookupStructural reaches Format A and calls
+// structuralKindFamilies(scopeKind) (internal/resolve/refs.go:2380-2390), which
+// knows only "component", "operation" and "schema". A `pattern` scope-kind gets
+// a nil family, so the kind-aware tier is skipped and the lookup falls through
+// to the unique-only byLocation index. Every AOP pointcut / advice node shares
+// its (file, Name) with the base extractor's SCOPE.Operation for the same Java
+// method by construction — `AuditAspect.anyApiCall` is both — so the pair is
+// flagged in ambigLocation and the endpoint is left as statusAmbiguous.
+//
+// Fixing it means teaching structuralKindFamilies a Pattern family, which is in
+// internal/resolve — under concurrent change by another work item, so out of
+// scope for this one. It is a genuine second defect, not a consequence of this
+// change: at 2f0175dfc these endpoints were unresolved too, for the earlier and
+// more basic reason that the ref never parsed at all.
+//
+// Scoped to the gate DELTA: `scope:` placeholders retained on the base path are
+// deliberate and are not this test's business.
+func TestCustomExtractorGateStructuralRefResidueIsRecorded6105(t *testing.T) {
+	added, _ := gateArms6105(t)
+	got := map[string]int{}
+	for d, n := range added {
+		if strings.HasPrefix(d.id, "scope:") {
+			got[d.String()] = n
+		}
+	}
+	want := map[string]int{
+		// `pattern` scope-kind: no family in structuralKindFamilies, and the
+		// (file, Name) pair collides with the base extractor's SCOPE.Operation
+		// for the same Java method. See the doc comment above.
+		"OWNS TO scope:pattern:advice:java:java/AuditAspect.java:AuditAspect.auditBefore":        1,
+		"OWNS TO scope:pattern:pointcut:java:java/AuditAspect.java:AuditAspect.anyApiCall":       1,
+		"REFERENCES TO scope:pattern:pointcut:java:java/AuditAspect.java:AuditAspect.anyApiCall": 1,
+		// findRefForType (types.go:120) fallback: `Address` is declared in
+		// dto/Address.java, but the ref is minted with the REFERENCING file's
+		// path, so byLocation[dto/OrderRequest.java]["Address"] can only miss.
+		// `dependency` also has no family in structuralKindFamilies, so the
+		// kind-aware tier is skipped too. Unresolved before this change as well
+		// — then on the segment count, now on an honest cross-file miss. The
+		// resolver declining to guess a type by bare name is correct; fixing it
+		// properly means emitting the DECLARING file's path, which is a Java
+		// extractor change out of scope here.
+		"VALIDATES TO scope:dependency:bean_validation:java:dto/OrderRequest.java:Address": 1,
+	}
+	for k, n := range got {
+		if want[k] != n {
+			t.Errorf("unrecorded unresolved structural-ref endpoint %q (%d).\n"+
+				"If this is a NEW five-segment ref, canonicalStructuralRef is not reaching it; "+
+				"if it is a `scope:pattern:` one, add it here with its reason.", k, n)
+		}
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("recorded structural-ref residue %q resolved (got %d, want %d) — "+
+				"the resolver has presumably learned a Pattern/Dependency family, or the "+
+				"emitting extractor now mints a resolvable ref; drop this entry.",
+				k, got[k], n)
+		}
+	}
+}
+
+// TestCustomExtractorColonNameRefsRemainUnresolved6105 pins defects (2) and (3)
+// as KNOWN AND UNFIXED rather than letting them rot unrecorded.
+//
+// WHY THEY ARE NOT FIXED HERE. Both need a resolver-side index — either byName
+// keyed on the FULL colon-bearing stub, or Properties["ref"] indexed under
+// byQualifiedName the way `scope:endpoint:` / `scope:testcoverage:` /
+// `scope:component:interface:<lang>:` already are (internal/resolve/refs.go:992,
+// :1006, :1029, :1045). internal/resolve is being changed concurrently by
+// another work item, so this change stays out of it. Neither can be fixed from
+// the extractor side without harm:
+//
+//   - Setting the cache-region entity's QualifiedName to the ref would make it
+//     resolvable, but cache regions converge ACROSS files by design and
+//     duplicate QualifiedNames are blanked to a collision sentinel — the same
+//     region cached in two files would resolve to nothing again, only now
+//     "ambiguous" instead of "unmatched".
+//   - `service:<Name>` has no target at all. Fabricating one is the placeholder
+//     invention this work explicitly must not do.
+//
+// Deleting the edges is not an option either: an edge pointing at nothing is
+// bad, silently dropping a relationship the extractor meant to express is
+// worse and unmeasurable.
+//
+// The test asserts the residue EXACTLY. If a future change resolves any of
+// these, this fails and must be deleted — it is a ratchet, not an endorsement.
+func TestCustomExtractorColonNameRefsRemainUnresolved6105(t *testing.T) {
+	added, _ := gateArms6105(t)
+	got := map[string]int{}
+	for d, n := range added {
+		switch d.kind {
+		case "CACHES", "INVALIDATES", "READS_FROM", "WRITES_TO", "DEPENDS_ON_SERVICE":
+			got[d.String()] = n
+		}
+	}
+	want := map[string]int{
+		// internal/custom/java/caching.go:96 — entity Name is "orders",
+		// Properties["ref"] is the stub; nothing indexes the stub.
+		"CACHES TO cache:spring:orders":      1,
+		"INVALIDATES TO cache:spring:orders": 1,
+		// internal/custom/python/caching.go:118 — entity NAME is the stub, but
+		// splitStub eats everything up to the first colon before probing byName.
+		"CACHES TO cache:django:orders":      1,
+		"INVALIDATES TO cache:django:orders": 1,
+		// internal/custom/python/redis.go:176 — same colon-name shape.
+		"READS_FROM TO Datastore:redis:orders": 1,
+		"WRITES_TO TO Datastore:redis:orders":  1,
+	}
+	if len(got) != len(want) {
+		t.Errorf("known-unresolved residue changed size: got %d, want %d\ngot:  %v\nwant: %v",
+			len(got), len(want), got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("known-unresolved endpoint %q: got %d, want %d", k, got[k], n)
+		}
+	}
+	for k, n := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("NEW unresolved colon-name endpoint %q (%d) — not in the recorded residue", k, n)
+		}
+	}
+}
+
+// TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105 measures the WIDENING
+// this fix introduces, which no dangling-based assertion can see.
+//
+// THE HAZARD. Making these refs parse also makes them eligible for
+// lookupStructural tiers they could never reach before. The sharpest is the #667
+// Java cross-file field tier (internal/resolve/refs.go:2250): predicate
+// `scopeKind == "schema" && lang == "java" && tail contains a dot`. On a
+// byLocation MISS it falls to lookupPackageMemberByLeafName(pkgDir, fieldName),
+// which binds to any class in the package DIRECTORY declaring that leaf name,
+// then to lookupUniqueSchemaFieldByName globally. For field names like `id` or
+// `name` "unique in package dir" is a weak guarantee. Before the fix these were
+// statusUnmatched; after it they could bind to an unrelated class's field — and
+// a mis-bind is RESOLVED, so the residue ratchets above are blind to it by
+// construction, exactly as they are for DEPENDS_ON_SERVICE.
+//
+// WHAT THE MEASUREMENT FOUND (re-run against c38c05f20, which landed #6098 and
+// widened precisely these tiers). The tier is reachable in SHAPE but is not
+// reached by any live emission, for two independent reasons:
+//
+//  1. It requires a DOTTED tail. Of the sixteen `scope:schema:` mint sites in
+//     internal/custom/java, only spring_dto_fields.go:188 and
+//     bean_validation.go:316 produce one (`<OwnerClass>.<field>`); every other
+//     site interpolates a bare class name, so `LastIndexByte(tail, '.') > 0` is
+//     false and the tier is never entered.
+//  2. Both dotted sites emit the target entity in the SAME FILE and the same
+//     extractor run as the ref, so byLocation always hits at refs.go:2091 —
+//     before the schema fallbacks at :2225 are consulted.
+//
+// So the conclusion is "not reached", not "acceptable heuristic". This test is
+// what keeps that true: the fixture puts three DTOs in one package directory
+// sharing the leaf names `id` and `reference`, so if a future change ever lets
+// one of these refs miss byLocation, the leaf-name tier has something wrong to
+// bind to and this fails loudly instead of silently rewiring the graph.
+func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
+	_, on := gateArms6105(t)
+
+	byID := make(map[string]*graph.Entity, len(on.Entities))
+	for i := range on.Entities {
+		byID[on.Entities[i].ID] = &on.Entities[i]
+	}
+
+	// Collect the bean-validation field entities and check each one is anchored
+	// to the file its own ref names, and owned by the class its name declares.
+	fields := map[string]*graph.Entity{}
+	leafOwners := map[string]map[string]bool{} // leaf field name -> set of files
+	for i := range on.Entities {
+		e := &on.Entities[i]
+		ref := e.PropGet("ref")
+		if !strings.HasPrefix(ref, "scope:schema:bean_validation_field:java:") {
+			continue
+		}
+		fields[e.ID] = e
+		rest := strings.TrimPrefix(ref, "scope:schema:bean_validation_field:java:")
+		colon := strings.IndexByte(rest, ':')
+		if colon <= 0 {
+			t.Errorf("field ref %q has no file segment", ref)
+			continue
+		}
+		refFile, refTail := rest[:colon], rest[colon+1:]
+		if e.SourceFile != refFile {
+			t.Errorf("field entity %s lives in %s but its ref names %s",
+				e.Name, e.SourceFile, refFile)
+		}
+		if e.Name != refTail {
+			t.Errorf("field entity Name %q disagrees with its ref tail %q", e.Name, refTail)
+		}
+		if owner := e.PropGet("owner_class"); owner != "" &&
+			!strings.HasPrefix(e.Name, owner+".") {
+			t.Errorf("field entity %s claims owner_class=%s — the membership was rewired",
+				e.Name, owner)
+		}
+		if dot := strings.LastIndexByte(e.Name, '.'); dot > 0 {
+			leaf := e.Name[dot+1:]
+			if leafOwners[leaf] == nil {
+				leafOwners[leaf] = map[string]bool{}
+			}
+			leafOwners[leaf][e.SourceFile] = true
+		}
+	}
+
+	// Non-vacuity: the fixture must actually present the leaf-name collision the
+	// widened tier would exploit, in more than one file.
+	collisions := 0
+	for _, files := range leafOwners {
+		if len(files) > 1 {
+			collisions++
+		}
+	}
+	if len(fields) < 6 || collisions < 2 {
+		t.Fatalf("fixture no longer exercises the widened tier: %d bean-validation field "+
+			"entities, %d field leaf names shared across files (want >= 6 and >= 2)",
+			len(fields), collisions)
+	}
+
+	// Every membership edge touching a field entity must stay inside one file.
+	// REFERENCES is excluded: the @Valid nested-DTO edge (bean_validation.go:356)
+	// legitimately crosses files, and it addresses its target as `Class:<Name>`,
+	// not as a schema structural ref, so it is not on the widened path.
+	for i := range on.Relationships {
+		r := &on.Relationships[i]
+		if r.Kind == "REFERENCES" {
+			continue
+		}
+		from, to := byID[r.FromID], byID[r.ToID]
+		if from == nil || to == nil {
+			continue
+		}
+		if fields[r.FromID] == nil && fields[r.ToID] == nil {
+			continue
+		}
+		if from.SourceFile == "" || to.SourceFile == "" || from.SourceFile == to.SourceFile {
+			continue
+		}
+		t.Errorf("%s edge crosses files onto a bean-validation field: %s (%s) -> %s (%s).\n"+
+			"This is the #667 leaf-name tier (refs.go:2250) firing — a byLocation miss now "+
+			"binds by field leaf name across the package directory.",
+			r.Kind, from.Name, from.SourceFile, to.Name, to.SourceFile)
+	}
+}
+
+// TestCustomExtractorDependsOnServiceTargetIsNeverCreated6105 pins defect (3)
+// at its source rather than through the dangling count, because on this fixture
+// the endpoint does not dangle — it binds to the WRONG entity.
+//
+// internal/custom/csharp/test_doubles.go:244 emits
+// `DEPENDS_ON_SERVICE -> service:PostgreSqlContainer`. splitStub strips
+// "service:" and probes byName["PostgreSqlContainer"], which here finds the
+// SCOPE.Operation the base C# extractor made for the `new PostgreSqlContainer()`
+// call site. So the edge reads "the container topology node depends on a
+// constructor call", which is not the relationship the extractor meant. On the
+// corpus, where no same-named entity exists, the same edge dangles instead.
+//
+// A dangling-count check cannot see this: the count IMPROVES when the edge
+// silently mis-binds. That is why it is asserted on content.
+func TestCustomExtractorDependsOnServiceTargetIsNeverCreated6105(t *testing.T) {
+	_, on := gateArms6105(t)
+
+	// No pass creates a service node for the container.
+	for i := range on.Entities {
+		e := &on.Entities[i]
+		if strings.HasPrefix(e.Name, "service:") {
+			t.Fatalf("a `service:` entity now exists (%s %s in %s) — defect (3) has changed shape "+
+				"and this test must be revisited", e.Kind, e.Name, e.SourceFile)
+		}
+	}
+
+	got := edgeSet6105(on, "DEPENDS_ON_SERVICE")
+	const misbound = "DEPENDS_ON_SERVICE: SCOPE.Pattern:container:PostgreSqlContainer -> SCOPE.Operation:PostgreSqlContainer"
+	if got[misbound] == 0 {
+		t.Errorf("the recorded DEPENDS_ON_SERVICE mis-binding is gone; got %v.\n"+
+			"If it now binds to a real service node, delete this test and close that part of #6105.", got)
+	}
+}

--- a/internal/custom/java/patterns_dispatch.go
+++ b/internal/custom/java/patterns_dispatch.go
@@ -311,6 +311,13 @@ func (e *javaPatternsExtractor) Extract(ctx context.Context, file extreg.FileInp
 // hang off a materialised injection-point entity. The synthesis is idempotent and
 // only fires when no real entity claims the SourceRef, so it never duplicates an
 // emitted carrier nor fabricates phantoms for refs a relationship does not use.
+//
+// #6105 — REFS ARE CANONICALISED HERE, ON EVERY SIDE. Every `scope:` ref minted
+// anywhere in this package is written as `scope:<kind>:<subtype>:<file>:<name>`;
+// the resolver's Format A is `scope:<kind>:<subtype>:<lang>:<file>:<name>`.
+// canonicalStructuralRef inserts the missing language slot on entity Refs,
+// SourceRefs and TargetRefs alike, so the byRef carrier index below still
+// matches and the emitted edge is addressable. See canonicalStructuralRef.
 func patternResultToRecords(res *PatternResult, filePath string) []types.EntityRecord {
 	if res == nil || (len(res.Entities) == 0 && len(res.Relationships) == 0) {
 		return nil
@@ -322,6 +329,7 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 	byRef := make(map[string]int, len(res.Entities)) // ref -> index in records
 
 	for _, se := range res.Entities {
+		se.Ref = canonicalStructuralRef(se.Ref)
 		rec := makeEntity(se.Name, se.Kind, se.Subtype, fileOr(se.SourceFile, filePath), "java", se.LineStart)
 		if se.LineEnd > rec.EndLine {
 			rec.EndLine = se.LineEnd
@@ -334,6 +342,14 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 			rec.Properties["ref"] = se.Ref
 		}
 		// Merge the extractor-set properties (string-coerced).
+		//
+		// #6105 — THIS RUNS AFTER the canonicalised ref is written above, so an
+		// extractor that ever sets se.Properties["ref"] would silently CLOBBER it
+		// with an un-canonicalised value and take the edge back out of the
+		// resolver's reach. No Extract* function does today (the ref lives in
+		// SecondaryEntity.Ref, which is the only supported home). If one ever
+		// needs to, canonicalise it here rather than reordering these two blocks —
+		// the ordering is what lets an extractor override provenance.
 		for k, v := range se.Properties {
 			rec.Properties[k] = stringifyProp(v)
 		}
@@ -345,6 +361,8 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 	// entity claims the SourceRef, synthesise a minimal carrier from the
 	// structured ref so the edge materialises instead of being dropped (#3605).
 	for _, r := range res.Relationships {
+		r.SourceRef = canonicalStructuralRef(r.SourceRef)
+		r.TargetRef = canonicalStructuralRef(r.TargetRef)
 		idx, ok := byRef[r.SourceRef]
 		if !ok {
 			synth, made := synthesizeCarrier(r.SourceRef, filePath)
@@ -379,6 +397,130 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 	return records
 }
 
+// structuralRefLang is the language slot the resolver's Format A expects in a
+// `scope:` structural ref.
+//
+// WHY ONE CONSTANT, WHEN THIS PACKAGE ALSO EXTRACTS KOTLIN (16 files;
+// ExtractSpringAOP accepts ctx.Language == "kotlin"). NOT because the slot is
+// ignored — it is not. The resolver reads it SEMANTICALLY in four places:
+// inferLangFromStub → normalizeLang (internal/resolve/refs.go:286-289), which
+// drives dynamic-pattern classification; the python component widening tier
+// (refs.go:2179); the go schema/receiver tier (refs.go:2225); and the #667 Java
+// cross-file EXTENDS field tier (refs.go:2250).
+//
+// The constant is correct because the slot must agree with the LANGUAGE STAMPED
+// ON THE RECORD, not with the source dialect. makeEntity in this package stamps
+// "java" on every record it builds — Kotlin sources included — so every entity
+// these refs address is indexed as Java. Emitting "kotlin" for Kotlin input
+// would DESYNCHRONISE the two and silently disable the java-gated tier for those
+// refs.
+//
+// So: if this package is ever changed to stamp a per-dialect Language on its
+// records, this constant must move with it. They are one decision, not two.
+const structuralRefLang = "java"
+
+// knownStructuralRefLangs is the set of language tokens that may legitimately
+// occupy Format A's language slot — the identifiers normalizeLang
+// (internal/resolve/refs.go:261-276) accepts, plus its aliases.
+//
+// USED ONLY TO DETECT AN ALREADY-CANONICAL REF, never to choose one. Segment
+// counting cannot do that job: entity names in this package legitimately contain
+// colons (`scope:pattern:obs_log_statement:<file>:<recv>:<level>:<line>`), so
+// segment count is not a function of ref shape.
+//
+// The residual ambiguity is a ref whose FILE segment is exactly a bare language
+// token with no path separator — `scope:x:y:go:Foo`. Such a ref is ambiguous by
+// construction (no reader can tell the two shapes apart) and no site in this
+// package can produce one: every ref interpolates ctx.FilePath, which is a repo-
+// relative path.
+var knownStructuralRefLangs = map[string]bool{
+	"java": true, "kotlin": true, "kt": true, "scala": true, "groovy": true,
+	"python": true, "py": true, "javascript": true, "js": true,
+	"typescript": true, "ts": true, "ruby": true, "rb": true,
+	"go": true, "rust": true, "csharp": true, "php": true, "swift": true,
+	"dart": true, "cpp": true, "c": true, "elixir": true, "lua": true,
+	"crystal": true, "nim": true, "fsharp": true,
+}
+
+// canonicalStructuralRef repairs the five-segment `scope:` refs this package
+// mints so they match the shape the resolver actually parses (#6105).
+//
+// THE DEFECT. Every structural ref in internal/custom/java is built as
+//
+//	scope:<kind>:<subtype>:<filePath>:<name>
+//
+// — the shape synthesizeCarrier's doc comment documents as this package's
+// convention. The resolver's Format A is
+//
+//	scope:<kind>:<subtype>:<lang>:<filePath>:<name>
+//
+// and lookupStructural splits on ':' with stubScopeSegments = 6, returning
+// statusUnmatched outright when the count differs (internal/resolve/refs.go:69,
+// :2037-2039). The Java custom extractors have only ever run behind
+// GRAFEL_SUBPROC_EXTRACT (no writers) or the default-off
+// GRAFEL_INPROC_CUSTOM_EXTRACTORS gate, so nothing ever exercised them against a
+// live resolver index. On the #5989 corpus this accounted for RETURNS
+// (1,072/1,072 dangling), OWNS (466/466) and ACCEPTS_INPUT (85/85).
+//
+// PRECISELY: refs whose NAME contains no colon produced five parts and were
+// rejected on the count. Refs whose name DOES contain colons produced six and
+// therefore parsed — but with every field shifted one place left, so the file
+// segment was read as the LANGUAGE and the first name fragment as the FILE.
+// Those could only ever miss. Both shapes are repaired here; the second is
+// repaired into something that can actually bind, since Format A takes the tail
+// as everything after the file segment (SplitN caps at 6) and
+// `…:<file>:<recv>:<level>:<line>` recomposes as tail `<recv>:<level>:<line>`.
+//
+// A colon-bearing FILE segment (`C:/proj/A.java`, `src/we:ird/`) is the one
+// shape this cannot repair: it yields seven fields and lands back on the
+// count rejection. That is strictly better than the status quo, where such a ref
+// parsed with lang="C" and file="/proj/A.java" and could mis-address; grafel
+// stores repo-relative forward-slash paths, so it is not a live shape.
+//
+// IDEMPOTENT, SHAPE-AWARE. A ref that already carries ANY known language token
+// in the slot is returned unchanged — not just "java:". Guarding on
+// structuralRefLang alone would corrupt exactly the case the guard exists for:
+// `scope:operation:method:kotlin:src/x/A.kt:foo` would become
+// `…:java:kotlin:src/x/A.kt:foo`, seven fields, unmatched. See
+// knownStructuralRefLangs for why a language set and not a segment count.
+//
+// Non-`scope:` refs are returned untouched: `cache:<framework>:<region>`,
+// `Class:<Name>` and the like are name-shaped, not structural, and repairing
+// those is a different defect (see #6105 defect (2)).
+//
+// WIDENING NOTE (#6105 review). Making these refs parse also makes them ELIGIBLE
+// for lookupStructural tiers they could never reach before — in particular the
+// #667 Java cross-file field tier at refs.go:2250, which the
+// `scope:schema:bean_validation_field:…` refs now match on shape. That tier is
+// measured, not assumed: see
+// TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105.
+func canonicalStructuralRef(ref string) string {
+	const prefix = "scope:"
+	if !strings.HasPrefix(ref, prefix) {
+		return ref
+	}
+	rest := ref[len(prefix):]
+	// rest must be "<kind>:<subtype>:<tail…>" — three fields minimum.
+	kindEnd := strings.IndexByte(rest, ':')
+	if kindEnd < 0 {
+		return ref
+	}
+	subEnd := strings.IndexByte(rest[kindEnd+1:], ':')
+	if subEnd < 0 {
+		return ref
+	}
+	head := rest[:kindEnd+1+subEnd+1] // "<kind>:<subtype>:"
+	tail := rest[len(head):]
+	// Already canonical when the next field is ANY known language token — not
+	// just this package's. A `structuralRefLang`-only guard would double-stamp a
+	// hand-written `…:kotlin:<file>:<name>` ref into an unmatched seven-field one.
+	if i := strings.IndexByte(tail, ':'); i > 0 &&
+		knownStructuralRefLangs[strings.ToLower(tail[:i])] {
+		return ref
+	}
+	return prefix + head + structuralRefLang + ":" + tail
+}
+
 // synthesizeCarrier builds a minimal carrier EntityRecord for an edge whose
 // SourceRef encodes its owner structurally but never emitted a standalone entity
 // (the di_injection_point and nested-@Valid edges). Pattern refs follow the shape
@@ -390,6 +532,14 @@ func patternResultToRecords(res *PatternResult, filePath string) []types.EntityR
 //
 // Only refs that an actual Relationship.SourceRef references reach this function,
 // so it never fabricates phantom carriers for unrelated refs.
+//
+// #6105 — IT SURVIVES THE LANGUAGE-SLOT INSERTION BY LUCK, NOT BY DESIGN. It
+// reads the kind from the FIRST colon and the name from the LAST, so an extra
+// field in the middle is invisible to it; the doc comment above still describes
+// the pre-#6105 five-field shape and is now one field short of what it receives.
+// Anyone changing this to a positional parse must account for the language slot
+// canonicalStructuralRef inserts, and for the fact that a name legitimately
+// contains colons (so the "last field" is a fragment, not the whole name).
 func synthesizeCarrier(sourceRef, filePath string) (types.EntityRecord, bool) {
 	const prefix = "scope:"
 	if !strings.HasPrefix(sourceRef, prefix) {

--- a/internal/custom/java/patterns_dispatch_refs_6105_test.go
+++ b/internal/custom/java/patterns_dispatch_refs_6105_test.go
@@ -1,0 +1,98 @@
+package java
+
+import "testing"
+
+// Issue #6105 — canonicalStructuralRef unit coverage.
+//
+// The end-to-end proof that this repairs real edges lives in
+// cmd/grafel/custom_extractor_dangling_6105_test.go, which indexes a fixture and
+// asserts the RETURNS / ACCEPTS_INPUT / OWNS endpoints bind to real entities.
+// What that test CANNOT reach is the already-canonical branch: no extractor in
+// this package emits a six-segment ref today, so the idempotence guard has no
+// live caller. It is kept because the natural next step is for extractors to
+// mint the full form directly, and a re-canonicalising helper would corrupt
+// those refs. Covering it here keeps it from being silently dead.
+func TestCanonicalStructuralRef6105(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "five-segment ref gains the language slot",
+			in:   "scope:schema:spring_dto:src/main/java/api/Orders.java:OrderRequest",
+			want: "scope:schema:spring_dto:java:src/main/java/api/Orders.java:OrderRequest",
+		},
+		{
+			// The tail is everything after the file segment, so a name that
+			// itself contains colons is repaired rather than truncated. Before
+			// the fix this ref's FILE segment was parsed as the language and its
+			// receiver as the file.
+			name: "colon-bearing name tail keeps its colons in the tail",
+			in:   "scope:pattern:obs_log_statement:src/x/A.java:log:info:42",
+			want: "scope:pattern:obs_log_statement:java:src/x/A.java:log:info:42",
+		},
+		{
+			name: "already canonical is returned unchanged",
+			in:   "scope:schema:spring_dto:java:src/x/A.java:OrderRequest",
+			want: "scope:schema:spring_dto:java:src/x/A.java:OrderRequest",
+		},
+		{
+			// The guard must be SHAPE-aware, not `structuralRefLang`-aware. This
+			// package extracts Kotlin too (ExtractSpringAOP accepts it), so the
+			// obvious `HasPrefix(tail, "java:")` guard would double-stamp a
+			// hand-written kotlin ref into `…:java:kotlin:…` — seven fields, and
+			// statusUnmatched. That failure is precisely the scenario the guard
+			// exists to protect, so it is covered here rather than left to the
+			// java case that cannot distinguish the two implementations.
+			name: "already-canonical kotlin slot is not double-stamped",
+			in:   "scope:operation:method:kotlin:src/x/A.kt:foo",
+			want: "scope:operation:method:kotlin:src/x/A.kt:foo",
+		},
+		{
+			name: "already-canonical go slot is not double-stamped",
+			in:   "scope:component:ref:go:a/b.go:Foo",
+			want: "scope:component:ref:go:a/b.go:Foo",
+		},
+		{
+			// Language aliases normalizeLang accepts (refs.go:261-276) count as
+			// canonical too — `kt` is what a Kotlin emitter may plausibly write.
+			name: "language alias in the slot is recognised",
+			in:   "scope:operation:method:kt:src/x/A.kt:foo",
+			want: "scope:operation:method:kt:src/x/A.kt:foo",
+		},
+		{
+			// A file segment that merely STARTS with a language name is not a
+			// language slot — the token must be the whole field. Without this the
+			// guard would skip every ref under a `java/` source root.
+			name: "file segment beginning with a language name is still repaired",
+			in:   "scope:schema:spring_dto:java/api/Orders.java:OrderRequest",
+			want: "scope:schema:spring_dto:java:java/api/Orders.java:OrderRequest",
+		},
+		{
+			// `cache:<framework>:<region>` and `Class:<Name>` are name-shaped
+			// refs, not structural ones. Repairing them is a different defect
+			// (#6105 defect (2)) and must not happen here.
+			name: "non-scope ref untouched",
+			in:   "cache:spring:orders",
+			want: "cache:spring:orders",
+		},
+		{
+			name: "structurally incomplete scope ref untouched",
+			in:   "scope:operation",
+			want: "scope:operation",
+		},
+		{
+			name: "empty ref untouched",
+			in:   "",
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := canonicalStructuralRef(tc.in); got != tc.want {
+				t.Errorf("canonicalStructuralRef(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/extractors/custom_java_patterns_smoke_test.go
+++ b/internal/extractors/custom_java_patterns_smoke_test.go
@@ -20,6 +20,16 @@ import (
 // assertion here therefore proves the dead layer is genuinely wired, not merely
 // unit-callable. Assertions are value-specific (exact Kind/Name and an exact
 // relationship Kind+ToID), never len > 0.
+//
+// #6105 — THE EXPECTED REFS GAINED A `java:` SEGMENT. Every ref asserted below
+// is now `scope:<kind>:<subtype>:java:<file>:<name>` rather than the five-segment
+// `scope:<kind>:<subtype>:<file>:<name>` these tests previously pinned. The old
+// shape was the defect: the resolver's Format A takes six segments
+// (internal/resolve/refs.go:69) and rejects anything else outright, so no ref
+// this package minted could ever bind. patternResultToRecords canonicalises them
+// at the output boundary — see canonicalStructuralRef. The Extract* functions
+// still build the five-segment form internally, so their own unit tests are
+// unaffected; only what LEAVES the package changed.
 
 // runJavaPatterns dispatches the live java custom-extractor pass and returns the
 // emitted records. It asserts the custom_java_patterns extractor is actually
@@ -128,7 +138,7 @@ public class UserService {
 
 	// 3. The @Autowired DI edge UserService -> UserRepository must emit as an
 	//    embedded DEPENDS_ON relationship on the service's stereotype entity.
-	wantTarget := "scope:dependency:spring_boot:" +
+	wantTarget := "scope:dependency:spring_boot:java:" +
 		"src/main/java/com/example/api/UserController.java:UserRepository"
 	if !hasRel(svc, "DEPENDS_ON", wantTarget) {
 		t.Errorf("expected DEPENDS_ON edge from UserService to UserRepository (%s); got rels %v",
@@ -165,7 +175,7 @@ public class Order {
 	}
 
 	// The @OneToMany association Order -> LineItem must emit as a DEPENDS_ON edge.
-	wantTarget := "scope:schema:hibernate_entity:" +
+	wantTarget := "scope:schema:hibernate_entity:java:" +
 		"src/main/java/com/example/model/Order.java:LineItem"
 	if !hasRel(order, "DEPENDS_ON", wantTarget) {
 		t.Errorf("expected DEPENDS_ON association edge Order -> LineItem (%s); got rels %v",
@@ -262,7 +272,7 @@ public class LoggingAspect {
 	recs := runJavaPatterns(t, "src/main/java/x/LoggingAspect.java", src)
 
 	// aspect_extraction
-	aspect := findByRef(recs, "scope:pattern:aspect:src/main/java/x/LoggingAspect.java:LoggingAspect")
+	aspect := findByRef(recs, "scope:pattern:aspect:java:src/main/java/x/LoggingAspect.java:LoggingAspect")
 	if aspect == nil {
 		t.Fatalf("expected @Aspect LoggingAspect to emit SCOPE.Pattern(aspect); got %v", names(recs))
 	}
@@ -271,7 +281,7 @@ public class LoggingAspect {
 	}
 
 	// advice_attribution — advice_type must be the resolved around designator.
-	advice := findByRef(recs, "scope:pattern:advice:src/main/java/x/LoggingAspect.java:LoggingAspect.logAround")
+	advice := findByRef(recs, "scope:pattern:advice:java:src/main/java/x/LoggingAspect.java:LoggingAspect.logAround")
 	if advice == nil {
 		t.Fatalf("expected @Around advice LoggingAspect.logAround to emit; got %v", names(recs))
 	}
@@ -284,7 +294,7 @@ public class LoggingAspect {
 	}
 
 	// pointcut_resolution — pointcut entity + advice REFERENCES pointcut.
-	pc := findByRef(recs, "scope:pattern:pointcut:src/main/java/x/LoggingAspect.java:LoggingAspect.anyOp")
+	pc := findByRef(recs, "scope:pattern:pointcut:java:src/main/java/x/LoggingAspect.java:LoggingAspect.anyOp")
 	if pc == nil {
 		t.Fatalf("expected @Pointcut LoggingAspect.anyOp to emit; got %v", names(recs))
 	}
@@ -312,7 +322,7 @@ public class OrderService {
 `
 	recs := runJavaPatterns(t, "src/main/java/x/OrderService.java", src)
 
-	tx := findByRef(recs, "scope:pattern:transaction_boundary:src/main/java/x/OrderService.java:OrderService.placeOrder")
+	tx := findByRef(recs, "scope:pattern:transaction_boundary:java:src/main/java/x/OrderService.java:OrderService.placeOrder")
 	if tx == nil {
 		t.Fatalf("expected @Transactional method to emit a transaction_boundary entity; got %v", names(recs))
 	}
@@ -344,7 +354,7 @@ public class OrderService {
 `
 	recs := runJavaPatterns(t, "src/main/java/x/OrderService.java", bean)
 	// di_binding_extraction + di_scope_resolution: @Singleton bean.
-	svc := findByRef(recs, "scope:service:micronaut_bean:src/main/java/x/OrderService.java:OrderService")
+	svc := findByRef(recs, "scope:service:micronaut_bean:java:src/main/java/x/OrderService.java:OrderService")
 	if svc == nil {
 		t.Fatalf("expected @Singleton OrderService micronaut bean; got %v", names(recs))
 	}
@@ -352,7 +362,7 @@ public class OrderService {
 		t.Errorf("micronaut bean scope = %q, want Singleton", got)
 	}
 	// di_injection_point: constructor DEPENDS_ON OrderRepository.
-	if !hasRel(svc, "DEPENDS_ON", "scope:dependency:micronaut:src/main/java/x/OrderService.java:OrderRepository") {
+	if !hasRel(svc, "DEPENDS_ON", "scope:dependency:micronaut:java:src/main/java/x/OrderService.java:OrderRepository") {
 		t.Errorf("expected ctor DEPENDS_ON OrderRepository edge; got %v", svc.Relationships)
 	}
 
@@ -368,12 +378,12 @@ public class LoggingInterceptor implements MethodInterceptor<Object, Object> {
 `
 	recs2 := runJavaPatterns(t, "src/main/java/x/LoggingInterceptor.java", interceptor)
 	// AOP aspect_extraction: MethodInterceptor class is an aspect.
-	asp := findByRef(recs2, "scope:pattern:aspect:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor")
+	asp := findByRef(recs2, "scope:pattern:aspect:java:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor")
 	if asp == nil {
 		t.Fatalf("expected MethodInterceptor to emit aspect; got %v", names(recs2))
 	}
 	// AOP advice_attribution: intercept() method advice_type=around + OWNS.
-	adv := findByRef(recs2, "scope:pattern:advice:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor.intercept")
+	adv := findByRef(recs2, "scope:pattern:advice:java:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor.intercept")
 	if adv == nil {
 		t.Fatalf("expected intercept() advice; got %v", names(recs2))
 	}
@@ -394,7 +404,7 @@ public class AuthFilter implements HttpServerFilter {
 `
 	recs3 := runJavaPatterns(t, "src/main/java/x/AuthFilter.java", filter)
 	// middleware_coverage: HttpServerFilter.
-	mw := findByRef(recs3, "scope:component:micronaut_filter:src/main/java/x/AuthFilter.java:AuthFilter")
+	mw := findByRef(recs3, "scope:component:micronaut_filter:java:src/main/java/x/AuthFilter.java:AuthFilter")
 	if mw == nil {
 		t.Fatalf("expected @Filter HttpServerFilter middleware; got %v", names(recs3))
 	}
@@ -419,14 +429,14 @@ public class LoggingInterceptor {
 }
 `
 	recs := runJavaPatterns(t, "src/main/java/x/LoggingInterceptor.java", cdi)
-	asp := findByRef(recs, "scope:pattern:cdi_interceptor:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor")
+	asp := findByRef(recs, "scope:pattern:cdi_interceptor:java:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor")
 	if asp == nil {
 		t.Fatalf("expected @Interceptor CDI aspect; got %v", names(recs))
 	}
 	if got := asp.Properties["kind"]; got != "cdi_interceptor" {
 		t.Errorf("CDI aspect kind = %q, want cdi_interceptor", got)
 	}
-	adv := findByRef(recs, "scope:pattern:cdi_advice:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor.logInvocation")
+	adv := findByRef(recs, "scope:pattern:cdi_advice:java:src/main/java/x/LoggingInterceptor.java:LoggingInterceptor.logInvocation")
 	if adv == nil {
 		t.Fatalf("expected @AroundInvoke advice; got %v", names(recs))
 	}
@@ -448,7 +458,7 @@ public class AuthFilter implements ContainerRequestFilter {
 }
 `
 	recs2 := runJavaPatterns(t, "src/main/java/x/AuthFilter.java", filter)
-	mw := findByRef(recs2, "scope:component:jaxrs_filter:src/main/java/x/AuthFilter.java:AuthFilter")
+	mw := findByRef(recs2, "scope:component:jaxrs_filter:java:src/main/java/x/AuthFilter.java:AuthFilter")
 	if mw == nil {
 		t.Fatalf("expected @Provider ContainerRequestFilter middleware; got %v", names(recs2))
 	}
@@ -473,7 +483,7 @@ public class UserResource {
 }
 `
 	recs := runJavaPatterns(t, "src/main/java/x/UserResource.java", src)
-	scoped := findByRef(recs, "scope:component:cdi_scoped_bean:src/main/java/x/UserResource.java:UserResource")
+	scoped := findByRef(recs, "scope:component:cdi_scoped_bean:java:src/main/java/x/UserResource.java:UserResource")
 	if scoped == nil {
 		t.Fatalf("expected @RequestScoped CDI scope component; got %v", names(recs))
 	}
@@ -526,7 +536,7 @@ public class CreateUserRequest {
 `
 	recs := runJavaPatterns(t, "src/main/java/x/CreateUserRequest.java", dto)
 	// schema_extraction: field-level constraints.
-	field := findByRef(recs, "scope:schema:bean_validation_field:src/main/java/x/CreateUserRequest.java:CreateUserRequest.email")
+	field := findByRef(recs, "scope:schema:bean_validation_field:java:src/main/java/x/CreateUserRequest.java:CreateUserRequest.email")
 	if field == nil {
 		t.Fatalf("expected @NotNull @Email field schema entity; got %v", names(recs))
 	}
@@ -534,7 +544,7 @@ public class CreateUserRequest {
 		t.Errorf("field constraints = %q, want @NotNull,@Email", got)
 	}
 	// nested_model_extraction: the @Valid nested field entity still emits.
-	nested := findByRef(recs, "scope:schema:bean_validation_field:src/main/java/x/CreateUserRequest.java:CreateUserRequest.address")
+	nested := findByRef(recs, "scope:schema:bean_validation_field:java:src/main/java/x/CreateUserRequest.java:CreateUserRequest.address")
 	if nested == nil {
 		t.Fatalf("expected @Valid nested field schema entity; got %v", names(recs))
 	}
@@ -549,7 +559,7 @@ public class PhoneValidator implements ConstraintValidator<ValidPhone, String> {
 `
 	recs2 := runJavaPatterns(t, "src/main/java/x/PhoneValidator.java", cv)
 	// custom_validator_extraction: ConstraintValidator implementor.
-	cve := findByRef(recs2, "scope:custom_validator:bean_validation:src/main/java/x/PhoneValidator.java:PhoneValidator")
+	cve := findByRef(recs2, "scope:custom_validator:bean_validation:java:src/main/java/x/PhoneValidator.java:PhoneValidator")
 	if cve == nil {
 		t.Fatalf("expected ConstraintValidator SCOPE.CustomValidator; got %v", names(recs2))
 	}
@@ -603,7 +613,7 @@ public class Order {
 
 	// relationship_extraction: the @OneToMany association Order -> LineItem must
 	// emit as a directed DEPENDS_ON edge, identical to the plain-JPA path.
-	wantTarget := "scope:schema:hibernate_entity:" + path + ":LineItem"
+	wantTarget := "scope:schema:hibernate_entity:java:" + path + ":LineItem"
 	if !hasRel(order, "DEPENDS_ON", wantTarget) {
 		t.Errorf("expected DEPENDS_ON association edge Order -> LineItem (%s) for spring_data_jpa; got rels %v",
 			wantTarget, order.Relationships)

--- a/internal/extractors/java_edge_carrier_reverify_test.go
+++ b/internal/extractors/java_edge_carrier_reverify_test.go
@@ -69,7 +69,7 @@ public class UserResource {
 	// The injecting class is the carrier: the @EJB DEPENDS_ON edge's SourceRef is
 	// scope:dependency:jakarta:<fp>:UserResource, which #3605 now materialises as a
 	// SCOPE.Class carrier so the edge survives instead of being dropped.
-	carrierRef := "scope:dependency:jakarta:" + path + ":UserResource"
+	carrierRef := "scope:dependency:jakarta:java:" + path + ":UserResource"
 	carrier := findByKindProp(recs, "SCOPE.Class", "ref", carrierRef)
 	if carrier == nil {
 		t.Fatalf("expected a synthesised SCOPE.Class carrier at ref %q for the @EJB injection point; got %v",
@@ -84,7 +84,7 @@ public class UserResource {
 
 	// The restored di_injection_point edge: DEPENDS_ON from UserResource to the
 	// injected UserService bean, tagged kind=ejb_inject.
-	targetRef := "scope:dependency:jakarta:" + path + ":UserService"
+	targetRef := "scope:dependency:jakarta:java:" + path + ":UserService"
 	if !relWithProp(carrier, "DEPENDS_ON", targetRef, "kind", "ejb_inject") {
 		t.Fatalf("expected restored di_injection_point DEPENDS_ON edge "+
 			"UserResource -> UserService (kind=ejb_inject); got rels %v", carrier.Relationships)
@@ -123,7 +123,7 @@ public class OrderRequest {
 	// The owning DTO is the carrier: the nested @Valid VALIDATES edge's SourceRef
 	// is scope:class:bean_validation:<fp>:OrderRequest, which #3605 now materialises
 	// as a SCOPE.Class carrier so the VALIDATES edge survives.
-	carrierRef := "scope:class:bean_validation:" + path + ":OrderRequest"
+	carrierRef := "scope:class:bean_validation:java:" + path + ":OrderRequest"
 	carrier := findByKindProp(recs, "SCOPE.Class", "ref", carrierRef)
 	if carrier == nil {
 		t.Fatalf("expected a synthesised SCOPE.Class carrier at ref %q for the nested @Valid edge; got %v",
@@ -135,7 +135,7 @@ public class OrderRequest {
 
 	// The restored nested_model_extraction edge: VALIDATES from OrderRequest to the
 	// nested Address type via the @Valid annotation on shippingAddress.
-	targetRef := "scope:dependency:bean_validation:" + path + ":Address"
+	targetRef := "scope:dependency:bean_validation:java:" + path + ":Address"
 	if !relWithProp(carrier, "VALIDATES", targetRef, "via", "valid_annotation") {
 		t.Fatalf("expected restored nested_model_extraction VALIDATES edge "+
 			"OrderRequest -> Address (via=valid_annotation); got rels %v", carrier.Relationships)


### PR DESCRIPTION
Six edge kinds were 100% dangling with `GRAFEL_INPROC_CUSTOM_EXTRACTORS` on. They turned out to be **three distinct defects**, not one. This fixes the first and files the other two.

## The defect

Every `scope:` ref literal in `internal/custom/java/**` emits **five** segments where Format A requires six — the **language slot was never emitted**. `stubScopeSegments = 6` (`internal/resolve/refs.go:69`) and `lookupStructural` returns `statusUnmatched` outright on `len(parts) != 6` (`refs.go:2036-2039`).

`grep ':java:|:kotlin:'` over non-test files in the package returns **0**. No ref this package has ever minted could bind. The target entities existed the whole time.

Fixed by `canonicalStructuralRef` in `patterns_dispatch.go`, applied once in `patternResultToRecords` to `Ref`, `SourceRef` and `TargetRef` alike so the `byRef` carrier index stays consistent.

**Coverage verified exhaustively in review:** all **249** ref-mint sites land in those three fields and all route through that function. The six sibling extractors that build `types.EntityRecord` directly mint zero `scope:` refs, and `Relationship.FromName` is only ever `"Class:"+name` — no bypass.

## Recovered more than the issue named

Neutering the fix and re-measuring: **13 distinct unresolved `scope:` endpoints before, 4 after.**

Recovered: `RETURNS` (2), `ACCEPTS_INPUT` (1), `OWNS` via an `operation` scope-kind (1) — and **six `CONTAINS → scope:schema:bean_validation_field:…` endpoints.** The #4367 DTO field-membership edges were 100% dangling too. #6105 never named them, and they are the largest single group this repair recovers. Now pinned per-field and per-owner.

## The mis-bind hazard, measured rather than assumed

Making these refs parse makes them eligible for tiers they could **never reach before**. Specifically `refs.go:2250` requires a dotted tail, and on a `byLocation` miss falls to `lookupPackageMemberByLeafName`, which binds to any class in the package directory declaring that field name — ambiguity-guarded, but "unique in package dir" is weak for names like `id`.

That matters because the residue test **cannot see a mis-bind by construction**: it inspects only *unresolved* endpoints, and a mis-bind is resolved. Same shape as #6123, where a dangling-count metric reads a wrong binding as an improvement.

**Result: reachable in shape, not reached by any live emission.** Two independent reasons, both established empirically:

1. Of the **sixteen** `scope:schema:` mint sites in the package, only two produce a dotted tail (`<OwnerClass>.<field>`). Every other site interpolates a bare class name, so the dotted-tail predicate is never satisfied.
2. Both dotted sites emit the target entity in the same file and the same run as the ref, so `byLocation` hits at `refs.go:2091` — before the schema fallbacks at `:2225`.

An adversarial fixture was built to break this: three DTOs in one package directory sharing leaf names `id` and `reference`. **All six `bean_validation_field` endpoints bound within their own file, each to its correct owner class.** The plausible escape hatch — a fully-qualified `@OneToMany List<com.example.model.LineItem>` giving hibernate a dotted schema tail — does not fire, because the association regex does not match FQN generics.

This was re-validated against `c38c05f20` (#6098), which widened exactly these tiers **after** this work's original baseline. That interaction could not have been measured before the rebase.

`TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105` ships the fixture, asserting each field entity is anchored to the file its own ref names, that `owner_class` matches its name prefix, and that **no non-`REFERENCES` edge touching a field entity crosses files** — with a non-vacuity guard requiring ≥6 field entities and ≥2 leaf names shared across files.

## The language constant — the reasoning was backwards

An earlier revision justified the single `"java"` constant by claiming the resolver matches the slot *positionally rather than semantically*. That is false: `parts[stubScopeLangIndex]` is read semantically in four places, including `inferLangFromStub` (`refs.go:286-289`), the python/go widening gates (`:2179`, `:2225`), and the #667 cross-file EXTENDS tier which gates on `== "java"` (`:2250`).

The corrected reasoning inverts the naive reading: the slot must agree with **the language stamped on the record**, not the source dialect. `makeEntity` in this package stamps `"java"` on every record it builds, Kotlin sources included. Emitting `"kotlin"` for Kotlin input would **desynchronise** the two and silently disable the java-gated tier for those refs.

So the constant and the record stamp are **one decision, not two** — if the package is ever changed to stamp a per-dialect `Language`, the constant must move with it. That is now recorded at the site.

## Idempotence guard is shape-aware

The guard was `HasPrefix(tail, structuralRefLang+":")` — `"java:"` only — while claiming to protect any ref that already carries a language slot. It failed precisely the case it was written for:

```
scope:operation:method:kotlin:src/x/A.kt:foo → …:java:kotlin:…   (7 fields → unmatched)
scope:component:ref:go:a/b.go:Foo            → …:java:go:…       (7 fields → unmatched)
```

Now a lookup against `knownStructuralRefLangs` (the `normalizeLang` identifiers plus aliases), with the table extended past `java` — including the `kt` alias, and a case that must **still be repaired**: `scope:schema:spring_dto:java/api/Orders.java:OrderRequest`, where the *file segment* merely starts with a language name. Without that, the guard would skip every ref under a `java/` source root.

A language set was chosen over a segment count deliberately: names in this package legitimately contain colons, so segment count is not a function of ref shape.

## Filed, not fixed

Three residuals, each pinned as a **bidirectional ratchet** that fails if behaviour changes in either direction — so a future change cannot silently "improve" one into a mis-bind:

- **#6122** — `splitStub` splits on the first colon and probes `byName` with the remainder, so `cache:django:orders` is looked up as `django:orders`. Structurally, any entity whose name contains a colon and is addressed by name is unresolvable. The extractor-side workaround (set `QualifiedName` to the ref) would break the cross-file convergence those nodes exist for.
- **#6123** — `DEPENDS_ON_SERVICE` targets a `service:` node no pass creates. On a name collision it **mis-binds** rather than dangling, improving the dangling metric while making the graph wrong.
- **#6124** — no Pattern family in `structuralKindFamilies`, so `scope:pattern:` refs fall to unique-only `byLocation` and collide by construction with the co-located `SCOPE.Operation`. Surfaced *by* this fix, which moved them one rung down the ladder.

A second residue entry was found during the schema measurement: `VALIDATES → scope:dependency:bean_validation:java:dto/OrderRequest.java:Address` — `findRefType` mints the fallback with the *referencing* file's path, so a type declared elsewhere can only miss. **Verified unresolved pre-fix as well**, so not a regression. Recorded with its reason.

No edges deleted, no placeholder entities created.

## Also corrected

- **An overstated absolute.** "Not one structural ref from this package has ever been resolvable" was wrong: colon-bearing-*name* refs already yielded 6 fields under `SplitN(…, 6)` and did parse — with every field shifted one place left, so they could only miss. The fix genuinely repairs those too.
- **Colon-bearing *file* segments** now yield seven fields and land on the count rejection. Before the fix they parsed *wrongly* (`lang="C"`, `file="/proj/A.java"`), so unmatched is strictly better. Not a live shape — grafel stores repo-relative forward-slash paths.
- `rec.Properties["ref"]` is written **before** the extractor-property merge, so a future extractor setting `se.Properties["ref"]` would silently clobber the canonicalised value. Commented, with the instruction to canonicalise in place rather than reorder — the ordering is what lets an extractor override provenance.
- `synthesizeCarrier` survives the shape change because it parses kind from the *first* colon and name from the *last*. **Safe by luck, not by design** — now annotated so nobody changes it unaware.

## A measurement trap worth recording

The first attempt to re-measure the pre-fix baseline used `git stash push` on a file whose change was already **committed**. It stashed nothing, the fix stayed active, and the test passed — which nearly read as "the residue predates the fix". Caught by checking the occurrence count in the supposedly-reverted file; the real measurement required neutering the function body.

Same family as the two other false-measurement traps found this cycle (a mutation that suppressed only a log, and a missing `runtime.KeepAlive` that let the GC reclaim mid-measurement). Anyone re-running this after the commit lands will hit it.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, skip counts include subtests:

| package | exit | skips |
|---|---|---|
| `./internal/custom/...` (21 pkgs) | 0 | **0** |
| `./internal/extractors/...` | 0 | 1 |
| `./cmd/grafel/` | 0 | 8 |
| `./internal/graph/...` | 0 | **0** |

All skips pre-existing measurement/perf gates.

Six mutants killed: revert to no-op · skip `TargetRef` · skip entity `Ref` · skip `SourceRef` · wrong language slot · truncate colon-bearing names. `TargetRef` and the truncation case are each killed by exactly one layer — both load-bearing, neither decorative. False-negative controls were run on every mutation before trusting a green.

Gate-off inertness re-confirmed post-rebase: both #6118-pinned digests pass untouched, nothing re-baselined.

Independently adversarially reviewed, returned REQUEST-CHANGES, re-verified.

Closes #6105
Refs #5989, #6122, #6123, #6124, #4367, #6098
