### PR TITLE
fix(#6183): two repos with the same basename collided onto one plist, so reconcile never converged

### DIFF
--- a/docs/platform/windows-service.md
+++ b/docs/platform/windows-service.md
@@ -195,7 +195,32 @@ Get-Content "$env:APPDATA\grafel\logs\daemon.log" -Tail 50
 The watcher is a separate scheduled task — one per watched repository — and
 follows the same install/uninstall/status lifecycle as the daemon service.
 Each task name uses the reverse-DNS convention
-`com.grafel.watcher.<group>.<repo-slug>`.
+`com.grafel.watcher.<group>.<repo-slug>-<hash>`.
+
+> **Changed in #6183.** `<repo-slug>` used to be the repo's directory name
+> alone, so two repos in one group with the same directory name — `api`, `web`,
+> `docs` across different orgs — produced **one** task name for two repos, and
+> only one of them was ever actually watched. The slug now carries `-<hash>`,
+> eight hex characters derived from the repo's full path, e.g.
+> `com.grafel.watcher.mygroup.myrepo-3f9c1e07`.
+>
+> The literal task names in the commands below are therefore **examples, not
+> values you can copy**. Get the real one from the staged XML directory:
+>
+> ```powershell
+> ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.*.xml"
+> ```
+>
+> Upgrading renames existing tasks. `grafel install` and `grafel update`
+> deregister the old task name and delete its staged XML before creating the new
+> one, so a repo ends up with exactly one task — not two. **Downgrading does
+> not:** an older binary derives the un-hashed name, does not find it, and
+> creates it alongside the hashed task that is still registered. If you roll
+> back, delete the hashed tasks by hand:
+>
+> ```powershell
+> schtasks /delete /tn com.grafel.watcher.mygroup.myrepo-3f9c1e07 /f
+> ```
 
 ### W1. Install a watcher for a repo
 
@@ -206,27 +231,27 @@ Each task name uses the reverse-DNS convention
 
 Expected output (approximate):
 ```
-watcher installed: com.grafel.watcher.mygroup.myrepo  running=true
+watcher installed: com.grafel.watcher.mygroup.myrepo-3f9c1e07  running=true
 ```
 
 ### W2. Verify the watcher task exists
 
 ```powershell
-schtasks /query /tn com.grafel.watcher.mygroup.myrepo /fo list /v
+schtasks /query /tn com.grafel.watcher.mygroup.myrepo-3f9c1e07 /fo list /v
 ```
 
 Key fields:
 
 | Field | Expected value |
 |---|---|
-| `Task Name` | `\com.grafel.watcher.mygroup.myrepo` |
+| `Task Name` | `\com.grafel.watcher.mygroup.myrepo-3f9c1e07` |
 | `Status` | `Running` |
 | `Logon Mode` | `Interactive/Background` |
 
 ### W3. Verify the task XML was staged to disk
 
 ```powershell
-ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.myrepo.xml"
+ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.myrepo-3f9c1e07.xml"
 # Expected: file exists
 ```
 
@@ -246,19 +271,28 @@ ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.myrepo.xml"
 After uninstall:
 
 ```powershell
-schtasks /query /tn com.grafel.watcher.mygroup.myrepo
+schtasks /query /tn com.grafel.watcher.mygroup.myrepo-3f9c1e07
 # Expected: ERROR: The system cannot find the file specified.
 
-ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.myrepo.xml"
+ls "$env:LOCALAPPDATA\grafel\tasks\com.grafel.watcher.mygroup.myrepo-3f9c1e07.xml"
 # Expected: file not found
+
+# Uninstall also removes any task left over from a pre-#6183 install, i.e. the
+# un-hashed name. It is the last moment at which that name can be derived.
+schtasks /query /tn com.grafel.watcher.mygroup.myrepo
+# Expected: ERROR: The system cannot find the file specified.
 ```
 
 ### W6. Expected file paths (per-repo watcher)
 
 | Artifact | Path |
 |---|---|
-| Task XML (staged) | `%LOCALAPPDATA%\grafel\tasks\com.grafel.watcher.<group>.<slug>.xml` |
-| Task name | `com.grafel.watcher.<group>.<slug>` |
+| Task XML (staged) | `%LOCALAPPDATA%\grafel\tasks\com.grafel.watcher.<group>.<slug>-<hash>.xml` |
+| Task name | `com.grafel.watcher.<group>.<slug>-<hash>` |
+
+`<hash>` is the first 8 hex characters of SHA-256 over the repo's cleaned
+absolute path (#6183). It makes the task name unique per repo PATH rather than
+per directory name.
 
 ---
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -408,11 +408,32 @@ const refreshStateQuietEnv = "GRAFEL_REFRESH_STATE_QUIET"
 // Silent when nothing was stale: that is the steady state and it deserves no
 // output at all.
 func printReconcileSummary(out io.Writer, res *install.ReconcileWatcherResult) {
-	if res == nil || len(res.Rewritten) == 0 {
+	if res == nil || (len(res.Rewritten) == 0 && len(res.Migrated) == 0 && res.Absent == 0) {
 		return
 	}
-	fmt.Fprintf(out, "✓ watcher units refreshed: %d rewritten, %d re-registered, %d already current\n",
-		len(res.Rewritten), len(res.Reloaded), res.Current)
+	if len(res.Rewritten) > 0 || len(res.Migrated) > 0 {
+		fmt.Fprintf(out, "✓ watcher units refreshed: %d rewritten, %d re-registered, %d already current\n",
+			len(res.Rewritten), len(res.Reloaded), res.Current)
+	}
+	if res.Absent > 0 {
+		// #6183 F2: a repo that is registered with watchers on but has no unit
+		// under either label used to be counted here and never mentioned. That
+		// silence is what made an interrupted migration unrecoverable in
+		// practice — the operator had no signal at all that a repo was
+		// unwatched. Reconcile still will not create these (that is Apply's
+		// job), so the remedy has to be said out loud.
+		fmt.Fprintf(out, "  %d registered repo(s) have watchers enabled but no watcher unit "+
+			"installed; run `grafel install` for their group to add one\n", res.Absent)
+	}
+	if len(res.Migrated) > 0 {
+		// #6183: the label now includes a path digest, so these repos' units
+		// moved to a new filename. Say so — a user who greps LaunchAgents for
+		// the old name after upgrading would otherwise conclude their watchers
+		// had been deleted.
+		fmt.Fprintf(out, "  %d watcher unit(s) were renamed to make repos with identical directory "+
+			"names distinguishable (issue #6183); the previous units were deregistered and removed\n",
+			len(res.Migrated))
+	}
 	if len(res.Reloaded) > 0 {
 		fmt.Fprintf(out, "  macOS may show up to %d Background Items notifications while these "+
 			"re-register — this is the one-time repair for issue #6179, not a recurrence\n",

--- a/internal/cli/watcher_rename_output_6183_test.go
+++ b/internal/cli/watcher_rename_output_6183_test.go
@@ -1,0 +1,79 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// TestPrintReconcileSummary_AnnouncesTheRename covers the user-visible half of
+// #6183. The label now carries a path digest, so the one-time repair RENAMES
+// every already-installed unit. A user who greps ~/Library/LaunchAgents for the
+// old filename after upgrading would otherwise find nothing and conclude their
+// watchers had been deleted.
+func TestPrintReconcileSummary_AnnouncesTheRename(t *testing.T) {
+	var buf bytes.Buffer
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{
+		Current:   10,
+		Rewritten: []string{"/a.plist", "/b.plist"},
+		Reloaded:  []string{"/a.plist", "/b.plist"},
+		Migrated:  []string{"/old-a.plist", "/old-b.plist"},
+	})
+	got := buf.String()
+	if !strings.Contains(got, "renamed") {
+		t.Fatalf("summary does not mention the rename:\n%s", got)
+	}
+	if !strings.Contains(got, "#6183") {
+		t.Fatalf("summary does not point at the issue:\n%s", got)
+	}
+	if !strings.Contains(got, "2 watcher unit") {
+		t.Fatalf("summary does not report how many were renamed:\n%s", got)
+	}
+}
+
+// A migration with nothing else to report must still be announced: the units
+// moved, which is exactly the surprising part.
+func TestPrintReconcileSummary_MigrationOnlyIsNotSilent(t *testing.T) {
+	var buf bytes.Buffer
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{
+		Current:  1,
+		Migrated: []string{"/old.plist"},
+	})
+	if !strings.Contains(buf.String(), "renamed") {
+		t.Fatalf("a migration-only reconcile printed nothing:\n%q", buf.String())
+	}
+}
+
+// And the steady state stays silent — #6179's property.
+func TestPrintReconcileSummary_SilentWhenNothingHappened(t *testing.T) {
+	var buf bytes.Buffer
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{Current: 140})
+	if buf.Len() != 0 {
+		t.Fatalf("expected silence, got:\n%s", buf.String())
+	}
+}
+
+// TestPrintReconcileSummary_SurfacesAbsentRepos covers #6183 F2's minimum.
+//
+// A repo that is registered with watchers enabled but has no unit under either
+// label is left alone by reconcile — creating it is Apply's job. That is a
+// defensible policy only if somebody is told. It was counted into Absent and
+// then never printed, so an interrupted migration, or any repo whose unit was
+// removed by hand, was unwatched with no signal anywhere.
+func TestPrintReconcileSummary_SurfacesAbsentRepos(t *testing.T) {
+	var buf bytes.Buffer
+	printReconcileSummary(&buf, &install.ReconcileWatcherResult{Current: 3, Absent: 2})
+	got := buf.String()
+	if !strings.Contains(got, "2 registered repo") {
+		t.Fatalf("Absent repos were not surfaced:\n%q", got)
+	}
+	if !strings.Contains(got, "grafel install") {
+		t.Fatalf("no remedy offered:\n%q", got)
+	}
+	// Nothing was rewritten, so the refresh headline must not claim otherwise.
+	if strings.Contains(got, "watcher units refreshed") {
+		t.Fatalf("claimed a refresh that did not happen:\n%q", got)
+	}
+}

--- a/internal/install/apply_migrate_6183_darwin_test.go
+++ b/internal/install/apply_migrate_6183_darwin_test.go
@@ -1,0 +1,105 @@
+//go:build darwin
+
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestApply_RetiresLegacyWatcherUnit covers the #6183 migration on the install
+// path.
+//
+// `grafel install` / `grafel update` are how most machines cross the label
+// change. If Apply only wrote the new unit, the pre-#6183 plist would stay on
+// disk AND stay loaded under the old label, and the new label would bootstrap
+// alongside it: two watchers running for one repo, which is strictly worse than
+// the collision being fixed.
+//
+// launchctl is stubbed — no test may mutate the developer's launchd session.
+func TestApply_RetiresLegacyWatcherUnit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	// No test may mutate the developer's launchd session.
+	stubLaunchctlRunner(t)
+
+	// The migration's deregistration is observed through the loader seam, not
+	// through the stubbed runner: darwin's Unload probes `launchctl list`
+	// first and short-circuits when the label is not loaded, which it never is
+	// in a sandbox.
+	fake := &fakeLoader{}
+	prevLoader := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prevLoader })
+
+	// The repo lives outside t.TempDir: install.Apply creates <repo>/.grafel/
+	// logs asynchronously after returning, which races t.TempDir cleanup
+	// (#6188). Owning the directory keeps that flake out of this test.
+	repoRoot, err := os.MkdirTemp("", "grafel-6183-apply-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := filepath.Join(repoRoot, "app")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		for i := 0; i < 3; i++ {
+			if err := os.RemoveAll(repoRoot); err == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	})
+
+	bin := filepath.Join(home, "bin", "grafel")
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+
+	// A unit installed by a pre-#6183 binary.
+	legacyPath, err := watchers.Write(watchers.LegacyOf(u))
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacyLabel := watchers.LegacyOf(u).Label()
+
+	cfg := &registry.GroupConfig{Name: "g", Repos: []registry.Repo{{Slug: "app", Path: repo}}}
+	cfg.Features.Watchers = true
+
+	if _, err := Apply(Options{
+		Group: "g", Config: cfg, BinPath: bin,
+		SkipHooks: true, SkipRulesFiles: true, SkipMCP: true,
+	}); err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("Apply left the pre-#6183 unit on disk (%s): %v", legacyPath, err)
+	}
+	newPath, _ := watchers.UnitPath(u)
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("Apply did not install the new unit: %v", err)
+	}
+
+	// A deleted plist is not a deregistered job: launchd still holds the old
+	// label. Assert the deregistration actually named it.
+	bootedOutLegacy := false
+	for _, l := range fake.unloaded {
+		if l == legacyLabel {
+			bootedOutLegacy = true
+		}
+		if l == u.Label() {
+			t.Fatalf("Apply deregistered the NEW label %s", l)
+		}
+	}
+	if !bootedOutLegacy {
+		t.Fatalf("no deregistration named the legacy label %q; unloaded=%v", legacyLabel, fake.unloaded)
+	}
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -271,6 +271,21 @@ func Apply(opts Options) (*Result, error) {
 		if !opts.SkipWatchers && opts.Config.Features.Watchers {
 			u := watchers.Unit{Group: opts.Group, Repo: repo, BinPath: opts.BinPath}
 			if !opts.DryRun {
+				// Retire any pre-#6183 unit for this repo FIRST (#6183). The
+				// label now carries a path digest, so a repo installed by an
+				// older binary has its unit under a different name — and that
+				// unit is still loaded. Writing the new one without booting the
+				// old one out would leave two watchers running for one repo.
+				// No-op (one stat) once the machine has been migrated.
+				// newWatcherLoader (watchersync.go) is watchers.NewLoader with
+				// a test seam; the migration goes through it so the bootout can
+				// be observed without a real launchd session. The darwin Unload
+				// probes `launchctl list` before booting out, so a stubbed
+				// runner alone cannot show whether the OLD label was named.
+				if _, merr := watchers.MigrateLegacyUnit(u, newWatcherLoader); merr != nil {
+					res.WatcherWarnings = append(res.WatcherWarnings,
+						fmt.Sprintf("could not retire the previous watcher unit for %s: %v", repo, merr))
+				}
 				path, err := watchers.Write(u)
 				if err != nil {
 					return nil, fmt.Errorf("watcher for %s: %w", repo, err)
@@ -489,6 +504,11 @@ func Uninstall(group string, purge bool) error {
 			// that the OS does not attempt to launch a missing binary.
 			_ = loader.Unload(u)
 			_ = watchers.Remove(u)
+			// And any unit installed under the pre-#6183 label (#6183). Once
+			// the group leaves the registry there is nothing left to derive
+			// that name from, so it has to happen here or never.
+			_ = loader.Unload(watchers.LegacyOf(u))
+			_ = watchers.Remove(watchers.LegacyOf(u))
 		}
 	}
 	if err := registry.RemoveGroup(group); err != nil {

--- a/internal/install/launchctl_stub_darwin_test.go
+++ b/internal/install/launchctl_stub_darwin_test.go
@@ -1,0 +1,32 @@
+//go:build darwin
+
+package install
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// stubLaunchctlRunner neutralises the launchctl command runner for the duration
+// of a test.
+//
+// Every test in this package that reaches an activation path must call this, or
+// swap newWatcherLoader, or both. The cost of forgetting is not a flake — it is
+// a permanently loaded launchd job in the developer's own gui/<uid> session
+// pointing at a deleted temp binary, which exits 78 and which launchd then
+// reschedules forever under KeepAlive{SuccessfulExit:false}. Nothing in grafel
+// can ever name it again: ReconcileWatcherUnits, Uninstall and Cleanup all
+// derive labels from the registry, and a temp repo is in no registry.
+//
+// Under #6183's path-digest label that leak is UNBOUNDED. The pre-#6183 label
+// was a constant for a given (group, basename), so repeated runs reused one job;
+// the digest is over os.MkdirTemp's unique path, so every run mints a new label
+// and leaks a new job. 23 were found accumulated on one machine.
+func stubLaunchctlRunner(t *testing.T) {
+	t.Helper()
+	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		return nil, nil
+	})
+	t.Cleanup(restore)
+}

--- a/internal/install/launchctl_stub_other_test.go
+++ b/internal/install/launchctl_stub_other_test.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package install
+
+import "testing"
+
+// stubLaunchctlRunner is a no-op off macOS; there is no launchctl to stub.
+func stubLaunchctlRunner(t *testing.T) { t.Helper() }

--- a/internal/install/uninstall_legacy_6183_test.go
+++ b/internal/install/uninstall_legacy_6183_test.go
@@ -1,0 +1,53 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// TestUninstall_RemovesLegacyWatcherUnit closes the last window the #6183 label
+// change opens.
+//
+// Uninstall is the only code that runs when a group stops being registered, and
+// it is the LAST moment at which the pre-#6183 label can be derived at all —
+// afterwards nothing knows the repo path, so nothing can name the old unit. A
+// legacy plist left here would stay on disk and stay loaded forever, relaunching
+// a watcher for a group grafel no longer has a config for.
+func TestUninstall_RemovesLegacyWatcherUnit(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "app")
+	registerGroup(t, home, "g", []string{repo}, true)
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	if _, err := watchers.UnitPath(u); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	legacyPath := writeUnitFile(t, watchers.LegacyOf(u), watchers.Render(watchers.LegacyOf(u)))
+	currentPath := writeUnitFile(t, u, watchers.Render(u))
+
+	// TODO(#6183-seam): assert WHICH label was deregistered once Uninstall
+	// builds its Loader through the newWatcherLoader seam. It still calls
+	// watchers.NewLoader() directly, so the deregistrations are invisible from
+	// here and a mutant that deletes the legacy Unload survives. The seam
+	// routing lands with fix/grafel-stop-leaves-indexing; the coordinator is
+	// filing the tracking issue. Cleanup's equivalent IS asserted by label in
+	// watchers/migrate_6183_test.go.
+	// Stub the runner so nothing this test does can reach a real launchctl in
+	// the meantime; darwin's Unload only probes `launchctl list` (read-only)
+	// before short-circuiting on a label that is not loaded.
+	stubLaunchctlRunner(t)
+
+	if err := Uninstall("g", false); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	for name, p := range map[string]string{"legacy": legacyPath, "current": currentPath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("Uninstall left the %s unit on disk (%s): %v", name, p, err)
+		}
+	}
+}

--- a/internal/install/watchers/migrate_6183_test.go
+++ b/internal/install/watchers/migrate_6183_test.go
@@ -1,0 +1,260 @@
+package watchers
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// recordingLoader records Unload/Load calls by LABEL instead of touching the
+// real OS scheduler. Nothing in this file ever runs launchctl / systemctl /
+// schtasks.
+type recordingLoader struct {
+	unloaded []string
+	loaded   []string
+	made     int
+}
+
+func (r *recordingLoader) Load(u Unit) error { r.loaded = append(r.loaded, u.Label()); return nil }
+func (r *recordingLoader) Unload(u Unit) error {
+	r.unloaded = append(r.unloaded, u.Label())
+	return nil
+}
+func (r *recordingLoader) Status(u Unit) (WatcherStatus, error) {
+	return WatcherStatus{TaskName: u.Label()}, nil
+}
+
+func (r *recordingLoader) ctor() Loader { r.made++; return r }
+
+// migrateSandbox points every unit-directory derivation at a temp dir.
+func migrateSandbox(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+}
+
+// TestMigrateLegacyUnit_BootsOutThenRemoves is the migration half of #6183.
+//
+// Changing Label orphans every installed unit: the old file stays on disk AND
+// stays loaded under the old identity. If migration only deleted the file, the
+// job would remain registered with launchd with nothing left to name it, and
+// the new label would register alongside it — two watchers per repo, strictly
+// worse than the collision. The deregistration must therefore happen, and it
+// must happen while the file still exists.
+func TestMigrateLegacyUnit_BootsOutThenRemoves(t *testing.T) {
+	migrateSandbox(t)
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+
+	legacyPath, err := LegacyUnitPath(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	if _, err := Write(LegacyOf(u)); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &recordingLoader{}
+	removed, err := MigrateLegacyUnit(u, rec.ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != legacyPath {
+		t.Fatalf("removed = %q, want %q", removed, legacyPath)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy unit file survived migration: %v", err)
+	}
+	if len(rec.unloaded) != 1 || rec.unloaded[0] != LegacyOf(u).Label() {
+		t.Fatalf("migration did not deregister the OLD label; unloaded=%v want [%s]",
+			rec.unloaded, LegacyOf(u).Label())
+	}
+	if rec.unloaded[0] == u.Label() {
+		t.Fatalf("migration deregistered the NEW label")
+	}
+}
+
+// TestMigrateLegacyUnit_IsIdempotentAndLoaderFree pins the two properties that
+// make it safe to call on every install and every reconcile: running it twice
+// changes nothing, and on an already-migrated machine it constructs no Loader
+// at all — which is what preserves #6179's "zero launchctl on an up-to-date
+// machine".
+func TestMigrateLegacyUnit_IsIdempotentAndLoaderFree(t *testing.T) {
+	migrateSandbox(t)
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+	if _, err := UnitPath(u); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	if _, err := Write(LegacyOf(u)); err != nil {
+		t.Fatal(err)
+	}
+
+	rec := &recordingLoader{}
+	if _, err := MigrateLegacyUnit(u, rec.ctor); err != nil {
+		t.Fatal(err)
+	}
+	afterFirst := rec.made
+
+	for i := 2; i <= 3; i++ {
+		removed, err := MigrateLegacyUnit(u, rec.ctor)
+		if err != nil {
+			t.Fatalf("run %d: %v", i, err)
+		}
+		if removed != "" {
+			t.Fatalf("run %d removed %q; migration is not idempotent", i, removed)
+		}
+	}
+	if rec.made != afterFirst {
+		t.Fatalf("Loader constructed %d times, %d after the first run — an already-migrated "+
+			"machine must construct none", rec.made, afterFirst)
+	}
+	if len(rec.unloaded) != 1 {
+		t.Fatalf("Unload called %d times, want 1", len(rec.unloaded))
+	}
+}
+
+// TestMigrateLegacyUnit_NoLegacyFileTouchesNothing covers the fresh install and
+// the already-migrated fleet: no legacy unit, so no loader and no filesystem
+// mutation. The live unit in particular must survive.
+func TestMigrateLegacyUnit_NoLegacyFileTouchesNothing(t *testing.T) {
+	migrateSandbox(t)
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+	current, err := Write(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+
+	rec := &recordingLoader{}
+	removed, err := MigrateLegacyUnit(u, rec.ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != "" {
+		t.Fatalf("removed %q with no legacy unit present", removed)
+	}
+	if rec.made != 0 {
+		t.Fatalf("constructed a Loader with nothing to migrate")
+	}
+	if _, err := os.Stat(current); err != nil {
+		t.Fatalf("migration deleted the LIVE unit: %v", err)
+	}
+}
+
+// TestMigrateLegacyUnit_LeavesOtherReposAlone: the migration names the unit it
+// retires by deriving the old label from the same (group, repo) as the new one.
+// It can therefore never reach a unit belonging to a different repo or group —
+// including groups this binary has no config for.
+func TestMigrateLegacyUnit_LeavesOtherReposAlone(t *testing.T) {
+	migrateSandbox(t)
+	base := t.TempDir()
+	mine := Unit{Group: "g", Repo: filepath.Join(base, "api"), BinPath: "/bin/grafel"}
+	otherRepo := Unit{Group: "g", Repo: filepath.Join(base, "web"), BinPath: "/bin/grafel"}
+	otherGroup := Unit{Group: "unregistered", Repo: filepath.Join(base, "api"), BinPath: "/bin/grafel"}
+
+	if _, err := Write(LegacyOf(mine)); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	otherRepoPath, _ := Write(LegacyOf(otherRepo))
+	otherGroupPath, _ := Write(LegacyOf(otherGroup))
+
+	rec := &recordingLoader{}
+	if _, err := MigrateLegacyUnit(mine, rec.ctor); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{otherRepoPath, otherGroupPath} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("migration removed an unrelated unit %s: %v", p, err)
+		}
+	}
+	if len(rec.unloaded) != 1 {
+		t.Fatalf("unloaded %v; migration must deregister exactly its own old label", rec.unloaded)
+	}
+}
+
+// TestCleanup_RemovesLegacyUnitToo: Cleanup runs when a repo stops being
+// registered, and it is the last moment at which the pre-#6183 label can be
+// derived at all — once the group leaves the registry nothing knows the repo
+// path any more. A legacy plist left behind here would stay loaded forever with
+// no way to name it.
+func TestCleanup_RemovesLegacyUnitToo(t *testing.T) {
+	migrateSandbox(t)
+	stubLaunchctl(t)
+	rec := &recordingLoader{}
+	prev := newLoader
+	newLoader = rec.ctor
+	t.Cleanup(func() { newLoader = prev })
+
+	u := Unit{Group: "demo", Repo: filepath.Join(t.TempDir(), "core"), BinPath: "/bin/grafel"}
+
+	legacyPath, err := Write(LegacyOf(u))
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	currentPath, _ := Write(u)
+
+	Cleanup(u.Group, u.Repo, u.BinPath)
+
+	for _, p := range []string{legacyPath, currentPath} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("Cleanup left %s behind: %v", p, err)
+		}
+	}
+	// Deleting the file does not deregister the job. Both labels must have been
+	// booted out — and after this point neither can be derived again.
+	want := map[string]bool{u.Label(): false, LegacyOf(u).Label(): false}
+	for _, l := range rec.unloaded {
+		want[l] = true
+	}
+	for label, seen := range want {
+		if !seen {
+			t.Fatalf("Cleanup never deregistered %s; unloaded=%v", label, rec.unloaded)
+		}
+	}
+}
+
+// statLoader records, at Unload time, whether the unit file still exists.
+type statLoader struct {
+	recordingLoader
+	path             string
+	fileAtUnloadTime bool
+}
+
+func (s *statLoader) Unload(u Unit) error {
+	if _, err := os.Stat(s.path); err == nil {
+		s.fileAtUnloadTime = true
+	}
+	return s.recordingLoader.Unload(u)
+}
+
+func (s *statLoader) ctor() Loader { s.made++; return s }
+
+// TestMigrateLegacyUnit_DeregistersBeforeDeleting pins the ordering.
+//
+// Deregistration has to happen while the unit file is still there. systemctl
+// --user disable resolves the unit by reading the file, so disabling after
+// deletion leaves the enablement state dangling and the job still wired up; on
+// launchd the plist is what a path-form bootout names. Deleting first is the
+// natural-looking order and it is wrong on both.
+func TestMigrateLegacyUnit_DeregistersBeforeDeleting(t *testing.T) {
+	migrateSandbox(t)
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+	legacyPath, err := Write(LegacyOf(u))
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+
+	sl := &statLoader{path: legacyPath}
+	if _, err := MigrateLegacyUnit(u, sl.ctor); err != nil {
+		t.Fatal(err)
+	}
+	if len(sl.unloaded) != 1 {
+		t.Fatalf("Unload called %d times, want 1", len(sl.unloaded))
+	}
+	if !sl.fileAtUnloadTime {
+		t.Fatalf("the legacy unit file was already deleted when Unload ran; " +
+			"deregistration must happen first")
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy unit file survived: %v", err)
+	}
+}

--- a/internal/install/watchers/slug_6183_test.go
+++ b/internal/install/watchers/slug_6183_test.go
@@ -1,0 +1,101 @@
+package watchers
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestLabel_DistinctPathsSameBasenameDoNotCollide is the core of #6183.
+//
+// slugify used to reduce a repo path to filepath.Base, so /x/my-repo and
+// /y/my_repo (both basename-slugged to "my-repo") produced ONE label — hence
+// one plist filename and one launchd job identity — for two different repos.
+func TestLabel_DistinctPathsSameBasenameDoNotCollide(t *testing.T) {
+	a := Unit{Group: "g", Repo: filepath.FromSlash("/x/my-repo"), BinPath: "/bin/grafel"}
+	b := Unit{Group: "g", Repo: filepath.FromSlash("/y/my_repo"), BinPath: "/bin/grafel"}
+
+	if a.Label() == b.Label() {
+		t.Fatalf("distinct repo paths share a label: %s", a.Label())
+	}
+
+	pa, err := UnitPath(a)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	pb, _ := UnitPath(b)
+	if pa == pb {
+		t.Fatalf("distinct repo paths share a unit path: %s", pa)
+	}
+}
+
+// TestLabel_StableAndReadable pins the two properties the disambiguation must
+// not trade away: the basename stays visible in the label (a bare hash for
+// every repo would be a usability regression), and the label is a pure
+// function of (group, path) so it does not drift between runs.
+func TestLabel_StableAndReadable(t *testing.T) {
+	u := Unit{Group: "g", Repo: filepath.FromSlash("/x/my-repo"), BinPath: "/bin/grafel"}
+	got := u.Label()
+	if got != u.Label() {
+		t.Fatalf("Label() is not deterministic")
+	}
+	if !contains(got, "com.grafel.watcher.g.my-repo") {
+		t.Fatalf("label lost the human-readable basename: %s", got)
+	}
+	// Adding an unrelated repo to the fleet must not change this one's label:
+	// Label() depends on nothing but the unit's own fields.
+	other := Unit{Group: "g", Repo: filepath.FromSlash("/y/my-repo"), BinPath: "/bin/grafel"}
+	if other.Label() == got {
+		t.Fatalf("collision persists: %s", got)
+	}
+	if u.Label() != got {
+		t.Fatalf("label changed after another unit was derived")
+	}
+}
+
+// TestLabel_CharsetIsLabelSafe keeps the disambiguator inside the character
+// set launchd/systemd/schtasks tolerate in a job identity and a filename.
+func TestLabel_CharsetIsLabelSafe(t *testing.T) {
+	u := Unit{Group: "g", Repo: filepath.FromSlash("/x/My Repo & Co"), BinPath: "/bin/grafel"}
+	for _, c := range u.Label() {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-', c == '.':
+		default:
+			t.Fatalf("label contains unsafe rune %q: %s", c, u.Label())
+		}
+	}
+}
+
+// TestLegacyOf_ReproducesPreFixLabel guarantees the migration can name the unit
+// it has to clean up. Without an exact legacy derivation the only alternative
+// is globbing com.grafel.watcher.* and guessing, which risks booting out units
+// that belong to somebody else's repo.
+func TestLegacyOf_ReproducesPreFixLabel(t *testing.T) {
+	u := Unit{Group: "g", Repo: filepath.FromSlash("/x/my-repo"), BinPath: "/bin/grafel"}
+	if got, want := LegacyOf(u).Label(), "com.grafel.watcher.g.my-repo"; got != want {
+		t.Fatalf("legacy label = %q, want %q", got, want)
+	}
+	if LegacyOf(u).Label() == u.Label() {
+		t.Fatalf("legacy label equals current label; migration would be a no-op")
+	}
+	// LegacyOf must not mutate the receiver or lose fields.
+	l := LegacyOf(u)
+	if l.Repo != u.Repo || l.Group != u.Group || l.BinPath != u.BinPath {
+		t.Fatalf("LegacyOf dropped fields: %+v", l)
+	}
+	if u.Label() == l.Label() {
+		t.Fatalf("receiver was mutated")
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s[:len(sub)] == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/install/watchers/stub_6183_darwin_test.go
+++ b/internal/install/watchers/stub_6183_darwin_test.go
@@ -1,0 +1,13 @@
+package watchers
+
+import "testing"
+
+// stubLaunchctl replaces the launchctl runner for the duration of a test. No
+// test in this package may mutate the developer's real launchd session.
+func stubLaunchctl(t *testing.T) {
+	t.Helper()
+	restore := SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		return nil, nil
+	})
+	t.Cleanup(restore)
+}

--- a/internal/install/watchers/stub_6183_other_test.go
+++ b/internal/install/watchers/stub_6183_other_test.go
@@ -1,0 +1,8 @@
+//go:build !darwin
+
+package watchers
+
+import "testing"
+
+// stubLaunchctl is a no-op off macOS; there is no launchctl to stub.
+func stubLaunchctl(t *testing.T) { t.Helper() }

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -7,6 +7,8 @@
 package watchers
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/xml"
 	"fmt"
 	"os"
@@ -88,12 +90,115 @@ type Unit struct {
 	Group   string
 	Repo    string
 	BinPath string // absolute path to the grafel binary
+
+	// legacy selects the PRE-#6183 label derivation (basename only, no path
+	// digest). It exists for exactly one purpose: naming the already-installed
+	// unit that a migration has to boot out and delete. Set it only via
+	// LegacyOf — the zero value is always the current derivation, so nothing
+	// can accidentally install a legacy-labelled unit.
+	legacy bool
 }
 
 // Label returns the platform-agnostic label for a unit.
+//
+// The label is also the unit FILENAME and the OS scheduler's job identity, so
+// two units that share a label share a file and a job. Before #6183 the slug
+// was filepath.Base(repo) alone, which meant two repos in one group with equal
+// basenames — `api`, `web`, `docs`, `infra` across different orgs, near-certain
+// on a large fleet — produced one label for two repos. The consequences were
+// that only one of the pair was ever actually watched, and that
+// ReconcileWatcherUnits never converged: each pass rewrote the shared file to
+// repo A's body, found it stale for repo B, rewrote it again, and re-registered
+// both, forever.
+//
+// Label depends on nothing but this unit's own fields. That matters: a
+// derivation that disambiguated only "where needed" would have to consult the
+// rest of the fleet, and then adding an unrelated repo would silently rename an
+// existing unit — the orphaning problem below, repeated on every fleet edit
+// rather than once.
 func (u Unit) Label() string {
 	slug := slugify(u.Repo)
+	if u.legacy {
+		slug = legacySlugify(u.Repo)
+	}
 	return fmt.Sprintf("com.grafel.watcher.%s.%s", u.Group, slug)
+}
+
+// LegacyOf returns a copy of u whose Label() is the pre-#6183 label.
+//
+// Migration needs to name the old unit EXACTLY. The alternative — globbing
+// com.grafel.watcher.* in the unit directory and guessing which entries are
+// stale — cannot distinguish a genuinely orphaned unit from one belonging to a
+// group this binary has no config for, and would boot out the latter. Deriving
+// the old label from the same (group, repo) the new one comes from names a unit
+// that belongs to this repo.
+//
+// Not STRICTLY so, and the caveat is worth writing down: the legacy and current
+// label spaces are not disjoint. A repo literally named `api-3f9c1e07` has the
+// legacy label `…watcher.g.api-3f9c1e07`, which is also the current label of a
+// repo named `api` whose path digests to 3f9c1e07. The MigrateLegacyUnit guard
+// below only catches the case where those two are the SAME unit. Cross-repo it
+// is ~2^-32 per pair within a group and requires an adversarially named repo;
+// the alternative (a separator no path component may contain) does not exist,
+// since the slug maps every non-alphanumeric byte to '-'.
+func LegacyOf(u Unit) Unit {
+	u.legacy = true
+	return u
+}
+
+// LegacyUnitPath returns the path a pre-#6183 unit for u occupies on this OS.
+func LegacyUnitPath(u Unit) (string, error) {
+	return UnitPath(LegacyOf(u))
+}
+
+// MigrateLegacyUnit removes the pre-#6183 unit for u, if one is installed.
+//
+// Changing the label orphans every unit already on disk: the old file stays
+// there and stays LOADED under the old identity, while the new label registers
+// alongside it. Without this the fix would leave a user with two watchers per
+// repo — strictly worse than the collision it repairs. So the old job is booted
+// out of the scheduler first (while the file it was bootstrapped from still
+// exists — on launchd the file is what a bootout names) and only then deleted.
+//
+// newLoader is called ONLY when there is actually a legacy unit to remove. That
+// preserves ReconcileWatcherUnits' property that an up-to-date machine
+// constructs no Loader and issues no launchctl at all (#6179).
+//
+// Idempotent: with no legacy file present it stats one path and returns ("",
+// nil) — no loader, no writes. It returns the removed path when it did work.
+func MigrateLegacyUnit(u Unit, newLoader func() Loader) (string, error) {
+	legacy := LegacyOf(u)
+	legacyPath, err := UnitPath(legacy)
+	if err != nil {
+		return "", err
+	}
+	currentPath, err := UnitPath(u)
+	if err != nil {
+		return "", err
+	}
+	// Defensive: if the derivations ever coincide, removing the "legacy" file
+	// would delete the live unit.
+	if legacyPath == currentPath {
+		return "", nil
+	}
+	if _, err := os.Stat(legacyPath); err != nil {
+		if os.IsNotExist(err) {
+			return "", nil
+		}
+		return "", err
+	}
+	if newLoader != nil {
+		if l := newLoader(); l != nil {
+			// Tolerate errors: "not loaded" already satisfies the desired
+			// absent state, and a scheduler that refuses must not stop the
+			// stale file from being deleted.
+			_ = l.Unload(legacy)
+		}
+	}
+	if err := os.Remove(legacyPath); err != nil && !os.IsNotExist(err) {
+		return "", err
+	}
+	return legacyPath, nil
 }
 
 // LaunchdPlist returns the macOS launchd .plist body for a watcher.
@@ -300,13 +405,27 @@ func Write(u Unit) (string, error) {
 // launchd jobs / plists from lingering and fighting a later recreate (#5338).
 func Cleanup(group, repoPath, binPath string) {
 	u := Unit{Group: group, Repo: repoPath, BinPath: binPath}
-	loader := NewLoader()
+	loader := newLoader()
 	// Deregister from the OS scheduler before deleting the file so the OS does
 	// not try to relaunch a missing binary. Errors are tolerated: "not loaded"
 	// already satisfies the desired absent state.
 	_ = loader.Unload(u)
 	_ = Remove(u)
+	// Also clear any pre-#6183 unit for this repo. Cleanup is the only place
+	// that runs when a repo stops being registered, so if it ignored the legacy
+	// label an old-scheme plist would survive the group's removal, stay loaded,
+	// and keep relaunching a watcher for a repo grafel no longer knows about —
+	// with nothing left in the registry to derive its name from later.
+	_ = loader.Unload(LegacyOf(u))
+	_ = Remove(LegacyOf(u))
 }
+
+// newLoader is the Loader constructor Cleanup uses. It is a package var so
+// tests can observe deregistrations without a real launchd/systemd session:
+// darwin's Unload probes `launchctl list` before booting out and short-circuits
+// when the label is not loaded, which it never is under a sandboxed HOME, so a
+// stubbed command runner cannot show which label was named.
+var newLoader = NewLoader
 
 // Remove deletes the unit file if it exists.
 func Remove(u Unit) error {
@@ -321,8 +440,55 @@ func Remove(u Unit) error {
 	return err
 }
 
-// slugify produces a label-safe slug from a path.
+// pathDigestLen is how many hex characters of the path digest go into a slug.
+//
+// 8 hex chars is 32 bits. Against the birthday bound that is a ~1-in-2.7-million
+// chance of one accidental collision across a 140-repo group, and it keeps the
+// label short enough that the basename in front of it is still what the eye
+// reads: com.grafel.watcher.g.api-3f9c1e07.
+const pathDigestLen = 8
+
+// slugify produces a label-safe, path-unique slug.
+//
+// basename + short digest of the full path, not the digest alone: the label is
+// the plist filename a user greps for and the identity `launchctl list` prints,
+// and a fleet of bare hashes would be a real usability regression. The digest
+// is over filepath.Clean of the whole path, so /x/api and /y/api differ.
 func slugify(s string) string {
+	return legacySlugify(s) + "-" + pathDigest(s)
+}
+
+// pathDigest returns the first pathDigestLen hex chars of SHA-256 over the
+// cleaned path.
+//
+// It is a function of the STRING the registry holds, not of the directory that
+// string names. filepath.Clean normalises separators and . / .. — `/x/api/`,
+// `/x/./api`, `/x/y/../api` and `/x/api//` all collapse to one label — but it
+// does not touch the filesystem, so two spellings that resolve to the same
+// directory still produce two labels:
+//
+//   - Case variants on a case-insensitive volume: on APFS `/X/Api` and `/x/api`
+//     are one directory and now two labels. The pre-#6183 slug lowercased the
+//     basename and collided them into one, so this is a behaviour change, in the
+//     direction of more units rather than fewer.
+//   - Symlinked aliases: no EvalSymlinks, deliberately — resolving would make
+//     the label depend on filesystem state at derivation time, so a moved or
+//     broken symlink would silently rename an installed unit, which is the
+//     orphaning problem this whole change exists to avoid paying twice.
+//
+// In both cases a repo registered twice under different spellings gets two
+// watcher units rather than one. That is wasteful, not incorrect, and it is
+// what registering the same repo twice already meant elsewhere in grafel.
+func pathDigest(s string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(s)))
+	return hex.EncodeToString(sum[:])[:pathDigestLen]
+}
+
+// legacySlugify is the pre-#6183 slug: filepath.Base, lowercased, with every
+// other byte mapped to '-'. It is retained ONLY so MigrateLegacyUnit can name
+// the units this scheme installed. Do not use it for new units — it is the
+// collision described on Label.
+func legacySlugify(s string) string {
 	s = filepath.Base(s)
 	out := make([]byte, 0, len(s))
 	for i := 0; i < len(s); i++ {

--- a/internal/install/watchers/watchers_test.go
+++ b/internal/install/watchers/watchers_test.go
@@ -7,9 +7,15 @@ import (
 
 var sample = Unit{Group: "demo", Repo: "/tmp/test/core", BinPath: "/usr/local/bin/grafel"}
 
+// TestLabelStable pins the exact label bytes. The digest suffix landed with
+// #6183 (see Label); this test exists so any further change to the derivation
+// is a deliberate edit here, because changing it renames every installed unit.
 func TestLabelStable(t *testing.T) {
-	if got := sample.Label(); got != "com.grafel.watcher.demo.core" {
+	if got := sample.Label(); got != "com.grafel.watcher.demo.core-96d54b5d" {
 		t.Fatalf("label: %q", got)
+	}
+	if got := LegacyOf(sample).Label(); got != "com.grafel.watcher.demo.core" {
+		t.Fatalf("legacy label: %q", got)
 	}
 }
 
@@ -17,7 +23,7 @@ func TestLaunchdPlist(t *testing.T) {
 	body := LaunchdPlist(sample)
 	for _, want := range []string{
 		`<key>Label</key>`,
-		`<string>com.grafel.watcher.demo.core</string>`,
+		`<string>com.grafel.watcher.demo.core-96d54b5d</string>`,
 		`<string>/usr/local/bin/grafel</string>`,
 		`<string>watch</string>`,
 		`<string>/tmp/test/core</string>`,

--- a/internal/install/watchersync.go
+++ b/internal/install/watchersync.go
@@ -42,6 +42,33 @@ package install
 //     new registrations for no benefit — and it would silently resurrect units
 //     a user deliberately booted out. Installing missing units remains Apply's
 //     job, where the user asked for it.
+//
+//     One narrow exception was added with #6183: a repo whose colliding sibling
+//     still has a unit. Those two repos shared ONE file under the old label, so
+//     "this repo has no unit" is a fact the collision itself manufactured, not
+//     a choice the user made. See planWatcherUnits.
+//
+// ── What this does NOT reap (#6183 F3) ───────────────────────────────────────
+//
+// Orphaned units are handled only where the label is derivable from the
+// registry — that is, for repos still listed in a group config. Two cases are
+// deliberately left alone, and neither is fixed by this file:
+//
+//   - A repo REMOVED from a group config. Its units (both labels) stay on disk
+//     and stay loaded. Reaping them would mean enumerating the unit directory
+//     and deleting whatever does not correspond to a registered repo — which
+//     cannot distinguish "the user removed this repo" from "this group's config
+//     is temporarily unreadable, or belongs to a checkout this binary cannot
+//     see", and would delete a live watcher in the second case. The label
+//     contains the group name verbatim, and group names may contain dots, so
+//     even parsing a label back into (group, repo) is not sound.
+//
+//   - Units for groups that are not in this binary's registry at all.
+//
+// `grafel uninstall <group>` reaps a group's units while it can still name
+// them. Removing a single repo from a config does not, today, reap that repo's
+// units. That is a pre-existing gap that #6183 narrows (by handling the
+// watchers-disabled group) but does not close.
 
 import (
 	"fmt"
@@ -71,8 +98,14 @@ type ReconcileWatcherResult struct {
 	// Current counts units whose on-disk bytes already matched the template.
 	// These are NOT rewritten and NOT re-registered.
 	Current int
-	// Absent counts repos with no unit file on disk. Left alone by design.
+	// Absent counts repos with no unit file on disk — under either the current
+	// or the pre-#6183 label. Left alone by design.
 	Absent int
+	// Migrated lists the pre-#6183 unit paths that were booted out of the OS
+	// scheduler and deleted because the repo's label changed (#6183). Each
+	// entry is an OLD path that no longer exists; the replacement appears in
+	// Rewritten.
+	Migrated []string
 	// Rewritten lists the unit paths whose content was stale and replaced.
 	Rewritten []string
 	// Reloaded lists the unit paths successfully re-registered with the OS.
@@ -80,6 +113,65 @@ type ReconcileWatcherResult struct {
 	// Warnings collects non-fatal per-unit failures. Reconciliation never
 	// aborts on one bad unit: the remaining 139 still need repairing.
 	Warnings []string
+}
+
+// watcherPlan is one repo's probed state: both label derivations, and whether a
+// unit exists under either. Purely observational — building a plan performs no
+// writes and constructs no Loader, which is what keeps an up-to-date machine a
+// pure read (#6179).
+type watcherPlan struct {
+	unit         watchers.Unit
+	path         string // unit path under the current label
+	legacyPath   string // unit path under the pre-#6183 label
+	exists       bool   // a unit file exists at path
+	legacyExists bool   // a unit file exists at legacyPath
+	body         []byte // contents of path, when it exists
+	statErr      error  // the ReadFile error (may be os.ErrNotExist)
+	readErr      error  // a REAL read failure, worth warning about
+}
+
+// planWatcherUnits probes every repo in a group before anything is mutated.
+//
+// Deriving all the paths up front is what lets the collision recovery survive a
+// crash: colliding repos share one legacy path, and once the first member
+// retires it the shared file is gone, so the shared-ness has to be read from the
+// registry rather than from the filesystem or from a memo of what this process
+// already did.
+//
+// Repos whose unit path cannot be derived at all are warned about and dropped.
+func planWatcherUnits(group string, cfg *registry.GroupConfig, binPath string, res *ReconcileWatcherResult) []watcherPlan {
+	plans := make([]watcherPlan, 0, len(cfg.Repos))
+	for _, r := range cfg.Repos {
+		u := watchers.Unit{Group: group, Repo: r.Path, BinPath: binPath}
+		path, err := watchers.UnitPath(u)
+		if err != nil {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", r.Path, err))
+			continue
+		}
+		pl := watcherPlan{unit: u, path: path}
+
+		legacyPath, lerr := watchers.LegacyUnitPath(u)
+		if lerr == nil && legacyPath != path {
+			pl.legacyPath = legacyPath
+			if _, serr := os.Stat(legacyPath); serr == nil {
+				pl.legacyExists = true
+			}
+		}
+
+		body, rerr := os.ReadFile(path)
+		pl.statErr = rerr
+		switch {
+		case rerr == nil:
+			pl.exists = true
+			pl.body = body
+		case os.IsNotExist(rerr):
+			// Absent is a normal state, not a failure.
+		default:
+			pl.readErr = rerr
+		}
+		plans = append(plans, pl)
+	}
+	return plans
 }
 
 // ReconcileWatcherUnits rewrites and re-registers every already-installed
@@ -105,6 +197,12 @@ func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResul
 
 	res := &ReconcileWatcherResult{}
 	var loader watchers.Loader // constructed lazily: an up-to-date machine needs none
+	lazyLoader := func() watchers.Loader {
+		if loader == nil {
+			loader = newWatcherLoader()
+		}
+		return loader
+	}
 
 	for _, ref := range refs {
 		cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
@@ -112,28 +210,101 @@ func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResul
 			res.Warnings = append(res.Warnings, fmt.Sprintf("group %s: %v", ref.Name, err))
 			continue
 		}
-		if !cfg.Features.Watchers {
-			continue
-		}
-		for _, r := range cfg.Repos {
-			u := watchers.Unit{Group: ref.Name, Repo: r.Path, BinPath: opts.BinPath}
-			path, err := watchers.UnitPath(u)
-			if err != nil {
-				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", r.Path, err))
+
+		// ── Phase 1: probe, decide nothing ───────────────────────────────────
+		//
+		// Every path derivation and every stat happens before the first
+		// mutation, and that ordering is load-bearing (#6183). Repos that
+		// collided under the pre-#6183 label SHARED one unit file, so the
+		// moment the first of them retires it the rest become
+		// indistinguishable from repos that never had a unit — and reconcile
+		// leaves those alone. Probing first means every member of a colliding
+		// set has already recorded legacyExists=true from the one file, so each
+		// gets its own unit no matter which order they are processed in. A
+		// single fused loop that re-stats as it goes silently watches only the
+		// first member, which is #6183's original symptom.
+		//
+		// Nothing here is remembered ACROSS calls, deliberately. A pass killed
+		// partway through a colliding set leaves the survivor with no unit
+		// under either label, and the next reconcile reports it Absent —
+		// printReconcileSummary names it and points at `grafel install`. That
+		// is the whole recovery, and it has to be, because "interrupted
+		// mid-migration" and "the user booted this watcher out on purpose" are
+		// byte-for-byte identical on disk: a sibling with a current unit, this
+		// repo with none, no legacy unit anywhere. An earlier revision tried to
+		// re-create the survivor automatically by treating a sibling's
+		// CURRENT-label unit as evidence of a just-retired shared unit. That
+		// evidence never expires, so every colliding repo whose unit a user had
+		// deliberately deleted was re-created and re-bootstrapped on every
+		// reconcile, forever — the #6183 non-convergence signature, restored,
+		// and gated on nothing more meaningful than two repos sharing a
+		// directory name. Reconcile does not guess at intent.
+		plans := planWatcherUnits(ref.Name, cfg, opts.BinPath, res)
+
+		// ── Phase 2: act ─────────────────────────────────────────────────────
+		for _, pl := range plans {
+			u := pl.unit
+
+			// A group whose watchers are switched off used to be skipped
+			// wholesale, before any repo was looked at. That left a pre-#6183
+			// unit on disk AND loaded for a repo that is still registered and
+			// whose legacy label is therefore still perfectly derivable — and
+			// #6183 turned that from harmless into harmful: re-enabling
+			// watchers would install the NEW label alongside the old one
+			// instead of overwriting it, giving the repo two watchers. Retire
+			// it. Install nothing: watchers are off, and that is the whole
+			// meaning of the flag.
+			if !cfg.Features.Watchers {
+				if pl.legacyExists {
+					if removed, merr := watchers.MigrateLegacyUnit(u, lazyLoader); merr != nil {
+						res.Warnings = append(res.Warnings,
+							fmt.Sprintf("retire legacy unit %s: %v", pl.legacyPath, merr))
+					} else if removed != "" {
+						res.Migrated = append(res.Migrated, removed)
+					}
+				}
 				continue
 			}
-			existing, err := os.ReadFile(path)
-			if os.IsNotExist(err) {
-				// No unit installed for this repo — not stale, not storming.
+
+			if !pl.exists && !pl.legacyExists {
+				// No unit under either label, and no colliding sibling that
+				// proves one used to cover this repo — not stale, not storming,
+				// and not something to create: installing missing units is
+				// Apply's job, where the user asked for it.
 				res.Absent++
 				continue
 			}
 			res.Examined++
-			if err != nil {
-				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", path, err))
+			if pl.readErr != nil {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("%s: %v", pl.path, pl.readErr))
 				continue
 			}
-			if string(existing) == watchers.Render(u) {
+
+			path := pl.path
+			legacyPath := pl.legacyPath
+			existing := pl.body
+			err := pl.statErr
+
+			// Retire the old-label unit before anything registers the new one,
+			// so the repo is never bootstrapped twice. This is what makes the
+			// label change a MOVE rather than a duplication.
+			if pl.legacyExists {
+				removed, merr := watchers.MigrateLegacyUnit(u, lazyLoader)
+				if merr != nil {
+					res.Warnings = append(res.Warnings,
+						fmt.Sprintf("retire legacy unit %s: %v", legacyPath, merr))
+					continue
+				}
+				if removed != "" {
+					res.Migrated = append(res.Migrated, removed)
+				}
+			}
+
+			// Checked AFTER the migration on purpose: if a previous run already
+			// wrote the new unit and something re-created the old file, the new
+			// one still needs no rewrite and no re-registration — only the
+			// duplicate had to go. Running this function twice is then a no-op.
+			if err == nil && pl.exists && string(existing) == watchers.Render(u) {
 				res.Current++
 				continue
 			}
@@ -151,15 +322,12 @@ func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResul
 			// first tick. Only re-registered units are reset — clearing every
 			// repo's history on every upgrade would quietly disarm the
 			// detector fleet-wide.
-			_ = watchers.ResetWatchStarts(r.Path)
+			_ = watchers.ResetWatchStarts(u.Repo)
 
 			// Only now does the OS need telling. A rewritten plist has no
 			// effect until the job is re-bootstrapped — launchd holds the
 			// settings it read at load time.
-			if loader == nil {
-				loader = newWatcherLoader()
-			}
-			if err := loader.Load(u); err != nil && !watchers.IsNonFatal(err) {
+			if err := lazyLoader().Load(u); err != nil && !watchers.IsNonFatal(err) {
 				res.Warnings = append(res.Warnings,
 					fmt.Sprintf("re-register %s: %v (the file is updated; it takes effect at next login)", path, err))
 				continue

--- a/internal/install/watchersync_6179_test.go
+++ b/internal/install/watchersync_6179_test.go
@@ -14,7 +14,13 @@ import (
 // fakeLoader records Load calls instead of shelling out to launchctl.
 type fakeLoader struct {
 	loaded []string
-	fail   map[string]error
+	// unloaded records deregistrations by LABEL — #6183's migration is only
+	// correct if it boots out the OLD label, which the repo path cannot show.
+	unloaded []string
+	// statused counts Status queries — Apply asks for one on the SAME loader it
+	// activated with, so a second construction would be another escape hatch.
+	statused int
+	fail     map[string]error
 }
 
 func (f *fakeLoader) Load(u watchers.Unit) error {
@@ -24,8 +30,12 @@ func (f *fakeLoader) Load(u watchers.Unit) error {
 	f.loaded = append(f.loaded, u.Repo)
 	return nil
 }
-func (f *fakeLoader) Unload(watchers.Unit) error { return nil }
+func (f *fakeLoader) Unload(u watchers.Unit) error {
+	f.unloaded = append(f.unloaded, u.Label())
+	return nil
+}
 func (f *fakeLoader) Status(u watchers.Unit) (watchers.WatcherStatus, error) {
+	f.statused++
 	return watchers.WatcherStatus{TaskName: u.Label()}, nil
 }
 

--- a/internal/install/watchersync_6183_test.go
+++ b/internal/install/watchersync_6183_test.go
@@ -1,0 +1,307 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// TestReconcileWatcherUnits_ConvergesWithDuplicateBasenames is the #6183
+// repro.
+//
+// Two repos in one group whose basenames slug identically used to share a
+// single plist path. Reconcile then rewrote that one file to repo A's body,
+// found it stale for repo B, rewrote it to B's body, and re-registered both —
+// every run, forever. The measured signature in the issue is run 2 onwards
+// reporting `current=0 rewritten=2 reloaded=2`.
+//
+// The property asserted here is convergence: after one pass that settles the
+// fleet, a second pass must do nothing at all — no rewrite, no launchctl, and
+// (see the loader-construction test below) no Loader constructed.
+func TestReconcileWatcherUnits_ConvergesWithDuplicateBasenames(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	// Same basename after slugging: "my-repo" and "my_repo" both slug to
+	// "my-repo" under the pre-#6183 derivation.
+	a := filepath.Join(home, "x", "my-repo")
+	b := filepath.Join(home, "y", "my_repo")
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	ua := watchers.Unit{Group: "g", Repo: a, BinPath: bin}
+	ub := watchers.Unit{Group: "g", Repo: b, BinPath: bin}
+
+	// Pre-existing (stale) units, as an already-installed machine has.
+	writeUnitFile(t, watchers.LegacyOf(ua), "OLD BODY A\n")
+	writeUnitFile(t, watchers.LegacyOf(ub), "OLD BODY B\n")
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	// Run 1: the repair pass. It is allowed to do work.
+	res1, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	loadsAfter1 := len(fake.loaded)
+	t.Logf("run 1: current=%d rewritten=%d reloaded=%d migrated=%d (cumulative Loads=%d)",
+		res1.Current, len(res1.Rewritten), len(res1.Reloaded), len(res1.Migrated), loadsAfter1)
+
+	// After run 1 BOTH repos must be watched under their own distinct unit.
+	pa, err := watchers.UnitPath(ua)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	pb, _ := watchers.UnitPath(ub)
+	if pa == pb {
+		t.Fatalf("both repos still share one unit path: %s", pa)
+	}
+	for _, p := range []string{pa, pb} {
+		if _, err := os.Stat(p); err != nil {
+			t.Fatalf("expected a unit at %s after reconcile: %v", p, err)
+		}
+	}
+	if got, _ := os.ReadFile(pa); string(got) != watchers.Render(ua) {
+		t.Fatalf("unit A does not carry repo A's body")
+	}
+	if got, _ := os.ReadFile(pb); string(got) != watchers.Render(ub) {
+		t.Fatalf("unit B does not carry repo B's body")
+	}
+
+	// Runs 2 and 3: the machine is current. Reconcile must do NOTHING.
+	for run := 2; run <= 3; run++ {
+		res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("run %d: current=%d rewritten=%d reloaded=%d migrated=%d (cumulative Loads=%d)",
+			run, res.Current, len(res.Rewritten), len(res.Reloaded), len(res.Migrated), len(fake.loaded))
+		if len(res.Rewritten) != 0 {
+			t.Fatalf("run %d rewrote %d units; reconcile never converges", run, len(res.Rewritten))
+		}
+		if len(res.Reloaded) != 0 {
+			t.Fatalf("run %d re-registered %d units on an up-to-date machine", run, len(res.Reloaded))
+		}
+		if len(res.Migrated) != 0 {
+			t.Fatalf("run %d migrated %d units; migration is not idempotent", run, len(res.Migrated))
+		}
+		if res.Current != 2 {
+			t.Fatalf("run %d: current=%d, want 2 (both repos have their own current unit)", run, res.Current)
+		}
+		if len(fake.loaded) != loadsAfter1 {
+			t.Fatalf("run %d called launchctl (cumulative Loads=%d, after run 1 it was %d)",
+				run, len(fake.loaded), loadsAfter1)
+		}
+	}
+}
+
+// TestReconcileWatcherUnits_MigratesLegacyLabelAndDeregistersIt is the
+// migration half of #6183 seen from reconcile: the pre-fix unit is booted out
+// under its OLD label and deleted, and the repo ends up with exactly one unit.
+func TestReconcileWatcherUnits_MigratesLegacyLabelAndDeregistersIt(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "api")
+	registerGroup(t, home, "g", []string{repo}, true)
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	legacyPath := writeUnitFile(t, watchers.LegacyOf(u), watchers.Render(watchers.LegacyOf(u)))
+	newPath, err := watchers.UnitPath(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(res.Migrated) != 1 || res.Migrated[0] != legacyPath {
+		t.Fatalf("Migrated = %v, want [%s]", res.Migrated, legacyPath)
+	}
+	if res.Absent != 0 {
+		t.Fatalf("a repo whose unit exists under the legacy label was reported Absent")
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy unit file survived: %v", err)
+	}
+	if _, err := os.Stat(newPath); err != nil {
+		t.Fatalf("repo lost its watcher: %v", err)
+	}
+	// The OLD label must have been deregistered. Deleting the plist without a
+	// bootout leaves the job loaded in launchd under a name nothing can derive
+	// any more, and the new label bootstraps alongside it: two watchers.
+	legacyLabel := watchers.LegacyOf(u).Label()
+	found := false
+	for _, l := range fake.unloaded {
+		if l == legacyLabel {
+			found = true
+		}
+		if l == u.Label() {
+			t.Fatalf("deregistered the NEW label %s", l)
+		}
+	}
+	if !found {
+		t.Fatalf("legacy label %s was never deregistered; unloaded=%v", legacyLabel, fake.unloaded)
+	}
+	if len(res.Reloaded) != 1 {
+		t.Fatalf("Reloaded = %v, want the new unit registered exactly once", res.Reloaded)
+	}
+}
+
+// TestReconcileWatcherUnits_DoesNotTouchUnregisteredUnits pins the blast
+// radius. Migration derives the old label from a REGISTERED (group, repo), so
+// it can only ever name a unit belonging to that repo. Units for groups or
+// repos that are not in the registry — a group installed by another checkout, a
+// repo the user removed by hand — are left exactly as they are, and non-grafel
+// LaunchAgents are never even looked at.
+func TestReconcileWatcherUnits_DoesNotTouchUnregisteredUnits(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	registered := filepath.Join(home, "repos", "api")
+	registerGroup(t, home, "g", []string{registered}, true)
+
+	u := watchers.Unit{Group: "g", Repo: registered, BinPath: bin}
+	if _, err := watchers.UnitPath(u); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	writeUnitFile(t, watchers.LegacyOf(u), "OLD BODY\n")
+
+	// Units nothing in the registry points at.
+	strayRepo := watchers.Unit{Group: "g", Repo: filepath.Join(home, "repos", "gone"), BinPath: bin}
+	strayGroup := watchers.Unit{Group: "othergroup", Repo: registered, BinPath: bin}
+	strayLegacyRepo := writeUnitFile(t, watchers.LegacyOf(strayRepo), "STRAY REPO\n")
+	strayCurrentGroup := writeUnitFile(t, strayGroup, "STRAY GROUP\n")
+
+	// And something that is not ours at all.
+	unitDir, err := watchers.UnitDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	foreign := filepath.Join(unitDir, "com.example.somebodyelse.plist")
+	if err := os.WriteFile(foreign, []byte("FOREIGN\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	if _, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin}); err != nil {
+		t.Fatal(err)
+	}
+
+	for name, p := range map[string]string{
+		"stray repo":  strayLegacyRepo,
+		"stray group": strayCurrentGroup,
+		"foreign":     foreign,
+	} {
+		b, err := os.ReadFile(p)
+		if err != nil {
+			t.Fatalf("%s unit was removed: %v", name, err)
+		}
+		if len(b) == 0 {
+			t.Fatalf("%s unit was rewritten", name)
+		}
+	}
+	for _, l := range fake.unloaded {
+		if l != watchers.LegacyOf(u).Label() {
+			t.Fatalf("deregistered an unrelated unit: %s", l)
+		}
+	}
+}
+
+// TestReconcileWatcherUnits_LegacyProbeConstructsNoLoader guards the property
+// #6179 exists to protect. Reconcile now stats a second path per repo to find
+// pre-#6183 units; that probe must stay a pure read. On a migrated, up-to-date
+// machine there must be no Loader and therefore no launchctl at all.
+func TestReconcileWatcherUnits_LegacyProbeConstructsNoLoader(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	a := filepath.Join(home, "x", "api")
+	b := filepath.Join(home, "y", "api")
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	for _, r := range []string{a, b} {
+		u := watchers.Unit{Group: "g", Repo: r, BinPath: bin}
+		if _, err := watchers.UnitPath(u); err != nil {
+			t.Skipf("unsupported OS: %v", err)
+		}
+		writeUnitFile(t, u, watchers.Render(u))
+	}
+
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("constructed a Loader on an up-to-date machine")
+		return nil
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Current != 2 || len(res.Rewritten) != 0 || len(res.Migrated) != 0 {
+		t.Fatalf("current=%d rewritten=%d migrated=%d, want 2/0/0",
+			res.Current, len(res.Rewritten), len(res.Migrated))
+	}
+}
+
+// TestReconcileWatcherUnits_MigrationResetsWatchStarts answers the question a
+// label change raises for the crash-loop detector: are its records orphaned
+// too?
+//
+// They are not. WatchStartsPath is keyed by REPO PATH (<repo>/.grafel/
+// watch-starts.json), not by label, so renaming the unit leaves the history
+// exactly where the watcher will look for it. That is the good outcome and the
+// bad one at once: the record survives, and the migration's bootstrap is itself
+// a counted start, so an over-threshold history would make the freshly
+// registered watcher give up on its first tick (#6179 F4-a). Migration must
+// therefore clear it, like every other re-registration path.
+func TestReconcileWatcherUnits_MigrationResetsWatchStarts(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "api")
+	registerGroup(t, home, "g", []string{repo}, true)
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	if _, err := watchers.UnitPath(u); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	writeUnitFile(t, watchers.LegacyOf(u), "OLD BODY\n")
+
+	starts := watchers.WatchStartsPath(repo)
+	if err := os.MkdirAll(filepath.Dir(starts), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(starts, []byte(`{"starts":[1,2,3,4,5,6]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// The record's location does not mention the label at all.
+	if strings.Contains(starts, u.Label()) || strings.Contains(starts, watchers.LegacyOf(u).Label()) {
+		t.Fatalf("watch-starts path is label-derived (%s); a rename would orphan it", starts)
+	}
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	if _, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(starts); !os.IsNotExist(err) {
+		t.Fatalf("migration re-registered without clearing the crash-loop history: %v", err)
+	}
+}

--- a/internal/install/watchersync_orphans_6183_test.go
+++ b/internal/install/watchersync_orphans_6183_test.go
@@ -1,0 +1,244 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// --- F2: an interrupted first migration pass must not strand the sibling ----
+
+// TestReconcileWatcherUnits_InterruptedMigrationLeavesTheSiblingAbsentAndSaysSo.
+//
+// Repos that collided under the pre-#6183 label shared ONE unit file. Within a
+// single pass that is fully handled: phase 1 stats the shared file before
+// anything is retired, so every member records legacyExists=true and every
+// member gets its own unit (see ConvergesWithDuplicateBasenames).
+//
+// A pass KILLED partway through — ^C, a closed lid, an OOM; a 140-repo fleet
+// gives that room — is different. The survivor is left with no unit under
+// either label, and reconcile will not create it. It cannot: that on-disk state
+// is byte-for-byte identical to a watcher the user deliberately booted out and
+// deleted, and re-creating those is a bug of its own (see
+// DoesNotResurrectADeliberatelyRemovedUnit).
+//
+// So the contract is: report it, do not guess. The repo is counted Absent, the
+// summary names the count and points at `grafel install`, and reconcile stays a
+// pure read — no rewrite, no launchctl, nothing that would drift.
+func TestReconcileWatcherUnits_InterruptedMigrationLeavesTheSiblingAbsentAndSaysSo(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	a := filepath.Join(home, "x", "my-repo")
+	b := filepath.Join(home, "y", "my_repo")
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	ua := watchers.Unit{Group: "g", Repo: a, BinPath: bin}
+	ub := watchers.Unit{Group: "g", Repo: b, BinPath: bin}
+	pa, err := watchers.UnitPath(ua)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	pb, _ := watchers.UnitPath(ub)
+
+	// The exact state an interrupted pass leaves behind: the shared legacy unit
+	// is gone, repo A has its new unit, repo B has nothing at all.
+	writeUnitFile(t, ua, watchers.Render(ua))
+	if _, err := os.Stat(pb); !os.IsNotExist(err) {
+		t.Fatalf("precondition: repo B must have no unit")
+	}
+	legacyPath, _ := watchers.LegacyUnitPath(ua)
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: the shared legacy unit must already be retired")
+	}
+
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("constructed a Loader: an interrupted migration is reported, not repaired")
+		return nil
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(pb); !os.IsNotExist(err) {
+		t.Fatalf("reconcile re-created repo B's unit; it cannot distinguish this from a " +
+			"watcher the user deliberately removed")
+	}
+	if res.Absent != 1 {
+		t.Fatalf("Absent = %d, want 1 — the operator's only signal that repo B is unwatched",
+			res.Absent)
+	}
+	if len(res.Rewritten) != 0 || len(res.Reloaded) != 0 {
+		t.Fatalf("rewritten=%d reloaded=%d, want a pure read",
+			len(res.Rewritten), len(res.Reloaded))
+	}
+	if _, err := os.Stat(pa); err != nil {
+		t.Fatalf("repo A lost its unit: %v", err)
+	}
+	// And Apply is the documented remedy: it always writes, so it recovers B.
+	if res.Current != 1 {
+		t.Fatalf("Current = %d, want 1", res.Current)
+	}
+}
+
+// TestReconcileWatcherUnits_DoesNotCreateUnitsForNonCollidingAbsentRepos is the
+// bound on the recovery above. A repo that simply has no unit — never installed,
+// or deliberately booted out by the user — must STILL be left alone. Only the
+// collision recovery is in scope; resurrecting units nobody asked for is what
+// ReconcileWatcherUnits exists not to do.
+func TestReconcileWatcherUnits_DoesNotCreateUnitsForNonCollidingAbsentRepos(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	a := filepath.Join(home, "x", "alpha")
+	b := filepath.Join(home, "y", "beta") // distinct basenames: never collided
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	ua := watchers.Unit{Group: "g", Repo: a, BinPath: bin}
+	pa, err := watchers.UnitPath(ua)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	writeUnitFile(t, ua, watchers.Render(ua))
+
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("constructed a Loader: nothing here is stale")
+		return nil
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pb, _ := watchers.UnitPath(watchers.Unit{Group: "g", Repo: b, BinPath: bin})
+	if _, err := os.Stat(pb); !os.IsNotExist(err) {
+		t.Fatalf("reconcile created a unit for a repo that never had one (%s)", pb)
+	}
+	if res.Absent != 1 {
+		t.Fatalf("Absent = %d, want 1", res.Absent)
+	}
+	if _, err := os.Stat(pa); err != nil {
+		t.Fatalf("repo A's unit was disturbed: %v", err)
+	}
+}
+
+// --- F3: legacy units that are orphaned while still perfectly derivable ------
+
+// TestReconcileWatcherUnits_RetiresLegacyUnitWhenWatchersAreDisabled.
+//
+// A group with Features.Watchers=false was `continue`d before any repo was
+// visited, so turning watchers off in fleet.json left a pre-#6183 plist on disk
+// and loaded — for a repo that is STILL REGISTERED and whose legacy label is
+// therefore still derivable. That is not the unnameable-orphan class the
+// registry-derivation bound is about; it is an orphan we can name and simply
+// were not naming.
+//
+// Retiring it is also what "watchers: false" already means everywhere else.
+func TestReconcileWatcherUnits_RetiresLegacyUnitWhenWatchersAreDisabled(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "api")
+	registerGroup(t, home, "g", []string{repo}, false) // watchers OFF
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	if _, err := watchers.UnitPath(u); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	legacyPath := writeUnitFile(t, watchers.LegacyOf(u), watchers.Render(watchers.LegacyOf(u)))
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("legacy unit survived in a watchers-disabled group: %v", err)
+	}
+	if len(res.Migrated) != 1 {
+		t.Fatalf("Migrated = %v, want the legacy unit reported", res.Migrated)
+	}
+	// It must NOT be replaced: watchers are off.
+	newPath, _ := watchers.UnitPath(u)
+	if _, err := os.Stat(newPath); !os.IsNotExist(err) {
+		t.Fatalf("reconcile installed a watcher for a group with watchers disabled")
+	}
+	if len(res.Reloaded) != 0 {
+		t.Fatalf("Reloaded = %v, want nothing registered", res.Reloaded)
+	}
+	// Deregistered under the OLD label.
+	if len(fake.unloaded) != 1 || fake.unloaded[0] != watchers.LegacyOf(u).Label() {
+		t.Fatalf("unloaded = %v, want [%s]", fake.unloaded, watchers.LegacyOf(u).Label())
+	}
+
+	// Idempotent: nothing left to do, so no Loader at all.
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("second pass constructed a Loader")
+		return nil
+	}
+	if _, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestReconcileWatcherUnits_CollidingPairWithNothingInstalledStaysAbsent is the
+// bound on the crash recovery.
+//
+// The recovery keys off "two registered repos in one group share a legacy
+// label". That condition is readable from the registry alone — which is what
+// makes it survive a crash — but it is therefore ALSO true on a machine where
+// no watcher was ever installed. Acting on it there would have reconcile
+// installing and bootstrapping watchers nobody asked for, on every upgrade,
+// which is the exact behaviour #6179 exists to prevent.
+//
+// So the collision only puts a repo in scope when a sibling actually has a unit
+// on disk. Nothing installed means nothing to recover.
+func TestReconcileWatcherUnits_CollidingPairWithNothingInstalledStaysAbsent(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	a := filepath.Join(home, "x", "my-repo")
+	b := filepath.Join(home, "y", "my_repo") // same legacy slug as a
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	ua := watchers.Unit{Group: "g", Repo: a, BinPath: bin}
+	pa, err := watchers.UnitPath(ua)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	pb, _ := watchers.UnitPath(watchers.Unit{Group: "g", Repo: b, BinPath: bin})
+	if watchers.LegacyOf(ua).Label() != watchers.LegacyOf(watchers.Unit{Group: "g", Repo: b, BinPath: bin}).Label() {
+		t.Fatalf("precondition: the two repos must share a legacy label")
+	}
+
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("constructed a Loader: nothing is installed, so nothing can be stale")
+		return nil
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{pa, pb} {
+		if _, err := os.Stat(p); !os.IsNotExist(err) {
+			t.Fatalf("reconcile installed a watcher nobody asked for: %s", p)
+		}
+	}
+	if res.Absent != 2 {
+		t.Fatalf("Absent = %d, want 2", res.Absent)
+	}
+	if len(res.Rewritten) != 0 || len(res.Reloaded) != 0 || len(res.Migrated) != 0 {
+		t.Fatalf("rewritten=%d reloaded=%d migrated=%d, want all zero",
+			len(res.Rewritten), len(res.Reloaded), len(res.Migrated))
+	}
+}

--- a/internal/install/watchersync_resurrect_6183_test.go
+++ b/internal/install/watchersync_resurrect_6183_test.go
@@ -1,0 +1,141 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// TestReconcileWatcherUnits_DoesNotResurrectADeliberatelyRemovedUnit.
+//
+// A user who boots out a watcher and deletes its plist has expressed an
+// intention. ReconcileWatcherUnits must respect it: a repo with no unit under
+// either label is left alone, which is the rule that makes reconcile safe to
+// run unconditionally on every upgrade.
+//
+// The collision recovery added for #6183 F2 briefly broke that rule, and only
+// for repos whose directory name happened to match a sibling's. Its in-scope
+// gate accepted `pl.exists` — the CURRENT-label unit — as evidence that a
+// shared legacy unit had just been retired. But `pl.exists` is true for every
+// ordinary, fully-migrated repo forever after, so once two repos in a group
+// shared a legacy label and either had any unit, the other was re-created and
+// re-bootstrapped on EVERY reconcile: the #6183 non-convergence signature
+// restored, with a Background Items notification per `grafel update`, and the
+// answer to "will reconcile install a watcher I never asked for" made to depend
+// on whether an unrelated repo shares my directory name.
+//
+// There is no predicate that separates the two cases, which is why the gate had
+// to go rather than be narrowed: "interrupted mid-migration" and "user deleted
+// this on purpose" are byte-for-byte identical on disk — sibling has a current
+// unit, this repo has none, no legacy unit anywhere. The recovery for the first
+// is `Absent` in the summary telling the operator to run `grafel install`.
+func TestReconcileWatcherUnits_DoesNotResurrectADeliberatelyRemovedUnit(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	// A fresh, modern install: no legacy unit has ever existed here. The two
+	// repos collide only under the OLD scheme.
+	a := filepath.Join(home, "x", "api")
+	b := filepath.Join(home, "y", "api")
+	registerGroup(t, home, "g", []string{a, b}, true)
+
+	ua := watchers.Unit{Group: "g", Repo: a, BinPath: bin}
+	ub := watchers.Unit{Group: "g", Repo: b, BinPath: bin}
+	pa, err := watchers.UnitPath(ua)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	pb, _ := watchers.UnitPath(ub)
+	if watchers.LegacyOf(ua).Label() != watchers.LegacyOf(ub).Label() {
+		t.Fatalf("precondition: the pair must collide under the legacy label")
+	}
+	legacyPath, _ := watchers.LegacyUnitPath(ua)
+	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: no legacy unit may exist")
+	}
+
+	// A is installed and current. B was deliberately booted out and deleted.
+	writeUnitFile(t, ua, watchers.Render(ua))
+
+	fake := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fake }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	for run := 1; run <= 3; run++ {
+		res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("run %d: current=%d rewritten=%d reloaded=%d migrated=%d absent=%d (cumulative Loads=%d)",
+			run, res.Current, len(res.Rewritten), len(res.Reloaded), len(res.Migrated),
+			res.Absent, len(fake.loaded))
+
+		if _, err := os.Stat(pb); !os.IsNotExist(err) {
+			t.Fatalf("run %d resurrected a unit the user deliberately removed (%s)", run, pb)
+		}
+		if res.Absent != 1 {
+			t.Fatalf("run %d: Absent = %d, want 1 (repo B, reported not re-created)", run, res.Absent)
+		}
+		if len(res.Rewritten) != 0 || len(res.Reloaded) != 0 {
+			t.Fatalf("run %d: rewritten=%d reloaded=%d on an up-to-date machine — #6179's "+
+				"whole property", run, len(res.Rewritten), len(res.Reloaded))
+		}
+		if len(fake.loaded) != 0 {
+			t.Fatalf("run %d: cumulative launchctl Loads=%d, want 0", run, len(fake.loaded))
+		}
+		if res.Current != 1 {
+			t.Fatalf("run %d: Current = %d, want 1 (repo A untouched)", run, res.Current)
+		}
+	}
+	if _, err := os.Stat(pa); err != nil {
+		t.Fatalf("repo A's unit was disturbed: %v", err)
+	}
+}
+
+// TestReconcileWatcherUnits_CollidingAndNonCollidingAbsentReposAreTreatedAlike
+// pins the symmetry directly. Whether reconcile creates a watcher must not
+// depend on whether some other repo happens to share this one's directory name.
+func TestReconcileWatcherUnits_CollidingAndNonCollidingAbsentReposAreTreatedAlike(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+
+	installed := filepath.Join(home, "x", "api")
+	colliding := filepath.Join(home, "y", "api")    // shares a legacy label with installed
+	nonColliding := filepath.Join(home, "z", "web") // shares nothing
+	registerGroup(t, home, "g", []string{installed, colliding, nonColliding}, true)
+
+	ui := watchers.Unit{Group: "g", Repo: installed, BinPath: bin}
+	if _, err := watchers.UnitPath(ui); err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	writeUnitFile(t, ui, watchers.Render(ui))
+
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader {
+		t.Fatalf("constructed a Loader: nothing is stale and nothing should be created")
+		return nil
+	}
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pc, _ := watchers.UnitPath(watchers.Unit{Group: "g", Repo: colliding, BinPath: bin})
+	pn, _ := watchers.UnitPath(watchers.Unit{Group: "g", Repo: nonColliding, BinPath: bin})
+	_, cErr := os.Stat(pc)
+	_, nErr := os.Stat(pn)
+	if os.IsNotExist(cErr) != os.IsNotExist(nErr) {
+		t.Fatalf("colliding and non-colliding absent repos treated differently: "+
+			"colliding created=%v, non-colliding created=%v", cErr == nil, nErr == nil)
+	}
+	if cErr == nil {
+		t.Fatalf("reconcile created a unit for a repo that has none (%s)", pc)
+	}
+	if res.Absent != 2 {
+		t.Fatalf("Absent = %d, want 2", res.Absent)
+	}
+}

--- a/internal/install/watchstarts_reset_6179_test.go
+++ b/internal/install/watchstarts_reset_6179_test.go
@@ -104,6 +104,13 @@ func TestApply_ResetsWatchStartsWhenRegisteringUnit(t *testing.T) {
 	})
 	recPath := seedWatchStarts(t, repo)
 
+	// Belt AND braces. Swapping newWatcherLoader is what keeps Apply away from
+	// launchctl; stubbing the runner is what keeps a future refactor that
+	// reintroduces a direct watchers.NewLoader() call from silently leaking a
+	// launchd job again. This test issued a real bootout+bootstrap into the
+	// developer's session on every run until #6183 (see stubLaunchctlRunner).
+	stubLaunchctlRunner(t)
+
 	fake := &fakeLoader{}
 	prev := newWatcherLoader
 	newWatcherLoader = func() watchers.Loader { return fake }


### PR DESCRIPTION
`slugify` opened with `filepath.Base`, so two repos in one group with equal basenames produced the **same `Label`** — and `Label` is both the plist filename and the launchd job identity. On a 140-repo fleet, duplicate `api` / `web` / `docs` / `infra` names across different orgs are close to certain.

Two consequences, both measured:

```
labelA=com.grafel.watcher.g.my-repo  labelB=com.grafel.watcher.g.my-repo  samePath=true
run 1: current=0 rewritten=2 reloaded=2   (cumulative Loads=2)
run 2: current=0 rewritten=2 reloaded=2   (cumulative Loads=4)   ← never converges
run 3: current=0 rewritten=2 reloaded=2   (cumulative Loads=6)
```

Every reconcile rewrote the shared file to repo A's body, then repo B's, and re-registered both — so #6179's "zero `launchctl` on an up-to-date machine" property was **false for exactly the reporter's configuration**, with a Background Items notification on every `grafel update`, forever. And silently: only one of each colliding pair was ever actually watched.

## The slug

`basename + "-" + 8 hex of SHA-256(filepath.Clean(path))`, **unconditional**. A derivation that consulted the rest of the fleet to disambiguate "only where needed" would rename an existing unit every time an unrelated repo was added — turning a one-time orphaning cost into one on every fleet edit. 8 hex is ~1-in-2.7M across a 140-repo group by the birthday bound, and the basename stays the thing the eye reads.

## Migration is the whole risk

Changing `Label` orphans every installed unit: the old plist stays on disk and stays loaded under the old label while the new one registers alongside it. Done carelessly, users end up with **two** watchers per repo — strictly worse than the bug.

`LegacyOf(u)` reproduces the pre-fix label via an unexported field, so `MigrateLegacyUnit` boots the old job out **while its file still exists** and only then deletes it. That ordering is load-bearing — `systemctl --user disable` resolves a unit by reading its file — and is pinned by `TestMigrateLegacyUnit_DeregistersBeforeDeleting`. Wired into `Apply`, `ReconcileWatcherUnits`, `Uninstall` and `Cleanup`.

Review enumerated every interruption ordering and **could not produce two watchers per repo on any of them**: interrupted between bootout and delete (next run re-stats, re-boots-out as a no-op, deletes); between delete and `Load` (new file present and current, so reconcile counts it and launchd picks it up at next login — self-heals); crash at 70 of 140; two `grafel install` racing (both `Unload` the same label, one `os.Remove` wins, the other's `NotExist` is tolerated, both bootstrap the *same* new label); legacy present but never loaded; both labels present and both loaded.

**The one ordering that does produce two watchers is a downgrade** to a pre-#6183 binary, which derives the basename-only label, finds no file, and registers it while the digest unit is still loaded. Unfixable from this side; documented in "Known limits" and in the Windows doc with a manual `schtasks /delete` remedy.

## The collision's silent half

Colliding repos shared *one* file, so the first member to migrate retires it — and the rest then look like repos that never had a unit, which reconcile deliberately does not create. Without handling that, migration would leave the previously-unwatched repo **still** unwatched.

`ReconcileWatcherUnits` now runs a **plan phase per group** that derives both labels and stats both paths before anything mutates, so every member of a colliding set observes the shared file within one pass regardless of retirement order. Phase 1 performs no writes; phase 2 re-stats before acting.

Review verified the two-phase split is TOCTOU-safe on every window traced, because each destructive step re-verifies: legacy file deleted between phases → `MigrateLegacyUnit` re-stats and returns cleanly, which is why the shared-file case counts `migrated=1` rather than 2; legacy created between phases → retired next run; a concurrent `Apply` writing the new unit → one redundant rewrite of identical bytes, wasteful not destructive. And fusing the loops is pinned as a regression: re-stat in phase 2 and member A's retirement makes member B's stat return `NotExist`, reproducing #6183's original symptom.

## The recovery gate was over-reach, and review caught it

The first attempt gated recovery on `pl.exists || pl.legacyExists`. `pl.exists` is the **current**-label unit — true for every ordinary migrated repo, forever — so once two repos shared a legacy label, deleting one's watcher **resurrected it on every reconcile, permanently**:

```
run 1: B RESURRECTED=true (Loads=1)
run 2: B RESURRECTED=true (Loads=2)
run 3: B RESURRECTED=true (Loads=3)
```

That is #6183's own non-convergence signature, plus a notification burst on every upgrade, plus a violation of the branch's own stated invariant that *"a repo deliberately booted out by the user must STILL be left alone."* A colliding sibling that was never installed also got created — so whether reconcile installed a watcher you never asked for depended on whether another repo happened to share your directory name.

**And it could not be patched with a better predicate:** the interrupted-migration state and the deliberate-removal state are byte-for-byte identical on disk. Two tests asserted opposite outcomes for the same state, passing only because one fixture collided and the other did not — while basename collision encodes nothing about user intent.

Removing `pl.exists` made `collidingInstalled` and `legacyMembers` **entirely redundant**, so both are deleted. That is provable, not observed: `planWatcherUnits` sets `legacyExists` only inside the branch that sets `legacyPath`, phase 1 performs no writes, so all members sharing a `legacyPath` stat the same path with no intervening mutation and record identical values — any sibling-derived map keyed on `legacyPath` is by construction equal to each member's own field. `pl.exists` was the **only** per-repo field in that disjunct that could differ between siblings, so its removal collapses the map to a pure function of `legacyPath`. Round 2's structure could only ever have been redundant or wrong; it was wrong.

The crash case now reports `Absent`, surfaced in `printReconcileSummary` with "run `grafel install` for their group" — which was the sufficient fix all along.

`TestReconcileWatcherUnits_InterruptedMigrationStillRecoversTheSibling` — the test that *encoded* the resurrection — is rewritten to `…LeavesTheSiblingAbsentAndSaysSo`: identical constructed state, opposite assertion, and the loader constructor `t.Fatalf`s if reached. **Both branches of the dilemma are now pinned by tests that conflict if the gate returns** — reinstating it fails three at once.

## A test-isolation leak this change would have amplified

`TestApply_ResetsWatchStartsWhenRegisteringUnit` stubs `newWatcherLoader`, but `Apply`'s activation path calls `watchers.NewLoader()` directly — so it issued real `launchctl bootout`/`bootstrap`. Pre-existing (#6179), but the old label was a **constant**, so run N replaced run N−1 and the leak was capped at one job. A digest of the temp path would have minted a **permanent new launchd job per test run**.

Measured on the dev machine: **24 orphaned jobs**, 23 distinct digests plus one undigested control from a pre-fix tree, each pointing at a deleted temp binary, exiting 78, rescheduling at the 60s throttle.

Fixed here with `stubLaunchctlRunner(t)`. The seam-routing half is deliberately left to `fix/grafel-stop-leaves-indexing`, which found the same root cause independently and owns those call sites.

**The measurement that justifies the new floor** — same test, only the stub removed:

```
stub removed:  launchctl bootout   gui/501/com.grafel.watcher.g.app-67df4fe8
               launchctl bootstrap gui/501 .../....plist
stub restored: launchctl list      com.grafel.watcher.g.app-2af0a631
```

**Both runs exit 0.** The test passes either way, which is why this went unseen — and why an in-process stub could never have caught it. Verification now runs behind a `launchctl`/`systemctl` PATH shim that logs argv and exits 1: **16 invocations across all three suites, all read-only `list`, zero mutating verbs.** `bootstrap` is emitted only by `Load`, and `Load` reaches launchctl only through `launchctlRunner`, so zero `bootstrap` lines is a positive observation of the leak's absence. (It is a floor, not a proof: the shim makes `list` exit 1, so `Unload` always short-circuits before its own `bootout`.)

## Also

The watchers-disabled group was `continue`d before any repo was visited, so its legacy unit stayed on disk and loaded. That became **harmful through this change** — pre-fix, re-enabling watchers overwrote the same file; post-fix it would write the new label alongside the still-loaded old one. Its legacy unit is now retired, with nothing installed.

Not reaped, and stated rather than implied: a repo dropped from a group config leaves both labels orphaned. Reaping needs enumerating the unit dir and deleting whatever no config claims, which cannot distinguish "user removed this repo" from "config unreadable / belongs to a checkout this binary cannot see" — and kills a live watcher in the second case. Label→(group, repo) parsing is not sound either, since the group name is interpolated verbatim and may contain dots. Documented under "What this does NOT reap".

`pathDigest`'s docstring is corrected to say the label is a function of the **string the registry holds**, not of the directory it names: `Clean` collapses every separator/dot form, APFS case variants now yield two labels where the old scheme gave one, and `EvalSymlinks` is deliberately absent because resolving would make the label depend on filesystem state, so a moved symlink would silently rename an installed unit — paying the orphaning cost a second time. `LegacyOf` carries the honest caveat that legacy and current label spaces are not disjoint (~2⁻³² per pair). `docs/platform/windows-service.md` updated throughout.

## Verification

`gofmt -l .` empty, `go build ./...` 0, `go vet ./...` 0. Behind the PATH shim, unpiped `$?`, `-count=1 -p 1`, `GOMAXPROCS=4`: `internal/install/watchers` 0, `internal/install` 0 (30.8s), `internal/cli` 0 (45.7s). `plutil -lint` OK on hostile names including `/z/My Repo & Co` and a group named `R&D`.

**29 mutants across four rounds.** Four initially survived and drove real work: `Apply` not retiring legacy units, `Uninstall`/`Cleanup` leaving them behind, and deleting the plist before the bootout. One is reported as **equivalent, not killed** — gating on a sibling's `legacyExists` rather than the repo's own — constructed deliberately to test the equivalence claim behind the deletion. Its survival is the predicted consequence of that claim; the failure mode would have been R1-a surviving too, and R1-a died on three tests.

Independently adversarially reviewed three times (REQUEST-CHANGES → REQUEST-CHANGES → APPROVE), with the reviewer running its own probes against each revision.

## Known limits

Real launchd, systemd and schtasks are unexercised — every test uses the shim or a seam, so "a bootout releases the job" and "exactly one watcher ends up running" are verified at the call level only. Downgrade is reasoned. Mutant M11 (delete `Uninstall`'s legacy `Unload`, keep the `Remove`) survives, because `Uninstall` still builds its loader directly; marked `TODO(#6183-seam)` and restorable once the sibling branch lands.

Closes #6183
Refs #6179, #6192
