### PR TITLE
fix(#6240): grafel install detached symlinked MCP configs, widened 0600 to 0644, and silently ate a wrong-typed mcpServers

### DIFF
--- a/internal/atomicfile/atomicfile.go
+++ b/internal/atomicfile/atomicfile.go
@@ -118,3 +118,20 @@ func WriteFile(path string, b []byte, perm os.FileMode) (err error) {
 	err = renameAtomic(tmp, path)
 	return err
 }
+
+// Rename renames tmp over path, recovering from the two Windows-only failures
+// described in rename.go: a read-only destination MoveFileEx refuses to replace,
+// and a transient sharing violation. On unix it is exactly one os.Rename.
+//
+// This is the second half of WriteFile exposed on its own, for the writers that
+// cannot use WriteFile because they need the two behaviours WriteFile
+// deliberately does NOT have (see the package doc's "Other ways this differs"):
+// writing THROUGH a symlink at the destination rather than replacing the link,
+// and carrying the destination's EXISTING mode rather than a caller-chosen one.
+// internal/install/mcpreg needs both — it rewrites user-owned dotfiles that are
+// routinely symlinked into a dotfiles repo and are routinely 0600 because they
+// hold credentials (#6240).
+//
+// Nothing about WriteFile's documented contract changes; this only stops that
+// call site from hand-rolling a seventh copy of the Windows rename loop.
+func Rename(tmp, path string) error { return renameAtomic(tmp, path) }

--- a/internal/atomicfile/guard_6018_test.go
+++ b/internal/atomicfile/guard_6018_test.go
@@ -81,6 +81,12 @@ import (
 //     []byte. Same follow-up as WriteAtomic.
 //   - internal/install/*, internal/cli/register.go, internal/agentpatterns/* are
 //     install-time / interactive single-writer paths.
+//     (internal/install/mcpreg/{mcpreg,toml}.go came OFF this list in #6240 —
+//     not by converting to atomicfile.WriteFile, which reproduces that bug
+//     exactly, but by growing a local writeThrough that keeps the unique
+//     CreateTemp name and shares only atomicfile.Rename. Converting a file is
+//     not the only way to leave the ledger; ceasing to build a deterministic
+//     temp name is.)
 //   - internal/enrichment/*, internal/dashboard/*, internal/embed,
 //     internal/indexer/diff, internal/agents and internal/graph/manifest are
 //     plausible follow-ups but were left out to keep the first commit
@@ -105,8 +111,6 @@ var notYetConverted = map[string]bool{
 	"internal/graph/manifest.go":                          true,
 	"internal/indexer/diff/diff.go":                       true,
 	"internal/install/agenthooks/claudecode.go":           true,
-	"internal/install/mcpreg/mcpreg.go":                   true,
-	"internal/install/mcpreg/toml.go":                     true,
 	"internal/install/mcptools/mcptools.go":               true,
 	"internal/install/rulesfiles/rulesfiles.go":           true,
 	"internal/install/state.go":                           true,

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -25,6 +25,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/grafel/internal/atomicfile"
 )
 
 // ServerName is the canonical key used in mcpServers maps.
@@ -335,6 +337,73 @@ func DetectClaudeConfigDirs(dirs []string) []string {
 	return out
 }
 
+// guardConfigPath applies the test-isolation guard to BOTH the path the caller
+// named and the file a write to it would actually land on.
+//
+// The second call is not redundant. The guard's whole job is to stop a test
+// that forgot to isolate $HOME from rewriting the developer's live editor
+// config, and it decides that by looking at the path string. Once this package
+// follows symlinks, a link inside a properly-isolated t.TempDir() pointing at
+// the real ~/.claude.json makes the named path look safe while the write is
+// anything but.
+func guardConfigPath(path string) {
+	guardResolvedConfigPath(path, "MCP host config")
+	if target := resolveWriteTarget(path); target != path {
+		guardResolvedConfigPath(target, "MCP host config (symlink target)")
+	}
+}
+
+// mcpServersOf returns the mcpServers map to merge into, or an error when the
+// key holds something that is not an object.
+//
+// The code this replaces was `servers, _ := doc["mcpServers"].(map[string]any)`.
+// The blank swallows a FAILED assertion: for `{"mcpServers": [...]}` servers
+// became a fresh empty map and the write then put that empty object back,
+// destroying whatever the user had there — silently, with an exit code of 0.
+//
+// This mirrors, one level down, the contract readSettings already enforces for
+// the top-level document (see the null-document comment there): `null` carries
+// nothing and is indistinguishable from absent, so it is tolerated; every other
+// non-object is a real value whose replacement destroys something, so it fails
+// and the file is left byte-identical.
+//
+// The error wraps ErrMalformedConfig so a caller CAN tell "the user's config is
+// broken" from "the write failed". No caller distinguishes them today and that
+// is deliberate — see the comment on ErrMalformedConfig's use in install.RunCopy
+// step 3.
+func mcpServersOf(doc map[string]any, path string) (map[string]any, error) {
+	raw, present := doc["mcpServers"]
+	if !present || raw == nil {
+		return map[string]any{}, nil
+	}
+	servers, ok := raw.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("%s: %w: mcpServers is a JSON %s, not an object",
+			filepath.Base(path), ErrMalformedConfig, jsonTypeName(raw))
+	}
+	return servers, nil
+}
+
+// jsonTypeName names the JSON type of a value decoded into `any`, for error
+// messages that tell the user what is actually in their file.
+func jsonTypeName(v any) string {
+	switch v.(type) {
+	case nil:
+		return "null"
+	case bool:
+		return "boolean"
+	case float64, json.Number:
+		return "number"
+	case string:
+		return "string"
+	case []any:
+		return "array"
+	case map[string]any:
+		return "object"
+	}
+	return fmt.Sprintf("%T", v)
+}
+
 // Register writes (or updates) the grafel entry in the given tool's
 // settings file. Other entries in `mcpServers` are preserved.
 //
@@ -435,7 +504,7 @@ func backupOnce(path string) error {
 // RestoreSnapshot. The merge is surgical: only mcpServers.grafel is added or
 // updated; every other key and sibling server is preserved.
 func RegisterPath(path, binPath string) (string, error) {
-	guardResolvedConfigPath(path, "MCP host config")
+	guardConfigPath(path)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
@@ -452,9 +521,9 @@ func RegisterPath(path, binPath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	servers, _ := doc["mcpServers"].(map[string]any)
-	if servers == nil {
-		servers = map[string]any{}
+	servers, err := mcpServersOf(doc, path)
+	if err != nil {
+		return "", err
 	}
 	servers[ServerName] = Entry{
 		Command: binPath,
@@ -482,7 +551,7 @@ func Unregister(tool Tool) error {
 // `{"mcpServers":{}}`. Returns nil if the file or entry doesn't exist
 // (idempotent). It NEVER overwrites foreign servers or resets the file to `{}`.
 func UnregisterPath(path string) error {
-	guardResolvedConfigPath(path, "MCP host config")
+	guardConfigPath(path)
 	if isTOML(path) {
 		return unregisterTOML(path)
 	}
@@ -520,6 +589,11 @@ func UnregisterPath(path string) error {
 // name. Callers that genuinely want removal call UnregisterPath, which says so.
 var ErrNoSnapshot = errors.New("mcpreg: no pristine snapshot for config path")
 
+// ErrMalformedConfig reports that the USER's host config is structurally
+// unusable, as opposed to grafel having failed to write it. See the comment on
+// mcpServersOf.
+var ErrMalformedConfig = errors.New("mcpreg: malformed host config")
+
 // RestoreSnapshot reverses a RegisterPath using the pristine backup taken by
 // backupOnce. It is the rollback entry point, and MUST be used instead of
 // writing `{}`:
@@ -534,7 +608,7 @@ var ErrNoSnapshot = errors.New("mcpreg: no pristine snapshot for config path")
 //
 // The sidecar backup is removed after a successful restore.
 func RestoreSnapshot(path string) error {
-	guardResolvedConfigPath(path, "MCP host config")
+	guardConfigPath(path)
 	sidecar := sidecarBackupPath(path)
 	b, err := os.ReadFile(sidecar)
 	if err != nil {
@@ -545,8 +619,14 @@ func RestoreSnapshot(path string) error {
 	}
 
 	if string(b) == backupSentinelAbsent {
-		// Original did not exist; remove grafel's file entirely.
-		if rmErr := os.Remove(path); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+		// Original did not exist; remove the file grafel created.
+		//
+		// resolveWriteTarget, not path: when path is a DANGLING symlink the
+		// absent-sentinel is exactly what backupOnce recorded, and the file
+		// grafel created is the link's TARGET. Removing the link instead would
+		// destroy the user's symlink and leave grafel's file orphaned behind
+		// it — the opposite of a restore in both halves.
+		if rmErr := os.Remove(resolveWriteTarget(path)); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 			return rmErr
 		}
 		_ = os.Remove(sidecar)
@@ -554,7 +634,14 @@ func RestoreSnapshot(path string) error {
 	}
 
 	// Restore the original content verbatim.
-	if err := os.WriteFile(path, b, 0o644); err != nil {
+	//
+	// Via writeThrough, not os.WriteFile(path, b, 0o644): the hardcoded 0644
+	// re-introduced #6240's mode widening on the rollback path, so a fixed
+	// install followed by a rollback still handed a 0600 config back at 0644.
+	// writeThrough also survives a read-only (0444) destination, which
+	// os.WriteFile cannot open at all — and which the fixed write path now
+	// leaves in place instead of widening away.
+	if err := writeThrough(path, b); err != nil {
 		return err
 	}
 	_ = os.Remove(sidecar)
@@ -594,7 +681,11 @@ func readSettings(path string) (map[string]any, error) {
 	}
 	doc := map[string]any{}
 	if err := json.Unmarshal(b, &doc); err != nil {
-		return nil, fmt.Errorf("%s: %w", filepath.Base(path), err)
+		// Wrapped with ErrMalformedConfig for the same reason mcpServersOf is:
+		// unparseable JSON and a wrong-typed mcpServers are one class — the
+		// USER's file is broken — and a sentinel that covered only one of them
+		// would be a classification callers cannot rely on.
+		return nil, fmt.Errorf("%s: %w: %v", filepath.Base(path), ErrMalformedConfig, err)
 	}
 	// The literal `null` is the one non-object that unmarshals into a map
 	// WITHOUT an error: encoding/json's documented behaviour is to set the map
@@ -615,11 +706,107 @@ func writeSettings(path string, doc map[string]any) error {
 	if err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+	return writeThrough(path, b)
+}
+
+// newConfigPerm is the mode for a host config grafel CREATES.
+//
+// It is 0600, not the 0644 the old temp file leaked in. These files carry
+// credentials — ~/.claude.json holds the OAuth token and the full per-project
+// history — and at minimum they enumerate every project on the machine. There
+// is no reason for another local account to be able to read a file grafel
+// invented. Configs that ALREADY exist keep whatever mode their owner chose;
+// this applies only when there was nothing there before.
+const newConfigPerm os.FileMode = 0o600
+
+// resolveWriteTarget follows a symlink chain at path and returns the real file
+// a write must land on.
+//
+// Why this exists: writing via temp-file + rename replaces the LINK INODE, so a
+// ~/.claude.json symlinked into a dotfiles repo silently DETACHES from that repo
+// on the first `grafel install` — the user keeps editing the repo copy and
+// Claude Code keeps reading a regular file that no longer tracks it (#6240).
+// Resolving here means the temp file is created in the TARGET's directory, so
+// the rename stays intra-filesystem and therefore atomic.
+//
+// A path that is not a symlink, a dangling symlink (the final target is
+// returned even though it does not exist yet, which is what a create must use),
+// and an unreadable link all return sensibly. A link CYCLE exhausts the hop
+// budget and returns the last hop; the write then fails loudly on its own,
+// which is the correct outcome for a config the user has broken.
+func resolveWriteTarget(path string) string {
+	const maxHops = 32
+	cur := path
+	for i := 0; i < maxHops; i++ {
+		fi, err := os.Lstat(cur)
+		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
+			return cur
+		}
+		dest, err := os.Readlink(cur)
+		if err != nil {
+			return cur
+		}
+		if !filepath.IsAbs(dest) {
+			dest = filepath.Join(filepath.Dir(cur), dest)
+		}
+		cur = filepath.Clean(dest)
+	}
+	return cur
+}
+
+// destPerm returns the mode a write to target must produce: the mode target
+// already has, or newConfigPerm when it does not exist.
+//
+// os.Stat, not os.Lstat, is deliberate — target is already resolved, and on the
+// unresolved path Lstat would report the LINK's mode (0777 on Linux), which is
+// not the mode any content is stored at.
+func destPerm(target string) os.FileMode {
+	if fi, err := os.Stat(target); err == nil {
+		return fi.Mode().Perm()
+	}
+	return newConfigPerm
+}
+
+// writeThrough replaces the contents of path atomically, writing THROUGH any
+// symlink and preserving the destination's existing mode.
+//
+// It deliberately does NOT use atomicfile.WriteFile: that helper documents both
+// of those behaviours as inverted on purpose ("a SYMLINK at path is REPLACED by
+// a regular file"; perm applied verbatim from the caller), so
+// atomicfile.WriteFile(path, b, 0o644) reproduces #6240 exactly. Only the
+// rename half is shared, because the Windows recovery in it is non-obvious and
+// already has five hand-rolled copies in this tree.
+func writeThrough(path string, b []byte) (err error) {
+	target := resolveWriteTarget(path)
+	// Trap: the entry-point guards see the UNRESOLVED path, so a symlink
+	// pointing out of a t.TempDir() into the real $HOME would walk straight
+	// past them. Guard what we are actually about to write.
+	guardResolvedConfigPath(target, "MCP host config (symlink target)")
+
+	perm := destPerm(target)
+	f, err := os.CreateTemp(filepath.Dir(target), "."+filepath.Base(target)+".tmp-*")
+	if err != nil {
 		return err
 	}
-	return os.Rename(tmp, path)
+	tmp := f.Name()
+	defer func() {
+		if err != nil {
+			_ = os.Remove(tmp)
+		}
+	}()
+	if _, err = f.Write(b); err != nil {
+		_ = f.Close()
+		return err
+	}
+	if err = f.Close(); err != nil {
+		return err
+	}
+	// os.CreateTemp always creates 0600; restore the destination's own mode.
+	if err = os.Chmod(tmp, perm); err != nil {
+		return err
+	}
+	err = atomicfile.Rename(tmp, target)
+	return err
 }
 
 // HasGrafelEntry reports whether the config file at path already contains a

--- a/internal/install/mcpreg/mcpreg.go
+++ b/internal/install/mcpreg/mcpreg.go
@@ -337,20 +337,24 @@ func DetectClaudeConfigDirs(dirs []string) []string {
 	return out
 }
 
-// guardConfigPath applies the test-isolation guard to BOTH the path the caller
-// named and the file a write to it would actually land on.
+// guardWriteTarget applies the test-isolation guard to a RESOLVED path — the
+// file an operation is actually about to touch, after following symlinks.
 //
-// The second call is not redundant. The guard's whole job is to stop a test
-// that forgot to isolate $HOME from rewriting the developer's live editor
-// config, and it decides that by looking at the path string. Once this package
-// follows symlinks, a link inside a properly-isolated t.TempDir() pointing at
-// the real ~/.claude.json makes the named path look safe while the write is
-// anything but.
-func guardConfigPath(path string) {
-	guardResolvedConfigPath(path, "MCP host config")
-	if target := resolveWriteTarget(path); target != path {
-		guardResolvedConfigPath(target, "MCP host config (symlink target)")
-	}
+// This is not redundant with the guardResolvedConfigPath(path) the exported
+// entry points already do. The guard decides by looking at the path STRING, so
+// once this package follows symlinks a link inside a properly-isolated
+// t.TempDir() pointing at the real ~/.claude.json makes the named path look
+// safe while the operation is anything but.
+//
+// There are exactly TWO call sites, one per operation that can touch a resolved
+// path: writeThrough (every write) and RestoreSnapshot's absent-sentinel branch
+// (the one delete, which never goes through writeThrough). Each is pinned by
+// its own test — TestRegisterPath_SymlinkTargetIsGuarded and
+// TestRestoreSnapshot_SentinelRemovalIsGuarded — because an earlier revision
+// had the same check in two overlapping places and deleting EITHER left the
+// suite green.
+func guardWriteTarget(target string) {
+	guardResolvedConfigPath(target, "MCP host config (symlink target)")
 }
 
 // mcpServersOf returns the mcpServers map to merge into, or an error when the
@@ -504,7 +508,7 @@ func backupOnce(path string) error {
 // RestoreSnapshot. The merge is surgical: only mcpServers.grafel is added or
 // updated; every other key and sibling server is preserved.
 func RegisterPath(path, binPath string) (string, error) {
-	guardConfigPath(path)
+	guardResolvedConfigPath(path, "MCP host config")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
@@ -551,7 +555,7 @@ func Unregister(tool Tool) error {
 // `{"mcpServers":{}}`. Returns nil if the file or entry doesn't exist
 // (idempotent). It NEVER overwrites foreign servers or resets the file to `{}`.
 func UnregisterPath(path string) error {
-	guardConfigPath(path)
+	guardResolvedConfigPath(path, "MCP host config")
 	if isTOML(path) {
 		return unregisterTOML(path)
 	}
@@ -608,7 +612,7 @@ var ErrMalformedConfig = errors.New("mcpreg: malformed host config")
 //
 // The sidecar backup is removed after a successful restore.
 func RestoreSnapshot(path string) error {
-	guardConfigPath(path)
+	guardResolvedConfigPath(path, "MCP host config")
 	sidecar := sidecarBackupPath(path)
 	b, err := os.ReadFile(sidecar)
 	if err != nil {
@@ -626,7 +630,14 @@ func RestoreSnapshot(path string) error {
 		// grafel created is the link's TARGET. Removing the link instead would
 		// destroy the user's symlink and leave grafel's file orphaned behind
 		// it — the opposite of a restore in both halves.
-		if rmErr := os.Remove(resolveWriteTarget(path)); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
+		target, resErr := resolveWriteTarget(path)
+		if resErr != nil {
+			return resErr
+		}
+		// This delete never passes through writeThrough, so it needs its own
+		// resolved-path guard — see guardWriteTarget.
+		guardWriteTarget(target)
+		if rmErr := os.Remove(target); rmErr != nil && !errors.Is(rmErr, os.ErrNotExist) {
 			return rmErr
 		}
 		_ = os.Remove(sidecar)
@@ -719,6 +730,16 @@ func writeSettings(path string, doc map[string]any) error {
 // this applies only when there was nothing there before.
 const newConfigPerm os.FileMode = 0o600
 
+// maxSymlinkHops bounds resolveWriteTarget's walk.
+//
+// 40 matches Linux's MAXSYMLINKS, deliberately the most permissive of the
+// kernel limits: anything the OS itself would follow must resolve here too. An
+// earlier 32 (macOS's limit) meant a 33-39 link chain resolved fine for the
+// kernel but ran out of budget here — and the old code answered that by
+// returning the last hop reached, which is itself a symlink. See the error
+// below for why that mattered.
+const maxSymlinkHops = 40
+
 // resolveWriteTarget follows a symlink chain at path and returns the real file
 // a write must land on.
 //
@@ -731,27 +752,34 @@ const newConfigPerm os.FileMode = 0o600
 //
 // A path that is not a symlink, a dangling symlink (the final target is
 // returned even though it does not exist yet, which is what a create must use),
-// and an unreadable link all return sensibly. A link CYCLE exhausts the hop
-// budget and returns the last hop; the write then fails loudly on its own,
-// which is the correct outcome for a config the user has broken.
-func resolveWriteTarget(path string) string {
-	const maxHops = 32
+// and an unreadable link all resolve to a usable answer.
+//
+// An UNRESOLVABLE chain — a cycle, or one longer than any kernel would
+// follow — is an ERROR, not a best-effort answer. Returning the last hop
+// reached looks harmless and is not: that path is a symlink, so the caller
+// renames over it and flattens one of the user's links into a regular file
+// while reporting success. That is this issue's own damage class, and on
+// RestoreSnapshot (which reaches the writer with no prior read to fail first)
+// it was live.
+func resolveWriteTarget(path string) (string, error) {
 	cur := path
-	for i := 0; i < maxHops; i++ {
+	for i := 0; i < maxSymlinkHops; i++ {
 		fi, err := os.Lstat(cur)
 		if err != nil || fi.Mode()&os.ModeSymlink == 0 {
-			return cur
+			return cur, nil
 		}
 		dest, err := os.Readlink(cur)
 		if err != nil {
-			return cur
+			return cur, nil
 		}
 		if !filepath.IsAbs(dest) {
 			dest = filepath.Join(filepath.Dir(cur), dest)
 		}
 		cur = filepath.Clean(dest)
 	}
-	return cur
+	return "", fmt.Errorf("%s: %w: symlink chain still unresolved after %d hops "+
+		"(a cycle, or longer than any kernel will follow)",
+		filepath.Base(path), ErrMalformedConfig, maxSymlinkHops)
 }
 
 // destPerm returns the mode a write to target must produce: the mode target
@@ -777,11 +805,14 @@ func destPerm(target string) os.FileMode {
 // rename half is shared, because the Windows recovery in it is non-obvious and
 // already has five hand-rolled copies in this tree.
 func writeThrough(path string, b []byte) (err error) {
-	target := resolveWriteTarget(path)
+	target, err := resolveWriteTarget(path)
+	if err != nil {
+		return err
+	}
 	// Trap: the entry-point guards see the UNRESOLVED path, so a symlink
 	// pointing out of a t.TempDir() into the real $HOME would walk straight
 	// past them. Guard what we are actually about to write.
-	guardResolvedConfigPath(target, "MCP host config (symlink target)")
+	guardWriteTarget(target)
 
 	perm := destPerm(target)
 	f, err := os.CreateTemp(filepath.Dir(target), "."+filepath.Base(target)+".tmp-*")

--- a/internal/install/mcpreg/symlink_perm_6240_test.go
+++ b/internal/install/mcpreg/symlink_perm_6240_test.go
@@ -25,6 +25,7 @@ package mcpreg
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -255,6 +256,223 @@ func TestRegisterPath_SymlinkTargetIsGuarded(t *testing.T) {
 		}
 	}()
 	_, _ = RegisterPath(cfg, testBin)
+}
+
+// ── Unresolvable link chains must fail, not flatten ──────────────────────────
+
+// seedSnapshotThroughLink registers through a symlink so a pristine sidecar
+// exists, then rewires cfg into whatever pathological link shape the caller
+// wants. It returns the pristine bytes.
+//
+// The sidecar keys on cfg (the caller's path, see
+// TestBackupSidecar_KeysOnTheUnresolvedPath), so it survives the rewiring —
+// which is what lets these tests drive RestoreSnapshot down its write path.
+func seedSnapshotThroughLink(t *testing.T, dir, cfg string) {
+	t.Helper()
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	seedConfig(t, real, 0o600)
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	if err := os.Remove(cfg); err != nil {
+		t.Fatalf("unlink cfg: %v", err)
+	}
+}
+
+// TestRestoreSnapshot_SymlinkCycleFailsLoudly is the review finding on the
+// first #6240 fix: resolveWriteTarget's comment CLAIMED a link cycle "exhausts
+// the hop budget and returns the last hop; the write then fails loudly on its
+// own". It did not. It returned a mid-cycle path that is ITSELF a symlink, and
+// writeThrough renamed over it — flattening the user's link into a regular file
+// and returning nil.
+//
+// RegisterPath and UnregisterPath are saved from this by accident: backupOnce's
+// os.ReadFile hits ELOOP first. RestoreSnapshot reaches the writer with no
+// prior read, so it was the one live path — the exact damage this issue is
+// about, inside the fix for it.
+func TestRestoreSnapshot_SymlinkCycleFailsLoudly(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	seedSnapshotThroughLink(t, dir, cfg)
+
+	// a -> b -> a
+	other := filepath.Join(dir, "loop-b.json")
+	if err := os.Symlink(other, cfg); err != nil {
+		t.Fatalf("symlink a->b: %v", err)
+	}
+	if err := os.Symlink(cfg, other); err != nil {
+		t.Fatalf("symlink b->a: %v", err)
+	}
+
+	if err := RestoreSnapshot(cfg); err == nil {
+		t.Error("RestoreSnapshot silently resolved a symlink CYCLE and wrote through it")
+	}
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("%s was flattened from a symlink into a regular file by a write "+
+			"that could not resolve it", cfg)
+	}
+}
+
+// TestRestoreSnapshot_OverlongSymlinkChainFailsLoudly is the Linux-only sibling
+// the reviewer found: a chain longer than the hop budget is not a cycle, and
+// returning the last hop reached is returning a SYMLINK, which the writer then
+// replaces. Linux's MAXSYMLINKS is 40, so a 33-39 link chain the kernel
+// resolves happily used to exhaust the old 32-hop budget; macOS stops at 32 and
+// so answered ELOOP instead, hiding it. The budget now matches the most
+// permissive kernel limit AND exhausting it is an error rather than a silent
+// mid-chain write.
+func TestRestoreSnapshot_OverlongSymlinkChainFailsLoudly(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	seedSnapshotThroughLink(t, dir, cfg)
+
+	linkChain(t, dir, cfg, filepath.Join(dir, "dotfiles", "claude.json"), 44)
+
+	if err := RestoreSnapshot(cfg); err == nil {
+		t.Error("RestoreSnapshot wrote through a link chain it could not fully resolve")
+	}
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("%s was flattened into a regular file mid-chain", cfg)
+	}
+}
+
+// linkChain builds cfg -> hop(n-1) -> ... -> hop0 -> final and returns nothing;
+// cfg must not already exist.
+func linkChain(t *testing.T, dir, cfg, final string, n int) {
+	t.Helper()
+	prev := final
+	for i := 0; i < n; i++ {
+		hop := filepath.Join(dir, fmt.Sprintf("hop%03d", i))
+		if err := os.Symlink(prev, hop); err != nil {
+			t.Fatalf("symlink hop %d: %v", i, err)
+		}
+		prev = hop
+	}
+	if err := os.Symlink(prev, cfg); err != nil {
+		t.Fatalf("symlink cfg: %v", err)
+	}
+}
+
+// TestRestoreSnapshot_ChainWithinTheKernelLimitStillResolves pins the hop
+// BUDGET, which the failure tests above cannot: a 44-link chain exhausts 32 and
+// 40 alike, so they would stay green if the budget were narrowed back.
+//
+// 35 links is inside Linux's MAXSYMLINKS (40) and outside macOS's (32). The
+// resolution here is grafel's own walk, not the kernel's, so this must succeed
+// on BOTH — and it is exactly the band where the original 32-hop budget
+// returned a mid-chain symlink and the writer flattened it.
+func TestRestoreSnapshot_ChainWithinTheKernelLimitStillResolves(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	seedSnapshotThroughLink(t, dir, cfg)
+
+	final := filepath.Join(dir, "dotfiles", "claude.json")
+	linkChain(t, dir, cfg, final, 35)
+
+	if err := RestoreSnapshot(cfg); err != nil {
+		t.Fatalf("RestoreSnapshot over a 35-link chain: %v", err)
+	}
+	if fi, err := os.Lstat(cfg); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("%s was flattened rather than written through", cfg)
+	}
+	// The restore must have landed on the END of the chain, not on some hop.
+	for i := 0; i < 35; i++ {
+		hop := filepath.Join(dir, fmt.Sprintf("hop%03d", i))
+		fi, err := os.Lstat(hop)
+		if err != nil {
+			t.Fatalf("lstat hop %d: %v", i, err)
+		}
+		if fi.Mode()&os.ModeSymlink == 0 {
+			t.Fatalf("hop %d was replaced by a regular file: the write landed "+
+				"mid-chain instead of on the real target", i)
+		}
+	}
+	if _, err := os.Stat(final); err != nil {
+		t.Errorf("chain target %s missing: %v", final, err)
+	}
+}
+
+// TestRegisterPath_SymlinkCycleFailsLoudly pins the same invariant on the
+// install path, which reaches it only because backupOnce's read ELOOPs first.
+// That is an accident of ordering, so it is stated as a requirement here rather
+// than left to whichever read happens to come first next year.
+func TestRegisterPath_SymlinkCycleFailsLoudly(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	other := filepath.Join(dir, "loop-b.json")
+	if err := os.Symlink(other, cfg); err != nil {
+		t.Fatalf("symlink a->b: %v", err)
+	}
+	if err := os.Symlink(cfg, other); err != nil {
+		t.Fatalf("symlink b->a: %v", err)
+	}
+
+	if _, err := RegisterPath(cfg, testBin); err == nil {
+		t.Error("RegisterPath silently wrote through a symlink cycle")
+	}
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("%s was flattened from a symlink into a regular file", cfg)
+	}
+}
+
+// TestRestoreSnapshot_SentinelRemovalIsGuarded pins the SECOND resolved-path
+// guard, the one on RestoreSnapshot's absent-sentinel branch.
+//
+// That branch os.Removes the resolved target without going anywhere near
+// writeThrough, so writeThrough's guard does not cover it: a dangling link out
+// of a t.TempDir() into the real $HOME would let a badly-isolated test DELETE a
+// file there. Reviewer finding LOW-2 was that the resolved-path guard existed
+// in two places and no test pinned either individually; there are now two
+// guards covering two distinct operations, and one test each.
+func TestRestoreSnapshot_SentinelRemovalIsGuarded(t *testing.T) {
+	requireSymlinks(t)
+	if realUserHomeAtInit == "" {
+		t.Skip("no real home to guard against")
+	}
+	canaryDir := filepath.Join(realUserHomeAtInit, ".grafel-6240-sentinel-canary")
+	t.Cleanup(func() { _ = os.RemoveAll(canaryDir) })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	// A sentinel sidecar: the original file did not exist.
+	if err := os.WriteFile(sidecarBackupPath(cfg), []byte(backupSentinelAbsent), 0o600); err != nil {
+		t.Fatalf("seed sidecar: %v", err)
+	}
+	if err := os.Symlink(filepath.Join(canaryDir, "claude.json"), cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("RestoreSnapshot's sentinel branch followed a symlink out of the "+
+				"test sandbox and would have deleted inside the REAL user home (%s)", canaryDir)
+		}
+	}()
+	_ = RestoreSnapshot(cfg)
 }
 
 // ── Defect 3: a wrong-typed mcpServers must not be discarded ─────────────────

--- a/internal/install/mcpreg/symlink_perm_6240_test.go
+++ b/internal/install/mcpreg/symlink_perm_6240_test.go
@@ -1,0 +1,582 @@
+// symlink_perm_6240_test.go pins the three #6240 defects in the way this
+// package rewrites a user's MCP host config.
+//
+// All three come out of one three-line writer (writeSettings, and its TOML twin
+// writeRaw): write a temp file, rename it over the destination.
+//
+//  1. The rename replaces the LINK INODE. A ~/.claude.json symlinked into a
+//     dotfiles repo silently detaches from that repo on the first `grafel
+//     install`, and every later edit the user makes in either place stops being
+//     seen by the other.
+//  2. The destination inherits the TEMP file's mode. A 0600 ~/.claude.json —
+//     which holds OAuth tokens and the full per-project history — comes back
+//     0644, world-readable, with no diff to notice.
+//  3. `servers, _ := doc["mcpServers"].(map[string]any)` swallows a failed type
+//     assertion. A config whose mcpServers is an array (or a string, or a
+//     number) loses that value entirely: servers becomes a fresh empty map and
+//     the write puts it back as an object.
+//
+// Every pre-existing fixture in this package seeds 0o644 and never reads the
+// mode back, so none of them can observe (2) at all — a 0644 seed is
+// indistinguishable from the widened result. The fixtures here seed 0600 and a
+// read-only 0444 deliberately.
+package mcpreg
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/grafel/internal/testsupport"
+)
+
+const testBin = "/usr/local/bin/grafel"
+
+// requireSymlinks skips when the platform (Windows without the developer-mode
+// or SeCreateSymbolicLink privilege) cannot create a symlink at all. It is a
+// capability PROBE rather than a runtime.GOOS check so that a Windows runner
+// which CAN make symlinks still runs these tests.
+func requireSymlinks(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Symlink(filepath.Join(dir, "target"), filepath.Join(dir, "link")); err != nil {
+		t.Skipf("symlinks unavailable here: %v", err)
+	}
+}
+
+// seedConfig writes a host config carrying a foreign server at mode perm.
+func seedConfig(t *testing.T, path string, perm os.FileMode) []byte {
+	t.Helper()
+	body := []byte(`{
+  "userIDOverride": "keep-me",
+  "mcpServers": {
+    "other": {
+      "command": "/opt/other/bin/other"
+    }
+  }
+}`)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(path, body, perm); err != nil {
+		t.Fatalf("seed %s: %v", path, err)
+	}
+	// os.WriteFile's perm is umask-masked and does not apply to an existing
+	// file, so state the mode explicitly.
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("chmod seed: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o666) })
+	return body
+}
+
+func assertGrafelRegistered(t *testing.T, path string) {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("%s is not a JSON object: %v (%s)", path, err, raw)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers[ServerName]; !ok {
+		t.Fatalf("no grafel entry in %s: %s", path, raw)
+	}
+	if _, ok := servers["other"]; !ok {
+		t.Errorf("foreign server lost from %s: %s", path, raw)
+	}
+}
+
+// ── Defect 2: the destination's mode must survive the write ──────────────────
+
+// TestRegisterPath_PreservesDestinationMode is the direct #6240 case: a user
+// whose ~/.claude.json is 0600 (Claude Code's own default for a file holding
+// OAuth tokens) must not find it 0644 after `grafel install`.
+//
+// The 0444 row is what gives this test any signal on Windows. Windows has no
+// Unix mode bits — os.Stat reports 0666 for a writable file and 0444 for one
+// carrying FILE_ATTRIBUTE_READONLY — so the 0600 and 0644 rows collapse into
+// "writable" there and a lost chmod would sail straight past them. See
+// testsupport.AssertPerm.
+func TestRegisterPath_PreservesDestinationMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o644, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			cfg := filepath.Join(dir, ".claude.json")
+			seedConfig(t, cfg, perm)
+
+			if _, err := RegisterPath(cfg, testBin); err != nil {
+				t.Fatalf("RegisterPath: %v", err)
+			}
+			testsupport.AssertPerm(t, cfg, perm)
+			assertGrafelRegistered(t, cfg)
+		})
+	}
+}
+
+// TestRegisterPath_NewConfigIsPrivate pins the deliberate behaviour change: a
+// config file grafel CREATES is 0600, not the 0644 the temp file used to leak
+// in. These files carry credentials (tokens in ~/.claude.json) or at minimum a
+// map of every project on the machine; there is no reason for another local
+// account to be able to read one grafel invented.
+func TestRegisterPath_NewConfigIsPrivate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".cursor", "mcp.json")
+
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	testsupport.AssertPerm(t, cfg, 0o600)
+}
+
+// ── Defect 1: a symlinked config must be written THROUGH ─────────────────────
+
+// TestRegisterPath_WritesThroughSymlink is the dotfiles-repo case. It asserts
+// ONLY the write-through half — the mode half is a separate test, because the
+// two fixes are independent and one test asserting both can pass for the wrong
+// reason.
+func TestRegisterPath_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	seedConfig(t, real, 0o644)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat %s: %v", cfg, err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is no longer a symlink — the rename replaced the link inode "+
+			"and the file has silently detached from the user's dotfiles repo", cfg)
+	}
+	// The entry must be in the TARGET, read directly, not merely through the
+	// link (reading through the link would pass even if the link were replaced).
+	assertGrafelRegistered(t, real)
+}
+
+// TestRegisterPath_SymlinkPreservesTargetMode is the other half: writing
+// through the link must carry the TARGET's mode, not the temp file's. A fix
+// that resolves the symlink but keeps os.WriteFile(tmp, b, 0o644) passes
+// TestRegisterPath_WritesThroughSymlink and fails here.
+func TestRegisterPath_SymlinkPreservesTargetMode(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	seedConfig(t, real, 0o600)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	testsupport.AssertPerm(t, real, 0o600)
+}
+
+// TestUnregisterPath_WritesThroughSymlinkAndKeepsMode: uninstall shares the
+// writer, so it shares both defects. A user who installs and then uninstalls
+// would otherwise end up with a detached, widened config either way.
+func TestUnregisterPath_WritesThroughSymlinkAndKeepsMode(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	seedConfig(t, real, 0o600)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	if err := UnregisterPath(cfg); err != nil {
+		t.Fatalf("UnregisterPath: %v", err)
+	}
+
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("UnregisterPath replaced the symlink at %s with a regular file", cfg)
+	}
+	testsupport.AssertPerm(t, real, 0o600)
+}
+
+// TestRegisterPath_SymlinkTargetIsGuarded covers the sandbox-escape hole the
+// symlink fix opens: guardResolvedConfigPath is handed the UNRESOLVED path, so
+// a link inside a t.TempDir() pointing at the real $HOME would let a
+// badly-isolated test write there — the exact incident the guard exists to
+// stop, re-entering through the back door.
+//
+// The canary target is a directory name that is not any real dotfile and is
+// removed again on cleanup, so even a REGRESSION here cannot damage the
+// developer's home.
+func TestRegisterPath_SymlinkTargetIsGuarded(t *testing.T) {
+	requireSymlinks(t)
+	if realUserHomeAtInit == "" {
+		t.Skip("no real home to guard against")
+	}
+	canaryDir := filepath.Join(realUserHomeAtInit, ".grafel-6240-guard-canary")
+	t.Cleanup(func() { _ = os.RemoveAll(canaryDir) })
+
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(filepath.Join(canaryDir, "claude.json"), cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("RegisterPath followed a symlink out of the test sandbox into the "+
+				"REAL user home (%s) without tripping the isolation guard", canaryDir)
+		}
+	}()
+	_, _ = RegisterPath(cfg, testBin)
+}
+
+// ── Defect 3: a wrong-typed mcpServers must not be discarded ─────────────────
+
+// TestRegisterPath_WrongTypedMCPServersFailsCleanly mirrors, one level down,
+// the contract readSettings already enforces for a non-object DOCUMENT
+// (nulldoc_6163_test.go): a value grafel cannot merge into is a real config
+// whose replacement destroys something, so it must be an error AND must leave
+// the file byte-identical.
+func TestRegisterPath_WrongTypedMCPServersFailsCleanly(t *testing.T) {
+	cases := []struct {
+		body     string
+		wantType string
+	}{
+		{`{"mcpServers": []}`, "array"},
+		{`{"mcpServers": [{"name":"other"}]}`, "array"},
+		{`{"mcpServers": "x"}`, "string"},
+		{`{"mcpServers": 42}`, "number"},
+		{`{"mcpServers": true}`, "boolean"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.body, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			cfg := filepath.Join(dir, ".claude.json")
+			if err := os.WriteFile(cfg, []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("RegisterPath panicked on %s: %v", tc.body, r)
+				}
+			}()
+
+			_, err := RegisterPath(cfg, testBin)
+			if err == nil {
+				t.Fatalf("RegisterPath silently discarded a %s mcpServers value", tc.wantType)
+			}
+			if !errors.Is(err, ErrMalformedConfig) {
+				t.Errorf("error does not classify as ErrMalformedConfig: %v", err)
+			}
+			if msg := err.Error(); !strings.Contains(msg, ".claude.json") || !strings.Contains(msg, tc.wantType) {
+				t.Errorf("error names neither the file nor the offending type: %q", msg)
+			}
+
+			got, err := os.ReadFile(cfg)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if string(got) != tc.body {
+				t.Errorf("file was modified despite the error:\n got: %s\nwant: %s", got, tc.body)
+			}
+		})
+	}
+}
+
+// TestRegisterPath_UnparseableConfigAlsoClassifies: the sentinel must cover the
+// WHOLE "the user's file is broken" class, not just the branch #6240 added. A
+// caller that wants to tell a broken config from a failed write — none does
+// today, deliberately; see the RunCopy note in the commit — would otherwise get
+// a classification that is right for one shape of breakage and silent for the
+// other, which is worse than none.
+func TestRegisterPath_UnparseableConfigAlsoClassifies(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfg, []byte("{ not json"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	_, err := RegisterPath(cfg, testBin)
+	if err == nil {
+		t.Fatal("RegisterPath accepted unparseable JSON")
+	}
+	if !errors.Is(err, ErrMalformedConfig) {
+		t.Errorf("unparseable JSON does not classify as ErrMalformedConfig: %v", err)
+	}
+}
+
+// TestRegisterPath_NullMCPServersIsTreatedAsAbsent: `null` is the one non-object
+// that carries nothing, so — exactly as for a null DOCUMENT (#6163) — it is
+// treated as empty and registration proceeds rather than failing.
+func TestRegisterPath_NullMCPServersIsTreatedAsAbsent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(cfg, []byte(`{"mcpServers": null, "keep": 1}`), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath on a null mcpServers: %v", err)
+	}
+	raw, err := os.ReadFile(cfg)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var doc map[string]any
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("not an object: %v", err)
+	}
+	servers, _ := doc["mcpServers"].(map[string]any)
+	if _, ok := servers[ServerName]; !ok {
+		t.Errorf("no grafel entry written: %s", raw)
+	}
+	if doc["keep"] == nil {
+		t.Errorf("unrelated key lost: %s", raw)
+	}
+}
+
+// ── RestoreSnapshot must not re-widen what the write path preserved ──────────
+
+// TestRestoreSnapshot_DoesNotWidenMode: RestoreSnapshot hardcoded 0o644. Without
+// this, a rollback silently re-introduces defect 2 the moment the write path is
+// fixed — the install preserves 0600 and the undo hands it back at 0644.
+//
+// The two rows are NOT redundant, and finding that out cost a mutant. os.WriteFile
+// applies perm only when it CREATES the file, so on the "destination still
+// there" row the old hardcoded 0644 was inert: the 0600 file was truncated in
+// place and kept its mode. That row is a regression pin, not a fix witness.
+// The witness is the "destination gone" row, where the restore CREATES the file
+// and the hardcoded 0644 hands a credential-bearing config back world-readable.
+func TestRestoreSnapshot_DoesNotWidenMode(t *testing.T) {
+	for _, removeFirst := range []bool{false, true} {
+		name := "destination still there"
+		if removeFirst {
+			name = "destination gone before the rollback"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			cfg := filepath.Join(dir, ".claude.json")
+			pristine := seedConfig(t, cfg, 0o600)
+
+			if _, err := RegisterPath(cfg, testBin); err != nil {
+				t.Fatalf("RegisterPath: %v", err)
+			}
+			if removeFirst {
+				if err := os.Remove(cfg); err != nil {
+					t.Fatalf("remove: %v", err)
+				}
+			}
+			if err := RestoreSnapshot(cfg); err != nil {
+				t.Fatalf("RestoreSnapshot: %v", err)
+			}
+			testsupport.AssertPerm(t, cfg, 0o600)
+
+			got, err := os.ReadFile(cfg)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if string(got) != string(pristine) {
+				t.Errorf("restore was not byte-identical:\n got: %s\nwant: %s", got, pristine)
+			}
+		})
+	}
+}
+
+// TestRestoreSnapshot_WritesThroughSymlink: the rollback path writes with
+// os.WriteFile, which already follows the link — this pins that it stays that
+// way, and that a read-only destination (which os.WriteFile CANNOT open) still
+// restores.
+func TestRestoreSnapshot_WritesThroughSymlink(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	pristine := seedConfig(t, real, 0o444)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	if err := RestoreSnapshot(cfg); err != nil {
+		t.Fatalf("RestoreSnapshot on a read-only symlinked target: %v", err)
+	}
+	if fi, err := os.Lstat(cfg); err != nil || fi.Mode()&os.ModeSymlink == 0 {
+		t.Errorf("RestoreSnapshot replaced the symlink at %s", cfg)
+	}
+	got, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if string(got) != string(pristine) {
+		t.Errorf("restore was not byte-identical:\n got: %s\nwant: %s", got, pristine)
+	}
+	testsupport.AssertPerm(t, real, 0o444)
+}
+
+// ── The Codex TOML writer has the identical defects ──────────────────────────
+
+// TestRegisterPath_TOMLPreservesMode covers ~/.codex/config.toml, whose
+// writeRaw is the same three lines as writeSettings. It was not named in the
+// original report; it is the same defect in the same package.
+func TestRegisterPath_TOMLPreservesMode(t *testing.T) {
+	for _, perm := range []os.FileMode{0o600, 0o444} {
+		t.Run(perm.String(), func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("HOME", dir)
+			cfg := filepath.Join(dir, ".codex", "config.toml")
+			if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(cfg, []byte("[mcp_servers.other]\ncommand = \"x\"\n"), perm); err != nil {
+				t.Fatalf("seed: %v", err)
+			}
+			if err := os.Chmod(cfg, perm); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			t.Cleanup(func() { _ = os.Chmod(cfg, 0o666) })
+
+			if _, err := RegisterPath(cfg, testBin); err != nil {
+				t.Fatalf("RegisterPath: %v", err)
+			}
+			testsupport.AssertPerm(t, cfg, perm)
+			raw, err := os.ReadFile(cfg)
+			if err != nil {
+				t.Fatalf("read back: %v", err)
+			}
+			if !strings.Contains(string(raw), "[mcp_servers.grafel]") {
+				t.Errorf("no grafel table written: %s", raw)
+			}
+			if !strings.Contains(string(raw), "[mcp_servers.other]") {
+				t.Errorf("foreign table lost: %s", raw)
+			}
+		})
+	}
+}
+
+// TestRegisterPath_TOMLNewConfigIsPrivate: a Codex config grafel creates is
+// 0600 for the same reason the JSON ones are.
+func TestRegisterPath_TOMLNewConfigIsPrivate(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfg := filepath.Join(dir, ".codex", "config.toml")
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	testsupport.AssertPerm(t, cfg, 0o600)
+}
+
+// TestRegisterPath_TOMLWritesThroughSymlink: ~/.codex/config.toml is as likely
+// to be symlinked into a dotfiles repo as ~/.claude.json.
+func TestRegisterPath_TOMLWritesThroughSymlink(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "codex.toml")
+	if err := os.MkdirAll(filepath.Dir(real), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(real, []byte("[mcp_servers.other]\ncommand = \"x\"\n"), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	cfg := filepath.Join(dir, ".codex", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(cfg), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+	fi, err := os.Lstat(cfg)
+	if err != nil {
+		t.Fatalf("lstat: %v", err)
+	}
+	if fi.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("%s is no longer a symlink", cfg)
+	}
+	raw, err := os.ReadFile(real)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if !strings.Contains(string(raw), "[mcp_servers.grafel]") {
+		t.Errorf("grafel table did not reach the symlink target: %s", raw)
+	}
+}
+
+// ── The sidecar keys on the UNRESOLVED path ──────────────────────────────────
+
+// TestBackupSidecar_KeysOnTheUnresolvedPath pins the decision made for #6240's
+// trap: the pristine `.grafel.bak` sidecar stays next to the path the CALLER
+// passed, not next to the symlink target.
+//
+// Every other user of that string — RestoreSnapshot, ClearBackup,
+// install.discardStaleMCPBackups, and the uninstall sweep — is handed the same
+// unresolved path from install state. If RegisterPath alone started keying on
+// the resolved path, the snapshot would be taken in one place and looked for in
+// another: a restore would find nothing (ErrNoSnapshot) and a stale sidecar
+// would never be swept. That divergence IS the #6168 failure mode.
+func TestBackupSidecar_KeysOnTheUnresolvedPath(t *testing.T) {
+	requireSymlinks(t)
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	real := filepath.Join(dir, "dotfiles", "claude.json")
+	seedConfig(t, real, 0o600)
+	cfg := filepath.Join(dir, ".claude.json")
+	if err := os.Symlink(real, cfg); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	if _, err := RegisterPath(cfg, testBin); err != nil {
+		t.Fatalf("RegisterPath: %v", err)
+	}
+
+	if _, err := os.Lstat(cfg + ".grafel.bak"); err != nil {
+		t.Errorf("no sidecar beside the caller's path %s: %v", cfg, err)
+	}
+	if _, err := os.Lstat(real + ".grafel.bak"); err == nil {
+		t.Errorf("sidecar was taken beside the symlink TARGET %s; RestoreSnapshot, "+
+			"ClearBackup and the uninstall sweep all key on the caller's path and "+
+			"would never find it there", real)
+	}
+	// And the round trip works: the restore keyed on the same caller path.
+	if err := RestoreSnapshot(cfg); err != nil {
+		t.Fatalf("RestoreSnapshot on the caller's path: %v", err)
+	}
+}

--- a/internal/install/mcpreg/toml.go
+++ b/internal/install/mcpreg/toml.go
@@ -145,15 +145,14 @@ func unregisterTOML(path string) error {
 	return writeRaw(path, strings.TrimRight(stripped, "\n")+"\n")
 }
 
-// writeRaw writes content atomically (temp file + rename), matching the JSON
-// writer's durability behaviour.
+// writeRaw writes content atomically, matching the JSON writer's behaviour in
+// every respect — including, since #6240, writing THROUGH a symlinked
+// ~/.codex/config.toml and preserving that file's existing mode. Codex's config
+// is as likely to be symlinked into a dotfiles repo as Claude Code's, and this
+// writer had the identical three-line defect.
 func writeRaw(path, content string) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
-	tmp := path + ".tmp"
-	if err := os.WriteFile(tmp, []byte(content), 0o644); err != nil {
-		return err
-	}
-	return os.Rename(tmp, path)
+	return writeThrough(path, []byte(content))
 }

--- a/internal/testsupport/permcheck.go
+++ b/internal/testsupport/permcheck.go
@@ -27,14 +27,22 @@ import (
 //
 // # Is anything security-sensitive weakened by this?
 //
-// No. The narrowest mode any atomicfile call site passes is 0o600, and those
-// destinations are daemon operational state (internal/daemon/mode/mode.go,
-// pins.go, sched/rss.go) — no credential, token or key is written through this
-// path anywhere in the tree. The runtime perm argument is unchanged on every
-// platform; only the test's expectation is adapted. On Windows those files are
-// protected by the ACL on the user profile directory they live in rather than
-// by mode bits, which is the platform's normal mechanism and is not something
-// a chmod could improve.
+// No — but the reason is narrower than it was, and the original wording ("no
+// credential, token or key is written through this path anywhere in the tree")
+// stopped being true in #6240. internal/install/mcpreg now asserts perms on
+// ~/.claude.json, which DOES hold an auth token, and creates such files 0600.
+//
+// What is unweakened is the thing that matters: the runtime perm argument is
+// identical on every platform; only the TEST's expectation is adapted. On
+// Windows those files are protected by the ACL on the user profile directory
+// they live in rather than by mode bits, which is the platform's normal
+// mechanism and is not something a chmod could improve — so there is no mode
+// this helper could assert there that would protect a token better.
+//
+// The practical consequence for a caller: on Windows this assertion cannot
+// distinguish 0600 from 0644, so a test that only ever seeds writable modes has
+// no signal there at all. Include a 0444 row — the one mode Windows can
+// represent — whenever the property under test is "the mode was applied".
 func AssertPerm(t *testing.T, path string, want os.FileMode) {
 	t.Helper()
 	fi, err := os.Stat(path)


### PR DESCRIPTION
`grafel install` rewrote MCP host configs with temp-file + `os.Rename` at `0o644`. Three consequences, on files grafel does not own.

## The symlink case is the destructive one, and not the way it reads

The content is not lost. The rename replaces the link inode with a regular file holding the merged document, and the dotfiles source still has its old bytes. What is lost is the **binding**, and the damage is delayed:

The grafel entry lands in the now-detached file; the managed source never receives it. The next `chezmoi apply` / `stow -R` / home-manager rebuild overwrites from source and the registration silently vanishes. Worse in reverse — **any edit the user makes through that path in the meantime is written to the detached file and then destroyed by the reconciler**, and because they believe the file is managed, it is not in their dotfiles git history either. Unreconstructible, and invisible when it happens.

Neither rollback path recovered it: `RestoreSnapshot` writes bytes to `path` and cannot recreate a symlink.

`~/.config/zed/settings.json` is in the blast radius and is `ShapeBroadSettings` — the whole editor config. So are eight other host paths, several **discovered** by scanning `$HOME` for `~/.claude-*` rather than named by a user.

## Permission widening was durable

`~/.claude.json` holds OAuth tokens and project history. `0600 → 0644` is fixable with a `chmod` — by someone who notices. Nothing told them, and every later write re-applied it.

## What changed

`writeThrough` resolves the destination and writes to the **target**, creating the temp in the *resolved* directory so the rename stays intra-filesystem. Mode is read from the destination and re-applied; **new files are `0600`** — a deliberate change from `0644`, because these carry credentials. `toml.go` (`~/.codex/config.toml`) had the identical defect and is fixed with it.

Wrong-typed `mcpServers` now fails with `ErrMalformedConfig` naming the file and the offending type, leaving the file byte-identical, mirroring the contract already enforced for top-level non-objects.

## Three decisions worth stating

**The sidecar keys on the unresolved path.** `RestoreSnapshot`, `ClearBackup`, `discardStaleMCPBackups` and the uninstall sweep all receive the caller's path. Resolving in `RegisterPath` alone would snapshot in one place and look in another — restores returning `ErrNoSnapshot`, stale sidecars never swept: the #6168 failure mode exactly. Pinned by `TestBackupSidecar_KeysOnTheUnresolvedPath`. It also keeps the sidecar out of the user's dotfiles repo.

**Malformed configs still trigger rollback.** That is the safe outcome — partial install undone, every file byte-identical — and matches what unparseable JSON already did. `ErrMalformedConfig` exists so callers *can* distinguish "the user's config is broken" from "the write failed"; no caller uses it yet, deliberately.

**`RestoreSnapshot`'s absent-sentinel branch now removes the resolved target, not the link.** With write-through, a dangling symlink means grafel created the target — removing the link would destroy the user's symlink and orphan grafel's file. That is this issue's own damage class, inside the fix for it.

## The review caught the same thing one level deeper

The first revision's comment claimed a link cycle *"exhausts the hop budget and returns the last hop; the write then fails loudly on its own."* It did not. On `a → b → a`, `writeThrough` returned **nil** and left the config a regular file — the link gone. `RegisterPath` was saved only by accident (`backupOnce` hits ELOOP first), but `RestoreSnapshot` reaches the write with no prior read.

Returning the last hop is unsafe *because that hop is itself a symlink*, handed to something about to rename over it. Budget exhaustion is now an error.

The budget also moved **32 → 40**, matching Linux's `MAXSYMLINKS`: a 33–39 link chain the kernel follows happily used to exhaust the budget and take the flatten path, while macOS's own 32 limit answers ELOOP and hides it. `TestRestoreSnapshot_ChainWithinTheKernelLimitStillResolves` builds a 35-link chain and walks all 35 hops confirming none was replaced — narrowing the constant back to 32 kills it. Without that test, both failure tests stay green at either value.

## Mutants

| Mutation | Killed by |
|---|---|
| never follow the link | 5 tests incl. `WritesThroughSymlink`, `TOMLWritesThroughSymlink` |
| perm → hardcoded `0o644` | 8 tests incl. `PreservesDestinationMode/{0600,0444}`, `NewConfigIsPrivate` |
| compute mode, never `Chmod` | `PreservesDestinationMode/{0644,0444}` |
| restore `servers, _ :=` | `WrongTypedMCPServersFailsCleanly` (all 5 rows) |
| `RestoreSnapshot` → `os.WriteFile(path, b, 0o644)` | `DoesNotWidenMode/destination_gone`, `WritesThroughSymlink` |
| budget exhaustion → `return cur, nil` | `SymlinkCycleFailsLoudly`, `OverlongSymlinkChainFailsLoudly` |
| `maxSymlinkHops` 40 → 32 | `ChainWithinTheKernelLimitStillResolves` |
| drop `writeThrough` guard | `SymlinkTargetIsGuarded` **only** |
| drop sentinel-branch guard | `SentinelRemovalIsGuarded` **only** |

The last two are disjoint by design and verified so at merge — an earlier revision had one guard covering both, so either copy could be deleted with a green suite. Independence of the symlink pair is also verified in both directions: the write-through mutant kills `WritesThroughSymlink` while `SymlinkPreservesTargetMode` survives, and the perm mutant does the exact inverse. Neither can pass for the other's reason.

## Anti-vacuity

Every existing fixture in this package seeded `0644` and never read the mode back — **a `0644` seed cannot observe widening**, so 40 test functions were blind to this by construction. New fixtures seed `0600` and `0444` and read back. Byte-identity assertions compare actual bytes against the exact seeded body.

`0444` is the one mode Windows can represent, so it is the only real Windows signal; mode checks go through `testsupport.AssertPerm`, which compares the read-only bit there. `atomicfile.Rename` is exported (a two-line wrapper over the existing `renameAtomic`) because `MoveFileEx` refuses to replace a read-only file — `WriteFile`'s documented contract is byte-untouched.

## #6018 ledger

Both entries removed: `writeThrough` uses `os.CreateTemp(dir, "."+base+".tmp-*")`, so neither file builds a deterministic temp name and `TestNoDeterministicTempNames` fails on the stale-entry branch until they go.

## Corrections to the issue

- `RestoreSnapshot`'s `0o644` was **not** a straight re-widening: `os.WriteFile` applies perm only on create, so against an existing file it was inert. The real exposure is the destination being absent at rollback, and `os.WriteFile` being unable to open a `0444` destination. Caught by a mutant against the fix's own first test, which was vacuous.
- The two rollback fixtures cited as depending on defect 3 seed an unparseable *document*, not a wrong-typed `mcpServers`. The fix adds a failure case rather than changing them.

## Not fixed here

Five more writers share this exact shape on user-owned files — filed as #6246, along with why `atomicfile.WriteFile` cannot be the remedy (it documents both behaviours as intended). A `WriteThrough` in `atomicfile` would serve all six, and cannot be `WriteFile` with a bool, because resolution has to be able to fail.

A symlinked-to-FIFO config hangs `grafel install` forever in `backupOnce` — pre-existing, filed as #6249.

Closes #6240
Refs #6246, #6249, #6018, #6168
