### PR TITLE
fix(#6209): a file whose extraction failed was stamped as indexed and never retried

### DIFF
--- a/cmd/grafel/daemon.go
+++ b/cmd/grafel/daemon.go
@@ -2140,6 +2140,17 @@ func daemonRebuildFuncCore(
 			// persistManifest below is unconditional on incrementalStateDir == "",
 			// not narrowed to !args.Wipe.
 			//
+			// RETRY BUDGETS GO WITH IT (#6209). The manifest a wiped rebuild
+			// writes is fresh, so every per-file consecutive-extraction-failure
+			// count starts again at whatever THIS run produced. That is the same
+			// answer as above for the same reason: the count is state describing
+			// previous passes, --wipe exists to discard exactly that, and the run
+			// doing the discarding has just re-extracted every file itself, so
+			// its own result is better evidence than the history it replaces. The
+			// cost of being wrong is bounded — a file that still fails
+			// deterministically spends its budget again over the next few passes
+			// and goes quiet — and --wipe is user-initiated, never a daemon tick.
+			//
 			// ORDERING (verified, not assumed): commitManifest (index.go) is called
 			// ONLY from the success branch of writeGraphGen inside Index /
 			// runIndexInternal — i.e. after wipe already ran (wipe is the very

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -316,6 +316,29 @@ type Indexer struct {
 	walkStampMu sync.Mutex
 	walkStamps  map[string]idiff.FileEntry
 
+	// failedExtractions names the walked files whose Pass-1 extraction returned
+	// an error this run (#6209). i.stats.failed counts them; only a NAME can be
+	// acted on, because the manifest entry that has to be qualified is per-file.
+	//
+	// Written by the extraction workers, read once in commitManifest, which
+	// hands it to diff.ApplyStampsAndFailures so those files' stamps carry a
+	// consecutive-failure count instead of passing for successfully indexed.
+	//
+	// TWO FAILURE CLASSES ARE DELIBERATELY NOT IN HERE.
+	//
+	// A file that could not be READ is never stamped in the first place (see the
+	// osReadFile branch in classifyAndReadWithProgress), so it already
+	// re-presents as new on every pass — over-reporting, never staleness — and
+	// marking it would be no improvement. It also could not be bounded: with no
+	// bytes there is no stamp to hang a count on.
+	//
+	// The GRAFEL_SUBPROC_EXTRACT path reports only extract.Result.Failed, a
+	// COUNT — the children never send the paths back. Naming them needs an IPC
+	// field, exactly as the hash-return note on stampUnreadFiles says, and that
+	// path is off by default.
+	failedMu          sync.Mutex
+	failedExtractions map[string]bool
+
 	// incrementalCarryForwardEntities holds the previous-graph entities sourced
 	// from UNCHANGED files during an incremental reindex. buildDocument seeds the
 	// resolver index with their (name, kind) → stable-ID identity so that
@@ -1101,6 +1124,26 @@ func (i *Indexer) stampUnreadFiles(absRepo string, rels []string) {
 	wg.Wait()
 }
 
+// recordFailedExtraction names one file whose Pass-1 extraction failed. Safe to
+// call from the extraction workers. See failedExtractions for what is and is
+// not routed here.
+func (i *Indexer) recordFailedExtraction(rel string) {
+	i.failedMu.Lock()
+	if i.failedExtractions == nil {
+		i.failedExtractions = make(map[string]bool)
+	}
+	i.failedExtractions[rel] = true
+	i.failedMu.Unlock()
+}
+
+// extractPass1 is the Pass-1 extraction entry point, indirected through a
+// package var for the same reason writeGraphGen and osReadFile are: the
+// failure it can return is the thing under test, and there is no fixture source
+// file that makes extractors.Extract fail on demand and keeps failing
+// deterministically pass after pass. Production always holds
+// extractors.Extract; only #6209's bounded-retry test replaces it.
+var extractPass1 = extractors.Extract
+
 // commitManifest persists the file-hash manifest describing THIS run: every
 // walked file, stamped with the hash the WALK computed, with entries for
 // anything no longer in the walk pruned. Best-effort — a write failure is
@@ -1154,11 +1197,20 @@ func (i *Indexer) stampUnreadFiles(absRepo string, rels []string) {
 // somewhere else, so a manifest can never describe a graph in another
 // directory. See WithManifestPersist for the ref-divergence that motivates it.
 //
-// KNOWN, PRE-EXISTING (#6207 review, to be filed): walkedFiles is the raw walk,
-// so a file whose EXTRACTION failed is still stamped as indexed and will not be
-// re-extracted until its bytes change. The consequence is a missing entity set,
-// not a stuck loop. This was already true on the WithIncremental path; #6207
-// makes it reachable from the fallback too.
+// FAILED EXTRACTIONS ARE STAMPED BUT NOT SILENT (#6209, was the KNOWN issue
+// noted here by the #6207 review). walkedFiles is the raw WALK, so a file whose
+// extraction failed is in it just like one that succeeded, and it is stamped at
+// the bytes the walk read. On its own that stamp is a lie the next pass cannot
+// see through: the hash matches, the file is classified unchanged, and its
+// entities are missing from the graph forever with no signal — strictly worse
+// than a file that was never stamped, which re-presents every pass and heals.
+//
+// The stamp still happens, because dropping it is what turns a
+// deterministically unparseable file into a re-parse on every pass for the life
+// of the repo. Instead the entry carries a consecutive-failure count and the
+// file is forced back into the changed set for the next diff.MaxExtractRetries
+// passes. Transient failures heal; deterministic ones cost a bounded number of
+// retries and then go quiet until their bytes change.
 func (i *Indexer) commitManifest(absRepo, graphDir string) {
 	if !i.persistManifest {
 		return
@@ -1180,7 +1232,20 @@ func (i *Indexer) commitManifest(absRepo, graphDir string) {
 		// ApplyStamps overlays rather than replaces.
 		m = idiff.LoadManifest(dest)
 	}
-	idiff.ApplyStamps(i.walkStamps, i.walkedFiles, m)
+	i.failedMu.Lock()
+	failed := i.failedExtractions
+	i.failedMu.Unlock()
+	exhausted := idiff.ApplyStampsAndFailures(i.walkStamps, i.walkedFiles, failed, m)
+	// The one moment worth a line: this file has now failed on every attempt it
+	// is going to get, so its entities are missing from the graph and will stay
+	// missing until someone edits it. Silence here is what #6209 was about —
+	// the count in the manifest is durable but nothing reads it, so without this
+	// the file goes dark with no signal at the exact instant it goes dark.
+	for _, rel := range exhausted {
+		fmt.Fprintf(os.Stderr, "grafel: %s failed extraction %d time(s); no longer retrying — its "+
+			"entities are absent from the graph until the file changes (#6209)\n",
+			rel, idiff.MaxExtractRetries+1)
+	}
 	if err := idiff.SaveManifest(dest, absRepo, m); err != nil {
 		fmt.Fprintf(os.Stderr, "grafel: save incremental manifest: %v (non-fatal)\n", err)
 	}
@@ -3774,7 +3839,7 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 					continue
 				}
 
-				ents, extractErr := extractors.Extract(ctx, file)
+				ents, extractErr := extractPass1(ctx, file)
 
 				// #5989 — dispatch the custom/framework extractors registered
 				// under internal/custom/** (Django/DRF/Celery/Flask/FastAPI/
@@ -3898,6 +3963,13 @@ func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo strin
 						i.stats.skipped++
 					} else {
 						i.stats.failed++
+						// #6209 — the bytes were read and stamped, but nothing
+						// came out of them. Name the file so commitManifest can
+						// qualify its stamp instead of recording it as indexed.
+						// Kept OUT of the ErrNoExtractorForLanguage branch on
+						// purpose: an unsupported language is a permanent,
+						// correct classification, not a failure to retry.
+						i.recordFailedExtraction(t.relPath)
 					}
 				} else {
 					i.stats.extracted++

--- a/cmd/grafel/manifest_failed_extract_6209_test.go
+++ b/cmd/grafel/manifest_failed_extract_6209_test.go
@@ -1,0 +1,256 @@
+package main
+
+// #6209 — a file whose EXTRACTION failed must not be recorded in the manifest
+// as though it had been indexed.
+//
+// commitManifest stamps every file in the raw walk. A file that was read
+// successfully is stamped at the bytes the walk read (#6212) — including when
+// the extractor that ran on those bytes returned an error and contributed
+// nothing to the graph. The next incremental pass hashes the file, matches the
+// stamp, classifies it UNCHANGED, and never extracts it again. The graph is
+// permanently short that file's entities and nothing anywhere says so; only a
+// content edit ever re-presents it.
+//
+// A file that is never stamped at all behaves the opposite way — it reads as
+// new on every pass and eventually succeeds — which is why the stamp, not the
+// failure, is the defect.
+//
+// THE TRADE-OFF THIS TEST PINS. Simply excluding failed files from the stamp
+// heals the transient case and converts the deterministic case into a permanent
+// tax: a genuinely unparseable file would be re-read and re-parsed on every pass
+// forever. So the manifest carries a per-file consecutive-failure counter and
+// the retry is BOUNDED (diff.MaxExtractRetries). Both halves are asserted here:
+// the file must come back, and it must eventually stop coming back.
+//
+// Assertions are on extraction counts per pass and on manifest contents. Never
+// on timing.
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// failedExtractHarness drives repeated Index(..., WithIncremental(stateDir))
+// passes over one committed git fixture with a single file whose extraction
+// always fails, and reports how many times each file was handed to Pass 1 on
+// each pass.
+type failedExtractHarness struct {
+	repo     string
+	stateDir string
+	victim   string
+	// unsupported, when set, is a file whose extractor reports
+	// ErrNoExtractorForLanguage. That is a permanent, CORRECT classification —
+	// the repo contains a language grafel does not model — not a failure to
+	// retry, and the indexer counts it as skipped rather than failed. Set
+	// before the first pass; read by the seam thereafter.
+	unsupported string
+
+	mu       sync.Mutex
+	attempts map[string]int
+	// lastLogs is the stderr of the most recent pass. The budget-exhaustion
+	// warning is the only thing that announces a file has gone permanently
+	// dark, so it is an assertable output, not decoration.
+	lastLogs string
+}
+
+func newFailedExtractHarness(t *testing.T, name, victim string) *failedExtractHarness {
+	t.Helper()
+	h := &failedExtractHarness{
+		repo:     fallbackManifestRepo(t, name, "main"),
+		victim:   victim,
+		attempts: map[string]int{},
+	}
+	h.stateDir = filepath.Join(t.TempDir(), "state")
+	if err := os.MkdirAll(h.stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GRAFEL_DAEMON_ROOT", h.stateDir)
+
+	prev := extractPass1
+	extractPass1 = func(ctx context.Context, f extractors.FileInput) ([]types.EntityRecord, error) {
+		rel := filepath.ToSlash(f.Path)
+		h.mu.Lock()
+		h.attempts[rel]++
+		h.mu.Unlock()
+		if rel == h.victim {
+			// Deterministic: the same file fails identically on every pass,
+			// which is precisely the case an unbounded retry would tax forever.
+			return nil, fmt.Errorf("synthetic deterministic extraction failure (#6209)")
+		}
+		if h.unsupported != "" && rel == h.unsupported {
+			return nil, extractors.ErrNoExtractorForLanguage
+		}
+		return prev(ctx, f)
+	}
+	t.Cleanup(func() { extractPass1 = prev })
+	return h
+}
+
+// pass runs one index and returns the per-file Pass-1 extraction counts for
+// THAT pass alone.
+func (h *failedExtractHarness) pass(t *testing.T) map[string]int {
+	t.Helper()
+	h.mu.Lock()
+	before := map[string]int{}
+	for k, v := range h.attempts {
+		before[k] = v
+	}
+	h.mu.Unlock()
+
+	var idxErr error
+	logs := captureStderr(t, func() {
+		idxErr = Index(h.repo, filepath.Join(h.stateDir, "graph.fb"), "test-repo",
+			[]string{"graph-algo"}, false, false, WithIncremental(h.stateDir))
+	})
+	if idxErr != nil {
+		t.Fatalf("Index: %v\n%s", idxErr, logs)
+	}
+	h.lastLogs = logs
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	delta := map[string]int{}
+	for k, v := range h.attempts {
+		if d := v - before[k]; d > 0 {
+			delta[k] = d
+		}
+	}
+	return delta
+}
+
+func (h *failedExtractHarness) manifest() *diff.Manifest {
+	return diff.LoadManifest(h.stateDir)
+}
+
+// TestIncremental_FailedExtractionIsRetried is the defect.
+//
+// Pass 1 indexes everything and the victim's extractor fails. Pass 2 must hand
+// that file to the extractor again: the graph does not contain its entities, so
+// the manifest may not claim it is indexed.
+func TestIncremental_FailedExtractionIsRetried(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs real index passes; skipped under -short")
+	}
+	const victim = "svc/thing.go"
+	const unsupported = "svc/gadget.go"
+	h := newFailedExtractHarness(t, "failstamp-retry", victim)
+	h.unsupported = unsupported
+
+	pass1 := h.pass(t)
+	if got := pass1[victim]; got != 1 {
+		t.Fatalf("fixture is inert: pass 1 handed %s to the extractor %d time(s), want exactly 1", victim, got)
+	}
+	if got := pass1[unsupported]; got != 1 {
+		t.Fatalf("fixture is inert: pass 1 handed %s to the extractor %d time(s), want exactly 1 — "+
+			"the ErrNoExtractorForLanguage case is not being exercised at all", unsupported, got)
+	}
+
+	m := h.manifest()
+	if _, ok := m.Files[victim]; !ok {
+		t.Fatalf("fixture is inert: %s has no manifest entry at all after pass 1, so there is "+
+			"nothing for pass 2 to hash-match away", victim)
+	}
+	if got := m.Files[victim].Failures; got != 1 {
+		t.Fatalf("manifest records %d consecutive extraction failure(s) for %s after pass 1, want 1 — "+
+			"the entry is indistinguishable from a successfully indexed file, which is exactly the "+
+			"silent gap #6209 is about", got, victim)
+	}
+	for _, rel := range fallbackFixtureFiles {
+		if rel == victim {
+			continue
+		}
+		if got := m.Files[rel].Failures; got != 0 {
+			if rel == unsupported {
+				t.Fatalf("manifest records %d failure(s) for %s, whose extractor reported "+
+					"ErrNoExtractorForLanguage. That is a permanent and CORRECT answer — the language "+
+					"is not modelled — so retrying it buys nothing and costs a re-read plus a re-parse "+
+					"on every unsupported file in the repo, %d times each (#6209)",
+					got, rel, diff.MaxExtractRetries)
+			}
+			t.Fatalf("manifest records %d failure(s) for %s, which extracted cleanly — the failure "+
+				"mark must name the file that failed, not the walk (#6209)", got, rel)
+		}
+	}
+
+	pass2 := h.pass(t)
+	if pass2[victim] != 1 {
+		t.Fatalf("pass 2 handed %s to the extractor %d time(s), want 1. The file's extraction FAILED "+
+			"on pass 1, so its entities are missing from the graph; stamping it as indexed anyway "+
+			"means it is hash-matched away on every future pass and never retried until its bytes "+
+			"change (#6209).\nfull pass-2 extraction set: %v", victim, pass2[victim], pass2)
+	}
+	for rel, n := range pass2 {
+		if rel != victim {
+			t.Fatalf("pass 2 also re-extracted %s (%d time(s)); only the failed file should have "+
+				"re-presented, otherwise the retry is just a full reindex wearing a hat: %v", rel, n, pass2)
+		}
+	}
+}
+
+// TestIncremental_FailedExtractionRetryIsBounded is the other half.
+//
+// The naive fix — leave a failed file unstamped so it re-presents — passes the
+// test above and fails this one: a deterministically unparseable file would be
+// re-read and re-parsed on every pass for the life of the repo. The retry
+// budget is what makes "never silently skipped" affordable.
+func TestIncremental_FailedExtractionRetryIsBounded(t *testing.T) {
+	if testing.Short() {
+		t.Skip("runs real index passes; skipped under -short")
+	}
+	if diff.MaxExtractRetries != 2 {
+		t.Fatalf("this test enumerates passes by hand for MaxExtractRetries == 2, got %d",
+			diff.MaxExtractRetries)
+	}
+	const victim = "svc/thing.go"
+	h := newFailedExtractHarness(t, "failstamp-bounded", victim)
+
+	// Pass 1 is the initial attempt; passes 2 and 3 are the two retries.
+	for n := 1; n <= 1+diff.MaxExtractRetries; n++ {
+		if got := h.pass(t)[victim]; got != 1 {
+			t.Fatalf("pass %d handed %s to the extractor %d time(s), want 1", n, victim, got)
+		}
+		if got := h.manifest().Files[victim].Failures; got != n {
+			t.Fatalf("after pass %d the manifest records %d consecutive failure(s) for %s, want %d — "+
+				"without a durable count the retry cannot be bounded (#6209)", n, got, victim, n)
+		}
+		// The warning belongs to the pass that spends the LAST attempt, and to
+		// no other. Earlier is a false alarm about a file still being retried.
+		warned := strings.Contains(h.lastLogs, "no longer retrying")
+		if want := n == 1+diff.MaxExtractRetries; warned != want {
+			t.Fatalf("pass %d logged the give-up warning = %v, want %v. The manifest count is durable "+
+				"but nothing outside the diff package reads it, so this line is the ONLY signal that "+
+				"%s just went permanently dark (#6209).\nlogs:\n%s", n, warned, want, victim, h.lastLogs)
+		}
+		if warned && !strings.Contains(h.lastLogs, victim) {
+			t.Fatalf("the give-up warning does not name the file it is about:\n%s", h.lastLogs)
+		}
+	}
+
+	// The budget is spent. The file stays stamped and stays quiet until its
+	// bytes change.
+	pass4 := h.pass(t)
+	if n := pass4[victim]; n != 0 {
+		t.Fatalf("pass %d re-extracted %s again (%d time(s)) after %d consecutive deterministic "+
+			"failures. An unbounded retry converts a silent gap into a permanent per-pass parse "+
+			"tax on every genuinely unparseable file in the repo (#6209).",
+			2+diff.MaxExtractRetries, victim, n, 1+diff.MaxExtractRetries)
+	}
+	if len(pass4) != 0 {
+		t.Fatalf("pass %d extracted %v; a pass with no content change must extract nothing",
+			2+diff.MaxExtractRetries, pass4)
+	}
+	if got := h.manifest().Files[victim].Failures; got != 1+diff.MaxExtractRetries {
+		t.Fatalf("the failure count for %s moved to %d on a pass that never re-extracted it, want it "+
+			"pinned at %d — the count records consecutive ATTEMPTS, and a pass that skipped the file "+
+			"has not made one (#6209)", victim, got, 1+diff.MaxExtractRetries)
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -586,6 +586,20 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 
 	// --- Step 3: AST-hash gate ---
 	// Skip files where the content hash matches the last stamp (whitespace edits).
+	//
+	// #6209 — diff.RetryDue IS PART OF THIS GATE, not an optimisation on top of
+	// it. This comparison is the SAME hex SHA-256 over the SAME raw bytes that
+	// diff.isChanged already made (FileStamp.ContentHash and FileEntry.SHA256
+	// are the same value), so it is a second, independent chance to drop a file
+	// the change-detector let through. A file whose EXTRACTION failed has
+	// unchanged bytes by construction — the failure does not edit it — so
+	// without this clause the retry-due union in diff.FilterWithGit puts the
+	// file into changedFiles and this gate immediately takes it back out,
+	// reallyChanged empties, the pass returns Done=true without writing a
+	// manifest, and the scheduler does not fall back. The failure count is then
+	// pinned at its current value for the life of the file: the budget never
+	// spends, the file is never retried, and #6209 is unfixed on the one path
+	// the daemon actually runs.
 	var reallyChanged []string
 	for _, rel := range changedFiles {
 		abs := filepath.Join(absRepo, filepath.FromSlash(rel))
@@ -595,7 +609,7 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 			continue
 		}
 		prev, ok := manifest.Files[rel]
-		if !ok || prev.SHA256 != stamp.ContentHash {
+		if !ok || prev.SHA256 != stamp.ContentHash || diff.RetryDue(prev) {
 			reallyChanged = append(reallyChanged, rel)
 		}
 		// else: hash unchanged (whitespace-only) — skip silently
@@ -1366,7 +1380,20 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// Also O(delta) instead of O(repo): the files this pass did not re-extract
 	// keep the stamps they already had, which is exactly what established them
 	// as unchanged in the first place (#6201, #6206).
-	diff.ApplyStamps(walkStamps, allFiles, manifest)
+	// The failed-extraction set is EXPLICITLY EMPTY here, and that is a property
+	// of this function, not an omission (#6209). The extraction loop above does
+	// not tolerate an extractor error at all: it returns fallback() the moment
+	// one occurs (see "#6151 — NOT non-fatal"), because Step 5 has already
+	// evicted that file's entities and persisting the graph would drop them.
+	// Reaching Step 9 therefore means every file in reallyChanged extracted
+	// cleanly, and the full reindex the fallback triggers is what records the
+	// failure — on the cmd/grafel path, which does mark it.
+	//
+	// Routed through ApplyStampsAndFailures rather than ApplyStamps anyway, so
+	// that if this path ever learns to tolerate a partial failure, the call site
+	// is already the one that records it instead of silently stamping it as
+	// indexed. A nil set makes this identical to ApplyStamps.
+	_ = diff.ApplyStampsAndFailures(walkStamps, allFiles, nil, manifest)
 	if saveErr := diff.SaveManifest(stateDir, absRepo, manifest); saveErr != nil {
 		logger.Printf("incremental: save manifest: %v (non-fatal)", saveErr)
 	}

--- a/internal/extractors/incremental_failed_extract_6209_test.go
+++ b/internal/extractors/incremental_failed_extract_6209_test.go
@@ -1,0 +1,201 @@
+package extractors_test
+
+// #6209 on the path the daemon actually takes.
+//
+// TryIncremental is Path A — the scheduler's per-tick incremental pass
+// (cmd/grafel/daemon.go). The retry for a file whose extraction failed has to
+// survive TWO independent gates here, and the first fix only cleared one:
+//
+//	1. diff.FilterWithGit (incremental.go, Step 2) — cleared by the retry-due
+//	   union, otherwise git's "nothing changed" verdict ends it.
+//	2. The Step-3 AST-hash gate — prev.SHA256 != stamp.ContentHash, over the
+//	   SAME hex SHA-256 of the SAME raw bytes. A file whose extraction failed
+//	   has unchanged bytes BY CONSTRUCTION, so this gate drops it straight back
+//	   out, reallyChanged empties, and the pass returns Done=true without
+//	   writing a manifest. The failure count is then pinned forever: the budget
+//	   never spends, the file is never retried, and the scheduler does not fall
+//	   back to a full index because Done was true.
+//
+// The cmd/grafel tests for #6209 drive Index(..., WithIncremental) — Path B, the
+// CLI. Neither of them touches this function, which is how gate 2 survived them.
+//
+// Assertions are on TryIncremental's own Result, on manifest contents and on the
+// logger's decision lines. Never on timing.
+
+import (
+	"context"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// markFailed sets rel's consecutive-failure count in the seeded manifest and
+// saves it, WITHOUT touching the working tree. That combination is the whole
+// point: the bytes are identical to what the manifest already records, so every
+// hash-based gate in the pipeline must say "unchanged", and only the failure
+// count can put the file back into the changed set.
+func markFailed(t *testing.T, repo, stateDir, rel string, n int) {
+	t.Helper()
+	m := diff.LoadManifest(stateDir)
+	e, ok := m.Files[rel]
+	if !ok {
+		t.Fatalf("fixture is inert: %s has no manifest entry to mark", rel)
+	}
+	e.Failures = n
+	m.Files[rel] = e
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// runPathA drives one real TryIncremental pass and returns its result plus the
+// logger output, which is where the pass records WHICH branch it took.
+func runPathA(t *testing.T, repo, stateDir string) (extractors.Result, string) {
+	t.Helper()
+	var logs strings.Builder
+	logger := log.New(&logs, "", 0)
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, logger, nil)
+	return res, logs.String()
+}
+
+// TestIncremental_PathA_RetriesFailedExtractionDespiteUnchangedHash is the
+// defect, on the daemon's primary path.
+//
+// Nothing in the working tree changes. The only thing that says this file needs
+// work is the failure count the previous pass recorded, and every byte-level
+// gate between here and the extractor will disagree with it.
+func TestIncremental_PathA_RetriesFailedExtractionDespiteUnchangedHash(t *testing.T) {
+	repo, stateDir, _ := incrementalStampFixture(t, 3)
+	const victim = "victim.go"
+	markFailed(t, repo, stateDir, victim, 1)
+
+	res, logs := runPathA(t, repo, stateDir)
+
+	if strings.Contains(logs, "had unchanged AST hash") {
+		t.Fatalf("the Step-3 AST-hash gate dropped the retry. A failed extraction does not edit the "+
+			"file, so its content hash MATCHES the stamp by construction — the gate can only ever "+
+			"say \"unchanged\" and the file is never retried on the daemon's path (#6209).\nlogs:\n%s",
+			logs)
+	}
+	if !res.Done {
+		t.Fatalf("the pass fell back (%q) instead of re-extracting the retry-due file; the fixture's "+
+			"file extracts fine, so a retry should simply succeed\nlogs:\n%s", res.FallbackReason, logs)
+	}
+	if res.ChangedFiles != 1 {
+		t.Fatalf("the pass re-extracted %d file(s), want exactly 1 (%s). 0 means the retry never "+
+			"reached the extractor and the failure count is pinned forever; more than 1 means the "+
+			"retry widened into something close to a full reindex.\nlogs:\n%s",
+			res.ChangedFiles, victim, logs)
+	}
+
+	// The retry SUCCEEDED, so the count must be gone — that is the budget being
+	// spent productively rather than pinned.
+	if got := diff.LoadManifest(stateDir).Files[victim].Failures; got != 0 {
+		t.Fatalf("%s still carries %d failure(s) after a successful re-extraction on Path A, want 0. "+
+			"A count that never clears is a count that never bounds anything (#6209)", victim, got)
+	}
+}
+
+// TestIncremental_PathA_ExhaustedBudgetIsNotRetried is the other half of the
+// bound, on this path: once the count is spent the file must stop forcing work,
+// exactly as on Path B.
+//
+// It doubles as the reachability proof for the totalChanged == 0 branch — see
+// TestIncremental_PathA_ZeroChangeBranchStaysReachable, which asserts the branch
+// by its log line rather than by its effect.
+func TestIncremental_PathA_ExhaustedBudgetIsNotRetried(t *testing.T) {
+	repo, stateDir, _ := incrementalStampFixture(t, 3)
+	const victim = "victim.go"
+	markFailed(t, repo, stateDir, victim, 1+diff.MaxExtractRetries)
+
+	res, logs := runPathA(t, repo, stateDir)
+
+	if !res.Done {
+		t.Fatalf("pass fell back (%q) with a spent budget and a clean tree\nlogs:\n%s",
+			res.FallbackReason, logs)
+	}
+	if res.ChangedFiles != 0 {
+		t.Fatalf("the pass re-extracted %d file(s) after %d consecutive deterministic failures, want 0. "+
+			"On the daemon's path an unbounded retry is a per-tick parse tax forever (#6209)\nlogs:\n%s",
+			res.ChangedFiles, 1+diff.MaxExtractRetries, logs)
+	}
+	if got := diff.LoadManifest(stateDir).Files[victim].Failures; got != 1+diff.MaxExtractRetries {
+		t.Fatalf("the failure count for %s moved to %d on a pass that never re-extracted it, want it "+
+			"pinned at %d", victim, got, 1+diff.MaxExtractRetries)
+	}
+}
+
+// TestIncremental_PathA_ZeroChangeBranchStaysReachable guards the collateral
+// damage the retry union could do.
+//
+// The union puts a retry-due file into the changed set, so totalChanged >= 1 and
+// the zero-change branch is skipped. That branch carries two things worth
+// keeping: the #5710 absent-graph guard, and the full-repo UpdateManifest sweep
+// that HEALS entries a #6201 scoped reject left stale. Suppressing it must be
+// BOUNDED — which it is, because a retry either succeeds (count cleared) or
+// fails (count incremented by the fallback full index) and dies at
+// MaxExtractRetries.
+//
+// The branch is asserted by the log line it does NOT emit: reaching the AST-hash
+// gate at all means the changed set was non-empty.
+func TestIncremental_PathA_ZeroChangeBranchStaysReachable(t *testing.T) {
+	repo, stateDir, _ := incrementalStampFixture(t, 3)
+
+	// No failure marks anywhere: the ordinary steady state.
+	res, logs := runPathA(t, repo, stateDir)
+	if !res.Done || res.ChangedFiles != 0 {
+		t.Fatalf("fixture is inert: a clean tree should be a zero-change no-op, got Done=%v changed=%d "+
+			"fallback=%q\nlogs:\n%s", res.Done, res.ChangedFiles, res.FallbackReason, logs)
+	}
+	if strings.Contains(logs, "had unchanged AST hash") {
+		t.Fatalf("a clean tree reached the AST-hash gate, so the changed set was NOT empty and the "+
+			"zero-change branch — with the #5710 absent-graph guard and the healing manifest sweep — "+
+			"was skipped. The retry union must add nothing when nothing has failed.\nlogs:\n%s", logs)
+	}
+
+	// And once a budget is spent, the branch is reachable again even though the
+	// count is still on the entry.
+	markFailed(t, repo, stateDir, "victim.go", 1+diff.MaxExtractRetries)
+	res, logs = runPathA(t, repo, stateDir)
+	if !res.Done || res.ChangedFiles != 0 {
+		t.Fatalf("spent budget did not return to a zero-change no-op: Done=%v changed=%d fallback=%q\nlogs:\n%s",
+			res.Done, res.ChangedFiles, res.FallbackReason, logs)
+	}
+	if strings.Contains(logs, "had unchanged AST hash") {
+		t.Fatalf("a spent budget still forced files into the changed set, so the zero-change branch is "+
+			"permanently unreachable for the life of the entry\nlogs:\n%s", logs)
+	}
+}
+
+// TestIncremental_PathA_RetryDoesNotReportSuccessOverAnAbsentGraph is the #5710
+// protection under the union.
+//
+// The absent-graph guard lives INSIDE the zero-change branch, which a retry-due
+// file skips. That would be a real regression if it were the only thing standing
+// between an absent graph.fb and a Done=true — so pin the other one: Step 4
+// cannot load a graph that is not there and falls back, which is the same
+// outcome the guard produces. Silent success over an empty graph stays
+// impossible.
+func TestIncremental_PathA_RetryDoesNotReportSuccessOverAnAbsentGraph(t *testing.T) {
+	repo, stateDir, _ := incrementalStampFixture(t, 3)
+	markFailed(t, repo, stateDir, "victim.go", 1)
+
+	if err := os.Remove(filepath.Join(stateDir, "graph.fb")); err != nil {
+		t.Fatalf("fixture is inert: no graph.fb to remove: %v", err)
+	}
+
+	res, logs := runPathA(t, repo, stateDir)
+	if res.Done {
+		t.Fatalf("the pass reported SUCCESS over an absent graph.fb with a non-empty tree. The retry "+
+			"union skips the zero-change branch where the #5710 guard lives, so the fallback here has "+
+			"to come from somewhere else — and it must come from somewhere (#5710/#6209)\nlogs:\n%s", logs)
+	}
+	if res.FallbackReason == "" {
+		t.Fatal("the pass declined without a reason, so the scheduler cannot log why it is doing a full index")
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -46,6 +46,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -72,11 +73,43 @@ const manifestFile = "file-index.json"
 // already re-spelled once, in internal/daemon/state_migrate.go).
 const ManifestFileName = manifestFile
 
+// MaxExtractRetries bounds how many EXTRA passes a file whose extraction failed
+// is forced back into the changed set before the manifest is allowed to treat it
+// as settled (#6209).
+//
+// Two is a deliberate middle: enough to ride out a transient failure (an
+// oversubscribed machine, a partially-written file, a cancelled child) without
+// making a genuinely unparseable file — an unsupported dialect, a vendored
+// minified blob, a generated file the grammar chokes on — cost a re-read and a
+// re-parse on every pass for the life of the repo. Once the budget is spent the
+// file goes quiet until its BYTES change, which is the only new information
+// that could plausibly change the outcome.
+const MaxExtractRetries = 2
+
 // FileEntry holds the hash + metadata for one indexed source file.
 type FileEntry struct {
 	SHA256 string `json:"sha256"`
 	Size   int64  `json:"size"`
 	Mtime  int64  `json:"mtime"` // UnixNano
+
+	// Failures counts CONSECUTIVE passes on which this file was read and
+	// stamped but its EXTRACTION failed, so the graph does not contain its
+	// entities even though the stamp says the bytes were indexed (#6209).
+	//
+	// It exists because those two facts are otherwise indistinguishable on
+	// disk. A stamp means "the graph was built from these bytes"; for a failed
+	// file that claim is false, and it is self-concealing — the next pass
+	// hash-matches the stamp, calls the file unchanged, and the missing entity
+	// set is never noticed, let alone healed.
+	//
+	// Non-zero and within MaxExtractRetries forces the file back into the
+	// changed set (see RetryDue). Reset to zero by any successful extraction —
+	// ApplyStamps overwrites the whole entry — and reset to one when the file's
+	// content changes, because different bytes earn a fresh budget.
+	//
+	// omitempty: the overwhelmingly common value is 0, and a manifest is
+	// written once per pass per repo.
+	Failures int `json:"failures,omitempty"`
 }
 
 // Manifest is the on-disk representation of the per-repo file index.
@@ -253,6 +286,20 @@ func UpdateManifestScoped(absRepo string, hashPaths, keepPaths []string, m *Mani
 				return
 			}
 			mu.Lock()
+			// #6209 — a re-hash must not silently clear the retry budget. This
+			// writes a fresh FileEntry, whose Failures is zero, over an entry
+			// that may be carrying a count; the too-many-changed reject at
+			// incremental.go passes exactly the changed set, and a retry-due
+			// file is IN it by construction. Zeroing there restarts the budget
+			// on every reject, which is the unbounded retry this design
+			// rejected, reached by accident.
+			//
+			// Same rule as ApplyStampsAndFailures: identical bytes keep the
+			// count, different bytes earn a fresh budget (here, zero — the file
+			// changed, so it is being re-extracted on its own merits anyway).
+			if prev, ok := m.Files[r]; ok && prev.SHA256 == entry.SHA256 {
+				entry.Failures = prev.Failures
+			}
 			m.Files[r] = entry
 			mu.Unlock()
 		}(rel)
@@ -285,6 +332,87 @@ func ApplyStamps(stamps map[string]FileEntry, keepPaths []string, m *Manifest) {
 		m.Files[rel] = e
 	}
 	reconcileMembership(keepPaths, m)
+}
+
+// ApplyStampsAndFailures is ApplyStamps plus the record of which of those
+// stamped files FAILED to extract on this pass (#6209).
+//
+// A stamp asserts "the graph was built from these bytes". For a file whose
+// extractor returned an error that assertion is false — the pipeline read the
+// bytes and produced nothing from them — and it is self-concealing: the next
+// pass hash-matches the stamp, classifies the file unchanged, and the missing
+// entity set is never noticed. Dropping the stamp instead would heal that, but
+// only by making a DETERMINISTICALLY unparseable file re-read and re-parse on
+// every pass forever. So the entry stays and carries a consecutive-failure
+// count, and retryDue spends it over the next MaxExtractRetries passes.
+//
+// The count must survive ApplyStamps, which overwrites whole entries, so the
+// prior counts are snapshotted first. Two resets are deliberate:
+//
+//   - A file that is NOT in failed keeps whatever ApplyStamps wrote, i.e. a
+//     zero count. One successful extraction clears the history; the count is
+//     "consecutive", not "lifetime".
+//   - A file that failed again but at DIFFERENT bytes restarts at one. New
+//     content is the only new information that could change the outcome, so it
+//     earns a fresh budget rather than inheriting a spent one.
+//
+// failed holds repo-relative paths, the same key space as stamps. Paths absent
+// from the manifest after the stamp+prune — never stamped at all, or pruned out
+// of the walk — are skipped: an absent entry already re-presents as new, which
+// is the stronger signal.
+//
+// It returns the paths whose count CROSSED MaxExtractRetries on this call —
+// the moment each file stops being retried and its missing entities become
+// permanent until someone edits it. That crossing is the one event in this
+// mechanism a human should hear about, and it happens exactly once per file, so
+// the caller logs it rather than the manifest quietly absorbing it.
+func ApplyStampsAndFailures(stamps map[string]FileEntry, keepPaths []string, failed map[string]bool, m *Manifest) (exhausted []string) {
+	prior := make(map[string]FileEntry, len(failed))
+	for rel := range failed {
+		if e, ok := m.Files[rel]; ok {
+			prior[rel] = e
+		}
+	}
+
+	ApplyStamps(stamps, keepPaths, m)
+
+	for rel := range failed {
+		e, ok := m.Files[rel]
+		if !ok {
+			continue
+		}
+		if p, had := prior[rel]; had && p.SHA256 == e.SHA256 {
+			e.Failures = p.Failures + 1
+		} else {
+			e.Failures = 1
+		}
+		m.Files[rel] = e
+		if e.Failures == MaxExtractRetries+1 {
+			exhausted = append(exhausted, rel)
+		}
+	}
+	sort.Strings(exhausted)
+	return exhausted
+}
+
+// RetryDue reports whether an entry's extraction failure is still within its
+// retry budget, and must therefore be forced back into the changed set even
+// though its bytes are unchanged (#6209).
+//
+// Both bounds matter. Failures == 0 is the ordinary case and must not be
+// disturbed. Failures > MaxExtractRetries is the file that has had its chances:
+// leaving it dirty forever would re-read and re-parse it on every pass for the
+// life of the repo, which is a worse trade than the gap it was fixing.
+//
+// EXPORTED BECAUSE ONE UNION IS NOT ENOUGH. internal/extractors.TryIncremental —
+// the daemon's per-tick path — re-checks content hashes of its own in the Step-3
+// AST-hash gate, downstream of everything this package decides. That gate
+// compares the same SHA-256 over the same bytes, so a failed file (whose bytes
+// are unchanged by construction) is dropped straight back out unless the caller
+// consults this predicate too. Any future gate that asks "did the bytes change?"
+// has to ask this as well, or the retry dies there silently.
+func RetryDue(e FileEntry) bool {
+	return e.Failures > 0 && e.Failures <= MaxExtractRetries
 }
 
 // reconcileMembership drops entries for files no longer in the walked set (#5667)
@@ -438,6 +566,26 @@ func FilterWithGit(absRepo string, relPaths []string, manifest *Manifest) (chang
 		}
 	}
 
+	// FAILED-EXTRACTION UNION (#6209).
+	//
+	// The isChanged gate alone is not enough on this path, because this path
+	// does not consult isChanged for everything: a file git does not report is
+	// trusted as unchanged and never hashed. A file whose extraction failed has
+	// unchanged BYTES by construction — that is the whole problem — so git is
+	// silent about it and the retry would never fire on the git-aware path,
+	// which is the one the daemon and Index()+WithIncremental both take.
+	//
+	// Union it in here so it reaches isChanged, which then applies the same
+	// budget. Costs one map walk over the manifest and, in the overwhelmingly
+	// common case of no failures, adds nothing to the changed set.
+	if manifest != nil {
+		for rel, e := range manifest.Files {
+			if RetryDue(e) {
+				gitChanged[rel] = true
+			}
+		}
+	}
+
 	// git-aware path: files reported by git go through hash-based check;
 	// files NOT reported by git are trusted as unchanged.
 	var gitDirty, gitClean []string
@@ -505,6 +653,12 @@ func isChanged(absPath, relPath string, manifest *Manifest) bool {
 	entry, ok := manifest.Files[relPath]
 	if !ok {
 		return true // new file
+	}
+	// #6209: the bytes may be identical and the file still not be in the graph,
+	// because the extractor that ran on them failed. Retry it, within budget,
+	// before the hash gets a chance to say "unchanged" and hide the gap.
+	if RetryDue(entry) {
+		return true
 	}
 	info, err := os.Lstat(absPath)
 	if err != nil {

--- a/internal/indexer/diff/failed_extract_6209_test.go
+++ b/internal/indexer/diff/failed_extract_6209_test.go
@@ -1,0 +1,268 @@
+package diff
+
+// #6209 — a stamp says "the graph was built from these bytes". For a file whose
+// EXTRACTION failed that is false, and false in the one direction the next pass
+// cannot detect: the hash matches, the file is classified unchanged, and its
+// entities stay missing from the graph with nothing anywhere recording why.
+//
+// ApplyStampsAndFailures keeps the stamp and qualifies it with a consecutive-
+// failure count; retryDue spends that count over the next MaxExtractRetries
+// passes. These are unit tests on the two halves the cmd/grafel end-to-end
+// fixture cannot reach: the non-git Filter path (its repo is always a git repo)
+// and the content-change reset (four more real index passes to observe).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeAndStamp writes body to dir/rel and returns the stamp the walk would
+// have produced for it — the real hash of the real bytes, so Filter's own
+// stat-and-hash check agrees with the manifest unless something else forces the
+// file dirty.
+func writeAndStamp(t *testing.T, dir, rel, body string) FileEntry {
+	t.Helper()
+	abs := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.WriteFile(abs, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	e, err := HashFile(abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return e
+}
+
+func changedSet(t *testing.T, dir string, rels []string, m *Manifest) map[string]bool {
+	t.Helper()
+	changed, _ := Filter(dir, rels, m)
+	got := make(map[string]bool, len(changed))
+	for _, c := range changed {
+		got[c] = true
+	}
+	return got
+}
+
+// TestFailedExtraction_IsRetriedThenGoesQuiet walks the whole budget in one
+// place: the file comes back for exactly MaxExtractRetries extra passes and then
+// stops, with the bytes never changing.
+//
+// The bytes not changing is the point. Every pass here would classify the file
+// UNCHANGED on the hash alone — that is precisely how the defect hid.
+func TestFailedExtraction_IsRetriedThenGoesQuiet(t *testing.T) {
+	dir := t.TempDir()
+	stamp := writeAndStamp(t, dir, "victim.go", "package v\n")
+	other := writeAndStamp(t, dir, "clean.go", "package v\n\nfunc C() {}\n")
+	walk := []string{"victim.go", "clean.go"}
+
+	m := newManifest()
+	stamps := map[string]FileEntry{"victim.go": stamp, "clean.go": other}
+	failed := map[string]bool{"victim.go": true}
+
+	// Pass 1: both stamped, one failed.
+	ApplyStampsAndFailures(stamps, walk, failed, m)
+	if got := m.Files["victim.go"].Failures; got != 1 {
+		t.Fatalf("after pass 1 victim.go carries %d failure(s), want 1 — an unqualified stamp is "+
+			"indistinguishable from a successful index (#6209)", got)
+	}
+	if got := m.Files["clean.go"].Failures; got != 0 {
+		t.Fatalf("clean.go carries %d failure(s) and never failed, want 0 — the mark must name the "+
+			"file, not the walk", got)
+	}
+	if got := m.Files["victim.go"].SHA256; got != stamp.SHA256 {
+		t.Fatalf("victim.go's stamp is %q, want the walk's %q — the failure mark qualifies the stamp, "+
+			"it does not replace it", got, stamp.SHA256)
+	}
+
+	// Passes 2..1+MaxExtractRetries: the file is due, and re-fails.
+	for n := 2; n <= 1+MaxExtractRetries; n++ {
+		got := changedSet(t, dir, walk, m)
+		if !got["victim.go"] {
+			t.Fatalf("pass %d did not re-present victim.go. Its bytes are unchanged BY CONSTRUCTION — "+
+				"a failed extraction does not edit the file — so the hash can only ever say "+
+				"\"unchanged\" and the missing entities are never retried (#6209)", n)
+		}
+		if got["clean.go"] {
+			t.Fatalf("pass %d also re-presented clean.go, which extracted fine; the retry must not "+
+				"widen into a full reindex", n)
+		}
+		ApplyStampsAndFailures(stamps, walk, failed, m)
+		if f := m.Files["victim.go"].Failures; f != n {
+			t.Fatalf("after pass %d victim.go carries %d failure(s), want %d — the count must be "+
+				"CONSECUTIVE and durable, or the retry cannot be bounded", n, f, n)
+		}
+	}
+
+	// The budget is spent.
+	if got := changedSet(t, dir, walk, m); got["victim.go"] {
+		t.Fatalf("victim.go is still re-presenting after %d consecutive deterministic failures. "+
+			"Unbounded retry means a genuinely unparseable file is re-read and re-parsed on every "+
+			"pass for the life of the repo — a silent gap traded for a permanent tax (#6209)",
+			1+MaxExtractRetries)
+	}
+}
+
+// TestFailedExtraction_ContentChangeRestartsTheBudget pins the reset.
+//
+// Once the budget is spent the file is quiet, which is only defensible while
+// nothing has changed. New bytes are the one piece of new information that could
+// plausibly change the outcome — a syntax error fixed, a generated file
+// regenerated — so they buy a fresh budget rather than inheriting a spent one.
+// Without this a file that failed three times in its lifetime could never be
+// retried again no matter how it was edited.
+func TestFailedExtraction_ContentChangeRestartsTheBudget(t *testing.T) {
+	dir := t.TempDir()
+	walk := []string{"victim.go"}
+	m := newManifest()
+
+	first := writeAndStamp(t, dir, "victim.go", "package v\n")
+	failed := map[string]bool{"victim.go": true}
+	for n := 1; n <= 1+MaxExtractRetries; n++ {
+		ApplyStampsAndFailures(map[string]FileEntry{"victim.go": first}, walk, failed, m)
+	}
+	if got := changedSet(t, dir, walk, m); got["victim.go"] {
+		t.Fatal("fixture is inert: the budget was not spent, so the reset below proves nothing")
+	}
+
+	// The developer edits the file and it fails again — at DIFFERENT bytes.
+	second := writeAndStamp(t, dir, "victim.go", "package v\n\nfunc Fixed() {}\n")
+	if second.SHA256 == first.SHA256 {
+		t.Fatal("fixture is inert: the edit produced identical bytes")
+	}
+	ApplyStampsAndFailures(map[string]FileEntry{"victim.go": second}, walk, failed, m)
+
+	if got := m.Files["victim.go"].Failures; got != 1 {
+		t.Fatalf("victim.go carries %d failure(s) after failing at NEW content, want 1 — inheriting a "+
+			"spent budget means an edited file is never retried again (#6209)", got)
+	}
+	if !changedSet(t, dir, walk, m)["victim.go"] {
+		t.Fatal("victim.go is not due for retry after failing at new content, so the fresh budget is " +
+			"not actually spendable")
+	}
+}
+
+// TestSuccessfulExtraction_ClearsTheFailureHistory pins the count as
+// CONSECUTIVE rather than lifetime: one success wipes it, so a file that fails
+// transiently and then succeeds is back to an ordinary entry with no residual
+// retry pressure.
+func TestSuccessfulExtraction_ClearsTheFailureHistory(t *testing.T) {
+	dir := t.TempDir()
+	walk := []string{"victim.go"}
+	stamp := writeAndStamp(t, dir, "victim.go", "package v\n")
+	m := newManifest()
+
+	ApplyStampsAndFailures(map[string]FileEntry{"victim.go": stamp}, walk,
+		map[string]bool{"victim.go": true}, m)
+	if m.Files["victim.go"].Failures != 1 {
+		t.Fatalf("fixture is inert: no failure was recorded")
+	}
+
+	// Same bytes, same stamp — this time extraction succeeded, so the file is
+	// not in the failed set.
+	ApplyStampsAndFailures(map[string]FileEntry{"victim.go": stamp}, walk, nil, m)
+
+	if got := m.Files["victim.go"].Failures; got != 0 {
+		t.Fatalf("victim.go still carries %d failure(s) after a SUCCESSFUL extraction, want 0 — the "+
+			"count is consecutive, and stale pressure re-extracts a healthy file for no reason", got)
+	}
+	if changedSet(t, dir, walk, m)["victim.go"] {
+		t.Fatal("victim.go is still due for retry after a successful extraction")
+	}
+}
+
+// TestApplyStampsAndFailures_ReportsTheBudgetCrossingOnce pins the only signal a
+// human gets. The count is durable but nothing outside this package reads it, so
+// the crossing — the instant a file stops being retried and its entities become
+// permanently absent — is returned to the caller to log. It must fire exactly
+// once, on the pass that spends the last attempt: a crossing reported early is a
+// false alarm, and one reported on every subsequent pass is noise that trains
+// the reader to ignore it.
+func TestApplyStampsAndFailures_ReportsTheBudgetCrossingOnce(t *testing.T) {
+	dir := t.TempDir()
+	walk := []string{"victim.go"}
+	stamp := writeAndStamp(t, dir, "victim.go", "package v\n")
+	failed := map[string]bool{"victim.go": true}
+	m := newManifest()
+
+	for n := 1; n <= MaxExtractRetries; n++ {
+		if got := ApplyStampsAndFailures(map[string]FileEntry{"victim.go": stamp}, walk, failed, m); len(got) != 0 {
+			t.Fatalf("pass %d reported %v as out of retries, but %d attempt(s) remain — a premature "+
+				"crossing tells the reader a file went dark while it is still being retried", n, got, 1+MaxExtractRetries-n)
+		}
+	}
+
+	got := ApplyStampsAndFailures(map[string]FileEntry{"victim.go": stamp}, walk, failed, m)
+	if len(got) != 1 || got[0] != "victim.go" {
+		t.Fatalf("the pass that spent the last attempt reported %v, want [victim.go] — this is the "+
+			"only moment anything announces that the file's entities are now permanently missing (#6209)", got)
+	}
+
+	if again := ApplyStampsAndFailures(map[string]FileEntry{"victim.go": stamp}, walk, failed, m); len(again) != 0 {
+		t.Fatalf("a later pass reported the crossing again (%v); it must fire once per file, not once "+
+			"per pass forever", again)
+	}
+}
+
+// TestUpdateManifestScoped_PreservesTheFailureBudget pins a coupling that is
+// easy to miss and silent when broken.
+//
+// UpdateManifestScoped re-hashes files off disk and writes fresh FileEntry
+// values, whose Failures is zero. The too-many-changed reject in
+// internal/extractors.TryIncremental calls it with exactly the changed set — and
+// a retry-due file is IN that set by construction, because the retry union put
+// it there. Zeroing the count there restarts the budget on every reject, which
+// is the unbounded retry this design deliberately rejected, reached by accident
+// rather than by decision.
+func TestUpdateManifestScoped_PreservesTheFailureBudget(t *testing.T) {
+	dir := t.TempDir()
+	stamp := writeAndStamp(t, dir, "victim.go", "package v\n")
+	m := newManifest()
+	m.Files["victim.go"] = FileEntry{SHA256: stamp.SHA256, Size: stamp.Size, Mtime: stamp.Mtime, Failures: 2}
+
+	UpdateManifestScoped(dir, []string{"victim.go"}, []string{"victim.go"}, m)
+
+	if got := m.Files["victim.go"].Failures; got != 2 {
+		t.Fatalf("a re-hash reset victim.go's failure count to %d, want 2 preserved. The bytes did not "+
+			"change, so nothing about the file's prospects changed either; restarting its budget on "+
+			"every too-many-changed reject makes the retry unbounded (#6209)", got)
+	}
+	if RetryDue(m.Files["victim.go"]) != true {
+		t.Fatal("victim.go is no longer retry-due after a re-hash that changed nothing")
+	}
+}
+
+// TestUpdateManifestScoped_NewContentClearsTheFailureBudget is the other side of
+// that rule: a re-hash that finds DIFFERENT bytes writes a fresh entry with no
+// count, because the file is being re-extracted on its own merits anyway and the
+// old budget described bytes that no longer exist.
+func TestUpdateManifestScoped_NewContentClearsTheFailureBudget(t *testing.T) {
+	dir := t.TempDir()
+	m := newManifest()
+	m.Files["victim.go"] = FileEntry{SHA256: "stamp-of-the-old-bytes", Size: 1, Mtime: 1, Failures: 2}
+	writeAndStamp(t, dir, "victim.go", "package v\n\nfunc Edited() {}\n")
+
+	UpdateManifestScoped(dir, []string{"victim.go"}, []string{"victim.go"}, m)
+
+	if got := m.Files["victim.go"].Failures; got != 0 {
+		t.Fatalf("victim.go kept %d failure(s) from bytes that no longer exist, want 0 — an edited "+
+			"file must not inherit a budget spent against different content (#6209)", got)
+	}
+}
+
+// TestApplyStampsAndFailures_SkipsFilesWithNoManifestEntry covers the file that
+// failed and was never stamped at all — the unreadable-file case, and anything
+// the membership prune drops. There is nothing to qualify, and an absent entry
+// already re-presents as new, which is the stronger signal. Marking must not
+// invent an entry with no hash: that would be a manifest row claiming a file
+// with no content, which Filter reads as unchanged-if-you-squint rather than as
+// absent.
+func TestApplyStampsAndFailures_SkipsFilesWithNoManifestEntry(t *testing.T) {
+	m := newManifest()
+	ApplyStampsAndFailures(nil, []string{"kept.go"}, map[string]bool{"never-stamped.go": true}, m)
+
+	if _, ok := m.Files["never-stamped.go"]; ok {
+		t.Fatalf("a failed file with no stamp was given a manifest entry %+v — an unstamped file must "+
+			"stay absent so it reads as NEW next pass (#6209)", m.Files["never-stamped.go"])
+	}
+}


### PR DESCRIPTION
The manifest was stamped from the raw walk, regardless of whether extraction succeeded. A file whose extraction failed was therefore recorded as indexed-at-this-content-hash, and the next incremental pass saw it as clean and skipped it. **It was never retried until its bytes changed** — a permanently missing entity set with no signal at all.

Pre-existing, but #6207 made the scheduler's fallback full index write a manifest too, so it became reachable from the daemon's automatic path — the one nobody is watching.

## Bounded retry, not exclusion

`FileEntry` gains `Failures`: consecutive passes on which the file was stamped but its extraction failed. `RetryDue` forces it back into the changed set while the count is within `MaxExtractRetries` (2) — three attempts, then quiet until the bytes change.

The obvious fix — leave failed files unstamped so they re-present — was rejected. It heals the transient case by making the deterministic case permanent: an unparseable file gets re-read and re-parsed on every pass forever and never succeeds. Unbounded retry was rejected for the same reason, and its cost is genuinely unbounded here: nothing about the file changes between passes, so the work is pure repetition, and the population is not self-limiting — every unparseable file in the repo pays, forever, on a daemon loop.

Two resets keep it honest. A success clears the count, so it is consecutive rather than lifetime. A failure at *different* bytes restarts at 1, so an edited file is always retried. `ErrNoExtractorForLanguage` is excluded — an unmodelled language is a correct permanent answer, not a failure.

## Two independent gates ask "did the bytes change?", and each one alone kills the retry

This is the part worth reading, because the first version of this change passed its whole test suite while doing nothing on the path the issue is about.

- `diff.isChanged` compares `FileEntry.SHA256`. Union the retry-due set in and this gate lets the file through.
- `internal/extractors/incremental.go:612` — `TryIncremental`'s Step-3 AST-hash gate compares `FileStamp.ContentHash`, which is **the same SHA-256 over the same raw bytes**. A failed extraction does not edit the file, so this gate can only ever answer "unchanged" and drops the retry straight back out.

The pass then returned `Done: true` without saving a manifest, and `daemon.go:1247` treats `Done` as "no fallback needed". The failure count was pinned at its initial value forever: budget never spent, file never retried, on the daemon's primary path.

`RetryDue` is exported and appears in *both* gates for that reason, stated in the code rather than left to be rediscovered.

The first round's tests missed this because they drove `Index(..., WithIncremental(...))` — Path B — and never touched `TryIncremental`. The new `internal/extractors/incremental_failed_extract_6209_test.go` drives Path A directly.

## The retry union must not suppress the zero-change branch

Forcing retry-due files into the changed set means `totalChanged >= 1` while any file is mid-budget, which would skip `incremental.go:531` — and with it the #5710 absent-graph guard and the healing full-repo manifest sweep, whose own comment says removing it "makes those entries permanent."

Suppression is bounded by construction: a retry either succeeds (count cleared) or fails (extract-error fallback to a full index, which increments it), so it ends within `MaxExtractRetries` passes. Both properties are pinned by tests — one asserts the branch stays reachable on a clean tree and on a spent budget, the other asserts a pass cannot report success over an absent `graph.fb` with a non-empty tree.

## Other corrections from review

- `UpdateManifestScoped` preserved `Failures` when a re-hash finds identical bytes, and clears it when they differ. Without this, a too-many-changed reject re-hashed the file, wiped the count, and restarted the budget on every reject — the unbounded-retry outcome the design rejects.
- The exhausted budget is now **logged once per file at the crossing**. Previously the count lived only in a JSON file with zero consumers, so "the manifest records it" was not a real answer to the silence complaint.
- Step 9 routed through `ApplyStampsAndFailures` with an explicitly empty set, and a comment naming why the `fallback()` at `incremental.go:922` makes it empty today.
- `--wipe` resetting the budget is documented rather than incidental.

## Plumbing

`i.stats.failed` was a bare counter with no names, so making it per-file is most of the diff: `Indexer.failedExtractions` records the rel-path at the failure site, and `commitManifest` hands it to `diff.ApplyStampsAndFailures`, which snapshots prior counts before `ApplyStamps` clobbers the entries.

Two classes stay out, both unactionable: read failures (already deliberately unstamped — with no bytes there is no stamp to hang a count on) and `GRAFEL_SUBPROC_EXTRACT`, whose children return a count rather than paths. That path is env-var-only with no config surface, and the gap is the same one the existing `stampUnreadFiles` note records.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/indexer/diff/...` 0, `./internal/extractors/...` 0, `./cmd/grafel/...` 0 (116.7s, zero `--- FAIL` lines).

**Fourteen mutants, zero survivors**, across two rounds. Independently adversarially reviewed; the reviewer re-ran 8 of the first round's mutants (all died as reported) and found the Path-A gap by writing a probe rather than by reading.

Two were re-run independently at merge:

- Deleting `|| diff.RetryDue(prev)` from the Step-3 gate reproduces the original defect exactly, emitting `all 1 changed file(s) had unchanged AST hash — skipping reindex`.
- Making the zero-change branch unreachable kills the reachability test — so that assertion, which is phrased on a log line *not* emitted, is load-bearing rather than vacuous.

Both files were restored from byte-level backups with shasums verified equal.

Closes #6209
Refs #6207, #6212, #5710
