### PR TITLE
fix(#5822): `status --ref` was inert and an un-runnable git made repos render as a healthy zero

### DIFF
--- a/internal/cli/ref_flag_test.go
+++ b/internal/cli/ref_flag_test.go
@@ -108,14 +108,29 @@ func TestStatus_Ref_Named(t *testing.T) {
 	}
 }
 
+// TestStatus_Ref_All: `--ref @all` is REFUSED (#5822 C).
+//
+// This test used to assert the opposite — that status printed
+// "Note: --ref @all shows per-ref graph state for all known refs." and carried
+// on. It did carry on: straight into the ordinary current-HEAD view. The note
+// was the entire implementation, so the command announced a per-ref breakdown
+// and then showed one ref's numbers under that heading. The breakdown is a real
+// feature and is out of scope here; until it exists, refusing is the only
+// honest answer, and this test now pins that. Nothing may be printed first — a
+// note that precedes the refusal is the same misleading claim, just shorter.
 func TestStatus_Ref_All(t *testing.T) {
 	setupRefTestEnv(t, "main", "feat/x")
 	var buf bytes.Buffer
-	if err := runStatus(&buf, "", "", true); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	err := runStatus(&buf, "", "", true)
+	if err == nil {
+		t.Fatal("--ref @all returned no error: status still advertises a per-ref " +
+			"breakdown it does not implement")
 	}
-	if !strings.Contains(buf.String(), "@all") {
-		t.Errorf("expected @all note, got: %s", buf.String())
+	if !strings.Contains(err.Error(), "@all") {
+		t.Errorf("error does not name the flag value: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("output written before refusing:\n%s", buf.String())
 	}
 }
 

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -30,9 +30,9 @@ func newStatusCmd() *cobra.Command {
 		Short: "Show daemon + index status",
 		Long: `Show daemon health and per-repo index state.
 
-When --ref is supplied the registry view is filtered to repos that have a
-graph stored for that ref.  Use --ref @all to show state across every known
-ref (implies a per-ref breakdown in the output).
+When --ref is supplied every repo's line reports the graph stored for THAT ref
+rather than for the repo's current HEAD; a repo with no graph for the ref shows
+as never indexed.  --ref @all is not implemented and is rejected.
 
 --json switches to the poll-safe status-plane read (#5725/#5729-W1): it
 resolves the current directory to its registered repo and prints the
@@ -73,12 +73,23 @@ when no engine has ever written a status file for this repo.`,
 //
 //	narrows the view to that ref's graph state.
 //
-// showAll   — true when --ref @all was passed; shows a per-ref breakdown.
+// showAll   — true when --ref @all was passed; rejected, see below.
 func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
+	// #5822 C: @all advertised a per-ref breakdown that has never existed. It
+	// printed that note and then rendered the ordinary current-HEAD view, so
+	// the output was a claim about all refs and a picture of one. The breakdown
+	// is a real feature (a per-ref line per repo, its own summary shape) and is
+	// deliberately NOT in scope here; refusing is the honest interim. A command
+	// that lies about what it is showing is worse than one that says it cannot.
 	if showAll {
-		fmt.Fprintln(w, "Note: --ref @all shows per-ref graph state for all known refs.")
-		fmt.Fprintln(w)
-	} else if ref != "" {
+		return fmt.Errorf(
+			"--ref @all is not implemented by `grafel status`: it promises a per-ref " +
+				"breakdown this command does not produce, and printing the current-HEAD " +
+				"view under that heading would misreport it. Use `grafel status --ref " +
+				"<branch>` for one ref, or `grafel status` for the current HEAD",
+		)
+	}
+	if ref != "" {
 		fmt.Fprintf(w, "Note: showing state for ref %q.\n\n", ref)
 	}
 	// Daemon section first — gives the operator a fast-glance view.
@@ -171,7 +182,9 @@ func runStatus(w io.Writer, filter string, ref string, showAll bool) error {
 		}
 
 		// Compute rich statistics for this group.
-		summary := ComputeStatusSummary(g.Name, cfg.Repos)
+		// #5822 C: the resolved ref goes all the way to the resolver now, so
+		// the note printed above and the numbers below describe the same thing.
+		summary := ComputeStatusSummaryForRef(g.Name, cfg.Repos, ref)
 		PrintStatusSummary(w, summary)
 
 		// PH3 (#2091): show linked worktree children indented under their parent.

--- a/internal/cli/status_ref_5822_test.go
+++ b/internal/cli/status_ref_5822_test.go
@@ -1,0 +1,294 @@
+package cli
+
+// status_ref_5822_test.go — #5822 defects C and D.
+//
+// Both defects have ONE root cause: `grafel status` re-derived every repo's
+// per-ref state directory from LIVE GIT at display time, instead of from the
+// ref the caller asked for (C) or from what is actually on disk (D).
+//
+//   C — `--ref main` was consumed only to print "Note: showing state for ref
+//       …"; ComputeStatusSummary took no ref at all and every repo resolved
+//       through daemon.StateDirForRepo → gitmeta.CaptureCached → current HEAD.
+//       The command therefore printed a note claiming one thing and rendered
+//       another.
+//   D — when git could not be RUN (2s deadline, EAGAIN on fork, an OOM-killed
+//       child), the capture is untrusted and its Ref is "", which
+//       RefSafeEncode turns into the "_unknown" sentinel directory. No graph
+//       ever lives there, so the repo rendered as "0 entities · 0 rels ·
+//       indexed (never)" — indistinguishable from a repo that genuinely has no
+//       graph — and contributed nothing to TOTAL. Next run git succeeded and
+//       the numbers came back.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// initGitRepoCLI creates a REAL git checkout on branch `main`.
+//
+// It is a real repo deliberately. A non-git tmpdir would make git answer "not a
+// git repository" — a durable, trusted answer that legitimately resolves to the
+// `_unknown` slot — so every assertion below would hold regardless of the
+// production code, which is exactly the fixture-vacuity trap this repo has been
+// bitten by before.
+func initGitRepoCLI(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runIn := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runIn("init")
+	runIn("checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn("add", ".")
+	runIn("commit", "-m", "init")
+	return dir
+}
+
+// seedSidecar writes a graph-stats.json with the given entity count into the
+// state directory for (repo, ref). It deliberately builds the path with
+// StateDirForRepoRef rather than StateDirForRepo: the latter would run a git
+// capture and MEMOIZE the resulting ref, which would then be served from cache
+// even while git is unavailable and would hide the defect under test.
+func seedSidecar(t *testing.T, repoPath, ref string, entities, rels int) string {
+	t.Helper()
+	dir := daemon.StateDirForRepoRef(repoPath, ref)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         time.Now().Add(-5 * time.Minute),
+		TotalEntities:      entities,
+		TotalRelationships: rels,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "graph-stats.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// stubGitUnrunnable puts a `git` on PATH that kills itself with SIGKILL. A
+// signalled child is classified gitUnavailable by internal/gitmeta, which is
+// the same state a fork EAGAIN or a fired 2s deadline produces — the #5822-D
+// trigger, injected rather than provoked. Returns the real PATH.
+func stubGitUnrunnable(t *testing.T) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte("#!/bin/sh\nkill -9 $$\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	real := os.Getenv("PATH")
+	t.Setenv("PATH", binDir)
+	return real
+}
+
+// TestComputeStatusSummaryForRef_ReadsTheRequestedRef is defect C.
+//
+// The fixture has TWO graphs on disk for one repo — one under refs/main (the
+// live HEAD) and a differently-sized one under refs/feature-x. Asking for
+// feature-x must report feature-x's numbers. Before the fix the ref never
+// reached the resolver and HEAD's numbers came back with a note claiming
+// otherwise.
+func TestComputeStatusSummaryForRef_ReadsTheRequestedRef(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	repoPath := initGitRepoCLI(t)
+
+	seedSidecar(t, repoPath, "main", 111, 222)
+	seedSidecar(t, repoPath, "feature-x", 7777, 8888)
+
+	// Anti-vacuity: the live HEAD must really be `main`, otherwise "asked for
+	// feature-x, got feature-x" could be true by accident.
+	if got, want := daemon.StateDirForRepo(repoPath), daemon.StateDirForRepoRef(repoPath, "main"); got != want {
+		t.Fatalf("fixture broken: live HEAD resolves to %q, want %q — this test can only "+
+			"distinguish 'used the requested ref' from 'used HEAD' when they differ", got, want)
+	}
+
+	repos := []registry.Repo{{Slug: "r", Path: repoPath}}
+	summary := ComputeStatusSummaryForRef("grp", repos, "feature-x")
+
+	rs, ok := summary.RepoStats["r"]
+	if !ok {
+		t.Fatal("repo missing from RepoStats")
+	}
+	if rs.Entities != 7777 || rs.Relationships != 8888 {
+		t.Fatalf("--ref feature-x reported %d entities / %d rels, want 7777/8888 — "+
+			"the ref was ignored and the current HEAD's graph was shown instead (#5822 C)",
+			rs.Entities, rs.Relationships)
+	}
+	if summary.TotalEntities != 7777 {
+		t.Fatalf("TOTAL entities = %d, want 7777", summary.TotalEntities)
+	}
+}
+
+// TestComputeStatusSummary_DefaultsToHEAD guards the other side: with no ref
+// requested, status must keep showing the current HEAD's graph exactly as
+// before.
+func TestComputeStatusSummary_DefaultsToHEAD(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	repoPath := initGitRepoCLI(t)
+
+	seedSidecar(t, repoPath, "main", 111, 222)
+	seedSidecar(t, repoPath, "feature-x", 7777, 8888)
+
+	summary := ComputeStatusSummary("grp", []registry.Repo{{Slug: "r", Path: repoPath}})
+	if rs := summary.RepoStats["r"]; rs.Entities != 111 {
+		t.Fatalf("default view reported %d entities, want 111 (the HEAD ref's graph)", rs.Entities)
+	}
+}
+
+// TestRunStatus_ThreadsRefIntoTheSummary is defect C end-to-end, through the
+// command function rather than through ComputeStatusSummaryForRef directly.
+//
+// The unit test above proves the summary CAN honour a ref; this proves `grafel
+// status --ref` actually asks it to. Without it, reverting one argument at the
+// call site — the literal defect, where the flag was resolved, validated,
+// announced in a note, and then dropped — would leave every other test green.
+func TestRunStatus_ThreadsRefIntoTheSummary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("GRAFEL_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "config"))
+	t.Setenv(daemon.EnvRoot, t.TempDir())
+
+	repoPath := initGitRepoCLI(t)
+	seedSidecar(t, repoPath, "main", 111, 222)
+	seedSidecar(t, repoPath, "feature-x", 7777, 8888)
+
+	cfgDir := filepath.Join(home, "config")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfgPath := filepath.Join(cfgDir, "testgroup.fleet.json")
+	cfg := registry.GroupConfig{Name: "testgroup"}
+	cfg.Repos = []registry.Repo{{Slug: "testrepo", Path: repoPath}}
+	if err := registry.SaveGroupConfig(cfgPath, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup("testgroup", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	if err := runStatus(&buf, "", "feature-x", false); err != nil {
+		t.Fatalf("runStatus: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, `ref "feature-x"`) {
+		t.Fatalf("fixture broken: the ref note is missing, so the run under test is not "+
+			"the --ref run:\n%s", out)
+	}
+	if !strings.Contains(out, fmtInt(7777)) {
+		t.Fatalf("status --ref feature-x did not report feature-x's graph — the note "+
+			"claims one ref and the numbers come from HEAD (#5822 C):\n%s", out)
+	}
+	if strings.Contains(out, fmtInt(111)+" entities") {
+		t.Fatalf("status --ref feature-x reported the HEAD ref's entity count:\n%s", out)
+	}
+}
+
+// The other half of defect C — `--ref @all` must refuse rather than print a
+// note advertising a per-ref breakdown it does not produce — lives with the
+// rest of the flag's coverage in ref_flag_test.go (TestStatus_Ref_All), which
+// previously asserted the misleading behaviour.
+
+// TestComputeStatusSummary_UnresolvableRefIsNotAHealthyZero is defect D.
+//
+// git cannot be run; the repo's ref is therefore UNKNOWN, not empty. The old
+// code turned that into refs/_unknown and rendered a perfectly healthy-looking
+// "0 entities · 0 rels · indexed (never)".
+func TestComputeStatusSummary_UnresolvableRefIsNotAHealthyZero(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	repoPath := initGitRepoCLI(t)
+	seedSidecar(t, repoPath, "main", 4242, 5252)
+
+	realPath := stubGitUnrunnable(t)
+
+	repos := []registry.Repo{{Slug: "r", Path: repoPath}}
+	summary := ComputeStatusSummaryForRef("grp", repos, "")
+	rs, ok := summary.RepoStats["r"]
+	if !ok {
+		t.Fatal("repo missing from RepoStats — an unknown ref must not make the repo vanish")
+	}
+	if !rs.RefUnknown {
+		t.Fatalf("RefUnknown is false: an un-runnable git fell through to the _unknown "+
+			"sentinel and the repo reads as %d entities / indexed %q (#5822 D)",
+			rs.Entities, rs.LastIndexedAge)
+	}
+
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, summary)
+	out := buf.String()
+	if strings.Contains(out, "indexed (never)") {
+		t.Fatalf("a repo whose ref could not be determined rendered as never-indexed — "+
+			"indistinguishable from a repo that genuinely has no graph:\n%s", out)
+	}
+	if !strings.Contains(out, "UNKNOWN") {
+		t.Fatalf("the unknown state is not surfaced to the user:\n%s", out)
+	}
+	if !strings.Contains(out, "INCOMPLETE") {
+		t.Fatalf("TOTAL does not disclose that a repo was skipped:\n%s", out)
+	}
+
+	// Anti-vacuity, and the "next run the numbers come back" half of the report:
+	// with git schedulable again the SAME fixture must report the real graph.
+	// If this fails, the seeded graph was never where production looks and the
+	// assertions above proved nothing.
+	t.Setenv("PATH", realPath)
+	back := ComputeStatusSummaryForRef("grp", repos, "")
+	if rs := back.RepoStats["r"]; rs.RefUnknown || rs.Entities != 4242 {
+		t.Fatalf("fixture broken: with git healthy the repo reports RefUnknown=%v / %d entities, "+
+			"want false / 4242", rs.RefUnknown, rs.Entities)
+	}
+}
+
+// TestComputeStatusSummary_ExplicitRefSurvivesAnUnrunnableGit ties the two
+// defects together: once the requested ref is threaded through, `--ref` needs
+// no git at all, so it keeps working in exactly the conditions that break the
+// default view.
+func TestComputeStatusSummary_ExplicitRefSurvivesAnUnrunnableGit(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(daemon.EnvRoot, root)
+	repoPath := initGitRepoCLI(t)
+	seedSidecar(t, repoPath, "main", 4242, 5252)
+
+	stubGitUnrunnable(t)
+
+	summary := ComputeStatusSummaryForRef("grp", []registry.Repo{{Slug: "r", Path: repoPath}}, "main")
+	rs := summary.RepoStats["r"]
+	if rs.RefUnknown || rs.Entities != 4242 {
+		t.Fatalf("--ref main with git unavailable: RefUnknown=%v entities=%d, want false/4242 — "+
+			"an explicitly requested ref needs no git capture", rs.RefUnknown, rs.Entities)
+	}
+}

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -94,6 +94,33 @@ type RepoStatus struct {
 	// are not the currently active (hot) ref. Nil when none exist.
 	ColdRefs []string
 
+	// RefUnknown is true when this repo's per-ref state directory could NOT be
+	// resolved because git could not be run (#5822 D): a fired 2s deadline, a
+	// fork EAGAIN under load, an OOM-killed child. `status` is a fresh process
+	// on every invocation, so its git cache is always cold and it forks ~5 git
+	// processes per run — which is exactly the population that loses this race
+	// on a loaded machine.
+	//
+	// It is a FOURTH state, alongside the three RepoStatus already models:
+	//
+	//   - healthy       → counts are real;
+	//   - no graph yet  → LastIndexedAge "(never)", counts genuinely zero;
+	//   - GraphLoadError → a graph exists but could not be read;
+	//   - RefUnknown    → we do not know WHICH graph to look at.
+	//
+	// When it is set, every count on this repo is MISSING, not zero, and the
+	// repo contributes nothing to the group totals. That is the whole point of
+	// the flag: the old code resolved the empty ref to the "_unknown" sentinel
+	// directory, found no graph there (none ever exists there), and rendered
+	// "0 entities · 0 rels · indexed (never)" — a healthy-looking zero that a
+	// user cannot tell apart from a repo that was never indexed. On the next
+	// run git succeeded and the numbers came back, which is the "counts swing
+	// between runs on an unchanged repo" report.
+	//
+	// Never set when a ref was requested explicitly with --ref: that path needs
+	// no git capture at all.
+	RefUnknown bool
+
 	// RebuildFailure is the "last rebuild FAILED" marker read from the
 	// status-plane sidecar (internal/statusfile), if any (#5822 sub-ask 3).
 	// Non-nil means the most recent rebuild attempt for this repo hard-failed
@@ -144,6 +171,26 @@ type RepoStatus struct {
 // Errors reading individual files are silently skipped so a partial result
 // does not prevent summary generation.
 func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
+	return ComputeStatusSummaryForRef(group, repos, "")
+}
+
+// ComputeStatusSummaryForRef is ComputeStatusSummary for a CALLER-CHOSEN ref
+// (#5822 C).
+//
+// ref == "" keeps the historical behaviour: each repo's state directory is
+// derived from its current HEAD. A non-empty ref selects that ref's stored
+// graph directly, for every repo in the group.
+//
+// Threading the ref this far down is the whole of defect C. `grafel status
+// --ref main` used to resolve the flag, validate it, print "Note: showing state
+// for ref …" — and then hand ComputeStatusSummary no ref at all, so every repo
+// went through daemon.StateDirForRepo → gitmeta capture → whatever HEAD pointed
+// at right then. The note described one thing and the numbers underneath it
+// described another.
+//
+// A requested ref also needs NO git subprocess, which is why it is immune to
+// defect D below.
+func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string) *StatusSummary {
 	s := &StatusSummary{
 		GroupName: group,
 		RepoStats: make(map[string]*RepoStatus),
@@ -183,7 +230,28 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			}
 		}
 
-		stateDir := daemon.StateDirForRepo(r.Path)
+		// Resolve which per-ref slot to read.
+		//
+		// An explicitly requested ref is used verbatim — no git, so nothing can
+		// fail here. Otherwise the repo's CURRENT ref has to be discovered, and
+		// that can fail transiently (#5822 D): when it does, the resolver says
+		// so instead of quietly handing back the "_unknown" sentinel, and this
+		// repo is recorded as unknown rather than as an indexed-never zero.
+		// Everything below would otherwise read a directory that never holds a
+		// graph and report confident zeros for a repo that may be fully indexed.
+		var stateDir string
+		if ref != "" {
+			stateDir = daemon.StateDirForRepoRef(r.Path, ref)
+		} else {
+			resolved, refKnown := daemon.StateDirForRepoResolved(r.Path)
+			if !refKnown {
+				rs.RefUnknown = true
+				rs.LastIndexedAge = "(unknown)"
+				s.RepoStats[r.Slug] = rs
+				continue
+			}
+			stateDir = resolved
+		}
 
 		// Load graph-stats.json sidecar for basic counts.
 		sidecarPath := filepath.Join(stateDir, "graph-stats.json")
@@ -578,6 +646,19 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// Print each repo on one line.
 	for _, slug := range slugs {
 		rs := s.RepoStats[slug]
+		// #5822 D: a repo whose ref could not be determined has NO numbers to
+		// print. Printing the zero-valued line would render it as a healthy,
+		// never-indexed repo — the exact confusion this replaces. The rebuild
+		// -failure marker below is ref-independent and still shown.
+		if rs.RefUnknown {
+			fmt.Fprintf(w, "  %-*s  state UNKNOWN — git could not be run to resolve this repo's current ref; counts are UNAVAILABLE (not zero). Retry, or name the ref with `grafel status --ref <branch>`.\n",
+				maxSlugLen, slug)
+			if rf := rs.RebuildFailure; rf != nil {
+				fmt.Fprintf(w, "  %-*s  ⚠ last rebuild FAILED: %s%s — see daemon.err; raise GRAFEL_REBUILD_REPO_TIMEOUT (or `grafel rebuild --timeout <dur>`) or rebuild again\n",
+					maxSlugLen, "", rf.Reason, formatRebuildFailureRef(rf))
+			}
+			continue
+		}
 		gitSuffix := formatGitRef(rs.IndexedRef, rs.IndexedSHA, rs.IsWorktree)
 		coldSuffix := formatColdRefs(rs.ColdRefs)
 		fmt.Fprintf(w, "  %-*s  %5s files  %6s entities  %6s rels  indexed %s%s%s\n",
@@ -612,9 +693,14 @@ func PrintStatusSummary(w io.Writer, s *StatusSummary) {
 	// flow/endpoint/orphan aggregates, so this headline under-reports. Marking
 	// only the per-repo lines would leave the number most people actually read
 	// silently wrong.
+	//
+	// #5822 D adds the second way a repo can contribute nothing: its ref could
+	// not be resolved, so we never even learned which graph to read. Same
+	// consequence for this headline — an under-report that reads as a fact —
+	// so it is disclosed the same way.
 	incomplete := 0
 	for _, rs := range s.RepoStats {
-		if rs.GraphLoadError != "" {
+		if rs.GraphLoadError != "" || rs.RefUnknown {
 			incomplete++
 		}
 	}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -428,11 +428,31 @@ func StateDirForRepoRef(repoPath, ref string) string {
 // AnyRef fallback still finds the newest indexed graph — "tried the wrong dir
 // first", not "found nothing".
 func StateDirForRepo(repoPath string) string {
+	dir, _ := StateDirForRepoResolved(repoPath)
+	return dir
+}
+
+// StateDirForRepoResolved is StateDirForRepo plus the answer to "could the ref
+// be determined at all?" (#5822 D).
+//
+// ok == false means git could not be RUN — a fired 2s deadline, a fork EAGAIN
+// under load, a signalled child. The capture's Ref is then "" purely because of
+// the moment, and RefSafeEncode maps "" to the "refs/_unknown/" sentinel, a
+// directory no indexer ever writes a graph into. The returned path is still the
+// sentinel (so StateDirForRepo's behaviour is bit-for-bit what it was, for the
+// many callers that have no way to act on the difference), but a caller that
+// CAN distinguish "this repo has no graph" from "I could not find out" must
+// check ok and say so rather than reporting a confident zero.
+//
+// ok == true with an empty ref is a real, durable state — a detached HEAD, or a
+// path that is not a git repository at all — and the sentinel is genuinely
+// where that repo's graph lives. Trust, not emptiness, is the axis.
+func StateDirForRepoResolved(repoPath string) (string, bool) {
 	if repoPath == "" {
-		return ""
+		return "", false
 	}
-	meta := gitmeta.CaptureCached(repoPath)
-	return StateDirForRepoRef(repoPath, meta.Ref)
+	meta, trusted := gitmeta.CaptureCachedTrusted(repoPath)
+	return StateDirForRepoRef(repoPath, meta.Ref), trusted
 }
 
 // ResolveIncrementalStateDir resolves the per-ref state directory to use for

--- a/internal/daemon/state_path_5822_test.go
+++ b/internal/daemon/state_path_5822_test.go
@@ -1,0 +1,81 @@
+package daemon
+
+// state_path_5822_test.go — #5822 defect D at the resolver layer.
+//
+// StateDirForRepo answers "which per-ref slot holds this repo's state?" by
+// running a git capture. It has no way to say "I could not tell you": an
+// un-runnable git yields Ref == "", which RefSafeEncode maps to the _unknown
+// sentinel — a directory that never holds a graph. Callers that can distinguish
+// the two need a resolver that reports the difference.
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func initGitRepo5822(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runIn := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runIn("init")
+	runIn("checkout", "-b", "main")
+	if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runIn("add", ".")
+	runIn("commit", "-m", "init")
+	return dir
+}
+
+// TestStateDirForRepoResolved_UnrunnableGitIsUnknown pins the new signal.
+func TestStateDirForRepoResolved_UnrunnableGitIsUnknown(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("stub git script is POSIX-shell only")
+	}
+	t.Setenv(EnvRoot, t.TempDir())
+	repo := initGitRepo5822(t)
+
+	// A SIGKILLed git is the injected stand-in for a fired 2s deadline / a fork
+	// EAGAIN: internal/gitmeta classifies all three as gitUnavailable.
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "git"), []byte("#!/bin/sh\nkill -9 $$\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir)
+
+	dir, ok := StateDirForRepoResolved(repo)
+	if ok {
+		t.Fatalf("resolver claims it knows the ref while git cannot be run: %q — "+
+			"that answer is the _unknown sentinel, where no graph ever lives (#5822 D)", dir)
+	}
+
+	// git schedulable again; HEAD never moved. Same fixture, real answer.
+	t.Setenv("PATH", realPath)
+	dir, ok = StateDirForRepoResolved(repo)
+	if !ok {
+		t.Fatal("resolver reports unknown for a healthy git — the fixture or the trust " +
+			"signal is wrong, and the assertion above would then hold vacuously")
+	}
+	if want := StateDirForRepoRef(repo, "main"); dir != want {
+		t.Fatalf("resolved %q, want %q", dir, want)
+	}
+	if strings.Contains(dir, "_unknown") {
+		t.Fatalf("resolved to the sentinel: %q", dir)
+	}
+}

--- a/internal/gitmeta/cache.go
+++ b/internal/gitmeta/cache.go
@@ -327,21 +327,55 @@ func indexOf(s, sub string) int {
 // When HEAD cannot be located (non-git directory) it runs a live Capture and
 // does not cache — identical observable behaviour to Capture for those inputs.
 func CaptureCached(repoPath string) Info {
+	info, _ := CaptureCachedTrusted(repoPath)
+	return info
+}
+
+// CaptureCachedTrusted is CaptureCached plus the trust flag captureStatus
+// already computes but which CaptureCached had no way to report (#5822 D).
+//
+// ok == false means one thing only: git could not be RUN to completion — the 2s
+// deadline fired, fork returned EAGAIN under load, or the child was signalled
+// (OOM killer, jetsam, a propagated SIGTERM). The returned Info then describes
+// the MOMENT, not the repository.
+//
+// A path git ran against and answered about — including "not a git repository"
+// and a detached HEAD's empty symbolic-ref — is ok == true with a possibly-empty
+// Ref, because that empty Ref is a durable fact about the repo.
+//
+// Why the distinction has to escape this package: an empty Ref is turned into
+// the "_unknown" state directory by daemon.RefSafeEncode, and no graph ever
+// lives there. For a detached HEAD that is correct — it is where the graph
+// really goes. For a fork failure it is a fabrication, and it made `grafel
+// status` render the repo as "0 entities · indexed (never)", which is
+// indistinguishable from a repo that has genuinely never been indexed. #6181
+// stopped MEMOIZING that value; callers were still handed it.
+//
+// LAST-KNOWN FALLBACK. When the capture cannot be run but this process has
+// already captured this repo before, the previous Info is served (ok == true)
+// even though the HEAD-pointer key has moved on. The memo is keyed on HEAD's
+// (path, mtime, size), so a HEAD rewrite invalidates it — and a rewrite
+// coinciding with an un-runnable git is precisely when the caller would
+// otherwise be handed the sentinel. The stale ref MAY be wrong (HEAD may have
+// just moved to another branch); the sentinel is wrong by construction. The
+// stale entry is served, never re-memoized, so the next successful capture
+// replaces it.
+func CaptureCachedTrusted(repoPath string) (Info, bool) {
 	if repoPath == "" {
-		return Capture(repoPath)
+		return captureStatus(repoPath)
 	}
 	key, ok := headPointerKey(repoPath)
 	if !ok {
 		// Not a resolvable git checkout: behave exactly like Capture.
-		return Capture(repoPath)
+		return captureStatus(repoPath)
 	}
 
 	captureMu.Lock()
-	if ent, hit := captureCache[repoPath]; hit && ent.headStat == key {
-		captureMu.Unlock()
-		return ent.info
-	}
+	prev, hasPrev := captureCache[repoPath]
 	captureMu.Unlock()
+	if hasPrev && prev.headStat == key {
+		return prev.info, true
+	}
 
 	info, trusted := captureStatus(repoPath)
 	if !trusted {
@@ -357,13 +391,19 @@ func CaptureCached(repoPath string) Info {
 		// This is deliberately narrower than "don't cache empty results": a path
 		// git ran against and reported "not a git repository" for is a durable
 		// answer and still caches, which is where the optimisation lives.
-		return info
+		if hasPrev {
+			// A stale-but-real ref for this repo beats a sentinel that is wrong
+			// by construction. Not re-memoized: the entry keeps its old key so
+			// the next runnable git still refreshes it.
+			return prev.info, true
+		}
+		return info, false
 	}
 
 	captureMu.Lock()
 	captureCache[repoPath] = captureEntry{info: info, headStat: key}
 	captureMu.Unlock()
-	return info
+	return info, true
 }
 
 // HeadToken returns an opaque token identifying the CURRENT state of repoPath's

--- a/internal/gitmeta/cache_trust_5822_test.go
+++ b/internal/gitmeta/cache_trust_5822_test.go
@@ -1,0 +1,78 @@
+package gitmeta
+
+// cache_trust_5822_test.go — #5822 defect D at the capture layer.
+//
+// #6181 stopped MEMOIZING an untrusted capture, but CaptureCached still RETURNS
+// it, so callers keep receiving Ref == "" — the value that becomes the
+// refs/_unknown sentinel. Two things follow from that:
+//
+//   - a caller that CAN say "unknown" needs the trust flag (CaptureCachedTrusted);
+//   - a long-lived process that has already seen this repo's ref should serve
+//     the last KNOWN ref rather than a sentinel it knows to be wrong.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestCaptureCachedTrusted_ReportsDistrust is the flag itself.
+func TestCaptureCachedTrusted_ReportsDistrust(t *testing.T) {
+	generousDeadline(t)
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	if info, ok := CaptureCachedTrusted(dir); !ok || info.Ref != "main" {
+		t.Fatalf("healthy git: got (%+v, %v), want (Ref=main, true)", info, ok)
+	}
+
+	resetCaptureCacheForTest() // no last-known value to fall back on
+	calls := withGitUnavailable(t)
+	info, ok := CaptureCachedTrusted(dir)
+	if *calls == 0 {
+		t.Fatal("seam was never exercised — the test is not testing anything")
+	}
+	if ok {
+		t.Fatalf("un-runnable git reported as trusted: %+v — Ref==%q then becomes the "+
+			"refs/_unknown sentinel with no way for the caller to notice (#5822 D)", info, info.Ref)
+	}
+}
+
+// TestCaptureCachedTrusted_ReusesLastKnownRef covers the long-lived-process
+// half. The memo is keyed on the HEAD pointer's (path, mtime, size), so a HEAD
+// REWRITE invalidates it — and if git happens to be un-runnable at that exact
+// moment, the caller used to be handed "" even though the process had a
+// perfectly good ref for this repo a moment earlier. A stale-but-real ref beats
+// a sentinel that is certainly wrong.
+func TestCaptureCachedTrusted_ReusesLastKnownRef(t *testing.T) {
+	generousDeadline(t)
+	resetCaptureCacheForTest()
+	dir := initGitRepo(t)
+
+	if got := CaptureCached(dir); got.Ref != "main" {
+		t.Fatalf("fixture broken: first capture Ref=%q, want main", got.Ref)
+	}
+
+	// Invalidate the memo the way production does — by moving HEAD's mtime —
+	// so the un-runnable capture below is actually REACHED rather than served
+	// from cache (which would make this test prove nothing).
+	head := filepath.Join(dir, ".git", "HEAD")
+	past := time.Now().Add(-time.Hour)
+	if err := os.Chtimes(head, past, past); err != nil {
+		t.Fatal(err)
+	}
+	before, okKey := headPointerKey(dir)
+	if !okKey {
+		t.Fatal("fixture broken: HEAD pointer no longer resolvable")
+	}
+	_ = before
+
+	withGitUnavailable(t)
+	info, ok := CaptureCachedTrusted(dir)
+	if info.Ref != "main" || !ok {
+		t.Fatalf("got (Ref=%q, %v), want (main, true): the process already knew this "+
+			"repo's ref and threw it away in favour of the _unknown sentinel (#5822 D)",
+			info.Ref, ok)
+	}
+}


### PR DESCRIPTION
Two defects from a contributor's field report on a 449k-entity graph. They looked independent and are not — both come from `status` re-deriving each repo's per-ref state directory from **live git at display time** instead of from what the caller asked for or what is on disk. Fixed as one change.

## `--ref` was inert, and the note made it worse

`ComputeStatusSummary` took no ref parameter. `--ref` was consumed only to print `Note: showing state for ref "X"`, then dropped; every repo resolved through `StateDirForRepo` → whatever HEAD points at right now.

So `grafel status --ref main` asserted it was showing `main` and then showed you something else. The reporter saw this as "`--ref` picks a transient branch" — a worktree moves HEAD onto a short-lived branch and that is what you get. The help text ("the registry view is filtered to repos that have a graph stored for that ref") described behaviour that did not exist.

`ComputeStatusSummaryForRef` threads the resolved ref through and goes straight to `StateDirForRepoRef` — no git capture at all when a ref is named. `ComputeStatusSummary` remains as a wrapper so ~20 existing call sites are untouched. The note and the numbers now describe the same thing, and the help text describes what the code does.

**`--ref @all` is refused rather than silently ignored.** It never had an implementation — the note *was* the implementation, with the current-HEAD view rendered underneath. Printing a per-ref breakdown promise and then not delivering one is the same defect in a second costume, so `runStatus` now errors before printing anything. A test that previously pinned the misleading behaviour now pins the refusal.

## Counts swung between runs because an unknown ref rendered as a healthy zero

`status` is a fresh process every invocation, so its git cache is always cold and it forks ~5 git processes under a 2s deadline every time. Under memory pressure — the reporter's exact environment — a fork fails or the deadline fires. That yields an empty ref, which encodes to a `_unknown` state directory where no graph exists, so the repo printed `0 entities · 0 rels · indexed (never)` and silently contributed nothing to `TOTAL`. Next run, git succeeded and the numbers came back.

The harm is not the flicker. It is that **a repo whose ref could not be determined was indistinguishable from a repo that genuinely has no graph.**

`CaptureCachedTrusted` now surfaces the `trusted` flag `captureStatus` already computed, and `StateDirForRepoResolved` propagates it. `StateDirForRepo`'s signature is unchanged for callers that cannot act on the difference. Two behaviours follow:

- a long-lived process reuses its **last known ref** rather than the sentinel (served, never re-memoized);
- a cold process — which is what `status` is — renders the repo as `state UNKNOWN`, reports counts as UNAVAILABLE rather than zero, and marks `TOTAL` INCOMPLETE.

`0 entities · indexed (never)` is never printed for a ref that simply could not be resolved.

## Mutants

Nine, all killed. The one worth naming is **M9 — the call site drops the ref again**, which **initially survived**: the unit tests proved the summary *can* honour a ref, but nothing proved the command *asks* it to. That is precisely the original defect's shape, and it is the third time recently this repo has had a test assert on a path production does not take. Its failure output is now the bug itself:

```
status --ref feature-x did not report feature-x's graph — the note claims
one ref and the numbers come from HEAD (#5822 C)
  Note: showing state for ref "feature-x".
  testrepo   0 files   111 entities   222 rels   indexed 5m ago
```

Others: `CaptureCachedTrusted` returning `true` for an untrusted capture; deleting the last-known-ref fallback; `StateDirForRepoResolved` always returning `ok=true`; deleting the `!refKnown` guard; ignoring the requested ref; deleting the `RefUnknown` render branch; dropping `RefUnknown` from the TOTAL-incomplete predicate; removing the `@all` refusal. All reverted by byte-level backup with verified shasums.

## What this does NOT fix, and one correction

The reported ~2× relationship over-count is **not addressed** — the write path was traced end to end and the sidecar equals the committed graph by construction, so it is not a counting bug. Two read-side surfaces would produce the same symptom and the reporter has been asked for the two data points that decide it.

**Correction to an earlier read.** A 3-OS matrix run showed `internal/gitmeta`'s #6181 tests red on macOS and Linux, and the initial reading was that #6181's fix was broken and this defect was worse than reported. That was wrong, and measuring it showed why: the test stub is `#!/bin/sh\nsleep 30` with `PATH` set to a directory containing only the `git` stub — so the child shell cannot find `sleep`, prints `sleep: command not found`, and exits **127 instantly**. 127 is a genuine non-zero exit, correctly classified as a durable answer, and the deadline branch is never reached. It passes locally only because the child is killed during process startup, before it reaches the `sleep` line.

So the fixture is environment-dependent in both directions — a false RED on fast runners, and green for the wrong reason elsewhere, since it exercises killed-at-startup rather than a wedged git. **#6181's production code is correct and this defect is not worse than reported.** The test harness is filed separately.

The new fixtures here are immune to that class: they use the shell **builtin** `kill -9 $$`, so there is no PATH lookup and no timing dependence, and each test also asserts the healthy path over the same fixture — so a stub that silently failed to take effect would be caught.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, and `./internal/cli/... ./internal/gitmeta/... ./internal/daemon/...` exit 0 with zero FAIL lines.

Refs #5822
