### PR TITLE
fix(#6208): grafel rebuild (plain or --wipe) wrote no manifest, so the next incremental pass had nothing to diff against

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -1876,6 +1876,15 @@ type rebuildSubprocessParams struct {
 	ProgressPub         progress.Publisher
 	Interactive         bool
 	IncrementalStateDir string
+	// PersistManifest — #6208: forwarded to the child as --persist-manifest
+	// whenever this repo's rebuild is NOT diff-aware (IncrementalStateDir ==
+	// ""), i.e. a plain `grafel rebuild` or any `--wipe` rebuild. Those runs
+	// walk and index every file but, before this, asked the child for neither
+	// WithIncremental (which self-persists) nor WithManifestPersist, so they
+	// left no baseline for the next incremental pass to diff against — the
+	// same class of gap #6207 closed for the scheduler's fallback. See the
+	// indexOneInner call site for the incremental-vs-persist decision.
+	PersistManifest bool
 }
 
 // runRebuildSubprocess indexes one repo for a rebuild via the subprocess indexer
@@ -1887,14 +1896,21 @@ type rebuildSubprocessParams struct {
 // rebuild produces the full graph (including the graph-algo pass) exactly as the
 // in-process rebuild path does, and forwards ref="" so the child resolves HEAD
 // via gitmeta just like the in-process indexer.
+// Routed through subprocessIndexRunner (the same seam daemonSchedulerIndex
+// uses) rather than calling sched.RunSubprocessIndex directly, so a test can
+// intercept ONE level below this function's own opts-mapping and observe the
+// real *sched.SubprocessIndexOptions this closure built — including
+// PersistManifest (#6208) — instead of having to replace this whole function
+// and reconstruct that mapping itself.
 var runRebuildSubprocess = func(ctx context.Context, p rebuildSubprocessParams) error {
-	return sched.RunSubprocessIndex(ctx, p.RepoPath, "", nil, &sched.SubprocessIndexOptions{
+	return subprocessIndexRunner(ctx, p.RepoPath, "", nil, &sched.SubprocessIndexOptions{
 		ProgressPub:         p.ProgressPub,
 		GroupSlug:           p.GroupSlug,
 		RepoSlug:            p.RepoSlug,
 		RunToken:            p.RunToken,
 		Interactive:         p.Interactive,
 		IncrementalStateDir: p.IncrementalStateDir,
+		PersistManifest:     p.PersistManifest,
 	}, slog.Default())
 }
 
@@ -2100,6 +2116,39 @@ func daemonRebuildFuncCore(
 			if args.Incremental && !args.Wipe {
 				incrementalStateDir = daemon.StateDirForRepo(rw.r.Path)
 			}
+			// #6208 — a rebuild that is NOT diff-aware (plain `grafel rebuild`, or
+			// ANY `--wipe` rebuild — args.Wipe forces incrementalStateDir empty
+			// above regardless of args.Incremental) still walks and indexes every
+			// file, and that is exactly what a manifest records. Before this it
+			// asked for neither WithIncremental (which self-persists via
+			// i.persistManifest, see index.go) nor WithManifestPersist, so the
+			// original daemon.go:2090-2092 gap left the next incremental pass with
+			// no baseline to diff against — the same conflation-shaped hole #6207
+			// closed on the scheduler's fallback path, left out of that change's
+			// scope and filed as #6208.
+			//
+			// --wipe DECISION (#6208, argued, not defaulted): a manifest is state,
+			// and --wipe exists to discard state — so does a wiped rebuild want a
+			// fresh manifest or none at all? Fresh wins. The manifest's job is to
+			// describe "what got indexed just now" so the NEXT incremental pass has
+			// a baseline; it does not describe or preserve anything about the wipe
+			// itself, and a wipe that leaves no manifest behind just forces the
+			// very next pass (incremental or not) to fall back to a full walk
+			// anyway — paying wipe's cost twice for no benefit. Refusing to write
+			// one here would not make the wipe "more thorough"; it would only make
+			// the next incremental pass redo the walk --wipe already paid for. So
+			// persistManifest below is unconditional on incrementalStateDir == "",
+			// not narrowed to !args.Wipe.
+			//
+			// ORDERING (verified, not assumed): commitManifest (index.go) is called
+			// ONLY from the success branch of writeGraphGen inside Index /
+			// runIndexInternal — i.e. after wipe already ran (wipe is the very
+			// first thing this closure does, above) and after the fresh graph is
+			// durably on disk. There is no path from here through
+			// WithManifestPersist/PersistManifest that reaches commitManifest
+			// before either the wipe or the graph write, so the manifest always
+			// describes the POST-wipe index, never one carried across it.
+			persistManifest := incrementalStateDir == ""
 			// Cross-path mutual exclusion (#5729 concurrency bug): this rebuild
 			// indexes the repo DIRECTLY (in-process OR via the subprocess child)
 			// and never touches the engine scheduler, so the scheduler's per-repo
@@ -2151,6 +2200,7 @@ func daemonRebuildFuncCore(
 					ProgressPub:         progressPub,
 					Interactive:         foreground,
 					IncrementalStateDir: incrementalStateDir,
+					PersistManifest:     persistManifest,
 				})
 				return
 			}
@@ -2158,6 +2208,15 @@ func daemonRebuildFuncCore(
 			var opts []IndexOption
 			if incrementalStateDir != "" {
 				opts = append(opts, WithIncremental(incrementalStateDir))
+			} else if persistManifest {
+				// #6208: not diff-aware, but still record what got indexed —
+				// WithIncremental above already does this internally
+				// (i.persistManifest = true), so this is the branch that needs
+				// the explicit ask. Gated on the SAME persistManifest variable
+				// the subprocess branch above uses (rather than re-deriving
+				// incrementalStateDir == "" here) so the two branches cannot
+				// silently diverge on the --wipe decision.
+				opts = append(opts, WithManifestPersist())
 			}
 			// Publish granular per-repo progress into the shared broker so the
 			// WebUI Index step renders live rows + file counters (#1531).

--- a/cmd/grafel/rebuild_manifest_6208_test.go
+++ b/cmd/grafel/rebuild_manifest_6208_test.go
@@ -1,0 +1,376 @@
+package main
+
+// rebuild_manifest_6208_test.go — #6208: the daemon's `grafel rebuild` path
+// (both plain and `--wipe`) has the same manifest gap #6207 fixed for the
+// scheduler's fallback full index, deliberately left out of that change's
+// scope.
+//
+// `daemonRebuildFuncCore`'s indexOneInner closure only set incrementalStateDir
+// when args.Incremental && !args.Wipe, and asked for a manifest ONLY via
+// WithIncremental(incrementalStateDir) / IncrementalStateDir on the subprocess
+// side — both of which are skipped whenever incrementalStateDir == "", i.e. on
+// a plain rebuild OR any --wipe rebuild. So neither of those two shapes left a
+// baseline behind, and the next incremental pass had nothing to diff against.
+//
+// --wipe DECISION PINNED HERE: a wiped rebuild gets a FRESH manifest
+// describing what --wipe just built, not no manifest at all. See the
+// daemon.go:2109 comment block for the argument; TestRebuild_Wipe_* below pins
+// the outcome, not the reasoning.
+//
+// Every test drives the REAL path (daemonRebuildFuncCore with the real Index
+// function, no mocks) so what is asserted is the manifest's CONTENT, never
+// timing. fallbackManifestRepo, assertManifestExact, assertNoManifestYet,
+// writeFixtureFile and seedGitRun are shared with
+// scheduler_fallback_manifest_6207_test.go / worktree_seed_parity_test.go
+// (same package).
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/daemon/proto"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// rebuildManifestFixtureRoot builds the SAME git fixture as #6207's
+// fallbackManifestRepo, but OWNS its root directory outside t.TempDir with a
+// best-effort retrying cleanup instead.
+//
+// WORKAROUND FOR #6188, not a defect in this test: a rebuild that reaches the
+// daemon's install/watcher-adjacent filesystem machinery creates state under
+// GRAFEL_DAEMON_ROOT asynchronously — after the call that appears to have
+// written it has already returned (measured in #6188 as 1-13 poll iterations
+// post-return for install.Apply's <repo>/.grafel/logs; the same class of
+// after-return write). A t.TempDir-owned root therefore races t.TempDir's
+// RemoveAll at cleanup and intermittently fails with
+// "TempDir RemoveAll cleanup: ... directory not empty" — reproduced here as a
+// flake in TestRebuild_WritesExactManifest_* only under full-package
+// scheduling pressure, never in isolation, exactly #6188's documented
+// signature ("Any future test that calls Apply with watchers enabled against
+// a t.TempDir repo will hit it" — this rebuild path is that future test).
+//
+// #6188 has been decided: Apply must not return before its owned side effects
+// are durable, and the #6179 workaround (same shape as this one) is reverted
+// when that lands. Revert this to t.TempDir() at the same time.
+func rebuildManifestFixtureRoot(t *testing.T, name, branch string) (repo string) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git unavailable")
+	}
+	root, err := os.MkdirTemp("", "grafel-6208-"+name+"-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		var lastErr error
+		for i := 0; i < 5; i++ {
+			lastErr = os.RemoveAll(root)
+			if lastErr == nil {
+				return
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+		// #6188 scopes this retry to the TRANSIENT race (Apply-adjacent
+		// machinery still writing under root when cleanup starts) — five
+		// attempts at 20ms is comfortably past the 1-13 poll iterations #6188
+		// measured. A PERMANENT failure (e.g. a future change leaks a live
+		// child holding an fd under root) must not go silent just because this
+		// workaround exists: t.TempDir's own cleanup would have logged
+		// "TempDir RemoveAll cleanup: ..." in that case, so this does too,
+		// rather than discarding the last error and leaving root on disk with
+		// nothing said.
+		t.Logf("rebuildManifestFixtureRoot: RemoveAll(%s) still failing after 5 retries: %v", root, lastErr)
+	})
+
+	// Never touch the real ~/.grafel, ~/Library/LaunchAgents or ~/.claude.json.
+	t.Setenv("HOME", filepath.Join(root, "home"))
+	t.Setenv("USERPROFILE", filepath.Join(root, "home"))
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, "grafelhome"))
+	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(root, "daemonroot"))
+	t.Setenv("GRAFEL_INCREMENTAL_REINDEX", "1")
+
+	repo = filepath.Join(root, name)
+	if err := os.MkdirAll(filepath.Join(repo, "svc"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixtureFile(t, repo, "go.mod", "module fallbackfixture\n\ngo 1.21\n")
+	writeFixtureFile(t, repo, "svc/widget.go", "package svc\n\ntype Widget struct{ Name string }\n\nfunc (w *Widget) Render() string { return w.Name }\n")
+	writeFixtureFile(t, repo, "svc/gadget.go", "package svc\n\nfunc Gadget() string { return \"g\" }\n")
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 7 }\n")
+
+	seedGitRun(t, repo, "init", "-q", "-b", branch)
+	seedGitRun(t, repo, "add", "-A")
+	seedGitRun(t, repo, "commit", "-q", "-m", "fixture")
+	return repo
+}
+
+// rebuildManifestGroup builds the #6208 git fixture (rebuildManifestFixtureRoot,
+// above — a #6188 workaround over #6207's fallbackManifestRepo shape) and
+// registers it as a one-repo fleet group so daemonRebuildFuncCore has a real
+// group to rebuild. Returns the group name and the repo path.
+func rebuildManifestGroup(t *testing.T, name, branch string) (group, repo string) {
+	t.Helper()
+	repo = rebuildManifestFixtureRoot(t, name, branch)
+	group = name + "-group"
+	cfgPath := daemonHomeFleetPath(t, group)
+	cfg := &registry.GroupConfig{
+		Name:  group,
+		Repos: []registry.Repo{{Slug: "svc", Path: repo}},
+	}
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+	if err := registry.AddGroup(group, cfgPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+	return group, repo
+}
+
+// daemonHomeFleetPath resolves the fleet.json path under the GRAFEL_HOME that
+// fallbackManifestRepo already pointed the environment at.
+func daemonHomeFleetPath(t *testing.T, group string) string {
+	t.Helper()
+	home := os.Getenv("GRAFEL_HOME")
+	if home == "" {
+		t.Fatal("GRAFEL_HOME resolved empty — fixture setup is not isolated")
+	}
+	return home + "/" + group + ".fleet.json"
+}
+
+// useInlineSubprocessRebuild forces the rebuild's subprocess reroute
+// (sched.SubprocessIndexEnabled) ON and drives the REAL child entrypoint
+// (runIndexInternal) in-process instead of forking a binary the test process
+// does not contain, by delegating to #6207's useInlineSubprocessIndex.
+//
+// Deliberately does NOT stub runRebuildSubprocess itself: that closure is now
+// what BUILDS the *sched.SubprocessIndexOptions (including PersistManifest,
+// #6208) from rebuildSubprocessParams and hands it to subprocessIndexRunner —
+// exactly the mapping this file's tests are about. Stubbing runRebuildSubprocess
+// wholesale would require the test to reconstruct that mapping itself, which
+// silently stops exercising it (caught in review: a mutant that dropped
+// PersistManifest from runRebuildSubprocess's SubprocessIndexOptions literal
+// passed every subprocess test here when they stubbed runRebuildSubprocess
+// directly). Intercepting one level lower, at subprocessIndexRunner — the same
+// seam daemonSchedulerIndex uses — captures the real opts runRebuildSubprocess
+// built; only the fork itself is elided.
+func useInlineSubprocessRebuild(t *testing.T, sawFork *bool) {
+	t.Helper()
+	useInlineSubprocessIndex(t, sawFork)
+}
+
+// --- plain `grafel rebuild` writes a manifest --------------------------------
+
+func TestRebuild_WritesExactManifest_InProcess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	forceInProcessRebuild(t)
+	group, repo := rebuildManifestGroup(t, "rebuild-plain-inprocess", "main")
+	stateDir := daemon.StateDirForRepo(repo)
+	assertNoManifestYet(t, stateDir)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+}
+
+func TestRebuild_WritesExactManifest_Subprocess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	group, repo := rebuildManifestGroup(t, "rebuild-plain-subprocess", "main")
+	var sawFork bool
+	useInlineSubprocessRebuild(t, &sawFork)
+	stateDir := daemon.StateDirForRepo(repo)
+	assertNoManifestYet(t, stateDir)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	if !sawFork {
+		t.Fatal("the subprocess branch was never taken — this test asserted nothing about it")
+	}
+	assertManifestExact(t, repo, stateDir)
+}
+
+// --- `grafel rebuild --wipe` writes a FRESH manifest, not none ---------------
+
+// TestRebuild_Wipe_WritesFreshManifestDescribingPostWipeIndex pins the --wipe
+// decision: the manifest describes what --wipe just built. It warms the repo
+// with an ordinary rebuild first (graph + manifest both present, so a wipe has
+// something to discard), then mutates a file's content and wipes+rebuilds. If
+// the wipe left the old manifest in place (never discarded) OR if a manifest
+// were written before the wipe ran (wrong ordering — RemoveAll would then
+// delete it, leaving none), the post-rebuild manifest would either be stale
+// (still stamping the OLD content) or absent. assertManifestExact re-hashes
+// the CURRENT bytes on disk, so either failure mode is caught.
+func TestRebuild_Wipe_WritesFreshManifestDescribingPostWipeIndex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	forceInProcessRebuild(t)
+	group, repo := rebuildManifestGroup(t, "rebuild-wipe-fresh", "main")
+	stateDir := daemon.StateDirForRepo(repo)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("warm-up rebuild: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+	before := diff.LoadManifest(stateDir)
+	staleStamp := before.Files["svc/thing.go"].SHA256
+
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 999 }\n\nfunc Extra() {}\n")
+	if sha256OfFile(t, repo+"/svc/thing.go") == staleStamp {
+		t.Fatal("fixture is inert: the mutated file hashes the same as before")
+	}
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Wipe: true, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("wipe rebuild: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+
+	after := diff.LoadManifest(stateDir)
+	if got := after.Files["svc/thing.go"].SHA256; got == staleStamp {
+		t.Fatalf("manifest still stamps svc/thing.go with the PRE-wipe hash %q — the manifest was "+
+			"carried across the wipe instead of describing what --wipe just built (#6208)", got)
+	}
+}
+
+func TestRebuild_Wipe_WritesFreshManifestDescribingPostWipeIndex_Subprocess(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	group, repo := rebuildManifestGroup(t, "rebuild-wipe-fresh-subprocess", "main")
+	var sawFork bool
+	useInlineSubprocessRebuild(t, &sawFork)
+	stateDir := daemon.StateDirForRepo(repo)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("warm-up rebuild: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Wipe: true, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("wipe rebuild: %v", err)
+	}
+	if !sawFork {
+		t.Fatal("the subprocess branch was never taken on the wipe rebuild")
+	}
+	assertManifestExact(t, repo, stateDir)
+}
+
+// --- the manifest a rebuild leaves behind is a real baseline ----------------
+
+// TestRebuild_IncrementalPassDiffsAgainstRebuildManifest pins the acceptance
+// criterion directly: after a plain `grafel rebuild`, a following incremental
+// pass must DIFF against the manifest the rebuild left behind (Done=true,
+// ChangedFiles == 1) rather than falling back to a full reindex because no
+// baseline exists.
+func TestRebuild_IncrementalPassDiffsAgainstRebuildManifest(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	forceInProcessRebuild(t)
+	group, repo := rebuildManifestGroup(t, "rebuild-diffbase", "main")
+	stateDir := daemon.StateDirForRepo(repo)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("rebuild: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 123 }\n")
+	seedGitRun(t, repo, "add", "-A")
+	seedGitRun(t, repo, "commit", "-q", "-m", "touch thing")
+
+	res := daemonSchedulerIncremental(context.Background(), repo, "", nil)
+	if !res.Done {
+		t.Fatalf("incremental pass DECLINED (reason=%q) — it had no baseline to diff against "+
+			"because the preceding rebuild wrote no manifest (#6208)", res.FallbackReason)
+	}
+	if res.ChangedFiles != 1 {
+		t.Fatalf("ChangedFiles = %d, want exactly 1 — the incremental pass did not diff narrowly "+
+			"against the rebuild's manifest", res.ChangedFiles)
+	}
+}
+
+// --- #6207's ordering property must still hold on the rebuild path ---------
+
+// TestRebuild_GraphWriteFailureLeavesManifestUntouched re-pins #6207's
+// ordering invariant (commitManifest only runs on writeGraphGen's success
+// branch) specifically through the REBUILD path this change touches, so a
+// mutant that opened a new route to commitManifest bypassing that ordering
+// (e.g. by committing before the graph write, or unconditionally) is caught
+// here even though #6207's own test file never drives daemonRebuildFuncCore.
+func TestRebuild_GraphWriteFailureLeavesManifestUntouched(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs a real index; skipped under -short")
+	}
+	forceInProcessRebuild(t)
+	group, repo := rebuildManifestGroup(t, "rebuild-graphfail", "main")
+	stateDir := daemon.StateDirForRepo(repo)
+
+	if _, _, err := daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	); err != nil {
+		t.Fatalf("pass 1: %v", err)
+	}
+	assertManifestExact(t, repo, stateDir)
+	before := diff.LoadManifest(stateDir)
+	staleStamp := before.Files["svc/thing.go"].SHA256
+	if staleStamp == "" {
+		t.Fatal("fixture is inert: no stamp recorded for svc/thing.go after pass 1")
+	}
+
+	writeFixtureFile(t, repo, "svc/thing.go", "package svc\n\nfunc Thing() int { return 42 }\n\nfunc Extra() {}\n")
+	if sha256OfFile(t, repo+"/svc/thing.go") == staleStamp {
+		t.Fatal("fixture is inert: the mutated file hashes the same as before")
+	}
+
+	prevWriter := writeGraphGen
+	writeGraphGen = func(dir string, doc *graph.Document) (string, error) {
+		return "", errors.New("injected: graph.fb write failed (disk full / EPERM / gen-flip)")
+	}
+	t.Cleanup(func() { writeGraphGen = prevWriter })
+
+	// Rebuild RPCs surface a per-repo child/index error; the graph write itself
+	// is non-fatal inside Index, so an error here is neither guaranteed nor
+	// what is asserted.
+	_, _, _ = daemonRebuildFuncCore(
+		1, proto.RebuildArgs{Group: group, Interactive: true}, Index, noopLinksFn,
+	)
+
+	after := diff.LoadManifest(stateDir)
+	if got := after.Files["svc/thing.go"].SHA256; got != staleStamp {
+		t.Fatalf("the manifest advanced svc/thing.go to %q even though the graph write FAILED "+
+			"(was %q) — commitManifest ran outside writeGraphGen's success branch (#6207/#6208)",
+			got, staleStamp)
+	}
+	if len(after.Files) != len(before.Files) {
+		t.Fatalf("manifest membership changed (%d → %d) on a failed graph write",
+			len(before.Files), len(after.Files))
+	}
+}


### PR DESCRIPTION
`indexOneInner` in `daemonRebuildFuncCore` asked for manifest persistence only when `incrementalStateDir != ""` — that is, only on `grafel rebuild --incremental`. A plain `grafel rebuild`, or any `--wipe`, wrote **no manifest**, so the next incremental pass had nothing to diff against and reconstructed the world.

Same class as #6207, on the path users invoke by hand rather than the one the scheduler drives. Before #6207 this call site had no legal move: the manifest write was gated on `i.incremental`, so setting a state dir would have made a full rebuild diff-aware — the opposite of what someone asking for a rebuild wants. With behaviour and persistence split, `WithManifestPersist()` is the fix.

## `--wipe` gets a fresh manifest, and the ordering is enforced rather than assumed

A manifest is state and `--wipe` exists to discard state, so this needed an argument rather than a default. The argument: the manifest's only job is *"what got indexed just now"* for the next incremental pass. Refusing to write one would not make the wipe more thorough — it would force the very next pass into a full walk anyway, paying the wipe's cost twice for nothing.

The ordering that makes it true:

- `daemon.go:2112-2114` — `os.RemoveAll(daemon.StateDirForRepo(...))` is the **first** statement in the closure, before any option construction or index call.
- `index.go:888` — `commitManifest` is called only inside the `else` of `fbErr != nil`, i.e. `writeGraphGen`'s success branch.
- `index.go:1166-1172` — `dest` falls back to `graphDir`, and `GraphPathForRepo` = `Join(StateDirForRepo(repoPath), "graph.json")`, so the manifest lands in exactly the directory the wipe cleared and the next pass reads.

No path leaves a pre-wipe manifest in place, and it is **test-enforced**: deferring the wipe until after the index is killed by both `TestRebuild_Wipe_*` tests. Even the one theoretical divergence — HEAD changing between the closure's `StateDirForRepo` and `Index`'s own resolution — is self-correcting, since `commitManifest` runs `LoadManifest` → `ApplyStamps` → `reconcileMembership`, so every surviving entry is either overwritten by a walk stamp or pruned.

## Composition with #6212, which is the risk worth stating

#6212 landed underneath this branch and restructured `commitManifest` to stamp from walk-time hashes via `diff.ApplyStamps`. A rebuild reaching that by a route #6212 did not anticipate could commit an **empty or partial stamp set** — silently writing a manifest missing entries, which is far worse than the bug being fixed.

It composes. Every `walkStamps` write site is unconditional on `incremental`/`persistManifest` (`index.go:1565`, `:3560`, `:3681`, `:3711`), `i.walkedFiles = allFiles` is likewise ungated, and a rebuild does a full walk with `skipPasses = nil` — so it feeds `commitManifest` a strictly **larger** input than the scheduler fallback #6212 was validated against, by the same `Index` → `writeGraphGen` success-branch route.

And a partial set is **detectable**, not merely absent: filtering `walkStamps` to `*.go` only, dropping `go.mod`, turns all seven tests red with `manifest key set is not the repo's file set`. `assertManifestExact` asserts exact key-set equality, so a silently-missing entry cannot pass.

## One shared variable, not two derivations

Mutation testing caught that `persistManifest` was being re-derived independently in the in-process and subprocess branches. Two expressions that must always agree, with nothing forcing them to, is the divergence class #6178 spent three review rounds on — so they were collapsed to one variable. The mutant that re-narrows only the in-process side is killed by the in-process wipe test.

`runRebuildSubprocess` now routes through the existing `subprocessIndexRunner` seam so its opts-mapping is testable without stubbing away the thing under test. Verified faithful: a direct function-value alias, argument list unchanged from the old direct call, `PersistManifest` the only added field and it is a named literal.

## Tests

Six, asserting manifest contents and never timing. Plain and `--wipe` rebuilds across in-process and subprocess branches; a following incremental pass diffing against the rebuild's manifest; and `TestRebuild_GraphWriteFailureLeavesManifestUntouched`, so #6207's ordering property is **guarded on this path** rather than inherited by argument — a mutant letting `commitManifest` escape the success branch kills both that test and #6207's.

**Fourteen mutants, zero survivors.** `persistManifest := false`; each branch's persistence removed; the subprocess field dropped at the call site and in `runRebuildSubprocess`; `&& !args.Wipe`; `WithManifestPersist()` made a no-op; the gate inverted; the child ignoring `--persist-manifest` while argv still renders it; partial and empty stamp sets; the manifest written to a sibling dir; the wipe deferred; and the two-derivations divergence re-narrowed on one side only.

All four flag combinations checked, including `--incremental --wipe` — reachable, since `wipe` and `inc` are independent CLI flags — which forces `incrementalStateDir` empty and correctly takes the persist path with a full rebuild.

## The #6188 workaround, and why it is here

The new tests hit `TempDir RemoveAll cleanup: ... directory not empty` intermittently under full-package load, never in isolation, and **never as an assertion failure**. That is #6188's exact signature — `install.Apply` returning before its filesystem side effects settle, measured there at 1–13 poll iterations post-return.

#6188 predicted this: *"Any future test that calls `Apply` with watchers enabled against a `t.TempDir` repo will hit it."* These are that test. So the fixture owns its root outside `t.TempDir` with a retrying cleanup — the same shape #6179 used — with an inline comment naming #6188 and stating that both workarounds revert together when it lands.

Full-package load did not *cause* this; it widened an existing window. An intermittent failure that vanishes in isolation is evidence about window size, not about whether the race exists — and reading it the other way is what initially sent this at repolock and tier-watcher machinery instead of at `Apply`.

The cleanup logs its final error rather than swallowing it, so a **permanent** failure — a leaked fd, a live child — stays visible while the transient race stays silenced. Without that, a future leak would accumulate a git fixture per run in silence, where before the workaround it would have shouted. Verified over ~17 runs: zero fixture traces in the real `~/.grafel`, zero leftover temp roots.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0. Full `go test -count=1 ./cmd/grafel/...` at the rebased head: **ok 122.5s, exit 0**, zero `TempDir RemoveAll` occurrences.

Independently adversarially reviewed (APPROVE), the reviewer re-running all five original mutants and adding nine of its own.

## Known limits

Neither subprocess test performs a real fork-exec — both elide it via the inline runner, a property inherited from #6207's harness. Argv rendering is verified statically and the child's flag *handling* is exercised by mutation, but nothing here spawns a real `grafel index-internal`.

`indexOne`'s per-repo timeout leaves the in-process goroutine running, so it can now write a manifest after the RPC already returned a timeout, where before a plain rebuild wrote none. Not a defect — the same goroutine writes the graph first and `commitManifest` stays on its success branch, so graph and manifest advance together; on the subprocess branch the ctx cancel SIGKILLs the child, leaving neither.

Closes #6208
Refs #6207, #6212, #6188, #6178
