### PR TITLE
fix(#6165): the curl installer never wrote install.json — so it printed the warning it caused

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -299,6 +299,32 @@ restart_daemon() {
   return 0
 }
 
+# record_install_state makes ~/.grafel/install.json agree with the binary we
+# just placed in $BIN_DIR.
+#
+# Without this the installer ships a bug it then reports: `install -m 0755`
+# replaces the binary but nothing rewrites install.json, whose CLI checksum is
+# only ever written by `grafel install`. So the recorded SHA stays the PREVIOUS
+# binary's, and grafel's quick-doctor preflight prefixes
+#   "grafel doctor: binary updated since last install …"
+# onto EVERY subsequent grafel command, forever — including the `grafel doctor`
+# call a few lines below in main().
+#
+# We deliberately do NOT run a bare `grafel install` here. That is a seven-step
+# transaction which, among other things, appends /.grafel/ to the .gitignore of
+# whatever repository the user's shell happened to be in when they piped this
+# script to bash, installs four git hooks into that same repository, rewrites
+# every detected .claude.json, and restarts the daemon with a 60s budget that
+# would duplicate and race restart_daemon below. A one-line installer must not
+# mutate a repo the user never mentioned. `--refresh-state` is the narrow
+# operation that only re-records the binary's path and checksum.
+#
+# Best-effort, like every other post-download step: a failure here prints
+# nothing fatal and never aborts the installer.
+record_install_state() {
+  "$BIN_DIR/grafel" install --refresh-state >/dev/null 2>&1 || true
+}
+
 configure_path() {
   shell_name=""
   if [ -n "${SHELL:-}" ]; then
@@ -365,6 +391,10 @@ main() {
     cp "$TMP_DIR/grafel" "$BIN_DIR/grafel"
     chmod +x "$BIN_DIR/grafel"
   }
+
+  # Record the binary we just placed BEFORE reporting doctor output, so the
+  # installer stops printing the stale-checksum warning it caused itself.
+  record_install_state
 
   configure_path
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/charmbracelet/huh"
 	"github.com/spf13/cobra"
@@ -136,6 +137,14 @@ Claude Code config directory's skills/ subdirectory.`,
 			// git hooks in the caller's repo, or blocking on a TTY prompt.
 			// See internal/install/refreshstate.go for the full argument.
 			if refreshState {
+				// Silently ignoring the rest would be its own trap: every
+				// other install flag asks for work --refresh-state explicitly
+				// does not do, so a user combining them would get a state
+				// rewrite and believe they got an install.
+				if conflicts := conflictingRefreshStateFlags(cmd); len(conflicts) > 0 {
+					return fmt.Errorf("--refresh-state only re-records this binary in install.json; it cannot be combined with %s "+
+						"(run 'grafel install' on its own for a full install)", strings.Join(conflicts, ", "))
+				}
 				return runRefreshState(out)
 			}
 
@@ -301,6 +310,22 @@ Claude Code config directory's skills/ subdirectory.`,
 	cmd.Flags().BoolVar(&refreshState, "refresh-state", false,
 		"only re-record this binary's path and checksum in ~/.grafel/install.json (no daemon restart, no skills, no MCP, no git changes); used by the curl installer after an in-place upgrade")
 	return cmd
+}
+
+// conflictingRefreshStateFlags returns the names of any explicitly-set install
+// flags that --refresh-state cannot honour. Only flags the user actually typed
+// count (Changed), so the --copy default of true is not a conflict.
+func conflictingRefreshStateFlags(cmd *cobra.Command) []string {
+	var conflicts []string
+	for _, name := range []string{
+		"foreground", "claude-config-dirs", "skills-source-dir", "skip-skill-link",
+		"mode", "copy", "dev", "force", "no-hooks", "tools", "no-wizard", "yes",
+	} {
+		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
+			conflicts = append(conflicts, "--"+name)
+		}
+	}
+	return conflicts
 }
 
 // runRefreshState executes the narrow install.json CLI-record refresh and

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -91,6 +91,7 @@ func newInstallCmd() *cobra.Command {
 	var toolsCSV string
 	var noWizard bool
 	var assumeYes bool
+	var refreshState bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -125,6 +126,18 @@ Install also copies or symlinks the grafel skills into every detected
 Claude Code config directory's skills/ subdirectory.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
+
+			// ── --refresh-state: record the on-disk binary, nothing else ───
+			// Handled FIRST, before the tool-selection wizard and before any
+			// of the install transaction: this path exists precisely so the
+			// curl installer can make ~/.grafel/install.json agree with the
+			// binary it just placed WITHOUT restarting the daemon, rewriting
+			// .claude.json, appending to the caller's .gitignore, installing
+			// git hooks in the caller's repo, or blocking on a TTY prompt.
+			// See internal/install/refreshstate.go for the full argument.
+			if refreshState {
+				return runRefreshState(out)
+			}
 
 			// ── per-tool selection (#5256) ─────────────────────────────────
 			// Resolve the desired tool set and persist it to every registered
@@ -283,7 +296,36 @@ Claude Code config directory's skills/ subdirectory.`,
 		"skip the interactive tool-selection wizard even on a TTY (keep the current/default tool set)")
 	cmd.Flags().BoolVar(&assumeYes, "yes", false,
 		"assume defaults for all prompts (alias for --no-wizard for tool selection); never blocks automation")
+	// Curl-installer support: record the running binary in install.json and do
+	// nothing else. Not a full install — see internal/install/refreshstate.go.
+	cmd.Flags().BoolVar(&refreshState, "refresh-state", false,
+		"only re-record this binary's path and checksum in ~/.grafel/install.json (no daemon restart, no skills, no MCP, no git changes); used by the curl installer after an in-place upgrade")
 	return cmd
+}
+
+// runRefreshState executes the narrow install.json CLI-record refresh and
+// prints a one-line summary. It never mutates anything outside install.json.
+func runRefreshState(out io.Writer) error {
+	bin, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+	res, err := install.RefreshState(install.RefreshOptions{BinPath: bin})
+	if err != nil {
+		return err
+	}
+	switch {
+	case !res.HadState:
+		// Nothing installed yet: quick-doctor is already silent in this state,
+		// and fabricating an install.json here would make `grafel doctor`
+		// report skills/MCP drift that does not exist.
+		fmt.Fprintln(out, "no ~/.grafel/install.json to refresh — run 'grafel install' to install grafel")
+	case !res.Changed:
+		fmt.Fprintf(out, "install state already current (%s)\n", res.Path)
+	default:
+		fmt.Fprintf(out, "✓ install state refreshed: %s (sha256 %s…)\n", res.Path, res.SHA256[:12])
+	}
+	return nil
 }
 
 // resolveToolSelection decides the per-tool selection for `grafel install`.

--- a/internal/cli/install_refreshstate_test.go
+++ b/internal/cli/install_refreshstate_test.go
@@ -1,0 +1,225 @@
+// install_refreshstate_test.go covers `grafel install --refresh-state` at the
+// CLI boundary.
+//
+// Review finding: the first pass shipped this flag with ZERO coverage in
+// internal/cli — the flag, runRefreshState, its three output branches and,
+// critically, the short-circuit that places it ahead of the tool-selection
+// wizard and the whole install transaction were asserted only by a comment.
+// That short-circuit IS the safety property: `grafel install` proper appends
+// /.grafel/ to the .gitignore of the caller's cwd and installs four git hooks
+// there (RunCopy steps 5 and 7), which is precisely why install.sh may not call
+// it. A regression that let --refresh-state fall through would put those
+// mutations back into the curl installer.
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// refreshStateEnv points HOME at a temp dir and returns its install.json path.
+func refreshStateEnv(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return filepath.Join(home, ".grafel", "install.json")
+}
+
+// runInstallRefreshState executes `install --refresh-state` (plus extraArgs)
+// against a fresh command tree and returns its output and error.
+func runInstallRefreshState(t *testing.T, extraArgs ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := newInstallCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(append([]string{"--refresh-state"}, extraArgs...))
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// TestInstallRefreshState_NoStateReportsAndDoesNotFabricate: an absent
+// install.json must stay absent — quick-doctor is already silent in that state,
+// and a synthetic record with no skills/MCP manifest would make `grafel doctor`
+// report drift that does not exist.
+func TestInstallRefreshState_NoStateReportsAndDoesNotFabricate(t *testing.T) {
+	statePath := refreshStateEnv(t)
+
+	out, err := runInstallRefreshState(t)
+	if err != nil {
+		t.Fatalf("install --refresh-state: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "no ~/.grafel/install.json to refresh") {
+		t.Errorf("expected the no-state branch, got: %q", out)
+	}
+	if _, statErr := os.Stat(statePath); !os.IsNotExist(statErr) {
+		t.Errorf("install.json must not be created out of nothing (stat err = %v)", statErr)
+	}
+}
+
+// TestInstallRefreshState_RewritesAStaleRecord exercises the branch the curl
+// installer depends on.
+func TestInstallRefreshState_RewritesAStaleRecord(t *testing.T) {
+	statePath := refreshStateEnv(t)
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: self, SHA256: strings.Repeat("0", 64)}
+	if werr := install.WriteState(statePath, st); werr != nil {
+		t.Fatalf("seed state: %v", werr)
+	}
+
+	out, err := runInstallRefreshState(t)
+	if err != nil {
+		t.Fatalf("install --refresh-state: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "install state refreshed") {
+		t.Errorf("expected the refreshed branch, got: %q", out)
+	}
+
+	got, rerr := install.ReadState(statePath)
+	if rerr != nil || got == nil {
+		t.Fatalf("ReadState: %v", rerr)
+	}
+	if got.CLI.Path != self {
+		t.Errorf("CLI.Path = %q, want %q", got.CLI.Path, self)
+	}
+	if got.CLI.SHA256 == strings.Repeat("0", 64) || got.CLI.SHA256 == "" {
+		t.Errorf("CLI.SHA256 was not refreshed: %q", got.CLI.SHA256)
+	}
+}
+
+// TestInstallRefreshState_SecondRunReportsAlreadyCurrent: the installer calls
+// this unconditionally, so a repeat run must be a quiet no-op, not an error.
+func TestInstallRefreshState_SecondRunReportsAlreadyCurrent(t *testing.T) {
+	statePath := refreshStateEnv(t)
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: self, SHA256: strings.Repeat("0", 64)}
+	if werr := install.WriteState(statePath, st); werr != nil {
+		t.Fatalf("seed state: %v", werr)
+	}
+
+	if out, rerr := runInstallRefreshState(t); rerr != nil {
+		t.Fatalf("first run: %v (out=%q)", rerr, out)
+	}
+	out, err := runInstallRefreshState(t)
+	if err != nil {
+		t.Fatalf("second run must not error: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "already current") {
+		t.Errorf("expected the already-current branch on the second run, got: %q", out)
+	}
+}
+
+// TestInstallRefreshState_DoesNotTouchTheCallersRepo is the safety property.
+// Run from inside a git repo — the shape of `curl … | bash` in a user's project
+// — the refresh must leave that repo completely alone: no /.grafel/ appended to
+// .gitignore (RunCopy step 5) and no git hooks written (step 7).
+func TestInstallRefreshState_DoesNotTouchTheCallersRepo(t *testing.T) {
+	statePath := refreshStateEnv(t)
+
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: self, SHA256: strings.Repeat("0", 64)}
+	if werr := install.WriteState(statePath, st); werr != nil {
+		t.Fatalf("seed state: %v", werr)
+	}
+
+	// A minimal but convincing git repo as the working directory.
+	repo := t.TempDir()
+	hooksDir := filepath.Join(repo, ".git", "hooks")
+	if mkErr := os.MkdirAll(hooksDir, 0o755); mkErr != nil {
+		t.Fatalf("mkdir .git/hooks: %v", mkErr)
+	}
+	gitignore := filepath.Join(repo, ".gitignore")
+	const originalIgnore = "node_modules/\n"
+	if werr := os.WriteFile(gitignore, []byte(originalIgnore), 0o644); werr != nil {
+		t.Fatalf("write .gitignore: %v", werr)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if cerr := os.Chdir(repo); cerr != nil {
+		t.Fatalf("chdir: %v", cerr)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	// Deliberately NOT fatal on error: the side-effect assertions below are the
+	// point of this test and must run either way. A mutant that removes the
+	// short-circuit drops into the real install transaction, which may fail for
+	// an unrelated environment reason (on macOS the temp HOME blows the 104-char
+	// unix socket limit at step 4) BEFORE reaching steps 5 and 7 — so aborting
+	// here would let the .gitignore/hooks checks be skipped exactly when they
+	// matter most.
+	if out, rerr := runInstallRefreshState(t); rerr != nil {
+		t.Errorf("install --refresh-state must succeed: %v (out=%q)", rerr, out)
+	}
+
+	after, rerr := os.ReadFile(gitignore)
+	if rerr != nil {
+		t.Fatalf("read .gitignore: %v", rerr)
+	}
+	if string(after) != originalIgnore {
+		t.Errorf("--refresh-state must not touch the caller's .gitignore; got:\n%s", after)
+	}
+
+	entries, rerr := os.ReadDir(hooksDir)
+	if rerr != nil {
+		t.Fatalf("read .git/hooks: %v", rerr)
+	}
+	if len(entries) != 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("--refresh-state must not install git hooks in the caller's repo; found: %v", names)
+	}
+}
+
+// TestInstallRefreshState_RejectsCombinedFlags: silently ignoring the rest is
+// its own trap — every other install flag asks for work --refresh-state does
+// not do, so a user combining them would get a state rewrite and believe they
+// got an install.
+func TestInstallRefreshState_RejectsCombinedFlags(t *testing.T) {
+	for _, arg := range []string{"--dev", "--force", "--tools=claude", "--no-hooks", "--copy=false"} {
+		t.Run(arg, func(t *testing.T) {
+			refreshStateEnv(t)
+			out, err := runInstallRefreshState(t, arg)
+			if err == nil {
+				t.Fatalf("--refresh-state %s must be rejected, got success: %q", arg, out)
+			}
+			if !strings.Contains(err.Error(), "--refresh-state") {
+				t.Errorf("error must explain the conflict, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestInstallRefreshState_PlainInstallFlagsStillWork: the conflict guard must
+// key on flags the user actually typed, not on defaults — `--copy` defaults to
+// true and must not be treated as a conflict.
+func TestInstallRefreshState_PlainInstallFlagsStillWork(t *testing.T) {
+	refreshStateEnv(t)
+	out, err := runInstallRefreshState(t)
+	if err != nil {
+		t.Fatalf("bare --refresh-state must not trip the conflict guard (--copy defaults to true): %v (out=%q)", err, out)
+	}
+}

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cajasmota/grafel/internal/install/skilllink"
 	"github.com/cajasmota/grafel/internal/registry"
 	"github.com/cajasmota/grafel/internal/statusfile"
+	"github.com/cajasmota/grafel/internal/version"
 )
 
 // DoctorSchemaVersion is the JSON schema version for DoctorReport.
@@ -338,6 +339,30 @@ func checkCLI(state *State) CheckResult {
 		cr.Drift = []string{fmt.Sprintf("sha256 mismatch: binary=%s install=%s (daemon still usable; re-run 'grafel install' to refresh)", actual[:16], state.CLI.SHA256[:16])}
 	}
 	return cr
+}
+
+// sameBinaryPath reports whether two binary paths denote the same file.
+//
+// The fast path is a plain string comparison, which is what matches on every
+// normal install. Only when that fails do we pay for symlink resolution — a
+// couple of lstat(2) calls, microseconds — because the two common ways to end
+// up with textually different paths for one binary are a symlinked bin dir
+// (/usr/local/bin -> /opt/homebrew/bin) and macOS's /tmp -> /private/tmp. If
+// either side cannot be resolved (the recorded binary was deleted, say) we fall
+// back to the textual answer rather than guessing.
+//
+// Deliberately NOT hashing both files: quick-doctor's budget is <50ms and it
+// runs before every command, so one SHA of one binary is the ceiling.
+func sameBinaryPath(a, b string) bool {
+	if a == b {
+		return true
+	}
+	ra, errA := filepath.EvalSymlinks(a)
+	rb, errB := filepath.EvalSymlinks(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return ra == rb
 }
 
 // isInGitWorktree reports whether the current process is running from inside
@@ -1110,6 +1135,18 @@ type QuickOptions struct {
 	// StatePath is the path of install.json.  Defaults to DefaultStatePath().
 	StatePath string
 
+	// Version is this binary's version string. Defaults to version.Version.
+	// Only used to suppress the running-vs-recorded path warning for dev
+	// builds — see the check-1 comment in RunQuickDoctor.
+	Version string
+
+	// SelfPath is the path of the binary this process is running from.
+	// Defaults to os.Executable(); an empty value that cannot be resolved
+	// simply disables the running-vs-recorded comparison. Overridable so
+	// tests can exercise both the "same binary, new bytes" and "different
+	// binary entirely" cases without re-execing.
+	SelfPath string
+
 	// DaemonPort is the HTTP port for the daemon's /healthz endpoint.
 	// Defaults to 47274.
 	DaemonPort int
@@ -1129,6 +1166,17 @@ func (o *QuickOptions) applyDefaults() error {
 			return err
 		}
 		o.StatePath = p
+	}
+	if o.SelfPath == "" {
+		// os.Executable() is a single syscall on every supported platform —
+		// no filesystem walk, no stat — so this stays inside the <50ms budget.
+		// A failure just leaves SelfPath empty and disables the comparison.
+		if self, err := os.Executable(); err == nil {
+			o.SelfPath = self
+		}
+	}
+	if o.Version == "" {
+		o.Version = version.Version
 	}
 	if o.DaemonPort == 0 {
 		o.DaemonPort = 47274
@@ -1166,11 +1214,46 @@ func RunQuickDoctor(opts QuickOptions) error {
 
 	var warnings []string
 
-	// Check 1: CLI SHA (skip if in a git worktree).
+	// Check 1: CLI identity (skip if in a git worktree).
+	//
+	// Two distinct conditions hide behind the old single SHA comparison, and
+	// they need different words because they need different mental models:
+	//
+	//  (a) same path, different bytes — the binary was replaced in place. This
+	//      is what the curl installer does on every upgrade, so it is by far
+	//      the common case and it is entirely benign; all that is stale is the
+	//      recorded hash.
+	//  (b) the process is running a DIFFERENT binary than install.json records.
+	//      Hashing the recorded path then says nothing at all about the process
+	//      you are in: a match is a false all-clear (you can be running a
+	//      second, older install picked up from PATH while the recorded one
+	//      sits untouched), and a mismatch gets misreported as "your binary was
+	//      updated" when the real story is two installs on the machine.
+	//
+	// Both are resolved by the same narrow command, which is what the message
+	// now says. The previous wording prescribed `grafel doctor` — which just
+	// reprints this line — leaving the user with a permanent warning and no way
+	// out short of guessing.
+	//
+	// Case (b) is reported for RELEASE builds only. isInGitWorktree() already
+	// exempts worktree development, but a contributor running a `go build`
+	// output from the MAIN checkout has .git as a directory and is not
+	// exempted — and for them the advice would be actively wrong: recording a
+	// scratch build as THE install would overwrite the record of their real
+	// one. A dev binary is by definition not the installed release, so the
+	// path difference carries no information about the install's health.
 	if state.CLI.Path != "" && state.CLI.SHA256 != "" && !isInGitWorktree() {
-		actual, shaErr := sha256File(state.CLI.Path)
-		if shaErr == nil && actual != state.CLI.SHA256 {
-			warnings = append(warnings, "binary updated since last install (daemon still usable)")
+		switch {
+		case !version.IsDev(opts.Version) && opts.SelfPath != "" && !sameBinaryPath(opts.SelfPath, state.CLI.Path):
+			warnings = append(warnings, fmt.Sprintf(
+				"running %s but install.json records %s — run 'grafel install --refresh-state'",
+				opts.SelfPath, state.CLI.Path))
+		default:
+			actual, shaErr := sha256File(state.CLI.Path)
+			if shaErr == nil && actual != state.CLI.SHA256 {
+				warnings = append(warnings,
+					"binary updated since last install (daemon still usable) — run 'grafel install --refresh-state'")
+			}
 		}
 	}
 
@@ -1178,18 +1261,24 @@ func RunQuickDoctor(opts QuickOptions) error {
 	url := fmt.Sprintf("http://127.0.0.1:%d/healthz", opts.DaemonPort)
 	client := &http.Client{Timeout: opts.DaemonTimeout}
 	resp, daemonErr := client.Get(url)
+	// The daemon branch is the one case where `grafel doctor` genuinely has
+	// more to say (it probes the RPC socket and the service unit), so it — and
+	// only it — keeps that pointer. Every warning now carries its own remedy
+	// instead of a single trailing "run 'grafel doctor'" that was a closed loop
+	// for the CLI checks above.
 	if daemonErr != nil {
-		warnings = append(warnings, fmt.Sprintf("daemon unreachable at :%d", opts.DaemonPort))
+		warnings = append(warnings, fmt.Sprintf(
+			"daemon unreachable at :%d — run 'grafel doctor' for details", opts.DaemonPort))
 	} else {
 		_ = resp.Body.Close()
 		if resp.StatusCode != http.StatusOK {
-			warnings = append(warnings, fmt.Sprintf("daemon /healthz returned %d", resp.StatusCode))
+			warnings = append(warnings, fmt.Sprintf(
+				"daemon /healthz returned %d — run 'grafel doctor' for details", resp.StatusCode))
 		}
 	}
 
 	if len(warnings) > 0 {
-		fmt.Fprintf(opts.Out, "grafel doctor: %s — run 'grafel doctor' for details\n",
-			strings.Join(warnings, "; "))
+		fmt.Fprintf(opts.Out, "grafel doctor: %s\n", strings.Join(warnings, "; "))
 	}
 
 	return nil

--- a/internal/install/doctor.go
+++ b/internal/install/doctor.go
@@ -23,6 +23,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -101,6 +102,12 @@ type DoctorOptions struct {
 	// ClaudeConfigDirs overrides .claude.json auto-detection (same flag as install).
 	ClaudeConfigDirs []string
 
+	// SelfPath / Version describe the binary this process is running as, and
+	// feed checkCLI's identity comparison. They default to os.Executable() and
+	// version.Version; see the matching fields on QuickOptions.
+	SelfPath string
+	Version  string
+
 	// DaemonPort is the daemon's dashboard HTTP port. Defaults to 47274.
 	//
 	// #6072: the daemon version check no longer uses it — it reads the RPC
@@ -146,6 +153,14 @@ func (o *DoctorOptions) applyDefaults() error {
 			return err
 		}
 		o.StatePath = p
+	}
+	if o.SelfPath == "" {
+		if self, err := os.Executable(); err == nil {
+			o.SelfPath = self
+		}
+	}
+	if o.Version == "" {
+		o.Version = version.Version
 	}
 	if o.DaemonPort == 0 {
 		o.DaemonPort = 47274
@@ -209,7 +224,7 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 	}
 
 	// ── Check 1: CLI binary SHA ─────────────────────────────────────────────
-	report.Checks = append(report.Checks, checkCLI(state))
+	report.Checks = append(report.Checks, checkCLI(state, opts.SelfPath, opts.Version))
 
 	// ── Check 2: Daemon version via the RPC socket (#6072) ──────────────────
 	report.Checks = append(report.Checks, checkDaemon(state, opts.ProbeDaemonVersion))
@@ -298,7 +313,20 @@ func RunDoctor(opts DoctorOptions) (*DoctorReport, error) {
 // checkCLI compares the running binary SHA against install.json.
 // Skips the check if running from a git worktree (which may have a different
 // binary path), and emits an INFO-level hint instead.
-func checkCLI(state *State) CheckResult {
+// checkCLI mirrors RunQuickDoctor's check 1 — deliberately, and it must keep
+// mirroring it. Before this was aligned, the two surfaces disagreed and the
+// MORE authoritative one gave the WORSE advice: quick-doctor had already
+// learned to distinguish "running a different binary" and to name a narrow
+// remedy, while `grafel doctor` still had no path check at all (so it handed
+// out the same false all-clear quick-doctor now catches) and prescribed
+// `re-run 'grafel install'` — a seven-step transaction that appends to the
+// .gitignore and installs four git hooks in whatever repo the user happens to
+// be standing in. See internal/install/refreshstate.go for that argument.
+//
+// selfPath is the binary this process is running as ("" disables the identity
+// comparison); ver is its version string (a dev build disables it too, for the
+// reason given in RunQuickDoctor).
+func checkCLI(state *State, selfPath, ver string) CheckResult {
 	cr := CheckResult{Surface: "cli", OK: true}
 
 	if state.CLI.Path == "" || state.CLI.SHA256 == "" {
@@ -319,6 +347,33 @@ func checkCLI(state *State) CheckResult {
 		return cr
 	}
 
+	identity := binarySame
+	if !version.IsDev(ver) {
+		identity = classifyBinaryIdentity(selfPath, state.CLI.Path)
+	}
+	switch identity {
+	case binaryDiffers:
+		// Two installs. Neither hashing nor re-recording helps — re-recording
+		// would just re-point install.json at whichever binary was invoked.
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf(
+			"running %s but install.json records %s — two grafel installs on this machine (daemon still usable); "+
+				"run 'which -a grafel' and remove the one you do not want", selfPath, state.CLI.Path)}
+		return cr
+	case binaryRecordedMissing:
+		cr.OK = false
+		cr.Severity = SeverityWarning
+		cr.Drift = []string{fmt.Sprintf(
+			"install.json records %s, which no longer exists; running %s (daemon still usable) — "+
+				"run 'grafel install --refresh-state' to record it", state.CLI.Path, selfPath)}
+		return cr
+	case binaryUnknown:
+		return cr
+	case binarySame:
+		// Fall through to the SHA comparison below.
+	}
+
 	// Compute current SHA.
 	actual, err := sha256File(state.CLI.Path)
 	if err != nil {
@@ -336,33 +391,73 @@ func checkCLI(state *State) CheckResult {
 		// Critical for unreadable/missing install.json and unhashable binaries.
 		cr.OK = false
 		cr.Severity = SeverityWarning
-		cr.Drift = []string{fmt.Sprintf("sha256 mismatch: binary=%s install=%s (daemon still usable; re-run 'grafel install' to refresh)", actual[:16], state.CLI.SHA256[:16])}
+		cr.Drift = []string{fmt.Sprintf("sha256 mismatch: binary=%s install=%s (daemon still usable; run 'grafel install --refresh-state' to refresh)", actual[:16], state.CLI.SHA256[:16])}
 	}
 	return cr
 }
 
-// sameBinaryPath reports whether two binary paths denote the same file.
+// binaryIdentity classifies the relationship between the binary this process
+// is running as and the binary install.json records. The three actionable
+// outcomes need three different messages because they need three different
+// remedies — see the check-1 comment in RunQuickDoctor.
+type binaryIdentity int
+
+const (
+	// binaryUnknown: we cannot tell. Always stay silent — a warning derived
+	// from a comparison we could not make is noise by construction.
+	binaryUnknown binaryIdentity = iota
+	// binarySame: this process IS the recorded install (possibly reached via
+	// a different path: a symlinked bin dir, a hard link, /tmp vs /private/tmp).
+	binarySame
+	// binaryDiffers: a genuinely different binary that also exists on disk —
+	// i.e. two grafel installs on this machine.
+	binaryDiffers
+	// binaryRecordedMissing: install.json points at a binary that is gone,
+	// and we are running a different one.
+	binaryRecordedMissing
+)
+
+// classifyBinaryIdentity compares the running binary against the recorded one.
 //
-// The fast path is a plain string comparison, which is what matches on every
-// normal install. Only when that fails do we pay for symlink resolution — a
-// couple of lstat(2) calls, microseconds — because the two common ways to end
-// up with textually different paths for one binary are a symlinked bin dir
-// (/usr/local/bin -> /opt/homebrew/bin) and macOS's /tmp -> /private/tmp. If
-// either side cannot be resolved (the recorded binary was deleted, say) we fall
-// back to the textual answer rather than guessing.
+// Identity is decided by os.SameFile (device+inode), not by path string or
+// EvalSymlinks. That is the same cost — two stat(2) calls, microseconds, well
+// inside quick-doctor's <50ms budget — and it is correct for every way one
+// binary ends up under two names: a symlinked bin dir (/usr/local/bin ->
+// /opt/homebrew/bin), a version-stamped prefix reached through a stable symlink
+// (Nix store paths, Linuxbrew's Cellar, asdf/mise shims), macOS's
+// /tmp -> /private/tmp, and hard links — which EvalSymlinks gets wrong.
 //
-// Deliberately NOT hashing both files: quick-doctor's budget is <50ms and it
-// runs before every command, so one SHA of one binary is the ceiling.
-func sameBinaryPath(a, b string) bool {
-	if a == b {
-		return true
+// The textual fast path is load-bearing, not an optimisation: when the recorded
+// path IS the path we are running, a stat failure must NOT be reported. That
+// happens transiently during an in-place upgrade (the rename window) and the
+// old code was correctly silent there; only the SHA check applies to that case.
+//
+// Deliberately NOT hashing both files: one SHA of one binary is the ceiling for
+// a check that runs before every command.
+func classifyBinaryIdentity(self, recorded string) binaryIdentity {
+	if self == "" || recorded == "" {
+		return binaryUnknown
 	}
-	ra, errA := filepath.EvalSymlinks(a)
-	rb, errB := filepath.EvalSymlinks(b)
-	if errA != nil || errB != nil {
-		return false
+	if self == recorded {
+		return binarySame
 	}
-	return ra == rb
+	ri, rerr := os.Stat(recorded)
+	if rerr != nil {
+		if errors.Is(rerr, fs.ErrNotExist) {
+			return binaryRecordedMissing
+		}
+		// Unreadable for some other reason (permissions, a dead mount): we
+		// learned nothing.
+		return binaryUnknown
+	}
+	si, serr := os.Stat(self)
+	if serr != nil {
+		return binaryUnknown
+	}
+	if os.SameFile(si, ri) {
+		return binarySame
+	}
+	return binaryDiffers
 }
 
 // isInGitWorktree reports whether the current process is running from inside
@@ -1216,44 +1311,62 @@ func RunQuickDoctor(opts QuickOptions) error {
 
 	// Check 1: CLI identity (skip if in a git worktree).
 	//
-	// Two distinct conditions hide behind the old single SHA comparison, and
-	// they need different words because they need different mental models:
+	// THREE distinct conditions hide behind the old single SHA comparison, and
+	// each needs its own words because each needs a DIFFERENT remedy. Giving
+	// them one shared remedy is how the original bug got its teeth.
 	//
-	//  (a) same path, different bytes — the binary was replaced in place. This
-	//      is what the curl installer does on every upgrade, so it is by far
-	//      the common case and it is entirely benign; all that is stale is the
-	//      recorded hash.
-	//  (b) the process is running a DIFFERENT binary than install.json records.
-	//      Hashing the recorded path then says nothing at all about the process
-	//      you are in: a match is a false all-clear (you can be running a
-	//      second, older install picked up from PATH while the recorded one
-	//      sits untouched), and a mismatch gets misreported as "your binary was
-	//      updated" when the real story is two installs on the machine.
+	//  (a) same binary, different bytes — replaced in place. This is what the
+	//      curl installer does on every upgrade: benign, only the recorded hash
+	//      is stale. Remedy: re-record it.
+	//  (b) a genuinely DIFFERENT binary that also exists — two grafel installs
+	//      on the machine. Hashing the recorded path says nothing about the
+	//      process you are in: a match is a false all-clear (you can be running
+	//      a second, older install found earlier on PATH while the recorded one
+	//      sits untouched). Remedy: find and remove the duplicate — NOT
+	//      re-recording, which merely re-points install.json at whichever
+	//      binary you happened to invoke. Prescribing the refresh here would
+	//      let a user standing in a stale /usr/local/bin/grafel record the OLD
+	//      binary as THE install while the skills/MCP manifest describes the
+	//      new one — manufacturing exactly the false all-clear this check
+	//      exists to catch.
+	//  (c) the recorded binary is GONE and we are running a different one — a
+	//      relocated install (new prefix, package manager migration). Nothing
+	//      is ambiguous and nothing can ping-pong: there is only one binary
+	//      left, so re-recording it is right.
 	//
-	// Both are resolved by the same narrow command, which is what the message
-	// now says. The previous wording prescribed `grafel doctor` — which just
-	// reprints this line — leaving the user with a permanent warning and no way
+	// The previous wording prescribed `grafel doctor` for all of it — which
+	// just reprints this line — leaving the user a permanent warning and no way
 	// out short of guessing.
 	//
-	// Case (b) is reported for RELEASE builds only. isInGitWorktree() already
-	// exempts worktree development, but a contributor running a `go build`
-	// output from the MAIN checkout has .git as a directory and is not
-	// exempted — and for them the advice would be actively wrong: recording a
-	// scratch build as THE install would overwrite the record of their real
-	// one. A dev binary is by definition not the installed release, so the
-	// path difference carries no information about the install's health.
+	// Cases (b) and (c) are reported for RELEASE builds only. isInGitWorktree()
+	// already exempts worktree development, but a contributor running a
+	// `go build` output from the MAIN checkout has .git as a directory and is
+	// not exempted — and for them the (c) advice would be actively wrong:
+	// recording a scratch build as THE install would overwrite the record of
+	// their real one. A dev binary is by definition not the installed release,
+	// so its path carries no information about the install's health.
 	if state.CLI.Path != "" && state.CLI.SHA256 != "" && !isInGitWorktree() {
-		switch {
-		case !version.IsDev(opts.Version) && opts.SelfPath != "" && !sameBinaryPath(opts.SelfPath, state.CLI.Path):
+		identity := binarySame
+		if !version.IsDev(opts.Version) {
+			identity = classifyBinaryIdentity(opts.SelfPath, state.CLI.Path)
+		}
+		switch identity {
+		case binaryDiffers:
 			warnings = append(warnings, fmt.Sprintf(
-				"running %s but install.json records %s — run 'grafel install --refresh-state'",
+				"running %s but install.json records %s — two grafel installs; 'which -a grafel' to find the extra one",
 				opts.SelfPath, state.CLI.Path))
-		default:
+		case binaryRecordedMissing:
+			warnings = append(warnings, fmt.Sprintf(
+				"install.json records %s, which no longer exists (daemon still usable) — run 'grafel install --refresh-state' to record %s",
+				state.CLI.Path, opts.SelfPath))
+		case binarySame:
 			actual, shaErr := sha256File(state.CLI.Path)
 			if shaErr == nil && actual != state.CLI.SHA256 {
 				warnings = append(warnings,
 					"binary updated since last install (daemon still usable) — run 'grafel install --refresh-state'")
 			}
+		case binaryUnknown:
+			// Nothing learned — say nothing.
 		}
 	}
 

--- a/internal/install/doctor_binident_test.go
+++ b/internal/install/doctor_binident_test.go
@@ -1,0 +1,176 @@
+// doctor_binident_test.go covers classifyBinaryIdentity and the QuickOptions /
+// DoctorOptions defaults that feed it.
+//
+// These are internal (package install) because the interesting cases —
+// "SelfPath could not be resolved", "the recorded binary was deleted mid-
+// upgrade", "one binary reached under two names" — are either unreachable
+// through RunQuickDoctor (applyDefaults always fills SelfPath) or would need a
+// re-exec to stage. Review of the first pass found four surviving mutants in
+// exactly this code for that reason; each case below kills one.
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeBin(t *testing.T, path, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// TestClassifyBinaryIdentity_IdenticalPath: the textual fast path.
+func TestClassifyBinaryIdentity_IdenticalPath(t *testing.T) {
+	p := writeBin(t, filepath.Join(t.TempDir(), "grafel"), "bin")
+	if got := classifyBinaryIdentity(p, p); got != binarySame {
+		t.Errorf("classifyBinaryIdentity(same path) = %v, want binarySame", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_IdenticalPathButDeleted is the load-bearing half
+// of the fast path, and the one a mutant that deletes `self == recorded` gets
+// wrong. During an in-place upgrade there is a window where the recorded path
+// does not exist; the old code was silent there (sha256File simply errored) and
+// it must stay silent, not start reporting a missing install. Only the SHA
+// check applies to "same path", and that check handles its own read error.
+func TestClassifyBinaryIdentity_IdenticalPathButDeleted(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "grafel") // never created
+	if got := classifyBinaryIdentity(p, p); got != binarySame {
+		t.Errorf("classifyBinaryIdentity(same path, missing file) = %v, want binarySame "+
+			"(the rename window of an in-place upgrade must not be reported as a relocated install)", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_SymlinkedBinDir: one binary reached under two
+// names. This is the shape of a symlinked bin dir (/usr/local/bin ->
+// /opt/homebrew/bin), a version-stamped prefix behind a stable symlink (Nix
+// store, Linuxbrew Cellar, asdf/mise shims) and macOS's /tmp -> /private/tmp.
+// Must be binarySame, or every such user gets a permanent false warning.
+func TestClassifyBinaryIdentity_SymlinkedBinDir(t *testing.T) {
+	tmp := t.TempDir()
+	real := writeBin(t, filepath.Join(tmp, "Cellar", "grafel", "0.2.0", "bin", "grafel"), "bin")
+	link := filepath.Join(tmp, "grafel-link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if got := classifyBinaryIdentity(link, real); got != binarySame {
+		t.Errorf("classifyBinaryIdentity(symlink, target) = %v, want binarySame", got)
+	}
+	if got := classifyBinaryIdentity(real, link); got != binarySame {
+		t.Errorf("classifyBinaryIdentity(target, symlink) = %v, want binarySame", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_HardLink: two names, one inode, no symlink
+// involved. EvalSymlinks-based comparison gets this wrong; os.SameFile does not.
+func TestClassifyBinaryIdentity_HardLink(t *testing.T) {
+	tmp := t.TempDir()
+	a := writeBin(t, filepath.Join(tmp, "grafel"), "bin")
+	b := filepath.Join(tmp, "grafel-hardlink")
+	if err := os.Link(a, b); err != nil {
+		t.Skipf("hard links unavailable: %v", err)
+	}
+	if got := classifyBinaryIdentity(b, a); got != binarySame {
+		t.Errorf("classifyBinaryIdentity(hard link, original) = %v, want binarySame", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_TwoRealInstalls: the case that must NOT be offered
+// --refresh-state.
+func TestClassifyBinaryIdentity_TwoRealInstalls(t *testing.T) {
+	tmp := t.TempDir()
+	a := writeBin(t, filepath.Join(tmp, "a", "grafel"), "install A")
+	b := writeBin(t, filepath.Join(tmp, "b", "grafel"), "install B")
+	if got := classifyBinaryIdentity(a, b); got != binaryDiffers {
+		t.Errorf("classifyBinaryIdentity(two distinct files) = %v, want binaryDiffers", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_RecordedGone: a relocated install. Distinct from
+// binaryDiffers because here re-recording IS the correct remedy — there is only
+// one binary left, so nothing can ping-pong.
+func TestClassifyBinaryIdentity_RecordedGone(t *testing.T) {
+	tmp := t.TempDir()
+	self := writeBin(t, filepath.Join(tmp, "new", "grafel"), "relocated")
+	gone := filepath.Join(tmp, "old", "grafel")
+	if got := classifyBinaryIdentity(self, gone); got != binaryRecordedMissing {
+		t.Errorf("classifyBinaryIdentity(self, missing recorded) = %v, want binaryRecordedMissing", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_UnresolvableInputsAreSilent: with no SelfPath
+// there is no comparison to make, and a warning derived from a comparison we
+// could not perform is noise by construction. Kills the mutant that drops the
+// empty-SelfPath guard.
+func TestClassifyBinaryIdentity_UnresolvableInputsAreSilent(t *testing.T) {
+	tmp := t.TempDir()
+	recorded := writeBin(t, filepath.Join(tmp, "grafel"), "bin")
+
+	if got := classifyBinaryIdentity("", recorded); got != binaryUnknown {
+		t.Errorf("classifyBinaryIdentity(\"\", recorded) = %v, want binaryUnknown", got)
+	}
+	if got := classifyBinaryIdentity(recorded, ""); got != binaryUnknown {
+		t.Errorf("classifyBinaryIdentity(self, \"\") = %v, want binaryUnknown", got)
+	}
+}
+
+// TestClassifyBinaryIdentity_UnstatableSelfIsSilent: the recorded binary exists
+// but we cannot stat our own path. We cannot tell whether they are the same
+// file, so we must not guess "different" — that would print the two-installs
+// warning off a failed comparison.
+func TestClassifyBinaryIdentity_UnstatableSelfIsSilent(t *testing.T) {
+	tmp := t.TempDir()
+	recorded := writeBin(t, filepath.Join(tmp, "grafel"), "bin")
+	missingSelf := filepath.Join(tmp, "vanished", "grafel")
+
+	if got := classifyBinaryIdentity(missingSelf, recorded); got != binaryUnknown {
+		t.Errorf("classifyBinaryIdentity(unstatable self, recorded) = %v, want binaryUnknown", got)
+	}
+}
+
+// TestQuickOptions_DefaultsResolveSelfPath: production wiring. cmd/grafel and
+// internal/cli both construct QuickOptions without a SelfPath, so the entire
+// identity check depends on this default being populated — nothing else covers
+// it, and a mutant removing it survived the first pass.
+func TestQuickOptions_DefaultsResolveSelfPath(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	var o QuickOptions
+	if err := o.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	if o.SelfPath != self {
+		t.Errorf("QuickOptions.SelfPath default = %q, want %q", o.SelfPath, self)
+	}
+	if o.Version == "" {
+		t.Error("QuickOptions.Version default must be populated")
+	}
+}
+
+// TestDoctorOptions_DefaultsResolveSelfPath: same wiring for full doctor, which
+// gained the identity check in this change.
+func TestDoctorOptions_DefaultsResolveSelfPath(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skipf("os.Executable unavailable: %v", err)
+	}
+	var o DoctorOptions
+	if err := o.applyDefaults(); err != nil {
+		t.Fatalf("applyDefaults: %v", err)
+	}
+	if o.SelfPath != self {
+		t.Errorf("DoctorOptions.SelfPath default = %q, want %q", o.SelfPath, self)
+	}
+	if o.Version == "" {
+		t.Error("DoctorOptions.Version default must be populated")
+	}
+}

--- a/internal/install/doctor_cli_remedy_test.go
+++ b/internal/install/doctor_cli_remedy_test.go
@@ -1,0 +1,155 @@
+// doctor_cli_remedy_test.go pins the FULL `grafel doctor` cli check against the
+// same contract quick-doctor already satisfies.
+//
+// Review finding: the first pass fixed quick-doctor and left full doctor
+// pointing at the dangerous command. `checkCLI` still emitted
+// "re-run 'grafel install' to refresh" — a seven-step transaction that appends
+// to the .gitignore and installs four git hooks in whatever repository the user
+// is standing in (see internal/install/refreshstate.go) — and it had no
+// identity check at all, so it kept handing out the false all-clear that
+// quick-doctor had just learned to catch. The two surfaces disagreed and the
+// MORE authoritative one gave the WORSE advice.
+package install_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// runDoctorAs runs full doctor with an explicit running-binary identity.
+func runDoctorAs(t *testing.T, env *doctorTestEnv, selfPath, ver string) *install.CheckResult {
+	t.Helper()
+	report, err := install.RunDoctor(install.DoctorOptions{
+		StatePath:          env.statePath,
+		ClaudeConfigDirs:   []string{env.claudeJSON},
+		DaemonTimeout:      200 * time.Millisecond,
+		ProbeDaemonVersion: daemonDownProbe,
+		SkillsDir:          env.skillsDir,
+		SelfPath:           selfPath,
+		Version:            ver,
+	})
+	if err != nil {
+		t.Fatalf("RunDoctor error: %v", err)
+	}
+	cli := findCheck(report, "cli")
+	if cli == nil {
+		t.Fatal("report has no cli check")
+	}
+	return cli
+}
+
+// TestDoctorCLI_SHADriftNamesTheNarrowCommand: the in-place upgrade case must
+// prescribe the narrow refresh, not the full transaction.
+func TestDoctorCLI_SHADriftNamesTheNarrowCommand(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	if err := os.WriteFile(env.fakeBin, []byte("#!/bin/sh\necho upgraded"), 0o755); err != nil {
+		t.Fatalf("upgrade binary: %v", err)
+	}
+
+	cli := runDoctorAs(t, env, env.fakeBin, "0.2.0")
+	drift := strings.Join(cli.Drift, " ")
+
+	if !strings.Contains(drift, "grafel install --refresh-state") {
+		t.Errorf("cli drift must prescribe the narrow refresh, got: %q", drift)
+	}
+	if strings.Contains(drift, "re-run 'grafel install'") {
+		t.Errorf("cli drift must not prescribe the full install transaction "+
+			"(it mutates .gitignore and installs git hooks in the caller's cwd), got: %q", drift)
+	}
+	if cli.Severity != install.SeverityWarning {
+		t.Errorf("#4463: SHA drift stays a Warning, got %v", cli.Severity)
+	}
+}
+
+// TestDoctorCLI_TwoInstallsAreReported is the false all-clear full doctor was
+// still giving: the recorded binary hashes perfectly while the process is a
+// DIFFERENT install found earlier on PATH. Before this, doctor said "cli OK".
+func TestDoctorCLI_TwoInstallsAreReported(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	other := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(other, []byte("#!/bin/sh\necho second install"), 0o755); err != nil {
+		t.Fatalf("write second install: %v", err)
+	}
+
+	cli := runDoctorAs(t, env, other, "0.2.0")
+	drift := strings.Join(cli.Drift, " ")
+
+	if cli.OK {
+		t.Errorf("running a different binary than install.json records must not be reported OK; drift=%q", drift)
+	}
+	if !strings.Contains(drift, "which -a grafel") {
+		t.Errorf("two-installs drift must tell the user how to find the duplicate, got: %q", drift)
+	}
+	if strings.Contains(drift, "refresh-state") {
+		t.Errorf("two coexisting installs must NOT be prescribed --refresh-state "+
+			"(it just re-points install.json at whichever binary was invoked), got: %q", drift)
+	}
+	if !strings.Contains(drift, other) || !strings.Contains(drift, env.fakeBin) {
+		t.Errorf("two-installs drift must name both paths, got: %q", drift)
+	}
+}
+
+// TestDoctorCLI_RelocatedInstallGetsTheRefresh: recorded binary gone, one
+// binary left — re-recording is right and cannot ping-pong.
+func TestDoctorCLI_RelocatedInstallGetsTheRefresh(t *testing.T) {
+	env := newDoctorTestEnv(t)
+	if err := os.Remove(env.fakeBin); err != nil {
+		t.Fatalf("remove recorded binary: %v", err)
+	}
+
+	moved := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(moved, []byte("#!/bin/sh\necho relocated"), 0o755); err != nil {
+		t.Fatalf("write moved binary: %v", err)
+	}
+
+	cli := runDoctorAs(t, env, moved, "0.2.0")
+	drift := strings.Join(cli.Drift, " ")
+
+	if !strings.Contains(drift, "no longer exists") {
+		t.Errorf("relocated-install drift must say the recorded binary is gone, got: %q", drift)
+	}
+	if !strings.Contains(drift, "grafel install --refresh-state") {
+		t.Errorf("relocated install must be offered the refresh, got: %q", drift)
+	}
+	if cli.Severity == install.SeverityCritical {
+		t.Errorf("a relocated install is advisory, not corruption; got Critical: %q", drift)
+	}
+}
+
+// TestDoctorCLI_SymlinkedBinDirIsOK: one binary, two names — still OK.
+func TestDoctorCLI_SymlinkedBinDirIsOK(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	link := filepath.Join(t.TempDir(), "grafel")
+	if err := os.Symlink(env.fakeBin, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	cli := runDoctorAs(t, env, link, "0.2.0")
+	if !cli.OK {
+		t.Errorf("a symlink to the recorded binary is the same install; drift=%q", strings.Join(cli.Drift, " "))
+	}
+}
+
+// TestDoctorCLI_DevBuildSkipsTheIdentityCheck: a contributor's scratch build
+// must not be told to record itself as THE install, on either surface.
+func TestDoctorCLI_DevBuildSkipsTheIdentityCheck(t *testing.T) {
+	env := newDoctorTestEnv(t)
+
+	scratch := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(scratch, []byte("#!/bin/sh\necho scratch"), 0o755); err != nil {
+		t.Fatalf("write scratch: %v", err)
+	}
+
+	cli := runDoctorAs(t, env, scratch, "0.0.0-dev")
+	drift := strings.Join(cli.Drift, " ")
+	if strings.Contains(drift, "which -a grafel") || strings.Contains(drift, "refresh-state") {
+		t.Errorf("a dev build's path says nothing about the install, got: %q", drift)
+	}
+}

--- a/internal/install/doctor_quick_remedy_test.go
+++ b/internal/install/doctor_quick_remedy_test.go
@@ -127,13 +127,19 @@ func TestQuickDoctor_SilentWhenBinaryMatches(t *testing.T) {
 	}
 }
 
-// TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase: install.json records
-// /a/grafel, but the process actually running is /b/grafel. Hashing /a/grafel
-// says nothing about this process — a match there is a FALSE all-clear (you can
-// be running a stale second install with a perfectly intact recorded SHA), and
-// a mismatch is misdiagnosed as "your binary was updated". Report the real
-// condition instead.
-func TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase(t *testing.T) {
+// TestQuickDoctor_TwoInstallsMustNotBeOfferedTheRefresh is the review finding
+// this test exists for. install.json records /a/grafel and both /a/grafel and
+// /b/grafel exist — two installs on the machine.
+//
+// Prescribing `--refresh-state` here is worse than saying nothing. It merely
+// re-points install.json at whichever binary was invoked, so the advice
+// ping-pongs; and a user who curl-upgraded to ~/.grafel/bin/grafel but whose
+// PATH still finds a stale /usr/local/bin/grafel would follow it FROM THE STALE
+// BINARY, recording the old one as THE install while the skills/MCP manifest
+// describes the new one. `grafel doctor` would then call the stale binary
+// healthy — manufacturing exactly the false all-clear this check exists to
+// catch. Name the duplicate instead.
+func TestQuickDoctor_TwoInstallsMustNotBeOfferedTheRefresh(t *testing.T) {
 	statePath, recorded := quickEnv(t)
 
 	other := filepath.Join(t.TempDir(), "grafel")
@@ -143,17 +149,75 @@ func TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase(t *testing.T) {
 
 	out := runQuick(t, statePath, other)
 
-	if !strings.Contains(out, "grafel install --refresh-state") {
-		t.Errorf("path-mismatch warning must name the command that resolves it, got: %q", out)
+	if strings.Contains(out, "refresh-state") {
+		t.Errorf("two coexisting installs must NOT be prescribed --refresh-state "+
+			"(it just re-points install.json at whichever binary was invoked), got: %q", out)
+	}
+	if !strings.Contains(out, "which -a grafel") {
+		t.Errorf("two-installs warning must tell the user how to find the duplicate, got: %q", out)
 	}
 	if strings.Contains(out, "binary updated since last install") {
-		t.Errorf("a path mismatch must not be misreported as an in-place binary update, got: %q", out)
+		t.Errorf("a second install must not be misreported as an in-place binary update, got: %q", out)
 	}
 	if !strings.Contains(out, other) || !strings.Contains(out, recorded) {
-		t.Errorf("path-mismatch warning must name both paths (running=%s recorded=%s), got: %q", other, recorded, out)
+		t.Errorf("two-installs warning must name both paths (running=%s recorded=%s), got: %q", other, recorded, out)
 	}
 	if n := countNonEmptyLines(out); n != 1 {
 		t.Errorf("quick-doctor printed %d lines, want 1: %q", n, out)
+	}
+}
+
+// TestQuickDoctor_RelocatedInstallSaysTheRecordedBinaryIsGone: the recorded
+// path no longer exists and we are running a different one — an install that
+// moved prefix. Here re-recording IS correct and cannot ping-pong (only one
+// binary remains), but the message has to state the useful fact: the recorded
+// binary is gone. The old code was silent in this state (sha256File errored),
+// so the user got no signal at all.
+func TestQuickDoctor_RelocatedInstallSaysTheRecordedBinaryIsGone(t *testing.T) {
+	statePath, recorded := quickEnv(t)
+	if err := os.Remove(recorded); err != nil {
+		t.Fatalf("remove recorded binary: %v", err)
+	}
+
+	moved := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(moved, []byte("#!/bin/sh\necho relocated\n"), 0o755); err != nil {
+		t.Fatalf("write moved bin: %v", err)
+	}
+
+	out := runQuick(t, statePath, moved)
+
+	if !strings.Contains(out, "no longer exists") {
+		t.Errorf("a relocated install must say the RECORDED binary is gone (that is the useful fact), got: %q", out)
+	}
+	if !strings.Contains(out, "grafel install --refresh-state") {
+		t.Errorf("a relocated install has one binary left, so it must be offered the refresh, got: %q", out)
+	}
+	if strings.Contains(out, "which -a grafel") {
+		t.Errorf("a relocated install is not a duplicate-install situation, got: %q", out)
+	}
+	if !strings.Contains(out, "still usable") {
+		t.Errorf("relocated-install wording must not read as corruption, got: %q", out)
+	}
+	if n := countNonEmptyLines(out); n != 1 {
+		t.Errorf("quick-doctor printed %d lines, want 1: %q", n, out)
+	}
+}
+
+// TestQuickDoctor_SymlinkedBinDirStaysSilent: reaching one binary under two
+// names (a symlinked bin dir, a version-stamped prefix behind a stable
+// symlink — Nix store, Linuxbrew Cellar, asdf/mise shims) is not a second
+// install and must not be reported as one.
+func TestQuickDoctor_SymlinkedBinDirStaysSilent(t *testing.T) {
+	statePath, recorded := quickEnv(t)
+
+	link := filepath.Join(t.TempDir(), "grafel")
+	if err := os.Symlink(recorded, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	out := runQuick(t, statePath, link)
+	if strings.Contains(out, "two grafel installs") || strings.Contains(out, "no longer exists") {
+		t.Errorf("a symlink to the recorded binary is the same install, got: %q", out)
 	}
 }
 
@@ -162,9 +226,9 @@ func TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase(t *testing.T) {
 // isInGitWorktree() does not exempt them) must not be told to record that
 // scratch build as their install — doing so would overwrite the record of
 // their real one. Release builds still get the warning; see
-// TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase.
+// TestQuickDoctor_TwoInstallsMustNotBeOfferedTheRefresh.
 func TestQuickDoctor_DevBuildDoesNotGetThePathWarning(t *testing.T) {
-	statePath, _ := quickEnv(t)
+	statePath, recorded := quickEnv(t)
 
 	scratch := filepath.Join(t.TempDir(), "grafel")
 	if err := os.WriteFile(scratch, []byte("#!/bin/sh\necho scratch build\n"), 0o755); err != nil {
@@ -174,6 +238,19 @@ func TestQuickDoctor_DevBuildDoesNotGetThePathWarning(t *testing.T) {
 	out := runQuickAs(t, statePath, scratch, "0.0.0-dev")
 	if strings.Contains(out, "refresh-state") {
 		t.Errorf("a dev build must not be told to re-record itself as the install, got: %q", out)
+	}
+	if strings.Contains(out, "two grafel installs") {
+		t.Errorf("a dev build's path says nothing about the install; no duplicate-install claim, got: %q", out)
+	}
+
+	// Same for the relocated shape: a dev build must not be told to record
+	// itself just because the recorded binary is gone.
+	if err := os.Remove(recorded); err != nil {
+		t.Fatalf("remove recorded binary: %v", err)
+	}
+	out = runQuickAs(t, statePath, scratch, "0.0.0-dev")
+	if strings.Contains(out, "refresh-state") || strings.Contains(out, "no longer exists") {
+		t.Errorf("a dev build must stay silent on the relocated-install case too, got: %q", out)
 	}
 }
 

--- a/internal/install/doctor_quick_remedy_test.go
+++ b/internal/install/doctor_quick_remedy_test.go
@@ -1,0 +1,193 @@
+// doctor_quick_remedy_test.go pins the second half of the curl-upgrade defect:
+// the one-line quick-doctor warning must NAME THE COMMAND THAT FIXES IT.
+//
+// As shipped, a user who upgraded via the curl installer saw, on EVERY grafel
+// command:
+//
+//	grafel doctor: binary updated since last install (daemon still usable);
+//	daemon unreachable at :47274 — run 'grafel doctor' for details
+//
+// The only prescription is `grafel doctor`, which re-prints the same line — the
+// message is a closed loop. It also cannot distinguish "the binary at the
+// recorded path was replaced" (the curl-upgrade case, fixed by re-recording it)
+// from "you are running a DIFFERENT binary than the one install.json records"
+// (two installs on PATH), which needs a different mental model entirely.
+package install_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// hashFile returns the hex SHA-256 of path's contents (the same value
+// install.RefreshState / step 1 of RunCopy record in install.json).
+func hashFile(t *testing.T, path string) string {
+	t.Helper()
+	sum, err := install.SHA256FilePublic(path)
+	if err != nil {
+		t.Fatalf("hash %s: %v", path, err)
+	}
+	return sum
+}
+
+// quickEnv builds a temp HOME with an install.json recording binPath at the
+// SHA of its current contents.
+func quickEnv(t *testing.T) (statePath, binPath string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	statePath = filepath.Join(tmp, ".grafel", "install.json")
+	binPath = filepath.Join(tmp, "bin", "grafel")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0o755); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\necho original\n"), 0o755); err != nil {
+		t.Fatalf("write bin: %v", err)
+	}
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: binPath, SHA256: hashFile(t, binPath)}
+	if err := install.WriteState(statePath, st); err != nil {
+		t.Fatalf("write state: %v", err)
+	}
+	return statePath, binPath
+}
+
+// runQuick runs quick-doctor against a dead daemon port as a RELEASE build and
+// returns the output. (Under `go test` version.Version is the dev sentinel;
+// these cases are about what a user who installed a release sees.)
+func runQuick(t *testing.T, statePath, selfPath string) string {
+	t.Helper()
+	return runQuickAs(t, statePath, selfPath, "0.2.0")
+}
+
+func runQuickAs(t *testing.T, statePath, selfPath, ver string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	err := install.RunQuickDoctor(install.QuickOptions{
+		StatePath:     statePath,
+		SelfPath:      selfPath,
+		Version:       ver,
+		DaemonPort:    1,
+		DaemonTimeout: 100 * time.Millisecond,
+		Out:           &buf,
+	})
+	if err != nil {
+		t.Fatalf("RunQuickDoctor must never return an error: %v", err)
+	}
+	return buf.String()
+}
+
+// TestQuickDoctor_SHADriftNamesTheFixCommand: when the binary at the RECORDED
+// path was replaced in place (exactly what `install -m 0755` in install.sh
+// does), the warning must tell the user the one command that clears it.
+func TestQuickDoctor_SHADriftNamesTheFixCommand(t *testing.T) {
+	statePath, binPath := quickEnv(t)
+
+	// Simulate the curl upgrade: same path, new bytes.
+	if err := os.WriteFile(binPath, []byte("#!/bin/sh\necho upgraded\n"), 0o755); err != nil {
+		t.Fatalf("upgrade bin: %v", err)
+	}
+
+	out := runQuick(t, statePath, binPath)
+
+	if !strings.Contains(out, "grafel install --refresh-state") {
+		t.Errorf("SHA-drift warning must name the command that resolves it, got: %q", out)
+	}
+	// #4463 regression guard: keep the non-alarming framing.
+	if !strings.Contains(out, "still usable") {
+		t.Errorf("SHA-drift warning must still reassure the daemon is usable, got: %q", out)
+	}
+	if strings.Contains(out, "reinstall recommended") {
+		t.Errorf("SHA-drift wording must not read as corruption, got: %q", out)
+	}
+	// Still exactly one line, still short enough to be a status prefix.
+	if n := countNonEmptyLines(out); n != 1 {
+		t.Errorf("quick-doctor printed %d lines, want 1: %q", n, out)
+	}
+	if len(out) > 220 {
+		t.Errorf("quick-doctor output too long (%d bytes): %q", len(out), out)
+	}
+}
+
+// TestQuickDoctor_SilentWhenBinaryMatches: the whole point of the installer
+// half of this fix. Once install.json records the on-disk binary, quick-doctor
+// must say nothing about the CLI at all.
+func TestQuickDoctor_SilentWhenBinaryMatches(t *testing.T) {
+	statePath, binPath := quickEnv(t)
+	out := runQuick(t, statePath, binPath)
+
+	if strings.Contains(out, "binary") || strings.Contains(out, "refresh-state") {
+		t.Errorf("quick-doctor must not warn about the CLI when the SHA matches, got: %q", out)
+	}
+}
+
+// TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase: install.json records
+// /a/grafel, but the process actually running is /b/grafel. Hashing /a/grafel
+// says nothing about this process — a match there is a FALSE all-clear (you can
+// be running a stale second install with a perfectly intact recorded SHA), and
+// a mismatch is misdiagnosed as "your binary was updated". Report the real
+// condition instead.
+func TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase(t *testing.T) {
+	statePath, recorded := quickEnv(t)
+
+	other := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(other, []byte("#!/bin/sh\necho other install\n"), 0o755); err != nil {
+		t.Fatalf("write other bin: %v", err)
+	}
+
+	out := runQuick(t, statePath, other)
+
+	if !strings.Contains(out, "grafel install --refresh-state") {
+		t.Errorf("path-mismatch warning must name the command that resolves it, got: %q", out)
+	}
+	if strings.Contains(out, "binary updated since last install") {
+		t.Errorf("a path mismatch must not be misreported as an in-place binary update, got: %q", out)
+	}
+	if !strings.Contains(out, other) || !strings.Contains(out, recorded) {
+		t.Errorf("path-mismatch warning must name both paths (running=%s recorded=%s), got: %q", other, recorded, out)
+	}
+	if n := countNonEmptyLines(out); n != 1 {
+		t.Errorf("quick-doctor printed %d lines, want 1: %q", n, out)
+	}
+}
+
+// TestQuickDoctor_DevBuildDoesNotGetThePathWarning: a contributor running a
+// locally built binary from the MAIN checkout (where .git is a directory, so
+// isInGitWorktree() does not exempt them) must not be told to record that
+// scratch build as their install — doing so would overwrite the record of
+// their real one. Release builds still get the warning; see
+// TestQuickDoctor_DifferentBinaryOnPathIsItsOwnCase.
+func TestQuickDoctor_DevBuildDoesNotGetThePathWarning(t *testing.T) {
+	statePath, _ := quickEnv(t)
+
+	scratch := filepath.Join(t.TempDir(), "grafel")
+	if err := os.WriteFile(scratch, []byte("#!/bin/sh\necho scratch build\n"), 0o755); err != nil {
+		t.Fatalf("write scratch bin: %v", err)
+	}
+
+	out := runQuickAs(t, statePath, scratch, "0.0.0-dev")
+	if strings.Contains(out, "refresh-state") {
+		t.Errorf("a dev build must not be told to re-record itself as the install, got: %q", out)
+	}
+}
+
+// TestQuickDoctor_DaemonWarningKeepsItsOwnRemedy: the daemon-unreachable branch
+// is the one case where `grafel doctor` genuinely has more to say, so it — and
+// only it — keeps that pointer.
+func TestQuickDoctor_DaemonWarningKeepsItsOwnRemedy(t *testing.T) {
+	statePath, binPath := quickEnv(t)
+	out := runQuick(t, statePath, binPath)
+
+	if !strings.Contains(out, "daemon unreachable") {
+		t.Fatalf("expected a daemon-unreachable warning against port 1, got: %q", out)
+	}
+	if !strings.Contains(out, "grafel doctor") {
+		t.Errorf("daemon warning should still point at 'grafel doctor', got: %q", out)
+	}
+}

--- a/internal/install/doctor_test.go
+++ b/internal/install/doctor_test.go
@@ -569,7 +569,13 @@ func TestDoctorQuickMode_Tampered(t *testing.T) {
 
 	var buf bytes.Buffer
 	opts := install.QuickOptions{
-		StatePath:     env.statePath,
+		StatePath: env.statePath,
+		// This test exercises the "same binary, new bytes" case (an in-place
+		// upgrade). Pin SelfPath to the recorded binary; left unset it would
+		// default to os.Executable() — the go test binary in a temp dir — and
+		// quick-doctor would (correctly) report the different-binary case
+		// instead. See doctor_quick_remedy_test.go for that case.
+		SelfPath:      env.fakeBin,
 		DaemonPort:    1,
 		DaemonTimeout: 100 * time.Millisecond,
 		Out:           &buf,

--- a/internal/install/doctor_test.go
+++ b/internal/install/doctor_test.go
@@ -571,11 +571,13 @@ func TestDoctorQuickMode_Tampered(t *testing.T) {
 	opts := install.QuickOptions{
 		StatePath: env.statePath,
 		// This test exercises the "same binary, new bytes" case (an in-place
-		// upgrade). Pin SelfPath to the recorded binary; left unset it would
-		// default to os.Executable() — the go test binary in a temp dir — and
-		// quick-doctor would (correctly) report the different-binary case
-		// instead. See doctor_quick_remedy_test.go for that case.
+		// upgrade), as a RELEASE build. Both pins are load-bearing: without
+		// Version the dev-build guard would skip the identity comparison
+		// entirely (making SelfPath dead), and without SelfPath the comparison
+		// would run against os.Executable() — the go test binary — and report
+		// the two-installs case instead. See doctor_quick_remedy_test.go.
 		SelfPath:      env.fakeBin,
+		Version:       "0.2.0",
 		DaemonPort:    1,
 		DaemonTimeout: 100 * time.Millisecond,
 		Out:           &buf,

--- a/internal/install/installsh_record_state_test.go
+++ b/internal/install/installsh_record_state_test.go
@@ -1,0 +1,158 @@
+// installsh_record_state_test.go pins the installer half of the curl-upgrade
+// defect.
+//
+// install.sh places the new binary with `install -m 0755 …` (falling back to
+// cp+chmod) and then, two lines later, runs `"$BIN_DIR/grafel" doctor`. It
+// never runs anything that writes ~/.grafel/install.json — so the CLI SHA
+// recorded there stays the PREVIOUS binary's, RunQuickDoctor's check-1 fires,
+// and the installer prints the very warning it just caused. It then tells the
+// user "grafel updated and daemon restarted" on the happy path, so the
+// outstanding step is never mentioned.
+//
+// The fix must (a) record the just-placed binary BEFORE the doctor call, and
+// (b) do it WITHOUT running the full `grafel install` transaction — steps 5 and
+// 7 of RunCopy append to .gitignore and install four git hooks in
+// opts.WorkingDir, i.e. in whatever repository the user's shell happened to be
+// sitting in when they piped the installer to bash. A curl installer must not
+// mutate an unrelated repo.
+//
+// Like installsh_restart_stopped_test.go, this test SOURCES install.sh as a
+// library (GRAFEL_INSTALL_SH_LIB=1) and calls the real function with a fake
+// binary on a temp BIN_DIR, so it verifies runtime behaviour and not just the
+// presence of a substring.
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeGrafelArgLogScript is a bash stand-in for the just-installed grafel
+// binary that appends every invocation's args to $GRAFEL_ARG_LOG and exits 0.
+const fakeGrafelArgLogScript = `#!/usr/bin/env bash
+echo "$@" >> "$GRAFEL_ARG_LOG"
+exit 0
+`
+
+// fakeGrafelArgLogFailScript is the same recorder but always exits 1, so we can
+// prove the installer's best-effort contract (a failing state refresh must not
+// abort the install).
+const fakeGrafelArgLogFailScript = `#!/usr/bin/env bash
+echo "$@" >> "$GRAFEL_ARG_LOG"
+exit 1
+`
+
+// runRecordInstallState sources install.sh and invokes record_install_state
+// with a fake grafel binary in a temp BIN_DIR. Returns the argument log and the
+// combined output.
+func runRecordInstallState(t *testing.T, binScript string) (argLog string, combined string, err error) {
+	t.Helper()
+	bash, lookErr := exec.LookPath("bash")
+	if lookErr != nil {
+		t.Skip("bash not available; skipping install.sh runtime test")
+	}
+
+	fakeHome := t.TempDir()
+	// install.sh hard-sets PREFIX="${GRAFEL_PREFIX:-$HOME/.grafel}" and
+	// BIN_DIR="$PREFIX/bin" at sourcing time, so redirect via GRAFEL_PREFIX.
+	fakePrefix := t.TempDir()
+	fakeBinDir := filepath.Join(fakePrefix, "bin")
+	if mkErr := os.MkdirAll(fakeBinDir, 0o755); mkErr != nil {
+		t.Fatalf("mkdir fake bin dir: %v", mkErr)
+	}
+	writeExecutable(t, fakeBinDir, "grafel", binScript)
+
+	logPath := filepath.Join(t.TempDir(), "grafel-args.log")
+
+	script := `set -eu; GRAFEL_INSTALL_SH_LIB=1 . "$1"; record_install_state`
+	cmd := exec.Command(bash, "-c", script, "bash", installShPath(t))
+	cmd.Env = append(os.Environ(),
+		"HOME="+fakeHome,
+		"GRAFEL_PREFIX="+fakePrefix,
+		"GRAFEL_ARG_LOG="+logPath,
+	)
+	out, runErr := cmd.CombinedOutput()
+
+	data, readErr := os.ReadFile(logPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("read arg log: %v", readErr)
+	}
+	return string(data), string(out), runErr
+}
+
+// TestInstallSh_RecordInstallState_InvokesTheNarrowRefresh is the RED test:
+// after placing the binary the installer must run something that rewrites
+// install.json's CLI record — and it must be the NARROW refresh, not the full
+// install transaction.
+func TestInstallSh_RecordInstallState_InvokesTheNarrowRefresh(t *testing.T) {
+	argLog, combined, err := runRecordInstallState(t, fakeGrafelArgLogScript)
+	if err != nil {
+		t.Fatalf("record_install_state: %v\noutput:\n%s", err, combined)
+	}
+	if argLog == "" {
+		t.Fatalf("record_install_state never invoked the installed binary (empty arg log)\noutput:\n%s", combined)
+	}
+	if !strings.Contains(argLog, "install --refresh-state") {
+		t.Errorf("record_install_state must invoke `grafel install --refresh-state`, got invocations:\n%s", argLog)
+	}
+	// The full transaction (a bare `grafel install`) appends to .gitignore and
+	// installs git hooks in the caller's cwd — never acceptable from a curl
+	// installer. Assert no invocation is a bare install.
+	for _, line := range strings.Split(strings.TrimSpace(argLog), "\n") {
+		if strings.TrimSpace(line) == "install" {
+			t.Errorf("record_install_state must not run the full `grafel install` transaction "+
+				"(it mutates .gitignore and installs git hooks in the caller's cwd); got invocations:\n%s", argLog)
+		}
+	}
+}
+
+// TestInstallSh_RecordInstallState_IsBestEffort: every post-download step in
+// install.sh is best-effort (none of them call the fatal err() helper). A
+// non-zero exit from the refresh must not propagate — under `set -e` a bare
+// failing command would abort the whole installer right before the daemon
+// restart.
+func TestInstallSh_RecordInstallState_IsBestEffort(t *testing.T) {
+	argLog, combined, err := runRecordInstallState(t, fakeGrafelArgLogFailScript)
+	if err != nil {
+		t.Fatalf("record_install_state must swallow a failing refresh (best-effort), got: %v\noutput:\n%s", err, combined)
+	}
+	if !strings.Contains(argLog, "--refresh-state") {
+		t.Errorf("expected the refresh to have been attempted, got:\n%s", argLog)
+	}
+}
+
+// TestInstallSh_Main_RecordsStateBeforeReportingDoctor is the ordering pin: the
+// state refresh must happen BEFORE `"$BIN_DIR/grafel" doctor` runs, otherwise
+// the installer still prints the stale-SHA warning it just caused.
+func TestInstallSh_Main_RecordsStateBeforeReportingDoctor(t *testing.T) {
+	src := installShSource(t)
+	mainFn := extractFunc(t, src, "main")
+
+	recordIdx := strings.Index(mainFn, "record_install_state")
+	if recordIdx < 0 {
+		t.Fatalf("main() must call record_install_state after placing the binary; body:\n%s", mainFn)
+	}
+	doctorIdx := strings.Index(mainFn, `"$BIN_DIR/grafel" doctor`)
+	if doctorIdx < 0 {
+		t.Fatalf(`main() no longer invokes "$BIN_DIR/grafel" doctor; body:\n%s`, mainFn)
+	}
+	if recordIdx > doctorIdx {
+		t.Errorf("record_install_state must run BEFORE the doctor report (otherwise the installer "+
+			"prints the stale-SHA warning it just caused); record at %d, doctor at %d", recordIdx, doctorIdx)
+	}
+
+	// It must also come after the binary is actually in place — recording the
+	// SHA of the previous binary would be worse than not recording at all.
+	placeIdx := strings.Index(mainFn, `"$BIN_DIR/grafel"`)
+	installCmdIdx := strings.Index(mainFn, `install -m 0755`)
+	if installCmdIdx < 0 {
+		t.Fatalf("main() no longer places the binary with `install -m 0755`; body:\n%s", mainFn)
+	}
+	if recordIdx < installCmdIdx {
+		t.Errorf("record_install_state must run AFTER the new binary is placed; record at %d, place at %d (first $BIN_DIR ref at %d)",
+			recordIdx, installCmdIdx, placeIdx)
+	}
+}

--- a/internal/install/refreshstate.go
+++ b/internal/install/refreshstate.go
@@ -1,0 +1,141 @@
+package install
+
+// refreshstate.go implements the narrow "record the binary that is actually on
+// disk" operation behind `grafel install --refresh-state`.
+//
+// ── Why this exists, and why it is NOT `grafel install` ──────────────────────
+//
+// install.sh (the curl one-liner) places the new binary with
+//
+//	install -m 0755 "$TMP_DIR/grafel" "$BIN_DIR/grafel"
+//
+// and never runs anything that writes ~/.grafel/install.json — which is only
+// ever written by RunCopy step 6. So after every curl UPGRADE the recorded
+// CLI.SHA256 is the PREVIOUS binary's, RunQuickDoctor's check 1 fires, and the
+// user sees "binary updated since last install" prefixed onto every single
+// grafel command until they happen to re-run `grafel install` by hand.
+//
+// The obvious fix — have install.sh call `"$BIN_DIR/grafel" install` — is the
+// wrong one. RunCopy is a seven-step transaction, and on an upgrade run from a
+// `curl … | bash` pipeline four of those steps are actively undesirable:
+//
+//	step 3  rewrites every detected .claude.json (MCP re-registration);
+//	step 4  restarts the daemon with a 60s readiness budget — install.sh
+//	        already does its own restart_daemon with version verification
+//	        immediately afterwards, so this both duplicates the work and
+//	        races it;
+//	step 5  appends /.grafel/ to the .gitignore of whatever git repo the
+//	        user's shell happened to be sitting in when they ran the curl;
+//	step 7  installs four git hooks (post-checkout, post-merge, post-rewrite,
+//	        pre-push) into that same unrelated repository.
+//
+// Steps 5 and 7 are the disqualifying ones: a one-line installer must not
+// mutate a repository the user never mentioned. (The `grafel install` CLI path
+// additionally runs the interactive tool-selection wizard when stdin is a TTY —
+// `bash install.sh` from a terminal would stop and prompt mid-install.)
+//
+// RefreshState is therefore the narrow alternative: it rewrites ONLY the CLI
+// record of an ALREADY-EXISTING install.json and leaves every other field
+// untouched. It performs no service, filesystem, config, or network work.
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+// RefreshOptions configures RefreshState.
+type RefreshOptions struct {
+	// BinPath is the binary to record. Defaults to os.Executable().
+	BinPath string
+
+	// StatePath is the path of install.json. Defaults to DefaultStatePath().
+	StatePath string
+}
+
+// RefreshResult reports what RefreshState did.
+type RefreshResult struct {
+	// HadState is false when there was no install.json to refresh.
+	HadState bool
+	// Changed is true only when the CLI record actually differed and was
+	// rewritten.
+	Changed bool
+	// StatePath is the install.json that was considered.
+	StatePath string
+	// Path is the binary that was recorded (empty when HadState is false).
+	Path string
+	// SHA256 is the hex SHA-256 recorded for Path.
+	SHA256 string
+}
+
+func (o *RefreshOptions) applyDefaults() error {
+	if o.BinPath == "" {
+		bin, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve binary path: %w", err)
+		}
+		o.BinPath = bin
+	}
+	if o.StatePath == "" {
+		p, err := DefaultStatePath()
+		if err != nil {
+			return err
+		}
+		o.StatePath = p
+	}
+	return nil
+}
+
+// RefreshState makes install.json's CLI record agree with the binary on disk.
+//
+// It is a no-op (HadState=false, no file created) when install.json does not
+// exist: an absent state file means `grafel install` has never run, and
+// quick-doctor is already silent in that condition. Fabricating a state there
+// would be worse than doing nothing — a synthetic record with no skills
+// manifest and no MCP registration would make `grafel doctor` start reporting
+// drift that does not exist.
+//
+// Every other field of the state — install mode, skills manifest, MCP
+// registration, gitignore record, daemon version, partial-install flags — is
+// preserved exactly as read.
+func RefreshState(opts RefreshOptions) (*RefreshResult, error) {
+	if err := opts.applyDefaults(); err != nil {
+		return nil, err
+	}
+
+	res := &RefreshResult{StatePath: opts.StatePath}
+
+	state, err := ReadState(opts.StatePath)
+	if err != nil {
+		return nil, err
+	}
+	if state == nil {
+		// Never installed — nothing to refresh, and nothing to invent.
+		return res, nil
+	}
+	res.HadState = true
+
+	// Hash BEFORE touching the state file: a missing/unreadable binary must
+	// leave the previous (still meaningful) CLI record intact rather than
+	// blanking it, which checkCLI would report as a CRITICAL partial install.
+	sha, err := sha256File(opts.BinPath)
+	if err != nil {
+		return nil, fmt.Errorf("hash binary %s: %w", opts.BinPath, err)
+	}
+	res.Path = opts.BinPath
+	res.SHA256 = sha
+
+	if state.CLI.Path == opts.BinPath && state.CLI.SHA256 == sha {
+		// Already current — do not rewrite the file, so the operation is
+		// genuinely idempotent and the installer can call it unconditionally.
+		return res, nil
+	}
+
+	state.CLI = CLIRecord{Path: opts.BinPath, SHA256: sha}
+	state.InstalledAt = time.Now().UTC().Format(time.RFC3339)
+	if err := WriteState(opts.StatePath, state); err != nil {
+		return nil, err
+	}
+	res.Changed = true
+	return res, nil
+}

--- a/internal/install/refreshstate.go
+++ b/internal/install/refreshstate.go
@@ -41,7 +41,6 @@ package install
 import (
 	"fmt"
 	"os"
-	"time"
 )
 
 // RefreshOptions configures RefreshState.
@@ -95,9 +94,10 @@ func (o *RefreshOptions) applyDefaults() error {
 // manifest and no MCP registration would make `grafel doctor` start reporting
 // drift that does not exist.
 //
-// Every other field of the state — install mode, skills manifest, MCP
-// registration, gitignore record, daemon version, partial-install flags — is
-// preserved exactly as read.
+// Every other field of the state — install mode, InstalledAt, skills manifest,
+// MCP registration, gitignore record, partial-install flags — is preserved
+// exactly as read. The sole exception is DaemonVersion, which an in-place
+// binary swap definitely invalidates; see the comment at the write below.
 func RefreshState(opts RefreshOptions) (*RefreshResult, error) {
 	if err := opts.applyDefaults(); err != nil {
 		return nil, err
@@ -125,14 +125,29 @@ func RefreshState(opts RefreshOptions) (*RefreshResult, error) {
 	res.Path = opts.BinPath
 	res.SHA256 = sha
 
-	if state.CLI.Path == opts.BinPath && state.CLI.SHA256 == sha {
+	if state.CLI.Path == opts.BinPath && state.CLI.SHA256 == sha && state.DaemonVersion == "" {
 		// Already current — do not rewrite the file, so the operation is
 		// genuinely idempotent and the installer can call it unconditionally.
 		return res, nil
 	}
 
+	// Path as well as SHA: the recorded path can be wrong on its own (an
+	// install that moved prefix), and correcting it is the sole remedy for
+	// quick-doctor's "install.json records <gone path>" warning.
 	state.CLI = CLIRecord{Path: opts.BinPath, SHA256: sha}
-	state.InstalledAt = time.Now().UTC().Format(time.RFC3339)
+
+	// InstalledAt is deliberately NOT touched: no install happened here, and
+	// stamping "now" would make the field assert something false.
+
+	// DaemonVersion IS cleared, and it is the one field an in-place binary
+	// swap definitely invalidates: install.sh replaces the binary and then
+	// restarts the daemon, so the recorded version describes a process that no
+	// longer exists and checkDaemon would report a version mismatch on every
+	// `grafel doctor`. checkDaemon early-returns on "", so dropping a
+	// known-wrong value is strictly better than preserving it; the next real
+	// `grafel install` / `grafel update` repopulates it from the live probe.
+	state.DaemonVersion = ""
+
 	if err := WriteState(opts.StatePath, state); err != nil {
 		return nil, err
 	}

--- a/internal/install/refreshstate_test.go
+++ b/internal/install/refreshstate_test.go
@@ -1,0 +1,201 @@
+// refreshstate_test.go pins the narrow "record the binary that is actually on
+// disk" operation that the curl installer needs.
+//
+// Background: install.sh places the new binary with `install -m 0755` and never
+// runs `grafel install`, which is the only thing that writes
+// ~/.grafel/install.json. The recorded CLI SHA therefore stays the PREVIOUS
+// binary's forever, and RunQuickDoctor prints "binary updated since last
+// install" on every single command until the user re-runs `grafel install` by
+// hand.
+//
+// Running the full `grafel install` transaction from a curl installer is not an
+// option (see the argument in refreshstate.go): steps 5 and 7 mutate whatever
+// git repo the user's shell happened to be sitting in. RefreshState is the
+// narrow alternative: it rewrites ONLY the CLI record of an EXISTING
+// install.json and leaves every other field — skills manifest, MCP
+// registration, gitignore record, install mode — exactly as it found them.
+package install_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// writeFakeBinary writes a file with known content and returns its path.
+func writeFakeBinary(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o755); err != nil {
+		t.Fatalf("write fake binary %s: %v", p, err)
+	}
+	return p
+}
+
+// seedState writes an install.json that looks like a completed COPY install
+// whose CLI record is stale (points at binPath but records an old SHA).
+func seedState(t *testing.T, statePath, binPath string) *install.State {
+	t.Helper()
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: binPath, SHA256: "0000000000000000000000000000000000000000000000000000000000000000"}
+	st.Skills = map[string]install.SkillRecord{
+		"grafel-tech-docs": {Files: map[string]string{"SKILL.md": "deadbeef"}},
+	}
+	st.MCP = install.MCPRecord{Name: "grafel", RegisteredPaths: []string{"/home/u/.claude.json"}}
+	st.Gitignore = install.GitignoreRecord{Repos: []string{"/home/u/repo"}}
+	st.DaemonVersion = "v0.1.7"
+	if err := install.WriteState(statePath, st); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+	return st
+}
+
+// TestRefreshState_RecordsOnDiskBinary is the core RED test: after a curl
+// upgrade replaces the binary in place, RefreshState must make install.json
+// agree with what is on disk.
+func TestRefreshState_RecordsOnDiskBinary(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "#!/bin/sh\necho v0.2.0\n")
+	seedState(t, statePath, bin)
+
+	res, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("RefreshState: %v", err)
+	}
+	if !res.HadState {
+		t.Error("HadState must be true when install.json exists")
+	}
+	if !res.Changed {
+		t.Error("Changed must be true when the recorded SHA was stale")
+	}
+
+	got, err := install.ReadState(statePath)
+	if err != nil || got == nil {
+		t.Fatalf("ReadState after refresh: %v (state=%v)", err, got)
+	}
+	if got.CLI.Path != bin {
+		t.Errorf("CLI.Path = %q, want %q", got.CLI.Path, bin)
+	}
+	if got.CLI.SHA256 == "" || got.CLI.SHA256 == "0000000000000000000000000000000000000000000000000000000000000000" {
+		t.Errorf("CLI.SHA256 was not refreshed: %q", got.CLI.SHA256)
+	}
+	if got.CLI.SHA256 != res.SHA256 {
+		t.Errorf("result SHA %q != persisted SHA %q", res.SHA256, got.CLI.SHA256)
+	}
+}
+
+// TestRefreshState_PreservesEverythingElse is the blast-radius pin: refreshing
+// the CLI record must NOT clobber the rest of the install transaction's record.
+// If this ever regresses, `grafel doctor` would start reporting a fully
+// installed system as having no skills and no MCP registration.
+func TestRefreshState_PreservesEverythingElse(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "new binary bytes")
+	before := seedState(t, statePath, bin)
+
+	if _, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath}); err != nil {
+		t.Fatalf("RefreshState: %v", err)
+	}
+
+	after, err := install.ReadState(statePath)
+	if err != nil || after == nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if after.InstallMode != before.InstallMode {
+		t.Errorf("InstallMode changed: %q -> %q", before.InstallMode, after.InstallMode)
+	}
+	if len(after.Skills) != len(before.Skills) {
+		t.Errorf("Skills manifest changed: %v -> %v", before.Skills, after.Skills)
+	}
+	if rec, ok := after.Skills["grafel-tech-docs"]; !ok || rec.Files["SKILL.md"] != "deadbeef" {
+		t.Errorf("skill record lost or altered: %+v", after.Skills)
+	}
+	if after.MCP.Name != "grafel" || len(after.MCP.RegisteredPaths) != 1 {
+		t.Errorf("MCP record changed: %+v", after.MCP)
+	}
+	if len(after.Gitignore.Repos) != 1 || after.Gitignore.Repos[0] != "/home/u/repo" {
+		t.Errorf("Gitignore record changed: %+v", after.Gitignore)
+	}
+	if after.DaemonVersion != before.DaemonVersion {
+		t.Errorf("DaemonVersion changed: %q -> %q", before.DaemonVersion, after.DaemonVersion)
+	}
+	if after.SchemaVersion != install.StateSchemaVersion {
+		t.Errorf("SchemaVersion = %d, want %d", after.SchemaVersion, install.StateSchemaVersion)
+	}
+}
+
+// TestRefreshState_NoInstallJSONIsASilentNoOp: a machine that has never run
+// `grafel install` has no install.json, and quick-doctor is silent in that
+// state. RefreshState must NOT fabricate one — a synthetic state with no
+// skills and no MCP record would make `grafel doctor` start reporting drift
+// that does not exist.
+func TestRefreshState_NoInstallJSONIsASilentNoOp(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "fresh install")
+
+	res, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("RefreshState with no install.json must not error: %v", err)
+	}
+	if res.HadState {
+		t.Error("HadState must be false when install.json is absent")
+	}
+	if res.Changed {
+		t.Error("Changed must be false when install.json is absent")
+	}
+	if _, statErr := os.Stat(statePath); !os.IsNotExist(statErr) {
+		t.Errorf("RefreshState must not create install.json out of nothing (stat err = %v)", statErr)
+	}
+}
+
+// TestRefreshState_IdempotentWhenAlreadyCurrent: the second run of the curl
+// installer over an unchanged binary must report no change (and must still not
+// error), so the installer can call it unconditionally.
+func TestRefreshState_IdempotentWhenAlreadyCurrent(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "same bytes")
+	seedState(t, statePath, bin)
+
+	if _, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath}); err != nil {
+		t.Fatalf("first RefreshState: %v", err)
+	}
+	res, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("second RefreshState: %v", err)
+	}
+	if !res.HadState {
+		t.Error("HadState must stay true")
+	}
+	if res.Changed {
+		t.Error("Changed must be false on a no-op refresh")
+	}
+}
+
+// TestRefreshState_MissingBinaryIsAnError: a caller that points at a binary
+// that is not there has a real problem; do not silently write a state with an
+// empty SHA (which checkCLI reports as a CRITICAL partial install).
+func TestRefreshState_MissingBinaryIsAnError(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "x")
+	seedState(t, statePath, bin)
+
+	missing := filepath.Join(tmp, "does-not-exist")
+	if _, err := install.RefreshState(install.RefreshOptions{BinPath: missing, StatePath: statePath}); err == nil {
+		t.Fatal("RefreshState must error when BinPath does not exist")
+	}
+
+	got, err := install.ReadState(statePath)
+	if err != nil || got == nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.CLI.SHA256 == "" {
+		t.Error("a failed refresh must leave the previous CLI record intact, not blank it")
+	}
+}

--- a/internal/install/refreshstate_test.go
+++ b/internal/install/refreshstate_test.go
@@ -87,6 +87,101 @@ func TestRefreshState_RecordsOnDiskBinary(t *testing.T) {
 	}
 }
 
+// TestRefreshState_CorrectsAWrongPath is the mutant a reviewer found surviving:
+// every other test here seeds a state whose CLI.Path ALREADY equals the binary,
+// so nothing proved RefreshState rewrites the PATH rather than just the SHA.
+//
+// That correction is load-bearing. It is the sole remedy for quick-doctor's
+// "install.json records <path>, which no longer exists" warning — if it
+// regressed, that warning would become permanent and unfixable, since running
+// the prescribed command would leave the wrong path in place.
+func TestRefreshState_CorrectsAWrongPath(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+
+	oldPath := filepath.Join(tmp, "old-prefix", "grafel")
+	newBin := writeFakeBinary(t, tmp, "grafel", "relocated binary bytes")
+
+	// State recorded at a prefix that no longer exists.
+	st := install.NewState(install.ModeCopy)
+	st.CLI = install.CLIRecord{Path: oldPath, SHA256: "1111111111111111111111111111111111111111111111111111111111111111"}
+	if err := install.WriteState(statePath, st); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	res, err := install.RefreshState(install.RefreshOptions{BinPath: newBin, StatePath: statePath})
+	if err != nil {
+		t.Fatalf("RefreshState: %v", err)
+	}
+	if !res.Changed {
+		t.Error("Changed must be true when the recorded PATH was wrong")
+	}
+
+	got, err := install.ReadState(statePath)
+	if err != nil || got == nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.CLI.Path != newBin {
+		t.Errorf("CLI.Path = %q, want %q — RefreshState must rewrite the recorded PATH, not only the SHA", got.CLI.Path, newBin)
+	}
+	if got.CLI.Path == oldPath {
+		t.Errorf("CLI.Path is still the stale %q", oldPath)
+	}
+}
+
+// TestRefreshState_PreservesInstalledAt: no install happened, so stamping the
+// timestamp with "now" would make the field assert something false.
+func TestRefreshState_PreservesInstalledAt(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "new bytes")
+
+	const originalInstall = "2020-01-02T03:04:05Z"
+	st := install.NewState(install.ModeCopy)
+	st.InstalledAt = originalInstall
+	st.CLI = install.CLIRecord{Path: bin, SHA256: "2222222222222222222222222222222222222222222222222222222222222222"}
+	if err := install.WriteState(statePath, st); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	if _, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath}); err != nil {
+		t.Fatalf("RefreshState: %v", err)
+	}
+
+	got, err := install.ReadState(statePath)
+	if err != nil || got == nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.InstalledAt != originalInstall {
+		t.Errorf("InstalledAt = %q, want it preserved as %q — no install happened here", got.InstalledAt, originalInstall)
+	}
+}
+
+// TestRefreshState_ClearsTheInvalidatedDaemonVersion: DaemonVersion is the one
+// field an in-place binary swap definitely invalidates. install.sh replaces the
+// binary and then restarts the daemon, so the recorded version describes a
+// process that no longer exists and checkDaemon would report a version mismatch
+// on every `grafel doctor`. checkDaemon early-returns on "", so dropping a
+// known-wrong value is strictly better than preserving it.
+func TestRefreshState_ClearsTheInvalidatedDaemonVersion(t *testing.T) {
+	tmp := t.TempDir()
+	statePath := filepath.Join(tmp, ".grafel", "install.json")
+	bin := writeFakeBinary(t, tmp, "grafel", "upgraded bytes")
+	seedState(t, statePath, bin) // seeds DaemonVersion = v0.1.7
+
+	if _, err := install.RefreshState(install.RefreshOptions{BinPath: bin, StatePath: statePath}); err != nil {
+		t.Fatalf("RefreshState: %v", err)
+	}
+
+	got, err := install.ReadState(statePath)
+	if err != nil || got == nil {
+		t.Fatalf("ReadState: %v", err)
+	}
+	if got.DaemonVersion != "" {
+		t.Errorf("DaemonVersion = %q, want it cleared — the recorded value describes the pre-upgrade daemon", got.DaemonVersion)
+	}
+}
+
 // TestRefreshState_PreservesEverythingElse is the blast-radius pin: refreshing
 // the CLI record must NOT clobber the rest of the install transaction's record.
 // If this ever regresses, `grafel doctor` would start reporting a fully
@@ -120,9 +215,11 @@ func TestRefreshState_PreservesEverythingElse(t *testing.T) {
 	if len(after.Gitignore.Repos) != 1 || after.Gitignore.Repos[0] != "/home/u/repo" {
 		t.Errorf("Gitignore record changed: %+v", after.Gitignore)
 	}
-	if after.DaemonVersion != before.DaemonVersion {
-		t.Errorf("DaemonVersion changed: %q -> %q", before.DaemonVersion, after.DaemonVersion)
+	if after.InstalledAt != before.InstalledAt {
+		t.Errorf("InstalledAt changed: %q -> %q", before.InstalledAt, after.InstalledAt)
 	}
+	// DaemonVersion is the deliberate exception — see
+	// TestRefreshState_ClearsTheInvalidatedDaemonVersion.
 	if after.SchemaVersion != install.StateSchemaVersion {
 		t.Errorf("SchemaVersion = %d, want %d", after.SchemaVersion, install.StateSchemaVersion)
 	}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -12,6 +12,17 @@ var (
 	Date    = "unknown"
 )
 
+// DevVersion is the Version value of a binary built without ldflags
+// injection, i.e. a local `go build` / `go run` rather than a release
+// artifact.
+const DevVersion = "0.0.0-dev"
+
+// IsDev reports whether v is the un-injected dev-build version string.
+// Callers that treat release binaries differently from scratch builds
+// (e.g. install-state drift reporting) use this rather than hard-coding
+// the sentinel.
+func IsDev(v string) bool { return v == DevVersion }
+
 // String returns a human-readable build descriptor. Pure function — no
 // package-state mutation. When the binary was built without ldflags
 // injection (typical `go build` with no Makefile), it falls back to
@@ -21,7 +32,7 @@ func String() string {
 	commit := Commit
 	date := Date
 
-	if v == "0.0.0-dev" {
+	if IsDev(v) {
 		if info, ok := debug.ReadBuildInfo(); ok {
 			for _, s := range info.Settings {
 				switch s.Key {


### PR DESCRIPTION
From a user report: after a curl upgrade, **every** command printed

```
grafel doctor: binary updated since last install (daemon still usable); daemon unreachable at :47274 — run 'grafel doctor' for details
```

and their MCP server had stopped working.

## Root cause

`RunQuickDoctor` (`internal/install/doctor.go`) compares `state.CLI.SHA256` from `~/.grafel/install.json` against `sha256File(state.CLI.Path)`.

`install.sh:364` places the binary with `install -m 0755` and **never writes `install.json`** — the only writer is `RunCopy` step 6. So after any curl upgrade the recorded SHA is the *previous* binary's, forever.

Two lines later the script runs `"$BIN_DIR/grafel" doctor`, so **the installer prints the warning it just caused**. Its `stale` branch does say "run `grafel install` to finish", but only on that one path; the `restarted` and no-daemon paths report success and never mention the outstanding step.

**The same gap explains the missing MCP.** Registration lives *only* in the install path (`copy.go:692`, `install.go:321`, `tooldelta.go:44`) — not the wizard, not the daemon. A curl install never registers MCP at all.

## `grafel install` from the installer would have been worse

The obvious fix is unsafe from a `curl … | bash` pipeline. Verified against `RunCopy`:

- **step 5** (`copy.go:762`) — `DetectGitRepo(opts.WorkingDir)` → `EnsureGitignore(repoRoot)`, with `WorkingDir` defaulting to `os.Getwd()` (`:833`). Appends `/.grafel/` to the `.gitignore` of **whatever repo the shell was in**.
- **step 7** (`copy.go:800`) — installs **four** git hooks into that same unnamed repo.
- **step 4** (`copy.go:717`, 60s budget) — duplicates and races `install.sh`'s own `restart_daemon` two steps later.
- **step 3** (`copy.go:687`) — rewrites every detected `.claude.json`.
- `RunCopy` begins `state := NewState(ModeCopy)` — a bare install **replaces** the state rather than amending it.
- `resolveToolSelection` → `stdinIsTTY()` (`install.go:352`): `curl | bash` inherits a pipe so no prompt, but **`bash install.sh` from a terminal blocks on the tool-selection wizard**.

So: **`grafel install --refresh-state`**, which rewrites only the CLI record of an **already-existing** `install.json` — preserving install mode, skills manifest, MCP registration, gitignore record and partial-install flags. No service, config or network work. An absent `install.json` stays absent; fabricating one with no skills/MCP record would make `doctor` report drift that does not exist.

`install.sh` calls it best-effort (`|| true`, non-fatal under `set -eu`) after placing the binary and **before** the `doctor` report, so the installer no longer prints the warning it caused.

## Three cases, three remedies — the second one was wrong at first

The first revision added a path-mismatch check with the *same* remedy as a SHA drift. Review demonstrated the ping-pong:

```
grafel-second --version                → warns (records "grafel")
grafel-second install --refresh-state
grafel --version                       → NOW warns (records "grafel-second")
```

Concretely harmful: someone curl-upgrades to `~/.grafel/bin/grafel` while PATH still finds a stale `/usr/local/bin/grafel`, obeys the prescription **from the stale binary**, and records the old binary as THE install — while the skills/MCP manifest describes the new one. `doctor` then calls the stale binary healthy: **the exact false all-clear this change exists to eliminate.**

Split into two genuinely different situations:

| state | message |
|---|---|
| recorded binary **exists** | `running <A> but install.json records <B> — two grafel installs; 'which -a grafel' to find the extra one` — **no refresh offered**, so the ping-pong is unreachable |
| recorded binary **gone** | `install.json records <p>, which no longer exists (daemon still usable) — run 'grafel install --refresh-state' to record <A>` |
| SHA drift | `binary updated since last install (daemon still usable) — run 'grafel install --refresh-state'` |

The "recorded binary gone" state was previously **silent** (`sha256File` errored), and is what a relocated install looks like — a new prefix, a package-manager migration. Only one binary remains there, so nothing can ping-pong.

## `os.SameFile`, and a projection turned into a measurement

Identity is now device+inode via `os.SameFile` rather than `EvalSymlinks` — same two syscalls, and correct for hard links and version-stamped prefixes.

Review projected that Homebrew-Cellar / Nix / asdf layouts would produce a false warning on every command. **Now measured, not projected:** a Cellar-style `bin/grafel → Cellar/0.2.0/bin/grafel` is silent (`TestClassifyBinaryIdentity_SymlinkedBinDir`, `TestQuickDoctor_SymlinkedBinDirStaysSilent`, `TestDoctorCLI_SymlinkedBinDirIsOK`). Linux remains unverified.

The textual fast path is kept and documented as **load-bearing, not an optimisation**: when the recorded path *is* the path being run, a stat failure must stay silent — that is the rename window of an in-place upgrade. Pinned by `TestClassifyBinaryIdentity_IdenticalPathButDeleted`.

## Full `doctor` was giving worse advice than quick-doctor

`checkCLI` still emitted `re-run 'grafel install' to refresh` — the command this change argues is unsafe from an arbitrary cwd — and had no identity check, so it kept giving the false all-clear quick-doctor now catches. It mirrors the three cases and prescribes `--refresh-state`. `TestDoctorCLI_TwoInstallsAreReported` demonstrates the old behaviour: with the identity check removed, full doctor reports `cli OK` with empty drift while the process is a different install.

## Also

`DaemonVersion` is now **cleared** rather than preserved — the installer restarts the daemon to the new version two steps later, so preserving it guaranteed a `daemon version mismatch` on every subsequent `doctor` (`checkDaemon` early-returns on `""`, `doctor.go:527`). `InstalledAt` is preserved. Flag conflicts are rejected, keyed on `Changed` so `--copy`'s default of true is not treated as a conflict.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty, `shellcheck -S warning install.sh` → 0. Sequential, `-count=1 -p 1`, `GOMAXPROCS=4`:

| package | exit | pass | skip |
|---|---|---|---|
| `./internal/install/...` `./internal/cli/` `./internal/version/` | 0 | 932 | 1 |
| `./cmd/grafel/` | 0 | 515 | 8 |

All 9 skips pre-existing. Quick-doctor latency **4.90ms** (`-tags perf`) against a 50ms budget — *faster* than before, since the identity check replaces a SHA with two stats on the mismatch paths. `RunQuickDoctor` still returns `nil` unconditionally on every path.

**15 mutants this pass**, listed in the commit message for replay, all killed on their intended assertion. That includes the five that survived the first review round — `RefreshState` keeping the old path, the textual fast path, stat-error-means-same, the empty-`SelfPath` guard, and the `os.Executable()` default, which meant the production wiring was entirely untested. Two compile-error false negatives were caught and re-run rather than banked.

`internal/cli` now covers `--refresh-state`'s three output branches and asserts the short-circuit **directly**: run from inside a git repo, `.gitignore` stays byte-identical and `.git/hooks` stays empty.

## Disclosed weakness

The short-circuit mutant (`N14b`) falls into the real install transaction, which dies at **step 4** in a temp HOME — the 104-char unix socket path limit — **before reaching steps 5 and 7**. So in this environment those two side-effect assertions cannot observe a step-5/7 mutation directly; the mutant dies on the earlier fatal instead. The test now records the failure and continues to the assertions rather than aborting, and they remain live wherever step 4 succeeds.

## Filed separately, not fixed here

- **#6162** — `grafel update` carries the identical `RunCopy` blast radius: a routine command that appends to a stranger's `.gitignore` and installs four hooks in it.
- **#6163** — Windows: `install.ps1` never writes `install.json` (same defect); `install.bat:320` runs bare `grafel.exe install`, taking the full blast radius **and** blocking on the wizard because an interactive console makes stdin a TTY.
- `WriteState`'s fixed `.tmp` path with no `O_EXCL`/flock, and `RefreshState`'s CAS-free read-modify-write — pre-existing, amplified by adding a second writer. Atomic rename means no torn file; concurrency is unguarded.

Independently adversarially reviewed (REQUEST-CHANGES), all findings addressed.

Refs #6070, #6162, #6163

Closes #6165
