### PR TITLE
fix(#6169,#6163): the installers placed a binary and stopped short of a working product

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ The script respects `GRAFEL_VERSION` (pin a release tag), `GRAFEL_PREFIX` (insta
 
 ## Windows — three ways to install
 
-All three paths install the same release binary into `%USERPROFILE%\.grafel\bin`, add that folder to your **user** PATH, and run `grafel install`. **None require administrator rights** — everything lives under your user profile. There is no native `windows_arm64` build; on Windows on ARM the x86_64 binary runs under x64 emulation, and the installers select it automatically.
+The scripted paths install the same release binary into `%USERPROFILE%\.grafel\bin`, add that folder to your **user** PATH, record the binary in `install.json`, and register grafel as an MCP server in your AI coding tools. They deliberately do **not** run bare `grafel install` (issue #6163): that command is scoped to the directory you run it from — it appends `/.grafel/` to that repo's `.gitignore` and installs four git hooks there — and an installer is run from wherever your console happens to be, not from a repository you chose. Run `grafel install` yourself, inside the repo you want it to configure. **None require administrator rights** — everything lives under your user profile. There is no native `windows_arm64` build; on Windows on ARM the x86_64 binary runs under x64 emulation, and the installers select it automatically.
 
 ### PowerShell (recommended)
 

--- a/install.bat
+++ b/install.bat
@@ -316,17 +316,48 @@ REM make grafel.exe resolvable in THIS session for the install step below.
 set "PATH=%PATH%;%BINDIR%"
 
 echo.
-REM --- register MCP / hooks / watchers (does NOT touch PATH) ---
-"%BINDIR%\grafel.exe" install
-REM `grafel install` may exit non-zero before any group exists; don't abort the
-REM whole installer on that — the binary is on disk and on PATH.
+REM --- finish the install: record state, then register MCP (issue #6163) ---
+REM
+REM This used to be a bare `"%BINDIR%\grafel.exe" install`, and that was the
+REM most damaging line in any of the three installers. `grafel install` is the
+REM seven-step RunCopy transaction, and a .bat is run from whatever directory
+REM the console happened to be in — which names no repository and grants no
+REM consent to modify one. It therefore:
+REM
+REM   * appended /.grafel/ to THAT directory's .gitignore (RunCopy step 5) and
+REM     wrote four git hooks — post-checkout, post-merge, post-rewrite,
+REM     pre-push — into THAT repository (step 7);
+REM   * restarted the daemon on a 60-second readiness budget (step 4), whose
+REM     failure path rolls step 3 back and restores the MCP host configs from
+REM     snapshots — on a first-ever install that is the absent-sentinel, i.e.
+REM     DELETING .claude.json and every foreign MCP server in it (#6168);
+REM   * and, because a .bat runs interactively from a console, stdin IS a TTY,
+REM     so resolveToolSelection opened the tool-selection wizard and the
+REM     install BLOCKED there waiting for input that an unattended run never
+REM     provides.
+REM
+REM #6162 gated the repo-scoped steps on an explicit CopyIntent, but that does
+REM not rescue this line: IntentInstall — which `grafel install` passes — still
+REM runs them, correctly, because running `grafel install` inside a repo on
+REM purpose is the case that wants them. This is not that case.
+REM
+REM The two narrow commands below are the parts an installer is entitled to do.
+REM --refresh-state records the .exe we just copied so grafel stops printing
+REM "binary updated since last install" on every command; --register-mcp writes
+REM the grafel entry into the detected host configs so the product is actually
+REM reachable (#6169). Neither restarts a daemon, prompts, or touches any
+REM repository. Both are idempotent and best-effort: a non-zero exit must not
+REM abort an installer whose binary is already on disk and on PATH.
+"%BINDIR%\grafel.exe" install --refresh-state
+"%BINDIR%\grafel.exe" install --register-mcp
 
 echo.
 "%BINDIR%\grafel.exe" --version 2>nul
 
 echo.
 echo Done. grafel is installed at %BINDIR%\grafel.exe
-echo Restart your shell ^(or open a new terminal^) so PATH picks up %BINDIR%, then run:
+echo Restart your shell ^(or open a new terminal^) so PATH picks up %BINDIR%.
+echo Restart Claude Code to load the grafel MCP tools, then run:
 echo   grafel --version
 echo   grafel wizard
 call :cleanup

--- a/install.ps1
+++ b/install.ps1
@@ -155,7 +155,15 @@ function Stop-Daemon {
 # grafel install registers a Task Scheduler task named 'com.grafel.daemon'.
 function Restart-Daemon {
     $taskName = 'com.grafel.daemon'
-    $hint = "re-run 'grafel install' or restart the daemon to finish the update"
+    # `grafel restart`, NOT `grafel install` (#6163). This hint is printed
+    # exactly when the daemon is known not to be healthy, which is the
+    # condition in which RunCopy's step-4 restart is most likely to fail — and
+    # its failure rolls step 3 back, restoring the MCP host configs from
+    # snapshots, which on a first-ever install deletes .claude.json and every
+    # foreign server in it (#6168). Bare `grafel install` from a console also
+    # writes .gitignore + four git hooks into whatever directory the user is
+    # standing in (#6162) and blocks on the TTY tool-selection wizard.
+    $hint = "run 'grafel restart' to finish the update"
 
     if (-not (Get-Command schtasks.exe -ErrorAction SilentlyContinue)) {
         return $false
@@ -228,6 +236,35 @@ try {
 
     Copy-Item -Path $binSrc.FullName -Destination $existing -Force
 
+    # Record the .exe we just placed, BEFORE reporting doctor output (#6163).
+    #
+    # Without this the script shipped a bug it then printed. Copy-Item replaces
+    # the binary but nothing rewrites ~/.grafel/install.json, whose CLI record
+    # is only ever written by `grafel install`. RunQuickDoctor compares
+    # state.CLI.SHA256 against the binary at state.CLI.Path, so after every
+    # upgrade the recorded SHA is the PREVIOUS binary's and
+    #   "grafel doctor: binary updated since last install …"
+    # is prefixed onto EVERY subsequent grafel command, permanently — including
+    # the `doctor` call three lines below. This is the same defect install.sh
+    # already fixed with record_install_state, and the same remedy.
+    #
+    # Then register the MCP server (#6169). The script placed a binary and
+    # registered nothing, so a first-ever Windows install produced a grafel no
+    # AI coding tool could see — grafel's entire interface is the MCP server.
+    #
+    # Both are narrow by construction: they write install.json and the MCP host
+    # configs and nothing else. Running bare `grafel install` here instead
+    # would restart the daemon on a 60s budget (duplicating and racing
+    # Restart-Daemon below), append /.grafel/ to the .gitignore of whatever
+    # directory the user launched this from and write four git hooks there
+    # (#6162), and — on an interactive console, where stdin is a TTY — block on
+    # the tool-selection wizard mid-install.
+    #
+    # Best-effort, like every other post-download step: neither may abort an
+    # installer whose binary is already on disk.
+    try { & $existing install --refresh-state } catch { }
+    try { & $existing install --register-mcp } catch { }
+
     Add-ToUserPath -Dir $BinDir
 
     Write-Info ""
@@ -245,7 +282,8 @@ try {
     if ($daemonRestarted) {
         Write-Info "grafel updated and daemon restarted."
     } else {
-        Write-Info "grafel installed. Run `"grafel wizard`" to set up your first group."
+        Write-Info "grafel installed and registered with your AI coding tools."
+        Write-Info "Restart Claude Code to load the grafel MCP tools, then run `"grafel wizard`" to set up your first group."
     }
     Write-Info "(open a new terminal so PATH picks up $BinDir)"
 }

--- a/install.sh
+++ b/install.sh
@@ -213,7 +213,12 @@ wait_for_daemon_version() {
 restart_daemon() {
   os=$1
   want_version=$2
-  hint="re-run 'grafel install' or restart the daemon to finish the update"
+  # `grafel restart`, NOT `grafel install`. This hint is printed exactly when
+  # the daemon is known not to be healthy, which is the condition in which
+  # RunCopy's step-4 restart is most likely to fail — and its failure rolls step
+  # 3 back, restoring MCP host configs from snapshots (#6168). restart is the
+  # stop→verify-dead→clear-stale-socket→start sequence and touches no config.
+  hint="run 'grafel restart' to finish the update"
 
   case "$os" in
     macos)
@@ -338,6 +343,69 @@ record_install_state() {
   unset _rs_out
 }
 
+# register_mcp makes the binary we just placed reachable as an MCP server.
+#
+# This is the step the installer used to omit entirely (issue #6169). Download,
+# checksum, place, record state, doctor, restart — not one of those writes a
+# grafel entry into ~/.claude.json. The only two registration sites in the whole
+# tree are RunCopy step 3 and ApplyToolDelta, and this script reached neither.
+# On a first-ever install that left a binary on PATH that Claude Code could not
+# see at all, i.e. no product: grafel's entire interface IS the MCP server.
+#
+# The script does it rather than telling the user to run `grafel install`
+# afterwards, because it cannot establish that that command is safe at the
+# moment it would print it. `grafel install` is the seven-step RunCopy
+# transaction: step 4 restarts the daemon on a 60s budget, and its failure path
+# rolls step 3 back by restoring MCP host configs from snapshots — which on a
+# first-ever install is the absent-sentinel, i.e. DELETING the config file and
+# every foreign MCP server in it (#6168). The moments right after a binary swap
+# are exactly when that restart is most likely to fail. Steps 5 and 7 would also
+# append /.grafel/ to the .gitignore of whatever repository the user's shell
+# happened to be in and write four git hooks there (#6162).
+#
+# `--register-mcp` depends on no daemon, no network and no repository. It is a
+# surgical JSON merge that preserves every foreign server, plus the install.json
+# record without which `grafel uninstall` could never remove what we wrote. It
+# has no rollback, so it cannot be the thing that deletes a config, and it is
+# idempotent, so running it on every upgrade is free (and repairs an entry whose
+# recorded command points at a binary that moved prefix).
+#
+# Best-effort, like every other post-download step: a failure prints what it can
+# and never aborts the installer.
+register_mcp() {
+  _mcp_out="$("$BIN_DIR/grafel" install --register-mcp 2>&1 || true)"
+  if [ -n "$_mcp_out" ]; then
+    printf '%s\n' "$_mcp_out"
+  fi
+  unset _mcp_out
+}
+
+# final_message prints the closing advice for a given restart_daemon result.
+#
+# Split out of main() so it can be exercised directly — the messages here are
+# the installer's only interface once it has finished, and the previous `stale`
+# text prescribed bare `grafel install`, the one command the comment above
+# explains is unsafe. It was prescribed in precisely the branch where the daemon
+# is KNOWN not to be healthy, which is the branch where RunCopy's step-4 restart
+# is most likely to fail and take the MCP rollback with it.
+#
+# `grafel restart` is the safe equivalent: stop, verify dead, clear a stale
+# pidfile/socket, start. It touches no MCP config and no repository.
+final_message() {
+  case "$1" in
+    restarted)
+      info "grafel updated and daemon restarted (confirmed running $2)."
+      ;;
+    stale)
+      info "grafel installed, but the daemon is still running the old version — run 'grafel restart' to finish."
+      ;;
+    *)
+      info "grafel installed and registered with your AI coding tools."
+      info "Restart Claude Code to load the grafel MCP tools, then run \"grafel wizard\" to set up your first group."
+      ;;
+  esac
+}
+
 configure_path() {
   shell_name=""
   if [ -n "${SHELL:-}" ]; then
@@ -409,6 +477,10 @@ main() {
   # installer stops printing the stale-checksum warning it caused itself.
   record_install_state
 
+  # Finish the install: without this the binary is on PATH and invisible to
+  # every AI coding tool on the machine (#6169).
+  register_mcp
+
   configure_path
 
   info ""
@@ -426,17 +498,7 @@ main() {
   daemon_restarted=$(restart_daemon "$os" "$version_no_v" || true)
 
   info ""
-  case "$daemon_restarted" in
-    restarted)
-      info "grafel updated and daemon restarted (confirmed running $version_no_v)."
-      ;;
-    stale)
-      info "grafel installed, but the daemon still running the old version — run 'grafel install' to finish."
-      ;;
-    *)
-      info "grafel installed. Run \"grafel wizard\" to set up your first group."
-      ;;
-  esac
+  final_message "$daemon_restarted" "$version_no_v"
   info "(restart your shell or 'source' your rc file so PATH picks up $BIN_DIR)"
 }
 

--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -93,6 +93,7 @@ func newInstallCmd() *cobra.Command {
 	var noWizard bool
 	var assumeYes bool
 	var refreshState bool
+	var registerMCPOnly bool
 
 	cmd := &cobra.Command{
 		Use:   "install",
@@ -146,6 +147,27 @@ Claude Code config directory's skills/ subdirectory.`,
 						"(run 'grafel install' on its own for a full install)", strings.Join(conflicts, ", "))
 				}
 				return runRefreshState(out)
+			}
+
+			// ── --register-mcp: write the MCP entry, nothing else (#6169) ──
+			// Handled in the same position and for the same reason as
+			// --refresh-state, one flag above: AHEAD of resolveToolSelection
+			// (whose TTY branch opens an interactive wizard that would block a
+			// `curl … | bash` install mid-run) and ahead of RunCopy (which
+			// restarts the daemon, appends /.grafel/ to the caller's
+			// .gitignore, and writes four git hooks into a repository the
+			// installer was never told about).
+			//
+			// This is the step install.sh was missing entirely: it placed the
+			// binary and never registered the MCP server, so a first-ever curl
+			// install produced a grafel that Claude Code could not see at all.
+			// See internal/install/registermcp.go for the full argument.
+			if registerMCPOnly {
+				if conflicts := conflictingRegisterMCPFlags(cmd); len(conflicts) > 0 {
+					return fmt.Errorf("--register-mcp only writes the grafel MCP entry into the detected host configs; it cannot be combined with %s "+
+						"(run 'grafel install' on its own for a full install)", strings.Join(conflicts, ", "))
+				}
+				return runRegisterMCP(out, claudeConfigDirs)
 			}
 
 			// ── per-tool selection (#5256) ─────────────────────────────────
@@ -317,23 +339,100 @@ Claude Code config directory's skills/ subdirectory.`,
 	// nothing else. Not a full install — see internal/install/refreshstate.go.
 	cmd.Flags().BoolVar(&refreshState, "refresh-state", false,
 		"only re-record this binary's path and checksum in ~/.grafel/install.json (no daemon restart, no skills, no MCP, no git changes); used by the curl installer after an in-place upgrade")
+	// Curl-installer support (#6169): register the MCP server and do nothing
+	// else. Not a full install — see internal/install/registermcp.go.
+	cmd.Flags().BoolVar(&registerMCPOnly, "register-mcp", false,
+		"only register this binary as the grafel MCP server in the detected host configs, recording it in ~/.grafel/install.json and a timestamped pre-change copy of each config under ~/.grafel/backups/mcpreg/ (no daemon restart, no skills, no git changes); used by the installers to finish a first-ever install")
 	return cmd
 }
 
-// conflictingRefreshStateFlags returns the names of any explicitly-set install
-// flags that --refresh-state cannot honour. Only flags the user actually typed
-// count (Changed), so the --copy default of true is not a conflict.
-func conflictingRefreshStateFlags(cmd *cobra.Command) []string {
+// refreshStateOnlyFlags is the set of install flags that ask for work neither
+// --refresh-state nor --register-mcp performs. Shared so the two narrow modes
+// cannot drift apart as flags are added.
+var refreshStateOnlyFlags = []string{
+	"foreground", "claude-config-dirs", "skills-source-dir", "skip-skill-link",
+	"mode", "copy", "dev", "force", "no-hooks", "tools", "no-wizard", "yes",
+}
+
+// conflictingFlags returns the names of the given flags the user explicitly
+// typed. Only flags with Changed set count, so the --copy default of true is
+// not a conflict.
+func conflictingFlags(cmd *cobra.Command, names []string) []string {
 	var conflicts []string
-	for _, name := range []string{
-		"foreground", "claude-config-dirs", "skills-source-dir", "skip-skill-link",
-		"mode", "copy", "dev", "force", "no-hooks", "tools", "no-wizard", "yes",
-	} {
+	for _, name := range names {
 		if f := cmd.Flags().Lookup(name); f != nil && f.Changed {
 			conflicts = append(conflicts, "--"+name)
 		}
 	}
 	return conflicts
+}
+
+// conflictingRefreshStateFlags returns the names of any explicitly-set install
+// flags that --refresh-state cannot honour.
+//
+// --register-mcp is included: --refresh-state records a checksum and registers
+// nothing, so honouring only the former for a user who asked for both would
+// report an install that did not happen.
+func conflictingRefreshStateFlags(cmd *cobra.Command) []string {
+	return conflictingFlags(cmd, append(append([]string(nil), refreshStateOnlyFlags...), "register-mcp"))
+}
+
+// conflictingRegisterMCPFlags returns the names of any explicitly-set install
+// flags that --register-mcp cannot honour.
+//
+// --claude-config-dirs is the one exception and is deliberately absent from the
+// list: it names the host configs to write, which is precisely what this mode
+// does.
+//
+// --refresh-state is NOT listed, and that is not an oversight: the
+// --refresh-state branch is evaluated first in RunE, so `--register-mcp
+// --refresh-state` never reaches this function — conflictingRefreshStateFlags
+// rejects it, and that rejection is what TestInstallRefreshState_RejectsRegisterMCP
+// pins. Listing it here would be unreachable code that reads like a guard.
+func conflictingRegisterMCPFlags(cmd *cobra.Command) []string {
+	var names []string
+	for _, n := range refreshStateOnlyFlags {
+		if n == "claude-config-dirs" {
+			continue
+		}
+		names = append(names, n)
+	}
+	return conflictingFlags(cmd, names)
+}
+
+// runRegisterMCP executes the narrow MCP registration and prints a summary.
+//
+// A host that could not be written is reported and the command still succeeds:
+// the installer calls this best-effort, and one unwritable config is not a
+// reason to fail an install whose other hosts are now working. An error is
+// returned only when nothing could be done at all.
+func runRegisterMCP(out io.Writer, claudeConfigDirs []string) error {
+	bin, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary path: %w", err)
+	}
+	res, err := install.RegisterMCP(install.RegisterMCPOptions{
+		BinPath:          bin,
+		ClaudeConfigDirs: claudeConfigDirs,
+	})
+	if err != nil {
+		return err
+	}
+	for _, f := range res.Failed {
+		fmt.Fprintf(out, "  ⚠ MCP register %s: %v\n", f.Path, f.Err)
+	}
+	if len(res.Registered) == 0 {
+		// Not an error: a machine with no MCP host installed is a legitimate
+		// state (server, CI runner). Say so plainly instead of claiming success.
+		fmt.Fprintln(out, "no MCP host configs detected — nothing to register")
+		return nil
+	}
+	fmt.Fprintf(out, "✓ grafel MCP registered in:\n")
+	for _, p := range res.Registered {
+		fmt.Fprintf(out, "    %s\n", p)
+	}
+	fmt.Fprintln(out, "  Restart Claude Code to load the grafel MCP tools.")
+	return nil
 }
 
 // runRefreshState executes the narrow install.json CLI-record refresh and

--- a/internal/cli/install_registermcp_6169_test.go
+++ b/internal/cli/install_registermcp_6169_test.go
@@ -1,0 +1,194 @@
+// install_registermcp_6169_test.go covers `grafel install --register-mcp` at
+// the CLI boundary.
+//
+// The flag exists so install.sh can finish a first-ever install (#6169) without
+// running `grafel install` proper. That makes the short-circuit — placing the
+// flag AHEAD of resolveToolSelection and of the whole RunCopy transaction — the
+// safety property, exactly as it is for --refresh-state:
+//
+//   - resolveToolSelection consults stdinIsTTY() and opens an interactive
+//     wizard, which would block a curl|bash install mid-run;
+//   - RunCopy step 5 appends /.grafel/ to the .gitignore of the caller's cwd
+//     and step 7 writes four git hooks there — a repository the installer was
+//     never told about (#6162);
+//   - RunCopy step 4 restarts the daemon on a 60s budget and its failure path
+//     rolls step 3 back, restoring MCP host configs from snapshots (#6168).
+//
+// A regression that let --register-mcp fall through would put all of that back
+// into the curl installer, so it is asserted here rather than assumed.
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/install"
+)
+
+// runInstallRegisterMCP executes `install --register-mcp` (plus extraArgs)
+// against a fresh command tree and returns its output and error.
+func runInstallRegisterMCP(t *testing.T, extraArgs ...string) (string, error) {
+	t.Helper()
+	var buf bytes.Buffer
+	cmd := newInstallCmd()
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+	cmd.SetArgs(append([]string{"--register-mcp"}, extraArgs...))
+	err := cmd.Execute()
+	return buf.String(), err
+}
+
+// TestInstallRegisterMCP_RegistersAndRecordsOnAVirginMachine is #6169 at the
+// CLI boundary: no install.json, no .claude.json, and afterwards both exist.
+func TestInstallRegisterMCP_RegistersAndRecordsOnAVirginMachine(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := filepath.Join(home, ".claude.json")
+	statePath := filepath.Join(home, ".grafel", "install.json")
+
+	out, err := runInstallRegisterMCP(t, "--claude-config-dirs", cfg)
+	if err != nil {
+		t.Fatalf("install --register-mcp: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, cfg) {
+		t.Errorf("output does not name the config it wrote: %q", out)
+	}
+
+	raw, rerr := os.ReadFile(cfg)
+	if rerr != nil {
+		t.Fatalf("config was not written: %v", rerr)
+	}
+	var doc map[string]any
+	if uerr := json.Unmarshal(raw, &doc); uerr != nil {
+		t.Fatalf("unmarshal config: %v", uerr)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["grafel"]; !ok {
+		t.Fatalf("no grafel MCP entry written: %s", raw)
+	}
+
+	st, serr := install.ReadState(statePath)
+	if serr != nil || st == nil {
+		t.Fatalf("install.json not recorded: st=%v err=%v", st, serr)
+	}
+	found := false
+	for _, p := range st.MCP.RegisteredPaths {
+		if p == cfg {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("MCP.RegisteredPaths = %v, want to contain %s", st.MCP.RegisteredPaths, cfg)
+	}
+}
+
+// TestInstallRegisterMCP_DoesNotTouchTheCallersRepo is the reason the flag
+// exists at all. The curl installer runs from whatever directory the user's
+// shell was in; `grafel install` would append to that repo's .gitignore and
+// install four git hooks in it.
+func TestInstallRegisterMCP_DoesNotTouchTheCallersRepo(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	repo := t.TempDir()
+	gitDir := filepath.Join(repo, ".git")
+	if err := os.MkdirAll(filepath.Join(gitDir, "hooks"), 0o755); err != nil {
+		t.Fatalf("mkdir .git/hooks: %v", err)
+	}
+	gitignore := filepath.Join(repo, ".gitignore")
+	const original = "node_modules/\n"
+	if err := os.WriteFile(gitignore, []byte(original), 0o644); err != nil {
+		t.Fatalf("seed .gitignore: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(repo); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prevWD) })
+
+	if out, rerr := runInstallRegisterMCP(t, "--claude-config-dirs", filepath.Join(home, ".claude.json")); rerr != nil {
+		t.Fatalf("install --register-mcp: %v (out=%q)", rerr, out)
+	}
+
+	got, rerr := os.ReadFile(gitignore)
+	if rerr != nil {
+		t.Fatalf("read .gitignore: %v", rerr)
+	}
+	if string(got) != original {
+		t.Errorf(".gitignore was modified:\n got: %q\nwant: %q", got, original)
+	}
+	entries, rerr := os.ReadDir(filepath.Join(gitDir, "hooks"))
+	if rerr != nil {
+		t.Fatalf("read hooks dir: %v", rerr)
+	}
+	if len(entries) != 0 {
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		t.Errorf("git hooks were installed into the caller's repo: %v", names)
+	}
+}
+
+// TestInstallRegisterMCP_RejectsCombinedFlags: every other install flag asks
+// for work --register-mcp explicitly does not do. Silently ignoring them would
+// let a user believe they got a full install.
+func TestInstallRegisterMCP_RejectsCombinedFlags(t *testing.T) {
+	for _, flag := range []string{"--no-hooks", "--force", "--dev", "--tools=claude", "--refresh-state", "--foreground"} {
+		t.Run(flag, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			out, err := runInstallRegisterMCP(t, flag)
+			if err == nil {
+				t.Fatalf("expected --register-mcp %s to be rejected; out=%q", flag, out)
+			}
+			if !strings.Contains(err.Error(), "--register-mcp") {
+				t.Errorf("error should name the flag that limited the operation: %v", err)
+			}
+		})
+	}
+}
+
+// TestInstallRegisterMCP_AcceptsClaudeConfigDirs: the one flag that IS
+// meaningful here. If it were rejected the installer could not be tested
+// hermetically and a multi-profile user could not target their configs.
+func TestInstallRegisterMCP_AcceptsClaudeConfigDirs(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	a := filepath.Join(home, "a", ".claude.json")
+	b := filepath.Join(home, "b", ".claude.json")
+
+	out, err := runInstallRegisterMCP(t, "--claude-config-dirs", a+","+b)
+	if err != nil {
+		t.Fatalf("install --register-mcp --claude-config-dirs: %v (out=%q)", err, out)
+	}
+	for _, p := range []string{a, b} {
+		if _, serr := os.Stat(p); serr != nil {
+			t.Errorf("%s was not registered: %v", p, serr)
+		}
+	}
+}
+
+// TestInstallRefreshState_RejectsRegisterMCP: the reverse guard. --refresh-state
+// records a checksum and registers nothing; a user who asked for both and got
+// only the former would be told, in effect, that MCP was registered.
+func TestInstallRefreshState_RejectsRegisterMCP(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	out, err := runInstallRefreshState(t, "--register-mcp")
+	if err == nil {
+		t.Fatalf("expected --refresh-state --register-mcp to be rejected; out=%q", out)
+	}
+	if !strings.Contains(err.Error(), "--register-mcp") {
+		t.Errorf("error should name --register-mcp: %v", err)
+	}
+}

--- a/internal/install/installsh_registermcp_6169_test.go
+++ b/internal/install/installsh_registermcp_6169_test.go
@@ -1,0 +1,190 @@
+// installsh_registermcp_6169_test.go pins the installer half of #6169.
+//
+// install.sh downloaded, verified, placed the binary, refreshed install.json,
+// ran doctor and restarted the daemon — and never registered the MCP server.
+// The only two registration sites in the tree are RunCopy step 3 and
+// ApplyToolDelta, and this script reached neither, so a first-ever curl install
+// left a binary on PATH that Claude Code could not see. It then told the user
+// to "run `grafel wizard`", which registers no MCP server either.
+//
+// These tests SOURCE install.sh as a library (GRAFEL_INSTALL_SH_LIB=1) against
+// a fake binary on a temp PREFIX and a temp HOME, and call the real functions —
+// so they verify runtime behaviour, not the presence of a substring. Nothing
+// here touches the real ~/.grafel or the real ~/.claude.json.
+package install
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sourceInstallSh runs `snippet` with install.sh sourced as a library, a fake
+// grafel on a temp BIN_DIR that logs its args to $GRAFEL_ARG_LOG, and HOME
+// pointed at a temp dir. Returns the arg log and the combined output.
+func sourceInstallSh(t *testing.T, binScript, snippet string) (argLog, combined string, err error) {
+	t.Helper()
+	bash, lookErr := exec.LookPath("bash")
+	if lookErr != nil {
+		t.Skip("bash not available; skipping install.sh runtime test")
+	}
+
+	fakeHome := t.TempDir()
+	fakePrefix := t.TempDir()
+	fakeBinDir := filepath.Join(fakePrefix, "bin")
+	if mkErr := os.MkdirAll(fakeBinDir, 0o755); mkErr != nil {
+		t.Fatalf("mkdir fake bin dir: %v", mkErr)
+	}
+	writeExecutable(t, fakeBinDir, "grafel", binScript)
+
+	logPath := filepath.Join(t.TempDir(), "grafel-args.log")
+
+	script := `set -eu; GRAFEL_INSTALL_SH_LIB=1 . "$1"; ` + snippet
+	cmd := exec.Command(bash, "-c", script, "bash", installShPath(t))
+	cmd.Env = append(os.Environ(),
+		"HOME="+fakeHome,
+		"GRAFEL_PREFIX="+fakePrefix,
+		"GRAFEL_ARG_LOG="+logPath,
+	)
+	out, runErr := cmd.CombinedOutput()
+
+	data, readErr := os.ReadFile(logPath)
+	if readErr != nil && !os.IsNotExist(readErr) {
+		t.Fatalf("read arg log: %v", readErr)
+	}
+	return string(data), string(out), runErr
+}
+
+// TestInstallSh_RegistersMCPWithTheNarrowFlag is #6169 itself: the installer
+// must actually perform the registration, and must do it with --register-mcp
+// rather than the full transaction.
+func TestInstallSh_RegistersMCPWithTheNarrowFlag(t *testing.T) {
+	argLog, out, err := sourceInstallSh(t, fakeGrafelArgLogScript, "register_mcp")
+	if err != nil {
+		t.Fatalf("register_mcp failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(argLog, "install --register-mcp") {
+		t.Fatalf("install.sh never registered MCP; grafel was invoked as: %q", argLog)
+	}
+	// A bare `install` line would be the seven-step RunCopy transaction: daemon
+	// restart, .gitignore append and four git hooks in the caller's cwd.
+	for _, line := range strings.Split(strings.TrimSpace(argLog), "\n") {
+		if strings.TrimSpace(line) == "install" {
+			t.Errorf("install.sh ran the full `grafel install` transaction: %q", argLog)
+		}
+	}
+}
+
+// TestInstallSh_RegisterMCPIsBestEffort: every post-download step in this
+// script is best-effort. A host config that cannot be written must not abort an
+// install whose binary is already on disk.
+func TestInstallSh_RegisterMCPIsBestEffort(t *testing.T) {
+	argLog, out, err := sourceInstallSh(t, fakeGrafelArgLogFailScript, "register_mcp")
+	if err != nil {
+		t.Fatalf("a failing registration must not abort the installer: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(argLog, "install --register-mcp") {
+		t.Errorf("registration was not attempted: %q", argLog)
+	}
+}
+
+// TestInstallSh_RegisterMCPReportsWhatItDid: this is the step that makes the
+// product usable, and it is invisible in the doctor output that follows. If the
+// installer swallowed it the user would have no way to tell a registration that
+// worked from one that silently did nothing — which is how #6169 survived.
+func TestInstallSh_RegisterMCPReportsWhatItDid(t *testing.T) {
+	const speaks = `#!/usr/bin/env bash
+echo "$@" >> "$GRAFEL_ARG_LOG"
+echo "GRAFEL MCP REGISTERED IN: /somewhere/.claude.json"
+exit 0
+`
+	_, out, err := sourceInstallSh(t, speaks, "register_mcp")
+	if err != nil {
+		t.Fatalf("register_mcp failed: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "GRAFEL MCP REGISTERED IN: /somewhere/.claude.json") {
+		t.Errorf("registration output was swallowed: %q", out)
+	}
+}
+
+// TestInstallSh_FinalMessageNeverPrescribesBareInstall.
+//
+// The closing advice is the installer's only interface once it has finished,
+// and it has to be safe to follow at the moment it is printed. Bare `grafel
+// install` is not: it is RunCopy, whose step-4 daemon restart failing rolls
+// step 3 back and restores MCP host configs from snapshots — deleting the file
+// and every foreign server in it on a first-ever install (#6168) — and whose
+// steps 5 and 7 write to whatever repository the caller's shell was in (#6162).
+//
+// The `stale` branch prescribed exactly that, in the one branch where the
+// daemon is KNOWN not to have picked up the new binary, i.e. where the step-4
+// restart is most likely to fail.
+func TestInstallSh_FinalMessageNeverPrescribesBareInstall(t *testing.T) {
+	for _, status := range []string{"restarted", "stale", "", "anything-else"} {
+		name := status
+		if name == "" {
+			name = "empty"
+		}
+		t.Run(name, func(t *testing.T) {
+			_, out, err := sourceInstallSh(t, fakeGrafelArgLogScript,
+				"final_message '"+status+"' 1.2.3")
+			if err != nil {
+				t.Fatalf("final_message %q: %v (out=%q)", status, err, out)
+			}
+			if out == "" {
+				t.Fatalf("final_message %q printed nothing", status)
+			}
+			// Match the QUOTED command form the installer uses to prescribe a
+			// next step ("run 'grafel install' to finish"), not the bare
+			// substring — "grafel installed" contains the latter and is not a
+			// prescription. Every flagged form here is a bare invocation:
+			// `grafel install --register-mcp` never appears inside quotes in
+			// user-facing advice.
+			for _, form := range []string{"'grafel install'", `"grafel install"`} {
+				if strings.Contains(out, form) {
+					t.Errorf("final_message %q prescribes bare %s, which is "+
+						"unsafe to run at this point: %q", status, form, out)
+				}
+			}
+		})
+	}
+}
+
+// TestInstallSh_StaleDaemonGetsTheSafeRemedy: it is not enough to drop the
+// unsafe advice — the stale branch describes a real problem (the daemon is
+// running the previous binary) and must still say how to fix it.
+func TestInstallSh_StaleDaemonGetsTheSafeRemedy(t *testing.T) {
+	_, out, err := sourceInstallSh(t, fakeGrafelArgLogScript, "final_message 'stale' 1.2.3")
+	if err != nil {
+		t.Fatalf("final_message stale: %v (out=%q)", err, out)
+	}
+	if !strings.Contains(out, "grafel restart") {
+		t.Errorf("the stale branch offers no remedy: %q", out)
+	}
+}
+
+// TestInstallSh_MainRegistersMCPBeforeReportingSuccess: register_mcp existing is
+// not the fix — main() calling it is. This asserts the wiring by grepping the
+// script for the call site inside main, which is the one property a runtime
+// test of the helper alone cannot reach (main() downloads from the network).
+func TestInstallSh_MainRegistersMCPBeforeReportingSuccess(t *testing.T) {
+	src := installShSource(t)
+	mainIdx := strings.Index(src, "\nmain() {")
+	if mainIdx < 0 {
+		t.Fatal("could not locate main() in install.sh")
+	}
+	body := src[mainIdx:]
+	callIdx := strings.Index(body, "\n  register_mcp\n")
+	if callIdx < 0 {
+		t.Fatalf("main() never calls register_mcp; the helper is dead code")
+	}
+	finalIdx := strings.Index(body, "final_message")
+	if finalIdx < 0 {
+		t.Fatal("could not locate the closing message in main()")
+	}
+	if callIdx > finalIdx {
+		t.Errorf("register_mcp is called after the success message is printed")
+	}
+}

--- a/internal/install/installwindows_6163_test.go
+++ b/internal/install/installwindows_6163_test.go
@@ -1,0 +1,546 @@
+// installwindows_6163_test.go covers the two Windows installers (#6163).
+//
+// ── HONESTY NOTE — read this before trusting anything below ──────────────────
+//
+// These are STATIC assertions over the text of install.bat and install.ps1.
+// Neither script has been executed, here or anywhere: this repository has no
+// Windows host and no cmd.exe/pwsh in CI, and the same is true of the machine
+// the fix was written on. What follows can prove that the dangerous command is
+// gone and the narrow ones are present and correctly ordered. It CANNOT prove
+// that either script runs — batch quoting, PowerShell parameter binding and the
+// behaviour of `& $exe` with arguments are unverified by this file.
+//
+// That is the same limitation installscript_version_test.go already operates
+// under (it models install.bat's string transforms rather than running them),
+// and it is stated here rather than left implicit because an unstated "known
+// limit" is what let a darwin-only build failure sit on main for two weeks.
+//
+// ── Why these tests parse rather than grep ──────────────────────────────────
+//
+// The first version of this file scanned raw script text with strings.Contains
+// and keyed the dangerous-command guard on the literal `grafel.exe" install` —
+// closing quote included. Review found it worthless in both directions:
+//
+//	B1: every install.bat assertion passed on a script whose real command lines
+//	    had been replaced by `REM` prose containing the same words. The tests
+//	    could not tell a comment from code, and since the script is never
+//	    executed anywhere they were the ONLY evidence the remedy was present.
+//	B2: the guard was defeated by re-quoting. `%BINDIR%\grafel.exe install`
+//	    (unquoted — the most natural alternative spelling of the exact bug) and
+//	    `set "G=…\grafel.exe"` + `"%G%" install` both passed.
+//
+// So the scripts are now reduced to a line model that strips comments and
+// blanks quoted spans, and `install` is matched as a TOKEN on those lines
+// rather than as a quoting-specific prefix. The model itself is tested against
+// synthetic fixtures below (TestScriptLineModel_*), because a guard whose
+// parser is wrong is indistinguishable from no guard.
+//
+// ── The two defects ─────────────────────────────────────────────────────────
+//
+// install.bat ran bare `grafel.exe install` — the full seven-step RunCopy
+// transaction — from whatever directory the console happened to be in. That
+// appends /.grafel/ to that directory's .gitignore and writes four git hooks
+// there (a repository the user never named, #6162), rewrites every detected
+// .claude.json with a step-4 daemon restart on a 60s budget behind it, and,
+// because a .bat is run interactively from a console, hits stdinIsTTY() in
+// resolveToolSelection and BLOCKS on the tool-selection wizard mid-install.
+//
+// install.ps1 had the opposite defect: it wrote no install.json at all. It
+// copies the new .exe over the old one and runs `doctor`; RunQuickDoctor
+// compares state.CLI.SHA256 against the binary at state.CLI.Path, so after
+// every upgrade the recorded SHA is the previous binary's and every grafel
+// command permanently prints "binary updated since last install". Its restart
+// hint compounded that by prescribing `grafel install` — the command the other
+// half of this issue is about.
+package install
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Script line model
+// ─────────────────────────────────────────────────────────────────────────────
+
+// scriptLang selects the comment syntax.
+type scriptLang int
+
+const (
+	langBat scriptLang = iota
+	langPs1
+)
+
+// scriptLine is one source line reduced to its executable content.
+type scriptLine struct {
+	// N is the 1-based line number, for error messages that a human can act on.
+	N int
+	// Raw is the original text.
+	Raw string
+	// Code is Raw with comments removed and every quoted span blanked to
+	// spaces. Blanking rather than deleting keeps token boundaries intact, so
+	// `"%BINDIR%\grafel.exe" install` still yields the token `install` while
+	// `"…grafel install…"` inside a string yields nothing.
+	Code string
+}
+
+// Fields returns the whitespace-separated tokens of the executable content.
+func (l scriptLine) Fields() []string { return strings.Fields(l.Code) }
+
+// blankQuoted replaces the contents of every quoted span — and the quote
+// characters themselves — with spaces.
+//
+// Both cmd.exe and PowerShell treat "…" as a quoted span; PowerShell also has
+// '…' and a backtick escape. Over-blanking is the safe direction for these
+// tests: it can only hide a token from the guard if that token is inside
+// quotes, which for `install` means it is prose, not a command.
+func blankQuoted(s string, lang scriptLang) string {
+	out := []rune(s)
+	var quote rune
+	runes := []rune(s)
+	for i := 0; i < len(runes); i++ {
+		c := runes[i]
+		if lang == langPs1 && c == '`' && i+1 < len(runes) {
+			// Backtick escapes the next character; neither can open or close a
+			// span. Blank both so an escaped quote cannot flip the state.
+			out[i] = ' '
+			out[i+1] = ' '
+			i++
+			continue
+		}
+		switch {
+		case quote != 0:
+			closing := c == quote
+			out[i] = ' '
+			if closing {
+				quote = 0
+			}
+		case c == '"' || (lang == langPs1 && c == '\''):
+			quote = c
+			out[i] = ' '
+		}
+	}
+	return string(out)
+}
+
+// outputVerbs are commands whose remaining arguments are text printed to the
+// user, not a command to run. cmd.exe's `echo` does not quote its argument, so
+// without this `echo install failed.` and `if exist … echo   upgrading existing
+// install at …` both read as invocations of `install`.
+var outputVerbs = map[string]bool{
+	"echo": true, "@echo": true,
+	"write-info": true, "write-host": true, "write-output": true,
+	"write-error": true, "write-warning": true,
+}
+
+// segmentSeparators split one source line into independently-executed commands.
+// Truncating a whole line at `echo` would otherwise hide a real invocation
+// chained after it (`echo hi & grafel.exe install`), so the truncation is
+// applied per segment rather than per line.
+func segmentSeparators(lang scriptLang) []string {
+	if lang == langPs1 {
+		return []string{";", "|"}
+	}
+	return []string{"&&", "||", "&", "|"}
+}
+
+// truncateAtOutputVerb drops everything from the first output verb onwards.
+func truncateAtOutputVerb(code string) string {
+	offset := 0
+	rest := code
+	for {
+		trimmedLen := len(rest) - len(strings.TrimLeft(rest, " \t"))
+		rest = rest[trimmedLen:]
+		offset += trimmedLen
+		if rest == "" {
+			return code
+		}
+		tokLen := len(rest)
+		if i := strings.IndexAny(rest, " \t"); i >= 0 {
+			tokLen = i
+		}
+		if outputVerbs[strings.ToLower(rest[:tokLen])] {
+			return code[:offset]
+		}
+		rest = rest[tokLen:]
+		offset += tokLen
+	}
+}
+
+// scriptLines reduces a script to its executable command segments. One source
+// line can yield several segments; each keeps the source line number so a
+// failure message points at something a human can open.
+func scriptLines(src string, lang scriptLang) []scriptLine {
+	var out []scriptLine
+	for i, raw := range strings.Split(src, "\n") {
+		trimmed := strings.TrimSpace(raw)
+		code := trimmed
+
+		if lang == langBat {
+			upper := strings.ToUpper(trimmed)
+			// `REM comment`, a bare `REM`, and the `::` label-comment form.
+			if upper == "REM" || strings.HasPrefix(upper, "REM ") || strings.HasPrefix(trimmed, "::") {
+				code = ""
+			}
+		}
+
+		code = blankQuoted(code, lang)
+
+		if lang == langPs1 {
+			// A '#' that survived quote-blanking starts a real comment.
+			if idx := strings.Index(code, "#"); idx >= 0 {
+				code = code[:idx]
+			}
+		}
+
+		// Split into independently-executed segments, then drop each segment's
+		// printed text.
+		seps := segmentSeparators(lang)
+		parts := []string{code}
+		for _, sep := range seps {
+			var next []string
+			for _, p := range parts {
+				next = append(next, strings.Split(p, sep)...)
+			}
+			parts = next
+		}
+		for _, p := range parts {
+			out = append(out, scriptLine{N: i + 1, Raw: trimmed, Code: truncateAtOutputVerb(p)})
+		}
+	}
+	return out
+}
+
+// installInvocations returns every executable line carrying `install` as a
+// standalone token, paired with the flag that follows it ("" when there is
+// none). This is the set of lines that actually run `grafel install`, however
+// the binary happens to be spelled or quoted.
+func installInvocations(lines []scriptLine) []scriptLine {
+	var out []scriptLine
+	for _, l := range lines {
+		for _, f := range l.Fields() {
+			if f == "install" {
+				out = append(out, l)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// installFlag returns the token immediately after `install` on a line, or "".
+func installFlag(l scriptLine) string {
+	fields := l.Fields()
+	for i, f := range fields {
+		if f != "install" {
+			continue
+		}
+		if i+1 < len(fields) {
+			return fields[i+1]
+		}
+		return ""
+	}
+	return ""
+}
+
+// bareInstallInvocations returns the lines that run `grafel install` with no
+// flag after it — i.e. the full RunCopy transaction.
+func bareInstallInvocations(lines []scriptLine) []scriptLine {
+	var out []scriptLine
+	for _, l := range installInvocations(lines) {
+		if flag := installFlag(l); flag == "" || !strings.HasPrefix(flag, "--") {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+// installFlagsUsed returns the set of flags passed to `install` across a script.
+func installFlagsUsed(lines []scriptLine) map[string]scriptLine {
+	out := map[string]scriptLine{}
+	for _, l := range installInvocations(lines) {
+		if flag := installFlag(l); strings.HasPrefix(flag, "--") {
+			out[flag] = l
+		}
+	}
+	return out
+}
+
+// repoRootFile reads a file at the repository root.
+func repoRootFile(t *testing.T, name string) string {
+	t.Helper()
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve test file path")
+	}
+	path := filepath.Join(filepath.Dir(thisFile), "..", "..", name)
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", name, err)
+	}
+	return string(raw)
+}
+
+func batLines(t *testing.T) []scriptLine {
+	t.Helper()
+	return scriptLines(repoRootFile(t, "install.bat"), langBat)
+}
+
+func ps1Lines(t *testing.T) []scriptLine {
+	t.Helper()
+	return scriptLines(repoRootFile(t, "install.ps1"), langPs1)
+}
+
+// firstLineWith returns the line number of the first executable line whose Code
+// contains sub, or -1.
+func firstLineWith(lines []scriptLine, sub string) int {
+	for _, l := range lines {
+		if strings.Contains(l.Code, sub) {
+			return l.N
+		}
+	}
+	return -1
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Guard the guard: the line model must actually distinguish code from prose.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestScriptLineModel_IgnoresComments is the direct answer to review finding
+// B1. Replacing install.bat's two real command lines with `REM` prose
+// containing the same words left every assertion in the previous version of
+// this file green.
+func TestScriptLineModel_IgnoresComments(t *testing.T) {
+	const bat = `@echo off
+REM "%BINDIR%\grafel.exe" install --refresh-state
+:: "%BINDIR%\grafel.exe" install --register-mcp
+rem %BINDIR%\grafel.exe install
+echo Done.
+`
+	lines := scriptLines(bat, langBat)
+	if got := installInvocations(lines); len(got) != 0 {
+		t.Errorf("commented-out commands were collected as invocations: %+v", got)
+	}
+	if got := bareInstallInvocations(lines); len(got) != 0 {
+		t.Errorf("a commented-out bare install was flagged: %+v", got)
+	}
+
+	const ps1 = `# & $existing install --refresh-state
+Write-Info "run 'grafel install' if this fails"   # & $existing install
+$msg = "grafel install"
+Write-Host grafel.exe install
+`
+	pl := scriptLines(ps1, langPs1)
+	if got := installInvocations(pl); len(got) != 0 {
+		t.Errorf("ps1 comments/strings were collected as invocations: %+v", got)
+	}
+}
+
+// TestScriptLineModel_CatchesEveryBareSpelling is review finding B2. Each of
+// these is a real, natural way to reintroduce the bug that the old
+// literal-prefix guard let through.
+func TestScriptLineModel_CatchesEveryBareSpelling(t *testing.T) {
+	batCases := map[string]string{
+		"quoted":            `"%BINDIR%\grafel.exe" install`,
+		"unquoted":          `%BINDIR%\grafel.exe install`,
+		"via variable":      `"%G%" install`,
+		"call prefix":       `call "%BINDIR%\grafel.exe" install`,
+		"trailing redirect": `"%BINDIR%\grafel.exe" install >nul`,
+		// Chained after printed text: truncating the whole line at `echo`
+		// would hide this, which is why the truncation is per segment.
+		"chained after echo": `echo installing… & "%BINDIR%\grafel.exe" install`,
+	}
+	for name, line := range batCases {
+		t.Run("bat/"+name, func(t *testing.T) {
+			lines := scriptLines(line+"\n", langBat)
+			if got := bareInstallInvocations(lines); len(got) != 1 {
+				t.Errorf("bare install not detected in %q (got %d)", line, len(got))
+			}
+		})
+	}
+
+	ps1Cases := map[string]string{
+		"variable":  `& $existing install`,
+		"quoted":    `& "$BinDir\grafel.exe" install`,
+		"bare path": `& $BinDir\grafel.exe install`,
+		"amp-less":  `$existing install`,
+	}
+	for name, line := range ps1Cases {
+		t.Run("ps1/"+name, func(t *testing.T) {
+			lines := scriptLines(line+"\n", langPs1)
+			if got := bareInstallInvocations(lines); len(got) != 1 {
+				t.Errorf("bare install not detected in %q (got %d)", line, len(got))
+			}
+		})
+	}
+}
+
+// TestScriptLineModel_AcceptsFlaggedInvocations: the guard must not fire on the
+// narrow commands, or it would be unsatisfiable and get deleted.
+func TestScriptLineModel_AcceptsFlaggedInvocations(t *testing.T) {
+	for _, line := range []string{
+		`"%BINDIR%\grafel.exe" install --refresh-state`,
+		`"%BINDIR%\grafel.exe" install --register-mcp`,
+	} {
+		lines := scriptLines(line+"\n", langBat)
+		if got := bareInstallInvocations(lines); len(got) != 0 {
+			t.Errorf("flagged invocation %q was wrongly reported as bare", line)
+		}
+		if len(installInvocations(lines)) != 1 {
+			t.Errorf("flagged invocation %q was not collected at all", line)
+		}
+	}
+	for _, line := range []string{
+		`try { & $existing install --refresh-state } catch { }`,
+		`try { & $existing install --register-mcp } catch { }`,
+	} {
+		lines := scriptLines(line+"\n", langPs1)
+		if got := bareInstallInvocations(lines); len(got) != 0 {
+			t.Errorf("flagged invocation %q was wrongly reported as bare", line)
+		}
+		if len(installInvocations(lines)) != 1 {
+			t.Errorf("flagged invocation %q was not collected at all", line)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// install.bat — the dangerous half. It writes to a repository the user never
+// named and can hang, so it goes first.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestInstallBat_NeverRunsTheFullInstallTransaction is the #6163 headline.
+//
+// A bare `grafel install` from a console is the case RunCopy's IntentInstall is
+// built FOR — the user standing in the repo they mean. install.bat is the case
+// it is not: the console's cwd is wherever the user launched from, and #6162's
+// intent gate does not rescue that, because install.bat invokes IntentInstall's
+// own entrypoint.
+func TestInstallBat_NeverRunsTheFullInstallTransaction(t *testing.T) {
+	for _, l := range bareInstallInvocations(batLines(t)) {
+		t.Errorf("install.bat:%d runs the full RunCopy transaction (gitignore + git hooks "+
+			"in the console's cwd, daemon restart, and a TTY tool-selection wizard that "+
+			"blocks mid-install): %q", l.N, l.Raw)
+	}
+}
+
+// TestInstallBat_RunsTheNarrowSteps: removing the dangerous command is only
+// half the fix — install.bat still has to leave a machine on which grafel
+// works, i.e. install.json recorded and the MCP server registered.
+//
+// This reads the INVOCATION set, not the raw text: review finding B1 was that
+// the previous version passed on a script whose commands were all comments.
+func TestInstallBat_RunsTheNarrowSteps(t *testing.T) {
+	flags := installFlagsUsed(batLines(t))
+	for _, want := range []string{"--refresh-state", "--register-mcp"} {
+		if _, ok := flags[want]; !ok {
+			t.Errorf("install.bat never RUNS `grafel install %s` (found: %v)", want, flagNames(flags))
+		}
+	}
+}
+
+// TestInstallBat_RefreshStatePrecedesTheVersionReport: --refresh-state exists to
+// stop the stale-checksum warning being printed by the very installer that
+// caused it, which only works if it runs first.
+func TestInstallBat_RefreshStatePrecedesTheVersionReport(t *testing.T) {
+	lines := batLines(t)
+	flags := installFlagsUsed(lines)
+	refresh, ok := flags["--refresh-state"]
+	if !ok {
+		t.Fatal("install.bat never runs `install --refresh-state`")
+	}
+	report := firstLineWith(lines, "--version")
+	if report < 0 {
+		t.Fatal("could not locate the version report in install.bat")
+	}
+	if refresh.N > report {
+		t.Errorf("install.bat reports the version at line %d before recording the binary "+
+			"it placed at line %d", report, refresh.N)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// install.ps1 — the stale-state half. Permanent but cosmetic; no data touched.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestInstallPs1_RecordsTheBinaryItPlaced is the ps1 defect: Copy-Item then
+// doctor, with nothing in between that writes install.json.
+func TestInstallPs1_RecordsTheBinaryItPlaced(t *testing.T) {
+	lines := ps1Lines(t)
+	flags := installFlagsUsed(lines)
+	refresh, ok := flags["--refresh-state"]
+	if !ok {
+		t.Fatal("install.ps1 never records the binary it just placed; every subsequent " +
+			"grafel command will print `binary updated since last install` forever")
+	}
+	copyN := firstLineWith(lines, "Copy-Item -Path $binSrc.FullName")
+	doctorN := firstLineWith(lines, "$existing doctor")
+	if copyN < 0 || doctorN < 0 {
+		t.Fatalf("could not locate the copy/doctor sequence (copy=%d doctor=%d)", copyN, doctorN)
+	}
+	if refresh.N < copyN {
+		t.Errorf("install.ps1 records the binary at line %d before placing it at line %d", refresh.N, copyN)
+	}
+	if refresh.N > doctorN {
+		t.Errorf("install.ps1 reports doctor output at line %d before recording the binary at "+
+			"line %d, so it prints the stale-checksum warning it caused itself", doctorN, refresh.N)
+	}
+}
+
+// TestInstallPs1_RegistersMCP: the ps1 installer has the #6169 gap too — it
+// places a binary and registers nothing.
+func TestInstallPs1_RegistersMCP(t *testing.T) {
+	if _, ok := installFlagsUsed(ps1Lines(t))["--register-mcp"]; !ok {
+		t.Errorf("install.ps1 never registers the MCP server, so a first-ever Windows " +
+			"install leaves a binary no AI coding tool can see")
+	}
+}
+
+// TestInstallPs1_NeverRunsTheFullInstallTransaction: the fix for the missing
+// state must not be the dangerous command install.bat is losing.
+func TestInstallPs1_NeverRunsTheFullInstallTransaction(t *testing.T) {
+	for _, l := range bareInstallInvocations(ps1Lines(t)) {
+		t.Errorf("install.ps1:%d runs the full RunCopy transaction: %q", l.N, l.Raw)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared: no installer may prescribe bare `grafel install` as a next step.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestInstallers_NoHintPrescribesBareInstall.
+//
+// All three installers printed "re-run 'grafel install'" as their remedy for a
+// daemon that did not restart. That advice is unsafe precisely where it is
+// printed: the daemon is known to be unhealthy, so RunCopy's step-4 restart is
+// the step most likely to fail, and its failure path rolls step 3 back —
+// restoring MCP host configs from snapshots, which on a first-ever install
+// means deleting the file and every foreign server in it (#6168). `grafel
+// restart` is the safe equivalent and touches no config.
+//
+// This one DOES scan raw text on purpose: it is about prose shown to the user,
+// so a match inside a string literal or an echo is exactly what it must catch.
+func TestInstallers_NoHintPrescribesBareInstall(t *testing.T) {
+	for _, name := range []string{"install.sh", "install.ps1", "install.bat"} {
+		t.Run(name, func(t *testing.T) {
+			src := repoRootFile(t, name)
+			for _, form := range []string{"'grafel install'", `"grafel install"`} {
+				if strings.Contains(src, form) {
+					t.Errorf("%s prescribes bare %s; use 'grafel restart' for a daemon that "+
+						"did not pick up the new binary", name, form)
+				}
+			}
+		})
+	}
+}
+
+func flagNames(m map[string]scriptLine) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -596,6 +596,17 @@ func readSettings(path string) (map[string]any, error) {
 	if err := json.Unmarshal(b, &doc); err != nil {
 		return nil, fmt.Errorf("%s: %w", filepath.Base(path), err)
 	}
+	// The literal `null` is the one non-object that unmarshals into a map
+	// WITHOUT an error: encoding/json's documented behaviour is to set the map
+	// to nil and return nil. Every caller then does doc[k] = v and panics with
+	// "assignment to entry in nil map" — a Go stack trace in the middle of a
+	// `curl … | bash`. A null document carries no user data, so it is treated
+	// exactly like a zero-byte file above. Every OTHER non-object (array,
+	// string, number, bool) is a real config whose replacement would destroy
+	// something, and those still fail on the type error two lines up.
+	if doc == nil {
+		doc = map[string]any{}
+	}
 	return doc, nil
 }
 

--- a/internal/install/mcpreg/nulldoc_6163_test.go
+++ b/internal/install/mcpreg/nulldoc_6163_test.go
@@ -1,0 +1,97 @@
+// nulldoc_6163_test.go pins RegisterPath against a host config whose top-level
+// JSON value is not an object.
+//
+// readSettings does `doc := map[string]any{}` and then json.Unmarshal(b, &doc).
+// For every scalar and for `[]` that is a type error and the call fails cleanly.
+// For the literal `null` it is NOT an error: encoding/json's documented
+// behaviour for unmarshalling null into a map is to set the map to nil and
+// return no error. RegisterPath then reaches `doc["mcpServers"] = servers` and
+// panics with "assignment to entry in nil map".
+//
+// This was reachable before only through `grafel install` proper. `grafel
+// install --register-mcp` (#6169) now runs on EVERY install for EVERY user
+// straight out of the curl one-liner, so a single stray `null` in any detected
+// host config turns a `curl … | bash` into a Go panic stack. No data is lost —
+// the write never happens — but a panic is not an installer's error report.
+package mcpreg
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRegisterPath_NullDocumentDoesNotPanic is the #6163 review finding.
+func TestRegisterPath_NullDocumentDoesNotPanic(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfg, []byte("null"), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	// A panic here fails the test by crashing it; the recover exists only to
+	// turn that into a readable failure rather than a stack dump.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RegisterPath panicked on a top-level null config: %v", r)
+		}
+	}()
+
+	if _, err := RegisterPath(cfg, "/usr/local/bin/grafel"); err != nil {
+		t.Fatalf("RegisterPath on a null config: %v", err)
+	}
+
+	// A `null` document carries no user data, so treating it as empty — the
+	// same as a zero-byte file — is the honest outcome: the entry is written
+	// and nothing was destroyed (the pre-existing bytes are in the sidecar
+	// backup either way).
+	raw, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("result is not a JSON object: %v (%s)", err, raw)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers["grafel"]; !ok {
+		t.Errorf("no grafel entry written: %s", raw)
+	}
+}
+
+// TestRegisterPath_NonObjectDocumentsStillFailCleanly: `null` is the one
+// non-object that must be tolerated, because it is indistinguishable from
+// "empty" and carries nothing. A top-level array or scalar is a real config the
+// caller would be destroying, so those must keep failing — and must leave the
+// file byte-identical.
+func TestRegisterPath_NonObjectDocumentsStillFailCleanly(t *testing.T) {
+	for _, body := range []string{`[]`, `[{"mcpServers":{}}]`, `"a string"`, `42`, `true`} {
+		t.Run(body, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			cfg := filepath.Join(dir, ".claude.json")
+			if err := os.WriteFile(cfg, []byte(body), 0o644); err != nil {
+				t.Fatalf("seed config: %v", err)
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("RegisterPath panicked on %s: %v", body, r)
+				}
+			}()
+
+			if _, err := RegisterPath(cfg, "/usr/local/bin/grafel"); err == nil {
+				t.Errorf("RegisterPath silently accepted a non-object config %s", body)
+			}
+			got, err := os.ReadFile(cfg)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if string(got) != body {
+				t.Errorf("file was modified despite the error:\n got: %s\nwant: %s", got, body)
+			}
+		})
+	}
+}

--- a/internal/install/registermcp.go
+++ b/internal/install/registermcp.go
@@ -1,0 +1,278 @@
+package install
+
+// registermcp.go implements the narrow "make this binary reachable as an MCP
+// server" operation behind `grafel install --register-mcp`.
+//
+// ── The gap it closes (#6169) ────────────────────────────────────────────────
+//
+// install.sh downloads the archive, verifies the checksum, places the binary
+// with `install -m 0755`, then runs `grafel install --refresh-state`, `grafel
+// doctor` and its own daemon restart. None of those registers the MCP server:
+// --refresh-state deliberately touches only install.json (and is a complete
+// no-op when install.json is absent, which is exactly the first-install case),
+// and doctor is read-only. The only two registration sites in the tree are
+// RunCopy step 3 and ApplyToolDelta, and the curl installer reaches neither.
+//
+// The consequence on a first-ever install is not cosmetic. grafel's interface
+// IS the MCP server; a binary on PATH with no entry in ~/.claude.json is a
+// product that has not been installed. The user is then told to "run `grafel
+// wizard`", which registers no MCP server either.
+//
+// ── Why the installer does this itself rather than printing advice ───────────
+//
+// The alternative fix is to detect the absent registration and print the next
+// command. That command would have to be bare `grafel install`, and the
+// installer cannot establish that it is safe to run at the moment it prints it:
+// `grafel install` is RunCopy, whose step 4 restarts the daemon on a 60s budget
+// and whose failure path rolls step 3 back — restoring MCP host configs from
+// snapshots, which for a first-ever install is the absent-sentinel, i.e.
+// DELETING the config file and every foreign server in it (#6168). The daemon
+// state right after a binary swap is precisely the state in which that failure
+// is likely. install.sh already prints that advice in its `stale` branch, which
+// is the one branch where the daemon is known not to be healthy.
+//
+// RegisterMCP depends on no daemon, no network and no repository. It is
+// idempotent, and — the point — it has NO ROLLBACK, so it can never be the
+// thing that deletes a config.
+//
+// ── Exactly which files it writes ────────────────────────────────────────────
+//
+// More than the host configs, and saying "a surgical JSON merge plus a state
+// record" hid that. Per registered target, mcpreg.RegisterPath also writes:
+//
+//	<cfg>.grafel.bak                      — the rollback sidecar. RegisterMCP
+//	                                        DELETES this again immediately
+//	                                        (ClearBackup), because it never
+//	                                        rolls back and the sentinel form of
+//	                                        this file is what a restore uses to
+//	                                        delete a config outright (#6168).
+//	~/.grafel/backups/mcpreg/<...>.json   — a timestamped audit copy of the
+//	                                        pre-change content. This one is
+//	                                        KEPT: it is grafel's own directory,
+//	                                        no restore path reads it
+//	                                        (RestoreSnapshot consults only the
+//	                                        sidecar), and it is the only record
+//	                                        of what a host config looked like
+//	                                        before grafel first touched it.
+//
+// plus ~/.grafel/install.json, which is the state record.
+//
+// ── What it deliberately does NOT do ─────────────────────────────────────────
+//
+// No skills copy, no daemon restart, no service registration, no .gitignore
+// append, no git hooks, no TTY prompt. Those are RunCopy's job and they are why
+// a one-line installer must not call it: steps 5 and 7 mutate the git
+// repository the user's shell happened to be sitting in, which the installer
+// was never given consent to touch (#6162).
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/cajasmota/grafel/internal/install/mcpreg"
+)
+
+// RegisterMCPOptions configures RegisterMCP.
+type RegisterMCPOptions struct {
+	// BinPath is the binary to register as the MCP command. Defaults to
+	// os.Executable().
+	BinPath string
+
+	// StatePath is the path of install.json. Defaults to DefaultStatePath().
+	StatePath string
+
+	// ClaudeConfigDirs, when non-empty, overrides auto-detection of the
+	// ~/.claude.json paths (the --claude-config-dirs flag). When it is set,
+	// auto-detected non-Claude hosts are NOT added: an explicit target list is
+	// a request for exactly those targets.
+	ClaudeConfigDirs []string
+}
+
+// MCPRegisterFailure records one host config that could not be written.
+type MCPRegisterFailure struct {
+	Path string
+	Err  error
+}
+
+// RegisterMCPResult reports what RegisterMCP did.
+type RegisterMCPResult struct {
+	// Registered lists the host config paths that now carry a grafel entry.
+	Registered []string
+	// Failed lists the hosts that could not be written. A non-empty Failed is
+	// NOT an error: the remaining hosts are still registered.
+	Failed []MCPRegisterFailure
+	// StatePath is the install.json that was updated.
+	StatePath string
+	// CreatedState is true when install.json did not exist and was created to
+	// record this registration.
+	CreatedState bool
+}
+
+func (o *RegisterMCPOptions) applyDefaults() error {
+	if o.BinPath == "" {
+		bin, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("resolve binary path: %w", err)
+		}
+		o.BinPath = bin
+	}
+	if o.StatePath == "" {
+		p, err := DefaultStatePath()
+		if err != nil {
+			return err
+		}
+		o.StatePath = p
+	}
+	return nil
+}
+
+// registerMCPTargets resolves the host config files to write.
+//
+// It mirrors RunCopy step 3's target set — every detected Claude config dir
+// plus any Windsurf config whose parent directory already exists — so that a
+// later `grafel install` finds nothing new to do and `grafel uninstall` sweeps
+// the same files. An explicit ClaudeConfigDirs list suppresses the Windsurf
+// probe: a caller naming its targets gets its targets.
+func registerMCPTargets(explicit []string) []string {
+	dirs := mcpreg.DetectClaudeConfigDirs(explicit)
+	if len(explicit) > 0 {
+		return dirs
+	}
+	targets := make([]string, 0, len(dirs)+1)
+	targets = append(targets, dirs...)
+	return append(targets, mcpreg.DetectWindsurfPaths()...)
+}
+
+// RegisterMCP registers the grafel MCP server in every detected host config and
+// records the registration in install.json.
+//
+// A host that cannot be written is reported in Result.Failed and the remaining
+// hosts are still registered; the call succeeds. That is the opposite of
+// RunCopy step 3 on purpose — see the rollback note in the file header.
+//
+// It returns an error only for conditions that make the whole operation
+// meaningless: an unhashable binary (there is no honest CLI record for a binary
+// that is not on disk, and registering a `command` that points at nothing would
+// produce a config that fails at every Claude Code start) or an unwritable
+// install.json.
+func RegisterMCP(opts RegisterMCPOptions) (*RegisterMCPResult, error) {
+	if err := opts.applyDefaults(); err != nil {
+		return nil, err
+	}
+
+	// Hash FIRST, before writing anything. A missing binary must leave both the
+	// host configs and install.json exactly as they were.
+	sha, err := sha256File(opts.BinPath)
+	if err != nil {
+		return nil, fmt.Errorf("hash binary %s: %w", opts.BinPath, err)
+	}
+
+	res := &RegisterMCPResult{StatePath: opts.StatePath}
+
+	for _, cfgPath := range registerMCPTargets(opts.ClaudeConfigDirs) {
+		if _, rerr := mcpreg.RegisterPath(cfgPath, opts.BinPath); rerr != nil {
+			res.Failed = append(res.Failed, MCPRegisterFailure{Path: cfgPath, Err: rerr})
+			continue
+		}
+		// Discard the rollback snapshot RegisterPath just planted.
+		//
+		// backupOnce writes `<cfg>.grafel.bak` before its first modification —
+		// on a first-ever install that is the absent-sentinel, the value whose
+		// restore DELETES the config file and every foreign server in it. This
+		// function never rolls back, so it has no use for a snapshot, and
+		// leaving one behind would make "RegisterMCP cannot be the thing that
+		// deletes a config" depend on the two RestoreSnapshot call sites
+		// (copy.go, dev.go) continuing to run discardStaleMCPBackups first.
+		// That is coordination between three files; clearing it here is a
+		// property of this one. Per-target rather than after the loop, so a
+		// later host failing cannot strand a live sentinel on an earlier
+		// success.
+		mcpreg.ClearBackup(cfgPath)
+		res.Registered = append(res.Registered, cfgPath)
+	}
+
+	if err := recordMCPRegistration(res, opts.BinPath, sha); err != nil {
+		return res, err
+	}
+	return res, nil
+}
+
+// recordMCPRegistration folds the registration into install.json.
+//
+// `grafel uninstall` deregisters strictly from state.MCP.RegisteredPaths, so a
+// registration that is not recorded there can never be removed — the entry
+// would outlive the uninstall and leave Claude Code launching a binary that is
+// gone. Recording is therefore not bookkeeping; it is what makes the write
+// reversible.
+//
+// When install.json is ABSENT it is created. This is the one place that
+// deliberately differs from RefreshState, which refuses to fabricate a state
+// file — and the difference is that RefreshState has nothing to record (no
+// install happened; it only re-reads a binary) whereas RegisterMCP has just
+// performed a real, user-visible mutation. The record it writes asserts only
+// what is true: this binary, this checksum, these MCP paths, and SkillsSkipped.
+//
+// On SkillsSkipped, precisely — an earlier draft of this comment claimed it
+// makes `grafel doctor` read the state as an advisory binary-only install
+// rather than a broken one. That was false. Repo-wide the field is written
+// (copy.go step 2, here) and cleared (copy.go's state merge) and read by
+// nothing outside tests; no doctor check consults it. It is set here for one
+// honest reason: it is the field whose meaning is "step 2 copied no skills",
+// that is exactly what happened, and RunCopy writes it in the same situation —
+// so the state this produces is the state `grafel install` would produce for
+// the same facts, rather than a shape unique to this path. It buys consistency
+// and a true record, not behaviour. A later real `grafel install` overwrites it
+// wholesale (the state merge clears SkillsSkipped once step 2 runs).
+func recordMCPRegistration(res *RegisterMCPResult, binPath, sha string) error {
+	state, err := ReadState(res.StatePath)
+	if err != nil {
+		return err
+	}
+	if state == nil {
+		state = NewState(ModeCopy)
+		// Nothing here copied skills, and this is the field that says so. No
+		// production code reads it today — see the note above; it is set to
+		// keep the record true and identical in shape to RunCopy's, not
+		// because anything downstream branches on it.
+		state.SkillsSkipped = true
+		res.CreatedState = true
+	}
+
+	// The CLI record is refreshed for the same reason --refresh-state exists:
+	// the installer just replaced the binary, and the MCP entry we wrote names
+	// that binary, so the two must agree.
+	state.CLI = CLIRecord{Path: binPath, SHA256: sha}
+
+	// InstalledAt is left alone on an existing state (no install happened
+	// here); DaemonVersion likewise — RegisterMCP restarts no daemon, so it has
+	// no grounds to invalidate the record of one. install.sh's own
+	// record_install_state runs --refresh-state, which owns that clearing.
+
+	state.MCP.Name = mcpreg.ServerName
+	state.MCP.RegisteredPaths = unionPaths(state.MCP.RegisteredPaths, res.Registered)
+
+	return WriteState(res.StatePath, state)
+}
+
+// unionPaths appends the paths of b that a does not already have, preserving
+// a's order. The installer calls RegisterMCP on every upgrade, so appending
+// blindly would grow the list without bound.
+func unionPaths(a, b []string) []string {
+	seen := make(map[string]bool, len(a))
+	out := make([]string, 0, len(a)+len(b))
+	for _, p := range a {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	for _, p := range b {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/install/registermcp_6169_test.go
+++ b/internal/install/registermcp_6169_test.go
@@ -1,0 +1,461 @@
+// registermcp_6169_test.go pins the missing half of the curl install (#6169).
+//
+// install.sh downloads, checksum-verifies and places the binary, then runs
+// `grafel install --refresh-state`, `grafel doctor` and restart_daemon. Not one
+// of those registers the MCP server. The ONLY two registration sites in the
+// tree are RunCopy step 3 and ApplyToolDelta, and install.sh reaches neither —
+// so after a first-ever curl install the user has a binary on PATH, no grafel
+// entry in ~/.claude.json, and therefore no product: grafel's entire interface
+// is the MCP server.
+//
+// RegisterMCP is the narrow operation that closes that gap under the same
+// discipline as RefreshState: it writes MCP host configs and install.json and
+// NOTHING else — no daemon restart, no skills copy, no .gitignore, no git
+// hooks, no TTY prompt. These tests hold it to that.
+package install
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// seedFakeBinary writes an executable stand-in and returns its path. RegisterMCP
+// hashes the binary for the install.json CLI record, so it has to be a real file.
+func seedFakeBinary(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "grafel")
+	if err := os.WriteFile(p, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("write fake binary: %v", err)
+	}
+	return p
+}
+
+// readMCPServers returns the mcpServers map of a JSON host config.
+func readMCPServers(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if servers == nil {
+		t.Fatalf("%s has no mcpServers object: %s", path, raw)
+	}
+	return servers
+}
+
+// grafelCommandIn returns the `command` recorded for the grafel MCP entry.
+func grafelCommandIn(t *testing.T, path string) string {
+	t.Helper()
+	entry, ok := readMCPServers(t, path)["grafel"].(map[string]any)
+	if !ok {
+		t.Fatalf("%s has no grafel MCP entry", path)
+	}
+	cmd, _ := entry["command"].(string)
+	return cmd
+}
+
+// TestRegisterMCP_FirstEverInstallRegistersAndRecords is #6169 itself.
+//
+// Starting state is a machine that has never run `grafel install`: no
+// install.json, no ~/.claude.json. After RegisterMCP the config must carry a
+// grafel entry pointing at the binary we were given, AND install.json must
+// record that path — otherwise `grafel uninstall` (which deregisters strictly
+// from state.MCP.RegisteredPaths) can never remove what we just wrote.
+func TestRegisterMCP_FirstEverInstallRegistersAndRecords(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	cfg := filepath.Join(home, ".claude.json")
+	statePath := filepath.Join(home, ".grafel", "install.json")
+
+	if _, err := os.Stat(cfg); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist yet (err=%v)", cfg, err)
+	}
+	if _, err := os.Stat(statePath); !os.IsNotExist(err) {
+		t.Fatalf("precondition: %s must not exist yet (err=%v)", statePath, err)
+	}
+
+	res, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        statePath,
+		ClaudeConfigDirs: []string{cfg},
+	})
+	if err != nil {
+		t.Fatalf("RegisterMCP: %v", err)
+	}
+
+	if got := grafelCommandIn(t, cfg); got != bin {
+		t.Errorf("grafel MCP command = %q, want %q", got, bin)
+	}
+	if len(res.Registered) != 1 || res.Registered[0] != cfg {
+		t.Errorf("Registered = %v, want [%s]", res.Registered, cfg)
+	}
+	if !res.CreatedState {
+		t.Errorf("CreatedState = false; a first-ever install must record itself")
+	}
+
+	st, err := ReadState(statePath)
+	if err != nil || st == nil {
+		t.Fatalf("ReadState after RegisterMCP: st=%v err=%v", st, err)
+	}
+	if !containsString(st.MCP.RegisteredPaths, cfg) {
+		t.Errorf("install.json MCP.RegisteredPaths = %v, want to contain %s "+
+			"(uninstall deregisters only from this list)", st.MCP.RegisteredPaths, cfg)
+	}
+	if st.CLI.Path != bin || st.CLI.SHA256 == "" {
+		t.Errorf("install.json CLI = %+v, want path %s with a checksum", st.CLI, bin)
+	}
+	if !st.SkillsSkipped {
+		t.Errorf("SkillsSkipped = false; RegisterMCP copies no skills and must say so " +
+			"rather than let doctor read an empty manifest as a complete install")
+	}
+}
+
+// TestRegisterMCP_PreservesForeignServersAndKeys: the host config belongs to
+// the user, not to us. A curl installer that clobbered a hand-written MCP
+// server list would be a worse bug than the one being fixed.
+func TestRegisterMCP_PreservesForeignServersAndKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	cfg := filepath.Join(home, ".claude.json")
+	seed := `{
+  "numStartups": 41,
+  "mcpServers": {
+    "someone-elses-server": {"command": "/opt/other/bin/srv", "args": ["serve"]}
+  }
+}`
+	if err := os.WriteFile(cfg, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if _, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        filepath.Join(home, ".grafel", "install.json"),
+		ClaudeConfigDirs: []string{cfg},
+	}); err != nil {
+		t.Fatalf("RegisterMCP: %v", err)
+	}
+
+	servers := readMCPServers(t, cfg)
+	other, ok := servers["someone-elses-server"].(map[string]any)
+	if !ok {
+		t.Fatalf("foreign MCP server was destroyed; servers=%v", servers)
+	}
+	if other["command"] != "/opt/other/bin/srv" {
+		t.Errorf("foreign server rewritten: %v", other)
+	}
+	if _, ok := servers["grafel"]; !ok {
+		t.Errorf("grafel entry missing; servers=%v", servers)
+	}
+
+	raw, _ := os.ReadFile(cfg)
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if doc["numStartups"] == nil {
+		t.Errorf("unrelated top-level key numStartups was dropped: %s", raw)
+	}
+}
+
+// TestRegisterMCP_PreservesAnExistingInstallRecord: on an UPGRADE install.json
+// already exists and describes a real install — skills manifest, install
+// timestamp, gitignore record. Re-registering MCP must not blank any of it.
+func TestRegisterMCP_PreservesAnExistingInstallRecord(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	cfg := filepath.Join(home, ".claude.json")
+	statePath := filepath.Join(home, ".grafel", "install.json")
+
+	prior := NewState(ModeCopy)
+	prior.InstalledAt = "2019-03-04T05:06:07Z"
+	prior.Skills = map[string]SkillRecord{
+		"grafel-help": {Files: map[string]string{"SKILL.md": strings.Repeat("a", 64)}},
+	}
+	prior.Gitignore = GitignoreRecord{Repos: []string{"/home/u/proj"}}
+	prior.DaemonVersion = "9.9.9"
+	prior.MCP = MCPRecord{Name: "grafel", RegisteredPaths: []string{"/home/u/.claude-work/.claude.json"}}
+	if err := WriteState(statePath, prior); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	res, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        statePath,
+		ClaudeConfigDirs: []string{cfg},
+	})
+	if err != nil {
+		t.Fatalf("RegisterMCP: %v", err)
+	}
+	if res.CreatedState {
+		t.Errorf("CreatedState = true, but install.json already existed")
+	}
+
+	st, err := ReadState(statePath)
+	if err != nil || st == nil {
+		t.Fatalf("ReadState: st=%v err=%v", st, err)
+	}
+	if st.InstalledAt != "2019-03-04T05:06:07Z" {
+		t.Errorf("InstalledAt rewritten to %q; no install happened here", st.InstalledAt)
+	}
+	if _, ok := st.Skills["grafel-help"]; !ok {
+		t.Errorf("skills manifest was blanked: %v", st.Skills)
+	}
+	if st.SkillsSkipped {
+		t.Errorf("SkillsSkipped set on a state that HAS a skills manifest")
+	}
+	if len(st.Gitignore.Repos) != 1 || st.Gitignore.Repos[0] != "/home/u/proj" {
+		t.Errorf("gitignore record lost: %+v", st.Gitignore)
+	}
+	if st.DaemonVersion != "9.9.9" {
+		t.Errorf("DaemonVersion = %q; RegisterMCP restarts no daemon and must not "+
+			"invalidate the record of one", st.DaemonVersion)
+	}
+	// Existing registrations survive; the new one is added.
+	if !containsString(st.MCP.RegisteredPaths, "/home/u/.claude-work/.claude.json") {
+		t.Errorf("previously registered path dropped: %v", st.MCP.RegisteredPaths)
+	}
+	if !containsString(st.MCP.RegisteredPaths, cfg) {
+		t.Errorf("new path not recorded: %v", st.MCP.RegisteredPaths)
+	}
+}
+
+// TestRegisterMCP_OneBadTargetDoesNotAbortTheRestAndRollsBackNothing.
+//
+// This is the #6168 lesson applied ahead of time. RunCopy step 3 is a
+// transaction: a failure part-way through UNDOES the registrations it already
+// made, and when the snapshot it restores is the absent-sentinel that means
+// DELETING the user's config file along with every foreign server in it.
+// RegisterMCP is not a transaction — the hosts are independent — so a failure
+// on one must leave the others registered and must restore nothing.
+func TestRegisterMCP_OneBadTargetDoesNotAbortTheRestAndRollsBackNothing(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+
+	// A directory where a config file is expected: every write path fails.
+	bad := filepath.Join(home, "bad", ".claude.json")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatalf("mkdir bad target: %v", err)
+	}
+	good := filepath.Join(home, "good", ".claude.json")
+
+	res, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        filepath.Join(home, ".grafel", "install.json"),
+		ClaudeConfigDirs: []string{bad, good},
+	})
+	if err != nil {
+		t.Fatalf("RegisterMCP must not fail the install over one bad host: %v", err)
+	}
+	if len(res.Failed) != 1 || res.Failed[0].Path != bad {
+		t.Errorf("Failed = %+v, want exactly the bad target %s", res.Failed, bad)
+	}
+	if !containsString(res.Registered, good) {
+		t.Errorf("the good target was skipped after the bad one failed: %v", res.Registered)
+	}
+	if got := grafelCommandIn(t, good); got != bin {
+		t.Errorf("good target command = %q, want %q", got, bin)
+	}
+	// Nothing was restored/deleted: the directory we used as the bad target is
+	// still there, untouched.
+	if info, statErr := os.Stat(bad); statErr != nil || !info.IsDir() {
+		t.Errorf("bad target was mutated by a rollback: info=%v err=%v", info, statErr)
+	}
+}
+
+// TestRegisterMCP_IsIdempotent: install.sh calls this on EVERY run, including
+// every upgrade. A second run must not duplicate the recorded paths nor change
+// the config's meaning.
+func TestRegisterMCP_IsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	cfg := filepath.Join(home, ".claude.json")
+	statePath := filepath.Join(home, ".grafel", "install.json")
+
+	opts := RegisterMCPOptions{BinPath: bin, StatePath: statePath, ClaudeConfigDirs: []string{cfg}}
+	if _, err := RegisterMCP(opts); err != nil {
+		t.Fatalf("first RegisterMCP: %v", err)
+	}
+	if _, err := RegisterMCP(opts); err != nil {
+		t.Fatalf("second RegisterMCP: %v", err)
+	}
+
+	st, err := ReadState(statePath)
+	if err != nil || st == nil {
+		t.Fatalf("ReadState: st=%v err=%v", st, err)
+	}
+	n := 0
+	for _, p := range st.MCP.RegisteredPaths {
+		if p == cfg {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("%s recorded %d times in %v, want exactly 1", cfg, n, st.MCP.RegisteredPaths)
+	}
+	if got := grafelCommandIn(t, cfg); got != bin {
+		t.Errorf("command after second run = %q, want %q", got, bin)
+	}
+}
+
+// TestRegisterMCP_RepointsAMovedBinary: on an upgrade that changed prefix, the
+// recorded `command` points at a binary that is gone and the MCP server simply
+// fails to start. Re-registering is the repair, so it must actually overwrite.
+func TestRegisterMCP_RepointsAMovedBinary(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	cfg := filepath.Join(home, ".claude.json")
+	seed := `{"mcpServers":{"grafel":{"command":"/old/prefix/bin/grafel","args":["mcp-bridge"],"type":"stdio"}}}`
+	if err := os.WriteFile(cfg, []byte(seed), 0o644); err != nil {
+		t.Fatalf("seed config: %v", err)
+	}
+
+	if _, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        filepath.Join(home, ".grafel", "install.json"),
+		ClaudeConfigDirs: []string{cfg},
+	}); err != nil {
+		t.Fatalf("RegisterMCP: %v", err)
+	}
+	if got := grafelCommandIn(t, cfg); got != bin {
+		t.Errorf("stale command left in place: %q, want %q", got, bin)
+	}
+}
+
+// TestRegisterMCP_MissingBinaryIsAnError: the CLI record it writes carries a
+// checksum, and there is no honest checksum for a binary that is not there.
+// Failing loudly beats recording a grafel entry that points at nothing.
+func TestRegisterMCP_MissingBinaryIsAnError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	cfg := filepath.Join(home, ".claude.json")
+	_, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          filepath.Join(home, "nope", "grafel"),
+		StatePath:        filepath.Join(home, ".grafel", "install.json"),
+		ClaudeConfigDirs: []string{cfg},
+	})
+	if err == nil {
+		t.Fatalf("RegisterMCP with a missing binary must fail")
+	}
+	if _, statErr := os.Stat(cfg); !os.IsNotExist(statErr) {
+		t.Errorf("a config was written for a binary that does not exist (err=%v)", statErr)
+	}
+}
+
+// TestRegisterMCP_LeavesNoRollbackSnapshotBehind.
+//
+// Review finding S1. "RegisterMCP has no rollback" was true of RegisterMCP and
+// still left the artifact a rollback CONSUMES: RegisterPath calls backupOnce,
+// which writes `<cfg>.grafel.bak` — on a first-ever install that is the
+// absent-sentinel, the value whose restore DELETES the config file and every
+// foreign server in it.
+//
+// Today both RestoreSnapshot call sites (copy.go, dev.go) run
+// discardStaleMCPBackups first, so the stale sidecar is inert. That makes the
+// safety COORDINATIONAL — it holds because two other files remember to sweep —
+// rather than structural. A third caller, or a reordering of either sweep, and
+// a snapshot this function planted becomes live again. Since RegisterMCP never
+// rolls back, it needs no snapshot at all, so it clears its own.
+func TestRegisterMCP_LeavesNoRollbackSnapshotBehind(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		seed string // "" = no pre-existing config (the sentinel case)
+	}{
+		{"first-ever install writes the absent-sentinel", ""},
+		{"upgrade snapshots real content", `{"mcpServers":{"other":{"command":"/x"}}}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+
+			bin := seedFakeBinary(t)
+			cfg := filepath.Join(home, ".claude.json")
+			if tc.seed != "" {
+				if err := os.WriteFile(cfg, []byte(tc.seed), 0o644); err != nil {
+					t.Fatalf("seed config: %v", err)
+				}
+			}
+
+			if _, err := RegisterMCP(RegisterMCPOptions{
+				BinPath:          bin,
+				StatePath:        filepath.Join(home, ".grafel", "install.json"),
+				ClaudeConfigDirs: []string{cfg},
+			}); err != nil {
+				t.Fatalf("RegisterMCP: %v", err)
+			}
+
+			sidecar := cfg + ".grafel.bak"
+			if _, err := os.Stat(sidecar); err == nil {
+				raw, _ := os.ReadFile(sidecar)
+				t.Errorf("RegisterMCP left a rollback snapshot at %s (content %q); "+
+					"a later RestoreSnapshot would act on it", sidecar, raw)
+			} else if !os.IsNotExist(err) {
+				t.Fatalf("stat sidecar: %v", err)
+			}
+
+			// The registration itself must still be intact — clearing the
+			// snapshot must not be confused with undoing the write.
+			if got := grafelCommandIn(t, cfg); got != bin {
+				t.Errorf("registration was lost: command = %q, want %q", got, bin)
+			}
+		})
+	}
+}
+
+// TestRegisterMCP_ClearsTheSnapshotItPlantedEvenForAFailedPeer: the sweep is
+// per-target, so one host failing must not leave a live sentinel on the hosts
+// that succeeded.
+func TestRegisterMCP_ClearsTheSnapshotItPlantedEvenForAFailedPeer(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	bin := seedFakeBinary(t)
+	bad := filepath.Join(home, "bad", ".claude.json")
+	if err := os.MkdirAll(bad, 0o755); err != nil {
+		t.Fatalf("mkdir bad target: %v", err)
+	}
+	good := filepath.Join(home, "good", ".claude.json")
+
+	if _, err := RegisterMCP(RegisterMCPOptions{
+		BinPath:          bin,
+		StatePath:        filepath.Join(home, ".grafel", "install.json"),
+		ClaudeConfigDirs: []string{bad, good},
+	}); err != nil {
+		t.Fatalf("RegisterMCP: %v", err)
+	}
+	if _, err := os.Stat(good + ".grafel.bak"); err == nil {
+		t.Errorf("snapshot left on the successful host after a peer failed")
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("stat sidecar: %v", err)
+	}
+}
+
+func containsString(hay []string, needle string) bool {
+	for _, s := range hay {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/install/state.go
+++ b/internal/install/state.go
@@ -85,9 +85,17 @@ type State struct {
 
 	// SkillsSkipped is true when step 2 (skills copy) was intentionally
 	// skipped because no skills source directory could be discovered (e.g. a
-	// brand-new binary-only install with no repo checkout). The install still
-	// succeeds and the daemon is installed; doctor reports this as advisory,
-	// not as a broken install.
+	// brand-new binary-only install with no repo checkout), or because the
+	// caller copies no skills at all (RegisterMCP). The install still succeeds
+	// and the daemon is installed.
+	//
+	// NOTE: this field is currently WRITE-ONLY. It is set by RunCopy step 2 and
+	// by RegisterMCP, cleared by the state merge, and read by nothing outside
+	// tests — no doctor check consults it. The previous comment here claimed
+	// "doctor reports this as advisory, not as a broken install", which was
+	// never true of any code in this repository. It is retained because it is
+	// the honest record of a real condition and the schema is persisted to
+	// disk, but do not write code that assumes it changes any behaviour today.
 	SkillsSkipped bool `json:"skills_skipped,omitempty"`
 
 	// MCP holds the MCP registration state.


### PR DESCRIPTION
Both installers place a binary and stop short of the state the rest of the product assumes exists — and the obvious remedy, bare `grafel install`, is itself unsafe.

**#6169** — `install.sh` never registers MCP on a first-ever install. `--refresh-state` is a **no-op when `install.json` is absent**, which is exactly the first-install case; `doctor` is read-only; and the only two registration sites (`RunCopy` step 3, `ApplyToolDelta`) are unreachable from the installer. The closing message points at `grafel wizard`, which has no `mcpreg` reference in any non-test file. The user ends with a working binary, no MCP registration, and nothing telling them so.

**#6163** — `install.ps1` never writes `install.json`, so every command permanently prints `binary updated since last install`, and its own hint suggests re-running `grafel install`. `install.bat` *runs* that bare command: the full `RunCopy` transaction, which appends `/.grafel/` to the `.gitignore` of `os.Getwd()` — whatever directory the console was in — installs four git hooks there, rewrites every detected `.claude.json`, restarts the daemon, and, because stdin is a TTY, **blocks on the tool-selection wizard mid-install**.

## The installer registers MCP itself, and print-a-command was not a real option

The alternative was to detect the missing registration and print a next command. That is unsatisfiable here: the only candidate is bare `grafel install`, whose step 4 restarts the daemon on a 60-second budget, and whose step 3 rolls back on failure by restoring MCP configs from snapshots. On a first-ever install that snapshot is the absent-sentinel — so the "remedy" deletes `.claude.json` and every foreign server in it (#6168). The moments right after a binary swap are precisely when that restart fails. `install.sh` was already printing that advice in its `stale` branch, the one branch where the daemon is *known* unhealthy.

New `grafel install --register-mcp`: no daemon, no network, no repo, no TTY. Surgical JSON merge preserving foreign servers, idempotent, and **no rollback path** — which is what makes it structurally incapable of the #6168 failure.

It does record into `install.json`, deliberately unlike `--refresh-state`, which refuses to fabricate. The distinction: `--refresh-state` has nothing to record, while `--register-mcp` has just performed a real mutation — and `grafel uninstall` deregisters strictly from `state.MCP.RegisteredPaths`, so an unrecorded registration would outlive the uninstall.

## What each installer does now

- **`install.sh`** — new `register_mcp()` after `record_install_state`, best-effort, output surfaced. The `stale` branch and the restart hint now say `grafel restart`, not `grafel install`.
- **`install.bat`** — bare `install` replaced by `--refresh-state` then `--register-mcp`. Kills the cwd `.gitignore` write, the four git hooks, the daemon restart and the TTY hang.
- **`install.ps1`** — both narrow calls added after `Copy-Item` and *before* the doctor report, so it stops printing the warning it caused.
- `docs/install.md:32` claimed all three Windows paths "run `grafel install`" — now false, and it was documenting the removed dangerous behaviour as intended.

## Review found the Windows tests guarded nothing

The first version's `install.bat` assertions scanned raw source text. Adversarial review replaced both real invocation lines with `REM MUTANT prose: install --refresh-state` and **every `install.bat` test stayed green** — and since the script is never executed anywhere, those were the only evidence the remedy was present at all. The dangerous-command guard was separately defeated by two spellings: unquoted `%BINDIR%\grafel.exe install`, and `set "G=…"` + `"%G%" install`, which was not even collected.

Replaced with a line model that strips comments, blanks quoted spans, splits into independently-executed segments (`&`/`&&`/`||`/`|` for bat, `;`/`|` for ps1), drops each segment's printed text at an output verb, and matches `install` as a **token** on the collected segments.

**The parser itself is tested** — a guard with a wrong parser is indistinguishable from no guard. `TestScriptLineModel_*` pins five bat and four ps1 spellings of the bare command as caught, and commented-out commands, string-literal prose and `Write-Host grafel.exe install` as ignored. Segmenting turned out to be load-bearing: truncating a whole line at `echo` produced two false positives on the real script and would have hidden `echo hi & grafel.exe install`.

Re-verified at merge — with both narrow lines kept and a bare `"%G%" install` added alongside:

```
install.bat:354 runs the full RunCopy transaction (gitignore + git hooks in the
console's cwd, daemon restart, and a TTY tool-selection wizard that blocks
mid-install): "\"%G%\" install"
```

## Two more from review

**A config containing top-level `null` panicked.** `json.Unmarshal` sets the map to nil *without* erroring, then the assignment panics — `panic: assignment to entry in nil map`, reached on every install for every user via the curl one-liner. Now normalised to an empty map, treated identically to a zero-byte file. A companion test pins that every *other* non-object (`[]`, populated array, string, number, bool) still fails on the type error and leaves the file byte-identical, so the fix cannot quietly widen into "accept anything".

**The no-rollback claim was true of `RegisterMCP` but it planted the artifact a rollback consumes.** `RegisterPath` → `backupOnce` writes a `<cfg>.grafel.bak` sidecar — the absent-sentinel on a first install. Both `RestoreSnapshot` callers happen to discard stale backups first, so it was inert *today*, making the safety coordinational rather than structural. Not theoretical: the review machine had carried a stale 46 KB `.claude.json.grafel.bak` since July. `ClearBackup` is now called **per target** after each successful `RegisterPath`, so a later host failing cannot strand a live sentinel on an earlier success. The timestamped audit copy is kept — `RestoreSnapshot` reads only the sidecar, so the audit dir is inert by construction.

`SkillsSkipped`'s stated rationale ("so doctor reads it as advisory") was **false** — it is write-only, read by no non-test code. The field is kept for consistency with what `grafel install` writes for the same facts, but all three comments including its canonical definition at `state.go:86-90` now say plainly that nothing branches on it.

## Verified versus reasoned-only

**Executed:** everything in Go, and every `install.sh` change — the shell tests source the script with `GRAFEL_INSTALL_SH_LIB=1` against a sandboxed `PREFIX` and `HOME` and call the real functions, verified non-vacuous by gutting `register_mcp` (kills three tests).

**Never executed: `install.ps1` and `install.bat`.** No Windows host, no `pwsh`, no PSScriptAnalyzer, no cmd.exe in CI. Their tests are now materially stronger static assertions — they survive re-quoting, renaming and comment-out — but they are still **not evidence that either script runs**. PowerShell argument binding for `& $existing install --refresh-state` and cmd.exe quoting under `EnableDelayedExpansion` remain arguments from precedent within each script, not observations.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/install/...` 0, `./internal/cli/...` 0. `shellcheck install.sh` reports the same two pre-existing SC2016 infos on untouched lines. No installer was run against any real machine; the real `~/.grafel` and `~/.claude.json` are byte-identical throughout.

Twenty-three mutants across two rounds, no survivors.

Closes #6169
Closes #6163
Refs #6165, #6168, #6162
