### PR TITLE
fix(#6162): stop `grafel update` writing .gitignore and 4 git hooks into whatever repo you are standing in

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -202,6 +202,14 @@ Claude Code config directory's skills/ subdirectory.`,
 			// performed (via service.Install inside RunCopy's step 4).
 			if copyMode {
 				return runInstallCopy(out, install.CopyOptions{
+					// #6162: `grafel install` is the ONE entrypoint that may
+					// touch the repo it is run in (.gitignore + the four git
+					// hooks) — running it here is the user asking for exactly
+					// that. `grafel update` passes IntentUpgrade and gets
+					// neither. RunCopy rejects an unset Intent, so this is
+					// stated at the construction site rather than patched in
+					// downstream where a future second caller would miss it.
+					Intent:           install.IntentInstall,
 					BinPath:          bin,
 					SkillsSourceDir:  skillsSourceDir,
 					ClaudeConfigDirs: claudeConfigDirs,
@@ -623,6 +631,10 @@ func runInstallDev(out io.Writer, opts install.DevOptions) error {
 // runInstallCopy runs the COPY-mode install transaction (issue #2210) and
 // prints a structured summary. Called from newInstallCmd when --copy is set.
 func runInstallCopy(out io.Writer, opts install.CopyOptions) error {
+	// opts.Intent is deliberately NOT forced here: it is the caller's
+	// declaration, and RunCopy rejects it unset (#6162). Setting it in this
+	// helper would silently launder any future caller that had not thought
+	// about whether it may modify the user's repository.
 	result, err := install.RunCopy(opts)
 	if err != nil {
 		fmt.Fprintf(out, "✗ install (copy mode) failed: %v\n", err)

--- a/internal/cli/update.go
+++ b/internal/cli/update.go
@@ -36,6 +36,10 @@ replaces the current binary, and re-runs the install transaction
 On success the previous binary is removed. On failure the previous
 binary is restored automatically (rollback).
 
+Update never modifies the git repository you happen to be standing in:
+the .gitignore entry and the git hooks belong to 'grafel install', which
+you run inside a repo on purpose.
+
   grafel update                # latest stable release
   grafel update --pre          # latest pre-release
   grafel update --tag v1.2.3   # pin to a specific version

--- a/internal/install/copy.go
+++ b/internal/install/copy.go
@@ -431,9 +431,53 @@ func versionsEquivalent(a, b string) bool {
 	return releaseIdentity(a) == releaseIdentity(b)
 }
 
-// CopyOptions is the input to RunCopy. All fields have sensible defaults;
-// callers only need to set overrides.
+// CopyIntent says WHY RunCopy is running. It is the difference between "the
+// user deliberately ran `grafel install` in this directory" and "the user
+// asked for a newer binary" — a difference that decides whether the
+// transaction may touch the git repository around opts.WorkingDir (#6162).
+type CopyIntent string
+
+const (
+	// IntentInstall is a first-class install the user invoked in a specific
+	// directory (`grafel install`). Its cwd-scoped steps — the .gitignore
+	// entry (step 5) and the four git hooks (step 7) — are the point of
+	// running it there, so they RUN.
+	IntentInstall CopyIntent = "install"
+
+	// IntentUpgrade is a binary replacement (`grafel update`). It runs from
+	// wherever the user's shell happens to be, which names no repository and
+	// grants no consent to modify one, so the cwd-scoped steps are SKIPPED and
+	// install.json is merged rather than replaced (#6162).
+	IntentUpgrade CopyIntent = "upgrade"
+)
+
+// repoScoped reports whether this intent may mutate the git repository around
+// opts.WorkingDir. Only a deliberate install may.
+//
+// COUPLING: the `!= IntentUpgrade` form is fail-OPEN by construction — any
+// value that is not exactly IntentUpgrade, including a hypothetical third
+// intent, is treated as permitted to write the user's .gitignore and hooks.
+// That is only safe because applyDefaults rejects both an empty and an
+// unrecognised Intent before any step runs. Loosen that validation and this
+// predicate silently starts granting repo access to whatever comes next.
+func (i CopyIntent) repoScoped() bool { return i != IntentUpgrade }
+
+// CopyOptions is the input to RunCopy. Most fields have sensible defaults and
+// callers only need to set overrides — the exception is Intent, which is
+// REQUIRED.
 type CopyOptions struct {
+	// Intent selects the install-vs-upgrade step set (#6162). It is REQUIRED
+	// and has NO DEFAULT: applyDefaults returns an error when it is empty or
+	// unrecognised, so omitting it fails the call rather than picking a
+	// meaning for you. A caller that has not declared whether it may modify
+	// the user's git repository has not thought about it, and the wrong guess
+	// here is silent — it appends to a stranger's tracked .gitignore and
+	// writes four hooks `git status` does not show.
+	//
+	// `grafel install` passes IntentInstall; `grafel update` passes
+	// IntentUpgrade.
+	Intent CopyIntent
+
 	// BinPath is the running grafel binary.  Defaults to os.Executable().
 	BinPath string
 
@@ -549,7 +593,7 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	}
 
 	result := &CopyResult{}
-	state := NewState(ModeCopy)
+	state := newTransactionState(opts)
 
 	// We track which steps succeeded so rollback is precise.
 	var completedSteps []int
@@ -788,8 +832,21 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 
 	// ─────────────────────────────────────────────────────────────────────────
 	// Step 5: .gitignore integration
+	//
+	// INSTALL ONLY (#6162). This step is scoped to opts.WorkingDir, which on a
+	// `grafel update` is nothing but the directory the user's shell was sitting
+	// in — appending to that repository's TRACKED .gitignore is a modification
+	// to a project the user never named, and one they then have to explain in
+	// a diff. `grafel install` keeps it: running install inside a repo IS the
+	// user pointing at that repo. The previously-recorded state.Gitignore
+	// survives an upgrade untouched (see newTransactionState).
 	// ─────────────────────────────────────────────────────────────────────────
-	if repoRoot, ok := DetectGitRepo(opts.WorkingDir); ok {
+	if !opts.Intent.repoScoped() {
+		// No git subprocess, no detection, no write: an upgrade has no repo in
+		// scope at all.
+		fmt.Fprintf(os.Stderr,
+			"grafel update: step 5 – skipped; an upgrade does not modify .gitignore in the current directory\n")
+	} else if repoRoot, ok := DetectGitRepo(opts.WorkingDir); ok {
 		if !opts.DryRun {
 			if _, err := EnsureGitignore(repoRoot); err != nil {
 				// .gitignore failure is non-fatal; warn but continue.
@@ -837,8 +894,18 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 	//         pre-push). Non-fatal: a hook install failure warns but does not
 	//         roll back the rest of the install.  Can be opted-out with
 	//         --no-hooks.
+	//
+	//         INSTALL ONLY (#6162). Same reasoning as step 5, and worse in one
+	//         respect: `git status` does not show .git/hooks, so hooks written
+	//         into a bystander repo are invisible until one of them fires. The
+	//         hook scripts are version-agnostic shims that shell out to
+	//         `grafel`, so replacing the binary in place does not make an
+	//         already-installed hook stale — an upgrade has nothing to refresh
+	//         here. Repos the user actually registered keep getting their hooks
+	//         from the registry-driven path in internal/cli/update.go, which
+	//         iterates cfg.Repos and honours cfg.Features.GitHooks.
 	// ─────────────────────────────────────────────────────────────────────────
-	if !opts.NoHooks {
+	if !opts.NoHooks && opts.Intent.repoScoped() {
 		hookOpts := HookInstallOptions{
 			RepoPath: opts.WorkingDir,
 			DryRun:   opts.DryRun,
@@ -853,6 +920,62 @@ func RunCopy(opts CopyOptions) (*CopyResult, error) {
 }
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+// newTransactionState returns the State this RunCopy run will fill in.
+//
+// An INSTALL starts from a blank State: every field it does not set is
+// genuinely unknown, and a fresh install is entitled to forget what a previous
+// one recorded.
+//
+// An UPGRADE does not (#6162). `grafel update` replaces a binary; it does not
+// re-decide anything the user settled at install time, and it deliberately
+// SKIPS steps 5 and 7. Starting from NewState(ModeCopy) would therefore write
+// an install.json whose gitignore record is empty — not because the entry was
+// removed from the user's .gitignore, but because this run never looked. That
+// is a lie the file then tells `grafel doctor`, which iterates
+// state.Gitignore.Repos (doctor.go:263) and would silently stop checking the
+// repo it had been checking the day before.
+//
+// So an upgrade MERGES: it starts from the recorded state and resets only the
+// fields this transaction genuinely recomputes. Everything else — including
+// fields added by future schema versions — is carried through untouched. A
+// missing or unreadable install.json degrades to a blank state, since an
+// upgrade must never fail on bookkeeping.
+func newTransactionState(opts CopyOptions) *State {
+	fresh := NewState(ModeCopy)
+	if opts.Intent != IntentUpgrade {
+		return fresh
+	}
+	prev, err := ReadState(opts.StatePath)
+	if err != nil || prev == nil {
+		return fresh
+	}
+
+	merged := *prev
+	// ASSUMPTION (#6162 review F5): relabelling prev's schema as current is
+	// only honest while State evolves ADDITIVELY — an older file's fields all
+	// still mean what this build thinks they mean. The first time a field
+	// CHANGES SHAPE, this line starts stamping "current" on old-shaped data
+	// and must become a real migration keyed on prev.SchemaVersion.
+	merged.SchemaVersion = StateSchemaVersion
+	// An upgrade IS an install event, so the timestamp is honestly refreshed.
+	merged.InstalledAt = fresh.InstalledAt
+	// RunCopy copies skills; whatever the previous mode was, this run's
+	// skills are copies.
+	merged.InstallMode = ModeCopy
+	// Step 2 rebuilds the manifest wholesale and only sets SkillsSkipped in
+	// its skip branches, so both must start clean or a stale skip flag / a
+	// removed skill would survive forever.
+	merged.Skills = make(map[string]SkillRecord)
+	merged.SkillsSkipped = false
+	// This transaction has not failed yet; a previous run's rollback markers
+	// must not be inherited as if they described this one.
+	merged.PartialInstall = false
+	merged.RollbackFromStep = 0
+	// CLI, MCP and DaemonVersion are unconditionally overwritten by steps 1,
+	// 3 and 4. Gitignore is NOT — that is the field this merge exists for.
+	return &merged
+}
 
 func (o *CopyOptions) applyDefaults() error {
 	if o.BinPath == "" {
@@ -869,7 +992,37 @@ func (o *CopyOptions) applyDefaults() error {
 		}
 		o.StatePath = p
 	}
-	if o.WorkingDir == "" {
+	// Intent has NO default (#6162). A caller that has not said whether it may
+	// modify the user's git repository has not thought about it, and the two
+	// possible defaults are not symmetric: defaulting to install means a
+	// forgetful caller silently appends to a stranger's tracked .gitignore and
+	// writes four hooks `git status` does not show — nothing fails, and the
+	// user finds out in a diff or never. Defaulting to upgrade means a
+	// forgetful caller merely produces no /.grafel/ line, which is loud,
+	// immediate, and already covered by a test. Rather than pick the
+	// less-bad silent failure, require the declaration.
+	if o.Intent == "" {
+		return fmt.Errorf("CopyOptions.Intent is required: pass IntentInstall " +
+			"(may modify the repo in WorkingDir) or IntentUpgrade (must not)")
+	}
+	if o.Intent != IntentInstall && o.Intent != IntentUpgrade {
+		return fmt.Errorf("CopyOptions.Intent %q is not a known intent", o.Intent)
+	}
+	// An upgrade has NO repository in scope, so a WorkingDir is not merely
+	// unused — it is a caller misunderstanding, and one worth failing on. The
+	// alternative (accept and ignore it) reads as a second layer of defence
+	// and is not one: DetectGitRepo("") shells out to `git -C "" rev-parse`,
+	// whose empty -C is a no-op, and InstallGitHooks falls back to os.Getwd()
+	// on an empty RepoPath (hooks_install.go:132). Dropping WorkingDir on the
+	// floor would therefore still hit a repo — the process cwd, i.e. the very
+	// repo #6162 is about. The gates on steps 5 and 7 are the whole defence;
+	// this check exists so nobody believes otherwise.
+	if o.Intent == IntentUpgrade && o.WorkingDir != "" {
+		return fmt.Errorf("CopyOptions.WorkingDir %q set under IntentUpgrade: "+
+			"an upgrade has no repository in scope (#6162)", o.WorkingDir)
+	}
+	// WorkingDir feeds ONLY the repo-scoped steps (5 and 7).
+	if o.WorkingDir == "" && o.Intent.repoScoped() {
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("resolve working dir: %w", err)

--- a/internal/install/copy_test.go
+++ b/internal/install/copy_test.go
@@ -32,6 +32,7 @@ func TestRunCopy_HappyPath(t *testing.T) {
 	env := newTestEnv(t)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -111,6 +112,7 @@ func TestRunCopy_Idempotent(t *testing.T) {
 	env := newTestEnv(t)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -165,6 +167,7 @@ func TestRunCopy_RollbackOnStep4Failure(t *testing.T) {
 	env := newTestEnv(t)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -219,6 +222,7 @@ func TestRunCopy_PartialInstallAutoRecovers(t *testing.T) {
 	}
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -258,6 +262,7 @@ func TestRunCopy_UnreadableStateStillBlocks(t *testing.T) {
 	}
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -471,6 +476,7 @@ func TestRunCopy_NoOnDiskSkills_EmbeddedFallbackInstalls(t *testing.T) {
 	restartCalled := false
 
 	opts := install.CopyOptions{
+		Intent:           install.IntentInstall,
 		BinPath:          isoBin,
 		SkillsSourceDir:  "/nonexistent/skills",
 		ClaudeConfigDirs: []string{env.claudeJSON},
@@ -563,6 +569,7 @@ func TestRunCopy_DaemonVersionMatch_NoEscalation(t *testing.T) {
 
 	escalateCalled := false
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -608,6 +615,7 @@ func TestRunCopy_DaemonVersionMismatch_EscalatesThenSucceeds(t *testing.T) {
 	probeCalls := 0
 	escalateCalled := false
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -662,6 +670,7 @@ func TestRunCopy_DaemonStillStaleAfterEscalation_ReturnsError(t *testing.T) {
 
 	escalateCalled := false
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -725,6 +734,7 @@ func TestRunCopy_DaemonVersionProbeHTML_TreatedAsUnknown_TriggersEscalation(t *t
 	probeCalls := 0
 	escalateCalled := false
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},

--- a/internal/install/dev_test.go
+++ b/internal/install/dev_test.go
@@ -217,6 +217,7 @@ func TestRunDev_ModeSwitchFromCopy(t *testing.T) {
 
 	// First install in COPY mode.
 	copyOpts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},

--- a/internal/install/gitignore_test.go
+++ b/internal/install/gitignore_test.go
@@ -276,6 +276,7 @@ func TestIntegration_RunCopy_GitignoreIdempotent(t *testing.T) {
 	env := newTestEnv(t)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},

--- a/internal/install/mcp_rollback_6168_test.go
+++ b/internal/install/mcp_rollback_6168_test.go
@@ -98,6 +98,7 @@ func TestRunCopy_Step4Failure_KeepsMCPRegistration(t *testing.T) {
 	writeConfigWithForeignServer(t, env.claudeJSON)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -127,6 +128,7 @@ func TestRunCopy_Step4VerifyFailure_KeepsMCPRegistration(t *testing.T) {
 	writeConfigWithForeignServer(t, env.claudeJSON)
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -181,6 +183,7 @@ func TestRunCopy_Step4Failure_KeepsAPreexistingGrafelEntry(t *testing.T) {
 	}
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -263,6 +266,7 @@ func TestRunCopy_Step3PartialFailure_RestoresAlreadyWrittenTargets(t *testing.T)
 	}
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{good, bad},
@@ -300,6 +304,7 @@ func TestRunCopy_SidecarBackupSurvivesUntilCommit(t *testing.T) {
 	sidecar := env.claudeJSON + ".grafel.bak"
 
 	failing := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},

--- a/internal/install/skills_acceptance_test.go
+++ b/internal/install/skills_acceptance_test.go
@@ -73,6 +73,7 @@ func TestRunCopy_EmbeddedSkillsLandAndUninstallRemoves(t *testing.T) {
 	}
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           fakeBin,
 		SkillsSourceDir:   "", // force discovery → embedded fallback
 		ClaudeConfigDirs:  []string{claudeJSON},

--- a/internal/install/stale_sidecar_6168_test.go
+++ b/internal/install/stale_sidecar_6168_test.go
@@ -64,6 +64,7 @@ func TestStaleSidecar_AbsentSentinelDoesNotDeleteTheUsersConfig(t *testing.T) {
 	}
 
 	run1 := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -143,6 +144,7 @@ func TestStaleSidecar_DoesNotResurrectAnOldSnapshotOverLiveContent(t *testing.T)
 	}
 
 	run1 := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -259,6 +261,7 @@ func TestStaleSidecar_UninstallSweepsOrphanedSidecars(t *testing.T) {
 	sidecar := env.claudeJSON + ".grafel.bak"
 
 	failed := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -293,6 +296,7 @@ func TestStaleSidecar_NoSidecarSurvivesAStep4Failure(t *testing.T) {
 	sidecar := env.claudeJSON + ".grafel.bak"
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -344,6 +348,7 @@ func TestRollback_SurfacesAFailedRestore(t *testing.T) {
 	bad := malformedTarget(t, filepath.Dir(good))
 
 	opts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{good, bad},

--- a/internal/install/uninstall_test.go
+++ b/internal/install/uninstall_test.go
@@ -20,6 +20,7 @@ func TestRunUninstall_HappyPath(t *testing.T) {
 
 	// First run a full install so there is a valid install.json.
 	_, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -91,6 +92,7 @@ func TestRunUninstall_Idempotent(t *testing.T) {
 
 	// First install.
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -126,6 +128,7 @@ func TestRunUninstall_Purge(t *testing.T) {
 
 	// First install.
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -200,6 +203,7 @@ func TestRunUninstall_PurgePreservesForeignRoot(t *testing.T) {
 	env := newTestEnv(t)
 
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -254,6 +258,7 @@ func TestRunUninstall_NoBinary(t *testing.T) {
 
 	// Install, then remove the binary manually.
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -285,6 +290,7 @@ func TestRunUninstall_ConfirmNo(t *testing.T) {
 	env := newTestEnv(t)
 
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -326,6 +332,7 @@ func TestRunUninstall_NonTTYAutoYes(t *testing.T) {
 	env := newTestEnv(t)
 
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -390,6 +397,7 @@ func TestRunUninstall_KeepsBinaryByDefault(t *testing.T) {
 	}
 
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -445,6 +453,7 @@ func TestRunUninstall_RemoveBinaryFlag(t *testing.T) {
 	env := newTestEnv(t)
 
 	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},
@@ -482,6 +491,7 @@ func TestRunUninstall_ReinstallAfterUninstall(t *testing.T) {
 	env := newTestEnv(t)
 
 	copyOpts := install.CopyOptions{
+		Intent:            install.IntentInstall,
 		BinPath:           env.fakeBin,
 		SkillsSourceDir:   env.skillsSourceDir,
 		ClaudeConfigDirs:  []string{env.claudeJSON},

--- a/internal/install/update.go
+++ b/internal/install/update.go
@@ -59,8 +59,19 @@ type UpdateOptions struct {
 	// Defaults to DefaultStatePath().
 	StatePath string
 
-	// WorkingDir is used for git repo detection when re-running install.
-	// Defaults to os.Getwd().
+	// WorkingDir is retained for API compatibility and is NO LONGER READ
+	// (#6162). It used to be forwarded to RunCopy, where it selected the
+	// repository whose .gitignore was appended to and whose .git/hooks were
+	// written — i.e. it made `grafel update` mutate whatever checkout the
+	// user's shell was sitting in. An upgrade has no repository in scope.
+	//
+	// Not forwarding it is NOT a safety measure and must not be read as one:
+	// with the step-5/7 gates removed, an empty WorkingDir resolves straight
+	// back to the process cwd (DetectGitRepo's `git -C "" rev-parse` no-ops
+	// the -C; InstallGitHooks defaults RepoPath to os.Getwd()), which is the
+	// same repository. The gates are the defence. RunCopy additionally
+	// REJECTS a non-empty WorkingDir under IntentUpgrade, so this field being
+	// ignored here is enforced rather than assumed.
 	WorkingDir string
 
 	// SkillsSourceDir overrides skills discovery during re-install.
@@ -149,13 +160,9 @@ func (o *UpdateOptions) applyDefaults() error {
 		}
 		o.StatePath = p
 	}
-	if o.WorkingDir == "" {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("resolve working dir: %w", err)
-		}
-		o.WorkingDir = cwd
-	}
+	// WorkingDir is intentionally not defaulted: nothing consumes it (#6162),
+	// and resolving a cwd an upgrade will never use is one more way for an
+	// upgrade to fail for a reason that has nothing to do with upgrading.
 	if o.HTTPClient == nil {
 		o.HTTPClient = &http.Client{Timeout: defaultUpdateTimeout}
 	}
@@ -256,11 +263,20 @@ func RunUpdate(opts UpdateOptions) (*UpdateResult, error) {
 
 	// ── re-run install ────────────────────────────────────────────────────────
 	installOpts := CopyOptions{
+		// #6162: an upgrade is NOT a re-install. IntentUpgrade runs steps
+		// 1-4 and 6 (new binary recorded, skills and MCP kept consistent with
+		// it, daemon restarted onto it, state persisted) and skips the two
+		// cwd-scoped steps — 5's .gitignore append and 7's four git hooks —
+		// which would otherwise modify whatever repository the user's shell
+		// happened to be in. Those gates are the ENTIRE defence; WorkingDir is
+		// not forwarded because RunCopy rejects it under IntentUpgrade, not
+		// because omitting it would protect anything (it would not — see the
+		// note on UpdateOptions.WorkingDir).
+		Intent:            IntentUpgrade,
 		BinPath:           opts.BinPath,
 		SkillsSourceDir:   opts.SkillsSourceDir,
 		ClaudeConfigDirs:  opts.ClaudeConfigDirs,
 		StatePath:         opts.StatePath,
-		WorkingDir:        opts.WorkingDir,
 		Force:             true, // update always re-installs
 		DryRun:            opts.DryRun,
 		SkipDaemonRestart: opts.SkipDaemonRestart,

--- a/internal/install/update_blast_radius_6162_test.go
+++ b/internal/install/update_blast_radius_6162_test.go
@@ -1,0 +1,443 @@
+package install_test
+
+// update_blast_radius_6162_test.go pins the blast radius of `grafel update`.
+//
+// #6162: `grafel update` re-ran the FULL seven-step install transaction with
+// WorkingDir defaulting to os.Getwd(), so two of those steps mutated whatever
+// git repository the user's shell happened to be sitting in:
+//
+//	step 5 — appended /.grafel/ to that repo's (tracked) .gitignore
+//	step 7 — installed four git hooks (pre-push, post-checkout, post-merge,
+//	         post-rewrite) into that repo's .git/hooks
+//
+// Neither is mentioned in the command's description, and `git status` does not
+// show the hooks at all. An upgrade replaces a binary and whatever must stay
+// consistent with it; it is not a re-install, and it must not touch a repo the
+// user never named.
+//
+// These tests assert on observable FILESYSTEM state — the bytes of .gitignore
+// and the presence of hook files — not on internal flags.
+
+import (
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// grafelHookNames are the four hooks step 7 installs.
+var grafelHookNames = []string{"pre-push", "post-checkout", "post-merge", "post-rewrite"}
+
+// newBinaryDownloader returns a DownloadBinary stub that writes distinct
+// content, so RunUpdate never fast-paths to Skipped.
+func newBinaryDownloader(content string) func(*http.Client, string, string, string, string) error {
+	return func(_ *http.Client, _, _, _, destPath string) error {
+		return os.WriteFile(destPath, []byte(content), 0o755)
+	}
+}
+
+func hookPresent(t *testing.T, repo, name string) bool {
+	t.Helper()
+	_, err := os.Stat(filepath.Join(repo, ".git", "hooks", name))
+	return err == nil
+}
+
+// newGitRepoFixture creates a REAL git repository (own .git DIRECTORY, own
+// .git/hooks) under t.TempDir() and returns its path. `git init` is required,
+// not faked: a hand-rolled .git without hooks/ would make every hook assertion
+// in this file vacuous, which is the exact failure mode these tests exist to
+// avoid.
+func newGitRepoFixture(t *testing.T, name string) string {
+	t.Helper()
+	dir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("create %s: %v", dir, err)
+	}
+	if out, err := exec.Command("git", "-C", dir, "init", "-q").CombinedOutput(); err != nil {
+		t.Skipf("git init unavailable (%v: %s); this test needs a real repo", err, out)
+	}
+	return dir
+}
+
+// standInsideRepo makes repo the PROCESS working directory, which is the only
+// channel the defect actually travels down.
+//
+// Setting UpdateOptions.WorkingDir instead would prove nothing: RunUpdate no
+// longer reads that field, so an assertion built on it holds no matter what
+// the production code does. And an empty WorkingDir does NOT mean "no repo" —
+// DetectGitRepo shells out to `git -C "" rev-parse --show-toplevel`, whose
+// empty -C is a no-op, and InstallGitHooks defaults RepoPath to os.Getwd()
+// (hooks_install.go:132). Both land on the process cwd. So the test has to
+// STAND in the repo, exactly as the user does.
+//
+// It also verifies the fixture can express the hooks half of the bug at all:
+// in a git WORKTREE, .git is a ~72-byte file rather than a directory, so
+// InstallGitHooks fails its `stat .git/hooks` regardless of any gate and the
+// hook assertions would pass vacuously. Fixtures must be real clones.
+func standInsideRepo(t *testing.T, repo string) {
+	t.Helper()
+
+	info, err := os.Stat(filepath.Join(repo, ".git"))
+	if err != nil {
+		t.Fatalf("fixture %s is not a git repo: %v", repo, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("fixture %s has a FILE .git (worktree/submodule); InstallGitHooks "+
+			"cannot write there under any gate, so the hook assertions would be "+
+			"vacuous. Use a real clone.", repo)
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".git", "hooks")); err != nil {
+		t.Fatalf("fixture %s has no .git/hooks; the hook assertions would be "+
+			"vacuous: %v", repo, err)
+	}
+
+	t.Chdir(repo)
+}
+
+// TestRunUpdate_LeavesUnregisteredRepoGitignoreByteIdentical is the primary
+// #6162 regression: an update run from inside an arbitrary git checkout must
+// not rewrite that checkout's .gitignore.
+func TestRunUpdate_LeavesUnregisteredRepoGitignoreByteIdentical(t *testing.T) {
+	env := newTestEnv(t)
+	standInsideRepo(t, env.gitRepo)
+
+	gitignorePath := filepath.Join(env.gitRepo, ".gitignore")
+	before := "node_modules/\n*.log\n"
+	if err := os.WriteFile(gitignorePath, []byte(before), 0o644); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.1-blastradius",
+		DownloadBinary:    newBinaryDownloader("#!/bin/sh\necho newer-grafel"),
+	}
+	if _, err := install.RunUpdate(opts); err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+
+	after, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("read .gitignore after update: %v", err)
+	}
+	if string(after) != before {
+		t.Errorf("#6162: grafel update modified the .gitignore of a repo it was\n"+
+			"merely run inside.\n before = %q\n after  = %q", before, string(after))
+	}
+}
+
+// TestRunUpdate_InstallsNoGitHooksInUnregisteredRepo is the invisible half of
+// #6162: `git status` never shows .git/hooks, so this side effect is silent.
+func TestRunUpdate_InstallsNoGitHooksInUnregisteredRepo(t *testing.T) {
+	env := newTestEnv(t)
+	standInsideRepo(t, env.gitRepo)
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.1-nohooks",
+		DownloadBinary:    newBinaryDownloader("#!/bin/sh\necho newer-grafel"),
+	}
+	if _, err := install.RunUpdate(opts); err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+
+	for _, name := range grafelHookNames {
+		if hookPresent(t, env.gitRepo, name) {
+			t.Errorf("#6162: grafel update installed the %s hook into a repo it was "+
+				"merely run inside (%s)", name, env.gitRepo)
+		}
+	}
+}
+
+// TestRunUpdate_DoesNotCreateGitignoreWhenAbsent covers the repo that has no
+// .gitignore at all: update must not create one.
+func TestRunUpdate_DoesNotCreateGitignoreWhenAbsent(t *testing.T) {
+	env := newTestEnv(t)
+	standInsideRepo(t, env.gitRepo)
+
+	gitignorePath := filepath.Join(env.gitRepo, ".gitignore")
+	if _, err := os.Stat(gitignorePath); err == nil {
+		t.Fatalf("fixture already has a .gitignore at %s", gitignorePath)
+	}
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.1-nocreate",
+		DownloadBinary:    newBinaryDownloader("#!/bin/sh\necho newer-grafel"),
+	}
+	res, err := install.RunUpdate(opts)
+	if err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+	if _, err := os.Stat(gitignorePath); err == nil {
+		t.Errorf("#6162: grafel update created %s in a repo it was merely run inside", gitignorePath)
+	}
+	if res.InstallResult != nil && res.InstallResult.GitignoreRepo != "" {
+		t.Errorf("#6162: update reported GitignoreRepo = %q; an upgrade touches no repo",
+			res.InstallResult.GitignoreRepo)
+	}
+}
+
+// TestRunUpdate_StillPerformsUpgradeWork pins the OTHER side of the fix: the
+// scoping change must not degenerate into "update does nothing". The steps an
+// upgrade genuinely owns — new binary in place, its SHA recorded, skills
+// re-copied to match the new binary, MCP entry re-registered — must all still
+// happen.
+func TestRunUpdate_StillPerformsUpgradeWork(t *testing.T) {
+	env := newTestEnv(t)
+	standInsideRepo(t, env.gitRepo)
+
+	const newContent = "#!/bin/sh\necho newer-grafel"
+
+	opts := install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.1-upgradework",
+		DownloadBinary:    newBinaryDownloader(newContent),
+	}
+	res, err := install.RunUpdate(opts)
+	if err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+	if res.Skipped {
+		t.Fatal("update reported Skipped for a genuinely different binary")
+	}
+
+	// The binary itself was replaced.
+	got, err := os.ReadFile(env.fakeBin)
+	if err != nil {
+		t.Fatalf("read binary: %v", err)
+	}
+	if string(got) != newContent {
+		t.Errorf("binary content = %q, want %q", got, newContent)
+	}
+
+	// install.json records the NEW binary's SHA (step 1 belongs to an upgrade).
+	wantSHA, err := install.SHA256FilePublic(env.fakeBin)
+	if err != nil {
+		t.Fatalf("sha new binary: %v", err)
+	}
+	state := readState(t, env.statePath)
+	if state == nil {
+		t.Fatal("install.json missing after update")
+	}
+	if state.CLI.SHA256 != wantSHA {
+		t.Errorf("install.json CLI.SHA256 = %q, want the new binary's %q", state.CLI.SHA256, wantSHA)
+	}
+	if state.PartialInstall {
+		t.Error("install.json: partial_install true after a successful update")
+	}
+
+	// Skills were re-copied (step 2 belongs to an upgrade: skills ship with
+	// the binary and must stay consistent with it).
+	if len(res.InstallResult.SkillsInstalled) == 0 {
+		t.Error("update installed no skills; skills must stay consistent with the new binary")
+	}
+
+	// MCP registration was refreshed (step 3).
+	cfg, err := os.ReadFile(env.claudeJSON)
+	if err != nil {
+		t.Fatalf("read .claude.json: %v", err)
+	}
+	if !strings.Contains(string(cfg), "grafel") {
+		t.Errorf("update left no grafel MCP entry in %s: %s", env.claudeJSON, cfg)
+	}
+}
+
+// TestRunUpdate_PreservesPriorInstallState pins the install.json decision: an
+// upgrade MERGES into the recorded state rather than replacing it with a fresh
+// NewState(ModeCopy). Concretely, the gitignore record written by the earlier
+// deliberate `grafel install` must survive an update — `grafel doctor`
+// iterates state.Gitignore.Repos, so blanking it silently drops that check.
+func TestRunUpdate_PreservesPriorInstallState(t *testing.T) {
+	env := newTestEnv(t)
+
+	// A deliberate install, run inside the repo: this one legitimately writes
+	// the .gitignore and records it.
+	if _, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	}); err != nil {
+		t.Fatalf("RunCopy (initial install): %v", err)
+	}
+	before := readState(t, env.statePath)
+	if before == nil || len(before.Gitignore.Repos) == 0 {
+		t.Fatalf("fixture: install did not record a gitignore repo: %+v", before)
+	}
+
+	// Now upgrade while STANDING IN A DIFFERENT REPO — the realistic case, and
+	// the one that catches both failure modes at once: the record must neither
+	// be blanked (no merge) nor rewritten to name this bystander (step 5 still
+	// running).
+	bystander := newGitRepoFixture(t, "bystander")
+	standInsideRepo(t, bystander)
+	if _, err := install.RunUpdate(install.UpdateOptions{
+		BinPath:           env.fakeBin,
+		StatePath:         env.statePath,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		SkipDaemonRestart: true,
+		Tag:               "v0.0.1-mergestate",
+		DownloadBinary:    newBinaryDownloader("#!/bin/sh\necho newer-grafel"),
+	}); err != nil {
+		t.Fatalf("RunUpdate: %v", err)
+	}
+
+	after := readState(t, env.statePath)
+	if after == nil {
+		t.Fatal("install.json missing after update")
+	}
+	if len(after.Gitignore.Repos) != len(before.Gitignore.Repos) ||
+		(len(after.Gitignore.Repos) > 0 && after.Gitignore.Repos[0] != before.Gitignore.Repos[0]) {
+		t.Errorf("#6162: update replaced install.json instead of merging into it;\n"+
+			" gitignore repos before = %v\n after = %v",
+			before.Gitignore.Repos, after.Gitignore.Repos)
+	}
+	// And the bystander must appear nowhere in the record, nor on disk.
+	for _, r := range after.Gitignore.Repos {
+		if strings.Contains(r, "bystander") {
+			t.Errorf("#6162: update recorded the repo it was standing in (%s) as a "+
+				"gitignore target", r)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(bystander, ".gitignore")); err == nil {
+		t.Errorf("#6162: update created a .gitignore in the bystander repo %s", bystander)
+	}
+}
+
+// TestRunCopy_StillDoesRepoIntegration guards the fix from over-reaching.
+// `grafel install` is cwd-aware BY DESIGN — the user ran it here, on purpose —
+// so it must keep writing .gitignore and installing the four hooks.
+func TestRunCopy_StillDoesRepoIntegration(t *testing.T) {
+	env := newTestEnv(t)
+
+	res, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentInstall,
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	})
+	if err != nil {
+		t.Fatalf("RunCopy: %v", err)
+	}
+
+	// DetectGitRepo returns git's own resolved root, so compare through
+	// EvalSymlinks (/var → /private/var on macOS).
+	wantRepo, err := filepath.EvalSymlinks(env.gitRepo)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+	gotRepo, err := filepath.EvalSymlinks(res.GitignoreRepo)
+	if err != nil {
+		t.Fatalf("install recorded no usable GitignoreRepo (%q): %v", res.GitignoreRepo, err)
+	}
+	if gotRepo != wantRepo {
+		t.Errorf("install GitignoreRepo = %q, want %q", gotRepo, wantRepo)
+	}
+	data, err := os.ReadFile(filepath.Join(env.gitRepo, ".gitignore"))
+	if err != nil {
+		t.Fatalf("install did not write .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), "/.grafel/") {
+		t.Errorf("install .gitignore lacks /.grafel/: %q", data)
+	}
+	for _, name := range grafelHookNames {
+		if !hookPresent(t, env.gitRepo, name) {
+			t.Errorf("install did not write the %s hook", name)
+		}
+	}
+}
+
+// TestRunCopy_RejectsUnsetIntent pins the zero-value decision (#6162 review).
+//
+// Intent has no default. The two candidate defaults are not symmetric: an
+// omission that means "install" silently appends to a stranger's tracked
+// .gitignore and writes four hooks `git status` does not show — nothing fails,
+// and the user finds out in a diff or never. Rather than pick the less-bad
+// silent failure, RunCopy refuses to guess, so every caller has to state
+// whether it may modify the user's repository.
+func TestRunCopy_RejectsUnsetIntent(t *testing.T) {
+	env := newTestEnv(t)
+	standInsideRepo(t, env.gitRepo)
+
+	_, err := install.RunCopy(install.CopyOptions{
+		// Intent deliberately unset.
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	})
+	if err == nil {
+		t.Fatal("#6162: RunCopy accepted an unset Intent; a caller that has not " +
+			"declared whether it may modify the user's repo must not be guessed for")
+	}
+	if !strings.Contains(err.Error(), "Intent") {
+		t.Errorf("error should name the missing field, got: %v", err)
+	}
+
+	// A rejected transaction must not have run any step.
+	if _, err := os.Stat(filepath.Join(env.gitRepo, ".gitignore")); err == nil {
+		t.Error("#6162: rejected RunCopy still wrote .gitignore")
+	}
+	for _, name := range grafelHookNames {
+		if hookPresent(t, env.gitRepo, name) {
+			t.Errorf("#6162: rejected RunCopy still wrote the %s hook", name)
+		}
+	}
+}
+
+// TestRunCopy_RejectsWorkingDirUnderUpgrade pins the hard-fail (#6162 review
+// F2). Accepting-and-ignoring a WorkingDir under IntentUpgrade would read as a
+// second layer of defence and is not one — an empty WorkingDir still resolves
+// to the process cwd inside both DetectGitRepo and InstallGitHooks. Failing
+// loudly is what keeps the next reader from believing in a defence that does
+// not exist.
+func TestRunCopy_RejectsWorkingDirUnderUpgrade(t *testing.T) {
+	env := newTestEnv(t)
+
+	_, err := install.RunCopy(install.CopyOptions{
+		Intent:            install.IntentUpgrade,
+		BinPath:           env.fakeBin,
+		SkillsSourceDir:   env.skillsSourceDir,
+		ClaudeConfigDirs:  []string{env.claudeJSON},
+		StatePath:         env.statePath,
+		WorkingDir:        env.gitRepo,
+		SkipDaemonRestart: true,
+	})
+	if err == nil {
+		t.Fatal("#6162: RunCopy accepted a WorkingDir under IntentUpgrade; " +
+			"an upgrade has no repository in scope")
+	}
+	if !strings.Contains(err.Error(), "WorkingDir") {
+		t.Errorf("error should name the offending field, got: %v", err)
+	}
+}


### PR DESCRIPTION
`grafel update` ran the full seven-step install transaction. Two of those steps are repo-scoped: step 5 appends `/.grafel/` to `.gitignore`, and step 7 writes four git hooks. Neither was gated on whether a repository was in scope at all, and `WorkingDir` defaulted to `os.Getwd()` — so updating the binary from inside any git checkout modified that checkout.

The `.gitignore` half is visible in `git status`. The hooks half is not: `git status` never shows `.git/hooks`, so `grafel update` silently installed four hooks into repositories that had never heard of grafel.

## The fix

An explicit `CopyIntent` on `CopyOptions` — `IntentInstall` or `IntentUpgrade` — gating steps 5 and 7. `grafel install` is the one entrypoint that may touch the repo it runs in, because running it there is the user asking for exactly that. `grafel update` passes `IntentUpgrade` and gets neither step.

`newTransactionState()` now merges the prior state rather than blanking it with `NewState(ModeCopy)`, since an upgrade must not discard what the install recorded.

## `Intent` is required, with no default

The two candidate defaults are not symmetric, and that asymmetry decided it:

- **Default to install** — a caller who forgets appends to a stranger's tracked `.gitignore` and writes four hooks `git status` does not show. Nothing fails. The user finds it in a diff, or never.
- **Default to upgrade** — a caller who forgets merely produces no `/.grafel/` line. Loud, immediate, and already covered by `TestRunCopy_StillDoesRepoIntegration`.

Rather than pick the less-bad silent failure, `applyDefaults` rejects an unset `Intent` outright. Both production call sites state their intent at the construction site. The forced assignment inside `runInstallCopy` was *removed* for the same reason: a helper that sets `Intent` on its caller's behalf launders any future caller that never considered whether it may modify a user's repository.

## A claim in the first round was false, and is corrected here

The original commit said `WorkingDir` not being forwarded was a second, independent layer of protection. It is not, and review proved it at runtime:

- `DetectGitRepo("")` shells out to `git -C "" rev-parse --show-toplevel`. **An empty `-C` is a no-op**, so it resolves to the process cwd.
- `InstallGitHooks` falls back to `os.Getwd()` on an empty `RepoPath` (`hooks_install.go:132-138`).

With the step-5 gate removed and `WorkingDir` still un-forwarded, the original bug reproduced exactly — it reported the reviewer's own worktree. Not forwarding `WorkingDir` changes *which* repo is hit from "the one you named" to "the one you're standing in," which is the same repo the issue is about.

**The gates on steps 5 and 7 are the entire defence.** So the claim was not merely deleted — it was made true: `IntentUpgrade` with a non-empty `WorkingDir` is now a hard error, on the grounds that an upgrade has no repository in scope and a caller passing one has misunderstood. A claimed-but-absent defence is worse than none, because it stops the next person looking.

## The tests had to change shape, and the first version was vacuous

The original tests set `UpdateOptions.WorkingDir` and asserted the named repo was untouched. The change had just made that field unused — production reads the process cwd — so the assertion held no matter what the code did. That is why the step-7 mutant survived: deleting `&& opts.Intent.repoScoped()` at `copy.go:893` left the **entire suite** passing.

Tests now `t.Chdir` into the fixture, so the fixture is the process cwd — the only channel the defect travels down.

There is a second vacuity trap, and it is guarded rather than merely avoided: **in a git worktree `.git` is a ~72-byte file, not a directory**, so `InstallGitHooks` fails its `stat .git/hooks` regardless of any gate and every hook assertion passes for the wrong reason. `standInsideRepo` fails the test outright if the fixture has a file `.git` or no `.git/hooks`, so a fixture that cannot express the bug is impossible rather than unlikely.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./internal/install/... ./internal/cli/...` 0, `go test -count=1 ./internal/install/... ./internal/cli/...` **exit 0, 12 packages**.

The step-7 mutant was re-run independently after the fix: deleting the gate now fails `TestRunUpdate_InstallsNoGitHooksInUnregisteredRepo`, naming all four hooks. `copy.go` was restored from a byte-level backup and confirmed identical, then re-run green.

Blast radius of making `Intent` required was checked exhaustively: two `CopyOptions` literals exist in production (`update.go:265`, `cli/install.go:204`), both set it; `runInstallCopy` has one caller; no `var opts CopyOptions` construction path exists.

## Known limits

Neither the `.gitignore` nor the hooks assertion exercises a real `grafel update` against a real GitHub release — the binary download is stubbed. What is covered is the step gating and the resulting filesystem state, which is where the defect lived.

The `newTransactionState` merge relabels an older state file's `SchemaVersion` as current. That is honest only while `State` evolves additively; the assumption is recorded inline at `copy.go:937` and must become a real migration the first time a field changes shape.

Closes #6162
