### PR TITLE
test(#6177): pin the mixed-language sentinel bind and the empty-Signature fail-open independently

### DIFF
--- a/internal/resolve/receiver_tier_ambiguity_6125_test.go
+++ b/internal/resolve/receiver_tier_ambiguity_6125_test.go
@@ -309,7 +309,7 @@ func TestReceiverTierPackageWideLeafTierNeverBoundThisAnyway6125(t *testing.T) {
 	all := []types.EntityRecord{a, b, sibling}
 	idx := BuildIndex(all)
 
-	if id, ok := idx.lookupPackageMemberByLeafName(recvPkg6125, recvMember6125, famOperation, true); ok || id != "" {
+	if id, ok := idx.lookupPackageMemberByLeafName(recvPkg6125, recvMember6125, famOperation, false); ok || id != "" {
 		t.Fatalf("lookupPackageMemberByLeafName(%q,%q) = (%q, %v), want (\"\", false). "+
 			"The blank sentinel from the (pkg, T11, Do11) collision is supposed to "+
 			"poison this scan; if it no longer does, the package-wide tier CAN now "+

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2006,7 +2006,7 @@ var publicKeywordRE = regexp.MustCompile(`\bpublic\b`)
 // `public` inside a comment cannot reach it.
 //
 // An EMPTY Signature fails OPEN. Graphs written before #4881 dropped the field
-// on load (internal/graph/load.go:596), and reading "no declaration text" as
+// on load (internal/graph/load.go:601), and reading "no declaration text" as
 // "not public" would dangle every Solidity field call in one. Same safe
 // direction as memberFamily staleness.
 func uncallableSolidityField(language, kind, signature string) bool {

--- a/internal/resolve/solidity_nonpublic_field_calls_6177_followup_test.go
+++ b/internal/resolve/solidity_nonpublic_field_calls_6177_followup_test.go
@@ -1,0 +1,136 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Follow-up fixtures for #6177's adversarial review. The base fixtures in
+// solidity_nonpublic_field_calls_6177_test.go pin the eligibility overlay
+// with every colliding candidate Solidity; these close three residual gaps
+// the review found and that were closed here rather than sent back to the
+// contributor.
+
+// --- Gap 1: the sentinel overlay converts a dangle into a bind whose
+// surviving candidate is not even the same language as the sentinel it
+// replaces --------------------------------------------------------------
+
+// javaMethodNamed builds a Java method entity shaped like the leaf-name
+// tiers see any dotted-Name entity: Kind Operation, no Signature, no
+// Language-specific marker that Index.uncallableMember could ever set for
+// it (uncallableSolidityField gates on language=="solidity", so this
+// entity's uncallableMember entry is always absent regardless of content).
+func javaMethodNamed(id, name, file string) types.EntityRecord {
+	return types.EntityRecord{
+		ID: id, Kind: "Operation", Name: name, SourceFile: file, Language: "java",
+	}
+}
+
+// TestMixedLanguageSentinel_JavaMethodSurvivesSolidityFieldCollision_6177
+// reproduces the reviewer's residual gap: `contracts/b.sol` declares
+// `contract Hidden { uint256 internal cap; }` and `contracts/Hidden.java`
+// declares `class Hidden { void cap() {} }` — same package dir ("contracts"),
+// same dotted key ("Hidden", "cap"), two different languages. Both land in
+// byPackageMember["contracts"]["Hidden"]["cap"] and collide into the blank
+// ambiguity sentinel, exactly like the same-language `Hidden`/`Hidden`
+// shape in solidity_nonpublic_field_calls_6177_test.go — except here the
+// surviving candidate under the eligible-subset overlay is the JAVA method,
+// not a second Solidity field.
+//
+// Before #6182 this sentinel aborted the scan unconditionally and the bare
+// call to `cap()` from contracts/a.sol dangled. After #6182 the overlay
+// resolves the key over its eligible subset: the Solidity field is
+// ineligible (internal, no getter), the Java method carries no
+// uncallableMember entry at all (uncallableSolidityField only ever fires for
+// language=="solidity"), so the subset is exactly one entity and the key
+// binds through the sentinel to the Java method.
+//
+// TestMixedLanguageSentinelControl_DeletingSolidityFieldBindsSameJavaMethod_6177
+// is the control: it removes the Solidity field so no collision exists at
+// all, and asserts the SAME Java method still binds by the direct
+// (non-colliding) route. Verified by running both fixtures against the
+// current tree before writing this pin: both resolve to the identical
+// entity, id=3333333333333333 / Operation / Hidden.cap /
+// contracts/Hidden.java — which is the evidence that the sentinel-mediated
+// bind here is a restoration of the correct answer, not a new mis-bind
+// smuggled in by the eligibility overlay. A hypothetical predicate
+// false-positive (uncallableSolidityField wrongly marking an eligible field
+// ineligible) would, without this fixture, compound into a confident WRONG
+// edge here instead of a safe dangle — which is why this shape needed its
+// own pin distinct from the same-language sentinel tests.
+func TestMixedLanguageSentinel_JavaMethodSurvivesSolidityFieldCollision_6177(t *testing.T) {
+	records := []types.EntityRecord{
+		solCaller("1111111111111111", "Consumer.run", "contracts/a.sol", "cap"),
+		solField("2222222222222222", "Hidden.cap", "contracts/b.sol", "uint256 internal cap"),
+		javaMethodNamed("3333333333333333", "Hidden.cap", "contracts/Hidden.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("bare CALLS `cap` left as stub %q; contracts/b.sol's `Hidden.cap` is an "+
+			"internal Solidity field (ineligible) and contracts/Hidden.java's `Hidden.cap` "+
+			"is a Java method (never marked uncallable), so the (\"contracts\",\"Hidden\","+
+			"\"cap\") sentinel's eligible subset is exactly the Java method and the key "+
+			"must bind through it rather than abort the scan", stub)
+	}
+	if got.id != "3333333333333333" {
+		t.Fatalf("bound to id=%s kind=%s name=%s file=%s; want 3333333333333333 / "+
+			"Hidden.cap [Java method, contracts/Hidden.java]",
+			got.id, got.kind, got.name, got.file)
+	}
+}
+
+func TestMixedLanguageSentinelControl_DeletingSolidityFieldBindsSameJavaMethod_6177(t *testing.T) {
+	records := []types.EntityRecord{
+		solCaller("1111111111111111", "Consumer.run", "contracts/a.sol", "cap"),
+		javaMethodNamed("3333333333333333", "Hidden.cap", "contracts/Hidden.java"),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("control: with the Solidity field removed entirely (no collision, no "+
+			"sentinel), the bare CALLS `cap` still failed to bind to the sole remaining "+
+			"candidate, stub=%q", stub)
+	}
+	if got.id != "3333333333333333" {
+		t.Fatalf("control: bound to id=%s kind=%s name=%s; want 3333333333333333 / "+
+			"Hidden.cap — the same entity the sentinel-mediated test above binds, which is "+
+			"the evidence that the sentinel bind restores the correct answer rather than "+
+			"introducing a new one", got.id, got.kind, got.name)
+	}
+}
+
+// --- Gap 2: the fail-open on an empty Signature, pinned at the resolver
+// level rather than only in the predicate table -------------------------
+
+// TestSolidityFieldEmptySignatureFailsOpen_ResolverLevel_6177 is the
+// resolver-level companion to the "" row in TestUncallableSolidityField_6177
+// (predicate table). uncallableSolidityField returns "eligible" whenever
+// Signature is empty — the state graphs written before #4881 lose that field
+// on load (internal/graph/load.go:601) hit exactly this path, and reading
+// "no declaration text" as "not public" would dangle every Solidity field
+// bind such a graph holds.
+//
+// A single caller and a single field with Signature: "" is enough to make
+// the fail-open direction observable independently of the predicate table:
+// if uncallableSolidityField were flipped to treat an empty Signature as
+// UNCALLABLE, idx.uncallableMember would gain an entry for this field, the
+// per-candidate skip in scanLeafMembers would fire (this fixture has no
+// collision, so the sentinel/overlay path is not involved at all — this is
+// the plain per-candidate skip #6141 already exercises), and the bare call
+// would dangle instead of binding.
+func TestSolidityFieldEmptySignatureFailsOpen_ResolverLevel_6177(t *testing.T) {
+	records := []types.EntityRecord{
+		solCaller("1111111111111111", "Consumer.run", "contracts/a.sol", "legacy"),
+		solField("2222222222222222", "Config.legacy", "contracts/b.sol", ""),
+	}
+	got, stub := resolveEdge(t, records, 0)
+	if stub != "" {
+		t.Fatalf("bare CALLS `legacy` left as stub %q; a Solidity field with an EMPTY "+
+			"Signature (the shape a pre-#4881 graph.fb load produces) must fail OPEN and "+
+			"still bind, not be treated as non-public", stub)
+	}
+	if got.id != "2222222222222222" {
+		t.Fatalf("bound to id=%s kind=%s name=%s; want 2222222222222222 / Config.legacy",
+			got.id, got.kind, got.name)
+	}
+}


### PR DESCRIPTION
Follow-up to #6182/#6203-era review. Additive tests and two comment corrections only — no production behaviour changed.

Three gaps the adversarial review of #6182 left open, which we said we would close ourselves rather than send back to the contributor.

**The mixed-language sentinel bind had no fixture.** #6182's eligibility-aware overlay converts a previously-dangling ambiguous key into a confident bind, and the surviving candidate need not be the same language: a Solidity `contract Hidden { uint256 internal cap; }` colliding with a Java `Hidden.cap()` now binds the Java method where the sentinel previously aborted the scan.

That was believed to be the correct restoration rather than a regression, but believed is not established, so the control was run rather than assumed: deleting the Solidity field entirely — no collision, no sentinel — and re-resolving the same caller binds the **identical** entity via the plain non-colliding lookup. The sentinel-mediated path and the no-collision control agree exactly, so the ineligible field was poisoning the key and the overlay removes the poisoning. Pinned as `TestMixedLanguageSentinel_JavaMethodSurvivesSolidityFieldCollision_6177`, with the control kept as its own test rather than discarded — it is the thing that makes the first test's verdict meaningful.

**The empty-`Signature` fail-open was pinned by one predicate-table test.** That fail-open protects every existing Solidity field bind in a pre-#4881 graph, where `Signature` is lost on load, and inverting it killed exactly one test. Now pinned at resolver level too, and verified to fail **independently** — run with the predicate-table test excluded, it still goes red against the mutant.

**Two citations corrected.** `internal/graph/load.go:596` is `:601` — off by five in `uncallableSolidityField`'s doc comment. And `receiver_tier_ambiguity_6125_test.go:312` now passes `callableOnly=false`, the faithful minimal edit for an all-Go fixture; confirmed by checking the fixture's `uncallableMember`/`eligiblePackageMember` really are empty rather than assuming it from the language.

Mutation table, unpiped exit codes, `GOMAXPROCS=4 -count=1`:

| mutant | result | killed by |
|---|---|---|
| `foldEligibleLeaf`: invert `!idUncallable` | killed | the new mixed-language test, plus two pre-existing sentinel tests |
| `uncallableSolidityField`: drop the `signature == ""` guard | killed | the new resolver-level test **and** the predicate table |
| same, scoped to only the new test | killed | the new test alone — the independence claim |

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/resolve/... ./internal/extractors/...` 0 across 77 packages, all four coverage gates 0 with no `gen` drift. Re-verified after rebasing onto #6138.

Refs #6177, #6182