### PR TITLE
fix(#6194,#6075): destructive fs ops ran on paths derived without a containment check

### DIFF
--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -1327,10 +1327,18 @@ func (s *Service) DeleteGroup(args *proto.DeleteGroupArgs, reply *proto.DeleteGr
 	_ = os.Remove(ref.ConfigPath)
 
 	// Delete per-group state directory.
-	stateDir, err := registry.StateDirFor(args.Group)
-	if err == nil {
-		_ = os.RemoveAll(stateDir)
+	//
+	// #6194: StateDirForExisting asserts the derived path is genuinely inside
+	// the state root before returning it. args.Group is matched against
+	// registry.json above, but a registry entry written before
+	// ValidateGroupName existed may still contain "..", and filepath.Join
+	// collapses it — so without this the RPC deletes an arbitrary directory.
+	// Surfaced, not swallowed: a delete that silently keeps state is a defect.
+	stateDir, err := registry.StateDirForExisting(args.Group)
+	if err != nil {
+		return fmt.Errorf("resolve group state directory: %w", err)
 	}
+	_ = os.RemoveAll(stateDir)
 
 	// Remove the GROUP-LEVEL artifacts keyed by the deleted group name. These
 	// are always safe to remove (they belong to this group alone, never shared
@@ -1416,7 +1424,19 @@ func removeGroupArtifacts(group string) int64 {
 	}
 
 	var freed int64
-	remove := func(m string) {
+	// removeUnder is the same containment discipline as #6194's
+	// StateDirForExisting, applied to the glob-derived sidecar paths. group is
+	// interpolated raw into the glob pattern below, and filepath.Join collapses
+	// "..", so a grandfathered registry name can point the pattern at a
+	// directory outside the intended root. Today ownerIsDeleted happens to
+	// reject such a match (the escaped basename never prefix-matches the "../"
+	// name), but that is an accident of string shape, not a guarantee — one
+	// change to the attribution rule and it becomes a delete outside the root
+	// again. Assert on the path.
+	removeUnder := func(root, m string) {
+		if !registry.PathContainedUnder(root, m) {
+			return
+		}
 		if sz, err := dirSize(m); err == nil {
 			freed += sz
 		}
@@ -1424,20 +1444,21 @@ func removeGroupArtifacts(group string) int64 {
 	}
 
 	// groups/<group>-*.json — subject is the basename (e.g. "api-v2-links.json").
-	if home, err := registry.HomeDir(); err == nil {
-		matches, _ := filepath.Glob(filepath.Join(home, "groups", group+"-*.json"))
+	if root, err := registry.StateRootDir(); err == nil {
+		matches, _ := filepath.Glob(filepath.Join(root, group+"-*.json"))
 		for _, m := range matches {
 			if ownerIsDeleted(filepath.Base(m)) {
-				remove(m)
+				removeUnder(root, m)
 			}
 		}
 	}
 	// store/group-<group>-* — subject is the basename with the "group-" prefix
 	// stripped (e.g. "api-v2-<hash>").
-	matches, _ := filepath.Glob(filepath.Join(StoreDir(), "group-"+group+"-*"))
+	storeRoot := StoreDir()
+	matches, _ := filepath.Glob(filepath.Join(storeRoot, "group-"+group+"-*"))
 	for _, m := range matches {
 		if ownerIsDeleted(strings.TrimPrefix(filepath.Base(m), "group-")) {
-			remove(m)
+			removeUnder(storeRoot, m)
 		}
 	}
 	return freed

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -552,10 +552,22 @@ func Uninstall(group string, purge bool) error {
 		return err
 	}
 	if purge {
-		stateDir, err := registry.StateDirFor(group)
-		if err == nil {
-			_ = os.RemoveAll(stateDir)
+		// #6194: StateDirForExisting, not StateDirFor. group comes straight
+		// from registry.json, filepath.Join collapses "..", and a
+		// grandfathered entry written before ValidateGroupName existed can
+		// therefore resolve outside the state root — which os.RemoveAll
+		// follows. The gate is on the derived path, not on the name, so a
+		// weird-but-contained legacy name still purges normally.
+		//
+		// The refusal is returned rather than swallowed: --purge reporting
+		// success while silently leaving state behind is its own defect, and
+		// a refused derivation means something is wrong with the registry
+		// that the operator needs to see.
+		stateDir, err := registry.StateDirForExisting(group)
+		if err != nil {
+			return err
 		}
+		_ = os.RemoveAll(stateDir)
 		_ = os.Remove(ref.ConfigPath)
 	}
 	return nil

--- a/internal/install/uninstall_purge_containment_6194_test.go
+++ b/internal/install/uninstall_purge_containment_6194_test.go
@@ -1,0 +1,139 @@
+package install_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// purgeSandbox builds an isolated grafel home with a canary directory that
+// lives OUTSIDE it, and seeds registry.json by writing the file directly.
+//
+// Writing the JSON by hand is the point, not a shortcut: registry.AddGroup
+// validates the name, so a traversing entry cannot be created through the API
+// any more. #6194 is only reachable through an entry that predates that
+// validation, and hand-writing the file is the only faithful way to reproduce
+// a grandfathered registry.
+//
+// Returns (grafelHome, canaryDir).
+func purgeSandbox(t *testing.T, names ...string) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	osHome := filepath.Join(base, "home")
+	grafelHome := filepath.Join(osHome, ".grafel")
+	if err := os.MkdirAll(filepath.Join(grafelHome, "groups"), 0o755); err != nil {
+		t.Fatalf("mkdir grafel home: %v", err)
+	}
+	canary := filepath.Join(base, "canary")
+	if err := os.MkdirAll(canary, 0o755); err != nil {
+		t.Fatalf("mkdir canary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(canary, "precious.txt"), []byte("do not delete"), 0o644); err != nil {
+		t.Fatalf("write canary file: %v", err)
+	}
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("GRAFEL_HOME", grafelHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "xdg"))
+
+	groups := make([]registry.GroupRef, 0, len(names))
+	for _, n := range names {
+		// A path inside the sandbox home: purge os.Remove()s ref.ConfigPath
+		// too, and it must not be able to reach outside the fixture either.
+		groups = append(groups, registry.GroupRef{
+			Name:       n,
+			ConfigPath: filepath.Join(grafelHome, "unused.fleet.json"),
+		})
+	}
+	b, err := json.Marshal(registry.Registry{Version: 1, Groups: groups})
+	if err != nil {
+		t.Fatalf("marshal registry: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(grafelHome, "registry.json"), b, 0o644); err != nil {
+		t.Fatalf("write registry.json: %v", err)
+	}
+	return grafelHome, canary
+}
+
+// TestUninstallPurge_DoesNotDeleteOutsideStateRoot pins #6194 at the call site.
+//
+// install.Uninstall(group, purge=true) ran os.RemoveAll on
+// registry.StateDirFor(group). filepath.Join collapses "..", so a
+// grandfathered registry entry named "../../../canary" made --purge delete a
+// directory that has nothing to do with grafel.
+//
+// The assertion is on the canary's survival, not on the returned error, so it
+// cannot be satisfied by a change that merely reports a problem while still
+// deleting.
+func TestUninstallPurge_DoesNotDeleteOutsideStateRoot(t *testing.T) {
+	const evil = "../../../canary"
+	_, canary := purgeSandbox(t, evil)
+
+	// Premise: the ungated derivation really does land on the canary. Without
+	// this, a refusal below could be refusing something harmless.
+	derived, err := registry.StateDirFor(evil)
+	if err != nil {
+		t.Fatalf("StateDirFor: %v", err)
+	}
+	if filepath.Clean(derived) != filepath.Clean(canary) {
+		t.Fatalf("test premise broken: StateDirFor(%q) = %q, want the canary %q; the fixture no "+
+			"longer reproduces the escape and this test would pass regardless of the fix",
+			evil, derived, canary)
+	}
+
+	// Uninstall is expected to surface the refusal rather than silently skip:
+	// a --purge that quietly leaves state behind is its own defect.
+	if err := install.Uninstall(evil, true); err == nil {
+		t.Errorf("Uninstall(%q, purge) returned nil; want a containment refusal so --purge does "+
+			"not silently appear to have succeeded (#6194)", evil)
+	}
+
+	if _, err := os.Stat(filepath.Join(canary, "precious.txt")); err != nil {
+		t.Fatalf("--purge deleted outside the state root: %s is gone (%v) (#6194)",
+			filepath.Join(canary, "precious.txt"), err)
+	}
+}
+
+// TestUninstallPurge_StillPurgesGrandfatheredContainedGroup is the mutant
+// killer for "just stop purging".
+//
+// "my/group" fails registry.ValidateGroupName but is strictly inside the state
+// root. It must still be purged: fixing #6194 with name validation at the
+// delete site would make grandfathered registries unpurgeable, which is the
+// regression the read-side validation split was written to avoid.
+func TestUninstallPurge_StillPurgesGrandfatheredContainedGroup(t *testing.T) {
+	const grandfathered = "my/group"
+	grafelHome, canary := purgeSandbox(t, grandfathered)
+
+	// Premise: the name is one name-validation rejects, so this test really
+	// does distinguish containment from validation.
+	if err := registry.ValidateGroupName(grandfathered); err == nil {
+		t.Fatalf("test premise broken: ValidateGroupName(%q) accepted the name", grandfathered)
+	}
+
+	stateDir := filepath.Join(grafelHome, "groups", "my", "group")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	marker := filepath.Join(stateDir, "graph.db")
+	if err := os.WriteFile(marker, []byte("state"), 0o644); err != nil {
+		t.Fatalf("write state marker: %v", err)
+	}
+
+	if err := install.Uninstall(grandfathered, true); err != nil {
+		t.Fatalf("Uninstall(%q, purge) = %v, want success for a contained name", grandfathered, err)
+	}
+	if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+		t.Fatalf("--purge did not remove the contained state dir %s (stat err = %v); the "+
+			"containment check must refuse escapes, not disable purging", stateDir, err)
+	}
+
+	// And it still did not touch anything outside.
+	if _, err := os.Stat(filepath.Join(canary, "precious.txt")); err != nil {
+		t.Fatalf("canary damaged during a legitimate purge: %v", err)
+	}
+}

--- a/internal/mcp/docgen.go
+++ b/internal/mcp/docgen.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/grafel/internal/gitmeta"
+	"github.com/cajasmota/grafel/internal/registry"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -95,22 +96,46 @@ func projectRootFromCWD(cwd string, noGit bool) (string, error) {
 // Helper: staging directory path
 // ---------------------------------------------------------------------------
 
-// stagingDirPath returns <project_root>/.grafel/staging/<run_id>.
-func stagingDirPath(projectRoot, runID string) string {
-	return filepath.Join(projectRoot, ".grafel", "staging", runID)
+// stagingRootPath returns <project_root>/.grafel/staging — the directory every
+// run's staging dir must live inside.
+func stagingRootPath(projectRoot string) string {
+	return filepath.Join(projectRoot, ".grafel", "staging")
 }
 
-// canonicalDocsPath returns ~/.grafel/docs/<group>.
+// stagingDirPath returns <project_root>/.grafel/staging/<run_id>.
+//
+// This is the READ-side derivation and does not gate run_id; callers that are
+// about to rename or delete the result must go through resolveStagingPath,
+// which asserts containment. See its doc comment.
+func stagingDirPath(projectRoot, runID string) string {
+	return filepath.Join(stagingRootPath(projectRoot), runID)
+}
+
+// canonicalDocsPath returns <docs root>/<group>, asserting the result is
+// genuinely inside the docs root before returning it (#6075).
+//
+// The containment assertion is not decoration. In handleDocgenPromote's
+// disk-lookup branch group comes straight off the wire
+// (argString(req, "group", "")), filepath.Join collapses "..", and the value
+// is then handed to os.Rename twice — once to rotate the existing directory
+// away and once to move staging on top of it. Without this, an agent-supplied
+// group of "../.." renames a directory that has nothing to do with docs.
+//
+// Equality with the root is refused too, so an empty group cannot resolve to
+// the docs root itself and rotate every group's docs in one call.
+//
+// See docsroot.go for why the root is injectable rather than merely guarded.
 func canonicalDocsPath(group string) (string, error) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		var err error
-		home, err = os.UserHomeDir()
-		if err != nil {
-			return "", fmt.Errorf("cannot determine home directory: %w", err)
-		}
+	root, err := docsRoot()
+	if err != nil {
+		return "", err
 	}
-	return filepath.Join(home, ".grafel", "docs", group), nil
+	p := filepath.Join(root, group)
+	if !registry.PathContainedUnder(root, p) {
+		return "", fmt.Errorf("group %q resolves to docs path %q, which is outside the docs root %q; "+
+			"refusing to derive a path that promote would rename (#6075)", group, filepath.Clean(p), root)
+	}
+	return p, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -324,7 +349,20 @@ func resolveStagingPath(s *Server, req mcpapi.CallToolRequest, runID string) (st
 	if err != nil {
 		return "", fmt.Errorf("run_id %q not found in active runs and cannot determine project root: %w", runID, err)
 	}
+	stagingRoot := stagingRootPath(projectRoot)
 	candidate := stagingDirPath(projectRoot, runID)
+	// Found while sweeping the delete side for #6194. runID is the raw,
+	// unvalidated run_id MCP argument and filepath.Join collapses "..", so the
+	// only gate on this fallback was the os.Stat below — which ANY existing
+	// directory satisfies. The resolved path is then os.Rename()d by
+	// handleDocgenPromote and os.RemoveAll()d by handleDocgenAbort, so a
+	// caller-supplied run_id of "../../.." reached two destructive operations
+	// on a directory of its choosing. Assert containment before the stat, so
+	// the refusal does not depend on what happens to exist on disk.
+	if !registry.PathContainedUnder(stagingRoot, candidate) {
+		return "", fmt.Errorf("run_id %q resolves to %q, which is outside the staging root %q; refusing",
+			runID, filepath.Clean(candidate), stagingRoot)
+	}
 	if _, statErr := os.Stat(candidate); statErr != nil {
 		return "", fmt.Errorf("run_id %q not found (checked %s)", runID, candidate)
 	}

--- a/internal/mcp/docgen_promote_containment_6075_test.go
+++ b/internal/mcp/docgen_promote_containment_6075_test.go
@@ -1,0 +1,263 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docgen_promote_containment_6075_test.go — #6075.
+//
+// handleDocgenPromote's rotate branch os.Rename()s canonicalDocsPath(group),
+// which resolved to $HOME/.grafel/docs/<group> — the user's live docs. The
+// only thing keeping the suite from renaming a developer's real docs directory
+// was that TestWorkflowDocgenDispatch's hardcoded run ID never matched a
+// generated one, so resolveStagingPath's os.Stat failed and promote returned
+// before reaching rotate. The suite's safety was a side effect of a broken
+// fixture: anyone improving that fixture to get real coverage would have been
+// punished with no failing assertion and damage outside any temp dir.
+//
+// These tests are the coverage that was previously unsafe. They only exist
+// because the docs root is injectable now.
+
+// TestCanonicalDocsPath_HonoursInjectedRoot pins the seam itself.
+//
+// The assertion is two-sided on purpose: it is not enough that the injected
+// root is used, it must also be impossible for the resolution to land under
+// the process's real home. A seam that is consulted but falls back to $HOME on
+// any edge would satisfy the first half alone.
+func TestCanonicalDocsPath_HonoursInjectedRoot(t *testing.T) {
+	realHome := t.TempDir() // stands in for the developer's ~ during this test
+	t.Setenv("HOME", realHome)
+	t.Setenv("USERPROFILE", realHome)
+	t.Setenv("GRAFEL_HOME", filepath.Join(realHome, ".grafel"))
+
+	root := t.TempDir()
+	setDocsRootForTest(t, root)
+
+	got, err := canonicalDocsPath("g")
+	if err != nil {
+		t.Fatalf("canonicalDocsPath: %v", err)
+	}
+	want := filepath.Join(root, "g")
+	if got != want {
+		t.Fatalf("canonicalDocsPath(\"g\") = %q, want the injected root %q", got, want)
+	}
+	if strings.HasPrefix(got, realHome) {
+		t.Fatalf("canonicalDocsPath resolved under the process home %q; with a docs root injected "+
+			"it must not be able to reach $HOME at all (#6075)", realHome)
+	}
+}
+
+// TestCanonicalDocsPath_HonoursGrafelHome pins the other half of the
+// derivation: with NO override installed, the docs root must come from the
+// shared GRAFEL_HOME-aware resolver, like every other docs writer
+// (internal/daemon/docs_path.go, internal/docgen/tier*.go, internal/cli/
+// docgen.go). canonicalDocsPath read os.Getenv("HOME") directly and never
+// looked at GRAFEL_HOME, so an isolated run promoted docs to a different
+// directory than the one every reader looked in — the live split-brain
+// recorded against this function in #6178's knownDeferred ledger and deferred
+// there to this issue.
+func TestCanonicalDocsPath_HonoursGrafelHome(t *testing.T) {
+	osHome := t.TempDir()
+	grafelHome := t.TempDir() // deliberately NOT under osHome
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("GRAFEL_HOME", grafelHome)
+
+	got, err := canonicalDocsPath("g")
+	if err != nil {
+		t.Fatalf("canonicalDocsPath: %v", err)
+	}
+	want := filepath.Join(grafelHome, "docs", "g")
+	if got != want {
+		t.Fatalf("canonicalDocsPath(\"g\") = %q, want %q — the docs root must come from "+
+			"registry.HomeDir() so promote writes where every other docs path reads (#6178/#6075)", got, want)
+	}
+}
+
+// TestCanonicalDocsPath_RefusesTraversingGroup covers the input side.
+//
+// In handleDocgenPromote's disk-lookup branch the group is taken straight from
+// the MCP tool arguments (argString(req, "group", "")), and it is joined into
+// the docs root with filepath.Join, which collapses "..". Without a
+// containment assertion an agent-supplied group escapes the docs root and the
+// rotate branch renames whatever is there.
+func TestCanonicalDocsPath_RefusesTraversingGroup(t *testing.T) {
+	// Isolate the home resolvers even though the docs root is injected below:
+	// before the fix this test demonstrably resolved "../../escape" onto the
+	// developer's REAL home, because the injected root was ignored. A test
+	// that only becomes safe once the code is fixed is not a safe test.
+	sandboxGrafelHome(t)
+
+	root := filepath.Join(t.TempDir(), "docs")
+	if err := os.MkdirAll(root, 0o755); err != nil {
+		t.Fatalf("mkdir docs root: %v", err)
+	}
+	setDocsRootForTest(t, root)
+
+	for _, group := range []string{"../escape", "../../escape", "..", ""} {
+		got, err := canonicalDocsPath(group)
+		if err == nil {
+			t.Errorf("canonicalDocsPath(%q) = %q, nil; want a containment refusal — the joined "+
+				"path is outside (or equal to) the docs root %q (#6075)", group, got, root)
+		}
+		if got != "" {
+			t.Errorf("canonicalDocsPath(%q) returned path %q with its error; a refusing derivation "+
+				"must return no path, or a caller ignoring err still renames it", group, got)
+		}
+	}
+}
+
+// TestDocgenPromote_RotatesInsideInjectedDocsRoot is the coverage #6075 asks
+// for: promote actually reaching the rotate branch, which the suite could not
+// safely do before.
+//
+// Everything it touches is inside two temp dirs. The assertions check the
+// rotation really happened (old content preserved under .previous-*, new
+// content in place, staging consumed) rather than just that the call returned
+// without error — a promote that no-ops returns success too.
+func TestDocgenPromote_RotatesInsideInjectedDocsRoot(t *testing.T) {
+	// A stand-in home that nothing in this test may write to. Asserted at the
+	// end, so a regression that reverts to $HOME resolution is caught here and
+	// not on a developer's machine.
+	realHome := t.TempDir()
+	t.Setenv("HOME", realHome)
+	t.Setenv("USERPROFILE", realHome)
+	t.Setenv("GRAFEL_HOME", filepath.Join(realHome, ".grafel"))
+
+	docsRootDir := t.TempDir()
+	setDocsRootForTest(t, docsRootDir)
+
+	const group = "g"
+	const runID = "promote-rotate-fixture"
+
+	// Pre-existing canonical docs — this is what rotate must preserve.
+	canonical := filepath.Join(docsRootDir, group)
+	if err := os.MkdirAll(canonical, 0o755); err != nil {
+		t.Fatalf("mkdir canonical: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(canonical, "old.md"), []byte("previous generation"), 0o644); err != nil {
+		t.Fatalf("write old doc: %v", err)
+	}
+
+	// Staging directory, reachable through the disk-lookup branch of
+	// resolveStagingPath: <project_root>/.grafel/staging/<run_id>.
+	project := t.TempDir()
+	staging := filepath.Join(project, ".grafel", "staging", runID)
+	if err := os.MkdirAll(staging, 0o755); err != nil {
+		t.Fatalf("mkdir staging: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(staging, "new.md"), []byte("fresh generation"), 0o644); err != nil {
+		t.Fatalf("write staged doc: %v", err)
+	}
+
+	srv := coreTestServer(t)
+	out := callBare(t, srv.handleDocgenPromote, map[string]any{
+		"run_id": runID,
+		"group":  group,
+		"cwd":    project,
+		"no_git": true,
+		"force":  true, // skip frontmatter/cross-link validation; not what this test is about
+	})
+
+	var res struct {
+		CanonicalPath string   `json:"canonical_path"`
+		PreviousPath  string   `json:"previous_path"`
+		FilesMoved    []string `json:"files_moved"`
+	}
+	if err := json.Unmarshal([]byte(out), &res); err != nil {
+		t.Fatalf("promote did not return a JSON result (%v): %s", err, out)
+	}
+
+	// The rotate branch must have run — this is the branch #6075 is about, and
+	// an empty previous_path would mean the test never reached it.
+	if res.PreviousPath == "" {
+		t.Fatalf("promote returned no previous_path, so the rotate branch never ran and this "+
+			"test asserts nothing about it: %s", out)
+	}
+	if !strings.HasPrefix(res.PreviousPath, canonical+".previous-") {
+		t.Errorf("previous_path = %q, want a %q.previous-<ts> sibling", res.PreviousPath, canonical)
+	}
+	if got, err := os.ReadFile(filepath.Join(res.PreviousPath, "old.md")); err != nil || string(got) != "previous generation" {
+		t.Errorf("rotated-away docs not preserved at %s: content %q, err %v", res.PreviousPath, got, err)
+	}
+
+	// New content is in place under the injected root.
+	if res.CanonicalPath != canonical {
+		t.Errorf("canonical_path = %q, want %q", res.CanonicalPath, canonical)
+	}
+	if got, err := os.ReadFile(filepath.Join(canonical, "new.md")); err != nil || string(got) != "fresh generation" {
+		t.Errorf("staged docs not promoted into %s: content %q, err %v", canonical, got, err)
+	}
+	if _, err := os.Stat(filepath.Join(canonical, "old.md")); !os.IsNotExist(err) {
+		t.Errorf("old.md still present in canonical after promote (stat err %v); the directory was "+
+			"not replaced, it was merged", err)
+	}
+	if _, err := os.Stat(staging); !os.IsNotExist(err) {
+		t.Errorf("staging dir %s survived promote (stat err %v)", staging, err)
+	}
+	if len(res.FilesMoved) != 1 || res.FilesMoved[0] != "new.md" {
+		t.Errorf("files_moved = %v, want [new.md]", res.FilesMoved)
+	}
+
+	// Nothing may have been created under the stand-in home.
+	if entries, err := os.ReadDir(realHome); err == nil && len(entries) > 0 {
+		var names []string
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Fatalf("promote wrote into the home directory (%v) despite an injected docs root; "+
+			"this is exactly the damage #6075 describes", names)
+	}
+}
+
+// TestResolveStagingPath_RefusesTraversingRunID covers the sibling traversal
+// found while sweeping the delete side for #6194.
+//
+// resolveStagingPath's disk-lookup fallback joins the raw, unvalidated run_id
+// MCP argument into <project_root>/.grafel/staging/. filepath.Join collapses
+// "..", and the only other gate is an os.Stat that any existing directory
+// satisfies. That path is then os.Rename()d by promote (into the docs root)
+// and os.RemoveAll()d by abort — so an agent-supplied run_id reached two
+// destructive operations on an arbitrary directory.
+func TestResolveStagingPath_RefusesTraversingRunID(t *testing.T) {
+	project := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(project, ".grafel", "staging"), 0o755); err != nil {
+		t.Fatalf("mkdir staging root: %v", err)
+	}
+	// A real directory outside the staging root for the traversal to land on,
+	// so the os.Stat gate would have been satisfied.
+	victim := filepath.Join(project, "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(victim, "precious.txt"), []byte("keep"), 0o644); err != nil {
+		t.Fatalf("write victim file: %v", err)
+	}
+
+	// Premise: the traversal really does resolve onto the victim, so a refusal
+	// below is refusing something that was genuinely reachable.
+	const evil = "../../victim"
+	if got := stagingDirPath(project, evil); filepath.Clean(got) != filepath.Clean(victim) {
+		t.Fatalf("test premise broken: stagingDirPath(%q) = %q, want the victim %q", evil, got, victim)
+	}
+
+	srv := coreTestServer(t)
+	out := callBare(t, srv.handleDocgenAbort, map[string]any{
+		"run_id": evil,
+		"group":  "g",
+		"cwd":    project,
+		"no_git": true,
+	})
+
+	if _, err := os.Stat(filepath.Join(victim, "precious.txt")); err != nil {
+		t.Fatalf("abort deleted outside the staging root: %s is gone (%v); result was %s",
+			filepath.Join(victim, "precious.txt"), err, out)
+	}
+	if !strings.Contains(out, "run_id") {
+		t.Errorf("expected a run_id-related refusal, got %s", out)
+	}
+}

--- a/internal/mcp/docsroot.go
+++ b/internal/mcp/docsroot.go
@@ -1,0 +1,69 @@
+package mcp
+
+import (
+	"fmt"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// docsRootOverride holds the TEST-ONLY docs-root seam. nil (the zero value)
+// means "use the real ~/.grafel/docs"; production never stores anything here.
+//
+// #6075: handleDocgenPromote's rotate branch os.Rename()s
+// canonicalDocsPath(group), which resolved to $HOME/.grafel/docs/<group> — the
+// user's live docs. Nothing in the test suite stopped that; the suite was safe
+// only because TestWorkflowDocgenDispatch's hardcoded run ID never matched a
+// generated one, so resolveStagingPath's os.Stat failed and promote returned
+// before reaching rotate. A contributor improving that fixture to get real
+// coverage would have been doing the right thing and would have had their own
+// ~/.grafel/docs renamed, with no failing assertion and damage outside any
+// temp dir.
+//
+// A refusal-to-rotate-outside-a-designated-root would have been the cheaper
+// interim, but it leaves promote's most destructive branch permanently
+// untestable — the defect is that the branch is only reachable by accident.
+// Injecting the root instead makes it reachable ON PURPOSE, inside a
+// t.TempDir, which is what the coverage in
+// docgen_promote_containment_6075_test.go depends on.
+//
+// #6056/#6059: this MUST stay an atomic, for the same reason as clock.go's
+// nowOverride — MCP tool handlers run on live, concurrent request goroutines,
+// so a test's t.Cleanup restore would race any in-flight handler reading a
+// plain package var.
+var docsRootOverride atomic.Pointer[string]
+
+// setDocsRootOverride installs (dir != "") or clears (dir == "") the docs-root
+// seam. TEST-ONLY; never called from production. Tests should prefer the
+// t.Cleanup-scoped wrapper setDocsRootForTest (docsroot_test.go).
+func setDocsRootOverride(dir string) {
+	if dir == "" {
+		docsRootOverride.Store(nil)
+		return
+	}
+	d := dir
+	docsRootOverride.Store(&d)
+}
+
+// docsRoot returns the directory holding every group's promoted docs: the
+// injected root when the seam is installed, else <grafel home>/docs.
+//
+// The real derivation goes through registry.HomeDir(), not os.Getenv("HOME").
+// canonicalDocsPath used to read HOME directly and never consult GRAFEL_HOME,
+// while every other docs path in the tree IS GRAFEL_HOME-aware
+// (internal/daemon/docs_path.go, internal/docgen/tier0.go..tier4.go,
+// internal/cli/docgen.go's promote path) — so an isolated GRAFEL_HOME run
+// promoted docs to one directory and read them from another. That split-brain
+// was recorded in #6178's knownDeferred ledger and deferred to this issue;
+// this is where it gets paid off, and the ledger entry is removed with it.
+func docsRoot() (string, error) {
+	if p := docsRootOverride.Load(); p != nil {
+		return *p, nil
+	}
+	home, err := registry.HomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine grafel home directory: %w", err)
+	}
+	return filepath.Join(home, "docs"), nil
+}

--- a/internal/mcp/docsroot_test.go
+++ b/internal/mcp/docsroot_test.go
@@ -1,0 +1,16 @@
+package mcp
+
+import "testing"
+
+// setDocsRootForTest points every docs-root derivation at dir for the duration
+// of the test and restores the real one afterwards.
+//
+// Mirrors setFixedNowForTest (clock_test.go). Use this rather than calling
+// setDocsRootOverride directly, so a test can never leak an override into a
+// later test in the same binary — which, for this particular seam, would mean
+// a later test silently operating on the developer's real ~/.grafel/docs.
+func setDocsRootForTest(t *testing.T, dir string) {
+	t.Helper()
+	setDocsRootOverride(dir)
+	t.Cleanup(func() { setDocsRootOverride("") })
+}

--- a/internal/mcp/meta_merges_test.go
+++ b/internal/mcp/meta_merges_test.go
@@ -19,13 +19,21 @@ import (
 
 // 1. grafel_docgen action= → start/status/list/promote/abort/validate.
 func TestWorkflowDocgenDispatch(t *testing.T) {
+	// #6075: isolate the home resolvers and pin the project root into a temp
+	// dir. action=start below really does create a staging run, and with
+	// neither of these the run landed in <repo>/.grafel/staging/<date>-* in
+	// whatever working tree the suite happened to run from — the same
+	// "a test resolves to a real user path" root cause as the promote defect.
+	sandboxGrafelHome(t)
+	project := t.TempDir()
+
 	srv := coreTestServer(t)
 	runID := "2026-05-26-testid01"
-	start := map[string]any{"group": "g", "no_git": true}
-	status := map[string]any{"run_id": runID, "no_git": true}
-	validate := map[string]any{"run_id": runID, "no_git": true}
-	promote := map[string]any{"run_id": runID, "group": "g", "no_git": true}
-	abort := map[string]any{"run_id": runID, "group": "g", "no_git": true}
+	start := map[string]any{"group": "g", "no_git": true, "cwd": project}
+	status := map[string]any{"run_id": runID, "no_git": true, "cwd": project}
+	validate := map[string]any{"run_id": runID, "no_git": true, "cwd": project}
+	promote := map[string]any{"run_id": runID, "group": "g", "no_git": true, "cwd": project}
+	abort := map[string]any{"run_id": runID, "group": "g", "no_git": true, "cwd": project}
 	list := map[string]any{"group": "g"}
 
 	with := func(base map[string]any, action string) map[string]any {
@@ -48,6 +56,14 @@ func TestWorkflowDocgenDispatch(t *testing.T) {
 	// default action=status.
 	assertSameDispatch(t, "action=default", srv.handleWorkflowDocgen, status, srv.handleDocgenStatus, status)
 	assertSameDispatch(t, "action=list", srv.handleWorkflowDocgen, with(list, "list"), srv.handleDocgenList, list)
+	// NOTE (#6075): runID above is deliberately unresolvable, so promote/abort
+	// compare two identical "run_id not found" errors. That is a routing
+	// assertion only — it says nothing about promote's behaviour, and it is
+	// the reason this test never reached the rotate branch. Do NOT "improve"
+	// it by making the run ID resolvable here; that would turn a dispatch test
+	// into a destructive one. The behavioural coverage for promote/rotate
+	// lives in docgen_promote_containment_6075_test.go, against an injected
+	// docs root.
 	assertSameDispatch(t, "action=promote", srv.handleWorkflowDocgen, with(promote, "promote"), srv.handleDocgenPromote, promote)
 	assertSameDispatch(t, "action=abort", srv.handleWorkflowDocgen, with(abort, "abort"), srv.handleDocgenAbort, abort)
 	assertSameDispatch(t, "action=validate", srv.handleWorkflowDocgen, with(validate, "validate"), srv.handleDocgenValidate, validate)

--- a/internal/registry/home_sweep_guard_6178_test.go
+++ b/internal/registry/home_sweep_guard_6178_test.go
@@ -203,8 +203,12 @@ var knownDeferred = map[string]string{
 	"internal/cli/feedback_timeline.go:runFeedbackTimeline": "RELOCATABLE — feedback timeline events/out dirs key off $HOME only, never GRAFEL_HOME. Reported in the wider-pattern sweep.",
 	"internal/mcp/activity_log.go:DefaultActivityLogPath":   "UNCLEAR in the wider-pattern sweep: may be deliberate (user-level telemetry, not group data) or should follow GRAFEL_HOME like the sidecar family — needs a maintainer decision, not a mechanical fix.",
 	"internal/mcp/persona_telemetry.go:personaEventsDir":    "UNCLEAR in the wider-pattern sweep, same open question as activity_log.go's DefaultActivityLogPath.",
-	"internal/mcp/docgen.go:canonicalDocsPath":              "LIVE SPLIT-BRAIN TODAY, not merely latent — no GRAFEL_HOME check at all (os.Getenv(\"HOME\") then os.UserHomeDir(), full stop) while every other docs writer IS GRAFEL_HOME-aware (internal/daemon/docs_path.go, internal/docgen/tier0.go through tier4.go, internal/cli/docgen.go's promote path) — so an isolated GRAFEL_HOME run promotes docs today at the wrong location relative to everything else that reads/writes them. Feeds handleDocgenPromote's ~/.grafel/docs path — the same feature area as issue #6075 (\"related and not duplicate\" per #6178's own text), so left for that issue rather than folded into this one; flagged here as live, not latent, so whoever reads this ledger prioritises it correctly.",
-	"internal/mcp/server.go:NewServer":                      "RELOCATABLE, low severity — the metrics dir (~/.grafel/metrics/) is a best-effort diagnostic path, plain os.UserHomeDir() only. Reported in the wider-pattern sweep as low severity.",
+	// internal/mcp/docgen.go:canonicalDocsPath was here, flagged as a LIVE
+	// split-brain and deferred to #6075. Paid off there: the docs root now
+	// comes from mcp.docsRoot(), which resolves registry.HomeDir() (and is
+	// injectable for tests), so the function no longer hand-rolls a home path
+	// and the scan no longer reports it. This ledger only shrinks.
+	"internal/mcp/server.go:NewServer": "RELOCATABLE, low severity — the metrics dir (~/.grafel/metrics/) is a best-effort diagnostic path, plain os.UserHomeDir() only. Reported in the wider-pattern sweep as low severity.",
 }
 
 func TestNoHandRolledGrafelHomePaths(t *testing.T) {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -275,12 +275,146 @@ func ConfigPathForNew(name string) (string, error) {
 }
 
 // StateDirFor returns the per-group state directory under HomeDir.
+//
+// Like ConfigPathFor this is a READ-safe derivation and intentionally does NOT
+// validate name, so a grandfathered-invalid registry entry stays resolvable.
+// Callers that are about to DELETE the returned path must use
+// StateDirForExisting instead — see #6194 and its doc comment.
 func StateDirFor(name string) (string, error) {
 	h, err := HomeDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(h, "groups", name), nil
+}
+
+// StateRootDir is the single directory that contains every per-group state
+// directory. It exists so the delete-side containment assertion has one named
+// root instead of each call site re-deriving its own idea of "inside".
+func StateRootDir() (string, error) {
+	h, err := HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(h, "groups"), nil
+}
+
+// StateDirForExisting is the delete-side counterpart of StateDirFor: it
+// derives the same path and then asserts that the result is genuinely inside
+// the state root before handing it back (#6194).
+//
+// Why a containment assertion and not ValidateGroupName. The two purge sites
+// (install.Uninstall and the daemon's DeleteGroup) ran
+// os.RemoveAll(StateDirFor(group)) on a name taken straight from registry.json.
+// filepath.Join collapses "..", so a name like "../../../work" resolves outside
+// the state root and RemoveAll follows it. Reachability is narrow and is the
+// direct, accepted consequence of the read/write split above: no NEW invalid
+// name can be created because every write path validates, but entries that
+// predate ValidateGroupName exist by design and must keep loading. Rejecting
+// such a name here would resurrect exactly the "registry becomes unusable"
+// problem that split was written to avoid — a grandfathered group would become
+// un-uninstallable. So the gate is on the derived PATH, not on the name: a
+// weird-but-contained name like "my/group" still purges; only an escape is
+// refused.
+//
+// It returns no path alongside its error, so a caller that ignores the error
+// still cannot delete anything.
+func StateDirForExisting(name string) (string, error) {
+	root, err := StateRootDir()
+	if err != nil {
+		return "", err
+	}
+	dir, err := StateDirFor(name)
+	if err != nil {
+		return "", err
+	}
+	if !PathContainedUnder(root, dir) {
+		return "", fmt.Errorf("group %q resolves to state directory %q, which is outside the state root %q; "+
+			"refusing to derive a deletable path (#6194)", name, filepath.Clean(dir), root)
+	}
+	return dir, nil
+}
+
+// PathContainedUnder reports whether p is a strict descendant of root.
+//
+// Three things this deliberately does NOT do, each of which is a real trap:
+//
+//   - It does not use strings.HasPrefix. "/home/u/.grafel-evil" has
+//     "/home/u/.grafel" as a literal prefix but is a sibling, not a child.
+//     filepath.Rel gives "../.grafel-evil" for that pair, which is rejected on
+//     the ".." boundary, so the separator boundary is enforced by construction.
+//
+//   - It does not compare unresolved strings. If the state root is reached
+//     through a symlink (~/.grafel on another volume is a supported layout) or
+//     an intermediate component inside it is a symlink pointing back out, a
+//     lexical comparison is meaningless in both directions: it rejects the
+//     legitimate symlinked root, and it accepts "esc/x" where <root>/esc links
+//     elsewhere — which os.RemoveAll happily follows. This is the same trap as
+//     #6187 in the watcher reaper. Both sides are therefore resolved through
+//     the deepest existing ancestor before comparing.
+//
+//   - It does not resolve p's own final component. os.RemoveAll does not
+//     follow a symlink at the leaf — it unlinks the link itself — so a state
+//     directory that is a symlink to another volume is not an escape, and
+//     refusing it would break that layout for no safety gain. Only the
+//     traversed part (p's parent chain) is resolved.
+//
+// Equality is not containment: p == root returns false, so an empty group name
+// cannot resolve to the state root itself and take every group with it.
+func PathContainedUnder(root, p string) bool {
+	rootAbs, err := filepath.Abs(root)
+	if err != nil {
+		return false
+	}
+	pAbs, err := filepath.Abs(p)
+	if err != nil {
+		return false
+	}
+	rootReal := resolveDeepestExisting(rootAbs)
+	pReal := filepath.Join(resolveDeepestExisting(filepath.Dir(pAbs)), filepath.Base(pAbs))
+
+	rel, err := filepath.Rel(rootReal, pReal)
+	if err != nil {
+		// Different volumes on Windows, or otherwise incomparable. Not
+		// contained, and unknowable is the same as unsafe here.
+		return false
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return true
+}
+
+// resolveDeepestExisting returns p with its longest existing ancestor replaced
+// by that ancestor's symlink-resolved form, leaving the not-yet-existing tail
+// appended.
+//
+// filepath.EvalSymlinks fails outright if any component is missing, but a
+// state directory legitimately may not exist yet (or any more) at the moment
+// containment is checked. Walking up until something resolves keeps the
+// comparison meaningful in that case instead of silently falling back to a
+// lexical check on one side only — which would make the two sides
+// incomparable and produce false verdicts in both directions.
+//
+// If nothing at all resolves, p is returned unchanged; both sides then get the
+// same lexical treatment, which is still enough to catch a "..".
+func resolveDeepestExisting(p string) string {
+	cur := p
+	var tail []string
+	for {
+		if resolved, err := filepath.EvalSymlinks(cur); err == nil {
+			for i := len(tail) - 1; i >= 0; i-- {
+				resolved = filepath.Join(resolved, tail[i])
+			}
+			return resolved
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			return p
+		}
+		tail = append(tail, filepath.Base(cur))
+		cur = parent
+	}
 }
 
 // Load reads the registry from disk. A missing file returns an empty

--- a/internal/registry/statedir_containment_6194_test.go
+++ b/internal/registry/statedir_containment_6194_test.go
@@ -1,0 +1,217 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// sandboxHomeWithSibling builds an isolated grafel home that has a *sibling*
+// directory outside it, so a traversal escape has somewhere real to land.
+//
+// withHome (registry_test.go) points GRAFEL_HOME straight at a t.TempDir(),
+// which makes "did the derived path escape?" unanswerable: everything the test
+// can reach is inside the same TempDir either way. Here the state root is
+// nested two levels down and the canary is a sibling of the outermost dir, so
+// an escaping derivation resolves onto a path the test can stat and a contained
+// one provably cannot.
+//
+// Returns (grafelHome, canaryDir).
+func sandboxHomeWithSibling(t *testing.T) (string, string) {
+	t.Helper()
+	base := t.TempDir()
+	osHome := filepath.Join(base, "home")
+	grafelHome := filepath.Join(osHome, ".grafel")
+	if err := os.MkdirAll(filepath.Join(grafelHome, "groups"), 0o755); err != nil {
+		t.Fatalf("mkdir grafel home: %v", err)
+	}
+	canary := filepath.Join(base, "canary")
+	if err := os.MkdirAll(canary, 0o755); err != nil {
+		t.Fatalf("mkdir canary: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(canary, "precious.txt"), []byte("do not delete"), 0o644); err != nil {
+		t.Fatalf("write canary file: %v", err)
+	}
+	// Isolate all three home resolvers per the hard isolation gate: HomeDir()
+	// reads GRAFEL_HOME first today, but the other two must never be able to
+	// reach the developer's real home if that order ever changes.
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("GRAFEL_HOME", grafelHome)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "xdg"))
+	return grafelHome, canary
+}
+
+// TestStateDirForExisting_RefusesTraversingName pins #6194.
+//
+// The two purge sites (install.Uninstall, daemon removeGroup) call
+// os.RemoveAll on registry.StateDirFor(group). StateDirFor is a filepath.Join
+// of a raw registry-supplied name, and Join collapses "..", so a grandfathered
+// registry entry named "../../../canary" resolves to a directory outside the
+// state root and RemoveAll deletes it.
+//
+// The assertion is deliberately two-sided so it cannot pass vacuously:
+//  1. it first proves the OLD derivation really does escape (otherwise a
+//     refusal from the new one would prove nothing about traversal), and
+//  2. it then requires the new derivation to refuse.
+func TestStateDirForExisting_RefusesTraversingName(t *testing.T) {
+	_, canary := sandboxHomeWithSibling(t)
+
+	// Enough ".." to climb out of <home>/.grafel/groups and into the sibling.
+	const evil = "../../../canary"
+
+	// (1) The premise: the ungated derivation escapes onto the canary.
+	escaped, err := StateDirFor(evil)
+	if err != nil {
+		t.Fatalf("StateDirFor(%q): %v", evil, err)
+	}
+	if filepath.Clean(escaped) != filepath.Clean(canary) {
+		t.Fatalf("test premise broken: StateDirFor(%q) = %q, want it to resolve onto the canary %q; "+
+			"without a real escape this test would prove nothing", evil, escaped, canary)
+	}
+
+	// (2) The fix: the delete-side derivation must refuse.
+	got, err := StateDirForExisting(evil)
+	if err == nil {
+		t.Fatalf("StateDirForExisting(%q) = %q, nil; want a containment refusal (#6194)", evil, got)
+	}
+	if got != "" {
+		t.Fatalf("StateDirForExisting(%q) returned path %q alongside its error; a refusing "+
+			"derivation must return no path at all, or a caller ignoring err still deletes it", evil, got)
+	}
+}
+
+// TestStateDirForExisting_AllowsGrandfatheredContainedName is the other half
+// of #6194 and is what makes the fix a *containment* assertion rather than
+// name validation.
+//
+// "my/group" fails registry.ValidateGroupName (it contains a path separator)
+// but is still strictly inside the state root once joined. Validating the name
+// at the delete site would refuse it and resurrect the exact problem the
+// read-side validation split exists to avoid: a registry entry written before
+// validation existed becomes unusable. Only escape may be refused.
+func TestStateDirForExisting_AllowsGrandfatheredContainedName(t *testing.T) {
+	grafelHome, _ := sandboxHomeWithSibling(t)
+
+	const grandfathered = "my/group"
+
+	// Premise: this name is genuinely one that name-validation rejects, so the
+	// test distinguishes containment from validation rather than restating it.
+	if err := ValidateGroupName(grandfathered); err == nil {
+		t.Fatalf("test premise broken: ValidateGroupName(%q) accepted the name, so this test no "+
+			"longer distinguishes a containment check from name validation", grandfathered)
+	}
+
+	got, err := StateDirForExisting(grandfathered)
+	if err != nil {
+		t.Fatalf("StateDirForExisting(%q) = %v; a grandfathered-but-contained name must still "+
+			"resolve, otherwise valid registries become unpurgeable (#6194)", grandfathered, err)
+	}
+	want := filepath.Join(grafelHome, "groups", "my", "group")
+	if got != want {
+		t.Fatalf("StateDirForExisting(%q) = %q, want %q", grandfathered, got, want)
+	}
+}
+
+// TestStateDirForExisting_RefusesSiblingWithSharedPrefix pins the specific
+// trap a naive containment check falls into: strings.HasPrefix(dir, root)
+// accepts "<root>-evil" because "<root>" is a literal prefix of it. The check
+// must compare on a separator boundary (or via filepath.Rel).
+func TestStateDirForExisting_RefusesSiblingWithSharedPrefix(t *testing.T) {
+	grafelHome, _ := sandboxHomeWithSibling(t)
+	root := filepath.Join(grafelHome, "groups")
+
+	// "../groups-evil" resolves to a sibling of the state root whose path has
+	// the root as a plain string prefix.
+	const sibling = "../groups-evil"
+	escaped, err := StateDirFor(sibling)
+	if err != nil {
+		t.Fatalf("StateDirFor: %v", err)
+	}
+	if !strings.HasPrefix(escaped, root) {
+		t.Fatalf("test premise broken: %q is not a plain-string prefix match against root %q, so "+
+			"this test does not exercise the HasPrefix trap", escaped, root)
+	}
+	if filepath.Dir(escaped) == root {
+		t.Fatalf("test premise broken: %q is genuinely inside the root %q", escaped, root)
+	}
+
+	if got, err := StateDirForExisting(sibling); err == nil {
+		t.Fatalf("StateDirForExisting(%q) = %q, nil; a prefix-only match is not containment (#6194)",
+			sibling, got)
+	}
+}
+
+// TestStateDirForExisting_SymlinkEscapeAndSymlinkedRoot covers the #6187 trap
+// (same shape as the watcher reaper): a purely lexical containment check is
+// blind to symlinks in two opposite directions.
+//
+//   - False NEGATIVE (the dangerous one): "esc/x" is lexically inside the
+//     state root, but if <root>/esc is a symlink pointing elsewhere then
+//     os.RemoveAll traverses it and deletes outside the root. A Clean+Rel
+//     comparison on unresolved strings accepts this.
+//   - False POSITIVE: if the state root itself is reached through a symlink
+//     (a supported layout — ~/.grafel on another volume), an ordinary group
+//     must still resolve. A check that resolves only one side rejects it.
+//
+// Both are asserted here, so neither "resolve nothing" nor "resolve too
+// eagerly" passes.
+func TestStateDirForExisting_SymlinkEscapeAndSymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation needs elevation on Windows")
+	}
+	base := t.TempDir()
+	realState := filepath.Join(base, "real-state")
+	if err := os.MkdirAll(filepath.Join(realState, "groups"), 0o755); err != nil {
+		t.Fatalf("mkdir real state: %v", err)
+	}
+	osHome := filepath.Join(base, "home")
+	if err := os.MkdirAll(osHome, 0o755); err != nil {
+		t.Fatalf("mkdir os home: %v", err)
+	}
+	// The state root is reached through a symlink.
+	link := filepath.Join(osHome, ".grafel")
+	if err := os.Symlink(realState, link); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+	// And an intermediate component inside it points back outside.
+	outside := filepath.Join(base, "outside")
+	if err := os.MkdirAll(filepath.Join(outside, "x"), 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(realState, "groups", "esc")); err != nil {
+		t.Skipf("symlink unsupported here: %v", err)
+	}
+
+	t.Setenv("HOME", osHome)
+	t.Setenv("USERPROFILE", osHome)
+	t.Setenv("GRAFEL_HOME", link)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(base, "xdg"))
+
+	// False-positive guard: the symlinked root must not break ordinary groups.
+	if _, err := StateDirForExisting("ordinary"); err != nil {
+		t.Fatalf("StateDirForExisting(%q) through a symlinked state root = %v, want it to resolve; "+
+			"a symlinked ~/.grafel is a supported layout and must stay purgeable", "ordinary", err)
+	}
+
+	// Premise: "esc/x" really is lexically contained, so refusing it can only
+	// come from resolving the symlink, not from a Clean+Rel string check.
+	lexical, err := StateDirFor("esc/x")
+	if err != nil {
+		t.Fatalf("StateDirFor: %v", err)
+	}
+	rel, err := filepath.Rel(filepath.Join(link, "groups"), filepath.Clean(lexical))
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Fatalf("test premise broken: %q is not lexically contained (rel=%q, err=%v), so this "+
+			"test does not exercise the symlink trap", lexical, rel, err)
+	}
+
+	// False-negative guard: it resolves outside, so it must be refused.
+	if got, err := StateDirForExisting("esc/x"); err == nil {
+		t.Fatalf("StateDirForExisting(%q) = %q, nil; the path is lexically contained but resolves "+
+			"outside the state root through a symlink, which os.RemoveAll follows (#6194/#6187)",
+			"esc/x", got)
+	}
+}


### PR DESCRIPTION
Two filed defects, one class: **a destructive filesystem operation on a path derived without a containment check.** The sweep they asked for found three more, two of which are worse than either issue.

## What the sweep found that was not filed

**`resolveStagingPath` joins the raw `run_id` MCP argument into the staging root**, gated only by an `os.Stat` that any existing directory satisfies. That path is `Rename`d by promote and **`RemoveAll`d by abort**. Demonstrated with the guard removed:

```
abort deleted outside the staging root: .../victim/precious.txt is gone
result was {"aborted":true,"run_id":"../../victim","staging_path":".../victim"}
```

An MCP tool argument could delete an arbitrary directory. That is more serious than #6075 as filed and was not in it.

**`canonicalDocsPath`'s `group` is also caller-supplied** on the disk-lookup branch (`argString(req, "group", "")`). Proven against the live home before the fix: `canonicalDocsPath("../../escape")` returned `/Users/<user>/escape` — the real home, not a fixture.

Both are now containment-checked.

## #6194 — `os.RemoveAll` on an unvalidated group name

`registry.StateDirForExisting` + `registry.PathContainedUnder` assert containment on the derived **path**, not the name. That distinction is the point: the name is grandfathered, and rejecting it outright would resurrect the "registry becomes unreadable" problem the read/write validation split exists to avoid. So `"my/group"` fails `ValidateGroupName` but still purges, while `"../../../canary"` is refused. It returns `("", err)`, so a caller that ignores the error still cannot delete.

Four containment details that decide whether this works at all:

- **`filepath.Rel` with a `".."` boundary, not `strings.HasPrefix`** — a prefix test accepts the sibling `<root>-evil`.
- **Both sides resolved through their deepest existing ancestor.** Plain `EvalSymlinks` fails outright on a not-yet-existing state dir, so it would silently resolve only one side and make the comparison meaningless. This is the same trap as #6187.
- **The leaf is deliberately left unresolved.** `RemoveAll` unlinks a leaf symlink rather than following it, so a state dir symlinked to another volume is not an escape — refusing it would break a supported layout for no safety gain.
- **Equality with the root is refused**, so an empty name cannot take every group.

The containment root is `HomeDir()/groups`, tighter than the `HomeDir()` the issue proposed: `"../store"` is inside `HomeDir()` but would delete the shared store.

Both call sites now **return** the refusal instead of swallowing it — a `--purge` that reports success while leaving state is its own defect.

## #6075 — `handleDocgenPromote` renaming the real `~/.grafel/docs`

Took the **injectable seam** (`docsroot.go`, mirroring `serverNow()`/`nowOverride` including the `atomic.Pointer` requirement from #6056/#6059) rather than the cheaper refuse-to-rotate guard. A guard would leave promote's most destructive branch permanently untestable, and that *is* the defect — the filed issue's own framing is that the suite's safety was a side effect of a fixture being broken.

So the previously-unsafe coverage now exists: `TestDocgenPromote_RotatesInsideInjectedDocsRoot` drives promote **through** rotate and asserts the old content survives under `.previous-*`, the new content landed, staging was consumed, and the stand-in home is still empty.

`TestWorkflowDocgenDispatch`'s run ID was deliberately **not** made resolvable — that would convert a dispatch test into a destructive one. A comment says so and points at the real coverage.

`docsRoot()` now resolves `registry.HomeDir()`, paying off the live split-brain recorded against `canonicalDocsPath` in #6178's `knownDeferred` ledger and explicitly deferred there to this issue. The ledger entry is removed, and #6178's stale-entry guard enforces that — confirmed as mutant M8.

## The sweep — 248 non-test sites

- **(a) literal/temp, ~200.** Dominated by the atomic-write idiom (`os.CreateTemp` sibling → `Rename`, paired `Remove` on failure), safe regardless of destination; plus `MkdirTemp` teardowns and `ReadDir`/`WalkDir`-basename joins, where a dir-entry name contains no separator.
- **(b) already contained.** `daemon.StateDirForRepo/ForRepoRef` (one-way hash of a cleaned absolute path), the daemon GC sweeps, `graph/genpath.go` (further constrained by `parseGen`), `dashboard/handlers_skills.go` (explicit `/` and `..` check), the local install-state removals.
- **(c) unchecked-derived — five, all fixed here.** `install.go` purge, `service.go` purge, `service.go`'s `removeGroupArtifacts` glob, `canonicalDocsPath`, `resolveStagingPath`.

`removeGroupArtifacts`' glob was safe only *accidentally* — an escaped basename never prefix-matches a `"../"` name. Hardened rather than left to luck.

**One correction to the issue:** `cmd/grafel/daemon_tier.go:453` is not a third `registry.StateDirFor` site. It is `daemon.StateDirForRepoRef`, hash-derived — class (b), no change.

## Mutants

Nine, no survivors: containment forced true and forced false; replaced with naive `HasPrefix`; deepest-existing resolution reduced to identity; docs-root seam no-op'd; `install.go` reverted to the old call plus swallow; staging containment removed; `docsRoot` reduced to `$HOME`-only (killed by the #6178 ledger guard as well); `canonicalDocsPath` containment removed.

Re-run independently at merge: removing the staging containment reproduces the arbitrary-delete quoted at the top.

**Anti-vacuity.** Every containment test first asserts its own **premise** — that the ungated derivation genuinely escapes onto the fixture's canary, that the "grandfathered" name genuinely fails `ValidateGroupName` (so the test distinguishes containment from validation), that the prefix case is genuinely a `HasPrefix` match, that the symlink case is genuinely lexically contained. Each premise fails with an explicit "this test would prove nothing" message. Five of the #6075 tests and one of the two #6194 call-site tests were observed red before the fix.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0. `internal/registry` ok, `internal/install` ok 27.6s, `internal/mcp` ok 134.5s, `internal/daemon` ok 30.6s.

The real `~/.grafel` listing is byte-identical before and after, `~/.grafel/docs` still does not exist, and no `.grafel/` appeared in the worktree.

Closes #6194
Closes #6075
Refs #6178, #6187, #6056, #6059
