### PR TITLE
fix(#6146,#6125): cover the PLT #537 tier; stop the receiver tier mis-binding without dropping correct same-file binds

### DIFF
--- a/internal/resolve/react_props_short_form_6146_test.go
+++ b/internal/resolve/react_props_short_form_6146_test.go
@@ -252,4 +252,20 @@ func TestSchemaShortFormColonGuardKeepsFormatBIntact6146(t *testing.T) {
 	assertBinding6146(t, bindingOf6146(t, all, id),
 		"SCOPE.Schema", "Pet.name", sqlFile,
 		"SQL column Format B ref")
+
+	// The mechanism, pinned separately from the outcome. What actually keeps
+	// six-segment consumers working is that the three-segment branch does not
+	// RETURN on a byLocation miss — it falls out of the block and lets the
+	// SplitN below run. Nothing else in the suite pins that: a refactor adding
+	// `return "", statusUnmatched, true` to the miss path would break every
+	// six-segment `scope:schema:` consumer with an otherwise-green suite.
+	//
+	// A `scope:schema:` ref whose FIRST '#' sits in a colon-free tail is what
+	// the three-segment branch would claim; here it must still reach Format B.
+	// Probing byLocation under the raw pre-split key proves the three-segment
+	// branch could not have been what resolved it.
+	if bucket, ok := idx.byLocation["column:sql:"+sqlFile+":Pet"]; ok {
+		t.Fatalf("byLocation has an entry under the three-segment branch's parse of "+
+			"this ref (%v) — the fixture no longer isolates the Format B path", bucket)
+	}
 }

--- a/internal/resolve/react_props_short_form_6146_test.go
+++ b/internal/resolve/react_props_short_form_6146_test.go
@@ -1,0 +1,255 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6146 — the PLT #537 short-form structural tier (refs.go:2012, the
+// `scope:schema:<file>#<member>` branch of lookupStructural) had ZERO coverage
+// in this package until #6122 added one neo4j-shaped test. Measured: disable
+// the tier, run ./internal/resolve/... -v, and out of ~2060 `=== RUN` entries
+// exactly one top-level test fails — the neo4j one. Before that commit the
+// tier could have been deleted outright and this suite stayed green.
+//
+// Its real consumer is internal/extractors/cross/react_props: every HAS_PROPS
+// edge on a .tsx component resolves its ToID through this branch. (The
+// resolver comment called that kind "USES_PROPS"; no such RelationshipKind
+// exists — it is types.RelationshipKindHasProps = "HAS_PROPS", kinds.go:517.
+// Corrected in the same change.)
+//
+// Everything below asserts what an endpoint BINDS TO, by kind / name /
+// source_file, in both directions. Nothing here counts dangling edges: a
+// count reads a mis-bind as an improvement, which is the whole subject of
+// #6123 and #6122.
+//
+// The tier-level subtests call idx.lookupStructural directly rather than
+// only driving ReferencesEmbedded. That is deliberate — #6123's lesson is
+// that a guard can be covered twice and look alive when only one mechanism
+// is doing the work, so the tier gets a test that no other mechanism can
+// satisfy on its behalf.
+
+const (
+	propsFile6146 = "src/components/AdditionalInfoFields.tsx"
+	propsType6146 = "AdditionalInfoFieldsProps"
+	propsComp6146 = "AdditionalInfoFields"
+	propsRef6146  = "scope:schema:" + propsFile6146 + "#" + propsType6146
+	compRef6146   = "scope:operation:" + propsFile6146 + "#" + propsComp6146
+)
+
+// reactPropsFixture6146 mirrors what the pipeline actually produces for one
+// .tsx file: the SCOPE.Operation component record (react_props
+// buildComponentEntity) and the SCOPE.Schema props-interface record
+// (buildPropsInterfaceEntity), plus a same-named props interface in a
+// DIFFERENT file. That third entity is the point of the fixture — "binds
+// correctly" is only meaningful when a wrong target of the identical name is
+// available to bind to.
+func reactPropsFixture6146() (comp, props, otherFileProps types.EntityRecord) {
+	comp = types.EntityRecord{
+		ID: "1a1a1a1a1a1a1a1a", Kind: "SCOPE.Operation", Subtype: "react_component",
+		Name: propsComp6146, SourceFile: propsFile6146, Language: "typescript",
+	}
+	props = types.EntityRecord{
+		ID: "2b2b2b2b2b2b2b2b", Kind: "SCOPE.Schema", Subtype: "react_props_interface",
+		Name: propsType6146, SourceFile: propsFile6146, Language: "typescript",
+	}
+	otherFileProps = types.EntityRecord{
+		ID: "3c3c3c3c3c3c3c3c", Kind: "SCOPE.Schema", Subtype: "react_props_interface",
+		Name: propsType6146, SourceFile: "src/legacy/AdditionalInfoFields.tsx",
+		Language: "typescript",
+	}
+	return comp, props, otherFileProps
+}
+
+// bindingOf6146 returns the fixture entity an endpoint landed on, so
+// assertions can be phrased in kind/name/source_file terms rather than in
+// opaque IDs. Producers salt IDs and (from, to, kind) is not a unique
+// relationship key, so identity has to be read off the entity record.
+func bindingOf6146(t *testing.T, ents []types.EntityRecord, id string) types.EntityRecord {
+	t.Helper()
+	for _, e := range ents {
+		if e.ID == id {
+			return e
+		}
+	}
+	t.Fatalf("endpoint %q matches no entity in the fixture — it was neither bound "+
+		"nor left verbatim as a recognisable stub", id)
+	return types.EntityRecord{}
+}
+
+func assertBinding6146(t *testing.T, got types.EntityRecord, wantKind, wantName, wantFile, what string) {
+	t.Helper()
+	if got.Kind != wantKind || got.Name != wantName || got.SourceFile != wantFile {
+		t.Fatalf("%s bound to {kind=%q name=%q source_file=%q}, want {kind=%q name=%q source_file=%q}",
+			what, got.Kind, got.Name, got.SourceFile, wantKind, wantName, wantFile)
+	}
+}
+
+// TestReactPropsHasPropsBindsBothEndpointsByContent6146 is the end-to-end arm:
+// the HAS_PROPS edge as react_props emits it (embedded on the component
+// record, both endpoints structural stubs) driven through ReferencesEmbedded,
+// asserted bidirectionally on entity content.
+func TestReactPropsHasPropsBindsBothEndpointsByContent6146(t *testing.T) {
+	comp, props, otherFileProps := reactPropsFixture6146()
+	all := []types.EntityRecord{comp, props, otherFileProps}
+	idx := BuildIndex(all)
+
+	recs := []types.EntityRecord{{
+		ID: comp.ID, Kind: comp.Kind, Name: comp.Name,
+		SourceFile: comp.SourceFile, Language: comp.Language,
+		Relationships: []types.RelationshipRecord{{
+			FromID: compRef6146,
+			ToID:   propsRef6146,
+			Kind:   string(types.RelationshipKindHasProps),
+			Properties: types.Props{
+				{K: "props_type", V: propsType6146},
+			},
+		}},
+	}}
+	ReferencesEmbedded(recs, idx)
+	edge := recs[0].Relationships[0]
+
+	assertBinding6146(t, bindingOf6146(t, all, edge.ToID),
+		"SCOPE.Schema", propsType6146, propsFile6146,
+		"HAS_PROPS ToID (the PLT #537 short-form tier)")
+	assertBinding6146(t, bindingOf6146(t, all, edge.FromID),
+		"SCOPE.Operation", propsComp6146, propsFile6146,
+		"HAS_PROPS FromID")
+
+	if edge.ToID == otherFileProps.ID {
+		t.Fatalf("HAS_PROPS ToID took the same-named props interface in %q — the "+
+			"byLocation probe must be file-scoped", otherFileProps.SourceFile)
+	}
+}
+
+// TestReactPropsShortFormTierBindsInPackage6146 is the same fact asserted
+// AT THE TIER, not through the pipeline. If the branch at refs.go:2012 is
+// removed, `scope:schema:<file>#<name>` has three colon-segments, so the
+// SplitN at refs.go:2129 yields len(parts) != 6 and lookupStructural returns
+// ("", statusUnmatched, true) — this subtest fails on the returned ID, which
+// is the intended assertion and not a compile error or a collateral one.
+func TestReactPropsShortFormTierBindsInPackage6146(t *testing.T) {
+	comp, props, otherFileProps := reactPropsFixture6146()
+	idx := BuildIndex([]types.EntityRecord{comp, props, otherFileProps})
+
+	id, status, handled := idx.lookupStructural(propsRef6146)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", propsRef6146)
+	}
+	if status != statusRewritten {
+		t.Fatalf("lookupStructural(%q) status=%d, want statusRewritten=%d — the PLT "+
+			"#537 short-form branch did not fire", propsRef6146, status, statusRewritten)
+	}
+	if id != props.ID {
+		t.Fatalf("lookupStructural(%q) = %q, want the same-file SCOPE.Schema %q "+
+			"(%s in %s)", propsRef6146, id, props.ID, props.Name, props.SourceFile)
+	}
+}
+
+// TestReactPropsShortFormTierIsFileScoped6146 pins the byLocation[file] probe
+// itself: the props type exists, but only in another file. The tier must
+// decline rather than reach across files, and the stub must survive verbatim
+// so the edge dangles honestly.
+func TestReactPropsShortFormTierIsFileScoped6146(t *testing.T) {
+	comp, _, otherFileProps := reactPropsFixture6146()
+	idx := BuildIndex([]types.EntityRecord{comp, otherFileProps})
+
+	id, status, handled := idx.lookupStructural(propsRef6146)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", propsRef6146)
+	}
+	if id != "" || status != statusUnmatched {
+		t.Fatalf("lookupStructural(%q) = (%q, status=%d) with the props type present "+
+			"only in %q; want (\"\", statusUnmatched=%d). A cross-file bind here is a "+
+			"confident wrong answer, not a recovery",
+			propsRef6146, id, status, otherFileProps.SourceFile, statusUnmatched)
+	}
+
+	recs := []types.EntityRecord{{
+		ID: comp.ID, Kind: comp.Kind, Name: comp.Name,
+		SourceFile: comp.SourceFile, Language: comp.Language,
+		Relationships: []types.RelationshipRecord{{
+			FromID: compRef6146, ToID: propsRef6146,
+			Kind: string(types.RelationshipKindHasProps),
+		}},
+	}}
+	ReferencesEmbedded(recs, idx)
+	if got := recs[0].Relationships[0].ToID; got != propsRef6146 {
+		t.Fatalf("HAS_PROPS ToID was rewritten to %q; want the stub %q left verbatim",
+			got, propsRef6146)
+	}
+}
+
+// TestReactPropsShortFormTierAmbiguousSameFile6146 covers the other decline
+// path: two entities share (file, name), so BuildIndex blanks the byLocation
+// entry (refs.go:1189-1197) and records ambigLocation. The tier's probe misses
+// and the stub survives. Without this the tier would pick whichever record
+// BuildIndex saw last.
+//
+// Honest note on redundancy (#6123's lesson runs both ways): this behaviour is
+// protected TWICE. Making byLocation last-writer-wins fails this test AND
+// TestReferences_StructuralLocationAmbiguous. Kept anyway because that other
+// test exercises the six-segment Format A path and would not notice a
+// regression confined to the three-segment branch — but a pass here is not
+// independent evidence that this branch is what is doing the work.
+func TestReactPropsShortFormTierAmbiguousSameFile6146(t *testing.T) {
+	comp, props, _ := reactPropsFixture6146()
+	twin := props
+	twin.ID = "4d4d4d4d4d4d4d4d"
+	twin.Kind = "SCOPE.Component"
+	idx := BuildIndex([]types.EntityRecord{comp, props, twin})
+
+	id, _, handled := idx.lookupStructural(propsRef6146)
+	if !handled {
+		t.Fatalf("lookupStructural did not claim %q (handled=false)", propsRef6146)
+	}
+	if id == props.ID || id == twin.ID {
+		t.Fatalf("lookupStructural(%q) picked %q out of an ambiguous (file, name) "+
+			"pair — it must decline, not choose", propsRef6146, id)
+	}
+	if id != "" {
+		t.Fatalf("lookupStructural(%q) = %q, want \"\"", propsRef6146, id)
+	}
+}
+
+// TestSchemaShortFormColonGuardKeepsFormatBIntact6146 pins the OUTCOME the
+// `!strings.Contains(filePath, ":")` guard exists to protect: the six-segment
+// Format B `scope:schema:column:sql:<file>:<table>#<column>` refs minted by
+// internal/extractor/structural_ref.go must still reach the Format B path and
+// land on the column entity, not be swallowed by this three-segment branch.
+//
+// Measured, and worth recording because it is not what the guard's placement
+// suggests: deleting `!strings.Contains(filePath, ":")` on its own does NOT
+// break anything. The tier would then claim the ref with filePath =
+// "column:sql:migrations/001_init.sql:Pet", miss byLocation, and — because a
+// miss falls out of the block instead of returning — continue to the
+// six-segment SplitN, which resolves it correctly anyway. That single-token
+// mutation survives this test and the whole resolve suite. The guard is
+// defence-in-depth and an early exit, not the load-bearing mechanism.
+//
+// What IS load-bearing is the fall-through-on-miss, and this test does catch
+// its removal: guard deleted AND the branch made to `return "",
+// statusUnmatched, true` on a byLocation miss fails here (and in the #6122
+// neo4j test). Recorded so a future reader does not mistake a surviving
+// mutation for an inert test.
+func TestSchemaShortFormColonGuardKeepsFormatBIntact6146(t *testing.T) {
+	const sqlFile = "migrations/001_init.sql"
+	column := types.EntityRecord{
+		ID: "5e5e5e5e5e5e5e5e", Kind: "SCOPE.Schema", Subtype: "column",
+		Name: "Pet.name", SourceFile: sqlFile, Language: "sql",
+	}
+	all := []types.EntityRecord{column}
+	idx := BuildIndex(all)
+
+	// Exactly the shape internal/extractor.SQLColumnRef mints.
+	const ref = "scope:schema:column:sql:" + sqlFile + ":Pet#name"
+	id, status, handled := idx.lookupStructural(ref)
+	if !handled || status != statusRewritten {
+		t.Fatalf("lookupStructural(%q) = (status=%d, handled=%v); the six-segment "+
+			"Format B path must still claim and resolve it", ref, status, handled)
+	}
+	assertBinding6146(t, bindingOf6146(t, all, id),
+		"SCOPE.Schema", "Pet.name", sqlFile,
+		"SQL column Format B ref")
+}

--- a/internal/resolve/receiver_tier_ambiguity_6125_test.go
+++ b/internal/resolve/receiver_tier_ambiguity_6125_test.go
@@ -17,33 +17,61 @@ import (
 // tier returned ("", true) — refusal — and the edge still landed on
 // other/z.go's Do11.
 //
-// # Why the fall-through, and not the comment, was the defect
+// # What the refusal actually reaches, and why a blanket refusal is wrong
 //
-// The two candidate indexes are keyed differently, and that asymmetry decides
-// it:
+// A first version of this fix terminated the ladder outright on refusal,
+// justified by: byPackageMember keys come from splitting an entity Name at
+// its LAST dot (refs.go:1207-1233), so declined candidates are named
+// "<Recv>.<member>"; byName is keyed on the WHOLE Name (refs.go:1474, 1497);
+// therefore a declined candidate can never come back and the downstream tier
+// is "structurally incapable" of returning one.
 //
-//   - byPackageMember is built by splitting an entity Name at its LAST dot
-//     (refs.go:1208-1228), so the candidates the receiver tier declines
-//     between are named "<Recv>.<member>".
-//   - byName is keyed on the WHOLE entity Name (refs.go:1474, 1497).
+// The byName half is true. The conclusion was FALSE, because byName is not
+// the only thing downstream. rewriteOneWithCaller (refs.go:3036-3041) routes
+// an unmatched bare CALLS stub into lookupBareWithLocality, whose CALLS arm
+// probes lookupMemberByLeafName over byMember[callerFile] (refs.go:3129) and
+// then lookupPackageMemberByLeafName over byPackageMember[pkgDir]
+// (refs.go:3134) — and byMember is built by the SAME last-dot split, in the
+// same loop, ten lines above byPackageMember. A declined candidate is not
+// merely reachable there; byMember is where it canonically lives.
 //
-// So byName[member] can NEVER contain a declined candidate. The downstream
-// tier is not making a better choice among the plausible targets — it is
-// structurally incapable of returning any of them. Whatever it returns is by
-// construction a different entity, usually in a foreign package. That is a
-// confident wrong bind, and an honest dangle beats it.
+// Measured cost of the blanket version, on the Go build-tag shape (legal and
+// common): two `T11.Do11` in package svc, caller in svc/a.go, no foreign
+// `Do11` anywhere.
 //
-// The contract was already documented on the helper itself, twice
-// (refs.go:2757-2762 and 2779-2781): ("", true) exists "so the caller can
-// leave the stub alone instead of falling back to global bare-name lookup
-// (which would risk binding to a foreign-package method of the same name)".
-// Two statements of intent on the helper, one contradicting call site — the
-// call site was the outlier. internal/extractors/sresolver already fixed the
-// identical misconception for #6098, so the full-rebuild and incremental
-// paths disagreed on this exact input until now.
+//	base 617aeba6c : {kind=Method name=T11.Do11 file=svc/a.go}  — correct
+//	blanket refusal: dangled                                     — REGRESSION
+//
+// So the fix keeps the terminal refusal but hoists the SAME-FILE probe above
+// it. The locality argument is the true one: the ambiguity that triggered the
+// refusal is package-wide, and the caller's own file is strictly narrower.
+// Under build tags exactly one of the colliding files compiles, so a caller
+// inside a.go means a.go's method.
+//
+// Full measured delta (all four asserted below):
+//
+//	scenario                                   base            this branch
+//	(a) 3rd-file caller, foreign global Do11    other/z.go      dangle    WIN
+//	(b) caller in svc/a.go                      svc/a.go        svc/a.go  KEPT
+//	(c) 3rd-file caller, sibling T22.Do11       dangle          dangle    same
+//	(d) caller file has two scopes w/ Do11      dangle          dangle    same
+//
+// (c) is the one to not guess about: the package-wide leaf tier looks like a
+// second mis-bind source but provably is not. scanLeafMembers returns
+// ("", false) on meeting a blank ambiguity sentinel (refs.go:2884-2888,
+// 2901-2906), and the refusal path is DEFINED by that sentinel being present
+// in the very pkgBucket the scan walks. Cutting that tier is a no-op. The
+// same-file scan is unaffected because the sentinel lives in byPackageMember,
+// not byMember.
+//
+// The helper contract (refs.go:2757-2762, 2779-2781) said the call site should
+// "leave the stub alone instead of falling back to global bare-name lookup".
+// Read precisely, that names byName — which is exactly what this cuts, and
+// nothing wider. internal/extractors/sresolver fixed the same misconception
+// for #6098.
 //
 // Nothing below counts dangling edges. For this issue a count is actively
-// deceptive: the two candidate fixes move it in opposite directions.
+// deceptive: the candidate fixes move it in opposite directions.
 
 const (
 	recvPkg6125    = "svc"
@@ -121,11 +149,11 @@ func TestReceiverTierRefusalIsTerminal6125(t *testing.T) {
 	for _, e := range all {
 		if e.ID == got {
 			t.Fatalf("ambiguous receiver bound to {kind=%q name=%q source_file=%q}. "+
-				"The receiver tier declined between %s/a.go and %s/b.go; every entity "+
-				"it declined between is named %q, so byName[%q] cannot contain any of "+
-				"them and this bind is by construction a non-candidate.",
-				e.Kind, e.Name, e.SourceFile, recvPkg6125, recvPkg6125,
-				recvType6125+"."+recvMember6125, recvMember6125)
+				"The caller is in a THIRD file, so no same-file candidate exists and "+
+				"the only reachable binder is byName — which is keyed on the whole "+
+				"entity Name, so it cannot hold any of the %q candidates the tier "+
+				"declined between. This bind is by construction a non-candidate.",
+				e.Kind, e.Name, e.SourceFile, recvType6125+"."+recvMember6125)
 		}
 	}
 	if got != recvMember6125 {
@@ -134,9 +162,89 @@ func TestReceiverTierRefusalIsTerminal6125(t *testing.T) {
 	}
 }
 
+// TestReceiverTierSameFileCandidateStillBinds6125 is scenario (b) — the
+// regression the first version of this fix introduced, now a permanent test.
+//
+// Two `T11.Do11` in package svc (so the receiver tier refuses, package-wide)
+// and the CALLER ITSELF in svc/a.go. There is no foreign `Do11`, so byName is
+// absent and cannot rescue anything: the only mechanism that can produce the
+// right answer is the same-file probe. Go build-tag variants produce exactly
+// this shape. Base bound it correctly and a blanket refusal dangled it.
+func TestReceiverTierSameFileCandidateStillBinds6125(t *testing.T) {
+	a, b, _ := ambiguousReceiverFixture6125()
+	all := []types.EntityRecord{a, b}
+	idx := BuildIndex(all)
+
+	if id, ok := idx.lookupPackageMember(recvPkg6125, recvType6125, recvMember6125); id != "" || !ok {
+		t.Fatalf("lookupPackageMember = (%q, %v), want (\"\", true) — the fixture must "+
+			"still trigger the package-wide refusal", id, ok)
+	}
+	if id, ok := idx.byName[recvMember6125]; ok {
+		t.Fatalf("byName[%q] = %q, want absent — this fixture must isolate the "+
+			"same-file probe as the ONLY mechanism that can bind", recvMember6125, id)
+	}
+
+	// Caller anchored in svc/a.go, the same file as candidate `a`.
+	recs := callerWithReceiverStamp6125(recvType6125)
+	recs[0].SourceFile = a.SourceFile
+	ReferencesEmbedded(recs, idx)
+
+	got := recs[0].Relationships[0].ToID
+	if got == recvMember6125 {
+		t.Fatalf("same-file caller dangled. The package-wide ambiguity must not "+
+			"suppress the caller's OWN FILE candidate %s in %s — under Go build tags "+
+			"exactly one of %s/a.go and %s/b.go compiles, and a caller inside a.go "+
+			"means a.go's method", a.Name, a.SourceFile, recvPkg6125, recvPkg6125)
+	}
+	if got != a.ID {
+		t.Fatalf("same-file caller bound to %q, want %q (%s in %s)",
+			got, a.ID, a.Name, a.SourceFile)
+	}
+}
+
+// TestReceiverTierSameFileRescueDeclinesOnCollision6125 is scenario (d), the
+// false-negative control on the rescue: the rescue must not guess either. Two
+// scopes inside the caller's own file both declare the leaf `Do11`, so
+// lookupMemberByLeafName declines (refs.go:2884-2888) and the refusal stands.
+func TestReceiverTierSameFileRescueDeclinesOnCollision6125(t *testing.T) {
+	a, b, _ := ambiguousReceiverFixture6125()
+	twinScope := types.EntityRecord{
+		ID: "d1d1d1d1d1d1d1d1", Kind: "Method", Name: "T22." + recvMember6125,
+		SourceFile: a.SourceFile, Language: "go",
+	}
+	all := []types.EntityRecord{a, b, twinScope}
+	idx := BuildIndex(all)
+
+	recs := callerWithReceiverStamp6125(recvType6125)
+	recs[0].SourceFile = a.SourceFile
+	ReferencesEmbedded(recs, idx)
+
+	got := recs[0].Relationships[0].ToID
+	for _, e := range all {
+		if e.ID == got {
+			t.Fatalf("same-file rescue picked {kind=%q name=%q source_file=%q} out of "+
+				"two scopes in one file that both declare %q — it must decline, not "+
+				"choose", e.Kind, e.Name, e.SourceFile, recvMember6125)
+		}
+	}
+	if got != recvMember6125 {
+		t.Fatalf("ToID = %q, want the stub %q left verbatim", got, recvMember6125)
+	}
+}
+
 // TestReceiverTierRefusalCountsAsAmbiguousNotResolved6125 pins the bookkeeping
 // alongside the binding. A refusal that silently vanished from the stats would
 // be indistinguishable from a resolution to any downstream consumer of Stats.
+//
+// The disposition half is the one that matters. classifyDispositionLang calls
+// this bug-resolver — "the resolver couldn't disambiguate it" — which feeds
+// Stats.BugRate (refs.go:817-818). Measured on this fixture, that put BugRate
+// at 0.5 for an endpoint the resolver refused CORRECTLY, meaning the headline
+// quality metric moves the wrong way exactly where this fix does its job.
+// Dynamic is documented as "not a bug; the call cannot be resolved statically
+// by design" (refs.go:163-166), and the framework-DSL receiver gate in the
+// same function already sets the precedent of a deliberate tier-level decline
+// recording Dynamic.
 func TestReceiverTierRefusalCountsAsAmbiguousNotResolved6125(t *testing.T) {
 	a, b, foreign := ambiguousReceiverFixture6125()
 	idx := BuildIndex([]types.EntityRecord{a, b, foreign})
@@ -148,6 +256,19 @@ func TestReceiverTierRefusalCountsAsAmbiguousNotResolved6125(t *testing.T) {
 	if stats.ToRewritten != 0 {
 		t.Fatalf("stats.ToRewritten = %d, want 0 — a refused endpoint must not be "+
 			"counted as rewritten", stats.ToRewritten)
+	}
+	if n := stats.DispositionCounts[DispositionBugResolver] +
+		stats.DispositionCounts[DispositionBugExtractor]; n != 0 {
+		t.Fatalf("a deliberate, correct refusal landed in %d bug-* disposition(s): %v. "+
+			"Those feed Stats.BugRate, so this would RAISE the headline quality metric "+
+			"precisely where the fix works", n, stats.DispositionCounts)
+	}
+	if stats.DispositionCounts[DispositionDynamic] != 1 {
+		t.Fatalf("disposition counts = %v, want exactly one %v", stats.DispositionCounts,
+			DispositionDynamic)
+	}
+	if stats.BugRate != 0 {
+		t.Fatalf("BugRate = %v, want 0", stats.BugRate)
 	}
 }
 
@@ -165,6 +286,41 @@ func TestReceiverTierRefusalIsTerminalForQualifiedStamp6125(t *testing.T) {
 		t.Fatalf("package-qualified receiver stamp %q resolved to %q; the leaf retry "+
 			"hit the same ambiguity and must terminate the ladder, leaving the stub %q",
 			"pkgq."+recvType6125, got, recvMember6125)
+	}
+}
+
+// TestReceiverTierPackageWideLeafTierNeverBoundThisAnyway6125 is scenario (c),
+// and it exists to stop a plausible-sounding claim from being asserted without
+// evidence — the exact failure this branch already made once.
+//
+// The package-wide leaf tier (refs.go:3134) looks like a second mis-bind
+// source: a sibling `T22.Do11` in the package, bound despite an explicit
+// receiver_type stamp of T11. It is not, and base does not bind it either.
+// scanLeafMembers returns ("", false) the moment it meets a blank ambiguity
+// sentinel (refs.go:2884-2888, 2901-2906), and the refusal path is defined by
+// that sentinel sitting in the very pkgBucket the scan walks. So cutting that
+// tier is a NO-OP, and this branch claims no credit for it.
+func TestReceiverTierPackageWideLeafTierNeverBoundThisAnyway6125(t *testing.T) {
+	a, b, _ := ambiguousReceiverFixture6125()
+	sibling := types.EntityRecord{
+		ID: "e1e1e1e1e1e1e1e1", Kind: "Method", Name: "T22." + recvMember6125,
+		SourceFile: recvPkg6125 + "/c.go", Language: "go",
+	}
+	all := []types.EntityRecord{a, b, sibling}
+	idx := BuildIndex(all)
+
+	if id, ok := idx.lookupPackageMemberByLeafName(recvPkg6125, recvMember6125, famOperation); ok || id != "" {
+		t.Fatalf("lookupPackageMemberByLeafName(%q,%q) = (%q, %v), want (\"\", false). "+
+			"The blank sentinel from the (pkg, T11, Do11) collision is supposed to "+
+			"poison this scan; if it no longer does, the package-wide tier CAN now "+
+			"mis-bind on the refusal path and this branch's reasoning needs redoing",
+			recvPkg6125, recvMember6125, id, ok)
+	}
+
+	recs := callerWithReceiverStamp6125(recvType6125)
+	ReferencesEmbedded(recs, idx)
+	if got := recs[0].Relationships[0].ToID; got != recvMember6125 {
+		t.Fatalf("ToID = %q, want the stub %q", got, recvMember6125)
 	}
 }
 
@@ -215,14 +371,22 @@ func TestReceiverTierMissStillFallsThrough6125(t *testing.T) {
 // fall-through — is deliberately left alone even though it shares the same
 // ("", true) refusal contract and looks like the same defect.
 //
-// byPackageComponent is keyed on the dot-FREE bare entity Name
-// (refs.go:1419-1427). So when it is ambiguous, its candidates are indexed in
-// byName under that identical string, and byName is necessarily ambiguous
-// too. The fall-through therefore cannot produce a confident wrong bind — it
-// dangles either way, and its inline comment says so accurately.
+// The exemption holds on TWO independent properties, and the first one alone
+// is not enough — that was the error corrected in this file's header:
 //
-// If that keying ever changes, this test fails and the exemption must be
-// re-argued rather than assumed.
+//  1. byPackageComponent is keyed on the dot-FREE bare entity Name
+//     (refs.go:1419-1427), so when it is ambiguous its candidates sit in
+//     byName under that identical string and byName is ambiguous too.
+//  2. More decisively, the leaf-name tiers that made a blanket refusal wrong
+//     for the receiver branch are not reachable from here at all:
+//     lookupBareWithLocality's switch (refs.go:3111-3144) puts
+//     lookupMemberByLeafName / lookupPackageMemberByLeafName ONLY on the
+//     CALLS arm. The EXTENDS/IMPLEMENTS arm has no leaf tier, and DEPENDS_ON
+//     — the dominant kind for this tier, per isComponentTargetKind — is not
+//     in the switch at all. Its refusals reach byName and stop.
+//
+// Property 2 is what makes this safe; property 1 is corroboration. If either
+// changes this test fails and the exemption must be re-argued, not assumed.
 func TestPackageComponentTierFallThroughCannotMisbind6125(t *testing.T) {
 	all := []types.EntityRecord{
 		{ID: "a2a2a2a2a2a2a2a2", Kind: "Component", Name: "Server", SourceFile: "svc/a.go", Language: "go"},

--- a/internal/resolve/receiver_tier_ambiguity_6125_test.go
+++ b/internal/resolve/receiver_tier_ambiguity_6125_test.go
@@ -1,0 +1,255 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6125 — the Go receiver-type tier in ReferencesEmbeddedWithAllowlist
+// (refs.go, the `Properties["receiver_type"]` branch) refused ambiguous
+// `(pkgDir, receiverType, member)` tuples and then fell through to
+// rewriteOneWithCaller → the global byName index, WHICH BINDS. The inline
+// comment claimed the opposite ("preserve the stub").
+//
+// MEASURED before the fix, not inferred: with two `T11.Do11` methods in
+// package `svc` and one unrelated `Do11` function in `other/`, the receiver
+// tier returned ("", true) — refusal — and the edge still landed on
+// other/z.go's Do11.
+//
+// # Why the fall-through, and not the comment, was the defect
+//
+// The two candidate indexes are keyed differently, and that asymmetry decides
+// it:
+//
+//   - byPackageMember is built by splitting an entity Name at its LAST dot
+//     (refs.go:1208-1228), so the candidates the receiver tier declines
+//     between are named "<Recv>.<member>".
+//   - byName is keyed on the WHOLE entity Name (refs.go:1474, 1497).
+//
+// So byName[member] can NEVER contain a declined candidate. The downstream
+// tier is not making a better choice among the plausible targets — it is
+// structurally incapable of returning any of them. Whatever it returns is by
+// construction a different entity, usually in a foreign package. That is a
+// confident wrong bind, and an honest dangle beats it.
+//
+// The contract was already documented on the helper itself, twice
+// (refs.go:2757-2762 and 2779-2781): ("", true) exists "so the caller can
+// leave the stub alone instead of falling back to global bare-name lookup
+// (which would risk binding to a foreign-package method of the same name)".
+// Two statements of intent on the helper, one contradicting call site — the
+// call site was the outlier. internal/extractors/sresolver already fixed the
+// identical misconception for #6098, so the full-rebuild and incremental
+// paths disagreed on this exact input until now.
+//
+// Nothing below counts dangling edges. For this issue a count is actively
+// deceptive: the two candidate fixes move it in opposite directions.
+
+const (
+	recvPkg6125    = "svc"
+	recvType6125   = "T11"
+	recvMember6125 = "Do11"
+)
+
+// ambiguousReceiverFixture6125 builds the shape the issue names: two same-named
+// methods on the same receiver type inside one Go package (so
+// byPackageMember["svc"]["T11"]["Do11"] carries the blank ambiguity sentinel),
+// plus a single globally-unique bare `Do11` in an unrelated package. The
+// foreign function is the whole point — refusal is only meaningful when
+// something wrong is available to bind to.
+func ambiguousReceiverFixture6125() (a, b, foreign types.EntityRecord) {
+	a = types.EntityRecord{
+		ID: "a1a1a1a1a1a1a1a1", Kind: "Method", Name: recvType6125 + "." + recvMember6125,
+		SourceFile: recvPkg6125 + "/a.go", Language: "go",
+	}
+	b = types.EntityRecord{
+		ID: "b1b1b1b1b1b1b1b1", Kind: "Method", Name: recvType6125 + "." + recvMember6125,
+		SourceFile: recvPkg6125 + "/b.go", Language: "go",
+	}
+	foreign = types.EntityRecord{
+		ID: "f1f1f1f1f1f1f1f1", Kind: "Function", Name: recvMember6125,
+		SourceFile: "other/z.go", Language: "go",
+	}
+	return a, b, foreign
+}
+
+// callerWithReceiverStamp6125 returns the caller record carrying the embedded
+// CALLS edge exactly as the Go extractor emits it: bare-name ToID plus a
+// Properties["receiver_type"] stamp, anchored on a file in the same package
+// directory as the ambiguous candidates.
+func callerWithReceiverStamp6125(recvStamp string) []types.EntityRecord {
+	return []types.EntityRecord{{
+		ID: "c1c1c1c1c1c1c1c1", Kind: "Method", Name: recvType6125 + ".Caller",
+		SourceFile: recvPkg6125 + "/caller.go", Language: "go",
+		Relationships: []types.RelationshipRecord{{
+			FromID:     "c1c1c1c1c1c1c1c1",
+			ToID:       recvMember6125,
+			Kind:       "CALLS",
+			Properties: types.Props{{K: "receiver_type", V: recvStamp}},
+		}},
+	}}
+}
+
+// TestReceiverTierRefusalIsTerminal6125 is the behavioural gate. Revert the
+// fix and this fails on the ToID assertion — the edge binds to other/z.go's
+// Do11 — which is the intended assertion, not a compile or collateral failure.
+func TestReceiverTierRefusalIsTerminal6125(t *testing.T) {
+	a, b, foreign := ambiguousReceiverFixture6125()
+	all := []types.EntityRecord{a, b, foreign}
+	idx := BuildIndex(all)
+
+	// The precondition, asserted rather than assumed: the tier really does
+	// refuse. ("", true) is the handled-but-ambiguous sentinel.
+	if id, ok := idx.lookupPackageMember(recvPkg6125, recvType6125, recvMember6125); id != "" || !ok {
+		t.Fatalf("lookupPackageMember(%q,%q,%q) = (%q, %v), want (\"\", true) — the "+
+			"fixture no longer produces the ambiguity this test is about",
+			recvPkg6125, recvType6125, recvMember6125, id, ok)
+	}
+	// And the collider really is bindable on its own: byName[member] is
+	// unique and points at the foreign package. Without this, "did not
+	// mis-bind" could just mean "nothing was reachable".
+	if got, ok := idx.byName[recvMember6125]; !ok || got != foreign.ID {
+		t.Fatalf("byName[%q] = (%q, %v), want the foreign Function %q — the "+
+			"wrong-bind target must be reachable for the refusal to mean anything",
+			recvMember6125, got, ok, foreign.ID)
+	}
+
+	recs := callerWithReceiverStamp6125(recvType6125)
+	ReferencesEmbedded(recs, idx)
+	got := recs[0].Relationships[0].ToID
+
+	for _, e := range all {
+		if e.ID == got {
+			t.Fatalf("ambiguous receiver bound to {kind=%q name=%q source_file=%q}. "+
+				"The receiver tier declined between %s/a.go and %s/b.go; every entity "+
+				"it declined between is named %q, so byName[%q] cannot contain any of "+
+				"them and this bind is by construction a non-candidate.",
+				e.Kind, e.Name, e.SourceFile, recvPkg6125, recvPkg6125,
+				recvType6125+"."+recvMember6125, recvMember6125)
+		}
+	}
+	if got != recvMember6125 {
+		t.Fatalf("ambiguous receiver rewrote the ToID to %q; want the stub %q left "+
+			"verbatim so the edge dangles honestly", got, recvMember6125)
+	}
+}
+
+// TestReceiverTierRefusalCountsAsAmbiguousNotResolved6125 pins the bookkeeping
+// alongside the binding. A refusal that silently vanished from the stats would
+// be indistinguishable from a resolution to any downstream consumer of Stats.
+func TestReceiverTierRefusalCountsAsAmbiguousNotResolved6125(t *testing.T) {
+	a, b, foreign := ambiguousReceiverFixture6125()
+	idx := BuildIndex([]types.EntityRecord{a, b, foreign})
+
+	stats := ReferencesEmbedded(callerWithReceiverStamp6125(recvType6125), idx)
+	if stats.ToAmbiguous != 1 {
+		t.Fatalf("stats.ToAmbiguous = %d, want 1", stats.ToAmbiguous)
+	}
+	if stats.ToRewritten != 0 {
+		t.Fatalf("stats.ToRewritten = %d, want 0 — a refused endpoint must not be "+
+			"counted as rewritten", stats.ToRewritten)
+	}
+}
+
+// TestReceiverTierRefusalIsTerminalForQualifiedStamp6125 covers the #364 arm.
+// The tier tries the stamp as-is first, then its leaf after the last dot; a
+// refusal on EITHER attempt must terminate the ladder. Without the fix this
+// binds to the foreign function just as the bare stamp does.
+func TestReceiverTierRefusalIsTerminalForQualifiedStamp6125(t *testing.T) {
+	a, b, foreign := ambiguousReceiverFixture6125()
+	idx := BuildIndex([]types.EntityRecord{a, b, foreign})
+
+	recs := callerWithReceiverStamp6125("pkgq." + recvType6125)
+	ReferencesEmbedded(recs, idx)
+	if got := recs[0].Relationships[0].ToID; got != recvMember6125 {
+		t.Fatalf("package-qualified receiver stamp %q resolved to %q; the leaf retry "+
+			"hit the same ambiguity and must terminate the ladder, leaving the stub %q",
+			"pkgq."+recvType6125, got, recvMember6125)
+	}
+}
+
+// TestReceiverTierStillBindsWhenUnambiguous6125 is the false-negative control
+// for the fix itself. Terminating on refusal must not turn into terminating on
+// a MISS: with a single `T11.Do11` in the package the tier must still bind it,
+// and it must be the local one rather than the foreign collider.
+func TestReceiverTierStillBindsWhenUnambiguous6125(t *testing.T) {
+	a, _, foreign := ambiguousReceiverFixture6125()
+	all := []types.EntityRecord{a, foreign}
+	idx := BuildIndex(all)
+
+	recs := callerWithReceiverStamp6125(recvType6125)
+	ReferencesEmbedded(recs, idx)
+	got := recs[0].Relationships[0].ToID
+	if got != a.ID {
+		t.Fatalf("unambiguous receiver bound to %q, want the same-package method %q "+
+			"(%s in %s). Issue #148's resolution must survive the #6125 fix",
+			got, a.ID, a.Name, a.SourceFile)
+	}
+}
+
+// TestReceiverTierMissStillFallsThrough6125 is the other half of that control.
+// A tuple the receiver tier never had an opinion about — ("", false), a plain
+// miss — must still reach the downstream tiers. Only REFUSAL is terminal.
+func TestReceiverTierMissStillFallsThrough6125(t *testing.T) {
+	_, _, foreign := ambiguousReceiverFixture6125()
+	all := []types.EntityRecord{foreign}
+	idx := BuildIndex(all)
+
+	if id, ok := idx.lookupPackageMember(recvPkg6125, recvType6125, recvMember6125); ok {
+		t.Fatalf("lookupPackageMember returned handled=true (id=%q) for a tuple with "+
+			"no entry; this control needs a plain miss", id)
+	}
+
+	recs := callerWithReceiverStamp6125(recvType6125)
+	ReferencesEmbedded(recs, idx)
+	got := recs[0].Relationships[0].ToID
+	if got != foreign.ID {
+		t.Fatalf("a receiver-tier MISS resolved to %q, want the global bare-name "+
+			"match %q (%s in %s). #6125 makes refusal terminal, not absence",
+			got, foreign.ID, foreign.Name, foreign.SourceFile)
+	}
+}
+
+// TestPackageComponentTierFallThroughCannotMisbind6125 records why the
+// SIBLING tier below the receiver branch — the Refs #44 byPackageComponent
+// fall-through — is deliberately left alone even though it shares the same
+// ("", true) refusal contract and looks like the same defect.
+//
+// byPackageComponent is keyed on the dot-FREE bare entity Name
+// (refs.go:1419-1427). So when it is ambiguous, its candidates are indexed in
+// byName under that identical string, and byName is necessarily ambiguous
+// too. The fall-through therefore cannot produce a confident wrong bind — it
+// dangles either way, and its inline comment says so accurately.
+//
+// If that keying ever changes, this test fails and the exemption must be
+// re-argued rather than assumed.
+func TestPackageComponentTierFallThroughCannotMisbind6125(t *testing.T) {
+	all := []types.EntityRecord{
+		{ID: "a2a2a2a2a2a2a2a2", Kind: "Component", Name: "Server", SourceFile: "svc/a.go", Language: "go"},
+		{ID: "b2b2b2b2b2b2b2b2", Kind: "Component", Name: "Server", SourceFile: "svc/b.go", Language: "go"},
+		{ID: "f2f2f2f2f2f2f2f2", Kind: "Component", Name: "Server", SourceFile: "other/z.go", Language: "go"},
+	}
+	idx := BuildIndex(all)
+
+	if id, ok := idx.lookupPackageComponent("svc", "Server"); id != "" || !ok {
+		t.Fatalf("lookupPackageComponent(svc, Server) = (%q, %v), want (\"\", true)", id, ok)
+	}
+	if id, ok := idx.byName["Server"]; ok && id != "" {
+		t.Fatalf("byName[\"Server\"] = %q — the component tier's declined candidates "+
+			"are supposed to poison the global bare-name entry too. If they no longer "+
+			"do, its fall-through can now mis-bind and needs the #6125 treatment", id)
+	}
+
+	recs := []types.EntityRecord{{
+		ID: "c2c2c2c2c2c2c2c2", Kind: "Method", Name: "Server.Run",
+		SourceFile: "svc/caller.go", Language: "go",
+		Relationships: []types.RelationshipRecord{{
+			FromID: "c2c2c2c2c2c2c2c2", ToID: "Server", Kind: "DEPENDS_ON",
+		}},
+	}}
+	ReferencesEmbedded(recs, idx)
+	if got := recs[0].Relationships[0].ToID; got != "Server" {
+		t.Fatalf("ambiguous package-component fall-through bound to %q; want the stub "+
+			"%q left verbatim", got, "Server")
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -5859,46 +5859,116 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 						continue
 					}
 					// Issue #6125 — ambiguous within (pkg, recv, member).
-					// Leave the stub verbatim and stop the ladder here.
 					//
-					// The old code merely set resolved=false and fell through
-					// to rewriteOneWithCaller → the global byName index, which
-					// binds. The inline comment claimed it "preserved the
-					// stub"; it did not. lookupPackageMember's own contract
-					// (refs.go:2757-2762, 2779-2781) states the opposite of
-					// what the call site did: ("", true) exists precisely "so
-					// the caller can leave the stub alone instead of falling
-					// back to global bare-name lookup".
+					// The old code set resolved=false and fell straight
+					// through, while its comment claimed it "preserved the
+					// stub". It did not: the ladder below binds. But the
+					// ladder is NOT just the global byName index, and the
+					// distinction is what this whole block turns on.
 					//
-					// Why this fall-through was unsound rather than merely
-					// lossy, measured not assumed: byPackageMember keys are
-					// derived by splitting an entity Name at its LAST dot
-					// (refs.go:1208-1228), so every candidate the receiver
-					// tier declined between is named "<Recv>.<member>". byName
-					// is keyed on the WHOLE Name (refs.go:1474, 1497). A
-					// declined candidate therefore can NEVER appear under
-					// byName[member]. The downstream tier is not choosing
-					// better between the candidates — it is structurally
-					// incapable of returning any of them, so it can only ever
-					// return a DIFFERENT entity, typically in a foreign
-					// package. An honest dangle beats a confident wrong bind.
+					// What the refusal used to reach, in order:
+					//   1. rewriteOneWithCaller → LookupStatusHint → byName
+					//      (refs.go:1474, 1497), keyed on the WHOLE entity
+					//      Name. byPackageMember keys come from splitting a
+					//      Name at its LAST dot (refs.go:1207-1233), so every
+					//      declined candidate is named "<Recv>.<member>" and
+					//      can never appear under byName[member]. Anything
+					//      this tier returns is a non-candidate — typically a
+					//      foreign-package function of the bare name.
+					//   2. refs.go:3036-3041 → lookupBareWithLocality, whose
+					//      CALLS arm probes lookupMemberByLeafName over
+					//      byMember[callerFile] (refs.go:3129) and then
+					//      lookupPackageMemberByLeafName over
+					//      byPackageMember[pkgDir] (refs.go:3134). byMember is
+					//      built by the SAME last-dot split, in the same loop
+					//      ten lines above byPackageMember — so a declined
+					//      candidate is not merely reachable here, byMember is
+					//      the canonical place it lives.
+					//
+					// So a blanket "refusal terminates" is wrong, and was
+					// measured wrong: with two `T11.Do11` in package svc and
+					// the CALLER ITSELF IN svc/a.go, tier 2's same-file probe
+					// binds svc/a.go's method — the correct answer, and one a
+					// blanket refusal turns into a dangle. Go build-tag
+					// variants produce exactly this shape and are legal and
+					// common.
+					//
+					// What we do instead: hoist the SAME-FILE probe above the
+					// refusal, then terminate. The locality argument is the
+					// real one — the ambiguity that triggered the refusal is
+					// package-wide, and the caller's own file is strictly
+					// narrower than the package. Under build tags exactly one
+					// of the colliding files compiles, and a caller inside
+					// a.go means a.go's method. lookupMemberByLeafName itself
+					// declines when two scopes in that one file share the leaf
+					// (refs.go:2794-2801), so this never guesses either.
+					//
+					// What is cut off is the global byName tier, which per the
+					// keying above can only ever return a non-candidate.
+					// Measured: with a foreign `Do11` in another package, base
+					// bound it and this does not.
+					//
+					// The PACKAGE-wide leaf tier at refs.go:3134 is also no
+					// longer reached, but that is a NO-OP rather than a second
+					// win, and the distinction is worth stating because the
+					// obvious guess is wrong. scanLeafMembers returns
+					// ("", false) the moment it meets a blank ambiguity
+					// sentinel (refs.go:2884-2888, 2901-2906), and the refusal
+					// path is DEFINED by byPackageMember[pkg][recv][member]
+					// being exactly that blank. The leaf scan walks that same
+					// pkgBucket, so it always meets the sentinel and always
+					// declines. Confirmed by measurement: a sibling
+					// `T22.Do11` in the package is NOT bound by base either.
+					// The same-file scan is unaffected because the sentinel
+					// lives in byPackageMember, not in byMember.
+					//
+					// An honest dangle beats a confident wrong bind; it does
+					// not beat a correct one.
 					//
 					// Contrast the byPackageComponent tier below, whose
-					// fall-through is retained and whose comment is accurate:
-					// that index is keyed on the dot-free bare Name
-					// (refs.go:1419-1427), so its ambiguous candidates are the
-					// same strings byName sees, and byName is necessarily
-					// ambiguous too. That fall-through provably cannot mis-bind.
+					// fall-through is retained. Not for the keying reason —
+					// for a sharper one: lookupBareWithLocality's switch
+					// (refs.go:3111-3144) has NO leaf-name tier on the
+					// EXTENDS/IMPLEMENTS arm, and DEPENDS_ON is not in the
+					// switch at all. That tier's refusals therefore reach only
+					// byName, where its candidates — indexed under the
+					// dot-free bare Name (refs.go:1419-1427) — are the same
+					// strings that made byName ambiguous. It provably cannot
+					// mis-bind, and its inline comment is accurate.
 					//
 					// This also brings the full-rebuild path into line with
-					// internal/extractors/sresolver, where the same
-					// misconception was fixed for #6098 with a three-outcome
-					// contract. Before this change the two paths disagreed on
-					// the identical input.
+					// internal/extractors/sresolver, fixed for #6098.
+					if ambiguousReceiver && parentSourceFile != "" {
+						if id, ok := idx.lookupMemberByLeafName(parentSourceFile, r.ToID, famOperation); ok && id != "" {
+							r.ToID = id
+							applyEndpointStats(&stats, statusRewritten, false)
+							d := idx.classifyDispositionLang(r.ToID, orig, lang, allow)
+							stats.recordDisposition(d, orig)
+							continue
+						}
+					}
 					if ambiguousReceiver {
+						// Counted Ambiguous (the honest structural counter,
+						// which does not feed BugRate) and dispositioned
+						// Dynamic.
+						//
+						// Disposition choice, deliberate: classifyDispositionLang
+						// would call this bug-resolver — "the resolver couldn't
+						// disambiguate" — which is literally true of the words
+						// and wrong about the meaning. bug-resolver feeds
+						// Stats.BugRate (refs.go:817-818), so a refusal that is
+						// working as designed would RAISE the headline quality
+						// metric precisely when this fix does its job. Dynamic
+						// is documented as "not a bug; the call cannot be
+						// resolved statically by design" (refs.go:163-166),
+						// which is what a build-tag-variant collision is from an
+						// indexer that does not evaluate build constraints. The
+						// framework-DSL receiver gate below (#514 / #517) sets
+						// the same precedent in this same function: a deliberate
+						// tier-level decline recorded as Dynamic. If a dedicated
+						// refusal bucket is ever added, this belongs there.
 						applyEndpointStats(&stats, statusAmbiguous, false)
-						d := idx.classifyDispositionLang(r.ToID, orig, lang, allow)
-						stats.recordDisposition(d, orig)
+						stats.recordDisposition(DispositionDynamic, orig)
 						continue
 					}
 				}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2011,12 +2011,18 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	}
 	// PLT #537 — react_props short-form: scope:schema:<file>#<name>.
 	// internal/extractors/cross/react_props/extractor.go's propsSchemaRef
-	// emits this 3-segment shape on USES_PROPS edge ToIDs targeting the
-	// component's Props interface / type-alias. The base JS/TS extractor
-	// indexes interfaces / type aliases under byLocation[file][name]; this
-	// short-form bypasses the 6-segment Format A path and binds directly.
-	// Without it every USES_PROPS edge on tsx components lands in
-	// bug-extractor (cfc 2.09% pre-fix — `AdditionalInfoFieldsProps` etc.).
+	// emits this 3-segment shape on HAS_PROPS edge ToIDs targeting the
+	// component's Props interface / type-alias. (The edge kind is
+	// types.RelationshipKindHasProps = "HAS_PROPS"; this comment said
+	// "USES_PROPS" until #6146 — no such kind exists.) The base JS/TS
+	// extractor indexes interfaces / type aliases under
+	// byLocation[file][name]; this short-form bypasses the 6-segment Format
+	// A path and binds directly. Without it every HAS_PROPS edge on tsx
+	// components lands in bug-extractor (cfc 2.09% pre-fix —
+	// `AdditionalInfoFieldsProps` etc.).
+	//
+	// Coverage: internal/resolve/react_props_short_form_6146_test.go pins
+	// this tier directly (it had none in this package before #6146).
 	if strings.HasPrefix(stub, "scope:schema:") && strings.IndexByte(stub, stubMemberDelim) > 0 {
 		rest := stub[len("scope:schema:"):]
 		if hash := strings.IndexByte(rest, stubMemberDelim); hash > 0 {
@@ -5828,6 +5834,9 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 					// `chi.Mux` (struct of type Mux in pkg chi, or any
 					// package whose dir name happens to match) still wins.
 					resolved := false
+					// Issue #6125 — refusal TERMINATES the ladder. See the
+					// long note below the loop.
+					ambiguousReceiver := false
 					tryTypes := []string{recvType}
 					if dot := strings.LastIndexByte(recvType, '.'); dot >= 0 && dot < len(recvType)-1 {
 						tryTypes = append(tryTypes, recvType[dot+1:])
@@ -5842,12 +5851,54 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 								resolved = true
 								break
 							}
-							// Ambiguous within (pkg, recv, member) — fall through
-							// to record as unmatched (preserve the stub).
+							ambiguousReceiver = true
 							break
 						}
 					}
 					if resolved {
+						continue
+					}
+					// Issue #6125 — ambiguous within (pkg, recv, member).
+					// Leave the stub verbatim and stop the ladder here.
+					//
+					// The old code merely set resolved=false and fell through
+					// to rewriteOneWithCaller → the global byName index, which
+					// binds. The inline comment claimed it "preserved the
+					// stub"; it did not. lookupPackageMember's own contract
+					// (refs.go:2757-2762, 2779-2781) states the opposite of
+					// what the call site did: ("", true) exists precisely "so
+					// the caller can leave the stub alone instead of falling
+					// back to global bare-name lookup".
+					//
+					// Why this fall-through was unsound rather than merely
+					// lossy, measured not assumed: byPackageMember keys are
+					// derived by splitting an entity Name at its LAST dot
+					// (refs.go:1208-1228), so every candidate the receiver
+					// tier declined between is named "<Recv>.<member>". byName
+					// is keyed on the WHOLE Name (refs.go:1474, 1497). A
+					// declined candidate therefore can NEVER appear under
+					// byName[member]. The downstream tier is not choosing
+					// better between the candidates — it is structurally
+					// incapable of returning any of them, so it can only ever
+					// return a DIFFERENT entity, typically in a foreign
+					// package. An honest dangle beats a confident wrong bind.
+					//
+					// Contrast the byPackageComponent tier below, whose
+					// fall-through is retained and whose comment is accurate:
+					// that index is keyed on the dot-free bare Name
+					// (refs.go:1419-1427), so its ambiguous candidates are the
+					// same strings byName sees, and byName is necessarily
+					// ambiguous too. That fall-through provably cannot mis-bind.
+					//
+					// This also brings the full-rebuild path into line with
+					// internal/extractors/sresolver, where the same
+					// misconception was fixed for #6098 with a three-outcome
+					// contract. Before this change the two paths disagreed on
+					// the identical input.
+					if ambiguousReceiver {
+						applyEndpointStats(&stats, statusAmbiguous, false)
+						d := idx.classifyDispositionLang(r.ToID, orig, lang, allow)
+						stats.recordDisposition(d, orig)
 						continue
 					}
 				}


### PR DESCRIPTION
Two `internal/resolve` gaps. Both issues cited **stale line numbers** — `#6146`'s `:1929` is now `uniqueMatchInFamily`, `#6125`'s `:5681-5697` is now a function signature — so both were re-grounded before anything was changed.

## #6146 — a tier with zero coverage

The PLT #537 short-form tier (`refs.go:2012-2033`) — `scope:<kind>:<file>#<member>`, probing `byLocation[file][member]` — had **no resolve-package coverage** until `673e786b8` added one test for neo4j. Disable the tier and exactly one top-level test failed, out of ~2060.

Consumers enumerated exhaustively — exactly **two** producers of the three-segment form, confirmed independently in review:

| consumer | coverage before |
|---|---|
| `cross/react_props/extractor.go:192` — the `HAS_PROPS` edge ToID | **none**; the extractor test asserted the minted string only |
| `internal/extractor/neo4j_node.go:113` | its own, from #6122 |

No third. Every other `scope:schema:` producer either carries no `#` (fails the `IndexByte(stub,'#') > 0` gate) or is six-segment with colons in the filePath slot (excluded by the colon guard).

A react_props-shaped resolution now drives the tier and asserts the binding by content. The resolver comment referenced **`USES_PROPS`, a relationship kind that does not exist** — the real one is `types.RelationshipKindHasProps`. Corrected.

## #6125 — the receiver tier's fall-through

`refs.go:5819-5853`: the receiver tier `break`s on ambiguity with `resolved=false`, then falls through and **binds**, while its comment claimed the opposite. `lookupPackageMember`'s own doc states the intended contract twice (`:2757-2762`, `:2779-2781`): `("", true)` exists "so the caller can leave the stub alone instead of falling back to global bare-name lookup". `sresolver` already fixed the identical misconception for #6098, so the two paths disagreed.

**The first justification for the fix was false, and review caught it.** It claimed `byName` is keyed on the whole Name, so a declined candidate could never be returned downstream — "structurally incapable". But `byName` is not the downstream tier: `rewriteOneWithCaller` (`:3036-3041`) routes unmatched bare CALLS into `lookupBareWithLocality`, whose CALLS arm probes **leaf-name** tiers over `byMember[callerFile]` (`:3129`) and `byPackageMember[pkgDir]` (`:3134`) — and `byMember` is built by the **same last-dot split, in the same loop, ten lines above** `byPackageMember` (`:1207-1233`). Asserted: `lookupMemberByLeafName("svc/a.go","Do11",famOperation)` returns the declined candidate.

That error hid a real regression, measured against true base:

| scenario | base `617aeba6c` | blanket refusal | shipped |
|---|---|---|---|
| 3rd-file caller, foreign global `Do11` | `other/z.go Do11` — **wrong** | dangle | dangle |
| **caller in `svc/a.go`** (build-tag variants) | `svc/a.go T11.Do11` — **correct** | dangle — **regression** | `svc/a.go T11.Do11` |
| 3rd-file caller, sibling `T22.Do11` | dangle | dangle | dangle |
| caller file has two `Do11` scopes | dangle | dangle | dangle |

The blanket version's only effect was on the refusal set — and within that same set it produced both the intended win and a silent loss.

**Shipped:** the terminal refusal is kept, with a same-file probe hoisted above it. The locality argument is now the true one — the refusal's ambiguity is package-wide, the caller's own file is strictly narrower, and under build tags exactly one colliding file compiles. `lookupMemberByLeafName` declines on an in-file leaf collision (`:2884-2888`), so the rescue never guesses.

## The disposition bucket nobody had looked at

Measured on the fixture: a deliberate, correct refusal was being counted `bug-resolver`, taking `BugRate` from 0 to **0.5**. Shipped as-is that would have **raised** the headline quality metric wherever the fix works — invisible until someone asked why bug-rate moved.

Now `DispositionDynamic`, documented as "not a bug; the call cannot be resolved statically by design" (`:163-166`), with precedent in the same function (the #514/#517 framework-DSL gate records a deliberate tier decline the same way). `Ambiguous`/`ToAmbiguous` still count; they don't feed `BugRate`. Asserted: zero `bug-*`, exactly one `dynamic`, `BugRate == 0`.

## Two claims withdrawn rather than shipped

**The sibling tier was not changed, and the exemption is re-argued on the correct ground.** `byPackageComponent`'s fall-through (`:5870-5883`) shares the same `("", true)` contract and looks like the same bug. It is not: `lookupBareWithLocality`'s switch (`:3111-3144`) puts the leaf tiers **only** on the CALLS arm — EXTENDS/IMPLEMENTS has none, DEPENDS_ON is not in the switch at all — so its refusals reach `byName` and stop. The dot-free keying is corroboration, not the load-bearing reason. `TestPackageComponentTierFallThroughCannotMisbind6125` makes the exemption falsifiable.

**A second claim of this branch's own was measured wrong and retracted.** Cutting the package-wide leaf tier (`:3134`) was described as an additional win. It is a **no-op**: `scanLeafMembers` returns `("", false)` on meeting a blank ambiguity sentinel (`:2884-2888`, `:2901-2906`), and the refusal path is *defined* by that sentinel sitting in the very bucket the scan walks, so it always declines. Now a permanent test asserting the poisoning, so the no-op is falsifiable rather than asserted.

## Mutations

**9 across two rounds, all killed on their intended assertion, none by compile error.** Notably: removing the same-file rescue is killed by `…SameFileCandidateStillBinds6125`; **widening** that rescue to the package-wide tier is killed by the same test, proving it must be file-scoped; reverting the disposition is killed on `bug-resolver`/`BugRate`; and terminating on a plain **miss** as well as a refusal is killed by exactly one test — the control proving refusal `("", true)` and miss `("", false)` stay distinct.

**One survivor, reported rather than hidden.** Deleting the `!strings.Contains(filePath, ":")` colon guard (`:2031`) breaks nothing: the tier claims the ref, misses `byLocation`, and — because a miss **falls out of the block with no `return`** — the six-segment Format B path still runs. The guard is an early exit and defence-in-depth, not a correctness gate. The test comment was corrected to say so, and the branch now pins *fall-through-on-miss*, so a future refactor adding `return "", statusUnmatched, true` there cannot break every six-segment consumer with a green suite.

Also flagged: one mutation is caught by a pre-existing test as well as the new one, so a pass there is not independent evidence.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`, via `rtk proxy` with unpiped `$?`:

| package | exit | pass | skip | fail |
|---|---|---|---|---|
| `./internal/resolve/...` | 0 | 2087 | 6 | 0 |
| `./internal/extractors/...` | 0 | 4122 | 1 | 0 |
| `./cmd/grafel/` | 0 | 513 | 8 | 0 |

Neither known flake appeared.

## Unverified

- **Frequency of the build-tag duplicate-method shape is unmeasured.** A corpus attempt during review was **retracted as invalid** — it reported "0 refusals" while `byPackageMember` and `byMember` were both empty despite 87 of 152 entities carrying dotted names, meaning extractor output alone never populates those indexes. No "0 refusals on stdlib" number should be cited from this work.
- The behavioural delta is proven on four hand-built fixtures plus 5137 existing subtests, not on a real index.
- `sresolver` parity is asserted from #6098's description, not a fresh side-by-side run.

Independently adversarially reviewed (REQUEST-CHANGES), all three findings confirmed by re-measurement and fixed.

Closes #6146, #6125
Refs #6098, #6122, #6123
