### PR TITLE
fix(#6122): neo4j node: refs could never address their target — five extractors, one guard tested

### DIFF
--- a/cmd/grafel/neo4j_graph_relates_6122_test.go
+++ b/cmd/grafel/neo4j_graph_relates_6122_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Issue #6122 — the neo4j `node:` ref cluster.
+//
+// THE DEFECT. The Cypher-string neo4j extractors in five languages
+// (csharp/elixir/golang/php/rust) mint a synthetic node-label entity whose Name
+// is `node:<label>` and then emit the GRAPH_RELATES edge with
+// `ToID: "node:" + dstLabel`. The target carries no QualifiedName, so
+// LookupStatusHint reaches byName through splitStub
+// (internal/resolve/refs.go:2658), which cuts at the FIRST colon and probes with
+// the REMAINDER — the BARE LABEL. A ref intending the entity `node:Movie` can
+// therefore only ever probe `byName["Movie"]`, which the intended target does
+// not carry.
+//
+// That leaves two fates, and the second is the one that matters: dangle, or bind
+// to whatever unrelated entity happens to be named `Movie`. A Cypher label is a
+// database label recovered from a query string; a repo that stores Movie nodes
+// very often also declares a Go struct / C# class called `Movie`. So the
+// mis-bind is the LIKELY outcome, not the corner case — and a mis-bind IMPROVES
+// the dangling-count metric while making the graph wrong. Every assertion below
+// is on which entity the edge lands on, never on a count.
+//
+// THE FIXTURE IS BUILT TO DETECT THE MIS-BIND. `store.go` declares a real Go
+// struct named `Movie` — the collider — alongside the Cypher that produces the
+// `node:Movie` schema entity. Without the collider present this test could not
+// tell "bound correctly" from "found nothing to mis-bind to", so its presence is
+// asserted separately (non-vacuity) before the edge itself is checked.
+func writeNeo4jFixture6122(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	files := map[string]string{
+		"store/store.go": "package store\n\n" +
+			"import \"github.com/neo4j/neo4j-go-driver/v5/neo4j\"\n\n" +
+			"// Movie is THE COLLIDER: a real Go struct whose name equals the Cypher\n" +
+			"// node label below. `node:Movie` splits to a bare `Movie` byName probe,\n" +
+			"// which this struct answers.\n" +
+			"type Movie struct {\n" +
+			"\tTitle string\n" +
+			"}\n\n" +
+			"func Cast(s neo4j.Session) {\n" +
+			"\t_, _ = s.Run(`MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m`, nil)\n" +
+			"}\n",
+	}
+	for rel, body := range files {
+		p := filepath.Join(root, rel)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", rel, err)
+		}
+		if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", rel, err)
+		}
+	}
+	return root
+}
+
+// TestNeo4jGraphRelatesBindsTheNodeEntityNotTheCollider6122 is the behavioural
+// gate for the fix. The GRAPH_RELATES edge must join the two SCOPE.Schema
+// node-label entities the Cypher pattern names — NOT the same-named Go struct.
+func TestNeo4jGraphRelatesBindsTheNodeEntityNotTheCollider6122(t *testing.T) {
+	fixture := writeNeo4jFixture6122(t)
+	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "1")
+	doc := persistAndReload(t, runIndexerOn(t, fixture, "neo4j6122", nil))
+
+	// (a) NON-VACUITY, both halves. The collider must exist, or a mis-bind is
+	// undetectable; the intended target must exist, or "does not bind to the
+	// collider" would be satisfied by an edge that simply has nothing to hit.
+	var collider, target *graph.Entity
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		switch {
+		case e.Name == "Movie" && e.Kind != "SCOPE.Schema":
+			collider = e
+		case e.Kind == "SCOPE.Schema" && e.Name == "node:Movie":
+			target = e
+		}
+	}
+	if collider == nil {
+		t.Fatalf("fixture no longer contains a non-schema entity named `Movie` — the " +
+			"collider is what makes a mis-bind visible here; rebuild it, do not delete " +
+			"the assertion")
+	}
+	if target == nil {
+		t.Fatalf("no SCOPE.Schema entity named `node:Movie` — the neo4j extractor did " +
+			"not run or no longer mints the node-label entity")
+	}
+
+	// (b) CONTENT, BOTH DIRECTIONS. The edge names the entities it joins by
+	// kind and name, so binding to the wrong node fails exactly as loudly as
+	// binding to nothing.
+	got := edgeSet6105(doc, "GRAPH_RELATES")
+	want := map[string]int{
+		"GRAPH_RELATES: SCOPE.Schema:node:Person -> SCOPE.Schema:node:Movie": 1,
+	}
+	if len(got) != len(want) {
+		t.Errorf("GRAPH_RELATES edge set changed size: got %v, want %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("GRAPH_RELATES %q: got %d, want %d (full set %v)", k, got[k], n, got)
+		}
+	}
+	for k, n := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("unexpected GRAPH_RELATES edge %q (%d) — full set %v", k, n, got)
+		}
+	}
+
+	// (c) The specific wrong answer, named. Redundant with (b) but it fails with
+	// the diagnosis rather than a set diff.
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind == "GRAPH_RELATES" && r.ToID == collider.ID {
+			t.Errorf("GRAPH_RELATES bound to the Go struct %s:%s (%s) instead of the "+
+				"SCOPE.Schema node entity — this is the #6122 mis-bind",
+				collider.Kind, collider.Name, collider.SourceFile)
+		}
+	}
+}

--- a/internal/custom/csharp/neo4j.go
+++ b/internal/custom/csharp/neo4j.go
@@ -173,14 +173,14 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			if label == "" {
 				continue
 			}
-			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "csharp", line)
+			n := makeEntity(extractor.Neo4jNodeName(label), "SCOPE.Schema", "", file.Path, "csharp", line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
 			before := len(entities)
 			add(n)
 			// add() dedupes; only register the index when actually appended.
 			if len(entities) == before+1 {
-				nodeIdx["node:"+label] = before
+				nodeIdx[extractor.Neo4jNodeName(label)] = before
 			}
 		}
 
@@ -211,7 +211,9 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
 		//
 		// The resolver fills FromID from the owning node entity and resolves
-		// ToID ("node:<label>") to the target node entity by name. Only emitted
+		// ToID (`scope:schema:<file>#node:<label>`, #6122) to the target node
+		// entity by LOCATION — addressing it by its colon-bearing Name could
+		// not work, see internal/extractor/neo4j_node.go. Only emitted
 		// when BOTH endpoints carry a static label AND the relation a static
 		// type; dynamic / parameterised relations stay label/type-only —
 		// honest-partial.
@@ -236,14 +238,25 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 				direction = "UNDIRECTED"
 			}
 
-			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			// #6122 — address the target node entity by LOCATION, not by its
+			// colon-bearing Name. `"node:"+dstLabel` reached byName through
+			// splitStub, which cuts at the first colon, so it probed the BARE
+			// label and bound to any code symbol of that name. "" means the
+			// helper refused a colon-bearing path/label: emit NO edge, because
+			// the alternative is not an honest dangle but a ref that PARSES as
+			// Format A. See internal/extractor/neo4j_node.go.
+			toID := extractor.Neo4jNodeTargetID(file.Path, dstLabel)
+			if toID == "" {
+				continue
+			}
+			ownerIdx, ok := nodeIdx[extractor.Neo4jNodeName(srcLabel)]
 			if !ok {
 				continue
 			}
 			entities[ownerIdx].Relationships = append(
 				entities[ownerIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: "node:" + dstLabel,
+					ToID: toID,
 					Kind: string(types.RelationshipKindGraphRelates),
 					Properties: types.Props{
 						{K: "direction", V: direction},

--- a/internal/custom/csharp/neo4j_test.go
+++ b/internal/custom/csharp/neo4j_test.go
@@ -42,13 +42,27 @@ func extractCSNeo4j(t *testing.T, src string) []types.EntityRecord {
 // findCSGraphRelates returns the GRAPH_RELATES edge from the node entity named
 // "node:<fromLabel>" to ToID "node:<toLabel>", or nil if absent.
 func findCSGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	// #6122 — the edge now addresses the target node entity by LOCATION
+	// (scope:schema:<file>#node:<label>), not by its colon-bearing Name. Derive
+	// the expected ToID from the entity ACTUALLY minted for toLabel rather than
+	// hard-coding a path, so a ref naming a file no entity lives in fails here.
+	want := ""
 	for i := range ents {
-		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(toLabel) {
+			want = extreg.Neo4jNodeTargetID(ents[i].SourceFile, toLabel)
+			break
+		}
+	}
+	if want == "" {
+		return nil
+	}
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(fromLabel)) {
 			continue
 		}
 		for j := range ents[i].Relationships {
 			r := &ents[i].Relationships[j]
-			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == want {
 				return r
 			}
 		}

--- a/internal/custom/elixir/neo4j.go
+++ b/internal/custom/elixir/neo4j.go
@@ -166,14 +166,14 @@ func (e *neo4jElixirExtractor) Extract(ctx context.Context, file extractor.FileI
 			if label == "" {
 				continue
 			}
-			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "elixir", line)
+			n := makeEntity(extractor.Neo4jNodeName(label), "SCOPE.Schema", "", file.Path, "elixir", line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
 			before := len(entities)
 			add(n)
 			// add() dedupes; only register the index when actually appended.
 			if len(entities) == before+1 {
-				nodeIdx["node:"+label] = before
+				nodeIdx[extractor.Neo4jNodeName(label)] = before
 			}
 		}
 
@@ -227,14 +227,25 @@ func (e *neo4jElixirExtractor) Extract(ctx context.Context, file extractor.FileI
 				direction = "UNDIRECTED"
 			}
 
-			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			// #6122 — address the target node entity by LOCATION, not by its
+			// colon-bearing Name. `"node:"+dstLabel` reached byName through
+			// splitStub, which cuts at the first colon, so it probed the BARE
+			// label and bound to any code symbol of that name. "" means the
+			// helper refused a colon-bearing path/label: emit NO edge, because
+			// the alternative is not an honest dangle but a ref that PARSES as
+			// Format A. See internal/extractor/neo4j_node.go.
+			toID := extractor.Neo4jNodeTargetID(file.Path, dstLabel)
+			if toID == "" {
+				continue
+			}
+			ownerIdx, ok := nodeIdx[extractor.Neo4jNodeName(srcLabel)]
 			if !ok {
 				continue
 			}
 			entities[ownerIdx].Relationships = append(
 				entities[ownerIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: "node:" + dstLabel,
+					ToID: toID,
 					Kind: string(types.RelationshipKindGraphRelates),
 					Properties: types.Props{
 						{K: "direction", V: direction},

--- a/internal/custom/elixir/neo4j_test.go
+++ b/internal/custom/elixir/neo4j_test.go
@@ -39,13 +39,27 @@ func extractExNeo4j(t *testing.T, src string) []types.EntityRecord {
 }
 
 func findExGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	// #6122 — the edge now addresses the target node entity by LOCATION
+	// (scope:schema:<file>#node:<label>), not by its colon-bearing Name. Derive
+	// the expected ToID from the entity ACTUALLY minted for toLabel rather than
+	// hard-coding a path, so a ref naming a file no entity lives in fails here.
+	want := ""
 	for i := range ents {
-		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(toLabel) {
+			want = extreg.Neo4jNodeTargetID(ents[i].SourceFile, toLabel)
+			break
+		}
+	}
+	if want == "" {
+		return nil
+	}
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(fromLabel)) {
 			continue
 		}
 		for j := range ents[i].Relationships {
 			r := &ents[i].Relationships[j]
-			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == want {
 				return r
 			}
 		}

--- a/internal/custom/golang/neo4j.go
+++ b/internal/custom/golang/neo4j.go
@@ -159,7 +159,7 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			if label == "" {
 				continue
 			}
-			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, file.Language, line)
+			n := makeEntity(extractor.Neo4jNodeName(label), "SCOPE.Schema", "", file.Path, file.Language, line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
 			before := len(entities)
@@ -167,7 +167,7 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			// Record the node entity's index the first time it is emitted.
 			// add() dedupes, so only register when it was actually appended.
 			if len(entities) == before+1 {
-				nodeIdx["node:"+label] = before
+				nodeIdx[extractor.Neo4jNodeName(label)] = before
 			}
 		}
 
@@ -198,7 +198,9 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 		//   (a:A)<-[:R]-(b:B)   →  B ─GRAPH_RELATES(R, OUTGOING)→ node:A
 		//
 		// The resolver fills FromID from the owning node entity and resolves
-		// ToID ("node:<label>") to the target node entity by name. Only emitted
+		// ToID (`scope:schema:<file>#node:<label>`, #6122) to the target node
+		// entity by LOCATION — addressing it by its colon-bearing Name could
+		// not work, see internal/extractor/neo4j_node.go. Only emitted
 		// when BOTH endpoints carry a static label AND the relation a static
 		// type; dynamic / parameterised relations don't match and stay
 		// label/type-only — honest-partial.
@@ -224,14 +226,25 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 				direction = "UNDIRECTED"
 			}
 
-			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			// #6122 — address the target node entity by LOCATION, not by its
+			// colon-bearing Name. `"node:"+dstLabel` reached byName through
+			// splitStub, which cuts at the first colon, so it probed the BARE
+			// label and bound to any code symbol of that name. "" means the
+			// helper refused a colon-bearing path/label: emit NO edge, because
+			// the alternative is not an honest dangle but a ref that PARSES as
+			// Format A. See internal/extractor/neo4j_node.go.
+			toID := extractor.Neo4jNodeTargetID(file.Path, dstLabel)
+			if toID == "" {
+				continue
+			}
+			ownerIdx, ok := nodeIdx[extractor.Neo4jNodeName(srcLabel)]
 			if !ok {
 				continue
 			}
 			entities[ownerIdx].Relationships = append(
 				entities[ownerIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: "node:" + dstLabel,
+					ToID: toID,
 					Kind: string(types.RelationshipKindGraphRelates),
 					Properties: types.Props{
 						{K: "direction", V: direction},

--- a/internal/custom/golang/neo4j_test.go
+++ b/internal/custom/golang/neo4j_test.go
@@ -247,3 +247,68 @@ func TestNeo4jGoImportGate(t *testing.T) {
 		t.Errorf("neo4j extractor must not fire without the driver import, got %+v", ents)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #6122 — the producer-side refusal arm.
+// ---------------------------------------------------------------------------
+
+// TestNeo4jGoGraphRelatesDroppedForColonBearingPath6122 covers the `continue`
+// in the GRAPH_RELATES pass that fires when extractor.Neo4jNodeTargetID refuses
+// to build a ref. Without this test that arm is unreachable from any fixture —
+// every other path in the repo is colon-free — and a mutant deleting it would
+// survive.
+//
+// WHY DROPPING THE EDGE IS RIGHT HERE, and why the usual "an honest dangle beats
+// nothing" rule does not apply: at two colons in the path the stub reaches
+// stubScopeSegments = 6, where lookupStructural stops rejecting and parses it as
+// Format A with parts[4] as a file path and parts[5] as an entity name
+// (internal/resolve/refs.go:2037). The alternative to dropping is not a dangle —
+// it is a ref that PARSES, and therefore mis-binds. The resolver half of this is
+// the "six segments" subtest of
+// internal/resolve.TestNeo4jNodeLocationRefBindsTheNodeEntity6122.
+//
+// The node-label ENTITIES are still emitted; only the edge is withheld.
+func TestNeo4jGoGraphRelatesDroppedForColonBearingPath6122(t *testing.T) {
+	e, ok := extreg.Get("custom_go_neo4j")
+	if !ok {
+		t.Fatal("custom_go_neo4j not registered")
+	}
+	src := "package store\n\nimport (\n" + neo4jImport + ")\n\n" +
+		"func q(session neo4j.Session) {\n" +
+		"\tsession.Run(`MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m`, nil)\n" +
+		"}\n"
+	ents, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     "a:b:c/store.go", // ':' is legal in a POSIX filename
+		Language: "go",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	// NON-VACUITY: the same source through a colon-free path DOES produce the
+	// edge, so "no edge" below means "refused", not "nothing was extracted".
+	if findGoGraphRelates(extractNeo4jRaw(t, src), "Person", "Movie") == nil {
+		t.Fatal("the control fixture emits no GRAPH_RELATES edge — this test could " +
+			"not tell a refusal from a parse failure")
+	}
+
+	var nodes int
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName("Movie") {
+			nodes++
+		}
+		for j := range ents[i].Relationships {
+			if r := &ents[i].Relationships[j]; r.Kind == string(types.RelationshipKindGraphRelates) {
+				t.Errorf("GRAPH_RELATES emitted with ToID %q from a file path containing "+
+					"':' — Neo4jNodeTargetID must refuse it and the caller must emit no "+
+					"edge, because a six-segment stub PARSES as Format A instead of "+
+					"dangling", r.ToID)
+			}
+		}
+	}
+	if nodes != 1 {
+		t.Errorf("node-label entity for `Movie` emitted %d times, want 1 — the refusal "+
+			"withholds the EDGE only, never the entities", nodes)
+	}
+}

--- a/internal/custom/golang/neo4j_test.go
+++ b/internal/custom/golang/neo4j_test.go
@@ -43,13 +43,27 @@ func extractNeo4jRaw(t *testing.T, src string) []types.EntityRecord {
 // findGoGraphRelates returns the GRAPH_RELATES edge from the node entity named
 // "node:<fromLabel>" to ToID "node:<toLabel>", or nil if absent.
 func findGoGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	// #6122 — the edge now addresses the target node entity by LOCATION
+	// (scope:schema:<file>#node:<label>), not by its colon-bearing Name. Derive
+	// the expected ToID from the entity ACTUALLY minted for toLabel rather than
+	// hard-coding a path, so a ref naming a file no entity lives in fails here.
+	want := ""
 	for i := range ents {
-		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(toLabel) {
+			want = extreg.Neo4jNodeTargetID(ents[i].SourceFile, toLabel)
+			break
+		}
+	}
+	if want == "" {
+		return nil
+	}
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(fromLabel)) {
 			continue
 		}
 		for j := range ents[i].Relationships {
 			r := &ents[i].Relationships[j]
-			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == want {
 				return r
 			}
 		}

--- a/internal/custom/php/neo4j.go
+++ b/internal/custom/php/neo4j.go
@@ -175,14 +175,14 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 			if label == "" {
 				continue
 			}
-			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "php", line)
+			n := makeEntity(extractor.Neo4jNodeName(label), "SCOPE.Schema", "", file.Path, "php", line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
 			before := len(entities)
 			add(n)
 			// add() dedupes; only register the index when actually appended.
 			if len(entities) == before+1 {
-				nodeIdx["node:"+label] = before
+				nodeIdx[extractor.Neo4jNodeName(label)] = before
 			}
 		}
 
@@ -236,14 +236,25 @@ func (e *neo4jExtractor) Extract(ctx context.Context, file extractor.FileInput) 
 				direction = "UNDIRECTED"
 			}
 
-			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			// #6122 — address the target node entity by LOCATION, not by its
+			// colon-bearing Name. `"node:"+dstLabel` reached byName through
+			// splitStub, which cuts at the first colon, so it probed the BARE
+			// label and bound to any code symbol of that name. "" means the
+			// helper refused a colon-bearing path/label: emit NO edge, because
+			// the alternative is not an honest dangle but a ref that PARSES as
+			// Format A. See internal/extractor/neo4j_node.go.
+			toID := extractor.Neo4jNodeTargetID(file.Path, dstLabel)
+			if toID == "" {
+				continue
+			}
+			ownerIdx, ok := nodeIdx[extractor.Neo4jNodeName(srcLabel)]
 			if !ok {
 				continue
 			}
 			entities[ownerIdx].Relationships = append(
 				entities[ownerIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: "node:" + dstLabel,
+					ToID: toID,
 					Kind: string(types.RelationshipKindGraphRelates),
 					Properties: types.Props{
 						{K: "direction", V: direction},

--- a/internal/custom/php/neo4j_test.go
+++ b/internal/custom/php/neo4j_test.go
@@ -39,13 +39,27 @@ func extractPHPNeo4j(t *testing.T, src string) []types.EntityRecord {
 }
 
 func findPHPGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	// #6122 — the edge now addresses the target node entity by LOCATION
+	// (scope:schema:<file>#node:<label>), not by its colon-bearing Name. Derive
+	// the expected ToID from the entity ACTUALLY minted for toLabel rather than
+	// hard-coding a path, so a ref naming a file no entity lives in fails here.
+	want := ""
 	for i := range ents {
-		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(toLabel) {
+			want = extreg.Neo4jNodeTargetID(ents[i].SourceFile, toLabel)
+			break
+		}
+	}
+	if want == "" {
+		return nil
+	}
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(fromLabel)) {
 			continue
 		}
 		for j := range ents[i].Relationships {
 			r := &ents[i].Relationships[j]
-			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == want {
 				return r
 			}
 		}

--- a/internal/custom/rust/neo4j.go
+++ b/internal/custom/rust/neo4j.go
@@ -170,14 +170,14 @@ func (e *neo4jRustExtractor) Extract(ctx context.Context, file extractor.FileInp
 			if label == "" {
 				continue
 			}
-			n := makeEntity("node:"+label, "SCOPE.Schema", "", file.Path, "rust", line)
+			n := makeEntity(extractor.Neo4jNodeName(label), "SCOPE.Schema", "", file.Path, "rust", line)
 			setProps(&n, "framework", "neo4j", "provenance", "INFERRED_FROM_NEO4J_CYPHER",
 				"node_label", label)
 			before := len(entities)
 			add(n)
 			// add() dedupes; only register the index when actually appended.
 			if len(entities) == before+1 {
-				nodeIdx["node:"+label] = before
+				nodeIdx[extractor.Neo4jNodeName(label)] = before
 			}
 		}
 
@@ -231,14 +231,25 @@ func (e *neo4jRustExtractor) Extract(ctx context.Context, file extractor.FileInp
 				direction = "UNDIRECTED"
 			}
 
-			ownerIdx, ok := nodeIdx["node:"+srcLabel]
+			// #6122 — address the target node entity by LOCATION, not by its
+			// colon-bearing Name. `"node:"+dstLabel` reached byName through
+			// splitStub, which cuts at the first colon, so it probed the BARE
+			// label and bound to any code symbol of that name. "" means the
+			// helper refused a colon-bearing path/label: emit NO edge, because
+			// the alternative is not an honest dangle but a ref that PARSES as
+			// Format A. See internal/extractor/neo4j_node.go.
+			toID := extractor.Neo4jNodeTargetID(file.Path, dstLabel)
+			if toID == "" {
+				continue
+			}
+			ownerIdx, ok := nodeIdx[extractor.Neo4jNodeName(srcLabel)]
 			if !ok {
 				continue
 			}
 			entities[ownerIdx].Relationships = append(
 				entities[ownerIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: "node:" + dstLabel,
+					ToID: toID,
 					Kind: string(types.RelationshipKindGraphRelates),
 					Properties: types.Props{
 						{K: "direction", V: direction},

--- a/internal/custom/rust/neo4j_test.go
+++ b/internal/custom/rust/neo4j_test.go
@@ -39,13 +39,27 @@ func extractRustNeo4j(t *testing.T, src string) []types.EntityRecord {
 }
 
 func findRustGraphRelates(ents []types.EntityRecord, fromLabel, toLabel string) *types.RelationshipRecord {
+	// #6122 — the edge now addresses the target node entity by LOCATION
+	// (scope:schema:<file>#node:<label>), not by its colon-bearing Name. Derive
+	// the expected ToID from the entity ACTUALLY minted for toLabel rather than
+	// hard-coding a path, so a ref naming a file no entity lives in fails here.
+	want := ""
 	for i := range ents {
-		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == "node:"+fromLabel) {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(toLabel) {
+			want = extreg.Neo4jNodeTargetID(ents[i].SourceFile, toLabel)
+			break
+		}
+	}
+	if want == "" {
+		return nil
+	}
+	for i := range ents {
+		if !(ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extreg.Neo4jNodeName(fromLabel)) {
 			continue
 		}
 		for j := range ents[i].Relationships {
 			r := &ents[i].Relationships[j]
-			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == "node:"+toLabel {
+			if r.Kind == string(types.RelationshipKindGraphRelates) && r.ToID == want {
 				return r
 			}
 		}

--- a/internal/extractor/neo4j_node.go
+++ b/internal/extractor/neo4j_node.go
@@ -1,0 +1,105 @@
+package extractor
+
+import "strings"
+
+// neo4j_node.go — the shared addressing convention for Cypher node-label
+// entities (issue #6122, refs #6105, #6123).
+//
+// WHO USES THIS. The five Cypher-STRING neo4j extractors —
+// internal/custom/{csharp,elixir,golang,php,rust}/neo4j.go. They recover node
+// labels from query text by regex ((n:Person), (:Movie)) and mint one synthetic
+// SCOPE.Schema entity per label per file, then promote a fully-static Cypher
+// triple to a traversable GRAPH_RELATES edge between two of them.
+//
+// WHY THE ENTITY NAME IS PREFIXED. A Cypher label is a DATABASE label pulled out
+// of a string literal, not a declaration. A repo that stores `Movie` nodes very
+// often also declares a `Movie` struct/class. The `node:` prefix keeps the two
+// apart in the entity namespace, and that decision is correct and is kept.
+//
+// WHY THE REF IS NOT THE NAME. It was, and that was the bug. LookupStatusHint
+// reaches byName through splitStub (internal/resolve/refs.go:2658), which cuts
+// at the FIRST colon and probes with the REMAINDER — so `ToID: "node:"+label`
+// could only ever probe `byName["<label>"]`, a key the intended target does not
+// carry and the colliding code symbol does. Measured end-to-end: the edge bound
+// to the Go struct (cmd/grafel.TestNeo4jGraphRelatesBindsTheNodeEntityNotThe
+// Collider6122); the resolver fact is pinned in
+// internal/resolve.TestNodeLabelRefCannotAddressANodeEntityAndMisbinds6122.
+//
+// WHY NOT THE `"Class:"+label` FORM THE SIBLINGS USE. java/neo4j.go:328,
+// python/neo4j_neomodel.go:247 and ruby/neo4j_activegraph.go:299 emit exactly
+// this relationship as `"Class:"+targetType` and DO resolve. That works because
+// their target is a real annotated CLASS whose entity Name is the BARE class
+// name, so splitStub's leaf probe lands on it. Pointed at a Cypher label the
+// same ref lands on the code symbol instead — the identical defect wearing a
+// different prefix, measured in
+// internal/resolve.TestClassRefWouldMisbindForACypherLabel6122. Convergence on
+// the ref STRING would be convergence on a bug: the two families address
+// structurally different targets. Renaming the synthetic entity to the bare
+// label to make `Class:` work is worse — it moves the collision from the edge
+// onto the entity, discarding the reason the prefix exists.
+//
+// WHY NOT A MINTED QualifiedName (the #6123 remedy). It would work, but it
+// addresses the label GLOBALLY, and byQualifiedName blanks its entry on any
+// collision (internal/resolve/refs.go:948-965). The node entities here are
+// per-file with a real SourceFile and line, so the same label appearing in two
+// files would blank the key and dangle BOTH edges. The #6123 service node dodges
+// that only by being file-agnostic (synthetic SourceFile ⇒ one shared ID), which
+// these are not. A file-scoped ref is also the more honest one: both endpoints
+// of a Cypher triple are minted by the same extractor run on the same file, so
+// the target is always in-file and never needs cross-file reach.
+//
+// WHAT IT USES INSTEAD. The PLT #537 short-form `scope:schema:<file>#<name>`
+// (internal/resolve/refs.go:1929), which probes byLocation[file][Name] with the
+// FULL entity Name — colon included. No new resolver code, no entity mutation,
+// and no cross-file ambiguity.
+
+// neo4jNodeNamePrefix namespaces a Cypher node label in the entity namespace so
+// it cannot be confused with a code symbol of the same name.
+const neo4jNodeNamePrefix = "node:"
+
+// Neo4jNodeName returns the canonical entity Name for a Cypher node label:
+//
+//	node:<label>
+//
+// Callers MUST mint the SCOPE.Schema node entity with this Name, because
+// Neo4jNodeTargetID addresses the entity by it.
+func Neo4jNodeName(label string) string {
+	return neo4jNodeNamePrefix + label
+}
+
+// Neo4jNodeTargetID returns the GRAPH_RELATES ToID addressing the node-label
+// entity for `label` in `filePath`. Shape:
+//
+//	scope:schema:<file>#node:<label>
+//
+// Returns "" when no safe ref can be built, and a caller that gets "" MUST emit
+// no edge. Dropping the relationship is deliberate and is NOT the usual
+// "an honest dangle beats nothing" case, because the alternative here is not a
+// dangle: it is a ref that PARSES, and therefore mis-binds.
+//
+// THE BOUND, and why it is load-bearing rather than defensive decoration.
+// The short-form at refs.go:1932 declines a file path containing ':'; on that
+// decline — and on a byLocation miss — execution falls through to the Format A
+// parse at refs.go:2037, which fires at EXACTLY stubScopeSegments = 6 with
+// parts[4] read as a file path and parts[5] as an entity name. Counting the two
+// fixed prefix colons plus the one in `#node:`, a file path with two colons, or
+// a label with two colons, reaches six. The resolver really does mis-bind there
+// — asserted, not assumed, in the "six segments" subtest of
+// internal/resolve.TestNeo4jNodeLocationRefBindsTheNodeEntity6122. This is the
+// same trap the #6123 fix walked into in its own output.
+//
+// Refusing ANY colon rather than counting to two is deliberate: the ceiling then
+// does not have to be recomputed if the prefix ever gains a segment, and no
+// legitimate input is lost. Every caller's label comes from a regex bounded to
+// [A-Za-z_]\w* and is colon-free by construction, so the label arm is
+// unreachable from live extraction and exists to keep it that way; the file-path
+// arm is reachable in principle (':' is legal in a POSIX filename).
+func Neo4jNodeTargetID(filePath, label string) string {
+	if filePath == "" || label == "" {
+		return ""
+	}
+	if strings.ContainsRune(filePath, ':') || strings.ContainsRune(label, ':') {
+		return ""
+	}
+	return "scope:schema:" + filePath + "#" + Neo4jNodeName(label)
+}

--- a/internal/extractor/neo4j_node.go
+++ b/internal/extractor/neo4j_node.go
@@ -94,6 +94,15 @@ func Neo4jNodeName(label string) string {
 // [A-Za-z_]\w* and is colon-free by construction, so the label arm is
 // unreachable from live extraction and exists to keep it that way; the file-path
 // arm is reachable in principle (':' is legal in a POSIX filename).
+//
+// ':' IS THE ONLY REFUSED CHARACTER, and '#' specifically is NOT — which the
+// "recompute the ceiling" reason above does not explain on its own. '#' is the
+// short-form's member delimiter (stubMemberDelim), so a path containing one
+// truncates filePath at the FIRST '#' and mis-reads the remainder as the member.
+// That is a miss, not a mis-bind: it adds no colons, so the stub cannot reach six
+// segments, misses byLocation, and is left verbatim to dangle honestly. Only ':'
+// can turn a miss into a Format A parse, so only ':' is refused. If the ceiling
+// or the delimiter ever changes, this is the sentence to revisit.
 func Neo4jNodeTargetID(filePath, label string) string {
 	if filePath == "" || label == "" {
 		return ""

--- a/internal/extractor/neo4j_node_test.go
+++ b/internal/extractor/neo4j_node_test.go
@@ -1,0 +1,83 @@
+package extractor
+
+import (
+	"strings"
+	"testing"
+)
+
+// Issue #6122 — the producer-side bound on the neo4j node-label ref.
+//
+// The paired resolver measurements live in
+// internal/resolve.TestNeo4jNodeLocationRefBindsTheNodeEntity6122; this file
+// tests the helper DIRECTLY and in-package, because an end-to-end assertion
+// cannot see a refusal that never had a chance to fire (the #6123 lesson: a
+// guard covered by a second mechanism looks alive when it is not).
+
+func TestNeo4jNodeTargetIDShape6122(t *testing.T) {
+	got := Neo4jNodeTargetID("store/store.go", "Movie")
+	const want = "scope:schema:store/store.go#node:Movie"
+	if got != want {
+		t.Fatalf("Neo4jNodeTargetID = %q, want %q", got, want)
+	}
+	// The ref must address the entity by the Name the extractor actually mints.
+	if !strings.HasSuffix(got, "#"+Neo4jNodeName("Movie")) {
+		t.Fatalf("ref %q does not end in the minted entity Name %q — the two must not "+
+			"be able to drift apart, which is why both come from this file",
+			got, Neo4jNodeName("Movie"))
+	}
+}
+
+// TestNeo4jNodeTargetIDStaysUnderTheStructuralCeiling6122 is the assertion that
+// makes the #6123 trap unreachable: a well-formed ref must not reach
+// stubScopeSegments = 6, where lookupStructural stops rejecting and starts
+// parsing as Format A.
+func TestNeo4jNodeTargetIDStaysUnderTheStructuralCeiling6122(t *testing.T) {
+	for _, tc := range []struct{ path, label string }{
+		{"store/store.go", "Movie"},
+		{"a.go", "X"},
+		{"deeply/nested/pkg/graph/queries.go", "PersonProfileNode"},
+	} {
+		ref := Neo4jNodeTargetID(tc.path, tc.label)
+		if ref == "" {
+			t.Fatalf("Neo4jNodeTargetID(%q, %q) refused a colon-free input", tc.path, tc.label)
+		}
+		// Mirrors strings.SplitN(stub, ":", 6) in internal/resolve/refs.go:2037.
+		if n := strings.Count(ref, ":") + 1; n >= 6 {
+			t.Fatalf("ref %q has %d colon-delimited segments; at 6 the resolver parses it "+
+				"as Format A with parts[4] as a file path and parts[5] as an entity name — "+
+				"the #6122/#6123 mis-bind", ref, n)
+		}
+	}
+}
+
+// TestNeo4jNodeTargetIDRefusesColonBearingInput6122 pins the refusal itself. A
+// deliberately colon-heavy label and a colon-bearing file path are BOTH refused,
+// and each is checked on its own so one arm cannot silently cover the other.
+func TestNeo4jNodeTargetIDRefusesColonBearingInput6122(t *testing.T) {
+	for _, tc := range []struct {
+		name, path, label string
+	}{
+		// Two colons in the path is exactly six segments — the hazard.
+		{"path with two colons", "a:b:c/store.go", "Movie"},
+		// One colon is only five, but it is refused too: the ceiling is not
+		// recomputed at each call site, and nothing legitimate is lost.
+		{"path with one colon", "weird:dir/store.go", "Movie"},
+		// The colon-heavy label the issue asks for by name. Unreachable from
+		// live extraction (every caller's label comes from a regex bounded to
+		// [A-Za-z_]\w*) — refused anyway so it stays unreachable.
+		{"colon-heavy label", "store/store.go", "My:Weird:Back`ticked:Label"},
+		{"label with one colon", "store/store.go", "My:Label"},
+		{"empty path", "", "Movie"},
+		{"empty label", "store/store.go", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Neo4jNodeTargetID(tc.path, tc.label); got != "" {
+				t.Fatalf("Neo4jNodeTargetID(%q, %q) = %q, want \"\" so the caller emits NO "+
+					"edge. Dropping the relationship is correct here because the "+
+					"alternative is not an honest dangle — it is a ref that parses as "+
+					"Format A and binds to an unrelated entity",
+					tc.path, tc.label, got)
+			}
+		})
+	}
+}

--- a/internal/extractors/neo4j_node_ref_6122_test.go
+++ b/internal/extractors/neo4j_node_ref_6122_test.go
@@ -1,0 +1,195 @@
+package extractors
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6122 — the neo4j node-label ref, tested across ALL FIVE Cypher-string
+// extractors at once.
+//
+// WHY THIS FILE EXISTS, AND WHY IT LIVES HERE. The per-language `neo4j_test.go`
+// files each test one package, and the refusal arm — `if toID == "" { continue }`
+// in the GRAPH_RELATES pass — was covered in golang ONLY. Deleting that guard
+// from rust, csharp, elixir AND php simultaneously left all four packages at
+// exit 0. That is the "protected zero times" variant of the shape this cycle has
+// hit repeatedly, and it is the same class as the golang mutant that survived
+// until the arm was found to be unreachable from any fixture.
+//
+// internal/extractors is the one package that blank-imports every custom
+// language package (custom_registry.go), so the five extractors are all
+// registered here and one table can drive them.
+//
+// THE ARM IS UNREACHABLE FROM A REAL REPO — deliberately. Every label reaches
+// the ref through a regex bounded to [A-Za-z_]\w*, and no path in any fixture in
+// this repo contains ':'. The only way to exercise the guard is to hand the
+// extractor a colon-bearing FileInput.Path, which is exactly what the hazard arm
+// below does; ':' is legal in a POSIX filename.
+//
+// WHY DROPPING THE EDGE IS RIGHT, and why the usual "an honest dangle beats
+// nothing" rule does not apply here: at two colons in the path the stub reaches
+// stubScopeSegments = 6, where lookupStructural stops REJECTING and parses it as
+// Format A with parts[4] as a file path and parts[5] as an entity name
+// (internal/resolve/refs.go:2037). The alternative to dropping the edge is not a
+// dangle — it is a ref that PARSES, and therefore mis-binds. The resolver half
+// is the "six segments" subtest of
+// internal/resolve.TestNeo4jNodeLocationRefBindsTheNodeEntity6122.
+
+// neo4jCase6122 is one Cypher-string extractor and a source fixture carrying the
+// same triple — (p:Person)-[:ACTED_IN]->(m:Movie) — in that language's host
+// syntax, past that language's import gate.
+type neo4jCase6122 struct {
+	id   string // registry ID
+	lang string // FileInput.Language the extractor gates on
+	path string // colon-free control path
+	src  string
+}
+
+func neo4jCases6122() []neo4jCase6122 {
+	return []neo4jCase6122{
+		{
+			id: "custom_go_neo4j", lang: "go", path: "store/store.go",
+			src: "package store\n\nimport (\n\t\"github.com/neo4j/neo4j-go-driver/v5/neo4j\"\n)\n\n" +
+				"func q(session neo4j.Session) {\n" +
+				"\tsession.Run(`MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m`, nil)\n" +
+				"}\n",
+		},
+		{
+			id: "custom_csharp_neo4j", lang: "csharp", path: "src/Store.cs",
+			src: "using Neo4j.Driver;\nnamespace App {\n  class Store {\n" +
+				"    async Task Q(IAsyncSession session) {\n" +
+				"      await session.RunAsync(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\");\n" +
+				"    }\n  }\n}\n",
+		},
+		{
+			id: "custom_elixir_neo4j", lang: "elixir", path: "lib/store.ex",
+			src: "defmodule App.Store do\n  alias Bolt.Sips\n" +
+				"  def q(conn) do\n" +
+				"    Bolt.Sips.query!(conn, \"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\")\n" +
+				"  end\nend\n",
+		},
+		{
+			id: "custom_php_neo4j", lang: "php", path: "src/Store.php",
+			src: "<?php\nuse Laudis\\Neo4j\\ClientBuilder;\n" +
+				"$client->run(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\");\n",
+		},
+		{
+			id: "custom_rust_neo4j", lang: "rust", path: "src/store.rs",
+			src: "use neo4rs::*;\n" +
+				"async fn q(graph: &Graph) {\n" +
+				"  graph.execute(query(\"MATCH (p:Person)-[:ACTED_IN]->(m:Movie) RETURN p, m\")).await.unwrap();\n" +
+				"}\n",
+		},
+	}
+}
+
+// extractNeo4j6122 runs one registered extractor over one fixture at one path.
+func extractNeo4j6122(t *testing.T, c neo4jCase6122, path string) []types.EntityRecord {
+	t.Helper()
+	e, ok := extractor.Get(c.id)
+	if !ok {
+		t.Fatalf("%s not registered — internal/extractors/custom_registry.go is the "+
+			"package that wires every custom language; if the ID changed, fix the table",
+			c.id)
+	}
+	ents, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: c.lang,
+		Content:  []byte(c.src),
+	})
+	if err != nil {
+		t.Fatalf("%s extract: %v", c.id, err)
+	}
+	return ents
+}
+
+// graphRelates6122 returns every GRAPH_RELATES ToID in the record set.
+func graphRelates6122(ents []types.EntityRecord) []string {
+	var out []string
+	for i := range ents {
+		for j := range ents[i].Relationships {
+			if r := &ents[i].Relationships[j]; r.Kind == string(types.RelationshipKindGraphRelates) {
+				out = append(out, r.ToID)
+			}
+		}
+	}
+	return out
+}
+
+// countNodeEntities6122 counts SCOPE.Schema entities carrying the node-label
+// Name for `label`.
+func countNodeEntities6122(ents []types.EntityRecord, label string) int {
+	n := 0
+	for i := range ents {
+		if ents[i].Kind == "SCOPE.Schema" && ents[i].Name == extractor.Neo4jNodeName(label) {
+			n++
+		}
+	}
+	return n
+}
+
+// TestNeo4jNodeRefIsLocationAddressedInEveryLanguage6122 is the CONTROL arm, and
+// it is what makes the refusal arm below non-vacuous: each of the five
+// extractors must emit exactly one GRAPH_RELATES edge, addressed by LOCATION at
+// the file the ref actually names.
+//
+// Asserted on CONTENT — the exact ToID string, derived from the same helper the
+// producer uses — never on a count of dangles, which reads a mis-bind as an
+// improvement.
+func TestNeo4jNodeRefIsLocationAddressedInEveryLanguage6122(t *testing.T) {
+	for _, c := range neo4jCases6122() {
+		t.Run(c.id, func(t *testing.T) {
+			ents := extractNeo4j6122(t, c, c.path)
+			want := extractor.Neo4jNodeTargetID(c.path, "Movie")
+			if want == "" {
+				t.Fatalf("Neo4jNodeTargetID refused the colon-free control path %q", c.path)
+			}
+			got := graphRelates6122(ents)
+			if len(got) != 1 || got[0] != want {
+				t.Fatalf("GRAPH_RELATES ToIDs = %v, want exactly [%q]. The ref must address "+
+					"the node entity by LOCATION; `node:Movie` reaches byName through "+
+					"splitStub and binds to any code symbol of that name (#6122)", got, want)
+			}
+			if n := countNodeEntities6122(ents, "Movie"); n != 1 {
+				t.Errorf("node-label entity for `Movie` emitted %d times, want 1 — the ref "+
+					"above addresses it by Name, so the two must agree", n)
+			}
+		})
+	}
+}
+
+// TestNeo4jNodeRefRefusalDropsTheEdgeInEveryLanguage6122 is the HAZARD arm: the
+// `if toID == "" { continue }` guard, driven in all five extractors.
+//
+// Before this test the guard existed in five places and was covered in one.
+// Deleting it from the other four simultaneously left those packages green.
+func TestNeo4jNodeRefRefusalDropsTheEdgeInEveryLanguage6122(t *testing.T) {
+	for _, c := range neo4jCases6122() {
+		t.Run(c.id, func(t *testing.T) {
+			// Two colons is exactly the six-segment hazard.
+			hazard := "a:b:c/" + c.path
+			if extractor.Neo4jNodeTargetID(hazard, "Movie") != "" {
+				t.Fatalf("Neo4jNodeTargetID accepted the colon-bearing path %q — this "+
+					"test has nothing to observe unless the helper refuses", hazard)
+			}
+			ents := extractNeo4j6122(t, c, hazard)
+
+			if got := graphRelates6122(ents); len(got) != 0 {
+				t.Errorf("GRAPH_RELATES emitted with ToIDs %v from a file path containing "+
+					"':' — the helper refused, so the caller must emit NO edge. A "+
+					"six-segment stub PARSES as Format A instead of dangling, so shipping "+
+					"the edge is a mis-bind, not an honest dangle", got)
+			}
+			// The refusal withholds the EDGE only, never the entities. Without
+			// this the test would also pass if the extractor had simply failed
+			// to parse the fixture at the odd path.
+			if n := countNodeEntities6122(ents, "Movie"); n != 1 {
+				t.Errorf("node-label entity for `Movie` emitted %d times, want 1 — the "+
+					"refusal must drop the edge and nothing else", n)
+			}
+		})
+	}
+}

--- a/internal/resolve/neo4j_node_ref_shape_6122_test.go
+++ b/internal/resolve/neo4j_node_ref_shape_6122_test.go
@@ -1,0 +1,177 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6122 — the resolver facts the neo4j `node:` cluster fix rests on.
+//
+// The Cypher-string neo4j extractors mint a synthetic node-label entity named
+// `node:<label>` with no QualifiedName, and address it with `ToID:
+// "node:"+label`. LookupStatusHint reaches byName through splitStub
+// (refs.go:2658), which cuts at the FIRST colon and probes with the REMAINDER,
+// so the ref can only ever probe `byName["<label>"]` — a key the intended target
+// does not carry, and one a real code symbol very often does.
+//
+// These tests pin THREE facts, so that a later resolver change cannot silently
+// take the producer fix's ground away, and so that the design choice is
+// falsifiable rather than asserted:
+//
+//  1. `node:<label>` mis-binds to a same-named code symbol. (The defect.)
+//  2. `Class:<label>` — the form the WORKING java/python/ruby siblings use —
+//     mis-binds in exactly the same way HERE. That is the measured reason the
+//     five Cypher extractors must NOT converge on the siblings' ref string:
+//     the siblings' targets are real classes whose entity Name is the BARE
+//     class name, so their leaf probe hits the right node. A Cypher label's
+//     target is a synthetic `node:`-namespaced entity, so the same leaf probe
+//     hits the code symbol instead.
+//  3. `scope:schema:<file>#<name>` — the PLT #537 short-form at refs.go:1929 —
+//     binds `node:<label>` correctly, with the collider present, because it
+//     probes byLocation[file][Name] with the FULL name including its colon.
+//
+// Neither asserts a count; all assert which entity an endpoint lands on.
+//
+// NOT a test of the fix itself — the behavioural gate for that is
+// cmd/grafel.TestNeo4jGraphRelatesBindsTheNodeEntityNotTheCollider6122.
+
+// neo4jColliderSet6122 returns the two entities every subtest below shares: the
+// synthetic Cypher node-label entity, and a real code symbol of the same bare
+// leaf name in the same file. The collider is the whole point — "does not
+// mis-bind" is only meaningful when something wrong is available to bind to.
+func neo4jColliderSet6122() (node, collider types.EntityRecord) {
+	node = entAt("1111000011110000", "SCOPE.Schema", "node:Movie", "store/store.go")
+	collider = entAt("2222000022220000", "SCOPE.Component", "Movie", "store/store.go")
+	return node, collider
+}
+
+// TestNodeLabelRefCannotAddressANodeEntityAndMisbinds6122 shows the old ref
+// shape was unusable in BOTH directions: the intended target is present and is
+// NOT what the ref binds to.
+func TestNodeLabelRefCannotAddressANodeEntityAndMisbinds6122(t *testing.T) {
+	node, collider := neo4jColliderSet6122()
+	idx := BuildIndex([]types.EntityRecord{node, collider})
+	rels := []types.RelationshipRecord{
+		{FromID: "3333000033330000", ToID: "node:Movie", Kind: "GRAPH_RELATES"},
+	}
+	References(rels, idx)
+
+	if rels[0].ToID == node.ID {
+		t.Fatalf("`node:Movie` now binds to the node entity by Name — splitStub no " +
+			"longer eats the prefix. The #6122 producer fix rests on it doing so; " +
+			"re-check internal/custom/*/neo4j.go before relaxing anything here.")
+	}
+	if rels[0].ToID != collider.ID {
+		t.Fatalf("`node:Movie` bound to %q, want the SCOPE.Component collider %q — this "+
+			"test is meant to DEMONSTRATE the mis-bind, so if the shape has changed the "+
+			"demonstration must be rebuilt, not deleted", rels[0].ToID, collider.ID)
+	}
+}
+
+// TestClassRefWouldMisbindForACypherLabel6122 is the measurement that decides
+// the design question: should the five Cypher extractors converge on the
+// `"Class:"+label` form their java/python/ruby siblings use?
+//
+// No, and this is why. `Class:` resolves for the siblings only because THEIR
+// target entity Name is the bare class name (java/neo4j.go emitNode,
+// ruby/neo4j_activegraph.go:188, python/neo4j_neomodel.go:247) — the leaf probe
+// lands on it. Point the same ref at a Cypher label and the leaf probe lands on
+// the code symbol instead, which is the identical defect wearing a different
+// prefix. Convergence on the ref STRING would be convergence on a bug; the two
+// families address structurally different targets.
+//
+// Renaming the synthetic entity to the bare label to make `Class:` work is the
+// other half of that trade and is worse still: the `node:` prefix exists
+// precisely to keep a database label recovered from query text from colliding
+// with a code symbol, and dropping it moves the collision from the edge to the
+// entity.
+func TestClassRefWouldMisbindForACypherLabel6122(t *testing.T) {
+	node, collider := neo4jColliderSet6122()
+	idx := BuildIndex([]types.EntityRecord{node, collider})
+	rels := []types.RelationshipRecord{
+		{FromID: "3333000033330000", ToID: "Class:Movie", Kind: "GRAPH_RELATES"},
+	}
+	References(rels, idx)
+
+	if rels[0].ToID != collider.ID {
+		t.Fatalf("`Class:Movie` bound to %q, want the collider %q. This test records WHY "+
+			"the five Cypher extractors do not adopt the siblings' ref form; if the "+
+			"resolver now sends `Class:` somewhere else, re-argue the design choice in "+
+			"internal/extractor/neo4j_node.go before changing it", rels[0].ToID, collider.ID)
+	}
+}
+
+// TestNeo4jNodeLocationRefBindsTheNodeEntity6122 is the property the fix relies
+// on: the PLT #537 `scope:schema:<file>#<name>` short-form probes
+// byLocation[file][Name] with the full, colon-bearing entity Name, so it reaches
+// a target `node:<label>` that no byName tier can address — and it declines
+// rather than falling through to the collider when the target is absent.
+func TestNeo4jNodeLocationRefBindsTheNodeEntity6122(t *testing.T) {
+	node, collider := neo4jColliderSet6122()
+	const ref = "scope:schema:store/store.go#node:Movie"
+
+	t.Run("node entity present: binds to it, not the collider", func(t *testing.T) {
+		idx := BuildIndex([]types.EntityRecord{node, collider})
+		rels := []types.RelationshipRecord{
+			{FromID: "3333000033330000", ToID: ref, Kind: "GRAPH_RELATES"},
+		}
+		References(rels, idx)
+		if rels[0].ToID != node.ID {
+			t.Fatalf("location ref bound to %q, want the node entity %q", rels[0].ToID, node.ID)
+		}
+	})
+
+	t.Run("structural tier consumes a miss and declines", func(t *testing.T) {
+		// Asserted IN-PACKAGE and DIRECTLY. The end-to-end arm below cannot
+		// distinguish "lookupStructural consumed the stub" from "the byName
+		// probe happened to miss", and a guard that is covered twice looks
+		// alive when only one mechanism is doing the work (the #6123 lesson).
+		idx := BuildIndex([]types.EntityRecord{collider})
+		id, status, handled := idx.lookupStructural(ref)
+		if !handled {
+			t.Fatalf("lookupStructural did not claim %q (handled=%v) — a `scope:`-prefixed "+
+				"stub that is not six segments must be consumed there, not passed down to "+
+				"the byName / kind-hint tiers where the collider lives", ref, handled)
+		}
+		if status != statusUnmatched || id != "" {
+			t.Fatalf("lookupStructural returned (%q, status=%d), want (\"\", statusUnmatched=%d)",
+				id, status, statusUnmatched)
+		}
+	})
+
+	t.Run("node entity absent: stays verbatim, does not take the collider", func(t *testing.T) {
+		idx := BuildIndex([]types.EntityRecord{collider})
+		rels := []types.RelationshipRecord{
+			{FromID: "3333000033330000", ToID: ref, Kind: "GRAPH_RELATES"},
+		}
+		References(rels, idx)
+		if rels[0].ToID != ref {
+			t.Fatalf("location ref was rewritten to %q; it must be left verbatim so the "+
+				"edge dangles honestly rather than taking the collider", rels[0].ToID)
+		}
+	})
+
+	// THE BOUNDARY, and the reason Neo4jNodeTargetID refuses colon-bearing
+	// inputs instead of merely documenting them.
+	//
+	// The short-form at refs.go:1932 guards `!strings.Contains(filePath, ":")`
+	// and, on a decline OR a byLocation miss, execution falls through to the
+	// Format A parse at refs.go:2037, which fires at EXACTLY six segments with
+	// parts[4] read as a file path and parts[5] as an entity name. Two colons in
+	// the file path reach six. This is the same trap the #6123 fix walked into
+	// in its own output; here the producer bound is what keeps real refs out of
+	// it.
+	t.Run("six segments: the resolver DOES mis-bind, hence the producer bound", func(t *testing.T) {
+		const hazard = "scope:schema:a:b:c#node:Movie"
+		victim := entAt("8888000088880000", "Class", "Movie", "c#node")
+		idx := BuildIndex([]types.EntityRecord{victim, collider})
+		id, status, handled := idx.lookupStructural(hazard)
+		if !handled || status != statusRewritten || id != victim.ID {
+			t.Fatalf("six-segment schema stub resolved to (%q, status=%d, handled=%v); this "+
+				"test documents that it MIS-BINDS to the entity named parts[5] in the file "+
+				"named parts[4]. If the resolver now declines it, Neo4jNodeTargetID's colon "+
+				"refusal may be relaxed — re-measure before doing so", id, status, handled)
+		}
+	})
+}


### PR DESCRIPTION
Five extractors emitted `ToID: "node:" + dstLabel` against targets minted as `Name = "node:" + label` with **no `QualifiedName`**. `splitStub` (`internal/resolve/refs.go:2658`) cuts at the first colon, so the ref could only ever probe `byName["<label>"]` — dangle, or bind to an unrelated entity of that leaf name.

Verified in all five (`grep -c QualifiedName` = 0):

| file | mints `"node:"+label` | emits `ToID` |
|---|---|---|
| `internal/custom/csharp/neo4j.go` | :176 | :246 |
| `internal/custom/elixir/neo4j.go` | :169 | :237 |
| `internal/custom/golang/neo4j.go` | :162 | :234 |
| `internal/custom/php/neo4j.go` | :178 | :246 |
| `internal/custom/rust/neo4j.go` | :173 | :241 |

**Measured, not projected.** Cypher `(p:Person)-[:ACTED_IN]->(m:Movie)` plus a `type Movie struct` in another file produced, end-to-end:

```
GRAPH_RELATES: SCOPE.Schema:node:Person -> SCOPE.Component:Movie
```

A Cypher label bound to a Go struct. A confident wrong bind, not a dangle — the shape where the dangling-count metric improves while the graph gets worse.

## Two designs rejected, both on measurement

**Converging on the working siblings' `"Class:"+targetType`.** Java, Python and Ruby emit this relationship that way and it resolves — so convergence looked obvious. It is wrong. Those targets are real annotated classes whose entity `Name` is the **bare** class name, so the leaf probe lands. A Cypher label is a different kind of target: the intended entity is named `node:Movie`, and **no byName-family probe can ever produce the string `Movie` for it**, whatever prefix is chosen. `TestClassRefWouldMisbindForACypherLabel6122` shows `Class:Movie` taking the collider. Eight-way convergence would be convergence on a bug.

Renaming the synthetic entity to the bare label to make `Class:` work only moves the collision from the edge onto the entity — `byName`/`nameKinds` blank on collision exactly as `byLocation` does (`refs.go:1156-1170`), so a bare-named `Movie` schema entity beside a `Movie` struct goes ambiguous. Dangle or mis-bind either way, and the `node:` prefix exists precisely to avoid that. The three siblings are untouched.

**Minting a `QualifiedName` and addressing it via `byQualifiedName`** — the #6123 remedy. `byQualifiedName` blanks its entry on any collision (`refs.go:948-965`), and these node entities are **per-file** with real SourceFile and line. Measured with two per-file `node:Movie` entities sharing one minted global QualifiedName: one file binds correctly; **two files dangle both edges verbatim**.

#6123's service node escapes this only by being file-agnostic — `ExternalServiceEntity` mints with a constant `SourceFile` and `StartLine: 1`, so `ComputeID()` yields one shared ID and the collision arm never fires. The distinction is structural, not rhetorical.

## Chosen: the existing PLT #537 short-form

`scope:schema:<file>#node:<label>` (`refs.go:1929`), probing `byLocation[file][Name]` with the full colon-bearing Name. No new resolver code, no entity mutation, no cross-file ambiguity. A shared helper `internal/extractor/neo4j_node.go` (`Neo4jNodeName` + `Neo4jNodeTargetID`) makes all five converge so Name and ref cannot drift.

**File-scoping is the honest reading, verified per language rather than assumed:** in all five, the label-minting regex and the triple regex use the identical alphabet `[A-Za-z_]\w*` over the same Cypher string in the same file. A query concatenated across files never matches the triple at all. The new shape is also strictly more robust than what it replaces — if a label first appears in one query and the triple in another within a file, `add()` dedupe means the name index was never re-registered, but `byLocation` still resolves.

## The segment-count trap, bounded

`stubScopeSegments = 6`: at exactly six segments `lookupStructural` stops rejecting and starts parsing as Format A, with `parts[4]` as a file path and `parts[5]` as an entity name. The short-form declines a colon-bearing path (`refs.go:1932`), and on that decline *or* a `byLocation` miss execution falls through to that parse. **Asserted, not assumed** — `scope:schema:a:b:c#node:Movie` mis-binds to the entity named `parts[5]` in file `parts[4]`.

`Neo4jNodeTargetID` refuses any colon in path or label and returns `""`; all five callers drop the edge. That is not the usual "a dangle beats nothing" case: the alternative is a ref that **parses**, and therefore mis-binds. Refusing any colon is a strict superset of the ceiling — a colon-free path yields 4 parts, and it takes two extra colons to reach 6.

`#` is deliberately not refused, and the helper comment now says why: `#` is the short-form's own member delimiter, so a path containing one truncates `filePath` and mis-reads the remainder as `member` — a **miss**, not a mis-bind. It adds no colons, cannot reach six segments, and dangles honestly. Only `:` converts a miss into a Format A parse.

## The guard existed in five places and was protected in one

Deleting `if toID == "" { continue }` from rust, csharp, elixir **and** php simultaneously left all four packages at exit 0. The original test covered golang only — the "protected zero times" shape.

Closed by `internal/extractors/neo4j_node_ref_6122_test.go`. That package blank-imports every custom language (`custom_registry.go`), so one table drives all five registered extractor IDs over the same triple in each host syntax:

- **control arm** — each extractor emits exactly one `GRAPH_RELATES` whose ToID is the exact location-addressed string, derived from the same helper the producer uses. This is what makes the hazard arm non-vacuous.
- **hazard arm** — a colon-bearing path, asserting no edge while the node-label entities still appear.

The four-site simultaneous deletion now fails with exactly **four** subtests, one per mutated language, `custom_go_neo4j` correctly still passing, each naming the ToID it smuggled through. A live-value substitution, so the kill is behavioural.

## A coverage absence found on the way

Disabling the PLT #537 tier fails exactly **one top-level test in `internal/resolve` — the one this branch adds** (out of 2060 `=== RUN` entries). Before this change, that tier — which carries every `USES_PROPS` edge on tsx components — had **zero** coverage in the resolve package; it could have been deleted and the suite would have stayed green. Filed as #6146; this branch is currently the only thing protecting it.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`, skips counted including subtests:

| package | exit | skips |
|---|---|---|
| `./internal/custom/...` | 0 | 0 |
| `./internal/resolve/...` | 0 | 6 |
| `./internal/extractor/` | 0 | 0 |
| `./internal/extractors/...` | 0 | 1 |
| `./internal/graph/...` | 0 | 0 |
| `./cmd/grafel/` | 0 | 8 |

All 15 skips pre-existing. **9 mutants, all kills behavioural.** Two were caught as false negatives and not banked — a compile error from an unused `strings` import (hit independently by both author and reviewer), and an early guard mutant that survived because the arm was unreachable from any fixture.

The inverse mutant `splitStub` → `LastIndexByte` **survives by design**: the fix does not depend on the colon-cut position, only on the ref never reaching `byName`.

## Measured vs projected

**Measured end-to-end through the real indexer, with a live collider:** golang, php, rust — reverting the ref shape reproduces the mis-bind in each (`→ SCOPE.Component:Movie`, `→ Model:Movie`, `→ SCOPE.Component:Movie`).

**Projection:** csharp and elixir are covered at extractor level and by the cross-language table, but not driven through the indexer against a collider. The five call sites were verified **byte-identical** in the changed region rather than assumed.

Also unmeasured: real-world frequency of a Cypher label colliding with a same-named code symbol; the refusal arm is unreachable from live extraction for labels (regex-bounded to `[A-Za-z_]\w*`) and reachable only in principle for paths.

Scope held to the neo4j cluster. The survey's other sites — `wcf.go:500`, `mobile_platform.go:756`, `tauri:event:`, and the `span:`/`validator:`/`route:`/`impl:`/`dto:` prefixes — remain open on #6122.

Independently adversarially reviewed (APPROVE), with the coverage gap closed on top.

Refs #6122, #6123, #6146
