### PR TITLE
fix(#6184,#6185,#6186): an untrusted archive's group name wrote outside the config dir; systemd directive injection; a timeout that did not bound

### DIFF
--- a/internal/cli/group_name_order_6186_test.go
+++ b/internal/cli/group_name_order_6186_test.go
@@ -21,6 +21,13 @@ import (
 // to what's being pinned — reuses the readSource/funcBody helpers already
 // established in watchersync_wiring_6179_test.go for exactly this kind of
 // "call X before call Y" invariant.
+//
+// #6186 R1 (found on round-2 review): after the R1 fix these two sites now
+// call registry.ConfigPathForNew (which validates internally) instead of a
+// separate registry.ValidateGroupName + registry.ConfigPathFor pair, so the
+// check accepts either shape — what matters is that SOME validated
+// derivation runs before SaveGroupConfig, not the literal spelling of the
+// call.
 func TestApplyGroupConfig_ValidatesBeforeSaving(t *testing.T) {
 	src := readSource(t, "wizard.go")
 	fn := funcBody(t, src, "applyGroupConfig")
@@ -33,18 +40,34 @@ func TestRunOnboard_ValidatesBeforeSaving(t *testing.T) {
 	assertValidatesBeforeSave(t, fn, "runOnboard (onboard.go)")
 }
 
+// firstIndexOfAny returns the earliest index at which any of needles occurs
+// in s, or -1 if none occur.
+func firstIndexOfAny(s string, needles ...string) int {
+	best := -1
+	for _, n := range needles {
+		if i := strings.Index(s, n); i >= 0 && (best < 0 || i < best) {
+			best = i
+		}
+	}
+	return best
+}
+
 func assertValidatesBeforeSave(t *testing.T, fn, where string) {
 	t.Helper()
-	iValidate := strings.Index(fn, "registry.ValidateGroupName")
+	// Either an explicit registry.ValidateGroupName call, or a validated
+	// write-side derivation (registry.ConfigPathForNew) that performs the
+	// same check internally, counts as "validated before saving".
+	iValidate := firstIndexOfAny(fn, "registry.ValidateGroupName", "registry.ConfigPathForNew")
 	iSave := strings.Index(fn, "registry.SaveGroupConfig")
 	if iValidate < 0 {
-		t.Fatalf("%s does not call registry.ValidateGroupName at all (#6186 F6)", where)
+		t.Fatalf("%s calls neither registry.ValidateGroupName nor registry.ConfigPathForNew "+
+			"(#6186 F6/R1)", where)
 	}
 	if iSave < 0 {
 		t.Fatalf("%s does not call registry.SaveGroupConfig (test assumption broke)", where)
 	}
 	if iValidate > iSave {
-		t.Errorf("%s calls registry.SaveGroupConfig before registry.ValidateGroupName; an "+
+		t.Errorf("%s calls registry.SaveGroupConfig before validating the group name; an "+
 			"unvalidated name (e.g. \"../../pwned\") can write a config file outside the config "+
 			"directory before the name is ever rejected (#6186 F6)", where)
 	}

--- a/internal/cli/group_name_order_6186_test.go
+++ b/internal/cli/group_name_order_6186_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// #6186 F6 (found on review): every real caller of registry.AddGroup wrote
+// the group config to disk (registry.SaveGroupConfig) BEFORE AddGroup's
+// name validation ever ran. registry.ConfigPathFor filepath.Joins the raw
+// name, which collapses "..", so an unvalidated name could write a config
+// file outside the intended config directory; the AddGroup rejection that
+// followed only left the stray file behind.
+//
+// These two pin the source order at the two internal/cli call sites (the
+// dashboard and internal/install call sites have their own direct
+// behavioral tests: internal/dashboard/create_group_traversal_6186_test.go,
+// internal/install/group_name_traversal_6186_test.go). Source-order
+// checking, not a full behavioral run, because reproducing the wizard TUI /
+// onboard flow end-to-end just to observe write ordering is disproportionate
+// to what's being pinned — reuses the readSource/funcBody helpers already
+// established in watchersync_wiring_6179_test.go for exactly this kind of
+// "call X before call Y" invariant.
+func TestApplyGroupConfig_ValidatesBeforeSaving(t *testing.T) {
+	src := readSource(t, "wizard.go")
+	fn := funcBody(t, src, "applyGroupConfig")
+	assertValidatesBeforeSave(t, fn, "applyGroupConfig (wizard.go)")
+}
+
+func TestRunOnboard_ValidatesBeforeSaving(t *testing.T) {
+	src := readSource(t, "onboard.go")
+	fn := funcBody(t, src, "runOnboard")
+	assertValidatesBeforeSave(t, fn, "runOnboard (onboard.go)")
+}
+
+func assertValidatesBeforeSave(t *testing.T, fn, where string) {
+	t.Helper()
+	iValidate := strings.Index(fn, "registry.ValidateGroupName")
+	iSave := strings.Index(fn, "registry.SaveGroupConfig")
+	if iValidate < 0 {
+		t.Fatalf("%s does not call registry.ValidateGroupName at all (#6186 F6)", where)
+	}
+	if iSave < 0 {
+		t.Fatalf("%s does not call registry.SaveGroupConfig (test assumption broke)", where)
+	}
+	if iValidate > iSave {
+		t.Errorf("%s calls registry.SaveGroupConfig before registry.ValidateGroupName; an "+
+			"unvalidated name (e.g. \"../../pwned\") can write a config file outside the config "+
+			"directory before the name is ever rejected (#6186 F6)", where)
+	}
+}

--- a/internal/cli/onboard.go
+++ b/internal/cli/onboard.go
@@ -94,6 +94,13 @@ func runOnboard(out io.Writer, start, parentDir string, nonInteractive bool) err
 		})
 	}
 
+	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
+	// filepath.Joins the raw name, which collapses "..", so a name like
+	// "../../pwned" resolves outside the config directory; validating only at
+	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
+	if err := registry.ValidateGroupName(cfg.Name); err != nil {
+		return err
+	}
 	cfgPath, err := registry.ConfigPathFor(cfg.Name)
 	if err != nil {
 		return err

--- a/internal/cli/onboard.go
+++ b/internal/cli/onboard.go
@@ -94,14 +94,12 @@ func runOnboard(out io.Writer, start, parentDir string, nonInteractive bool) err
 		})
 	}
 
-	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
-	// filepath.Joins the raw name, which collapses "..", so a name like
-	// "../../pwned" resolves outside the config directory; validating only at
-	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
-	if err := registry.ValidateGroupName(cfg.Name); err != nil {
-		return err
-	}
-	cfgPath, err := registry.ConfigPathFor(cfg.Name)
+	// #6186 F6/R1: ConfigPathForNew validates before deriving the path, not
+	// after — ConfigPathFor filepath.Joins the raw name, which collapses
+	// "..", so a name like "../../pwned" resolves outside the config
+	// directory; validating only at AddGroup (after SaveGroupConfig already
+	// wrote the file) is too late.
+	cfgPath, err := registry.ConfigPathForNew(cfg.Name)
 	if err != nil {
 		return err
 	}

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -1,11 +1,13 @@
 package cli
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -129,12 +131,22 @@ version the command exits 0 without downloading anything.`,
 // Best-effort and silent on success: an update must not fail because a watcher
 // plist could not be rewritten. A package var so tests can assert the wiring
 // without spawning anything.
-var refreshWatcherUnitsWithNewBinary = func(out io.Writer) {
-	bin, err := os.Executable()
-	if err != nil {
-		return
-	}
-	cmd := exec.Command(bin, "install", "--refresh-state")
+// watcherRefreshTimeout bounds how long refreshWatcherUnitsWithNewBinary will
+// wait for the child before giving up (#6184).
+//
+// At 140 repos the child makes hundreds of serial launchctl calls
+// (loader_darwin.go:64-100 retries bootstrap up to 3x on exit-5 with a 200ms
+// backoff). With a wedged launchd — a documented failure mode — the child
+// itself can hang indefinitely. 3 minutes is generous for 140 units' worth of
+// launchctl round-trips under normal conditions while still bounding the
+// worst case instead of inheriting it.
+var watcherRefreshTimeout = 3 * time.Minute
+
+// runWatcherRefreshCmd runs the `install --refresh-state` child and returns
+// its combined output. A package var so tests can substitute a child that
+// blocks past the deadline without needing a real wedged launchd.
+var runWatcherRefreshCmd = func(ctx context.Context, bin string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, bin, "install", "--refresh-state")
 	// GRAFEL_SKIP_QUICK_DOCTOR: the child would otherwise run the quick-doctor
 	// preflight against a daemon that RunCopy may still be restarting, and
 	// print a spurious drift warning in the middle of update's own output.
@@ -143,7 +155,28 @@ var refreshWatcherUnitsWithNewBinary = func(out io.Writer) {
 	cmd.Env = append(os.Environ(),
 		"GRAFEL_SKIP_QUICK_DOCTOR=1",
 		refreshStateQuietEnv+"=1")
-	b, err := cmd.CombinedOutput()
+	return cmd.CombinedOutput()
+}
+
+var refreshWatcherUnitsWithNewBinary = func(out io.Writer) {
+	bin, err := os.Executable()
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), watcherRefreshTimeout)
+	defer cancel()
+	b, err := runWatcherRefreshCmd(ctx, bin)
+	if ctx.Err() == context.DeadlineExceeded {
+		// #6184: CombinedOutput used to buffer until exit with no deadline at
+		// all, so a wedged launchd meant `grafel update` hung forever with no
+		// indication of what it was doing. Report the timeout explicitly
+		// instead of inheriting that silence.
+		reportWatcherRefresh(out, b, fmt.Errorf(
+			"timed out after %s waiting for watcher unit refresh (launchd may be wedged); "+
+				"the update itself already completed, only watcher-unit reconcile was skipped",
+			watcherRefreshTimeout))
+		return
+	}
 	reportWatcherRefresh(out, b, err)
 }
 

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -142,11 +142,33 @@ version the command exits 0 without downloading anything.`,
 // worst case instead of inheriting it.
 var watcherRefreshTimeout = 3 * time.Minute
 
+// watcherRefreshWaitDelay caps how long CombinedOutput will wait, AFTER the
+// context deadline fires and the direct child is signalled, before os/exec
+// force-closes the child's I/O pipes and returns.
+//
+// #6184 F1 (found on review): exec.CommandContext only SIGKILLs the DIRECT
+// child. CombinedOutput backs stdout/stderr with an os.Pipe, and Wait()
+// blocks on that pipe's read side until every WRITER closes it — including
+// any grandchild that inherited the fd. install --refresh-state's own child
+// is exactly launchctl, which is what #6184 says can be wedged: killing the
+// direct child leaves a wedged launchctl grandchild holding the pipe open,
+// so watcherRefreshTimeout alone does not bound wall-clock time at all.
+// Measured: a 1s deadline against a process with a surviving grandchild
+// returned in 20.55s, not ~1s.
+//
+// This is the same failure mode fixed for git children in
+// internal/gitmeta/gitmeta.go (applyWaitDelay / waitDelayGrace, #5286);
+// WaitDelay (Go 1.20+) is the precedented fix, reused here rather than
+// invented fresh. 3s matches gitmeta's value: enough for a clean process to
+// flush and exit, short enough not to reintroduce the original hang.
+const watcherRefreshWaitDelay = 3 * time.Second
+
 // runWatcherRefreshCmd runs the `install --refresh-state` child and returns
 // its combined output. A package var so tests can substitute a child that
 // blocks past the deadline without needing a real wedged launchd.
 var runWatcherRefreshCmd = func(ctx context.Context, bin string) ([]byte, error) {
 	cmd := exec.CommandContext(ctx, bin, "install", "--refresh-state")
+	cmd.WaitDelay = watcherRefreshWaitDelay
 	// GRAFEL_SKIP_QUICK_DOCTOR: the child would otherwise run the quick-doctor
 	// preflight against a daemon that RunCopy may still be restarting, and
 	// print a spurious drift warning in the middle of update's own output.

--- a/internal/cli/update_realexec_6184_test.go
+++ b/internal/cli/update_realexec_6184_test.go
@@ -1,0 +1,57 @@
+package cli
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// TestRunWatcherRefreshCmd_BoundedEvenWithSurvivingGrandchild pins #6184 F1,
+// found on review: exec.CommandContext SIGKILLs only the DIRECT child.
+// CombinedOutput backs stdout/stderr with an os.Pipe, and Wait() blocks on
+// that pipe until every WRITER closes it — including a grandchild that
+// inherited the fd. install --refresh-state's own child is launchctl, which
+// is exactly the process #6184 says can wedge: killing the direct child
+// alone leaves a surviving launchctl grandchild holding the pipe open, so a
+// context deadline with no WaitDelay does not bound wall-clock time at all.
+//
+// This exercises the REAL production function — runWatcherRefreshCmd — with
+// a real child process, not a context-obeying stub, so it can actually fail
+// against the pre-WaitDelay implementation (a prior version of this test
+// substituted the whole function with a `select { case <-ctx.Done() }` stub,
+// which honours the context by construction and could never observe this
+// bug).
+//
+// The spawned shell backgrounds a grandchild that inherits stdout/stderr and
+// outlives the direct child, then the direct child itself prints "partial"
+// and sleeps 20s. Measured against the unfixed code: 1s deadline, 20.55s
+// elapsed. WaitDelay must bound that to a few seconds.
+func TestRunWatcherRefreshCmd_BoundedEvenWithSurvivingGrandchild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("posix shell only")
+	}
+	script := filepath.Join(t.TempDir(), "wedged.sh")
+	body := "#!/bin/sh\n(sleep 20) &\necho partial\nsleep 20\n"
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	out, err := runWatcherRefreshCmd(ctx, script)
+	elapsed := time.Since(start)
+
+	if elapsed > 5*time.Second {
+		t.Fatalf("runWatcherRefreshCmd did not return promptly with a surviving grandchild "+
+			"holding the output pipe open (#6184 F1): took %s, want well under the 20s the "+
+			"grandchild sleeps\nerr=%v out=%q", elapsed, err, out)
+	}
+	if err == nil {
+		t.Errorf("expected an error from the killed child, got nil (out=%q)", out)
+	}
+}

--- a/internal/cli/update_realexec_6184_test.go
+++ b/internal/cli/update_realexec_6184_test.go
@@ -25,33 +25,88 @@ import (
 // which honours the context by construction and could never observe this
 // bug).
 //
-// The spawned shell backgrounds a grandchild that inherits stdout/stderr and
-// outlives the direct child, then the direct child itself prints "partial"
-// and sleeps 20s. Measured against the unfixed code: 1s deadline, 20.55s
-// elapsed. WaitDelay must bound that to a few seconds.
+// The spawned shell backgrounds a grandchild that inherits stdout/stderr,
+// then signals readiness (touches a file) before sleeping 20s itself. The
+// grandchild also sleeps 20s, holding the pipe open after the direct child
+// is killed. WaitDelay must bound the wait for that grandchild to a few
+// seconds instead of the full 20s.
+//
+// #6184 R2 (found on round-2 review): the first cut of this test raced a
+// fixed context deadline (300ms, later 1s) against how long /bin/sh takes to
+// fork+exec the grandchild and print "partial". On a loaded machine that
+// fork/exec cost is not bounded tightly enough for any fixed short deadline
+// to be reliable — measured 6 of 8 mutant runs vacuous at 300ms, and even at
+// 1s this machine still produced occasional vacuous runs (deadline fired
+// before the child had backgrounded anything, so nothing was ever holding
+// the pipe and the elapsed-time assertion proved nothing about WaitDelay).
+//
+// Fix: remove the race instead of tuning it. The script signals readiness
+// (touches readyFile) only AFTER backgrounding its grandchild and printing
+// "partial", so the test polls for that file — deterministically, not on a
+// clock — before ever cancelling the context. Cancellation and the bounded-
+// return assertion now measure only the thing #6184 F1 is about: how long
+// CombinedOutput takes to return once a grandchild is confirmed to be
+// holding the pipe open, not how fast a shell can fork.
 func TestRunWatcherRefreshCmd_BoundedEvenWithSurvivingGrandchild(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("posix shell only")
 	}
-	script := filepath.Join(t.TempDir(), "wedged.sh")
-	body := "#!/bin/sh\n(sleep 20) &\necho partial\nsleep 20\n"
+	dir := t.TempDir()
+	script := filepath.Join(dir, "wedged.sh")
+	readyFile := filepath.Join(dir, "ready")
+	body := "#!/bin/sh\n(sleep 20) &\necho partial\ntouch " + readyFile + "\nsleep 20\n"
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
 		t.Fatal(err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	type result struct {
+		out []byte
+		err error
+	}
+	done := make(chan result, 1)
+	go func() {
+		out, err := runWatcherRefreshCmd(ctx, script)
+		done <- result{out, err}
+	}()
+
+	// Wait, deterministically (not on a clock), until the grandchild has
+	// actually been backgrounded before cancelling — this is the fix for
+	// R2's flake, not a longer timeout.
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if _, statErr := os.Stat(readyFile); statErr == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("child never signalled readiness within 10s; test infrastructure issue, " +
+				"not the thing under test")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
 	start := time.Now()
-	out, err := runWatcherRefreshCmd(ctx, script)
+	cancel()
+	var res result
+	select {
+	case res = <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("runWatcherRefreshCmd did not return within 10s of cancellation " +
+			"(#6184 F1: WaitDelay is not bounding the wait for the surviving grandchild)")
+	}
 	elapsed := time.Since(start)
 
 	if elapsed > 5*time.Second {
-		t.Fatalf("runWatcherRefreshCmd did not return promptly with a surviving grandchild "+
-			"holding the output pipe open (#6184 F1): took %s, want well under the 20s the "+
-			"grandchild sleeps\nerr=%v out=%q", elapsed, err, out)
+		t.Fatalf("runWatcherRefreshCmd did not return promptly after the surviving grandchild "+
+			"was confirmed to be holding the output pipe open (#6184 F1): took %s, want well "+
+			"under the 20s the grandchild sleeps\nerr=%v out=%q", elapsed, res.err, res.out)
 	}
-	if err == nil {
-		t.Errorf("expected an error from the killed child, got nil (out=%q)", out)
+	if res.err == nil {
+		t.Errorf("expected an error from the killed child, got nil (out=%q)", res.out)
+	}
+	if string(res.out) != "partial\n" {
+		t.Fatalf("runWatcherRefreshCmd output = %q, want \"partial\\n\"", res.out)
 	}
 }

--- a/internal/cli/update_timeout_6184_test.go
+++ b/internal/cli/update_timeout_6184_test.go
@@ -1,0 +1,52 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// #6184: refreshWatcherUnitsWithNewBinary used cmd.CombinedOutput() with no
+// deadline. At 140 repos the child makes hundreds of serial launchctl calls;
+// with a wedged launchd (a documented failure mode), `grafel update` blocks
+// indefinitely with no output at all, because CombinedOutput buffers until
+// exit. This pins that a deadline is enforced and that a timeout is reported
+// explicitly instead of inheriting silence.
+//
+// runWatcherRefreshCmd stands in for the wedged child: it blocks until either
+// the context is cancelled (the fix working) or a bounded 5s "the child never
+// died" ceiling, whichever comes first. That keeps this test's own worst case
+// bounded even if the deadline enforcement regresses — no infinite runaway.
+func TestRefreshWatcherUnits_TimesOutInsteadOfHangingForever(t *testing.T) {
+	prevTimeout := watcherRefreshTimeout
+	prevRun := runWatcherRefreshCmd
+	watcherRefreshTimeout = 50 * time.Millisecond
+	runWatcherRefreshCmd = func(ctx context.Context, bin string) ([]byte, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(5 * time.Second):
+			return nil, nil
+		}
+	}
+	t.Cleanup(func() {
+		watcherRefreshTimeout = prevTimeout
+		runWatcherRefreshCmd = prevRun
+	})
+
+	var buf bytes.Buffer
+	start := time.Now()
+	refreshWatcherUnitsWithNewBinary(&buf)
+	elapsed := time.Since(start)
+
+	if elapsed > 2*time.Second {
+		t.Fatalf("refreshWatcherUnitsWithNewBinary did not return promptly on a wedged child "+
+			"(#6184): took %s, want well under the 5s simulated hang", elapsed)
+	}
+	if !strings.Contains(strings.ToLower(buf.String()), "timed out") {
+		t.Fatalf("expected an explicit timeout explanation instead of silence (#6184), got %q",
+			buf.String())
+	}
+}

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -437,6 +437,13 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 		}
 	}
 
+	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
+	// filepath.Joins the raw name, which collapses "..", so a name like
+	// "../../pwned" resolves outside the config directory; validating only at
+	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
+	if err := registry.ValidateGroupName(cfg.Name); err != nil {
+		return nil, err
+	}
 	cfgPath, err := registry.ConfigPathFor(cfg.Name)
 	if err != nil {
 		return nil, err

--- a/internal/cli/wizard.go
+++ b/internal/cli/wizard.go
@@ -437,14 +437,12 @@ func applyGroupConfig(out io.Writer, cfg *registry.GroupConfig, ga groupApplyOpt
 		}
 	}
 
-	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
-	// filepath.Joins the raw name, which collapses "..", so a name like
-	// "../../pwned" resolves outside the config directory; validating only at
-	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
-	if err := registry.ValidateGroupName(cfg.Name); err != nil {
-		return nil, err
-	}
-	cfgPath, err := registry.ConfigPathFor(cfg.Name)
+	// #6186 F6/R1: ConfigPathForNew validates before deriving the path, not
+	// after — ConfigPathFor filepath.Joins the raw name, which collapses
+	// "..", so a name like "../../pwned" resolves outside the config
+	// directory; validating only at AddGroup (after SaveGroupConfig already
+	// wrote the file) is too late.
+	cfgPath, err := registry.ConfigPathForNew(cfg.Name)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/daemon/docs_path.go
+++ b/internal/daemon/docs_path.go
@@ -18,8 +18,11 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/registry"
 )
 
 // DocsDir returns the root of the daemon's external docs store —
@@ -56,6 +59,50 @@ func BusinessDocsDir(group string) string {
 		return ""
 	}
 	return filepath.Join(DocsDir(), group, "business")
+}
+
+// RepoDocsDir/BusinessDocsDir are READ-safe derivations: they are also used
+// to resolve the docs location of an already-registered group (docgen, the
+// docs handlers, export), including one whose name predates
+// registry.ValidateGroupName or is otherwise grandfathered-invalid. They
+// intentionally do NOT validate group — see registry.ValidateGroupName's doc
+// comment for why gating reads would be worse than the bug it prevents.
+//
+// RepoDocsDirForNew and BusinessDocsDirForNew are the write-side
+// counterparts: they validate group before deriving the path.
+//
+// #6186 R1 (found on review): the import/restore handler in
+// internal/dashboard/handlers_v2_graph_export.go derives a destination
+// directory from RepoDocsDir/BusinessDocsDir using a group name taken from
+// an uploaded archive's manifest.json (or a request query override) and then
+// os.MkdirAll + unzips into it — with no validation anywhere on that path,
+// because it was never on the hand-enumerated list of AddGroup callers the
+// F6 fix walked. filepath.Join collapses "..", so an archive whose manifest
+// group is "../../../../tmp/pwn" wrote into that directory before the
+// (too-late) registry.AddGroup rejection at the end of the handler ever ran.
+//
+// Use the ForNew variants (not RepoDocsDir/BusinessDocsDir) at any call site
+// that is about to CREATE or POPULATE a docs directory for a name that is
+// not already a trusted, registered group — the validated path is
+// structurally distinct from the read path, rather than relying on the
+// caller to remember a check.
+func RepoDocsDirForNew(group, repoSlug string) (string, error) {
+	if err := registry.ValidateGroupName(group); err != nil {
+		return "", err
+	}
+	if repoSlug == "" {
+		return "", fmt.Errorf("repo slug required")
+	}
+	return RepoDocsDir(group, repoSlug), nil
+}
+
+// BusinessDocsDirForNew is RepoDocsDirForNew's counterpart for the group-level
+// business docs directory. See RepoDocsDirForNew for the rationale.
+func BusinessDocsDirForNew(group string) (string, error) {
+	if err := registry.ValidateGroupName(group); err != nil {
+		return "", err
+	}
+	return BusinessDocsDir(group), nil
 }
 
 // LegacyInRepoDocsDir returns the historical `<repo>/docs/` location.

--- a/internal/dashboard/create_group_traversal_6186_test.go
+++ b/internal/dashboard/create_group_traversal_6186_test.go
@@ -1,0 +1,47 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestCreateGroup_RejectsTraversalBeforeWritingConfig pins #6186 F6 (found on
+// review): every real caller of registry.AddGroup — including this one,
+// liveStore.CreateGroup — computes the config path with
+// registry.ConfigPathFor(name) and calls registry.SaveGroupConfig BEFORE
+// registry.AddGroup ever validates the name. ConfigPathFor filepath.Joins
+// the raw name, which collapses "..", so
+//
+//	ConfigPathFor("../../pwned") = <XDG config dir>/../../pwned.fleet.json
+//	                              = <two levels up>/pwned.fleet.json
+//
+// and SaveGroupConfig wrote that file BEFORE AddGroup's rejection ever ran —
+// #6186's own headline traversal input still wrote a file outside the
+// config directory; the rejection only left the stray file behind.
+//
+// The fix validates the name before the first write (registry.
+// ValidateGroupName, called ahead of SaveGroupConfig), not just at AddGroup.
+func TestCreateGroup_RejectsTraversalBeforeWritingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	// Compute the exact path the unvalidated code would have written to, the
+	// same way the reviewer's probe did.
+	escapedPath, err := registry.ConfigPathFor("../../pwned")
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+
+	if _, err := (liveStore{}).CreateGroup("../../pwned"); err == nil {
+		t.Fatal("CreateGroup(\"../../pwned\") succeeded, want rejection (#6186 F6)")
+	}
+
+	if _, statErr := os.Stat(escapedPath); statErr == nil {
+		t.Fatalf("SaveGroupConfig wrote outside the config directory at %s despite the name "+
+			"being rejected (#6186 F6)", escapedPath)
+	}
+}

--- a/internal/dashboard/create_group_traversal_6186_test.go
+++ b/internal/dashboard/create_group_traversal_6186_test.go
@@ -26,6 +26,7 @@ import (
 // ValidateGroupName, called ahead of SaveGroupConfig), not just at AddGroup.
 func TestCreateGroup_RejectsTraversalBeforeWritingConfig(t *testing.T) {
 	home := t.TempDir()
+	t.Setenv("HOME", home)
 	t.Setenv("GRAFEL_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
 

--- a/internal/dashboard/handlers_v2_graph_export.go
+++ b/internal/dashboard/handlers_v2_graph_export.go
@@ -300,6 +300,21 @@ func (s *Server) handleV2GraphImport(w http.ResponseWriter, r *http.Request) {
 		writeV2Err(w, http.StatusBadRequest, "bad_request", "manifest is missing group name")
 		return
 	}
+	// #6186 R1: validate the group name as soon as it is decided, before it
+	// is used to derive ANY filesystem path below (conflict check, docs
+	// restore, config write). finalGroup is untrusted input — it comes from
+	// an uploaded archive's manifest.json or a caller-supplied query
+	// parameter — and registry.ConfigPathFor / daemon.RepoDocsDir /
+	// daemon.BusinessDocsDir all filepath.Join it raw, which collapses "..".
+	// This is a fail-fast, defense-in-depth check ahead of the ForNew
+	// derivations used at each individual write below; it exists so the
+	// handler rejects a hostile archive before doing any work (including the
+	// conflict-check registry read), not after MkdirAll/unzip has already
+	// run.
+	if err := registry.ValidateGroupName(finalGroup); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid group name: "+err.Error())
+		return
+	}
 
 	// Conflict check.
 	existingPath, _ := groupConfigPath(finalGroup)
@@ -349,8 +364,19 @@ func (s *Server) handleV2GraphImport(w http.ResponseWriter, r *http.Request) {
 	if manifest.Kind == "all" {
 		for _, rp := range cfg.Repos {
 			archivePrefix := archiveGroup + "/docs/" + rp.Slug + "/"
-			destDocsDir := daemon.RepoDocsDir(finalGroup, rp.Slug)
-			if destDocsDir == "" || !zipPrefixExists(zr, archivePrefix) {
+			if !zipPrefixExists(zr, archivePrefix) {
+				continue
+			}
+			// #6186 R1: RepoDocsDirForNew validates finalGroup before
+			// deriving the path (defense-in-depth alongside the early
+			// ValidateGroupName check above — this is the write, so it gets
+			// its own gate).
+			destDocsDir, err := daemon.RepoDocsDirForNew(finalGroup, rp.Slug)
+			if err != nil {
+				writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid group name: "+err.Error())
+				return
+			}
+			if destDocsDir == "" {
 				continue
 			}
 			if err := os.MkdirAll(destDocsDir, 0o755); err != nil {
@@ -366,7 +392,13 @@ func (s *Server) handleV2GraphImport(w http.ResponseWriter, r *http.Request) {
 		}
 		bizPrefix := archiveGroup + "/docs/business/"
 		if zipPrefixExists(zr, bizPrefix) {
-			destBiz := daemon.BusinessDocsDir(finalGroup)
+			// #6186 R1: BusinessDocsDirForNew validates finalGroup before
+			// deriving the path.
+			destBiz, err := daemon.BusinessDocsDirForNew(finalGroup)
+			if err != nil {
+				writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid group name: "+err.Error())
+				return
+			}
 			if destBiz != "" {
 				_ = os.MkdirAll(destBiz, 0o755)
 				if err := extractZipPrefix(zr, bizPrefix, destBiz); err != nil {
@@ -379,10 +411,12 @@ func (s *Server) handleV2GraphImport(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Persist the fleet config + register the group.
-	finalConfigPath, err := registry.ConfigPathFor(finalGroup)
+	// #6186 R1: ConfigPathForNew validates finalGroup before deriving the
+	// path (defense-in-depth alongside the early ValidateGroupName check
+	// above).
+	finalConfigPath, err := registry.ConfigPathForNew(finalGroup)
 	if err != nil {
-		writeV2Err(w, http.StatusInternalServerError, "internal_error",
-			"resolve config path: "+err.Error())
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid group name: "+err.Error())
 		return
 	}
 	if err := registry.SaveGroupConfig(finalConfigPath, cfg); err != nil {

--- a/internal/dashboard/handlers_v2_graph_export_test.go
+++ b/internal/dashboard/handlers_v2_graph_export_test.go
@@ -34,6 +34,7 @@ func buildGraphExportTestServer(t *testing.T) (*Server, *registry.GroupConfig, s
 	t.Helper()
 
 	home := t.TempDir()
+	t.Setenv("HOME", home)
 	t.Setenv("GRAFEL_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
 

--- a/internal/dashboard/import_group_traversal_r1_test.go
+++ b/internal/dashboard/import_group_traversal_r1_test.go
@@ -1,0 +1,133 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// #6186 R1 (found on round-2 review): handleV2GraphImport is a fifth writer
+// that derives a group name from an uploaded archive (manifest.Group, or the
+// `name=` query override) and never calls registry.ValidateGroupName
+// anywhere on that path before using it to construct filesystem paths:
+//
+//	registry.ConfigPathFor(finalGroup)            (config file)
+//	daemon.RepoDocsDir(finalGroup, repoSlug)       (per-repo docs)
+//	daemon.BusinessDocsDir(finalGroup)             (group docs)
+//
+// All three filepath.Join the raw name, which collapses "..". The F6 fix
+// enumerated AddGroup's four known callers and missed this one — the
+// takeaway from round 2 is "validate the derivation, not the caller list",
+// hence the write-side ConfigPathForNew/RepoDocsDirForNew/
+// BusinessDocsDirForNew helpers added alongside this fix.
+//
+// This test imports an archive whose manifest.Group is a traversal string
+// and asserts nothing was written outside the config/docs roots, using the
+// exact escaped paths the reviewer's probe used.
+func TestGraphImport_RejectsGroupNameEscapingConfigDir(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+
+	// Export "alpha" (kind=graph is enough: the config-path escape does not
+	// require docs).
+	er := httptest.NewRequest("GET", "/api/v2/groups/alpha/export?format=zip&kind=graph", nil)
+	ew := httptest.NewRecorder()
+	srv.routes().ServeHTTP(ew, er)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+	archive := ew.Body.Bytes()
+
+	escapedConfigPath, err := registry.ConfigPathFor("../../../../tmp/pwn")
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+
+	body, contentType := multipartZip(t, archive)
+	ir := httptest.NewRequest("POST",
+		"/api/v2/groups/import?name="+"..%2F..%2F..%2F..%2Ftmp%2Fpwn", body)
+	ir.Header.Set("Content-Type", contentType)
+	iw := httptest.NewRecorder()
+	srv.routes().ServeHTTP(iw, ir)
+
+	if iw.Code == http.StatusOK {
+		t.Fatalf("import with a traversal group name succeeded (200): %s", iw.Body.String())
+	}
+
+	if _, statErr := os.Stat(escapedConfigPath); statErr == nil {
+		t.Fatalf("SaveGroupConfig wrote outside the config directory at %s (#6186 R1)",
+			escapedConfigPath)
+	}
+}
+
+// TestGraphImport_RejectsGroupNameEscapingDocsDir is the docs-tree half of
+// R1: kind=all restoration derives destDocsDir/destBiz from finalGroup via
+// daemon.RepoDocsDir/BusinessDocsDir and MkdirAll's + unzips into them.
+func TestGraphImport_RejectsGroupNameEscapingDocsDir(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+
+	techDir := daemon.RepoDocsDir("alpha", "alpha-repo")
+	mustWrite(t, filepath.Join(techDir, "overview.md"), "# Alpha\n")
+	bizDir := daemon.BusinessDocsDir("alpha")
+	mustWrite(t, filepath.Join(bizDir, "capabilities.md"), "# Caps\n")
+
+	er := httptest.NewRequest("GET", "/api/v2/groups/alpha/export?format=zip&kind=all", nil)
+	ew := httptest.NewRecorder()
+	srv.routes().ServeHTTP(ew, er)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+	archive := ew.Body.Bytes()
+
+	escapedRepoDocs := daemon.RepoDocsDir("../../../../tmp/pwn", "alpha-repo")
+	escapedBizDocs := daemon.BusinessDocsDir("../../../../tmp/pwn")
+
+	body, contentType := multipartZip(t, archive)
+	ir := httptest.NewRequest("POST",
+		"/api/v2/groups/import?name="+"..%2F..%2F..%2F..%2Ftmp%2Fpwn", body)
+	ir.Header.Set("Content-Type", contentType)
+	iw := httptest.NewRecorder()
+	srv.routes().ServeHTTP(iw, ir)
+
+	if iw.Code == http.StatusOK {
+		t.Fatalf("import with a traversal group name succeeded (200): %s", iw.Body.String())
+	}
+
+	if _, statErr := os.Stat(escapedRepoDocs); statErr == nil {
+		t.Fatalf("extractZipPrefix wrote outside the docs directory at %s (#6186 R1)", escapedRepoDocs)
+	}
+	if _, statErr := os.Stat(escapedBizDocs); statErr == nil {
+		t.Fatalf("extractZipPrefix wrote outside the docs directory at %s (#6186 R1)", escapedBizDocs)
+	}
+}
+
+// TestGraphImport_RejectsControlCharacterGroupName pins that the import path
+// gets the same widened validation (control chars, NUL, whitespace-only,
+// over-length — #6186 F5) as the other four writers, not just the path-
+// separator subset.
+func TestGraphImport_RejectsControlCharacterGroupName(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+
+	er := httptest.NewRequest("GET", "/api/v2/groups/alpha/export?format=zip&kind=graph", nil)
+	ew := httptest.NewRecorder()
+	srv.routes().ServeHTTP(ew, er)
+	archive := ew.Body.Bytes()
+
+	body, contentType := multipartZip(t, archive)
+	ir := httptest.NewRequest("POST",
+		"/api/v2/groups/import?name="+"g%0A%5BService%5D", body) // "g\n[Service]"
+	ir.Header.Set("Content-Type", contentType)
+	iw := httptest.NewRecorder()
+	srv.routes().ServeHTTP(iw, ir)
+
+	if iw.Code == http.StatusOK {
+		var env v2Envelope
+		_ = json.Unmarshal(iw.Body.Bytes(), &env)
+		t.Fatalf("import with a control-character group name succeeded (200): %s", iw.Body.String())
+	}
+}

--- a/internal/dashboard/import_group_traversal_r1_test.go
+++ b/internal/dashboard/import_group_traversal_r1_test.go
@@ -30,11 +30,27 @@ import (
 // This test imports an archive whose manifest.Group is a traversal string
 // and asserts nothing was written outside the config/docs roots, using the
 // exact escaped paths the reviewer's probe used.
+//
+// L2 (found on round-3 review): the ORIGINAL sandbox (XDG_CONFIG_HOME =
+// <home>/xdg, one level under home) is exactly deep enough that a four-level
+// "../../../../" traversal escapes past t.TempDir() entirely, landing in the
+// shared /var/folders/.../T/ root that no test cleans up. That is harmless
+// TODAY only because the fix rejects the write before it happens — on a
+// regression (the thing this test exists to catch) the write would succeed
+// and the artifact would escape the test's own sandbox, which is precisely
+// the failure class R1 is about. deepenSandbox nests XDG_CONFIG_HOME (and
+// GRAFEL_HOME, for the docs-dir sibling test) five levels under home so a
+// four-level traversal still lands inside t.TempDir() and gets cleaned up
+// automatically even if this test is red.
 func TestGraphImport_RejectsGroupNameEscapingConfigDir(t *testing.T) {
 	srv, _, _ := buildGraphExportTestServer(t)
 
 	// Export "alpha" (kind=graph is enough: the config-path escape does not
-	// require docs).
+	// require docs). Export first, deepen after: the "alpha" group and its
+	// exported archive both already exist under the original (shallow)
+	// sandbox paths set up by buildGraphExportTestServer, so deepening only
+	// changes where the IMPORT under test — the thing that might escape —
+	// resolves paths.
 	er := httptest.NewRequest("GET", "/api/v2/groups/alpha/export?format=zip&kind=graph", nil)
 	ew := httptest.NewRecorder()
 	srv.routes().ServeHTTP(ew, er)
@@ -42,6 +58,8 @@ func TestGraphImport_RejectsGroupNameEscapingConfigDir(t *testing.T) {
 		t.Fatalf("export: expected 200, got %d: %s", ew.Code, ew.Body.String())
 	}
 	archive := ew.Body.Bytes()
+
+	deepenSandbox(t)
 
 	escapedConfigPath, err := registry.ConfigPathFor("../../../../tmp/pwn")
 	if err != nil {
@@ -83,6 +101,8 @@ func TestGraphImport_RejectsGroupNameEscapingDocsDir(t *testing.T) {
 		t.Fatalf("export: expected 200, got %d: %s", ew.Code, ew.Body.String())
 	}
 	archive := ew.Body.Bytes()
+
+	deepenSandbox(t)
 
 	escapedRepoDocs := daemon.RepoDocsDir("../../../../tmp/pwn", "alpha-repo")
 	escapedBizDocs := daemon.BusinessDocsDir("../../../../tmp/pwn")
@@ -130,4 +150,26 @@ func TestGraphImport_RejectsControlCharacterGroupName(t *testing.T) {
 		_ = json.Unmarshal(iw.Body.Bytes(), &env)
 		t.Fatalf("import with a control-character group name succeeded (200): %s", iw.Body.String())
 	}
+}
+
+// deepenSandbox re-nests GRAFEL_HOME and XDG_CONFIG_HOME five levels under
+// the sandbox home buildGraphExportTestServer already isolated (still inside
+// the SAME t.TempDir(), so t.Cleanup still reaps it) so that a four-level
+// "../../../../" traversal — the shape used throughout this file — lands
+// back inside t.TempDir() instead of escaping into the shared /var/folders/
+// .../T/ root (#6186 L2, found on round-3 review).
+//
+// Call this AFTER any setup/export that must happen under the original
+// (shallow) paths, and BEFORE computing an escaped-path assertion or issuing
+// the import request under test — only the import path's resolution needs
+// to see the deepened env.
+func deepenSandbox(t *testing.T) {
+	t.Helper()
+	home := os.Getenv("GRAFEL_HOME")
+	if home == "" {
+		t.Fatal("deepenSandbox: GRAFEL_HOME not set — call after buildGraphExportTestServer")
+	}
+	deep := filepath.Join(home, "a", "b", "c", "d", "e")
+	t.Setenv("GRAFEL_HOME", deep)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(deep, "xdg"))
 }

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -392,8 +392,12 @@ func graphSourceModTime(desc graph.GraphDescriptor) (time.Time, bool) {
 }
 
 func (liveStore) CreateGroup(name string) (GroupSummary, error) {
-	if name == "" {
-		return GroupSummary{}, errors.New("group name required")
+	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
+	// filepath.Joins the raw name, which collapses "..", so a name like
+	// "../../pwned" resolves outside the config directory; validating only at
+	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
+	if err := registry.ValidateGroupName(name); err != nil {
+		return GroupSummary{}, err
 	}
 	configPath, err := registry.ConfigPathFor(name)
 	if err != nil {

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -392,14 +392,12 @@ func graphSourceModTime(desc graph.GraphDescriptor) (time.Time, bool) {
 }
 
 func (liveStore) CreateGroup(name string) (GroupSummary, error) {
-	// #6186 F6: validate BEFORE computing/using the config path. ConfigPathFor
-	// filepath.Joins the raw name, which collapses "..", so a name like
-	// "../../pwned" resolves outside the config directory; validating only at
-	// AddGroup (after SaveGroupConfig already wrote the file) is too late.
-	if err := registry.ValidateGroupName(name); err != nil {
-		return GroupSummary{}, err
-	}
-	configPath, err := registry.ConfigPathFor(name)
+	// #6186 F6/R1: ConfigPathForNew validates before deriving the path, not
+	// after — ConfigPathFor filepath.Joins the raw name, which collapses
+	// "..", so a name like "../../pwned" resolves outside the config
+	// directory; validating only at AddGroup (after SaveGroupConfig already
+	// wrote the file) is too late.
+	configPath, err := registry.ConfigPathForNew(name)
 	if err != nil {
 		return GroupSummary{}, err
 	}

--- a/internal/install/group_name_traversal_6186_test.go
+++ b/internal/install/group_name_traversal_6186_test.go
@@ -1,0 +1,47 @@
+package install_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestApply_RejectsTraversalBeforeWritingConfig pins #6186 F6 (found on
+// review) for install.Apply, one of the four real callers of
+// registry.AddGroup. Apply computes registry.ConfigPathFor(opts.Group) and
+// calls registry.SaveGroupConfig with it BEFORE registry.AddGroup ever
+// validates the name; ConfigPathFor filepath.Joins the raw name, which
+// collapses "..", so an unvalidated "../../pwned" writes a config file
+// outside the intended config directory before the (too-late) AddGroup
+// rejection.
+func TestApply_RejectsTraversalBeforeWritingConfig(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	escapedPath, err := registry.ConfigPathFor("../../pwned")
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+
+	repo := t.TempDir()
+	cfg := &registry.GroupConfig{
+		Name:  "../../pwned",
+		Repos: []registry.Repo{{Slug: "r", Path: repo}},
+	}
+	if _, err := install.Apply(install.Options{
+		Group:   "../../pwned",
+		Config:  cfg,
+		BinPath: "/usr/local/bin/grafel",
+	}); err == nil {
+		t.Fatal("Apply with group \"../../pwned\" succeeded, want rejection (#6186 F6)")
+	}
+
+	if _, statErr := os.Stat(escapedPath); statErr == nil {
+		t.Fatalf("SaveGroupConfig wrote outside the config directory at %s despite the name "+
+			"being rejected (#6186 F6)", escapedPath)
+	}
+}

--- a/internal/install/group_name_traversal_6186_test.go
+++ b/internal/install/group_name_traversal_6186_test.go
@@ -20,6 +20,7 @@ import (
 func TestApply_RejectsTraversalBeforeWritingConfig(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
 
 	escapedPath, err := registry.ConfigPathFor("../../pwned")

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -110,6 +110,15 @@ func Apply(opts Options) (*Result, error) {
 	if opts.Group == "" {
 		return nil, errors.New("group is required")
 	}
+	// #6186 F6: validate BEFORE ConfigPathFor/StateDirFor are used below.
+	// Both filepath.Join the raw name, which collapses "..", so an unchecked
+	// name can compute (and, via SaveGroupConfig/os.MkdirAll further down,
+	// write to) a path outside the intended config/state directory;
+	// validating only at AddGroup runs after those writes have already
+	// happened.
+	if err := registry.ValidateGroupName(opts.Group); err != nil {
+		return nil, err
+	}
 	if opts.Config == nil {
 		return nil, errors.New("config is required")
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -297,7 +297,17 @@ func Apply(opts Options) (*Result, error) {
 				}
 				path, err := watchers.Write(u)
 				if err != nil {
-					return nil, fmt.Errorf("watcher for %s: %w", repo, err)
+					// #6185/#6186 R3: a per-repo watchers.Write failure (e.g.
+					// validateUnitFields rejecting a corrupted repo path) is
+					// NON-FATAL, matching watchersync.go's reconcile loop and
+					// the same reasoning WatcherWarnings already documents
+					// for activation failures — the group config is already
+					// persisted, so it is registered and will index
+					// regardless. One bad repo must not deny watchers to
+					// every other repo in this Apply call.
+					res.WatcherWarnings = append(res.WatcherWarnings,
+						fmt.Sprintf("watcher for %s not written: %v; the group is still registered and will index", repo, err))
+					continue
 				}
 				res.WatcherUnits = append(res.WatcherUnits, path)
 

--- a/internal/install/watcher_write_nonfatal_r3_test.go
+++ b/internal/install/watcher_write_nonfatal_r3_test.go
@@ -1,0 +1,82 @@
+package install_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// TestApply_WatcherWriteFailureIsNonFatal pins the #6185/#6186 R3 decision
+// (found on round-2 review): install.Apply and internal/install/
+// watchersync.go's reconcile disagreed on how to treat a per-repo
+// watchers.Write failure — Apply aborted the ENTIRE multi-repo install,
+// watchersync warned and continued. That inconsistency existed before this
+// fix, but validateUnitFields (control characters, trailing backslash) made
+// Write fail in new, plausible circumstances (a corrupted fleet.json repo
+// path, hand-edited or restored from an old backup), so a single bad repo
+// among many could deny watchers to every OTHER repo in the group.
+//
+// Decision: Apply is the path a user runs directly (onboarding, the wizard,
+// `grafel install`) and the group config is already fully persisted before
+// any watcher is written (see WatcherWarnings' doc comment) — the group is
+// registered and will index regardless of a per-repo watcher failure. The
+// same reasoning that made activation failures non-fatal (#5338) extends to
+// write failures: one repo's rejected watcher unit must not deny watchers to
+// every other repo in the same Apply call. This aligns Apply with
+// watchersync.go's existing warn-and-continue behavior instead of leaving
+// the two callers to disagree.
+func TestApply_WatcherWriteFailureIsNonFatal(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+
+	// Never let a real launchctl run even if activation is reached for the
+	// good repo.
+	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		return []byte(""), exec.Command("true").Run()
+	})
+	defer restore()
+
+	goodRepo := t.TempDir()
+	badRepo := "/tmp/bad\x00repo" // control byte -> watchers.Write rejects it
+	cfg := &registry.GroupConfig{
+		Name: "demo",
+		Repos: []registry.Repo{
+			{Slug: "bad", Path: badRepo},
+			{Slug: "good", Path: goodRepo},
+		},
+	}
+	cfg.Features.Watchers = true
+
+	res, err := install.Apply(install.Options{
+		Group:          "demo",
+		Config:         cfg,
+		BinPath:        "/usr/local/bin/grafel",
+		SkipHooks:      true,
+		SkipRulesFiles: true,
+		SkipMCP:        true,
+	})
+	if err != nil {
+		t.Fatalf("Apply should be non-fatal on a per-repo watcher write failure, got: %v", err)
+	}
+	foundWarning := false
+	for _, w := range res.WatcherWarnings {
+		if strings.Contains(w, "bad") {
+			foundWarning = true
+		}
+	}
+	if !foundWarning {
+		t.Fatalf("expected a WatcherWarning mentioning the bad repo, got: %v", res.WatcherWarnings)
+	}
+	if len(res.WatcherUnits) != 1 {
+		t.Fatalf("expected the good repo's watcher unit to still be written despite the bad "+
+			"repo's failure, got %d unit(s): %v", len(res.WatcherUnits), res.WatcherUnits)
+	}
+}

--- a/internal/install/watchers/systemd_injection_6185_test.go
+++ b/internal/install/watchers/systemd_injection_6185_test.go
@@ -1,0 +1,244 @@
+package watchers
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// #6185 F3 (found on review): iniEsc only escapes '%'. A newline in a
+// repo/group/bin-path field is not something any systemd assignment line can
+// escape — WorkingDirectory=, Description=, etc. take the rest of the
+// physical line literally, so an embedded '\n' always starts a NEW line that
+// systemd's unit parser reads as a new directive. Example: a repo path of
+// "/tmp/r\nExecStartPost=/bin/sh" makes ExecStartPost run at login, injected
+// into the [Service] section beneath WorkingDirectory. The same vector
+// reaches Description= via the group name, and — because #6186's
+// validateGroupName only blocked path separators and "."/".." — a group
+// named "g\n[Service]\nExecStart=evil" passed registry validation entirely.
+//
+// There is no per-value escape for this (unlike '%'), so the fix is to
+// refuse to render/persist a unit whose fields contain control characters,
+// at the one place that actually writes a file: Write().
+
+// hostileControl unions the two concrete injection vectors above: an
+// ExecStartPost injected via the repo path (through WorkingDirectory), and a
+// bogus directive injected via the group name (through Description).
+var hostileControl = Unit{
+	Group:   "g\n[Service]\nExecStart=evil",
+	Repo:    "/tmp/r\nExecStartPost=/bin/sh",
+	BinPath: "/usr/local/bin/grafel",
+}
+
+// TestWrite_RejectsControlCharacters pins that Write — the sole place a unit
+// is ever persisted (internal/install/install.go, internal/install/
+// watchersync.go both go through it) — refuses to write a file for any of
+// the three fields when it contains a control character, instead of
+// silently persisting an injected unit.
+func TestWrite_RejectsControlCharacters(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("GRAFEL_HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	cases := []Unit{
+		{Group: "g\nbad", Repo: "/tmp/ok", BinPath: "/usr/local/bin/grafel"},
+		{Group: "ok", Repo: "/tmp/r\nExecStartPost=/bin/sh", BinPath: "/usr/local/bin/grafel"},
+		{Group: "ok", Repo: "/tmp/ok", BinPath: "/usr/local/bin/graf\rel"},
+		{Group: "ok", Repo: "/tmp/ok\x00", BinPath: "/usr/local/bin/grafel"},
+		hostileControl,
+	}
+	for i, u := range cases {
+		if path, err := Write(u); err == nil {
+			os.Remove(path)
+			t.Errorf("case %d: Write(%+v) succeeded, want rejection of the control character "+
+				"(#6185 F3); wrote %s", i, u, path)
+		}
+	}
+}
+
+// TestWrite_StillAcceptsOrdinaryUnits pins that the fix does not overreach:
+// ordinary group/repo/bin-path values (including ones with spaces, which are
+// common in real directory names) must still write successfully.
+func TestWrite_StillAcceptsOrdinaryUnits(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("GRAFEL_HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	u := Unit{Group: "demo", Repo: filepath.Join(dir, "My Repo"), BinPath: "/usr/local/bin/grafel"}
+	path, err := Write(u)
+	if err != nil {
+		t.Fatalf("Write(%+v) failed, want success: %v", u, err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("unit file not written: %v", err)
+	}
+}
+
+// ── minimal systemd unit parser, used as a real assertion oracle ───────────
+//
+// #6185 F4 (found on review): the original test suite was six
+// strings.Contains checks pinning only the one character ('%') that was
+// fixed; the ExecStartPost-injection unit above contains no raw '%' and
+// passed all six unchanged. This parser is a real (if minimal) INI/unit-file
+// reader: it walks the actual line structure systemd would see, so an
+// injected line becomes an extra (section,key) pair or a malformed line
+// rather than a substring that a Contains check can miss. It also makes
+// unbalanced ExecStart quoting a hard parse error, mirroring systemd's own
+// word extractor.
+//
+// It is intentionally strict: any line that is not a "[Section]" header, a
+// "key=value" assignment, or blank is rejected, and a repeated key within a
+// section is rejected as a directive collision. This is stricter than real
+// systemd where useful, but a false rejection of a well-formed unit fails
+// TestSystemdUnit_ParsesCleanly loudly rather than silently under-detecting.
+type parsedUnit struct {
+	order    []string // section names, in file order
+	sections map[string]map[string]string
+}
+
+func parseSystemdUnit(body string) (*parsedUnit, error) {
+	p := &parsedUnit{sections: map[string]map[string]string{}}
+	cur := ""
+	for i, line := range strings.Split(body, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			if !strings.HasSuffix(line, "]") {
+				return nil, fmt.Errorf("line %d: malformed section header %q", i+1, line)
+			}
+			name := strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")
+			if _, ok := p.sections[name]; ok {
+				return nil, fmt.Errorf("line %d: section %q appears more than once (possible "+
+					"injected duplicate section)", i+1, name)
+			}
+			cur = name
+			p.sections[cur] = map[string]string{}
+			p.order = append(p.order, cur)
+			continue
+		}
+		if cur == "" {
+			return nil, fmt.Errorf("line %d: assignment %q outside any section", i+1, line)
+		}
+		key, val, ok := strings.Cut(line, "=")
+		if !ok {
+			return nil, fmt.Errorf("line %d: not a \"key=value\" assignment: %q "+
+				"(possible injected directive or unescaped newline)", i+1, line)
+		}
+		if key == "" {
+			return nil, fmt.Errorf("line %d: empty key", i+1)
+		}
+		if _, dup := p.sections[cur][key]; dup {
+			return nil, fmt.Errorf("line %d: key %q set more than once in [%s] "+
+				"(possible injected duplicate directive)", i+1, key, cur)
+		}
+		if err := checkBalancedQuotes(val); err != nil {
+			return nil, fmt.Errorf("line %d: %s=%s: %w", i+1, key, val, err)
+		}
+		p.sections[cur][key] = val
+	}
+	return p, nil
+}
+
+// checkBalancedQuotes rejects a value with an odd number of unescaped double
+// quotes — systemd's ExecStart= word extractor treats '"' as a shell-style
+// quote delimiter, and an odd count means a quote that never closes.
+func checkBalancedQuotes(val string) error {
+	depth := 0
+	esc := false
+	for _, r := range val {
+		if esc {
+			esc = false
+			continue
+		}
+		switch r {
+		case '\\':
+			esc = true
+		case '"':
+			depth ^= 1
+		}
+	}
+	if depth != 0 {
+		return fmt.Errorf("unbalanced double quote")
+	}
+	return nil
+}
+
+// systemdExpectedKeys is the allow-list of keys this package ever emits, per
+// section. Anything else showing up is an injected directive.
+var systemdExpectedKeys = map[string][]string{
+	"Unit":    {"Description", "After", "StartLimitIntervalSec", "StartLimitBurst"},
+	"Service": {"Type", "ExecStart", "WorkingDirectory", "Restart", "RestartSec"},
+	"Install": {"WantedBy"},
+}
+
+func (p *parsedUnit) assertNoInjection(t *testing.T) {
+	t.Helper()
+	for section, keys := range p.sections {
+		allowed, ok := systemdExpectedKeys[section]
+		if !ok {
+			t.Errorf("unexpected section [%s] (possible injected section)", section)
+			continue
+		}
+		for k := range keys {
+			if !contains(allowed, k) {
+				t.Errorf("unexpected key %q in [%s] (possible injected directive): %v", k, section, keys)
+			}
+		}
+	}
+}
+
+func contains(list []string, s string) bool {
+	for _, x := range list {
+		if x == s {
+			return true
+		}
+	}
+	return false
+}
+
+// TestSystemdUnit_ParsesCleanly is the sanity check for the oracle itself:
+// legitimate output from a legitimate Unit must parse with no errors and no
+// unexpected keys.
+func TestSystemdUnit_ParsesCleanly(t *testing.T) {
+	body := SystemdUnit(sample)
+	p, err := parseSystemdUnit(body)
+	if err != nil {
+		t.Fatalf("parser rejected a legitimate unit: %v\n%s", err, body)
+	}
+	p.assertNoInjection(t)
+	got := append([]string{}, p.order...)
+	sort.Strings(got)
+	want := []string{"Install", "Service", "Unit"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Errorf("sections = %v, want %v", got, want)
+	}
+}
+
+// TestSystemdUnit_OracleDetectsTheInjection proves the oracle is a real
+// detector, not a rubber stamp: fed the RAW render of the hostile unit
+// (bypassing Write's guard, exactly as the unescaped code before this fix
+// would have persisted it), it must either fail to parse or surface an
+// injected key/section — not silently accept it the way six
+// strings.Contains checks did.
+func TestSystemdUnit_OracleDetectsTheInjection(t *testing.T) {
+	body := SystemdUnit(hostileControl)
+	p, err := parseSystemdUnit(body)
+	if err != nil {
+		// A parse failure IS detection: systemd's own line-oriented parser
+		// would choke on this too.
+		return
+	}
+	if svc, ok := p.sections["Service"]; ok {
+		if _, injected := svc["ExecStartPost"]; injected {
+			return // detected: the injected directive parsed as its own key
+		}
+	}
+	t.Errorf("oracle failed to detect the ExecStartPost injection in a raw (unescaped) render:\n%s", body)
+}

--- a/internal/install/watchers/systemd_injection_6185_test.go
+++ b/internal/install/watchers/systemd_injection_6185_test.go
@@ -138,8 +138,22 @@ func parseSystemdUnit(body string) (*parsedUnit, error) {
 			return nil, fmt.Errorf("line %d: key %q set more than once in [%s] "+
 				"(possible injected duplicate directive)", i+1, key, cur)
 		}
-		if err := checkBalancedQuotes(val); err != nil {
-			return nil, fmt.Errorf("line %d: %s=%s: %w", i+1, key, val, err)
+		// #6185 R4 (found on round-2 review): checkBalancedQuotes used to run
+		// on every value, including Description= and WorkingDirectory=. Those
+		// two are NOT word-split/shell-quoted by systemd — only ExecStart=
+		// is, via systemd's C-style command-line word extractor — so a
+		// legitimate quote character in, say, a group name ("app\"co")
+		// false-positived as "unbalanced double quote" on a value where an
+		// unbalanced quote is actually harmless. Scoping the check to
+		// ExecStart (the one key where an unbalanced quote is a real defect)
+		// removes that false positive without losing real detection: an
+		// unbalanced quote can only reach ExecStart today via Go's %q, which
+		// always emits a balanced, escaped string, so this check would only
+		// ever fire if that guarantee broke.
+		if key == "ExecStart" {
+			if err := checkBalancedQuotes(val); err != nil {
+				return nil, fmt.Errorf("line %d: %s=%s: %w", i+1, key, val, err)
+			}
 		}
 		p.sections[cur][key] = val
 	}
@@ -178,19 +192,34 @@ var systemdExpectedKeys = map[string][]string{
 	"Install": {"WantedBy"},
 }
 
-func (p *parsedUnit) assertNoInjection(t *testing.T) {
-	t.Helper()
+// findInjections returns a human-readable description of every
+// section/key the parsed unit contains that is not on systemdExpectedKeys'
+// allow-list. Empty means the unit is exactly what SystemdUnit's template
+// ever legitimately produces. A plain function (not a *testing.T-taking
+// assertion) so it can be exercised as a yes/no check in a test that wants
+// to assert "detected" without wanting the failure to be reported against
+// the wrong test name.
+func (p *parsedUnit) findInjections() []string {
+	var problems []string
 	for section, keys := range p.sections {
 		allowed, ok := systemdExpectedKeys[section]
 		if !ok {
-			t.Errorf("unexpected section [%s] (possible injected section)", section)
+			problems = append(problems, fmt.Sprintf("unexpected section [%s] (possible injected section)", section))
 			continue
 		}
 		for k := range keys {
 			if !contains(allowed, k) {
-				t.Errorf("unexpected key %q in [%s] (possible injected directive): %v", k, section, keys)
+				problems = append(problems, fmt.Sprintf("unexpected key %q in [%s] (possible injected directive): %v", k, section, keys))
 			}
 		}
+	}
+	return problems
+}
+
+func (p *parsedUnit) assertNoInjection(t *testing.T) {
+	t.Helper()
+	for _, msg := range p.findInjections() {
+		t.Error(msg)
 	}
 }
 
@@ -241,4 +270,99 @@ func TestSystemdUnit_OracleDetectsTheInjection(t *testing.T) {
 		}
 	}
 	t.Errorf("oracle failed to detect the ExecStartPost injection in a raw (unescaped) render:\n%s", body)
+}
+
+// #6185 R4 (found on round-2 review): the oracle was only ever fed sample
+// (legitimate) and hostileControl — both control-character cases already
+// blocked upstream by validateUnitFields, so no test exercised the oracle
+// against the non-control attack surface it actually exists to cover.
+// Reviewer probe against inputs validateUnitFields ACCEPTS:
+//
+//	quote-in-repo             oracle: "line 2: unbalanced double quote"  (false
+//	                          positive — that's the Description= line, which
+//	                          systemd does not word-split)
+//	trailing-backslash-repo   oracle: <nil>  (blind spot, fixed by R3)
+//
+// These three tests point the oracle at exactly those non-control cases.
+
+// TestSystemdUnit_OracleAcceptsLegitimateQuoteOutsideExecStart pins the fix
+// for the false positive: a literal '"' in a group name is real, legitimate
+// input (nothing in validateUnitFields or ValidateGroupName forbids it) and
+// only ever lands on Description=, which systemd does not word-split — it
+// must not be flagged.
+func TestSystemdUnit_OracleAcceptsLegitimateQuoteOutsideExecStart(t *testing.T) {
+	u := Unit{Group: `app"co`, Repo: "/tmp/repo", BinPath: "/usr/local/bin/grafel"}
+	body := SystemdUnit(u)
+	p, err := parseSystemdUnit(body)
+	if err != nil {
+		t.Fatalf("a legitimate quote in a group name must not be rejected by the parser "+
+			"(it only ever reaches Description=, which systemd does not word-split): %v\n%s", err, body)
+	}
+	if got := p.findInjections(); len(got) != 0 {
+		t.Errorf("false positive: %v\n%s", got, body)
+	}
+}
+
+// TestCheckBalancedQuotes_DetectsUnbalancedExecStart is a direct unit test
+// of the oracle's quote check, independent of whether Unit's fields can
+// currently produce an unbalanced ExecStart (they cannot: Go's %q always
+// emits a properly escaped, balanced string — see the comment in
+// parseSystemdUnit). This pins that the check itself is a real detector,
+// not dead code, so it still catches a future renderer that stops using %q.
+func TestCheckBalancedQuotes_DetectsUnbalancedExecStart(t *testing.T) {
+	if err := checkBalancedQuotes(`"/usr/local/bin/grafel" watch "/tmp/quote"repo"`); err == nil {
+		t.Error("expected an unbalanced-quote value to be rejected")
+	}
+	if err := checkBalancedQuotes(`"/usr/local/bin/grafel" watch "/tmp/quote\"repo"`); err != nil {
+		t.Errorf("a properly backslash-escaped quote (what %%q always produces) must not be "+
+			"flagged as unbalanced: %v", err)
+	}
+}
+
+// TestSystemdUnit_OracleDetectsInjectedKeyWithoutDuplication closes the
+// "load-bearing coincidence" gap: hostileControl's injected content happens
+// to re-declare "[Service]" and "ExecStart=", both of which the legitimate
+// template already emits, so parseSystemdUnit's duplicate-key check alone
+// is enough to reject it — independent of whether the allow-list
+// (findInjections/assertNoInjection) is ever exercised. This constructs a
+// structurally well-formed unit where the injected key (ExecStartPost) has
+// no duplicate anywhere, so only the allow-list can catch it, proving that
+// detection generalizes rather than depending on the specific fixture.
+func TestSystemdUnit_OracleDetectsInjectedKeyWithoutDuplication(t *testing.T) {
+	body := "[Unit]\n" +
+		"Description=grafel watcher (demo/repo)\n" +
+		"After=default.target\n" +
+		"StartLimitIntervalSec=3600\n" +
+		"StartLimitBurst=5\n" +
+		"\n" +
+		"[Service]\n" +
+		"Type=simple\n" +
+		`ExecStart="/bin/grafel" watch "/tmp/r"` + "\n" +
+		"WorkingDirectory=/tmp/r\n" +
+		"Restart=on-failure\n" +
+		"RestartSec=60\n" +
+		"ExecStartPost=/bin/sh\n" + // genuinely new key: no duplicate anywhere in this body
+		"\n" +
+		"[Install]\n" +
+		"WantedBy=default.target\n"
+
+	p, err := parseSystemdUnit(body)
+	if err != nil {
+		t.Fatalf("parser rejected a structurally well-formed (if hostile) unit — this test needs "+
+			"a body the parser accepts so findInjections is what does the catching: %v\n%s", err, body)
+	}
+	got := p.findInjections()
+	if len(got) == 0 {
+		t.Fatal("findInjections failed to flag ExecStartPost — a key with no legitimate " +
+			"counterpart anywhere in the template and no duplicate to trigger on instead (#6185 R4)")
+	}
+	found := false
+	for _, msg := range got {
+		if strings.Contains(msg, "ExecStartPost") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("findInjections flagged something, but not ExecStartPost specifically: %v", got)
+	}
 }

--- a/internal/install/watchers/systemd_injection_6185_test.go
+++ b/internal/install/watchers/systemd_injection_6185_test.go
@@ -208,7 +208,7 @@ func (p *parsedUnit) findInjections() []string {
 			continue
 		}
 		for k := range keys {
-			if !contains(allowed, k) {
+			if !containsString(allowed, k) {
 				problems = append(problems, fmt.Sprintf("unexpected key %q in [%s] (possible injected directive): %v", k, section, keys))
 			}
 		}
@@ -221,15 +221,6 @@ func (p *parsedUnit) assertNoInjection(t *testing.T) {
 	for _, msg := range p.findInjections() {
 		t.Error(msg)
 	}
-}
-
-func contains(list []string, s string) bool {
-	for _, x := range list {
-		if x == s {
-			return true
-		}
-	}
-	return false
 }
 
 // TestSystemdUnit_ParsesCleanly is the sanity check for the oracle itself:

--- a/internal/install/watchers/systemd_percent_6185_test.go
+++ b/internal/install/watchers/systemd_percent_6185_test.go
@@ -1,0 +1,71 @@
+package watchers
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// percentHostile is a Unit whose group and repo path contain '%', the
+// systemd specifier-escape character. systemd requires '%%' for a literal
+// percent; a raw '%' yields a broken ExecStart that systemd silently
+// rejects, so the watcher never runs and nothing explains why (#6185).
+//
+// This is a different escape rule from the XML fix in #6179: xmlEsc is wrong
+// for INI and '%%' is wrong for XML, so this is deliberately its own check,
+// not a shared "escape for output format" helper.
+var percentHostile = Unit{
+	Group:   "R%D",
+	Repo:    "/tmp/100%done",
+	BinPath: "/usr/local/bin/graf%el",
+}
+
+// TestSystemdUnit_EscapesPercent pins #6185. Before the fix every
+// interpolated field (Group, Repo, BinPath) went into the INI body raw.
+func TestSystemdUnit_EscapesPercent(t *testing.T) {
+	body := SystemdUnit(percentHostile)
+
+	if strings.Contains(body, "R%D") {
+		t.Errorf("group's raw '%%' survived unescaped:\n%s", body)
+	}
+	if strings.Contains(body, "100%done") {
+		t.Errorf("repo path's raw '%%' survived unescaped:\n%s", body)
+	}
+	if strings.Contains(body, "graf%el") {
+		t.Errorf("bin path's raw '%%' survived unescaped:\n%s", body)
+	}
+	if !strings.Contains(body, "R%%D") {
+		t.Errorf("expected the group's '%%' escaped to '%%%%':\n%s", body)
+	}
+	if !strings.Contains(body, "100%%done") {
+		t.Errorf("expected the repo path's '%%' escaped to '%%%%':\n%s", body)
+	}
+	if !strings.Contains(body, "graf%%el") {
+		t.Errorf("expected the bin path's '%%' escaped to '%%%%':\n%s", body)
+	}
+}
+
+// TestSystemdUnit_SystemdAnalyzeVerify runs systemd-analyze verify over a
+// generated unit where available — the systemd-side equivalent of the
+// plutil -lint test that pins the macOS half of #6179.
+func TestSystemdUnit_SystemdAnalyzeVerify(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("systemd-analyze is Linux-only")
+	}
+	bin, err := exec.LookPath("systemd-analyze")
+	if err != nil {
+		t.Skip("systemd-analyze not on PATH")
+	}
+	for name, u := range map[string]Unit{"plain": sample, "hostile": percentHostile} {
+		path := filepath.Join(t.TempDir(), name+".service")
+		if err := os.WriteFile(path, []byte(SystemdUnit(u)), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if out, err := exec.Command(bin, "verify", "--no-pager", path).CombinedOutput(); err != nil {
+			t.Errorf("systemd-analyze verify rejected the %s unit: %v\n%s\n%s", name, err, out, SystemdUnit(u))
+		}
+	}
+}

--- a/internal/install/watchers/trailing_backslash_r3_test.go
+++ b/internal/install/watchers/trailing_backslash_r3_test.go
@@ -1,0 +1,63 @@
+package watchers
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// #6185 R3 (found on round-2 review): '\' is not a control byte, so
+// validateUnitFields accepted it, but systemd.syntax(7) treats a line ending
+// in '\' as continuing onto the next physical line — the two lines are
+// concatenated as if the newline between them were not there. A repo path
+// of "/tmp/back\\" renders:
+//
+//	WorkingDirectory=/tmp/back\
+//	Restart=on-failure
+//
+// which systemd reads as "WorkingDirectory=/tmp/back Restart=on-failure":
+// Restart=on-failure silently disappears (removing #6179's crash-recovery
+// half) and WorkingDirectory points at a directory that doesn't exist, so
+// the unit fails to start. '\' is a legal character in a Linux filename, so
+// this is reachable without any other validation catching it.
+//
+// WorkingDirectory=%s is the only line in the current template where a raw
+// (non-%q-quoted) field is the last thing before the newline — ExecStart's
+// two fields go through Go's %q, which always closes with an actual '"'
+// (it escapes a trailing backslash inside the string as "\\", never leaves
+// a bare one at the end), and every other line ends in a literal (")",
+// a digit, or a fixed suffix) supplied by the format string itself, not by
+// the field. So only a trailing backslash on Repo is reachable.
+
+// TestWrite_RejectsTrailingBackslashInRepo pins the fix: Write refuses a
+// Repo ending in '\' rather than silently deleting the next directive.
+func TestWrite_RejectsTrailingBackslashInRepo(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("GRAFEL_HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
+
+	u := Unit{Group: "ok", Repo: "/tmp/back\\", BinPath: "/usr/local/bin/grafel"}
+	if path, err := Write(u); err == nil {
+		os.Remove(path)
+		t.Fatalf("Write(%+v) succeeded, want rejection of the trailing backslash "+
+			"(#6185 R3); wrote %s", u, path)
+	}
+}
+
+// TestSystemdUnit_TrailingBackslashDeletesTheNextDirective demonstrates the
+// defect directly against the raw renderer (bypassing Write's guard, as the
+// unfixed code would have persisted it) — the render this test inspects is
+// exactly what ships on disk if validateUnitFields does not catch it.
+func TestSystemdUnit_TrailingBackslashDeletesTheNextDirective(t *testing.T) {
+	u := Unit{Group: "ok", Repo: "/tmp/back\\", BinPath: "/usr/local/bin/grafel"}
+	body := SystemdUnit(u)
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "WorkingDirectory=") && strings.HasSuffix(line, "\\") {
+			return // confirmed: the line-continuation hazard is present in the raw render
+		}
+	}
+	t.Fatalf("expected a WorkingDirectory= line ending in a raw backslash in the unguarded "+
+		"render; the test fixture or renderer changed:\n%s", body)
+}

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -427,6 +427,23 @@ func validateUnitFields(u Unit) error {
 				"(it could inject a directive into a line-oriented unit format)", name)
 		}
 	}
+	// #6185 R3 (found on review): '\' is not a control byte, but
+	// systemd.syntax(7) treats a line ending in '\' as continuing onto the
+	// next physical line — the two lines are concatenated as if the newline
+	// between them were absent. SystemdUnit's WorkingDirectory=%s is the
+	// only line in the template where a raw (non-%q-quoted) field is the
+	// last thing before the newline: ExecStart's fields go through Go's %q,
+	// which always closes with an actual '"' (a trailing backslash inside
+	// the value is escaped as "\\", never left bare at the line end), and
+	// every other line ends in a literal supplied by the format string
+	// itself. A Repo ending in '\' therefore silently deletes the directive
+	// on the following line (Restart=on-failure) and leaves
+	// WorkingDirectory pointing at the wrong text — '\' is a legal character
+	// in a Linux filename, so this is reachable in practice.
+	if strings.HasSuffix(u.Repo, `\`) {
+		return fmt.Errorf("watcher unit field Repo ends in a backslash, refusing to write " +
+			"(systemd would treat it as a line continuation and delete the next directive)")
+	}
 	return nil
 }
 

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -85,6 +85,22 @@ func xmlEsc(s string) string {
 	return b.String()
 }
 
+// iniEsc escapes s for inclusion in a systemd unit (INI-format) value.
+//
+// #6185: systemd treats '%' as a specifier escape (e.g. %h for the user's
+// home) and requires '%%' for a literal percent. Group names and repo paths
+// are user-supplied, so a repo path containing '%' previously produced an
+// ExecStart line systemd silently rejects — the unit fails to register and
+// nothing says why, the INI counterpart of the XML bug xmlEsc fixed in #6179.
+//
+// This is deliberately its own function, not shared with xmlEsc: the two
+// escape rules are unrelated (xmlEsc is wrong for INI, '%%' is wrong for
+// XML), so a shared "escape for output format" helper would be the wrong
+// abstraction.
+func iniEsc(s string) string {
+	return strings.ReplaceAll(s, "%", "%%")
+}
+
 // Unit describes a single watcher unit to install.
 type Unit struct {
 	Group   string
@@ -272,8 +288,8 @@ RestartSec=%d
 
 [Install]
 WantedBy=default.target
-`, u.Group, filepath.Base(u.Repo), StartLimitIntervalSeconds, StartLimitBurst,
-		u.BinPath, u.Repo, u.Repo, RestartSecSeconds)
+`, iniEsc(u.Group), iniEsc(filepath.Base(u.Repo)), StartLimitIntervalSeconds, StartLimitBurst,
+		iniEsc(u.BinPath), iniEsc(u.Repo), iniEsc(u.Repo), RestartSecSeconds)
 }
 
 // SchtasksXML returns a Windows Task Scheduler XML definition.

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -394,11 +394,50 @@ func Render(u Unit) string {
 	return ""
 }
 
+// hasControlByte reports whether s contains an ASCII control byte (0x00-0x1F
+// or 0x7F), including NUL, CR and LF.
+//
+// #6185 F3 (found on review): iniEsc only escapes '%', which is the only
+// character systemd's INI-format unit gives a per-value escape for. A
+// newline has no such escape — WorkingDirectory=, Description=, etc. take
+// the rest of the physical line literally, so an embedded '\n' always starts
+// a new line that systemd's line-oriented parser reads as a new directive
+// (e.g. a repo path of ".../r\nExecStartPost=/bin/sh" injects a directive
+// that runs at login). The plist/schtasks XML formats are not vulnerable to
+// this — XML escaping keeps an embedded newline inside character data, it
+// does not create new structure — so this check is scoped to what actually
+// needs it: the fields that reach the systemd render.
+func hasControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return true
+		}
+	}
+	return false
+}
+
+// validateUnitFields rejects Group/Repo/BinPath values that could break the
+// line-oriented systemd unit format. There is no per-value escape for a
+// control character the way there is for '%', so the only correct fix is to
+// refuse to render/persist the unit at all.
+func validateUnitFields(u Unit) error {
+	for name, v := range map[string]string{"Group": u.Group, "Repo": u.Repo, "BinPath": u.BinPath} {
+		if hasControlByte(v) {
+			return fmt.Errorf("watcher unit field %s contains a control character, refusing to write "+
+				"(it could inject a directive into a line-oriented unit format)", name)
+		}
+	}
+	return nil
+}
+
 // Write writes the unit file to its canonical path. Caller is
 // responsible for invoking the OS-native loader (`launchctl load`,
 // `systemctl --user daemon-reload`, or `schtasks /create /xml`) — we
 // keep this package free of side effects beyond the file.
 func Write(u Unit) (string, error) {
+	if err := validateUnitFields(u); err != nil {
+		return "", err
+	}
 	path, err := UnitPath(u)
 	if err != nil {
 		return "", err

--- a/internal/registry/group_name_6186_test.go
+++ b/internal/registry/group_name_6186_test.go
@@ -50,6 +50,48 @@ func TestAddGroup_AcceptsOrdinaryNames(t *testing.T) {
 	}
 }
 
+// TestAddGroup_RejectsControlWhitespaceAndOverlength pins #6186 F5 (found on
+// review): the first cut of validateGroupName only blocked path separators
+// and "."/"..", so all of these were accepted and persisted:
+//
+//	AddGroup("g\n[Service]\nExecStart=evil", ...) -> nil  (reaches Description=
+//	                                                        in the systemd unit)
+//	AddGroup("g\rh", ...)      -> nil  (breaks the Label launchd/systemd expect)
+//	AddGroup("   ", ...)       -> nil  (whitespace-only Label)
+//	AddGroup("\x00", ...)      -> nil  (later ConfigPathFor/StateDirFor/plist
+//	                                     ops fail EINVAL forever)
+//	AddGroup("g\x00h", ...)    -> nil  (same)
+//	AddGroup(<300 bytes>, ...) -> nil  (pushes ConfigPathFor past NAME_MAX=255
+//	                                     on APFS)
+func TestAddGroup_RejectsControlWhitespaceAndOverlength(t *testing.T) {
+	home := withHome(t)
+	cfgPath := filepath.Join(home, "xdg", "grafel", "g.fleet.json")
+	writeFleetFixture(t, cfgPath)
+
+	long := make([]byte, 300)
+	for i := range long {
+		long[i] = 'a'
+	}
+
+	for _, bad := range []string{
+		"g\n[Service]\nExecStart=evil",
+		"g\rh",
+		"   ",
+		"\x00",
+		"g\x00h",
+		string(long),
+	} {
+		if err := AddGroup(bad, cfgPath); err == nil {
+			t.Errorf("AddGroup(%q) succeeded; want rejection (#6186 F5)", bad)
+		}
+	}
+
+	groups, _ := Groups()
+	if len(groups) != 0 {
+		t.Fatalf("expected no groups registered after rejected names, got %d: %+v", len(groups), groups)
+	}
+}
+
 func writeFleetFixture(t *testing.T, path string) {
 	t.Helper()
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {

--- a/internal/registry/group_name_6186_test.go
+++ b/internal/registry/group_name_6186_test.go
@@ -1,0 +1,61 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// #6186: slugify sanitises the repo segment of a watcher Label but not the
+// group segment, and AddGroup only checked non-empty. A group named "g/h"
+// makes Unit.Label() = "com.grafel.watcher.g/h.<repo>", and watchers.Write
+// does os.MkdirAll(filepath.Dir(path)), so that group creates a DIRECTORY
+// inside ~/Library/LaunchAgents (which launchd does not scan) and the
+// watcher is silently never registered. A group named "../x" escapes
+// ~/Library/LaunchAgents entirely.
+//
+// Fix: validate at the registry boundary (AddGroup), not by sanitising at
+// plist-write time, so the constraint is visible when the group is created.
+// This intentionally does NOT touch slugify or Unit.Label() (#6183 owns
+// that).
+func TestAddGroup_RejectsPathSeparatorInName(t *testing.T) {
+	home := withHome(t)
+	cfgPath := filepath.Join(home, "xdg", "grafel", "g.fleet.json")
+	writeFleetFixture(t, cfgPath)
+
+	for _, bad := range []string{"g/h", "g\\h", "../escape", "."} {
+		if err := AddGroup(bad, cfgPath); err == nil {
+			t.Errorf("AddGroup(%q) succeeded; want rejection — a group name containing a path "+
+				"separator turns into a directory inside ~/Library/LaunchAgents (#6186)", bad)
+		}
+	}
+
+	groups, _ := Groups()
+	if len(groups) != 0 {
+		t.Fatalf("expected no groups registered after rejected names, got %d: %+v", len(groups), groups)
+	}
+}
+
+// TestAddGroup_AcceptsOrdinaryNames pins that the fix does not overreach:
+// group names derived from real directory basenames (which commonly contain
+// spaces, dots, and underscores) must keep working.
+func TestAddGroup_AcceptsOrdinaryNames(t *testing.T) {
+	home := withHome(t)
+	for _, ok := range []string{"grafel", "my-group", "my_group", "my.group", "My Group"} {
+		cfgPath := filepath.Join(home, "xdg", "grafel", ok+".fleet.json")
+		writeFleetFixture(t, cfgPath)
+		if err := AddGroup(ok, cfgPath); err != nil {
+			t.Errorf("AddGroup(%q) failed, want success: %v", ok, err)
+		}
+	}
+}
+
+func writeFleetFixture(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -305,12 +305,51 @@ func saveTo(path string, r *Registry) error {
 	return atomicfile.WriteFile(path, b, 0o644)
 }
 
+// validateGroupName rejects group names that are unsafe as a filesystem path
+// segment (#6186).
+//
+// Group is interpolated raw into Unit.Label(), which is both the watcher
+// plist's filename and launchd's job identity (internal/install/watchers).
+// A group containing a path separator — e.g. "g/h" — turns
+// "com.grafel.watcher.g/h.<repo>.plist" into a path with an intermediate
+// directory component; watchers.Write then os.MkdirAll's that directory
+// inside ~/Library/LaunchAgents, which launchd does not scan, so the watcher
+// is silently never registered. A name like "../escape" or "." escapes (or
+// collides with) that directory entirely.
+//
+// This intentionally validates only the two concrete failure modes above
+// (path separators and "."/".." path segments) rather than reusing
+// slugify's full alnum-only character class: group names are commonly
+// derived from a directory basename (defaultGroupName in internal/cli/
+// wizard.go), which routinely contains spaces, dots, and underscores — none
+// of those are unsafe as a single path segment, and rejecting them would be
+// a regression for existing onboarding flows. Only characters that can
+// actually create or traverse a directory are blocked.
+//
+// This check runs at AddGroup (registration) only, not at Load/Groups() —
+// registries that already contain an invalid name (written before this fix,
+// or edited by hand) must keep loading normally. Rejecting on load would
+// turn a silently-broken watcher into a hard failure to even read the
+// registry, which is worse than the bug being fixed.
+func validateGroupName(name string) error {
+	if name == "" {
+		return errors.New("group name required")
+	}
+	if strings.ContainsAny(name, "/\\") {
+		return fmt.Errorf("group name %q must not contain a path separator", name)
+	}
+	if name == "." || name == ".." {
+		return fmt.Errorf("group name %q is not a valid path segment", name)
+	}
+	return nil
+}
+
 // AddGroup adds a group to the registry and persists. Idempotent: if the
 // group already exists it is updated in place. The config file must exist
 // at the target path; otherwise an error is returned.
 func AddGroup(name, configPath string) error {
-	if name == "" {
-		return errors.New("group name required")
+	if err := validateGroupName(name); err != nil {
+		return err
 	}
 	// Validate that the config file exists.
 	if _, err := os.Stat(configPath); err == os.ErrNotExist {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -230,12 +230,48 @@ func ConfigDir() (string, error) {
 }
 
 // ConfigPathFor returns the standard config-path for a group name.
+//
+// This is a READ-safe derivation: it is also used to resolve the config path
+// of an already-registered group (docgen, doctor, export, the CLI group
+// list, ...), including one written before ValidateGroupName existed or
+// whose name is otherwise grandfathered-invalid. It intentionally does NOT
+// validate name — see ValidateGroupName's doc comment for why gating reads
+// would be worse than the bug it prevents. Callers about to CREATE or
+// OVERWRITE a config file for a name that is not yet known-registered MUST
+// use ConfigPathForNew instead.
 func ConfigPathFor(name string) (string, error) {
 	d, err := ConfigDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(d, name+".fleet.json"), nil
+}
+
+// ConfigPathForNew is the write-side counterpart of ConfigPathFor: it
+// validates name before deriving the path.
+//
+// #6186 R1 (found on review): the F6 fix added a ValidateGroupName call
+// ahead of SaveGroupConfig at AddGroup's four known callers, enumerated by
+// hand. A fifth writer — the archive-import handler in
+// internal/dashboard/handlers_v2_graph_export.go, which takes its group name
+// from an uploaded ZIP's manifest.json or a request query parameter — used
+// ConfigPathFor + SaveGroupConfig with no validation anywhere on that path,
+// because it was never on the enumerated list. filepath.Join collapses
+// "..", so a manifest group of "../../../../tmp/pwn" made SaveGroupConfig
+// write a file outside the config directory before AddGroup's (too-late)
+// rejection ever ran.
+//
+// The fix to that shape, not just that site: a validated derivation that is
+// structurally distinct from the read path, so a NEW writer reaches into
+// this function by construction rather than by remembering to call
+// ValidateGroupName itself. Use this (not ConfigPathFor) at any call site
+// that is about to create or overwrite a group's config file for a name
+// that is not already a trusted, registered group.
+func ConfigPathForNew(name string) (string, error) {
+	if err := ValidateGroupName(name); err != nil {
+		return "", err
+	}
+	return ConfigPathFor(name)
 }
 
 // StateDirFor returns the per-group state directory under HomeDir.

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -305,8 +305,18 @@ func saveTo(path string, r *Registry) error {
 	return atomicfile.WriteFile(path, b, 0o644)
 }
 
-// validateGroupName rejects group names that are unsafe as a filesystem path
-// segment (#6186).
+// maxGroupNameBytes bounds how long a group name may be.
+//
+// ConfigPathFor appends ".fleet.json" (11 bytes) to the name to form a
+// filename; StateDirFor uses the name as a bare directory component. Most
+// filesystems this ships on (APFS, ext4, NTFS's practical limit) cap a single
+// path component at 255 bytes. 100 leaves generous headroom for the
+// ".fleet.json" suffix and any future per-name derived filenames, without
+// being so tight it constrains a real (if unusually long) project name.
+const maxGroupNameBytes = 100
+
+// ValidateGroupName rejects group names that are unsafe as a filesystem path
+// segment (#6186, widened by #6186 F5).
 //
 // Group is interpolated raw into Unit.Label(), which is both the watcher
 // plist's filename and launchd's job identity (internal/install/watchers).
@@ -317,22 +327,37 @@ func saveTo(path string, r *Registry) error {
 // is silently never registered. A name like "../escape" or "." escapes (or
 // collides with) that directory entirely.
 //
-// This intentionally validates only the two concrete failure modes above
-// (path separators and "."/".." path segments) rather than reusing
-// slugify's full alnum-only character class: group names are commonly
-// derived from a directory basename (defaultGroupName in internal/cli/
-// wizard.go), which routinely contains spaces, dots, and underscores — none
-// of those are unsafe as a single path segment, and rejecting them would be
-// a regression for existing onboarding flows. Only characters that can
-// actually create or traverse a directory are blocked.
+// Also rejected, per review of the first cut of this fix:
+//   - control characters / NUL: "g\n[Service]\nExecStart=evil" reaches
+//     Description= in the rendered systemd unit (see
+//     internal/install/watchers' validateUnitFields, which independently
+//     guards the write path — this is defense at the earlier, more visible
+//     boundary) and "g\x00h" makes every later ConfigPathFor/StateDirFor/
+//     plist path operation fail EINVAL, leaving a registry entry that can
+//     never be materialised.
+//   - all-whitespace: produces a Label launchd will not accept — the exact
+//     silent-non-registration failure mode #6186 exists to prevent.
+//   - over-length: risks exceeding NAME_MAX on the derived path.
 //
-// This check runs at AddGroup (registration) only, not at Load/Groups() —
-// registries that already contain an invalid name (written before this fix,
-// or edited by hand) must keep loading normally. Rejecting on load would
-// turn a silently-broken watcher into a hard failure to even read the
-// registry, which is worse than the bug being fixed.
-func validateGroupName(name string) error {
-	if name == "" {
+// This intentionally does NOT reuse slugify's full alnum-only character
+// class: group names are commonly derived from a directory basename
+// (defaultGroupName in internal/cli/wizard.go), which routinely contains
+// spaces, dots, and underscores — none of those are unsafe as a single path
+// segment, and rejecting them would be a regression for existing onboarding
+// flows. Only characters/shapes that can actually create/traverse a
+// directory, corrupt a derived path, or break the watcher formats are
+// blocked.
+//
+// This check runs at group-creation time (AddGroup, and — per #6186 F6,
+// callers must invoke it before ever calling SaveGroupConfig — see
+// internal/cli/wizard.go, internal/cli/onboard.go, internal/install/
+// install.go, internal/dashboard/store.go), not at Load/Groups(): registries
+// that already contain an invalid name (written before this fix, or edited
+// by hand) must keep loading normally. Rejecting on load would turn a
+// silently-broken watcher into a hard failure to even read the registry,
+// which is worse than the bug being fixed.
+func ValidateGroupName(name string) error {
+	if strings.TrimSpace(name) == "" {
 		return errors.New("group name required")
 	}
 	if strings.ContainsAny(name, "/\\") {
@@ -341,14 +366,35 @@ func validateGroupName(name string) error {
 	if name == "." || name == ".." {
 		return fmt.Errorf("group name %q is not a valid path segment", name)
 	}
+	if hasControlByte(name) {
+		return fmt.Errorf("group name %q must not contain a control character", name)
+	}
+	if len(name) > maxGroupNameBytes {
+		return fmt.Errorf("group name %q is %d bytes, want at most %d", name, len(name), maxGroupNameBytes)
+	}
 	return nil
+}
+
+// hasControlByte reports whether s contains an ASCII control byte (0x00-0x1F
+// or 0x7F), including NUL, CR and LF. Mirrors
+// internal/install/watchers.hasControlByte; kept as an independent,
+// unexported copy rather than a shared dependency between the two packages
+// for what is a five-line check with different callers and different
+// rationale (path-segment safety here vs. unit-format injection there).
+func hasControlByte(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if s[i] < 0x20 || s[i] == 0x7f {
+			return true
+		}
+	}
+	return false
 }
 
 // AddGroup adds a group to the registry and persists. Idempotent: if the
 // group already exists it is updated in place. The config file must exist
 // at the target path; otherwise an error is returned.
 func AddGroup(name, configPath string) error {
-	if err := validateGroupName(name); err != nil {
+	if err := ValidateGroupName(name); err != nil {
 		return err
 	}
 	// Validate that the config file exists.

--- a/internal/registry/registry_test.go
+++ b/internal/registry/registry_test.go
@@ -11,6 +11,12 @@ import (
 func withHome(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	// HOME is redundant with GRAFEL_HOME today (registry.HomeDir() checks
+	// GRAFEL_HOME first and never falls through to os.UserHomeDir() when it's
+	// set), but per the hard isolation gate (round-2 review of #6184/#6185/
+	// #6186), isolate all three so this helper stays safe if that check order
+	// ever changes.
+	t.Setenv("HOME", dir)
 	t.Setenv("GRAFEL_HOME", dir)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, "xdg"))
 	return dir


### PR DESCRIPTION
Three small issues from the #6179 review. Two turned out larger than filed, and one turned into a security fix.

## #6186 — a group name from an untrusted archive wrote outside the config directory

`slugify` sanitises the *repo* segment of a watcher label but not the *group* segment, and `registry.AddGroup` validated only that a group name was non-empty. Measured: `Unit{Group:"g/h"}` yields `~/Library/LaunchAgents/com.grafel.watcher.g/h.r.plist`, and because `watchers.Write` does `os.MkdirAll(filepath.Dir(path))` that creates a **directory** inside `LaunchAgents` — which launchd does not scan — so the watcher is silently never registered. `../…` writes outside `LaunchAgents` entirely.

**The first fix validated at `AddGroup` and was measurably too late.** Every real caller writes the group config *before* calling it — `wizard.go:444→447`, `onboard.go:101→104`, `install.go:148→151`, `dashboard/store.go:407→410` — and `ConfigPathFor` `filepath.Join`s the raw name, which collapses `..`:

```
ConfigPathFor("../../pwned") = <XDG>/../../pwned.fleet.json  → <parent>/pwned.fleet.json
SaveGroupConfig WROTE outside config dir; exists=true
AddGroup rejects afterwards: must not contain a path separator
```

So the issue's own headline input still performed the write, with the rejection arriving after the damage and leaving a stray file.

**The second fix moved validation ahead of all four writers — and review found a fifth that takes its group name from an uploaded ZIP.** `handlers_v2_graph_export.go:295-397` runs the pre-fix sequence with no validation anywhere: `finalGroup := manifest.Group` → `RepoDocsDir(finalGroup, …)` → `MkdirAll` → `extractZipPrefix` (attacker-controlled contents) → `BusinessDocsDir` → `MkdirAll` + extract → `ConfigPathFor` → `SaveGroupConfig` → `AddGroup` rejects, far too late. Measured:

```
group="../../../../tmp/pwn"
  RepoDocsDir     = <T>/tmp/pwn/r
  BusinessDocsDir = <T>/tmp/pwn/business
MkdirAll SUCCEEDED outside docs root
```

**Arbitrary file write from an untrusted archive**, and `../../Library/LaunchAgents` is not a hypothetical target on this codebase.

That is the shape the review named: *a validation on four of several writers is not a validation.* So the fix is structural — new `registry.ConfigPathForNew`, `daemon.RepoDocsDirForNew`, `daemon.BusinessDocsDirForNew`: validated **write-side** derivations, distinct from the read-side functions, plus an early fail-fast gate in the handler.

Review swept every caller of the three read-side derivations and found **no sixth writer**: `ConfigPathFor` has 13 non-test callers, all reads except `install.go:142` (covered by `Apply`'s gate); `internal/cli/tools.go:229` looked like a candidate but its write is unreachable for an unregistered name because `LoadGroupConfig` ENOENTs first; `RepoDocsDir`/`BusinessDocsDir` have 6 callers, all reads. Layering confirmed by mutation: reverting **only** the early gate still fails at the `ForNew` derivations.

`extractZipPrefix` was audited and is zip-slip safe — `filepath.Join(absRoot, rel)` cleans the traversal and the guard uses the sibling-safe `HasPrefix(destPath+sep, absRoot+sep)` form rather than a naked prefix; directory entries are skipped and files go through `os.Create`, so no symlink can be materialised. The other untrusted-archive vector, `StateDirForRepo(rp.Path)` from the uploaded fleet.json, is contained: `repoBaseDir` maps through `repoSlug`/`repoStateHash` after `Abs`+`Clean`, so it is a name derivation rather than a path pass-through.

**Read paths are deliberately still ungated.** They are also used to read already-registered — possibly already-invalid — groups across docgen, doctor, export and the daemon; gating reads would turn a silently-broken watcher into a hard failure to even list the group. The validated set is deliberately narrower than `slugify`'s: group names are commonly directory basenames with spaces, dots and underscores (`defaultGroupName`), so an alnum-only rule would break ordinary onboarding. Rejected: path separators, `.`/`..`, control characters and NUL, all-whitespace, and over 100 bytes (100 + `.fleet.json` = 111, well under `NAME_MAX` 255 on APFS).

## #6185 — systemd directive injection, and rejection rather than escaping

The systemd unit interpolated `Group`, `Repo` and `BinPath` raw into INI. `%` is a systemd specifier needing `%%`, so a repo path containing one yields a broken `ExecStart` that systemd silently rejects — the same silent-non-registration class as the unescaped `&` fixed for the plist in #6179. `iniEsc` handles that, deliberately separate from `xmlEsc`: the escape rules differ and a shared "escape for output format" helper would be the wrong abstraction.

**But `%` was not the whole surface.** `WorkingDirectory=%s` is interpolated unquoted, so a newline in a repo path or group name injects arbitrary directives:

```
ExecStart="/usr/local/bin/grafel" watch "/tmp/r\nExecStartPost=/bin/sh"
WorkingDirectory=/tmp/r
ExecStartPost=/bin/sh          <-- injected, runs at login
```

`ExecStart` survived only because Go's `%q` escaped the newline. And the injecting group name **passed the validator added in the same branch** — two fixes, each defensible alone, exploitable together.

Fixed by **rejecting** rather than escaping: `validateUnitFields` refuses any `Group`/`Repo`/`BinPath` containing a control byte. There is no per-value escape for a newline in a line-oriented INI format, so refusing to persist is the only sound answer — `systemd-escape` operates on unit *names*, not values. Review independently endorsed the direction and checked the "legitimate path" worries: a tab would break the unit anyway, and a CR from a Windows-authored config cannot reach here because the fleet config is JSON.

A trailing `\` is also rejected. `systemd.syntax(7)` concatenates a line ending in backslash with the next, so `WorkingDirectory=/tmp/back\` makes systemd read `WorkingDirectory=/tmp/back Restart=on-failure` — **silently deleting `Restart=on-failure`**, removing the crash-recovery half of #6179, with the unit pointing at a nonexistent path. `\` is legal in a Linux filename. `WorkingDirectory` is the only bare-tail field; `ExecStart` goes through `%q`, which always closes on `"`.

`install.Apply`'s per-repo watcher-write failure is now **non-fatal** (warn and continue), matching `watchersync`. `WatcherWarnings` is genuinely surfaced (`cli/wizard.go:497`, `wiztui/indexview.go:657`), so degrading does not recreate the silent-non-registration failure this issue family is about — whereas fatal would deny watchers to 139 other repos for a condition the user can see and fix.

## #6184 — the timeout did not bound the wall clock, and its test could not tell

`refreshWatcherRefreshCmd` used `exec.CommandContext` with no `WaitDelay`. `CommandContext` SIGKILLs **only the direct child**, and `CombinedOutput` blocks until every pipe writer closes — so a wedged `launchctl` grandchild inherits the descriptor and survives the kill. Measured against the real function with a 1s deadline:

```
elapsed=20.551s  err=signal: killed  out="partial\n"
```

The user-visible symptom — a hung `grafel update` with no output — was unchanged; the only addition was that it eventually printed "timed out". Fixed with `cmd.WaitDelay`, reusing the existing `internal/gitmeta` `applyWaitDelay`/`waitDelayGrace` precedent, whose comment describes this exact failure.

**The first test could not have caught it**, substituting the command runner with a stub that honours the context by construction — so it asserted that `context.WithTimeout` works and never touched the exec behaviour that fails.

**The replacement was worse: measurably vacuous 6 times out of 8.** Its 300ms deadline usually expired before the shell had forked the grandchild, so nothing held the pipe. Eight runs against the mutant: 2 real failures, 6 vacuous passes — a ~75% false-green on a loaded machine.

Fixed by removing the race rather than widening the deadline: the child signals readiness with a file touch after backgrounding its grandchild, and the test polls for that. Mutant `-count=8` → **8/8 FAIL**, bounded at ~10.4-11.0s by the test's own safety timeout, no runaway. Restored code `-count=8` → exit 0.

## Test quality

The systemd oracle replaced six `strings.Contains` checks with a real INI/unit parser walking section and key structure. Two problems review found in it, both fixed: `checkBalancedQuotes` applied to every value including `Description=`, where systemd does no word-splitting, so it would false-positive on any legitimate quoted group name — now scoped to `ExecStart`; and `systemdExpectedKeys` detected injection **only because all five `[Service]` keys were already emitted**, making any injected key a duplicate — load-bearing coincidence, not design, now closed by a test feeding a well-formed body whose injected key duplicates nothing.

The oracle was also only ever fed inputs the validator already rejects, so it tested the guard rather than the renderer. It is now pointed at the non-control hostile cases.

The traversal test's own escaped write landed four levels above `t.TempDir()`, in the shared temp root nothing cleans — and `isUnsafeTestWritePath` explicitly exempts `os.TempDir()`, so the registry guard would never catch it. The sandbox is now nested five levels deep so a traversal on the red path stays inside `t.TempDir()`; verified by re-mutating all three guards out and confirming a `find` sweep of the shared root turns up nothing.

## Verification

`go build ./...` 0, `go vet ./...` 0, `gofmt -l .` empty. Unpiped `$?`, `-count=1 -p 1`: a full targeted sweep across `install`, `install/watchers`, `cli`, `registry`, `dashboard`, `daemon` — **exit 0, every package ok, none skipped** — run after the rebase onto #6183, plus `TestGraphImport_|Traversal` and the `WaitDelay` test at `-count=8`, both 0.

Independently adversarially reviewed three times (REQUEST-CHANGES → REQUEST-CHANGES → APPROVE), with the reviewer re-running its own probes against each revision and confirming `~/.claude.json`, `~/.grafel/registry.json` and `~/Library/LaunchAgents` unchanged.

## Corrected for the record

An earlier report claimed the suite "passed with no panic, which is the guard's signature failure mode, so it did not trip." **There is no guard on that path.** `testing.Testing()` guards exist only in `internal/registry` and `internal/install/mcpreg`; `internal/install/watchers`' default runner shells to real `launchctl` unconditionally, and `Unload`/`Status` bypass `SetLaunchctlRunnerForTest` entirely with direct `exec.Command`.

The conclusion was right for a different reason: `Unload` calls the read-only `launchctl list <label>` first, and for a label never actually bootstrapped (because only `Load` routes through the fake seam) that returns non-zero and short-circuits before the mutating `bootout`. `~/Library/LaunchAgents` confirmed unchanged throughout. *"No panic, therefore safe"* from an absent guard is the same inference shape this issue family is about, so it is retracted explicitly rather than left standing.

## Filed separately, not fixed here

- **#6194** — `os.RemoveAll(registry.StateDirFor(group))` on an unvalidated name at `install.go:537` and `daemon/service.go:1330`. The read/write split deliberately leaves reads ungated, but a delete is where an unvalidated grandfathered name stops being misplaced and becomes destructive.
- A narrow interaction with #6183: if a registered repo path contains a control byte or trailing `\`, #6183's migration deletes the legacy plist and this branch's `Write` refuses the replacement, so the repo ends with no watcher where it had one. Requires a path no real checkout has, and degrades to a surfaced warning rather than silence — recreating an injection-capable unit would be worse.

Closes #6184, #6185, #6186
Refs #6179, #6183, #6194
