### PR TITLE
fix(#6115): `grafel status` printed "0 files" for every repo in the shipping format

### DIFF
--- a/internal/cli/status_files_6115_test.go
+++ b/internal/cli/status_files_6115_test.go
@@ -1,0 +1,240 @@
+package cli
+
+// #6115 — `grafel status` printed "0 files" for every .fb-backed repo.
+//
+// The file count is not encoded in ANY .fb layout (see internal/graph/schema/
+// graph.fbs: the Graph root table has no file-count field), so a graph loaded
+// back from .fb necessarily reports Stats.Files == 0 — GraphStream.DocStats
+// says so explicitly. graph-stats.json IS the carrier of the real number, and
+// ComputeStatusSummaryForRef already reads it into rs.Files... and then, a few
+// lines later, assigned the graph's own (structurally zero) count over the top.
+// The real value was in hand and discarded on the way to the screen.
+//
+// These tests assert on the RENDERED status line, not on the struct field: the
+// defect is a discard on the render path, and an in-memory assertion would not
+// have seen it.
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/grafel/internal/daemon"
+	"github.com/cajasmota/grafel/internal/graph"
+	"github.com/cajasmota/grafel/internal/graph/fbwriter"
+	"github.com/cajasmota/grafel/internal/registry"
+)
+
+// assertFBBacked fails unless stateDir is genuinely served by a .fb layout and
+// holds NO graph.json.
+//
+// This is the anti-vacuity guard for both tests below. graph.json is the ONE
+// layout whose Stats.Files is already non-zero, so a fixture that silently fell
+// back to it would make "7 files" appear on screen no matter what the
+// production code does — the assertion would pass against the unfixed binary.
+func assertFBBacked(t *testing.T, stateDir string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(stateDir, "graph.json")); err == nil {
+		t.Fatalf("fixture is not .fb-backed: graph.json exists in %s", stateDir)
+	}
+	desc, err := graph.CurrentGraphDescriptor(stateDir)
+	if err != nil {
+		t.Fatalf("resolve graph descriptor: %v", err)
+	}
+	if desc.Kind != graph.GraphSingleFile && desc.Kind != graph.GraphSegmentSet {
+		t.Fatalf("fixture is not .fb-backed: descriptor kind = %v", desc.Kind)
+	}
+	// And the .fb really does report zero files, which is what makes the
+	// overwrite destructive. If this ever stops being true the fix below is
+	// no longer load-bearing and this test should be revisited, not deleted.
+	stream, err := graph.OpenGraphStream(stateDir)
+	if err != nil {
+		t.Fatalf("open graph stream: %v", err)
+	}
+	defer stream.Close()
+	if got := stream.DocStats().Files; got != 0 {
+		t.Fatalf("precondition changed: .fb graph now reports Files = %d, want 0", got)
+	}
+}
+
+// files6115Doc is a minimal but real graph document. Stats.Files is set to a
+// value that the .fb writer cannot persist — proving the number on screen came
+// from the sidecar and not from the graph.
+func files6115Doc() *graph.Document {
+	return &graph.Document{
+		Repo:        "fbrepo",
+		GeneratedAt: time.Now().Add(-30 * time.Minute),
+		IndexedRef:  "main",
+		IndexedSHA:  "abcdef012345",
+		Stats:       graph.Stats{Files: 999},
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "A", Kind: "function", SourceFile: "a.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{},
+	}
+}
+
+func files6115Sidecar(t *testing.T, stateDir string, files, ents, rels int) {
+	t.Helper()
+	side := graph.GraphStatsSidecar{
+		Version:            1,
+		ComputedAt:         time.Now().Add(-30 * time.Minute),
+		TotalFiles:         files,
+		TotalEntities:      ents,
+		TotalRelationships: rels,
+	}
+	data, err := json.Marshal(side)
+	if err != nil {
+		t.Fatalf("marshal sidecar: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), data, 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+}
+
+func files6115Repo(t *testing.T, root, slug string) (string, string) {
+	t.Helper()
+	repoPath := filepath.Join(root, slug)
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	return repoPath, stateDir
+}
+
+// renderStatus returns the line of PrintStatusSummary output for slug.
+func renderStatusLine(t *testing.T, group string, repos []registry.Repo, slug string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	PrintStatusSummary(&buf, ComputeStatusSummary(group, repos))
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), slug+" ") {
+			return line
+		}
+	}
+	t.Fatalf("no status line for %q in:\n%s", slug, buf.String())
+	return ""
+}
+
+// TestStatusPrintsSidecarFileCountForFBRepo is the #6115 regression: a
+// .fb-backed repo with a graph-stats.json must print the sidecar's TotalFiles,
+// not zero.
+func TestStatusPrintsSidecarFileCountForFBRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath, stateDir := files6115Repo(t, tmpDir, "fbrepo")
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), files6115Doc()); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	// 4321 is deliberately unlike every other number in this fixture (1 entity,
+	// 0 rels, doc.Stats.Files 999) so the digits on screen can only have come
+	// from the sidecar.
+	files6115Sidecar(t, stateDir, 4321, 1, 0)
+	assertFBBacked(t, stateDir)
+
+	line := renderStatusLine(t, "g6115", []registry.Repo{{Slug: "fbrepo", Path: repoPath}}, "fbrepo")
+	// Rendered with fmtInt's thousands separator; spelled out literally rather
+	// than via fmtInt so the expectation cannot drift with the formatter.
+	if !strings.Contains(line, "4,321 files") {
+		t.Fatalf("status line lost the sidecar file count (#6115)\n got: %q\nwant it to contain %q", line, "4,321 files")
+	}
+	if strings.Contains(line, "999") {
+		t.Fatalf("status line reported the graph document's file count, not the sidecar's: %q", line)
+	}
+}
+
+// TestStatusReportsZeroFilesWhenNoSidecar is the negative control for the fix
+// above: with no sidecar there is no real file count anywhere, and status must
+// keep saying 0 rather than inventing one. Without this, "always keep whatever
+// rs.Files already holds" and "hardcode a number" both pass the test above.
+func TestStatusReportsZeroFilesWhenNoSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath, stateDir := files6115Repo(t, tmpDir, "nosidecar")
+	if err := fbwriter.WriteAtomic(filepath.Join(stateDir, "graph.fb"), files6115Doc()); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+	assertFBBacked(t, stateDir)
+
+	line := renderStatusLine(t, "g6115", []registry.Repo{{Slug: "nosidecar", Path: repoPath}}, "nosidecar")
+	if !strings.Contains(line, "0 files") {
+		t.Fatalf("a .fb repo with no sidecar has no known file count; want %q in %q", "0 files", line)
+	}
+}
+
+// TestStatusPrintsDocumentFileCountForJSONRepoWithoutSidecar pins the OTHER
+// direction of the #6115 guard.
+//
+// graph.json is the one layout that DOES carry a real Stats.Files, and a
+// sidecar-less graph.json repo has nowhere else to get the number from. A fix
+// that simply deleted the assignment — "the sidecar is always right" — would
+// regress this repo from 7 files to 0 and no other test in the package would
+// notice, because every parity fixture on the graph.json path also has a
+// sidecar.
+func TestStatusPrintsDocumentFileCountForJSONRepoWithoutSidecar(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath, stateDir := files6115Repo(t, tmpDir, "jsonrepo")
+	doc := files6115Doc()
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), raw, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+	// No sidecar, and no .fb: the document is the ONLY source of the count.
+	if _, statErr := os.Stat(filepath.Join(stateDir, "graph-stats.json")); statErr == nil {
+		t.Fatalf("fixture invalid: a sidecar exists")
+	}
+
+	line := renderStatusLine(t, "g6115", []registry.Repo{{Slug: "jsonrepo", Path: repoPath}}, "jsonrepo")
+	if !strings.Contains(line, "999 files") {
+		t.Fatalf("graph.json repo lost its document file count\n got: %q", line)
+	}
+}
+
+// TestStatusPrintsSidecarFileCountForSegmentSetRepo covers the OTHER .fb
+// layout. The segment-set path resolves through a different descriptor branch
+// (graph.<gen>/ + manifest.json, no flat .fb), and it is the layout a
+// corpus-sized repo actually uses — a fix verified only against the flat file
+// would leave the big repos reading zero.
+func TestStatusPrintsSidecarFileCountForSegmentSetRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmpDir)
+
+	repoPath, stateDir := files6115Repo(t, tmpDir, "segrepo")
+	doc := files6115Doc()
+	genDir := filepath.Join(stateDir, graph.GenDirName(3))
+	segName := graph.SegmentFileName(0)
+	if err := fbwriter.WriteAtomic(filepath.Join(genDir, segName), doc); err != nil {
+		t.Fatalf("write segment: %v", err)
+	}
+	m := &graph.Manifest{FormatVersion: graph.ManifestFormatVersion, Segments: []graph.SegmentMeta{{
+		File: segName, Kind: graph.SegmentEntities, EntityCount: len(doc.Entities),
+		MinKey: doc.Entities[0].ID, MaxKey: doc.Entities[0].ID,
+	}}}
+	if err := graph.WriteManifest(genDir, m); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	if err := graph.WriteCurrentPointerRaw(stateDir, graph.GenDirName(3)); err != nil {
+		t.Fatalf("write current pointer: %v", err)
+	}
+	files6115Sidecar(t, stateDir, 8765, 1, 0)
+	assertFBBacked(t, stateDir)
+
+	line := renderStatusLine(t, "g6115", []registry.Repo{{Slug: "segrepo", Path: repoPath}}, "segrepo")
+	if !strings.Contains(line, "8,765 files") {
+		t.Fatalf("segment-set status line lost the sidecar file count (#6115)\n got: %q", line)
+	}
+}

--- a/internal/cli/status_output_parity_5995_test.go
+++ b/internal/cli/status_output_parity_5995_test.go
@@ -12,6 +12,15 @@ package cli
 // Regenerate deliberately (and only when a reported value is MEANT to change):
 //
 //	GRAFEL_UPDATE_GOLDEN=1 go test ./internal/cli/ -run StatusOutputParity
+//
+// Regenerated once since capture, for #6115: the golden pinned "0 files" on the
+// three .fb-backed fixtures that HAVE a graph-stats.json (healthy, segmentset,
+// coldrefs), because status assigned the .fb layout's structurally-zero file
+// count over the sidecar's real one. Those three cells moved 0 → 7 and NOTHING
+// else did — jsononly still reports its document's 7, the sidecar-less and
+// failed-load fixtures still report 0, and the TOTAL line is byte-identical.
+// That is the whole of the intended change; a wider diff on a future
+// regeneration is a regression, not a rebase.
 
 import (
 	"bytes"

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -379,7 +379,14 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 				//
 				// Stats.Files is zero for every .fb-backed graph (the format
 				// encodes no file count) and real only for the graph.json
-				// fallback — see GraphStream.DocStats. Preserved verbatim.
+				// fallback — see GraphStream.DocStats.
+				//
+				// #6115: that zero used to be assigned over rs.Files
+				// unconditionally, a few lines below, destroying the real
+				// TotalFiles this function had already read out of
+				// graph-stats.json — so `status` printed "0 files" for every
+				// repo in the shipping format. The graph's count is now taken
+				// only when it HAS one; see the commit at rs.Files below.
 				files := stream.DocStats().Files
 				// Phase 0 git metadata (#2088), straight off the header.
 				meta := stream.Header()
@@ -395,7 +402,25 @@ func ComputeStatusSummaryForRef(group string, repos []registry.Repo, ref string)
 					}
 					return true
 				})
-				rs.Files = files
+				// #6115: a graph-derived file count is authoritative only when
+				// the graph actually carries one. No .fb layout does — the
+				// Graph root table in internal/graph/schema/graph.fbs has no
+				// file-count field, so `files` is STRUCTURALLY zero there, not
+				// measured-as-zero — while graph.json does. graph-stats.json is
+				// the carrier of the real number and was already read into
+				// rs.Files above; overwriting it with a structural zero threw
+				// the only true answer away.
+				//
+				// Guarding on `> 0` rather than on layout keeps both directions
+				// honest: a graph.json repo still reports its document count
+				// (unchanged), a .fb repo keeps its sidecar count, and a repo
+				// with neither still reports 0 — which for a .fb repo without a
+				// sidecar is the truthful "not known", the same 0 it printed
+				// before. Nothing here can invent a number that was not
+				// measured somewhere.
+				if files > 0 {
+					rs.Files = files
+				}
 				rs.IndexedRef = meta.IndexedRef
 				rs.IndexedSHA = meta.IndexedSHA
 				rs.IsWorktree = meta.IsWorktree

--- a/internal/cli/testdata/status_parity_5995.golden
+++ b/internal/cli/testdata/status_parity_5995.golden
@@ -1,11 +1,11 @@
 
 Group: parity
-  coldrefs          0 files       6 entities       2 rels  indexed 1d ago @ main (c01dc01dc01d) [+ develop cold]
-  healthy           0 files       6 entities       2 rels  indexed 3m ago @ main (abc123def456)
+  coldrefs          7 files       6 entities       2 rels  indexed 1d ago @ main (c01dc01dc01d) [+ develop cold]
+  healthy           7 files       6 entities       2 rels  indexed 3m ago @ main (abc123def456)
   jsononly          7 files       6 entities       2 rels  indexed 1h ago @ main (111122223333)
   neverindexed      0 files       0 entities       0 rels  indexed (never)
   nosidecar         0 files       6 entities       2 rels  indexed 1h30m ago @ feat/x (0badc0ffee11) [worktree]
-  segmentset        0 files       6 entities       2 rels  indexed 10m ago @ main (5e65e75e7000)
+  segmentset        7 files       6 entities       2 rels  indexed 10m ago @ main (5e65e75e7000)
   truncated         0 files       6 entities       2 rels  indexed 1h30m ago
                 ⚠ graph FAILED to load: panic while reading the graph: runtime error: slice bounds out of range [888:500] — file/endpoint/flow counts above are INCOMPLETE; run `grafel reset parity` to rebuild from scratch
   unreadable        0 files       0 entities       0 rels  indexed 1h30m ago

--- a/internal/graph/stream.go
+++ b/internal/graph/stream.go
@@ -200,6 +200,12 @@ func (s *GraphStream) Header() fbreader.GraphMeta {
 // and only the graph.json fallback carries a real value. This method reproduces
 // that exactly rather than papering over it — a caller that wants the true
 // indexed-file count should read graph-stats.json's TotalFiles instead.
+//
+// Treat a zero Files here as UNKNOWN, never as "this repo has no files": it is
+// the value the .fb layouts are structurally incapable of carrying, not a
+// measurement. `grafel status` assigned it over a real sidecar count and
+// printed "0 files" for every repo in the shipping format (#6115); it now takes
+// this field only when it is non-zero.
 func (s *GraphStream) DocStats() Stats {
 	if s == nil {
 		return Stats{}


### PR DESCRIPTION
`grafel status` printed **`files = 0` for every `.fb`-backed repo** — which is every real repo, since `.fb` is the shipping format. Only `graph.json` repos showed a real number.

The correct value was already in hand and then thrown away: `status` reads `graph-stats.json` first for the entity and relationship counts, and then `rs.Files = doc.Stats.Files` overwrote the sidecar's real `TotalFiles` with the document's zero.

## Option 1 was not implementable, and would not have fixed this anyway

The issue offered two fixes: populate `Stats.Files` in `materializeGraphView`, or stop the overwrite. Checking the first before choosing:

- **`graph.fbs`'s root `Graph` table has no file-count field.** There is nothing in the `.fb` bytes to populate `Stats.Files` *from*. Adding one is a schema plus format-version bump, putting every installed user through the #6167 reindex migration for a display column.
- **More decisively, it would not touch the reported defect.** Since #5995, `status` does not call `materializeGraphView` at all — it uses `GraphStream`, and the header-only path decodes no entities. Even a "count distinct `SourceFile`" derivation would still yield zero on the exact path that renders the column. It would also answer a different question: "files holding at least one entity" is not "files indexed."

So the two options are not two views of one fix. "Sidecar populated, document zero" is not a residual edge case a guard mops up after option 1 lands — **it is the permanent state of every `.fb` repo**, and the guard is the fix.

`if files > 0 { rs.Files = files }`, conditioned on the **value** rather than the layout: `graph.json` keeps reporting its document count, `.fb` keeps its sidecar count, and neither still yields `0`, which now truthfully means *unknown*. Nothing can invent an unmeasured number. `GraphStream.DocStats`' doc comment now says zero means unknown, never "no files".

## Consumers of `Document.Stats.Files`

Enumerated before choosing, since option 1 would have changed the value for all of them:

| Site | Doc origin | Relies on the zero? |
|---|---|---|
| `cmd/grafel/index.go:5977`, `:1320` | **writes** it from `i.stats.files` | n/a — the source |
| `cmd/grafel/sidecar_build.go:41` → `TotalFiles` | in-memory doc from a full index | No |
| `internal/extractors/incremental.go:1403` → `TotalFiles` | doc merged from on-disk `.fb`, so 0 | No — but see below |
| `internal/cli/status_stats.go:383` | the defect | No — it *destroyed* a real value |
| `internal/graph/stream.go:203` `DocStats` | reproduces it verbatim by design | No |

**No consumer treats 0 as "unknown" and falls back**, so nothing changes behaviour. `RepoStatus.Files` has exactly one reader (`PrintStatusSummary`) — no JSON, statusline or dashboard surface reads it.

## One correction to the issue

The issue says *"the correct value is available: `graph-stats.json` carries it."* That is true after a **full** index and **false after an incremental reindex**: `incremental.go:1403` builds its sidecar with `TotalFiles: doc.Stats.Files` where `doc` came from the on-disk `.fb` — so zero — and `WriteSidecar` overwrites the file wholesale with no carry-forward, `omitempty` dropping the key entirely.

So an incrementally-reindexed repo has a **zeroed sidecar**, and this change leaves it printing `0 files` until the next full index. Same root cause (`.fb` cannot carry the count), different write path.

Deliberately not fixed here: it is a sidecar-correctness defect rather than a display defect, it needs its own test, and the obvious source — `len(manifest.Files)` — is only updated in Step 9, *after* the sidecar write. Filed separately.

## Golden file

`status_parity_5995.golden` pinned the zero, and the issue calls updating it the intended signal. Regenerated and diffed against a shasum-verified backup: **three lines, three cells, same line count.** `coldrefs`, `healthy` and `segmentset` move `0 files` → `7 files`; `jsononly` still 7; `nosidecar`, `truncated`, `unreadable`, `neverindexed` still 0; the `TOTAL:` line byte-identical. The regeneration rationale is recorded in the parity test's header so a future wider diff reads as a regression rather than a rebase.

## Mutants

| Mutation | Killed by |
|---|---|
| restore the defect (`rs.Files = files` unconditional) | `TestStatusPrintsSidecarFileCountForFBRepo`, `…ForSegmentSetRepo`, `TestStatusOutputParity` |
| "sidecar is always right" — drop the assignment | `TestStatusPrintsDocumentFileCountForJSONRepoWithoutSidecar` |
| drop the sidecar read | the two sidecar tests + parity |

The second mutant is why a `graph.json`-without-sidecar test was added: **nothing in the package covered that direction** — every existing `graph.json` parity fixture also has a sidecar — so the deletion-style fix would have passed silently.

Re-verified at merge: making the guard unconditional reproduces `0 files` across the `.fb` fixtures.

**Anti-vacuity.** `assertFBBacked` fails the fixture unless no `graph.json` exists in the state dir, the descriptor kind is `GraphSingleFile` or `GraphSegmentSet`, **and** `OpenGraphStream(...).DocStats().Files == 0` — the precondition that makes the overwrite destructive is asserted, not assumed. The document's own `Stats.Files` is `999` while the sidecar says `4321`/`8765`, so the digits on screen can only have come from the sidecar, and the test fails outright if `999` appears. Both `.fb` layouts are covered; segment-set is what corpus-sized repos actually use and resolves through a different descriptor branch.

## Verification

`gofmt -l .` silent, `go build ./...` 0, `go vet ./...` 0, `./internal/cli/...` 0, `./internal/graph/...` 0.

Closes #6115
Refs #5995
