### PR TITLE
fix(#6131): stop import-placeholder-prune orphaning REFERENCES edges on the full path

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -454,40 +454,32 @@ var cpKnownPathA = []cpKnown{
 		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
 	},
 
-	// ── #6129 family: the incremental path never runs import-placeholder-prune ──
+	// ── #6131: REFERENCES edges the full run's import-placeholder-prune orphaned ──
 	//
-	// STILL LIVE, but RE-KEYED by the headline fix above — this entry was
-	// updated, not deleted.
+	// FIXED — the two entries that stood here (the INVENTED
+	// `…→Module/…:REFERENCES` half and the LOST `…→«unbound»<hex>:REFERENCES`
+	// half) went STALE and were removed by the ratchet below.
 	//
-	// The full run's import-placeholder-prune drops the placeholder entities and
-	// ORPHANS the REFERENCES edges that pointed at them (the full graph keeps
-	// them pointing at a now-absent hex id). The incremental run never prunes,
-	// so the same edges stay bound to something live.
+	// The history is worth keeping because this divergence is the reason the
+	// ratchet's "re-key, don't delete" rule earned its place: #6129's fix moved
+	// what these edges bound to on the incremental side (SCOPE.External → the
+	// real in-repo Module) WITHOUT closing the divergence, so the entries were
+	// updated in place and kept covering a live defect.
 	//
-	// Before the headline fix that "something live" was the SCOPE.External
-	// placeholder, and this entry was keyed on `→SCOPE.External/`. The fix makes
-	// the same edges bind to the real in-repo `Module` instead, so the key moved
-	// to `→Module/` while the divergence itself — full leaves the endpoint
-	// dangling, incremental binds it — is unchanged. The count evidence that
-	// this is a RE-TARGET and not a new edge: full=56/inc=57 edges, full=23/
-	// inc=24 entities and full=13/inc=12 unbound endpoints are byte-identical
-	// before and after the fix; only the bound CONTENT moved.
-	//
-	// Note the incremental answer is arguably the BETTER one here (a live Module
-	// beats a dangling hex id). Parity is still parity: the two paths must agree,
-	// and closing this one means teaching the incremental path to prune.
-	{
-		Issue:    "#6129",
-		Why:      "Incremental never runs import-placeholder-prune, so REFERENCES edges the full run orphans stay bound. Unfixed (re-keyed from SCOPE.External to Module by the headline fix).",
-		Bucket:   cpEdgeInvented,
-		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→Module/", ":REFERENCES"},
-	},
-	{
-		Issue:    "#6129",
-		Why:      "The LOST half: the full rebuild's orphaned REFERENCES edges left pointing at the pruned placeholder's id.",
-		Bucket:   cpEdgeLost,
-		Contains: []string{"SCOPE.Operation/cp_handle@cphandler_delta.py→«unbound»", ":REFERENCES"},
-	},
+	// It was also the one case in this file where the INCREMENTAL answer was the
+	// better one. Full pruned the import placeholder and left the REFERENCES
+	// endpoint pointing at a hex id no entity carried; incremental never pruned
+	// and kept a live Module binding. Parity could have been restored in either
+	// direction — teaching incremental to prune (worse but consistent) or
+	// teaching full not to orphan (better, larger blast radius). Grounding
+	// PruneImportPlaceholders decided it: its own doc comment asserts the
+	// placeholders "have no incoming edges" by the time it runs, and the only
+	// previous falsification of that premise (#642, JS/TS relative IMPORTS) was
+	// answered by rewriting the edge rather than accepting the dangle. The
+	// orphaning was incidental, not intentional, so the FULL path was fixed —
+	// re-pointing each incoming edge at the entity the import resolver had
+	// ALREADY bound the same whole-module import to. See the #6131 block in
+	// internal/resolve/imports.go and `ref_repoints` in the prune's log line.
 
 	// ── #6129 family: builtin CALLS endpoint blanked vs retained ──
 	//

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -5280,13 +5280,30 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 	// or returns them as standalone rels when no carrier exists.
 	// Cross-repo linker (#566/#570/#578) match targets (file-level
 	// entities and qualified ext:<module>:<name>) are untouched.
-	prunedMerged, pruneOrphanRels, pruneStats := resolve.PruneImportPlaceholders(merged)
+	// #6131 — the prune's incoming-edge repoint must be able to target an
+	// entity that lives in the carried-forward (unchanged-file) portion of an
+	// incremental run: `merged` holds only the re-extracted files, but the
+	// resolver above already bound this run's IMPORTS edges against
+	// `indexEntities`, which includes them. Without this set the repoint would
+	// reject those targets as non-surviving and orphan the edge on exactly the
+	// path it exists to protect. Empty (nil) on a full rebuild.
+	var pruneExtraLive map[string]bool
+	if n := len(i.incrementalCarryForwardEntities); n > 0 {
+		pruneExtraLive = make(map[string]bool, n)
+		for k := range i.incrementalCarryForwardEntities {
+			if id := i.incrementalCarryForwardEntities[k].ID; id != "" {
+				pruneExtraLive[id] = true
+			}
+		}
+	}
+	prunedMerged, pruneOrphanRels, pruneStats := resolve.PruneImportPlaceholdersWithLiveIDs(merged, pruneExtraLive)
 	merged = prunedMerged
 	if pruneStats.Considered > 0 {
 		fmt.Fprintf(os.Stderr,
-			"import-placeholder-prune: considered=%d pruned=%d rels_hoisted=%d rels_orphaned=%d kept=%d edge_toid_rewrites=%d\n",
+			"import-placeholder-prune: considered=%d pruned=%d rels_hoisted=%d rels_orphaned=%d kept=%d edge_toid_rewrites=%d ref_repoints=%d\n",
 			pruneStats.Considered, pruneStats.Pruned, pruneStats.RelsHoisted,
-			pruneStats.RelsOrphaned, pruneStats.PlaceholderKept, pruneStats.EdgeToIDRewrites)
+			pruneStats.RelsOrphaned, pruneStats.PlaceholderKept, pruneStats.EdgeToIDRewrites,
+			pruneStats.PlaceholderRefRepoints)
 	}
 	if len(pruneOrphanRels) > 0 {
 		// Migrate to the standalone pass2Rels stream so the

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2993,17 +2993,56 @@ func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive 
 	// (`SCOPE.Component/file/cphandler_delta.py --IMPORTS--> Module/cperrs_static`).
 	// We index those and re-point incoming edges at them.
 	//
-	// Deliberately narrow, so this can only ever convert a would-be dangling
-	// endpoint into a live one:
+	// Deliberately narrow. Four guards, each with a test that fails when it is
+	// removed (see imports_test.go — the file-scoping one especially, which
+	// survived a parity gate and a multi-language corpus diff before it had a
+	// case of its own):
 	//   - only placeholders that are actually being PRUNED are considered;
-	//   - only WHOLE-MODULE imports (imported_name == source_module) supply a
-	//     target — a member import (`from m import Thing`) resolves to the
-	//     member, not to the module the placeholder stands for;
+	//   - a resolution is scoped to the IMPORTER FILE it was found in. When one
+	//     file's import of a module resolved and another's did not, borrowing
+	//     the first file's target invents a cross-file reference nobody wrote —
+	//     a confident mis-bind, which is worse than the dangle being repaired.
+	//     The ambiguity guard below does NOT cover this: an unscoped key sees
+	//     one resolution, not a conflict;
+	//   - only WHOLE-MODULE imports supply a target. The test is
+	//     `imported_name == source_module`, i.e. the imported name IS the
+	//     module name, which is exactly what the placeholder stands for. A
+	//     member import (`from m import Thing`) resolves to Thing and supplies
+	//     nothing. Note `from x import x` legitimately passes: in Python that
+	//     rebinds the local name to the submodule, so a reference to `x` SHOULD
+	//     follow that IMPORTS target. It is intended behaviour, not an escape;
 	//   - a module resolving to two different targets within one file is
 	//     ambiguous and supplies nothing;
-	//   - the target must be a surviving record. Re-pointing at another
-	//     pruned placeholder would just move the dangle.
-	// No edge is created or removed and no already-live endpoint is touched.
+	//   - the target must be a surviving record (or, on the incremental path,
+	//     a known-live carried-forward id). Re-pointing at another pruned
+	//     placeholder would just move the dangle.
+	//
+	// No edge is created or removed. Endpoints are moved only where the ToID
+	// equals the stamped id of a placeholder being pruned — which is a
+	// would-be-dangling endpoint by construction, PROVIDED no surviving entity
+	// shares that id. That proviso is not free: graph.EntityID hashes
+	// repo/kind/name/sourceFile and NOT Subtype (internal/graph/graph.go:259),
+	// so a `SCOPE.Component` placeholder named M in file F collides with any
+	// other `SCOPE.Component` named M in F, and edges legitimately bound to the
+	// survivor would move with it. No reachable instance is known and the
+	// collision is pre-existing — every id-keyed pass in this function,
+	// including the #642 rewrite above, rests on the same assumption — but it
+	// is the precondition this block actually relies on, so it is stated
+	// rather than implied.
+	//
+	// Reachability. Both halves must be present in the same file: a placeholder
+	// with Subtype=="import", AND an IMPORTS edge carrying source_module ==
+	// imported_name resolved to a surviving entity. That excludes more
+	// languages than it looks. Go and Java import placeholders leave Subtype
+	// EMPTY (internal/extractors/golang/extractor.go ~2449;
+	// internal/extractors/java/references.go:194 says so outright), so they are
+	// never pruned and never repointed — `SCOPE.Component/fmt@…` survives as a
+	// live entity. JS/TS relative imports are already carried across by the
+	// #642 rewrite above. The placeholders this block actually repairs come
+	// from internal/extractors/cross/imports (Python and its siblings) and any
+	// other extractor emitting both halves. ONLY PYTHON IS EXERCISED, by the
+	// tests here and by the parity gate; the sibling languages are reachable
+	// and unmeasured.
 	if repoints := buildPlaceholderRepoints(records, prunable, extraLive); len(repoints) > 0 {
 		for i := range records {
 			r := &records[i]
@@ -3098,7 +3137,12 @@ func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, ext
 		}
 	}
 
-	// Placeholders being pruned, keyed by importer file then module string.
+	// Placeholders being pruned, keyed by importer file AND module string.
+	// The file component of this key is load-bearing, not incidental: without
+	// it a resolution found in one file supplies a target for a placeholder in
+	// another, which invents a cross-file reference. The ambiguity guard below
+	// does not catch that case — see
+	// TestPruneImportPlaceholders_RepointTargetIsFileScoped.
 	// Nothing to repair if there are none.
 	type phKey struct{ file, module string }
 	phIDs := make(map[phKey][]string)
@@ -3144,8 +3188,11 @@ func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, ext
 			if module == "" {
 				continue
 			}
-			// Whole-module import only. `from m import Thing` resolves to
-			// Thing, which is not what the placeholder for `m` stands for.
+			// Whole-module import only: the imported name IS the module name,
+			// which is what the placeholder stands for. `from m import Thing`
+			// resolves to Thing and is not a candidate. `from x import x`
+			// passes and SHOULD — in Python that rebinds the local name to the
+			// submodule, so a reference to `x` follows this IMPORTS target.
 			if rel.Properties.Get("imported_name") != module {
 				continue
 			}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2757,6 +2757,14 @@ type PruneImportPlaceholderStats struct {
 	// stops rewriting (and therefore drops every JS/TS relative
 	// IMPORTS edge from the graph) is visible.
 	EdgeToIDRewrites int
+	// PlaceholderRefRepoints is the number of INCOMING edges (any kind —
+	// in practice REFERENCES) that pointed at a placeholder about to be
+	// pruned and were re-pointed at the entity the pipeline had already
+	// resolved the same (importer file, source_module) import to. See
+	// the #6131 block in the function body. Surfaced so a regression
+	// that silently stops re-pointing — and therefore starts orphaning
+	// those edges again — is visible in the indexer log.
+	PlaceholderRefRepoints int
 }
 
 // PruneImportPlaceholders removes import-placeholder entities (kind =
@@ -2766,10 +2774,16 @@ type PruneImportPlaceholderStats struct {
 // (internal/extractors/cross/imports) as a structural carrier for
 // IMPORTS / DEPENDS_ON relationships. After the import-resolver and
 // references-resolver passes have rewritten ToID / FromID values, the
-// placeholders themselves have no incoming edges — they are pure
-// structural overhead and account for the largest single bucket of
-// orphan entities on the verify2 corpus (2,583 of 9,390 fixture-b
-// orphans, root-cause analysis 2026-05-19).
+// placeholders are pure structural overhead and account for the largest
+// single bucket of orphan entities on the verify2 corpus (2,583 of 9,390
+// fixture-b orphans, root-cause analysis 2026-05-19).
+//
+// This comment used to assert that the placeholders have NO INCOMING EDGES
+// by the time this runs. That has been falsified twice — #642 (JS/TS
+// relative IMPORTS) and #6131 (Python module REFERENCES) — and both times
+// the answer was to carry the incoming edge across to a durable entity
+// rather than accept a dangling endpoint. Both repairs live in the
+// pre-prune blocks below; do not re-introduce the assumption.
 //
 // The function preserves the placeholders' embedded relationships by
 // hoisting them onto the file-level SCOPE.Component entity that
@@ -2790,6 +2804,24 @@ type PruneImportPlaceholderStats struct {
 // a stats record. The input slice's element ordering among survivors
 // is preserved.
 func PruneImportPlaceholders(records []types.EntityRecord) ([]types.EntityRecord, []types.RelationshipRecord, PruneImportPlaceholderStats) {
+	return PruneImportPlaceholdersWithLiveIDs(records, nil)
+}
+
+// PruneImportPlaceholdersWithLiveIDs is PruneImportPlaceholders with an
+// explicit extra set of entity IDs that are KNOWN TO SURVIVE into the final
+// graph even though they are absent from `records`.
+//
+// It exists for the incremental indexer path, where `records` holds only the
+// re-extracted changed files and the unchanged-file entities are spliced back
+// in after this pass runs (see `incrementalCarryForwardEntities` in
+// cmd/grafel/index.go). The #6131 repoint below must be able to re-point an
+// edge at such an entity: on that path the import resolver has already bound
+// the importing file's IMPORTS edge to a carried-forward module, and refusing
+// the target purely because it is not in `records` would leave the edge
+// orphaned on exactly the path the repoint exists to protect.
+//
+// extraLive may be nil, which is the full-rebuild case.
+func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive map[string]bool) ([]types.EntityRecord, []types.RelationshipRecord, PruneImportPlaceholderStats) {
 	var stats PruneImportPlaceholderStats
 	if len(records) == 0 {
 		return records, nil, stats
@@ -2936,6 +2968,55 @@ func PruneImportPlaceholders(records []types.EntityRecord) ([]types.EntityRecord
 		}
 	}
 
+	// Pre-prune INCOMING-edge repoint (issue #6131).
+	//
+	// This function's contract above states that by the time it runs "the
+	// placeholders themselves have no incoming edges". That premise has now
+	// been falsified twice. The first time was #642 — JS/TS relative IMPORTS,
+	// handled by the ToID rewrite above — and the answer chosen then was NOT
+	// to accept a dangling endpoint but to carry the edge across to a durable
+	// entity before dropping the placeholder. This is the second instance and
+	// takes the same answer.
+	//
+	// The shape (measured on the #6130 parity fixture): the Python extractor
+	// emits an import placeholder for `import cperrs_static`, the references
+	// resolver binds `cperrs_static.cp_raise(x)` inside a function to that
+	// placeholder's stamped id, and prune then removes the placeholder. The
+	// full rebuild's REFERENCES edge is left pointing at an id no entity
+	// carries; the incremental path, which never prunes, keeps it bound. That
+	// is the full-vs-incremental divergence #6131 tracks, and the full side is
+	// the wrong one: the pipeline HAD already resolved that import.
+	//
+	// The repair target is therefore not guessed. The same record set holds an
+	// IMPORTS edge emitted by the SAME importer file for the SAME module,
+	// already rewritten by the import resolver to the real in-repo entity
+	// (`SCOPE.Component/file/cphandler_delta.py --IMPORTS--> Module/cperrs_static`).
+	// We index those and re-point incoming edges at them.
+	//
+	// Deliberately narrow, so this can only ever convert a would-be dangling
+	// endpoint into a live one:
+	//   - only placeholders that are actually being PRUNED are considered;
+	//   - only WHOLE-MODULE imports (imported_name == source_module) supply a
+	//     target — a member import (`from m import Thing`) resolves to the
+	//     member, not to the module the placeholder stands for;
+	//   - a module resolving to two different targets within one file is
+	//     ambiguous and supplies nothing;
+	//   - the target must be a surviving record. Re-pointing at another
+	//     pruned placeholder would just move the dangle.
+	// No edge is created or removed and no already-live endpoint is touched.
+	if repoints := buildPlaceholderRepoints(records, prunable, extraLive); len(repoints) > 0 {
+		for i := range records {
+			r := &records[i]
+			for j := range r.Relationships {
+				rel := &r.Relationships[j]
+				if id, ok := repoints[rel.ToID]; ok {
+					rel.ToID = id
+					stats.PlaceholderRefRepoints++
+				}
+			}
+		}
+	}
+
 	// Second pass: compute the post-prune index for each original
 	// index. Original indices that aren't pruned land at
 	// (originalIdx - prunedBefore). Original indices that are pruned
@@ -2983,6 +3064,123 @@ func PruneImportPlaceholders(records []types.EntityRecord) ([]types.EntityRecord
 	stats.PlaceholderKept = stats.Considered - stats.Pruned
 
 	return out, orphanRels, stats
+}
+
+// buildPlaceholderRepoints maps the stamped id of each import placeholder
+// that is about to be PRUNED onto the id of the entity the import resolver
+// has already bound the same whole-module import to, within the same importer
+// file. PruneImportPlaceholders uses it to re-point incoming edges so they
+// survive the prune bound rather than dangling (issue #6131).
+//
+// prunable is indexed in parallel with records and must already be decided:
+// a placeholder that is being KEPT still has a live id, so its incoming edges
+// need no repair, and a target that is itself being pruned would only relocate
+// the dangle.
+//
+// Returns nil when there is nothing to repair, which is the common case.
+func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, extraLive map[string]bool) map[string]string {
+	// ambiguous marks a (file, module) pair with conflicting resolutions. It
+	// cannot collide with a real id because ids are hex.
+	const ambiguous = "\x00ambiguous"
+
+	// Survivor lookup. A repoint target must be a record that outlives the
+	// prune; anything else (an `ext:` qualified name, a raw module string, an
+	// id belonging to a pruned placeholder) supplies no target.
+	survivor := make(map[string]bool, len(records)+len(extraLive))
+	for i := range records {
+		if id := records[i].ID; id != "" && !prunable[i] {
+			survivor[id] = true
+		}
+	}
+	for id := range extraLive {
+		if id != "" {
+			survivor[id] = true
+		}
+	}
+
+	// Placeholders being pruned, keyed by importer file then module string.
+	// Nothing to repair if there are none.
+	type phKey struct{ file, module string }
+	phIDs := make(map[phKey][]string)
+	for i := range records {
+		r := &records[i]
+		if !prunable[i] || r.ID == "" {
+			continue
+		}
+		if !(r.Kind == "SCOPE.Component" && r.Subtype == "import") {
+			continue
+		}
+		module := r.Name
+		if r.Properties != nil {
+			if m := r.Properties["module"]; m != "" {
+				module = m
+			}
+		}
+		file := normalizePath(r.SourceFile)
+		if module == "" || file == "" {
+			continue
+		}
+		k := phKey{file: file, module: module}
+		phIDs[k] = append(phIDs[k], r.ID)
+	}
+	if len(phIDs) == 0 {
+		return nil
+	}
+
+	// Resolved whole-module IMPORTS edges, keyed the same way.
+	resolved := make(map[phKey]string, len(phIDs))
+	for i := range records {
+		r := &records[i]
+		file := normalizePath(r.SourceFile)
+		if file == "" {
+			continue
+		}
+		for j := range r.Relationships {
+			rel := &r.Relationships[j]
+			if rel.Kind != importRelKind {
+				continue
+			}
+			module := rel.Properties.Get("source_module")
+			if module == "" {
+				continue
+			}
+			// Whole-module import only. `from m import Thing` resolves to
+			// Thing, which is not what the placeholder for `m` stands for.
+			if rel.Properties.Get("imported_name") != module {
+				continue
+			}
+			k := phKey{file: file, module: module}
+			if _, want := phIDs[k]; !want {
+				continue
+			}
+			if !survivor[rel.ToID] {
+				continue
+			}
+			if prev, seen := resolved[k]; seen && prev != rel.ToID {
+				resolved[k] = ambiguous
+				continue
+			}
+			resolved[k] = rel.ToID
+		}
+	}
+
+	out := make(map[string]string, len(phIDs))
+	for k, ids := range phIDs {
+		target, ok := resolved[k]
+		if !ok || target == ambiguous {
+			continue
+		}
+		for _, id := range ids {
+			if id == target {
+				continue
+			}
+			out[id] = target
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }
 
 // resolveRelativeImportTarget resolves a JS/TS relative import string

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -1634,6 +1634,101 @@ func TestPruneImportPlaceholders_RepointsIncomingEdgesToResolvedImport(t *testin
 	}
 }
 
+// TestPruneImportPlaceholders_RepointTargetIsFileScoped pins the FIRST guard
+// on the #6131 repoint: a resolution found in one importer file must never
+// supply a target for a placeholder in a different file.
+//
+// This is the guard with the worst failure mode and the least obvious
+// coverage. The ambiguity guard only fires when the SAME key collects two
+// different targets, so it protects nothing here: when file A's `import
+// shared` resolved and file B's did not, an unscoped key sees exactly ONE
+// resolution and repoints B's reference at A's target with full confidence.
+// A confident cross-file mis-bind is strictly worse than the dangling
+// endpoint this change exists to remove — the graph gains a reference that
+// was never written.
+//
+// Dropping `file` from the repoint key survived every other test in this
+// file, the full-vs-incremental parity gate, and an independent multi-language
+// corpus diff. This case is the only thing standing under it.
+func TestPruneImportPlaceholders_RepointTargetIsFileScoped(t *testing.T) {
+	const (
+		fileA  = "a_importer.py"
+		fileB  = "b_importer.py"
+		module = "shared"
+
+		modShared = "1111111111111111" // the real module, resolved from A only
+		carrierA  = "2222222222222222"
+		carrierB  = "3333333333333333"
+		phA       = "4444444444444444"
+		phB       = "5555555555555555"
+		fnA       = "6666666666666666"
+		fnB       = "7777777777777777"
+	)
+	records := []types.EntityRecord{
+		{ID: modShared, Name: module, Kind: "Module", Subtype: "package", SourceFile: "shared.py"},
+		{
+			// File A: the import resolver bound this file's whole-module
+			// IMPORTS edge to the real module.
+			ID: carrierA, Name: fileA, Kind: "SCOPE.Component", Subtype: "file", SourceFile: fileA,
+			Relationships: []types.RelationshipRecord{
+				{FromID: carrierA, ToID: modShared, Kind: "IMPORTS",
+					Properties: types.PropsFromMap(map[string]string{"source_module": module, "imported_name": module})},
+			},
+		},
+		{
+			// File B: imports the SAME module name, but nothing resolved it —
+			// the shape a partially-resolvable corpus produces constantly.
+			// There is no target for B, and A's is not B's to borrow.
+			ID: carrierB, Name: fileB, Kind: "SCOPE.Component", Subtype: "file", SourceFile: fileB,
+		},
+		{ID: phA, Name: module, Kind: "SCOPE.Component", Subtype: "import", SourceFile: fileA},
+		{ID: phB, Name: module, Kind: "SCOPE.Component", Subtype: "import", SourceFile: fileB},
+		{
+			ID: fnA, Name: "a_handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: fileA,
+			Relationships: []types.RelationshipRecord{{FromID: fnA, ToID: phA, Kind: "REFERENCES"}},
+		},
+		{
+			ID: fnB, Name: "b_handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: fileB,
+			Relationships: []types.RelationshipRecord{{FromID: fnB, ToID: phB, Kind: "REFERENCES"}},
+		},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	if stats.PlaceholderRefRepoints != 1 {
+		t.Errorf("PlaceholderRefRepoints = %d, want 1 — only file A has a resolution; "+
+			"2 means file B borrowed it across the file boundary", stats.PlaceholderRefRepoints)
+	}
+
+	// Assert BOTH endpoints of BOTH edges as a multiset. Keying on the edge
+	// kind alone, or on the from-side alone, cannot tell "B kept its dangle"
+	// apart from "B was repointed at A's module".
+	got := map[string]int{}
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			if rel.Kind == "REFERENCES" {
+				got[rel.FromID+"->"+rel.ToID]++
+			}
+		}
+	}
+	want := map[string]int{
+		fnA + "->" + modShared: 1, // repaired from A's own resolution
+		fnB + "->" + phB:       1, // left alone: no resolution in B's file
+	}
+	if len(got) != len(want) {
+		t.Fatalf("REFERENCES multiset = %v, want %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("REFERENCES %s occurs %d time(s), want %d (full multiset: %v)", k, got[k], n, got)
+		}
+	}
+	if got[fnB+"->"+modShared] > 0 {
+		t.Errorf("file B's reference was repointed at file A's target %q — a confident "+
+			"cross-file mis-bind, which is worse than the dangle it replaced", modShared)
+	}
+}
+
 // TestPruneImportPlaceholders_RefusesAmbiguousRepointTarget pins the second
 // guard on the #6131 repoint: when one importer file carries two whole-module
 // IMPORTS edges for the SAME module that resolved to DIFFERENT entities — the

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -1524,6 +1524,266 @@ func TestPruneImportPlaceholders_RewritesIMPORTSToFileCarrier(t *testing.T) {
 	}
 }
 
+// TestPruneImportPlaceholders_RepointsIncomingEdgesToResolvedImport is the
+// #6131 post-prune half.
+//
+// PruneImportPlaceholders' contract (see its doc comment) asserts that by the
+// time it runs "the placeholders themselves have no incoming edges". That
+// premise has been falsified twice. The first time — #642, JS/TS relative
+// IMPORTS — the answer was NOT to accept the dangling endpoint but to rewrite
+// the edge before dropping the placeholder. This is the second: the Python
+// references-resolver binds a module reference (`cperrs_static.cp_raise(x)`)
+// to the import placeholder, prune drops the placeholder, and the REFERENCES
+// edge is left pointing at an id no entity carries.
+//
+// The repair target is not guessed: the SAME record set already holds an
+// IMPORTS edge, emitted by the SAME importer file for the SAME source_module,
+// that the import resolver has already bound to the real in-repo entity. The
+// prune re-points incoming edges at that, so the graph keeps the resolution
+// the pipeline had already computed instead of discarding it.
+//
+// The two incoming edges below originate from ONE entity and target TWO
+// different placeholders on purpose: an assertion keyed only on (Kind, FromID)
+// collapses them into one and passes while half the fix is missing.
+func TestPruneImportPlaceholders_RepointsIncomingEdgesToResolvedImport(t *testing.T) {
+	const (
+		handlerFile = "cphandler_delta.py"
+		modErrsID   = "1111111111111111" // Module cperrs_static (real, in-repo)
+		modProdID   = "2222222222222222" // Module cpprod_static (real, in-repo)
+		classProdID = "7777777777777777" // class CpProducer, member-imported
+		fileCarrier = "3333333333333333" // SCOPE.Component file for the importer
+		phErrsID    = "4444444444444444" // import placeholder for cperrs_static
+		phProdID    = "5555555555555555" // import placeholder for cpprod_static
+		handlerFn   = "6666666666666666" // the function holding the REFERENCES
+	)
+	records := []types.EntityRecord{
+		{ID: modErrsID, Name: "cperrs_static", Kind: "Module", Subtype: "package", SourceFile: "cperrs_static.py"},
+		{ID: modProdID, Name: "cpprod_static", Kind: "Module", Subtype: "package", SourceFile: "cpprod_static.py"},
+		{ID: classProdID, Name: "CpProducer", Kind: "Controller", Subtype: "class", SourceFile: "cpprod_static.py"},
+		{
+			ID: fileCarrier, Name: handlerFile, Kind: "SCOPE.Component", Subtype: "file", SourceFile: handlerFile,
+			// Already resolved by the import-aware resolver: these are the
+			// bindings the prune must propagate rather than discard.
+			Relationships: []types.RelationshipRecord{
+				{FromID: fileCarrier, ToID: modErrsID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "cperrs_static", "imported_name": "cperrs_static", "local_name": "cperrs_static"})},
+				{FromID: fileCarrier, ToID: modProdID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "cpprod_static", "imported_name": "cpprod_static", "local_name": "cpprod_static"})},
+				// `from cpprod_static import CpProducer` — SAME source_module,
+				// DIFFERENT target. The placeholder stands for the module, not
+				// the member, so an implementation that keyed on source_module
+				// alone would either bind the REFERENCES edge to the class or
+				// declare the pair ambiguous and repair nothing. Both are
+				// caught by the assertions below; this row is what makes the
+				// whole-module guard load-bearing rather than decorative.
+				{FromID: fileCarrier, ToID: classProdID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "cpprod_static", "imported_name": "CpProducer", "local_name": "CpProducer"})},
+			},
+		},
+		{ID: phErrsID, Name: "cperrs_static", Kind: "SCOPE.Component", Subtype: "import", SourceFile: handlerFile},
+		{ID: phProdID, Name: "cpprod_static", Kind: "SCOPE.Component", Subtype: "import", SourceFile: handlerFile},
+		{
+			ID: handlerFn, Name: "cp_handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: handlerFile,
+			Relationships: []types.RelationshipRecord{
+				{FromID: handlerFn, ToID: phErrsID, Kind: "REFERENCES"},
+				{FromID: handlerFn, ToID: phProdID, Kind: "REFERENCES"},
+			},
+		},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	if stats.Pruned != 2 {
+		t.Fatalf("expected both placeholders pruned, got %d", stats.Pruned)
+	}
+	if stats.PlaceholderRefRepoints != 2 {
+		t.Errorf("PlaceholderRefRepoints = %d, want 2 (one per incoming REFERENCES edge)", stats.PlaceholderRefRepoints)
+	}
+
+	// Multiset over BOTH endpoints. Keying on (Kind, FromID) alone would let a
+	// fix that repaired only the first edge pass.
+	live := make(map[string]bool, len(out))
+	for _, e := range out {
+		live[e.ID] = true
+	}
+	got := map[string]int{}
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			if rel.Kind != "REFERENCES" {
+				continue
+			}
+			got[e.ID+"|"+rel.FromID+"->"+rel.ToID]++
+		}
+	}
+	want := map[string]int{
+		handlerFn + "|" + handlerFn + "->" + modErrsID: 1,
+		handlerFn + "|" + handlerFn + "->" + modProdID: 1,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("REFERENCES multiset = %v, want %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("REFERENCES %s occurs %d time(s), want %d (full multiset: %v)", k, got[k], n, got)
+		}
+	}
+	// The point of the exercise: nothing dangles.
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			if rel.Kind == "REFERENCES" && !live[rel.ToID] {
+				t.Errorf("REFERENCES from %s left dangling at %q after prune", e.ID, rel.ToID)
+			}
+		}
+	}
+}
+
+// TestPruneImportPlaceholders_RefusesAmbiguousRepointTarget pins the second
+// guard on the #6131 repoint: when one importer file carries two whole-module
+// IMPORTS edges for the SAME module that resolved to DIFFERENT entities — the
+// shape a multi-carrier language produces when a module name maps to both a
+// package entity and a file entity — there is no single answer, and guessing
+// one would silently re-point a reference at the wrong target. The edge is
+// left exactly as the prune leaves it today instead.
+//
+// Without this case a last-write-wins implementation passes every other test
+// in this file.
+func TestPruneImportPlaceholders_RefusesAmbiguousRepointTarget(t *testing.T) {
+	const (
+		f      = "app.py"
+		modA   = "1111111111111111"
+		modB   = "2222222222222222"
+		fileC  = "3333333333333333"
+		ph     = "4444444444444444"
+		fn     = "6666666666666666"
+		module = "shared"
+	)
+	whole := func(to string) types.RelationshipRecord {
+		return types.RelationshipRecord{FromID: fileC, ToID: to, Kind: "IMPORTS",
+			Properties: types.PropsFromMap(map[string]string{"source_module": module, "imported_name": module})}
+	}
+	records := []types.EntityRecord{
+		{ID: modA, Name: module, Kind: "Module", Subtype: "package", SourceFile: "shared/__init__.py"},
+		{ID: modB, Name: module + ".py", Kind: "SCOPE.Component", Subtype: "file", SourceFile: "shared.py"},
+		{
+			ID: fileC, Name: f, Kind: "SCOPE.Component", Subtype: "file", SourceFile: f,
+			Relationships: []types.RelationshipRecord{whole(modA), whole(modB)},
+		},
+		{ID: ph, Name: module, Kind: "SCOPE.Component", Subtype: "import", SourceFile: f},
+		{
+			ID: fn, Name: "handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: f,
+			Relationships: []types.RelationshipRecord{{FromID: fn, ToID: ph, Kind: "REFERENCES"}},
+		},
+	}
+	out, _, stats := PruneImportPlaceholders(records)
+	if stats.PlaceholderRefRepoints != 0 {
+		t.Errorf("PlaceholderRefRepoints = %d, want 0 — two whole-module resolutions for %q, no single answer",
+			stats.PlaceholderRefRepoints, module)
+	}
+	for _, e := range out {
+		if e.ID != fn {
+			continue
+		}
+		if len(e.Relationships) != 1 || e.Relationships[0].ToID != ph {
+			t.Errorf("REFERENCES = %+v, want ToID %q left untouched rather than guessed", e.Relationships, ph)
+		}
+	}
+}
+
+// TestPruneImportPlaceholdersWithLiveIDs_AcceptsCarryForwardTarget covers the
+// incremental indexer's shape, where `records` holds ONLY the re-extracted
+// changed file and the import target lives in the carried-forward portion of
+// the previous graph that is spliced back in after this pass.
+//
+// The resolver has already bound the IMPORTS edge to that carried-forward id
+// (it resolves against merged + carry-forward), so the repoint target is just
+// as real as on a full rebuild — it is simply not in this slice. Judging
+// survival by `records` alone therefore orphans the edge on exactly the path
+// the repoint exists to protect, which is what made the #6131 fix fail the
+// Path-B half of the parity gate before extraLive was threaded through.
+//
+// The nil-extraLive leg is the control: it pins that the parameter is what
+// makes the difference, so a change that ignored it could not pass.
+func TestPruneImportPlaceholdersWithLiveIDs_AcceptsCarryForwardTarget(t *testing.T) {
+	const (
+		f       = "cphandler_delta.py"
+		modErrs = "1111111111111111" // carried forward — NOT in records
+		fileC   = "3333333333333333"
+		ph      = "4444444444444444"
+		fn      = "6666666666666666"
+	)
+	build := func() []types.EntityRecord {
+		return []types.EntityRecord{
+			{
+				ID: fileC, Name: f, Kind: "SCOPE.Component", Subtype: "file", SourceFile: f,
+				Relationships: []types.RelationshipRecord{
+					{FromID: fileC, ToID: modErrs, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "cperrs_static", "imported_name": "cperrs_static"})},
+				},
+			},
+			{ID: ph, Name: "cperrs_static", Kind: "SCOPE.Component", Subtype: "import", SourceFile: f},
+			{
+				ID: fn, Name: "cp_handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: f,
+				Relationships: []types.RelationshipRecord{{FromID: fn, ToID: ph, Kind: "REFERENCES"}},
+			},
+		}
+	}
+
+	out, _, stats := PruneImportPlaceholdersWithLiveIDs(build(), map[string]bool{modErrs: true})
+	if stats.PlaceholderRefRepoints != 1 {
+		t.Errorf("with carry-forward live set: PlaceholderRefRepoints = %d, want 1", stats.PlaceholderRefRepoints)
+	}
+	for _, e := range out {
+		if e.ID != fn {
+			continue
+		}
+		if len(e.Relationships) != 1 || e.Relationships[0].ToID != modErrs {
+			t.Errorf("REFERENCES = %+v, want ToID re-pointed to the carried-forward module %q", e.Relationships, modErrs)
+		}
+	}
+
+	// Control: without the carry-forward set the target is indistinguishable
+	// from a dead id and must be refused.
+	_, _, nilStats := PruneImportPlaceholdersWithLiveIDs(build(), nil)
+	if nilStats.PlaceholderRefRepoints != 0 {
+		t.Errorf("without carry-forward live set: PlaceholderRefRepoints = %d, want 0 — "+
+			"the target is not known to survive, so re-pointing at it would only move the dangle",
+			nilStats.PlaceholderRefRepoints)
+	}
+}
+
+// TestPruneImportPlaceholders_LeavesUnresolvableIncomingEdgesAlone pins the
+// boundary of the #6131 repair: the re-point fires ONLY when the pipeline has
+// already resolved the same (importer file, module) pair to a real entity. A
+// genuinely third-party import has no such resolution, so there is nothing to
+// propagate and the edge is left exactly as the full rebuild leaves it today.
+// Without this, the repair would be free to invent a binding.
+func TestPruneImportPlaceholders_LeavesUnresolvableIncomingEdgesAlone(t *testing.T) {
+	const (
+		f     = "app.py"
+		fileC = "3333333333333333"
+		ph    = "4444444444444444"
+		fn    = "6666666666666666"
+	)
+	records := []types.EntityRecord{
+		{ID: fileC, Name: f, Kind: "SCOPE.Component", Subtype: "file", SourceFile: f},
+		{ID: ph, Name: "requests", Kind: "SCOPE.Component", Subtype: "import", SourceFile: f},
+		{
+			ID: fn, Name: "handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: f,
+			Relationships: []types.RelationshipRecord{
+				{FromID: fn, ToID: ph, Kind: "REFERENCES"},
+			},
+		},
+	}
+	out, _, stats := PruneImportPlaceholders(records)
+	if stats.PlaceholderRefRepoints != 0 {
+		t.Errorf("PlaceholderRefRepoints = %d, want 0 — no resolved IMPORTS edge exists for `requests`", stats.PlaceholderRefRepoints)
+	}
+	for _, e := range out {
+		if e.ID != fn {
+			continue
+		}
+		if len(e.Relationships) != 1 || e.Relationships[0].ToID != ph {
+			t.Errorf("REFERENCES edge was altered: %+v, want ToID %q untouched", e.Relationships, ph)
+		}
+	}
+}
+
 // TestResolveRelativeImportTarget_TriesAllJSExtensions guards the
 // extension-search ordering inside resolveRelativeImportTarget so a
 // future change to jsExtensions doesn't silently stop resolving


### PR DESCRIPTION
`PruneImportPlaceholders` removes `SCOPE.Component/import` carrier entities, leaving incoming `REFERENCES` edges pointing at ids no entity carries. The incremental path never prunes, so full and incremental disagreed — and the full rebuild was the wrong one.

## The prune's own doc states this as a precondition, and it is false

`internal/resolve/imports.go:2768-2772`:

> *"After the import-resolver and references-resolver passes have rewritten ToID / FromID values, the placeholders themselves have no incoming edges."*

That is an assertion about the world, not a policy. It was falsified once before — #642, JS/TS relative imports — and the recorded answer there was to **rewrite the incoming edge to a durable entity before dropping the placeholder**, not to accept the dangle. Same function, same falsified premise, same remedy.

Measured on the gate fixture, the record set holds **two contradictory bindings for one import** at prune time:

| | binding |
|---|---|
| `IMPORTS from=5b13f231a92947d1` | `c63a552934b754f7` = `Module/cperrs_static@cperrs_static.py` — resolved |
| `REFERENCES to=d862a32cf7af4cf1` | `SCOPE.Component/import "cperrs_static"` — the placeholder |

The prune deletes the placeholder and discards the **resolved** answer.

## Fix

`buildPlaceholderRepoints` re-points incoming edges to the entity the import resolver already bound the same whole-module import to, **in the same importer file**. No edge is created or removed. Three guards, each with a killing test: whole-module only, ambiguity refuses, target must survive the prune.

Gate: Path A 11 → 7 divergences, Path B 10 → 6, full-rebuild unbound endpoints 13 → 11. Two Path-A allow entries went stale and were deleted — verified closed, not re-keyed (the #6132 failure mode).

## Why the full path, not the incremental one

`PruneImportPlaceholders` already hoists outgoing relationships and already rewrites `ToID`s. It is a function that removes a structural carrier **while preserving its edges**, not one expressing "unresolvable". Teaching incremental to prune too would have deleted a correct binding to match a broken one — the #6123 anti-pattern, where the dangling metric improves while the graph gets worse.

## Blast radius — measured, because this changes default full-rebuild output

This is the only change in the cluster that alters what a full index produces for every repo. Review built an independent Python/JS-TS/Go corpus and diffed full rebuilds bidirectionally with content-keyed parity:

- entities **55 → 55**, relationships **109 → 109** — identical
- unbound endpoints **26 → 23**
- **exactly 3 rows changed, every one `«unbound»<hex>` → a live entity**

Nothing appeared, disappeared, or moved between two live entities. The invariant — "can only convert a would-be dangling endpoint into a live one" — held on a corpus harder than the fixture.

## Path B was always dangling here

Fixing full made `TestContentParity_PathB_6129` fail with 4 unexpected rows. Not collateral: on an incremental `Index` run the repoint target lives in `incrementalCarryForwardEntities`, not `merged` (merge happens later, `cmd/grafel/index.go:1754`), so the survivor check rejected it. `PruneImportPlaceholdersWithLiveIDs` now takes the carry-forward id set.

Path B matched full only because full was equally broken. It is genuinely fixed, not made to agree: the comparison is content-keyed, so `Module/…` could not compare equal to `«unbound»<hex>` — both sides must bind. **No allow entry added.**

## The reachability condition, after two corrections

The first scoping claim was "Go and JS/TS whole-module imports are untested". Review showed they are **unreachable**, not untested: Go and Java import placeholders carry an empty `Subtype` (`internal/extractors/golang/extractor.go:2449`, `internal/extractors/java/references.go:194`), so they fail the `Subtype == "import"` filter and are never pruned *or* repointed. Verified — `SCOPE.Component/fmt@…` survives as a live entity.

The follow-on claim "only `internal/extractors/cross/imports` is affected" is **also wrong, in the other direction**. `Subtype: "import"` placeholders are emitted by at least 14 extractors (javascript, kotlin, cpp, vue, razor, proto, graphql, css/scss/less, markdown, just, fish, cross/imports), and `source_module`/`imported_name` IMPORTS props by a similarly wide set. JS/TS's IMPORTS case is covered by #642, but its placeholders *are* pruned — so this repoint is not structurally excluded there the way Go/Java is.

Recorded as a **condition** rather than a language list: both halves must be present in the same file — a `Subtype=="import"` placeholder, and an IMPORTS edge with `source_module == imported_name` resolved to a surviving entity. The emitter behind the observed fixture is `cross/imports/extractor.go:450` (its `is_local`/`external_dependency`/`ref`/`provenance` property set matches the probe output byte for byte).

**Only Python is exercised.** Ruby, rust, csharp, elixir and the other both-halves extractors are reachable and unmeasured.

## The guard that had no test

Review's mutation battery ran 6 mutants; five died. **M6 — dropping `file` from the repoint key — survived the unit tests, the parity gate, and the corpus.**

That guard is load-bearing. With two files importing the same module name and only one resolved, dropping file-scoping repoints the unresolved file's edge to the *other file's* target: a confident cross-file mis-bind, which is strictly worse than the dangle this change removes. It fails safe only when both resolve, because then the ambiguity guard catches the conflict.

`TestPruneImportPlaceholders_RepointTargetIsFileScoped` now pins it. Under the neutered key it fails on three assertions — repoint count `2, want 1`; the multiset losing B's own dangle and gaining A's target; and the explicit mis-bind check. `go build` and `go vet` are both clean under the mutation, so the failure is behavioural, not an unused-import artefact (the false-negative class caught in #6107 review).

The ambiguity guard also survived its first mutation during implementation; `TestPruneImportPlaceholders_RefusesAmbiguousRepointTarget` closes that one.

## Recorded, not fixed

`graph.EntityID` (`internal/graph/graph.go:259`) hashes repo/kind/name/sourceFile — **`Subtype` is absent from the digest**. So a `SCOPE.Component/import` named M in file F shares an id with any other `SCOPE.Component` named M in file F, and the application loop rewrites any relationship whose `ToID` matches. No reachable instance could be constructed. The "no already-live endpoint is touched" comment is softened to the precondition it actually relies on — every id-keyed pass in the function, including the #642 rewrite, rests on the same assumption.

The whole-module guard's doc previously said a member import "resolves to the member, not the module". What `imported_name == source_module` means is *the imported name IS the module name* — which is why `from x import x` passes and **should**: Python rebinds the local name to the submodule, so the reference correctly follows the IMPORTS target. Now stated as intended behaviour rather than a guard escape.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, skips counted including subtests:

| package | exit | skips |
|---|---|---|
| `./internal/resolve/...` | 0 | 6 |
| `./internal/extractors/...` | 0 | 1 |
| `./cmd/grafel/` | 0 | 8 |
| `./internal/graph/...` | 0 | **0** |

All skips pre-existing. `internal/graph/parity/**` unmodified; comparator and remaining allow-lists untouched.

Independently adversarially reviewed (APPROVE), with the MEDIUM finding closed on top.

Refs #6131, #6129, #6123, #6132, #642
