### PR TITLE
fix(#6197): grafel stop left 140 launchd-owned watchers running, so indexing continued

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -435,6 +435,14 @@ func printReconcileSummary(out io.Writer, res *install.ReconcileWatcherResult) {
 			len(res.Migrated))
 	}
 	if len(res.Reloaded) > 0 {
+		// Re-registering a unit RE-ACTIVATES it, including one a previous
+		// `grafel stop` deactivated (Loader.Load clears the persisted
+		// disable). Saying so is the difference between an acceptable
+		// side effect and a silent one: `grafel update` is run to get a new
+		// binary, not to restart watchers, so a user who stopped grafel a week
+		// ago must be told that some of it is running again.
+		fmt.Fprintf(out, "  note: re-activated %d repo watcher(s) — if you had run 'grafel stop', "+
+			"run it again to stop them\n", len(res.Reloaded))
 		fmt.Fprintf(out, "  macOS may show up to %d Background Items notifications while these "+
 			"re-register — this is the one-time repair for issue #6179, not a recurrence\n",
 			len(res.Reloaded))

--- a/internal/cli/ref_flag_test.go
+++ b/internal/cli/ref_flag_test.go
@@ -36,6 +36,12 @@ import (
 func setupRefTestEnv(t *testing.T, refs ...string) (home, repoPath string) {
 	t.Helper()
 	home = t.TempDir()
+	// HOME too, not just GRAFEL_HOME: runStatus now reports the per-repo
+	// watcher fleet, and the unit directory is resolved from HOME
+	// (~/Library/LaunchAgents). With only GRAFEL_HOME redirected this test
+	// globbed the developer's REAL 140 watcher plists and ran a `launchctl
+	// list` per unit — read-only, but machine-variable and 140 process spawns.
+	t.Setenv("HOME", home)
 	t.Setenv("GRAFEL_HOME", home)
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -135,6 +135,14 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 		fmt.Fprintf(w, "Daemon: error: %v\n", err)
 	}
 
+	// Per-repo watcher fleet. This section exists so a stop is VERIFIABLE.
+	// The `com.grafel.watcher.<group>.<slug>` units are owned by
+	// launchd/systemd/schtasks and index independently of the daemon, so
+	// "Daemon: not running" on its own says nothing about whether grafel is
+	// still doing work. If watchers survived a `grafel stop`, this line is what
+	// says so out loud instead of leaving the user to infer it from CPU load.
+	printWatcherFleetStatus(w)
+
 	// Registry / per-repo view stays — useful even when the daemon is
 	// down so users can see what would be indexed once they `start`.
 	groups, err := registry.Groups()
@@ -172,6 +180,26 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 		}
 	}
 	return nil
+}
+
+// printWatcherFleetStatus prints the per-repo watcher fleet line. It is
+// deliberately quiet when no watcher units are installed at all (the common
+// dev/foreground case) and never fails the status command: an enumeration
+// error is reported inline, because "I could not tell you" is itself
+// information a user checking whether grafel really stopped needs.
+func printWatcherFleetStatus(w io.Writer) {
+	sum, err := summarizeFleetWatchers()
+	if err != nil {
+		fmt.Fprintf(w, "Watchers: unknown (%v)\n", err)
+		return
+	}
+	if sum.Installed == 0 {
+		return
+	}
+	fmt.Fprintf(w, "Watchers: %d installed, %d running\n", sum.Installed, sum.Running)
+	if sum.Running > 0 {
+		fmt.Fprintf(w, "  these index independently of the daemon; 'grafel stop' stops them too\n")
+	}
 }
 
 // printWorktreeChildren prints the ephemeral worktree-child entries for the

--- a/internal/cli/status_test.go
+++ b/internal/cli/status_test.go
@@ -20,6 +20,13 @@ func TestStatusMissingFleetConfig(t *testing.T) {
 			os.Unsetenv("GRAFEL_HOME")
 		}
 	}()
+	// HOME too, not just GRAFEL_HOME: runStatus now reports the per-repo
+	// watcher fleet, and the unit directory is resolved from HOME
+	// (~/Library/LaunchAgents). With only GRAFEL_HOME redirected this test
+	// globbed the developer's REAL 140 watcher plists and ran a `launchctl
+	// list` per unit — read-only, but machine-variable and 140 process spawns.
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 	os.Setenv("GRAFEL_HOME", tmpHome)
 
 	// Create a registry entry with a missing config file.
@@ -61,6 +68,13 @@ func TestStatusExistingFleetConfig(t *testing.T) {
 			os.Unsetenv("GRAFEL_HOME")
 		}
 	}()
+	// HOME too, not just GRAFEL_HOME: runStatus now reports the per-repo
+	// watcher fleet, and the unit directory is resolved from HOME
+	// (~/Library/LaunchAgents). With only GRAFEL_HOME redirected this test
+	// globbed the developer's REAL 140 watcher plists and ran a `launchctl
+	// list` per unit — read-only, but machine-variable and 140 process spawns.
+	t.Setenv("HOME", tmpHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpHome, ".config"))
 	os.Setenv("GRAFEL_HOME", tmpHome)
 
 	// Create a valid config file.

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -19,10 +20,19 @@ import (
 	"github.com/cajasmota/grafel/internal/process"
 )
 
-// start/stop/restart now drive the per-machine daemon (ADR-0017). The
-// old per-repo watcher fanout under launchd/systemd is gone — the
-// daemon owns all watchers in Phase B and a single OS service unit
-// keeps the daemon alive (Phase C).
+// start/stop/restart drive the per-machine daemon (ADR-0017): a single OS
+// service unit keeps the daemon alive (Phase C).
+//
+// This comment used to continue "the old per-repo watcher fanout under
+// launchd/systemd is gone — the daemon owns all watchers in Phase B". That was
+// false, and expensively so. `grafel install` still writes one
+// `com.grafel.watcher.<group>.<slug>` unit PER REPO
+// (internal/install/install.go), each running `grafel watch <repo>` under
+// launchd/systemd/schtasks, entirely outside the daemon's lifecycle. Anyone
+// reading `stop` and believing this header had no reason to look for the 140
+// processes it was not stopping. The fanout is handled explicitly now — see
+// watcher_fleet.go — and the ADR-0017 Phase B migration this described is not
+// finished.
 
 func newStartCmd() *cobra.Command {
 	var maxRSSBudget int64
@@ -131,7 +141,16 @@ func runDaemonRestart(out io.Writer) error {
 	// owns the correct unload→load→wait-ready dance internally, so none of
 	// the pidfile bookkeeping below is needed (or safe) on this path.
 	if serviceInstalledForThisRoot() {
-		return serviceRestartForThisRoot(out)
+		err := serviceRestartForThisRoot(out)
+		// Restore the watcher fleet on this branch too. It is an EARLY RETURN
+		// that never reaches the stop/start sequence below, and on any machine
+		// that ran `grafel install` — i.e. the machine in the bug report — it is
+		// the branch that gets taken. Without this, `grafel stop` followed by
+		// `grafel restart` left every watcher persistently disabled with the
+		// daemon back up, and nothing on screen hinting that `grafel start` was
+		// the way out.
+		startFleetWatchers(out)
+		return err
 	}
 
 	layout, err := daemon.DefaultLayout()
@@ -143,9 +162,14 @@ func runDaemonRestart(out io.Writer) error {
 	// exact process exits (rather than racing a freshly-spawned one).
 	oldPID := daemon.ReadPIDFile(layout.PIDPath)
 
+	// errWatchersNotStopped is tolerated for the same reason as
+	// errStopNotConfirmed: runDaemonStart below re-activates the fleet anyway,
+	// so a watcher that resisted deactivation is not a reason to abort a
+	// restart. `grafel stop` still surfaces it as a failure.
 	if err := runDaemonStop(out); err != nil &&
 		!errors.Is(err, client.ErrDaemonNotRunning) &&
-		!errors.Is(err, errStopNotConfirmed) {
+		!errors.Is(err, errStopNotConfirmed) &&
+		!errors.Is(err, errWatchersNotStopped) {
 		return err
 	}
 
@@ -570,8 +594,34 @@ func runDaemonStop(out io.Writer) error {
 	// daemon drains rather than being fed while it shuts down. It also means a
 	// failure in the daemon stop below cannot leave the fleet running silently.
 	// See watcher_fleet.go for the full contract.
-	stopFleetWatchers(out)
+	//
+	// The fleet's OUTPUT, however, is buffered and flushed after the daemon
+	// line. On 140 repos the warnings would otherwise scroll far above
+	// "daemon stopped", leaving an unqualified success message as the last
+	// thing the user sees while watchers are still running. Action order and
+	// report order are deliberately opposite here.
+	var fleetOut bytes.Buffer
+	fleetRes := stopFleetWatchers(&fleetOut)
 
+	daemonErr := stopDaemonOnly(out)
+	if fleetOut.Len() > 0 {
+		_, _ = out.Write(fleetOut.Bytes())
+	}
+	if daemonErr != nil {
+		return daemonErr
+	}
+	// A stop that left watchers running did not do what it says. Report a
+	// non-zero exit so scripts and `&&` chains cannot read it as success.
+	if len(fleetRes.Failures) > 0 {
+		return fmt.Errorf("%w: %d still running (see above)", errWatchersNotStopped, len(fleetRes.Failures))
+	}
+	return nil
+}
+
+// stopDaemonOnly is the daemon half of stop, with no watcher-fleet
+// involvement. Split out of runDaemonStop so the fleet's report can be
+// ordered after the daemon's while the fleet's ACTION stays before it.
+func stopDaemonOnly(out io.Writer) error {
 	// #6044: `start` is service-aware (it routes through the OS service
 	// manager when one is installed for this root, via
 	// serviceRestartForThisRoot); `stop` was not — it only asked the daemon

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -53,13 +53,23 @@ Use 'grafel dashboard' to open the dashboard in your browser.`,
 func newStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the daemon and all managed services",
-		Long: `Stop the grafel daemon.
+		Short: "Stop everything grafel is running",
+		Long: `Stop grafel.
 
 Stopping the daemon also stops all services it manages:
   - MCP server
   - Indexer + file-watcher
   - Dashboard HTTP server
+
+It ALSO deactivates the per-repo watchers ('grafel watch <repo>') that
+'grafel install' registers with the OS service manager, one per repo. Those
+are NOT children of the daemon — they run on their own schedule and enqueue
+index work — so stopping the daemon alone used to leave them indexing. Stop
+now names any watcher it could not deactivate; 'grafel status' reports how
+many are still running.
+
+'grafel install' and 'grafel update' re-activate watchers, because asking to
+(re)install them is asking for them to run.
 
 When the daemon is registered as an OS service (launchd on macOS, systemd on
 Linux, Task Scheduler on Windows — i.e. it was set up via 'grafel install'),
@@ -238,6 +248,26 @@ func runDaemonStartWithBudget(out io.Writer, maxRSSBudgetMB int64) error {
 // short ping poll. If the daemon is already running, start is a no-op
 // (the call is idempotent — important for service-managed restarts).
 func runDaemonStartOpts(out io.Writer, maxRSSBudgetMB int64, noAutoCleanup bool) error {
+	err := startDaemonOnly(out, maxRSSBudgetMB, noAutoCleanup)
+	// Restore the per-repo watcher fleet that `grafel stop` deactivated, on
+	// EVERY start path — including the "daemon already running" fast path,
+	// which is exactly the state a user lands in after `stop` + a manual
+	// daemon launch, and the one where forgetting to restore would leave
+	// watchers permanently off with nothing saying why.
+	//
+	// This runs after the daemon so restored watchers have something live to
+	// enqueue into, and it runs even when the daemon start FAILED: leaving the
+	// fleet deactivated because of a daemon problem would silently extend a
+	// temporary stop into a permanent one. Only groups with features.watchers
+	// enabled are restored — see watcher_fleet.go.
+	startFleetWatchers(out)
+	return err
+}
+
+// startDaemonOnly is the daemon half of start: the pidfile/socket/service
+// bookkeeping, with no watcher-fleet involvement. Split out of
+// runDaemonStartOpts so the fleet restore above happens on every return path.
+func startDaemonOnly(out io.Writer, maxRSSBudgetMB int64, noAutoCleanup bool) error {
 	layout, err := daemon.DefaultLayout()
 	if err != nil {
 		return err
@@ -526,6 +556,22 @@ func defaultServiceStopForThisRoot(out io.Writer) error {
 }
 
 func runDaemonStop(out io.Writer) error {
+	// Stop the PER-REPO watcher fleet FIRST, before the daemon.
+	//
+	// This is the half of "stop" that was missing entirely. The per-repo
+	// `com.grafel.watcher.<group>.<slug>` units installed by `grafel install`
+	// are owned by launchd/systemd/schtasks, not by the daemon: each runs
+	// `grafel watch <repo>` and enqueues index work on its own schedule, and on
+	// macOS KeepAlive respawns any that exit. Stopping only the daemon left
+	// them running — which is how a user could run `grafel stop`, be told
+	// "daemon stopped", and watch indexing continue across 140 repos.
+	//
+	// Watchers go first because they are the SOURCE of work: with them down the
+	// daemon drains rather than being fed while it shuts down. It also means a
+	// failure in the daemon stop below cannot leave the fleet running silently.
+	// See watcher_fleet.go for the full contract.
+	stopFleetWatchers(out)
+
 	// #6044: `start` is service-aware (it routes through the OS service
 	// manager when one is installed for this root, via
 	// serviceRestartForThisRoot); `stop` was not — it only asked the daemon

--- a/internal/cli/watcher_ctl_service_test.go
+++ b/internal/cli/watcher_ctl_service_test.go
@@ -130,6 +130,10 @@ func TestRunDaemonRestart_RoutesToServiceRestart_WhenInstalled_NoManualForkOrPid
 // stubServiceSeams but for the stop path.
 func stubStopSeam(t *testing.T, installed bool) (stopCalls *int) {
 	t.Helper()
+	// `stop` now also sweeps the per-repo watcher fleet, which resolves the
+	// unit directory from HOME. Without this, these tests reach the
+	// developer's real ~/Library/LaunchAgents. See isolateWatcherFleet.
+	isolateWatcherFleet(t)
 	stopCalls = new(int)
 
 	origInstalled := serviceInstalledForThisRoot

--- a/internal/cli/watcher_ctl_service_test.go
+++ b/internal/cli/watcher_ctl_service_test.go
@@ -28,6 +28,10 @@ import (
 // and restores them on cleanup. It returns pointers to call counters.
 func stubServiceSeams(t *testing.T, installed bool) (restartCalls, forkCalls *int) {
 	t.Helper()
+	// `start`/`restart` now also restore the per-repo watcher fleet, so without
+	// an isolated home these tests would Load the DEVELOPER's real watcher
+	// units. See isolateWatcherFleet in watcher_fleet_review_test.go.
+	isolateWatcherFleet(t)
 	restartCalls = new(int)
 	forkCalls = new(int)
 

--- a/internal/cli/watcher_ctl_stop_rpc_test.go
+++ b/internal/cli/watcher_ctl_stop_rpc_test.go
@@ -53,6 +53,9 @@ func (s *stopStub) Stop(_ proto.StopArgs, _ *proto.StopReply) error {
 // exposing only Stop, and returns the stub for assertions.
 func serveStopStub(t *testing.T, closeAfter time.Duration) *stopStub {
 	t.Helper()
+	// `stop` now also sweeps the per-repo watcher fleet; isolate the home so it
+	// sees an empty fleet rather than the developer's real LaunchAgents.
+	isolateWatcherFleet(t)
 	root, err := os.MkdirTemp("", "ag-stop-")
 	if err != nil {
 		t.Fatalf("mkdirtemp: %v", err)

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -31,7 +31,15 @@ package cli
 //
 // Neither direction ever CREATES or DELETES a unit file. Installing units is
 // `grafel install`'s job; removing them is `grafel uninstall`/group-delete's.
-// Stop/start only flip activation, so the pair is losslessly reversible.
+// Stop/start only flip activation.
+//
+// The pair is NOT symmetric, and stop says so out loud rather than implying
+// otherwise. A unit whose group has features.watchers off — or an orphan unit
+// no group owns — is deactivated by stop and is NOT reactivated by start; the
+// only way back is `grafel install`. stopFleetWatchers names every such unit
+// on stdout. (Claiming a reversibility the code does not have would repeat the
+// stale comment at watcher_ctl.go's head, which asserted the daemon owned all
+// watchers and is a large part of why this bug went unnoticed.)
 //
 // ── Persistence ──────────────────────────────────────────────────────────────
 //
@@ -45,15 +53,31 @@ package cli
 // and now pairs with `launchctl disable` (see loader_darwin.go).
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
 )
+
+// errWatchersNotStopped marks a stop that left at least one watcher running.
+//
+// It exists so `grafel stop` can FAIL when it did not do what it says on the
+// tin. The first cut printed the warnings and returned nil, so a stop that
+// deactivated 0 of 140 watchers still exited 0 and any `&&` chain or script
+// read it as success — the original defect with more text in it.
+//
+// A sentinel (not a bare error) so runDaemonRestart can tolerate it the way it
+// already tolerates errStopNotConfirmed: restart re-activates the fleet
+// immediately afterward, so a watcher that resisted deactivation is not a
+// reason to abort the restart.
+var errWatchersNotStopped = errors.New("some repo watchers could not be stopped")
 
 // newFleetWatcherLoader constructs the platform Loader used for fleet-wide
 // activation changes. A package var so tests can substitute a fake and never
@@ -78,10 +102,26 @@ type fleetWatcherResult struct {
 	Failures []string
 }
 
+// fleetSweepTimeout bounds the WHOLE fleet sweep. Each individual OS call is
+// separately bounded inside the platform loader, but 140 units at 8-way
+// concurrency could still add up, and a `grafel stop` that hangs is a worse
+// failure than the one this file fixes. Units not reached before the deadline
+// are reported as not stopped — never silently skipped. A var so tests can
+// shrink it.
+var fleetSweepTimeout = 90 * time.Second
+
 // fleetWatcherUnit pairs a unit with its on-disk path.
 type fleetWatcherUnit struct {
 	unit watchers.Unit
 	path string
+	// display is what to call this unit in output: the repo path when we know
+	// it, else the bare label (an orphan discovered by scanning the unit dir).
+	display string
+	// restorable is false when `grafel start` will NOT bring this unit back —
+	// its group has features.watchers off, or it is an orphan with no group at
+	// all. Stop still deactivates it, but it must say so: that combination is a
+	// one-way door out of which only `grafel install` leads.
+	restorable bool
 }
 
 // installedFleetWatcherUnits enumerates every registered repo's watcher unit
@@ -94,21 +134,28 @@ type fleetWatcherUnit struct {
 // A group whose config cannot be read is skipped with a warning rather than
 // aborting: one bad fleet.json must not leave the other 139 watchers running.
 func installedFleetWatcherUnits(onlyEnabled bool) ([]fleetWatcherUnit, []string, error) {
+	bin, _ := os.Executable() // best effort; Label/UnitPath do not depend on it
+
+	// Pass 1 — the registry's view: "which units SHOULD exist, and do they?"
+	// This is the only pass that knows a unit's repo path and its group's
+	// features.watchers flag, so it is what start is driven from.
+	byPath := map[string]fleetWatcherUnit{}
+	var warnings []string
 	refs, err := registry.Groups()
 	if err != nil {
 		return nil, nil, fmt.Errorf("read group registry: %w", err)
 	}
-	bin, _ := os.Executable() // best effort; Label/UnitPath do not depend on it
-
-	var units []fleetWatcherUnit
-	var warnings []string
 	for _, ref := range refs {
 		cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
 		if err != nil {
+			// The units of an unreadable group are still on disk and still
+			// running. Pass 2 picks them up by label; this warning explains why
+			// they show up without a repo path.
 			warnings = append(warnings, fmt.Sprintf("group %s: %v", ref.Name, err))
 			continue
 		}
-		if onlyEnabled && !cfg.Features.Watchers {
+		enabled := cfg.Features.Watchers
+		if onlyEnabled && !enabled {
 			continue
 		}
 		for _, r := range cfg.Repos {
@@ -123,41 +170,114 @@ func installedFleetWatcherUnits(onlyEnabled bool) ([]fleetWatcherUnit, []string,
 				// deactivate. Not an error and not a warning.
 				continue
 			}
-			units = append(units, fleetWatcherUnit{unit: u, path: path})
+			byPath[path] = fleetWatcherUnit{
+				unit: u, path: path, display: r.Path, restorable: enabled,
+			}
 		}
 	}
+
+	// Pass 2 — the DISK's view: "what is actually installed?"
+	//
+	// Skipped for start (onlyEnabled), which must never activate a unit it
+	// cannot attribute to a group the user has watchers enabled for.
+	//
+	// For stop this pass is the point. The registry cannot see a unit left by a
+	// partially-failed watchers.Cleanup (best-effort: `_ = loader.Unload(u); _
+	// = Remove(u)`), a unit belonging to the unreadable group warned about
+	// above, a unit whose group was dropped from registry.json, or a unit whose
+	// label was derived by an older slug rule. Every one of those is a live
+	// `grafel watch` process. Enumerating only from the registry answers
+	// "which units should exist?" — and taking that for an answer to "what is
+	// running?" is the exact reasoning error that produced the original bug.
+	if !onlyEnabled {
+		disk, derr := watchers.InstalledUnits()
+		if derr != nil {
+			warnings = append(warnings, fmt.Sprintf("scan watcher unit dir: %v", derr))
+		}
+		for _, du := range disk {
+			path, perr := watchers.UnitPath(du)
+			if perr != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", du.Label(), perr))
+				continue
+			}
+			if _, seen := byPath[path]; seen {
+				continue // already attributed to a group, with richer info
+			}
+			byPath[path] = fleetWatcherUnit{
+				unit: du, path: path, display: du.Label(),
+				restorable: false, // no group owns it; start cannot restore it
+			}
+		}
+	}
+
+	units := make([]fleetWatcherUnit, 0, len(byPath))
+	for _, u := range byPath {
+		units = append(units, u)
+	}
+	sort.Slice(units, func(i, j int) bool { return units[i].path < units[j].path })
 	return units, warnings, nil
 }
 
 // sweepFleetWatchers applies act to every enumerated unit, bounded by
 // fleetWatcherConcurrency, and collects failures.
+// It is bounded by fleetSweepTimeout: a unit whose OS call has not returned by
+// the deadline is counted as NOT changed and named in Failures. The sweep never
+// waits on a straggler past the deadline — `launchctl bootout` blocks until the
+// job exits and `grafel watch` drains on SIGTERM, so one wedged watcher could
+// otherwise hang the whole command with no output at all.
 func sweepFleetWatchers(units []fleetWatcherUnit, act func(watchers.Unit) error) fleetWatcherResult {
 	res := fleetWatcherResult{Total: len(units)}
 	if len(units) == 0 {
 		return res
 	}
-	var (
-		mu  sync.Mutex
-		wg  sync.WaitGroup
-		sem = make(chan struct{}, fleetWatcherConcurrency)
-	)
+	ctx, cancel := context.WithTimeout(context.Background(), fleetSweepTimeout)
+	defer cancel()
+
+	type outcome struct {
+		display string
+		err     error
+	}
+	results := make(chan outcome, len(units))
+	sem := make(chan struct{}, fleetWatcherConcurrency)
 	for _, fu := range units {
-		wg.Add(1)
 		go func(fu fleetWatcherUnit) {
-			defer wg.Done()
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			err := act(fu.unit)
-			mu.Lock()
-			defer mu.Unlock()
-			if err != nil && !watchers.IsNonFatal(err) {
-				res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", fu.unit.Repo, err))
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				results <- outcome{fu.display, ctx.Err()}
 				return
 			}
-			res.Changed++
+			results <- outcome{fu.display, act(fu.unit)}
 		}(fu)
 	}
-	wg.Wait()
+
+	// Collect exactly len(units) outcomes, or give up at the deadline and
+	// report whatever has not come back. Workers still in flight are left to
+	// finish and drain into the buffered channel; they are never joined, which
+	// is the point — this function must always return.
+	pending := map[string]bool{}
+	for _, fu := range units {
+		pending[fu.display] = true
+	}
+	for i := 0; i < len(units); i++ {
+		select {
+		case o := <-results:
+			delete(pending, o.display)
+			if o.err != nil && !watchers.IsNonFatal(o.err) {
+				res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", o.display, o.err))
+				continue
+			}
+			res.Changed++
+		case <-ctx.Done():
+			for d := range pending {
+				res.Failures = append(res.Failures,
+					fmt.Sprintf("%s: timed out after %s", d, fleetSweepTimeout))
+			}
+			sort.Strings(res.Failures)
+			return res
+		}
+	}
 	sort.Strings(res.Failures)
 	return res
 }
@@ -183,6 +303,29 @@ func stopFleetWatchers(out io.Writer) fleetWatcherResult {
 
 	fmt.Fprintf(out, "stopped %d/%d repo watcher(s) (will not restart automatically — even across reboot — until 'grafel start')\n",
 		res.Changed, res.Total)
+
+	// Name the one-way doors. Stop is deliberately ungated by
+	// features.watchers — a unit on disk is running whatever the config now
+	// says — but start IS gated, so these specific units will not come back
+	// from `grafel start`. Saying nothing would make the stop/start pair look
+	// symmetric when it is not, and a comment claiming a property the code does
+	// not have is exactly the failure that hid the original bug.
+	var oneWay []string
+	for _, fu := range units {
+		if !fu.restorable {
+			oneWay = append(oneWay, fu.display)
+		}
+	}
+	if len(oneWay) > 0 {
+		sort.Strings(oneWay)
+		fmt.Fprintf(out, "  note: %d of these will NOT be restored by 'grafel start' "+
+			"(their group has watchers disabled, or no group owns them). "+
+			"Run 'grafel install' to re-enable:\n", len(oneWay))
+		for _, d := range oneWay {
+			fmt.Fprintf(out, "     %s\n", d)
+		}
+	}
+
 	if len(res.Failures) > 0 {
 		fmt.Fprintf(out, "  ⚠️ %d repo watcher(s) could NOT be stopped and are still running:\n", len(res.Failures))
 		for _, f := range res.Failures {
@@ -242,14 +385,31 @@ func summarizeFleetWatchers() (fleetWatcherSummary, error) {
 	}
 	loader := newFleetWatcherLoader()
 	sum := fleetWatcherSummary{Installed: len(units)}
+
+	// Bounded parallelism, not a serial loop. `grafel status` is now the
+	// surface a user checks to confirm a stop actually worked, and each
+	// Status() is a process spawn — 140 of them serially would make the
+	// verification command noticeably slower than the thing it verifies.
+	var (
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		sem = make(chan struct{}, fleetWatcherConcurrency)
+	)
 	for _, fu := range units {
-		st, err := loader.Status(fu.unit)
-		if err != nil {
-			continue
-		}
-		if st.Running {
+		wg.Add(1)
+		go func(fu fleetWatcherUnit) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			st, err := loader.Status(fu.unit)
+			if err != nil || !st.Running {
+				return
+			}
+			mu.Lock()
 			sum.Running++
-		}
+			mu.Unlock()
+		}(fu)
 	}
+	wg.Wait()
 	return sum, nil
 }

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -189,6 +189,31 @@ func installedFleetWatcherUnits(onlyEnabled bool) ([]fleetWatcherUnit, []string,
 	// `grafel watch` process. Enumerating only from the registry answers
 	// "which units should exist?" — and taking that for an answer to "what is
 	// running?" is the exact reasoning error that produced the original bug.
+	//
+	// ── Interaction with #6183's label migration ─────────────────────────────
+	//
+	// #6183 changed the label derivation (basename → basename+path digest) and
+	// added its own orphan handling, whose LegacyOf comment argues AGAINST
+	// globbing: it cannot tell a genuinely orphaned unit from one belonging to
+	// a group this binary has no config for, "and would boot out the latter".
+	//
+	// That argument is right for MIGRATION and does not transfer to stop.
+	// Migration runs unasked, as a side effect of install/update, and DELETES
+	// units — so a wrong guess destroys state the user never mentioned. It
+	// therefore derives the old label from the same (group, repo) as the new
+	// one and touches nothing else. Stop is the opposite on every axis: the
+	// user asked for it by name, it only DEACTIVATES (no unit file is created
+	// or deleted, so it is reversible), and stopping a unit the registry cannot
+	// account for is the entire point — that unit is a running process the user
+	// just asked to stop.
+	//
+	// The overlap is real, and mid-migration is when it bites: a machine
+	// part-way through #6183 carries old-slug plists the registry can no longer
+	// name, and stop will disable them. That is the correct outcome — they are
+	// running watchers — but `grafel start` will NOT restore them, so stop
+	// names every such unit. See the orphan branch of stopFleetWatchers, which
+	// deliberately does not point orphan owners at `grafel install`: for an
+	// unregistered unit it would not help.
 	if !onlyEnabled {
 		disk, derr := watchers.InstalledUnits()
 		if derr != nil {

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -310,18 +310,41 @@ func stopFleetWatchers(out io.Writer) fleetWatcherResult {
 	// from `grafel start`. Saying nothing would make the stop/start pair look
 	// symmetric when it is not, and a comment claiming a property the code does
 	// not have is exactly the failure that hid the original bug.
-	var oneWay []string
+	// The two one-way-door cases need DIFFERENT remedies, because
+	// `grafel install` only writes units for REGISTERED repos.
+	//
+	//   - a registered repo whose group has features.watchers off: install
+	//     re-writes and re-loads its unit, so pointing there is correct.
+	//   - a true orphan, whose group is not in the registry at all: install
+	//     will never touch it, so that advice sends the user somewhere that
+	//     cannot help — in exactly the case this notice was added to cover.
+	var disabledGroup, orphans []string
 	for _, fu := range units {
-		if !fu.restorable {
-			oneWay = append(oneWay, fu.display)
+		if fu.restorable {
+			continue
+		}
+		if fu.unit.RawLabel != "" {
+			orphans = append(orphans, fu.display)
+		} else {
+			disabledGroup = append(disabledGroup, fu.display)
 		}
 	}
-	if len(oneWay) > 0 {
-		sort.Strings(oneWay)
+	if len(disabledGroup) > 0 {
+		sort.Strings(disabledGroup)
 		fmt.Fprintf(out, "  note: %d of these will NOT be restored by 'grafel start' "+
-			"(their group has watchers disabled, or no group owns them). "+
-			"Run 'grafel install' to re-enable:\n", len(oneWay))
-		for _, d := range oneWay {
+			"(their group has watchers disabled). Run 'grafel install' to re-enable:\n",
+			len(disabledGroup))
+		for _, d := range disabledGroup {
+			fmt.Fprintf(out, "     %s\n", d)
+		}
+	}
+	if len(orphans) > 0 {
+		sort.Strings(orphans)
+		fmt.Fprintf(out, "  note: %d of these will NOT be restored by 'grafel start' — "+
+			"no registered group owns them, so re-installing will not bring them back "+
+			"either. Delete the unit file to be rid of them, or re-enable one by hand:\n",
+			len(orphans))
+		for _, d := range orphans {
 			fmt.Fprintf(out, "     %s\n", d)
 		}
 	}

--- a/internal/cli/watcher_fleet.go
+++ b/internal/cli/watcher_fleet.go
@@ -1,0 +1,255 @@
+package cli
+
+// watcher_fleet.go — fleet-wide control of the PER-REPO watcher units.
+//
+// ── What was actually wrong ──────────────────────────────────────────────────
+//
+// `grafel install` writes one OS unit per registered repo
+// (internal/install/install.go, watchers.Write + Loader.Load): a launchd
+// LaunchAgent `com.grafel.watcher.<group>.<slug>` on macOS, a systemd --user
+// service on Linux, a scheduled task on Windows. Each one runs
+// `grafel watch <repo>`, which polls the repo and enqueues index work on its
+// own ~30s schedule.
+//
+// Those units are owned by the OS service manager, NOT by the daemon. Nothing
+// about stopping the daemon stops them; on macOS KeepAlive respawns any that
+// exit. `grafel stop` (runDaemonStop) only ever stopped the DAEMON's own
+// service — #6044 made that stop service-aware and persistent, but only for
+// the one `com.grafel.daemon` label. On a 140-repo machine the other 140
+// labels carried right on indexing after a "daemon stopped" success message.
+//
+// ── The contract this file implements ────────────────────────────────────────
+//
+//	stop  → every INSTALLED watcher unit is deactivated, whatever the group's
+//	        features.watchers flag says (that flag is not retroactive: units
+//	        written by an earlier install survive it), and whatever fails is
+//	        NAMED on stdout. Silence is what produced the report.
+//	start → every installed unit belonging to a group with features.watchers
+//	        enabled is reactivated. Start is gated on the flag precisely
+//	        because stop is not: an unconditional restore would resurrect
+//	        watchers the user deliberately turned off.
+//
+// Neither direction ever CREATES or DELETES a unit file. Installing units is
+// `grafel install`'s job; removing them is `grafel uninstall`/group-delete's.
+// Stop/start only flip activation, so the pair is losslessly reversible.
+//
+// ── Persistence ──────────────────────────────────────────────────────────────
+//
+// The stop is PERSISTENT across reboot/login, matching the daemon stop that
+// #6044 established ("will not restart automatically — even across reboot —
+// until 'grafel start'"). A session-only watcher stop would mean `grafel stop`
+// changes meaning at the next login, and a user who stops grafel to get their
+// laptop back does not expect it to come back by itself. The persistence lives
+// in each platform Loader.Unload: systemd `disable --now` and the schtasks
+// delete were already persistent; the darwin loader's bare `bootout` was not,
+// and now pairs with `launchctl disable` (see loader_darwin.go).
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"sync"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// newFleetWatcherLoader constructs the platform Loader used for fleet-wide
+// activation changes. A package var so tests can substitute a fake and never
+// shell out to a real launchctl/systemctl/schtasks.
+var newFleetWatcherLoader = watchers.NewLoader
+
+// fleetWatcherConcurrency bounds how many units are acted on in parallel. Each
+// action is one-to-three short exec calls; at 140 repos a strictly serial sweep
+// costs several seconds of wall clock on a command a user expects to be quick.
+// It is kept small because the underlying service managers serialise internally
+// anyway and a wide fan-out buys nothing.
+const fleetWatcherConcurrency = 8
+
+// fleetWatcherResult reports the outcome of one fleet-wide sweep.
+type fleetWatcherResult struct {
+	// Total counts units that were installed on disk and therefore acted on.
+	Total int
+	// Changed counts units whose activation change succeeded.
+	Changed int
+	// Failures holds one "<repo>: <error>" line per unit that did not change.
+	// Sorted, so output is deterministic.
+	Failures []string
+}
+
+// fleetWatcherUnit pairs a unit with its on-disk path.
+type fleetWatcherUnit struct {
+	unit watchers.Unit
+	path string
+}
+
+// installedFleetWatcherUnits enumerates every registered repo's watcher unit
+// that actually exists on disk.
+//
+// onlyEnabled restricts the sweep to groups whose features.watchers is on.
+// Pass false for stop (a unit on disk is running regardless of what the config
+// currently says) and true for start (never resurrect what the user disabled).
+//
+// A group whose config cannot be read is skipped with a warning rather than
+// aborting: one bad fleet.json must not leave the other 139 watchers running.
+func installedFleetWatcherUnits(onlyEnabled bool) ([]fleetWatcherUnit, []string, error) {
+	refs, err := registry.Groups()
+	if err != nil {
+		return nil, nil, fmt.Errorf("read group registry: %w", err)
+	}
+	bin, _ := os.Executable() // best effort; Label/UnitPath do not depend on it
+
+	var units []fleetWatcherUnit
+	var warnings []string
+	for _, ref := range refs {
+		cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
+		if err != nil {
+			warnings = append(warnings, fmt.Sprintf("group %s: %v", ref.Name, err))
+			continue
+		}
+		if onlyEnabled && !cfg.Features.Watchers {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			u := watchers.Unit{Group: ref.Name, Repo: r.Path, BinPath: bin}
+			path, err := watchers.UnitPath(u)
+			if err != nil {
+				warnings = append(warnings, fmt.Sprintf("%s: %v", r.Path, err))
+				continue
+			}
+			if _, err := os.Stat(path); err != nil {
+				// No unit installed for this repo — nothing to activate or
+				// deactivate. Not an error and not a warning.
+				continue
+			}
+			units = append(units, fleetWatcherUnit{unit: u, path: path})
+		}
+	}
+	return units, warnings, nil
+}
+
+// sweepFleetWatchers applies act to every enumerated unit, bounded by
+// fleetWatcherConcurrency, and collects failures.
+func sweepFleetWatchers(units []fleetWatcherUnit, act func(watchers.Unit) error) fleetWatcherResult {
+	res := fleetWatcherResult{Total: len(units)}
+	if len(units) == 0 {
+		return res
+	}
+	var (
+		mu  sync.Mutex
+		wg  sync.WaitGroup
+		sem = make(chan struct{}, fleetWatcherConcurrency)
+	)
+	for _, fu := range units {
+		wg.Add(1)
+		go func(fu fleetWatcherUnit) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			err := act(fu.unit)
+			mu.Lock()
+			defer mu.Unlock()
+			if err != nil && !watchers.IsNonFatal(err) {
+				res.Failures = append(res.Failures, fmt.Sprintf("%s: %v", fu.unit.Repo, err))
+				return
+			}
+			res.Changed++
+		}(fu)
+	}
+	wg.Wait()
+	sort.Strings(res.Failures)
+	return res
+}
+
+// stopFleetWatchers deactivates every installed per-repo watcher unit and
+// reports, on out, both what it stopped and — crucially — anything it could
+// not stop, naming the repo so the user can act on it.
+func stopFleetWatchers(out io.Writer) fleetWatcherResult {
+	units, warnings, err := installedFleetWatcherUnits(false /* every installed unit */)
+	if err != nil {
+		fmt.Fprintf(out, "  ⚠️ could not enumerate repo watchers (%v); they may still be running\n", err)
+		return fleetWatcherResult{Failures: []string{err.Error()}}
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(out, "  ⚠️ %s (its watchers may still be running)\n", w)
+	}
+	if len(units) == 0 {
+		return fleetWatcherResult{}
+	}
+
+	loader := newFleetWatcherLoader()
+	res := sweepFleetWatchers(units, loader.Unload)
+
+	fmt.Fprintf(out, "stopped %d/%d repo watcher(s) (will not restart automatically — even across reboot — until 'grafel start')\n",
+		res.Changed, res.Total)
+	if len(res.Failures) > 0 {
+		fmt.Fprintf(out, "  ⚠️ %d repo watcher(s) could NOT be stopped and are still running:\n", len(res.Failures))
+		for _, f := range res.Failures {
+			fmt.Fprintf(out, "     %s\n", f)
+		}
+		fmt.Fprintln(out, "     Run 'grafel status' to re-check, or stop them manually.")
+	}
+	return res
+}
+
+// startFleetWatchers reactivates the installed per-repo watcher units for every
+// group that has watchers enabled. It is the exact inverse of the sweep
+// stopFleetWatchers performs, minus the groups the user turned watchers off for.
+func startFleetWatchers(out io.Writer) fleetWatcherResult {
+	units, warnings, err := installedFleetWatcherUnits(true /* enabled groups only */)
+	if err != nil {
+		fmt.Fprintf(out, "  ⚠️ could not enumerate repo watchers (%v); they were not restarted\n", err)
+		return fleetWatcherResult{Failures: []string{err.Error()}}
+	}
+	for _, w := range warnings {
+		fmt.Fprintf(out, "  ⚠️ %s (its watchers were not restarted)\n", w)
+	}
+	if len(units) == 0 {
+		return fleetWatcherResult{}
+	}
+
+	loader := newFleetWatcherLoader()
+	res := sweepFleetWatchers(units, loader.Load)
+
+	fmt.Fprintf(out, "started %d/%d repo watcher(s)\n", res.Changed, res.Total)
+	if len(res.Failures) > 0 {
+		fmt.Fprintf(out, "  ⚠️ %d repo watcher(s) could NOT be started:\n", len(res.Failures))
+		for _, f := range res.Failures {
+			fmt.Fprintf(out, "     %s\n", f)
+		}
+	}
+	return res
+}
+
+// fleetWatcherSummary is the fleet state `grafel status` reports.
+type fleetWatcherSummary struct {
+	Installed int
+	Running   int
+}
+
+// summarizeFleetWatchers reports how many per-repo watcher units are installed
+// and how many the OS says are actually running. This is what makes a stop
+// verifiable: if watchers survived a stop, status says so instead of showing a
+// down daemon and implying nothing is happening.
+func summarizeFleetWatchers() (fleetWatcherSummary, error) {
+	units, _, err := installedFleetWatcherUnits(false)
+	if err != nil {
+		return fleetWatcherSummary{}, err
+	}
+	if len(units) == 0 {
+		return fleetWatcherSummary{}, nil
+	}
+	loader := newFleetWatcherLoader()
+	sum := fleetWatcherSummary{Installed: len(units)}
+	for _, fu := range units {
+		st, err := loader.Status(fu.unit)
+		if err != nil {
+			continue
+		}
+		if st.Running {
+			sum.Running++
+		}
+	}
+	return sum, nil
+}

--- a/internal/cli/watcher_fleet_6180_test.go
+++ b/internal/cli/watcher_fleet_6180_test.go
@@ -39,11 +39,19 @@ type fakeFleetLoader struct {
 	unloaded []string
 	failOn   map[string]error // keyed by repo path
 	running  map[string]bool  // keyed by repo path
+	labels   []string         // every label acted on, incl. orphans
+	// block, when non-nil, makes every Load/Unload wait on it. Used to
+	// simulate a wedged `launchctl bootout` for the sweep-deadline test.
+	block chan struct{}
 }
 
 func (f *fakeFleetLoader) Load(u watchers.Unit) error {
+	if f.block != nil {
+		<-f.block
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.labels = append(f.labels, u.Label())
 	if err := f.failOn[u.Repo]; err != nil {
 		return err
 	}
@@ -52,8 +60,12 @@ func (f *fakeFleetLoader) Load(u watchers.Unit) error {
 }
 
 func (f *fakeFleetLoader) Unload(u watchers.Unit) error {
+	if f.block != nil {
+		<-f.block
+	}
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.labels = append(f.labels, u.Label())
 	if err := f.failOn[u.Repo]; err != nil {
 		return err
 	}
@@ -69,6 +81,19 @@ func (f *fakeFleetLoader) Status(u watchers.Unit) (watchers.WatcherStatus, error
 		Installed: true,
 		Running:   f.running[u.Repo],
 	}, nil
+}
+
+// sawLabel reports whether the loader ever acted on the given label. Orphan
+// units have no repo path, so the label is the only handle on them.
+func (f *fakeFleetLoader) sawLabel(label string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, l := range f.labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
 }
 
 func (f *fakeFleetLoader) sortedUnloaded() []string {

--- a/internal/cli/watcher_fleet_6180_test.go
+++ b/internal/cli/watcher_fleet_6180_test.go
@@ -1,0 +1,387 @@
+package cli
+
+// watcher_fleet_6180_test.go pins the defect behind the "`grafel stop` and
+// indexing kept happening" report.
+//
+// `grafel install` writes ONE per-repo watcher unit per registered repo
+// (internal/install/install.go, watchers.Write + Loader.Load). Those units are
+// owned by launchd/systemd/schtasks, not by the daemon: each one runs
+// `grafel watch <repo>`, which polls and enqueues index work on its own
+// schedule. `grafel stop` (internal/cli/watcher_ctl.go runDaemonStop) only ever
+// stopped the DAEMON's own OS service — the per-repo watcher fleet was never
+// touched, so on a 140-repo machine 140 watcher processes carried on indexing
+// after a "successful" stop, and KeepAlive/Restart respawned any that exited.
+//
+// These tests exercise the fleet-wide stop/start/report contract with a fake
+// Loader, so no real launchctl/systemctl/schtasks is ever invoked.
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// fakeFleetLoader records Load/Unload calls instead of shelling out.
+type fakeFleetLoader struct {
+	mu       sync.Mutex
+	loaded   []string
+	unloaded []string
+	failOn   map[string]error // keyed by repo path
+	running  map[string]bool  // keyed by repo path
+}
+
+func (f *fakeFleetLoader) Load(u watchers.Unit) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.failOn[u.Repo]; err != nil {
+		return err
+	}
+	f.loaded = append(f.loaded, u.Repo)
+	return nil
+}
+
+func (f *fakeFleetLoader) Unload(u watchers.Unit) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if err := f.failOn[u.Repo]; err != nil {
+		return err
+	}
+	f.unloaded = append(f.unloaded, u.Repo)
+	return nil
+}
+
+func (f *fakeFleetLoader) Status(u watchers.Unit) (watchers.WatcherStatus, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return watchers.WatcherStatus{
+		TaskName:  u.Label(),
+		Installed: true,
+		Running:   f.running[u.Repo],
+	}, nil
+}
+
+func (f *fakeFleetLoader) sortedUnloaded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]string(nil), f.unloaded...)
+	sort.Strings(out)
+	return out
+}
+
+func (f *fakeFleetLoader) sortedLoaded() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := append([]string(nil), f.loaded...)
+	sort.Strings(out)
+	return out
+}
+
+// installFleetLoader swaps the fleet Loader constructor for the test.
+func installFleetLoader(t *testing.T, f *fakeFleetLoader) {
+	t.Helper()
+	orig := newFleetWatcherLoader
+	t.Cleanup(func() { newFleetWatcherLoader = orig })
+	newFleetWatcherLoader = func() watchers.Loader { return f }
+}
+
+// fleetRepo describes one repo to seed into the fake registry.
+type fleetRepo struct {
+	path      string // filled in by seedFleet
+	unitOnDsk bool
+}
+
+// seedFleet builds an isolated HOME + GRAFEL_HOME + XDG_CONFIG_HOME with a
+// registry containing one group, and writes a watcher unit file for each repo
+// flagged unitOnDsk. It returns the absolute repo paths in declaration order.
+func seedFleet(t *testing.T, group string, watchersEnabled bool, repos []fleetRepo) []string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+	t.Setenv(daemon.EnvRoot, filepath.Join(home, ".grafel"))
+
+	cfg := &registry.GroupConfig{Name: group}
+	cfg.Features.Watchers = watchersEnabled
+	paths := make([]string, 0, len(repos))
+	for i := range repos {
+		p := filepath.Join(home, "repos", group, repos[i].path)
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatalf("mkdir repo: %v", err)
+		}
+		repos[i].path = p
+		paths = append(paths, p)
+		cfg.Repos = append(cfg.Repos, registry.Repo{Slug: filepath.Base(p), Path: p})
+	}
+
+	cfgPath, err := registry.ConfigPathFor(group)
+	if err != nil {
+		t.Fatalf("config path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir config dir: %v", err)
+	}
+	b, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(cfgPath, b, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	regPath, err := registry.RegistryPath()
+	if err != nil {
+		t.Fatalf("registry path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(regPath), 0o755); err != nil {
+		t.Fatalf("mkdir registry dir: %v", err)
+	}
+	rb, _ := json.MarshalIndent(registry.Registry{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: group, ConfigPath: cfgPath}},
+	}, "", "  ")
+	if err := os.WriteFile(regPath, rb, 0o644); err != nil {
+		t.Fatalf("write registry: %v", err)
+	}
+
+	for _, r := range repos {
+		if !r.unitOnDsk {
+			continue
+		}
+		u := watchers.Unit{Group: group, Repo: r.path, BinPath: "/usr/local/bin/grafel"}
+		if _, err := watchers.Write(u); err != nil {
+			t.Fatalf("write unit for %s: %v", r.path, err)
+		}
+	}
+	return paths
+}
+
+// TestStopFleetWatchers_UnloadsEveryInstalledUnit is the core defect: a stop
+// must deactivate every per-repo watcher unit that is installed on disk.
+func TestStopFleetWatchers_UnloadsEveryInstalledUnit(t *testing.T) {
+	repos := []fleetRepo{
+		{path: "alpha", unitOnDsk: true},
+		{path: "beta", unitOnDsk: true},
+		{path: "gamma", unitOnDsk: false}, // no unit — nothing to stop
+	}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	var buf bytes.Buffer
+	res := stopFleetWatchers(&buf)
+
+	if res.Total != 2 {
+		t.Fatalf("Total = %d, want 2 (only installed units count)", res.Total)
+	}
+	if len(res.Failures) != 0 {
+		t.Fatalf("unexpected failures: %v", res.Failures)
+	}
+	got := f.sortedUnloaded()
+	want := []string{paths[0], paths[1]}
+	sort.Strings(want)
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("unloaded = %v, want %v", got, want)
+	}
+	if !strings.Contains(buf.String(), "watcher") {
+		t.Fatalf("stop output does not mention watchers:\n%s", buf.String())
+	}
+}
+
+// TestStopFleetWatchers_IgnoresFeatureFlag: a group whose fleet config has
+// features.watchers=false can still have units on disk from an earlier install
+// (the flag is not retroactive). Stop must mean stop for those too.
+func TestStopFleetWatchers_IgnoresFeatureFlag(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", false /* watchers disabled in config */, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	res := stopFleetWatchers(io.Discard)
+	if res.Total != 1 {
+		t.Fatalf("Total = %d, want 1", res.Total)
+	}
+	if got := f.sortedUnloaded(); len(got) != 1 || got[0] != paths[0] {
+		t.Fatalf("unloaded = %v, want [%s]", got, paths[0])
+	}
+}
+
+// TestStopFleetWatchers_ReportsWhatItCouldNotStop: silence is what produced
+// the report. A watcher that fails to deactivate must be named.
+func TestStopFleetWatchers_ReportsWhatItCouldNotStop(t *testing.T) {
+	repos := []fleetRepo{
+		{path: "alpha", unitOnDsk: true},
+		{path: "beta", unitOnDsk: true},
+	}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{failOn: map[string]error{paths[1]: os.ErrPermission}}
+	installFleetLoader(t, f)
+
+	var buf bytes.Buffer
+	res := stopFleetWatchers(&buf)
+
+	if len(res.Failures) != 1 {
+		t.Fatalf("Failures = %v, want exactly 1", res.Failures)
+	}
+	if !strings.Contains(res.Failures[0], paths[1]) {
+		t.Fatalf("failure does not name the repo: %q", res.Failures[0])
+	}
+	out := buf.String()
+	if !strings.Contains(out, paths[1]) || !strings.Contains(out, "still running") {
+		t.Fatalf("stop output must name what it could not stop:\n%s", out)
+	}
+}
+
+// TestRunDaemonStop_StopsTheWatcherFleet wires the fleet stop into the actual
+// `grafel stop` entry point. Before the fix runDaemonStop only stopped the
+// daemon's own service.
+func TestRunDaemonStop_StopsTheWatcherFleet(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	origInstalled := serviceInstalledForThisRoot
+	origStop := serviceStopForThisRoot
+	t.Cleanup(func() {
+		serviceInstalledForThisRoot = origInstalled
+		serviceStopForThisRoot = origStop
+	})
+	serviceInstalledForThisRoot = func() bool { return true }
+	serviceStopForThisRoot = func(w io.Writer) error { return nil }
+
+	var buf bytes.Buffer
+	if err := runDaemonStop(&buf); err != nil {
+		t.Fatalf("runDaemonStop: %v", err)
+	}
+	if got := f.sortedUnloaded(); len(got) != 1 || got[0] != paths[0] {
+		t.Fatalf("grafel stop did not stop the watcher fleet: unloaded=%v", got)
+	}
+}
+
+// TestRunDaemonStart_RestoresTheWatcherFleet: a stop that turns watchers off
+// is only acceptable if start turns them back on.
+func TestRunDaemonStart_RestoresTheWatcherFleet(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	origInstalled := serviceInstalledForThisRoot
+	origRestart := serviceRestartForThisRoot
+	t.Cleanup(func() {
+		serviceInstalledForThisRoot = origInstalled
+		serviceRestartForThisRoot = origRestart
+	})
+	serviceInstalledForThisRoot = func() bool { return true }
+	serviceRestartForThisRoot = func(w io.Writer) error { return nil }
+
+	var buf bytes.Buffer
+	if err := runDaemonStartOpts(&buf, 0, false); err != nil {
+		t.Fatalf("runDaemonStartOpts: %v", err)
+	}
+	if got := f.sortedLoaded(); len(got) != 1 || got[0] != paths[0] {
+		t.Fatalf("grafel start did not restore the watcher fleet: loaded=%v", got)
+	}
+}
+
+// TestStartFleetWatchers_RespectsDisabledFeature: start must not resurrect
+// watchers for a group the user turned watchers off for. (Stop is unconditional;
+// start is not — that asymmetry is deliberate.)
+func TestStartFleetWatchers_RespectsDisabledFeature(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	seedFleet(t, "grp", false, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	res := startFleetWatchers(io.Discard)
+	if res.Total != 0 {
+		t.Fatalf("Total = %d, want 0 (feature disabled)", res.Total)
+	}
+	if got := f.sortedLoaded(); len(got) != 0 {
+		t.Fatalf("start resurrected watchers for a watchers=false group: %v", got)
+	}
+}
+
+// TestStatusReportsRunningWatchers: `grafel status` must tell the truth about
+// the fleet — if watchers are still running after a stop, status must say so.
+func TestStatusReportsRunningWatchers(t *testing.T) {
+	repos := []fleetRepo{
+		{path: "alpha", unitOnDsk: true},
+		{path: "beta", unitOnDsk: true},
+	}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{running: map[string]bool{paths[0]: true}}
+	installFleetLoader(t, f)
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "Watchers:") {
+		t.Fatalf("status has no Watchers section:\n%s", out)
+	}
+	if !strings.Contains(out, "1 running") {
+		t.Fatalf("status does not report the running watcher count:\n%s", out)
+	}
+}
+
+// TestDarwinWatcherUnloadIsPersistent: on macOS, `launchctl bootout` only
+// clears the CURRENT login session — the plist stays in ~/Library/LaunchAgents
+// and RunAtLoad fires again at next login. The daemon's own service already
+// pairs bootout with `launchctl disable` for exactly this reason (#6044,
+// internal/daemon/service/launchd_darwin.go Unload). The per-repo watcher
+// loader must do the same, and Load must re-enable.
+func TestDarwinWatcherUnloadIsPersistent(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: launchctl disable/enable semantics")
+	}
+	var calls []string
+	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return nil, nil
+	})
+	t.Cleanup(restore)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	u := watchers.Unit{Group: "grp", Repo: filepath.Join(home, "alpha"), BinPath: "/usr/local/bin/grafel"}
+	if _, err := watchers.Write(u); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+
+	if err := watchers.NewLoader().Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	joined := strings.Join(calls, "\n")
+	if !strings.Contains(joined, "bootout") {
+		t.Fatalf("Unload did not bootout:\n%s", joined)
+	}
+	if !strings.Contains(joined, "disable") {
+		t.Fatalf("Unload did not persist the stop (no `launchctl disable`):\n%s", joined)
+	}
+
+	calls = nil
+	if err := watchers.NewLoader().Load(u); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	joined = strings.Join(calls, "\n")
+	if !strings.Contains(joined, "enable") {
+		t.Fatalf("Load did not clear a persisted disable (no `launchctl enable`):\n%s", joined)
+	}
+	ei := strings.Index(joined, "enable")
+	bi := strings.Index(joined, "bootstrap")
+	if bi >= 0 && ei > bi {
+		t.Fatalf("`launchctl enable` must precede bootstrap:\n%s", joined)
+	}
+}

--- a/internal/cli/watcher_fleet_review_test.go
+++ b/internal/cli/watcher_fleet_review_test.go
@@ -1,0 +1,267 @@
+package cli
+
+// watcher_fleet_review_test.go pins the defects an adversarial review of the
+// first fleet-stop cut found. Each test is named for the property it protects.
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// R1: `grafel stop` must NOT exit 0 after telling the user watchers are still
+// running. The first cut discarded the fleet result entirely, so a stop that
+// deactivated 0 of 140 watchers returned nil and any `&&` chain read success.
+func TestRunDaemonStop_FailsWhenWatchersSurvive(t *testing.T) {
+	repos := []fleetRepo{
+		{path: "alpha", unitOnDsk: true},
+		{path: "beta", unitOnDsk: true},
+	}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{failOn: map[string]error{
+		paths[0]: os.ErrPermission,
+		paths[1]: os.ErrPermission,
+	}}
+	installFleetLoader(t, f)
+	stubDaemonStopSeam(t, nil)
+
+	var buf bytes.Buffer
+	err := runDaemonStop(&buf)
+	if err == nil {
+		t.Fatalf("runDaemonStop returned nil after 0/2 watchers stopped; output:\n%s", buf.String())
+	}
+	if !errors.Is(err, errWatchersNotStopped) {
+		t.Fatalf("want errWatchersNotStopped, got %v", err)
+	}
+}
+
+// R1b: the LAST thing the user sees must not be an unqualified success line
+// while watchers are still running. On 140 repos the warnings would otherwise
+// scroll above "daemon stopped".
+func TestRunDaemonStop_WarningsComeAfterTheDaemonLine(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{failOn: map[string]error{paths[0]: os.ErrPermission}}
+	installFleetLoader(t, f)
+	stubDaemonStopSeam(t, func(w io.Writer) error {
+		_, _ = io.WriteString(w, "daemon stopped\n")
+		return nil
+	})
+
+	var buf bytes.Buffer
+	_ = runDaemonStop(&buf)
+	out := buf.String()
+	di := strings.Index(out, "daemon stopped")
+	wi := strings.Index(out, "still running")
+	if di < 0 || wi < 0 {
+		t.Fatalf("missing daemon line or warning:\n%s", out)
+	}
+	if wi < di {
+		t.Fatalf("watcher warning must come AFTER the daemon line:\n%s", out)
+	}
+}
+
+// R1c: a fleet-stop failure must not prevent the daemon from being stopped.
+func TestRunDaemonStop_StopsDaemonEvenWhenFleetFails(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{failOn: map[string]error{paths[0]: os.ErrPermission}}
+	installFleetLoader(t, f)
+	called := 0
+	stubDaemonStopSeam(t, func(io.Writer) error { called++; return nil })
+
+	_ = runDaemonStop(io.Discard)
+	if called != 1 {
+		t.Fatalf("daemon stop called %d times, want 1", called)
+	}
+}
+
+// R3: enumeration must come from DISK, not only from the registry. An orphan
+// unit — left by a partially-failed watchers.Cleanup, an unreadable group
+// config, a group dropped from registry.json, or a slug-derivation change —
+// is a live watcher the registry cannot see.
+func TestStopFleetWatchers_StopsOrphanUnitsOnDisk(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	seedFleet(t, "grp", true, repos)
+
+	// An orphan plist for a group that is not in the registry at all.
+	dir, err := watchers.UnitDir()
+	if err != nil {
+		t.Fatalf("UnitDir: %v", err)
+	}
+	orphanLabel := "com.grafel.watcher.deletedgroup.orphan"
+	orphanPath := filepath.Join(dir, orphanLabel+unitExtForTest(t))
+	if err := os.WriteFile(orphanPath, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+	var buf bytes.Buffer
+	res := stopFleetWatchers(&buf)
+
+	if res.Total != 2 {
+		t.Fatalf("Total = %d, want 2 (registered + orphan); output:\n%s", res.Total, buf.String())
+	}
+	if !f.sawLabel(orphanLabel) {
+		t.Fatalf("orphan unit %s was never unloaded; unloaded=%v", orphanLabel, f.sortedUnloaded())
+	}
+}
+
+// R3b: an orphan must be counted by status too, or status under-reports what
+// is running after a stop.
+func TestStatusCountsOrphanUnits(t *testing.T) {
+	seedFleet(t, "grp", true, []fleetRepo{{path: "alpha", unitOnDsk: true}})
+	dir, _ := watchers.UnitDir()
+	orphan := filepath.Join(dir, "com.grafel.watcher.deletedgroup.orphan"+unitExtForTest(t))
+	if err := os.WriteFile(orphan, []byte("orphan"), 0o644); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	installFleetLoader(t, &fakeFleetLoader{})
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	if !strings.Contains(buf.String(), "2 installed") {
+		t.Fatalf("status did not count the orphan unit:\n%s", buf.String())
+	}
+}
+
+// R4: `grafel restart` on a service-installed root took an early-return branch
+// that never touched the fleet, so `stop` then `restart` left watchers
+// persistently disabled with the daemon up and no hint of the way out.
+func TestRunDaemonRestart_RestoresTheFleetOnServiceRoot(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+	f := &fakeFleetLoader{}
+	installFleetLoader(t, f)
+
+	origInstalled := serviceInstalledForThisRoot
+	origRestart := serviceRestartForThisRoot
+	t.Cleanup(func() {
+		serviceInstalledForThisRoot = origInstalled
+		serviceRestartForThisRoot = origRestart
+	})
+	serviceInstalledForThisRoot = func() bool { return true }
+	serviceRestartForThisRoot = func(io.Writer) error { return nil }
+
+	var buf bytes.Buffer
+	if err := runDaemonRestart(&buf); err != nil {
+		t.Fatalf("runDaemonRestart: %v", err)
+	}
+	if got := f.sortedLoaded(); len(got) != 1 || got[0] != paths[0] {
+		t.Fatalf("restart did not restore the fleet: loaded=%v out=%q", got, buf.String())
+	}
+}
+
+// R5: stop deactivates units whose group has watchers=false, but start will
+// not bring them back. That is the intended asymmetry — but it is a one-way
+// door, so stop must SAY so rather than claim to be reversible.
+func TestStopFleetWatchers_NamesUnitsStartWillNotRestore(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", false /* watchers disabled */, repos)
+	installFleetLoader(t, &fakeFleetLoader{})
+
+	var buf bytes.Buffer
+	stopFleetWatchers(&buf)
+	out := buf.String()
+	if !strings.Contains(out, paths[0]) {
+		t.Fatalf("stop did not name the one-way-door unit:\n%s", out)
+	}
+	if !strings.Contains(out, "grafel install") {
+		t.Fatalf("stop did not tell the user how to get it back:\n%s", out)
+	}
+}
+
+// R6: the sweep must be bounded. `launchctl bootout` blocks until the job
+// exits and `grafel watch` drains on SIGTERM, so a wedged watcher could hang
+// `grafel stop` forever with no output.
+func TestStopFleetWatchers_BoundedByDeadline(t *testing.T) {
+	repos := []fleetRepo{{path: "alpha", unitOnDsk: true}}
+	paths := seedFleet(t, "grp", true, repos)
+
+	orig := fleetSweepTimeout
+	fleetSweepTimeout = 150 * time.Millisecond
+	t.Cleanup(func() { fleetSweepTimeout = orig })
+
+	f := &fakeFleetLoader{block: make(chan struct{})}
+	t.Cleanup(func() { close(f.block) })
+	installFleetLoader(t, f)
+
+	done := make(chan fleetWatcherResult, 1)
+	var buf bytes.Buffer
+	go func() { done <- stopFleetWatchers(&buf) }()
+
+	select {
+	case res := <-done:
+		if len(res.Failures) != 1 {
+			t.Fatalf("a wedged unit must be reported as not stopped, got %v", res.Failures)
+		}
+		if !strings.Contains(res.Failures[0], paths[0]) {
+			t.Fatalf("failure does not name the wedged repo: %q", res.Failures[0])
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("stopFleetWatchers hung past its deadline")
+	}
+}
+
+// unitExtForTest returns the current platform's watcher-unit file extension by
+// asking watchers.UnitPath, so the test does not hard-code a per-OS suffix.
+func unitExtForTest(t *testing.T) string {
+	t.Helper()
+	p, err := watchers.UnitPath(watchers.Unit{Group: "g", Repo: "/r"})
+	if err != nil {
+		t.Fatalf("UnitPath: %v", err)
+	}
+	return filepath.Ext(p)
+}
+
+// isolateWatcherFleet points HOME / XDG_CONFIG_HOME / GRAFEL_HOME at temp
+// directories so any code path that enumerates the watcher fleet sees an EMPTY
+// fleet instead of the developer's real 140 registered repos and their real
+// ~/Library/LaunchAgents.
+//
+// This is not belt-and-braces. `grafel start` now restores the fleet, so any
+// test that drives runDaemonStartOpts/runDaemonRestart without this would call
+// Loader.Load on the developer's REAL watcher units — i.e. `launchctl enable`
+// + `bootstrap` against live jobs. The fail-closed guard in
+// internal/install/watchers/test_isolation_guard.go catches that and panics
+// (it caught exactly this in TestRunDaemonStartOpts_RoutesToServiceRestart_
+// WhenInstalled, one call short of re-enabling a real user watcher), but the
+// guard is the backstop; isolating the home is the fix.
+func isolateWatcherFleet(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+}
+
+// stubDaemonStopSeam replaces the OS-service stop with a stub so runDaemonStop
+// never touches a real service manager.
+func stubDaemonStopSeam(t *testing.T, fn func(io.Writer) error) {
+	t.Helper()
+	// No isolateWatcherFleet here on purpose: every caller runs seedFleet
+	// first, which already isolates HOME *and* seeds a registry. Re-isolating
+	// would clobber that seed and silently reduce these tests to empty fleets.
+	origInstalled := serviceInstalledForThisRoot
+	origStop := serviceStopForThisRoot
+	t.Cleanup(func() {
+		serviceInstalledForThisRoot = origInstalled
+		serviceStopForThisRoot = origStop
+	})
+	serviceInstalledForThisRoot = func() bool { return true }
+	if fn == nil {
+		fn = func(io.Writer) error { return nil }
+	}
+	serviceStopForThisRoot = fn
+}

--- a/internal/cli/watcher_fleet_review_test.go
+++ b/internal/cli/watcher_fleet_review_test.go
@@ -181,6 +181,55 @@ func TestStopFleetWatchers_NamesUnitsStartWillNotRestore(t *testing.T) {
 	}
 }
 
+// R5b: the remedy printed for a TRUE orphan was wrong. `grafel install` only
+// writes units for REGISTERED repos, so telling the owner of a unit whose group
+// is not in the registry to run `grafel install` sends them somewhere that
+// cannot help — in exactly the case the message was added to cover.
+func TestStopFleetWatchers_OrphanRemedyIsNotGrafelInstall(t *testing.T) {
+	seedFleet(t, "grp", true, []fleetRepo{{path: "alpha", unitOnDsk: true}})
+	dir, _ := watchers.UnitDir()
+	orphanLabel := "com.grafel.watcher.deletedgroup.orphan"
+	if err := os.WriteFile(filepath.Join(dir, orphanLabel+unitExtForTest(t)), []byte("x"), 0o644); err != nil {
+		t.Fatalf("write orphan: %v", err)
+	}
+	installFleetLoader(t, &fakeFleetLoader{})
+
+	var buf bytes.Buffer
+	stopFleetWatchers(&buf)
+	out := buf.String()
+
+	// The orphan must be named...
+	oi := strings.Index(out, orphanLabel)
+	if oi < 0 {
+		t.Fatalf("orphan not named in stop output:\n%s", out)
+	}
+	// ...and the line that names it must not be under a "run grafel install"
+	// heading. Split the output at the orphan section and check its remedy.
+	orphanSection := out[oi:]
+	if strings.Contains(orphanSection, "grafel install") {
+		t.Fatalf("orphan remedy points at 'grafel install', which cannot restore an "+
+			"unregistered unit:\n%s", out)
+	}
+	if !strings.Contains(out, "no registered group owns") {
+		t.Fatalf("stop does not explain that the orphan has no owning group:\n%s", out)
+	}
+}
+
+// R5c: the watchers=false case keeps the `grafel install` remedy, which IS
+// correct there — the repo is registered, install re-writes and re-loads it.
+func TestStopFleetWatchers_DisabledGroupRemedyIsGrafelInstall(t *testing.T) {
+	paths := seedFleet(t, "grp", false, []fleetRepo{{path: "alpha", unitOnDsk: true}})
+	installFleetLoader(t, &fakeFleetLoader{})
+
+	var buf bytes.Buffer
+	stopFleetWatchers(&buf)
+	out := buf.String()
+	if !strings.Contains(out, paths[0]) || !strings.Contains(out, "grafel install") {
+		t.Fatalf("a registered repo whose group has watchers off must still be pointed at "+
+			"'grafel install':\n%s", out)
+	}
+}
+
 // R6: the sweep must be bounded. `launchctl bootout` blocks until the job
 // exits and `grafel watch` drains on SIGTERM, so a wedged watcher could hang
 // `grafel stop` forever with no output.

--- a/internal/daemon/selfdefense_test.go
+++ b/internal/daemon/selfdefense_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 )
 
 // TestSelfDefenseCheck_AllowsCanonicalBinary verifies that SelfDefenseCheck
@@ -160,7 +161,14 @@ func TestSelfDefenseCheck_RunRefusesWhenCalledFromTmpBinary(t *testing.T) {
 	// The raw string literal is also why the original #6134 sweep missed this
 	// site: it greps for daemon.EnvRoot, and a literal does not match. Using the
 	// constant keeps this line discoverable by the next audit.
-	cmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot)
+	cmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot,
+		// Guard belt (#stop-fleet): testing.Testing() is false in this
+		// go-built child, so the watchers package's service-manager guard
+		// cannot see that it is under test. Export the belt so a child that
+		// ever reaches `grafel stop`/`install`/`update` refuses to mutate the
+		// developer's real launchd/systemd state instead of doing it silently.
+		watchers.NoServiceMutationEnv+"=1",
+	)
 	cmd.Stderr = &stderrBuf
 
 	waitErr := cmd.Run()

--- a/internal/daemon/service/guard_coverage_darwin_test.go
+++ b/internal/daemon/service/guard_coverage_darwin_test.go
@@ -1,0 +1,53 @@
+//go:build darwin
+
+package service
+
+// guard_coverage_darwin_test.go proves the service-manager guard actually
+// covers THIS package's mutating call sites.
+//
+// These four vars manage `com.grafel.daemon` — the label serving the user's
+// live MCP session. A test that reaches launchctlBootout here does not disable
+// a watcher, it kills the running daemon. They were seamed (package vars) but
+// unguarded, which is the "declared a seam, then did not use it" shape that
+// already let install.go drive real launchctl calls while a test believed
+// itself isolated.
+//
+// Why a PATH-shim measurement does not substitute for this: a shim that makes
+// `launchctl list` exit non-zero makes every Unload short-circuit before its
+// bootout, so "zero mutating verbs observed" proves only that the path was not
+// reached under that launchd state — not that it cannot be. Guarding the call
+// site makes the property hold regardless of what is loaded.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestMutatingLaunchctlHelpersAreGuarded calls each REAL helper (not a stub)
+// and requires it to panic rather than shell out.
+func TestMutatingLaunchctlHelpersAreGuarded(t *testing.T) {
+	cases := []struct {
+		name string
+		call func()
+	}{
+		{"bootout", func() { _ = launchctlBootout("0") }},
+		{"bootstrap", func() { _, _ = launchctlBootstrap("0", "/nonexistent.plist") }},
+		{"disable", func() { _ = launchctlDisable("0") }},
+		{"enable", func() { _ = launchctlEnable("0") }},
+	}
+	for _, c := range cases {
+		func() {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("launchctl %s is NOT guarded — a test can boot out the user's live daemon", c.name)
+				}
+				msg, ok := r.(string)
+				if !ok || !strings.Contains(msg, c.name) {
+					t.Fatalf("panic does not name the verb %q: %v", c.name, r)
+				}
+			}()
+			c.call()
+		}()
+	}
+}

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -171,22 +171,30 @@ func (m *launchdManager) WriteUnit() error {
 // with no seam to observe them at all, so deleting either line outright left
 // the whole suite green.
 var launchctlBootout = func(uid string) error {
-	watchers.GuardServiceCall("launchctl", []string{"bootout", "gui/" + uid + "/" + launchLabel})
+	if err := watchers.GuardServiceCall("launchctl", []string{"bootout", "gui/" + uid + "/" + launchLabel}); err != nil {
+		return err
+	}
 	return exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchLabel).Run()
 }
 
 var launchctlBootstrap = func(uid, plistPath string) ([]byte, error) {
-	watchers.GuardServiceCall("launchctl", []string{"bootstrap", "gui/" + uid, plistPath})
+	if err := watchers.GuardServiceCall("launchctl", []string{"bootstrap", "gui/" + uid, plistPath}); err != nil {
+		return nil, err
+	}
 	return exec.Command("launchctl", "bootstrap", "gui/"+uid, plistPath).CombinedOutput()
 }
 
 var launchctlDisable = func(uid string) error {
-	watchers.GuardServiceCall("launchctl", []string{"disable", "gui/" + uid + "/" + launchLabel})
+	if err := watchers.GuardServiceCall("launchctl", []string{"disable", "gui/" + uid + "/" + launchLabel}); err != nil {
+		return err
+	}
 	return exec.Command("launchctl", "disable", "gui/"+uid+"/"+launchLabel).Run()
 }
 
 var launchctlEnable = func(uid string) error {
-	watchers.GuardServiceCall("launchctl", []string{"enable", "gui/" + uid + "/" + launchLabel})
+	if err := watchers.GuardServiceCall("launchctl", []string{"enable", "gui/" + uid + "/" + launchLabel}); err != nil {
+		return err
+	}
 	return exec.Command("launchctl", "enable", "gui/"+uid+"/"+launchLabel).Run()
 }
 

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 )
 
 const (
@@ -170,18 +171,22 @@ func (m *launchdManager) WriteUnit() error {
 // with no seam to observe them at all, so deleting either line outright left
 // the whole suite green.
 var launchctlBootout = func(uid string) error {
+	watchers.GuardServiceCall("launchctl", []string{"bootout", "gui/" + uid + "/" + launchLabel})
 	return exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchLabel).Run()
 }
 
 var launchctlBootstrap = func(uid, plistPath string) ([]byte, error) {
+	watchers.GuardServiceCall("launchctl", []string{"bootstrap", "gui/" + uid, plistPath})
 	return exec.Command("launchctl", "bootstrap", "gui/"+uid, plistPath).CombinedOutput()
 }
 
 var launchctlDisable = func(uid string) error {
+	watchers.GuardServiceCall("launchctl", []string{"disable", "gui/" + uid + "/" + launchLabel})
 	return exec.Command("launchctl", "disable", "gui/"+uid+"/"+launchLabel).Run()
 }
 
 var launchctlEnable = func(uid string) error {
+	watchers.GuardServiceCall("launchctl", []string{"enable", "gui/" + uid + "/" + launchLabel})
 	return exec.Command("launchctl", "enable", "gui/"+uid+"/"+launchLabel).Run()
 }
 

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -117,7 +117,9 @@ func currentUserSID() string {
 // launched from a GUI context (e.g., Task Scheduler running grafel install,
 // or the daemon task itself restarting on logon).
 func schtasksCmd(args ...string) *exec.Cmd {
-	watchers.GuardServiceCall("schtasks", args)
+	if watchers.GuardServiceCall("schtasks", args) != nil {
+		return exec.Command("cmd", "/c", "exit", "1")
+	}
 	cmd := exec.Command("schtasks", args...)
 	executil.NoWindow(cmd)
 	return cmd

--- a/internal/daemon/service/schtasks_windows.go
+++ b/internal/daemon/service/schtasks_windows.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cajasmota/grafel/internal/daemon/transport"
 	"github.com/cajasmota/grafel/internal/executil"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 )
 
 const (
@@ -116,6 +117,7 @@ func currentUserSID() string {
 // launched from a GUI context (e.g., Task Scheduler running grafel install,
 // or the daemon task itself restarting on logon).
 func schtasksCmd(args ...string) *exec.Cmd {
+	watchers.GuardServiceCall("schtasks", args)
 	cmd := exec.Command("schtasks", args...)
 	executil.NoWindow(cmd)
 	return cmd

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/transport"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 )
 
 const (
@@ -117,6 +118,7 @@ func (m *systemdManager) WriteUnit() error {
 	}
 	// Reload so systemd picks up the (re)written unit file. Non-fatal if the
 	// user systemd manager isn't reachable yet — Load surfaces real failures.
+	guardSystemctl("daemon-reload")
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
@@ -138,13 +140,17 @@ func (m *systemdManager) Unload() error {
 	stopRunningDaemon(m.opts.SocketPath)
 	// disable --now stops + disables. systemctl exits non-zero when the unit is
 	// not loaded; treat that as success-to-proceed (desired state reached).
+	guardSystemctl("disable")
 	_ = exec.Command("systemctl", "--user", "disable", "--now", m.unitID).Run()
+	guardSystemctl("reset-failed")
 	_ = exec.Command("systemctl", "--user", "reset-failed", m.unitID).Run()
+	guardSystemctl("daemon-reload")
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
 
 func (m *systemdManager) Load() error {
+	guardSystemctl("enable")
 	if out, err := exec.Command("systemctl", "--user", "enable", "--now", m.unitID).CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl enable --now: %w\n%s", err, out)
 	}
@@ -155,6 +161,7 @@ func (m *systemdManager) RemoveArtifacts() error {
 	if err := os.Remove(m.unitPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove unit %s: %w", m.unitPath, err)
 	}
+	guardSystemctl("daemon-reload")
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
@@ -287,4 +294,11 @@ func status(opts Options) (StatusInfo, error) {
 		}
 	}
 	return info, nil
+}
+
+// guardSystemctl refuses a real, mutating systemctl call from a test process.
+// See watchers.GuardServiceCall: these units manage com.grafel.daemon, the
+// label serving the user's live session.
+func guardSystemctl(verb string) {
+	watchers.GuardServiceCall("systemctl", []string{"--user", verb})
 }

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -118,7 +118,9 @@ func (m *systemdManager) WriteUnit() error {
 	}
 	// Reload so systemd picks up the (re)written unit file. Non-fatal if the
 	// user systemd manager isn't reachable yet — Load surfaces real failures.
-	guardSystemctl("daemon-reload")
+	if err := guardSystemctl("daemon-reload"); err != nil {
+		return err
+	}
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
@@ -140,17 +142,25 @@ func (m *systemdManager) Unload() error {
 	stopRunningDaemon(m.opts.SocketPath)
 	// disable --now stops + disables. systemctl exits non-zero when the unit is
 	// not loaded; treat that as success-to-proceed (desired state reached).
-	guardSystemctl("disable")
+	if err := guardSystemctl("disable"); err != nil {
+		return err
+	}
 	_ = exec.Command("systemctl", "--user", "disable", "--now", m.unitID).Run()
-	guardSystemctl("reset-failed")
+	if err := guardSystemctl("reset-failed"); err != nil {
+		return err
+	}
 	_ = exec.Command("systemctl", "--user", "reset-failed", m.unitID).Run()
-	guardSystemctl("daemon-reload")
+	if err := guardSystemctl("daemon-reload"); err != nil {
+		return err
+	}
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
 
 func (m *systemdManager) Load() error {
-	guardSystemctl("enable")
+	if err := guardSystemctl("enable"); err != nil {
+		return err
+	}
 	if out, err := exec.Command("systemctl", "--user", "enable", "--now", m.unitID).CombinedOutput(); err != nil {
 		return fmt.Errorf("systemctl enable --now: %w\n%s", err, out)
 	}
@@ -161,7 +171,9 @@ func (m *systemdManager) RemoveArtifacts() error {
 	if err := os.Remove(m.unitPath); err != nil && !os.IsNotExist(err) {
 		return fmt.Errorf("remove unit %s: %w", m.unitPath, err)
 	}
-	guardSystemctl("daemon-reload")
+	if err := guardSystemctl("daemon-reload"); err != nil {
+		return err
+	}
 	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
 	return nil
 }
@@ -299,6 +311,6 @@ func status(opts Options) (StatusInfo, error) {
 // guardSystemctl refuses a real, mutating systemctl call from a test process.
 // See watchers.GuardServiceCall: these units manage com.grafel.daemon, the
 // label serving the user's live session.
-func guardSystemctl(verb string) {
-	watchers.GuardServiceCall("systemctl", []string{"--user", verb})
+func guardSystemctl(verb string) error {
+	return watchers.GuardServiceCall("systemctl", []string{"--user", verb})
 }

--- a/internal/dashboard/handlers_system.go
+++ b/internal/dashboard/handlers_system.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/version"
 )
 
@@ -379,11 +380,25 @@ func classifySeverity(line string) string {
 // platform's native service manager. On macOS this is launchctl; on Linux
 // it is systemctl. Falls back to a direct exec if neither is available.
 // This is called by handleSystemRestart after the response is flushed.
+// Both calls are guarded. This force-restarts com.grafel.daemon — the label
+// serving the user's live MCP session — so reaching it from a test kills the
+// daemon rather than a watcher. No test reaches it today (a PATH-shim run of
+// ./internal/dashboard/ observes zero calls here), but "no test reaches it
+// today" is precisely the argument this guard exists to stop relying on: it is
+// a statement about the current suite, not a property of the code.
 func restartViaBinary() {
 	switch runtime.GOOS {
 	case "darwin":
-		_ = exec.Command("launchctl", "kickstart", "-k", "gui/"+strconv.Itoa(os.Getuid())+"/com.grafel.daemon").Run()
+		args := []string{"kickstart", "-k", "gui/" + strconv.Itoa(os.Getuid()) + "/com.grafel.daemon"}
+		if watchers.GuardServiceCall("launchctl", args) != nil {
+			return
+		}
+		_ = exec.Command("launchctl", args...).Run()
 	case "linux":
-		_ = exec.Command("systemctl", "--user", "restart", "grafel").Run()
+		args := []string{"--user", "restart", "grafel"}
+		if watchers.GuardServiceCall("systemctl", args) != nil {
+			return
+		}
+		_ = exec.Command("systemctl", args...).Run()
 	}
 }

--- a/internal/dashboard/restart_guard_darwin_test.go
+++ b/internal/dashboard/restart_guard_darwin_test.go
@@ -1,0 +1,27 @@
+//go:build darwin
+
+package dashboard
+
+// restart_guard_darwin_test.go pins that restartViaBinary cannot force-restart
+// the developer's live daemon from a test.
+//
+// `launchctl kickstart -k gui/<uid>/com.grafel.daemon` restarts the label
+// serving the user's MCP session. No test in this package reaches it today —
+// a PATH-shim run observes zero calls — but that is a statement about the
+// current suite, not a property of the code, and it is the reasoning that let
+// install.go drive real launchctl calls for as long as it did.
+
+import (
+	"testing"
+)
+
+// TestRestartViaBinaryIsGuarded calls the REAL function and requires the guard
+// to stop it before it shells out.
+func TestRestartViaBinaryIsGuarded(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("restartViaBinary is NOT guarded — a test can kickstart the user's live daemon")
+		}
+	}()
+	restartViaBinary()
+}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -326,7 +326,14 @@ func Apply(opts Options) (*Result, error) {
 				// group config is already persisted (above), so the group is
 				// registered and will index regardless. Aborting here used to
 				// fail the whole wizard on a flaky launchctl error (#5338).
-				loader := watchers.NewLoader()
+				// newWatcherLoader, not watchers.NewLoader() directly: this
+				// call site bypassed the package's own test seam, so
+				// TestApply_ResetsWatchStartsWhenRegisteringUnit — which DOES
+				// stub newWatcherLoader and believed itself isolated — was in
+				// fact driving a real `launchctl bootout`/`bootstrap` against
+				// gui/<uid>/com.grafel.watcher.g.app on the developer's
+				// machine every time the suite ran.
+				loader := newWatcherLoader()
 				if lerr := loader.Load(u); lerr != nil && !watchers.IsNonFatal(lerr) {
 					res.WatcherWarnings = append(res.WatcherWarnings,
 						fmt.Sprintf("watcher for %s not activated: %v; the group is still registered and will index", repo, lerr))
@@ -501,7 +508,9 @@ func Uninstall(group string, purge bool) error {
 	}
 	bin, _ := os.Executable()
 	if cfg != nil {
-		loader := watchers.NewLoader()
+		// Through the test seam, like the Apply path above — an unseamed
+		// uninstall would boot out real launchd jobs from a test run.
+		loader := newWatcherLoader()
 		for _, r := range cfg.Repos {
 			_ = hooks.Uninstall(r.Path)
 			_ = agenthooks.Uninstall(r.Path)

--- a/internal/install/launchctl_stub_darwin_test.go
+++ b/internal/install/launchctl_stub_darwin_test.go
@@ -23,10 +23,10 @@ import (
 // was a constant for a given (group, basename), so repeated runs reused one job;
 // the digest is over os.MkdirTemp's unique path, so every run mints a new label
 // and leaks a new job. 23 were found accumulated on one machine.
+// It delegates to watchers.StubServiceCallsForTest, the single cross-platform
+// stub mechanism, rather than swapping launchctlRunner directly — see
+// watchers/stub_6183_darwin_test.go for why there is only one.
 func stubLaunchctlRunner(t *testing.T) {
 	t.Helper()
-	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
-		return nil, nil
-	})
-	t.Cleanup(restore)
+	t.Cleanup(watchers.StubServiceCallsForTest())
 }

--- a/internal/install/launchctl_stub_other_test.go
+++ b/internal/install/launchctl_stub_other_test.go
@@ -2,7 +2,18 @@
 
 package install
 
-import "testing"
+import (
+	"testing"
 
-// stubLaunchctlRunner is a no-op off macOS; there is no launchctl to stub.
-func stubLaunchctlRunner(t *testing.T) { t.Helper() }
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// stubLaunchctlRunner neutralises service-manager calls off macOS too: the
+// Linux loader shells out to `systemctl --user disable --now` and the Windows
+// one to `schtasks /delete`, both of which mutate the developer's real session.
+// "There is no launchctl to stub" was true of the command and false of the
+// property.
+func stubLaunchctlRunner(t *testing.T) {
+	t.Helper()
+	t.Cleanup(watchers.StubServiceCallsForTest())
+}

--- a/internal/install/watchers/cleanup_test.go
+++ b/internal/install/watchers/cleanup_test.go
@@ -6,10 +6,26 @@ import (
 	"testing"
 )
 
+// seamLaunchctl installs a no-op fake service-manager runner for the duration
+// of the test.
+//
+// Cleanup -> Loader.Unload issues real OS service-manager calls. `gui/<uid>/
+// <label>` is a system database that no environment variable sandboxes, so
+// redirecting $HOME (as these tests do) does NOT isolate them: without this
+// seam the suite writes launchd override entries for the `demo` fixtures onto
+// the developer's machine, permanently and with no cleanup. The fail-closed
+// guard in test_isolation_guard.go now panics rather than letting that happen;
+// this seam is how the test does what it actually means to do.
+func seamLaunchctl(t *testing.T) {
+	t.Helper()
+	t.Cleanup(StubServiceCallsForTest())
+}
+
 // TestCleanup_RemovesUnitFile verifies the #5338 group-delete fix: Cleanup
 // removes the on-disk watcher unit/plist for a repo so a later recreate does
 // not fight stale state.
 func TestCleanup_RemovesUnitFile(t *testing.T) {
+	seamLaunchctl(t)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
 
@@ -35,6 +51,7 @@ func TestCleanup_RemovesUnitFile(t *testing.T) {
 // TestCleanup_Idempotent verifies Cleanup tolerates a never-installed unit
 // (no file on disk, not loaded) without panicking or erroring.
 func TestCleanup_Idempotent(t *testing.T) {
+	seamLaunchctl(t)
 	t.Setenv("HOME", t.TempDir())
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), ".config"))
 

--- a/internal/install/watchers/guard_allowlist_test.go
+++ b/internal/install/watchers/guard_allowlist_test.go
@@ -94,12 +94,23 @@ func TestGuard_MutatingVerbsPanicForEveryTool(t *testing.T) {
 // `grafel stop`/`install`/`update` the guard is bypassed completely and
 // silently. The env belt is what those harnesses export.
 func TestGuard_EnvBeltActivatesOutsideGoTest(t *testing.T) {
-	t.Setenv(NoServiceMutationEnv, "1")
-	if !serviceMutationGuardActive() {
-		t.Fatal("guard must be active when the env belt is set")
+	// The interesting case is underGoTest=false — which this test process can
+	// never itself be in, hence the explicit inputs.
+	if !guardActiveFor(false, "1") {
+		t.Fatal("the env belt alone must activate the guard in a go-built binary")
 	}
+	if guardActiveFor(false, "") {
+		t.Fatal("outside go test with no belt the guard must be inert (production)")
+	}
+	if guardActiveFor(false, "0") {
+		t.Fatal("only \"1\" activates the belt")
+	}
+	if !guardActiveFor(true, "") {
+		t.Fatal("under go test the guard must be active regardless of the belt")
+	}
+	// And the wiring: the real predicate must be true here (we ARE under test).
 	t.Setenv(NoServiceMutationEnv, "")
 	if !serviceMutationGuardActive() {
-		t.Fatal("guard must still be active under `go test` with the env unset")
+		t.Fatal("serviceMutationGuardActive must be true under go test")
 	}
 }

--- a/internal/install/watchers/guard_allowlist_test.go
+++ b/internal/install/watchers/guard_allowlist_test.go
@@ -1,0 +1,105 @@
+package watchers
+
+// guard_allowlist_test.go pins the guard's inversion from a denylist of known
+// mutating verbs to an allowlist of known read-only ones, and the env belt that
+// covers the case testing.Testing() cannot see.
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestGuard_UnlistedVerbsArePanics: the first cut called itself "fail-closed"
+// while documenting "anything not listed is allowed" — the opposite. It was
+// complete for the verbs in use and silently open to every other one.
+// `launchctl submit`, `setenv`, `kill` and `config` all mutate and were all
+// absent from the denylist.
+func TestGuard_UnlistedVerbsArePanics(t *testing.T) {
+	for _, verb := range []string{"submit", "setenv", "kill", "config", "reboot", "somethingnew"} {
+		func() {
+			defer func() {
+				if r := recover(); r == nil {
+					t.Fatalf("guardServiceCall(%q) must panic — an unrecognised verb is not known to be safe", verb)
+				}
+			}()
+			guardServiceCall("launchctl", []string{verb, "gui/0/x"})
+		}()
+	}
+}
+
+// TestGuard_ReadOnlyVerbsPassForEveryTool: the allowlist must be keyed on the
+// VERB, not on every argument, or the flags and unit names that systemctl and
+// schtasks pass would each look like an unrecognised verb.
+func TestGuard_ReadOnlyVerbsPassForEveryTool(t *testing.T) {
+	cases := []struct {
+		tool string
+		args []string
+	}{
+		{"launchctl", []string{"list", "com.grafel.watcher.a.b"}},
+		{"launchctl", []string{"print", "gui/501/com.grafel.watcher.a.b"}},
+		{"launchctl", []string{"print-disabled", "gui/501"}},
+		{"systemctl", []string{"--user", "is-active", "--quiet", "com.grafel.watcher.a.b.service"}},
+		{"systemctl", []string{"--user", "is-enabled", "x.service"}},
+		{"schtasks", []string{"/query", "/tn", "com.grafel.watcher.a.b"}},
+		{"schtasks", []string{"/query", "/fo", "csv", "/v", "/tn", "x"}},
+	}
+	for _, c := range cases {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("guardServiceCall(%q, %v) must not panic: %v", c.tool, c.args, r)
+				}
+			}()
+			guardServiceCall(c.tool, c.args)
+		}()
+	}
+}
+
+// TestGuard_MutatingVerbsPanicForEveryTool: schtasks was listed in the verb
+// table but nothing ever called guardServiceCall("schtasks", ...) — the entries
+// were dead and misleading. The windows loader is guarded now, so the table
+// entries have to mean something.
+func TestGuard_MutatingVerbsPanicForEveryTool(t *testing.T) {
+	cases := []struct {
+		tool string
+		args []string
+	}{
+		{"launchctl", []string{"bootout", "gui/501/x"}},
+		{"launchctl", []string{"bootstrap", "gui/501", "/tmp/x.plist"}},
+		{"systemctl", []string{"--user", "disable", "--now", "x.service"}},
+		{"systemctl", []string{"--user", "daemon-reload"}},
+		{"schtasks", []string{"/create", "/xml", "/tmp/x.xml", "/tn", "x", "/f"}},
+		{"schtasks", []string{"/delete", "/tn", "x", "/f"}},
+		{"schtasks", []string{"/end", "/tn", "x"}},
+	}
+	for _, c := range cases {
+		func() {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("guardServiceCall(%q, %v) did not panic", c.tool, c.args)
+				}
+				if !strings.Contains(r.(string), c.tool) {
+					t.Fatalf("panic message does not name the tool: %v", r)
+				}
+			}()
+			guardServiceCall(c.tool, c.args)
+		}()
+	}
+}
+
+// TestGuard_EnvBeltActivatesOutsideGoTest: testing.Testing() is false in a
+// binary produced by `go build`, and several tests build ./cmd/grafel and exec
+// it. Today those harnesses only run `grafel daemon`; the moment one runs
+// `grafel stop`/`install`/`update` the guard is bypassed completely and
+// silently. The env belt is what those harnesses export.
+func TestGuard_EnvBeltActivatesOutsideGoTest(t *testing.T) {
+	t.Setenv(NoServiceMutationEnv, "1")
+	if !serviceMutationGuardActive() {
+		t.Fatal("guard must be active when the env belt is set")
+	}
+	t.Setenv(NoServiceMutationEnv, "")
+	if !serviceMutationGuardActive() {
+		t.Fatal("guard must still be active under `go test` with the env unset")
+	}
+}

--- a/internal/install/watchers/guard_bounded_test.go
+++ b/internal/install/watchers/guard_bounded_test.go
@@ -1,0 +1,84 @@
+//go:build darwin
+
+package watchers
+
+// guard_bounded_test.go covers the two properties the first mutation round
+// found unprotected: the test-isolation guard itself, and cmd.WaitDelay.
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestGuardServiceCall_PanicsOnMutatingVerb: the guard is the structural
+// backstop that stops a test writing into the developer's real launchd
+// database. If it stops firing, nothing else notices.
+func TestGuardServiceCall_PanicsOnMutatingVerb(t *testing.T) {
+	for _, verb := range []string{"disable", "enable", "bootout", "bootstrap"} {
+		func() {
+			defer func() {
+				r := recover()
+				if r == nil {
+					t.Fatalf("guardServiceCall(%q) did not panic", verb)
+				}
+				if !strings.Contains(r.(string), verb) {
+					t.Fatalf("panic message does not name the verb: %v", r)
+				}
+			}()
+			guardServiceCall("launchctl", []string{verb, "gui/0/x"})
+		}()
+	}
+}
+
+// TestGuardServiceCall_AllowsReadOnlyVerbs: `launchctl list` / `print` are
+// common, harmless and legitimately exercised, so the guard must not block
+// them — a guard that fires on everything gets disabled.
+func TestGuardServiceCall_AllowsReadOnlyVerbs(t *testing.T) {
+	for _, verb := range []string{"list", "print", "print-disabled"} {
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("guardServiceCall(%q) must not panic, got %v", verb, r)
+				}
+			}()
+			guardServiceCall("launchctl", []string{verb, "com.grafel.watcher.x.y"})
+		}()
+	}
+}
+
+// TestRunBoundedServiceCmd_ReturnsWhenAGrandchildHoldsThePipe is the WaitDelay
+// test.
+//
+// A context deadline alone is NOT enough: exec.CommandContext's cancel kills
+// only the DIRECT child, while CombinedOutput blocks until every writer to the
+// output pipe has closed it. A grandchild that inherited stdout keeps that pipe
+// open, so Wait blocks well past the deadline — measured elsewhere in this tree
+// at 20.5s past a 1s deadline. cmd.WaitDelay is what caps it unconditionally.
+//
+// The fixture reproduces exactly that shape: /bin/sh backgrounds a long sleep
+// (which inherits the pipe) and exits immediately. Without WaitDelay this call
+// blocks for the full sleep; with it, it returns within the grace period.
+func TestRunBoundedServiceCmd_ReturnsWhenAGrandchildHoldsThePipe(t *testing.T) {
+	origT, origW := launchctlTimeout, launchctlWaitDelay
+	launchctlTimeout = 200 * time.Millisecond
+	launchctlWaitDelay = 300 * time.Millisecond
+	t.Cleanup(func() { launchctlTimeout, launchctlWaitDelay = origT, origW })
+
+	done := make(chan time.Duration, 1)
+	go func() {
+		start := time.Now()
+		_, _ = runBoundedServiceCmd("/bin/sh", "-c", "sleep 30 & exit 0")
+		done <- time.Since(start)
+	}()
+
+	select {
+	case elapsed := <-done:
+		// Generous ceiling: the point is "seconds, not 30 seconds".
+		if elapsed > 5*time.Second {
+			t.Fatalf("runBoundedServiceCmd took %s — WaitDelay is not capping the pipe wait", elapsed)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("runBoundedServiceCmd never returned: a grandchild holding the pipe blocks it forever")
+	}
+}

--- a/internal/install/watchers/guard_production_test.go
+++ b/internal/install/watchers/guard_production_test.go
@@ -1,0 +1,117 @@
+package watchers
+
+// guard_production_test.go pins the two properties that separate a guard from a
+// liability: it must never panic in a SHIPPED binary, and the plumbing that
+// activates it outside `go test` must itself be exercised.
+
+import (
+	"strings"
+	"testing"
+)
+
+// withGuardInputs forces the guard's two inputs for the duration of a test.
+// Only these seams make the production case reachable: a test process always
+// has testing.Testing()==true, so nothing else can observe what a `go build`
+// binary would do.
+func withGuardInputs(t *testing.T, underGoTest bool, env string) {
+	t.Helper()
+	origTest, origGetenv := guardUnderGoTest, getenvForGuard
+	guardUnderGoTest = underGoTest
+	getenvForGuard = func(k string) string {
+		if k == NoServiceMutationEnv {
+			return env
+		}
+		return ""
+	}
+	t.Cleanup(func() { guardUnderGoTest, getenvForGuard = origTest, origGetenv })
+}
+
+// TestGuard_BeltInProductionReturnsErrorNeverPanics is the finding-1 test.
+//
+// The belt is reachable in a shipped binary — internal/verify and
+// internal/daemon now export it to a spawned `grafel daemon`, which serves
+// group-delete RPCs that reach watchers.Cleanup. A panic there is three wrongs
+// at once: it aborts code whose own contract is best-effort (Cleanup is
+// documented idempotent, and `_ = loader.Unload(u)` deliberately discards), it
+// happens inside a goroutine spawned by sweepFleetWatchers where no recover()
+// can reach it so the whole process dies, and it says "test attempted" when
+// there is no test.
+func TestGuard_BeltInProductionReturnsErrorNeverPanics(t *testing.T) {
+	withGuardInputs(t, false /* NOT under go test */, "1" /* belt set */)
+
+	var err error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("guardServiceCall must NOT panic outside go test, got: %v", r)
+			}
+		}()
+		err = guardServiceCall("launchctl", []string{"bootout", "gui/501/com.grafel.daemon"})
+	}()
+	if err == nil {
+		t.Fatal("guardServiceCall must return an error when the belt is set")
+	}
+	if strings.Contains(err.Error(), "test attempted") {
+		t.Fatalf("the production message must not claim a test is running: %q", err)
+	}
+	if !strings.Contains(err.Error(), "bootout") {
+		t.Fatalf("error should name the refused verb: %q", err)
+	}
+}
+
+// TestGuard_PanicsUnderGoTest keeps the loud behaviour where it belongs: a real
+// test leak must be impossible to ignore, not returned as an error some
+// best-effort call site discards.
+func TestGuard_PanicsUnderGoTest(t *testing.T) {
+	withGuardInputs(t, true /* under go test */, "")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatal("guardServiceCall must panic under go test")
+		}
+	}()
+	_ = guardServiceCall("launchctl", []string{"bootout", "gui/501/x"})
+}
+
+// TestGuard_InertInProductionWithoutTheBelt: a shipped binary with no belt must
+// be completely unaffected — no panic, no error, no behaviour change.
+func TestGuard_InertInProductionWithoutTheBelt(t *testing.T) {
+	withGuardInputs(t, false, "")
+	if err := guardServiceCall("launchctl", []string{"bootout", "gui/501/x"}); err != nil {
+		t.Fatalf("guard must be inert in production, got %v", err)
+	}
+}
+
+// TestGuard_ReadsTheEnvVarByName is the finding-3 test (mutant P5').
+//
+// guardActiveFor's decision was pinned, but the plumbing from os.Getenv into it
+// was not: keeping the os.Getenv call and discarding its value left every suite
+// green while the belt was silently dead. Since finding 1 proves the belt is
+// the ONLY thing between a `go build` child and real launchd mutation — with
+// two harnesses now depending on it — a dead belt is a silent removal of the
+// protection, not a cosmetic defect.
+func TestGuard_ReadsTheEnvVarByName(t *testing.T) {
+	var asked []string
+	origTest, origGetenv := guardUnderGoTest, getenvForGuard
+	guardUnderGoTest = false
+	getenvForGuard = func(k string) string {
+		asked = append(asked, k)
+		if k == NoServiceMutationEnv {
+			return "1"
+		}
+		return ""
+	}
+	t.Cleanup(func() { guardUnderGoTest, getenvForGuard = origTest, origGetenv })
+
+	if !serviceMutationGuardActive() {
+		t.Fatal("the belt's value must reach the decision, not be read and discarded")
+	}
+	found := false
+	for _, k := range asked {
+		if k == NoServiceMutationEnv {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("guard never read %s; asked=%v", NoServiceMutationEnv, asked)
+	}
+}

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -75,6 +75,15 @@ func (darwinLoader) Load(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
 	label := u.Label()
 
+	// Clear any persisted disable override before bootstrapping. Unload writes
+	// one (see below) so that `grafel stop` survives logout/reboot; without a
+	// matching enable here, RunAtLoad silently does nothing on a disabled job
+	// and `grafel start` would report success over a watcher that never runs.
+	// Best-effort, exactly like the daemon service's own enable/disable pairing
+	// in internal/daemon/service/launchd_darwin.go: bootstrap below is the real
+	// convergence signal.
+	_, _ = launchctlRunner("enable", "gui/"+uid+"/"+label)
+
 	var lastOut []byte
 	var lastErr error
 	for attempt := 1; attempt <= bootstrapRetries; attempt++ {
@@ -106,21 +115,44 @@ func (darwinLoader) Load(u Unit) error {
 // ("No such process" etc.), which breaks on non-English macOS. If the service
 // is not listed there is nothing to bootout — the desired absent state is
 // already reached, so we report success without shelling out to bootout.
+// The stop is PERSISTENT: bootout alone only clears the CURRENT login
+// session, because the plist stays in ~/Library/LaunchAgents and RunAtLoad
+// fires again at next login — so a bare bootout is "stop until you log in
+// again", not a stop. `launchctl disable` writes an override that suppresses
+// that automatic relaunch across login/reboot. This is the same pairing the
+// grafel daemon's own service already uses (#6044,
+// internal/daemon/service/launchd_darwin.go Unload) and it puts macOS on equal
+// footing with systemd's `disable --now` (loader_linux.go) and the schtasks
+// delete (loader_windows.go), both of which already persisted. Load() above
+// re-enables, so the ordinary install/reconcile Unload;Load cycle is unaffected
+// — the disable only matters for a caller that stops WITHOUT a following Load,
+// i.e. `grafel stop`.
+//
+// Every launchctl invocation goes through launchctlRunner rather than a bare
+// exec.Command so this whole path is testable without booting out a real
+// watcher on the developer's own machine. Before this, only Load was seamed:
+// deleting the bootout outright left the suite green.
 func (darwinLoader) Unload(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
+	label := u.Label()
+
+	// Persist the stop first, so it holds even if bootout races or the process
+	// is already gone. disable is idempotent and independent of load state.
+	_, _ = launchctlRunner("disable", "gui/"+uid+"/"+label)
+
 	// launchctl list <label> exits non-zero when the label is not loaded; that
 	// is the locale-invariant signal that the desired absent state already holds.
-	if err := exec.Command("launchctl", "list", u.Label()).Run(); err != nil {
+	if _, err := launchctlRunner("list", label); err != nil {
 		return nil // not loaded — already gone
 	}
-	if out, err := exec.Command("launchctl", "bootout", "gui/"+uid+"/"+u.Label()).CombinedOutput(); err != nil {
+	if out, err := launchctlRunner("bootout", "gui/"+uid+"/"+label); err != nil {
 		// Race: the service was listed above but disappeared before bootout.
 		// Re-check via the exit code of `launchctl list`; if it is now gone,
 		// the desired state is reached. Never match the localized error text.
-		if lerr := exec.Command("launchctl", "list", u.Label()).Run(); lerr != nil {
+		if _, lerr := launchctlRunner("list", label); lerr != nil {
 			return nil // gone now — success-to-proceed
 		}
-		return fmt.Errorf("launchctl bootout %s: %w\n%s", u.Label(), err, out)
+		return fmt.Errorf("launchctl bootout %s: %w\n%s", label, err, out)
 	}
 	return nil
 }

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -23,6 +23,9 @@ func NewLoader() Loader { return darwinLoader{} }
 // and error. It is a package var so tests can inject a fake launchctl (e.g. to
 // simulate the flaky err-5 bootstrap) without shelling out.
 var launchctlRunner = func(args ...string) ([]byte, error) {
+	if serviceCallsAreStubbed() {
+		return nil, nil
+	}
 	guardServiceCall("launchctl", args)
 	return runBoundedServiceCmd("launchctl", args...)
 }
@@ -174,29 +177,44 @@ func (darwinLoader) Unload(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
 	label := u.Label()
 
-	// The not-loaded probe comes FIRST, and nothing mutating may precede it.
+	// ── The disable is gated on the PLIST, not on the job being loaded ───────
 	//
-	// `launchctl list <label>` exits non-zero when the label is not loaded —
-	// the locale-invariant signal that the desired absent state already holds.
-	// Returning here keeps Unload a genuine no-op for a label that was never
-	// loaded, which is what makes watchers.Cleanup safe to call from tests and
-	// from group-delete on machines that never activated a watcher.
+	// This gate has been wrong in both directions and the middle is the only
+	// correct place for it.
 	//
-	// The first cut of this fix put the `disable` above this probe, reasoning
-	// that a not-loaded job with a plist still needs suppressing. That is true
-	// in the abstract and wrong in practice: it made every unseamed test that
-	// touches Cleanup write real entries into the developer's launchd override
-	// database (see test_isolation_guard.go for the incident). It also buys
-	// nothing for `grafel stop`, whose entire purpose is stopping watchers that
-	// ARE loaded — a not-loaded job is not indexing. If a plist is on disk and
-	// unloaded, the next login loads it and the next stop disables it.
-	if _, err := launchctlRunner("list", label); err != nil {
-		return nil // not loaded — already gone, and nothing to persist
+	// Unconditional (round 1) was persistent but made Unload mutate real
+	// launchd state for a label that was never installed, so every unseamed
+	// test touching Cleanup wrote entries into the developer's override
+	// database (see test_isolation_guard.go).
+	//
+	// After the not-loaded probe (round 2) was clean but threw the guarantee
+	// away. `KeepAlive={SuccessfulExit:false}` (#6179) means any watcher that
+	// exits deliberately stays unloaded until next login, the daemon's reaper
+	// SIGTERMs foreign and duplicate watchers, and the flap detector stops
+	// others — so across 140 units some subset is unloaded at any instant.
+	// For those, stop issued no disable at all: the plist stayed on disk with
+	// RunAtLoad=true, launchd loaded it at the next login, and indexing
+	// resumed — under a message that had just promised "even across reboot".
+	// That is the original bug recurring in narrower form with a false
+	// assurance attached.
+	//
+	// Gating on the unit file is what both requirements actually want. A plist
+	// on disk is a thing that WILL run again, loaded or not, so it must be
+	// suppressed; a unit that was never installed has nothing to suppress and
+	// so touches nothing. Test hygiene no longer depends on this ordering
+	// either way — the structural guard and the newWatcherLoader seam fixes
+	// cover it, which is what makes restoring the guarantee safe.
+	if path, perr := UnitPath(u); perr == nil {
+		if _, serr := os.Stat(path); serr == nil {
+			_, _ = launchctlRunner("disable", "gui/"+uid+"/"+label)
+		}
 	}
 
-	// Persist the stop. See the comment above for why this is a disable and not
-	// just a bootout.
-	_, _ = launchctlRunner("disable", "gui/"+uid+"/"+label)
+	// `launchctl list <label>` exits non-zero when the label is not loaded —
+	// the locale-invariant signal that there is no running job to boot out.
+	if _, err := launchctlRunner("list", label); err != nil {
+		return nil // not loaded — nothing to boot out (already disabled above)
+	}
 
 	if out, err := launchctlRunner("bootout", "gui/"+uid+"/"+label); err != nil {
 		// Race: the service was listed above but disappeared before bootout.

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -3,6 +3,7 @@
 package watchers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -22,7 +23,44 @@ func NewLoader() Loader { return darwinLoader{} }
 // and error. It is a package var so tests can inject a fake launchctl (e.g. to
 // simulate the flaky err-5 bootstrap) without shelling out.
 var launchctlRunner = func(args ...string) ([]byte, error) {
-	return exec.Command("launchctl", args...).CombinedOutput()
+	guardServiceCall("launchctl", args)
+	return runBoundedServiceCmd("launchctl", args...)
+}
+
+// launchctlTimeout bounds a single launchctl invocation.
+//
+// `launchctl bootout` does not return until the job has actually exited, and
+// `grafel watch` installs a SIGTERM handler that drains in-flight work — so a
+// watcher caught mid-index can hold a bootout open. Unbounded, that turns a
+// fleet-wide `grafel stop` into a hang with no output, which is a worse failure
+// than the one being fixed. The daemon stop path already bounds itself
+// (stopConfirmTimeout); the fleet needs the same.
+//
+// Vars, not consts, so tests can shrink them.
+var (
+	launchctlTimeout = 15 * time.Second
+
+	// launchctlWaitDelay is the grace period AFTER the deadline fires and the
+	// child is signalled, before os/exec force-closes its I/O pipes.
+	//
+	// This is the load-bearing half, and it is not optional:
+	// exec.CommandContext's cancel kills only the DIRECT child, while
+	// CombinedOutput blocks until every writer to the pipe closes. launchctl
+	// can leave a grandchild holding that pipe, so a bare deadline does not
+	// unblock the read — measured elsewhere in this tree at 20.5s past a 1s
+	// deadline. WaitDelay caps it unconditionally. Precedent:
+	// internal/gitmeta/gitmeta.go waitDelayGrace (#5286).
+	launchctlWaitDelay = 3 * time.Second
+)
+
+// runBoundedServiceCmd runs a service-manager command under both a context
+// deadline and a WaitDelay, so it always returns.
+func runBoundedServiceCmd(tool string, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), launchctlTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, tool, args...)
+	cmd.WaitDelay = launchctlWaitDelay
+	return cmd.CombinedOutput()
 }
 
 // SetLaunchctlRunnerForTest swaps the launchctl command runner and returns a
@@ -136,15 +174,30 @@ func (darwinLoader) Unload(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
 	label := u.Label()
 
-	// Persist the stop first, so it holds even if bootout races or the process
-	// is already gone. disable is idempotent and independent of load state.
+	// The not-loaded probe comes FIRST, and nothing mutating may precede it.
+	//
+	// `launchctl list <label>` exits non-zero when the label is not loaded —
+	// the locale-invariant signal that the desired absent state already holds.
+	// Returning here keeps Unload a genuine no-op for a label that was never
+	// loaded, which is what makes watchers.Cleanup safe to call from tests and
+	// from group-delete on machines that never activated a watcher.
+	//
+	// The first cut of this fix put the `disable` above this probe, reasoning
+	// that a not-loaded job with a plist still needs suppressing. That is true
+	// in the abstract and wrong in practice: it made every unseamed test that
+	// touches Cleanup write real entries into the developer's launchd override
+	// database (see test_isolation_guard.go for the incident). It also buys
+	// nothing for `grafel stop`, whose entire purpose is stopping watchers that
+	// ARE loaded — a not-loaded job is not indexing. If a plist is on disk and
+	// unloaded, the next login loads it and the next stop disables it.
+	if _, err := launchctlRunner("list", label); err != nil {
+		return nil // not loaded — already gone, and nothing to persist
+	}
+
+	// Persist the stop. See the comment above for why this is a disable and not
+	// just a bootout.
 	_, _ = launchctlRunner("disable", "gui/"+uid+"/"+label)
 
-	// launchctl list <label> exits non-zero when the label is not loaded; that
-	// is the locale-invariant signal that the desired absent state already holds.
-	if _, err := launchctlRunner("list", label); err != nil {
-		return nil // not loaded — already gone
-	}
 	if out, err := launchctlRunner("bootout", "gui/"+uid+"/"+label); err != nil {
 		// Race: the service was listed above but disappeared before bootout.
 		// Re-check via the exit code of `launchctl list`; if it is now gone,
@@ -171,7 +224,11 @@ func (darwinLoader) Status(u Unit) (WatcherStatus, error) {
 	}
 
 	// launchctl list <label> prints: <pid | -> <exit> <label>
-	out, err := exec.Command("launchctl", "list", u.Label()).Output()
+	// Routed through launchctlRunner like every other invocation, so the status
+	// path is seamed and bounded too — `grafel status` is now the surface a
+	// user checks to confirm a stop worked, and it must not be the one call
+	// that can hang or that no test can observe.
+	out, err := launchctlRunner("list", u.Label())
 	if err != nil {
 		return ws, nil // not loaded — not running
 	}

--- a/internal/install/watchers/loader_darwin.go
+++ b/internal/install/watchers/loader_darwin.go
@@ -26,7 +26,9 @@ var launchctlRunner = func(args ...string) ([]byte, error) {
 	if serviceCallsAreStubbed() {
 		return nil, nil
 	}
-	guardServiceCall("launchctl", args)
+	if err := guardServiceCall("launchctl", args); err != nil {
+		return nil, err
+	}
 	return runBoundedServiceCmd("launchctl", args...)
 }
 
@@ -169,10 +171,10 @@ func (darwinLoader) Load(u Unit) error {
 // — the disable only matters for a caller that stops WITHOUT a following Load,
 // i.e. `grafel stop`.
 //
-// Every launchctl invocation goes through launchctlRunner rather than a bare
-// exec.Command so this whole path is testable without booting out a real
-// watcher on the developer's own machine. Before this, only Load was seamed:
-// deleting the bootout outright left the suite green.
+// Every launchctl invocation in this file goes through launchctlRunner rather
+// than a bare exec.Command, so the whole path — Load, Unload AND Status — is
+// both testable and guarded without booting out a real watcher on the
+// developer's own machine.
 func (darwinLoader) Unload(u Unit) error {
 	uid := strconv.Itoa(os.Getuid())
 	label := u.Label()

--- a/internal/install/watchers/loader_darwin_persist2_test.go
+++ b/internal/install/watchers/loader_darwin_persist2_test.go
@@ -1,0 +1,83 @@
+//go:build darwin
+
+package watchers
+
+// loader_darwin_persist2_test.go pins the property round 2 broke.
+//
+// Round 1 put `launchctl disable` first, unconditionally — persistent, but it
+// made Unload mutate real launchd state for a label that was never loaded.
+// Round 2 fixed that by moving the disable AFTER the not-loaded early return,
+// which threw away the persistence guarantee for any unit that happens to be
+// unloaded at the moment `grafel stop` runs. With KeepAlive={SuccessfulExit:
+// false} (#6179) that is a live subset at any instant across 140 units: the
+// plist stays on disk with RunAtLoad=true, loads at the next login, and starts
+// indexing — while stop said "even across reboot".
+//
+// The correct gate is neither "always" nor "only when loaded" but "whenever
+// there is a plist on disk to suppress". That keeps the guarantee AND keeps a
+// never-installed unit from touching launchd at all.
+
+import (
+	"os"
+	"strconv"
+	"testing"
+)
+
+// TestUnload_DisablesWhenPlistExistsButJobIsNotLoaded is the regression test
+// for the round-2 blocker.
+func TestUnload_DisablesWhenPlistExistsButJobIsNotLoaded(t *testing.T) {
+	u := testUnit(t)
+	if _, err := Write(u); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	var calls [][]string
+	orig := launchctlRunner
+	launchctlRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "list" {
+			return nil, os.ErrNotExist // job NOT currently loaded
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { launchctlRunner = orig })
+
+	if err := (darwinLoader{}).Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	target := "gui/" + strconv.Itoa(os.Getuid()) + "/" + u.Label()
+	if !hasArgv(calls, []string{"disable", target}) {
+		t.Fatalf("a plist on disk must be disabled even when the job is not loaded, "+
+			"or it comes back at next login; calls=%v", calls)
+	}
+}
+
+// TestUnload_NoPlistNoMutation keeps the test-hygiene property that motivated
+// the round-2 reordering: a unit that was never installed must not touch
+// launchd at all.
+func TestUnload_NoPlistNoMutation(t *testing.T) {
+	u := testUnit(t) // no Write — nothing on disk
+
+	var calls [][]string
+	orig := launchctlRunner
+	launchctlRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "list" {
+			// Never installed implies never loaded. (A job that IS loaded with
+			// no plist on disk still gets booted out — that is correct, and is
+			// covered by TestUnload_DisablesWithExactTarget.)
+			return nil, os.ErrNotExist
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { launchctlRunner = orig })
+
+	if err := (darwinLoader{}).Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	for _, c := range calls {
+		if len(c) > 0 && !readOnlyServiceVerbs[c[0]] {
+			t.Fatalf("Unload of a never-installed unit must issue no mutating call, got %v", c)
+		}
+	}
+}

--- a/internal/install/watchers/loader_darwin_persist_test.go
+++ b/internal/install/watchers/loader_darwin_persist_test.go
@@ -1,0 +1,234 @@
+//go:build darwin
+
+package watchers
+
+// loader_darwin_persist_test.go covers the persistent-stop pairing
+// (bootout + `launchctl disable`, and the matching `enable` on Load) and the
+// two hazards an adversarial review found in the first cut:
+//
+//   - `disable` ran BEFORE the not-loaded early return, so Unload was no
+//     longer a no-op for a label that was never loaded. Every test calling
+//     watchers.Cleanup without a launchctl seam therefore wrote real entries
+//     into the developer's launchd disabled database (gui/<uid> is a system
+//     database; redirecting $HOME does not sandbox it).
+//   - the assertions matched substrings over a joined blob. "enable" is a
+//     SUBSTRING of "disable", so an ordering assertion built on strings.Index
+//     silently inverts the moment Load also issues a disable, and a call with
+//     the wrong uid or a malformed target would pass. Every assertion below is
+//     on the exact argv slice.
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"testing"
+)
+
+// recordLaunchctl installs a fake launchctl that records exact argv slices.
+func recordLaunchctl(t *testing.T) *[][]string {
+	t.Helper()
+	var calls [][]string
+	orig := launchctlRunner
+	launchctlRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return nil, nil
+	}
+	t.Cleanup(func() { launchctlRunner = orig })
+	return &calls
+}
+
+func hasArgv(calls [][]string, want []string) bool {
+	for _, c := range calls {
+		if reflect.DeepEqual(c, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func argvIndex(calls [][]string, verb string) int {
+	for i, c := range calls {
+		if len(c) > 0 && c[0] == verb {
+			return i
+		}
+	}
+	return -1
+}
+
+func testUnit(t *testing.T) Unit {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return Unit{Group: "demo", Repo: filepath.Join(home, "core"), BinPath: "/bin/grafel"}
+}
+
+// TestUnload_DisablesWithExactTarget: the disable must name gui/<uid>/<label>
+// exactly. A wrong uid or a malformed target silently does nothing.
+func TestUnload_DisablesWithExactTarget(t *testing.T) {
+	u := testUnit(t)
+	if _, err := Write(u); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	calls := recordLaunchctl(t)
+	// A loaded job: `launchctl list <label>` succeeds (our fake returns nil).
+	if err := (darwinLoader{}).Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	uid := strconv.Itoa(os.Getuid())
+	target := "gui/" + uid + "/" + u.Label()
+	if !hasArgv(*calls, []string{"disable", target}) {
+		t.Fatalf("no exact `launchctl disable %s`; calls=%v", target, *calls)
+	}
+	if !hasArgv(*calls, []string{"bootout", target}) {
+		t.Fatalf("no exact `launchctl bootout %s`; calls=%v", target, *calls)
+	}
+}
+
+// TestUnload_IsNoOpWhenNotLoaded is the merge blocker: a label that is not
+// loaded must produce NO mutating launchctl call at all. Otherwise every test
+// in the tree that calls Cleanup writes into the real launchd database.
+func TestUnload_IsNoOpWhenNotLoaded(t *testing.T) {
+	u := testUnit(t)
+	var calls [][]string
+	orig := launchctlRunner
+	launchctlRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		if len(args) > 0 && args[0] == "list" {
+			return nil, os.ErrNotExist // not loaded
+		}
+		return nil, nil
+	}
+	t.Cleanup(func() { launchctlRunner = orig })
+
+	if err := (darwinLoader{}).Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	for _, c := range calls {
+		if len(c) > 0 && c[0] != "list" {
+			t.Fatalf("Unload of a not-loaded label must issue no mutating launchctl call, got %v (all: %v)", c, calls)
+		}
+	}
+}
+
+// TestLoad_EnablesBeforeBootstrap: without the enable, RunAtLoad silently does
+// nothing on a job a previous `grafel stop` disabled. Ordering is asserted on
+// argv positions, not on substring offsets.
+func TestLoad_EnablesBeforeBootstrap(t *testing.T) {
+	u := testUnit(t)
+	if _, err := Write(u); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	calls := recordLaunchctl(t)
+	if err := (darwinLoader{}).Load(u); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	uid := strconv.Itoa(os.Getuid())
+	if !hasArgv(*calls, []string{"enable", "gui/" + uid + "/" + u.Label()}) {
+		t.Fatalf("Load issued no exact `launchctl enable`; calls=%v", *calls)
+	}
+	ei := argvIndex(*calls, "enable")
+	bi := argvIndex(*calls, "bootstrap")
+	if bi < 0 || ei > bi {
+		t.Fatalf("enable must precede bootstrap; calls=%v", *calls)
+	}
+}
+
+// TestStatus_GoesThroughTheSeam: the review found `launchctl list` in Status
+// was still a bare exec.Command, so the "every launchctl invocation goes
+// through launchctlRunner" claim was false and the status path was untestable.
+func TestStatus_GoesThroughTheSeam(t *testing.T) {
+	u := testUnit(t)
+	if _, err := Write(u); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	var calls [][]string
+	orig := launchctlRunner
+	launchctlRunner = func(args ...string) ([]byte, error) {
+		calls = append(calls, append([]string(nil), args...))
+		return []byte("4242\t0\t" + u.Label()), nil
+	}
+	t.Cleanup(func() { launchctlRunner = orig })
+
+	st, err := (darwinLoader{}).Status(u)
+	if err != nil {
+		t.Fatalf("Status: %v", err)
+	}
+	if !hasArgv(calls, []string{"list", u.Label()}) {
+		t.Fatalf("Status did not go through launchctlRunner; calls=%v", calls)
+	}
+	if !st.Running || st.PID != 4242 {
+		t.Fatalf("Status = %+v, want Running with pid 4242", st)
+	}
+}
+
+// TestInstalledUnits_ReadsFromDisk: the fleet sweep must be able to see units
+// the registry cannot — orphans left by a partially-failed Cleanup, a dropped
+// group, or a slug-derivation change.
+func TestInstalledUnits_ReadsFromDisk(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	dir, err := UnitDir()
+	if err != nil {
+		t.Fatalf("UnitDir: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, name := range []string{
+		"com.grafel.watcher.demo.core.plist",
+		"com.grafel.watcher.gone.orphan.plist",
+		"com.example.other.plist", // must be ignored
+		"notaplist.txt",           // must be ignored
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	units, err := InstalledUnits()
+	if err != nil {
+		t.Fatalf("InstalledUnits: %v", err)
+	}
+	got := map[string]bool{}
+	for _, u := range units {
+		got[u.Label()] = true
+	}
+	if len(got) != 2 || !got["com.grafel.watcher.demo.core"] || !got["com.grafel.watcher.gone.orphan"] {
+		t.Fatalf("InstalledUnits = %v, want exactly the two com.grafel.watcher.* labels", got)
+	}
+}
+
+// TestInstalledUnits_MissingDirIsEmpty: no units installed is not an error.
+func TestInstalledUnits_MissingDirIsEmpty(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	units, err := InstalledUnits()
+	if err != nil {
+		t.Fatalf("InstalledUnits: %v", err)
+	}
+	if len(units) != 0 {
+		t.Fatalf("want no units, got %v", units)
+	}
+}
+
+// TestRawLabelRoundTrips: a unit discovered by label alone must address the
+// same launchd job and the same file as the derived one, or the disk-glob
+// sweep would boot out the wrong thing.
+func TestRawLabelRoundTrips(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	derived := Unit{Group: "demo", Repo: "/tmp/core", BinPath: "/bin/grafel"}
+	raw := Unit{RawLabel: derived.Label()}
+	if raw.Label() != derived.Label() {
+		t.Fatalf("label mismatch: %q vs %q", raw.Label(), derived.Label())
+	}
+	dp, err := UnitPath(derived)
+	if err != nil {
+		t.Fatalf("UnitPath derived: %v", err)
+	}
+	rp, err := UnitPath(raw)
+	if err != nil {
+		t.Fatalf("UnitPath raw: %v", err)
+	}
+	if dp != rp {
+		t.Fatalf("path mismatch: %q vs %q", dp, rp)
+	}
+}

--- a/internal/install/watchers/loader_linux.go
+++ b/internal/install/watchers/loader_linux.go
@@ -24,6 +24,9 @@ import (
 // WaitDelay is the load-bearing half — CommandContext's kill reaches only the
 // direct child while CombinedOutput waits on every pipe writer.
 var systemctlRunner = func(args ...string) ([]byte, error) {
+	if serviceCallsAreStubbed() {
+		return nil, nil
+	}
 	guardServiceCall("systemctl", args)
 	ctx, cancel := context.WithTimeout(context.Background(), systemctlTimeout)
 	defer cancel()

--- a/internal/install/watchers/loader_linux.go
+++ b/internal/install/watchers/loader_linux.go
@@ -3,9 +3,38 @@
 package watchers
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
+	"time"
+)
+
+// systemctlRunner runs `systemctl <args...>` bounded by both a deadline and a
+// WaitDelay, and returns its combined output.
+//
+// It is a package var for the same two reasons the darwin loader has one: tests
+// must be able to observe the call without mutating the developer's real
+// systemd user session, and the guard in test_isolation_guard.go must be able
+// to catch any that slip through unseamed.
+//
+// The bound matters as much here as on macOS: `systemctl --user disable --now`
+// blocks on the unit actually stopping, and `grafel watch` drains on SIGTERM,
+// so a fleet-wide stop across 140 units could otherwise hang indefinitely.
+// WaitDelay is the load-bearing half — CommandContext's kill reaches only the
+// direct child while CombinedOutput waits on every pipe writer.
+var systemctlRunner = func(args ...string) ([]byte, error) {
+	guardServiceCall("systemctl", args)
+	ctx, cancel := context.WithTimeout(context.Background(), systemctlTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "systemctl", args...)
+	cmd.WaitDelay = systemctlWaitDelay
+	return cmd.CombinedOutput()
+}
+
+var (
+	systemctlTimeout   = 15 * time.Second
+	systemctlWaitDelay = 3 * time.Second
 )
 
 // linuxLoader implements Loader using systemctl --user for Linux systemd units.
@@ -27,12 +56,12 @@ func (linuxLoader) Load(u Unit) error {
 	}
 
 	// Reload the unit manager so it picks up the new file.
-	if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+	if out, err := systemctlRunner("--user", "daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl --user daemon-reload: %w\n%s", err, out)
 	}
 
 	// Enable + start atomically.
-	out, err := exec.Command("systemctl", "--user", "enable", "--now", u.Label()+".service").CombinedOutput()
+	out, err := systemctlRunner("--user", "enable", "--now", u.Label()+".service")
 	if err != nil {
 		return fmt.Errorf("systemctl --user enable --now %s: %w\n%s", u.Label(), err, out)
 	}
@@ -55,7 +84,7 @@ func (linuxLoader) Unload(u Unit) error {
 		return nil // no unit file — already gone
 	}
 	// --now stops the unit in addition to disabling it.
-	out, derr := exec.Command("systemctl", "--user", "disable", "--now", u.Label()+".service").CombinedOutput()
+	out, derr := systemctlRunner("--user", "disable", "--now", u.Label()+".service")
 	if derr != nil {
 		// Race: the unit file vanished between the stat above and disable.
 		// Re-stat; if it is gone now, the desired absent state is reached.
@@ -82,7 +111,7 @@ func (linuxLoader) Status(u Unit) (WatcherStatus, error) {
 	}
 
 	// is-active exits 0 when the unit is active.
-	if err := exec.Command("systemctl", "--user", "is-active", "--quiet", u.Label()+".service").Run(); err == nil {
+	if _, err := systemctlRunner("--user", "is-active", "--quiet", u.Label()+".service"); err == nil {
 		ws.Running = true
 	}
 	return ws, nil

--- a/internal/install/watchers/loader_linux.go
+++ b/internal/install/watchers/loader_linux.go
@@ -27,7 +27,9 @@ var systemctlRunner = func(args ...string) ([]byte, error) {
 	if serviceCallsAreStubbed() {
 		return nil, nil
 	}
-	guardServiceCall("systemctl", args)
+	if err := guardServiceCall("systemctl", args); err != nil {
+		return nil, err
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), systemctlTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "systemctl", args...)

--- a/internal/install/watchers/loader_windows.go
+++ b/internal/install/watchers/loader_windows.go
@@ -3,12 +3,14 @@
 package watchers
 
 import (
+	"context"
 	"encoding/csv"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cajasmota/grafel/internal/executil"
 )
@@ -18,11 +20,46 @@ type windowsLoader struct{}
 
 // schtasksCmd returns an exec.Cmd for schtasks.exe with CREATE_NO_WINDOW set
 // so that the subprocess never flashes a visible console window.
+//
+// It is bounded by a deadline AND a WaitDelay for the same reason the launchctl
+// and systemctl runners are: `schtasks /end` waits on the task actually
+// stopping and `grafel watch` drains on shutdown, so an unbounded call turns a
+// 140-unit fleet stop into a hang. CommandContext's kill reaches only the
+// direct child while CombinedOutput waits on every pipe writer, so the
+// WaitDelay is the half that actually guarantees a return.
+//
+// It also routes through guardServiceCall. Before this, Windows was the one
+// platform with no guard at all — while test_isolation_guard.go listed
+// /create, /delete, /run, /end and /change in its verb table with nothing ever
+// calling it for schtasks. Those entries were dead and actively misleading: a
+// reader concluded Windows was covered, and on a Windows dev box
+// `go test ./internal/install/watchers/` really did run `schtasks /create` and
+// `/delete` against the developer's Task Scheduler. Same incident, one platform
+// behind.
 func schtasksCmd(args ...string) *exec.Cmd {
-	cmd := exec.Command("schtasks", args...)
+	if serviceCallsAreStubbed() {
+		// A command that always succeeds and prints nothing, so Run/Output/
+		// CombinedOutput all behave like a benign schtasks call.
+		return exec.Command("cmd", "/c", "exit", "0")
+	}
+	guardServiceCall("schtasks", args)
+	ctx, cancel := context.WithTimeout(context.Background(), schtasksTimeout)
+	cmd := exec.CommandContext(ctx, "schtasks", args...)
+	cmd.WaitDelay = schtasksWaitDelay
+	// The context must outlive this function; Cancel runs on Wait, and the
+	// deadline goroutine is released when the process exits.
+	cmd.Cancel = func() error {
+		defer cancel()
+		return cmd.Process.Kill()
+	}
 	executil.NoWindow(cmd)
 	return cmd
 }
+
+var (
+	schtasksTimeout   = 15 * time.Second
+	schtasksWaitDelay = 3 * time.Second
+)
 
 // NewLoader returns the Windows schtasks-based Loader.
 func NewLoader() Loader { return windowsLoader{} }

--- a/internal/install/watchers/loader_windows.go
+++ b/internal/install/watchers/loader_windows.go
@@ -42,7 +42,13 @@ func schtasksCmd(args ...string) *exec.Cmd {
 		// CombinedOutput all behave like a benign schtasks call.
 		return exec.Command("cmd", "/c", "exit", "0")
 	}
-	guardServiceCall("schtasks", args)
+	if err := guardServiceCall("schtasks", args); err != nil {
+		// schtasksCmd returns a *exec.Cmd and cannot surface an error directly.
+		// A command that exits non-zero is the faithful equivalent: every call
+		// site treats a failing schtasks as "did not happen", which is exactly
+		// what the guard is asserting.
+		return exec.Command("cmd", "/c", "exit", "1")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), schtasksTimeout)
 	cmd := exec.CommandContext(ctx, "schtasks", args...)
 	cmd.WaitDelay = schtasksWaitDelay

--- a/internal/install/watchers/stub_6183_darwin_test.go
+++ b/internal/install/watchers/stub_6183_darwin_test.go
@@ -2,12 +2,16 @@ package watchers
 
 import "testing"
 
-// stubLaunchctl replaces the launchctl runner for the duration of a test. No
-// test in this package may mutate the developer's real launchd session.
+// stubLaunchctl neutralises service-manager calls for the duration of a test.
+// No test in this package may mutate the developer's real launchd session.
+//
+// It delegates to StubServiceCallsForTest rather than swapping launchctlRunner
+// directly (#6183 landed the latter; the fleet-stop work landed the former).
+// Two mechanisms for one property is how one of them ends up not covering a
+// path: StubServiceCallsForTest is the cross-platform one and it short-circuits
+// systemctl and schtasks too, so it is the single mechanism both now use. The
+// name is kept so #6183's call sites read unchanged.
 func stubLaunchctl(t *testing.T) {
 	t.Helper()
-	restore := SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
-		return nil, nil
-	})
-	t.Cleanup(restore)
+	t.Cleanup(StubServiceCallsForTest())
 }

--- a/internal/install/watchers/stub_6183_other_test.go
+++ b/internal/install/watchers/stub_6183_other_test.go
@@ -4,5 +4,14 @@ package watchers
 
 import "testing"
 
-// stubLaunchctl is a no-op off macOS; there is no launchctl to stub.
-func stubLaunchctl(t *testing.T) { t.Helper() }
+// stubLaunchctl neutralises service-manager calls off macOS too.
+//
+// It used to be a no-op on the reasoning that "there is no launchctl to stub".
+// That was true of launchctl and false of the property: on Linux the loader
+// shells out to `systemctl --user disable --now`, and on Windows to
+// `schtasks /delete`, both of which mutate the developer's real session.
+// StubServiceCallsForTest covers all three.
+func stubLaunchctl(t *testing.T) {
+	t.Helper()
+	t.Cleanup(StubServiceCallsForTest())
+}

--- a/internal/install/watchers/test_isolation_guard.go
+++ b/internal/install/watchers/test_isolation_guard.go
@@ -64,7 +64,21 @@ const NoServiceMutationEnv = "GRAFEL_NO_SERVICE_MUTATION"
 // should be refused: under `go test`, or whenever a parent test process has
 // exported NoServiceMutationEnv into this one.
 func serviceMutationGuardActive() bool {
-	return testing.Testing() || os.Getenv(NoServiceMutationEnv) == "1"
+	return guardActiveFor(testing.Testing(), os.Getenv(NoServiceMutationEnv))
+}
+
+// guardActiveFor is the decision, split out from its two inputs so the env
+// belt is observable on its own.
+//
+// Testing serviceMutationGuardActive directly cannot distinguish the belt from
+// testing.Testing(): under `go test` the latter is always true, so the belt
+// contributes nothing an assertion can see and a mutant deleting it survives
+// (it did, in the first cut). The belt exists precisely for the case
+// testing.Testing() is FALSE — a `go build` binary that a harness execs —
+// which a test in this package can never itself be in. Passing both inputs
+// explicitly is the only way to pin it.
+func guardActiveFor(underGoTest bool, envValue string) bool {
+	return underGoTest || envValue == "1"
 }
 
 // readOnlyServiceVerbs is an ALLOWLIST of sub-commands known not to change

--- a/internal/install/watchers/test_isolation_guard.go
+++ b/internal/install/watchers/test_isolation_guard.go
@@ -1,0 +1,86 @@
+package watchers
+
+// test_isolation_guard.go — fail-closed guard against a test mutating the
+// developer's real OS service manager.
+//
+// ── The incident this exists for ─────────────────────────────────────────────
+//
+// The first cut of the persistent-stop fix put `launchctl disable` as the FIRST
+// statement of darwinLoader.Unload, ahead of the read-only `launchctl list`
+// guard that had made Unload a no-op for a label that was never loaded.
+// cleanup_test.go calls watchers.Cleanup with no launchctl seam — it redirects
+// $HOME, which is irrelevant, because `disable` targets `gui/<uid>/<label>`, a
+// SYSTEM database that no environment variable sandboxes. Running
+// `go test ./internal/install/...` therefore wrote
+//
+//	com.grafel.watcher.demo.core  => disabled
+//	com.grafel.watcher.demo.never => disabled
+//
+// into the developer's launchd override database, permanently, with no cleanup.
+// Those labels exist nowhere but two test fixtures. Had a real user's group
+// been named `demo` with a repo basename `core` — entirely plausible — the test
+// suite would have silently and persistently disabled their live watcher.
+//
+// ── Why a guard and not just a fixed ordering ────────────────────────────────
+//
+// The ordering IS fixed (see loader_darwin.go: disable now runs only after the
+// not-loaded early return). But that fix is one line away from being undone by
+// anyone who does not know why the line is where it is, and the failure is
+// SILENT — the suite stays green while the damage accrues on the developer's
+// machine. So the invariant is enforced structurally instead: under `go test`,
+// any MUTATING service-manager verb that reaches a real exec is a panic.
+// Read-only verbs (list/print) are allowed through: they are common, harmless,
+// and several tests legitimately probe them.
+//
+// A test that genuinely needs to exercise a mutating path installs a fake
+// runner (SetLaunchctlRunnerForTest / the launchctlRunner var), which never
+// reaches this guard. It is inert in the shipping binary — testing.Testing() is
+// false there — so production behaviour is untouched.
+
+import (
+	"fmt"
+	"testing"
+)
+
+// mutatingServiceVerbs are the sub-commands that change OS service-manager
+// state. Anything not listed is treated as read-only and allowed.
+var mutatingServiceVerbs = map[string]bool{
+	// launchctl
+	"disable":   true,
+	"enable":    true,
+	"bootout":   true,
+	"bootstrap": true,
+	"load":      true,
+	"unload":    true,
+	"kickstart": true,
+	"remove":    true,
+	"stop":      true,
+	"start":     true,
+	// systemctl (verb is args[1] there; guardServiceCall checks every arg)
+	"daemon-reload": true,
+	// schtasks
+	"/create": true,
+	"/delete": true,
+	"/run":    true,
+	"/end":    true,
+	"/change": true,
+}
+
+// guardServiceCall panics if, while running under `go test`, a MUTATING
+// service-manager command is about to be executed for real. See the file
+// comment for the incident this prevents.
+func guardServiceCall(tool string, args []string) {
+	if !testing.Testing() {
+		return
+	}
+	for _, a := range args {
+		if mutatingServiceVerbs[a] {
+			panic(fmt.Sprintf(
+				"watchers: test attempted a REAL mutating service-manager call: %s %v\n"+
+					"This would change the developer's actual launchd/systemd state, which no\n"+
+					"environment variable sandboxes (gui/<uid>/<label> is a system database).\n"+
+					"Install a fake runner (watchers.SetLaunchctlRunnerForTest) in this test.",
+				tool, args))
+		}
+	}
+}

--- a/internal/install/watchers/test_isolation_guard.go
+++ b/internal/install/watchers/test_isolation_guard.go
@@ -39,48 +39,147 @@ package watchers
 
 import (
 	"fmt"
+	"os"
+	"strings"
+	"sync/atomic"
 	"testing"
 )
 
-// mutatingServiceVerbs are the sub-commands that change OS service-manager
-// state. Anything not listed is treated as read-only and allowed.
-var mutatingServiceVerbs = map[string]bool{
-	// launchctl
-	"disable":   true,
-	"enable":    true,
-	"bootout":   true,
-	"bootstrap": true,
-	"load":      true,
-	"unload":    true,
-	"kickstart": true,
-	"remove":    true,
-	"stop":      true,
-	"start":     true,
-	// systemctl (verb is args[1] there; guardServiceCall checks every arg)
-	"daemon-reload": true,
-	// schtasks
-	"/create": true,
-	"/delete": true,
-	"/run":    true,
-	"/end":    true,
-	"/change": true,
+// NoServiceMutationEnv activates the guard in a process where
+// testing.Testing() is false.
+//
+// That gap is real and cannot be closed from here: testing.Testing() reads a
+// flag the linker sets for a test binary, so it is false in anything produced
+// by `go build` — and internal/verify/harness_test.go,
+// internal/cli/patterns_test.go and internal/daemon/selfdefense_test.go all
+// build ./cmd/grafel and exec it. Today those harnesses only run
+// `grafel daemon`, which touches no service manager. The moment one of them
+// runs `grafel stop`, `install` or `update`, the guard is bypassed completely
+// and silently, and the incident this file exists for happens again through a
+// door the file cannot see. Every build-and-run harness therefore exports this
+// variable to the child.
+const NoServiceMutationEnv = "GRAFEL_NO_SERVICE_MUTATION"
+
+// serviceMutationGuardActive reports whether mutating service-manager calls
+// should be refused: under `go test`, or whenever a parent test process has
+// exported NoServiceMutationEnv into this one.
+func serviceMutationGuardActive() bool {
+	return testing.Testing() || os.Getenv(NoServiceMutationEnv) == "1"
 }
 
-// guardServiceCall panics if, while running under `go test`, a MUTATING
-// service-manager command is about to be executed for real. See the file
-// comment for the incident this prevents.
+// readOnlyServiceVerbs is an ALLOWLIST of sub-commands known not to change
+// service-manager state. Everything else is refused.
+//
+// The first cut was the inverse — a denylist of known-mutating verbs, with
+// "anything not listed is treated as read-only and allowed" — which is
+// fail-OPEN however it is described. It was complete for the verbs this
+// package happens to use and silently permissive for every other one:
+// `launchctl submit`, `setenv`, `kill` and `config` all mutate and were all
+// absent. An allowlist fails the right way: a verb nobody has classified is
+// refused, and adding a read-only one is a deliberate, reviewable act.
+var readOnlyServiceVerbs = map[string]bool{
+	// launchctl
+	"list":           true,
+	"print":          true,
+	"print-disabled": true,
+	"procinfo":       true,
+	"examine":        true,
+	"blame":          true,
+	"managername":    true,
+	"manageruid":     true,
+	"managerpid":     true,
+	// systemctl
+	"is-active":  true,
+	"is-enabled": true,
+	"is-failed":  true,
+	"status":     true,
+	"show":       true,
+	"cat":        true,
+	"list-units": true,
+	// schtasks
+	"/query": true,
+}
+
+// serviceVerb extracts the sub-command from a service-manager argv.
+//
+// The check has to be on the VERB, not on every argument: systemctl is invoked
+// as `--user is-active --quiet <unit>` and schtasks as `/query /tn <name>`, so
+// testing each argument would treat flags, unit names and file paths as
+// unrecognised verbs and refuse everything. schtasks verbs are `/`-prefixed and
+// come first; for the others the verb is the first non-flag argument.
+func serviceVerb(args []string) string {
+	for _, a := range args {
+		if strings.HasPrefix(a, "/") {
+			return a // schtasks: /query, /create, /delete, …
+		}
+		if strings.HasPrefix(a, "-") {
+			continue // a flag (--user, --quiet, -k …)
+		}
+		return a
+	}
+	return ""
+}
+
+// guardServiceCall panics if, while running under `go test` (or with the env
+// belt set), a command that is not a known read-only probe is about to be
+// executed for real against the OS service manager. See the file comment for
+// the incident this prevents.
 func guardServiceCall(tool string, args []string) {
-	if !testing.Testing() {
+	if !serviceMutationGuardActive() {
 		return
 	}
-	for _, a := range args {
-		if mutatingServiceVerbs[a] {
-			panic(fmt.Sprintf(
-				"watchers: test attempted a REAL mutating service-manager call: %s %v\n"+
-					"This would change the developer's actual launchd/systemd state, which no\n"+
-					"environment variable sandboxes (gui/<uid>/<label> is a system database).\n"+
-					"Install a fake runner (watchers.SetLaunchctlRunnerForTest) in this test.",
-				tool, args))
-		}
+	verb := serviceVerb(args)
+	if readOnlyServiceVerbs[verb] {
+		return
 	}
+	panic(fmt.Sprintf(
+		"watchers: test attempted a REAL service-manager call that is not a known "+
+			"read-only probe: %s %v\n"+
+			"This can change the developer's actual launchd/systemd/Task Scheduler state,\n"+
+			"which no environment variable sandboxes (gui/<uid>/<label> is a system\n"+
+			"database). Install a fake runner (watchers.SetLaunchctlRunnerForTest, or the\n"+
+			"systemctlRunner / schtasksRunner vars) in this test. If %q really is read-only,\n"+
+			"add it to readOnlyServiceVerbs deliberately.",
+		tool, args, verb))
 }
+
+// serviceCallsStubbed, when true, turns every service-manager invocation in
+// this package into a success-returning no-op.
+//
+// It exists because the seam has to be CROSS-PLATFORM. The per-platform runner
+// vars (launchctlRunner, systemctlRunner) are build-tagged and Windows drives
+// schtasks through an *exec.Cmd rather than a runner func, so a test that is
+// itself cross-platform — cleanup_test.go is the one that started all of this —
+// has no single seam to reach for. Without one, such a test either invokes the
+// developer's real service manager or trips the guard, and the only remaining
+// option is to delete the coverage.
+var serviceCallsStubbed atomic.Bool
+
+// StubServiceCallsForTest makes every launchctl/systemctl/schtasks invocation
+// in this package a no-op that reports success, and returns a restore func.
+// Test-only; production code never sets it.
+func StubServiceCallsForTest() (restore func()) {
+	prev := serviceCallsStubbed.Swap(true)
+	return func() { serviceCallsStubbed.Store(prev) }
+}
+
+// serviceCallsAreStubbed reports whether runners should short-circuit.
+func serviceCallsAreStubbed() bool { return serviceCallsStubbed.Load() }
+
+// GuardServiceCall is the exported form of the guard, for other packages that
+// shell out to a service manager.
+//
+// internal/daemon/service does exactly that, and against a HIGHER-value target
+// than the watcher fleet: `com.grafel.daemon` is the label serving the user's
+// live MCP session, so a test that reaches its bootout does not disable a
+// watcher, it kills the running daemon. Those call sites are package vars
+// (seamed) but were never guarded, which is the same "declared a seam, then
+// did not use it" shape that let install.go drive real launchctl calls.
+//
+// A note on why a PATH-shim measurement is not a substitute for this: a shim
+// that makes `launchctl list` exit non-zero causes every Unload to
+// short-circuit before its bootout, so "zero mutating verbs observed" proves
+// only that the path was not reached under that launchd state — not that it
+// cannot be. Guarding the call site is what makes the property hold regardless
+// of what happens to be loaded.
+func GuardServiceCall(tool string, args []string) { guardServiceCall(tool, args) }

--- a/internal/install/watchers/test_isolation_guard.go
+++ b/internal/install/watchers/test_isolation_guard.go
@@ -23,12 +23,16 @@ package watchers
 //
 // ── Why a guard and not just a fixed ordering ────────────────────────────────
 //
-// The ordering IS fixed (see loader_darwin.go: disable now runs only after the
-// not-loaded early return). But that fix is one line away from being undone by
-// anyone who does not know why the line is where it is, and the failure is
+// The ordering was then "fixed" by moving the disable AFTER the not-loaded
+// probe — which silently dropped the persistence guarantee for any unit that
+// happened to be unloaded, and had to be reversed again. It now gates on the
+// PLIST existing (see loader_darwin.go), which satisfies both requirements at
+// once. That two-round detour is the argument for this file: an ordering
+// constraint held in place by a comment is one line from being undone by
+// someone who does not know why the line is where it is, and the failure is
 // SILENT — the suite stays green while the damage accrues on the developer's
-// machine. So the invariant is enforced structurally instead: under `go test`,
-// any MUTATING service-manager verb that reaches a real exec is a panic.
+// machine. So the invariant is enforced structurally instead: any MUTATING
+// service-manager verb that reaches a real exec from a test is refused.
 // Read-only verbs (list/print) are allowed through: they are common, harmless,
 // and several tests legitimately probe them.
 //
@@ -64,8 +68,22 @@ const NoServiceMutationEnv = "GRAFEL_NO_SERVICE_MUTATION"
 // should be refused: under `go test`, or whenever a parent test process has
 // exported NoServiceMutationEnv into this one.
 func serviceMutationGuardActive() bool {
-	return guardActiveFor(testing.Testing(), os.Getenv(NoServiceMutationEnv))
+	return guardActiveFor(guardUnderGoTest, getenvForGuard(NoServiceMutationEnv))
 }
+
+// guardUnderGoTest and getenvForGuard are the guard's two inputs, as seams.
+//
+// They are seams because the interesting case — a process where
+// testing.Testing() is FALSE — is one a test in this package can never be in,
+// and both halves of it need pinning: that a shipped binary with the belt set
+// gets an ERROR rather than a panic, and that the env var is actually READ
+// rather than called and discarded. A mutant doing the latter left every suite
+// green while the belt was silently dead, which matters because the belt is the
+// only thing standing between a `go build` child and real launchd mutation.
+var (
+	guardUnderGoTest = testing.Testing()
+	getenvForGuard   = os.Getenv
+)
 
 // guardActiveFor is the decision, split out from its two inputs so the env
 // belt is observable on its own.
@@ -134,17 +152,39 @@ func serviceVerb(args []string) string {
 	return ""
 }
 
-// guardServiceCall panics if, while running under `go test` (or with the env
-// belt set), a command that is not a known read-only probe is about to be
-// executed for real against the OS service manager. See the file comment for
-// the incident this prevents.
-func guardServiceCall(tool string, args []string) {
+// guardServiceCall refuses a command that is not a known read-only probe when
+// the guard is active. See the file comment for the incident it prevents.
+//
+// It PANICS under `go test` and returns an ERROR otherwise. That split is not
+// cosmetic:
+//
+//   - Under `go test`, a leak must be impossible to ignore. Every call site in
+//     this package is best-effort — watchers.Cleanup is documented idempotent
+//     and does `_ = loader.Unload(u)` — so an error would be discarded and the
+//     guard would report nothing. A panic is the only signal those call sites
+//     cannot swallow.
+//
+//   - Outside `go test` the guard is reachable in a SHIPPED binary, because the
+//     env belt is just an environment variable and internal/verify and
+//     internal/daemon export it to a spawned `grafel daemon` — which serves
+//     group-delete RPCs that reach Cleanup. Panicking there would abort
+//     best-effort code, and it would do so inside a goroutine spawned by
+//     sweepFleetWatchers, where no recover() can reach it and the whole process
+//     dies. The runners return ([]byte, error) and every call site absorbs an
+//     error correctly, so an error is both survivable and honest.
+func guardServiceCall(tool string, args []string) error {
 	if !serviceMutationGuardActive() {
-		return
+		return nil
 	}
 	verb := serviceVerb(args)
 	if readOnlyServiceVerbs[verb] {
-		return
+		return nil
+	}
+	if !guardUnderGoTest {
+		return fmt.Errorf(
+			"refusing a mutating service-manager call because %s is set: %s %v "+
+				"(this process was told not to change launchd/systemd/Task Scheduler state)",
+			NoServiceMutationEnv, tool, args)
 	}
 	panic(fmt.Sprintf(
 		"watchers: test attempted a REAL service-manager call that is not a known "+
@@ -171,7 +211,13 @@ var serviceCallsStubbed atomic.Bool
 
 // StubServiceCallsForTest makes every launchctl/systemctl/schtasks invocation
 // in this package a no-op that reports success, and returns a restore func.
-// Test-only; production code never sets it.
+//
+// TEST-ONLY. It is exported, and therefore present in the shipping binary, for
+// one reason: the seam has to be reachable from OTHER packages' tests, so
+// export_test.go cannot provide it. Nothing in production ever calls it, and
+// with it unset the only cost is one atomic load per service-manager
+// invocation — of which there are at most a few hundred in the life of a
+// process. Do not call it from non-test code.
 func StubServiceCallsForTest() (restore func()) {
 	prev := serviceCallsStubbed.Swap(true)
 	return func() { serviceCallsStubbed.Store(prev) }
@@ -196,4 +242,4 @@ func serviceCallsAreStubbed() bool { return serviceCallsStubbed.Load() }
 // only that the path was not reached under that launchd state — not that it
 // cannot be. Guarding the call site is what makes the property hold regardless
 // of what happens to be loaded.
-func GuardServiceCall(tool string, args []string) { guardServiceCall(tool, args) }
+func GuardServiceCall(tool string, args []string) error { return guardServiceCall(tool, args) }

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -101,6 +101,11 @@ func iniEsc(s string) string {
 	return strings.ReplaceAll(s, "%", "%%")
 }
 
+// LabelPrefix is the common prefix of every watcher unit label. It is the only
+// thing that identifies a unit file on disk as ours, which is what lets
+// InstalledUnits find units the registry cannot account for.
+const LabelPrefix = "com.grafel.watcher."
+
 // Unit describes a single watcher unit to install.
 type Unit struct {
 	Group   string
@@ -113,6 +118,22 @@ type Unit struct {
 	// LegacyOf — the zero value is always the current derivation, so nothing
 	// can accidentally install a legacy-labelled unit.
 	legacy bool
+
+	// RawLabel, when non-empty, IS the unit's label — Group/Repo are not
+	// consulted to derive one. It exists for units discovered by scanning the
+	// unit directory (InstalledUnits), where the label is all we have: slugify
+	// is lossy, so a label cannot be turned back into a Group/Repo pair. Such a
+	// unit is enough to address the OS job (Load/Unload/Status all key off
+	// Label()) and enough to address the file (UnitPath appends the extension
+	// to Label()), which is all a stop needs. It must never be used to Write or
+	// Render a unit — those need a real Repo.
+	//
+	// RawLabel and legacy are orthogonal and never both meaningful: legacy
+	// DERIVES an old label from (group, repo), RawLabel SUPPLIES one that was
+	// read off disk. RawLabel wins in Label() because a unit that came from the
+	// unit directory already knows its own name — re-deriving it, by either
+	// rule, would rename it.
+	RawLabel string
 }
 
 // Label returns the platform-agnostic label for a unit.
@@ -133,11 +154,14 @@ type Unit struct {
 // existing unit — the orphaning problem below, repeated on every fleet edit
 // rather than once.
 func (u Unit) Label() string {
+	if u.RawLabel != "" {
+		return u.RawLabel
+	}
 	slug := slugify(u.Repo)
 	if u.legacy {
 		slug = legacySlugify(u.Repo)
 	}
-	return fmt.Sprintf("com.grafel.watcher.%s.%s", u.Group, slug)
+	return fmt.Sprintf("%s%s.%s", LabelPrefix, u.Group, slug)
 }
 
 // LegacyOf returns a copy of u whose Label() is the pre-#6183 label.
@@ -379,6 +403,63 @@ func UnitPath(u Unit) (string, error) {
 		return filepath.Join(dir, u.Label()+".xml"), nil
 	}
 	return "", fmt.Errorf("unsupported OS: %s", runtime.GOOS)
+}
+
+// unitExt returns the unit-file extension for the current OS, or "" if this OS
+// has no watcher units.
+func unitExt() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return ".plist"
+	case "linux":
+		return ".service"
+	case "windows":
+		return ".xml"
+	}
+	return ""
+}
+
+// InstalledUnits enumerates every watcher unit file present in UnitDir(),
+// returning one Unit per file addressed by its RawLabel.
+//
+// This answers "what is actually installed?", which is a DIFFERENT question
+// from the registry's "what should be installed?" — and the difference is
+// exactly where a stop leaks. A unit is on disk but absent from the registry
+// whenever Cleanup failed partway (it is best-effort: `_ = loader.Unload(u); _
+// = Remove(u)`), whenever a group config is unreadable, whenever a group left
+// registry.json without cleanup, and after any change to how a label's slug is
+// derived. In every one of those cases a `grafel watch` process is running that
+// a registry-derived sweep would walk straight past.
+//
+// A missing unit directory is not an error — it means nothing is installed.
+func InstalledUnits() ([]Unit, error) {
+	dir, err := UnitDir()
+	if err != nil {
+		return nil, err
+	}
+	ext := unitExt()
+	if ext == "" {
+		return nil, nil
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var units []Unit
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasPrefix(name, LabelPrefix) || !strings.HasSuffix(name, ext) {
+			continue
+		}
+		units = append(units, Unit{RawLabel: strings.TrimSuffix(name, ext)})
+	}
+	return units, nil
 }
 
 // Render returns the unit body for the current OS.

--- a/internal/verify/harness_test.go
+++ b/internal/verify/harness_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cajasmota/grafel/internal/daemon"
 	"github.com/cajasmota/grafel/internal/daemon/client"
 	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/install/watchers"
 )
 
 // jsonStats mirrors the cmd/grafel JSONStats shape. Re-declared here
@@ -117,7 +118,14 @@ func TestHarness_FixturesCorpus(t *testing.T) {
 	dcmd := exec.Command(bin, "daemon")
 	// #6134 — GRAFEL_HOME too, or the child inherits the real one via os.Environ()
 	// and prunes the developer's live store on startup. See the note above.
-	dcmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot)
+	dcmd.Env = append(os.Environ(), daemon.EnvRoot+"="+daemonRoot, "GRAFEL_HOME="+daemonRoot,
+		// Guard belt (#stop-fleet): testing.Testing() is false in this
+		// go-built child, so the watchers package's service-manager guard
+		// cannot see that it is under test. Export the belt so a child that
+		// ever reaches `grafel stop`/`install`/`update` refuses to mutate the
+		// developer's real launchd/systemd state instead of doing it silently.
+		watchers.NoServiceMutationEnv+"=1",
+	)
 	var daemonOut bytes.Buffer
 	dcmd.Stdout = &daemonOut
 	dcmd.Stderr = &daemonOut


### PR DESCRIPTION
A user with **140 registered repos** ran `grafel stop` and indexing kept happening in the background.

## What was wrong

`grafel stop` stopped exactly one launchd label: `com.grafel.daemon`. The 140 per-repo `com.grafel.watcher.<group>.<slug>` LaunchAgents are **launchd-owned and entirely independent of the daemon** — `ProgramArguments = [<bin>, watch, <repo>]`, `RunAtLoad=true`, `KeepAlive={SuccessfulExit:false}` — and kept polling and indexing. `internal/cli/watcher_ctl.go` had **zero references to `watchers.*`** anywhere in the stop/start/restart path.

The reason nobody caught it is in the file's own header:

> `// the old per-repo watcher fanout under launchd/systemd is gone — the daemon owns all watchers`

That is false, and anyone reading `stop` to check this exact question would have concluded there was nothing to stop. It is corrected in place and now states that the ADR-0017 Phase B migration it describes is unfinished.

Two more, found along the way:

- **`grafel status` never mentioned watchers at all** — zero matches for "watcher" in `status.go`. "Daemon: not running" was the only signal, which is why the reporter had to discover this by watching CPU rather than by asking the tool.
- **Even the existing `Unload` would only have half-worked on macOS.** It was a bare `bootout` with no `disable`, so the plist stays and `RunAtLoad` re-fires at next login. Linux (`disable --now`) and Windows (task delete) were already persistent — macOS was the odd one out.

The daemon's own `KeepAlive` was investigated and **refuted** as a cause: `Unload` already did `bootout` + `disable`, and `stopService` errors if the disable fails.

## The fix

`internal/cli/watcher_fleet.go` enumerates every watcher unit and flips activation, 8-way bounded parallel (140 × ~3 execs serially would make `stop` take ~15s).

**Enumeration reads the disk, not the registry.** `watchers.InstalledUnits()` globs the unit dir for `com.grafel.watcher.*` and stop/status union it with the registry view; `Unit.RawLabel` addresses a unit by label alone, since `slugify` is lossy. Deriving the watcher set from the registry — reasoning about what *should* exist rather than what *does* — is the same class of mistake that produced the original bug, and it is measurable: an orphan from a deleted group was neither stopped nor mentioned before this.

**Stop is ungated by `features.watchers`; start is gated.** That flag was never retroactive — units from an earlier install survive it — so a stop that honoured it would leave exactly the stragglers this issue is about. Start must not resurrect watchers a user disabled. Neither direction creates or deletes a unit file.

`runDaemonStop` returns a sentinel error when any unit fails, so **the process exits non-zero** rather than reporting success over a partial stop; fleet output is buffered and flushed *after* the daemon line so "daemon stopped" is never the last thing on screen while watchers are up. `runDaemonStartOpts` restores on every return path including "daemon already running" and daemon-start-failed, and the service-installed `restart` branch — previously an early return that reached neither stop nor start — now restores too. `grafel status` reports `Watchers: N installed, M running`. `grafel update` prints `re-activated N repo watcher(s) — if you had run 'grafel stop', run it again to stop them`.

**Persistence:** across reboot and login, matching what #6044 established for the daemon. A session-only watcher stop would quietly change meaning at next login — the same silence that produced this report.

## The gate that was wrong twice

`loader_darwin.go`'s `disable` placement went wrong in both directions before landing:

- **Round 1** — unconditional `disable`: persistent, but it mutated real launchd state for a never-installed label. **The test suite wrote permanent entries into the developer's launchd database**, because `cleanup_test.go` redirects `$HOME`, which is irrelevant to `gui/<uid>/<label>`.
- **Round 2** — moved behind the not-loaded probe: clean, but it silently dropped the guarantee for any unit that happened to be *unloaded*, while printing "even across reboot" over it. Measured `disable issued? 0`.
- **Now** — gated on `os.Stat(unitPath)` succeeding, ahead of the probe. A plist on disk will run again whether or not it is currently loaded, so it is suppressed; a never-installed unit has nothing to suppress and touches nothing. Measured `disable issued? 1` under the identical conditions that gave `0`.

Both directions are pinned by mutants that each kill a different test. **The gate went wrong twice precisely because only one side was ever tested** — that is the durable lesson here, and it is why every fix in this branch is now pinned in both directions rather than only the direction that was broken.

## Test isolation, made structural

`test_isolation_guard.go` panics under `go test` when a mutating service-manager verb reaches a real exec. Read-only verbs (`list`, `print`) pass through deliberately — a guard that fires on everything gets disabled.

**It caught three further leaks immediately**, two of them pre-existing:

1. `internal/cli`'s start/restart tests drove the fleet against the real `~/Library/LaunchAgents` — it panicked on `launchctl enable` for **a live user watcher, one call from being re-enabled by a test run**.
2. `install.go`'s `Apply` and `Uninstall` called `watchers.NewLoader()` **directly**, bypassing the package's own `newWatcherLoader` seam — so a test could stub the seam, believe itself isolated, and still drive a real `bootout`/`bootstrap`. That is the root cause of **24 orphaned launchd jobs** measured on the dev machine, each pointing at a deleted temp binary, exiting 78, rescheduling at the 60s throttle.
3. `stubStopSeam` in `watcher_ctl_service_test.go`, reaching `launchctl disable` on the same live label.

The guard is an **allowlist** of read-only verbs keyed on the **verb position**, not a denylist — `systemctl` passes `--user`, `schtasks` passes `/`-prefixed verbs, so per-argument checking refuses everything. Anything unclassified is refused. It **panics only under `go test` and returns an error otherwise**: a panic is the only signal those call sites cannot swallow (`watchers.Cleanup` does `_ = loader.Unload(u)`), while in production an error is survivable and honest. Verified — with `GRAFEL_NO_SERVICE_MUTATION=1` set, a real binary now **refuses and reports** through the exit-code contract instead of crashing.

Guarding was extended to `internal/daemon/service`'s four launchd helpers, its systemd verbs, `schtasksCmd`, and `internal/dashboard`'s `kickstart -k` — all seamed-but-unguarded, the same shape as `install.go`, **against the label serving the user's live MCP session.**

**Reconciling this branch's stub with #6183's found a live gap neither review caught.** Both had `!darwin` variants that were no-ops, on the reasoning "there is no launchctl to stub" — true of the command, **false of the property**: on Linux the loader shells to `systemctl --user disable --now`, on Windows to `schtasks /delete`. On a Linux or Windows dev box those stubs stubbed nothing. All four sites now delegate to one mechanism, checked in all three loaders.

## Two orphan handlers, answering different questions

This branch and #6183 both handle orphaned units, with opposite defaults, and the asymmetry is now argued at the enumeration site rather than left implicit.

#6183's migration argues **against** globbing because it would boot out a unit belonging to a group this binary has no config for. That is right for **migration** — it runs unasked as a side effect of install/update and **`os.Remove`s** the legacy path, so a wrong guess destroys state the user never mentioned. It does not transfer to **stop**, which is user-invoked by name and only flips activation (verified: `stopFleetWatchers` calls `Unload`, never `Remove`). Stopping a unit the registry cannot name is the entire point — it is a running process the user just asked to stop.

Half-migrated fleet, probed end to end: the legacy unit is found by disk glob though the registry cannot name it, deactivated, **named individually**, and given the correct remedy — *not* pointed at `grafel install`, which cannot restore a unit no registered group owns. `start` declines to resurrect it. `status` shows `1 installed, 0 running`.

## Timeouts

Both loaders take a context deadline **and `cmd.WaitDelay`**, plus a whole-sweep `fleetSweepTimeout` with un-swept units reported as failures rather than skipped. `WaitDelay` is load-bearing and was a surviving mutant until pinned: `exec.CommandContext` kills only the direct child, and `CombinedOutput` blocks until every pipe writer closes, so a surviving grandchild defeats a bare deadline. `TestRunBoundedServiceCmd_ReturnsWhenAGrandchildHoldsThePipe` reproduces it — without `WaitDelay` the call never returns inside a 10s ceiling.

## Verification

`go build ./...` 0, `go vet ./...` 0, `gofmt -l .` 0. Suites: `cli`, `install/...`, `daemon/service`, `dashboard`, `verify`, `registry` all 0. `-race` on the fleet paths and on `watchers`+`daemon/service`: 0. Cross-vet `GOOS=linux|windows|darwin` on `internal/install/watchers` and `internal/daemon/service`: 0 each.

**PATH-shim floor** — `launchctl`/`systemctl`/`schtasks` shims logging argv and exiting 1, which is strictly stronger than the in-process stub because some call sites `exec.Command` directly:

| package | exit | mutating verbs |
|---|---|---|
| `internal/install/...` | 0 | **0** |
| `internal/cli/` | 0 | **0** |
| `internal/daemon/service/` | 0 | **0** |
| `internal/dashboard/` | 0 | **0** |
| `internal/verify/` | 0 | **0** |

Read-only probes only. Two honest caveats kept: `internal/install/...` reads 0 because the stubs short-circuit, so **the guard proves it there, not the shim**; and because the shim makes `launchctl list` exit 1, a short-circuiting `Unload` proves the path was not reached *under that launchd state*, not that it cannot be. The `disable`-on-plist-existence gate now fires *ahead* of that short-circuit, so this floor is measured under a strictly more sensitive code path than earlier rounds.

**Mutation across four rounds: 30 run, 29 killed.** Two failed to compile on first cut and one produced a 5-minute runaway rather than a failure — all re-cut before counting, none banked as kills.

Independently adversarially reviewed four times (REQUEST-CHANGES ×3 → APPROVE), with the reviewer re-running its own process-boundary probes against each revision.

## Known limits

**Real launchd is not exercised.** Three claims rest on documentation: that `launchctl disable` suppresses `RunAtLoad` across login, that `enable` clears it, and — the one this bug actually turns on — that a `bootout` of a **currently running** job with `KeepAlive={SuccessfulExit:false}` wins because the job is disabled in the domain. The first two are shared risk with #6044, which already ships the identical pairing; the third is new and is the thing to confirm by hand: after `grafel stop`, `launchctl print-disabled gui/$UID | grep com.grafel.watcher` should show the labels as `true`.

**Windows `schtasksCmd` guard wiring is unexecuted** — no Windows runner. The verb table is exercised on darwin; the wiring is four lines with no branching, covered by reading plus `GOOS=windows go vet`.

**The env belt's end-to-end behaviour in a real `go build` binary is unexecuted.** The seams pin every branch of the decision and the plumbing into it, but no test runs in a process where `testing.Testing()` is genuinely false — so rebinding the seam to something that never reads the environment leaves every suite green. Defence-in-depth over `testing.Testing()`, which is unaffected. Filed as a follow-up: a ten-line `go build` helper closes it, the shape `internal/verify/harness_test.go` already uses.

**Stop's glob is prefix-based over the shared unit dir**, so on a machine with two grafel roots a stop from root A deactivates root B's watchers — unlike the daemon stop, which is root-scoped. Arguably correct ("stop grafel" means stop grafel), but a deliberate scope difference now written down.

## Filed separately

- `grafel update` re-activates watchers, silently un-doing a persistent stop. Legitimate for an explicit install; `update` is run for a different reason. Mitigated by the new output line, not fixed.
- On the Windows arm, a guard refusal surfaces as a bare `exit status 1` rather than the guard's explanatory message.
- `status` does not repeat the orphan note stop printed.
- **Pre-existing and unrelated:** `internal/install`'s test binary does not compile off macOS — `watcher_write_nonfatal_r3_test.go` uses the darwin-only `SetLaunchctlRunnerForTest` with no build tag, so `GOOS=linux go vet ./internal/install/...` fails on `origin/main` too. No Linux contributor or CI runner can build that package's tests.

Refs #6044, #6050, #6179, #6183

Closes #6197
