### PR TITLE
fix(#6212): the manifest recorded what the working tree held at commit time, not what the walk fed the graph

### DIFF
--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -306,6 +306,16 @@ type Indexer struct {
 	walkedFiles  []string
 	diffManifest *idiff.Manifest
 
+	// walkStamps is the manifest entry for every file this run examined,
+	// captured AT THE MOMENT the walk looked at it (#6212). It is what
+	// commitManifest stamps from, and the reason commitManifest hashes nothing.
+	//
+	// Written by the extraction workers (classifyAndReadWithProgress) and by the
+	// subprocess-extract branch, both in Run; read once, single-threaded, in
+	// commitManifest. The mutex covers the concurrent writers only.
+	walkStampMu sync.Mutex
+	walkStamps  map[string]idiff.FileEntry
+
 	// incrementalCarryForwardEntities holds the previous-graph entities sourced
 	// from UNCHANGED files during an incremental reindex. buildDocument seeds the
 	// resolver index with their (name, kind) → stable-ID identity so that
@@ -1006,9 +1016,95 @@ var capturedStats io.Writer
 // return to inject through and no other way to reach that branch.
 var writeGraphGen = fbwriter.WriteGraphGen
 
+// osStat and osReadFile are the extraction worker's stat and read behind vars,
+// so a test can make a working-tree write land at a precise point INSIDE the
+// per-file sequence (#6212). One indirect call each per file.
+//
+// They exist because the two properties the stamp rests on are both about
+// ORDER, and order is unobservable from outside the loop:
+//
+//   - the stat is taken BEFORE the read, so the stamp's mtime can only be
+//     staler than its content, never fresher. A test hooks osStat to rewrite
+//     the file as a side effect; the read then sees post-write bytes and the
+//     stamp must pair them with the PRE-write mtime.
+//   - the hash is over the bytes the pipeline RECEIVED, not a re-read of the
+//     path. A test hooks osReadFile to return bytes that are not on disk; a
+//     re-reading implementation stamps the disk's bytes and dies.
+//
+// Without these, replacing `content` with a fresh os.ReadFile of the same path
+// — same value, different moment — passes the whole suite.
+var (
+	osStat     = os.Stat
+	osReadFile = os.ReadFile
+)
+
+// recordWalkStamp records the manifest entry for one walked file, computed at
+// the moment the pipeline examined it. Safe to call from the extraction workers.
+//
+// FIRST WRITE WINS, and that is a correctness rule, not an optimisation. A .py
+// file is read TWICE per run — once by the cross-file registry pre-pass in
+// runPass1ExtractWithProgress, once by the worker below — and both reads feed
+// the graph (the registry drives extractBaseClasses' cross-file INHERITS and the
+// DRF bare-Route suppression). If a write lands between them the two halves of
+// the graph disagree, and the only stamp that cannot LEAD the graph is the
+// EARLIEST one: stamping the first read means a later divergence re-presents the
+// file as changed and it is re-extracted, where stamping the second would
+// hash-match the disk and freeze the registry's wrong contribution in place
+// (#6212).
+func (i *Indexer) recordWalkStamp(rel string, e idiff.FileEntry) {
+	i.walkStampMu.Lock()
+	if i.walkStamps == nil {
+		i.walkStamps = make(map[string]idiff.FileEntry)
+	}
+	if _, seen := i.walkStamps[rel]; !seen {
+		i.walkStamps[rel] = e
+	}
+	i.walkStampMu.Unlock()
+}
+
+// stampReadFile records the walk stamp for a file whose bytes the pipeline has
+// in hand. The SHA-256 is over exactly THOSE bytes — the ones the document is
+// built from — and never over a re-read of the path, which is the whole defect:
+// the same path at two moments is not the same bytes (#6212). See
+// diff.StampBytes for the stat-before-read requirement.
+func (i *Indexer) stampReadFile(rel string, content []byte, statSize int64, statMtime int64) {
+	i.recordWalkStamp(rel, idiff.StampBytes(content, statSize, statMtime))
+}
+
+// stampUnreadFiles records walk stamps for files whose bytes this process never
+// sees at all: the GRAFEL_SUBPROC_EXTRACT path, where the children do the
+// reading. Files the classifier SKIPS are hashed inline in the worker instead,
+// at the moment of the skip decision — see there for why the timing matters.
+//
+// The manifest must carry an entry for every walked file or the prune's absence
+// re-presents it as new on every pass, which is #5667's immortal-entry loop in
+// the other direction. go.mod in the #6207 fixture is exactly this case.
+func (i *Indexer) stampUnreadFiles(absRepo string, rels []string) {
+	sem := make(chan struct{}, 16)
+	var wg sync.WaitGroup
+	for _, rel := range rels {
+		wg.Add(1)
+		go func(r string) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			entry, err := idiff.HashFile(filepath.Join(absRepo, filepath.FromSlash(r)))
+			if err != nil {
+				// Unreadable or vanished. Leaving it unstamped matches what
+				// UpdateManifest did on a hash error: no entry, so the next
+				// pass treats it as new. Over-reporting, never staleness.
+				return
+			}
+			i.recordWalkStamp(r, entry)
+		}(rel)
+	}
+	wg.Wait()
+}
+
 // commitManifest persists the file-hash manifest describing THIS run: every
-// walked file, re-stamped, with entries for anything no longer in the walk
-// pruned. Best-effort — a write failure is logged and never fails the index.
+// walked file, stamped with the hash the WALK computed, with entries for
+// anything no longer in the walk pruned. Best-effort — a write failure is
+// logged and never fails the index.
 //
 // ORDERING IS THE POINT (#6207 review). Index calls this only on the success
 // branch of fbwriter.WriteGraphGen, never from Run. Run returns before the
@@ -1035,28 +1131,23 @@ var writeGraphGen = fbwriter.WriteGraphGen
 // scoped reject leaves behind — the files re-read as changed and are
 // re-extracted. Over-reporting, never staleness.
 //
-// CONTENT: per file, the manifest can be newer than the graph, and here the
-// hazard is real. UpdateManifest hashes each file AT THIS MOMENT, whereas the
-// document was built from the bytes Run's walk read. A working-tree write
-// landing in between is stamped into the manifest but is not in the graph, so
-// the next pass hash-matches it, classifies it UNCHANGED (diff.go:411-413) and
-// the edit stays invisible until the file is touched again or HEAD advances.
-// Measured, not theorised: a probe injecting a working-tree write inside the
-// writeGraphGen seam confirmed the manifest stamps post-walk content. The
-// realistic trigger is exactly the watcher-driven fallback — it fires BECAUSE
-// files are changing.
+// CONTENT: on every path that BUILDS a graph, the manifest can only ever be
+// older than that graph, never newer (#6212). Nothing is hashed here. Every
+// stamp was computed at the moment the pipeline read the file, so it describes
+// exactly the bytes the document was built from, whatever the working tree has
+// done since. A write landing inside this window re-presents as changed on the
+// next pass and is picked up, instead of being stamped as indexed and
+// hash-matched away. internal/extractors.TryIncremental's Step 9 holds the same
+// invariant by the same means.
 //
-// This is pre-existing on the WithIncremental path but NEW on the fallback,
-// which previously wrote no manifest at all, so the old stamp caught the edit.
-// The window also got wider on both: it now spans rename-detect, algo
-// carry-forward, sortDocumentForEmission and the whole of WriteGraphGen —
-// seconds on a real repo, where it used to be immediately post-extraction.
-//
-// It is nevertheless the RIGHT TRADE and must not be reverted: losing one edit
-// until its next touch is self-recovering, while the permanent stuck state
-// above is not. The real fix — stamping from the hashes the walk already
-// computed, so the manifest describes the same bytes the graph was built from —
-// is filed separately.
+// ONE SITE IS STILL EXEMPT, and it is not this one: the zero-change pass in
+// internal/extractors/incremental.go is the last caller of diff.UpdateManifest
+// and still sweeps the whole repo. That pass extracts nothing, so it has no
+// bytes to stamp from;
+// the sweep is there to HEAL the residuals a #6201 scoped reject leaves behind,
+// and deleting it is #6206's job, not this one. Until then a write landing
+// inside that pass is stamped without being indexed. Do not read the paragraph
+// above as covering it.
 //
 // graphDir is filepath.Dir(outPath) — the directory the graph was just written
 // to. It is the destination whenever the run did not read a manifest from
@@ -1081,13 +1172,15 @@ func (i *Indexer) commitManifest(absRepo, graphDir string) {
 	}
 	m := i.diffManifest
 	if m == nil {
-		// A full index never loaded one. Start from whatever is on disk — the
-		// UpdateManifest below re-stamps every walked file and prunes
-		// everything else, so the result is the walk either way; loading only
-		// keeps the manifest's own metadata continuous.
+		// A full index never loaded one. Start from whatever is on disk — a
+		// full walk stamps every file and the prune drops everything else, so
+		// the result is the walk either way; loading only keeps the manifest's
+		// own metadata continuous. On a DELTA run the loaded manifest carries
+		// the stamps for the files this run did not walk, which is why
+		// ApplyStamps overlays rather than replaces.
 		m = idiff.LoadManifest(dest)
 	}
-	idiff.UpdateManifest(absRepo, i.walkedFiles, m)
+	idiff.ApplyStamps(i.walkStamps, i.walkedFiles, m)
 	if err := idiff.SaveManifest(dest, absRepo, m); err != nil {
 		fmt.Fprintf(os.Stderr, "grafel: save incremental manifest: %v (non-fatal)\n", err)
 	}
@@ -1459,6 +1552,17 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 
 	trk.PhaseStart(progress.PhaseExtractAST, 0, 0)
 	if subprocExtract() {
+		// #6212 — the children read the bytes in another process, so this side
+		// has no hash to thread out. Take them HERE, before the coordinator
+		// starts, rather than at commit time. A write racing the children then
+		// leaves the manifest stamping the PRE-write bytes while the graph got
+		// the post-write ones: the file re-presents as changed next pass and is
+		// re-extracted. Over-reporting, which is the safe direction — the
+		// commit-time hash had it the other way round and lost the edit.
+		// Threading the real hashes back out of extract.Coordinate would remove
+		// even that; it needs an IPC field and this path is off by default
+		// (GRAFEL_SUBPROC_EXTRACT).
+		i.stampUnreadFiles(absRepo, files)
 		res, cerr := extract.Coordinate(ctx, absRepo, files, extract.CoordinatorConfig{
 			Concurrency: subprocConcurrency(),
 			BatchSize:   subprocBatchSize(),
@@ -3436,7 +3540,24 @@ func (i *Indexer) runPass1ExtractWithProgress(ctx context.Context, absRepo strin
 		if !strings.HasSuffix(strings.ToLower(rel), ".py") {
 			continue
 		}
-		if content, err := os.ReadFile(abs); err == nil {
+		// #6212 — this is the FIRST of two reads of every .py file, and its
+		// output reaches the graph (cross-file INHERITS via extractBaseClasses,
+		// and DRF bare-Route suppression). So it is a point the graph is built
+		// from, and it must be stamped like one.
+		//
+		// recordWalkStamp is first-wins, so this stamp beats the worker's later
+		// read of the same file. That is the correct direction: if a write lands
+		// between the two reads, the registry holds pre-write bytes and the
+		// entities post-write, and only the EARLIER stamp re-presents the file
+		// as changed next pass. Stamping the later read would hash-match the
+		// disk and freeze a wrong INHERITS edge in place.
+		statSize, statMtime := int64(-1), int64(0)
+		if st, serr := osStat(abs); serr == nil {
+			statSize = st.Size()
+			statMtime = st.ModTime().UnixNano()
+		}
+		if content, err := osReadFile(abs); err == nil {
+			i.stampReadFile(rel, content, statSize, statMtime)
 			pyextr.ScanPythonClassRegistry(rel, string(content))
 			engine.ScanDRFRegisterNames(content)
 		}
@@ -3536,12 +3657,29 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 		go func() {
 			defer wg.Done()
 			for t := range tasks {
+				// #6212 — this stat is also the manifest stamp's size/mtime, and
+				// it is taken BEFORE the read on purpose. See diff.StampBytes.
 				size := int64(-1)
-				if st, err := os.Stat(t.absPath); err == nil {
+				statMtime := int64(0)
+				if st, err := osStat(t.absPath); err == nil {
 					size = st.Size()
+					statMtime = st.ModTime().UnixNano()
 				}
+				statSize := size
 				cr := i.classifier.ClassifyWithSize(ctx, t.relPath, size)
 				if cr.Skip || cr.Language == "" {
+					// Hashed INLINE, here, rather than batched after the worker
+					// pool joins (#6212). The classifier decided on the size
+					// this stat reported, so the stamp has to be taken against
+					// the same observation: deferring it to the end of
+					// extraction let an oversized file be truncated in between
+					// and stamped at its new, small content — which then
+					// hash-matches on the next pass and is never extracted even
+					// though it is now indexable. Serialising a big hash into a
+					// worker is a throughput cost; that was a correctness one.
+					if entry, herr := idiff.HashFile(t.absPath); herr == nil {
+						i.recordWalkStamp(t.relPath, entry)
+					}
 					mu.Lock()
 					i.stats.skipped++
 					mu.Unlock()
@@ -3550,8 +3688,14 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					continue
 				}
 
-				content, err := os.ReadFile(t.absPath)
+				content, err := osReadFile(t.absPath)
 				if err != nil {
+					// Deliberately UNSTAMPED. With no bytes there is no evidence
+					// of what was indexed, and stamping a transient failure from
+					// a later successful hash would claim content nothing ever
+					// extracted. Unstamped means the file reads as new next pass
+					// — over-reporting, never staleness, which is the same rule
+					// the hash-error branch in stampUnreadFiles follows.
 					mu.Lock()
 					i.stats.failed++
 					mu.Unlock()
@@ -3559,6 +3703,12 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					recordAndMaybeTick(atomic.LoadInt64(&byteCounter), t.relPath)
 					continue
 				}
+
+				// The graph is built from THESE bytes, so this is the hash the
+				// manifest must carry (#6212). Recorded here rather than
+				// re-derived at commit time, which is what made the manifest
+				// able to describe content the walk never saw.
+				i.stampReadFile(t.relPath, content, statSize, statMtime)
 
 				if size < 0 {
 					size = int64(len(content))

--- a/cmd/grafel/manifest_walk_stamp_6212_test.go
+++ b/cmd/grafel/manifest_walk_stamp_6212_test.go
@@ -1,0 +1,167 @@
+package main
+
+// #6212 — the manifest must be stamped from the hashes computed during the
+// WALK, not from a re-hash at commit time.
+//
+// commitManifest used to call diff.UpdateManifest, which opens and SHA-256s
+// every walked file AT COMMIT TIME. The document, however, was built from the
+// bytes Run's walk read — and #6207 widened the gap between those two moments
+// to span rename-detect, algo carry-forward, sortDocumentForEmission and the
+// whole of WriteGraphGen. Anything written into the working tree inside that
+// window was stamped into the manifest without ever being indexed, and the next
+// pass hash-matched it and classified it UNCHANGED (diff.go isChanged), so the
+// edit stayed invisible until the file was touched again or HEAD advanced.
+//
+// The realistic trigger is the watcher-driven fallback reindex — it fires
+// BECAUSE files are changing, so a developer saving a file mid-reindex is the
+// ordinary case.
+//
+// Both tests here drive the real scheduler fallback and use the writeGraphGen
+// seam — the same seam #6207's review used to MEASURE the skew — as the point
+// "after the walk, before the manifest commit". Assertions are on observable
+// state: the stamp bytes, and a hash-call counter. Never on timing.
+//
+// The fixture helpers (fallbackManifestRepo, useInProcessIndex,
+// declineIncrementalPass, ...) live in scheduler_fallback_manifest_6207_test.go.
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// TestFallbackIndex_WriteAfterTheWalkIsNotStampedAsIndexed is the defect itself.
+//
+// A working-tree write lands between the walk that fed the document and the
+// manifest commit. The graph therefore contains the OLD bytes. If the manifest
+// records the NEW ones it is claiming to have indexed content that is not in
+// the graph, and — worse than merely being wrong — that claim is self-
+// concealing: the next pass hash-matches the file, calls it unchanged, and the
+// edit is never picked up.
+//
+// The manifest may lag (stamping the old bytes re-presents the file as changed
+// next pass, which is self-correcting). It may not LEAD.
+func TestFallbackIndex_WriteAfterTheWalkIsNotStampedAsIndexed(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "walkstamp-midwrite", "main")
+	useInProcessIndex(t)
+	stateDir := daemon.StateDirForRepo(repo)
+
+	const victim = "svc/thing.go"
+	victimAbs := filepath.Join(repo, filepath.FromSlash(victim))
+	indexedHash := sha256OfFile(t, victimAbs)
+
+	assertNoManifestYet(t, stateDir)
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	assertNoManifestYet(t, stateDir)
+
+	// The seam: the walk has happened, the document is built, the graph is
+	// about to be written and commitManifest has not run yet. A developer
+	// saving a file lands exactly here.
+	var midWriteHash string
+	prevWriter := writeGraphGen
+	writeGraphGen = func(dir string, doc *graph.Document) (string, error) {
+		writeFixtureFile(t, repo, victim, "package svc\n\nfunc Thing() int { return 12345 }\n\nfunc AddedMidIndex() {}\n")
+		midWriteHash = sha256OfFile(t, victimAbs)
+		return prevWriter(dir, doc)
+	}
+	t.Cleanup(func() { writeGraphGen = prevWriter })
+
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+
+	if midWriteHash == "" {
+		t.Fatal("fixture is inert: the writeGraphGen seam never fired, so no write ever landed " +
+			"inside the walk→commit window")
+	}
+	if midWriteHash == indexedHash {
+		t.Fatal("fixture is inert: the mid-index write produced the same bytes as the indexed ones")
+	}
+
+	m := diff.LoadManifest(stateDir)
+	got := m.Files[victim].SHA256
+	if got == midWriteHash {
+		t.Fatalf("the manifest stamped %s with the POST-WALK content (%s…) — those bytes were never "+
+			"extracted, so the graph does not contain them, yet the next pass will hash-match this "+
+			"stamp and classify the file UNCHANGED. The edit is invisible until the file is touched "+
+			"again or HEAD advances (#6212).", victim, got[:12])
+	}
+	if got != indexedHash {
+		t.Fatalf("the manifest stamped %s with %q, want the hash of the bytes the walk actually read "+
+			"(%q). The manifest's contract is \"these bytes are what the graph was built from\" (#6212).",
+			victim, got, indexedHash)
+	}
+
+	// The other three fixture files were untouched, so their stamps must still
+	// be exact — the walk-time stamp is the WHOLE manifest, not a special case
+	// for the raced file.
+	for _, rel := range fallbackFixtureFiles {
+		if rel == victim {
+			continue
+		}
+		want := sha256OfFile(t, filepath.Join(repo, filepath.FromSlash(rel)))
+		if m.Files[rel].SHA256 != want {
+			t.Fatalf("manifest stamp for untouched file %q is %q, want %q (#6212)",
+				rel, m.Files[rel].SHA256, want)
+		}
+	}
+}
+
+// TestCommitManifest_PerformsNoHashSweep pins the removal.
+//
+// Once the stamps come from the walk, commitManifest has nothing left to hash:
+// it merges the walk's stamps into the manifest and reconciles membership, both
+// of which are map work. The O(repo) SHA-256 sweep — 218 ms of the 738 ms a
+// zero-change pass burns on a 3003-file fixture (#6206) — is simply gone.
+//
+// The observable is diff.HashCallCount, a counter incremented inside
+// diff.hashFile, sampled at the writeGraphGen seam and again after the index
+// returns. Everything between those two samples is the graph write plus
+// commitManifest. Deliberately NOT a timing assertion: a wall-clock budget here
+// is the test-that-cannot-fail shape this repo keeps producing.
+func TestCommitManifest_PerformsNoHashSweep(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	repo := fallbackManifestRepo(t, "walkstamp-nosweep", "main")
+	useInProcessIndex(t)
+	stateDir := daemon.StateDirForRepo(repo)
+
+	assertNoManifestYet(t, stateDir)
+	declineIncrementalPass(t, repo, "absent-graph-nonempty-tree")
+	assertNoManifestYet(t, stateDir)
+
+	var atSeam int64
+	var seamFired bool
+	prevWriter := writeGraphGen
+	writeGraphGen = func(dir string, doc *graph.Document) (string, error) {
+		atSeam = diff.HashCallCount()
+		seamFired = true
+		return prevWriter(dir, doc)
+	}
+	t.Cleanup(func() { writeGraphGen = prevWriter })
+
+	if err := daemonSchedulerIndex(context.Background(), repo, ""); err != nil {
+		t.Fatalf("daemonSchedulerIndex: %v", err)
+	}
+	if !seamFired {
+		t.Fatal("fixture is inert: writeGraphGen never ran, so nothing was sampled")
+	}
+
+	if swept := diff.HashCallCount() - atSeam; swept != 0 {
+		t.Fatalf("commitManifest hashed %d file(s) after the graph write. It must stamp from the "+
+			"hashes the walk already computed — re-hashing here is both the O(repo) sweep #6206 "+
+			"wants gone AND the source of the post-walk skew (#6212).", swept)
+	}
+
+	// The sweep is gone and the manifest is still exact — the point is that the
+	// work moved, not that it was dropped.
+	assertManifestExact(t, repo, stateDir)
+}

--- a/cmd/grafel/manifest_walk_stamp_ordering_6212_test.go
+++ b/cmd/grafel/manifest_walk_stamp_ordering_6212_test.go
@@ -1,0 +1,268 @@
+package main
+
+// #6212, review follow-up — the two ORDER properties the walk stamp rests on.
+//
+// The end-to-end tests in manifest_walk_stamp_6212_test.go pin the coarse
+// moment: the stamp comes from the walk, not from a re-hash at commit time. They
+// cannot see either of the properties below, because both are about the order of
+// operations INSIDE the per-file sequence, and from outside the loop a stamp
+// taken from `content` and a stamp taken from a fresh os.ReadFile of the same
+// path are indistinguishable — same value, different moment.
+//
+// So these drive classifyAndReadWithProgress directly and inject a working-tree
+// write at a precise point via the osStat / osReadFile seams. No index run, no
+// git fixture: a temp dir with two files, which keeps them cheap enough to run
+// on their own.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func sha256OfBytes(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// stampProbeIndexer builds a repo with one Go file and returns the indexer plus
+// the repo root. The file is real so the classifier accepts it and the worker
+// takes the read path.
+func stampProbeIndexer(t *testing.T, body string) (*Indexer, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rel := "victim.go"
+	if err := os.WriteFile(filepath.Join(repo, rel), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	idx := newTestIndexer(t, "stampprobe", []string{"extract"}, "")
+	return idx, repo, rel
+}
+
+// TestWalkStamp_HashesTheBytesThePipelineReceived_NotAReReadOfThePath is F3.
+//
+// The stamp's meaning is "these bytes are what the graph was built from". The
+// bytes the graph is built from are the ones os.ReadFile RETURNED — not whatever
+// the path holds a moment later. Re-reading to hash reintroduces the entire
+// #6212 defect in miniature: a window, and a stamp describing content no
+// extractor ever saw.
+//
+// The seam returns bytes that are deliberately NOT on disk, so an implementation
+// that re-reads stamps the disk's bytes and dies here, while producing an
+// identical stamp to the correct one in every other test.
+func TestWalkStamp_HashesTheBytesThePipelineReceived_NotAReReadOfThePath(t *testing.T) {
+	const onDisk = "package victim\n\nfunc OnDisk() {}\n"
+	const handedToPipeline = "package victim\n\nfunc HandedToThePipeline() int { return 7 }\n"
+
+	idx, repo, rel := stampProbeIndexer(t, onDisk)
+
+	prev := osReadFile
+	osReadFile = func(name string) ([]byte, error) {
+		if filepath.Base(name) == rel {
+			return []byte(handedToPipeline), nil
+		}
+		return prev(name)
+	}
+	t.Cleanup(func() { osReadFile = prev })
+
+	idx.classifyAndReadWithProgress(context.Background(), repo, []string{rel}, false, nil)
+
+	got := idx.walkStamps[rel].SHA256
+	if got == "" {
+		t.Fatal("fixture is inert: no stamp was recorded for the victim file at all")
+	}
+	if got == sha256OfBytes([]byte(onDisk)) {
+		t.Fatalf("the stamp is the hash of the bytes ON DISK, not of the bytes the pipeline was "+
+			"handed. The extractors saw %q and the graph contains those entities, but the manifest "+
+			"describes something else — a re-read of the path is the #6212 defect in miniature "+
+			"(#6212)", handedToPipeline)
+	}
+	if want := sha256OfBytes([]byte(handedToPipeline)); got != want {
+		t.Fatalf("stamp is %q, want the hash of the bytes the pipeline received (%q)", got, want)
+	}
+}
+
+// TestWalkStamp_StatIsTakenBeforeTheRead is F5.
+//
+// size/mtime feed isChanged's fast path: when both match, the next pass skips
+// the hash entirely and calls the file unchanged. So pairing POST-write metadata
+// with PRE-write content is the one combination that loses an edit silently — it
+// is the fast path lying, which no hash ever gets to correct.
+//
+// Taking the stat before the read makes the metadata at worst STALER than the
+// content, which sends the next pass to the hash. This test makes a write land
+// between the stat and the read: the read sees the new bytes, and the stamp must
+// therefore carry the new hash beside the OLD mtime. An implementation that
+// stats after reading records the new mtime, and the pair becomes self-
+// consistent-but-wrong the moment anything else diverges.
+func TestWalkStamp_StatIsTakenBeforeTheRead(t *testing.T) {
+	const before = "package victim\n\nfunc Before() {}\n"
+	const after = "package victim\n\nfunc After() int { return 99 }\n"
+
+	idx, repo, rel := stampProbeIndexer(t, before)
+	abs := filepath.Join(repo, rel)
+
+	preInfo, err := os.Stat(abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preMtime := preInfo.ModTime().UnixNano()
+
+	prev := osStat
+	var fired bool
+	osStat = func(name string) (os.FileInfo, error) {
+		info, serr := prev(name)
+		if filepath.Base(name) == rel && !fired {
+			fired = true
+			// The write lands AFTER the stat was taken and BEFORE the read.
+			if werr := os.WriteFile(abs, []byte(after), 0o644); werr != nil {
+				t.Error(werr)
+			}
+		}
+		return info, serr
+	}
+	t.Cleanup(func() { osStat = prev })
+
+	idx.classifyAndReadWithProgress(context.Background(), repo, []string{rel}, false, nil)
+
+	if !fired {
+		t.Fatal("fixture is inert: the osStat seam never saw the victim file")
+	}
+	postInfo, err := os.Stat(abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if postInfo.ModTime().UnixNano() == preMtime {
+		t.Skip("filesystem mtime granularity did not separate the two writes; nothing to observe")
+	}
+
+	stamp := idx.walkStamps[rel]
+	if stamp.SHA256 != sha256OfBytes([]byte(after)) {
+		t.Fatalf("stamp hash is %q, want the hash of the bytes the read actually returned — the "+
+			"write landed before the read, so those are the bytes the graph was built from", stamp.SHA256)
+	}
+	if stamp.Mtime != preMtime {
+		t.Fatalf("stamp mtime is %d, want the PRE-write %d. The stat must be taken before the read: "+
+			"post-write metadata beside pre-write content makes isChanged take its fast path and "+
+			"call the file unchanged, and no hash ever gets to correct that (#6212)",
+			stamp.Mtime, preMtime)
+	}
+}
+
+// TestWalkStamp_FirstReadWins pins the recordWalkStamp PRIMITIVE.
+//
+// A .py file is read TWICE per run: once by the cross-file registry pre-pass in
+// runPass1ExtractWithProgress (which feeds extractBaseClasses' cross-file
+// INHERITS and the DRF bare-Route suppression) and once by the worker. Both
+// reach the graph, so if a write lands between them the graph is built from two
+// different versions of the file.
+//
+// Only the EARLIER stamp is safe. Stamping the later read hash-matches the disk
+// on the next pass and freezes the registry's stale contribution — a Django
+// models.py rewritten in that gap keeps a wrong INHERITS edge permanently.
+// Stamping the earlier one makes the file read as changed and be re-extracted.
+//
+// This calls stampReadFile directly, so it pins the rule and NOT its caller. The
+// pre-pass's own stamp call is pinned end to end by
+// TestWalkStamp_PythonPrePassStampWinsOverTheWorkerRead below — deleting that
+// call survives this test entirely.
+func TestWalkStamp_FirstReadWins(t *testing.T) {
+	idx, _, rel := stampProbeIndexer(t, "package victim\n")
+
+	first := sha256OfBytes([]byte("the earlier read"))
+	idx.stampReadFile(rel, []byte("the earlier read"), 16, 1111)
+	idx.stampReadFile(rel, []byte("the later read"), 14, 2222)
+
+	got := idx.walkStamps[rel]
+	if got.SHA256 != first || got.Mtime != 1111 {
+		t.Fatalf("stamp is %+v, want the FIRST read's (sha %q, mtime 1111). Last-write-wins lets the "+
+			"worker's read overwrite the registry pre-pass's, so a write landing between the two is "+
+			"hash-matched away and the registry's stale cross-file contribution becomes permanent "+
+			"(#6212)", got, first)
+	}
+}
+
+// TestWalkStamp_PythonPrePassStampWinsOverTheWorkerRead pins the CALLER — the
+// stamp inside the registry pre-pass itself.
+//
+// The primitive above is first-wins, but that only matters if the pre-pass
+// actually records a stamp. Delete its stampReadFile call and every .py file
+// silently reverts to the worker's later read: nothing else in the suite
+// notices, because with no write between the two reads both produce the same
+// hash. The two implementations differ only when it counts.
+//
+// So this drives the real runPass1ExtractWithProgress over a .py fixture and
+// makes the two reads return DIFFERENT bytes, via osReadFile. The pre-pass reads
+// first and its bytes are what seeded the class registry, so its hash is the one
+// that must survive. If the worker's read wins, the manifest hash-matches the
+// disk on the next pass and the registry's stale cross-file INHERITS
+// contribution is frozen in place permanently.
+func TestWalkStamp_PythonPrePassStampWinsOverTheWorkerRead(t *testing.T) {
+	const prePassBytes = "class Model:\n    pass\n\n\nclass FromThePrePass(Model):\n    pass\n"
+	const workerBytes = "class Model:\n    pass\n\n\nclass FromTheWorker(Model):\n    pass\n"
+
+	root := t.TempDir()
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	repo := filepath.Join(root, "repo")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const rel = "models.py"
+	if err := os.WriteFile(filepath.Join(repo, rel), []byte(prePassBytes), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read 1 is the registry pre-pass, read 2 is the worker. A developer saving
+	// the file in between is what this simulates.
+	var reads int
+	prev := osReadFile
+	osReadFile = func(name string) ([]byte, error) {
+		if filepath.Base(name) != rel {
+			return prev(name)
+		}
+		reads++
+		if reads == 1 {
+			return []byte(prePassBytes), nil
+		}
+		return []byte(workerBytes), nil
+	}
+	t.Cleanup(func() { osReadFile = prev })
+
+	idx := newTestIndexer(t, "pyprepass", nil, "")
+	if _, _, err := idx.runPass1ExtractWithProgress(context.Background(), repo, []string{rel}, nil); err != nil {
+		t.Fatalf("runPass1ExtractWithProgress: %v", err)
+	}
+
+	if reads < 2 {
+		t.Fatalf("fixture is inert: the .py file was read %d time(s), so there were not two reads "+
+			"to disagree about", reads)
+	}
+
+	got := idx.walkStamps[rel].SHA256
+	if got == "" {
+		t.Fatal("no stamp was recorded for the .py file at all")
+	}
+	if got == sha256OfBytes([]byte(workerBytes)) {
+		t.Fatal("the stamp is the WORKER's read. The registry pre-pass read this file first and its " +
+			"bytes are what seeded the cross-file class registry, so the graph's INHERITS edges " +
+			"come from those bytes — but the manifest now describes the later ones and will " +
+			"hash-match the disk next pass, freezing the registry's stale contribution permanently. " +
+			"The pre-pass must stamp, and recordWalkStamp's first-wins rule must let it beat the " +
+			"worker (#6212).")
+	}
+	if want := sha256OfBytes([]byte(prePassBytes)); got != want {
+		t.Fatalf("stamp is %q, want the registry pre-pass's bytes (%q)", got, want)
+	}
+}

--- a/internal/extractors/export_6212_test.go
+++ b/internal/extractors/export_6212_test.go
@@ -1,0 +1,17 @@
+package extractors
+
+import "github.com/cajasmota/grafel/internal/graph"
+
+// GraphGenWriter is the signature of fbwriter.WriteGraphGen.
+type GraphGenWriter = func(stateDir string, doc *graph.Document) (string, error)
+
+// SwapWriteGraphGen replaces the graph-write seam and returns both a restore
+// func and the previous writer, so a test can wrap the real one rather than
+// replace it. It exists only for the external extractors_test package, which
+// holds this package's TryIncremental fixtures but cannot reach an unexported
+// var (#6212).
+func SwapWriteGraphGen(fn GraphGenWriter) (restore func(), prev GraphGenWriter) {
+	prev = writeGraphGen
+	writeGraphGen = fn
+	return func() { writeGraphGen = prev }, prev
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -335,6 +335,14 @@ var (
 	frameworkDetectorInst *engine.Detector
 )
 
+// writeGraphGen is fbwriter.WriteGraphGen behind a var so a test can land a
+// working-tree write at the one point that matters for #6212: after this pass
+// read the bytes it extracted, before Step 9 records what it indexed. That is
+// the same seam, for the same reason, as cmd/grafel/index.go's — and this is the
+// path that actually runs, since TryIncremental's only non-test caller is the
+// daemon scheduler.
+var writeGraphGen = fbwriter.WriteGraphGen
+
 // frameworkDetector returns the shared Detector, or nil if the embedded rules
 // failed to load. A nil return degrades this path to its pre-#6148 behaviour
 // (classes keep their generic kind, framework-only entities are not emitted)
@@ -749,6 +757,17 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	var newEntities []graph.Entity
 	var newRels []graph.Relationship
+	// walkStamps is the manifest entry for each re-extracted file, computed from
+	// the bytes THIS loop reads (#6212). Step 9 stamps from these instead of
+	// re-hashing the repo off disk.
+	//
+	// This is the daemon's primary path — TryIncremental's only non-test caller
+	// is the scheduler — so it is where the defect actually bites: the window
+	// from the read below to Step 9 spans the re-extraction, the scoped resolve,
+	// the merge, the flow recompute, the canonical sort and all of
+	// WriteGraphGen. A developer saving a file inside it had that save stamped
+	// as indexed and then hash-matched away on the next pass.
+	walkStamps := make(map[string]diff.FileEntry, len(reallyChanged))
 	// #6148 — count of generic class records re-typed from the YAML rule sets,
 	// logged with the run so a silent regression to zero is visible.
 	classKindFolds := 0
@@ -784,12 +803,31 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	for _, rel := range reallyChanged {
 		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
+		// Stat BEFORE the read — see diff.StampBytes for why that ordering is
+		// load-bearing rather than incidental.
+		statSize, statMtime := int64(-1), int64(0)
+		if st, sErr := os.Stat(abs); sErr == nil {
+			statSize = st.Size()
+			statMtime = st.ModTime().UnixNano()
+		}
 		content, readErr := os.ReadFile(abs)
 		if readErr != nil {
 			// File deleted → nothing to extract; entities were already removed.
+			// Deliberately UNSTAMPED: with no bytes there is no evidence of what
+			// was indexed. A deleted file leaves allFiles and is pruned by
+			// ApplyStamps; a transiently unreadable one keeps its old stamp and
+			// re-presents as changed. Over-reporting, never staleness.
 			logger.Printf("incremental: %s deleted or unreadable — entities removed", rel)
 			continue
 		}
+
+		// Stamp HERE, on the successful read, and not at any of the `continue`s
+		// below (#6212). These are the bytes this pass saw, whatever the
+		// pipeline went on to do with them — and every skip below is a file that
+		// genuinely CHANGED, so it still needs a refreshed stamp or it
+		// re-presents as changed on every pass, counts against the
+		// too-many-changed limit and pins the daemon in a reindex loop (#5668).
+		walkStamps[rel] = diff.StampBytes(content, statSize, statMtime)
 
 		// Classify to get language.
 		cr := cls.ClassifyWithSize(ctx, rel, int64(len(content)))
@@ -1288,7 +1326,7 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// instead of overwriting graph.fb. This never renames over a possibly-
 	// mapped graph.fb (Windows ERROR_USER_MAPPED_FILE). fbPath is the gen
 	// file written, passed to the directory-keyed sidecar writer below.
-	fbPath, writeErr := fbwriter.WriteGraphGen(stateDir, doc)
+	fbPath, writeErr := writeGraphGen(stateDir, doc)
 	if writeErr != nil {
 		return fallback(t0, "write-graph-fb: "+writeErr.Error())
 	}
@@ -1319,7 +1357,16 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	}
 
 	// --- Step 9: update manifest ---
-	diff.UpdateManifest(absRepo, allFiles, manifest)
+	//
+	// Stamped from the bytes the re-extraction loop read, NOT re-hashed off disk
+	// (#6212). The graph fbwriter.WriteGraphGen just wrote was built from those
+	// bytes; anything the working tree has done since belongs to the next pass,
+	// and re-hashing here would stamp it as indexed and then hash-match it away.
+	//
+	// Also O(delta) instead of O(repo): the files this pass did not re-extract
+	// keep the stamps they already had, which is exactly what established them
+	// as unchanged in the first place (#6201, #6206).
+	diff.ApplyStamps(walkStamps, allFiles, manifest)
 	if saveErr := diff.SaveManifest(stateDir, absRepo, manifest); saveErr != nil {
 		logger.Printf("incremental: save manifest: %v (non-fatal)", saveErr)
 	}

--- a/internal/extractors/incremental_skipped_restamp_6212_test.go
+++ b/internal/extractors/incremental_skipped_restamp_6212_test.go
@@ -1,0 +1,113 @@
+package extractors_test
+
+// #6212 — a file that GENUINELY CHANGED but that the extractor pipeline declines
+// must still be re-stamped, or it becomes an immortal entry (#5668).
+//
+// This pins WHERE the stamp is taken in TryIncremental's re-extraction loop, a
+// property the rest of the #6212 suite cannot see. The stamp sits immediately
+// after the successful read and BEFORE the classifier/extractor `continue`s
+// below it, because "the bytes this pass saw" is the correct claim whatever the
+// pipeline went on to do with them. Move it below those continues — which reads
+// as tidier, since only extracted files would then be stamped — and the loop
+// this test describes opens up.
+//
+// The mechanism, end to end: the file is in the walk, git reports it changed, it
+// enters reallyChanged, the classifier returns no language, the loop continues,
+// nothing stamps it, and Step 9 (which no longer sweeps the repo — that is the
+// whole point of #6212) leaves the pre-edit hash in place. Next pass it reads as
+// changed again. And the next. It counts against GRAFEL_INCREMENTAL_MAX_FILES on
+// every tick, so a handful of them permanently trips the too-many-changed
+// fallback and pins the daemon in a full-reindex loop.
+//
+// This is not exotic. A developer edits LICENSE; a build regenerates a .golden
+// fixture; a data file is refreshed. Originally built as a review probe, which
+// measured 4 of 5 such files going stale with the stamp moved below the continue.
+
+import (
+	"context"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// TestIncremental_ClassifierSkippedChangedFileIsRestamped drives real edits to
+// files the classifier has no language for through a successful TryIncremental.
+//
+// The candidates deliberately span the ways a walked file ends up unextractable:
+// a .golden fixture, a bare LICENSE, a .txt, a .dat. notes.md is included as the
+// control — markdown classifies to a real language, so it takes the extracted
+// path and must be re-stamped for the ordinary reason. If every candidate were
+// unextractable, a mutant that stamped nothing at all would be indistinguishable
+// from one that stamped only the extracted files.
+func TestIncremental_ClassifierSkippedChangedFileIsRestamped(t *testing.T) {
+	isolateHome(t)
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+
+	writeFile(t, repo, "victim.go", "package p\n\nfunc Victim() int { return 1 }\n")
+	candidates := []string{"notes.md", "data.txt", "blob.dat", "fixture.golden", "LICENSE"}
+	for _, c := range candidates {
+		writeFile(t, repo, c, "original content for "+c+"\n")
+	}
+
+	initGitRepo(t, repo)
+	gitCommitAll(t, repo, "base")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Victim", "victim.go"),
+			Name: "Victim", Kind: "SCOPE.Operation", SourceFile: "victim.go", Language: "go"},
+	}, nil)
+	seedManifest(t, repo, stateDir)
+
+	before := map[string]string{}
+	mb := diff.LoadManifest(stateDir)
+	for _, c := range candidates {
+		before[c] = mb.Files[c].SHA256
+	}
+
+	// Every candidate genuinely changes, so every one of them is something the
+	// next pass must NOT be told it has already indexed.
+	for _, c := range candidates {
+		writeFile(t, repo, c, "EDITED BY A DEVELOPER: "+c+"\n")
+	}
+
+	logger := log.New(io.Discard, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if !res.Done {
+		t.Fatalf("fixture is inert: the pass did not succeed (fallback=%q), so Step 9 never ran",
+			res.FallbackReason)
+	}
+
+	after := diff.LoadManifest(stateDir)
+	checked, stale := 0, 0
+	for _, c := range candidates {
+		if before[c] == "" {
+			// Not in the walk at all (a skip layer excluded it) — nothing to say.
+			t.Logf("not in the walk, skipped: %s", c)
+			continue
+		}
+		checked++
+		got := after.Files[c].SHA256
+		want := shaOf("EDITED BY A DEVELOPER: " + c + "\n")
+		if got == want {
+			continue
+		}
+		stale++
+		t.Errorf("%s kept a stamp that is not its post-edit content (got %q, want %q). It is in the "+
+			"walk and it genuinely changed, so it re-presents as changed on EVERY subsequent pass, "+
+			"counts against GRAFEL_INCREMENTAL_MAX_FILES every tick and pins the daemon in a "+
+			"full-reindex loop — #5668's immortal entry, on the daemon's primary path. The stamp "+
+			"must be taken on the successful READ, above the classifier/extractor continues, not "+
+			"only for the files that reach extraction (#6212).", c, got, want)
+	}
+	if checked == 0 {
+		t.Fatal("fixture is inert: none of the candidate files were in the walk, so nothing was asserted")
+	}
+	if stale == 0 {
+		t.Logf("all %d walked candidates re-stamped", checked)
+	}
+}

--- a/internal/extractors/incremental_walk_stamp_6212_test.go
+++ b/internal/extractors/incremental_walk_stamp_6212_test.go
@@ -1,0 +1,182 @@
+package extractors_test
+
+// #6212 on the path that actually runs.
+//
+// TryIncremental's only non-test caller is the daemon scheduler
+// (cmd/grafel/daemon.go), so this is what executes on every tick where the delta
+// is small — the common case, and precisely the "developer saves a file mid-
+// reindex" scenario the issue is about. Step 9 used to call
+// diff.UpdateManifest(absRepo, allFiles, manifest), re-hashing the whole repo
+// off disk long after the bytes it extracted were read: the window spans the
+// re-extraction, the scoped resolve, the merge, the flow recompute, the
+// canonical sort and all of WriteGraphGen.
+//
+// Both tests below drive the real TryIncremental to a SUCCESSFUL pass (Done ==
+// true), which is the branch that was unfixed. Assertions are on the manifest's
+// bytes and on surviving poison stamps — observable work, never elapsed time.
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+func shaOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// incrementalStampFixture builds a committed repo with one file that will be
+// edited plus a set of provably-clean ones, a minimal prior graph, and a correct
+// manifest baseline. It returns the repo, the state dir and the clean file list.
+func incrementalStampFixture(t *testing.T, nStable int) (repo, stateDir string, stable []string) {
+	t.Helper()
+	isolateHome(t)
+	repo = t.TempDir()
+	stateDir = t.TempDir()
+
+	// Distinct basename stems: FilterWithGit invalidates by stem (moduleBase),
+	// so a shared one would drag a "clean" file into the changed set.
+	stable = make([]string, nStable)
+	for i := range stable {
+		stable[i] = fmt.Sprintf("stable_%02d.go", i)
+		writeFile(t, repo, stable[i], fmt.Sprintf("package p\n\nfunc Stable%02d() {}\n", i))
+	}
+	writeFile(t, repo, "victim.go", "package p\n\nfunc Victim() int { return 1 }\n")
+
+	initGitRepo(t, repo)
+	gitCommitAll(t, repo, "base")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "Victim", "victim.go"),
+			Name: "Victim", Kind: "SCOPE.Operation", SourceFile: "victim.go", Language: "go"},
+	}, nil)
+	seedManifest(t, repo, stateDir)
+	return repo, stateDir, stable
+}
+
+// TestIncremental_Success_DoesNotStampWritesThatLandAfterExtraction is the
+// defect, on the daemon's primary path.
+//
+// The pass extracts version 2 of the file. Version 3 is written into the working
+// tree at the writeGraphGen seam — after the extraction, before Step 9. The graph
+// therefore contains version 2's entities. If the manifest records version 3 it
+// is claiming to have indexed content that is not in the graph, and the claim is
+// self-concealing: the next pass hash-matches version 3, classifies the file
+// UNCHANGED, and the edit is never picked up.
+func TestIncremental_Success_DoesNotStampWritesThatLandAfterExtraction(t *testing.T) {
+	repo, stateDir, _ := incrementalStampFixture(t, 3)
+
+	const extracted = "package p\n\nfunc Victim() int { return 2 }\n"
+	const landedMidPass = "package p\n\nfunc Victim() int { return 3 }\n\nfunc SavedMidReindex() {}\n"
+	writeFile(t, repo, "victim.go", extracted)
+
+	// prev is assigned by the swap below and read only when the seam FIRES,
+	// which is during TryIncremental — long after the assignment.
+	var seamFired bool
+	var prev extractors.GraphGenWriter
+	var restore func()
+	restore, prev = extractors.SwapWriteGraphGen(func(dir string, doc *graph.Document) (string, error) {
+		seamFired = true
+		writeFile(t, repo, "victim.go", landedMidPass)
+		return prev(dir, doc)
+	})
+	t.Cleanup(restore)
+
+	logger := log.New(io.Discard, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if !res.Done {
+		t.Fatalf("fixture is inert: the pass did not succeed (fallback=%q), so Step 9 never ran",
+			res.FallbackReason)
+	}
+	if !seamFired {
+		t.Fatal("fixture is inert: writeGraphGen never ran, so no write landed inside the window")
+	}
+
+	got := diff.LoadManifest(stateDir).Files["victim.go"].SHA256
+	if got == shaOf(landedMidPass) {
+		t.Fatalf("Step 9 stamped victim.go with the content that landed AFTER extraction. Those " +
+			"bytes are not in the graph, yet the next pass hash-matches this stamp and classifies " +
+			"the file UNCHANGED — the save is invisible until the file is touched again or HEAD " +
+			"advances. This is the daemon's primary path (#6212).")
+	}
+	if want := shaOf(extracted); got != want {
+		t.Fatalf("victim.go stamped %q, want the hash of the bytes this pass actually extracted "+
+			"(%q) — the manifest must describe what the graph was built from (#6212)", got, want)
+	}
+}
+
+// TestIncremental_Success_DoesNotSweepUnchangedFiles is the removal, on the
+// success path.
+//
+// #6201 took the full-repo sweep off the too-many-changed REJECT; the successful
+// pass kept one. Stamping from the extraction loop's own bytes removes it there
+// too, which makes Step 9 O(delta) instead of O(repo).
+//
+// Same proof shape as #6201's, and it needs no seam: the clean files are
+// committed, untouched and not reported by `git diff --name-only HEAD`, so the
+// change detector never opens them. Only an indiscriminate full-repo sweep can
+// overwrite a poison stamp, so surviving poison IS the evidence that none ran.
+func TestIncremental_Success_DoesNotSweepUnchangedFiles(t *testing.T) {
+	const nStable = 6
+	repo, stateDir, stable := incrementalStampFixture(t, nStable)
+
+	const poison = "poison-stamp-6212"
+	m := diff.LoadManifest(stateDir)
+	for _, rel := range stable {
+		e := m.Files[rel]
+		e.SHA256 = poison
+		m.Files[rel] = e
+	}
+	preVictim := m.Files["victim.go"].SHA256
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("save poisoned manifest: %v", err)
+	}
+
+	writeFile(t, repo, "victim.go", "package p\n\nfunc Victim() int { return 42 }\n")
+
+	logger := log.New(io.Discard, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	if !res.Done {
+		t.Fatalf("fixture is inert: the pass did not succeed (fallback=%q)", res.FallbackReason)
+	}
+
+	after := diff.LoadManifest(stateDir)
+
+	// PROPERTY 1 — no full-repo sweep on the success path.
+	swept := 0
+	for _, rel := range stable {
+		e, ok := after.Files[rel]
+		if !ok {
+			t.Fatalf("clean file %s was pruned from the manifest by a successful pass", rel)
+		}
+		if e.SHA256 != poison {
+			swept++
+		}
+	}
+	if swept != 0 {
+		t.Fatalf("a successful incremental pass hashed %d/%d provably-clean files (poison stamp "+
+			"overwritten) — Step 9 still re-hashes the whole repo to reproduce stamps it already "+
+			"holds (#6212, #6206)", swept, nStable)
+	}
+
+	// PROPERTY 2 — the #5668 loop guard survives the removal. The file that DID
+	// change must be re-stamped, or it re-presents as changed on every pass,
+	// counts against the too-many-changed limit and pins the daemon in a loop.
+	e, ok := after.Files["victim.go"]
+	if !ok {
+		t.Fatal("the changed file is missing from the manifest entirely")
+	}
+	if e.SHA256 == preVictim || e.SHA256 == "" {
+		t.Fatalf("the changed file kept its stale stamp %q — dropping the sweep also dropped the "+
+			"#5668 reindex loop guard", e.SHA256)
+	}
+}

--- a/internal/indexer/diff/apply_stamps_6212_test.go
+++ b/internal/indexer/diff/apply_stamps_6212_test.go
@@ -1,0 +1,123 @@
+package diff
+
+// #6212 — ApplyStamps is the manifest's new write path: the indexer hands it the
+// hashes computed while the walk read each file, and it must record them and
+// reconcile membership WITHOUT touching the filesystem.
+//
+// These are unit tests on the function's three obligations, because the
+// end-to-end fixtures in cmd/grafel cannot see two of them: their walks never
+// shrink (so nothing stale ever needs pruning) and their runs stamp every file
+// (so the "keep what you were not given" rule is never exercised).
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func manifestWith(entries map[string]string) *Manifest {
+	m := newManifest()
+	for rel, sha := range entries {
+		m.Files[rel] = FileEntry{SHA256: sha, Size: 1, Mtime: 1}
+	}
+	return m
+}
+
+func manifestKeys(m *Manifest) string {
+	keys := make([]string, 0, len(m.Files))
+	for k := range m.Files {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return strings.Join(keys, ",")
+}
+
+// TestApplyStamps_RecordsWalkStampsWithoutHashingAnything is the removal itself.
+//
+// The O(repo) SHA-256 sweep the commit used to pay (218 ms of a zero-change
+// pass's 738 ms on a 3003-file fixture, #6206) is gone because the hashes now
+// arrive from the walk. The counter, not a stopwatch, is the proof: it must read
+// zero even though a real file sits at the stamped path and would hash fine.
+func TestApplyStamps_RecordsWalkStampsWithoutHashingAnything(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newManifest()
+	before := HashCallCount()
+	ApplyStamps(map[string]FileEntry{
+		"a.go": {SHA256: "walktimehash", Size: 10, Mtime: 42},
+	}, []string{"a.go"}, m)
+
+	if n := HashCallCount() - before; n != 0 {
+		t.Fatalf("ApplyStamps hashed %d file(s); it must do no file I/O at all — the walk already "+
+			"paid for these hashes and re-taking them is what made the manifest able to describe "+
+			"bytes that were never indexed (#6212)", n)
+	}
+	got := m.Files["a.go"]
+	if got.SHA256 != "walktimehash" || got.Size != 10 || got.Mtime != 42 {
+		t.Fatalf("stamp not recorded verbatim: %+v — the entry must be the walk's, not a re-derived "+
+			"one (#6212)", got)
+	}
+}
+
+// TestApplyStamps_PrunesEntriesNoLongerInTheWalk pins #5667's loop guard on the
+// new path.
+//
+// An entry for a file that has left the gitignore-aware walk is otherwise
+// immortal: it is reported "deleted" on every pass, perpetually trips the
+// too-many-changed full-reindex fallback and pins the daemon in a reindex loop.
+// UpdateManifestScoped carried this reconcile; ApplyStamps replaced it as the
+// commit-path writer, so the guard has to come with it.
+func TestApplyStamps_PrunesEntriesNoLongerInTheWalk(t *testing.T) {
+	m := manifestWith(map[string]string{
+		"live.go":        "old",
+		"now-ignored.go": "stale",
+	})
+
+	ApplyStamps(map[string]FileEntry{
+		"live.go": {SHA256: "fresh", Size: 2, Mtime: 2},
+	}, []string{"live.go"}, m)
+
+	if got := manifestKeys(m); got != "live.go" {
+		t.Fatalf("manifest keys are %q, want \"live.go\" — an entry for a file no longer in the walk "+
+			"survived. It re-presents as \"deleted\" on every pass and re-trips the too-many-changed "+
+			"fallback forever (#5667)", got)
+	}
+	if m.Files["live.go"].SHA256 != "fresh" {
+		t.Fatalf("live.go kept its old stamp %q, want the walk's %q", m.Files["live.go"].SHA256, "fresh")
+	}
+}
+
+// TestApplyStamps_KeepsEntriesForWalkedFilesItWasNotGiven pins the delta case.
+//
+// On an incremental run the walk only reads the changed files, so only those
+// carry a stamp. Every other walked file must keep the entry it already had —
+// the same rule UpdateManifestScoped applies to its unhashed keepPaths, correct
+// for the same reason: the caller has already established they did not change.
+// Dropping them instead would make every unchanged file read as new on the next
+// pass, which is #5667's loop from the other direction.
+func TestApplyStamps_KeepsEntriesForWalkedFilesItWasNotGiven(t *testing.T) {
+	m := manifestWith(map[string]string{
+		"changed.go":   "old",
+		"untouched.go": "baseline",
+	})
+
+	ApplyStamps(map[string]FileEntry{
+		"changed.go": {SHA256: "new", Size: 3, Mtime: 3},
+	}, []string{"changed.go", "untouched.go"}, m)
+
+	if got := manifestKeys(m); got != "changed.go,untouched.go" {
+		t.Fatalf("manifest keys are %q, want both files — a walked file with no stamp this pass lost "+
+			"its baseline and will read as new forever (#6212)", got)
+	}
+	if got := m.Files["untouched.go"].SHA256; got != "baseline" {
+		t.Fatalf("untouched.go's stamp changed to %q, want %q untouched", got, "baseline")
+	}
+	if got := m.Files["changed.go"].SHA256; got != "new" {
+		t.Fatalf("changed.go's stamp is %q, want the walk's %q", got, "new")
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -48,6 +48,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
@@ -258,13 +259,42 @@ func UpdateManifestScoped(absRepo string, hashPaths, keepPaths []string, m *Mani
 	}
 	wg.Wait()
 
-	// Reconcile (#5667): drop entries for files no longer in the walked set so
-	// the manifest cannot retain stale records — e.g. a file that became
-	// gitignored (build artifacts now excluded by walk.WalkRepo). All callers
-	// pass the complete current walk as keepPaths, so membership in it is
-	// authoritative. Without this prune an entry, once added, is immortal: a
-	// now-ignored file is reported as "deleted" on every pass, perpetually
-	// tripping the too-many-changed full-reindex fallback and pinning the daemon.
+	reconcileMembership(keepPaths, m)
+}
+
+// ApplyStamps records stamps that were computed ELSEWHERE — at walk time, from
+// the bytes the extraction pipeline actually read — and then reconciles
+// membership against keepPaths exactly as UpdateManifestScoped does.
+//
+// It performs NO file I/O. That is the whole point (#6212): the manifest's
+// contract is "these bytes are what the graph was built from", and a re-hash at
+// commit time cannot honour it, because the document was built from the bytes
+// the walk read and the working tree may have moved on since. Hashing at the
+// point of reading makes the contract true BY CONSTRUCTION rather than true
+// whenever no write happened to land in a multi-second window. It also deletes
+// the O(repo) SHA-256 sweep the commit used to pay (#6206).
+//
+// Files in keepPaths with no stamp keep whatever entry they already had — the
+// same rule UpdateManifestScoped applies to its unhashed keepPaths, and correct
+// for the same reason: the caller has established they did not change.
+func ApplyStamps(stamps map[string]FileEntry, keepPaths []string, m *Manifest) {
+	if m.Files == nil {
+		m.Files = make(map[string]FileEntry, len(stamps))
+	}
+	for rel, e := range stamps {
+		m.Files[rel] = e
+	}
+	reconcileMembership(keepPaths, m)
+}
+
+// reconcileMembership drops entries for files no longer in the walked set (#5667)
+// so the manifest cannot retain stale records — e.g. a file that became
+// gitignored (build artifacts now excluded by walk.WalkRepo). All callers pass
+// the complete current walk as keepPaths, so membership in it is authoritative.
+// Without this prune an entry, once added, is immortal: a now-ignored file is
+// reported as "deleted" on every pass, perpetually tripping the
+// too-many-changed full-reindex fallback and pinning the daemon.
+func reconcileMembership(keepPaths []string, m *Manifest) {
 	want := make(map[string]struct{}, len(keepPaths))
 	for _, r := range keepPaths {
 		want[r] = struct{}{}
@@ -491,8 +521,56 @@ func isChanged(absPath, relPath string, manifest *Manifest) bool {
 	return newEntry.SHA256 != entry.SHA256
 }
 
+// hashCalls counts every hashFile invocation in the process.
+//
+// It exists so a test can assert that a code path performs NO file hashing at
+// all — the #6212 acceptance criterion for commitManifest, and the shape #6206
+// asks for in general ("assert on observable work — a hash counter, a seam —
+// never on elapsed time"). A wall-clock budget is the test-that-cannot-fail
+// shape; a counter that must read zero cannot pass for the wrong reason.
+//
+// Monotonic and process-wide: callers compare two samples, never the absolute.
+var hashCalls atomic.Int64
+
+// HashCallCount returns the number of files hashed by this package so far.
+// See hashCalls for why it is exported.
+func HashCallCount() int64 { return hashCalls.Load() }
+
+// HashFile is hashFile, exported for the callers that must produce a manifest
+// stamp for a file the extraction pipeline never reads — a binary, an oversized
+// file, an unsupported extension (#6212). Everything the pipeline DOES read is
+// stamped with StampBytes, from the bytes in hand, without reopening the file.
+func HashFile(path string) (FileEntry, error) { return hashFile(path) }
+
+// StampBytes builds the manifest entry for content a caller already holds.
+//
+// This is the #6212 primitive: the hash is over the bytes PASSED IN — the ones
+// the graph is being built from — never over a re-read of the path. Re-reading
+// is the whole defect, because "the same file" at two different moments is not
+// the same bytes, and the manifest that results claims content the graph does
+// not contain.
+//
+// statSize/statMtime must come from a stat taken BEFORE the read. They feed
+// isChanged's fast path only. A stat taken after the read can pair post-write
+// metadata with pre-write content, and the next pass then takes the fast path
+// and calls the file unchanged; a pre-read stat can only be staler than the
+// bytes, which routes the next pass to the hash instead. statSize < 0 means the
+// stat failed, and len(content) stands in.
+func StampBytes(content []byte, statSize, statMtime int64) FileEntry {
+	sum := sha256.Sum256(content)
+	if statSize < 0 {
+		statSize = int64(len(content))
+	}
+	return FileEntry{
+		SHA256: hex.EncodeToString(sum[:]),
+		Size:   statSize,
+		Mtime:  statMtime,
+	}
+}
+
 // hashFile computes the SHA-256 of the file at path and returns a FileEntry.
 func hashFile(path string) (FileEntry, error) {
+	hashCalls.Add(1)
 	f, err := os.Open(path)
 	if err != nil {
 		return FileEntry{}, err


### PR DESCRIPTION
`commitManifest` hashed every file **at commit time**, while the document was built from the bytes the walk read. Anything written in between was stamped into the manifest and absent from the graph, so the next pass hash-matched it, classified it UNCHANGED (`diff.go:411-413`) and the edit stayed invisible until the file was touched again or HEAD advanced.

Measured, not theorised: a probe injecting a working-tree write inside the `writeGraphGen` seam confirmed the manifest stamped post-walk content. The realistic trigger is the watcher-driven reindex — which fires *because* files are changing — so a developer saving a file mid-index is the ordinary case, not an exotic one.

#6207 widened this. The window now spans rename-detect, algo carry-forward, `sortDocumentForEmission` and all of `WriteGraphGen` — seconds on a real repo, where it used to be immediately post-extraction. That was the correct trade at the time (one edit lost until its next touch is self-recovering; the permanent stuck state #6207 fixed was not), but it is a trade, and this is the bill.

## Hash at walk time

The bytes were already in hand: `classifyAndReadWithProgress` holds `content` from a single `os.ReadFile`. So the stamp is a `sha256.Sum256` over a slice already in memory — no second read, no second walk. `diff.StampBytes` centralises *"hash the bytes passed in, never re-read the path"*, and `commitManifest` calls the new `diff.ApplyStamps`, which does no file I/O at all.

The contract — *these bytes are what the graph was built from* — is now true **by construction** rather than true whenever no write happened to land in a multi-second window. That is the difference between an invariant and a probability.

**The sweep is gone**, measured by `diff.HashCallCount` at the `writeGraphGen` seam: **4 → 0**.

## Review found the fix had missed the path that matters

The first version fixed the fallback and then wrote a system-wide invariant. `internal/extractors/incremental.go` Step 9 — the **successful** `TryIncremental` path — still called `UpdateManifest` and hashed from disk. Its one non-test caller is the scheduler, so that is the path running on every tick where the delta is small: the common case, and precisely the scenario this issue is about.

It now stamps from the re-extraction loop's bytes, which also drops Step 9 from O(repo) to O(delta). `diff.UpdateManifest` has exactly one non-test caller left — the zero-change pass — and the `commitManifest` comment names it as the remaining exemption rather than claiming coverage it does not have.

**The stamp goes immediately after the successful read, deliberately not at any of the `continue`s below it.** Every skip below — no language, no extractor — is a file that genuinely changed and still needs a refreshed stamp, or it re-presents forever and pins the daemon. That is #5668's immortal entry, and it is now pinned rather than argued (below).

## The single-read-site claim was false, and fixing it required a rule, not a caveat

`runPass1ExtractWithProgress` reads **every `.py` file** with a separate `os.ReadFile` before the worker loop, single-threaded over the whole set. Both outputs reach the graph: the class registry drives `extractBaseClasses`' cross-file `INHERITS`, and the DRF register-names registry suppresses bare Route entities.

So for Python the graph is built from two reads. `recordWalkStamp` is now **first-wins**, and the pre-pass stamps too — because the earlier read is the only stamp that cannot lead the graph. Stamping the worker's later read would hash-match disk and freeze the registry's stale cross-file contribution: a `models.py` rewritten between the two reads would keep a wrong `INHERITS` edge permanently.

There is no race to guard against, and it is stronger than a mutex: the pre-pass runs to completion before `classifyAndReadWithProgress` is called, so first-wins holds by **program order**. Verified on every path — `skipPasses[PassExtract]` skips the pre-pass entirely so there is only one read; `GRAFEL_SUBPROC_EXTRACT` bypasses it; an oversized `.py` is read by the pre-pass (no size gate) and stamped at T0 while the worker skips and hashes at T1, so first-wins keeps the earlier one.

## Two ordering hazards closed at the cause rather than documented

**Skips are hashed inline in the worker**, at the moment of the skip decision, so the classifier's size observation and the stamp are adjacent. This closes the oversize-truncation window — a file oversized at classification and truncated before a batched post-join stamp would have been recorded as extractable-at-that-hash and never extracted. The batched call is gone; *"the hash pool does not compete with the parsers"* was a throughput preference dressed as a rationale.

**Read failures are now left unstamped**, consistently across all three sites, with the same reason given at each. Previously a transient EACCES would permanently drop a file from the graph until its bytes changed again. The hash-error branch already reasoned *"leaving it unstamped … over-reporting, never staleness"*; that rule now applies everywhere.

## Tests — the two that were argued-only are now pinned

Both fixes above were correct and **provably unpinned** — review demonstrated each with a mutant that survived the entire suite.

**`TestIncremental_ClassifierSkippedChangedFileIsRestamped`.** Five walked candidates driven through a real successful `TryIncremental`; with the stamp moved below the classifier `continue`, four go stale. `notes.md` is a deliberate control — it classifies to a language and takes the extracted path, so a mutant that stamps nothing at all stays distinguishable from one that stamps only extracted files. The failure it prevents is concrete: a developer edits `LICENSE`, or a build regenerates a `.golden` fixture; it is in the walk, git reports it changed, the classifier returns no language, and under the mutant it is never stamped — re-presenting on every tick and counting against `GRAFEL_INCREMENTAL_MAX_FILES` forever.

**`TestWalkStamp_PythonPrePassStampWinsOverTheWorkerRead`.** `TestWalkStamp_FirstReadWins` calls `stampReadFile` twice directly, so it pinned the primitive and never the caller — deleting the pre-pass stamp survived it and every other test. The new test hooks `osReadFile` to return different bytes on read 1 vs read 2 of `models.py`, driven through the real `runPass1ExtractWithProgress`. `_FirstReadWins`' doc now says explicitly that it does not cover the caller and points here; that misreading is what let the gap exist.

**Seams, and why each is the only thing that discriminates.** `osReadFile` — `stampReadFile` takes no path, so a "re-read the path instead of hashing the slice" mutant lives at the call site and only bytes-not-on-disk separate the two. `osStat` — the test's stat hook rewrites the file as a side effect, so the read sees post-write bytes and the stamp must pair them with the **pre-write** mtime. An earlier claim that this ordering could not be pinned was wrong; `var osStat = os.Stat` is the same pattern the file already uses for `writeGraphGen`.

**Twelve mutants**, each independently red. Killed: `ApplyStamps` → `UpdateManifest` at both sites; the second-read mutant; the post-read-stat mutant; last-wins; stamp below the `continue`; pre-pass stamp deleted; skip-branch inline hash removed; truncated slice; prune-only-stamped; `reconcileMembership` dropped; replace-instead-of-overlay. `#6207`'s ordering test was confirmed **not** made vacuous — moving `commitManifest` before the graph write still kills it, and only it.

One methodology note from review, worth recording: M4 and M12 were first run combined on the theory their kill sets were disjoint. They are not — M12 wipes `m.Files`, removing the stale entry M4's test looks for, so M12 masked M4. Both kill individually.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0. At the rebased head, unpiped `$?`, `GOMAXPROCS=4 -count=1`: `cmd/grafel` 0, `internal/extractors` 0, `internal/indexer/diff` 0, `internal/daemon/sched` 0.

Independently adversarially reviewed three times (REQUEST-CHANGES → REQUEST-CHANGES → both remaining asks pinned), the reviewer re-running the mutation battery itself, adding its own mutants, and building the daemon-pinning probe that became the first test above.

## Known limits

**`stampUnreadFiles` is now reachable only from the default-off `GRAFEL_SUBPROC_EXTRACT` branch**, so making it a no-op survives the suite where it previously killed all seven tests. Not a defect — a coverage cliff created by moving skip-hashing inline, and that branch's manifest behaviour is now entirely unexercised. Filed separately.

**`TestWalkStamp_StatIsTakenBeforeTheRead` can self-skip** on a filesystem whose mtime granularity does not separate two writes. It did not skip on APFS in any run, and the skip is logged rather than silent.

**The zero-change pass still sweeps** (#6206) and the reject path's manifest write is unchanged. `GRAFEL_SUBPROC_EXTRACT` pre-hashes before its children start, so a racing write leaves the manifest *lagging* the graph — over-reporting, the safe direction, and the opposite of what commit-time hashing did.

Closes #6212
Refs #6199, #6206, #6207
