### PR TITLE
fix(#5822): the incremental reject stamped the manifest with live HEAD for a pass that indexed nothing

### DIFF
--- a/internal/daemon/statuswriter_reject_commit_5822_test.go
+++ b/internal/daemon/statuswriter_reject_commit_5822_test.go
@@ -1,0 +1,148 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+	"github.com/cajasmota/grafel/internal/statusfile"
+)
+
+func runGit5822(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir}, args...)...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return string(bytes.TrimSpace(out))
+}
+
+// TestStatusPlane_RejectPathDoesNotAdvanceSurfacedCommit is the #5822 ② test on
+// the SURFACED plane: what `grafel status`, the dashboard and the statusline
+// actually print.
+//
+// The per-repo SHAs printed by `grafel status` itself come from the graph.fb
+// header (internal/cli/status_stats.go) and were always right. The two readers
+// pinned here are the ones that prefer the DIFF MANIFEST over that header —
+// indexedCommitShortNoGit (the status-file write path, i.e. the statusline and
+// dashboard) and IndexedCommitForRepo (the RPC path, i.e. grafel_index_status)
+// — so a manifest that advanced without an index makes both of them report a
+// commit the graph has never contained, and IndexedCommitForRepo additionally
+// reports AtHead=true for a graph that is not at HEAD.
+//
+// The sequence is reject-then-NO-reindex, which is the whole complaint: a
+// rejected incremental pass returns a full-reindex REQUEST, and that request
+// can be cancelled, watchdog-killed, or simply queued behind other work. Until
+// it runs, the graph is at c1. The label must say c1.
+//
+// Fixture: a REAL git repo whose HEAD genuinely moves (asserted). Against a
+// non-git tmpdir every commit field is "" and both assertions below would hold
+// against the defective code — the failure mode this repo keeps re-committing.
+// The graph.fb here is written WITHOUT an indexed-SHA header on purpose: both
+// readers fall back to the header only when the manifest field is EMPTY, and
+// it is non-empty in both the fixed and the defective world, so the assertion
+// is unambiguously about the manifest.
+func TestStatusPlane_RejectPathDoesNotAdvanceSurfacedCommit(t *testing.T) {
+	t.Setenv("GRAFEL_HOME", t.TempDir())
+	t.Setenv("GRAFEL_DAEMON_ROOT", t.TempDir())
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "2")
+
+	repo := t.TempDir()
+	runGit5822(t, repo, "init", "-q")
+	runGit5822(t, repo, "config", "user.email", "test@test")
+	runGit5822(t, repo, "config", "user.name", "Test")
+
+	files := []string{"a.go", "b.go", "c.go", "d.go", "e.go"}
+	writeAll := func(tag int) {
+		for i, rel := range files {
+			body := fmt.Sprintf("package p\n\nfunc F%d() { _ = %d }\n", i, tag)
+			if err := os.WriteFile(filepath.Join(repo, rel), []byte(body), 0o644); err != nil {
+				t.Fatalf("write %s: %v", rel, err)
+			}
+		}
+	}
+	commit := func(msg string) (string, string) {
+		runGit5822(t, repo, "add", "-A")
+		runGit5822(t, repo, "commit", "-q", "-m", msg)
+		return runGit5822(t, repo, "rev-parse", "--short", "HEAD"),
+			runGit5822(t, repo, "rev-parse", "HEAD")
+	}
+
+	writeAll(0)
+	c1Short, c1Full := commit("c1")
+
+	stateDir := StateDirForRepo(repo)
+	if stateDir == "" {
+		t.Fatal("fixture: StateDirForRepo returned empty")
+	}
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir stateDir: %v", err)
+	}
+	doc := &graph.Document{
+		Version:     graph.SchemaVersion,
+		GeneratedAt: time.Now().UTC(),
+		Repo:        "test-repo",
+		Entities: []graph.Entity{{
+			ID:   graph.EntityID("test-repo", "SCOPE.Operation", "F0", "a.go"),
+			Name: "F0", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go",
+		}},
+		Stats: graph.Stats{Entities: 1},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), doc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, files, m)
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+	if seeded := diff.LoadManifest(stateDir); seeded.GitCommit != c1Short {
+		t.Fatalf("fixture: seeded GitCommit = %q, want %q — the fixture is not being read as a git repo, so this test would assert nothing", seeded.GitCommit, c1Short)
+	}
+
+	// Advance HEAD. Working tree ends clean, so only the #5710 commit-range
+	// diff can surface these files — the post-pull shape.
+	writeAll(1)
+	c2Short, c2Full := commit("c2")
+	if c1Short == c2Short || c1Full == c2Full {
+		t.Fatalf("fixture: HEAD did not move (c1=%s c2=%s)", c1Short, c2Short)
+	}
+
+	// The reject. No full reindex follows it — that is the point.
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if res.Done {
+		t.Fatalf("expected the too-many-changed reject, got Done=true — the path under test never ran")
+	}
+
+	// Reader 1: the status-file write path (statusline / dashboard).
+	writeRepoStatusFile(repo, nil)
+	got, err := statusfile.Read(repo)
+	if err != nil {
+		t.Fatalf("statusfile.Read: %v", err)
+	}
+	if got.IndexedCommit != c1Short {
+		t.Errorf("status file IndexedCommit = %q, want %q — the statusline is showing a commit that was never indexed (%q is live HEAD; the reject built no graph)", got.IndexedCommit, c1Short, c2Short)
+	}
+
+	// Reader 2: the RPC path (grafel_index_status).
+	info := IndexedCommitForRepo(repo)
+	if info.CommitShort != c1Short {
+		t.Errorf("IndexedCommitForRepo CommitShort = %q, want %q", info.CommitShort, c1Short)
+	}
+	if info.Commit != c1Full {
+		t.Errorf("IndexedCommitForRepo Commit = %q, want %q", info.Commit, c1Full)
+	}
+	if info.AtHead {
+		t.Errorf("IndexedCommitForRepo AtHead = true, want false — the graph is at %s and HEAD is %s; reporting AtHead here is the self-conceal that stops anything ever asking for the reindex again", c1Short, c2Short)
+	}
+}

--- a/internal/extractors/incremental.go
+++ b/internal/extractors/incremental.go
@@ -520,8 +520,43 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 		//
 		// Log a path SAMPLE so a recurrence is diagnosable, not just a bare
 		// count (#5668).
+		// THE COMMIT LABEL MUST NOT ADVANCE HERE (#5822 ②).
+		//
+		// This pass changed no entity: it reconciles the manifest and asks the
+		// caller for a full reindex. The persisted graph is therefore still the
+		// graph built at manifest.GitCommit, and that is the only value of
+		// git_commit that is TRUE. SaveManifest stamps LIVE HEAD, which made
+		// the manifest claim "indexed at HEAD" for a pass that indexed nothing;
+		// daemon.indexedCommitShortNoGit and daemon.IndexedCommitForRepo both
+		// prefer this field over the graph.fb header, so the statusline, the
+		// dashboard and grafel_index_status all reported a commit the graph had
+		// never contained — and IndexedCommitForRepo reported AtHead=true over
+		// it. If the full reindex we are requesting is cancelled,
+		// watchdog-killed, or merely queued behind other work, that label stays
+		// advanced over the older graph indefinitely.
+		//
+		// It is also self-concealing, which is the worse half. The #5710
+		// head-advance detector above re-surfaces this delta on every later
+		// pass precisely BECAUSE manifest.GitCommit trails HEAD. Advancing it
+		// here disarms that detector: the next pass sees HEAD == manifest,
+		// stamps that match disk, zero changes, and returns Done=true over a
+		// graph that was never rebuilt. The reindex is then never requested
+		// again by anything.
+		//
+		// PRESERVING the previous value is the choice, not blanking it. Blank
+		// would be the honest answer to "we do not know", but we DO know — the
+		// graph is at manifest.GitCommit — and blanking additionally breaks the
+		// `manifest.GitCommit != ""` guard the head-advance detector is gated
+		// on, silently disabling the same detector by the other route.
+		//
+		// NOT saving at all would also fix the label, and is wrong: #6201/#5668
+		// established that this path MUST persist a reconciled manifest, or the
+		// changed files re-surface next pass and re-trip this very reject
+		// forever, and #5667's prune of entries absent from the gitignore-aware
+		// walk stops happening too. The write stays; only the commit stamp is
+		// corrected.
 		diff.UpdateManifestScoped(absRepo, changedFiles, allFiles, manifest)
-		_ = diff.SaveManifest(stateDir, absRepo, manifest)
+		_ = diff.SaveManifestAtCommit(stateDir, manifest, manifest.GitCommit, manifest.GitCommitFull)
 		logger.Printf("incremental: too-many-changed files=%d limit=%d (changed=%d deleted=%d) changed=%v deleted=%v",
 			totalChanged, limit, len(changedFiles), len(deletedFiles),
 			samplePaths(changedFiles), samplePaths(deletedFiles))
@@ -648,8 +683,12 @@ func TryIncremental(ctx context.Context, repoPath, stateDir string, logger *log.
 	// this comment previously claimed it was, which would have told the next
 	// reader it runs. The live guard is the reachable branch above.
 	if len(reallyChanged) > limit {
+		// Same reasoning as the reachable reject above (#5822 ②) — kept in step
+		// with it deliberately, so that if the proof of unreachability ever
+		// stops holding this branch does not resurrect the defect. No test can
+		// pin this, because no input reaches it.
 		diff.UpdateManifestScoped(absRepo, changedFiles, allFiles, manifest)
-		_ = diff.SaveManifest(stateDir, absRepo, manifest)
+		_ = diff.SaveManifestAtCommit(stateDir, manifest, manifest.GitCommit, manifest.GitCommitFull)
 		logger.Printf("incremental: too-many-changed after-hash-gate files=%d limit=%d really=%v",
 			len(reallyChanged), limit, samplePaths(reallyChanged))
 		return fallback(t0, fmt.Sprintf("too-many-changed after-hash-gate files=%d limit=%d",

--- a/internal/extractors/incremental_reject_commit_5822_test.go
+++ b/internal/extractors/incremental_reject_commit_5822_test.go
@@ -1,0 +1,243 @@
+package extractors_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/extractors"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/indexer/diff"
+)
+
+// gitRevParse5822 runs `git -C dir rev-parse <args...>` and returns the trimmed
+// stdout, failing the test on error.
+func gitRevParse5822(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	out, err := exec.Command("git", append([]string{"-C", dir, "rev-parse"}, args...)...).Output()
+	if err != nil {
+		t.Fatalf("git rev-parse %v: %v", args, err)
+	}
+	return string(bytes.TrimSpace(out))
+}
+
+// diskSHA5822 is the hex SHA-256 of the file's CURRENT bytes on disk — the
+// value a correctly-refreshed manifest stamp must carry.
+func diskSHA5822(t *testing.T, abs string) string {
+	t.Helper()
+	b, err := os.ReadFile(abs)
+	if err != nil {
+		t.Fatalf("read %s: %v", abs, err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// TestIncremental_RejectPathDoesNotAdvanceIndexedCommit is the RED test for
+// #5822 part ②: the too-many-changed REJECT path stamped the manifest's
+// git_commit from LIVE HEAD at save time, not from the commit the graph was
+// actually built at.
+//
+// The reject path indexes NOTHING — it reconciles the manifest and returns a
+// full-reindex request. Stamping live HEAD there makes the manifest claim
+// "indexed at HEAD" for a pass that touched no entity, and every consumer of
+// that field (grafel status / the dashboard / the statusline, via
+// daemon.indexedCommitShortNoGit and daemon.IndexedCommitForRepo, both of
+// which prefer the manifest over the graph.fb header) then reports a commit
+// the graph has never seen. If the requested full reindex is cancelled,
+// watchdog-killed, or merely queued behind other work, the label stays
+// advanced over an older graph INDEFINITELY — and worse, it disarms the #5710
+// HEAD-advance detector, which re-requests the reindex precisely BECAUSE
+// manifest.GitCommit trails HEAD. Once the manifest lies about being at HEAD,
+// nothing ever asks again.
+//
+// FIXTURE, and why each property is load-bearing (fixture vacuity has been
+// this repo's recurring test failure — a git-dependent path tested against a
+// non-git tmpdir asserts nothing):
+//
+//   - repo is a REAL git repo. diff.HeadCommit/headCommit shell out to
+//     `git rev-parse`; against a plain t.TempDir() they return "" and
+//     SaveManifest's stamp is unconditionally "" — the assertion below would
+//     pass against the defective code because there is no commit to advance
+//     TO. TestIncremental_FallbackRefreshesStampsAndReconciles (#5668) is
+//     exactly that shape, which is why it never caught this.
+//   - HEAD GENUINELY MOVES (c1 -> c2), asserted explicitly. A repo with one
+//     commit makes "did not advance" and "advanced" the same value.
+//   - the working tree is CLEAN at c2. `git diff --name-only HEAD` is then
+//     empty, so the ONLY thing that puts the five files into the changed set
+//     is the #5710 commit-RANGE diff off manifest.GitCommit. That is the
+//     post-fetch/checkout/pull shape the reject path actually meets in
+//     production, and it also proves the range detector ran.
+//   - the reject is asserted to have FIRED (Done=false, reason
+//     too-many-changed). Without that the manifest assertions would hold
+//     trivially on any code path that never reached the write.
+func TestIncremental_RejectPathDoesNotAdvanceIndexedCommit(t *testing.T) {
+	t.Setenv("GRAFEL_INCREMENTAL_MAX_FILES", "2") // 5 changed > 2 → reject
+
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	initGitRepo(t, repo)
+
+	files := []string{"a.go", "b.go", "c.go", "d.go", "e.go"}
+	for i, rel := range files {
+		writeFile(t, repo, rel, fmt.Sprintf("package p\n\nfunc F%d() {}\n", i))
+	}
+	c1Short := gitCommitAll(t, repo, "c1")
+	c1Full := gitRevParse5822(t, repo, "HEAD")
+
+	// A materialized, non-empty graph so the #5710 absent-graph guard cannot
+	// be what forces the fallback (it would fire before the trigger limit and
+	// take a DIFFERENT path, one that deliberately writes no manifest).
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F0", "a.go"),
+			Name: "F0", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
+
+	// Baseline manifest: correct stamps for every file, pinned at c1. This is
+	// the honest record of a graph built from c1.
+	seedManifest(t, repo, stateDir)
+	seeded := diff.LoadManifest(stateDir)
+	if seeded.GitCommit != c1Short {
+		t.Fatalf("fixture: seeded manifest GitCommit = %q, want %q — the fixture repo is not being seen as a git repo, so this test would assert nothing", seeded.GitCommit, c1Short)
+	}
+	if seeded.GitCommitFull != c1Full {
+		t.Fatalf("fixture: seeded manifest GitCommitFull = %q, want %q", seeded.GitCommitFull, c1Full)
+	}
+
+	// Advance HEAD: rewrite every file and commit. Working tree ends CLEAN.
+	for i, rel := range files {
+		writeFile(t, repo, rel, fmt.Sprintf("package p\n\nfunc F%d() { _ = %d }\n", i, i+100))
+	}
+	c2Short := gitCommitAll(t, repo, "c2")
+	c2Full := gitRevParse5822(t, repo, "HEAD")
+
+	if c1Short == c2Short || c1Full == c2Full {
+		t.Fatalf("fixture: HEAD did not move (c1=%s/%s c2=%s/%s) — 'did not advance' and 'advanced' would be indistinguishable", c1Short, c1Full, c2Short, c2Full)
+	}
+	if got := diff.HeadCommit(repo); got != c2Short {
+		t.Fatalf("fixture: diff.HeadCommit(repo) = %q, want %q — git is not resolving in this fixture", got, c2Short)
+	}
+
+	// ── Pass 1: the reject ────────────────────────────────────────────────
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if res.Done {
+		t.Fatalf("pass 1: expected the too-many-changed reject, got Done=true (reason=%q) — the reject path under test never ran", res.FallbackReason)
+	}
+	if !strings.Contains(res.FallbackReason, "too-many-changed") {
+		t.Fatalf("pass 1: fell back for the WRONG reason %q — this test only pins the too-many-changed reject; another path reaching here means the fixture stopped exercising it", res.FallbackReason)
+	}
+
+	after1 := diff.LoadManifest(stateDir)
+
+	// THE DEFECT. Nothing was indexed, so the graph is still the c1 graph and
+	// the label must still say c1.
+	if after1.GitCommit != c1Short {
+		t.Errorf("pass 1: manifest GitCommit = %q, want %q (the commit the graph was actually built at). The reject indexed nothing; %q is live HEAD at save time, which the graph has never seen.", after1.GitCommit, c1Short, c2Short)
+	}
+	if after1.GitCommitFull != c1Full {
+		t.Errorf("pass 1: manifest GitCommitFull = %q, want %q", after1.GitCommitFull, c1Full)
+	}
+
+	// THE GUARD THAT FORBIDS "just don't save on reject". #6201 established
+	// that the reject MUST still persist a reconciled manifest: #5668's stamp
+	// refresh (or the changed files re-surface next pass and re-trip the same
+	// reject forever) and #5667's prune. Removing the write to fix the commit
+	// label would trade a wrong label for a permanent reject loop.
+	for _, rel := range files {
+		e, ok := after1.Files[rel]
+		if !ok {
+			t.Fatalf("pass 1: %s missing from the manifest — the reject path's write was dropped, re-entering #5667", rel)
+		}
+		if want := diskSHA5822(t, filepath.Join(repo, rel)); e.SHA256 != want {
+			t.Errorf("pass 1: %s stamp = %q, want the on-disk hash %q — the reject path stopped refreshing stamps, re-entering the #5668 reject loop", rel, e.SHA256, want)
+		}
+	}
+
+	// ── Pass 2: NO full reindex happened in between ───────────────────────
+	// The graph is still the c1 graph. The pass must therefore still ask for
+	// the reindex, and must still label the graph c1. Against the defective
+	// code pass 1 wrote GitCommit=c2, so this pass sees HEAD==manifest, no
+	// head-advance, matching stamps, zero changes — and reports Done=true
+	// over a graph that was never rebuilt. That is the self-conceal.
+	res2 := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if res2.Done {
+		t.Errorf("pass 2: Done=true with no reindex in between — the advanced label concealed the stale graph and the reindex is never requested again")
+	}
+
+	after2 := diff.LoadManifest(stateDir)
+	if after2.GitCommit != c1Short {
+		t.Errorf("pass 2: manifest GitCommit = %q, want %q — the label must keep describing the graph until a reindex actually rebuilds it", after2.GitCommit, c1Short)
+	}
+	if after2.GitCommitFull != c1Full {
+		t.Errorf("pass 2: manifest GitCommitFull = %q, want %q", after2.GitCommitFull, c1Full)
+	}
+}
+
+// TestIncremental_ZeroChangePassDoesAdvanceIndexedCommit pins the OTHER half of
+// the #5822 ② decision, so a later reader does not "simplify" the fix into
+// "never stamp the commit from HEAD".
+//
+// On the zero-change pass the graph genuinely DOES reflect the current HEAD:
+// the head-advance detector ran, the commit-range diff was computed and
+// CONFIRMED (unconfirmed takes the earlier fallback), and it produced no
+// walked source file. A commit that touched only README/CI/.gitignore is
+// exactly this. Refusing to advance there would leave manifest.GitCommit
+// permanently behind HEAD, and the range diff would be recomputed on every
+// single poll for the life of the repo.
+//
+// Fixture note, and it took a correction to get right: the second commit must
+// touch ONLY a file the source walk does not surface, so the range diff is
+// non-empty while the changed-SOURCE set stays empty. A first draft advanced
+// HEAD by editing README.md — the walk surfaces markdown, so the pass took the
+// ordinary INCREMENTAL SUCCESS path (ChangedFiles=1) and the zero-change branch
+// this test names was never reached, while the assertion passed anyway.
+// node_modules/ is in the walker's hard-exclude set (internal/daemon/walk),
+// and the manifest is seeded with the walked set only, so the excluded file is
+// not reported deleted either. res.ChangedFiles==0 is asserted for exactly
+// that reason: it is what distinguishes this branch from the success path.
+func TestIncremental_ZeroChangePassDoesAdvanceIndexedCommit(t *testing.T) {
+	repo := t.TempDir()
+	stateDir := t.TempDir()
+	initGitRepo(t, repo)
+
+	writeFile(t, repo, "a.go", "package p\n\nfunc F() {}\n")
+	writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 1\n")
+	c1Short := gitCommitAll(t, repo, "c1")
+
+	buildMinimalGraph(t, stateDir, []graph.Entity{
+		{ID: graph.EntityID("test-repo", "SCOPE.Operation", "F", "a.go"),
+			Name: "F", Kind: "SCOPE.Operation", SourceFile: "a.go", Language: "go"},
+	}, nil)
+	m := diff.LoadManifest(stateDir)
+	diff.UpdateManifest(repo, []string{"a.go"}, m) // walked set only
+	if err := diff.SaveManifest(stateDir, repo, m); err != nil {
+		t.Fatalf("seed manifest: %v", err)
+	}
+
+	// Advance HEAD without touching any file the source walk surfaces.
+	writeFile(t, repo, "node_modules/pkg/index.js", "module.exports = 2\n")
+	c2Short := gitCommitAll(t, repo, "c2")
+	if c1Short == c2Short {
+		t.Fatalf("fixture: HEAD did not move")
+	}
+
+	res := extractors.TryIncremental(context.Background(), repo, stateDir, nil, nil)
+	if !res.Done {
+		t.Fatalf("expected the zero-change no-op, got fallback %q — this test is not exercising the zero-change branch", res.FallbackReason)
+	}
+	if res.ChangedFiles != 0 {
+		t.Fatalf("expected the ZERO-change branch, but %d file(s) were re-extracted — this pass took the incremental SUCCESS path, whose manifest write is a different call site", res.ChangedFiles)
+	}
+
+	m = diff.LoadManifest(stateDir)
+	if m.GitCommit != c2Short {
+		t.Errorf("zero-change pass: manifest GitCommit = %q, want %q. This pass CONFIRMED that no walked source file differs between the two commits, so the existing graph does describe HEAD; pinning it at %q would re-run the range diff on every poll forever.", m.GitCommit, c2Short, c1Short)
+	}
+}

--- a/internal/indexer/diff/diff.go
+++ b/internal/indexer/diff/diff.go
@@ -146,12 +146,40 @@ func LoadManifest(stateDir string) *Manifest {
 	return &m
 }
 
-// SaveManifest atomically writes m to stateDir. It sets IndexedAt and captures
-// the current HEAD commit (best-effort). Returns nil on success.
+// SaveManifest atomically writes m to stateDir, stamping GitCommit /
+// GitCommitFull from repoPath's LIVE HEAD at save time (best-effort; empty when
+// not a git repo). Returns nil on success.
+//
+// Live HEAD is the right stamp only for a caller whose pass actually built the
+// graph from the tree at that commit. A caller that indexed NOTHING — or that
+// knows which commit it read, because it captured it before doing the work —
+// must use SaveManifestAtCommit instead. See #5822 ②.
 func SaveManifest(stateDir, repoPath string, m *Manifest) error {
+	return SaveManifestAtCommit(stateDir, m, headCommit(repoPath), headCommitFull(repoPath))
+}
+
+// SaveManifestAtCommit atomically writes m to stateDir, stamping GitCommit /
+// GitCommitFull from the caller-supplied commit rather than from live HEAD.
+//
+// WHY THE COMMIT IS A PARAMETER (#5822 ②). GitCommit answers exactly one
+// question — "which commit is the persisted graph built from?" — and only the
+// caller knows the answer. SaveManifest's live-HEAD read answers a DIFFERENT
+// question, "which commit is checked out at this instant", and the two diverge
+// on every path that writes a manifest without building a graph from HEAD. The
+// too-many-changed reject in internal/extractors is the load-bearing one: it
+// re-stamps files and returns a full-reindex REQUEST, having changed no entity,
+// so live HEAD there records a commit the graph has never contained. This is
+// the same correction #6212 made for the per-FILE stamps, which likewise moved
+// from "hash the path at commit time" to "record what the pass actually read".
+//
+// short and full must describe the SAME commit; pass both or neither. Empty
+// strings are written through as empty (the non-git case), NOT treated as
+// "leave whatever m already holds" — a save must never leave the two fields
+// disagreeing with what the caller asked for.
+func SaveManifestAtCommit(stateDir string, m *Manifest, short, full string) error {
 	m.IndexedAt = time.Now().UTC()
-	m.GitCommit = headCommit(repoPath)
-	m.GitCommitFull = headCommitFull(repoPath)
+	m.GitCommit = short
+	m.GitCommitFull = full
 
 	data, err := json.Marshal(m)
 	if err != nil {


### PR DESCRIPTION
`SaveManifest` stamped `GitCommit` from **live HEAD at save time**, regardless of what the pass actually indexed. The load-bearing caller is the incremental **too-many-changed reject**: it saves a manifest and then returns a full-reindex fallback, so the manifest claims "indexed at HEAD" for a pass that indexed nothing.

Reported as a cosmetic stale label. It is not cosmetic.

## The label conceals the staleness it causes

The advanced stamp **disarms the #5710 head-advance detector**, which re-requests a reindex precisely *because* `GitCommit` trails HEAD. After one reject:

- `IndexedCommitForRepo` reports **`AtHead=true`** over a graph that never saw that commit;
- the next incremental pass returns `Done=true`, so the scheduler does not fall back;
- nothing ever asks for the reindex again.

So the failure is not "the label persists if the fallback reindex is cancelled." It is that the label **prevents** the fallback from being requested a second time. The two new tests assert exactly that — pass 2 must not be `Done=true` with no reindex in between.

This was explicitly deferred: `ce84cf962` (#6212) closed the per-file stamping hazard and its message says *"NOT DONE HERE, deliberately: … the reject path's own manifest write."* Still accurate — #6209 added `FileEntry.Failures` and touched `commitManifest`, but nothing moved the commit stamp.

## Decision: pass the commit in, keep the write, preserve the previous value

**Not saving on reject is wrong**, verified rather than assumed: deleting the write turns the pre-existing #5668 test red alongside the new stamp-refresh guard. The write carries #5668's stamp refresh and #5667's prune — without them the reject re-trips forever. This also matches #6201, which established that the reject path must still write something.

**Preserve rather than blank.** We know where the graph is: the previous commit. Blanking also breaks the `manifest.GitCommit != ""` gate the head-advance detector sits behind — the blank-it mutant's pass 2 no-ops and then stamps live HEAD through the zero-change path, reproducing the defect one pass later. That was empirical, not predicted.

**The zero-change pass still advances**, deliberately. There the range diff was computed *and confirmed* and yielded no walked source file, so the graph genuinely does describe HEAD. Pinning it would recompute the range diff on every poll forever. A characterization test guards that boundary, and the over-apply mutant (preserve there too) is killed only by it.

Mechanism: `diff.SaveManifestAtCommit(stateDir, m, short, full)`. `SaveManifest` keeps live-HEAD semantics and delegates, so every caller that genuinely built from HEAD is untouched.

## Fixture vacuity, caught in our own work

The zero-change fixture initially advanced HEAD by editing `README.md` — which the walk surfaces, so the pass took the ordinary *success* path with `ChangedFiles=1` and the branch under test never ran, **while the assertion passed**. It now edits a `node_modules/` path (hard-excluded at `internal/daemon/walk/walker.go:441`) and asserts `ChangedFiles==0`.

Every fixture is a real git repo asserting its own preconditions — that the seeded manifest really carries c1, that HEAD really moved, that the reject really fired — with a clean working tree so only the commit-range diff can surface files.

## Mutants

| Mutation | Killed by |
|---|---|
| reject calls `SaveManifest` again (the defect) | both #5822 tests, both planes |
| reject passes `currentHead` explicitly | both, both planes |
| reject passes `""` (blank not preserve) | both; pass 2 then advances anyway |
| reject's manifest write deleted | new stamp-refresh guard **and** pre-existing #5668 |
| `SaveManifestAtCommit` ignores its args | #5729 gitcommit + `IndexedCommitForRepo` tests |
| zero-change path preserves too (over-apply) | **only** `_ZeroChangePassDoesAdvance` |

No survivors. Re-run independently at merge: restoring the defect fails both planes with

```
pass 2: Done=true with no reindex in between — the advanced label concealed the stale graph
IndexedCommitForRepo AtHead = true, want false
```

Files restored from byte-level backups, shasums verified.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/indexer/diff/...` 0, `./internal/extractors/...` 0, `./internal/daemon/...` 0, `./cmd/grafel/...` 0 (115.6s).

Refs #5822, #5710, #6212, #5668, #6201
