### PR TITLE
fix(#6202): the file fold read `.ts` as "this file is a component", so every backend module lost its stem-named class

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -467,7 +467,9 @@ func semanticDigest6118(doc *graph.Document) string {
 //
 // #6138 MOVED IT A SECOND TIME, and the delta is again a pure gain. The file
 // fold now only fires where the ecosystem makes a module and its exported
-// declaration the same entity (fileIsDeclarationExtensions), so eight
+// declaration the same entity (fileIsItsDeclaration — named
+// fileIsDeclarationExtensions until #6202 split the extension allow-list into a
+// component-extension set and a default-export test), so eight
 // declarations this fixture used to delete come back, each with the span and
 // signature the extractor read:
 //

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -30,6 +30,7 @@ import (
 	bazelextract "github.com/cajasmota/grafel/internal/extractors/bazel"
 	configextract "github.com/cajasmota/grafel/internal/extractors/config"
 	"github.com/cajasmota/grafel/internal/extractors/cross"
+	jsextract "github.com/cajasmota/grafel/internal/extractors/javascript"
 	mageextract "github.com/cajasmota/grafel/internal/extractors/mage"
 	pyextr "github.com/cajasmota/grafel/internal/extractors/python"
 	taskextract "github.com/cajasmota/grafel/internal/extractors/task"
@@ -4682,12 +4683,13 @@ func filePathStem(path string) string {
 	return strings.ToLower(stem)
 }
 
-// fileIsDeclarationExtensions are the source-file extensions whose ecosystems
-// treat a module file and the declaration it exports as the same thing: the
-// module system addresses the file, importers name the file, and the framework
-// resolves the component through its path. `LoginPage` in `LoginPage.tsx` is a
-// second name for that module, so a File+Component pair there is a true
-// duplicate and folding it removes a duplicate.
+// componentFileExtensions are the source-file extensions that NAME the
+// convention on their own: the ecosystem treats a module file and the
+// declaration it exports as the same thing, and the extension exists for
+// nothing else. The module system addresses the file, importers name the file,
+// and the framework resolves the component through its path. `LoginPage` in
+// `LoginPage.tsx` is a second name for that module, so a File+Component pair
+// there is a true duplicate and folding it removes a duplicate. Issue #1727.
 //
 // EVERY OTHER ECOSYSTEM TREATS A FILE AS A CONTAINER, even when it holds
 // exactly one declaration. `interface IERC4626` in `IERC4626.sol` is a
@@ -4697,10 +4699,72 @@ func filePathStem(path string) string {
 // @openzeppelin/contracts@5.2.0 the name==stem rule dropped 42 of 61
 // interfaces while leaving all 71 contracts, purely because "contract" is not
 // in classLikeComponentSubtypes and "interface" is. Issue #6138.
-var fileIsDeclarationExtensions = map[string]bool{
-	".js": true, ".jsx": true, ".mjs": true, ".cjs": true,
-	".ts": true, ".tsx": true, ".mts": true, ".cts": true,
+var componentFileExtensions = map[string]bool{
+	".jsx": true, ".tsx": true,
 	".vue": true, ".svelte": true, ".astro": true,
+}
+
+// moduleFileExtensions are the extensions that carry the component convention
+// AND every other kind of module. `.ts` is the extension for
+// `src/components/LoginPage.ts` and for `src/domain/IUserRepository.ts` alike,
+// so membership says nothing about whether the file IS its declaration and
+// allow-listing it wholesale left #6138 live inside TypeScript and JavaScript:
+// `class UserRepository` in `UserRepository.ts` was deleted exactly like a
+// React component. Issue #6202.
+//
+// These need a per-file signal instead — see fileIsItsDeclaration.
+var moduleFileExtensions = map[string]bool{
+	".js": true, ".mjs": true, ".cjs": true,
+	".ts": true, ".mts": true, ".cts": true,
+}
+
+// fileIsItsDeclaration reports whether the module in sourceFile exists to
+// export the single declaration declName, which is what makes the File +
+// Component pair a duplicate rather than a container and its contents.
+//
+// For componentFileExtensions the extension answers it. For
+// moduleFileExtensions the answer is the module's DEFAULT EXPORT — the actual
+// mechanic behind the React/Vue convention, where a component module is
+// `export default LoginPage` while a backend module is `export class
+// UserRepository` / `export interface IUserRepository`, a named export
+// addressed by its own name. defaultExport is the file entity's
+// jsextract.DefaultExportProp, empty when the module has no default export
+// naming one of its own declarations.
+//
+// The absence of the signal denies the fold, so an unresolvable default export
+// (`export default connect(...)(LoginPage)`) keeps the declaration's entity.
+// That is the direction that loses nothing: an un-folded pair is a duplicate
+// the MCP layer can still see, a folded one is a declaration nobody can
+// (internal/mcp/denoise.go classifies a subtype="file" component as a
+// noiseContainer unconditionally). Issue #6202.
+//
+// THE NAME COMPARISON IS CASE-SENSITIVE, AND MUST STAY THAT WAY. These are two
+// identifiers read out of the SAME source file, where case is the language's
+// identity rule and `logger` and `Logger` are two different bindings. The
+// singleton-instance convention is ubiquitous:
+//
+//	export class Logger { … }
+//	const logger = new Logger();
+//	export default logger;
+//
+// Under a case-insensitive comparison that module reads as "default-exports its
+// class" and `class Logger` is deleted — the exact deletion this change exists
+// to stop, on the shape #6202's second row names. The default export there is
+// the INSTANCE; the module is a container holding both.
+//
+// The separate stem-vs-name comparison at the fold decision stays
+// case-insensitive, because a filename is not an identifier: `loginPage.ts`
+// holding `class LoginPage` is one declaration under two spellings of one name,
+// so that fold is still correct and nothing legitimate is lost here.
+func fileIsItsDeclaration(sourceFile, declName, defaultExport string) bool {
+	ext := strings.ToLower(filepath.Ext(sourceFile))
+	if componentFileExtensions[ext] {
+		return true
+	}
+	if !moduleFileExtensions[ext] {
+		return false
+	}
+	return defaultExport != "" && defaultExport == declName
 }
 
 // foldFileComponentDuplicates collapses SCOPE.Component class-like nodes into
@@ -4722,10 +4786,12 @@ var fileIsDeclarationExtensions = map[string]bool{
 //     AND whose SourceFile matches the survivor's SourceFile.
 //  3. Anti-over-fold guard: if the class entity's name does NOT match the file
 //     stem — meaning it's a *different* class inside the same file — keep both.
-//  4. Convention guard: the file must be one whose ecosystem makes a module and
-//     its exported declaration the same entity (fileIsDeclarationExtensions).
-//     Elsewhere a file is a container and the declaration is not a duplicate of
-//     it, so folding would delete a real declaration. Issue #6138.
+//  4. Convention guard: the file must be one that exists to export this one
+//     declaration (fileIsItsDeclaration) — either because its extension names
+//     the component convention (#6138) or because the module default-exports
+//     the declaration by name (#6202). Elsewhere a file is a container and the
+//     declaration is not a duplicate of it, so folding would delete a real
+//     declaration.
 //
 // Runs AFTER foldClassHierarchyShadows (so shadows are already resolved) and
 // AFTER stampEntityIDs (so r.ID is populated).
@@ -4741,15 +4807,22 @@ func (i *Indexer) foldFileComponentDuplicates(
 		idx  int
 		id   string
 		stem string // lower-cased filename without extension
+		// defaultExport is the name this module default-exports, stamped by
+		// the JS/TS extractor (jsextract.DefaultExportProp). Read here rather
+		// than at the fold decision so it is the extractor's answer and never
+		// a property this pass copied onto the survivor from an earlier fold.
+		// Issue #6202.
+		defaultExport string
 	}
 	fileBySourceFile := make(map[string]fileEnt)
 	for k := range merged {
 		r := &merged[k]
 		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.ID != "" {
 			fileBySourceFile[r.SourceFile] = fileEnt{
-				idx:  k,
-				id:   r.ID,
-				stem: filePathStem(r.SourceFile),
+				idx:           k,
+				id:            r.ID,
+				stem:          filePathStem(r.SourceFile),
+				defaultExport: r.Properties[jsextract.DefaultExportProp],
 			}
 		}
 	}
@@ -4788,8 +4861,8 @@ func (i *Indexer) foldFileComponentDuplicates(
 			continue
 		}
 		// Only fold where the file IS the declaration; elsewhere the file is a
-		// container and folding deletes a real declaration. Issue #6138.
-		if !fileIsDeclarationExtensions[strings.ToLower(filepath.Ext(r.SourceFile))] {
+		// container and folding deletes a real declaration. Issues #6138, #6202.
+		if !fileIsItsDeclaration(r.SourceFile, r.Name, fe.defaultExport) {
 			continue
 		}
 		if fe.id == r.ID {

--- a/cmd/grafel/issue6138_interface_fold_test.go
+++ b/cmd/grafel/issue6138_interface_fold_test.go
@@ -183,15 +183,23 @@ func TestIssue6138_ContainerFileLanguagesKeepStemNamedDeclarations(t *testing.T)
 func TestIssue6138_FileIsTheDeclarationEcosystemsStillFold(t *testing.T) {
 	const classSig = "class LoginPage extends React.Component<Props>"
 
-	for _, tc := range []struct{ name, path, decl string }{
-		{"tsx", "src/components/LoginPage.tsx", "LoginPage"},
-		{"js", "src/components/LoginPage.js", "LoginPage"},
-		{"vue", "src/components/LoginPage.vue", "LoginPage"},
-		{"svelte", "src/components/LoginPage.svelte", "LoginPage"},
+	// defaultExport carries the file entity's javascript.DefaultExportProp.
+	// `.tsx`, `.vue` and `.svelte` name the component convention in the
+	// extension itself and fold without it. `.js` does not — it is the
+	// extension for a component module AND for every other kind of module — so
+	// #6202 made its fold conditional on the module actually default-exporting
+	// the declaration. This row therefore had to say which `.js` file it is;
+	// the un-defaulted `.js` module is now pinned as a SURVIVOR in
+	// TestIssue6202_NamedExportModulesKeepTheirDeclarations.
+	for _, tc := range []struct{ name, path, decl, defaultExport string }{
+		{"tsx", "src/components/LoginPage.tsx", "LoginPage", ""},
+		{"js", "src/components/LoginPage.js", "LoginPage", "LoginPage"},
+		{"vue", "src/components/LoginPage.vue", "LoginPage", ""},
+		{"svelte", "src/components/LoginPage.svelte", "LoginPage", ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			records := []types.EntityRecord{
-				fileEnt6138("f000000000000010", tc.path),
+				fileEnt6202("f000000000000010", tc.path, tc.defaultExport),
 				{
 					ID:         "c000000000000010",
 					Kind:       "SCOPE.Component",

--- a/cmd/grafel/issue6202_ts_module_fold_test.go
+++ b/cmd/grafel/issue6202_ts_module_fold_test.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// Issue #6202 — #6138 is still live inside TypeScript and JavaScript.
+//
+// #6138 gated foldFileComponentDuplicates on an extension allow-list, which is
+// the right shape: the fold's premise is a CONVENTION ("this module exists to
+// export this one declaration"), not a language. But `.ts` and `.js` were
+// allow-listed wholesale, and they are the extension for that convention AND
+// for every other kind of TypeScript/JavaScript module. So a backend tree still
+// lost stem-named declarations: `class UserRepository` in `UserRepository.ts`
+// is deleted exactly like `class LoginPage` in `LoginPage.tsx`, and because
+// internal/mcp/denoise.go classifies a subtype="file" component as a
+// noiseContainer unconditionally, the declaration does not merely change owner
+// — it stops being visible to MCP consumers at all.
+//
+// The distinction is not carryable by the extension. It is carried by the
+// module's DEFAULT EXPORT: the React/Vue component convention is
+// `export default LoginPage`, and a backend module is `export interface
+// IUserRepository` / `export class UserRepository` — a named export. So a file
+// whose default export is the stem-named declaration IS that declaration and
+// still folds; a file that merely happens to contain a stem-named declaration
+// is a container and keeps it.
+//
+// `.tsx`, `.jsx`, `.vue`, `.svelte` and `.astro` are unchanged: those
+// extensions name the convention on their own, so they fold with or without a
+// default export, exactly as #1727 and #6138 left them.
+
+// fileEnt6202 builds the SCOPE.Component(subtype="file") record every extractor
+// emits per file. defaultExport, when non-empty, is the name the module default
+// exports — the signal the JS/TS extractor now stamps (see
+// internal/extractors/javascript, TestIssue6202_FileEntityCarriesDefaultExportName).
+func fileEnt6202(id, path, defaultExport string) types.EntityRecord {
+	r := types.EntityRecord{
+		ID:         id,
+		Kind:       "SCOPE.Component",
+		Subtype:    "file",
+		Name:       path,
+		SourceFile: path,
+	}
+	if defaultExport != "" {
+		r.Properties = map[string]string{"default_export": defaultExport}
+	}
+	return r
+}
+
+// TestIssue6202_NamedExportModulesKeepTheirDeclarations is the regression gate.
+// A stem-named declaration in a `.ts`/`.js` module with NO matching default
+// export must survive with its span, subtype and signature intact.
+//
+// The rows are the three shapes #6202 measured against the real function, plus
+// the `.js` and `.mts` variants of the same convention.
+func TestIssue6202_NamedExportModulesKeepTheirDeclarations(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		path    string
+		decl    string
+		subtype string
+		sig     string
+		props   map[string]string
+	}{
+		{
+			name:    "interface",
+			path:    "src/domain/IUserRepository.ts",
+			decl:    "IUserRepository",
+			subtype: "interface",
+			sig:     "interface IUserRepository extends IReadRepo<User>",
+		},
+		{
+			name:    "class",
+			path:    "src/domain/UserRepository.ts",
+			decl:    "UserRepository",
+			subtype: "class",
+			sig:     "class UserRepository implements IUserRepository",
+		},
+		{
+			name:    "service",
+			path:    "src/orders/OrdersService.ts",
+			decl:    "OrdersService",
+			subtype: "service",
+			sig:     "@Injectable class OrdersService",
+		},
+		{
+			name:    "role_class_door",
+			path:    "src/orders/OrdersGateway.ts",
+			decl:    "OrdersGateway",
+			subtype: "gateway",
+			sig:     "@WebSocketGateway class OrdersGateway",
+			props:   map[string]string{"role": "class"},
+		},
+		{
+			name:    "javascript",
+			path:    "src/domain/OrderMapper.js",
+			decl:    "OrderMapper",
+			subtype: "class",
+			sig:     "class OrderMapper",
+		},
+		{
+			name:    "typescript_module",
+			path:    "src/domain/Money.mts",
+			decl:    "Money",
+			subtype: "class",
+			sig:     "class Money",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records := []types.EntityRecord{
+				fileEnt6202("f000000000006202", tc.path, ""),
+				{
+					ID:         "d000000000006202",
+					Kind:       "SCOPE.Component",
+					Subtype:    tc.subtype,
+					Name:       tc.decl,
+					SourceFile: tc.path,
+					StartLine:  7,
+					EndLine:    41,
+					Signature:  tc.sig,
+					Properties: tc.props,
+				},
+			}
+
+			out, _, stats := dupkindIndexer().foldFileComponentDuplicates(records, nil)
+
+			if stats.Folded != 0 {
+				t.Errorf("expected 0 folds — %s is a named export, so the module is a container "+
+					"and not a second name for the declaration; got %d", tc.decl, stats.Folded)
+			}
+			var kept *types.EntityRecord
+			for i := range out {
+				if out[i].Name == tc.decl && out[i].Subtype == tc.subtype {
+					kept = &out[i]
+				}
+			}
+			if kept == nil {
+				t.Fatalf("%s in %s lost its entity to the file fold", tc.decl, tc.path)
+			}
+			if kept.StartLine != 7 || kept.EndLine != 41 {
+				t.Errorf("%s span = %d..%d, want 7..41", tc.decl, kept.StartLine, kept.EndLine)
+			}
+			if kept.Signature != tc.sig {
+				t.Errorf("%s signature = %q, want %q", tc.decl, kept.Signature, tc.sig)
+			}
+		})
+	}
+}
+
+// TestIssue6202_DefaultExportModulesStillFold is the door #1727 relies on, and
+// the one bullet of #6202's acceptance that had to be a test rather than a line
+// of reasoning. A `.ts`/`.js` file that genuinely IS its component — default
+// export, name matching the stem — must still fold, or the fix has simply
+// traded #6138 for #1727.
+//
+// THE STEM-CASE ROWS PIN A DELIBERATE ASYMMETRY between the fold's two name
+// comparisons, which are NOT interchangeable:
+//
+//   - stem vs declaration name is case-INSENSITIVE, because a filename is not
+//     an identifier. `loginPage.ts`, `loginpage.ts` and `LOGINPAGE.ts` are all
+//     the file that holds `class LoginPage`; filesystems disagree about case
+//     and developers spell module files in every convention.
+//   - default export vs declaration name is case-SENSITIVE, because those ARE
+//     two identifiers from one source file, where `logger` and `Logger` are
+//     different bindings (see DefaultExportOfADifferentSymbolDoesNotFold).
+//
+// Collapsing both to one rule breaks something either way: making the stem
+// comparison case-sensitive stops every camelCase-filed component folding, and
+// making the identifier comparison case-insensitive deletes every singleton's
+// class. Without these rows only the first failure mode is untested.
+func TestIssue6202_DefaultExportModulesStillFold(t *testing.T) {
+	const classSig = "class LoginPage extends React.Component<Props>"
+
+	for _, tc := range []struct{ name, path string }{
+		{"ts", "src/components/LoginPage.ts"},
+		{"js", "src/components/LoginPage.js"},
+		{"mjs", "src/components/LoginPage.mjs"},
+		{"cts", "src/components/LoginPage.cts"},
+		// Stem case differs from the declaration; the default export does not.
+		{"ts_stem_case_differs", "src/components/loginPage.ts"},
+		{"ts_stem_all_lower", "src/components/loginpage.ts"},
+		{"ts_stem_all_upper", "src/components/LOGINPAGE.ts"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records := []types.EntityRecord{
+				fileEnt6202("f000000000006210", tc.path, "LoginPage"),
+				{
+					ID:         "d000000000006210",
+					Kind:       "SCOPE.Component",
+					Subtype:    "class",
+					Name:       "LoginPage",
+					SourceFile: tc.path,
+					StartLine:  3,
+					EndLine:    30,
+					Signature:  classSig,
+				},
+			}
+
+			out, _, stats := dupkindIndexer().foldFileComponentDuplicates(records, nil)
+
+			if stats.Folded != 1 {
+				t.Fatalf("expected the default-exported LoginPage to fold into its %s file entity, got %d folds",
+					tc.path, stats.Folded)
+			}
+			var file *types.EntityRecord
+			for i := range out {
+				if out[i].Subtype == "file" {
+					file = &out[i]
+				}
+				if out[i].Name == "LoginPage" && out[i].Subtype == "class" {
+					t.Error("LoginPage was not absorbed by its file entity")
+				}
+			}
+			if file == nil {
+				t.Fatal("file entity disappeared")
+			}
+			if file.StartLine != 3 {
+				t.Errorf("file entity start line = %d, want 3", file.StartLine)
+			}
+			if file.Signature != classSig {
+				t.Errorf("file entity signature = %q, want %q", file.Signature, classSig)
+			}
+		})
+	}
+}
+
+// TestIssue6202_DefaultExportOfADifferentSymbolDoesNotFold pins that the signal
+// is the default export MATCHING the declaration, not the mere presence of a
+// default export.
+//
+// The singleton row is the one that matters most, and it is why the comparison
+// is case-SENSITIVE. `export class Logger` + `const logger = new Logger()` +
+// `export default logger` is the ubiquitous singleton-instance convention: the
+// default export is the INSTANCE, and the module is a container holding both it
+// and the class. Under a case-insensitive comparison `logger` reads as a second
+// name for `Logger` and the class is deleted — the exact deletion #6202 exists
+// to stop, on the shape its own second row names. These are two identifiers
+// from one source file, where case is the language's identity rule.
+func TestIssue6202_DefaultExportOfADifferentSymbolDoesNotFold(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		path          string
+		decl          string
+		sig           string
+		defaultExport string
+	}{
+		{
+			name:          "factory_function",
+			path:          "src/domain/UserRepository.ts",
+			decl:          "UserRepository",
+			sig:           "class UserRepository implements IUserRepository",
+			defaultExport: "createUserRepository",
+		},
+		{
+			// `const logger = new Logger(); export default logger;`
+			name:          "singleton_instance_differs_only_by_case",
+			path:          "src/infra/Logger.ts",
+			decl:          "Logger",
+			sig:           "class Logger",
+			defaultExport: "logger",
+		},
+		{
+			// The issue's own second row, in its singleton form.
+			name:          "singleton_instance_camel_case",
+			path:          "src/domain/UserRepository.ts",
+			decl:          "UserRepository",
+			sig:           "class UserRepository implements IUserRepository",
+			defaultExport: "userRepository",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records := []types.EntityRecord{
+				fileEnt6202("f000000000006220", tc.path, tc.defaultExport),
+				{
+					ID:         "d000000000006220",
+					Kind:       "SCOPE.Component",
+					Subtype:    "class",
+					Name:       tc.decl,
+					SourceFile: tc.path,
+					StartLine:  9,
+					EndLine:    60,
+					Signature:  tc.sig,
+				},
+			}
+
+			out, _, stats := dupkindIndexer().foldFileComponentDuplicates(records, nil)
+
+			if stats.Folded != 0 {
+				t.Fatalf("expected 0 folds — the module default-exports %q, not %q, so it is "+
+					"not a second name for the class; got %d", tc.defaultExport, tc.decl, stats.Folded)
+			}
+			var kept *types.EntityRecord
+			for i := range out {
+				if out[i].Name == tc.decl && out[i].Subtype == "class" {
+					kept = &out[i]
+				}
+			}
+			if kept == nil {
+				t.Fatalf("%s was deleted by a default export (%q) that names a different symbol",
+					tc.decl, tc.defaultExport)
+			}
+			if kept.Signature != tc.sig {
+				t.Errorf("%s signature = %q, want %q intact", tc.decl, kept.Signature, tc.sig)
+			}
+		})
+	}
+}
+
+// TestIssue6202_ComponentExtensionsFoldWithoutADefaultExport is the other half
+// of the placement. `.tsx`, `.jsx`, `.vue`, `.svelte` and `.astro` name the
+// convention in the extension itself, so the default-export requirement must
+// NOT reach them — requiring it everywhere would delete #1727's fold for every
+// React component that uses a named export, which is a regression the extension
+// gate was specifically shaped to avoid.
+func TestIssue6202_ComponentExtensionsFoldWithoutADefaultExport(t *testing.T) {
+	for _, tc := range []struct{ name, path string }{
+		{"tsx", "src/components/LoginPage.tsx"},
+		{"jsx", "src/components/LoginPage.jsx"},
+		{"vue", "src/components/LoginPage.vue"},
+		{"svelte", "src/components/LoginPage.svelte"},
+		{"astro", "src/components/LoginPage.astro"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			records := []types.EntityRecord{
+				fileEnt6202("f000000000006230", tc.path, ""),
+				{
+					ID:         "d000000000006230",
+					Kind:       "SCOPE.Component",
+					Subtype:    "class",
+					Name:       "LoginPage",
+					SourceFile: tc.path,
+					StartLine:  3,
+					EndLine:    30,
+					Signature:  "class LoginPage",
+				},
+			}
+
+			_, _, stats := dupkindIndexer().foldFileComponentDuplicates(records, nil)
+
+			if stats.Folded != 1 {
+				t.Fatalf("%s names the component convention in the extension itself and must fold "+
+					"without a default export, got %d folds", tc.path, stats.Folded)
+			}
+		})
+	}
+}
+
+// TestIssue6202_BackendTypeScriptSurvivesFullIndex is the end-to-end form. The
+// unit tests above hand foldFileComponentDuplicates records built by hand, so
+// they cannot show that the JS/TS extractor really emits the default-export
+// property the gate now reads — without that, the gate would deny every `.ts`
+// fold and #1727 would be broken in production while the unit tests stayed
+// green.
+//
+// UserRepository is the shape that actually reproduces #6202 through the real
+// extractor. (`export interface IUserRepository` does NOT: the TS extractor
+// emits an interface as SCOPE.Schema, which the fold never considers. The
+// interface row is still pinned at the record level above, because the fold is
+// language-agnostic and any extractor emitting SCOPE.Component/interface for a
+// `.ts` file reaches it — as the Solidity one does.)
+func TestIssue6202_BackendTypeScriptSurvivesFullIndex(t *testing.T) {
+	root := t.TempDir()
+	files := map[string]string{
+		"src/domain/UserRepository.ts": `import { User } from "./User";
+
+export class UserRepository {
+  async findById(id: string): Promise<User | null> { return null; }
+  async save(u: User): Promise<void> {}
+}
+`,
+		"src/domain/User.ts": `export class User {
+  constructor(public id: string) {}
+}
+`,
+		// The singleton-instance convention: the default export is the
+		// INSTANCE, whose name differs from the class only by case. The module
+		// is a container holding both, so the class must keep its entity.
+		"src/infra/Logger.ts": `export class Logger {
+  log(m: string) {}
+}
+
+const logger = new Logger();
+
+export default logger;
+`,
+		"src/components/LoginPage.ts": `import React from "react";
+
+class LoginPage extends React.Component {
+  render() { return null; }
+}
+
+export default LoginPage;
+`,
+		"src/components/SignupPage.ts": `import React from "react";
+
+export default class SignupPage extends React.Component {
+  render() { return null; }
+}
+`,
+	}
+	for rel, body := range files {
+		full := filepath.Join(root, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(body), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	doc := runIndexerOn(t, root, "issue6202", nil)
+
+	find := func(name, subtype string) *graph.Entity {
+		for i := range doc.Entities {
+			e := &doc.Entities[i]
+			if e.Kind == "SCOPE.Component" && e.Name == name && e.Subtype == subtype {
+				return e
+			}
+		}
+		return nil
+	}
+
+	// The file entity is the fold survivor, so its presence is what makes the
+	// deletion reachable: without it the test would pass for the wrong reason.
+	if find("src/domain/UserRepository.ts", "file") == nil {
+		t.Fatal("no file component for src/domain/UserRepository.ts — the fold trigger is gone " +
+			"and this test would pass for the wrong reason")
+	}
+
+	repo := find("UserRepository", "class")
+	if repo == nil {
+		t.Fatal("class UserRepository in src/domain/UserRepository.ts lost its entity to the file " +
+			"fold — it is a named export, so the module is a container, not a second name for it")
+	}
+	if repo.StartLine <= 0 {
+		t.Errorf("UserRepository start line = %d, want a real line", repo.StartLine)
+	}
+	if !strings.Contains(repo.Signature, "UserRepository") {
+		t.Errorf("UserRepository signature = %q, want the declaration text", repo.Signature)
+	}
+	if find("User", "class") == nil {
+		t.Error("class User in src/domain/User.ts lost its entity")
+	}
+
+	// The singleton module, end to end. `default_export` IS stamped here
+	// (`logger`), the stem guard DOES pass, and the only thing standing between
+	// `class Logger` and deletion is that the name comparison is
+	// case-sensitive. A case-insensitive one folds this and leaves nothing but
+	// the tier-5 file container MCP treats as noise.
+	if lf := find("src/infra/Logger.ts", "file"); lf == nil {
+		t.Fatal("no file component for src/infra/Logger.ts — the fold trigger is gone")
+	} else if lf.PropGet("default_export") != "logger" {
+		t.Fatalf("src/infra/Logger.ts default_export = %q, want %q — without the stamped "+
+			"instance name this row cannot exercise the case-sensitivity it exists to pin",
+			lf.PropGet("default_export"), "logger")
+	}
+	if find("Logger", "class") == nil {
+		t.Error("class Logger in src/infra/Logger.ts lost its entity: the module default-exports " +
+			"the INSTANCE `logger`, not the class, so it is a container for both")
+	}
+
+	// The #1727 door, end to end: both default-export forms still fold, so the
+	// declaration is absorbed and the file entity carries its span+signature.
+	for _, tc := range []struct{ decl, path string }{
+		{"LoginPage", "src/components/LoginPage.ts"},
+		{"SignupPage", "src/components/SignupPage.ts"},
+	} {
+		if find(tc.decl, "class") != nil {
+			t.Errorf("%s default-exports itself from %s and must still fold into its file entity",
+				tc.decl, tc.path)
+		}
+		fe := find(tc.path, "file")
+		if fe == nil {
+			t.Fatalf("no file component for %s", tc.path)
+		}
+		if fe.PropGet("default_export") != tc.decl {
+			t.Errorf("%s file entity default_export = %q, want %q — the fold gate reads this "+
+				"property and silently denies every fold when it is absent",
+				tc.path, fe.PropGet("default_export"), tc.decl)
+		}
+		if !strings.Contains(fe.Signature, tc.decl) {
+			t.Errorf("%s file entity signature = %q, want the absorbed declaration text",
+				tc.path, fe.Signature)
+		}
+	}
+}

--- a/internal/extractors/javascript/default_export.go
+++ b/internal/extractors/javascript/default_export.go
@@ -1,0 +1,128 @@
+package javascript
+
+// Default-export surfacing — Issue #6202.
+//
+// WHAT THIS IS FOR. foldFileComponentDuplicates (cmd/grafel/index.go) collapses
+// a stem-named class-like declaration into its SCOPE.Component(subtype="file")
+// sibling. That is correct where a module and the declaration it exports are
+// the same entity (#1727: `LoginPage` in `LoginPage.tsx`) and destructive
+// everywhere else (#6138: `interface IERC4626` in `IERC4626.sol`).
+//
+// #6138 drew that line with an extension allow-list. `.tsx`, `.jsx`, `.vue`,
+// `.svelte` and `.astro` name the component convention on their own, so the
+// extension is a sufficient signal for them. `.ts` and `.js` are not: they are
+// the extension for that convention AND for every other kind of TypeScript and
+// JavaScript module, so gating on them left `class UserRepository` in
+// `UserRepository.ts` being deleted exactly like a React component (#6202).
+//
+// The mechanic behind the convention is the DEFAULT EXPORT. A component module
+// is `export default LoginPage` — importers name the file and get the
+// declaration, so the two really are one entity. A domain module is
+// `export class UserRepository` / `export interface IUserRepository`: a named
+// export, addressed by its own name, in a file that is a container.
+//
+// Nothing surfaced that at the point the fold runs. walk() unwraps
+// `export_statement` and recurses into the declaration inside it, so the export
+// form was discarded before any entity was emitted. This pass reads it back off
+// the AST and stamps it on the file entity, which is the record the fold
+// already holds as the fold survivor.
+//
+// DELIBERATELY CONSERVATIVE. Only a default export that names a declaration in
+// this module is stamped: `export default class Foo`, `export default function
+// foo`, and `export default Foo;`. An anonymous default, a call-expression
+// default (`export default connect(...)(Foo)`) and a re-exported default
+// (`export { default } from './Foo'`) are left unstamped, because the fold
+// treats the absence of the signal as "keep the declaration" — the answer that
+// loses nothing when the guess would have been wrong.
+
+import "github.com/cajasmota/grafel/internal/treesitter/ts"
+
+// DefaultExportProp is the file-entity property carrying the name of the
+// symbol this module default-exports, or absent when the module has no default
+// export that names one of its own declarations.
+const DefaultExportProp = "default_export"
+
+// stampDefaultExport records the module's default-export name on the file
+// entity. No-op when the module has no resolvable default export.
+func (x *extractor) stampDefaultExport(root ts.Node) {
+	name := x.defaultExportName(root)
+	if name == "" {
+		return
+	}
+	for i := range x.entities {
+		e := &x.entities[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "file" {
+			continue
+		}
+		if e.Properties == nil {
+			e.Properties = map[string]string{}
+		}
+		e.Properties[DefaultExportProp] = name
+		return
+	}
+}
+
+// defaultExportName returns the name of the declaration this module default
+// exports, or "" when there is none or it does not name a declaration.
+//
+// A default export is only legal at module scope, so this scans the program's
+// direct children rather than the whole tree.
+func (x *extractor) defaultExportName(root ts.Node) string {
+	if root == nil {
+		return ""
+	}
+	count := int(root.ChildCount())
+	for i := 0; i < count; i++ {
+		n := root.Child(i)
+		if n == nil || n.Type() != "export_statement" {
+			continue
+		}
+		// The `default` keyword must be a DIRECT child. That is also what
+		// excludes `export { default } from './Foo'`, which forwards ANOTHER
+		// module's default: there the token sits inside an export_clause, so
+		// this module is correctly not read as the declaration.
+		if !exportStatementIsDefault(n) {
+			continue
+		}
+		// `export default class Foo {}` / `export default function foo() {}`.
+		if d := n.ChildByFieldName("declaration"); d != nil {
+			if nm := d.ChildByFieldName("name"); nm != nil {
+				return x.nodeText(nm)
+			}
+			// Anonymous declaration — nothing to match a file stem against.
+			//
+			// KEPT DELIBERATELY THOUGH IT IS EQUIVALENT TO FALLING THROUGH: a
+			// declaration node carries no `value` field today, so the check
+			// below would return "" anyway and no test can distinguish the
+			// two. That equivalence is a property of the grammar, not of this
+			// pass — reaching the `value` branch with a declaration in hand
+			// would be reading a second answer out of a node that already gave
+			// one. The unreachable re-export guard removed alongside this was
+			// a different case: its intent was already carried by
+			// exportStatementIsDefault, so it said nothing this file did not.
+			return ""
+		}
+		// `export default Foo;` — a bare identifier referring to a declaration
+		// made earlier in the same module. Anything else (a call expression, an
+		// object literal, an arrow function) names no declaration.
+		if v := n.ChildByFieldName("value"); v != nil && v.Type() == "identifier" {
+			return x.nodeText(v)
+		}
+		return ""
+	}
+	return ""
+}
+
+// exportStatementIsDefault reports whether an export_statement carries the
+// `default` keyword as a direct child. The keyword is an anonymous token, so it
+// is found by type rather than by field.
+func exportStatementIsDefault(n ts.Node) bool {
+	count := int(n.ChildCount())
+	for i := 0; i < count; i++ {
+		c := n.Child(i)
+		if c != nil && c.Type() == "default" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -399,6 +399,18 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		x.emitTranslationKeyEdges(root)
 	}()
 
+	// Issue #6202 — stamp the module's default-export name on the file entity.
+	// foldFileComponentDuplicates needs to tell a component module (`export
+	// default LoginPage`, where the module and the declaration are one entity)
+	// from a domain module (`export class UserRepository`, where the file is a
+	// container); `.ts` and `.js` are the extension for both, so the extension
+	// gate #6138 added cannot carry that distinction on its own. Runs after
+	// walk so the file entity exists.
+	func() {
+		defer func() { _ = recover() }()
+		x.stampDefaultExport(root)
+	}()
+
 	// Third pass (#713): platform-variant and test-file relationship emission.
 	// Detects React Native platform-specific file naming (.ios.tsx,
 	// .android.tsx, .tablet.tsx, …) and emits PLATFORM_VARIANT_OF edges.

--- a/internal/extractors/javascript/issue6202_default_export_test.go
+++ b/internal/extractors/javascript/issue6202_default_export_test.go
@@ -1,0 +1,134 @@
+package javascript_test
+
+// Issue #6202 — the file entity must carry the name of the module's default
+// export.
+//
+// foldFileComponentDuplicates (cmd/grafel/index.go) collapses a stem-named
+// declaration into its subtype="file" sibling. #6138 gated that on the file
+// extension, but `.ts` and `.js` are the extension for the React/Vue component
+// convention AND for every other kind of module, so a backend module still lost
+// its declarations. The signal that separates the two is the DEFAULT EXPORT:
+// a component module is `export default LoginPage`, a domain module is
+// `export class UserRepository`.
+//
+// Nothing surfaced that at the point the fold runs. The walk unwraps
+// `export_statement` and recurses into the declaration inside it
+// (extractor.go), so the export form was discarded before any entity was
+// emitted, and the file entity's properties were kind/subtype/module/language
+// only. These tests pin the property that closes that gap; the fold's use of it
+// is pinned in cmd/grafel (TestIssue6202_*).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// fileEntityOf returns the per-file SCOPE.Component(subtype="file") record.
+func fileEntityOf(t *testing.T, entities []types.EntityRecord) *types.EntityRecord {
+	t.Helper()
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "file" {
+			return &entities[i]
+		}
+	}
+	t.Fatal("no file entity emitted")
+	return nil
+}
+
+// TestIssue6202_FileEntityCarriesDefaultExportName pins the property on every
+// default-export form the convention actually uses, and pins its ABSENCE for
+// the module shapes that must not be read as "this module is this declaration".
+func TestIssue6202_FileEntityCarriesDefaultExportName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		src  string
+		want string
+	}{
+		{
+			name: "default_class_declaration",
+			src:  "import React from 'react';\nexport default class LoginPage extends React.Component {\n  render() { return null; }\n}\n",
+			want: "LoginPage",
+		},
+		{
+			name: "default_function_declaration",
+			src:  "export default function LoginPage() {\n  return null;\n}\n",
+			want: "LoginPage",
+		},
+		{
+			name: "default_async_function_declaration",
+			src:  "export default async function loadPage() {\n  return null;\n}\n",
+			want: "loadPage",
+		},
+		{
+			name: "default_identifier_after_declaration",
+			src:  "class LoginPage {\n  render() { return null; }\n}\n\nexport default LoginPage;\n",
+			want: "LoginPage",
+		},
+		{
+			name: "default_identifier_after_const_arrow",
+			src:  "const LoginPage = () => null;\n\nexport default LoginPage;\n",
+			want: "LoginPage",
+		},
+		{
+			// The backend shape #6202 is about. A named export says nothing
+			// about the module being a second name for the declaration.
+			name: "named_export_only",
+			src:  "export class UserRepository {\n  findById(id: string) { return null; }\n}\n",
+			want: "",
+		},
+		{
+			name: "named_interface_export_only",
+			src:  "export interface IUserRepository {\n  findById(id: string): void;\n}\n",
+			want: "",
+		},
+		{
+			// Anonymous default: there is no name to match a stem against, so
+			// stamping anything here would be an invention.
+			name: "anonymous_default_class",
+			src:  "export default class {\n  render() { return null; }\n}\n",
+			want: "",
+		},
+		{
+			// `export default connect(mapState)(LoginPage)` — the default
+			// export is a call result, not a declaration in this module.
+			// Deliberately not resolved: the conservative answer keeps the
+			// declaration's entity rather than deleting it on a guess.
+			name: "default_call_expression",
+			src:  "const LoginPage = () => null;\nexport default connect(mapState)(LoginPage);\n",
+			want: "",
+		},
+		{
+			// A re-export forwards another module's default; this module is
+			// not the declaration.
+			name: "reexport_default_from_other_module",
+			src:  "export { default } from './LoginPage';\n",
+			want: "",
+		},
+		{
+			name: "no_exports_at_all",
+			src:  "class LoginPage {\n  render() { return null; }\n}\n",
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			src := []byte(tc.src)
+			ents := extractAtPath(t, src, "typescript", "src/components/LoginPage.ts")
+			got := fileEntityOf(t, ents).Properties["default_export"]
+			if got != tc.want {
+				t.Errorf("file entity default_export = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIssue6202_DefaultExportStampedForJavaScriptToo pins the same property on
+// the JavaScript grammar. `.js` is allow-listed by the fold for the same reason
+// `.ts` is, so it needs the same signal or the gate denies every `.js` fold.
+func TestIssue6202_DefaultExportStampedForJavaScriptToo(t *testing.T) {
+	src := []byte("import React from 'react';\n\nclass LoginPage extends React.Component {\n  render() { return null; }\n}\n\nexport default LoginPage;\n")
+	ents := extractAtPath(t, src, "javascript", "src/components/LoginPage.js")
+	if got := fileEntityOf(t, ents).Properties["default_export"]; got != "LoginPage" {
+		t.Errorf("file entity default_export = %q, want %q", got, "LoginPage")
+	}
+}

--- a/tools/coverage/capability-map.yaml
+++ b/tools/coverage/capability-map.yaml
@@ -379,12 +379,30 @@ records:
     capabilities:
       Structure:
         component_extraction:
+          # foldFileComponentDuplicates decides whether a component module keeps
+          # one entity or two: it collapses a stem-named declaration into its
+          # subtype="file" sibling, which is right for a React component module
+          # (#1727) and destructive anywhere a file is a container (#6138). The
+          # extension gate #6138 added could not carry that for `.ts`/`.js`,
+          # which are the extension for both, so #6202 made the fold read the
+          # module's DEFAULT EXPORT — surfaced by stampDefaultExport — and a
+          # backend `export class UserRepository` stopped being deleted while
+          # `export default LoginPage` still folds.
           status: partial
           symbols:
             - file: internal/extractors/javascript/extractor.go
               functions: [extractJSXRendersRelationships]
-          issues_implemented: ["2735"]
-          verified_at: "2026-05-28"
+            - file: internal/extractors/javascript/default_export.go
+              functions: [stampDefaultExport, defaultExportName, exportStatementIsDefault]
+            - file: cmd/grafel/index.go
+              functions: [foldFileComponentDuplicates, fileIsItsDeclaration]
+          tests:
+            - file: internal/extractors/javascript/issue6202_default_export_test.go
+              functions: [TestIssue6202_FileEntityCarriesDefaultExportName, TestIssue6202_DefaultExportStampedForJavaScriptToo]
+            - file: cmd/grafel/issue6202_ts_module_fold_test.go
+              functions: [TestIssue6202_NamedExportModulesKeepTheirDeclarations, TestIssue6202_DefaultExportModulesStillFold, TestIssue6202_DefaultExportOfADifferentSymbolDoesNotFold, TestIssue6202_ComponentExtensionsFoldWithoutADefaultExport, TestIssue6202_BackendTypeScriptSurvivesFullIndex]
+          issues_implemented: ["2735", "6202"]
+          verified_at: "2026-08-06"
         context_extraction:
           status: full
           symbols:


### PR DESCRIPTION
#6138 closed the file fold for Solidity, Java, Go and C# by gating it on an extension allow-list. `.ts` and `.js` were allow-listed **wholesale** — and those extensions serve the React/Vue component convention *and* every other kind of module. So a backend TypeScript tree still lost its stem-named classes.

## The measurements in the issue were wrong, and the correction matters

Only one of the three reported rows reproduces end to end:

| declaration | reported | measured through a real index |
|---|---|---|
| `class UserRepository` in `UserRepository.ts` | deleted | **deleted — confirmed** |
| `interface IUserRepository` in `IUserRepository.ts` | deleted | **survives** — TS emits interfaces as `SCOPE.Schema`, which the fold never considers |
| `OrdersService`, `subtype="service"` | deleted | **survives** — NestJS classes are stamped `angular_service`, absent from `classLikeComponentSubtypes` |

The issue was written against the fold predicate on hand-built records rather than through the pipeline, so two of its rows never reach the function at all. **A predicate probe and an end-to-end run answer different questions, and the difference is everything upstream of the predicate.** Both non-reproducing rows are still pinned at the record level, because the pass is language-agnostic and any extractor emitting `SCOPE.Component` with a class-like subtype for a `.ts` file reaches it — Solidity's already does.

The second row's cause is filed as #6213: `classLikeComponentSubtypes` contains `"service"`, and that entry never fires for NestJS. Five subtypes are affected, and the adjacent comment shows Controller/Resolver/Gateway were deliberately named to match the allow-list while `@Injectable` was missed. That is #6138's own mechanism — behaviour decided by set membership rather than by what the code is — one level down.

## The signal did not exist, so it had to be built

Dropping `.ts`/`.js` from the allow-list is the obvious fix and it is wrong: `TestDupKindFold_*` fixtures are `.tsx`/`.ts`, and a React project with `src/components/LoginPage.ts` re-exporting its component is exactly what would regress. The distinction is not carryable by the extension at all. It needs a signal meaning *"this module exists to export this one declaration"*.

That signal was **absent**. The JS/TS extractor hits `case "export_statement"` and immediately recurses into the declaration inside (`internal/extractors/javascript/extractor.go:877`), discarding the export form before any entity is emitted — confirmed by probe: a `.ts` file entity carried `kind`/`subtype`/`module`/`test_reachable` and nothing about exports. (`internal/substrate/entry_points_jsts.go` does sniff default exports by regex, but for entry-point seeding, and its answer never reaches these records.)

So `internal/extractors/javascript/default_export.go` stamps `default_export=<name>` on the file entity — the record the fold already holds as the survivor. Deliberately conservative: only `export default class Foo`, `export default function foo`, `export default Foo;`. Anonymous, call-expression and re-exported defaults are unstamped, and **absence denies the fold** — a missing stamp keeps an entity, a false stamp deletes a declaration, so every ambiguity resolves toward keeping.

`fileIsDeclarationExtensions` splits into `componentFileExtensions` (`.jsx/.tsx/.vue/.svelte/.astro` — the extension names the convention, unchanged) and `moduleFileExtensions` (`.js/.mjs/.cjs/.ts/.mts/.cts` — fold only when the module default-exports the declaration by name).

## The comparison is case-sensitive, and review caught that it wasn't

The first version compared with `strings.EqualFold`. `defaultExport` and `declName` are two identifiers **from the same source file**, where case is the language's identity rule — so the ubiquitous singleton convention read as "this module default-exports its class":

```ts
export class Logger { … }
const logger = new Logger();
export default logger;
```

Stamp is `"logger"`, stem guard passes, `EqualFold("logger","Logger")` is true, **`class Logger` deleted** — reproduced end to end, and the same shape kills `UserRepository`, the entity this change exists to save. The default export is the *instance*; the module is a container holding both, which is precisely the distinction being drawn. Not a regression from `main`, but an incomplete fix in the destructive direction on the exact shape the issue targets.

Now `==`, with the asymmetry documented: the **stem**-vs-name comparison stays case-insensitive because a filename is not an identifier, so `loginPage.ts` holding `class LoginPage` still folds. Verified in order — the case-insensitive stem guard matches first, then `LoginPage == LoginPage`.

`==` is not too strict anywhere: every shape where two same-file identifiers differ only by case is genuinely two bindings, and no extractor case-normalises entity names for these extensions.

## The unfolded HOC module is a strict improvement, not a concession

`export default connect(...)(LoginPage)` is unresolved, so such a module no longer folds. Measured against a reconstructed pre-fix predicate rather than assumed:

| | folded (pre-fix) | unfolded (now) |
|---|---|---|
| entities | 9 | 10 |
| `class LoginPage` | **gone** | present, tier 0 |
| `RENDERS` from `Home` | → the tier-5 `noiseContainer` file entity | → the **class** |
| `EXTENDS → React.Component` | re-homed onto the file entity | on the class |
| dangling edges | 6 (pre-existing) | 6 — unchanged |

No double-counting, no duplicate in MCP output, no broken edge. For a React HOC module the unfolded state answers *"where is `LoginPage`"* and *"what renders it"* better than folding did.

## Tests

18 adversarial extractor shapes probed; 16 correct and both misses in the keep-the-entity direction. `Foo.d.ts` stamps but never folds (stem is `foo.d`); `export { Foo as default }`, `export default (Foo)`, `export default Foo as Bar` and a `default` inside a `namespace` all yield no stamp; a `default` in a comment or string yields none, because this reads the AST rather than the source.

Mutation: 11 in the first round plus 9 in review. `fileIsItsDeclaration` always-true and always-false are killed by **disjoint** sets. The singleton rows are killed by reverting `==` to `EqualFold` while `factory_function`, all four `DefaultExportModulesStillFold` rows, all five `ComponentExtensions` rows, `TestIssue6138_*` and all eight `TestDupKindFold_*` survive — so the new rows carry case-sensitivity rather than restating existing coverage, and `==` costs the #1727 door nothing.

Three rows pin the stem-case asymmetry that the comment describes (`loginPage.ts`, `loginpage.ts`, `LOGINPAGE.ts`, all folding `class LoginPage`). They are killed only by a mutant that makes the **stem** comparison case-sensitive too — the edit a future reader "simplifying both comparisons" would actually make. A first attempt at that mutant killed all seven rows including the pre-existing ones, which made it worthless as evidence; it was discarded rather than banked.

`TestIssue6202_BackendTypeScriptSurvivesFullIndex` runs end to end and asserts the stamp's *value*, so it cannot pass because the stamp went missing — the kill lands on the deleted class, not on the stamp assertion.

Two mutants are reported as **equivalent rather than survivors**, with the distinction argued: a deleted re-export guard was logically dominated by `exportStatementIsDefault`, while the retained anonymous-declaration `return ""` is equivalent only because tree-sitter declaration nodes carry no `value` field *today* — a property of the grammar, not of this pass. Guarding an invariant you rely on but do not control is not dead code.

## Upgrade behaviour — the fix lands per file, not at once

Verified by driving `mergeIncrementalPrevSource` directly: the incremental path runs `buildDocument` over the changed subset only and carries unchanged files' entities forward verbatim (`cmd/grafel/index.go:5863`). So an index built before this change **keeps its missing declarations** until each affected file changes or the repo is fully re-indexed. Safe direction — nothing new is destroyed — but it means the fix is invisible on existing indexes. Release note at tag time: re-index to recover declarations deleted by #6138/#6202.

## Cost

`defaultExportName` walks only the program's top-level statements and returns at the first default export; no second tree-walk, no regex over source. Benchmarked worst case (1200 top-level `export` statements, none default, so the scan runs with no early exit): 307.1 ms/op vs 302.6 ms/op — below noise, both dominated by parse and walk.

## Known limits

`internal/mcp/denoise.go:132` still classifies file and module components as `noiseContainer` unconditionally, which is what converts a fold into an invisibility — including for `.tsx`, where the fold is intended. Out of scope.

`internal/substrate/entry_points_jsts.go` is now a second independent answer to "what does this module default-export", via line-anchored regexes. They already disagree — the regex misses `export default abstract class`, this pass misses nothing the regex catches. Different consumers, no bug today, but they will drift.

TS interfaces being `SCOPE.Schema` means they are invisible to every pass keyed on `SCOPE.Component`, including #6118's span donation. Possibly deliberate; not documented anywhere found.

Independently adversarially reviewed twice (REQUEST-CHANGES → APPROVE), the reviewer re-running the mutation battery itself and verifying survivals by subtest count rather than inference.

Closes #6202
Refs #6138, #6213, #1727, #6075
