### PR TITLE
fix(ci): make the test tree build on windows and linux, not just darwin

### DIFF
--- a/internal/cli/watch_exit_6179_test.go
+++ b/internal/cli/watch_exit_6179_test.go
@@ -2,9 +2,7 @@ package cli
 
 import (
 	"os"
-	"os/signal"
 	"path/filepath"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -105,51 +103,11 @@ func TestRunWatch_GiveUpAfterIndexFailuresExitsSuccessfully(t *testing.T) {
 	}
 }
 
-// TestRunWatch_SignalExitsSuccessfully covers the SIGTERM path end-to-end.
-//
-// This one matters specifically for the reaper interaction noted in #6179: the
-// daemon's sweep SIGTERMs foreign/duplicate `grafel watch` processes, and under
-// the old unconditional KeepAlive launchd relaunched them immediately — a
-// reap↔respawn oscillation. Exiting 0 on signal is what makes the reap stick.
-// (launchd treats death BY an unhandled signal as an unsuccessful exit, so the
-// handler returning normally, rather than the process being signal-killed, is
-// load-bearing.)
-func TestRunWatch_SignalExitsSuccessfully(t *testing.T) {
-	home := withSandboxHome(t)
-	repo := filepath.Join(home, "repos", "signalled")
-	if err := os.MkdirAll(repo, 0o755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Register a test-owned handler FIRST so the SIGTERM below can never take
-	// the default action and kill the test binary, whatever runWatch is doing.
-	guard := make(chan os.Signal, 1)
-	signal.Notify(guard, syscall.SIGTERM)
-	t.Cleanup(func() { signal.Stop(guard) })
-
-	prevTrigger := indexTriggerFunc
-	indexTriggerFunc = func(string) error { return nil }
-	t.Cleanup(func() { indexTriggerFunc = prevTrigger })
-
-	done := make(chan error, 1)
-	go func() { done <- runWatch(repo, "", time.Hour) }()
-
-	// Let runWatch reach its own signal.Notify before signalling.
-	time.Sleep(250 * time.Millisecond)
-	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
-		t.Fatalf("raise SIGTERM: %v", err)
-	}
-
-	select {
-	case err := <-done:
-		if err != nil {
-			t.Fatalf("runWatch returned %v on SIGTERM; a stop request is deliberate and must "+
-				"exit 0 so launchd does not respawn what the reaper just killed (#6179)", err)
-		}
-	case <-time.After(30 * time.Second):
-		t.Fatal("runWatch did not exit on SIGTERM")
-	}
-}
+// TestRunWatch_SignalExitsSuccessfully lives in
+// watch_exit_signal_6179_unix_test.go — it raises a real SIGTERM at itself,
+// which Windows cannot express (see that file's header for why a portable
+// rewrite would assert the opposite of #6179's contract). Everything else in
+// this file builds and runs on all three platforms.
 
 // TestWatchCmd_BadArgvStillFails is the counterweight: making deliberate exits
 // succeed must not make EVERY exit succeed. A human typing `grafel watch` with

--- a/internal/cli/watch_exit_signal_6179_unix_test.go
+++ b/internal/cli/watch_exit_signal_6179_unix_test.go
@@ -1,0 +1,79 @@
+//go:build !windows
+
+// This test is excluded from Windows at BUILD time rather than skipped at run
+// time, and the exclusion is about the assertion, not about a missing API.
+//
+// The property under test is unix signal semantics: a SIGTERM delivered to a
+// running `grafel watch` must be HANDLED (the handler returns normally and the
+// process exits 0) rather than taking the default action. That distinction is
+// what launchd/systemd read — death BY an unhandled signal counts as an
+// unsuccessful exit and re-triggers KeepAlive/Restart, which is the exact
+// reap-respawn oscillation #6179 fixed.
+//
+// Windows has no mechanism to express that. syscall.Kill does not exist there,
+// and the portable spellings do not preserve the intent either: os.Process.Signal
+// on Windows accepts only os.Kill, which terminates the process outright and can
+// never be observed by a handler. Rewriting the test to use it would assert the
+// opposite of what #6179 requires. There is also nothing on Windows for the
+// assertion to protect — the respawn contract belongs to launchd and systemd;
+// the Windows watcher backend is schtasks, which has no equivalent semantics.
+//
+// The other four tests in watch_exit_6179_test.go stay untagged and keep running
+// on all three platforms.
+
+package cli
+
+import (
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// TestRunWatch_SignalExitsSuccessfully covers the SIGTERM path end-to-end.
+//
+// This one matters specifically for the reaper interaction noted in #6179: the
+// daemon's sweep SIGTERMs foreign/duplicate `grafel watch` processes, and under
+// the old unconditional KeepAlive launchd relaunched them immediately — a
+// reap↔respawn oscillation. Exiting 0 on signal is what makes the reap stick.
+// (launchd treats death BY an unhandled signal as an unsuccessful exit, so the
+// handler returning normally, rather than the process being signal-killed, is
+// load-bearing.)
+func TestRunWatch_SignalExitsSuccessfully(t *testing.T) {
+	home := withSandboxHome(t)
+	repo := filepath.Join(home, "repos", "signalled")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Register a test-owned handler FIRST so the SIGTERM below can never take
+	// the default action and kill the test binary, whatever runWatch is doing.
+	guard := make(chan os.Signal, 1)
+	signal.Notify(guard, syscall.SIGTERM)
+	t.Cleanup(func() { signal.Stop(guard) })
+
+	prevTrigger := indexTriggerFunc
+	indexTriggerFunc = func(string) error { return nil }
+	t.Cleanup(func() { indexTriggerFunc = prevTrigger })
+
+	done := make(chan error, 1)
+	go func() { done <- runWatch(repo, "", time.Hour) }()
+
+	// Let runWatch reach its own signal.Notify before signalling.
+	time.Sleep(250 * time.Millisecond)
+	if err := syscall.Kill(os.Getpid(), syscall.SIGTERM); err != nil {
+		t.Fatalf("raise SIGTERM: %v", err)
+	}
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("runWatch returned %v on SIGTERM; a stop request is deliberate and must "+
+				"exit 0 so launchd does not respawn what the reaper just killed (#6179)", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("runWatch did not exit on SIGTERM")
+	}
+}

--- a/internal/cli/watcher_fleet_6180_test.go
+++ b/internal/cli/watcher_fleet_6180_test.go
@@ -21,7 +21,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -361,52 +360,7 @@ func TestStatusReportsRunningWatchers(t *testing.T) {
 	}
 }
 
-// TestDarwinWatcherUnloadIsPersistent: on macOS, `launchctl bootout` only
-// clears the CURRENT login session — the plist stays in ~/Library/LaunchAgents
-// and RunAtLoad fires again at next login. The daemon's own service already
-// pairs bootout with `launchctl disable` for exactly this reason (#6044,
-// internal/daemon/service/launchd_darwin.go Unload). The per-repo watcher
-// loader must do the same, and Load must re-enable.
-func TestDarwinWatcherUnloadIsPersistent(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("darwin-only: launchctl disable/enable semantics")
-	}
-	var calls []string
-	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
-		calls = append(calls, strings.Join(args, " "))
-		return nil, nil
-	})
-	t.Cleanup(restore)
-
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	u := watchers.Unit{Group: "grp", Repo: filepath.Join(home, "alpha"), BinPath: "/usr/local/bin/grafel"}
-	if _, err := watchers.Write(u); err != nil {
-		t.Fatalf("write unit: %v", err)
-	}
-
-	if err := watchers.NewLoader().Unload(u); err != nil {
-		t.Fatalf("Unload: %v", err)
-	}
-	joined := strings.Join(calls, "\n")
-	if !strings.Contains(joined, "bootout") {
-		t.Fatalf("Unload did not bootout:\n%s", joined)
-	}
-	if !strings.Contains(joined, "disable") {
-		t.Fatalf("Unload did not persist the stop (no `launchctl disable`):\n%s", joined)
-	}
-
-	calls = nil
-	if err := watchers.NewLoader().Load(u); err != nil {
-		t.Fatalf("Load: %v", err)
-	}
-	joined = strings.Join(calls, "\n")
-	if !strings.Contains(joined, "enable") {
-		t.Fatalf("Load did not clear a persisted disable (no `launchctl enable`):\n%s", joined)
-	}
-	ei := strings.Index(joined, "enable")
-	bi := strings.Index(joined, "bootstrap")
-	if bi >= 0 && ei > bi {
-		t.Fatalf("`launchctl enable` must precede bootstrap:\n%s", joined)
-	}
-}
+// TestDarwinWatcherUnloadIsPersistent lives in
+// watcher_persist_6180_darwin_test.go — it drives the darwin-only
+// watchers.SetLaunchctlRunnerForTest seam, so it has to be excluded from the
+// linux/windows BUILD, not just skipped at run time.

--- a/internal/cli/watcher_persist_6180_darwin_test.go
+++ b/internal/cli/watcher_persist_6180_darwin_test.go
@@ -1,0 +1,70 @@
+package cli
+
+// Split out of watcher_fleet_6180_test.go, which is otherwise fully portable.
+//
+// This test drives watchers.SetLaunchctlRunnerForTest, a seam that exists only
+// in loader_darwin.go, so the file it lived in did not COMPILE on linux or
+// windows — its `runtime.GOOS != "darwin"` t.Skip guarded the run but not the
+// build, which is what `go vet ./...` reports. The `_darwin_test.go` suffix is
+// this package's existing convention for the same situation (see
+// watcher_ctl_detect_darwin_test.go), and it makes the t.Skip redundant, so it
+// is gone: the file is now excluded from linux/windows builds entirely.
+//
+// The assertion is genuinely darwin-only — it is about launchctl's
+// disable/enable verbs and their ordering relative to bootstrap. There is no
+// systemd or schtasks equivalent to assert, so nothing is lost off macOS.
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// TestDarwinWatcherUnloadIsPersistent: on macOS, `launchctl bootout` only
+// clears the CURRENT login session — the plist stays in ~/Library/LaunchAgents
+// and RunAtLoad fires again at next login. The daemon's own service already
+// pairs bootout with `launchctl disable` for exactly this reason (#6044,
+// internal/daemon/service/launchd_darwin.go Unload). The per-repo watcher
+// loader must do the same, and Load must re-enable.
+func TestDarwinWatcherUnloadIsPersistent(t *testing.T) {
+	var calls []string
+	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
+		calls = append(calls, strings.Join(args, " "))
+		return nil, nil
+	})
+	t.Cleanup(restore)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	u := watchers.Unit{Group: "grp", Repo: filepath.Join(home, "alpha"), BinPath: "/usr/local/bin/grafel"}
+	if _, err := watchers.Write(u); err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+
+	if err := watchers.NewLoader().Unload(u); err != nil {
+		t.Fatalf("Unload: %v", err)
+	}
+	joined := strings.Join(calls, "\n")
+	if !strings.Contains(joined, "bootout") {
+		t.Fatalf("Unload did not bootout:\n%s", joined)
+	}
+	if !strings.Contains(joined, "disable") {
+		t.Fatalf("Unload did not persist the stop (no `launchctl disable`):\n%s", joined)
+	}
+
+	calls = nil
+	if err := watchers.NewLoader().Load(u); err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	joined = strings.Join(calls, "\n")
+	if !strings.Contains(joined, "enable") {
+		t.Fatalf("Load did not clear a persisted disable (no `launchctl enable`):\n%s", joined)
+	}
+	ei := strings.Index(joined, "enable")
+	bi := strings.Index(joined, "bootstrap")
+	if bi >= 0 && ei > bi {
+		t.Fatalf("`launchctl enable` must precede bootstrap:\n%s", joined)
+	}
+}

--- a/internal/install/watcher_write_nonfatal_r3_test.go
+++ b/internal/install/watcher_write_nonfatal_r3_test.go
@@ -1,14 +1,13 @@
 package install_test
 
 import (
-	"os/exec"
-	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/install"
 	"github.com/cajasmota/grafel/internal/install/watchers"
 	"github.com/cajasmota/grafel/internal/registry"
+	"github.com/cajasmota/grafel/internal/testsupport"
 )
 
 // TestApply_WatcherWriteFailureIsNonFatal pins the #6185/#6186 R3 decision
@@ -30,19 +29,29 @@ import (
 // every other repo in the same Apply call. This aligns Apply with
 // watchersync.go's existing warn-and-continue behavior instead of leaving
 // the two callers to disagree.
+// Nothing in this test is macOS-specific: the property is Apply's per-repo
+// warn-and-continue, and watchers.Write rejects a control byte in Unit.Repo on
+// every platform (validateUnitFields, not the plist renderer). It nevertheless
+// used the darwin-only watchers.SetLaunchctlRunnerForTest seam and a bare
+// t.Setenv("HOME", ...), so it did not COMPILE on linux or windows —
+// `GOOS=linux go vet ./internal/install/...` failed on origin/main too. That was
+// noted verbatim in #6197's PR body as "pre-existing and unrelated" and left in
+// place; it is fixed here rather than tagged, because tagging would concede
+// coverage the test never needed to give up.
+//
+// The two portable spellings both already exist in this package:
+//   - testsupport.IsolateHome sets HOME *and* %USERPROFILE% (os.UserHomeDir
+//     reads the latter on Windows, which watchers.UnitDir goes through) and
+//     asserts the redirect took effect. See guidance_test.go for the same call.
+//   - watchers.StubServiceCallsForTest is the documented single cross-platform
+//     stub — it short-circuits launchctl, systemctl AND schtasks. The darwin
+//     helper in launchctl_stub_darwin_test.go delegates to it for that reason.
 func TestApply_WatcherWriteFailureIsNonFatal(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	t.Setenv("GRAFEL_HOME", home)
-	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
-	t.Setenv("GRAFEL_DAEMON_ROOT", filepath.Join(home, ".grafel"))
+	testsupport.IsolateHome(t)
 
-	// Never let a real launchctl run even if activation is reached for the
-	// good repo.
-	restore := watchers.SetLaunchctlRunnerForTest(func(args ...string) ([]byte, error) {
-		return []byte(""), exec.Command("true").Run()
-	})
-	defer restore()
+	// Never let a real service manager run even if activation is reached for
+	// the good repo.
+	t.Cleanup(watchers.StubServiceCallsForTest())
 
 	goodRepo := t.TempDir()
 	badRepo := "/tmp/bad\x00repo" // control byte -> watchers.Write rejects it


### PR DESCRIPTION
The pre-tag 3-OS matrix on `be635f038` failed on Windows at `go vet ./...` with two test-only build breaks. A third was found by sweep — `vet` stops at the first failure, so CI could never have reported it.

```
vet.exe: internal\cli\watch_exit_6179_test.go:139:20: undefined: syscall.Kill
vet.exe: internal\install\watcher_write_nonfatal_r3_test.go:42:22: undefined: watchers.SetLaunchctlRunnerForTest
```

**The second was already documented and left.** #6197's PR body says it verbatim: *"`internal/install`'s test binary does not compile off macOS … `GOOS=linux go vet ./internal/install/...` fails on `origin/main` too. No Linux contributor or CI runner can build that package's tests."* It was written into a "known limits" section and never fixed, and it is what blocked this release.

Nothing here touches production code. The shipped binary was always fine — but `go vet ./...` is part of the suite, so no platform leg could pass.

## Three files, three different right answers

**`internal/cli/watch_exit_6179_test.go` — tagged `//go:build !windows`, split into its own file.**

`TestRunWatch_SignalExitsSuccessfully` is genuinely Unix signal semantics: it asserts SIGTERM is *handled* and the handler returns normally (exit 0), because launchd and systemd treat death by an unhandled signal as unsuccessful and re-fire `KeepAlive` — the exact oscillation #6179 fixed. Windows cannot express it. `os.Process.Signal` accepts only `os.Kill` there, which terminates outright and can never reach a handler, so a "portable" rewrite would assert the **opposite** of the contract. There is also nothing to protect on Windows: respawn semantics belong to launchd and systemd, not schtasks.

Split rather than tagged in place so the other **four** tests in that file keep running on all three platforms.

**`internal/cli/watcher_fleet_6180_test.go` — the third break, tagged via a `_darwin_test.go` filename.**

`TestDarwinWatcherUnloadIsPersistent` used `SetLaunchctlRunnerForTest` behind a `runtime.GOOS != "darwin"` `t.Skip`. **That guards execution, not compilation** — the file failed to build off macOS regardless. Filename suffix matches the package's existing convention (`watcher_ctl_detect_darwin_test.go`); the now-dead `t.Skip` and its unused `runtime` import are removed. The assertion really is launchctl `disable`/`enable` verb ordering, with no systemd or schtasks equivalent, so nothing is lost.

**`internal/install/watcher_write_nonfatal_r3_test.go` — made portable, not tagged.**

Nothing about `TestApply_WatcherWriteFailureIsNonFatal` is macOS-specific: the property is `Apply`'s per-repo warn-and-continue, and `validateUnitFields` rejects the control byte on every platform. Both portable spellings already existed in this package — `watchers.StubServiceCallsForTest` (the documented cross-platform stub, which `launchctl_stub_darwin_test.go` already delegates to) and `testsupport.IsolateHome` (which sets `%USERPROFILE%`, the variable `os.UserHomeDir` → `watchers.UnitDir` reads on Windows; `guidance_test.go` documents that exact trap).

No assertion weakened, nothing `t.Skip`ped into silent green. Tagging a test off a platform costs that coverage permanently, so portability was preferred wherever the test's intent survived it — which was one case in three.

## What could be verified locally, and what could not

**Cross-`GOOS` vet cannot be run to completion on this machine.** With `CGO_ENABLED=0` the tree-sitter bindings drop all their files, `internal/treesitter/ts/official` fails to type-check, and everything downstream — including `internal/cli` — is never reached. No cross C toolchain is installed and pulling one in was judged not worth it here.

| check | before | after |
|---|---|---|
| `go vet ./...` darwin | 0 | **0** |
| `go vet -tags perf ./...` darwin | 0 | **0** |
| `GOOS=windows CGO_ENABLED=0 go vet ./internal/install/...` | **1** | **0** |
| `GOOS=linux CGO_ENABLED=0 go vet ./internal/install/...` | **1** | **0** |
| `GOOS=windows/linux CGO_ENABLED=0 go vet ./...` | 1 — 2 real findings + cgo noise | 1 — **cgo type errors only, zero findings outside them** |

`go build ./...` 0, `gofmt -l .` silent, `go test -count=1 ./internal/cli/... ./internal/install/...` 0.

Build-constraint selection was proved with `go list -f '{{.TestGoFiles}}'` under each `GOOS`, which evaluates constraints without type-checking and therefore needs no cgo: **windows selects neither new file, linux selects the `_unix_test.go` only, darwin selects both.**

**Stated plainly, because a known-limits section is what caused this issue:** `internal/cli` was never type-checked cross-`GOOS` — it sits inside the cgo cone. Both files edited there are *untagged*, so darwin's clean vet type-checks the identical source Windows and Linux will see, and the only cross-platform variable is file selection, which `go list` proved. That is close to a proof but is not the vet run itself. And the now-portable `internal/install` test has literally never executed on Windows or Linux; if the matrix comes back red on one test, that is the likeliest culprit and `//go:build darwin` is the one-line fallback.

## The sweep

Every file `go list` selects for `GOOS=windows` and `GOOS=linux`, with and without `-tags perf` — 4,381 files — grepped for `syscall.Kill/Mkfifo/Umask/Getrlimit/Setpgid/Statfs/Wait4/Syscall/SYS_*/SIGUSR*/Credential/Stat_t`, `golang.org/x/sys/unix`, `SetLaunchctlRunnerForTest`, and Windows-only API leaking into Unix builds.

After the change the only remaining hits are **string literals**: a regexp source in `guard_6053_liveness_test.go`, an error message in `test_isolation_guard.go`, a map key in `extractors/golang/imports.go`. Everything else was already correctly excluded by an existing `//go:build !windows` or `//go:build darwin`.

## The gap this exposes, filed separately

**The repo's own CI cannot detect this class before the expensive matrix.** `pre-merge.yml` and `test.yml`'s default leg run `go vet ./...` on Linux only; `windows.yml` is `workflow_dispatch`-only to conserve free-tier minutes; the 3-OS matrix is gated on a `ci:full` label or a tag. So a darwin-only build break in a test file can merge, sit on `main` — this one sat since #6197, *documented* — and surface only at release tagging, where it is a blocker.

An always-on compile-only leg (`GOOS=windows go build ./... && GOOS=linux go build ./...`) would have caught all three for a few free-tier seconds: compile-only needs no test runner and no Windows runner.

Secondary, smaller, and real: **`runtime.GOOS != "darwin"` plus `t.Skip` reads as a platform guard and is not one.** It guards execution, not compilation. That idiom produced the third break here and is worth a one-time grep.

Refs #6197, #6179, #6180
