### PR TITLE
fix(#6170): a lost MCP registration made the wizard show the tool unchecked, so that run failed to re-register it

### DIFF
--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/detect"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/install/mcptools"
@@ -269,7 +270,12 @@ func (s *Server) groupExists(name string) bool {
 // "Configure MCP for which tools?" step can render its checkboxes (#5344). It
 // performs NO writes.
 func (s *Server) handleV2DetectMCPTools(w http.ResponseWriter, _ *http.Request) {
-	detected := mcptools.Detect()
+	// The (B2) durable signal (#6170): install.json still records the config
+	// paths a previous install registered grafel in, even after the entry
+	// itself was deleted. Without it a lost registration + a config older than
+	// RecentWindow arrives here unchecked, and the wizard remembers the
+	// accident as a choice.
+	detected := mcptools.DetectWithPrevious(install.PreviouslyRegisteredMCPPaths())
 	tools := make([]v2MCPToolStatus, 0, len(detected))
 	for _, t := range detected {
 		tools = append(tools, v2MCPToolStatus{

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon/proto"
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/mcptools"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
@@ -457,6 +458,45 @@ func TestV2DetectMCPTools_PreviouslyRegisteredIsChecked(t *testing.T) {
 	}
 	if !sel {
 		t.Error("claude must be default-selected: install.json records grafel was registered at ~/.claude.json")
+	}
+}
+
+// TestV2DetectMCPTools_SavedOptOutSurvivesTheRecord is the wire-level safety
+// property (#6170): the user unchecked Claude Code in a previous wizard run,
+// which registerWizardMCP persisted via mcptools.SaveLastChoice. install.json
+// still records the old registration — and must NOT be allowed to re-check the
+// box the user cleared.
+func TestV2DetectMCPTools_SavedOptOutSurvivesTheRecord(t *testing.T) {
+	home := testsupport.IsolateHome(t)
+	claudeJSON := staleClaudeConfigNoGrafel(t, home)
+	// A cursor config so the saved choice has something to keep.
+	cursorPath := filepath.Join(home, ".cursor", "mcp.json")
+	if err := os.MkdirAll(filepath.Dir(cursorPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cursorPath, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	st := install.NewState(install.ModeCopy)
+	st.MCP = install.MCPRecord{Name: mcpreg.ServerName, RegisteredPaths: []string{claudeJSON}}
+	if err := install.WriteState(filepath.Join(home, ".grafel", "install.json"), st); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+	// The recorded decision, written the way production writes it.
+	if err := mcptools.SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	sel, found := detectClaudeDefaultSelected(t, ts)
+	if !found {
+		t.Fatal("claude not detected")
+	}
+	if sel {
+		t.Error("claude was deliberately unchecked and saved; the install.json record must not re-check it")
 	}
 }
 

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
 	"github.com/cajasmota/grafel/internal/testsupport"
 )
@@ -367,6 +368,95 @@ func TestV2DetectMCPTools(t *testing.T) {
 	}
 	if !claude.DefaultSelected {
 		t.Errorf("claude (recent config) should be default-selected: %+v", *claude)
+	}
+}
+
+// detectClaudeDefaultSelected GETs /api/v2/mcp-tools/detect and returns
+// (defaultSelected, found) for the claude row.
+func detectClaudeDefaultSelected(t *testing.T, ts *httptest.Server) (bool, bool) {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/api/v2/mcp-tools/detect")
+	if err != nil {
+		t.Fatalf("GET mcp-tools/detect: %v", err)
+	}
+	defer resp.Body.Close()
+	var env struct {
+		OK   bool                  `json:"ok"`
+		Data v2MCPToolsDetectReply `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK {
+		t.Fatalf("not ok: %+v", env)
+	}
+	for _, tool := range env.Data.Tools {
+		if tool.ID == "claude" {
+			return tool.DefaultSelected, true
+		}
+	}
+	return false, false
+}
+
+// staleClaudeConfigNoGrafel writes ~/.claude.json with NO grafel entry and an
+// mtime well past mcptools.RecentWindow — the state a lost registration leaves
+// behind (#6170). Returns its path.
+func staleClaudeConfigNoGrafel(t *testing.T, home string) string {
+	t.Helper()
+	path := filepath.Join(home, ".claude.json")
+	if err := os.WriteFile(path, []byte(`{"mcpServers":{"other":{"command":"x"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().Add(-90 * 24 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestV2DetectMCPTools_RatchetWithoutRecord pins the ratchet at the wire: with
+// the grafel entry gone, a stale config and nothing recorded in install.json,
+// claude arrives UNCHECKED — the state a press-enter run turns into a
+// permanent opt-out (#6170).
+func TestV2DetectMCPTools_RatchetWithoutRecord(t *testing.T) {
+	home := testsupport.IsolateHome(t)
+	staleClaudeConfigNoGrafel(t, home)
+
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	sel, found := detectClaudeDefaultSelected(t, ts)
+	if !found {
+		t.Fatal("claude not detected")
+	}
+	if sel {
+		t.Error("without an install.json record claude is expected unchecked here (that IS the ratchet)")
+	}
+}
+
+// TestV2DetectMCPTools_PreviouslyRegisteredIsChecked is the fix end-to-end:
+// install.json still records that grafel registered itself at ~/.claude.json,
+// so the wizard arrives CHECKED despite the entry being gone and the config
+// being stale.
+func TestV2DetectMCPTools_PreviouslyRegisteredIsChecked(t *testing.T) {
+	home := testsupport.IsolateHome(t)
+	claudeJSON := staleClaudeConfigNoGrafel(t, home)
+
+	st := install.NewState(install.ModeCopy)
+	st.MCP = install.MCPRecord{Name: mcpreg.ServerName, RegisteredPaths: []string{claudeJSON}}
+	if err := install.WriteState(filepath.Join(home, ".grafel", "install.json"), st); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	sel, found := detectClaudeDefaultSelected(t, ts)
+	if !found {
+		t.Fatal("claude not detected")
+	}
+	if !sel {
+		t.Error("claude must be default-selected: install.json records grafel was registered at ~/.claude.json")
 	}
 }
 

--- a/internal/install/mcpprev.go
+++ b/internal/install/mcpprev.go
@@ -26,11 +26,18 @@ import (
 // mcptools.DetectWithPrevious.
 //
 // Paths belonging to a tool the user has DELIBERATELY turned off are removed
-// first. That subtraction is the safety property: the recorded registration
-// must only repair an accidental unchecking, never re-check a box the user
-// went out of their way to clear. The durable record of "off" is the group
-// configs' explicit tool selection (registry.GroupConfig.Tools, resolved via
-// tooladapter.EnabledAdapters) — the same set `uninstall` and `doctor` sweep.
+// first, using the group configs' explicit tool selection
+// (registry.GroupConfig.Tools via tooladapter.EnabledAdapters) — the same set
+// `uninstall` and `doctor` sweep.
+//
+// This subtraction is DEFENCE IN DEPTH, not the safety property. The property
+// — "a recorded decision is never overridden" — is carried by the bound in
+// mcptools.detectWith, which suppresses B2 entirely once any choice has been
+// recorded; strengthen that if it ever needs strengthening. This layer catches
+// only the residual cross-path case: a user who set an explicit tool list via
+// the CLI (`grafel install`, `--tools`) AND has no ~/.grafel/mcp-tools.json,
+// so the bound has nothing to key on. Narrow by construction — the dashboard
+// wizard, the sole consumer, creates groups without writing cfg.Tools.
 //
 // Everything here is best-effort: an unreadable install.json or registry
 // yields nil, which simply restores the pre-#6170 default. It never errors and

--- a/internal/install/mcpprev.go
+++ b/internal/install/mcpprev.go
@@ -66,7 +66,16 @@ func previouslyRegisteredMCPPaths(
 		return nil
 	}
 
-	for _, tool := range deliberatelyDisabledMCPTools(groupsFn, loadFn) {
+	disabled, ok := deliberatelyDisabledMCPTools(groupsFn, loadFn)
+	if !ok {
+		// We could not read the tool selection, so we cannot know whether a
+		// tool was deliberately disabled. Offer nothing rather than risk
+		// re-checking a box the user cleared: the cost of failing closed is
+		// the pre-#6170 default, the cost of failing open is a silent
+		// override of the user's decision on a transient read error.
+		return nil
+	}
+	for _, tool := range disabled {
 		for _, p := range mcpConfigPathsFor(tool) {
 			delete(out, filepath.Clean(p))
 		}
@@ -79,24 +88,52 @@ func previouslyRegisteredMCPPaths(
 
 // deliberatelyDisabledMCPTools returns the MCP-capable tools that NO registered
 // group enables — i.e. the user made an explicit tool selection and left these
-// out.
+// out — and whether the selection could be read at all.
 //
-// With no groups registered (or an unreadable registry) there is no explicit
-// selection to read, so nothing is reported disabled: absence of evidence is
-// not an opt-out. A group with an empty Tools list means "all tools"
-// (tooladapter.EnabledAdapters), so it too disables nothing.
+// ok=false means "unknown": the registry or a group config would not load, so
+// the caller MUST fail closed. It is deliberately distinguished from the two
+// legitimately-empty answers — no groups registered (nothing to disable
+// anything) and a group with an empty Tools list, which means "all tools"
+// (tooladapter.EnabledAdapters). Absence of evidence is not an opt-out; an
+// unreadable config is not evidence of absence.
+//
+// This walks the registry directly rather than through
+// resolveEnabledToolBindings because that helper collapses a load failure into
+// a shorter list — fine for doctor's advisory sweep, wrong here, where the
+// difference between "nothing disabled" and "cannot tell" is the whole point.
 func deliberatelyDisabledMCPTools(
 	groupsFn func() ([]registry.GroupRef, error),
 	loadFn func(path string) (*registry.GroupConfig, error),
-) []mcpreg.Tool {
-	bindings := resolveEnabledToolBindings(groupsFn, loadFn)
-	if len(bindings) == 0 {
-		return nil
+) ([]mcpreg.Tool, bool) {
+	if groupsFn == nil {
+		groupsFn = registry.Groups
 	}
+	if loadFn == nil {
+		loadFn = registry.LoadGroupConfig
+	}
+	groups, err := groupsFn()
+	if err != nil {
+		return nil, false
+	}
+	if len(groups) == 0 {
+		return nil, true // no explicit selection exists anywhere
+	}
+
 	enabled := make(map[mcpreg.Tool]bool)
-	for _, t := range mcpToolsFromBindings(bindings) {
-		enabled[t] = true
+	for _, g := range groups {
+		cfg, err := loadFn(g.ConfigPath)
+		if err != nil || cfg == nil {
+			return nil, false
+		}
+		for _, a := range tooladapter.EnabledAdapters(cfg) {
+			if a.SupportsMCP() {
+				if t := a.MCPTool(); t != "" {
+					enabled[t] = true
+				}
+			}
+		}
 	}
+
 	var out []mcpreg.Tool
 	for _, a := range tooladapter.All() {
 		if !a.SupportsMCP() {
@@ -108,7 +145,7 @@ func deliberatelyDisabledMCPTools(
 		}
 		out = append(out, t)
 	}
-	return out
+	return out, true
 }
 
 // mcpConfigPathsFor returns every host config path grafel's installer may have
@@ -124,7 +161,11 @@ func mcpConfigPathsFor(tool mcpreg.Tool) []string {
 	switch tool {
 	case mcpreg.ClaudeCode:
 		out = append(out, mcpreg.DetectClaudeConfigDirs(nil)...)
-	case mcpreg.Windsurf, mcpreg.WindsurfJetBrains:
+	case mcpreg.Windsurf:
+		// DetectWindsurfPaths covers BOTH the desktop and the JetBrains config
+		// files, which is what step 3 registers. There is deliberately no
+		// WindsurfJetBrains arm: no adapter returns that tool from MCPTool(),
+		// so it can never reach this function.
 		out = append(out, mcpreg.DetectWindsurfPaths()...)
 	}
 	return out

--- a/internal/install/mcpprev.go
+++ b/internal/install/mcpprev.go
@@ -1,0 +1,131 @@
+// mcpprev.go — the durable "grafel's MCP was registered here" signal (#6170).
+//
+// The tool-selection wizard pre-checks a tool from two erasable facts: the
+// config file was touched recently, or it still contains a grafel entry. Both
+// go false the moment something deletes the entry (the #6168 rollback being
+// the demonstrated way) and the file then sits untouched past RecentWindow.
+// The tool arrives UNCHECKED, and a user pressing enter through the next run
+// persists that accident as their preference — a one-way ratchet.
+//
+// install.json already records what grafel itself did: state.MCP.RegisteredPaths
+// is the list of host config paths RunCopy/RunDev registered the server in, and
+// it survives the entry being deleted. That is the signal the wizard was
+// missing. No new store.
+package install
+
+import (
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/install/tooladapter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// PreviouslyRegisteredMCPPaths returns the set of MCP host config paths a
+// previous grafel install recorded registering the server in, for
+// mcptools.DetectWithPrevious.
+//
+// Paths belonging to a tool the user has DELIBERATELY turned off are removed
+// first. That subtraction is the safety property: the recorded registration
+// must only repair an accidental unchecking, never re-check a box the user
+// went out of their way to clear. The durable record of "off" is the group
+// configs' explicit tool selection (registry.GroupConfig.Tools, resolved via
+// tooladapter.EnabledAdapters) — the same set `uninstall` and `doctor` sweep.
+//
+// Everything here is best-effort: an unreadable install.json or registry
+// yields nil, which simply restores the pre-#6170 default. It never errors and
+// never writes.
+func PreviouslyRegisteredMCPPaths() map[string]bool {
+	return previouslyRegisteredMCPPaths(DefaultStatePath, nil, nil)
+}
+
+// previouslyRegisteredMCPPaths is the injectable core of
+// PreviouslyRegisteredMCPPaths. statePathFn locates install.json; groupsFn /
+// loadFn are the registry accessors (nil = the real ones).
+func previouslyRegisteredMCPPaths(
+	statePathFn func() (string, error),
+	groupsFn func() ([]registry.GroupRef, error),
+	loadFn func(path string) (*registry.GroupConfig, error),
+) map[string]bool {
+	statePath, err := statePathFn()
+	if err != nil {
+		return nil
+	}
+	state, err := ReadState(statePath)
+	if err != nil || state == nil {
+		return nil
+	}
+
+	out := make(map[string]bool, len(state.MCP.RegisteredPaths))
+	for _, p := range state.MCP.RegisteredPaths {
+		if p != "" {
+			out[filepath.Clean(p)] = true
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+
+	for _, tool := range deliberatelyDisabledMCPTools(groupsFn, loadFn) {
+		for _, p := range mcpConfigPathsFor(tool) {
+			delete(out, filepath.Clean(p))
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// deliberatelyDisabledMCPTools returns the MCP-capable tools that NO registered
+// group enables — i.e. the user made an explicit tool selection and left these
+// out.
+//
+// With no groups registered (or an unreadable registry) there is no explicit
+// selection to read, so nothing is reported disabled: absence of evidence is
+// not an opt-out. A group with an empty Tools list means "all tools"
+// (tooladapter.EnabledAdapters), so it too disables nothing.
+func deliberatelyDisabledMCPTools(
+	groupsFn func() ([]registry.GroupRef, error),
+	loadFn func(path string) (*registry.GroupConfig, error),
+) []mcpreg.Tool {
+	bindings := resolveEnabledToolBindings(groupsFn, loadFn)
+	if len(bindings) == 0 {
+		return nil
+	}
+	enabled := make(map[mcpreg.Tool]bool)
+	for _, t := range mcpToolsFromBindings(bindings) {
+		enabled[t] = true
+	}
+	var out []mcpreg.Tool
+	for _, a := range tooladapter.All() {
+		if !a.SupportsMCP() {
+			continue
+		}
+		t := a.MCPTool()
+		if t == "" || enabled[t] {
+			continue
+		}
+		out = append(out, t)
+	}
+	return out
+}
+
+// mcpConfigPathsFor returns every host config path grafel's installer may have
+// registered this tool at — the canonical settings path plus the extra targets
+// step 3 of RunCopy fans out to (Claude's sidecar profile dirs, Windsurf's
+// desktop + JetBrains variants). Those two families are exactly what lands in
+// state.MCP.RegisteredPaths, so this is the inverse of that mapping.
+func mcpConfigPathsFor(tool mcpreg.Tool) []string {
+	var out []string
+	if p, err := mcpreg.SettingsPath(tool); err == nil {
+		out = append(out, p)
+	}
+	switch tool {
+	case mcpreg.ClaudeCode:
+		out = append(out, mcpreg.DetectClaudeConfigDirs(nil)...)
+	case mcpreg.Windsurf, mcpreg.WindsurfJetBrains:
+		out = append(out, mcpreg.DetectWindsurfPaths()...)
+	}
+	return out
+}

--- a/internal/install/mcpprev_test.go
+++ b/internal/install/mcpprev_test.go
@@ -7,6 +7,7 @@ package install
 // reach the developer's real ~/.claude.json, ~/.grafel or launchd.
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -156,12 +157,49 @@ func TestPreviouslyRegisteredMCPPaths_EmptyToolsIsNotAnOptOut(t *testing.T) {
 	}
 }
 
+// TestPreviouslyRegisteredMCPPaths_UnreadableGroupFailsClosed verifies the
+// safety-critical direction of an error: if a group config cannot be loaded we
+// cannot know whether a tool was deliberately disabled, so NO paths are
+// offered. Fail-open here would silently re-check a tool the user turned off
+// on nothing more than a transient permission error.
+func TestPreviouslyRegisteredMCPPaths_UnreadableGroupFailsClosed(t *testing.T) {
+	home := isolatePrevHome(t)
+	claudeJSON := filepath.Join(home, ".claude.json")
+	statePathFn := writePrevState(t, home, []string{claudeJSON})
+
+	groupsFn := func() ([]registry.GroupRef, error) {
+		return []registry.GroupRef{{Name: "g", ConfigPath: "/fake/g.json"}}, nil
+	}
+	loadFn := func(string) (*registry.GroupConfig, error) {
+		return nil, errors.New("permission denied")
+	}
+
+	if got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn); got != nil {
+		t.Errorf("an unreadable group config must yield NO paths (fail closed); got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_RegistryErrorFailsClosed is the same
+// property one level up: an unreadable registry is not evidence that nothing
+// is disabled.
+func TestPreviouslyRegisteredMCPPaths_RegistryErrorFailsClosed(t *testing.T) {
+	home := isolatePrevHome(t)
+	statePathFn := writePrevState(t, home, []string{filepath.Join(home, ".claude.json")})
+
+	groupsFn := func() ([]registry.GroupRef, error) { return nil, errors.New("registry unreadable") }
+	loadFn := func(string) (*registry.GroupConfig, error) { return nil, nil }
+
+	if got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn); got != nil {
+		t.Errorf("an unreadable registry must yield NO paths (fail closed); got %v", got)
+	}
+}
+
 // TestDeliberatelyDisabledMCPTools_NoGroupsIsNoSignal verifies absence of
 // evidence is not an opt-out: with no groups registered nothing is reported
 // disabled, so a fresh machine's recorded paths are never subtracted away.
 func TestDeliberatelyDisabledMCPTools_NoGroupsIsNoSignal(t *testing.T) {
 	groupsFn, loadFn := noGroups()
-	if got := deliberatelyDisabledMCPTools(groupsFn, loadFn); len(got) != 0 {
-		t.Errorf("no groups must yield no disabled tools; got %v", got)
+	if got, ok := deliberatelyDisabledMCPTools(groupsFn, loadFn); !ok || len(got) != 0 {
+		t.Errorf("no groups must yield no disabled tools and a READABLE verdict; got %v ok=%v", got, ok)
 	}
 }

--- a/internal/install/mcpprev_test.go
+++ b/internal/install/mcpprev_test.go
@@ -1,0 +1,167 @@
+package install
+
+// mcpprev_test.go — the durable previously-registered MCP signal (#6170).
+//
+// Every test isolates HOME, XDG_CONFIG_HOME and GRAFEL_HOME into a t.TempDir
+// and drives the registry through injected accessors, so nothing here can
+// reach the developer's real ~/.claude.json, ~/.grafel or launchd.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// isolatePrevHome points HOME/XDG_CONFIG_HOME/GRAFEL_HOME at a temp dir and
+// returns it. Nothing under test writes; this guards the READS too so a
+// missing fixture can never be answered by a real file.
+func isolatePrevHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "cfg"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+	return home
+}
+
+// writePrevState writes an install.json under the isolated home recording the
+// given RegisteredPaths, and returns a statePathFn pointing at it.
+func writePrevState(t *testing.T, home string, paths []string) func() (string, error) {
+	t.Helper()
+	statePath := filepath.Join(home, ".grafel", "install.json")
+	st := NewState(ModeCopy)
+	st.MCP = MCPRecord{Name: mcpreg.ServerName, RegisteredPaths: paths}
+	if err := WriteState(statePath, st); err != nil {
+		t.Fatalf("WriteState: %v", err)
+	}
+	return func() (string, error) { return statePath, nil }
+}
+
+// noGroups is the "nothing registered yet" registry: no explicit tool
+// selection exists anywhere, so nothing can be deliberately disabled.
+func noGroups() (func() ([]registry.GroupRef, error), func(string) (*registry.GroupConfig, error)) {
+	return func() ([]registry.GroupRef, error) { return nil, nil },
+		func(string) (*registry.GroupConfig, error) { return nil, nil }
+}
+
+// TestPreviouslyRegisteredMCPPaths_ReadsRegisteredPaths verifies the recorded
+// paths come back as a cleaned set — the signal that survives the grafel entry
+// being deleted from the config file (#6170).
+func TestPreviouslyRegisteredMCPPaths_ReadsRegisteredPaths(t *testing.T) {
+	home := isolatePrevHome(t)
+	claudeJSON := filepath.Join(home, ".claude.json")
+	statePathFn := writePrevState(t, home, []string{claudeJSON + "/", ""})
+	groupsFn, loadFn := noGroups()
+
+	got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn)
+	if !got[claudeJSON] {
+		t.Errorf("want %s in the recorded set; got %v", claudeJSON, got)
+	}
+	if len(got) != 1 {
+		t.Errorf("empty entries must be dropped; got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_NoStateFile verifies a machine with no
+// install.json yields nil — the pre-#6170 default, not a crash.
+func TestPreviouslyRegisteredMCPPaths_NoStateFile(t *testing.T) {
+	home := isolatePrevHome(t)
+	missing := func() (string, error) { return filepath.Join(home, ".grafel", "install.json"), nil }
+	groupsFn, loadFn := noGroups()
+
+	if got := previouslyRegisteredMCPPaths(missing, groupsFn, loadFn); got != nil {
+		t.Errorf("no install.json should yield nil; got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_CorruptStateFile verifies an unreadable
+// install.json degrades to nil rather than propagating an error into the
+// wizard.
+func TestPreviouslyRegisteredMCPPaths_CorruptStateFile(t *testing.T) {
+	home := isolatePrevHome(t)
+	statePath := filepath.Join(home, ".grafel", "install.json")
+	if err := os.MkdirAll(filepath.Dir(statePath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(statePath, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	groupsFn, loadFn := noGroups()
+
+	if got := previouslyRegisteredMCPPaths(func() (string, error) { return statePath, nil }, groupsFn, loadFn); got != nil {
+		t.Errorf("corrupt install.json should yield nil; got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_DeliberateOptOutSubtracted is the safety
+// property at the install layer: a group config that explicitly enables only
+// cursor is a deliberate "claude off", so claude's recorded path must NOT be
+// handed to the wizard as a reason to re-check it.
+func TestPreviouslyRegisteredMCPPaths_DeliberateOptOutSubtracted(t *testing.T) {
+	home := isolatePrevHome(t)
+	claudeJSON := filepath.Join(home, ".claude.json")
+	cursorJSON := filepath.Join(home, ".cursor", "mcp.json")
+	statePathFn := writePrevState(t, home, []string{claudeJSON, cursorJSON})
+
+	groupsFn, loadFn := fakeGroups(&registry.GroupConfig{Name: "g", Tools: []string{"cursor"}})
+
+	got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn)
+	if got[claudeJSON] {
+		t.Errorf("claude is explicitly disabled in the group config — its recorded path must be subtracted; got %v", got)
+	}
+	if !got[cursorJSON] {
+		t.Errorf("cursor is still enabled — its recorded path must survive; got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_ClaudeSidecarSubtracted verifies the
+// subtraction covers every path family step 3 registers a tool at, not just
+// the canonical one: a ~/.claude-personal profile must be dropped too when
+// claude is disabled.
+func TestPreviouslyRegisteredMCPPaths_ClaudeSidecarSubtracted(t *testing.T) {
+	home := isolatePrevHome(t)
+	sidecarDir := filepath.Join(home, ".claude-personal")
+	if err := os.MkdirAll(sidecarDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(sidecarDir, ".claude.json")
+	if err := os.WriteFile(sidecar, []byte(`{"mcpServers":{}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	statePathFn := writePrevState(t, home, []string{sidecar})
+
+	groupsFn, loadFn := fakeGroups(&registry.GroupConfig{Name: "g", Tools: []string{"cursor"}})
+
+	if got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn); got[sidecar] {
+		t.Errorf("the sidecar Claude profile must be subtracted with claude disabled; got %v", got)
+	}
+}
+
+// TestPreviouslyRegisteredMCPPaths_EmptyToolsIsNotAnOptOut verifies the
+// empty-means-all contract: a group with no explicit Tools selection disables
+// nothing, so the recorded paths pass through.
+func TestPreviouslyRegisteredMCPPaths_EmptyToolsIsNotAnOptOut(t *testing.T) {
+	home := isolatePrevHome(t)
+	claudeJSON := filepath.Join(home, ".claude.json")
+	statePathFn := writePrevState(t, home, []string{claudeJSON})
+
+	groupsFn, loadFn := fakeGroups(&registry.GroupConfig{Name: "g"}) // Tools nil = all
+
+	if got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn); !got[claudeJSON] {
+		t.Errorf("an empty Tools list means ALL tools, not an opt-out; got %v", got)
+	}
+}
+
+// TestDeliberatelyDisabledMCPTools_NoGroupsIsNoSignal verifies absence of
+// evidence is not an opt-out: with no groups registered nothing is reported
+// disabled, so a fresh machine's recorded paths are never subtracted away.
+func TestDeliberatelyDisabledMCPTools_NoGroupsIsNoSignal(t *testing.T) {
+	groupsFn, loadFn := noGroups()
+	if got := deliberatelyDisabledMCPTools(groupsFn, loadFn); len(got) != 0 {
+		t.Errorf("no groups must yield no disabled tools; got %v", got)
+	}
+}

--- a/internal/install/mcpprev_test.go
+++ b/internal/install/mcpprev_test.go
@@ -179,6 +179,38 @@ func TestPreviouslyRegisteredMCPPaths_UnreadableGroupFailsClosed(t *testing.T) {
 	}
 }
 
+// TestPreviouslyRegisteredMCPPaths_PartialGroupReadFailsClosed is the test that
+// actually discriminates. In the single-group case above, skipping the
+// unreadable config and failing closed both end at nil (an empty enabled set
+// marks every tool disabled, subtracting everything anyway) — so that test
+// alone does NOT pin the contract.
+//
+// Here one group loads and enables claude while a second will not load.
+// Skipping the failure would leave claude's path in play on a partial read;
+// failing closed offers nothing until the picture is complete.
+func TestPreviouslyRegisteredMCPPaths_PartialGroupReadFailsClosed(t *testing.T) {
+	home := isolatePrevHome(t)
+	claudeJSON := filepath.Join(home, ".claude.json")
+	statePathFn := writePrevState(t, home, []string{claudeJSON})
+
+	groupsFn := func() ([]registry.GroupRef, error) {
+		return []registry.GroupRef{
+			{Name: "ok", ConfigPath: "/fake/ok.json"},
+			{Name: "broken", ConfigPath: "/fake/broken.json"},
+		}, nil
+	}
+	loadFn := func(path string) (*registry.GroupConfig, error) {
+		if path == "/fake/ok.json" {
+			return &registry.GroupConfig{Name: "ok", Tools: []string{"claude"}}, nil
+		}
+		return nil, errors.New("permission denied")
+	}
+
+	if got := previouslyRegisteredMCPPaths(statePathFn, groupsFn, loadFn); got != nil {
+		t.Errorf("one unreadable group among several must yield NO paths (fail closed), not a verdict from the readable subset; got %v", got)
+	}
+}
+
 // TestPreviouslyRegisteredMCPPaths_RegistryErrorFailsClosed is the same
 // property one level up: an unreadable registry is not evidence that nothing
 // is disabled.

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -131,7 +131,17 @@ func Detect() []Tool {
 // but a temp $HOME, and reading the state would drag internal/install and
 // internal/registry into that. Callers use install.PreviouslyRegisteredMCPPaths().
 func DetectWithPrevious(prev map[string]bool) []Tool {
-	last, _ := ReadLastChoice() // best-effort; nil when no prior choice
+	last, err := ReadLastChoice()
+	if err != nil {
+		// The file could not be READ (permissions, I/O). It may well record an
+		// opt-out, so it must not be mistaken for "no choice was ever made" —
+		// that is the one input the B2 bound trusts. Substitute an empty
+		// non-nil set: B2 is suppressed and (C) names nothing, so the (B)
+		// default decides, exactly as before #6170. Same rule as
+		// install.PreviouslyRegisteredMCPPaths: an unreadable config is not
+		// evidence of absence.
+		last = map[string]bool{}
+	}
 	return detectWith(last, prev)
 }
 
@@ -140,8 +150,11 @@ func DetectWithPrevious(prev map[string]bool) []Tool {
 // (possibly nil) is the set of config paths a previous install recorded a
 // grafel registration at.
 //
-// B2 is bounded to the case where lastChoice is nil, and that bound is the
-// safety property. It cannot be carried by precedence within the expression,
+// B2 is bounded to the case where lastChoice is nil, and that bound is THE
+// carrier of the safety property for this fix (install.PreviouslyRegisteredMCPPaths'
+// opt-out subtraction is a second, narrower layer beneath it).
+//
+// The bound cannot be carried by precedence within the expression,
 // because (C) cannot express "off": ReadLastChoice builds its set only from
 // the file's `selected` list, so every value it can yield is true and an
 // opted-out tool is merely ABSENT from the map — the `def = sel` branch below
@@ -261,8 +274,13 @@ func LastChoicePath() (string, error) {
 	return filepath.Join(home, ".grafel", "mcp-tools.json"), nil
 }
 
-// ReadLastChoice loads the remembered selection as a set of tool IDs. Returns
-// (nil, nil) when no choice has been saved yet (the common first-run case).
+// ReadLastChoice loads the remembered selection as a set of tool IDs.
+//
+// nil is returned ONLY when no choice has been saved — the file does not
+// exist. That distinction is load-bearing: detectWith keys the B2 bound on it,
+// so every other outcome (an empty selection, a corrupt document) must return
+// a non-nil map, and a read error must be surfaced so the caller can do the
+// same. Do not collapse any of those to nil.
 func ReadLastChoice() (map[string]bool, error) {
 	path, err := LastChoicePath()
 	if err != nil {
@@ -277,8 +295,13 @@ func ReadLastChoice() (map[string]bool, error) {
 	}
 	var doc lastChoiceFile
 	if err := json.Unmarshal(b, &doc); err != nil {
-		// A corrupt file must not break the wizard — treat as "no choice".
-		return nil, nil
+		// A corrupt file must not break the wizard, but it is NOT "no choice":
+		// the file exists, so a choice was recorded — we just cannot read which
+		// tools it named. Yield a NON-NIL empty set, keeping it distinguishable
+		// from the genuine no-file case (nil) that the B2 bound keys on. Named
+		// nothing means the (C) override does nothing, so the (B) default
+		// decides — unchanged behaviour, minus the fail-open.
+		return map[string]bool{}, nil
 	}
 	set := make(map[string]bool, len(doc.Selected))
 	for _, id := range doc.Selected {

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -13,20 +13,32 @@
 //
 //   - (B) smart default: a tool is checked when its config was modified
 //     recently (within RecentWindow) OR it already contains a grafel entry
-//     (previously configured) OR a previous install RECORDED registering
-//     grafel at that config path (B2, #6170 — see DetectWithPrevious).
-//     Clearly-stale tools are unchecked but stay visible so the user can
-//     re-check them.
+//     (previously configured). Clearly-stale tools are unchecked but stay
+//     visible so the user can re-check them.
 //
-//     B2 exists because both other terms are erased by the very accident it
-//     guards: something deletes the grafel entry (the #6168 rollback being the
-//     demonstrated way), so hasGrafel goes false, and if the file is also
-//     older than RecentWindow the tool arrives UNCHECKED — from which a
-//     press-enter run persists the accident as the user's preference.
+//   - (B2) previously registered (#6170): also checked when a previous install
+//     RECORDED registering grafel at that config path — but ONLY while no
+//     choice has been recorded at all. See DetectWithPrevious / detectWith.
+//
+//     B2 exists because both (B) terms are erased by the same accident:
+//     something deletes the grafel entry (the #6168 rollback being the
+//     demonstrated way) so hasGrafel goes false, and if the file is then left
+//     untouched past RecentWindow the tool arrives UNCHECKED — so that run
+//     silently fails to (re-)register grafel's MCP for a tool the user has.
+//
+//     Its coverage is PARTIAL, inherently: only RunCopy/RunDev record into
+//     state.MCP.RegisteredPaths, and only the Claude and Windsurf config
+//     paths. install.Apply registers MCP for every enabled adapter but
+//     persists nothing, so for Cursor, Codex, Kiro and Antigravity B2 is a
+//     permanent no-op and the (B) default stands alone.
 //
 //   - (C) remember last choice: the user's selection is persisted to
-//     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default
-//     (C overrides B once a choice has been made).
+//     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default.
+//
+//     NOTE the asymmetry, which detectWith depends on: the file stores only
+//     the SELECTED ids, so (C) can force a tool ON but never OFF — a tool the
+//     user unchecked is simply ABSENT from it, and (B) re-decides. "C
+//     overrides B" holds in one direction only.
 package mcptools
 
 import (
@@ -110,29 +122,43 @@ func Detect() []Tool {
 
 // DetectWithPrevious is Detect plus the durable (B2) "grafel was registered
 // here before" signal: prev is a set of MCP host config PATHS a previous
-// grafel install recorded (install.json's state.MCP.RegisteredPaths).
+// grafel install recorded (install.json's state.MCP.RegisteredPaths). It is
+// consulted ONLY when no last choice has been recorded — see detectWith.
 //
-// The set is INJECTED rather than read here on purpose. install.json is
-// internal/install's file and reading it needs internal/install (and, for the
-// deliberate-opt-out subtraction, internal/registry); mcptools deliberately
-// depends only on mcpreg + tooladapter so it stays cheap and trivially
-// testable. Callers use install.PreviouslyRegisteredMCPPaths().
+// The set is INJECTED rather than read here for layering, not for a cycle:
+// internal/install does not import mcptools, so reading install.json here
+// would compile. It is still the wrong shape — mcptools' tests need nothing
+// but a temp $HOME, and reading the state would drag internal/install and
+// internal/registry into that. Callers use install.PreviouslyRegisteredMCPPaths().
 func DetectWithPrevious(prev map[string]bool) []Tool {
 	last, _ := ReadLastChoice() // best-effort; nil when no prior choice
 	return detectWith(last, prev)
 }
 
-// detectWith is the testable core of Detect: lastChoice (possibly nil) is the
-// remembered selection set; prevRegistered (possibly nil) is the set of config
-// paths a previous install recorded a grafel registration at.
+// detectWith is the testable core of Detect: lastChoice is the remembered
+// selection set, nil ONLY when no choice has ever been recorded; prevRegistered
+// (possibly nil) is the set of config paths a previous install recorded a
+// grafel registration at.
 //
-// Precedence is deliberate: B2 composes UNDER (C), never over it. A user who
-// deliberately opted a tool out is named in lastChoice and stays unchecked no
-// matter what install.json remembers — only the ACCIDENTAL unchecking is
-// repaired.
+// B2 is bounded to the case where lastChoice is nil, and that bound is the
+// safety property. It cannot be carried by precedence within the expression,
+// because (C) cannot express "off": ReadLastChoice builds its set only from
+// the file's `selected` list, so every value it can yield is true and an
+// opted-out tool is merely ABSENT from the map — the `def = sel` branch below
+// can only ever set def=true. Composing B2 under a (C) that can only say "on"
+// would let the install.json record re-check a box the user cleared, which is
+// a REGRESSION on today's behaviour, not a repair.
+//
+// So: a recorded choice — any recorded choice, including "none" — owns the
+// default, and B2 applies only while none exists. It repairs a fresh accident
+// and never overrules a decision.
 func detectWith(lastChoice, prevRegistered map[string]bool) []Tool {
 	now := nowFunc()
-	prev := cleanPathSet(prevRegistered)
+	// A recorded choice suppresses B2 entirely (see above).
+	var prev map[string]bool
+	if lastChoice == nil {
+		prev = cleanPathSet(prevRegistered)
+	}
 	var out []Tool
 	for _, a := range mcpAdapters() {
 		path, err := mcpreg.SettingsPath(a.tool)
@@ -148,7 +174,8 @@ func detectWith(lastChoice, prevRegistered map[string]bool) []Tool {
 		recent := fileExists && now.Sub(mtime) <= RecentWindow
 		// (B2) grafel registered itself at this exact config path on a previous
 		// install, per install.json. Unlike hasGrafel this SURVIVES the entry
-		// being deleted, which is the whole point (#6170).
+		// being deleted, which is the whole point (#6170). prev is nil whenever
+		// a choice has been recorded, so this is false there.
 		previouslyRegistered := prev[filepath.Clean(path)]
 
 		// (B) smart default.

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -276,10 +276,14 @@ func LastChoicePath() (string, error) {
 
 // ReadLastChoice loads the remembered selection as a set of tool IDs.
 //
-// nil is returned ONLY when no choice has been saved — the file does not
-// exist. That distinction is load-bearing: detectWith keys the B2 bound on it,
-// so every other outcome (an empty selection, a corrupt document) must return
-// a non-nil map, and a read error must be surfaced so the caller can do the
+// nil WITH NO ERROR is returned ONLY when no choice has been saved — the file
+// does not exist. nil WITH an error is a different thing entirely: the file
+// could not be read, and DetectWithPrevious substitutes an empty non-nil set
+// there.
+//
+// That distinction is load-bearing: detectWith keys the B2 bound on it, so
+// every other outcome (an empty selection, a corrupt document) must return a
+// non-nil map, and a read error must be surfaced so the caller can do the
 // same. Do not collapse any of those to nil.
 func ReadLastChoice() (map[string]bool, error) {
 	path, err := LastChoicePath()

--- a/internal/install/mcptools/mcptools.go
+++ b/internal/install/mcptools/mcptools.go
@@ -13,8 +13,17 @@
 //
 //   - (B) smart default: a tool is checked when its config was modified
 //     recently (within RecentWindow) OR it already contains a grafel entry
-//     (previously configured). Clearly-stale tools are unchecked but stay
-//     visible so the user can re-check them.
+//     (previously configured) OR a previous install RECORDED registering
+//     grafel at that config path (B2, #6170 — see DetectWithPrevious).
+//     Clearly-stale tools are unchecked but stay visible so the user can
+//     re-check them.
+//
+//     B2 exists because both other terms are erased by the very accident it
+//     guards: something deletes the grafel entry (the #6168 rollback being the
+//     demonstrated way), so hasGrafel goes false, and if the file is also
+//     older than RecentWindow the tool arrives UNCHECKED — from which a
+//     press-enter run persists the accident as the user's preference.
+//
 //   - (C) remember last choice: the user's selection is persisted to
 //     ~/.grafel/mcp-tools.json and, on subsequent runs, becomes the default
 //     (C overrides B once a choice has been made).
@@ -96,14 +105,34 @@ var nowFunc = time.Now
 // Detect never errors on individual tools — an unreadable config simply yields
 // HasGrafel=false / a zero mtime.
 func Detect() []Tool {
+	return DetectWithPrevious(nil)
+}
+
+// DetectWithPrevious is Detect plus the durable (B2) "grafel was registered
+// here before" signal: prev is a set of MCP host config PATHS a previous
+// grafel install recorded (install.json's state.MCP.RegisteredPaths).
+//
+// The set is INJECTED rather than read here on purpose. install.json is
+// internal/install's file and reading it needs internal/install (and, for the
+// deliberate-opt-out subtraction, internal/registry); mcptools deliberately
+// depends only on mcpreg + tooladapter so it stays cheap and trivially
+// testable. Callers use install.PreviouslyRegisteredMCPPaths().
+func DetectWithPrevious(prev map[string]bool) []Tool {
 	last, _ := ReadLastChoice() // best-effort; nil when no prior choice
-	return detectWith(last)
+	return detectWith(last, prev)
 }
 
 // detectWith is the testable core of Detect: lastChoice (possibly nil) is the
-// remembered selection set.
-func detectWith(lastChoice map[string]bool) []Tool {
+// remembered selection set; prevRegistered (possibly nil) is the set of config
+// paths a previous install recorded a grafel registration at.
+//
+// Precedence is deliberate: B2 composes UNDER (C), never over it. A user who
+// deliberately opted a tool out is named in lastChoice and stays unchecked no
+// matter what install.json remembers — only the ACCIDENTAL unchecking is
+// repaired.
+func detectWith(lastChoice, prevRegistered map[string]bool) []Tool {
 	now := nowFunc()
+	prev := cleanPathSet(prevRegistered)
 	var out []Tool
 	for _, a := range mcpAdapters() {
 		path, err := mcpreg.SettingsPath(a.tool)
@@ -117,9 +146,13 @@ func detectWith(lastChoice map[string]bool) []Tool {
 		}
 		hasGrafel := mcpreg.HasGrafelEntry(path)
 		recent := fileExists && now.Sub(mtime) <= RecentWindow
+		// (B2) grafel registered itself at this exact config path on a previous
+		// install, per install.json. Unlike hasGrafel this SURVIVES the entry
+		// being deleted, which is the whole point (#6170).
+		previouslyRegistered := prev[filepath.Clean(path)]
 
 		// (B) smart default.
-		def := recent || hasGrafel
+		def := recent || hasGrafel || previouslyRegistered
 		// (C) remembered choice overrides B for tools it names.
 		if lastChoice != nil {
 			if sel, ok := lastChoice[a.id]; ok {
@@ -136,6 +169,23 @@ func detectWith(lastChoice map[string]bool) []Tool {
 			LastModified:    mtime,
 			DefaultSelected: def,
 		})
+	}
+	return out
+}
+
+// cleanPathSet normalises a set of file paths so lookups are not defeated by a
+// trailing separator or an unnormalised "." component in what install.json
+// happens to record. Returns nil for a nil/empty input (lookups on a nil map
+// are legal and always false).
+func cleanPathSet(in map[string]bool) map[string]bool {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]bool, len(in))
+	for p, v := range in {
+		if v && p != "" {
+			out[filepath.Clean(p)] = true
+		}
 	}
 	return out
 }

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/install/mcpreg"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // setupHome points HOME at a temp dir so detection reads only files we create,
@@ -16,11 +17,17 @@ func setupHome(t *testing.T) string {
 	t.Helper()
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	// USERPROFILE too: os.UserHomeDir reads it on Windows, and mcpreg's
+	// SettingsPath falls back to os.UserHomeDir when HOME is unset.
+	t.Setenv("USERPROFILE", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 	// GRAFEL_HOME too: nothing in this package resolves it today, but leaving
 	// it pointed at the developer's real ~/.grafel is exactly how the two
 	// sandbox escapes this cycle happened.
 	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+	// Fail fast if any of that failed to take effect: these tests WRITE
+	// ~/.grafel/mcp-tools.json via SaveLastChoice.
+	testsupport.GuardRealHome(t)
 	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
 	nowFunc = func() time.Time { return now }
 	t.Cleanup(func() { nowFunc = time.Now })
@@ -246,25 +253,54 @@ func TestPreviouslyRegistered_EmptyOrNilIsInert(t *testing.T) {
 	}
 }
 
-// TestPreviouslyRegistered_DeliberateOptOutStillWins is THE safety property:
-// the (C) remembered choice overrides the new (B2) term exactly as it
-// overrides (B). A user who genuinely wants grafel's MCP off must not be
-// re-checked by the durable registration record.
-func TestPreviouslyRegistered_DeliberateOptOutStillWins(t *testing.T) {
+// TestPreviouslyRegistered_OptOutViaRealRoundTrip is THE safety property, and
+// it is asserted through the ONLY API that can record an opt-out in
+// production: SaveLastChoice writes the file, DetectWithPrevious reads it back.
+//
+// A hand-built map{"claude": false} would certify nothing — ReadLastChoice
+// builds its set only from `selected`, so every value it yields is true and an
+// opted-out tool is merely ABSENT. The recorded decision has to be honoured on
+// the strength of that absence alone.
+func TestPreviouslyRegistered_OptOutViaRealRoundTrip(t *testing.T) {
 	setupHome(t)
 	path := staleClaudeNoEntry(t)
-
-	// Deliberate opt-out for claude, and a RECENT cursor config so the same
-	// override is exercised against (B) too.
 	writeConfig(t, mcpreg.Cursor, false, nowFunc())
-	last := map[string]bool{"claude": false, "cursor": false}
 
-	tools := detectWith(last, map[string]bool{path: true})
-	if c := find(t, tools, "claude"); c.DefaultSelected {
-		t.Errorf("claude opted out (C) must stay UNCHECKED despite the previously-registered record; got %+v", c)
+	// The user unchecked claude and kept cursor. This is exactly what the
+	// dashboard wizard persists via registerWizardMCP → SaveLastChoice.
+	if err := SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
 	}
-	if c := find(t, tools, "cursor"); c.DefaultSelected {
-		t.Errorf("cursor opted out (C) must stay UNCHECKED despite a recent config (B); got %+v", c)
+
+	tools := DetectWithPrevious(map[string]bool{path: true})
+	if c := find(t, tools, "claude"); c.DefaultSelected {
+		t.Errorf("claude was deliberately unchecked and the choice was SAVED; the install.json record must not re-check it. got %+v", c)
+	}
+	if c := find(t, tools, "cursor"); !c.DefaultSelected {
+		t.Errorf("cursor was chosen and saved; it must stay checked. got %+v", c)
+	}
+}
+
+// TestPreviouslyRegistered_SuppressedByAnyRecordedChoice pins the bound on B2:
+// it repairs an accident only while NO choice has been recorded. Once a
+// last-choice file exists — even one that says "none" — the recorded decision
+// owns the default and the durable registration record is inert.
+func TestPreviouslyRegistered_SuppressedByAnyRecordedChoice(t *testing.T) {
+	setupHome(t)
+	path := staleClaudeNoEntry(t)
+	prev := map[string]bool{path: true}
+
+	// No file yet → B2 repairs.
+	if c := find(t, DetectWithPrevious(prev), "claude"); !c.DefaultSelected {
+		t.Fatalf("precondition: with no recorded choice B2 must check claude; got %+v", c)
+	}
+
+	// The user chose "none" — an explicit decision, not an accident.
+	if err := SaveLastChoice([]string{}); err != nil {
+		t.Fatalf("SaveLastChoice(none): %v", err)
+	}
+	if c := find(t, DetectWithPrevious(prev), "claude"); c.DefaultSelected {
+		t.Errorf("a recorded choice of NONE must suppress B2; got %+v", c)
 	}
 }
 

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -17,6 +17,10 @@ func setupHome(t *testing.T) string {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	// GRAFEL_HOME too: nothing in this package resolves it today, but leaving
+	// it pointed at the developer's real ~/.grafel is exactly how the two
+	// sandbox escapes this cycle happened.
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
 	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
 	nowFunc = func() time.Time { return now }
 	t.Cleanup(func() { nowFunc = time.Now })
@@ -84,7 +88,7 @@ func TestSmartDefault_B(t *testing.T) {
 	// windsurf: stale, no grafel → unchecked.
 	writeConfig(t, mcpreg.Windsurf, false, now.Add(-90*24*time.Hour))
 
-	tools := detectWith(nil)
+	tools := detectWith(nil, nil)
 
 	if c := find(t, tools, "claude"); !c.DefaultSelected {
 		t.Error("claude (recent) should be default-checked")
@@ -109,7 +113,7 @@ func TestRememberedChoice_C(t *testing.T) {
 
 	// Remembered choice: cursor IN, claude OUT — the inverse of B.
 	last := map[string]bool{"cursor": true, "claude": false}
-	tools := detectWith(last)
+	tools := detectWith(last, nil)
 
 	if c := find(t, tools, "claude"); c.DefaultSelected {
 		t.Error("claude should be UNchecked: remembered choice (C) overrides recent (B)")
@@ -126,7 +130,7 @@ func TestDetect_OnlyDetectedTools(t *testing.T) {
 	writeConfig(t, mcpreg.ClaudeCode, false, nowFunc())
 	// Nothing for cursor/windsurf/etc.
 
-	tools := detectWith(nil)
+	tools := detectWith(nil, nil)
 	if got := ids(tools); len(got) != 1 || got[0] != "claude" {
 		t.Errorf("detected = %v, want only [claude]", got)
 	}
@@ -167,6 +171,116 @@ func TestLastChoice_RoundTrip(t *testing.T) {
 	}
 	if set == nil || len(set) != 0 {
 		t.Errorf("empty choice round-trip = %v, want non-nil empty set", set)
+	}
+}
+
+// ── (#6170) the durable previously-registered signal ────────────────────────
+
+// staleClaudeNoEntry lays down the ratchet fixture: a Claude config that is
+// OLDER than RecentWindow and carries NO grafel entry — i.e. the entry was
+// removed (the #6168 rollback being the demonstrated way) and the file has not
+// been touched since. Returns its path.
+func staleClaudeNoEntry(t *testing.T) string {
+	t.Helper()
+	return writeConfig(t, mcpreg.ClaudeCode, false, nowFunc().Add(-90*24*time.Hour))
+}
+
+// TestRatchet_StaleConfigWithLostEntryIsUnchecked pins the BUG: with the entry
+// gone, a stale config and no remembered choice, Claude Code arrives in the
+// wizard UNCHECKED — the state from which a press-enter run persists the
+// removal as the user's preference (#6170). This is the "before" half; the
+// repair is TestPreviouslyRegistered_RepairsRatchet.
+func TestRatchet_StaleConfigWithLostEntryIsUnchecked(t *testing.T) {
+	setupHome(t)
+	staleClaudeNoEntry(t)
+
+	if c := find(t, detectWith(nil, nil), "claude"); c.DefaultSelected {
+		t.Error("without the previously-registered signal, claude is expected to be unchecked here (that IS the ratchet)")
+	}
+}
+
+// TestPreviouslyRegistered_RepairsRatchet is the fix: install.json still
+// records that grafel registered itself at that exact config path, so the
+// wizard must arrive CHECKED even though the entry is gone and the file is
+// stale.
+func TestPreviouslyRegistered_RepairsRatchet(t *testing.T) {
+	setupHome(t)
+	path := staleClaudeNoEntry(t)
+
+	tools := detectWith(nil, map[string]bool{path: true})
+	if c := find(t, tools, "claude"); !c.DefaultSelected {
+		t.Errorf("claude must be default-checked: install.json records grafel was registered at %s; got %+v", path, c)
+	}
+}
+
+// TestPreviouslyRegistered_UnrelatedPathDoesNotCheck verifies the signal is
+// keyed on the tool's OWN config path — a recorded path belonging to some
+// other host must not check this tool.
+func TestPreviouslyRegistered_UnrelatedPathDoesNotCheck(t *testing.T) {
+	setupHome(t)
+	staleClaudeNoEntry(t)
+	// A stale cursor config too, so cursor is detected but unchecked by B.
+	writeConfig(t, mcpreg.Cursor, false, nowFunc().Add(-90*24*time.Hour))
+
+	claudePath, _ := mcpreg.SettingsPath(mcpreg.ClaudeCode)
+	tools := detectWith(nil, map[string]bool{claudePath: true})
+
+	if c := find(t, tools, "cursor"); c.DefaultSelected {
+		t.Errorf("cursor must stay unchecked: only claude's path is recorded; got %+v", c)
+	}
+}
+
+// TestPreviouslyRegistered_EmptyOrNilIsInert verifies an absent/empty recorded
+// set changes nothing — the (B) default stands on its own.
+func TestPreviouslyRegistered_EmptyOrNilIsInert(t *testing.T) {
+	setupHome(t)
+	staleClaudeNoEntry(t)
+
+	for name, prev := range map[string]map[string]bool{
+		"nil":   nil,
+		"empty": {},
+	} {
+		if c := find(t, detectWith(nil, prev), "claude"); c.DefaultSelected {
+			t.Errorf("prev=%s: claude should be unchecked (B alone); got %+v", name, c)
+		}
+	}
+}
+
+// TestPreviouslyRegistered_DeliberateOptOutStillWins is THE safety property:
+// the (C) remembered choice overrides the new (B2) term exactly as it
+// overrides (B). A user who genuinely wants grafel's MCP off must not be
+// re-checked by the durable registration record.
+func TestPreviouslyRegistered_DeliberateOptOutStillWins(t *testing.T) {
+	setupHome(t)
+	path := staleClaudeNoEntry(t)
+
+	// Deliberate opt-out for claude, and a RECENT cursor config so the same
+	// override is exercised against (B) too.
+	writeConfig(t, mcpreg.Cursor, false, nowFunc())
+	last := map[string]bool{"claude": false, "cursor": false}
+
+	tools := detectWith(last, map[string]bool{path: true})
+	if c := find(t, tools, "claude"); c.DefaultSelected {
+		t.Errorf("claude opted out (C) must stay UNCHECKED despite the previously-registered record; got %+v", c)
+	}
+	if c := find(t, tools, "cursor"); c.DefaultSelected {
+		t.Errorf("cursor opted out (C) must stay UNCHECKED despite a recent config (B); got %+v", c)
+	}
+}
+
+// TestDetectWithPrevious_ReadsLastChoice verifies the exported wrapper still
+// consults the on-disk (C) choice, so the override is not bypassed by callers
+// that supply a previously-registered set.
+func TestDetectWithPrevious_ReadsLastChoice(t *testing.T) {
+	setupHome(t)
+	// Stale cursor, no grafel entry → B unchecks it; the saved choice checks it.
+	writeConfig(t, mcpreg.Cursor, false, nowFunc().Add(-365*24*time.Hour))
+	if err := SaveLastChoice([]string{"cursor"}); err != nil {
+		t.Fatalf("SaveLastChoice: %v", err)
+	}
+
+	if c := find(t, DetectWithPrevious(nil), "cursor"); !c.DefaultSelected {
+		t.Errorf("DetectWithPrevious must honour the saved (C) choice; got %+v", c)
 	}
 }
 

--- a/internal/install/mcptools/mcptools_test.go
+++ b/internal/install/mcptools/mcptools_test.go
@@ -304,6 +304,74 @@ func TestPreviouslyRegistered_SuppressedByAnyRecordedChoice(t *testing.T) {
 	}
 }
 
+// writeRawLastChoice writes arbitrary bytes to ~/.grafel/mcp-tools.json,
+// bypassing SaveLastChoice, so a malformed document can be staged.
+func writeRawLastChoice(t *testing.T, content []byte, mode os.FileMode) string {
+	t.Helper()
+	path, err := LastChoicePath()
+	if err != nil {
+		t.Fatalf("LastChoicePath: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, mode); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) }) // so TempDir cleanup can unlink
+	return path
+}
+
+// TestPreviouslyRegistered_MalformedChoiceFileSuppressesB2 closes the bound's
+// fail-open leak: B2's whole premise is that a nil lastChoice faithfully means
+// "no choice was ever recorded". A file that EXISTS but cannot be parsed or
+// read is evidence a choice WAS recorded — the same rule mcpprev.go already
+// applies to an unreadable group config. Treating it as first-run would let B2
+// re-check a box the user cleared, which is the very regression the bound was
+// introduced to prevent.
+func TestPreviouslyRegistered_MalformedChoiceFileSuppressesB2(t *testing.T) {
+	cases := map[string]struct {
+		content []byte
+		mode    os.FileMode
+	}{
+		"truncated JSON": {[]byte(`{"selected":["curs`), 0o600},
+		"zero bytes":     {[]byte(``), 0o600},
+		"unreadable":     {[]byte(`{"selected":["cursor"]}`), 0o000},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			setupHome(t)
+			path := staleClaudeNoEntry(t)
+			writeRawLastChoice(t, tc.content, tc.mode)
+
+			tools := DetectWithPrevious(map[string]bool{path: true})
+			if c := find(t, tools, "claude"); c.DefaultSelected {
+				t.Errorf("a %s choice file must suppress B2 — the file existing is evidence a choice was recorded; got %+v", name, c)
+			}
+		})
+	}
+}
+
+// TestReadLastChoice_CorruptIsARecordedChoice pins the representation the bound
+// depends on: a corrupt document yields a NON-NIL empty set, so it is
+// distinguishable from the genuine no-file case (nil). Both still leave the
+// (C) override naming nothing, so the (B) default is unchanged.
+func TestReadLastChoice_CorruptIsARecordedChoice(t *testing.T) {
+	setupHome(t)
+	writeRawLastChoice(t, []byte(`{not json`), 0o600)
+
+	set, err := ReadLastChoice()
+	if err != nil {
+		t.Fatalf("a corrupt file must not error out of the wizard: %v", err)
+	}
+	if set == nil {
+		t.Error("corrupt file must yield a NON-NIL empty set (a choice exists but is unreadable), not nil (no choice)")
+	}
+	if len(set) != 0 {
+		t.Errorf("corrupt file must name no tools; got %v", set)
+	}
+}
+
 // TestDetectWithPrevious_ReadsLastChoice verifies the exported wrapper still
 // consults the on-disk (C) choice, so the override is not bypassed by callers
 // that supply a previously-registered set.


### PR DESCRIPTION
After a lost MCP registration — #6168's rollback being the demonstrated cause — the dashboard wizard shows the tool **unchecked**, so that run silently fails to re-register grafel's MCP.

The pre-check default was `def := recent || hasGrafel`. Both terms are erased by the accident itself: delete the `grafel` entry and `hasGrafel` is false; leave the config untouched past `RecentWindow` and `recent` is false. Nothing in the expression remembers grafel was ever there.

Fix: a third, durable term. `install.json`'s `state.MCP.RegisteredPaths` survives entry deletion, so `def := recent || hasGrafel || previouslyRegistered`.

## Two corrections to the issue as filed

**The issue's mechanism does not exist.** It claimed the accidental uncheck is persisted into `GroupConfig.Tools` via `ApplyToolDelta` → `UnregisterMCP`. That path is real but is **not fed by `def`** — it is reached from `runToolWizard`, which pre-checks from `tooladapter.WizardChoices(nil)` → `DetectInstalled()` (the config file merely existing). Deleting the MCP entry does not delete `~/.claude.json`, so the tool stays **pre-checked** there. The only consumer of `DefaultSelected` is `GET /api/v2/mcp-tools/detect`; the second `mcptools.Detect()` in the dashboard reads only `t.ID`.

**And the `def`-fed path has no permanence either**, because the last-choice file cannot express "off" (below). So **nothing ratchets.** The issue was rescoped to the single-run failure, and this fix is sized to that.

## The safety property could not rest where it was assumed to

The requirement: *a deliberate opt-out must still win.* That was assumed to be carried by the (C) last-choice override. It cannot be — `ReadLastChoice` builds its set only from `Selected`, so an unchecked tool is **absent** from the map and `if sel, ok := lastChoice[id]; ok` falls through to (B). **The override can force-check; it can never force-uncheck.** Two existing tests assert otherwise using a hand-built `map[string]bool{"claude": false}`, a value `ReadLastChoice` never produces — tests certifying a state the system cannot reach.

A first attempt therefore **regressed the property it was written to protect**. Driven through the only API that can produce an opt-out in production (`SaveLastChoice` → `DetectWithPrevious`):

```
ReadLastChoice()["claude"] = (false, ok=false)   full=map[cursor:true]
SAFETY VIOLATION: ... DefaultSelected:true
--- FAIL: TestProbe_OptOutViaRealRoundTrip
--- PASS: TestProbe_PreFixBaseline
```

Pre-fix the opt-out held; post-fix B2 overrode it. The subtraction built to carry the property instead (subtract paths belonging to tools no group config enables) was **structurally inert at the only call site**: the dashboard's `CreateGroup` never writes `cfg.Tools`, so `EnabledTools` returns everything and nothing is ever subtracted.

## The remedy: bound, not ordered

B2 now applies **only while `lastChoice == nil`** — no recorded choice of any kind. Any recorded choice, including "none" (an empty non-nil map), owns the default and makes the durable record inert. Ordering within the expression no longer carries meaning, which is the point: **the property no longer depends on a precedence the file format cannot back.**

The alternative — making absence mean "off" — was rejected. Every existing `mcp-tools.json` was written under absence-means-fall-back-to-B, so reinterpreting them converts historical non-selections into opt-outs on upgrade. Concretely, a file holding `{"selected":["claude"]}` would retroactively become a deliberate opt-out for Cursor, Codex, Kiro, Windsurf **and** Antigravity — five decisions the user never made, on every machine holding the file. That is this issue's own defect pointed the other way, with a far larger blast radius, and it needs a schema version plus a migration. Tracked as #6191.

## The bound leaked, in the direction the sibling file already guards against

Review found the bound rests on `nil` faithfully meaning "no file" — true for every well-formed document, false for three malformed ones:

| on-disk state | B2 fires? | |
|---|---|---|
| missing file | yes | ✅ by design |
| `{"selected":[]}` / `{"selected":null}` / `{}` | no | ✅ |
| truncated JSON / zero bytes / unreadable `0o000` | **yes** | ❌ |

A user who deliberately unchecked a tool, whose file is later zero-byted by an unclean shutdown or made unreadable by a permissions repair, was treated as a **first-run user**: B2 fires, the tool is pre-checked, enter re-registers what they turned off.

`mcpprev.go` already states the rule — *"the cost of failing open is a silent override of the user's decision on a transient read error"* — and `mcptools` was breaking it one file over. Fixed: `ReadLastChoice` returns a **non-nil empty map** on parse failure (the file existing *is* the evidence a choice was recorded; we simply cannot read which tools it named), and `DetectWithPrevious` captures the read error instead of discarding it and substitutes the same empty set.

Putting the guard in `DetectWithPrevious` rather than only in the parse branch is the more general fix, and review demonstrated it by adding a row nobody staged — **`EISDIR`**, neither `ErrNotExist` nor a parse failure — which is handled correctly for free. All eight rows now behave.

The invariant is written into `ReadLastChoice`'s contract, since the bound depends on a return-value distinction that reads like an implementation detail: **nil *with no error* means "no file"; nil *with* an error is a different thing entirely.** That comment is the tripwire against a future "simplification" back into the leak, so it says so explicitly rather than delegating to a following sentence a skimmer will not reach.

## Fail-closed on unreadable group configs

The subtraction no longer routes through `resolveEnabledToolBindings`, which collapses a load error into a shorter list — right for doctor's advisory sweep, wrong here, where "nothing disabled" and "cannot tell" are the whole contract.

Mutant `group-load error → continue` initially **survived**: with a single group, skipping the failure leaves an empty enabled set, which marks every tool disabled and subtracts everything — landing on the same `nil` as failing closed. Two behaviours, one observable outcome. Closed by a two-group fixture where they diverge. The `continue` variant is *safe* in the safety direction (it can only under-apply B2), so this was a specification gap rather than a live hole.

## Verification

`go build ./...` 0, `go vet ./...` 0, `gofmt -l .` empty. Unpiped `$?`: `internal/install/mcptools` 0, `internal/install` 0 (26.2s against main's enlarged test set), `internal/dashboard` 0.

Mutants across three rounds, no survivors and one reported equivalent:

- remove the B2 bound (compose under C again) — killed ×3
- gate on `len(lastChoice)==0` instead of `== nil` — killed ("chose none" would stop suppressing B2)
- caller ignores the `ok` flag — killed ×2
- `DetectWithPrevious` drops the recorded choice — killed ×3
- registry error fails open — killed
- group-load error fails open — survived, test hardened, killed
- parse failure → `nil, nil` — killed
- `last, _ := ReadLastChoice()` — killed
- **well-formed empty selection → nil** — killed by `TestLastChoice_RoundTrip` + `_SuppressedByAnyRecordedChoice`; added unprompted after review showed the unconditional `make` was carrying three table rows with nothing proving it

The mutants **partition cleanly**: the parse-failure mutant leaves the `unreadable` subtest passing and vice versa, so the two guards are independently pinned rather than one test masking both. And the nil-reservation invariant is pinned from both ends by a single test — a fresh home must yield nil, a saved empty selection must yield non-nil-empty.

**Equivalent, reported rather than hidden:** applying B2 after the (C) block now survives, because under the bound `prev` is nil whenever `lastChoice != nil` and the (C) block is skipped entirely when it is nil — no execution exists where a (C) assignment and a true `previouslyRegistered` coexist. Ordering is unobservable, so no test pins it; `_SuppressedByAnyRecordedChoice` pins the bound itself instead.

Both safety tests route through `SaveLastChoice` rather than a hand-built map, so they certify a reachable state.

Independently adversarially reviewed three times (REQUEST-CHANGES → REQUEST-CHANGES → APPROVE), with the reviewer re-running its own probes against each revision and verifying `~/.claude.json`, `~/.grafel/mcp-tools.json` and `~/Library/LaunchAgents` byte-identical before and after every run.

## Scope, stated plainly

**B2 fires only where `~/.grafel/mcp-tools.json` does not exist.** Per the #44 comment that is most users, but it means the fix is inert by construction on any machine that has completed a tool wizard. The helped population — never completed a wizard, hit the #6168 rollback, config stale past `RecentWindow` — is small, but it is precisely the #6168 victim cohort this was split out to protect, and it is **disjoint from anyone the bound could harm**.

**And it covers two of six MCP-capable tools.** `RegisteredPaths` is written only by `RunCopy`/`RunDev` step 3, whose targets are the Claude config dirs plus Windsurf. `install.Apply` registers MCP for every enabled adapter (into `res.MCPSettings`) and never persists them, so Cursor, Codex, Kiro and Antigravity have no durable record and B2 is a permanent no-op for them. Documented in the package doc rather than left to read as full coverage.

The subtraction is now belt-and-braces rather than the mechanism: it can only fire for a user with an explicit `GroupConfig.Tools` list **and** no `mcp-tools.json`.

## Also

The dead `WindsurfJetBrains` arm is removed — no adapter returns it — with a note on why. The import-cycle comment is corrected: `go list -deps ./internal/install` shows no mcptools dependency, so there is no cycle; the injected-set design is kept for layering (pushing the registry read into `mcptools` would drag `internal/registry` into a package whose tests need only a temp `$HOME`). `setupHome` gains `USERPROFILE` and `testsupport.GuardRealHome`.

Path matching keys on `filepath.Clean` only — no symlink resolution or case folding — so a miss degrades to the pre-fix default. Fail-safe, but silent; `grafel doctor` already walks `RegisteredPaths` against live configs, which is the right home for a "recorded at X but X has no grafel entry" diagnostic without putting `EvalSymlinks` on every detect.

Closes #6170
Refs #6168, #6191
