### PR TITLE
fix(#6201): stop the incremental reject re-hashing the whole repo, and scale the ceiling with repo size

### DIFF
--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -133,9 +133,16 @@ func (c *ExtractorConfig) EmitDestructureDetail() bool {
 // Config (when IncrementalReindexSet=true) wins; env var is the fallback.
 //
 // Default flipped to ON (#5231, the reindex-storm fix): the incremental
-// file-level patch is ~25× faster than a full reindex for single-file edits
-// and has a proven safe fall-through to the full IndexFn on any precondition
-// failure. Operators can still force the legacy full-reindex-every-time
+// file-level patch is measurably faster than a full reindex and has a proven
+// safe fall-through to the full IndexFn on any precondition failure.
+//
+// "~25× faster" stood here until #6201 and had no in-tree backing. Measured
+// (#6199, synthetic 3003-file / 58.5k-entity fixture, GOMAXPROCS=4, N=14,
+// medians): 6.0× at one changed file, 4.9× at fifty, 3.2× at two hundred. The
+// speedup is bounded by an O(repo)/O(graph) fixed tail every pass pays
+// regardless of delta size — see internal/extractors/incremental.go and #6199.
+//
+// Operators can still force the legacy full-reindex-every-time
 // behaviour with GRAFEL_INCREMENTAL_REINDEX=0 (or =false), which boolFromEnv
 // reports as an explicitly-set falsy value.
 func (c *ExtractorConfig) IsIncrementalEnabled() bool {

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -4,9 +4,25 @@
 // # Conservative v1 design (S3 #2167) + follow-up (S3 #2170)
 //
 // The full-reindex pipeline rewrites graph.fb from scratch on every daemon
-// watcher tick. For a 60 k-entity repo that takes ~5 s. When only one file
-// changed, we want ~200 ms: parse that file, swap its entities in the graph,
-// and atomically re-emit graph.fb without touching anything else.
+// watcher tick. This path instead parses only the changed files, swaps their
+// entities in the graph, and atomically re-emits graph.fb.
+//
+// MEASURED, not aspirational (#6199/#6201). Fixture: a synthetic 3003-file /
+// 58.5k-entity Go+Python tree, GOMAXPROCS=4, N=14, medians:
+//
+//	full reindex                    9,540 ms
+//	incremental,   1 changed file   1,576 ms   (6.0x faster)
+//	incremental,  50 changed files  1,920 ms   (4.9x)
+//	incremental, 200 changed files  2,947 ms   (3.2x)
+//	incremental, 500 changed files  5,276 ms   (1.8x)
+//
+// The header of this file previously claimed ~5 s for the full reindex and
+// ~200 ms for a one-file edit. Both were unmeasured and both were wrong by
+// roughly a factor of 8; the ~25x speedup claimed at
+// internal/extractor/extractor.go was wrong by a factor of 4. The reason the
+// numbers are so much flatter than "re-parse one file" suggests is that only
+// two phases are O(delta) — see #6199 for the per-phase breakdown of the
+// O(repo)/O(graph) fixed tail that dominates every pass.
 //
 // Correctness guarantee: the opt-in flag (GRAFEL_INCREMENTAL_REINDEX=1)
 // is NOT set by default. Four safety valves are applied before attempting a
@@ -14,11 +30,14 @@
 //
 //  1. Trigger limit: if more than the effective limit files changed in the
 //     debounced batch we fall back to full reindex. The effective limit is:
-//     - GRAFEL_INCREMENTAL_MAX_FILES env var (if set to a valid int)
-//     - 50 when the active ref is the repo's default (main) branch
-//     - 20 otherwise (feature branches)
-//     The #2167 conservative default of 5 is still the hard floor when the
-//     env override is absent; 20 is the raised default for feature branches.
+//     - cfg.IncrementalMaxFiles / GRAFEL_INCREMENTAL_MAX_FILES, honoured
+//     verbatim when set (including values below the floors), or
+//     - max(floor, walkedFiles/4), floor = 50 on the repo's default branch
+//     and 20 on a feature branch (#6201).
+//     There is no hard floor of 5: no such clamp exists in effectiveLimit or
+//     in ExtractorConfig.EffectiveIncrementalMaxFiles, and
+//     GRAFEL_INCREMENTAL_MAX_FILES=1 is honoured as 1. The header claimed one
+//     until #6201 deleted the claim rather than the behaviour.
 //
 //  2. AST-hash gate: files whose content hash (SHA-256) is unchanged since
 //     the last manifest stamp are skipped entirely (whitespace-only edits).
@@ -84,32 +103,134 @@ import (
 	"github.com/cajasmota/grafel/internal/types"
 )
 
-// defaultIncrementalFiles is the raised default trigger limit for feature
-// branches (S3 #2170). The S3 #2167 conservative value of 5 still acts as the
-// minimum; 20 is the new default for non-main branches.
+// defaultIncrementalFiles is the FLOOR trigger limit for feature branches
+// (S3 #2170). It is a floor, not the limit: see incrementalFilesDivisor.
 const defaultIncrementalFiles = 20
 
-// mainBranchIncrementalFiles is the hot-path limit for the default (main)
-// branch. Commits to main tend to be small focused changes; we allow up to 50
-// files before falling back to a full reindex.
+// mainBranchIncrementalFiles is the FLOOR trigger limit for the default (main)
+// branch. Commits to main tend to be small focused changes.
 const mainBranchIncrementalFiles = 50
 
-// effectiveLimit returns the trigger-limit for the given repoPath and optional
-// ExtractorConfig.
+// incrementalFilesDivisor derives the trigger limit from the size of the repo
+// being indexed: limit = max(floor, walkedFiles/incrementalFilesDivisor).
 //
-// Priority (issue #2320):
+// WHY A RATIO AT ALL, and why this one (#6201, measured under #6199).
+//
+// The point of the trigger limit is to fall back to a full reindex once
+// incremental stops being cheaper. That crossover is not a constant: it is
+// where (fixed tail + per-file cost x delta) meets the full-reindex cost, and
+// BOTH sides scale with the repo. A flat constant can only be right at one repo
+// size, and the shipped flat 20/50 was wrong by ~25x.
+//
+// Measured cost model — fixture: a synthetic 3003-file / 58.5k-entity Go+Python
+// tree, GOMAXPROCS=4, N=14, medians (issue #6199's per-phase matrix; the same
+// four columns tabulated in this file's header):
+//
+//	full reindex = 9540 ms
+//	incremental  = 1536 ms fixed + 7.42 ms per changed file
+//	=> crossover at (9540 - 1536) / 7.42 = ~1078 changed files
+//	=> ~0.36 x the walked file count on that fixture
+//
+// That is an ordinary least-squares fit over all four measured points
+// (1/50/200/500 changed files → 1576/1920/2947/5276 ms). Residuals
+// +33/+13/-74/+28 ms, worst 2.5%. A two-point fit over the extremes alone
+// agrees closely: 7.41 ms/file, intercept 1569 ms, crossover ~1075 files
+// (0.358x) — so the number is not an artifact of the fitting method.
+//
+// #6201's issue body stated 1451 ms + 6.26 ms/file → crossover ~1292 (0.43x),
+// and this comment repeated it. It does NOT reproduce the table it was drawn
+// from: it under-predicts every measured point, by +119/+156/+244/+695 ms, the
+// error growing with the delta — i.e. the slope is ~16% too shallow, which
+// inflates the crossover by ~20%. Corrected here rather than propagated,
+// because shipping an unreconcilable performance claim inside the fix for
+// unreconcilable performance claims would be self-defeating.
+//
+// Corroborating points from the same matrix, all of which the flat ceiling
+// rejected: 50 changed files = 20% of a full reindex; 200 = 31%; 500 = 55%.
+//
+// The divisor is 4 (limit = 0.25 x repo), NOT the measured 0.36. The margin is
+// deliberate and is the honest part of this number:
+//
+//   - The crossover is one fixture. The fixed tail scales with GRAPH size and
+//     the per-file term with FILE size, so a repo with denser entities per file
+//     crosses over sooner. 0.25 sits 30% below the measured 0.359, which covers
+//     a fixture up to ~1.44x denser in entities per file before the ratio
+//     starts losing. (Against the issue's overstated 0.43 the same divisor
+//     looked like a 42% margin and 1.7x of headroom; the real figures are 30%
+//     and 1.44x. The divisor is unchanged because it is below both crossovers —
+//     but the margin is the entire justification for it, so it has to be the
+//     real one.)
+//   - Peak memory, not just throughput, is a reason the ceiling exists — a
+//     large delta can mean a large peak, and that is an independent reason to
+//     bound it. Re-checked AT the new ceiling rather than assumed: on a
+//     1200-file fixture (ceiling 300) the Go heap is flat across the whole
+//     range — HeapSys 93.1 / 94.3 / 93.3 MB and HeapInuse 58.6 / 42.5 / 65.6 MB
+//     at 1 / 50 / 300 changed files, with total allocation growing only ~1.6x
+//     over a 300x delta increase. That matches #6199's own matrix
+//     (257-289 MB from 1 to 500 changed files, vs 465 MB RSS for a full
+//     reindex). Memory therefore does not argue for a low ceiling on either
+//     fixture — but it is still two fixtures, and the margin buys room for it.
+//     RSS was deliberately NOT used: the measuring machine was swapping, which
+//     makes RSS an upper bound rather than a footprint.
+//
+// If you re-measure on a different fixture, change the divisor here and say
+// which fixture, rather than re-deriving this from scratch.
+const incrementalFilesDivisor = 4
+
+// effectiveLimit returns the trigger-limit for the given repoPath, optional
+// ExtractorConfig, and the number of files the repo walk produced.
+//
+// Priority (issue #2320, ratio added in #6201):
 //  1. cfg.IncrementalMaxFiles (when cfg is non-nil and > 0) — Config channel.
 //  2. GRAFEL_INCREMENTAL_MAX_FILES env var (backward-compat fallback).
-//  3. mainBranchIncrementalFiles when the active ref is the repo's default branch.
-//  4. defaultIncrementalFiles (20) for feature branches.
-func effectiveLimit(repoPath string, cfg *extractor.ExtractorConfig) int {
+//     Both overrides are honoured verbatim — the ratio is NOT maxed against
+//     them. An operator pinning a small number on a large repo (e.g. 5 during
+//     an incident, to bound the pass) means 5, and must not silently receive
+//     walkedFiles/4 instead. Pinned by
+//     TestIncremental_LowOverrideIsHonouredOnLargeRepo, which places the
+//     override below the ratio so the two are distinguishable — the earlier
+//     override tests all ran on repos small enough that the ratio could not
+//     have won anyway, and a reordering of this expression survived them.
+//  3. Otherwise max(branch floor, walkedFiles/incrementalFilesDivisor). The
+//     floor keeps small repos at their previous behaviour — a 40-file repo
+//     would otherwise get a ceiling of 10, which is strictly worse than the
+//     20/50 it has today.
+//
+// THE BRANCH DISTINCTION IS NOW DEAD ABOVE ~200 FILES, deliberately.
+// walkedFiles/4 overtakes the feature-branch floor of 20 at 84 walked files and
+// the default-branch floor of 50 at 204, so from ~204 files up both branches
+// get the identical ceiling and gitmeta.IsDefaultBranch stops affecting the
+// outcome. That is not an oversight — it retires a proxy:
+//
+//   - The trigger limit is a COST gate, not a risk gate. What guards
+//     CORRECTNESS on this path is branch-independent: the AST-hash gate, the
+//     scoped resolver's unresolved-relationship safety net, and the
+//     fall-through to a full reindex on any precondition failure (safety
+//     valves 2-4 in this file's header). A 300-file delta is not less safe to
+//     patch on main than on a feature branch — it is only more expensive, and
+//     the ratio prices exactly that.
+//   - The 20/50 split was a stand-in for "how big is a typical delta here",
+//     which scales with the repo. Keying that guess to the branch could only
+//     ever be right at one repo size — the same mistake as the flat ceiling
+//     itself, one level down.
+//
+// The floors survive only where the ratio is uselessly small, i.e. repos under
+// ~200 files, which is precisely the regime where the branch heuristic was
+// cheap and harmless to keep. If a future measurement shows feature branches
+// genuinely need a tighter bound at scale, express it as a second divisor, not
+// as a constant.
+func effectiveLimit(repoPath string, cfg *extractor.ExtractorConfig, walkedFiles int) int {
 	if n := cfg.EffectiveIncrementalMaxFiles(); n > 0 {
 		return n
 	}
+	floor := defaultIncrementalFiles
 	if gitmeta.IsDefaultBranch(repoPath) {
-		return mainBranchIncrementalFiles
+		floor = mainBranchIncrementalFiles
 	}
-	return defaultIncrementalFiles
+	if scaled := walkedFiles / incrementalFilesDivisor; scaled > floor {
+		return scaled
+	}
+	return floor
 }
 
 // IncrementalEnabled reports whether S3 incremental reindex is opt-in active.
@@ -192,11 +313,14 @@ func StampFile(absPath string) (FileStamp, error) {
 //     mitigation: Detector.Detect already early-outs on an unknown language
 //     before it touches the content (detector.go, the `sets, ok :=
 //     d.compiled[file.Language]` branch). Those languages pay ~0, not 8.7 ms.
-//   - The worst case is a fixed number, not a repo-sized one. This runs per
-//     CHANGED file, and the changed set is hard-capped by the trigger limits
-//     below — defaultIncrementalFiles=20, mainBranchIncrementalFiles=50 — so the
-//     ceiling is 50 × 8.7 ms ≈ 435 ms per run. Above the cap the path falls back
-//     to a full rebuild, which pays the same 8.7 ms for every file in the repo.
+//   - It is bounded by the trigger limit, which since #6201 is
+//     max(20|50, walkedFiles/4) rather than a flat 20/50 — so this is now a
+//     repo-sized worst case, not a fixed one (a 3000-file repo caps at 750
+//     changed files ≈ 6.5 s of Detect). That is accounted for: the 6.26 ms per
+//     changed file in #6201's cost model was measured on code that already runs
+//     Detect, so the ~0.43x-of-repo crossover the divisor is derived from
+//     already carries this term. Above the cap the path falls back to a full
+//     rebuild, which pays the same 8.7 ms for EVERY file in the repo.
 //
 // Content-hash caching across runs would buy nothing: Step 3's AST-hash gate has
 // already established that every file reaching here has changed content.
@@ -363,17 +487,32 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// --- Step 2: trigger limit (#2170 raised limits + main-branch hot-path) ---
 	// Issue #2396: cfg is now threaded through from the caller so programmatic
 	// config overrides the env-var / gitmeta path when non-nil.
-	limit := effectiveLimit(absRepo, cfg)
+	// Issue #6201: the limit is now derived from the walked file count, because
+	// the crossover it approximates scales with the repo — see
+	// incrementalFilesDivisor for the measurement.
+	limit := effectiveLimit(absRepo, cfg, len(allFiles))
 	if totalChanged > limit {
-		// Fully reconcile + persist the manifest BEFORE falling back. Saving only
-		// the GC'd map (#5667) left file STAMPS stale and skipped the absent-entry
-		// prune, so the same files re-surfaced as changed/deleted on the next pass
-		// and re-tripped this fallback, looping the reindex even without a manual
-		// clean-manifest rebuild. UpdateManifest refreshes stamps AND prunes
-		// entries absent from the gitignore-aware walk, making the fallback path's
-		// manifest as clean as the success path's (#5668). Log a path SAMPLE so a
-		// recurrence is diagnosable, not just a bare count (#5668).
-		diff.UpdateManifest(absRepo, allFiles, manifest)
+		// Reconcile + persist the manifest BEFORE falling back, but at O(delta),
+		// not O(repo) (#6201).
+		//
+		// Both loop guards this path carries are preserved, and neither needs a
+		// full-repo sweep:
+		//   #5667 — prune entries absent from the gitignore-aware walk, or a
+		//           now-ignored file is reported "deleted" forever and re-trips
+		//           this fallback on every pass. That is a map walk: free.
+		//   #5668 — refresh the STAMPS of the files that actually changed, or
+		//           they re-surface as changed next pass and re-trip it too.
+		//           That is O(changed), and changedFiles is exactly that set.
+		// What is NOT needed is re-hashing the files the change-detector just
+		// established are CLEAN. That sweep measured ~220 ms of the 696 ms a
+		// reject burned on a 3003-file fixture, and every byte of it was thrown
+		// away: the caller's full reindex re-walks and re-hashes the repo
+		// immediately afterwards. A rejected attempt cost 7% MORE than never
+		// having attempted one (#6201).
+		//
+		// Log a path SAMPLE so a recurrence is diagnosable, not just a bare
+		// count (#5668).
+		diff.UpdateManifestScoped(absRepo, changedFiles, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		logger.Printf("incremental: too-many-changed files=%d limit=%d (changed=%d deleted=%d) changed=%v deleted=%v",
 			totalChanged, limit, len(changedFiles), len(deletedFiles),
@@ -417,6 +556,21 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		}
 		// Nothing to do — manifest is already up-to-date and the graph is a
 		// genuine reflection of the (possibly empty / codeless) tree.
+		//
+		// READ THIS BEFORE DELETING THIS CALL (#6201). #6199 lists the sweep on
+		// a zero-change pass as pure waste and the cheapest remaining win, and
+		// on its own that is true. But since #6201 made the too-many-changed
+		// rejects re-stamp only the CHANGED files, this full-repo
+		// UpdateManifest is also the path that HEALS what a scoped reject left
+		// behind: a file that was stale or absent in the manifest but not in
+		// the reject's changed set keeps its old stamp until some pass sweeps
+		// the whole repo, and this is the only remaining pass that does. The
+		// consequence of never healing is over-reporting (those files read as
+		// changed and are re-extracted), not a stale graph — so this is a
+		// latent cost, not a correctness bug, and it is why the deletion is
+		// still worth doing. Just replace the healing when you do: sweep here
+		// but skip the SaveManifest, or move the reconcile onto the fallback
+		// full index. Deleting it naively makes those entries permanent.
 		diff.UpdateManifest(absRepo, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		return Result{Done: true, Duration: time.Since(t0)}
@@ -452,9 +606,27 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	// Re-check trigger limit after whitespace filtering.
+	//
+	// THIS BRANCH IS UNREACHABLE. Predates #6201; flagged during its review and
+	// left in place only so the deletion can be filed on its own.
+	//
+	// Proof: the gate above established totalChanged <= limit, where
+	// totalChanged = len(changedFiles) + len(deletedFiles). The AST-hash loop
+	// ranges over changedFiles and appends each element at most once, so after
+	// it len(reallyChanged) <= len(changedFiles); the deletedFiles append then
+	// makes len(reallyChanged) <= totalChanged. Between the two gates nothing
+	// reassigns limit, changedFiles, deletedFiles or totalChanged — the only
+	// writes are those appends. Hence len(reallyChanged) <= limit always, and
+	// this condition cannot hold. Confirmed empirically too: a panic at this
+	// branch head survives internal/extractors/..., internal/indexer/diff/...
+	// and the cmd/grafel integration suite (which drives TryIncremental
+	// end-to-end) with every package still green.
+	//
+	// The call below is therefore dead code, NOT a live #5667/#5668 guard —
+	// this comment previously claimed it was, which would have told the next
+	// reader it runs. The live guard is the reachable branch above.
 	if len(reallyChanged) > limit {
-		// Fully reconcile + persist before falling back (see #5667, #5668).
-		diff.UpdateManifest(absRepo, allFiles, manifest)
+		diff.UpdateManifestScoped(absRepo, changedFiles, allFiles, manifest)
 		_ = diff.SaveManifest(stateDir, absRepo, manifest)
 		logger.Printf("incremental: too-many-changed after-hash-gate files=%d limit=%d really=%v",
 			len(reallyChanged), limit, samplePaths(reallyChanged))

--- a/internal/extractors/incremental_fallback_tax_6201_test.go
+++ b/internal/extractors/incremental_fallback_tax_6201_test.go
@@ -1,0 +1,287 @@
+package extractors_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// isolateHome redirects every ambient path a pass might touch away from the
+// developer's real home. TryIncremental takes repoPath/stateDir explicitly, but
+// gitmeta / config lookups underneath it do not, and a test must never be able
+// to write to the live daemon state.
+func isolateHome(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+}
+
+// TestIncremental_RejectPath_DoesNotSweepUnchangedFiles is the #6201 regression
+// test for the fallback tax.
+//
+// The too-many-changed reject used to call diff.UpdateManifest(absRepo,
+// allFiles, manifest) BEFORE returning — a SHA-256 hash of every file in the
+// repo, changed or not — and then throw the result away, because the caller
+// immediately runs a full reindex that walks and hashes everything again.
+// Measured on a 3003-file fixture: 696 ms of work for a reject, on top of a
+// 9,540 ms full reindex, i.e. a rejected attempt cost 7% MORE than never having
+// attempted one.
+//
+// The property pinned here is WORK PERFORMED, not elapsed time. The manifest is
+// seeded with a poison stamp for files that are provably CLEAN (committed,
+// untouched, and not reported by `git diff --name-only HEAD`). A full-repo hash
+// sweep necessarily overwrites those poison stamps with the real content hash;
+// a delta-scoped reconcile cannot, because it never opens those files. So the
+// surviving poison IS the proof that no full-repo sweep ran.
+//
+// The second half pins the property that must NOT be lost in the process: the
+// #5668 loop guard. The stamps of the files that DID change still have to be
+// refreshed and persisted, or the next pass re-reports them as changed,
+// re-trips this same fallback, and the daemon loops a full reindex forever.
+func TestIncremental_RejectPath_DoesNotSweepUnchangedFiles(t *testing.T) {
+	isolateHome(t)
+	// Force a low ceiling so the reject fires on a small fixture. This test is
+	// about what the reject PATH costs, not about where the ceiling sits.
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "3")
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	const nStable = 6
+	const nDirty = 5
+
+	// Distinct basename stems throughout: diff.FilterWithGit performs
+	// cross-file invalidation by basename stem (moduleBase), so a shared stem
+	// would drag a "stable" file into the dirty set and invalidate the fixture.
+	stable := make([]string, nStable)
+	for i := range stable {
+		stable[i] = fmt.Sprintf("stable_%02d.go", i)
+		writeFile(t, repo, stable[i], fmt.Sprintf("package p\n\nfunc Stable%02d() {}\n", i))
+	}
+	dirty := make([]string, nDirty)
+	for i := range dirty {
+		dirty[i] = fmt.Sprintf("dirty_%02d.go", i)
+		writeFile(t, repo, dirty[i], fmt.Sprintf("package p\n\nfunc Dirty%02d() {}\n", i))
+	}
+
+	initGitRepo(t, repo)
+	gitCommitAll(t, repo, "base")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Stable00", "stable_00.go"),
+			Name: "Stable00", Kind: "SCOPE.Operation", SourceFile: "stable_00.go", Language: "go"},
+	}, nil)
+
+	// Manifest baseline: correct stamps for everything, pinned at HEAD.
+	seedManifest(t, repo, stateDir)
+
+	// Poison the stable entries. They are committed and untouched, so git
+	// reports them clean and the change-detector never hashes them — only an
+	// indiscriminate full-repo sweep can overwrite these.
+	const poison = "poison-stamp-6201"
+	m := diff.LoadManifest(stateDir)
+	for _, rel := range stable {
+		e := m.Files[rel]
+		e.SHA256 = poison
+		m.Files[rel] = e
+	}
+	// Record the pre-pass stamps of the dirty files so we can prove they WERE
+	// refreshed (the #5668 loop guard).
+	preDirty := make(map[string]string, nDirty)
+	for _, rel := range dirty {
+		preDirty[rel] = m.Files[rel].SHA256
+	}
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("save poisoned manifest: %v", err)
+	}
+
+	// Dirty 5 files in the working tree → 5 > limit 3 → too-many-changed.
+	for i, rel := range dirty {
+		writeFile(t, repo, rel, fmt.Sprintf("package p\n\nfunc Dirty%02d() { _ = %d }\n", i, i+1))
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if res.Done {
+		t.Fatalf("expected a too-many-changed fallback, got Done=true")
+	}
+
+	after := diff.LoadManifest(stateDir)
+
+	// PROPERTY 1 — no full-repo SHA-256 sweep. Every clean file's poison stamp
+	// must have survived: hashing it is work the reject path has no use for.
+	swept := 0
+	for _, rel := range stable {
+		e, ok := after.Files[rel]
+		if !ok {
+			t.Fatalf("clean file %s was pruned from the manifest by the reject path", rel)
+		}
+		if e.SHA256 != poison {
+			swept++
+		}
+	}
+	if swept != 0 {
+		t.Fatalf("reject path hashed %d/%d provably-clean files (poison stamp overwritten) — "+
+			"the too-many-changed check still runs AFTER the full-repo SHA-256 sweep it "+
+			"immediately discards (#6201)", swept, nStable)
+	}
+
+	// PROPERTY 2 — the #5668 loop guard survives. The files that really did
+	// change must have their stamps refreshed and persisted, or the next pass
+	// re-trips this fallback forever.
+	for _, rel := range dirty {
+		e, ok := after.Files[rel]
+		if !ok {
+			t.Fatalf("changed file %s missing from the reconciled manifest", rel)
+		}
+		if e.SHA256 == preDirty[rel] || e.SHA256 == "" {
+			t.Fatalf("changed file %s kept its stale stamp %q — the #5668 reindex loop guard "+
+				"was dropped along with the sweep", rel, e.SHA256)
+		}
+	}
+}
+
+// TestIncremental_CeilingScalesWithRepoSize is the #6201 regression test for the
+// second defect: the trigger ceiling sat ~25x below the measured crossover.
+//
+// The shipped ceiling was a flat 20 (feature branch) / 50 (default branch),
+// independent of repo size. Refit against the measured medians on a 3003-file /
+// 58.5k-entity fixture (see incrementalFilesDivisor for the arithmetic):
+// 1536 ms fixed + 7.42 ms per changed file, against a 9,540 ms full reindex —
+// incremental stops winning near 1078 changed files, i.e. ~0.36 of the repo.
+// The flat constants therefore reject work that is 3-5x cheaper than the
+// fallback they trigger.
+//
+// This pins the proportional term specifically: a 240-file repo must accept a
+// 60-file delta, which the flat feature-branch ceiling of 20 rejects. The
+// fixture is a plain (non-git) temp dir, so gitmeta.IsDefaultBranch is false and
+// the floor is the feature-branch 20 — that makes 60 unambiguously a product of
+// the repo-size term and not of a raised constant.
+func TestIncremental_CeilingScalesWithRepoSize(t *testing.T) {
+	isolateHome(t)
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "") // no override: exercise the real ceiling
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	const nFiles = 240
+	const nChanged = 60 // == nFiles/4, the derived ceiling; > the flat floor of 20
+
+	for i := 0; i < nFiles; i++ {
+		writeFile(t, repo, fmt.Sprintf("f%03d.go", i),
+			fmt.Sprintf("package p\n\nfunc F%03d() {}\n", i))
+	}
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F000", "f000.go"),
+			Name: "F000", Kind: "SCOPE.Operation", SourceFile: "f000.go", Language: "go"},
+	}, nil)
+	seedManifest(t, repo, stateDir)
+
+	for i := 0; i < nChanged; i++ {
+		writeFile(t, repo, fmt.Sprintf("f%03d.go", i),
+			fmt.Sprintf("package p\n\nfunc F%03d() { _ = %d }\n", i, i+1))
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if !res.Done {
+		t.Fatalf("a %d-file delta on a %d-file repo fell back (reason=%q); the ceiling must "+
+			"scale with repo size — the measured crossover is ~0.43x the walked file count, "+
+			"not a flat 20/50 (#6201)", nChanged, nFiles, res.FallbackReason)
+	}
+	if res.ChangedFiles != nChanged {
+		t.Fatalf("ChangedFiles = %d, want %d", res.ChangedFiles, nChanged)
+	}
+}
+
+// TestIncremental_LowOverrideIsHonouredOnLargeRepo pins the invariant that the
+// repo-size ratio must NOT be maxed against an explicit operator override.
+//
+// effectiveLimit documents the overrides as honoured verbatim, but until this
+// test nothing could fail if they were not. Every pre-existing override test
+// (incremental_test.go:580, env=5 on 8 files; the reject-path test above, env=3
+// on 11 files) runs on a repo small enough that walkedFiles/4 is BELOW the
+// override — so `return n` and `return max(n, walkedFiles/4)` are
+// indistinguishable there, and a reordering of the expression survives the
+// whole suite.
+//
+// The scenario this protects is concrete: an operator pins
+// GRAFEL_INCREMENTAL_MAX_FILES=5 on a 4,000-file repo to bound a pass during an
+// incident. If the ratio is ever allowed to win, they silently get 1,000
+// instead of 5, and nothing goes red.
+//
+// Fixture: 240 files (ratio → 60), override → 5, delta → 60. Correct behaviour
+// rejects at limit=5. A ratio-wins mutant computes limit=60, does not reject,
+// and returns Done — so the assertion is on the DECISION, and the limit value
+// is pinned in the fallback reason so a mutant that rejects for a different
+// reason cannot pass either.
+func TestIncremental_LowOverrideIsHonouredOnLargeRepo(t *testing.T) {
+	const nFiles = 240
+	const nChanged = 60 // == nFiles/4, the ratio's value; deliberately > override
+	const override = 5
+
+	// Both override channels carry the same documented promise, and priority 1
+	// (cfg) is not reachable through the env var, so drive each separately.
+	for _, tc := range []struct {
+		name   string
+		useCfg bool
+	}{
+		{"env_var", false},
+		{"cfg_channel", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			isolateHome(t)
+
+			var cfg *extractor.ExtractorConfig
+			if tc.useCfg {
+				t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "")
+				cfg = &extractor.ExtractorConfig{IncrementalMaxFiles: override}
+			} else {
+				t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", fmt.Sprint(override))
+			}
+
+			repo := t.TempDir()
+			stateDir := t.TempDir()
+			for i := 0; i < nFiles; i++ {
+				writeFile(t, repo, fmt.Sprintf("f%03d.go", i),
+					fmt.Sprintf("package p\n\nfunc F%03d() {}\n", i))
+			}
+			buildMinimalGraph(t, stateDir, []graph.Entity{
+				{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F000", "f000.go"),
+					Name: "F000", Kind: "SCOPE.Operation", SourceFile: "f000.go", Language: "go"},
+			}, nil)
+			seedManifest(t, repo, stateDir)
+
+			for i := 0; i < nChanged; i++ {
+				writeFile(t, repo, fmt.Sprintf("f%03d.go", i),
+					fmt.Sprintf("package p\n\nfunc F%03d() { _ = %d }\n", i, i+1))
+			}
+
+			res := extractors.TryIncremental(context.Background(), repo, stateDir,
+				log.New(io.Discard, "", 0), cfg)
+
+			if res.Done {
+				t.Fatalf("a %d-file delta completed under an explicit override of %d on a "+
+					"%d-file repo: the repo-size ratio (%d) overrode the operator's pinned "+
+					"limit. An override is a ceiling the operator chose; the ratio must never "+
+					"raise it (#6201)", nChanged, override, nFiles, nFiles/4)
+			}
+			want := fmt.Sprintf("limit=%d", override)
+			if !strings.Contains(res.FallbackReason, want) {
+				t.Fatalf("fallback reason = %q, want it to report %q — the reject must be "+
+					"attributed to the operator's override, not to some other limit",
+					res.FallbackReason, want)
+			}
+		})
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -206,12 +206,41 @@ func Filter(absRepo string, relPaths []string, manifest *Manifest) (changed, unc
 // UpdateManifest records the current on-disk state for every file in
 // relPaths into m. Call this after a successful index write so the next
 // incremental run has accurate baseline hashes.
+//
+// This is the O(repo) form: it opens and SHA-256s every path it is given. Use
+// it where the caller has just processed the whole repo anyway. A caller that
+// already knows which files changed — and is about to discard the graph work,
+// not commit it — wants UpdateManifestScoped instead (#6201).
 func UpdateManifest(absRepo string, relPaths []string, m *Manifest) {
+	UpdateManifestScoped(absRepo, relPaths, relPaths, m)
+}
+
+// UpdateManifestScoped re-stamps only hashPaths, while reconciling manifest
+// MEMBERSHIP against keepPaths.
+//
+// The split exists because the two halves of UpdateManifest have wildly
+// different costs and only one of them is always needed (#6201):
+//
+//   - Re-stamping is O(files hashed) and requires reading each file. On a
+//     3003-file fixture the full-repo sweep measured ~220 ms of the 696 ms that
+//     the too-many-changed reject path used to burn and then throw away.
+//   - The membership prune is a pair of map walks — effectively free — and it
+//     is the half that #5667 needs: an entry for a file no longer in the
+//     gitignore-aware walk is otherwise immortal, is reported as "deleted" on
+//     every pass, perpetually trips the too-many-changed fallback, and pins the
+//     daemon in a reindex loop.
+//
+// Passing the changed-file set as hashPaths and the full walk as keepPaths
+// therefore keeps both loop guards (#5667's prune and #5668's stamp refresh for
+// the files that actually moved) at O(delta) instead of O(repo). Files in
+// keepPaths but not hashPaths keep whatever stamp they already had, which is
+// correct precisely because the caller has established they did not change.
+func UpdateManifestScoped(absRepo string, hashPaths, keepPaths []string, m *Manifest) {
 	var mu sync.Mutex
 	// Best-effort parallel hash for large repos.
 	sem := make(chan struct{}, 16)
 	var wg sync.WaitGroup
-	for _, rel := range relPaths {
+	for _, rel := range hashPaths {
 		wg.Add(1)
 		go func(r string) {
 			defer wg.Done()
@@ -232,12 +261,12 @@ func UpdateManifest(absRepo string, relPaths []string, m *Manifest) {
 	// Reconcile (#5667): drop entries for files no longer in the walked set so
 	// the manifest cannot retain stale records — e.g. a file that became
 	// gitignored (build artifacts now excluded by walk.WalkRepo). All callers
-	// pass the complete current walk, so membership in relPaths is
+	// pass the complete current walk as keepPaths, so membership in it is
 	// authoritative. Without this prune an entry, once added, is immortal: a
 	// now-ignored file is reported as "deleted" on every pass, perpetually
 	// tripping the too-many-changed full-reindex fallback and pinning the daemon.
-	want := make(map[string]struct{}, len(relPaths))
-	for _, r := range relPaths {
+	want := make(map[string]struct{}, len(keepPaths))
+	for _, r := range keepPaths {
 		want[r] = struct{}{}
 	}
 	for k := range m.Files {


### PR DESCRIPTION
Measured under #6199: at one changed file an incremental pass costs 1576 ms, of which **35 ms** is extracting the file. 92% of the pass is delta-independent. This fixes the two defects at the reject boundary; the fixed tail itself is separate work.

## The reject cost more than never having tried

The `too-many-changed` check fired *after* the tree walk, the git diff, a full SHA-256 sweep of every file and a manifest save. Measured on a 3003-file / 58.5k-entity fixture:

```
200 changed files, as shipped:   696 ms (rejected) + 9,540 ms (full reindex) = 10,236 ms
200 changed files, full reindex alone:                                          9,540 ms
```

**A rejected pass cost 7% more than not attempting one**, and the ceiling was 50 (default branch) / 20 (feature branch) against a crossover near a thousand files — so it rejected constantly.

## The issue's proposed fix was wrong, and finding that out is most of this change

#6201 said to delete the reject-path manifest write, on the reasoning that the full reindex rewrites it. **It does not.** `cmd/grafel/daemon.go:1336` `daemonSchedulerIndex` never sets `IncrementalStateDir` — neither its subprocess branch nor its in-process branch — so the fallback runs with `i.incremental=false` and `cmd/grafel/index.go:2393` writes nothing. The only site that sets it is `daemon.go:2108`, the user-initiated rebuild, not the scheduler's fallback. `TryIncremental` has exactly one non-test caller.

So the manifest on that path is advanced *only* by `TryIncremental` itself, and deleting the write would have re-entered the same reject on every pass with nothing to break the loop. Two existing regression tests already pin it — `TestTryIncremental_FlushesStaleManifest_NoLoop` (#5667) is named for precisely that failure — and both go red when it is removed.

The fix therefore removes the **cost** and keeps the **guard**: `diff.UpdateManifest` split into `UpdateManifestScoped(absRepo, hashPaths, keepPaths, m)`, with the reject passing `changedFiles` to hash and `allFiles` to keep. It never opens a file already proved clean. #5667's prune is a map walk; #5668's stamp refresh is exactly the delta.

**Why that is not a correctness regression, argued rather than probed.** `UpdateManifest(absRepo, X, m) ≡ UpdateManifestScoped(absRepo, X, X, m)`. The reject calls `Scoped(changed, all)` with `changed ⊆ all`. The membership half is byte-identical — same `keepPaths` — and the stamping half writes a strict subset of the entries the old call wrote. So the set of files claimed clean-at-current-content is a **strict subset** of what the old code claimed: a scoped reconcile cannot introduce a false-clean the full sweep did not already make. Every residual case lands on the over-reporting side (a redundant re-extraction), never under-reporting (a stale graph).

## The ceiling is a ratio, because a constant is what produced the error

`max(20|50, walkedFiles/4)`. Both sides of the crossover scale with the repo, so the bound had to as well; the old constants were size-blind, which is why they sat ~20× below the real crossover.

The model is refitted against the measured medians rather than carried over from the issue body, which under-predicted every point:

| fit | slope | intercept | crossover | ×walk |
|---|---|---|---|---|
| OLS over all four medians | 7.42 ms/file | 1536 ms | 1078 files | 0.359 |
| two-point over the extremes | 7.41 | 1569 | 1075 | 0.358 |

Residuals `+33 / +13 / −74 / +28` ms, worst 2.5%, and both methods agree — so the fit is not an artifact. The issue's `1451 + 6.26` was ~16% too shallow in slope and put the crossover ~20% too high.

Divisor 4 is unchanged, since 0.25× sits below both crossovers, but **the margin is restated honestly: 30% below 0.359 and 1.44× density headroom, not the 42% / 1.7× the issue claimed.** The margin is the entire justification for the divisor, so an inflated one is not a cosmetic error. Corrected in the constant's comment, in the test doc comment that had copied it, and here.

Heap was re-measured at the new ceiling rather than assumed: a 1200-file fixture with ceiling 300, at 1 / 50 / 300 changed files, gives HeapSys 93.1 / 94.3 / 93.3 MB and HeapInuse 58.6 / 42.5 / 65.6 MB — flat across a 300× delta increase. Go heap rather than RSS, because swap was at 9.7 of 11.2 GB and RSS under that pressure means nothing.

## Two claims settled rather than deferred

**The check cannot be hoisted ahead of the tree walk.** `internal/indexer/diff/diff.go:389-408` computes the changed set as `gitChanged ∩ walkedPaths` and then expands it by basename-stem invalidation over every walked path; `incremental.go:281-292` defines deleted files as manifest-minus-walk. The git diff alone gives neither an upper bound (it holds non-source paths the walk excludes) nor a lower bound (stem invalidation adds files git never mentioned). The walk is a genuine prerequisite.

**The second `UpdateManifestScoped` call site is unreachable.** The first gate establishes `totalChanged ≤ limit`; the AST-hash loop appends each element of `changedFiles` at most once and nothing between the gates reassigns `limit`, `changedFiles`, `deletedFiles` or `totalChanged`, so `len(reallyChanged) ≤ limit` always. Confirmed empirically — a `panic()` at the branch head survives `internal/extractors/...`, `internal/indexer/diff/...` and `cmd/grafel` (which drives `TryIncremental` end to end). Pre-existing, so it is not deleted here; the misleading comment claiming it satisfies #5667/#5668 is replaced with the proof and an explicit "this is dead code, NOT a live guard."

## Tests

Each pins observable work performed, never elapsed time — a timing assertion here would be the test-that-cannot-fail shape this repo keeps producing.

- **The reject performs no sweep and no full manifest write.** Asserts on the manifest's `SHA256` field for files that are committed, untouched, git-clean and given distinct basename stems so `moduleBase` cross-file invalidation cannot drag them in. The stamp *is* the hash output, so it observes hashing directly rather than a correlate.
- **The ceiling scales with repo size** — a 60-file delta on a 240-file repo must complete rather than fall back.
- **A low operator override is honoured on a large repo** — 240 files (ratio → 60), override → 5, delta → 60. Added because review found the "overrides are honoured verbatim" invariant had a **surviving mutant**: every existing override test used a 6–11 file repo where `walkedFiles/4` was already below the override, so the ratio could never have won and the mutation was unobservable. Run as two subtests (env var and `cfg.IncrementalMaxFiles`) since the priority-1 channel is not reachable through the env. It asserts the fallback *reason* reports `limit=5`, so a mutant that rejects for a different reason cannot pass either.

Mutation battery: 10 run by the implementer plus 3 added independently in review. Killed — scoped→full at the live site, ratio term deleted, manifest write deleted (dies on #5667 and #5668 as well), `keepPaths` nilled, floor inverted into a ceiling, prune against `hashPaths`, prune loop deleted, divisor 4→1, and the override-reordering mutant above. Reported as equivalent rather than banked: the dead second call site, and divisor 4→2 (only a lower bound is pinned).

## Not fixed here

`FilterWithGit:430-441`'s basename-stem inflation still makes a 1-file edit present as ~40, so the effective ceiling stays below the nominal one — mitigated by the higher ceiling rather than depended on. The `totalChanged == 0` no-op still pays a full-repo sweep to conclude nothing happened (738 ms, #6199's cheapest remaining win); its comment now records that it is **also** the healing path for the residual entries a scoped reject leaves behind, and names two ways to keep that healing when it is removed. And the scheduler's fallback not writing a manifest is the root cause of why the reject needs loop guards at all — fixing it means either making the "full" reindex diff-aware, which is wrong, or reconciling post-index in `daemonSchedulerIndex`. Separate change, separate risk.

Two false in-tree performance claims are corrected: `incremental.go:6-9` said a 60k-entity full index is ~5 s and one changed file ~200 ms (measured 9.5 s and 1576 ms), and `extractor/extractor.go:136` claimed ~25× faster (measured 6.0× at one file, 4.9× at fifty). They are the reason nobody looked here.

Independently adversarially reviewed (APPROVE), with the reviewer re-running the mutation battery itself and adding three mutants of its own.

Closes #6201
Refs #6199, #6180
