### PR TITLE
fix(#6143,#6154,#6144): two of four 'test hygiene' issues were product defects — and the suite was deleting from the user's live store

### DIFF
--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -710,6 +710,9 @@ func TestCustomExtractorSchemaFieldRefsStayInTheirOwnFile6105(t *testing.T) {
 // A dangling-count check cannot see any of this: the count IMPROVES when the
 // edge silently mis-binds and WORSENS under this fix. That is why every
 // assertion here is on content.
+//
+// #6144 EXTENDED THIS TEST'S REACH to the edge's SOURCE endpoint, which #6123
+// deliberately left alone — see the note on the (c) expectation below.
 func TestCustomExtractorDependsOnServiceDoesNotMisbind6123(t *testing.T) {
 	_, on := gateArms6105(t)
 
@@ -736,11 +739,31 @@ func TestCustomExtractorDependsOnServiceDoesNotMisbind6123(t *testing.T) {
 			"collision target — a mis-bind would now be undetectable here")
 	}
 
-	// (c) The edge exists, joins the container node to the canonical
-	// external-service ref, and binds to NOTHING (honest dangle).
+	// (c) The edge exists, joins THE TEST to the canonical external-service ref,
+	// and binds to NOTHING (honest dangle).
+	//
+	// #6144 — THE FROM ENDPOINT MOVED, AND THIS IS THE END-TO-END PROOF. This
+	// expectation used to be `SCOPE.Pattern:container:PostgreSqlContainer -> …`,
+	// i.e. the edge hung off the container node, so it ran
+	// container:PostgreSqlContainer -> service PostgreSqlContainer: both
+	// endpoints derived from one token, with the test — the thing test_doubles.go
+	// has always documented as the dependent — nowhere in it. That assertion was
+	// pinning the tautology.
+	//
+	// The extractor now attaches the edge to the enclosing test type (OrderTests)
+	// as a #6104 Tier A merge facet. Two later passes then act on it, and their
+	// combined effect is what this string records: the facet merges onto the base
+	// C# extractor's SCOPE.Component:OrderTests, and foldFileComponentDuplicates
+	// folds that class component into the FILE component for cs/OrderTests.cs,
+	// repointing the edge (`edges_repointed` in its log line). So the surviving
+	// shape is file-granular rather than class-granular — still the test, still
+	// non-tautological, and it confirms the facet really did land on a node the
+	// rest of the pipeline recognises rather than creating a stray parallel one.
+	// If it had NOT merged, a second SCOPE.Component:OrderTests would survive the
+	// fold and show up here as an extra edge.
 	got := edgeSet6105(on, "DEPENDS_ON_SERVICE")
 	want := map[string]int{
-		"DEPENDS_ON_SERVICE: SCOPE.Pattern:container:PostgreSqlContainer -> " +
+		"DEPENDS_ON_SERVICE: SCOPE.Component:cs/OrderTests.cs -> " +
 			"DANGLING(scope:externalservice:PostgreSqlContainer)": 1,
 	}
 	if len(got) != len(want) {

--- a/cmd/grafel/custom_extractor_dangling_6105_test.go
+++ b/cmd/grafel/custom_extractor_dangling_6105_test.go
@@ -757,10 +757,20 @@ func TestCustomExtractorDependsOnServiceDoesNotMisbind6123(t *testing.T) {
 	// folds that class component into the FILE component for cs/OrderTests.cs,
 	// repointing the edge (`edges_repointed` in its log line). So the surviving
 	// shape is file-granular rather than class-granular — still the test, still
-	// non-tautological, and it confirms the facet really did land on a node the
-	// rest of the pipeline recognises rather than creating a stray parallel one.
-	// If it had NOT merged, a second SCOPE.Component:OrderTests would survive the
-	// fold and show up here as an extra edge.
+	// non-tautological.
+	//
+	// WHAT THIS TEST DOES NOT PROVE. An earlier revision of this comment claimed
+	// the expectation also demonstrates the Tier A merge, on the grounds that an
+	// unmerged duplicate would show up as an extra edge. That is false HERE: the
+	// fixture's class (OrderTests) has the same name as its file stem
+	// (OrderTests.cs), so a merged facet and an unmerged duplicate both fold into
+	// the SAME file component and the edge set is byte-identical either way. The
+	// merge is real, but it is pinned where it can actually be observed —
+	// TestTestDoubles_ContainerServiceEdgeHangsOffTheTestType6144 asserts the
+	// facet's identity (SourceFile, Kind, Name, Subtype) directly at the
+	// extractor boundary, before any folding pass can hide a duplicate. What
+	// THIS test proves is the end-to-end one: the edge no longer originates at
+	// the container node.
 	got := edgeSet6105(on, "DEPENDS_ON_SERVICE")
 	want := map[string]int{
 		"DEPENDS_ON_SERVICE: SCOPE.Component:cs/OrderTests.cs -> " +

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1572,8 +1572,10 @@ func startGroupAlgoProgress(ctx context.Context, group, mode string) func() {
 	}
 
 	done := make(chan struct{})
+	exited := make(chan struct{})
 	var once sync.Once
 	go func() {
+		defer close(exited)
 		t := time.NewTicker(every)
 		defer t.Stop()
 		for {
@@ -1583,6 +1585,28 @@ func startGroupAlgoProgress(ctx context.Context, group, mode string) func() {
 			case <-ctx.Done():
 				return
 			case now := <-t.C:
+				// #6134 — RE-CHECK THE STOP SIGNAL AFTER A TICK WINS.
+				//
+				// A Go select chooses UNIFORMLY AT RANDOM among the cases that
+				// are ready. Once the ticker has a pending tick, an
+				// already-closed `done` therefore wins only about half the
+				// time — so the loop above would emit one more line after the
+				// pass had ended, reporting elapsed time and a phase for work
+				// that was already over. Measured: 3/3 runs, deterministic
+				// enough to fail on a cycle-0 iteration, not a load artifact.
+				//
+				// That is the #6047 class (progress reported after the work it
+				// describes has finished), which is why #6134 was NOT closed by
+				// loosening the test: the test was right and the heartbeat was
+				// wrong. The non-blocking re-check below makes the stop signal
+				// win unconditionally once it is set.
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				default:
+				}
 				attrs := []any{
 					"group", group,
 					"mode", mode,
@@ -1604,7 +1628,26 @@ func startGroupAlgoProgress(ctx context.Context, group, mode string) func() {
 			}
 		}
 	}()
-	return func() { once.Do(func() { close(done) }) }
+	// #6134 — stop() IS A BARRIER, NOT A REQUEST.
+	//
+	// Closing `done` only makes the goroutine eligible to exit; it says nothing
+	// about whether it has observed the close, or whether it is mid-log. Callers
+	// (and the wizard) treat the return of stop() as "this pass no longer
+	// reports", so waiting for the goroutine to actually exit is what makes that
+	// true. Combined with the re-check inside the loop, the guarantee is exact:
+	// once stop() has returned, no further progress line for this pass can be
+	// emitted, ever.
+	//
+	// It cannot deadlock. The goroutine's only blocking operation is the log
+	// write, which every other logging site in this file already performs
+	// synchronously; both the `done` close and ctx cancellation drive it to
+	// close `exited`, and `exited` is closed by a defer, so a panic in the body
+	// still releases the wait. Idempotent: the second call sees the once already
+	// fired and receives from an already-closed channel.
+	return func() {
+		once.Do(func() { close(done) })
+		<-exited
+	}
 }
 
 // daemonIndexFunc is the IndexFunc handed to daemon.Run. It bridges the

--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1508,9 +1508,16 @@ func daemonSchedulerGroupAlgo(ctx context.Context, group string) error {
 // GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL=1ns is accepted and the heartbeat spins a
 // core logging — a diagnostic knob that becomes its own CPU incident. 10ms is
 // low enough for a test to drive and high enough to cost nothing.
+//
+// groupAlgoStopBarrier (#6134) is the ceiling on how long stop() will wait for
+// the heartbeat goroutine to exit. Generous relative to the goroutine's actual
+// work (one CPU read plus one log line) so it never trips in normal operation,
+// and short relative to a group-algo pass so a stalled log sink cannot wedge
+// one. See the barrier note in startGroupAlgoProgress.
 const (
 	groupAlgoProgressInterval = time.Minute
 	groupAlgoProgressMin      = 10 * time.Millisecond
+	groupAlgoStopBarrier      = 2 * time.Second
 )
 
 func groupAlgoProgressEvery() time.Duration {
@@ -1638,15 +1645,31 @@ func startGroupAlgoProgress(ctx context.Context, group, mode string) func() {
 	// once stop() has returned, no further progress line for this pass can be
 	// emitted, ever.
 	//
-	// It cannot deadlock. The goroutine's only blocking operation is the log
-	// write, which every other logging site in this file already performs
-	// synchronously; both the `done` close and ctx cancellation drive it to
-	// close `exited`, and `exited` is closed by a defer, so a panic in the body
-	// still releases the wait. Idempotent: the second call sees the once already
-	// fired and receives from an already-closed channel.
+	// THE WAIT IS BOUNDED, and an earlier revision of this comment argued it
+	// did not need to be ("the goroutine's only blocking operation is the log
+	// write"). That argument is only as good as the sink. Both call sites are
+	// `defer startGroupAlgoProgress(...)()`, so an unbounded wait here blocks the
+	// group-algo pass itself: a slog sink that stalls — tty flow control under
+	// the wizard, a full pipe, a stuck filesystem — would convert what used to be
+	// a benign leaked ticker goroutine into a wedged pass. That is a strictly
+	// worse failure than the one being fixed, so the barrier takes a ceiling.
+	//
+	// Timing out only forfeits the barrier, never correctness: the in-loop
+	// re-check above has already made a post-stop line impossible independently
+	// of this wait, because it returns whenever `done`/ctx is closed and cannot
+	// drop a legitimate line. The wait exists to make "stop() returned" mean
+	// "the goroutine is gone", and a stalled sink is exactly the case where that
+	// promise is not worth blocking a pass for.
+	//
+	// `exited` is closed by a defer, so a panic in the body releases the wait
+	// too. Idempotent: the second call sees the once already fired and receives
+	// from an already-closed channel.
 	return func() {
 		once.Do(func() { close(done) })
-		<-exited
+		select {
+		case <-exited:
+		case <-time.After(groupAlgoStopBarrier):
+		}
 	}
 }
 

--- a/cmd/grafel/daemon_parse_cap_5970_test.go
+++ b/cmd/grafel/daemon_parse_cap_5970_test.go
@@ -371,20 +371,68 @@ func bodyCallsSelector(fn *ast.FuncDecl, pkg, name string) bool {
 
 // TestDaemonParseCapDocumentsWhyNotGOMAXPROCS is a cheap guard against the
 // regression returning by copy-paste: the daemon must not derive its parse cap
-// from runtime.GOMAXPROCS again. Checked on the resolved value, using the real
-// host, so it fails on any machine where the two differ.
+// from runtime.GOMAXPROCS again.
+//
+// #6143 — HOW THIS IS ASSERTED, AND WHY IT CHANGED. The original form compared
+// the resolved cap against the AMBIENT runtime.GOMAXPROCS(0):
+//
+//	if got >= runtime.GOMAXPROCS(0) { fail }
+//
+// That is a proxy for the real invariant, and it is only a valid proxy while
+// GOMAXPROCS happens to equal NumCPU. Running the suite as this project asks
+// contributors to run it on a shared machine — `GOMAXPROCS=3 go test ...`, the
+// documented alternative to CPU spinners — makes the comparison
+// `3 >= 3` and produces a red in a package the contributor never touched. Two
+// independent reviewers hit exactly that, hours apart.
+//
+// The alternative reading was that daemonParseCap SHOULD respect a lowered
+// GOMAXPROCS, i.e. that the product was at fault. It is not, on three grounds:
+//
+//  1. GOMAXPROCS CANNOT BOUND THIS WORK. Tree-sitter parsing is cgo; a
+//     goroutine inside a cgo call parks in _Gsyscall and hands its P to another
+//     goroutine, so N concurrent parses occupy N OS threads whatever GOMAXPROCS
+//     says. Deriving the gate from it would restore the illusory ceiling #5970
+//     was filed to remove. See daemonParseCap's own doc.
+//  2. THE OPERATOR SURFACE ALREADY EXISTS, and daemonParseCap honours it
+//     UNCLAMPED in both directions: GRAFEL_DAEMON_GOMAXPROCS and cpu.json's
+//     daemon GOMAXPROCS field. An operator asking this daemon for less
+//     parallelism has a knob that works; that chain is pinned by
+//     TestDaemonParseCapPrecedence/TestDaemonParseCapFileVal above.
+//  3. IN THE DAEMON, GOMAXPROCS IS DERIVED, NOT DECLARED. runDaemonMode SETS
+//     runtime.GOMAXPROCS from resolveDaemonGOMAXPROCSWith. Sizing the parse cap
+//     off it would make one resolved value the input to the other — a loop, and
+//     literally the #5970 shape.
+//
+// So the invariant is not "the cap is below the ambient GOMAXPROCS"; it is
+// "the cap does not depend on GOMAXPROCS at all". That is now asserted
+// DIRECTLY and differentially — the resolved value must be identical across a
+// swept range of GOMAXPROCS settings, including ones below the cap — which is
+// both stronger than the old proxy (it would catch a cap that tracked
+// GOMAXPROCS while staying strictly under it) and independent of how the
+// contributor pinned their machine.
 func TestDaemonParseCapDocumentsWhyNotGOMAXPROCS(t *testing.T) {
 	t.Setenv("GRAFEL_DAEMON_GOMAXPROCS", "")
-	if runtime.NumCPU() < 8 {
-		t.Skipf("host has %d cores; budget and GOMAXPROCS can legitimately coincide", runtime.NumCPU())
-	}
-	got := daemonParseCap(runtime.NumCPU(), 0)
-	if got >= runtime.GOMAXPROCS(0) {
-		t.Fatalf("daemonParseCap(%d) = %d >= GOMAXPROCS %d: the cap is GOMAXPROCS-shaped again (#5970)",
-			runtime.NumCPU(), got, runtime.GOMAXPROCS(0))
-	}
-	if got != process.IndexCoreBudget() {
+
+	want := process.IndexCoreBudget()
+	if want != daemonParseCap(runtime.NumCPU(), 0) {
 		t.Fatalf("daemonParseCap(NumCPU) = %d, want process.IndexCoreBudget() = %d",
-			got, process.IndexCoreBudget())
+			daemonParseCap(runtime.NumCPU(), 0), want)
+	}
+
+	// Sweep GOMAXPROCS across values below, at, and above the resolved cap. If
+	// the cap were GOMAXPROCS-shaped in any way — floor, ceiling, or a
+	// proportion — at least one of these would move it.
+	restore := runtime.GOMAXPROCS(0)
+	t.Cleanup(func() { runtime.GOMAXPROCS(restore) })
+	for _, procs := range []int{1, 2, 3, want, want + 1, runtime.NumCPU()} {
+		if procs < 1 {
+			continue
+		}
+		runtime.GOMAXPROCS(procs)
+		if got := daemonParseCap(runtime.NumCPU(), 0); got != want {
+			t.Fatalf("GOMAXPROCS=%d: daemonParseCap(%d) = %d, want %d — the cap moved with "+
+				"GOMAXPROCS, i.e. it is GOMAXPROCS-shaped again (#5970)",
+				procs, runtime.NumCPU(), got, want)
+		}
 	}
 }

--- a/cmd/grafel/daemon_parse_cap_5970_test.go
+++ b/cmd/grafel/daemon_parse_cap_5970_test.go
@@ -399,9 +399,14 @@ func bodyCallsSelector(fn *ast.FuncDecl, pkg, name string) bool {
 //     parallelism has a knob that works; that chain is pinned by
 //     TestDaemonParseCapPrecedence/TestDaemonParseCapFileVal above.
 //  3. IN THE DAEMON, GOMAXPROCS IS DERIVED, NOT DECLARED. runDaemonMode SETS
-//     runtime.GOMAXPROCS from resolveDaemonGOMAXPROCSWith. Sizing the parse cap
-//     off it would make one resolved value the input to the other — a loop, and
-//     literally the #5970 shape.
+//     runtime.GOMAXPROCS from resolveDaemonGOMAXPROCSWith, so sizing the parse
+//     cap off it would make one resolved value the input to the other. To be
+//     precise — an earlier revision of this comment called that "a loop", which
+//     over-claims: resolveDaemonGOMAXPROCSWith settles on a fixed value, so it
+//     is circular COUPLING, not an unbounded loop, and it would merely make the
+//     cap track a knob that means something else. The conclusion rests on (1)
+//     and (2), which are sufficient on their own; this is a supporting reason,
+//     not a proof.
 //
 // So the invariant is not "the cap is below the ambient GOMAXPROCS"; it is
 // "the cap does not depend on GOMAXPROCS at all". That is now asserted
@@ -422,6 +427,15 @@ func TestDaemonParseCapDocumentsWhyNotGOMAXPROCS(t *testing.T) {
 	// Sweep GOMAXPROCS across values below, at, and above the resolved cap. If
 	// the cap were GOMAXPROCS-shaped in any way — floor, ceiling, or a
 	// proportion — at least one of these would move it.
+	//
+	// THIS MUTATES PROCESS-GLOBAL STATE. runtime.GOMAXPROCS is per-process, not
+	// per-test, so for the duration of this test every other goroutine in the
+	// binary sees the swept value; it is restored via t.Cleanup. That is safe
+	// today only because no test in cmd/grafel calls t.Parallel(), so nothing
+	// else is running concurrently — an undeclared assumption in the first
+	// version of this test, stated here so that adding t.Parallel() anywhere in
+	// this package is a decision made with this in view rather than a silent
+	// source of flakiness.
 	restore := runtime.GOMAXPROCS(0)
 	t.Cleanup(func() { runtime.GOMAXPROCS(restore) })
 	for _, procs := range []int{1, 2, 3, want, want + 1, runtime.NumCPU()} {

--- a/cmd/grafel/group_algo_cpu_budget_6108_test.go
+++ b/cmd/grafel/group_algo_cpu_budget_6108_test.go
@@ -226,6 +226,29 @@ func TestGroupAlgoProgress_EmitsPhaseAndCPU(t *testing.T) {
 
 // TestGroupAlgoProgress_StopsWithThePass: the heartbeat must not outlive the
 // pass, or a daemon accumulates one ticker goroutine per group-algo run.
+//
+// #6134 — WHY THIS IS ASSERTED WITHOUT A SETTLING SLEEP, AND WHY THE PRODUCT
+// CHANGED. This test used to sleep 30ms after stop() before taking its
+// baseline count, and compared that baseline against a count 80ms later. It
+// failed under host load (1 -> 2 lines) and passed in isolation, which reads
+// like a tight test. It was not: the 30ms sleep was hiding a genuine race, and
+// on a loaded machine the race simply outlived the sleep.
+//
+// stop() closed a channel and returned. The heartbeat goroutine selected over
+// {done, ctx.Done(), ticker}. A Go select chooses UNIFORMLY AT RANDOM among
+// ready cases, so once a tick was pending, a closed `done` won only half the
+// time — and the goroutine had no obligation to have reached the select at all.
+// A line could therefore be emitted AFTER stop() returned, reporting elapsed
+// time and a phase for a pass that had already ended. That is the #6047 class
+// (progress reported after the work it describes has finished), not a test
+// artifact: the wizard could print a heartbeat for a finished pass.
+//
+// startGroupAlgoProgress now makes stop() a real barrier — it re-checks the
+// stop signal after a tick wins the select, and waits for the goroutine to
+// exit before returning. So the guarantee is exact and needs no settling
+// window: once stop() has RETURNED, the line count is final forever. Sampling
+// immediately after stop() is what actually tests that guarantee; sleeping
+// first tests a weaker one and is what made this load-sensitive.
 func TestGroupAlgoProgress_StopsWithThePass(t *testing.T) {
 	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "10ms")
 
@@ -238,19 +261,94 @@ func TestGroupAlgoProgress_StopsWithThePass(t *testing.T) {
 	stop := startGroupAlgoProgress(context.Background(), "gStop", "child")
 	time.Sleep(60 * time.Millisecond)
 	stop()
-	time.Sleep(30 * time.Millisecond)
+
+	// No settling sleep: the count is taken the instant stop() returns.
 	mu.Lock()
 	settled := strings.Count(buf.String(), "group-algo: progress")
 	mu.Unlock()
-	time.Sleep(80 * time.Millisecond)
+
+	// Fixture validity: if the heartbeat never emitted anything, "no further
+	// lines" is vacuously true and this test proves nothing.
+	if settled == 0 {
+		t.Fatalf("heartbeat emitted no progress line in 60ms at a 10ms interval — "+
+			"the no-further-lines assertion below would be vacuous:\n%s", buf.String())
+	}
+
+	// Several more intervals must produce nothing.
+	time.Sleep(120 * time.Millisecond)
 	mu.Lock()
 	after := strings.Count(buf.String(), "group-algo: progress")
 	mu.Unlock()
 	if after != settled {
-		t.Errorf("progress heartbeat kept ticking after the pass ended (%d -> %d lines) — one leaked goroutine per pass", settled, after)
+		t.Errorf("progress heartbeat kept ticking after stop() RETURNED (%d -> %d lines) — "+
+			"the pass is over and the heartbeat is still reporting on it (#6134/#6047)", settled, after)
 	}
-	// Calling stop twice must not panic on a double close.
+	// Calling stop twice must not panic on a double close, and must still return.
 	stop()
+}
+
+// TestGroupAlgoProgress_StopIsABarrier is the direct, load-independent pin on
+// the #6134 guarantee, separate from the line-count test above: stop() must not
+// return until the heartbeat goroutine has actually exited. Asserted by having
+// the log sink record whether any write happens after stop() returns, over many
+// stop/start cycles — the race is probabilistic per cycle (a select coin-flip),
+// so a single cycle is not evidence either way.
+func TestGroupAlgoProgress_StopIsABarrier(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "1ms")
+
+	for i := range 40 {
+		var mu sync.Mutex
+		buf := &bytes.Buffer{}
+		var stopped bool
+		var lateWrite bool
+		sink := &lateDetectWriter{mu: &mu, w: buf, stopped: &stopped, late: &lateWrite}
+
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(sink, nil)))
+
+		stop := startGroupAlgoProgress(context.Background(), "gBarrier", "child")
+		// Long enough at the 1ms floor for the ticker to be firing steadily, so
+		// stop() genuinely races a pending tick rather than arriving before the
+		// first one.
+		time.Sleep(20 * time.Millisecond)
+		stop()
+		mu.Lock()
+		stopped = true
+		mu.Unlock()
+
+		// Give any goroutine that survived stop() ample room to emit.
+		time.Sleep(10 * time.Millisecond)
+
+		mu.Lock()
+		late := lateWrite
+		out := buf.String()
+		mu.Unlock()
+		slog.SetDefault(prev)
+
+		if late {
+			t.Fatalf("cycle %d: the heartbeat wrote a line AFTER stop() returned — stop() is not a "+
+				"barrier, so a finished pass can still report progress (#6134):\n%s", i, out)
+		}
+	}
+}
+
+// lateDetectWriter flags any write that lands after the test marked the pass
+// stopped. Unlike a count comparison it cannot be satisfied by a write that
+// merely happens to arrive between two samples.
+type lateDetectWriter struct {
+	mu      *sync.Mutex
+	w       *bytes.Buffer
+	stopped *bool
+	late    *bool
+}
+
+func (s *lateDetectWriter) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if *s.stopped {
+		*s.late = true
+	}
+	return s.w.Write(p)
 }
 
 // TestGroupAlgoProgress_Disabled: "0" turns the heartbeat off entirely.

--- a/cmd/grafel/group_algo_cpu_budget_6108_test.go
+++ b/cmd/grafel/group_algo_cpu_budget_6108_test.go
@@ -408,3 +408,119 @@ func TestGroupAlgoProgressEvery_OverrideParsing(t *testing.T) {
 		})
 	}
 }
+
+// TestGroupAlgoProgress_NoLineIsCommittedInsideTheStopWindow is the test that
+// pins the IN-LOOP RE-CHECK, as opposed to the barrier.
+//
+// #6134 — WHY THE OTHER TWO TESTS ARE NOT ENOUGH. Both of them sample at or
+// after stop() RETURNS, so neither can observe a line committed *during* stop().
+// Mutation-tested: removing the `<-exited` barrier kills them, but removing the
+// re-check leaves them fully green — the extra line is written while stop() is
+// still waiting, and by the time stop() returns the goroutine is gone and the
+// count is stable. So the half of the fix that actually prevents a finished pass
+// from reporting was, until this test, unpinned.
+//
+// HOW THE RACE IS MADE DETERMINISTIC RATHER THAN SAMPLED. A rate-based check
+// ("count writes inside the stop window") has an irreducible false positive: a
+// tick body that was already in flight when the stop signal was set is a
+// legitimate line, and no external observer can distinguish it. This test
+// removes the ambiguity by driving the goroutine into a known position instead:
+//
+//  1. A gated sink blocks the goroutine INSIDE its first log write.
+//  2. The test then sleeps past the interval, so the ticker has a tick queued
+//     (time.Ticker buffers exactly one).
+//  3. stop() is called from another goroutine; it closes `done` and blocks on
+//     the barrier. `done` is now closed BEFORE the goroutine re-enters select.
+//  4. The sink is released. The goroutine finishes write #1 and loops into a
+//     select where BOTH `done` and the pending tick are ready — the exact
+//     coin-flip the re-check exists for.
+//
+// With the re-check, no second line is possible, by construction. Without it,
+// select picks the tick about half the time and emits one. Repeated cycles make
+// a surviving mutant vanishingly unlikely while keeping false positives at
+// exactly zero — the legitimate in-flight line is write #1, which is expected
+// and counted.
+func TestGroupAlgoProgress_NoLineIsCommittedInsideTheStopWindow(t *testing.T) {
+	t.Setenv("GRAFEL_GROUP_ALGO_PROGRESS_INTERVAL", "10ms")
+
+	const cycles = 24
+	for i := range cycles {
+		sink := &gatedWriter{
+			entered: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		prev := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(sink, nil)))
+
+		stop := startGroupAlgoProgress(context.Background(), "gWindow", "child")
+
+		// (1) Park the goroutine inside its first write.
+		select {
+		case <-sink.entered:
+		case <-time.After(5 * time.Second):
+			slog.SetDefault(prev)
+			close(sink.release)
+			stop()
+			t.Fatalf("cycle %d: heartbeat never emitted a first line — the fixture cannot "+
+				"position the goroutine and the assertion below would be vacuous", i)
+		}
+
+		// (2) Queue a tick behind it.
+		time.Sleep(30 * time.Millisecond)
+
+		// (3) Close `done` while the goroutine is still parked in the write.
+		stopReturned := make(chan struct{})
+		go func() {
+			stop()
+			close(stopReturned)
+		}()
+		time.Sleep(20 * time.Millisecond) // let stop() reach close(done)
+
+		// (4) Release: the goroutine now re-enters select with both ready.
+		close(sink.release)
+
+		select {
+		case <-stopReturned:
+		case <-time.After(5 * time.Second):
+			slog.SetDefault(prev)
+			t.Fatalf("cycle %d: stop() did not return after the sink was released", i)
+		}
+		slog.SetDefault(prev)
+
+		if got := sink.count(); got != 1 {
+			t.Fatalf("cycle %d: %d lines written, want exactly 1 — a progress line was committed "+
+				"AFTER the stop signal was set and while stop() was still running. The pass is "+
+				"over and the heartbeat reported on it anyway (#6134/#6047); the in-loop re-check "+
+				"is what prevents this, and the barrier alone does not.", i, got)
+		}
+	}
+}
+
+// gatedWriter blocks the FIRST write until release is closed, so a test can pin
+// the heartbeat goroutine at a known point in its loop. Later writes pass
+// straight through and are counted — they are the ones that must not happen.
+type gatedWriter struct {
+	mu      sync.Mutex
+	writes  int
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (w *gatedWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	w.writes++
+	first := w.writes == 1
+	w.mu.Unlock()
+	if first {
+		w.once.Do(func() { close(w.entered) })
+		<-w.release
+	}
+	return len(p), nil
+}
+
+func (w *gatedWriter) count() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -12,8 +12,13 @@
 //
 //	Container topology (Testcontainers):
 //	  new XxxContainer()       /  new ContainerBuilder().WithImage("img")
-//	  -> SCOPE.Pattern/container_topology; the test DEPENDS_ON_SERVICE the
-//	  container'd service, addressed by the canonical external-service ref
+//	  -> SCOPE.Pattern/container_topology; the ENCLOSING TEST TYPE
+//	  DEPENDS_ON_SERVICE the container'd service (#6144 — until then the edge
+//	  hung off the container node, so it ran container:X -> service X with both
+//	  endpoints from one token and the test nowhere in it; the edge now lands on
+//	  the base extractor's class node via the #6104 Tier A identity merge, and
+//	  falls back to the container node only when no enclosing type is found),
+//	  addressed by the canonical external-service ref
 //	  (scope:externalservice:<image-or-container>, #6123 — no service node is
 //	  fabricated, so the edge dangles honestly unless one already exists, and the
 //	  ref is colon-bounded by containerServiceRef so it can never reach the
@@ -129,7 +134,65 @@ var (
 	// Group 1 = variable, group 2 = mocked type. Used to resolve .Object uses
 	// back to the interface they double.
 	reMoqVarBinding = regexp.MustCompile(`\b(\w+)\s*=\s*new\s+Mock\s*<\s*([\w.]+)\s*>`)
+
+	// #6144 — enclosing type declaration, used to attach the container's
+	// DEPENDS_ON_SERVICE edge to the TEST CLASS rather than to the container
+	// node. Deliberately matches the same four declaration forms the BASE csharp
+	// extractor turns into SCOPE.Component entities (csharp.go:153:
+	// class/interface/struct/record_declaration), because the whole point is to
+	// land on the identity the base extractor already emits — see
+	// enclosingCSharpType.
+	reCSharpTypeDecl = regexp.MustCompile(`(?m)^[\t ]*(?:\[[^\]]*\][\t ]*)*(?:(?:public|internal|private|protected|static|sealed|abstract|partial|file)\s+)*(?:class|record|struct|interface)\s+(\w+)`)
 )
+
+// enclosingCSharpType returns the name of the nearest type declaration that
+// starts at or before offset, or "" when there is none.
+//
+// #6144 — WHY THIS EXISTS AND WHAT IT IS FOR. The container's
+// DEPENDS_ON_SERVICE edge used to hang off the container node itself, so the
+// emitted edge was `container:PostgreSqlContainer -> service PostgreSqlContainer`:
+// both endpoints derived from a single token, and the TEST — the thing this
+// file's package doc says depends on the service — appeared nowhere in it.
+// Attaching the edge to the enclosing test type instead makes it say something
+// a caller cannot already read off the container node's properties: "this test
+// suite needs a Postgres".
+//
+// HOW THE EDGE REACHES THE TEST CLASS WITHOUT FABRICATING A NODE. The FROM
+// endpoint of a relationship is whichever EntityRecord carries it, and this
+// extractor does not emit test classes. It does not need to: MergeWithCustom's
+// Tier A (issue #6104, extractors/custom_dispatch.go) COMBINES a custom record
+// with a base record of the same identity — (SourceFile, Kind, Name) — into one
+// survivor, carrying the custom record's relationships onto it. The base csharp
+// extractor emits every class as Kind="SCOPE.Component", Subtype="class", Name=
+// the class name, in this same file. So emitting a minimal facet with exactly
+// that identity lands the edge on the real class node rather than creating a
+// second one. The facet sets no field the base does not already set to the same
+// value, and its span is a single line at the declaration, so the Tier A span
+// union (min non-zero start, max end) cannot narrow the base class's span.
+//
+// HONEST-PARTIAL, AND WHERE IT STOPS. The scan is lexical and takes the NEAREST
+// PRECEDING declaration; it does not track braces, so a container constructed
+// inside a nested type is attributed to that nested type (correct) but one
+// constructed after a nested type has closed is attributed to the nested type
+// too (wrong). Both are still a type IN THE SAME FILE, so the edge remains
+// vastly more informative than the tautology it replaces, and when no
+// declaration precedes the match at all the caller keeps the edge on the
+// container node rather than dropping it — a relationship the extractor meant
+// to express is never silently lost (#6123).
+// Returns the declaration's byte offset alongside the name so the merge facet
+// can be stamped with the class's own declaration line rather than the
+// container's — a facet line inside the class body would drag the Tier A span
+// union's StartLine down below the real declaration.
+func enclosingCSharpType(src string, offset int) (string, int) {
+	if offset <= 0 || offset > len(src) {
+		return "", 0
+	}
+	name, at := "", 0
+	for _, m := range reCSharpTypeDecl.FindAllStringSubmatchIndex(src[:offset], -1) {
+		name, at = src[m[2]:m[3]], m[2]
+	}
+	return name, at
+}
 
 // reLeafType strips a dotted/namespaced C# type to its leaf token, e.g.
 // "Acme.Domain.IFoo" -> "IFoo". Used so mock targets match the type entities
@@ -283,14 +346,26 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// Container topology — Testcontainers. The test DEPENDS_ON_SERVICE the
 	// container'd service.
 	//
-	// #6144 — that sentence describes the FROM endpoint the extractor MEANT, not
-	// the one it emits. The relationship is appended to `ent` below, so the edge
-	// runs container:X -> service X: both endpoints derive from one token and the
-	// test appears nowhere. The `image` / `container_type` payload is also already
-	// duplicated as properties on the container node, so the edge carries nothing
-	// a caller could not read off the node. Filed separately rather than folded in
-	// here — #6123 is about the TARGET, and repointing the source needs an
-	// enclosing-scope lookup this closure does not do.
+	// #6144 — FIXED: that sentence now describes what is emitted. It previously
+	// described the FROM endpoint the extractor MEANT, not the one it produced:
+	// the relationship was appended to `ent`, so the edge ran
+	// container:X -> service X, both endpoints derived from one token, with the
+	// test nowhere in it. Since the `image` / `container_type` payload is ALSO
+	// duplicated as properties on the container node, the edge carried nothing an
+	// MCP caller could not already read off the node — a tautology, not a
+	// relationship.
+	//
+	// The FROM endpoint is now the enclosing test type (enclosingCSharpType +
+	// the #6104 Tier A identity merge, both documented there). Of the three
+	// options #6144 laid out, this is (1). (2) "drop the edge" was rejected: the
+	// edge is the only thing that would state a test's infrastructure dependency
+	// at all, and #6123's principle — a silently dropped relationship is worse
+	// than an honest dangle, and unmeasurable afterwards — applies once the edge
+	// is no longer vacuous. (3) "keep it and fix the doc" was rejected as
+	// documenting a tautology rather than removing one. The blocker #6144 cited
+	// for (1) — "needs an enclosing-scope lookup this closure does not do" — was
+	// real but small: the lookup is lexical, and the merge mechanism for landing
+	// an edge on an entity another extractor owns already existed.
 	//
 	// #6123 — the target ref. This edge used to carry `service:<name>`, which
 	// LOOKS like the Name of an external-service node (extractor.ExternalServiceName
@@ -355,7 +430,12 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// two are conditional on the ref NOT reaching six segments. See
 	// containerServiceRef.
 	// -------------------------------------------------------------------------
-	emitContainer := func(name, image, ctype string, line int) {
+	// testTypeFacets indexes the #6144 merge facet emitted per enclosing test
+	// type, so several containers in one class accumulate their edges on ONE
+	// facet instead of colliding in `add`'s dedup and losing all but the first.
+	testTypeFacets := make(map[string]int) // type name -> index in entities
+
+	emitContainer := func(name, image, ctype string, offset, line int) {
 		ent := makeEntity("container:"+name, "SCOPE.Pattern", "container_topology",
 			file.Path, "csharp", line)
 		props := []string{"framework", "test_doubles",
@@ -367,18 +447,63 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 			props = append(props, "container_type", ctype)
 		}
 		setProps(&ent, props...)
-		if ref := containerServiceRef(name); ref != "" {
-			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
-				ToID: ref,
-				Kind: string(types.RelationshipKindDependsOnService),
-				Properties: types.Props{
-					{K: "container_type", V: ctype},
-					{K: "framework", V: "test_doubles"},
-					{K: "image", V: image},
-					{K: "line", V: itoa(line)},
-					{K: "role", V: "container_topology"},
-				},
-			})
+
+		ref := containerServiceRef(name)
+		rel := types.RelationshipRecord{
+			ToID: ref,
+			Kind: string(types.RelationshipKindDependsOnService),
+			Properties: types.Props{
+				{K: "container_type", V: ctype},
+				{K: "framework", V: "test_doubles"},
+				{K: "image", V: image},
+				{K: "line", V: itoa(line)},
+				{K: "role", V: "container_topology"},
+			},
+		}
+
+		// #6144 — the FROM endpoint. Prefer the enclosing test type: the edge
+		// then reads "MyIntegrationTests DEPENDS_ON_SERVICE postgres", which is
+		// what the package doc has always claimed and what an MCP caller cannot
+		// reconstruct from the container node alone. Falling back to the
+		// container node when no enclosing type is found keeps the pre-#6144
+		// behaviour rather than dropping the relationship.
+		owner, declAt := "", 0
+		if ref != "" {
+			owner, declAt = enclosingCSharpType(src, offset)
+		}
+		if owner != "" {
+			// Set, not append: types.Props is binary-searched (find/Get) and must
+			// stay key-sorted, so "container" has to be inserted in position.
+			rel.Properties.Set("container", "container:"+name)
+			idx, ok := testTypeFacets[owner]
+			if !ok {
+				// Identity-matched facet for the base extractor's class node —
+				// Kind/Subtype/Name/SourceFile all equal to what csharp.go emits,
+				// so MergeWithCustom Tier A combines rather than duplicating.
+				facet := makeEntity(owner, "SCOPE.Component", "class",
+					file.Path, "csharp", lineOf(src, declAt))
+				setProps(&facet, "framework", "test_doubles",
+					"provenance", "INFERRED_FROM_TESTCONTAINER")
+				before := len(entities)
+				add(facet)
+				if len(entities) == before {
+					// Deduped against an earlier facet for the same type that is
+					// not in the map (cannot happen today, but never silently
+					// drop the edge if it ever does).
+					ent.Relationships = append(ent.Relationships, rel)
+					add(ent)
+					return
+				}
+				idx = len(entities) - 1
+				testTypeFacets[owner] = idx
+			}
+			entities[idx].Relationships = append(entities[idx].Relationships, rel)
+			add(ent)
+			return
+		}
+
+		if ref != "" {
+			ent.Relationships = append(ent.Relationships, rel)
 		}
 		add(ent)
 	}
@@ -389,11 +514,11 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 		if ctype == "ContainerBuilder" {
 			continue
 		}
-		emitContainer(ctype, "", ctype, lineOf(src, m[0]))
+		emitContainer(ctype, "", ctype, m[0], lineOf(src, m[0]))
 	}
 	for _, m := range reTcWithImage.FindAllStringSubmatchIndex(src, -1) {
 		image := src[m[2]:m[3]]
-		emitContainer(image, image, "", lineOf(src, m[0]))
+		emitContainer(image, image, "", m[0], lineOf(src, m[0]))
 	}
 
 	// -------------------------------------------------------------------------

--- a/internal/custom/csharp/test_doubles.go
+++ b/internal/custom/csharp/test_doubles.go
@@ -135,18 +135,42 @@ var (
 	// back to the interface they double.
 	reMoqVarBinding = regexp.MustCompile(`\b(\w+)\s*=\s*new\s+Mock\s*<\s*([\w.]+)\s*>`)
 
-	// #6144 — enclosing type declaration, used to attach the container's
-	// DEPENDS_ON_SERVICE edge to the TEST CLASS rather than to the container
-	// node. Deliberately matches the same four declaration forms the BASE csharp
-	// extractor turns into SCOPE.Component entities (csharp.go:153:
-	// class/interface/struct/record_declaration), because the whole point is to
-	// land on the identity the base extractor already emits — see
-	// enclosingCSharpType.
-	reCSharpTypeDecl = regexp.MustCompile(`(?m)^[\t ]*(?:\[[^\]]*\][\t ]*)*(?:(?:public|internal|private|protected|static|sealed|abstract|partial|file)\s+)*(?:class|record|struct|interface)\s+(\w+)`)
+	// #6144 — enclosing CLASS declaration, used to attach the container's
+	// DEPENDS_ON_SERVICE edge to the test class rather than to the container node.
+	//
+	// PLAIN `class` ONLY, DELIBERATELY. An earlier revision matched the four
+	// declaration forms the base extractor turns into SCOPE.Component entities
+	// (csharp.go:153 — class/interface/struct/record_declaration). That was wrong
+	// twice over, and adversarial review caught the first:
+	//
+	//  1. KEYWORD ORDER. A `(?:class|record|struct|interface)` alternation matches
+	//     `record` FIRST in `record struct Row(int Id)`, capturing the NEXT word —
+	//     "struct" — as the type name. Positional records beside a test class are
+	//     ordinary modern C#, and the consequence is severe: SCOPE.Component/
+	//     class/"struct" matches no base entity, survives the #6104 merge as a
+	//     standalone Tier C node, and carries the edge. That is exactly the node
+	//     fabrication this function's contract promises never happens.
+	//
+	//  2. SUBTYPE. Reordering the alternation fixes the capture but not the
+	//     identity. The facet claims Subtype "class"; the base extractor maps
+	//     record_declaration to "type" and struct_declaration to "struct". Tier A
+	//     keys on (SourceFile, Kind, Name) and lets the CUSTOM value win on
+	//     conflict, so a facet for a record would silently displace the base
+	//     node's Subtype — corrupting an entity to attach an edge to it.
+	//
+	// Matching plain `class` alone removes both. A Testcontainers fixture is
+	// constructed in a class, never in a record or an interface; `class` is the
+	// one form whose base Subtype is unambiguously "class", so the facet can
+	// never displace anything; and a `record struct` declared INSIDE a test class
+	// no longer shadows it, because the nearest preceding `class` is still the
+	// test class — which is the correct attribution anyway. `record class X` is
+	// deliberately NOT matched (its base Subtype is "type"): that falls back to
+	// the container node, which is honest rather than corrupting.
+	reCSharpClassDecl = regexp.MustCompile(`(?m)^[\t ]*(?:\[[^\]]*\][\t ]*)*(?:(?:public|internal|private|protected|static|sealed|abstract|partial|file)\s+)*class\s+(\w+)`)
 )
 
-// enclosingCSharpType returns the name of the nearest type declaration that
-// starts at or before offset, or "" when there is none.
+// enclosingCSharpClass returns the name of the nearest plain `class`
+// declaration that starts at or before offset, or "" when there is none.
 //
 // #6144 — WHY THIS EXISTS AND WHAT IT IS FOR. The container's
 // DEPENDS_ON_SERVICE edge used to hang off the container node itself, so the
@@ -171,24 +195,28 @@ var (
 // union (min non-zero start, max end) cannot narrow the base class's span.
 //
 // HONEST-PARTIAL, AND WHERE IT STOPS. The scan is lexical and takes the NEAREST
-// PRECEDING declaration; it does not track braces, so a container constructed
-// inside a nested type is attributed to that nested type (correct) but one
-// constructed after a nested type has closed is attributed to the nested type
-// too (wrong). Both are still a type IN THE SAME FILE, so the edge remains
-// vastly more informative than the tautology it replaces, and when no
-// declaration precedes the match at all the caller keeps the edge on the
+// PRECEDING class declaration; it does not track braces, so a container
+// constructed inside a nested class is attributed to that nested class (correct)
+// but one constructed after a nested class has closed is attributed to the
+// nested class too (wrong). Both are still a class IN THE SAME FILE, so the edge
+// remains vastly more informative than the tautology it replaces, and when no
+// class declaration precedes the match at all the caller keeps the edge on the
 // container node rather than dropping it — a relationship the extractor meant
-// to express is never silently lost (#6123).
+// to express is never silently lost (#6123). Restricting to `class` also means
+// a record/struct/interface declared INSIDE a test class cannot shadow it; see
+// reCSharpClassDecl for why that restriction is load-bearing and not merely
+// convenient.
+//
 // Returns the declaration's byte offset alongside the name so the merge facet
 // can be stamped with the class's own declaration line rather than the
 // container's — a facet line inside the class body would drag the Tier A span
 // union's StartLine down below the real declaration.
-func enclosingCSharpType(src string, offset int) (string, int) {
+func enclosingCSharpClass(src string, offset int) (string, int) {
 	if offset <= 0 || offset > len(src) {
 		return "", 0
 	}
 	name, at := "", 0
-	for _, m := range reCSharpTypeDecl.FindAllStringSubmatchIndex(src[:offset], -1) {
+	for _, m := range reCSharpClassDecl.FindAllStringSubmatchIndex(src[:offset], -1) {
 		name, at = src[m[2]:m[3]], m[2]
 	}
 	return name, at
@@ -355,7 +383,7 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 	// MCP caller could not already read off the node — a tautology, not a
 	// relationship.
 	//
-	// The FROM endpoint is now the enclosing test type (enclosingCSharpType +
+	// The FROM endpoint is now the enclosing test type (enclosingCSharpClass +
 	// the #6104 Tier A identity merge, both documented there). Of the three
 	// options #6144 laid out, this is (1). (2) "drop the edge" was rejected: the
 	// edge is the only thing that would state a test's infrastructure dependency
@@ -469,7 +497,7 @@ func (e *testDoublesExtractor) Extract(ctx context.Context, file extractor.FileI
 		// behaviour rather than dropping the relationship.
 		owner, declAt := "", 0
 		if ref != "" {
-			owner, declAt = enclosingCSharpType(src, offset)
+			owner, declAt = enclosingCSharpClass(src, offset)
 		}
 		if owner != "" {
 			// Set, not append: types.Props is binary-searched (find/Get) and must

--- a/internal/custom/csharp/test_doubles_test.go
+++ b/internal/custom/csharp/test_doubles_test.go
@@ -26,6 +26,34 @@ func relOf(recs []types.EntityRecord, kind, toID string) *types.RelationshipReco
 	return nil
 }
 
+// relOwnersOf returns every entity carrying a relationship of the given kind to
+// toID — i.e. the FROM endpoints. relOf deliberately searches all records and
+// therefore cannot see which node an edge hangs off; #6144 is entirely about
+// that endpoint, so it needs its own helper.
+func relOwnersOf(recs []types.EntityRecord, kind, toID string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for i := range recs {
+		for j := range recs[i].Relationships {
+			r := &recs[i].Relationships[j]
+			if r.Kind == kind && r.ToID == toID {
+				out = append(out, recs[i])
+				break
+			}
+		}
+	}
+	return out
+}
+
+// recByKindName finds an entity by (Kind, Name).
+func recByKindName(recs []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == kind && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
 func TestTestDoubles_MoqMockBinding(t *testing.T) {
 	src := `
 using Moq;
@@ -482,4 +510,164 @@ public class NotSteps
 			t.Error("step_definition should not fire without [Binding]")
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// #6144 — the DEPENDS_ON_SERVICE **FROM** endpoint.
+// ---------------------------------------------------------------------------
+//
+// #6123 fixed this edge's TARGET. Its SOURCE was a separate defect: the
+// relationship hung off the container node, so the edge ran
+// `container:PostgreSqlContainer -> service PostgreSqlContainer` — both
+// endpoints derived from one token, the test nowhere in it, and the whole
+// payload (image, container_type) already duplicated as properties on the
+// container node. It told an MCP caller nothing grafel_inspect on that node
+// would not.
+//
+// The edge now hangs off the ENCLOSING TEST TYPE, emitted as a merge facet with
+// the identity the base csharp extractor gives that class (SourceFile, Kind
+// SCOPE.Component, Name) so #6104's Tier A combines the two rather than
+// creating a second node.
+//
+// Asserted bidirectionally on CONTENT, not counts: the class must own the edge
+// AND the container node must not, because "the class owns it" alone would also
+// be satisfied by emitting the edge twice.
+
+func TestTestDoubles_ContainerServiceEdgeHangsOffTheTestType6144(t *testing.T) {
+	src := `
+using Testcontainers.PostgreSql;
+using DotNet.Testcontainers.Builders;
+using Xunit;
+
+public class OrderIntegrationTests
+{
+    public OrderIntegrationTests()
+    {
+        var pg = new PostgreSqlContainer();
+        var cache = new ContainerBuilder()
+            .WithImage("redis:7")
+            .Build();
+    }
+}
+`
+	recs := extractFull(t, "custom_csharp_test_doubles", fi("OrderIntegrationTests.cs", "csharp", src))
+
+	pgRef := extractor.ExternalServiceTargetID("PostgreSqlContainer")
+	redisRef := extractor.ExternalServiceTargetID("redis:7")
+
+	for _, tc := range []struct{ what, ref, container string }{
+		{"typed container", pgRef, "container:PostgreSqlContainer"},
+		{"image binding", redisRef, "container:redis:7"},
+	} {
+		owners := relOwnersOf(recs, "DEPENDS_ON_SERVICE", tc.ref)
+		if len(owners) != 1 {
+			t.Fatalf("%s: expected exactly 1 entity to own the DEPENDS_ON_SERVICE edge to %s, got %d (%v)",
+				tc.what, tc.ref, len(owners), ownerNames(owners))
+		}
+		owner := owners[0]
+
+		// FORWARD: the owner is the test type, with the identity the base
+		// extractor gives it — anything else creates a second node instead of
+		// merging onto the class (#6104 Tier A keys on SourceFile+Kind+Name).
+		if owner.Name != "OrderIntegrationTests" {
+			t.Errorf("%s: DEPENDS_ON_SERVICE hangs off %q, want the enclosing test type "+
+				"%q — the edge is tautological when it hangs off the container (#6144)",
+				tc.what, owner.Name, "OrderIntegrationTests")
+		}
+		if owner.Kind != "SCOPE.Component" || owner.Subtype != "class" {
+			t.Errorf("%s: owner is %s/%s, want SCOPE.Component/class so #6104 Tier A merges it "+
+				"onto the base extractor's class node instead of adding a duplicate",
+				tc.what, owner.Kind, owner.Subtype)
+		}
+		if owner.SourceFile != "OrderIntegrationTests.cs" {
+			t.Errorf("%s: owner SourceFile = %q, want the file under extraction — identity must "+
+				"match the base class node exactly", tc.what, owner.SourceFile)
+		}
+
+		// REVERSE: the container node must NOT also carry it.
+		if c := recByKindName(recs, "SCOPE.Pattern", tc.container); c == nil {
+			t.Errorf("%s: container node %q was not emitted at all", tc.what, tc.container)
+		} else {
+			for _, r := range c.Relationships {
+				if r.Kind == "DEPENDS_ON_SERVICE" {
+					t.Errorf("%s: the container node %q still carries a DEPENDS_ON_SERVICE edge to %q — "+
+						"the tautological edge was duplicated, not moved (#6144)", tc.what, tc.container, r.ToID)
+				}
+			}
+		}
+
+		// The edge must still name the container it came from, or moving the
+		// FROM endpoint would LOSE the association the old shape encoded.
+		e := relOf(recs, "DEPENDS_ON_SERVICE", tc.ref)
+		if got := e.Properties.Get("container"); got != tc.container {
+			t.Errorf("%s: edge property container = %q, want %q — the class-level edge must still "+
+				"say which container produced it", tc.what, got, tc.container)
+		}
+	}
+
+	// The container nodes keep their own payload: moving the edge must not
+	// strip the properties an MCP caller reads off the node.
+	if c := recByKindName(recs, "SCOPE.Pattern", "container:PostgreSqlContainer"); c == nil {
+		t.Fatal("container:PostgreSqlContainer node missing")
+	} else if c.Properties["container_type"] != "PostgreSqlContainer" {
+		t.Errorf("container node lost its container_type property: %v", c.Properties)
+	}
+	if c := recByKindName(recs, "SCOPE.Pattern", "container:redis:7"); c == nil {
+		t.Fatal("container:redis:7 node missing")
+	} else if c.Properties["image"] != "redis:7" {
+		t.Errorf("container node lost its image property: %v", c.Properties)
+	}
+
+	// Exactly ONE facet for the test type, however many containers it holds —
+	// otherwise `add`'s dedup silently drops all but the first edge.
+	facets := 0
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" && r.Name == "OrderIntegrationTests" {
+			facets++
+		}
+	}
+	if facets != 1 {
+		t.Errorf("emitted %d SCOPE.Component/OrderIntegrationTests records, want exactly 1 "+
+			"(two containers in one class must share one merge facet)", facets)
+	}
+}
+
+// TestTestDoubles_ContainerEdgeFallsBackToTheContainerNode6144 pins the
+// fallback: with no enclosing type there is nothing to re-point at, and the
+// edge must stay on the container node rather than being dropped — #6123's
+// principle that a silently dropped relationship is worse than an honest
+// dangle, and unmeasurable afterwards.
+func TestTestDoubles_ContainerEdgeFallsBackToTheContainerNode6144(t *testing.T) {
+	// Top-level statements: no class declaration anywhere in the file.
+	src := `
+using Testcontainers.PostgreSql;
+
+var pg = new PostgreSqlContainer();
+`
+	recs := extractFull(t, "custom_csharp_test_doubles", fi("Program.cs", "csharp", src))
+
+	ref := extractor.ExternalServiceTargetID("PostgreSqlContainer")
+	owners := relOwnersOf(recs, "DEPENDS_ON_SERVICE", ref)
+	if len(owners) != 1 {
+		t.Fatalf("expected the edge to survive with no enclosing type, got %d owners (%v)",
+			len(owners), ownerNames(owners))
+	}
+	if owners[0].Name != "container:PostgreSqlContainer" {
+		t.Errorf("fallback owner = %q, want the container node — with no test type to attribute "+
+			"the dependency to, the pre-#6144 shape is the honest one", owners[0].Name)
+	}
+	// And no phantom class facet may be invented for a file that has no class.
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" {
+			t.Errorf("invented a SCOPE.Component %q for a file with no type declaration", r.Name)
+		}
+	}
+}
+
+func ownerNames(recs []types.EntityRecord) []string {
+	out := make([]string, 0, len(recs))
+	for _, r := range recs {
+		out = append(out, r.Kind+"/"+r.Name)
+	}
+	return out
 }

--- a/internal/custom/csharp/test_doubles_test.go
+++ b/internal/custom/csharp/test_doubles_test.go
@@ -671,3 +671,153 @@ func ownerNames(recs []types.EntityRecord) []string {
 	}
 	return out
 }
+
+// TestTestDoubles_RecordStructDoesNotFabricateAComponent6144 is the regression
+// test for the node-fabrication defect adversarial review found in the #6144
+// enclosing-class scan.
+//
+// The original regex alternated `(?:class|record|struct|interface)`, and Go's
+// regexp is leftmost-first over an alternation, so `record struct Row(int Id)`
+// matched `record` and captured the FOLLOWING word — "struct" — as the type
+// name. A positional record beside a test class is ordinary modern C#, so when
+// one was the nearest preceding declaration the extractor emitted
+// SCOPE.Component/class/"struct": an entity matching nothing the base extractor
+// produces, surviving the #6104 merge as a standalone Tier C node, and carrying
+// the DEPENDS_ON_SERVICE edge. That is precisely the fabrication
+// enclosingCSharpClass's contract says never happens, and which
+// TestTestDoubles_ContainerEdgeFallsBackToTheContainerNode6144 asserts against
+// in the no-class case.
+//
+// Restricting the scan to plain `class` fixes it at the root: the record is
+// skipped entirely, so the nearest preceding class is the enclosing test class —
+// which is also the correct attribution. Asserted on content in both directions:
+// the bogus names must be absent AND the edge must land on the real class.
+func TestTestDoubles_RecordStructDoesNotFabricateAComponent6144(t *testing.T) {
+	src := `
+using Testcontainers.PostgreSql;
+using Xunit;
+
+public class OrderIntegrationTests
+{
+    public record struct Row(int Id);
+    public record class Boxed(int Id);
+    public readonly struct Flag { }
+    public interface IMarker { }
+
+    public OrderIntegrationTests()
+    {
+        var pg = new PostgreSqlContainer();
+    }
+}
+`
+	recs := extractFull(t, "custom_csharp_test_doubles", fi("OrderIntegrationTests.cs", "csharp", src))
+
+	// No component may be named after a KEYWORD — that is the fabrication.
+	for _, r := range recs {
+		for _, kw := range []string{"struct", "class", "record", "interface"} {
+			if r.Name == kw {
+				t.Errorf("fabricated an entity named after the keyword %q (%s/%s in %s) — the "+
+					"declaration scan captured a keyword as a type name", kw, r.Kind, r.Subtype, r.SourceFile)
+			}
+		}
+	}
+
+	// The edge must land on the enclosing test class, not on Row/Boxed/Flag/
+	// IMarker (whose base Subtypes are type/type/struct/interface, so a facet
+	// claiming "class" would displace them) and not on a keyword.
+	ref := extractor.ExternalServiceTargetID("PostgreSqlContainer")
+	owners := relOwnersOf(recs, "DEPENDS_ON_SERVICE", ref)
+	if len(owners) != 1 {
+		t.Fatalf("expected exactly 1 owner for the DEPENDS_ON_SERVICE edge, got %d (%v)",
+			len(owners), ownerNames(owners))
+	}
+	if owners[0].Name != "OrderIntegrationTests" || owners[0].Kind != "SCOPE.Component" {
+		t.Errorf("edge owner = %s/%s, want SCOPE.Component/OrderIntegrationTests — a record or "+
+			"struct declared inside the test class must not shadow it",
+			owners[0].Kind, owners[0].Name)
+	}
+	if owners[0].Subtype != "class" {
+		t.Errorf("edge owner Subtype = %q, want \"class\"; the facet must only ever claim the "+
+			"subtype the base extractor gives a class_declaration, or the #6104 Tier A merge "+
+			"lets it displace a record's \"type\" or a struct's \"struct\"", owners[0].Subtype)
+	}
+
+	// Exactly one component facet, and it is the test class.
+	comps := 0
+	for _, r := range recs {
+		if r.Kind == "SCOPE.Component" {
+			comps++
+			if r.Name != "OrderIntegrationTests" {
+				t.Errorf("unexpected SCOPE.Component %q — this extractor may only ever emit a "+
+					"facet for the enclosing test class", r.Name)
+			}
+		}
+	}
+	if comps != 1 {
+		t.Errorf("emitted %d SCOPE.Component records, want exactly 1", comps)
+	}
+}
+
+// TestTestDoubles_RecordStructImmediatelyBeforeContainer6144 is the narrow
+// shape: the `record struct` is the LAST declaration before the container
+// construction, so under the old alternation it was the nearest preceding match
+// and its bogus capture — the literal word "struct" — became the emitted entity
+// name. The sibling test above happens to have an interface nearer the
+// container, which catches the shadowing but not the capture itself.
+func TestTestDoubles_RecordStructImmediatelyBeforeContainer6144(t *testing.T) {
+	src := `
+using Testcontainers.PostgreSql;
+using Xunit;
+
+public class DbFixtureTests
+{
+    public DbFixtureTests()
+    {
+        var pg = new PostgreSqlContainer();
+    }
+
+    public record struct Row(int Id);
+}
+`
+	// NOTE the container is constructed BEFORE the record here, so the nearest
+	// preceding declaration is the class. The inverse ordering is covered below.
+	recs := extractFull(t, "custom_csharp_test_doubles", fi("DbFixtureTests.cs", "csharp", src))
+	assertContainerOwnedByClass6144(t, recs, "DbFixtureTests")
+
+	// Now the ordering that actually triggered the defect.
+	src2 := `
+using Testcontainers.PostgreSql;
+using Xunit;
+
+public class DbFixtureTests
+{
+    public record struct Row(int Id);
+
+    public DbFixtureTests()
+    {
+        var pg = new PostgreSqlContainer();
+    }
+}
+`
+	recs2 := extractFull(t, "custom_csharp_test_doubles", fi("DbFixtureTests.cs", "csharp", src2))
+	assertContainerOwnedByClass6144(t, recs2, "DbFixtureTests")
+}
+
+func assertContainerOwnedByClass6144(t *testing.T, recs []types.EntityRecord, class string) {
+	t.Helper()
+	for _, r := range recs {
+		if r.Name == "struct" || r.Name == "class" || r.Name == "record" || r.Name == "interface" {
+			t.Fatalf("emitted an entity named after the keyword %q (%s/%s) — the declaration scan "+
+				"captured the word after `record` as the type name (#6144)", r.Name, r.Kind, r.Subtype)
+		}
+	}
+	owners := relOwnersOf(recs, "DEPENDS_ON_SERVICE",
+		extractor.ExternalServiceTargetID("PostgreSqlContainer"))
+	if len(owners) != 1 {
+		t.Fatalf("expected 1 DEPENDS_ON_SERVICE owner, got %d (%v)", len(owners), ownerNames(owners))
+	}
+	if owners[0].Name != class || owners[0].Kind != "SCOPE.Component" || owners[0].Subtype != "class" {
+		t.Errorf("edge owner = %s/%s/%s, want SCOPE.Component/class/%s",
+			owners[0].Kind, owners[0].Subtype, owners[0].Name, class)
+	}
+}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -110,6 +110,25 @@ func isolateDaemonEnv(t *testing.T) string {
 		}
 	}
 	t.Setenv(daemon.EnvRoot, root)
+	// #6134 — GRAFEL_DAEMON_ROOT ALONE DOES NOT ISOLATE THIS DAEMON.
+	//
+	// EnvRoot is read by DefaultLayout, so it moves the socket, pidfile and log
+	// dir into the sandbox. It is NOT read by StoreDir(), which resolves
+	// homeDir()/store, i.e. $GRAFEL_HOME or ~/.grafel — and Run()'s startup tail
+	// calls MigrateToRefStore(StoreDir()) AND PruneStaleGenerations(StoreDir())
+	// (server.go), with startEnginePlane doing the same. Every test that starts a
+	// daemon in-process was therefore migrating the layout of, and DELETING
+	// generations from, the developer's live store — while their real daemon was
+	// serving MCP out of it. StoreDir's own doc already claims it is the store
+	// root "when no isolated GRAFEL_DAEMON_ROOT is in effect"; nothing enforced
+	// that, so the enforcement is here, at the isolation boundary.
+	//
+	// isolateSupervisorEnv (supervise_test.go) already sets both for exactly this
+	// reason. This is the same pin, applied to the harness the rest of the
+	// package's daemon tests go through.
+	//
+	// Pinned by TestIsolateDaemonEnvAlsoIsolatesTheStore.
+	t.Setenv("GRAFEL_HOME", root)
 	t.Setenv(daemon.EnvDisableSelfDefense, "1")
 	return root
 }

--- a/internal/daemon/selfdefense_test.go
+++ b/internal/daemon/selfdefense_test.go
@@ -148,7 +148,19 @@ func TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary(t *testing.T) {
 
 	var stderrBuf strings.Builder
 	cmd := exec.CommandContext(ctx, helperBin, "daemon")
-	cmd.Env = append(os.Environ(), "GRAFEL_DAEMON_ROOT="+daemonRoot)
+	// #6134 — GRAFEL_HOME must be pinned alongside the daemon root, and via the
+	// daemon.EnvRoot CONSTANT rather than a raw literal.
+	//
+	// The root only isolates DefaultLayout (socket/pid/log); daemon.StoreDir()
+	// resolves $GRAFEL_HOME (else ~/.grafel) + "/store", which this child would
+	// otherwise inherit from the developer's real environment via os.Environ() —
+	// and its startup tail runs MigrateToRefStore and PruneStaleGenerations
+	// against it, mutating and pruning the live store.
+	//
+	// The raw string literal is also why the original #6134 sweep missed this
+	// site: it greps for daemon.EnvRoot, and a literal does not match. Using the
+	// constant keeps this line discoverable by the next audit.
+	cmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot)
 	cmd.Stderr = &stderrBuf
 
 	waitErr := cmd.Run()

--- a/internal/daemon/store_isolation_6134_test.go
+++ b/internal/daemon/store_isolation_6134_test.go
@@ -1,0 +1,95 @@
+package daemon_test
+
+// store_isolation_6134_test.go — #6134, the hygiene half.
+//
+// Run()'s startup tail does two things to StoreDir(): MigrateToRefStore, which
+// RELOCATES legacy flat-layout artifacts into per-ref sub-directories, and
+// PruneStaleGenerations, which DELETES generations beyond keepN. Both take
+// StoreDir() — homeDir()/store — not anything derived from cfg.Layout.
+//
+// isolateDaemonEnv used to set only GRAFEL_DAEMON_ROOT, which DefaultLayout
+// reads and StoreDir does not. So every test in this package that starts a
+// daemon in-process ran a migration and a pruning pass over the developer's
+// real ~/.grafel/store — concurrently with the real daemon serving MCP out of
+// it. `go test ./internal/daemon/` mutated live user state.
+//
+// The assertion below is on the resolved path, not on a call count, and it is
+// bidirectional: the store must be INSIDE the sandbox root and must NOT be
+// under the real user home. Either half alone is satisfiable by an accident —
+// a store under /tmp that is not this test's root would pass the second check,
+// and a root that happened to sit under the home dir would pass the first.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+// TestIsolateDaemonEnvAlsoIsolatesTheStore is the RED/GREEN test for the
+// #6134 hygiene defect. Before the GRAFEL_HOME pin in isolateDaemonEnv this
+// fails with a StoreDir under the developer's real home.
+func TestIsolateDaemonEnvAlsoIsolatesTheStore(t *testing.T) {
+	root := isolateDaemonEnv(t)
+
+	store := daemon.StoreDir()
+	if store == "" {
+		t.Fatal("StoreDir() is empty; server.go skips the migration entirely on empty, so this test would be vacuous")
+	}
+
+	// (1) The store must live inside the sandbox this test was handed.
+	rel, err := filepath.Rel(root, store)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("StoreDir() = %q is not under the isolated daemon root %q (rel=%q, err=%v): "+
+			"MigrateToRefStore and PruneStaleGenerations would run against it from daemon.Run",
+			store, root, rel, err)
+	}
+
+	// (2) And it must not be under the real user home, independently of (1) —
+	// this is the check that actually names the damage.
+	if realHome := testsupport.RealUserHome(); realHome != "" {
+		hrel, herr := filepath.Rel(realHome, store)
+		if herr == nil && !strings.HasPrefix(hrel, "..") && hrel != "." {
+			t.Fatalf("StoreDir() = %q resolves under the REAL user home %q — running this suite "+
+				"migrates and prunes the developer's live store (#6134)", store, realHome)
+		}
+	}
+
+	// (3) Fixture validity: the layout the daemon would actually use must agree
+	// with the root, so a passing (1)+(2) cannot come from an isolation that
+	// moved the store somewhere the daemon does not look.
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if layout.Root != root {
+		t.Fatalf("DefaultLayout().Root = %q, want the isolated root %q", layout.Root, root)
+	}
+}
+
+// TestIsolateDaemonEnvStoreIsWritableSandbox proves the isolated store path is
+// a usable location rather than merely a different string — a pin that points
+// at an unwritable path would "isolate" the suite by making every daemon
+// startup log a warning instead of doing the work.
+func TestIsolateDaemonEnvStoreIsWritableSandbox(t *testing.T) {
+	isolateDaemonEnv(t)
+
+	store := daemon.StoreDir()
+	if err := os.MkdirAll(store, 0o755); err != nil {
+		t.Fatalf("mkdir isolated store %q: %v", store, err)
+	}
+	probe := filepath.Join(store, "probe.txt")
+	if err := os.WriteFile(probe, []byte("6134"), 0o600); err != nil {
+		t.Fatalf("write into isolated store %q: %v", probe, err)
+	}
+	got, err := os.ReadFile(probe)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != "6134" {
+		t.Fatalf("read back %q, want %q", got, "6134")
+	}
+}

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -42,7 +42,9 @@ type Extractor struct{}
 func (e *Extractor) Language() string { return "dockerfile" }
 
 // Extract walks the tree-sitter CST and returns a single EntityRecord for the
-// Dockerfile file. On nil tree or empty src, returns empty slice with nil error.
+// Dockerfile file. On empty src, returns an empty slice with nil error; on a nil
+// tree with non-empty src it parses the content itself (under the daemon-wide
+// parse gate) rather than bailing — see the #6154 note on the guard below.
 func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("extractor.dockerfile")
 	ctx, span := tracer.Start(ctx, "indexer.extract.dockerfile",
@@ -50,7 +52,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	)
 	defer span.End()
 
-	if file.TSTree == nil || len(file.Content) == 0 {
+	// #6154 — this guard used to also bail on `file.TSTree == nil`, which made
+	// the self-parse fallback at the `if tree == nil` block below UNREACHABLE:
+	// the only way to reach it was with a nil tree, and a nil tree returned here
+	// first. The other six AcquireParseSlot self-parse extractors (python,
+	// golang, html, hcl, cpp, yaml) guard on empty content ONLY, so their
+	// fallbacks are live; dockerfile was the sole outlier, and the dead block
+	// read as coverage in two contradictory audits at once. Guard on content
+	// alone, matching the other six, so the fallback the comment below describes
+	// can actually run.
+	if len(file.Content) == 0 {
 		span.SetAttributes(
 			attribute.Int("file_line_count", 0),
 			attribute.Int("entity_count", 0),

--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -19,8 +19,10 @@ package dockerfile
 import (
 	"context"
 	"encoding/json"
-	"github.com/cajasmota/grafel/internal/indexstate"
+	"fmt"
 	"strings"
+
+	"github.com/cajasmota/grafel/internal/indexstate"
 
 	"github.com/cajasmota/grafel/internal/treesitter/ts"
 	"go.opentelemetry.io/otel"
@@ -71,6 +73,22 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	// Reuse pre-parsed tree or parse inline.
+	//
+	// #6154 — WHAT A NIL TSTree ACTUALLY MEANS AT THE PRODUCTION CALL SITE, and
+	// the one place this fallback is in tension with the rest of the pipeline.
+	// index.go:3447 leaves TSTree nil whenever the factory's Parse returned an
+	// error, and ErrHighSyntaxErrorRate is exactly that case — a file the
+	// syntax-error gate deliberately rejected. Re-parsing here does not consult
+	// that gate, so a rejected Dockerfile is extracted rather than skipped.
+	//
+	// This is currently harmless and is left deliberately: the re-parse produces
+	// the same mostly-ERROR tree the gate saw, and buildDockerfileEntity walks it
+	// to the same (empty or near-empty) result, so both paths agree — the parity
+	// asserted in dockerfile_test.go. But it does narrow the claim at
+	// incremental.go:565-568 that "both paths emit nothing and neither is
+	// lying": here the fallback path emits nothing because the tree is bad, not
+	// because it declined to look. If the gate ever grows a policy the extractor
+	// must honour, this is the site that has to consult it.
 	tree := file.TSTree
 	if tree == nil {
 		parser, perr := dockerfileAdapter.NewParser(dockerfileGrammar())
@@ -96,6 +114,24 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		if err != nil {
 			return nil, err
 		}
+		// #6154 — NIL TREE WITH A NIL ERROR IS REACHABLE, and making this
+		// fallback live is what makes it reachable HERE. official.Parse returns
+		// (nil, nil) when the parse watchdog is disabled (timeout == 0,
+		// ts/official/official.go:155) — it only converts a nil tree into
+		// ErrParseDeadlineExceeded while the watchdog is armed. Without this
+		// guard the tree.RootNode() below is a nil dereference on a path that
+		// did not exist before this change. python (extractor.go:142) and golang
+		// (:108) both guard exactly here; dockerfile now matches them.
+		if tree == nil {
+			return nil, fmt.Errorf("dockerfile extractor: parse produced nil tree")
+		}
+		// Close ONLY the tree we parsed ourselves — file.TSTree belongs to the
+		// caller and is closed by the indexer. Without this the CST leaks for the
+		// daemon's lifetime: #5963 (see treesitter/parser.go) measures a
+		// tree-sitter CST at ~19.7 bytes of C heap per source byte, and v0.24
+		// attaches no finalizer, so nothing reclaims it. Scoped to the function,
+		// not the parse closure, because the node walk below still needs the tree.
+		defer tree.Close()
 	}
 
 	lineCount := strings.Count(string(file.Content), "\n") + 1

--- a/internal/extractors/dockerfile/dockerfile_test.go
+++ b/internal/extractors/dockerfile/dockerfile_test.go
@@ -105,8 +105,33 @@ func TestDockerfileExtractor_EmptyContent(t *testing.T) {
 // Asserted by EQUIVALENCE, not by a count: self-parsing must produce the same
 // entity content as the pre-parsed path. A count-only assertion would pass on a
 // fallback that parsed garbage.
+//
+// WHAT THIS EQUIVALENCE DOES AND DOES NOT COVER. parseForTest builds the same
+// adapter and grammar the fallback does (tsofficial + tsdockerfile), so the two
+// sides run the SAME parser — this pins that the fallback WIRES the parser
+// correctly and walks the resulting tree the same way, not that the official
+// binding agrees with the production ParserFactory path. The factory adds the
+// parse watchdog and the shared gate; the fallback's use of the gate is asserted
+// separately by the AcquireParseSlot wiring, and its nil-tree contract by
+// nil_tree_6154_internal_test.go.
+//
+// The property comparison is over the WHOLE map rather than a named subset. An
+// earlier revision listed three keys, one of which (`base_image`) the extractor
+// never emits — a comparison of "" against "" that looked like coverage and was
+// not. Comparing every key cannot go vacuous that way, and the non-vacuity check
+// below pins that the map is non-trivial in the first place.
 func TestDockerfileExtractor_NilTreeSelfParses6154(t *testing.T) {
-	const src = "FROM ubuntu:22.04\nRUN apt-get update\nEXPOSE 8080\n"
+	// Exercises every instruction family the entity folds into properties
+	// (#2063): multi-stage FROM, RUN, COPY --from, EXPOSE, ENV, ARG, ENTRYPOINT.
+	const src = `FROM golang:1.22 AS build
+ARG VERSION=1.0
+RUN go build -o /app ./...
+FROM ubuntu:22.04
+COPY --from=build /app /usr/bin/app
+ENV MODE=prod
+EXPOSE 8080
+ENTRYPOINT ["/usr/bin/app"]
+`
 
 	selfParsed := extractEntities(t, "Dockerfile", src, nil)
 	if len(selfParsed) == 0 {
@@ -130,11 +155,32 @@ func TestDockerfileExtractor_NilTreeSelfParses6154(t *testing.T) {
 			t.Errorf("entity %d: SourceFile %q vs %q", i, got.SourceFile, want.SourceFile)
 		}
 		// The instruction detail is folded into properties (#2063), so this is
-		// where a wrongly-parsed tree would actually show up.
-		for _, key := range []string{"base_image", "stages", "exposed_ports"} {
-			if got.Properties[key] != want.Properties[key] {
-				t.Errorf("entity %d: property %q = %q on the self-parse path, %q on the pre-parsed path",
-					i, key, got.Properties[key], want.Properties[key])
+		// where a wrongly-parsed tree would actually show up. Compare the whole
+		// map in both directions — a one-sided loop misses keys the self-parse
+		// path failed to emit at all.
+		if len(got.Properties) != len(want.Properties) {
+			t.Errorf("entity %d: %d properties self-parsed vs %d pre-parsed (%v vs %v)",
+				i, len(got.Properties), len(want.Properties), got.Properties, want.Properties)
+		}
+		for k, wv := range want.Properties {
+			if gv, ok := got.Properties[k]; !ok {
+				t.Errorf("entity %d: property %q missing on the self-parse path (want %q)", i, k, wv)
+			} else if gv != wv {
+				t.Errorf("entity %d: property %q = %q self-parsed, %q pre-parsed", i, k, gv, wv)
+			}
+		}
+		for k := range got.Properties {
+			if _, ok := want.Properties[k]; !ok {
+				t.Errorf("entity %d: property %q only on the self-parse path", i, k)
+			}
+		}
+		// NON-VACUITY: the instruction-derived properties must actually be
+		// populated, or the whole comparison above comes down to two identical
+		// near-empty maps.
+		for _, key := range []string{"stages", "exposed_ports", "env_vars", "build_args", "entrypoint"} {
+			if want.Properties[key] == "" {
+				t.Errorf("fixture no longer populates %q — the property equivalence above is "+
+					"comparing empty against empty for that key", key)
 			}
 		}
 		if len(got.Relationships) != len(want.Relationships) {

--- a/internal/extractors/dockerfile/dockerfile_test.go
+++ b/internal/extractors/dockerfile/dockerfile_test.go
@@ -83,19 +83,93 @@ func TestDockerfileExtractor_EmptyContent(t *testing.T) {
 	}
 }
 
-func TestDockerfileExtractor_NilTree(t *testing.T) {
+// TestDockerfileExtractor_NilTreeSelfParses6154 replaces the old
+// TestDockerfileExtractor_NilTree, which asserted "nil tree -> 0 entities".
+//
+// #6154 — THAT ASSERTION WAS PINNING DEAD CODE. Extract's guard bailed on
+// `file.TSTree == nil || len(Content) == 0`, so the `if tree == nil { …
+// AcquireParseSlot … parser.Parse … }` fallback below it could never run: the
+// only input that reaches it is a nil tree, and a nil tree returned first. The
+// block was unreachable while READING as coverage — it made dockerfile appear
+// simultaneously in the audit list of extractors that bail on a nil tree and in
+// the list that already self-parse. Both were literally true; the second was
+// dead, and the ambiguity cost real time in #6151, where the extractor set was
+// miscounted three times.
+//
+// The other six AcquireParseSlot self-parse extractors (python, golang, html,
+// hcl, cpp, yaml) guard on empty content ONLY, so their fallbacks are live.
+// dockerfile now matches them, which makes the fallback reachable rather than
+// deleting it — the option the issue preferred, since the incremental path can
+// legitimately hand over content without a tree.
+//
+// Asserted by EQUIVALENCE, not by a count: self-parsing must produce the same
+// entity content as the pre-parsed path. A count-only assertion would pass on a
+// fallback that parsed garbage.
+func TestDockerfileExtractor_NilTreeSelfParses6154(t *testing.T) {
+	const src = "FROM ubuntu:22.04\nRUN apt-get update\nEXPOSE 8080\n"
+
+	selfParsed := extractEntities(t, "Dockerfile", src, nil)
+	if len(selfParsed) == 0 {
+		t.Fatal("nil tree + non-empty content produced no entities — the self-parse fallback is " +
+			"still unreachable (#6154)")
+	}
+
+	preParsed := extractEntities(t, "Dockerfile", src, parseForTest(t, src))
+	if len(preParsed) != len(selfParsed) {
+		t.Fatalf("self-parse produced %d entities, pre-parsed path produced %d — the fallback is "+
+			"reachable but not equivalent", len(selfParsed), len(preParsed))
+	}
+
+	for i := range preParsed {
+		got, want := selfParsed[i], preParsed[i]
+		if got.Name != want.Name || got.Kind != want.Kind || got.Subtype != want.Subtype {
+			t.Errorf("entity %d: self-parse gave %s/%s/%s, pre-parsed gave %s/%s/%s",
+				i, got.Kind, got.Subtype, got.Name, want.Kind, want.Subtype, want.Name)
+		}
+		if got.SourceFile != want.SourceFile {
+			t.Errorf("entity %d: SourceFile %q vs %q", i, got.SourceFile, want.SourceFile)
+		}
+		// The instruction detail is folded into properties (#2063), so this is
+		// where a wrongly-parsed tree would actually show up.
+		for _, key := range []string{"base_image", "stages", "exposed_ports"} {
+			if got.Properties[key] != want.Properties[key] {
+				t.Errorf("entity %d: property %q = %q on the self-parse path, %q on the pre-parsed path",
+					i, key, got.Properties[key], want.Properties[key])
+			}
+		}
+		if len(got.Relationships) != len(want.Relationships) {
+			t.Errorf("entity %d: %d relationships self-parsed vs %d pre-parsed",
+				i, len(got.Relationships), len(want.Relationships))
+			continue
+		}
+		for j := range want.Relationships {
+			if got.Relationships[j].ToID != want.Relationships[j].ToID ||
+				got.Relationships[j].Kind != want.Relationships[j].Kind {
+				t.Errorf("entity %d rel %d: %s->%s self-parsed, %s->%s pre-parsed", i, j,
+					got.Relationships[j].Kind, got.Relationships[j].ToID,
+					want.Relationships[j].Kind, want.Relationships[j].ToID)
+			}
+		}
+	}
+}
+
+// TestDockerfileExtractor_NilTreeEmptyContent6154 keeps the other half of the
+// old guard: content is still the thing that decides whether there is anything
+// to do, and a nil tree with no content must stay a no-op rather than parsing
+// an empty buffer.
+func TestDockerfileExtractor_NilTreeEmptyContent6154(t *testing.T) {
 	ext, _ := extractor.Get("dockerfile")
 	entities, err := ext.Extract(context.Background(), extractor.FileInput{
 		Path:     "Dockerfile",
-		Content:  []byte("FROM ubuntu:22.04\n"),
+		Content:  nil,
 		Language: "dockerfile",
-		TSTree:   nil, // nil tree → empty result per spec
+		TSTree:   nil,
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(entities) != 0 {
-		t.Errorf("expected 0 entities for nil tree, got %d", len(entities))
+		t.Errorf("expected 0 entities for nil tree + no content, got %d", len(entities))
 	}
 }
 

--- a/internal/extractors/dockerfile/grammar.go
+++ b/internal/extractors/dockerfile/grammar.go
@@ -12,4 +12,11 @@ import (
 
 func dockerfileGrammar() ts.Language { return tsdockerfile.Language() }
 
-var dockerfileAdapter = tsofficial.New()
+// Declared as the ts.Adapter INTERFACE rather than the concrete type so a test
+// can substitute a binding stub. #6154 made the extractor's self-parse fallback
+// reachable, and ts.Parser.Parse is documented to return "nil if the binding
+// produced no tree" (ts.go:136) — official.Parse does exactly that, with a nil
+// error, whenever the parse watchdog is disabled (official.go:155). That nil
+// tree is a real input to the fallback and the only way to exercise its guard is
+// to inject a parser that produces one.
+var dockerfileAdapter ts.Adapter = tsofficial.New()

--- a/internal/extractors/dockerfile/nil_tree_6154_internal_test.go
+++ b/internal/extractors/dockerfile/nil_tree_6154_internal_test.go
@@ -1,0 +1,142 @@
+package dockerfile
+
+// nil_tree_6154_internal_test.go — the self-parse fallback's nil-tree guard.
+//
+// #6154 made this fallback reachable (before, a nil TSTree returned at the top
+// guard, so the block could never run). That newly-live path ends in
+// tree.RootNode(), and ts.Parser.Parse is documented to return "nil if the
+// binding produced no tree" (ts/ts.go:136) — official.Parse returns (nil, nil)
+// whenever the parse watchdog is disabled (ts/official/official.go:155; it only
+// converts a nil tree into ErrParseDeadlineExceeded while the watchdog is
+// armed). python (extractor.go:142) and golang (:108) both guard exactly here.
+//
+// So this is not a hypothetical: making the fallback live is precisely what
+// makes a nil dereference reachable, and the guard has to be pinned
+// behaviourally rather than by inspection. Removing it turns this test into a
+// panic rather than a failed assertion — which is the point.
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/treesitter/ts"
+	tsofficial "github.com/cajasmota/grafel/internal/treesitter/ts/official"
+)
+
+// nilTreeAdapter produces parsers that return (nil, nil) — the documented
+// "binding produced no tree" case, with no error to distinguish it.
+type nilTreeAdapter struct{}
+
+func (nilTreeAdapter) Name() string { return "official" }
+
+func (nilTreeAdapter) NewParser(ts.Language) (ts.Parser, error) { return nilTreeParser{}, nil }
+
+type nilTreeParser struct{}
+
+func (nilTreeParser) Parse([]byte) (ts.Tree, error) { return nil, nil }
+func (nilTreeParser) Close()                        {}
+
+// TestDockerfileSelfParseGuardsNilTree6154 pins that a nil tree from the
+// fallback parse is reported as an error rather than dereferenced.
+func TestDockerfileSelfParseGuardsNilTree6154(t *testing.T) {
+	prev := dockerfileAdapter
+	dockerfileAdapter = nilTreeAdapter{}
+	t.Cleanup(func() { dockerfileAdapter = prev })
+
+	e := &Extractor{}
+	entities, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "Dockerfile",
+		Content:  []byte("FROM ubuntu:22.04\n"),
+		Language: "dockerfile",
+		TSTree:   nil, // forces the self-parse fallback
+	})
+
+	if err == nil {
+		t.Fatal("a nil tree from the self-parse fallback returned no error — the guard is " +
+			"missing and tree.RootNode() would be a nil dereference (#6154)")
+	}
+	if entities != nil {
+		t.Errorf("expected no entities alongside the error, got %d", len(entities))
+	}
+}
+
+// TestDockerfileSelfParseClosesItsOwnTree6154 pins the other half of the
+// fallback's resource contract: a tree the extractor parsed ITSELF must be
+// closed, and a tree handed in by the caller must NOT be — the indexer owns
+// that one and closing it would be a double free.
+//
+// Without the Close the CST leaks for the daemon's lifetime: #5963
+// (treesitter/parser.go) measures a tree-sitter CST at ~19.7 bytes of C heap per
+// source byte, and the v0.24 binding attaches no finalizer, so nothing reclaims
+// it. One leak per Dockerfile, on the watcher-driven reindex path.
+func TestDockerfileSelfParseClosesItsOwnTree6154(t *testing.T) {
+	const src = "FROM ubuntu:22.04\nEXPOSE 8080\n"
+
+	t.Run("self-parsed tree is closed", func(t *testing.T) {
+		real := parseWithRealAdapter(t, src)
+		tracked := &closeTrackingTree{Tree: real}
+
+		prev := dockerfileAdapter
+		dockerfileAdapter = fixedTreeAdapter{tree: tracked}
+		t.Cleanup(func() { dockerfileAdapter = prev })
+
+		e := &Extractor{}
+		if _, err := e.Extract(context.Background(), extractor.FileInput{
+			Path: "Dockerfile", Content: []byte(src), Language: "dockerfile", TSTree: nil,
+		}); err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if tracked.closes != 1 {
+			t.Errorf("self-parsed tree closed %d times, want exactly 1 — the CST leaks for the "+
+				"daemon's lifetime otherwise (#5963, ~19.7 B/source byte, no finalizer)", tracked.closes)
+		}
+	})
+
+	t.Run("caller-supplied tree is not closed", func(t *testing.T) {
+		tracked := &closeTrackingTree{Tree: parseWithRealAdapter(t, src)}
+		defer tracked.Tree.Close()
+
+		e := &Extractor{}
+		if _, err := e.Extract(context.Background(), extractor.FileInput{
+			Path: "Dockerfile", Content: []byte(src), Language: "dockerfile", TSTree: tracked,
+		}); err != nil {
+			t.Fatalf("extract: %v", err)
+		}
+		if tracked.closes != 0 {
+			t.Errorf("caller-supplied tree closed %d times, want 0 — the indexer owns it and "+
+				"closing it here is a double free", tracked.closes)
+		}
+	})
+}
+
+func parseWithRealAdapter(t *testing.T, src string) ts.Tree {
+	t.Helper()
+	p, err := tsofficial.New().NewParser(dockerfileGrammar())
+	if err != nil {
+		t.Fatalf("parser init: %v", err)
+	}
+	defer p.Close()
+	tree, err := p.Parse([]byte(src))
+	if err != nil || tree == nil {
+		t.Fatalf("parse: tree=%v err=%v", tree, err)
+	}
+	return tree
+}
+
+type closeTrackingTree struct {
+	ts.Tree
+	closes int
+}
+
+func (c *closeTrackingTree) Close() { c.closes++ }
+
+type fixedTreeAdapter struct{ tree ts.Tree }
+
+func (fixedTreeAdapter) Name() string                               { return "official" }
+func (f fixedTreeAdapter) NewParser(ts.Language) (ts.Parser, error) { return fixedTreeParser(f), nil }
+
+type fixedTreeParser struct{ tree ts.Tree }
+
+func (f fixedTreeParser) Parse([]byte) (ts.Tree, error) { return f.tree, nil }
+func (fixedTreeParser) Close()                          {}

--- a/internal/testsupport/guard_main.go
+++ b/internal/testsupport/guard_main.go
@@ -28,8 +28,21 @@ func GuardRealHomeMain() {
 	if os.Getenv("GRAFEL_TEST_REQUIRE_ISOLATED_HOME") != "1" {
 		return
 	}
-	// If an isolation env is already in effect, the binary is sandboxed.
-	if os.Getenv(envDaemonRoot) != "" {
+	// #6134 — GRAFEL_DAEMON_ROOT ALONE IS NOT SANDBOXING, and treating it as
+	// such is what disarmed this guard against the very defect it exists for.
+	//
+	// EnvRoot is read by daemon.DefaultLayout, so it moves the socket, pidfile
+	// and log dir. It is NOT read by daemon.StoreDir(), which resolves
+	// $GRAFEL_HOME (else ~/.grafel) + "/store" — and the daemon's startup tail
+	// runs MigrateToRefStore and PruneStaleGenerations against exactly that
+	// path. So a binary with only EnvRoot set still RELOCATES and DELETES parts
+	// of the developer's live store, which is the incident class this guard
+	// advertises. Returning early on it made the guard blind to it.
+	//
+	// The store follows the HOME/GRAFEL_HOME axis, so that is what has to be
+	// checked; GRAFEL_HOME set to anything is sufficient, since homeDir()
+	// prefers it over the real home unconditionally.
+	if os.Getenv(envGrafelHome) != "" {
 		return
 	}
 	if eff := effectiveHome(); realUserHome != "" && eff == realUserHome {
@@ -37,7 +50,9 @@ func GuardRealHomeMain() {
 			"testsupport: REFUSING to run — HOME (%q) is the real user home and "+
 				"GRAFEL_TEST_REQUIRE_ISOLATED_HOME=1. These tests can corrupt the live "+
 				"~/.claude.json / ~/.codeium / ~/.grafel or kill the live daemon. Run under a "+
-				"sandbox HOME (export HOME=$(mktemp -d); export GRAFEL_DAEMON_ROOT=$HOME/.grafel).\n",
+				"sandbox HOME (export HOME=$(mktemp -d); export GRAFEL_DAEMON_ROOT=$HOME/.grafel; "+
+				"export GRAFEL_HOME=$HOME/.grafel). GRAFEL_DAEMON_ROOT alone is NOT enough: it "+
+				"moves the socket/pid/log but not the store, which follows GRAFEL_HOME (#6134).\n",
 			eff,
 		)
 		os.Exit(2)

--- a/internal/verify/harness_test.go
+++ b/internal/verify/harness_test.go
@@ -81,9 +81,20 @@ func TestHarness_FixturesCorpus(t *testing.T) {
 	corpus := filepath.Join(root, "testdata", "fixtures", "sources")
 
 	// Per ADR-0017, indexing happens inside the daemon. Point the daemon
-	// at an isolated tempdir (so this test never touches ~/.grafel)
-	// and start it in the background; the test calls Index via RPC and
-	// stops the daemon on cleanup.
+	// at an isolated tempdir and start it in the background; the test calls
+	// Index via RPC and stops the daemon on cleanup.
+	//
+	// #6134 — THE OLD VERSION OF THIS COMMENT CLAIMED "so this test never
+	// touches ~/.grafel", AND THAT WAS FALSE. GRAFEL_DAEMON_ROOT is read by
+	// daemon.DefaultLayout (socket/pid/log) but NOT by daemon.StoreDir(), which
+	// resolves $GRAFEL_HOME (else ~/.grafel) + "/store". The daemon spawned
+	// below inherits the developer's real HOME through os.Environ(), and its
+	// startup tail runs MigrateToRefStore AND PruneStaleGenerations against that
+	// real store — relocating its layout and deleting generations from it, while
+	// the developer's own daemon may be serving MCP out of it. A false isolation
+	// claim is worse than none, because it stops the next reader checking.
+	// GRAFEL_HOME is now pinned to the same sandbox on both this process and the
+	// child, which is what makes the claim true.
 	//
 	// macOS limits AF_UNIX sun_path to ~103 bytes — t.TempDir() can
 	// easily exceed that, so we mint a short dir under os.TempDir() instead.
@@ -97,13 +108,16 @@ func TestHarness_FixturesCorpus(t *testing.T) {
 	// Derive the layout to get the correct socket path (named pipe on Windows,
 	// Unix domain socket on other platforms).
 	t.Setenv(daemon.EnvRoot, daemonRoot)
+	t.Setenv("GRAFEL_HOME", daemonRoot)
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		t.Fatalf("daemon layout: %v", err)
 	}
 
 	dcmd := exec.Command(bin, "daemon")
-	dcmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot)
+	// #6134 — GRAFEL_HOME too, or the child inherits the real one via os.Environ()
+	// and prunes the developer's live store on startup. See the note above.
+	dcmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot)
 	var daemonOut bytes.Buffer
 	dcmd.Stdout = &daemonOut
 	dcmd.Stderr = &daemonOut


### PR DESCRIPTION
Four issues filed as small test-hygiene items. **Two were product defects**, and one had been damaging the developer's live store on every test run.

## #6134 — not a flake. A real product race.

`startGroupAlgoProgress` (`cmd/grafel/daemon.go:1560`) selected over `{done, ctx.Done(), ticker}`. Go's `select` picks **uniformly at random** among ready cases, so once a tick was pending an already-closed `done` won only ~half the time — and `stop()` was a bare `close()` that waited for nothing. The heartbeat could emit a line **after `stop()` returned**, reporting `elapsed=` and a phase for a finished pass. That is #6047's class exactly.

Reproduced on unmodified `main` @ `617aeba6c`: **6 failures across 3 runs, failing at cycle 0** — not load-dependent. The old test's 30ms settling sleep was hiding it; load merely outlived the sleep.

Fixed in the product: a non-blocking re-check after a tick wins, plus `stop()` waiting for goroutine exit.

**The half this change leads with was initially untested.** Removing the barrier failed 20 tests; removing the re-check passed 140/140 — yet instrumentation over 300 cycles showed the re-check preventing a post-stop line in ~7% of cycles (21/606 without it, 0/575 with). Both original tests sampled at or after `stop()` returned, so neither could observe the window being fixed.

Now pinned deterministically rather than by rate: a gated sink parks the goroutine *inside* its first write, queues a tick behind it, closes `done` while parked, then releases — so the goroutine re-enters a select with both cases ready, which is the coin-flip itself. With the re-check a second line is impossible **by construction**; without it the mutant dies at cycle 0, with no false positives. (A rate-based check has an irreducible false positive: an in-flight tick body is a legitimate line.)

`stop()`'s barrier is **bounded at 2s**. The original "it cannot deadlock" claim was sink-dependent — both call sites are `defer startGroupAlgoProgress(...)()`, so a blocking slog sink (tty flow control under the wizard, a full pipe, a stalled FS) would have converted a benign goroutine leak into a wedge. Timing out forfeits only the barrier, never correctness: the re-check makes a post-stop line impossible independently of the wait.

## #6134 hygiene — the test suite was mutating the user's real store

`isolateDaemonEnv` set only `GRAFEL_DAEMON_ROOT`, which `DefaultLayout` reads (`paths_unix.go:50`) and **`StoreDir()` does not** (`state_path.go:273` → `homeDir()` at `:249`, GRAFEL_HOME/UserHomeDir only). Disjoint. `Run()`'s startup tail calls `MigrateToRefStore(StoreDir())` (`server.go:438`, `:577`) **and `PruneStaleGenerations(StoreDir())`** (`:589`, which deletes).

So running `./internal/daemon/` migrated **and deleted generations from** the developer's live `~/.grafel/store` — while their daemon served MCP out of it. `StoreDir`'s own doc already claimed it applied "when no isolated `GRAFEL_DAEMON_ROOT` is in effect"; nothing enforced it.

**The first sweep missed two sites** because it keyed on symbols like `StoreDir`/`daemon.Run` and so could never see a *subprocess* spawn. Both now fixed:

- `internal/verify/harness_test.go:106` — whose own comment claimed *"so this test never touches `~/.grafel`"*. The comment now records why that was false.
- `internal/daemon/selfdefense_test.go:151` — set the variable as a **raw string literal**, so it did not appear in `EnvRoot` greps. Now uses `daemon.EnvRoot` to stay greppable.

`testsupport.GuardRealHomeMain` — the guard that should have caught all of this — early-returned whenever `GRAFEL_DAEMON_ROOT` was merely non-empty, disarmed by the same misconception as the bug. Re-armed on the GRAFEL_HOME axis and verified both directions: armed + real HOME + EnvRoot-only now **refuses (exit 2)** where it previously passed; armed + GRAFEL_HOME passes. Default runs are unaffected (opt-in env var).

**One control deliberately not run:** the destructive proof for the subprocess sites — revert and observe the mutation — would prune generations from the live store while the daemon serves MCP from it. Verified non-destructively instead (store fingerprint 48 entries before/after, zero modified); the mechanism is already established by the in-process control. Recorded as a gap rather than claimed as coverage.

## #6154 — the dead fallback, and the nil-deref that making it live exposed

`dockerfile.go:53` returned early on a nil tree, making the `AcquireParseSlot` self-parse block at `:63` **unreachable**. That is why dockerfile appeared in two contradictory audits at once — "bails on nil tree" and "already self-parses" were both true, and the second was dead code. Verified the other six `AcquireParseSlot` extractors guard on `len(file.Content) == 0` only, so their fallbacks are live: one file, not six.

Making it reachable exposed a nil dereference. `ts/official/official.go:155` returns `(nil, nil)` when the parse watchdog is disabled — and `ts.Parser.Parse`'s own interface doc says *"Returns nil if the binding produced no tree"* (`ts.go:136`), so it is a documented contract. python (`extractor.go:142-145`) and golang (`:108-111`) both guard **and** `defer tree.Close()`; dockerfile's fallback did neither, going straight to `tree.RootNode()`.

Both added. To pin it behaviourally, `dockerfileAdapter` is now declared as the `ts.Adapter` **interface** so a binding stub can be injected: guard removed → real panic; `Close` removed → "closed 0 times, want 1". An inverse subtest asserts a **caller-supplied** tree is *not* closed, or the fallback would double-free the indexer's tree.

The pre-existing `TestDockerfileExtractor_NilTree` was **pinning the dead code**; replaced with whole-property-map bidirectional equivalence against the pre-parsed path over a fixture exercising every instruction family, plus a non-vacuity check — a count-only check would pass on a fallback that parsed garbage. Noted honestly: `parseForTest` builds the same adapter and grammar, so this pins wiring, not `ParserFactory` agreement.

Documented at the site: the fallback re-parses content the `ErrHighSyntaxErrorRate` gate just rejected. Both paths still agree, so parity holds — but this narrows the claim at `incremental.go:565-568`.

## #6144 — repointing the tautological edge, and a regex that corrupted entities

The `DEPENDS_ON_SERVICE` edge ran `container:X → service X`, both endpoints from one token, with the payload already duplicated as properties on the container node. Repointed at the enclosing test type. #6104's Tier A merge (records sharing `(SourceFile, Kind, Name)`) lands the facet on the real class node without fabricating one — verified with a fixture where the class name *mismatches* the file stem, so `foldFileComponentDuplicates` cannot mask a failure: exactly one `SCOPE.Component/class/OrderTests`, no stray second component.

**`reCSharpTypeDecl` fabricated a garbage node.** Its alternation `(?:class|record|struct|interface)\s+(\w+)` matched `record` first:

```
record struct Row(int Id);  → owner = "struct"
record class  Row(int Id);  → owner = "class"
```

A positional record above the constructor in a test class is ordinary modern C#. The result was `SCOPE.Component/class/"struct"` — matching no base entity, surviving Tier C as a standalone node, carrying the edge. Exactly the node fabrication this change's own rationale says never happens.

**Matching plain `class` only** — tighter than the suggested reordering, which fixes the *capture* but not the *identity*: the facet claims `Subtype: "class"` while the base extractor maps `record_declaration`→`"type"` and `struct_declaration`→`"struct"`, and Tier A lets the custom value win, so a record facet would **silently displace a real node's Subtype** — corrupting an entity in order to attach an edge to it. Matching `class` only kills both, and is semantically better: a `record struct` inside a test class no longer shadows it, because the nearest `class` *is* the test class. The suggested regex is retained as a killed mutant, since it still lets an `interface` shadow.

## #6143 — the cap should not track `GOMAXPROCS`

Reproduced: base at `GOMAXPROCS=3` on a 12-core host gives `daemonParseCap(12) = 3 >= GOMAXPROCS 3` — a tautological failure. Capping `GOMAXPROCS` is the recommended discipline on a shared machine, so correct practice produced a false red in an unrelated package; two independent reviewers hit it hours apart.

Reading taken: the cap should **not** track `GOMAXPROCS`. Parsing is cgo (go-tree-sitter v0.24), so goroutines park in `_Gsyscall` and N parses hold N OS threads regardless; the real operator knobs exist and are honoured unclamped (`daemon.go:466`); and in the daemon `GOMAXPROCS` is itself derived, so sizing the cap off it is circular **coupling** (stated as coupling, not an unbounded loop — the conclusion rests on the cgo and operator-surface grounds alone).

Replaced `got >= runtime.GOMAXPROCS(0)` — a proxy valid only while `GOMAXPROCS == NumCPU` — with a differential sweep (below/at/above the cap; the value must be identical). Strictly stronger, and it drops a `<8-core` skip that disabled the test on small hosts. The sweep mutates process-global `runtime.GOMAXPROCS`; `cmd/grafel` has no real `t.Parallel()` today (the sole grep hit is a comment forbidding it), so it is safe — now declared rather than assumed.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Full suites green: `cmd/grafel`, `internal/daemon`, `internal/custom/csharp`, `internal/extractors/dockerfile`, `internal/testsupport`, `internal/verify`. Heartbeat 10/10 at `GOMAXPROCS=2` under load; parse-cap green at 1/3/4/12.

**No `append` to a `types.Props` anywhere in the diff** — it is binary-searched and must stay key-sorted, so a raw append would silently corrupt lookups. `Properties.Set` is the only Props write.

Every mutation has a false-negative control that failed on its intended assertion, never a compile error. Reverts from file copies throughout; no `git checkout --`, no `stash`.

## Also corrected

`TestShutdownAcceptBound` — cited in the original brief as a known flake — **exists neither in the tree nor anywhere in history**. The real file is `internal/daemon/shutdown_accept_bound_test.go`, whose tests use 5s/8s bounds; 300ms appears only as a test-local watchdog *input*. The hypothesis that store contamination was the destabiliser is mechanically plausible but unfalsifiable without a captured failing run, so that half of #6134 stays **open and unconfirmed** rather than closed.

Independently adversarially reviewed (REQUEST-CHANGES), all three HIGH findings confirmed and fixed.

Closes #6143, #6154, #6144
Refs #6134, #6047, #6104, #6123, #5963
