### PR TITLE
test(#6234): pin the closing-brace offset with a member whose brace is at column 0

### DIFF
--- a/internal/extractors/solidity/issue6234_declaration_spans_test.go
+++ b/internal/extractors/solidity/issue6234_declaration_spans_test.go
@@ -17,8 +17,12 @@ import (
 // spanFixture line 1 is the SPDX comment. It carries one of each shape that
 // used to be attributed wrongly: a bodiless function and a bodiless modifier
 // each followed by a bodied member, a function whose signature wraps, and an
-// event whose parameter list wraps. `last` is bodied and comes last, so a
-// regression that widens a span has somewhere to run to.
+// event whose parameter list wraps. `columnZeroBrace` closes at column 0, the
+// shape machine-generated and `solc --standard-json` flattened sources emit;
+// it is the only member whose closing brace is preceded by a newline, which is
+// what distinguishes the end offset from the one byte before it. Every member
+// is followed by another, so a regression that widens a span has somewhere to
+// run to.
 const spanFixture = `// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
@@ -56,6 +60,10 @@ abstract contract Base {
     function last() public {
         doLast();
     }
+
+    function columnZeroBrace() public {
+        doFlush();
+}
 }
 `
 
@@ -83,6 +91,10 @@ func TestSolidity_DeclarationSpans(t *testing.T) {
 		// this read 27, being the start line plus the body's newlines alone.
 		{"Base.wrappedSignature", "function", 24, 33},
 		{"Base.last", "function", 35, 37},
+		// The closing brace sits at column 0, so the byte before it is a
+		// newline. Reading the end offset one byte short lands on that newline
+		// and reports 40, the body's last line, instead of the brace's own.
+		{"Base.columnZeroBrace", "function", 39, 41},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ent := solFindSubtype(ents, tc.name, "SCOPE.Operation", tc.subtype)


### PR DESCRIPTION
The contributor fix in `b50730ea3` (#6235, issue #6234) ends its brace-body branch with:

```go
// body is src[i+1:close], so close sits len(body)+1 past i.
return body, i + len(body) + 1
```

The arithmetic is **correct** — `extractBracedBody` slices `body := src[start+1 : i]` with `start == openPos`, so `len(body) == close - i - 1`.

**Nothing pinned the `+1`.** Adversarial review mutated it to `i + len(body)` and the entire `internal/extractors/solidity` package still passed. The two spellings differ only when the byte immediately before a closing `}` is a newline — i.e. when a member's closing brace sits at **column 0** — and every fixture in the repo indents its member braces.

That is a live gap rather than a theoretical one: machine-generated `.sol` and `solc --standard-json` flattened output routinely emit column-0 braces.

## The fixture

One member appended to the existing `spanFixture`, one case added to the existing `TestSolidity_DeclarationSpans` table — no new test function. Appending rather than inserting leaves every existing case's line numbers untouched, so the diff is 14 added / 2 removed, the 2 being the fixture's doc comment, which claimed `last` comes last and no longer does. The comment now records *why* this member exists: it is the only one whose closing brace is preceded by a newline.

## Verification

Mutating `i + len(body) + 1` → `i + len(body)` fails with:

```
--- FAIL: TestSolidity_DeclarationSpans/Base.columnZeroBrace
    EndLine = 40, want 41
```

Run against the **full package**, not just the one test — `Base.columnZeroBrace` is the sole failure. That is the stronger claim and the one worth having: the `+1` is now pinned by exactly one assertion rather than incidentally covered by several, so the fixture cannot be removed without the constraint going unguarded.

Killed on the first attempt, no iteration. Production code is byte-identical to `b50730ea3` — restored by `cp` from a backup with a matching shasum, never `git checkout --`.

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/extractors/solidity/...` 0.

## Scope note

`Base.columnZeroBrace` was deliberately **not** added to `TestSolidity_BodilessDeclarationMakesNoCalls`, even though it contains a `doFlush()` call. That table is about phantom CALLS edges on *bodiless* declarations, which this member is not. Its `doFlush` edge is therefore unasserted — noted rather than hidden.

Refs #6234, #6235