### PR TITLE
fix(#6123): DEPENDS_ON_SERVICE mis-bound because the ref shape could never address a service node

### DIFF
--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -53,12 +53,13 @@ import (
 //  3. DEPENDS_ON_SERVICE — the target does not exist AND the ref shape could
 //     never have addressed it. FIXED in #6123, which corrected the #6105
 //     description: passes DO create `service:` entities
-//     (extractor.ExternalServiceName, internal/extractor/external_service.go:87)
+//     (extractor.ExternalServiceName, internal/extractor/external_service.go:82-90)
 //     — what no pass creates is one for a Testcontainers image. The ref was a
 //     colon-bearing NAME, i.e. defect (2)'s class, so it could only dangle or
 //     mis-bind; on this fixture it mis-bound. The producer now mints the
-//     canonical `scope:externalservice:<name>` ref, which cannot mis-bind, and
-//     no service node is fabricated. See
+//     canonical `scope:externalservice:<name>` ref, colon-bounded so it stays
+//     below the six-segment structural form where it WOULD mis-bind, and no
+//     service node is fabricated. See
 //     TestCustomExtractorDependsOnServiceDoesNotMisbind6123.
 //
 // WHY BEHAVIOURAL. A source scan ("every ref literal contains a language
@@ -665,7 +666,7 @@ func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
 //
 // WHAT WAS ACTUALLY WRONG (#6105 defect (3) restated after grounding). The
 // issue text says "no pass anywhere creates a `service:` entity". That premise
-// is false: internal/extractor/external_service.go:87 (ExternalServiceName)
+// is false: internal/extractor/external_service.go:82-90 (ExternalServiceName)
 // mints entities whose Name is exactly `service:<svc>` — `service:stripe`,
 // `service:aws-s3` — and they are the canonical DEPENDS_ON_SERVICE target
 // (internal/types/kinds.go:1239). What no pass creates is a service node for a
@@ -687,14 +688,24 @@ func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
 // THE FIX. test_doubles.go now mints the canonical target ref rather than the
 // unaddressable Name. Where a matching service node exists the edge binds to it
 // via the byQualifiedName tier; where none exists — the Testcontainers case,
-// always, since nothing normalises a docker image to a canonical service name —
-// the ref is `scope:`-prefixed and therefore handled by lookupStructural, which
-// rejects any stub that is not six segments (refs.go:2037-2039) and returns
-// statusUnmatched WITHOUT falling through to byName. The edge dangles honestly
-// and cannot mis-bind.
+// always — the ref is `scope:`-prefixed and therefore handled by
+// lookupStructural, which rejects any stub that is not six segments
+// (refs.go:2037-2039) and returns statusUnmatched WITHOUT falling through to
+// byName. The edge dangles honestly.
 //
-// NOT FIXED, DELIBERATELY: no service entity is fabricated. See the argument in
-// internal/custom/csharp/test_doubles.go's emitContainer comment.
+// "CANNOT MIS-BIND" IS CONDITIONAL, and an earlier revision of this comment
+// stated it unconditionally, which was false. The guarantee holds only while the
+// stub stays under six segments; a legal docker reference with a registry port,
+// a tag AND a digest reaches six and is parsed as Format A. The producer bounds
+// the colon count (containerServiceRef) and the boundary itself is pinned in
+// internal/resolve.TestExternalServiceRefBindsOrDanglesWhenColonSafe6123.
+//
+// NOT FIXED, DELIBERATELY: no service entity is fabricated. Note that
+// normalising the name would not have removed the dangle anyway —
+// `PostgreSqlContainer` -> `postgres` still has no node, because the curated
+// dictionary (external_service.go:52-79) is Stripe/Twilio/AWS/SaaS SDKs and
+// contains no databases at all. The real choice was fabricate-or-dangle. See the
+// argument in internal/custom/csharp/test_doubles.go's emitContainer comment.
 //
 // A dangling-count check cannot see any of this: the count IMPROVES when the
 // edge silently mis-binds and WORSENS under this fix. That is why every

--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -50,12 +50,16 @@ import (
 //     colon and an edge addresses it by that Name is structurally unresolvable.
 //     NOT fixed here: see TestCustomExtractorColonNameRefsRemainUnresolved6105.
 //
-//  3. DEPENDS_ON_SERVICE — failure mode 1, and the only one of the three where
-//     the target does not exist. internal/custom/csharp/test_doubles.go:244
-//     points the edge at `service:<Name>` and no pass anywhere creates a
-//     `service:` entity; the only node it emits is `container:<Name>`. Also not
-//     fixed here — inventing the missing node is exactly the placeholder
-//     fabrication this work is not allowed to do.
+//  3. DEPENDS_ON_SERVICE — the target does not exist AND the ref shape could
+//     never have addressed it. FIXED in #6123, which corrected the #6105
+//     description: passes DO create `service:` entities
+//     (extractor.ExternalServiceName, internal/extractor/external_service.go:87)
+//     — what no pass creates is one for a Testcontainers image. The ref was a
+//     colon-bearing NAME, i.e. defect (2)'s class, so it could only dangle or
+//     mis-bind; on this fixture it mis-bound. The producer now mints the
+//     canonical `scope:externalservice:<name>` ref, which cannot mis-bind, and
+//     no service node is fabricated. See
+//     TestCustomExtractorDependsOnServiceDoesNotMisbind6123.
 //
 // WHY BEHAVIOURAL. A source scan ("every ref literal contains a language
 // segment") is satisfied by any string that happens to contain one, and three
@@ -430,6 +434,17 @@ func TestCustomExtractorGateStructuralRefResidueIsRecorded6105(t *testing.T) {
 		"OWNS TO scope:pattern:advice:java:java/AuditAspect.java:AuditAspect.auditBefore":        1,
 		"OWNS TO scope:pattern:pointcut:java:java/AuditAspect.java:AuditAspect.anyApiCall":       1,
 		"REFERENCES TO scope:pattern:pointcut:java:java/AuditAspect.java:AuditAspect.anyApiCall": 1,
+		// #6123 — the Testcontainers container-topology edge. Now minted as the
+		// canonical external-service ref (extractor.ExternalServiceTargetID)
+		// instead of the unaddressable Name `service:PostgreSqlContainer`. It is
+		// three segments, so lookupStructural rejects it at refs.go:2037-2039 and
+		// returns statusUnmatched WITHOUT falling through to byName — which is the
+		// point: the previous ref bound to the base extractor's SCOPE.Operation for
+		// the `new PostgreSqlContainer()` call site. This entry is an INTENDED
+		// dangle, not a defect: no pass creates a service node for a docker image,
+		// and fabricating one would poison the corpus-wide external-service
+		// convergence namespace. See TestCustomExtractorDependsOnServiceDoesNotMisbind6123.
+		"DEPENDS_ON_SERVICE TO scope:externalservice:PostgreSqlContainer": 1,
 		// findRefForType (types.go:120) fallback: `Address` is declared in
 		// dto/Address.java, but the ref is minted with the REFERENCING file's
 		// path, so byLocation[dto/OrderRequest.java]["Address"] can only miss.
@@ -458,24 +473,28 @@ func TestCustomExtractorGateStructuralRefResidueIsRecorded6105(t *testing.T) {
 	}
 }
 
-// TestCustomExtractorColonNameRefsRemainUnresolved6105 pins defects (2) and (3)
-// as KNOWN AND UNFIXED rather than letting them rot unrecorded.
+// TestCustomExtractorColonNameRefsRemainUnresolved6105 pins defect (2) as KNOWN
+// AND UNFIXED rather than letting it rot unrecorded.
 //
-// WHY THEY ARE NOT FIXED HERE. Both need a resolver-side index — either byName
+// #6123 UPDATE: defect (3) — DEPENDS_ON_SERVICE — used to be covered here too.
+// It was the same colon-name class (an entity Name containing a colon can never
+// be addressed by that Name, because splitStub cuts at the first colon), but it
+// is now fixed at its producer: the ref is the canonical
+// `scope:externalservice:<name>` and its residue is recorded in
+// TestCustomExtractorGateStructuralRefResidueIsRecorded6105 instead. The kind
+// switch below no longer collects it.
+//
+// WHY IT IS NOT FIXED HERE. It needs a resolver-side index — either byName
 // keyed on the FULL colon-bearing stub, or Properties["ref"] indexed under
 // byQualifiedName the way `scope:endpoint:` / `scope:testcoverage:` /
 // `scope:component:interface:<lang>:` already are (internal/resolve/refs.go:992,
 // :1006, :1029, :1045). internal/resolve is being changed concurrently by
-// another work item, so this change stays out of it. Neither can be fixed from
-// the extractor side without harm:
-//
-//   - Setting the cache-region entity's QualifiedName to the ref would make it
-//     resolvable, but cache regions converge ACROSS files by design and
-//     duplicate QualifiedNames are blanked to a collision sentinel — the same
-//     region cached in two files would resolve to nothing again, only now
-//     "ambiguous" instead of "unmatched".
-//   - `service:<Name>` has no target at all. Fabricating one is the placeholder
-//     invention this work explicitly must not do.
+// another work item, so this change stays out of it. It cannot be fixed from
+// the extractor side without harm: setting the cache-region entity's
+// QualifiedName to the ref would make it resolvable, but cache regions converge
+// ACROSS files by design and duplicate QualifiedNames are blanked to a collision
+// sentinel — the same region cached in two files would resolve to nothing again,
+// only now "ambiguous" instead of "unmatched".
 //
 // Deleting the edges is not an option either: an edge pointing at nothing is
 // bad, silently dropping a relationship the extractor meant to express is
@@ -488,7 +507,7 @@ func TestCustomExtractorColonNameRefsRemainUnresolved6105(t *testing.T) {
 	got := map[string]int{}
 	for d, n := range added {
 		switch d.kind {
-		case "CACHES", "INVALIDATES", "READS_FROM", "WRITES_TO", "DEPENDS_ON_SERVICE":
+		case "CACHES", "INVALIDATES", "READS_FROM", "WRITES_TO":
 			got[d.String()] = n
 		}
 	}
@@ -641,36 +660,89 @@ func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
 	}
 }
 
-// TestCustomExtractorDependsOnServiceTargetIsNeverCreated6105 pins defect (3)
-// at its source rather than through the dangling count, because on this fixture
-// the endpoint does not dangle — it binds to the WRONG entity.
+// TestCustomExtractorDependsOnServiceDoesNotMisbind6123 replaces the #6105
+// ratchet that PINNED the mis-binding. Issue #6123 is the fix.
 //
-// internal/custom/csharp/test_doubles.go:244 emits
-// `DEPENDS_ON_SERVICE -> service:PostgreSqlContainer`. splitStub strips
-// "service:" and probes byName["PostgreSqlContainer"], which here finds the
+// WHAT WAS ACTUALLY WRONG (#6105 defect (3) restated after grounding). The
+// issue text says "no pass anywhere creates a `service:` entity". That premise
+// is false: internal/extractor/external_service.go:87 (ExternalServiceName)
+// mints entities whose Name is exactly `service:<svc>` — `service:stripe`,
+// `service:aws-s3` — and they are the canonical DEPENDS_ON_SERVICE target
+// (internal/types/kinds.go:1239). What no pass creates is a service node for a
+// Testcontainers image/type.
+//
+// The defect is therefore the SAME CLASS as #6105 defect (2), the colon-name
+// refs: an entity whose Name contains a colon can never be addressed by that
+// Name. LookupStatusHint runs splitStub (internal/resolve/refs.go:2658), which
+// cuts at the FIRST colon and probes byName with the REMAINDER — so a
+// `service:X` ref probes byName["X"], never byName["service:X"]. Real service
+// nodes are reached by QualifiedName (`scope:externalservice:<svc>`,
+// ExternalServiceTargetID at external_service.go:102), not by Name. So
+// `service:X` could never bind to a service node even where one existed, and
+// on a leaf-name collision it binds to whatever else is called X — here the
 // SCOPE.Operation the base C# extractor made for the `new PostgreSqlContainer()`
-// call site. So the edge reads "the container topology node depends on a
-// constructor call", which is not the relationship the extractor meant. On the
-// corpus, where no same-named entity exists, the same edge dangles instead.
+// call site, reached through the DEPENDS_ON_SERVICE operation-family hint
+// (refs.go:1782).
 //
-// A dangling-count check cannot see this: the count IMPROVES when the edge
-// silently mis-binds. That is why it is asserted on content.
-func TestCustomExtractorDependsOnServiceTargetIsNeverCreated6105(t *testing.T) {
+// THE FIX. test_doubles.go now mints the canonical target ref rather than the
+// unaddressable Name. Where a matching service node exists the edge binds to it
+// via the byQualifiedName tier; where none exists — the Testcontainers case,
+// always, since nothing normalises a docker image to a canonical service name —
+// the ref is `scope:`-prefixed and therefore handled by lookupStructural, which
+// rejects any stub that is not six segments (refs.go:2037-2039) and returns
+// statusUnmatched WITHOUT falling through to byName. The edge dangles honestly
+// and cannot mis-bind.
+//
+// NOT FIXED, DELIBERATELY: no service entity is fabricated. See the argument in
+// internal/custom/csharp/test_doubles.go's emitContainer comment.
+//
+// A dangling-count check cannot see any of this: the count IMPROVES when the
+// edge silently mis-binds and WORSENS under this fix. That is why every
+// assertion here is on content.
+func TestCustomExtractorDependsOnServiceDoesNotMisbind6123(t *testing.T) {
 	_, on := gateArms6105(t)
 
-	// No pass creates a service node for the container.
+	// (a) No service entity is fabricated for the container.
 	for i := range on.Entities {
 		e := &on.Entities[i]
 		if strings.HasPrefix(e.Name, "service:") {
-			t.Fatalf("a `service:` entity now exists (%s %s in %s) — defect (3) has changed shape "+
-				"and this test must be revisited", e.Kind, e.Name, e.SourceFile)
+			t.Errorf("a `service:` entity now exists (%s %s in %s) — the fix must not "+
+				"fabricate a service node for a Testcontainers image", e.Kind, e.Name, e.SourceFile)
 		}
 	}
 
+	// (b) NON-VACUITY. The collision the old code fell into must still be
+	// present in the graph, or this test could not detect a mis-bind at all.
+	collision := false
+	for i := range on.Entities {
+		if on.Entities[i].Kind == "SCOPE.Operation" && on.Entities[i].Name == "PostgreSqlContainer" {
+			collision = true
+			break
+		}
+	}
+	if !collision {
+		t.Fatalf("fixture no longer contains the SCOPE.Operation:PostgreSqlContainer " +
+			"collision target — a mis-bind would now be undetectable here")
+	}
+
+	// (c) The edge exists, joins the container node to the canonical
+	// external-service ref, and binds to NOTHING (honest dangle).
 	got := edgeSet6105(on, "DEPENDS_ON_SERVICE")
-	const misbound = "DEPENDS_ON_SERVICE: SCOPE.Pattern:container:PostgreSqlContainer -> SCOPE.Operation:PostgreSqlContainer"
-	if got[misbound] == 0 {
-		t.Errorf("the recorded DEPENDS_ON_SERVICE mis-binding is gone; got %v.\n"+
-			"If it now binds to a real service node, delete this test and close that part of #6105.", got)
+	want := map[string]int{
+		"DEPENDS_ON_SERVICE: SCOPE.Pattern:container:PostgreSqlContainer -> " +
+			"DANGLING(scope:externalservice:PostgreSqlContainer)": 1,
+	}
+	if len(got) != len(want) {
+		t.Errorf("DEPENDS_ON_SERVICE edge set changed size: got %v, want %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("DEPENDS_ON_SERVICE %q: got %d, want %d (full set %v)", k, got[k], n, got)
+		}
+	}
+	for k, n := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("unexpected DEPENDS_ON_SERVICE edge %q (%d) — full set %v", k, n, got)
+		}
 	}
 }

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -15,7 +15,9 @@
 //	  -> SCOPE.Pattern/container_topology; the test DEPENDS_ON_SERVICE the
 //	  container'd service, addressed by the canonical external-service ref
 //	  (scope:externalservice:<image-or-container>, #6123 — no service node is
-//	  fabricated, so the edge dangles honestly unless one already exists). The node carries
+//	  fabricated, so the edge dangles honestly unless one already exists, and the
+//	  ref is colon-bounded by containerServiceRef so it can never reach the
+//	  resolver's six-segment structural form). The node carries
 //	  image=<docker-image> when expressed via .WithImage("…") and
 //	  container_type=<XxxContainer> for the typed-builder forms.
 //
@@ -53,6 +55,7 @@ package csharp
 import (
 	"context"
 	"regexp"
+	"strings"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -138,6 +141,56 @@ func leafCSharpType(t string) string {
 		return m[1]
 	}
 	return t
+}
+
+// containerServiceRefMaxColons is the most colons a container name may carry
+// before `scope:externalservice:<name>` reaches the resolver's six-segment
+// structural-ref threshold (stubScopeSegments, internal/resolve/refs.go:2037-2039).
+// The prefix contributes two segments, so three colons in the name is the point
+// where the stub stops being REJECTED and starts being PARSED as Format A.
+const containerServiceRefMaxColons = 2
+
+// containerServiceRef returns the external-service ref for a container name, or
+// "" when no ref can be minted without risking a mis-bind.
+//
+// WHY THIS EXISTS. #6123 repaired this extractor's DEPENDS_ON_SERVICE target by
+// switching it from the unaddressable Name `service:<X>` to the canonical
+// `scope:externalservice:<X>` ref, whose safety rests on lookupStructural
+// rejecting any `scope:` stub that is not six segments. Adversarial review found
+// that the repaired shape reintroduces the same defect class at three colons:
+// once the stub IS six segments it is no longer rejected, and Format A reads
+// parts[4] as a FILE PATH and parts[5] as an entity NAME. Measured against a live
+// index, `scope:externalservice:registry.io:5000/app/pg:15@sha256:deadbeef` binds
+// to an entity named "deadbeef" in a file named "15@sha256". A registry port plus
+// tag plus digest is a legal docker reference, and reTcWithImage (:96) captures an
+// arbitrary unvalidated string literal, so the token cannot be assumed safe.
+//
+// Two steps, which fail on different inputs:
+//
+//  1. Drop the content digest (`@sha256:…`). A digest pins a BUILD, not a service
+//     identity, so it has no place in a convergence ref — and it is the third
+//     colon in every legal reference (registry port + tag + digest is the maximum;
+//     tags and repository paths cannot themselves contain colons). After this
+//     step every well-formed reference is at most two colons, i.e. safe. The raw
+//     reference is still recorded verbatim in the `image` property on both the
+//     container node and the edge, so nothing a caller could act on is lost.
+//
+//  2. Refuse anything still above the ceiling. Unreachable from a well-formed
+//     reference; it exists because the capture is unvalidated. Refusing means NO
+//     DEPENDS_ON_SERVICE edge for that container — deliberately, and narrowly.
+//     The general principle that dropping an extractor-intended relationship is
+//     worse than a dangle does not apply here, because the alternative is not a
+//     dangle: it is a ref that PARSES, and therefore mis-binds. The container
+//     node and its properties are still emitted; only the unnameable service
+//     reference is withheld.
+func containerServiceRef(name string) string {
+	if at := strings.IndexByte(name, '@'); at > 0 {
+		name = name[:at]
+	}
+	if strings.Count(name, ":") > containerServiceRefMaxColons {
+		return ""
+	}
+	return extractor.ExternalServiceTargetID(name)
 }
 
 // ---------------------------------------------------------------------------
@@ -252,12 +305,20 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// (external_service.go:20-30), and the namespace is deliberately gated on a
 	// curated SDK dictionary. The names available here are a .NET type
 	// (`PostgreSqlContainer`) or a raw docker image (`postgres:15` — itself
-	// colon-bearing), neither of which is a canonical service name; normalising
-	// them would mean inventing a second, competing service dictionary. Nor does
-	// the #6131 "repair the edge rather than accept a dangle" precedent transfer:
-	// there a correct binding already existed in the record set, and here the
-	// only candidates are the container node itself (a self-edge) and the
-	// constructor call site (the mis-bind we are removing).
+	// colon-bearing), neither of which is a canonical service name.
+	//
+	// AND NORMALISING WOULD NOT HAVE HELPED. This is the decisive point, not the
+	// "competing dictionary" one: even a perfect `PostgreSqlContainer` ->
+	// `postgres` normalisation leaves the edge dangling, because the curated
+	// dictionary (external_service.go:52-79) is Stripe / Twilio / SendGrid / AWS /
+	// SaaS SDKs and contains NO DATABASES AT ALL. There is no `postgres` node to
+	// bind to under any spelling. So the choice was never normalise-or-dangle; it
+	// was fabricate-or-dangle, and an honest dangle wins.
+	//
+	// Nor does the #6131 "repair the edge rather than accept a dangle" precedent
+	// transfer: there a correct binding already existed in the record set, and
+	// here the only candidates are the container node itself (a self-edge) and
+	// the constructor call site (the mis-bind we are removing).
 	//
 	// So the ref is the canonical one and the edge dangles honestly wherever no
 	// service node matches. That is deliberate, and it is safe for TWO
@@ -268,13 +329,22 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	//  1. `scope:`-prefixed stubs are consumed by lookupStructural, which
 	//     rejects anything that is not six segments (refs.go:2037-2039) and
 	//     returns statusUnmatched WITHOUT reaching the byName / kind-hint tiers.
-	//  2. Even without (1), splitStub cuts at the FIRST colon, so the byName
-	//     probe would be "externalservice:<name>" — a string no entity Name
-	//     carries. The old ref's probe was the bare leaf `<name>`, which real
-	//     entities do carry; that is the whole difference.
+	//     This is the load-bearing one: an inverse mutant that changed splitStub
+	//     to cut at the LAST colon left every #6123 assertion passing, so (1)
+	//     alone is sufficient and the fix survives a splitStub change.
+	//  2. Redundantly — and only accidentally so — splitStub cuts at the FIRST
+	//     colon, so the byName probe would be "externalservice:<name>", a string
+	//     no entity Name carries. The old ref's probe was the bare leaf `<name>`,
+	//     which real entities do carry; that is the whole difference.
 	//
-	// The ref still binds correctly, via byQualifiedName, if a genuine service
-	// node with that name is ever present.
+	// (1) cannot block a LEGITIMATE bind, because the byQualifiedName tier runs
+	// BEFORE lookupStructural (refs.go:1615): a genuine service node whose
+	// QualifiedName equals this ref is matched and returned before the structural
+	// tier is ever consulted. That ordering is why the guard is safe.
+	//
+	// The colon ceiling below is the third part, and it exists because the first
+	// two are conditional on the ref NOT reaching six segments. See
+	// containerServiceRef.
 	// -------------------------------------------------------------------------
 	emitContainer := func(name, image, ctype string, line int) {
 		ent := makeEntity("container:"+name, "SCOPE.Pattern", "container_topology",
@@ -288,17 +358,19 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 			props = append(props, "container_type", ctype)
 		}
 		setProps(&ent, props...)
-		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
-			ToID: extractor.ExternalServiceTargetID(name),
-			Kind: string(types.RelationshipKindDependsOnService),
-			Properties: types.Props{
-				{K: "container_type", V: ctype},
-				{K: "framework", V: "test_doubles"},
-				{K: "image", V: image},
-				{K: "line", V: itoa(line)},
-				{K: "role", V: "container_topology"},
-			},
-		})
+		if ref := containerServiceRef(name); ref != "" {
+			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+				ToID: ref,
+				Kind: string(types.RelationshipKindDependsOnService),
+				Properties: types.Props{
+					{K: "container_type", V: ctype},
+					{K: "framework", V: "test_doubles"},
+					{K: "image", V: image},
+					{K: "line", V: itoa(line)},
+					{K: "role", V: "container_topology"},
+				},
+			})
+		}
 		add(ent)
 	}
 

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -283,6 +283,15 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// Container topology — Testcontainers. The test DEPENDS_ON_SERVICE the
 	// container'd service.
 	//
+	// #6144 — that sentence describes the FROM endpoint the extractor MEANT, not
+	// the one it emits. The relationship is appended to `ent` below, so the edge
+	// runs container:X -> service X: both endpoints derive from one token and the
+	// test appears nowhere. The `image` / `container_type` payload is also already
+	// duplicated as properties on the container node, so the edge carries nothing
+	// a caller could not read off the node. Filed separately rather than folded in
+	// here — #6123 is about the TARGET, and repointing the source needs an
+	// enclosing-scope lookup this closure does not do.
+	//
 	// #6123 — the target ref. This edge used to carry `service:<name>`, which
 	// LOOKS like the Name of an external-service node (extractor.ExternalServiceName
 	// mints exactly that shape) but can never address one: LookupStatusHint runs

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -13,7 +13,9 @@
 //	Container topology (Testcontainers):
 //	  new XxxContainer()       /  new ContainerBuilder().WithImage("img")
 //	  -> SCOPE.Pattern/container_topology; the test DEPENDS_ON_SERVICE the
-//	  container'd service (service:<image-or-container>). The node carries
+//	  container'd service, addressed by the canonical external-service ref
+//	  (scope:externalservice:<image-or-container>, #6123 — no service node is
+//	  fabricated, so the edge dangles honestly unless one already exists). The node carries
 //	  image=<docker-image> when expressed via .WithImage("…") and
 //	  container_type=<XxxContainer> for the typed-builder forms.
 //
@@ -227,6 +229,43 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// -------------------------------------------------------------------------
 	// Container topology — Testcontainers. The test DEPENDS_ON_SERVICE the
 	// container'd service.
+	//
+	// #6123 — the target ref. This edge used to carry `service:<name>`, which
+	// LOOKS like the Name of an external-service node (extractor.ExternalServiceName
+	// mints exactly that shape) but can never address one: LookupStatusHint runs
+	// splitStub (internal/resolve/refs.go:2658), which cuts at the first colon
+	// and probes byName with the REMAINDER, so `service:X` probes byName["X"].
+	// Real service nodes are addressed by QualifiedName — the
+	// `scope:externalservice:<svc>` ref that ExternalServiceTargetID mints
+	// (internal/extractor/external_service.go:102) — never by Name. The old ref
+	// therefore had exactly two outcomes: dangle, or bind to some unrelated
+	// entity that happened to be called X. On the #6105 fixture it took the
+	// second: it bound to the base extractor's SCOPE.Operation for the
+	// `new PostgreSqlContainer()` call site, via the DEPENDS_ON_SERVICE
+	// operation-family hint (refs.go:1782). A mis-bind IMPROVES a dangling
+	// count, so no count-based gate could see it.
+	//
+	// WHY NOT FABRICATE THE SERVICE NODE. Emitting an ExternalServiceEntity here
+	// would make the edge resolve, and was rejected. The external-service node is
+	// a corpus-wide CONVERGENCE node whose inbound DEPENDS_ON_SERVICE set is
+	// documented as "the codebase's full <vendor> footprint"
+	// (external_service.go:20-30), and the namespace is deliberately gated on a
+	// curated SDK dictionary. The names available here are a .NET type
+	// (`PostgreSqlContainer`) or a raw docker image (`postgres:15` — itself
+	// colon-bearing), neither of which is a canonical service name; normalising
+	// them would mean inventing a second, competing service dictionary. Nor does
+	// the #6131 "repair the edge rather than accept a dangle" precedent transfer:
+	// there a correct binding already existed in the record set, and here the
+	// only candidates are the container node itself (a self-edge) and the
+	// constructor call site (the mis-bind we are removing).
+	//
+	// So the ref is the canonical one and the edge dangles honestly wherever no
+	// service node matches. That is deliberate: `scope:`-prefixed stubs are
+	// consumed by lookupStructural, which rejects anything that is not six
+	// segments (refs.go:2037-2039) and returns statusUnmatched WITHOUT falling
+	// through to the byName / kind-hint tiers — so this ref is structurally
+	// incapable of mis-binding, while still binding correctly if a genuine
+	// service node with that name is ever present.
 	// -------------------------------------------------------------------------
 	emitContainer := func(name, image, ctype string, line int) {
 		ent := makeEntity("container:"+name, "SCOPE.Pattern", "container_topology",
@@ -241,7 +280,7 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 		}
 		setProps(&ent, props...)
 		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
-			ToID: "service:" + name,
+			ToID: extractor.ExternalServiceTargetID(name),
 			Kind: string(types.RelationshipKindDependsOnService),
 			Properties: types.Props{
 				{K: "container_type", V: ctype},

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -260,12 +260,21 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// constructor call site (the mis-bind we are removing).
 	//
 	// So the ref is the canonical one and the edge dangles honestly wherever no
-	// service node matches. That is deliberate: `scope:`-prefixed stubs are
-	// consumed by lookupStructural, which rejects anything that is not six
-	// segments (refs.go:2037-2039) and returns statusUnmatched WITHOUT falling
-	// through to the byName / kind-hint tiers — so this ref is structurally
-	// incapable of mis-binding, while still binding correctly if a genuine
-	// service node with that name is ever present.
+	// service node matches. That is deliberate, and it is safe for TWO
+	// independent reasons — both pinned in
+	// internal/resolve/service_ref_shape_6123_test.go, because a mutation that
+	// disabled the first alone was covered for by the second:
+	//
+	//  1. `scope:`-prefixed stubs are consumed by lookupStructural, which
+	//     rejects anything that is not six segments (refs.go:2037-2039) and
+	//     returns statusUnmatched WITHOUT reaching the byName / kind-hint tiers.
+	//  2. Even without (1), splitStub cuts at the FIRST colon, so the byName
+	//     probe would be "externalservice:<name>" — a string no entity Name
+	//     carries. The old ref's probe was the bare leaf `<name>`, which real
+	//     entities do carry; that is the whole difference.
+	//
+	// The ref still binds correctly, via byQualifiedName, if a genuine service
+	// node with that name is ever present.
 	// -------------------------------------------------------------------------
 	emitContainer := func(name, image, ctype string, line int) {
 		ent := makeEntity("container:"+name, "SCOPE.Pattern", "container_topology",

--- a/internal/custom/csharp/test_doubles_test.go
+++ b/internal/custom/csharp/test_doubles_test.go
@@ -6,8 +6,10 @@ package csharp_test
 // ---------------------------------------------------------------------------
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/cajasmota/grafel/internal/extractor"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -100,21 +102,48 @@ public class DbFixture
 `
 	recs := extractFull(t, "custom_csharp_test_doubles", fi("DbFixture.cs", "csharp", src))
 
-	// Typed container -> DEPENDS_ON_SERVICE service:PostgreSqlContainer
-	if e := relOf(recs, "DEPENDS_ON_SERVICE", "service:PostgreSqlContainer"); e == nil {
-		t.Error("expected new PostgreSqlContainer() -> DEPENDS_ON_SERVICE service:PostgreSqlContainer")
+	// #6123 — the target is the CANONICAL external-service ref
+	// (extractor.ExternalServiceTargetID), not the entity Name `service:<X>`.
+	// A Name containing a colon is unaddressable: the resolver's splitStub cuts
+	// at the first colon and probes byName with the remainder, so the old shape
+	// could only dangle or bind to some unrelated entity called <X>. Asserted
+	// through the helper so a change to the ref convention fails here rather
+	// than silently rewiring the graph downstream.
+	//
+	// Typed container -> DEPENDS_ON_SERVICE scope:externalservice:PostgreSqlContainer
+	if e := relOf(recs, "DEPENDS_ON_SERVICE", extractor.ExternalServiceTargetID("PostgreSqlContainer")); e == nil {
+		t.Error("expected new PostgreSqlContainer() -> DEPENDS_ON_SERVICE scope:externalservice:PostgreSqlContainer")
 	} else if e.Properties.Get("container_type") != "PostgreSqlContainer" {
 		t.Errorf("expected container_type prop, got %v", e.Properties)
 	}
-	// Image binding -> DEPENDS_ON_SERVICE service:redis:7
-	if e := relOf(recs, "DEPENDS_ON_SERVICE", "service:redis:7"); e == nil {
-		t.Error("expected .WithImage(\"redis:7\") -> DEPENDS_ON_SERVICE service:redis:7")
+	// Image binding -> DEPENDS_ON_SERVICE scope:externalservice:redis:7
+	if e := relOf(recs, "DEPENDS_ON_SERVICE", extractor.ExternalServiceTargetID("redis:7")); e == nil {
+		t.Error("expected .WithImage(\"redis:7\") -> DEPENDS_ON_SERVICE scope:externalservice:redis:7")
 	} else if e.Properties.Get("image") != "redis:7" {
 		t.Errorf("expected image=redis:7, got %v", e.Properties)
 	}
-	// ContainerBuilder itself must NOT emit a service node.
-	if relOf(recs, "DEPENDS_ON_SERVICE", "service:ContainerBuilder") != nil {
-		t.Error("ContainerBuilder should be excluded from container topology")
+	// The unaddressable old shape must be gone on BOTH containers.
+	for _, stale := range []string{"service:PostgreSqlContainer", "service:redis:7"} {
+		if relOf(recs, "DEPENDS_ON_SERVICE", stale) != nil {
+			t.Errorf("DEPENDS_ON_SERVICE still emits the unaddressable Name ref %q (#6123)", stale)
+		}
+	}
+	// ContainerBuilder itself must NOT emit a service edge, under either shape.
+	for _, excluded := range []string{
+		extractor.ExternalServiceTargetID("ContainerBuilder"),
+		"service:ContainerBuilder",
+	} {
+		if relOf(recs, "DEPENDS_ON_SERVICE", excluded) != nil {
+			t.Errorf("ContainerBuilder should be excluded from container topology (saw %q)", excluded)
+		}
+	}
+	// No service ENTITY is fabricated for a container — the external-service
+	// namespace is a corpus-wide convergence node gated on a curated SDK
+	// dictionary, and a docker image is not a canonical service name (#6123).
+	for _, r := range recs {
+		if strings.HasPrefix(r.Name, "service:") || r.Kind == "SCOPE.ExternalService" {
+			t.Errorf("test-doubles extractor fabricated a service entity: %s %s", r.Kind, r.Name)
+		}
 	}
 }
 

--- a/internal/custom/csharp/test_doubles_test.go
+++ b/internal/custom/csharp/test_doubles_test.go
@@ -147,6 +147,94 @@ public class DbFixture
 	}
 }
 
+// TestTestDoubles_ContainerServiceRefIsColonBounded6123 covers the defect that
+// adversarial review found IN THE #6123 FIX ITSELF: the repaired ref shape could
+// still mis-bind, on the very class of input the repair was about.
+//
+// ExternalServiceTargetID prefixes two colon-delimited segments, so
+// `scope:externalservice:<name>` hits the resolver's six-segment structural-ref
+// threshold (internal/resolve/refs.go:2037-2039) once <name> carries THREE
+// colons. At six segments the stub stops being rejected and enters Format A,
+// with parts[4] read as a FILE PATH and parts[5] as an entity NAME. Measured
+// against a live index: `scope:externalservice:registry.io:5000/app/pg:15@sha256:deadbeef`
+// resolves to an entity named "deadbeef" in a file named "15@sha256". A registry
+// port + tag + digest is a legal docker reference, and reTcWithImage
+// (test_doubles.go:96) captures an arbitrary unvalidated string literal.
+//
+// Both halves of the guard are asserted here, because they fail differently:
+// the digest strip covers every LEGAL reference, and the colon ceiling covers
+// input that is not a well-formed reference at all.
+func TestTestDoubles_ContainerServiceRefIsColonBounded6123(t *testing.T) {
+	src := `
+using DotNet.Testcontainers.Builders;
+
+public class RegistryFixture
+{
+    public RegistryFixture()
+    {
+        var pinned = new ContainerBuilder()
+            .WithImage("registry.io:5000/app/pg:15@sha256:deadbeef")
+            .Build();
+        var junk = new ContainerBuilder()
+            .WithImage("a:b:c:d")
+            .Build();
+    }
+}
+`
+	recs := extractFull(t, "custom_csharp_test_doubles", fi("RegistryFixture.cs", "csharp", src))
+
+	// (1) Digest stripped: a build pin is not a service identity, and it is the
+	// third colon in every legal reference. The surviving ref is five segments,
+	// so lookupStructural still rejects it and the edge dangles honestly.
+	const stripped = "scope:externalservice:registry.io:5000/app/pg:15"
+	if e := relOf(recs, "DEPENDS_ON_SERVICE", stripped); e == nil {
+		t.Errorf("expected the digest-stripped ref %q", stripped)
+	} else if got := e.Properties.Get("image"); got != "registry.io:5000/app/pg:15@sha256:deadbeef" {
+		// The RAW reference is still recorded on the edge/node, so stripping the
+		// digest from the REF loses nothing a caller could act on.
+		t.Errorf("raw image reference was lost from the edge properties: %q", got)
+	}
+	// The six-segment form must never be minted — this is the mis-bind.
+	const hazard = "scope:externalservice:registry.io:5000/app/pg:15@sha256:deadbeef"
+	if relOf(recs, "DEPENDS_ON_SERVICE", hazard) != nil {
+		t.Errorf("minted the six-segment ref %q — it parses as Format A and binds to "+
+			"entity parts[5] in file parts[4] (#6123 review)", hazard)
+	}
+
+	// (2) Colon ceiling: `a:b:c:d` is not a well-formed reference and survives the
+	// digest strip at three colons, so NO ref can be minted for it. Refusing the
+	// edge is deliberate and narrow — the alternative is a ref that parses, which
+	// is the exact defect this file was repaired for.
+	for _, r := range recs {
+		for i := range r.Relationships {
+			rel := &r.Relationships[i]
+			if rel.Kind != "DEPENDS_ON_SERVICE" {
+				continue
+			}
+			if strings.Count(rel.ToID, ":") >= 6 {
+				t.Errorf("DEPENDS_ON_SERVICE ToID %q reaches the six-segment structural "+
+					"threshold and can mis-bind", rel.ToID)
+			}
+			if strings.Contains(rel.ToID, "a:b:c:d") {
+				t.Errorf("minted a ref for the malformed image `a:b:c:d`: %q", rel.ToID)
+			}
+		}
+	}
+
+	// NON-VACUITY: the malformed container node itself must still be emitted, so
+	// "no edge" means "declined to name the service", not "dropped the container".
+	found := false
+	for _, r := range recs {
+		if r.Name == "container:a:b:c:d" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the malformed-image container node was dropped entirely; only the " +
+			"unnameable service REF should be refused")
+	}
+}
+
 func TestTestDoubles_SpecFlowStepDefinitions(t *testing.T) {
 	src := `
 using TechTalk.SpecFlow;

--- a/internal/resolve/service_ref_shape_6123_test.go
+++ b/internal/resolve/service_ref_shape_6123_test.go
@@ -11,7 +11,7 @@ import (
 // #6123 was filed as "DEPENDS_ON_SERVICE targets a `service:` node no pass
 // creates". Grounding it showed the premise is only half right, and the wrong
 // half is the important one: passes DO create `service:<svc>` entities
-// (internal/extractor/external_service.go:87, ExternalServiceName). What no
+// (internal/extractor/external_service.go:82-90, ExternalServiceName). What no
 // pass creates is one for a Testcontainers image — and, separately, a
 // `service:<X>` ref could never have addressed a service node even where one
 // existed, because LookupStatusHint reaches byName through splitStub
@@ -59,27 +59,40 @@ func TestServiceNameRefCannotAddressAServiceNodeAndMisbinds6123(t *testing.T) {
 	}
 }
 
-// TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123 is the property the
-// fix relies on: the canonical ref binds to the service node when one exists,
-// and when none exists it is left VERBATIM rather than falling through to the
-// byName / kind-hint tiers that produced the mis-bind above. The collider is
-// present in both arms, so "dangles" here means "declined a wrong answer that
+// TestExternalServiceRefBindsOrDanglesWhenColonSafe6123 is the property the fix
+// relies on: a COLON-SAFE canonical ref binds to the service node when one
+// exists, and when none exists it is left VERBATIM rather than falling through
+// to the byName / kind-hint tiers that produced the mis-bind above. The collider
+// is present in both arms, so "dangles" here means "declined a wrong answer that
 // was available", not "had nothing to bind to".
 //
-// TWO INDEPENDENT MECHANISMS make that true, and BOTH are asserted below — an
-// earlier draft of this test claimed only the first and a mutation that disabled
-// it survived, because the second silently covered for it:
+// THE NAME IS DELIBERATELY CONDITIONAL. An earlier revision called this
+// "…ButNeverMisbinds", which was unconditional and FALSE: the guarantee holds
+// only while the stub stays under six segments, and adversarial review produced
+// a legal docker reference that breaks it. That case is now the last subtest
+// here, and the producer-side bound that keeps real refs out of it lives in
+// containerServiceRef (internal/custom/csharp/test_doubles.go).
+//
+// TWO MECHANISMS make the safe case true, and BOTH are asserted, because an
+// earlier draft claimed only the first and a mutation disabling it survived:
 //
 //  1. lookupStructural consumes ANY `scope:`-prefixed stub (handled=true) and
 //     returns statusUnmatched for one that is not six segments
 //     (internal/resolve/refs.go:2037-2039), so the byName tiers are never
 //     reached. Asserted directly in the "structural tier consumes it" subtest,
-//     because the end-to-end assertion cannot see this one on its own.
-//  2. Even with (1) removed, splitStub cuts at the FIRST colon, so the byName
-//     probe would be "externalservice:<name>" — a string no entity Name carries.
-//     The old `service:<X>` ref had NEITHER protection: not `scope:`-prefixed,
-//     and its byName probe is the bare leaf `X`, which real entities do carry.
-func TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123(t *testing.T) {
+//     because the end-to-end assertion cannot see this one on its own. This is
+//     the LOAD-BEARING one — an inverse mutant changing splitStub to cut at the
+//     LAST colon leaves every #6123 assertion passing.
+//  2. Redundantly, and only accidentally so: splitStub cuts at the FIRST colon,
+//     so the byName probe would be "externalservice:<name>" — a string no entity
+//     Name carries. The old `service:<X>` ref had NEITHER protection: not
+//     `scope:`-prefixed, and its byName probe is the bare leaf `X`, which real
+//     entities do carry.
+//
+// Mechanism (1) cannot block a LEGITIMATE bind, because the byQualifiedName tier
+// runs BEFORE lookupStructural (refs.go:1615) — the "service node present"
+// subtest is what pins that ordering.
+func TestExternalServiceRefBindsOrDanglesWhenColonSafe6123(t *testing.T) {
 	collider := entAt("6666000066660000", "SCOPE.Operation", "postgres", "cs/OrderTests.cs")
 
 	t.Run("structural tier consumes it and declines", func(t *testing.T) {
@@ -120,6 +133,28 @@ func TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123(t *testing.T) {
 				"dangles honestly. lookupStructural (refs.go:2037-2039) is supposed to consume "+
 				"any `scope:` stub that is not six segments and return statusUnmatched without "+
 				"consulting byName", rels[0].ToID)
+		}
+	})
+
+	// THE BOUNDARY. Three colons in the name pushes `scope:externalservice:<name>`
+	// to six segments, where lookupStructural stops rejecting it and parses it as
+	// Format A — parts[4] as a file path, parts[5] as an entity name. This subtest
+	// asserts the resolver DOES mis-bind there, which is what makes the
+	// producer-side ceiling in containerServiceRef load-bearing rather than
+	// defensive decoration. If the resolver is ever taught to distrust an
+	// `externalservice` scope-kind, this fails and the producer bound can be
+	// revisited.
+	t.Run("six segments: the resolver DOES mis-bind, hence the producer bound", func(t *testing.T) {
+		// The shape a legal `registry:port/repo:tag@sha256:digest` reference makes.
+		const hazard = "scope:externalservice:registry.io:5000/app/pg:15@sha256:deadbeef"
+		victim := entAt("8888000088880000", "Class", "deadbeef", "15@sha256")
+		idx := BuildIndex([]types.EntityRecord{victim, collider})
+		id, status, handled := idx.lookupStructural(hazard)
+		if !handled || status != statusRewritten || id != "8888000088880000" {
+			t.Fatalf("six-segment external-service stub resolved to (%q, status=%d, handled=%v); "+
+				"this test documents that it MIS-BINDS to the entity named parts[5] in the file "+
+				"named parts[4]. If the resolver now declines it, containerServiceRef's colon "+
+				"ceiling may be relaxed — re-measure before doing so", id, status, handled)
 		}
 	})
 }

--- a/internal/resolve/service_ref_shape_6123_test.go
+++ b/internal/resolve/service_ref_shape_6123_test.go
@@ -1,0 +1,97 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6123 — the two resolver facts the C# test-doubles fix depends on.
+//
+// #6123 was filed as "DEPENDS_ON_SERVICE targets a `service:` node no pass
+// creates". Grounding it showed the premise is only half right, and the wrong
+// half is the important one: passes DO create `service:<svc>` entities
+// (internal/extractor/external_service.go:87, ExternalServiceName). What no
+// pass creates is one for a Testcontainers image — and, separately, a
+// `service:<X>` ref could never have addressed a service node even where one
+// existed, because LookupStatusHint reaches byName through splitStub
+// (refs.go:2658), which cuts at the FIRST colon and probes with the REMAINDER.
+//
+// These two tests pin that pair of behaviours so a later resolver change cannot
+// silently take the producer fix's ground away. Neither asserts a count; both
+// assert which entity an endpoint lands on.
+//
+// NOT a test of the fix itself — the behavioural gate for that is
+// cmd/grafel.TestCustomExtractorDependsOnServiceDoesNotMisbind6123.
+
+// TestServiceNameRefCannotAddressAServiceNodeAndMisbinds6123 shows why the old
+// ref shape was unusable in BOTH directions: the real service node is present
+// and is NOT what the ref binds to.
+func TestServiceNameRefCannotAddressAServiceNodeAndMisbinds6123(t *testing.T) {
+	svc := entAt("5555000055550000", "SCOPE.ExternalService", "service:postgres", "<external-service>")
+	svc.QualifiedName = "scope:externalservice:postgres"
+	entities := []types.EntityRecord{
+		svc,
+		// The leaf-name collision: an unrelated call-site operation that merely
+		// happens to be called "postgres". This is the shape the C# extractor
+		// hit — its collider was SCOPE.Operation "PostgreSqlContainer".
+		entAt("6666000066660000", "SCOPE.Operation", "postgres", "cs/OrderTests.cs"),
+		// A second same-named entity so the bare name is genuinely ambiguous and
+		// the DEPENDS_ON_SERVICE operation-family hint (refs.go:1782) is what
+		// picks a winner — exactly the path taken in the field.
+		entAt("7777000077770000", "Component", "postgres", "infra/postgres.tf"),
+	}
+	idx := BuildIndex(entities)
+	rels := []types.RelationshipRecord{
+		{FromID: "5555000055550000", ToID: "service:postgres", Kind: "DEPENDS_ON_SERVICE"},
+	}
+	References(rels, idx)
+
+	if rels[0].ToID == "5555000055550000" {
+		t.Fatalf("`service:postgres` now binds to the service node by Name — splitStub " +
+			"no longer eats the prefix. The #6123 producer fix rests on it doing so; " +
+			"re-check internal/custom/csharp/test_doubles.go before relaxing anything here.")
+	}
+	if rels[0].ToID != "6666000066660000" {
+		t.Fatalf("`service:postgres` bound to %q, want the SCOPE.Operation collider "+
+			"6666000066660000 — this test is meant to demonstrate the mis-bind, so if the "+
+			"shape has changed the demonstration must be rebuilt, not deleted", rels[0].ToID)
+	}
+}
+
+// TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123 is the property the
+// fix relies on: the canonical ref binds to the service node when one exists,
+// and when none exists it is left VERBATIM rather than falling through to the
+// byName / kind-hint tiers that produced the mis-bind above. The collider is
+// present in both arms, so "dangles" here means "declined a wrong answer that
+// was available", not "had nothing to bind to".
+func TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123(t *testing.T) {
+	collider := entAt("6666000066660000", "SCOPE.Operation", "postgres", "cs/OrderTests.cs")
+
+	t.Run("service node present: binds to it", func(t *testing.T) {
+		svc := entAt("5555000055550000", "SCOPE.ExternalService", "service:postgres", "<external-service>")
+		svc.QualifiedName = "scope:externalservice:postgres"
+		idx := BuildIndex([]types.EntityRecord{svc, collider})
+		rels := []types.RelationshipRecord{
+			{FromID: "6666000066660000", ToID: "scope:externalservice:postgres", Kind: "DEPENDS_ON_SERVICE"},
+		}
+		References(rels, idx)
+		if rels[0].ToID != "5555000055550000" {
+			t.Fatalf("canonical ref bound to %q, want the service node 5555000055550000", rels[0].ToID)
+		}
+	})
+
+	t.Run("no service node: stays verbatim, does not take the collider", func(t *testing.T) {
+		idx := BuildIndex([]types.EntityRecord{collider})
+		rels := []types.RelationshipRecord{
+			{FromID: "6666000066660000", ToID: "scope:externalservice:postgres", Kind: "DEPENDS_ON_SERVICE"},
+		}
+		References(rels, idx)
+		if rels[0].ToID != "scope:externalservice:postgres" {
+			t.Fatalf("canonical ref was rewritten to %q; it must be left verbatim so the edge "+
+				"dangles honestly. lookupStructural (refs.go:2037-2039) is supposed to consume "+
+				"any `scope:` stub that is not six segments and return statusUnmatched without "+
+				"consulting byName", rels[0].ToID)
+		}
+	})
+}

--- a/internal/resolve/service_ref_shape_6123_test.go
+++ b/internal/resolve/service_ref_shape_6123_test.go
@@ -65,8 +65,36 @@ func TestServiceNameRefCannotAddressAServiceNodeAndMisbinds6123(t *testing.T) {
 // byName / kind-hint tiers that produced the mis-bind above. The collider is
 // present in both arms, so "dangles" here means "declined a wrong answer that
 // was available", not "had nothing to bind to".
+//
+// TWO INDEPENDENT MECHANISMS make that true, and BOTH are asserted below — an
+// earlier draft of this test claimed only the first and a mutation that disabled
+// it survived, because the second silently covered for it:
+//
+//  1. lookupStructural consumes ANY `scope:`-prefixed stub (handled=true) and
+//     returns statusUnmatched for one that is not six segments
+//     (internal/resolve/refs.go:2037-2039), so the byName tiers are never
+//     reached. Asserted directly in the "structural tier consumes it" subtest,
+//     because the end-to-end assertion cannot see this one on its own.
+//  2. Even with (1) removed, splitStub cuts at the FIRST colon, so the byName
+//     probe would be "externalservice:<name>" — a string no entity Name carries.
+//     The old `service:<X>` ref had NEITHER protection: not `scope:`-prefixed,
+//     and its byName probe is the bare leaf `X`, which real entities do carry.
 func TestExternalServiceRefBindsOrDanglesButNeverMisbinds6123(t *testing.T) {
 	collider := entAt("6666000066660000", "SCOPE.Operation", "postgres", "cs/OrderTests.cs")
+
+	t.Run("structural tier consumes it and declines", func(t *testing.T) {
+		idx := BuildIndex([]types.EntityRecord{collider})
+		id, status, handled := idx.lookupStructural("scope:externalservice:postgres")
+		if !handled {
+			t.Fatalf("lookupStructural did not claim `scope:externalservice:postgres` "+
+				"(handled=%v) — a non-six-segment `scope:` stub must be consumed there, "+
+				"not passed down to the byName / kind-hint tiers", handled)
+		}
+		if status != statusUnmatched || id != "" {
+			t.Fatalf("lookupStructural returned (%q, status=%d), want (\"\", statusUnmatched=%d)",
+				id, status, statusUnmatched)
+		}
+	})
 
 	t.Run("service node present: binds to it", func(t *testing.T) {
 		svc := entAt("5555000055550000", "SCOPE.ExternalService", "service:postgres", "<external-service>")


### PR DESCRIPTION
`DEPENDS_ON_SERVICE` edges from the C# Testcontainers extractor bound to a real, unrelated code entity instead of dangling — so the dangling-count metric improved while the graph got worse.

## The issue's premise is half wrong, and the wrong half is the root cause

**Filed:** *"targets a `service:` node no pass creates."*

**Measured:** passes *do* create them. `extractor.ExternalServiceName` (`internal/extractor/external_service.go:82-90`) mints `service:<svc>` as the entity **Name**, and that node is the documented target (`internal/types/kinds.go:1239`). What no pass creates is one for a *Testcontainers image*.

The real cause is a **ref-shape mismatch** of #6105's colon-bearing-name class:

- `internal/custom/csharp/test_doubles.go` emitted `ToID: "service:" + name`.
- `splitStub` (`internal/resolve/refs.go:2658`) cuts at the **first** colon and `LookupStatusHint` probes `byName[remainder]`. So `service:X` probes `byName["X"]` and can never reach `byName["service:X"]`. Real service nodes are addressed by `QualifiedName` (`scope:externalservice:<svc>`).

So the old ref had exactly two possible fates: dangle, or bind to whatever else was named `X`. On the #6105 fixture it took the second — `SCOPE.Operation:PostgreSqlContainer`, the base extractor's `new PostgreSqlContainer()` call site, via the operation-family hint at `refs.go:1782`.

Proved directly rather than inferred: `TestServiceNameRefCannotAddressAServiceNodeAndMisbinds6123` builds an index containing the **real** `service:postgres` node *and* a same-leaf collider — the ref still lands on the collider. The ref shape was unusable even where the target existed. Review confirmed the test discriminates ref shape rather than fixture construction: the companion subtest uses the same index with the new ref and binds correctly.

## Fix: canonical ref, honest dangle, nothing fabricated

`ToID` is now `extractor.ExternalServiceTargetID(name)`, binding through `byQualifiedName` when a genuine service node matches and dangling otherwise.

**Fabricating the service node was rejected**, and the decisive argument is not the one first written. It is not that normalising invents a competing dictionary — it is that **normalisation would not remove the dangle anyway**: `PostgreSqlContainer` → `postgres` still has no node, because `external_service.go:52-79` is a curated SaaS-SDK dictionary (Stripe, Twilio, SendGrid, AWS) with **no databases at all**. The choice was fabricate-or-dangle.

**#6131's repair-the-edge precedent does not transfer.** There a correct binding already existed in the record set. Here the only candidates are the container node itself (a self-edge) and the constructor call site being removed. There is no correct target.

## The fix reintroduced the defect class in its own output — found in review, fixed

`stubScopeSegments = 6`, and `lookupStructural` stops *rejecting* and starts *parsing* as Format A at exactly six segments. A docker reference with three colons — `registry.io:5000/app/pg:15@sha256:deadbeef`, legal (registry port + tag + digest) — reaches six:

```
-> status=statusRewritten handled=true, bound to entity "deadbeef" in file "15@sha256"
```

`reTcWithImage` (`test_doubles.go:97`) captures an **arbitrary unvalidated string literal**, so the token was never safe to interpolate into a namespace helper written for colon-free names.

`containerServiceRef` now bounds it in two steps that fail on different inputs and are asserted separately:

1. **Drop the content digest.** A digest pins a build, not a service identity, and it is the third colon in every legal reference — tags and repository paths cannot contain colons, so registry-port + tag + digest is the maximum. After the strip, every well-formed reference is ≤2 colons. The raw reference is preserved verbatim in `image` on both node and edge.
2. **Refuse anything still above the ceiling** — no edge at all. Unreachable from a well-formed reference. The usual "a dangle beats dropping the relationship" rule does **not** apply here, because the alternative is not a dangle: it is a ref that parses, and therefore mis-binds.

Claims narrowed to what is provable: the test is `…WhenColonSafe6123`, not `…ButNeverMisbinds6123`, and the "cannot mis-bind" language in both the source comment and the `cmd/grafel` header now states the six-segment condition explicitly.

## A guard that claimed more than it proved

The first version of the resolver-side guard **survived** mutation M3 (`lookupStructural` short-stub → `statusSkip, false`). `scope:externalservice:postgres` turns out to be protected **twice**: `lookupStructural` consuming the short stub, and `splitStub` leaving `externalservice:postgres` as a `byName` probe no entity Name carries. The second silently covered for the first, and no end-to-end assertion can separate them — under M3, exactly **1 test of 2046** in `internal/resolve` fails and the `cmd/grafel` end-to-end passes.

An in-package subtest now calls `lookupStructural` directly, and the comment credits both mechanisms.

**The redundancy is accidental, not load-bearing.** The inverse mutant (`splitStub` → `LastIndexByte`) leaves all four #6123 assertions passing, so mechanism (1) alone suffices and the fix survives a `splitStub` change. It was `TestCustomExtractorColonNameRefsRemainUnresolved6105` — the *other* #6105 defect — that depended on `splitStub`'s shape.

The guard cannot block a legitimate bind: `byQualifiedName` (`refs.go:1615`) runs **before** `lookupStructural`, pinned by the "service node present" subtest.

## One instance of a live class

The same shape — a ref intending a colon-bearing **Name** against a target with no `QualifiedName` — is live in at least eight more sites. Cheapest next win: the **neo4j `node:` cluster in five languages** (`csharp`, `elixir`, `golang`, `php`, `rust`), whose Java/Python/Ruby siblings emit the same edge as `"Class:"+targetType` and resolve correctly. Surveyed on #6122; scope deliberately not expanded here.

The `FROM` side is filed as #6144: the edge runs container→its-own-service, both endpoints derived from one token, with `image`/`container_type` already duplicated as properties on the container node — so the edge carries nothing an MCP caller can't get from `grafel_inspect`.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`, skips counted including subtests:

| package | exit | skips |
|---|---|---|
| `./internal/resolve/...` `./internal/extractors/...` `./internal/custom/...` `./internal/extractor/` `./internal/graph/...` | 0 | 7 |
| `./cmd/grafel/` | 0 | 8 |

Full suites run **before** each commit. All skips pre-existing.

**9 mutants, all killed behaviourally, none by compile error:** revert `ToID` · fabricate the entity · `lookupStructural` short-stub → skip · rename the collider · remove the colon ceiling · remove the digest strip · ceiling off-by-one · resolver declines the scope-kind · `splitStub` last-colon (survives by design, proving mechanism 1 sufficient).

Assertions are on the full `DEPENDS_ON_SERVICE` edge **set** — size and content, both directions — never on a dangling count, which is the metric this defect exploits. The commit records that the count **worsens** under this fix.

## Unverified, stated rather than left silent

- **Corpus scale is a projection.** Nothing was indexed. If the corpus holds a same-leaf collider for any Testcontainers type name, the pre-fix behaviour there was mis-bind rather than dangle, and the improvement is larger than claimed.
- **`.WithImage(...)`** is covered at producer and resolver level including registry/tag/digest, but no `cmd/grafel` fixture drives it through a full index — that arm still only exercises the typed-container form.
- **The refusal branch has no field evidence.** It fires only on input that is not a well-formed docker reference; the test uses a synthetic `a:b:c:d`. It is defence against an unvalidated capture, not a measured occurrence.

Independently adversarially reviewed (REQUEST-CHANGES), both findings addressed.

Closes #6123
Refs #6105, #6122, #6131, #6144
