### PR TITLE
test(#6129): content-keyed full-vs-incremental parity gate — catches rebinds every existing metric reports as healthy

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -1,0 +1,624 @@
+// Package main — incremental_content_parity_6129_test.go
+//
+// FULL-vs-INCREMENTAL CONTENT PARITY GATE (#6129, building on #6037).
+//
+// Why this file exists
+// ────────────────────
+// Four defects in quick succession shared one shape: an incremental run
+// producing edges that resolve to a DIFFERENT OR SPURIOUS TARGET than a full
+// rebuild, rather than producing FEWER edges.
+//
+//	#6037 — the parity comparator compared sets, not multisets, so a
+//	        destroy-and-re-add was invisible.
+//	#6094 — a one-directional comparison under-scoped the defect: the rows were
+//	        present, but pointing at a name.
+//	#6123 — a mis-bind IMPROVES the dangling-endpoint metric while making the
+//	        graph wrong.
+//	#6129 — Path A binds IMPORTS to SCOPE.External placeholders instead of the
+//	        real in-repo Module entities; Path B emits spurious DEPENDS_ON rows.
+//
+// Every metric used in this area historically — entity counts, relationship
+// counts, dangling-endpoint rates, one-directional diffs — reports that shape
+// as HEALTHY. At four instances the answer is an instrument, not a fifth point
+// fix. This is that instrument.
+//
+// What it asserts
+// ───────────────
+// For each incremental path, over a fixture corpus with a one-file delta:
+//
+//	graph(incremental over baseline → end-state)  ≡
+//	graph(clean full rebuild of the same end-state)
+//
+// compared as a BIDIRECTIONAL MULTISET on BOUND-TARGET CONTENT.
+//
+// Design decisions, and why each one is load-bearing:
+//
+//   - CONTENT, not ids (`parity.Options.ContentKeyedIdentity`, added for this).
+//     An edge endpoint is keyed by the `kind/name@source_file` tuple of the
+//     entity it binds to IN ITS OWN GRAPH, or by `«unbound»<raw>` when it binds
+//     to nothing. An edge that resolves to a different entity therefore appears
+//     as a LOST key and an INVENTED key naming both targets. Keying on hex ids
+//     would report the same thing opaquely, and would not distinguish a
+//     placeholder endpoint from a real one at all.
+//
+//   - BIDIRECTIONAL MULTISETS. LOST and INVENTED are reported separately and
+//     with multiplicity. `internal/graph/parity` was fixed for exactly this in
+//     #6037 and is REUSED here rather than reimplemented; the only extension is
+//     the content keying above (a new Options field — no existing behaviour
+//     changed, the default path still keys on ids).
+//
+//   - BOTH PATHS, NOT CONFLATED. `dvIncremental` drives Path A
+//     (`internal/extractors.TryIncremental`, the daemon path — what MCP callers
+//     see between full reindexes). `cfPathBIncremental` (#6128) drives Path B
+//     (a SECOND `Index(..., WithIncremental(stateDir))` over a populated state
+//     dir — the CLI path). They are DIFFERENT code with DIFFERENT defects;
+//     using the wrong harness manufactures a divergence that belongs to the
+//     other path. Each path gets its own test and its own allow-list.
+//
+//   - THE RUN MUST ACTUALLY BE INCREMENTAL. Both harnesses already fail loudly
+//     on a fallback to full reindex (Path A on `res.Done`; Path B on the
+//     captured "falling back to full reindex" / "incremental — processing"
+//     stderr lines), which is the only thing standing between this gate and
+//     total vacuity: a full-reindex fallback trivially satisfies full-vs-full
+//     parity. The fixture keeps EVERY BASENAME UNIQUE because `diff.Filter`
+//     cross-invalidates by basename, which turns a 1-file delta into an N-file
+//     change and trips the too-many-changed fallback.
+//
+//   - GRAPHS ARE READ BACK FROM DISK via `LoadGraphFromDir`. Never from
+//     run-log counts (#6094 was under-scoped by trusting those) and never by
+//     comparing raw `graph.fb` bytes (indexing is nondeterministic at byte
+//     level — #6083).
+//
+// Known-divergence allow-list
+// ───────────────────────────
+// The #6129 divergences are REAL and UNFIXED. This gate landing red on them
+// would be correct but useless as a ratchet, so each is characterised
+// explicitly below by its exact shape, issue number and reason. Anything else —
+// a new divergence, or an allow-listed one that stops reproducing — fails.
+// The comparison itself is NOT weakened: no tolerance profile, no ignored edge
+// kind, no ignored property. Fixing #6129 is deliberately out of scope here.
+//
+// Refs #6129, #6037, #6094, #6123, #6083, #6128.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/parity"
+)
+
+// ─────────────────────────── divergence model ───────────────────────────
+
+// cpBucket names the dimension a divergence was found on. LOST (present in the
+// full rebuild, absent from the incremental result) and INVENTED (the reverse)
+// are kept as SEPARATE buckets: a one-directional comparison is what
+// under-scoped #6094, and a mis-bind shows up as one of each.
+type cpBucket string
+
+const (
+	cpEntityLost      cpBucket = "ENTITY-LOST"     // in full rebuild, not in incremental
+	cpEntityInvented  cpBucket = "ENTITY-INVENTED" // in incremental, not in full rebuild
+	cpEntityMult      cpBucket = "ENTITY-MULTIPLICITY"
+	cpEntityFields    cpBucket = "ENTITY-FIELDS"
+	cpEdgeLost        cpBucket = "EDGE-LOST"
+	cpEdgeInvented    cpBucket = "EDGE-INVENTED"
+	cpEdgeMult        cpBucket = "EDGE-MULTIPLICITY"
+	cpEdgeProps       cpBucket = "EDGE-PROPS"
+	cpCommunityAssign cpBucket = "COMMUNITY-ASSIGNMENT"
+	cpCommunitySet    cpBucket = "COMMUNITY-MEMBERSHIP"
+)
+
+// cpDivergence is one row of the flattened parity report.
+type cpDivergence struct {
+	Bucket cpBucket
+	Key    string
+	Detail string
+}
+
+func (d cpDivergence) String() string {
+	if d.Detail == "" {
+		return fmt.Sprintf("[%s] %s", d.Bucket, d.Key)
+	}
+	return fmt.Sprintf("[%s] %s — %s", d.Bucket, d.Key, d.Detail)
+}
+
+// cpFlatten turns a parity.Report into a flat, sorted divergence list. Every
+// field of the report is covered; a new report field left unhandled here would
+// silently drop divergences, so the mapping is exhaustive by construction.
+func cpFlatten(r parity.Report) []cpDivergence {
+	var out []cpDivergence
+	add := func(b cpBucket, keys []string) {
+		for _, k := range keys {
+			out = append(out, cpDivergence{Bucket: b, Key: k})
+		}
+	}
+	addF := func(b cpBucket, fds []parity.FieldDiff) {
+		for _, f := range fds {
+			out = append(out, cpDivergence{Bucket: b, Key: f.Key, Detail: f.Detail})
+		}
+	}
+	add(cpEntityLost, r.EntitiesOnlyInA)
+	add(cpEntityInvented, r.EntitiesOnlyInB)
+	addF(cpEntityMult, r.EntityMultiplicityDiffs)
+	addF(cpEntityFields, r.EntityFieldDiffs)
+	add(cpEdgeLost, r.RelsOnlyInA)
+	add(cpEdgeInvented, r.RelsOnlyInB)
+	addF(cpEdgeMult, r.RelMultiplicityDiffs)
+	addF(cpEdgeProps, r.RelPropDiffs)
+	addF(cpCommunityAssign, r.CommunityAssignmentDiffs)
+	add(cpCommunitySet, r.CommunitySetDiff)
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Bucket != out[j].Bucket {
+			return out[i].Bucket < out[j].Bucket
+		}
+		return out[i].Key < out[j].Key
+	})
+	return out
+}
+
+// ───────────────────────────── allow-list ─────────────────────────────
+
+// cpKnown characterises ONE known-and-unfixed divergence shape. It is keyed to
+// the specific shape — bucket plus every substring that must appear in the
+// divergence key — so it cannot accidentally absorb an unrelated regression in
+// the same bucket. Issue and Why are mandatory: an allow entry without a filed
+// issue and a stated reason is an ignored bug.
+type cpKnown struct {
+	Issue  string   // the issue tracking the divergence
+	Why    string   // why it is tolerated TODAY (never "to make the test pass")
+	Bucket cpBucket // the dimension it was found on
+
+	// Contains: ALL must be substrings of the divergence key.
+	Contains []string
+	// DetailContains: ALL must be substrings of the divergence detail. Used on
+	// the multiplicity / property buckets so that a CHANGE in the magnitude of a
+	// known divergence (a row duplicated 3× instead of 2×, a weight drifting
+	// from 5 to 9) is a NEW divergence and fails, rather than being absorbed.
+	DetailContains []string
+}
+
+func (k cpKnown) matches(d cpDivergence) bool {
+	if d.Bucket != k.Bucket {
+		return false
+	}
+	for _, s := range k.Contains {
+		if !strings.Contains(d.Key, s) {
+			return false
+		}
+	}
+	for _, s := range k.DetailContains {
+		if !strings.Contains(d.Detail, s) {
+			return false
+		}
+	}
+	return true
+}
+
+// cpAssertParity is the gate. It compares the two graphs bidirectionally as
+// content-keyed multisets, then partitions the divergences into
+// known-and-allow-listed vs everything else.
+//
+// Three ways it fails, all deliberate:
+//
+//  1. an UNEXPECTED divergence — a new full-vs-incremental defect, or an
+//     existing one changing shape;
+//  2. a STALE allow entry that matched nothing — the divergence was fixed (or
+//     the fixture stopped reaching it) and the entry must be deleted, so the
+//     allow-list can only ever shrink;
+//  3. an INERT comparison — the graphs carry no edges at all, which would make
+//     "equivalent" meaningless.
+func cpAssertParity(t *testing.T, path string, full, inc *graph.Document, known []cpKnown) {
+	t.Helper()
+
+	// (3) Inertness guard. A comparison of two empty (or edge-free) graphs is
+	// trivially equivalent and proves nothing.
+	if len(full.Entities) == 0 || len(full.Relationships) == 0 {
+		t.Fatalf("%s: fixture is inert — the full rebuild produced %d entities / %d edges; "+
+			"a parity comparison over that measures nothing",
+			path, len(full.Entities), len(full.Relationships))
+	}
+
+	// The two aggregate metrics this class of defect historically hid behind,
+	// logged on every run so the failure output shows for itself that they are
+	// NOT sufficient: a mis-bind moves neither of them.
+	t.Logf("%s: edges full=%d inc=%d | entities full=%d inc=%d | unbound endpoints full=%d inc=%d",
+		path, len(full.Relationships), len(inc.Relationships),
+		len(full.Entities), len(inc.Entities),
+		cpUnboundEndpoints(full), cpUnboundEndpoints(inc))
+
+	rep := parity.CompareWithOptions(full, inc, parity.Options{ContentKeyedIdentity: true})
+	divs := cpFlatten(rep)
+
+	hits := make([]int, len(known))
+	var unexpected []cpDivergence
+	for _, d := range divs {
+		matched := false
+		for i, k := range known {
+			if k.matches(d) {
+				hits[i]++
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			unexpected = append(unexpected, d)
+		}
+	}
+
+	// (1) New / reshaped divergence.
+	if len(unexpected) > 0 {
+		var b strings.Builder
+		fmt.Fprintf(&b, "%s: %d full-vs-incremental divergence(s) NOT on the known list.\n\n", path, len(unexpected))
+		b.WriteString("A = full rebuild of the end state (reference); B = incremental result.\n")
+		b.WriteString("Endpoints are keyed by the CONTENT of the entity they bind to, so an edge\n")
+		b.WriteString("that resolved to a DIFFERENT target appears as one EDGE-LOST plus one\n")
+		b.WriteString("EDGE-INVENTED naming both targets — the shape counts and dangling rates miss.\n\n")
+		for _, d := range unexpected {
+			fmt.Fprintf(&b, "  %s\n", d)
+		}
+		if n := len(divs) - len(unexpected); n > 0 {
+			fmt.Fprintf(&b, "\n(%d further divergence(s) matched the known-issue allow-list and are not shown.)\n", n)
+		}
+		t.Errorf("%s", b.String())
+	}
+
+	// (2) Stale allow entry — the ratchet.
+	for i, k := range known {
+		if hits[i] == 0 {
+			t.Errorf("%s: allow-list entry for %s (%v %v) matched NOTHING.\n"+
+				"  reason it was allowed: %s\n"+
+				"Either the divergence was fixed — delete this entry, the allow-list only shrinks — "+
+				"or the fixture no longer reaches it, in which case the gate has gone quiet on a live defect.",
+				path, k.Issue, k.Bucket, k.Contains, k.Why)
+		}
+	}
+
+	if !t.Failed() && len(divs) > 0 {
+		t.Logf("%s: %d known divergence(s) tolerated (all filed):", path, len(divs))
+		for _, d := range divs {
+			t.Logf("    %s", d)
+		}
+	}
+}
+
+// cpUnboundEndpoints counts relationship endpoints that bind to no entity in
+// their own document — the "dangling rate" numerator. It exists here purely to
+// be LOGGED alongside the real comparison, as standing evidence of why it is
+// not a sufficient gate: an edge rebound to a different EXISTING entity leaves
+// this number untouched, and a mis-bind onto a placeholder that does exist can
+// even IMPROVE it (#6123).
+func cpUnboundEndpoints(d *graph.Document) int {
+	live := make(map[string]bool, len(d.Entities))
+	for _, e := range d.Entities {
+		live[e.ID] = true
+	}
+	n := 0
+	for _, r := range d.Relationships {
+		if !live[r.FromID] {
+			n++
+		}
+		if !live[r.ToID] {
+			n++
+		}
+	}
+	return n
+}
+
+// ────────────────────────────── fixture ──────────────────────────────
+//
+// A small Python corpus with cross-file imports — the construct #6129's Path-A
+// divergence rides on (IMPORTS edges that must bind to in-repo Module entities
+// rather than SCOPE.External placeholders), and which also drives the
+// module-aggregation DEPENDS_ON edges Path B gets wrong.
+//
+// EVERY BASENAME IS UNIQUE across the corpus. diff.Filter cross-invalidates
+// files sharing a basename, so a repeated one would drag the "unchanged" files
+// into the changed set, trip the too-many-changed guard, and silently turn the
+// whole gate into a full-vs-full comparison.
+
+// cpStatic writes the files that are NEVER touched between the baseline and the
+// incremental pass. They must stay out of the changed set for the run to be
+// genuinely incremental.
+func cpStatic(t *testing.T, repo string) {
+	t.Helper()
+	dvWriteFile(t, repo, "cperrs_static.py", `class CpNotFound(Exception):
+    pass
+
+
+def cp_raise(x):
+    raise CpNotFound("nope")
+`)
+	dvWriteFile(t, repo, "cpprod_static.py", `def cp_target(x):
+    return x * 3
+
+
+class CpProducer:
+    def cp_method(self, y):
+        return y + 1
+`)
+	dvWriteFile(t, repo, "cpcfg_static.py", `CP_SETTING = "abc"
+CP_OTHER = 12
+`)
+}
+
+// cpDelta writes the SINGLE file that differs between the baseline pass
+// (pass 0) and the end state (pass 1). Its imports reach into every static file
+// above, so the delta's blast radius genuinely crosses file boundaries.
+func cpDelta(t *testing.T, repo string, pass int) {
+	t.Helper()
+	dvWriteFile(t, repo, "cphandler_delta.py", fmt.Sprintf(`import cperrs_static
+import cpprod_static
+from cpprod_static import CpProducer
+from cpcfg_static import CP_SETTING
+
+
+def cp_handle(x):
+    try:
+        return cperrs_static.cp_raise(x) + %d
+    except cperrs_static.CpNotFound:
+        return cpprod_static.cp_target(x)
+
+
+def cp_use_class(y):
+    c = CpProducer()
+    return c.cp_method(y) + len(CP_SETTING)
+`, pass))
+}
+
+// cpEndState builds a pristine repo holding exactly the end state and returns a
+// CLEAN FULL REBUILD of it — the reference side of every comparison. A separate
+// repo dir keeps it uncontaminated by the baseline run's state.
+func cpEndState(t *testing.T) *graph.Document {
+	t.Helper()
+	repo := t.TempDir()
+	cpStatic(t, repo)
+	cpDelta(t, repo, 1)
+	return dvFullRebuild(t, repo, t.TempDir())
+}
+
+// ──────────────────────────── Path A gate ────────────────────────────
+
+// cpKnownPathA characterises the #6129 Path-A divergences.
+//
+// Path A is internal/extractors.TryIncremental — the daemon's in-place reindex,
+// and therefore what MCP callers see between full reindexes.
+//
+// Every entry below was OBSERVED, not predicted: the gate was written with an
+// empty allow-list, run, and each divergence it reported was characterised.
+// None of them is a comparator artefact — the comparison is unweakened and the
+// divergence set is reproducible run to run.
+//
+// Nothing here is fixed by this change. Deliberately: the point of a gate is to
+// pin today's state so tomorrow's regression is visible, and #6129 is another
+// agent's to take.
+var cpKnownPathA = []cpKnown{
+	// ── #6129, headline defect: IMPORTS bound to the wrong KIND of target ──
+	//
+	// `import cperrs_static` / `import cpprod_static` name modules that EXIST
+	// in the repo. The full rebuild binds each IMPORTS edge to the in-repo
+	// `Module` entity. The incremental run binds it to a `SCOPE.External`
+	// placeholder — asserting a dependency on a third-party package where the
+	// source imports a local one.
+	//
+	// This is the pair that motivated the whole gate: the edge is PRESENT and
+	// RESOLVED on both sides, so entity counts, edge counts and dangling-
+	// endpoint rates are all identical and all report "healthy". Only comparing
+	// the CONTENT of the bound target separates them.
+	{
+		Issue:    "#6129",
+		Why:      "Path A binds IMPORTS to a SCOPE.External placeholder instead of the real in-repo Module. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→SCOPE.External/", ":IMPORTS"},
+	},
+	{
+		Issue:    "#6129",
+		Why:      "The LOST half of the same mis-bind: the real Module target the full rebuild binds.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→Module/", ":IMPORTS"},
+	},
+
+	// ── #6129 family: a from-import left as a verbatim stub ──
+	//
+	// `from cpcfg_static import CP_SETTING` — the full rebuild binds the IMPORTS
+	// edge to cpcfg_static.py's file component; the incremental run leaves the
+	// raw "cpcfg_static.CP_SETTING" text as the endpoint. Newly characterised by
+	// this gate (not named in #6129's text) and reproduced on BOTH paths, which
+	// is why it is listed on both allow-lists rather than folded into one.
+	//
+	// Unlike the entry above this one is a LOSS, not a mis-bind, so it is the
+	// class a dangling-endpoint metric would have caught — it is listed
+	// separately precisely so the two classes never get conflated.
+	{
+		Issue:    "#6129",
+		Why:      "from-import of a module constant is left as a verbatim stub by the incremental resolver. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"→«unbound»cpcfg_static.CP_SETTING", ":IMPORTS"},
+	},
+	{
+		Issue:    "#6129",
+		Why:      "The LOST half of the same missed bind: the file component the full rebuild binds.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
+	},
+
+	// ── #6129 family: SCOPE.External placeholders survive the prune ──
+	//
+	// The full run's import-placeholder-prune drops the placeholder entities and
+	// ORPHANS the REFERENCES edges that pointed at them (the full graph keeps
+	// them pointing at a now-absent hex id). The incremental run never prunes,
+	// so the same edges stay bound to a live SCOPE.External entity. Same root
+	// cause as the headline defect — placeholder retention — seen on a different
+	// edge kind.
+	{
+		Issue:    "#6129",
+		Why:      "Incremental keeps SCOPE.External placeholders the full run's import-placeholder-prune removes. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→SCOPE.External/", ":REFERENCES"},
+	},
+	{
+		Issue:    "#6129",
+		Why:      "The LOST half: the full rebuild's orphaned REFERENCES edges left pointing at the pruned placeholder's id.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→«unbound»", ":REFERENCES"},
+	},
+
+	// ── #6129 family: builtin CALLS endpoint blanked vs retained ──
+	//
+	// `len(...)` is a Python builtin with no in-repo definition. The full
+	// rebuild finishes with an EMPTY ToID; the incremental run leaves the name
+	// "len". Both are unbound, so no dangling-count moves — but they are not the
+	// same graph, and a query joining on the endpoint sees different rows.
+	{
+		Issue:    "#6129",
+		Why:      "Incremental leaves the builtin's name on the CALLS endpoint where the full run blanks it. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"SCOPE.Operation/cp_use_class@cphandler_delta.py→«unbound»len:CALLS"},
+	},
+	{
+		Issue:    "#6129",
+		Why:      "The LOST half: the full rebuild's blank-endpoint form of the same builtin call.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Operation/cp_use_class@cphandler_delta.py→«unbound»:CALLS"},
+	},
+
+	// ── #6094 family: a duplicated row persisted into graph.fb ──
+	//
+	// The exception-type entity synthesised for `CpNotFound` is written TWICE by
+	// the incremental run, and its CONTAINS edge with it. This is the exact
+	// class #6037 taught the comparator to see (a set comparison cannot); it is
+	// pinned here with its magnitude so a 3rd copy would fail.
+	{
+		Issue:          "#6129 (duplicate-row class of #6094 / #6037)",
+		Why:            "Incremental persists a second copy of the synthesised exception-type entity. Unfixed.",
+		Bucket:         cpEntityMult,
+		Contains:       []string{"SCOPE.ExceptionType|exception:CpNotFound"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6129 (duplicate-row class of #6094 / #6037)",
+		Why:            "The CONTAINS edge to the duplicated entity, duplicated with it.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"→SCOPE.ExceptionType/exception:CpNotFound@<exception>:CONTAINS"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
+		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
+		Bucket:   cpCommunitySet,
+		Contains: []string{"community ∅: 23 member(s) in A, 24 in B"},
+	},
+
+	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──
+	//
+	// #6129 reports "an extra DEPENDS_ON test-repo → _external row" on Path A.
+	// On this fixture it lands as a WEIGHT over-count on the single aggregated
+	// row (5 where the full rebuild computes 1) rather than a second row —
+	// module aggregation folds duplicates into the weight property. The
+	// magnitude is pinned so a drift fails.
+	{
+		Issue:          "#6129 (weight over-count class of #6098)",
+		Why:            "Incremental module-aggregation over-counts the external DEPENDS_ON weight 5× (the retained placeholders above). Unfixed.",
+		Bucket:         cpEdgeProps,
+		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
+		DetailContains: []string{`weight "1"≠"5"`},
+	},
+}
+
+// TestContentParity_PathA_6129 runs the gate over Path A.
+func TestContentParity_PathA_6129(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	cpStatic(t, repo)
+	cpDelta(t, repo, 0)
+	dvFullRebuild(t, repo, stateDir) // baseline graph + diff manifest
+
+	full := cpEndState(t)
+
+	dvSeedManifest(t, repo, stateDir)
+	cpDelta(t, repo, 1)
+	// dvIncremental fails the test if TryIncremental falls back to a full
+	// reindex, which is what keeps this from becoming a full-vs-full no-op.
+	inc := dvIncremental(t, repo, stateDir)
+
+	cpAssertParity(t, "path A (extractors.TryIncremental)", full, inc, cpKnownPathA)
+}
+
+// ──────────────────────────── Path B gate ────────────────────────────
+
+// cpKnownPathB characterises the #6129 Path-B divergences.
+//
+// Path B is a SECOND Index(..., WithIncremental(stateDir)) over a populated
+// state dir — the CLI path. It is DIFFERENT code from Path A with DIFFERENT
+// defects; the two allow-lists are deliberately not shared.
+var cpKnownPathB = []cpKnown{
+	// ── #6129, headline Path-B defect: a DEPENDS_ON SELF-EDGE ──
+	//
+	// The incremental run emits `CpProducer → CpProducer` — a module-aggregation
+	// dependency from an entity onto itself, which a full rebuild never
+	// produces and which is meaningless as a dependency. (#6129 records the same
+	// shape as `ProdClassU → ProdClassU` on the #6119 fixture.) Edge counts move
+	// by one in a direction that reads as "more resolved".
+	{
+		Issue:    "#6129",
+		Why:      "Path B emits a spurious DEPENDS_ON self-edge a full rebuild does not. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"Controller/CpProducer@cpprod_static.py→Controller/CpProducer@cpprod_static.py:DEPENDS_ON"},
+	},
+
+	// ── #6129, second Path-B defect: duplicated file→external DEPENDS_ON ──
+	//
+	// The `scope:component:file:* → *[SCOPE.External]` rows #6129 names are not
+	// merely present — they are present TWICE where the full rebuild has one.
+	// A set comparison cannot see this at all (#6037); a count comparison sees
+	// "more edges" and cannot say which. Magnitude pinned.
+	{
+		Issue:          "#6129",
+		Why:            "Path B duplicates the file→SCOPE.External DEPENDS_ON rows. Unfixed.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"«unbound»scope:component:file:cphandler_delta.py→SCOPE.External/", ":DEPENDS_ON"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+
+	// ── Shared with Path A: the from-import left as a verbatim stub ──
+	//
+	// Identical shape to the Path-A entry of the same name. Listed separately
+	// rather than shared because the two paths are different code: if one is
+	// fixed and the other is not, the stale-entry check must fail on exactly the
+	// path that was fixed.
+	{
+		Issue:    "#6129",
+		Why:      "from-import of a module constant is left as a verbatim stub by the incremental resolver. Unfixed.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"→«unbound»cpcfg_static.CP_SETTING", ":IMPORTS"},
+	},
+	{
+		Issue:    "#6129",
+		Why:      "The LOST half of the same missed bind: the file component the full rebuild binds.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
+	},
+}
+
+// TestContentParity_PathB_6129 runs the gate over Path B.
+func TestContentParity_PathB_6129(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	cpStatic(t, repo)
+	cpDelta(t, repo, 0)
+	dvFullRebuild(t, repo, stateDir)
+
+	full := cpEndState(t)
+
+	dvSeedManifest(t, repo, stateDir)
+	cpDelta(t, repo, 1)
+	// cfPathBIncremental asserts from the run's own stderr that the incremental
+	// branch was taken and that no full-reindex fallback fired.
+	inc := cfPathBIncremental(t, repo, stateDir)
+
+	cpAssertParity(t, "path B (Index + WithIncremental)", full, inc, cpKnownPathB)
+}

--- a/internal/graph/parity/content_key_6129_test.go
+++ b/internal/graph/parity/content_key_6129_test.go
@@ -1,0 +1,130 @@
+// Package parity — content_key_6129_test.go
+//
+// Direct coverage for Options.ContentKeyedIdentity (#6129): the endpoint keying
+// that makes a REBOUND edge — one that resolves to a different entity rather
+// than disappearing — visible as a LOST/INVENTED pair naming both targets.
+//
+// The end-to-end gate lives in cmd/grafel/incremental_content_parity_6129_test.go;
+// these cases pin the comparator behaviour it depends on, independently of the
+// indexer.
+package parity
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+func ckEnt(id, kind, name, file string) graph.Entity {
+	return graph.Entity{ID: id, Kind: kind, Name: name, SourceFile: file}
+}
+
+func ckRel(from, to, kind string) graph.Relationship {
+	return graph.Relationship{ID: graph.RelationshipID(from, to, kind), FromID: from, ToID: to, Kind: kind}
+}
+
+// ckDoc builds a document with three entities and one CALLS edge from `caller`
+// to whichever of the two targets `to` names.
+func ckDoc(to string) *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			ckEnt("aaaaaaaaaaaaaaa1", "SCOPE.Operation", "caller", "caller.go"),
+			ckEnt("aaaaaaaaaaaaaaa2", "SCOPE.Operation", "wanted", "wanted.go"),
+			ckEnt("aaaaaaaaaaaaaaa3", "SCOPE.External", "wanted", ""),
+		},
+		Relationships: []graph.Relationship{ckRel("aaaaaaaaaaaaaaa1", to, "CALLS")},
+	}
+}
+
+// TestContentKeyedIdentity_RebindIsLostPlusInvented_6129 is the core case: both
+// graphs hold exactly one CALLS edge from the same source, both endpoints
+// resolve to a real entity, and both graphs have identical entity and edge
+// counts and zero dangling endpoints. Only the BOUND TARGET differs.
+//
+// This is the shape #6037/#6094/#6123/#6129 all shared and that every aggregate
+// metric reports as healthy.
+func TestContentKeyedIdentity_RebindIsLostPlusInvented_6129(t *testing.T) {
+	full := ckDoc("aaaaaaaaaaaaaaa2") // binds the real in-repo operation
+	inc := ckDoc("aaaaaaaaaaaaaaa3")  // binds the SCOPE.External placeholder
+
+	rep := CompareWithOptions(full, inc, Options{ContentKeyedIdentity: true})
+	if rep.Equivalent {
+		t.Fatalf("a rebound edge compared EQUIVALENT — the comparator is blind to the "+
+			"exact divergence class #6129 is about:\n%s", rep.String())
+	}
+	if len(rep.RelsOnlyInA) != 1 || len(rep.RelsOnlyInB) != 1 {
+		t.Fatalf("want exactly one LOST and one INVENTED edge, got %d/%d:\n%s",
+			len(rep.RelsOnlyInA), len(rep.RelsOnlyInB), rep.String())
+	}
+	// The diff must NAME both targets, not print two hex ids.
+	if !strings.Contains(rep.RelsOnlyInA[0], "SCOPE.Operation/wanted@wanted.go") {
+		t.Errorf("LOST key does not name the full rebuild's target: %q", rep.RelsOnlyInA[0])
+	}
+	if !strings.Contains(rep.RelsOnlyInB[0], "SCOPE.External/wanted@") {
+		t.Errorf("INVENTED key does not name the incremental result's target: %q", rep.RelsOnlyInB[0])
+	}
+}
+
+// TestContentKeyedIdentity_UnboundEndpointIsDistinctFromBound_6129 pins that an
+// endpoint binding to NOTHING never compares equal to one binding to a real
+// entity — the missed-bind half of the divergence set, kept distinct from the
+// mis-bind half above.
+func TestContentKeyedIdentity_UnboundEndpointIsDistinctFromBound_6129(t *testing.T) {
+	full := ckDoc("aaaaaaaaaaaaaaa2")
+	inc := ckDoc("some.dotted.stub") // verbatim stub, resolves to nothing
+
+	rep := CompareWithOptions(full, inc, Options{ContentKeyedIdentity: true})
+	if rep.Equivalent {
+		t.Fatalf("an unresolved endpoint compared EQUIVALENT to a resolved one:\n%s", rep.String())
+	}
+	if len(rep.RelsOnlyInB) != 1 || !strings.Contains(rep.RelsOnlyInB[0], "«unbound»some.dotted.stub") {
+		t.Fatalf("INVENTED key should carry the verbatim unbound endpoint, got %v:\n%s",
+			rep.RelsOnlyInB, rep.String())
+	}
+}
+
+// TestContentKeyedIdentity_IdenticalGraphsAreEquivalent_6129 is the
+// false-positive guard: the option must not manufacture divergences. Without
+// this, the two cases above could be satisfied by a comparator that reports
+// everything as different.
+func TestContentKeyedIdentity_IdenticalGraphsAreEquivalent_6129(t *testing.T) {
+	rep := CompareWithOptions(ckDoc("aaaaaaaaaaaaaaa2"), ckDoc("aaaaaaaaaaaaaaa2"),
+		Options{ContentKeyedIdentity: true})
+	if !rep.Equivalent {
+		t.Fatalf("identical graphs compared NON-equivalent under content keying:\n%s", rep.String())
+	}
+}
+
+// TestContentKeyedIdentity_IsMultiset_6129 confirms the #6037 multiset property
+// survives content keying: a duplicated edge is not folded into its twin by the
+// change of key.
+func TestContentKeyedIdentity_IsMultiset_6129(t *testing.T) {
+	full := ckDoc("aaaaaaaaaaaaaaa2")
+	inc := ckDoc("aaaaaaaaaaaaaaa2")
+	inc.Relationships = append(inc.Relationships, inc.Relationships[0])
+
+	rep := CompareWithOptions(full, inc, Options{ContentKeyedIdentity: true})
+	if rep.Equivalent || len(rep.RelMultiplicityDiffs) != 1 {
+		t.Fatalf("a duplicated edge was not reported as a multiplicity divergence "+
+			"(equivalent=%v, mult diffs=%d):\n%s",
+			rep.Equivalent, len(rep.RelMultiplicityDiffs), rep.String())
+	}
+}
+
+// TestContentKeyedIdentity_IsOptIn_6129 pins that the new option changes nothing
+// by default: the pre-existing id-keyed behaviour is untouched, so every
+// existing caller of Compare / CompareWithOptions is unaffected.
+func TestContentKeyedIdentity_IsOptIn_6129(t *testing.T) {
+	full := ckDoc("aaaaaaaaaaaaaaa2")
+	inc := ckDoc("aaaaaaaaaaaaaaa3")
+
+	rep := Compare(full, inc)
+	if rep.Equivalent {
+		t.Fatalf("default (id-keyed) comparison should still see the rebind as a diff:\n%s", rep.String())
+	}
+	// ...but it reports it in raw hex, which is the legibility gap the option closes.
+	if len(rep.RelsOnlyInA) != 1 || !strings.Contains(rep.RelsOnlyInA[0], "aaaaaaaaaaaaaaa2") {
+		t.Fatalf("default keying should report the verbatim endpoint id, got %v", rep.RelsOnlyInA)
+	}
+}

--- a/internal/graph/parity/parity.go
+++ b/internal/graph/parity/parity.go
@@ -87,6 +87,38 @@ type Options struct {
 	// This is the edge-FromID normalization gap #5309 will close in the scoped
 	// resolver; until then the validator normalizes rather than false-alarms.
 	NormalizeStubEndpoints bool
+
+	// ContentKeyedIdentity keys BOTH entities and relationship endpoints by the
+	// CONTENT of the entity rather than by its hex id (#6129).
+	//
+	// Why this exists. The default keying folds graph.EntityID into the entity
+	// key and keys an edge on its verbatim (FromID, ToID) pair. That is exact,
+	// but it is opaque and it is only as stable as the id scheme: EntityID
+	// hashes (repo, kind, name, source_file), so anything that perturbs the repo
+	// tag, and any endpoint that is NOT an entity id at all (a `SCOPE.External`
+	// placeholder, an unresolved stub), produces a key that cannot be read and
+	// cannot be compared against its counterpart on the other side.
+	//
+	// With this on, an endpoint is replaced by the content tuple
+	// `kind/name@source_file` of the entity it binds to IN ITS OWN DOCUMENT, or
+	// by `«unbound»<raw>` when it binds to nothing there. Two consequences,
+	// both load-bearing for the full-vs-incremental gate:
+	//
+	//  1. An edge that resolves to a DIFFERENT entity than the reference run
+	//     shows up as a LOST key plus an INVENTED key naming both targets, in
+	//     terms a human can act on — the exact shape (#6037, #6094, #6123,
+	//     #6129) that entity counts, edge counts, dangling rates and
+	//     one-directional diffs all report as healthy.
+	//  2. Binding to a placeholder is visibly distinct from binding to the real
+	//     in-repo entity, instead of being two opaque hex strings.
+	//
+	// Resolution is deliberately PER-DOCUMENT (unlike NormalizeStubEndpoints,
+	// which builds one name→id index over the union of both sides and would
+	// therefore fold a placeholder onto the real entity that the other side
+	// bound — hiding exactly the defect this is here to catch). The two options
+	// are independent; setting both keeps the union-normalisation OFF for the
+	// endpoint pass.
+	ContentKeyedIdentity bool
 }
 
 // Strict returns the zero-tolerance options (exact structural equality).
@@ -226,7 +258,7 @@ func CompareWithOptions(a, b *graph.Document, opts Options) Report {
 
 	compareEntities(a, b, &r, opts)
 	compareRelationships(a, b, &r, opts)
-	compareCommunities(a, b, &r)
+	compareCommunities(a, b, &r, opts)
 
 	if len(r.EntitiesOnlyInA) > 0 || len(r.EntitiesOnlyInB) > 0 ||
 		len(r.EntityFieldDiffs) > 0 || len(r.EntityMultiplicityDiffs) > 0 ||
@@ -245,7 +277,13 @@ func CompareWithOptions(a, b *graph.Document, opts Options) Report {
 // when present, but fold in the human-readable identity so the diff output is
 // legible and so two entities with a hash collision (astronomically unlikely)
 // still compare on their real fields.
-func entityKey(e graph.Entity) string {
+//
+// Under ContentKeyedIdentity the id is dropped from the key entirely and the
+// entity is identified by its content alone (#6129) — see the option's doc.
+func entityKey(e graph.Entity, opts Options) string {
+	if opts.ContentKeyedIdentity {
+		return fmt.Sprintf("%s|%s|%s|%s", e.Kind, e.Name, e.QualifiedName, e.SourceFile)
+	}
 	id := e.ID
 	if id == "" {
 		id = graph.EntityID("", e.Kind, e.Name, e.SourceFile)
@@ -254,6 +292,31 @@ func entityKey(e graph.Entity) string {
 	// the id already hashes (kind, name, source_file), so two entities that
 	// share a key necessarily share these fields.
 	return fmt.Sprintf("%s|%s|%s|%s|%s", id, e.Kind, e.Name, e.QualifiedName, e.SourceFile)
+}
+
+// contentEndpointResolver maps a relationship endpoint id to the CONTENT tuple
+// of the entity it binds to WITHIN d, or to a `«unbound»`-prefixed marker
+// carrying the verbatim endpoint when nothing in d has that id (#6129).
+//
+// It is built over a SINGLE document on purpose. Resolving against the union of
+// both sides would let an endpoint that binds to a `SCOPE.External` placeholder
+// on one side match the real in-repo entity the other side bound, which is the
+// divergence class this whole option exists to expose.
+func contentEndpointResolver(d *graph.Document) func(string) string {
+	byID := make(map[string]graph.Entity, len(d.Entities))
+	for _, e := range d.Entities {
+		if e.ID != "" {
+			if _, seen := byID[e.ID]; !seen {
+				byID[e.ID] = e
+			}
+		}
+	}
+	return func(id string) string {
+		if e, ok := byID[id]; ok {
+			return fmt.Sprintf("%s/%s@%s", e.Kind, e.Name, e.SourceFile)
+		}
+		return "«unbound»" + id
+	}
 }
 
 // compareEntities compares the two entity collections as MULTISETS (#6037).
@@ -265,8 +328,8 @@ func entityKey(e graph.Entity) string {
 // slice order. Grouping instead of overwriting fixes both: row COUNT is compared
 // per key, and the field comparison over a duplicate group is order-independent.
 func compareEntities(a, b *graph.Document, r *Report, opts Options) {
-	mapA := groupEntities(a.Entities)
-	mapB := groupEntities(b.Entities)
+	mapA := groupEntities(a.Entities, opts)
+	mapB := groupEntities(b.Entities, opts)
 
 	for k, ga := range mapA {
 		gb, ok := mapB[k]
@@ -296,10 +359,10 @@ func compareEntities(a, b *graph.Document, r *Report, opts Options) {
 	sortFieldDiffs(r.EntityMultiplicityDiffs)
 }
 
-func groupEntities(ents []graph.Entity) map[string][]graph.Entity {
+func groupEntities(ents []graph.Entity, opts Options) map[string][]graph.Entity {
 	m := make(map[string][]graph.Entity, len(ents))
 	for _, e := range ents {
-		k := entityKey(e)
+		k := entityKey(e, opts)
 		m[k] = append(m[k], e)
 	}
 	return m
@@ -386,10 +449,15 @@ func compareRelationships(a, b *graph.Document, r *Report, opts Options) {
 	// Build a stub→entity-id resolver over the union of both entity sets so that
 	// an un-resolved cross-file edge endpoint (the incremental scoped-resolver
 	// gap) folds onto the entity it names. No-op unless NormalizeStubEndpoints.
-	resolver := newEndpointResolver(a, b, opts)
+	// Under ContentKeyedIdentity each side resolves its OWN endpoints to entity
+	// content (#6129); otherwise both sides share the union-normalising resolver.
+	resolveA, resolveB := newEndpointResolver(a, b, opts), newEndpointResolver(a, b, opts)
+	if opts.ContentKeyedIdentity {
+		resolveA, resolveB = contentEndpointResolver(a), contentEndpointResolver(b)
+	}
 
-	mapA := groupRelationships(a.Relationships, resolver, opts)
-	mapB := groupRelationships(b.Relationships, resolver, opts)
+	mapA := groupRelationships(a.Relationships, resolveA, opts)
+	mapB := groupRelationships(b.Relationships, resolveB, opts)
 
 	for k, ga := range mapA {
 		gb, ok := mapB[k]
@@ -472,14 +540,14 @@ func relGroupPropDiff(ga, gb []graph.Relationship, opts Options) string {
 // Only entities present in BOTH graphs are considered for assignment parity —
 // entities that are added/removed are already reported by compareEntities, and
 // re-reporting their (necessarily different) community here would be noise.
-func compareCommunities(a, b *graph.Document, r *Report) {
+func compareCommunities(a, b *graph.Document, r *Report, opts Options) {
 	keyA := make(map[string]graph.Entity, len(a.Entities))
 	for _, e := range a.Entities {
-		keyA[entityKey(e)] = e
+		keyA[entityKey(e, opts)] = e
 	}
 
 	for _, eb := range b.Entities {
-		k := entityKey(eb)
+		k := entityKey(eb, opts)
 		ea, ok := keyA[k]
 		if !ok {
 			continue // entity-set diff already reports this
@@ -498,7 +566,7 @@ func compareCommunities(a, b *graph.Document, r *Report) {
 	shared := func(d *graph.Document, other map[string]graph.Entity) map[string][]string {
 		m := make(map[string][]string)
 		for _, e := range d.Entities {
-			k := entityKey(e)
+			k := entityKey(e, opts)
 			if _, ok := other[k]; !ok {
 				continue
 			}
@@ -511,7 +579,7 @@ func compareCommunities(a, b *graph.Document, r *Report) {
 	}
 	keyB := make(map[string]graph.Entity, len(b.Entities))
 	for _, e := range b.Entities {
-		keyB[entityKey(e)] = e
+		keyB[entityKey(e, opts)] = e
 	}
 	memA := shared(a, keyB)
 	memB := shared(b, keyA)


### PR DESCRIPTION
Four defects in two days shared one shape: an incremental run producing edges that resolve to a **different or spurious target** than a full rebuild — not *fewer* edges. #6037 (sets vs multisets), #6094 (one-directional diff), #6123 (a mis-bind improving the dangling metric), #6129 (`IMPORTS` bound to `SCOPE.External` placeholders).

Every metric used in this area reports that shape as healthy. This builds the instrument.

## The proof that it catches what nothing else does

Two mutations applied to the incremental path, then reverted:

**Rebind a resolved `CALLS` edge to a different existing entity.** The gate reports 4 unexpected divergences — `EDGE-LOST` on the old target, `EDGE-MULTIPLICITY 1≠2` on the new one, plus a property diff. Meanwhile the aggregate counts were:

```
edges full=56 inc=57 | entities full=23 inc=24 | unbound endpoints full=13 inc=12
```

**Byte-identical to the unmutated run.** That is the failure mode existing metrics miss, demonstrated rather than argued. Those counts are now a permanent log line so the evidence prints on every run.

**Drop a `CALLS` edge** → gate reports 2 unexpected divergences including `[EDGE-LOST] cp_handle→cp_target:CALLS`.

## And the dangling metric is not merely insufficient — it is inverted

On the unmutated baseline, the incremental Path-A graph has **fewer** unbound endpoints than the full rebuild (12 vs 13) while being demonstrably wrong. #6123's hazard is not hypothetical; it is live in the data on the default path.

## What it does

`internal/graph/parity` gains an opt-in `Options.ContentKeyedIdentity` — the #6037 comparator **extended, not replaced**, so the multiset semantics carry through and the default id-keyed path is untouched (pinned by `TestContentKeyedIdentity_IsOptIn_6129`).

- Entities keyed by content alone; id dropped from the key, since ids are not stable across runs.
- An edge endpoint is replaced by the `kind/name@source_file` tuple of the entity it binds to **in its own document**, or `«unbound»<raw>` when it binds to nothing.

**Per-document resolution is the load-bearing decision.** The pre-existing `NormalizeStubEndpoints` builds one name→id index over *both* sides, which folds a placeholder on one side onto the real entity the other side bound — hiding exactly this defect class.

The gate itself (`cmd/grafel/incremental_content_parity_6129_test.go`) runs per path: baseline full rebuild → seed manifest → one-file delta → incremental run, compared against a **clean full rebuild of the same end state in a separate repo dir**. Path A via `dvIncremental`, Path B via `cfPathBIncremental` — separate tests, separate allow-lists, because using the wrong harness shows the other path's divergence (a probe was already lost to that during #6119).

Three failure modes: an unexpected divergence, a **stale allow entry that matched nothing** — so the list can only shrink — and an inertness guard.

## It lands red on known state, allow-listed by shape

**22 divergences across ~7 distinct shapes**, deterministic across repeat runs. Manageable, so no escalation.

Path A (16): the #6129 `IMPORTS → SCOPE.External` headline (4); a from-import of a module constant left as a verbatim stub (2); `REFERENCES` placeholders the full run's `import-placeholder-prune` removes (4); a builtin `CALLS` endpoint retained vs blanked (2); a duplicated `SCOPE.ExceptionType` entity with its `CONTAINS` edge and community member (3, the #6094/#6037 duplicate-row class); and one `DEPENDS_ON` weight over-count (1).

Path B (6): the `Controller/CpProducer → Controller/CpProducer` self-edge, three `scope:component:file:* → SCOPE.External/*` rows present twice where full has one, and the same constant-import miss as Path A.

Multiplicity and property entries pin their **magnitude**, so a third copy or a drifted weight is a new divergence rather than an existing allowance.

## Four corrections to #6129, all from running the gate

1. **The "extra `DEPENDS_ON test-repo → _external` row" is not a row on this fixture.** Module aggregation folds it into a **5× weight over-count** on a single row. Same defect, different observable — a row-count check would have missed it entirely.
2. **Path B's "spurious rows" are duplicates**, 1 vs 2, not new rows. A set comparison reports them as identical.
3. **A fifth shape exists that #6129 does not name:** `from <module> import <CONSTANT>` is left as a verbatim stub on **both** paths.
4. The dangling-count inversion above.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, skips counted including subtests:

| package | exit | skips |
|---|---|---|
| `./internal/graph/...` | 0 | **0** |
| `./internal/extractors/...` | 0 | 1 |
| `./cmd/grafel/` | 0 | 8 |

All skips pre-existing perf/bench gates.

Five unit cases cover the new option, including a false-positive guard (identical graphs must compare equivalent) and the opt-in pin. Both harnesses fail loudly on full-reindex fallback; all fixture basenames are unique so `diff.Filter` cannot cross-invalidate. Graphs are read back via `LoadGraphFromDir`, never from run-log counts (#6094), never by raw `graph.fb` bytes (#6083).

`git diff f5fbad0c6 HEAD` on `incremental.go` and `incremental_prior_resolution.go` is empty — both mutations were reverted.

Refs #6129, #6037, #6094, #6123, #6098
