### PR TITLE
fix(ci): nine tests that had never been able to pass off macOS — three were production bugs

### DIFF
--- a/cmd/grafel/group_algo_cpu_budget_6108_test.go
+++ b/cmd/grafel/group_algo_cpu_budget_6108_test.go
@@ -200,11 +200,23 @@ func TestGroupAlgoProgress_EmitsPhaseAndCPU(t *testing.T) {
 	stop := startGroupAlgoProgress(context.Background(), "gProg", "in-process")
 	deadline := time.Now().Add(5 * time.Second)
 	var out string
+	// Wait for the cpu_pct-bearing line, not merely for the first progress
+	// line.
+	//
+	// This is belt, not the fix, and the distinction matters because an earlier
+	// revision of this comment got it wrong. cpu_pct is a delta, but
+	// startGroupAlgoProgress SEEDS lastCPU/cpuOK from a CPUTimeSeconds call
+	// before the ticker goroutine starts, so the very first tick already carries
+	// the field: there was no race on unix. The Windows failure was
+	// process.CPUTimeSeconds erroring unconditionally, which left cpuOK false
+	// forever — fixed in internal/process, not here. What this loop now buys is
+	// that a single failed sample (the seeding call losing a race with process
+	// start, say) shifts the field one tick later instead of failing the test.
 	for time.Now().Before(deadline) {
 		mu.Lock()
 		out = buf.String()
 		mu.Unlock()
-		if strings.Contains(out, "group-algo: progress") {
+		if strings.Contains(out, "group-algo: progress") && strings.Contains(out, "cpu_pct=") {
 			break
 		}
 		time.Sleep(5 * time.Millisecond)

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -118,6 +118,26 @@ func (m *systemdManager) WriteUnit() error {
 	}
 	// Reload so systemd picks up the (re)written unit file. Non-fatal if the
 	// user systemd manager isn't reachable yet — Load surfaces real failures.
+	return daemonReload()
+}
+
+// daemonReload runs the post-write `systemctl --user daemon-reload`.
+//
+// It is a package var so a test can exercise WriteUnit — a pure file-rendering
+// contract — without the reload. There is no way to write that test otherwise:
+// the reload is unconditional inside WriteUnit, and watchers.GuardServiceCall
+// (correctly) PANICS on any mutating verb reaching a real service manager from
+// a test process, so TestWriteUnit_RewritesLegacyDaemonUnitToServe died on
+// Linux the moment CI got far enough to run it. Substituting the reload is the
+// fix the guard's own message asks for ("install a fake runner"); adding
+// daemon-reload to the read-only allowlist would NOT be, because the allowlist
+// only stops the panic — the real exec.Command below would still run against
+// the developer's live user manager.
+//
+// Substituting it is unsynchronised, so a test that swaps it must not be
+// parallel. Nothing in this package calls t.Parallel(), and the var is never
+// written in production.
+var daemonReload = func() error {
 	if err := guardSystemctl("daemon-reload"); err != nil {
 		return err
 	}

--- a/internal/daemon/service/systemd_rewrite_linux_test.go
+++ b/internal/daemon/service/systemd_rewrite_linux_test.go
@@ -59,6 +59,16 @@ func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
 		t.Fatalf("newServiceManager: %v", err)
 	}
 
+	// WriteUnit ends in `systemctl --user daemon-reload`, which is a REAL
+	// mutating call against whatever user manager the process can reach —
+	// watchers.GuardServiceCall panics on it, and rightly so. Substitute the
+	// reload and count it, so what is under test stays the rendering contract
+	// while the "WriteUnit asks systemd to re-read" half is still asserted.
+	reloads := 0
+	prevReload := daemonReload
+	daemonReload = func() error { reloads++; return nil }
+	t.Cleanup(func() { daemonReload = prevReload })
+
 	if err := sm.WriteUnit(); err != nil {
 		t.Fatalf("WriteUnit (rewrite pass): %v", err)
 	}
@@ -84,5 +94,8 @@ func TestWriteUnit_RewritesLegacyDaemonUnitToServe(t *testing.T) {
 	}
 	if string(again) != string(rewritten) {
 		t.Errorf("WriteUnit is not idempotent:\nfirst:\n%s\nsecond:\n%s", rewritten, again)
+	}
+	if reloads != 2 {
+		t.Errorf("daemon-reload ran %d times, want one per WriteUnit (2)", reloads)
 	}
 }

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -295,6 +295,15 @@ func Apply(opts Options) (*Result, error) {
 					res.WatcherWarnings = append(res.WatcherWarnings,
 						fmt.Sprintf("could not retire the previous watcher unit for %s: %v", repo, merr))
 				}
+				// And the pre-slash-normalisation label (NativeDigestOf): a
+				// Windows install written before pathDigest normalised
+				// separators sits under a name neither the current nor the
+				// pre-#6183 derivation produces. A no-op off Windows and once
+				// migrated — one stat either way.
+				if _, merr := watchers.MigrateNativeDigestUnit(u, newWatcherLoader); merr != nil {
+					res.WatcherWarnings = append(res.WatcherWarnings,
+						fmt.Sprintf("could not retire the superseded watcher unit for %s: %v", repo, merr))
+				}
 				path, err := watchers.Write(u)
 				if err != nil {
 					// #6185/#6186 R3: a per-repo watchers.Write failure (e.g.

--- a/internal/install/watchers/migrate_6183_test.go
+++ b/internal/install/watchers/migrate_6183_test.go
@@ -3,6 +3,7 @@ package watchers
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -256,5 +257,104 @@ func TestMigrateLegacyUnit_DeregistersBeforeDeleting(t *testing.T) {
 	}
 	if _, err := os.Stat(legacyPath); !os.IsNotExist(err) {
 		t.Fatalf("legacy unit file survived: %v", err)
+	}
+}
+
+// ── The pre-slash-normalisation label ────────────────────────────────────────
+
+// windowsClean is filepath.Clean's Windows behaviour, spelled for a host that
+// is not Windows: it is what makes the superseded derivation reachable — and
+// therefore testable — from darwin and linux.
+func windowsClean(s string) string {
+	return strings.ReplaceAll(filepath.Clean(s), "/", `\`)
+}
+
+// TestMigrateNativeDigestUnit_BootsOutThenRemoves is the migration half of the
+// slash normalisation, and it is the same defect as #6183 one derivation later.
+//
+// pathDigest now hashes the SLASH-NORMALISED path, so a Windows machine's units
+// — hashed over filepath.Clean's backslash form — are all renamed by an
+// upgrade. Nothing else in the tree can derive the old name: reconcile stats
+// the current and pre-#6183 labels only, finds neither, counts the repo Absent
+// and does nothing, while the old `.xml` and (worse) its REGISTERED SCHEDULED
+// TASK stay put and keep spawning `grafel watch`. Then install writes the new
+// label beside it. Two watchers per repo.
+func TestMigrateNativeDigestUnit_BootsOutThenRemoves(t *testing.T) {
+	migrateSandbox(t)
+	restore := SetNativeCleanForTest(windowsClean)
+	t.Cleanup(restore)
+
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+	old := NativeDigestOf(u)
+	if old.Label() == u.Label() {
+		t.Fatalf("precondition: the superseded label must differ from the current one (%q)", u.Label())
+	}
+	oldPath, err := NativeDigestUnitPath(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	writeRawUnit(t, oldPath)
+
+	rec := &recordingLoader{}
+	removed, err := MigrateNativeDigestUnit(u, rec.ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != oldPath {
+		t.Fatalf("removed = %q, want %q", removed, oldPath)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("the superseded unit file survived: %v", err)
+	}
+	// Deleting the file is NOT enough: on Windows the scheduled task is
+	// registered under the label, independently of the .xml, and only Unload
+	// (schtasks /delete /tn <label>) removes it.
+	if len(rec.unloaded) != 1 || rec.unloaded[0] != old.Label() {
+		t.Fatalf("unloaded = %v, want exactly [%s] — the scheduled task outlives the file",
+			rec.unloaded, old.Label())
+	}
+}
+
+// TestMigrateNativeDigestUnit_IsANoOpWhereTheDerivationsCoincide: off Windows
+// the superseded and current derivations are the same string, and a migration
+// that did not notice would boot out and delete the LIVE unit on every install.
+func TestMigrateNativeDigestUnit_IsANoOpWhereTheDerivationsCoincide(t *testing.T) {
+	migrateSandbox(t)
+	u := Unit{Group: "g", Repo: filepath.Join(t.TempDir(), "api"), BinPath: "/bin/grafel"}
+	path, err := Write(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	if NativeDigestOf(u).Label() != u.Label() {
+		t.Skip("this host's native clean differs from the slash form; covered by the migration test")
+	}
+
+	rec := &recordingLoader{}
+	removed, err := MigrateNativeDigestUnit(u, rec.ctor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed != "" {
+		t.Fatalf("removed %q — that is the repo's LIVE unit", removed)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("the live unit was deleted: %v", err)
+	}
+	if rec.made != 0 || len(rec.unloaded) != 0 {
+		t.Fatalf("constructed %d loaders and unloaded %v; a coincident derivation must cost nothing",
+			rec.made, rec.unloaded)
+	}
+}
+
+// writeRawUnit writes a placeholder unit file at path. The superseded unit is
+// addressed by RawLabel, which Unit documents as unusable for Write/Render, so
+// the file is created directly rather than through Write.
+func writeRawUnit(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("superseded unit\n"), 0o644); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/install/watchers/systemd_percent_6185_test.go
+++ b/internal/install/watchers/systemd_percent_6185_test.go
@@ -51,6 +51,17 @@ func TestSystemdUnit_EscapesPercent(t *testing.T) {
 // TestSystemdUnit_SystemdAnalyzeVerify runs systemd-analyze verify over a
 // generated unit where available — the systemd-side equivalent of the
 // plutil -lint test that pins the macOS half of #6179.
+//
+// The units are built over paths this test CREATES rather than over the
+// package's `sample` / `percentHostile` fixtures. systemd-analyze does not stop
+// at syntax: it stats ExecStart and fails the whole run with "Command
+// /usr/local/bin/grafel is not executable: No such file or directory" on any
+// machine where that fixture path does not happen to exist — which is every CI
+// runner, and is why this test had never passed on Linux. Verifying against a
+// real binary keeps the assertion (verify must ACCEPT the unit) intact and adds
+// one: because systemd resolves `%%` back to a literal `%`, verify finding the
+// file proves the #6185 escaping round-trips through systemd itself, not just
+// through strings.Contains.
 func TestSystemdUnit_SystemdAnalyzeVerify(t *testing.T) {
 	if runtime.GOOS != "linux" {
 		t.Skip("systemd-analyze is Linux-only")
@@ -59,13 +70,36 @@ func TestSystemdUnit_SystemdAnalyzeVerify(t *testing.T) {
 	if err != nil {
 		t.Skip("systemd-analyze not on PATH")
 	}
-	for name, u := range map[string]Unit{"plain": sample, "hostile": percentHostile} {
+
+	// realUnit returns a Unit whose BinPath is an executable that exists and
+	// whose Repo is a directory that exists, both named as caller asks so the
+	// hostile case still carries '%' through the generated INI.
+	realUnit := func(t *testing.T, group, repoName, binName string) Unit {
+		t.Helper()
+		dir := t.TempDir()
+		repo := filepath.Join(dir, repoName)
+		if err := os.MkdirAll(repo, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		binPath := filepath.Join(dir, binName)
+		if err := os.WriteFile(binPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		return Unit{Group: group, Repo: repo, BinPath: binPath}
+	}
+
+	units := map[string]Unit{
+		"plain":   realUnit(t, "demo", "core", "grafel"),
+		"hostile": realUnit(t, "R%D", "100%done", "graf%el"),
+	}
+	for name, u := range units {
+		body := SystemdUnit(u)
 		path := filepath.Join(t.TempDir(), name+".service")
-		if err := os.WriteFile(path, []byte(SystemdUnit(u)), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 			t.Fatal(err)
 		}
 		if out, err := exec.Command(bin, "verify", "--no-pager", path).CombinedOutput(); err != nil {
-			t.Errorf("systemd-analyze verify rejected the %s unit: %v\n%s\n%s", name, err, out, SystemdUnit(u))
+			t.Errorf("systemd-analyze verify rejected the %s unit: %v\n%s\n%s", name, err, out, body)
 		}
 	}
 }

--- a/internal/install/watchers/watchers.go
+++ b/internal/install/watchers/watchers.go
@@ -12,6 +12,7 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -191,6 +192,43 @@ func LegacyUnitPath(u Unit) (string, error) {
 	return UnitPath(LegacyOf(u))
 }
 
+// NativeDigestOf returns a copy of u whose Label() is the one this repo was
+// installed under BEFORE pathDigest normalised separators — the digest over
+// filepath.Clean's OS-native output.
+//
+// On unix that derivation and the current one coincide and this returns a unit
+// with the same label, which every caller then treats as "nothing to migrate".
+// On Windows they differ — `/tmp/test/core` cleaned to `\tmp\test\core` digests
+// to e419b067 where the slash form digests to 96d54b5d — and the difference is
+// a machine upgrading across that change: nothing else in the tree can derive
+// e419b067, so ReconcileWatcherUnits (which stats only the current and
+// pre-#6183 labels) sees no unit under any name it knows, counts the repo
+// Absent, and leaves the old `.xml` AND its registered scheduled task in place.
+// `grafel install` then writes the new label beside it: two live watchers per
+// repo, the failure mode MigrateLegacyUnit's own doc calls "strictly worse than
+// the collision it repairs".
+//
+// The label is supplied via RawLabel rather than re-derived from a flag, so the
+// unit is usable for exactly what a migration needs (UnitPath, Unload — both
+// key off Label()) and is refused by Write/Render, which need a real Repo.
+func NativeDigestOf(u Unit) Unit {
+	if u.RawLabel != "" || u.legacy {
+		return u
+	}
+	return Unit{
+		Group:    u.Group,
+		Repo:     u.Repo,
+		BinPath:  u.BinPath,
+		RawLabel: fmt.Sprintf("%s%s.%s-%s", LabelPrefix, u.Group, legacySlugify(u.Repo), nativePathDigest(u.Repo)),
+	}
+}
+
+// NativeDigestUnitPath returns the path a pre-slash-normalisation unit for u
+// occupies on this OS.
+func NativeDigestUnitPath(u Unit) (string, error) {
+	return UnitPath(NativeDigestOf(u))
+}
+
 // MigrateLegacyUnit removes the pre-#6183 unit for u, if one is installed.
 //
 // Changing the label orphans every unit already on disk: the old file stays
@@ -207,7 +245,31 @@ func LegacyUnitPath(u Unit) (string, error) {
 // Idempotent: with no legacy file present it stats one path and returns ("",
 // nil) — no loader, no writes. It returns the removed path when it did work.
 func MigrateLegacyUnit(u Unit, newLoader func() Loader) (string, error) {
-	legacy := LegacyOf(u)
+	return MigrateSupersededUnit(u, LegacyOf(u), newLoader)
+}
+
+// MigrateNativeDigestUnit removes the pre-slash-normalisation unit for u, if
+// one is installed. See NativeDigestOf for what that label is and why it must
+// still be derivable.
+//
+// A no-op off Windows: the superseded and current derivations coincide there,
+// which MigrateSupersededUnit's same-path guard turns into a single stat-free
+// return.
+func MigrateNativeDigestUnit(u Unit, newLoader func() Loader) (string, error) {
+	return MigrateSupersededUnit(u, NativeDigestOf(u), newLoader)
+}
+
+// MigrateSupersededUnit removes the unit u used to be installed under, named
+// by old, if one is on disk.
+//
+// One function for both retired derivations because the ORDER is the whole
+// contract and it must not be re-implemented per derivation: boot the old job
+// out of the scheduler while the file it was bootstrapped from still exists,
+// then delete the file. On Windows the bootout is what removes the registered
+// scheduled task, which lives in Task Scheduler independently of the `.xml` and
+// would otherwise keep spawning `grafel watch` after the file was gone.
+func MigrateSupersededUnit(u, old Unit, newLoader func() Loader) (string, error) {
+	legacy := old
 	legacyPath, err := UnitPath(legacy)
 	if err != nil {
 		return "", err
@@ -246,7 +308,12 @@ func LaunchdPlist(u Unit) string {
 	// (An unused `pl` struct used to sit here describing the plist keys; it was
 	// never marshalled and drifted out of sync with the hand-built body below,
 	// claiming an unconditional KeepAlive bool. Removed with #6179.)
-	logDir := filepath.Join(u.Repo, ".grafel", "logs")
+	// path.Join, not filepath.Join: a launchd plist is a Darwin artifact whose
+	// paths are always POSIX, but this renderer compiles and is tested on every
+	// OS, so filepath.Join emitted `\tmp\repo\.grafel\logs/watcher.out.log` when
+	// the test ran on Windows. On Darwin the two are identical, so nothing the
+	// real platform sees changes.
+	logDir := path.Join(u.Repo, ".grafel", "logs")
 	body := strings.Builder{}
 	body.WriteString(`<?xml version="1.0" encoding="UTF-8"?>` + "\n")
 	body.WriteString(`<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">` + "\n")
@@ -571,6 +638,14 @@ func Cleanup(group, repoPath, binPath string) {
 	// with nothing left in the registry to derive its name from later.
 	_ = loader.Unload(LegacyOf(u))
 	_ = Remove(LegacyOf(u))
+	// And the pre-slash-normalisation label, for the identical reason one
+	// derivation later (NativeDigestOf). Off Windows this repeats the Unload
+	// and Remove already done for the current label — both are idempotent and
+	// "not loaded"/"not present" are the states being asked for anyway.
+	if old := NativeDigestOf(u); old.Label() != u.Label() {
+		_ = loader.Unload(old)
+		_ = Remove(old)
+	}
 }
 
 // newLoader is the Loader constructor Cleanup uses. It is a package var so
@@ -632,8 +707,75 @@ func slugify(s string) string {
 // In both cases a repo registered twice under different spellings gets two
 // watcher units rather than one. That is wasteful, not incorrect, and it is
 // what registering the same repo twice already meant elsewhere in grafel.
+// The digest is taken over the SLASH-normalised form of the cleaned path, not
+// over filepath.Clean's OS-native output. filepath.Clean rewrites separators to
+// the host's, so `/x/api` digests one way on unix and another on Windows (where
+// Clean returns `\x\api`) — the same repo string, two labels, depending only on
+// which OS derived it. Label is documented as platform-agnostic and is asserted
+// against pinned bytes in watchers_test.go, which runs on all three; ToSlash is
+// what makes both true. It preserves the dedup property Clean provides, since
+// `C:\r\api` and `C:/r/api` still land on one string.
+//
+// ToSlash is a NO-OP on unix, so this rename lands on Windows alone — and a
+// rename is exactly the orphaning MigrateLegacyUnit exists to prevent. See
+// NativeDigestOf for the superseded derivation and the migration that retires
+// it.
 func pathDigest(s string) string {
-	sum := sha256.Sum256([]byte(filepath.Clean(s)))
+	return digestOf(filepath.ToSlash(filepath.Clean(s)))
+}
+
+// nativePathDigest is the SUPERSEDED digest: SHA-256 over filepath.Clean's
+// OS-native output, with no slash normalisation.
+//
+// It is retained for exactly the reason legacySlugify is — a label that is no
+// longer derived is a unit that can no longer be found, and on Windows a unit
+// that cannot be found is a REGISTERED SCHEDULED TASK that keeps spawning
+// `grafel watch` forever (loader_windows.go keys /tn off Label()). Off Windows
+// this is byte-identical to pathDigest, so the migration built on it is a
+// self-cancelling no-op there rather than dead code that only one platform's CI
+// ever exercises.
+//
+// Do not use it for new units.
+func nativePathDigest(s string) string {
+	return digestOf(cleanForNativeDigest(s))
+}
+
+// cleanForNativeDigest is filepath.Clean, as a seam.
+//
+// The superseded derivation is host-native BY DEFINITION — that is the whole
+// defect — so off Windows it coincides with the current one, and every test of
+// the migration built on it would be vacuous on the only platforms this repo's
+// developers and two of its three CI legs can run. The seam lets a darwin or
+// linux test spell the Windows form and drive the real migration and its real
+// wiring, so deleting either fails a test HERE instead of orphaning a watcher
+// on a machine nobody has. Production never replaces it.
+var cleanForNativeDigest = filepath.Clean
+
+// SetNativeCleanForTest replaces the path-cleaning step of the SUPERSEDED
+// digest derivation and returns a restore func.
+//
+// TEST-ONLY, and exported for the same reason StubServiceCallsForTest is: the
+// caller that has to be exercised is in ANOTHER package
+// (internal/install.ReconcileWatcherUnits), so export_test.go cannot reach it.
+// Do not call it from non-test code.
+func SetNativeCleanForTest(clean func(string) string) (restore func()) {
+	prev := cleanForNativeDigest
+	cleanForNativeDigest = clean
+	return func() { cleanForNativeDigest = prev }
+}
+
+// digestOf is the raw digest — pathDigestLen hex chars of SHA-256 over the
+// bytes given, with no cleaning and no separator rewriting.
+//
+// Split out from pathDigest so both derivations are one normalisation step over
+// a shared primitive, and so watchers_test.go can pin each of them against a
+// LITERAL string on every platform. That matters: TestLabelStable's pinned
+// constant is the canary for "any change to the derivation is a deliberate edit
+// here", and a canary expressed only through a host-dependent normalisation is
+// structurally blind on the host it is not running on. It was: the ToSlash
+// change left the unix bytes identical and the test never moved.
+func digestOf(s string) string {
+	sum := sha256.Sum256([]byte(s))
 	return hex.EncodeToString(sum[:])[:pathDigestLen]
 }
 

--- a/internal/install/watchers/watchers_test.go
+++ b/internal/install/watchers/watchers_test.go
@@ -1,6 +1,7 @@
 package watchers
 
 import (
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -10,12 +11,50 @@ var sample = Unit{Group: "demo", Repo: "/tmp/test/core", BinPath: "/usr/local/bi
 // TestLabelStable pins the exact label bytes. The digest suffix landed with
 // #6183 (see Label); this test exists so any further change to the derivation
 // is a deliberate edit here, because changing it renames every installed unit.
+//
+// It pins TWO digests, and the second one is the lesson. Until the slash
+// normalisation went in, this test held one constant over sample.Repo — and
+// sample.Repo is spelled with forward slashes, which is the form the
+// normalisation leaves untouched. So the canary was structurally blind on
+// Windows: the derivation changed there, every installed unit was renamed, and
+// the constant guarding exactly that did not move. A pinned constant is only a
+// canary for the platform whose bytes it happens to describe, so both
+// derivations are now pinned over LITERAL strings — which is host-independent
+// and therefore checks on all three legs.
 func TestLabelStable(t *testing.T) {
 	if got := sample.Label(); got != "com.grafel.watcher.demo.core-96d54b5d" {
 		t.Fatalf("label: %q", got)
 	}
 	if got := LegacyOf(sample).Label(); got != "com.grafel.watcher.demo.core" {
 		t.Fatalf("legacy label: %q", got)
+	}
+
+	// The current derivation hashes the slash-normalised path on every OS.
+	if got := digestOf("/tmp/test/core"); got != "96d54b5d" {
+		t.Fatalf("current digest derivation moved: %q, want 96d54b5d — every installed unit is renamed", got)
+	}
+	// The SUPERSEDED derivation hashed filepath.Clean's output, which on
+	// Windows is the backslash form. This is the label Windows machines have
+	// on disk and in Task Scheduler today; NativeDigestOf must keep reaching
+	// it, or the migration cannot name what it has to retire.
+	if got := digestOf(`\tmp\test\core`); got != "e419b067" {
+		t.Fatalf("superseded digest derivation moved: %q, want e419b067 — "+
+			"the Windows migration can no longer name the unit it must retire", got)
+	}
+
+	// And that the superseded derivation is wired to those bytes: on Windows it
+	// must produce the old label, everywhere else it must collapse onto the
+	// current one so the migration built on it is a no-op rather than a
+	// deletion of a live unit.
+	native := NativeDigestOf(sample).Label()
+	if runtime.GOOS == "windows" {
+		if native != "com.grafel.watcher.demo.core-e419b067" {
+			t.Fatalf("superseded label on windows: %q", native)
+		}
+	} else if native != sample.Label() {
+		t.Fatalf("off windows the superseded label must equal the current one "+
+			"(%q vs %q); a difference here means the migration would retire a LIVE unit",
+			native, sample.Label())
 	}
 }
 

--- a/internal/install/watchersync.go
+++ b/internal/install/watchersync.go
@@ -120,11 +120,16 @@ type ReconcileWatcherResult struct {
 // writes and constructs no Loader, which is what keeps an up-to-date machine a
 // pure read (#6179).
 type watcherPlan struct {
-	unit         watchers.Unit
-	path         string // unit path under the current label
-	legacyPath   string // unit path under the pre-#6183 label
+	unit       watchers.Unit
+	path       string // unit path under the current label
+	legacyPath string // unit path under the pre-#6183 label
+	// nativePath is the unit path under the pre-slash-normalisation label —
+	// the digest over filepath.Clean's OS-native output. Empty off Windows,
+	// where that derivation coincides with the current one.
+	nativePath   string
 	exists       bool   // a unit file exists at path
 	legacyExists bool   // a unit file exists at legacyPath
+	nativeExists bool   // a unit file exists at nativePath
 	body         []byte // contents of path, when it exists
 	statErr      error  // the ReadFile error (may be os.ErrNotExist)
 	readErr      error  // a REAL read failure, worth warning about
@@ -155,6 +160,19 @@ func planWatcherUnits(group string, cfg *registry.GroupConfig, binPath string, r
 			pl.legacyPath = legacyPath
 			if _, serr := os.Stat(legacyPath); serr == nil {
 				pl.legacyExists = true
+			}
+		}
+
+		// The pre-slash-normalisation label, probed in the same phase-1 pass
+		// and for the same reason: a derivation nothing stats is a unit that
+		// stays installed and loaded under a name this binary can no longer
+		// utter. The `!= path` guard is what makes this cost one stat and find
+		// nothing off Windows, where the two derivations coincide.
+		nativePath, nerr := watchers.NativeDigestUnitPath(u)
+		if nerr == nil && nativePath != path && nativePath != legacyPath {
+			pl.nativePath = nativePath
+			if _, serr := os.Stat(nativePath); serr == nil {
+				pl.nativeExists = true
 			}
 		}
 
@@ -263,10 +281,18 @@ func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResul
 						res.Migrated = append(res.Migrated, removed)
 					}
 				}
+				if pl.nativeExists {
+					if removed, merr := watchers.MigrateNativeDigestUnit(u, lazyLoader); merr != nil {
+						res.Warnings = append(res.Warnings,
+							fmt.Sprintf("retire superseded unit %s: %v", pl.nativePath, merr))
+					} else if removed != "" {
+						res.Migrated = append(res.Migrated, removed)
+					}
+				}
 				continue
 			}
 
-			if !pl.exists && !pl.legacyExists {
+			if !pl.exists && !pl.legacyExists && !pl.nativeExists {
 				// No unit under either label, and no colliding sibling that
 				// proves one used to cover this repo — not stale, not storming,
 				// and not something to create: installing missing units is
@@ -293,6 +319,23 @@ func ReconcileWatcherUnits(opts ReconcileWatcherOptions) (*ReconcileWatcherResul
 				if merr != nil {
 					res.Warnings = append(res.Warnings,
 						fmt.Sprintf("retire legacy unit %s: %v", legacyPath, merr))
+					continue
+				}
+				if removed != "" {
+					res.Migrated = append(res.Migrated, removed)
+				}
+			}
+
+			// Same, for the pre-slash-normalisation label. Separate because
+			// the two superseded derivations are independent: a Windows
+			// machine that upgraded through #6183 and then through the
+			// normalisation has a unit under BOTH, and retiring only one
+			// leaves the other registered.
+			if pl.nativeExists {
+				removed, merr := watchers.MigrateNativeDigestUnit(u, lazyLoader)
+				if merr != nil {
+					res.Warnings = append(res.Warnings,
+						fmt.Sprintf("retire superseded unit %s: %v", pl.nativePath, merr))
 					continue
 				}
 				if removed != "" {

--- a/internal/install/watchersync_slugdigest_test.go
+++ b/internal/install/watchersync_slugdigest_test.go
@@ -1,0 +1,221 @@
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+)
+
+// windowsClean is filepath.Clean's Windows behaviour, spelled for a host that
+// is not Windows. watchers.SetNativeCleanForTest takes it so the SUPERSEDED
+// label derivation — which is host-native by definition — is reachable from
+// darwin and linux, and so the reconcile wiring that retires it is exercised
+// by the two CI legs that are not Windows.
+func windowsClean(s string) string {
+	return strings.ReplaceAll(filepath.Clean(s), "/", `\`)
+}
+
+// TestReconcileWatcherUnits_RetiresThePreSlashNormalisationUnit.
+//
+// pathDigest now hashes the slash-normalised path. On Windows that renames
+// every installed unit, and before this wiring existed NOTHING in the tree
+// could derive the old name: planWatcherUnits stats the current label and the
+// pre-#6183 label, so the machine's actual unit matched neither, the repo was
+// counted Absent, and reconcile did nothing. The stale `.xml` stayed — and with
+// it the REGISTERED SCHEDULED TASK, which loader_windows.go names by Label()
+// and which therefore outlives the file — while `grafel install` wrote the new
+// label alongside. Two live watchers per repo: the #6197 orphan mode, and the
+// outcome MigrateLegacyUnit's doc calls strictly worse than the collision it
+// repairs.
+//
+// This is the mutant test for the migration: delete the nativeExists probe in
+// planWatcherUnits or the MigrateNativeDigestUnit call beside it and this
+// fails, on every platform.
+func TestReconcileWatcherUnits_RetiresThePreSlashNormalisationUnit(t *testing.T) {
+	home := reconcileSandbox(t)
+	restore := watchers.SetNativeCleanForTest(windowsClean)
+	t.Cleanup(restore)
+
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "x", "api")
+	registerGroup(t, home, "g", []string{repo}, true)
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	current, err := watchers.UnitPath(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	old := watchers.NativeDigestOf(u)
+	oldPath, err := watchers.NativeDigestUnitPath(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldPath == current {
+		t.Fatalf("precondition: the superseded path must differ from the current one (%s)", current)
+	}
+
+	// The exact state a Windows machine is in the moment it upgrades across the
+	// normalisation: a unit under the old label, nothing under the new one.
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("superseded unit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fl := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fl }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if res.Absent != 0 {
+		t.Fatalf("the repo was counted Absent (%d): reconcile cannot see the unit it actually has, "+
+			"so the old one is left installed and a new one is written beside it", res.Absent)
+	}
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("the superseded unit file survived at %s: %v", oldPath, err)
+	}
+	if _, err := os.Stat(current); err != nil {
+		t.Fatalf("no unit was written under the current label: %v", err)
+	}
+	// Deleting the file does not deregister the job — on Windows the scheduled
+	// task is registered under the LABEL and survives the .xml.
+	var sawOld bool
+	for _, l := range fl.unloaded {
+		if l == old.Label() {
+			sawOld = true
+		}
+	}
+	if !sawOld {
+		t.Fatalf("the superseded label %s was never deregistered; unloaded=%v — "+
+			"the scheduled task keeps spawning `grafel watch` forever", old.Label(), fl.unloaded)
+	}
+	if len(res.Migrated) != 1 || res.Migrated[0] != oldPath {
+		t.Errorf("Migrated = %v, want [%s]", res.Migrated, oldPath)
+	}
+}
+
+// TestReconcileWatcherUnits_RetiresThePreSlashNormalisationUnitWhenWatchersAreDisabled
+// is the same retirement in the branch where nobody is looking.
+//
+// A group with Features.Watchers=false takes its own arm of the reconcile loop
+// and `continue`s before anything is installed. #6183 established why that arm
+// still has to RETIRE: a superseded unit for a registered repo stays on disk and
+// stays loaded, and re-enabling watchers later would add the new label beside it
+// rather than over it. One derivation later the stakes are higher and the
+// visibility is lower — on Windows the orphan is a registered SCHEDULED TASK
+// spawning `grafel watch` forever, in a group where every signal that would
+// surface it is switched off.
+//
+// The legacy arm of this branch is pinned by
+// TestReconcileWatcherUnits_RetiresLegacyUnitWhenWatchersAreDisabled; this is
+// its counterpart, and the mutant test for the second wiring site.
+func TestReconcileWatcherUnits_RetiresThePreSlashNormalisationUnitWhenWatchersAreDisabled(t *testing.T) {
+	home := reconcileSandbox(t)
+	restore := watchers.SetNativeCleanForTest(windowsClean)
+	t.Cleanup(restore)
+
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "repos", "api")
+	registerGroup(t, home, "g", []string{repo}, false) // watchers OFF
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	current, err := watchers.UnitPath(u)
+	if err != nil {
+		t.Skipf("unsupported OS: %v", err)
+	}
+	old := watchers.NativeDigestOf(u)
+	oldPath, err := watchers.NativeDigestUnitPath(u)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if oldPath == current {
+		t.Fatalf("precondition: the superseded path must differ from the current one (%s)", current)
+	}
+	if err := os.MkdirAll(filepath.Dir(oldPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(oldPath, []byte("superseded unit\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	fl := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fl }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+		t.Fatalf("the superseded unit survived at %s in a watchers-disabled group: %v", oldPath, err)
+	}
+	var sawOld bool
+	for _, l := range fl.unloaded {
+		if l == old.Label() {
+			sawOld = true
+		}
+	}
+	if !sawOld {
+		t.Fatalf("the superseded label %s was never deregistered; unloaded=%v — the scheduled "+
+			"task outlives the file, in the group least likely to be watched", old.Label(), fl.unloaded)
+	}
+	if len(res.Migrated) != 1 || res.Migrated[0] != oldPath {
+		t.Errorf("Migrated = %v, want [%s]", res.Migrated, oldPath)
+	}
+	// And nothing may be installed: watchers are off, and that is the whole
+	// meaning of the flag.
+	if _, err := os.Stat(current); !os.IsNotExist(err) {
+		t.Fatalf("reconcile installed a watcher for a group with watchers disabled")
+	}
+	if len(res.Reloaded) != 0 {
+		t.Fatalf("Reloaded = %v, want nothing registered", res.Reloaded)
+	}
+}
+
+// TestReconcileWatcherUnits_LeavesTheLiveUnitAloneWhereDerivationsCoincide is
+// the other half: with the host's native clean in force (the real production
+// case off Windows) the superseded derivation IS the current one, and a
+// migration that did not notice would boot out and delete the live unit on
+// every reconcile.
+func TestReconcileWatcherUnits_LeavesTheLiveUnitAloneWhereDerivationsCoincide(t *testing.T) {
+	home := reconcileSandbox(t)
+	bin := filepath.Join(home, "bin", "grafel")
+	repo := filepath.Join(home, "x", "api")
+	registerGroup(t, home, "g", []string{repo}, true)
+
+	u := watchers.Unit{Group: "g", Repo: repo, BinPath: bin}
+	if watchers.NativeDigestOf(u).Label() != u.Label() {
+		t.Skip("this host's native clean differs from the slash form; covered by the migration test")
+	}
+	path := writeUnitFile(t, u, watchers.Render(u))
+
+	fl := &fakeLoader{}
+	prev := newWatcherLoader
+	newWatcherLoader = func() watchers.Loader { return fl }
+	t.Cleanup(func() { newWatcherLoader = prev })
+
+	res, err := ReconcileWatcherUnits(ReconcileWatcherOptions{BinPath: bin})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("reconcile deleted the live unit: %v", err)
+	}
+	if len(res.Migrated) != 0 {
+		t.Fatalf("Migrated = %v; a coincident derivation must retire nothing", res.Migrated)
+	}
+	if res.Current != 1 {
+		t.Errorf("Current = %d, want 1 (an up-to-date unit is left alone)", res.Current)
+	}
+}

--- a/internal/mcp/data_flows_db_edge_4299_test.go
+++ b/internal/mcp/data_flows_db_edge_4299_test.go
@@ -27,7 +27,7 @@ func docWithJoinEdge(repo, kind string) *graph.Document {
 // data_flows(sink_kind=db). Before the fix handleDataFlows read only the taint
 // sidecar, so this returned 0.
 func TestDataFlows_JoinsCollectionProjectedAsDBSink(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // no sidecar — pure graph-edge projection
+	sandboxGrafelHome(t) // no sidecar — pure graph-edge projection
 	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
 
 	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
@@ -77,7 +77,7 @@ func TestDataFlows_DBEdgeSiblingsProjected(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.kind, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
+			sandboxGrafelHome(t)
 			srv := newTestServer(t, docWithJoinEdge("repo-a", c.kind))
 			out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
 			flows, _ := out["data_flows"].([]any)
@@ -94,7 +94,7 @@ func TestDataFlows_DBEdgeSiblingsProjected(t *testing.T) {
 // TestDataFlows_NonDBEdgeNotProjected is the negative: a non-DB semantic edge of
 // the same node shape (THROWS) must NOT be projected as a db sink.
 func TestDataFlows_NonDBEdgeNotProjected(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	sandboxGrafelHome(t)
 	srv := newTestServer(t, docWithJoinEdge("repo-a", "THROWS"))
 	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db"})
 	flows, _ := out["data_flows"].([]any)
@@ -111,7 +111,7 @@ func TestDataFlows_NonDBEdgeNotProjected(t *testing.T) {
 // TestDataFlows_NonDBSinkKindFilterExcludesGraphEdges asserts a non-db sink_kind
 // filter (http) excludes the graph-edge DB projection entirely.
 func TestDataFlows_NonDBSinkKindFilterExcludesGraphEdges(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	sandboxGrafelHome(t)
 	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
 	out := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "http"})
 	flows, _ := out["data_flows"].([]any)
@@ -124,7 +124,7 @@ func TestDataFlows_NonDBSinkKindFilterExcludesGraphEdges(t *testing.T) {
 // filter db_read selects the JOINS_COLLECTION projection (which maps to db_read)
 // and db_write excludes it.
 func TestDataFlows_DBReadFilterMatchesProjectedKind(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	sandboxGrafelHome(t)
 	srv := newTestServer(t, docWithJoinEdge("repo-a", "JOINS_COLLECTION"))
 
 	got := callFlowTool(t, srv.handleDataFlows, map[string]any{"sink_kind": "db_read"})

--- a/internal/mcp/data_flows_tool_test.go
+++ b/internal/mcp/data_flows_tool_test.go
@@ -13,8 +13,7 @@ import (
 // temp HOME so handleDataFlows (which resolves via os.UserHomeDir) reads it.
 func writeDataFlowSidecar(t *testing.T, doc dataFlowSidecarDoc) {
 	t.Helper()
-	home := t.TempDir()
-	t.Setenv("HOME", home)
+	home := sandboxGrafelHome(t)
 	dir := filepath.Join(home, ".grafel", "groups")
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		t.Fatal(err)
@@ -104,7 +103,7 @@ func TestDataFlowsTool_SinkKindFilter(t *testing.T) {
 
 // TestDataFlowsTool_MissingSidecar asserts the honest empty/missing contract.
 func TestDataFlowsTool_MissingSidecar(t *testing.T) {
-	t.Setenv("HOME", t.TempDir()) // no sidecar written
+	sandboxGrafelHome(t) // no sidecar written
 	srv := newTestServer(t, &graph.Document{Repo: "repo-a"})
 	out := callFlowTool(t, srv.handleDataFlows, map[string]any{})
 	if src, _ := out["source"].(string); src != "missing" {

--- a/internal/mcp/field_stub_4669_test.go
+++ b/internal/mcp/field_stub_4669_test.go
@@ -22,7 +22,7 @@ import (
 // docs. Mirrors stubTwoGroupServer but wires the on-disk Path.
 func stubFieldServer(t *testing.T, dir string, v3, oracle *graph.Document) *Server {
 	t.Helper()
-	t.Setenv("HOME", t.TempDir())
+	sandboxGrafelHome(t)
 	reg := &Registry{Groups: map[string]RegistryGroup{
 		"v3":     {Repos: map[string]RegistryRepo{"r": {Path: dir}}},
 		"oracle": {Repos: map[string]RegistryRepo{"r": {Path: dir}}},

--- a/internal/mcp/stub_detector_tool_test.go
+++ b/internal/mcp/stub_detector_tool_test.go
@@ -85,7 +85,7 @@ func callsEdge(from, to string) graph.Relationship {
 func stubTwoGroupServer(t *testing.T, v3 *graph.Document, oracle *graph.Document) *Server {
 	t.Helper()
 	// Isolate the effects-sidecar lookup directory per test.
-	t.Setenv("HOME", t.TempDir())
+	sandboxGrafelHome(t)
 	reg := &Registry{Groups: map[string]RegistryGroup{
 		"v3":     {Repos: map[string]RegistryRepo{"r": {Path: t.TempDir()}}},
 		"oracle": {Repos: map[string]RegistryRepo{"r": {Path: t.TempDir()}}},

--- a/internal/mcp/testhelpers_test.go
+++ b/internal/mcp/testhelpers_test.go
@@ -9,10 +9,44 @@ package mcp
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/cajasmota/grafel/internal/graph"
 )
+
+// sandboxGrafelHome points every grafel-home derivation at a fresh temp dir
+// and returns it, so a test that writes a sidecar can be sure the tool reads
+// THAT one — and a test that writes none can be sure the tool reads nothing.
+//
+// t.Setenv("HOME", …) alone does neither on Windows, which is what failed the
+// four internal/mcp tests in run 31132076151. The grafel-home derivation
+// bottoms out in registry.HomeDir() → os.UserHomeDir(), and os.UserHomeDir()
+// reads %USERPROFILE% on Windows and ignores HOME (#6178). A HOME-only sandbox
+// there resolves to the runner's REAL profile, so the sidecar the test wrote
+// under HOME was invisible and the tool fell back to the entity-property
+// effects — the exact "v3 resolved=false, oracle resolved=true" the stub
+// detector reported. For the isolation-only callers the same gap points the
+// tool at whatever happens to sit in the developer's real ~/.grafel.
+//
+// Both vars are set on every platform: the one that is not consulted is inert,
+// and a per-GOOS switch here would be a second thing to keep correct.
+//
+// GRAFEL_HOME is set too, and it is not redundant — registry.HomeDir() checks
+// it FIRST and returns it verbatim, so a developer who exports it (plausible in
+// this repo) would otherwise have every one of these tests reading and writing
+// their real grafel home no matter what HOME said. CI does not set it, so this
+// is a developer-machine hazard rather than a CI one. The value mirrors what
+// the HOME path resolves to, so the sidecar writers' <home>/.grafel/groups join
+// and the readers' registry.HomeDir() land on the same directory either way.
+func sandboxGrafelHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("GRAFEL_HOME", filepath.Join(home, ".grafel"))
+	return home
+}
 
 // newTestServer builds a minimal Server with one group ("test") loaded from
 // the supplied documents.

--- a/internal/process/process_windows.go
+++ b/internal/process/process_windows.go
@@ -87,12 +87,48 @@ func CPUPercent(_ int) (float64, error) {
 	return 0, fmt.Errorf("process.CPUPercent: unsupported platform windows")
 }
 
-// CPUTimeSeconds is not implemented on Windows. A caller (e.g. the
-// engine-liveness heartbeat's CPU-delta sampler) treats the error as "CPU%
-// unavailable" and simply omits the CPU portion of its readout — RSS is still
-// reported via RSSBytes.
-func CPUTimeSeconds(_ int) (float64, error) {
-	return 0, fmt.Errorf("process.CPUTimeSeconds: unsupported platform windows")
+// CPUTimeSeconds returns the total CPU time (kernel + user) the process with
+// the given pid has consumed, via kernel32!GetProcessTimes.
+//
+// This used to return "unsupported platform windows", and callers duly degraded:
+// the engine-liveness heartbeat and the group-algo progress line both omit their
+// CPU field when the sampler errors. That was a silent hole exactly where the
+// number matters most — the group-algo heartbeat exists so a wedged pass is
+// distinguishable from a slow one (#6108), and on Windows it shipped without the
+// draw beside the cap, which is the comparison the line is for.
+// TestGroupAlgoProgress_EmitsPhaseAndCPU asserts the field unconditionally and
+// so could never pass on Windows.
+//
+// GetProcessTimes needs only PROCESS_QUERY_LIMITED_INFORMATION — the same
+// low-privilege, cross-session handle RSSBytes and IsAlive already open — and
+// reports FILETIMEs in 100-nanosecond units.
+func CPUTimeSeconds(pid int) (float64, error) {
+	if pid <= 0 {
+		return 0, fmt.Errorf("process.CPUTimeSeconds: invalid pid %d", pid)
+	}
+	h, err := windows.OpenProcess(windows.PROCESS_QUERY_LIMITED_INFORMATION, false, uint32(pid))
+	if err != nil {
+		return 0, fmt.Errorf("OpenProcess(%d): %w", pid, err)
+	}
+	defer windows.CloseHandle(h)
+
+	var creation, exit, kernel, user windows.Filetime
+	if err := windows.GetProcessTimes(h, &creation, &exit, &kernel, &user); err != nil {
+		return 0, fmt.Errorf("GetProcessTimes(%d): %w", pid, err)
+	}
+	// NOT Filetime.Nanoseconds(): that helper subtracts the 1601→1970 epoch
+	// offset, which is correct for a wall-clock FILETIME and nonsense for a
+	// DURATION one — kernel and user here are elapsed CPU, not timestamps.
+	// Combine the halves and scale the raw 100ns ticks directly.
+	const ticksPerSecond = 1e7
+	ticks := float64(filetimeTicks(kernel) + filetimeTicks(user))
+	return ticks / ticksPerSecond, nil
+}
+
+// filetimeTicks joins a FILETIME's two 32-bit halves into its raw count of
+// 100-nanosecond intervals, with no epoch adjustment.
+func filetimeTicks(ft windows.Filetime) int64 {
+	return int64(ft.HighDateTime)<<32 | int64(ft.LowDateTime)
 }
 
 // processMemoryCounters mirrors the Win32 PROCESS_MEMORY_COUNTERS struct


### PR DESCRIPTION
The 3-OS matrix had not reached the Test step in weeks — earlier attempts died at `go vet` or were cancelled by a GitHub outage. Run 31132076151 finally ran it and all three legs failed with eleven failures. **None were regressions.** They had accumulated behind a gate that never ran.

Two are a separate test-harness defect, filed as #6223. The other nine are here.

**Three of the nine turned out to be production bugs, not test hygiene.** That is the part worth reading.

## `pathDigest` hashed an OS-native path, so a repo's watcher identity depended on the OS

`internal/install/watchers/watchers.go` hashed `filepath.Clean(s)`, whose output is native: `/tmp/x` on unix, `\tmp\x` on Windows. The same repository therefore produced **different labels on different platforms**:

```
sha256("/tmp/test/core")[:8] = 96d54b5d
sha256("\tmp\test\core")[:8] = e419b067
```

Fixed by hashing `filepath.ToSlash(filepath.Clean(s))`. Unix bytes are unchanged.

### The rename needed a migration, and this is where the change nearly shipped a defect

Correcting the derivation renames every unit already installed on Windows, and `MigrateLegacyUnit`'s own doc states the consequence: *"the old file stays there and stays LOADED under the old identity, while the new label registers alongside it… two watchers per repo — strictly worse than the collision it repairs."* That is #6197's 140-orphan mode.

Neither existing sweep could name the old label. `ReconcileWatcherUnits` stats exactly two paths per repo — the current label and the pre-#6183 basename one — and `InstalledUnits` has a single caller gated on the user explicitly running fleet **stop**, which deactivates rather than deletes. The orphan is also not merely a stale file: `loader_windows.go` uses the label as the schtasks `/tn`, so the **registered scheduled task** survives independently and keeps spawning `grafel watch`.

So the retirement path is explicit: `NativeDigestOf` reconstructs the superseded label, and `MigrateSupersededUnit` (extracted so both retired derivations share one implementation) boots out through `Loader.Unload` — the scheduled task, not just the file — then deletes. Wired into **all four** sites that retire a unit: `planWatcherUnits`, the watchers-disabled branch, `Apply`, and `Cleanup`. Off Windows every one self-cancels on a same-path guard: one stat, no loader, no deletion.

### The canary was blind to the platform it guarded

`TestLabelStable` exists for exactly this — its comment says any change to the derivation must be a deliberate edit *"because changing it renames every installed unit."* But it pinned only unix bytes, the spelling `ToSlash` leaves untouched, so it could not fire on the one platform where the rename happens. It now pins **both** derivations over literal strings, which is host-independent and therefore checks on all three legs, plus the wiring that `NativeDigestOf` equals the current label everywhere except Windows — so the migration can never retire a live unit.

**Honest limit:** on unix, "hash `Clean`" and "hash `ToSlash(Clean)`" are the same function, so no test here can distinguish them; a straight revert of the normalisation is invisible on darwin. What *is* observable everywhere is that the superseded label is derivable and gets retired.

## `CPUTimeSeconds` was unimplemented on Windows

It returned "unsupported platform windows", so the #6108 heartbeat shipped there without the CPU draw beside the cap — the comparison the field exists for. Implemented via `kernel32!GetProcessTimes` under the same `PROCESS_QUERY_LIMITED_INFORMATION` handle `RSSBytes` opens. Deliberately **not** `Filetime.Nanoseconds()`, which subtracts the 1601→1970 epoch offset — correct for a timestamp, nonsense for a duration.

## `TestSystemdUnit_SystemdAnalyzeVerify` could never have passed

`systemd-analyze verify` stats `ExecStart`, and the fixture's `/usr/local/bin/grafel` exists on no runner. The fixture now builds a real executable, which also strengthens the assertion: systemd resolves `%%` back to `%`, so verify finding the file proves #6185's escaping round-trips through systemd rather than merely parsing.

## `WriteUnit` had no seam at all

`internal/daemon/service` ends in an unconditional `systemctl --user daemon-reload`. The isolation guard was not catching something escaping a stub — it was catching that there was no stub. Adding `daemon-reload` to the read-only verb list would have silenced the panic while still hitting the developer's live user manager. It is now a package var the test substitutes and counts.

## `internal/mcp` ×4 — `HOME` alone does not isolate on Windows

`t.Setenv("HOME", …)` only. The grafel-home derivation reaches `os.UserHomeDir()`, which reads `%USERPROFILE%` on Windows and ignores `HOME`, so the sidecars the tests wrote were invisible and the tools fell back to entity-property effects. A shared `sandboxGrafelHome(t)` now sets `HOME`, `USERPROFILE` **and** `GRAFEL_HOME` — the last because `registry.HomeDir()` checks it *first*, which the original helper's docstring overlooked.

This strengthens rather than weakens: `TestDataFlowsTool_MissingSidecar` now genuinely guarantees "no sidecar" instead of hoping the developer's real `~/.grafel` is empty.

## Additional latent instances

- Six more `HOME`-only sandboxes in the same sidecar family, accidentally green but pointing at the real `~/.grafel` on Windows rather than at nothing. Converted.
- Repo-wide, **82 files call `t.Setenv("HOME", …)` and only 26 also set `USERPROFILE`.** Most are fine because those paths prefer `$HOME` explicitly, but it is a broad class worth its own sweep.
- No remaining instance of #6218's "`runtime.GOOS` check mistaken for a build constraint" in the two watchers/service packages.

## One correction to an earlier claim

An intermediate version described a "pre-existing race" in `TestGroupAlgoProgress_EmitsPhaseAndCPU`. There was none on unix: `cmd/grafel/daemon.go:1621-1624` seeds `lastCPU`/`cpuOK` before the ticker goroutine starts, so the first tick already carries `cpu_pct`. The real cause was Windows-only — `CPUTimeSeconds` erroring left `cpuOK` false forever. The poll-loop change is kept as belt (a failed sample now shifts the field one tick instead of failing) and the comment corrected.

## Verification

No build constraints added, no test skipped, no assertion weakened. `go list -f '{{.TestGoFiles}}'` selection is byte-identical under all three `GOOS` values.

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0. Darwin suites green for every touched package. Per-package cross-`GOOS` vet — which needs no cgo, as these packages do not reach tree-sitter — clean under `GOOS=windows` and `GOOS=linux`, type-checking every platform-only file touched.

Independently adversarially reviewed. The reviewer computed the label divergence directly and confirmed the missing migration was a static fact about `watchersync.go` rather than a runtime guess. Two mutants were then re-run at merge: disabling the reconcile wiring and disabling the **watchers-disabled** wiring each kill a specific test. The second of those was a real coverage gap found after the first review round — the watchers-off branch is where an orphan is least likely to be noticed, because every signal that would surface it is switched off.

**Unproven until CI runs:** every Linux and Windows *runtime* outcome — the `systemd-analyze` acceptance, the `daemon-reload` seam under a live user manager, the Windows label/plist/sidecar results, and `GetProcessTimes` returning a sane delta. All compile for those platforms and darwin behaviour is unchanged; that is the limit of what this machine can show.

Refs #6218, #6197, #6183, #6185, #6108, #6178
