### PR TITLE
fix(#6156): every third-party import lost its file->package edge on the full-rebuild path

### DIFF
--- a/cmd/grafel/external_import_orphan_6156_test.go
+++ b/cmd/grafel/external_import_orphan_6156_test.go
@@ -1,0 +1,203 @@
+// Package main — external_import_orphan_6156_test.go
+//
+// Issue #6156. On the FULL rebuild path a THIRD-PARTY import's IMPORTS edge is
+// left pointing at the hex id of the import placeholder that
+// resolve.PruneImportPlaceholders has already removed — a dangling endpoint —
+// even though the `SCOPE.External` entity that edge should bind to exists in
+// the very same graph (external.Synthesize runs later and creates it).
+//
+// The #6131 repoint cannot cover this shape: it re-points an incoming edge at
+// the entity the pipeline had ALREADY resolved the same (importer file,
+// source_module) import to, and for a third-party module nothing is resolved at
+// prune time.
+//
+// Everything below is asserted against the graph READ BACK FROM DISK
+// (graph.LoadGraphFromDir), which is how #6156's measurements were taken.
+//
+// Refs #6156, #6131, #642, #6129.
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/graph"
+)
+
+// oiIndex builds a two-file Python corpus and returns a full rebuild of it,
+// loaded from disk.
+//
+// The corpus is deliberately minimal and reaches BOTH halves of the prune's
+// repoint decision in one graph:
+//
+//	`import falcon`         — a package with no in-repo definition. Nothing
+//	                          resolves it at prune time; external.Synthesize
+//	                          creates `ext:falcon` afterwards. This is #6156.
+//	`import oi_lib_static`  — a module that DOES exist in the repo. The import
+//	                          resolver binds it before the prune runs, so the
+//	                          #6131 repoint has a target. It is the control:
+//	                          the #6156 repair must not disturb it.
+func oiIndex(t *testing.T) *graph.Document {
+	t.Helper()
+	repo := t.TempDir()
+	dvWriteFile(t, repo, "oi_lib_static.py", `def oi_target(x):
+    return x + 1
+`)
+	dvWriteFile(t, repo, "oi_main.py", `import falcon
+import oi_lib_static
+
+
+def oi_handle(x):
+    app = falcon.App()
+    return app, oi_lib_static.oi_target(x)
+`)
+	return dvFullRebuild(t, repo, t.TempDir())
+}
+
+// oiLiveIDs returns the set of entity ids present in the document.
+func oiLiveIDs(doc *graph.Document) map[string]bool {
+	live := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		live[doc.Entities[i].ID] = true
+	}
+	return live
+}
+
+// oiFileComponentID returns the id of the file-level SCOPE.Component carrier
+// for path, failing the test when there is none — the IMPORTS edges under test
+// hang off it, so its absence would make every assertion below vacuous.
+func oiFileComponentID(t *testing.T, doc *graph.Document, path string) string {
+	t.Helper()
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" && e.SourceFile == path {
+			return e.ID
+		}
+	}
+	t.Fatalf("no file-level SCOPE.Component carrier for %s in the persisted graph — "+
+		"the fixture never reached the shape under test", path)
+	return ""
+}
+
+// oiWholeModuleImport returns the single IMPORTS edge emitted by fromID whose
+// source_module is module and whose imported_name is the module itself (the
+// whole-module form `import <module>`), failing when there is not exactly one.
+func oiWholeModuleImport(t *testing.T, doc *graph.Document, fromID, module string) *graph.Relationship {
+	t.Helper()
+	var hits []*graph.Relationship
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "IMPORTS" || r.FromID != fromID {
+			continue
+		}
+		if r.PropGet("source_module") != module {
+			continue
+		}
+		if r.PropGet("imported_name") != module {
+			continue
+		}
+		hits = append(hits, r)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("want exactly 1 whole-module IMPORTS edge for %q from %s, got %d — "+
+			"the fixture no longer reaches the shape under test", module, fromID, len(hits))
+	}
+	return hits[0]
+}
+
+// TestFullRebuild_ThirdPartyImportBindsToExternal_6156 is the #6156 gate.
+//
+// It asserts its own PREMISES before the behaviour, because each of them is a
+// way this test could pass while measuring nothing:
+//
+//	P1 `falcon` is genuinely third-party — no in-repo entity defines it, so the
+//	   import resolver has nothing to bind and the #6131 repoint has no target.
+//	P2 the import placeholder for it was genuinely PRUNED — no surviving entity
+//	   is a `SCOPE.Component` subtype="import" for it. If prune had kept the
+//	   placeholder, the edge would bind trivially and the defect would be absent
+//	   for the wrong reason.
+//	P3 the `SCOPE.External` node genuinely EXISTS in the same graph. The defect
+//	   is not "no external node was created"; it is that the edge does not bind
+//	   to the one that was.
+func TestFullRebuild_ThirdPartyImportBindsToExternal_6156(t *testing.T) {
+	doc := oiIndex(t)
+	if len(doc.Relationships) == 0 {
+		t.Fatalf("persisted graph carries no relationships — the comparison is inert")
+	}
+	live := oiLiveIDs(doc)
+	mainID := oiFileComponentID(t, doc, "oi_main.py")
+
+	// P1 — falcon is third-party: nothing in the repo defines it.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == "SCOPE.External" {
+			continue
+		}
+		if e.Name == "falcon" || e.QualifiedName == "falcon" {
+			t.Fatalf("premise broken: in-repo entity %s/%s@%s claims the name falcon, "+
+				"so the import is not third-party and this test measures the #6131 path instead",
+				e.Kind, e.Name, e.SourceFile)
+		}
+	}
+	// The control import, by contrast, MUST have an in-repo definition —
+	// otherwise the two arms of the test are the same arm.
+	oiFileComponentID(t, doc, "oi_lib_static.py")
+
+	// P2 — the import placeholder was pruned.
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" {
+			t.Fatalf("premise broken: import placeholder %s@%s survived the prune; "+
+				"the dangling-endpoint shape #6156 describes cannot arise when the "+
+				"placeholder is still live", e.Name, e.SourceFile)
+		}
+	}
+
+	// P3 — the SCOPE.External node exists in this same graph.
+	extID := ""
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind == "SCOPE.External" && e.Name == "falcon" {
+			extID = e.ID
+			break
+		}
+	}
+	if extID == "" {
+		t.Fatalf("premise broken: no SCOPE.External entity for falcon in the persisted graph — " +
+			"#6156 is about an edge failing to bind to a node that EXISTS, so without it " +
+			"this test would be measuring a different defect")
+	}
+
+	// Behaviour — the third-party import binds to that node rather than
+	// dangling on the pruned placeholder's hex id.
+	rel := oiWholeModuleImport(t, doc, mainID, "falcon")
+	if !live[rel.ToID] {
+		t.Errorf("#6156: IMPORTS edge for `import falcon` dangles — ToID %q resolves to no "+
+			"entity in the persisted graph, though SCOPE.External falcon (%s) is right there",
+			rel.ToID, extID)
+	}
+	if rel.ToID != extID {
+		t.Errorf("#6156: IMPORTS edge for `import falcon` binds to %q; want the SCOPE.External "+
+			"node %q", rel.ToID, extID)
+	}
+
+	// Control — the in-repo import is untouched by the repair and still binds
+	// to a live in-repo entity (this is the #6131 case; a fix that hijacked it
+	// would turn a first-party dependency into a third-party one).
+	ctrl := oiWholeModuleImport(t, doc, mainID, "oi_lib_static")
+	if !live[ctrl.ToID] {
+		t.Errorf("control: IMPORTS edge for `import oi_lib_static` dangles on ToID %q", ctrl.ToID)
+	}
+	if ctrl.ToID == extID {
+		t.Errorf("control: the in-repo import bound to the falcon external node")
+	}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.ID != ctrl.ToID {
+			continue
+		}
+		if e.Kind == "SCOPE.External" {
+			t.Errorf("control: `import oi_lib_static` bound to SCOPE.External %s — the repo "+
+				"defines that module, so a third-party bind is a mis-bind", e.Name)
+		}
+	}
+}

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -784,55 +784,28 @@ var cpKnownPathA = []cpKnown{
 
 	// ── #6156: the full rebuild orphans a THIRD-PARTY import's IMPORTS edge ──
 	//
-	// The only divergence the #6150 fixture reaches where the INCREMENTAL answer
-	// is the correct one, which is why it is allow-listed rather than "fixed":
-	// closing it on this side would mean teaching Path A to dangle.
+	// FIXED — the FOUR entries that stood here went STALE and were removed by
+	// the ratchet: the INVENTED/LOST pair for `import falcon` (Python) and the
+	// INVENTED/LOST pair for `require("express")` (JS), listed separately so
+	// that one of them going quiet could never be absorbed by the other.
 	//
-	// `import falcon` names a package with no in-repo definition. BOTH graphs
-	// contain the `SCOPE.External|falcon` entity (measured — `external.Synthesize`
-	// runs on both paths). The FULL rebuild's IMPORTS edge points at the hex id
-	// of the import PLACEHOLDER that PruneImportPlaceholders has already removed,
-	// so it dangles; Path A binds the same edge to the live `ext:falcon` node.
+	// It was the second case in this file where the INCREMENTAL answer was the
+	// better one, and the history is worth keeping. `import falcon` names a
+	// package with no in-repo definition. BOTH graphs contained the
+	// `SCOPE.External|falcon` entity — external.Synthesize runs on both paths —
+	// but the FULL rebuild's IMPORTS edge pointed at the hex id of the import
+	// PLACEHOLDER that PruneImportPlaceholders had already removed, so it
+	// dangled, while Path A bound the same edge to the live `ext:falcon` node.
+	// Every third-party import in every repo, on the default path.
 	//
-	// #6131's repoint does not cover it: it re-points at the entity the pipeline
-	// already resolved that import to, and for a third-party module there is
-	// nothing resolved at prune time — the SCOPE.External node is synthesised
-	// afterwards. See #6156 for the log line (`rels_orphaned=2`) and the fix
-	// direction.
-	{
-		Issue:    "#6156",
-		Why:      "Path A binds the third-party import to the live SCOPE.External node; the FULL rebuild dangles on the pruned placeholder. Incremental is the correct side. Unfixed, and not fixable from the incremental path.",
-		Bucket:   cpEdgeInvented,
-		Contains: []string{"→SCOPE.External/falcon@", ":IMPORTS"},
-	},
-	{
-		Issue:    "#6156",
-		Why:      "The LOST half of the same orphan: the full rebuild's dangling endpoint on the pruned import placeholder.",
-		Bucket:   cpEdgeLost,
-		Contains: []string{"SCOPE.Component/cphandler_delta.py@cphandler_delta.py→«unbound»", ":IMPORTS"},
-	},
-	{
-		// A CONSEQUENCE of the row above, not a second defect: module
-		// aggregation skips any edge whose endpoint resolves to no entity, so
-		// the full rebuild's orphaned IMPORTS edge is not counted and Path A's
-		// bound one is. Recorded as such because #6129 filed the same shape as
-		// "an extra DEPENDS_ON row" and it was a consequence then too.
-		// NET OF TWO FILED CAUSES, and it is kept keyed on the exact numbers
-		// so that fixing either one moves it and forces a re-derivation rather
-		// than silently continuing to match:
-		//   #6156 pushes B UP by 2 — module aggregation cannot count the full
-		//         rebuild's two orphaned third-party IMPORTS edges (falcon,
-		//         express), but counts Path A's bound ones;
-		//   #6159 pushes B DOWN by 1 — Path A has no ENTRY_POINT_OF edge from
-		//         the /cpview2 endpoint to its process node, because it never
-		//         resolved the handler and the flow was never built.
-		// Net +1 for B.
-		Issue:          "#6156 + #6159 (net; see the comment)",
-		Why:            "Module-aggregation weight is the net of the orphaned third-party imports (#6156, +2) and the flow edges the incremental graph lacks (#6159, -1).",
-		Bucket:         cpEdgeProps,
-		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
-		DetailContains: []string{`weight "6"≠"7"`},
-	},
+	// #6131's repoint could not cover it: it re-points at the entity the
+	// pipeline ALREADY resolved that import to, and for a third-party module
+	// nothing is resolved at prune time. The answer, following #642 and #6131
+	// for the third time, was to carry the endpoint across to something durable
+	// rather than accept the dangle — here by RESTORING it to the raw module
+	// string, the pre-resolution form external.Synthesize classifies, which is
+	// exactly the endpoint Path A was already handing it. See the #6156 block in
+	// internal/resolve/imports.go and `module_restores` in the prune's log line.
 	// ── #6159, the NO-SURVIVOR case: kept, but at the registration file ──
 	//
 	// `cpapi2_delta.py` registers /cpview2 against a view in `cpview2_delta.py`
@@ -907,7 +880,7 @@ var cpKnownPathA = []cpKnown{
 		Contains: []string{"http_endpoint_definition/http:GET:/cpview2@cpview2_delta.py→SCOPE.Process/"},
 	},
 	{
-		// Single-cause, unlike its test-repo→_external twin above: B is lower
+		// Single-cause, like its test-repo→_external twin below: B is lower
 		// by exactly the two STEP_IN_PROCESS edges the missing process node
 		// would have contributed from _external into test-repo.
 		Issue:          "#6159",
@@ -916,22 +889,27 @@ var cpKnownPathA = []cpKnown{
 		Contains:       []string{"Module/_external@→Module/test-repo@:DEPENDS_ON"},
 		DetailContains: []string{`weight "11"≠"9"`},
 	},
-	// The SAME #6156 defect on the second third-party import in the corpus.
-	// Listed separately rather than folded into a looser key on the entries
-	// above: one entry matching both would go on matching if only one of them
-	// stopped reproducing, which is precisely the blindness the ratchet exists
-	// to prevent.
 	{
-		Issue:    "#6156",
-		Why:      "Second instance, JS: Path A binds the express require to the live SCOPE.External node; the FULL rebuild dangles on the pruned placeholder.",
-		Bucket:   cpEdgeInvented,
-		Contains: []string{"→SCOPE.External/express@", ":IMPORTS"},
-	},
-	{
-		Issue:    "#6156",
-		Why:      "The LOST half of the express orphan.",
-		Bucket:   cpEdgeLost,
-		Contains: []string{"SCOPE.Component/cproutes_delta.js@cproutes_delta.js→«unbound»", ":IMPORTS"},
+		// RE-KEYED, not deleted, when #6156 was fixed — the divergence still
+		// reproduces, with one of its two causes removed.
+		//
+		// It was `weight "6"≠"7"`, the NET of two filed causes: #6156 pushed B
+		// UP by 2 (module aggregation skips an edge whose endpoint resolves to
+		// no entity, so the full rebuild's two orphaned third-party IMPORTS
+		// edges — falcon, express — went uncounted while Path A's bound ones
+		// did not), and #6159 pushed B DOWN by 1. Fixing #6156 moved the FULL
+		// side up by exactly 2, to 8, with no change to the aggregation code —
+		// which is the evidence that the under-count was a consequence of the
+		// orphan and not a second defect.
+		//
+		// What remains is single-cause: Path A has no ENTRY_POINT_OF edge from
+		// the /cpview2 endpoint to its process node, because it never resolved
+		// the handler and the flow was never built.
+		Issue:          "#6159",
+		Why:            "Module-aggregation weight, over by the one ENTRY_POINT_OF edge of the process node Path A never built.",
+		Bucket:         cpEdgeProps,
+		Contains:       []string{"Module/test-repo@→Module/_external@:DEPENDS_ON"},
+		DetailContains: []string{`weight "8"≠"7"`},
 	},
 
 	// ── #6159: a cross-file handler leaves its endpoint unenriched ──

--- a/cmd/grafel/index.go
+++ b/cmd/grafel/index.go
@@ -5677,10 +5677,10 @@ func (i *Indexer) buildDocument(pass1, pass2 *[]types.EntityRecord, pass2Rels []
 	merged = prunedMerged
 	if pruneStats.Considered > 0 {
 		fmt.Fprintf(os.Stderr,
-			"import-placeholder-prune: considered=%d pruned=%d rels_hoisted=%d rels_orphaned=%d kept=%d edge_toid_rewrites=%d ref_repoints=%d\n",
+			"import-placeholder-prune: considered=%d pruned=%d rels_hoisted=%d rels_orphaned=%d kept=%d edge_toid_rewrites=%d ref_repoints=%d module_restores=%d\n",
 			pruneStats.Considered, pruneStats.Pruned, pruneStats.RelsHoisted,
 			pruneStats.RelsOrphaned, pruneStats.PlaceholderKept, pruneStats.EdgeToIDRewrites,
-			pruneStats.PlaceholderRefRepoints)
+			pruneStats.PlaceholderRefRepoints, pruneStats.PlaceholderModuleRestores)
 	}
 	if len(pruneOrphanRels) > 0 {
 		// Migrate to the standalone pass2Rels stream so the

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -2765,6 +2765,14 @@ type PruneImportPlaceholderStats struct {
 	// that silently stops re-pointing — and therefore starts orphaning
 	// those edges again — is visible in the indexer log.
 	PlaceholderRefRepoints int
+	// PlaceholderModuleRestores is the number of INCOMING edges pointing at a
+	// pruned import placeholder for a NON-RELATIVE module that the pipeline
+	// resolved to nothing, whose endpoint was restored to the raw module
+	// string so external.Synthesize can classify it (issue #6156). See the
+	// #6156 block in the function body. Surfaced so a regression that silently
+	// stops restoring — and therefore starts orphaning every third-party
+	// import edge again — is visible in the indexer log.
+	PlaceholderModuleRestores int
 }
 
 // PruneImportPlaceholders removes import-placeholder entities (kind =
@@ -3043,7 +3051,69 @@ func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive 
 	// other extractor emitting both halves. ONLY PYTHON IS EXERCISED, by the
 	// tests here and by the parity gate; the sibling languages are reachable
 	// and unmeasured.
-	if repoints := buildPlaceholderRepoints(records, prunable, extraLive); len(repoints) > 0 {
+	//
+	// Pre-prune INCOMING-edge MODULE-STRING RESTORE (issue #6156).
+	//
+	// The block above repairs an incoming edge by re-pointing it at the entity
+	// the pipeline HAD ALREADY RESOLVED the same (importer file, source_module)
+	// import to. For a THIRD-PARTY import there is nothing resolved at prune
+	// time: `import falcon` names no in-repo module, so no IMPORTS edge in that
+	// file carries a surviving target, the repoint finds no candidate, and the
+	// endpoint is orphaned. Measured on the #6129 content-parity corpus as
+	// `rels_orphaned=2` with the IMPORTS edge left on a hex id no entity
+	// carries — while `SCOPE.External|falcon` sits in the very same graph.
+	//
+	// The durable entity DOES exist; it just does not exist YET. external.Synthesize
+	// runs after resolution and after this prune (cmd/grafel/index.go), creates
+	// `ext:<module>`, and adopts an endpoint by CLASSIFYING IT — it skips any
+	// ToID that already looks like a hex id (internal/external/synth.go, the
+	// `isHexID` guard at the top of its relationship loop). So the endpoint it
+	// can adopt is the raw module string, which is precisely the form this edge
+	// carried before the dotted-import resolver rewrote it to the placeholder.
+	//
+	// Hence the repair: RESTORE, rather than defer the prune or teach Synthesize
+	// about placeholders it can no longer see.
+	//
+	//   - Deferring the placeholder (keeping it live so Synthesize can adopt the
+	//     dangle) reinstates exactly the orphan-entity bucket this prune exists
+	//     to remove, and leaves the edge bound to a structural carrier instead of
+	//     the package — which is the wrong target: `grafel_expand`, lib-boundary
+	//     and module aggregation all read file→package, not file→placeholder.
+	//   - Teaching Synthesize to re-point endpoints dangling on pruned
+	//     placeholders means plumbing a pruned-id→module map across four pipeline
+	//     stages so a later pass can undo an earlier one's damage. The module
+	//     string is the only thing that map would carry, and it is already here.
+	//
+	// The restored endpoint is the SAME endpoint the incremental path carries,
+	// which is why this closes a full-vs-incremental divergence rather than
+	// moving it: Path A never rewrites the ToID to the placeholder, so its edge
+	// arrives at Synthesize as `falcon` and binds to `ext:falcon`.
+	//
+	// Two guards:
+	//   - only when the module resolved to an in-repo entity NOWHERE in the
+	//     record set. An import that resolved keeps its resolution; one that
+	//     resolved AMBIGUOUSLY, or resolved in a sibling file but not this one,
+	//     keeps today's behaviour rather than being reclassified as third-party.
+	//     Note this membership test is corpus-wide where the #6131 repoint key
+	//     is file-scoped, and deliberately so — see buildPlaceholderRepoints'
+	//     second return value for why the two questions scope differently.
+	//   - only NON-RELATIVE module strings. A `./x` that failed to resolve is a
+	//     resolver fidelity bug, not a dependency; Synthesize will never classify
+	//     it as an external package, so restoring it swaps one unresolved shape
+	//     for another and widens this repair onto the #642 path for nothing.
+	//
+	// What happens to a module with NO durable home — neither in-repo nor ever
+	// synthesised as external (e.g. a same-repo Python root that failed to
+	// resolve, which classifyExternal deliberately REFUSES to launder into an
+	// `ext:` node)? Its edge keeps the raw module string as its endpoint:
+	// unresolved, but not dangling, and identical to what an edge the resolver
+	// never touched looks like. It stays visible to unresolved-endpoint
+	// reporting as the fidelity bug it is. That is the third behaviour, and it
+	// is chosen over silently dropping the edge — no edge is created or removed
+	// by this block either.
+	repoints, resolvedModules := buildPlaceholderRepoints(records, prunable, extraLive)
+	restores := buildPlaceholderModuleRestores(records, prunable, resolvedModules)
+	if len(repoints) > 0 || len(restores) > 0 {
 		for i := range records {
 			r := &records[i]
 			for j := range r.Relationships {
@@ -3051,6 +3121,11 @@ func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive 
 				if id, ok := repoints[rel.ToID]; ok {
 					rel.ToID = id
 					stats.PlaceholderRefRepoints++
+					continue
+				}
+				if module, ok := restores[rel.ToID]; ok {
+					rel.ToID = module
+					stats.PlaceholderModuleRestores++
 				}
 			}
 		}
@@ -3117,7 +3192,20 @@ func PruneImportPlaceholdersWithLiveIDs(records []types.EntityRecord, extraLive 
 // the dangle.
 //
 // Returns nil when there is nothing to repair, which is the common case.
-func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, extraLive map[string]bool) map[string]string {
+//
+// The second return value is the set of MODULE STRINGS that resolved to a
+// surviving in-repo entity ANYWHERE in the record set — including ones the
+// ambiguity guard then refused a target for. #6156's module-string restore
+// consults it to decide whether a module is third-party.
+//
+// That question is deliberately NOT file-scoped, unlike the repoint key above.
+// The file scoping exists because borrowing a resolved TARGET ID across files
+// invents a specific cross-file reference nobody wrote. "Is this module
+// third-party?" is not a per-file fact: if any file in the corpus resolved
+// `shared` to an in-repo entity then `shared` is in-repo, and a file whose
+// import of it merely failed to resolve has a resolver fidelity bug, not a
+// dependency on a package of the same name.
+func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, extraLive map[string]bool) (map[string]string, map[string]bool) {
 	// ambiguous marks a (file, module) pair with conflicting resolutions. It
 	// cannot collide with a real id because ids are hex.
 	const ambiguous = "\x00ambiguous"
@@ -3168,7 +3256,7 @@ func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, ext
 		phIDs[k] = append(phIDs[k], r.ID)
 	}
 	if len(phIDs) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	// Resolved whole-module IMPORTS edges, keyed the same way.
@@ -3212,9 +3300,14 @@ func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, ext
 	}
 
 	out := make(map[string]string, len(phIDs))
+	resolvedModules := make(map[string]bool, len(phIDs))
 	for k, ids := range phIDs {
 		target, ok := resolved[k]
-		if !ok || target == ambiguous {
+		if !ok {
+			continue
+		}
+		resolvedModules[k.module] = true
+		if target == ambiguous {
 			continue
 		}
 		for _, id := range ids {
@@ -3223,6 +3316,90 @@ func buildPlaceholderRepoints(records []types.EntityRecord, prunable []bool, ext
 			}
 			out[id] = target
 		}
+	}
+	if len(out) == 0 {
+		out = nil
+	}
+	if len(resolvedModules) == 0 {
+		resolvedModules = nil
+	}
+	return out, resolvedModules
+}
+
+// buildPlaceholderModuleRestores maps the stamped id of each import placeholder
+// that is about to be PRUNED, and whose import the pipeline resolved to
+// nothing, onto the raw module string it stands for (issue #6156).
+//
+// PruneImportPlaceholders uses it to restore incoming endpoints to the
+// pre-resolution form external.Synthesize can classify, so a third-party
+// import's edge binds to `ext:<module>` instead of dangling on an id no entity
+// carries. See the #6156 block in the function body for why restoring is
+// preferred to deferring the prune or re-pointing from Synthesize.
+//
+// prunable is indexed in parallel with records and must already be decided; a
+// placeholder being KEPT still has a live id and its incoming edges need no
+// repair. resolvedModules is buildPlaceholderRepoints' second return value —
+// the modules that resolved to a surviving in-repo entity somewhere in the
+// record set, whether unambiguously (the #6131 repoint took the target) or
+// ambiguously (nothing took it, and it keeps today's behaviour rather than
+// being laundered into a third-party dependency).
+//
+// Relative specifiers are excluded — see the second guard in the #6156 block.
+//
+// Returns nil when there is nothing to restore.
+func buildPlaceholderModuleRestores(records []types.EntityRecord, prunable []bool, resolvedModules map[string]bool) map[string]string {
+	// Ids that a SURVIVING record also carries. graph.EntityID hashes
+	// repo/kind/name/sourceFile and NOT Subtype (internal/graph/graph.go), so a
+	// pruned `SCOPE.Component` placeholder named M in file F has the SAME id as
+	// any other `SCOPE.Component` named M in F — and an edge bound to the
+	// survivor is indistinguishable, by id, from one bound to the placeholder.
+	//
+	// The #6131 block above notes this collision and records that no reachable
+	// instance was known. There IS one, found by the pinned-digest test in
+	// cmd/grafel/custom_extractor_spans_6118_test.go while #6156 was being
+	// measured: Go's extractor emits `SCOPE.Component` import entities with an
+	// EMPTY Subtype (so they are never pruned and stay live), while the
+	// cross-language imports extractor emits a Subtype="import" placeholder for
+	// the same import in the same file. On `svc/handler.go` importing net/http
+	// both exist, the placeholder is pruned, the live one is not — and rewriting
+	// that id would take `Handler.ServeHTTP -REFERENCES-> SCOPE.Component/net/http`,
+	// a perfectly bound edge, and un-resolve it into `ext:net`.
+	//
+	// So: an id a survivor carries is not a would-be-dangling endpoint and is
+	// never touched. (The #6131 repoint has the same hole and is left as it is
+	// here — it is pre-existing, out of #6156's scope, and would need its own
+	// measurement.)
+	survivor := make(map[string]bool, len(records))
+	for i := range records {
+		if id := records[i].ID; id != "" && !prunable[i] {
+			survivor[id] = true
+		}
+	}
+	out := make(map[string]string)
+	for i := range records {
+		r := &records[i]
+		if !prunable[i] || r.ID == "" {
+			continue
+		}
+		if !(r.Kind == "SCOPE.Component" && r.Subtype == "import") {
+			continue
+		}
+		module := r.Name
+		if r.Properties != nil {
+			if m := r.Properties["module"]; m != "" {
+				module = m
+			}
+		}
+		if module == "" || module == r.ID || survivor[r.ID] {
+			continue
+		}
+		if resolvedModules[module] {
+			continue
+		}
+		if strings.HasPrefix(module, "./") || strings.HasPrefix(module, "../") {
+			continue
+		}
+		out[r.ID] = module
 	}
 	if len(out) == 0 {
 		return nil

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -1842,13 +1842,21 @@ func TestPruneImportPlaceholdersWithLiveIDs_AcceptsCarryForwardTarget(t *testing
 	}
 }
 
-// TestPruneImportPlaceholders_LeavesUnresolvableIncomingEdgesAlone pins the
+// TestPruneImportPlaceholders_InventsNoBindingForUnresolvableImport pins the
 // boundary of the #6131 repair: the re-point fires ONLY when the pipeline has
 // already resolved the same (importer file, module) pair to a real entity. A
 // genuinely third-party import has no such resolution, so there is nothing to
-// propagate and the edge is left exactly as the full rebuild leaves it today.
-// Without this, the repair would be free to invent a binding.
-func TestPruneImportPlaceholders_LeavesUnresolvableIncomingEdgesAlone(t *testing.T) {
+// propagate. Without this, the repair would be free to invent a binding.
+//
+// This case used to assert the edge was left "exactly as the full rebuild
+// leaves it today" — i.e. dangling on the pruned placeholder's id. That WAS the
+// full rebuild's behaviour and it was the #6156 defect, filed after this test
+// was written: every third-party import in every repo lost its file→package
+// edge on the default path. The #6131 half of the assertion is unchanged (no
+// in-repo target is invented); what the endpoint becomes is now #6156's
+// business — the raw module string, which external.Synthesize classifies into
+// `ext:requests`.
+func TestPruneImportPlaceholders_InventsNoBindingForUnresolvableImport(t *testing.T) {
 	const (
 		f     = "app.py"
 		fileC = "3333333333333333"
@@ -1873,8 +1881,16 @@ func TestPruneImportPlaceholders_LeavesUnresolvableIncomingEdgesAlone(t *testing
 		if e.ID != fn {
 			continue
 		}
-		if len(e.Relationships) != 1 || e.Relationships[0].ToID != ph {
-			t.Errorf("REFERENCES edge was altered: %+v, want ToID %q untouched", e.Relationships, ph)
+		if len(e.Relationships) != 1 {
+			t.Fatalf("REFERENCES = %+v, want exactly one edge", e.Relationships)
+		}
+		got := e.Relationships[0].ToID
+		if got == ph {
+			t.Errorf("#6156: REFERENCES ToID left at the pruned placeholder %q — a dangling endpoint", ph)
+		}
+		if got != "requests" {
+			t.Errorf("REFERENCES ToID = %q, want the raw module string \"requests\"; anything "+
+				"else means an in-repo binding was invented for a module the repo does not define", got)
 		}
 	}
 }
@@ -2828,6 +2844,320 @@ func TestResolveGoInTreeImports_UnknownPkgDirSkipped(t *testing.T) {
 			r := &records[k].Relationships[j]
 			if r.Kind == importRelKind && r.ToID != rawToID {
 				t.Errorf("IMPORTS ToID rewritten to %q; expected it unchanged (%q)", r.ToID, rawToID)
+			}
+		}
+	}
+}
+
+// TestPruneImportPlaceholders_RestoresModuleStringForThirdPartyImport is the
+// #6156 unit half of the fix whose end-to-end gate lives in
+// cmd/grafel/external_import_orphan_6156_test.go.
+//
+// #6131 repairs an incoming edge by re-pointing it at the entity the pipeline
+// had ALREADY resolved the same (importer file, source_module) import to. For a
+// THIRD-PARTY module nothing is resolved at prune time — the `SCOPE.External`
+// node is synthesised by external.Synthesize afterwards — so that block finds
+// no candidate and the endpoint is orphaned.
+//
+// The repair: restore the endpoint to the raw module string, which is the
+// pre-resolution form external.Synthesize classifies. The edge then binds to
+// `ext:<module>` exactly as it does on the incremental path (which never
+// rewrote the endpoint to the placeholder in the first place).
+//
+// The record set below carries BOTH arms deliberately. With only the falcon
+// arm, an implementation that restored the module string unconditionally —
+// clobbering #6131's in-repo bind — would pass.
+func TestPruneImportPlaceholders_RestoresModuleStringForThirdPartyImport(t *testing.T) {
+	const (
+		mainFile    = "oi_main.py"
+		modLibID    = "1111111111111111" // Module oi_lib_static (real, in-repo)
+		fileCarrier = "3333333333333333" // SCOPE.Component file for the importer
+		phFalconID  = "4444444444444444" // import placeholder for falcon (third-party)
+		phLibID     = "5555555555555555" // import placeholder for oi_lib_static (in-repo)
+		handlerFn   = "6666666666666666" // the function holding the REFERENCES
+	)
+	records := []types.EntityRecord{
+		{ID: modLibID, Name: "oi_lib_static", Kind: "Module", Subtype: "package", SourceFile: "oi_lib_static.py"},
+		{
+			ID: fileCarrier, Name: mainFile, Kind: "SCOPE.Component", Subtype: "file", SourceFile: mainFile,
+			Relationships: []types.RelationshipRecord{
+				// Third-party: the dotted-import resolver found no in-repo target
+				// and left the endpoint on the placeholder's stamped id. This is
+				// the edge #6156 orphans.
+				{FromID: fileCarrier, ToID: phFalconID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "falcon", "imported_name": "falcon", "local_name": "falcon"})},
+				// In-repo: already bound. #6131's case, and the control here.
+				{FromID: fileCarrier, ToID: modLibID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "oi_lib_static", "imported_name": "oi_lib_static", "local_name": "oi_lib_static"})},
+			},
+		},
+		{ID: phFalconID, Name: "falcon", Kind: "SCOPE.Component", Subtype: "import", SourceFile: mainFile},
+		{ID: phLibID, Name: "oi_lib_static", Kind: "SCOPE.Component", Subtype: "import", SourceFile: mainFile},
+		{
+			ID: handlerFn, Name: "oi_handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: mainFile,
+			Relationships: []types.RelationshipRecord{
+				// `falcon.App()` — a reference bound to the third-party placeholder.
+				{FromID: handlerFn, ToID: phFalconID, Kind: "REFERENCES"},
+				// `oi_lib_static.oi_target(x)` — the #6131 shape.
+				{FromID: handlerFn, ToID: phLibID, Kind: "REFERENCES"},
+			},
+		},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	// Premise: both placeholders were genuinely removed. If either survived,
+	// its incoming edges would bind trivially and this test would measure
+	// nothing.
+	if stats.Pruned != 2 {
+		t.Fatalf("expected both placeholders pruned, got %d", stats.Pruned)
+	}
+	for _, e := range out {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" {
+			t.Fatalf("import placeholder %s@%s survived the prune", e.Name, e.SourceFile)
+		}
+	}
+	if stats.PlaceholderRefRepoints != 1 {
+		t.Errorf("PlaceholderRefRepoints = %d, want 1 (the in-repo oi_lib_static reference only)", stats.PlaceholderRefRepoints)
+	}
+	if stats.PlaceholderModuleRestores != 2 {
+		t.Errorf("PlaceholderModuleRestores = %d, want 2 (the falcon IMPORTS edge and the falcon REFERENCES edge)", stats.PlaceholderModuleRestores)
+	}
+
+	live := make(map[string]bool, len(out))
+	for _, e := range out {
+		live[e.ID] = true
+	}
+	got := map[string]int{}
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			got[rel.Kind+"|"+rel.FromID+"->"+rel.ToID]++
+		}
+	}
+	want := map[string]int{
+		// Restored to the raw module string, which is what external.Synthesize
+		// classifies into ext:falcon.
+		"IMPORTS|" + fileCarrier + "->falcon":       1,
+		"REFERENCES|" + handlerFn + "->falcon":      1,
+		"IMPORTS|" + fileCarrier + "->" + modLibID:  1,
+		"REFERENCES|" + handlerFn + "->" + modLibID: 1,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("edge multiset = %v, want %v", got, want)
+	}
+	for k, n := range want {
+		if got[k] != n {
+			t.Errorf("edge %s occurs %d time(s), want %d (full multiset: %v)", k, got[k], n, got)
+		}
+	}
+	// Nothing may be left pointing at a hex id no entity carries — that is the
+	// orphan #6156 is about.
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			if isHexLikeID(rel.ToID) && !live[rel.ToID] {
+				t.Errorf("edge %s from %s left dangling at hex id %q after prune", rel.Kind, e.ID, rel.ToID)
+			}
+		}
+	}
+}
+
+// isHexLikeID reports whether s looks like a stamped 16-hex-digit entity id.
+// Used by the #6156 test to tell a dangling id endpoint from a legitimately
+// unresolved module string.
+func isHexLikeID(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if !(c >= '0' && c <= '9' || c >= 'a' && c <= 'f') {
+			return false
+		}
+	}
+	return true
+}
+
+// TestPruneImportPlaceholders_DoesNotRestoreIDSharedWithSurvivor pins the
+// fourth guard on the #6156 restore, and it is the one that was found the hard
+// way rather than reasoned to.
+//
+// graph.EntityID hashes repo/kind/name/sourceFile and NOT Subtype, so a pruned
+// `SCOPE.Component` placeholder named M in file F carries the SAME id as any
+// other `SCOPE.Component` named M in F. The #6131 block records this collision
+// and says no reachable instance is known. There is one: Go's extractor emits
+// import entities with an EMPTY Subtype — never pruned, so they stay live —
+// while the cross-language imports extractor emits a Subtype="import"
+// placeholder for the same import in the same file.
+//
+// The pinned-digest test in cmd/grafel/custom_extractor_spans_6118_test.go
+// caught it: on `svc/handler.go` importing net/http, an unguarded restore took
+// `Handler.ServeHTTP -REFERENCES-> SCOPE.Component/net/http` — a perfectly bound
+// edge — and un-resolved it to the raw module string, which
+// external.Synthesize then folded into `ext:net`. An id a survivor carries is
+// not a would-be-dangling endpoint.
+//
+// Remove the survivor check in buildPlaceholderModuleRestores and this fails.
+func TestPruneImportPlaceholders_DoesNotRestoreIDSharedWithSurvivor(t *testing.T) {
+	const (
+		f      = "svc/handler.go"
+		shared = "4444444444444444" // BOTH import entities hash to this id
+		fn     = "6666666666666666"
+	)
+	records := []types.EntityRecord{
+		// The Go extractor's import entity: Subtype empty, so never pruned.
+		{ID: shared, Name: "net/http", Kind: "SCOPE.Component", Subtype: "", SourceFile: f},
+		// The cross-language extractor's placeholder for the SAME import in the
+		// SAME file: same id, Subtype="import", pruned.
+		{ID: shared, Name: "net/http", Kind: "SCOPE.Component", Subtype: "import", SourceFile: f},
+		{
+			ID: fn, Name: "Handler.ServeHTTP", Kind: "SCOPE.Operation", Subtype: "method", SourceFile: f,
+			Relationships: []types.RelationshipRecord{{FromID: fn, ToID: shared, Kind: "REFERENCES"}},
+		},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	// Premise: the placeholder was pruned AND the colliding entity survived.
+	// Without both halves the collision is not reached.
+	if stats.Pruned != 1 {
+		t.Fatalf("premise broken: pruned=%d, want 1 (the Subtype=\"import\" record only)", stats.Pruned)
+	}
+	survived := false
+	for _, e := range out {
+		if e.ID == shared && e.Subtype == "" {
+			survived = true
+		}
+		if e.Subtype == "import" {
+			t.Fatalf("premise broken: the placeholder survived the prune")
+		}
+	}
+	if !survived {
+		t.Fatalf("premise broken: the colliding Go import entity did not survive, so the id is dead")
+	}
+
+	if stats.PlaceholderModuleRestores != 0 {
+		t.Errorf("PlaceholderModuleRestores = %d, want 0 — a live entity carries that id, so the "+
+			"endpoint is bound, not dangling", stats.PlaceholderModuleRestores)
+	}
+	for _, e := range out {
+		if e.ID != fn {
+			continue
+		}
+		if len(e.Relationships) != 1 || e.Relationships[0].ToID != shared {
+			t.Errorf("REFERENCES = %+v, want ToID %q left bound to the surviving entity",
+				e.Relationships, shared)
+		}
+	}
+}
+
+// TestPruneImportPlaceholders_DoesNotRestoreOntoKeptPlaceholder pins the third
+// guard on the #6156 restore: it applies only to placeholders actually being
+// PRUNED.
+//
+// A KEPT placeholder (one whose embedded rels could not be safely migrated —
+// see canMigrate) still carries a live id, so an incoming edge bound to it is
+// bound to a real entity in the final graph. Restoring that endpoint to a raw
+// module string would take a working binding and un-resolve it, which is a
+// strictly worse graph than the one #6156 set out to repair.
+//
+// Remove the `prunable[i]` gate in buildPlaceholderModuleRestores and this test
+// must fail.
+func TestPruneImportPlaceholders_DoesNotRestoreOntoKeptPlaceholder(t *testing.T) {
+	const (
+		f  = "app.py"
+		ph = "4444444444444444"
+		fn = "6666666666666666"
+	)
+	records := []types.EntityRecord{
+		// No file-level carrier for app.py, AND the placeholder carries a rel
+		// with an EMPTY FromID — canMigrate refuses, so the prune keeps it.
+		{
+			ID: ph, Name: "requests", Kind: "SCOPE.Component", Subtype: "import", SourceFile: f,
+			Relationships: []types.RelationshipRecord{
+				{FromID: "", ToID: "requests", Kind: "IMPORTS"},
+			},
+		},
+		{
+			ID: fn, Name: "handle", Kind: "SCOPE.Operation", Subtype: "function", SourceFile: f,
+			Relationships: []types.RelationshipRecord{{FromID: fn, ToID: ph, Kind: "REFERENCES"}},
+		},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	// Premise: the placeholder really was KEPT. If it were pruned this test
+	// would be asserting the opposite behaviour to the one it names.
+	if stats.PlaceholderKept != 1 || stats.Pruned != 0 {
+		t.Fatalf("premise broken: kept=%d pruned=%d, want kept=1 pruned=0", stats.PlaceholderKept, stats.Pruned)
+	}
+	live := false
+	for _, e := range out {
+		if e.ID == ph {
+			live = true
+		}
+	}
+	if !live {
+		t.Fatalf("premise broken: the kept placeholder is not in the survivor slice")
+	}
+
+	if stats.PlaceholderModuleRestores != 0 {
+		t.Errorf("PlaceholderModuleRestores = %d, want 0 — the placeholder survives, so the "+
+			"incoming edge binds to a real entity and needs no repair", stats.PlaceholderModuleRestores)
+	}
+	for _, e := range out {
+		if e.ID != fn {
+			continue
+		}
+		if len(e.Relationships) != 1 || e.Relationships[0].ToID != ph {
+			t.Errorf("REFERENCES = %+v, want ToID %q (the surviving placeholder) left bound",
+				e.Relationships, ph)
+		}
+	}
+}
+
+// TestPruneImportPlaceholders_LeavesRelativeImportPlaceholderAlone pins the
+// gate on the #6156 restore: it applies to NON-RELATIVE module strings only.
+//
+// A relative specifier (`./missing`) that failed to resolve is a fidelity bug
+// in the resolver, not a third-party dependency. external.Synthesize will never
+// classify `./missing` as an external package, so restoring the string buys
+// nothing and would merely swap one unresolved endpoint shape for another while
+// widening the blast radius of the repair onto the #642 path.
+//
+// Remove the relative-prefix guard and this test must fail.
+func TestPruneImportPlaceholders_LeavesRelativeImportPlaceholderAlone(t *testing.T) {
+	const (
+		appFile     = "src/app.ts"
+		fileCarrier = "3333333333333333"
+		phRelID     = "4444444444444444"
+	)
+	records := []types.EntityRecord{
+		{
+			ID: fileCarrier, Name: appFile, Kind: "SCOPE.Component", Subtype: "file", SourceFile: appFile,
+			Relationships: []types.RelationshipRecord{
+				{FromID: fileCarrier, ToID: phRelID, Kind: "IMPORTS", Properties: types.PropsFromMap(map[string]string{"source_module": "./missing", "imported_name": "./missing"})},
+			},
+		},
+		// No carrier exists for src/missing.* — the relative import is
+		// genuinely unresolvable in this record set, which is the premise.
+		{ID: phRelID, Name: "./missing", Kind: "SCOPE.Component", Subtype: "import", SourceFile: appFile},
+	}
+
+	out, _, stats := PruneImportPlaceholders(records)
+
+	if stats.Pruned != 1 {
+		t.Fatalf("expected the relative placeholder pruned, got %d", stats.Pruned)
+	}
+	if stats.EdgeToIDRewrites != 0 {
+		t.Fatalf("premise broken: the #642 rewrite resolved ./missing (%d rewrite(s)), so this "+
+			"test is not exercising the unresolvable case", stats.EdgeToIDRewrites)
+	}
+	if stats.PlaceholderModuleRestores != 0 {
+		t.Errorf("PlaceholderModuleRestores = %d, want 0 — a relative specifier is not a "+
+			"third-party package", stats.PlaceholderModuleRestores)
+	}
+	for _, e := range out {
+		for _, rel := range e.Relationships {
+			if rel.ToID != phRelID {
+				t.Errorf("IMPORTS ToID = %q; want it left at %q (unchanged)", rel.ToID, phRelID)
 			}
 		}
 	}


### PR DESCRIPTION
On the full-rebuild path, the `IMPORTS` edge for every **third-party** import pointed at the hex id of an import placeholder `PruneImportPlaceholders` had already removed — a dangling endpoint — while the `SCOPE.External` node it should bind to existed in the same graph. The incremental path bound it correctly, so this was a full-path defect with the incremental answer being right.

Blast radius: every third-party import in every repo, on the default path. The graph lost the file→package edge that `grafel_expand`, lib-boundary and module aggregation read.

## Neither of the issue's two directions was right, for a mechanical reason

`external.Synthesize` (`internal/external/synth.go:309`) **skips any `ToID` that `isHexID` matches.** It cannot adopt a dangling hex endpoint at all — not because it doesn't know about pruned placeholders, but because it only ever binds by *classifying a string*.

So deferring the prune would reinstate the orphan-entity bucket the prune exists to remove, and bind the edge to a structural carrier rather than the package — the wrong target for every consumer. And re-pointing from `Synthesize` would mean plumbing a pruned-id→module map across four stages so a later pass could undo an earlier one's damage, when the module string is already in hand at prune time.

**Restore instead.** A pruned placeholder whose module resolved to nothing has its incoming endpoints rewritten back to the **raw module string** — the pre-resolution form `Synthesize` classifies. That is byte-identical to what the incremental path already hands it, which is why this closes the divergence rather than relocating it.

**A placeholder with no durable home** — neither in-repo nor ever synthesised as external, e.g. a same-repo Python root that `classifyExternal` deliberately refuses to launder into an `ext:` node — keeps the raw module string. Unresolved but not dangling, identical to an edge the resolver never touched, and still visible to unresolved-endpoint reporting as the fidelity bug it is. No edge is created or dropped. That third behaviour is chosen over silently dropping.

## The `DEPENDS_ON` weight corrected itself

`Module/test-repo→Module/_external:DEPENDS_ON` moved `weight "6"≠"7"` → `"8"≠"7"`. The full side rose by **exactly 2** — the two orphans — with zero change to aggregation code. That is the evidence the under-count was a consequence rather than a second defect.

The residual `8≠7` is single-cause #6159 (Path A's missing `ENTRY_POINT_OF`), so the ledger entry was **re-keyed to #6159** rather than deleted, per that file's own "re-key, don't delete" rule.

## A claim in the existing #6131 block is false, and the first cut hit it

#6131 asserts the `EntityID`-omits-`Subtype` collision has **no reachable instance**. It does. Go's extractor emits import entities with an **empty** `Subtype` (never pruned, stays live); the cross-language extractor emits a `Subtype="import"` placeholder for the same import in the same file. Same hash.

Rewriting that id takes a perfectly bound edge and **un-resolves** it — a regression, not a gain:

```
- Handler.ServeHTTP -[REFERENCES]-> SCOPE.Component|net/http   (bound, live)
+ Handler.ServeHTTP -[REFERENCES]-> SCOPE.External|net         (unresolved)
```

Caught by `TestCustomExtractorGateOffGraphIsUnchanged`, a pinned semantic digest, and diagnosed by diffing the graph before and after rather than by reading. The survivor-id guard closes it, and the digest is now byte-identical to the pinned `gateOffDigest6138` — **no re-baselining was needed**, which is the check that the fix adds the intended edge and nothing else.

The identical hole in #6131's own repoint is left alone — pre-existing, out of scope, and it needs its own measurement — but is now documented at both sites instead of being asserted away.

## Mutants

Six. **M5 initially survived** — removing the `prunable[i]` gate — so `TestPruneImportPlaceholders_DoesNotRestoreOntoKeptPlaceholder` was written, which kills it. The rest: the restore itself removed (counter still bumped); the relative-prefix guard removed; the `resolvedModules` guard removed; that map recorded *after* the ambiguity gate instead of before; the survivor-id guard removed.

Re-run independently at merge — neutralising the restore fails with the endpoints named:

```
edge IMPORTS from 3333333333333333 left dangling at hex id "4444444444444444" after prune
REFERENCES ToID = "4444444444444444", want the raw module string "requests"
```

## Four ledger entries went stale, not three

`cpAssertParity`'s ratchet — any `cpKnown` with `hits[i] == 0` raises `allow-list entry … matched NOTHING` — named **four**. Beyond the falcon pair, the express pair (`→SCOPE.External/express@:IMPORTS` and its `«unbound»` half) went stale too: the same defect hit the JS `require`, which the issue did not mention. All four deleted. The weight row went stale via `DetailContains` and was re-keyed as above.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/resolve/...` 0, `./internal/external/...` 0, `./internal/graph/...` 0, `./cmd/grafel/...` 0 (112s, single run).

Closes #6156
Refs #6131, #642, #6129, #6159
