### PR TITLE
fix(#6129): rank SCOPE.External below real entities in the scoped name index

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -15,7 +15,8 @@
 //	#6123 — a mis-bind IMPROVES the dangling-endpoint metric while making the
 //	        graph wrong.
 //	#6129 — Path A binds IMPORTS to SCOPE.External placeholders instead of the
-//	        real in-repo Module entities; Path B emits spurious DEPENDS_ON rows.
+//	        real in-repo Module entities (since FIXED — see the allow-list);
+//	        Path B emits spurious DEPENDS_ON rows.
 //
 // Every metric used in this area historically — entity counts, relationship
 // counts, dangling-endpoint rates, one-directional diffs — reports that shape
@@ -71,12 +72,21 @@
 //
 // Known-divergence allow-list
 // ───────────────────────────
-// The #6129 divergences are REAL and UNFIXED. This gate landing red on them
+// The divergences characterised below are REAL. This gate landing red on them
 // would be correct but useless as a ratchet, so each is characterised
-// explicitly below by its exact shape, issue number and reason. Anything else —
+// explicitly by its exact shape, issue number and reason. Anything else —
 // a new divergence, or an allow-listed one that stops reproducing — fails.
 // The comparison itself is NOT weakened: no tolerance profile, no ignored edge
-// kind, no ignored property. Fixing #6129 is deliberately out of scope here.
+// kind, no ignored property.
+//
+// The ratchet has since paid for itself. #6129's headline Path-A defect was
+// fixed in internal/extractors/sresolver, and this gate — not the fixing
+// change's own tests — is what established the exact scope of that fix: three
+// allow entries went stale (both halves of the IMPORTS mis-bind and the
+// `DEPENDS_ON → _external` weight over-count, which turned out to be a
+// CONSEQUENCE of the mis-bind rather than a second defect), while a fourth was
+// re-keyed rather than deleted because the fix moved its bound target without
+// closing it. A fix's own tests could not have drawn that boundary.
 //
 // Refs #6129, #6037, #6094, #6123, #6083, #6128.
 package main
@@ -399,28 +409,26 @@ func cpEndState(t *testing.T) *graph.Document {
 var cpKnownPathA = []cpKnown{
 	// ── #6129, headline defect: IMPORTS bound to the wrong KIND of target ──
 	//
-	// `import cperrs_static` / `import cpprod_static` name modules that EXIST
-	// in the repo. The full rebuild binds each IMPORTS edge to the in-repo
-	// `Module` entity. The incremental run binds it to a `SCOPE.External`
-	// placeholder — asserting a dependency on a third-party package where the
-	// source imports a local one.
+	// FIXED — the two entries that stood here (the INVENTED
+	// `…→SCOPE.External/…:IMPORTS` half and the LOST `…→Module/…:IMPORTS` half)
+	// went STALE and were removed by the ratchet below.
 	//
-	// This is the pair that motivated the whole gate: the edge is PRESENT and
-	// RESOLVED on both sides, so entity counts, edge counts and dangling-
-	// endpoint rates are all identical and all report "healthy". Only comparing
-	// the CONTENT of the bound target separates them.
-	{
-		Issue:    "#6129",
-		Why:      "Path A binds IMPORTS to a SCOPE.External placeholder instead of the real in-repo Module. Unfixed.",
-		Bucket:   cpEdgeInvented,
-		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→SCOPE.External/", ":IMPORTS"},
-	},
-	{
-		Issue:    "#6129",
-		Why:      "The LOST half of the same mis-bind: the real Module target the full rebuild binds.",
-		Bucket:   cpEdgeLost,
-		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→Module/", ":IMPORTS"},
-	},
+	// `import cperrs_static` / `import cpprod_static` name modules that EXIST in
+	// the repo, and Path A bound each IMPORTS edge to a `SCOPE.External`
+	// placeholder instead of the in-repo `Module` — asserting a dependency on a
+	// third-party package where the source imports a local one. Root cause: the
+	// scoped resolver indexes the PREVIOUS PERSISTED graph, which is
+	// post-`external.Synthesize`, so the previous run's `ext:` placeholder
+	// competed as an ordinary name candidate and won on last-writer-wins. A full
+	// rebuild's index can never hold one, because Synthesize runs AFTER
+	// resolution. Fixed by a precedence rank in
+	// internal/extractors/sresolver/scoped.go (`externalPlaceholderRank`).
+	//
+	// This was the pair that motivated the whole gate, and it is worth keeping
+	// the reason recorded now that it no longer reproduces: the edge was PRESENT
+	// and RESOLVED on both sides, so entity counts, edge counts and
+	// dangling-endpoint rates were identical and all reported "healthy". Only
+	// comparing the CONTENT of the bound target separated them.
 
 	// ── #6129 family: a from-import left as a verbatim stub ──
 	//
@@ -446,19 +454,33 @@ var cpKnownPathA = []cpKnown{
 		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
 	},
 
-	// ── #6129 family: SCOPE.External placeholders survive the prune ──
+	// ── #6129 family: the incremental path never runs import-placeholder-prune ──
+	//
+	// STILL LIVE, but RE-KEYED by the headline fix above — this entry was
+	// updated, not deleted.
 	//
 	// The full run's import-placeholder-prune drops the placeholder entities and
 	// ORPHANS the REFERENCES edges that pointed at them (the full graph keeps
 	// them pointing at a now-absent hex id). The incremental run never prunes,
-	// so the same edges stay bound to a live SCOPE.External entity. Same root
-	// cause as the headline defect — placeholder retention — seen on a different
-	// edge kind.
+	// so the same edges stay bound to something live.
+	//
+	// Before the headline fix that "something live" was the SCOPE.External
+	// placeholder, and this entry was keyed on `→SCOPE.External/`. The fix makes
+	// the same edges bind to the real in-repo `Module` instead, so the key moved
+	// to `→Module/` while the divergence itself — full leaves the endpoint
+	// dangling, incremental binds it — is unchanged. The count evidence that
+	// this is a RE-TARGET and not a new edge: full=56/inc=57 edges, full=23/
+	// inc=24 entities and full=13/inc=12 unbound endpoints are byte-identical
+	// before and after the fix; only the bound CONTENT moved.
+	//
+	// Note the incremental answer is arguably the BETTER one here (a live Module
+	// beats a dangling hex id). Parity is still parity: the two paths must agree,
+	// and closing this one means teaching the incremental path to prune.
 	{
 		Issue:    "#6129",
-		Why:      "Incremental keeps SCOPE.External placeholders the full run's import-placeholder-prune removes. Unfixed.",
+		Why:      "Incremental never runs import-placeholder-prune, so REFERENCES edges the full run orphans stay bound. Unfixed (re-keyed from SCOPE.External to Module by the headline fix).",
 		Bucket:   cpEdgeInvented,
-		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→SCOPE.External/", ":REFERENCES"},
+		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→Module/", ":REFERENCES"},
 	},
 	{
 		Issue:    "#6129",
@@ -515,18 +537,20 @@ var cpKnownPathA = []cpKnown{
 
 	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──
 	//
-	// #6129 reports "an extra DEPENDS_ON test-repo → _external row" on Path A.
-	// On this fixture it lands as a WEIGHT over-count on the single aggregated
-	// row (5 where the full rebuild computes 1) rather than a second row —
-	// module aggregation folds duplicates into the weight property. The
-	// magnitude is pinned so a drift fails.
-	{
-		Issue:          "#6129 (weight over-count class of #6098)",
-		Why:            "Incremental module-aggregation over-counts the external DEPENDS_ON weight 5× (the retained placeholders above). Unfixed.",
-		Bucket:         cpEdgeProps,
-		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
-		DetailContains: []string{`weight "1"≠"5"`},
-	},
+	// FIXED — the entry that stood here went STALE and was removed by the
+	// ratchet.
+	//
+	// #6129 reported "an extra DEPENDS_ON test-repo → _external row" on Path A.
+	// On this fixture it landed as a WEIGHT over-count on the single aggregated
+	// row (5 where the full rebuild computes 1) rather than a second row, because
+	// module aggregation folds duplicates into the weight property.
+	//
+	// It was never an independent defect: module-aggregation was faithfully
+	// counting the mis-bound IMPORTS edges from the headline entry above, each of
+	// which pointed into `_external`. Fixing the bind removed the input, and the
+	// weight fell to the full rebuild's 1 with no change to the aggregation code.
+	// Recorded because "extra DEPENDS_ON row" reads like a separate bug in the
+	// issue text and is not one.
 }
 
 // TestContentParity_PathA_6129 runs the gate over Path A.

--- a/cmd/grafel/incremental_imports_external_6129_test.go
+++ b/cmd/grafel/incremental_imports_external_6129_test.go
@@ -1,0 +1,178 @@
+// Package main — incremental_imports_external_6129_test.go
+//
+// #6129 Path A (`internal/extractors.TryIncremental`, the daemon path — what MCP
+// callers see between full reindexes).
+//
+// The defect: an IMPORTS edge naming an in-repo Python package binds to the
+// `ext:<pkg>` / SCOPE.External placeholder instead of the real in-repo `Module`
+// entity that a full rebuild binds it to. The incremental graph therefore
+// asserts a dependency on an EXTERNAL package where the source imports a LOCAL
+// one — a wrong answer to "what does this depend on?".
+//
+// Why no existing check caught it: the mis-bind is not a loss (that class was
+// #6090). Both graphs have the same entity count, the same relationship count,
+// no dangling endpoints, and the mis-bind actually IMPROVES the dangling metric
+// (#6123) because `ext:pkgbeta` exists while a stub would not. Every count-shaped
+// or one-directional comparison reports it as healthy. So the assertions below
+// are on BOUND-TARGET CONTENT — the kind/name of the entity each edge actually
+// points at — and never on counts.
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// im6129Targets renders every IMPORTS / DEPENDS_ON edge as a single descriptor
+// naming BOTH endpoints by content, and returns the MULTISET of those
+// descriptors. Comparing the multiset between a full rebuild and an incremental
+// run is a content comparison: an edge that resolved to a different target
+// appears as one descriptor lost and one gained, and neither shows up in a
+// count of edges, entities or dangling endpoints.
+//
+// Both design choices here are load-bearing, and the first was a review catch:
+//
+//   - THE TARGET IS PART OF THE KEY, not the value. An earlier version keyed on
+//     (Kind, FromID) alone and stored the target as the map value, so two
+//     imports out of the same file collapsed onto one entry and half the
+//     assertions vanished silently. That is vacuity mode 3 in the list on the
+//     test below — the fixture has one import today, and adding a second would
+//     have disarmed it with no failure anywhere.
+//
+//   - MULTISET, not set. A duplicated row is the #6037 / #6094 class; a set
+//     comparison cannot see it. Counting occurrences means a second copy of an
+//     edge fails here rather than being folded away.
+func im6129Targets(d *graph.Document) map[string]int {
+	byID := make(map[string]graph.Entity, len(d.Entities))
+	for _, e := range d.Entities {
+		byID[e.ID] = e
+	}
+	describe := func(id string) string {
+		if e, ok := byID[id]; ok {
+			return fmt.Sprintf("%s/%s name=%q@%s", e.Kind, e.Subtype, e.Name, e.SourceFile)
+		}
+		return "«unbound»" + id
+	}
+	out := make(map[string]int)
+	for _, r := range d.Relationships {
+		if r.Kind != "IMPORTS" && r.Kind != "DEPENDS_ON" {
+			continue
+		}
+		out[fmt.Sprintf("%s: %s → %s", r.Kind, describe(r.FromID), describe(r.ToID))]++
+	}
+	return out
+}
+
+// TestIncrementalImportsBindLocalModuleNotExternal_6129 pins Path A on a corpus
+// whose only import names an in-repo package.
+//
+// THREE WAYS THIS FIXTURE CAN GO SILENTLY VACUOUS. All three were hit — two
+// while grounding the defect, one caught in review — and none announces itself:
+// the test just passes.
+//
+//  1. THE DELTA MUST TOUCH THE IMPORTING FILE. A delta on any OTHER file
+//     produces no divergence at all, even pre-fix, because the mis-bind happens
+//     when the scoped resolver RE-RESOLVES an IMPORTS edge — and it only does
+//     that for edges out of a re-extracted file. The first probe written for
+//     this defect edited a bystander file, saw full and incremental agree, and
+//     very nearly concluded the issue did not reproduce. A future edit that
+//     re-points the delta at `betaother.py` to "keep the fixture simple" would
+//     silently disarm this test.
+//
+//  2. EVERY BASENAME MUST BE UNIQUE. `diff.Filter` cross-invalidates by
+//     basename, so a repeated filename turns a 1-file delta into an N-file
+//     change and trips the too-many-changed full-reindex fallback — testing a
+//     full rebuild against a full rebuild. dvIncremental fatals on that
+//     fallback, so the incremental path is at least asserted to have run.
+//
+//  3. THE COMPARISON KEY MUST NAME THE TARGET. See im6129Targets — an earlier
+//     version keyed on (Kind, FromID) and stored the target as the value, so a
+//     second import out of the same file would have collapsed onto the first
+//     and silently dropped half the assertions. Fixed by folding both endpoints
+//     into the key and comparing multisets.
+//
+// A fourth guard is explicit rather than structural: the precondition below
+// fails loudly if the full rebuild stops producing the edge under test.
+func TestIncrementalImportsBindLocalModuleNotExternal_6129(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	dvWriteFile(t, repo, "pkgbeta/__init__.py", "VALUE = 1\n")
+	dvWriteFile(t, repo, "betamain.py", "import pkgbeta\n\ndef run():\n    return pkgbeta.VALUE\n")
+	dvWriteFile(t, repo, "betaother.py", "def other():\n    return 1\n")
+
+	dvFullRebuild(t, repo, stateDir)
+	dvSeedManifest(t, repo, stateDir)
+
+	// Re-extract the importing file. This is what makes the scoped resolver
+	// re-bind its IMPORTS edge against a name index built over the PREVIOUS
+	// PERSISTED graph — which, unlike the full resolver's index, already
+	// contains the post-synthesis `ext:pkgbeta` placeholder.
+	dvWriteFile(t, repo, "betamain.py", "import pkgbeta\n\ndef run():\n    return pkgbeta.VALUE + 1\n")
+
+	b := dvIncremental(t, repo, stateDir)
+
+	endDir := t.TempDir()
+	c := dvFullRebuild(t, repo, endDir)
+
+	full := im6129Targets(c)
+	inc := im6129Targets(b)
+
+	// Guard against a vacuous pass: the full rebuild must actually bind an
+	// IMPORTS edge to the in-repo Module, or there is no mis-bind to detect.
+	sawLocalImport := false
+	for descriptor := range full {
+		if strings.HasPrefix(descriptor, "IMPORTS: ") &&
+			strings.Contains(descriptor, `→ Module/package name="pkgbeta"`) {
+			sawLocalImport = true
+		}
+	}
+	if !sawLocalImport {
+		t.Fatalf("precondition failed: the full rebuild bound no IMPORTS edge to the "+
+			"in-repo Module \"pkgbeta\", so this case cannot detect the mis-bind.\n"+
+			"full rebuild edges:%s", im6129Render(full))
+	}
+
+	keys := make(map[string]bool, len(full)+len(inc))
+	for k := range full {
+		keys[k] = true
+	}
+	for k := range inc {
+		keys[k] = true
+	}
+	ordered := make([]string, 0, len(keys))
+	for k := range keys {
+		ordered = append(ordered, k)
+	}
+	sort.Strings(ordered)
+
+	// A re-target shows up as one LOST plus one INVENTED naming both targets —
+	// that pairing IS the mis-bind, and it is invisible to any count.
+	for _, k := range ordered {
+		switch fv, iv := full[k], inc[k]; {
+		case fv > 0 && iv == 0:
+			t.Errorf("edge present in the full rebuild but ABSENT from incremental:\n  %s", k)
+		case fv == 0 && iv > 0:
+			t.Errorf("SPURIOUS edge emitted only by the incremental path:\n  %s", k)
+		case fv != iv:
+			t.Errorf("edge row count differs: %d in the full rebuild, %d in incremental:\n  %s", fv, iv, k)
+		}
+	}
+}
+
+func im6129Render(m map[string]int) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	s := ""
+	for _, k := range keys {
+		s += fmt.Sprintf("\n  ×%d %s", m[k], k)
+	}
+	return s
+}

--- a/internal/extractors/sresolver/external_shadow_6129_test.go
+++ b/internal/extractors/sresolver/external_shadow_6129_test.go
@@ -1,0 +1,132 @@
+package sresolver_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/sresolver"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// #6129 — a synthesized SCOPE.External placeholder must never shadow a real
+// in-repo entity of the same name in the scoped name index.
+//
+// Why this can only happen on the incremental path: `external.Synthesize` runs
+// AFTER resolution on a full rebuild, so the corpus-wide resolver's name index
+// never contains an `ext:` placeholder. The scoped resolver, by contrast, builds
+// its index over `existingEntities` loaded from the PREVIOUS PERSISTED GRAPH —
+// which is post-synthesis and therefore does contain them. With a plain
+// last-writer-wins index, `ext:pkgbeta` overwrites the real `Module` named
+// "pkgbeta" and every IMPORTS edge naming that module binds to the placeholder,
+// asserting an external dependency where the source imports a local package.
+//
+// The assertion is on the BOUND TARGET, not on counts: the mis-bind produces
+// the same number of entities and edges as a full rebuild (and even improves
+// the dangling-endpoint metric), so no count-shaped check can see it.
+func TestResolveScoped_ExternalPlaceholderDoesNotShadowRealEntity(t *testing.T) {
+	// Existing (previous persisted graph) — real module first, placeholder
+	// second, which is the order that makes last-writer-wins pick the wrong one.
+	existing := []graph.Entity{
+		{ID: "aaaa1111", Name: "pkgbeta", Kind: "Module", SourceFile: "pkgbeta/__init__.py"},
+		{ID: "ext:pkgbeta", Name: "pkgbeta", Kind: "SCOPE.External", SourceFile: ""},
+	}
+	// …and the reverse order, which must land on the same answer.
+	reversed := []graph.Entity{
+		{ID: "ext:pkgbeta", Name: "pkgbeta", Kind: "SCOPE.External", SourceFile: ""},
+		{ID: "aaaa1111", Name: "pkgbeta", Kind: "Module", SourceFile: "pkgbeta/__init__.py"},
+	}
+
+	for _, tc := range []struct {
+		name string
+		ents []graph.Entity
+	}{
+		{"real-then-placeholder", existing},
+		{"placeholder-then-real", reversed},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			newRels := []graph.Relationship{{ID: "r1", FromID: "bbbb2222", ToID: "pkgbeta", Kind: "IMPORTS"}}
+			res := sresolver.ResolveScoped(
+				[]graph.Entity{{ID: "bbbb2222", Name: "betamain.py", Kind: "SCOPE.Component", SourceFile: "betamain.py"}},
+				tc.ents, newRels, nil, nil,
+			)
+			if res.FallbackRequired {
+				t.Fatalf("unexpected fallback")
+			}
+			got := res.ResolvedNewRelationships[0].ToID
+			if got != "aaaa1111" {
+				t.Fatalf("IMPORTS bound to %q, want the real in-repo Module %q "+
+					"(a SCOPE.External placeholder shadowed it)", got, "aaaa1111")
+			}
+		})
+	}
+}
+
+// A name that has ONLY a SCOPE.External placeholder must still bind to it —
+// the placeholder is deliberate for genuinely external references (#6129 is
+// about a LOCAL module being classified external, not about the fallback
+// existing at all).
+func TestResolveScoped_ExternalPlaceholderStillBindsWhenNoRealEntity(t *testing.T) {
+	existing := []graph.Entity{
+		{ID: "ext:requests", Name: "requests", Kind: "SCOPE.External", SourceFile: ""},
+	}
+	newRels := []graph.Relationship{{ID: "r1", FromID: "bbbb2222", ToID: "requests", Kind: "IMPORTS"}}
+	res := sresolver.ResolveScoped(
+		[]graph.Entity{{ID: "bbbb2222", Name: "betamain.py", Kind: "SCOPE.Component", SourceFile: "betamain.py"}},
+		existing, newRels, nil, nil,
+	)
+	if got := res.ResolvedNewRelationships[0].ToID; got != "ext:requests" {
+		t.Fatalf("IMPORTS bound to %q, want the external placeholder %q", got, "ext:requests")
+	}
+}
+
+// The rank added for #6129 orders candidates ACROSS ranks only. WITHIN a rank
+// the index must stay last-writer-wins, exactly as it was before the change.
+//
+// This is pinned because the #6129 comment now ASSERTS the property, and
+// because it was previously untested in either direction: the mutation
+// `rank >= nameRank[name]` — first-writer-wins across the board — survived
+// ./internal/extractors/..., ./internal/resolve/... and ./cmd/grafel/ with
+// every suite exiting 0. Two same-rank entities sharing a name is the only
+// shape that separates the two policies, and nothing in the corpus produced
+// one, so the guard has to be written directly.
+//
+// Direction matters: `existingEntities` are indexed before `newEntities`, so a
+// freshly extracted entity is the LAST writer and must win. That is what lets
+// a re-extracted file's entity displace its own stale predecessor under the
+// same name.
+func TestResolveScoped_SameRankKeepsLastWriterWins(t *testing.T) {
+	// Both real entities (rank 0), same name, different IDs.
+	existing := []graph.Entity{
+		{ID: "aaaa1111", Name: "Shadowed", Kind: "SCOPE.Operation", SourceFile: "first.py"},
+		{ID: "bbbb2222", Name: "Shadowed", Kind: "SCOPE.Operation", SourceFile: "second.py"},
+	}
+	// A new entity under the same name is written last of all and must win over
+	// BOTH existing ones.
+	newEnts := []graph.Entity{
+		{ID: "cccc3333", Name: "Caller", Kind: "SCOPE.Operation", SourceFile: "caller.py"},
+		{ID: "dddd4444", Name: "Shadowed", Kind: "SCOPE.Operation", SourceFile: "third.py"},
+	}
+	newRels := []graph.Relationship{{ID: "r1", FromID: "cccc3333", ToID: "Shadowed", Kind: "CALLS"}}
+
+	res := sresolver.ResolveScoped(newEnts, existing, newRels, nil, nil)
+	if res.FallbackRequired {
+		t.Fatalf("unexpected fallback")
+	}
+	if got := res.ResolvedNewRelationships[0].ToID; got != "dddd4444" {
+		t.Fatalf("same-rank collision bound to %q, want the LAST writer %q — "+
+			"within a rank the index must remain last-writer-wins, and a newly "+
+			"extracted entity must be able to displace a stale same-named one",
+			got, "dddd4444")
+	}
+
+	// The same policy among EXISTING entities alone: later wins.
+	res2 := sresolver.ResolveScoped(
+		[]graph.Entity{{ID: "cccc3333", Name: "Caller", Kind: "SCOPE.Operation", SourceFile: "caller.py"}},
+		existing,
+		[]graph.Relationship{{ID: "r1", FromID: "cccc3333", ToID: "Shadowed", Kind: "CALLS"}},
+		nil, nil,
+	)
+	if got := res2.ResolvedNewRelationships[0].ToID; got != "bbbb2222" {
+		t.Fatalf("same-rank collision among existing entities bound to %q, want "+
+			"the LAST writer %q", got, "bbbb2222")
+	}
+}

--- a/internal/extractors/sresolver/scoped.go
+++ b/internal/extractors/sresolver/scoped.go
@@ -104,6 +104,94 @@ func splitFormatAStructuralRef(stub string) (filePath, name string, ok bool) {
 	return filePath, tail, true
 }
 
+// kindExternalPlaceholder is the entity kind `internal/external.Synthesize`
+// stamps on the placeholder nodes it creates for references that resolution
+// could not bind to anything in the repo. Kept in lockstep with
+// internal/types.EntityKindExternal / internal/external.KindExternal; duplicated
+// rather than imported for the same package-weight reason as the stub constants
+// above.
+const kindExternalPlaceholder = "SCOPE.External"
+
+// externalPlaceholderRank returns the precedence of e as a name-index candidate.
+// Lower wins. 0 is a real entity extracted from the repo; 1 is a synthesized
+// SCOPE.External placeholder.
+//
+// # Why the scoped resolver needs this and the corpus-wide resolver does not (#6129)
+//
+// On a full rebuild, `external.Synthesize` runs AFTER resolution. The
+// corpus-wide resolver's name index is therefore built over extracted entities
+// only and can never contain an `ext:` placeholder — an IMPORTS edge naming an
+// in-repo package binds to that package's real `Module` entity, and only genuinely
+// unbindable references survive to be given a placeholder afterwards.
+//
+// The scoped resolver's `existingEntities` come from the PREVIOUS PERSISTED
+// GRAPH, which is post-synthesis. So a placeholder synthesized for one
+// reference is visible as an ordinary name-index candidate on the next
+// incremental pass, and under plain last-writer-wins it displaced the real
+// entity: `ext:pkgbeta` overwrote the `Module` named "pkgbeta", and every
+// re-extracted `import pkgbeta` bound to the placeholder. The incremental graph
+// then asserted a dependency on an external package where the source imports a
+// local one, and module-aggregation followed the mis-bound edge into a spurious
+// `DEPENDS_ON <repo> → _external` row that no full rebuild produces.
+//
+// This is a PRECEDENCE rule, not a suppression of the placeholder. The
+// SCOPE.External fallback is deliberate and stays: a name for which no real
+// entity exists still binds to its placeholder. The rank only decides who wins a
+// COLLISION — and a collision is precisely the signal that distinguishes the two
+// cases, because a real in-repo entity carrying that exact name is the thing a
+// full rebuild would have bound to.
+//
+// What the placeholder-only case does NOT mean is parity with a full rebuild.
+// A full rebuild synthesises the placeholder after resolution and then
+// `import-placeholder-prune` drops it again, leaving the edge on a DANGLING
+// endpoint; the incremental path, which never prunes, keeps it bound to a live
+// SCOPE.External node. So on a genuinely-external name the two paths still
+// disagree — full lands on an unresolved id where this lands on the
+// placeholder. That divergence is real, is tracked on the #6130 content-parity
+// allow-list, and is NOT addressed here: this rank fixes the post-synthesis
+// half of the problem (a placeholder shadowing a real entity), not the
+// post-prune half (a placeholder surviving where a full rebuild removed it).
+// # The stricter alternative, and why it does not transfer to THIS path
+//
+// The obvious stronger fix is to exclude SCOPE.External from the scoped name
+// index ENTIRELY, making it mirror the full resolver's index exactly, and let a
+// post-merge `external.Synthesize` regenerate whatever the graph still needs —
+// which would close the post-prune half above as well.
+//
+// That reasoning holds on Path B (`Index` + `WithIncremental`) and is written
+// into cmd/grafel/index.go's merge comments, but it does NOT hold here. Path A
+// (`extractors.TryIncremental`) never synthesises: `internal/extractors` does
+// not import `internal/external` at all, and the only `external.Synthesize`
+// call in the tree is cmd/grafel/index.go:1848, inside `Index`. Every `ext:`
+// node this path sees is INHERITED from the persisted baseline that some
+// earlier full `Index` run produced, and nothing regenerates it. So excluding
+// the kind from the index here would not hand the work to a later synthesis
+// step — it would simply leave those endpoints unbound.
+//
+// (That may in fact be closer to what a full rebuild lands on, since the full
+// path prunes the placeholder and leaves the endpoint dangling. It is also
+// unmeasured, and it changes the binding of every genuinely-external name on
+// this path at once.)
+//
+// The rank is therefore the conservative choice: it alters binding ONLY where a
+// real entity and a placeholder collide. Recorded so the alternative is not
+// rediscovered from scratch — and so its Path-A precondition is not assumed.
+//
+// # Coverage limits of the rank, as it stands
+//
+//   - `SCOPE.ExternalAPI` and `SCOPE.ExternalService` are also synthetic,
+//     file-less kinds and are NOT ranked here. Whether they can shadow a real
+//     entity on this path is untested in either direction — no fixture produces
+//     the collision. Worth a follow-up rather than a silent assumption.
+//   - The measured blast radius is single-fixture (a Python corpus). No Go,
+//     JS/TS or multi-package corpus exercises this rank.
+func externalPlaceholderRank(e graph.Entity) int {
+	if e.Kind == kindExternalPlaceholder {
+		return 1
+	}
+	return 0
+}
+
 // ScopedResult is the output of ResolveScoped.
 //
 // The two relationship slices are deliberately kept SEPARATE (#6033). They have
@@ -232,10 +320,22 @@ func ResolveScoped(
 	// to the unique bare-name index. byLocation[file][name] holds "" as an
 	// ambiguity sentinel when two entities in the same file share a name.
 	byLocation := make(map[string]map[string]string)
-	addName := func(name, id string) {
-		if name != "" {
-			nameToID[name] = id
+	// nameRank records the placeholder rank (see externalPlaceholderRank) of the
+	// entity currently stored in nameToID for each name, so a synthesized
+	// SCOPE.External placeholder can never shadow a real in-repo entity of the
+	// same name. Within a rank, last-writer-wins is preserved verbatim.
+	nameRank := make(map[string]int, len(newEntities)+len(existingEntities))
+	addName := func(name, id string, rank int) {
+		if name == "" {
+			return
 		}
+		if _, seen := nameToID[name]; seen && rank > nameRank[name] {
+			// A lower-precedence candidate (an external placeholder) never
+			// displaces a real entity that already claimed this name.
+			return
+		}
+		nameToID[name] = id
+		nameRank[name] = rank
 	}
 	addLocation := func(e graph.Entity) {
 		if e.SourceFile == "" || e.Name == "" {
@@ -253,13 +353,15 @@ func ResolveScoped(
 		}
 	}
 	for _, e := range existingEntities {
-		addName(e.Name, e.ID)
-		addName(e.QualifiedName, e.ID)
+		rank := externalPlaceholderRank(e)
+		addName(e.Name, e.ID, rank)
+		addName(e.QualifiedName, e.ID, rank)
 		addLocation(e)
 	}
 	for _, e := range newEntities {
-		addName(e.Name, e.ID)
-		addName(e.QualifiedName, e.ID)
+		rank := externalPlaceholderRank(e)
+		addName(e.Name, e.ID, rank)
+		addName(e.QualifiedName, e.ID, rank)
 		addLocation(e)
 	}
 


### PR DESCRIPTION
The daemon incremental path bound `IMPORTS` edges to `SCOPE.External` placeholders instead of real in-repo `Module` entities — asserting an external dependency where the source imports a local one. Path A is the default for a watched repo, so this is what MCP callers see between full reindexes.

## Root cause

`sresolver` builds its name index (`scoped.go:235` `addName`, last-writer-wins `nameToID`) over the **previous persisted graph**, which is *post*-`external.Synthesize`. Last run's `ext:` placeholder therefore competes as an ordinary resolution candidate and, arriving later, wins.

A full rebuild's index can never hold one, because `Synthesize` runs *after* resolution.

Observed directly by instrumenting `addName`:

```
name="pkgbeta" prev=2f60344b4e3b2f77 new=ext:pkgbeta
```

| edge | full rebuild | incremental (before) |
|---|---|---|
| `IMPORTS betamain.py → …` | `Module/pkgbeta` | `SCOPE.External/pkgbeta` |
| `DEPENDS_ON test-repo → _external` | absent | present |

Not the ladder gap closed in #6098 — the receiver/leaf tiers never run, because the whole-string tier above them binds first.

## Fix

A precedence rank in the scoped name index: `SCOPE.External` = 1, real entity = 0; a higher rank never displaces a lower one. Within a rank, last-writer-wins is preserved.

**This does not suppress the fallback.** The signal distinguishing "genuinely external" from "local mis-classified" is the collision itself — a real in-repo entity carrying that exact name is what a full rebuild would have bound to. A name with only a placeholder still binds to it.

The spurious `DEPENDS_ON test-repo → _external` is a **consequence**, not an independent defect: one change removes both.

## No inversion — the attack that would have broken it

Review ran the case that worries most: a local package `logging/` alongside `import logging` and `import requests` in one file.

The full rebuild **also** binds `import logging` → `Module/logging`. That is pre-existing full-resolver semantics, not something this fix invented — so the fix restores parity rather than introducing a new preference. `import requests` correctly stays external on both paths.

The stale-carry-forward attack also fails: with `pkgbeta/__init__.py` deleted in the delta while the import survives, the incremental path does not retain a stale `Module` — it lands on `SCOPE.External/pkgbeta`, leaving only the already-allow-listed no-prune divergence.

## The parity gate validated this, and caught what a clean story would have missed

`f25a0cbca` shipped a content-keyed full-vs-incremental parity gate with these divergences allow-listed and a ratchet: **a stale allow entry that matches nothing is a failure**.

After rebasing, the gate reported **4 stale entries *and* 2 divergences not on the list** — not the clean "everything went stale" outcome.

The 2 are a **re-key, not a regression**: the `REFERENCES` entry's divergence is still live (the full run's `import-placeholder-prune` orphans those edges; the incremental path never prunes), and this fix only moved *what they bind to*, `SCOPE.External/x` → `Module/x`, so the old key stopped matching. Same source endpoint, same kind, same multiplicity before and after.

That entry was **updated in place rather than deleted**, so the gate still covers a live defect. Deleting it would have been the papering-over.

Counts are byte-identical before and after — `edges full=56 inc=57 | entities full=23 inc=24 | unbound 13/12` — so edges were re-targeted, none added or removed. Review measured the blast radius independently: base gate PASS with 16 tolerated divergences, branch PASS with 11, **exactly 5 changed**, and no other edge kind changed binding on this fixture.

## A sub-claim in #6129 is retracted, with an arithmetic proof

The `DEPENDS_ON → _external` **weight over-count was never an independent defect**. Module aggregation was faithfully counting its inputs: pre-fix weight **5** (4 mis-bound edges), post-fix **1** (0), and under a mutation restoring the mis-bind for `REFERENCES` only it lands on exactly **3** (2). No aggregation defect exists.

## The generalisation, narrowed twice

*"The incremental path re-resolves against a post-synthesis, post-prune entity set the full resolver never sees."*

That sentence is sound but explains **fewer observations than first claimed**, and this fix addresses **only the post-synthesis half**. The post-prune half is untouched — which is exactly why the `REFERENCES` entry re-keyed instead of closing.

Of the three remaining divergences, only the prune case belongs to this framing. The Python `from pkg import mod` stub loss is a **weaker ladder** (missing tier, #6098's class); the builtin `CALLS` blank-vs-name is **endpoint normalisation**. Tracked as #6131.

## A recorded design alternative — and the correction to it

The stricter fix suggested in review was: exclude `SCOPE.External` from the scoped index outright, mirroring the full resolver's index exactly, and let post-merge `Synthesize` regenerate what the graph needs.

**That does not transfer to Path A, and the evidence cited for it was Path B's.** Grounded:

- `internal/extractors` does **not import `internal/external` at all**
- the **only** `external.Synthesize` call in the tree is `cmd/grafel/index.go:1848`, inside `Index`

So Path A never synthesises. Every `ext:` node it sees is *inherited* from a baseline some earlier full `Index` produced, and nothing regenerates it. Excluding placeholders there would not hand the work to a later step — it would leave those endpoints **unbound**. (Possibly *closer* to the full rebuild's post-prune dangling endpoint — but unmeasured, and it would change every genuinely-external binding at once.)

Recorded on the function with its Path-A precondition explicit, so the idea survives without the false premise.

## Tests

- `TestResolveScoped_SameRankKeepsLastWriterWins` — added because review found the "LWW preserved verbatim" claim was asserted by a comment and enforced by nothing (mutating to first-writer-wins survived every suite). Now dies: `same-rank collision bound to "aaaa1111", want the LAST writer "dddd4444"`. Two assertions, since direction is load-bearing — a new entity must beat both existing ones (what lets a re-extracted file displace its own stale predecessor), and among existing entities the later must still win.
- `im6129Targets` re-keyed to a **multiset** naming both endpoints by content. It previously keyed on `(Kind, FromID)` and overwrote, so a second import from one file would have silently dropped half the assertions — the same silent-disarming class the file's own header warns about twice. Duplicated rows (#6037/#6094 class) now fail rather than folding away. Documented as vacuity mode 3.
- The delta must edit the **importing** file: a delta on a file with no imports produces no divergence at all. An early probe edited a bystander and came close to concluding the defect did not reproduce. Documented alongside the `diff.Filter` basename trap.

Mutants killed: revert the rank · invert it · apply it to `IMPORTS` only · first-writer-wins. The gate is a killer for three of the four.

Review caught a **false negative in its own battery**: the first "IMPORTS-only" mutation bypassed just the whole-string tier and passed everything, because the `REFERENCES` stubs are Format-A and resolve via the tail lookup — it would have wrongly reported the rank has no effect outside `IMPORTS`. Re-implemented over the full ladder, it dies.

## Bounds, stated rather than left silent

- The blast-radius result is a **single-fixture Python measurement**, not a general proof. No Go, JS/TS, or multi-package corpus exercises the rank.
- `SCOPE.ExternalAPI` and `SCOPE.ExternalService` are also synthetic file-less kinds **not covered** by the rank. Whether they can shadow a real entity here is untested in either direction — follow-up-worthy.
- Path B does not share the cause (`cmd/grafel/index.go` never imports `sresolver`). Its `scope:component:file:*` half no longer reproduces on this base; its `ProdClassU → ProdClassU` self-edge does, from a separate root cause, left alone.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, skips counted including subtests:

| package | exit | skips |
|---|---|---|
| `./internal/extractors/...` | 0 | 1 |
| `./internal/resolve/...` | 0 | 6 |
| `./cmd/grafel/` | 0 | 8 |
| `./internal/graph/...` | 0 | **0** |

All skips pre-existing.

Independently adversarially reviewed (APPROVE), with two medium findings addressed on top.

Refs #6129, #6131, #6130, #6098, #6037, #6094
