### PR TITLE
fix(#6150): incremental consumed only the class-kind slice of Pass 2.5 — 12 divergences to 3

### DIFF
--- a/cmd/grafel/determinism.go
+++ b/cmd/grafel/determinism.go
@@ -30,29 +30,15 @@ func sortClassifiedFiles(cs []classifiedFile) {
 // sortEntityRecords orders an EntityRecord slice by the tuple
 // (Kind, Name, SourceFile, StartLine, EndLine, Signature). This is the same
 // tuple BuildIndex uses to disambiguate, so first-writer-wins is now
-// deterministic. We use sort.SliceStable so records that compare equal keep
-// their relative arrival order (defence in depth — should be rare in
-// practice).
+// deterministic.
+//
+// #6150 — the comparator itself moved to types.SortEntityRecordsCanonical so
+// the incremental producer in internal/extractors sorts by the SAME order this
+// path does instead of carrying a third copy that can drift. Same precedent as
+// #5974 for the emission sort. Behaviour here is unchanged; this is a
+// delegation, not a re-ordering.
 func sortEntityRecords(rs []types.EntityRecord) {
-	sort.SliceStable(rs, func(i, j int) bool {
-		a, b := &rs[i], &rs[j]
-		if a.Kind != b.Kind {
-			return a.Kind < b.Kind
-		}
-		if a.Name != b.Name {
-			return a.Name < b.Name
-		}
-		if a.SourceFile != b.SourceFile {
-			return a.SourceFile < b.SourceFile
-		}
-		if a.StartLine != b.StartLine {
-			return a.StartLine < b.StartLine
-		}
-		if a.EndLine != b.EndLine {
-			return a.EndLine < b.EndLine
-		}
-		return a.Signature < b.Signature
-	})
+	types.SortEntityRecordsCanonical(rs)
 }
 
 // sortRelationshipRecords orders Pass 2.5 standalone relationships by

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -406,9 +406,32 @@ CP_OTHER = 12
 //     internal/extractors/incremental.go (see engine.FoldFrameworkClassKinds).
 //     No class had ever appeared in this file's delta, which is the whole reason
 //     the gate stayed green through it.
+//
+//   - `import falcon` + `cp_app = falcon.App()` + `cp_app.add_route(...)` +
+//     the `on_get` responder — #6150. This is the FULL Falcon registration
+//     shape, and every part of it is load-bearing; the fixture reached a
+//     weaker version of it and the gate went quiet on six entities.
+//
+//     `on_get` (not some inert method name) is what makes the responder a
+//     ROUTE and gives the endpoint a verb. `add_route` is what fires falcon's
+//     YAML `relationship_rules` — the ONLY thing in this corpus that produces
+//     a Pass-2.5 STANDALONE relationship, which is a different producer from
+//     the record-embedded edges everything else here exercises. Together they
+//     are what make Pass 2.5 emit an `http_endpoint_definition`, which is what
+//     the flow pass needs to build the `SCOPE.Process` node and its four
+//     dependent edges. `import falcon` reaches the third-party-import path
+//     (#6156).
+//
+//     Before #6150 this shape diverged TWELVE ways from a full rebuild with at
+//     least six distinct causes, and the previous fixture could not see any of
+//     them: naming the probe method something inert and omitting the app
+//     object is functionally an allow-list entry with no filed issue, and the
+//     stale-entry ratchet below structurally CANNOT detect that dodge. Do not
+//     weaken any of these four lines.
 func cpDelta(t *testing.T, repo string, pass int) {
 	t.Helper()
-	dvWriteFile(t, repo, "cphandler_delta.py", fmt.Sprintf(`import cperrs_static
+	dvWriteFile(t, repo, "cphandler_delta.py", fmt.Sprintf(`import falcon
+import cperrs_static
 import cpprod_static
 from cpprod_static import CpProducer
 from cpcfg_static import CP_SETTING
@@ -432,6 +455,7 @@ class CpPlainProbe:
 
 
 cp_app = falcon.App()
+cp_app.add_route("/cpthings", CpPlainProbe())
 
 
 class CpLeafBag:
@@ -576,13 +600,20 @@ var cpKnownPathA = []cpKnown{
 		Contains:       []string{"SCOPE.ExceptionType|exception:CpNotFound"},
 		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
 	},
-	{
-		Issue:          "#6129 (duplicate-row class of #6094 / #6037)",
-		Why:            "The CONTAINS edge to the duplicated entity, duplicated with it.",
-		Bucket:         cpEdgeMult,
-		Contains:       []string{"→SCOPE.ExceptionType/exception:CpNotFound@<exception>:CONTAINS"},
-		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
-	},
+	// The CONTAINS edge to that duplicated entity used to be duplicated WITH it,
+	// and had its own entry here. FIXED — the entry went STALE and was removed
+	// by the ratchet.
+	//
+	// It was collateral of the record→graph seam honouring EntityRecord.ID
+	// instead of deriving one (the #6150 fix in entityRecordToGraphEntity): the
+	// two copies of the exception record carried different ids, so their
+	// CONTAINS edges had different RelationshipIDs and the seenRel guard could
+	// not collapse them. Deriving the id makes both edges the same edge and one
+	// of them is dropped, matching the full rebuild exactly.
+	//
+	// The ENTITY-MULTIPLICITY entry above still reproduces: the duplicate
+	// exception ROW is a separate defect from the id it carried, and only the
+	// second one is closed.
 	// Re-keyed (not deleted) when the fixture grew for #6141/#6148/#6150: the
 	// divergence still reproduces and is still the same one — the unassigned
 	// community carries exactly ONE extra member, the duplicate row above — but
@@ -591,7 +622,7 @@ var cpKnownPathA = []cpKnown{
 	// moves whenever a fixture file is added. Anything other than +1 is a
 	// different divergence and must fail.
 	//
-	// This entry has now been re-keyed three times for fixture growth and zero
+	// This entry has now been re-keyed four times for fixture growth and zero
 	// times for a change in the defect, which is a smell in the KEY, not in the
 	// entry: it is the only allow entry keyed on an absolute count rather than on
 	// a shape. Keying it on the DELTA would end the churn and would still fail on
@@ -603,7 +634,49 @@ var cpKnownPathA = []cpKnown{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 35 member(s) in A, 36 in B"},
+		Contains: []string{"community ∅: 39 member(s) in A, 40 in B"},
+	},
+
+	// ── #6156: the full rebuild orphans a THIRD-PARTY import's IMPORTS edge ──
+	//
+	// The only divergence the #6150 fixture reaches where the INCREMENTAL answer
+	// is the correct one, which is why it is allow-listed rather than "fixed":
+	// closing it on this side would mean teaching Path A to dangle.
+	//
+	// `import falcon` names a package with no in-repo definition. BOTH graphs
+	// contain the `SCOPE.External|falcon` entity (measured — `external.Synthesize`
+	// runs on both paths). The FULL rebuild's IMPORTS edge points at the hex id
+	// of the import PLACEHOLDER that PruneImportPlaceholders has already removed,
+	// so it dangles; Path A binds the same edge to the live `ext:falcon` node.
+	//
+	// #6131's repoint does not cover it: it re-points at the entity the pipeline
+	// already resolved that import to, and for a third-party module there is
+	// nothing resolved at prune time — the SCOPE.External node is synthesised
+	// afterwards. See #6156 for the log line (`rels_orphaned=2`) and the fix
+	// direction.
+	{
+		Issue:    "#6156",
+		Why:      "Path A binds the third-party import to the live SCOPE.External node; the FULL rebuild dangles on the pruned placeholder. Incremental is the correct side. Unfixed, and not fixable from the incremental path.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"→SCOPE.External/falcon@", ":IMPORTS"},
+	},
+	{
+		Issue:    "#6156",
+		Why:      "The LOST half of the same orphan: the full rebuild's dangling endpoint on the pruned import placeholder.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→«unbound»", ":IMPORTS"},
+	},
+	{
+		// A CONSEQUENCE of the row above, not a second defect: module
+		// aggregation skips any edge whose endpoint resolves to no entity, so
+		// the full rebuild's orphaned IMPORTS edge is not counted and Path A's
+		// bound one is. Recorded as such because #6129 filed the same shape as
+		// "an extra DEPENDS_ON row" and it was a consequence then too.
+		Issue:          "#6156",
+		Why:            "Downstream of the orphaned IMPORTS edge: module aggregation cannot count an edge with a dangling endpoint, so the full rebuild's weight is one lower.",
+		Bucket:         cpEdgeProps,
+		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
+		DetailContains: []string{`weight "2"≠"3"`},
 	},
 
 	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -88,7 +88,43 @@
 // re-keyed rather than deleted because the fix moved its bound target without
 // closing it. A fix's own tests could not have drawn that boundary.
 //
-// Refs #6129, #6037, #6094, #6123, #6083, #6128.
+// WHAT THIS GATE CANNOT SEE
+// ─────────────────────────
+// It is relied on as though it were total. It is not, and the list below is
+// concrete rather than a disclaimer — each item has been demonstrated, not
+// supposed. Read it before concluding "the gate is green, therefore the two
+// paths agree".
+//
+//   - ENTITY IDS. Keying on CONTENT is the design (see above) and it means two
+//     graphs whose entities carry DIFFERENT ids compare equal. That is not
+//     hypothetical: the incremental path emitted an endpoint whose id was the
+//     literal string "http:GET:/cpthings" where a full rebuild had a hex, and
+//     this gate reported nothing. It surfaced only because the flow pass
+//     embeds the id as TEXT in entry_id / chain / branches_dag, i.e. by
+//     accident. Fixed in #6150 — but the blind spot is structural and remains.
+//
+//   - CANONICAL SORTEDNESS of the entity slice. parity.Compare is multiset-
+//     based, so ORDER is invisible to it — while graph.fb's `(key)` binary
+//     search behind LookupEntityByID requires ids in canonical order (#5974).
+//     A producer that emits a correct set in the wrong order passes here and
+//     silently breaks lookup. No gate covers this today.
+//
+//   - RelationshipID. Never compared; `relKey` is (endpoints, kind). Two graphs
+//     whose edges carry different relationship ids compare equal.
+//
+//   - EVERYTHING ABOVE THE ENTITY/EDGE LEVEL. Document.Stats, SurpriseEdges,
+//     AlgorithmStats, IndexerVersion, CoverageStatus and IndexedRef/SHA are not
+//     compared at all. Community labels are checked only for entities present
+//     on BOTH sides.
+//
+// Demonstrated, and the reason this section exists: a mutant that split the
+// Pass-2.5 stub index key on its first colon — the #6105/#6123 mis-bind shape —
+// PASSED this gate with an identical tolerated-divergence list. It was caught
+// only by a unit test in internal/extractors. A content-keyed multiset over
+// entities and edges is a strong instrument for one class of defect and blind
+// to several others; pair it with unit tests at the seam being changed.
+//
+// Refs #6129, #6037, #6094, #6123, #6083, #6128, #6150, #5974.
 package main
 
 import (
@@ -375,6 +411,48 @@ CP_OTHER = 12
     def cp_owner(self):
         return 1
 `)
+	// #6150 — the CROSS-FILE handler half of the endpoint shape. The route is
+	// registered in cproutes_delta.js (the delta); the handler it names lives
+	// HERE. Every framework in the corpus that dispatches from a different
+	// module than it implements in — Express + imported controller, Flask
+	// add_url_rule + imported function, DRF router + ViewSet — has this shape,
+	// and the Falcon delta cannot reach it because a Falcon responder is a
+	// method on the class the route registers.
+	//
+	// It is the shape that separates "unresolved" from "DELETED". Per-file
+	// Pass 2.5 stamps `source_handler="Controller:cpListUsers"` on the
+	// synthetic; engine.ResolveHTTPEndpointHandlers DROPS a synthetic whose
+	// source_handler resolves to nothing in the slice it is handed
+	// (`stats.HandlerDropped++`), and a file-scoped call makes "no candidate in
+	// the corpus" and "no candidate in this file" the same condition. Running
+	// that pass file-scoped without a keep guard therefore destroys every
+	// cross-file endpoint on the incremental path — strictly worse than not
+	// running it at all, and invisible to a Falcon-only fixture.
+	dvWriteFile(t, repo, "cpctl_static.js", `function cpListUsers(req, res) {
+  return res.json({ ok: 1 });
+}
+
+module.exports = { cpListUsers };
+`)
+	// #6150 — the CROSS-FILE REBIND shape, and the one that separates the two
+	// wrong answers to an unresolvable endpoint synthetic.
+	//
+	// cpwsgi_delta.py registers `/cpview` against a view IMPORTED from here. A
+	// full rebuild resolves that handler corpus-wide and `bridgeEndpointToHandler`
+	// REBINDS the endpoint's source_file onto the handler's body — so the
+	// endpoint ends up anchored HERE, in an unchanged file, and survives the
+	// delta untouched. The re-extracted registration file then contributes a
+	// SECOND, unresolved copy at its own coordinates unless something notices.
+	//
+	// Measured: full rebuild ONE endpoint at cpview_static.py; incremental TWO.
+	// That duplicate predates #6150 — it reproduces identically with the
+	// endpoint-resolve pass disabled — and it is what
+	// pruneSupersededEndpointSynthetics closes. Nothing in this corpus reached
+	// it before, because Falcon responders are methods on the class the route
+	// registers and Express handlers here resolve to a local binding.
+	dvWriteFile(t, repo, "cpview_static.py", `def cp_view_handler(req):
+    return {"ok": 1}
+`)
 }
 
 // cpDelta writes the SINGLE file that differs between the baseline pass
@@ -464,6 +542,38 @@ class CpLeafBag:
 
 def cp_leaf_call():
     return cp_owner()
+`, pass))
+
+	// The SECOND delta file (#6150). Express router whose handler is
+	// `require`d from cpctl_static.js — see the cpctl_static.js block in
+	// cpStatic for why this shape has to be in the DELTA (a construct in a
+	// static file is carried forward from the baseline full rebuild and
+	// compares equal no matter what re-extraction would have made of it).
+	//
+	// Two changed files still runs incremental: the too-many-changed guard's
+	// limit is far above 2, and dvIncremental fails the test if the run falls
+	// back regardless, so this cannot silently turn the gate vacuous.
+	// THIRD delta file (#6150) — the cross-file REBIND shape. See the
+	// cpview_static.py block in cpStatic for what it separates and why the
+	// registration has to be in the delta.
+	dvWriteFile(t, repo, "cpwsgi_delta.py", fmt.Sprintf(`from flask import Flask
+from cpview_static import cp_view_handler
+
+cp_wsgi = Flask(__name__)
+cp_wsgi.add_url_rule("/cpview", "cp_view_handler", cp_view_handler)
+
+CP_WSGI_PASS = %d
+`, pass))
+
+	dvWriteFile(t, repo, "cproutes_delta.js", fmt.Sprintf(`const express = require("express");
+const { cpListUsers } = require("./cpctl_static");
+
+const cpRouter = express.Router();
+cpRouter.get("/cpusers", cpListUsers);
+
+const cpPass = %d;
+
+module.exports = { cpRouter, cpPass };
 `, pass))
 }
 
@@ -622,7 +732,7 @@ var cpKnownPathA = []cpKnown{
 	// moves whenever a fixture file is added. Anything other than +1 is a
 	// different divergence and must fail.
 	//
-	// This entry has now been re-keyed four times for fixture growth and zero
+	// This entry has now been re-keyed five times for fixture growth and zero
 	// times for a change in the defect, which is a smell in the KEY, not in the
 	// entry: it is the only allow entry keyed on an absolute count rather than on
 	// a shape. Keying it on the DELTA would end the churn and would still fail on
@@ -634,7 +744,7 @@ var cpKnownPathA = []cpKnown{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 39 member(s) in A, 40 in B"},
+		Contains: []string{"community ∅: 60 member(s) in A, 61 in B"},
 	},
 
 	// ── #6156: the full rebuild orphans a THIRD-PARTY import's IMPORTS edge ──
@@ -673,10 +783,52 @@ var cpKnownPathA = []cpKnown{
 		// bound one is. Recorded as such because #6129 filed the same shape as
 		// "an extra DEPENDS_ON row" and it was a consequence then too.
 		Issue:          "#6156",
-		Why:            "Downstream of the orphaned IMPORTS edge: module aggregation cannot count an edge with a dangling endpoint, so the full rebuild's weight is one lower.",
+		Why:            "Downstream of the orphaned IMPORTS edges: module aggregation cannot count an edge with a dangling endpoint, so the full rebuild's weight is lower by exactly the number of orphaned third-party imports (2 here: falcon and express).",
 		Bucket:         cpEdgeProps,
 		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
-		DetailContains: []string{`weight "2"≠"3"`},
+		DetailContains: []string{`weight "5"≠"7"`},
+	},
+	// The SAME #6156 defect on the second third-party import in the corpus.
+	// Listed separately rather than folded into a looser key on the entries
+	// above: one entry matching both would go on matching if only one of them
+	// stopped reproducing, which is precisely the blindness the ratchet exists
+	// to prevent.
+	{
+		Issue:    "#6156",
+		Why:      "Second instance, JS: Path A binds the express require to the live SCOPE.External node; the FULL rebuild dangles on the pruned placeholder.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"→SCOPE.External/express@", ":IMPORTS"},
+	},
+	{
+		Issue:    "#6156",
+		Why:      "The LOST half of the express orphan.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Component/cproutes_delta.js@cproutes_delta.js→«unbound»", ":IMPORTS"},
+	},
+
+	// ── #6159: a cross-file handler leaves its endpoint unenriched ──
+	//
+	// The residual of #6150's file-scoped enrichment, and NOT a regression:
+	// before #6150 this path ran neither enrichment pass, so the endpoint
+	// carried none of these properties either. What changed is that the gate
+	// can now see it.
+	//
+	// `cpRouter.get("/cpusers", cpListUsers)` names a handler defined in
+	// cpctl_static.js. engine.ApplyResponseShapesCorpus needs the HANDLER'S
+	// BODY to extract the response shape, and the reader this path supplies
+	// serves only the file being re-extracted — so the endpoint survives
+	// (#6150's keep guard) but without response_keys / status_codes /
+	// response_keys_known.
+	//
+	// The endpoint itself is present and correctly identified on both sides:
+	// this is a property gap, not a loss, and it is listed as ENTITY-FIELDS
+	// rather than ENTITY-LOST for exactly that reason.
+	{
+		Issue:          "#6159",
+		Why:            "File-scoped response-shape extraction cannot read a handler body in another file. Unfixed; needs the previous graph's entities as candidates.",
+		Bucket:         cpEntityFields,
+		Contains:       []string{"http_endpoint_definition|http:GET:/cpusers"},
+		DetailContains: []string{"response_keys_known"},
 	},
 
 	// ── #6129 / #6098 family: over-counted DEPENDS_ON weight ──
@@ -769,6 +921,113 @@ var cpKnownPathB = []cpKnown{
 		Why:      "The LOST half of the same missed bind: the file component the full rebuild binds.",
 		Bucket:   cpEdgeLost,
 		Contains: []string{"→SCOPE.Component/cpcfg_static.py@cpcfg_static.py", ":IMPORTS"},
+	},
+
+	// ── #6129, more instances of the SAME duplicated file→external row ──
+	//
+	// The entry above this block pins the shape on cphandler_delta.py. The
+	// #6150 fixture growth added two more registration files, and each
+	// reproduces it against its own imports. Same defect, more instances — so
+	// they carry the same issue number, but they are separate ENTRIES rather
+	// than one loosened key, because a fix that repaired only one of the three
+	// must fail the ratchet on the other two.
+	{
+		Issue:          "#6129",
+		Why:            "Same duplicated file→external DEPENDS_ON, from the JS registration file.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"«unbound»scope:component:file:cproutes_delta.js→"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6129",
+		Why:            "Same duplicated file→external DEPENDS_ON, from the Flask registration file.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"«unbound»scope:component:file:cpwsgi_delta.py→"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6129",
+		Why:            "Same duplication reaching a framework-typed importer rather than a file component.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"«unbound»Model:Flask→SCOPE.External/Flask@:DEPENDS_ON"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+
+	// ── #6160: a REBOUND endpoint and its whole flow subtree, twice ──
+	//
+	// engine.bridgeEndpointToHandler rebinds a resolved synthetic's source_file
+	// onto the handler's BODY (#2678). An endpoint registered in a CHANGED file
+	// but resolved to a handler in an UNCHANGED one therefore ends up anchored
+	// in the unchanged file — and is both carried forward from the previous
+	// graph AND re-produced by this run. Both copies derive the same id, so it
+	// is one entity emitted twice, and the flow pass builds a second
+	// SCOPE.Process on top of it.
+	//
+	// Path A is clean on the identical fixture (it dedupes by reEmittedIDs and
+	// seenNewRel), which is why this is on Path B's list alone. Reproduced
+	// byte-identically at 617aeba6c — #6150 made the fixture reach it, it did
+	// not cause it.
+	{
+		Issue:          "#6160",
+		Why:            "Path B emits the rebound endpoint's IMPLEMENTS bridge twice — once in its synthesis-time form, once resolved. Unfixed.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"→http_endpoint_definition/http:GET:/cpview@cpview_static.py:IMPLEMENTS"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6160",
+		Why:            "The property evidence for the row above: the duplicate pair is the same bridge at two pipeline stages (synthesis_time_bridge + synthesis_resolved).",
+		Bucket:         cpEdgeProps,
+		Contains:       []string{"→http_endpoint_definition/http:GET:/cpview@cpview_static.py:IMPLEMENTS"},
+		DetailContains: []string{"http_endpoint_synthesis_time_bridge"},
+	},
+	{
+		Issue:          "#6160",
+		Why:            "The process-flow node built on the duplicated endpoint, duplicated with it.",
+		Bucket:         cpEntityMult,
+		Contains:       []string{"SCOPE.Process|http:GET:/cpview → cp_view_handler"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6160",
+		Why:            "Its STEP_IN_PROCESS edge to the handler operation.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"SCOPE.Process/http:GET:/cpview → cp_view_handler@cpview_static.py→SCOPE.Operation/cp_view_handler@cpview_static.py:STEP_IN_PROCESS"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6160",
+		Why:            "Its STEP_IN_PROCESS edge to the endpoint.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"SCOPE.Process/http:GET:/cpview → cp_view_handler@cpview_static.py→http_endpoint_definition/"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6160",
+		Why:            "Its ENTRY_POINT_OF edge.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{":ENTRY_POINT_OF"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:    "#6160",
+		Why:      "Downstream of the duplicated Process entity: the unassigned community carries one extra member. Keyed on the absolute pair, so it moves with fixture size — see the same note on Path A's copy.",
+		Bucket:   cpCommunitySet,
+		Contains: []string{"community ∅: 60 member(s) in A, 61 in B"},
+	},
+
+	// ── #6159, shared with Path A: cross-file handler, unenriched endpoint ──
+	//
+	// Listed separately from Path A's entry because the two paths are different
+	// code: if one is fixed and the other is not, the stale-entry check must
+	// fail on exactly the path that was fixed. Reproduced at 617aeba6c, so it
+	// is a residual of file-scoped enrichment on BOTH paths, not a regression.
+	{
+		Issue:          "#6159",
+		Why:            "Response-shape extraction does not reach a handler body in another file. Unfixed.",
+		Bucket:         cpEntityFields,
+		Contains:       []string{"http_endpoint_definition|http:GET:/cpusers"},
+		DetailContains: []string{"response_keys_known"},
 	},
 }
 

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -565,6 +565,41 @@ cp_wsgi.add_url_rule("/cpview", "cp_view_handler", cp_view_handler)
 CP_WSGI_PASS = %d
 `, pass))
 
+	// FOURTH and FIFTH delta files (#6150) — the NO-SURVIVOR case, and the only
+	// shape in this corpus that separates the two candidate answers to an
+	// unresolvable endpoint synthetic end-to-end.
+	//
+	// cpapi2_delta.py registers `/cpview2` against a view imported from
+	// cpview2_delta.py, and BOTH are in the delta. A full rebuild resolves the
+	// handler corpus-wide and rebinds the endpoint onto the VIEW's file — but
+	// that file is re-extracted too, so Step 5 evicts the previous graph's copy
+	// and NOTHING survives carrying this endpoint. That is the state in which
+	// the three possible verdicts finally diverge in the persisted graph:
+	//
+	//	DROP        (engine's corpus entry point) — the endpoint is DELETED.
+	//	KEEP+PRUNE  (what ships) — kept at the registration file: ENTITY-LOST
+	//	            for the full rebuild's anchor plus ENTITY-INVENTED for this
+	//	            one, i.e. the route still exists and still names its handler.
+	//	KEEP always — same as above here, but duplicates the endpoint in the
+	//	            cpwsgi_delta.py/cpview_static.py pair above.
+	//
+	// Every other endpoint shape in this corpus is blind to that difference:
+	// /cpusers resolves in-file (the destructured require creates a local
+	// binding), and /cpview has a survivor at cpview_static.py that carries it
+	// whichever way the verdict goes. Without this pair the gate cannot tell
+	// the shipped behaviour from the one the review rejected.
+	dvWriteFile(t, repo, "cpview2_delta.py", fmt.Sprintf(`def cp_view2_handler(req):
+    return {"ok": %d}
+`, pass))
+	dvWriteFile(t, repo, "cpapi2_delta.py", fmt.Sprintf(`from flask import Flask
+from cpview2_delta import cp_view2_handler
+
+cp_api2 = Flask(__name__)
+cp_api2.add_url_rule("/cpview2", "cp_view2_handler", cp_view2_handler)
+
+CP_API2_PASS = %d
+`, pass))
+
 	dvWriteFile(t, repo, "cproutes_delta.js", fmt.Sprintf(`const express = require("express");
 const { cpListUsers } = require("./cpctl_static");
 
@@ -732,7 +767,7 @@ var cpKnownPathA = []cpKnown{
 	// moves whenever a fixture file is added. Anything other than +1 is a
 	// different divergence and must fail.
 	//
-	// This entry has now been re-keyed five times for fixture growth and zero
+	// This entry has now been re-keyed six times for fixture growth and zero
 	// times for a change in the defect, which is a smell in the KEY, not in the
 	// entry: it is the only allow entry keyed on an absolute count rather than on
 	// a shape. Keying it on the DELTA would end the churn and would still fail on
@@ -744,7 +779,7 @@ var cpKnownPathA = []cpKnown{
 		Issue:    "#6129 (duplicate-row class of #6094 / #6037)",
 		Why:      "Downstream of the duplicated entity: the unassigned community carries one extra member.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 60 member(s) in A, 61 in B"},
+		Contains: []string{"community ∅: 67 member(s) in A, 68 in B"},
 	},
 
 	// ── #6156: the full rebuild orphans a THIRD-PARTY import's IMPORTS edge ──
@@ -782,11 +817,104 @@ var cpKnownPathA = []cpKnown{
 		// the full rebuild's orphaned IMPORTS edge is not counted and Path A's
 		// bound one is. Recorded as such because #6129 filed the same shape as
 		// "an extra DEPENDS_ON row" and it was a consequence then too.
-		Issue:          "#6156",
-		Why:            "Downstream of the orphaned IMPORTS edges: module aggregation cannot count an edge with a dangling endpoint, so the full rebuild's weight is lower by exactly the number of orphaned third-party imports (2 here: falcon and express).",
+		// NET OF TWO FILED CAUSES, and it is kept keyed on the exact numbers
+		// so that fixing either one moves it and forces a re-derivation rather
+		// than silently continuing to match:
+		//   #6156 pushes B UP by 2 — module aggregation cannot count the full
+		//         rebuild's two orphaned third-party IMPORTS edges (falcon,
+		//         express), but counts Path A's bound ones;
+		//   #6159 pushes B DOWN by 1 — Path A has no ENTRY_POINT_OF edge from
+		//         the /cpview2 endpoint to its process node, because it never
+		//         resolved the handler and the flow was never built.
+		// Net +1 for B.
+		Issue:          "#6156 + #6159 (net; see the comment)",
+		Why:            "Module-aggregation weight is the net of the orphaned third-party imports (#6156, +2) and the flow edges the incremental graph lacks (#6159, -1).",
 		Bucket:         cpEdgeProps,
 		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
-		DetailContains: []string{`weight "5"≠"7"`},
+		DetailContains: []string{`weight "6"≠"7"`},
+	},
+	// ── #6159, the NO-SURVIVOR case: kept, but at the registration file ──
+	//
+	// `cpapi2_delta.py` registers /cpview2 against a view in `cpview2_delta.py`
+	// and BOTH are in the delta, so nothing survives carrying the endpoint. The
+	// full rebuild resolves the handler corpus-wide and rebinds the endpoint
+	// onto the VIEW's file; Path A cannot resolve it from one file's records and
+	// keeps it, unenriched, at the REGISTRATION file.
+	//
+	// This block is where the shipped verdict is visible end-to-end. Under the
+	// rejected DROP behaviour — and under a prune that dropped the last copy —
+	// the ENTITY-INVENTED row below simply is not there, and its entry goes
+	// stale. Every other row in the block is downstream of the same single
+	// cause: no bind ⇒ no IMPLEMENTS ⇒ no process flow ⇒ none of its edges.
+	{
+		Issue:    "#6159",
+		Why:      "The kept copy: Path A anchors the unresolvable endpoint at the registration file. This row is the difference between keeping the route and deleting it.",
+		Bucket:   cpEntityInvented,
+		Contains: []string{"http_endpoint_definition|http:GET:/cpview2", "cpapi2_delta.py"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "The full rebuild's anchor for the same endpoint, on the handler's file after the #2678 rebind.",
+		Bucket:   cpEntityLost,
+		Contains: []string{"http_endpoint_definition|http:GET:/cpview2", "cpview2_delta.py"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "Module CONTAINS for the kept copy.",
+		Bucket:   cpEdgeInvented,
+		Contains: []string{"→http_endpoint_definition/http:GET:/cpview2@cpapi2_delta.py:CONTAINS"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "Module CONTAINS for the full rebuild's copy.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"→http_endpoint_definition/http:GET:/cpview2@cpview2_delta.py:CONTAINS"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "No bind ⇒ no IMPLEMENTS bridge from the handler to the endpoint.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Operation/cp_view2_handler@cpview2_delta.py→http_endpoint_definition/", ":IMPLEMENTS"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "No IMPLEMENTS ⇒ the flow pass never builds the process node for this endpoint.",
+		Bucket:   cpEntityLost,
+		Contains: []string{"SCOPE.Process|http:GET:/cpview2 → cp_view2_handler"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "The absent process node's containment edge.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"→SCOPE.Process/http:GET:/cpview2 → cp_view2_handler@cpview2_delta.py:CONTAINS"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "The absent process node's STEP_IN_PROCESS edge to the handler.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Process/http:GET:/cpview2 → cp_view2_handler@cpview2_delta.py→SCOPE.Operation/"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "The absent process node's STEP_IN_PROCESS edge to the endpoint.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"SCOPE.Process/http:GET:/cpview2 → cp_view2_handler@cpview2_delta.py→http_endpoint_definition/"},
+	},
+	{
+		Issue:    "#6159",
+		Why:      "The absent process node's ENTRY_POINT_OF edge.",
+		Bucket:   cpEdgeLost,
+		Contains: []string{"http_endpoint_definition/http:GET:/cpview2@cpview2_delta.py→SCOPE.Process/"},
+	},
+	{
+		// Single-cause, unlike its test-repo→_external twin above: B is lower
+		// by exactly the two STEP_IN_PROCESS edges the missing process node
+		// would have contributed from _external into test-repo.
+		Issue:          "#6159",
+		Why:            "Module-aggregation weight, short by the two STEP_IN_PROCESS edges of the process node Path A never built.",
+		Bucket:         cpEdgeProps,
+		Contains:       []string{"Module/_external@→Module/test-repo@:DEPENDS_ON"},
+		DetailContains: []string{`weight "11"≠"9"`},
 	},
 	// The SAME #6156 defect on the second third-party import in the corpus.
 	// Listed separately rather than folded into a looser key on the entries
@@ -947,6 +1075,13 @@ var cpKnownPathB = []cpKnown{
 	},
 	{
 		Issue:          "#6129",
+		Why:            "Same duplicated file→external DEPENDS_ON, from the second Flask registration file (the no-survivor pair).",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"«unbound»scope:component:file:cpapi2_delta.py→"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
+	},
+	{
+		Issue:          "#6129",
 		Why:            "Same duplication reaching a framework-typed importer rather than a file component.",
 		Bucket:         cpEdgeMult,
 		Contains:       []string{"«unbound»Model:Flask→SCOPE.External/Flask@:DEPENDS_ON"},
@@ -1013,7 +1148,7 @@ var cpKnownPathB = []cpKnown{
 		Issue:    "#6160",
 		Why:      "Downstream of the duplicated Process entity: the unassigned community carries one extra member. Keyed on the absolute pair, so it moves with fixture size — see the same note on Path A's copy.",
 		Bucket:   cpCommunitySet,
-		Contains: []string{"community ∅: 60 member(s) in A, 61 in B"},
+		Contains: []string{"community ∅: 69 member(s) in A, 70 in B"},
 	},
 
 	// ── #6159, shared with Path A: cross-file handler, unenriched endpoint ──

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -81,12 +81,19 @@ var resolverKindEquivalents = map[string][]string{
 // Exposed so cmd/grafel can log a stats line analogous to the
 // import-aware resolver line.
 type ResolveHTTPEndpointStats struct {
-	Synthetics       int // total http_endpoint* records seen
-	HandlerResolved  int // source_handler resolved → IMPLEMENTS edge emitted
-	HandlerDropped   int // synthetics dropped because source_handler unresolved
-	NoHandlerProp    int // synthetics with no source_handler property (kept as-is)
-	CallerResolved   int // #754: source_caller resolved → FETCHES edge emitted
-	CallerUnresolved int // #754: source_caller present but not found in-file
+	Synthetics      int // total http_endpoint* records seen
+	HandlerResolved int // source_handler resolved → IMPLEMENTS edge emitted
+	HandlerDropped  int // synthetics dropped because source_handler unresolved
+	NoHandlerProp   int // synthetics with no source_handler property (kept as-is)
+	// #6150 — synthetics a FILE-SCOPED caller could not resolve and therefore
+	// KEPT rather than dropped, source_handler intact. Always 0 on the
+	// corpus-scoped entry point. A non-zero value on the incremental path is
+	// the normal, expected count of cross-file handlers in the delta; it is
+	// surfaced so that "the endpoint survived unenriched" stays distinguishable
+	// from "the endpoint resolved" in the run log.
+	HandlerUnresolvedKept int
+	CallerResolved        int // #754: source_caller resolved → FETCHES edge emitted
+	CallerUnresolved      int // #754: source_caller present but not found in-file
 	// #1217 migration counters.
 	DefinitionsMigrated int // entities that were http_endpoint (legacy) → definition
 	CallsMigrated       int // entities that were http_endpoint (legacy) → call
@@ -173,6 +180,47 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 // caller retains the pre-call view, the compaction will be visible to them as
 // scrambled contents. If you need the input intact, hand over a copy.
 func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag string) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
+	return resolveHTTPEndpointHandlers(merged, repoTag, false)
+}
+
+// ResolveHTTPEndpointHandlersFileScoped is ResolveHTTPEndpointHandlersWithRepo
+// for a caller whose `merged` is NOT the whole corpus — today, the incremental
+// path's one re-extracted file (#6150).
+//
+// It differs in exactly one verdict. The corpus-scoped pass DROPS a synthetic
+// whose `source_handler` matches no record in `merged`, and on a corpus-wide
+// slice that is right: the endpoint names a handler that does not exist
+// anywhere, and keeping it would leave an orphan http_endpoint node. On a
+// ONE-FILE slice the same test means something completely different — "the
+// handler is not in THIS file" — and a handler in another file is the ordinary
+// arrangement, not a defect: Express router + imported controller, Flask
+// `add_url_rule` + imported function, DRF router + ViewSet. Dropping there
+// DESTROYS live endpoints, which is strictly worse than not running the pass.
+//
+// So this entry point KEEPS such a synthetic, with `source_handler` intact, and
+// counts it in HandlerUnresolvedKept. That is not new policy: the same function
+// already refuses to drop in the two other situations where its evidence is
+// admittedly partial — #2851 (a `handler_file` hint matched nothing in that
+// file) and #3426 (every global candidate is a non-app/tooling file) — and both
+// give the same reason, that the handler IS attributed via the property and the
+// route must be preserved rather than destroyed for want of a cross-link.
+//
+// The MALFORMED-reference drop (a `source_handler` that does not parse as
+// `Kind:Name`) and the Spring `Route:<path>` placeholder drop are NOT relaxed:
+// neither verdict depends on how much of the corpus the caller could see.
+//
+// Every ownership rule of ResolveHTTPEndpointHandlersWithRepo applies unchanged
+// — it consumes `merged`, edits in place and compacts over the same backing
+// array. Read only the returned slice.
+func ResolveHTTPEndpointHandlersFileScoped(merged []types.EntityRecord, repoTag string) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
+	return resolveHTTPEndpointHandlers(merged, repoTag, true)
+}
+
+// resolveHTTPEndpointHandlers is the shared implementation. keepUnresolved
+// selects the file-scoped verdict on the one drop branch whose meaning depends
+// on how much of the corpus `merged` contains; see
+// ResolveHTTPEndpointHandlersFileScoped.
+func resolveHTTPEndpointHandlers(merged []types.EntityRecord, repoTag string, keepUnresolved bool) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	var stats ResolveHTTPEndpointStats
 
 	// (kind, name, sourceFile) → index into `merged`.
@@ -620,6 +668,15 @@ func ResolveHTTPEndpointHandlersWithRepo(merged []types.EntityRecord, repoTag st
 				// handler_file-hint miss path (#2851).
 				if hasGlobalCandidate(globalMulti, knKey{hk, hn}, resolverKindEquivalents[hk]) {
 					stats.NoHandlerProp++
+					continue
+				}
+				// #6150 — THE scope-dependent verdict. "No candidate at all" is
+				// a genuine orphan only when `merged` is the whole corpus. A
+				// file-scoped caller cannot tell that apart from "the handler
+				// is in another file", so it keeps the endpoint (unenriched,
+				// source_handler intact) instead of destroying it.
+				if keepUnresolved {
+					stats.HandlerUnresolvedKept++
 					continue
 				}
 				stats.HandlerDropped++

--- a/internal/engine/http_endpoint_resolve_filescoped_6150_test.go
+++ b/internal/engine/http_endpoint_resolve_filescoped_6150_test.go
@@ -156,3 +156,65 @@ func TestResolveHTTPEndpointHandlersFileScoped_StillDropsMalformedRef(t *testing
 		t.Errorf("HandlerDropped = %d, want 1", stats.HandlerDropped)
 	}
 }
+
+// TestResolveHTTPEndpointHandlersFileScoped_CanonicalOrderMakesTheBindStable
+// is the Sev-2 evidence: the resolver's answer DEPENDS on the order of the
+// slice it is handed, so "`merged` MUST already be sorted in canonical order
+// (#481)" is a real precondition and not documentation hygiene.
+//
+// Measured on the orderings below, WITHOUT the sort: the pass binds the handler
+// at line 10 when that record comes first and the one at line 50 when it does,
+// then rebinds the endpoint's coordinates onto whichever won — so the two
+// answers differ in the graph, not just in the edge. The index behind that
+// choice (globalIdx / globalMulti / sameFileBareIdx) is first-writer-wins over
+// slice order.
+//
+// What is asserted is the INVARIANT that makes the caller safe rather than the
+// order-dependence itself: sort-then-resolve gives the same answer for any
+// input permutation. That is the property the incremental path relies on when
+// it hands over FoldFrameworkClassKinds' output, which is explicitly "the
+// extractor's records first, then Detect's" — not canonical order.
+func TestResolveHTTPEndpointHandlersFileScoped_CanonicalOrderMakesTheBindStable(t *testing.T) {
+	handler := func(line int) types.EntityRecord {
+		return types.EntityRecord{
+			Kind: "SCOPE.Operation", Name: "cpDup", SourceFile: "routes.js",
+			Language: "javascript", StartLine: line, EndLine: line + 2,
+		}
+	}
+	endpoint := func() types.EntityRecord {
+		r := fsEndpoint("http:GET:/dup", "routes.js", "SCOPE.Operation:cpDup")
+		r.StartLine = 1
+		return r
+	}
+
+	orders := map[string][]types.EntityRecord{
+		"canonical":      {handler(10), handler(50), endpoint()},
+		"reversed":       {handler(50), handler(10), endpoint()},
+		"endpoint_first": {endpoint(), handler(50), handler(10)},
+	}
+
+	var first string
+	for _, name := range []string{"canonical", "reversed", "endpoint_first"} {
+		recs := append([]types.EntityRecord(nil), orders[name]...)
+		types.SortEntityRecordsCanonical(recs)
+		out, _ := ResolveHTTPEndpointHandlersFileScoped(recs, "test-repo")
+
+		var got string
+		for _, r := range out {
+			if r.Name == "http:GET:/dup" {
+				got = r.SourceFile + ":" + itoaSmall(r.StartLine)
+			}
+		}
+		if got == "" {
+			t.Fatalf("%s: endpoint vanished", name)
+		}
+		if first == "" {
+			first = got
+			continue
+		}
+		if got != first {
+			t.Errorf("%s: endpoint rebound to %s, but the canonical ordering gives %s — "+
+				"sort-then-resolve must be permutation-independent", name, got, first)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_resolve_filescoped_6150_test.go
+++ b/internal/engine/http_endpoint_resolve_filescoped_6150_test.go
@@ -1,0 +1,158 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// #6150 — the FILE-SCOPED entry point to the endpoint→handler resolve.
+//
+// ResolveHTTPEndpointHandlersWithRepo is written for the full rebuild, where
+// `merged` is the WHOLE corpus. On that input, "no record anywhere matches this
+// synthetic's source_handler" genuinely means "this endpoint names a handler
+// that does not exist", and dropping the synthetic is right: keeping it would
+// leave an orphan http_endpoint node in the graph.
+//
+// The incremental path hands it ONE re-extracted file's records. That makes
+// "no candidate in the corpus" and "no candidate in this file" the SAME
+// condition — and a handler in another file is the ordinary case, not the
+// exception (Express router + imported controller, Flask add_url_rule +
+// imported function, DRF router + ViewSet). Running the unmodified pass on that
+// input DELETES those endpoints rather than leaving them unenriched, which is
+// strictly worse than not running the pass at all.
+//
+// The keep branch is not new policy. The same function already refuses to drop
+// for exactly this reason twice — #2851 (a handler_file hint that matched
+// nothing in that file) and #3426 (every global candidate lives in a
+// non-app/tooling file) — and both say the same thing: the handler IS
+// attributed via the property, it is simply not cross-linked, so preserve the
+// route. A caller that cannot see the rest of the corpus is in that position
+// for EVERY unresolved synthetic.
+//
+// These tests drive the real pass, not a copy of its logic.
+
+// fsHandler is a handler record the resolver can bind an endpoint to.
+func fsHandler(kind, name, file string) types.EntityRecord {
+	return types.EntityRecord{Kind: kind, Name: name, SourceFile: file, Language: "javascript"}
+}
+
+// fsEndpoint is an http_endpoint synthetic naming `handlerRef` as its handler.
+func fsEndpoint(name, file, handlerRef string) types.EntityRecord {
+	return types.EntityRecord{
+		Kind:       "http_endpoint",
+		Name:       name,
+		SourceFile: file,
+		Language:   "javascript",
+		Properties: map[string]string{"source_handler": handlerRef},
+	}
+}
+
+// fsNames keys on NAME ALONE, deliberately. The pass performs the #1217
+// http_endpoint → http_endpoint_definition kind migration on the way through,
+// so a kind-qualified key would report a surviving endpoint as absent and turn
+// this file into a test of the migration rather than of the drop verdict.
+func fsNames(recs []types.EntityRecord) map[string]bool {
+	out := make(map[string]bool, len(recs))
+	for _, r := range recs {
+		out[r.Name] = true
+	}
+	return out
+}
+
+// TestResolveHTTPEndpointHandlersFileScoped_KeepsCrossFileHandler is the Sev-1
+// regression. One file's records: a route file carrying an endpoint whose
+// handler lives in a DIFFERENT file, which is therefore absent from the slice.
+//
+// The corpus-scoped entry point DELETES it — that is correct for its own
+// caller and is asserted here so the difference between the two entry points is
+// pinned from both sides, not assumed.
+func TestResolveHTTPEndpointHandlersFileScoped_KeepsCrossFileHandler(t *testing.T) {
+	build := func() []types.EntityRecord {
+		return []types.EntityRecord{
+			fsHandler("SCOPE.Operation", "cpRouterSetup", "routes.js"),
+			fsEndpoint("http:GET:/users", "routes.js", "Controller:cpListUsers"),
+		}
+	}
+
+	corpus, corpusStats := ResolveHTTPEndpointHandlersWithRepo(build(), "test-repo")
+	if fsNames(corpus)["http:GET:/users"] {
+		t.Fatalf("corpus-scoped entry point kept the unresolvable synthetic; " +
+			"this test's premise (that it drops) no longer holds")
+	}
+	if corpusStats.HandlerDropped != 1 {
+		t.Errorf("corpus HandlerDropped = %d, want 1", corpusStats.HandlerDropped)
+	}
+
+	scoped, scopedStats := ResolveHTTPEndpointHandlersFileScoped(build(), "test-repo")
+	if !fsNames(scoped)["http:GET:/users"] {
+		t.Errorf("file-scoped entry point DELETED the endpoint whose handler lives in another file; " +
+			"it must keep it (unenriched), not destroy it")
+	}
+	if scopedStats.HandlerDropped != 0 {
+		t.Errorf("file-scoped HandlerDropped = %d, want 0", scopedStats.HandlerDropped)
+	}
+	if scopedStats.HandlerUnresolvedKept != 1 {
+		t.Errorf("file-scoped HandlerUnresolvedKept = %d, want 1", scopedStats.HandlerUnresolvedKept)
+	}
+	// The property that names the handler must SURVIVE: it is the whole
+	// attribution the endpoint has left, and a later corpus-wide pass (or the
+	// next full rebuild) resolves it from there.
+	for _, r := range scoped {
+		if r.Name == "http:GET:/users" && r.Properties["source_handler"] != "Controller:cpListUsers" {
+			t.Errorf("source_handler = %q, want it preserved on the kept synthetic",
+				r.Properties["source_handler"])
+		}
+	}
+}
+
+// TestResolveHTTPEndpointHandlersFileScoped_StillResolvesCoLocated: the keep
+// guard must not cost the resolution the pass exists for. When the handler IS
+// in the slice, the file-scoped entry point behaves exactly like the corpus one
+// — the IMPLEMENTS bridge is emitted and source_handler is cleared.
+func TestResolveHTTPEndpointHandlersFileScoped_StillResolvesCoLocated(t *testing.T) {
+	recs := []types.EntityRecord{
+		fsHandler("SCOPE.Operation", "cpListUsers", "routes.js"),
+		fsEndpoint("http:GET:/users", "routes.js", "SCOPE.Operation:cpListUsers"),
+	}
+	out, stats := ResolveHTTPEndpointHandlersFileScoped(recs, "test-repo")
+	if stats.HandlerResolved != 1 {
+		t.Fatalf("HandlerResolved = %d, want 1 — the keep guard must not suppress a real bind", stats.HandlerResolved)
+	}
+	if stats.HandlerUnresolvedKept != 0 {
+		t.Errorf("HandlerUnresolvedKept = %d, want 0", stats.HandlerUnresolvedKept)
+	}
+	var bridged bool
+	for _, r := range out {
+		if r.Kind != "SCOPE.Operation" {
+			continue
+		}
+		for _, rel := range r.Relationships {
+			if rel.Kind == implementsEdgeKind {
+				bridged = true
+			}
+		}
+	}
+	if !bridged {
+		t.Error("no IMPLEMENTS bridge emitted from the co-located handler")
+	}
+}
+
+// TestResolveHTTPEndpointHandlersFileScoped_StillDropsMalformedRef: the keep
+// guard is scoped to the ONE drop branch whose verdict depends on how much of
+// the corpus the caller could see. A source_handler that does not parse as
+// `Kind:Name` is malformed no matter how wide the slice is, and dropping it
+// stops a bad reference leaking into the graph — that branch is unchanged.
+func TestResolveHTTPEndpointHandlersFileScoped_StillDropsMalformedRef(t *testing.T) {
+	recs := []types.EntityRecord{
+		fsHandler("SCOPE.Operation", "cpRouterSetup", "routes.js"),
+		fsEndpoint("http:GET:/users", "routes.js", "no-colon-here"),
+	}
+	out, stats := ResolveHTTPEndpointHandlersFileScoped(recs, "test-repo")
+	if fsNames(out)["http:GET:/users"] {
+		t.Error("a malformed source_handler must still be dropped: its verdict does not depend on slice scope")
+	}
+	if stats.HandlerDropped != 1 {
+		t.Errorf("HandlerDropped = %d, want 1", stats.HandlerDropped)
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -580,6 +580,12 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// #6148 — count of generic class records re-typed from the YAML rule sets,
 	// logged with the run so a silent regression to zero is visible.
 	classKindFolds := 0
+	// #6150 — Pass-2.5 standalone relationships bound against the re-extracted
+	// file's own records, and the ones no record of that file could bind.
+	// Logged with the run: `dropped` climbing while `bound` stays at zero is the
+	// signature of a rule set whose endpoints stopped naming in-file records,
+	// which is silent in the graph (the rows simply are not there).
+	pass25RelsBound, pass25RelsDropped := 0, 0
 	// #6094 — one identity per (FromID, ToID, Kind), shared across every file in
 	// this re-extraction batch. See convertExtractedRecords for why the triple is
 	// a safe identity here and how this scope differs from buildDocument's.
@@ -745,19 +751,39 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// The fold is keyed by (source_file, name) and never pairs records across
 		// files, so applying it per re-extracted file is the whole of it.
 		//
-		// Detect's standalone RELATIONSHIPS are deliberately NOT consumed here.
-		// Measured: they arrive as structural name refs the full path binds in a
-		// resolver pass this path does not run, so emitting them landed unbound
-		// endpoints and duplicate DEPENDS_ON rows — strictly worse than the gap.
+		// Detect's standalone RELATIONSHIPS are consumed here too (#6150), but
+		// only after being BOUND — see bindPass25StubEndpoints. They arrive as
+		// `Kind:Name` structural refs that the full path binds in a corpus-wide
+		// resolver pass this path does not run, and emitting them raw was
+		// measured to land `«unbound»Controller:X → «unbound»Service:y` rows
+		// plus duplicate DEPENDS_ON: strictly worse than the gap. Binding them
+		// against THIS FILE's own records — and dropping the ones that do not
+		// bind — is what turns them into an improvement. A YAML relationship_rule
+		// matches one line of one file, so both of its endpoints naming records
+		// of that file is the ordinary case, not a lucky one.
 		//
-		// That exclusion is a RESIDUAL, and it is untested: the committed parity
-		// fixture produces zero standalone framework relationships, so the gate is
-		// blind to this either way. Reaching it needs a relationship_rule match in
-		// the delta (falcon's REGISTERED_ON fires on `app.add_route(...)`), and
-		// that same line drags in the flow/endpoint-enrichment divergences that
-		// are the rest of #6150's scope — which is why it is recorded here rather
-		// than half-covered by a fixture that would need allow entries for four
-		// other defects to stay green.
+		// The two endpoint-enrichment passes between the fold and the bind are
+		// the full path's, in the full path's order:
+		//
+		//	Pass 2.7  engine.ApplyResponseShapesCorpus — reads the handler body
+		//	          to stamp response_keys_known / response shape onto the
+		//	          endpoint. MUST run before the handler resolve below, which
+		//	          clears the `source_handler` property it navigates by.
+		//	Pass 2.8  engine.ResolveHTTPEndpointHandlersWithRepo — binds an
+		//	          http_endpoint_definition to its handler: emits the
+		//	          IMPLEMENTS bridge, rebinds the endpoint's coordinates onto
+		//	          the handler body and stamps attribution="handler_resolved".
+		//	          buildDocument runs this on `merged`; the whole of it that
+		//	          concerns one file's endpoints is reachable from one file's
+		//	          records.
+		//
+		// Both are corpus-wide on the full path and file-scoped here. The
+		// difference is not cosmetic and is a REMAINING DIVERGENCE, not a fixed
+		// one: an endpoint whose handler lives in ANOTHER file resolves on the
+		// full path and does not resolve here, leaving the same property gap
+		// this closes for the co-located case. Scoping wider needs the previous
+		// graph's entities as candidates, which is a different (and much larger)
+		// change than reconciling one re-extracted file with itself.
 		if det := frameworkDetector(); det != nil {
 			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
 				logger.Printf("incremental: framework detect %s: %v", rel, dErr)
@@ -765,6 +791,24 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 				var n int
 				records, n = engine.FoldFrameworkClassKinds(records, fwRes.Entities)
 				classKindFolds += n
+
+				fileContent := content
+				engine.ApplyResponseShapesCorpus(records, fwRes.Relationships,
+					func(p string) []byte {
+						if p == rel {
+							return fileContent
+						}
+						return nil
+					})
+
+				// OWNERSHIP: this pass consumes `records` and compacts over its
+				// backing array — read only the returned slice (see its doc).
+				records, _ = engine.ResolveHTTPEndpointHandlersWithRepo(records, doc.Repo)
+
+				var bound, unbindable int
+				records, bound, unbindable = bindPass25StubEndpoints(records, fwRes.Relationships, doc.Repo)
+				pass25RelsBound += bound
+				pass25RelsDropped += unbindable
 			}
 		}
 
@@ -1027,8 +1071,9 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	dur := time.Since(t0)
-	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d flows_recomputed=%t took=%s",
-		len(reallyChanged), len(newEntities), len(newRels), classKindFolds, flowsRecomputed, dur.Truncate(time.Millisecond))
+	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d pass25_rels_bound=%d pass25_rels_dropped=%d flows_recomputed=%t took=%s",
+		len(reallyChanged), len(newEntities), len(newRels), classKindFolds,
+		pass25RelsBound, pass25RelsDropped, flowsRecomputed, dur.Truncate(time.Millisecond))
 
 	return Result{
 		Done:         true,
@@ -1238,10 +1283,28 @@ func walkSourceFiles(absRepo string) ([]string, error) {
 // extractor into a graph.Entity. Mirrors the buildDocument pass in cmd/grafel/index.go
 // without importing that package (avoids a cmd → internal cycle).
 func entityRecordToGraphEntity(r types.EntityRecord, repoTag string) graph.Entity {
-	id := r.ID
-	if id == "" {
-		id = graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
-	}
+	// #6150 — DERIVE, always. The record's own ID is deliberately ignored, which
+	// is what buildDocument does (its assembly loop computes
+	// graph.EntityID(repoTag, Kind, Name, SourceFile) unconditionally and never
+	// reads r.ID). Honouring r.ID here made the two paths disagree on the
+	// IDENTITY of an entity, not just its content: engine's http_endpoint
+	// synthesis stamps ID with the routable form of the endpoint — literally
+	// "http:GET:/things" (#1725, the same string it uses as QualifiedName) — so
+	// an endpoint in a re-extracted file carried a raw routable string where a
+	// full rebuild had a deterministic hex.
+	//
+	// Ids are the join key for every edge endpoint, for the FlatBuffers `(key)`
+	// binary search behind LookupEntityByID (#5974, which needs ids in canonical
+	// order), and for the flow passes' entry_id / chain / branches_dag
+	// properties — the last of which is how it surfaced: the incremental
+	// SCOPE.Process node described its entry as "http:GET:/cpthings".
+	//
+	// A content-keyed parity comparison CANNOT see this on its own (it keys
+	// entities and edge endpoints by kind/name/source_file precisely so that
+	// ids are not compared), and the incremental graph is internally consistent
+	// with the wrong id, so nothing downstream of it dangles. It surfaced only
+	// because a flow property happens to embed the id as text.
+	id := graph.EntityID(repoTag, r.Kind, r.Name, r.SourceFile)
 	return graph.Entity{
 		ID:            id,
 		Name:          r.Name,
@@ -1319,6 +1382,145 @@ func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenR
 		}
 	}
 	return ents, rels
+}
+
+// bindPass25StubEndpoints binds the `Kind:Name` structural endpoint refs that
+// Pass 2.5 produces against ONE re-extracted file's own records (#6150).
+//
+// Two producers emit them, and both are handled:
+//
+//   - Detect's STANDALONE relationships (`standalone`) — a YAML
+//     `relationship_rules` match, e.g. falcon's `app.add_route(path, Res())`
+//     giving `Controller:Res → Service:app` with the REGISTERED_ON kind. These
+//     carry no owner, so a bound one is APPENDED to its source record with an
+//     EMPTY FromID: that is the "my owner" form relRecordToGraphRel substitutes
+//     the owning entity's id for, and it is what makes the edge visible to the
+//     FromID-keyed stale-edge eviction (#6094) on the next edit of this file.
+//   - EMBEDDED relationships already on the records — notably the endpoint→
+//     handler IMPLEMENTS bridge that engine.ResolveHTTPEndpointHandlers appends
+//     with `Kind:Name` on BOTH ends (bridgeEndpointToHandler). Those are
+//     rewritten in place.
+//
+// WHY BINDING IS REQUIRED, not a nicety. The full path emits these stubs raw
+// and a corpus-wide resolver pass (internal/resolve) rewrites them against the
+// stamped entity index. TryIncremental runs the SCOPED resolver instead, which
+// indexes the previous persisted graph by name and has no notion of a
+// `Kind:Name` structural ref — so an unbound stub reaches graph.fb verbatim.
+// Measured, when #6148 first tried emitting them unchanged: rows keyed
+// `«unbound»Controller:X → «unbound»Service:y` and duplicate DEPENDS_ON. The
+// binder is what makes consuming Detect's relationships an improvement instead
+// of a second defect.
+//
+// WHAT IT REFUSES. Only an endpoint whose whole string is `Kind + ":" + Name`
+// of EXACTLY ONE record in the SAME FILE as the record being bound is
+// rewritten; everything else is left alone, and a standalone relationship with
+// an endpoint that does not bind is DROPPED rather than emitted unbound. Three
+// consequences, all deliberate:
+//
+//   - a bare name ("len"), a dotted import ("cfg.SETTING") and an already
+//     stamped hex id contain no matching key, so the scoped resolver — which
+//     knows how to bind those corpus-wide — keeps them;
+//   - a cross-file target is refused. The alternative is guessing at a name the
+//     full path resolves against the whole corpus, and a WRONG bind is worse
+//     than a missing row: it improves every count-based and dangling-endpoint
+//     metric while making the graph say something false (#6123);
+//   - an AMBIGUOUS key (two records, same file, same kind and name) is refused
+//     for the same reason. The corpus resolver has an ambiguity sentinel; this
+//     has one row of evidence and no way to choose.
+//
+// The lookup key is the WHOLE `Kind:Name` string, never a split on the first
+// colon: `http_endpoint_definition:http:GET:/things` is kind
+// "http_endpoint_definition" and name "http:GET:/things", and a splitter would
+// look up kind "http_endpoint_definition", name "http" and miss every endpoint.
+//
+// Returns the records (same slice, mutated in place), the number of standalone
+// relationships bound, and the number dropped as unbindable.
+func bindPass25StubEndpoints(
+	records []types.EntityRecord,
+	standalone []types.RelationshipRecord,
+	repoTag string,
+) ([]types.EntityRecord, int, int) {
+	if len(records) == 0 {
+		return records, 0, len(standalone)
+	}
+
+	// (file, "Kind:Name") → index into records, or ambiguousStubIdx when more
+	// than one record of that file carries the pair.
+	const ambiguousStubIdx = -1
+	type stubKey struct{ file, kindName string }
+	idx := make(map[stubKey]int, len(records))
+	for i := range records {
+		r := &records[i]
+		if r.Kind == "" || r.Name == "" || r.SourceFile == "" {
+			continue
+		}
+		k := stubKey{r.SourceFile, r.Kind + ":" + r.Name}
+		if _, dup := idx[k]; dup {
+			idx[k] = ambiguousStubIdx
+			continue
+		}
+		idx[k] = i
+	}
+	resolve := func(file, ref string) (string, bool) {
+		i, ok := idx[stubKey{file, ref}]
+		if !ok || i == ambiguousStubIdx {
+			return "", false
+		}
+		return entityRecordToGraphEntity(records[i], repoTag).ID, true
+	}
+
+	// Embedded stubs: rewrite in place, in the owning record's own file.
+	for i := range records {
+		r := &records[i]
+		for j := range r.Relationships {
+			e := &r.Relationships[j]
+			if id, ok := resolve(r.SourceFile, e.FromID); ok {
+				e.FromID = id
+			}
+			if id, ok := resolve(r.SourceFile, e.ToID); ok {
+				e.ToID = id
+			}
+		}
+	}
+
+	// Standalone relationships: bind both ends or drop.
+	bound, dropped := 0, 0
+	for _, sr := range standalone {
+		// The SOURCE end decides which file's records the target is looked up
+		// in, so a relationship rule that fired in file X can only ever bind
+		// within X — which is the only file this call has evidence about.
+		srcIdx := -1
+		for i := range records {
+			r := &records[i]
+			if r.SourceFile == "" || r.Kind == "" || r.Name == "" {
+				continue
+			}
+			if r.Kind+":"+r.Name != sr.FromID {
+				continue
+			}
+			if got, ok := idx[stubKey{r.SourceFile, sr.FromID}]; !ok || got == ambiguousStubIdx {
+				srcIdx = -1
+				break
+			}
+			srcIdx = i
+			break
+		}
+		if srcIdx < 0 {
+			dropped++
+			continue
+		}
+		toID, ok := resolve(records[srcIdx].SourceFile, sr.ToID)
+		if !ok {
+			dropped++
+			continue
+		}
+		e := sr
+		e.FromID = "" // owned by records[srcIdx]; see relRecordToGraphRel.
+		e.ToID = toID
+		records[srcIdx].Relationships = append(records[srcIdx].Relationships, e)
+		bound++
+	}
+	return records, bound, dropped
 }
 
 // relRecordToGraphRel converts an embedded types.RelationshipRecord to a

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -586,6 +586,25 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// signature of a rule set whose endpoints stopped naming in-file records,
 	// which is silent in the graph (the rows simply are not there).
 	pass25RelsBound, pass25RelsDropped := 0, 0
+	// #6150 — endpoint→handler outcomes for the re-extracted files.
+	// `kept_unresolved` is the cross-file-handler count (#6159): those endpoints
+	// survive with source_handler intact but without the IMPLEMENTS bridge, the
+	// attribution or the response shape a full rebuild gives them. It is logged
+	// because the alternative reading of the same situation — the endpoint being
+	// DELETED — is invisible in a graph and was exactly the hazard the
+	// file-scoped entry point exists to prevent.
+	endpointsResolved, endpointsKeptUnresolved, endpointsSuperseded := 0, 0, 0
+	// Endpoint synthetics already carried by the graph that SURVIVED Step 5's
+	// eviction, keyed Kind|Name. Built once, from doc.Entities, which at this
+	// point holds exactly the entities of the files NOT being re-extracted —
+	// so a hit means "another file already owns this endpoint", which is the
+	// evidence pruneSupersededEndpointSynthetics needs.
+	survivingEndpoints := make(map[string]bool)
+	for k := range doc.Entities {
+		if e := &doc.Entities[k]; e.Kind == endpointSyntheticKind {
+			survivingEndpoints[e.Kind+"|"+e.Name] = true
+		}
+	}
 	// #6094 — one identity per (FromID, ToID, Kind), shared across every file in
 	// this re-extraction batch. See convertExtractedRecords for why the triple is
 	// a safe identity here and how this scope differs from buildDocument's.
@@ -766,24 +785,50 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// the full path's, in the full path's order:
 		//
 		//	Pass 2.7  engine.ApplyResponseShapesCorpus — reads the handler body
-		//	          to stamp response_keys_known / response shape onto the
-		//	          endpoint. MUST run before the handler resolve below, which
-		//	          clears the `source_handler` property it navigates by.
-		//	Pass 2.8  engine.ResolveHTTPEndpointHandlersWithRepo — binds an
+		//	          to stamp response_keys / status_codes / response_keys_known
+		//	          onto the endpoint. MUST run before the handler resolve
+		//	          below, which clears the `source_handler` property it
+		//	          navigates by.
+		//	Pass 2.8  engine.ResolveHTTPEndpointHandlersFileScoped — binds an
 		//	          http_endpoint_definition to its handler: emits the
 		//	          IMPLEMENTS bridge, rebinds the endpoint's coordinates onto
 		//	          the handler body and stamps attribution="handler_resolved".
-		//	          buildDocument runs this on `merged`; the whole of it that
-		//	          concerns one file's endpoints is reachable from one file's
-		//	          records.
 		//
-		// Both are corpus-wide on the full path and file-scoped here. The
-		// difference is not cosmetic and is a REMAINING DIVERGENCE, not a fixed
-		// one: an endpoint whose handler lives in ANOTHER file resolves on the
-		// full path and does not resolve here, leaving the same property gap
-		// this closes for the co-located case. Scoping wider needs the previous
-		// graph's entities as candidates, which is a different (and much larger)
-		// change than reconciling one re-extracted file with itself.
+		// FILE-SCOPED, and the distinction is not a nicety. The corpus entry
+		// point (ResolveHTTPEndpointHandlersWithRepo, what buildDocument calls)
+		// DROPS a synthetic whose source_handler matches nothing in the slice —
+		// correct when the slice is the whole corpus, catastrophic when it is
+		// one file, because then "no candidate anywhere" and "the handler is in
+		// another file" become the same condition and every Express-router /
+		// Flask-add_url_rule / DRF-router endpoint in the delta is DELETED
+		// rather than left unenriched. The file-scoped entry point keeps them,
+		// source_handler intact, and counts them in HandlerUnresolvedKept. See
+		// its doc comment for why that is the same verdict #2851 and #3426
+		// already reach inside the same function.
+		//
+		// THE REMAINING DIVERGENCE, precisely. A cross-file handler is KEPT but
+		// not ENRICHED: no IMPLEMENTS bridge, no attribution, and no response
+		// shape (the reader below serves only the file being re-extracted, and
+		// the shape pass needs the handler's body). A full rebuild resolves it.
+		// That gap is #6159, allow-listed on the parity gate — it is a smaller
+		// gap than the deletion above, and unlike the deletion it is not a
+		// regression: before this change the endpoint carried none of those
+		// properties either. Closing it needs the previous graph's entities as
+		// resolution candidates, which is a materially larger change than
+		// reconciling one re-extracted file with itself.
+		//
+		// CANONICAL ORDER FIRST. Both passes disambiguate by FIRST-WRITER-WINS
+		// over the slice they are handed (ApplyResponseShapesCorpus' handler
+		// index; the resolver's globalIdx / globalMulti / sameFileBareIdx), and
+		// the resolver's doc makes it a documented precondition: "`merged` MUST
+		// already be sorted in canonical order (#481)". buildDocument satisfies
+		// it with sortEntityRecords; the fold's output does NOT — it is
+		// deliberately "the extractor's records first, then Detect's". Without
+		// this sort the precondition is simply unmet, and with two same-file
+		// candidates the two paths can bind different handlers. Sorting AFTER
+		// the fold is deliberate: the fold's own last-resort tiebreak reads that
+		// emission order, so sorting before it would change which record wins a
+		// three-way tie.
 		if det := frameworkDetector(); det != nil {
 			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
 				logger.Printf("incremental: framework detect %s: %v", rel, dErr)
@@ -791,6 +836,8 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 				var n int
 				records, n = engine.FoldFrameworkClassKinds(records, fwRes.Entities)
 				classKindFolds += n
+
+				types.SortEntityRecordsCanonical(records)
 
 				fileContent := content
 				engine.ApplyResponseShapesCorpus(records, fwRes.Relationships,
@@ -803,7 +850,14 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 				// OWNERSHIP: this pass consumes `records` and compacts over its
 				// backing array — read only the returned slice (see its doc).
-				records, _ = engine.ResolveHTTPEndpointHandlersWithRepo(records, doc.Repo)
+				var hStats engine.ResolveHTTPEndpointStats
+				records, hStats = engine.ResolveHTTPEndpointHandlersFileScoped(records, doc.Repo)
+				endpointsResolved += hStats.HandlerResolved
+				endpointsKeptUnresolved += hStats.HandlerUnresolvedKept
+
+				var superseded int
+				records, superseded = pruneSupersededEndpointSynthetics(records, survivingEndpoints)
+				endpointsSuperseded += superseded
 
 				var bound, unbindable int
 				records, bound, unbindable = bindPass25StubEndpoints(records, fwRes.Relationships, doc.Repo)
@@ -1071,9 +1125,10 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	dur := time.Since(t0)
-	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d pass25_rels_bound=%d pass25_rels_dropped=%d flows_recomputed=%t took=%s",
+	logger.Printf("incremental: done changed=%d entities=%d rels=%d class_kind_folds=%d pass25_rels_bound=%d pass25_rels_dropped=%d endpoints_resolved=%d endpoints_kept_unresolved=%d endpoints_superseded=%d flows_recomputed=%t took=%s",
 		len(reallyChanged), len(newEntities), len(newRels), classKindFolds,
-		pass25RelsBound, pass25RelsDropped, flowsRecomputed, dur.Truncate(time.Millisecond))
+		pass25RelsBound, pass25RelsDropped, endpointsResolved, endpointsKeptUnresolved, endpointsSuperseded,
+		flowsRecomputed, dur.Truncate(time.Millisecond))
 
 	return Result{
 		Done:         true,
@@ -1384,6 +1439,73 @@ func convertExtractedRecords(records []types.EntityRecord, repoTag string, seenR
 	return ents, rels
 }
 
+// endpointSyntheticKind is the kind engine's http_endpoint synthesis settles on
+// for a route DEFINITION after the #1217 migration inside the resolve pass.
+const endpointSyntheticKind = "http_endpoint_definition"
+
+// pruneSupersededEndpointSynthetics drops an UNRESOLVED endpoint synthetic that
+// the surviving graph already carries under the same (kind, name) (#6150).
+//
+// It exists because both obvious verdicts on an endpoint whose handler is not
+// in the re-extracted file are wrong, and the two failure modes are opposites:
+//
+//	DROPPING it destroys a live endpoint whenever nothing else in the graph
+//	carries it — the Express-router-plus-imported-controller shape, where the
+//	full rebuild leaves the endpoint anchored at the router file and the
+//	incremental run is the only producer of it. That is why the pass is called
+//	through engine.ResolveHTTPEndpointHandlersFileScoped rather than the corpus
+//	entry point, which drops.
+//
+//	KEEPING it invents a DUPLICATE whenever the full rebuild resolved the same
+//	endpoint cross-file: bridgeEndpointToHandler REBINDS the synthetic's
+//	source_file onto the handler's body, so the previous graph's copy is
+//	anchored at the HANDLER's file, survives the delta untouched, and the
+//	re-extracted router file contributes a second, unresolved copy at its own
+//	coordinates. Measured on Flask `add_url_rule` + an imported view: the full
+//	rebuild has one endpoint at the view's file; the incremental run had two.
+//
+// The second failure mode PREDATES this work — it reproduces byte-identically
+// with the endpoint-resolve pass disabled entirely, because before #6150 this
+// path emitted Detect's synthetic unconditionally. It is not a regression
+// introduced by the keep guard; the keep guard simply must not perpetuate it.
+//
+// The path is not short of evidence, which is what makes a third verdict
+// possible: it holds the SURVIVING graph. `survivors` is keyed
+// `Kind + "|" + Name` over the entities that outlived Step 5's eviction — so an
+// unresolved synthetic already carried by one of them is the same endpoint,
+// already correctly anchored, and the new copy is redundant. An unresolved
+// synthetic with no survivor is the only copy there is, and is kept.
+//
+// A RESOLVED synthetic is never pruned: it is the fresh, correct record for its
+// handler, and the survivor sharing its name is the previous graph's copy of
+// the same entity, which has the same derived id and merges rather than
+// duplicating.
+//
+// Returns the filtered slice (compacted in place over the caller's backing
+// array, like the resolve pass it follows) and the number pruned.
+func pruneSupersededEndpointSynthetics(records []types.EntityRecord, survivors map[string]bool) ([]types.EntityRecord, int) {
+	if len(records) == 0 || len(survivors) == 0 {
+		return records, 0
+	}
+	pruned := 0
+	out := records[:0]
+	for i := range records {
+		r := &records[i]
+		// source_handler's PRESENCE is the unresolved signal: the resolve pass
+		// deletes the property the moment it binds (bridgeEndpointToHandler).
+		if r.Kind == endpointSyntheticKind && r.Properties["source_handler"] != "" &&
+			survivors[r.Kind+"|"+r.Name] {
+			pruned++
+			continue
+		}
+		out = append(out, records[i])
+	}
+	for i := len(out); i < len(records); i++ {
+		records[i] = types.EntityRecord{}
+	}
+	return out, pruned
+}
+
 // bindPass25StubEndpoints binds the `Kind:Name` structural endpoint refs that
 // Pass 2.5 produces against ONE re-extracted file's own records (#6150).
 //
@@ -1483,34 +1605,40 @@ func bindPass25StubEndpoints(
 		}
 	}
 
+	// SOURCE index: `Kind:Name` → the single record carrying it, ACROSS FILES.
+	// The source end is looked up without a file to key on (a standalone
+	// relationship carries no owner), and whichever record wins then decides
+	// which file the TARGET is looked up in — so an ambiguous source is two
+	// guesses stacked on one coin flip, and it is refused for the same reason
+	// the target lookup refuses one. A first-wins source was the asymmetry in
+	// this function's first version.
+	srcIdxByRef := make(map[string]int, len(records))
+	for i := range records {
+		r := &records[i]
+		if r.Kind == "" || r.Name == "" || r.SourceFile == "" {
+			continue
+		}
+		ref := r.Kind + ":" + r.Name
+		if _, dup := srcIdxByRef[ref]; dup {
+			srcIdxByRef[ref] = ambiguousStubIdx
+			continue
+		}
+		srcIdxByRef[ref] = i
+	}
+
 	// Standalone relationships: bind both ends or drop.
 	bound, dropped := 0, 0
 	for _, sr := range standalone {
 		// The SOURCE end decides which file's records the target is looked up
 		// in, so a relationship rule that fired in file X can only ever bind
 		// within X — which is the only file this call has evidence about.
-		srcIdx := -1
-		for i := range records {
-			r := &records[i]
-			if r.SourceFile == "" || r.Kind == "" || r.Name == "" {
-				continue
-			}
-			if r.Kind+":"+r.Name != sr.FromID {
-				continue
-			}
-			if got, ok := idx[stubKey{r.SourceFile, sr.FromID}]; !ok || got == ambiguousStubIdx {
-				srcIdx = -1
-				break
-			}
-			srcIdx = i
-			break
-		}
-		if srcIdx < 0 {
+		srcIdx, ok := srcIdxByRef[sr.FromID]
+		if !ok || srcIdx == ambiguousStubIdx {
 			dropped++
 			continue
 		}
-		toID, ok := resolve(records[srcIdx].SourceFile, sr.ToID)
-		if !ok {
+		toID, tok := resolve(records[srcIdx].SourceFile, sr.ToID)
+		if !tok {
 			dropped++
 			continue
 		}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -829,6 +829,25 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		// the fold is deliberate: the fold's own last-resort tiebreak reads that
 		// emission order, so sorting before it would change which record wins a
 		// three-way tie.
+		//
+		// NOT COVERED END-TO-END, and it was attempted. Deleting this line
+		// passes both ./internal/extractors/... and ./cmd/grafel/ — including a
+		// fixture built specifically to break it (two same-named `def`s plus a
+		// registration naming them, in one re-extracted file: identical
+		// divergence sets with and without the sort). The reason is structural:
+		// the competing records here come from a per-language extractor, which
+		// emits in FILE order, and file order already coincides with canonical
+		// order for records sharing (Kind, Name, SourceFile) — StartLine is the
+		// tiebreak. Reaching a difference needs a producer that emits two
+		// same-key records out of line order, which nothing on this path does
+		// today. The guarantee is pinned at unit level instead, as a
+		// permutation invariant over the resolve
+		// (TestResolveHTTPEndpointHandlersFileScoped_CanonicalOrderMakesTheBindStable),
+		// where the order-dependence IS demonstrated: line 10 vs line 50.
+		//
+		// That probe also found a real defect and it is filed as #6161 — this
+		// path has no entity-identity gate, so the two same-named records
+		// became two graph rows with one id where a full rebuild emits one.
 		if det := frameworkDetector(); det != nil {
 			if fwRes, dErr := det.Detect(ctx, input); dErr != nil {
 				logger.Printf("incremental: framework detect %s: %v", rel, dErr)
@@ -855,6 +874,15 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 				endpointsResolved += hStats.HandlerResolved
 				endpointsKeptUnresolved += hStats.HandlerUnresolvedKept
 
+				// Ordering note: this runs BEFORE the stub bind below, so a
+				// standalone Pass-2.5 relationship whose target is a synthetic
+				// pruned here can no longer bind and is counted in
+				// pass25_rels_dropped rather than in endpoints_superseded. That
+				// is the right net behaviour — the edge would otherwise point
+				// at a record that is not being emitted — but the two counters
+				// do not add up to a partition of the work, and reading
+				// pass25_rels_dropped as "rule sets stopped naming in-file
+				// records" is wrong by exactly that amount.
 				var superseded int
 				records, superseded = pruneSupersededEndpointSynthetics(records, survivingEndpoints)
 				endpointsSuperseded += superseded
@@ -1476,10 +1504,27 @@ const endpointSyntheticKind = "http_endpoint_definition"
 // already correctly anchored, and the new copy is redundant. An unresolved
 // synthetic with no survivor is the only copy there is, and is kept.
 //
-// A RESOLVED synthetic is never pruned: it is the fresh, correct record for its
-// handler, and the survivor sharing its name is the previous graph's copy of
-// the same entity, which has the same derived id and merges rather than
-// duplicating.
+// A RESOLVED synthetic is never pruned, and the reason is NOT that it merges
+// with the survivor. It does not: entityRecordToGraphEntity derives
+// EntityID(repoTag, Kind, Name, SourceFile), and a survivor is by construction
+// anchored in a file that was NOT re-extracted, so the SourceFile differs and
+// so does the id. The real reason is that a same-named endpoint in a DIFFERENT
+// file is a DIFFERENT ROUTE — one a full rebuild also carries, as two rows —
+// so pruning the resolved one would delete a route on the strength of a name
+// collision.
+//
+// TWO LIMITS OF THE KEY, both deliberate and both untested by any fixture:
+//
+//   - It is `Kind|Name`, unqualified by path or repo. Two files legitimately
+//     registering the SAME route therefore collapse onto whichever the graph
+//     already had. That is the correct answer for the case this exists for (a
+//     rebound endpoint IS the same route under a different anchor) and the
+//     wrong one for a genuine same-route-twice corpus. Qualifying by path
+//     cannot work — the whole point is that the survivor's path differs.
+//
+//   - It sees only doc.Entities, i.e. files NOT in this delta. An endpoint
+//     carried by a file that IS in the delta is not a survivor, which is what
+//     makes the no-survivor case reach the keep branch at all.
 //
 // Returns the filtered slice (compacted in place over the caller's backing
 // array, like the resolve pass it follows) and the number pruned.

--- a/internal/extractors/incremental_pass25_rels_6150_test.go
+++ b/internal/extractors/incremental_pass25_rels_6150_test.go
@@ -1,0 +1,238 @@
+// Package extractors — #6150 unit coverage for the Pass-2.5 standalone
+// relationship binder.
+//
+// IN-PACKAGE (`extractors`, not `extractors_test`) because
+// `bindPass25StubEndpoints` is unexported. The end-to-end proof that these
+// edges reach the persisted graph is the #6129 content-parity gate in
+// cmd/grafel; what is asserted HERE is the part the gate cannot separate: WHICH
+// stub binds, which one is refused, and that a refusal drops the row rather
+// than emitting an unbound endpoint.
+//
+// The refusal half is the load-bearing one. #6148's first attempt at consuming
+// Detect's relationships emitted them verbatim and landed
+// `«unbound»Controller:X → «unbound»Service:y` plus duplicate DEPENDS_ON rows,
+// because the stubs are `Kind:Name` structural refs that the full path binds in
+// a corpus-wide resolver pass this path does not run. Binding in-file and
+// DROPPING the rest is what makes consuming them an improvement rather than a
+// second defect, so a change that starts emitting unbound rows again must fail
+// here.
+package extractors
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+func p25rec(kind, name, file string) types.EntityRecord {
+	return types.EntityRecord{Kind: kind, Name: name, SourceFile: file}
+}
+
+// p25find returns the record with the given kind+name, or nil.
+func p25find(recs []types.EntityRecord, kind, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Kind == kind && recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+// TestBindPass25StubEndpoints_BindsBothEndsInFile is the #6150 headline: the
+// falcon `app.add_route(...)` REGISTERED_ON rule emits
+// `Controller:CpPlainProbe → Service:cp_app`, both of which name records in the
+// file being re-extracted. The edge must land OWNED by the source record, with
+// the TARGET rewritten to the target record's deterministic entity id.
+func TestBindPass25StubEndpoints_BindsBothEndsInFile(t *testing.T) {
+	recs := []types.EntityRecord{
+		p25rec("Controller", "Probe", "h.py"),
+		p25rec("Service", "app", "h.py"),
+	}
+	rels := []types.RelationshipRecord{{
+		FromID: "Controller:Probe",
+		ToID:   "Service:app",
+		Kind:   "REGISTERED_ON",
+	}}
+
+	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	if bound != 1 || dropped != 0 {
+		t.Fatalf("bound=%d dropped=%d; want 1/0", bound, dropped)
+	}
+	src := p25find(out, "Controller", "Probe")
+	if src == nil || len(src.Relationships) != 1 {
+		t.Fatalf("source record did not receive the edge: %+v", src)
+	}
+	got := src.Relationships[0]
+	if got.Kind != "REGISTERED_ON" {
+		t.Errorf("kind = %q, want REGISTERED_ON", got.Kind)
+	}
+	// FromID must be EMPTY, meaning "my owner" — relRecordToGraphRel
+	// substitutes the owning entity's id, and that substitution is what makes
+	// the edge visible to the FromID-keyed stale-edge eviction (#6094).
+	if got.FromID != "" {
+		t.Errorf("FromID = %q, want empty (owner substitution)", got.FromID)
+	}
+	wantTo := graph.EntityID("test-repo", "Service", "app", "h.py")
+	if got.ToID != wantTo {
+		t.Errorf("ToID = %q, want the Service record's entity id %q", got.ToID, wantTo)
+	}
+	// The target record must NOT also carry a copy.
+	if tgt := p25find(out, "Service", "app"); tgt != nil && len(tgt.Relationships) != 0 {
+		t.Errorf("target record carries %d edge(s); the edge is owned by the source only",
+			len(tgt.Relationships))
+	}
+}
+
+// TestBindPass25StubEndpoints_DropsUnbindableStub: a stub naming an entity that
+// is not among this file's records is DROPPED, not emitted with the raw text as
+// an endpoint. This is the assertion that keeps the #6148 measurement — unbound
+// `«unbound»Controller:X` rows in the persisted graph — from coming back.
+func TestBindPass25StubEndpoints_DropsUnbindableStub(t *testing.T) {
+	recs := []types.EntityRecord{p25rec("Controller", "Probe", "h.py")}
+	rels := []types.RelationshipRecord{
+		{FromID: "Controller:Probe", ToID: "Service:elsewhere", Kind: "REGISTERED_ON"},
+		{FromID: "Controller:absent", ToID: "Controller:Probe", Kind: "REGISTERED_ON"},
+	}
+
+	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	if bound != 0 || dropped != 2 {
+		t.Fatalf("bound=%d dropped=%d; want 0/2", bound, dropped)
+	}
+	for i := range out {
+		if len(out[i].Relationships) != 0 {
+			t.Fatalf("record %s|%s received %d edge(s); an unbindable stub must emit nothing",
+				out[i].Kind, out[i].Name, len(out[i].Relationships))
+		}
+	}
+}
+
+// TestBindPass25StubEndpoints_RewritesEmbeddedStubs covers the OTHER stub
+// producer on this path: engine.ResolveHTTPEndpointHandlers appends the
+// endpoint→handler IMPLEMENTS bridge as an EMBEDDED edge whose endpoints are
+// the same `Kind:Name` form. Those must be rewritten in place, or the bridge
+// the full rebuild binds lands unbound here.
+func TestBindPass25StubEndpoints_RewritesEmbeddedStubs(t *testing.T) {
+	handler := p25rec("SCOPE.Operation", "Probe.on_get", "h.py")
+	handler.Relationships = []types.RelationshipRecord{{
+		FromID: "SCOPE.Operation:Probe.on_get",
+		ToID:   "http_endpoint_definition:http:GET:/things",
+		Kind:   "IMPLEMENTS",
+	}}
+	recs := []types.EntityRecord{
+		handler,
+		p25rec("http_endpoint_definition", "http:GET:/things", "h.py"),
+	}
+
+	out, _, _ := bindPass25StubEndpoints(recs, nil, "test-repo")
+	got := p25find(out, "SCOPE.Operation", "Probe.on_get").Relationships[0]
+	if want := graph.EntityID("test-repo", "SCOPE.Operation", "Probe.on_get", "h.py"); got.FromID != want {
+		t.Errorf("FromID = %q, want %q", got.FromID, want)
+	}
+	// The endpoint's NAME itself contains colons ("http:GET:/things"). The
+	// lookup key is the whole `Kind + ":" + Name` string, so this resolves; a
+	// binder that split on the first colon would look up kind
+	// "http_endpoint_definition", name "http" and miss.
+	if want := graph.EntityID("test-repo", "http_endpoint_definition", "http:GET:/things", "h.py"); got.ToID != want {
+		t.Errorf("ToID = %q, want %q", got.ToID, want)
+	}
+}
+
+// TestBindPass25StubEndpoints_LeavesNonStubEndpointsAlone: the binder must be
+// invisible to every edge that is not a `Kind:Name` stub matching a record of
+// this file. A bare call target ("len"), a dotted import ("cfg.SETTING") and an
+// already-stamped hex id all pass through untouched — the scoped resolver owns
+// those, and rewriting them here would take the binding away from the pass that
+// knows how to do it corpus-wide.
+func TestBindPass25StubEndpoints_LeavesNonStubEndpointsAlone(t *testing.T) {
+	caller := p25rec("SCOPE.Operation", "cp_use", "h.py")
+	stamped := graph.EntityID("test-repo", "Module", "other", "other.py")
+	caller.Relationships = []types.RelationshipRecord{
+		{ToID: "len", Kind: "CALLS"},
+		{ToID: "cfg.SETTING", Kind: "IMPORTS"},
+		{ToID: stamped, Kind: "REFERENCES"},
+		{ToID: "", Kind: "CALLS"},
+	}
+	recs := []types.EntityRecord{caller, p25rec("Controller", "len", "h.py")}
+
+	out, _, _ := bindPass25StubEndpoints(recs, nil, "test-repo")
+	got := p25find(out, "SCOPE.Operation", "cp_use").Relationships
+	want := []string{"len", "cfg.SETTING", stamped, ""}
+	for i, w := range want {
+		if got[i].ToID != w {
+			t.Errorf("rel %d ToID = %q, want %q (unchanged)", i, got[i].ToID, w)
+		}
+	}
+}
+
+// TestBindPass25StubEndpoints_NoCrossFileBind: two records with the same
+// Kind:Name in DIFFERENT files are both present (the caller hands this function
+// one file's records, but nothing in the type system enforces it). The bind is
+// keyed on file as well as kind/name, so a stub can only reach a record of the
+// file that produced the relationship — the source record's own file.
+func TestBindPass25StubEndpoints_NoCrossFileBind(t *testing.T) {
+	recs := []types.EntityRecord{
+		p25rec("Controller", "Probe", "a.py"),
+		p25rec("Service", "app", "b.py"),
+	}
+	rels := []types.RelationshipRecord{{
+		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
+	}}
+	_, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	if bound != 0 || dropped != 1 {
+		t.Fatalf("bound=%d dropped=%d; want 0/1 (target lives in another file)", bound, dropped)
+	}
+}
+
+// TestBindPass25StubEndpoints_AmbiguousStubIsRefused: when two records of the
+// SAME file share a Kind:Name, the stub names no single entity. Binding it
+// would be a coin flip that a full rebuild's resolver (which has an ambiguity
+// sentinel) refuses, so this refuses too — a wrong bind reads as an improvement
+// on every count-based metric (#6123).
+func TestBindPass25StubEndpoints_AmbiguousStubIsRefused(t *testing.T) {
+	a := p25rec("Service", "app", "h.py")
+	a.StartLine = 1
+	b := p25rec("Service", "app", "h.py")
+	b.StartLine = 9
+	recs := []types.EntityRecord{p25rec("Controller", "Probe", "h.py"), a, b}
+	rels := []types.RelationshipRecord{{
+		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
+	}}
+	_, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	if bound != 0 || dropped != 1 {
+		t.Fatalf("bound=%d dropped=%d; want 0/1 (ambiguous target)", bound, dropped)
+	}
+}
+
+// TestEntityRecordToGraphEntity_DerivesIDIgnoringRecordID pins the record→graph
+// seam's id rule (#6150).
+//
+// engine's http_endpoint synthesis stamps EntityRecord.ID with the ROUTABLE
+// FORM of the endpoint — literally "http:GET:/things" (#1725, where the same
+// string is also used as the QualifiedName). buildDocument overwrites it: every
+// entity it emits gets graph.EntityID(repo, kind, name, source_file) and the
+// record's own ID is never read. This path honoured it, so the SAME endpoint
+// carried a deterministic hex id after a full rebuild and a raw routable string
+// after an incremental one.
+//
+// That is not cosmetic. Entity ids are what every edge endpoint, the
+// FlatBuffers `(key)` binary search behind LookupEntityByID (#5974) and the
+// flow passes' entry_id/chain/branches_dag properties join on — the last of
+// which made it visible: the incremental SCOPE.Process node described its entry
+// as "http:GET:/cpthings" where the full rebuild had the hex.
+func TestEntityRecordToGraphEntity_DerivesIDIgnoringRecordID(t *testing.T) {
+	rec := types.EntityRecord{
+		ID:         "http:GET:/things",
+		Kind:       "http_endpoint_definition",
+		Name:       "http:GET:/things",
+		SourceFile: "h.py",
+	}
+	got := entityRecordToGraphEntity(rec, "test-repo")
+	want := graph.EntityID("test-repo", "http_endpoint_definition", "http:GET:/things", "h.py")
+	if got.ID != want {
+		t.Errorf("ID = %q, want the derived %q — the record's own ID must not win", got.ID, want)
+	}
+	if got.ID == rec.ID {
+		t.Errorf("ID is the record's stamped routable form %q; buildDocument never emits that", rec.ID)
+	}
+}

--- a/internal/extractors/incremental_pass25_rels_6150_test.go
+++ b/internal/extractors/incremental_pass25_rels_6150_test.go
@@ -236,3 +236,133 @@ func TestEntityRecordToGraphEntity_DerivesIDIgnoringRecordID(t *testing.T) {
 		t.Errorf("ID is the record's stamped routable form %q; buildDocument never emits that", rec.ID)
 	}
 }
+
+// TestBindPass25StubEndpoints_AmbiguousSourceIsRefused is the SOURCE-side twin
+// of TestBindPass25StubEndpoints_AmbiguousStubIsRefused, and it closes an
+// asymmetry the first version of this function had: the target lookup refused
+// ambiguity, but the source lookup took the FIRST record matching the stub
+// anywhere in the slice — and the file of whichever record won then decided
+// where the TARGET was looked up. Two guesses stacked on one coin flip.
+//
+// Latent today (the caller passes one file's records), which is exactly why it
+// is pinned: the guard has to survive a caller that stops being careful, and
+// this function is the one place on the path that could silently choose.
+func TestBindPass25StubEndpoints_AmbiguousSourceIsRefused(t *testing.T) {
+	recs := []types.EntityRecord{
+		p25rec("Controller", "Probe", "a.py"),
+		p25rec("Service", "app", "a.py"),
+		p25rec("Controller", "Probe", "b.py"), // same Kind:Name, other file
+		p25rec("Service", "app", "b.py"),
+	}
+	rels := []types.RelationshipRecord{{
+		FromID: "Controller:Probe", ToID: "Service:app", Kind: "REGISTERED_ON",
+	}}
+	out, bound, dropped := bindPass25StubEndpoints(recs, rels, "test-repo")
+	if bound != 0 || dropped != 1 {
+		t.Fatalf("bound=%d dropped=%d; want 0/1 — the source stub names two records in two files", bound, dropped)
+	}
+	for i := range out {
+		if len(out[i].Relationships) != 0 {
+			t.Fatalf("record %s|%s@%s received an edge from an ambiguous source stub",
+				out[i].Kind, out[i].Name, out[i].SourceFile)
+		}
+	}
+}
+
+// ── superseded-synthetic prune (#6150 / #6159) ────────────────────────────
+
+// p25endpoint builds an http_endpoint_definition synthetic. A non-empty
+// handlerRef means UNRESOLVED: engine.ResolveHTTPEndpointHandlers clears
+// source_handler when it binds, so the property's presence IS the "this
+// endpoint never found its handler" signal.
+func p25endpoint(name, file, handlerRef string) types.EntityRecord {
+	r := types.EntityRecord{Kind: "http_endpoint_definition", Name: name, SourceFile: file}
+	if handlerRef != "" {
+		r.Properties = map[string]string{"source_handler": handlerRef}
+	}
+	return r
+}
+
+// TestPruneSupersededEndpointSynthetics_DropsWhenSurvivorExists is the second
+// half of the file-scoping answer, and it exists because BOTH obvious verdicts
+// on an unresolvable endpoint synthetic are wrong:
+//
+//	DROP it   — deletes a live endpoint when nothing else in the graph carries
+//	            it (the Express-router / imported-controller shape).
+//	KEEP it   — INVENTS a duplicate when the full rebuild resolved the same
+//	            endpoint cross-file and REBOUND it onto the handler's file: the
+//	            correctly-anchored copy is carried forward from the previous
+//	            graph, and the re-extracted router file adds a second,
+//	            unresolved one at its own coordinates. Measured on a Flask
+//	            `add_url_rule` + imported view: full has ONE endpoint at the
+//	            view's file; incremental had TWO. That duplicate PREDATES this
+//	            work — it reproduces identically with the resolve pass disabled.
+//
+// The path is not actually short of evidence: it holds the surviving graph. An
+// unresolved synthetic whose (kind, name) is ALREADY carried by a survivor is
+// the same endpoint, already correctly anchored, so the new copy is dropped.
+func TestPruneSupersededEndpointSynthetics_DropsWhenSurvivorExists(t *testing.T) {
+	recs := []types.EntityRecord{
+		p25rec("SCOPE.Operation", "zz_setup", "app.py"),
+		p25endpoint("http:GET:/zzc", "app.py", "Controller:zz_list_c"),
+	}
+	survivors := map[string]bool{"http_endpoint_definition|http:GET:/zzc": true}
+
+	out, pruned := pruneSupersededEndpointSynthetics(recs, survivors)
+	if pruned != 1 {
+		t.Fatalf("pruned = %d, want 1", pruned)
+	}
+	for _, r := range out {
+		if r.Kind == "http_endpoint_definition" {
+			t.Errorf("superseded synthetic survived: %s@%s", r.Name, r.SourceFile)
+		}
+	}
+	if len(out) != 1 || out[0].Name != "zz_setup" {
+		t.Errorf("prune disturbed the non-endpoint records: %+v", out)
+	}
+}
+
+// TestPruneSupersededEndpointSynthetics_KeepsWhenNoSurvivor is the Sev-1 half:
+// with nothing in the surviving graph carrying this endpoint, dropping it
+// destroys the only copy. The graph must keep it, unenriched.
+func TestPruneSupersededEndpointSynthetics_KeepsWhenNoSurvivor(t *testing.T) {
+	recs := []types.EntityRecord{p25endpoint("http:GET:/zzc", "app.py", "Controller:zz_list_c")}
+	out, pruned := pruneSupersededEndpointSynthetics(recs, map[string]bool{
+		"http_endpoint_definition|http:GET:/other": true,
+	})
+	if pruned != 0 || len(out) != 1 {
+		t.Fatalf("pruned=%d len(out)=%d; want 0/1 — this is the only copy of the endpoint", pruned, len(out))
+	}
+}
+
+// TestPruneSupersededEndpointSynthetics_KeepsResolvedSynthetic: a synthetic the
+// resolve pass BOUND (source_handler cleared) is never pruned. It is the fresh,
+// correct record for its handler, and the survivor with the same name is the
+// previous graph's copy of the same entity — which has the same id and merges,
+// rather than duplicating.
+func TestPruneSupersededEndpointSynthetics_KeepsResolvedSynthetic(t *testing.T) {
+	recs := []types.EntityRecord{p25endpoint("http:GET:/zzc", "views.py", "")}
+	out, pruned := pruneSupersededEndpointSynthetics(recs, map[string]bool{
+		"http_endpoint_definition|http:GET:/zzc": true,
+	})
+	if pruned != 0 || len(out) != 1 {
+		t.Fatalf("pruned=%d len(out)=%d; want 0/1 — a resolved synthetic is never superseded", pruned, len(out))
+	}
+}
+
+// TestPruneSupersededEndpointSynthetics_IgnoresNonEndpointRecords: the prune is
+// scoped to endpoint synthetics. A same-named record of any other kind is not
+// its business, and a `source_handler` property on a non-endpoint record does
+// not make it one.
+func TestPruneSupersededEndpointSynthetics_IgnoresNonEndpointRecords(t *testing.T) {
+	odd := p25rec("Controller", "http:GET:/zzc", "app.py")
+	odd.Properties = map[string]string{"source_handler": "Controller:x"}
+	recs := []types.EntityRecord{odd}
+	out, pruned := pruneSupersededEndpointSynthetics(recs, map[string]bool{
+		"Controller|http:GET:/zzc":               true,
+		"http_endpoint_definition|http:GET:/zzc": true,
+	})
+	if pruned != 0 || len(out) != 1 {
+		t.Fatalf("pruned=%d len(out)=%d; want 0/1", pruned, len(out))
+	}
+}

--- a/internal/extractors/incremental_pass25_rels_6150_test.go
+++ b/internal/extractors/incremental_pass25_rels_6150_test.go
@@ -366,3 +366,27 @@ func TestPruneSupersededEndpointSynthetics_IgnoresNonEndpointRecords(t *testing.
 		t.Fatalf("pruned=%d len(out)=%d; want 0/1", pruned, len(out))
 	}
 }
+
+// TestPruneSupersededEndpointSynthetics_SameRouteInTwoFilesCollapses pins the
+// documented LIMIT of the `Kind|Name` key rather than a desirable behaviour.
+//
+// The key is unqualified by path — deliberately, because the case the prune
+// exists for is precisely one where the survivor's path DIFFERS (an endpoint
+// rebound onto its handler's file by #2678). The cost is that two files
+// legitimately registering the SAME route collapse onto whichever copy the
+// graph already had: the re-extracted one is treated as superseded even though
+// a full rebuild would carry both rows.
+//
+// Pinned so the trade-off is a decision with a test on it rather than an
+// accident, and so that a future path- or repo-qualified key fails here loudly
+// instead of silently changing which routes survive an edit.
+func TestPruneSupersededEndpointSynthetics_SameRouteInTwoFilesCollapses(t *testing.T) {
+	recs := []types.EntityRecord{p25endpoint("http:GET:/dup", "second_registration.py", "Controller:h")}
+	out, pruned := pruneSupersededEndpointSynthetics(recs, map[string]bool{
+		// survivor lives in a DIFFERENT file, registering the same route
+		"http_endpoint_definition|http:GET:/dup": true,
+	})
+	if pruned != 1 || len(out) != 0 {
+		t.Fatalf("pruned=%d len(out)=%d; want 1/0 — the key is Kind|Name, unqualified by path", pruned, len(out))
+	}
+}

--- a/internal/types/entity_order.go
+++ b/internal/types/entity_order.go
@@ -1,0 +1,49 @@
+package types
+
+import "sort"
+
+// SortEntityRecordsCanonical orders an EntityRecord slice by the tuple
+// (Kind, Name, SourceFile, StartLine, EndLine, Signature) — issue #481's
+// canonical order.
+//
+// WHY IT LIVES HERE. Several downstream passes disambiguate identically-named
+// entities by FIRST-WRITER-WINS over the slice they are handed
+// (resolve.BuildIndex, the seenEntity/seenRel dedup in buildDocument,
+// engine.ResolveHTTPEndpointHandlers' globalIdx / globalMulti /
+// sameFileBareIdx, engine.ApplyResponseShapesCorpus' handler index). Whoever
+// comes first in the slice therefore DECIDES the graph, so a producer that
+// hands those passes a differently-ordered slice can bind a different entity
+// than the full rebuild does — a mis-bind, which is the class every count-based
+// metric reports as healthy (#6123).
+//
+// There were two copies of this comparator before #6150 (cmd/grafel's
+// determinism.go and internal/daemon/extract's coordinator.go) and the
+// incremental producer needed a third, which is exactly the drift #5974 fixed
+// for the emission sort by moving it into one shared place. This is that place
+// for the canonical order: it is the lowest package all three producers already
+// depend on, so no import cycle is possible.
+//
+// sort.SliceStable, not sort.Slice: records comparing equal on all six fields
+// keep their arrival order, so the answer stays a function of the input rather
+// than of the sort's internal pivot choices.
+func SortEntityRecordsCanonical(rs []EntityRecord) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		a, b := &rs[i], &rs[j]
+		if a.Kind != b.Kind {
+			return a.Kind < b.Kind
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.SourceFile != b.SourceFile {
+			return a.SourceFile < b.SourceFile
+		}
+		if a.StartLine != b.StartLine {
+			return a.StartLine < b.StartLine
+		}
+		if a.EndLine != b.EndLine {
+			return a.EndLine < b.EndLine
+		}
+		return a.Signature < b.Signature
+	})
+}


### PR DESCRIPTION
The incremental path ran the framework classifier but consumed only its class-kind output, paying the full `Detect` cost and discarding the rest. On the deep Falcon shape — `import falcon` + `falcon.App()` + `add_route` + `on_get` — that measured **12 divergences**.

**12 → 3.** The remaining three are one filed cause.

## What it consumes now

Four changes, in the full path's own order:

1. **`engine.ApplyResponseShapesCorpus`** per re-extracted file — restores `response_keys_known`.
2. **`engine.ResolveHTTPEndpointHandlersWithRepo`** per file — restores the `IMPLEMENTS` bridge, `attribution="handler_resolved"`, and the endpoint's coordinate rebind.
3. **`bindPass25StubEndpoints`** — consumes Detect's standalone relationships by binding `Kind:Name` stubs against the re-extracted file's **own** records, dropping what does not bind. Prior work excluded these because emitting them raw produced `«unbound»Controller:X→«unbound»Service:y`; binding-or-dropping is what makes them safe. The lookup key is the whole `Kind+":"+Name` string, never split on the first colon — that split has caused two separate defects this cycle (#6105, #6123).
4. **`entityRecordToGraphEntity` derives the entity id** instead of honouring `EntityRecord.ID`, matching `buildDocument`, which computes `graph.EntityID(...)` unconditionally and never reads that field.

**The `SCOPE.Process` flow node and its four edges came back for free.** The flow pass *does* run here (`RunFlowsIncremental`); it was starved of input, not unreachable. Disabling the binder re-loses all five as one group — causal, not correlated.

## A defect class the parity gate cannot see

`http_endpoint_synthesis` stamps `ID` with the routable form (#1725), so an endpoint in a re-extracted file carried the literal string `"http:GET:/cpthings"` as its graph id.

**Content-keyed comparison cannot detect this by construction** — `entityKey` drops the id, `entityStructuralDiff` never compares it, and `contentEndpointResolver` resolves edge endpoints *through* the id into a content tuple, so a wrong-but-internally-consistent id hides on the edge side too. It surfaced only because the flow pass embeds the id as **text** in `entry_id`/`chain`/`branches_dag`.

The gate's header now records what it cannot see: entity ids, canonical entity ordering (which `graph.fb`'s binary search behind `LookupEntityByID` depends on — #5974's class), `RelationshipID` (`relKey` is `from→to:kind`), and everything above the entity/edge level — `Stats`, `SurpriseEdges`, `AlgorithmStats`, `IndexerVersion`, `CoverageStatus`. Demonstrated: a mutant reproducing the #6105/#6123 first-colon split **passes the gate outright**, caught only by a unit test.

## Three verdicts, not two — and the first two are both wrong

Review found that file-scoping `ResolveHTTPEndpointHandlersWithRepo` **deletes** endpoints (`http_endpoint_resolve.go:626` sets `drop[i]` and compacts), and proposed keep-don't-drop. Measurement rejected both:

- **drop** destroys the only copy when nothing else carries the endpoint.
- **keep** *invents a duplicate* whenever the full rebuild resolved cross-file — `bridgeEndpointToHandler` rebinds the synthetic onto the **handler's** file (#2678), so the correctly-anchored copy is carried forward from the previous graph while the re-extracted registration file adds a second, unresolved one. Measured on Flask `add_url_rule` + imported view: full **one** endpoint at the view's file, incremental **two**.

That duplicate is **byte-identical with the resolve pass disabled entirely** — it predates all of this. Plain keep-don't-drop would have shipped a pre-existing defect as the fix.

The incremental path holds the surviving graph, so a third verdict exists: **keep, then prune iff a survivor already carries that `(kind, name)`**. `survivingEndpoints` is built *after* Step 5's eviction completes, so it can never contain the re-extracted file's own old copies — verified as the load-bearing ordering.

Review's own end-to-end numbers did not reproduce: at `45ceece6e` (the drop version) the gate shows `/cpusers` as `[ENTITY-FIELDS] {-response_keys, -response_keys_known, -status_codes}`, a property gap, **not `ENTITY-LOST`**. `pass25_rels_dropped` is fed by `bindPass25StubEndpoints`' second return (`incremental.go:1558`) and has never counted endpoints.

## The fixture was the problem, twice

The first fixture could not distinguish the three verdicts at all — `/cpusers` resolves in-file via a destructured `require` binding, and `/cpview` has a survivor, so drop was harmless on both. Drop and keep+prune produced **identical divergence sets**.

Now a Flask registration **and the view it imports are both in the delta**, so Step 5 evicts the previous copy and nothing survives carrying the endpoint — the only state where the verdicts differ in the persisted graph. Both mutants are killed **end-to-end by `./cmd/grafel/`**, not by unit tests alone.

## A guarantee that could not be pinned, stated rather than implied

`types.SortEntityRecordsCanonical` establishes the canonical-order precondition `ResolveHTTPEndpointHandlersWithRepo` documents as a `MUST` (`copy`'s `globalIdx`/`globalMulti`/`sameFileBareIdx` are first-writer-wins). Sorting happens **after** the fold, since the fold's last tiebreak reads emission order.

The order-dependence is real and pinned at unit level — same records, different order → binds the handler at line 10 vs line 50, and rebinds the endpoint's coordinates onto whichever won. **But a mutant removing the call-site sort survives the whole suite, and a fixture for it is not constructible on this path:** the competing records come from a per-language extractor emitting in file order, which already coincides with canonical order for records sharing `(Kind, Name, SourceFile)` because `StartLine` is the tiebreak. Reaching a difference needs a producer emitting two same-key records out of line order; nothing here does. Recorded at the site and in the commit rather than left implied.

## Filed with measurements, not deferred silently

- **#6156** — the full rebuild's `IMPORTS` edge points at the hex of a placeholder `PruneImportPlaceholders` already removed (`rels_orphaned=2` in its own log) while incremental binds the live node. **A full-path defect where the incremental answer is correct.** The `DEPENDS_ON weight 2≠3` row is *consequential*, not a second defect: `internal/module/aggregate.go:234` skips edges with a dangling endpoint before incrementing, giving exactly +1.
- **#6159** — cross-file handler ⇒ endpoint kept but unenriched, and anchored at the registration file where a full rebuild anchors it at the handler's. Reproduced at `617aeba6c`; a **trade**, not a fix — keeping a mis-anchored route beats deleting the only copy — and allow-listed as a divergence.
- **#6160** — Path B duplicates a rebound endpoint, its `IMPLEMENTS` bridge and its whole process-flow subtree. Verified at base: Path B's divergence set is *identical* at `617aeba6c` and here.
- **#6161** — `convertExtractedRecords` has no entity-identity gate, so two same-named records become **two graph rows carrying one id** where `buildDocument`'s `seenEntity` emits one. The relationship half of that loop got its gate in #6094; the entity half never did. Found by a probe that was then reverted rather than kept, since pinning it would drag ~8 unrelated allow entries into this gate.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`, rebased onto `a4c00b1f7` **before** running:

| package | exit |
|---|---|
| `./internal/engine/...` | 0 |
| `./internal/extractors/...` | 0 |
| `./internal/types/...` | 0 |
| `./internal/resolve/...` | 0 |
| `./internal/graph/...` | 0 |
| `./cmd/grafel/` | 0 |

17 subtest-aware skips, all pre-existing. Rebasing first matters here: this branch predated `a4c00b1f7`'s store-isolation guard, so running `cmd/grafel` with only `GRAFEL_DAEMON_ROOT` set would have touched the live `~/.grafel/store`.

**13 mutants across three rounds, all killed behaviourally on their intended assertion**, with survivors reported rather than hidden. Reverts from file copies throughout after one disclosed `git checkout --` incident that destroyed an uncommitted test — caught by grepping for the test name, restored, and independently confirmed complete (all 11 new symbols have ≥4 references; no orphaned helpers, no second casualty).

Independently adversarially reviewed three times (REQUEST-CHANGES → REQUEST-CHANGES → REQUEST-CHANGES), all findings addressed or explicitly declined with evidence.

Closes #6150
Refs #6148, #6129, #6156, #6159, #6160, #6161, #6105, #6123, #5974, #2678, #1725
