### PR TITLE
fix(#6180): the watch cap counted directories, so macOS opened 40k descriptors for one repo

### DIFF
--- a/internal/cli/status_daemon_detail.go
+++ b/internal/cli/status_daemon_detail.go
@@ -31,6 +31,14 @@ func printDaemonDetail(w io.Writer, st proto.StatusReply) {
 		}
 		fmt.Fprintln(w)
 	}
+	// #6180: a repo the watcher refused for want of file descriptors is not
+	// being watched at all. Printed on its own line and NOT gated on the
+	// condition above — the worst case is exactly the one where WatcherRepos
+	// is zero because every repo was refused.
+	if st.WatcherUnwatched > 0 {
+		fmt.Fprintf(w, "  watcher: %d repo(s) NOT WATCHED — file-descriptor budget full (%d/%d used); edits there will not re-index\n",
+			st.WatcherUnwatched, st.WatcherFDUsed, st.WatcherFDLimit)
+	}
 	if st.QueueLen > 0 || len(st.IndexInFlight) > 0 ||
 		len(st.PendingAlgo) > 0 || len(st.PendingLinks) > 0 {
 		fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",

--- a/internal/daemon/fdlimit/fdlimit_other.go
+++ b/internal/daemon/fdlimit/fdlimit_other.go
@@ -8,3 +8,10 @@ package fdlimit
 func Raise(target uint64) (old, updated uint64, err error) {
 	return 0, 0, nil
 }
+
+// Current reports zero limits on platforms without POSIX RLIMIT_NOFILE
+// semantics. Callers must treat a zero soft limit as "unknown" rather than as
+// "no descriptors available".
+func Current() (soft, hard uint64, err error) {
+	return 0, 0, nil
+}

--- a/internal/daemon/fdlimit/fdlimit_unix.go
+++ b/internal/daemon/fdlimit/fdlimit_unix.go
@@ -54,6 +54,21 @@ func Raise(target uint64) (old, updated uint64, err error) {
 	return old, old, err
 }
 
+// Current returns the process's EFFECTIVE RLIMIT_NOFILE soft and hard limits,
+// read back from the kernel. This is the post-clamp truth, not what anyone
+// asked for: on Darwin a launchd plist may request NumberOfFiles 65536 while
+// kern.maxfilesperproc caps the process at 61440, and the excess is dropped
+// silently. Any budget computed from a requested figure over-commits by
+// exactly the amount the kernel refused, so callers that need to divide the
+// descriptor supply must read it from here.
+func Current() (soft, hard uint64, err error) {
+	var lim syscall.Rlimit
+	if err = syscall.Getrlimit(syscall.RLIMIT_NOFILE, &lim); err != nil {
+		return 0, 0, err
+	}
+	return lim.Cur, lim.Max, nil
+}
+
 // candidates returns a descending, de-duplicated list of soft-limit targets to
 // attempt, each clamped to the hard max. hardMax==0 is treated as "unknown"
 // and applies no clamp.

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -79,16 +79,24 @@ type StatusReply struct {
 
 	// Phase B additions — watcher + scheduler observability. Fields
 	// are optional; older clients ignore them.
-	WatcherRepos   int                `json:"watcher_repos,omitempty"`
-	WatcherDirs    int                `json:"watcher_dirs,omitempty"`
-	WatcherEvents  uint64             `json:"watcher_events,omitempty"`
-	WatcherDropped uint64             `json:"watcher_dropped,omitempty"`
-	QueueLen       int                `json:"queue_len,omitempty"`
-	IndexInFlight  []string           `json:"index_in_flight,omitempty"`
-	PendingAlgo    []string           `json:"pending_algo,omitempty"`
-	PendingLinks   []string           `json:"pending_links,omitempty"`
-	IndexedRepos   []IndexedRepoState `json:"indexed_repos,omitempty"`
-	RecentLog      []SchedLogEntry    `json:"recent_log,omitempty"`
+	WatcherRepos   int    `json:"watcher_repos,omitempty"`
+	WatcherDirs    int    `json:"watcher_dirs,omitempty"`
+	WatcherEvents  uint64 `json:"watcher_events,omitempty"`
+	WatcherDropped uint64 `json:"watcher_dropped,omitempty"`
+
+	// WatcherUnwatched counts repos the watcher REFUSED because the
+	// file-descriptor budget was full, and WatcherFDUsed/WatcherFDLimit are
+	// the ledger behind that decision (#6180). A non-zero WatcherUnwatched
+	// means edits in those repos are not being picked up at all.
+	WatcherUnwatched int                `json:"watcher_unwatched,omitempty"`
+	WatcherFDUsed    int                `json:"watcher_fd_used,omitempty"`
+	WatcherFDLimit   int                `json:"watcher_fd_limit,omitempty"`
+	QueueLen         int                `json:"queue_len,omitempty"`
+	IndexInFlight    []string           `json:"index_in_flight,omitempty"`
+	PendingAlgo      []string           `json:"pending_algo,omitempty"`
+	PendingLinks     []string           `json:"pending_links,omitempty"`
+	IndexedRepos     []IndexedRepoState `json:"indexed_repos,omitempty"`
+	RecentLog        []SchedLogEntry    `json:"recent_log,omitempty"`
 
 	// GroupAlgoRunning names the groups whose ANNOTATION (group-algo) pass is
 	// executing right now, and GroupAlgoInFlight counts them. The pass produces

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -396,11 +396,17 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	reply.DaemonMode = s.daemonMode
 
 	if s.watcher != nil {
-		repos, dirs, events, dropped := s.watcher.Stats()
+		repos, dirs, events, dropped, unwatched := s.watcher.Stats()
 		reply.WatcherRepos = repos
 		reply.WatcherDirs = dirs
 		reply.WatcherEvents = events
 		reply.WatcherDropped = dropped
+		// #6180: surface repos that are NOT watched for want of file
+		// descriptors, plus the ledger, so `grafel status` says so out loud.
+		reply.WatcherUnwatched = unwatched
+		fdUsed, fdLimit, _, _ := s.watcher.FDBudgetStats()
+		reply.WatcherFDUsed = fdUsed
+		reply.WatcherFDLimit = fdLimit
 	}
 	// PH2a (#2096): report pause/resume slot counts.
 	if s.watcherMgrStats != nil {

--- a/internal/daemon/watch/fdbudget.go
+++ b/internal/daemon/watch/fdbudget.go
@@ -1,0 +1,162 @@
+package watch
+
+import (
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// ---------------------------------------------------------------------------
+// Descriptor cost model (#6180)
+//
+// The watcher's only ceiling used to be walk.DefaultWatchDirCap, which counts
+// DIRECTORIES. On macOS that number is not the cost. fsnotify v1.10.1 ships no
+// FSEvents backend — backend_kqueue.go carries `//go:build ... || darwin` — and
+// kqueue cannot watch a path without an open descriptor on it. Worse, for a
+// directory fsnotify additionally calls watchDirectoryFiles(), opening one more
+// descriptor for EVERY FILE in that directory (fsnotify documents this in its
+// own Close() comment).
+//
+// So a single subscription costs dirs + files-in-those-dirs descriptors, and a
+// directory-only cap is blind to the term that dominates: a live measurement on
+// one repo showed 40,079 descriptors, 32,073 of them regular files and 7,995
+// directories — the per-file term was 4x the per-directory term. Against
+// kern.maxfilesperproc = 61,440 that is 65% of the process ceiling for ONE
+// repo, so at 100,000 directories the old cap was effectively infinite.
+//
+// On Linux, inotify spends a watch descriptor per directory out of
+// max_user_watches, not a process file descriptor per file; on Windows the
+// ReadDirectoryChangesW backend differs again. The per-file term is a macOS
+// fact, so the cost model — and whether the budget is enabled at all — is
+// selected by build tag, never by a runtime GOOS check (#6218).
+// ---------------------------------------------------------------------------
+
+// fdCostModel says how many descriptors the platform's fsnotify backend spends
+// on a subscription of a given shape.
+type fdCostModel struct {
+	perDir  int
+	perFile int
+}
+
+// cost returns the descriptor cost of watching dirs directories that between
+// them contain files files.
+func (m fdCostModel) cost(dirs, files int) int {
+	return dirs*m.perDir + files*m.perFile
+}
+
+// kqueueCostModel is the macOS/BSD reality: one descriptor for the directory
+// plus one for each file inside it.
+var kqueueCostModel = fdCostModel{perDir: 1, perFile: 1}
+
+// inotifyCostModel is the Linux reality: a watch per directory, drawn from
+// max_user_watches rather than from RLIMIT_NOFILE, and nothing per file.
+var inotifyCostModel = fdCostModel{perDir: 1, perFile: 0}
+
+// ---------------------------------------------------------------------------
+// The budget
+// ---------------------------------------------------------------------------
+
+// errFDBudget is returned by AddRepo when a subscription cannot be afforded
+// within the process-wide descriptor budget. Callers get a real error instead
+// of a repo that is registered but silently receives no events.
+var errFDBudget = errors.New("watch: file-descriptor budget exhausted")
+
+// isFDBudgetError reports whether err is (or wraps) the budget refusal.
+func isFDBudgetError(err error) bool { return errors.Is(err, errFDBudget) }
+
+// fdBudget is a ledger of descriptors committed to fs watches. A limit <= 0
+// disables accounting entirely (reservations always succeed), which is what
+// non-macOS platforms get.
+type fdBudget struct {
+	mu    sync.Mutex
+	limit int
+	used  int
+}
+
+func newFDBudget(limit int) *fdBudget {
+	if limit < 0 {
+		limit = 0
+	}
+	return &fdBudget{limit: limit}
+}
+
+// reserve commits n descriptors if they fit. It is all-or-nothing: a refused
+// reservation consumes nothing.
+func (b *fdBudget) reserve(n int) bool {
+	if n <= 0 {
+		return true
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.limit <= 0 {
+		b.used += n
+		return true
+	}
+	if b.used+n > b.limit {
+		return false
+	}
+	b.used += n
+	return true
+}
+
+// release returns n descriptors to the ledger.
+func (b *fdBudget) release(n int) {
+	if n <= 0 {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.used -= n
+	if b.used < 0 {
+		b.used = 0
+	}
+}
+
+// snapshot returns the committed count and the ceiling (0 == unlimited).
+func (b *fdBudget) snapshot() (used, limit int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.used, b.limit
+}
+
+// ---------------------------------------------------------------------------
+// Process-wide default
+// ---------------------------------------------------------------------------
+
+var (
+	sharedFDBudgetOnce sync.Once
+	sharedFDBudgetVal  *fdBudget
+)
+
+// sharedFDBudget is the process-wide ledger. Every Watcher constructed without
+// an explicit Config.FDBudget shares it, so the ceiling is global across
+// subscriptions — which is the point: the kernel limit is per PROCESS, not per
+// Watcher and certainly not per repo.
+func sharedFDBudget() *fdBudget {
+	sharedFDBudgetOnce.Do(func() {
+		sharedFDBudgetVal = newFDBudget(defaultFDBudgetLimit())
+	})
+	return sharedFDBudgetVal
+}
+
+// fdBudgetEnv is the operator override. A value <= 0 disables the budget.
+const fdBudgetEnv = "GRAFEL_WATCH_FD_BUDGET"
+
+// envFDBudget returns (value, true) when the override is set to a parseable
+// integer.
+func envFDBudget() (int, bool) {
+	v := strings.TrimSpace(os.Getenv(fdBudgetEnv))
+	if v == "" {
+		return 0, false
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, false
+	}
+	if n < 0 {
+		n = 0
+	}
+	return n, true
+}

--- a/internal/daemon/watch/fdbudget_darwin.go
+++ b/internal/daemon/watch/fdbudget_darwin.go
@@ -1,0 +1,65 @@
+//go:build darwin
+
+package watch
+
+import (
+	"math"
+
+	"github.com/cajasmota/grafel/internal/daemon/fdlimit"
+)
+
+// fdDescriptorPerFile records that on this platform a watched directory costs
+// one OS file descriptor per file inside it, so descriptor accounting is real
+// and the budget is enforced. Selected by build tag rather than runtime.GOOS
+// so the constant is available to the compiler and to build-tagged tests
+// (#6218: a runtime GOOS check plus t.Skip guards execution, not compilation).
+const fdDescriptorPerFile = true
+
+// defaultCostModel returns the kqueue arithmetic: dirs + files.
+func defaultCostModel() fdCostModel { return kqueueCostModel }
+
+// fdBudgetReserveFraction is the share of the effective descriptor limit held
+// back for everything in the daemon that is NOT an fs watch: graph mmaps and
+// segment files, the unix socket and its accepted connections, the dashboard
+// listener, log files, and the pipes of every `git` subprocess the indexer
+// spawns. A quarter is deliberately generous — running out of descriptors for
+// the store is a corruption risk, whereas running out of watch budget only
+// costs freshness, and this fix exists precisely so the second failure is the
+// one we take.
+const fdBudgetReserveNumerator, fdBudgetReserveDenominator = 1, 4
+
+// fdBudgetMinReserve is the floor on that headroom, for the case of an
+// unusually low soft limit where a quarter would be a handful of descriptors.
+const fdBudgetMinReserve = 1024
+
+// defaultFDBudgetLimit derives the watch budget from the EFFECTIVE descriptor
+// limit — the post-clamp RLIMIT_NOFILE soft limit read back via getrlimit, not
+// the number anyone asked for. That distinction is the whole point on Darwin:
+// the daemon's launchd plist requests NumberOfFiles 65536, which exceeds
+// kern.maxfilesperproc (61440 on the measured machine) and is silently clamped
+// down, and fdlimit.Raise likewise falls back to smaller candidates on EINVAL.
+// Budgeting from the requested value would over-commit by exactly the amount
+// the kernel refused.
+func defaultFDBudgetLimit() int {
+	if n, ok := envFDBudget(); ok {
+		return n
+	}
+	soft, _, err := fdlimit.Current()
+	if err != nil || soft == 0 {
+		// Unknown limit: do not invent a ceiling we cannot justify. The
+		// pre-existing directory cap still applies.
+		return 0
+	}
+	if soft > math.MaxInt32 {
+		soft = math.MaxInt32 // RLIM_INFINITY and friends
+	}
+	limit := int(soft)
+	reserve := limit * fdBudgetReserveNumerator / fdBudgetReserveDenominator
+	if reserve < fdBudgetMinReserve {
+		reserve = fdBudgetMinReserve
+	}
+	if reserve >= limit {
+		return 0
+	}
+	return limit - reserve
+}

--- a/internal/daemon/watch/fdbudget_other.go
+++ b/internal/daemon/watch/fdbudget_other.go
@@ -1,0 +1,24 @@
+//go:build !darwin
+
+package watch
+
+// fdDescriptorPerFile records that on this platform a watched directory does
+// NOT cost an OS file descriptor per file inside it. Linux inotify spends one
+// watch descriptor per directory out of the /proc/sys/fs/inotify/max_user_watches
+// budget — a different resource with different arithmetic — and the Windows
+// ReadDirectoryChangesW backend holds one handle per watched tree. Neither is
+// the macOS failure, so grafel does not impose the macOS ceiling here.
+const fdDescriptorPerFile = false
+
+// defaultCostModel returns the per-watch arithmetic: dirs only.
+func defaultCostModel() fdCostModel { return inotifyCostModel }
+
+// defaultFDBudgetLimit reports 0 — descriptor accounting is disabled — unless
+// an operator explicitly opts in via GRAFEL_WATCH_FD_BUDGET. The pre-existing
+// walk.WatchDirCap directory ceiling is the relevant bound on these platforms.
+func defaultFDBudgetLimit() int {
+	if n, ok := envFDBudget(); ok {
+		return n
+	}
+	return 0
+}

--- a/internal/daemon/watch/fdbudget_test.go
+++ b/internal/daemon/watch/fdbudget_test.go
@@ -1,0 +1,362 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture helper + its own premise assertion.
+//
+// Fixture vacuity is the failure mode these tests are written against: a tree
+// that does not actually contain the dirs/files the assertions assume would
+// make every budget assertion true for the wrong reason. countTree walks the
+// fixture INDEPENDENTLY of any production code and is asserted against the
+// numbers each test does arithmetic with.
+// ---------------------------------------------------------------------------
+
+// makeTree builds root/ with nFiles files, plus root/src/ with nFiles files.
+// Returns the tree root. Names are deliberately mundane so no skip layer
+// (SkipDirs, ExcludeDirs, .gitignore) removes anything.
+func makeTree(t *testing.T, nFiles int) string {
+	t.Helper()
+	root := t.TempDir()
+	sub := filepath.Join(root, "src")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	for _, d := range []string{root, sub} {
+		for i := 0; i < nFiles; i++ {
+			p := filepath.Join(d, "f"+string(rune('a'+i))+".go")
+			if err := os.WriteFile(p, []byte("package p\n"), 0o644); err != nil {
+				t.Fatalf("write %s: %v", p, err)
+			}
+		}
+	}
+	return root
+}
+
+// countTree counts directories and regular files under root, using nothing
+// from the production watcher. This is the premise oracle.
+func countTree(t *testing.T, root string) (dirs, files int) {
+	t.Helper()
+	err := filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			dirs++
+		} else {
+			files++
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("countTree: %v", err)
+	}
+	return dirs, files
+}
+
+func TestMakeTreePremise(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	if dirs != 2 {
+		t.Fatalf("fixture premise broken: want 2 dirs (root + src), got %d", dirs)
+	}
+	if files != 8 {
+		t.Fatalf("fixture premise broken: want 8 files (4 per dir), got %d", files)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The cost model.
+// ---------------------------------------------------------------------------
+
+// TestKqueueCostModelChargesPerFile pins the arithmetic that the whole fix
+// rests on: on kqueue a watched directory costs one descriptor for itself AND
+// one for every file inside it (fsnotify's watchDirectoryFiles). The inotify
+// model must NOT charge per file — asserted here so a copy-paste that made
+// both models identical is caught.
+func TestKqueueCostModelChargesPerFile(t *testing.T) {
+	if got := kqueueCostModel.cost(3, 100); got != 103 {
+		t.Fatalf("kqueue cost(3 dirs, 100 files) = %d, want 103", got)
+	}
+	if got := inotifyCostModel.cost(3, 100); got != 3 {
+		t.Fatalf("inotify cost(3 dirs, 100 files) = %d, want 3 (per-watch, not per-fd)", got)
+	}
+	if kqueueCostModel == inotifyCostModel {
+		t.Fatal("premise broken: the two cost models are identical, so gating is vacuous")
+	}
+}
+
+// TestDefaultCostModelIsPlatformGated asserts the platform selection, not the
+// arithmetic. Build-tagged constants (not runtime.GOOS + t.Skip) decide, so
+// this compiles and runs on every platform (#6218).
+func TestDefaultCostModelIsPlatformGated(t *testing.T) {
+	got := defaultCostModel()
+	if fdDescriptorPerFile {
+		if got != kqueueCostModel {
+			t.Fatalf("on a per-file-descriptor platform want kqueue model, got %+v", got)
+		}
+	} else {
+		if got != inotifyCostModel {
+			t.Fatalf("on a per-watch platform want inotify model, got %+v", got)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// The budget itself.
+// ---------------------------------------------------------------------------
+
+func TestFDBudgetReserveRefusesOverLimit(t *testing.T) {
+	b := newFDBudget(10)
+
+	if !b.reserve(6) {
+		t.Fatal("reserve(6) against a limit of 10 was refused")
+	}
+	// Premise: the budget genuinely read the injected limit and genuinely
+	// recorded the reservation. If used stayed 0 the next assertion would
+	// pass vacuously.
+	if used, limit := b.snapshot(); used != 6 || limit != 10 {
+		t.Fatalf("after reserve(6): used=%d limit=%d, want 6/10", used, limit)
+	}
+
+	if b.reserve(5) {
+		t.Fatal("reserve(5) on top of 6/10 was granted — budget not enforced")
+	}
+	if used, _ := b.snapshot(); used != 6 {
+		t.Fatalf("refused reservation must not consume: used=%d, want 6", used)
+	}
+
+	if !b.reserve(4) {
+		t.Fatal("reserve(4) to exactly fill 10 was refused — off-by-one")
+	}
+	if used, _ := b.snapshot(); used != 10 {
+		t.Fatalf("used=%d, want 10", used)
+	}
+
+	b.release(10)
+	if used, _ := b.snapshot(); used != 0 {
+		t.Fatalf("after release: used=%d, want 0", used)
+	}
+}
+
+func TestFDBudgetZeroLimitIsUnlimited(t *testing.T) {
+	b := newFDBudget(0)
+	if !b.reserve(1 << 20) {
+		t.Fatal("a zero (disabled) budget refused a reservation")
+	}
+	if _, limit := b.snapshot(); limit != 0 {
+		t.Fatalf("limit=%d, want 0 (disabled)", limit)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: the watcher must refuse a subscription it cannot afford.
+// ---------------------------------------------------------------------------
+
+func newBudgetedWatcher(t *testing.T, budget int) *Watcher {
+	t.Helper()
+	w, err := NewWatcherConfig(Config{
+		Debounce:          time.Hour,
+		BulkThreshold:     10000,
+		HeartbeatInterval: time.Hour,
+		FDBudget:          budget,
+		fdCost:            kqueueCostModel, // test the macOS arithmetic everywhere
+	}, func(string, bool) {}, nil)
+	if err != nil {
+		t.Fatalf("NewWatcherConfig: %v", err)
+	}
+	t.Cleanup(w.Stop)
+	return w
+}
+
+// TestSubscribeSucceedsWhenBudgetCoversDirsAndFiles is the positive premise
+// for the refusal test below: with a budget of EXACTLY dirs+files the repo is
+// accepted and every directory is subscribed. If this failed, the refusal test
+// would be proving nothing about the budget.
+func TestSubscribeSucceedsWhenBudgetCoversDirsAndFiles(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	w := newBudgetedWatcher(t, dirs+files)
+
+	added, err := w.AddRepo(root)
+	if err != nil {
+		t.Fatalf("AddRepo with an exactly-sufficient budget failed: %v", err)
+	}
+	if added != dirs {
+		t.Fatalf("subscribed %d dirs, want %d", added, dirs)
+	}
+	used, limit := w.fdb.snapshot()
+	if limit != dirs+files {
+		t.Fatalf("watcher budget limit=%d, want the injected %d", limit, dirs+files)
+	}
+	if used != dirs+files {
+		t.Fatalf("charged %d descriptors, want dirs+files=%d — the estimate is not counting files", used, dirs+files)
+	}
+	if _, _, _, _, unwatched := w.Stats(); unwatched != 0 {
+		t.Fatalf("unwatched=%d on a successful subscription, want 0", unwatched)
+	}
+}
+
+// TestSubscribeRefusedWhenBudgetCoversOnlyDirs is the defect. Today the cap
+// counts directories only, so a budget large enough for every DIRECTORY but
+// far too small for the per-file descriptors kqueue also opens is accepted —
+// and the process walks on toward EMFILE. With the fix the subscription is
+// refused.
+func TestSubscribeRefusedWhenBudgetCoversOnlyDirs(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	if files == 0 {
+		t.Fatal("fixture premise broken: no files, so dir-only accounting is indistinguishable")
+	}
+	// Enough for every directory, one short of the true dirs+files cost.
+	budget := dirs + files - 1
+	if budget < dirs {
+		t.Fatalf("premise broken: budget %d cannot even cover %d dirs", budget, dirs)
+	}
+	w := newBudgetedWatcher(t, budget)
+
+	added, err := w.AddRepo(root)
+	if err == nil {
+		t.Fatalf("AddRepo was accepted with budget=%d for a tree costing %d descriptors (added %d dirs)",
+			budget, dirs+files, added)
+	}
+	if !isFDBudgetError(err) {
+		t.Fatalf("AddRepo failed with %v, want an FD-budget refusal", err)
+	}
+	if added != 0 {
+		t.Fatalf("a refused subscription reported %d dirs added, want 0", added)
+	}
+}
+
+// TestRefusalUnwindsEveryDescriptor: a refusal must leave nothing behind, or
+// the descriptors it opened before giving up are leaked for the process
+// lifetime and the budget slowly poisons itself.
+func TestRefusalUnwindsEveryDescriptor(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	w := newBudgetedWatcher(t, dirs+files-1)
+
+	if _, err := w.AddRepo(root); err == nil {
+		t.Fatal("premise broken: AddRepo was not refused")
+	}
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("after a refusal the budget still holds %d descriptors, want 0", used)
+	}
+	w.mu.Lock()
+	nDirs := len(w.dirToRepo)
+	_, stillRegistered := w.repos[root]
+	w.mu.Unlock()
+	if nDirs != 0 {
+		t.Fatalf("refusal left %d subscribed dirs behind, want 0", nDirs)
+	}
+	if stillRegistered {
+		t.Fatal("refused repo is still in the repos map — it would look watched but receive nothing")
+	}
+}
+
+// TestRefusalIsVisibleInStats: silently not watching is the failure mode this
+// codebase keeps producing. A budget-refused repo must be countable.
+func TestRefusalIsVisibleInStats(t *testing.T) {
+	root := makeTree(t, 4)
+	dirs, files := countTree(t, root)
+	w := newBudgetedWatcher(t, dirs+files-1)
+
+	if _, err := w.AddRepo(root); err == nil {
+		t.Fatal("premise broken: AddRepo was not refused")
+	}
+	repos, _, _, _, unwatched := w.Stats()
+	if repos != 0 {
+		t.Fatalf("repos=%d, want 0 — a refused repo must not be counted as watched", repos)
+	}
+	if unwatched != 1 {
+		t.Fatalf("Stats unwatched=%d, want 1", unwatched)
+	}
+	used, limit, un, paths := w.FDBudgetStats()
+	if limit != dirs+files-1 {
+		t.Fatalf("FDBudgetStats limit=%d, want the injected %d", limit, dirs+files-1)
+	}
+	if used != 0 {
+		t.Fatalf("FDBudgetStats used=%d, want 0", used)
+	}
+	if un != 1 || len(paths) != 1 || paths[0] != root {
+		t.Fatalf("FDBudgetStats unwatched=%d paths=%v, want 1 / [%s]", un, paths, root)
+	}
+}
+
+// TestRemoveRepoReleasesBudget: without release, a store that churns repos
+// would exhaust the budget permanently even though no descriptors are held.
+func TestRemoveRepoReleasesBudget(t *testing.T) {
+	a := makeTree(t, 4)
+	b := makeTree(t, 4)
+	dirs, files := countTree(t, a)
+	// Room for exactly one of the two trees.
+	w := newBudgetedWatcher(t, dirs+files)
+
+	if _, err := w.AddRepo(a); err != nil {
+		t.Fatalf("premise broken: first AddRepo failed: %v", err)
+	}
+	if _, err := w.AddRepo(b); err == nil {
+		t.Fatal("premise broken: second AddRepo fitted in a budget sized for one tree")
+	}
+
+	w.RemoveRepo(a)
+	if used, _ := w.fdb.snapshot(); used != 0 {
+		t.Fatalf("RemoveRepo left %d descriptors reserved, want 0", used)
+	}
+	if _, err := w.AddRepo(b); err != nil {
+		t.Fatalf("AddRepo after RemoveRepo freed the budget still failed: %v", err)
+	}
+	if _, _, _, _, unwatched := w.Stats(); unwatched != 0 {
+		t.Fatalf("unwatched=%d after the repo was successfully re-admitted, want 0", unwatched)
+	}
+}
+
+// TestBudgetIsGlobalAcrossRepos: the cap must be a single global ledger, not a
+// per-repo one. Two trees that each fit individually must not both fit.
+func TestBudgetIsGlobalAcrossRepos(t *testing.T) {
+	a := makeTree(t, 4)
+	b := makeTree(t, 4)
+	dirs, files := countTree(t, a)
+	one := dirs + files
+	w := newBudgetedWatcher(t, one+1) // room for one tree and one spare fd
+
+	if _, err := w.AddRepo(a); err != nil {
+		t.Fatalf("premise broken: first tree did not fit in a budget of %d: %v", one+1, err)
+	}
+	if _, err := w.AddRepo(b); err == nil {
+		t.Fatal("both trees fitted a budget sized for one — the budget is not global")
+	}
+	if _, _, _, _, unwatched := w.Stats(); unwatched != 1 {
+		t.Fatalf("unwatched=%d, want 1", unwatched)
+	}
+}
+
+// TestDefaultBudgetLimitIsPlatformGated: on platforms where a watch does not
+// cost a descriptor per file, grafel must not impose a macOS-shaped ceiling.
+func TestDefaultBudgetLimitIsPlatformGated(t *testing.T) {
+	t.Setenv("GRAFEL_WATCH_FD_BUDGET", "")
+	got := defaultFDBudgetLimit()
+	if fdDescriptorPerFile {
+		if got <= 0 {
+			t.Fatalf("defaultFDBudgetLimit()=%d on a per-file-descriptor platform, want a positive ceiling", got)
+		}
+	} else if got != 0 {
+		t.Fatalf("defaultFDBudgetLimit()=%d on a per-watch platform, want 0 (accounting disabled)", got)
+	}
+}
+
+func TestFDBudgetEnvOverride(t *testing.T) {
+	t.Setenv("GRAFEL_WATCH_FD_BUDGET", "4096")
+	if got := defaultFDBudgetLimit(); got != 4096 {
+		t.Fatalf("GRAFEL_WATCH_FD_BUDGET=4096 gave %d", got)
+	}
+	t.Setenv("GRAFEL_WATCH_FD_BUDGET", "0")
+	if got := defaultFDBudgetLimit(); got != 0 {
+		t.Fatalf("GRAFEL_WATCH_FD_BUDGET=0 gave %d, want 0 (disabled)", got)
+	}
+}

--- a/internal/daemon/watch/resilience_5392_test.go
+++ b/internal/daemon/watch/resilience_5392_test.go
@@ -185,12 +185,12 @@ func waitForEvents5392(t *testing.T, w *Watcher, n uint64, d time.Duration) {
 	t.Helper()
 	deadline := time.Now().Add(d)
 	for time.Now().Before(deadline) {
-		if _, _, ev, _ := w.Stats(); ev >= n {
+		if _, _, ev, _, _ := w.Stats(); ev >= n {
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
-	if _, _, ev, _ := w.Stats(); ev < n {
+	if _, _, ev, _, _ := w.Stats(); ev < n {
 		t.Fatalf("watcher observed %d events, want ≥ %d within %s", ev, n, d)
 	}
 }

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,6 +48,19 @@ type Config struct {
 	// SkipDirs) that this watcher instance will not subscribe to.
 	// Useful for per-group custom exclusions.
 	ExcludeDirs []string
+
+	// FDBudget caps the total number of OS file descriptors this watcher may
+	// commit to fs watches, across every subscription (#6180). Zero uses the
+	// process-wide default, which is derived from the effective RLIMIT_NOFILE
+	// on macOS and disabled elsewhere; a negative value disables the budget
+	// for this watcher. Tests inject a small value so the arithmetic is
+	// deterministic and never depends on the host's real descriptor limit.
+	FDBudget int
+
+	// fdCost overrides the platform descriptor cost model. Unexported: it
+	// exists so in-package tests can exercise the macOS (kqueue) arithmetic on
+	// every platform. The zero value selects defaultCostModel().
+	fdCost fdCostModel
 }
 
 func (c *Config) debounce() time.Duration {
@@ -113,14 +127,25 @@ type Watcher struct {
 	// observes per-directory churn at the event boundary and drops events
 	// under directories it has quarantined. nil disables the feature.
 	quarantine *QuarantineTracker
-	mu         sync.Mutex
-	fs         *fsnotify.Watcher
-	repos      map[string]*repoState // key: absolute repo path
-	dirToRepo  map[string]string     // key: absolute dir path → repo path
-	stopOnce   sync.Once
-	stopCh     chan struct{}
-	stoppedCh  chan struct{}
-	restartCh  chan struct{} // signals heartbeat loop to recreate fsnotify
+	// fdb is the descriptor ledger (#6180) and fdCost the platform arithmetic
+	// it charges with. fdb is shared process-wide unless Config.FDBudget
+	// overrides it, because the kernel's ceiling is per process.
+	fdb       *fdBudget
+	fdCost    fdCostModel
+	mu        sync.Mutex
+	fs        *fsnotify.Watcher
+	repos     map[string]*repoState // key: absolute repo path
+	dirToRepo map[string]string     // key: absolute dir path → repo path
+	// fdReserved records how many descriptors each subscribed repo holds, so
+	// RemoveRepo can hand them back.
+	fdReserved map[string]int
+	// fdUnwatched names repos refused because the budget was full. These are
+	// NOT in repos: they receive no events, and this is how they say so.
+	fdUnwatched map[string]struct{}
+	stopOnce    sync.Once
+	stopCh      chan struct{}
+	stoppedCh   chan struct{}
+	restartCh   chan struct{} // signals heartbeat loop to recreate fsnotify
 	// counters — accessed atomically outside mu where latency matters
 	totalEvents   uint64
 	droppedSkips  uint64
@@ -174,18 +199,33 @@ func NewWatcherConfig(cfg Config, sink EventSink, logger *slog.Logger) (*Watcher
 		extraSkip[d] = struct{}{}
 	}
 
+	// Descriptor budget (#6180). A zero Config.FDBudget shares the
+	// process-wide ledger; any explicit value gets a private one.
+	fdb := sharedFDBudget()
+	if cfg.FDBudget != 0 {
+		fdb = newFDBudget(cfg.FDBudget)
+	}
+	fdCost := cfg.fdCost
+	if fdCost == (fdCostModel{}) {
+		fdCost = defaultCostModel()
+	}
+
 	w := &Watcher{
-		logger:    logger,
-		cfg:       cfg,
-		sink:      sink,
-		extraSkip: extraSkip,
-		clk:       realClock{},
-		fs:        fw,
-		repos:     map[string]*repoState{},
-		dirToRepo: map[string]string{},
-		stopCh:    make(chan struct{}),
-		stoppedCh: make(chan struct{}),
-		restartCh: make(chan struct{}, 1),
+		logger:      logger,
+		cfg:         cfg,
+		sink:        sink,
+		extraSkip:   extraSkip,
+		clk:         realClock{},
+		fdb:         fdb,
+		fdCost:      fdCost,
+		fs:          fw,
+		repos:       map[string]*repoState{},
+		dirToRepo:   map[string]string{},
+		fdReserved:  map[string]int{},
+		fdUnwatched: map[string]struct{}{},
+		stopCh:      make(chan struct{}),
+		stoppedCh:   make(chan struct{}),
+		restartCh:   make(chan struct{}, 1),
 	}
 	// Adaptive index-trash quarantine (#5394). The tracker observes
 	// per-directory churn at the event boundary and quarantines dirs that
@@ -267,6 +307,22 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 
 	added, err := w.subscribeRepo(abs)
 	if err != nil {
+		if isFDBudgetError(err) {
+			// The subscription was refused and fully unwound. Drop the repo
+			// from the watched set as well — leaving it there would make it
+			// LOOK watched in Repos()/Stats() while receiving no events, which
+			// is precisely the silent half-failure this guard exists to stop.
+			// subscribeRepo has already recorded it in fdUnwatched.
+			w.mu.Lock()
+			if rs, ok := w.repos[abs]; ok {
+				if rs.timer != nil {
+					rs.timer.Stop()
+				}
+				delete(w.repos, abs)
+			}
+			w.mu.Unlock()
+			return 0, err
+		}
 		return added, err
 	}
 	w.logger.Info("watcher: registered", "repo", abs, "dirs", added, "debounce", w.cfg.debounce())
@@ -281,15 +337,42 @@ func (w *Watcher) AddRepo(repoPath string) (int, error) {
 //  1. Hard-coded SkipDirs / walk.IsHardcodedSkip (ShouldSkipDir)
 //  2. Per-instance ExcludeDirs (extraSkip)
 //  3. .gitignore + .grafel/watch.json (ShouldSkipDirGitignore)
+//
+// Descriptor budget (#6180): the walk is also the estimator. Every directory
+// costs fdCost.perDir descriptors and every file inside a directory we
+// subscribed costs fdCost.perFile — which is exactly what fsnotify's kqueue
+// backend opens (addWatch on the dir, then watchDirectoryFiles on its
+// contents). Charging incrementally as the existing walk streams entries
+// avoids a second pass over the tree and, unlike a pre-flight estimate, can
+// never open more descriptors than the budget allows before it notices.
 func (w *Watcher) subscribeRepo(abs string) (int, error) {
 	added := 0
 	dirCap := walk.WatchDirCap()
 	capWarned := false
+
+	reserved := 0
+	budgetHit := false
+	// Dirs this walk actually subscribed. A file is only charged if the
+	// directory holding it is one we opened — files under a skipped or
+	// failed-to-add directory cost fsnotify nothing.
+	subscribed := map[string]struct{}{}
+
 	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if !d.IsDir() {
+			if w.fdCost.perFile <= 0 {
+				return nil
+			}
+			if _, ok := subscribed[filepath.Dir(p)]; !ok {
+				return nil
+			}
+			if !w.fdb.reserve(w.fdCost.perFile) {
+				budgetHit = true
+				return errFDBudget
+			}
+			reserved += w.fdCost.perFile
 			return nil
 		}
 		// TCC guard (#5296): never subscribe to protected macOS media folders
@@ -326,16 +409,55 @@ func (w *Watcher) subscribeRepo(abs string) (int, error) {
 				}
 			}
 		}
+		if !w.fdb.reserve(w.fdCost.perDir) {
+			budgetHit = true
+			return errFDBudget
+		}
 		if err := w.fs.Add(p); err != nil {
+			w.fdb.release(w.fdCost.perDir)
 			w.logger.Warn("watcher: add failed", "path", p, "err", err)
 			return nil
 		}
+		reserved += w.fdCost.perDir
+		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = abs
 		w.mu.Unlock()
 		added++
 		return nil
 	})
+
+	if budgetHit {
+		// Refuse, do not half-watch. Every descriptor this attempt opened is
+		// handed back so a refusal cannot slowly poison the ledger.
+		for p := range subscribed {
+			_ = w.fs.Remove(p)
+		}
+		w.mu.Lock()
+		for p := range subscribed {
+			delete(w.dirToRepo, p)
+		}
+		delete(w.fdReserved, abs)
+		w.fdUnwatched[abs] = struct{}{}
+		w.mu.Unlock()
+		w.fdb.release(reserved)
+
+		used, limit := w.fdb.snapshot()
+		w.logger.Warn("watcher: NOT WATCHING repo — file-descriptor budget exhausted; "+
+			"edits under this repo will not trigger a re-index until budget frees up",
+			"repo", abs,
+			"dirs_reached", added,
+			"fd_used", used,
+			"fd_limit", limit,
+			"override_env", fdBudgetEnv)
+		return 0, fmt.Errorf("%w: %s does not fit in the remaining watch budget (used %d of %d descriptors); "+
+			"raise %s or unregister repos", errFDBudget, abs, used, limit, fdBudgetEnv)
+	}
+
+	w.mu.Lock()
+	w.fdReserved[abs] = reserved
+	delete(w.fdUnwatched, abs)
+	w.mu.Unlock()
 	return added, walkErr
 }
 
@@ -360,6 +482,13 @@ func (w *Watcher) RemoveRepo(repoPath string) {
 			delete(w.dirToRepo, d)
 		}
 	}
+	// Hand the descriptors back (#6180). Without this a store that churns
+	// repos would exhaust the budget permanently while holding nothing.
+	if n := w.fdReserved[abs]; n > 0 {
+		w.fdb.release(n)
+	}
+	delete(w.fdReserved, abs)
+	delete(w.fdUnwatched, abs)
 	// Evict gitignore cache so a re-add picks up any .gitignore changes.
 	evictRepoIgnoreState(abs)
 }
@@ -375,15 +504,34 @@ func (w *Watcher) Repos() []string {
 	return out
 }
 
-// Stats returns coarse counters for /status output. Signature is
-// intentionally identical to the pre-#1270 version so service.go
-// doesn't need changes.
-func (w *Watcher) Stats() (repos int, dirs int, events uint64, dropped uint64) {
+// Stats returns coarse counters for /status output.
+//
+// unwatched (#6180) is the number of repos that are NOT being watched because
+// the file-descriptor budget was full when they were offered. It is reported
+// alongside the healthy counters on purpose: a repo that is registered with
+// the daemon but receiving no fs events is the exact failure this codebase
+// keeps shipping silently, and /status is where an operator looks first.
+func (w *Watcher) Stats() (repos int, dirs int, events uint64, dropped uint64, unwatched int) {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return len(w.repos), len(w.dirToRepo),
 		atomic.LoadUint64(&w.totalEvents),
-		atomic.LoadUint64(&w.droppedSkips) + atomic.LoadUint64(&w.droppedReplay)
+		atomic.LoadUint64(&w.droppedSkips) + atomic.LoadUint64(&w.droppedReplay),
+		len(w.fdUnwatched)
+}
+
+// FDBudgetStats reports the descriptor ledger for /diagnostics (#6180): how
+// many descriptors the watch set has committed, the ceiling (0 == accounting
+// disabled on this platform), and the repos refused for want of budget.
+func (w *Watcher) FDBudgetStats() (used, limit, unwatched int, unwatchedRepos []string) {
+	used, limit = w.fdb.snapshot()
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	for p := range w.fdUnwatched {
+		unwatchedRepos = append(unwatchedRepos, p)
+	}
+	sort.Strings(unwatchedRepos)
+	return used, limit, len(w.fdUnwatched), unwatchedRepos
 }
 
 // RepoStat holds per-repo watcher statistics for the /diagnostics endpoint.
@@ -441,6 +589,13 @@ func (w *Watcher) Stop() {
 				rs.timer.Stop()
 			}
 		}
+		// fs.Close() released every descriptor this watcher held; give the
+		// budget back so a later Watcher in the same process can use it
+		// (#6180 — the ledger is process-wide, not per-Watcher).
+		for repo, n := range w.fdReserved {
+			w.fdb.release(n)
+			delete(w.fdReserved, repo)
+		}
 		w.mu.Unlock()
 	})
 }
@@ -473,6 +628,13 @@ func (w *Watcher) heartbeat() {
 			w.fs = fw
 			// Clear stale dirToRepo — will be repopulated by subscribeRepo.
 			w.dirToRepo = make(map[string]string, len(w.dirToRepo))
+			// The old fsnotify instance is gone, so its descriptors are gone
+			// too (#6180). Return them to the ledger before re-subscribing, or
+			// the restart double-charges and every repo is refused.
+			for repo, n := range w.fdReserved {
+				w.fdb.release(n)
+				delete(w.fdReserved, repo)
+			}
 			repos := make([]string, 0, len(w.repos))
 			for p := range w.repos {
 				repos = append(repos, p)
@@ -644,11 +806,28 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 	if repo == "" {
 		return
 	}
+	reserved := 0
+	budgetHit := false
+	subscribed := map[string]struct{}{}
 	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
 		if err != nil {
 			return nil
 		}
 		if !d.IsDir() {
+			// Same per-file descriptor cost as the initial subscription
+			// (#6180): a directory created by `git checkout` brings its files
+			// with it, and kqueue opens one descriptor for each.
+			if w.fdCost.perFile <= 0 {
+				return nil
+			}
+			if _, ok := subscribed[filepath.Dir(p)]; !ok {
+				return nil
+			}
+			if !w.fdb.reserve(w.fdCost.perFile) {
+				budgetHit = true
+				return errFDBudget
+			}
+			reserved += w.fdCost.perFile
 			return nil
 		}
 		// TCC guard (#5296): never recurse into protected media folders/bundles.
@@ -659,14 +838,35 @@ func (w *Watcher) subscribeDirRecursive(root string) {
 		if p != root && w.shouldSkipDir(base) {
 			return filepath.SkipDir
 		}
+		if !w.fdb.reserve(w.fdCost.perDir) {
+			budgetHit = true
+			return errFDBudget
+		}
 		if err := w.fs.Add(p); err != nil {
+			w.fdb.release(w.fdCost.perDir)
 			return nil
 		}
+		reserved += w.fdCost.perDir
+		subscribed[p] = struct{}{}
 		w.mu.Lock()
 		w.dirToRepo[p] = repo
 		w.mu.Unlock()
 		return nil
 	})
+
+	// Whatever we did manage to subscribe stays (the repo as a whole is
+	// already watched; this is an incremental extension, so a partial
+	// extension is strictly better than none). Charge it to the owning repo
+	// so RemoveRepo returns it, and say loudly when we ran out.
+	w.mu.Lock()
+	w.fdReserved[repo] += reserved
+	w.mu.Unlock()
+	if budgetHit {
+		used, limit := w.fdb.snapshot()
+		w.logger.Warn("watcher: new subtree only partially watched — file-descriptor budget exhausted",
+			"repo", repo, "dir", root, "fd_used", used, "fd_limit", limit,
+			"override_env", fdBudgetEnv)
+	}
 }
 
 // recordAndArm updates per-repo event counters and (re)starts the

--- a/internal/dashboard/handlers_diagnostics.go
+++ b/internal/dashboard/handlers_diagnostics.go
@@ -66,11 +66,18 @@ type DaemonDiagnostics struct {
 	GroupCount   int    `json:"group_count"`
 
 	// Watcher stats (#1270) — non-zero when the watcher is running.
-	WatcherRepos         int    `json:"watcher_repos,omitempty"`
-	WatcherDirs          int    `json:"watcher_dirs,omitempty"`
-	WatcherTotalEvents   uint64 `json:"watcher_total_events,omitempty"`
-	WatcherDropped       uint64 `json:"watcher_dropped,omitempty"`
-	WatcherForceRescanOK bool   `json:"watcher_force_rescan_available"`
+	WatcherRepos       int    `json:"watcher_repos,omitempty"`
+	WatcherDirs        int    `json:"watcher_dirs,omitempty"`
+	WatcherTotalEvents uint64 `json:"watcher_total_events,omitempty"`
+	WatcherDropped     uint64 `json:"watcher_dropped,omitempty"`
+
+	// Descriptor budget (#6180). WatcherUnwatchedRepos are registered repos
+	// that are NOT being watched because the budget was full.
+	WatcherUnwatched      int      `json:"watcher_unwatched,omitempty"`
+	WatcherUnwatchedRepos []string `json:"watcher_unwatched_repos,omitempty"`
+	WatcherFDUsed         int      `json:"watcher_fd_used,omitempty"`
+	WatcherFDLimit        int      `json:"watcher_fd_limit,omitempty"`
+	WatcherForceRescanOK  bool     `json:"watcher_force_rescan_available"`
 }
 
 // GroupDiagnostics covers one group's health.
@@ -320,12 +327,20 @@ func (s *Server) buildDaemonDiagnostics() DaemonDiagnostics {
 
 	// Watcher stats (#1270)
 	if s.watcher != nil {
-		repos, dirs, events, dropped := s.watcher.Stats()
+		repos, dirs, events, dropped, unwatched := s.watcher.Stats()
 		d.WatcherRepos = repos
 		d.WatcherDirs = dirs
 		d.WatcherTotalEvents = events
 		d.WatcherDropped = dropped
 		d.WatcherForceRescanOK = true
+		// #6180: a repo refused for want of file descriptors receives no
+		// events at all. Name the repos, not just the count — "watching 12 of
+		// 14" is only actionable if you know which two.
+		fdUsed, fdLimit, _, unwatchedRepos := s.watcher.FDBudgetStats()
+		d.WatcherUnwatched = unwatched
+		d.WatcherUnwatchedRepos = unwatchedRepos
+		d.WatcherFDUsed = fdUsed
+		d.WatcherFDLimit = fdLimit
 	}
 
 	return d

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -148,8 +148,13 @@ type applyToolDeltaFunc func(cfg *registry.GroupConfig, group, binPath string, p
 // direct import of internal/daemon/watch.
 type watcherForceRescan interface {
 	ForceRescan()
-	// Stats returns (repos, dirs, totalEvents, dropped).
-	Stats() (int, int, uint64, uint64)
+	// Stats returns (repos, dirs, totalEvents, dropped, unwatched). unwatched
+	// counts repos refused for want of file descriptors (#6180).
+	Stats() (int, int, uint64, uint64, int)
+	// FDBudgetStats returns (used, limit, unwatched, unwatchedRepos) for the
+	// watcher's descriptor ledger (#6180). limit == 0 means the platform does
+	// not do descriptor accounting.
+	FDBudgetStats() (int, int, int, []string)
 }
 
 // webhookDispatcherIface is the subset of notifications.Dispatcher used by the


### PR DESCRIPTION
**39,894 file descriptors for a single repo, against a hard ceiling of 61,440.** One repo at 65% of the limit; a 140-repo store cannot work on macOS.

The cause is a library fact, not a configuration choice: `fsnotify v1.10.1` has **no FSEvents backend** — `backend_kqueue.go` carries `//go:build … || darwin`. In kqueue, `addWatch` takes a descriptor on the directory and then `watchDirectoryFiles(d)` takes one more **per file inside it**. fsnotify documents this in its own `Close()`.

`walk.DefaultWatchDirCap = 100000` counts **directories only** — blind to the per-file cost, which is 4× larger. At 100k directories it is effectively infinite. `GRAFEL_WORKTREE_ACTIVATE_CONCURRENCY` bounds concurrent subscription *setup*, not how many subscriptions exist. Nothing anywhere bounded total descriptors.

## Scope

This settles **one** of the four things #6180 says a fix needs — the descriptor-aware cap. It deliberately does not touch `Pause`-on-COLD, `isPinnedMain`, `ExpiredWindow`, or the `tierAfterIndex` resume policy.

Skipping `Pause`-on-COLD was #2645, a real correctness fix rather than an oversight: dropping the subscription made TS/TSX **edits** undetectable, and nothing else covers them — the HEAD poller stats only `HEAD` and `refs/heads/<branch>`, so it cannot see a file save. Closing that gate needs a query-time working-tree staleness probe first, or it reintroduces #2645 at 140× blast radius. That is its own change with its own measurement.

## Charged incrementally, not estimated

`dirs*perDir + files*perFile` — on macOS both are 1, i.e. dirs plus files-in-those-dirs, matching what kqueue opens.

There is **no second walk and no pre-flight pass.** The existing `filepath.WalkDir` in `subscribeRepo` is the estimator: a directory is charged when it is added, a file when the walk streams past it — and only if its parent is a directory this walk actually subscribed, since files under a skipped or failed directory cost fsnotify nothing. Charging incrementally is strictly stronger than estimating first: it cannot open more than the budget allows before noticing. `subscribeDirRecursive` (the `git checkout` path) charges the same way.

## The budget reads the post-clamp limit

A process-wide singleton ledger, not per-`Watcher` and not per-repo — the kernel's ceiling is per process.

Derived from a new `fdlimit.Current()` read-back of `getrlimit(RLIMIT_NOFILE)`, which is the **post-clamp** value. The daemon plist asks for 65536, `kern.maxfilesperproc` is 61440, and the excess is dropped silently — `internal/daemon/fdlimit` already documented that Darwin quirk. Budgeting from the requested number would over-commit by exactly what the kernel refused.

**Headroom 25%, floor 1024** — so 61440 yields 46080 of watch budget with 15360 reserved for graph mmaps and segment files, the unix socket and its connections, the dashboard listener, logs, and the pipes of every `git` subprocess the indexer spawns. Deliberately generous, and the asymmetry is the argument: running out of descriptors for the **store** risks corruption, running out of **watch** budget only costs freshness. This change exists to make sure the second is the failure we take. `GRAFEL_WATCH_FD_BUDGET` overrides; `<= 0` disables.

## A refusal is unwound and loud

Refused and **fully unwound** — descriptors returned, dirs unsubscribed, repo dropped from the `repos` map. Leaving it there would make it look watched in `Repos()`/`Stats()` while receiving nothing, which is the exact silent half-failure this is meant to stop. `RemoveRepo`, `Stop` and the heartbeat restart all return their reservations; the restart one matters, because without it a re-subscribe double-charges and then refuses everything.

- `AddRepo` returns a typed error naming the repo and the ledger.
- `WARN watcher: NOT WATCHING repo — file-descriptor budget exhausted; edits under this repo will not trigger a re-index until budget frees up`, with `repo`, `dirs_reached`, `fd_used`, `fd_limit`, `override_env`.
- `Watcher.Stats()` gained `unwatched`, surfaced in `/status` and in `grafel status` as `watcher: N repo(s) NOT WATCHED — file-descriptor budget full (U/L used)`. That line is deliberately **not** gated on `WatcherRepos > 0`: the worst case is precisely the one where that count is zero because everything was refused.
- `/diagnostics` names the repos, not just the count.

## Platform gating

Build constraints by filename, not `runtime.GOOS` plus `t.Skip` — that guards execution, not compilation (#6218). `fdbudget_darwin.go` carries the kqueue cost model and the getrlimit-derived limit; `fdbudget_other.go` carries the inotify model (per-directory only, since Linux spends watch descriptors out of `max_user_watches`, a different resource) with limit 0, i.e. accounting off unless an operator opts in.

Tests inject `kqueueCostModel` explicitly so the macOS arithmetic is exercised on **every** platform, and the gating tests branch on the build-tagged constant so they compile and run everywhere. `CGO_ENABLED=0 GOOS=linux` and `GOOS=windows` vet both exit 0 for `watch`/`fdlimit`/`proto`.

## Mutants

Ten, no survivors. Two are the anti-vacuity pair: ignoring the injected `Config.FDBudget` proves the budget genuinely reads the injected limit, and forcing `perFile = 0` proves the estimate genuinely counts files. `TestMakeTreePremise` independently asserts the fixture is 2 dirs / 8 files via a walk touching no production code, and `countTree` is the oracle every arithmetic assertion is written against.

Re-run at merge: skipping the per-file charge — the original defect — fails with `premise broken: AddRepo was not refused` and `both trees fitted a budget sized for one — the budget is not global`.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, cross-`GOOS` vet linux 0 / windows 0, and `./internal/daemon/...`, `./internal/dashboard/...`, `./internal/cli/...` exit 0 with zero FAIL lines.

## What remains unfixed

**This makes exhaustion legible, not absent.** At 46080 of budget against the measured ~40k cost of one repo, roughly one repo of that size fits plus a handful of small ones. A 140-repo store still cannot watch everything on macOS — it now refuses the surplus with a named reason instead of walking into EMFILE mid-store-write.

Specifically still open:

- **Refused repos get no freshness at all.** No reduced-fidelity watch, no polling tier, no LRU that evicts a cold repo to admit a hot one — first-come-first-served on registration order. That is the real remaining gap and it is what the other three items in #6180 are about.
- Subscription is all-or-nothing per repo; no partial subscription of the hottest subtrees. `subscribeDirRecursive` is the one place that does partially subscribe, which is an intentional but real inconsistency.
- **`internal/daemon/worktree` opens its own separate `fsnotify.Watcher` and is not on this ledger.** It draws from the same kernel limit. A second unbudgeted consumer, filed separately.
- The 25% reserve is a judgement call, not a measurement — the daemon's actual non-watch descriptor usage was not measured. If it exceeds 15360 the process can still reach the ceiling.
- `walk.DefaultWatchDirCap` is left alone; it is now the weaker of the two bounds on macOS and the only one on Linux.

Refs #6180, #2645, #6218
