### PR TITLE
fix(#6187): a symlinked grafel had every launchd watcher classified foreign and killed on every sweep

### DIFF
--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -134,24 +134,26 @@ const (
 // These exits used to be non-zero, so an unconditional KeepAlive respawned them
 // — loudly and wastefully, but the repo did keep getting a watcher. Exiting 0
 // removes that accidental self-healing, which means any OTHER bug that kills
-// watchers now produces silence instead of noise. One such bug exists today and
-// is NOT fixed here:
+// watchers now produces silence instead of noise. One such bug existed when
+// #6179 landed and was FIXED in #6187:
 //
-//	internal/daemon/watchscan/watchscan.go's sameExe compares the reaper's
+//	internal/daemon/watchscan/watchscan.go's sameExe compared the reaper's
 //	os.Executable() against the plist's BinPath with filepath.Clean and no
-//	EvalSymlinks. When those differ only by a symlink — a brew shim, a BinPath
-//	recorded from a different install prefix — every launchd watcher for a
-//	managed repo is classified Foreign and SIGTERMed on the 5-minute sweep.
+//	EvalSymlinks. When those differed only by a symlink — a brew shim, a
+//	BinPath recorded from a different install prefix — every launchd watcher
+//	for a managed repo was classified Foreign and SIGTERMed on the 5-minute
+//	sweep.
 //
-// Before this change that was a visible reap↔respawn oscillation. After it,
-// the first reap is final: the watcher exits 0, launchd leaves it stopped, and
-// the only trace is one line in that repo's watcher.err.log. The reaper is out
-// of scope for #6179 (it is filed separately, together with whether per-repo
-// LaunchAgents should exist at all), but the interaction is real and this is
-// where someone debugging "my watchers all silently stopped" should land.
-// A coherent fix there would resolve symlinks in sameExe AND have the reaper
-// bootout the launchd unit when it reaps a launchd-owned watcher, so the
-// on-disk state stops claiming a job that is not running.
+// Before #6179 that was a visible reap↔respawn oscillation. After it, the first
+// reap was final: the watcher exits 0, launchd leaves it stopped, and the only
+// trace is one line in that repo's watcher.err.log. #6187 resolved symlinks in
+// sameExe (and made an unresolvable path mean "not skew", never "foreign"), and
+// gave the reaper an UnloadWatcherUnit hook so a repo it leaves with no watcher
+// has its unit deregistered instead of staying registered-but-dead.
+//
+// The general hazard remains and this is still where someone debugging "my
+// watchers all silently stopped" should land: exiting 0 means nothing retries,
+// so any future path that kills a watcher must also make that visible.
 var watchExitRespawn = map[watchExitReason]bool{
 	watchExitSignal:   false,
 	watchExitRepoGone: false,

--- a/internal/daemon/engineplane.go
+++ b/internal/daemon/engineplane.go
@@ -390,6 +390,13 @@ func startEnginePlane(ctx context.Context, cfg Config, svc *Service, logger *slo
 				// matched (cleaned-absolute) against this set so unrelated
 				// processes are never touched.
 				ManagedRepo: makeManagedRepoPredicate(trackedRepos),
+				// #6187: a SIGTERM is only half a reap. When a foreign reap
+				// leaves a managed repo with no watcher at all, deregister
+				// its OS unit so on-disk state stops claiming a loaded job
+				// that is not running — since #6179 the watcher exits 0 and
+				// launchd will never relaunch it, so without this the repo
+				// is silently and permanently unwatched.
+				UnloadWatcherUnit: makeWatcherUnitUnloader(logger),
 				// #5933: this reaper runs inside the ENGINE process, not the
 				// daemon/serve process that stamps watcher entries'
 				// OwnerDaemonPID (internal/cli/watch.go's liveDaemonPID), so

--- a/internal/daemon/reaper.go
+++ b/internal/daemon/reaper.go
@@ -32,6 +32,8 @@ import (
 	"errors"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/cajasmota/grafel/internal/daemon/watchreg"
@@ -98,6 +100,27 @@ type ReaperConfig struct {
 	// sweep). Injectable for tests so the sweep can be exercised without
 	// touching real processes.
 	KillWatchProc func(pid int) error
+
+	// UnloadWatcherUnit, when non-nil, deregisters the OS watcher unit for a
+	// repo path from the scheduler (launchctl bootout / systemctl disable /
+	// schtasks delete), leaving the unit FILE in place. The foreign-watcher
+	// sweep calls it for every managed repo where it reaped a foreign watcher
+	// and left NO watcher running (#6187).
+	//
+	// Killing the process is only half of a reap. The unit stays registered, so
+	// on-disk state claims a loaded job with nothing behind it — and since
+	// #6179 the watcher exits 0 on SIGTERM, so launchd will never relaunch it.
+	// Booting it out makes the two views agree: the repo now visibly HAS no
+	// watcher, which `grafel doctor` reports and `grafel start` / `grafel
+	// install` can put right, instead of a phantom that every tool believes is
+	// running.
+	//
+	// The "no watcher left" condition is what makes this safe. A foreign
+	// hand-started watcher alongside a healthy launchd-owned one is reaped
+	// without touching the unit, because nothing about that repo's state is
+	// incoherent. nil disables the deregistration entirely; the reap itself is
+	// unaffected.
+	UnloadWatcherUnit func(repoPath string)
 
 	// LiveDaemonPID returns the PID of the currently-live daemon/serve process,
 	// used to detect orphaned watchers (their OwnerDaemonPID is stamped from
@@ -361,6 +384,11 @@ func (r *Reaper) sweepForeignWatchers() int {
 		kill = sigtermPID
 	}
 
+	// repoOf remembers each PID's repo so the sweep can decide, after the kills,
+	// which repos were left with no watcher at all (see UnloadWatcherUnit).
+	// Populated from the same enumeration the plan is computed from, so the two
+	// cannot drift.
+	repoOf := map[int]string{}
 	plan := watchscan.Compute(watchscan.Deps{
 		SelfExe: selfExe,
 		Managed: r.cfg.ManagedRepo,
@@ -371,6 +399,9 @@ func (r *Reaper) sweepForeignWatchers() int {
 			}
 			out := make([]watchscan.Proc, 0, len(procs))
 			for _, p := range procs {
+				if p.PID > 0 && p.Repo != "" {
+					repoOf[p.PID] = filepath.Clean(p.Repo)
+				}
 				out = append(out, watchscan.Proc{PID: p.PID, Exe: p.Exe, Repo: p.Repo})
 			}
 			return out, nil
@@ -378,6 +409,18 @@ func (r *Reaper) sweepForeignWatchers() int {
 	})
 
 	pids := plan.PIDs()
+	// killedRepos are the repos this sweep actually terminated a watcher for,
+	// and deadPID the PIDs it terminated. Together they answer the only
+	// question the unload step asks: did the sweep leave a repo with NO watcher
+	// at all? A repo is entered here on ANY successful kill, foreign or
+	// duplicate — the two need not be distinguished, because a duplicate
+	// collapse always keeps a survivor by construction (pickSurvivor's choice
+	// is never in the plan) and so can never satisfy the no-watcher-left
+	// condition. Making that an explicit second condition would add a branch no
+	// test could falsify.
+	killedRepos := map[string]bool{}
+	deadPID := map[int]bool{}
+
 	reaped := 0
 	for _, pid := range pids {
 		if pid == os.Getpid() {
@@ -388,12 +431,52 @@ func (r *Reaper) sweepForeignWatchers() int {
 			continue
 		}
 		reaped++
+		deadPID[pid] = true
+		if repo := repoOf[pid]; repo != "" {
+			killedRepos[repo] = true
+		}
 	}
 	if reaped > 0 {
 		r.logger.Info("reaper: reaped foreign/duplicate grafel-watch processes",
 			"reaped", reaped, "foreign", len(plan.Foreign), "duplicate", len(plan.Duplicate))
 	}
+	r.unloadOrphanedWatcherUnits(killedRepos, deadPID, repoOf)
 	return reaped
+}
+
+// unloadOrphanedWatcherUnits deregisters the OS unit of every repo in
+// killedRepos that has NO surviving watcher process (#6187). A repo where some
+// watcher is still alive — including one whose SIGTERM failed, and including
+// the survivor a duplicate collapse deliberately keeps — is left alone: its
+// unit is not lying about anything, and booting it out would take a healthy
+// watcher down. That single condition is what keeps this safe against the
+// awkward case, a hand-started stale-binary watcher reaped alongside a healthy
+// launchd-owned one.
+//
+// Repos are visited in sorted order so a sweep's side effects and its log lines
+// are reproducible.
+func (r *Reaper) unloadOrphanedWatcherUnits(killedRepos map[string]bool, deadPID map[int]bool, repoOf map[int]string) {
+	if r.cfg.UnloadWatcherUnit == nil || len(killedRepos) == 0 {
+		return
+	}
+	survives := map[string]bool{}
+	for pid, repo := range repoOf {
+		if !deadPID[pid] {
+			survives[repo] = true
+		}
+	}
+	orphaned := make([]string, 0, len(killedRepos))
+	for repo := range killedRepos {
+		if !survives[repo] {
+			orphaned = append(orphaned, repo)
+		}
+	}
+	sort.Strings(orphaned)
+	for _, repo := range orphaned {
+		r.logger.Info("reaper: deregistering watcher unit for a repo left with no watcher after a foreign reap (#6187)",
+			"repo", repo)
+		r.cfg.UnloadWatcherUnit(repo)
+	}
 }
 
 // sigtermPID sends SIGTERM to pid via the process package's portable Kill.

--- a/internal/daemon/reaper_foreign_watch_test.go
+++ b/internal/daemon/reaper_foreign_watch_test.go
@@ -28,21 +28,29 @@ func managedClean(repos ...string) func(string) bool {
 // for a MANAGED repo is SIGTERM'd, while a same-exe watcher and a watcher for an
 // UNMANAGED repo are left alone. Kills are observed via the injected
 // KillWatchProc so no real process is touched.
+// The exe fixtures are REAL, DISTINCT FILES. With the string literals this test
+// originally used, #6187's fix makes both paths unresolvable, so neither is
+// provable skew, PID 100 lands in the survivor set and is reaped as a
+// DUPLICATE instead — same killed list, entirely different code path, and the
+// test's name becomes a lie. The unload hook is wired to a recorder rather than
+// left nil so this also pins that the SIGTERM alone is not the whole reap.
 func TestReaper_sweepForeignWatchers(t *testing.T) {
-	const self = "/home/u/.grafel/bin/grafel"
+	self, foreign := twoRealExes(t)
 
 	var killed []int
+	var unloaded []string
 	r := NewReaper(ReaperConfig{
 		SelfExe:     func() (string, error) { return self, nil },
 		ManagedRepo: managedClean("/work/repo-a"),
 		ListWatchProcs: func() ([]process.WatchProc, error) {
 			return []process.WatchProc{
-				{PID: 100, Exe: "/home/u/go/bin/grafel", Repo: "/work/repo-a"},  // foreign, managed → reap
-				{PID: 101, Exe: self, Repo: "/work/repo-a"},                     // own, managed → keep
-				{PID: 102, Exe: "/home/u/go/bin/grafel", Repo: "/other/repo-z"}, // foreign, UNMANAGED → keep
+				{PID: 100, Exe: foreign, Repo: "/work/repo-a"},  // foreign, managed → reap
+				{PID: 101, Exe: self, Repo: "/work/repo-a"},     // own, managed → keep
+				{PID: 102, Exe: foreign, Repo: "/other/repo-z"}, // foreign, UNMANAGED → keep
 			}, nil
 		},
-		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+		KillWatchProc:     func(pid int) error { killed = append(killed, pid); return nil },
+		UnloadWatcherUnit: func(repo string) { unloaded = append(unloaded, repo) },
 	})
 
 	res := r.Sweep()
@@ -51,6 +59,11 @@ func TestReaper_sweepForeignWatchers(t *testing.T) {
 	}
 	if !reflect.DeepEqual(killed, []int{100}) {
 		t.Fatalf("killed = %v, want [100] (only the foreign managed-repo watcher)", killed)
+	}
+	// repo-a keeps a live watcher (101) and repo-z was never touched, so no
+	// unit is left claiming a job that is not running.
+	if len(unloaded) != 0 {
+		t.Fatalf("unloaded = %v, want none (every repo still has a watcher)", unloaded)
 	}
 }
 

--- a/internal/daemon/reaper_unload_6187_test.go
+++ b/internal/daemon/reaper_unload_6187_test.go
@@ -1,0 +1,196 @@
+package daemon
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/process"
+)
+
+// realExe creates an actual file and returns its path. Required for the same
+// reason as in internal/daemon/watchscan (#6187): version skew is only declared
+// between two paths that BOTH resolve on disk, so a foreign-watcher fixture
+// built from string literals silently stops being a foreign-watcher fixture.
+func realExe(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("fixture premise broken: %s must exist: %v", p, err)
+	}
+	return p
+}
+
+// twoRealExes builds a self/foreign pair and asserts the premise that they are
+// two distinct, existing binaries — otherwise "foreign" would not be provable
+// and the sweep under test would correctly reap nothing, passing the
+// no-unload assertions for entirely the wrong reason.
+func twoRealExes(t *testing.T) (self, foreign string) {
+	t.Helper()
+	root := t.TempDir()
+	self = realExe(t, filepath.Join(root, "installed"), "grafel")
+	foreign = realExe(t, filepath.Join(root, "gopath"), "grafel")
+	if filepath.Clean(self) == filepath.Clean(foreign) {
+		t.Fatalf("fixture premise broken: %q and %q must differ", self, foreign)
+	}
+	fs, _ := os.Stat(self)
+	ff, _ := os.Stat(foreign)
+	if os.SameFile(fs, ff) {
+		t.Fatalf("fixture premise broken: self and foreign must be different files")
+	}
+	return self, foreign
+}
+
+// #6187, second half. When the sweep reaps a foreign watcher and NO watcher is
+// left running for that repo, the OS unit is deregistered.
+//
+// Killing the process alone leaves incoherent on-disk state: the plist says the
+// job is loaded, nothing is running, and since #6179 the watcher exits 0 so
+// launchd will never bring it back. Booting the unit out makes the two agree,
+// so `grafel doctor` / `grafel start` see an absent watcher instead of a
+// phantom loaded one.
+func TestReaper_foreignReapUnloadsWatcherUnit(t *testing.T) {
+	self, foreign := twoRealExes(t)
+
+	var killed []int
+	var unloaded []string
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: managedClean("/work/repo-a"),
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 100, Exe: foreign, Repo: "/work/repo-a"},
+			}, nil
+		},
+		KillWatchProc:     func(pid int) error { killed = append(killed, pid); return nil },
+		UnloadWatcherUnit: func(repo string) { unloaded = append(unloaded, repo) },
+	})
+
+	res := r.Sweep()
+	if res.ForeignWatchersReaped != 1 || !reflect.DeepEqual(killed, []int{100}) {
+		t.Fatalf("reaped=%d killed=%v, want 1 / [100]", res.ForeignWatchersReaped, killed)
+	}
+	if want := []string{filepath.Clean("/work/repo-a")}; !reflect.DeepEqual(unloaded, want) {
+		t.Fatalf("unloaded = %v, want %v", unloaded, want)
+	}
+}
+
+// A repo that still has a live watcher after the sweep must NOT have its unit
+// booted out. This is the case that makes an unconditional bootout dangerous: a
+// hand-started stale-binary watcher is reaped while the launchd-owned one is
+// perfectly healthy, and deregistering the unit would take the healthy watcher
+// down with it. Nothing is incoherent here — the plist says loaded and a
+// watcher IS running — so there is nothing to repair.
+func TestReaper_foreignReapKeepsUnitWhenWatcherSurvives(t *testing.T) {
+	self, foreign := twoRealExes(t)
+
+	var killed []int
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: managedClean("/work/repo-a"),
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 100, Exe: foreign, Repo: "/work/repo-a"}, // reaped
+				{PID: 101, Exe: self, Repo: "/work/repo-a"},    // survives
+			}, nil
+		},
+		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+		UnloadWatcherUnit: func(repo string) {
+			t.Fatalf("must not unload %s: a watcher for it is still running", repo)
+		},
+	})
+
+	res := r.Sweep()
+	if res.ForeignWatchersReaped != 1 || !reflect.DeepEqual(killed, []int{100}) {
+		t.Fatalf("reaped=%d killed=%v, want 1 / [100] (the premise: exactly one reap, one survivor)", res.ForeignWatchersReaped, killed)
+	}
+}
+
+// A DUPLICATE-only reap never unloads. Duplicates are collapsed precisely
+// because one watcher for the repo remains, so the unit is doing its job and
+// deregistering it would be a plain regression.
+func TestReaper_duplicateReapDoesNotUnloadUnit(t *testing.T) {
+	self, _ := twoRealExes(t)
+
+	var killed []int
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: managedClean("/work/repo-a"),
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 200, Exe: self, Repo: "/work/repo-a"},
+				{PID: 300, Exe: self, Repo: "/work/repo-a"},
+				{PID: 400, Exe: self, Repo: "/work/repo-a"},
+			}, nil
+		},
+		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+		UnloadWatcherUnit: func(repo string) {
+			t.Fatalf("must not unload %s on a duplicate collapse", repo)
+		},
+	})
+
+	res := r.Sweep()
+	sort.Ints(killed)
+	if res.ForeignWatchersReaped != 2 || !reflect.DeepEqual(killed, []int{300, 400}) {
+		t.Fatalf("reaped=%d killed=%v, want 2 / [300 400] (the premise: a duplicate collapse happened)", res.ForeignWatchersReaped, killed)
+	}
+}
+
+// If the SIGTERM failed, the watcher is still running. Deregistering the unit
+// then would produce exactly the incoherence this half exists to remove, only
+// inverted: launchd no longer owns a process that is still alive.
+func TestReaper_failedKillDoesNotUnloadUnit(t *testing.T) {
+	self, foreign := twoRealExes(t)
+
+	attempted := 0
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: managedClean("/work/repo-a"),
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{
+				{PID: 100, Exe: foreign, Repo: "/work/repo-a"},
+			}, nil
+		},
+		KillWatchProc: func(int) error { attempted++; return errors.New("EPERM") },
+		UnloadWatcherUnit: func(repo string) {
+			t.Fatalf("must not unload %s: its watcher could not be killed", repo)
+		},
+	})
+
+	res := r.Sweep()
+	if attempted != 1 {
+		t.Fatalf("kill attempts = %d, want 1 (the premise: a reap was attempted at all)", attempted)
+	}
+	if res.ForeignWatchersReaped != 0 {
+		t.Fatalf("ForeignWatchersReaped = %d, want 0 when the kill failed", res.ForeignWatchersReaped)
+	}
+}
+
+// A nil UnloadWatcherUnit must leave the sweep working exactly as before —
+// every caller that does not wire the hook (tests, non-service deployments)
+// still reaps.
+func TestReaper_nilUnloadHookIsHarmless(t *testing.T) {
+	self, foreign := twoRealExes(t)
+
+	var killed []int
+	r := NewReaper(ReaperConfig{
+		SelfExe:     func() (string, error) { return self, nil },
+		ManagedRepo: managedClean("/work/repo-a"),
+		ListWatchProcs: func() ([]process.WatchProc, error) {
+			return []process.WatchProc{{PID: 100, Exe: foreign, Repo: "/work/repo-a"}}, nil
+		},
+		KillWatchProc: func(pid int) error { killed = append(killed, pid); return nil },
+	})
+	if res := r.Sweep(); res.ForeignWatchersReaped != 1 || !reflect.DeepEqual(killed, []int{100}) {
+		t.Fatalf("reaped=%d killed=%v, want 1 / [100]", res.ForeignWatchersReaped, killed)
+	}
+}

--- a/internal/daemon/watcher_unit_unload.go
+++ b/internal/daemon/watcher_unit_unload.go
@@ -1,0 +1,104 @@
+// watcher_unit_unload.go — the production half of ReaperConfig.UnloadWatcherUnit
+// (#6187).
+//
+// The foreign-watcher sweep decides WHICH repos were left with no watcher after
+// a reap (reaper.go, unit-tested against a fake hook). This file is the part
+// that touches the machine: it maps a repo path back to its installed watcher
+// unit and deregisters that unit from the OS scheduler.
+//
+// Why the reaper needs this at all: SIGTERMing the process is only half a reap.
+// The launchd job stays bootstrapped, so `launchctl list` and every tool built
+// on it still report a loaded watcher for a repo that has none — and since
+// #6179 the watcher exits 0 on SIGTERM, so launchd deliberately never brings it
+// back. Booting the unit out is what turns "silently broken" into "visibly
+// absent", which is a state `grafel doctor` reports and `grafel start` /
+// `grafel install` can put right.
+//
+// The unit FILE is deliberately left on disk. It is the repo's configuration,
+// not its runtime state; deleting it would discard information the user did not
+// ask us to discard and would make re-establishment harder, not easier.
+package daemon
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// newWatcherUnitLoader constructs the OS scheduler loader. A package var so
+// tests can observe which unit was deregistered: the real darwin loader probes
+// `launchctl list` first and short-circuits when the label is not loaded (which
+// it never is under a sandboxed HOME), so stubbing the command runner alone
+// cannot show the label. Production never replaces it.
+var newWatcherUnitLoader = watchers.NewLoader
+
+// makeWatcherUnitUnloader returns the ReaperConfig.UnloadWatcherUnit hook.
+//
+// It is conservative by construction. It acts only on a repo that is REGISTERED
+// (so the group — and therefore the unit label — is derived, never guessed) and
+// whose unit file is actually present on disk (so it never calls the scheduler
+// about a unit nothing installed). Anything else is a no-op with a debug line.
+func makeWatcherUnitUnloader(logger *slog.Logger) func(repoPath string) {
+	return func(repoPath string) {
+		u, unitPath, ok := watcherUnitForRepo(repoPath, logger)
+		if !ok {
+			logger.Debug("reaper: no installed watcher unit for reaped repo — nothing to deregister",
+				"repo", repoPath)
+			return
+		}
+		// Unload, not Cleanup: deactivate the registration, keep the unit file.
+		if err := newWatcherUnitLoader().Unload(u); err != nil {
+			logger.Warn("reaper: could not deregister watcher unit after reaping its watcher (non-fatal)",
+				"repo", repoPath, "label", u.Label(), "unit", unitPath, "err", err)
+			return
+		}
+		logger.Info("reaper: deregistered watcher unit whose watcher was reaped as foreign (#6187) — "+
+			"run `grafel install` or `grafel start` to re-establish it",
+			"repo", repoPath, "label", u.Label(), "unit", unitPath)
+	}
+}
+
+// watcherUnitForRepo resolves repoPath to its installed watcher unit, returning
+// the unit, its on-disk path, and whether one was found.
+//
+// The group is what makes a label derivable, and only the registry knows it, so
+// an unregistered repo yields nothing rather than a guess. A group whose config
+// cannot be read is skipped: one unreadable fleet.json must not stop the others
+// from being resolved.
+func watcherUnitForRepo(repoPath string, logger *slog.Logger) (watchers.Unit, string, bool) {
+	bin, _ := os.Executable() // best effort; Label/UnitPath do not depend on it.
+	want := filepath.Clean(repoPath)
+
+	refs, err := registry.Groups()
+	if err != nil {
+		logger.Warn("reaper: cannot read group registry to locate a watcher unit (non-fatal)", "err", err)
+		return watchers.Unit{}, "", false
+	}
+	for _, ref := range refs {
+		cfg, err := registry.LoadGroupConfig(ref.ConfigPath)
+		if err != nil {
+			logger.Debug("reaper: skipping unreadable group config while locating a watcher unit",
+				"group", ref.Name, "err", err)
+			continue
+		}
+		for _, r := range cfg.Repos {
+			if filepath.Clean(r.Path) != want {
+				continue
+			}
+			u := watchers.Unit{Group: ref.Name, Repo: r.Path, BinPath: bin}
+			path, err := watchers.UnitPath(u)
+			if err != nil {
+				logger.Debug("reaper: cannot derive unit path", "group", ref.Name, "repo", r.Path, "err", err)
+				continue
+			}
+			if _, err := os.Stat(path); err != nil {
+				continue // no unit installed for this repo — nothing to deregister.
+			}
+			return u, path, true
+		}
+	}
+	return watchers.Unit{}, "", false
+}

--- a/internal/daemon/watcher_unit_unload_6187_test.go
+++ b/internal/daemon/watcher_unit_unload_6187_test.go
@@ -1,0 +1,195 @@
+package daemon
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install/watchers"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// recordingLoader observes Unload without any launchctl/systemctl/schtasks
+// call. The real darwin loader probes `launchctl list` and short-circuits when
+// the label is not loaded — which under a sandboxed HOME it never is — so a
+// stubbed command runner alone could not show WHICH unit was named, and the
+// assertion that matters here is exactly which unit was named.
+type recordingLoader struct{ unloaded *[]watchers.Unit }
+
+func (l recordingLoader) Load(watchers.Unit) error { return nil }
+func (l recordingLoader) Unload(u watchers.Unit) error {
+	*l.unloaded = append(*l.unloaded, u)
+	return nil
+}
+func (l recordingLoader) Status(watchers.Unit) (watchers.WatcherStatus, error) {
+	return watchers.WatcherStatus{}, nil
+}
+
+// sandboxWatcherHome redirects grafel's home, the OS unit directory and the
+// systemd/XDG directory into a temp tree, and stubs every service-manager
+// invocation. Nothing this test does may reach ~/.grafel or the developer's
+// live launchd session.
+func sandboxWatcherHome(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	t.Setenv("HOME", root)
+	t.Setenv("USERPROFILE", root) // os.UserHomeDir on Windows
+	t.Setenv("GRAFEL_HOME", filepath.Join(root, ".grafel"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(root, ".config"))
+	t.Cleanup(watchers.StubServiceCallsForTest())
+
+	// Premise: the sandbox actually took. If HomeDir still pointed at the real
+	// ~/.grafel every assertion below would be reading the developer's machine.
+	got, err := registry.HomeDir()
+	if err != nil {
+		t.Fatalf("registry.HomeDir: %v", err)
+	}
+	if got != filepath.Join(root, ".grafel") {
+		t.Fatalf("sandbox premise broken: registry.HomeDir() = %q, want it under %q", got, root)
+	}
+	return root
+}
+
+// registerRepo writes a registry + group config naming repoPath, and returns
+// the group name.
+func registerRepo(t *testing.T, repoPath string) string {
+	t.Helper()
+	home, err := registry.HomeDir()
+	if err != nil {
+		t.Fatalf("HomeDir: %v", err)
+	}
+	const group = "g"
+	cfgPath := filepath.Join(home, "groups", group, "fleet.json")
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	cfg := map[string]any{
+		"name":  group,
+		"repos": []map[string]any{{"name": filepath.Base(repoPath), "path": repoPath}},
+	}
+	writeJSON(t, cfgPath, cfg)
+	writeJSON(t, filepath.Join(home, "registry.json"), map[string]any{
+		"groups": []map[string]any{{"name": group, "config_path": cfgPath}},
+	})
+
+	// Premise: the registry we just wrote is the one the resolver will read.
+	refs, err := registry.Groups()
+	if err != nil || len(refs) != 1 || refs[0].Name != group {
+		t.Fatalf("fixture premise broken: registry.Groups() = %v, err = %v", refs, err)
+	}
+	return group
+}
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal %s: %v", path, err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func quietLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// #6187: the production unloader finds the registered repo's unit and
+// deregisters exactly that unit from the OS scheduler.
+func TestWatcherUnitUnloader_UnloadsTheRegisteredRepoUnit(t *testing.T) {
+	sandboxWatcherHome(t)
+	repo := t.TempDir()
+	group := registerRepo(t, repo)
+
+	// Install a unit file for the repo — the resolver only deregisters units
+	// it can see on disk.
+	want := watchers.Unit{Group: group, Repo: repo, BinPath: "/anything"}
+	unitPath, err := watchers.Write(want)
+	if err != nil {
+		t.Fatalf("write unit: %v", err)
+	}
+	if _, err := os.Stat(unitPath); err != nil {
+		t.Fatalf("fixture premise broken: unit file %s must exist: %v", unitPath, err)
+	}
+
+	var unloaded []watchers.Unit
+	prev := newWatcherUnitLoader
+	newWatcherUnitLoader = func() watchers.Loader { return recordingLoader{&unloaded} }
+	t.Cleanup(func() { newWatcherUnitLoader = prev })
+
+	makeWatcherUnitUnloader(quietLogger())(repo)
+
+	if len(unloaded) != 1 {
+		t.Fatalf("unloaded %d units, want exactly 1: %v", len(unloaded), unloaded)
+	}
+	// Label is the identity launchctl/systemd/schtasks key off, so that is what
+	// must match — not the struct, whose BinPath the resolver fills from
+	// os.Executable().
+	if got := unloaded[0].Label(); got != want.Label() {
+		t.Fatalf("unloaded label = %q, want %q", got, want.Label())
+	}
+}
+
+// A repo with no unit file installed is left entirely alone: there is no
+// registration to repair, and calling the OS scheduler for a unit that was
+// never written can only produce noise.
+func TestWatcherUnitUnloader_NoUnitFileNoCall(t *testing.T) {
+	sandboxWatcherHome(t)
+	repo := t.TempDir()
+	registerRepo(t, repo)
+
+	var unloaded []watchers.Unit
+	prev := newWatcherUnitLoader
+	newWatcherUnitLoader = func() watchers.Loader { return recordingLoader{&unloaded} }
+	t.Cleanup(func() { newWatcherUnitLoader = prev })
+
+	makeWatcherUnitUnloader(quietLogger())(repo)
+
+	if len(unloaded) != 0 {
+		t.Fatalf("unloaded = %v, want none (no unit file was ever installed)", unloaded)
+	}
+}
+
+// A repo that is not in the registry at all is never acted on. The reaper can
+// see `grafel watch` processes for paths grafel does not manage; the unloader
+// must not guess a group for them — and in particular must not deregister SOME
+// OTHER repo's unit just because that one happened to be resolvable.
+//
+// The registered repo therefore gets a REAL, INSTALLED unit. Without it the
+// unit-file existence check alone would reject every candidate and the test
+// would pass with the repo-path match deleted.
+func TestWatcherUnitUnloader_UnregisteredRepoNoCall(t *testing.T) {
+	sandboxWatcherHome(t)
+	registered := t.TempDir()
+	group := registerRepo(t, registered)
+	stranger := t.TempDir()
+
+	if filepath.Clean(stranger) == filepath.Clean(registered) {
+		t.Fatal("fixture premise broken: the two repo paths must differ")
+	}
+	decoy, err := watchers.Write(watchers.Unit{Group: group, Repo: registered, BinPath: "/anything"})
+	if err != nil {
+		t.Fatalf("write decoy unit: %v", err)
+	}
+	if _, err := os.Stat(decoy); err != nil {
+		t.Fatalf("fixture premise broken: the registered repo must have an installed unit to be mis-matched against: %v", err)
+	}
+
+	var unloaded []watchers.Unit
+	prev := newWatcherUnitLoader
+	newWatcherUnitLoader = func() watchers.Loader { return recordingLoader{&unloaded} }
+	t.Cleanup(func() { newWatcherUnitLoader = prev })
+
+	makeWatcherUnitUnloader(quietLogger())(stranger)
+
+	if len(unloaded) != 0 {
+		t.Fatalf("unloaded = %v, want none for an unregistered repo", unloaded)
+	}
+}

--- a/internal/daemon/watchscan/exe_resolve_6187_test.go
+++ b/internal/daemon/watchscan/exe_resolve_6187_test.go
@@ -1,0 +1,170 @@
+package watchscan
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// writeExe creates a real, distinct file under dir and returns its absolute
+// path. Real files matter: after #6187 the reaper only declares version skew
+// when BOTH executable paths resolve on disk, so a fixture built from string
+// literals that name nothing would make every "genuinely foreign" assertion
+// vacuously pass through the not-resolvable escape hatch instead of through the
+// comparison under test.
+func writeExe(t *testing.T, dir, name string) string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write %s: %v", p, err)
+	}
+	return p
+}
+
+// mustExist asserts the test's own premise that p names something on disk. A
+// fixture that silently failed to create the file would otherwise be read as
+// "not resolvable" and pass the not-reaped assertions for the wrong reason.
+func mustExist(t *testing.T, p string) {
+	t.Helper()
+	if _, err := os.Stat(p); err != nil {
+		t.Fatalf("fixture premise broken: %s must exist on disk: %v", p, err)
+	}
+}
+
+// mustNotExist asserts the converse premise for the unresolvable cases.
+func mustNotExist(t *testing.T, p string) {
+	t.Helper()
+	if _, err := os.Stat(p); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("fixture premise broken: %s must NOT exist (stat err = %v)", p, err)
+	}
+}
+
+// mustDifferTextually asserts the two paths are not the same string after
+// Clean. Every test below exists to probe what happens BEYOND the lexical
+// comparison; if the fixture accidentally produced two equal strings, the old
+// filepath.Clean path would short-circuit and the assertion would say nothing.
+func mustDifferTextually(t *testing.T, a, b string) {
+	t.Helper()
+	if filepath.Clean(a) == filepath.Clean(b) {
+		t.Fatalf("fixture premise broken: %q and %q must differ textually after Clean", a, b)
+	}
+}
+
+// mustBeSameFile asserts two paths reach the same inode, so a symlink fixture
+// that silently failed to link (or linked to the wrong target) cannot pass as
+// coverage of "same binary, different spelling".
+func mustBeSameFile(t *testing.T, a, b string) {
+	t.Helper()
+	fa, err := os.Stat(a)
+	if err != nil {
+		t.Fatalf("fixture premise broken: stat %s: %v", a, err)
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		t.Fatalf("fixture premise broken: stat %s: %v", b, err)
+	}
+	if !os.SameFile(fa, fb) {
+		t.Fatalf("fixture premise broken: %s and %s must be the SAME file", a, b)
+	}
+}
+
+// mustBeDifferentFiles is the converse premise for the genuine-skew fixture.
+func mustBeDifferentFiles(t *testing.T, a, b string) {
+	t.Helper()
+	fa, err := os.Stat(a)
+	if err != nil {
+		t.Fatalf("fixture premise broken: stat %s: %v", a, err)
+	}
+	fb, err := os.Stat(b)
+	if err != nil {
+		t.Fatalf("fixture premise broken: stat %s: %v", b, err)
+	}
+	if os.SameFile(fa, fb) {
+		t.Fatalf("fixture premise broken: %s and %s must be DIFFERENT files", a, b)
+	}
+}
+
+// #6187 (direction 2 of 2): a genuinely foreign binary — a different file, both
+// resolvable — is still reaped. Without this the symlink fix would be
+// unfalsifiable: "never reap anything" also passes the not-reaped tests.
+func TestCompute_GenuinelyForeignExeStillReaped(t *testing.T) {
+	root := t.TempDir()
+	self := writeExe(t, filepath.Join(root, "installed", "bin"), "grafel")
+	stale := writeExe(t, filepath.Join(root, "gopath", "bin"), "grafel")
+
+	mustExist(t, self)
+	mustExist(t, stale)
+	mustDifferTextually(t, self, stale)
+	mustBeDifferentFiles(t, self, stale)
+
+	plan := Compute(Deps{
+		SelfExe: self,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 100, Exe: stale, Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if got, want := plan.PIDs(), []int{100}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs() = %v, want %v (a different, existing binary is genuine version skew)", got, want)
+	}
+	if len(plan.Foreign) != 1 || plan.Foreign[0] != 100 {
+		t.Fatalf("Foreign = %v, want [100]", plan.Foreign)
+	}
+}
+
+// #6187: the watcher's recorded executable no longer exists — the ordinary
+// state of a stale plist whose BinPath pointed at an install prefix that has
+// since been removed or moved. Skew is UNKNOWABLE there, and the fail-safe
+// verdict is "not foreign": misclassifying kills the user's watchers
+// permanently (#6179 removed the respawn), whereas declining to reap a
+// genuinely foreign watcher is recoverable and loud.
+func TestCompute_UnresolvableWatcherExeNotReaped(t *testing.T) {
+	root := t.TempDir()
+	self := writeExe(t, filepath.Join(root, "installed", "bin"), "grafel")
+	gone := filepath.Join(root, "removed", "bin", "grafel")
+
+	mustExist(t, self)
+	mustNotExist(t, gone)
+	mustDifferTextually(t, self, gone)
+
+	plan := Compute(Deps{
+		SelfExe: self,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 100, Exe: gone, Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty (an unresolvable watcher exe is not provable skew)", pids)
+	}
+}
+
+// #6187, the mirror case: the DAEMON's own executable is the one that no longer
+// resolves (it was replaced in place by an upgrade, or read from a stale
+// pidfile-era path). Same verdict, same reason — skew cannot be established
+// from a path that names nothing.
+func TestCompute_UnresolvableSelfExeNotReaped(t *testing.T) {
+	root := t.TempDir()
+	live := writeExe(t, filepath.Join(root, "installed", "bin"), "grafel")
+	goneSelf := filepath.Join(root, "removed", "bin", "grafel")
+
+	mustExist(t, live)
+	mustNotExist(t, goneSelf)
+	mustDifferTextually(t, live, goneSelf)
+
+	plan := Compute(Deps{
+		SelfExe: goneSelf,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 100, Exe: live, Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty (an unresolvable SELF exe is not provable skew)", pids)
+	}
+}

--- a/internal/daemon/watchscan/exe_symlink_6187_notwindows_test.go
+++ b/internal/daemon/watchscan/exe_symlink_6187_notwindows_test.go
@@ -1,0 +1,107 @@
+//go:build !windows
+
+// The symlink fixtures below need os.Symlink to succeed unprivileged, which is
+// not the case on Windows. The exclusion is a BUILD TAG, not runtime.GOOS plus
+// t.Skip: a runtime skip still has to compile, and #6218 showed that a test
+// guarded only at execution time can break the build on the platforms it was
+// meant to spare. The resolvable/unresolvable behaviour these tests share with
+// every OS is covered platform-agnostically in exe_resolve_6187_test.go.
+
+package watchscan
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+// symlinkExe creates link -> target and returns link. It asserts the link
+// genuinely resolves to target's inode, so a fixture that quietly produced a
+// dangling or wrong link cannot masquerade as coverage.
+func symlinkExe(t *testing.T, target, link string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(link), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(link), err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink %s -> %s: %v", link, target, err)
+	}
+	mustBeSameFile(t, target, link)
+	return link
+}
+
+// #6187 (direction 1 of 2), the exact production shape: grafel is invoked
+// through a shim — a Homebrew symlink in /opt/homebrew/bin, or a plist BinPath
+// recorded from a different install prefix — so the daemon's os.Executable()
+// and the watcher's executable are DIFFERENT STRINGS naming the SAME binary.
+// Before the fix, filepath.Clean called that version skew and every launchd
+// watcher for every managed repo was SIGTERMed on each 5-minute sweep; after
+// #6179 the first reap was final and silent.
+func TestCompute_SymlinkedShimIsNotForeign(t *testing.T) {
+	root := t.TempDir()
+	real := writeExe(t, filepath.Join(root, "Cellar", "grafel", "bin"), "grafel")
+	shim := symlinkExe(t, real, filepath.Join(root, "brew", "bin", "grafel"))
+
+	// Premises: two different spellings, one binary.
+	mustExist(t, real)
+	mustExist(t, shim)
+	mustDifferTextually(t, real, shim)
+	mustBeSameFile(t, real, shim)
+
+	plan := Compute(Deps{
+		// The daemon was spawned via the shim; the watcher's plist BinPath
+		// records the resolved Cellar path (or vice versa — both directions
+		// asserted below).
+		SelfExe: shim,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 100, Exe: real, Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty (shim and target are the same binary)", pids)
+	}
+
+	// Symmetry: the same must hold with the roles swapped.
+	plan = Compute(Deps{
+		SelfExe: real,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{{PID: 100, Exe: shim, Repo: "/work/repo-a"}}, nil
+		},
+	})
+	if pids := plan.PIDs(); len(pids) != 0 {
+		t.Fatalf("PIDs() = %v, want empty (comparison must be symmetric)", pids)
+	}
+}
+
+// A symlinked-but-still-ours watcher must also be RECOGNISED as ours when
+// picking the survivor among duplicates — otherwise the reaper keeps an
+// unidentifiable watcher and reaps the one it can vouch for. PID order is
+// deliberately against the desired outcome: the lowest-PID fallback would keep
+// 10, so keeping 20 can only come from resolving the symlink.
+func TestCompute_SymlinkedOwnExePreferredAsSurvivor(t *testing.T) {
+	root := t.TempDir()
+	real := writeExe(t, filepath.Join(root, "Cellar", "grafel", "bin"), "grafel")
+	shim := symlinkExe(t, real, filepath.Join(root, "brew", "bin", "grafel"))
+	mustDifferTextually(t, real, shim)
+	mustBeSameFile(t, real, shim)
+
+	plan := Compute(Deps{
+		SelfExe: shim,
+		Managed: managedSet("/work/repo-a"),
+		List: func() ([]Proc, error) {
+			return []Proc{
+				{PID: 10, Exe: "", Repo: "/work/repo-a"},   // exe unreadable → not skew, but not vouchable
+				{PID: 20, Exe: real, Repo: "/work/repo-a"}, // same binary via the shim → keep
+			}, nil
+		},
+	})
+	if got, want := plan.PIDs(), []int{10}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("PIDs() = %v, want %v (the symlink-identified own-exe watcher survives)", got, want)
+	}
+	if len(plan.Foreign) != 0 {
+		t.Fatalf("Foreign = %v, want empty (this is a duplicate collapse, not skew)", plan.Foreign)
+	}
+}

--- a/internal/daemon/watchscan/watchscan.go
+++ b/internal/daemon/watchscan/watchscan.go
@@ -22,8 +22,12 @@
 // the decision logic is unit-testable with no real processes), and for each one
 // targeting a repo the daemon MANAGES it decides whether to reap it:
 //
-//   - a watcher whose executable path differs from the daemon's own
-//     os.Executable() is a stale/foreign-version watcher → reap; and
+//   - a watcher whose executable is PROVABLY a different binary from the
+//     daemon's own os.Executable() is a stale/foreign-version watcher → reap.
+//     "Provably" is load-bearing: the comparison resolves symlinks and treats
+//     any path it cannot resolve as unknown rather than as skew, because a
+//     false foreign verdict silently and permanently kills the user's watchers
+//     (#6187, and see #6179 for why it stopped being self-healing); and
 //   - among watchers for the SAME managed repo, keep exactly one (the
 //     daemon's-own-exe one if present, else the lowest PID) and reap the rest.
 //
@@ -56,8 +60,11 @@ type Deps struct {
 	// List, or one that errors, makes Plan return an empty plan (best-effort).
 	List func() ([]Proc, error)
 	// SelfExe is the daemon's own executable path (os.Executable() in
-	// production). A watcher whose Exe differs from this — when both are known —
-	// is treated as a stale/foreign-version watcher.
+	// production). A watcher whose Exe is PROVABLY a different binary from this
+	// — both paths known, both resolving on disk, resolving to different files
+	// — is treated as a stale/foreign-version watcher. Symlinks are resolved,
+	// so a shim invocation is not skew; an unresolvable path on either side is
+	// not skew either. See sameExe (#6187).
 	SelfExe string
 	// Managed reports whether repoPath is a repo the daemon manages. Only
 	// watchers for managed repos are ever reaped. Required; a nil Managed makes
@@ -96,14 +103,103 @@ func (p Plan) PIDs() []int {
 	return out
 }
 
-// sameExe reports whether two executable paths refer to the same binary. Both
-// must be non-empty to compare; an unknown path (empty) is never declared a
-// mismatch, so we don't reap a watcher merely because we couldn't read its exe.
+// sameExe reports whether two executable paths MIGHT refer to the same binary
+// — i.e. whether reaping is forbidden. It is deliberately asymmetric: it
+// returns false (→ reap as foreign) only when the two paths are PROVABLY
+// different binaries, and true in every case where the answer cannot be
+// established.
+//
+// # Why a lexical comparison was wrong (#6187)
+//
+// This used to be filepath.Clean(a) == filepath.Clean(b). SelfExe is the
+// engine's os.Executable() and the watcher's exe is its plist's BinPath, and
+// those two spellings routinely differ while naming ONE binary: grafel invoked
+// through a Homebrew shim, through any symlink on PATH, or with a BinPath
+// recorded from an install prefix that is now a symlink to the real one. Every
+// such install had EVERY launchd watcher for EVERY managed repo classified
+// foreign and SIGTERMed on the 5-minute sweep. Before #6179 that was a loud
+// reap↔respawn oscillation; after it the watcher exits 0, launchd leaves it
+// dead forever, and the only trace is one line in the repo's watcher.err.log.
+// Resolving symlinks is what stops a shim from looking like version skew.
+//
+// # Why an unresolvable path means "not foreign"
+//
+// filepath.EvalSymlinks fails outright on a path that does not exist, and "the
+// recorded exe no longer exists" is an ORDINARY state here — a stale plist
+// whose BinPath pointed into a prefix since removed, an upgrade that replaced
+// the tree rather than the file, a binary deleted out from under a running
+// process. resolveDeepestExisting (internal/registry, #6194) is the sibling
+// answer to the same EvalSymlinks trap, but it does not fit: it resolves the
+// deepest existing ANCESTOR and re-appends the missing tail so a path that does
+// not exist yet stays comparable. The missing tail here IS the binary, and two
+// prefixes that resolve identically tell us nothing about whether the two
+// binaries were the same file. Re-appending would manufacture a verdict from
+// directory names alone — including a FOREIGN verdict, which is the one that
+// costs the user their watchers.
+//
+// So the two verdicts are not symmetric in consequence, and the code follows
+// the consequence:
+//
+//   - a wrong "foreign" is permanent and silent: the watcher is killed, launchd
+//     does not bring it back, and nothing tells the user;
+//   - a wrong "same" leaves a stale-version watcher running, which is
+//     recoverable, visible in `grafel doctor`, and — for the case that actually
+//     matters, two watchers on one repo — still collapsed by the duplicate
+//     rule below, which prefers the watcher we can vouch for.
+//
+// Hence: unknown (empty), or either side unresolvable, or resolving to the same
+// file → same. Only two paths that BOTH resolve, to different files, are skew.
 func sameExe(a, b string) bool {
 	if a == "" || b == "" {
 		return true
 	}
-	return filepath.Clean(a) == filepath.Clean(b)
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	ra, okA := resolveExe(a)
+	if !okA {
+		return true // unresolvable → unknowable → never reap on this basis.
+	}
+	rb, okB := resolveExe(b)
+	if !okB {
+		return true
+	}
+	return ra == rb
+}
+
+// definitelySameExe is sameExe's strict converse: it reports whether the two
+// paths are PROVABLY the same binary. Where sameExe answers "may I reap this?",
+// this answers "can I vouch for this one?" — and an unknown must not count as a
+// vouch, or the duplicate rule would keep a watcher whose executable it could
+// not read in preference to one it could.
+func definitelySameExe(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	if filepath.Clean(a) == filepath.Clean(b) {
+		return true
+	}
+	ra, okA := resolveExe(a)
+	if !okA {
+		return false
+	}
+	rb, okB := resolveExe(b)
+	if !okB {
+		return false
+	}
+	return ra == rb
+}
+
+// resolveExe returns p's symlink-resolved, cleaned form, and whether it
+// resolved at all. A path that does not exist does not resolve, and that is
+// reported rather than papered over so both callers above can apply their own
+// fail-safe direction to it.
+func resolveExe(p string) (string, bool) {
+	r, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Clean(r), true
 }
 
 // Compute computes which managed-repo watchers to reap. It is pure (no process
@@ -179,9 +275,14 @@ func Compute(deps Deps) Plan {
 // the one whose exe matches the daemon's own if present, else the lowest PID.
 // survivors is assumed PID-sorted ascending.
 func pickSurvivor(survivors []Proc, selfExe string) int {
+	// definitelySameExe, not a Clean comparison: when the daemon was invoked
+	// through a shim the own-exe watcher spells its path differently, and a
+	// lexical check would fail to recognise it and fall through to the lowest
+	// PID — keeping an arbitrary watcher and reaping the one we can vouch for
+	// (#6187).
 	if selfExe != "" {
 		for _, p := range survivors {
-			if p.Exe != "" && filepath.Clean(p.Exe) == filepath.Clean(selfExe) {
+			if definitelySameExe(p.Exe, selfExe) {
 				return p.PID
 			}
 		}

--- a/internal/daemon/watchscan/watchscan_test.go
+++ b/internal/daemon/watchscan/watchscan_test.go
@@ -22,19 +22,29 @@ func managedSet(repos ...string) func(string) bool {
 
 // A foreign-exe watcher for a MANAGED repo is selected; a same-exe watcher and
 // an UNRELATED-repo watcher are skipped.
+//
+// The exe fixtures are REAL FILES (#6187): skew is now only declared when both
+// paths resolve on disk, so string literals naming nothing would take the
+// unresolvable escape hatch and the "foreign is selected" assertion would be
+// testing nothing.
 func TestCompute_ForeignWatcherSelected_UnrelatedSkipped(t *testing.T) {
-	self := "/home/u/.grafel/bin/grafel"
+	root := t.TempDir()
+	self := writeExe(t, filepath.Join(root, "grafel-bin"), "grafel")
+	stale := writeExe(t, filepath.Join(root, "gopath-bin"), "grafel")
+	mustDifferTextually(t, self, stale)
+	mustBeDifferentFiles(t, self, stale)
+
 	plan := Compute(Deps{
 		SelfExe: self,
 		Managed: managedSet("/work/repo-a"),
 		List: func() ([]Proc, error) {
 			return []Proc{
 				// foreign-version watcher for a managed repo → reap.
-				{PID: 100, Exe: "/home/u/go/bin/grafel", Repo: "/work/repo-a"},
+				{PID: 100, Exe: stale, Repo: "/work/repo-a"},
 				// same-exe watcher for a managed repo → keep.
 				{PID: 101, Exe: self, Repo: "/work/repo-a"},
 				// foreign watcher for an UNMANAGED repo → never touched.
-				{PID: 102, Exe: "/home/u/go/bin/grafel", Repo: "/other/repo-z"},
+				{PID: 102, Exe: stale, Repo: "/other/repo-z"},
 			}, nil
 		},
 	})
@@ -69,20 +79,33 @@ func TestCompute_DuplicateCollapse_KeepsOne(t *testing.T) {
 
 // A foreign watcher is preferred for reaping; the own-exe survivor is kept even
 // if it has a higher PID than the foreign one.
+//
+// Real files again, and the Foreign classification is asserted directly: with
+// literal paths PID 10 would come out unresolvable, land in the survivor set,
+// and be reaped as a DUPLICATE — identical PIDs(), nothing to do with the
+// property this test is named for.
 func TestCompute_PrefersOwnExeSurvivor(t *testing.T) {
-	self := "/opt/grafel"
+	root := t.TempDir()
+	self := writeExe(t, filepath.Join(root, "opt"), "grafel")
+	stale := writeExe(t, filepath.Join(root, "stale"), "grafel")
+	mustDifferTextually(t, self, stale)
+	mustBeDifferentFiles(t, self, stale)
+
 	plan := Compute(Deps{
 		SelfExe: self,
 		Managed: managedSet("/work/repo-a"),
 		List: func() ([]Proc, error) {
 			return []Proc{
-				{PID: 10, Exe: "/stale/grafel", Repo: "/work/repo-a"}, // foreign
-				{PID: 20, Exe: self, Repo: "/work/repo-a"},            // own → keep
+				{PID: 10, Exe: stale, Repo: "/work/repo-a"}, // foreign
+				{PID: 20, Exe: self, Repo: "/work/repo-a"},  // own → keep
 			}, nil
 		},
 	})
 	if got, want := plan.PIDs(), []int{10}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("PIDs() = %v, want %v (foreign reaped, own kept)", got, want)
+	}
+	if got, want := plan.Foreign, []int{10}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("Foreign = %v, want %v — 10 must be reaped as SKEW, not as a duplicate", got, want)
 	}
 }
 


### PR DESCRIPTION
`sameExe` was `filepath.Clean(a) == filepath.Clean(b)` with no symlink resolution. When the engine's `os.Executable()` and a plist's recorded `BinPath` differ **textually** — a `brew` shim, a symlinked invocation, a `BinPath` recorded from another install location — every launchd watcher for a managed repo is classified `Foreign` and SIGTERM'd on every 5-minute sweep.

Before #6179 that was a loud oscillation: reap → `KeepAlive` respawn → reap. #6179 deliberately made the reaper authoritative with no re-establishment path, which was right for the storm it fixed and turned this into a **silent, permanent** loss: reaped once, the watcher exits 0 and launchd leaves it dead forever. The only trace is a line in `<repo>/.grafel/logs/watcher.err.log`.

## Half 1 — resolution, deliberately asymmetric

`sameExe` now returns "different binary" — the verdict that kills a watcher — **only when both paths resolve on disk and resolve to different files.** Unresolvable on either side means "same", so nothing is reaped on that basis.

The two errors are not symmetric in cost. A wrong "foreign" is permanent and silent after #6179. A wrong "same" leaves a stale-version watcher running, which is recoverable, visible, and — for the case that actually matters, two watchers on one repo — still collapsed by the duplicate rule.

The honest cost, stated rather than buried: a watcher whose binary has been **deleted** is no longer reaped as skew, where #5632 used to reap it. Where it shares a repo with a healthy watcher, the duplicate rule still takes it.

A strict converse, `definitelySameExe`, backs `pickSurvivor`. Without it a shim-invoked daemon fails to recognise its *own* watcher among duplicates, falls back to lowest-PID, and reaps the one watcher it could actually vouch for. That case is pinned by its own test — the defect mutant fails it with `[10 20], want [10]`.

## Half 2 — the unit is booted out when the reap leaves nothing running

New `ReaperConfig.UnloadWatcherUnit`, wired in `engineplane.go`. The sweep calls it for every managed repo it leaves with **no watcher running**; the resolver maps the repo through the registry to its unit and calls `loader.Unload` (launchctl bootout / systemctl disable / schtasks delete). Otherwise the on-disk state lies: the plist says loaded, the process is gone.

Two scoping decisions:

- **Only when no watcher survives.** An unconditional bootout is unsafe — a hand-started stale-binary watcher reaped alongside a healthy launchd-owned one would take the healthy one down with it. If a survivor exists the plist is not lying and there is nothing to repair.
- **`Unload`, not `Cleanup`.** The unit *file* is the repo's configuration, not its runtime state. Deleting it discards something the user never asked us to discard.

## Why `resolveDeepestExisting` was not reused

#6194 (`12d4eb062`) solved the sibling problem by resolving through the deepest existing **ancestor** and re-appending the missing tail, so a not-yet-existing path stays comparable. That is wrong here: the missing tail **is the binary**. Two prefixes resolving identically says nothing about whether the two binaries were ever one file, and re-appending would manufacture a verdict from directory names — including the foreign verdict, the expensive one. Same trap, opposite safe direction, so a different answer. Recorded in the code, not just here.

## Mutants

Eight, no survivors: dropping symlink resolution (the original defect); inverting the not-resolvable default; `pickSurvivor` back to `Clean`; removing the unload; dropping the survivor check; unloading despite a failed kill; dropping the unit-file existence check; dropping the repo-path match.

**Two initially survived and were fixed rather than reported away.** A foreign-only guard on the unload turned out to be unfalsifiable dead logic — a duplicate collapse always keeps a survivor by construction, so it could never reach the unload — and was deleted. And an unregistered-repo test had no installed unit, so a stat check masked the missing path match; it now installs a decoy unit for the registered repo.

## Fixture vacuity found in existing tests

`TestCompute_ForeignWatcherSelected_UnrelatedSkipped` and `TestReaper_sweepForeignWatchers` named their "foreign" binaries as string literals. Under the new rule those paths are unresolvable, so the PID they assert on becomes a **duplicate** reap rather than a foreign one — identical output, different code path, and the test name a lie. Both are rebased on real files with the premise asserted. `TestCompute_PrefersOwnExeSurvivor` now asserts `plan.Foreign` rather than only `PIDs()`, for the same reason.

## One correction to the issue's framing

`internal/daemon` and `internal/cli` are **inside** the cgo cone — they pull `internal/treesitter/ts/official` and ~25 grammar bindings — so cross-`GOOS` vet cannot reach them and fails on pre-existing binding errors unrelated to this change. `internal/daemon/watchscan`, which holds all the platform-sensitive path logic, is outside it and cross-vets clean on `GOOS=linux` and `GOOS=windows`, confirming the `!windows` build tag compiles out correctly.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/daemon/...` and `./internal/cli/...` exit 0 with zero FAIL lines.

Tests sandbox through `t.Setenv` of `HOME`/`USERPROFILE`/`GRAFEL_HOME`/`XDG_CONFIG_HOME` plus `watchers.StubServiceCallsForTest`, with the sandbox itself asserted. Re-checked at merge: the live daemon's processes are untouched and no LaunchAgents plist was modified. The darwin-specific tests use a `_notwindows_test.go` filename rather than `runtime.GOOS` plus `t.Skip`, which guards execution and not compilation (#6218).

Closes #6187
Refs #6179, #6194, #5632
