### PR TITLE
fix(#6141): prefer operations in the leaf-name tiers — the prescribed hard filter was measured wrong

### DIFF
--- a/internal/extractors/ruby/attr_accessor_calls_6141_test.go
+++ b/internal/extractors/ruby/attr_accessor_calls_6141_test.go
@@ -1,0 +1,111 @@
+package ruby_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// TestRubyAttrAccessorCallStillBinds_6141 is the measurement that decided the
+// shape of the #6141 fix, kept as a regression test because nothing else in
+// the tree would catch its loss.
+//
+// Issue #6141 prescribes kind-filtering the resolver's leaf-name tiers to
+// operationKindFamily, on the reasoning that a call target must be an
+// operation. In Ruby that reasoning fails against the graph:
+//
+//   - field_members.go emits every `attr_accessor :owner` as the entity
+//     `Account.owner` with Kind SCOPE.Schema — but in Ruby that IS a
+//     generated method;
+//   - ruby.go emits real methods under BARE names, and rubyCallTarget
+//     discards the receiver, so the call site emits the bare stub `owner`;
+//   - therefore lookupMemberByLeafName matching `.owner` against a
+//     SCOPE.Schema entity is the ONLY route that can bind the edge.
+//
+// A hard operation-filter was implemented and this test measured it turning
+// the binding into a dangle. That is why refs.go PREFERS operations instead
+// of requiring them (scanLeafMembersPreferring), and why the precision half
+// of #6141 is left as a documented gap.
+//
+// This runs the real Ruby extractor and the real resolver, and asserts on
+// what the edge binds to BY CONTENT — never on a dangling count, which
+// cannot see this at all.
+func TestRubyAttrAccessorCallStillBinds_6141(t *testing.T) {
+	const src = `class Account
+  attr_accessor :owner
+
+  def describe
+    owner
+  end
+end
+`
+	ents := rbExtract(t, src, "app/models/account.rb")
+	// The extractor leaves ID blank — IDs are computed later in the
+	// pipeline, and BuildIndex reads "" as its ambiguity sentinel. Stamp
+	// distinct IDs first or this measures nothing.
+	for i := range ents {
+		ents[i].ID = fmt.Sprintf("%016x", i+1)
+	}
+
+	// Precondition 1: the attr_accessor really is modelled as a field.
+	var attrID string
+	for _, e := range ents {
+		if e.Name == "Account.owner" {
+			if e.Kind != "SCOPE.Schema" {
+				t.Fatalf("precondition changed: Account.owner now has Kind %q, not SCOPE.Schema. "+
+					"If attr_accessor is now emitted as an operation, the #6141 precision gap can "+
+					"be closed for Ruby — re-check the JS/TS case before doing so", e.Kind)
+			}
+			attrID = e.ID
+		}
+	}
+	if attrID == "" {
+		t.Fatal("precondition changed: no Account.owner entity emitted for attr_accessor :owner")
+	}
+
+	// Precondition 2: the call site really emits a BARE stub, which is what
+	// forces the leaf-name tier to be the only binding route.
+	found := false
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if strings.EqualFold(r.Kind, "CALLS") && r.ToID == "owner" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Fatal("precondition changed: no bare CALLS stub \"owner\" emitted from the method body")
+	}
+
+	idx := resolve.BuildIndex(ents)
+	resolve.ReferencesEmbedded(ents, idx)
+
+	byID := map[string]types.EntityRecord{}
+	for _, e := range ents {
+		byID[e.ID] = e
+	}
+	for _, e := range ents {
+		if e.Name != "describe" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if !strings.EqualFold(r.Kind, "CALLS") {
+				continue
+			}
+			tgt, ok := byID[r.ToID]
+			if !ok {
+				t.Fatalf("Ruby attr_accessor read DANGLES (ToID=%q). A kind filter on the "+
+					"leaf-name tiers destroys this edge — see the comment above.", r.ToID)
+			}
+			if tgt.ID != attrID || tgt.Name != "Account.owner" || tgt.Kind != "SCOPE.Schema" {
+				t.Fatalf("bound to id=%s kind=%s name=%s; want the attr_accessor entity "+
+					"id=%s / SCOPE.Schema / Account.owner", tgt.ID, tgt.Kind, tgt.Name, attrID)
+			}
+			return
+		}
+	}
+	t.Fatal("no CALLS edge found on the `describe` method — fixture no longer exercises the tier")
+}

--- a/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
+++ b/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
@@ -149,3 +149,42 @@ func TestResolveScoped_LeafTier_TwoOperationsStillAmbiguous_6141(t *testing.T) {
 			"got a confident binding ToID=%q", got.ToID)
 	}
 }
+
+// TestResolveScoped_LeafTier_PreferenceIsWithinTierNotAcrossTiers_6141 is the
+// tier-ORDER guard, and it is the shape every other fixture in this file
+// misses: they all put the competing member in a DIFFERENT file from the
+// caller, so file-scope and package-scope never actually contend.
+//
+//	caller  Local07      svc/a.go
+//	field   Other.owner  svc/a.go   SCOPE.Schema  <- caller's OWN file
+//	op      Owned.owner  svc/b.go   SCOPE.Operation
+//
+// internal/resolve applies the operation preference INSIDE each tier —
+// (fileOp, fileAny) then (pkgOp, pkgAny) — so the caller's own file wins and
+// it binds the FIELD. An implementation that applies the preference ACROSS
+// tiers — fileOp, pkgOp, fileAny, pkgAny — reaches into the sibling file and
+// binds the OPERATION instead.
+//
+// Both are defensible in isolation; what is not defensible is the two
+// resolvers choosing differently, because then a full rebuild and an
+// incremental build disagree on the same source. That is reachable in
+// ordinary code: a Ruby `attr_accessor :owner` beside a sibling class's
+// `def owner`. Locality wins, matching refs.go.
+func TestResolveScoped_LeafTier_PreferenceIsWithinTierNotAcrossTiers_6141(t *testing.T) {
+	existing := []graph.Entity{lfEnt(lfOp, "Owned.owner", "svc/b.go", "SCOPE.Operation")}
+	fresh := []graph.Entity{
+		lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation"),
+		lfEnt(lfField, "Other.owner", "svc/a.go", "SCOPE.Schema"),
+	}
+	newRels := []graph.Relationship{mtCallRel(lfCaller, "owner", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+	if got.ToID != lfField {
+		t.Errorf("the operation preference must apply WITHIN a tier, not ACROSS tiers: the "+
+			"caller's own file declares `owner` (%s) and must win over the sibling-file "+
+			"operation (%s); got ToID=%q. internal/resolve binds the caller-file member here, "+
+			"so this ordering is what keeps a full rebuild and an incremental build agreeing",
+			lfField, lfOp, got.ToID)
+	}
+}

--- a/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
+++ b/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
@@ -1,0 +1,133 @@
+package sresolver_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/sresolver"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// Issue #6141 in the SCOPED (incremental) resolver.
+//
+// memberIndexes.leafByFile / leafByPkg are the scoped path's ports of
+// internal/resolve/refs.go's lookupMemberByLeafName /
+// lookupPackageMemberByLeafName, and they inherited the same defect: the
+// index is built over every dotted-name entity regardless of Kind, so a
+// bare CALLS stub binds to a FIELD, and a legitimate operation binding is
+// LOST when an unrelated same-leaf-named field trips the ambiguity guard.
+//
+// These are separate tests rather than a note on the refs.go fix because
+// the two resolvers are separate code with separate indexes: fixing only
+// refs.go would make an incremental build disagree with a full rebuild on
+// exactly these shapes, which is the divergence class pkgmember.go's own
+// header warns about.
+
+const (
+	lfCaller = "1111111111111111" // svc/a.go — the calling method
+	lfOp     = "2222222222222222" // svc/b.go — Owned.owner, an OPERATION
+	lfField  = "3333333333333333" // svc/c.go — Other.owner, a FIELD
+)
+
+// lfEnt builds an entity with an explicit Kind (mtEnt hardcodes
+// SCOPE.Operation, which is exactly the distinction under test here).
+func lfEnt(id, name, sourceFile, kind string) graph.Entity {
+	return graph.Entity{
+		ID: id, Name: name, Kind: kind,
+		SourceFile: sourceFile, Language: "go",
+	}
+}
+
+// TestResolveScoped_LeafTier_MustNotBindCallToField_6141 — precision. The
+// only `owner` in the caller's package is a state variable / struct field.
+// A bare call must stay unresolved rather than bind cross-scope to data.
+func TestResolveScoped_LeafTier_MustNotBindCallToField_6141(t *testing.T) {
+	existing := []graph.Entity{lfEnt(lfField, "Other.owner", "svc/c.go", "SCOPE.Schema")}
+	fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
+	newRels := []graph.Relationship{mtCallRel(lfCaller, "owner", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+	if got.ToID != "owner" {
+		t.Errorf("bare CALLS `owner` bound to the FIELD Other.owner [SCOPE.Schema] @ svc/c.go "+
+			"(ToID=%q); a call target must be an operation, so the stub must stay verbatim", got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_FieldMustNotShadowOperation_6141 — recall. The
+// package holds one genuine operation `Owned.owner` and one unrelated field
+// `Other.owner`. Today the field enters the candidate set, two distinct
+// scopes claim the leaf name, and the CORRECT edge is dropped.
+func TestResolveScoped_LeafTier_FieldMustNotShadowOperation_6141(t *testing.T) {
+	existing := []graph.Entity{
+		lfEnt(lfOp, "Owned.owner", "svc/b.go", "SCOPE.Operation"),
+		lfEnt(lfField, "Other.owner", "svc/c.go", "SCOPE.Schema"),
+	}
+	fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
+	newRels := []graph.Relationship{mtCallRel(lfCaller, "owner", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+	if got.ToID != lfOp {
+		t.Errorf("bare CALLS `owner` should bind to the unique OPERATION Owned.owner (%s) — "+
+			"the sibling FIELD Other.owner must not enter the candidate set and trip the "+
+			"ambiguity guard; got ToID=%q", lfOp, got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_ReceiverTierStillSeesFields_6141 is the scope
+// guard: only the LEAF tiers are kind-filtered. Tier 1 (receiver-stamped
+// byPackageMember) names its scope explicitly, so it is precise by
+// construction and is deliberately left kind-blind — filtering it would be
+// a separate, unassessed change. This test fails if the filter is applied
+// to the receiver tier's index by mistake.
+func TestResolveScoped_LeafTier_ReceiverTierStillSeesFields_6141(t *testing.T) {
+	existing := []graph.Entity{lfEnt(lfField, "Other.owner", "svc/c.go", "SCOPE.Schema")}
+	fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
+	newRels := []graph.Relationship{mtCallRel(lfCaller, "owner", "Other")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+	if got.ToID != lfField {
+		t.Errorf("the receiver-stamped tier names its scope (receiver_type=Other) and must stay "+
+			"kind-blind; want ToID=%s, got %q", lfField, got.ToID)
+	}
+}
+
+// TestResolveScoped_LeafTier_OperationKindsStillBind_6141 pins the whole
+// operation kind family through the scoped leaf tiers, so the filter cannot
+// silently drop a language whose callables carry a different operation kind.
+func TestResolveScoped_LeafTier_OperationKindsStillBind_6141(t *testing.T) {
+	for _, kind := range []string{"Operation", "Function", "Method", "SCOPE.Operation"} {
+		t.Run(kind, func(t *testing.T) {
+			existing := []graph.Entity{lfEnt(lfOp, "T11.Do11", "svc/b.go", kind)}
+			fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
+			newRels := []graph.Relationship{mtCallRel(lfCaller, "Do11", "")}
+
+			res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+			got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+			if got.ToID != lfOp {
+				t.Errorf("callable of kind %q no longer binds through the scoped leaf tier; "+
+					"want ToID=%s, got %q", kind, lfOp, got.ToID)
+			}
+		})
+	}
+}
+
+// TestResolveScoped_LeafTier_TwoOperationsStillAmbiguous_6141 is the
+// false-negative control on the guard: the kind filter must NARROW the
+// candidate set, never DISABLE the ambiguity refusal.
+func TestResolveScoped_LeafTier_TwoOperationsStillAmbiguous_6141(t *testing.T) {
+	existing := []graph.Entity{
+		lfEnt(lfOp, "T11.Do11", "svc/b.go", "SCOPE.Operation"),
+		lfEnt(lfField, "T23.Do11", "svc/c.go", "SCOPE.Operation"),
+	}
+	fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
+	newRels := []graph.Relationship{mtCallRel(lfCaller, "Do11", "")}
+
+	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
+	if got.ToID != "Do11" {
+		t.Errorf("two same-named OPERATIONS in package svc must stay unresolved; "+
+			"got a confident binding ToID=%q", got.ToID)
+	}
+}

--- a/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
+++ b/internal/extractors/sresolver/leafname_kind_filter_6141_test.go
@@ -16,6 +16,11 @@ import (
 // bare CALLS stub binds to a FIELD, and a legitimate operation binding is
 // LOST when an unrelated same-leaf-named field trips the ambiguity guard.
 //
+// Only the RECALL half is fixed, matching internal/resolve: a hard kind
+// filter was implemented, then measured to destroy real Ruby and JS/TS
+// bindings and reduced to an operation PREFERENCE. The precision half is
+// pinned as a known gap below rather than left untested.
+//
 // These are separate tests rather than a note on the refs.go fix because
 // the two resolvers are separate code with separate indexes: fixing only
 // refs.go would make an incremental build disagree with a full rebuild on
@@ -37,19 +42,32 @@ func lfEnt(id, name, sourceFile, kind string) graph.Entity {
 	}
 }
 
-// TestResolveScoped_LeafTier_MustNotBindCallToField_6141 — precision. The
-// only `owner` in the caller's package is a state variable / struct field.
-// A bare call must stay unresolved rather than bind cross-scope to data.
-func TestResolveScoped_LeafTier_MustNotBindCallToField_6141(t *testing.T) {
+// TestResolveScoped_LeafTier_PrecisionGap_StillBindsToField_6141 is the
+// scoped mirror of internal/resolve's
+// TestLeafNameTier_PrecisionGap_CallStillBindsToField_6141 — a
+// CHARACTERISATION test on behaviour that is still wrong for
+// Solidity/Java/Go and deliberately left that way.
+//
+// The only `owner` in the caller's package is a field, so the
+// operation-preferring pass finds nothing and the kind-blind pass binds the
+// call to it. Refusing instead was measured to destroy real Ruby
+// attr_accessor and JS function-field bindings; see the note on
+// memberIndexes.leafByFileOp.
+//
+// The two resolvers MUST agree here. If you change one, change the other,
+// or an incremental build and a full rebuild will disagree on the same
+// source — the divergence class this file's header warns about.
+func TestResolveScoped_LeafTier_PrecisionGap_StillBindsToField_6141(t *testing.T) {
 	existing := []graph.Entity{lfEnt(lfField, "Other.owner", "svc/c.go", "SCOPE.Schema")}
 	fresh := []graph.Entity{lfEnt(lfCaller, "Local07", "svc/a.go", "SCOPE.Operation")}
 	newRels := []graph.Relationship{mtCallRel(lfCaller, "owner", "")}
 
 	res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
 	got := mtOnlyCall(t, res.ResolvedNewRelationships, lfCaller)
-	if got.ToID != "owner" {
-		t.Errorf("bare CALLS `owner` bound to the FIELD Other.owner [SCOPE.Schema] @ svc/c.go "+
-			"(ToID=%q); a call target must be an operation, so the stub must stay verbatim", got.ToID)
+	if got.ToID != lfField {
+		t.Errorf("known precision gap changed shape: bare CALLS `owner` gave ToID=%q, want the "+
+			"field %s. If a refusal was intended, make internal/resolve refuse too and check the "+
+			"Ruby attr_accessor end-to-end test", got.ToID, lfField)
 	}
 }
 

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -132,6 +132,20 @@ type memberIndexes struct {
 	leafByFile      map[string]map[string]string            // [file][member]
 	leafByPkg       map[string]map[string]string            // [dir][member]
 
+	// #6141 — operation-only twins of the two leaf indexes, probed FIRST.
+	// The leaf tiers do not know the scope they are binding into, so an
+	// unrelated same-leaf-named FIELD used to enter the candidate set and
+	// trip the ambiguity guard, destroying a correct binding to a real
+	// operation. Preferring operations removes the field from that
+	// contest. They are a PREFERENCE, not a filter: the kind-blind twins
+	// above are still consulted when no operation matches, because Ruby
+	// (attr_accessor) and JS/TS (`handler = function(){}`) model genuinely
+	// invocable members as SCOPE.Schema fields and the leaf tier is their
+	// only binding route. See scanLeafMembersPreferring in
+	// internal/resolve/refs.go for the measurement that established this.
+	leafByFileOp map[string]map[string]string // [file][member], operations only
+	leafByPkgOp  map[string]map[string]string // [dir][member],  operations only
+
 	// callerLoc maps an entity ID to its location. It is probed with the
 	// edge's RESOLVED FromID, which is why ResolveScoped must rewrite the
 	// from-side of an edge before the to-side: the Go extractor emits the
@@ -208,6 +222,8 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 		byPackageMember: map[string]map[string]map[string]string{},
 		leafByFile:      map[string]map[string]string{},
 		leafByPkg:       map[string]map[string]string{},
+		leafByFileOp:    map[string]map[string]string{},
+		leafByPkgOp:     map[string]map[string]string{},
 		callerLoc:       map[string]callerLocation{},
 	}
 
@@ -249,32 +265,6 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 			}
 			put(scopeBucket, member, e.ID)
 
-			// Issue #6141 — the leaf tiers, unlike tier 1, do NOT know the
-			// scope: they bind a bare name to a member of ANY scope. That
-			// makes a kind filter load-bearing in BOTH directions. Without
-			// it a bare `owner()` binds to a sibling type's FIELD `owner`
-			// (precision), AND a correct binding to a real `owner()` method
-			// is LOST because the unrelated field enters the candidate set
-			// and trips the ambiguity guard (recall). The two symptoms move
-			// a dangling count in opposite directions, so neither is
-			// visible in aggregate — see the binding-content assertions in
-			// leafname_kind_filter_6141_test.go.
-			//
-			// Filtered at BUILD time rather than at lookup because these
-			// two indexes have exactly one consumer (lookupLeaf, gated to
-			// CALLS), so an excluded entity has no other reader. Tier 1's
-			// byPackageMember above is deliberately NOT filtered: its key
-			// names the scope, so it is precise by construction, and it is
-			// also probed for field-shaped edges.
-			//
-			// Mirrors internal/resolve/refs.go's famOperation filter on
-			// lookupMemberByLeafName / lookupPackageMemberByLeafName. The
-			// two resolvers must agree here or an incremental build and a
-			// full rebuild disagree on the same source.
-			if !isOperationKind(e.Kind) {
-				continue
-			}
-
 			fileBucket := idx.leafByFile[file]
 			if fileBucket == nil {
 				fileBucket = map[string]string{}
@@ -288,6 +278,26 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 				idx.leafByPkg[dir] = pkgLeaf
 			}
 			put(pkgLeaf, member, e.ID)
+
+			// #6141 — operation-only twins, probed ahead of the two above.
+			// A field never enters these, so it can no longer trip the
+			// ambiguity guard against a real operation.
+			if !isOperationKind(e.Kind) {
+				continue
+			}
+			fileOp := idx.leafByFileOp[file]
+			if fileOp == nil {
+				fileOp = map[string]string{}
+				idx.leafByFileOp[file] = fileOp
+			}
+			put(fileOp, member, e.ID)
+
+			pkgOp := idx.leafByPkgOp[dir]
+			if pkgOp == nil {
+				pkgOp = map[string]string{}
+				idx.leafByPkgOp[dir] = pkgOp
+			}
+			put(pkgOp, member, e.ID)
 		}
 	}
 	scan(existingEntities)
@@ -440,6 +450,24 @@ func (idx *memberIndexes) lookupLeaf(r *graph.Relationship, callerEndpoint strin
 	// same gate is what stops a DEPENDS_ON from catching a same-named method.
 	if !strings.EqualFold(r.Kind, "CALLS") {
 		return "", false
+	}
+	// #6141 — operation-preferring passes run AHEAD of the kind-blind
+	// ones, preserving the same file-before-package order within each.
+	// An ambiguous operation hit still refuses (returns handled) rather
+	// than falling through to the kind-blind twin: two real operations
+	// contesting the name is not made resolvable by adding fields to the
+	// contest.
+	if id, ok := idx.leafByFileOp[loc.file][member]; ok {
+		if id == ambiguous {
+			return "", true
+		}
+		return id, true
+	}
+	if id, ok := idx.leafByPkgOp[loc.dir][member]; ok {
+		if id == ambiguous {
+			return "", true
+		}
+		return id, true
 	}
 	// Tier 2 — same file, any scope.
 	if id, ok := idx.leafByFile[loc.file][member]; ok {

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -451,32 +451,50 @@ func (idx *memberIndexes) lookupLeaf(r *graph.Relationship, callerEndpoint strin
 	if !strings.EqualFold(r.Kind, "CALLS") {
 		return "", false
 	}
-	// #6141 — operation-preferring passes run AHEAD of the kind-blind
-	// ones, preserving the same file-before-package order within each.
+	// #6141 — the operation preference is applied WITHIN each tier, never
+	// ACROSS them: (fileOp, fileAny) and only then (pkgOp, pkgAny).
+	//
+	// The distinction is load-bearing and was got wrong first time round.
+	// Probing both operation indexes up front — fileOp, pkgOp, fileAny,
+	// pkgAny — reaches into a SIBLING FILE for an operation instead of
+	// binding a same-leaf-named member in the caller's own file, which is
+	// the opposite of what internal/resolve does and of what every
+	// surrounding tier does (locality first). Measured on a randomized
+	// differential: the across-tiers order changed 6,616 of ~200,000
+	// bindings; the within-tier order changes 0 and keeps all the gains.
+	//
+	// This resolver exists to agree with internal/resolve on the same
+	// source — divergence here means a full rebuild and an incremental
+	// build produce different graphs, reachable in ordinary code (a Ruby
+	// `attr_accessor :owner` beside a sibling class's `def owner`).
+	// Pinned by TestResolveScoped_LeafTier_PreferenceIsWithinTierNotAcrossTiers_6141
+	// and its twin in internal/resolve.
+	//
 	// An ambiguous operation hit still refuses (returns handled) rather
 	// than falling through to the kind-blind twin: two real operations
 	// contesting the name is not made resolvable by adding fields to the
 	// contest.
+
+	// Tier 2 — same file: operations first, then any scope.
 	if id, ok := idx.leafByFileOp[loc.file][member]; ok {
 		if id == ambiguous {
 			return "", true
 		}
 		return id, true
 	}
-	if id, ok := idx.leafByPkgOp[loc.dir][member]; ok {
-		if id == ambiguous {
-			return "", true
-		}
-		return id, true
-	}
-	// Tier 2 — same file, any scope.
 	if id, ok := idx.leafByFile[loc.file][member]; ok {
 		if id == ambiguous {
 			return "", true
 		}
 		return id, true
 	}
-	// Tier 3 — same package directory, any scope. The #6090-residual tier.
+	// Tier 3 — same package directory. The #6090-residual tier.
+	if id, ok := idx.leafByPkgOp[loc.dir][member]; ok {
+		if id == ambiguous {
+			return "", true
+		}
+		return id, true
+	}
 	if id, ok := idx.leafByPkg[loc.dir][member]; ok {
 		if id == ambiguous {
 			return "", true

--- a/internal/extractors/sresolver/pkgmember.go
+++ b/internal/extractors/sresolver/pkgmember.go
@@ -162,6 +162,25 @@ type callerLocation struct {
 // indexed under its dotted form. Left divergent rather than aligned so the
 // gate keeps stating the condition this code actually depends on, but the
 // coupling is written down here.
+// isOperationKind reports whether an entity Kind is call-target shaped —
+// the scoped port of internal/resolve/refs.go's operationKindFamily
+// (issue #6141). Both the raw kind and its SCOPE.-trimmed form are
+// consulted, mirroring the dual-indexing the corpus-wide resolver applies,
+// so a hypothetical "SCOPE.Method" still classifies as an operation.
+//
+// Kept as a literal list rather than importing internal/resolve because
+// that package depends on the extractor types and importing it here would
+// close a cycle. The list is pinned against drift by
+// TestResolveScoped_LeafTier_OperationKindsStillBind_6141, which walks the
+// same four kinds the resolve-side test walks.
+func isOperationKind(kind string) bool {
+	switch strings.TrimPrefix(kind, "SCOPE.") {
+	case "Operation", "Function", "Method":
+		return true
+	}
+	return false
+}
+
 func relWantsMemberTier(r *graph.Relationship) bool {
 	if r.ToID == "" || isHexID(r.ToID) || strings.IndexByte(r.ToID, ':') >= 0 {
 		return false
@@ -229,6 +248,32 @@ func buildMemberIndexes(newEntities, existingEntities []graph.Entity) *memberInd
 				pkgBucket[scope] = scopeBucket
 			}
 			put(scopeBucket, member, e.ID)
+
+			// Issue #6141 — the leaf tiers, unlike tier 1, do NOT know the
+			// scope: they bind a bare name to a member of ANY scope. That
+			// makes a kind filter load-bearing in BOTH directions. Without
+			// it a bare `owner()` binds to a sibling type's FIELD `owner`
+			// (precision), AND a correct binding to a real `owner()` method
+			// is LOST because the unrelated field enters the candidate set
+			// and trips the ambiguity guard (recall). The two symptoms move
+			// a dangling count in opposite directions, so neither is
+			// visible in aggregate — see the binding-content assertions in
+			// leafname_kind_filter_6141_test.go.
+			//
+			// Filtered at BUILD time rather than at lookup because these
+			// two indexes have exactly one consumer (lookupLeaf, gated to
+			// CALLS), so an excluded entity has no other reader. Tier 1's
+			// byPackageMember above is deliberately NOT filtered: its key
+			// names the scope, so it is precise by construction, and it is
+			// also probed for field-shaped edges.
+			//
+			// Mirrors internal/resolve/refs.go's famOperation filter on
+			// lookupMemberByLeafName / lookupPackageMemberByLeafName. The
+			// two resolvers must agree here or an incremental build and a
+			// full rebuild disagree on the same source.
+			if !isOperationKind(e.Kind) {
+				continue
+			}
 
 			fileBucket := idx.leafByFile[file]
 			if fileBucket == nil {

--- a/internal/extractors/sresolver/resolver_agreement_6141_test.go
+++ b/internal/extractors/sresolver/resolver_agreement_6141_test.go
@@ -1,0 +1,193 @@
+package sresolver_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors/sresolver"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/resolve"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Cross-resolver AGREEMENT gate for the leaf-name tiers (#6141, refs #6129).
+//
+// Why this exists, and why it is not the #6129 corpus gate
+// ───────────────────────────────────────────────────────
+// internal/resolve (full rebuild) and internal/extractors/sresolver
+// (incremental) are separate code with separate indexes that must bind the
+// same source identically. #6141 shipped a tier reordering to both; the
+// first attempt got sresolver's order wrong and a full rebuild and an
+// incremental run bound the same call to DIFFERENT entities.
+//
+// The #6129 content-parity gate in cmd/grafel is the corpus-level instrument
+// for that class, and it PASSED while the divergence was live: its fixture
+// keeps the competing member in a different file from the caller, so it
+// never reaches the shape that separates the two orderings.
+//
+// Extending that fixture was attempted and is blocked by an unrelated,
+// undiagnosed divergence: adding ANY class to its delta file — a bare
+// `class C: def m(self): return 1`, with no #6141 shape at all — makes the
+// full rebuild classify it `Controller` and the incremental run
+// `SCOPE.Component`, producing four spurious CONTAINS divergences. That is
+// a genuine pre-existing defect in the incremental path (classes in STATIC
+// files classify identically on both sides), but it needs its own issue
+// before the gate's allow-list can name it, and that gate's rules forbid an
+// allow entry without a filed issue.
+//
+// So the invariant is pinned HERE instead, directly and at unit cost. This
+// is a tighter guard than the corpus gate for this specific defect: it
+// drives both resolvers over one entity set and asserts they agree on the
+// bound target BY CONTENT.
+//
+// If you add a leaf-name tier, a preference, or a reordering to either
+// resolver, add its shape to agreementShapes below.
+
+// agreementShape is one fixture: a caller with a bare CALLS stub, plus the
+// members that compete for that leaf name.
+type agreementShape struct {
+	name string
+	// members are (name, file, kind) triples; the caller is always
+	// "Local07" in callerFile.
+	callerFile string
+	members    [][3]string
+	stub       string
+}
+
+var agreementShapes = []agreementShape{
+	{
+		// THE shape that separates within-tier from across-tiers ordering,
+		// and the one the #6129 corpus fixture cannot reach. A field in the
+		// caller's OWN file versus an operation in a SIBLING file.
+		name:       "caller_file_field_beside_sibling_file_operation",
+		callerFile: "svc/a.go",
+		members: [][3]string{
+			{"Other.owner", "svc/a.go", "SCOPE.Schema"},
+			{"Owned.owner", "svc/b.go", "SCOPE.Operation"},
+		},
+		stub: "owner",
+	},
+	{
+		// The recall half: a sibling FIELD must not shadow a sibling
+		// OPERATION.
+		name:       "sibling_field_must_not_shadow_sibling_operation",
+		callerFile: "svc/a.go",
+		members: [][3]string{
+			{"Owned.owner", "svc/b.go", "SCOPE.Operation"},
+			{"Other.owner", "svc/c.go", "SCOPE.Schema"},
+		},
+		stub: "owner",
+	},
+	{
+		// The precision gap: only a field exists, both must still bind it
+		// (the Ruby attr_accessor / JS function-field constraint).
+		name:       "field_only_still_binds",
+		callerFile: "svc/a.go",
+		members:    [][3]string{{"Other.owner", "svc/c.go", "SCOPE.Schema"}},
+		stub:       "owner",
+	},
+	{
+		// Two operations must stay ambiguous in BOTH resolvers.
+		name:       "two_operations_stay_ambiguous",
+		callerFile: "svc/a.go",
+		members: [][3]string{
+			{"RepoA.find", "svc/b.go", "SCOPE.Operation"},
+			{"RepoB.find", "svc/c.go", "SCOPE.Operation"},
+		},
+		stub: "find",
+	},
+	{
+		// Same-file operation beats same-file field: the operation
+		// preference inside the file tier.
+		name:       "same_file_operation_beats_same_file_field",
+		callerFile: "svc/a.go",
+		members: [][3]string{
+			{"Owned.owner", "svc/a.go", "SCOPE.Operation"},
+			{"Other.owner", "svc/a.go", "SCOPE.Schema"},
+		},
+		stub: "owner",
+	},
+	{
+		// Caller-file OPERATION beside a sibling-file operation: locality
+		// wins, and it must win identically in both.
+		name:       "caller_file_operation_beside_sibling_file_operation",
+		callerFile: "svc/a.go",
+		members: [][3]string{
+			{"Owned.owner", "svc/a.go", "SCOPE.Operation"},
+			{"Sib.owner", "svc/b.go", "SCOPE.Operation"},
+		},
+		stub: "owner",
+	},
+}
+
+// TestLeafTier_FullAndIncrementalResolversAgree_6141 drives both resolvers
+// over each shape and fails when they bind the same stub differently.
+func TestLeafTier_FullAndIncrementalResolversAgree_6141(t *testing.T) {
+	for _, sh := range agreementShapes {
+		t.Run(sh.name, func(t *testing.T) {
+			const callerID = "1111111111111111"
+
+			// Describe the world once; feed both resolvers from it so a
+			// divergence can only come from the resolvers themselves.
+			type member struct{ id, name, file, kind string }
+			members := make([]member, 0, len(sh.members))
+			for i, m := range sh.members {
+				members = append(members, member{
+					id:   fmt.Sprintf("%016x", i+2),
+					name: m[0], file: m[1], kind: m[2],
+				})
+			}
+
+			// ---- full-rebuild resolver (internal/resolve) ----
+			recs := []types.EntityRecord{{
+				ID: callerID, Kind: "SCOPE.Operation", Name: "Local07",
+				SourceFile: sh.callerFile,
+				Relationships: []types.RelationshipRecord{{
+					FromID: callerID, ToID: sh.stub, Kind: "CALLS",
+				}},
+			}}
+			for _, m := range members {
+				recs = append(recs, types.EntityRecord{
+					ID: m.id, Kind: m.kind, Name: m.name, SourceFile: m.file,
+				})
+			}
+			idx := resolve.BuildIndex(recs)
+			resolve.ReferencesEmbedded(recs, idx)
+			full := recs[0].Relationships[0].ToID
+
+			// ---- incremental resolver (sresolver) ----
+			fresh := []graph.Entity{lfEnt(callerID, "Local07", sh.callerFile, "SCOPE.Operation")}
+			var existing []graph.Entity
+			for _, m := range members {
+				e := lfEnt(m.id, m.name, m.file, m.kind)
+				// Members in the caller's own file are part of the delta.
+				if m.file == sh.callerFile {
+					fresh = append(fresh, e)
+					continue
+				}
+				existing = append(existing, e)
+			}
+			newRels := []graph.Relationship{mtCallRel(callerID, sh.stub, "")}
+			res := sresolver.ResolveScoped(fresh, existing, newRels, nil, nil)
+			incr := mtOnlyCall(t, res.ResolvedNewRelationships, callerID).ToID
+
+			if full != incr {
+				describe := func(id string) string {
+					for _, m := range members {
+						if m.id == id {
+							return fmt.Sprintf("%s [%s] @ %s", m.name, m.kind, m.file)
+						}
+					}
+					return fmt.Sprintf("«unbound»%s", id)
+				}
+				t.Fatalf("full rebuild and incremental disagree on bare CALLS %q:\n"+
+					"  internal/resolve            -> %s\n"+
+					"  internal/extractors/sresolver -> %s\n"+
+					"A full reindex and an incremental reindex must produce the same graph "+
+					"for the same source. Align the tier ORDER in sresolver.lookupLeaf with "+
+					"scanLeafMembersPreferring in internal/resolve/refs.go.",
+					sh.stub, describe(full), describe(incr))
+			}
+		})
+	}
+}

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -392,3 +392,43 @@ func TestLeafNameTier_SameScopeDuplicateStaysAmbiguous_6141(t *testing.T) {
 			"both IDs before the kind filter can see them, so this must stay unresolved", stub)
 	}
 }
+
+// TestLeafNameTier_FieldStubMustNotPreferOperation_6141 is the guard that
+// makes the `0` mask at the #667 Java inherited-field call site actually
+// load-bearing.
+//
+// It exists because the obvious guard is NOT one. With the two-pass design,
+// passing famOperation at a field-shaped call site is invisible whenever
+// only ONE candidate exists: the operation pass misses and the kind-blind
+// fallback binds the field anyway. Mutating 0 -> famOperation there
+// survived the whole suite. The mutation only becomes observable when the
+// package holds BOTH a field and an operation of that leaf name — then an
+// operation preference actively picks the wrong one.
+//
+// So: a field-shaped REFERENCES stub must never bind to Helper.parentField
+// [SCOPE.Operation]. Leaving it unresolved is fine; binding to the
+// operation is the failure.
+func TestLeafNameTier_FieldStubMustNotPreferOperation_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "1111111111111111", Kind: "Operation", Name: "Child.use", SourceFile: "src/Child.java",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "1111111111111111",
+				ToID:   "scope:schema:ref:java:src/Child.java:Child.parentField",
+				Kind:   "REFERENCES",
+			}},
+		},
+		entAt("cccccccccccccccc", "SCOPE.Schema", "Parent.parentField", "src/Parent.java"),
+		// An OPERATION sharing the leaf name, in the same package.
+		entAt("eeeeeeeeeeeeeeee", "SCOPE.Operation", "Helper.parentField", "src/Helper.java"),
+		// Cross-package decoy — defeats lookupUniqueSchemaFieldByName so the
+		// package leaf tier is the only thing that could bind.
+		entAt("dddddddddddddddd", "SCOPE.Schema", "Elsewhere.parentField", "other/Elsewhere.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub == "" && got.id == "eeeeeeeeeeeeeeee" {
+		t.Fatalf("a field-shaped REFERENCES stub bound to the OPERATION Helper.parentField "+
+			"[%s] @ %s — the #667 call site must pass mask 0, never famOperation",
+			got.kind, got.file)
+	}
+}

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -1,0 +1,239 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6141 — the leaf-name tiers (lookupMemberByLeafName /
+// lookupPackageMemberByLeafName) bind a bare CALLS stub to ANY entity in
+// the caller's file / package directory whose dotted Name ends in the
+// stub, regardless of the entity's Kind. A call target must be an
+// operation; without a kind filter the tier binds calls to FIELDS.
+//
+// The defect costs precision AND recall at once, in opposite directions:
+//
+//   - PRECISION: a bare `owner()` call binds cross-scope, cross-file to a
+//     sibling contract's `address public owner` state variable.
+//   - RECALL: a CORRECT operation binding is LOST when an unrelated
+//     same-leaf-named field joins the candidate set and trips the
+//     ambiguity guard.
+//
+// Every assertion below is on what the edge binds TO, by content
+// (kind / name / source_file) — never on an aggregate dangling count,
+// which is blind here because the two symptoms cancel.
+
+// callerWithCall builds an entity record carrying one embedded bare CALLS
+// edge, which is the shape ReferencesEmbedded resolves with caller
+// (file, pkgDir) context — the only path that reaches the leaf-name tiers.
+func callerWithCall(id, kind, name, file, target string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: kind, Name: name, SourceFile: file,
+		Relationships: []types.RelationshipRecord{{
+			FromID: id, ToID: target, Kind: "CALLS",
+		}},
+	}
+}
+
+// boundTo describes what an edge actually bound to, resolved back through
+// the entity set by ID. A nil result means the edge is still a stub.
+type boundTo struct {
+	id, kind, name, file string
+}
+
+// resolveEdge runs ReferencesEmbedded over records and returns the content
+// of whatever records[callerIdx]'s first embedded edge bound to. Returns
+// ("", ...) with stub set when the edge was left verbatim.
+func resolveEdge(t *testing.T, records []types.EntityRecord, callerIdx int) (got boundTo, stub string) {
+	t.Helper()
+	idx := BuildIndex(records)
+	ReferencesEmbedded(records, idx)
+	to := records[callerIdx].Relationships[0].ToID
+	for i := range records {
+		if records[i].ID == to {
+			return boundTo{records[i].ID, records[i].Kind, records[i].Name, records[i].SourceFile}, ""
+		}
+	}
+	return boundTo{}, to
+}
+
+// --- PRECISION: the wrong bind --------------------------------------------
+
+// TestLeafNameTier_PackageScope_MustNotBindCallToField_6141 is the wrong-bind
+// half, package-scoped. contracts/Vault.sol calls bare `owner()`; a SIBLING
+// FILE declares the state variable `Registry.owner`. Nothing in the package
+// declares an OPERATION named `owner`, so the correct outcome is an
+// unresolved stub — not a cross-contract, cross-file bind to a field.
+func TestLeafNameTier_PackageScope_MustNotBindCallToField_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
+		entAt("2222222222222222", "SCOPE.Schema", "Registry.owner", "contracts/Registry.sol"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "owner" {
+		t.Fatalf("bare CALLS `owner` bound to a non-operation: id=%s kind=%s name=%s file=%s; "+
+			"want the stub %q left verbatim (no operation named `owner` exists in the package)",
+			got.id, got.kind, got.name, got.file, "owner")
+	}
+}
+
+// TestLeafNameTier_FileScope_MustNotBindCallToField_6141 is the wrong-bind
+// half, file-scoped (lookupMemberByLeafName). Same file, different scope:
+// `Vault.deposit` calls bare `owner()` and only `Other.owner` — a field —
+// declares that leaf name.
+func TestLeafNameTier_FileScope_MustNotBindCallToField_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
+		entAt("3333333333333333", "SCOPE.Schema", "Other.owner", "contracts/Vault.sol"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "owner" {
+		t.Fatalf("same-file bare CALLS `owner` bound to a non-operation: id=%s kind=%s name=%s file=%s; "+
+			"want the stub %q left verbatim", got.id, got.kind, got.name, got.file, "owner")
+	}
+}
+
+// --- RECALL: the lost edge -------------------------------------------------
+
+// TestLeafNameTier_PackageScope_FieldMustNotShadowOperation_6141 is the
+// recall half, package-scoped. `Owned.owner()` is a real operation in a
+// sibling file and is the ONLY legitimate target. Adding an unrelated
+// `Other.owner` FIELD to the same package directory trips the cross-scope
+// ambiguity guard and the correct edge is lost. The field is not a call
+// target and must never enter the candidate set.
+func TestLeafNameTier_PackageScope_FieldMustNotShadowOperation_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
+		entAt("4444444444444444", "SCOPE.Operation", "Owned.owner", "contracts/Owned.sol"),
+		entAt("5555555555555555", "SCOPE.Schema", "Other.owner", "contracts/Other.sol"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("bare CALLS `owner` left as stub %q; want it bound to the operation "+
+			"Owned.owner [SCOPE.Operation] @ contracts/Owned.sol — the sibling FIELD "+
+			"Other.owner must not enter the candidate set", stub)
+	}
+	if got.id != "4444444444444444" || got.kind != "SCOPE.Operation" ||
+		got.name != "Owned.owner" || got.file != "contracts/Owned.sol" {
+		t.Fatalf("bound to id=%s kind=%s name=%s file=%s; want id=4444444444444444 "+
+			"kind=SCOPE.Operation name=Owned.owner file=contracts/Owned.sol",
+			got.id, got.kind, got.name, got.file)
+	}
+}
+
+// TestLeafNameTier_FileScope_FieldMustNotShadowOperation_6141 is the recall
+// half, file-scoped. Two scopes in ONE file: `Owned.owner` (operation, the
+// correct target) and `Other.owner` (field). The file-scoped tier's
+// cross-scope ambiguity guard drops the correct edge.
+func TestLeafNameTier_FileScope_FieldMustNotShadowOperation_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
+		entAt("6666666666666666", "SCOPE.Operation", "Owned.owner", "contracts/Vault.sol"),
+		entAt("7777777777777777", "SCOPE.Schema", "Other.owner", "contracts/Vault.sol"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("same-file bare CALLS `owner` left as stub %q; want it bound to the "+
+			"operation Owned.owner [SCOPE.Operation]", stub)
+	}
+	if got.id != "6666666666666666" || got.kind != "SCOPE.Operation" || got.name != "Owned.owner" {
+		t.Fatalf("bound to id=%s kind=%s name=%s file=%s; want id=6666666666666666 "+
+			"kind=SCOPE.Operation name=Owned.owner", got.id, got.kind, got.name, got.file)
+	}
+}
+
+// --- POSITIVE CONTROLS: what must keep binding ----------------------------
+
+// TestLeafNameTier_JavaCrossFileMethodStillBinds_6141 is the #778 contract
+// the tiers exist for: a bare Java CALLS stub binding to a same-package,
+// cross-file method. It must be untouched by the kind filter. Java methods
+// are emitted with Kind "Operation".
+func TestLeafNameTier_JavaCrossFileMethodStillBinds_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "Operation", "OrderService.place", "src/svc/OrderService.java", "merge"),
+		entAt("8888888888888888", "Operation", "InventoryService.merge", "src/svc/InventoryService.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("#778 Java cross-file bare CALLS regressed: stub %q left verbatim", stub)
+	}
+	if got.id != "8888888888888888" || got.name != "InventoryService.merge" {
+		t.Fatalf("bound to id=%s kind=%s name=%s; want InventoryService.merge", got.id, got.kind, got.name)
+	}
+}
+
+// TestLeafNameTier_EveryOperationKindStillBinds_6141 pins the whole
+// operationKindFamily through the leaf-name tiers. If any language emits
+// its callables under one of these kinds, the filter must not drop it.
+func TestLeafNameTier_EveryOperationKindStillBinds_6141(t *testing.T) {
+	for _, kind := range []string{"Operation", "Function", "Method", "SCOPE.Operation"} {
+		t.Run(kind, func(t *testing.T) {
+			records := []types.EntityRecord{
+				callerWithCall("1111111111111111", "Operation", "Caller.run", "src/pkg/Caller.java", "helper"),
+				entAt("9999999999999999", kind, "Util.helper", "src/pkg/Util.java"),
+			}
+			got, stub := resolveEdge(t, records, 0)
+			if stub != "" {
+				t.Fatalf("callable of kind %q no longer binds through the leaf-name tier: stub %q", kind, stub)
+			}
+			if got.id != "9999999999999999" {
+				t.Fatalf("kind %q bound to id=%s name=%s; want 9999999999999999 / Util.helper",
+					kind, got.id, got.name)
+			}
+		})
+	}
+}
+
+// TestLeafNameTier_TwoOperationsStillAmbiguous_6141 is the false-negative
+// control on the ambiguity guard itself: the kind filter must NARROW the
+// candidate set, never DISABLE the guard. Two genuine operations sharing a
+// leaf name in one package remain unresolvable.
+func TestLeafNameTier_TwoOperationsStillAmbiguous_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "Operation", "Caller.run", "src/pkg/Caller.java", "find"),
+		entAt("aaaaaaaaaaaaaaaa", "Operation", "RepoA.find", "src/pkg/RepoA.java"),
+		entAt("bbbbbbbbbbbbbbbb", "Operation", "RepoB.find", "src/pkg/RepoB.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "find" {
+		t.Fatalf("two same-named operations bound anyway: id=%s name=%s file=%s; "+
+			"want the ambiguity guard to leave the stub verbatim", got.id, got.name, got.file)
+	}
+}
+
+// TestLeafNameTier_JavaFieldHintStubStillBinds_6141 is the scope guard on
+// the OTHER caller of lookupPackageMemberByLeafName: the #667 Java
+// `scope:schema:ref:java:<file>:<Class>.<field>` inherited-field hint. That
+// call site is FIELD-shaped and must NOT be operation-filtered.
+//
+// TestJavaExtendsFieldRef already covers the shape, but it CANNOT protect
+// this call site: with a single global `*.parentField` entity the resolver
+// would fall through to lookupUniqueSchemaFieldByName and bind anyway, so
+// filtering the package tier would not fail it. A DECOY field of the same
+// leaf name in a DIFFERENT package directory makes the global-unique tier
+// ambiguous, leaving lookupPackageMemberByLeafName as the only tier that
+// can bind — which is what makes this a real guard.
+func TestLeafNameTier_JavaFieldHintStubStillBinds_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			ID: "1111111111111111", Kind: "Operation", Name: "Child.use", SourceFile: "src/Child.java",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "1111111111111111",
+				ToID:   "scope:schema:ref:java:src/Child.java:Child.parentField",
+				Kind:   "REFERENCES",
+			}},
+		},
+		entAt("cccccccccccccccc", "SCOPE.Schema", "Parent.parentField", "src/Parent.java"),
+		// Decoy in another package — defeats lookupUniqueSchemaFieldByName.
+		entAt("dddddddddddddddd", "SCOPE.Schema", "Elsewhere.parentField", "other/Elsewhere.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("#667 Java inherited-field hint stub regressed: %q left verbatim", stub)
+	}
+	if got.id != "cccccccccccccccc" || got.kind != "SCOPE.Schema" {
+		t.Fatalf("bound to id=%s kind=%s name=%s; want cccccccccccccccc / SCOPE.Schema / Parent.parentField",
+			got.id, got.kind, got.name)
+	}
+}

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -432,3 +432,44 @@ func TestLeafNameTier_FieldStubMustNotPreferOperation_6141(t *testing.T) {
 			got.kind, got.file)
 	}
 }
+
+// TestLeafNameTier_PreferenceIsWithinTierNotAcrossTiers_6141 pins the tier
+// ORDER itself, which nothing else in this file could distinguish.
+//
+// The operation preference is applied INSIDE each tier — (fileOp, fileAny)
+// then (pkgOp, pkgAny) — so locality beats kind. The alternative structure,
+// applying it ACROSS tiers (fileOp, pkgOp, fileAny, pkgAny), reaches into a
+// sibling file for an operation rather than binding the caller's own file.
+// Every other fixture here puts the competing member in a different file
+// from the caller, so the two orderings are indistinguishable to them: a
+// mutant swapping refs.go to the across-tiers order passed the entire
+// internal/resolve, ruby and javascript suites.
+//
+//	caller  Vault.deposit  contracts/Vault.sol
+//	field   Other.owner    contracts/Vault.sol   <- caller's OWN file
+//	op      Owned.owner    contracts/Owned.sol
+//
+// Locality wins: the caller's own file is the better evidence about what a
+// bare name means, and it is the rule the surrounding tiers already follow
+// (lookupBareWithLocality tries byLocation[callerFile] before any
+// package-scoped bucket). internal/extractors/sresolver.lookupLeaf MUST
+// order its four passes the same way — see the twin test there. If these
+// two drift apart, a full rebuild and an incremental build bind the same
+// source differently.
+func TestLeafNameTier_PreferenceIsWithinTierNotAcrossTiers_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
+		entAt("2222222222222222", "SCOPE.Schema", "Other.owner", "contracts/Vault.sol"),
+		entAt("3333333333333333", "SCOPE.Operation", "Owned.owner", "contracts/Owned.sol"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("bare CALLS `owner` left as stub %q; want the caller's own file to win", stub)
+	}
+	if got.id != "2222222222222222" {
+		t.Fatalf("the operation preference must apply WITHIN a tier, not ACROSS tiers: bound to "+
+			"id=%s kind=%s name=%s file=%s; want the caller-file member Other.owner "+
+			"(2222222222222222), not the sibling-file operation Owned.owner",
+			got.id, got.kind, got.name, got.file)
+	}
+}

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -237,3 +237,123 @@ func TestLeafNameTier_JavaFieldHintStubStillBinds_6141(t *testing.T) {
 			got.id, got.kind, got.name)
 	}
 }
+
+// --- DIRECT unit tests of the new mechanism -------------------------------
+//
+// These exist because the end-to-end tests above cannot reach every arm.
+// memberFamilyMask's SCOPE.-trim branch in particular has no fixture: no
+// extractor emits "SCOPE.Method" today, so the branch would survive
+// mutation while only being protected by a language nobody ships. Testing
+// the helper directly is what makes it a guard rather than decoration.
+
+func TestMemberFamilyMask_6141(t *testing.T) {
+	cases := []struct {
+		kind string
+		want uint8
+	}{
+		// Operation family, raw.
+		{"Operation", famOperation},
+		{"Function", famOperation},
+		{"Method", famOperation},
+		{"SCOPE.Operation", famOperation},
+		// Operation family reached ONLY via the SCOPE.-trim branch.
+		{"SCOPE.Method", famOperation},
+		{"SCOPE.Function", famOperation},
+		// Schema family — the kinds a call must never bind to.
+		{"Schema", famSchema},
+		{"Field", famSchema},
+		{"Property", famSchema},
+		{"SCOPE.Schema", famSchema},
+		// Component family.
+		{"Component", famComponent},
+		{"Class", famComponent},
+		{"SCOPE.Component", famComponent},
+		// Outside every family — must classify as 0 so a family-filtered
+		// lookup rejects it. These are real kinds seen on dotted-name
+		// entities (SCOPE.Pattern from internal/custom, Module from the
+		// python package-module emitter, SCOPE.Datastore from dbt sources).
+		{"SCOPE.Pattern", 0},
+		{"Module", 0},
+		{"SCOPE.Datastore", 0},
+		{"Handler", 0},
+		{"", 0},
+	}
+	for _, c := range cases {
+		if got := memberFamilyMask(c.kind); got != c.want {
+			t.Errorf("memberFamilyMask(%q) = %d, want %d", c.kind, got, c.want)
+		}
+	}
+}
+
+// TestMemberFamilyMask_FamiliesAreDisjoint_6141 pins the assumption the
+// bitmask encoding rests on: no entity kind sits in two families at once.
+// If a future kind is added to two of the slices the mask silently becomes
+// a union and a call could bind to a field again.
+func TestMemberFamilyMask_FamiliesAreDisjoint_6141(t *testing.T) {
+	for kind, mask := range familyMaskByKind {
+		if mask&(mask-1) != 0 {
+			t.Errorf("kind %q belongs to more than one kind family (mask=%b); the "+
+				"leaf-name filter assumes the families are disjoint", kind, mask)
+		}
+	}
+}
+
+// TestInFamily_ZeroMaskDisablesFilter_6141 pins the escape hatch the #667
+// Java field call site depends on.
+func TestInFamily_ZeroMaskDisablesFilter_6141(t *testing.T) {
+	idx := BuildIndex([]types.EntityRecord{
+		entAt("1111111111111111", "SCOPE.Schema", "Parent.field", "src/Parent.java"),
+	})
+	if !idx.inFamily("1111111111111111", 0) {
+		t.Error("want == 0 must disable the filter entirely")
+	}
+	if idx.inFamily("1111111111111111", famOperation) {
+		t.Error("a SCOPE.Schema member must not pass the operation filter")
+	}
+	if !idx.inFamily("1111111111111111", famSchema) {
+		t.Error("a SCOPE.Schema member must pass the schema filter")
+	}
+	if idx.inFamily("no-such-id", famOperation) {
+		t.Error("an id absent from memberFamily must not pass a non-zero filter")
+	}
+}
+
+// TestMemberFamily_OnlyDottedNamesIndexed_6141 pins the side-table's size
+// contract: it exists to serve the member indexes, so an entity that never
+// reaches byMember must not occupy a slot in it.
+func TestMemberFamily_OnlyDottedNamesIndexed_6141(t *testing.T) {
+	idx := BuildIndex([]types.EntityRecord{
+		entAt("1111111111111111", "SCOPE.Operation", "Bare", "pkg/a.go"),          // undotted
+		entAt("2222222222222222", "SCOPE.Operation", "Scoped.member", "pkg/b.go"), // dotted
+		entAt("3333333333333333", "SCOPE.Pattern", "Other.member", "pkg/c.go"),    // dotted, no family
+	})
+	if _, ok := idx.memberFamily["1111111111111111"]; ok {
+		t.Error("undotted entity must not enter memberFamily — it never reaches byMember")
+	}
+	if idx.memberFamily["2222222222222222"] != famOperation {
+		t.Errorf("dotted operation missing from memberFamily: %d", idx.memberFamily["2222222222222222"])
+	}
+	if _, ok := idx.memberFamily["3333333333333333"]; ok {
+		t.Error("zero-mask kind must be OMITTED, not stored — the entry would cost memory for nothing")
+	}
+}
+
+// TestLeafNameTier_SameScopeDuplicateStaysAmbiguous_6141 documents the
+// mechanism's blind spot, so the limitation is pinned rather than assumed.
+// When a field and an operation collide inside ONE scope — the Java
+// `Cell.borderTop` field + setter shape, and the internal/custom pattern of
+// re-emitting `Class.method` under SCOPE.Pattern — byMember stores a BLANK
+// sentinel and both entity IDs are erased. The kind filter cannot see
+// through that, so the edge is ambiguous before AND after the fix.
+func TestLeafNameTier_SameScopeDuplicateStaysAmbiguous_6141(t *testing.T) {
+	records := []types.EntityRecord{
+		callerWithCall("1111111111111111", "Operation", "Caller.run", "src/pkg/Caller.java", "borderTop"),
+		entAt("2222222222222222", "SCOPE.Operation", "Cell.borderTop", "src/pkg/Cell.java"),
+		entAt("3333333333333333", "SCOPE.Schema", "Cell.borderTop", "src/pkg/Cell.java"),
+	}
+	_, stub := resolveEdge(t, records, 0)
+	if stub != "borderTop" {
+		t.Fatalf("same-scope field/operation collision resolved to %q; the blank sentinel erases "+
+			"both IDs before the kind filter can see them, so this must stay unresolved", stub)
+	}
+}

--- a/internal/resolve/leafname_kind_filter_6141_test.go
+++ b/internal/resolve/leafname_kind_filter_6141_test.go
@@ -20,6 +20,21 @@ import (
 //     same-leaf-named field joins the candidate set and trips the
 //     ambiguity guard.
 //
+// ONLY THE RECALL HALF IS FIXED, and deliberately so. The issue prescribes
+// hard-filtering these tiers to operationKindFamily. That was implemented,
+// then MEASURED against the real extractors and reverted: Ruby models every
+// attr_accessor as `Class.attr` / SCOPE.Schema and JS/TS models
+// `handler = function(){}` the same way, while both languages emit their
+// real methods under BARE names — so for those languages the leaf tier is
+// the ONLY binding route to what is genuinely a method. A hard filter turns
+// those correct edges into dangles. See scanLeafMembersPreferring in refs.go
+// and TestRubyAttrAccessorCallStillBinds_6141 in internal/extractors/ruby,
+// which measures it end-to-end through the actual Ruby extractor.
+//
+// The tiers therefore PREFER operations rather than requiring them. The
+// precision half is pinned below as a known gap rather than silently left
+// untested.
+//
 // Every assertion below is on what the edge binds TO, by content
 // (kind / name / source_file) — never on an aggregate dangling count,
 // which is blind here because the two symptoms cancel.
@@ -58,39 +73,59 @@ func resolveEdge(t *testing.T, records []types.EntityRecord, callerIdx int) (got
 	return boundTo{}, to
 }
 
-// --- PRECISION: the wrong bind --------------------------------------------
+// --- PRECISION: the wrong bind, PINNED AS A KNOWN GAP ----------------------
 
-// TestLeafNameTier_PackageScope_MustNotBindCallToField_6141 is the wrong-bind
-// half, package-scoped. contracts/Vault.sol calls bare `owner()`; a SIBLING
-// FILE declares the state variable `Registry.owner`. Nothing in the package
-// declares an OPERATION named `owner`, so the correct outcome is an
-// unresolved stub — not a cross-contract, cross-file bind to a field.
-func TestLeafNameTier_PackageScope_MustNotBindCallToField_6141(t *testing.T) {
+// TestLeafNameTier_PrecisionGap_CallStillBindsToField_6141 is a
+// CHARACTERISATION test: it asserts behaviour that is still WRONG for
+// Solidity/Java/Go, so that the tradeoff is visible rather than forgotten.
+//
+// contracts/Vault.sol calls bare `owner()`; a SIBLING FILE declares the
+// state variable `Registry.owner`. No operation of that leaf name exists,
+// so the operation-preferring pass finds nothing and the unrestricted pass
+// binds the call cross-contract, cross-file to the FIELD — exactly the
+// mis-bind issue #6141 reports.
+//
+// It is left unfixed because the only resolver-side remedy (refuse
+// non-operation candidates outright) was measured to destroy real Ruby and
+// JS/TS bindings; see the file header. Closing it properly needs the
+// extractors to distinguish a data field from an invocable member modelled
+// as a field.
+//
+// If a future change makes this bind correctly refuse, this test SHOULD
+// fail — update it, and check TestRubyAttrAccessorCallStillBinds_6141 still
+// passes, because that is the constraint that put the gap here.
+func TestLeafNameTier_PrecisionGap_CallStillBindsToField_6141(t *testing.T) {
 	records := []types.EntityRecord{
 		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
 		entAt("2222222222222222", "SCOPE.Schema", "Registry.owner", "contracts/Registry.sol"),
 	}
 	got, stub := resolveEdge(t, records, 0)
-	if stub != "owner" {
-		t.Fatalf("bare CALLS `owner` bound to a non-operation: id=%s kind=%s name=%s file=%s; "+
-			"want the stub %q left verbatim (no operation named `owner` exists in the package)",
-			got.id, got.kind, got.name, got.file, "owner")
+	if stub != "" {
+		t.Fatalf("bare CALLS `owner` now refuses to bind (stub %q). If that was intentional, "+
+			"confirm the Ruby attr_accessor end-to-end test still passes before updating this test", stub)
+	}
+	if got.id != "2222222222222222" || got.kind != "SCOPE.Schema" || got.name != "Registry.owner" {
+		t.Fatalf("known precision gap changed shape: bound to id=%s kind=%s name=%s file=%s",
+			got.id, got.kind, got.name, got.file)
 	}
 }
 
-// TestLeafNameTier_FileScope_MustNotBindCallToField_6141 is the wrong-bind
-// half, file-scoped (lookupMemberByLeafName). Same file, different scope:
-// `Vault.deposit` calls bare `owner()` and only `Other.owner` — a field —
-// declares that leaf name.
-func TestLeafNameTier_FileScope_MustNotBindCallToField_6141(t *testing.T) {
+// TestLeafNameTier_PrecisionGap_FileScope_6141 is the same known gap on the
+// file-scoped tier. Same file, different scope: `Vault.deposit` calls bare
+// `owner()` and only the field `Other.owner` declares that leaf name.
+func TestLeafNameTier_PrecisionGap_FileScope_6141(t *testing.T) {
 	records := []types.EntityRecord{
 		callerWithCall("1111111111111111", "SCOPE.Operation", "Vault.deposit", "contracts/Vault.sol", "owner"),
 		entAt("3333333333333333", "SCOPE.Schema", "Other.owner", "contracts/Vault.sol"),
 	}
 	got, stub := resolveEdge(t, records, 0)
-	if stub != "owner" {
-		t.Fatalf("same-file bare CALLS `owner` bound to a non-operation: id=%s kind=%s name=%s file=%s; "+
-			"want the stub %q left verbatim", got.id, got.kind, got.name, got.file, "owner")
+	if stub != "" {
+		t.Fatalf("same-file bare CALLS `owner` now refuses to bind (stub %q); see the sibling "+
+			"package-scoped gap test before updating", stub)
+	}
+	if got.id != "3333333333333333" || got.kind != "SCOPE.Schema" {
+		t.Fatalf("known precision gap changed shape: bound to id=%s kind=%s name=%s",
+			got.id, got.kind, got.name)
 	}
 }
 

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -472,6 +472,22 @@ type Index struct {
 	// silently picking a wrong overload.
 	byPackageMember map[string]map[string]map[string]string
 
+	// memberFamily[entity_id] = kind-family bitmask, populated ONLY for the
+	// dotted-name entities that land in byMember / byPackageMember. Issue
+	// #6141: those two indexes are keyed on (scope, member) and carry no
+	// kind, so the leaf-name tiers that scan them for a bare CALLS target
+	// bound a call to whatever shared the leaf name — including a FIELD.
+	// This side-table is what lets those tiers filter by kind family the way
+	// lookupByKindHint already does, without changing the member indexes'
+	// value type (they are shared with Format B structural resolution, which
+	// legitimately addresses fields).
+	//
+	// Memory: one map entry per dotted-name entity whose kind falls in a
+	// known family — a uint8 value, and entries are OMITTED when the mask is
+	// zero, so unclassifiable kinds cost nothing. byMember and
+	// byPackageMember already hold one string entry each per such entity.
+	memberFamily map[string]uint8
+
 	// byPackageOperation[pkg_dir][name] = entity_id. Used by the
 	// Refs #44 Go bare-call structural-ref path: the extractor rewrites
 	// identifier-form CALLS edges (e.g. `helper()` from `main`) to
@@ -898,6 +914,7 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		byLocationKind:     make(LocationKindIndex),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
+		memberFamily:       make(map[string]uint8),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byNamespaceMember:  make(map[string]map[string]map[string]string),
@@ -1178,6 +1195,11 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			// scope="Foo", member="bar" — unchanged from issue #45.
 			if dot := strings.LastIndexByte(e.Name, dottedNameSep); dot > 0 {
 				scope, member := e.Name[:dot], e.Name[dot+1:]
+				// #6141 — kind-family side-table for the leaf-name tiers.
+				// Zero masks are omitted: absent == "no known family".
+				if m := memberFamilyMask(e.Kind); m != 0 {
+					idx.memberFamily[e.ID] = m
+				}
 				fileBucket := idx.byMember[sourceFile]
 				if fileBucket == nil {
 					fileBucket = make(map[string]map[string]string)
@@ -1794,6 +1816,65 @@ func hintKinds(relKind string) []string {
 	return nil
 }
 
+// Kind-family bitmask (issue #6141). The leaf-name tiers scan member
+// indexes whose values are bare entity IDs, so they need a per-ID kind
+// classification to filter candidates. A 3-bit mask is enough and keeps the
+// side-table one byte per entry.
+const (
+	famOperation uint8 = 1 << iota
+	famComponent
+	famSchema
+)
+
+// familyMaskByKind maps every entity Kind named in the three kind families
+// to its mask bit. Derived from the family slices themselves rather than
+// re-listed, so it cannot drift out of agreement with hintKinds /
+// structuralKindFamilies — the same invariant issue #49 centralised the
+// slices for.
+var familyMaskByKind = func() map[string]uint8 {
+	m := make(map[string]uint8, 16)
+	for _, spec := range []struct {
+		kinds []string
+		bit   uint8
+	}{
+		{operationKindFamily, famOperation},
+		{componentKindFamily, famComponent},
+		{schemaKindFamily, famSchema},
+	} {
+		for _, k := range spec.kinds {
+			m[k] |= spec.bit
+		}
+	}
+	return m
+}()
+
+// memberFamilyMask classifies one entity Kind into the kind-family mask.
+// Both the raw kind and its SCOPE.-trimmed form are consulted, mirroring
+// the dual-indexing BuildIndex applies to byKind — so a hypothetical
+// "SCOPE.Method" classifies as an operation via its trimmed form.
+// Returns 0 for kinds in no family; such an entity is never a candidate
+// for a family-filtered leaf-name lookup.
+func memberFamilyMask(kind string) uint8 {
+	if kind == "" {
+		return 0
+	}
+	mask := familyMaskByKind[kind]
+	if trimmed := strings.TrimPrefix(kind, scopeKindPrefix); trimmed != kind && trimmed != "" {
+		mask |= familyMaskByKind[trimmed]
+	}
+	return mask
+}
+
+// inFamily reports whether the member-indexed entity id belongs to the
+// requested kind family. want == 0 disables the filter (every candidate
+// passes), which is what the field-shaped call sites pass.
+func (idx Index) inFamily(id string, want uint8) bool {
+	if want == 0 {
+		return true
+	}
+	return idx.memberFamily[id]&want != 0
+}
+
 // lookupByKindHint disambiguates a name using the relKind hint. Returns
 // (id, true) only when the hinted family yields exactly one entity for
 // this name; otherwise ("", false).
@@ -2260,7 +2341,7 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 					// package's member index for any class that declares
 					// this field name. The ChildClass may differ from
 					// the ParentClass that owns the field.
-					if id, ok := idx.lookupPackageMemberByLeafName(pkgDir, fieldName); ok {
+					if id, ok := idx.lookupPackageMemberByLeafName(pkgDir, fieldName, 0); ok {
 						return id, statusRewritten, true
 					}
 				}
@@ -2706,7 +2787,14 @@ func (idx Index) lookupPackageMember(pkgDir, receiverType, member string) (strin
 // names). Scanning byMember for the leaf name is the correct fallback:
 // a caller inside InventoryService calling `merge()` should bind to
 // byMember[callerFile]["InventoryService"]["merge"].
-func (idx Index) lookupMemberByLeafName(filePath, memberName string) (string, bool) {
+//
+// Issue #6141 — `want` is the kind-family mask a candidate must belong to
+// (0 = no filter). The member indexes are kind-blind, so without it a bare
+// CALLS target binds to a same-leaf-named FIELD. Note the filter SKIPS a
+// rejected candidate rather than aborting: that is what recovers the
+// correct operation binding when an unrelated field of the same leaf name
+// would otherwise have tripped the cross-scope ambiguity guard.
+func (idx Index) lookupMemberByLeafName(filePath, memberName string, want uint8) (string, bool) {
 	if filePath == "" || memberName == "" {
 		return "", false
 	}
@@ -2719,6 +2807,9 @@ func (idx Index) lookupMemberByLeafName(filePath, memberName string) (string, bo
 	for _, scopeBucket := range fileBucket {
 		id, ok := scopeBucket[memberName]
 		if !ok {
+			continue
+		}
+		if id != "" && !idx.inFamily(id, want) {
 			continue
 		}
 		if id == "" {
@@ -2749,7 +2840,12 @@ func (idx Index) lookupMemberByLeafName(filePath, memberName string) (string, bo
 //
 // Issue #778 — package-level fallback after the same-file scan misses
 // (e.g. when the callee is defined in a sibling file of the same package).
-func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string) (string, bool) {
+// Issue #6141 — `want` is the kind-family mask, as in lookupMemberByLeafName.
+// The CALLS call sites pass famOperation; the #667 Java inherited-field hint
+// site passes 0 (unfiltered) because its stub is field-shaped by
+// construction and a schema filter there would be a separate, unassessed
+// behaviour change.
+func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string, want uint8) (string, bool) {
 	if pkgDir == "" || memberName == "" {
 		return "", false
 	}
@@ -2762,6 +2858,9 @@ func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string) (strin
 	for _, scopeBucket := range pkgBucket {
 		id, ok := scopeBucket[memberName]
 		if !ok {
+			continue
+		}
+		if id != "" && !idx.inFamily(id, want) {
 			continue
 		}
 		if id == "" {
@@ -2965,12 +3064,12 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 			// we cannot pick without additional type information and leave the
 			// stub unresolved (correct: ambiguous, not a false bind).
 			if callerFile != "" {
-				if id, ok := idx.lookupMemberByLeafName(callerFile, name); ok {
+				if id, ok := idx.lookupMemberByLeafName(callerFile, name, famOperation); ok {
 					return id, true
 				}
 			}
 			if callerPkgDir != "" {
-				if id, ok := idx.lookupPackageMemberByLeafName(callerPkgDir, name); ok {
+				if id, ok := idx.lookupPackageMemberByLeafName(callerPkgDir, name, famOperation); ok {
 					return id, true
 				}
 			}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -482,10 +482,21 @@ type Index struct {
 	// value type (they are shared with Format B structural resolution, which
 	// legitimately addresses fields).
 	//
-	// Memory: one map entry per dotted-name entity whose kind falls in a
-	// known family — a uint8 value, and entries are OMITTED when the mask is
-	// zero, so unclassifiable kinds cost nothing. byMember and
-	// byPackageMember already hold one string entry each per such entity.
+	// Memory (#5954): MEASURED at ~47 bytes per entry — Go map overhead
+	// dominates; the uint8 value is free and the key's string header shares
+	// e.ID's backing array, so no character data is copied. That is ~14 MB
+	// per 300k dotted-name entities: bounded and acceptable, but not the
+	// "one byte each" the shape suggests. byMember and byPackageMember
+	// already hold one string entry each per such entity.
+	//
+	// Entries whose mask is zero are omitted, but do NOT count on that as a
+	// saving: in practice almost every dotted-name entity is Operation,
+	// Schema or Component. It matters for correctness, not size.
+	//
+	// Staleness fails OPEN, which is the safe direction: a missing entry
+	// makes the operation-preferring pass skip the candidate, the kind-blind
+	// fallback runs, and the result is the pre-#6141 behaviour — never a
+	// wrong bind. The lazy/module index path is pinned by the parity test.
 	memberFamily map[string]uint8
 
 	// byPackageOperation[pkg_dir][name] = entity_id. Used by the

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2788,13 +2788,11 @@ func (idx Index) lookupPackageMember(pkgDir, receiverType, member string) (strin
 // a caller inside InventoryService calling `merge()` should bind to
 // byMember[callerFile]["InventoryService"]["merge"].
 //
-// Issue #6141 — `want` is the kind-family mask a candidate must belong to
-// (0 = no filter). The member indexes are kind-blind, so without it a bare
-// CALLS target binds to a same-leaf-named FIELD. Note the filter SKIPS a
-// rejected candidate rather than aborting: that is what recovers the
-// correct operation binding when an unrelated field of the same leaf name
-// would otherwise have tripped the cross-scope ambiguity guard.
-func (idx Index) lookupMemberByLeafName(filePath, memberName string, want uint8) (string, bool) {
+// Issue #6141 — `prefer` is a kind-family mask that gets a FIRST pass of
+// its own. See scanLeafMembers for why this is a preference and not a
+// filter; the short version is that a hard filter was measured to destroy
+// real Ruby and JS/TS bindings.
+func (idx Index) lookupMemberByLeafName(filePath, memberName string, prefer uint8) (string, bool) {
 	if filePath == "" || memberName == "" {
 		return "", false
 	}
@@ -2802,9 +2800,80 @@ func (idx Index) lookupMemberByLeafName(filePath, memberName string, want uint8)
 	if fileBucket == nil {
 		return "", false
 	}
+	return idx.scanLeafMembersPreferring(fileBucket, memberName, prefer)
+}
+
+// scanLeafMembersPreferring runs scanLeafMembers twice: once restricted to
+// the preferred kind family, then — only if that pass found nothing at all
+// — unrestricted, which is the pre-#6141 behaviour.
+//
+// # Why a PREFERENCE and not a filter
+//
+// Issue #6141 prescribes kind-filtering these tiers to operationKindFamily,
+// on the reasoning that a call target must be an operation. That is true of
+// the LANGUAGE but not of the GRAPH: several extractors deliberately model
+// an invocable member as a field.
+//
+//	ruby   internal/extractors/ruby/field_members.go — every attr_accessor /
+//	       attr_reader / attr_writer symbol becomes `Class.attr` with Kind
+//	       SCOPE.Schema. Those ARE generated methods, Ruby's real methods
+//	       carry BARE names, and ruby.go's rubyCallTarget discards the
+//	       receiver, so a bare `owner` CALLS edge has NO other binding route.
+//	js/ts  internal/extractors/javascript/extractor.go — a class field is
+//	       emitted as an Operation only when its initialiser is an
+//	       `arrow_function`; `handler = function(){}` falls through to
+//	       `Class.handler` / SCOPE.Schema. Interface `method_signature`
+//	       members are emitted as SCOPE.Schema by design.
+//
+// MEASURED on the unfixed tree, not projected: a Ruby method reading its own
+// `attr_accessor :owner` binds to `Account.owner [SCOPE.Schema]`. Under a
+// hard operation-filter that edge DANGLES. The regression test is
+// TestRubyAttrAccessorCallStillBinds_6141 in internal/extractors/ruby.
+//
+// So this two-pass shape takes the half of #6141 that is unconditionally
+// safe and leaves the other half alone:
+//
+//	RECALL  (fixed, every language): an unrelated same-leaf-named FIELD can
+//	        no longer trip the cross-scope ambiguity guard and destroy a
+//	        correct binding to a real operation — the operation pass never
+//	        sees the field.
+//	PRECISION (NOT fixed): when NO operation of that leaf name exists, the
+//	        second pass still binds the call to a field, which is right for
+//	        Ruby/JS and wrong for Solidity/Java/Go. Fixing it needs the
+//	        extractors to distinguish "field" from "invocable member modelled
+//	        as a field"; doing it in the resolver means guessing per
+//	        language. Tracked separately — do NOT "finish the job" by
+//	        deleting the fallback without that upstream signal.
+//
+// The pass order is strictly additive: every binding the unrestricted scan
+// produced before still happens, and the preferred pass only ever converts
+// a previously-AMBIGUOUS stub into a binding.
+func (idx Index) scanLeafMembersPreferring(
+	scopes map[string]map[string]string, memberName string, prefer uint8,
+) (string, bool) {
+	if prefer != 0 {
+		if id, ok := idx.scanLeafMembers(scopes, memberName, prefer); ok {
+			return id, true
+		}
+	}
+	return idx.scanLeafMembers(scopes, memberName, 0)
+}
+
+// scanLeafMembers walks every scope bucket for memberName and returns the
+// single matching entity ID. want != 0 restricts candidates to that kind
+// family; a rejected candidate is SKIPPED rather than aborting the scan,
+// which is what keeps a field from tripping the ambiguity guard.
+//
+// Returns ("", false) when the name is missing from all scopes, when two or
+// more scopes share a member of that leaf name, or when a scope's bucket
+// holds the blank ambiguity sentinel (two overloads in one class — the
+// sentinel has erased both IDs, so no kind information survives for the
+// filter to use).
+func (idx Index) scanLeafMembers(
+	scopes map[string]map[string]string, memberName string, want uint8,
+) (string, bool) {
 	var match string
-	ambig := false
-	for _, scopeBucket := range fileBucket {
+	for _, scopeBucket := range scopes {
 		id, ok := scopeBucket[memberName]
 		if !ok {
 			continue
@@ -2813,20 +2882,19 @@ func (idx Index) lookupMemberByLeafName(filePath, memberName string, want uint8)
 			continue
 		}
 		if id == "" {
-			// Blank sentinel within this scope = ambiguous member for this scope.
-			// Two different overloads in the same class — can't resolve.
-			ambig = true
-			break
+			// Blank sentinel within this scope = ambiguous member for this
+			// scope. Two different overloads in the same class — can't
+			// resolve, and the kind filter cannot see through it either.
+			return "", false
 		}
 		if match != "" && match != id {
 			// Two different scopes each have a member named memberName —
 			// ambiguous across scopes; do not pick one.
-			ambig = true
-			break
+			return "", false
 		}
 		match = id
 	}
-	if ambig || match == "" {
+	if match == "" {
 		return "", false
 	}
 	return match, true
@@ -2840,12 +2908,12 @@ func (idx Index) lookupMemberByLeafName(filePath, memberName string, want uint8)
 //
 // Issue #778 — package-level fallback after the same-file scan misses
 // (e.g. when the callee is defined in a sibling file of the same package).
-// Issue #6141 — `want` is the kind-family mask, as in lookupMemberByLeafName.
-// The CALLS call sites pass famOperation; the #667 Java inherited-field hint
-// site passes 0 (unfiltered) because its stub is field-shaped by
-// construction and a schema filter there would be a separate, unassessed
-// behaviour change.
-func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string, want uint8) (string, bool) {
+// Issue #6141 — `prefer` is a kind-family mask given a first pass of its
+// own; see scanLeafMembersPreferring for why it is a preference rather than
+// a filter. The CALLS call sites pass famOperation. The #667 Java
+// inherited-field hint site passes 0: its stub is field-shaped by
+// construction, so an operation preference there would be actively wrong.
+func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string, prefer uint8) (string, bool) {
 	if pkgDir == "" || memberName == "" {
 		return "", false
 	}
@@ -2853,30 +2921,7 @@ func (idx Index) lookupPackageMemberByLeafName(pkgDir, memberName string, want u
 	if pkgBucket == nil {
 		return "", false
 	}
-	var match string
-	ambig := false
-	for _, scopeBucket := range pkgBucket {
-		id, ok := scopeBucket[memberName]
-		if !ok {
-			continue
-		}
-		if id != "" && !idx.inFamily(id, want) {
-			continue
-		}
-		if id == "" {
-			ambig = true
-			break
-		}
-		if match != "" && match != id {
-			ambig = true
-			break
-		}
-		match = id
-	}
-	if ambig || match == "" {
-		return "", false
-	}
-	return match, true
+	return idx.scanLeafMembersPreferring(pkgBucket, memberName, prefer)
 }
 
 // isComponentTargetKind reports whether the relationship-kind's natural

--- a/internal/resolve/symbol_index.go
+++ b/internal/resolve/symbol_index.go
@@ -271,6 +271,7 @@ func MergeModuleBatch(si *SymbolIndex, offset, batchSize int) (Index, int) {
 		byLocationKind:     make(LocationKindIndex, total/2+1),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
+		memberFamily:       make(map[string]uint8),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byNamespaceMember:  make(map[string]map[string]map[string]string),
@@ -521,6 +522,7 @@ func accumulatorIndex(totalEntities int) Index {
 		byLocationKind:     make(LocationKindIndex, cap2),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
+		memberFamily:       make(map[string]uint8),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byNamespaceMember:  make(map[string]map[string]map[string]string),
@@ -544,6 +546,7 @@ func emptyIndex() Index {
 		byLocationKind:     make(LocationKindIndex),
 		byMember:           make(map[string]map[string]map[string]string),
 		byPackageMember:    make(map[string]map[string]map[string]string),
+		memberFamily:       make(map[string]uint8),
 		byPackageOperation: make(map[string]map[string]string),
 		byPackageComponent: make(map[string]map[string]string),
 		byNamespaceMember:  make(map[string]map[string]map[string]string),
@@ -692,6 +695,10 @@ func insertModuleEntry(
 			dot := strings.LastIndexByte(me.name, dottedNameSep)
 			if dot > 0 {
 				scope, member := me.name[:dot], me.name[dot+1:]
+				// #6141 — mirrors BuildIndex; see Index.memberFamily.
+				if m := memberFamilyMask(me.kind); m != 0 {
+					idx.memberFamily[me.id] = m
+				}
 				fileBucket := idx.byMember[sf]
 				if fileBucket == nil {
 					fileBucket = make(map[string]map[string]string)

--- a/internal/resolve/symbol_index_parity_test.go
+++ b/internal/resolve/symbol_index_parity_test.go
@@ -135,6 +135,7 @@ func indexParityDiff(a, b Index) []string {
 	cmp("byQualifiedName", a.byQualifiedName, b.byQualifiedName)
 	cmp("byMember", a.byMember, b.byMember)
 	cmp("byPackageMember", a.byPackageMember, b.byPackageMember)
+	cmp("memberFamily", a.memberFamily, b.memberFamily)
 	cmp("byPackageOperation", a.byPackageOperation, b.byPackageOperation)
 	cmp("byPackageComponent", a.byPackageComponent, b.byPackageComponent)
 	cmp("byNamespaceMember", a.byNamespaceMember, b.byNamespaceMember)


### PR DESCRIPTION
`lookupPackageMemberByLeafName` (`internal/resolve/refs.go:2752`) binds a bare call to any entity in the same package directory whose leaf name matches, **without filtering by kind**. A call target should be an operation; the tier will bind it to a field.

The missing filter costs precision *and* recall at once, and the two symptoms move a dangling count in opposite directions — so both can be present while the aggregate looks unchanged:

- **Wrong bind** — `Vault.sol` calls bare `owner()`; sibling `Registry.sol` declares `address public owner`. Binds cross-contract, cross-file to the field.
- **Lost edge** — `Owned.owner()` alone binds correctly; add a sibling declaring `address public owner` and the *correct* edge dangles, because the unrelated field enters the candidate set and trips the ambiguity guard.

## The prescribed fix was wrong, and measuring it is the main result

#6141 said: kind-filter these tiers to `operationKindFamily`, mirroring `lookupByKindHint` (`refs.go:1824`). That was implemented, then measured against the real extractor and resolver:

```ruby
class Account
  attr_accessor :owner
  def describe; owner; end
end
```

| | `CALLS owner` |
|---|---|
| base `673e786b8` | **BOUND** → `Account.owner [SCOPE.Schema]` |
| hard filter | **DANGLE** |

`internal/extractors/ruby/field_members.go` emits every `attr_accessor` as `Class.attr` / `SCOPE.Schema` — and in Ruby that **is** a generated method. Ruby's real methods carry bare names and `rubyCallTarget` discards the receiver, so the leaf-name tier is the *only* route that can bind the edge. The filter is a pure recall loss, and **no dangling-count metric would show it as a regression** — the count moving is exactly what the fix was supposed to do.

Independently reproduced in review, which also promoted the JS/TS case from projection to **measurement**: `handler = function(){}` emits `Account.handler`/`SCOPE.Schema` (a class field becomes an Operation only when its initialiser is an `arrow_function`, `javascript/extractor.go:1199`), the call site emits a bare stub with no `receiver_type`, and it dangles under the filter. Interface `method_signature` members are `SCOPE.Schema` by design (`:1632`).

## Shipped: operations preferred, not required

An operation-only pass runs first; if it finds nothing, the pre-existing kind-blind scan runs. That splits the issue:

- **Recall half — fixed, every language.** A same-leaf-named field can no longer trip the ambiguity guard and destroy a correct operation binding. A randomized differential over 200,000 fixtures gives **0 regressions, 8,559 gains** for `refs.go`.
- **Precision half — deliberately NOT fixed.** With no operation of that leaf name, the fallback still binds a call to a field. Correct for Ruby and JS/TS, wrong for Solidity, Java and Go. The resolver cannot tell the difference; the distinction lives in the **extractors**, some of which model an invocable member as a field. Guessing per language in the resolver is not sound. Pinned by characterisation tests in both resolvers so deleting the fallback fails loudly.

Because this is a *preference* rather than a filter, the per-language safe/lossy classification is **documentation, not a correctness dependency** — any language modelling an invocable as a field is served by the fallback regardless of which bucket it was placed in. The unmeasured half of that table therefore carries no risk.

## The consistency fix that introduced its own inconsistency

`sresolver`'s `leafByFile`/`leafByPkg` twins were changed too, because fixing only `refs.go` would make incremental and full rebuild disagree on the same source — #6129's class.

**Review found that the sresolver change introduced exactly that divergence.** `refs.go` applied the preference *within* each tier (`fileOp, fileAny` then `pkgOp, pkgAny`); sresolver applied it *across* tiers (`fileOp, pkgOp, fileAny, pkgAny`). The separating shape is a same-leaf field in the caller's own file beside a real operation in a sibling file:

| | binds |
|---|---|
| base sresolver | the field |
| branch sresolver (before fix) | the sibling operation |
| branch `refs.go` | the field |

So "strictly additive" was **false for sresolver**: 200,000 fixtures gave **6,616 changed bindings** (~3.3%) alongside 14,343 gains. Every sresolver fixture put the field in a *different* file from the caller, which is why they missed it.

Corrected to `fileOp, fileAny, pkgOp, pkgAny`, mirroring `refs.go` — **0 changed bindings, 13,846 gains**. Locality wins, matching every surrounding tier: `lookupBareWithLocality` tries `byLocation[callerFile]` before any package bucket.

## Test gaps this exposed

**Nothing pinned the ordering, in either direction.** A mutant making `refs.go` adopt the across-tiers order survived the entire `internal/resolve` + ruby + javascript suite. Now pinned by `TestLeafNameTier_PreferenceIsWithinTierNotAcrossTiers_6141` and its sresolver twin.

Added `TestLeafTier_FullAndIncrementalResolversAgree_6141`, which drives **both** resolvers over one entity set across six shapes and asserts identical bindings by content. It catches both directions of the ordering mutant and fires on four others. For this defect class it is a tighter instrument than the corpus gate.

**The #6129 parity gate passed the whole time** — its fixture keeps every basename unique and never reaches the divergent shape. Extending it was attempted and **blocked by an unrelated pre-existing defect**: adding *any* class to the delta file makes the full rebuild classify it `Controller` and the incremental path `SCOPE.Component`. Reduced to a bare `class C: def m(self): return 1` with no classification-worthy features; classes in *static* files classify identically, so it is specific to re-extraction. Filed as **#6148** with the reproduction patch; no allow-list entries were invented for it. That fixture extension should land with #6148's fix.

## Leaf-name tiers, enumerated

| tier | in scope |
|---|---|
| `lookupMemberByLeafName` (file) | **fixed** |
| `lookupPackageMemberByLeafName` (package) | **fixed** |
| `sresolver` `leafByFile` / `leafByPkg` | **fixed** — the incremental port |
| testmap `scope:operation:<file>#<name>` Tier 2 | not changed — same kind-blind class; its Tier 3 filters to `{Function, Method}`, narrower than `operationKindFamily`. Pre-existing inconsistency, tracked |
| Format A bare-tail walk | not changed — **not** the same class: exact full-name match within a file, preceded by an already kind-filtered `lookupLocationKind` |
| #667 Java inherited-field site | deliberately unfiltered (mask 0), guarded |
| receiver-stamped `byPackageMember` | deliberately kind-blind — its key names the scope, and it serves field-shaped edges |

Mechanism: a `memberFamily map[string]uint8` side-table (id → kind-family bitmask), populated only for dotted-name entities. Measured cost **~47 bytes/entry** (Go map overhead; string headers share `e.ID`'s backing, no data copy) — ~14 MB per 300k dotted entities. Zero-mask omission is a correctness device, not a saving. Staleness fails **open**: a missing entry skips the operation pass and falls through to pre-#6141 behaviour.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`, skips subtest-aware:

| package | exit | pass | skip |
|---|---|---|---|
| `./internal/resolve/...` | 0 | 2073 | 6 |
| `./internal/extractors/...` | 0 | 4111 | 1 |
| `./internal/custom/...` | 0 | 3965 | 0 |
| `./internal/graph/...` | 0 | 504 | 0 |
| `./cmd/grafel/` | 0 | 513 | 8 |

All skips pre-existing. **11 mutants, all killed behaviourally, none by compile error** — drop the preferred pass · `prefer`→0 · drop the fallback (the issue's prescribed filter, separately confirmed to kill the Ruby test) · skip→refuse · drop the sresolver twins · drop lazy-path population · field-site mask · `SCOPE.`-trim branch · sresolver across-tiers · refs.go across-tiers.

## Measured vs projected

**Measured:** the Ruby refutation (both paths), the JS/TS refutation, the sresolver divergence and its disappearance, all mutant kills, the memory figure.

**Projected:** the safe-to-filter list (Java, Go, Python, Solidity, PHP, Rust) and remaining lossy languages (Kotlin, Scala, C#, Dart) are read from extractor source — and, as noted, nothing in the design depends on them. No corpus-scale run; the 200k-fixture differentials are randomized synthetic fixtures, and real-world frequency of the divergent shape is unmeasured.

Independently adversarially reviewed (REQUEST-CHANGES), blocker addressed.

Refs #6141, #6129, #6148, #6135, #6137
