### PR TITLE
fix(#6234): a bodiless declaration adopted the next member's body, taking its EndLine and its CALLS edges

### DIFF
--- a/internal/extractors/solidity/extractor.go
+++ b/internal/extractors/solidity/extractor.go
@@ -283,10 +283,10 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 			fnName := body[fm[2]:fm[3]]
 			qualName := name + "." + fnName
 			fnStartLine := braceLine + strings.Count(body[:fm[0]], "\n")
-			fnBody, fnEndLine := extractBracedBody(body, fm[1])
-			_ = fnBody
-			if fnEndLine == 0 {
-				fnEndLine = fnStartLine
+			fnBody, fnEnd := declBody(body, fm[1])
+			fnEndLine := fnStartLine
+			if fnEnd >= 0 {
+				fnEndLine = braceLine + strings.Count(body[:fnEnd], "\n")
 			}
 			rawFnSig := declSignature(body, fm[0], fm[1])
 
@@ -298,7 +298,7 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 				SourceFile:    filePath,
 				Language:      "solidity",
 				StartLine:     fnStartLine,
-				EndLine:       fnStartLine + strings.Count(fnBody, "\n"),
+				EndLine:       fnEndLine,
 				Signature:     rawFnSig,
 				Relationships: callRels,
 			}
@@ -323,6 +323,11 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 			qualName := name + "." + evName
 			evStartLine := braceLine + strings.Count(body[:em[0]], "\n")
 			rawEvSig := declSignature(body, em[0], em[1])
+			// An event is always bodiless, so declBody yields the ';' offset.
+			evEndLine := evStartLine
+			if _, evEnd := declBody(body, em[1]); evEnd >= 0 {
+				evEndLine = braceLine + strings.Count(body[:evEnd], "\n")
+			}
 
 			evRec := types.EntityRecord{
 				Name:       qualName,
@@ -331,7 +336,7 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 				SourceFile: filePath,
 				Language:   "solidity",
 				StartLine:  evStartLine,
-				EndLine:    evStartLine,
+				EndLine:    evEndLine,
 				Signature:  rawEvSig,
 			}
 			out = append(out, evRec)
@@ -352,7 +357,11 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 			qualName := name + "." + modName
 			modStartLine := braceLine + strings.Count(body[:mm[0]], "\n")
 			rawModSig := declSignature(body, mm[0], mm[1])
-			modBody, _ := extractBracedBody(body, mm[1])
+			modBody, modEnd := declBody(body, mm[1])
+			modEndLine := modStartLine
+			if modEnd >= 0 {
+				modEndLine = braceLine + strings.Count(body[:modEnd], "\n")
+			}
 
 			callRels := collectCallsFromBody(modBody, qualName)
 			modRec := types.EntityRecord{
@@ -362,7 +371,7 @@ func findContracts(src, filePath string, signals frameworkSignals) []types.Entit
 				SourceFile:    filePath,
 				Language:      "solidity",
 				StartLine:     modStartLine,
-				EndLine:       modStartLine + strings.Count(modBody, "\n"),
+				EndLine:       modEndLine,
 				Signature:     rawModSig,
 				Relationships: callRels,
 			}
@@ -572,6 +581,48 @@ func extractBracedBody(src string, openPos int) (string, int) {
 		i++
 	}
 	return "", 0
+}
+
+// declBody returns the braced body of the member declaration whose regex match
+// ended at matchEnd, together with the offset of the token that ends the
+// declaration: the closing '}' of the body, or the ';' of a bodiless one. It
+// returns "" and -1 when the declaration is unterminated.
+//
+// The ';' bound is the whole point. extractBracedBody on its own scans forward
+// to the next '{' it can find anywhere, so on a bodiless declaration — an
+// interface method, or `virtual` in an abstract contract — it runs past the
+// ';' and returns the FOLLOWING member's body. That body then supplies the
+// bodiless declaration's line span and, through collectCallsFromBody, its
+// CALLS edges.
+//
+// src is scrubbed (see stripCommentsAndStrings), so a delimiter inside a
+// comment or a string literal cannot end the declaration early. matchEnd sits
+// just past the '(' opening the parameter list, so the paren scan starts one
+// level deep.
+func declBody(src string, matchEnd int) (string, int) {
+	depth := 1
+	for i := matchEnd; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ';':
+			if depth == 0 {
+				return "", i
+			}
+		case '{':
+			if depth == 0 {
+				body, endLine := extractBracedBody(src, i)
+				if endLine == 0 {
+					return "", -1
+				}
+				// body is src[i+1:close], so close sits len(body)+1 past i.
+				return body, i + len(body) + 1
+			}
+		}
+	}
+	return "", -1
 }
 
 // declSignature returns the declaration starting at declStart up to the first

--- a/internal/extractors/solidity/issue6234_declaration_spans_test.go
+++ b/internal/extractors/solidity/issue6234_declaration_spans_test.go
@@ -1,0 +1,145 @@
+package solidity_test
+
+// Issue #6234: extractBracedBody scanned forward for the next '{' with no
+// bound, so a bodiless declaration returned the FOLLOWING member's body. That
+// body supplied the bodiless declaration's EndLine and, through
+// collectCallsFromBody, its CALLS edges. A second defect in the same lines
+// computed EndLine from the body's newline count added to the declaration's
+// start line, which drops every newline inside the declaration itself.
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/types"
+)
+
+// spanFixture line 1 is the SPDX comment. It carries one of each shape that
+// used to be attributed wrongly: a bodiless function and a bodiless modifier
+// each followed by a bodied member, a function whose signature wraps, and an
+// event whose parameter list wraps. `last` is bodied and comes last, so a
+// regression that widens a span has somewhere to run to.
+const spanFixture = `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+abstract contract Base {
+    event Multi(
+        address indexed who,
+        uint256 amount
+    );
+
+    function mustOverride(uint256 a) public virtual returns (uint256);
+
+    function implemented() public {
+        transferSomething();
+        emitSomething();
+    }
+
+    modifier bodiless() virtual;
+
+    modifier withBody() {
+        require(true);
+        _;
+    }
+
+    function wrappedSignature(
+        uint256 a,
+        address b
+    )
+        public
+        returns (uint256)
+    {
+        doWork();
+        return a;
+    }
+
+    function last() public {
+        doLast();
+    }
+}
+`
+
+// TestSolidity_DeclarationSpans (#6234) pins EndLine for every member of
+// spanFixture. Nothing in this package asserted EndLine on a function, event
+// or modifier before, which is how both defects survived;
+// TestSolidity_LineAttribution pins StartLine only.
+func TestSolidity_DeclarationSpans(t *testing.T) {
+	ents := runSolidity(t, spanFixture, "contracts/Base.sol")
+
+	for _, tc := range []struct {
+		name    string
+		subtype string
+		start   int
+		end     int
+	}{
+		{"Base.Multi", "event", 5, 8},
+		// Bodiless: the span is the declaration, ending at its ';'. Before
+		// the fix this read 13, the closing brace of `implemented`.
+		{"Base.mustOverride", "function", 10, 10},
+		{"Base.implemented", "function", 12, 15},
+		{"Base.bodiless", "modifier", 17, 17},
+		{"Base.withBody", "modifier", 19, 22},
+		// The declaration wraps over six lines before its '{'. Before the fix
+		// this read 27, being the start line plus the body's newlines alone.
+		{"Base.wrappedSignature", "function", 24, 33},
+		{"Base.last", "function", 35, 37},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ent := solFindSubtype(ents, tc.name, "SCOPE.Operation", tc.subtype)
+			if ent == nil {
+				t.Fatalf("no %s entity named %q", tc.subtype, tc.name)
+			}
+			if ent.StartLine != tc.start {
+				t.Errorf("StartLine = %d, want %d", ent.StartLine, tc.start)
+			}
+			if ent.EndLine != tc.end {
+				t.Errorf("EndLine = %d, want %d", ent.EndLine, tc.end)
+			}
+		})
+	}
+}
+
+// TestSolidity_BodilessDeclarationMakesNoCalls (#6234): the phantom CALLS
+// edges were the sharper half of the defect. A bodiless declaration collected
+// the next member's calls, additively, so one call site produced two CALLS
+// records on two different functions. Asserted bidirectionally: the bodiless
+// member must have none AND the bodied one must keep its own, so deleting the
+// edges outright cannot pass this.
+func TestSolidity_BodilessDeclarationMakesNoCalls(t *testing.T) {
+	ents := runSolidity(t, spanFixture, "contracts/Base.sol")
+
+	for _, tc := range []struct {
+		name    string
+		subtype string
+		want    []string
+	}{
+		{"Base.mustOverride", "function", nil},
+		{"Base.implemented", "function", []string{"emitSomething", "transferSomething"}},
+		{"Base.wrappedSignature", "function", []string{"doWork"}},
+		{"Base.last", "function", []string{"doLast"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ent := solFindSubtype(ents, tc.name, "SCOPE.Operation", tc.subtype)
+			if ent == nil {
+				t.Fatalf("no %s entity named %q", tc.subtype, tc.name)
+			}
+			if got := solRawCallees(ent); !slices.Equal(got, tc.want) {
+				t.Errorf("CALLS = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// solRawCallees returns the callee names on the pre-resolve CALLS edges of one
+// entity, sorted, since nothing promises source order. The existing
+// solCallTargets describes what edges BOUND to and so needs resolved records.
+func solRawCallees(ent *types.EntityRecord) []string {
+	var out []string
+	for _, rel := range ent.Relationships {
+		if rel.Kind == "CALLS" {
+			out = append(out, rel.ToID)
+		}
+	}
+	slices.Sort(out)
+	return out
+}


### PR DESCRIPTION
## Summary

`extractBracedBody` scans forward for the first `{` it can find, with no upper bound, so a bodiless declaration returned the **following** member's body. That body supplied the bodiless declaration's `EndLine` and, through `collectCallsFromBody`, its `CALLS` edges. A second defect in the same lines computed `EndLine` as the declaration's start line plus the body's newline count, which drops every newline inside the declaration itself.

`declBody` bounds the scan at the declaration's terminator: a body only when `{` precedes `;`, and that terminator's offset either way. `declSignature` already drew this distinction on the same scrubbed text, so the discrimination existed in the file and was not being reused. The function, event and modifier branches now share it. Events were previously pinned to their start line, so a wrapped event declaration was short too.

## Closes / Refs

Closes #6234

## Testing

`go test ./...` on darwin/arm64: no failing packages. `gofmt -l` and `go vet` clean on the changed package.

`TestSolidity_DeclarationSpans` and `TestSolidity_BodilessDeclarationMakesNoCalls` are new; nothing in the package asserted `EndLine` on a function, event or modifier before. Reverting `extractor.go` alone and rerunning them against `adff65308` gives:

```
Base.Multi              EndLine = 5, want 8
Base.mustOverride       EndLine = 13, want 10
Base.bodiless           EndLine = 20, want 17
Base.wrappedSignature   EndLine = 27, want 33
Base.mustOverride       CALLS = [emitSomething transferSomething], want []
```

`Base.implemented`, `Base.withBody` and `Base.last` pass both before and after. They are the controls that stop the fix from being edge deletion.

No cross-language parity risk: the diff is confined to `internal/extractors/solidity/extractor.go`, and no shared helper changed.

## Notes

The CALLS assertion is bidirectional on purpose. Dropping phantom edges lowers the bound-edge count, which a count-only check reads as a regression, so the test pins which callee names survive on which caller rather than how many there are.

Scope limit: this covers functions, events and modifiers, the members that go through the regex-then-brace path. State variables take the separate `stateVarDecl` path from #6135 and are untouched.
