### PR TITLE
fix(#6179): the watcher plist told launchd to respawn deliberate exits, unthrottled — and no upgrade path rewrote it

### DIFF
--- a/cmd/grafel/main.go
+++ b/cmd/grafel/main.go
@@ -102,7 +102,34 @@ func main() {
 	// Silent on success; prints one-line warning to stderr on drift.
 	// Skipped when the user is explicitly running `grafel doctor` (which
 	// runs its own full check) and when GRAFEL_SKIP_QUICK_DOCTOR=1.
-	if len(os.Args) < 2 || os.Args[1] != "doctor" {
+	//
+	// Also skipped for `watch` (#6179 F2). Two reasons, both about the
+	// supervised watcher path:
+	//
+	//  1. It is dead weight there. `grafel watch` is launched by launchd/
+	//     systemd, not by a human at a prompt, so a drift warning on its
+	//     stderr goes to watcher.err.log where nobody reads it — and at 140
+	//     repos it is 140 daemon /healthz probes fired simultaneously at
+	//     login, against a daemon that is itself still starting.
+	//  2. It is roughly half of the watcher's signal-handling blind spot.
+	//     runWatch installs the SIGTERM handler that converts a stop request
+	//     into a clean exit 0; until it is installed, a SIGTERM kills the
+	//     process by default action, which both launchd and systemd read as
+	//     an unsuccessful exit and respawn.
+	//
+	//     Measured (5 runs per delay, counting exit-0): before this change the
+	//     window was ~130-150ms; after it, ~60-80ms. So this probe was about
+	//     half of it, NOT essentially all of it — the residual ~70ms is Go
+	//     runtime init, cobra command-tree construction and flag parsing, all
+	//     of which happen before runWatch is entered and cannot be moved
+	//     behind an earlier signal.Notify without arming signals in main().
+	//
+	//     That residual is deliberately left alone. The daemon's reaper only
+	//     targets processes it enumerated via `ps`, so it can never signal a
+	//     70ms-old process, and this was never the reported failure. Arming
+	//     signals in main() to close it would trade a real, global complexity
+	//     cost against a window nothing is known to reach.
+	if len(os.Args) < 2 || (os.Args[1] != "doctor" && os.Args[1] != "watch") {
 		runQuickDoctorHook()
 	}
 	cli.Execute(cli.Hooks{

--- a/install.sh
+++ b/install.sh
@@ -321,8 +321,21 @@ restart_daemon() {
 #
 # Best-effort, like every other post-download step: a failure here prints
 # nothing fatal and never aborts the installer.
+#
+# The output is no longer blanket-discarded (issue #6179 F1-b). --refresh-state
+# also repairs stale per-repo watcher units, and on a machine where they are all
+# stale that re-registers every one of them — hundreds of launchctl invocations
+# and a wave of macOS "Background Items" notifications, right after the user
+# upgrades. Silently is the worst way for that to happen: the only available
+# reading is that the upgrade caused the storm. So the watcher summary is
+# surfaced and everything else (install-state bookkeeping, errors) is still
+# suppressed, keeping the installer quiet in the steady state.
 record_install_state() {
-  "$BIN_DIR/grafel" install --refresh-state >/dev/null 2>&1 || true
+  _rs_out="$("$BIN_DIR/grafel" install --refresh-state 2>/dev/null || true)"
+  if [ -n "$_rs_out" ]; then
+    printf '%s\n' "$_rs_out" | grep -E 'watcher units|Background Items' || true
+  fi
+  unset _rs_out
 }
 
 configure_path() {

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -339,18 +339,88 @@ func runRefreshState(out io.Writer) error {
 	if err != nil {
 		return err
 	}
-	switch {
-	case !res.HadState:
-		// Nothing installed yet: quick-doctor is already silent in this state,
-		// and fabricating an install.json here would make `grafel doctor`
-		// report skills/MCP drift that does not exist.
-		fmt.Fprintln(out, "no ~/.grafel/install.json to refresh — run 'grafel install' to install grafel")
-	case !res.Changed:
-		fmt.Fprintf(out, "install state already current (%s)\n", res.Path)
-	default:
-		fmt.Fprintf(out, "✓ install state refreshed: %s (sha256 %s…)\n", res.Path, res.SHA256[:12])
+	// GRAFEL_REFRESH_STATE_QUIET: `grafel update` re-invokes this command as a
+	// child purely to reach the watcher reconcile below (#6179 F1) and forwards
+	// its output. The install-state bookkeeping lines are noise in that context
+	// — update prints its own version summary — but the watcher summary is the
+	// whole reason the child exists, so quiet mode suppresses only the former.
+	if os.Getenv(refreshStateQuietEnv) == "" {
+		switch {
+		case !res.HadState:
+			// Nothing installed yet: quick-doctor is already silent in this
+			// state, and fabricating an install.json here would make `grafel
+			// doctor` report skills/MCP drift that does not exist.
+			fmt.Fprintln(out, "no ~/.grafel/install.json to refresh — run 'grafel install' to install grafel")
+		case !res.Changed:
+			fmt.Fprintf(out, "install state already current (%s)\n", res.Path)
+		default:
+			fmt.Fprintf(out, "✓ install state refreshed: %s (sha256 %s…)\n", res.Path, res.SHA256[:12])
+		}
 	}
+
+	// ── watcher-unit reconcile (#6179 F1) ──────────────────────────────────
+	// This is the ONE hook the curl installer already calls with the NEWLY
+	// placed binary (install.sh's record_install_state → `grafel install
+	// --refresh-state`), which makes it the only place a template fix can
+	// reach an existing install automatically. Without it, an upgrade leaves
+	// every already-written watcher unit carrying the old settings —
+	// unconditional KeepAlive, no ThrottleInterval — and the storm #6179
+	// reports continues after the "fix" ships.
+	//
+	// It stays inside RefreshState's spirit rather than violating it: the
+	// argument in internal/install/refreshstate.go is that the installer must
+	// not mutate a repository the user never mentioned, restart the daemon, or
+	// rewrite .claude.json. This touches none of those — only grafel's OWN
+	// already-registered watcher units, only the ones whose rendered content
+	// actually differs, and it is a pure read (no writes, no launchctl) on a
+	// machine that is already current.
+	reconcileWatcherUnits(out, bin)
 	return nil
+}
+
+// reconcileWatcherUnits repairs stale watcher unit files and reports what it
+// did. Best-effort by design: this is a repair bolted onto an unrelated
+// command, so it must never turn a successful --refresh-state into a failure.
+// It is a package var so tests can observe the wiring without a real registry.
+var reconcileWatcherUnits = func(out io.Writer, bin string) {
+	res, err := install.ReconcileWatcherUnits(install.ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		fmt.Fprintf(out, "watcher units: could not reconcile: %v\n", err)
+		return
+	}
+	printReconcileSummary(out, res)
+}
+
+// refreshStateQuietEnv suppresses --refresh-state's install-state bookkeeping
+// lines while keeping the watcher-unit summary. Set by `grafel update` on the
+// child it spawns; not a user-facing knob.
+const refreshStateQuietEnv = "GRAFEL_REFRESH_STATE_QUIET"
+
+// printReconcileSummary reports what the watcher reconcile did.
+//
+// It says the notification burst is coming (#6179 F1-b). On a machine where
+// every unit is stale — precisely the machine #6179 was reported from — the
+// one-time repair re-registers all of them, and each re-registration is a
+// launchctl bootout+bootstrap that macOS posts a Background Items notification
+// for. Silence there would look exactly like the bug recurring the moment the
+// user upgrades, so the burst has to be announced rather than merely tolerated.
+//
+// Silent when nothing was stale: that is the steady state and it deserves no
+// output at all.
+func printReconcileSummary(out io.Writer, res *install.ReconcileWatcherResult) {
+	if res == nil || len(res.Rewritten) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "✓ watcher units refreshed: %d rewritten, %d re-registered, %d already current\n",
+		len(res.Rewritten), len(res.Reloaded), res.Current)
+	if len(res.Reloaded) > 0 {
+		fmt.Fprintf(out, "  macOS may show up to %d Background Items notifications while these "+
+			"re-register — this is the one-time repair for issue #6179, not a recurrence\n",
+			len(res.Reloaded))
+	}
+	for _, w := range res.Warnings {
+		fmt.Fprintf(out, "  warning: %s\n", w)
+	}
 }
 
 // resolveToolSelection decides the per-tool selection for `grafel install`.

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -75,11 +77,24 @@ version the command exits 0 without downloading anything.`,
 						}
 					}
 				}
-				// Re-run install to refresh watcher units + MCP entries.
+				// Re-run install to refresh MCP entries.
+				//
+				// SkipWatchers (#6179 F1): this loop runs BEFORE runSelfUpdate
+				// swaps the binary, so `bin` here is the OLD grafel and Apply
+				// would render the OLD unit template — writing and re-registering
+				// every watcher with exactly the settings we are trying to
+				// replace, and then having the post-swap reconcile rewrite and
+				// re-register all of them again. At 140 repos that is 280
+				// launchctl bootout+bootstrap cycles — two rounds of the macOS
+				// Background Items notification burst — to reach a state one
+				// round reaches. Watcher units are owned by the post-swap
+				// reconcile in runSelfUpdate, which renders the NEW template and
+				// touches only the units whose content actually changed.
 				_, _ = install.Apply(install.Options{
-					Group:   g.Name,
-					Config:  cfg,
-					BinPath: bin,
+					Group:        g.Name,
+					Config:       cfg,
+					BinPath:      bin,
+					SkipWatchers: true,
 				})
 			}
 			// MCP entries should always reflect the live binary path.
@@ -99,6 +114,68 @@ version the command exits 0 without downloading anything.`,
 	return cmd
 }
 
+// refreshWatcherUnitsWithNewBinary re-invokes the just-installed binary as
+// `grafel install --refresh-state`, whose handler reconciles stale watcher unit
+// files (#6179 F1).
+//
+// Why a subprocess: after RunUpdate's atomic rename the file at os.Executable()
+// is the NEW grafel, but this process is still running the OLD code, including
+// the OLD unit template. Rendering the fixed template requires executing the
+// new binary. `install --refresh-state` is reused rather than a new subcommand
+// because it is the same narrow, non-mutating entrypoint the curl installer
+// already calls for exactly this "make on-disk state agree with the binary I
+// just placed" purpose.
+//
+// Best-effort and silent on success: an update must not fail because a watcher
+// plist could not be rewritten. A package var so tests can assert the wiring
+// without spawning anything.
+var refreshWatcherUnitsWithNewBinary = func(out io.Writer) {
+	bin, err := os.Executable()
+	if err != nil {
+		return
+	}
+	cmd := exec.Command(bin, "install", "--refresh-state")
+	// GRAFEL_SKIP_QUICK_DOCTOR: the child would otherwise run the quick-doctor
+	// preflight against a daemon that RunCopy may still be restarting, and
+	// print a spurious drift warning in the middle of update's own output.
+	// refreshStateQuietEnv drops the child's install-state bookkeeping lines so
+	// only the watcher summary is forwarded.
+	cmd.Env = append(os.Environ(),
+		"GRAFEL_SKIP_QUICK_DOCTOR=1",
+		refreshStateQuietEnv+"=1")
+	b, err := cmd.CombinedOutput()
+	reportWatcherRefresh(out, b, err)
+}
+
+// reportWatcherRefresh forwards the watcher-reconcile child's output.
+//
+// #6179 F1-b: this previously printed only when the child FAILED, so on the
+// success path — the normal path, and the one that produces the burst — the
+// summary was swallowed. On a machine where all 140 units are stale the
+// reconcile re-registers all of them, and loader_darwin.go retries bootstrap up
+// to 3x serially, so the user can see hundreds of launchctl invocations and a
+// wave of macOS Background Items notifications immediately after upgrading.
+// With no output the only available reading is "the fix made it worse".
+//
+// Silence is preserved when the child had nothing to say, which is the steady
+// state once a machine is current.
+func reportWatcherRefresh(out io.Writer, combined []byte, err error) {
+	text := strings.TrimSpace(string(combined))
+	if err != nil {
+		fmt.Fprintf(out, "  watchers: could not refresh watcher units: %v\n", err)
+		if text != "" {
+			fmt.Fprintf(out, "            %s\n", text)
+		}
+		return
+	}
+	if text == "" {
+		return
+	}
+	for _, line := range strings.Split(text, "\n") {
+		fmt.Fprintf(out, "  %s\n", strings.TrimSpace(line))
+	}
+}
+
 // runSelfUpdate executes the new atomic self-update path (#2213) and prints a
 // summary to out.
 func runSelfUpdate(out io.Writer, opts install.UpdateOptions) error {
@@ -111,6 +188,18 @@ func runSelfUpdate(out io.Writer, opts install.UpdateOptions) error {
 		fmt.Fprintln(out, "The previous binary has been restored.")
 		return err
 	}
+
+	// ── watcher-unit reconcile (#6179 F1) ──────────────────────────────────
+	// The binary at this path has just been replaced, so THIS process is still
+	// the old code and cannot render the new unit template. The new binary has
+	// to do it, which is why this re-invokes it rather than calling
+	// install.ReconcileWatcherUnits in-process.
+	//
+	// It runs on the skipped path too: "already at the latest version" only
+	// says the binary matches, not that the units on disk do — a machine that
+	// updated before this fix existed is exactly that case, and it is the one
+	// the #6179 reporter is in.
+	refreshWatcherUnitsWithNewBinary(out)
 
 	if result.Skipped {
 		fmt.Fprintf(out, "✓ grafel is already at the latest version (%s)\n", result.Tag)

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -73,6 +73,112 @@ func (c watchBackoffConfig) shouldDie(failures int) bool {
 	return c.maxConsecutive > 0 && failures >= c.maxConsecutive
 }
 
+// watchExitReason names one way `grafel watch` can terminate.
+//
+// #6179: the launchd unit's respawn contract is expressed as
+// KeepAlive={SuccessfulExit:false}, i.e. launchd reads the decision "should
+// this come back?" off the process EXIT STATUS and nothing else. So every exit
+// path here has to be classified deliberately, and the classification has to be
+// converted into the right status. Getting this wrong in either direction is
+// bad: respawning a deliberate give-up turns one diagnosable failure into a
+// permanent 10s respawn loop (the reported storm), while suppressing a real
+// crash leaves a repo silently unwatched.
+type watchExitReason string
+
+const (
+	// watchExitSignal — SIGINT/SIGTERM. An operator, `grafel watcher stop`, or
+	// the daemon's reaper asked this process to go away.
+	watchExitSignal watchExitReason = "signal"
+	// watchExitRepoGone — the repo path no longer stats at startup.
+	watchExitRepoGone watchExitReason = "repo-missing"
+	// watchExitGaveUp — the consecutive-index-failure ceiling (#5140).
+	watchExitGaveUp watchExitReason = "index-failures"
+	// watchExitFlapping — the rapid-restart detector in watch_flap.go tripped.
+	watchExitFlapping watchExitReason = "crash-loop"
+	// watchExitUsage — argv did not name exactly one repo.
+	watchExitUsage watchExitReason = "usage"
+)
+
+// watchExitRespawn maps each exit reason to whether the supervisor (launchd's
+// KeepAlive, systemd's Restart=on-failure) should bring the watcher back.
+//
+// true  → return a non-nil error; cli.Execute exits 1; the supervisor respawns.
+// false → return nil; the process exits 0; the supervisor leaves it dead.
+//
+// Rationale per entry:
+//
+//   - signal: false. Someone asked us to stop. Respawning fights the requester
+//     — notably the daemon's reaper, which SIGTERMs foreign/duplicate watchers
+//     on its sweep; under the old unconditional KeepAlive that was a reap↔
+//     respawn oscillation.
+//   - repo-missing: false. Relaunching cannot make a deleted path exist. The
+//     tradeoff is deliberate: a repo on a volume that mounts late will not be
+//     retried until the next login or `grafel install`, and that is preferred
+//     over an unbounded respawn loop. The stderr line says so.
+//   - index-failures: false. #5140 made the watcher exit here precisely so an
+//     orphaned watcher reaps itself; a supervisor that immediately undoes that
+//     defeats the whole mechanism.
+//   - crash-loop: false. See watch_flap.go — this IS the give-up, so respawning
+//     it would be a contradiction.
+//   - usage: true. A malformed argv is a genuine non-zero failure and a human
+//     running `grafel watch` by hand must see it. launchd never produces this
+//     case — the generated plist always passes exactly one repo — so
+//     classifying it as respawnable costs nothing in the supervised path.
+//
+// Note that a panic, a SIGKILL/OOM, or any other abnormal termination bypasses
+// this table entirely and yields a non-zero status, so a genuinely crashed
+// watcher still comes back. That is the intent.
+//
+// ── What "do not respawn" now costs, honestly (#6179 F3) ─────────────────────
+//
+// These exits used to be non-zero, so an unconditional KeepAlive respawned them
+// — loudly and wastefully, but the repo did keep getting a watcher. Exiting 0
+// removes that accidental self-healing, which means any OTHER bug that kills
+// watchers now produces silence instead of noise. One such bug exists today and
+// is NOT fixed here:
+//
+//	internal/daemon/watchscan/watchscan.go's sameExe compares the reaper's
+//	os.Executable() against the plist's BinPath with filepath.Clean and no
+//	EvalSymlinks. When those differ only by a symlink — a brew shim, a BinPath
+//	recorded from a different install prefix — every launchd watcher for a
+//	managed repo is classified Foreign and SIGTERMed on the 5-minute sweep.
+//
+// Before this change that was a visible reap↔respawn oscillation. After it,
+// the first reap is final: the watcher exits 0, launchd leaves it stopped, and
+// the only trace is one line in that repo's watcher.err.log. The reaper is out
+// of scope for #6179 (it is filed separately, together with whether per-repo
+// LaunchAgents should exist at all), but the interaction is real and this is
+// where someone debugging "my watchers all silently stopped" should land.
+// A coherent fix there would resolve symlinks in sameExe AND have the reaper
+// bootout the launchd unit when it reaps a launchd-owned watcher, so the
+// on-disk state stops claiming a job that is not running.
+var watchExitRespawn = map[watchExitReason]bool{
+	watchExitSignal:   false,
+	watchExitRepoGone: false,
+	watchExitGaveUp:   false,
+	watchExitFlapping: false,
+	watchExitUsage:    true,
+}
+
+// watchExit renders the termination of `grafel watch` for reason, always
+// logging the cause to stderr (so the condition stays diagnosable in
+// watcher.err.log even when the process exits 0) and returning nil or an error
+// according to watchExitRespawn.
+//
+// An unclassified reason is treated as respawnable — fail safe toward "come
+// back" rather than silently going dark.
+func watchExit(reason watchExitReason, format string, args ...any) error {
+	msg := fmt.Sprintf(format, args...)
+	respawn, known := watchExitRespawn[reason]
+	if !known || respawn {
+		return fmt.Errorf("grafel watch: %s", msg)
+	}
+	fmt.Fprintf(os.Stderr,
+		"grafel watch: %s — exiting 0 (%s); the supervisor will not respawn this watcher\n",
+		msg, reason)
+	return nil
+}
+
 // indexRPCFunc issues the daemon's Index RPC. It is a var (not a direct
 // client.Dial + c.Index call) so tests can stub it and assert on the
 // IndexArgs the watcher builds (e.g. Async) without a live daemon
@@ -195,7 +301,11 @@ func newWatchCmd() *cobra.Command {
 		Short: "Long-lived watcher process (used by launchd/systemd units)",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) != 1 {
-				return errors.New("watch expects exactly one repo path")
+				// Classified respawnable (#6179): a malformed argv is a real
+				// failure a human must see as a non-zero status. The generated
+				// unit always passes exactly one repo, so launchd never
+				// reaches this path.
+				return watchExit(watchExitUsage, "expects exactly one repo path, got %d", len(args))
 			}
 			return runWatch(args[0], group, interval)
 		},
@@ -206,11 +316,38 @@ func newWatchCmd() *cobra.Command {
 }
 
 func runWatch(repo, group string, interval time.Duration) error {
-	if _, err := os.Stat(repo); err != nil {
-		return fmt.Errorf("repo: %w", err)
-	}
+	// Arm the signal handler FIRST (#6179 F2), before any work that can block
+	// or fail. Until signal.Notify runs, a SIGTERM kills this process by
+	// default action — which is death BY a signal, and both launchd
+	// (KeepAlive={SuccessfulExit:false}) and systemd (Restart=on-failure) read
+	// that as an unsuccessful exit and respawn. The whole "a stop request
+	// makes the watcher exit 0 and stay stopped" contract depends on the
+	// handler being installed, so it must not sit behind a filesystem stat.
+	// See also cmd/grafel/main.go, which skips the quick-doctor preflight for
+	// `watch` for the same reason.
+	//
+	// This narrows the window, it does not close it: ~70ms of Go runtime init,
+	// cobra tree construction and flag parsing still precede this line, and
+	// nothing here can cover that. Measured ~130-150ms before these two
+	// changes, ~60-80ms after. The residual is knowingly accepted — the
+	// daemon's reaper only signals processes it enumerated via `ps`, so it
+	// cannot reach a process this young.
 	stop := make(chan os.Signal, 1)
 	signal.Notify(stop, syscall.SIGINT, syscall.SIGTERM)
+
+	if _, err := os.Stat(repo); err != nil {
+		// Deliberate give-up, not a crash (#6179): relaunching cannot make a
+		// path that does not stat start existing. Exit 0 so the supervisor
+		// leaves this watcher dead instead of relaunching it every
+		// ThrottleInterval forever. Re-registering the repo (`grafel install`)
+		// or the next login rewrites and reloads the unit.
+		return watchExit(watchExitRepoGone, "repo %s: %v", repo, err)
+	}
+	// Crash-loop give-up (#6179 F4). Branch on stop, not on err: a deliberate
+	// give-up carries a nil err by design, because it must exit 0.
+	if stop, err := recordWatchStart(repo); stop {
+		return err
+	}
 	tick := time.NewTicker(interval)
 	defer tick.Stop()
 	fmt.Fprintf(os.Stderr, "grafel watch: %s (every %s)\n", repo, interval)
@@ -257,7 +394,10 @@ func runWatch(repo, group string, interval time.Duration) error {
 	for {
 		select {
 		case <-stop:
-			return nil
+			// SIGINT/SIGTERM — an operator, `grafel watcher stop`, or the
+			// daemon's reaper asked us to go away. Exit 0 (#6179) so the
+			// supervisor does not respawn what someone just told us to stop.
+			return watchExit(watchExitSignal, "stopping %s on signal", repo)
 		case <-tick.C:
 			// 1. Reindex the watched repo first. Per ADR-0017 the
 			// indexer runs inside the daemon — `watch` becomes a thin
@@ -280,13 +420,19 @@ func runWatch(repo, group string, interval time.Duration) error {
 				// and spam its err log forever. Exit after N consecutive
 				// failures so an orphaned watcher reaps itself.
 				if backoff.shouldDie(consecutiveFailures) {
-					return fmt.Errorf("grafel watch: giving up after %d consecutive index failures (last: %w)",
+					// Deliberate give-up (#6179). #5140 introduced this exit so
+					// an orphaned watcher reaps itself; under the old
+					// unconditional KeepAlive the supervisor immediately undid
+					// it, which is the sustained-storm mechanism. Exit 0.
+					return watchExit(watchExitGaveUp,
+						"giving up after %d consecutive index failures (last: %v)",
 						consecutiveFailures, err)
 				}
 				sleep := backoff.backoffSleep(consecutiveFailures)
 				select {
 				case <-stop:
-					return nil
+					// Same signal path as above, reached mid-backoff.
+					return watchExit(watchExitSignal, "stopping %s on signal", repo)
 				case <-time.After(sleep):
 				}
 				continue

--- a/internal/cli/watch_exit_6179_test.go
+++ b/internal/cli/watch_exit_6179_test.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestWatchExitClassification pins the whole point of #6179 defect 2: every way
+// `grafel watch` can terminate is deliberately classified as "launchd should
+// respawn" or "launchd must not respawn". The plist's
+// KeepAlive={SuccessfulExit:false} contract is only correct if this table is
+// correct, because launchd reads the classification off the exit STATUS.
+func TestWatchExitClassification(t *testing.T) {
+	for _, tc := range []struct {
+		reason      watchExitReason
+		wantRespawn bool
+		why         string
+	}{
+		{watchExitSignal, false,
+			"SIGINT/SIGTERM is an operator (or reaper) instruction to stop; respawning fights it"},
+		{watchExitRepoGone, false,
+			"the repo path no longer stats — relaunching cannot make it exist"},
+		{watchExitGaveUp, false,
+			"the consecutive-index-failure ceiling is a deliberate give-up, not a crash"},
+		{watchExitUsage, true,
+			"a bad argv is a real non-zero failure; launchd never produces it, humans must see it"},
+	} {
+		got, known := watchExitRespawn[tc.reason]
+		if !known {
+			t.Fatalf("exit reason %q is unclassified — every exit path must be classified", tc.reason)
+		}
+		if got != tc.wantRespawn {
+			t.Errorf("watchExitRespawn[%q] = %v, want %v — %s", tc.reason, got, tc.wantRespawn, tc.why)
+		}
+	}
+}
+
+// TestWatchExit_DeliberateReasonsReturnNil proves the classification actually
+// reaches the process exit status: cli.Execute exits 1 on a non-nil error, so a
+// deliberate exit must surface as nil.
+func TestWatchExit_DeliberateReasonsReturnNil(t *testing.T) {
+	for _, r := range []watchExitReason{watchExitSignal, watchExitRepoGone, watchExitGaveUp} {
+		if err := watchExit(r, "because %d", 1); err != nil {
+			t.Errorf("watchExit(%q) = %v, want nil (deliberate exit must be exit status 0)", r, err)
+		}
+	}
+	if err := watchExit(watchExitUsage, "bad argv"); err == nil {
+		t.Error("watchExit(usage) = nil, want a non-nil error (genuine failure must be exit status non-zero)")
+	}
+}
+
+// TestRunWatch_MissingRepoExitsSuccessfully covers watch.go's stat guard. A
+// watcher whose repo path is gone previously returned an error → exit 1 →
+// KeepAlive respawn → exit 1 → forever, at launchd's 10s default. It must now
+// exit 0 so launchd leaves it dead.
+func TestRunWatch_MissingRepoExitsSuccessfully(t *testing.T) {
+	home := withSandboxHome(t)
+	missing := filepath.Join(home, "repos", "was-deleted")
+
+	if err := runWatch(missing, "", time.Second); err != nil {
+		t.Fatalf("runWatch on a missing repo returned %v; a vanished repo is a deliberate "+
+			"give-up and must exit 0 so launchd does not respawn it (#6179)", err)
+	}
+}
+
+// TestRunWatch_GiveUpAfterIndexFailuresExitsSuccessfully covers the
+// consecutive-failure ceiling (shouldDie). #5140 made the watcher exit rather
+// than tight-loop; #6179 makes that exit SUCCESSFUL so launchd's KeepAlive does
+// not immediately undo it.
+//
+// This supersedes the old TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable
+// assertion that the return was non-nil — it must still exit, but cleanly.
+func TestRunWatch_GiveUpAfterIndexFailuresExitsSuccessfully(t *testing.T) {
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "solo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	prevBackoff := activeWatchBackoff
+	activeWatchBackoff = func() watchBackoffConfig {
+		return watchBackoffConfig{base: time.Millisecond, max: 5 * time.Millisecond, maxConsecutive: 3}
+	}
+	t.Cleanup(func() { activeWatchBackoff = prevBackoff })
+
+	prevTrigger := indexTriggerFunc
+	indexTriggerFunc = func(string) error { return errDaemonNotRunning }
+	t.Cleanup(func() { indexTriggerFunc = prevTrigger })
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(repo, "", 5*time.Millisecond) }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runWatch gave up with %v; the give-up path is deliberate and must exit 0 "+
+				"so launchd's KeepAlive does not respawn it every ThrottleInterval (#6179)", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runWatch did not exit after repeated index failures (#5140 regression)")
+	}
+}
+
+// TestRunWatch_SignalExitsSuccessfully covers the SIGTERM path end-to-end.
+//
+// This one matters specifically for the reaper interaction noted in #6179: the
+// daemon's sweep SIGTERMs foreign/duplicate `grafel watch` processes, and under
+// the old unconditional KeepAlive launchd relaunched them immediately — a
+// reap↔respawn oscillation. Exiting 0 on signal is what makes the reap stick.
+// (launchd treats death BY an unhandled signal as an unsuccessful exit, so the
+// handler returning normally, rather than the process being signal-killed, is
+// load-bearing.)
+func TestRunWatch_SignalExitsSuccessfully(t *testing.T) {
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "signalled")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register a test-owned handler FIRST so the SIGTERM below can never take
+	// the default action and kill the test binary, whatever runWatch is doing.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGTERM)
+	t.Cleanup(func() { signal.Stop(guard) })
+
+	prevTrigger := indexTriggerFunc
+	indexTriggerFunc = func(string) error { return nil }
+	t.Cleanup(func() { indexTriggerFunc = prevTrigger })
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(repo, "", time.Hour) }()
+
+	// Let runWatch reach its own signal.Notify before signalling.
+	time.Sleep(250 * time.Millisecond)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("raise SIGTERM: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runWatch returned %v on SIGTERM; a stop request is deliberate and must "+
+				"exit 0 so launchd does not respawn what the reaper just killed (#6179)", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runWatch did not exit on SIGTERM")
+	}
+}
+
+// TestWatchCmd_BadArgvStillFails is the counterweight: making deliberate exits
+// succeed must not make EVERY exit succeed. A human typing `grafel watch` with
+// no repo still gets a non-zero status.
+func TestWatchCmd_BadArgvStillFails(t *testing.T) {
+	cmd := newWatchCmd()
+	if err := cmd.RunE(cmd, nil); err == nil {
+		t.Fatal("`grafel watch` with no repo argument must return a non-nil error (exit status 1)")
+	}
+	if err := cmd.RunE(cmd, []string{"a", "b"}); err == nil {
+		t.Fatal("`grafel watch a b` must return a non-nil error (exit status 1)")
+	}
+}

--- a/internal/cli/watch_flap.go
+++ b/internal/cli/watch_flap.go
@@ -1,0 +1,145 @@
+package cli
+
+// watch_flap.go implements the watcher-side rapid-restart detector (#6179 F4).
+//
+// ── Why the supervisor cannot do this on macOS ───────────────────────────────
+//
+// ThrottleInterval bounds how OFTEN launchd relaunches a job, but it is a flat
+// floor rather than a backoff, and launchd never gives up on a KeepAlive job.
+// So a watcher that crashes for a reason relaunching cannot fix — a panic on a
+// corrupt state file, an OOM, a BinPath a package manager moved out from under
+// the plist — relaunches every 60s forever. At the 140 repos #6179 reports that
+// is ~2.3 process launches per second, indefinitely: lower amplitude than the
+// ~14/s the issue describes, but the same unbounded duration, and every launch
+// is still a macOS Background Items event.
+//
+// systemd has StartLimitBurst for exactly this and the unit now sets it
+// (see watchers.StartLimitBurst). launchd has no equivalent, so on macOS the
+// give-up has to live inside the process: count our own recent starts, and once
+// they are clearly a crash loop, exit 0. KeepAlive={SuccessfulExit:false} then
+// leaves the job stopped, which is the only way a launchd job ever stops.
+//
+// ── What is actually counted, and what that costs ────────────────────────────
+//
+// This counts STARTS, not crashes. It cannot do otherwise: by the time the
+// process is running, "launchd relaunched me because I crashed" and "a human
+// just registered me" are indistinguishable from the inside. So every
+// legitimate launch counts too — a manual `grafel watch`, or the launch that
+// follows a launchctl bootstrap.
+//
+// That has a sharp consequence, and it is why watchers.ResetWatchStarts exists:
+// registering a unit must clear the history, or the documented remedy for a
+// tripped detector would be self-defeating (the re-registration is itself a
+// counted start, so the revived watcher would give up again). install.Apply and
+// install.ReconcileWatcherUnits both reset on registration.
+//
+// ── Why the thresholds ───────────────────────────────────────────────────────
+//
+// A healthy watcher starts once per login and runs for days. A crash-looping
+// one starts every ThrottleInterval — 60 starts/hour. flapMaxStarts=12 in
+// flapWindow=1h trips a crash loop in about twelve minutes.
+//
+// The margin against human workflow is real but not enormous, precisely because
+// starts and not crashes are counted: the person most likely to reach this
+// threshold is someone actively debugging watchers, who is also the person
+// running `grafel watch` by hand repeatedly. Registration resets remove the
+// dominant source (install / group add / reconcile), and 12 leaves room for a
+// dozen manual runs an hour; the cost of the higher number is four extra
+// minutes of a crash loop, which is the cheaper side of that trade.
+//
+// The record is per-repo and lives beside the watcher's own log files, so it is
+// naturally scoped, naturally cleaned up when the repo is removed, and visible
+// to anyone already looking at watcher.err.log for an explanation.
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+const (
+	// flapWindow is how far back start timestamps are counted.
+	flapWindow = time.Hour
+	// flapMaxStarts is the number of starts within flapWindow that means
+	// "this is a crash loop, not a workflow".
+	flapMaxStarts = 12
+)
+
+// flapNow is time.Now, indirected so tests can drive the clock.
+var flapNow = time.Now
+
+// flapRecordPath returns the per-repo start-history file. The location is
+// owned by the watchers package because the registration paths there must be
+// able to reset it (see watchers.ResetWatchStarts).
+func flapRecordPath(repo string) string {
+	return watchers.WatchStartsPath(repo)
+}
+
+// flapRecord is the on-disk start history.
+type flapRecord struct {
+	// Starts holds the timestamps of recent watcher starts, oldest first,
+	// pruned to flapWindow on every read.
+	Starts []time.Time `json:"starts"`
+}
+
+// readFlapRecord loads the start history, pruned to the window. A missing,
+// unreadable or corrupt file yields an empty history: this is a safety valve,
+// and a safety valve that fails closed would take out healthy watchers.
+func readFlapRecord(path string, now time.Time) flapRecord {
+	var rec flapRecord
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return flapRecord{}
+	}
+	if err := json.Unmarshal(b, &rec); err != nil {
+		return flapRecord{}
+	}
+	cutoff := now.Add(-flapWindow)
+	kept := rec.Starts[:0]
+	for _, ts := range rec.Starts {
+		if ts.After(cutoff) {
+			kept = append(kept, ts)
+		}
+	}
+	rec.Starts = kept
+	return rec
+}
+
+// recordWatchStart appends this start to the repo's history and reports whether
+// the watcher should give up.
+//
+// It returns (stop, err). The two results are deliberately separate: a
+// deliberate give-up is an exit-0 give-up, so its err is nil — exactly like
+// every other entry in watchExitRespawn that is classified do-not-respawn.
+// Signalling the give-up through the error alone would make it identical to
+// "everything is fine", which is precisely the confusion #6179 is about. The
+// caller must branch on stop, not on err.
+//
+// Any I/O problem is swallowed and returns (false, nil): an unwritable .grafel
+// directory must degrade to the previous behaviour (no give-up) rather than
+// stopping a watcher that is otherwise healthy.
+func recordWatchStart(repo string) (stop bool, err error) {
+	now := flapNow()
+	path := flapRecordPath(repo)
+	rec := readFlapRecord(path, now)
+	rec.Starts = append(rec.Starts, now)
+
+	if mkErr := os.MkdirAll(filepath.Dir(path), 0o755); mkErr == nil {
+		if b, mErr := json.Marshal(rec); mErr == nil {
+			_ = os.WriteFile(path, b, 0o644)
+		}
+	}
+
+	if len(rec.Starts) <= flapMaxStarts {
+		return false, nil
+	}
+	return true, watchExit(watchExitFlapping,
+		"started %d times in the last %s for %s — treating this as a crash loop and stopping. "+
+			"The cause is in this repo's watcher.err.log. To resume once it is fixed, either "+
+			"delete %s or re-run 'grafel install' (which re-registers the unit and clears this "+
+			"count for you)",
+		len(rec.Starts), flapWindow, repo, path)
+}

--- a/internal/cli/watch_flap_6179_test.go
+++ b/internal/cli/watch_flap_6179_test.go
@@ -1,0 +1,217 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// TestRecordWatchStart_TripsOnCrashLoop pins #6179 F4's macOS give-up.
+//
+// ThrottleInterval only bounds how fast launchd relaunches a crashing watcher,
+// never whether it eventually stops — launchd has no StartLimitBurst. Without
+// this detector, 140 crash-looping watchers relaunch at ~2.3/s forever, which
+// is a lower-amplitude version of the reported storm with the same unbounded
+// duration.
+func TestRecordWatchStart_TripsOnCrashLoop(t *testing.T) {
+	repo := t.TempDir()
+
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	prev := flapNow
+	flapNow = func() time.Time { return now }
+	t.Cleanup(func() { flapNow = prev })
+
+	// A crash loop relaunches every ThrottleInterval (60s).
+	for i := 1; i <= flapMaxStarts; i++ {
+		if stop, err := recordWatchStart(repo); stop || err != nil {
+			t.Fatalf("start %d tripped the detector early: stop=%v err=%v", i, stop, err)
+		}
+		now = now.Add(time.Minute)
+	}
+	// The next start is over the line. It must be a DELIBERATE exit: nil, so
+	// the process exits 0 and KeepAlive={SuccessfulExit:false} leaves it dead.
+	stop, err := recordWatchStart(repo)
+	if !stop {
+		t.Fatal("the crash-loop detector never tripped; without it a crashing watcher relaunches " +
+			"every ThrottleInterval forever, since launchd has no StartLimitBurst")
+	}
+	if err != nil {
+		t.Fatalf("the crash-loop give-up returned %v; it must exit 0 like every other "+
+			"deliberate give-up, or launchd relaunches it and the detector achieves nothing", err)
+	}
+	if !watchExitRespawn[watchExitFlapping] == false {
+		t.Fatal("watchExitFlapping must be classified as do-not-respawn")
+	}
+}
+
+// TestRecordWatchStart_RemediationActuallyWorks pins #6179 F4-a.
+//
+// The give-up message tells the user to re-run `grafel install`. That
+// instruction was false: re-registering the unit triggers a launchctl
+// bootstrap, the bootstrap's launch is itself a counted start, so the revived
+// watcher immediately saw an over-threshold history and gave up again. Within
+// the counting window the watcher could not be brought back at all — and the
+// person hitting this is by definition someone debugging watchers, i.e. exactly
+// the person who accumulated the starts in the first place.
+//
+// Registration now resets the history (watchers.ResetWatchStarts, called from
+// install.Apply and install.ReconcileWatcherUnits). This asserts the property
+// end to end: trip it, register, and the next start must survive.
+func TestRecordWatchStart_RemediationActuallyWorks(t *testing.T) {
+	repo := t.TempDir()
+
+	now := time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	prev := flapNow
+	flapNow = func() time.Time { return now }
+	t.Cleanup(func() { flapNow = prev })
+
+	// Drive it over the threshold.
+	var tripped bool
+	for i := 0; i <= flapMaxStarts; i++ {
+		stop, _ := recordWatchStart(repo)
+		tripped = tripped || stop
+		now = now.Add(30 * time.Second)
+	}
+	if !tripped {
+		t.Fatal("setup: the detector never tripped")
+	}
+	// Confirm it is genuinely stuck without the remedy — this is the state the
+	// reviewer measured, and it must stay reproducible if the reset regresses.
+	if stop, _ := recordWatchStart(repo); !stop {
+		t.Fatal("setup: expected the watcher to remain tripped inside the window")
+	}
+
+	// The remedy: re-register the unit. This is what `grafel install` does.
+	if err := watchers.ResetWatchStarts(repo); err != nil {
+		t.Fatalf("ResetWatchStarts: %v", err)
+	}
+
+	// The launch that the bootstrap itself produces must NOT re-trip.
+	if stop, err := recordWatchStart(repo); stop || err != nil {
+		t.Fatalf("the watcher gave up again immediately after re-registration (stop=%v err=%v). "+
+			"The give-up message promises `grafel install` brings it back; if registration does "+
+			"not clear the count, that promise is false (#6179 F4-a)", stop, err)
+	}
+	// And it has real headroom afterwards, not one spare start.
+	for i := 0; i < flapMaxStarts-2; i++ {
+		now = now.Add(30 * time.Second)
+		if stop, _ := recordWatchStart(repo); stop {
+			t.Fatalf("re-registration bought only %d starts of headroom; the reset must clear "+
+				"the whole history, not trim it", i+1)
+		}
+	}
+}
+
+// TestRecordWatchStart_HealthyWatcherNeverTrips: a watcher that starts once per
+// login and runs for days must never be stopped by this. The window prunes, so
+// starts spread across weeks never accumulate.
+func TestRecordWatchStart_HealthyWatcherNeverTrips(t *testing.T) {
+	repo := t.TempDir()
+
+	now := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	prev := flapNow
+	flapNow = func() time.Time { return now }
+	t.Cleanup(func() { flapNow = prev })
+
+	// Thirty logins, one per day — far more than flapMaxStarts in total.
+	for i := 0; i < 30; i++ {
+		if stop, err := recordWatchStart(repo); stop || err != nil {
+			t.Fatalf("daily login %d tripped the crash-loop detector: stop=%v err=%v", i, stop, err)
+		}
+		now = now.Add(24 * time.Hour)
+	}
+}
+
+// TestRecordWatchStart_WindowPrunes proves the count is windowed, not
+// cumulative: starts older than flapWindow must drop out of the record.
+func TestRecordWatchStart_WindowPrunes(t *testing.T) {
+	repo := t.TempDir()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	prev := flapNow
+	flapNow = func() time.Time { return now }
+	t.Cleanup(func() { flapNow = prev })
+
+	for i := 0; i < flapMaxStarts; i++ {
+		if stop, err := recordWatchStart(repo); stop || err != nil {
+			t.Fatalf("stop=%v err=%v", stop, err)
+		}
+		now = now.Add(time.Minute)
+	}
+	// Jump past the window; the accumulated history must age out.
+	now = now.Add(2 * flapWindow)
+	rec := readFlapRecord(flapRecordPath(repo), now)
+	if len(rec.Starts) != 0 {
+		t.Fatalf("record still holds %d starts after %s; the window does not prune",
+			len(rec.Starts), 2*flapWindow)
+	}
+	if stop, err := recordWatchStart(repo); stop || err != nil {
+		t.Fatalf("a start after the window elapsed must not trip: stop=%v err=%v", stop, err)
+	}
+}
+
+// TestRecordWatchStart_UnwritableRepoDoesNotStopTheWatcher: this is a safety
+// valve, and a safety valve that fails closed is worse than no valve. A repo
+// whose .grafel cannot be written must degrade to the previous behaviour.
+func TestRecordWatchStart_UnwritableRepoDoesNotStopTheWatcher(t *testing.T) {
+	repo := t.TempDir()
+	// Make .grafel a FILE so MkdirAll and WriteFile both fail.
+	if err := os.WriteFile(filepath.Join(repo, ".grafel"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < flapMaxStarts*3; i++ {
+		if stop, err := recordWatchStart(repo); stop || err != nil {
+			t.Fatalf("an unwritable record must never stop a watcher, got stop=%v err=%v", stop, err)
+		}
+	}
+}
+
+// TestRecordWatchStart_CorruptRecordIsIgnored: same fail-open argument for a
+// truncated or hand-edited JSON file.
+func TestRecordWatchStart_CorruptRecordIsIgnored(t *testing.T) {
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, ".grafel"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(flapRecordPath(repo), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if stop, err := recordWatchStart(repo); stop || err != nil {
+		t.Fatalf("a corrupt record must be treated as empty, got stop=%v err=%v", stop, err)
+	}
+}
+
+// TestRunWatch_CrashLoopExitsSuccessfully wires the detector into runWatch
+// end-to-end: a repo whose history is already at the ceiling must make runWatch
+// return immediately with nil, never reaching the poll loop.
+func TestRunWatch_CrashLoopExitsSuccessfully(t *testing.T) {
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "flapper")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	prev := flapNow
+	flapNow = func() time.Time { return now }
+	t.Cleanup(func() { flapNow = prev })
+
+	for i := 0; i <= flapMaxStarts; i++ {
+		_, _ = recordWatchStart(repo)
+		now = now.Add(time.Second)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(repo, "", time.Hour) }()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runWatch returned %v; the crash-loop give-up must exit 0", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("runWatch entered the poll loop despite a tripped crash-loop detector")
+	}
+}

--- a/internal/cli/watch_invariants_6179_test.go
+++ b/internal/cli/watch_invariants_6179_test.go
@@ -1,0 +1,336 @@
+package cli
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+)
+
+// #6179 F6: TestWatchExitClassification iterates a table the test itself
+// declares, so it can only check the reasons it already knows about — a fifth
+// exit reason, or a new bare `return err` inside runWatch, passes it unchanged
+// while silently reintroducing exactly the defect #6179 is about. These tests
+// read the actual source instead, so they fail on code that exists rather than
+// on code the test happened to enumerate.
+
+// parseWatchFiles returns the parsed AST for the watch sources.
+func parseWatchFiles(t *testing.T) (*token.FileSet, map[string]*ast.File) {
+	t.Helper()
+	fset := token.NewFileSet()
+	out := map[string]*ast.File{}
+	for _, name := range []string{"watch.go", "watch_flap.go"} {
+		src, err := os.ReadFile(name)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		f, err := parser.ParseFile(fset, name, src, parser.ParseComments)
+		if err != nil {
+			t.Fatalf("parse %s: %v", name, err)
+		}
+		out[name] = f
+	}
+	return fset, out
+}
+
+func findFunc(f *ast.File, name string) *ast.FuncDecl {
+	for _, d := range f.Decls {
+		if fd, ok := d.(*ast.FuncDecl); ok && fd.Name.Name == name && fd.Recv == nil {
+			return fd
+		}
+	}
+	return nil
+}
+
+// TestEveryWatchExitReasonIsClassified walks the watchExitReason const block in
+// the source and requires each declared constant to appear as a key in the
+// watchExitRespawn map literal. Adding a reason without classifying it is the
+// exact shape of the original defect — an exit path whose respawn behaviour was
+// decided by accident.
+func TestEveryWatchExitReasonIsClassified(t *testing.T) {
+	_, files := parseWatchFiles(t)
+	f := files["watch.go"]
+
+	// Collect declared const names of type watchExitReason.
+	declared := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		gd, ok := n.(*ast.GenDecl)
+		if !ok || gd.Tok != token.CONST {
+			return true
+		}
+		for _, spec := range gd.Specs {
+			vs, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			id, ok := vs.Type.(*ast.Ident)
+			if !ok || id.Name != "watchExitReason" {
+				continue
+			}
+			for _, name := range vs.Names {
+				declared[name.Name] = true
+			}
+		}
+		return true
+	})
+	if len(declared) == 0 {
+		t.Fatal("found no watchExitReason constants — has the type been renamed?")
+	}
+
+	// Collect the keys of the watchExitRespawn map literal.
+	classified := map[string]bool{}
+	ast.Inspect(f, func(n ast.Node) bool {
+		vs, ok := n.(*ast.ValueSpec)
+		if !ok {
+			return true
+		}
+		for i, name := range vs.Names {
+			if name.Name != "watchExitRespawn" || i >= len(vs.Values) {
+				continue
+			}
+			cl, ok := vs.Values[i].(*ast.CompositeLit)
+			if !ok {
+				continue
+			}
+			for _, elt := range cl.Elts {
+				if kv, ok := elt.(*ast.KeyValueExpr); ok {
+					if id, ok := kv.Key.(*ast.Ident); ok {
+						classified[id.Name] = true
+					}
+				}
+			}
+		}
+		return true
+	})
+
+	for name := range declared {
+		if !classified[name] {
+			t.Errorf("exit reason %s is declared but has no entry in watchExitRespawn — "+
+				"every way `grafel watch` can terminate must be classified deliberately, "+
+				"because launchd decides whether to respawn purely from the exit status (#6179)", name)
+		}
+	}
+	for name := range classified {
+		if !declared[name] {
+			t.Errorf("watchExitRespawn classifies %s, which is not a declared watchExitReason", name)
+		}
+	}
+}
+
+// TestRunWatchReturnsOnlyThroughWatchExit walks every return statement in
+// runWatch and requires it to be a call to watchExit or a call to a helper that
+// itself returns a watchExit result. A bare `return err` there is how the
+// original defect looked: an exit whose status nobody chose.
+func TestRunWatchReturnsOnlyThroughWatchExit(t *testing.T) {
+	fset, files := parseWatchFiles(t)
+	fn := findFunc(files["watch.go"], "runWatch")
+	if fn == nil {
+		t.Fatal("runWatch not found")
+	}
+
+	// Helpers whose own returns are themselves watchExit results, verified
+	// separately (recordWatchStart is checked below).
+	allowedHelpers := map[string]bool{"recordWatchStart": true}
+
+	// `if stop, err := recordWatchStart(repo); stop { return err }` is the
+	// legitimate way to propagate a verified helper's already-classified
+	// result. Collect the body ranges of such if-statements so a bare
+	// `return err` inside one is accepted — and only there.
+	type span struct{ lo, hi token.Pos }
+	var helperGuards []span
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		ifs, ok := n.(*ast.IfStmt)
+		if !ok || ifs.Init == nil {
+			return true
+		}
+		as, ok := ifs.Init.(*ast.AssignStmt)
+		if !ok || len(as.Rhs) != 1 {
+			return true
+		}
+		call, ok := as.Rhs[0].(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); ok && allowedHelpers[id.Name] {
+			helperGuards = append(helperGuards, span{ifs.Body.Pos(), ifs.Body.End()})
+		}
+		return true
+	})
+	insideHelperGuard := func(p token.Pos) bool {
+		for _, s := range helperGuards {
+			if p >= s.lo && p <= s.hi {
+				return true
+			}
+		}
+		return false
+	}
+
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		// Do not descend into nested function literals: their returns belong
+		// to the closure, not to runWatch's exit status.
+		if _, ok := n.(*ast.FuncLit); ok {
+			return false
+		}
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok {
+			return true
+		}
+		pos := fset.Position(ret.Pos())
+		if len(ret.Results) != 1 {
+			t.Errorf("%s: runWatch returns %d values; expected exactly one error routed "+
+				"through watchExit (#6179)", pos, len(ret.Results))
+			return true
+		}
+		call, ok := ret.Results[0].(*ast.CallExpr)
+		if !ok {
+			// Propagating an already-classified result out of a verified
+			// helper's guard is the one non-call form allowed.
+			if _, isIdent := ret.Results[0].(*ast.Ident); isIdent && insideHelperGuard(ret.Pos()) {
+				return true
+			}
+			t.Errorf("%s: runWatch has a return that does not go through watchExit — every "+
+				"exit path must classify itself, or launchd's respawn decision is made by "+
+				"accident (#6179)", pos)
+			return true
+		}
+		id, ok := call.Fun.(*ast.Ident)
+		if !ok || (id.Name != "watchExit" && !allowedHelpers[id.Name]) {
+			t.Errorf("%s: runWatch returns the result of %s; only watchExit (or a verified "+
+				"helper) may decide the exit status (#6179)", pos, exprName(call.Fun))
+		}
+		return true
+	})
+}
+
+// TestRecordWatchStartReturnsThroughWatchExit is the companion for the one
+// helper runWatch is allowed to return directly.
+func TestRecordWatchStartReturnsThroughWatchExit(t *testing.T) {
+	fset, files := parseWatchFiles(t)
+	fn := findFunc(files["watch_flap.go"], "recordWatchStart")
+	if fn == nil {
+		t.Fatal("recordWatchStart not found")
+	}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		ret, ok := n.(*ast.ReturnStmt)
+		if !ok || len(ret.Results) != 1 {
+			return true
+		}
+		if id, ok := ret.Results[0].(*ast.Ident); ok && id.Name == "nil" {
+			return true // "not flapping" is a legitimate nil
+		}
+		call, ok := ret.Results[0].(*ast.CallExpr)
+		if !ok {
+			t.Errorf("%s: recordWatchStart returns a non-nil value that is not a watchExit call",
+				fset.Position(ret.Pos()))
+			return true
+		}
+		if id, ok := call.Fun.(*ast.Ident); !ok || id.Name != "watchExit" {
+			t.Errorf("%s: recordWatchStart returns %s; must go through watchExit",
+				fset.Position(ret.Pos()), exprName(call.Fun))
+		}
+		return true
+	})
+}
+
+// TestSignalHandlerArmedBeforeAnyFallibleWork pins #6179 F2 structurally.
+//
+// Until signal.Notify runs, a SIGTERM kills the process by default action —
+// death BY a signal, which launchd and systemd both read as an unsuccessful
+// exit and respawn. The "a stop request means exit 0 and stay stopped" contract
+// therefore holds only from the moment Notify is installed, and it must not sit
+// behind a filesystem stat or anything else that can block.
+//
+// The end-to-end signal test cannot catch a regression here: it raises SIGTERM
+// in-process, so the handler is always already armed by the time it fires.
+//
+// DO NOT over-trust this test. It asserts a PROXY — that signal.Notify's source
+// byte offset precedes os.Stat's inside runWatch — not the property anyone
+// actually cares about, which is "armed before any SIGTERM can arrive". Those
+// are different, and the gap is measured, not theoretical: even with this test
+// green there is a ~70ms window before runWatch is entered at all (Go runtime
+// init, cobra tree construction, flag parsing) during which a SIGTERM kills the
+// process by default action and the supervisor respawns it. Closing that would
+// mean arming signals in main(), which is deliberately not done — see the
+// argument at cmd/grafel/main.go's quick-doctor guard. This test is worth
+// keeping because it kills the specific regression of moving Notify back below
+// the stat; it is not evidence that the window is zero.
+func TestSignalHandlerArmedBeforeAnyFallibleWork(t *testing.T) {
+	fset, files := parseWatchFiles(t)
+	fn := findFunc(files["watch.go"], "runWatch")
+	if fn == nil {
+		t.Fatal("runWatch not found")
+	}
+
+	notifyOffset, statOffset := -1, -1
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return true
+		}
+		off := fset.Position(call.Pos()).Offset
+		switch {
+		case pkg.Name == "signal" && sel.Sel.Name == "Notify" && notifyOffset < 0:
+			notifyOffset = off
+		case pkg.Name == "os" && sel.Sel.Name == "Stat" && statOffset < 0:
+			statOffset = off
+		}
+		return true
+	})
+
+	if notifyOffset < 0 {
+		t.Fatal("runWatch no longer calls signal.Notify — SIGTERM would kill the watcher by " +
+			"default action, which both launchd and systemd respawn (#6179 F2)")
+	}
+	if statOffset >= 0 && notifyOffset > statOffset {
+		t.Errorf("signal.Notify (offset %d) runs AFTER os.Stat (offset %d); a SIGTERM arriving "+
+			"in that window kills the watcher by signal, which the supervisor reads as an "+
+			"unsuccessful exit and respawns (#6179 F2)", notifyOffset, statOffset)
+	}
+}
+
+// TestQuickDoctorSkippedForWatch pins the other half of F2: the preflight in
+// cmd/grafel/main.go ran before cobra dispatch, so it was ~100ms during which
+// no watcher signal handler existed — and 140 daemon health probes fired at
+// login for no reader.
+func TestQuickDoctorSkippedForWatch(t *testing.T) {
+	b, err := os.ReadFile("../../cmd/grafel/main.go")
+	if err != nil {
+		t.Fatalf("read main.go: %v", err)
+	}
+	src := string(b)
+	i := strings.Index(src, "runQuickDoctorHook()")
+	if i < 0 {
+		t.Skip("quick-doctor hook no longer present")
+	}
+	// The guard is the `if` immediately preceding the call.
+	start := strings.LastIndex(src[:i], "if ")
+	if start < 0 {
+		t.Fatal("could not locate the quick-doctor guard")
+	}
+	guard := src[start:i]
+	if !strings.Contains(guard, `"watch"`) {
+		t.Errorf("the quick-doctor preflight is not skipped for `watch`; it runs before cobra "+
+			"dispatch, so it is dead time during which the watcher has no signal handler, and "+
+			"at 140 repos it is 140 daemon probes at login (#6179 F2)\nguard: %s", guard)
+	}
+}
+
+func exprName(e ast.Expr) string {
+	switch v := e.(type) {
+	case *ast.Ident:
+		return v.Name
+	case *ast.SelectorExpr:
+		return exprName(v.X) + "." + v.Sel.Name
+	}
+	return "<expr>"
+}

--- a/internal/cli/watch_test.go
+++ b/internal/cli/watch_test.go
@@ -199,6 +199,11 @@ func TestWatchBackoff_ShouldDie(t *testing.T) {
 // check that runWatch returns (exits) after the consecutive-failure
 // ceiling instead of looping forever when the daemon is not running
 // (issue #5140). No live daemon is started; Dial fails fast.
+//
+// #6179 changed the STATUS of that exit, not the fact of it: giving up is
+// deliberate, so it must exit 0 or launchd's KeepAlive respawns it every
+// ThrottleInterval forever. This test now only asserts that it exits;
+// TestRunWatch_GiveUpAfterIndexFailuresExitsSuccessfully asserts the status.
 func TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable(t *testing.T) {
 	home := withSandboxHome(t)
 	repo := filepath.Join(home, "repos", "solo")
@@ -220,10 +225,8 @@ func TestRunWatch_BacksOffAndDiesWhenDaemonUnreachable(t *testing.T) {
 	}()
 
 	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("expected runWatch to return a give-up error, got nil")
-		}
+	case <-done:
+		// Exited — that is the #5140 property under test here.
 	case <-time.After(30 * time.Second):
 		t.Fatal("runWatch did not exit after repeated daemon-unreachable failures (issue #5140 regression)")
 	}

--- a/internal/cli/watcher_refresh_output_6179_test.go
+++ b/internal/cli/watcher_refresh_output_6179_test.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// #6179 F1-b: on the reporter's machine all 140 units are stale, so the
+// reconcile rewrites and re-registers all 140 — and loader_darwin.go retries
+// bootstrap up to 3x serially, so worst case is ~560 launchctl invocations.
+// That is a Background Items notification burst in the same class as the one
+// the issue reports, fired immediately after an upgrade. If it happens with no
+// output explaining it, the natural reading is "the fix made it worse". Both
+// call sites previously discarded the message.
+
+// TestReportWatcherRefresh_ForwardsChildOutputOnSuccess pins the `grafel
+// update` side. The child's summary was printed only when the child FAILED, so
+// on the success path — the normal path, the one that produces the burst — it
+// was swallowed.
+func TestReportWatcherRefresh_ForwardsChildOutputOnSuccess(t *testing.T) {
+	summary := "✓ watcher units refreshed: 140 rewritten, 140 re-registered, 0 already current"
+
+	var buf bytes.Buffer
+	reportWatcherRefresh(&buf, []byte(summary+"\n"), nil)
+	if !strings.Contains(buf.String(), "140 rewritten") {
+		t.Fatalf("the child's watcher summary was not surfaced on the success path; the user "+
+			"sees a launchctl burst with no explanation (#6179 F1-b)\ngot: %q", buf.String())
+	}
+
+	// Silence stays silence: nothing stale means nothing to say.
+	buf.Reset()
+	reportWatcherRefresh(&buf, nil, nil)
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Errorf("empty child output must produce no noise, got %q", buf.String())
+	}
+
+	// Failures still surface.
+	buf.Reset()
+	reportWatcherRefresh(&buf, []byte("boom"), io.ErrUnexpectedEOF)
+	if !strings.Contains(buf.String(), "boom") {
+		t.Errorf("a failing refresh must still report, got %q", buf.String())
+	}
+}
+
+// TestReconcileSummary_WarnsAboutTheNotificationBurst: the summary has to say
+// why macOS is about to light up, or a one-time repair reads as a relapse of
+// the very bug being fixed.
+func TestReconcileSummary_WarnsAboutTheNotificationBurst(t *testing.T) {
+	var buf bytes.Buffer
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{
+		Rewritten: []string{"a", "b"},
+		Reloaded:  []string{"a", "b"},
+		Current:   3,
+	})
+	got := buf.String()
+	if !strings.Contains(got, "2") {
+		t.Errorf("summary should report how many units were rewritten, got %q", got)
+	}
+	low := strings.ToLower(got)
+	if !strings.Contains(low, "notification") && !strings.Contains(low, "background item") {
+		t.Errorf("the summary must warn that re-registering units produces macOS Background "+
+			"Items notifications — otherwise the one-time burst reads as the bug recurring "+
+			"(#6179 F1-b)\ngot: %q", got)
+	}
+
+	// Nothing rewritten: stay silent.
+	buf.Reset()
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{Current: 140})
+	if strings.TrimSpace(buf.String()) != "" {
+		t.Errorf("an up-to-date machine must print nothing, got %q", buf.String())
+	}
+}
+
+// TestRunRefreshState_QuietKeepsWatcherSummary: `grafel update` re-invokes this
+// command as a child and forwards its output. The install-state bookkeeping
+// lines are noise in that context, but the watcher summary is the whole point,
+// so quiet mode must drop the former and keep the latter.
+func TestRunRefreshState_QuietKeepsWatcherSummary(t *testing.T) {
+	withSandboxHome(t)
+	t.Setenv(refreshStateQuietEnv, "1")
+
+	prev := reconcileWatcherUnits
+	reconcileWatcherUnits = func(w io.Writer, _ string) {
+		_, _ = io.WriteString(w, "✓ watcher units refreshed: 7 rewritten\n")
+	}
+	t.Cleanup(func() { reconcileWatcherUnits = prev })
+
+	var buf bytes.Buffer
+	if err := runRefreshState(&buf); err != nil {
+		t.Fatal(err)
+	}
+	got := buf.String()
+	if !strings.Contains(got, "watcher units refreshed") {
+		t.Errorf("quiet mode dropped the watcher summary, which is the one thing the parent "+
+			"needs to forward (#6179 F1-b)\ngot: %q", got)
+	}
+	if strings.Contains(got, "install.json") || strings.Contains(got, "install state") {
+		t.Errorf("quiet mode must suppress the install-state bookkeeping lines, got %q", got)
+	}
+
+	// Without the env var the bookkeeping line comes back.
+	_ = os.Unsetenv(refreshStateQuietEnv)
+	buf.Reset()
+	if err := runRefreshState(&buf); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(buf.String(), "install") {
+		t.Errorf("non-quiet mode must keep reporting install state, got %q", buf.String())
+	}
+}

--- a/internal/cli/watchersync_wiring_6179_test.go
+++ b/internal/cli/watchersync_wiring_6179_test.go
@@ -1,0 +1,114 @@
+package cli
+
+import (
+	"bytes"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
+
+// #6179 F1: the fix to the unit template is worthless unless an upgrade path
+// rewrites the units already on disk. These tests pin the two hooks that make
+// that happen, because both are easy to delete without any other test noticing.
+
+// TestRefreshState_ReconcilesWatcherUnits pins the hook the curl installer
+// reaches. install.sh's record_install_state runs `grafel install
+// --refresh-state` with the NEWLY placed binary — the only automatic point in
+// the curl upgrade path where new-template code executes. If runRefreshState
+// stops calling the reconcile, a curl upgrade silently leaves every watcher
+// unit stale and the storm survives the fix.
+func TestRefreshState_ReconcilesWatcherUnits(t *testing.T) {
+	withSandboxHome(t)
+
+	calls := 0
+	var gotBin string
+	prev := reconcileWatcherUnits
+	reconcileWatcherUnits = func(_ io.Writer, bin string) {
+		calls++
+		gotBin = bin
+	}
+	t.Cleanup(func() { reconcileWatcherUnits = prev })
+
+	// No install.json in the sandbox: RefreshState reports HadState=false and
+	// returns nil. The reconcile must run anyway — the units on disk are stale
+	// regardless of whether install.json happens to exist.
+	if err := runRefreshState(&bytes.Buffer{}); err != nil {
+		t.Fatalf("runRefreshState: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("runRefreshState called the watcher reconcile %d times, want 1 — without it "+
+			"a curl upgrade never rewrites the stale watcher units (#6179 F1)", calls)
+	}
+	if gotBin == "" {
+		t.Error("reconcile was called without a binary path; the rendered unit body includes it")
+	}
+}
+
+// TestSelfUpdate_ReInvokesNewBinaryForWatcherUnits pins the second hook.
+// RunUpdate's post-swap step is RunCopy, which never touches watcher units, and
+// the pre-swap Apply in the legacy loop renders the OLD template. Re-invoking
+// the new binary is the only way `grafel update` reaches the new template.
+func TestSelfUpdate_ReInvokesNewBinaryForWatcherUnits(t *testing.T) {
+	src := readSource(t, "update.go")
+	fn := funcBody(t, src, "runSelfUpdate")
+	if !strings.Contains(fn, "refreshWatcherUnitsWithNewBinary") {
+		t.Fatal("runSelfUpdate no longer refreshes watcher units with the new binary (#6179 F1)")
+	}
+	// It has to run before the Skipped early-return, or the very machine that
+	// most needs the repair — already on the latest binary, stale units from an
+	// update that predates this fix — never gets it.
+	iCall := strings.Index(fn, "refreshWatcherUnitsWithNewBinary")
+	iSkip := strings.Index(fn, "result.Skipped")
+	if iSkip >= 0 && iCall > iSkip {
+		t.Errorf("the watcher reconcile runs after the result.Skipped early-return; a machine "+
+			"already on the latest binary with stale units would never be repaired (#6179 F1)\n%s", fn)
+	}
+}
+
+// TestUpdateLegacyLoop_SkipsWatchers: the pre-swap Apply must not write watcher
+// units. It runs with the OLD binary, so it would render the OLD template and
+// re-register all 140 units with the settings being replaced — then the
+// post-swap reconcile would do it all again. Two notification bursts to reach
+// what one reaches.
+func TestUpdateLegacyLoop_SkipsWatchers(t *testing.T) {
+	src := readSource(t, "update.go")
+	fn := funcBody(t, src, "newUpdateCmd")
+	if !strings.Contains(fn, "SkipWatchers: true") {
+		t.Fatalf("update's pre-swap install.Apply does not set SkipWatchers; it would write "+
+			"the OLD unit template with the OLD binary (#6179 F1)\n%s", fn)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+func readSource(t *testing.T, name string) string {
+	t.Helper()
+	b, err := os.ReadFile(name)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(b)
+}
+
+// funcBody returns the source text of the named top-level func.
+func funcBody(t *testing.T, src, name string) string {
+	t.Helper()
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, "src.go", src, 0)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	for _, d := range f.Decls {
+		fd, ok := d.(*ast.FuncDecl)
+		if !ok || fd.Name.Name != name || fd.Body == nil {
+			continue
+		}
+		return src[fset.Position(fd.Body.Pos()).Offset:fset.Position(fd.Body.End()).Offset]
+	}
+	t.Fatalf("func %s not found", name)
+	return ""
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -277,6 +277,15 @@ func Apply(opts Options) (*Result, error) {
 				}
 				res.WatcherUnits = append(res.WatcherUnits, path)
 
+				// Clear any crash-loop give-up history for this repo (#6179
+				// F4-a). Registering a unit is an explicit "I want this
+				// watcher running", and it is the remedy the detector's own
+				// message points at — but the bootstrap below is itself a
+				// counted start, so without this reset a watcher that gave up
+				// would immediately give up again and the instruction would be
+				// false.
+				_ = watchers.ResetWatchStarts(repo)
+
 				// Activate the watcher unit through the OS-native loader
 				// (launchctl on macOS, systemctl on Linux, schtasks on Windows).
 				// A watcher that fails to activate is a NON-FATAL warning: the

--- a/internal/install/installsh_watcher_output_6179_test.go
+++ b/internal/install/installsh_watcher_output_6179_test.go
@@ -1,0 +1,77 @@
+package install
+
+import (
+	"strings"
+	"testing"
+)
+
+// fakeGrafelWatcherSummaryScript stands in for a real `grafel install
+// --refresh-state` that found stale watcher units and repaired them.
+const fakeGrafelWatcherSummaryScript = `#!/usr/bin/env bash
+echo "$@" >> "$GRAFEL_ARG_LOG"
+echo "install state already current (/tmp/bin/grafel)"
+echo "✓ watcher units refreshed: 140 rewritten, 140 re-registered, 0 already current"
+echo "  macOS may show up to 140 Background Items notifications while these re-register"
+exit 0
+`
+
+// fakeGrafelSilentScript stands in for the steady state: nothing stale, nothing
+// to say.
+const fakeGrafelSilentScript = `#!/usr/bin/env bash
+echo "$@" >> "$GRAFEL_ARG_LOG"
+echo "install state already current (/tmp/bin/grafel)"
+exit 0
+`
+
+// TestInstallSh_RecordInstallState_SurfacesWatcherSummary pins #6179 F1-b on
+// the curl-installer side.
+//
+// install.sh discarded the refresh's output entirely (`>/dev/null 2>&1`). On a
+// machine whose watcher units are all stale, that command re-registers every
+// one of them — hundreds of launchctl invocations and a wave of macOS
+// Background Items notifications — immediately after the user upgrades, with
+// nothing on screen to explain it. The only available reading is that the
+// upgrade caused the storm.
+func TestInstallSh_RecordInstallState_SurfacesWatcherSummary(t *testing.T) {
+	_, combined, err := runRecordInstallState(t, fakeGrafelWatcherSummaryScript)
+	if err != nil {
+		t.Fatalf("record_install_state: %v\noutput:\n%s", err, combined)
+	}
+	if !strings.Contains(combined, "watcher units refreshed") {
+		t.Errorf("the installer swallowed the watcher-unit summary; the user sees a launchctl "+
+			"burst with no explanation (#6179 F1-b)\noutput:\n%s", combined)
+	}
+	if !strings.Contains(combined, "Background Items") {
+		t.Errorf("the notification warning must survive to the installer's output too\noutput:\n%s", combined)
+	}
+	// The install-state bookkeeping line is not the installer's business — it
+	// is why the output was piped to /dev/null in the first place.
+	if strings.Contains(combined, "install state already current") {
+		t.Errorf("record_install_state should surface only the watcher summary, not the "+
+			"install-state bookkeeping\noutput:\n%s", combined)
+	}
+}
+
+// TestInstallSh_RecordInstallState_SilentWhenNothingStale: the steady state
+// must stay quiet. A one-liner installer that starts narrating bookkeeping on
+// every run is its own regression.
+func TestInstallSh_RecordInstallState_SilentWhenNothingStale(t *testing.T) {
+	_, combined, err := runRecordInstallState(t, fakeGrafelSilentScript)
+	if err != nil {
+		t.Fatalf("record_install_state: %v\noutput:\n%s", err, combined)
+	}
+	if strings.TrimSpace(combined) != "" {
+		t.Errorf("record_install_state must print nothing when no watcher units were "+
+			"refreshed, got:\n%s", combined)
+	}
+}
+
+// TestInstallSh_RecordInstallState_StillBestEffortOnFailure re-asserts the
+// existing contract now that output is no longer blanket-discarded: a failing
+// refresh must still not abort the installer.
+func TestInstallSh_RecordInstallState_StillBestEffortOnFailure(t *testing.T) {
+	_, combined, err := runRecordInstallState(t, fakeGrafelArgLogFailScript)
+	if err != nil {
+		t.Fatalf("a failing refresh must not abort the installer: %v\noutput:\n%s", err, combined)
+	}
+}

--- a/internal/install/watchers/escaping_6179_test.go
+++ b/internal/install/watchers/escaping_6179_test.go
@@ -1,0 +1,170 @@
+package watchers
+
+import (
+	"encoding/xml"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// hostile is a Unit whose group and repo path contain the three characters that
+// are illegal as raw XML character data. Group names and repo paths are both
+// user-supplied, so this is reachable — a group named `R&D` is enough.
+var hostile = Unit{
+	Group:   "R&D",
+	Repo:    "/tmp/re<po>&more",
+	BinPath: "/usr/local/bin/graf&el",
+}
+
+// TestLaunchdPlist_EscapesXML pins #6179 F5. Before the fix the body contained
+// a raw `&`, which makes the whole plist unparseable: launchd rejects the job
+// silently, so the watcher never runs and nothing explains why.
+func TestLaunchdPlist_EscapesXML(t *testing.T) {
+	body := LaunchdPlist(hostile)
+	assertWellFormedXML(t, body)
+	if strings.Contains(body, "re<po>") {
+		t.Errorf("repo path was not escaped:\n%s", body)
+	}
+	if !strings.Contains(body, "&amp;") {
+		t.Errorf("expected an escaped ampersand in the body:\n%s", body)
+	}
+	// And the escaping must be escaping, not deletion — the real path has to
+	// survive a round-trip so launchd actually watches the right directory.
+	if got := roundTripStrings(t, body); !containsString(got, hostile.Repo) {
+		t.Errorf("repo path did not survive escaping; decoded <string> values: %q", got)
+	}
+	if !containsString(roundTripStrings(t, body), hostile.BinPath) {
+		t.Errorf("bin path did not survive escaping")
+	}
+}
+
+// TestSchtasksXML_EscapesXML pins the identical defect in the Windows task
+// definition, which is built by the same string-concatenation shape.
+func TestSchtasksXML_EscapesXML(t *testing.T) {
+	body := SchtasksXML(hostile)
+	// The task definition declares encoding="UTF-16", which Go's decoder
+	// refuses without a CharsetReader. Drop the declaration — we are checking
+	// escaping and nesting, not the encoding label schtasks wants.
+	if i := strings.Index(body, "?>"); i >= 0 {
+		assertWellFormedXML(t, body[i+2:])
+	} else {
+		t.Fatalf("no XML declaration in schtasks body:\n%s", body)
+	}
+	if strings.Contains(body, "R&D") {
+		t.Errorf("group was not escaped:\n%s", body)
+	}
+}
+
+// TestLaunchdPlist_PlutilLint runs Apple's own parser over a generated plist.
+// This is the only check in the suite that uses a real system tool; it writes
+// to a temp dir and never touches ~/Library/LaunchAgents or launchctl.
+func TestLaunchdPlist_PlutilLint(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("plutil is macOS-only")
+	}
+	plutil, err := exec.LookPath("plutil")
+	if err != nil {
+		t.Skip("plutil not on PATH")
+	}
+	for name, u := range map[string]Unit{"plain": sample, "hostile": hostile} {
+		path := filepath.Join(t.TempDir(), name+".plist")
+		if err := os.WriteFile(path, []byte(LaunchdPlist(u)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if out, err := exec.Command(plutil, "-lint", path).CombinedOutput(); err != nil {
+			t.Errorf("plutil -lint rejected the %s plist: %v\n%s\n%s",
+				name, err, out, LaunchdPlist(u))
+		}
+	}
+}
+
+// TestSystemdUnit_RateLimitedAndGivesUp pins #6179 F4.
+//
+// Restart=on-failure already carried the exit-status half of the fix, but
+// RestartSec=5 across 140 units is ~28 restarts/second — worse than macOS was.
+// RestartSec must move to the same floor as ThrottleIntervalSeconds, and
+// because five 60s-spaced restarts can never trip systemd's default 10s
+// StartLimit window, the window has to be widened explicitly or Linux loses its
+// only give-up.
+func TestSystemdUnit_RateLimitedAndGivesUp(t *testing.T) {
+	body := SystemdUnit(sample)
+	if strings.Contains(body, "RestartSec=5\n") {
+		t.Fatalf("RestartSec=5 is the unfixed value\n%s", body)
+	}
+	if RestartSecSeconds != ThrottleIntervalSeconds {
+		t.Errorf("RestartSecSeconds = %d, want it to track ThrottleIntervalSeconds = %d",
+			RestartSecSeconds, ThrottleIntervalSeconds)
+	}
+	for _, want := range []string{
+		"Restart=on-failure",
+		"RestartSec=60",
+		"StartLimitIntervalSec=3600",
+		"StartLimitBurst=5",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("systemd unit missing %q\n%s", want, body)
+		}
+	}
+	// The give-up must actually be reachable: burst restarts spaced RestartSec
+	// apart have to fit inside the limit window, or the unit restarts forever.
+	if RestartSecSeconds*StartLimitBurst >= StartLimitIntervalSeconds {
+		t.Errorf("StartLimit window (%ds) is too short for %d restarts %ds apart — "+
+			"systemd would never fail the unit, so there is no give-up",
+			StartLimitIntervalSeconds, StartLimitBurst, RestartSecSeconds)
+	}
+}
+
+func assertWellFormedXML(t *testing.T, body string) {
+	t.Helper()
+	dec := xml.NewDecoder(strings.NewReader(body))
+	dec.Strict = true
+	for {
+		_, err := dec.Token()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("not well-formed XML: %v\n%s", err, body)
+		}
+	}
+}
+
+// roundTripStrings decodes every <string> element's character data.
+func roundTripStrings(t *testing.T, body string) []string {
+	t.Helper()
+	dec := xml.NewDecoder(strings.NewReader(body))
+	var out []string
+	in := false
+	for {
+		tok, err := dec.Token()
+		if err == io.EOF {
+			return out
+		}
+		if err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		switch el := tok.(type) {
+		case xml.StartElement:
+			in = el.Name.Local == "string"
+		case xml.CharData:
+			if in {
+				out = append(out, string(el))
+			}
+		case xml.EndElement:
+			in = false
+		}
+	}
+}
+
+func containsString(hay []string, needle string) bool {
+	for _, h := range hay {
+		if h == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/watchers/plist_respawn_6179_test.go
+++ b/internal/install/watchers/plist_respawn_6179_test.go
@@ -1,0 +1,165 @@
+package watchers
+
+import (
+	"encoding/xml"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestLaunchdPlist_DeclaresThrottleInterval pins issue #6179 defect 1.
+//
+// The generated watcher plist declared no ThrottleInterval, so launchd's
+// 10-second default applied. On the reporting machine that is 140 labels each
+// eligible to relaunch every 10s — ~14 process launches per second, forever,
+// which is what produced the unbroken stream of macOS Background Activity
+// notifications.
+func TestLaunchdPlist_DeclaresThrottleInterval(t *testing.T) {
+	body := LaunchdPlist(sample)
+	if !strings.Contains(body, "<key>ThrottleInterval</key>") {
+		t.Fatalf("plist must declare ThrottleInterval — without it launchd applies its 10s default\n%s", body)
+	}
+	// The value must actually bound the rate: launchd's own default is 10s, so
+	// anything <= 10 buys nothing.
+	if ThrottleIntervalSeconds <= 10 {
+		t.Fatalf("ThrottleIntervalSeconds = %d; must exceed launchd's 10s default to bound the respawn rate",
+			ThrottleIntervalSeconds)
+	}
+	// It must also be at least the watcher's own default poll interval (30s):
+	// relaunching a watcher faster than one duty cycle cannot make progress.
+	if ThrottleIntervalSeconds < 30 {
+		t.Fatalf("ThrottleIntervalSeconds = %d; must be >= the watcher's 30s default poll interval",
+			ThrottleIntervalSeconds)
+	}
+	want := fmt.Sprintf("<integer>%d</integer>", ThrottleIntervalSeconds)
+	if !strings.Contains(body, want) {
+		t.Fatalf("plist ThrottleInterval value must render as %s\n%s", want, body)
+	}
+}
+
+// TestLaunchdPlist_KeepAliveOnlyOnUnsuccessfulExit pins issue #6179 defect 2.
+//
+// KeepAlive=true is an unconditional respawn contract: launchd relaunches the
+// job no matter WHY it exited. `grafel watch` has deliberate exit paths (the
+// repo path no longer stats; the consecutive-index-failure ceiling), so an
+// unconditional contract converts a diagnosable one-shot failure into a
+// permanent respawn loop. KeepAlive must be conditional on SuccessfulExit=false
+// so only genuine crashes are respawned.
+func TestLaunchdPlist_KeepAliveOnlyOnUnsuccessfulExit(t *testing.T) {
+	body := LaunchdPlist(sample)
+	if strings.Contains(body, "<key>KeepAlive</key><true/>") ||
+		strings.Contains(body, "<key>KeepAlive</key>\n  <true/>") {
+		t.Fatalf("KeepAlive must not be unconditionally true — that respawns deliberate exits\n%s", body)
+	}
+
+	// Structural: SuccessfulExit must be nested INSIDE the KeepAlive dict. A
+	// flat `<key>SuccessfulExit</key><false/>` sitting in the top-level job
+	// dict is meaningless to launchd, so a substring check alone is not enough.
+	inner, ok := keepAliveDictBody(body)
+	if !ok {
+		t.Fatalf("KeepAlive must be a <dict>\n%s", body)
+	}
+	if !strings.Contains(inner, "<key>SuccessfulExit</key>") {
+		t.Fatalf("KeepAlive dict must contain SuccessfulExit, got:\n%s", inner)
+	}
+	if !strings.Contains(inner, "<false/>") || strings.Contains(inner, "<true/>") {
+		t.Fatalf("KeepAlive.SuccessfulExit must be <false/> (respawn only on unsuccessful exit), got:\n%s", inner)
+	}
+}
+
+// keepAliveDictBody returns the raw text between the <dict> that immediately
+// follows <key>KeepAlive</key> and its matching </dict>.
+func keepAliveDictBody(body string) (string, bool) {
+	i := strings.Index(body, "<key>KeepAlive</key>")
+	if i < 0 {
+		return "", false
+	}
+	rest := body[i+len("<key>KeepAlive</key>"):]
+	open := strings.Index(rest, "<dict>")
+	if open < 0 || strings.TrimSpace(rest[:open]) != "" {
+		return "", false // KeepAlive's value is not a dict
+	}
+	rest = rest[open+len("<dict>"):]
+	end := strings.Index(rest, "</dict>")
+	if end < 0 {
+		return "", false
+	}
+	return rest[:end], true
+}
+
+// TestLaunchdPlist_WellFormedXML guards against the hand-built dict losing its
+// nesting — the plist body is assembled by string concatenation, so a
+// mismatched <dict> is a plausible regression, and launchd would reject it at
+// bootstrap time with an opaque error.
+func TestLaunchdPlist_WellFormedXML(t *testing.T) {
+	body := LaunchdPlist(sample)
+	dec := xml.NewDecoder(strings.NewReader(body))
+	dec.Strict = true
+	for {
+		_, err := dec.Token()
+		if err == io.EOF {
+			return
+		}
+		if err != nil {
+			t.Fatalf("plist is not well-formed XML: %v\n%s", err, body)
+		}
+	}
+}
+
+// TestWrite_RewritesStalePlistInPlace covers the migration question in #6179:
+// existing installs already have 140 plists on disk carrying the old settings.
+// A template-only change helps nobody unless the writer overwrites what is
+// already there. Write must replace the file's full contents, not merge or
+// skip.
+//
+// Uses a sandboxed HOME. It never invokes launchctl and never touches the real
+// ~/Library/LaunchAgents.
+func TestWrite_RewritesStalePlistInPlace(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("launchd plist migration is macOS-only")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	path, err := UnitPath(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(path, home) {
+		t.Fatalf("sandbox escape: UnitPath = %q, want it under %q", path, home)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A pre-#6179 plist: unconditional KeepAlive, no ThrottleInterval.
+	stale := "<?xml version=\"1.0\"?>\n<plist version=\"1.0\">\n<dict>\n" +
+		"  <key>Label</key><string>" + sample.Label() + "</string>\n" +
+		"  <key>RunAtLoad</key><true/>\n" +
+		"  <key>KeepAlive</key><true/>\n</dict>\n</plist>\n"
+	if err := os.WriteFile(path, []byte(stale), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Write(sample)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != path {
+		t.Fatalf("Write returned %q, want %q", got, path)
+	}
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(b)
+	if strings.Contains(body, "<key>KeepAlive</key><true/>") {
+		t.Fatalf("stale unconditional KeepAlive survived the rewrite\n%s", body)
+	}
+	if !strings.Contains(body, "<key>ThrottleInterval</key>") {
+		t.Fatalf("rewritten plist still lacks ThrottleInterval\n%s", body)
+	}
+}

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -15,6 +15,74 @@ import (
 	"strings"
 )
 
+// ThrottleIntervalSeconds is the minimum number of seconds launchd must let
+// elapse between two launches of the same watcher label (issue #6179).
+//
+// Why a value at all: with the key absent, launchd applies its own 10-second
+// default. On a 140-repo machine that is 140 labels each eligible to relaunch
+// every 10s — a ceiling of ~14 process launches per second, sustained forever,
+// which is what produced the unbroken stream of macOS Background Activity
+// notifications.
+//
+// Why 60: it has to clear three bars.
+//   - It must exceed launchd's 10s default, or it buys nothing.
+//   - It must be at least the watcher's own default poll interval (30s, see
+//     newWatchCmd's --interval): relaunching a watcher faster than one duty
+//     cycle cannot make progress, it only pays process-startup cost.
+//   - It must still recover a genuinely crashed watcher promptly. 60s is one
+//     minute of lost reactivity on a poll loop that already tolerates 30s.
+//
+// 60s also lowers the worst-case fleet-wide launch ceiling from ~14/s to
+// ~2.3/s at 140 repos.
+//
+// ThrottleInterval is a flat floor, NOT a backoff, and launchd never abandons a
+// KeepAlive job. On its own it therefore reduces the AMPLITUDE of a genuine
+// crash loop (panic, OOM, a BinPath that a package manager moved) but not its
+// DURATION: 140 crash-looping labels would relaunch at ~2.3/s indefinitely.
+// That remaining unbounded-duration case is closed on the watcher side instead,
+// by the rapid-restart detector in internal/cli/watch.go (watchExitFlapping),
+// which gives up and exits 0 — launchd has no equivalent of systemd's
+// StartLimitBurst, so the give-up has to live in the process.
+const ThrottleIntervalSeconds = 60
+
+// RestartSecSeconds and the StartLimit* values below are the systemd
+// counterparts of ThrottleIntervalSeconds (#6179 F4).
+//
+// The unit already said Restart=on-failure, so the exit-status half of the fix
+// (deliberate give-ups now exit 0) lands on Linux for free. The rate-limit half
+// did not: RestartSec=5 with 140 units is ~28 restarts/second, worse than
+// unfixed macOS. RestartSec moves to the same 60s floor for the same reasons.
+//
+// Raising RestartSec alone would have REMOVED Linux's only give-up, though.
+// systemd's defaults (StartLimitBurst=5 within StartLimitIntervalSec=10s)
+// eventually push a crash-looping unit into a failed state — but five restarts
+// 60s apart span 300s, so the 10s window can never trip and the unit would
+// restart forever. The limit window is therefore set explicitly to an hour, so
+// StartLimitBurst still means something at the new interval.
+const (
+	RestartSecSeconds         = 60
+	StartLimitIntervalSeconds = 3600
+	StartLimitBurst           = 5
+)
+
+// xmlEsc escapes s for inclusion in XML character data or an XML attribute.
+//
+// #6179 F5: Group names and repo paths are user-supplied, and the plist/task
+// bodies below are assembled by string concatenation. A group named `R&D`, or
+// any path containing `&`, `<` or `>`, previously produced a body that fails
+// `plutil -lint` ("unknown ampersand-escape sequence") — launchd then silently
+// rejects the job, so the watcher never runs and nothing says why.
+//
+// Note this escapes the RENDERED body only. Unit.Label() is deliberately left
+// alone: the label is also the plist FILENAME and launchd's job identity, so
+// changing how it is derived would orphan every already-installed unit.
+func xmlEsc(s string) string {
+	var b strings.Builder
+	// EscapeText writes to an io.Writer and never fails on a strings.Builder.
+	_ = xml.EscapeText(&b, []byte(s))
+	return b.String()
+}
+
 // Unit describes a single watcher unit to install.
 type Unit struct {
 	Group   string
@@ -30,16 +98,9 @@ func (u Unit) Label() string {
 
 // LaunchdPlist returns the macOS launchd .plist body for a watcher.
 func LaunchdPlist(u Unit) string {
-	type pl struct {
-		XMLName     xml.Name `xml:"dict"`
-		Label       string
-		ProgramArgs []string
-		WorkingDir  string
-		RunAtLoad   bool
-		KeepAlive   bool
-		StdOutPath  string
-		StdErrPath  string
-	}
+	// (An unused `pl` struct used to sit here describing the plist keys; it was
+	// never marshalled and drifted out of sync with the hand-built body below,
+	// claiming an unconditional KeepAlive bool. Removed with #6179.)
 	logDir := filepath.Join(u.Repo, ".grafel", "logs")
 	body := strings.Builder{}
 	body.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
@@ -47,45 +108,74 @@ func LaunchdPlist(u Unit) string {
 	body.WriteString(`<plist version="1.0">` + "\n")
 	body.WriteString("<dict>\n")
 	body.WriteString("  <key>Label</key>\n")
-	body.WriteString(fmt.Sprintf("  <string>%s</string>\n", u.Label()))
+	body.WriteString(fmt.Sprintf("  <string>%s</string>\n", xmlEsc(u.Label())))
 	body.WriteString("  <key>ProgramArguments</key>\n")
 	body.WriteString("  <array>\n")
-	body.WriteString(fmt.Sprintf("    <string>%s</string>\n", u.BinPath))
+	body.WriteString(fmt.Sprintf("    <string>%s</string>\n", xmlEsc(u.BinPath)))
 	body.WriteString("    <string>watch</string>\n")
-	body.WriteString(fmt.Sprintf("    <string>%s</string>\n", u.Repo))
+	body.WriteString(fmt.Sprintf("    <string>%s</string>\n", xmlEsc(u.Repo)))
 	body.WriteString("  </array>\n")
 	body.WriteString("  <key>RunAtLoad</key><true/>\n")
-	body.WriteString("  <key>KeepAlive</key><true/>\n")
+	// KeepAlive is CONDITIONAL, not unconditional (#6179). `grafel watch` has
+	// deliberate exit paths — the repo path no longer stats, and the
+	// consecutive-index-failure ceiling from #5140 — and it exits 0 on those
+	// (see internal/cli/watch.go's watchExitRespawn table). SuccessfulExit=false
+	// means "respawn only when the last exit was NOT successful", so those
+	// give-ups stay dead and a genuine crash (panic, OOM, signal death) still
+	// comes back. Under the previous <true/> launchd respawned everything
+	// including the give-ups, which is how a single diagnosable failure became a
+	// permanent relaunch loop.
+	body.WriteString("  <key>KeepAlive</key>\n")
+	body.WriteString("  <dict>\n")
+	body.WriteString("    <key>SuccessfulExit</key><false/>\n")
+	body.WriteString("  </dict>\n")
+	// Bound the relaunch rate. Absent this key launchd uses a 10s default; see
+	// ThrottleIntervalSeconds for why 60.
+	body.WriteString("  <key>ThrottleInterval</key>\n")
+	body.WriteString(fmt.Sprintf("  <integer>%d</integer>\n", ThrottleIntervalSeconds))
 	body.WriteString("  <key>WorkingDirectory</key>\n")
-	body.WriteString(fmt.Sprintf("  <string>%s</string>\n", u.Repo))
+	body.WriteString(fmt.Sprintf("  <string>%s</string>\n", xmlEsc(u.Repo)))
 	body.WriteString("  <key>StandardOutPath</key>\n")
-	body.WriteString(fmt.Sprintf("  <string>%s/watcher.out.log</string>\n", logDir))
+	body.WriteString(fmt.Sprintf("  <string>%s/watcher.out.log</string>\n", xmlEsc(logDir)))
 	body.WriteString("  <key>StandardErrorPath</key>\n")
-	body.WriteString(fmt.Sprintf("  <string>%s/watcher.err.log</string>\n", logDir))
+	body.WriteString(fmt.Sprintf("  <string>%s/watcher.err.log</string>\n", xmlEsc(logDir)))
 	body.WriteString("</dict>\n")
 	body.WriteString("</plist>\n")
 	return body.String()
 }
 
 // SystemdUnit returns the Linux systemd-user .service body.
+//
+// Restart=on-failure is the systemd analogue of the plist's
+// KeepAlive={SuccessfulExit:false}: the deliberate give-ups in
+// internal/cli/watch.go now exit 0, so systemd leaves them stopped. RestartSec
+// and the StartLimit* pair are the rate-limit and give-up halves — see the
+// constants for why 60/3600/5.
 func SystemdUnit(u Unit) string {
 	return fmt.Sprintf(`[Unit]
 Description=grafel watcher (%s/%s)
 After=default.target
+StartLimitIntervalSec=%d
+StartLimitBurst=%d
 
 [Service]
 Type=simple
 ExecStart=%q watch %q
 WorkingDirectory=%s
 Restart=on-failure
-RestartSec=5
+RestartSec=%d
 
 [Install]
 WantedBy=default.target
-`, u.Group, filepath.Base(u.Repo), u.BinPath, u.Repo, u.Repo)
+`, u.Group, filepath.Base(u.Repo), StartLimitIntervalSeconds, StartLimitBurst,
+		u.BinPath, u.Repo, u.Repo, RestartSecSeconds)
 }
 
 // SchtasksXML returns a Windows Task Scheduler XML definition.
+//
+// Every interpolated field is XML-escaped for the same reason as the plist
+// (#6179 F5): group names and repo paths are user-supplied, and an unescaped
+// `&` produces a task definition schtasks /create refuses to parse.
 func SchtasksXML(u Unit) string {
 	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-16"?>
 <Task version="1.4" xmlns="http://schemas.microsoft.com/windows/2004/02/mit/task">
@@ -109,7 +199,7 @@ func SchtasksXML(u Unit) string {
     </Exec>
   </Actions>
 </Task>
-`, u.Group, filepath.Base(u.Repo), u.BinPath, u.Repo, u.Repo)
+`, xmlEsc(u.Group), xmlEsc(filepath.Base(u.Repo)), xmlEsc(u.BinPath), xmlEsc(u.Repo), xmlEsc(u.Repo))
 }
 
 // PlistDir returns the user-level launchd directory.

--- a/internal/install/watchers/watchers_test.go
+++ b/internal/install/watchers/watchers_test.go
@@ -22,7 +22,9 @@ func TestLaunchdPlist(t *testing.T) {
 		`<string>watch</string>`,
 		`<string>/tmp/test/core</string>`,
 		`<key>RunAtLoad</key><true/>`,
-		`<key>KeepAlive</key><true/>`,
+		// #6179: KeepAlive is now a conditional dict, asserted structurally in
+		// plist_respawn_6179_test.go.
+		`<key>KeepAlive</key>`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("plist missing %q\n%s", want, body)

--- a/internal/install/watchers/watchstarts.go
+++ b/internal/install/watchers/watchstarts.go
@@ -1,0 +1,53 @@
+package watchers
+
+// watchstarts.go owns the location and lifecycle of the per-repo watcher
+// start-history file.
+//
+// The file itself is written and read by the crash-loop detector in
+// internal/cli/watch_flap.go (#6179 F4). Its PATH and its RESET live here
+// because both sides need them and only this package is imported by both:
+// internal/install registers units, internal/cli runs the watcher.
+//
+// ── Why registration must reset it (#6179 F4-a) ──────────────────────────────
+//
+// The detector counts STARTS, not crashes — it cannot distinguish "launchd
+// relaunched me because I crashed" from "a human just registered me", because
+// by the time the process is running both look identical. A launchctl bootstrap
+// IS a start. So without this reset, the documented remedy for a tripped
+// detector ("re-run grafel install") was self-defeating: the re-registration
+// counted as another start, the freshly bootstrapped watcher saw a
+// still-over-threshold history, and gave up again. Within the counting window
+// the watcher could not be brought back at all.
+//
+// Registering a unit is an explicit operator action that says "I want this
+// watcher running", so it is exactly the right point to clear the history.
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WatchStartsPath returns the per-repo watcher start-history file.
+func WatchStartsPath(repo string) string {
+	return filepath.Join(repo, ".grafel", "watch-starts.json")
+}
+
+// ResetWatchStarts deletes the start history for repo, so a watcher that gave
+// up as a crash loop starts counting again from zero.
+//
+// Idempotent: a missing record — or a missing repo — is already the desired
+// state and reports success. Registration paths call this unconditionally.
+func ResetWatchStarts(repo string) error {
+	err := os.Remove(WatchStartsPath(repo))
+	if err == nil || os.IsNotExist(err) {
+		return nil
+	}
+	// A repo directory that does not exist at all surfaces as ENOTDIR on some
+	// platforms rather than ENOENT; both mean "nothing to clear".
+	if pe, ok := err.(*os.PathError); ok {
+		if pe.Err == os.ErrNotExist {
+			return nil
+		}
+	}
+	return err
+}

--- a/internal/install/watchers/watchstarts_6179_test.go
+++ b/internal/install/watchers/watchstarts_6179_test.go
@@ -1,0 +1,51 @@
+package watchers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestWatchStartsPath_IsUnderRepoStateDir pins where the watcher's start
+// history lives. It has to be somewhere BOTH the watcher (internal/cli) and the
+// registration paths (internal/install) can name, which is why the path helper
+// lives here rather than next to the detector.
+func TestWatchStartsPath_IsUnderRepoStateDir(t *testing.T) {
+	got := WatchStartsPath("/tmp/some/repo")
+	want := filepath.Join("/tmp/some/repo", ".grafel", "watch-starts.json")
+	if got != want {
+		t.Fatalf("WatchStartsPath = %q, want %q", got, want)
+	}
+}
+
+// TestResetWatchStarts_ClearsAndIsIdempotent pins #6179 F4-a's remedy.
+//
+// The crash-loop detector counts STARTS, and a launchctl bootstrap is a start.
+// So registering a unit — `grafel install`, `group add`, the reconcile — must
+// clear the history, or a watcher that has given up can never be brought back
+// within the window: the very act of re-registering it counts against it.
+func TestResetWatchStarts_ClearsAndIsIdempotent(t *testing.T) {
+	repo := t.TempDir()
+	path := WatchStartsPath(repo)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"starts":["2026-01-01T00:00:00Z"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ResetWatchStarts(repo); err != nil {
+		t.Fatalf("ResetWatchStarts: %v", err)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("start history still present after reset (stat err = %v)", err)
+	}
+	// Idempotent: registration paths call this unconditionally, including for
+	// repos that never had a record.
+	if err := ResetWatchStarts(repo); err != nil {
+		t.Fatalf("ResetWatchStarts on a missing record must succeed, got %v", err)
+	}
+	if err := ResetWatchStarts(filepath.Join(repo, "does", "not", "exist")); err != nil {
+		t.Fatalf("ResetWatchStarts on a missing repo must succeed, got %v", err)
+	}
+}

--- a/internal/install/watchersync.go
+++ b/internal/install/watchersync.go
@@ -1,0 +1,171 @@
+package install
+
+// watchersync.go implements ReconcileWatcherUnits: bring already-installed
+// per-repo watcher units on disk into agreement with the CURRENT binary's unit
+// template, and re-register only the ones whose content actually changed.
+//
+// ── Why this exists (issue #6179 F1) ─────────────────────────────────────────
+//
+// #6179 fixed the generated LaunchAgent (conditional KeepAlive, a
+// ThrottleInterval) and the exit statuses that make the conditional mean
+// something. But a template fix reaches nobody who is already affected unless
+// something rewrites the units that are already on disk, and before this file
+// nothing on any supported upgrade path did:
+//
+//   - watchers.Write is reached ONLY from Apply's per-repo loop.
+//   - `grafel update` calls Apply from internal/cli/update.go BEFORE
+//     runSelfUpdate swaps the binary, so that pass renders the OLD template;
+//     the post-swap step is RunCopy, which never touches watcher units.
+//   - The curl installer runs `grafel install --refresh-state`, which
+//     short-circuits to RefreshState — it records the binary and does nothing
+//     else.
+//
+// So the reporter, at 140 repos, could upgrade by either supported path and end
+// up with 140 plists still saying `<key>KeepAlive</key><true/>` with no
+// ThrottleInterval, still loaded, still storming.
+//
+// ── Why it is a content diff, and why it only touches existing units ─────────
+//
+// The obvious repair — re-run Apply for every group — re-registers every unit,
+// and each registration is a launchctl bootout+bootstrap that macOS Ventura+
+// posts a Background Items notification for. That burst across 140 repos is
+// itself part of what #6179 reports. Two constraints follow:
+//
+//  1. Render first, compare to the bytes on disk, and do NOTHING when they
+//     match. On a machine already carrying the current template this is a pure
+//     read: zero writes, zero launchctl calls, zero notifications. That makes
+//     it safe to call unconditionally from every upgrade path, and it means the
+//     one-time repair costs exactly one registration per genuinely stale unit.
+//
+//  2. Only reconcile units that ALREADY EXIST on disk. A repo with no unit file
+//     has no stale plist and is not storming, so creating one here would be
+//     new registrations for no benefit — and it would silently resurrect units
+//     a user deliberately booted out. Installing missing units remains Apply's
+//     job, where the user asked for it.
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// newWatcherLoader is the Loader constructor ReconcileWatcherUnits uses. It is
+// a package var so tests can count Load calls without shelling out to
+// launchctl/systemctl/schtasks.
+var newWatcherLoader = watchers.NewLoader
+
+// ReconcileWatcherOptions configures ReconcileWatcherUnits.
+type ReconcileWatcherOptions struct {
+	// BinPath is the grafel binary the units should invoke. Defaults to
+	// os.Executable(). It participates in the rendered body, so a changed
+	// BinPath is itself a reason to rewrite.
+	BinPath string
+}
+
+// ReconcileWatcherResult reports what ReconcileWatcherUnits did.
+type ReconcileWatcherResult struct {
+	// Examined counts units considered (registered repo, watchers enabled).
+	Examined int
+	// Current counts units whose on-disk bytes already matched the template.
+	// These are NOT rewritten and NOT re-registered.
+	Current int
+	// Absent counts repos with no unit file on disk. Left alone by design.
+	Absent int
+	// Rewritten lists the unit paths whose content was stale and replaced.
+	Rewritten []string
+	// Reloaded lists the unit paths successfully re-registered with the OS.
+	Reloaded []string
+	// Warnings collects non-fatal per-unit failures. Reconciliation never
+	// aborts on one bad unit: the remaining 139 still need repairing.
+	Warnings []string
+}
+
+// ReconcileWatcherUnits rewrites and re-registers every already-installed
+// watcher unit whose on-disk content differs from what this binary renders.
+//
+// It is safe to call unconditionally and is a no-op on an up-to-date machine.
+// Errors from individual units are collected as warnings rather than returned:
+// a single unwritable plist must not stop the other repos from being repaired.
+// A non-nil error is returned only when the registry itself cannot be read.
+func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResult, error) {
+	if opts.BinPath == "" {
+		bin, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("resolve binary path: %w", err)
+		}
+		opts.BinPath = bin
+	}
+
+	refs, err := registry.Groups()
+	if err != nil {
+		return nil, fmt.Errorf("read group registry: %w", err)
+	}
+
+	res := &ReconcileWatcherResult{}
+	var loader watchers.Loader // constructed lazily: an up-to-date machine needs none
+
+	for _, ref := range refs {
+		cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
+		if err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("group %s: %v", ref.Name, err))
+			continue
+		}
+		if !cfg.Features.Watchers {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			u := watchers.Unit{Group: ref.Name, Repo: r.Path, BinPath: opts.BinPath}
+			path, err := watchers.UnitPath(u)
+			if err != nil {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", r.Path, err))
+				continue
+			}
+			existing, err := os.ReadFile(path)
+			if os.IsNotExist(err) {
+				// No unit installed for this repo — not stale, not storming.
+				res.Absent++
+				continue
+			}
+			res.Examined++
+			if err != nil {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", path, err))
+				continue
+			}
+			if string(existing) == watchers.Render(u) {
+				res.Current++
+				continue
+			}
+
+			if _, err := watchers.Write(u); err != nil {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("rewrite %s: %v", path, err))
+				continue
+			}
+			res.Rewritten = append(res.Rewritten, path)
+
+			// Clear the crash-loop history BEFORE re-registering (#6179 F4-a).
+			// Load performs a bootout+bootstrap, and the resulting launch is
+			// itself a counted start; leaving an over-threshold history in
+			// place would make the freshly registered watcher give up on its
+			// first tick. Only re-registered units are reset — clearing every
+			// repo's history on every upgrade would quietly disarm the
+			// detector fleet-wide.
+			_ = watchers.ResetWatchStarts(r.Path)
+
+			// Only now does the OS need telling. A rewritten plist has no
+			// effect until the job is re-bootstrapped — launchd holds the
+			// settings it read at load time.
+			if loader == nil {
+				loader = newWatcherLoader()
+			}
+			if err := loader.Load(u); err != nil && !watchers.IsNonFatal(err) {
+				res.Warnings = append(res.Warnings,
+					fmt.Sprintf("re-register %s: %v (the file is updated; it takes effect at next login)", path, err))
+				continue
+			}
+			res.Reloaded = append(res.Reloaded, path)
+		}
+	}
+	return res, nil
+}

--- a/internal/install/watchersync_6179_test.go
+++ b/internal/install/watchersync_6179_test.go
@@ -1,0 +1,238 @@
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// fakeLoader records Load calls instead of shelling out to launchctl.
+type fakeLoader struct {
+	loaded []string
+	fail   map[string]error
+}
+
+func (f *fakeLoader) Load(u watchers.Unit) error {
+	if err, ok := f.fail[u.Repo]; ok {
+		return err
+	}
+	f.loaded = append(f.loaded, u.Repo)
+	return nil
+}
+func (f *fakeLoader) Unload(watchers.Unit) error { return nil }
+func (f *fakeLoader) Status(u watchers.Unit) (watchers.WatcherStatus, error) {
+	return watchers.WatcherStatus{TaskName: u.Label()}, nil
+}
+
+// reconcileSandbox redirects HOME, GRAFEL_HOME and XDG_CONFIG_HOME into a temp
+// dir so unit paths, the registry and group configs are all sandboxed. Nothing
+// here ever invokes launchctl or touches the real ~/Library/LaunchAgents.
+func reconcileSandbox(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("GRAFEL_HOME", filepath.Join(dir, ".grafel"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+	return dir
+}
+
+// registerGroup writes a group config with watchers enabled and adds it to the
+// registry, returning the repo paths.
+func registerGroup(t *testing.T, home, group string, repos []string, watchersOn bool) {
+	t.Helper()
+	cfgDir, err := registry.ConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := registry.GroupConfig{Name: group}
+	cfg.Features.Watchers = watchersOn
+	for _, r := range repos {
+		if err := os.MkdirAll(r, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		cfg.Repos = append(cfg.Repos, registry.Repo{Slug: filepath.Base(r), Path: r})
+	}
+	p := filepath.Join(cfgDir, group+".fleet.json")
+	b, _ := json.Marshal(cfg)
+	if err := os.WriteFile(p, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup(group, p); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeUnitFile(t *testing.T, u watchers.Unit, body string) string {
+	t.Helper()
+	p, err := watchers.UnitPath(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestReconcileWatcherUnits_RepairsStaleAndSkipsCurrent is the core of #6179
+// F1. Existing installs carry pre-fix unit files; something on the upgrade path
+// has to rewrite them, and it must not re-register the ones that are already
+// correct — every re-registration is a launchctl bootout+bootstrap that macOS
+// posts a Background Items notification for, and 140 of those at once is the
+// burst the issue reports.
+func TestReconcileWatcherUnits_RepairsStaleAndSkipsCurrent(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	stale := filepath.Join(home, "repos", "stale")
+	current := filepath.Join(home, "repos", "current")
+	absent := filepath.Join(home, "repos", "absent")
+	registerGroup(t, home, "g", []string{stale, current, absent}, true)
+
+	staleUnit := watchers.Unit{Group: "g", Repo: stale, BinPath: bin}
+	currentUnit := watchers.Unit{Group: "g", Repo: current, BinPath: bin}
+
+	// A pre-fix unit body, and an already-correct one.
+	stalePath := writeUnitFile(t, staleUnit, "OLD UNIT BODY - unconditional KeepAlive\n")
+	currentPath := writeUnitFile(t, currentUnit, watchers.Render(currentUnit))
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Rewritten) != 1 || res.Rewritten[0] != stalePath {
+		t.Errorf("Rewritten = %v, want exactly [%s]", res.Rewritten, stalePath)
+	}
+	if res.Current != 1 {
+		t.Errorf("Current = %d, want 1 (the already-correct unit must not be rewritten)", res.Current)
+	}
+	if res.Absent != 1 {
+		t.Errorf("Absent = %d, want 1 (a repo with no unit file must be left alone)", res.Absent)
+	}
+	if len(fake.loaded) != 1 || fake.loaded[0] != stale {
+		t.Errorf("re-registered %v, want only the stale repo %q — re-registering a "+
+			"unit whose content did not change is a Background Items notification "+
+			"for no benefit (#6179)", fake.loaded, stale)
+	}
+
+	// The stale file must now carry the current template...
+	got, err := os.ReadFile(stalePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != watchers.Render(staleUnit) {
+		t.Errorf("stale unit was not rewritten to the current template:\n%s", got)
+	}
+	// ...and the already-correct one must be byte-identical, untouched.
+	if b, _ := os.ReadFile(currentPath); string(b) != watchers.Render(currentUnit) {
+		t.Errorf("current unit was modified")
+	}
+	// No unit invented for the repo that had none.
+	absentPath, _ := watchers.UnitPath(watchers.Unit{Group: "g", Repo: absent, BinPath: bin})
+	if _, err := os.Stat(absentPath); !os.IsNotExist(err) {
+		t.Errorf("reconcile created a unit for a repo that had none: %s", absentPath)
+	}
+}
+
+// TestReconcileWatcherUnits_NoOpWhenAllCurrent proves the operation is free on
+// an up-to-date machine — no writes, and critically no loader constructed at
+// all, so nothing shells out to launchctl.
+func TestReconcileWatcherUnits_NoOpWhenAllCurrent(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "a")
+	registerGroup(t, home, "g", []string{repo}, true)
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	writeUnitFile(t, u, watchers.Render(u))
+
+	constructed := 0
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		constructed++
+		return &fakeLoader{}
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if constructed != 0 {
+		t.Errorf("constructed a Loader %d times on an up-to-date machine; reconcile must "+
+			"not touch the service manager when nothing changed", constructed)
+	}
+	if len(res.Rewritten) != 0 || res.Current != 1 {
+		t.Errorf("Rewritten=%v Current=%d, want no rewrites and 1 current", res.Rewritten, res.Current)
+	}
+}
+
+// TestReconcileWatcherUnits_SkipsGroupsWithWatchersDisabled: a group that opted
+// out of watchers must not have units written or loaded for it.
+func TestReconcileWatcherUnits_SkipsGroupsWithWatchersDisabled(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "off")
+	registerGroup(t, home, "g", []string{repo}, false)
+	writeUnitFile(t, watchers.Unit{Group: "g", Repo: repo, BinPath: bin}, "OLD BODY\n")
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Examined != 0 || len(res.Rewritten) != 0 || len(fake.loaded) != 0 {
+		t.Errorf("watchers-disabled group was reconciled: %+v loaded=%v", res, fake.loaded)
+	}
+}
+
+// TestReconcileWatcherUnits_OneBadUnitDoesNotStopTheRest: at 140 repos a single
+// failing re-registration must not abandon the other 139 stale plists.
+func TestReconcileWatcherUnits_OneBadUnitDoesNotStopTheRest(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	bad := filepath.Join(home, "repos", "bad")
+	good := filepath.Join(home, "repos", "good")
+	registerGroup(t, home, "g", []string{bad, good}, true)
+	writeUnitFile(t, watchers.Unit{Group: "g", Repo: bad, BinPath: bin}, "OLD BODY\n")
+	writeUnitFile(t, watchers.Unit{Group: "g", Repo: good, BinPath: bin}, "OLD BODY\n")
+
+	fake := &fakeLoader{fail: map[string]error{bad: os.ErrPermission}}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatalf("one bad unit must not fail the whole reconcile: %v", err)
+	}
+	if len(res.Rewritten) != 2 {
+		t.Errorf("Rewritten = %v, want both files rewritten regardless of load failure", res.Rewritten)
+	}
+	if len(res.Reloaded) != 1 {
+		t.Errorf("Reloaded = %v, want only the good one", res.Reloaded)
+	}
+	if len(res.Warnings) != 1 || !strings.Contains(res.Warnings[0], "re-register") {
+		t.Errorf("Warnings = %v, want one re-register warning", res.Warnings)
+	}
+}

--- a/internal/install/watchstarts_reset_6179_test.go
+++ b/internal/install/watchstarts_reset_6179_test.go
@@ -1,0 +1,127 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// seedWatchStarts writes an over-threshold-looking start history for repo.
+func seedWatchStarts(t *testing.T, repo string) string {
+	t.Helper()
+	p := watchers.WatchStartsPath(repo)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(`{"starts":["2026-01-01T00:00:00Z"]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// TestReconcileWatcherUnits_ResetsWatchStartsOnReRegistration pins #6179 F4-a
+// on the reconcile path.
+//
+// The crash-loop detector counts starts, and a bootstrap is a start. If
+// re-registering a unit does not clear the history, a watcher that gave up can
+// never come back inside the counting window — the act of bringing it back
+// counts against it. Registration is an explicit "I want this running", so it
+// must reset.
+func TestReconcileWatcherUnits_ResetsWatchStartsOnReRegistration(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	stale := filepath.Join(home, "repos", "stale")
+	current := filepath.Join(home, "repos", "current")
+	registerGroup(t, home, "g", []string{stale, current}, true)
+
+	staleUnit := watchers.Unit{Group: "g", Repo: stale, BinPath: bin}
+	currentUnit := watchers.Unit{Group: "g", Repo: current, BinPath: bin}
+	writeUnitFile(t, staleUnit, "OLD UNIT BODY\n")
+	writeUnitFile(t, currentUnit, watchers.Render(currentUnit))
+
+	stalePath := seedWatchStarts(t, stale)
+	currentPath := seedWatchStarts(t, current)
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	if _, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+		t.Errorf("re-registered unit kept its start history (stat err = %v); the bootstrap "+
+			"this triggers is itself a counted start, so the watcher would give up again "+
+			"immediately (#6179 F4-a)", err)
+	}
+	// A unit that was NOT re-registered must keep its history: nothing about
+	// it changed, and clearing it would quietly disarm the detector on every
+	// upgrade for every repo.
+	if _, err := os.Stat(currentPath); err != nil {
+		t.Errorf("an untouched unit lost its start history (%v); only re-registration resets", err)
+	}
+}
+
+// TestApply_ResetsWatchStartsWhenRegisteringUnit pins the same property on the
+// path a human actually reaches: `grafel install` / `grafel group add`. This is
+// the remedy the detector's own message points at, so it has to work.
+func TestApply_ResetsWatchStartsWhenRegisteringUnit(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	// The repo deliberately does NOT live under a t.TempDir. Apply creates
+	// <repo>/.grafel/logs shortly AFTER it returns — observed 1-13 poll
+	// iterations later, so something in that path writes asynchronously — and
+	// t.TempDir's own RemoveAll then races it and fails the test with
+	// "directory not empty" roughly one run in three. That async write is
+	// pre-existing and outside #6179's scope; owning the directory here keeps
+	// this test measuring what it claims to measure instead of inheriting an
+	// unrelated flake.
+	repoRoot, err := os.MkdirTemp("", "grafel-6179-apply-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(repoRoot, "app")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		// Best-effort, and retried: the same async writer can lose us a race
+		// here too, and a cleanup failure must not fail a passing test.
+		for i := 0; i < 3; i++ {
+			if err := os.RemoveAll(repoRoot); err == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	})
+	recPath := seedWatchStarts(t, repo)
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	cfg := &registry.GroupConfig{Name: "g", Repos: []registry.Repo{{Slug: "app", Path: repo}}}
+	cfg.Features.Watchers = true
+
+	if _, err := Apply(Options{
+		Group: "g", Config: cfg, BinPath: bin,
+		SkipHooks: true, SkipMCP: true,
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if _, err := os.Stat(recPath); !os.IsNotExist(err) {
+		t.Errorf("`grafel install` did not clear the watcher start history (stat err = %v). "+
+			"The crash-loop detector tells the user to re-run install; if install does not "+
+			"reset the count, that instruction is false (#6179 F4-a)", err)
+	}
+}


### PR DESCRIPTION
A user with **140 registered repos** reported a continuous stream of macOS "App Background Activity" alerts — a 44-second video of them, unbroken.

## What was wrong

`grafel watch` has exit paths that are **conclusions, not crashes**: the repo path no longer stats (`watch.go:209`), and the #5140 consecutive-failure ceiling that exists precisely so an orphaned watcher reaps itself. Both returned a non-nil error → `cli.Execute` exits 1.

The per-repo plist said `KeepAlive=true` — unconditional respawn — with **no `ThrottleInterval`**, so launchd's 10s default applied. A watcher that had correctly decided to stop was relaunched every 10 seconds and re-decided to stop, forever. At 140 labels that is ~14 process launches per second.

The daemon's reaper (`reaper.go:331-398`) independently SIGTERMs foreign/duplicate watchers on a 5-minute tick, and `KeepAlive` respawned them immediately — a reap↔respawn oscillation on top.

**Why it was previously ruled out:** daemon-side counters showed `service.Restart` 0 times in an 18-hour capture, 12 subprocess spawns in 4 hours, and one daemon start during the alert video. Those measurements are correct and the inference from them was wrong — **launchd is the spawner, not the daemon.** No daemon-side instrument can observe a `launchctl`-driven respawn.

## The fix

`ThrottleIntervalSeconds = 60` (must beat launchd's 10s default; must be ≥ the watcher's own 30s poll interval; must still recover a real crash promptly), and `KeepAlive → {SuccessfulExit: false}` with an explicit classification table routing every exit through one `watchExit()` helper:

| path | status | respawn |
|---|---|---|
| signal (SIGINT/SIGTERM) | 0 | no |
| repo-missing | 0 | no |
| index-failures give-up | 0 | no |
| bad argv | non-zero | yes |

Panic/OOM/signal-death bypasses the table and still exits non-zero, so a genuine crash still comes back.

**The reaper conflict resolves as a consequence, without touching `reaper.go`:** the reaper SIGTERMs, the handler returns normally, exit 0, launchd leaves it dead.

**Linux was half-fixed for free and needed the other half.** The systemd unit already said `Restart=on-failure`, equally defeated by give-ups exiting non-zero — so the exit-status fix lands there too. But `RestartSec` was 5, which at 140 units is ~28/s, *worse* than macOS post-fix. Raising it alone would have destroyed Linux's only give-up (five 60s restarts cannot trip a 10s `StartLimitIntervalSec`), so the window moved with it, pinned by a test asserting `RestartSec × Burst < Interval`.

macOS has no equivalent give-up, so `watch_flap.go` implements one: per-repo start counting, exit 0 above 12/hour. Fails open on an unwritable or corrupt record.

## The fix reached nobody — that was the blocker

Review established that **no automatic upgrade path rewrote the plists**:

- `install.Apply` is the only writer, and `cli/update.go:60-83` calls it with the **old** binary, before `runSelfUpdate` at `:91`.
- `install/update.go:257-286`'s post-swap step is `RunCopy`, **not** `Apply` — grepping that file for `Apply(`/`watchers` returns **zero hits**.
- `install.sh:313-325` deliberately runs `grafel install --refresh-state`, which short-circuits to `runRefreshState` — record the binary, nothing else.

So the reporter would upgrade by either supported path and still have 140 plists with the old settings. The fix would land only on a full `grafel install` / `wizard` / `group add`, none of which anyone is told to run.

New `install.ReconcileWatcherUnits` (`internal/install/watchersync.go`) is **content-diff driven**: render the current template, compare to the bytes on disk, rewrite and re-register **only units that differ**. On an up-to-date machine it constructs no Loader at all — verified independently: `ctors=0 loads=0`, not merely zero writes. That matters because any blanket rewrite re-triggers 140 bootout+bootstrap registrations, which is the burst that plausibly caused the video in the first place.

Wired into `grafel install --refresh-state` — the hook `install.sh` already calls **with the new binary** — and into `runSelfUpdate`, which re-invokes the just-swapped binary. **The obvious alternative of ordering `Apply` after the swap does not work**: the running process is still old code and cannot render the new template. Placed before the `result.Skipped` early-return, since "already on the latest binary, stale units" is exactly the reporter's state. The legacy pre-swap loop now sets `SkipWatchers: true` — it was writing and registering the very settings being replaced, so reconcile would redo all 140. **280 registrations cut to 140.**

Units that do not exist are left alone: no stale plist means nothing is storming, and creating them would resurrect ones a user deliberately booted out.

## Two things the fix got wrong about the user's experience

**The flap detector's own remediation instruction did not work.** It said *"re-run `grafel install` to start watching again"* — but a `grafel install` triggers a bootstrap, **which is itself a counted start**, so the freshly-registered watcher immediately gave up again. The person hitting this is by definition debugging watchers; nine invocations in an hour is ordinary, and *guaranteed* if they follow the printed advice. `ResetWatchStarts` now runs from `Apply` and `ReconcileWatcherUnits` before `Load`, so the bootstrap's own start lands on a cleared record — and **only for re-registered repos**, since clearing every repo on every upgrade would quietly disarm the detector fleet-wide (mutant N3 catches exactly that).

**The reconcile burst was silent on both paths.** `install.sh` discarded output; `update.go` printed only on error. On the reporter's machine all 140 units are stale, so all 140 rewrite and re-register — worst case ~560 serial `launchctl` calls, a notification burst in the same class as the original video, **immediately after upgrading, with nothing explaining it.** The natural reading is "the fix made it worse." Both paths now surface it, with the summary saying plainly that it is the one-time repair for #6179 and not a recurrence.

## A measurement that corrected the diagnosis

The SIGTERM→exit-0 contract had a measured unarmed window. `signal.Notify` was hoisted above `os.Stat` **and** quick-doctor skipped for `watch` (it runs before cobra dispatch, so hoisting inside `runWatch` alone would not have helped). Independently re-measured at the same load, 5 runs per cell, count of exit-0:

```
delay:     20ms  40ms  60ms  80ms  100ms 120ms 150ms
before:    0/5   0/5   0/5   0/5   0/5   0/5   4/5
after:     0/5   0/5   0/5   5/5   5/5   5/5   5/5
```

~130–150ms → ~60–80ms. **About half, not essentially all** — the claim that quick-doctor was the whole cause was wrong and the comment now says so. The residual ~70ms is Go runtime init + cobra tree construction + flag parsing, before `runWatch` is entered. Arming in `main()` is **deliberately declined**: the reaper enumerates targets via `ps`, so it can never reach a 70ms-old process.

Skipping the preflight also removes 140 simultaneous daemon health probes at login.

## XML escaping

`LaunchdPlist` interpolated user-supplied group names and repo paths raw. Measured: a group named `R&D` produced a body failing `plutil -lint` with *"unknown ampersand-escape sequence"* — an unparseable plist that launchd silently rejects. `xmlEsc` now covers every interpolated field in both `LaunchdPlist` and `SchtasksXML`; all adversarial units lint clean.

`Unit.Label()` is deliberately **unchanged** — it is both the plist filename and the launchd job identity, so altering its derivation would orphan every installed unit.

## Test-quality work

The classification test originally iterated a table the test itself declared, so a new exit path passed it unchanged — the stated invariant "every exit path is classified" was not enforced. Replaced with AST checks over real source: every declared `watchExitReason` must appear in `watchExitRespawn`; every `return` in `runWatch` must route through `watchExit`; `signal.Notify` must precede `os.Stat`.

**Those caught two real bugs in this change before review did.** `recordWatchStart` returned `error`, so a give-up returned `nil` — indistinguishable from healthy, meaning **the flap detector never fired**.

`TestSignalHandlerArmedBeforeAnyFallibleWork` now carries an explicit *do not over-trust this test* note: it asserts a source byte offset, and is green in a state where the real invariant is violated for ~70ms. It kills the mutant it was written for; it is a proxy, and the file says so.

## Verification

`go build ./...` 0 · `go vet ./...` 0 · `gofmt -l .` empty · `shellcheck -S error install.sh` 0 · `bash -n install.sh` 0 · linux and windows cross-build of `watchers` 0. Suites with unpiped `$?`, `-count=1 -p 1`, `GOMAXPROCS=4`: `internal/install/watchers`, `internal/install`, `internal/cli`, `cmd/grafel` all **0, zero skips**.

**22 mutants across two rounds, all killed.** Three were not clean kills on first attempt and were re-cut rather than banked: two compile errors, and `flapMaxStarts=100000`, which produced a 5-minute runaway instead of a failure.

Independent adversarial review measured, rather than accepted: reconcile idempotence, partial-failure behaviour (3 of 4 rewritten, one warning, no abort), `plutil -lint` across hostile inputs, the flap detector tripping at start 9, and both key mutants.

## Not verified

**Real launchd.** No mutating `launchctl` was run and `~/Library/LaunchAgents` was never touched; `plutil -lint` ran only on files generated in temp dirs. So unverified by execution: that launchd honours `ThrottleInterval=60`, that `SuccessfulExit:false` suppresses respawn on exit 0 in practice, and that a handler returning normally after SIGTERM registers as a successful exit. These rest on `launchd.plist(5)`. Real systemd likewise unverified. The `exec` of a genuinely updated binary in `refreshWatcherUnitsWithNewBinary` is stubbed in tests.

## Behaviour change, disclosed

With `SkipWatchers: true` on the legacy loop and reconcile deliberately leaving absent units alone, **no upgrade path creates a missing watcher unit any more.** Both decisions are individually right; together they are a change. A repo whose plist was deleted is restored only by a full `grafel install`.

## Filed separately

- **#6183** — `slugify` uses `filepath.Base` only, so two repos with the same basename in one group share a plist path. Measured: never converges; rewrites and re-registers both every run. On 140 repos duplicate `api`/`web`/`docs` names are near-certain, so the zero-launchctl property is false for exactly the reporter's configuration, and only one of each pair is ever watched.
- **#6184** — `refreshWatcherUnitsWithNewBinary` has no timeout; with a wedged launchd, `grafel update` blocks indefinitely with no output, since the child's output is buffered until exit.
- **#6185** — the systemd unit interpolates raw into INI, and systemd treats `%` as a specifier needing `%%`. Same silent-non-registration class as the XML bug; the third format has its own escape rule.
- **#6186** — `slugify` sanitises the repo segment but not the *group* segment: a group named `g/h` creates a directory inside `~/Library/LaunchAgents` (never scanned, silently unregistered); `../…` writes outside it.
- **#6187** — `watchscan.sameExe` lacks `EvalSymlinks`, so a brew shim or symlinked invocation classifies every watcher as foreign. Before this change that was a loud oscillation; now the first reap is final and silent. Documented at `watchExitRespawn`, but a comment is not a tracked defect.
- **#6188** — `install.Apply` creates `<repo>/.grafel/logs` asynchronously, 1–13 poll iterations after it returns, racing `t.TempDir`'s cleanup. Pre-existing; any future test calling `Apply` with watchers enabled against a `t.TempDir` repo will hit it.

Independently adversarially reviewed twice (REQUEST-CHANGES → APPROVE).

Closes #6179
