### PR TITLE
fix(#6181): a git call that never ran was cached as a fact about the repo

### DIFF
--- a/internal/gitmeta/cache.go
+++ b/internal/gitmeta/cache.go
@@ -261,7 +261,11 @@ func CaptureCachedFresh(repoPath string) Info {
 	}
 	captureMu.Unlock()
 
-	info := Capture(repoPath)
+	info, trusted := captureStatus(repoPath)
+	if !trusted {
+		// git could not be RUN (#6181) — see CaptureCached.
+		return info
+	}
 
 	captureMu.Lock()
 	captureFreshCache[repoPath] = captureFreshEntry{info: info, headStat: key, commitToken: tok}
@@ -339,7 +343,22 @@ func CaptureCached(repoPath string) Info {
 	}
 	captureMu.Unlock()
 
-	info := Capture(repoPath)
+	info, trusted := captureStatus(repoPath)
+	if !trusted {
+		// git could not be RUN — the 2s deadline fired, or fork failed under
+		// load. The zero Info this produced is a fact about the moment, not
+		// about the repo, and the HEAD-pointer key cannot see the difference:
+		// it is a pure os.Stat that succeeds regardless of load, so the escape
+		// above never fires and the memo would survive until HEAD next moves or
+		// the daemon restarts — pinning the repo to refs/_unknown and a full
+		// reindex on EVERY incremental pass (#6181). Serve the value, keep no
+		// memory of it.
+		//
+		// This is deliberately narrower than "don't cache empty results": a path
+		// git ran against and reported "not a git repository" for is a durable
+		// answer and still caches, which is where the optimisation lives.
+		return info
+	}
 
 	captureMu.Lock()
 	captureCache[repoPath] = captureEntry{info: info, headStat: key}

--- a/internal/gitmeta/cache_transient_6181_test.go
+++ b/internal/gitmeta/cache_transient_6181_test.go
@@ -42,6 +42,21 @@ func generousDeadline(t *testing.T) {
 	t.Cleanup(func() { gitCallTimeout = prev })
 }
 
+// TestGitCallTimeoutDefault pins the production deadline.
+//
+// generousDeadline now lifts it in most tests in this file, and the only tests
+// that set it deliberately set it short — so nothing else would notice if the
+// default changed. The value is load-bearing in both directions: too low and
+// healthy forks are classified unavailable (measured p99.9 ≈ 171ms under load,
+// so 2s is ~12× headroom); too high and a genuinely wedged git blocks the MCP
+// query path for that long.
+func TestGitCallTimeoutDefault(t *testing.T) {
+	if gitCallTimeout != 2*time.Second {
+		t.Fatalf("gitCallTimeout default is %v, want 2s — if this is a deliberate "+
+			"change, weigh it against both failure modes above, not just one", gitCallTimeout)
+	}
+}
+
 // countingRealGit installs a seam that forwards to real git while counting
 // invocations, so a test can prove a second CaptureCached did (or did not) fork.
 func countingRealGit(t *testing.T) *int {

--- a/internal/gitmeta/cache_transient_6181_test.go
+++ b/internal/gitmeta/cache_transient_6181_test.go
@@ -24,6 +24,24 @@ func withGitUnavailable(t *testing.T) *int {
 	return &calls
 }
 
+// generousDeadline removes the production 2s deadline for the duration of a
+// test that needs a git invocation to actually COMPLETE.
+//
+// This is not belt-and-braces. It was added after a real failure: under load
+// average 8.2 on a shared machine, forking a stub `git` that does nothing but
+// `exit 128` took longer than 2s, the deadline fired, and the classifier
+// correctly reported gitUnavailable to a test asserting gitAnswered. That is the
+// #6181 production trigger reproducing spontaneously in the test suite — which
+// is a fine thing to have observed and a terrible thing to leave in a test whose
+// subject is the OTHER branch. Tests that assert on the timeout branch set their
+// own short deadline instead.
+func generousDeadline(t *testing.T) {
+	t.Helper()
+	prev := gitCallTimeout
+	gitCallTimeout = 2 * time.Minute
+	t.Cleanup(func() { gitCallTimeout = prev })
+}
+
 // countingRealGit installs a seam that forwards to real git while counting
 // invocations, so a test can prove a second CaptureCached did (or did not) fork.
 func countingRealGit(t *testing.T) *int {
@@ -50,6 +68,7 @@ func countingRealGit(t *testing.T) *int {
 //
 // The trigger is transient; the consequence must not be sticky.
 func TestCaptureCached_DoesNotMemoizeUnrunnableGit(t *testing.T) {
+	generousDeadline(t)
 	resetCaptureCacheForTest()
 	dir := initGitRepo(t)
 
@@ -74,6 +93,7 @@ func TestCaptureCached_DoesNotMemoizeUnrunnableGit(t *testing.T) {
 // commit-fresh variant (ResolveCWD / grafel_whoami), which memoizes on the same
 // unconditional write.
 func TestCaptureCachedFresh_DoesNotMemoizeUnrunnableGit(t *testing.T) {
+	generousDeadline(t)
 	resetCaptureCacheForTest()
 	dir := initGitRepo(t)
 
@@ -96,6 +116,7 @@ func TestCaptureCachedFresh_DoesNotMemoizeUnrunnableGit(t *testing.T) {
 // poisonous as a total failure and must not be memoized either. Trust is a
 // property of the whole capture, not of its first call.
 func TestCaptureCached_DoesNotMemoizeAMidCaptureFailure(t *testing.T) {
+	generousDeadline(t)
 	resetCaptureCacheForTest()
 	dir := initGitRepo(t)
 
@@ -153,6 +174,7 @@ func TestCapture_DistrustIsPerCall_EverySubcommand(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			generousDeadline(t)
 			resetCaptureCacheForTest()
 			dir := initGitRepo(t)
 
@@ -202,6 +224,7 @@ func TestCapture_DistrustIsPerCall_EverySubcommand(t *testing.T) {
 // (so the :330 escape does NOT fire and the cache write is reached), while git
 // exits non-zero with "not a git repository".
 func TestCaptureCached_StillCachesAGenuineNonRepo(t *testing.T) {
+	generousDeadline(t)
 	resetCaptureCacheForTest()
 	dir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
@@ -324,12 +347,9 @@ func stubGit(t *testing.T, body string) (realPath string) {
 // returns -1 when the process was terminated by a signal, on every platform.
 func TestRunGitStatus_SignalDeathIsUnavailableNotAnAnswer(t *testing.T) {
 	stubGit(t, "kill -9 $$")
-
-	// Deadline is generous and deliberately never fires: this must be caught by
-	// signal detection, not by ctx.Err().
-	prev := gitCallTimeout
-	gitCallTimeout = 30 * time.Second
-	t.Cleanup(func() { gitCallTimeout = prev })
+	// The deadline deliberately never fires: this must be caught by signal
+	// detection, not by ctx.Err().
+	generousDeadline(t)
 
 	out, st := runGitStatus(t.TempDir(), "rev-parse", "--show-toplevel")
 	if st != gitUnavailable || out != "" {
@@ -346,9 +366,7 @@ func TestCaptureCached_DoesNotMemoizeASignalledGit(t *testing.T) {
 	dir := initGitRepo(t)
 
 	realPath := stubGit(t, "kill -9 $$")
-	prev := gitCallTimeout
-	gitCallTimeout = 30 * time.Second
-	t.Cleanup(func() { gitCallTimeout = prev })
+	generousDeadline(t)
 
 	if got := CaptureCached(dir); got != (Info{}) {
 		t.Fatalf("expected zero Info from a killed git, got %+v", got)
@@ -367,6 +385,7 @@ func TestCaptureCached_DoesNotMemoizeASignalledGit(t *testing.T) {
 // optimisation away.
 func TestRunGitStatus_NormalNonZeroExitStaysAnAnswer(t *testing.T) {
 	stubGit(t, "exit 128")
+	generousDeadline(t)
 
 	if out, st := runGitStatus(t.TempDir(), "rev-parse", "--show-toplevel"); st != gitAnswered || out != "" {
 		t.Fatalf("exit 128: got (%q, %v), want (\"\", gitAnswered)", out, st)
@@ -377,6 +396,7 @@ func TestRunGitStatus_NormalNonZeroExitStaysAnAnswer(t *testing.T) {
 // itself against real git: a non-zero exit is an ANSWER (reproducible, about
 // the repo), while a missing binary means git never spoke.
 func TestRunGitStatus_ClassifiesAnsweredVsUnavailable(t *testing.T) {
+	generousDeadline(t)
 	dir := t.TempDir() // no .git anywhere under TempDir
 
 	if out, st := runGitStatus(dir, "rev-parse", "--show-toplevel"); st != gitAnswered || out != "" {

--- a/internal/gitmeta/cache_transient_6181_test.go
+++ b/internal/gitmeta/cache_transient_6181_test.go
@@ -1,0 +1,236 @@
+package gitmeta
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// withGitUnavailable installs a seam that simulates git being un-runnable — the
+// 2s deadline firing, or fork returning EAGAIN under load. It is deliberately
+// injected rather than provoked: you cannot reliably starve a machine into a
+// fork failure, and #6181 is exactly the load-correlated case.
+func withGitUnavailable(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	prev := runGitFn
+	runGitFn = func(dir string, args ...string) (string, gitStatus) {
+		calls++
+		return "", gitUnavailable
+	}
+	t.Cleanup(func() { runGitFn = prev })
+	return &calls
+}
+
+// countingRealGit installs a seam that forwards to real git while counting
+// invocations, so a test can prove a second CaptureCached did (or did not) fork.
+func countingRealGit(t *testing.T) *int {
+	t.Helper()
+	calls := 0
+	prev := runGitFn
+	runGitFn = func(dir string, args ...string) (string, gitStatus) {
+		calls++
+		return prev(dir, args...)
+	}
+	t.Cleanup(func() { runGitFn = prev })
+	return &calls
+}
+
+// TestCaptureCached_DoesNotMemoizeUnrunnableGit is the #6181 regression.
+//
+// A transient failure to RUN git (2s timeout, EAGAIN on fork) makes Capture
+// return the zero Info with Ref == "". headPointerKey is a pure os.Stat that
+// succeeds regardless of load, so the "don't cache non-git paths" escape does
+// not fire and that momentary zero value gets memoized against a HEAD that has
+// not moved. Every later lookup then resolves the repo to refs/_unknown — a
+// state dir that never holds a graph — so every incremental pass falls back to
+// a full reindex until HEAD moves or the daemon restarts.
+//
+// The trigger is transient; the consequence must not be sticky.
+func TestCaptureCached_DoesNotMemoizeUnrunnableGit(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	stop := withGitUnavailable(t)
+	if got := CaptureCached(dir); got != (Info{}) {
+		t.Fatalf("expected zero Info while git is unavailable, got %+v", got)
+	}
+	if *stop == 0 {
+		t.Fatal("seam was never exercised — the test is not testing anything")
+	}
+	runGitFn = runGitReal // git is schedulable again; HEAD never moved
+
+	got := CaptureCached(dir)
+	if got.Ref != "main" {
+		t.Fatalf("repo is stuck on a memoized failure: Ref=%q want %q "+
+			"(a failed Capture was cached against an unchanged HEAD, pinning the "+
+			"repo to refs/_unknown and a full reindex every pass)", got.Ref, "main")
+	}
+}
+
+// TestCaptureCachedFresh_DoesNotMemoizeUnrunnableGit is the same defect on the
+// commit-fresh variant (ResolveCWD / grafel_whoami), which memoizes on the same
+// unconditional write.
+func TestCaptureCachedFresh_DoesNotMemoizeUnrunnableGit(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	withGitUnavailable(t)
+	if got := CaptureCachedFresh(dir); got != (Info{}) {
+		t.Fatalf("expected zero Info while git is unavailable, got %+v", got)
+	}
+	runGitFn = runGitReal
+
+	got := CaptureCachedFresh(dir)
+	if got.Ref != "main" || got.SHA == "" {
+		t.Fatalf("stuck on a memoized failure: %+v", got)
+	}
+}
+
+// TestCaptureCached_DoesNotMemoizeAMidCaptureFailure covers the partial case:
+// `rev-parse --show-toplevel` succeeds, so Capture proceeds, and the LATER
+// `symbolic-ref` — the call that produces .Ref, the only field the hot caller
+// reads — is the one that cannot be run. The resulting Ref == "" is just as
+// poisonous as a total failure and must not be memoized either. Trust is a
+// property of the whole capture, not of its first call.
+func TestCaptureCached_DoesNotMemoizeAMidCaptureFailure(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	prev := runGitFn
+	runGitFn = func(d string, args ...string) (string, gitStatus) {
+		if len(args) > 0 && args[0] == "symbolic-ref" {
+			return "", gitUnavailable
+		}
+		return prev(d, args...)
+	}
+	t.Cleanup(func() { runGitFn = prev })
+
+	if got := CaptureCached(dir); got.Ref != "" {
+		t.Fatalf("fixture broken: expected empty Ref, got %+v", got)
+	}
+	runGitFn = prev
+
+	if got := CaptureCached(dir); got.Ref != "main" {
+		t.Fatalf("repo stuck on a memoized mid-capture failure: Ref=%q want \"main\"", got.Ref)
+	}
+}
+
+// TestCaptureCached_StillCachesAGenuineNonRepo pins the other half of the
+// distinction. A path where git RAN and reported "not a git repository" is a
+// durable fact, and caching it is a real optimisation (the daemon walks such
+// paths repeatedly). The fix must not throw that away by refusing to cache
+// every empty result.
+//
+// The fixture is a directory with an empty .git dir: headPointerKey resolves it
+// (so the :330 escape does NOT fire and the cache write is reached), while git
+// exits non-zero with "not a git repository".
+func TestCaptureCached_StillCachesAGenuineNonRepo(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := headPointerKey(dir); !ok {
+		t.Fatal("fixture unusable: headPointerKey must resolve, else the cache " +
+			"write is never reached and this test proves nothing")
+	}
+
+	calls := countingRealGit(t)
+	if got := CaptureCached(dir); got != (Info{}) {
+		t.Fatalf("expected zero Info for a non-repo, got %+v", got)
+	}
+	first := *calls
+	if first == 0 {
+		t.Fatal("fixture unusable: no git invocation happened")
+	}
+	if got := CaptureCached(dir); got != (Info{}) {
+		t.Fatalf("second call: %+v", got)
+	}
+	if *calls != first {
+		t.Fatalf("non-repo answer was not cached: %d extra git invocations on the "+
+			"second call — the caching optimisation was thrown away", *calls-first)
+	}
+}
+
+// TestRunGitStatus_TimeoutIsUnavailableNotAnAnswer pins the branch that the
+// production incident actually took: the 2s deadline firing.
+//
+// CommandContext kills the child when the deadline fires, and a killed child
+// surfaces as an *exec.ExitError — indistinguishable, by error type alone, from
+// git exiting 128 with "not a git repository". Only the ctx.Err() check
+// separates them. Without it a timeout is classified as a durable answer and
+// the zero Info gets memoized again, which is #6181 verbatim.
+//
+// A real 2s wait is not needed to exercise it: gitCallTimeout is shrunk and a
+// stub `git` that sleeps stands in for a wedged one.
+func TestRunGitStatus_TimeoutIsUnavailableNotAnAnswer(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	binDir := t.TempDir()
+	stub := filepath.Join(binDir, "git")
+	if err := os.WriteFile(stub, []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	prev := gitCallTimeout
+	gitCallTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { gitCallTimeout = prev })
+
+	out, st := runGitStatus(t.TempDir(), "rev-parse", "--show-toplevel")
+	if st != gitUnavailable || out != "" {
+		t.Fatalf("a timed-out git was classified as (%q, %v), want (\"\", gitUnavailable) — "+
+			"a killed child is an *exec.ExitError, so without the deadline check it "+
+			"reads as a durable answer and gets cached (#6181)", out, st)
+	}
+}
+
+// TestCaptureCached_DoesNotMemoizeATimeout is the end-to-end form of the above:
+// a timing-out git must leave no memo behind.
+func TestCaptureCached_DoesNotMemoizeATimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte("#!/bin/sh\nsleep 30\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir)
+	prev := gitCallTimeout
+	gitCallTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { gitCallTimeout = prev })
+
+	if got := CaptureCached(dir); got != (Info{}) {
+		t.Fatalf("expected zero Info from a timing-out git, got %+v", got)
+	}
+
+	// git is healthy again; HEAD never moved.
+	t.Setenv("PATH", realPath)
+	gitCallTimeout = prev
+	if got := CaptureCached(dir); got.Ref != "main" {
+		t.Fatalf("repo stuck on a memoized timeout: Ref=%q want \"main\"", got.Ref)
+	}
+}
+
+// TestRunGitStatus_ClassifiesAnsweredVsUnavailable pins the classification
+// itself against real git: a non-zero exit is an ANSWER (reproducible, about
+// the repo), while a missing binary means git never spoke.
+func TestRunGitStatus_ClassifiesAnsweredVsUnavailable(t *testing.T) {
+	dir := t.TempDir() // no .git anywhere under TempDir
+
+	if out, st := runGitStatus(dir, "rev-parse", "--show-toplevel"); st != gitAnswered || out != "" {
+		t.Fatalf("non-repo: got (%q, %v), want (\"\", gitAnswered)", out, st)
+	}
+	t.Setenv("PATH", "")
+	if out, st := runGitStatus(dir, "rev-parse", "--show-toplevel"); st != gitUnavailable || out != "" {
+		t.Fatalf("git off PATH: got (%q, %v), want (\"\", gitUnavailable)", out, st)
+	}
+}

--- a/internal/gitmeta/cache_transient_6181_test.go
+++ b/internal/gitmeta/cache_transient_6181_test.go
@@ -118,6 +118,80 @@ func TestCaptureCached_DoesNotMemoizeAMidCaptureFailure(t *testing.T) {
 	}
 }
 
+// TestCapture_DistrustIsPerCall_EverySubcommand closes the gap that the
+// mid-capture test alone leaves open (F3).
+//
+// captureStatus claims trust is a property of the WHOLE capture, but only the
+// --show-toplevel and symbolic-ref calls were actually pinned. The remaining
+// three feed .SHA and .IsWorktree, which CaptureCachedFresh serves to
+// grafel_whoami and ResolveCWD — so a narrowing of the distrust rule would
+// memoize SHA=""/IsWorktree=false from a moment and no test would notice.
+//
+// One case per git invocation Capture makes after the top-level probe.
+func TestCapture_DistrustIsPerCall_EverySubcommand(t *testing.T) {
+	matches := func(args, want []string) bool {
+		if len(args) < len(want) {
+			return false
+		}
+		for i, w := range want {
+			if args[i] != w {
+				return false
+			}
+		}
+		return true
+	}
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"sha", []string{"rev-parse", "--short=12", "HEAD"}},
+		{"symbolic-ref", []string{"symbolic-ref", "--short", "HEAD"}},
+		{"git-dir", []string{"rev-parse", "--git-dir"}},
+		{"git-common-dir", []string{"rev-parse", "--git-common-dir"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resetCaptureCacheForTest()
+			dir := initGitRepo(t)
+
+			prev := runGitFn
+			hit := false
+			runGitFn = func(d string, args ...string) (string, gitStatus) {
+				if matches(args, tc.args) {
+					hit = true
+					return "", gitUnavailable
+				}
+				return prev(d, args...)
+			}
+			t.Cleanup(func() { runGitFn = prev })
+
+			_, trusted := captureStatus(dir)
+			if !hit {
+				t.Fatalf("fixture never intercepted %v — Capture no longer makes this "+
+					"call, so this case proves nothing", tc.args)
+			}
+			if trusted {
+				t.Fatalf("capture marked trusted despite %v being un-runnable: a "+
+					"moment's failure would be memoized", tc.args)
+			}
+
+			// And end-to-end: nothing may have been memoized by either variant.
+			_ = CaptureCached(dir)
+			_ = CaptureCachedFresh(dir)
+			runGitFn = prev
+
+			if got := CaptureCached(dir); got.Ref != "main" || got.TopLevel == "" {
+				t.Fatalf("CaptureCached stuck on a memoized failure: %+v", got)
+			}
+			if got := CaptureCachedFresh(dir); got.Ref != "main" || got.SHA == "" {
+				t.Fatalf("CaptureCachedFresh stuck on a memoized failure: %+v", got)
+			}
+		})
+	}
+}
+
 // TestCaptureCached_StillCachesAGenuineNonRepo pins the other half of the
 // distinction. A path where git RAN and reported "not a git repository" is a
 // durable fact, and caching it is a real optimisation (the daemon walks such
@@ -217,6 +291,85 @@ func TestCaptureCached_DoesNotMemoizeATimeout(t *testing.T) {
 	gitCallTimeout = prev
 	if got := CaptureCached(dir); got.Ref != "main" {
 		t.Fatalf("repo stuck on a memoized timeout: Ref=%q want \"main\"", got.Ref)
+	}
+}
+
+// stubGit installs a fake `git` on PATH with the given shell body and returns
+// the real PATH so a test can restore it.
+func stubGit(t *testing.T, body string) (realPath string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realPath = os.Getenv("PATH")
+	t.Setenv("PATH", binDir)
+	return realPath
+}
+
+// TestRunGitStatus_SignalDeathIsUnavailableNotAnAnswer covers the general case
+// that the deadline check is only a subset of.
+//
+// A git killed by the OOM killer, macOS jetsam, or a SIGTERM propagated to the
+// daemon's process group surfaces as an *exec.ExitError with ctx.Err() == nil —
+// so a deadline-only check classifies it as a durable answer about the repo and
+// caches the zero Info. That is #6181 verbatim, and it is MORE load-correlated
+// than the timeout case, not less: the OOM killer fires under exactly the memory
+// pressure that makes forks fail.
+//
+// The correct axis is signalled-vs-exited, not deadline-vs-not. ExitCode()
+// returns -1 when the process was terminated by a signal, on every platform.
+func TestRunGitStatus_SignalDeathIsUnavailableNotAnAnswer(t *testing.T) {
+	stubGit(t, "kill -9 $$")
+
+	// Deadline is generous and deliberately never fires: this must be caught by
+	// signal detection, not by ctx.Err().
+	prev := gitCallTimeout
+	gitCallTimeout = 30 * time.Second
+	t.Cleanup(func() { gitCallTimeout = prev })
+
+	out, st := runGitStatus(t.TempDir(), "rev-parse", "--show-toplevel")
+	if st != gitUnavailable || out != "" {
+		t.Fatalf("a SIGKILLed git was classified as (%q, %v), want (\"\", gitUnavailable) — "+
+			"a signalled process is an *exec.ExitError with ctx.Err()==nil, so a "+
+			"deadline-only check reads it as a durable answer and caches it (#6181)", out, st)
+	}
+}
+
+// TestCaptureCached_DoesNotMemoizeASignalledGit is the end-to-end form: an
+// OOM-killed git must not pin the repo to refs/_unknown.
+func TestCaptureCached_DoesNotMemoizeASignalledGit(t *testing.T) {
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	realPath := stubGit(t, "kill -9 $$")
+	prev := gitCallTimeout
+	gitCallTimeout = 30 * time.Second
+	t.Cleanup(func() { gitCallTimeout = prev })
+
+	if got := CaptureCached(dir); got != (Info{}) {
+		t.Fatalf("expected zero Info from a killed git, got %+v", got)
+	}
+
+	// git is healthy again; HEAD never moved.
+	t.Setenv("PATH", realPath)
+	if got := CaptureCached(dir); got.Ref != "main" {
+		t.Fatalf("repo pinned to _unknown by an OOM-killed git: Ref=%q want \"main\"", got.Ref)
+	}
+}
+
+// TestRunGitStatus_NormalNonZeroExitStaysAnAnswer guards the other side of F1:
+// splitting on signalled-vs-exited must not sweep git's ordinary non-zero exits
+// (128 for "not a git repository") into gitUnavailable and throw the caching
+// optimisation away.
+func TestRunGitStatus_NormalNonZeroExitStaysAnAnswer(t *testing.T) {
+	stubGit(t, "exit 128")
+
+	if out, st := runGitStatus(t.TempDir(), "rev-parse", "--show-toplevel"); st != gitAnswered || out != "" {
+		t.Fatalf("exit 128: got (%q, %v), want (\"\", gitAnswered)", out, st)
 	}
 }
 

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -199,11 +199,16 @@ const (
 // — you cannot reliably starve a machine into a fork failure, and the bug it
 // guards (#6181) is precisely the load-correlated case. Unexported and
 // test-only; production always uses runGitReal.
+//
+// NOT SYNCHRONISED. Both this and gitCallTimeout are plain globals that tests
+// write mid-run, which is only safe because no test in this package calls
+// t.Parallel(). If you add one, these need a mutex or a per-call injection
+// point first — `go test -race` is green today by that accident, not by design.
 var runGitFn = runGitReal
 
 // gitCallTimeout is RunGit's deadline. A var, not a const, only so a test can
 // shrink it and exercise the timeout branch in milliseconds rather than
-// seconds. Production never changes it.
+// seconds. Production never changes it. See runGitFn on synchronisation.
 var gitCallTimeout = 2 * time.Second
 
 // runGitStatus runs git and reports both stdout and why it failed, if it did.
@@ -221,14 +226,31 @@ func runGitReal(dir string, args ...string) (string, gitStatus) {
 	if err == nil {
 		return strings.TrimSpace(string(out)), gitOK
 	}
-	// Deadline first: CommandContext kills the child on timeout, which surfaces
-	// as an *exec.ExitError (signal: killed) and would otherwise be misread as
-	// "git answered".
+	// Deadline first: CommandContext kills the child on timeout. Strictly
+	// redundant with the signal check below — a killed child is a signalled
+	// child — but it is cheaper and it documents the intent at the point where
+	// the timeout is set.
 	if ctx.Err() != nil {
 		return "", gitUnavailable
 	}
 	var ee *exec.ExitError
 	if errors.As(err, &ee) {
+		// *exec.ExitError collapses two different meanings, and the axis that
+		// separates them is signalled-vs-exited — NOT deadline-vs-not, which is
+		// only a subset of it. A git killed by the OOM killer, macOS jetsam, or a
+		// SIGTERM propagated to the daemon's process group never got to answer,
+		// and arrives here with ctx.Err() == nil. Classifying that as a durable
+		// fact about the repository is #6181 verbatim, and it is MORE
+		// load-correlated than the timeout: the OOM killer fires under exactly
+		// the memory pressure that makes forks fail.
+		//
+		// ExitCode() returns -1 when the process was terminated by a signal, on
+		// every platform — no syscall import, correct on Windows.
+		if ee.ExitCode() < 0 {
+			return "", gitUnavailable
+		}
+		// A real non-zero exit (128 "not a git repository", 1 "no such ref") is a
+		// reproducible answer about the repo and stays cacheable.
 		return "", gitAnswered
 	}
 	// Everything else — exec.ErrNotFound, EAGAIN on fork, ENOMEM, pipe errors —

--- a/internal/gitmeta/gitmeta.go
+++ b/internal/gitmeta/gitmeta.go
@@ -8,6 +8,7 @@ package gitmeta
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -171,36 +172,113 @@ func IsDefaultBranch(repoPath string) bool {
 	return false
 }
 
-// RunGit runs git with the given args inside dir and returns stdout trimmed.
-// Returns "" on any failure. Uses a 2-second timeout consistent with Capture.
-// This is the shared low-level runner used by both Capture and callers in
-// other packages that need ad-hoc git queries (e.g. --git-common-dir for
-// worktree resolution in internal/mcp/routing.go, PH1c of #2087).
-func RunGit(dir string, args ...string) string {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+// gitStatus classifies WHY an external git invocation produced no usable
+// output. Empty stdout on its own is ambiguous — it is what you get both when
+// git ran and reported "this is not a git repository" and when git could not be
+// run at all — and that ambiguity is the root of #6181: a transient fork
+// failure was memoized as a durable fact about the repository.
+type gitStatus int
+
+const (
+	// gitOK: git ran and exited 0. The output is the answer.
+	gitOK gitStatus = iota
+	// gitAnswered: git ran to completion and exited non-zero. This is still a
+	// real answer ABOUT THE REPO — "not a git repository", "detached HEAD has no
+	// symbolic ref", "no such ref" — and it is reproducible, so a caller may
+	// safely memoize what it derived from it.
+	gitAnswered
+	// gitUnavailable: git could not be run to completion — the 2s deadline
+	// fired, fork failed (EAGAIN under load), the binary is not on PATH, or a
+	// pipe broke. This says nothing about the repository, only about the moment.
+	// A caller MUST NOT memoize anything derived from it (#6181).
+	gitUnavailable
+)
+
+// runGitFn is the seam through which every git invocation in this package is
+// made. It exists so tests can inject a gitUnavailable outcome deterministically
+// — you cannot reliably starve a machine into a fork failure, and the bug it
+// guards (#6181) is precisely the load-correlated case. Unexported and
+// test-only; production always uses runGitReal.
+var runGitFn = runGitReal
+
+// gitCallTimeout is RunGit's deadline. A var, not a const, only so a test can
+// shrink it and exercise the timeout branch in milliseconds rather than
+// seconds. Production never changes it.
+var gitCallTimeout = 2 * time.Second
+
+// runGitStatus runs git and reports both stdout and why it failed, if it did.
+func runGitStatus(dir string, args ...string) (string, gitStatus) {
+	return runGitFn(dir, args...)
+}
+
+func runGitReal(dir string, args ...string) (string, gitStatus) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitCallTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "git", args...)
 	cmd.Dir = dir
 	executil.NoWindow(cmd)
 	out, err := cmd.Output()
-	if err != nil {
-		return ""
+	if err == nil {
+		return strings.TrimSpace(string(out)), gitOK
 	}
-	return strings.TrimSpace(string(out))
+	// Deadline first: CommandContext kills the child on timeout, which surfaces
+	// as an *exec.ExitError (signal: killed) and would otherwise be misread as
+	// "git answered".
+	if ctx.Err() != nil {
+		return "", gitUnavailable
+	}
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return "", gitAnswered
+	}
+	// Everything else — exec.ErrNotFound, EAGAIN on fork, ENOMEM, pipe errors —
+	// means git never got to speak.
+	return "", gitUnavailable
+}
+
+// RunGit runs git with the given args inside dir and returns stdout trimmed.
+// Returns "" on any failure. Uses a 2-second timeout consistent with Capture.
+// This is the shared low-level runner used by both Capture and callers in
+// other packages that need ad-hoc git queries (e.g. --git-common-dir for
+// worktree resolution in internal/mcp/routing.go, PH1c of #2087).
+//
+// It deliberately collapses gitAnswered and gitUnavailable into "": callers
+// outside this package do not memoize on the result, so the distinction buys
+// them nothing. Anything that CACHES a git-derived value must use runGitStatus
+// and refuse to cache a gitUnavailable outcome (#6181).
+func RunGit(dir string, args ...string) string {
+	out, _ := runGitStatus(dir, args...)
+	return out
 }
 
 // Capture runs a small set of git commands against repoPath and returns the
 // HEAD metadata. All git calls use a 2-second timeout; any failure (non-git
 // directory, git not on PATH, etc.) returns the zero-value Info with no error.
 func Capture(repoPath string) Info {
+	info, _ := captureStatus(repoPath)
+	return info
+}
+
+// captureStatus is Capture plus a trust flag. trusted is false when ANY of the
+// git invocations could not be run to completion, which means the returned Info
+// describes the moment rather than the repository and must not be memoized
+// (#6181). A repo that git ran against and reported on — including "not a git
+// repository" and a detached HEAD's empty symbolic-ref — is trusted, so the
+// negative result stays cacheable and the cache keeps its value.
+func captureStatus(repoPath string) (info Info, trusted bool) {
+	trusted = true
 	run := func(args ...string) string {
-		return RunGit(repoPath, args...)
+		out, st := runGitStatus(repoPath, args...)
+		if st == gitUnavailable {
+			trusted = false
+		}
+		return out
 	}
 
 	// Sanity-check: is this a git repo at all?
 	topLevel := run("rev-parse", "--show-toplevel")
 	if topLevel == "" {
-		return Info{}
+		return Info{}, trusted
 	}
 
 	// Abbreviated SHA (12 chars matches GitHub's default).
@@ -219,5 +297,5 @@ func Capture(repoPath string) Info {
 		SHA:        sha,
 		IsWorktree: isWorktree,
 		TopLevel:   topLevel,
-	}
+	}, trusted
 }

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1418,15 +1418,30 @@ func skeletonizeDocRows(doc *graph.Document) {
 // Callers MUST pass lr.Path, not any other spelling of the repo path: the memo
 // has one slot, so two callers feeding it different paths would invalidate each
 // other on every call and reinstate the per-call fork this exists to remove.
+// DO NOT SEAL AN "_unknown" RESOLUTION (#6181). The HEAD token is an os.Stat
+// that succeeds regardless of system load, so it cannot see the difference
+// between "git says this repo has no ref" and "git could not be run just now".
+// gitmeta no longer memoizes the latter, but this memo holds the DERIVED value
+// and would keep serving the sentinel long after gitmeta recovered — until HEAD
+// next moves. That is not cosmetic: applyFlowOverlay feeds this directory
+// straight into flows.Read, so a stuck "_unknown" silently drops the
+// process-flow overlay from every State.Group call, with no error raised.
+//
+// Re-resolving an "_unknown" repo costs a gitmeta.CaptureCached, which for a
+// genuinely ref-less repo (detached HEAD, non-git path) is a memo hit on a
+// trusted capture — a map lookup and a stat, not a fork. The per-call fork
+// #6060 removed stays removed.
 func (lr *LoadedRepo) currentRefDirLocked(repoPath string) string {
 	tok, _ := gitmeta.HeadToken(repoPath)
 	if lr.curRefKnown && tok == lr.curRefHeadTok {
 		return lr.curRefDir
 	}
-	lr.curRefDir = daemon.StateDirForRepo(repoPath)
+	dir := daemon.StateDirForRepo(repoPath)
+	lr.curRefDir = dir
 	lr.curRefHeadTok = tok
-	lr.curRefKnown = true
-	return lr.curRefDir
+	// Seal the memo only for a resolution that named a real ref.
+	lr.curRefKnown = dir != "" && dir != daemon.StateDirForRepoRef(repoPath, "")
+	return dir
 }
 
 // reloadAllLocked is the reload body; the caller MUST already hold s.mu. Split

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -1427,20 +1427,32 @@ func skeletonizeDocRows(doc *graph.Document) {
 // straight into flows.Read, so a stuck "_unknown" silently drops the
 // process-flow overlay from every State.Group call, with no error raised.
 //
-// Re-resolving an "_unknown" repo costs a gitmeta.CaptureCached, which for a
-// genuinely ref-less repo (detached HEAD, non-git path) is a memo hit on a
-// trusted capture — a map lookup and a stat, not a fork. The per-call fork
-// #6060 removed stays removed.
+// Re-resolving a repo that HAS a HEAD costs a gitmeta.CaptureCached, which for a
+// detached HEAD is a memo hit on a capture git actually answered — a map lookup
+// and a stat, not a fork.
+//
+// A path with NO HEAD is the opposite case and must still be sealed. gitmeta
+// cannot memoize it at all (headPointerKey fails, so CaptureCached falls through
+// to a live Capture), so leaving it unsealed forks git on every call — exactly
+// the per-call cost the paragraph above says this memo exists to remove. It is
+// also safe to seal: no .git means no ref that could later resolve, so there is
+// no recovery to wait for. hasHead is the discriminator.
 func (lr *LoadedRepo) currentRefDirLocked(repoPath string) string {
-	tok, _ := gitmeta.HeadToken(repoPath)
+	tok, hasHead := gitmeta.HeadToken(repoPath)
 	if lr.curRefKnown && tok == lr.curRefHeadTok {
 		return lr.curRefDir
 	}
 	dir := daemon.StateDirForRepo(repoPath)
 	lr.curRefDir = dir
 	lr.curRefHeadTok = tok
-	// Seal the memo only for a resolution that named a real ref.
-	lr.curRefKnown = dir != "" && dir != daemon.StateDirForRepoRef(repoPath, "")
+	// Seal for a resolution that named a real ref, or for a path with no HEAD to
+	// move at all. Leave a repo that HAS a HEAD but resolved to "_unknown"
+	// unsealed, so it recovers without waiting for HEAD to move (#6181).
+	//
+	// A branch literally named "_unknown" collides with the sentinel and is never
+	// sealed. It is a real repo, so re-resolution is a gitmeta memo hit and costs
+	// no fork; the collision is pre-existing in RefSafeEncode (state_path.go).
+	lr.curRefKnown = dir != "" && (!hasHead || dir != daemon.StateDirForRepoRef(repoPath, ""))
 	return dir
 }
 

--- a/internal/mcp/state_unknown_memo_6181_test.go
+++ b/internal/mcp/state_unknown_memo_6181_test.go
@@ -17,6 +17,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/daemon"
@@ -62,10 +64,10 @@ func detachedHeadRepo(t *testing.T) string {
 // state dir it names holds no graph, so a sealed memo converts a momentary
 // failure into a permanent one for the life of the HEAD generation.
 //
-// The assertion is on the memo flag rather than on a second differing return
-// value on purpose: making the underlying resolution change without moving HEAD
-// requires injecting a git failure, and that seam is unexported inside gitmeta.
-// The flag IS the stickiness.
+// This asserts on the memo flag, which is the stickiness itself. The end-to-end
+// form — the value the CALLER receives, before and after a git outage, with HEAD
+// never moving — is TestCurrentRefDir_RecoversAfterATransientGitFailure below;
+// no unexported seam is needed for it, a PATH stub reaches the same path.
 func TestCurrentRefDir_DoesNotSealAnUnknownResolution(t *testing.T) {
 	repo := detachedHeadRepo(t)
 
@@ -87,6 +89,127 @@ func TestCurrentRefDir_DoesNotSealAnUnknownResolution(t *testing.T) {
 			"once a transient git failure resolves here, every later State.Group call " +
 			"is served _unknown until HEAD moves — flows.Read misses and the process-flow " +
 			"overlay is silently dropped (#6181)")
+	}
+}
+
+// countingGitStub replaces `git` on PATH with a script that records every
+// invocation to a file and then behaves as `exit <code>`. It returns a func
+// reporting how many times git was forked. Reaching the real resolution path
+// from inside package mcp needs nothing unexported — a PATH stub is enough.
+func countingGitStub(t *testing.T, body string) func() int {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	binDir := t.TempDir()
+	counter := filepath.Join(binDir, "calls")
+	script := "#!/bin/sh\necho x >> " + counter + "\n" + body + "\n"
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+	return func() int {
+		data, err := os.ReadFile(counter)
+		if err != nil {
+			return 0
+		}
+		return strings.Count(string(data), "x")
+	}
+}
+
+// TestCurrentRefDir_NonGitPathDoesNotForkPerCall is the F2a regression.
+//
+// Refusing to seal an "_unknown" resolution (#6181) is correct for a repo whose
+// ref might later resolve. It is WRONG for a registered path with no .git at
+// all: gitmeta.CaptureCached cannot memoize such a path — headPointerKey fails,
+// so it falls through to a live, uncached Capture — and re-resolving it on every
+// call forks git every time. That is precisely the per-call fork #6060 removed,
+// and this file's own comment (see currentRefDirLocked) names the non-git path
+// as the entire reason the memo exists.
+//
+// A path with no HEAD has no ref that could later resolve, so there is nothing
+// to recover to and nothing is lost by sealing it.
+func TestCurrentRefDir_NonGitPathDoesNotForkPerCall(t *testing.T) {
+	dir := t.TempDir() // deliberately no .git
+	forks := countingGitStub(t, "exit 128")
+
+	lr := &LoadedRepo{Path: dir}
+	var last string
+	for i := 0; i < 5; i++ {
+		last = lr.currentRefDirLocked(dir)
+	}
+	if last == "" {
+		t.Fatal("fixture unusable: no resolution at all")
+	}
+	if n := forks(); n > 1 {
+		t.Fatalf("a non-git registered path forked git %d times across 5 calls "+
+			"(want at most 1): the _unknown guard re-resolves a path gitmeta cannot "+
+			"memoize, reinstating the per-call fork #6060 removed — one such directory "+
+			"means one fork per MCP tool call, forever", n)
+	}
+}
+
+// TestCurrentRefDir_DetachedHeadDoesNotForkPerCall pins the other side: a real
+// repo on a detached HEAD is left unsealed on purpose, and that must stay cheap.
+// gitmeta CAN memoize it (git ran and answered), so re-resolving is a map lookup
+// and a stat, not a fork.
+func TestCurrentRefDir_DetachedHeadDoesNotForkPerCall(t *testing.T) {
+	repo := detachedHeadRepo(t)
+
+	lr := &LoadedRepo{Path: repo}
+	if got := lr.currentRefDirLocked(repo); got != daemon.StateDirForRepoRef(repo, "") {
+		t.Fatalf("fixture degenerate: detached HEAD resolved to %q, not the sentinel", got)
+	}
+
+	// Only now install the counter: the priming call above is allowed to fork.
+	forks := countingGitStub(t, "exit 128")
+	for i := 0; i < 5; i++ {
+		lr.currentRefDirLocked(repo)
+	}
+	if n := forks(); n != 0 {
+		t.Fatalf("detached HEAD forked git %d times across 5 calls, want 0 — "+
+			"gitmeta memoizes a capture git actually answered", n)
+	}
+}
+
+// TestCurrentRefDir_RecoversAfterATransientGitFailure is the end-to-end
+// assertion, on the value the CALLER receives rather than on the memo flag.
+//
+// A real repo on a real branch, git killed by a signal for the duration of the
+// outage, HEAD never touched. During the outage the resolution is the "_unknown"
+// sentinel; once git is healthy again the very next call must return the branch
+// directory — with no HEAD movement and no daemon restart to rescue it.
+func TestCurrentRefDir_RecoversAfterATransientGitFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	repo := detachedHeadRepo(t)
+	cmd := exec.Command("git", "checkout", "main")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout main: %v\n%s", err, out)
+	}
+	wantDir := daemon.StateDirForRepoRef(repo, "main")
+	realPath := os.Getenv("PATH")
+
+	// The outage: every git dies by signal, so nothing may be memoized anywhere.
+	countingGitStub(t, "kill -9 $$")
+
+	lr := &LoadedRepo{Path: repo}
+	during := lr.currentRefDirLocked(repo)
+	if during != daemon.StateDirForRepoRef(repo, "") {
+		t.Fatalf("during outage: resolved to %q, want the _unknown sentinel", during)
+	}
+	if lr.curRefKnown {
+		t.Fatal("during outage: an _unknown resolution was sealed — the repo is now " +
+			"pinned to a state dir that holds no graph until HEAD moves (#6181)")
+	}
+
+	// git recovers. HEAD has not moved, so nothing invalidates anything.
+	t.Setenv("PATH", realPath)
+	if after := lr.currentRefDirLocked(repo); after != wantDir {
+		t.Fatalf("after recovery: resolved to %q, want %q — the repo did not recover "+
+			"from a transient git failure", after, wantDir)
 	}
 }
 

--- a/internal/mcp/state_unknown_memo_6181_test.go
+++ b/internal/mcp/state_unknown_memo_6181_test.go
@@ -1,0 +1,123 @@
+// state_unknown_memo_6181_test.go — issue #6181, second sticky site.
+//
+// gitmeta no longer memoizes a capture that failed because git could not be
+// RUN. But internal/mcp memoizes the DERIVED value — the resolved per-ref state
+// directory — on the very same HEAD-pointer token, which is an os.Stat that
+// succeeds regardless of load. So a repo that resolved to the "_unknown"
+// sentinel during a transient git failure keeps being served "_unknown" from
+// this layer even after gitmeta has recovered, until HEAD next moves.
+//
+// The consequence is not cosmetic: applyFlowOverlay feeds this directory
+// straight into flows.Read, so a memoized "_unknown" silently drops the
+// process-flow overlay from every State.Group call — a successful MCP response
+// with data missing and no error anywhere.
+package mcp
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+)
+
+// detachedHeadRepo creates a real git repo and detaches HEAD, which is the
+// cheapest honest way to make StateDirForRepo resolve to the "_unknown"
+// sentinel: `git symbolic-ref --short HEAD` exits non-zero on a detached HEAD,
+// so Ref is "" through an entirely healthy git.
+func detachedHeadRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	run := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return string(out)
+	}
+	run("init")
+	run("checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run("add", ".")
+	run("commit", "-m", "init")
+	run("checkout", "--detach", "HEAD")
+	return dir
+}
+
+// TestCurrentRefDir_DoesNotSealAnUnknownResolution is the #6181 F2 regression.
+//
+// "_unknown" is the resolution the daemon reaches when it could not determine a
+// ref — which happens both legitimately (detached HEAD) and transiently (git
+// could not be run). It is never a durable answer worth sealing a memo on: the
+// state dir it names holds no graph, so a sealed memo converts a momentary
+// failure into a permanent one for the life of the HEAD generation.
+//
+// The assertion is on the memo flag rather than on a second differing return
+// value on purpose: making the underlying resolution change without moving HEAD
+// requires injecting a git failure, and that seam is unexported inside gitmeta.
+// The flag IS the stickiness.
+func TestCurrentRefDir_DoesNotSealAnUnknownResolution(t *testing.T) {
+	repo := detachedHeadRepo(t)
+
+	unknownDir := daemon.StateDirForRepoRef(repo, "")
+	if unknownDir == "" {
+		t.Fatal("fixture unusable: no _unknown sentinel dir")
+	}
+
+	lr := &LoadedRepo{Path: repo}
+	got := lr.currentRefDirLocked(repo)
+
+	if got != unknownDir {
+		t.Fatalf("fixture degenerate: resolved to %q, not the _unknown sentinel %q — "+
+			"this test cannot exercise the sticky path", got, unknownDir)
+	}
+	// Behaviour for the caller must be unchanged: it still gets the resolution.
+	if lr.curRefKnown {
+		t.Fatalf("an _unknown resolution was sealed into the memo (curRefKnown=true): " +
+			"once a transient git failure resolves here, every later State.Group call " +
+			"is served _unknown until HEAD moves — flows.Read misses and the process-flow " +
+			"overlay is silently dropped (#6181)")
+	}
+}
+
+// TestCurrentRefDir_StillMemoizesAResolvedRef guards the optimisation the
+// mitigation must not damage: a repo on a real branch seals its memo on the
+// first call and is served from it thereafter, with no re-resolution. This is
+// what #6060 bought and F2 must not spend.
+func TestCurrentRefDir_StillMemoizesAResolvedRef(t *testing.T) {
+	repo := detachedHeadRepo(t)
+	// Re-attach to a branch: now there is a real ref to resolve.
+	cmd := exec.Command("git", "checkout", "main")
+	cmd.Dir = repo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("checkout main: %v\n%s", err, out)
+	}
+
+	lr := &LoadedRepo{Path: repo}
+	first := lr.currentRefDirLocked(repo)
+	if first == daemon.StateDirForRepoRef(repo, "") {
+		t.Fatalf("fixture degenerate: an attached HEAD still resolved to _unknown (%q)", first)
+	}
+	if !lr.curRefKnown {
+		t.Fatal("a real ref resolution was not memoized — the #6060 optimisation is gone")
+	}
+
+	// Break the memo's inputs: if it re-resolves, it cannot return the same dir.
+	sealed := lr.curRefDir
+	lr.curRefDir = "SENTINEL-NOT-RERESOLVED"
+	if got := lr.currentRefDirLocked(repo); got != "SENTINEL-NOT-RERESOLVED" {
+		t.Fatalf("memo was not used on the second call: got %q, want the sealed value "+
+			"(re-resolution costs a Capture per State.Group call per repo)", got)
+	}
+	lr.curRefDir = sealed
+}


### PR DESCRIPTION
Three of 28 `incremental fallback` events in an 18-hour production capture were `refs/_unknown`, correlating with 14 `deadref: git ref enumeration failed` warnings. Same root cause, two symptoms.

## The chain

`gitmeta.CaptureCached` memoized a **failed** `Capture`.

`RunGit` ran under a 2-second timeout and **swallowed every error into `""`** — timeout, `EAGAIN` on fork, and "genuinely not a git repo" were indistinguishable. `Capture` then returned the zero `Info{}` with `Ref == ""`, and `cache.go:344-346` cached it, keyed on a `.git/HEAD` `os.Stat` that **succeeds regardless of load** — so the "don't cache non-git paths" escape at `:330` never fired.

Once poisoned, `StateDirForRepo` returned `refs/_unknown` for that repo until `.git/HEAD` changed or the daemon restarted. `refs/_unknown` has no `graph.fb`, so `LoadGraphFromDir` failed and **every incremental pass fell back to a full reindex** — 42s–4m53s each.

The trigger is transient; the consequence is sticky. And it is **load-correlated**, so it fires exactly when a full reindex is most expensive, clustering failures instead of spreading them.

## The fix: classification *is* cache policy

| outcome | meaning | cached? |
|---|---|---|
| `gitOK` | exit 0 | yes |
| `gitAnswered` | git ran to completion, exited non-zero — a reproducible fact *about the repo* ("not a git repository", detached HEAD's empty `symbolic-ref`) | **yes** — this is where the optimisation lives |
| `gitUnavailable` | deadline fired, fork failed, binary missing, pipe broke — says nothing about the repo | **never** |

`captureStatus` returns `(Info, trusted)`, and `trusted` is false if **any** call in the capture was unavailable, not just the first — `.Ref` is the only field the hot caller reads, so a `symbolic-ref` that could not run is exactly as poisonous as a total failure.

`RunGit`'s signature is unchanged; its 10 external callers do not memoize, so they gain nothing from the distinction and take no blast radius.

## Splitting `*exec.ExitError` on the wrong axis — twice

**First cut** separated deadline-vs-not. Mutation testing found that dropping the `ctx.Err()` check **survived**: `CommandContext` SIGKILLs on timeout and that surfaces as `*exec.ExitError`, byte-identical in type to `git exit 128`. The tests injected `gitUnavailable` through the seam and never exercised the real classifier's timeout path — the exact production trigger. Covered and killed.

**Second cut still had it.** Review measured that a git killed by anything *else* — OOM killer, jetsam, a SIGTERM propagated to the process group, SIGSEGV — also surfaces as `*exec.ExitError` with `ctx.Err() == nil`, and was classified as a durable fact about the repo:

```
SIGKILL, deadline never fires:  status=gitAnswered
after git recovers, HEAD unmoved: Ref=""
DEFECT #6181 SURVIVES: repo pinned to _unknown by an OOM-killed git
```

That is the original chain, verbatim, and **more** load-correlated than the timeout case — the OOM killer fires under exactly the memory pressure that makes forks fail.

Deadline-vs-not is a proper subset of signalled-vs-exited. Now `ee.ExitCode() < 0` → `gitUnavailable` (portable; Go documents -1 for signal termination on all platforms). The `ctx.Err()` check is kept as cheaper, self-documenting redundancy — its mutant now survives **by construction**, which is reported rather than papered over. Verified: SIGSEGV/SIGTERM/SIGBUS/SIGABRT all unavailable, a `127` shim still `gitAnswered`, and `TestCaptureCached_StillCachesAGenuineNonRepo` stays green so the optimisation survives.

## A second sticky site, shipped rather than deferred

`internal/mcp/state.go` `currentRefDirLocked` memoizes the **derived** state dir on the same load-blind stat. It is genuinely off the reindex chain — `ResolveIncrementalStateDir` calls `StateDirForRepo` directly with no second memo — but of its two callers, `applyFlowOverlay` feeds the state dir straight into `flows.Read`. A poisoned `_unknown` there means the read misses, `next = nil`, and **the flow overlay is silently dropped from every `State.Group` call until HEAD moves** — successful MCP responses with process-flow data missing, no error, sticky exactly like the original bug.

The memo is now sealed only when the resolution named a real ref. Review proved the guard is *exactly* complete rather than merely covering detached HEAD: `StateDirForRepo` reaches `_unknown` **iff** `meta.Ref == ""`, and `StateDirForRepoRef(repoPath, "")` is pure path math — no fork, no stat — so the guard is free.

## The mitigation walked into the case its own file documents

That guard introduced a regression, caught in review and measured:

| fixture | forks / 5 calls | before |
|---|---|---|
| **non-git path (no `.git`)** | **5** | 1 |
| detached HEAD | 0 | 0 |
| branch named `_unknown` | 0 | 0 |

A registered path with no `.git` also resolves to `_unknown`, so it was never sealed, so it re-resolved every call — and `headPointerKey` returns `!ok`, falling through to a **live, uncached `Capture` that forks**. One `git` fork per such repo per MCP tool call, forever.

The `#6060` comment thirty lines above says precisely this: *"for a non-git repo path gitmeta cannot memoize the capture, so a direct call would fork git per call per repo."* The first fix quoted its detached-HEAD half and asserted the non-git half without measuring it.

Fixed with the `!hasHead` discriminator — `HeadToken`'s `ok` was already computed and discarded one line above. Sound because a failing `headPointerKey` means there is no `.git`, hence no repo whose ref could later resolve, hence nothing to recover to. Measured after: non-git 1 fork/5 calls, detached HEAD still 0 and unsealed, both recovery paths intact. Both cases are now pinned in **opposite** directions, so the next person cannot fix one by silently breaking the other.

## Recovery asserted at the caller, not at the flag

The claim that an end-to-end test needed an unexported seam was wrong — a PATH stub reaches it from inside `package mcp`. Real repo on `main`, `git` replaced by `kill -9 $$`, HEAD never touched:

```
during outage:                   dir="_unknown"  curRefKnown=false
after recovery (HEAD unmoved):   dir="main"
```

That asserts the value the caller receives, not the memo field. The doc comment claiming a seam was required is deleted rather than amended.

## On the 2-second deadline — deliberately not widened

During verification `./internal/gitmeta/...` failed once at exactly **2.01s**, on a test whose stub `git` does nothing but `exit 128`, at load 8.22. That is this defect's trigger reproducing spontaneously.

But it does **not** support widening the budget. Measured on the same class of machine:

```
load 7.67, real `git rev-parse`, n=100:   p50 15.1ms  p99 22.8ms  max 23.7ms
load ~6.5, 8-way concurrent, n=4000:      p99.9 170.8ms  max 172.3ms
                                          >200ms: 0  >500ms: 0  >1s: 0  >2s: 0
```

2s is ~12× the p99.9, and **no fork exceeded 200ms in 4300 samples**. So the 2.01s event was a multi-second stall of a single process — a tail two orders of magnitude off the distribution — not evidence that forks cost seconds under load. Build/link contention is at least as good an explanation as fork latency, and it is recorded as one unreproduced data point rather than characterised. Widening to 10s would reduce its frequency, could not eliminate it, and would cost 5× the latency whenever git is genuinely wedged — on the MCP query path.

**The deadline does not have to be right, and that is what this change buys.** Before it, a stall was recorded as a durable fact about the repository. After it, a stall is just a stall.

Filed separately rather than widened here.

## `deadref` needs no fix

`LiveGitRefs` fails on the identical first git call, which is why those 14 warnings correlate. But it is **already fail-closed**: returns `(nil, false)`, the caller skips the repo and logs, nothing is cached, nothing is deleted, no state persists past the sweep. The warning is a correct report of a real transient condition.

## Verification

`go build ./...` 0 · `go vet ./...` 0 · `gofmt -l .` empty. Unpiped `$?`, `-count=1 -p 1`, `GOMAXPROCS=4`, rebased first: `./internal/gitmeta/...` 0 (×3), `./internal/mcp/...` 0, `./internal/daemon/...` 0, `./internal/cli/...` 0, `-race` on the new tests 0.

Two seams added and disclosed, both unexported and written only in the package's own file and tests: `runGitFn` (inject a deterministic `gitUnavailable` — a machine cannot be reliably starved into a fork failure) and `gitCallTimeout` (a `var` so a test exercises the timeout branch in 50ms). Neither is reachable from production. Both are unsynchronised globals written mid-test, so `-race` is green only because nothing in the package calls `t.Parallel()` — now noted at the seam.

Two tests are deliberately **not red-able** — they assert behaviour correct before and after and exist purely as mutation targets. Review judged them legitimate: one kills the obvious over-correction (distrust everything non-`gitOK`), which would have thrown the caching optimisation away.

Independently adversarially reviewed twice (REQUEST-CHANGES → REQUEST-CHANGES → fixed), with the reviewer re-running its own probes against each revision rather than accepting reports. Two surviving mutants are reported as equivalent-by-construction rather than hidden.

## Deferred, with its constraint recorded

Detached HEAD resolves to `refs/_unknown` **by design** (`git symbolic-ref --short HEAD` is empty), so `git bisect`, CI-style checkouts and some worktree flows take a full reindex every pass. Keying the state dir on the commit SHA is worse, not better — every bisect step would get a fresh dir holding one full reindex that is never reused. Resolving to the branch the commit is reachable from is more promising, but `git branch --points-at HEAD` is ambiguous (zero matches mid-bisect, N after a merge), and **sharing the branch's dir as a write target would corrupt the branch graph for every other reader**. If it ships, read-only fallback with its own write target. Not implemented.

Closes #6181
Refs #6167
