### PR TITLE
fix(#6168): a failed daemon restart deleted the user's MCP registration

### DIFF
--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -693,6 +693,22 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	copy(allMCPTargets, claudeDirs)
 	allMCPTargets = append(allMCPTargets, mcpreg.DetectWindsurfPaths()...)
 
+	// Discard any sidecar left behind by an EARLIER run before taking this
+	// run's snapshots. backupOnce refuses to overwrite an existing sidecar, so
+	// without this a snapshot from a previous run — one that ended at a failed
+	// step 4 and so never reached the commit-time clear — would be treated as
+	// this run's pristine original. A later rollback would then write weeks-old
+	// content over the user's live config, or, if that stale snapshot is the
+	// absent-sentinel from a first-ever install, DELETE the config file
+	// outright along with every foreign server in it.
+	//
+	// This is safe at the start of step 3 precisely because no in-flight
+	// transaction can need a previous run's snapshot: rollback only ever
+	// restores what the CURRENT run wrote.
+	if !opts.DryRun {
+		discardStaleMCPBackups(allMCPTargets)
+	}
+
 	for _, cfgPath := range allMCPTargets {
 		if opts.DryRun {
 			registeredPaths = append(registeredPaths, cfgPath)
@@ -1168,11 +1184,24 @@ func rollbackMCPRegistration(touchedPaths []string) {
 }
 
 // commitMCPBackups discards the pristine sidecar snapshots once the install
-// transaction has committed. It is the ONLY place backups are cleared: keeping
-// the snapshot alive for the whole transaction is what makes a rollback a real
-// restore rather than a silent delete (#6168).
+// transaction has committed. Keeping the snapshot alive for the whole
+// transaction is what makes a rollback a real restore rather than a silent
+// delete (#6168).
 func commitMCPBackups(registeredPaths []string) {
 	for _, cfgPath := range registeredPaths {
+		mcpreg.ClearBackup(cfgPath)
+	}
+}
+
+// discardStaleMCPBackups drops sidecars inherited from an EARLIER run, so this
+// run's backupOnce takes a snapshot of the config as it is NOW.
+//
+// commitMCPBackups alone is not enough: it is unreachable on any failure after
+// step 3, and a failed daemon restart is the common ending for exactly the
+// users this fix targets. Without this second clear, a stale snapshot survives
+// indefinitely and the next run's rollback restores it over live content.
+func discardStaleMCPBackups(targets []string) {
+	for _, cfgPath := range targets {
 		mcpreg.ClearBackup(cfgPath)
 	}
 }

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -722,8 +722,11 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 			// targets is known. rollback(3) cannot do it: it fires before
 			// `completedSteps` contains 3, and state.MCP.RegisteredPaths is
 			// still empty because it is assigned only after this loop (#6168).
-			rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
+			rbErr := rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
 			rollback(3)
+			if rbErr != nil {
+				return nil, fmt.Errorf("step 3 – MCP register %s: %w; ROLLBACK INCOMPLETE: %v", cfgPath, err, rbErr)
+			}
 			return nil, fmt.Errorf("step 3 – MCP register %s: %w", cfgPath, err)
 		}
 		registeredPaths = append(registeredPaths, cfgPath)
@@ -820,7 +823,7 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	// Only now are the pristine MCP sidecar backups discarded, so the next
 	// install snapshots fresh and a later restore never resurrects stale
 	// grafel-containing content. Clearing them at step 3 (as this used to)
-	// meant a later rollback found no snapshot and RestorePath silently
+	// meant a later rollback found no snapshot and RestoreSnapshot silently
 	// degraded to UnregisterPath — a "restore" that deleted (#6168).
 	if !opts.DryRun {
 		commitMCPBackups(registeredPaths)
@@ -1164,11 +1167,16 @@ func rollbackSkillsCopy(opts CopyOptions, state *State) {
 // state.MCP.RegisteredPaths, because the only caller is the mid-loop failure
 // site where that field has not been assigned yet (#6168).
 //
-// It calls RestoreSnapshot, not RestorePath: with no snapshot there is nothing
-// this function is entitled to undo, and RestorePath's documented fallback
-// would delete the entry instead. A missing snapshot is reported, never acted
-// on.
-func rollbackMCPRegistration(touchedPaths []string) {
+// It calls RestoreSnapshot: with no snapshot there is nothing this function is
+// entitled to undo, so a missing snapshot is skipped rather than guessed at.
+//
+// It returns a non-nil error listing the paths whose restore FAILED. Those
+// files are left partially modified, which the caller must surface: on a
+// multi-host install, a failure to restore host A while reporting only "step 3
+// – MCP register B failed" would leave the user with a silently inconsistent
+// multi-host state and no signal that A needs attention (#6168 S4).
+func rollbackMCPRegistration(touchedPaths []string) error {
+	var failed []string
 	for _, cfgPath := range touchedPaths {
 		err := mcpreg.RestoreSnapshot(cfgPath)
 		switch {
@@ -1179,8 +1187,14 @@ func rollbackMCPRegistration(touchedPaths []string) {
 		default:
 			fmt.Fprintf(os.Stderr,
 				"grafel install: rollback warning – restore %s: %v\n", cfgPath, err)
+			failed = append(failed, fmt.Sprintf("%s (%v)", cfgPath, err))
 		}
 	}
+	if len(failed) > 0 {
+		return fmt.Errorf("could not restore %d config file(s), left partially modified: %s",
+			len(failed), strings.Join(failed, "; "))
+	}
+	return nil
 }
 
 // commitMCPBackups discards the pristine sidecar snapshots once the install

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -20,6 +20,7 @@ package install
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -562,8 +563,16 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 			switch s {
 			case 2:
 				rollbackSkillsCopy(opts, state)
-			case 3:
-				rollbackMCPRegistration(opts, state)
+				// Step 3 (MCP registration) is deliberately NOT rolled back
+				// here (#6168). A completed registration is correct whether or
+				// not a LATER step succeeded — the bridge answers `initialize`
+				// locally and falls back to offlineToolList when the daemon is
+				// down (internal/cli/mcp_bridge.go), so a wedged or slow daemon
+				// is not a reason to remove the user's MCP entry. Only a
+				// step-3 failure MID-LOOP leaves inconsistent state, and that
+				// is undone at the failure site itself, where the exact set of
+				// already-written targets is known.
+				//
 				// Steps 1, 4, 5, 6 are either non-destructive (1, 6) or have
 				// best-effort rollback that is a no-op (4 daemon was already
 				// running or we just tried to restart it; 5 gitignore append
@@ -690,6 +699,14 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 			continue
 		}
 		if _, err := mcpreg.RegisterPath(cfgPath, opts.BinPath); err != nil {
+			// Step 3 aborted PART-WAY through its targets: some files now
+			// carry a grafel entry and some do not. That inconsistency is the
+			// one case that genuinely needs step 3 undone, and it is undone
+			// here — at the failure site, where the exact set of written
+			// targets is known. rollback(3) cannot do it: it fires before
+			// `completedSteps` contains 3, and state.MCP.RegisteredPaths is
+			// still empty because it is assigned only after this loop (#6168).
+			rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
 			rollback(3)
 			return nil, fmt.Errorf("step 3 – MCP register %s: %w", cfgPath, err)
 		}
@@ -700,15 +717,6 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 		RegisteredPaths: registeredPaths,
 	}
 	result.MCPPaths = registeredPaths
-	// Step 3 succeeded for every target: discard the pristine backups so the
-	// next install snapshots fresh and a later uninstall won't restore stale
-	// grafel-containing content. (Rollback only fires on FAILURE, before
-	// this point.)
-	if !opts.DryRun {
-		for _, cfgPath := range registeredPaths {
-			mcpreg.ClearBackup(cfgPath)
-		}
-	}
 	completedSteps = append(completedSteps, 3)
 
 	// ─────────────────────────────────────────────────────────────────────────
@@ -791,6 +799,16 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	}
 	result.StatePath = opts.StatePath
 	completedSteps = append(completedSteps, 6)
+
+	// ── COMMIT: the transaction can no longer roll back ─────────────────────
+	// Only now are the pristine MCP sidecar backups discarded, so the next
+	// install snapshots fresh and a later restore never resurrects stale
+	// grafel-containing content. Clearing them at step 3 (as this used to)
+	// meant a later rollback found no snapshot and RestorePath silently
+	// degraded to UnregisterPath — a "restore" that deleted (#6168).
+	if !opts.DryRun {
+		commitMCPBackups(registeredPaths)
+	}
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 7: Git hook installation (post-checkout, post-merge, post-rewrite,
@@ -1121,12 +1139,40 @@ func rollbackSkillsCopy(opts CopyOptions, state *State) {
 	}
 }
 
-// rollbackMCPRegistration reverses step 3 by RESTORING each touched config
-// file from the pristine backup taken before grafel's first write. This
+// rollbackMCPRegistration reverses an ABORTED step 3 by RESTORING each touched
+// config file from the pristine backup taken before grafel's first write. This
 // brings back any foreign mcpServers entries verbatim and deletes files
 // grafel created — it NEVER resets a shared config to `{}` (see #4829).
-func rollbackMCPRegistration(_ CopyOptions, state *State) {
-	for _, cfgPath := range state.MCP.RegisteredPaths {
-		_ = mcpreg.RestorePath(cfgPath)
+//
+// It takes the touched paths explicitly rather than reading
+// state.MCP.RegisteredPaths, because the only caller is the mid-loop failure
+// site where that field has not been assigned yet (#6168).
+//
+// It calls RestoreSnapshot, not RestorePath: with no snapshot there is nothing
+// this function is entitled to undo, and RestorePath's documented fallback
+// would delete the entry instead. A missing snapshot is reported, never acted
+// on.
+func rollbackMCPRegistration(touchedPaths []string) {
+	for _, cfgPath := range touchedPaths {
+		err := mcpreg.RestoreSnapshot(cfgPath)
+		switch {
+		case err == nil:
+		case errors.Is(err, mcpreg.ErrNoSnapshot):
+			// Nothing was written to this path (RegisterPath failed before its
+			// first modification), so there is nothing to undo.
+		default:
+			fmt.Fprintf(os.Stderr,
+				"grafel install: rollback warning – restore %s: %v\n", cfgPath, err)
+		}
+	}
+}
+
+// commitMCPBackups discards the pristine sidecar snapshots once the install
+// transaction has committed. It is the ONLY place backups are cleared: keeping
+// the snapshot alive for the whole transaction is what makes a rollback a real
+// restore rather than a silent delete (#6168).
+func commitMCPBackups(registeredPaths []string) {
+	for _, cfgPath := range registeredPaths {
+		mcpreg.ClearBackup(cfgPath)
 	}
 }

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -820,11 +820,14 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	completedSteps = append(completedSteps, 6)
 
 	// ── COMMIT: the transaction can no longer roll back ─────────────────────
-	// Only now are the pristine MCP sidecar backups discarded, so the next
-	// install snapshots fresh and a later restore never resurrects stale
-	// grafel-containing content. Clearing them at step 3 (as this used to)
-	// meant a later rollback found no snapshot and RestoreSnapshot silently
-	// degraded to UnregisterPath — a "restore" that deleted (#6168).
+	// THIS run's snapshots are discarded only here, so a rollback anywhere
+	// above still had a real snapshot to restore from. Discarding them on
+	// step-3 SUCCESS (as this used to) put the clear before rollback(4), so a
+	// later rollback found no snapshot and the since-deleted RestorePath
+	// silently degraded to UnregisterPath — a "restore" that deleted (#6168).
+	//
+	// Distinct from the clear at the START of step 3, which discards the
+	// PREVIOUS run's leftovers so this run snapshots the config as it is now.
 	if !opts.DryRun {
 		commitMCPBackups(registeredPaths)
 	}

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -234,6 +234,11 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 	// Step 3: MCP registration
 	// ─────────────────────────────────────────────────────────────────────────
 	var registeredPaths []string
+	// Drop sidecars inherited from an earlier run before snapshotting fresh —
+	// see the matching comment in RunCopy (#6168).
+	if !opts.DryRun {
+		discardStaleMCPBackups(claudeDirs)
+	}
 	for _, cfgPath := range claudeDirs {
 		if opts.DryRun {
 			registeredPaths = append(registeredPaths, cfgPath)

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -147,8 +147,9 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 			switch s {
 			case 2:
 				rollbackSkillsSymlinks(opts, state)
-			case 3:
-				rollbackMCPRegistration(CopyOptions{ClaudeConfigDirs: opts.ClaudeConfigDirs}, state)
+				// Step 3 is deliberately absent — see the matching comment in
+				// RunCopy: a completed MCP registration is not undone by a
+				// later step's failure (#6168).
 			}
 		}
 		if !opts.DryRun {
@@ -239,6 +240,8 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 			continue
 		}
 		if _, err := mcpreg.RegisterPath(cfgPath, opts.BinPath); err != nil {
+			// Mid-loop abort: undo only the targets this loop touched (#6168).
+			rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
 			rollback(3)
 			return nil, fmt.Errorf("step 3 – MCP register %s: %w", cfgPath, err)
 		}
@@ -249,12 +252,6 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 		RegisteredPaths: registeredPaths,
 	}
 	result.MCPPaths = registeredPaths
-	// Step 3 succeeded: discard pristine backups (see copy.go rationale).
-	if !opts.DryRun {
-		for _, cfgPath := range registeredPaths {
-			mcpreg.ClearBackup(cfgPath)
-		}
-	}
 	completedSteps = append(completedSteps, 3)
 
 	// ─────────────────────────────────────────────────────────────────────────
@@ -304,6 +301,11 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 	}
 	result.StatePath = opts.StatePath
 	completedSteps = append(completedSteps, 6)
+
+	// ── COMMIT: discard the pristine MCP snapshots (see RunCopy, #6168) ─────
+	if !opts.DryRun {
+		commitMCPBackups(registeredPaths)
+	}
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 7: Git hook installation (post-checkout, post-merge, post-rewrite,

--- a/internal/install/dev.go
+++ b/internal/install/dev.go
@@ -246,8 +246,11 @@ func RunDev(opts DevOptions) (*DevResult, error) {
 		}
 		if _, err := mcpreg.RegisterPath(cfgPath, opts.BinPath); err != nil {
 			// Mid-loop abort: undo only the targets this loop touched (#6168).
-			rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
+			rbErr := rollbackMCPRegistration(append(append([]string(nil), registeredPaths...), cfgPath))
 			rollback(3)
+			if rbErr != nil {
+				return nil, fmt.Errorf("step 3 – MCP register %s: %w; ROLLBACK INCOMPLETE: %v", cfgPath, err, rbErr)
+			}
 			return nil, fmt.Errorf("step 3 – MCP register %s: %w", cfgPath, err)
 		}
 		registeredPaths = append(registeredPaths, cfgPath)

--- a/internal/install/mcp_rollback_6168_test.go
+++ b/internal/install/mcp_rollback_6168_test.go
@@ -162,7 +162,7 @@ func TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration(t *testing.T) {
 // This test separates the two defects that combine to produce that outcome.
 // With the sidecar backup still alive, a rollback would have RESTORED the
 // pre-existing entry (present, old command) — bad but survivable. With the
-// backup already discarded at step 3, RestorePath degraded to UnregisterPath
+// backup already discarded at step 3, RestoreSnapshot degraded to UnregisterPath
 // and the entry was DELETED outright. Asserting the entry is present at all
 // therefore fails only under the full original code.
 func TestRunCopy_Step4Failure_KeepsAPreexistingGrafelEntry(t *testing.T) {

--- a/internal/install/mcp_rollback_6168_test.go
+++ b/internal/install/mcp_rollback_6168_test.go
@@ -1,0 +1,330 @@
+package install_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// ── #6168 helpers ────────────────────────────────────────────────────────────
+
+// writeConfigWithForeignServer seeds a config file with one non-grafel MCP
+// server so every assertion below can distinguish "grafel entry removed" from
+// "whole file clobbered".
+func writeConfigWithForeignServer(t *testing.T, path string) {
+	t.Helper()
+	doc := map[string]any{
+		"mcpServers": map[string]any{
+			"someoneElse": map[string]any{"command": "/usr/bin/other", "type": "stdio"},
+		},
+	}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed config: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write seed config %s: %v", path, err)
+	}
+}
+
+// mcpServersOf reads the mcpServers map out of a JSON config file.
+func mcpServersOf(t *testing.T, path string) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v (content: %s)", path, err, data)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	return servers
+}
+
+func assertGrafelPresent(t *testing.T, path, why string) {
+	t.Helper()
+	servers := mcpServersOf(t, path)
+	if servers == nil {
+		t.Fatalf("%s: mcpServers key is absent from %s — the whole registration was dropped", why, path)
+	}
+	if _, ok := servers["grafel"]; !ok {
+		t.Fatalf("%s: grafel entry missing from %s (servers: %v)", why, path, servers)
+	}
+}
+
+func assertGrafelAbsent(t *testing.T, path, why string) {
+	t.Helper()
+	servers := mcpServersOf(t, path)
+	if servers == nil {
+		return
+	}
+	if _, ok := servers["grafel"]; ok {
+		t.Fatalf("%s: grafel entry still present in %s", why, path)
+	}
+}
+
+func assertForeignServerIntact(t *testing.T, path, why string) {
+	t.Helper()
+	servers := mcpServersOf(t, path)
+	if servers == nil {
+		t.Fatalf("%s: mcpServers key is absent from %s — foreign server lost", why, path)
+	}
+	if _, ok := servers["someoneElse"]; !ok {
+		t.Fatalf("%s: foreign server 'someoneElse' lost from %s (servers: %v)", why, path, servers)
+	}
+}
+
+// ── 1. A step-4 (daemon) failure must NOT un-register MCP ────────────────────
+
+// TestRunCopy_Step4Failure_KeepsMCPRegistration is the core #6168 regression.
+//
+// Registering an MCP server is not undone by a daemon that failed to restart:
+// the entry is correct either way, and the bridge tolerates a down daemon
+// (internal/cli/mcp_bridge.go answers `initialize` locally and falls back to
+// offlineToolList). Deleting a working registration because an unrelated later
+// step failed is strictly worse for the user than leaving it.
+func TestRunCopy_Step4Failure_KeepsMCPRegistration(t *testing.T) {
+	env := newTestEnv(t)
+	writeConfigWithForeignServer(t, env.claudeJSON)
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false, // let step 4 run and fail
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("injected daemon restart failure (#6168)")
+		},
+	}
+
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected RunCopy to fail when the daemon restart fails")
+	}
+
+	assertGrafelPresent(t, env.claudeJSON, "after a step-4 daemon failure")
+	assertForeignServerIntact(t, env.claudeJSON, "after a step-4 daemon failure")
+	assertMCPRegistered(t, env.claudeJSON, env.fakeBin)
+}
+
+// TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration covers the OTHER step-4
+// exit: the restart "succeeds" but the running daemon reports the wrong
+// version and the escalated restart still cannot fix it (#5850 path). This is
+// exactly the shape a #6167 reindex stampede produces on a saturated box.
+func TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration(t *testing.T) {
+	env := newTestEnv(t)
+	writeConfigWithForeignServer(t, env.claudeJSON)
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		InstalledVersion:  "v9.9.9",
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "ok", nil
+		},
+		EscalateDaemonRestart: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "ok", nil
+		},
+		ProbeDaemonVersion: func() (install.ProbedVersion, error) {
+			// never matches v9.9.9 -> verify fails before and after escalation
+			return install.ProbedVersion{Display: "v0.0.0-stale", Bare: "v0.0.0-stale"}, nil
+		},
+	}
+
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected RunCopy to fail when the daemon version never verifies")
+	}
+
+	assertGrafelPresent(t, env.claudeJSON, "after a step-4 version-verify failure")
+	assertForeignServerIntact(t, env.claudeJSON, "after a step-4 version-verify failure")
+}
+
+// TestRunDev_Step4Failure_KeepsMCPRegistration mirrors the above for DEV mode,
+// which carries a byte-identical copy of the same defect.
+func TestRunDev_Step4Failure_KeepsMCPRegistration(t *testing.T) {
+	env := newTestEnv(t)
+	writeConfigWithForeignServer(t, env.claudeJSON)
+
+	opts := install.DevOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		NoHooks:           true,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("injected daemon restart failure (#6168)")
+		},
+	}
+
+	if _, err := install.RunDev(opts); err == nil {
+		t.Fatal("expected RunDev to fail when the daemon restart fails")
+	}
+
+	assertGrafelPresent(t, env.claudeJSON, "after a DEV-mode step-4 daemon failure")
+	assertForeignServerIntact(t, env.claudeJSON, "after a DEV-mode step-4 daemon failure")
+}
+
+// ── 2. A step-3 failure MID-WAY through the targets must clean up ────────────
+
+// TestRunCopy_Step3PartialFailure_RestoresAlreadyWrittenTargets is the case
+// that genuinely DOES need step 3 undone: the transaction aborts inside the
+// registration loop, so some config files carry a grafel entry and some do
+// not. Before the fix nothing cleaned those up at all — `rollback(3)` fires
+// before `completedSteps` contains 3, so the `case 3` arm never ran, AND
+// `state.MCP.RegisteredPaths` (the only list the arm consulted) was still
+// empty because it is assigned only after the loop completes.
+//
+// The already-written file must come back byte-identical to its pre-install
+// content: foreign server intact, no grafel entry, no orphan `{}`.
+func TestRunCopy_Step3PartialFailure_RestoresAlreadyWrittenTargets(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Target 1: a healthy config that WILL be written.
+	good := env.claudeJSON
+	writeConfigWithForeignServer(t, good)
+	pristine, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read pristine: %v", err)
+	}
+
+	// Target 2: malformed JSON, so RegisterPath fails on it after target 1
+	// has already been modified.
+	bad := filepath.Join(filepath.Dir(good), "broken", ".claude.json")
+	if err := os.MkdirAll(filepath.Dir(bad), 0o755); err != nil {
+		t.Fatalf("mkdir bad: %v", err)
+	}
+	if err := os.WriteFile(bad, []byte("{ this is not json"), 0o644); err != nil {
+		t.Fatalf("write bad config: %v", err)
+	}
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{good, bad},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}
+
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected RunCopy to fail when a step-3 target cannot be registered")
+	}
+
+	got, err := os.ReadFile(good)
+	if err != nil {
+		t.Fatalf("read good config after rollback: %v", err)
+	}
+	if string(got) != string(pristine) {
+		t.Errorf("step-3 partial failure did not restore the already-written target.\n got: %s\nwant: %s", got, pristine)
+	}
+	assertGrafelAbsent(t, good, "after a step-3 partial failure")
+	assertForeignServerIntact(t, good, "after a step-3 partial failure")
+}
+
+// ── 3. The sidecar backup must outlive step 3 ────────────────────────────────
+
+// TestRunCopy_SidecarBackupSurvivesUntilCommit pins the lifetime invariant
+// that makes the restore-becomes-delete trap unreachable: the pristine
+// `.grafel.bak` sidecar is discarded only when the WHOLE transaction commits.
+// While the transaction is still in flight (here: aborted at step 4) the
+// snapshot must still be on disk, so any restore that does run restores rather
+// than degrading to a delete.
+func TestRunCopy_SidecarBackupSurvivesUntilCommit(t *testing.T) {
+	env := newTestEnv(t)
+	writeConfigWithForeignServer(t, env.claudeJSON)
+	sidecar := env.claudeJSON + ".grafel.bak"
+
+	failing := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("injected daemon restart failure (#6168)")
+		},
+	}
+	if _, err := install.RunCopy(failing); err == nil {
+		t.Fatal("expected RunCopy to fail at step 4")
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("sidecar backup %s was discarded while the transaction was still in flight: %v", sidecar, err)
+	}
+
+	// And on a committed install it IS cleared, so the next install snapshots
+	// fresh and a later restore never resurrects grafel-containing content.
+	ok := failing
+	ok.SkipDaemonRestart = true
+	ok.RestartDaemon = nil
+	ok.Force = true
+	if _, err := install.RunCopy(ok); err != nil {
+		t.Fatalf("second RunCopy (committing): %v", err)
+	}
+	if _, err := os.Stat(sidecar); err == nil {
+		t.Errorf("sidecar backup %s still present after a committed install", sidecar)
+	}
+}
+
+// ── 4. `grafel update`'s failure path must not leave the user MCP-less ───────
+
+// TestRunUpdate_ReinstallFailure_LeavesMCPRegistered covers update.go's error
+// path: on a RunCopy error only rollbackBinary() runs, so nothing re-registers
+// MCP. The user must still end up with a working binary AND a working
+// registration pointing at it.
+func TestRunUpdate_ReinstallFailure_LeavesMCPRegistered(t *testing.T) {
+	env := newTestEnv(t)
+	writeConfigWithForeignServer(t, env.claudeJSON)
+
+	newBin := filepath.Join(t.TempDir(), "new-grafel")
+	if err := os.WriteFile(newBin, []byte("#!/bin/sh\necho new-grafel"), 0o755); err != nil {
+		t.Fatalf("write new binary: %v", err)
+	}
+
+	opts := install.UpdateOptions{
+		BinPath:          env.fakeBin,
+		StatePath:        env.statePath,
+		WorkingDir:       env.gitRepo,
+		SkillsSourceDir:  env.skillsSourceDir,
+		ClaudeConfigDirs: []string{env.claudeJSON},
+		Tag:              "v0.0.1-test",
+		DownloadBinary: func(_ *http.Client, _, _, _, destPath string) error {
+			return copyTestFile(newBin, destPath)
+		},
+		// Step 4 of the re-install fails — the #6167 saturated-daemon shape.
+		SkipDaemonRestart: false,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("injected daemon restart failure (#6168)")
+		},
+	}
+
+	if _, err := install.RunUpdate(opts); err == nil {
+		t.Fatal("expected RunUpdate to fail when the re-install's daemon restart fails")
+	}
+
+	// The old binary is back at the same path...
+	if _, err := os.Stat(env.fakeBin); err != nil {
+		t.Fatalf("binary missing after update rollback: %v", err)
+	}
+	// ...and the MCP entry still points at it.
+	assertGrafelPresent(t, env.claudeJSON, "after a failed grafel update")
+	assertForeignServerIntact(t, env.claudeJSON, "after a failed grafel update")
+	assertMCPRegistered(t, env.claudeJSON, env.fakeBin)
+}

--- a/internal/install/mcp_rollback_6168_test.go
+++ b/internal/install/mcp_rollback_6168_test.go
@@ -162,9 +162,9 @@ func TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration(t *testing.T) {
 // This test separates the two defects that combine to produce that outcome.
 // With the sidecar backup still alive, a rollback would have RESTORED the
 // pre-existing entry (present, old command) — bad but survivable. With the
-// backup already discarded at step 3, RestoreSnapshot degraded to UnregisterPath
-// and the entry was DELETED outright. Asserting the entry is present at all
-// therefore fails only under the full original code.
+// backup already discarded at step 3, the then-current RestorePath degraded to
+// UnregisterPath and the entry was DELETED outright. Asserting the entry is
+// present at all therefore fails only under the full original code.
 func TestRunCopy_Step4Failure_KeepsAPreexistingGrafelEntry(t *testing.T) {
 	env := newTestEnv(t)
 	doc := map[string]any{

--- a/internal/install/mcp_rollback_6168_test.go
+++ b/internal/install/mcp_rollback_6168_test.go
@@ -154,6 +154,54 @@ func TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration(t *testing.T) {
 	assertForeignServerIntact(t, env.claudeJSON, "after a step-4 version-verify failure")
 }
 
+// TestRunCopy_Step4Failure_KeepsAPreexistingGrafelEntry is the reporter's own
+// situation: grafel was ALREADY registered, they re-ran `grafel install` on the
+// advice of install.sh, the daemon did not come back, and their MCP server was
+// gone afterwards.
+//
+// This test separates the two defects that combine to produce that outcome.
+// With the sidecar backup still alive, a rollback would have RESTORED the
+// pre-existing entry (present, old command) — bad but survivable. With the
+// backup already discarded at step 3, RestorePath degraded to UnregisterPath
+// and the entry was DELETED outright. Asserting the entry is present at all
+// therefore fails only under the full original code.
+func TestRunCopy_Step4Failure_KeepsAPreexistingGrafelEntry(t *testing.T) {
+	env := newTestEnv(t)
+	doc := map[string]any{
+		"mcpServers": map[string]any{
+			"grafel": map[string]any{"command": "/old/path/grafel", "args": []any{"mcp-bridge"}, "type": "stdio"},
+		},
+	}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal seed: %v", err)
+	}
+	if err := os.WriteFile(env.claudeJSON, b, 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon: func(_ string, _ int, _ time.Duration) (string, error) {
+			return "", fmt.Errorf("injected daemon restart failure (#6168)")
+		},
+	}
+
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected RunCopy to fail when the daemon restart fails")
+	}
+
+	assertGrafelPresent(t, env.claudeJSON, "after a step-4 failure over a pre-existing registration")
+	// The registration must also point at the binary the install just wrote,
+	// not be silently reverted to the stale one.
+	assertMCPRegistered(t, env.claudeJSON, env.fakeBin)
+}
+
 // TestRunDev_Step4Failure_KeepsMCPRegistration mirrors the above for DEV mode,
 // which carries a byte-identical copy of the same defect.
 func TestRunDev_Step4Failure_KeepsMCPRegistration(t *testing.T) {

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -511,7 +511,7 @@ func UnregisterPath(path string) error {
 // ErrNoSnapshot reports that no pristine sidecar backup exists for a config
 // path, so there is nothing to restore.
 //
-// There used to be a RestoreSnapshot that swallowed this condition and fell
+// There used to be a RestorePath that swallowed this condition and fell
 // through to the surgical UnregisterPath instead. That fallback is what turned
 // a rollback into a deletion of the user's MCP entry once the snapshot had been
 // cleared early (#6168), so it was removed rather than documented around: an
@@ -565,8 +565,20 @@ func RestoreSnapshot(path string) error {
 // a SUCCESSFUL install so the next install can take a fresh snapshot (and so a
 // future uninstall does not "restore" stale grafel-containing content).
 // Idempotent: missing backups are ignored.
+//
+// A remove that fails for any other reason is NON-FATAL but warned about: the
+// caller's invariant quietly degrades from "this run snapshots fresh" to "this
+// run inherits whatever was already there", and silence would defer discovery
+// of that to rollback time, when it is expensive (#6168). Callers that need the
+// clear to have worked must check the sidecar themselves.
 func ClearBackup(path string) {
-	_ = os.Remove(sidecarBackupPath(path))
+	sidecar := sidecarBackupPath(path)
+	if err := os.Remove(sidecar); err != nil && !errors.Is(err, os.ErrNotExist) {
+		fmt.Fprintf(os.Stderr,
+			"grafel: warning – could not discard stale MCP backup %s: %v\n"+
+				"  a rollback may restore outdated content; remove it by hand\n",
+			sidecar, err)
+	}
 }
 
 func readSettings(path string) (map[string]any, error) {

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -521,14 +521,37 @@ func UnregisterPath(path string) error {
 //
 // The sidecar backup is removed after a successful restore.
 func RestorePath(path string) error {
+	err := RestoreSnapshot(path)
+	if errors.Is(err, ErrNoSnapshot) {
+		// No snapshot — fall back to surgical removal so we never
+		// clobber foreign servers.
+		return UnregisterPath(path)
+	}
+	return err
+}
+
+// ErrNoSnapshot reports that no pristine sidecar backup exists for a config
+// path, so there is nothing to restore.
+//
+// It exists so callers can distinguish "restore" from "delete". RestorePath
+// deliberately degrades to UnregisterPath in this case, which is right for its
+// documented "registration never ran" caller but catastrophic for a caller
+// that KNOWS a registration ran and merely wants it undone: it silently turns
+// a restore into a removal (#6168). Rollback paths therefore call
+// RestoreSnapshot and surface this error rather than deleting blind.
+var ErrNoSnapshot = errors.New("mcpreg: no pristine snapshot for config path")
+
+// RestoreSnapshot is RestorePath WITHOUT the delete-if-no-snapshot fallback:
+// it restores the pristine sidecar (or removes a file grafel created, per the
+// absent-sentinel) and returns ErrNoSnapshot when there is no snapshot to
+// restore from. It never removes an entry it has no snapshot for.
+func RestoreSnapshot(path string) error {
 	guardResolvedConfigPath(path, "MCP host config")
 	sidecar := sidecarBackupPath(path)
 	b, err := os.ReadFile(sidecar)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
-			// No snapshot — fall back to surgical removal so we never
-			// clobber foreign servers.
-			return UnregisterPath(path)
+			return ErrNoSnapshot
 		}
 		return err
 	}

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -432,7 +432,7 @@ func backupOnce(path string) error {
 //
 // Before its FIRST modification of a given file, RegisterPath snapshots the
 // original (via backupOnce) so a later rollback can restore it exactly — see
-// RestorePath. The merge is surgical: only mcpServers.grafel is added or
+// RestoreSnapshot. The merge is surgical: only mcpServers.grafel is added or
 // updated; every other key and sibling server is preserved.
 func RegisterPath(path, binPath string) (string, error) {
 	guardResolvedConfigPath(path, "MCP host config")
@@ -444,7 +444,7 @@ func RegisterPath(path, binPath string) (string, error) {
 	}
 	if isTOML(path) {
 		// Codex-style TOML host. The same backup/sidecar machinery above
-		// already snapshotted the original, so rollback (RestorePath) is
+		// already snapshotted the original, so rollback (RestoreSnapshot) is
 		// format-agnostic — it restores or deletes the raw bytes.
 		return path, registerTOML(path, binPath)
 	}
@@ -508,43 +508,31 @@ func UnregisterPath(path string) error {
 	return writeSettings(path, doc)
 }
 
-// RestorePath reverses a RegisterPath using the pristine backup taken by
-// backupOnce. This is the rollback/de-register entry point that MUST be used
-// instead of writing `{}`:
+// ErrNoSnapshot reports that no pristine sidecar backup exists for a config
+// path, so there is nothing to restore.
+//
+// There used to be a RestoreSnapshot that swallowed this condition and fell
+// through to the surgical UnregisterPath instead. That fallback is what turned
+// a rollback into a deletion of the user's MCP entry once the snapshot had been
+// cleared early (#6168), so it was removed rather than documented around: an
+// exported function whose contract is "silently converts a restore into a
+// delete" is a trap for the next author who reaches for the obvious-looking
+// name. Callers that genuinely want removal call UnregisterPath, which says so.
+var ErrNoSnapshot = errors.New("mcpreg: no pristine snapshot for config path")
+
+// RestoreSnapshot reverses a RegisterPath using the pristine backup taken by
+// backupOnce. It is the rollback entry point, and MUST be used instead of
+// writing `{}`:
 //
 //   - If grafel CREATED the file (sentinel backup), the file is DELETED so
 //     no orphan `{}` / `{"mcpServers":{}}` is left behind.
 //   - If a real original was backed up, the file is restored byte-for-byte,
 //     bringing back every foreign server and unrelated key exactly.
-//   - If no backup exists (e.g. registration never ran), fall back to the
-//     surgical UnregisterPath so we still only remove grafel's own entry.
+//   - If no backup exists, ErrNoSnapshot is returned and NOTHING is written.
+//     There is nothing this function is entitled to undo, and guessing is how
+//     #6168 deleted registrations it had no snapshot for.
 //
 // The sidecar backup is removed after a successful restore.
-func RestorePath(path string) error {
-	err := RestoreSnapshot(path)
-	if errors.Is(err, ErrNoSnapshot) {
-		// No snapshot — fall back to surgical removal so we never
-		// clobber foreign servers.
-		return UnregisterPath(path)
-	}
-	return err
-}
-
-// ErrNoSnapshot reports that no pristine sidecar backup exists for a config
-// path, so there is nothing to restore.
-//
-// It exists so callers can distinguish "restore" from "delete". RestorePath
-// deliberately degrades to UnregisterPath in this case, which is right for its
-// documented "registration never ran" caller but catastrophic for a caller
-// that KNOWS a registration ran and merely wants it undone: it silently turns
-// a restore into a removal (#6168). Rollback paths therefore call
-// RestoreSnapshot and surface this error rather than deleting blind.
-var ErrNoSnapshot = errors.New("mcpreg: no pristine snapshot for config path")
-
-// RestoreSnapshot is RestorePath WITHOUT the delete-if-no-snapshot fallback:
-// it restores the pristine sidecar (or removes a file grafel created, per the
-// absent-sentinel) and returns ErrNoSnapshot when there is no snapshot to
-// restore from. It never removes an entry it has no snapshot for.
 func RestoreSnapshot(path string) error {
 	guardResolvedConfigPath(path, "MCP host config")
 	sidecar := sidecarBackupPath(path)

--- a/internal/install/mcpreg/mcpreg_test.go
+++ b/internal/install/mcpreg/mcpreg_test.go
@@ -2,6 +2,7 @@ package mcpreg
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -947,7 +948,7 @@ func TestRegisterPreservesForeignServer(t *testing.T) {
 }
 
 // TestRestorePreservesForeignServerOnRollback: register into a config holding a
-// foreign server, then roll back via RestorePath. The foreign server must
+// foreign server, then roll back via RestoreSnapshot. The foreign server must
 // survive and the file must NOT be `{}` — it must equal the original byte-wise.
 func TestRestorePreservesForeignServerOnRollback(t *testing.T) {
 	home := withHome(t)
@@ -963,7 +964,7 @@ func TestRestorePreservesForeignServerOnRollback(t *testing.T) {
 	if _, err := RegisterPath(path, "/bin/grafel"); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestorePath(path); err != nil {
+	if err := RestoreSnapshot(path); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1006,7 +1007,7 @@ func TestRestoreNewFileRemovesOrphan(t *testing.T) {
 		t.Fatalf("register should have created the file: %v", err)
 	}
 
-	if err := RestorePath(path); err != nil {
+	if err := RestoreSnapshot(path); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {
@@ -1090,9 +1091,16 @@ func TestDetectWindsurfPaths_BothCodeiumTargets(t *testing.T) {
 	}
 }
 
-// TestRestoreFallsBackToSurgicalWhenNoBackup: if no sidecar backup exists,
-// RestorePath must still remove only grafel (never wipe foreign servers).
-func TestRestoreFallsBackToSurgicalWhenNoBackup(t *testing.T) {
+// TestUnregisterIsSurgicalWhenNoBackup: removing grafel's entry from a file
+// that was never snapshotted must take out ONLY grafel and never wipe foreign
+// servers.
+//
+// This was TestRestoreFallsBackToSurgicalWhenNoBackup, asserting the same
+// property of RestorePath's no-snapshot fallback. That fallback was deleted
+// with RestorePath (#6168) — a "restore" that deletes is a trap, and callers
+// that want removal now say UnregisterPath. The property is unchanged and
+// still worth pinning; it just belongs to the function that owns it.
+func TestUnregisterIsSurgicalWhenNoBackup(t *testing.T) {
 	home := withHome(t)
 	path := filepath.Join(home, ".claude.json")
 	pre := `{"mcpServers":{"playwright":{"command":"/bin/pw"},"grafel":{"command":"/old"}}}`
@@ -1100,18 +1108,41 @@ func TestRestoreFallsBackToSurgicalWhenNoBackup(t *testing.T) {
 		t.Fatal(err)
 	}
 	// No RegisterPath call → no sidecar backup.
-	if err := RestorePath(path); err != nil {
+	if err := UnregisterPath(path); err != nil {
 		t.Fatal(err)
 	}
 	b, _ := os.ReadFile(path)
 	if string(b) == "{}" || string(b) == "{}\n" {
-		t.Fatalf("restore-without-backup wiped the file: %s", b)
+		t.Fatalf("surgical removal wiped the file: %s", b)
 	}
 	var doc map[string]any
 	_ = json.Unmarshal(b, &doc)
 	servers, _ := doc["mcpServers"].(map[string]any)
 	if _, ok := servers["playwright"]; !ok {
-		t.Fatalf("foreign server lost in fallback restore: %s", b)
+		t.Fatalf("foreign server lost in surgical removal: %s", b)
+	}
+	if _, ok := servers["grafel"]; ok {
+		t.Fatalf("grafel entry not removed: %s", b)
+	}
+}
+
+// TestRestoreSnapshot_NoSnapshotIsInert: with no snapshot, RestoreSnapshot must
+// report ErrNoSnapshot and write NOTHING — not even grafel's own entry is
+// removed. This is the guard that stops a rollback from deleting a
+// registration it has no snapshot for (#6168).
+func TestRestoreSnapshot_NoSnapshotIsInert(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/pw"},"grafel":{"command":"/old"}}}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RestoreSnapshot(path); !errors.Is(err, ErrNoSnapshot) {
+		t.Fatalf("RestoreSnapshot error = %v, want ErrNoSnapshot", err)
+	}
+	b, _ := os.ReadFile(path)
+	if string(b) != pre {
+		t.Fatalf("RestoreSnapshot modified a file it had no snapshot for:\n got: %s\nwant: %s", b, pre)
 	}
 }
 

--- a/internal/install/mcpreg/restore_snapshot_6168_test.go
+++ b/internal/install/mcpreg/restore_snapshot_6168_test.go
@@ -8,36 +8,19 @@ import (
 	"testing"
 )
 
-// #6168: RestorePath's no-snapshot fallback is a trap for any caller whose
-// intent is "undo a registration that DID run". Once the pristine sidecar has
-// been discarded, the "restore" silently becomes a "delete" — which is exactly
-// how an install that got as far as registering MCP, then tripped over an
-// unrelated later step, ended up removing the user's MCP server.
+// #6168: a "restore" that silently becomes a "delete" once its snapshot has
+// been discarded is how an install that got as far as registering MCP, then
+// tripped over an unrelated later step, ended up removing the user's MCP
+// server. The old RestorePath had exactly that fallback; it has been deleted
+// rather than documented around, because an exported name whose contract is
+// "may delete instead" is what the next author reaches for by mistake.
 //
-// RestoreSnapshot exists so that intent is expressible: no snapshot means
-// nothing to restore, reported as ErrNoSnapshot, never acted on.
+// RestoreSnapshot makes the intent explicit: no snapshot means nothing to
+// restore, reported as ErrNoSnapshot, never acted on. Callers that want removal
+// call UnregisterPath, which says so.
 
-// TestRestorePath_DegradesToDeleteWithoutSnapshot pins the documented (and
-// dangerous) behaviour of RestorePath so the difference below is not
-// theoretical.
-func TestRestorePath_DegradesToDeleteWithoutSnapshot(t *testing.T) {
-	home := withHome(t)
-	path := filepath.Join(home, ".claude.json")
-	if _, err := RegisterPath(path, "/bin/grafel"); err != nil {
-		t.Fatalf("RegisterPath: %v", err)
-	}
-	ClearBackup(path) // the discarded-too-early snapshot
-
-	if err := RestorePath(path); err != nil {
-		t.Fatalf("RestorePath: %v", err)
-	}
-	if hasGrafel(t, path) {
-		t.Fatal("RestorePath kept the entry — this test pins the DELETE behaviour it is documented to have")
-	}
-}
-
-// TestRestoreSnapshot_ReportsInsteadOfDeleting is the guard: the same setup
-// must NOT remove the entry.
+// TestRestoreSnapshot_ReportsInsteadOfDeleting: a snapshot discarded mid-flight
+// must NOT cause the entry to be removed.
 func TestRestoreSnapshot_ReportsInsteadOfDeleting(t *testing.T) {
 	home := withHome(t)
 	path := filepath.Join(home, ".claude.json")

--- a/internal/install/mcpreg/restore_snapshot_6168_test.go
+++ b/internal/install/mcpreg/restore_snapshot_6168_test.go
@@ -1,0 +1,98 @@
+package mcpreg
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #6168: RestorePath's no-snapshot fallback is a trap for any caller whose
+// intent is "undo a registration that DID run". Once the pristine sidecar has
+// been discarded, the "restore" silently becomes a "delete" — which is exactly
+// how an install that got as far as registering MCP, then tripped over an
+// unrelated later step, ended up removing the user's MCP server.
+//
+// RestoreSnapshot exists so that intent is expressible: no snapshot means
+// nothing to restore, reported as ErrNoSnapshot, never acted on.
+
+// TestRestorePath_DegradesToDeleteWithoutSnapshot pins the documented (and
+// dangerous) behaviour of RestorePath so the difference below is not
+// theoretical.
+func TestRestorePath_DegradesToDeleteWithoutSnapshot(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	if _, err := RegisterPath(path, "/bin/grafel"); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	ClearBackup(path) // the discarded-too-early snapshot
+
+	if err := RestorePath(path); err != nil {
+		t.Fatalf("RestorePath: %v", err)
+	}
+	if hasGrafel(t, path) {
+		t.Fatal("RestorePath kept the entry — this test pins the DELETE behaviour it is documented to have")
+	}
+}
+
+// TestRestoreSnapshot_ReportsInsteadOfDeleting is the guard: the same setup
+// must NOT remove the entry.
+func TestRestoreSnapshot_ReportsInsteadOfDeleting(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	if _, err := RegisterPath(path, "/bin/grafel"); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	ClearBackup(path)
+
+	err := RestoreSnapshot(path)
+	if !errors.Is(err, ErrNoSnapshot) {
+		t.Fatalf("RestoreSnapshot error = %v, want ErrNoSnapshot", err)
+	}
+	if !hasGrafel(t, path) {
+		t.Fatal("RestoreSnapshot deleted the grafel entry it had no snapshot for (#6168)")
+	}
+}
+
+// TestRestoreSnapshot_RestoresWhenSnapshotExists confirms the happy path is
+// unchanged: a real snapshot is restored byte-for-byte.
+func TestRestoreSnapshot_RestoresWhenSnapshotExists(t *testing.T) {
+	home := withHome(t)
+	path := filepath.Join(home, ".claude.json")
+	pre := `{"mcpServers":{"playwright":{"command":"/bin/playwright"}},"other":"keep"}`
+	if err := os.WriteFile(path, []byte(pre), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := RegisterPath(path, "/bin/grafel"); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	if err := RestoreSnapshot(path); err != nil {
+		t.Fatalf("RestoreSnapshot: %v", err)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(b) != pre {
+		t.Fatalf("not restored byte-for-byte:\n got: %s\nwant: %s", b, pre)
+	}
+}
+
+func hasGrafel(t *testing.T, path string) bool {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(b, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if servers == nil {
+		return false
+	}
+	_, ok := servers[ServerName]
+	return ok
+}

--- a/internal/install/mcpreg/test_isolation_guard.go
+++ b/internal/install/mcpreg/test_isolation_guard.go
@@ -19,7 +19,7 @@ package mcpreg
 // Why guard the writers and not homeDir()/SettingsPath(): a read-only path
 // resolution is harmless and extremely common (used to detect whether a tool
 // is installed); only a WRITE clobbers the developer's live editor config.
-// Guarding RegisterPath/UnregisterPath/RestorePath — BEFORE backupOnce, which
+// Guarding RegisterPath/UnregisterPath/RestoreSnapshot — BEFORE backupOnce, which
 // itself writes a `.grafel.bak` sidecar and an audit copy under
 // ~/.grafel/backups/mcpreg/ — catches every mutating entry point in this
 // package.

--- a/internal/install/mcpreg/test_isolation_guard_test.go
+++ b/internal/install/mcpreg/test_isolation_guard_test.go
@@ -53,9 +53,9 @@ func TestGuard_UnregisterPathPanicsWhenWritingRealHome(t *testing.T) {
 	t.Fatalf("UnregisterPath returned without panicking — guard did not fire")
 }
 
-// TestGuard_RestorePathPanicsWhenWritingRealHome mirrors the above for the
+// TestGuard_RestoreSnapshotPanicsWhenWritingRealHome mirrors the above for the
 // rollback path.
-func TestGuard_RestorePathPanicsWhenWritingRealHome(t *testing.T) {
+func TestGuard_RestoreSnapshotPanicsWhenWritingRealHome(t *testing.T) {
 	if realUserHomeAtInit == "" {
 		t.Skip("no real user home captured")
 	}
@@ -65,8 +65,8 @@ func TestGuard_RestorePathPanicsWhenWritingRealHome(t *testing.T) {
 			t.Fatalf("expected guard panic restoring MCP config at real home %q", escape)
 		}
 	}()
-	_ = RestorePath(escape)
-	t.Fatalf("RestorePath returned without panicking — guard did not fire")
+	_ = RestoreSnapshot(escape)
+	t.Fatalf("RestoreSnapshot returned without panicking — guard did not fire")
 }
 
 // TestGuard_AllowsWriteUnderIsolatedHome proves the guard is inert once the

--- a/internal/install/mcpreg/toml.go
+++ b/internal/install/mcpreg/toml.go
@@ -17,7 +17,7 @@ import (
 // [mcp_servers.grafel] block. Every other table — including foreign MCP
 // servers such as [mcp_servers.other] and unrelated top-level keys — is
 // preserved byte-for-byte. The same backup/sidecar machinery used for the
-// JSON hosts snapshots the original first, so rollback (RestorePath) is
+// JSON hosts snapshots the original first, so rollback (RestoreSnapshot) is
 // format-agnostic.
 
 // codexServerTable is the TOML table header grafel owns in Codex config.

--- a/internal/install/mcpreg/toml_test.go
+++ b/internal/install/mcpreg/toml_test.go
@@ -207,7 +207,7 @@ func TestTOML_RestoreRollsBackToOriginal(t *testing.T) {
 		t.Fatal(err)
 	}
 	// Rollback restores the byte-exact original (backup is format-agnostic).
-	if err := RestorePath(path); err != nil {
+	if err := RestoreSnapshot(path); err != nil {
 		t.Fatal(err)
 	}
 	s, _ := os.ReadFile(path)
@@ -223,7 +223,7 @@ func TestTOML_RestoreDeletesCreatedFile(t *testing.T) {
 	if _, err := Register(Codex, "/bin/grafel", "/r.json"); err != nil {
 		t.Fatal(err)
 	}
-	if err := RestorePath(path); err != nil {
+	if err := RestoreSnapshot(path); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := os.Stat(path); !os.IsNotExist(err) {

--- a/internal/install/stale_sidecar_6168_test.go
+++ b/internal/install/stale_sidecar_6168_test.go
@@ -1,0 +1,224 @@
+package install_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// #6168 follow-up (S1): the pristine sidecar snapshot must never outlive the
+// install run that took it.
+//
+// backupOnce (mcpreg.go:397-402) REFUSES to overwrite an existing sidecar, so
+// whatever snapshot is on disk at the start of a run is the one a rollback in
+// that run will write back. If a run ends without clearing its sidecar — which
+// every step-4 failure does, and a saturated #6167 daemon makes that the COMMON
+// ending — the next run inherits a snapshot that is arbitrarily stale. A step-3
+// mid-loop failure in that later run then restores weeks-old content over the
+// user's live config.
+//
+// This is the invariant the original "so the next install snapshots fresh"
+// comment was protecting. It was load-bearing, not cargo.
+
+// failingRestart is the injected step-4 failure used to end a run without
+// committing.
+func failingRestart(_ string, _ int, _ time.Duration) (string, error) {
+	return "", fmt.Errorf("injected daemon restart failure (#6168 S1)")
+}
+
+// malformedTarget writes an unparseable config so RegisterPath fails on it,
+// aborting step 3 part-way through the target list.
+func malformedTarget(t *testing.T, dir string) string {
+	t.Helper()
+	p := filepath.Join(dir, "broken", ".claude.json")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(p, []byte("{ not json"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	return p
+}
+
+// TestStaleSidecar_AbsentSentinelDoesNotDeleteTheUsersConfig is the
+// catastrophic case.
+//
+// Run 1 is a first-ever install: no .claude.json exists, so the sidecar is the
+// GRAFEL_BACKUP_ORIGINAL_ABSENT sentinel. Step 4 fails, so the run never
+// commits. If the sentinel is left on disk, run 2's step-3 rollback takes
+// RestoreSnapshot's sentinel branch — os.Remove(path) — and deletes the config
+// file the user has since filled with real state: every foreign MCP server and
+// all unrelated Claude Code keys.
+func TestStaleSidecar_AbsentSentinelDoesNotDeleteTheUsersConfig(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Run 1: first-ever install — the config must NOT exist beforehand.
+	if err := os.Remove(env.claudeJSON); err != nil {
+		t.Fatalf("remove seed config: %v", err)
+	}
+
+	run1 := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon:     failingRestart,
+	}
+	if _, err := install.RunCopy(run1); err == nil {
+		t.Fatal("run 1: expected a step-4 failure")
+	}
+
+	// Between runs the user keeps using Claude Code: the config now holds real
+	// state that exists nowhere else.
+	live := map[string]any{
+		"mcpServers": map[string]any{
+			"playwright": map[string]any{"command": "/bin/playwright", "type": "stdio"},
+		},
+		"projects":       map[string]any{"/home/u/work": map[string]any{"allowedTools": []any{}}},
+		"oauthAccount":   map[string]any{"emailAddress": "u@example.com"},
+		"numStartups":    41,
+		"userIDOverride": "keep-me",
+	}
+	b, err := json.MarshalIndent(live, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal live config: %v", err)
+	}
+	if err := os.WriteFile(env.claudeJSON, b, 0o644); err != nil {
+		t.Fatalf("write live config: %v", err)
+	}
+
+	// Run 2 aborts inside step 3, triggering the mid-loop restore.
+	run2 := run1
+	run2.Force = true // run 1 left PartialInstall=true
+	run2.SkipDaemonRestart = true
+	run2.RestartDaemon = nil
+	run2.ClaudeConfigDirs = []string{env.claudeJSON, malformedTarget(t, filepath.Dir(env.claudeJSON))}
+	if _, err := install.RunCopy(run2); err == nil {
+		t.Fatal("run 2: expected a step-3 failure")
+	}
+
+	// The user's config must still be there. Deleting it is unrecoverable.
+	raw, err := os.ReadFile(env.claudeJSON)
+	if err != nil {
+		t.Fatalf("the user's .claude.json was DELETED by a stale absent-sentinel snapshot: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse config after run 2: %v (content: %s)", err, raw)
+	}
+	if got["userIDOverride"] != "keep-me" {
+		t.Errorf("unrelated Claude Code state lost: userIDOverride = %v, want \"keep-me\" (content: %s)", got["userIDOverride"], raw)
+	}
+	servers, _ := got["mcpServers"].(map[string]any)
+	if _, ok := servers["playwright"]; !ok {
+		t.Errorf("foreign MCP server 'playwright' lost (content: %s)", raw)
+	}
+}
+
+// TestStaleSidecar_DoesNotResurrectAnOldSnapshotOverLiveContent is the normal
+// (non-sentinel) case: a server the user added BETWEEN runs is silently
+// destroyed when run 2 restores run 1's snapshot.
+func TestStaleSidecar_DoesNotResurrectAnOldSnapshotOverLiveContent(t *testing.T) {
+	env := newTestEnv(t)
+
+	// Pre-existing config with one foreign server.
+	seed := `{
+  "mcpServers": {
+    "alpha": {
+      "command": "/bin/alpha",
+      "type": "stdio"
+    }
+  }
+}`
+	if err := os.WriteFile(env.claudeJSON, []byte(seed), 0o644); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	run1 := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon:     failingRestart,
+	}
+	if _, err := install.RunCopy(run1); err == nil {
+		t.Fatal("run 1: expected a step-4 failure")
+	}
+
+	// Between runs the user adds a SECOND MCP server by hand.
+	cur := mcpServersOf(t, env.claudeJSON)
+	if cur == nil {
+		cur = map[string]any{}
+	}
+	cur["beta"] = map[string]any{"command": "/bin/beta", "type": "stdio"}
+	doc := map[string]any{"mcpServers": cur}
+	b, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(env.claudeJSON, b, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	run2 := run1
+	run2.Force = true
+	run2.SkipDaemonRestart = true
+	run2.RestartDaemon = nil
+	run2.ClaudeConfigDirs = []string{env.claudeJSON, malformedTarget(t, filepath.Dir(env.claudeJSON))}
+	if _, err := install.RunCopy(run2); err == nil {
+		t.Fatal("run 2: expected a step-3 failure")
+	}
+
+	after := mcpServersOf(t, env.claudeJSON)
+	if after == nil {
+		t.Fatal("mcpServers key gone after run 2")
+	}
+	if _, ok := after["beta"]; !ok {
+		t.Errorf("foreign server 'beta', added between runs, was destroyed by run 1's stale snapshot (servers: %v)", after)
+	}
+	if _, ok := after["alpha"]; !ok {
+		t.Errorf("foreign server 'alpha' lost (servers: %v)", after)
+	}
+}
+
+// TestStaleSidecar_NoSidecarSurvivesAStep4Failure states the invariant
+// directly: no run may leave a sidecar behind for the next run to inherit.
+func TestStaleSidecar_NoSidecarSurvivesAStep4Failure(t *testing.T) {
+	env := newTestEnv(t)
+	sidecar := env.claudeJSON + ".grafel.bak"
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon:     failingRestart,
+	}
+	if _, err := install.RunCopy(opts); err == nil {
+		t.Fatal("expected a step-4 failure")
+	}
+
+	// The failed run may leave one (it is still the in-flight snapshot), but
+	// the NEXT run must not inherit it: starting step 3 clears stale sidecars.
+	next := opts
+	next.Force = true
+	next.SkipDaemonRestart = true
+	next.RestartDaemon = nil
+	if _, err := install.RunCopy(next); err != nil {
+		t.Fatalf("second RunCopy: %v", err)
+	}
+	if _, err := os.Stat(sidecar); err == nil {
+		t.Errorf("sidecar %s survived a committed install", sidecar)
+	}
+}

--- a/internal/install/stale_sidecar_6168_test.go
+++ b/internal/install/stale_sidecar_6168_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -315,5 +316,50 @@ func TestStaleSidecar_NoSidecarSurvivesAStep4Failure(t *testing.T) {
 	}
 	if _, err := os.Stat(sidecar); err == nil {
 		t.Errorf("sidecar %s survived a committed install", sidecar)
+	}
+}
+
+// TestRollback_SurfacesAFailedRestore (#6168 S4): when a mid-loop step-3 abort
+// cannot restore an already-written target, the returned error must say so.
+// Reporting only "MCP register <bad> failed" would leave the user with a
+// partially-modified multi-host state and no signal that the other host needs
+// attention.
+//
+// The restore is made to fail without touching production code by occupying
+// the sidecar path with a non-empty DIRECTORY: ClearBackup's os.Remove cannot
+// unlink it, backupOnce's os.Stat sees "a backup already exists" and no-ops,
+// and RestoreSnapshot's os.ReadFile then fails with EISDIR — a real error that
+// is neither nil nor ErrNoSnapshot.
+func TestRollback_SurfacesAFailedRestore(t *testing.T) {
+	env := newTestEnv(t)
+
+	good := env.claudeJSON
+	writeConfigWithForeignServer(t, good)
+
+	occupied := good + ".grafel.bak"
+	if err := os.MkdirAll(filepath.Join(occupied, "sub"), 0o755); err != nil {
+		t.Fatalf("occupy sidecar path: %v", err)
+	}
+
+	bad := malformedTarget(t, filepath.Dir(good))
+
+	opts := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{good, bad},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}
+
+	_, err := install.RunCopy(opts)
+	if err == nil {
+		t.Fatal("expected RunCopy to fail on the malformed target")
+	}
+	if !strings.Contains(err.Error(), "ROLLBACK INCOMPLETE") {
+		t.Errorf("error does not surface the failed restore: %v", err)
+	}
+	if !strings.Contains(err.Error(), good) {
+		t.Errorf("error does not name the unrestored path %s: %v", good, err)
 	}
 }

--- a/internal/install/stale_sidecar_6168_test.go
+++ b/internal/install/stale_sidecar_6168_test.go
@@ -190,6 +190,101 @@ func TestStaleSidecar_DoesNotResurrectAnOldSnapshotOverLiveContent(t *testing.T)
 	}
 }
 
+// TestStaleSidecar_DevModeAlsoDiscardsStaleSnapshots covers the dev.go mirror.
+// An unguarded copy of this hole is exactly how the class of bug survives a
+// fix, so the mirror gets its own probe rather than relying on inspection.
+func TestStaleSidecar_DevModeAlsoDiscardsStaleSnapshots(t *testing.T) {
+	env := newTestEnv(t)
+	if err := os.Remove(env.claudeJSON); err != nil {
+		t.Fatalf("remove seed config: %v", err)
+	}
+
+	run1 := install.DevOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		NoHooks:           true,
+		RestartDaemon:     failingRestart,
+	}
+	if _, err := install.RunDev(run1); err == nil {
+		t.Fatal("run 1: expected a step-4 failure")
+	}
+
+	live := `{
+  "mcpServers": {
+    "playwright": {
+      "command": "/bin/playwright",
+      "type": "stdio"
+    }
+  },
+  "userIDOverride": "keep-me"
+}`
+	if err := os.WriteFile(env.claudeJSON, []byte(live), 0o644); err != nil {
+		t.Fatalf("write live config: %v", err)
+	}
+
+	run2 := run1
+	run2.Force = true
+	run2.SkipDaemonRestart = true
+	run2.RestartDaemon = nil
+	run2.ClaudeConfigDirs = []string{env.claudeJSON, malformedTarget(t, filepath.Dir(env.claudeJSON))}
+	if _, err := install.RunDev(run2); err == nil {
+		t.Fatal("run 2: expected a step-3 failure")
+	}
+
+	raw, err := os.ReadFile(env.claudeJSON)
+	if err != nil {
+		t.Fatalf("DEV mode: the user's .claude.json was DELETED by a stale absent-sentinel snapshot: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("parse: %v (content: %s)", err, raw)
+	}
+	if got["userIDOverride"] != "keep-me" {
+		t.Errorf("DEV mode: unrelated state lost (content: %s)", raw)
+	}
+}
+
+// TestStaleSidecar_UninstallSweepsOrphanedSidecars (#6168 S2): a failed install
+// leaves a `<config>.grafel.bak` in the user's home. Nothing else removes it —
+// the install clears sidecars only on paths a failed run never reaches, and the
+// uninstall MCP loop is surgical and never consults them — so without an
+// explicit sweep the file survives `grafel uninstall` forever.
+func TestStaleSidecar_UninstallSweepsOrphanedSidecars(t *testing.T) {
+	env := newTestEnv(t)
+	sidecar := env.claudeJSON + ".grafel.bak"
+
+	failed := install.CopyOptions{
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: false,
+		RestartDaemon:     failingRestart,
+	}
+	if _, err := install.RunCopy(failed); err == nil {
+		t.Fatal("expected a step-4 failure")
+	}
+	if _, err := os.Stat(sidecar); err != nil {
+		t.Fatalf("precondition: expected an orphaned sidecar at %s: %v", sidecar, err)
+	}
+
+	if _, err := install.RunUninstall(install.UninstallOptions{
+		StatePath:      env.statePath,
+		SkipDaemonStop: true,
+	}); err != nil {
+		t.Fatalf("RunUninstall: %v", err)
+	}
+
+	if _, err := os.Stat(sidecar); err == nil {
+		t.Errorf("orphaned sidecar %s survived grafel uninstall", sidecar)
+	}
+}
+
 // TestStaleSidecar_NoSidecarSurvivesAStep4Failure states the invariant
 // directly: no run may leave a sidecar behind for the next run to inherit.
 func TestStaleSidecar_NoSidecarSurvivesAStep4Failure(t *testing.T) {

--- a/internal/install/uninstall.go
+++ b/internal/install/uninstall.go
@@ -268,6 +268,12 @@ func RunUninstall(opts UninstallOptions) (*UninstallResult, error) {
 		} else {
 			result.MCPPaths = append(result.MCPPaths, cfgPath)
 		}
+		// Sweep any pristine sidecar left by a FAILED install (#6168 S2).
+		// Nothing else ever removes these: the install clears them only on a
+		// path that a failed run never reaches, and this loop is surgical and
+		// never consults them. Without this, `<config>.grafel.bak` sits in the
+		// user's home permanently and survives `grafel uninstall`.
+		mcpreg.ClearBackup(cfgPath)
 	}
 
 	// ── Step 2b: Sweep every enabled tool's own MCP config (#5258) ────────────


### PR DESCRIPTION
A user's MCP server disappeared from Claude Code after a curl upgrade. The installer did not remove it — `install.sh` touches no MCP config on any path. **`grafel install` deleted it, because an unrelated daemon restart failed.**

## The chain

`RunCopy` treated step 3 (MCP registration) as one atomic transaction with step 4 (daemon restart):

1. `copy.go:692` — step 3 registers successfully.
2. `copy.go:707-711` — on success it **discards the pristine sidecar backup** of every config it wrote, carrying this comment:

   > `// (Rollback only fires on FAILURE, before this point.)`

   That comment is the defect's own false justification. `rollback(4)` fires strictly *after* it.
3. `copy.go:731-755` — any step-4 failure calls `rollback(4)`, which replays `completedSteps` in reverse and hits `case 3`.
4. `mcpreg.go:526-532` — `RestorePath` finds no sidecar and **falls through to `UnregisterPath`**. `delete(servers, "grafel")`.

A restore silently becomes a delete because its snapshot was already thrown away. The registration was correct and harmless; a wedged daemon is not a reason to remove it.

**This is live, not theoretical.** #6167 — a format-version bump enqueues every pre-upgrade repo for a full reindex at once — makes the daemon stop answering for hours, so step 4's restart-and-verify fails *by construction*. And `install.sh:421` prints `run 'grafel install' to finish`, steering the user straight into it.

## Step 3 does not belong in the step-4+ rollback set

Verified, not assumed: `mcp_bridge.go:559-579` answers `initialize` **locally** — the comment says it exists to avoid "a race where the daemon might not be running yet" — and `:597` falls back to `offlineToolList` when the daemon is unreachable. **A registration whose daemon is down is a working registration.** The entry's only content is `command: opts.BinPath`, already installed and hashed at step 1. Nothing step 4 does can make it wrong.

`dev.go` carried a byte-identical copy of the same defect (`dev.go:150-151`, `:255`) and got the same fix.

## A second defect inside the first

An *earlier*-step failure genuinely does need cleanup, and today it gets none. `rollback(3)` at `copy.go:693` fires while `completedSteps` is `[1,2]` — the `case 3` arm never runs. And `state.MCP.RegisteredPaths` is assigned only *after* the loop (`copy.go:713`), so the arm had an empty list to work from anyway. **A two-target install that failed on target 2 left target 1 modified with zero cleanup.** Fixed at the failure site, where the written set is actually known.

## The first revision of this fix was worse than the bug

Review caught it, measured. `backupOnce` (`mcpreg.go:397-402`) **refuses to overwrite an existing sidecar**, so moving `ClearBackup` to commit-time — unreachable on any step-4 failure — meant a sidecar was orphaned on disk forever, and the *next* run's "pristine" snapshot was the previous run's, weeks stale. Probes, `origin/main` vs the pre-fix branch:

| | main | rev 1 |
|---|---|---|
| `TestStaleSidecar_AbsentSentinelDoesNotDeleteTheUsersConfig` | PASS | **FAIL** |
| `TestStaleSidecar_DoesNotResurrectAnOldSnapshotOverLiveContent` | PASS | **FAIL** |

Worst case: first-ever install, sidecar is the `ORIGINAL_ABSENT` sentinel, step 4 fails, sentinel orphaned. The next step-3 failure takes the sentinel branch → `os.Remove(path)` → **the user's entire `.claude.json` deleted**, every foreign MCP server and all unrelated state with it.

So the original `ClearBackup` was **load-bearing** — its *stated reason* was false, but the action was holding an invariant nobody had written down. Fixed properly: `discardStaleMCPBackups` at the **start** of step 3, before the register loop, *in addition to* the commit-time clear. Both invariants now hold independently — a snapshot always describes the config as it is now, **and** it survives until the transaction commits.

## `RestorePath` is deleted, not kept

The first revision added an intent-explicit `RestoreSnapshot` returning `ErrNoSnapshot`, and kept `RestorePath` — leaving a surviving mutant that could only be explained, not killed. Review's conclusion was right: an unused API whose documented behaviour is "silently converts a restore into a delete", plus a new test **pinning that behaviour as correct**, is how this defect gets reintroduced by the next author reaching for the obvious-looking function.

`RestorePath` is gone. Five test call sites migrated. `TestRestorePath_DegradesToDeleteWithoutSnapshot` replaced by `TestRestoreSnapshot_NoSnapshotIsInert` asserting byte-identity. `TestRestoreFallsBackToSurgicalWhenNoBackup` → `TestUnregisterIsSurgicalWhenNoBackup`, which review judged to *strengthen* the property — it now also asserts grafel was actually removed. The sentinel/absent-original branch, `RestorePath`'s most dangerous arm, remains reachable and covered on `RestoreSnapshot`.

## A refuted claim, recorded because it cost real time

While verifying, an orphaned pre-registration sidecar was found on a maintainer's machine — `~/.claude.json.grafel.bak`, Jul 10, containing `[pencil, playwright]` with no grafel, beside a live config containing all three. It looked like a second route to the same symptom: `RestorePath` finds a sidecar that *does* exist and restores it verbatim.

**Measured and refuted.** On main, that scenario yields surgical removal with unrelated keys surviving — route 1, exactly as filed. `case 3` is reachable only when `3 ∈ completedSteps`, and the only path to that append runs *through* the step-3-success `ClearBackup` loop, which clears unconditionally by path — orphans included. `RestorePath` can never observe one.

The orphan is inert on main. It was armed only by **revision 1 of this branch**, and revision 2 disarms it. Its actual source is one of five callers that create sidecars and never clear them (`cli/install.go:34`, `install/install.go:321`, `tooldelta.go:44`, `cli/update.go:87`, `dashboard/v2_wizard.go:362`) — unchanged here and harmless, since no restore path reads them.

## Also

`uninstall` now sweeps sidecars alongside `UnregisterPath`. `rollbackMCPRegistration` returns which paths failed to restore, and callers surface `ROLLBACK INCOMPLETE: …` rather than swallowing it. `ClearBackup` warns on a non-`ENOENT` remove failure, so the invariant degrading from "fresh snapshot" to "no snapshot" is visible when it happens instead of at rollback time.

`update.go` needed **no change**, and this is verified rather than reasoned: `RunUpdate` restores the old binary to the same path the entry points at, so once `RunCopy` stops deleting, the failure path ends with a working binary *and* a correct registration. `TestRunUpdate_ReinstallFailure_LeavesMCPRegistered` proves it end-to-end and dies under the rollback mutants.

## Verification

`go build ./...` → 0, `go vet` → 0, `gofmt -l .` → empty. `./internal/install/...` → **0 with no `-skip`** (all 10 packages), `./internal/cli/` → 0. Exit codes from an unpiped `$?`, `GOMAXPROCS=4`, `-count=1 -p 1`.

`./cmd/grafel/` deliberately not re-run: `go build ./...` covers the deleted symbol, grep confirms no reference outside `internal/install/mcpreg`, and no production file outside `internal/install`, `internal/install/mcpreg` and `uninstall.go` changed.

**No surviving mutants.** The one that survived revision 1 is gone because the function it targeted no longer exists. The pair worth reading: reinstating the old rollback with backups kept yields a **stale** entry; reinstating the exact original code yields **no** entry — and only the second matches the reporter's symptom, which is how we know the right defect is fixed.

Independently adversarially reviewed twice (REQUEST-CHANGES → APPROVE).

## Filed separately, not fixed here

- **#6170** — the wizard ratchets a lost registration into a permanent opt-out: once the entry is gone `hasGrafel` is false, Claude Code arrives unchecked, and pressing enter persists the removal into `GroupConfig.Tools`. The existing last-choice override protects almost nobody, since `wizard.go:484-488` records that its backing file "fires RARELY" since #44.
- **#6172** — `uninstall`'s step-2b loop misses `ClearBackup` for every non-Claude host (Cursor, Codex, Kiro, Zed, Antigravity, ContinueDev). Litter only; verified no restore path reads those.
- **#6169** — a first-ever curl install never registers MCP at all.

Closes #6168
Refs #6167, #6169, #6170, #6172
