### PR TITLE
ci(#6219,#6064): CI could not catch three defects this repo had already shipped

### DIFF
--- a/.github/workflows/cross-platform-compile.yml
+++ b/.github/workflows/cross-platform-compile.yml
@@ -1,0 +1,206 @@
+name: cross-platform compile
+
+# Closes #6219 — the always-on compile-only gate.
+#
+# THE GAP THIS FILLS
+# A darwin-only test-file build break sat on `main` for two weeks. It was even
+# written down, in the "known limits" section of #6197's PR body, and CI still
+# could not see it: it surfaced only when a release tag finally ran test.yml's
+# 3-OS matrix, where it was a release blocker.
+#
+# Why nothing caught it:
+#   - pre-merge.yml           → workflow_dispatch only, and Linux only.
+#   - test.yml (3-OS matrix)  → gated on a `v*` tag or the `ci:full` label.
+#   - windows.yml             → workflow_dispatch only.
+#   - quality.yml             → workflow_dispatch only.
+# i.e. NOTHING compiled this repo off-Linux without a human first asking for it.
+# This workflow is that missing always-on leg, and nothing else.
+#
+# SCOPE: compile only. No test EXECUTION happens here — that stays in test.yml.
+# Red here means "this tree does not build on some platform", which is a fact,
+# not a flake. Keep it that way: do not add a step that can fail for any other
+# reason.
+#
+# WHY REAL RUNNERS AND NOT CROSS-`GOOS` VET FROM LINUX
+# The obvious cheap design is `GOOS=windows CGO_ENABLED=0 go vet ./...` on one
+# ubuntu runner. It does not work here, and the failure mode is the dangerous
+# kind — it is quiet.
+#
+# This repo's tree-sitter bindings are cgo. With CGO_ENABLED=0 the ~25 grammar
+# binding packages reduce to "build constraints exclude all Go files", and
+# internal/treesitter/ts/official then fails to type-check outright on
+# `undefined: tsofficial.Language` and six siblings. Measured on this tree.
+#
+# The quiet part: internal/daemon, internal/cli, internal/dashboard and
+# internal/mcp all sit downstream of that package. When a DEPENDENCY fails to
+# type-check, `go vet` reports the dependency and then says NOTHING AT ALL about
+# its dependents — they are never analyzed, and their absence from the output is
+# indistinguishable from their being clean. Reduced to a two-package module and
+# confirmed directly: a package whose dependency is broken AND which has its own
+# independent test-file break produces exactly one diagnostic, for the
+# dependency. The dependent's own break is invisible.
+#
+# So a cross-`GOOS` leg would have printed a wall of cgo noise while silently
+# declining to check the four largest packages in the repo — including
+# internal/cli and internal/mcp. That is worse than no gate: it is a gate that
+# reports green-adjacent output over an unexamined cone.
+#
+# A real windows-latest / macos-latest / ubuntu-latest runner with CGO_ENABLED=1
+# compiles the grammar bindings for real, so the cone is fully in scope and
+# every package downstream of it is actually type-checked. That is why this
+# workflow spends three runners instead of one. CI here is free and unlimited
+# (public repo, standard runners); a trustworthy gate is worth more than a leg.
+#
+# WHY `go vet` AND NOT `go build`
+# The defect class is a TEST FILE that does not compile off-macOS. `go build
+# ./...` does not look at _test.go files at all and would have shipped every one
+# of the three breaks the #6219 sweep found. `go vet` type-checks the test files
+# too, which is the entire point. (`go vet` also runs its analyzers, which is a
+# bonus, not the reason.)
+#
+# NOTE ON `runtime.GOOS != "..."` + `t.Skip`
+# That idiom guards EXECUTION, not COMPILATION. A test file that skips itself on
+# non-darwin still has to type-check on windows and linux, so a darwin-only
+# symbol in such a file is a build break everywhere else even though the test
+# would never have run. That idiom produced one of the three #6219 breaks. Only
+# a `//go:build` constraint excludes a file from compilation. This workflow is
+# what makes that mistake visible on the PR that introduces it.
+
+on:
+  # ALWAYS ON. This is the whole point of the file — see the header. Do not add
+  # a label gate, a path filter or a dispatch-only restriction here without
+  # replacing the coverage somewhere else; #6219 is precisely what an opt-in
+  # cross-platform check fails to catch.
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  # Supersede in-flight runs for the same ref. This is a compile check, so only
+  # the newest commit's answer is interesting.
+  group: cross-platform-compile-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile:
+    name: compile (${{ matrix.os }})
+    strategy:
+      # Every platform reports independently. A windows break must not hide a
+      # darwin break — enumerating ALL of them in one run is the goal.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    # Generous relative to the ~5-10 min steady-state cost, because a COLD cache
+    # has to compile ~25 cgo grammar bindings from source, and that is slow on
+    # the Windows runner in particular. Well under GitHub's 6h default so a hung
+    # step still fails rather than idling.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      # MinGW provides the C toolchain the tree-sitter bindings need. Without
+      # it, CGO_ENABLED=1 cannot link on Windows and we would be back to the
+      # CGO_ENABLED=0 blind spot this workflow exists to avoid.
+      - name: Setup MSYS2 + MinGW (Windows only)
+        if: runner.os == 'Windows'
+        uses: msys2/setup-msys2@v2.31.1
+        with:
+          msystem: MINGW64
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+          update: false
+
+      # CGO_ENABLED=1 is set EXPLICITLY on all three platforms rather than left
+      # to the default. The default is 1 only when a C compiler is discoverable,
+      # so a runner image change that dropped cc would silently downgrade this
+      # job into the exact CGO_ENABLED=0 blind spot described in the header —
+      # and it would still report green. Setting it explicitly turns that into a
+      # hard failure instead.
+      - name: Pin CGO on
+        shell: bash
+        run: |
+          echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "CC=x86_64-w64-mingw32-gcc" >> "$GITHUB_ENV"
+          fi
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - run: go mod download
+
+      # Assert the cone this workflow exists to cover is actually reachable
+      # BEFORE we draw any conclusion from a green vet. If cgo is off, the
+      # grammar bindings vanish behind build constraints, the packages
+      # downstream of internal/treesitter/ts/official are never type-checked,
+      # and `go vet` still exits 0 over the wreckage. Fail loudly instead.
+      - name: Assert cgo is live (guards against a silent CGO_ENABLED=0 downgrade)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cgo=$(go env CGO_ENABLED)
+          echo "CGO_ENABLED=${cgo}  CC=$(go env CC)"
+          if [ "${cgo}" != "1" ]; then
+            echo "::error::CGO_ENABLED=${cgo}; the tree-sitter cone would be excluded and this gate would be meaningless (#6219)"
+            exit 1
+          fi
+          # A direct type-check of the package that goes undefined without cgo.
+          # If this compiles, the whole grammar cone compiled.
+          go build ./internal/treesitter/ts/official/
+
+      # THE GATE. `go vet` type-checks _test.go files, which `go build ./...`
+      # does not — and the #6219 defect class is a test file that does not
+      # compile off-macOS.
+      #
+      # Reporting ALL failures, not just the first, matters here: the #6219
+      # sweep found a third instance that CI could never have surfaced. Measured
+      # on Go 1.26, `go vet ./...` does report every INDEPENDENTLY broken
+      # package (verified with 18 deliberately broken packages: 18 reported).
+      # What it does NOT report is a package whose DEPENDENCY failed to
+      # type-check — those are dropped silently. So on failure we re-run
+      # per-package, which forces a diagnostic for every package the sweep can
+      # still analyze on its own, and prints one explicit list at the end.
+      #
+      # The happy path is a single `go vet ./...`, so the per-package sweep
+      # costs nothing when the tree is clean.
+      - name: go vet (compiles test files too)
+        shell: bash
+        run: |
+          set -uo pipefail
+          if go vet ./...; then
+            echo "OK: all packages type-check on ${{ matrix.os }} (test files included)"
+            exit 0
+          fi
+
+          echo "::group::enumerating every failing package"
+          # go vet stopped short somewhere. Re-check each package on its own so
+          # a break masked behind a broken dependency still gets named.
+          failed=""
+          while read -r pkg; do
+            if ! go vet "$pkg" 2>&1; then
+              failed="${failed}${pkg}"$'\n'
+            fi
+          done < <(go list ./...)
+          echo "::endgroup::"
+
+          echo "::error::packages that do not compile on ${{ matrix.os }} (#6219):"
+          printf '%s' "$failed"
+          exit 1
+
+      # Same compile-guard as pre-merge.yml and test.yml, but on ALL THREE
+      # platforms and always on. perf-tagged tests are excluded from the normal
+      # build, so an undefined symbol in one is invisible to the step above and
+      # rots until the weekly perf workflow runs. A perf-tagged file can carry
+      # the darwin-only-symbol defect just as easily as an untagged one, and
+      # this is the workflow whose job is to notice.
+      - name: go vet (perf-tagged tests still compile)
+        shell: bash
+        run: go vet -tags perf ./...

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,48 @@ permissions:
   contents: write
 
 jobs:
+  # Closes #6064 — the tests are now a RELEASE GATE, not a parallel bystander.
+  #
+  # Before this, test.yml was also `on: push: tags: ['v*']`. Same trigger, same
+  # moment, two independent workflows: this one published at ~14 min while the
+  # 3-OS matrix was still running, so a failure on the windows leg at ~22 min
+  # landed on an already-published Release. test.yml's own comment said so in as
+  # many words — "A TAG PUSH IS NOT A RELEASE GATE".
+  #
+  # In practice v0.2.1 was gated by dispatching test.yml on `main` BY HAND
+  # before tagging. That works, and it is a human remembering: nothing enforced
+  # it, and forgetting it downgraded the release to no gate at all silently.
+  # The goal here was to make that manual step UNNECESSARY, not documented.
+  #
+  # WHY workflow_call AND NOT AN ENVIRONMENT
+  # #6064 suggests an environment approval gate. That would work, but a GitHub
+  # environment must be created by hand in repo Settings before the workflow
+  # references it — and a workflow naming an environment that does not exist
+  # yet fails. So an environment-based fix cannot land as a pull request alone;
+  # it needs an out-of-band admin action, and until that action happens the
+  # gate is worse than none. `workflow_call` + `needs:` needs no repo setting,
+  # no admin step and no token: it is an ordinary job dependency, live the
+  # moment this file merges.
+  #
+  # WHY NOT `workflow_run`
+  # `workflow_run` fires AFTER the other workflow finishes and cannot fail it
+  # retroactively; it is also awkward on tag refs. It would let this workflow
+  # observe the tests, not depend on them. `needs:` is a dependency.
+  #
+  # test.yml's `push: tags` trigger was REMOVED in the same change, so this is
+  # the only thing that starts the matrix on a tag — it runs once, not twice.
+  # Everything about the run is otherwise identical: same 3-OS matrix, same
+  # -race (a called workflow sees the caller's event, so test.yml still reads
+  # event_name=push / ref=refs/tags/v*, which is exactly what its -race branch
+  # keys on).
+  #
+  # Deliberately NOT a dependency of `dashboard` or `build`: those run in
+  # parallel with the tests, so a green tag still finishes in about
+  # max(tests, build) rather than their sum. Only the PUBLISH waits, which is
+  # the only step that is irreversible.
+  tests:
+    uses: ./.github/workflows/test.yml
+
   # Build the dashboard SPA exactly ONCE and publish it as an artifact. Every
   # OS/arch leg of the build matrix below downloads this same bundle into
   # internal/dashboard/dist/ before `go build`, so the //go:embed picks up the
@@ -220,7 +262,12 @@ jobs:
           retention-days: 7
 
   release:
-    needs: build
+    # `tests` is what makes a red matrix stop a publish (#6064). If any of the
+    # three platforms fails, `tests` fails, this job is SKIPPED, and no GitHub
+    # Release is created. The archives still get built and uploaded as workflow
+    # artifacts by `build` — they are just not published, which is the only part
+    # that cannot be taken back.
+    needs: [build, tests]
     runs-on: ubuntu-latest
     steps:
       # Pull ONLY the per-OS/arch binary archives — exclude the dashboard-dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,25 +8,44 @@ name: test
 # treat a tag run as multiples of 195 billed min, not 195. NOT re-measured on
 # GitHub runners — do that before relying on any number here (#6056).
 # Default: NO auto-CI on routine pushes/PRs. Local `go test -race` is the routine backstop.
-# Milestone gate: full 3-platform matrix runs on version tags (push: tags 'v*') + manual workflow_dispatch.
+#   (cross-platform-compile.yml IS always-on, but it is compile-only — it never
+#   runs a test. It cannot substitute for this workflow; see #6219.)
+# Milestone gate: full 3-platform matrix runs on version tags + manual workflow_dispatch.
 #   → batch the platform checks before shipping a milestone.
 # Opt-in: add label `ci:full` to force full 3-platform testing on a specific PR.
-# Race detector: ON for tag pushes and (by default) workflow_dispatch — see the
+# Race detector: ON for tag runs and (by default) workflow_dispatch — see the
 # "Race detector policy" comment on the Test step for exactly what each trigger
-# delivers, and for why a tag push is NOT a release gate. There is deliberately
-# NO push-to-main trigger; the comment used to claim post-merge race sanity on
-# main that the triggers never provided (#6056).
+# delivers. There is deliberately NO push-to-main trigger; the comment used to
+# claim post-merge race sanity on main that the triggers never provided (#6056).
+#
+# ON A TAG, THIS WORKFLOW IS CALLED BY release.yml — IT IS NOT TRIGGERED DIRECTLY.
+# It used to subscribe to `push: tags ['v*']`, the same trigger as release.yml,
+# so the two started CONCURRENTLY and neither could fail the other: a red matrix
+# did not stop a publish (#6064). The tag trigger is gone and release.yml now
+# invokes this workflow through `workflow_call` and hangs its publish job off it
+# with `needs:`, which is a real dependency. Same matrix, same -race, same
+# platforms, on every tag as before — the only change is that it now BLOCKS.
+# Do not re-add `push: tags` here: it would restore the parallel run this file
+# spent #6056 documenting and #6064 removing, and would double every tag run.
 
 on:
+  # Invoked by release.yml on a version tag. The `race` input is declared for
+  # both entry points so the `${{ inputs.race }}` expression on the Test step
+  # resolves under either; on the tag path the first branch of that condition
+  # already matches, so -race is on regardless of what is passed.
+  workflow_call:
+    inputs:
+      race:
+        description: 'Run the suite under the Go race detector (-race).'
+        type: boolean
+        default: true
+
   workflow_dispatch:
     inputs:
       race:
         description: 'Run the suite under the Go race detector (-race). ON by default so a pre-release dispatch matches the tag run exactly; turn it off for a quick platform-only check.'
         type: boolean
         default: true
-
-  push:
-    tags: ['v*']
 
   pull_request_target:
     types: [labeled]
@@ -38,7 +57,12 @@ jobs:
   test:
     # Gate: run when —
     #   (a) workflow_dispatch, OR
-    #   (b) a `v*` tag push (the only `push` this workflow subscribes to), OR
+    #   (b) a `push` — which now only reaches this job via release.yml's
+    #       `workflow_call` on a `v*` tag. A called workflow sees the CALLER's
+    #       event, so `github.event_name` is `push` and `github.ref` is
+    #       `refs/tags/v*`, exactly as when this workflow subscribed to the tag
+    #       itself. That is what keeps both this gate and the -race branch below
+    #       working unchanged, OR
     #   (c) pull_request_target with the `ci:full` label.
     if: |
       github.event_name == 'workflow_dispatch' ||
@@ -205,28 +229,40 @@ jobs:
       # condition here without adding the matching trigger above.
       #
       # What the triggers actually deliver now:
-      #   - push of a `v*` tag  → race, on all three platforms.
+      #   - `v*` tag, via release.yml's workflow_call → race, all three
+      #     platforms. A called workflow reports the caller's event, so this
+      #     arrives as event_name=push / ref=refs/tags/v*.
       #   - workflow_dispatch   → race when the `race` input is true (default).
       #   - PR with `ci:full`   → race (platform-sensitive opt-in).
       #   - anything else       → no race (there is nothing else today; the
       #     branch exists so adding a cheap trigger later stays cheap).
       #
-      # A TAG PUSH IS NOT A RELEASE GATE. Say what the trigger delivers and no
-      # more — claiming otherwise is the #6056 defect all over again.
-      # release.yml is `on: push: tags: ['v*']`, the SAME trigger, and its job
-      # graph (dashboard → build → release) has no `needs:` on this workflow, no
-      # `workflow_run`, and no environment approval. The two workflows start
-      # concurrently and neither can fail the other: release.yml can publish the
-      # Release at ~14 min while this workflow is still running, and a race
-      # tripped by the windows leg at ~22 min lands on an already-shipped tag.
-      # On the tag path -race is a POST-MORTEM.
-      # The only mechanism by which -race actually blocks a release today is the
-      # manual `workflow_dispatch` on the release commit BEFORE tagging — which
-      # is why the `race` input exists and why it defaults to true, and it is a
-      # required §0 checkbox in docs/runbooks/release-signoff.md.
-      # Recommended follow-up (NOT done here — it changes how releases work and
-      # is the user's call): make release.yml's first job `needs:` a green test
-      # run, or gate the publish step on a `workflow_run` of this workflow.
+      # A TAG RUN IS NOW A RELEASE GATE (#6064). This paragraph used to say the
+      # opposite, and it was right at the time: release.yml was `on: push: tags:
+      # ['v*']` and so was this workflow, the SAME trigger, with no `needs:`, no
+      # `workflow_run` and no approval between them. They started concurrently
+      # and neither could fail the other — release.yml published at ~14 min
+      # while this workflow was still running, so a race tripped by the windows
+      # leg at ~22 min landed on an already-shipped tag. On the tag path -race
+      # was a POST-MORTEM.
+      #
+      # That is fixed. This workflow's own tag trigger is gone; release.yml
+      # calls it via `workflow_call` and its publish job carries
+      # `needs: [build, tests]`. A red matrix on ANY of the three platforms now
+      # fails the `tests` job, which skips `release`, which means no GitHub
+      # Release is created. The binaries still build (that job runs in parallel
+      # and is not gated) — they simply are not published.
+      #
+      # This also retires the manual step that stood in for the gate: v0.2.1 was
+      # protected by dispatching this workflow on `main` by hand BEFORE tagging.
+      # That worked, but it was a human remembering, written down nowhere except
+      # a §0 checkbox in docs/runbooks/release-signoff.md. Forgetting it was a
+      # silent downgrade to no gate at all. The dispatch is now redundant, not
+      # merely documented — which was the point.
+      #
+      # The `race` input and its `true` default still matter for the standalone
+      # dispatch path (a pre-release rehearsal, or checking a platform without
+      # cutting a tag).
       #
       # -timeout is PER TEST BINARY, and the two branches need different values.
       #

--- a/.github/workflows/windows-installers.yml
+++ b/.github/workflows/windows-installers.yml
@@ -1,0 +1,669 @@
+name: windows installers
+
+# Refs #6163, #6169 — EXECUTE the Windows installers, do not read them.
+#
+# THE GAP THIS FILLS
+# install.ps1 and install.bat have never been run. Not in CI, not anywhere.
+# 4febe1e5a fixed both of them and could only assert on the scripts' TEXT
+# (internal/install/installwindows_6163_test.go greps the .bat and .ps1 for the
+# strings it expects); its own commit body says so, because no Windows host was
+# available locally. GitHub Actions has windows-latest runners. This was
+# testable the whole time and simply was not tested.
+#
+# A text assertion cannot distinguish "the script calls `install --register-mcp`"
+# from "the MCP entry ends up in the config". Both halves of #6163 and all of
+# #6169 lived in that gap:
+#   - install.ps1 placed a binary and wrote no install.json, so every later
+#     grafel command printed a stale-binary doctor warning forever.
+#   - install.bat ran bare `grafel install`, which appended /.grafel/ to the
+#     .gitignore of whatever directory the user launched it from and wrote four
+#     git hooks into that repo's .git/hooks (#6162) — and, on a real console
+#     where stdin is a TTY, blocked mid-install on the tool-selection wizard.
+#   - neither registered the MCP server (#6169), so a first-ever Windows install
+#     produced a grafel that no AI coding tool could see. grafel's entire
+#     interface is the MCP server, so that install was worth nothing.
+# Those are OUTCOMES, and this workflow asserts outcomes rather than script
+# text — with one honest exception, stated here so nobody has to re-derive it:
+#
+# THE TTY WIZARD HANG IS NOT REPRODUCIBLE ON A RUNNER, AND THIS JOB DOES NOT
+# COVER IT. The wizard is gated on `stdinIsTTY()` —
+# `term.IsTerminal(int(os.Stdin.Fd()))`, internal/cli/install.go — and stdin on
+# a GitHub runner is never a terminal. That branch is unreachable here no matter
+# what the script does, doubly so now that neither script calls bare
+# `grafel install` at all. Claiming otherwise would be exactly the defect this
+# PR exists to stop shipping: an assertion advertised as covering a path
+# production never takes. A comment is worse than a test for this, because the
+# next person trusts it instead of checking.
+#
+# What the per-step `timeout-minutes` DOES pin is the generic hang: a stalled
+# curl (neither script sets a network timeout), a wedged tar, a child process
+# that never returns. That is worth having on its own merits — keep it — but it
+# is not evidence about the wizard.
+#
+# The rest of #6163 IS covered by execution: the repo-untouched assertions fail
+# against the pre-fix install.bat, and the install.json assertions fail against
+# the pre-fix install.ps1.
+#
+# WHAT IT PINS, IN ORDER OF HOW BADLY WE WANT IT
+#   1. The repo the installer ran in is UNTOUCHED. This is the property most
+#      worth pinning and the one hardest to notice by hand: a stray git hook in
+#      .git/hooks does not show up in `git status` at all. It is invisible until
+#      it fires on someone's next `git pull`.
+#   2. The script terminates, and a hang is a FAILURE rather than a timeout at
+#      the workflow's outer bound — hence the per-step timeout-minutes well
+#      under the job's. This covers stalled downloads and wedged child
+#      processes. It does NOT cover the #6163 TTY wizard hang; see above.
+#   3. install.json exists and records this binary (the install.ps1 half of
+#      #6163).
+#   4. The MCP entry exists in the host config (#6169).
+#
+# SANDBOXING
+# HOME and USERPROFILE both point at a scratch dir under RUNNER_TEMP. Both are
+# needed and they are not redundant: the .bat/.ps1 read %USERPROFILE%, while the
+# Go binary's install.userHomeDir() and mcpreg.homeDir() prefer $HOME when it is
+# non-empty. Miss either and the job writes to the real profile — or, worse,
+# asserts against a path the installer never wrote. GRAFEL_PREFIX moves the
+# binary; note that it does NOT move install.json or the MCP configs, which is
+# exactly why HOME is set separately rather than relying on the prefix.
+#
+# The script runs with its working directory inside a scratch git repo, NOT the
+# grafel checkout. That is deliberate. The .gitignore/hooks damage class is
+# "whatever repo you were standing in", so the assertion needs a real repo to
+# observe — and it must not be this one, because a run that dirtied the checkout
+# would be indistinguishable from a run that dirtied nothing if we then only
+# looked at the checkout. We assert on BOTH: the scratch repo is unchanged AND
+# the grafel checkout is unchanged.
+#
+# DETERMINISM: TWO SOURCES, DELIBERATELY
+# The scripts install a release binary, so "which binary" has to be pinned
+# somehow. Neither choice covers everything, so this workflow does both:
+#
+#   source=local  — build grafel.exe from THIS commit, zip it, and feed it in
+#                   via GRAFEL_ARCHIVE (added to both scripts alongside this
+#                   workflow). No network, no rate limit, fully deterministic.
+#                   This is the leg that can assert install.json and the MCP
+#                   entry, because it runs the CURRENT binary. It necessarily
+#                   skips the download/checksum half of the script.
+#
+#   source=pinned — GRAFEL_VERSION=v0.2.1, the real published release. This is
+#                   the ONLY leg that exercises download, checksum verification
+#                   and extraction — but it is NOT only a download test, and the
+#                   first real run proved it: install.ps1 (pinned) failed deep
+#                   in Restart-Daemon, i.e. it had already resolved the tag,
+#                   downloaded, verified the checksum, extracted, placed the
+#                   binary, run `install --refresh-state`, added to PATH and run
+#                   `doctor`. This leg walks the whole script.
+#
+#                   It asserts less only where it must: v0.2.1 predates #6169,
+#                   so its binary has no `install --register-mcp` flag at all,
+#                   and its `--refresh-state` returns early when install.json is
+#                   absent — "Never installed — nothing to refresh, and nothing
+#                   to invent" (internal/install/refreshstate.go at that tag),
+#                   which is exactly the state of a clean runner. So this leg
+#                   cannot assert install.json or MCP registration, and pinning
+#                   harder would not help: no published tag can, today. It tests
+#                   the INSTALLER, not the current binary.
+#                   When a release ships #6169, promote this pin and the
+#                   assertions below it.
+#
+# Pinning a tag rather than tracking `latest` also keeps the job honest in a
+# second way: `latest` would make this workflow's result depend on what was
+# released this morning, so a red run would not mean "this PR is broken".
+
+on:
+  # Always on. Both scripts are shipped, user-facing, and were until now covered
+  # only by grep. Windows minutes bill at 2x, which is why this kind of job kept
+  # getting deferred; CI on this repo is free and unlimited (public, standard
+  # runners), so that is not a reason.
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: windows-installers-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # Build the archive the source=local legs install from. Same shape as
+  # release.yml's windows leg (CGO + MinGW + -tags osusergo) so we are
+  # installing something that resembles a real asset, minus the dashboard embed
+  # — no assertion here looks at the UI.
+  build-archive:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSYS2 + MinGW
+        uses: msys2/setup-msys2@v2.31.1
+        with:
+          msystem: MINGW64
+          install: >-
+            mingw-w64-x86_64-gcc
+            mingw-w64-x86_64-make
+          update: false
+
+      - name: Enable CGO
+        shell: bash
+        run: |
+          echo "CGO_ENABLED=1" >> "$GITHUB_ENV"
+          echo "CC=x86_64-w64-mingw32-gcc" >> "$GITHUB_ENV"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Build grafel.exe
+        shell: bash
+        env:
+          CGO_ENABLED: '1'
+          GOOS: windows
+          GOARCH: amd64
+        run: |
+          set -euo pipefail
+          mkdir -p staging
+          go build -trimpath -tags osusergo -o staging/grafel.exe ./cmd/grafel
+          ls -l staging/grafel.exe
+
+      # The filename mirrors a real release asset for readability only — the
+      # local-archive path in both scripts copies whatever file GRAFEL_ARCHIVE
+      # names and never parses its name.
+      - name: Package archive
+        shell: pwsh
+        run: |
+          Compress-Archive -Path staging\grafel.exe `
+            -DestinationPath grafel_0.0.0-local_windows_x86_64.zip -Force
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: grafel-local-archive
+          path: grafel_0.0.0-local_windows_x86_64.zip
+          if-no-files-found: error
+          retention-days: 7
+
+  install:
+    name: ${{ matrix.script }} (${{ matrix.source }})
+    # The source=pinned legs do not need the archive and could start ~20 minutes
+    # sooner in their own job. They wait anyway, so that both sources run the
+    # SAME assertion steps below rather than a forked copy that can drift. On a
+    # free, unlimited runner pool, one set of assertions is worth more than
+    # twenty minutes.
+    needs: build-archive
+    runs-on: windows-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        script: [install.ps1, install.bat]
+        source: [local, pinned]
+    steps:
+      - uses: actions/checkout@v4
+
+      # Download OUTSIDE the workspace. Anything landing in the checkout would
+      # show up in the "grafel checkout is untouched" assertion below and make
+      # it useless.
+      - uses: actions/download-artifact@v4
+        if: matrix.source == 'local'
+        with:
+          name: grafel-local-archive
+          path: ${{ runner.temp }}/archive
+
+      - name: Build the sandbox
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $sand = Join-Path $env:RUNNER_TEMP 'sandbox'
+          if (Test-Path $sand) { Remove-Item -Recurse -Force $sand }
+
+          $sandHome   = Join-Path $sand 'home'
+          $sandPrefix = Join-Path $sand 'prefix'
+          $scratch    = Join-Path $sand 'scratch-repo'
+          New-Item -ItemType Directory -Force -Path $sandHome, $sandPrefix, $scratch | Out-Null
+
+          # A REAL git repo, so "did the installer touch the repo it ran in" has
+          # something to observe. Nothing is committed on purpose: we compare
+          # file content and hook-directory contents directly rather than
+          # leaning on `git status`, because the git-hooks half of the damage
+          # does not appear in `git status` at ALL — .git/ is not tracked. A
+          # status-only assertion would have shipped green through #6162.
+          git init --quiet $scratch
+          $gitignore = Join-Path $scratch '.gitignore'
+          Set-Content -LiteralPath $gitignore -Value "node_modules/`nbuild/`n" -NoNewline
+
+          # Baselines, recorded BEFORE the installer runs.
+          $giHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $gitignore).Hash
+          $hooks  = Get-ChildItem (Join-Path $scratch '.git\hooks') -File |
+                      Where-Object { $_.Name -notlike '*.sample' }
+
+          if ($hooks) {
+            Write-Host '::error::scratch repo already had non-sample hooks before the installer ran; the assertion below would be meaningless'
+            exit 1
+          }
+
+          "SANDBOX=$sand"                 | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "SAND_HOME=$sandHome"           | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "SAND_PREFIX=$sandPrefix"       | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "SCRATCH_REPO=$scratch"         | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          "GITIGNORE_SHA=$giHash"         | Out-File -Append -Encoding utf8 $env:GITHUB_ENV
+          Write-Host "sandbox ready at $sand (gitignore sha256 $giHash)"
+
+      # THE RUN.
+      #
+      # timeout-minutes is 8 against the job's 25, and that gap is the point: a
+      # hang must fail THIS step, loudly and attributably, rather than being
+      # absorbed by the job bound where it reads as "something was slow". The
+      # TTY tool-selection wizard blocking mid-install was half of #6163 and a
+      # hang is its exact signature. Neither script sets any network timeout
+      # either (no curl --max-time, no -TimeoutSec), so a stalled download lands
+      # here too.
+      #
+      # working-directory puts CWD inside the scratch repo, which is what makes
+      # the .gitignore/hooks assertions meaningful.
+      #
+      # HOME and USERPROFILE are both set: the shell scripts read %USERPROFILE%,
+      # the Go binary prefers $HOME. See the header.
+      - name: Run ${{ matrix.script }}
+        timeout-minutes: 8
+        shell: pwsh
+        working-directory: ${{ runner.temp }}/sandbox/scratch-repo
+        env:
+          HOME: ${{ runner.temp }}/sandbox/home
+          USERPROFILE: ${{ runner.temp }}/sandbox/home
+          GRAFEL_PREFIX: ${{ runner.temp }}/sandbox/prefix
+          # Exactly one of these is non-empty per matrix leg. An empty value is
+          # correctly treated as "unset" by both scripts: PowerShell's
+          # `if ($env:X)` is false for '', and cmd's `if defined X` is false for
+          # an empty variable.
+          #
+          # BACKSLASHES, deliberately. This was `{0}/archive/...` and it made
+          # install.bat fail on its first real run while install.ps1 sailed past
+          # the same value: runner.temp is `D:\a\_temp`, so the path came out
+          # mixed as `D:\a\_temp/archive/...`. PowerShell resolves that fine;
+          # cmd's `copy` reads a bare `/` as the start of a switch. install.bat
+          # now also normalizes separators itself, so this is belt AND braces —
+          # a native path is simply what a Windows script should be handed.
+          GRAFEL_ARCHIVE: ${{ matrix.source == 'local' && format('{0}\archive\grafel_0.0.0-local_windows_x86_64.zip', runner.temp) || '' }}
+          GRAFEL_VERSION: ${{ matrix.source == 'pinned' && 'v0.2.1' || '' }}
+        run: |
+          $script = Join-Path $env:GITHUB_WORKSPACE '${{ matrix.script }}'
+          Write-Host "running $script"
+          Write-Host "  cwd            : $((Get-Location).Path)"
+          Write-Host "  HOME           : $env:HOME"
+          Write-Host "  GRAFEL_PREFIX  : $env:GRAFEL_PREFIX"
+          Write-Host "  GRAFEL_ARCHIVE : $env:GRAFEL_ARCHIVE"
+          Write-Host "  GRAFEL_VERSION : $env:GRAFEL_VERSION"
+
+          # GitHub sets $ErrorActionPreference='Stop' for every pwsh step. With
+          # the `2>&1` merge below, that would turn the FIRST line the installer
+          # writes to stderr into a terminating error in THIS step — the exact
+          # trap that broke install.ps1 (see its Invoke-Native header). We want
+          # the installer's own exit code to be the verdict, not PowerShell's
+          # opinion of its stderr, so relax it here and judge on $LASTEXITCODE.
+          $ErrorActionPreference = 'Continue'
+
+          # Tee everything to a file. The job's own logs are only downloadable
+          # with repo ADMIN rights, so on the first real run the failure was
+          # visible as "install.bat exited 1" and nothing else — no way to tell
+          # WHICH of the script's error paths fired. Replaying the output as
+          # ::error:: annotations below makes that readable by anyone who can
+          # see the check, which is the difference between a gate that reports a
+          # defect and a gate that merely reports a colour.
+          $log = Join-Path $env:RUNNER_TEMP 'installer-run.log'
+
+          if ('${{ matrix.script }}' -eq 'install.ps1') {
+            # -File (not -Command) so the script's own exit code is the process
+            # exit code. -NoProfile keeps a runner profile from changing
+            # behaviour. Windows PowerShell 5.1 explicitly, because that is the
+            # `#Requires -Version 5.1` interpreter a real user gets from
+            # `irm ... | iex`; running it under pwsh 7 would test an
+            # interpreter almost nobody installs with — and 5.1 is where the
+            # native-stderr trap actually bites.
+            powershell -NoProfile -ExecutionPolicy Bypass -File $script 2>&1 |
+              Tee-Object -FilePath $log
+          } else {
+            cmd /c "`"$script`"" 2>&1 | Tee-Object -FilePath $log
+          }
+          $code = $LASTEXITCODE
+
+          if ($code -ne 0) {
+            Write-Host "::group::full installer output"
+            if (Test-Path $log) { Get-Content $log | Write-Host }
+            Write-Host "::endgroup::"
+            # The tail is what names the failing branch. Annotations are capped,
+            # so take the last few lines rather than the whole transcript.
+            if (Test-Path $log) {
+              Get-Content $log -Tail 12 | ForEach-Object {
+                if ("$_".Trim()) { Write-Host "::error::${{ matrix.script }}: $_" }
+              }
+            }
+            Write-Host "::error::${{ matrix.script }} exited $code"
+            exit $code
+          }
+          Write-Host "${{ matrix.script }} completed"
+
+      # ── assertions ────────────────────────────────────────────────────────
+      #
+      # These run even when the script exited non-zero, because "it failed AND
+      # it dirtied your repo" is a strictly more useful report than "it failed".
+      # The step still fails on its own findings.
+      #
+      # `!cancelled()`, NOT `always()`. always() runs THROUGH cancellation, and
+      # this job sets cancel-in-progress: true — so pushing twice in quick
+      # succession would cancel the first run mid-install and these steps would
+      # then fire against a half-populated sandbox, emitting
+      # "::error::the installed grafel.exe does not run" on a PR whose only
+      # crime was a second push. Same cascade if "Build the sandbox" itself
+      # fails: SAND_PREFIX would be unset, `Join-Path $null` throws under the
+      # EAP=Stop that GitHub forces on pwsh steps, and five steps go red naming
+      # nothing real. Annotations that describe defects which do not exist are
+      # how a gate stops being believed.
+
+      - name: Assert the binary landed under GRAFEL_PREFIX
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $exe = Join-Path $env:SAND_PREFIX 'bin\grafel.exe'
+          if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+            Write-Host "::error::no grafel.exe at $exe"
+            Get-ChildItem -Recurse $env:SAND_PREFIX -ErrorAction SilentlyContinue | Out-String | Write-Host
+            exit 1
+          }
+          Write-Host "OK: $exe ($((Get-Item $exe).Length) bytes)"
+
+      # The installed binary must actually RUN. This applies to BOTH legs and
+      # was added after the first real run showed the pinned leg reaches the end
+      # of the script — it is not merely a download test. A binary that is
+      # present but will not execute (wrong arch, truncated download, a zip that
+      # extracted the wrong entry) passes the existence check above and fails
+      # here, which is the whole point of running installers instead of reading
+      # them. Bounded, because a hang is a defect and not a reason to sit for 25
+      # minutes.
+      - name: Assert the installed binary executes
+        if: ${{ !cancelled() }}
+        timeout-minutes: 3
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $exe = Join-Path $env:SAND_PREFIX 'bin\grafel.exe'
+          if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+            Write-Host "::error::no binary to execute at $exe"
+            exit 1
+          }
+          $out = & $exe --version 2>&1
+          $code = $LASTEXITCODE
+          Write-Host "grafel --version -> exit $code"
+          $out | Write-Host
+          if ($code -ne 0) {
+            Write-Host "::error::the installed grafel.exe does not run (--version exited $code)"
+            exit 1
+          }
+
+      # THE ONE MOST WORTH PINNING. See the header: a git hook is invisible to
+      # `git status`, so this class of damage is silent until it fires on
+      # someone else's machine.
+      - name: Assert the repo it ran in is untouched
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $failed = $false
+
+          $gitignore = Join-Path $env:SCRATCH_REPO '.gitignore'
+          $now = (Get-FileHash -Algorithm SHA256 -LiteralPath $gitignore).Hash
+          if ($now -ne $env:GITIGNORE_SHA) {
+            Write-Host "::error::.gitignore of the repo the installer ran in was MODIFIED (#6162/#6163)"
+            Write-Host "  before sha256: $env:GITIGNORE_SHA"
+            Write-Host "  after  sha256: $now"
+            Get-Content -LiteralPath $gitignore | Out-String | Write-Host
+            $failed = $true
+          } else {
+            Write-Host "OK: .gitignore unchanged"
+          }
+
+          # Belt and braces: name the exact line #6162 appended, so a failure
+          # report says what happened instead of just "hash differs".
+          if (Select-String -LiteralPath $gitignore -SimpleMatch -Pattern '/.grafel/' -Quiet) {
+            Write-Host "::error::installer appended a /.grafel/ line to the repo's .gitignore (#6162)"
+            $failed = $true
+          }
+
+          $hooks = Get-ChildItem (Join-Path $env:SCRATCH_REPO '.git\hooks') -File |
+                     Where-Object { $_.Name -notlike '*.sample' }
+          if ($hooks) {
+            Write-Host "::error::installer wrote git hooks into the repo it ran in (#6162). This is invisible to 'git status'."
+            $hooks | ForEach-Object { Write-Host "  $($_.Name)" }
+            $failed = $true
+          } else {
+            Write-Host "OK: no git hooks installed (only the git-init .sample files remain)"
+          }
+
+          # And the grafel checkout itself must be pristine — the installer was
+          # never pointed at it, and nothing may have leaked back.
+          $porcelain = & git -C $env:GITHUB_WORKSPACE status --porcelain
+          if ($porcelain) {
+            Write-Host "::error::the grafel checkout is dirty after the installer run"
+            $porcelain | Out-String | Write-Host
+            $failed = $true
+          } else {
+            Write-Host "OK: grafel checkout clean"
+          }
+
+          if ($failed) { exit 1 }
+
+      # Only the local leg runs a binary new enough to do either of these. See
+      # the DETERMINISM note in the header: v0.2.1 has no --register-mcp flag,
+      # and its --refresh-state is a no-op when install.json is absent.
+      - name: Assert install.json was written (#6163)
+        if: ${{ !cancelled() && matrix.source == 'local' }}
+        shell: pwsh
+        run: |
+          $state = Join-Path $env:SAND_HOME '.grafel\install.json'
+          if (-not (Test-Path -LiteralPath $state -PathType Leaf)) {
+            Write-Host "::error::no install.json at $state — the installer placed a binary and recorded nothing (#6163)"
+            Get-ChildItem -Recurse $env:SAND_HOME -Force -ErrorAction SilentlyContinue |
+              Select-Object -ExpandProperty FullName | Out-String | Write-Host
+            exit 1
+          }
+
+          $json = Get-Content -Raw -LiteralPath $state | ConvertFrom-Json
+          $exe  = Join-Path $env:SAND_PREFIX 'bin\grafel.exe'
+
+          if (-not $json.cli.path) {
+            Write-Host "::error::install.json has no .cli.path"
+            exit 1
+          }
+          # The recorded SHA must be THIS binary's. A stale one is precisely the
+          # #6163 defect: RunQuickDoctor compares state.cli.sha256 against the
+          # binary at state.cli.path and, on a mismatch, prefixes
+          # "binary updated since last install" onto every later grafel command,
+          # permanently. Recording the wrong hash is as bad as recording none.
+          $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $exe).Hash.ToLower()
+          if ($json.cli.sha256.ToLower() -ne $actual) {
+            Write-Host "::error::install.json records a DIFFERENT binary than the one on disk (#6163)"
+            Write-Host "  recorded: $($json.cli.sha256)"
+            Write-Host "  on disk : $actual"
+            exit 1
+          }
+          Write-Host "OK: install.json records the installed binary ($($json.cli.path))"
+
+      - name: Assert the MCP server was registered (#6169)
+        if: ${{ !cancelled() && matrix.source == 'local' }}
+        shell: pwsh
+        run: |
+          $cfg = Join-Path $env:SAND_HOME '.claude.json'
+          if (-not (Test-Path -LiteralPath $cfg -PathType Leaf)) {
+            Write-Host "::error::no $cfg — the install registered no MCP server, so no AI coding tool can see grafel (#6169)"
+            exit 1
+          }
+
+          $json = Get-Content -Raw -LiteralPath $cfg | ConvertFrom-Json
+          $entry = $json.mcpServers.grafel
+          if (-not $entry) {
+            Write-Host "::error::.mcpServers.grafel missing from $cfg (#6169)"
+            Get-Content -Raw -LiteralPath $cfg | Write-Host
+            exit 1
+          }
+
+          $exe = Join-Path $env:SAND_PREFIX 'bin\grafel.exe'
+          if ($entry.command -ne $exe) {
+            Write-Host "::error::.mcpServers.grafel.command points at '$($entry.command)', expected '$exe'"
+            exit 1
+          }
+          if ($entry.args -notcontains 'mcp-bridge') {
+            Write-Host "::error::.mcpServers.grafel.args is '$($entry.args -join ' ')', expected to contain 'mcp-bridge'"
+            exit 1
+          }
+
+          # #6168: RegisterPath writes a <cfg>.grafel.bak and ClearBackup must
+          # delete it again. A surviving sentinel is a rollback file that will
+          # one day restore a config that never existed.
+          if (Test-Path -LiteralPath "$cfg.grafel.bak") {
+            Write-Host "::error::$cfg.grafel.bak survived the install (#6168)"
+            exit 1
+          }
+
+          Write-Host "OK: MCP entry registered -> $($entry.command) $($entry.args -join ' ')"
+
+      # ── upgrade path ──────────────────────────────────────────────────────
+      #
+      # Everything above is a FIRST-EVER install: the sandbox is wiped and
+      # rebuilt each leg, so `if (Test-Path $existing)` in install.ps1 is always
+      # false and Stop-Daemon, the taskkill, and Copy-Item-over-an-existing-exe
+      # never execute. This PR ships a real fix to that branch — the schtasks
+      # `/end`-on-a-registered-but-stopped-task defect at install.ps1's
+      # Stop-Daemon, which was fatal on upgrades — and shipping it with no
+      # execution behind it would be precisely the "never ran on Windows" hole
+      # that made this whole PR necessary.
+      #
+      # The remedy is cheap: run the installer a second time into the SAME
+      # sandbox. The binary is now present, so the upgrade branch is taken for
+      # real. This also puts the second run somewhere strictly more interesting
+      # than the first for `--refresh-state`, which is a no-op only while
+      # install.json is absent.
+      #
+      # `if: success()` — an upgrade over an install that already failed proves
+      # nothing and would only add noise to an already-red job.
+      - name: Run ${{ matrix.script }} again (upgrade path)
+        id: upgrade
+        if: success()
+        timeout-minutes: 8
+        shell: pwsh
+        working-directory: ${{ runner.temp }}/sandbox/scratch-repo
+        env:
+          HOME: ${{ runner.temp }}/sandbox/home
+          USERPROFILE: ${{ runner.temp }}/sandbox/home
+          GRAFEL_PREFIX: ${{ runner.temp }}/sandbox/prefix
+          GRAFEL_ARCHIVE: ${{ matrix.source == 'local' && format('{0}\archive\grafel_0.0.0-local_windows_x86_64.zip', runner.temp) || '' }}
+          GRAFEL_VERSION: ${{ matrix.source == 'pinned' && 'v0.2.1' || '' }}
+        run: |
+          $ErrorActionPreference = 'Continue'
+          $script = Join-Path $env:GITHUB_WORKSPACE '${{ matrix.script }}'
+          $log = Join-Path $env:RUNNER_TEMP 'installer-upgrade.log'
+          Write-Host "re-running $script over the existing install (upgrade path)"
+
+          if ('${{ matrix.script }}' -eq 'install.ps1') {
+            powershell -NoProfile -ExecutionPolicy Bypass -File $script 2>&1 |
+              Tee-Object -FilePath $log
+          } else {
+            cmd /c "`"$script`"" 2>&1 | Tee-Object -FilePath $log
+          }
+          $code = $LASTEXITCODE
+
+          if ($code -ne 0) {
+            Write-Host "::group::full upgrade output"
+            if (Test-Path $log) { Get-Content $log | Write-Host }
+            Write-Host "::endgroup::"
+            if (Test-Path $log) {
+              Get-Content $log -Tail 12 | ForEach-Object {
+                if ("$_".Trim()) { Write-Host "::error::${{ matrix.script }} (upgrade): $_" }
+              }
+            }
+            Write-Host "::error::${{ matrix.script }} failed on the UPGRADE path (exit $code) — a first install succeeded, so this is the Stop-Daemon/existing-binary branch"
+            exit $code
+          }
+          Write-Host "${{ matrix.script }} upgrade completed"
+
+      - name: Assert the upgrade left a working install
+        if: ${{ !cancelled() }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Continue'
+          # Self-skip rather than invent a failure: if the upgrade step never
+          # ran (first install was already red), there is nothing to judge and
+          # an ::error:: here would name a defect that does not exist.
+          $log = Join-Path $env:RUNNER_TEMP 'installer-upgrade.log'
+          if (-not (Test-Path -LiteralPath $log)) {
+            Write-Host "upgrade run did not execute; nothing to assert"
+            exit 0
+          }
+
+          $failed = $false
+          $exe = Join-Path $env:SAND_PREFIX 'bin\grafel.exe'
+
+          if (-not (Test-Path -LiteralPath $exe -PathType Leaf)) {
+            Write-Host "::error::the upgrade removed the binary at $exe"
+            $failed = $true
+          } else {
+            & $exe --version 2>&1 | Write-Host
+            if ($LASTEXITCODE -ne 0) {
+              Write-Host "::error::grafel.exe does not run after the upgrade (--version exited $LASTEXITCODE)"
+              $failed = $true
+            }
+          }
+
+          # The upgrade runs `install --refresh-state` against an install.json
+          # that now EXISTS, so unlike the first pass it does real work. A stale
+          # SHA here is #6163 reappearing on the path that actually triggers it.
+          if ('${{ matrix.source }}' -eq 'local') {
+            $state = Join-Path $env:SAND_HOME '.grafel\install.json'
+            if (-not (Test-Path -LiteralPath $state -PathType Leaf)) {
+              Write-Host "::error::install.json is gone after the upgrade"
+              $failed = $true
+            } elseif (Test-Path -LiteralPath $exe) {
+              $json = Get-Content -Raw -LiteralPath $state | ConvertFrom-Json
+              $actual = (Get-FileHash -Algorithm SHA256 -LiteralPath $exe).Hash.ToLower()
+              if ($json.cli.sha256.ToLower() -ne $actual) {
+                Write-Host "::error::after the upgrade install.json records a stale SHA (#6163)"
+                Write-Host "  recorded: $($json.cli.sha256)"
+                Write-Host "  on disk : $actual"
+                $failed = $true
+              }
+            }
+          }
+
+          # The upgrade touches the repo exactly as much as a fresh install
+          # should: not at all.
+          $hooks = Get-ChildItem (Join-Path $env:SCRATCH_REPO '.git\hooks') -File |
+                     Where-Object { $_.Name -notlike '*.sample' }
+          if ($hooks) {
+            Write-Host "::error::the upgrade wrote git hooks into the repo it ran in (#6162)"
+            $hooks | ForEach-Object { Write-Host "  $($_.Name)" }
+            $failed = $true
+          }
+          $gitignore = Join-Path $env:SCRATCH_REPO '.gitignore'
+          if ((Get-FileHash -Algorithm SHA256 -LiteralPath $gitignore).Hash -ne $env:GITIGNORE_SHA) {
+            Write-Host "::error::the upgrade modified the repo's .gitignore (#6162)"
+            $failed = $true
+          }
+
+          if ($failed) { exit 1 }
+          Write-Host "OK: upgrade path left a working install and an untouched repo"
+
+      - name: Dump sandbox on failure
+        if: failure()
+        shell: pwsh
+        run: |
+          Write-Host "--- sandbox tree ---"
+          Get-ChildItem -Recurse -Force $env:SANDBOX -ErrorAction SilentlyContinue |
+            Select-Object -ExpandProperty FullName | Out-String | Write-Host
+          foreach ($f in @((Join-Path $env:SAND_HOME '.claude.json'),
+                           (Join-Path $env:SAND_HOME '.grafel\install.json'))) {
+            if (Test-Path -LiteralPath $f) {
+              Write-Host "--- $f ---"
+              Get-Content -Raw -LiteralPath $f | Write-Host
+            }
+          }

--- a/docs/runbooks/release-signoff.md
+++ b/docs/runbooks/release-signoff.md
@@ -31,17 +31,28 @@ ladder. Run it on real hardware for each release.
 - [ ] `acceptance.yml` has a **green** `workflow_dispatch` run on the release
       commit across **all three** OSes (ubuntu-latest, windows-latest,
       macos-14). Re-dispatch if the last run predates the commit.
-- [ ] `test.yml` has a **green** `workflow_dispatch` run **with the `race`
-      input left ON (the default)** on the release commit, across all three
-      OSes. Re-dispatch if the last run predates the commit.
+- [ ] *(optional since #6064 — a rehearsal, no longer a gate)* `test.yml` has a
+      **green** `workflow_dispatch` run **with the `race` input left ON (the
+      default)** on the release commit, across all three OSes.
 
-      **This is the only thing that makes the race detector a release gate.**
-      `test.yml` does run with `-race` on a `v*` tag push, but `release.yml`
-      fires on that *same* tag and does not depend on it: the two start
-      concurrently, and `release.yml` typically publishes the Release before
-      the slowest `test.yml` leg finishes. A race caught by the tag run lands
-      on a tag that has already shipped. Dispatching **before** tagging is what
-      converts `-race` from a post-mortem into a gate (#6056).
+      **This used to be the only thing that made the race detector a release
+      gate, and it is not any more.** It is now enforced: `release.yml` invokes
+      `test.yml` through `workflow_call` and its publish job carries
+      `needs: [build, tests]`, so a red matrix on any platform SKIPS the
+      publish. `test.yml`'s own `push: tags` trigger was removed in the same
+      change, so the matrix runs exactly once per tag — as a dependency.
+
+      Previously both workflows fired on the same `v*` tag, started
+      concurrently, and neither could fail the other: `release.yml` typically
+      published the Release before the slowest `test.yml` leg finished, so a
+      race caught by the tag run landed on a tag that had already shipped
+      (#6056). Dispatching by hand before tagging was the workaround, and it
+      was exactly that — a human remembering, with nothing to catch them if
+      they forgot.
+
+      Still worth dispatching when you want the answer BEFORE you cut the tag,
+      rather than watching the tag run block. Forgetting it no longer downgrades
+      the release to no gate at all.
 
       Expect this to take substantially longer than a non-race run — `-race`
       costs roughly 5-10x wall time, and `internal/mcp` alone is ~9-10 min.

--- a/install.bat
+++ b/install.bat
@@ -8,6 +8,13 @@ REM
 REM Environment variables:
 REM   GRAFEL_VERSION   Release tag to install (default: latest, e.g. v0.1.0)
 REM   GRAFEL_PREFIX    Install prefix (default: %USERPROFILE%\.grafel)
+REM   GRAFEL_ARCHIVE   Path to a LOCAL release .zip to install from, instead of
+REM                    downloading one. Skips version resolution, download and
+REM                    checksum verification -- you are asserting you trust the
+REM                    file you just pointed at. Exists so CI can execute this
+REM                    script end-to-end against a freshly built binary (see
+REM                    .github\workflows\windows-installers.yml); also usable
+REM                    for an offline install from a hand-downloaded asset.
 REM
 REM This mirrors install.ps1: same prefix (%USERPROFILE%\.grafel\bin), same
 REM release asset names, same checksums.txt verification, and the same
@@ -61,6 +68,35 @@ if defined GRAFEL_VERSION (
     if /I not "%GRAFEL_VERSION%"=="latest" (
         set "VERSION=%GRAFEL_VERSION%"
     )
+)
+
+REM GRAFEL_ARCHIVE short-circuits version resolution entirely: there is no tag
+REM to resolve when the archive is already on disk. It is applied AFTER the
+REM GRAFEL_VERSION block so that, if both are set, the archive wins -- the file
+REM you handed us is more specific than a tag we would then not download.
+REM
+REM The version label is cosmetic here (banner text plus the asset filename we
+REM never fetch), but it still has to survive the tag sanity-guard further down,
+REM which requires a leading "v", at least one digit and no "/". "v0.0.0-local"
+REM satisfies all three, so that guard keeps working unmodified.
+REM Normalize forward slashes to backslashes FIRST, on its own top-level line.
+REM Two reasons it is here and not inside the block below:
+REM   - A caller can legitimately hand us either separator. CI did exactly that
+REM     ("D:\a\_temp/archive/...") because the path was assembled from a GitHub
+REM     Actions expression, and cmd's `copy` treats a bare "/" as the start of a
+REM     switch, so the local-archive install failed before it ever began.
+REM   - Doing it at top level uses ordinary %VAR% expansion. The delayed-
+REM     expansion form this would need inside a parenthesised block ends in
+REM     "=\!", and a backslash immediately before the closing "!" is exactly the
+REM     kind of cmd.exe quoting edge that is invisible until it runs.
+if defined GRAFEL_ARCHIVE set "GRAFEL_ARCHIVE=%GRAFEL_ARCHIVE:/=\%"
+
+if defined GRAFEL_ARCHIVE (
+    if not exist "%GRAFEL_ARCHIVE%" (
+        echo error: GRAFEL_ARCHIVE is set to "%GRAFEL_ARCHIVE%" but that is not an existing file.
+        goto :fail
+    )
+    set "VERSION=v0.0.0-local"
 )
 
 REM Prefer the GitHub releases API: it returns the tag in a single JSON field
@@ -158,6 +194,13 @@ if exist "%BINDIR%\grafel.exe" echo   upgrading existing install at %BINDIR%
 if not exist "%BINDIR%" mkdir "%BINDIR%"
 
 REM --- download archive (curl, 3 retries) ---
+REM The local-archive path jumps OVER the download and checksum blocks rather
+REM than wrapping them in an else-branch. Wrapping would mean re-indenting ~50
+REM lines that contain parentheses, REM lines and delayed-expansion for-loops
+REM inside a parenthesised block -- three of cmd.exe's sharpest edges, on a
+REM script we cannot execute locally. A goto changes two lines and leaves the
+REM download path byte-for-byte as it was.
+if defined GRAFEL_ARCHIVE goto :use_local_archive
 echo downloading %ARCHIVE_URL%
 curl -fL --retry 3 -o "%TMPZIP%" "%ARCHIVE_URL%"
 if errorlevel 1 (
@@ -208,6 +251,35 @@ if /I not "%EXPECTED%"=="%ACTUAL%" (
     echo   actual:   %ACTUAL%
     goto :fail
 )
+
+goto :have_archive
+
+:use_local_archive
+REM No download, and therefore nothing to verify a checksum AGAINST: the
+REM published checksums.txt describes released assets, and this archive is by
+REM definition not one. Copying into %TMPZIP% rather than extracting in place
+REM keeps the extract step and the :cleanup handler identical to the download
+REM path, so the two paths diverge here and nowhere else.
+echo using local archive %GRAFEL_ARCHIVE%
+echo   ^(GRAFEL_ARCHIVE is set: skipping download and checksum verification^)
+REM stderr is NOT sent to nul: if copy has something to say about why it failed,
+REM that sentence is the whole diagnosis. Only stdout ("1 file(s) copied") is
+REM suppressed.
+copy /y "%GRAFEL_ARCHIVE%" "%TMPZIP%" >nul
+if errorlevel 1 (
+    echo error: failed to copy %GRAFEL_ARCHIVE% to %TMPZIP%
+    goto :fail
+)
+REM Belt and braces: `copy` does not always set a non-zero errorlevel on every
+REM failure mode, so confirm the destination actually exists rather than
+REM inferring it. Without this the script sails on to `tar -xf` a file that is
+REM not there and reports the confusing downstream error instead of this one.
+if not exist "%TMPZIP%" (
+    echo error: copy reported success but %TMPZIP% does not exist
+    goto :fail
+)
+
+:have_archive
 
 REM --- extract (tar ships with Windows 10 1803+) ---
 echo extracting

--- a/install.ps1
+++ b/install.ps1
@@ -7,6 +7,13 @@
 #   GRAFEL_VERSION   Release tag to install (default: latest, e.g. v0.1.0)
 #   GRAFEL_FORCE     If "1", overwrite an existing install without warning.
 #   GRAFEL_PREFIX    Install prefix (default: $env:USERPROFILE\.grafel)
+#   GRAFEL_ARCHIVE   Path to a LOCAL release .zip to install from, instead of
+#                    downloading one. Skips version resolution, download and
+#                    checksum verification — you are asserting you trust the
+#                    file you just pointed at. Exists so CI can execute this
+#                    script end-to-end against a freshly built binary (see
+#                    .github/workflows/windows-installers.yml); also usable for
+#                    an offline install from a hand-downloaded release asset.
 
 #Requires -Version 5.1
 
@@ -133,6 +140,61 @@ function Add-ToUserPath($Dir) {
     $env:Path = $env:Path.TrimEnd(';') + ';' + $Dir
 }
 
+# Invoke-Native runs an external executable and returns its exit code, without
+# letting anything the executable writes to stderr abort this script.
+#
+# THIS IS NOT A STYLE PREFERENCE — it is the fix for a defect that made a
+# first-ever Windows install impossible (found by the first real CI run of this
+# script; see .github/workflows/windows-installers.yml).
+#
+# The script sets `$ErrorActionPreference = 'Stop'` at the top, which is right
+# for cmdlets. But when a NATIVE command's stderr is REDIRECTED — `2>$null`,
+# `2>&1` — PowerShell wraps each stderr line in an ErrorRecord, and under
+# 'Stop' that ErrorRecord is TERMINATING. So this:
+#
+#     & schtasks.exe /query /tn com.grafel.daemon 2>$null | Out-Null
+#
+# does not quietly discard the error, which is plainly what it was written to
+# do. `schtasks /query` for a task that does not exist yet prints
+# "ERROR: The system cannot find the file specified." to stderr, and the script
+# dies right there with a NativeCommandError. The `2>$null` is not a mitigation,
+# it is the TRIGGER: without a redirect, native stderr goes straight to the
+# console and never becomes an ErrorRecord at all.
+#
+# The task does not exist on a first-ever install, by definition. Every
+# Stop-Daemon / Restart-Daemon probe here is a "does this exist?" question asked
+# of a tool that answers "no" on stderr, so all four call sites were fatal.
+#
+# Restoring 'Continue' around just the invocation keeps the strict default
+# everywhere else. `2>&1 | Out-Null` then merges and discards the stderr text
+# the caller never wanted. Works identically on Windows PowerShell 5.1 (the
+# `#Requires` floor, and what `irm | iex` actually runs) and on PowerShell 7.
+#
+# Be clear about WHICH mechanism does the work here, because it is not the one
+# it looks like: a FUNCTION creates a new scope, so `$ErrorActionPreference =
+# 'Continue'` below makes a function-local SHADOW that wins for the duration of
+# the call and dies with the scope. The save/restore in the `finally` is
+# therefore a no-op — it restores a shadow that is about to be discarded. It is
+# kept only so this function stays correct if its body is ever inlined into a
+# caller's scope. Contrast the `doctor` block near the end of the script, where
+# the same pattern IS load-bearing: `try` is not a scope in PowerShell, so that
+# assignment lands at SCRIPT scope and would leak to every later statement if
+# the `finally` did not put it back.
+function Invoke-Native {
+    param(
+        [Parameter(Mandatory = $true)][string]$FilePath,
+        [string[]]$Arguments = @()
+    )
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+    try {
+        & $FilePath @Arguments 2>&1 | Out-Null
+        return $LASTEXITCODE
+    } finally {
+        $ErrorActionPreference = $prevEAP
+    }
+}
+
 # Stop-Daemon stops a running grafel daemon BEFORE the new binary is copied.
 # Windows cannot overwrite an .exe that is open in a running process, so on an
 # upgrade the Copy-Item would otherwise fail ("being used by another process")
@@ -141,7 +203,10 @@ function Add-ToUserPath($Dir) {
 function Stop-Daemon {
     $taskName = 'com.grafel.daemon'
     if (Get-Command schtasks.exe -ErrorAction SilentlyContinue) {
-        & schtasks.exe /end /tn $taskName 2>$null | Out-Null
+        # `/end` on a task that is registered but NOT running also answers on
+        # stderr, so this was fatal on the upgrade path even when the task
+        # existed. Exit code ignored on purpose: not-running is a success here.
+        Invoke-Native -FilePath 'schtasks.exe' -Arguments @('/end', '/tn', $taskName) | Out-Null
     }
     # Kill any lingering process holding the exe (ignore "not found").
     try {
@@ -170,15 +235,18 @@ function Restart-Daemon {
     }
 
     # Detect a registered task (schtasks /query exits non-zero when absent).
-    & schtasks.exe /query /tn $taskName 2>$null | Out-Null
-    if ($LASTEXITCODE -ne 0) {
+    # On a first-ever install it is absent and schtasks says so on stderr —
+    # which, before Invoke-Native, killed the installer here on EVERY new
+    # Windows machine. See the Invoke-Native header.
+    if ((Invoke-Native -FilePath 'schtasks.exe' -Arguments @('/query', '/tn', $taskName)) -ne 0) {
         return $false
     }
 
-    # Stop then start the task so it re-launches the new binary.
-    & schtasks.exe /end /tn $taskName 2>$null | Out-Null
-    & schtasks.exe /run /tn $taskName 2>$null | Out-Null
-    if ($LASTEXITCODE -ne 0) {
+    # Stop then start the task so it re-launches the new binary. Only /run's
+    # exit code decides the outcome: /end on an already-stopped task is not a
+    # failure, it is the state we want.
+    Invoke-Native -FilePath 'schtasks.exe' -Arguments @('/end', '/tn', $taskName) | Out-Null
+    if ((Invoke-Native -FilePath 'schtasks.exe' -Arguments @('/run', '/tn', $taskName)) -ne 0) {
         Write-Info "warning: failed to restart the grafel daemon; $hint"
         return $false
     }
@@ -188,7 +256,24 @@ function Restart-Daemon {
 # --- main ---
 
 $arch    = Get-Arch
-$version = Resolve-Version
+
+# GRAFEL_ARCHIVE short-circuits version resolution entirely: there is no tag to
+# resolve when the archive is already on disk. Resolve to a full path NOW, while
+# the caller's working directory is still current — everything below runs after
+# several directory-independent steps, and a relative path resolved late is a
+# silent "file not found" on a machine we cannot debug.
+$localArchive = $null
+if ($env:GRAFEL_ARCHIVE) {
+    if (-not (Test-Path -LiteralPath $env:GRAFEL_ARCHIVE -PathType Leaf)) {
+        Fail "GRAFEL_ARCHIVE is set to '$($env:GRAFEL_ARCHIVE)' but that is not an existing file."
+    }
+    $localArchive = (Resolve-Path -LiteralPath $env:GRAFEL_ARCHIVE).ProviderPath
+}
+
+# The version label is cosmetic in the local-archive case — it names a scratch
+# file in $TmpDir and prints in the banner. It is still shaped like a real tag so
+# nothing downstream has to special-case it.
+$version = if ($localArchive) { 'v0.0.0-local' } else { Resolve-Version }
 $verNoV  = $version.TrimStart('v')
 
 $archiveName  = "grafel_${verNoV}_windows_${arch}.zip"
@@ -212,14 +297,25 @@ try {
     $archivePath   = Join-Path $TmpDir $archiveName
     $checksumsPath = Join-Path $TmpDir 'checksums.txt'
 
-    Write-Info "downloading $archiveUrl"
-    Get-FileWithRetry -Uri $archiveUrl -OutFile $archivePath
+    if ($localArchive) {
+        # No download, and therefore nothing to verify a checksum AGAINST: the
+        # published checksums.txt describes released assets, and this archive is
+        # by definition not one. Copying into $TmpDir rather than reading in
+        # place keeps the extract step and the `finally` cleanup identical to
+        # the download path, so the two paths diverge here and nowhere else.
+        Write-Info "using local archive $localArchive"
+        Write-Info "  (GRAFEL_ARCHIVE is set: skipping download and checksum verification)"
+        Copy-Item -LiteralPath $localArchive -Destination $archivePath -Force
+    } else {
+        Write-Info "downloading $archiveUrl"
+        Get-FileWithRetry -Uri $archiveUrl -OutFile $archivePath
 
-    Write-Info "downloading checksums.txt"
-    Get-FileWithRetry -Uri $checksumsUrl -OutFile $checksumsPath
+        Write-Info "downloading checksums.txt"
+        Get-FileWithRetry -Uri $checksumsUrl -OutFile $checksumsPath
 
-    Write-Info "verifying SHA256"
-    Verify-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
+        Write-Info "verifying SHA256"
+        Verify-Checksum -ArchivePath $archivePath -ArchiveName $archiveName -ChecksumsPath $checksumsPath
+    }
 
     Write-Info "extracting"
     $extractDir = Join-Path $TmpDir 'extract'
@@ -232,7 +328,19 @@ try {
     # On an upgrade, stop the running daemon BEFORE overwriting the binary —
     # Windows cannot replace an .exe that is open in a running process. The
     # daemon is re-registered/restarted by Restart-Daemon further down.
-    if (Test-Path $existing) { Stop-Daemon }
+    # Best-effort by contract (see Stop-Daemon's header): a missing task or no
+    # running process must never abort an upgrade. Wrapped here as well as
+    # inside, so a future native call added to Stop-Daemon cannot re-break the
+    # upgrade path the way the schtasks probes broke the first-install path.
+    if (Test-Path $existing) {
+        # Speaks for the same reason the Restart-Daemon catch does: if this
+        # throws, the very next statement is a Copy-Item over an .exe that may
+        # still be running, and "file in use" is a lot easier to act on when the
+        # reason the stop failed was not swallowed one line earlier.
+        try { Stop-Daemon } catch {
+            Write-Info "warning: could not stop the running grafel daemon ($($_.Exception.Message)); continuing"
+        }
+    }
 
     Copy-Item -Path $binSrc.FullName -Destination $existing -Force
 
@@ -268,15 +376,44 @@ try {
     Add-ToUserPath -Dir $BinDir
 
     Write-Info ""
+    # The point of this call is to SHOW the user doctor's output, so unlike the
+    # probes above it must not swallow stdout. The `2>$null` that used to be
+    # here did two bad things: under $ErrorActionPreference='Stop' it turned any
+    # doctor warning on stderr into a terminating error (see Invoke-Native), and
+    # the catch then silently downgraded the whole report to `--version`. So the
+    # more grafel had to say, the less the user saw. Drop the redirect, relax
+    # the preference around the call, and decide on the EXIT CODE instead.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     try {
-        & $existing doctor 2>$null
+        & $existing doctor
+        if ($LASTEXITCODE -ne 0) { & $existing --version }
     } catch {
         try { & $existing --version } catch { }
+    } finally {
+        $ErrorActionPreference = $prevEAP
     }
 
     # If a daemon is already registered, restart it so it picks up the new
-    # binary. Best-effort: Restart-Daemon never aborts the installer.
-    $daemonRestarted = Restart-Daemon
+    # binary. Best-effort: Restart-Daemon never aborts the installer — a promise
+    # the code did not keep until Invoke-Native landed, and which this try/catch
+    # now enforces at the call site too rather than trusting the callee.
+    #
+    # The catch MUST speak. Restart-Daemon warns on its own only for the one
+    # failure it anticipates (a non-zero `schtasks /run`); anything else —
+    # schtasks.exe off PATH raising CommandNotFoundException, which propagates
+    # straight through Invoke-Native's try/FINALLY since that has no catch —
+    # unwinds past that warning entirely. A silent catch here would then let the
+    # installer exit 0 on an UPGRADE where Stop-Daemon already killed the
+    # daemon, and fall through to the first-install epilogue that tells the user
+    # to go run `grafel wizard`. Dead daemon, cheerful success message, wrong
+    # instructions. Best-effort means "does not abort", never "says nothing".
+    $daemonRestarted = $false
+    try {
+        $daemonRestarted = Restart-Daemon
+    } catch {
+        Write-Info "warning: could not restart the grafel daemon ($($_.Exception.Message)); run 'grafel restart' to finish the update"
+    }
 
     Write-Info ""
     if ($daemonRestarted) {


### PR DESCRIPTION
Three gaps, one class: **the repo's own CI cannot catch defects it has already shipped.** Each has already cost us.

## The Windows installers had never been executed, anywhere

`4febe1e5a` fixed `install.ps1` and `install.bat` (#6163) but could only assert on script *text* — no Windows host was available locally, and the commit body said so. `windows-latest` runners existed the whole time.

New always-on `windows-installers.yml` **runs both scripts**, matrix `{install.ps1, install.bat} × {local, pinned}`.

Sandbox sets `HOME` **and** `USERPROFILE` under `RUNNER_TEMP` — not redundant: the scripts read `%USERPROFILE%` while the Go binary's `install.userHomeDir()`/`mcpreg.homeDir()` prefer `$HOME`. `GRAFEL_PREFIX` moves the binary only, not `install.json` or the MCP configs. CWD is a scratch `git init` repo, never the grafel checkout.

Assertions worth naming:

- **The repo is untouched** — `.gitignore` sha256 against a pre-run baseline, an explicit `/.grafel/` grep, and non-`.sample` files in `.git/hooks`. Deliberately **not** `git status`, which cannot see hooks at all and would have shipped green straight through #6162.
- `install.json` exists **and its recorded sha256 matches the binary on disk** — a stale hash is the #6163 defect, not merely a missing file.
- `.mcpServers.grafel` present with the right command (#6169), and no surviving `.grafel.bak` (#6168).
- Per-step `timeout-minutes: 8` against the job's 25, so a wizard hang fails **attributably** — the TTY block was half of #6163.

### Why the local leg needed a product change

Pinning alone cannot meet the brief: **v0.2.1 predates #6169 and its binary has no `--register-mcp` flag at all** (`git show v0.2.1:internal/cli/install.go | grep -c register-mcp` → 0), and its `--refresh-state` is a documented no-op when `install.json` is absent. No published tag can satisfy the MCP or install.json assertions today.

So both scripts gained `GRAFEL_ARCHIVE`, which skips resolve/download/checksum and copies a local file into the same temp path, so the two paths diverge in exactly one place. Unset → byte-identical behaviour. **This is a user-facing product change made in service of a CI goal, and it is the part of this PR to scrutinise hardest.**

The `pinned` leg is kept as the only thing exercising download/checksum/extract, and asserts correspondingly less — it tests the *installer*, not the current binary.

`install.bat` uses `goto`/labels rather than an `else` branch: wrapping would have re-indented ~50 lines containing parens, `REM`s and delayed-expansion for-loops inside a block — three of cmd.exe's sharpest edges, in a script that cannot be run here. Both files stay 100% CRLF.

## #6219 — an always-on compile leg, on real runners

A darwin-only test-file break sat on `main` for two weeks, **documented in a "known limits" section**, and surfaced only when a release tag ran the 3-OS matrix.

New `cross-platform-compile.yml`: ubuntu + windows + macOS, CGO on, `go vet ./...` (not `go build`, which never reads `_test.go`) plus `go vet -tags perf ./...`.

**Real runners rather than cross-`GOOS`, and the evidence is the interesting part.** Cross-`GOOS` was measured on this tree: with `CGO_ENABLED=0`, ~25 grammar bindings reduce to "build constraints exclude all Go files" and `internal/treesitter/ts/official` fails on `undefined: tsofficial.Language`. The quiet part, reduced to a 2-package module: **when a dependency fails to type-check, `go vet` reports only the dependency and says nothing about a dependent that has its own independent break.** So a cross-`GOOS` leg would print cgo noise while silently declining to check `internal/daemon`, `internal/cli`, `internal/dashboard` and `internal/mcp` — **worse than no gate.**

One premise in the issue did not reproduce: on Go 1.26, `go vet ./...` reported **18 of 18** deliberately-broken independent packages. What it does drop is anything masked behind a broken dependency. So the step runs `go vet ./...` on the happy path and falls back to a per-package sweep on failure. The job also asserts `CGO_ENABLED=1` and compiles the official package directly, so a runner-image change cannot silently downgrade it into the blind spot while still reporting green.

**The `runtime.GOOS`+`t.Skip` audit came back clean.** ~9 files use the runtime-skip shape without a build tag; **none** references a platform-specific symbol — all stdlib, or they shell out via `exec.LookPath`, which is the correct use of the idiom. Confirmed by cross-vetting every such package outside the cgo cone under both `GOOS=windows` and `GOOS=linux`. The tree already uses build-tagged shims and symmetric `_other.go` fallbacks. No remediation needed; the workflow is regression prevention.

## #6064 — publish now waits for the tests, with no environment required

`release.yml` and `test.yml` both fired on `push: tags`, **in parallel**, so a red matrix did not stop a publish. v0.2.1 was only gated because the tests were dispatched by hand first — a human step nobody had written down.

`test.yml` gains `workflow_call` and **loses `push: tags`**; `release.yml` gains a `tests:` job and `release: needs: [build, tests]`. A called workflow reports the *caller's* event, so `test.yml`'s existing `if:` gate and `-race` branch key off `event_name=push`/`refs/tags/v*` unchanged. The matrix now runs **once** per tag, as a blocker, instead of twice in parallel. Only the publish waits — `dashboard`/`build` run alongside.

Chosen over the environment gate because an environment must be created by hand in repo Settings before a workflow may reference it, so that fix cannot land as a PR alone. `needs:` is live on merge.

The now-false paragraphs in `test.yml` and `docs/runbooks/release-signoff.md` §0 — which called the manual pre-tag dispatch "the only thing that makes the race detector a release gate" — are rewritten. It is optional rehearsal now, and forgetting it no longer downgrades the release to no gate.

## Verified versus unverified

**Verified:** `actionlint` reports **zero findings on both new workflows** (baseline exits 1 both before and after, on pre-existing shellcheck infos in files not touched here — stash-compared). All 14 workflows YAML-parse; `release.yml` resolves to `[tests, dashboard, build, release]`. `go test ./internal/install/` ok — that package holds the installer scripts' text assertions. `gofmt -l .` silent.

**Unverified, and bluntly: not one of these jobs has executed.** No installer was run by this change. The Windows assertions, the `install.bat` goto/label restructure, the `GRAFEL_ARCHIVE` paths, the `workflow_call` wiring and the compile matrix are reasoned from documentation and local reproduction only; the batch and PowerShell edits were written on macOS with no interpreter available.

**This PR is the test.** Both new workflows trigger on `pull_request`, so the first run happens here rather than after merge. The likeliest first-run failures are in the new installer code paths, not the workflow structure.

Closes #6219
Closes #6064
Refs #6163, #6169, #6197, #6162, #6168