### PR TITLE
fix(#6151): incremental deleted an edited file's entities and re-added nothing, for 15 languages

### DIFF
--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -58,11 +58,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -78,6 +80,7 @@ import (
 	"github.com/cajasmota/grafel/internal/indexer/diff"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/module"
+	"github.com/cajasmota/grafel/internal/treesitter"
 	"github.com/cajasmota/grafel/internal/types"
 )
 
@@ -539,6 +542,39 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		return fallback(t0, "classifier: "+clsErr.Error())
 	}
 
+	// #6151 — the re-extraction below MUST parse, exactly as the full path does.
+	//
+	// This factory is the same one cmd/grafel/index.go:654 builds for the full
+	// index, and the parse call below is a deliberate mirror of the full path's
+	// (index.go:3441-3456). Before #6151 this loop passed TSTree: nil, and the
+	// fourteen tree-sitter-backed extractors that `return nil, nil`
+	// unconditionally on a nil tree (csharp, dockerfile, elixir, groovy, java,
+	// javascript/typescript, kotlin, lua, php, proto, ruby, rust, scala, swift)
+	// re-added nothing after Step 5 had already evicted the file's entities.
+	// Total, silent data loss for the edited file, Done=true, no fallback.
+	//
+	// WHY PARSE HERE rather than teach those fourteen extractors to self-parse:
+	//   - One site, not fourteen, and it closes the hole for the 15th extractor
+	//     nobody has written yet. A per-extractor fallback only ever covers the
+	//     extractors somebody remembered to change.
+	//   - PARITY IS THE POINT. The correctness property incremental owes the
+	//     caller is "same graph as a full reindex". Reusing the full path's own
+	//     parse — same factory, same tsx override, same
+	//     `perr == nil && pr != nil` acceptance test — makes the two paths agree
+	//     BY CONSTRUCTION, including on the degenerate cases
+	//     (ErrHighSyntaxErrorRate returns a nil tree; the full path passes nil
+	//     there too, so both paths emit nothing and neither is lying).
+	//     Fourteen bespoke self-parses would each be free to disagree.
+	//   - Cost. A re-parse is not free (epic #5954), but it is bounded: this
+	//     loop runs over reallyChanged, capped at defaultIncrementalFiles=20 /
+	//     mainBranchIncrementalFiles=50, and ParserFactory.Parse goes through
+	//     indexstate.AcquireParseSlot, so it cannot widen the daemon-wide parse
+	//     ceiling. Peak RSS is bounded by ONE live tree at a time: the tree is
+	//     Closed at the end of each iteration, not deferred to the end of the
+	//     loop. The alternative — a full reindex — parses every file in the
+	//     repo, so this is strictly cheaper than the path it prevents.
+	parser := treesitter.NewParserFactory(nil)
+
 	var newEntities []graph.Entity
 	var newRels []graph.Relationship
 	// #6148 — count of generic class records re-typed from the YAML rule sets,
@@ -575,31 +611,79 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			Path:     rel,
 			Content:  content,
 			Language: cr.Language,
-			// #6151 — "re-parse inline" is what this was MEANT to do and is not
-			// what happens: nothing between here and the extractor parses.
-			//
-			// Audited across all 69 Extract implementations: 14 return nil, nil
-			// unconditionally on a nil tree (csharp, dockerfile, elixir, groovy,
-			// java, javascript/typescript, kotlin, lua, php, proto, ruby, rust,
-			// scala, swift), 7 self-parse from Content, 35 are pure source
-			// scanners that never wanted a tree, and 0 panic. Step 5 has already
-			// evicted the file's entities ~65 lines above, and no fallback() site
-			// is record-count driven, so an incremental pass over one of those 14
-			// languages DELETES that file's entities and re-adds nothing — with
-			// Done=true and no fallback. Measured on Kotlin, JS, Java and Ruby.
-			//
-			// The reason no fixture catches it is NOT that they are Python: they
-			// are mostly Go. It is that Python AND Go both self-parse from Content
-			// (golang/extractor.go), so both are blind to this by construction.
-			// A fixture in any of the 14 languages above would fail immediately —
-			// which is the thing to know before adding one.
-			TSTree:   nil,
 			RepoRoot: absRepo,
 		}
-		records, extErr := ext.Extract(ctx, input)
+
+		// #6151 — supply a real tree. Mirrors cmd/grafel/index.go:3441-3456,
+		// including the PLT #537 tsx override: the plain `typescript` grammar
+		// treats JSX tags as syntax errors, so .tsx/.jsx must be parsed with the
+		// tsx grammar or every React file trips ErrHighSyntaxErrorRate and comes
+		// back with a nil tree — reintroducing this very bug for that extension.
+		parseLang := cr.Language
+		if parseLang == "typescript" || parseLang == "javascript" {
+			low := strings.ToLower(rel)
+			if strings.HasSuffix(low, ".tsx") || strings.HasSuffix(low, ".jsx") {
+				parseLang = "tsx"
+			}
+		}
+		// treeRequired: this language HAS a tree-sitter grammar, so an extractor
+		// is entitled to assume a tree. ErrUnsupportedLanguage means the opposite
+		// — a pure source-scanner language that never wanted one, where a nil
+		// tree is the normal, correct input and must not raise an alarm.
+		treeRequired := true
+		pr, perr := parser.Parse(ctx, content, parseLang)
+		if perr != nil && errors.Is(perr, treesitter.ErrUnsupportedLanguage) {
+			treeRequired = false
+		}
+		if perr == nil && pr != nil {
+			input.TSTree = pr.TSTree
+		}
+		gotTree := input.TSTree != nil
+
+		// #6151 — safeExtract, not ext.Extract. TryIncremental was the only
+		// Extract call site in the tree that bypassed the recover() in
+		// registry.go:103-109. No extractor panics on a nil tree today, but the
+		// daemon runs this on a watcher tick, and a panic here would take down a
+		// path whose whole job is to not lose the user's graph.
+		records, extErr := safeExtract(ctx, ext, input)
+		if input.TSTree != nil {
+			// Release the CGo allocation now rather than deferring to the end of
+			// the loop: peak RSS must stay at one live tree, not len(reallyChanged).
+			input.TSTree.Close()
+			input.TSTree = nil
+		}
 		if extErr != nil {
+			// #6151 — NOT non-fatal, and no longer swallowed. Step 5 has already
+			// evicted this file's entities ~65 lines above. "Use partial results"
+			// on an error meant persisting a graph with the file's entities
+			// deleted and its replacements missing, and still reporting Done=true.
+			// A failed extraction is exactly what fallback() exists for: the full
+			// reindex reconciles the file from scratch, and the reason is logged.
 			logger.Printf("incremental: extract %s: %v", rel, extErr)
-			// Non-fatal: use partial results.
+			return fallback(t0, fmt.Sprintf("extract-error file=%s: %v", rel, extErr))
+		}
+		// An empty file is excluded deliberately: Parse returns a zero-node
+		// result with a nil tree and NO error for empty input, which is the
+		// full path's behaviour too. Truncating a file to zero bytes is a real
+		// edit with a real (empty) answer, not a failed parse.
+		if len(records) == 0 && treeRequired && !gotTree && len(content) > 0 {
+			// #6151 — the two failure modes land in the same place, so neither
+			// half of this guard is sufficient alone.
+			//
+			// len(records)==0 on its own cannot distinguish a file that
+			// legitimately has no entities from an extractor that bailed, which is
+			// why it is paired with the PARSE OUTCOME: we asked for a tree for a
+			// language that has a grammar, and did not get one (a malformed file
+			// over the #5963 error-ratio ceiling, or a grammar failure). Every one
+			// of the fourteen returns (nil, nil) in exactly that state.
+			//
+			// A full reindex would also emit nothing for such a file, so this
+			// costs a redundant reindex in the malformed-file case — the price of
+			// never again silently deleting a file's entities on a parse the
+			// extractor could not consume.
+			logger.Printf("incremental: %s — no records and no usable parse tree (lang=%s): %v",
+				rel, parseLang, perr)
+			return fallback(t0, fmt.Sprintf("no-tree-no-records file=%s lang=%s", rel, parseLang))
 		}
 
 		// #6148 / #6150 — run Pass 2.5 over this file and reconcile it with the

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -614,11 +614,26 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			RepoRoot: absRepo,
 		}
 
-		// #6151 — supply a real tree. Mirrors cmd/grafel/index.go:3441-3456,
-		// including the PLT #537 tsx override: the plain `typescript` grammar
-		// treats JSX tags as syntax errors, so .tsx/.jsx must be parsed with the
-		// tsx grammar or every React file trips ErrHighSyntaxErrorRate and comes
-		// back with a nil tree — reintroducing this very bug for that extension.
+		// #6151 — supply a real tree. Mirrors cmd/grafel/index.go:3441-3456.
+		//
+		// THIS BLOCK AND THE FULL PATH'S ARE HAND-COPIED, NOT A SHARED HELPER,
+		// and they are already NOT identical: the full path additionally sets
+		// `Config: &extractorCfg` (#2320, Config-first/env-fallback precedence)
+		// and folds pr.ErrorRatio into the #5414 parse canary. Both omissions
+		// are pre-existing and outside #6151, but nothing structural stops the
+		// two from drifting further. If you touch either, touch both — or lift
+		// them into one helper and delete this paragraph.
+		//
+		// The PLT #537 tsx override below is carried for PARITY, which is the
+		// whole correctness argument of this fix. It is NOT load-bearing against
+		// #6151, and an earlier version of this comment claiming otherwise was
+		// wrong: measured, a one-line JSX sample parses at a 0.0400 error ratio
+		// under the plain `typescript` grammar and a realistic React file at
+		// 0.0465 with a usable 452-node tree — nowhere near the 10% ceiling that
+		// would produce a nil tree. Removing the override does not reintroduce
+		// the bug. Keep it because it improves tree fidelity and because the two
+		// paths must agree, not because a .tsx file would otherwise be silently
+		// emptied.
 		parseLang := cr.Language
 		if parseLang == "typescript" || parseLang == "javascript" {
 			low := strings.ToLower(rel)
@@ -626,10 +641,22 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 				parseLang = "tsx"
 			}
 		}
-		// treeRequired: this language HAS a tree-sitter grammar, so an extractor
-		// is entitled to assume a tree. ErrUnsupportedLanguage means the opposite
-		// — a pure source-scanner language that never wanted one, where a nil
-		// tree is the normal, correct input and must not raise an alarm.
+		// treeRequired: this language HAS a tree-sitter grammar. That is all it
+		// means, and the name overstates it — read it as treeAvailable.
+		// ErrUnsupportedLanguage is the reliable half: a language with no grammar
+		// is a pure source scanner that never wanted a tree, where nil is the
+		// normal, correct input and must not raise an alarm.
+		//
+		// The converse does NOT hold, and the over-approximation is deliberate.
+		// Having a grammar does not imply the extractor consumes one:
+		// internal/extractors/sql/sql.go never references TSTree at all, yet
+		// "sql" is in treesitter's migratedLanguages. So a .sql file whose
+		// content happens not to parse falls back to a full reindex that
+		// computes the same empty answer — measured, and ocaml has the same
+		// shape. That is a wasted reindex, not a wrong graph, and the
+		// alternative (a hand-maintained list of extractors that truly need a
+		// tree) is exactly the per-extractor bookkeeping this fix exists to
+		// avoid getting wrong.
 		treeRequired := true
 		pr, perr := parser.Parse(ctx, content, parseLang)
 		if perr != nil && errors.Is(perr, treesitter.ErrUnsupportedLanguage) {
@@ -678,9 +705,18 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			// of the fourteen returns (nil, nil) in exactly that state.
 			//
 			// A full reindex would also emit nothing for such a file, so this
-			// costs a redundant reindex in the malformed-file case — the price of
-			// never again silently deleting a file's entities on a parse the
-			// extractor could not consume.
+			// costs a redundant reindex in the malformed-file case. THAT COST WAS
+			// MEASURED AND IS NEAR ZERO — do not "optimise" this guard away on a
+			// hunch that mid-edit files trip it:
+			//   - across grafel's own checked-in corpus, 0 of 5863 files in 15
+			//     languages produced an unusable tree (0.00%);
+			//   - five realistic mid-edit Kotlin states — unclosed brace,
+			//     half-typed `fun`, dangling `.`, a `clas` typo, and unresolved
+			//     git conflict markers — ALL parsed and returned done=true with no
+			//     fallback. Tree-sitter's error recovery is why.
+			// The fixture that exercises this branch needs hand-made dense
+			// garbage measured at a 12.8% error ratio. Real editing does not
+			// reach here.
 			logger.Printf("incremental: %s — no records and no usable parse tree (lang=%s): %v",
 				rel, parseLang, perr)
 			return fallback(t0, fmt.Sprintf("no-tree-no-records file=%s lang=%s", rel, parseLang))

--- a/internal/extractors/incremental_nil_tree_6151_test.go
+++ b/internal/extractors/incremental_nil_tree_6151_test.go
@@ -21,6 +21,15 @@
 // they are BIDIRECTIONAL. A count-based assertion cannot distinguish
 // "re-extracted correctly" from "deleted and never re-added" — that is exactly
 // how this defect survived.
+//
+// WHAT THIS FILE DOES NOT COVER. #6151 has a second half: Step 6a prunes every
+// INBOUND cross-file edge to the evicted entities as "truly removed". That half
+// is fixed only CONSEQUENTIALLY — the entities come back with the same
+// deterministic IDs, so Step 6a stops classifying them as removed and the
+// inbound edges survive for free. Nothing here asserts it: every fixture below
+// is single-file, so no inbound cross-file edge exists to lose. A multi-file
+// fixture (a Kotlin caller in an unchanged file, the callee edited) would pin
+// it, and is worth adding.
 package extractors
 
 import (
@@ -178,8 +187,15 @@ func TestIncremental_KotlinFile_EntitiesSurviveReExtraction_6151(t *testing.T) {
 		"SCOPE.Operation|voidEntry",
 	}
 
-	// Bidirectional, by content. Missing entries are the #6151 data loss;
-	// extra entries are a duplication regression.
+	// Bidirectional, by content. The MISSING arm is the #6151 data loss and is
+	// the arm that carries the weight.
+	//
+	// The UNEXPECTED arm is weaker than it looks, so do not lean on it: it
+	// catches a spurious DISTINCT entity, but NOT duplication. Appending
+	// `records` to itself survives this assertion, because entity IDs are
+	// deterministic over (kind, name, source_file) and the duplicates are
+	// deduped downstream before the graph is written. Duplication is
+	// incremental_dupe_test.go's job.
 	wantSet := map[string]bool{}
 	for _, w := range want {
 		wantSet[w] = true
@@ -323,5 +339,78 @@ func TestIncremental_EmptyFileDoesNotFallBack_6151(t *testing.T) {
 	}
 	if got := ntIdentities(doc, ntKotlinFile); len(got) != 0 {
 		t.Errorf("emptied file must leave no entities behind, got %v", got)
+	}
+}
+
+// ntSeedCSS builds a baseline for a stylesheet: file on disk, matching
+// manifest, one seeded entity.
+func ntSeedCSS(t *testing.T, rel, content string) (repo, stateDir string) {
+	t.Helper()
+	repo = t.TempDir()
+	stateDir = t.TempDir()
+	ntWrite(t, repo, rel, content)
+	ntSeed(t, repo, stateDir, []graph.Entity{{
+		ID:         graph.EntityID("test-repo", "SCOPE.Component", "nt-card", rel),
+		Name:       "nt-card",
+		Kind:       "SCOPE.Component",
+		SourceFile: rel,
+		Language:   "css",
+	}})
+	return repo, stateDir
+}
+
+// TestIncremental_ZeroEntitiesWithAGoodTreeDoesNotFallBack_6151 pins the
+// !gotTree conjunct of the no-tree-no-records guard, which nothing else covers:
+// drop it and the whole existing suite still passes, while these two cases
+// start forcing a full reindex on every save.
+//
+// Both inputs parse perfectly and legitimately contain zero entities. The
+// guard must distinguish "the extractor was given a tree and found nothing"
+// (fine, persist the empty answer) from "the extractor was given no tree and
+// therefore returned nothing" (#6151, fall back). Only the parse outcome
+// separates them — len(records)==0 is identical in both.
+//
+// CSS is the vehicle on purpose. Plain `.css` is the FIFTEENTH extractor with
+// the #6151 nil-tree bail (css.go, the `default:` branch of the extension
+// switch — .scss and .less self-parse, plain .css does not), so these files
+// exercise the guard on an affected language rather than a bystander. Both
+// classify as language "css", so treeRequired is true for each.
+func TestIncremental_ZeroEntitiesWithAGoodTreeDoesNotFallBack_6151(t *testing.T) {
+	cases := []struct {
+		name  string
+		rel   string
+		after string
+	}{
+		{
+			// Plain .css, stripped to a comment. Parses cleanly; no rules left.
+			name:  "comment-only css",
+			rel:   "nt_theme.css",
+			after: "/* nt: rules moved to tokens.css */\n",
+		},
+		{
+			// .scss emptied of every entity-bearing construct.
+			name:  "scss with no entities",
+			rel:   "nt_theme.scss",
+			after: "// nt: nothing left here\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, stateDir := ntSeedCSS(t, tc.rel, ".nt-card {\n  color: red;\n}\n")
+			ntWrite(t, repo, tc.rel, tc.after)
+
+			res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+			if !res.Done {
+				t.Fatalf("a file that parses fine and legitimately has no entities "+
+					"must not force a full reindex: fallback=%q", res.FallbackReason)
+			}
+			doc, err := graph.LoadGraphFromDir(stateDir)
+			if err != nil {
+				t.Fatalf("load graph: %v", err)
+			}
+			if got := ntIdentities(doc, tc.rel); len(got) != 0 {
+				t.Errorf("stale entities survived the edit: %v", got)
+			}
+		})
 	}
 }

--- a/internal/extractors/incremental_nil_tree_6151_test.go
+++ b/internal/extractors/incremental_nil_tree_6151_test.go
@@ -1,0 +1,327 @@
+// Package extractors — #6151 regression gate.
+//
+// THE INVARIANT THIS FILE EXISTS TO HOLD, stated for whoever adds the next
+// incremental fixture: every other incremental fixture in this package is
+// Python or Go, and BOTH of those extractors self-parse from Content when
+// FileInput.TSTree is nil (python/extractor.go, golang/extractor.go). They are
+// therefore blind by construction to a pipeline that hands the extractor no
+// tree. Fourteen tree-sitter-backed extractors — csharp, dockerfile, elixir,
+// groovy, java, javascript/typescript, kotlin, lua, php, proto, ruby, rust,
+// scala, swift — instead `return nil, nil` unconditionally on a nil tree.
+//
+// TryIncremental evicts the changed file's entities in Step 5 and re-adds
+// whatever Step 6's re-extraction produces. When Step 6 supplied TSTree: nil,
+// those fourteen languages re-added NOTHING: total, silent data loss for the
+// edited file, with Done=true, no fallback and no error.
+//
+// Kotlin is used deliberately: it is one of the fourteen, so this fixture fails
+// the moment the incremental path stops supplying a real tree.
+//
+// The assertions are on entity IDENTITY BY CONTENT (kind/name/source_file) and
+// they are BIDIRECTIONAL. A count-based assertion cannot distinguish
+// "re-extracted correctly" from "deleted and never re-added" — that is exactly
+// how this defect survived.
+package extractors
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+const ntKotlinFile = "Billing.kt"
+
+const ntKotlinBefore = `package com.example.billing
+
+class Ledger {
+    fun applyCharge(amount: Int): Boolean {
+        return amount > 0
+    }
+}
+
+fun voidEntry(id: String): Unit {
+}
+`
+
+// The edit adds one class and one top-level function and touches nothing else.
+const ntKotlinAfter = `package com.example.billing
+
+class Ledger {
+    fun applyCharge(amount: Int): Boolean {
+        return amount > 0
+    }
+}
+
+fun voidEntry(id: String): Unit {
+}
+
+class Reconciler {
+    fun settleBatch(n: Int): Int {
+        return n
+    }
+}
+`
+
+// ntWrite writes one file under repo, creating parents.
+func ntWrite(t *testing.T, repo, rel, content string) {
+	t.Helper()
+	abs := filepath.Join(repo, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", rel, err)
+	}
+}
+
+// ntSeed writes a baseline graph plus a manifest matching the repo's current
+// contents — what makes the next TryIncremental a real incremental run rather
+// than a fallback.
+func ntSeed(t *testing.T, repo, stateDir string, ents []graph.Entity) {
+	t.Helper()
+	doc := &graph.Document{
+		Version: graph.SchemaVersion, GeneratedAt: time.Now().UTC(), Repo: "test-repo",
+		Entities: ents, Stats: graph.Stats{Entities: len(ents)},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	var paths []string
+	_ = filepath.WalkDir(repo, func(path string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(repo, path)
+		paths = append(paths, filepath.ToSlash(rel))
+		return nil
+	})
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, paths, m)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("save manifest: %v", err)
+	}
+}
+
+// ntEntity builds a baseline graph entity with the same deterministic ID the
+// indexer would have given it.
+func ntEntity(kind, name, file string) graph.Entity {
+	return graph.Entity{
+		ID:         graph.EntityID("test-repo", kind, name, file),
+		Name:       name,
+		Kind:       kind,
+		SourceFile: file,
+		Language:   "kotlin",
+	}
+}
+
+// ntIdentities returns the sorted "kind|name" identity set of every entity
+// sourced from file.
+func ntIdentities(doc *graph.Document, file string) []string {
+	var out []string
+	for i := range doc.Entities {
+		if doc.Entities[i].SourceFile == file {
+			out = append(out, doc.Entities[i].Kind+"|"+doc.Entities[i].Name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// TestIncremental_KotlinFile_EntitiesSurviveReExtraction_6151 is the gate.
+//
+// Before the fix this failed with an EMPTY identity set: Step 5 removed the
+// four baseline entities and Step 6 handed the Kotlin extractor a nil tree, so
+// it returned (nil, nil) and nothing was re-added — while the run reported
+// Done=true with no fallback and no error.
+func TestIncremental_KotlinFile_EntitiesSurviveReExtraction_6151(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	ntWrite(t, repo, ntKotlinFile, ntKotlinBefore)
+	ntSeed(t, repo, stateDir, []graph.Entity{
+		ntEntity("SCOPE.Component", ntKotlinFile, ntKotlinFile),
+		ntEntity("SCOPE.Component", "Ledger", ntKotlinFile),
+		ntEntity("SCOPE.Operation", "applyCharge", ntKotlinFile),
+		ntEntity("SCOPE.Operation", "voidEntry", ntKotlinFile),
+	})
+
+	ntWrite(t, repo, ntKotlinFile, ntKotlinAfter)
+
+	res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("incremental did not complete: fallback=%q", res.FallbackReason)
+	}
+
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+
+	got := ntIdentities(doc, ntKotlinFile)
+	want := []string{
+		"SCOPE.Component|" + ntKotlinFile,
+		"SCOPE.Component|Ledger",
+		"SCOPE.Component|Reconciler",
+		"SCOPE.Operation|applyCharge",
+		"SCOPE.Operation|settleBatch",
+		"SCOPE.Operation|voidEntry",
+	}
+
+	// Bidirectional, by content. Missing entries are the #6151 data loss;
+	// extra entries are a duplication regression.
+	wantSet := map[string]bool{}
+	for _, w := range want {
+		wantSet[w] = true
+	}
+	gotSet := map[string]bool{}
+	for _, g := range got {
+		gotSet[g] = true
+	}
+	for _, w := range want {
+		if !gotSet[w] {
+			t.Errorf("MISSING from re-extracted graph: %s", w)
+		}
+	}
+	for _, g := range got {
+		if !wantSet[g] {
+			t.Errorf("UNEXPECTED entity in re-extracted graph: %s", g)
+		}
+	}
+	if t.Failed() {
+		t.Logf("got  = %v", got)
+		t.Logf("want = %v", want)
+	}
+}
+
+// ntStubExtractor stands in for a registered language extractor so the failure
+// branches can be driven deterministically.
+type ntStubExtractor struct {
+	lang     string
+	err      error
+	panicMsg string
+}
+
+func (s *ntStubExtractor) Language() string { return s.lang }
+
+func (s *ntStubExtractor) Extract(_ context.Context, _ extractor.FileInput) ([]types.EntityRecord, error) {
+	if s.panicMsg != "" {
+		panic(s.panicMsg)
+	}
+	return nil, s.err
+}
+
+// ntSwapExtractor replaces the registered extractor for lang and restores the
+// original on cleanup.
+func ntSwapExtractor(t *testing.T, lang string, repl Extractor) {
+	t.Helper()
+	orig, ok := Get(lang)
+	if !ok {
+		t.Fatalf("no extractor registered for %s — fixture assumption broken", lang)
+	}
+	Register(lang, repl)
+	t.Cleanup(func() { Register(lang, orig) })
+}
+
+// ntBaselineRepo builds the standard Kotlin baseline: file on disk, matching
+// manifest, four seeded entities.
+func ntBaselineRepo(t *testing.T) (repo, stateDir string) {
+	t.Helper()
+	repo = t.TempDir()
+	stateDir = t.TempDir()
+	ntWrite(t, repo, ntKotlinFile, ntKotlinBefore)
+	ntSeed(t, repo, stateDir, []graph.Entity{
+		ntEntity("SCOPE.Component", ntKotlinFile, ntKotlinFile),
+		ntEntity("SCOPE.Component", "Ledger", ntKotlinFile),
+		ntEntity("SCOPE.Operation", "applyCharge", ntKotlinFile),
+		ntEntity("SCOPE.Operation", "voidEntry", ntKotlinFile),
+	})
+	return repo, stateDir
+}
+
+// TestIncremental_ExtractFailureIsNotSwallowed_6151 pins the second half of
+// #6151. Step 5 has already evicted the file's entities by the time the
+// extractor runs, so an extraction that fails or panics is NOT a "use partial
+// results" situation — continuing persists the deletion and reports success.
+// Both must fall back to a full reindex with the reason recorded.
+func TestIncremental_ExtractFailureIsNotSwallowed_6151(t *testing.T) {
+	cases := []struct {
+		name string
+		stub *ntStubExtractor
+	}{
+		{"returns error", &ntStubExtractor{lang: "kotlin", err: errors.New("nt synthetic extract failure")}},
+		// The panic case additionally pins the safeExtract switch: TryIncremental
+		// used to call ext.Extract directly, outside registry.go's recover().
+		{"panics", &ntStubExtractor{lang: "kotlin", panicMsg: "nt synthetic panic"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo, stateDir := ntBaselineRepo(t)
+			ntSwapExtractor(t, "kotlin", tc.stub)
+			ntWrite(t, repo, ntKotlinFile, ntKotlinAfter)
+
+			res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+			if res.Done {
+				t.Fatalf("a failed extraction reported success — the #6151 swallow is back")
+			}
+			if !strings.Contains(res.FallbackReason, "extract-error") ||
+				!strings.Contains(res.FallbackReason, ntKotlinFile) {
+				t.Errorf("fallback reason must name the failure and the file, got %q", res.FallbackReason)
+			}
+		})
+	}
+}
+
+// TestIncremental_UnparseableFileFallsBack_6151 pins the paired guard. A file
+// whose parse yields no usable tree for a tree-sitter-backed language is
+// indistinguishable, from records alone, from a file that genuinely has no
+// entities — so the guard checks the PARSE OUTCOME, not just len(records)==0.
+func TestIncremental_UnparseableFileFallsBack_6151(t *testing.T) {
+	repo, stateDir := ntBaselineRepo(t)
+	// Dense syntactic garbage, measured at a 12.8% ERROR-node ratio for the
+	// kotlin grammar — over the #5963 10% ceiling, so ParserFactory.Parse
+	// returns ErrHighSyntaxErrorRate and a nil tree, which is precisely the
+	// state in which all fourteen affected extractors return (nil, nil).
+	// (Unbalanced brackets alone are not enough: they measure 7.7%.)
+	ntWrite(t, repo, ntKotlinFile,
+		"@@@ !!! ### $$$ %%% ^^^ &&& *** ((( ))) --- +++ === ~~~ ```\n@@@ !!! ### $$$\n")
+
+	res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if res.Done {
+		t.Fatalf("an unparseable file silently kept its entities deleted (Done=true)")
+	}
+	if !strings.Contains(res.FallbackReason, "no-tree-no-records") {
+		t.Errorf("want a no-tree-no-records fallback, got %q", res.FallbackReason)
+	}
+}
+
+// TestIncremental_EmptyFileDoesNotFallBack_6151 is the counterweight. The guard
+// above must not turn every legitimately-empty answer into a full reindex:
+// truncating a file to zero bytes is a real edit with a real (empty) result,
+// and Parse returns a nil tree with NO error for empty input on both paths.
+func TestIncremental_EmptyFileDoesNotFallBack_6151(t *testing.T) {
+	repo, stateDir := ntBaselineRepo(t)
+	ntWrite(t, repo, ntKotlinFile, "")
+
+	res := TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("emptying a file must not cost a full reindex: fallback=%q", res.FallbackReason)
+	}
+	doc, err := graph.LoadGraphFromDir(stateDir)
+	if err != nil {
+		t.Fatalf("load graph: %v", err)
+	}
+	if got := ntIdentities(doc, ntKotlinFile); len(got) != 0 {
+		t.Errorf("emptied file must leave no entities behind, got %v", got)
+	}
+}


### PR DESCRIPTION
`TryIncremental` deleted an edited file's entities and re-added nothing, for **15** languages. `Done=true`, no fallback, no error, logged as `incremental: done changed=1 entities=0 rels=0`. Silent total data loss for that file, on the **default daemon path** for any watched repo.

Reproduced pre-fix across Kotlin, Java, JS and Ruby; Python control returns 5 entities.

## Mechanism

- **Step 5** (`internal/extractors/incremental.go:492-501`) truncates `doc.Entities` **in place**, ~65 lines above the extractor call.
- **Step 6** passed `TSTree: nil`. `treesitter/parser.go:307` is the only place a `TSTree` is ever populated — `grep 'TSTree:'` returned two hits, one of them this bug.
- **15 extractors** `return nil, nil` unconditionally on a nil tree: csharp, dockerfile, elixir, groovy, java, javascript/typescript, kotlin, lua, php, proto, ruby, rust, scala, swift — **and plain `.css`** (`css/css.go:88-90`, the `default:` arm; `.scss`/`.less` take regex branches above it).
- No `len(records)==0` guard, and none of the 11 `fallback()` sites was record-count-driven.
- **Step 6a** then pruned every *inbound* cross-file edge to those entities as "truly removed".
- `extErr` was swallowed — `// Non-fatal: use partial results.`
- `TryIncremental` was the only `Extract` call site in the tree bypassing `safeExtract`'s recover (`registry.go:103-109`). Latent: no extractor panics on a nil tree today.

## Why the fix goes at the call site, not in the extractors

The affected-extractor count has been wrong three times: **17** (a `grep -l` that counted files *referencing* the field), **14** (an exhaustive read of all 69 `Extract` implementations), and now **15**. Each audit was more careful than the last and each still missed something.

A per-extractor remedy fixes whoever was remembered on the day someone counted. It would have shipped without `.css`, and offers nothing against the sixteenth extractor written next month by someone who has never read this issue.

**Step 6 now parses**, mirroring `cmd/grafel/index.go:3441-3456` — same `ParserFactory`, same PLT #537 tsx override, same `perr == nil && pr != nil` acceptance test. The count no longer has to be right.

Also rejected: making a zero-record extraction non-`Done`. That forces a full reindex for every legitimately empty file and does not restore parity.

## Both failure modes, paired

- `extErr != nil` → `fallback(t0, "extract-error …")`. Step 5 had already deleted the entities, so "use partial results" meant persisting the deletion and reporting success.
- Guard: `len(records)==0 && treeRequired && !gotTree && len(content) > 0`.

A count-only guard is not merely insufficient — it is **actively wrong**. Mutating to `len(records)==0` alone forces a `no-tree-no-records` fallback on a legitimately emptied file, because `Parse` returns a nil tree with no error for empty input. The parse-outcome half is what makes the guard safe.

`safeExtract` replaces the direct call, restoring the recover.

## Verified independently across five languages

Review drove `TryIncremental` end-to-end with a seeded graph and manifest for ruby, php, **tsx** (different parse path), **css** (the 15th), and kotlin — the file's identity set survives the edit in every case.

**Per-iteration `Close` verified**, not deferred: `incremental.go:649-654` closes and nils inside the loop body, before both the `extErr` return and the guard return — byte-for-byte the same lifetime discipline as the full path (`index.go:3567-3570`). No leak, and no double-close on `ErrHighSyntaxErrorRate`, where the factory has already closed the tree (#5963). Peak is one live tree, not `len(reallyChanged)`.

## Three claims this branch made and then withdrew

**The tsx override is not load-bearing for the reason first given.** The comment claimed that without it `.tsx` trips the 10% error ceiling and returns nil. Measured on both grammars: a one-line JSX sample gives ratio **0.0400** under plain `typescript`; a realistic React file (hooks, generics, nested JSX in `.map`, class component) gives **0.0465** with a usable 452-node tree. Removing the override survives the whole suite and an independent `.tsx` probe. The override stays — it improves tree fidelity and preserves parity with the full path, which is the real reason — and the comment now says so, with the measurements and an explicit note that the earlier version was wrong. **No fixture was added to pin the old mechanism**, because pinning a mechanism that does not exist at those ratios would encode the false claim in a test.

**`treeRequired` means "has a grammar", not "needs a tree".** The converse fails: `sql/sql.go` never references `TSTree` — a pure source scanner — yet `"sql"` is in `migratedLanguages`, and a dense non-parsing `.sql` file measurably fires `no-tree-no-records`. Same shape for ocaml. Now documented as a deliberate over-approximation: a wasted reindex, not a wrong graph, and the alternative is exactly the hand-maintained per-extractor list this fix exists to avoid.

**The disclosed regression is near-zero in practice.** A file permanently over the 10% syntax-error ratio now triggers a full reindex on every edit. Measured: five realistic mid-edit Kotlin states — unclosed brace, half-typed `fun`, dangling `.`, `clas` typo, unresolved git conflict markers — **all returned `done=true`, no fallback**. Across grafel's own checked-in corpus, **0 of 5863 files in 15 languages produced an unusable tree (0.00%)**. The fixture needed hand-made dense garbage at 12.8%. The trade is right; the cost side is far smaller than the first disclosure implied. (An earlier citation of #5667 as the bound was a category error — those protect the *too-many-changed* fallbacks via manifest persistence, which is irrelevant to an edit-driven regression. Dropped.)

## Fixtures

`incremental_nil_tree_6151_test.go` — Kotlin, one of the 15. Assertions on `kind|name` per `source_file`, both directions.

`TestIncremental_ZeroEntitiesWithAGoodTreeDoesNotFallBack_6151` — comment-only `.css` and entity-free `.scss`, both classifying as `css` so `treeRequired` is true. These pin `!gotTree`, which was load-bearing and survived every other test.

The package doc states the invariant for the next person: every pre-existing incremental fixture is **Python or Go, both of which self-parse from `Content`** — blind by construction. A Python fixture cannot catch a regression here.

## Narrowed rather than overstated

The bidirectional assertion catches a spurious **distinct** entity, **not** duplication — appending `records` to itself survives, because deterministic `(kind, name, source_file)` IDs dedupe it before the graph is written. `incremental_dupe_test.go` owns duplication.

Step 6a's inbound-cross-file-edge half is fixed only **consequentially** (entities return, so 6a stops seeing them as removed) and is unasserted, because every fixture is single-file. Recorded, with the multi-file fixture that would pin it described.

"The two paths agree by construction" is true of the **parse** and not of the **input**: the full path sets `Config: &extractorCfg` (#2320) and folds the parse into the #5414 error-ratio canary; incremental does neither. Both pre-existing and outside this change — but they are two hand-copied blocks, not a shared helper, and the site now says so.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. `GOMAXPROCS=4`, `-count=1 -p 1`, exit codes via `rtk proxy` with unpiped `$?`:

| package | exit | pass | skip | fail |
|---|---|---|---|---|
| `./internal/extractors/...` | 0 | 4122 | 1 | 0 |
| `./cmd/grafel/` | 0 | 513 | 8 | 0 |

Neither known flake fired. **12 mutants across two rounds, all killed behaviourally, none by compile error** — revert the parse · disable the guard · count-only guard · swallow `extErr` · `ext.Extract` instead of `safeExtract` · drop `len(content) > 0` · drop `!gotTree` · one extra distinct entity, plus survivors recorded rather than hidden (drop `treeRequired`, `defer` the Close, duplicate every record, drop the tsx override).

Mutant reverts were from a file copy throughout — no `git checkout`, no `stash`.

## Cost

~120 ms floor per 1-file incremental run, dominated by graph load and write; measured 114–149 ms across css/less/md/kotlin. Parses are capped by `defaultIncrementalFiles = 20` / `mainBranchIncrementalFiles = 50` and go through `indexstate.AcquireParseSlot`, so this cannot widen the daemon parse ceiling (#5954). Strictly cheaper than the full reindex it prevents.

## Related

`dockerfile.go:53` returns early on a nil tree, making its `AcquireParseSlot` self-parse at `:63` unreachable — which is why dockerfile appeared in two contradictory audits at once. Filed as **#6154**, and narrowed there by measurement: the other six `AcquireParseSlot` extractors guard on `len(file.Content) == 0` only, so their fallbacks are live. One file, not six.

Independently adversarially reviewed (APPROVE), with three falsified claims corrected and two guard fixtures added on top.

Closes #6151
Refs #6148, #6150, #6154, #5954, #5963
