### PR TITLE
fix(#6207): the indexer could not record what it indexed without also indexing only the delta

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1350,22 +1350,60 @@ func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) erro
 				"state_dir", stateDir, "err", cerr)
 		}
 	}()
+	// #6207 — POST-INDEX RECONCILE. This is a FULL index, and it must stay one:
+	// it is reached when the incremental pass declined, i.e. precisely when the
+	// delta could not be trusted, so it is never given --incremental /
+	// WithIncremental. But a full index establishes ground truth for every file
+	// in the repo, which is exactly what the manifest records — so it now
+	// records it.
+	//
+	// Before this, neither branch below asked for a manifest, i.incremental
+	// stayed false and index.go skipped the write entirely. The manifest on the
+	// scheduler path was therefore advanced only by TryIncremental, which is
+	// why its reject path has to carry loop guards (#5667, #5668) to stop the
+	// identical changed set re-presenting on every subsequent pass.
+	//
+	// NEITHER BRANCH NAMES A DESTINATION, and `stateDir` above deliberately is
+	// not one. stateDir is resolved from `ref`, the ref captured at ENQUEUE
+	// time; the graph is written wherever gitmeta resolves HEAD at INDEX time
+	// (the `_ = ref` comment below has always said so). A checkout landing in
+	// that window would put the manifest and the graph it describes under
+	// different refs — one branch left with no baseline, the other with a
+	// manifest stamped from the wrong branch. The indexer writes the manifest
+	// beside its own graph instead, so the two cannot diverge by construction.
+	//
+	// The sweep is O(repo) hashing on a path that has just spent seconds
+	// parsing that same repo — noise here, as opposed to ~30% of a 738 ms
+	// no-op, which is where the equivalent sweep currently lands (#6206).
 	if sched.SubprocessIndexEnabled() {
 		// S5 path: fork-exec `grafel index-internal` for memory isolation.
-		var opts *sched.SubprocessIndexOptions
+		//
+		// THE CHILD WRITES THE MANIFEST, not the parent. The child owns the walk
+		// — the gitignore-aware traversal, the extension filters, the skipped
+		// files — so it is the only side that knows the set that was actually
+		// indexed. Re-deriving that set in the parent means a second walk that
+		// has to reproduce every one of those filters and will drift the first
+		// time one of them changes, and it would decouple the manifest from the
+		// graph generation the child wrote: a manifest claiming files the graph
+		// does not contain is worse than no manifest at all. The child is also
+		// the only side that can ORDER the manifest write after its own graph
+		// write, which is what stops a failed graph write from publishing a
+		// manifest for a graph that never landed.
+		opts := &sched.SubprocessIndexOptions{PersistManifest: true}
 		if repoTag != "" {
 			// RepoSlug is forwarded to the child as --repo-tag. No publisher is
 			// set, so no other subprocess flag changes.
-			opts = &sched.SubprocessIndexOptions{RepoSlug: repoTag}
+			opts.RepoSlug = repoTag
 		}
-		err = sched.RunSubprocessIndex(ctx, repoPath, ref, []string{"graph-algo"}, opts, slog.Default())
+		err = subprocessIndexRunner(ctx, repoPath, ref, []string{"graph-algo"}, opts, slog.Default())
 	} else {
 		// In-process path (opt-out via GRAFEL_SUBPROCESS_INDEXER=0).
 		// ADR-0016 flip-day (#808): graph.fb is always written by default now.
 		// ref is stored via StateDirForRepo → StateDirForRepoRef at write time;
 		// the indexer itself resolves the correct path via gitmeta at index time.
 		_ = ref
-		err = Index(repoPath, "", repoTag, []string{"graph-algo"}, false, false)
+		err = Index(repoPath, "", repoTag, []string{"graph-algo"}, false, false,
+			WithManifestPersist())
 	}
 	// Drop the cached mmap so the next MCP query reopens against the
 	// freshly written graph.fb. Done on both success and failure paths
@@ -1375,6 +1413,13 @@ func daemonSchedulerIndex(ctx context.Context, repoPath string, ref string) erro
 	tierAfterIndex(repoPath, ref)
 	return err
 }
+
+// subprocessIndexRunner is the fork-exec used by daemonSchedulerIndex. A var
+// solely so a test can drive the child's real entrypoint with the parent's real
+// argv (see sched.SubprocessIndexArgs) instead of forking a binary a test
+// binary does not contain — which is the only way to assert on what the child
+// WRITES rather than on which flags it was handed.
+var subprocessIndexRunner = sched.RunSubprocessIndex
 
 // subprocessLinksRunner is the fork-exec used by daemonSchedulerLinks. A var
 // solely so a test can observe that the scheduler path forks (and that the

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -277,13 +277,33 @@ type Indexer struct {
 	// trust-model rules in docs/specs/repair-trust-model.md.
 	enableRepairApply bool
 
-	// incremental enables diff-aware re-indexing (issue #1339). When true the
-	// indexer loads the per-repo file-hash manifest from incrementalStateDir,
-	// filters the walk result down to only changed files, and updates the
-	// manifest after a successful write. Full rebuild still runs when the
-	// manifest is absent or stale.
+	// BEHAVIOUR AND PERSISTENCE ARE DELIBERATELY SEPARATE FIELDS (#6207). Until
+	// #6207 a single pair set together by WithIncremental gated BOTH halves at
+	// once, and the conflation was the defect: there was no way to say "record
+	// what this run indexed" without also saying "index only the delta".
+	//
+	// incremental + incrementalStateDir gate diff-aware BEHAVIOUR (issue
+	// #1339): load the manifest from incrementalStateDir, filter the walk down
+	// to changed files, stream in the previous graph from the same dir and
+	// carry forward the unchanged-file entities. Both are needed; neither is
+	// meaningful alone. Set only by WithIncremental.
+	//
+	// persistManifest gates manifest PERSISTENCE on its own, with no state dir
+	// of its own — see WithManifestPersist for why it takes no directory.
+	// persistManifest && !incremental is the scheduler's fallback full index:
+	// index EVERYTHING, then record ground truth for every file. That is not a
+	// contradiction — it is what a full reindex has just earned the right to
+	// write.
 	incremental         bool
-	incrementalStateDir string // directory that holds file-index.json
+	incrementalStateDir string // directory that holds file-index.json + graph.fb
+	persistManifest     bool
+
+	// walkedFiles + diffManifest are handed from Run to commitManifest. They
+	// exist because the manifest can only be written once graph.fb is durably
+	// on disk, and that write happens in Index AFTER Run has returned — see
+	// commitManifest for the failure mode that ordering prevents.
+	walkedFiles  []string
+	diffManifest *idiff.Manifest
 
 	// incrementalCarryForwardEntities holds the previous-graph entities sourced
 	// from UNCHANGED files during an incremental reindex. buildDocument seeds the
@@ -526,6 +546,40 @@ func WithIncremental(stateDir string) IndexOption {
 	return func(i *Indexer) {
 		i.incremental = true
 		i.incrementalStateDir = stateDir
+		i.persistManifest = true
+	}
+}
+
+// WithManifestPersist makes this run record what it indexed — a complete
+// file-hash manifest — WITHOUT enabling diff-aware re-indexing (#6207). Every
+// file is walked, parsed and indexed exactly as on any full index; the only
+// thing that changes is that the next incremental pass is left a baseline.
+//
+// IT TAKES NO DIRECTORY, ON PURPOSE. The manifest is written beside the graph
+// this run produced — filepath.Dir(outPath), the same expression Index uses for
+// every other artifact — and a caller cannot point it somewhere else. An
+// earlier version of this option took a state dir and the scheduler passed it
+// the ref captured at ENQUEUE time, while the graph landed under whatever HEAD
+// resolved to at INDEX time; a `git checkout` in that window put the manifest
+// and the graph it describes in different ref directories, leaving one branch
+// with no baseline and the other with a manifest stamped from the wrong branch.
+// The manifest describes the graph; it is not separately addressable.
+//
+// This option exists because WithIncremental used to be the only way to get a
+// manifest written at all, and it buys persistence at the price of behaviour.
+// The scheduler's fallback full index needs exactly the opposite trade: it fell
+// back BECAUSE the delta could not be trusted incrementally, so it must not be
+// diff-aware — but it is precisely the run whose output the manifest should
+// describe, because it has just re-established ground truth for the whole repo.
+//
+// Before this option existed, daemonSchedulerIndex set nothing, so the fallback
+// wrote no manifest and the manifest on the scheduler path was advanced only by
+// TryIncremental — including on the passes where it declined to do any work,
+// which is why the reject path had to carry loop guards (#5667, #5668) to
+// compensate.
+func WithManifestPersist() IndexOption {
+	return func(i *Indexer) {
+		i.persistManifest = true
 	}
 }
 
@@ -746,8 +800,8 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	// emitted RENAMED_FROM edges are included in graph.fb / graph.json.
 	// The pass is append-only and safe to skip with --skip-pass=rename-detect.
 	if !skipSet[PassRenameDetect] {
-		stateDir := filepath.Dir(outPath)
-		if prevDoc, err := graph.LoadGraphFromDir(stateDir); err == nil {
+		graphDir := filepath.Dir(outPath)
+		if prevDoc, err := graph.LoadGraphFromDir(graphDir); err == nil {
 			renameStats = algorithms.DetectRenamesBounded(prevDoc, doc, renameWorkBudget())
 			if renameStats.Renames > 0 {
 				fmt.Fprintf(os.Stderr,
@@ -790,8 +844,8 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 	// un-annotated until the next full algo pass runs — never worse than the
 	// pre-fix behaviour where ALL entities lost their community.
 	if skipSet[PassGraphAlgo] {
-		stateDir := filepath.Dir(outPath)
-		if prevDoc, perr := graph.LoadGraphFromDir(stateDir); perr == nil && prevDoc != nil {
+		graphDir := filepath.Dir(outPath)
+		if prevDoc, perr := graph.LoadGraphFromDir(graphDir); perr == nil && prevDoc != nil {
 			carryForwardAlgoAttrs(doc, prevDoc)
 		}
 	}
@@ -808,7 +862,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		// #5891 gen layout: write a NEW graph.<gen>.fb + flip the `current`
 		// pointer instead of overwriting a fixed graph.fb. fbPath is the gen
 		// file actually written (used below for the identical-mtime stamp).
-		fbPath, fbErr := fbwriter.WriteGraphGen(filepath.Dir(outPath), doc)
+		fbPath, fbErr := writeGraphGen(filepath.Dir(outPath), doc)
 		if fbErr != nil {
 			fmt.Fprintf(os.Stderr, "grafel: graph.fb write failed: %v\n", fbErr)
 			// Non-fatal — we still try to write graph.json so the system
@@ -816,6 +870,11 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			// propagates below.
 		} else {
 			fmt.Fprintf(os.Stderr, "grafel: wrote %s\n", fbPath)
+			// #6207 — the manifest is committed HERE, and only here: the graph
+			// it describes is now durably on disk and the `current` pointer has
+			// been flipped to it. Everything above this line is best-effort
+			// work that can still be thrown away.
+			idx.commitManifest(absRepo, filepath.Dir(outPath))
 		}
 
 		// #5720 — the graph is now loadable/queryable (graph.fb is on disk),
@@ -939,6 +998,99 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 // either thread the buffer through explicitly or move stats capture
 // into Indexer state. For Phase A the single-writer assumption holds.
 var capturedStats io.Writer
+
+// writeGraphGen is fbwriter.WriteGraphGen behind a var so a test can make the
+// graph write FAIL — the failure this file's manifest ordering exists to
+// survive (#6207). The write is non-fatal by design, so there is no error
+// return to inject through and no other way to reach that branch.
+var writeGraphGen = fbwriter.WriteGraphGen
+
+// commitManifest persists the file-hash manifest describing THIS run: every
+// walked file, re-stamped, with entries for anything no longer in the walk
+// pruned. Best-effort — a write failure is logged and never fails the index.
+//
+// ORDERING IS THE POINT (#6207 review). Index calls this only on the success
+// branch of fbwriter.WriteGraphGen, never from Run. Run returns before the
+// graph is written, and that write is explicitly non-fatal — it can fail on a
+// full disk, on EPERM, on a #5891 generation-pointer flip, or simply not happen
+// because the index-internal child was SIGKILLed by a ctx cancel (which
+// subprocess_runner is emphatic gives the child no chance to clean up).
+//
+// Writing the manifest before that point creates a PERMANENT stuck state on the
+// daemon's automatic healing path. The manifest would say every file is
+// indexed; the graph would still be the previous generation. The next
+// scheduler pass computes totalChanged == 0, and the #5710 absent-graph guard
+// fires on ABSENCE only — the previous generation's graph.fb is still there and
+// `current` still points at it — so TryIncremental reports Done over a
+// permanently stale graph. Before #6207 the manifest was simply untouched on
+// that path, the same changed set re-presented on the next pass, and it healed
+// itself.
+//
+// The residual window has TWO axes and they point in opposite directions. Do
+// not read the first as covering the second.
+//
+// GENERATION: killed between the graph write and this call, the graph is newer
+// than the manifest. That is the safe direction, and the same one #6201's
+// scoped reject leaves behind — the files re-read as changed and are
+// re-extracted. Over-reporting, never staleness.
+//
+// CONTENT: per file, the manifest can be newer than the graph, and here the
+// hazard is real. UpdateManifest hashes each file AT THIS MOMENT, whereas the
+// document was built from the bytes Run's walk read. A working-tree write
+// landing in between is stamped into the manifest but is not in the graph, so
+// the next pass hash-matches it, classifies it UNCHANGED (diff.go:411-413) and
+// the edit stays invisible until the file is touched again or HEAD advances.
+// Measured, not theorised: a probe injecting a working-tree write inside the
+// writeGraphGen seam confirmed the manifest stamps post-walk content. The
+// realistic trigger is exactly the watcher-driven fallback — it fires BECAUSE
+// files are changing.
+//
+// This is pre-existing on the WithIncremental path but NEW on the fallback,
+// which previously wrote no manifest at all, so the old stamp caught the edit.
+// The window also got wider on both: it now spans rename-detect, algo
+// carry-forward, sortDocumentForEmission and the whole of WriteGraphGen —
+// seconds on a real repo, where it used to be immediately post-extraction.
+//
+// It is nevertheless the RIGHT TRADE and must not be reverted: losing one edit
+// until its next touch is self-recovering, while the permanent stuck state
+// above is not. The real fix — stamping from the hashes the walk already
+// computed, so the manifest describes the same bytes the graph was built from —
+// is filed separately.
+//
+// graphDir is filepath.Dir(outPath) — the directory the graph was just written
+// to. It is the destination whenever the run did not read a manifest from
+// somewhere else, so a manifest can never describe a graph in another
+// directory. See WithManifestPersist for the ref-divergence that motivates it.
+//
+// KNOWN, PRE-EXISTING (#6207 review, to be filed): walkedFiles is the raw walk,
+// so a file whose EXTRACTION failed is still stamped as indexed and will not be
+// re-extracted until its bytes change. The consequence is a missing entity set,
+// not a stuck loop. This was already true on the WithIncremental path; #6207
+// makes it reachable from the fallback too.
+func (i *Indexer) commitManifest(absRepo, graphDir string) {
+	if !i.persistManifest {
+		return
+	}
+	dest := i.incrementalStateDir
+	if dest == "" {
+		dest = graphDir
+	}
+	if dest == "" {
+		return
+	}
+	m := i.diffManifest
+	if m == nil {
+		// A full index never loaded one. Start from whatever is on disk — the
+		// UpdateManifest below re-stamps every walked file and prunes
+		// everything else, so the result is the walk either way; loading only
+		// keeps the manifest's own metadata continuous.
+		m = idiff.LoadManifest(dest)
+	}
+	idiff.UpdateManifest(absRepo, i.walkedFiles, m)
+	if err := idiff.SaveManifest(dest, absRepo, m); err != nil {
+		fmt.Fprintf(os.Stderr, "grafel: save incremental manifest: %v (non-fatal)\n", err)
+	}
+}
 
 func setCapturedStats(w io.Writer) (restore func()) {
 	prev := capturedStats
@@ -1196,6 +1348,11 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// The stream owns an mmap for the lifetime of the run; release it on every
 	// exit path. Nil-safe, so this is correct on the full-index path too.
 	defer func() { _ = incrementalPrev.Close() }()
+	// This block is the diff-aware BEHAVIOUR half, and #6207 left its condition
+	// exactly as it was: reading a manifest to filter the walk genuinely needs
+	// both the flag and a dir to read from. What #6207 changed is the other
+	// half — persistence no longer requires passing through here (see
+	// commitManifest), so a full index can record what it indexed.
 	if i.incremental && i.incrementalStateDir != "" {
 		diffManifest = idiff.LoadManifest(i.incrementalStateDir)
 		changed, unchanged := idiff.FilterWithGit(absRepo, files, diffManifest)
@@ -2385,17 +2542,13 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		printRelBreakdown(os.Stderr, i.stats.pass3RelsByExt, "pass3")
 	}
 
-	// Incremental mode (issue #1339): persist the updated file-hash manifest
-	// so the next incremental run can skip unchanged files. We update all
-	// files (changed + unchanged) so the manifest stays complete even when
-	// only a subset was re-extracted this run. Best-effort: a write failure
-	// is logged but never fails the index.
-	if i.incremental && diffManifest != nil {
-		idiff.UpdateManifest(absRepo, allFiles, diffManifest)
-		if err := idiff.SaveManifest(i.incrementalStateDir, absRepo, diffManifest); err != nil {
-			fmt.Fprintf(os.Stderr, "grafel: save incremental manifest: %v (non-fatal)\n", err)
-		}
-	}
+	// THE MANIFEST IS NOT WRITTEN HERE. Run does not write it at all — it only
+	// hands the walk and the loaded manifest to commitManifest, which Index
+	// calls after graph.fb is durably on disk. Run returns BEFORE the graph is
+	// written, so writing here would publish a manifest describing a graph that
+	// might never land. See commitManifest for the stuck state that causes.
+	i.walkedFiles = allFiles
+	i.diffManifest = diffManifest
 
 	// Issue #2341 — sanity-check: warn when entities with a recognized source
 	// extension have an empty Language tag. A non-zero count here means the

--- a/cmd/grafel/index_internal.go
+++ b/cmd/grafel/index_internal.go
@@ -35,18 +35,19 @@ func runIndexInternal(argv []string) int {
 	fs.SetOutput(os.Stderr)
 
 	var (
-		repo         = fs.String("repo", "", "absolute path of the repository to index (required)")
-		ref          = fs.String("ref", "", "git ref captured at enqueue time; passed as hint only (may be empty)")
-		out          = fs.String("out", "", "output directory for graph.fb; defaults to daemon store layout")
-		repoTag      = fs.String("repo-tag", "", "slug written into every graph entity (defaults to dir basename)")
-		skipPasses   = fs.String("skip-pass", "", "comma-separated list of pass names to skip")
-		exportJSON   = fs.Bool("export-json", false, "also emit graph.json alongside graph.fb")
-		ingestDocs   = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md and *.pdf files as Document/Section nodes + exact-mention links (no LLM, no network)")
-		emitProgress = fs.Bool("emit-progress", false, "stream per-module progress.Event JSON lines on stdout for the parent to republish (rebuild / wizard first-index)")
-		groupSlug    = fs.String("group-slug", "", "group slug stamped on progress events when --emit-progress is set")
-		runToken     = fs.String("run-token", "", "per-run identity (RebuildArgs.ProgressToken) stamped on progress events when --emit-progress is set (#5937)")
-		interactive  = fs.Bool("interactive", false, "run at the foreground GRAFEL_REBUILD_GOMAXPROCS extract cap (human-awaited rebuild) instead of the background cap")
-		incremental  = fs.String("incremental", "", "state dir enabling diff-aware re-indexing (matches WithIncremental); empty = full index")
+		repo            = fs.String("repo", "", "absolute path of the repository to index (required)")
+		ref             = fs.String("ref", "", "git ref captured at enqueue time; passed as hint only (may be empty)")
+		out             = fs.String("out", "", "output directory for graph.fb; defaults to daemon store layout")
+		repoTag         = fs.String("repo-tag", "", "slug written into every graph entity (defaults to dir basename)")
+		skipPasses      = fs.String("skip-pass", "", "comma-separated list of pass names to skip")
+		exportJSON      = fs.Bool("export-json", false, "also emit graph.json alongside graph.fb")
+		ingestDocs      = fs.Bool("ingest-docs", false, "opt-in: deterministically ingest in-repo *.md and *.pdf files as Document/Section nodes + exact-mention links (no LLM, no network)")
+		emitProgress    = fs.Bool("emit-progress", false, "stream per-module progress.Event JSON lines on stdout for the parent to republish (rebuild / wizard first-index)")
+		groupSlug       = fs.String("group-slug", "", "group slug stamped on progress events when --emit-progress is set")
+		runToken        = fs.String("run-token", "", "per-run identity (RebuildArgs.ProgressToken) stamped on progress events when --emit-progress is set (#5937)")
+		interactive     = fs.Bool("interactive", false, "run at the foreground GRAFEL_REBUILD_GOMAXPROCS extract cap (human-awaited rebuild) instead of the background cap")
+		incremental     = fs.String("incremental", "", "state dir enabling diff-aware re-indexing (matches WithIncremental); empty = full index")
+		persistManifest = fs.Bool("persist-manifest", false, "record what this run indexed as a diff manifest beside the graph, without enabling diff-aware re-indexing (matches WithManifestPersist, #6207)")
 	)
 
 	if err := fs.Parse(argv); err != nil {
@@ -94,6 +95,12 @@ func runIndexInternal(argv []string) int {
 	// and stay at the throttled GRAFEL_EXTRACT_GOMAXPROCS default.
 	if *interactive {
 		opts = append(opts, WithInteractive(true))
+	}
+	// #6207: manifest persistence without diff-aware behaviour — the
+	// scheduler's fallback full index. Applied BEFORE --incremental so that if
+	// both are somehow set the superset (behaviour + persistence) wins.
+	if *persistManifest {
+		opts = append(opts, WithManifestPersist())
 	}
 	// Diff-aware re-indexing when the rebuild path requested it.
 	if *incremental != "" {

--- a/cmd/grafel/scheduler_fallback_manifest_6207_test.go
+++ b/cmd/grafel/scheduler_fallback_manifest_6207_test.go
@@ -1,0 +1,469 @@
+package main
+
+// #6207 — the scheduler's fallback full index must leave a COMPLETE, EXACT and
+// CORRECTLY LOCATED diff manifest behind, must write it only once the graph it
+// describes is durably on disk, and must remain a FULL index.
+//
+// `daemonSchedulerIncremental` declines (any reason), the scheduler runs
+// `daemonSchedulerIndex`, and that full index has just established ground truth
+// for every file in the repo. That is exactly what a manifest records, so the
+// manifest must reflect it. Before this change neither branch of
+// daemonSchedulerIndex asked for a manifest, so `i.incremental` stayed false
+// and index.go's write was skipped entirely — the manifest on the scheduler
+// path was advanced ONLY by TryIncremental, including on the passes where it
+// did no work.
+//
+// Every test here drives the REAL path: it makes an incremental pass decline
+// and then runs the fallback the scheduler runs. Assertions are on observable
+// state — the manifest's contents hashed against the bytes on disk, the
+// directory it landed in, and the indexer's own per-run file counts — never on
+// timing.
+//
+// The cold fixture reaches the decline via the #5710 `absent-graph-nonempty-tree`
+// guard: there is no graph.fb yet, which is the ordinary state of a repo the
+// daemon has never indexed. That branch writes no manifest of its own, so
+// anything found in the manifest afterwards came from the fallback and nowhere
+// else — and each test asserts that emptiness before proceeding rather than
+// assuming it.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/sched"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// fallbackFixtureFiles is the repo-relative file set the manifest must account
+// for, EXACTLY. Hand-derived from the fixture rather than from the indexer's
+// own walk, so neither an empty walk nor an over-broad one can satisfy it.
+var fallbackFixtureFiles = []string{"go.mod", "svc/gadget.go", "svc/thing.go", "svc/widget.go"}
+
+// fallbackManifestRepo builds a tiny committed git repo and isolates every
+// state dir the daemon or the indexer might touch. branch selects the branch
+// the fixture is committed on, which matters to the ref-divergence test.
+func fallbackManifestRepo(t *testing.T, name, branch string) (repo string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root := t.TempDir()
+	// Never touch the real ~/.grafel, ~/Library/LaunchAgents or ~/.claude.json.
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "1")
+
+	repo = filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Join(repo, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, repo, "go.mod", "module fallbackfixture\n\ngo 1.21\n")
+	writeFixtureFile(t, repo, "svc/widget.go", "package svc\n\ntype Widget struct{ Name string }\n\nfunc (w *Widget) Render() string { return w.Name }\n")
+	writeFixtureFile(t, repo, "svc/gadget.go", "package svc\n\nfunc Gadget() string { return \"g\" }\n")
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 7 }\n")
+
+	seedGitRun(t, repo, "init", "-q", "-b", branch)
+	seedGitRun(t, repo, "add", "-A")
+	seedGitRun(t, repo, "commit", "-q", "-m", "fixture")
+	return repo
+}
+
+func writeFixtureFile(t *testing.T, repo, rel, body string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(repo, filepath.FromSlash(rel)), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func sha256OfFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// assertManifestExact is the property under test. It is deliberately an
+// EXACTNESS check, not a presence check: the manifest's key set must equal the
+// repo's file set, and every stamp must be the hash of the bytes on disk.
+//
+// Cardinality matters as much as presence. UpdateManifest's prune is the same
+// mechanism as #5667's loop guard — a manifest entry for a file no longer in
+// the gitignore-aware walk is otherwise immortal, is reported "deleted" on
+// every pass, and re-trips the too-many-changed fallback forever. "No stale
+// entry survives" is therefore the most valuable half of this assertion, and a
+// want-list walk alone would never see it.
+func assertManifestExact(t *testing.T, repo, stateDir string) {
+	t.Helper()
+	m := diff.LoadManifest(stateDir)
+	if m == nil || len(m.Files) == 0 {
+		t.Fatalf("the fallback full index wrote NO manifest in %s — the next incremental pass "+
+			"sees the same changed set again, forever (#6207)", stateDir)
+	}
+	got := make([]string, 0, len(m.Files))
+	for k := range m.Files {
+		got = append(got, k)
+	}
+	sort.Strings(got)
+	want := append([]string(nil), fallbackFixtureFiles...)
+	sort.Strings(want)
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("manifest key set is not the repo's file set\n got: %v\nwant: %v\n"+
+			"an extra entry is a stale record that re-presents as \"deleted\" on every pass (#5667); "+
+			"a missing one is a file with no baseline (#6207)", got, want)
+	}
+	for _, rel := range want {
+		wantHash := sha256OfFile(t, filepath.Join(repo, filepath.FromSlash(rel)))
+		if m.Files[rel].SHA256 != wantHash {
+			t.Fatalf("manifest stamp for %q is %q, want the indexed content hash %q — "+
+				"the manifest does not reflect what was indexed (#6207)",
+				rel, m.Files[rel].SHA256, wantHash)
+		}
+	}
+}
+
+// declineIncrementalPass drives the scheduler's incremental callback and
+// requires that it DECLINES for the expected reason. Asserting the reason (not
+// just the decline) keeps the fixture honest: if the pass ever starts
+// succeeding, or starts declining somewhere else that happens to write a
+// manifest of its own, this fails rather than passing for the wrong reason.
+func declineIncrementalPass(t *testing.T, repo, wantReason string) {
+	t.Helper()
+	res := daemonSchedulerIncremental(context.Background(), repo, "", nil)
+	if res.Done {
+		t.Fatal("fixture is inert: the incremental pass SUCCEEDED, so the scheduler would never " +
+			"reach the fallback full index this test is about")
+	}
+	if !strings.Contains(res.FallbackReason, wantReason) {
+		t.Fatalf("incremental declined with reason %q, want one containing %q — the fixture is "+
+			"exercising a different decline path than this test assumes", res.FallbackReason, wantReason)
+	}
+}
+
+// assertNoManifestYet proves the decline path itself wrote nothing, so whatever
+// a later assertion finds is attributable to the fallback index alone.
+func assertNoManifestYet(t *testing.T, stateDir string) {
+	t.Helper()
+	if m := diff.LoadManifest(stateDir); len(m.Files) != 0 {
+		t.Fatalf("fixture is inert: a manifest with %d entries already exists in %s, so the "+
+			"assertions below would not be about the fallback index at all", len(m.Files), stateDir)
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was
+// written. The indexer logs its per-run file counts there, which is the only
+// observable that distinguishes a full walk from a delta-filtered one.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	prev := os.Stderr
+	os.Stderr = w
+	defer func() { os.Stderr = prev }()
+
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+
+	os.Stderr = prev
+	_ = w.Close()
+	out := <-done
+	_ = r.Close()
+	return out
+}
+
+// useInProcessIndex forces daemonSchedulerIndex down its in-process branch.
+func useInProcessIndex(t *testing.T) {
+	t.Helper()
+	prev := sched.SetSubprocessIndexEnabled(false)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prev) })
+}
+
+// useInlineSubprocessIndex forces the fork branch and runs the child IN-PROCESS
+// through its real entrypoint.
+//
+// The child is the side that writes the manifest — it owns the walk, and it is
+// the only side that can order the write after its own graph write — so the
+// property can only be pinned by driving the parent's argv construction INTO a
+// child. Rather than fork a binary this test does not have, it captures the
+// exact opts the scheduler hands to sched.RunSubprocessIndex, renders them
+// through the same argv builder the real fork uses (sched.SubprocessIndexArgs),
+// and feeds that argv to runIndexInternal. Every link in the chain (opts field
+// → flag → IndexOption → manifest write) is therefore exercised; only the fork
+// itself is elided.
+func useInlineSubprocessIndex(t *testing.T, sawFork *bool) {
+	t.Helper()
+	prevEnabled := sched.SetSubprocessIndexEnabled(true)
+	t.Cleanup(func() { sched.SetSubprocessIndexEnabled(prevEnabled) })
+	prevRunner := subprocessIndexRunner
+	subprocessIndexRunner = func(ctx context.Context, repoPath, ref string, skipPasses []string, opts *sched.SubprocessIndexOptions, logger *slog.Logger) error {
+		args := sched.SubprocessIndexArgs(repoPath, ref, skipPasses, opts)
+		if len(args) == 0 || args[0] != "index-internal" {
+			return fmt.Errorf("unexpected child argv %v", args)
+		}
+		*sawFork = true
+		if code := runIndexInternal(args[1:]); code != 0 {
+			return fmt.Errorf("index-internal child exited %d (argv %v)", code, args)
+		}
+		return nil
+	}
+	t.Cleanup(func() { subprocessIndexRunner = prevRunner })
+}
+
+// --- the core property, on both branches ------------------------------------
+
+// TestSchedulerFallbackIndex_WritesExactManifest_InProcess covers the
+// in-process branch of daemonSchedulerIndex (GRAFEL_SUBPROCESS_INDEXER=0).
+func TestSchedulerFallbackIndex_WritesExactManifest_InProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "fallback-inprocess", "main")
+	useInProcessIndex(t)
+
+	stateDir := daemon.StateDirForRepo(repo)
+	assertNoManifestYet(t, stateDir)
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	assertNoManifestYet(t, stateDir)
+
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+}
+
+// TestSchedulerFallbackIndex_WritesExactManifest_Subprocess covers the fork
+// branch. See useInlineSubprocessIndex for how the child is driven.
+func TestSchedulerFallbackIndex_WritesExactManifest_Subprocess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "fallback-subprocess", "main")
+	var sawFork bool
+	useInlineSubprocessIndex(t, &sawFork)
+
+	stateDir := daemon.StateDirForRepo(repo)
+	assertNoManifestYet(t, stateDir)
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	assertNoManifestYet(t, stateDir)
+
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+	if !sawFork {
+		t.Fatal("the subprocess branch was never taken — this test asserted nothing about it")
+	}
+	assertManifestExact(t, repo, stateDir)
+}
+
+// --- the manifest must land beside the graph, not beside the enqueue ref -----
+
+// TestSchedulerFallbackIndex_ManifestLandsBesideTheGraph pins that the manifest
+// is written to the directory the GRAPH went to, not to one derived from the
+// ref captured at enqueue time.
+//
+// daemonSchedulerIndex resolves its stateDir from the `ref` argument — the ref
+// as of ENQUEUE. The indexer resolves its output directory from gitmeta at
+// INDEX time. A checkout landing between the two makes those different
+// directories. This test reproduces that by enqueuing with a ref the repo is
+// NOT on: the graph goes under the current HEAD's ref dir, and the manifest
+// must follow it there and must NOT appear under the enqueue ref.
+//
+// Getting this wrong is not silently fatal — the #5710 head-advance guard
+// usually catches the mismatch — but it leaves one branch with no baseline and
+// the other with a manifest describing a graph built from a different branch,
+// which costs reindex cycles that get attributed elsewhere.
+func TestSchedulerFallbackIndex_ManifestLandsBesideTheGraph(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "fallback-refdiverge", "main")
+	useInProcessIndex(t)
+
+	const enqueueRef = "refs/heads/feature-a"
+	graphDir := daemon.StateDirForRepo(repo) // resolved from HEAD, at index time
+	enqueueDir := daemon.StateDirForRepoRef(repo, enqueueRef)
+	if graphDir == enqueueDir {
+		t.Fatal("fixture is inert: the enqueue-ref dir and the HEAD-resolved dir are the same, " +
+			"so this test could not observe a divergence")
+	}
+	assertNoManifestYet(t, graphDir)
+	assertNoManifestYet(t, enqueueDir)
+
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+
+	// Enqueue-time ref is feature-a; HEAD is main.
+	if err := daemonSchedulerIndex(context.Background(), repo, enqueueRef); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+
+	// The graph must be where gitmeta put it, and the manifest must be with it.
+	if _, err := graph.LoadGraphFromDir(graphDir); err != nil {
+		t.Fatalf("fixture is inert: no graph under the HEAD-resolved dir %s: %v", graphDir, err)
+	}
+	assertManifestExact(t, repo, graphDir)
+	if m := diff.LoadManifest(enqueueDir); len(m.Files) != 0 {
+		t.Fatalf("a manifest with %d entries was written under the ENQUEUE ref %s while the graph "+
+			"went to %s — the manifest describes a graph that is not next to it (#6207)",
+			len(m.Files), enqueueDir, graphDir)
+	}
+}
+
+// --- no manifest unless the graph it describes is durably on disk ------------
+
+// TestSchedulerFallbackIndex_GraphWriteFailureLeavesManifestUntouched pins the
+// ordering constraint.
+//
+// The manifest must be written only AFTER graph.fb is durably on disk. The
+// graph write is explicitly non-fatal and the index-internal child can be
+// SIGKILLed at any point, so "the index returned" is not the same as "the graph
+// landed". A manifest published for a graph that never landed is a PERMANENT
+// stuck state on the daemon's automatic healing path: the next pass computes
+// totalChanged == 0, the #5710 absent-graph guard fires on ABSENCE only and the
+// previous generation is still present, so the pass reports Done over a stale
+// graph forever. Leaving the manifest untouched instead means the same changed
+// set re-presents next pass and the repo heals itself.
+func TestSchedulerFallbackIndex_GraphWriteFailureLeavesManifestUntouched(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "fallback-graphfail", "main")
+	useInProcessIndex(t)
+	stateDir := daemon.StateDirForRepo(repo)
+
+	// Pass 1: an ordinary successful fallback. Establishes both a graph and a
+	// manifest, so the repo is in the state where the stuck-forever failure is
+	// reachable (a PRESENT previous generation).
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+	before := diff.LoadManifest(stateDir)
+	staleStamp := before.Files["svc/thing.go"].SHA256
+	if staleStamp == "" {
+		t.Fatal("fixture is inert: no stamp recorded for svc/thing.go after pass 1")
+	}
+
+	// Mutate a file so a manifest written by pass 2 would be observably
+	// DIFFERENT from pass 1's, then make the graph write fail.
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 99 }\n\nfunc Extra() {}\n")
+	if sha256OfFile(t, filepath.Join(repo, "svc", "thing.go")) == staleStamp {
+		t.Fatal("fixture is inert: the mutated file hashes the same as before")
+	}
+
+	prevWriter := writeGraphGen
+	writeGraphGen = func(dir string, doc *graph.Document) (string, error) {
+		return "", errors.New("injected: graph.fb write failed (disk full / EPERM / gen-flip)")
+	}
+	t.Cleanup(func() { writeGraphGen = prevWriter })
+
+	// Pass 2: the index runs, the graph write fails. Index() treats that as
+	// non-fatal, so a returned error is neither guaranteed nor what is asserted.
+	_ = daemonSchedulerIndex(context.Background(), repo, "")
+
+	after := diff.LoadManifest(stateDir)
+	if got := after.Files["svc/thing.go"].SHA256; got != staleStamp {
+		t.Fatalf("the manifest advanced svc/thing.go to %q even though the graph write FAILED "+
+			"(was %q). The graph on disk is still the previous generation, so the next pass sees "+
+			"totalChanged==0 over a stale graph and reports Done forever — a permanent stuck state "+
+			"on the automatic healing path (#6207)", got, staleStamp)
+	}
+	if len(after.Files) != len(before.Files) {
+		t.Fatalf("manifest membership changed (%d → %d) on a failed graph write",
+			len(before.Files), len(after.Files))
+	}
+}
+
+// --- the fallback must remain a FULL index -----------------------------------
+
+// TestSchedulerFallbackIndex_StaysAFullIndex pins the BEHAVIOUR half of the
+// flag split, which the manifest-content assertions above cannot see.
+//
+// On a cold repo, making the fallback diff-aware changes nothing observable:
+// the manifest is empty, the prior graph will not open, and the incremental
+// path falls back to processing everything anyway. So a mutant that re-fuses
+// the two flags — or a call site that simply hands WithIncremental to the
+// fallback, which is the wrong shape #6207 exists to reject — passes every
+// other test in this file.
+//
+// This test warms the repo first (manifest + graph both present), then forces a
+// reject with a limit of 1, and asserts the fallback index processed the FULL
+// walk. A diff-aware fallback would filter to the delta — the very delta the
+// reject just declared untrustworthy.
+func TestSchedulerFallbackIndex_StaysAFullIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "fallback-stayfull", "main")
+	useInProcessIndex(t)
+	stateDir := daemon.StateDirForRepo(repo)
+
+	// Warm: a successful fallback leaves a graph AND a complete manifest.
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("warm-up index: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+
+	// Change two files and cap the incremental limit at one, so the next pass
+	// rejects with too-many-changed rather than succeeding.
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "1")
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 99 }\n")
+	writeFixtureFile(t, repo, "svc/gadget.go", "package svc\n\nfunc Gadget() string { return \"gg\" }\n")
+	declineIncrementalPass(t, repo, "too-many-changed")
+
+	out := captureStderr(t, func() {
+		if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+			t.Errorf("fallback index: %v", err)
+		}
+	})
+	t.Log(out)
+
+	if strings.Contains(out, "incremental — processing") {
+		t.Fatalf("the FALLBACK index was delta-filtered — it logged an incremental cache-hit line. "+
+			"The run taken BECAUSE the delta could not be trusted must not filter its walk to that "+
+			"same delta (#6207).\nstderr:\n%s", out)
+	}
+	// "processed=N extracted=M" is the indexer's per-run summary: M is the count
+	// of files the pipeline actually parsed. The fixture's four walked files
+	// are three .go files plus go.mod; go.mod is filtered out before the
+	// processed/extracted counters, so both read 3 on a FULL walk. A
+	// delta-filtered run would report the size of the delta instead.
+	//
+	// The `processed=` prefix is load-bearing, not decoration. Pass 2.5 emits
+	// `shape_extracted=%d` on the same stream, which CONTAINS "extracted=3" —
+	// it is gated on shapeStats.Endpoints > 0 so it cannot fire on this
+	// endpoint-free fixture today, but the day someone adds an HTTP handler to
+	// it this assertion would become satisfiable without a full walk.
+	const wantExtracted = "processed=3 extracted=3"
+	if !strings.Contains(out, wantExtracted) {
+		t.Fatalf("the fallback index did not extract the full walk (wanted %q in its per-run "+
+			"summary) — it processed a delta, not the repo (#6207).\nstderr:\n%s", wantExtracted, out)
+	}
+	// The manifest must still be exact afterwards.
+	assertManifestExact(t, repo, stateDir)
+}

--- a/internal/daemon/sched/subprocess_ipc.go
+++ b/internal/daemon/sched/subprocess_ipc.go
@@ -179,4 +179,35 @@ type SubprocessIndexOptions struct {
 	// IncrementalStateDir, when non-empty, enables diff-aware re-indexing in the
 	// child (--incremental=<dir>), matching the in-process WithIncremental path.
 	IncrementalStateDir string
+
+	// PersistManifest tells the child to record what it indexed — a complete
+	// diff manifest (--persist-manifest) — without enabling diff-aware
+	// re-indexing (#6207). It is the half of IncrementalStateDir that records
+	// ground truth, separated from the half that consumes it.
+	//
+	// The scheduler's FALLBACK full index sets this and never
+	// IncrementalStateDir: the reason it fell back is that the delta was too
+	// large (or the prior graph unusable) to trust incrementally, so making the
+	// "full" reindex diff-aware would defeat the fallback. But the full index
+	// has just established ground truth for every file, which is exactly what a
+	// manifest records — and before #6207 it recorded nothing, so the manifest
+	// on the scheduler path advanced only via TryIncremental.
+	//
+	// IT CARRIES NO DIRECTORY. The child writes the manifest beside the graph
+	// it produced, resolving that path itself. The parent must not name the
+	// destination: the parent only has the ref captured at ENQUEUE time, while
+	// the child resolves HEAD at INDEX time, so a checkout in between would
+	// separate the manifest from the graph it describes.
+	//
+	// The CHILD writes it, not the parent: the child owns the walk (ignore
+	// rules, extension filters, per-pass exclusions) and therefore is the only
+	// side that knows the file set that was actually indexed. A parent-side
+	// write would need a second walk that reproduces those filters exactly and
+	// would drift the moment either changes, and it would decouple the manifest
+	// from the graph generation the child wrote — a manifest claiming files the
+	// graph does not contain is worse than no manifest. Writing it in the child
+	// also makes failure handling free: a child that dies before the manifest
+	// write leaves the previous manifest intact, and the child is the only side
+	// that can order the write after its own graph write.
+	PersistManifest bool
 }

--- a/internal/daemon/sched/subprocess_runner.go
+++ b/internal/daemon/sched/subprocess_runner.go
@@ -429,12 +429,16 @@ type ipcEvent struct {
 // It is NOT a SIGTERM: an earlier version of this comment said so and was
 // simply wrong, and nothing on this path may depend on the child getting a
 // chance to run deferred cleanup.
-func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, opts *SubprocessIndexOptions, logger *slog.Logger) error {
-	binary, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("subprocess-indexer: resolve binary: %w", err)
-	}
-
+// SubprocessIndexArgs renders the complete argv (argv[0] == "index-internal")
+// that RunSubprocessIndex fork-execs for the given job. It is a separate,
+// exported function purely so the child's contract can be exercised without a
+// fork: a test can hand this argv straight to the child entrypoint and observe
+// what the child actually does with it, instead of asserting on flag strings —
+// which proves only that a string was built, never that it was honoured.
+//
+// A nil opts (the scheduler background reindex before #6207) yields exactly
+// argv{index-internal, --repo, --ref, --skip-pass}.
+func SubprocessIndexArgs(repoPath, ref string, skipPasses []string, opts *SubprocessIndexOptions) []string {
 	args := []string{
 		"index-internal",
 		"--repo=" + repoPath,
@@ -447,11 +451,8 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 	// supplies a Publisher the child is told to STREAM per-module progress on
 	// stdout (--emit-progress) and to stamp events with the rebuild's group/repo
 	// slugs so republished rows key the same (group, repo, module) identity the
-	// in-process path emits. A nil opts (the scheduler background reindex) adds
-	// none of these flags, so its child args are byte-identical to before.
-	var progressPub progress.Publisher
+	// in-process path emits.
 	if opts != nil {
-		progressPub = opts.ProgressPub
 		if opts.RepoSlug != "" {
 			args = append(args, "--repo-tag="+opts.RepoSlug)
 		}
@@ -472,9 +473,30 @@ func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []
 		if opts.IncrementalStateDir != "" {
 			args = append(args, "--incremental="+opts.IncrementalStateDir)
 		}
+		// #6207: manifest persistence WITHOUT diff-aware behaviour, and with no
+		// destination — the child writes it beside the graph it produces.
+		// --incremental already implies persistence, so setting both is
+		// harmless and redundant rather than contradictory.
+		if opts.PersistManifest {
+			args = append(args, "--persist-manifest")
+		}
 		if opts.Interactive {
 			args = append(args, "--interactive")
 		}
+	}
+	return args
+}
+
+func RunSubprocessIndex(ctx context.Context, repoPath, ref string, skipPasses []string, opts *SubprocessIndexOptions, logger *slog.Logger) error {
+	binary, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("subprocess-indexer: resolve binary: %w", err)
+	}
+
+	args := SubprocessIndexArgs(repoPath, ref, skipPasses, opts)
+	var progressPub progress.Publisher
+	if opts != nil {
+		progressPub = opts.ProgressPub
 	}
 
 	cmd := exec.CommandContext(ctx, binary, args...)


### PR DESCRIPTION
The scheduler's fallback full index wrote no manifest, so the incremental reject had to carry loop guards to compensate — and #6206 could not delete the zero-change SHA-256 sweep, which was doubling as a healing path.

## The defect was a conflated flag, not a missing call

`cmd/grafel/index.go` gated the manifest **load** on `i.incremental && i.incrementalStateDir != ""` and the **write** on `i.incremental && diffManifest != nil`, where `diffManifest` was assigned only inside the load block. So the write was reachable exclusively from a run that had also filtered its walk to the delta.

`daemonSchedulerIndex` therefore had **no legal move**. Setting a state dir would have made the "full" fallback diff-aware — filtering its walk to exactly the delta the reject had just declared untrustworthy. So it set neither field, and `TryIncremental` became the only thing advancing the manifest on that path, including on the passes where it declined to do any work.

**The indexer could not record what it indexed without also indexing only the delta.** That is the whole bug. `incremental` now gates behaviour; `stateDir` gates persistence.

## Two design choices, both load-bearing

**The child writes the manifest, not the parent.** The child owns the walk — gitignore traversal, extension filters, skipped files — so it is the only side that knows the set actually indexed. Parent-side derivation means a second walk reproducing every filter, drifting the first time one changes, and decoupling the manifest from the graph generation the child wrote. Expressible only because of the split: `SubprocessIndexOptions.PersistManifest` → `--persist-manifest` → `WithManifestPersist`.

**The option cannot name a destination.** `WithManifestPersist()` takes no directory, `PersistManifest` is a bool, and `commitManifest` writes to `graphDir = filepath.Dir(outPath)` — the identical expression `Index` uses for every other artifact. Review's first round found the earlier shape threaded the *enqueue-time* ref into a path the graph writer does not use, so a `git checkout` between enqueue and index would put `graph.<gen>.fb` in `refs/main/` and the manifest in `refs/feature-a/`, stamped with main's HEAD. Removing the parameter makes that unrepresentable rather than merely fixed.

## The ordering, which review caught and which mattered most

The first version wrote the manifest inside `Run()`. `graph.fb` is written by the caller **after** `Run()` returns, and that write is explicitly non-fatal.

So: fallback runs, manifest written for all N files, then `WriteGraphGen` fails — disk full, EPERM, a #5891 gen-pointer flip — or the child is SIGKILLed in the window. Next pass sees `totalChanged == 0`, and the #5710 guard fires on **absence only**; the previous generation's graph is still present and `current` still points at it. `Done: true`, permanently, over a stale graph. Before this change the manifest was untouched on that path and the failure self-healed. **A new permanent stuck state on the daemon's automatic healing path** — strictly worse than the bug being fixed.

The write moved to `(*Indexer).commitManifest`, called from `Index` on the success branch of the graph write. This covers the pre-existing `WithIncremental` path too, which had the identical hazard and no test.

Verified empirically rather than argued, with a positive control first — a `WithIncremental` run that wrote no manifest at all would pass the negative test trivially. Control: a successful run advances the manifest. Negative: with an injected graph-write failure the manifest file is unchanged **byte-for-byte on disk**. Residual window simulated: the next pass re-processes and heals rather than sticking.

## What the residual window actually costs, stated in full

The comment initially claimed the window always leaves the graph newer than the manifest — *over-reporting, never staleness*. **Per file that is false**, and it was measured, not theorised.

`commitManifest` hashes each file *at commit time*, while the document was built from the bytes `Run`'s walk read. A probe injecting a working-tree write inside the `writeGraphGen` seam confirmed the manifest stamps **post-walk content** — bytes the graph does not contain. Next pass, `FilterWithGit` hash-matches and classifies the file UNCHANGED (`diff.go:411-413`), so the edit is invisible until the file is touched again or HEAD advances.

The realistic trigger is exactly the watcher-driven fallback, which fires *because* files are changing. It is pre-existing on `WithIncremental` but **new on the fallback**, which previously wrote no manifest so the old stamp caught the edit — and the window is now **wider on both**, spanning rename-detect, algo carry-forward, `sortDocumentForEmission` and all of `WriteGraphGen`, seconds where it used to be immediately post-extraction.

It is nevertheless the right trade and must not be reverted: one edit lost until its next touch is self-recovering; the stuck state above is not. The comment now names the **generation** and **content** axes separately, because #6207 exists precisely because a non-obvious fact was not written down, and a comment confidently wrong about the remaining hazard would be the same failure one level down. Real fix filed separately: stamp from walk-time hashes, which makes the manifest's contract true by construction *and* deletes the O(repo) sweep from `commitManifest`.

## Tests

Five, all asserting observable state — manifest contents, extraction counters — never elapsed time.

- **`_GraphWriteFailureLeavesManifestUntouched`** — warm the repo so the stuck state is reachable, mutate a file, inject a failing graph write, assert the stamp and membership did not move. Does not assert on a returned error: the write is non-fatal, so there may not be one.
- **`_ManifestLandsBesideTheGraph`** — fixture committed on `main`, enqueued as `refs/heads/feature-a`. Asserts the dirs differ (an inert-fixture guard), the graph loads from the HEAD-resolved dir, the manifest there is exact, and **no** manifest exists under the enqueue ref.
- **`_StaysAFullIndex`** — the behaviour half. Warm repo, `GRAFEL_INCREMENTAL_MAX_FILES=1`, two files changed, confirm the decline, then assert the fallback logged no cache-hit line **and** reported the full walk's counters. Added because review found the persistence half was pinned and the behaviour half was not: on a cold repo the incremental path falls back anyway and produces an identical manifest, so a re-conflation was invisible.
- Plus the in-process and subprocess exactness pair. `assertManifestExact` does sorted key-set equality **and** per-file SHA-256 — cardinality and membership both — because `UpdateManifest`'s prune is the #5667 loop guard this change is meant to supersede, making *"no stale entries survive"* the property most worth pinning. `declineIncrementalPass` takes an expected reason and fails on mismatch rather than logging it.

**Mutation: 15 constructed independently in review, plus the author's own.** Killed — `WithManifestPersist` no-op; persistence re-gated on `i.incremental`; empty manifest; manifest missing one file; ghost entry (kills all five); manifest to the parent dir; `WithIncremental` at the call site; that plus the cache-hit line renamed away, which dies on the counters alone; argv builder drops the flag; child ignores the flag; in-process branch drops the option; commit on both branches of `fbErr`; and the v1 ordering, committing before the graph write.

One reported as a **null mutant rather than a survivor**: `WithManifestPersist` also setting `i.incremental = true` changes nothing, because the behaviour gate requires a state dir and the no-argument option provides none. That is the design working — the only reachable way to re-fuse behaviour and persistence is to hand the fallback a directory, and every route that does is killed.

## #5667 / #5668 are NOT redundant, and the reason is structural

Worth recording, because the tempting next step is to delete them.

They never invoke the fallback at all — they call `extractors.TryIncremental` twice back to back and assert on the manifest in between. The fallback lives in `cmd/grafel`, which is `package main` and which imports `internal/extractors`, so the reverse edge is a hard cycle. This change's manifest is never written in their fixtures and **cannot** make them pass. Measured: with the fix in place, deleting the reject-path write turns three tests red.

A guard that compensates for a gap in another package cannot verify its own obsolescence. Before those guards can go, they must be relocated to where the full cycle — decline → fallback → next pass — is expressible. Noted on #6206.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0. At the rebased head, unpiped `$?`, `GOMAXPROCS=4 -count=1`: `cmd/grafel` 0, `internal/extractors` 0, `internal/indexer/diff` 0, `internal/daemon/sched` 0.

Independently adversarially reviewed twice (REQUEST-CHANGES → APPROVE), the reviewer re-running the mutation battery itself and adding its own probes.

## Known limits

`commitManifest` is unreachable when `--skip-pass=build-document` is set, so that combination used to write a manifest and now does not. More correct — no graph written, no manifest — and nothing in production passes that skip.

The ordering test covers the in-process branch only; on the subprocess branch the seam lives in the child and is not injectable from the parent. Same `Index` code, same guarantee, and the child is confirmed to reach `commitManifest` via the subprocess exactness test.

`commitManifest`'s `dest := i.incrementalStateDir` remains addressable via `WithIncremental` only — pre-existing and unchanged here.

A file whose extraction failed is still stamped as indexed. Pre-existing on the `WithIncremental` path, newly reachable from the fallback. Filed as #6209.

Closes #6207
Refs #6199, #6201, #6206, #6208, #6209
