### PR TITLE
fix(#6114): State.Group() hands out a snapshot — the unfiled map race could throw uncatchably and kill the daemon

### DIFF
--- a/internal/mcp/cross_link_cache_integration_test.go
+++ b/internal/mcp/cross_link_cache_integration_test.go
@@ -363,15 +363,19 @@ func TestCrossLinkCache_QueryPathWireIn(t *testing.T) {
 	// We use the real group name but inject lg.Links directly so we don't need
 	// the links file on disk.
 	const groupName = "wire-in-test-group"
+	// Inject a cross-repo link and a LoadedRepo with the right IndexedRef.
+	// #6114: configure the LIVE group. This previously wrote through a Group()
+	// view and passed only because the same view was read back — the shape that
+	// silently loses the write the moment the two are separated.
+	mutateGroup(t, st, groupName, func(g *LoadedGroup) {
+		g.Links = []CrossRepoLink{
+			{Source: "repo-a::SvcA", Target: "repo-b::SvcB", Kind: "call", Confidence: 0.9},
+			{Source: "repo-b::SvcB", Target: "repo-a::HandlerA", Kind: "import", Confidence: 0.8},
+		}
+	})
 	lg := st.Group(groupName)
 	if lg == nil {
 		t.Fatalf("group %q not found after Reload", groupName)
-	}
-
-	// Inject a cross-repo link and a LoadedRepo with the right IndexedRef.
-	lg.Links = []CrossRepoLink{
-		{Source: "repo-a::SvcA", Target: "repo-b::SvcB", Kind: "call", Confidence: 0.9},
-		{Source: "repo-b::SvcB", Target: "repo-a::HandlerA", Kind: "import", Confidence: 0.8},
 	}
 
 	// Synthetic LoadedRepo for repoA@main.

--- a/internal/mcp/evict_group_5872_test.go
+++ b/internal/mcp/evict_group_5872_test.go
@@ -457,11 +457,15 @@ func TestEvictGroup_LeavesOtherGroupsUntouched(t *testing.T) {
 	}}
 	st.mu.Unlock()
 
-	otherBefore := st.Group("other")
+	// #6114: State.Group hands back an immutable per-call VIEW, so a fresh
+	// pointer every call is expected and says nothing. The property under test —
+	// "evicting 'test' did not disturb the resident 'other'" — is about the LIVE
+	// group instance, so compare that.
+	otherBefore := liveGroup(st, "other")
 	if !st.EvictGroup("test", false) {
 		t.Fatal("EvictGroup(test) returned false")
 	}
-	otherAfter := st.Group("other")
+	otherAfter := liveGroup(st, "other")
 	if otherBefore != otherAfter {
 		t.Fatal("evicting 'test' swapped the 'other' group pointer")
 	}

--- a/internal/mcp/find_paths_1690_test.go
+++ b/internal/mcp/find_paths_1690_test.go
@@ -44,17 +44,19 @@ func TestFindPaths_1690_RepoPrefixAlias(t *testing.T) {
 		},
 	}
 	srv := newTestServer(t, docMobile, docCore)
-	lg := srv.State.Group("test")
 	// The links emitter wrote the acme-core side as `acme_core::handler_fn`
 	// (path-basename with underscores) — this MUST still resolve.
-	lg.Links = []CrossRepoLink{
-		{
-			Source:   prefixedID("acme-mobile", "ep_call"),
-			Target:   "acme_core::handler_fn",
-			Relation: "calls",
-			Method:   "http",
-		},
-	}
+	// #6114: configure the LIVE group; State.Group returns an immutable view.
+	mutateGroup(t, srv.State, "test", func(lg *LoadedGroup) {
+		lg.Links = []CrossRepoLink{
+			{
+				Source:   prefixedID("acme-mobile", "ep_call"),
+				Target:   "acme_core::handler_fn",
+				Relation: "calls",
+				Method:   "http",
+			},
+		}
+	})
 
 	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",
@@ -105,15 +107,17 @@ func TestFindPaths_1690_ReverseImplementsAcrossRepo(t *testing.T) {
 		},
 	}
 	srv := newTestServer(t, docMobile, docCore)
-	lg := srv.State.Group("test")
-	lg.Links = []CrossRepoLink{
-		{
-			Source:   prefixedID("acme-mobile", "ep_call"),
-			Target:   prefixedID("acme-core", "ep_def"), // lands on the endpoint, NOT the handler
-			Relation: "calls",
-			Method:   "http",
-		},
-	}
+	// #6114: configure the LIVE group; State.Group returns an immutable view.
+	mutateGroup(t, srv.State, "test", func(lg *LoadedGroup) {
+		lg.Links = []CrossRepoLink{
+			{
+				Source:   prefixedID("acme-mobile", "ep_call"),
+				Target:   prefixedID("acme-core", "ep_def"), // lands on the endpoint, NOT the handler
+				Relation: "calls",
+				Method:   "http",
+			},
+		}
+	})
 
 	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",

--- a/internal/mcp/group_lock_scope_6060_test.go
+++ b/internal/mcp/group_lock_scope_6060_test.go
@@ -137,8 +137,13 @@ func TestGroup_ConcurrentRevivesMaterializeOnce(t *testing.T) {
 		if g == nil {
 			t.Fatalf("goroutine %d got a nil group", i)
 		}
-		if g != got[0] {
-			t.Errorf("goroutine %d observed a different group instance — revive was not single-flighted", i)
+		// #6114: State.Group returns an immutable per-call VIEW, so the group
+		// POINTER is expected to differ per caller and proves nothing. The
+		// single-flight property is about the MATERIALIZED instance behind the
+		// view, so compare the per-repo record — which the view shares by
+		// pointer and which the revive is what creates.
+		if g.Repos["r"] != got[0].Repos["r"] {
+			t.Errorf("goroutine %d observed a different materialized repo instance — revive was not single-flighted", i)
 		}
 		// Fully materialized, not half: the LabelIndex dropped by the eviction is back.
 		lr := g.Repos["r"]

--- a/internal/mcp/maphandle.go
+++ b/internal/mcp/maphandle.go
@@ -1,10 +1,16 @@
 // F1 of ADR-0027 (mmap + zero-copy resident graph): the deferred-unmap
 // MapHandle lifetime. This is the safety keystone the whole epic rests on.
 //
-// Today the serve read path is lock-free by construction: State.Group() copies
-// the *LoadedGroup pointer under s.mu and releases the lock, after which a
-// handler reads the derived state for the whole tool call without holding any
-// lock. That is safe ONLY because the materialized heap *graph.Document stays
+// Today the serve read path is lock-free by construction: State.Group() resolves
+// the group under s.mu and releases the lock, after which a handler reads the
+// derived state for the whole tool call without holding any lock. (#6114: what
+// it returns is an immutable per-call VIEW — a shallow copy with its own repo
+// map — rather than the live *LoadedGroup, so an unlocked `range lg.Repos`
+// cannot race reload's map write. Each *LoadedRepo inside is still shared by
+// pointer, which is what keeps the handle lifetime below meaningful, and is also
+// why residual (A) — reload mutating those records in place — is still open.
+// See snapshotLocked.) That is safe ONLY because the materialized heap
+// *graph.Document stays
 // GC-reachable through the in-flight goroutine's pointers. Once queries alias
 // bytes straight out of the mmap (F3, behind GRAFEL_SERVE_FROM_MMAP), GC
 // reachability no longer covers them — a concurrent reload that munmaps while a

--- a/internal/mcp/overlay_sidetable_parity_test.go
+++ b/internal/mcp/overlay_sidetable_parity_test.go
@@ -291,7 +291,12 @@ func TestOverlaySideTable_BuiltFromReaderNotDoc(t *testing.T) {
 		t.Fatalf("reload: %v", err)
 	}
 
-	grp := st.Group("acme")
+	// #6114: the LIVE group, not a Group() view — this test both writes
+	// grp.algoApplied and hands grp to applyGroupAlgoOverlay, which is a
+	// production mutator and panics on a view. Written through a view, the
+	// re-stamp below would be silently discarded and the test would assert
+	// against a side-table nobody rebuilt.
+	grp := liveGroup(st, "acme")
 	lr := grp.Repos["svc"]
 	if lr == nil || lr.Reader == nil || lr.LabelIndex == nil {
 		t.Fatalf("svc repo not loaded with a resident Reader + LabelIndex")

--- a/internal/mcp/security_finding_promotion_test.go
+++ b/internal/mcp/security_finding_promotion_test.go
@@ -54,7 +54,11 @@ func TestSecurityFindingPromotionRoundtrip(t *testing.T) {
 
 	// Point the memory store at a temp dir so we never touch ~/.grafel.
 	memDir := t.TempDir()
-	srv.State.Group("test").MemoryDir = memDir
+	// #6114: State.Group returns an immutable per-call VIEW, so writing through
+	// it would be silently discarded. Mutate the live group under s.mu.
+	srv.State.mu.Lock()
+	srv.State.groups["test"].MemoryDir = memDir
+	srv.State.mu.Unlock()
 
 	// 1) Save a benign note first — it must NOT show up in the security query.
 	noteOut := callRawTool(t, srv.handleSaveResult, map[string]any{

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1944,8 +1944,9 @@ func (s *State) Group(name string) *LoadedGroup {
 	s.mu.Lock()
 	if grp := s.groups[name]; grp != nil {
 		s.touchGroupLocked(grp)
+		snap := grp.snapshotLocked()
 		s.mu.Unlock()
-		return grp
+		return snap
 	}
 	// Cold-gate revive (memory epic #5850, issue #5872 PR1): a group EvictGroup
 	// reclaimed is absent from s.groups and pinned in s.evicted. An explicit
@@ -1967,8 +1968,9 @@ func (s *State) Group(name string) *LoadedGroup {
 	// may have published the group by now.
 	if grp := s.groups[name]; grp != nil {
 		s.touchGroupLocked(grp)
+		snap := grp.snapshotLocked()
 		s.mu.Unlock()
-		return grp
+		return snap
 	}
 	cold, gated := s.evicted[name]
 	if !gated {
@@ -1983,8 +1985,9 @@ func (s *State) Group(name string) *LoadedGroup {
 		if grp != nil {
 			s.touchGroupLocked(grp)
 		}
+		snap := grp.snapshotLocked()
 		s.mu.Unlock()
-		return grp
+		return snap
 	}
 	s.mu.Unlock()
 
@@ -2005,8 +2008,110 @@ func (s *State) Group(name string) *LoadedGroup {
 	delete(s.evicted, name)
 	s.groups[name] = cold
 	s.touchGroupLocked(cold)
+	snap := cold.snapshotLocked()
 	s.mu.Unlock()
-	return cold
+	return snap
+}
+
+// snapshotLocked returns the immutable per-call VIEW of grp that State.Group
+// hands to an unlocked reader (issue #6114). Caller MUST hold s.mu.
+//
+// What it fixes. The serve read path is lock-free by construction: Group()
+// resolves the group under s.mu, releases the lock, and the handler then reads
+// for the whole tool call with no lock held (see maphandle.go). Handing back the
+// LIVE *LoadedGroup meant an unlocked `range lg.Repos` in every repo-scoped tool
+// (resolveRepoFilter, groupIndexedRefSHA, the repo-stats loop) ran concurrently
+// with reloadAllLocked's `grp.Repos[rName] = lr` / `delete(grp.Repos, rName)` —
+// which fire whenever registry.json gains or loses a repo mid-session. A map
+// write concurrent with an unsynchronised map read is not a benign race in Go:
+// the runtime's best-effort detector can throw "concurrent map read and map
+// write", which is NOT recoverable — it takes the daemon process down, and with
+// it every concurrent agent session. TestGroupReadersDoNotRaceWithRepoSetChange
+// reproduces the race under -race.
+//
+// The copy is per tool call and shallow: the repo set is O(repos in group) —
+// single digits — and every *LoadedRepo is shared BY POINTER, so identity,
+// lazily-built index memoization (idxOnce), and the MapHandle lifetime are all
+// unchanged. Callers that must observe live per-repo mutation (reload swapping
+// GraphFile/Doc) still do, because they hold the same *LoadedRepo.
+//
+// WHAT THIS DOES NOT FIX — do not restate it more strongly. The per-repo record
+// is still MUTATED IN PLACE by reload (`lr.Doc = doc`), so a reader that
+// nil-checks lr.Doc and dereferences it through a second load can still observe
+// two different Docs. Today both are non-nil and the consequence is a
+// mixed-generation answer, not a crash. Clearing Doc is what turns that into a
+// nil deref, which is why `lr.Doc = nil` STILL must not be done in place even
+// with this snapshot: publish a successor *LoadedRepo into the repo set instead,
+// so a reader holding an older snapshot keeps a record whose Doc never changes.
+// See unservableRepo.
+func (grp *LoadedGroup) snapshotLocked() *LoadedGroup {
+	if grp == nil {
+		return nil
+	}
+	// LoadedGroup carries no mutex, so a struct copy is well-defined (and
+	// go vet's copylocks agrees). Slice-header fields (Links, Communities) are
+	// copied by value, which is what makes a reload's whole-slice REPLACEMENT
+	// invisible to an in-flight reader.
+	snap := *grp
+	snap.Repos = make(map[string]*LoadedRepo, len(grp.Repos))
+	for name, lr := range grp.Repos {
+		snap.Repos[name] = lr
+	}
+	return &snap
+}
+
+// unservableRepo returns a copy-on-write SUCCESSOR of lr that reports the repo
+// as unservable: Doc nil plus a loadErr, which is exactly the shape tools.go's
+// `unavailable` list keys on. It is the safe way to reach the "report
+// unavailable" state that #6080's review identified and rejected as unreachable.
+//
+// Why a successor and not `lr.Doc = nil` (issue #6114). Readers hold their
+// *LoadedRepo pointers with no lock for the length of a tool call and use a
+// check-then-dereference shape (`if r.Doc == nil { continue }` … `r.Doc.X`).
+// Clearing Doc on the record a reader is already holding turns a stale answer
+// into a nil dereference across the whole read surface. Publishing a distinct
+// record into the group's repo set under s.mu makes the transition atomic from
+// a reader's point of view: it either holds the predecessor (whose Doc is never
+// written again) or picks up the successor (whose Doc is nil for its whole
+// life). Neither observes a transition.
+//
+// The mapping's lifetime follows coldShellRepo's proven pattern (issue #5872):
+// the successor SHARES lr's *MapHandle and points sharedReaderMu at lr's
+// EFFECTIVE mutex (rmu(), not a fresh zero value), so the successor's eventual
+// retireHandle and an in-flight read on the predecessor serialise on the one
+// mutex that governs that one mapping. Dropping the handle here instead would
+// orphan the mapping — nothing left in s.groups would ever retire it.
+//
+// The derived indexes are deliberately NOT carried over: they are built FROM
+// the Doc this successor no longer has.
+//
+// Caller MUST hold s.mu and MUST publish the result into grp.Repos (replacing
+// lr) rather than mutating lr.
+//
+// INERT: no production caller yet, exactly like borrowGroup at F1. It exists so
+// the seam and its reader-safety are proven
+// (TestUnservableRepoNeverShowsAReaderADocGoingNil) before the #5954 memory work
+// that needs it lands.
+func unservableRepo(lr *LoadedRepo, loadErr string) *LoadedRepo {
+	if lr == nil {
+		return nil
+	}
+	return &LoadedRepo{
+		Repo:      lr.Repo,
+		Path:      lr.Path,
+		GraphFile: lr.GraphFile,
+		// Doc, LabelIndex, BM25 and every derived index are intentionally zero.
+		Reader:          lr.Reader,
+		handle:          lr.handle,
+		sharedReaderMu:  lr.rmu(),
+		Semantic:        lr.Semantic,
+		semMtime:        lr.semMtime,
+		mtime:           lr.mtime,
+		contentHash:     lr.contentHash,
+		loadErr:         loadErr,
+		reindexRequired: lr.reindexRequired,
+		reindexReason:   lr.reindexReason,
+	}
 }
 
 // reviveGateLocked returns the per-group revive mutex for name, creating it on
@@ -2601,13 +2706,16 @@ func (s *State) SweepToMemoryBudget(budgetBytes uint64, keepReader bool) int {
 	return 0
 }
 
-// SnapshotGroups returns a stable list of loaded group pointers.
+// SnapshotGroups returns a stable list of loaded groups as immutable per-call
+// views (issue #6114): like State.Group, each element is a shallow copy with its
+// own repo map, so an unlocked caller ranging over g.Repos cannot race a
+// reload's map write. Repos are shared by pointer.
 func (s *State) SnapshotGroups() []*LoadedGroup {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	out := make([]*LoadedGroup, 0, len(s.groups))
 	for _, g := range s.groups {
-		out = append(out, g)
+		out = append(out, g.snapshotLocked())
 	}
 	return out
 }

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1126,6 +1126,20 @@ type LoadedGroup struct {
 	// never routed to through State.Group (e.g. eager startup warm never queried):
 	// mirroring bm25LastUse, such a group is NOT idle-eligible until first access.
 	lastAccess time.Time
+
+	// isView marks this as an immutable per-call VIEW produced by
+	// snapshotLocked, not the live group (#6114). State.Group and
+	// SnapshotGroups hand out views; s.groups holds live groups.
+	//
+	// It exists because the new invariant — "a write through a Group() result is
+	// silently discarded" — is otherwise enforced only by a doc comment, and
+	// this change already found SIX fixtures that had written through the live
+	// group and would have gone quietly wrong. A full compile-time guard needs a
+	// distinct GroupView type with accessors across ~80 call sites; this flag
+	// buys most of the protection for four lines by making the ONE production
+	// group-mutator (applyGroupAlgoOverlay) panic on a view, turning a silent
+	// discard into a loud, immediate test failure.
+	isView bool
 }
 
 // WorktreeLookup is the narrow interface ResolveCWD uses to query the PH3
@@ -2035,14 +2049,33 @@ func (s *State) Group(name string) *LoadedGroup {
 // unchanged. Callers that must observe live per-repo mutation (reload swapping
 // GraphFile/Doc) still do, because they hold the same *LoadedRepo.
 //
-// WHAT THIS DOES NOT FIX — do not restate it more strongly. The per-repo record
-// is still MUTATED IN PLACE by reload (`lr.Doc = doc`), so a reader that
-// nil-checks lr.Doc and dereferences it through a second load can still observe
-// two different Docs. Today both are non-nil and the consequence is a
-// mixed-generation answer, not a crash. Clearing Doc is what turns that into a
-// nil deref, which is why `lr.Doc = nil` STILL must not be done in place even
-// with this snapshot: publish a successor *LoadedRepo into the repo set instead,
-// so a reader holding an older snapshot keeps a record whose Doc never changes.
+// WHAT THIS DOES NOT FIX — residual (A) of #6114, and it is WIDER than "the Doc
+// pointer". The repo RECORD is shared by pointer (that is the whole point), and
+// reloadAllLocked mutates it IN PLACE, unsynchronised against unlocked readers,
+// across at least eleven fields:
+//
+//	Doc, LabelIndex, Semantic, TestsEdgeCount   (pointers / int)
+//	GraphFile, loadErr, reindexReason           (STRINGS — ptr+len, two words)
+//	mtime, semMtime                             (time.Time — three words)
+//	contentHash, reindexRequired
+//
+// Do NOT reason about this as "a pointer store won't tear". That argument covers
+// only the single-word fields. A string header and a time.Time are multi-word,
+// so a reader CAN observe a half-updated value — and the exposed read shapes are
+// ordinary: handleGraphStats builds `name+": "+r.loadErr` (tools.go) against
+// reload's `lr.loadErr = ""`, which reproduces under -race.
+//
+// Nor is the single-word half harmless. groupIndexedRefSHA (tools.go) loads
+// lr.Doc THREE separate times and can pair IndexedRef from one generation with
+// IndexedSHA from the next, returning a ref/SHA combination that never existed
+// to an MCP caller as this repo's indexed state. That is a silently-wrong
+// answer, not a stale one.
+//
+// Closing residual (A) requires the per-repo record to become copy-on-write on
+// EVERY reload. Until then, `lr.Doc = nil` in particular must NOT be done in
+// place — it converts the above into a nil dereference across the whole read
+// surface. Publish a successor *LoadedRepo into the repo set instead, so a
+// reader holding an older view keeps a record whose fields never change again.
 // See unservableRepo.
 func (grp *LoadedGroup) snapshotLocked() *LoadedGroup {
 	if grp == nil {
@@ -2053,6 +2086,7 @@ func (grp *LoadedGroup) snapshotLocked() *LoadedGroup {
 	// copied by value, which is what makes a reload's whole-slice REPLACEMENT
 	// invisible to an in-flight reader.
 	snap := *grp
+	snap.isView = true
 	snap.Repos = make(map[string]*LoadedRepo, len(grp.Repos))
 	for name, lr := range grp.Repos {
 		snap.Repos[name] = lr
@@ -2075,15 +2109,44 @@ func (grp *LoadedGroup) snapshotLocked() *LoadedGroup {
 // written again) or picks up the successor (whose Doc is nil for its whole
 // life). Neither observes a transition.
 //
-// The mapping's lifetime follows coldShellRepo's proven pattern (issue #5872):
-// the successor SHARES lr's *MapHandle and points sharedReaderMu at lr's
-// EFFECTIVE mutex (rmu(), not a fresh zero value), so the successor's eventual
-// retireHandle and an in-flight read on the predecessor serialise on the one
-// mutex that governs that one mapping. Dropping the handle here instead would
-// orphan the mapping — nothing left in s.groups would ever retire it.
+// THE SUCCESSOR MUST BE RECOVERABLE. contentHash is deliberately ZEROED, not
+// carried forward. reloadAllLocked's inner fast path is
 //
-// The derived indexes are deliberately NOT carried over: they are built FROM
-// the Doc this successor no longer has.
+//	if hErr == nil && lr.contentHash != 0 && newHash == lr.contentHash { … }
+//
+// — "identical bytes, skip the reparse" — which advances mtime and NEVER assigns
+// Doc. Inheriting the predecessor's hash therefore strands the repo: the outer
+// guard correctly decides work is needed, the hash says there is none, and the
+// repo stays Doc==nil against a perfectly valid on-disk graph until its bytes
+// happen to change. The zero value is the documented "next reload re-parses"
+// sentinel already used at the assignment site. Pinned by
+// TestUnservableRepoRecoversOnTheNextReload.
+//
+// The mapping is RETIRED rather than shared. coldShellRepo shares lr's
+// *MapHandle because a cold shell still SERVES from it; an unservable repo by
+// definition does not, and a successor holding a live Reader with a nil Doc and
+// a nil LabelIndex is a shape no read path has been validated against. Instead
+// the predecessor's mapping goes through the F1 (ADR-0027) drain — the same
+// retireHandle that EvictGroup and State.Close use — so an in-flight borrow
+// drains before the munmap and a flag-on read choke point sees readRetired under
+// the shared readerMu and falls back instead of dereferencing freed memory.
+// retireHandle mutates lr.Reader/lr.handle in place, which is SAFE (unlike the
+// #6114 residual on Doc): that pair is the one part of LoadedRepo already
+// synchronised, on readerMu, which every flag-on reader also holds. With mmap
+// serving ON the predecessor's Doc is skeletonized, so a reader still holding
+// the predecessor degrades to empty rather than stale — the intended direction
+// for a repo being declared unservable.
+//
+// sharedReaderMu still points at lr's EFFECTIVE mutex (rmu()) so that if a
+// future reload publishes a handle onto this record, it collapses onto the one
+// origin mutex exactly as #5872 requires rather than opening a second one.
+//
+// Deliberately NOT carried over (contrast coldShellRepo, which keeps them
+// because it keeps the Doc): every derived index, since they are built FROM the
+// Doc this record no longer has; TestsEdgeCount, which is an O(R) count OF that
+// Doc and would otherwise be served by grafel_whoami as fact about a graph that
+// is not loaded; and algoStampedMt, since there are no entities to stamp and the
+// recovering reparse must re-apply the overlay from scratch.
 //
 // Caller MUST hold s.mu and MUST publish the result into grp.Repos (replacing
 // lr) rather than mutating lr.
@@ -2096,22 +2159,24 @@ func unservableRepo(lr *LoadedRepo, loadErr string) *LoadedRepo {
 	if lr == nil {
 		return nil
 	}
-	return &LoadedRepo{
+	next := &LoadedRepo{
 		Repo:      lr.Repo,
 		Path:      lr.Path,
 		GraphFile: lr.GraphFile,
-		// Doc, LabelIndex, BM25 and every derived index are intentionally zero.
-		Reader:          lr.Reader,
-		handle:          lr.handle,
-		sharedReaderMu:  lr.rmu(),
-		Semantic:        lr.Semantic,
-		semMtime:        lr.semMtime,
-		mtime:           lr.mtime,
-		contentHash:     lr.contentHash,
+		// Doc, Reader, handle, LabelIndex, BM25, TestsEdgeCount, algoStampedMt
+		// and every derived index are intentionally zero — see above.
+		sharedReaderMu: lr.rmu(),
+		Semantic:       lr.Semantic,
+		semMtime:       lr.semMtime,
+		mtime:          lr.mtime,
+		// contentHash: 0 — the "next reload re-parses" sentinel. See above.
 		loadErr:         loadErr,
 		reindexRequired: lr.reindexRequired,
 		reindexReason:   lr.reindexReason,
 	}
+	// Drain the predecessor's mapping through F1 rather than orphaning it.
+	lr.retireHandle()
+	return next
 }
 
 // reviveGateLocked returns the per-group revive mutex for name, creating it on
@@ -2422,6 +2487,13 @@ func (b *groupBorrow) Release() {
 // F1: inert — no production caller yet. Wired here so the seam and its race
 // safety are proven (TestBorrowGroupSurvivesReload) before F3 lights the read
 // path.
+//
+// #6114: the borrow carries a VIEW, not the live group. borrowGroup is the
+// designated F3 read path, so handing back the live *LoadedGroup would
+// reintroduce defect (B) — an unlocked `range b.Group.Repos` against reload's
+// map write — in full the moment F3 lights up. The overlay refresh below runs
+// against the LIVE group first (it is a mutator; see applyGroupAlgoOverlay's
+// view guard), and the view is taken after it.
 func (s *State) borrowGroup(name string) *groupBorrow {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -2430,7 +2502,7 @@ func (s *State) borrowGroup(name string) *groupBorrow {
 		return nil
 	}
 	s.refreshGroupAlgoOverlayLocked(grp)
-	b := &groupBorrow{Group: grp}
+	b := &groupBorrow{Group: grp.snapshotLocked()}
 	for _, lr := range grp.Repos {
 		if lr != nil && lr.handle != nil {
 			b.handles = append(b.handles, lr.handle.borrow())
@@ -3040,6 +3112,14 @@ func filterLinksBySource(links []CrossRepoLink, repo string) []CrossRepoLink {
 // value first, then this re-applies the (matching) overlay — so a stale overlay
 // (which always coincides with a graph.fb mtime change) cleanly falls back.
 func applyGroupAlgoOverlay(grp *LoadedGroup) {
+	// #6114: this is the one production mutator of a *LoadedGroup. State.Group
+	// hands back an immutable per-call VIEW, so applying the overlay to a view
+	// would write grp.algoFile/algoMt/algoApplied/Communities into an object
+	// that is discarded when the call returns — a silent no-op that re-reads and
+	// re-stamps the overlay on every single call. Fail loudly instead.
+	if grp != nil && grp.isView {
+		panic("mcp: applyGroupAlgoOverlay called on a Group() view; pass the live group (see snapshotLocked, #6114)")
+	}
 	path, err := groupalgo.OverlayPath(grp.Name)
 	if err != nil || path == "" {
 		return

--- a/internal/mcp/state_group_locking_6114_test.go
+++ b/internal/mcp/state_group_locking_6114_test.go
@@ -1,0 +1,417 @@
+// state_group_locking_6114_test.go — issue #6114.
+//
+// State.Group() copies the *LoadedGroup pointer under s.mu and RELEASES the
+// lock; the handler then reads the group's repo set and each repo's Doc for the
+// whole tool call with no lock held (this is stated as the design invariant in
+// maphandle.go's package comment). Meanwhile reloadAllLocked mutates those very
+// structures IN PLACE under s.mu: `lr.Doc = doc` (state.go), and
+// `grp.Repos[rName] = lr` / `delete(grp.Repos, rName)` when the registry's repo
+// set changes.
+//
+// Two distinct defects follow, of different severity:
+//
+//	(A) Doc pointer race — a reader that nil-checks r.Doc and dereferences it
+//	    later can observe two different Docs. Today both are non-nil so the
+//	    consequence is a mixed-generation answer; the moment `lr.Doc = nil`
+//	    exists (the #5954 memory work this issue blocks) it becomes a nil deref.
+//
+//	(B) Repo-set map race — an unlocked `range lg.Repos` concurrent with the
+//	    reload's map write is "concurrent map iteration and map write", a Go
+//	    RUNTIME THROW. It is not a panic: recover() cannot catch it and the
+//	    daemon process dies, taking every concurrent agent session with it.
+//
+// Both tests drive the REAL reload path against a REAL on-disk repo and read
+// through the REAL production read shape, so a pass is evidence about
+// production and not about the fixture.
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+)
+
+// readDocLikeToolsGo is the exact check-then-dereference shape the read surface
+// uses today — see groupIndexedRefSHA in tools.go, which nil-checks lr.Doc and
+// then reads lr.Doc.IndexedSHA through a SECOND load of the field. Keeping the
+// two loads separate is the point: collapsing them into one local would hide
+// defect (A) rather than fix it.
+func readDocLikeToolsGo(lg *LoadedGroup) int {
+	n := 0
+	for slug := range lg.Repos {
+		lr := lg.Repos[slug]
+		if lr == nil || lr.Doc == nil {
+			continue
+		}
+		if lr.Doc.IndexedSHA != "" {
+			n++
+		}
+		n += len(lr.Doc.Entities)
+	}
+	return n
+}
+
+// bumpMtime advances a file's mtime past its current value so an mtime-gated
+// re-read (refreshRegistryFromDisk gates on ModTime().After) is guaranteed to
+// fire even where the filesystem timestamp granularity is coarse.
+func bumpMtime(path string) {
+	fi, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	future := fi.ModTime().Add(2 * time.Second)
+	_ = os.Chtimes(path, future, future)
+}
+
+// TestGroupReadersDoNotRaceWithReloadDocSwap is defect (A) — STILL OPEN, and
+// this test is the executable evidence for it rather than a regression guard.
+//
+// Readers acquire the group through State.Group() — the production routing
+// choke point — and then read each repo's Doc with no lock held, exactly as a
+// tool handler does. Concurrently a writer publishes a new generation and calls
+// State.Reload(), which walks reloadAllLocked's `lr.Doc = doc` in-place swap.
+//
+// Measured on this fixture under -race (first run, unmodified tree):
+//
+//	WARNING: DATA RACE
+//	Write at 0x... by goroutine 38:
+//	  (*State).reloadAllLocked()  state.go:1638      // lr.Doc = doc
+//	Previous read at 0x... by goroutine 42:
+//	  readDocLikeToolsGo()        (the tool read shape)
+//
+// The #6114 snapshot does NOT close this: the snapshot shares *LoadedRepo BY
+// POINTER (deliberately — identity, index memoization and MapHandle lifetime all
+// depend on it), so an in-place write to lr.Doc is still visible to a reader
+// holding a snapshot. Closing it requires the per-repo record to become
+// copy-on-write on EVERY reload, not just when a repo goes unservable.
+//
+// SKIPPED rather than deleted: it must run green the day per-repo COW lands, and
+// a deleted test proves nothing. Un-skip it then. It is not skipped because it
+// is flaky — it fails deterministically under -race today.
+func TestGroupReadersDoNotRaceWithReloadDocSwap(t *testing.T) {
+	t.Skip("#6114 residual: reload still swaps lr.Doc in place; per-repo copy-on-write not yet landed (see unservableRepo)")
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+	if _, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("gen0")); err != nil {
+		t.Fatalf("publish gen 0: %v", err)
+	}
+
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}})
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	lg0 := st.Group("test")
+	if lg0 == nil || lg0.Repos["r"] == nil || lg0.Repos["r"].Doc == nil {
+		t.Fatal("fixture degenerate: repo not loaded with a Doc")
+	}
+	first := lg0.Repos["r"].Doc
+
+	stop := make(chan struct{})
+	var swaps atomic.Int64
+	var writer, readers sync.WaitGroup
+
+	// Writer: a same-branch reindex loop — the ordinary edit-and-reindex event.
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		for i := 1; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			if _, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker(fmt.Sprintf("gen%d", i))); err != nil {
+				return
+			}
+			if _, err := st.Reload(); err != nil {
+				return
+			}
+			swaps.Add(1)
+		}
+	}()
+
+	// Readers: the unlocked tool-handler read path, on a fixed iteration budget.
+	var sink atomic.Int64
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 3000; j++ {
+				lg := st.Group("test")
+				if lg == nil {
+					continue
+				}
+				sink.Add(int64(readDocLikeToolsGo(lg)))
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+
+	if swaps.Load() == 0 {
+		t.Fatal("vacuous: the writer never completed a reload, so no Doc swap raced the readers")
+	}
+	if cur := st.Group("test").Repos["r"].Doc; cur == first {
+		t.Fatalf("vacuous: the Doc pointer never changed across %d reloads", swaps.Load())
+	}
+}
+
+// TestGroupReadersDoNotRaceWithRepoSetChange is defect (B) — the one the issue
+// does not mention and which is strictly more severe than the Doc race it does.
+//
+// A mid-session `grafel group add-repo` / `remove-repo` rewrites registry.json;
+// the next reload picks it up (refreshRegistryFromDisk) and mutates the LIVE
+// grp.Repos map that unlocked readers are ranging over. That is a Go runtime
+// throw, not a recoverable panic.
+//
+// Non-vacuity: the reload must have observed BOTH repo-set shapes, so a
+// registry rewrite that never took effect cannot pass silently.
+func TestGroupReadersDoNotRaceWithRepoSetChange(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoA := gitRepoForDiscovery(t)
+	repoB := gitRepoForDiscovery(t)
+	for _, d := range []string{repoA, repoB} {
+		if _, err := fbwriter.WriteGraphGen(daemon.StateDirForRepoRef(d, "main"), genDocWithMarker("g")); err != nil {
+			t.Fatalf("publish graph for %s: %v", d, err)
+		}
+	}
+
+	regPath := filepath.Join(t.TempDir(), "registry.json")
+	writeReg := func(withB bool) {
+		repos := map[string]RegistryRepo{"a": {Path: repoA}}
+		if withB {
+			repos["b"] = RegistryRepo{Path: repoB}
+		}
+		b, err := json.Marshal(&Registry{Groups: map[string]RegistryGroup{"test": {Repos: repos}}})
+		if err != nil {
+			return
+		}
+		_ = os.WriteFile(regPath, b, 0o644)
+		bumpMtime(regPath)
+	}
+	writeReg(false)
+
+	reg, err := LoadRegistry(regPath)
+	if err != nil {
+		t.Fatalf("load registry: %v", err)
+	}
+	st := NewState(reg)
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	stop := make(chan struct{})
+	var reloads atomic.Int64
+	var shapes sync.Map // distinct len(grp.Repos) values the reload actually produced
+	var writer, readers sync.WaitGroup
+
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		withB := true
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			writeReg(withB)
+			if _, err := st.Reload(); err != nil {
+				return
+			}
+			st.mu.Lock()
+			n := len(st.groups["test"].Repos)
+			st.mu.Unlock()
+			shapes.Store(n, true)
+			reloads.Add(1)
+			withB = !withB
+		}
+	}()
+
+	var sink atomic.Int64
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 3000; j++ {
+				lg := st.Group("test")
+				if lg == nil {
+					continue
+				}
+				// The unlocked map iteration every repo-scoped tool performs.
+				sink.Add(int64(readDocLikeToolsGo(lg)))
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+
+	if reloads.Load() == 0 {
+		t.Fatal("vacuous: the writer never completed a reload")
+	}
+	n := 0
+	shapes.Range(func(any, any) bool { n++; return true })
+	if n < 2 {
+		t.Fatalf("vacuous: the repo set never changed shape (%d distinct sizes across %d reloads) — "+
+			"the registry rewrite did not take effect, so no map write raced the readers", n, reloads.Load())
+	}
+}
+
+// TestUnservableRepoNeverShowsAReaderADocGoingNil is the unblock evidence for
+// #5954's "nil out Doc after use" work.
+//
+// It answers the question the epic actually needs answered: can a repo be marked
+// unservable (Doc nil, loadErr set — the shape tools.go's `unavailable` list
+// keys on) without the unlocked read surface observing a nil TRANSITION and
+// dereferencing through it?
+//
+// The reader below is the production check-then-dereference shape with the two
+// loads deliberately kept apart. A reader that captures its group view and then
+// reads Doc must NEVER see the nil-check pass and the dereference fault. The
+// test asserts that directly, and asserts non-vacuity: the successor must
+// genuinely have been published (some reader saw the unservable shape) and the
+// predecessor's Doc must genuinely still be non-nil.
+func TestUnservableRepoNeverShowsAReaderADocGoingNil(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	if _, err := fbwriter.WriteGraphGen(daemon.StateDirForRepoRef(repoDir, "main"), genDocWithMarker("gen0")); err != nil {
+		t.Fatalf("publish gen 0: %v", err)
+	}
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}})
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+	st.mu.Lock()
+	pred := st.groups["test"].Repos["r"]
+	st.mu.Unlock()
+	if pred == nil || pred.Doc == nil {
+		t.Fatal("fixture degenerate: repo not loaded with a Doc")
+	}
+
+	stop := make(chan struct{})
+	var faults, sawUnservable, sawServable atomic.Int64
+	var writer, readers sync.WaitGroup
+
+	// Writer: flip the repo between servable and unservable by PUBLISHING a
+	// successor record — never by mutating the record readers already hold.
+	writer.Add(1)
+	go func() {
+		defer writer.Done()
+		down := true
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			st.mu.Lock()
+			grp := st.groups["test"]
+			if down {
+				grp.Repos["r"] = unservableRepo(pred, "no graph file found (graph.fb or graph.json)")
+			} else {
+				grp.Repos["r"] = pred
+			}
+			st.mu.Unlock()
+			down = !down
+		}
+	}()
+
+	for i := 0; i < 8; i++ {
+		readers.Add(1)
+		go func() {
+			defer readers.Done()
+			for j := 0; j < 4000; j++ {
+				lg := st.Group("test")
+				if lg == nil {
+					continue
+				}
+				lr := lg.Repos["r"]
+				if lr == nil {
+					continue
+				}
+				// The production check-then-dereference, two separate loads.
+				if lr.Doc == nil {
+					if lr.loadErr == "" {
+						faults.Add(1) // unservable but nothing to report
+					}
+					sawUnservable.Add(1)
+					continue
+				}
+				// If the field could go nil under us this dereference faults.
+				// It must not: this record's Doc is immutable for its whole life.
+				if lr.Doc.IndexedRef == "\x00never" {
+					faults.Add(1)
+				}
+				sawServable.Add(1)
+			}
+		}()
+	}
+	readers.Wait()
+	close(stop)
+	writer.Wait()
+
+	if got := faults.Load(); got != 0 {
+		t.Fatalf("reader observed a Doc transition through the check-then-deref: %d faults", got)
+	}
+	// Non-vacuity: both shapes must genuinely have been observed, or the test
+	// never exercised the transition it claims to make safe.
+	if sawUnservable.Load() == 0 {
+		t.Fatal("vacuous: no reader ever observed the unservable successor")
+	}
+	if sawServable.Load() == 0 {
+		t.Fatal("vacuous: no reader ever observed the servable predecessor")
+	}
+	// The predecessor's Doc must never have been touched — that is the whole
+	// invariant that makes a snapshot-holding reader safe.
+	if pred.Doc == nil {
+		t.Fatal("predecessor record's Doc was cleared in place — the successor protocol was not used")
+	}
+}
+
+// liveGroup returns the LIVE *LoadedGroup for name.
+//
+// State.Group returns an immutable per-call VIEW (#6114), so a fixture that
+// needs to CONFIGURE a resident group — or an assertion about group INSTANCE
+// identity — must go through the live map under s.mu. Writing through a
+// Group() result compiles and is silently discarded.
+func liveGroup(s *State, name string) *LoadedGroup {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.groups[name]
+}
+
+// mutateGroup applies fn to the LIVE group under s.mu (see liveGroup).
+func mutateGroup(t *testing.T, s *State, name string, fn func(*LoadedGroup)) {
+	t.Helper()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	g := s.groups[name]
+	if g == nil {
+		t.Fatalf("group %q is not resident", name)
+	}
+	fn(g)
+}

--- a/internal/mcp/state_group_locking_6114_test.go
+++ b/internal/mcp/state_group_locking_6114_test.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -414,4 +415,184 @@ func mutateGroup(t *testing.T, s *State, name string, fn func(*LoadedGroup)) {
 		t.Fatalf("group %q is not resident", name)
 	}
 	fn(g)
+}
+
+// TestUnservableRepoRecoversOnTheNextReload pins the recovery half of the
+// unservable contract, which is the half that is easy to get wrong and
+// invisible if you only assert the transition.
+//
+// unservableRepo must not carry contentHash forward. reloadAllLocked's inner
+// fast path is "hash matches what we last parsed → identical bytes → skip the
+// reparse", and it advances mtime WITHOUT ever assigning Doc. A successor that
+// inherited the predecessor's hash is therefore stranded: the graph on disk is
+// valid and untouched, every reload agrees there is nothing to do, and the repo
+// reports unservable forever — until the bytes happen to change.
+//
+// The fixture deliberately does NOT rewrite the graph: recovery must come from
+// the reparse alone, against byte-identical on-disk content.
+func TestUnservableRepoRecoversOnTheNextReload(t *testing.T) {
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repoDir := gitRepoForDiscovery(t)
+	mainDir := daemon.StateDirForRepoRef(repoDir, "main")
+	genPath, err := fbwriter.WriteGraphGen(mainDir, genDocWithMarker("alive"))
+	if err != nil {
+		t.Fatalf("publish graph: %v", err)
+	}
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"test": {Repos: map[string]RegistryRepo{"r": {Path: repoDir}}},
+	}})
+	t.Cleanup(st.Close)
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("initial reload: %v", err)
+	}
+
+	st.mu.Lock()
+	pred := st.groups["test"].Repos["r"]
+	st.mu.Unlock()
+	if pred == nil || pred.Doc == nil {
+		t.Fatal("fixture degenerate: repo not loaded with a Doc")
+	}
+	// Non-vacuity: the predecessor must actually carry a content hash, or
+	// zeroing it in the successor proves nothing.
+	if pred.contentHash == 0 {
+		t.Fatal("vacuous: predecessor has no contentHash, so the fast path could not have stranded it")
+	}
+	fiBefore, err := os.Stat(genPath)
+	if err != nil {
+		t.Fatalf("stat graph: %v", err)
+	}
+
+	// Mark the repo unservable through the successor protocol.
+	st.mu.Lock()
+	st.groups["test"].Repos["r"] = unservableRepo(pred, "simulated unservable")
+	st.mu.Unlock()
+
+	if lr := st.Group("test").Repos["r"]; lr.Doc != nil || lr.loadErr != "simulated unservable" {
+		t.Fatalf("successor is not in the unservable shape: Doc=%v loadErr=%q", lr.Doc, lr.loadErr)
+	}
+
+	// The next reload must bring it back, with no change on disk.
+	if _, _, err := st.reloadLocked(); err != nil {
+		t.Fatalf("recovery reload: %v", err)
+	}
+	fiAfter, err := os.Stat(genPath)
+	if err != nil {
+		t.Fatalf("stat graph after: %v", err)
+	}
+	// Non-vacuity: recovery must be attributable to the reparse, not to the
+	// graph having changed underneath us.
+	if !fiBefore.ModTime().Equal(fiAfter.ModTime()) || fiBefore.Size() != fiAfter.Size() {
+		t.Fatalf("vacuous: the on-disk graph changed across the recovery reload (%v/%d -> %v/%d)",
+			fiBefore.ModTime(), fiBefore.Size(), fiAfter.ModTime(), fiAfter.Size())
+	}
+
+	lr := st.Group("test").Repos["r"]
+	if lr == nil || lr.Doc == nil {
+		t.Fatalf("repo is permanently stranded: reload left Doc=%v loadErr=%q against a valid, untouched graph "+
+			"— unservableRepo must zero contentHash so the reparse is not skipped", lr.Doc, lr.loadErr)
+	}
+	if lr.loadErr != "" {
+		t.Errorf("recovered repo still carries loadErr %q", lr.loadErr)
+	}
+	if _, ok := lr.getByIDOne("alive"); !ok {
+		t.Error("recovered repo does not serve its entity — the Doc was assigned but not usable")
+	}
+}
+
+// TestSnapshotGroupsHandsOutViewsNotLiveGroups covers the SnapshotGroups half of
+// the #6114 change, which otherwise has no test at all: it has no production
+// caller today, so a mutant that reverts it to returning live groups survives
+// the entire suite.
+func TestSnapshotGroupsHandsOutViewsNotLiveGroups(t *testing.T) {
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	st.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	snaps := st.SnapshotGroups()
+	if len(snaps) != 1 {
+		t.Fatalf("SnapshotGroups returned %d groups, want 1", len(snaps))
+	}
+	got := snaps[0]
+
+	live := liveGroup(st, "g")
+	if got == live {
+		t.Fatal("SnapshotGroups returned the LIVE group — an unlocked caller ranging over it races reload's map write (#6114)")
+	}
+	if !got.isView {
+		t.Fatal("SnapshotGroups result is not marked as a view")
+	}
+	// The repo map must be a distinct map: mutating the live one must not be
+	// visible through an already-taken snapshot. This is the actual property —
+	// pointer inequality alone would also hold for a copy that shared the map.
+	st.mu.Lock()
+	st.groups["g"].Repos["added-later"] = &LoadedRepo{Repo: "added-later"}
+	st.mu.Unlock()
+	if _, leaked := got.Repos["added-later"]; leaked {
+		t.Fatal("SnapshotGroups shared the live repo map — a later reload's insert is visible through an in-flight snapshot")
+	}
+	// Repos are shared BY POINTER (that is deliberate, and what keeps index
+	// memoization and handle lifetime intact).
+	if got.Repos["r"] != lr {
+		t.Fatal("SnapshotGroups deep-copied the repo record; it must share *LoadedRepo by pointer")
+	}
+}
+
+// TestApplyGroupAlgoOverlayRejectsAView proves the #6114 view guard actually
+// fires. Without it, the new invariant ("a write through a Group() result is
+// silently discarded") is enforced only by a doc comment — and this change
+// already found six fixtures that had written through the live group, one of
+// which handed that object straight to this very function.
+func TestApplyGroupAlgoOverlayRejectsAView(t *testing.T) {
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	st.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{}}
+
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("applyGroupAlgoOverlay accepted a Group() view: the write would be silently discarded (#6114)")
+		}
+		msg, _ := r.(string)
+		if !strings.Contains(msg, "view") {
+			t.Fatalf("panicked for the wrong reason: %v", r)
+		}
+	}()
+	applyGroupAlgoOverlay(st.Group("g"))
+}
+
+// TestBorrowGroupHandsOutAView is the #6114 guard on the ADR-0027 F3 read path.
+// borrowGroup is inert today, but it is the designated read path for F3; if it
+// hands back the live group, defect (B) — an unlocked `range Group.Repos`
+// against reload's map write — returns in full the moment F3 lights up. Cheaper
+// to pin now than to rediscover it under a flag flip.
+func TestBorrowGroupHandsOutAView(t *testing.T) {
+	st := NewState(&Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{}},
+	}})
+	lr := &LoadedRepo{Repo: "r"}
+	st.groups["g"] = &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{"r": lr}}
+
+	b := st.borrowGroup("g")
+	if b == nil {
+		t.Fatal("borrowGroup returned nil for a resident group")
+	}
+	defer b.Release()
+
+	if b.Group == liveGroup(st, "g") {
+		t.Fatal("borrowGroup carries the LIVE group — F3 would reintroduce the #6114 repo-set race")
+	}
+	st.mu.Lock()
+	st.groups["g"].Repos["added-later"] = &LoadedRepo{Repo: "added-later"}
+	st.mu.Unlock()
+	if _, leaked := b.Group.Repos["added-later"]; leaked {
+		t.Fatal("borrowGroup shared the live repo map: a reload insert is visible through an in-flight borrow")
+	}
+	if b.Group.Repos["r"] != lr {
+		t.Fatal("borrowGroup deep-copied the repo record; it must share *LoadedRepo by pointer")
+	}
 }

--- a/internal/mcp/ux_1650_test.go
+++ b/internal/mcp/ux_1650_test.go
@@ -167,13 +167,12 @@ func TestUX1650_EndpointStatsCrossRepoLinks(t *testing.T) {
 	}
 	srv := newTestServer(t, doc)
 	// Inject a cross-repo link covering the caller.
-	lg := srv.State.Group("test")
-	if lg == nil {
-		t.Fatal("no test group")
-	}
-	lg.Links = []CrossRepoLink{
-		{Source: prefixedID("repo1", "caller"), Target: "other_repo::ext_unknown", Kind: "CALLS", Confidence: 1.0},
-	}
+	// #6114: configure the LIVE group; State.Group returns an immutable view.
+	mutateGroup(t, srv.State, "test", func(lg *LoadedGroup) {
+		lg.Links = []CrossRepoLink{
+			{Source: prefixedID("repo1", "caller"), Target: "other_repo::ext_unknown", Kind: "CALLS", Confidence: 1.0},
+		}
+	})
 
 	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
 	totals := res["totals"].(map[string]any)
@@ -202,14 +201,16 @@ func TestUX1650_FindPathsCrossRepo(t *testing.T) {
 		},
 	}
 	srv := newTestServer(t, docA, docB)
-	lg := srv.State.Group("test")
-	lg.Links = []CrossRepoLink{
-		{
-			Source: prefixedID("repoA", "mobile_call"),
-			Target: prefixedID("repoB", "backend_handler"),
-			Kind:   "FETCHES",
-		},
-	}
+	// #6114: configure the LIVE group; State.Group returns an immutable view.
+	mutateGroup(t, srv.State, "test", func(lg *LoadedGroup) {
+		lg.Links = []CrossRepoLink{
+			{
+				Source: prefixedID("repoA", "mobile_call"),
+				Target: prefixedID("repoB", "backend_handler"),
+				Kind:   "FETCHES",
+			},
+		}
+	})
 
 	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
 		"group": "test",


### PR DESCRIPTION
`internal/mcp/maphandle.go:4-11` documents the serve read path as lock-free by construction: `State.Group()` copies the group pointer under `s.mu`, releases, and a handler then reads derived state for a whole tool call holding no lock. `internal/daemon/server.go:982` serves every connection on its own goroutine into one shared `*mcp.Server`/`*State`, and `reloadBeforeCall` fires a full reload from whichever goroutine wins the debounce.

Driving the real reload path against a real on-disk repo under `-race` found **two** defects, not the one filed.

## (B) — not in the issue, and the one that can kill the daemon

`state.go:1573` `grp.Repos[rName] = lr` and `state.go:1831` `delete(grp.Repos, rName)` race the unlocked `range lg.Repos` that every repo-scoped tool performs (`tools.go:452` `groupIndexedRefSHA`, `resolveRepoFilter`). Both confirmed under `-race`. It fires whenever registry.json gains or loses a repo mid-session — any `grafel group add-repo` while agents are connected.

This is an unsynchronised map read against a map write, which the runtime can turn into a `concurrent map read and map write` **throw that `recover()` cannot catch**: the daemon process dies, taking every agent session on it.

**Stated as a projection, not a measurement.** The data race is reproduced; the throw itself was never observed in 8 runs without `-race`. Both author and reviewer held that line.

## (A) — the filed one, and the severity argument was wrong twice

`state.go:1638` `lr.Doc = doc` races the unlocked reader. Confirmed.

The first characterisation — "a pointer store won't tear, so this is a mixed-generation answer" — does not survive checking:

- Reload mutates **11+ fields in place** on the shared `*LoadedRepo`, not just `Doc`: `GraphFile`, `loadErr`, `reindexReason` (string headers), `mtime`, `semMtime` (`time.Time`), plus `LabelIndex`, `Semantic`, `TestsEdgeCount`, `contentHash`. Multi-word, genuinely tearable. Measured: the production read shape at `tools.go:3313` (`name+": "+r.loadErr`) races `state.go:1641` (`lr.loadErr = ""`).
- **A mixed-generation read is not harmless.** `groupIndexedRefSHA` (`tools.go:452`ff) loads `lr.Doc` three separate times and can return an `IndexedRef`/`IndexedSHA` pair from two different generations — a state that never existed, served to an MCP caller as the indexed state.

Both corrections are now in the `snapshotLocked` comment rather than left as the softer reading.

## Fix

`Group()` and `SnapshotGroups()` return a shallow copy with their own repo map, taken under `s.mu`. `*LoadedRepo` values are shared **by pointer**, so identity, `idxOnce` index memoization and `MapHandle` lifetime are unchanged. This closes (B). `borrowGroup` — the designated ADR-0027 F3 read path — now carries a view too, so (B) does not return when F3 lights up.

**Cost measured**, since `Group()` is on the hot path of every MCP tool call: the copy is O(repos), not O(entities). 4 repos × 10 entities = **105.6 ns/op**; 4 repos × 100k entities = **112.9 ns/op** — flat. 1 repo 75.6 ns / 0 allocs; 64 repos 1.67 µs / 3 allocs.

## The design's own hazard, guarded rather than documented

The returned view is not writable: a write-through compiles and is **silently discarded**. The first full-suite run after the change was red in five untouched tests — **eight fixtures** wrote through a `Group()` result and had been silently disarmed. One of them (`overlay_sidetable_parity_test.go:294`) wrote `algoApplied` on a view and passed that view straight into the production mutator `applyGroupAlgoOverlay`, passing only because write and read landed on the same object.

A doc comment is too thin for an invariant that generates defects, so: an unexported `LoadedGroup.isView`, set in `snapshotLocked`, panicked on in `applyGroupAlgoOverlay` — the single production group-mutator. Silent discard becomes a loud failure. Verified zero production write-through callers today; all eight test sites now route through `mutateGroup`/`liveGroup`, and the redirected identity assertions were checked to still mean what they meant (`liveGroup` preserves #5872's, and #6060's switch to `*LoadedRepo` identity still detects a double-revive).

## What it unblocks, and what it does not

`Doc` **cannot** be nil'd by writing `lr.Doc = nil` — the view shares repo records by pointer, so an in-place clear is still visible mid-read. The route is to publish a successor record into `grp.Repos` under `s.mu`: a reader then holds either the predecessor (whose `Doc` is never written again) or the successor (nil for its whole life), and no transition is observable. `unservableRepo` is that successor, inert, with `TestUnservableRepoNeverShowsAReaderADocGoingNil` proving it on the two-load check-then-deref shape with non-vacuity on both branches.

**It shipped with a stranding bug, found in review and fixed.** Carrying `contentHash` forward onto a `Doc=nil` successor meant the next reload's content-hash fast path skipped the reparse and advanced `mtime` **without ever assigning `Doc`** — permanently unservable until the bytes changed. Now zeroed, with `TestUnservableRepoRecoversOnTheNextReload` asserting the on-disk graph's mtime *and* size are unchanged across recovery, so the recovery is attributable to the reparse rather than to the fixture moving.

The successor also no longer shares the `MapHandle`. `coldShellRepo` shares because a cold shell still *serves* from the mapping; an unservable repo does not, and `Reader` non-nil with `Doc`/`LabelIndex` nil was an unvalidated shape. The predecessor's mapping goes through the F1 `retireHandle` drain. That in-place write is safe for a stated reason: `Reader`/`handle` are the one part of `LoadedRepo` already synchronised — on `readerMu`, held by every flag-on reader — so they are not part of the (A) surface.

**Residual (A) is unfixed by design and now accurately documented.** Reload's ordinary non-nil→non-nil `lr.Doc = doc` swap still races; closing it needs per-repo copy-on-write, ~250 lines restructuring `reloadAllLocked` across six `continue` exits, and it fails silently rather than at compile time. `TestGroupReadersDoNotRaceWithReloadDocSwap` ships **deliberately skipped**, carrying the measured race — verified in review that un-skipping fails deterministically at `state.go:1638`, so it is honest rather than quietly broken.

A third race is filed separately: `applyGroupAlgoOverlay` stamps fields *inside* `doc.Entities` in place while unlocked readers read those entities.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, skips counted including subtests:

| package | exit | fails | skips |
|---|---|---|---|
| `./internal/mcp/` | 0 | 0 | 9 |
| `./internal/mcp/` **-race** | 0 | 0 races | 9 |
| `./internal/daemon/` | 0 | 0 | 3 |
| `./cmd/grafel/` | 0 | 0 | 8 |

9 skips = 8 pre-existing + the one deliberate. **7 mutants, all killed behaviourally, none by compile error:** share the live map · clear `Doc` in place · drop `loadErr` · carry `contentHash` forward · `isView = false` · `SnapshotGroups` returns live · `borrowGroup` returns live. The `contentHash` mutant **built cleanly** before failing, which is what makes it a real kill rather than a compile artefact.

Independently adversarially reviewed (REQUEST-CHANGES), all findings addressed.

Closes #6114
Refs #5954, #5872, #6060, #6134
