### PR TITLE
fix(#6152): every bare Python class was typed `Controller`, in every repo

### DIFF
--- a/cmd/grafel/custom_extractor_spans_6118_test.go
+++ b/cmd/grafel/custom_extractor_spans_6118_test.go
@@ -489,10 +489,29 @@ func semanticDigest6118(doc *graph.Document) string {
 // the position the span donation gives it. The one entity that changes in place
 // is the java/OrdersController.java file component, which hands qualified_name
 // `api.OrdersController` back to the class it belongs to.
+// #6152 MOVED IT A THIRD TIME, and the delta is again characterised rather than
+// absorbed. Two Python rule sets (falcon, cherrypy) carried a source_pattern
+// matching a BARE `class X:` and typing it `Controller`; Detect resolved rule
+// sets by file.Language alone, so both fired on every Python file whether or not
+// the framework was present. Gating them on the rule file's own
+// frameworks.detection.import_markers changes exactly two things in this
+// fixture, both in myapp/serializers.py:
+//
+//	Controller/OrderSerializer  ->  SCOPE.Component/OrderSerializer   (re-kinded)
+//	Controller/Meta             ->  (deleted)
+//
+// `class Meta:` is a nested DRF options class. The Python extractor already
+// emits it, correctly named `OrderSerializer.Meta`; the ungated bare-class
+// pattern emitted a SECOND, differently-named node for the same declaration.
+// Removing it takes the counts 149/292 -> 148/291: one phantom node and the one
+// Module->Meta CONTAINS edge that carried it. No real declaration is lost —
+// TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain still finds
+// every file component and every donated span.
 const (
 	gateOffDigest6118Base = "a0a6ede910d8d0465d901153f483b27b8a57a565bdd79dd0104bef53786d9ca1"
 	gateOffDigest6118     = "387a9c36cb585b4d73828afc997744dbe02e6df347e0860054adf69431996d46"
 	gateOffDigest6138     = "8726464ce66a815e8b8a69bf8a9ee272368903f623c161fba81235237e235025"
+	gateOffDigest6152     = "774eaec1d5ad5d9731d2c043a6207fdb7b3882b9fdf0f37e4a6b9dbdc555662f"
 )
 
 func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
@@ -500,8 +519,12 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 	t.Setenv("GRAFEL_INPROC_CUSTOM_EXTRACTORS", "")
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 	got := semanticDigest6118(off)
-	if got == gateOffDigest6138 {
+	if got == gateOffDigest6152 {
 		return
+	}
+	if got == gateOffDigest6138 {
+		t.Fatalf("gate-OFF graph reverted to the pre-#6152 baseline — the falcon/cherrypy " +
+			"bare-class patterns are typing plain Python classes `Controller` again")
 	}
 	if got == gateOffDigest6118 {
 		t.Fatalf("gate-OFF graph reverted to the pre-#6138 baseline — the file fold is " +
@@ -511,9 +534,9 @@ func TestCustomExtractorGateOffGraphIsUnchanged(t *testing.T) {
 		t.Fatalf("gate-OFF graph reverted to the pre-fix 2f0175dfc baseline — the #6118 " +
 			"span donation is no longer reaching the default path")
 	}
-	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
-		"(entities=%d relationships=%d)", got, gateOffDigest6138, gateOffDigest6118,
-		gateOffDigest6118Base, len(off.Entities), len(off.Relationships))
+	t.Fatalf("gate-OFF graph changed against ALL pinned digests\n got  %s\n post-#6152 %s\n post-#6138 %s\n post-#6118 %s\n 2f0175dfc %s\n"+
+		"(entities=%d relationships=%d)", got, gateOffDigest6152, gateOffDigest6138,
+		gateOffDigest6118, gateOffDigest6118Base, len(off.Entities), len(off.Relationships))
 }
 
 // TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain pins the shape
@@ -528,10 +551,13 @@ func TestCustomExtractorGateOffDeltaIsExactlyTheDocumentedSpanGain(t *testing.T)
 	off := persistAndReload(t, runIndexerOn(t, fixture, "span6118", nil))
 
 	// 141/284 at 2f0175dfc, plus the eight declarations #6138 stopped deleting
-	// and the eight Module->declaration CONTAINS edges that carry them.
+	// and the eight Module->declaration CONTAINS edges that carry them (149/292),
+	// minus the one phantom `Controller/Meta` node the ungated falcon/cherrypy
+	// bare-class patterns emitted for the nested DRF `class Meta:` and the
+	// Module->Meta CONTAINS edge that carried it (#6152).
 	const (
-		wantEntities = 149
-		wantRels     = 292
+		wantEntities = 148
+		wantRels     = 291
 	)
 	if len(off.Entities) != wantEntities || len(off.Relationships) != wantRels {
 		t.Fatalf("gate-OFF graph size moved: entities=%d (want %d) relationships=%d (want %d) — "+

--- a/cmd/grafel/incremental_content_parity_6129_test.go
+++ b/cmd/grafel/incremental_content_parity_6129_test.go
@@ -985,15 +985,28 @@ var cpKnownPathB = []cpKnown{
 	// ── #6129, headline Path-B defect: a DEPENDS_ON SELF-EDGE ──
 	//
 	// The incremental run emits `CpProducer → CpProducer` — a module-aggregation
-	// dependency from an entity onto itself, which a full rebuild never
-	// produces and which is meaningless as a dependency. (#6129 records the same
-	// shape as `ProdClassU → ProdClassU` on the #6119 fixture.) Edge counts move
-	// by one in a direction that reads as "more resolved".
+	// dependency from an entity onto itself, which is meaningless as a
+	// dependency. (#6129 records the same shape as `ProdClassU → ProdClassU` on
+	// the #6119 fixture.) Edge counts move by one in a direction that reads as
+	// "more resolved".
+	//
+	// #6152 changed how this row PRESENTS, not whether it is a defect. Before
+	// the framework-presence gate, `class CpProducer:` was typed `Controller` by
+	// the ungated falcon/cherrypy bare-class patterns, and the full rebuild's
+	// own copy of this self-edge dangled on the unresolved placeholder endpoint
+	// `Model:CpProducer` — so the content-keyed comparator saw zero rows in A
+	// and one in B, i.e. EDGE-INVENTED. With the gate the class is
+	// SCOPE.Component, the full rebuild's self-edge binds to the real entity,
+	// and the divergence is the same one row of Path-B excess expressed as
+	// multiplicity: 1 in A, 2 in B. Entity and relationship totals for the full
+	// rebuild are unchanged across #6152 (69 / 145 either way) — nothing was
+	// added or destroyed, an endpoint that used to dangle now resolves.
 	{
-		Issue:    "#6129",
-		Why:      "Path B emits a spurious DEPENDS_ON self-edge a full rebuild does not. Unfixed.",
-		Bucket:   cpEdgeInvented,
-		Contains: []string{"Controller/CpProducer@cpprod_static.py→Controller/CpProducer@cpprod_static.py:DEPENDS_ON"},
+		Issue:          "#6129",
+		Why:            "Path B emits one DEPENDS_ON self-edge more than a full rebuild. Unfixed.",
+		Bucket:         cpEdgeMult,
+		Contains:       []string{"SCOPE.Component/CpProducer@cpprod_static.py→SCOPE.Component/CpProducer@cpprod_static.py:DEPENDS_ON"},
+		DetailContains: []string{"row count 1 in A (full rebuild) ≠ 2 in B (incremental)"},
 	},
 
 	// ── #6129, second Path-B defect: duplicated file→external DEPENDS_ON ──

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -25,6 +25,9 @@ type compiledSourcePattern struct {
 	nameGroup  int
 	scope      string
 	framework  string
+	// requiresFramework mirrors SourcePattern.RequiresFramework: fire only when
+	// the owning rule set's import markers are present in the file (#6152).
+	requiresFramework bool
 }
 
 // compiledRelationshipRule is a RelationshipRule with its regex pre-compiled.
@@ -73,6 +76,26 @@ type compiledRuleSet struct {
 	sourcePatterns    []compiledSourcePattern
 	relationshipRules []compiledRelationshipRule
 	fileConventions   []compiledFileConvention
+	// importMarkers is the rule file's frameworks.detection.import_markers —
+	// literal substrings whose presence means the framework is in play in this
+	// file. Consumed by frameworkPresent for requires_framework patterns.
+	importMarkers []string
+}
+
+// frameworkPresent reports whether this rule set's framework is detectable in
+// content, by literal import-marker substring (#6152).
+//
+// A rule set with NO declared markers returns false: a requires_framework
+// pattern in a marker-less file has no way to establish presence, so the safe
+// reading is "not present". compile() logs that combination, and
+// TestGatedPatternsAreLoaded_6152 fails on it, so it cannot land silently.
+func (c compiledRuleSet) frameworkPresent(content string) bool {
+	for _, m := range c.importMarkers {
+		if m != "" && strings.Contains(content, m) {
+			return true
+		}
+	}
+	return false
 }
 
 // dormantBucketAliases maps a flavor-named rule bucket (the directory key the
@@ -123,7 +146,7 @@ func (d *Detector) compile() {
 	for lang, frameworkRules := range d.rules {
 		var sets []compiledRuleSet
 		for _, fr := range frameworkRules {
-			cs := compiledRuleSet{}
+			cs := compiledRuleSet{importMarkers: fr.Frameworks.Detection.ImportMarkers}
 
 			for _, sp := range fr.SourcePatterns {
 				re, err := regexp.Compile(sp.Pattern)
@@ -131,12 +154,18 @@ func (d *Detector) compile() {
 					log.Printf("engine: invalid source_pattern regex in %s: %q: %v", lang, sp.Pattern, err)
 					continue
 				}
+				if sp.RequiresFramework && len(cs.importMarkers) == 0 {
+					log.Printf("engine: source_pattern in %s is marked requires_framework but its "+
+						"rule file declares no frameworks.detection.import_markers; it can never "+
+						"fire: %q", lang, sp.Pattern)
+				}
 				cs.sourcePatterns = append(cs.sourcePatterns, compiledSourcePattern{
-					regex:      re,
-					entityType: sp.EntityType,
-					nameGroup:  sp.NameGroup,
-					scope:      sp.Scope,
-					framework:  lang,
+					regex:             re,
+					entityType:        sp.EntityType,
+					nameGroup:         sp.NameGroup,
+					scope:             sp.Scope,
+					framework:         lang,
+					requiresFramework: sp.RequiresFramework,
 				})
 			}
 
@@ -296,10 +325,35 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		}
 		conventionAnnotation := strings.Join(matchedConventionGlobs, ",")
 
+		// Framework-presence gate (#6152). Evaluated once per (ruleset, file)
+		// and only when some pattern in the set actually asks for it, so the
+		// overwhelming majority of rule sets pay nothing.
+		//
+		// Rules exist whose regex matches plain language syntax — falcon.yaml
+		// and cherrypy.yaml both type a bare `class Foo:` as Controller. Those
+		// patterns are correct WHEN the framework is present and pure noise
+		// otherwise, and Detect resolves rule sets by file.Language alone, so
+		// before this gate every bare Python class in every indexed repo came
+		// out `Controller`.
+		frameworkGateNeeded := false
+		for _, sp := range cs.sourcePatterns {
+			if sp.requiresFramework {
+				frameworkGateNeeded = true
+				break
+			}
+		}
+		frameworkSeen := false
+		if frameworkGateNeeded {
+			frameworkSeen = cs.frameworkPresent(content)
+		}
+
 		// Extract entities from source patterns.
 		// Issue #1413 — use FindAllStringSubmatchIndex so we have byte offsets
 		// for computing StartLine. Also derives QualifiedName for Python entities.
 		for _, sp := range cs.sourcePatterns {
+			if sp.requiresFramework && !frameworkSeen {
+				continue
+			}
 			idxMatches := sp.regex.FindAllStringSubmatchIndex(content, -1)
 			for _, idxMatch := range idxMatches {
 				if len(idxMatch) < 2 {

--- a/internal/engine/python_bare_class_controller_6152_test.go
+++ b/internal/engine/python_bare_class_controller_6152_test.go
@@ -1,0 +1,267 @@
+// Package engine — #6152.
+//
+// Two Python framework rule sets carry a source_pattern that matches a BARE
+// class declaration and types it `Controller`:
+//
+//	falcon.yaml    class\s+(\w+)\s*(?:\([^)]*\))?\s*:
+//	cherrypy.yaml  class\s+(\w+)\s*(?:\(object\))?\s*:
+//
+// Detect resolves compiled rule sets by file.Language alone, so both fired on
+// EVERY Python file in every repo, framework present or not — every bare class
+// in the graph came out `Controller`. (internal/extractors/migration_prune.go
+// exists to delete a slice of that output for migration files specifically;
+// see #3173.)
+//
+// The fix gates those two patterns on the framework's own detection metadata —
+// the `frameworks.detection.import_markers` list already sitting in each YAML
+// file — via an explicit `requires_framework: true` opt-in on the pattern.
+//
+// This file asserts BOTH directions, because a gate that kills recall is worse
+// than the bug:
+//
+//   - a bare class in a file with no falcon/cherrypy marker is NOT a Controller
+//   - a real falcon resource / cherrypy app class still IS a Controller
+//
+// Every fixture's PREMISE is asserted against the YAML rule files themselves —
+// not against the Go structs under test — so a fixture that silently stops
+// exercising the gate fails loudly instead of passing through another path.
+package engine
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/grafel/internal/extractor"
+)
+
+// cpMarkerYAML is a minimal view of a framework rule file, parsed straight off
+// disk. It deliberately does NOT reuse the engine's own schema types: the
+// premise assertions below must be grounded in the rule FILES, so that a bug in
+// the loader/schema (the layer under test) cannot make them vacuously true.
+type cpMarkerYAML struct {
+	Frameworks struct {
+		Detection struct {
+			ImportMarkers []string `yaml:"import_markers"`
+		} `yaml:"detection"`
+	} `yaml:"frameworks"`
+}
+
+// cpImportMarkers reads the on-disk import_markers for one python framework
+// rule file and fails if the list is empty — an empty list would make every
+// "no marker present" premise below trivially true.
+func cpImportMarkers(t *testing.T, framework string) []string {
+	t.Helper()
+	path := "rules/python/frameworks/" + framework + ".yaml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc cpMarkerYAML
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	markers := doc.Frameworks.Detection.ImportMarkers
+	if len(markers) == 0 {
+		t.Fatalf("%s declares no frameworks.detection.import_markers — the gate this test "+
+			"exercises has no signal to gate on, and every premise below would be vacuous", path)
+	}
+	return markers
+}
+
+// cpAssertNoMarker asserts the fixture genuinely contains NO detection marker
+// for either gated framework. This is the negative test's premise: without it,
+// "bare class is not a Controller" could pass because the fixture accidentally
+// tripped some unrelated rule.
+func cpAssertNoMarker(t *testing.T, src string) {
+	t.Helper()
+	for _, fw := range []string{"falcon", "cherrypy"} {
+		for _, m := range cpImportMarkers(t, fw) {
+			if strings.Contains(src, m) {
+				t.Fatalf("fixture premise broken: source contains %s marker %q, so it is not a "+
+					"bare no-framework file and cannot test the gate's negative direction", fw, m)
+			}
+		}
+	}
+}
+
+// cpAssertHasMarker asserts the fixture genuinely contains at least one
+// detection marker for the named framework — the positive test's premise.
+func cpAssertHasMarker(t *testing.T, framework, src string) {
+	t.Helper()
+	for _, m := range cpImportMarkers(t, framework) {
+		if strings.Contains(src, m) {
+			return
+		}
+	}
+	t.Fatalf("fixture premise broken: source contains none of %s's import_markers %q, so a "+
+		"Controller verdict would not prove the gate lets a real %s class through",
+		framework, cpImportMarkers(t, framework), framework)
+}
+
+// cpDetect runs the REAL embedded rule set — the same one Pass 2.5 runs.
+func cpDetect(t *testing.T, path, src string) *DetectResult {
+	t.Helper()
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	res, err := New(rules).Detect(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "python",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("detect: %v", err)
+	}
+	if res == nil {
+		t.Fatal("detect returned nil result")
+	}
+	return res
+}
+
+// cpKindsFor returns every Kind the detector emitted for the named entity.
+func cpKindsFor(res *DetectResult, name string) []string {
+	var out []string
+	for i := range res.Entities {
+		if res.Entities[i].Name == name {
+			out = append(out, res.Entities[i].Kind)
+		}
+	}
+	return out
+}
+
+// cpBareClassSource is a Python file with no framework anywhere: no import, no
+// decorator, no base class, no responder method name. Method and class names
+// are prefixed so they cannot collide with any other rule's vocabulary.
+const cpBareClassSource = `class CpPlainProbe:
+    def cp_probe_noop(self):
+        return 1
+`
+
+// TestBarePythonClass_IsNotController_6152 is the gate's negative direction.
+//
+// Before the fix this reported kind=Controller (twice — once from falcon.yaml,
+// once from cherrypy.yaml, deduplicated to one row by entity key).
+func TestBarePythonClass_IsNotController_6152(t *testing.T) {
+	cpAssertNoMarker(t, cpBareClassSource)
+
+	res := cpDetect(t, "cp_plain.py", cpBareClassSource)
+
+	for _, k := range cpKindsFor(res, "CpPlainProbe") {
+		if k == "Controller" {
+			t.Errorf("bare Python class CpPlainProbe typed %q by the YAML engine: the "+
+				"falcon/cherrypy bare-class patterns are firing on a file with no framework "+
+				"marker (#6152)", k)
+		}
+	}
+}
+
+// cpFalconSource is a genuine Falcon resource module: it carries the `import
+// falcon` marker, registers a route, and defines an on_get responder.
+const cpFalconSource = `import falcon
+
+
+class CpFalconProbe:
+    def on_get(self, req, resp):
+        resp.text = "ok"
+
+
+cp_app = falcon.App()
+cp_app.add_route('/cp-probe', CpFalconProbe())
+`
+
+// TestFalconResourceClass_StaysController_6152 is the gate's positive
+// direction: the recall the falcon rule exists to provide must survive.
+func TestFalconResourceClass_StaysController_6152(t *testing.T) {
+	cpAssertHasMarker(t, "falcon", cpFalconSource)
+
+	res := cpDetect(t, "cp_falcon.py", cpFalconSource)
+
+	kinds := cpKindsFor(res, "CpFalconProbe")
+	found := false
+	for _, k := range kinds {
+		if k == "Controller" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("falcon resource class CpFalconProbe lost its Controller kind (got %q): the "+
+			"#6152 gate is too strict and has cost real recall", kinds)
+	}
+}
+
+// cpCherryPySource is a genuine CherryPy application module.
+const cpCherryPySource = `import cherrypy
+
+
+class CpCherryProbe(object):
+    @cherrypy.expose
+    def cp_index(self):
+        return "ok"
+
+
+cherrypy.quickstart(CpCherryProbe())
+`
+
+// TestCherryPyAppClass_StaysController_6152 is the second positive direction.
+func TestCherryPyAppClass_StaysController_6152(t *testing.T) {
+	cpAssertHasMarker(t, "cherrypy", cpCherryPySource)
+
+	res := cpDetect(t, "cp_cherry.py", cpCherryPySource)
+
+	kinds := cpKindsFor(res, "CpCherryProbe")
+	found := false
+	for _, k := range kinds {
+		if k == "Controller" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("cherrypy app class CpCherryProbe lost its Controller kind (got %q): the "+
+			"#6152 gate is too strict and has cost real recall", kinds)
+	}
+}
+
+// TestGatedPatternsAreLoaded_6152 pins the wiring itself: the two bare-class
+// patterns must actually carry requires_framework, and their rule sets must
+// actually carry import markers into the compiled form. Without this, a future
+// edit that drops the YAML flag would silently reopen #6152 while the negative
+// test above kept passing for the wrong reason (no marker → no match either way
+// is indistinguishable from no gate → …no, it is not: it would REGRESS. This
+// test makes the wiring itself observable rather than inferred).
+func TestGatedPatternsAreLoaded_6152(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	d := New(rules)
+	d.once.Do(d.compile)
+
+	gated := 0
+	markerBearing := 0
+	for _, cs := range d.compiled["python"] {
+		if len(cs.importMarkers) > 0 {
+			markerBearing++
+		}
+		for _, sp := range cs.sourcePatterns {
+			if sp.requiresFramework {
+				gated++
+				if len(cs.importMarkers) == 0 {
+					t.Errorf("source pattern %q is marked requires_framework but its rule set "+
+						"carries no import_markers — the gate would suppress it unconditionally",
+						sp.regex.String())
+				}
+			}
+		}
+	}
+	if gated == 0 {
+		t.Error("no python source_pattern carries requires_framework: the #6152 gate is not wired")
+	}
+	if markerBearing == 0 {
+		t.Error("no python rule set carries import_markers: detection metadata is not being loaded")
+	}
+}

--- a/internal/engine/rules/python/frameworks/cherrypy.yaml
+++ b/internal/engine/rules/python/frameworks/cherrypy.yaml
@@ -39,11 +39,16 @@ source_patterns:
     entity_type: Route
     name_group: 1
     scope: file
-  # CherryPy application class inheriting from object
+  # CherryPy application class inheriting from object. `(object)` is optional
+  # in the regex, so this matches ANY class declaration and carries no
+  # CherryPy-specific token; it is gated on the detection markers above.
+  # Without the gate it typed every bare Python class in every repo as a
+  # Controller (#6152).
   - pattern: "class\\s+(\\w+)\\s*(?:\\(object\\))?\\s*:"
     entity_type: Controller
     name_group: 1
     scope: class
+    requires_framework: true
   # cherrypy.quickstart(Root()) — application entry point
   - pattern: "cherrypy\\.quickstart\\s*\\(\\s*(\\w+)"
     entity_type: Service

--- a/internal/engine/rules/python/frameworks/falcon.yaml
+++ b/internal/engine/rules/python/frameworks/falcon.yaml
@@ -50,11 +50,15 @@ source_patterns:
     entity_type: Service
     name_group: 1
     scope: file
-  # Resource class (any class with on_get/on_post etc.)
+  # Resource class. The regex matches ANY class declaration — it carries no
+  # Falcon-specific token at all — so it is gated on the detection markers
+  # above. Without the gate it typed every bare Python class in every repo as
+  # a Controller (#6152).
   - pattern: "class\\s+(\\w+)\\s*(?:\\([^)]*\\))?\\s*:"
     entity_type: Controller
     name_group: 1
     scope: class
+    requires_framework: true
 
 # relationship_rules: edges between entities.
 relationship_rules:

--- a/internal/engine/schema.go
+++ b/internal/engine/schema.go
@@ -11,12 +11,39 @@ package engine
 // FrameworkRule is the top-level schema for a single framework YAML file.
 // Each file describes detection patterns for one framework (e.g. gin.yaml).
 type FrameworkRule struct {
+	// Frameworks carries the file's detection metadata (framework identity and
+	// the markers that say "this framework is actually present"). Every rule
+	// file already declares it; before #6152 nothing in Go read it, so Detect
+	// resolved rule sets by file.Language ALONE and every rule fired on every
+	// file of that language regardless of whether the framework was there.
+	Frameworks FrameworkMeta `yaml:"frameworks"`
 	// FileConventions lists file naming conventions for this framework.
 	FileConventions []FileConvention `yaml:"file_conventions"`
 	// SourcePatterns maps regex patterns to entity types.
 	SourcePatterns []SourcePattern `yaml:"source_patterns"`
 	// RelationshipRules maps regex patterns to relationship edges.
 	RelationshipRules []RelationshipRule `yaml:"relationship_rules"`
+}
+
+// FrameworkMeta is the `frameworks:` block of a rule file: who the framework
+// is and how to tell it is present. Only the fields the engine consumes are
+// modelled; the rest of the block (category, github_stars_2025, notes, …) is
+// descriptive and deliberately unmapped.
+type FrameworkMeta struct {
+	// Name is the human framework name (e.g. "Falcon").
+	Name string `yaml:"name"`
+	// Detection holds the presence signals for this framework.
+	Detection FrameworkDetection `yaml:"detection"`
+}
+
+// FrameworkDetection lists the signals that say a framework is in play.
+type FrameworkDetection struct {
+	// ImportMarkers are literal source substrings that only appear when the
+	// framework is imported or used (e.g. "import falcon", "from falcon
+	// import"). This is the signal source_patterns marked requires_framework
+	// are gated on — it is the only detection signal available from the file
+	// content Detect is handed.
+	ImportMarkers []string `yaml:"import_markers"`
 }
 
 // FileConvention describes a file naming pattern for a framework.
@@ -54,6 +81,18 @@ type SourcePattern struct {
 	// Scope controls matching: "file" scans the entire file content,
 	// "line" scans line-by-line.
 	Scope string `yaml:"scope"`
+	// RequiresFramework opts this pattern into the framework-presence gate
+	// (#6152). When true the pattern only fires on files that carry at least
+	// one of the owning rule file's frameworks.detection.import_markers.
+	//
+	// Opt-IN, not opt-out, and deliberately so: most patterns are already
+	// self-gating because their regex names the framework ("cherrypy.expose",
+	// ".add_route("). The flag is for patterns whose regex is broad enough to
+	// match plain language syntax — a bare `class Foo:` — where the framework
+	// is what makes the match meaningful and nothing in the regex checks for
+	// it. Defaulting every pattern to gated would suppress cross-file recall
+	// for the self-gating majority.
+	RequiresFramework bool `yaml:"requires_framework"`
 }
 
 // RelationshipRule maps a regex pattern to a directed relationship edge.


### PR DESCRIPTION
Every bare Python class was typed `Controller` — in every repo, on both the full and (since #6148) the incremental path. Two rule sets match a bare class declaration and neither was gated on the framework being present:

- `python/frameworks/falcon.yaml` — `class\s+(\w+)\s*(?:\([^)]*\))?\s*:` → `Controller`
- `python/frameworks/cherrypy.yaml` — `class\s+(\w+)\s*(?:\(object\))?\s*:` → `Controller`

`migration_prune.go` already existed to delete some of the fallout, and its comment names this exact cause.

## The metadata existed. Nothing read it.

Both rule files carry `frameworks.detection.import_markers`, and the issue (and my brief) said the modular loader consumes it. **It does not.** `engine.FrameworkRule` never modelled the `frameworks:` block, and `grep -rn ImportMarkers --include='*.go'` returned nothing across the tree before this change. The detection metadata was decorative.

So the fix is to make it real:

- `internal/engine/schema.go` — model `FrameworkMeta`/`FrameworkDetection`, plus a per-pattern `requires_framework`.
- `internal/engine/detector.go` — `compiledRuleSet.importMarkers` and `frameworkPresent(content)`; `Detect` skips a `requires_framework` pattern unless a marker appears literally. Presence is computed once per (ruleset, file), and only when some pattern asks.
- The two bare-class patterns opt in.

**Opt-in rather than opt-out**, deliberately: most patterns already name their framework inside the regex (`.add_route(`, `cherrypy.expose`), and gating those would cost cross-file recall for no benefit.

## Before / after

| input | before | after |
|---|---|---|
| `class CpPlainProbe:` (no framework) | `Controller` from **both** rule sets | no YAML-engine entity at all |
| same, end to end through the indexer | `Controller` | **`SCOPE.Component`** — measured, not assumed |
| falcon class with `import falcon` + `add_route` + `on_get` | `Controller` | `Controller`, plus Route/Service/`http_endpoint_definition` unchanged |
| cherrypy class with `import cherrypy` + `@cherrypy.expose` | `Controller` | `Controller` |
| Django migration `class Migration(...)` | `Controller` | only the intended `Migration` file-tag |

## Golden fixtures: recall goes up, not down

All 20 fixtures measured before and after. **Exactly one moves, and it moves up.** Nineteen byte-identical, forbidden hits 0 everywhere, no must-have lost anywhere.

`python-django-mini` entities **23/28 (82.1%) → 26/28 (92.9%)**, relationships **3/12 (25%) → 7/12 (58.3%)** — recovering `ActiveUserManager`, `UsersConfig` and `UserAdmin`, which were typed `Controller` instead of `SCOPE.Component` and had lost their CONTAINS/EXTENDS edges as a result.

Corpus totals: entities **229/258 → 232/258**, relationships **90/121 → 94/121**.

## A documented invariant that is not true

`AGENTS.md:13` states the golden fixtures "must hold 100% must-have recall on every PR." **They do not, and did not on `55c7fc7a5`.** 14 of 20 exit non-zero on baseline (`csharp-hangfire` 0/5, `python-rq` 0/3, `python-dramatiq` 0/4, …), and `groovy-grails-mini` / `swift-swiftui-mini` fail to index at all, before and after.

Entirely pre-existing and untouched here, but a gate that is documented as enforcing and does not enforce is worth naming rather than quietly working around. Filed separately.

## Migration prune is now redundant — and deliberately left in place

`prunedMigrationKinds`' `"Controller": true` is unreachable via the falcon/cherrypy route now: a migration file with no marker yields only the `Migration` file-tag. Removing it is a separate decision with its own blast radius, and a prune that is a no-op is harmless. The other six kinds in that map still do real work.

## Two pinned expectations updated — re-characterised, not re-baselined

Both were verified as caused by this change (pass on baseline, fail with the fix) and the exact delta measured before anything was touched.

- **`custom_extractor_spans_6118`**: 149/292 → 148/291. The nested DRF `class Meta:` was getting a **second** node named `Meta` beside the correctly-named `OrderSerializer.Meta` the Python extractor already emits. The phantom and its one CONTAINS edge go; `OrderSerializer` re-kinds `Controller` → `SCOPE.Component`. **No real declaration lost.**
- **`incremental_content_parity_6129`** Path-B allow-list: the same unfixed #6129 self-edge, differently visible. The full rebuild always emitted `CpProducer → CpProducer` DEPENDS_ON but on an unresolved endpoint, so the content-keyed comparator scored it INVENTED; with the correct kind the endpoint resolves and it scores MULTIPLICITY. Full-rebuild totals unchanged either way (69/145) — both sides measured specifically to rule out a newly-introduced edge.

## Mutants

Seven, no survivors: gate removed (the revert-reproduces-the-defect proof); gate inverted; `frameworkPresent` forced true; forced false; `requires_framework` dropped from each YAML file in turn; markers not loaded into `compiledRuleSet`.

Anti-vacuity: each fixture's premise is asserted against the **YAML parsed off disk** with a local struct — not the Go types under test — and an empty `import_markers` list is a hard `t.Fatal`. Re-run at merge: removing the gate fails with `bare Python class CpPlainProbe typed "Controller" by the YAML engine`.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/engine/...` 0, `./internal/quality/...` 0 (2789 tests), `./internal/extractors/...` 0 (76 packages), `./cmd/grafel/...` 0 (133.9s, zero `--- FAIL`).

## Release note

> Python classes that are not Falcon or CherryPy resources are no longer misclassified as `Controller`. Existing graphs keep the stale label until re-extracted, so **re-index to pick up the corrected classification**.

Closes #6152
Refs #6148, #3173
