### PR TITLE
fix(#6148,#6150): the incremental path never ran the framework classifier — and the gate fixture was dodging the residual

### DIFF
--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -426,8 +426,11 @@ def cp_use_class(y):
 
 
 class CpPlainProbe:
-    def cp_probe_noop(self):
+    def on_get(self, req, resp):
         return 1
+
+
+cp_app = falcon.App()
 
 
 class CpLeafBag:
@@ -590,7 +593,7 @@ var cpKnownPathA = []cpKnown{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 32 member(s) in A, 33 in B"},
+		Contains: []string{"community ∅: 35 member(s) in A, 36 in B"},
 	},
 
 	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -354,11 +354,57 @@ class CpProducer:
 	dvWriteFile(t, repo, "cpcfg_static.py", `CP_SETTING = "abc"
 CP_OTHER = 12
 `)
+	// #6141 — the leaf-name tier shape. `CpSibling.cp_owner` is an OPERATION
+	// in a SIBLING file of the same package directory (pkgDirOf returns "."
+	// for every repo-root file, so the package-scoped tier is live here).
+	// The delta file below declares a same-leaf-named FIELD in the CALLER's
+	// OWN file (CpLeafBag.cp_owner) plus a bare `cp_owner()` call.
+	//
+	// That triple is what separates the two possible tier orderings, and
+	// nothing in this corpus reached it before: every other fixture puts the
+	// competing member in a different file from the caller.
+	//
+	//	within-tier  (fileOp, fileAny, pkgOp, pkgAny) -> the caller-file FIELD
+	//	across-tiers (fileOp, pkgOp, fileAny, pkgAny) -> the sibling OPERATION
+	//
+	// internal/resolve does the former. When internal/extractors/sresolver
+	// did the latter, a full rebuild and an incremental run bound this call
+	// to DIFFERENT entities — and this gate passed anyway, because the shape
+	// was absent. It is here so it cannot pass blind again.
+	dvWriteFile(t, repo, "cpleaf_static.py", `class CpSibling:
+    def cp_owner(self):
+        return 1
+`)
 }
 
 // cpDelta writes the SINGLE file that differs between the baseline pass
 // (pass 0) and the end state (pass 1). Its imports reach into every static file
 // above, so the delta's blast radius genuinely crosses file boundaries.
+//
+// Two of its declarations exist only to reach a shape this gate was blind to.
+// Both are in the DELTA file on purpose — the incremental path re-extracts only
+// these, so a construct placed in a static file is carried forward from the
+// baseline full rebuild and compares equal no matter what the re-extraction
+// would have made of it. That is precisely why both defects below hid here:
+//
+//   - CpLeafBag.cp_owner + cp_leaf_call — the #6141 leaf-name tier triple. See
+//     the cpleaf_static.py block in cpStatic for what it separates. The field
+//     must be a CLASS-LEVEL annotated attribute: `self.cp_owner = 1` in
+//     __init__ emits no field entity at all, so the competing member would be
+//     absent and the shape only apparently reached.
+//
+//   - CpPlainProbe — #6148. A class with no decorator, no base class, no route
+//     annotation and no naming convention: nothing classification-worthy. The
+//     full rebuild still TYPES it, because Pass 2.5 runs the YAML rule sets
+//     (falcon/cherrypy match a bare `class X:`) and the #1613 fold collapses the
+//     AST's generic SCOPE.Component node into that typed record. The incremental
+//     path ran the language extractor alone and left the generic kind, so the
+//     same class was `Controller` after a full rebuild and `SCOPE.Component`
+//     after an incremental one — a one-entity divergence that dragged four
+//     CONTAINS edges with it, since entity ids hash the kind. Fixed in
+//     internal/extractors/incremental.go (see engine.FoldFrameworkClassKinds).
+//     No class had ever appeared in this file's delta, which is the whole reason
+//     the gate stayed green through it.
 func cpDelta(t *testing.T, repo string, pass int) {
 	t.Helper()
 	dvWriteFile(t, repo, "cphandler_delta.py", fmt.Sprintf(`import cperrs_static
@@ -377,6 +423,19 @@ def cp_handle(x):
 def cp_use_class(y):
     c = CpProducer()
     return c.cp_method(y) + len(CP_SETTING)
+
+
+class CpPlainProbe:
+    def cp_probe_noop(self):
+        return 1
+
+
+class CpLeafBag:
+    cp_owner: int = 1
+
+
+def cp_leaf_call():
+    return cp_owner()
 `, pass))
 }
 
@@ -520,11 +579,18 @@ var cpKnownPathA = []cpKnown{
 		Contains:       []string{"→SCOPE.ExceptionType/exception:CpNotFound@<exception>:CONTAINS"},
 		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
 	},
+	// Re-keyed (not deleted) when the fixture grew for #6141/#6148: the
+	// divergence still reproduces and is still the same one — the unassigned
+	// community carries exactly ONE extra member, the duplicate row above — but
+	// the key spells out ABSOLUTE membership counts, and those track the size of
+	// the corpus. The load-bearing part of the key is the +1; the absolute pair
+	// moves whenever a fixture file is added. Anything other than +1 is a
+	// different divergence and must fail.
 	{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 23 member(s) in A, 24 in B"},
+		Contains: []string{"community ∅: 32 member(s) in A, 33 in B"},
 	},
 
 	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -583,13 +583,22 @@ var cpKnownPathA = []cpKnown{
 		Contains:       []string{"→SCOPE.ExceptionType/exception:CpNotFound@<exception>:CONTAINS"},
 		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
 	},
-	// Re-keyed (not deleted) when the fixture grew for #6141/#6148: the
+	// Re-keyed (not deleted) when the fixture grew for #6141/#6148/#6150: the
 	// divergence still reproduces and is still the same one — the unassigned
 	// community carries exactly ONE extra member, the duplicate row above — but
 	// the key spells out ABSOLUTE membership counts, and those track the size of
 	// the corpus. The load-bearing part of the key is the +1; the absolute pair
 	// moves whenever a fixture file is added. Anything other than +1 is a
 	// different divergence and must fail.
+	//
+	// This entry has now been re-keyed three times for fixture growth and zero
+	// times for a change in the defect, which is a smell in the KEY, not in the
+	// entry: it is the only allow entry keyed on an absolute count rather than on
+	// a shape. Keying it on the DELTA would end the churn and would still fail on
+	// a magnitude change — but the delta is not in the divergence string today
+	// (parity.Report renders "N member(s) in A, M in B"), so it needs a
+	// comparator change to reach, not an allow-list edit. Worth doing the next
+	// time this file is opened for anything else.
 	{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -396,7 +396,8 @@ CP_OTHER = 12
 //   - CpPlainProbe — #6148. A class with no decorator, no base class, no route
 //     annotation and no naming convention: nothing classification-worthy. The
 //     full rebuild still TYPES it, because Pass 2.5 runs the YAML rule sets
-//     (falcon/cherrypy match a bare `class X:`) and the #1613 fold collapses the
+//     (falcon/cherrypy match a bare `class X:` with no framework gate at all —
+//     #6152) and the #1613 fold collapses the
 //     AST's generic SCOPE.Component node into that typed record. The incremental
 //     path ran the language extractor alone and left the generic kind, so the
 //     same class was `Controller` after a full rebuild and `SCOPE.Component`

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -4189,138 +4189,25 @@ type foldShadowStats struct {
 	ShadowsStillLine0 int
 }
 
-// frameworkClassKindPriority ranks framework-typed node kinds by how strongly
-// they represent a class/type *declaration* (vs a nested artifact that merely
-// shares the class name, e.g. a Django Meta `Constraint`). These are the only
-// kinds eligible to be a fold *survivor*. When several share a fold source's
-// source_file+name, the highest-priority kind wins. Higher value = stronger
-// class signal. SCOPE.Component is intentionally absent: it is the generic AST
-// node we fold AWAY into a framework-typed survivor (so a class with a View
-// resolves to ONE node), and it is itself the survivor only when no
-// framework-typed node exists (handled separately, never as a candidate here).
+// The class-fold vocabulary (kind priority, canonical rank, class-like
+// subtypes) and the two predicates below MOVED to internal/engine (#6148).
 //
-// Both bare kind names (emitted by Java/Django custom extractors) AND their
-// "SCOPE."-prefixed forms (emitted by Kotlin, TypeScript, proto, and pattern
-// extractors) must appear so that frameworkClassKindPriority[r.Kind] matches
-// regardless of which extractor emitted the survivor. Issue #1700.
-var frameworkClassKindPriority = map[string]int{
-	// Bare names (Java/Django/Spring-boot custom extractors)
-	"Model":          100,
-	"View":           100,
-	"Controller":     100,
-	"Service":        100,
-	"Middleware":     100,
-	"Repository":     100,
-	"Worker":         100,
-	"Job":            100,
-	"Topic":          100,
-	"TestClass":      90,
-	"Schema":         80,
-	"Plugin":         80,
-	"Implementation": 80,
-	"Interface":      80,
-	"Task":           70,
+// They were private to this file while the full rebuild was the only path that
+// folded. The incremental path now has to resolve the SAME framework-typed kind
+// for a class it re-extracts — a class arriving in a changed file was typed by
+// a full rebuild and left as a generic SCOPE.Component by the incremental one —
+// and a second copy of these tables would be free to drift from this one. The
+// aliases keep every existing reference (including this package's tests)
+// pointing at the single definition.
+var (
+	frameworkClassKindPriority  = engine.FrameworkClassKindPriority
+	frameworkClassKindCanonRank = engine.FrameworkClassKindCanonRank
+	classLikeComponentSubtypes  = engine.ClassLikeComponentSubtypes
+)
 
-	// SCOPE.-prefixed equivalents (Kotlin extractor, proto extractor, NestJS
-	// service_detector, and any other extractor that emits the canonical
-	// "SCOPE.<Kind>" form for a class-like entity). Priorities mirror the bare
-	// form so that the highest-fidelity named node always beats a generic shadow.
-	// Issue #1700.
-	"SCOPE.Service":     100,
-	"SCOPE.View":        100, // #1727: View+Component fold (SCOPE-prefixed form)
-	"SCOPE.Model":       100,
-	"SCOPE.UIComponent": 100,
-	"SCOPE.GrpcService": 90,
-	"SCOPE.Schema":      80,
-}
+func isShadowRecord(r *types.EntityRecord) bool { return engine.IsClassHierarchyShadow(r) }
 
-// frameworkClassKindCanonRank is the deterministic tiebreaker used when two or
-// more framework-typed nodes share the SAME (source_file, name) AND the SAME
-// frameworkClassKindPriority — i.e. one class symbol was double-emitted under
-// two equally-strong kinds (the #3172/#3195 DRF/Django family: a Django
-// `models.Model` class surfacing as BOTH "Model" AND "Controller"). Both are
-// survivor candidates of priority 100, so without a tiebreaker the fold leaves
-// two nodes for one class, violating the #1613 "every class → ONE node"
-// invariant (TestClassShadowFold_NoLine0Shadows).
-//
-// Higher value = stronger canonical signal. The ranking prefers a kind that
-// names what the class structurally *is* (its declaration role: a data Model, a
-// rendered View, a Service, a Repository, a Schema) over a kind that names how
-// the class is *dispatched/routed* ("Controller"). A Controller is the role
-// most prone to spurious co-emission from route/endpoint synthesis on a class
-// that is really a Model/View, so it is deliberately ranked below the structural
-// declaration kinds. Kinds absent from this map rank as 0 (only consulted to
-// break an exact-priority tie; the priority map remains the primary order).
-var frameworkClassKindCanonRank = map[string]int{
-	"Model": 5, "SCOPE.Model": 5,
-	"View": 5, "SCOPE.View": 5,
-	"Repository": 4,
-	"Service":    4, "SCOPE.Service": 4,
-	"Schema": 3, "SCOPE.Schema": 3,
-	"Worker": 2, "Job": 2, "Topic": 2,
-	"Middleware": 1,
-	"Controller": 0,
-}
-
-func isShadowRecord(r *types.EntityRecord) bool {
-	return r.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY"
-}
-
-// classLikeComponentSubtypes are the SCOPE.Component subtypes that denote a
-// class/type declaration (as opposed to subtype="file"/"import"/"module").
-// Language AST subtypes ("class", "struct", …) are the primary set. Framework-
-// injected subtypes from NestJS, Angular, Spring-boot, Quarkus, and similar
-// extractors are included so that an inferential SCOPE.Component(subtype="service")
-// node emitted alongside a real SCOPE.Service node for the same class symbol is
-// recognised as a fold source and collapsed into the typed survivor. Issue #1700.
-//
-// "view" is included so that SCOPE.Component(subtype="view") nodes emitted
-// alongside a real SCOPE.View (or bare "View") node for the same class symbol
-// are recognised as fold sources. Issue #1727.
-var classLikeComponentSubtypes = map[string]bool{
-	// Language AST subtypes
-	"class": true, "struct": true, "interface": true,
-	"protocol": true, "trait": true, "behaviour": true,
-	// Framework-injected subtypes (NestJS, Angular, Spring, Quarkus, …)
-	"service": true, "controller": true, "repository": true,
-	"guard": true, "interceptor": true, "pipe": true,
-	"middleware": true, "resolver": true, "gateway": true,
-	"worker": true, "job": true, "task": true,
-	// View-type subtypes (Django CBV, MVC view layers, …) — #1727
-	"view": true,
-}
-
-// isFoldSource reports whether r is a class-representation node that should be
-// folded into a framework-typed node when one exists for the same symbol:
-//   - the INFERRED_FROM_CLASS_HIERARCHY shadow emitted by the hierarchy pass, OR
-//   - the generic SCOPE.Component class node emitted by the per-language AST
-//     extractor (these two share an EntityID and pre-merge at assembly), OR
-//   - a SCOPE.Component carrying Properties["role"]="class" (hierarchy pass
-//     annotations on nodes where the language AST subtype is not yet in
-//     classLikeComponentSubtypes — e.g. TypeScript/React class components
-//     with a framework-injected role tag). Issue #1727.
-//
-// When NO framework-typed node exists, a fold source is kept as the single
-// node for that class (it already carries a real line from its extractor).
-func isFoldSource(r *types.EntityRecord) bool {
-	if r.Name == "" {
-		return false
-	}
-	if isShadowRecord(r) {
-		return true
-	}
-	if r.Kind != "SCOPE.Component" {
-		return false
-	}
-	// Subtype-based recognition: language AST and framework-injected subtypes.
-	if classLikeComponentSubtypes[r.Subtype] {
-		return true
-	}
-	// Role-property recognition: hierarchy pass sets role="class" on SCOPE.Component
-	// nodes whose subtype is not yet in the allowlist (e.g. component, vue_component,
-	// empty subtype from certain extractors). Issue #1727.
-	return r.Properties["role"] == "class"
-}
+func isFoldSource(r *types.EntityRecord) bool { return engine.IsClassFoldSource(r) }
 
 // foldClassHierarchyShadows folds line-less / generic class nodes into the real
 // framework-typed node (View/Model/Controller/…) for the same source_file +

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -4199,6 +4199,12 @@ type foldShadowStats struct {
 // and a second copy of these tables would be free to drift from this one. The
 // aliases keep every existing reference (including this package's tests)
 // pointing at the single definition.
+//
+// They are ALIASES, not copies: `var x = engine.Y` on a map copies the header,
+// so both names address one backing map. Writing through either — a test poking
+// an entry, say — mutates engine's state for the whole process. Nothing writes
+// to them today, and nothing should; if one ever needs a local override, copy
+// it explicitly at the point of use.
 var (
 	frameworkClassKindPriority  = engine.FrameworkClassKindPriority
 	frameworkClassKindCanonRank = engine.FrameworkClassKindCanonRank

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -1,0 +1,269 @@
+package engine
+
+// Class-representation folding vocabulary, shared by the two paths that have to
+// agree on what KIND a class-like entity ends up carrying (#6148).
+//
+// The full rebuild runs Pass 2.5 (Detector.Detect over the YAML rule sets),
+// which emits a framework-typed record — Model / View / Controller / Service /
+// … — for every class symbol a rule matches, and then folds the per-language
+// AST's generic SCOPE.Component class node into that record (the #1613
+// class-shadow fold in cmd/grafel/index.go).
+//
+// The incremental path re-extracts a changed file with the per-language
+// extractor ONLY. Before #6148 it therefore never saw Pass 2.5's answer: a
+// class arriving in a changed file kept the generic SCOPE.Component kind, while
+// a full rebuild of the same tree typed it. Classes in UNCHANGED files hid the
+// defect, because those entities are carried forward from the previous full
+// rebuild's graph with the typed kind already on them.
+//
+// The maps below were the fold's private vocabulary in package main. They live
+// here so the incremental path resolves the same kind from the same table
+// rather than from a second copy that can drift.
+
+import "github.com/cajasmota/grafel/internal/types"
+
+// FrameworkClassKindPriority ranks framework-typed node kinds by how strongly
+// they represent a class/type *declaration* (vs a nested artifact that merely
+// shares the class name, e.g. a Django Meta `Constraint`). These are the only
+// kinds eligible to be a fold *survivor*. When several share a fold source's
+// source_file+name, the highest-priority kind wins. Higher value = stronger
+// class signal. SCOPE.Component is intentionally absent: it is the generic AST
+// node we fold AWAY into a framework-typed survivor (so a class with a View
+// resolves to ONE node), and it is itself the survivor only when no
+// framework-typed node exists (handled separately, never as a candidate here).
+//
+// Both bare kind names (emitted by Java/Django custom extractors) AND their
+// "SCOPE."-prefixed forms (emitted by Kotlin, TypeScript, proto, and pattern
+// extractors) must appear so that FrameworkClassKindPriority[r.Kind] matches
+// regardless of which extractor emitted the survivor. Issue #1700.
+var FrameworkClassKindPriority = map[string]int{
+	// Bare names (Java/Django/Spring-boot custom extractors)
+	"Model":          100,
+	"View":           100,
+	"Controller":     100,
+	"Service":        100,
+	"Middleware":     100,
+	"Repository":     100,
+	"Worker":         100,
+	"Job":            100,
+	"Topic":          100,
+	"TestClass":      90,
+	"Schema":         80,
+	"Plugin":         80,
+	"Implementation": 80,
+	"Interface":      80,
+	"Task":           70,
+
+	// SCOPE.-prefixed equivalents (Kotlin extractor, proto extractor, NestJS
+	// service_detector, and any other extractor that emits the canonical
+	// "SCOPE.<Kind>" form for a class-like entity). Priorities mirror the bare
+	// form so that the highest-fidelity named node always beats a generic shadow.
+	// Issue #1700.
+	"SCOPE.Service":     100,
+	"SCOPE.View":        100, // #1727: View+Component fold (SCOPE-prefixed form)
+	"SCOPE.Model":       100,
+	"SCOPE.UIComponent": 100,
+	"SCOPE.GrpcService": 90,
+	"SCOPE.Schema":      80,
+}
+
+// FrameworkClassKindCanonRank is the deterministic tiebreaker used when two or
+// more framework-typed nodes share the SAME (source_file, name) AND the SAME
+// FrameworkClassKindPriority — i.e. one class symbol was double-emitted under
+// two equally-strong kinds (the #3172/#3195 DRF/Django family: a Django
+// `models.Model` class surfacing as BOTH "Model" AND "Controller"). Both are
+// survivor candidates of priority 100, so without a tiebreaker the fold leaves
+// two nodes for one class, violating the #1613 "every class → ONE node"
+// invariant (TestClassShadowFold_NoLine0Shadows).
+//
+// Higher value = stronger canonical signal. The ranking prefers a kind that
+// names what the class structurally *is* (its declaration role: a data Model, a
+// rendered View, a Service, a Repository, a Schema) over a kind that names how
+// the class is *dispatched/routed* ("Controller"). A Controller is the role
+// most prone to spurious co-emission from route/endpoint synthesis on a class
+// that is really a Model/View, so it is deliberately ranked below the structural
+// declaration kinds. Kinds absent from this map rank as 0 (only consulted to
+// break an exact-priority tie; the priority map remains the primary order).
+var FrameworkClassKindCanonRank = map[string]int{
+	"Model": 5, "SCOPE.Model": 5,
+	"View": 5, "SCOPE.View": 5,
+	"Repository": 4,
+	"Service":    4, "SCOPE.Service": 4,
+	"Schema": 3, "SCOPE.Schema": 3,
+	"Worker": 2, "Job": 2, "Topic": 2,
+	"Middleware": 1,
+	"Controller": 0,
+}
+
+// ClassLikeComponentSubtypes are the SCOPE.Component subtypes that denote a
+// class/type declaration (as opposed to subtype="file"/"import"/"module").
+// Language AST subtypes ("class", "struct", …) are the primary set. Framework-
+// injected subtypes from NestJS, Angular, Spring-boot, Quarkus, and similar
+// extractors are included so that an inferential SCOPE.Component(subtype="service")
+// node emitted alongside a real SCOPE.Service node for the same class symbol is
+// recognised as a fold source and collapsed into the typed survivor. Issue #1700.
+//
+// "view" is included so that SCOPE.Component(subtype="view") nodes emitted
+// alongside a real SCOPE.View (or bare "View") node for the same class symbol
+// are recognised as fold sources. Issue #1727.
+var ClassLikeComponentSubtypes = map[string]bool{
+	// Language AST subtypes
+	"class": true, "struct": true, "interface": true,
+	"protocol": true, "trait": true, "behaviour": true,
+	// Framework-injected subtypes (NestJS, Angular, Spring, Quarkus, …)
+	"service": true, "controller": true, "repository": true,
+	"guard": true, "interceptor": true, "pipe": true,
+	"middleware": true, "resolver": true, "gateway": true,
+	"worker": true, "job": true, "task": true,
+	// View-type subtypes (Django CBV, MVC view layers, …) — #1727
+	"view": true,
+}
+
+// IsClassHierarchyShadow reports whether r is the line-less duplicate the
+// class-hierarchy pass emits for every class it sees.
+func IsClassHierarchyShadow(r *types.EntityRecord) bool {
+	return r.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY"
+}
+
+// IsClassFoldSource reports whether r is a class-representation node that should
+// be folded into a framework-typed node when one exists for the same symbol:
+//   - the INFERRED_FROM_CLASS_HIERARCHY shadow emitted by the hierarchy pass, OR
+//   - the generic SCOPE.Component class node emitted by the per-language AST
+//     extractor (these two share an EntityID and pre-merge at assembly), OR
+//   - a SCOPE.Component carrying Properties["role"]="class" (hierarchy pass
+//     annotations on nodes where the language AST subtype is not yet in
+//     ClassLikeComponentSubtypes — e.g. TypeScript/React class components
+//     with a framework-injected role tag). Issue #1727.
+//
+// When NO framework-typed node exists, a fold source is kept as the single
+// node for that class (it already carries a real line from its extractor).
+func IsClassFoldSource(r *types.EntityRecord) bool {
+	if r.Name == "" {
+		return false
+	}
+	if IsClassHierarchyShadow(r) {
+		return true
+	}
+	if r.Kind != "SCOPE.Component" {
+		return false
+	}
+	// Subtype-based recognition: language AST and framework-injected subtypes.
+	if ClassLikeComponentSubtypes[r.Subtype] {
+		return true
+	}
+	// Role-property recognition: hierarchy pass sets role="class" on SCOPE.Component
+	// nodes whose subtype is not yet in the allowlist (e.g. component, vue_component,
+	// empty subtype from certain extractors). Issue #1727.
+	return r.Properties["role"] == "class"
+}
+
+// betterFrameworkClassCandidate reports whether c should displace best as the
+// canonical framework-typed survivor for one (source_file, name). It is the
+// precedence the #1613 fold's bestCand applies, minus the final id tiebreak
+// (ids are not stamped yet at the point the incremental path folds):
+//
+//  1. highest FrameworkClassKindPriority (class-declaration strength),
+//  2. highest FrameworkClassKindCanonRank (structural-role tiebreaker),
+//  3. smallest real (>0) start_line — the declaration; 0 == "no line" loses.
+//
+// A full tie keeps the incumbent, so the answer is a function of emission order
+// only when the two candidates are indistinguishable on all three axes, and
+// Detect's emission order is itself deterministic (rule-set order × regex match
+// order over the file).
+func betterFrameworkClassCandidate(c, best *types.EntityRecord) bool {
+	cp, bp := FrameworkClassKindPriority[c.Kind], FrameworkClassKindPriority[best.Kind]
+	if cp != bp {
+		return cp > bp
+	}
+	cr, br := FrameworkClassKindCanonRank[c.Kind], FrameworkClassKindCanonRank[best.Kind]
+	if cr != br {
+		return cr > br
+	}
+	if c.StartLine != best.StartLine {
+		return (best.StartLine == 0 && c.StartLine > 0) ||
+			(c.StartLine > 0 && c.StartLine < best.StartLine)
+	}
+	return false
+}
+
+// FoldFrameworkClassKinds folds the generic class records in recs into the
+// framework-typed records in fw for the same (source_file, name), IN PLACE, and
+// returns the number of records folded.
+//
+// This is the incremental path's equivalent of the full rebuild's Pass 2.5 +
+// #1613 fold, restricted to ONE file's records — which loses nothing, because
+// that fold is keyed by (SourceFile, Name) and so never pairs records from
+// different files.
+//
+// The framework-typed record is the SURVIVOR, exactly as in the full path: it
+// carries the kind, subtype, qualified name, language and line span the fold
+// keeps, and the fold source contributes only the properties the survivor lacks
+// (minus "provenance"/"ref", which describe the source and would mislead on the
+// survivor) plus the edges it owns. Doing it the other way round — keeping the
+// source record and merely re-kinding it — would reproduce the KIND but not the
+// subtype or the property set, and the content-keyed parity gate compares those.
+//
+// Records in recs that are not fold sources, and fold sources with no
+// framework-typed counterpart, are left untouched: a class no rule matches must
+// stay the generic node, which is exactly what the full path does with it.
+func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord) int {
+	if len(recs) == 0 || len(fw) == 0 {
+		return 0
+	}
+
+	// Index the canonical framework-typed survivor per (source_file, name).
+	type key struct{ file, name string }
+	best := make(map[key]*types.EntityRecord)
+	for i := range fw {
+		c := &fw[i]
+		if c.Name == "" {
+			continue
+		}
+		if _, eligible := FrameworkClassKindPriority[c.Kind]; !eligible {
+			continue
+		}
+		k := key{c.SourceFile, c.Name}
+		if cur, seen := best[k]; !seen || betterFrameworkClassCandidate(c, cur) {
+			best[k] = c
+		}
+	}
+	if len(best) == 0 {
+		return 0
+	}
+
+	folded := 0
+	for i := range recs {
+		src := &recs[i]
+		if !IsClassFoldSource(src) {
+			continue
+		}
+		// The framework records are emitted against the file being extracted, so
+		// an empty SourceFile on either side is never a legitimate match.
+		sv, ok := best[key{src.SourceFile, src.Name}]
+		if !ok || sv.Kind == src.Kind {
+			continue
+		}
+
+		merged := *sv
+		merged.Properties = make(map[string]string, len(sv.Properties)+len(src.Properties))
+		for pk, pv := range sv.Properties {
+			merged.Properties[pk] = pv
+		}
+		for pk, pv := range src.Properties {
+			if pk == "provenance" || pk == "ref" {
+				continue
+			}
+			if _, exists := merged.Properties[pk]; !exists {
+				merged.Properties[pk] = pv
+			}
+		}
+		// Edges the fold source OWNS move onto the survivor. Their FromID is
+		// either empty (meaning "the owning record") or the source's own id; in
+		// both cases the owner is re-derived from the survivor downstream, so
+		// carrying them across unchanged is what re-homes them.
+		merged.Relationships = append(append([]types.RelationshipRecord(nil), sv.Relationships...), src.Relationships...)
+		*src = merged
+		folded++
+	}
+	return folded
+}

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -186,84 +186,155 @@ func betterFrameworkClassCandidate(c, best *types.EntityRecord) bool {
 	return false
 }
 
-// FoldFrameworkClassKinds folds the generic class records in recs into the
-// framework-typed records in fw for the same (source_file, name), IN PLACE, and
-// returns the number of records folded.
+// FoldFrameworkClassKinds is the incremental path's port of the full rebuild's
+// Pass 2.5 + #1613 fold, for ONE file. recs is the per-language extractor's
+// output for that file; fw is engine.Detector's. It returns the record set to
+// emit and the number of class-representation records folded.
 //
-// This is the incremental path's equivalent of the full rebuild's Pass 2.5 +
-// #1613 fold, restricted to ONE file's records — which loses nothing, because
-// that fold is keyed by (SourceFile, Name) and so never pairs records from
-// different files.
+// What "one file" costs, precisely. The full path's fold indexes survivor
+// candidates from the WHOLE corpus but keys them by (SourceFile, Name), so no
+// pair of records from different files can ever fold together — restricting the
+// candidate set to one file's records is therefore lossless ON THE FILE AXIS.
+// It is not lossless in general, and an earlier version of this comment claimed
+// otherwise: the full path also indexes candidates emitted by the LANGUAGE
+// EXTRACTOR itself, not just by Detect. Several extractors emit a
+// framework-typed kind directly for a class they also emit a generic node for —
+// kotlin (SCOPE.Service for a Spring stereotype, the #1700 case), proto, razor,
+// cobol, fsharp, elm. Indexing only Detect's output left those classes with TWO
+// nodes on this path, breaking the #1613 "one class → one node" invariant the
+// fold exists to enforce. Both sets are candidates here.
+//
+// Detect's records that fold with nothing are EMITTED, not discarded (#6150):
+// a Route from a responder method, a Service from an app object and a Config
+// from its constructor have no extractor counterpart at all, and a full rebuild
+// carries every one of them. Running the classifier and keeping only the class
+// half would pay its whole cost for a seventh of its output.
+//
+// The two loops mirror the full path's, in its order:
+//
+//  1. SIBLING-SURVIVOR FOLD. All eligible framework-typed candidates for one
+//     (file, name) collapse into the best one; the losers are dropped after
+//     donating their properties and owned edges. Without it, a symbol emitted
+//     under two equally-strong kinds resolves to >1 node (#3172/#3195).
+//  2. FOLD-SOURCE LOOP. Each class-representation record (see IsClassFoldSource)
+//     folds into the survivor for its symbol, if one exists.
 //
 // The framework-typed record is the SURVIVOR, exactly as in the full path: it
 // carries the kind, subtype, qualified name, language and line span the fold
-// keeps, and the fold source contributes only the properties the survivor lacks
-// (minus "provenance"/"ref", which describe the source and would mislead on the
-// survivor) plus the edges it owns. Doing it the other way round — keeping the
-// source record and merely re-kinding it — would reproduce the KIND but not the
-// subtype or the property set, and the content-keyed parity gate compares those.
+// keeps, and the folded-away record contributes only the properties the survivor
+// lacks (minus "provenance"/"ref") plus the edges it owns. Doing it the other
+// way round — keeping the source record and merely re-kinding it — reproduces
+// the KIND but neither the subtype nor the property set, and the content-keyed
+// parity gate compares both (measured: that mutant is killed by the gate AND by
+// this package's tests).
 //
-// Records in recs that are not fold sources, and fold sources with no
-// framework-typed counterpart, are left untouched: a class no rule matches must
-// stay the generic node, which is exactly what the full path does with it.
-func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord) int {
-	if len(recs) == 0 || len(fw) == 0 {
-		return 0
+// A fold source with no framework-typed candidate is returned unchanged: a class
+// no rule matches must stay the generic node, which is what the full path does
+// with it. Records that are neither candidates nor fold sources pass through
+// untouched and in order.
+func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord) ([]types.EntityRecord, int) {
+	if len(recs) == 0 && len(fw) == 0 {
+		return recs, 0
 	}
 
-	// Index the canonical framework-typed survivor per (source_file, name).
-	type key struct{ file, name string }
-	best := make(map[key]*types.EntityRecord)
-	for i := range fw {
-		c := &fw[i]
-		if c.Name == "" {
-			continue
-		}
-		if _, eligible := FrameworkClassKindPriority[c.Kind]; !eligible {
-			continue
-		}
-		k := key{c.SourceFile, c.Name}
-		if cur, seen := best[k]; !seen || betterFrameworkClassCandidate(c, cur) {
-			best[k] = c
-		}
-	}
-	if len(best) == 0 {
-		return 0
-	}
-
-	folded := 0
+	// all is the candidate/emission universe in the full path's order: the
+	// extractor's records first, then Detect's. Order is load-bearing only as the
+	// last tiebreak (see betterFrameworkClassCandidate), where the full path uses
+	// the smallest stamped id — not available here, ids are stamped downstream.
+	all := make([]*types.EntityRecord, 0, len(recs)+len(fw))
 	for i := range recs {
-		src := &recs[i]
-		if !IsClassFoldSource(src) {
-			continue
-		}
-		// The framework records are emitted against the file being extracted, so
-		// an empty SourceFile on either side is never a legitimate match.
-		sv, ok := best[key{src.SourceFile, src.Name}]
-		if !ok || sv.Kind == src.Kind {
-			continue
-		}
+		all = append(all, &recs[i])
+	}
+	for i := range fw {
+		all = append(all, &fw[i])
+	}
 
-		merged := *sv
-		merged.Properties = make(map[string]string, len(sv.Properties)+len(src.Properties))
-		for pk, pv := range sv.Properties {
-			merged.Properties[pk] = pv
+	type key struct{ file, name string }
+	// eligible reports whether r can be a fold SURVIVOR. The blank checks are
+	// enforcement, not decoration: without them every file-less or nameless
+	// record would key onto {"",""} and fold with the others.
+	eligible := func(r *types.EntityRecord) bool {
+		if r.Name == "" || r.SourceFile == "" {
+			return false
+		}
+		_, ok := FrameworkClassKindPriority[r.Kind]
+		return ok
+	}
+
+	// ── Loop 1: sibling-survivor fold ──
+	best := make(map[key]*types.EntityRecord)
+	for _, r := range all {
+		if !eligible(r) {
+			continue
+		}
+		k := key{r.SourceFile, r.Name}
+		if cur, seen := best[k]; !seen || betterFrameworkClassCandidate(r, cur) {
+			best[k] = r
+		}
+	}
+	dropped := make(map[*types.EntityRecord]bool)
+	for _, r := range all {
+		if !eligible(r) {
+			continue
+		}
+		if sv := best[key{r.SourceFile, r.Name}]; sv != r {
+			donate(sv, r)
+			dropped[r] = true
+		}
+	}
+
+	// ── Loop 2: fold-source loop ──
+	folded := 0
+	for _, r := range all {
+		if dropped[r] || !IsClassFoldSource(r) {
+			continue
+		}
+		// sv == r is reachable: a class-hierarchy SHADOW carrying an eligible
+		// framework kind is BOTH a survivor candidate and a fold source, and
+		// without this it would donate its own edges to itself.
+		sv, ok := best[key{r.SourceFile, r.Name}]
+		if !ok || sv == r {
+			continue
+		}
+		donate(sv, r)
+		dropped[r] = true
+		folded++
+	}
+
+	out := make([]types.EntityRecord, 0, len(all))
+	for _, r := range all {
+		if !dropped[r] {
+			out = append(out, *r)
+		}
+	}
+	return out, folded
+}
+
+// donate folds src away into sv: sv keeps every field of its own and gains the
+// properties src carried that it lacks, plus the edges src owns.
+//
+// "provenance" and "ref" describe the record being folded AWAY — provenance
+// records that a node was INFERRED_FROM_CLASS_HIERARCHY, which is false of the
+// survivor — so they are the two the full path refuses to donate.
+//
+// An owned edge carries either an empty FromID (meaning "my owner") or its
+// owner's id, and the record→graph seam substitutes the OWNING record's id for
+// the empty form. Appending them to the survivor is therefore what re-homes
+// them; rewriting FromID here would bind them to an id that no longer exists.
+func donate(sv, src *types.EntityRecord) {
+	if len(src.Properties) > 0 {
+		if sv.Properties == nil {
+			sv.Properties = make(map[string]string, len(src.Properties))
 		}
 		for pk, pv := range src.Properties {
 			if pk == "provenance" || pk == "ref" {
 				continue
 			}
-			if _, exists := merged.Properties[pk]; !exists {
-				merged.Properties[pk] = pv
+			if _, exists := sv.Properties[pk]; !exists {
+				sv.Properties[pk] = pv
 			}
 		}
-		// Edges the fold source OWNS move onto the survivor. Their FromID is
-		// either empty (meaning "the owning record") or the source's own id; in
-		// both cases the owner is re-derived from the survivor downstream, so
-		// carrying them across unchanged is what re-homes them.
-		merged.Relationships = append(append([]types.RelationshipRecord(nil), sv.Relationships...), src.Relationships...)
-		*src = merged
-		folded++
 	}
-	return folded
+	sv.Relationships = append(sv.Relationships, src.Relationships...)
+	src.Relationships = nil
 }

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -238,6 +238,26 @@ func betterFrameworkClassCandidate(c, best *types.EntityRecord) bool {
 // no rule matches must stay the generic node, which is what the full path does
 // with it. Records that are neither candidates nor fold sources pass through
 // untouched and in order.
+//
+// TWO PARTS OF THE FULL PATH ARE DELIBERATELY ABSENT, and both are sound only
+// because of where this runs:
+//
+//   - The SHADOW branch — index.go's nonShadowByID lookup, the ShadowsBackfilled
+//     / ShadowsStillLine0 stats and the provenance strip on a shadow that
+//     survives with real coordinates. The only producer of
+//     INFERRED_FROM_CLASS_HIERARCHY is the cross/hierarchy extractor, and
+//     TryIncremental runs no cross extractors at all, so no shadow can reach
+//     this function from that path. IsClassFoldSource still recognises one (a
+//     caller passing records from elsewhere gets the right answer), but the
+//     branch that only makes sense once shadows exist is not ported.
+//   - The ID REMAP. index.go rewrites edge endpoints from a folded record's
+//     stamped id onto the survivor's. Records here are pre-stamp — ids are
+//     derived downstream from kind/name/source_file — so there is no id to
+//     remap; donate() re-homes owned edges instead, and the endpoint rewrite
+//     happens for free because the survivor's id is what gets derived.
+//
+// If either premise changes — a shadow producer on this path, or ids stamped
+// before this point — both omissions become defects.
 func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord) ([]types.EntityRecord, int) {
 	if len(recs) == 0 && len(fw) == 0 {
 		return recs, 0
@@ -259,6 +279,14 @@ func FoldFrameworkClassKinds(recs []types.EntityRecord, fw []types.EntityRecord)
 	// eligible reports whether r can be a fold SURVIVOR. The blank checks are
 	// enforcement, not decoration: without them every file-less or nameless
 	// record would key onto {"",""} and fold with the others.
+	//
+	// DIVERGENCE FROM THE FULL PATH, deliberate: index.go's candidate loop
+	// screens only `r.Name == ""`, not the source file. It can afford to —
+	// its records are all post-assembly and carry a SourceFile — whereas this
+	// runs on raw extractor and Detect output where a file-less record is
+	// reachable. Hardening, not a behaviour change on any record either loop
+	// would actually pair; called out because this function is otherwise a
+	// faithful port and the next reader will diff them.
 	eligible := func(r *types.EntityRecord) bool {
 		if r.Name == "" || r.SourceFile == "" {
 			return false

--- a/internal/engine/classfold.go
+++ b/internal/engine/classfold.go
@@ -204,6 +204,12 @@ func betterFrameworkClassCandidate(c, best *types.EntityRecord) bool {
 // nodes on this path, breaking the #1613 "one class → one node" invariant the
 // fold exists to enforce. Both sets are candidates here.
 //
+// The kinds this assigns are the rule sets' business, not this function's: a
+// bare Python class comes back "Controller" because falcon.yaml and
+// cherrypy.yaml match `class X:` with no framework gate (#6152). Matching that
+// is the point — the two paths must agree on the answer before it is worth
+// arguing about the answer.
+//
 // Detect's records that fold with nothing are EMITTED, not discarded (#6150):
 // a Route from a responder method, a Service from an app object and a Config
 // from its constructor have no extractor counterpart at all, and a full rebuild

--- a/internal/engine/classfold_test.go
+++ b/internal/engine/classfold_test.go
@@ -25,6 +25,7 @@ func cfRows(recs []types.EntityRecord) []string {
 
 func cfAssertRows(t *testing.T, got, want []string) {
 	t.Helper()
+	sort.Strings(want)
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Errorf("record rows:\n  want %v\n  got  %v", want, got)
 	}
@@ -55,10 +56,11 @@ func TestFoldFrameworkClassKinds_TypedSurvivorReplacesGenericNode(t *testing.T) 
 	}
 	fw := []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}
 
-	if n := FoldFrameworkClassKinds(recs, fw); n != 1 {
+	out, n := FoldFrameworkClassKinds(recs, fw)
+	if n != 1 {
 		t.Errorf("folded %d records, want 1", n)
 	}
-	cfAssertRows(t, cfRows(recs), []string{
+	cfAssertRows(t, cfRows(out), []string{
 		"Controller|Probe||a.py",
 		"SCOPE.Operation|Probe.m|method|a.py",
 	})
@@ -66,7 +68,12 @@ func TestFoldFrameworkClassKinds_TypedSurvivorReplacesGenericNode(t *testing.T) 
 	// The survivor is the framework record — including its EMPTY subtype, which
 	// the content-keyed parity comparator compares — carrying the properties the
 	// source had and it lacked, minus the source-describing ones.
-	sv := recs[0]
+	var sv types.EntityRecord
+	for _, r := range out {
+		if r.Kind == "Controller" {
+			sv = r
+		}
+	}
 	if sv.Properties["framework"] != "python" || sv.Properties["pattern_type"] != "yaml_driven" {
 		t.Errorf("survivor lost its own properties: %v", sv.Properties)
 	}
@@ -78,6 +85,29 @@ func TestFoldFrameworkClassKinds_TypedSurvivorReplacesGenericNode(t *testing.T) 
 	}
 }
 
+// TestFoldFrameworkClassKinds_ExtractorEmittedSurvivorAbsorbsGenericNode is the
+// #1700 case: the SURVIVOR comes from the LANGUAGE EXTRACTOR, not from Detect.
+// kotlin emits SCOPE.Service for a Spring-stereotyped class and a generic
+// SCOPE.Component for the same symbol; proto, razor, cobol, fsharp and elm have
+// the same shape. A fold that indexed candidates only from Detect's output left
+// BOTH nodes standing — one class, two nodes, the exact invariant the fold
+// exists to enforce.
+func TestFoldFrameworkClassKinds_ExtractorEmittedSurvivorAbsorbsGenericNode(t *testing.T) {
+	svc := types.EntityRecord{
+		Kind: "SCOPE.Service", Name: "BillingService", SourceFile: "Billing.kt",
+		QualifiedName: "Billing.kt::BillingService", Language: "kotlin", StartLine: 6, EndLine: 9,
+		Properties: map[string]string{"provenance": "@Service", "source_type": "class"},
+	}
+	recs := []types.EntityRecord{cfSource("BillingService", "Billing.kt"), svc}
+
+	// No Detect output at all — the survivor must still be found.
+	out, n := FoldFrameworkClassKinds(recs, nil)
+	if n != 1 {
+		t.Errorf("folded %d records, want 1", n)
+	}
+	cfAssertRows(t, cfRows(out), []string{"SCOPE.Service|BillingService||Billing.kt"})
+}
+
 // TestFoldFrameworkClassKinds_NoCandidateLeavesGenericNode pins the other half:
 // a class no rule matches must stay generic. Without this, a fix that typed
 // every class would pass the test above and corrupt every unmatched class.
@@ -85,17 +115,42 @@ func TestFoldFrameworkClassKinds_NoCandidateLeavesGenericNode(t *testing.T) {
 	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
 	before := cfRows(recs)
 
-	// Framework records that must NOT match: right name wrong file, right file
-	// wrong name, and a kind that is not class-declaration-strength at all.
+	// Framework records that must NOT match the class: right name wrong file,
+	// right file wrong name, and a kind that is not class-declaration-strength.
+	// All three still have to be EMITTED — they are Detect's non-class output,
+	// which the full rebuild carries and this path must too.
 	fw := []types.EntityRecord{
 		cfFramework("Controller", "Probe", "other.py"),
 		cfFramework("Controller", "Other", "a.py"),
 		cfFramework("Route", "Probe", "a.py"),
 	}
-	if n := FoldFrameworkClassKinds(recs, fw); n != 0 {
+	out, n := FoldFrameworkClassKinds(recs, fw)
+	if n != 0 {
 		t.Errorf("folded %d records, want 0", n)
 	}
-	cfAssertRows(t, cfRows(recs), before)
+	cfAssertRows(t, cfRows(out), append(before,
+		"Controller|Other||a.py", "Controller|Probe||other.py", "Route|Probe||a.py"))
+}
+
+// TestFoldFrameworkClassKinds_NonClassFrameworkRecordsAreEmitted is #6150's
+// half: Detect output that pairs with NO extractor record (a Route from a
+// responder method, a Service from an app object, a Config from its
+// constructor) is what a full rebuild carries and an incremental run dropped.
+func TestFoldFrameworkClassKinds_NonClassFrameworkRecordsAreEmitted(t *testing.T) {
+	recs := []types.EntityRecord{{Kind: "SCOPE.Operation", Name: "on_get", SourceFile: "a.py"}}
+	fw := []types.EntityRecord{
+		cfFramework("Route", "on_get", "a.py"),
+		cfFramework("Service", "app", "a.py"),
+		cfFramework("Config", "App()", "a.py"),
+	}
+	out, n := FoldFrameworkClassKinds(recs, fw)
+	if n != 0 {
+		t.Errorf("folded %d records, want 0", n)
+	}
+	cfAssertRows(t, cfRows(out), []string{
+		"Config|App()||a.py", "Route|on_get||a.py",
+		"SCOPE.Operation|on_get||a.py", "Service|app||a.py",
+	})
 }
 
 // TestFoldFrameworkClassKinds_NonClassRecordsUntouched: an operation, a file
@@ -108,24 +163,25 @@ func TestFoldFrameworkClassKinds_NonClassRecordsUntouched(t *testing.T) {
 		{Kind: "SCOPE.Component", Subtype: "import", Name: "Probe", SourceFile: "a.py"},
 	}
 	before := cfRows(recs)
-	if n := FoldFrameworkClassKinds(recs, []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}); n != 0 {
+	out, n := FoldFrameworkClassKinds(recs, []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")})
+	if n != 0 {
 		t.Errorf("folded %d records, want 0", n)
 	}
-	cfAssertRows(t, cfRows(recs), before)
+	cfAssertRows(t, cfRows(out), append(before, "Controller|Probe||a.py"))
 }
 
 // TestFoldFrameworkClassKinds_CanonRankBreaksEqualPriority reproduces the
 // #3172/#3195 double-emission: one class surfacing as BOTH Model and
 // Controller, equal priority. The structural-declaration kind must win, and
-// exactly ONE node must remain for the class.
+// exactly ONE node must remain for the class — the loser is folded away, not
+// left standing beside the winner.
 func TestFoldFrameworkClassKinds_CanonRankBreaksEqualPriority(t *testing.T) {
 	for _, order := range [][]types.EntityRecord{
 		{cfFramework("Controller", "Probe", "a.py"), cfFramework("Model", "Probe", "a.py")},
 		{cfFramework("Model", "Probe", "a.py"), cfFramework("Controller", "Probe", "a.py")},
 	} {
-		recs := []types.EntityRecord{cfSource("Probe", "a.py")}
-		FoldFrameworkClassKinds(recs, order)
-		cfAssertRows(t, cfRows(recs), []string{"Model|Probe||a.py"})
+		out, _ := FoldFrameworkClassKinds([]types.EntityRecord{cfSource("Probe", "a.py")}, order)
+		cfAssertRows(t, cfRows(out), []string{"Model|Probe||a.py"})
 	}
 }
 
@@ -134,54 +190,127 @@ func TestFoldFrameworkClassKinds_CanonRankBreaksEqualPriority(t *testing.T) {
 // "TestClass" (priority 90, rank 0) must lose to "Controller" (priority 100,
 // rank 0) — and "Task" (priority 70) to "Schema" (priority 80, rank 3).
 func TestFoldFrameworkClassKinds_PriorityBeatsRank(t *testing.T) {
-	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
-	FoldFrameworkClassKinds(recs, []types.EntityRecord{
-		cfFramework("TestClass", "Probe", "a.py"),
-		cfFramework("Controller", "Probe", "a.py"),
-	})
-	cfAssertRows(t, cfRows(recs), []string{"Controller|Probe||a.py"})
+	out, _ := FoldFrameworkClassKinds([]types.EntityRecord{cfSource("Probe", "a.py")},
+		[]types.EntityRecord{
+			cfFramework("TestClass", "Probe", "a.py"),
+			cfFramework("Controller", "Probe", "a.py"),
+		})
+	cfAssertRows(t, cfRows(out), []string{"Controller|Probe||a.py"})
 
-	recs = []types.EntityRecord{cfSource("Probe", "a.py")}
-	FoldFrameworkClassKinds(recs, []types.EntityRecord{
-		cfFramework("Task", "Probe", "a.py"),
-		cfFramework("Schema", "Probe", "a.py"),
-	})
-	cfAssertRows(t, cfRows(recs), []string{"Schema|Probe||a.py"})
+	out, _ = FoldFrameworkClassKinds([]types.EntityRecord{cfSource("Probe", "a.py")},
+		[]types.EntityRecord{
+			cfFramework("Task", "Probe", "a.py"),
+			cfFramework("Schema", "Probe", "a.py"),
+		})
+	cfAssertRows(t, cfRows(out), []string{"Schema|Probe||a.py"})
 }
 
-// TestFoldFrameworkClassKinds_EdgesTheSourceOwnsMoveToSurvivor: the fold must
-// never drop an edge. The source's owned edges keep an empty FromID, which the
+// TestFoldFrameworkClassKinds_StartLineBreaksEqualKind exercises the third
+// tiebreak, which nothing else reaches: candidates of the SAME kind (so
+// priority and rank tie) where one carries no line at all. A line-less record is
+// the "no coordinates" case the #1613 fold was written for — it must lose to the
+// one that points at real source, whichever order they arrive in.
+func TestFoldFrameworkClassKinds_StartLineBreaksEqualKind(t *testing.T) {
+	mk := func(qn string, line int) types.EntityRecord {
+		r := cfFramework("Controller", "Probe", "a.py")
+		r.QualifiedName, r.StartLine = qn, line
+		return r
+	}
+	for _, order := range [][]types.EntityRecord{
+		{mk("lineless", 0), mk("real", 12), mk("later", 40)},
+		{mk("later", 40), mk("real", 12), mk("lineless", 0)},
+		{mk("real", 12), mk("later", 40), mk("lineless", 0)},
+	} {
+		out, _ := FoldFrameworkClassKinds(nil, order)
+		if len(out) != 1 {
+			t.Fatalf("want exactly one survivor, got %v", cfRows(out))
+		}
+		if out[0].QualifiedName != "real" || out[0].StartLine != 12 {
+			t.Errorf("survivor should be the smallest REAL start line: got qn=%q line=%d",
+				out[0].QualifiedName, out[0].StartLine)
+		}
+	}
+}
+
+// TestFoldFrameworkClassKinds_EdgesTheFoldedRecordOwnsMoveToSurvivor: the fold
+// must never drop an edge. Owned edges keep an empty FromID, which the
 // record→graph seam resolves to the OWNING record's id — so carrying them onto
-// the survivor is what re-homes them onto the typed node.
-func TestFoldFrameworkClassKinds_EdgesTheSourceOwnsMoveToSurvivor(t *testing.T) {
+// the survivor is what re-homes them.
+func TestFoldFrameworkClassKinds_EdgesTheFoldedRecordOwnsMoveToSurvivor(t *testing.T) {
 	src := cfSource("Probe", "a.py")
 	src.Relationships = []types.RelationshipRecord{{ToID: "Probe.m", Kind: "CONTAINS"}}
 	fwRec := cfFramework("Controller", "Probe", "a.py")
 	fwRec.Relationships = []types.RelationshipRecord{{ToID: "Other", Kind: "MOUNTS"}}
+	// A losing sibling's edges must survive the sibling fold too.
+	loser := cfFramework("TestClass", "Probe", "a.py")
+	loser.Relationships = []types.RelationshipRecord{{ToID: "Suite", Kind: "TESTS"}}
 
-	recs := []types.EntityRecord{src}
-	FoldFrameworkClassKinds(recs, []types.EntityRecord{fwRec})
-
+	out, _ := FoldFrameworkClassKinds([]types.EntityRecord{src}, []types.EntityRecord{fwRec, loser})
+	if len(out) != 1 {
+		t.Fatalf("want one surviving record, got %v", cfRows(out))
+	}
 	var kinds []string
-	for _, r := range recs[0].Relationships {
+	for _, r := range out[0].Relationships {
 		if r.FromID != "" {
 			t.Errorf("owned edge gained an explicit FromID %q — it would no longer bind to the survivor", r.FromID)
 		}
 		kinds = append(kinds, r.Kind+"→"+r.ToID)
 	}
 	sort.Strings(kinds)
-	cfAssertRows(t, kinds, []string{"CONTAINS→Probe.m", "MOUNTS→Other"})
+	cfAssertRows(t, kinds, []string{"CONTAINS→Probe.m", "MOUNTS→Other", "TESTS→Suite"})
+}
+
+// TestFoldFrameworkClassKinds_BlankKeyFieldsNeverPair pins the guard the
+// docstring claims rather than leaving it asserted-but-unenforced: a record with
+// no SourceFile (or no Name) is not keyable. Two unrelated records both keyed
+// {"",""} would otherwise collapse into one.
+func TestFoldFrameworkClassKinds_BlankKeyFieldsNeverPair(t *testing.T) {
+	fw := []types.EntityRecord{
+		{Kind: "Controller", Name: "Probe", SourceFile: ""},
+		{Kind: "Controller", Name: "", SourceFile: ""},
+	}
+	out, n := FoldFrameworkClassKinds(
+		[]types.EntityRecord{cfSource("Probe", ""), cfSource("", "")}, fw)
+	if n != 0 {
+		t.Errorf("folded %d records with blank key fields, want 0", n)
+	}
+	cfAssertRows(t, cfRows(out), []string{
+		"Controller|Probe||", "Controller|||",
+		"SCOPE.Component|Probe|class|", "SCOPE.Component||class|",
+	})
 }
 
 // TestFoldFrameworkClassKinds_NoInputsIsANoOp covers the guard clauses: no
-// records, or no framework records, must not panic and must not fold.
+// records at all must not panic, and either side alone must pass through.
 func TestFoldFrameworkClassKinds_NoInputsIsANoOp(t *testing.T) {
-	if n := FoldFrameworkClassKinds(nil, []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}); n != 0 {
-		t.Errorf("folded %d with no records", n)
+	out, n := FoldFrameworkClassKinds(nil, nil)
+	if n != 0 || len(out) != 0 {
+		t.Errorf("empty input produced folded=%d out=%v", n, cfRows(out))
 	}
-	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
-	if n := FoldFrameworkClassKinds(recs, nil); n != 0 {
+	out, n = FoldFrameworkClassKinds([]types.EntityRecord{cfSource("Probe", "a.py")}, nil)
+	if n != 0 {
 		t.Errorf("folded %d with no framework records", n)
 	}
-	cfAssertRows(t, cfRows(recs), []string{"SCOPE.Component|Probe|class|a.py"})
+	cfAssertRows(t, cfRows(out), []string{"SCOPE.Component|Probe|class|a.py"})
+}
+
+// TestFoldFrameworkClassKinds_CandidateThatIsAlsoAFoldSourceKeepsItself covers
+// the self-fold guard, which is reachable in exactly one shape: a
+// class-hierarchy SHADOW carrying an eligible framework kind is BOTH a survivor
+// candidate and a fold source. Without the guard it would be looked up, find
+// itself, and donate its own edges to itself — duplicating them.
+func TestFoldFrameworkClassKinds_CandidateThatIsAlsoAFoldSourceKeepsItself(t *testing.T) {
+	self := types.EntityRecord{
+		Kind: "Service", Name: "Probe", SourceFile: "a.py", StartLine: 4,
+		Properties:    map[string]string{"provenance": "INFERRED_FROM_CLASS_HIERARCHY"},
+		Relationships: []types.RelationshipRecord{{ToID: "Probe.m", Kind: "CONTAINS"}},
+	}
+	out, n := FoldFrameworkClassKinds([]types.EntityRecord{self}, nil)
+	if n != 0 {
+		t.Errorf("a record folded into itself: folded=%d", n)
+	}
+	cfAssertRows(t, cfRows(out), []string{"Service|Probe||a.py"})
+	if len(out) != 1 || len(out[0].Relationships) != 1 {
+		t.Errorf("owned edges duplicated by a self-fold: %+v", out)
+	}
 }

--- a/internal/engine/classfold_test.go
+++ b/internal/engine/classfold_test.go
@@ -1,0 +1,187 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// cfRows renders a record set as sorted "kind|name|subtype|file" content
+// tuples. Assertions below compare these sets WHOLE, in both directions: a
+// "the typed row is present" check passes while the generic row also survives
+// (two nodes for one class), and a "the generic row is gone" check passes on an
+// empty set.
+func cfRows(recs []types.EntityRecord) []string {
+	out := make([]string, 0, len(recs))
+	for i := range recs {
+		r := &recs[i]
+		out = append(out, r.Kind+"|"+r.Name+"|"+r.Subtype+"|"+r.SourceFile)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func cfAssertRows(t *testing.T, got, want []string) {
+	t.Helper()
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("record rows:\n  want %v\n  got  %v", want, got)
+	}
+}
+
+func cfSource(name, file string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind: "SCOPE.Component", Subtype: "class", Name: name, SourceFile: file,
+		QualifiedName: "m." + name, Language: "python", StartLine: 3, EndLine: 9,
+		Properties: map[string]string{"role": "class", "provenance": "INFERRED_FROM_CLASS_HIERARCHY"},
+	}
+}
+
+func cfFramework(kind, name, file string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind: kind, Name: name, SourceFile: file,
+		QualifiedName: "m." + name, Language: "python", StartLine: 3,
+		Properties: map[string]string{"framework": "python", "pattern_type": "yaml_driven"},
+	}
+}
+
+// TestFoldFrameworkClassKinds_TypedSurvivorReplacesGenericNode is the #6148
+// core: the generic class record becomes the framework-typed record.
+func TestFoldFrameworkClassKinds_TypedSurvivorReplacesGenericNode(t *testing.T) {
+	recs := []types.EntityRecord{
+		cfSource("Probe", "a.py"),
+		{Kind: "SCOPE.Operation", Subtype: "method", Name: "Probe.m", SourceFile: "a.py"},
+	}
+	fw := []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}
+
+	if n := FoldFrameworkClassKinds(recs, fw); n != 1 {
+		t.Errorf("folded %d records, want 1", n)
+	}
+	cfAssertRows(t, cfRows(recs), []string{
+		"Controller|Probe||a.py",
+		"SCOPE.Operation|Probe.m|method|a.py",
+	})
+
+	// The survivor is the framework record — including its EMPTY subtype, which
+	// the content-keyed parity comparator compares — carrying the properties the
+	// source had and it lacked, minus the source-describing ones.
+	sv := recs[0]
+	if sv.Properties["framework"] != "python" || sv.Properties["pattern_type"] != "yaml_driven" {
+		t.Errorf("survivor lost its own properties: %v", sv.Properties)
+	}
+	if got := sv.Properties["role"]; got != "class" {
+		t.Errorf("survivor should inherit the source property it lacks (role): %v", sv.Properties)
+	}
+	if _, ok := sv.Properties["provenance"]; ok {
+		t.Errorf("provenance describes the folded-away source and must not travel: %v", sv.Properties)
+	}
+}
+
+// TestFoldFrameworkClassKinds_NoCandidateLeavesGenericNode pins the other half:
+// a class no rule matches must stay generic. Without this, a fix that typed
+// every class would pass the test above and corrupt every unmatched class.
+func TestFoldFrameworkClassKinds_NoCandidateLeavesGenericNode(t *testing.T) {
+	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
+	before := cfRows(recs)
+
+	// Framework records that must NOT match: right name wrong file, right file
+	// wrong name, and a kind that is not class-declaration-strength at all.
+	fw := []types.EntityRecord{
+		cfFramework("Controller", "Probe", "other.py"),
+		cfFramework("Controller", "Other", "a.py"),
+		cfFramework("Route", "Probe", "a.py"),
+	}
+	if n := FoldFrameworkClassKinds(recs, fw); n != 0 {
+		t.Errorf("folded %d records, want 0", n)
+	}
+	cfAssertRows(t, cfRows(recs), before)
+}
+
+// TestFoldFrameworkClassKinds_NonClassRecordsUntouched: an operation, a file
+// component and an import placeholder are not class representations and must
+// survive verbatim even when a framework record shares their name.
+func TestFoldFrameworkClassKinds_NonClassRecordsUntouched(t *testing.T) {
+	recs := []types.EntityRecord{
+		{Kind: "SCOPE.Operation", Name: "Probe", SourceFile: "a.py"},
+		{Kind: "SCOPE.Component", Subtype: "file", Name: "Probe", SourceFile: "a.py"},
+		{Kind: "SCOPE.Component", Subtype: "import", Name: "Probe", SourceFile: "a.py"},
+	}
+	before := cfRows(recs)
+	if n := FoldFrameworkClassKinds(recs, []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}); n != 0 {
+		t.Errorf("folded %d records, want 0", n)
+	}
+	cfAssertRows(t, cfRows(recs), before)
+}
+
+// TestFoldFrameworkClassKinds_CanonRankBreaksEqualPriority reproduces the
+// #3172/#3195 double-emission: one class surfacing as BOTH Model and
+// Controller, equal priority. The structural-declaration kind must win, and
+// exactly ONE node must remain for the class.
+func TestFoldFrameworkClassKinds_CanonRankBreaksEqualPriority(t *testing.T) {
+	for _, order := range [][]types.EntityRecord{
+		{cfFramework("Controller", "Probe", "a.py"), cfFramework("Model", "Probe", "a.py")},
+		{cfFramework("Model", "Probe", "a.py"), cfFramework("Controller", "Probe", "a.py")},
+	} {
+		recs := []types.EntityRecord{cfSource("Probe", "a.py")}
+		FoldFrameworkClassKinds(recs, order)
+		cfAssertRows(t, cfRows(recs), []string{"Model|Probe||a.py"})
+	}
+}
+
+// TestFoldFrameworkClassKinds_PriorityBeatsRank guards the ordering of the two
+// tiebreakers: priority is primary, canonical rank only breaks an exact tie.
+// "TestClass" (priority 90, rank 0) must lose to "Controller" (priority 100,
+// rank 0) — and "Task" (priority 70) to "Schema" (priority 80, rank 3).
+func TestFoldFrameworkClassKinds_PriorityBeatsRank(t *testing.T) {
+	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
+	FoldFrameworkClassKinds(recs, []types.EntityRecord{
+		cfFramework("TestClass", "Probe", "a.py"),
+		cfFramework("Controller", "Probe", "a.py"),
+	})
+	cfAssertRows(t, cfRows(recs), []string{"Controller|Probe||a.py"})
+
+	recs = []types.EntityRecord{cfSource("Probe", "a.py")}
+	FoldFrameworkClassKinds(recs, []types.EntityRecord{
+		cfFramework("Task", "Probe", "a.py"),
+		cfFramework("Schema", "Probe", "a.py"),
+	})
+	cfAssertRows(t, cfRows(recs), []string{"Schema|Probe||a.py"})
+}
+
+// TestFoldFrameworkClassKinds_EdgesTheSourceOwnsMoveToSurvivor: the fold must
+// never drop an edge. The source's owned edges keep an empty FromID, which the
+// record→graph seam resolves to the OWNING record's id — so carrying them onto
+// the survivor is what re-homes them onto the typed node.
+func TestFoldFrameworkClassKinds_EdgesTheSourceOwnsMoveToSurvivor(t *testing.T) {
+	src := cfSource("Probe", "a.py")
+	src.Relationships = []types.RelationshipRecord{{ToID: "Probe.m", Kind: "CONTAINS"}}
+	fwRec := cfFramework("Controller", "Probe", "a.py")
+	fwRec.Relationships = []types.RelationshipRecord{{ToID: "Other", Kind: "MOUNTS"}}
+
+	recs := []types.EntityRecord{src}
+	FoldFrameworkClassKinds(recs, []types.EntityRecord{fwRec})
+
+	var kinds []string
+	for _, r := range recs[0].Relationships {
+		if r.FromID != "" {
+			t.Errorf("owned edge gained an explicit FromID %q — it would no longer bind to the survivor", r.FromID)
+		}
+		kinds = append(kinds, r.Kind+"→"+r.ToID)
+	}
+	sort.Strings(kinds)
+	cfAssertRows(t, kinds, []string{"CONTAINS→Probe.m", "MOUNTS→Other"})
+}
+
+// TestFoldFrameworkClassKinds_NoInputsIsANoOp covers the guard clauses: no
+// records, or no framework records, must not panic and must not fold.
+func TestFoldFrameworkClassKinds_NoInputsIsANoOp(t *testing.T) {
+	if n := FoldFrameworkClassKinds(nil, []types.EntityRecord{cfFramework("Controller", "Probe", "a.py")}); n != 0 {
+		t.Errorf("folded %d with no records", n)
+	}
+	recs := []types.EntityRecord{cfSource("Probe", "a.py")}
+	if n := FoldFrameworkClassKinds(recs, nil); n != 0 {
+		t.Errorf("folded %d with no framework records", n)
+	}
+	cfAssertRows(t, cfRows(recs), []string{"SCOPE.Component|Probe|class|a.py"})
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -164,13 +164,32 @@ func StampFile(absPath string) (FileStamp, error) {
 }
 
 // frameworkDetectorOnce guards the one-time load of the embedded YAML rule sets
-// used to type class records on re-extraction (#6148).
+// Pass 2.5 applies to every re-extracted file (#6148, #6150).
 //
 // The rules are compiled into the binary (engine.LoadAllRules reads an embedded
 // FS) and are not repo-scoped, so one Detector serves every incremental run in
-// the process; engine.Detector is documented safe for concurrent use. Loading
-// per call would repeat a whole-tree YAML parse on the daemon's hot path for a
-// result that cannot differ between calls.
+// the process; engine.Detector is documented safe for concurrent use.
+//
+// COST, measured here (go test -bench, GOMAXPROCS=4, 40-declaration file):
+//
+//	LoadAllRules + New   15.6 ms, 11.6 MiB   ONCE per process
+//	Detect, python file   8.7 ms,  0.7 MiB   per CHANGED file
+//
+// The per-file number is the real one and it is not small next to the language
+// extractor. It is NOT avoidable by guarding on "does this file declare a
+// class": Detect's output is also consumed for the framework entities that pair
+// with no extractor record at all — a Route from a responder method, a Service
+// from an app object — so a file with no class-like declaration is precisely a
+// file whose Detect output would be silently dropped again (#6150). What bounds
+// it instead is that this runs per CHANGED file, not per repo file, and the
+// changed set is already capped by the incremental trigger limit; a full rebuild
+// pays the same 8.7 ms for every file in the repo.
+//
+// The once is deliberately not retried. The rules are embedded, so a load
+// failure is a build-level defect with no transient component, and retrying
+// would re-pay 15.6 ms per file to fail identically. It is logged with its
+// consequence spelled out, because the graph is otherwise silently the
+// pre-#6148 shape until the process restarts.
 var (
 	frameworkDetectorOnce sync.Once
 	frameworkDetectorInst *engine.Detector
@@ -178,13 +197,21 @@ var (
 
 // frameworkDetector returns the shared Detector, or nil if the embedded rules
 // failed to load. A nil return degrades this path to its pre-#6148 behaviour
-// (classes stay generic) rather than failing the incremental run: the rules are
-// an enrichment input, not a correctness precondition for re-extraction.
-func frameworkDetector() *engine.Detector {
+// (classes keep their generic kind, framework-only entities are not emitted)
+// rather than failing the incremental run: the rules are an enrichment input,
+// not a correctness precondition for re-extraction.
+//
+// It is a var so a test can drive that degraded path. Nothing else assigns it —
+// the #6129 parity gate catches the rules being IGNORED, but nothing else
+// asserted that LOSING them degrades instead of panicking.
+var frameworkDetector = func() *engine.Detector {
 	frameworkDetectorOnce.Do(func() {
 		rules, err := engine.LoadAllRules()
 		if err != nil {
-			log.Printf("incremental: load engine rules: %v — class records will keep their generic kind", err)
+			log.Printf("incremental: FRAMEWORK RULES UNAVAILABLE: %v — "+
+				"every incremental run in this process will leave class entities at their "+
+				"generic kind and drop framework-only entities, diverging from a full rebuild "+
+				"until the process is restarted", err)
 			return
 		}
 		frameworkDetectorInst = engine.New(rules)
@@ -544,29 +571,40 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			// Non-fatal: use partial results.
 		}
 
-		// #6148 — type the class records this file declares.
+		// #6148 / #6150 — run Pass 2.5 over this file and reconcile it with the
+		// extractor's records.
 		//
 		// The per-language extractor emits every class as a generic
-		// SCOPE.Component. On the full path Pass 2.5 (engine.Detector over the
-		// YAML rule sets) emits a framework-typed record — Controller / Model /
-		// View / Service / … — for the same symbol, and the #1613 fold collapses
-		// the generic node into it, so a full rebuild's graph carries ONE typed
-		// node per class. This path ran the extractor alone, so a class in a
-		// CHANGED file kept the generic kind while the identical class in an
-		// unchanged file kept the typed kind it was carried forward with — the
-		// same tree, two answers, depending only on which files the delta
-		// touched. Entity IDs hash the kind, so the divergence also moved every
-		// edge incident on the class.
+		// SCOPE.Component, and emits nothing at all for a framework construct
+		// that is not a language declaration. On the full path Pass 2.5
+		// (engine.Detector over the YAML rule sets) supplies both: a
+		// framework-typed record — Controller / Model / View / Service / … — for
+		// each class symbol a rule matches, which the #1613 fold collapses the
+		// generic node into, plus standalone records for the constructs that have
+		// no declaration behind them (a Route from a responder method, a Service
+		// from an app object).
 		//
-		// The fold is keyed by (source_file, name) and so never pairs records
-		// across files; applying it per re-extracted file is the whole of it.
+		// This path ran the extractor alone. A class in a CHANGED file therefore
+		// kept the generic kind while the identical class in an unchanged file
+		// kept the typed kind it was carried forward with — the same tree, two
+		// answers, decided only by which files the delta touched — and the
+		// framework-only records were dropped outright. Entity ids hash the kind,
+		// so the class divergence moved every edge incident on it too.
+		//
+		// The fold is keyed by (source_file, name) and never pairs records across
+		// files, so applying it per re-extracted file is the whole of it.
+		//
+		// Detect's standalone RELATIONSHIPS are deliberately NOT consumed here.
+		// Measured: they arrive as structural name refs the full path binds in a
+		// resolver pass this path does not run, so emitting them landed unbound
+		// endpoints and duplicate DEPENDS_ON rows — strictly worse than the gap.
 		if det := frameworkDetector(); det != nil {
 			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
 				logger.Printf("incremental: framework detect %s: %v", rel, dErr)
 			} else if fwRes != nil {
-				if n := engine.FoldFrameworkClassKinds(records, fwRes.Entities); n > 0 {
-					classKindFolds += n
-				}
+				var n int
+				records, n = engine.FoldFrameworkClassKinds(records, fwRes.Entities)
+				classKindFolds += n
 			}
 		}
 

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -63,6 +63,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/classifier"
@@ -160,6 +161,35 @@ func StampFile(absPath string) (FileStamp, error) {
 		ContentHash: hex.EncodeToString(h.Sum(nil)),
 		Mtime:       info.ModTime().UnixNano(),
 	}, nil
+}
+
+// frameworkDetectorOnce guards the one-time load of the embedded YAML rule sets
+// used to type class records on re-extraction (#6148).
+//
+// The rules are compiled into the binary (engine.LoadAllRules reads an embedded
+// FS) and are not repo-scoped, so one Detector serves every incremental run in
+// the process; engine.Detector is documented safe for concurrent use. Loading
+// per call would repeat a whole-tree YAML parse on the daemon's hot path for a
+// result that cannot differ between calls.
+var (
+	frameworkDetectorOnce sync.Once
+	frameworkDetectorInst *engine.Detector
+)
+
+// frameworkDetector returns the shared Detector, or nil if the embedded rules
+// failed to load. A nil return degrades this path to its pre-#6148 behaviour
+// (classes stay generic) rather than failing the incremental run: the rules are
+// an enrichment input, not a correctness precondition for re-extraction.
+func frameworkDetector() *engine.Detector {
+	frameworkDetectorOnce.Do(func() {
+		rules, err := engine.LoadAllRules()
+		if err != nil {
+			log.Printf("incremental: load engine rules: %v — class records will keep their generic kind", err)
+			return
+		}
+		frameworkDetectorInst = engine.New(rules)
+	})
+	return frameworkDetectorInst
 }
 
 // TryIncremental attempts a file-level incremental reindex for repoPath.
@@ -471,6 +501,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	var newEntities []graph.Entity
 	var newRels []graph.Relationship
+	// #6148 — count of generic class records re-typed from the YAML rule sets,
+	// logged with the run so a silent regression to zero is visible.
+	classKindFolds := 0
 	// #6094 — one identity per (FromID, ToID, Kind), shared across every file in
 	// this re-extraction batch. See convertExtractedRecords for why the triple is
 	// a safe identity here and how this scope differs from buildDocument's.
@@ -498,16 +531,43 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			continue
 		}
 
-		records, extErr := ext.Extract(ctx, extractor.FileInput{
+		input := extractor.FileInput{
 			Path:     rel,
 			Content:  content,
 			Language: cr.Language,
 			TSTree:   nil, // re-parse inline
 			RepoRoot: absRepo,
-		})
+		}
+		records, extErr := ext.Extract(ctx, input)
 		if extErr != nil {
 			logger.Printf("incremental: extract %s: %v", rel, extErr)
 			// Non-fatal: use partial results.
+		}
+
+		// #6148 — type the class records this file declares.
+		//
+		// The per-language extractor emits every class as a generic
+		// SCOPE.Component. On the full path Pass 2.5 (engine.Detector over the
+		// YAML rule sets) emits a framework-typed record — Controller / Model /
+		// View / Service / … — for the same symbol, and the #1613 fold collapses
+		// the generic node into it, so a full rebuild's graph carries ONE typed
+		// node per class. This path ran the extractor alone, so a class in a
+		// CHANGED file kept the generic kind while the identical class in an
+		// unchanged file kept the typed kind it was carried forward with — the
+		// same tree, two answers, depending only on which files the delta
+		// touched. Entity IDs hash the kind, so the divergence also moved every
+		// edge incident on the class.
+		//
+		// The fold is keyed by (source_file, name) and so never pairs records
+		// across files; applying it per re-extracted file is the whole of it.
+		if det := frameworkDetector(); det != nil {
+			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
+				logger.Printf("incremental: framework detect %s: %v", rel, dErr)
+			} else if fwRes != nil {
+				if n := engine.FoldFrameworkClassKinds(records, fwRes.Entities); n > 0 {
+					classKindFolds += n
+				}
+			}
 		}
 
 		// Convert types.EntityRecord → graph.Entity (same logic as buildDocument).
@@ -769,8 +829,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	dur := time.Since(t0)
-	logger.Printf("incremental: done changed=%d entities=%d rels=%d flows_recomputed=%t took=%s",
-		len(reallyChanged), len(newEntities), len(newRels), flowsRecomputed, dur.Truncate(time.Millisecond))
+	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d flows_recomputed=%t took=%s",
+		len(reallyChanged), len(newEntities), len(newRels), classKindFolds, flowsRecomputed, dur.Truncate(time.Millisecond))
 
 	return Result{
 		Done:         true,

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -562,7 +562,14 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			Path:     rel,
 			Content:  content,
 			Language: cr.Language,
-			TSTree:   nil, // re-parse inline
+			// #6151 — "re-parse inline" is what this was MEANT to do and is not
+			// what happens: nothing between here and the extractor parses, and 17
+			// extractors (kotlin, java, javascript, ruby, rust, php, swift, …)
+			// return no records at all on a nil tree. Step 5 has already evicted
+			// the file's entities by then, so an incremental pass over one of
+			// those languages DELETES them. Python is unaffected, which is why
+			// every fixture in this package and in the #6129 gate is green.
+			TSTree:   nil,
 			RepoRoot: absRepo,
 		}
 		records, extErr := ext.Extract(ctx, input)

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -176,14 +176,27 @@ func StampFile(absPath string) (FileStamp, error) {
 //	Detect, python file   8.7 ms,  0.7 MiB   per CHANGED file
 //
 // The per-file number is the real one and it is not small next to the language
-// extractor. It is NOT avoidable by guarding on "does this file declare a
-// class": Detect's output is also consumed for the framework entities that pair
-// with no extractor record at all — a Route from a responder method, a Service
-// from an app object — so a file with no class-like declaration is precisely a
-// file whose Detect output would be silently dropped again (#6150). What bounds
-// it instead is that this runs per CHANGED file, not per repo file, and the
-// changed set is already capped by the incremental trigger limit; a full rebuild
-// pays the same 8.7 ms for every file in the repo.
+// extractor. Three things bound it, and none of them is a guard that could be
+// added later:
+//
+//   - It is NOT avoidable by pre-checking "does this file declare a class".
+//     Detect's output is also consumed for framework entities that pair with no
+//     extractor record at all, and `app = falcon.App()` alone — a line with no
+//     class anywhere near it — yields BOTH a Service and a Config record. A file
+//     with no class-like declaration is therefore precisely a file whose Detect
+//     output such a guard would silently drop again (#6150).
+//   - "Only run Detect for languages that have rules" is not a missing
+//     mitigation: Detector.Detect already early-outs on an unknown language
+//     before it touches the content (detector.go, the `sets, ok :=
+//     d.compiled[file.Language]` branch). Those languages pay ~0, not 8.7 ms.
+//   - The worst case is a fixed number, not a repo-sized one. This runs per
+//     CHANGED file, and the changed set is hard-capped by the trigger limits
+//     below — defaultIncrementalFiles=20, mainBranchIncrementalFiles=50 — so the
+//     ceiling is 50 × 8.7 ms ≈ 435 ms per run. Above the cap the path falls back
+//     to a full rebuild, which pays the same 8.7 ms for every file in the repo.
+//
+// Content-hash caching across runs would buy nothing: Step 3's AST-hash gate has
+// already established that every file reaching here has changed content.
 //
 // The once is deliberately not retried. The rules are embedded, so a load
 // failure is a build-level defect with no transient component, and retrying
@@ -563,12 +576,23 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			Content:  content,
 			Language: cr.Language,
 			// #6151 — "re-parse inline" is what this was MEANT to do and is not
-			// what happens: nothing between here and the extractor parses, and 17
-			// extractors (kotlin, java, javascript, ruby, rust, php, swift, …)
-			// return no records at all on a nil tree. Step 5 has already evicted
-			// the file's entities by then, so an incremental pass over one of
-			// those languages DELETES them. Python is unaffected, which is why
-			// every fixture in this package and in the #6129 gate is green.
+			// what happens: nothing between here and the extractor parses.
+			//
+			// Audited across all 69 Extract implementations: 14 return nil, nil
+			// unconditionally on a nil tree (csharp, dockerfile, elixir, groovy,
+			// java, javascript/typescript, kotlin, lua, php, proto, ruby, rust,
+			// scala, swift), 7 self-parse from Content, 35 are pure source
+			// scanners that never wanted a tree, and 0 panic. Step 5 has already
+			// evicted the file's entities ~65 lines above, and no fallback() site
+			// is record-count driven, so an incremental pass over one of those 14
+			// languages DELETES that file's entities and re-adds nothing — with
+			// Done=true and no fallback. Measured on Kotlin, JS, Java and Ruby.
+			//
+			// The reason no fixture catches it is NOT that they are Python: they
+			// are mostly Go. It is that Python AND Go both self-parse from Content
+			// (golang/extractor.go), so both are blind to this by construction.
+			// A fixture in any of the 14 languages above would fail immediately —
+			// which is the thing to know before adding one.
 			TSTree:   nil,
 			RepoRoot: absRepo,
 		}
@@ -605,6 +629,15 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// Measured: they arrive as structural name refs the full path binds in a
 		// resolver pass this path does not run, so emitting them landed unbound
 		// endpoints and duplicate DEPENDS_ON rows — strictly worse than the gap.
+		//
+		// That exclusion is a RESIDUAL, and it is untested: the committed parity
+		// fixture produces zero standalone framework relationships, so the gate is
+		// blind to this either way. Reaching it needs a relationship_rule match in
+		// the delta (falcon's REGISTERED_ON fires on `app.add_route(...)`), and
+		// that same line drags in the flow/endpoint-enrichment divergences that
+		// are the rest of #6150's scope — which is why it is recorded here rather
+		// than half-covered by a fixture that would need allow entries for four
+		// other defects to stay green.
 		if det := frameworkDetector(); det != nil {
 			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
 				logger.Printf("incremental: framework detect %s: %v", rel, dErr)

--- a/internal/extractors/incremental_class_kind_6148_test.go
+++ b/internal/extractors/incremental_class_kind_6148_test.go
@@ -28,25 +28,32 @@ import (
 	"github.com/cajasmota/grafel/internal/graph"
 )
 
-// ckProbeSource is the minimum case from #6148: a class with no decorator, no
-// base class, no route annotation and no naming convention — nothing that
-// should attract any particular classification on either path. What it gets is
-// beside the point; the two paths must agree on it.
+// ckProbeSource carries both halves of what Pass 2.5 produces for one file:
+//
+//   - CkPlainProbe — a class with no decorator and no base class. What kind it
+//     gets is beside the point; the two paths must agree on it (#6148).
+//   - the `on_get` responder and `ck_app = falcon.App()` — framework records
+//     that pair with NO extractor record, so nothing folds them and the class
+//     fold alone would still leave them dropped (#6150).
 const ckProbeSource = `def ck_handle(x):
     return x + 1
 
 
 class CkPlainProbe:
-    def ck_probe_noop(self):
+    def on_get(self, req, resp):
         return 1
+
+
+ck_app = falcon.App()
 `
 
-// ckExpectedClassKind asks the SAME oracle the full rebuild's Pass 2.5 asks —
-// engine.Detector over the embedded YAML rules — what kind this class symbol
-// carries. Hard-coding the answer would pin today's rule set rather than the
-// invariant under test (the two paths agree), and would go stale the moment a
-// rule changes.
-func ckExpectedClassKind(t *testing.T, path, src string) string {
+// ckDetect is the ORACLE: the same engine.Detector over the same embedded YAML
+// rules that the full rebuild's Pass 2.5 runs. Every expectation below is
+// derived from it rather than hard-coded, so this file pins the invariant (the
+// two paths agree) instead of pinning today's rule set — which would go stale
+// the moment a rule changes, in a test that would then be asserting the wrong
+// thing while still passing.
+func ckDetect(t *testing.T, path, src string) *engine.DetectResult {
 	t.Helper()
 	rules, err := engine.LoadAllRules()
 	if err != nil {
@@ -60,6 +67,13 @@ func ckExpectedClassKind(t *testing.T, path, src string) string {
 	if err != nil || res == nil {
 		t.Fatalf("detect: %v", err)
 	}
+	return res
+}
+
+// ckExpectedClassKind asks the oracle what kind this class symbol carries.
+func ckExpectedClassKind(t *testing.T, path, src string) string {
+	t.Helper()
+	res := ckDetect(t, path, src)
 	var best string
 	for i := range res.Entities {
 		e := &res.Entities[i]
@@ -146,4 +160,69 @@ func TestIncremental_ClassInChangedFile_CarriesFrameworkKind_6148(t *testing.T) 
 			"rules) and folds the generic AST node into it; the incremental path must reach "+
 			"the same kind for the class it re-extracted.", want, got)
 	}
+
+	// #6150 — the other half of Pass 2.5's output. `ck_app = falcon.App()` and
+	// the `on_get` responder produce framework records that pair with NO
+	// extractor record at all, so the class fold alone would leave them dropped:
+	// a full rebuild carries them and this path did not. Asserted as a SET, both
+	// directions, against the same oracle rather than a hard-coded kind list.
+	wantFW := ckFrameworkOnlyRows(t, "ckhandler.py", ckProbeSource)
+	if len(wantFW) == 0 {
+		t.Fatal("fixture no longer reaches any framework-only record — the rules that matched " +
+			"the app object / responder changed, and this assertion has gone vacuous")
+	}
+	gotFW := ckRowsFor(t, stateDir, "ckhandler.py", wantFW)
+	if strings.Join(gotFW, ",") != strings.Join(wantFW, ",") {
+		t.Errorf("framework-only rows after incremental re-extraction:\n  want %v\n  got  %v\n"+
+			"Pass 2.5 emits these on a full rebuild; the incremental path must emit them too.",
+			wantFW, gotFW)
+	}
+}
+
+// ckFrameworkOnlyRows asks the oracle which Detect records for this file pair
+// with no extractor record — the ones whose only source is Pass 2.5.
+func ckFrameworkOnlyRows(t *testing.T, path, src string) []string {
+	t.Helper()
+	res := ckDetect(t, path, src)
+	var out []string
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		// The class itself is covered by the fold assertion above; here we want
+		// only the records that have no counterpart in the extractor's output.
+		if e.Name == "CkPlainProbe" {
+			continue
+		}
+		out = append(out, e.Kind+"|"+e.Name+"|"+path)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// ckRowsFor returns the graph's rows for path whose KIND is one the oracle
+// emitted — not merely the rows the oracle predicted. Keying on the kind
+// vocabulary rather than on the wanted rows themselves is what makes the
+// comparison bidirectional: a row INVENTED under one of those kinds shows up as
+// an extra element, where a containment check would miss it. It is bounded, and
+// deliberately so: an invention under an unrelated kind is the #6129 parity
+// gate's job, not this test's.
+func ckRowsFor(t *testing.T, stateDir, path string, oracle []string) []string {
+	t.Helper()
+	kinds := make(map[string]bool, len(oracle))
+	for _, row := range oracle {
+		kinds[strings.SplitN(row, "|", 2)[0]] = true
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	var out []string
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.SourceFile != path || !kinds[e.Kind] || e.Name == "CkPlainProbe" {
+			continue
+		}
+		out = append(out, e.Kind+"|"+e.Name+"|"+e.SourceFile)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/extractors/incremental_class_kind_6148_test.go
+++ b/internal/extractors/incremental_class_kind_6148_test.go
@@ -1,0 +1,149 @@
+// Package extractors_test — #6148.
+//
+// A class that arrives in a CHANGED file must end up carrying the same KIND the
+// full rebuild gives it.
+//
+// The full path types class symbols in Pass 2.5 (engine.Detector over the YAML
+// rule sets) and then folds the per-language AST's generic SCOPE.Component node
+// into that framework-typed record (#1613). The incremental path re-extracts a
+// changed file with the per-language extractor ONLY, so before this change the
+// class kept the generic kind and a full rebuild of the same tree disagreed.
+//
+// Classes in UNCHANGED files never showed it: those entities are carried
+// forward from the previous full rebuild's graph with the typed kind already on
+// them. Only a class the incremental path actually re-extracts diverges — which
+// is why the #6129 parity gate, whose fixture had never put a class in its
+// delta file, stayed green throughout.
+package extractors_test
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// ckProbeSource is the minimum case from #6148: a class with no decorator, no
+// base class, no route annotation and no naming convention — nothing that
+// should attract any particular classification on either path. What it gets is
+// beside the point; the two paths must agree on it.
+const ckProbeSource = `def ck_handle(x):
+    return x + 1
+
+
+class CkPlainProbe:
+    def ck_probe_noop(self):
+        return 1
+`
+
+// ckExpectedClassKind asks the SAME oracle the full rebuild's Pass 2.5 asks —
+// engine.Detector over the embedded YAML rules — what kind this class symbol
+// carries. Hard-coding the answer would pin today's rule set rather than the
+// invariant under test (the two paths agree), and would go stale the moment a
+// rule changes.
+func ckExpectedClassKind(t *testing.T, path, src string) string {
+	t.Helper()
+	rules, err := engine.LoadAllRules()
+	if err != nil {
+		t.Fatalf("load engine rules: %v", err)
+	}
+	res, err := engine.New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "python",
+		Content:  []byte(src),
+	})
+	if err != nil || res == nil {
+		t.Fatalf("detect: %v", err)
+	}
+	var best string
+	for i := range res.Entities {
+		e := &res.Entities[i]
+		if e.Name != "CkPlainProbe" {
+			continue
+		}
+		if _, eligible := engine.FrameworkClassKindPriority[e.Kind]; !eligible {
+			continue
+		}
+		if best == "" ||
+			engine.FrameworkClassKindPriority[e.Kind] > engine.FrameworkClassKindPriority[best] {
+			best = e.Kind
+		}
+	}
+	if best == "" {
+		t.Fatalf("fixture no longer reaches a framework-typed class kind — the rule set that " +
+			"typed a bare Python class changed, so this test can no longer distinguish the two paths")
+	}
+	return best
+}
+
+// ckClassRows returns every entity row for the probe class as a content tuple
+// (kind|name|source_file), sorted. Content, not ids: the id is a hash OF the
+// kind, so an id-keyed assertion would report a re-kinded entity as "a
+// different entity" without ever naming the kind that changed.
+func ckClassRows(t *testing.T, stateDir string) []string {
+	t.Helper()
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	var out []string
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Name != "CkPlainProbe" {
+			continue
+		}
+		out = append(out, e.Kind+"|"+e.Name+"|"+e.SourceFile)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestIncremental_ClassInChangedFile_CarriesFrameworkKind_6148 is the gate.
+//
+// The assertion is BIDIRECTIONAL over the content rows for the class symbol:
+// the expected row must be present AND nothing else may be. A one-directional
+// "the typed row exists" check would pass while the generic row also survived —
+// two nodes for one class, the #1613 invariant broken — and a one-directional
+// "the generic row is gone" check would pass on an empty graph.
+func TestIncremental_ClassInChangedFile_CarriesFrameworkKind_6148(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	// Baseline: the same file WITHOUT the class.
+	writeFile(t, repo, "ckhandler.py", "def ck_handle(x):\n    return x\n")
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{
+			ID:         graph.EntityID("test-repo", "SCOPE.Operation", "ck_handle", "ckhandler.py"),
+			Name:       "ck_handle",
+			Kind:       "SCOPE.Operation",
+			SourceFile: "ckhandler.py",
+			Language:   "python",
+		},
+	}, nil)
+	seedManifest(t, repo, stateDir)
+
+	// The delta: the class appears.
+	writeFile(t, repo, "ckhandler.py", ckProbeSource)
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("TryIncremental fell back to a full reindex (%s) — the run under test never "+
+			"happened, and a full-reindex fallback would trivially satisfy this assertion",
+			res.FallbackReason)
+	}
+
+	want := []string{ckExpectedClassKind(t, "ckhandler.py", ckProbeSource) + "|CkPlainProbe|ckhandler.py"}
+	got := ckClassRows(t, stateDir)
+
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("class rows after incremental re-extraction:\n  want %v\n  got  %v\n"+
+			"The full rebuild types this class via Pass 2.5 (engine.Detector over the YAML "+
+			"rules) and folds the generic AST node into it; the incremental path must reach "+
+			"the same kind for the class it re-extracted.", want, got)
+	}
+}

--- a/internal/extractors/incremental_degraded_6148_test.go
+++ b/internal/extractors/incremental_degraded_6148_test.go
@@ -1,0 +1,110 @@
+// Package extractors — #6148 degraded-path coverage.
+//
+// This file is IN-PACKAGE (the rest of the incremental tests are
+// `extractors_test`) for one reason: `frameworkDetector` is unexported, and the
+// behaviour under test is what happens when it returns nil — the embedded YAML
+// rule sets failed to load.
+//
+// Nothing else asserts this. The #6129 parity gate notices the rules being
+// wired away (that is the whole point of it), but "the rules are GONE" and "the
+// rules are ignored" are different failures: the first must degrade to the
+// pre-#6148 graph shape, quietly and without panicking, and the second must
+// fail the gate. Only the second was covered.
+package extractors
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/engine"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// dgWrite writes one file under repo, creating parents.
+func dgWrite(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// dgSeed writes a one-entity baseline graph plus a manifest matching the repo's
+// current contents, which is what makes the next TryIncremental a real
+// incremental run rather than a fallback.
+func dgSeed(t *testing.T, repo, stateDir string, ents []graph.Entity) {
+	t.Helper()
+	doc := &graph.Document{
+		Version: graph.SchemaVersion, GeneratedAt: time.Now().UTC(), Repo: "test-repo",
+		Entities: ents, Stats: graph.Stats{Entities: len(ents)},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	var paths []string
+	_ = filepath.WalkDir(repo, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(repo, path)
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, paths, m)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+}
+
+// TestIncremental_FrameworkRulesUnavailable_DegradesNotPanics_6148 pins the
+// contract of a nil detector: the run still completes, the file's entities are
+// still re-extracted, and the class simply keeps its generic kind. The rules are
+// an enrichment input, not a precondition for re-extraction — losing them must
+// not cost the caller its graph.
+func TestIncremental_FrameworkRulesUnavailable_DegradesNotPanics_6148(t *testing.T) {
+	prev := frameworkDetector
+	frameworkDetector = func() *engine.Detector { return nil }
+	t.Cleanup(func() { frameworkDetector = prev })
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	dgWrite(t, repo, "dghandler.py", "def dg_handle(x):\n    return x\n")
+	dgSeed(t, repo, stateDir, []graph.Entity{{
+		ID:         graph.EntityID("test-repo", "SCOPE.Operation", "dg_handle", "dghandler.py"),
+		Name:       "dg_handle",
+		Kind:       "SCOPE.Operation",
+		SourceFile: "dghandler.py",
+		Language:   "python",
+	}})
+	dgWrite(t, repo, "dghandler.py", "def dg_handle(x):\n    return x\n\n\nclass DgProbe:\n    def m(self):\n        return 1\n")
+
+	res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("a nil detector must not cost the run: fell back with %q", res.FallbackReason)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	var kinds []string
+	for i := range doc.Entities {
+		if doc.Entities[i].Name == "DgProbe" {
+			kinds = append(kinds, doc.Entities[i].Kind)
+		}
+	}
+	// Exactly one node for the class, carrying the pre-#6148 generic kind. Not
+	// zero (the re-extraction must still have happened) and not two.
+	if len(kinds) != 1 || kinds[0] != "SCOPE.Component" {
+		t.Errorf("degraded run: want exactly [SCOPE.Component] for the class, got %v", kinds)
+	}
+}


### PR DESCRIPTION
Adding **any** class to the #6129 parity fixture's delta file made the two paths disagree: full rebuild says `Controller`, incremental says `SCOPE.Component`, plus four spurious `CONTAINS` divergences.

## Root cause: the incremental path never ran the framework classifier at all

Not a stale carried-forward signal — never computed on re-extraction.

- **Full rebuild Pass 2.5** (`cmd/grafel/index.go:3738`) calls `i.detector.Detect`. `internal/engine/rules/python/frameworks/{falcon,cherrypy}.yaml` carry an **ungated** `class\s+(\w+)...` → `entity_type: Controller`. The #1613 class-shadow fold (`index.go:4348`) then collapses the extractor's generic `SCOPE.Component/class` into the typed record, so the framework record's Kind, Subtype, Signature, qualified name and span are what survive.
- **Incremental Path A step 6** (`internal/extractors/incremental.go:501`) called `ext.Extract` and nothing else.
- Static-file classes agreed only because they were carried forward already-typed from the baseline.
- The four `CONTAINS` divergences are not a second defect: `graph.EntityID` hashes the kind, so re-kinding moves the entity id and every incident edge follows.

Path B was green throughout and remains so — it goes through `Index()`, which runs Pass 2.5.

## What the fix does

`internal/engine/classfold.go` — the fold vocabulary (`FrameworkClassKindPriority`, `FrameworkClassKindCanonRank`, `ClassLikeComponentSubtypes`, `IsClassHierarchyShadow`, `IsClassFoldSource`) **moved verbatim** out of package main so both paths read one table; `index.go` keeps aliases, so every existing reference and test still resolves. Reviewed as byte-identical modulo rename, with no divergent copy and no writer anywhere.

`incremental.go` runs a `sync.Once`-memoized `engine.Detector` per re-extracted file, applies the fold, and logs `class_kind_folds=N`. A rule-load failure degrades to the old behaviour rather than failing the run.

## The residual was 6 of 7, and the fixture was dodging it

Review measured the real gap end-to-end: on a changed Falcon file the full rebuild yields **10** entities and incremental **4**. Still dropped were every `http_endpoint_definition`, every `Route`, the `SCOPE.Process` flow node, `Config|App()` and `Service|app`. The first cut recovered exactly one — the class fold — while paying the entire `Detect` cost.

Worse: the gate fixture reached `Controller|CpPlainProbe` **only** because its probe method was named `cp_probe_noop` with no app object. Choosing fixture content that avoids a known divergence is functionally an allow-list entry with no filed issue, and **the stale-entry ratchet structurally cannot detect it.**

So the fixture now declares `on_get(self, req, resp)` and `cp_app = falcon.App()` — the shape it was avoiding — and the non-class Detect output is consumed. Measured on that fixture: **3 ENTITY-LOST + 3 EDGE-LOST before, zero after, no allow entries added.** Verified in review by reverting this half against the new fixture and reproducing exactly those six rows. Allow list: **11 entries at base, 11 at HEAD**, one changed line, nothing added or widened. #6150 closed.

## Two exclusions, both measured rather than assumed

**Detect's standalone relationships** are not consumed. Emitting them made things worse — `«unbound»Controller:CpPlainProbe→«unbound»Service:cp_app:REGISTERED_ON` plus duplicate `DEPENDS_ON` rows — because they arrive as `Kind:Name` structural refs bound by a resolver pass this path does not run. Recorded at the site with the measurement, including that the committed fixture produces zero of them, so the gate is blind either way.

**The deeper Falcon shape** (`import falcon` + `add_route`) is declined. Review measured **12 divergences with ≥6 distinct causes** — the missing `REGISTERED_ON`, an import-binding split, an absent `SCOPE.Process` flow entity with four dependent edges, `http_endpoint_definition` attribution drift, a lost `IMPLEMENTS`, and the #6098-family `DEPENDS_ON weight 5≠3`. Allow-listing that under #6150 would have buried five unrelated defects.

## The candidate set — a docstring that claimed a losslessness the code lacked

The full path indexes fold candidates from **all of `merged`**, including framework-typed records the *language extractors themselves* emit (`kotlin/kotlin.go:812-819` emits `SCOPE.Service` with the same Name and SourceFile — the #1700 case the priority table's own comment cites; also proto, razor, cobol, fsharp, elm). The first cut indexed only Detect's output, leaving **two nodes for one class** and violating the #1613 invariant the fold exists to enforce.

Now a faithful port of **both** full-path loops — sibling-survivor collapse, then fold-source — with candidates from `recs ∪ fw`. The docstring is corrected: lossless on the **file axis only**. Review confirmed per-file folding is genuinely equivalent on that axis (`bySymbol` keys on `[2]string{SourceFile, Name}`; no path pairs two files).

## Cost: bounded, with the number

`LoadAllRules+New` costs 15.6 ms and ~11.6 MiB **once per process**. `Detect` costs ~8.7 ms per re-extracted Python file — a real +191% on extraction.

A guard skipping `Detect` for files with no class-like declaration was proposed and **refused as unsound**: `cp_app = falcon.App()`, a line with no class near it, yields both a `Service` and a `Config` record, so the pre-check demonstrably drops output. The bound is structural instead: `detector.go:269-270` already early-outs for languages with no compiled rules (they pay ~0), and the changed set is capped at `defaultIncrementalFiles = 20` / `mainBranchIncrementalFiles = 50`, so the worst case is **50 × 8.7 ms ≈ 435 ms per run** — above which the path falls back to a full rebuild, which pays the same per file anyway. Content-hash caching buys nothing: Step 3's AST-hash gate already guarantees changed content.

## A more serious defect surfaced on the way

A reviewer could not reproduce the Kotlin double-node because those extractors returned zero records with `TSTree: nil`, and assumed a harness limitation. It is not.

**`TryIncremental` over 14 languages deletes the edited file's entities and re-adds nothing** — `Done=true`, no fallback, no error, logged as a clean success. Reproduced independently across Kotlin, Java, JS and Ruby (Python control: 5 entities). Step 5 truncates `doc.Entities` ~65 lines before the extractor call, there is no `len(records)==0` guard, none of the 11 `fallback()` sites is record-count-driven, Step 6a additionally prunes inbound cross-file edges as "truly removed", and `extErr` is swallowed.

Filed as **#6151**. Pre-existing — `TSTree: nil` is unchanged at `8845017da`; this branch only replaced a misleading `// re-parse inline` comment with an accurate one. It hid because every incremental fixture is Python or Go, **both of which self-parse from `Content`**, and no fixture anywhere uses one of the 14 affected languages.

Also filed: **#6152**, for the fact that falcon/cherrypy type *every* bare Python class as `Controller` ungated — `migration_prune.go:63-77` exists to mop up that noise. Matching that behaviour is correct scope discipline for an issue about two paths disagreeing; reclassifying every Python class in every repo needs its own measurement and re-index.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`:

| package | exit | fails | skips |
|---|---|---|---|
| `./internal/engine/...` | 0 | 0 | 2 |
| `./internal/extractors/...` | 0 | 0 | 1 |
| `./internal/resolve/...` | 0 | 0 | 6 |
| `./internal/graph/...` | 0 | 0 | 0 |
| `./cmd/grafel/` | 0 | 0 | 8 |

Both parity gates pass: Path A 7 tolerated divergences (all filed), Path B 6. All skips pre-existing.

**Mutants: 12 by the author, 7 independent by review, all killed behaviourally, none by compile error.** One author mutant was found mis-targeted (it only fired when nothing folded) and rebuilt rather than counted. The Blocker-2 test is the *sole* thing killing a candidate-set regression — verified not vacuous.

**Disclosed:** a mutant helper ran `git checkout --` against uncommitted source and wiped the implementation; it was caught on the next build error, rebuilt, and committed before any further mutants ran, with the remaining battery reverting from file copies. Review independently diffed the committed tree against `8845017da` and confirmed every change is present *behaviourally* — no partially-reapplied fix, no test passing because its subject is missing.

## Recorded, not fixed

The port omits the full path's shadow branch and ID remap. Both premises are now written at the site — `INFERRED_FROM_CLASS_HIERARCHY` comes only from `cross/hierarchy`, which `TryIncremental` never runs, and records here are pre-stamp so there is no id to remap — with the note that losing either premise turns both omissions into defects.

The community-membership allow entry is the only one keyed on an absolute count rather than a shape, which is why fixture growth has re-keyed it three times and the defect zero times. Re-keying it to a delta needs a `parity.Report` change, not an allow-list edit.

Independently adversarially reviewed twice (REQUEST-CHANGES → APPROVE).

Closes #6148, #6150
Refs #6129, #6141, #6151, #6152, #5954
