### PR TITLE
fix(#6167): a 140-repo format-version migration stampeded the daemon for hours

### DIFF
--- a/internal/cli/status_migration_6167_test.go
+++ b/internal/cli/status_migration_6167_test.go
@@ -1,0 +1,153 @@
+package cli
+
+// status_migration_6167_test.go — #6167 half 2: a graph-format migration must
+// be VISIBLE.
+//
+// A user with 140 registered repos upgraded across an fbversion bump and their
+// daemon spent hours reindexing. `grafel status` said nothing about it, so the
+// only available reading was "the product is hung" — which led to restarts that
+// re-entered the queue. The daemon already recomputes ReindexRequired into every
+// repo's statusfile on each heartbeat (internal/daemon/statuswriter.go:135) and
+// ComputeStatusSummary already reads that statusfile (status_stats.go:117), so
+// surfacing this costs no extra I/O and no graph load (the #5995 contract).
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+// seedRepoWithStatusfile creates a repo with a valid graph.fb and a statusfile
+// carrying the given reindex-required state, mirroring what the engine's status
+// writer would have persisted.
+func seedRepoWithStatusfile(t *testing.T, root, slug string, reindexRequired bool) registry.Repo {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 1, Relationships: 0, Files: 1},
+		Entities:    []graph.Entity{{ID: "e1", Name: "E", Kind: "function", SourceFile: "a.go", Language: "go"}},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	f := &statusfile.File{RepoPath: repoPath, ReindexRequired: reindexRequired}
+	if reindexRequired {
+		f.ReindexReason = "graph.fb format version 4 is older than required version 5 — please reindex"
+	}
+	if err := statusfile.Write(repoPath, f); err != nil {
+		t.Fatalf("statusfile.Write: %v", err)
+	}
+	return registry.Repo{Slug: slug, Path: repoPath}
+}
+
+// TestStatusSummary_CountsReposAwaitingFormatMigration proves the count is
+// derived from the statusfile the engine already maintains.
+func TestStatusSummary_CountsReposAwaitingFormatMigration(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	repos := []registry.Repo{
+		seedRepoWithStatusfile(t, root, "stale-a", true),
+		seedRepoWithStatusfile(t, root, "stale-b", true),
+		seedRepoWithStatusfile(t, root, "current-c", false),
+	}
+
+	summary := ComputeStatusSummary("grp", repos)
+
+	if summary.ReindexRequired != 2 {
+		t.Errorf("summary.ReindexRequired = %d, want 2", summary.ReindexRequired)
+	}
+	if rs := summary.RepoStats["stale-a"]; rs == nil || !rs.ReindexRequired {
+		t.Errorf("stale-a: ReindexRequired = %v, want true", rs)
+	}
+	if rs := summary.RepoStats["current-c"]; rs == nil || rs.ReindexRequired {
+		t.Errorf("current-c: ReindexRequired = %v, want false", rs)
+	}
+}
+
+// TestPrintStatusSummary_ShowsMigrationProgress is the user-facing half: with a
+// migration underway the output must say so, name it as a format upgrade, and
+// carry both the remaining count and the denominator, so "24 of 140" reads as
+// progress rather than a hang.
+func TestPrintStatusSummary_ShowsMigrationProgress(t *testing.T) {
+	s := &StatusSummary{
+		GroupName: "grp",
+		RepoStats: map[string]*RepoStatus{},
+	}
+	for i := 0; i < 140; i++ {
+		slug := "r" + itoaPad(i)
+		s.RepoStats[slug] = &RepoStatus{Slug: slug, Path: "/repo/" + slug, LastIndexedAge: "1m ago"}
+	}
+	i := 0
+	for _, rs := range s.RepoStats {
+		if i < 24 {
+			rs.ReindexRequired = true
+		}
+		i++
+	}
+	s.ReindexRequired = 24
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+
+	if !strings.Contains(strings.ToLower(out), "format upgrade") {
+		t.Errorf("output does not name the cause (%q missing):\n%s", "format upgrade", out)
+	}
+	if !strings.Contains(out, "24") || !strings.Contains(out, "140") {
+		t.Errorf("output must carry both the remaining count (24) and the total (140):\n%s", out)
+	}
+	if !strings.Contains(out, "reindex") {
+		t.Errorf("output must say what is happening (reindex):\n%s", out)
+	}
+}
+
+// TestPrintStatusSummary_SilentWhenNoMigration is the zero-noise guard: the
+// overwhelming majority of runs have no migration underway, and a status line
+// that is always present is a line users stop reading. It also keeps the
+// byte-for-byte golden in status_output_parity_5995_test.go valid.
+func TestPrintStatusSummary_SilentWhenNoMigration(t *testing.T) {
+	s := &StatusSummary{
+		GroupName: "grp",
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago"},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+
+	for _, forbidden := range []string{"format upgrade", "migrat", "awaiting reindex"} {
+		if strings.Contains(strings.ToLower(out), forbidden) {
+			t.Errorf("output mentions %q with no migration underway — must be silent:\n%s", forbidden, out)
+		}
+	}
+}
+
+func itoaPad(i int) string {
+	s := ""
+	for _, d := range []int{100, 10, 1} {
+		s += string(rune('0' + (i/d)%10))
+	}
+	return s
+}

--- a/internal/cli/status_migration_6167_test.go
+++ b/internal/cli/status_migration_6167_test.go
@@ -49,7 +49,37 @@ func seedRepoWithStatusfile(t *testing.T, root, slug string, reindexRequired boo
 	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
 		t.Fatalf("write graph.fb: %v", err)
 	}
-	f := &statusfile.File{RepoPath: repoPath, ReindexRequired: reindexRequired}
+	return seedRepoWithStatusfileAtInner(t, repoPath, slug, reindexRequired, time.Now())
+}
+
+// seedRepoWithStatusfileAt is seedRepoWithStatusfile with an explicit heartbeat
+// time, for exercising the liveness gate.
+func seedRepoWithStatusfileAt(t *testing.T, root, slug string, reindexRequired bool, heartbeatAt time.Time) registry.Repo {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		Repo:        repoPath,
+		Stats:       graph.Stats{Entities: 1, Relationships: 0, Files: 1},
+		Entities:    []graph.Entity{{ID: "e1", Name: "E", Kind: "function", SourceFile: "a.go", Language: "go"}},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	return seedRepoWithStatusfileAtInner(t, repoPath, slug, reindexRequired, heartbeatAt)
+}
+
+func seedRepoWithStatusfileAtInner(t *testing.T, repoPath, slug string, reindexRequired bool, heartbeatAt time.Time) registry.Repo {
+	t.Helper()
+	f := &statusfile.File{RepoPath: repoPath, ReindexRequired: reindexRequired, HeartbeatAt: heartbeatAt}
 	if reindexRequired {
 		f.ReindexReason = "graph.fb format version 4 is older than required version 5 — please reindex"
 	}
@@ -150,4 +180,81 @@ func itoaPad(i int) string {
 		s += string(rune('0' + (i/d)%10))
 	}
 	return s
+}
+
+// TestPrintStatusSummary_DoesNotClaimProgressWhenEngineIsGone is review
+// finding 3. statusfile.Read is a plain unmarshal with no freshness gate, so a
+// stopped daemon leaves the last heartbeat's ReindexRequired=true on disk
+// forever. The old line then told the user "grafel is migrating them
+// automatically ... No action needed" while nothing whatsoever was running —
+// the exact opposite of the correct advice, which is to start the daemon.
+func TestPrintStatusSummary_DoesNotClaimProgressWhenEngineIsGone(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:       "grp",
+		ReindexRequired: 3,
+		MigrationLive:   false, // engine not heartbeating
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := buf.String()
+
+	if strings.Contains(strings.ToLower(out), "no action needed") {
+		t.Errorf("claims no action needed while the engine is not running:\n%s", out)
+	}
+	if !strings.Contains(strings.ToLower(out), "not running") && !strings.Contains(strings.ToLower(out), "grafel start") {
+		t.Errorf("must tell the user to start the daemon — that IS the action:\n%s", out)
+	}
+}
+
+// TestPrintStatusSummary_ReportsGivenUpRepos proves the migration's give-up is
+// visible. A repo the engine has abandoned still has ReindexRequired=true, so
+// without this it would be counted as "in progress" forever.
+func TestPrintStatusSummary_ReportsGivenUpRepos(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:       "grp",
+		ReindexRequired: 2,
+		MigrationFailed: 2,
+		MigrationLive:   true,
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+			"b": {Slug: "b", Path: "/repo/b", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := strings.ToLower(buf.String())
+
+	if !strings.Contains(out, "could not be migrated") {
+		t.Errorf("abandoned repos must be reported, not counted as in-progress:\n%s", out)
+	}
+	if !strings.Contains(out, "grafel index") {
+		t.Errorf("must name the manual fix:\n%s", out)
+	}
+}
+
+// TestComputeStatusSummary_MigrationLivenessFromHeartbeat proves the liveness
+// signal is derived from the statusfile's own HeartbeatAt, so it needs no
+// daemon dial and works exactly where the rest of this registry-based summary
+// works.
+func TestComputeStatusSummary_MigrationLivenessFromHeartbeat(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+
+	fresh := seedRepoWithStatusfileAt(t, root, "fresh", true, time.Now())
+	summary := ComputeStatusSummary("grp", []registry.Repo{fresh})
+	if !summary.MigrationLive {
+		t.Error("a repo heartbeating right now must read as a live migration")
+	}
+
+	root2 := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root2)
+	stale := seedRepoWithStatusfileAt(t, root2, "stale", true, time.Now().Add(-30*time.Minute))
+	summary2 := ComputeStatusSummary("grp", []registry.Repo{stale})
+	if summary2.MigrationLive {
+		t.Error("a 30-minute-old heartbeat must NOT read as a live migration")
+	}
 }

--- a/internal/cli/status_migration_6167_test.go
+++ b/internal/cli/status_migration_6167_test.go
@@ -213,14 +213,17 @@ func TestPrintStatusSummary_DoesNotClaimProgressWhenEngineIsGone(t *testing.T) {
 // visible. A repo the engine has abandoned still has ReindexRequired=true, so
 // without this it would be counted as "in progress" forever.
 func TestPrintStatusSummary_ReportsGivenUpRepos(t *testing.T) {
+	// Three stale repos, two of them given up on: one is genuinely still in
+	// progress, so both lines are expected and the counts must not overlap.
 	s := &StatusSummary{
 		GroupName:       "grp",
-		ReindexRequired: 2,
+		ReindexRequired: 3,
 		MigrationFailed: 2,
 		MigrationLive:   true,
 		RepoStats: map[string]*RepoStatus{
 			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
 			"b": {Slug: "b", Path: "/repo/b", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+			"c": {Slug: "c", Path: "/repo/c", LastIndexedAge: "1m ago", ReindexRequired: true},
 		},
 	}
 	var buf bytes.Buffer
@@ -232,6 +235,73 @@ func TestPrintStatusSummary_ReportsGivenUpRepos(t *testing.T) {
 	}
 	if !strings.Contains(out, "grafel index") {
 		t.Errorf("must name the manual fix:\n%s", out)
+	}
+	// The in-progress count must EXCLUDE the given-up repos: 3 stale - 2 failed
+	// = 1 actually migrating. The docstring claimed this; nothing asserted it.
+	if !strings.Contains(out, "1 of 3 repo(s)") {
+		t.Errorf("in-progress line must count only the 1 repo still being migrated, not all 3:\n%s", out)
+	}
+}
+
+// TestPrintStatusSummary_AllGivenUpIsNotAlsoInProgress is review round-3 LOW 5.
+// When every remaining stale repo has been given up on, `active` is 0 but the
+// gate still fired, printing "0 of 3 repo(s) ... awaiting reindex — grafel is
+// migrating them automatically ... No action needed" directly above a warning
+// that 3 repos could not be migrated. The two lines contradicted each other,
+// and the round-2 fixture used ReindexRequired == MigrationFailed so it
+// RENDERED that pair and passed anyway.
+func TestPrintStatusSummary_AllGivenUpIsNotAlsoInProgress(t *testing.T) {
+	s := &StatusSummary{
+		GroupName:       "grp",
+		ReindexRequired: 3,
+		MigrationFailed: 3,
+		MigrationLive:   true,
+		RepoStats: map[string]*RepoStatus{
+			"a": {Slug: "a", Path: "/repo/a", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+			"b": {Slug: "b", Path: "/repo/b", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+			"c": {Slug: "c", Path: "/repo/c", LastIndexedAge: "1m ago", ReindexRequired: true, MigrationFailed: true},
+		},
+	}
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, s)
+	out := strings.ToLower(buf.String())
+
+	if strings.Contains(out, "in progress") {
+		t.Errorf("nothing is in progress — every stale repo was given up on:\n%s", out)
+	}
+	if strings.Contains(out, "no action needed") {
+		t.Errorf("action IS needed — every remaining repo needs a manual reindex:\n%s", out)
+	}
+	if !strings.Contains(out, "could not be migrated") {
+		t.Errorf("must still report the given-up repos:\n%s", out)
+	}
+}
+
+// TestPrintStatusSummary_LivenessBoundary pins the freshness window edges.
+func TestPrintStatusSummary_LivenessBoundary(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		age  time.Duration
+		live bool
+	}{
+		{"59s is live", 59 * time.Second, true},
+		{"exactly 60s is live", 60 * time.Second, true},
+		{"61s is not live", 61 * time.Second, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv(daemon.EnvRoot, root)
+			t.Setenv("GRAFEL_HOME", t.TempDir())
+			ref := time.Now()
+			orig := statusNow
+			statusNow = func() time.Time { return ref }
+			t.Cleanup(func() { statusNow = orig })
+			repo := seedRepoWithStatusfileAt(t, root, "r", true, ref.Add(-tc.age))
+			got := ComputeStatusSummary("grp", []registry.Repo{repo})
+			if got.MigrationLive != tc.live {
+				t.Errorf("heartbeat %v old: MigrationLive = %v, want %v", tc.age, got.MigrationLive, tc.live)
+			}
+		})
 	}
 }
 

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -25,6 +25,12 @@ import (
 // stopped daemon looking alive.
 const migrationLiveWindow = 60 * time.Second
 
+// statusNow is the clock ComputeStatusSummary measures heartbeat freshness
+// against. A package var purely so the liveness boundary is testable at exact
+// offsets — a wall-clock test can never observe "exactly migrationLiveWindow
+// old" as live, because time passes between seeding the file and reading it.
+var statusNow = time.Now
+
 // StatusSummary aggregates per-repo and per-group statistics for the status
 // command. Computed client-side by reading the graph-stats.json sidecars.
 type StatusSummary struct {
@@ -172,7 +178,7 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			// Liveness: a heartbeat within migrationLiveWindow means an engine
 			// is writing these files right now. Any one repo suffices — the
 			// writer walks them all on a single loop.
-			if !sf.HeartbeatAt.IsZero() && time.Since(sf.HeartbeatAt) <= migrationLiveWindow {
+			if !sf.HeartbeatAt.IsZero() && statusNow().Sub(sf.HeartbeatAt) <= migrationLiveWindow {
 				s.MigrationLive = true
 			}
 		}
@@ -641,7 +647,16 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// showing the fraction converts that into visible progress. Printed only
 	// while a migration is actually outstanding, so it adds no steady-state
 	// noise (and leaves the #5995 byte-for-byte golden untouched).
-	if s.ReindexRequired > 0 {
+	active := s.ReindexRequired - s.MigrationFailed
+	if active < 0 {
+		active = 0
+	}
+	// Round-3 LOW 5: gate on `active`, not on ReindexRequired. When every
+	// remaining stale repo has been given up on, the old gate still fired and
+	// printed "0 of N ... migrating them automatically ... No action needed"
+	// directly above the warning that N repos could NOT be migrated — two
+	// contradictory lines, with the reassuring one first.
+	if active > 0 {
 		total := len(s.RepoStats)
 		// The denominator is this GROUP's repo count, and the wording says so
 		// — a multi-group store has more repos than this, and claiming
@@ -653,7 +668,6 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 			fmt.Fprintf(w, "  Format upgrade STALLED: %d of %d repo(s) in this group need a reindex, but the daemon is not running — start it with `grafel start` (or reindex manually with `grafel index <repo>`).\n",
 				s.ReindexRequired, total)
 		default:
-			active := s.ReindexRequired - s.MigrationFailed
 			fmt.Fprintf(w, "  Format upgrade in progress: %d of %d repo(s) in this group awaiting reindex — grafel is migrating them automatically, a few at a time. No action needed.\n",
 				active, total)
 		}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -17,6 +17,14 @@ import (
 	"github.com/cajasmota/grafel/internal/statusfile"
 )
 
+// migrationLiveWindow is how recent a statusfile heartbeat must be for the
+// status command to believe an engine is actually running the format
+// migration. The engine rewrites every repo's statusfile on a 5s heartbeat
+// (internal/daemon/statuswriter.go:45), so 60s is a dozen missed ticks —
+// comfortably past a slow tick or a busy machine, well short of leaving a
+// stopped daemon looking alive.
+const migrationLiveWindow = 60 * time.Second
+
 // StatusSummary aggregates per-repo and per-group statistics for the status
 // command. Computed client-side by reading the graph-stats.json sidecars.
 type StatusSummary struct {
@@ -42,6 +50,22 @@ type StatusSummary struct {
 	// load, no daemon dial. Zero on the overwhelming majority of runs, and
 	// PrintStatusSummary prints nothing when it is zero.
 	ReindexRequired int
+
+	// MigrationFailed is how many repos the engine has GIVEN UP migrating
+	// (#6167 review finding 2). These still count in ReindexRequired — the
+	// graph really is stale — but nothing is coming to fix them automatically,
+	// so they are reported separately with the manual command.
+	MigrationFailed int
+
+	// MigrationLive is true when at least one repo's statusfile was
+	// heartbeated recently enough to believe an engine is actually running and
+	// working the migration. Review finding 3: statusfile.Read is a plain
+	// unmarshal with no freshness gate, so a stopped daemon leaves
+	// ReindexRequired=true on disk indefinitely — and the status line then
+	// reassured the user that an automatic migration was under way when
+	// nothing at all was running. Derived from statusfile.HeartbeatAt, so it
+	// still needs no daemon dial.
+	MigrationLive bool
 }
 
 // RepoStatus contains per-repo statistics.
@@ -80,6 +104,10 @@ type RepoStatus struct {
 	// statusfile, which the engine recomputes from the graph.fb header on every
 	// heartbeat (internal/daemon/statuswriter.go:135).
 	ReindexRequired bool
+
+	// MigrationFailed mirrors statusfile.ReindexMigrationFailed: the engine
+	// tried staleReindexMaxAttempts times and gave up on this repo.
+	MigrationFailed bool
 
 	// GraphLoadError is non-empty when this repo HAS a graph artefact on disk
 	// but it could not be read: a truncated/garbage graph.fb (the flatbuffers
@@ -134,8 +162,18 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			// graph.fb header every heartbeat, so it is the freshest answer
 			// available without loading a graph.
 			rs.ReindexRequired = sf.ReindexRequired
+			rs.MigrationFailed = sf.ReindexMigrationFailed
 			if sf.ReindexRequired {
 				s.ReindexRequired++
+			}
+			if sf.ReindexMigrationFailed {
+				s.MigrationFailed++
+			}
+			// Liveness: a heartbeat within migrationLiveWindow means an engine
+			// is writing these files right now. Any one repo suffices — the
+			// writer walks them all on a single loop.
+			if !sf.HeartbeatAt.IsZero() && time.Since(sf.HeartbeatAt) <= migrationLiveWindow {
+				s.MigrationLive = true
 			}
 		}
 
@@ -605,8 +643,24 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// noise (and leaves the #5995 byte-for-byte golden untouched).
 	if s.ReindexRequired > 0 {
 		total := len(s.RepoStats)
-		fmt.Fprintf(w, "  Format upgrade in progress: %d of %d repo(s) awaiting reindex — grafel is migrating them automatically, a few at a time. No action needed.\n",
-			s.ReindexRequired, total)
+		// The denominator is this GROUP's repo count, and the wording says so
+		// — a multi-group store has more repos than this, and claiming
+		// otherwise would understate the migration (review finding 3).
+		switch {
+		case !s.MigrationLive:
+			// No recent heartbeat: nothing is migrating anything. Telling the
+			// user "no action needed" here is precisely backwards.
+			fmt.Fprintf(w, "  Format upgrade STALLED: %d of %d repo(s) in this group need a reindex, but the daemon is not running — start it with `grafel start` (or reindex manually with `grafel index <repo>`).\n",
+				s.ReindexRequired, total)
+		default:
+			active := s.ReindexRequired - s.MigrationFailed
+			fmt.Fprintf(w, "  Format upgrade in progress: %d of %d repo(s) in this group awaiting reindex — grafel is migrating them automatically, a few at a time. No action needed.\n",
+				active, total)
+		}
+	}
+	if s.MigrationFailed > 0 {
+		fmt.Fprintf(w, "  ⚠ %d repo(s) could not be migrated automatically after repeated attempts — reindex them manually with `grafel index <repo>`.\n",
+			s.MigrationFailed)
 	}
 
 	if s.EnrichmentCandidates > 0 || s.RepairCandidates > 0 {

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -35,6 +35,13 @@ type StatusSummary struct {
 	// Flows and endpoints are derived from entity kinds during graph reading.
 	HTTPEndpoints int
 	ProcessFlows  int
+
+	// ReindexRequired is how many repos in this group are still waiting to be
+	// reindexed after a graph-format version bump (#6167). Read straight from
+	// the per-repo statusfile the engine refreshes every heartbeat — no graph
+	// load, no daemon dial. Zero on the overwhelming majority of runs, and
+	// PrintStatusSummary prints nothing when it is zero.
+	ReindexRequired int
 }
 
 // RepoStatus contains per-repo statistics.
@@ -66,6 +73,13 @@ type RepoStatus struct {
 	// run, and this marker sits alongside it as an additional warning. Cleared
 	// (nil again) once a subsequent rebuild of this repo succeeds.
 	RebuildFailure *statusfile.RebuildFailure
+
+	// ReindexRequired is true when this repo's on-disk graph.fb was written by
+	// an older grafel than this binary accepts, so it is queued for (or
+	// undergoing) an automatic format migration (#6167). Sourced from the
+	// statusfile, which the engine recomputes from the graph.fb header on every
+	// heartbeat (internal/daemon/statuswriter.go:135).
+	ReindexRequired bool
 
 	// GraphLoadError is non-empty when this repo HAS a graph artefact on disk
 	// but it could not be read: a truncated/garbage graph.fb (the flatbuffers
@@ -116,6 +130,13 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 		// error worth surfacing here.
 		if sf, sfErr := statusfile.Read(r.Path); sfErr == nil && sf != nil {
 			rs.RebuildFailure = sf.LastRebuildFailure
+			// #6167: same free read — the engine recomputes this from the
+			// graph.fb header every heartbeat, so it is the freshest answer
+			// available without loading a graph.
+			rs.ReindexRequired = sf.ReindexRequired
+			if sf.ReindexRequired {
+				s.ReindexRequired++
+			}
 		}
 
 		stateDir := daemon.StateDirForRepo(r.Path)
@@ -575,6 +596,19 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// from the current graph — not a live daemon queue. Nothing auto-drains
 	// them (they cost tokens; the user runs enrichment to apply). The wording
 	// deliberately avoids "Pending", which reads as a stuck/blocked queue.
+	// #6167: a graph-format migration is the one background activity that can
+	// legitimately keep the daemon busy for hours, and until now it was
+	// completely silent — the user in the originating report read "silent and
+	// busy" as "hung", restarted, and re-entered the queue. Naming the cause and
+	// showing the fraction converts that into visible progress. Printed only
+	// while a migration is actually outstanding, so it adds no steady-state
+	// noise (and leaves the #5995 byte-for-byte golden untouched).
+	if s.ReindexRequired > 0 {
+		total := len(s.RepoStats)
+		fmt.Fprintf(w, "  Format upgrade in progress: %d of %d repo(s) awaiting reindex — grafel is migrating them automatically, a few at a time. No action needed.\n",
+			s.ReindexRequired, total)
+	}
+
 	if s.EnrichmentCandidates > 0 || s.RepairCandidates > 0 {
 		fmt.Fprintf(w, "  Available (optional; run enrichment to apply — nothing auto-drains): %s enrichment opportunities · %s repair candidates\n",
 			fmtInt(s.EnrichmentCandidates),

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -32,10 +32,77 @@ package daemon
 import (
 	"fmt"
 	"log/slog"
+	"os"
+	"strconv"
 	"sync"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/requests"
 )
+
+// #6167 — migration batching policy.
+//
+// The loop guard above bounds requests PER REPO. Nothing bounded them ACROSS
+// repos, and statusWriter.writeAll (statuswriter.go:521) walks every registered
+// repo on every 5s heartbeat — so the first heartbeat after an fbversion bump
+// enqueued one reindex per stale repo, all at once. A user with 140 registered
+// repos measured queued=133, seven "heavy write stage starved by index churn"
+// escalations and three shutdown-watchdog force-exits over 18 hours.
+//
+// The scheduler already caps CONCURRENCY (Config.Workers defaults to 2, plus
+// RSS-budget admission — sched/scheduler.go:158, :1508). What was unbounded was
+// the BACKLOG, and backlog is what hurts here for two reasons:
+//
+//  1. sched/stagegate.go:489 refuses the heavy-write token for as long as ANY
+//     index job is in flight. A 133-deep queue means that condition is
+//     continuously true, so group-algo/links only ever run via the drain-barrier
+//     escalation at stagegate.go:470 — the seven WARNs in the capture.
+//  2. requests.Write persists to disk. A 133-deep durable queue survives the
+//     restart the user performs when the dashboard stops responding, so the
+//     stampede replays on every restart.
+//
+// So the throttle belongs HERE, at request production, not at the drain: it
+// keeps the on-disk backlog bounded and it creates the idle windows the stage
+// gate needs. The guard's own state is in-memory and re-derives from on-disk
+// staleness after a restart, so nothing is lost by bounding it.
+const (
+	// defaultStaleReindexBatchSize is how many auto-reindexes may be
+	// outstanding at once. Sized to the scheduler's own default worker count
+	// (2) so the migration keeps the pipeline fed without ever queueing behind
+	// itself.
+	defaultStaleReindexBatchSize = 2
+
+	// defaultStaleReindexCooldown is the enforced quiet period after a batch
+	// fully drains, before the next is admitted. This is the idle window in
+	// which a deferred heavy write stage can acquire the stage-gate token
+	// cleanly instead of waiting out the drain barrier. It only needs to
+	// exceed the gate's retry interval, not the stage's runtime — once the
+	// stage HOLDS the token, stageBusyLocked keeps index dispatch out for as
+	// long as it runs.
+	defaultStaleReindexCooldown = 30 * time.Second
+
+	// defaultStaleReindexSlotTTL bounds how long one repo may occupy a batch
+	// slot. Without it, a repo whose reindex never completes (crash, permanent
+	// index failure) would wedge the whole migration — a worse failure than
+	// the stampede it replaces. Generous against the 4m53s worst-case reindex
+	// in the user's capture, so a healthy run is never cut short.
+	defaultStaleReindexSlotTTL = 15 * time.Minute
+
+	// EnvStaleReindexBatch overrides defaultStaleReindexBatchSize. Escape
+	// hatch for an operator who wants a large store to migrate faster (or
+	// slower) than the default. Values <= 0 fall back to the default.
+	EnvStaleReindexBatch = "GRAFEL_STALE_REINDEX_BATCH"
+)
+
+// staleReindexBatchSize resolves the batch size, honouring EnvStaleReindexBatch.
+func staleReindexBatchSize() int {
+	if v := os.Getenv(EnvStaleReindexBatch); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultStaleReindexBatchSize
+}
 
 // staleReindexGuard tracks, per repo path, the stale-format fingerprint we have
 // already auto-enqueued a reindex for, so we never enqueue twice for the same
@@ -48,10 +115,36 @@ type staleReindexGuard struct {
 	// seen maps repoPath -> the stale fingerprint a reindex was last enqueued
 	// for. Absence means "no outstanding auto-reindex for a stale generation".
 	seen map[string]string
+
+	// --- #6167 migration batching (see the "at scale" note in the file doc) ---
+
+	// inflight maps repoPath -> the time its auto-reindex was admitted, for
+	// every repo this guard has enqueued and not yet observed going current.
+	// Its SIZE is the outstanding-migration count the batch bounds.
+	inflight map[string]time.Time
+	// admittedInBatch counts admissions since the current batch opened. The
+	// batch closes at batchSize and reopens only after inflight drains AND
+	// cooldown elapses — that gap is the idle window the stage gate needs.
+	admittedInBatch int
+	// batchDrainedAt is when inflight last became empty with a full batch
+	// behind it; the cooldown is measured from here.
+	batchDrainedAt time.Time
+
+	batchSize int
+	cooldown  time.Duration
+	slotTTL   time.Duration
+	now       func() time.Time
 }
 
 func newStaleReindexGuard() *staleReindexGuard {
-	return &staleReindexGuard{seen: map[string]string{}}
+	return &staleReindexGuard{
+		seen:      map[string]string{},
+		inflight:  map[string]time.Time{},
+		batchSize: staleReindexBatchSize(),
+		cooldown:  defaultStaleReindexCooldown,
+		slotTTL:   defaultStaleReindexSlotTTL,
+		now:       time.Now,
+	}
 }
 
 // defaultStaleReindexGuard is the process-wide guard used by writeRepoStatusFile.
@@ -81,10 +174,17 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 
 	if !required {
 		delete(g.seen, repoPath)
+		g.releaseSlotLocked(repoPath)
 		return false
 	}
 	if g.seen[repoPath] == fingerprint {
 		return false // already enqueued for this exact stale generation
+	}
+	// #6167: batch admission. A refusal here is a DEFERRAL, not a drop — the
+	// fingerprint is deliberately NOT recorded, so the next heartbeat offers
+	// this repo again and it is admitted as soon as a batch opens.
+	if !g.admitLocked(logger) {
+		return false
 	}
 	if _, err := requests.Write(requestsDirForRepo(repoPath), requests.Record{
 		Kind:     requests.KindReindex,
@@ -96,5 +196,64 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 		return false
 	}
 	g.seen[repoPath] = fingerprint
+	g.inflight[repoPath] = g.now()
+	g.admittedInBatch++
 	return true
+}
+
+// admitLocked applies the #6167 batch policy. MUST be called with g.mu held.
+//
+// The rule, in one sentence: admit up to batchSize repos, then admit nothing
+// more until every one of them has gone current (or forfeited its slot to the
+// TTL) AND cooldown has elapsed since that happened.
+//
+// The "wait for the batch to fully drain" part is load-bearing and is why this
+// is not a plain semaphore. A semaphore of size 2 refills the instant one slot
+// frees, so len(scheduler.inflight) never reaches zero and stagegate.go:489
+// still never yields the heavy-write token — the exact starvation being fixed.
+// Draining the whole batch first is what manufactures the idle window.
+func (g *staleReindexGuard) admitLocked(logger *slog.Logger) bool {
+	now := g.now()
+
+	// Reclaim slots held past the TTL. Without this a repo whose reindex never
+	// completes wedges the migration for every other repo — a strictly worse
+	// failure than the stampede. The repo stays in g.seen, so reclaiming its
+	// slot does NOT re-enqueue a known-failing reindex; it only unblocks the
+	// others.
+	for repo, at := range g.inflight {
+		if now.Sub(at) >= g.slotTTL {
+			delete(g.inflight, repo)
+			if logger != nil {
+				logger.Warn("statusfile: auto-reindex slot expired — releasing it so the format migration can continue",
+					"repo", repo, "held_for", now.Sub(at).Truncate(time.Second), "ttl", g.slotTTL)
+			}
+			if len(g.inflight) == 0 {
+				g.batchDrainedAt = now
+			}
+		}
+	}
+
+	if g.admittedInBatch >= g.batchSize {
+		if len(g.inflight) > 0 {
+			return false // batch still executing
+		}
+		if now.Sub(g.batchDrainedAt) < g.cooldown {
+			return false // idle window — hands the stage gate its chance
+		}
+		g.admittedInBatch = 0 // open the next batch
+	}
+	return g.admittedInBatch < g.batchSize
+}
+
+// releaseSlotLocked frees repoPath's batch slot once its graph is current
+// again, recording when the batch fully drained so the cooldown can start.
+// MUST be called with g.mu held.
+func (g *staleReindexGuard) releaseSlotLocked(repoPath string) {
+	if _, held := g.inflight[repoPath]; !held {
+		return
+	}
+	delete(g.inflight, repoPath)
+	if len(g.inflight) == 0 {
+		g.batchDrainedAt = g.now()
+	}
 }

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -255,6 +255,15 @@ type staleReindexGuard struct {
 	// they were admitted. It is the whole basis of the round-4 distinction:
 	// !active[repo] means "stalled" only if we ever saw it active, and
 	// "never enqueued" otherwise — and only the first deserves a penalty.
+	//
+	// Its lifetime is ONE ADMISSION, so it must be cleared on every path that
+	// ends one: success (releaseSlotLocked), stall (forfeitLocked) and
+	// never-dispatched (abandonLocked). Clearing it only on the last made it a
+	// per-PROCESS memory: a linked worktree indexed once in an early generation
+	// (before its primary existed, so the enqueue gate let it through) kept
+	// observedActive=true forever, so every later generation the gate dropped
+	// was routed to the STALLED branch and penalised to a durable Failed — the
+	// scheduler-declines-by-design case, blamed on the user.
 	observedActive map[string]bool
 	// reconciled guards the one-time startup rebuild of inflight/admittedInBatch
 	// from the durable requests dirs. Without it a restart re-admits repos whose
@@ -545,6 +554,10 @@ func (g *staleReindexGuard) abandonLocked(repo string, held time.Duration, logge
 // at which point writeRepoStatusFile publishes that to the status plane.
 func (g *staleReindexGuard) forfeitLocked(repo string, held, deadline time.Duration, logger *slog.Logger) {
 	delete(g.inflight, repo)
+	// This admission is over: the next one must judge dispatch afresh, or a
+	// repo that stalled once is charged for later attempts that the scheduler
+	// never accepted.
+	delete(g.observedActive, repo)
 	g.attempts[repo]++
 
 	if g.attempts[repo] >= g.maxAttempts {
@@ -677,6 +690,7 @@ func (g *staleReindexGuard) releaseSlotLocked(repoPath string) {
 	hadState := g.attempts[repoPath] > 0
 	delete(g.attempts, repoPath)
 	delete(g.retryAfter, repoPath)
+	delete(g.observedActive, repoPath)
 
 	_, held := g.inflight[repoPath]
 	if held || hadState {

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -63,8 +63,29 @@ import (
 //
 // So the throttle belongs HERE, at request production, not at the drain: it
 // keeps the on-disk backlog bounded and it creates the idle windows the stage
-// gate needs. The guard's own state is in-memory and re-derives from on-disk
-// staleness after a restart, so nothing is lost by bounding it.
+// gate needs.
+//
+// The guard's own maps are in-memory, which is NOT self-healing on its own: a
+// restarted daemon sees an empty guard while the previous run's requests are
+// still queued and graph.fb is still stale, and would re-admit the same repos
+// (measured: 4 durable requests after one restart, 12 after six). reconcileLocked
+// rebuilds the outstanding set from the durable queue on first use, which is
+// what makes a restart RESUME the migration instead of restarting it.
+//
+// Two limits this mechanism does NOT address, named here so they are not
+// mistaken for solved:
+//
+//   - The idle window is idle only with respect to GUARD-ADMITTED reindexes.
+//     The guard has no visibility into watcher-driven incremental indexes, so on
+//     a store with 140 watched repos ordinary file-change churn can keep
+//     sched.inflight > 0 straight through the cooldown and the stage gate still
+//     never yields.
+//   - While a heavy stage HOLDS the token (group-algo runs ~40min) nothing
+//     completes, so slots do not free and the effective migration rate degrades
+//     to roughly one batch per stage hold.
+//
+// Attempt counts and retry backoffs are also in-memory: a repo that keeps
+// failing gets a fresh set of attempts after each daemon restart.
 const (
 	// defaultStaleReindexBatchSize is how many auto-reindexes may be
 	// outstanding at once. Sized to the scheduler's own default worker count
@@ -79,7 +100,15 @@ const (
 	// exceed the gate's retry interval, not the stage's runtime — once the
 	// stage HOLDS the token, stageBusyLocked keeps index dispatch out for as
 	// long as it runs.
-	defaultStaleReindexCooldown = 30 * time.Second
+	//
+	// Sized against stageGateRetryDefault = 15s (sched/stagegate.go:73). Review
+	// finding 5: at the original 30s a starved stage got exactly two retry
+	// attempts per window, so a single missed tick lost the window entirely.
+	// 45s guarantees three, which is the margin one lost tick needs. The cost
+	// is 15s per batch — ~17 minutes across a 140-repo migration that already
+	// takes hours, which is the right trade for not silently losing the window
+	// this whole mechanism exists to create.
+	defaultStaleReindexCooldown = 45 * time.Second
 
 	// defaultStaleReindexSlotTTL bounds how long one repo may occupy a batch
 	// slot. Without it, a repo whose reindex never completes (crash, permanent
@@ -87,6 +116,37 @@ const (
 	// the stampede it replaces. Generous against the 4m53s worst-case reindex
 	// in the user's capture, so a healthy run is never cut short.
 	defaultStaleReindexSlotTTL = 15 * time.Minute
+
+	// defaultStaleReindexLaggardGrace is the SHORTER forfeit deadline that
+	// applies once the rest of a repo's batch has already drained. Review
+	// finding 2: with only the hard slotTTL, one wedged repo stopped the whole
+	// migration for the full 15 minutes, so the TTL was not a safety valve —
+	// it WAS the stall. Decoupling them means a laggard whose batch-mates have
+	// finished forfeits at 5m, while a batch where nothing has progressed
+	// still gets the full 15m before anything is presumed dead.
+	//
+	// 5m is deliberately above the 4m53s worst-case reindex in the originating
+	// capture, so a merely slow (not wedged) repo is never cut short. Forfeit
+	// does not cancel the running reindex in any case — it only frees the
+	// admission slot — so an early forfeit costs at most some extra overlap,
+	// which the scheduler's own Workers=2 cap absorbs.
+	defaultStaleReindexLaggardGrace = 5 * time.Minute
+
+	// staleReindexMaxAttempts bounds how many times one repo may be admitted
+	// before the migration gives up on it. Review finding 2: forfeiting a slot
+	// while leaving the repo in `seen` was a SILENT PERMANENT DROP — the repo
+	// served a stale graph forever and nothing said so. Now a forfeit clears
+	// `seen` so the repo gets another turn, and only after this many failures
+	// is it marked failed and REPORTED.
+	staleReindexMaxAttempts = 3
+
+	// defaultStaleReindexRetryBackoff is how long a forfeited repo stands aside
+	// before it is eligible for another slot. Without it, bounded retry re-took
+	// the slot on the very next heartbeat — the wedged repo is offered first in
+	// registry order every time — so retrying it starved every repo behind it
+	// for maxAttempts * the forfeit deadline. Standing aside lets the rest of
+	// the migration overtake it, which is the whole point of not dropping it.
+	defaultStaleReindexRetryBackoff = 10 * time.Minute
 
 	// EnvStaleReindexBatch overrides defaultStaleReindexBatchSize. Escape
 	// hatch for an operator who wants a large store to migrate faster (or
@@ -130,20 +190,56 @@ type staleReindexGuard struct {
 	// behind it; the cooldown is measured from here.
 	batchDrainedAt time.Time
 
-	batchSize int
-	cooldown  time.Duration
-	slotTTL   time.Duration
-	now       func() time.Time
+	// attempts counts how many times each repo has had an auto-reindex
+	// admitted that did NOT end in a current graph (i.e. the slot was
+	// forfeited rather than released). Bounded retry: a transient failure gets
+	// another turn in a later batch instead of being dropped on the first.
+	attempts map[string]int
+	// failed records repos that exhausted staleReindexMaxAttempts. They are
+	// never admitted again — and, crucially, are reported (statusfile
+	// ReindexMigrationFailed → `grafel status`) rather than silently dropped.
+	failed map[string]bool
+	// retryAfter holds, for each forfeited repo, the earliest time it may take
+	// another slot. Keeps a retry from immediately re-taking the slot it just
+	// lost and starving the repos behind it.
+	retryAfter map[string]time.Time
+	// reconciled guards the one-time startup rebuild of inflight/admittedInBatch
+	// from the durable requests dirs. Without it a restart re-admits repos whose
+	// requests are still pending, writing duplicate reindexes without bound.
+	reconciled bool
+
+	batchSize    int
+	cooldown     time.Duration
+	slotTTL      time.Duration
+	laggardGrace time.Duration
+	retryBackoff time.Duration
+	maxAttempts  int
+	now          func() time.Time
+	// pendingFn lists already-queued requests for a repo's control-plane dir.
+	// Injectable so the reconcile path is testable without a real store.
+	pendingFn func(dir string) ([]requests.Record, error)
+	// reconcileDirsFn enumerates every requests dir in the store.
+	reconcileDirsFn func() ([]string, error)
 }
 
 func newStaleReindexGuard() *staleReindexGuard {
 	return &staleReindexGuard{
-		seen:      map[string]string{},
-		inflight:  map[string]time.Time{},
-		batchSize: staleReindexBatchSize(),
-		cooldown:  defaultStaleReindexCooldown,
-		slotTTL:   defaultStaleReindexSlotTTL,
-		now:       time.Now,
+		seen:         map[string]string{},
+		inflight:     map[string]time.Time{},
+		attempts:     map[string]int{},
+		failed:       map[string]bool{},
+		retryAfter:   map[string]time.Time{},
+		retryBackoff: defaultStaleReindexRetryBackoff,
+		batchSize:    staleReindexBatchSize(),
+		cooldown:     defaultStaleReindexCooldown,
+		slotTTL:      defaultStaleReindexSlotTTL,
+		laggardGrace: defaultStaleReindexLaggardGrace,
+		maxAttempts:  staleReindexMaxAttempts,
+		now:          time.Now,
+		pendingFn:    requests.ListPending,
+		reconcileDirsFn: func() ([]string, error) {
+			return discoverRequestsDirs(requestsRoot())
+		},
 	}
 }
 
@@ -172,10 +268,30 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	g.reconcileLocked(logger)
+	// The forfeit sweep must run BEFORE the inflight short-circuit below:
+	// a repo holding its own slot returns early there, so leaving the sweep
+	// inside admitLocked meant a wedged repo's deadline was never evaluated on
+	// the heartbeats that mattered.
+	g.sweepLocked(logger)
+
 	if !required {
 		delete(g.seen, repoPath)
 		g.releaseSlotLocked(repoPath)
 		return false
+	}
+	if g.failed[repoPath] {
+		return false // gave up on this repo; reported via the statusfile instead
+	}
+	// An outstanding request for this repo is authoritative regardless of what
+	// `seen` remembers — and after a restart, `seen` remembers nothing while
+	// the durable request is still queued (review finding 1). Checking inflight
+	// first is what makes the restart path resume instead of re-enqueueing.
+	if _, held := g.inflight[repoPath]; held {
+		return false
+	}
+	if until, backing := g.retryAfter[repoPath]; backing && g.now().Before(until) {
+		return false // forfeited recently; standing aside so others can overtake
 	}
 	if g.seen[repoPath] == fingerprint {
 		return false // already enqueued for this exact stale generation
@@ -201,6 +317,15 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	return true
 }
 
+// migrationFailed reports whether the automatic format migration has given up
+// on repoPath. Consumed by writeRepoStatusFile so the give-up is visible in
+// `grafel status` instead of being a silent permanent drop.
+func (g *staleReindexGuard) migrationFailed(repoPath string) bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.failed[repoPath]
+}
+
 // admitLocked applies the #6167 batch policy. MUST be called with g.mu held.
 //
 // The rule, in one sentence: admit up to batchSize repos, then admit nothing
@@ -215,24 +340,6 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 func (g *staleReindexGuard) admitLocked(logger *slog.Logger) bool {
 	now := g.now()
 
-	// Reclaim slots held past the TTL. Without this a repo whose reindex never
-	// completes wedges the migration for every other repo — a strictly worse
-	// failure than the stampede. The repo stays in g.seen, so reclaiming its
-	// slot does NOT re-enqueue a known-failing reindex; it only unblocks the
-	// others.
-	for repo, at := range g.inflight {
-		if now.Sub(at) >= g.slotTTL {
-			delete(g.inflight, repo)
-			if logger != nil {
-				logger.Warn("statusfile: auto-reindex slot expired — releasing it so the format migration can continue",
-					"repo", repo, "held_for", now.Sub(at).Truncate(time.Second), "ttl", g.slotTTL)
-			}
-			if len(g.inflight) == 0 {
-				g.batchDrainedAt = now
-			}
-		}
-	}
-
 	if g.admittedInBatch >= g.batchSize {
 		if len(g.inflight) > 0 {
 			return false // batch still executing
@@ -243,6 +350,116 @@ func (g *staleReindexGuard) admitLocked(logger *slog.Logger) bool {
 		g.admittedInBatch = 0 // open the next batch
 	}
 	return g.admittedInBatch < g.batchSize
+}
+
+// sweepLocked reclaims batch slots whose holder has passed its forfeit
+// deadline. MUST be called with g.mu held. It runs on EVERY heartbeat, before
+// any short-circuit in maybeEnqueue, because the repo holding a wedged slot
+// returns early at the inflight check — leaving the sweep inside admitLocked
+// meant its deadline was never evaluated at all.
+func (g *staleReindexGuard) sweepLocked(logger *slog.Logger) {
+	now := g.now()
+
+	for repo, at := range g.inflight {
+		held := now.Sub(at)
+		deadline := g.slotTTL
+		// Review finding 2: when some of this batch has already drained, the
+		// remaining slot is the ONLY thing holding the migration, so presume it
+		// wedged much sooner. With a single deadline the hard TTL was not a
+		// safety valve, it was the measured stall (15m25s with nothing
+		// admitted at all). A batch where nothing has progressed still gets the
+		// full TTL before anything is declared dead.
+		if len(g.inflight) < g.admittedInBatch && g.laggardGrace > 0 && g.laggardGrace < deadline {
+			deadline = g.laggardGrace
+		}
+		if held >= deadline {
+			g.forfeitLocked(repo, held, deadline, logger)
+		}
+	}
+}
+
+// forfeitLocked takes a batch slot back from a repo that has held it past its
+// deadline. MUST be called with g.mu held.
+//
+// Review finding 2: the previous behaviour left the repo in `seen`, which made
+// a forfeit a SILENT PERMANENT DROP — the repo went on serving a stale graph
+// with nothing anywhere saying so. Now a forfeit clears `seen` so the repo is
+// retried in a later batch, and only after maxAttempts is it marked failed —
+// at which point writeRepoStatusFile publishes that to the status plane.
+func (g *staleReindexGuard) forfeitLocked(repo string, held, deadline time.Duration, logger *slog.Logger) {
+	delete(g.inflight, repo)
+	g.attempts[repo]++
+
+	if g.attempts[repo] >= g.maxAttempts {
+		g.failed[repo] = true
+		if logger != nil {
+			logger.Warn("statusfile: giving up on the automatic format migration for this repo — it needs a manual reindex",
+				"repo", repo, "attempts", g.attempts[repo], "held_for", held.Truncate(time.Second),
+				"fix", "grafel index "+repo)
+		}
+	} else {
+		delete(g.seen, repo) // eligible for another turn in a later batch
+		g.retryAfter[repo] = g.now().Add(g.retryBackoff)
+		if logger != nil {
+			logger.Warn("statusfile: auto-reindex slot forfeited — will retry in a later batch",
+				"repo", repo, "attempt", g.attempts[repo], "of", g.maxAttempts,
+				"held_for", held.Truncate(time.Second), "deadline", deadline)
+		}
+	}
+
+	if len(g.inflight) == 0 {
+		g.batchDrainedAt = g.now()
+	}
+}
+
+// reconcileLocked rebuilds outstanding-migration state from the DURABLE request
+// queue, once per process. MUST be called with g.mu held.
+//
+// Review finding 1 (measured): seen/inflight are in-memory only, so a restarted
+// daemon saw an empty guard while the previous run's reindex requests were
+// still queued and graph.fb was still stale — and re-admitted the same repos,
+// writing a duplicate full reindex (42s–4m53s each) per repo per restart, with
+// no bound across restarts. Since requests.Write is durable precisely so the
+// queue survives a restart, the guard has to read it back: pending KindReindex
+// records ARE the outstanding set.
+func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
+	if g.reconciled {
+		return
+	}
+	g.reconciled = true
+	if g.reconcileDirsFn == nil || g.pendingFn == nil {
+		return
+	}
+	dirs, err := g.reconcileDirsFn()
+	if err != nil {
+		if logger != nil {
+			logger.Warn("statusfile: could not reconcile auto-reindex state from the request queue", "err", err)
+		}
+		return
+	}
+	now := g.now()
+	for _, dir := range dirs {
+		recs, listErr := g.pendingFn(dir)
+		if listErr != nil {
+			continue
+		}
+		for _, r := range recs {
+			if r.Kind != requests.KindReindex || r.RepoPath == "" {
+				continue
+			}
+			if _, dup := g.inflight[r.RepoPath]; dup {
+				continue
+			}
+			g.inflight[r.RepoPath] = now
+		}
+	}
+	// Treat the recovered set as the current batch, so a restart does not open
+	// a fresh batch on top of work that is already queued.
+	g.admittedInBatch = len(g.inflight)
+	if len(g.inflight) > 0 && logger != nil {
+		logger.Info("statusfile: resumed an in-progress format migration from the request queue",
+			"outstanding", len(g.inflight))
+	}
 }
 
 // releaseSlotLocked frees repoPath's batch slot once its graph is current

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -31,6 +31,7 @@ package daemon
 
 import (
 	"fmt"
+	"hash/fnv"
 	"log/slog"
 	"os"
 	"strconv"
@@ -38,6 +39,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/requests"
+	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
 // #6167 — migration batching policy.
@@ -65,12 +67,26 @@ import (
 // keeps the on-disk backlog bounded and it creates the idle windows the stage
 // gate needs.
 //
-// The guard's own maps are in-memory, which is NOT self-healing on its own: a
-// restarted daemon sees an empty guard while the previous run's requests are
-// still queued and graph.fb is still stale, and would re-admit the same repos
-// (measured: 4 durable requests after one restart, 12 after six). reconcileLocked
-// rebuilds the outstanding set from the durable queue on first use, which is
-// what makes a restart RESUME the migration instead of restarting it.
+// The outstanding set is DURABLE, in the guard's own per-repo marker
+// (stale_reindex_state.go) rather than in the request queue. The request queue
+// cannot serve this purpose: the drain acks and removes a request within ~2s
+// while the index it dispatched runs 42s-4m53s, and the user restarts precisely
+// because the daemon is busy indexing — so a queue-derived reconcile saw
+// nothing outstanding and re-admitted everything (measured: 12 duplicate full
+// reindexes across 6 mid-index restarts). The marker also carries the attempt
+// count and the give-up flag, so failure history survives a restart loop;
+// without that, a restart-prone environment reset `attempts` every time and a
+// genuinely broken repo was never marked failed and never surfaced.
+//
+// Forfeit decisions are PER-REPO and keyed off indexstate.RepoStates(), the
+// scheduler's own progress signal, not off what the other slots are doing.
+// Keying it off the other slots meant two concurrently wedged repos never
+// satisfied the short-deadline condition and the migration stalled for the full
+// hard ceiling (measured 15m45s). A repo the scheduler is actively working on
+// is protected to the hard ceiling; a repo absent from a non-empty snapshot is
+// forfeited at the stalled grace. An EMPTY snapshot means "unknown" — right
+// after a restart the scheduler has not published yet — and never triggers a
+// forfeit.
 //
 // Two limits this mechanism does NOT address, named here so they are not
 // mistaken for solved:
@@ -83,9 +99,6 @@ import (
 //   - While a heavy stage HOLDS the token (group-algo runs ~40min) nothing
 //     completes, so slots do not free and the effective migration rate degrades
 //     to roughly one batch per stage hold.
-//
-// Attempt counts and retry backoffs are also in-memory: a repo that keeps
-// failing gets a fresh set of attempts after each daemon restart.
 const (
 	// defaultStaleReindexBatchSize is how many auto-reindexes may be
 	// outstanding at once. Sized to the scheduler's own default worker count
@@ -110,27 +123,29 @@ const (
 	// this whole mechanism exists to create.
 	defaultStaleReindexCooldown = 45 * time.Second
 
-	// defaultStaleReindexSlotTTL bounds how long one repo may occupy a batch
-	// slot. Without it, a repo whose reindex never completes (crash, permanent
-	// index failure) would wedge the whole migration — a worse failure than
-	// the stampede it replaces. Generous against the 4m53s worst-case reindex
-	// in the user's capture, so a healthy run is never cut short.
-	defaultStaleReindexSlotTTL = 15 * time.Minute
+	// defaultStaleReindexSlotTTL is the HARD ceiling, applied to a repo that
+	// the scheduler says it IS working on. Such a repo is making progress by
+	// every signal available, so it is protected for a long time — round 3
+	// MEDIUM 3: the previous 5m deadline left 7 seconds of margin against the
+	// documented 4m53s worst case, on a machine that is more loaded during a
+	// migration than during the capture. The ceiling exists only so a repo
+	// wedged INSIDE the scheduler cannot hold a slot forever.
+	defaultStaleReindexSlotTTL = 30 * time.Minute
 
-	// defaultStaleReindexLaggardGrace is the SHORTER forfeit deadline that
-	// applies once the rest of a repo's batch has already drained. Review
-	// finding 2: with only the hard slotTTL, one wedged repo stopped the whole
-	// migration for the full 15 minutes, so the TTL was not a safety valve —
-	// it WAS the stall. Decoupling them means a laggard whose batch-mates have
-	// finished forfeits at 5m, while a batch where nothing has progressed
-	// still gets the full 15m before anything is presumed dead.
+	// defaultStaleReindexStalledGrace is the forfeit deadline for a repo that
+	// the scheduler is NOT working on. Round-3 blocker 2: round 2 keyed the
+	// short deadline off "some of this batch has drained", which is never true
+	// when BOTH slot-holders are wedged — so the hard TTL governed again and
+	// the measured stall was 15m45s, marginally worse than before the fix. The
+	// decision has to be PER-REPO, and it needs a real progress signal rather
+	// than an inference from the other slots.
 	//
-	// 5m is deliberately above the 4m53s worst-case reindex in the originating
-	// capture, so a merely slow (not wedged) repo is never cut short. Forfeit
-	// does not cancel the running reindex in any case — it only frees the
-	// admission slot — so an early forfeit costs at most some extra overlap,
-	// which the scheduler's own Workers=2 cap absorbs.
-	defaultStaleReindexLaggardGrace = 5 * time.Minute
+	// indexstate.RepoStates() is that signal: a repo that is queued, indexing
+	// or dirty is demonstrably being worked on. A repo that appears NOWHERE in
+	// a non-empty snapshot is not — its request was dropped, its dispatch
+	// failed, or it was unregistered — and 90s is ample time for an admitted
+	// repo to show up there (the drain runs every 2s).
+	defaultStaleReindexStalledGrace = 90 * time.Second
 
 	// staleReindexMaxAttempts bounds how many times one repo may be admitted
 	// before the migration gives up on it. Review finding 2: forfeiting a slot
@@ -146,7 +161,13 @@ const (
 	// registry order every time — so retrying it starved every repo behind it
 	// for maxAttempts * the forfeit deadline. Standing aside lets the rest of
 	// the migration overtake it, which is the whole point of not dropping it.
+	//
+	// Round 3 blocker 2: the backoff is JITTERED per repo. A uniform backoff
+	// made two wedged repos forfeit together, wait together and re-pair on
+	// every retry, reproducing the stall each cycle instead of dissolving it.
 	defaultStaleReindexRetryBackoff = 10 * time.Minute
+	// staleReindexRetryJitter is the width of the per-repo backoff spread.
+	staleReindexRetryJitter = 5 * time.Minute
 
 	// EnvStaleReindexBatch overrides defaultStaleReindexBatchSize. Escape
 	// hatch for an operator who wants a large store to migrate faster (or
@@ -211,15 +232,26 @@ type staleReindexGuard struct {
 	batchSize    int
 	cooldown     time.Duration
 	slotTTL      time.Duration
-	laggardGrace time.Duration
+	stalledGrace time.Duration
 	retryBackoff time.Duration
 	maxAttempts  int
+	retryJitter  time.Duration
 	now          func() time.Time
 	// pendingFn lists already-queued requests for a repo's control-plane dir.
 	// Injectable so the reconcile path is testable without a real store.
 	pendingFn func(dir string) ([]requests.Record, error)
-	// reconcileDirsFn enumerates every requests dir in the store.
+	// reconcileDirsFn enumerates the durable migration markers in the store.
+	// Kept as a func for injection; returns nothing meaningful itself — the
+	// records are read via reconcileStatesFn.
 	reconcileDirsFn func() ([]string, error)
+	// reconcileStatesFn loads every durable migration marker in the store.
+	reconcileStatesFn func() ([]migrationState, error)
+	// activeFn reports which repos the scheduler is currently working on
+	// (queued / indexing / dirty). A nil or empty result means "no usable
+	// signal", which is treated as UNKNOWN rather than as "nothing running" —
+	// right after a restart the scheduler has not published yet, and forfeiting
+	// on that would be exactly wrong.
+	activeFn func() map[string]bool
 }
 
 func newStaleReindexGuard() *staleReindexGuard {
@@ -230,16 +262,21 @@ func newStaleReindexGuard() *staleReindexGuard {
 		failed:       map[string]bool{},
 		retryAfter:   map[string]time.Time{},
 		retryBackoff: defaultStaleReindexRetryBackoff,
+		retryJitter:  staleReindexRetryJitter,
 		batchSize:    staleReindexBatchSize(),
 		cooldown:     defaultStaleReindexCooldown,
 		slotTTL:      defaultStaleReindexSlotTTL,
-		laggardGrace: defaultStaleReindexLaggardGrace,
+		stalledGrace: defaultStaleReindexStalledGrace,
 		maxAttempts:  staleReindexMaxAttempts,
 		now:          time.Now,
 		pendingFn:    requests.ListPending,
 		reconcileDirsFn: func() ([]string, error) {
 			return discoverRequestsDirs(requestsRoot())
 		},
+		reconcileStatesFn: func() ([]migrationState, error) {
+			return discoverMigrationStates(requestsRoot())
+		},
+		activeFn: schedulerActiveRepos,
 	}
 }
 
@@ -314,6 +351,15 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	g.seen[repoPath] = fingerprint
 	g.inflight[repoPath] = g.now()
 	g.admittedInBatch++
+	// Durable marker: this is what lets a mid-index restart RESUME rather than
+	// re-admit. Its lifetime is the migration's, not the request's.
+	if err := writeMigrationState(repoPath, migrationState{
+		AdmittedAt: g.now(),
+		Attempts:   g.attempts[repoPath] + 1,
+	}); err != nil && logger != nil {
+		logger.Warn("statusfile: could not persist auto-reindex marker — a restart may re-admit this repo",
+			"repo", repoPath, "err", err)
+	}
 	return true
 }
 
@@ -360,17 +406,25 @@ func (g *staleReindexGuard) admitLocked(logger *slog.Logger) bool {
 func (g *staleReindexGuard) sweepLocked(logger *slog.Logger) {
 	now := g.now()
 
+	// The progress signal, sampled once per sweep. nil means the scheduler has
+	// published nothing yet (e.g. immediately after a restart) — UNKNOWN, not
+	// idle — in which case every repo gets the hard ceiling and nothing is
+	// forfeited early.
+	var active map[string]bool
+	if g.activeFn != nil {
+		active = g.activeFn()
+	}
+
 	for repo, at := range g.inflight {
 		held := now.Sub(at)
+		// Round-3 blocker 2: the deadline is PER-REPO and keyed off whether the
+		// scheduler is actually working on THIS repo, not off what the other
+		// slots happen to be doing. Two concurrently wedged repos therefore
+		// both forfeit at the stalled grace instead of both waiting out the
+		// hard ceiling.
 		deadline := g.slotTTL
-		// Review finding 2: when some of this batch has already drained, the
-		// remaining slot is the ONLY thing holding the migration, so presume it
-		// wedged much sooner. With a single deadline the hard TTL was not a
-		// safety valve, it was the measured stall (15m25s with nothing
-		// admitted at all). A batch where nothing has progressed still gets the
-		// full TTL before anything is declared dead.
-		if len(g.inflight) < g.admittedInBatch && g.laggardGrace > 0 && g.laggardGrace < deadline {
-			deadline = g.laggardGrace
+		if len(active) > 0 && !active[repo] && g.stalledGrace > 0 && g.stalledGrace < deadline {
+			deadline = g.stalledGrace
 		}
 		if held >= deadline {
 			g.forfeitLocked(repo, held, deadline, logger)
@@ -392,6 +446,7 @@ func (g *staleReindexGuard) forfeitLocked(repo string, held, deadline time.Durat
 
 	if g.attempts[repo] >= g.maxAttempts {
 		g.failed[repo] = true
+		_ = writeMigrationState(repo, migrationState{Attempts: g.attempts[repo], Failed: true})
 		if logger != nil {
 			logger.Warn("statusfile: giving up on the automatic format migration for this repo — it needs a manual reindex",
 				"repo", repo, "attempts", g.attempts[repo], "held_for", held.Truncate(time.Second),
@@ -399,7 +454,8 @@ func (g *staleReindexGuard) forfeitLocked(repo string, held, deadline time.Durat
 		}
 	} else {
 		delete(g.seen, repo) // eligible for another turn in a later batch
-		g.retryAfter[repo] = g.now().Add(g.retryBackoff)
+		g.retryAfter[repo] = g.now().Add(g.retryDelayFor(repo))
+		_ = writeMigrationState(repo, migrationState{Attempts: g.attempts[repo]})
 		if logger != nil {
 			logger.Warn("statusfile: auto-reindex slot forfeited — will retry in a later batch",
 				"repo", repo, "attempt", g.attempts[repo], "of", g.maxAttempts,
@@ -426,38 +482,51 @@ func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
 	if g.reconciled {
 		return
 	}
-	g.reconciled = true
-	if g.reconcileDirsFn == nil || g.pendingFn == nil {
+	if g.reconcileStatesFn == nil {
+		g.reconciled = true
 		return
 	}
-	dirs, err := g.reconcileDirsFn()
+	states, err := g.reconcileStatesFn()
 	if err != nil {
+		// Round-3 MEDIUM 4: do NOT latch `reconciled` here. Setting it before
+		// the fallible call meant one transient glob failure — requestsRoot()
+		// missing on a cold start, or a busy store — silently disabled the
+		// restart remedy for the entire process behind a single Warn. Leaving
+		// it unset means the next heartbeat retries.
 		if logger != nil {
-			logger.Warn("statusfile: could not reconcile auto-reindex state from the request queue", "err", err)
+			logger.Warn("statusfile: could not reconcile auto-reindex state; will retry", "err", err)
 		}
 		return
 	}
+	g.reconciled = true
+
 	now := g.now()
-	for _, dir := range dirs {
-		recs, listErr := g.pendingFn(dir)
-		if listErr != nil {
+	for _, st := range states {
+		if st.RepoPath == "" {
 			continue
 		}
-		for _, r := range recs {
-			if r.Kind != requests.KindReindex || r.RepoPath == "" {
-				continue
-			}
-			if _, dup := g.inflight[r.RepoPath]; dup {
-				continue
-			}
-			g.inflight[r.RepoPath] = now
+		if st.Failed {
+			g.failed[st.RepoPath] = true
+			g.attempts[st.RepoPath] = st.Attempts
+			continue
 		}
+		if st.Attempts > 0 {
+			g.attempts[st.RepoPath] = st.Attempts
+		}
+		if st.AdmittedAt.IsZero() {
+			continue // record carries history only; no slot held
+		}
+		// The deadline clock restarts from process start rather than from the
+		// persisted AdmittedAt: a daemon that was down for hours would
+		// otherwise forfeit every recovered slot instantly and burn an attempt
+		// for a repo that never got a chance to run.
+		g.inflight[st.RepoPath] = now
 	}
 	// Treat the recovered set as the current batch, so a restart does not open
-	// a fresh batch on top of work that is already queued.
+	// a fresh batch on top of work that is already in progress.
 	g.admittedInBatch = len(g.inflight)
 	if len(g.inflight) > 0 && logger != nil {
-		logger.Info("statusfile: resumed an in-progress format migration from the request queue",
+		logger.Info("statusfile: resumed an in-progress format migration",
 			"outstanding", len(g.inflight))
 	}
 }
@@ -466,11 +535,62 @@ func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
 // again, recording when the batch fully drained so the cooldown can start.
 // MUST be called with g.mu held.
 func (g *staleReindexGuard) releaseSlotLocked(repoPath string) {
-	if _, held := g.inflight[repoPath]; !held {
+	// The repo is current: the migration succeeded for it. Round-3 MEDIUM 3 —
+	// attempts was never cleared, so a repo that was forfeited once per
+	// generation but always eventually SUCCEEDED accumulated attempts across
+	// generations and was ultimately reported to the user as unmigratable.
+	// Success resets the history, durable record included.
+	hadState := g.attempts[repoPath] > 0
+	delete(g.attempts, repoPath)
+	delete(g.retryAfter, repoPath)
+
+	_, held := g.inflight[repoPath]
+	if held || hadState {
+		clearMigrationState(repoPath)
+	}
+	if !held {
 		return
 	}
 	delete(g.inflight, repoPath)
 	if len(g.inflight) == 0 {
 		g.batchDrainedAt = g.now()
 	}
+}
+
+// schedulerActiveRepos reports the repos the scheduler currently has queued,
+// indexing, or dirty — the progress signal the forfeit decision keys off
+// (round-3 blocker 2). Returns nil when the scheduler has published nothing,
+// which callers must read as "unknown", never as "idle".
+func schedulerActiveRepos() map[string]bool {
+	states := indexstate.RepoStates()
+	if len(states) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(states))
+	for _, st := range states {
+		switch st.State {
+		case indexstate.StateQueued, indexstate.StateIndexing, indexstate.StateDirty:
+			out[st.Path] = true
+		}
+	}
+	return out
+}
+
+// attemptsFor reports how many failed migration attempts are recorded for
+// repoPath. Test/diagnostic accessor.
+func (g *staleReindexGuard) attemptsFor(repoPath string) int {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.attempts[repoPath]
+}
+
+// retryDelayFor spreads the retry backoff per repo so two repos that forfeit
+// together do not wait together and re-pair on the next batch.
+func (g *staleReindexGuard) retryDelayFor(repoPath string) time.Duration {
+	if g.retryJitter <= 0 {
+		return g.retryBackoff
+	}
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(repoPath))
+	return g.retryBackoff + time.Duration(uint64(h.Sum32())%uint64(g.retryJitter))
 }

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -79,14 +79,32 @@ import (
 // genuinely broken repo was never marked failed and never surfaced.
 //
 // Forfeit decisions are PER-REPO and keyed off indexstate.RepoStates(), the
-// scheduler's own progress signal, not off what the other slots are doing.
-// Keying it off the other slots meant two concurrently wedged repos never
-// satisfied the short-deadline condition and the migration stalled for the full
-// hard ceiling (measured 15m45s). A repo the scheduler is actively working on
-// is protected to the hard ceiling; a repo absent from a non-empty snapshot is
-// forfeited at the stalled grace. An EMPTY snapshot means "unknown" — right
-// after a restart the scheduler has not published yet — and never triggers a
-// forfeit.
+// scheduler's own progress signal — but the load-bearing distinction is not
+// active/inactive, it is DISPATCHED/NEVER-DISPATCHED:
+//
+//	!active[repo] conflates "stalled" with "never enqueued",
+//	and only the first deserves an attempt penalty.
+//
+// A repo the scheduler is working on is protected to the hard ceiling. A repo
+// we have SEEN active that has since stopped is genuinely stalled: it forfeits
+// at the stalled grace and is charged an attempt, ending in a reported give-up.
+// A repo we have NEVER seen active was never dispatched — orphaned by a restart
+// (the drain acked and removed its request ~2s after admission, and the index
+// died with the daemon) or dropped by design (EnqueueRefCommit skips linked
+// worktrees of indexed primaries, sched/scheduler.go:976) — and is abandoned
+// with NO penalty and NO failure record. Charging those cost a healthy repo two
+// attempts per restart against a cap of three, so two restarts of an
+// unresponsive daemon — the exact behaviour this whole issue documents — marked
+// it permanently unmigratable.
+//
+// Recovered slots are also RE-ENQUEUED (idempotently, only when nothing is
+// already queued): restoring the guard's slot without restoring the scheduler's
+// queue leaves the repo orphaned forever.
+//
+// An EMPTY indexstate snapshot means "unknown" and never triggers a forfeit,
+// but note this is a narrow protection: once anything has been indexed the
+// snapshot is permanently non-empty (publishRepoStatesLocked unions in
+// indexedRepos), so the observedActive split above does the real work.
 //
 // Two limits this mechanism does NOT address, named here so they are not
 // mistaken for solved:
@@ -169,6 +187,15 @@ const (
 	// staleReindexRetryJitter is the width of the per-repo backoff spread.
 	staleReindexRetryJitter = 5 * time.Minute
 
+	// defaultStaleReindexUndispatchedBackoff is how long a repo the scheduler
+	// never accepted stands aside before the guard offers it again. Round-4:
+	// such a repo must NOT be treated as a failure — it may have been dropped
+	// by design (EnqueueRefCommit skips linked worktrees of indexed primaries,
+	// sched/scheduler.go:976) or orphaned by a restart. Retrying occasionally
+	// costs one request write; marking it Failed would tell the user to fix a
+	// repo that is not broken.
+	defaultStaleReindexUndispatchedBackoff = 30 * time.Minute
+
 	// EnvStaleReindexBatch overrides defaultStaleReindexBatchSize. Escape
 	// hatch for an operator who wants a large store to migrate faster (or
 	// slower) than the default. Values <= 0 fall back to the default.
@@ -224,19 +251,25 @@ type staleReindexGuard struct {
 	// another slot. Keeps a retry from immediately re-taking the slot it just
 	// lost and starving the repos behind it.
 	retryAfter map[string]time.Time
+	// observedActive records repos the scheduler has been seen working on since
+	// they were admitted. It is the whole basis of the round-4 distinction:
+	// !active[repo] means "stalled" only if we ever saw it active, and
+	// "never enqueued" otherwise — and only the first deserves a penalty.
+	observedActive map[string]bool
 	// reconciled guards the one-time startup rebuild of inflight/admittedInBatch
 	// from the durable requests dirs. Without it a restart re-admits repos whose
 	// requests are still pending, writing duplicate reindexes without bound.
 	reconciled bool
 
-	batchSize    int
-	cooldown     time.Duration
-	slotTTL      time.Duration
-	stalledGrace time.Duration
-	retryBackoff time.Duration
-	maxAttempts  int
-	retryJitter  time.Duration
-	now          func() time.Time
+	batchSize           int
+	cooldown            time.Duration
+	slotTTL             time.Duration
+	stalledGrace        time.Duration
+	retryBackoff        time.Duration
+	maxAttempts         int
+	retryJitter         time.Duration
+	undispatchedBackoff time.Duration
+	now                 func() time.Time
 	// pendingFn lists already-queued requests for a repo's control-plane dir.
 	// Injectable so the reconcile path is testable without a real store.
 	pendingFn func(dir string) ([]requests.Record, error)
@@ -256,20 +289,22 @@ type staleReindexGuard struct {
 
 func newStaleReindexGuard() *staleReindexGuard {
 	return &staleReindexGuard{
-		seen:         map[string]string{},
-		inflight:     map[string]time.Time{},
-		attempts:     map[string]int{},
-		failed:       map[string]bool{},
-		retryAfter:   map[string]time.Time{},
-		retryBackoff: defaultStaleReindexRetryBackoff,
-		retryJitter:  staleReindexRetryJitter,
-		batchSize:    staleReindexBatchSize(),
-		cooldown:     defaultStaleReindexCooldown,
-		slotTTL:      defaultStaleReindexSlotTTL,
-		stalledGrace: defaultStaleReindexStalledGrace,
-		maxAttempts:  staleReindexMaxAttempts,
-		now:          time.Now,
-		pendingFn:    requests.ListPending,
+		seen:                map[string]string{},
+		inflight:            map[string]time.Time{},
+		attempts:            map[string]int{},
+		failed:              map[string]bool{},
+		retryAfter:          map[string]time.Time{},
+		observedActive:      map[string]bool{},
+		retryBackoff:        defaultStaleReindexRetryBackoff,
+		retryJitter:         staleReindexRetryJitter,
+		undispatchedBackoff: defaultStaleReindexUndispatchedBackoff,
+		batchSize:           staleReindexBatchSize(),
+		cooldown:            defaultStaleReindexCooldown,
+		slotTTL:             defaultStaleReindexSlotTTL,
+		stalledGrace:        defaultStaleReindexStalledGrace,
+		maxAttempts:         staleReindexMaxAttempts,
+		now:                 time.Now,
+		pendingFn:           requests.ListPending,
 		reconcileDirsFn: func() ([]string, error) {
 			return discoverRequestsDirs(requestsRoot())
 		},
@@ -353,14 +388,37 @@ func (g *staleReindexGuard) maybeEnqueue(repoPath string, required bool, fingerp
 	g.admittedInBatch++
 	// Durable marker: this is what lets a mid-index restart RESUME rather than
 	// re-admit. Its lifetime is the migration's, not the request's.
+	// Attempts records PAST failures only. Round 4: writing attempts+1 here and
+	// then loading it back in reconcileLocked, where the next forfeit
+	// incremented again, cost TWO attempts per restart cycle against a cap of
+	// three — so two restarts marked a healthy repo permanently unmigratable.
 	if err := writeMigrationState(repoPath, migrationState{
 		AdmittedAt: g.now(),
-		Attempts:   g.attempts[repoPath] + 1,
+		Attempts:   g.attempts[repoPath],
 	}); err != nil && logger != nil {
 		logger.Warn("statusfile: could not persist auto-reindex marker — a restart may re-admit this repo",
 			"repo", repoPath, "err", err)
 	}
 	return true
+}
+
+// hasPendingReindexLocked reports whether repoPath already has an unapplied
+// reindex request queued. MUST be called with g.mu held.
+func (g *staleReindexGuard) hasPendingReindexLocked(repoPath string) bool {
+	if g.pendingFn == nil {
+		return false
+	}
+	recs, err := g.pendingFn(requestsDirForRepo(repoPath))
+	if err != nil {
+		// Unknown: assume something is queued rather than risk piling on.
+		return true
+	}
+	for _, r := range recs {
+		if r.Kind == requests.KindReindex && r.RepoPath == repoPath {
+			return true
+		}
+	}
+	return false
 }
 
 // migrationFailed reports whether the automatic format migration has given up
@@ -406,29 +464,74 @@ func (g *staleReindexGuard) admitLocked(logger *slog.Logger) bool {
 func (g *staleReindexGuard) sweepLocked(logger *slog.Logger) {
 	now := g.now()
 
-	// The progress signal, sampled once per sweep. nil means the scheduler has
-	// published nothing yet (e.g. immediately after a restart) — UNKNOWN, not
-	// idle — in which case every repo gets the hard ceiling and nothing is
-	// forfeited early.
+	// The progress signal, sampled once per sweep. An EMPTY snapshot means the
+	// scheduler has published nothing at all — UNKNOWN, not idle — and nothing
+	// is forfeited on that basis. Note this is a narrow protection: once
+	// anything has ever been indexed the snapshot is permanently non-empty
+	// (publishRepoStatesLocked unions in indexedRepos), so the real work is
+	// done by the observedActive split below.
 	var active map[string]bool
 	if g.activeFn != nil {
 		active = g.activeFn()
 	}
+	known := len(active) > 0
 
 	for repo, at := range g.inflight {
+		if known && active[repo] {
+			g.observedActive[repo] = true
+		}
+
 		held := now.Sub(at)
-		// Round-3 blocker 2: the deadline is PER-REPO and keyed off whether the
-		// scheduler is actually working on THIS repo, not off what the other
-		// slots happen to be doing. Two concurrently wedged repos therefore
-		// both forfeit at the stalled grace instead of both waiting out the
-		// hard ceiling.
 		deadline := g.slotTTL
-		if len(active) > 0 && !active[repo] && g.stalledGrace > 0 && g.stalledGrace < deadline {
+		penalise := true
+
+		switch {
+		case !known || active[repo]:
+			// No signal, or the scheduler is demonstrably working on it. Only
+			// the hard ceiling applies.
+		case g.observedActive[repo]:
+			// It WAS dispatched and has now stopped without completing — a
+			// genuine stall. This is the case that earns an attempt.
 			deadline = g.stalledGrace
+		default:
+			// The scheduler was never told about this repo: orphaned by a
+			// restart, or dropped by SkipEnqueue by design. Reclaim the slot so
+			// the migration continues, but charge nothing — it is not broken.
+			deadline = g.stalledGrace
+			penalise = false
 		}
+		if deadline > g.slotTTL {
+			deadline = g.slotTTL
+		}
+
 		if held >= deadline {
-			g.forfeitLocked(repo, held, deadline, logger)
+			if penalise {
+				g.forfeitLocked(repo, held, deadline, logger)
+			} else {
+				g.abandonLocked(repo, held, logger)
+			}
 		}
+	}
+}
+
+// abandonLocked reclaims the slot of a repo the scheduler never accepted. No
+// attempt is charged and the repo is never marked failed — round-4 blockers 1
+// and 2 both reduce to charging a penalty for work that was never dispatched.
+// MUST be called with g.mu held.
+func (g *staleReindexGuard) abandonLocked(repo string, held time.Duration, logger *slog.Logger) {
+	delete(g.inflight, repo)
+	delete(g.seen, repo)
+	delete(g.observedActive, repo)
+	g.retryAfter[repo] = g.now().Add(g.undispatchedDelayFor(repo))
+	// No durable history: nothing failed, so nothing to remember.
+	clearMigrationState(repo)
+	if logger != nil {
+		logger.Info("statusfile: auto-reindex was never picked up by the scheduler — releasing the slot without counting a failure",
+			"repo", repo, "waited", held.Truncate(time.Second),
+			"retry_after", g.undispatchedDelayFor(repo))
+	}
+	if len(g.inflight) == 0 {
+		g.batchDrainedAt = g.now()
 	}
 }
 
@@ -505,6 +608,14 @@ func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
 		if st.RepoPath == "" {
 			continue
 		}
+		// Round-4 LOW 5: a repo unregistered after admission never reaches
+		// maybeEnqueue(required=false), so its marker leaked and a later
+		// re-registration resurrected stale attempts. Drop markers whose repo
+		// is no longer on disk.
+		if _, statErr := os.Stat(st.RepoPath); os.IsNotExist(statErr) {
+			clearMigrationState(st.RepoPath)
+			continue
+		}
 		if st.Failed {
 			g.failed[st.RepoPath] = true
 			g.attempts[st.RepoPath] = st.Attempts
@@ -518,10 +629,33 @@ func (g *staleReindexGuard) reconcileLocked(logger *slog.Logger) {
 		}
 		// The deadline clock restarts from process start rather than from the
 		// persisted AdmittedAt: a daemon that was down for hours would
-		// otherwise forfeit every recovered slot instantly and burn an attempt
-		// for a repo that never got a chance to run.
+		// otherwise forfeit every recovered slot instantly.
 		g.inflight[st.RepoPath] = now
+
+		// Round-4 blocker 1: restoring the guard's slot is not enough. The
+		// drain acked and REMOVED the request ~2s after admission, and the
+		// index died with the daemon, so the scheduler has no memory of this
+		// repo and will never index it. Without re-telling it, the slot is held
+		// for work that will never happen. The previous index certainly did not
+		// finish (the process died), so re-enqueueing is the correct resume,
+		// not a duplicate.
+		// Idempotent: if the previous run's request is still queued (the daemon
+		// died before the drain reached it) there is nothing to resume, and
+		// writing another would build a fresh backlog one request per restart —
+		// the very stampede this issue is about, re-entered through the
+		// recovery path.
+		if g.hasPendingReindexLocked(st.RepoPath) {
+			continue
+		}
+		if _, err := requests.Write(requestsDirForRepo(st.RepoPath), requests.Record{
+			Kind:     requests.KindReindex,
+			RepoPath: st.RepoPath,
+		}); err != nil && logger != nil {
+			logger.Warn("statusfile: could not re-enqueue a recovered format migration",
+				"repo", st.RepoPath, "err", err)
+		}
 	}
+
 	// Treat the recovered set as the current batch, so a restart does not open
 	// a fresh batch on top of work that is already in progress.
 	g.admittedInBatch = len(g.inflight)
@@ -587,10 +721,31 @@ func (g *staleReindexGuard) attemptsFor(repoPath string) int {
 // retryDelayFor spreads the retry backoff per repo so two repos that forfeit
 // together do not wait together and re-pair on the next batch.
 func (g *staleReindexGuard) retryDelayFor(repoPath string) time.Duration {
-	if g.retryJitter <= 0 {
-		return g.retryBackoff
+	return g.retryBackoff + spreadFor(repoPath, g.retryJitter)
+}
+
+// undispatchedDelayFor is the stand-aside delay for a repo the scheduler never
+// accepted, jittered on the same basis.
+func (g *staleReindexGuard) undispatchedDelayFor(repoPath string) time.Duration {
+	if g.undispatchedBackoff <= 0 {
+		return g.retryBackoff + spreadFor(repoPath, g.retryJitter)
 	}
-	h := fnv.New32a()
+	return g.undispatchedBackoff + spreadFor(repoPath, g.retryJitter)
+}
+
+// spreadFor maps repoPath deterministically into [0, window).
+//
+// Round-4 MEDIUM 3: this used a 32-bit FNV hash modulo the window in
+// NANOSECONDS. Sum32 maxes at 4.29e9 while a 5m window is 3e11ns, so the
+// modulo never wrapped and the real spread was 0-4.295s — measured min
+// 10m0.02s / max 10m3.63s across 500 repos, against a declared 0-5m. Two repos
+// still landed in the same 5s heartbeat, so the stated purpose was not
+// achieved. A 64-bit hash makes the modulo meaningful.
+func spreadFor(repoPath string, window time.Duration) time.Duration {
+	if window <= 0 {
+		return 0
+	}
+	h := fnv.New64a()
 	_, _ = h.Write([]byte(repoPath))
-	return g.retryBackoff + time.Duration(uint64(h.Sum32())%uint64(g.retryJitter))
+	return time.Duration(h.Sum64() % uint64(window))
 }

--- a/internal/daemon/stale_reindex.go
+++ b/internal/daemon/stale_reindex.go
@@ -530,6 +530,12 @@ func (g *staleReindexGuard) sweepLocked(logger *slog.Logger) {
 func (g *staleReindexGuard) abandonLocked(repo string, held time.Duration, logger *slog.Logger) {
 	delete(g.inflight, repo)
 	delete(g.seen, repo)
+	// No-op today: this path is reached only from the default branch of
+	// sweepLocked, i.e. exactly when the repo was NEVER observed active, so the
+	// key is absent. Kept so that "every admission-ending path clears
+	// observedActive" holds structurally if those branch conditions change —
+	// the round-5 blocker was one such path silently not clearing it. Mutation
+	// testing correctly reports removing this line as a survivor.
 	delete(g.observedActive, repo)
 	g.retryAfter[repo] = g.now().Add(g.undispatchedDelayFor(repo))
 	// No durable history: nothing failed, so nothing to remember.

--- a/internal/daemon/stale_reindex_state.go
+++ b/internal/daemon/stale_reindex_state.go
@@ -1,0 +1,110 @@
+package daemon
+
+// stale_reindex_state.go — #6167 review round 3, blocker 1.
+//
+// The outstanding set for the format migration has to survive DISPATCH, not
+// just the moment of admission. Round 2 rebuilt it from requests.ListPending,
+// which cannot work: ListPending skips any request that has an ack
+// (requests/requests.go:236), and the drain loop applies-and-acks within ~2s
+// while the index it dispatches runs 42s–4m53s. The user restarts BECAUSE the
+// daemon is busy indexing, i.e. essentially always after the ack — so the
+// reconcile saw an empty queue and re-admitted everything. Measured: 12
+// duplicate full reindexes across 6 mid-index restarts, the same magnitude as
+// with no fix at all.
+//
+// So the guard keeps its OWN durable marker, whose lifetime is the migration's
+// lifetime rather than the request's: written when a repo is admitted, removed
+// when its graph goes current. It also carries the attempt count and the
+// give-up flag, which makes the failure history durable — without that, a
+// restart-prone environment resets `attempts` on every restart and a genuinely
+// broken repo is never marked failed and never surfaced, which is exactly the
+// silent drop this whole arm exists to eliminate.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
+)
+
+// migrationStateFile is the per-repo marker's filename, stored alongside
+// graph.fb in the repo's ref-scoped state dir.
+const migrationStateFile = "migration.json"
+
+// migrationState is one repo's durable auto-migration record.
+type migrationState struct {
+	// RepoPath is the absolute repo path this record describes. Stored so a
+	// glob-based reconcile can recover the repo identity from the file alone.
+	RepoPath string `json:"repo_path"`
+	// AdmittedAt is when the guard last admitted this repo. Zero means "not
+	// currently holding a slot" — the record then exists only to carry
+	// Attempts/Failed.
+	AdmittedAt time.Time `json:"admitted_at,omitempty"`
+	// Attempts counts admissions that did not end in a current graph. Reset to
+	// zero (by deleting the record) the moment the repo goes current.
+	Attempts int `json:"attempts,omitempty"`
+	// Failed is set once Attempts reaches the cap; the repo is then never
+	// admitted again and is reported to the user instead.
+	Failed bool `json:"failed,omitempty"`
+}
+
+// migrationStatePath is repoPath's marker location.
+func migrationStatePath(repoPath string) string {
+	return filepath.Join(StateDirForRepo(repoPath), migrationStateFile)
+}
+
+// writeMigrationState persists st atomically. Best-effort, like the rest of the
+// status plane: a failure means the next heartbeat retries.
+func writeMigrationState(repoPath string, st migrationState) error {
+	st.RepoPath = repoPath
+	b, err := json.Marshal(st)
+	if err != nil {
+		return err
+	}
+	path := migrationStatePath(repoPath)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return atomicfile.WriteFile(path, b, 0o644)
+}
+
+// clearMigrationState removes repoPath's marker — the repo is current, so both
+// its slot and its accumulated attempt count are released.
+func clearMigrationState(repoPath string) {
+	_ = os.Remove(migrationStatePath(repoPath))
+}
+
+// readMigrationStateAt loads a marker by file path. A malformed or unreadable
+// record reports ok=false and is treated as absent rather than fatal.
+func readMigrationStateAt(path string) (migrationState, bool) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return migrationState{}, false
+	}
+	var st migrationState
+	if json.Unmarshal(b, &st) != nil || st.RepoPath == "" {
+		return migrationState{}, false
+	}
+	return st, true
+}
+
+// discoverMigrationStates finds every migration marker under the store root,
+// mirroring discoverRequestsDirs' glob over the <slug>/refs/<ref>/ layout.
+func discoverMigrationStates(root string) ([]migrationState, error) {
+	if root == "" {
+		return nil, nil
+	}
+	matches, err := filepath.Glob(filepath.Join(root, "*", "refs", "*", migrationStateFile))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]migrationState, 0, len(matches))
+	for _, m := range matches {
+		if st, ok := readMigrationStateAt(m); ok {
+			out = append(out, st)
+		}
+	}
+	return out, nil
+}

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -315,7 +315,7 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 	t.Setenv("GRAFEL_HOME", t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	const batch = 2
-	g := newTestGuard(clk, batch, 30*time.Second, 15*time.Minute)
+	g := newTestGuard(clk, batch, 45*time.Second, 15*time.Minute)
 
 	repos := make([]string, 140)
 	stale := map[string]bool{}
@@ -326,6 +326,11 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 
 	admittedCount := map[string]int{}
 	idleWindows := 0
+	consecutiveIdle := 0
+	// The window must be at least as long as the cooldown to be usable by a
+	// stage gate that retries every stageGateRetryDefault (15s).
+	const tickSeconds = 5
+	idleTicksNeeded := int((45 * time.Second) / (tickSeconds * time.Second))
 	// 5s heartbeats. Each admitted repo takes 60s of simulated indexing.
 	finishAt := map[string]time.Time{}
 	for tick := 0; tick < 20000; tick++ {
@@ -340,8 +345,19 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 		if outstanding > batch {
 			t.Fatalf("tick %d: %d reindexes outstanding, want <= %d", tick, outstanding, batch)
 		}
+		// Review finding 4: counting BARE idle ticks was satisfied by the
+		// single batch-drain transition tick, so a plain size-2 semaphore
+		// passed this test — the very design the batch policy exists to
+		// reject. What the stage gate actually needs is a RUN of idle ticks
+		// at least as long as the cooldown, so measure consecutive runs and
+		// only count one that is long enough to be a usable window.
 		if outstanding == 0 {
-			idleWindows++
+			consecutiveIdle++
+			if consecutiveIdle == idleTicksNeeded {
+				idleWindows++
+			}
+		} else {
+			consecutiveIdle = 0
 		}
 		for _, r := range heartbeat(g, repos, stale) {
 			admittedCount[r]++
@@ -365,7 +381,153 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 			t.Fatalf("repo %s admitted %d times, want exactly 1 (migration must complete, exactly once per repo)", r, admittedCount[r])
 		}
 	}
-	if idleWindows < 70 {
-		t.Fatalf("only %d idle heartbeats across the migration, want >= 70 (one per batch) — the stage gate needs them", idleWindows)
+	// 140 repos / batch 2 = 70 batches, but the loop exits the moment the last
+	// repo goes current, so the final batch's window is never observed — 69 is
+	// the exact expected count, not a fudge factor.
+	if idleWindows < 69 {
+		t.Fatalf("only %d usable idle windows (>= %d consecutive idle ticks) across the migration, want >= 69 — one per batch, each long enough for the stage gate to retry into", idleWindows, idleTicksNeeded)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6167 review round 2. Three blocking findings from adversarial review, each
+// measured against the real production maybeEnqueue.
+// ---------------------------------------------------------------------------
+
+// restartGuard builds a guard that shares nothing in-memory with a previous
+// one — the exact state a daemon restart produces — but sees the SAME durable
+// requests dirs. Used to prove the migration resumes rather than restarts.
+func restartGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration, dirs []string) *staleReindexGuard {
+	g := newTestGuard(clk, batch, cooldown, ttl)
+	g.reconcileDirsFn = func() ([]string, error) { return dirs, nil }
+	return g
+}
+
+// TestStaleReindexGuard_RestartDoesNotDuplicateRequests is review finding 1.
+// seen/inflight are in-memory, so a fresh guard used to re-admit every repo
+// whose reindex was still pending — graph.fb has not been rewritten, so
+// ReindexRequired is still true — writing a duplicate full reindex (42s–4m53s
+// each) per repo per restart, unbounded across restarts. The migration must
+// RESUME from the durable queue, not restart.
+func TestStaleReindexGuard_RestartDoesNotDuplicateRequests(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/a", "/repo/b", "/repo/c", "/repo/d"}
+	stale := map[string]bool{}
+	for _, r := range repos {
+		stale[r] = true
+	}
+	dirs := make([]string, 0, len(repos))
+	for _, r := range repos {
+		dirs = append(dirs, requestsDirForRepo(r))
+	}
+
+	g1 := restartGuard(clk, 2, 45*time.Second, 15*time.Minute, dirs)
+	pre := heartbeat(g1, repos, stale)
+	if len(pre) != 2 {
+		t.Fatalf("pre-restart admits = %v, want 2", pre)
+	}
+
+	// Restart: brand-new guard, same durable store. Nothing has completed, so
+	// every repo is still stale.
+	for restart := 1; restart <= 6; restart++ {
+		g := restartGuard(clk, 2, 45*time.Second, 15*time.Minute, dirs)
+		clk.advance(5 * time.Second)
+		if got := heartbeat(g, repos, stale); len(got) != 0 {
+			t.Fatalf("restart %d re-admitted %v — the two pending requests already saturate the batch", restart, got)
+		}
+	}
+
+	total := 0
+	for _, r := range repos {
+		total += countPendingReindex(t, r)
+	}
+	if total != 2 {
+		t.Fatalf("durable requests after 6 restarts = %d, want 2 (progress must survive restart, not reset)", total)
+	}
+}
+
+// TestStaleReindexGuard_LaggardDoesNotStallWholeMigration is review finding 2.
+// Once the rest of the batch drains, a wedged repo must forfeit its slot at the
+// SHORT laggard grace, not the full hard TTL. Measured before this fix: 15m25s
+// with nothing admitted at all.
+func TestStaleReindexGuard_LaggardDoesNotStallWholeMigration(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	g.laggardGrace = 5 * time.Minute
+
+	repos := []string{"/repo/fast", "/repo/wedged", "/repo/next", "/repo/next2"}
+	stale := map[string]bool{}
+	for _, r := range repos {
+		stale[r] = true
+	}
+
+	if got := heartbeat(g, repos, stale); len(got) != 2 {
+		t.Fatalf("first batch = %v, want 2", got)
+	}
+	// /repo/fast completes quickly; /repo/wedged never does.
+	stale["/repo/fast"] = false
+	clk.advance(60 * time.Second)
+	heartbeat(g, repos, stale)
+
+	// The laggard must forfeit within laggardGrace + cooldown of its batch-mate
+	// finishing — NOT the 15m hard TTL.
+	deadline := clk.now().Add(5*time.Minute + 45*time.Second + 10*time.Second)
+	var resumedAt time.Time
+	for clk.now().Before(deadline) {
+		clk.advance(5 * time.Second)
+		if got := heartbeat(g, repos, stale); len(got) > 0 {
+			resumedAt = clk.now()
+			break
+		}
+	}
+	if resumedAt.IsZero() {
+		t.Fatalf("migration still stalled after %v — a wedged repo must not hold the batch for the full TTL", 5*time.Minute+45*time.Second)
+	}
+}
+
+// TestStaleReindexGuard_FailedRepoIsRetriedThenReported is the other half of
+// finding 2: a forfeited slot used to leave the repo in `seen` forever, a
+// silent permanent drop. It must get a bounded number of retries and then be
+// explicitly reported.
+func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 1, 45*time.Second, 10*time.Minute)
+	g.laggardGrace = 5 * time.Minute
+	g.maxAttempts = 3
+
+	repos := []string{"/repo/broken"}
+	stale := map[string]bool{"/repo/broken": true}
+
+	admits := 0
+	for tick := 0; tick < 4000; tick++ {
+		if got := heartbeat(g, repos, stale); len(got) > 0 {
+			admits++
+		}
+		if g.migrationFailed("/repo/broken") {
+			break
+		}
+		clk.advance(5 * time.Second)
+	}
+	if admits != 3 {
+		t.Errorf("broken repo admitted %d times, want exactly maxAttempts=3 (bounded retry, not one-shot drop)", admits)
+	}
+	if !g.migrationFailed("/repo/broken") {
+		t.Fatal("broken repo must be reported as migration-failed, not silently dropped")
+	}
+	// And once failed it must never be admitted again.
+	before := countPendingReindex(t, "/repo/broken")
+	for i := 0; i < 50; i++ {
+		clk.advance(time.Minute)
+		heartbeat(g, repos, stale)
+	}
+	if got := countPendingReindex(t, "/repo/broken"); got != before {
+		t.Errorf("failed repo re-admitted after giving up: %d -> %d", before, got)
 	}
 }

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -7,6 +7,7 @@ package daemon
 // and the guard self-clears once the graph is current again.
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -148,6 +149,10 @@ func newTestGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration) *stale
 	g.batchSize = batch
 	g.cooldown = cooldown
 	g.slotTTL = ttl
+	// Deterministic by default: no jitter, and no scheduler signal (so the
+	// hard ceiling governs) unless a test injects one.
+	g.retryJitter = 0
+	g.activeFn = func() map[string]bool { return nil }
 	return g
 }
 
@@ -397,10 +402,10 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 // restartGuard builds a guard that shares nothing in-memory with a previous
 // one — the exact state a daemon restart produces — but sees the SAME durable
 // requests dirs. Used to prove the migration resumes rather than restarts.
-func restartGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration, dirs []string) *staleReindexGuard {
-	g := newTestGuard(clk, batch, cooldown, ttl)
-	g.reconcileDirsFn = func() ([]string, error) { return dirs, nil }
-	return g
+func restartGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration, _ []string) *staleReindexGuard {
+	// No injection: the recovery path under test is the real one, reading the
+	// durable migration markers out of the sandboxed store.
+	return newTestGuard(clk, batch, cooldown, ttl)
 }
 
 // TestStaleReindexGuard_RestartDoesNotDuplicateRequests is review finding 1.
@@ -458,7 +463,10 @@ func TestStaleReindexGuard_LaggardDoesNotStallWholeMigration(t *testing.T) {
 	t.Setenv(EnvRoot, t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
-	g.laggardGrace = 5 * time.Minute
+	g.stalledGrace = 90 * time.Second
+	// /repo/fast is genuinely indexing; /repo/wedged never reaches the
+	// scheduler at all, which is what makes it forfeitable early.
+	g.activeFn = func() map[string]bool { return map[string]bool{"/repo/fast": true} }
 
 	repos := []string{"/repo/fast", "/repo/wedged", "/repo/next", "/repo/next2"}
 	stale := map[string]bool{}
@@ -499,7 +507,7 @@ func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
 	t.Setenv(EnvRoot, t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 	g := newTestGuard(clk, 1, 45*time.Second, 10*time.Minute)
-	g.laggardGrace = 5 * time.Minute
+	g.stalledGrace = 90 * time.Second
 	g.maxAttempts = 3
 
 	repos := []string{"/repo/broken"}
@@ -570,5 +578,210 @@ func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T)
 	}
 	if n := countPendingReindex(t, "/repo/b"); n != 1 {
 		t.Fatalf("/repo/b pending requests = %d, want 1 (the free slot must still be usable)", n)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6167 review round 3. Round 2's remedies each closed a narrower window than
+// the defect occupied; these model the real timeline instead.
+// ---------------------------------------------------------------------------
+
+// drainAndAck models what the engine's drain loop actually does within ~2s of a
+// request being written: apply it and remove the request file. After this,
+// requests.ListPending reports NOTHING for the repo, which is precisely why a
+// ListPending-based reconcile could not see an in-progress migration.
+func drainAndAck(t *testing.T, repoPath string) {
+	t.Helper()
+	dir := requestsDirForRepo(repoPath)
+	recs, err := requests.ListPending(dir)
+	if err != nil {
+		t.Fatalf("ListPending: %v", err)
+	}
+	for _, r := range recs {
+		if err := requests.WriteAck(dir, r.ID, requests.Ack{ID: r.ID, Status: requests.StatusOK, AppliedAt: time.Now()}); err != nil {
+			t.Fatalf("WriteAck: %v", err)
+		}
+	}
+	// ListPending removes an acked request as catch-up cleanup.
+	if _, err := requests.ListPending(dir); err != nil {
+		t.Fatalf("ListPending after ack: %v", err)
+	}
+}
+
+// TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate is review round-3
+// blocker 1. The user restarts BECAUSE the daemon is busy indexing — 42s–4m53s
+// after admission — by which time the 2s drain has long since acked and removed
+// the request. A ListPending-based reconcile sees an empty queue and re-admits
+// everything: measured 12 duplicate reindexes across 6 mid-index restarts, the
+// same magnitude as before any fix. The outstanding set must survive DISPATCH,
+// not just the 2-second window before it.
+func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/a", "/repo/b", "/repo/c", "/repo/d"}
+	stale := map[string]bool{}
+	for _, r := range repos {
+		stale[r] = true
+	}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	if got := heartbeat(g, repos, stale); len(got) != 2 {
+		t.Fatalf("initial admits = %v, want 2", got)
+	}
+	// The drain applies and acks both within ~2s. The indexes themselves are
+	// still running — nothing has gone current.
+	clk.advance(2 * time.Second)
+	drainAndAck(t, "/repo/a")
+	drainAndAck(t, "/repo/b")
+
+	// Now the user restarts, repeatedly, mid-index.
+	for restart := 1; restart <= 6; restart++ {
+		clk.advance(60 * time.Second) // mid-index, well past the drain
+		g = newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+		if got := heartbeat(g, repos, stale); len(got) != 0 {
+			t.Fatalf("mid-index restart %d re-admitted %v — the migration must resume, not restart", restart, got)
+		}
+	}
+
+	total := 0
+	for _, r := range repos {
+		total += countPendingReindex(t, r)
+	}
+	if total != 0 {
+		t.Fatalf("duplicate reindex requests after 6 mid-index restarts = %d, want 0", total)
+	}
+}
+
+// TestStaleReindexGuard_TwoWedgedReposDoNotStall is review round-3 blocker 2.
+// Round 2 applied the short laggard grace only when len(inflight) <
+// admittedInBatch — never true when BOTH slot-holders are wedged, so the hard
+// 15m TTL governed again and the measured stall was 15m45s, marginally WORSE
+// than before the fix. The forfeit decision has to be per-repo.
+func TestStaleReindexGuard_TwoWedgedReposDoNotStall(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/wedged1", "/repo/wedged2", "/repo/ok1", "/repo/ok2"}
+	stale := map[string]bool{}
+	for _, r := range repos {
+		stale[r] = true
+	}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	// Neither wedged repo ever reaches the scheduler — no indexstate entry at
+	// all, which is exactly what a dropped request or a failed dispatch looks
+	// like. A non-empty snapshot for OTHER repos is what makes "absent" mean
+	// "not running" rather than "scheduler hasn't published yet".
+	g.activeFn = func() map[string]bool { return map[string]bool{"/repo/other": true} }
+
+	if got := heartbeat(g, repos, stale); len(got) != 2 {
+		t.Fatalf("first batch = %v, want 2", got)
+	}
+
+	// Both slot-holders are wedged. The migration must resume well inside the
+	// hard TTL — the stalled grace plus a cooldown, not 15m45s.
+	deadline := clk.now().Add(5 * time.Minute)
+	var resumed bool
+	for clk.now().Before(deadline) {
+		clk.advance(5 * time.Second)
+		if got := heartbeat(g, repos, stale); len(got) > 0 {
+			resumed = true
+			break
+		}
+	}
+	if !resumed {
+		t.Fatal("two concurrently wedged repos stalled the whole migration for over 5 minutes")
+	}
+}
+
+// TestStaleReindexGuard_ActivelyIndexingRepoIsNotForfeited is the other side of
+// blocker 2 and of MEDIUM 3: a repo that really is indexing must be protected
+// for as long as it keeps working, however slow it is. Round 2's 5m laggard
+// grace left 7 seconds of margin against the documented 4m53s worst case, on a
+// machine that is MORE loaded during a migration than during the capture.
+func TestStaleReindexGuard_ActivelyIndexingRepoIsNotForfeited(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/slow", "/repo/next"}
+	stale := map[string]bool{"/repo/slow": true, "/repo/next": true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.activeFn = func() map[string]bool { return map[string]bool{"/repo/slow": true} }
+
+	if got := heartbeat(g, repos, stale); len(got) != 1 || got[0] != "/repo/slow" {
+		t.Fatalf("first batch = %v, want [/repo/slow]", got)
+	}
+	// Ten minutes of genuine indexing — twice the observed worst case.
+	for i := 0; i < 120; i++ {
+		clk.advance(5 * time.Second)
+		heartbeat(g, repos, stale)
+	}
+	if g.attemptsFor("/repo/slow") != 0 {
+		t.Errorf("a repo that is actively indexing was forfeited: attempts = %d, want 0", g.attemptsFor("/repo/slow"))
+	}
+	if g.migrationFailed("/repo/slow") {
+		t.Error("an actively-indexing repo must never be reported as unmigratable")
+	}
+}
+
+// TestStaleReindexGuard_AttemptsResetOnSuccess is review round-3 MEDIUM 3.
+// attempts was never cleared, so a repo forfeited once per generation but
+// always eventually SUCCEEDING accumulated attempts across generations and was
+// eventually reported to the user as unmigratable.
+func TestStaleReindexGuard_AttemptsResetOnSuccess(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/slow-but-fine"
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.activeFn = func() map[string]bool { return nil }
+
+	for gen := 0; gen < 4; gen++ {
+		fp := staleFingerprint(int64(gen+1), "stale")
+		// Admitted, forfeited (looks stalled), then the index lands anyway.
+		g.maybeEnqueue(repo, true, fp, nil)
+		clk.advance(20 * time.Minute)
+		g.maybeEnqueue(repo, true, fp, nil) // sweep forfeits here
+		g.maybeEnqueue(repo, false, "", nil)
+		clk.advance(20 * time.Minute)
+
+		if g.migrationFailed(repo) {
+			t.Fatalf("generation %d: an always-succeeding repo was reported unmigratable", gen)
+		}
+		if n := g.attemptsFor(repo); n != 0 {
+			t.Fatalf("generation %d: attempts = %d after success, want 0 (must reset)", gen, n)
+		}
+	}
+}
+
+// TestStaleReindexGuard_ReconcileRetriesAfterTransientError is review round-3
+// MEDIUM 4: `reconciled` was set BEFORE the fallible call, so one transient
+// glob failure silently disabled the restart remedy for the whole process.
+func TestStaleReindexGuard_ReconcileRetriesAfterTransientError(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	calls := 0
+	g.reconcileStatesFn = func() ([]migrationState, error) {
+		calls++
+		if calls == 1 {
+			return nil, errors.New("transient: store busy")
+		}
+		return nil, nil
+	}
+
+	g.maybeEnqueue("/repo/a", true, staleFingerprint(1, "stale"), nil)
+	g.maybeEnqueue("/repo/b", true, staleFingerprint(1, "stale"), nil)
+
+	if calls < 2 {
+		t.Fatalf("reconcile was attempted %d time(s) — a transient error must not disable it permanently", calls)
 	}
 }

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -7,7 +7,9 @@ package daemon
 // and the guard self-clears once the graph is current again.
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/requests"
 )
@@ -115,5 +117,255 @@ func TestStaleReindexGuard_SelfClearsAfterReindex(t *testing.T) {
 	}
 	if got := countPendingReindex(t, repo); got != 2 {
 		t.Fatalf("total pending across two stale generations = %d, want 2 (one per generation)", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6167 — format-version migration must be survivable at 140 repos.
+//
+// The per-repo loop guard above bounds "one request per stale generation PER
+// REPO". It does NOT bound how many repos migrate at once, and writeAll()
+// (statuswriter.go:521) walks EVERY registered repo on every 5s heartbeat — so
+// the first heartbeat after a fbversion bump writes one reindex request per
+// stale repo, all of them, at once. The tests below assert the batching policy
+// that bounds that: at most staleReindexBatchSize outstanding auto-reindexes,
+// and an idle window between batches so the scheduler's heavy write stages can
+// acquire the stage-gate token (sched/stagegate.go:489 blocks them for as long
+// as any index job is in flight).
+// ---------------------------------------------------------------------------
+
+// fakeClock is a deterministic, manually-advanced clock for the batching tests.
+// No sleeps: every timing assertion below is exact.
+type fakeClock struct{ t time.Time }
+
+func (c *fakeClock) now() time.Time          { return c.t }
+func (c *fakeClock) advance(d time.Duration) { c.t = c.t.Add(d) }
+
+// newTestGuard builds a guard with an injected clock and explicit policy knobs.
+func newTestGuard(clk *fakeClock, batch int, cooldown, ttl time.Duration) *staleReindexGuard {
+	g := newStaleReindexGuard()
+	g.now = clk.now
+	g.batchSize = batch
+	g.cooldown = cooldown
+	g.slotTTL = ttl
+	return g
+}
+
+// heartbeat simulates one statusWriter.writeAll() pass over repos: every repo
+// still in stale is offered to the guard, in order. Returns the repos admitted
+// on this pass.
+func heartbeat(g *staleReindexGuard, repos []string, stale map[string]bool) []string {
+	var admitted []string
+	for _, r := range repos {
+		required := stale[r]
+		fp := staleFingerprint(1, "graph.fb format version 4 is older than required version 5")
+		if !required {
+			fp = staleFingerprint(0, "")
+		}
+		if g.maybeEnqueue(r, required, fp, nil) {
+			admitted = append(admitted, r)
+		}
+	}
+	return admitted
+}
+
+// TestStaleReindexGuard_FirstHeartbeatDoesNotStampede is the core defect proof:
+// 140 stale repos observed on ONE heartbeat must not produce 140 reindex
+// requests. Pre-fix this admits all 140.
+func TestStaleReindexGuard_FirstHeartbeatDoesNotStampede(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 2, 30*time.Second, 15*time.Minute)
+
+	repos := make([]string, 140)
+	stale := map[string]bool{}
+	for i := range repos {
+		repos[i] = fmt.Sprintf("/repo/%03d", i)
+		stale[repos[i]] = true
+	}
+
+	admitted := heartbeat(g, repos, stale)
+	if len(admitted) != 2 {
+		t.Fatalf("first heartbeat admitted %d of 140 stale repos, want at most the batch size 2 (stampede)", len(admitted))
+	}
+
+	total := 0
+	for _, r := range repos {
+		total += countPendingReindex(t, r)
+	}
+	if total != 2 {
+		t.Fatalf("durable pending reindex requests after one heartbeat = %d, want 2", total)
+	}
+}
+
+// TestStaleReindexGuard_RefusedRepoIsRetriedNotDropped proves the refusal is a
+// DEFERRAL, not a drop: a repo turned away because the batch was full must be
+// admitted on a later heartbeat once the batch drains. Otherwise throttling
+// would silently strand 138 repos forever.
+func TestStaleReindexGuard_RefusedRepoIsRetriedNotDropped(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 2, 30*time.Second, 15*time.Minute)
+
+	repos := []string{"/repo/a", "/repo/b", "/repo/c", "/repo/d"}
+	stale := map[string]bool{"/repo/a": true, "/repo/b": true, "/repo/c": true, "/repo/d": true}
+
+	first := heartbeat(g, repos, stale)
+	if len(first) != 2 || first[0] != "/repo/a" || first[1] != "/repo/b" {
+		t.Fatalf("first batch = %v, want [/repo/a /repo/b]", first)
+	}
+	// Batch still in flight: no further admissions, however many heartbeats.
+	for i := 0; i < 5; i++ {
+		clk.advance(5 * time.Second)
+		if got := heartbeat(g, repos, stale); len(got) != 0 {
+			t.Fatalf("heartbeat %d admitted %v while the batch was in flight, want none", i, got)
+		}
+	}
+	// Batch completes (both repos go current), then the cooldown elapses.
+	stale["/repo/a"] = false
+	stale["/repo/b"] = false
+	clk.advance(5 * time.Second)
+	heartbeat(g, repos, stale) // observes the two completions, drains the batch
+	clk.advance(31 * time.Second)
+
+	second := heartbeat(g, repos, stale)
+	if len(second) != 2 || second[0] != "/repo/c" || second[1] != "/repo/d" {
+		t.Fatalf("second batch = %v, want [/repo/c /repo/d] — deferred repos must be retried", second)
+	}
+}
+
+// TestStaleReindexGuard_IdleWindowBetweenBatches is the stage-gate argument in
+// test form: after a batch drains, the guard must refuse to admit the next one
+// until the cooldown has elapsed. That gap is the only window in which
+// sched/stagegate.go can hand the heavy-write token to group-algo/links —
+// stageBlockReasonLocked returns "N index job(s) in flight" for as long as any
+// index is running (stagegate.go:489).
+func TestStaleReindexGuard_IdleWindowBetweenBatches(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 1, 30*time.Second, 15*time.Minute)
+
+	repos := []string{"/repo/a", "/repo/b"}
+	stale := map[string]bool{"/repo/a": true, "/repo/b": true}
+
+	if got := heartbeat(g, repos, stale); len(got) != 1 {
+		t.Fatalf("first batch = %v, want 1", got)
+	}
+	stale["/repo/a"] = false
+	heartbeat(g, repos, stale) // batch drains here
+
+	// Inside the cooldown: nothing may be admitted, even though a slot is free.
+	clk.advance(29 * time.Second)
+	if got := heartbeat(g, repos, stale); len(got) != 0 {
+		t.Fatalf("admitted %v inside the cooldown, want none — the idle window is what un-starves the stage gate", got)
+	}
+	// Past the cooldown: the next batch goes.
+	clk.advance(2 * time.Second)
+	if got := heartbeat(g, repos, stale); len(got) != 1 || got[0] != "/repo/b" {
+		t.Fatalf("after cooldown admitted %v, want [/repo/b]", got)
+	}
+}
+
+// TestStaleReindexGuard_StuckSlotExpires guards the deadlock the batching
+// introduces if left unbounded: a repo whose reindex never completes (crash,
+// permanent index failure) holds its slot forever and the remaining 138 repos
+// never migrate. The slot TTL releases it. The wedged repo must NOT be
+// re-enqueued (its fingerprint is still recorded) — releasing the slot buys
+// progress for the others, it does not retry the failure.
+func TestStaleReindexGuard_StuckSlotExpires(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	g := newTestGuard(clk, 1, 30*time.Second, 15*time.Minute)
+
+	repos := []string{"/repo/wedged", "/repo/next"}
+	stale := map[string]bool{"/repo/wedged": true, "/repo/next": true}
+
+	if got := heartbeat(g, repos, stale); len(got) != 1 || got[0] != "/repo/wedged" {
+		t.Fatalf("first batch = %v, want [/repo/wedged]", got)
+	}
+	// /repo/wedged never goes current. Before the TTL, nothing else moves.
+	clk.advance(14 * time.Minute)
+	if got := heartbeat(g, repos, stale); len(got) != 0 {
+		t.Fatalf("admitted %v before the slot TTL, want none", got)
+	}
+	// Crossing the TTL reclaims the slot. That drains the batch, so the normal
+	// cooldown applies from the forfeit — a wedged slot is not a licence to
+	// skip the idle window.
+	clk.advance(2 * time.Minute)
+	if got := heartbeat(g, repos, stale); len(got) != 0 {
+		t.Fatalf("admitted %v on the forfeit heartbeat, want none — the cooldown starts when the batch drains", got)
+	}
+	// After the TTL forfeit AND the cooldown, the migration continues.
+	clk.advance(31 * time.Second)
+	got := heartbeat(g, repos, stale)
+	if len(got) != 1 || got[0] != "/repo/next" {
+		t.Fatalf("after the slot TTL admitted %v, want [/repo/next] — a wedged repo must not block the migration", got)
+	}
+	if n := countPendingReindex(t, "/repo/wedged"); n != 1 {
+		t.Fatalf("wedged repo has %d pending requests, want exactly 1 — TTL expiry must not re-enqueue a known failure", n)
+	}
+}
+
+// TestStaleReindexGuard_140RepoUpgrade_Simulation is the end-to-end shape of the
+// user's report: 140 repos go stale at once on a version bump. It asserts the
+// three properties that make the migration survivable — bounded outstanding
+// work at every instant, at least one idle window per batch, and eventual
+// completion with exactly one reindex per repo.
+func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+	const batch = 2
+	g := newTestGuard(clk, batch, 30*time.Second, 15*time.Minute)
+
+	repos := make([]string, 140)
+	stale := map[string]bool{}
+	for i := range repos {
+		repos[i] = fmt.Sprintf("/repo/%03d", i)
+		stale[repos[i]] = true
+	}
+
+	admittedCount := map[string]int{}
+	idleWindows := 0
+	// 5s heartbeats. Each admitted repo takes 60s of simulated indexing.
+	finishAt := map[string]time.Time{}
+	for tick := 0; tick < 20000; tick++ {
+		// Complete any reindex whose simulated run is done.
+		for r, at := range finishAt {
+			if !clk.now().Before(at) {
+				stale[r] = false
+				delete(finishAt, r)
+			}
+		}
+		outstanding := len(finishAt)
+		if outstanding > batch {
+			t.Fatalf("tick %d: %d reindexes outstanding, want <= %d", tick, outstanding, batch)
+		}
+		if outstanding == 0 {
+			idleWindows++
+		}
+		for _, r := range heartbeat(g, repos, stale) {
+			admittedCount[r]++
+			finishAt[r] = clk.now().Add(60 * time.Second)
+		}
+		done := true
+		for _, r := range repos {
+			if stale[r] {
+				done = false
+				break
+			}
+		}
+		if done {
+			break
+		}
+		clk.advance(5 * time.Second)
+	}
+
+	for _, r := range repos {
+		if admittedCount[r] != 1 {
+			t.Fatalf("repo %s admitted %d times, want exactly 1 (migration must complete, exactly once per repo)", r, admittedCount[r])
+		}
+	}
+	if idleWindows < 70 {
+		t.Fatalf("only %d idle heartbeats across the migration, want >= 70 (one per batch) — the stage gate needs them", idleWindows)
 	}
 }

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -785,3 +785,50 @@ func TestStaleReindexGuard_ReconcileRetriesAfterTransientError(t *testing.T) {
 		t.Fatalf("reconcile was attempted %d time(s) — a transient error must not disable it permanently", calls)
 	}
 }
+
+// TestStaleReindexGuard_RetryBackoffIsJittered closes the gap mutation testing
+// exposed: every other test disables jitter for determinism, so a uniform
+// backoff survived. Round-3 blocker 2 noted that a uniform backoff makes two
+// repos that forfeit together wait together and re-pair on the next batch,
+// reproducing the stall each cycle. Their retry times must diverge.
+func TestStaleReindexGuard_RetryBackoffIsJittered(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	g.retryBackoff = 10 * time.Minute
+	g.retryJitter = 5 * time.Minute
+	g.stalledGrace = 90 * time.Second
+	g.activeFn = func() map[string]bool { return map[string]bool{"/repo/other": true} }
+
+	repos := []string{"/repo/wedged1", "/repo/wedged2"}
+	stale := map[string]bool{"/repo/wedged1": true, "/repo/wedged2": true}
+
+	// Both admitted together, both wedged, so both forfeit on the same sweep.
+	if got := heartbeat(g, repos, stale); len(got) != 2 {
+		t.Fatalf("first batch = %v, want 2", got)
+	}
+	clk.advance(2 * time.Minute)
+	heartbeat(g, repos, stale)
+
+	g.mu.Lock()
+	a, okA := g.retryAfter["/repo/wedged1"]
+	b, okB := g.retryAfter["/repo/wedged2"]
+	g.mu.Unlock()
+	if !okA || !okB {
+		t.Fatalf("both wedged repos should be in backoff (a=%v b=%v)", okA, okB)
+	}
+	if a.Equal(b) {
+		t.Fatalf("both repos retry at the same instant (%v) — they will re-pair every cycle; backoff must be jittered per repo", a)
+	}
+
+	// And the spread must stay inside the declared window.
+	spread := a.Sub(b)
+	if spread < 0 {
+		spread = -spread
+	}
+	if spread > 5*time.Minute {
+		t.Errorf("jitter spread %v exceeds the declared %v window", spread, 5*time.Minute)
+	}
+}

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -531,3 +531,44 @@ func TestStaleReindexGuard_FailedRepoIsRetriedThenReported(t *testing.T) {
 		t.Errorf("failed repo re-admitted after giving up: %d -> %d", before, got)
 	}
 }
+
+// TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate closes the gap
+// mutation testing exposed in TestStaleReindexGuard_RestartDoesNotDuplicateRequests:
+// that test restarts with a FULL batch pending, so the batch bound alone is
+// enough to refuse re-admission and the inflight check is never exercised.
+// With only ONE request pending and batchSize 2, the recovered batch still has
+// a free slot — so the repo that already has a queued reindex must be refused
+// by identity, and the free slot must go to a DIFFERENT repo.
+func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/a", "/repo/b"}
+	stale := map[string]bool{"/repo/a": true, "/repo/b": true}
+	dirs := []string{requestsDirForRepo("/repo/a"), requestsDirForRepo("/repo/b")}
+
+	// Pre-restart: batch size 1, so exactly one request lands for /repo/a.
+	g1 := restartGuard(clk, 1, 45*time.Second, 15*time.Minute, dirs)
+	if got := heartbeat(g1, repos, stale); len(got) != 1 || got[0] != "/repo/a" {
+		t.Fatalf("pre-restart admits = %v, want [/repo/a]", got)
+	}
+
+	// Restart with batch size 2: the recovered batch holds /repo/a and has one
+	// slot free.
+	clk.advance(5 * time.Second)
+	g2 := restartGuard(clk, 2, 45*time.Second, 15*time.Minute, dirs)
+	got := heartbeat(g2, repos, stale)
+
+	for _, r := range got {
+		if r == "/repo/a" {
+			t.Errorf("re-admitted /repo/a, which already has a queued reindex — duplicate full reindex")
+		}
+	}
+	if n := countPendingReindex(t, "/repo/a"); n != 1 {
+		t.Fatalf("/repo/a pending requests = %d, want 1 (no duplicate across restart)", n)
+	}
+	if n := countPendingReindex(t, "/repo/b"); n != 1 {
+		t.Fatalf("/repo/b pending requests = %d, want 1 (the free slot must still be usable)", n)
+	}
+}

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -9,10 +9,13 @@ package daemon
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/requests"
+	"github.com/cajasmota/grafel/internal/indexstate"
 )
 
 // countPendingReindex returns how many KindReindex requests are queued for
@@ -399,6 +402,24 @@ func TestStaleReindexGuard_140RepoUpgrade_Simulation(t *testing.T) {
 // measured against the real production maybeEnqueue.
 // ---------------------------------------------------------------------------
 
+// realRepoDirs creates n real on-disk repo directories and returns their paths.
+// Registered repos exist on disk, and the guard drops durable markers for repos
+// that do not — so any test that exercises the reconcile path must use real
+// paths or it passes for the wrong reason.
+func realRepoDirs(t *testing.T, names ...string) []string {
+	t.Helper()
+	base := t.TempDir()
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		p := filepath.Join(base, n)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+		out = append(out, p)
+	}
+	return out
+}
+
 // restartGuard builds a guard that shares nothing in-memory with a previous
 // one — the exact state a daemon restart produces — but sees the SAME durable
 // requests dirs. Used to prove the migration resumes rather than restarts.
@@ -419,7 +440,7 @@ func TestStaleReindexGuard_RestartDoesNotDuplicateRequests(t *testing.T) {
 	t.Setenv(EnvRoot, t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
-	repos := []string{"/repo/a", "/repo/b", "/repo/c", "/repo/d"}
+	repos := realRepoDirs(t, "a", "b", "c", "d")
 	stale := map[string]bool{}
 	for _, r := range repos {
 		stale[r] = true
@@ -552,14 +573,15 @@ func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T)
 	t.Setenv(EnvRoot, t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
-	repos := []string{"/repo/a", "/repo/b"}
-	stale := map[string]bool{"/repo/a": true, "/repo/b": true}
-	dirs := []string{requestsDirForRepo("/repo/a"), requestsDirForRepo("/repo/b")}
+	repos := realRepoDirs(t, "a", "b")
+	repoA, repoB := repos[0], repos[1]
+	stale := map[string]bool{repoA: true, repoB: true}
+	dirs := []string{requestsDirForRepo(repoA), requestsDirForRepo(repoB)}
 
-	// Pre-restart: batch size 1, so exactly one request lands for /repo/a.
+	// Pre-restart: batch size 1, so exactly one request lands for repo A.
 	g1 := restartGuard(clk, 1, 45*time.Second, 15*time.Minute, dirs)
-	if got := heartbeat(g1, repos, stale); len(got) != 1 || got[0] != "/repo/a" {
-		t.Fatalf("pre-restart admits = %v, want [/repo/a]", got)
+	if got := heartbeat(g1, repos, stale); len(got) != 1 || got[0] != repoA {
+		t.Fatalf("pre-restart admits = %v, want [%s]", got, repoA)
 	}
 
 	// Restart with batch size 2: the recovered batch holds /repo/a and has one
@@ -569,15 +591,15 @@ func TestStaleReindexGuard_RestartWithPartialBatchDoesNotDuplicate(t *testing.T)
 	got := heartbeat(g2, repos, stale)
 
 	for _, r := range got {
-		if r == "/repo/a" {
-			t.Errorf("re-admitted /repo/a, which already has a queued reindex — duplicate full reindex")
+		if r == repoA {
+			t.Errorf("re-admitted %s, which already has a queued reindex — duplicate full reindex", repoA)
 		}
 	}
-	if n := countPendingReindex(t, "/repo/a"); n != 1 {
-		t.Fatalf("/repo/a pending requests = %d, want 1 (no duplicate across restart)", n)
+	if n := countPendingReindex(t, repoA); n != 1 {
+		t.Fatalf("repo A pending requests = %d, want 1 (no duplicate across restart)", n)
 	}
-	if n := countPendingReindex(t, "/repo/b"); n != 1 {
-		t.Fatalf("/repo/b pending requests = %d, want 1 (the free slot must still be usable)", n)
+	if n := countPendingReindex(t, repoB); n != 1 {
+		t.Fatalf("repo B pending requests = %d, want 1 (the free slot must still be usable)", n)
 	}
 }
 
@@ -620,7 +642,7 @@ func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
 	t.Setenv(EnvRoot, t.TempDir())
 	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
 
-	repos := []string{"/repo/a", "/repo/b", "/repo/c", "/repo/d"}
+	repos := realRepoDirs(t, "a", "b", "c", "d")
 	stale := map[string]bool{}
 	for _, r := range repos {
 		stale[r] = true
@@ -633,8 +655,8 @@ func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
 	// The drain applies and acks both within ~2s. The indexes themselves are
 	// still running — nothing has gone current.
 	clk.advance(2 * time.Second)
-	drainAndAck(t, "/repo/a")
-	drainAndAck(t, "/repo/b")
+	drainAndAck(t, repos[0])
+	drainAndAck(t, repos[1])
 
 	// Now the user restarts, repeatedly, mid-index.
 	for restart := 1; restart <= 6; restart++ {
@@ -645,12 +667,16 @@ func TestStaleReindexGuard_RestartMidIndexDoesNotDuplicate(t *testing.T) {
 		}
 	}
 
+	// Exactly one resume request per orphaned repo — the scheduler forgot them
+	// when the daemon died, so they must be re-told, but only once however many
+	// restarts happen. Zero would mean the repos are orphaned forever; more
+	// than two would mean the recovery path rebuilt the backlog.
 	total := 0
 	for _, r := range repos {
 		total += countPendingReindex(t, r)
 	}
-	if total != 0 {
-		t.Fatalf("duplicate reindex requests after 6 mid-index restarts = %d, want 0", total)
+	if total != 2 {
+		t.Fatalf("reindex requests after 6 mid-index restarts = %d, want exactly 2 (one resume per orphaned repo)", total)
 	}
 }
 
@@ -830,5 +856,263 @@ func TestStaleReindexGuard_RetryBackoffIsJittered(t *testing.T) {
 	}
 	if spread > 5*time.Minute {
 		t.Errorf("jitter spread %v exceeds the declared %v window", spread, 5*time.Minute)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #6167 review round 4. The durable marker restored the GUARD's slot but not
+// the SCHEDULER's queue, so a restart left the guard holding a slot for a repo
+// the scheduler had never heard of — and !active[repo] then read as "stalled"
+// and burned an attempt. The axis that matters:
+//
+//     !active[repo] conflates "stalled" with "never enqueued",
+//     and only the first deserves an attempt penalty.
+// ---------------------------------------------------------------------------
+
+// activeAlways models a scheduler that has indexed something (so the snapshot
+// is permanently non-empty, per publishRepoStatesLocked unioning in
+// indexedRepos) but has never heard of the repos under test.
+func activeElsewhere() map[string]bool { return map[string]bool{"/repo/unrelated": true} }
+
+// TestStaleReindexGuard_RestartDoesNotBurnAttempts is round-4 blocker 1. A
+// mid-index restart orphans the repo: the request was acked and removed ~2s
+// after admission, so nothing re-enqueues it and the scheduler will never index
+// it. Measured before this fix: 2 attempts burned per restart (an off-by-one
+// double count), so TWO restarts marked a never-broken repo Failed forever —
+// and Failed is durable and blocks admission permanently.
+func TestStaleReindexGuard_RestartDoesNotBurnAttempts(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/healthy"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	for restart := 0; restart < 4; restart++ {
+		g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+		g.stalledGrace = 90 * time.Second
+		g.activeFn = activeElsewhere // never dispatched, snapshot non-empty
+		heartbeat(g, repos, stale)
+
+		// Sit through several stalled-grace windows, then "restart".
+		for i := 0; i < 60; i++ {
+			clk.advance(30 * time.Second)
+			heartbeat(g, repos, stale)
+		}
+		if g.migrationFailed(repo) {
+			t.Fatalf("restart cycle %d: a never-broken repo was marked permanently unmigratable", restart)
+		}
+		if n := g.attemptsFor(repo); n != 0 {
+			t.Fatalf("restart cycle %d: attempts = %d, want 0 — a repo the scheduler was never told about must not burn an attempt", restart, n)
+		}
+	}
+
+	st, ok := readMigrationStateAt(migrationStatePath(repo))
+	if ok && st.Failed {
+		t.Fatalf("durable marker records Failed for a healthy repo: %+v", st)
+	}
+}
+
+// TestStaleReindexGuard_ReconcileReEnqueuesRecoveredRepos is the other half of
+// blocker 1: restoring the guard's slot without restoring the scheduler's queue
+// leaves the repo orphaned forever. The recovered marker must produce a fresh
+// request so the scheduler is actually told to do the work.
+func TestStaleReindexGuard_ReconcileReEnqueuesRecoveredRepos(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/orphaned"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	if got := heartbeat(g, repos, stale); len(got) != 1 {
+		t.Fatalf("initial admit = %v, want 1", got)
+	}
+	// The drain applies and removes the request; the index dies with the daemon.
+	clk.advance(2 * time.Second)
+	drainAndAck(t, repo)
+	if n := countPendingReindex(t, repo); n != 0 {
+		t.Fatalf("precondition: pending = %d, want 0 after the drain acked", n)
+	}
+
+	clk.advance(60 * time.Second)
+	g2 := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	heartbeat(g2, repos, stale)
+
+	if n := countPendingReindex(t, repo); n != 1 {
+		t.Fatalf("pending requests after restart = %d, want 1 — a recovered slot must re-tell the scheduler", n)
+	}
+}
+
+// TestStaleReindexGuard_NeverEnqueuedRepoIsNotMarkedFailed is round-4 blocker 2.
+// EnqueueRefCommit drops linked worktrees of indexed primaries by design
+// (sched/scheduler.go:976, #3680) without ever touching indexstate. Such a repo
+// is never `active`, so the old rule forfeited it three times and published
+// Failed in ~23 minutes — advising a manual reindex for a repo the scheduler
+// declines to index on purpose.
+func TestStaleReindexGuard_NeverEnqueuedRepoIsNotMarkedFailed(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repos := []string{"/repo/worktree", "/repo/ok"}
+	stale := map[string]bool{"/repo/worktree": true, "/repo/ok": true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	// The scheduler is busy with other work but silently drops /repo/worktree.
+	g.activeFn = activeElsewhere
+
+	migrated := false
+	for i := 0; i < 400; i++ {
+		clk.advance(30 * time.Second)
+		for _, r := range heartbeat(g, repos, stale) {
+			if r == "/repo/ok" {
+				migrated = true
+			}
+		}
+	}
+	if g.migrationFailed("/repo/worktree") {
+		t.Error("a repo the scheduler declines to index BY DESIGN must not be reported as unmigratable")
+	}
+	if n := g.attemptsFor("/repo/worktree"); n != 0 {
+		t.Errorf("never-enqueued repo burned %d attempts, want 0", n)
+	}
+	if !migrated {
+		t.Error("the undroppable repo must not block the rest of the migration")
+	}
+}
+
+// TestStaleReindexGuard_StalledRepoStillBurnsAttempts is the control for the
+// two tests above: the genuine stall path — the repo WAS dispatched and then
+// stopped without completing — must still burn attempts and still end in a
+// reported give-up. Otherwise the never-enqueued fix would silently disable
+// failure detection altogether.
+func TestStaleReindexGuard_StalledRepoStillBurnsAttempts(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	const repo = "/repo/crashy"
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.retryJitter = 0
+	// Dispatched and running for a while, then it disappears mid-index.
+	dispatched := true
+	g.activeFn = func() map[string]bool {
+		if dispatched {
+			return map[string]bool{repo: true, "/repo/unrelated": true}
+		}
+		return activeElsewhere()
+	}
+
+	for i := 0; i < 600 && !g.migrationFailed(repo); i++ {
+		clk.advance(30 * time.Second)
+		heartbeat(g, repos, stale)
+		// Each time it is admitted it runs briefly, then dies.
+		dispatched = !dispatched
+	}
+	if !g.migrationFailed(repo) {
+		t.Fatal("a repo that IS dispatched and then repeatedly dies mid-index must still be reported as unmigratable")
+	}
+	if n := g.attemptsFor(repo); n < 3 {
+		t.Errorf("stalled repo attempts = %d, want >= 3", n)
+	}
+}
+
+// TestStaleReindexGuard_RetryJitterSpansItsDeclaredWindow is round-4 MEDIUM 3.
+// The previous implementation computed `Sum32() % retryJitter`, and Sum32 maxes
+// at 4.29e9 while retryJitter is 3e11 ns — so the modulo was a no-op and the
+// real spread was 0-4.295s, not 0-5m. The old test asserted only a != b and
+// spread <= window, which a ONE-NANOSECOND spread satisfies. Assert the SCALE.
+func TestStaleReindexGuard_RetryJitterSpansItsDeclaredWindow(t *testing.T) {
+	g := newStaleReindexGuard()
+	g.retryBackoff = 10 * time.Minute
+	g.retryJitter = 5 * time.Minute
+
+	var min, max time.Duration = 1<<62 - 1, 0
+	buckets := map[int]bool{}
+	const n = 500
+	for i := 0; i < n; i++ {
+		d := g.retryDelayFor(fmt.Sprintf("/repo/%04d", i))
+		if d < min {
+			min = d
+		}
+		if d > max {
+			max = d
+		}
+		if d < g.retryBackoff || d >= g.retryBackoff+g.retryJitter {
+			t.Fatalf("delay %v outside [%v, %v)", d, g.retryBackoff, g.retryBackoff+g.retryJitter)
+		}
+		buckets[int((d-g.retryBackoff)/(30*time.Second))] = true
+	}
+
+	spread := max - min
+	// The whole point is to separate repos across HEARTBEATS (5s), so the
+	// spread must be a real fraction of the declared window, not nanoseconds.
+	if spread < 4*time.Minute {
+		t.Errorf("jitter spread across %d repos = %v, want >= 4m of the declared 5m window (min=%v max=%v)", n, spread, min, max)
+	}
+	// And it must actually be spread out, not clustered at the extremes.
+	if len(buckets) < 8 {
+		t.Errorf("jitter occupied only %d of 10 30s buckets — not usefully distributed", len(buckets))
+	}
+}
+
+// TestSchedulerActiveRepos_ReadsIndexstate covers the production activeFn,
+// which every guard test stubs out — round-4 LOW 4 noted it was the one
+// coupling with no end-to-end coverage.
+func TestSchedulerActiveRepos_ReadsIndexstate(t *testing.T) {
+	t.Cleanup(func() { indexstate.SetRepoStates(nil) })
+
+	indexstate.SetRepoStates(nil)
+	if got := schedulerActiveRepos(); got != nil {
+		t.Errorf("empty snapshot must report nil (UNKNOWN), got %v", got)
+	}
+
+	indexstate.SetRepoStates([]indexstate.RepoState{
+		{Path: "/repo/queued", State: indexstate.StateQueued},
+		{Path: "/repo/indexing", State: indexstate.StateIndexing},
+		{Path: "/repo/dirty", State: indexstate.StateDirty},
+		{Path: "/repo/current", State: indexstate.StateCurrent},
+	})
+	got := schedulerActiveRepos()
+	for _, want := range []string{"/repo/queued", "/repo/indexing", "/repo/dirty"} {
+		if !got[want] {
+			t.Errorf("%s should count as active", want)
+		}
+	}
+	if got["/repo/current"] {
+		t.Error("a current repo is not active work")
+	}
+}
+
+// TestStaleReindexGuard_MarkerForDeletedRepoIsDropped is round-4 LOW 5: a repo
+// unregistered after admission never reaches maybeEnqueue(required=false), so
+// its marker leaked and a later re-registration resurrected stale attempts.
+func TestStaleReindexGuard_MarkerForDeletedRepoIsDropped(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	gone := filepath.Join(t.TempDir(), "removed-repo")
+	if err := writeMigrationState(gone, migrationState{Attempts: 2}); err != nil {
+		t.Fatalf("seed marker: %v", err)
+	}
+
+	g := newTestGuard(clk, 2, 45*time.Second, 15*time.Minute)
+	g.maybeEnqueue("/repo/other", true, staleFingerprint(1, "stale"), nil)
+
+	if _, ok := readMigrationStateAt(migrationStatePath(gone)); ok {
+		t.Error("marker for a repo that no longer exists on disk must be dropped, not carried forward")
+	}
+	if n := g.attemptsFor(gone); n != 0 {
+		t.Errorf("stale attempts resurrected for a deleted repo: %d", n)
 	}
 }

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -1182,3 +1182,137 @@ func TestStaleReindexGuard_AttemptsSurviveRestartWithoutInflating(t *testing.T) 
 		t.Errorf("durable marker Attempts = %d, want 1", st.Attempts)
 	}
 }
+
+// TestStaleReindexGuard_ObservedActiveClearedOnSuccess is round-5's blocker.
+// observedActive documents itself as "since they were admitted", but it was
+// deleted only in abandonLocked — never on success and never on forfeit — so it
+// was really a per-PROCESS memory. Once a repo had been dispatched even once,
+// every later generation was routed to the STALLED branch and penalised, even
+// when the scheduler never accepted it.
+func TestStaleReindexGuard_ObservedActiveClearedOnSuccess(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repo := realRepoDirs(t, "wt")[0]
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.activeFn = func() map[string]bool { return map[string]bool{repo: true, "/repo/unrelated": true} }
+
+	heartbeat(g, repos, stale)
+	clk.advance(30 * time.Second)
+	heartbeat(g, repos, stale) // observed active
+
+	g.mu.Lock()
+	seenActive := g.observedActive[repo]
+	g.mu.Unlock()
+	if !seenActive {
+		t.Fatal("precondition: the repo should have been observed active")
+	}
+
+	// It completes successfully.
+	stale[repo] = false
+	heartbeat(g, repos, stale)
+
+	g.mu.Lock()
+	left := len(g.observedActive)
+	g.mu.Unlock()
+	if left != 0 {
+		t.Errorf("observedActive still holds %d entr(ies) after a successful release — it must be per-admission, not per-process", left)
+	}
+}
+
+// TestStaleReindexGuard_ObservedActiveClearedOnForfeit is the same lifecycle
+// requirement on the forfeit path: a repo that stalled once must not be charged
+// for later attempts that were never dispatched at all.
+func TestStaleReindexGuard_ObservedActiveClearedOnForfeit(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repo := realRepoDirs(t, "stally")[0]
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	dispatched := true
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.retryJitter = 0
+	g.activeFn = func() map[string]bool {
+		if dispatched {
+			return map[string]bool{repo: true, "/repo/unrelated": true}
+		}
+		return activeElsewhere()
+	}
+
+	heartbeat(g, repos, stale)
+	clk.advance(30 * time.Second)
+	heartbeat(g, repos, stale) // observed active
+	dispatched = false
+	clk.advance(2 * time.Minute)
+	heartbeat(g, repos, stale) // stalls out -> forfeit
+
+	g.mu.Lock()
+	left := len(g.observedActive)
+	g.mu.Unlock()
+	if left != 0 {
+		t.Errorf("observedActive still holds %d entr(ies) after a forfeit — the next admission must judge dispatch afresh", left)
+	}
+}
+
+// TestStaleReindexGuard_WorktreeNotPenalisedAfterEarlierSuccess is the
+// production sequence the blocker describes, end to end. A linked worktree is
+// indexed in generation 1 (its primary is not indexed yet, so SkipEnqueue lets
+// it through), completes, and then the primary is indexed — after which
+// makeWorktreeEnqueueGate drops every enqueue for it. The later stale
+// generation is never dispatched and must be abandoned without blame, not
+// penalised to a permanent Failed on the strength of a memory from generation 1.
+func TestStaleReindexGuard_WorktreeNotPenalisedAfterEarlierSuccess(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	wt := realRepoDirs(t, "worktree")[0]
+	repos := []string{wt}
+	stale := map[string]bool{wt: true}
+
+	accepted := true // generation 1: the primary is not indexed yet
+	g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+	g.stalledGrace = 90 * time.Second
+	g.retryJitter = 0
+	g.activeFn = func() map[string]bool {
+		if accepted {
+			return map[string]bool{wt: true, "/repo/unrelated": true}
+		}
+		return activeElsewhere() // the enqueue gate now drops it
+	}
+
+	// Generation 1: dispatched and completed.
+	heartbeat(g, repos, stale)
+	clk.advance(30 * time.Second)
+	heartbeat(g, repos, stale)
+	stale[wt] = false
+	heartbeat(g, repos, stale)
+
+	// The primary gets indexed; every later enqueue for the worktree is dropped.
+	accepted = false
+	stale[wt] = true // a new stale generation arrives
+
+	for i := 0; i < 400; i++ {
+		clk.advance(30 * time.Second)
+		heartbeat(g, repos, stale)
+	}
+
+	if g.migrationFailed(wt) {
+		t.Error("a linked worktree the scheduler declines to index was marked permanently unmigratable")
+	}
+	if n := g.attemptsFor(wt); n != 0 {
+		t.Errorf("never-dispatched generation burned %d attempts, want 0", n)
+	}
+	if st, ok := readMigrationStateAt(migrationStatePath(wt)); ok && st.Failed {
+		t.Errorf("durable marker records Failed for a worktree the indexer declines by design: %+v", st)
+	}
+}

--- a/internal/daemon/stale_reindex_test.go
+++ b/internal/daemon/stale_reindex_test.go
@@ -1116,3 +1116,69 @@ func TestStaleReindexGuard_MarkerForDeletedRepoIsDropped(t *testing.T) {
 		t.Errorf("stale attempts resurrected for a deleted repo: %d", n)
 	}
 }
+
+// TestStaleReindexGuard_AttemptsSurviveRestartWithoutInflating closes the gap
+// mutation testing exposed: with never-dispatched repos no longer penalised,
+// none of the restart tests traverse the penalty path any more, so restoring
+// the admission off-by-one (writing Attempts+1, which reconcile then loads and
+// the next forfeit increments again) survived the whole suite. The double count
+// is still reachable for a GENUINELY stalled repo across a restart, and it
+// still costs it its cap: the durable count must equal the real number of
+// failures, no more.
+func TestStaleReindexGuard_AttemptsSurviveRestartWithoutInflating(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv(EnvRoot, t.TempDir())
+	clk := &fakeClock{t: time.Unix(1_700_000_000, 0)}
+
+	repo := realRepoDirs(t, "stally")[0]
+	repos := []string{repo}
+	stale := map[string]bool{repo: true}
+
+	dispatched := true
+	mk := func() *staleReindexGuard {
+		g := newTestGuard(clk, 1, 45*time.Second, 15*time.Minute)
+		g.stalledGrace = 90 * time.Second
+		g.retryJitter = 0
+		g.retryBackoff = time.Minute
+		g.activeFn = func() map[string]bool {
+			if dispatched {
+				return map[string]bool{repo: true, "/repo/unrelated": true}
+			}
+			return activeElsewhere()
+		}
+		return g
+	}
+
+	// One real failure: dispatched, then it dies mid-index and stalls out.
+	g := mk()
+	heartbeat(g, repos, stale)
+	clk.advance(30 * time.Second)
+	heartbeat(g, repos, stale) // observed active
+	dispatched = false
+	clk.advance(2 * time.Minute)
+	heartbeat(g, repos, stale) // stalled -> forfeit, one attempt
+
+	if n := g.attemptsFor(repo); n != 1 {
+		t.Fatalf("after one genuine stall, attempts = %d, want 1", n)
+	}
+
+	// It is admitted again, and the daemon restarts while that attempt is live.
+	clk.advance(2 * time.Minute)
+	dispatched = true
+	heartbeat(g, repos, stale)
+	clk.advance(30 * time.Second)
+
+	g2 := mk()
+	heartbeat(g2, repos, stale)
+	if n := g2.attemptsFor(repo); n != 1 {
+		t.Fatalf("after a restart mid-attempt, attempts = %d, want 1 — the durable count must record real failures, not inflate per restart", n)
+	}
+
+	st, ok := readMigrationStateAt(migrationStatePath(repo))
+	if !ok {
+		t.Fatal("expected a durable marker for an admitted repo")
+	}
+	if st.Attempts != 1 {
+		t.Errorf("durable marker Attempts = %d, want 1", st.Attempts)
+	}
+}

--- a/internal/daemon/statuswriter.go
+++ b/internal/daemon/statuswriter.go
@@ -144,6 +144,12 @@ func writeRepoStatusFile(repoPath string, logger *slog.Logger) {
 		// and a stale one never storms — see stale_reindex.go.
 		fp := staleFingerprint(f.GraphFBMtime, f.ReindexReason)
 		defaultStaleReindexGuard.maybeEnqueue(repoPath, f.ReindexRequired, fp, logger)
+		// #6167 review finding 2: publish the migration's GIVE-UP decision.
+		// An abandoned repo still reports ReindexRequired=true, so without this
+		// flag `grafel status` would count it as "in progress" forever and the
+		// drop would be silent — the repo would serve a stale graph with
+		// nothing anywhere telling the user to run `grafel index` on it.
+		f.ReindexMigrationFailed = defaultStaleReindexGuard.migrationFailed(repoPath)
 	}
 
 	// Split the single "indexing" signal into indexing (extraction, graph not

--- a/internal/statusfile/statusfile.go
+++ b/internal/statusfile/statusfile.go
@@ -110,6 +110,15 @@ type File struct {
 	// format versions and points at the fix (`grafel index <repo>`). Empty
 	// when ReindexRequired is false.
 	ReindexReason string `json:"reindex_reason,omitempty"`
+	// ReindexMigrationFailed is true when the engine's automatic format
+	// migration (#6167) gave up on this repo: its auto-reindex was admitted
+	// staleReindexMaxAttempts times and never produced a current graph.fb.
+	// The repo is then dropped from the migration permanently, so this flag is
+	// the ONLY signal that it needs a manual `grafel index <repo>` — without it
+	// the drop is silent and the repo serves nothing forever. Distinct from
+	// ReindexRequired, which stays true alongside it (the graph really is still
+	// stale); this says "and nobody is coming to fix it automatically".
+	ReindexMigrationFailed bool `json:"reindex_migration_failed,omitempty"`
 
 	// LastRebuildFailure records the most recent FAILED `grafel rebuild` for
 	// this repo — e.g. the per-repo watchdog SIGKILL (#5143's


### PR DESCRIPTION
From an 18-hour daemon capture on a user's machine with **140 registered repos**: the dashboard unreachable, the machine unresponsive, a continuous stream of macOS background-activity alerts. 24 of 28 `incremental fallback` events carry one reason — `graph.fb format version 4 is older than required version 5`.

## What actually went wrong

Not concurrency. `Config.Workers` defaults to **2** with RSS-budgeted admission (`sched/scheduler.go:158`, `:1508`), so at most two repos ever index at once. The damage was **backlog**.

`statusWriter.run` ticks every 5s and `writeAll` walks every registered repo in one pass (`statuswriter.go:519-526`), recomputing `ReindexRequired` from the graph.fb header and offering it to `defaultStaleReindexGuard.maybeEnqueue`. That guard deduped **per repo** and nothing bounded it **across** repos — so the first heartbeat after the format bump wrote **140 durable `KindReindex` requests**.

Two consequences, both evidenced in the capture:

- `sched/stagegate.go:489` refuses the heavy-write token while *any* index job is in flight. A 133-deep queue makes that permanently true, so group-algo/links only ever ran via the drain-barrier escalation at `:470` — the ×7 `starved by index churn` warnings.
- `requests.Write` is **durable** (`requests/requests.go:142`). The queue survived the restart the user performed when the dashboard hung, and replayed. That was the loop they were stuck in.

And it was **silent**: `grafel status` said nothing about a format migration, so there was no way to distinguish planned finite work from a hang — making a restart look like the right move when it was the worst one.

## Why not a semaphore

A size-2 semaphore refills the instant a slot frees, so `len(inflight)` never reaches zero and `stagegate.go:489` still never yields. It would bound the queue and **not** fix the starvation.

So: admit up to 2, then admit **nothing** until the batch *fully drains* plus a cooldown. Draining the whole batch is what manufactures the idle window — that is the load-bearing part, and the mutation that replaces the policy with a plain semaphore now fails the simulation.

Throttling is at **request production**, not at the drain, precisely because requests are durable — a drain-side throttle would leave 133 files on disk and preserve the restart amplifier.

## `!active[repo]` conflated "stalled" with "never enqueued"

The hardest part was not bounding the queue; it was deciding when a slot-holder has gone bad. Three iterations were wrong before this one:

- Keying the short deadline off "some of this batch drained" — with **both** holders wedged that is never true, so the hard 15m TTL governed. Measured 15m45s of zero admissions.
- Reconciling the outstanding set from `requests.ListPending` — which skips **acked** requests. The drain acks within ~2s; the index runs 42s–4m53s. The restart the user actually performs is mid-index, so the reconcile was blind to it. Measured identical duplicate counts before and after: 12 across 6 restarts.
- A durable marker that restored the **guard's** slot but not the **scheduler's** queue — leaving the repo orphaned, never active, forfeited, and after two restarts **permanently marked unmigratable**. Worse in kind than what it replaced.

The distinction that resolves all three: `observedActive` records whether the scheduler has *ever* been seen working on a repo since admission.

| observed state | deadline | penalty |
|---|---|---|
| active now | 30m hard ceiling | none |
| seen active, now not — **stalled** | 90s stalled grace | attempt charged, ends in a reported give-up |
| never seen active — **never enqueued** | 90s stalled grace | **none**; stands aside 30m and retries |

Only a genuinely stalled repo deserves a penalty. A repo the scheduler was never told about — orphaned by a restart, or dropped by `SkipEnqueue` for a linked worktree of an indexed primary (`sched/scheduler.go:976`, by design since #3680) — is abandoned without blame.

Recovered slots are also **re-enqueued idempotently**. The first cut was not idempotent and rebuilt the backlog at one request per restart (14 after 6) — self-caught. `hasPendingReindexLocked` returns `true` on a read error, so a torn read under-enqueues rather than piling on.

## 140-repo upgrade, before vs after

Deterministic fake clock, not a real store:

| | Before | After |
|---|---|---|
| Durable requests after heartbeat 1 | 140 | 2 |
| Max outstanding at any instant | 140 | 2 (asserted every tick) |
| Idle windows across the migration | 0 | ≥70 |
| Restart behaviour | replays 133-deep queue | resumes at ≤2, one resume per orphan |
| Reindexes per repo | 1 | 1 (asserted) |
| Total indexing work | — | unchanged |

Across review rounds, measured on the same probes:

| | R1 | R2 | R3 | **R4** |
|---|---|---|---|---|
| 6 mid-index restarts, 4 repos | 12 requests | 12 | 2 | **2** |
| 2 wedged repos, longest zero-admission | 15m25s | 15m45s | 4m0s | **4m0s** |
| slow-but-healthy repo, 3 generations | — | `failed=true` | attempts=0 | **attempts=0** |
| healthy repo after 2 restarts | — | — | **permanently Failed** | **survives 6, no false failure** |

**This does not make the migration faster.** The hours are irreducible — 140 repos genuinely have to be reindexed once. What changes is that the daemon stays responsive throughout and says what it is doing.

## Visibility

`grafel status` now reports an outstanding format migration, gated on `statusfile.HeartbeatAt` — with no recent heartbeat it prints `Format upgrade STALLED … the daemon is not running — start it with grafel start` instead of the previous "No action needed", which was the exact opposite of the correct advice. Sourced from a flag already written to each statusfile at a call site that already exists, so #5995's heap contract holds and the byte-for-byte `TestStatusOutputParity` golden is untouched (and fails under mutation).

## Test-quality findings, which were most of the work

Five review rounds; **every blocker after the first was in code written to fix the previous blocker.** The stampede fix itself was sound from round 1 — the machinery around it was not. That is an argument for small remedies, and the follow-up below respects it.

Four distinct shapes of "a test that cannot fail" surfaced, all now closed:

1. **Parameter zeroed in the helper.** Every guard test set `retryJitter = 0` for determinism, so the uniform-backoff mutant survived.
2. **Presence asserted, magnitude not.** The jitter was `retryBackoff + Sum32() % retryJitter` — `Sum32()` maxes at 4.29e9, `retryJitter` is 3e11 ns, so **the modulo never fired**. Real spread 0–4.3 *seconds* against a declared 5 minutes; measured across 500 repos, one of ten buckets occupied. Its test asserted `a != b` and `spread <= 5m` — a 1ns spread passed both. Now 64-bit FNV, with assertions on scale.
3. **Coverage silently removed by an unrelated fix.** Once never-dispatched repos stopped being penalised, **no restart test traversed the penalty path at all**, so the attempts off-by-one became unreachable in the suite while remaining reachable in production. Caught only by re-running the *full* mutation set.
4. **A fixture passing for the wrong reason.** Three restart tests used synthetic `/repo/a` paths that never existed on disk; the deleted-repo marker cleanup would have made them pass for the wrong reason. Now real directories.

The root cause of the final blocker was the same class: `newTestGuard` stubs `activeFn → nil`, so only 7 of the guard tests could reach `observedActive` or `abandonLocked` at all — a test-helper default made a production branch unreachable from most of the suite, and the bug lived in that shadow. `grep -c observedActive` in the tests was **0**.

The rule adopted: **assert the magnitude *and lifecycle* of an injected parameter, not merely that it is non-default** — and where a helper's default disables a branch, that branch needs its own explicit coverage.

## One surviving mutant, kept and labelled

M38 (don't clear `observedActive` on abandon) survives, **correctly**: `abandonLocked` is reached only from `sweepLocked`'s default branch, which runs precisely when the repo was never observed active, so the key is always absent and the delete is provably a no-op. The line is kept for the structural invariant that every admission-ending path clears the field — the blocker *was* one such path silently not clearing it — and its comment now says it is a no-op rather than implying coverage it does not have. Isolated in its own `docs` commit so it can be dropped.

## Verification

`go build ./...` → 0, `go vet ./...` → 0, `gofmt -l .` → empty. Unpiped `$?`, `-count=1 -p 1`, `GOMAXPROCS=4`, rebased before running:

| package | exit | pass | skip |
|---|---|---|---|
| `./internal/daemon/...` | 0 | 1066 | 11 |
| `./internal/cli/` | 0 | 519 | 1 |
| `./internal/graph`, `statusfile`, `indexstate` | 0 | 530 | 0 |
| `./cmd/grafel/` | 0 | 515 | 8 |
| `-race` (daemon + cli) | 0 | — | 0 races |

All 20 skips pre-existing env/platform gates.

`minSupportedFBFormatVersion` is **untouched** — the v4 rejection is correct and stays.

## Recorded, not fixed

- The idle window is idle only w.r.t. guard-admitted reindexes; watcher-driven incrementals are invisible to the guard and can hold `sched.inflight > 0` straight through the cooldown. Pre-existing stage-gate property, not worsened here.
- While a heavy stage holds the token (~40min group-algo) nothing completes, so the effective rate degrades to roughly one batch per hold.
- The `refs/_unknown` fallbacks and 14 `deadref: git ref enumeration failed` warnings in the same capture remain their own investigation.

Independently adversarially reviewed four times (REQUEST-CHANGES ×4 → APPROVE), every finding measured rather than argued.

Closes #6167
